### PR TITLE
feat(re-entry): name worktrees in re-entry summary instead of counting

### DIFF
--- a/src/components/ui/ReEntrySummary.tsx
+++ b/src/components/ui/ReEntrySummary.tsx
@@ -1,54 +1,33 @@
 import { useEffect, useState } from "react";
 import { createPortal } from "react-dom";
-import { X, Bell, AlertTriangle, AlertCircle, CheckCircle2 } from "lucide-react";
+import { X, Bell, AlertTriangle, AlertCircle, CheckCircle2, Pin } from "lucide-react";
 import { cn } from "@/lib/utils";
 import { useUIStore } from "@/store/uiStore";
 import { useWorktreeSelectionStore } from "@/store/worktreeStore";
 import type { ReEntrySummaryState } from "@/hooks/useReEntrySummary";
+import type { NotificationHistoryEntry } from "@/store/slices/notificationHistorySlice";
 
 const AUTO_DISMISS_MS = 8000;
 
-function buildLines(counts: ReEntrySummaryState["counts"]): Array<{
-  icon: typeof AlertCircle;
-  text: string;
-  emphasis: boolean;
-}> {
-  const lines: Array<{ icon: typeof AlertCircle; text: string; emphasis: boolean }> = [];
-  if (counts.error > 0) {
-    lines.push({
-      icon: AlertCircle,
-      text: `${counts.error} failed`,
-      emphasis: true,
-    });
-  }
-  if (counts.warning > 0) {
-    lines.push({
-      icon: AlertTriangle,
-      text: `${counts.warning} waiting for input`,
-      emphasis: true,
-    });
-  }
-  if (counts.success > 0) {
-    lines.push({
-      icon: CheckCircle2,
-      text: `${counts.success} completed`,
-      emphasis: false,
-    });
-  }
-  if (counts.info > 0) {
-    lines.push({
-      icon: Bell,
-      text: `${counts.info} update${counts.info !== 1 ? "s" : ""}`,
-      emphasis: false,
-    });
-  }
-  return lines;
-}
+const SEVERITY_ICON: Record<NotificationHistoryEntry["type"], typeof AlertCircle> = {
+  error: AlertCircle,
+  warning: AlertTriangle,
+  info: Bell,
+  success: CheckCircle2,
+};
+
+const SEVERITY_CLASS: Record<NotificationHistoryEntry["type"], string> = {
+  error: "text-red-400",
+  warning: "text-amber-400",
+  info: "text-blue-400",
+  success: "text-green-400",
+};
 
 export function ReEntrySummary({ state }: { state: ReEntrySummaryState }) {
-  const { visible, dismiss, entries } = state;
+  const { visible, dismiss, entries, rows, overflowCount } = state;
   const [isVisible, setIsVisible] = useState(false);
   const [isPaused, setIsPaused] = useState(false);
+  const [isPinned, setIsPinned] = useState(false);
   const entryCount = entries.length;
 
   useEffect(() => {
@@ -61,15 +40,14 @@ export function ReEntrySummary({ state }: { state: ReEntrySummaryState }) {
   }, [visible, entryCount]);
 
   useEffect(() => {
-    if (!visible || isPaused) return;
+    if (!visible || isPaused || isPinned) return;
     const timer = setTimeout(dismiss, AUTO_DISMISS_MS);
     return () => clearTimeout(timer);
-  }, [visible, dismiss, isPaused, entryCount]);
+  }, [visible, dismiss, isPaused, isPinned, entryCount]);
 
   if (!state.visible) return null;
 
