### PR TITLE
fix(animation): normalize peripheral-flash durations to 200ms band

### DIFF
--- a/src/components/Layout/NotificationCenterToolbarButton.tsx
+++ b/src/components/Layout/NotificationCenterToolbarButton.tsx
@@ -132,7 +132,6 @@ export const NotificationCenterToolbarButton = memo(function NotificationCenterT
   // no will-change layer hint lingers on the long-lived toolbar element.
   const prevEvictedRef = useRef(evictedToInboxCount);
   const [isBellBlipping, setIsBellBlipping] = useState(false);
-  const isBlippingRef = useRef(false);
   useEffect(() => {
     const prev = prevEvictedRef.current;
     prevEvictedRef.current = evictedToInboxCount;
@@ -140,29 +139,23 @@ export const NotificationCenterToolbarButton = memo(function NotificationCenterT
     // Count decreased — clear any in-flight animation state.
     if (evictedToInboxCount < prev) {
       setIsBellBlipping(false);
-      isBlippingRef.current = false;
       return;
     }
 
     if (evictedToInboxCount > prev && !isDndActive) {
       setIsBellBlipping(true);
-      isBlippingRef.current = true;
     }
   }, [evictedToInboxCount, isDndActive]);
 
   const handleBellAnimationEnd = useCallback(() => {
     setIsBellBlipping(false);
-    isBlippingRef.current = false;
   }, []);
 
   // Safety timeout — under reduced-motion CSS sets `animation: none`, so
   // `animationend` never fires and isBellBlipping would latch true.
   useEffect(() => {
     if (!isBellBlipping) return;
-    const timer = setTimeout(() => {
-      setIsBellBlipping(false);
-      isBlippingRef.current = false;
-    }, DURATION_200 + 50);
+    const timer = setTimeout(() => setIsBellBlipping(false), DURATION_200 + 50);
     return () => clearTimeout(timer);
   }, [isBellBlipping]);
 

--- a/src/components/Layout/NotificationCenterToolbarButton.tsx
+++ b/src/components/Layout/NotificationCenterToolbarButton.tsx
@@ -1,4 +1,4 @@
-import { useRef, useEffect, useState, memo } from "react";
+import { useRef, useEffect, useState, memo, useCallback } from "react";
 import { Button } from "@/components/ui/button";
 import { FixedDropdown } from "@/components/ui/fixed-dropdown";
 import { Bell, BellOff } from "lucide-react";
@@ -9,13 +9,9 @@ import { useNotificationSettingsStore } from "@/store/notificationSettingsStore"
 import { useUIStore } from "@/store/uiStore";
 import { useShallow } from "zustand/react/shallow";
 import { isScheduledQuietNow } from "@shared/utils/quietHours";
+import { DURATION_200 } from "@/lib/animationUtils";
 
 const toolbarIconButtonClass = "toolbar-icon-button text-daintree-text transition-colors";
-
-// Strip the bell `animate-activity-blip` class shortly after it plays so the
-// CSS `will-change: transform, opacity` layer-promotion hint does not linger
-// on a long-lived toolbar element. Covers the 260ms animation plus a buffer.
-const BELL_BLIP_CLEANUP_MS = 320;
 
 const timeFormatter = new Intl.DateTimeFormat(undefined, {
   hour: "numeric",
@@ -130,29 +126,45 @@ export const NotificationCenterToolbarButton = memo(function NotificationCenterT
     if (!notificationsEnabled && notificationCenterOpen) closeNotificationCenter();
   }, [notificationsEnabled, notificationCenterOpen, closeNotificationCenter]);
 
-  // Bump the bell key whenever a new notification lands in the inbox while
-  // DND is inactive. Remounting the wrapped <Icon /> (Pattern A from
-  // WorktreeDetailsSection) restarts the CSS `animate-activity-blip`
-  // animation cleanly without an imperative classList reflow. A ref-tracked
-  // baseline avoids firing on the first render or on resets to zero.
+  // Toggle a one-shot blip on the bell whenever a new notification lands in the
+  // inbox while DND is inactive. Uses boolean class toggle with onAnimationEnd
+  // cleanup (matching AgentStatusIndicator) instead of key-based remounting, so
+  // no will-change layer hint lingers on the long-lived toolbar element.
   const prevEvictedRef = useRef(evictedToInboxCount);
-  const [bellBumpKey, setBellBumpKey] = useState(0);
+  const [isBellBlipping, setIsBellBlipping] = useState(false);
+  const isBlippingRef = useRef(false);
   useEffect(() => {
     const prev = prevEvictedRef.current;
     prevEvictedRef.current = evictedToInboxCount;
+
+    // Count decreased — clear any in-flight animation state.
+    if (evictedToInboxCount < prev) {
+      setIsBellBlipping(false);
+      isBlippingRef.current = false;
+      return;
+    }
+
     if (evictedToInboxCount > prev && !isDndActive) {
-      setBellBumpKey((k) => k + 1);
+      setIsBellBlipping(true);
+      isBlippingRef.current = true;
     }
   }, [evictedToInboxCount, isDndActive]);
 
-  // Reset bumpKey shortly after each blip so the animation class drops off
-  // and `will-change` is no longer applied. Further bumps cancel the pending
-  // timer via the dependency array.
+  const handleBellAnimationEnd = useCallback(() => {
+    setIsBellBlipping(false);
+    isBlippingRef.current = false;
+  }, []);
+
+  // Safety timeout — under reduced-motion CSS sets `animation: none`, so
+  // `animationend` never fires and isBellBlipping would latch true.
   useEffect(() => {
-    if (bellBumpKey === 0) return;
-    const t = setTimeout(() => setBellBumpKey(0), BELL_BLIP_CLEANUP_MS);
-    return () => clearTimeout(t);
-  }, [bellBumpKey]);
+    if (!isBellBlipping) return;
+    const timer = setTimeout(() => {
+      setIsBellBlipping(false);
+      isBlippingRef.current = false;
+    }, DURATION_200 + 50);
+    return () => clearTimeout(timer);
+  }, [isBellBlipping]);
 
   if (!notificationsEnabled) return null;
 
@@ -185,9 +197,9 @@ export const NotificationCenterToolbarButton = memo(function NotificationCenterT
             aria-haspopup="dialog"
           >
             <span
-              key={bellBumpKey}
               data-testid="notification-bell-icon"
-              className={bellBumpKey > 0 ? "inline-flex animate-activity-blip" : "inline-flex"}
+              className={isBellBlipping ? "inline-flex animate-activity-blip" : "inline-flex"}
+              onAnimationEnd={handleBellAnimationEnd}
             >
               <Icon />
             </span>

--- a/src/components/Layout/TrashContainer.tsx
+++ b/src/components/Layout/TrashContainer.tsx
@@ -50,7 +50,6 @@ type TrashDisplayItem = GroupedTrashItem | GroupedTrashGroup;
 export function TrashContainer({ trashedTerminals, compact = false }: TrashContainerProps) {
   const [isOpen, setIsOpen] = useState(false);
   const [isTrashPulsing, setIsTrashPulsing] = useState(false);
-  const isPulsingRef = useRef(false);
   const prevLengthRef = useRef(trashedTerminals.length);
   const { worktreeMap } = useWorktrees();
   // Only show the ghost pill for panel drags — worktree-card sort drags also flip
@@ -65,28 +64,22 @@ export function TrashContainer({ trashedTerminals, compact = false }: TrashConta
     prevLengthRef.current = trashedTerminals.length;
     if (!increased) {
       setIsTrashPulsing(false);
-      isPulsingRef.current = false;
       return;
     }
     setIsTrashPulsing(true);
-    isPulsingRef.current = true;
     const shortcut = isMac() ? "Cmd+Shift+T" : "Ctrl+Shift+T";
     useAnnouncerStore.getState().announce(`Panel closed — press ${shortcut} to restore`);
   }, [trashedTerminals.length]);
 
   const handleTrashAnimationEnd = useCallback(() => {
     setIsTrashPulsing(false);
-    isPulsingRef.current = false;
   }, []);
 
   // Safety timeout — under reduced-motion CSS sets `animation: none`, so
   // `animationend` never fires and isTrashPulsing would latch true.
   useEffect(() => {
     if (!isTrashPulsing) return;
-    const timer = setTimeout(() => {
-      setIsTrashPulsing(false);
-      isPulsingRef.current = false;
-    }, DURATION_200 + 50);
+    const timer = setTimeout(() => setIsTrashPulsing(false), DURATION_200 + 50);
     return () => clearTimeout(timer);
   }, [isTrashPulsing]);
 

--- a/src/components/Layout/TrashContainer.tsx
+++ b/src/components/Layout/TrashContainer.tsx
@@ -1,4 +1,4 @@
-import { useState, useMemo, useEffect, useRef } from "react";
+import { useState, useMemo, useEffect, useRef, useCallback } from "react";
 import { Trash2 } from "lucide-react";
 import { useDroppable } from "@dnd-kit/core";
 import { Popover, PopoverContent, PopoverTrigger } from "@/components/ui/popover";
@@ -12,6 +12,7 @@ import {
   useIsWorktreeSortDragging,
   TRASH_DROPPABLE_ID,
 } from "@/components/DragDrop";
+import { DURATION_200 } from "@/lib/animationUtils";
 import type { TerminalInstance } from "@/store";
 import type { TrashedTerminal, TrashedTerminalGroupMetadata } from "@/store/slices";
 import { TrashBinItem } from "./TrashBinItem";
@@ -48,7 +49,8 @@ type TrashDisplayItem = GroupedTrashItem | GroupedTrashGroup;
 
 export function TrashContainer({ trashedTerminals, compact = false }: TrashContainerProps) {
   const [isOpen, setIsOpen] = useState(false);
-  const [pulseKey, setPulseKey] = useState(0);
+  const [isTrashPulsing, setIsTrashPulsing] = useState(false);
+  const isPulsingRef = useRef(false);
   const prevLengthRef = useRef(trashedTerminals.length);
   const { worktreeMap } = useWorktrees();
   // Only show the ghost pill for panel drags — worktree-card sort drags also flip
@@ -62,15 +64,31 @@ export function TrashContainer({ trashedTerminals, compact = false }: TrashConta
     const increased = trashedTerminals.length > prevLengthRef.current;
     prevLengthRef.current = trashedTerminals.length;
     if (!increased) {
-      setPulseKey(0);
-      return undefined;
+      setIsTrashPulsing(false);
+      isPulsingRef.current = false;
+      return;
     }
-    setPulseKey((k) => k + 1);
+    setIsTrashPulsing(true);
+    isPulsingRef.current = true;
     const shortcut = isMac() ? "Cmd+Shift+T" : "Ctrl+Shift+T";
     useAnnouncerStore.getState().announce(`Panel closed — press ${shortcut} to restore`);
-    const timer = setTimeout(() => setPulseKey(0), 450);
-    return () => clearTimeout(timer);
   }, [trashedTerminals.length]);
+
+  const handleTrashAnimationEnd = useCallback(() => {
+    setIsTrashPulsing(false);
+    isPulsingRef.current = false;
+  }, []);
+
+  // Safety timeout — under reduced-motion CSS sets `animation: none`, so
+  // `animationend` never fires and isTrashPulsing would latch true.
+  useEffect(() => {
+    if (!isTrashPulsing) return;
+    const timer = setTimeout(() => {
+      setIsTrashPulsing(false);
+      isPulsingRef.current = false;
+    }, DURATION_200 + 50);
+    return () => clearTimeout(timer);
+  }, [isTrashPulsing]);
 
   // Group trash items by groupRestoreId
   const displayItems = useMemo((): TrashDisplayItem[] => {
@@ -195,7 +213,10 @@ export function TrashContainer({ trashedTerminals, compact = false }: TrashConta
             aria-controls={contentId}
             aria-label={`Trash: ${count} terminal${count === 1 ? "" : "s"}`}
           >
-            <span key={pulseKey} className={cn("relative", pulseKey > 0 && "animate-trash-pulse")}>
+            <span
+              className={cn("relative", isTrashPulsing && "animate-trash-pulse")}
+              onAnimationEnd={handleTrashAnimationEnd}
+            >
               <Trash2 className="w-3.5 h-3.5 text-daintree-text/60" aria-hidden="true" />
               {compact && count > 0 && (
                 <span className="absolute -top-1.5 -right-1.5 z-10 flex items-center justify-center min-w-[14px] h-[14px] px-0.5 rounded-full bg-daintree-text/40 text-[10px] font-bold tabular-nums text-text-inverse">

--- a/src/components/Layout/__tests__/NotificationCenterToolbarButton.test.tsx
+++ b/src/components/Layout/__tests__/NotificationCenterToolbarButton.test.tsx
@@ -12,6 +12,15 @@
  *  - aria-label / tooltip describes the muted state with a time-of-day when known
  */
 import { describe, it, expect, beforeEach, vi, afterEach } from "vitest";
+
+// jsdom does not ship AnimationEvent.
+if (typeof AnimationEvent === "undefined") {
+  (globalThis as Record<string, unknown>).AnimationEvent = class AnimationEvent extends Event {
+    constructor(type: string, init?: EventInit) {
+      super(type, init);
+    }
+  };
+}
 import { render, act } from "@testing-library/react";
 import { NotificationCenterToolbarButton } from "../NotificationCenterToolbarButton";
 import { useNotificationHistoryStore } from "@/store/slices/notificationHistorySlice";
@@ -442,7 +451,9 @@ describe("NotificationCenterToolbarButton — DND state surface", () => {
   // Issue #6424 — when a notification lands in the inbox (toast eviction or
   // priority:"low" direct-to-inbox), the bell should play a brief one-shot
   // arrival animation. The animation must not fire during DND/quiet hours
-  // and must not fire on the initial mount baseline.
+  // and must not fire on the initial mount baseline. Cleanup uses the
+  // onAnimationEnd + safety-timeout pattern from AgentStatusIndicator so
+  // no will-change layer hint lingers on the toolbar element.
   describe("inbox arrival animation (issue #6424)", () => {
     it("does not animate on the initial render", () => {
       useNotificationHistoryStore.setState({ evictedToInboxCount: 0 });
@@ -482,19 +493,13 @@ describe("NotificationCenterToolbarButton — DND state surface", () => {
       await act(async () => {
         useNotificationHistoryStore.setState({ evictedToInboxCount: 1 });
       });
-      const firstWrapper = getByTestId("notification-bell-icon");
-      expect(firstWrapper.className).toContain("animate-activity-blip");
+      expect(getByTestId("notification-bell-icon").className).toContain("animate-activity-blip");
 
-      // Reset — count drops 1 → 0. evictedToInboxCount > prev is false, so the
-      // bumpKey does not increment and the bell wrapper is not remounted.
-      // (The CSS animation is `both`-fill at scale(1)/opacity(0.9), so a
-      // residual class on the existing wrapper is visually inert.)
+      // Reset — count drops 1 → 0. Decrease clears isBellBlipping so the
+      // next increase triggers a fresh animation cycle.
       await act(async () => {
         useNotificationHistoryStore.setState({ evictedToInboxCount: 0 });
       });
-      // Sanity: the count drop alone did not trigger another bump cycle.
-      // (We can't directly observe React's internal key, but a fresh
-      // increment from 0 → 1 below confirms the bumpKey path still works.)
       await act(async () => {
         useNotificationHistoryStore.setState({ evictedToInboxCount: 1 });
       });
@@ -550,7 +555,7 @@ describe("NotificationCenterToolbarButton — DND state surface", () => {
       expect(getByTestId("notification-bell-icon").className).toContain("animate-activity-blip");
     });
 
-    it("strips the animation class shortly after the blip so will-change does not linger", async () => {
+    it("removes the animation class via safety timeout when the animation completes", async () => {
       vi.useFakeTimers();
       const { getByTestId } = render(<NotificationCenterToolbarButton />);
       await act(async () => {
@@ -558,16 +563,17 @@ describe("NotificationCenterToolbarButton — DND state surface", () => {
       });
       expect(getByTestId("notification-bell-icon").className).toContain("animate-activity-blip");
 
-      // Advance past the BELL_BLIP_CLEANUP_MS timer (260ms blip + buffer).
+      // Advance past the 250ms safety timeout (DURATION_200 + 50). In jsdom
+      // `animationend` doesn't fire via dispatchEvent, so the safety timeout
+      // is the testable cleanup path — same as AgentStatusIndicator.
       await act(async () => {
-        vi.advanceTimersByTime(400);
+        vi.advanceTimersByTime(300);
       });
 
-      // After cleanup, the wrapper falls back to the no-animation className —
-      // the will-change layer-promotion hint is no longer applied.
       expect(getByTestId("notification-bell-icon").className).not.toContain(
         "animate-activity-blip"
       );
+      vi.useRealTimers();
     });
   });
 });

--- a/src/components/Layout/__tests__/TrashContainer.test.tsx
+++ b/src/components/Layout/__tests__/TrashContainer.test.tsx
@@ -6,6 +6,15 @@ import { useAnnouncerStore } from "@/store/accessibilityAnnouncerStore";
 import type { TerminalInstance } from "@/store";
 import type { TrashedTerminal } from "@/store/slices";
 
+// jsdom does not ship AnimationEvent.
+if (typeof AnimationEvent === "undefined") {
+  (globalThis as Record<string, unknown>).AnimationEvent = class AnimationEvent extends Event {
+    constructor(type: string, init?: EventInit) {
+      super(type, init);
+    }
+  };
+}
+
 const dndMocks = vi.hoisted(() => ({
   isDragging: false,
   isWorktreeSortDragging: false,
@@ -140,15 +149,18 @@ describe("TrashContainer", () => {
     expect(container.querySelector(".animate-trash-pulse")).not.toBeNull();
   });
 
-  it("removes pulse class after timeout", () => {
+  it("removes pulse class via safety timeout after the animation completes", () => {
     const items = [makeTrashedItem("1")];
     const { container, rerender } = render(<TrashContainer trashedTerminals={items} />);
 
     rerender(<TrashContainer trashedTerminals={[...items, makeTrashedItem("2")]} />);
     expect(container.querySelector(".animate-trash-pulse")).not.toBeNull();
 
+    // Advance past the 250ms safety timeout (DURATION_200 + 50). In jsdom
+    // `animationend` doesn't fire via dispatchEvent, so the safety timeout
+    // is the testable cleanup path — same as AgentStatusIndicator.
     act(() => {
-      vi.advanceTimersByTime(500);
+      vi.advanceTimersByTime(300);
     });
     expect(container.querySelector(".animate-trash-pulse")).toBeNull();
   });
@@ -204,15 +216,15 @@ describe("TrashContainer", () => {
     rerender(<TrashContainer trashedTerminals={[...items, makeTrashedItem("2")]} />);
     expect(container.querySelector(".animate-trash-pulse")).not.toBeNull();
 
-    // Second increase before timeout — should still be pulsing
+    // Second increase before timeout — class already present, stays alive.
     rerender(
       <TrashContainer trashedTerminals={[...items, makeTrashedItem("2"), makeTrashedItem("3")]} />
     );
     expect(container.querySelector(".animate-trash-pulse")).not.toBeNull();
 
-    // Timer from second increase should clear the pulse
+    // Safety timeout from the second trigger clears the pulse.
     act(() => {
-      vi.advanceTimersByTime(500);
+      vi.advanceTimersByTime(300);
     });
     expect(container.querySelector(".animate-trash-pulse")).toBeNull();
   });

--- a/src/index.css
+++ b/src/index.css
@@ -1225,7 +1225,7 @@ body,
 }
 
 .animate-diagnostics-flash {
-  animation: diagnostics-state-flash 0.4s ease-out 1;
+  animation: diagnostics-state-flash 200ms cubic-bezier(0.4, 0, 0.2, 1) both;
 }
 
 /* Activity blip animation - for new activity signals */
@@ -1235,7 +1235,7 @@ body,
     opacity: 0.9;
   }
   35% {
-    transform: scale(1.25);
+    transform: scale(1.06);
     opacity: 1;
   }
   100% {
@@ -1245,8 +1245,7 @@ body,
 }
 
 .animate-activity-blip {
-  animation: activity-blip 260ms cubic-bezier(0.4, 0, 0.2, 1) both;
-  will-change: transform, opacity;
+  animation: activity-blip 200ms cubic-bezier(0.4, 0, 0.2, 1) both;
 }
 
 /* Trash pulse animation - for trash icon when panels are added */
@@ -1256,7 +1255,7 @@ body,
     opacity: 1;
   }
   30% {
-    transform: scale(1.15);
+    transform: scale(1.06);
     opacity: 0.85;
   }
   100% {
@@ -1266,8 +1265,7 @@ body,
 }
 
 .animate-trash-pulse {
-  animation: trash-pulse 400ms cubic-bezier(0.4, 0, 0.2, 1) both;
-  will-change: transform, opacity;
+  animation: trash-pulse 200ms cubic-bezier(0.4, 0, 0.2, 1) both;
 }
 
 /* All-clear flash: subtle full-screen overlay when all agents complete */


### PR DESCRIPTION
## Summary
- Narrows three peripheral-flash keyframes (`activity-blip`, `trash-pulse`, `diagnostics-flash`) from 260-400ms into the 200ms band that the rest of the chrome uses, matching `badge-bump` as the reference idiom.
- Drops peak scale from 1.15-1.25 down to 1.06 so these flashes read as the same class of arrival gesture instead of feeling disproportionately punchy.
- Removes `will-change` from the CSS classes — layer promotion is fine for short-lived elements, but these animations now sit on long-lived toolbar buttons where the hint shouldn't linger.

Resolves #6834

## Changes
- `src/index.css` — tighten durations to 200ms, peak scale to 1.06, add `both` fill to diagnostics flash, strip `will-change` from activity-blip and trash-pulse
- `NotificationCenterToolbarButton.tsx` — replace `bumpKey`-based remounting with an `isBellBlipping` boolean toggle and `onAnimationEnd` cleanup, the same pattern `AgentStatusIndicator` uses
- `TrashContainer.tsx` — same boolean-toggle migration replacing `pulseKey`
- Tests updated for the new cleanup timing and the jsdom `AnimationEvent` requirement

## Testing
- Bell animation unit tests pass: initial-render baseline, increment trigger, decrement reset, DND gating, and safety-timeout cleanup
- Trash pulse unit tests pass: trigger, timeout removal, and rapid re-trigger before the first animation completes
- Typecheck, format, and lint clean