### PR TITLE
fix(crash-recovery): refine dialog microcopy and gate auto-restore on crash loops

### DIFF
--- a/electron/ipc/handlers/app/crashRecovery.ts
+++ b/electron/ipc/handlers/app/crashRecovery.ts
@@ -15,7 +15,9 @@ export function registerCrashRecoveryHandlers(): () => void {
       if (getCrashLoopGuard().isSafeMode()) {
         return null;
       }
-      return getCrashRecoveryService().getPendingCrash();
+      const pending = getCrashRecoveryService().getPendingCrash();
+      if (!pending) return null;
+      return { ...pending, crashCount: getCrashLoopGuard().getCrashCount() };
     })
   );
 

--- a/shared/types/ipc/crashRecovery.ts
+++ b/shared/types/ipc/crashRecovery.ts
@@ -58,6 +58,7 @@ export interface PendingCrash {
   hasBackup: boolean;
   backupTimestamp?: number;
   panels?: PanelSummary[];
+  crashCount?: number;
 }
 
 export interface CrashRecoveryConfig {

--- a/src/components/Recovery/CrashRecoveryDialog.tsx
+++ b/src/components/Recovery/CrashRecoveryDialog.tsx
@@ -50,6 +50,7 @@ export function CrashRecoveryDialog({
 }: CrashRecoveryDialogProps) {
   const panels = useMemo(() => crash.panels ?? [], [crash.panels]);
   const hasPanels = panels.length > 0;
+  const isInCrashLoop = (crash.crashCount ?? 0) >= 2;
 
   const [selectedIds, setSelectedIds] = useState<Set<string>>(
     () => new Set(panels.map((p) => p.id))
@@ -218,7 +219,7 @@ export function CrashRecoveryDialog({
                 disabled={resolving}
                 data-testid="fresh-button"
               >
-                Start fresh
+                Continue without restoring
               </Button>
             </div>
 
@@ -265,7 +266,9 @@ export function CrashRecoveryDialog({
                 <div className="h-2 w-2 rounded-full bg-daintree-text/40" />
               </div>
               <div>
-                <div className="text-sm font-medium text-daintree-text">Start fresh</div>
+                <div className="text-sm font-medium text-daintree-text">
+                  Continue without restoring
+                </div>
                 <div className="text-xs text-daintree-text/60 mt-0.5">
                   Reset to a clean layout — open panels will be cleared
                 </div>
@@ -371,27 +374,38 @@ export function CrashRecoveryDialog({
                   className="text-xs text-status-warning/90 bg-status-warning/10 rounded px-2 py-1.5"
                   data-testid="privacy-warning"
                 >
-                  Crash info may include panel titles, panel kinds, file paths, and stack traces.
-                  Click again to copy to clipboard and open GitHub Issues. You'll need to paste the
-                  info into the form.
+                  Opens GitHub Issues in your browser. The report includes platform info, app
+                  version, panel kinds, file paths, error message, and stack trace — and will be
+                  publicly visible. Review before pasting.
                 </p>
               )}
             </div>
           )}
         </div>
 
-        <label className="flex items-center gap-2 cursor-pointer" data-testid="auto-restore-label">
-          <input
-            type="checkbox"
-            checked={config.autoRestoreOnCrash}
-            onChange={(e) => handleAutoRestore(e.target.checked)}
-            className="accent-daintree-accent h-4 w-4"
-            data-testid="auto-restore-checkbox"
-          />
-          <span className="text-xs text-daintree-text/60">
-            Always restore sessions automatically
-          </span>
-        </label>
+        {isInCrashLoop ? (
+          config.autoRestoreOnCrash && (
+            <p className="text-xs text-daintree-text/60" data-testid="auto-restore-paused">
+              Auto-restore paused — too many consecutive crashes.
+            </p>
+          )
+        ) : (
+          <label
+            className="flex items-center gap-2 cursor-pointer"
+            data-testid="auto-restore-label"
+          >
+            <input
+              type="checkbox"
+              checked={config.autoRestoreOnCrash}
+              onChange={(e) => handleAutoRestore(e.target.checked)}
+              className="accent-daintree-accent h-4 w-4"
+              data-testid="auto-restore-checkbox"
+            />
+            <span className="text-xs text-daintree-text/60">
+              Always restore sessions automatically
+            </span>
+          </label>
+        )}
       </AppDialog.Body>
     </AppDialog>
   );

--- a/src/components/Recovery/__tests__/CrashRecoveryDialog.test.tsx
+++ b/src/components/Recovery/__tests__/CrashRecoveryDialog.test.tsx
@@ -211,7 +211,7 @@ describe("CrashRecoveryDialog", () => {
       expect(call.panelIds).not.toContain("t2");
     });
 
-    it("calls onResolve with fresh when Start Fresh is clicked", async () => {
+    it("calls onResolve with fresh when 'Continue without restoring' is clicked", async () => {
       const { onResolve } = setup();
       fireEvent.click(screen.getByTestId("fresh-button"));
       await waitFor(() => expect(onResolve).toHaveBeenCalledWith({ kind: "fresh" }));

--- a/src/components/Recovery/__tests__/CrashRecoveryDialog.test.tsx
+++ b/src/components/Recovery/__tests__/CrashRecoveryDialog.test.tsx
@@ -308,10 +308,10 @@ describe("CrashRecoveryDialog", () => {
     fireEvent.click(screen.getByTestId("details-toggle"));
     fireEvent.click(screen.getByTestId("report-button"));
     expect(screen.getByTestId("privacy-warning")).toBeTruthy();
-    expect(screen.getByTestId("privacy-warning").textContent).toContain("copy to clipboard");
     expect(screen.getByTestId("privacy-warning").textContent).toContain(
-      "You'll need to paste the info into the form"
+      "Opens GitHub Issues in your browser"
     );
+    expect(screen.getByTestId("privacy-warning").textContent).toContain("publicly visible");
     expect(screen.getByTestId("report-button").textContent).toContain("Copy & report on GitHub");
 
     fireEvent.click(screen.getByTestId("report-button"));
@@ -325,6 +325,34 @@ describe("CrashRecoveryDialog", () => {
     const { onUpdateConfig } = setup();
     fireEvent.click(screen.getByTestId("auto-restore-checkbox"));
     await waitFor(() => expect(onUpdateConfig).toHaveBeenCalledWith({ autoRestoreOnCrash: true }));
+  });
+
+  describe("crash-loop guard", () => {
+    it("shows the auto-restore checkbox when crashCount is undefined", () => {
+      setup();
+      expect(screen.getByTestId("auto-restore-checkbox")).toBeTruthy();
+      expect(screen.queryByTestId("auto-restore-paused")).toBeNull();
+    });
+
+    it("shows the auto-restore checkbox when crashCount is 1", () => {
+      setup({ crash: { crashCount: 1 } });
+      expect(screen.getByTestId("auto-restore-checkbox")).toBeTruthy();
+      expect(screen.queryByTestId("auto-restore-paused")).toBeNull();
+    });
+
+    it("hides the checkbox at crashCount 2 with auto-restore disabled", () => {
+      setup({ crash: { crashCount: 2 }, config: { autoRestoreOnCrash: false } });
+      expect(screen.queryByTestId("auto-restore-checkbox")).toBeNull();
+      expect(screen.queryByTestId("auto-restore-paused")).toBeNull();
+    });
+
+    it("hides the checkbox and shows paused note at crashCount 2 with auto-restore enabled", () => {
+      setup({ crash: { crashCount: 2 }, config: { autoRestoreOnCrash: true } });
+      expect(screen.queryByTestId("auto-restore-checkbox")).toBeNull();
+      const note = screen.getByTestId("auto-restore-paused");
+      expect(note.textContent).toContain("Auto-restore paused");
+      expect(note.textContent).toContain("too many consecutive crashes");
+    });
   });
 
   it("shows environment metadata in detail section", () => {

--- a/src/hooks/__tests__/useCrashRecoveryGate.test.tsx
+++ b/src/hooks/__tests__/useCrashRecoveryGate.test.tsx
@@ -125,6 +125,57 @@ describe("useCrashRecoveryGate", () => {
     expect(result.current.state.status).toBe("none");
   });
 
+  it("skips auto-restore at crashCount 2 and surfaces the dialog", async () => {
+    const resolve = vi.fn(async () => {});
+    Object.defineProperty(window, "electron", {
+      configurable: true,
+      writable: true,
+      value: makeElectron({
+        pending: { ...mockCrash, crashCount: 2 },
+        config: { autoRestoreOnCrash: true },
+        resolve,
+      }),
+    });
+
+    const { result } = renderHook(() => useCrashRecoveryGate());
+
+    await act(async () => {
+      await Promise.resolve();
+      await Promise.resolve();
+      await Promise.resolve();
+    });
+
+    expect(resolve).not.toHaveBeenCalled();
+    expect(result.current.state.status).toBe("pending");
+  });
+
+  it("auto-restores at crashCount 1 (below crash-loop threshold)", async () => {
+    const resolve = vi.fn(async () => {});
+    Object.defineProperty(window, "electron", {
+      configurable: true,
+      writable: true,
+      value: makeElectron({
+        pending: { ...mockCrash, crashCount: 1 },
+        config: { autoRestoreOnCrash: true },
+        resolve,
+      }),
+    });
+
+    const { result } = renderHook(() => useCrashRecoveryGate());
+
+    await act(async () => {
+      await Promise.resolve();
+      await Promise.resolve();
+      await Promise.resolve();
+    });
+
+    expect(resolve).toHaveBeenCalledWith({
+      kind: "restore",
+      panelIds: ["t1", "t2"],
+    });
+    expect(result.current.state.status).toBe("none");
+  });
+
   it("auto-restores with empty panelIds when no panels available", async () => {
     const resolve = vi.fn(async () => {});
     const crashNoPanels: PendingCrash = {

--- a/src/hooks/__tests__/useCrashRecoveryGate.test.tsx
+++ b/src/hooks/__tests__/useCrashRecoveryGate.test.tsx
@@ -248,6 +248,7 @@ describe("useCrashRecoveryGate", () => {
       await result.current.updateConfig({ autoRestoreOnCrash: true });
     });
 
+    expect(result.current.state.status).toBe("pending");
     if (result.current.state.status === "pending") {
       expect(result.current.state.config.autoRestoreOnCrash).toBe(true);
     }

--- a/src/hooks/app/useCrashRecoveryGate.ts
+++ b/src/hooks/app/useCrashRecoveryGate.ts
@@ -29,7 +29,7 @@ export function useCrashRecoveryGate(): {
           return;
         }
 
-        if (config.autoRestoreOnCrash) {
+        if (config.autoRestoreOnCrash && (pending.crashCount ?? 0) < 2) {
           const allPanelIds = (pending.panels ?? []).map((p) => p.id);
           electron.crashRecovery
             .resolve({ kind: "restore", panelIds: allPanelIds })


### PR DESCRIPTION
## Summary

- Renamed the two `Start fresh` labels to `Continue without restoring` — the original read as a factory reset rather than a decline-restore action
- Gated the auto-restore checkbox on crash-loop state: at `crashCount >= 2` the checkbox is replaced with an inline note that auto-restore is paused; `useCrashRecoveryGate` also skips the auto-restore branch at that threshold to prevent looping
- Rewrote the privacy warning paragraph destination-first so users see where the report goes (GitHub Issues, publicly visible) before the payload list

Resolves #6868

## Changes

- `shared/types/ipc/crashRecovery.ts` — added `crashCount?: number` to `PendingCrash`
- `electron/ipc/handlers/app/crashRecovery.ts` — `CRASH_RECOVERY_GET_PENDING` augments the payload with `getCrashLoopGuard().getCrashCount()` after a defensive null check
- `src/hooks/app/useCrashRecoveryGate.ts` — auto-restore guard now bails when `(pending.crashCount ?? 0) >= 2`
- `src/components/Recovery/CrashRecoveryDialog.tsx` — button/card relabels, crash-loop inline note vs checkbox toggle, destination-first privacy warning
- Tests: 4 new dialog tests for crash-loop states, 2 new hook tests for the `crashCount` gate at 1 and 2; existing privacy-warning assertions updated; stale test description renamed

## Testing

42 component and hook tests passing. Typecheck, lint (ratchet), format, and build all clean.