-  const lines = buildLines(state.counts);
-  const hasUrgent = state.counts.error > 0 || state.counts.warning > 0;
+  const hasUrgent = rows.some((r) => r.worstType === "error" || r.worstType === "warning");
   const accentClass = hasUrgent ? "border-l-status-warning" : "border-l-status-success";
 
   const handleOpenNotifications = () => {
@@ -77,10 +55,8 @@ export function ReEntrySummary({ state }: { state: ReEntrySummaryState }) {
     state.dismiss();
   };
 
-  const handleGoToWorktree = () => {
-    if (state.singleWorktreeId) {
-      useWorktreeSelectionStore.getState().selectWorktree(state.singleWorktreeId);
-    }
+  const handleRowClick = (worktreeId: string) => {
+    useWorktreeSelectionStore.getState().selectWorktree(worktreeId);
     state.dismiss();
   };
 
@@ -111,35 +87,79 @@ export function ReEntrySummary({ state }: { state: ReEntrySummaryState }) {
           <h4 className="font-medium leading-tight tracking-tight text-xs text-daintree-text">
             While you were away
           </h4>
-          <button
-            type="button"
-            onClick={state.dismiss}
-            aria-label="Dismiss summary"
-            className={cn(
-              "shrink-0 rounded-[var(--radius-xs)]",
-              "h-6 w-6 flex items-center justify-center",
-              "text-daintree-text/40 transition-colors duration-150",
-              "hover:text-daintree-text/80 hover:bg-tint/10",
-              "focus-visible:outline focus-visible:outline-2 focus-visible:outline-daintree-accent focus-visible:outline-offset-2"
-            )}
-          >
-            <X className="h-3.5 w-3.5" />
-          </button>
+          <div className="flex items-center gap-0.5">
+            <button
+              type="button"
+              onClick={() => setIsPinned((p) => !p)}
+              aria-label={isPinned ? "Unpin summary" : "Pin summary"}
+              aria-pressed={isPinned}
+              className={cn(
+                "shrink-0 rounded-[var(--radius-xs)]",
+                "h-6 w-6 flex items-center justify-center",
+                "text-daintree-text/40 transition-colors duration-150",
+                "hover:text-daintree-text/80 hover:bg-tint/10",
+                "focus-visible:outline focus-visible:outline-2 focus-visible:outline-daintree-accent focus-visible:outline-offset-2",
+                isPinned && "text-daintree-text/80"
+              )}
+            >
+              <Pin className={cn("h-3.5 w-3.5", isPinned && "fill-current")} />
+            </button>
+            <button
+              type="button"
+              onClick={state.dismiss}
+              aria-label="Dismiss summary"
+              className={cn(
+                "shrink-0 rounded-[var(--radius-xs)]",
+                "h-6 w-6 flex items-center justify-center",
+                "text-daintree-text/40 transition-colors duration-150",
+                "hover:text-daintree-text/80 hover:bg-tint/10",
+                "focus-visible:outline focus-visible:outline-2 focus-visible:outline-daintree-accent focus-visible:outline-offset-2"
+              )}
+            >
+              <X className="h-3.5 w-3.5" />
+            </button>
+          </div>
         </div>
 
         <ul className="mt-1.5 space-y-0.5">
-          {lines.map((line) => (
-            <li
-              key={line.text}
-              className={cn(
-                "flex items-center gap-1.5 text-xs",
-                line.emphasis ? "text-daintree-text" : "text-daintree-text/70"
-              )}
-            >
-              <line.icon className="h-3.5 w-3.5 shrink-0" />
-              <span className="tabular-nums">{line.text}</span>
+          {rows.map((row) => {
+            const Icon = SEVERITY_ICON[row.worstType];
+            return (
+              <li key={row.worktreeId}>
+                <button
+                  type="button"
+                  onClick={() => handleRowClick(row.worktreeId)}
+                  className={cn(
+                    "flex items-center gap-1.5 w-full text-left text-xs",
+                    "rounded-[var(--radius-xs)] px-0.5 py-0.5 -mx-0.5",
+                    "hover:bg-tint/5 transition-colors duration-150",
+                    "focus-visible:outline focus-visible:outline-2 focus-visible:outline-daintree-accent focus-visible:outline-offset-2",
+                    row.worstType === "error" || row.worstType === "warning"
+                      ? "text-daintree-text"
+                      : "text-daintree-text/70"
+                  )}
+                >
+                  <Icon className={cn("h-3.5 w-3.5 shrink-0", SEVERITY_CLASS[row.worstType])} />
+                  <span className="font-medium truncate">{row.worktreeName}</span>
+                  <span className="text-daintree-text/50 truncate">{row.highlightTitle}</span>
+                </button>
+              </li>
+            );
+          })}
+          {overflowCount > 0 && (
+            <li>
+              <button
+                type="button"
+                onClick={handleOpenNotifications}
+                className={cn(
+                  "text-xs text-daintree-text/50 hover:text-daintree-text/70",
+                  "px-0.5 py-0.5 transition-colors duration-150"
+                )}
+              >
+                +{overflowCount} more
+              </button>
             </li>
-          ))}
+          )}
         </ul>
 
         <div className="mt-2 flex flex-wrap gap-1.5">
@@ -156,21 +176,6 @@ export function ReEntrySummary({ state }: { state: ReEntrySummaryState }) {
           >
             Open Notifications
           </button>
-          {state.singleWorktreeId && (
-            <button
-              type="button"
-              onClick={handleGoToWorktree}
-              className={cn(
-                "px-2.5 py-1 rounded-[var(--radius-xs)]",
-                "text-xs font-medium",
-                "bg-tint/5 text-daintree-text/70",
-                "hover:bg-tint/10 hover:text-daintree-text transition-colors",
-                "focus-visible:outline focus-visible:outline-2 focus-visible:outline-daintree-accent focus-visible:outline-offset-2"
-              )}
-            >
-              Go to Worktree
-            </button>
-          )}
         </div>
       </div>
     </div>,

--- a/src/components/ui/ReEntrySummary.tsx
+++ b/src/components/ui/ReEntrySummary.tsx
@@ -4,6 +4,7 @@ import { X, Bell, AlertTriangle, AlertCircle, CheckCircle2, Pin } from "lucide-r
 import { cn } from "@/lib/utils";
 import { useUIStore } from "@/store/uiStore";
 import { useWorktreeSelectionStore } from "@/store/worktreeStore";
+import { getCurrentViewStoreOrNull } from "@/store/createWorktreeStore";
 import type { ReEntrySummaryState } from "@/hooks/useReEntrySummary";
 import type { NotificationHistoryEntry } from "@/store/slices/notificationHistorySlice";
 
@@ -35,15 +36,18 @@ export function ReEntrySummary({ state }: { state: ReEntrySummaryState }) {
       setIsVisible(false);
       return;
     }
+    setIsPinned(false);
     const handle = requestAnimationFrame(() => setIsVisible(true));
     return () => cancelAnimationFrame(handle);
   }, [visible, entryCount]);
+
+  const rowsKey = rows.map((r) => r.worktreeId).join(",");
 
   useEffect(() => {
     if (!visible || isPaused || isPinned) return;
     const timer = setTimeout(dismiss, AUTO_DISMISS_MS);
     return () => clearTimeout(timer);
-  }, [visible, dismiss, isPaused, isPinned, entryCount]);
+  }, [visible, dismiss, isPaused, isPinned, rowsKey]);
 
   if (!state.visible) return null;
 
@@ -56,6 +60,8 @@ export function ReEntrySummary({ state }: { state: ReEntrySummaryState }) {
   };
 
   const handleRowClick = (worktreeId: string) => {
+    const hasWorktree = getCurrentViewStoreOrNull()?.getState().worktrees.has(worktreeId) ?? false;
+    if (!hasWorktree) return;
     useWorktreeSelectionStore.getState().selectWorktree(worktreeId);
     state.dismiss();
   };
@@ -140,8 +146,10 @@ export function ReEntrySummary({ state }: { state: ReEntrySummaryState }) {
                   )}
                 >
                   <Icon className={cn("h-3.5 w-3.5 shrink-0", SEVERITY_CLASS[row.worstType])} />
-                  <span className="font-medium truncate">{row.worktreeName}</span>
-                  <span className="text-daintree-text/50 truncate">{row.highlightTitle}</span>
+                  <span className="font-medium truncate min-w-0">{row.worktreeName}</span>
+                  <span className="text-daintree-text/50 truncate min-w-0">
+                    {row.highlightTitle}
+                  </span>
                 </button>
               </li>
             );

--- a/src/components/ui/__tests__/reentry-summary.test.tsx
+++ b/src/components/ui/__tests__/reentry-summary.test.tsx
@@ -5,6 +5,10 @@ import { ReEntrySummary } from "../ReEntrySummary";
 import type { ReEntrySummaryState, WorktreeRow } from "@/hooks/useReEntrySummary";
 import type { NotificationHistoryEntry } from "@/store/slices/notificationHistorySlice";
 
+vi.mock("@/store/createWorktreeStore", () => ({
+  getCurrentViewStoreOrNull: vi.fn(),
+}));
+
 vi.stubGlobal(
   "requestAnimationFrame",
   (cb: FrameRequestCallback) => setTimeout(() => cb(0), 0) as unknown as number
@@ -34,8 +38,18 @@ function makeState(overrides: Partial<ReEntrySummaryState> = {}): ReEntrySummary
 }
 
 describe("ReEntrySummary", () => {
-  beforeEach(() => {
+  beforeEach(async () => {
     vi.useFakeTimers();
+    const { getCurrentViewStoreOrNull } = await import("@/store/createWorktreeStore");
+    vi.mocked(getCurrentViewStoreOrNull).mockReturnValue({
+      getState: () => ({
+        worktrees: new Map([
+          ["wt-1", { name: "feature-test" }],
+          ["wt-2", { name: "feature-other" }],
+          ["wt-42", { name: "fix-bug" }],
+        ]),
+      }),
+    } as ReturnType<typeof getCurrentViewStoreOrNull>);
   });
 
   afterEach(() => {
@@ -255,6 +269,76 @@ describe("ReEntrySummary", () => {
       vi.advanceTimersByTime(8000);
     });
     expect(dismiss).toHaveBeenCalledOnce();
+  });
+
+  it("resets pin state when summary goes invisible then reappears", () => {
+    const dismiss = vi.fn();
+    const { rerender } = render(
+      <ReEntrySummary
+        state={makeState({
+          visible: true,
+          dismiss,
+          rows: [makeRow({ worktreeId: "wt-1", highlightTitle: "First" })],
+        })}
+      />
+    );
+
+    fireEvent.click(screen.getByLabelText("Pin summary"));
+    expect(screen.getByLabelText("Unpin summary").getAttribute("aria-pressed")).toBe("true");
+
+    rerender(
+      <ReEntrySummary
+        state={makeState({
+          visible: false,
+          dismiss,
+          rows: [],
+        })}
+      />
+    );
+
+    rerender(
+      <ReEntrySummary
+        state={makeState({
+          visible: true,
+          dismiss,
+          rows: [makeRow({ worktreeId: "wt-2", highlightTitle: "Second" })],
+        })}
+      />
+    );
+
+    expect(screen.getByLabelText("Pin summary").getAttribute("aria-pressed")).toBe("false");
+  });
+
+  it("restarts auto-dismiss timer when rows change but entryCount stays the same", () => {
+    const dismiss = vi.fn();
+    const { rerender } = render(
+      <ReEntrySummary
+        state={makeState({
+          dismiss,
+          entries: [{ id: "a", type: "info", message: "x", timestamp: 1 } as any],
+          rows: [makeRow({ worktreeId: "wt-1", highlightTitle: "First" })],
+        })}
+      />
+    );
+
+    act(() => {
+      vi.advanceTimersByTime(7000);
+    });
+
+    rerender(
+      <ReEntrySummary
+        state={makeState({
+          dismiss,
+          entries: [{ id: "b", type: "info", message: "y", timestamp: 2 } as any],
+          rows: [makeRow({ worktreeId: "wt-2", highlightTitle: "Second" })],
+        })}
+      />
+    );
+
+    act(() => {
+      vi.advanceTimersByTime(2000);
+    });
+    expect(dismiss).not.toHaveBeenCalled();
   });
 
   it("does not steal focus", () => {

--- a/src/components/ui/__tests__/reentry-summary.test.tsx
+++ b/src/components/ui/__tests__/reentry-summary.test.tsx
@@ -2,7 +2,8 @@
 import { render, screen, act, fireEvent } from "@testing-library/react";
 import { describe, expect, it, beforeEach, vi, afterEach } from "vitest";
 import { ReEntrySummary } from "../ReEntrySummary";
-import type { ReEntrySummaryState } from "@/hooks/useReEntrySummary";
+import type { ReEntrySummaryState, WorktreeRow } from "@/hooks/useReEntrySummary";
+import type { NotificationHistoryEntry } from "@/store/slices/notificationHistorySlice";
 
 vi.stubGlobal(
   "requestAnimationFrame",
@@ -10,12 +11,23 @@ vi.stubGlobal(
 );
 vi.stubGlobal("cancelAnimationFrame", (id: number) => clearTimeout(id));
 
+function makeRow(overrides: Partial<WorktreeRow> = {}): WorktreeRow {
+  return {
+    worktreeId: "wt-1",
+    worktreeName: "feature-test",
+    worstType: "error" as NotificationHistoryEntry["type"],
+    highlightTitle: "Build failed",
+    entryCount: 2,
+    ...overrides,
+  };
+}
+
 function makeState(overrides: Partial<ReEntrySummaryState> = {}): ReEntrySummaryState {
   return {
     visible: true,
     entries: [],
-    counts: { warning: 0, error: 0, success: 0, info: 0 },
-    singleWorktreeId: null,
+    rows: [],
+    overflowCount: 0,
     dismiss: vi.fn(),
     ...overrides,
   };
@@ -35,21 +47,37 @@ describe("ReEntrySummary", () => {
     expect(container.innerHTML).toBe("");
   });
 
-  it("renders with correct counts for mixed entry types", () => {
+  it("renders worktree rows with severity icon, name, and title", () => {
     const state = makeState({
-      counts: { warning: 1, error: 2, success: 3, info: 0 },
+      rows: [
+        makeRow({
+          worktreeId: "wt-1",
+          worktreeName: "feature-foo",
+          worstType: "error",
+          highlightTitle: "Build failed",
+        }),
+        makeRow({
+          worktreeId: "wt-2",
+          worktreeName: "feature-bar",
+          worstType: "warning",
+          highlightTitle: "Tests flaky",
+        }),
+      ],
     });
     render(<ReEntrySummary state={state} />);
     expect(screen.getByText("While you were away")).toBeTruthy();
-    expect(screen.getByText("2 failed")).toBeTruthy();
-    expect(screen.getByText("1 waiting for input")).toBeTruthy();
-    expect(screen.getByText("3 completed")).toBeTruthy();
+    expect(screen.getByText("feature-foo")).toBeTruthy();
+    expect(screen.getByText("Build failed")).toBeTruthy();
+    expect(screen.getByText("feature-bar")).toBeTruthy();
+    expect(screen.getByText("Tests flaky")).toBeTruthy();
   });
 
   it("has role=status", () => {
     render(
       <ReEntrySummary
-        state={makeState({ counts: { warning: 0, error: 0, success: 1, info: 0 } })}
+        state={makeState({
+          rows: [makeRow({ worstType: "success", highlightTitle: "Done" })],
+        })}
       />
     );
     expect(screen.getByRole("status")).toBeTruthy();
@@ -59,7 +87,10 @@ describe("ReEntrySummary", () => {
     const dismiss = vi.fn();
     render(
       <ReEntrySummary
-        state={makeState({ dismiss, counts: { warning: 0, error: 0, success: 1, info: 0 } })}
+        state={makeState({
+          dismiss,
+          rows: [makeRow({ worstType: "success", highlightTitle: "Done" })],
+        })}
       />
     );
     fireEvent.click(screen.getByLabelText("Dismiss summary"));
@@ -74,7 +105,10 @@ describe("ReEntrySummary", () => {
     const dismiss = vi.fn();
     render(
       <ReEntrySummary
-        state={makeState({ dismiss, counts: { warning: 0, error: 0, success: 1, info: 0 } })}
+        state={makeState({
+          dismiss,
+          rows: [makeRow({ worstType: "success", highlightTitle: "Done" })],
+        })}
       />
     );
     fireEvent.click(screen.getByText("Open Notifications"));
@@ -82,29 +116,7 @@ describe("ReEntrySummary", () => {
     expect(dismiss).toHaveBeenCalledOnce();
   });
 
-  it("Go to Worktree button appears only when singleWorktreeId is set", () => {
-    const { rerender } = render(
-      <ReEntrySummary
-        state={makeState({
-          singleWorktreeId: null,
-          counts: { warning: 0, error: 0, success: 1, info: 0 },
-        })}
-      />
-    );
-    expect(screen.queryByText("Go to Worktree")).toBeNull();
-
-    rerender(
-      <ReEntrySummary
-        state={makeState({
-          singleWorktreeId: "wt-1",
-          counts: { warning: 0, error: 0, success: 1, info: 0 },
-        })}
-      />
-    );
-    expect(screen.getByText("Go to Worktree")).toBeTruthy();
-  });
-
-  it("Go to Worktree button calls selectWorktree and dismiss", async () => {
+  it("clicking a worktree row calls selectWorktree and dismiss", async () => {
     const { useWorktreeSelectionStore } = await import("@/store/worktreeStore");
     const selectSpy = vi.fn();
     useWorktreeSelectionStore.setState({ selectWorktree: selectSpy });
@@ -114,13 +126,45 @@ describe("ReEntrySummary", () => {
       <ReEntrySummary
         state={makeState({
           dismiss,
-          singleWorktreeId: "wt-42",
-          counts: { warning: 0, error: 0, success: 1, info: 0 },
+          rows: [makeRow({ worktreeId: "wt-42", worktreeName: "fix-bug" })],
         })}
       />
     );
-    fireEvent.click(screen.getByText("Go to Worktree"));
+    fireEvent.click(screen.getByText("fix-bug"));
     expect(selectSpy).toHaveBeenCalledWith("wt-42");
+    expect(dismiss).toHaveBeenCalledOnce();
+  });
+
+  it("renders +N more overflow row when overflowCount > 0", () => {
+    const state = makeState({
+      rows: [
+        makeRow({ worktreeId: "wt-1", worktreeName: "a" }),
+        makeRow({ worktreeId: "wt-2", worktreeName: "b" }),
+        makeRow({ worktreeId: "wt-3", worktreeName: "c" }),
+      ],
+      overflowCount: 2,
+    });
+    render(<ReEntrySummary state={state} />);
+    expect(screen.getByText("+2 more")).toBeTruthy();
+  });
+
+  it("overflow row opens notification center", async () => {
+    const { useUIStore } = await import("@/store/uiStore");
+    const openSpy = vi.fn();
+    useUIStore.setState({ openNotificationCenter: openSpy });
+
+    const dismiss = vi.fn();
+    render(
+      <ReEntrySummary
+        state={makeState({
+          dismiss,
+          rows: [makeRow()],
+          overflowCount: 3,
+        })}
+      />
+    );
+    fireEvent.click(screen.getByText("+3 more"));
+    expect(openSpy).toHaveBeenCalledOnce();
     expect(dismiss).toHaveBeenCalledOnce();
   });
 
@@ -128,7 +172,10 @@ describe("ReEntrySummary", () => {
     const dismiss = vi.fn();
     render(
       <ReEntrySummary
-        state={makeState({ dismiss, counts: { warning: 0, error: 0, success: 1, info: 0 } })}
+        state={makeState({
+          dismiss,
+          rows: [makeRow({ worstType: "success", highlightTitle: "Done" })],
+        })}
       />
     );
     expect(dismiss).not.toHaveBeenCalled();
@@ -142,7 +189,10 @@ describe("ReEntrySummary", () => {
     const dismiss = vi.fn();
     render(
       <ReEntrySummary
-        state={makeState({ dismiss, counts: { warning: 0, error: 0, success: 1, info: 0 } })}
+        state={makeState({
+          dismiss,
+          rows: [makeRow({ worstType: "success", highlightTitle: "Done" })],
+        })}
       />
     );
     const card = screen.getByRole("status");
@@ -160,28 +210,59 @@ describe("ReEntrySummary", () => {
     expect(dismiss).toHaveBeenCalledOnce();
   });
 
-  it("shows info count with correct pluralization", () => {
+  it("pin button toggles aria-pressed and prevents auto-dismiss", () => {
+    const dismiss = vi.fn();
     render(
       <ReEntrySummary
-        state={makeState({ counts: { warning: 0, error: 0, success: 0, info: 1 } })}
+        state={makeState({
+          dismiss,
+          rows: [makeRow({ worstType: "success", highlightTitle: "Done" })],
+        })}
       />
     );
-    expect(screen.getByText("1 update")).toBeTruthy();
+
+    const pinButton = screen.getByLabelText("Pin summary");
+    expect(pinButton.getAttribute("aria-pressed")).toBe("false");
+
+    fireEvent.click(pinButton);
+    expect(pinButton.getAttribute("aria-pressed")).toBe("true");
+
+    act(() => {
+      vi.advanceTimersByTime(20000);
+    });
+    expect(dismiss).not.toHaveBeenCalled();
   });
 
-  it("shows plural info count", () => {
+  it("unpin resumes auto-dismiss behavior", () => {
+    const dismiss = vi.fn();
     render(
       <ReEntrySummary
-        state={makeState({ counts: { warning: 0, error: 0, success: 0, info: 3 } })}
+        state={makeState({
+          dismiss,
+          rows: [makeRow({ worstType: "success", highlightTitle: "Done" })],
+        })}
       />
     );
-    expect(screen.getByText("3 updates")).toBeTruthy();
+
+    const pinButton = screen.getByLabelText("Pin summary");
+    fireEvent.click(pinButton);
+    expect(pinButton.getAttribute("aria-pressed")).toBe("true");
+
+    fireEvent.click(pinButton);
+    expect(pinButton.getAttribute("aria-pressed")).toBe("false");
+
+    act(() => {
+      vi.advanceTimersByTime(8000);
+    });
+    expect(dismiss).toHaveBeenCalledOnce();
   });
 
   it("does not steal focus", () => {
     render(
       <ReEntrySummary
-        state={makeState({ counts: { warning: 0, error: 0, success: 1, info: 0 } })}
+        state={makeState({
+          rows: [makeRow({ worstType: "success", highlightTitle: "Done" })],
+        })}
       />
     );
     const card = screen.getByRole("status");

--- a/src/components/ui/__tests__/reentry-summary.test.tsx
+++ b/src/components/ui/__tests__/reentry-summary.test.tsx
@@ -15,6 +15,19 @@ vi.stubGlobal(
 );
 vi.stubGlobal("cancelAnimationFrame", (id: number) => clearTimeout(id));
 
+function makeEntry(overrides: Partial<NotificationHistoryEntry> = {}): NotificationHistoryEntry {
+  return {
+    id: "e1",
+    type: "info",
+    message: "test",
+    timestamp: 1,
+    seenAsToast: false,
+    summarized: false,
+    countable: true,
+    ...overrides,
+  };
+}
+
 function makeRow(overrides: Partial<WorktreeRow> = {}): WorktreeRow {
   return {
     worktreeId: "wt-1",
@@ -41,12 +54,40 @@ describe("ReEntrySummary", () => {
   beforeEach(async () => {
     vi.useFakeTimers();
     const { getCurrentViewStoreOrNull } = await import("@/store/createWorktreeStore");
+    // eslint-disable-next-line @typescript-eslint/no-unsafe-type-assertion
     vi.mocked(getCurrentViewStoreOrNull).mockReturnValue({
       getState: () => ({
         worktrees: new Map([
-          ["wt-1", { name: "feature-test" }],
-          ["wt-2", { name: "feature-other" }],
-          ["wt-42", { name: "fix-bug" }],
+          [
+            "wt-1",
+            {
+              id: "wt-1",
+              path: "/tmp/wt-1",
+              name: "feature-test",
+              isCurrent: false,
+              worktreeId: "wt-1",
+            },
+          ],
+          [
+            "wt-2",
+            {
+              id: "wt-2",
+              path: "/tmp/wt-2",
+              name: "feature-other",
+              isCurrent: false,
+              worktreeId: "wt-2",
+            },
+          ],
+          [
+            "wt-42",
+            {
+              id: "wt-42",
+              path: "/tmp/wt-42",
+              name: "fix-bug",
+              isCurrent: false,
+              worktreeId: "wt-42",
+            },
+          ],
         ]),
       }),
     } as ReturnType<typeof getCurrentViewStoreOrNull>);
@@ -315,7 +356,7 @@ describe("ReEntrySummary", () => {
       <ReEntrySummary
         state={makeState({
           dismiss,
-          entries: [{ id: "a", type: "info", message: "x", timestamp: 1 } as any],
+          entries: [makeEntry({ id: "a", message: "x" })],
           rows: [makeRow({ worktreeId: "wt-1", highlightTitle: "First" })],
         })}
       />
@@ -329,7 +370,7 @@ describe("ReEntrySummary", () => {
       <ReEntrySummary
         state={makeState({
           dismiss,
-          entries: [{ id: "b", type: "info", message: "y", timestamp: 2 } as any],
+          entries: [makeEntry({ id: "b", message: "y" })],
           rows: [makeRow({ worktreeId: "wt-2", highlightTitle: "Second" })],
         })}
       />

--- a/src/hooks/__tests__/useReEntrySummary.test.tsx
+++ b/src/hooks/__tests__/useReEntrySummary.test.tsx
@@ -372,9 +372,21 @@ describe("useReEntrySummary", () => {
 
   it("resolves worktree name from current view store", async () => {
     const { getCurrentViewStoreOrNull } = await import("@/store/createWorktreeStore");
+    // eslint-disable-next-line @typescript-eslint/no-unsafe-type-assertion
     vi.mocked(getCurrentViewStoreOrNull).mockReturnValue({
       getState: () => ({
-        worktrees: new Map([["wt-1", { name: "feature-xyz" }]]),
+        worktrees: new Map([
+          [
+            "wt-1",
+            {
+              id: "wt-1",
+              path: "/tmp/wt-1",
+              name: "feature-xyz",
+              isCurrent: false,
+              worktreeId: "wt-1",
+            },
+          ],
+        ]),
       }),
     } as ReturnType<typeof getCurrentViewStoreOrNull>);
 
@@ -427,9 +439,15 @@ describe("useReEntrySummary", () => {
 
   it("falls back to truncated ID when worktree name is empty string", async () => {
     const { getCurrentViewStoreOrNull } = await import("@/store/createWorktreeStore");
+    // eslint-disable-next-line @typescript-eslint/no-unsafe-type-assertion
     vi.mocked(getCurrentViewStoreOrNull).mockReturnValue({
       getState: () => ({
-        worktrees: new Map([["wt-1", { name: "" }]]),
+        worktrees: new Map([
+          [
+            "wt-1",
+            { id: "wt-1", path: "/tmp/wt-1", name: "", isCurrent: false, worktreeId: "wt-1" },
+          ],
+        ]),
       }),
     } as ReturnType<typeof getCurrentViewStoreOrNull>);
 

--- a/src/hooks/__tests__/useReEntrySummary.test.tsx
+++ b/src/hooks/__tests__/useReEntrySummary.test.tsx
@@ -4,10 +4,15 @@ import { act, renderHook } from "@testing-library/react";
 import { useReEntrySummary } from "../useReEntrySummary";
 import { useNotificationHistoryStore } from "@/store/slices/notificationHistorySlice";
 
+vi.mock("@/store/createWorktreeStore", () => ({
+  getCurrentViewStoreOrNull: vi.fn(),
+}));
+
 function addEntry(
   overrides: Partial<{
     type: "success" | "error" | "info" | "warning";
     message: string;
+    title: string;
     seenAsToast: boolean;
     context: { worktreeId?: string };
   }> = {}
@@ -15,6 +20,7 @@ function addEntry(
   useNotificationHistoryStore.getState().addEntry({
     type: overrides.type ?? "success",
     message: overrides.message ?? "Test",
+    title: overrides.title,
     seenAsToast: overrides.seenAsToast,
     ...(overrides.context ? { context: overrides.context } : {}),
   });
@@ -41,9 +47,11 @@ function simulateBlurFocusCycle(blurDurationMs: number) {
 describe("useReEntrySummary", () => {
   let hasFocusSpy: ReturnType<typeof vi.spyOn>;
 
-  beforeEach(() => {
+  beforeEach(async () => {
     useNotificationHistoryStore.setState({ entries: [], unreadCount: 0 });
     hasFocusSpy = vi.spyOn(document, "hasFocus").mockReturnValue(true);
+    const { getCurrentViewStoreOrNull } = await import("@/store/createWorktreeStore");
+    vi.mocked(getCurrentViewStoreOrNull).mockReturnValue(null);
   });
 
   afterEach(() => {
@@ -54,6 +62,7 @@ describe("useReEntrySummary", () => {
     const { result } = renderHook(() => useReEntrySummary());
     expect(result.current.visible).toBe(false);
     expect(result.current.entries).toHaveLength(0);
+    expect(result.current.rows).toHaveLength(0);
   });
 
   it("shows summary on focus after 3+ seconds blur with unseen entries", () => {
@@ -63,8 +72,16 @@ describe("useReEntrySummary", () => {
       window.dispatchEvent(new Event("blur"));
     });
 
-    addEntry({ type: "error", message: "Build failed" });
-    addEntry({ type: "success", message: "Agent done" });
+    addEntry({
+      type: "error",
+      message: "Build failed",
+      context: { worktreeId: "wt-1" },
+    });
+    addEntry({
+      type: "success",
+      message: "Agent done",
+      context: { worktreeId: "wt-2" },
+    });
 
     const realNow = Date.now;
     const later = realNow() + 5000;
@@ -78,8 +95,9 @@ describe("useReEntrySummary", () => {
 
     expect(result.current.visible).toBe(true);
     expect(result.current.entries).toHaveLength(2);
-    expect(result.current.counts.error).toBe(1);
-    expect(result.current.counts.success).toBe(1);
+    expect(result.current.rows).toHaveLength(2);
+    expect(result.current.rows[0]!.worstType).toBe("error");
+    expect(result.current.rows[1]!.worstType).toBe("success");
   });
 
   it("does not show summary when blur is less than 3 seconds", () => {
@@ -93,7 +111,12 @@ describe("useReEntrySummary", () => {
   it("does not show summary when no unseen entries exist", () => {
     const { result } = renderHook(() => useReEntrySummary());
 
-    addEntry({ type: "success", message: "Seen", seenAsToast: true });
+    addEntry({
+      type: "success",
+      message: "Seen",
+      seenAsToast: true,
+      context: { worktreeId: "wt-1" },
+    });
 
     simulateBlurFocusCycle(5000);
 
@@ -106,7 +129,11 @@ describe("useReEntrySummary", () => {
     act(() => {
       window.dispatchEvent(new Event("blur"));
     });
-    addEntry({ type: "success", message: "First batch" });
+    addEntry({
+      type: "success",
+      message: "First batch",
+      context: { worktreeId: "wt-1" },
+    });
 
     const realNow = Date.now;
     let now = realNow();
@@ -129,7 +156,11 @@ describe("useReEntrySummary", () => {
     });
 
     now += 5000;
-    addEntry({ type: "error", message: "Second batch" });
+    addEntry({
+      type: "error",
+      message: "Second batch",
+      context: { worktreeId: "wt-1" },
+    });
 
     now += 5000;
     act(() => {
@@ -149,7 +180,11 @@ describe("useReEntrySummary", () => {
     act(() => {
       window.dispatchEvent(new Event("blur"));
     });
-    addEntry({ type: "success", message: "Test" });
+    addEntry({
+      type: "success",
+      message: "Test",
+      context: { worktreeId: "wt-1" },
+    });
 
     const realNow = Date.now;
     Date.now = () => realNow() + 5000;
@@ -160,8 +195,8 @@ describe("useReEntrySummary", () => {
 
     Date.now = realNow;
 
-    const entries = useNotificationHistoryStore.getState().entries;
-    expect(entries[0]!.summarized).toBe(true);
+    const storeEntries = useNotificationHistoryStore.getState().entries;
+    expect(storeEntries[0]!.summarized).toBe(true);
   });
 
   it("does not trigger when document.hasFocus() returns false", () => {
@@ -171,53 +206,15 @@ describe("useReEntrySummary", () => {
     act(() => {
       window.dispatchEvent(new Event("blur"));
     });
-    addEntry({ type: "success", message: "Test" });
+    addEntry({
+      type: "success",
+      message: "Test",
+      context: { worktreeId: "wt-1" },
+    });
 
     simulateBlurFocusCycle(5000);
 
     expect(result.current.visible).toBe(false);
-  });
-
-  it("computes singleWorktreeId when all entries share one worktree", () => {
-    const { result } = renderHook(() => useReEntrySummary());
-
-    act(() => {
-      window.dispatchEvent(new Event("blur"));
-    });
-    addEntry({ type: "success", message: "A", context: { worktreeId: "wt-1" } });
-    addEntry({ type: "error", message: "B", context: { worktreeId: "wt-1" } });
-
-    const realNow = Date.now;
-    Date.now = () => realNow() + 5000;
-
-    act(() => {
-      window.dispatchEvent(new Event("focus"));
-    });
-
-    Date.now = realNow;
-
-    expect(result.current.singleWorktreeId).toBe("wt-1");
-  });
-
-  it("returns null singleWorktreeId when entries span multiple worktrees", () => {
-    const { result } = renderHook(() => useReEntrySummary());
-
-    act(() => {
-      window.dispatchEvent(new Event("blur"));
-    });
-    addEntry({ type: "success", message: "A", context: { worktreeId: "wt-1" } });
-    addEntry({ type: "error", message: "B", context: { worktreeId: "wt-2" } });
-
-    const realNow = Date.now;
-    Date.now = () => realNow() + 5000;
-
-    act(() => {
-      window.dispatchEvent(new Event("focus"));
-    });
-
-    Date.now = realNow;
-
-    expect(result.current.singleWorktreeId).toBeNull();
   });
 
   it("dismiss hides the summary", () => {
@@ -226,7 +223,11 @@ describe("useReEntrySummary", () => {
     act(() => {
       window.dispatchEvent(new Event("blur"));
     });
-    addEntry({ type: "success", message: "Test" });
+    addEntry({
+      type: "success",
+      message: "Test",
+      context: { worktreeId: "wt-1" },
+    });
 
     const realNow = Date.now;
     Date.now = () => realNow() + 5000;
@@ -246,6 +247,204 @@ describe("useReEntrySummary", () => {
     expect(result.current.visible).toBe(false);
   });
 
+  it("groups entries by worktreeId and picks worst severity and highlight title", () => {
+    const { result } = renderHook(() => useReEntrySummary());
+
+    act(() => {
+      window.dispatchEvent(new Event("blur"));
+    });
+    addEntry({
+      type: "info",
+      message: "Info message",
+      title: "Info Title",
+      context: { worktreeId: "wt-1" },
+    });
+    addEntry({
+      type: "error",
+      message: "Error message",
+      title: "Error Title",
+      context: { worktreeId: "wt-1" },
+    });
+
+    const realNow = Date.now;
+    Date.now = () => realNow() + 5000;
+
+    act(() => {
+      window.dispatchEvent(new Event("focus"));
+    });
+
+    Date.now = realNow;
+
+    expect(result.current.visible).toBe(true);
+    expect(result.current.rows).toHaveLength(1);
+    expect(result.current.rows[0]!.worktreeId).toBe("wt-1");
+    expect(result.current.rows[0]!.worstType).toBe("error");
+    expect(result.current.rows[0]!.highlightTitle).toBe("Error Title");
+    expect(result.current.rows[0]!.entryCount).toBe(2);
+  });
+
+  it("falls back to message when title is undefined", () => {
+    const { result } = renderHook(() => useReEntrySummary());
+
+    act(() => {
+      window.dispatchEvent(new Event("blur"));
+    });
+    addEntry({
+      type: "warning",
+      message: "Warning fallback",
+      context: { worktreeId: "wt-1" },
+    });
+
+    const realNow = Date.now;
+    Date.now = () => realNow() + 5000;
+
+    act(() => {
+      window.dispatchEvent(new Event("focus"));
+    });
+
+    Date.now = realNow;
+
+    expect(result.current.rows[0]!.highlightTitle).toBe("Warning fallback");
+  });
+
+  it("sorts rows by severity, then entry count, then worktree name", () => {
+    const { result } = renderHook(() => useReEntrySummary());
+
+    act(() => {
+      window.dispatchEvent(new Event("blur"));
+    });
+    addEntry({
+      type: "info",
+      message: "A",
+      context: { worktreeId: "wt-info" },
+    });
+    addEntry({
+      type: "error",
+      message: "B",
+      context: { worktreeId: "wt-error" },
+    });
+    addEntry({
+      type: "warning",
+      message: "C",
+      context: { worktreeId: "wt-warn" },
+    });
+
+    const realNow = Date.now;
+    Date.now = () => realNow() + 5000;
+
+    act(() => {
+      window.dispatchEvent(new Event("focus"));
+    });
+
+    Date.now = realNow;
+
+    expect(result.current.rows[0]!.worstType).toBe("error");
+    expect(result.current.rows[1]!.worstType).toBe("warning");
+    expect(result.current.rows[2]!.worstType).toBe("info");
+  });
+
+  it("caps rows at 3 and sets overflowCount", () => {
+    const { result } = renderHook(() => useReEntrySummary());
+
+    act(() => {
+      window.dispatchEvent(new Event("blur"));
+    });
+    for (let i = 0; i < 5; i++) {
+      addEntry({
+        type: "info",
+        message: `Entry ${i}`,
+        context: { worktreeId: `wt-${i}` },
+      });
+    }
+
+    const realNow = Date.now;
+    Date.now = () => realNow() + 5000;
+
+    act(() => {
+      window.dispatchEvent(new Event("focus"));
+    });
+
+    Date.now = realNow;
+
+    expect(result.current.rows).toHaveLength(3);
+    expect(result.current.overflowCount).toBe(2);
+  });
+
+  it("resolves worktree name from current view store", async () => {
+    const { getCurrentViewStoreOrNull } = await import("@/store/createWorktreeStore");
+    vi.mocked(getCurrentViewStoreOrNull).mockReturnValue({
+      getState: () => ({
+        worktrees: new Map([["wt-1", { name: "feature-xyz" }]]),
+      }),
+    } as ReturnType<typeof getCurrentViewStoreOrNull>);
+
+    const { result } = renderHook(() => useReEntrySummary());
+
+    act(() => {
+      window.dispatchEvent(new Event("blur"));
+    });
+    addEntry({
+      type: "success",
+      message: "Done",
+      context: { worktreeId: "wt-1" },
+    });
+
+    const realNow = Date.now;
+    Date.now = () => realNow() + 5000;
+
+    act(() => {
+      window.dispatchEvent(new Event("focus"));
+    });
+
+    Date.now = realNow;
+
+    expect(result.current.rows[0]!.worktreeName).toBe("feature-xyz");
+  });
+
+  it("falls back to truncated worktreeId when worktree not in store", () => {
+    const { result } = renderHook(() => useReEntrySummary());
+
+    act(() => {
+      window.dispatchEvent(new Event("blur"));
+    });
+    addEntry({
+      type: "success",
+      message: "Done",
+      context: { worktreeId: "abcdef1234567890" },
+    });
+
+    const realNow = Date.now;
+    Date.now = () => realNow() + 5000;
+
+    act(() => {
+      window.dispatchEvent(new Event("focus"));
+    });
+
+    Date.now = realNow;
+
+    expect(result.current.rows[0]!.worktreeName).toBe("abcdef123456");
+  });
+
+  it("suppresses card when all entries lack worktreeId", () => {
+    const { result } = renderHook(() => useReEntrySummary());
+
+    act(() => {
+      window.dispatchEvent(new Event("blur"));
+    });
+    addEntry({ type: "success", message: "No worktree" });
+
+    const realNow = Date.now;
+    Date.now = () => realNow() + 5000;
+
+    act(() => {
+      window.dispatchEvent(new Event("focus"));
+    });
+
+    Date.now = realNow;
+
+    expect(result.current.visible).toBe(false);
+  });
+
   it("only includes entries created during the blur period", () => {
     const realNow = Date.now;
     let now = 10000;
@@ -253,7 +452,11 @@ describe("useReEntrySummary", () => {
 
     const { result } = renderHook(() => useReEntrySummary());
 
-    addEntry({ type: "info", message: "Old low-priority" });
+    addEntry({
+      type: "info",
+      message: "Old low-priority",
+      context: { worktreeId: "wt-old" },
+    });
 
     now += 5000;
     act(() => {
@@ -261,7 +464,11 @@ describe("useReEntrySummary", () => {
     });
 
     now += 1000;
-    addEntry({ type: "error", message: "During blur" });
+    addEntry({
+      type: "error",
+      message: "During blur",
+      context: { worktreeId: "wt-new" },
+    });
 
     now += 4000;
     act(() => {

--- a/src/hooks/__tests__/useReEntrySummary.test.tsx
+++ b/src/hooks/__tests__/useReEntrySummary.test.tsx
@@ -425,6 +425,78 @@ describe("useReEntrySummary", () => {
     expect(result.current.rows[0]!.worktreeName).toBe("abcdef123456");
   });
 
+  it("falls back to truncated ID when worktree name is empty string", async () => {
+    const { getCurrentViewStoreOrNull } = await import("@/store/createWorktreeStore");
+    vi.mocked(getCurrentViewStoreOrNull).mockReturnValue({
+      getState: () => ({
+        worktrees: new Map([["wt-1", { name: "" }]]),
+      }),
+    } as ReturnType<typeof getCurrentViewStoreOrNull>);
+
+    const { result } = renderHook(() => useReEntrySummary());
+
+    act(() => {
+      window.dispatchEvent(new Event("blur"));
+    });
+    addEntry({ type: "success", message: "Done", context: { worktreeId: "wt-1" } });
+
+    const realNow = Date.now;
+    Date.now = () => realNow() + 5000;
+
+    act(() => {
+      window.dispatchEvent(new Event("focus"));
+    });
+
+    Date.now = realNow;
+
+    expect(result.current.rows[0]!.worktreeName).toBe("wt-1");
+  });
+
+  it("sorts by name as tiebreaker when severity and count are equal", () => {
+    const { result } = renderHook(() => useReEntrySummary());
+
+    act(() => {
+      window.dispatchEvent(new Event("blur"));
+    });
+    addEntry({ type: "info", message: "Z", context: { worktreeId: "wt-zeta" } });
+    addEntry({ type: "info", message: "A", context: { worktreeId: "wt-alpha" } });
+    addEntry({ type: "info", message: "B", context: { worktreeId: "wt-beta" } });
+
+    const realNow = Date.now;
+    Date.now = () => realNow() + 5000;
+
+    act(() => {
+      window.dispatchEvent(new Event("focus"));
+    });
+
+    Date.now = realNow;
+
+    expect(result.current.rows[0]!.worktreeId).toBe("wt-alpha");
+    expect(result.current.rows[1]!.worktreeId).toBe("wt-beta");
+    expect(result.current.rows[2]!.worktreeId).toBe("wt-zeta");
+  });
+
+  it("marks entries as summarized even when card is suppressed (no worktreeId)", () => {
+    renderHook(() => useReEntrySummary());
+
+    act(() => {
+      window.dispatchEvent(new Event("blur"));
+    });
+    addEntry({ type: "success", message: "No worktree" });
+
+    const realNow = Date.now;
+    Date.now = () => realNow() + 5000;
+
+    act(() => {
+      window.dispatchEvent(new Event("focus"));
+    });
+
+    Date.now = realNow;
+
+    const storeEntries = useNotificationHistoryStore.getState().entries;
+    expect(storeEntries[0]!.summarized).toBe(true);
+  });
+
   it("suppresses card when all entries lack worktreeId", () => {
     const { result } = renderHook(() => useReEntrySummary());
 

--- a/src/hooks/index.ts
+++ b/src/hooks/index.ts
@@ -61,7 +61,7 @@ export { useWindowNotifications } from "./useWindowNotifications";
 export { useWatchedPanelNotifications } from "./useWatchedPanelNotifications";
 
 export { useReEntrySummary } from "./useReEntrySummary";
-export type { ReEntrySummaryState, ReEntryCounts } from "./useReEntrySummary";
+export type { ReEntrySummaryState, WorktreeRow } from "./useReEntrySummary";
 
 export { useWorktreeActions } from "./useWorktreeActions";
 export type { UseWorktreeActionsOptions, WorktreeActions } from "./useWorktreeActions";

--- a/src/hooks/useReEntrySummary.ts
+++ b/src/hooks/useReEntrySummary.ts
@@ -3,45 +3,89 @@ import {
   useNotificationHistoryStore,
   type NotificationHistoryEntry,
 } from "@/store/slices/notificationHistorySlice";
+import { getCurrentViewStoreOrNull } from "@/store/createWorktreeStore";
 
 const MIN_BLUR_MS = 3000;
 
-export interface ReEntryCounts {
-  warning: number;
-  error: number;
-  success: number;
-  info: number;
+const SEVERITY_WEIGHTS: Record<NotificationHistoryEntry["type"], number> = {
+  error: 3,
+  warning: 2,
+  info: 1,
+  success: 0,
+};
+
+export interface WorktreeRow {
+  worktreeId: string;
+  worktreeName: string;
+  worstType: NotificationHistoryEntry["type"];
+  highlightTitle: string;
+  entryCount: number;
 }
 
 export interface ReEntrySummaryState {
   visible: boolean;
   entries: NotificationHistoryEntry[];
-  counts: ReEntryCounts;
-  singleWorktreeId: string | null;
+  rows: WorktreeRow[];
+  overflowCount: number;
   dismiss: () => void;
 }
 
-function computeCounts(entries: NotificationHistoryEntry[]): ReEntryCounts {
-  const counts: ReEntryCounts = { warning: 0, error: 0, success: 0, info: 0 };
-  for (const e of entries) {
-    counts[e.type]++;
-  }
-  return counts;
-}
+function buildWorktreeRows(entries: NotificationHistoryEntry[]): WorktreeRow[] {
+  const byWorktree = new Map<string, NotificationHistoryEntry[]>();
 
-function getSingleWorktreeId(entries: NotificationHistoryEntry[]): string | null {
-  const ids = new Set<string>();
   for (const e of entries) {
-    if (e.context?.worktreeId) ids.add(e.context.worktreeId);
+    const wid = e.context?.worktreeId;
+    if (!wid) continue;
+    const group = byWorktree.get(wid);
+    if (group) {
+      group.push(e);
+    } else {
+      byWorktree.set(wid, [e]);
+    }
   }
-  return ids.size === 1 ? ([...ids][0] ?? null) : null;
+
+  const worktrees = getCurrentViewStoreOrNull()?.getState().worktrees ?? new Map();
+
+  const rows: WorktreeRow[] = [];
+
+  for (const [worktreeId, groupEntries] of byWorktree) {
+    let worst = groupEntries[0]!;
+    for (let i = 1; i < groupEntries.length; i++) {
+      const e = groupEntries[i]!;
+      const ww = SEVERITY_WEIGHTS[e.type];
+      const cw = SEVERITY_WEIGHTS[worst.type];
+      if (ww > cw || (ww === cw && e.timestamp > worst.timestamp)) {
+        worst = e;
+      }
+    }
+
+    const worktreeName = worktrees.get(worktreeId)?.name ?? worktreeId.slice(0, 12);
+
+    rows.push({
+      worktreeId,
+      worktreeName,
+      worstType: worst.type,
+      highlightTitle: worst.title?.trim() || worst.message,
+      entryCount: groupEntries.length,
+    });
+  }
+
+  rows.sort((a, b) => {
+    const sv = SEVERITY_WEIGHTS[b.worstType] - SEVERITY_WEIGHTS[a.worstType];
+    if (sv !== 0) return sv;
+    const cv = b.entryCount - a.entryCount;
+    if (cv !== 0) return cv;
+    return a.worktreeName.localeCompare(b.worktreeName);
+  });
+
+  return rows;
 }
 
 const EMPTY: ReEntrySummaryState = {
   visible: false,
   entries: [],
-  counts: { warning: 0, error: 0, success: 0, info: 0 },
-  singleWorktreeId: null,
+  rows: [],
+  overflowCount: 0,
   dismiss: () => {},
 };
 
@@ -50,8 +94,8 @@ export function useReEntrySummary(): ReEntrySummaryState {
   const [state, setState] = useState<Omit<ReEntrySummaryState, "dismiss">>({
     visible: false,
     entries: [],
-    counts: { warning: 0, error: 0, success: 0, info: 0 },
-    singleWorktreeId: null,
+    rows: [],
+    overflowCount: 0,
   });
 
   const dismiss = useCallback(() => {
@@ -72,12 +116,15 @@ export function useReEntrySummary(): ReEntrySummaryState {
       );
       if (unseen.length === 0) return;
 
+      const allRows = buildWorktreeRows(unseen);
+      if (allRows.length === 0) return;
+
       markSummarized(unseen.map((e) => e.id));
       setState({
         visible: true,
         entries: unseen,
-        counts: computeCounts(unseen),
-        singleWorktreeId: getSingleWorktreeId(unseen),
+        rows: allRows.slice(0, 3),
+        overflowCount: Math.max(0, allRows.length - 3),
       });
     };
 

--- a/src/hooks/useReEntrySummary.ts
+++ b/src/hooks/useReEntrySummary.ts
@@ -59,7 +59,7 @@ function buildWorktreeRows(entries: NotificationHistoryEntry[]): WorktreeRow[] {
       }
     }
 
-    const worktreeName = worktrees.get(worktreeId)?.name ?? worktreeId.slice(0, 12);
+    const worktreeName = worktrees.get(worktreeId)?.name?.trim() || worktreeId.slice(0, 12);
 
     rows.push({
       worktreeId,
@@ -116,10 +116,10 @@ export function useReEntrySummary(): ReEntrySummaryState {
       );
       if (unseen.length === 0) return;
 
+      markSummarized(unseen.map((e) => e.id));
+
       const allRows = buildWorktreeRows(unseen);
       if (allRows.length === 0) return;
-
-      markSummarized(unseen.map((e) => e.id));
       setState({
         visible: true,
         entries: unseen,


### PR DESCRIPTION
## Summary
Rather than showing aggregate counts, the re-entry summary card now names up to 3 worktrees. Each row shows the severity icon, the worktree name, and the entry title -- all clickable through to that worktree. A pin button lets the card persist past auto-dismiss.

This is built for parallel-agent workflows with 5-30 active worktrees, where the old counts couldn't answer whether anything actually needs attention.

Resolves #6841

## Changes
- `useReEntrySummary` groups notifications by worktree and resolves names from the store, falling back to a short `worktreeId` slice when the lookup misses
- `ReEntrySummary` renders named rows with severity icons and a pin button, dropping the now-redundant single-worktree shortcut
- Status text is always the entry's own title -- never an AI-generated summary
- 34 tests across hook and component suites covering grouping, sorting, overflow, fallback, pin, and timer behavior