### PR TITLE
feat(settings): roll validation errors to sidebar dot on remaining tabs

### DIFF
--- a/src/components/Settings/DaintreeAssistantSettingsTab.tsx
+++ b/src/components/Settings/DaintreeAssistantSettingsTab.tsx
@@ -17,6 +17,7 @@ import { SettingsSection } from "./SettingsSection";
 import { SettingsInput } from "./SettingsInput";
 import { SettingsSelect } from "./SettingsSelect";
 import { SettingsSwitchCard } from "./SettingsSwitchCard";
+import { useSettingsTabValidation } from "./SettingsValidationRegistry";
 import { formatErrorMessage } from "@shared/utils/errorMessage";
 
 import { logError } from "@/utils/logger";
@@ -53,6 +54,8 @@ export function DaintreeAssistantSettingsTab() {
   const [error, setError] = useState<string | null>(null);
   const [copied, setCopied] = useState(false);
   const copyTimeoutRef = useRef<ReturnType<typeof setTimeout> | null>(null);
+
+  useSettingsTabValidation("assistant", Boolean(error));
 
   const preferredAgentId = useHelpPanelStore((s) => s.preferredAgentId);
   const setPreferredAgent = useHelpPanelStore((s) => s.setPreferredAgent);

--- a/src/components/Settings/GitHubSettingsTab.tsx
+++ b/src/components/Settings/GitHubSettingsTab.tsx
@@ -153,7 +153,7 @@ export function GitHubSettingsTab() {
     );
   }, []);
 
-  useSettingsTabValidation("github", Boolean(loadError));
+  useSettingsTabValidation("github", Boolean(loadError) || loadTimedOut);
 
   if (isLoading) {
     if (loadTimedOut) {

--- a/src/components/Settings/GitHubSettingsTab.tsx
+++ b/src/components/Settings/GitHubSettingsTab.tsx
@@ -6,6 +6,7 @@ import { useGitHubConfigStore } from "@/store";
 import { actionService } from "@/services/ActionService";
 import type { GitHubTokenConfig, GitHubTokenValidation } from "@/types";
 import { SettingsSection } from "./SettingsSection";
+import { useSettingsTabValidation } from "./SettingsValidationRegistry";
 import { logError } from "@/utils/logger";
 
 type ValidationResult = "success" | "error" | "test-success" | "test-error" | null;
@@ -151,6 +152,8 @@ export function GitHubSettingsTab() {
       { source: "user" }
     );
   }, []);
+
+  useSettingsTabValidation("github", Boolean(loadError));
 
   if (isLoading) {
     if (loadTimedOut) {

--- a/src/components/Settings/McpServerSettingsTab.tsx
+++ b/src/components/Settings/McpServerSettingsTab.tsx
@@ -17,6 +17,7 @@ import { Button } from "@/components/ui/button";
 import { EmptyState } from "@/components/ui/EmptyState";
 import { SettingsSection } from "@/components/Settings/SettingsSection";
 import { SettingsSwitchCard } from "@/components/Settings/SettingsSwitchCard";
+import { useSettingsTabValidation } from "@/components/Settings/SettingsValidationRegistry";
 import { formatErrorMessage } from "@shared/utils/errorMessage";
 import { logError } from "@/utils/logger";
 import {
@@ -89,6 +90,8 @@ export function McpServerSettingsTab() {
   const [auditLoading, setAuditLoading] = useState(true);
   const [toolFilter, setToolFilter] = useState("");
   const [resultFilter, setResultFilter] = useState<AuditResultFilter>("all");
+
+  useSettingsTabValidation("mcp", Boolean(error));
 
   const refreshAuditRecords = useCallback(async (): Promise<void> => {
     try {

--- a/src/components/Settings/SettingsValidationRegistry.tsx
+++ b/src/components/Settings/SettingsValidationRegistry.tsx
@@ -69,10 +69,12 @@ export function useSettingsTabValidation(tab: SettingsTab, hasError: boolean) {
     throw new Error("useSettingsTabValidation must be used within a SettingsValidationProvider");
   }
 
+  const { setTabHasError, clearTab } = context;
+
   useEffect(() => {
-    context.setTabHasError(tab, hasError);
+    setTabHasError(tab, hasError);
     return () => {
-      context.clearTab(tab);
+      clearTab(tab);
     };
-  }, [context, tab, hasError]);
+  }, [setTabHasError, clearTab, tab, hasError]);
 }

--- a/src/components/Settings/VoiceInputSettingsTab.tsx
+++ b/src/components/Settings/VoiceInputSettingsTab.tsx
@@ -23,6 +23,7 @@ import { SettingsSection } from "./SettingsSection";
 import { SettingsSwitchCard } from "./SettingsSwitchCard";
 import { SettingsSelect } from "./SettingsSelect";
 import { SettingsTextarea } from "./SettingsTextarea";
+import { useSettingsTabValidation } from "./SettingsValidationRegistry";
 import { dispatchVoiceInputSettingsChanged } from "@/lib/voiceInputSettingsEvents";
 import { logWarn } from "@/utils/logger";
 import { formatErrorMessage } from "@shared/utils/errorMessage";
@@ -187,6 +188,8 @@ export function VoiceInputSettingsTab() {
   const removeDictionaryWord = (word: string) => {
     update({ customDictionary: settings.customDictionary.filter((w) => w !== word) });
   };
+
+  useSettingsTabValidation("voice", loadState === "error");
 
   if (loadState === "loading") {
     return (

--- a/src/components/Settings/__tests__/DaintreeAssistantSettingsTab.test.tsx
+++ b/src/components/Settings/__tests__/DaintreeAssistantSettingsTab.test.tsx
@@ -99,6 +99,7 @@ vi.mock("@/config/agents", () => ({
 }));
 
 import { DaintreeAssistantSettingsTab } from "../DaintreeAssistantSettingsTab";
+import { SettingsValidationProvider } from "../SettingsValidationRegistry";
 
 const writeText = vi.fn().mockResolvedValue(undefined);
 
@@ -174,7 +175,11 @@ describe("DaintreeAssistantSettingsTab", () => {
     );
 
   it("loads settings and MCP status on mount", async () => {
-    const { container } = render(<DaintreeAssistantSettingsTab />);
+    const { container } = render(
+      <SettingsValidationProvider>
+        <DaintreeAssistantSettingsTab />
+      </SettingsValidationProvider>
+    );
     await waitForContent(container, "Search documentation");
 
     expect(window.electron.helpAssistant.getSettings).toHaveBeenCalledTimes(1);
@@ -182,7 +187,11 @@ describe("DaintreeAssistantSettingsTab", () => {
   });
 
   it("toggling doc search persists docSearch=false", async () => {
-    const { container } = render(<DaintreeAssistantSettingsTab />);
+    const { container } = render(
+      <SettingsValidationProvider>
+        <DaintreeAssistantSettingsTab />
+      </SettingsValidationProvider>
+    );
     await waitForContent(container, "Search documentation");
 
     const toggle = screen.getByLabelText("Allow the assistant to search Daintree documentation");
@@ -194,7 +203,11 @@ describe("DaintreeAssistantSettingsTab", () => {
   });
 
   it("turning on skip permissions reveals the inline warning copy", async () => {
-    const { container } = render(<DaintreeAssistantSettingsTab />);
+    const { container } = render(
+      <SettingsValidationProvider>
+        <DaintreeAssistantSettingsTab />
+      </SettingsValidationProvider>
+    );
     await waitForContent(container, "Skip permission prompts");
 
     expect(container.textContent).not.toContain("becomes the only safeguard");
@@ -209,7 +222,11 @@ describe("DaintreeAssistantSettingsTab", () => {
   });
 
   it("rotate key calls mcpServer.rotateApiKey", async () => {
-    const { container } = render(<DaintreeAssistantSettingsTab />);
+    const { container } = render(
+      <SettingsValidationProvider>
+        <DaintreeAssistantSettingsTab />
+      </SettingsValidationProvider>
+    );
     await waitForContent(container, "Rotate MCP key");
 
     fireEvent.click(screen.getByRole("button", { name: /rotate mcp key/i }));
@@ -220,7 +237,11 @@ describe("DaintreeAssistantSettingsTab", () => {
   });
 
   it("copy MCP config writes the snippet to the clipboard and shows confirmation", async () => {
-    const { container } = render(<DaintreeAssistantSettingsTab />);
+    const { container } = render(
+      <SettingsValidationProvider>
+        <DaintreeAssistantSettingsTab />
+      </SettingsValidationProvider>
+    );
     await waitForContent(container, "Copy MCP config");
 
     fireEvent.click(screen.getByRole("button", { name: /copy mcp config/i }));
@@ -245,7 +266,11 @@ describe("DaintreeAssistantSettingsTab", () => {
       }
     );
 
-    const { container } = render(<DaintreeAssistantSettingsTab />);
+    const { container } = render(
+      <SettingsValidationProvider>
+        <DaintreeAssistantSettingsTab />
+      </SettingsValidationProvider>
+    );
     await waitForContent(container, "MCP server is off");
 
     expect(screen.queryByRole("button", { name: /rotate mcp key/i })).toBeNull();
@@ -253,7 +278,11 @@ describe("DaintreeAssistantSettingsTab", () => {
   });
 
   it("does not render a Preferred model section", async () => {
-    const { container } = render(<DaintreeAssistantSettingsTab />);
+    const { container } = render(
+      <SettingsValidationProvider>
+        <DaintreeAssistantSettingsTab />
+      </SettingsValidationProvider>
+    );
     await waitForContent(container, "Search documentation");
 
     expect(container.textContent).not.toContain("Preferred model");
@@ -273,7 +302,11 @@ describe("DaintreeAssistantSettingsTab", () => {
       { getStatus: vi.fn().mockRejectedValue(new Error("ipc down")) }
     );
 
-    const { container } = render(<DaintreeAssistantSettingsTab />);
+    const { container } = render(
+      <SettingsValidationProvider>
+        <DaintreeAssistantSettingsTab />
+      </SettingsValidationProvider>
+    );
     await waitForContent(container, "Search documentation");
 
     const docSearchToggle = screen.getByLabelText(
@@ -288,7 +321,11 @@ describe("DaintreeAssistantSettingsTab", () => {
       setSettings: vi.fn().mockRejectedValue(new Error("disk full")),
     });
 
-    const { container } = render(<DaintreeAssistantSettingsTab />);
+    const { container } = render(
+      <SettingsValidationProvider>
+        <DaintreeAssistantSettingsTab />
+      </SettingsValidationProvider>
+    );
     await waitForContent(container, "Search documentation");
 
     fireEvent.click(screen.getByLabelText("Allow the assistant to search Daintree documentation"));
@@ -299,7 +336,11 @@ describe("DaintreeAssistantSettingsTab", () => {
   it("does not flash 'Copied' when clipboard.writeText rejects", async () => {
     writeText.mockRejectedValueOnce(new Error("permission denied"));
 
-    const { container } = render(<DaintreeAssistantSettingsTab />);
+    const { container } = render(
+      <SettingsValidationProvider>
+        <DaintreeAssistantSettingsTab />
+      </SettingsValidationProvider>
+    );
     await waitForContent(container, "Copy MCP config");
 
     fireEvent.click(screen.getByRole("button", { name: /copy mcp config/i }));
@@ -314,7 +355,11 @@ describe("DaintreeAssistantSettingsTab", () => {
     const setEnabled = vi.fn();
     installApi({}, { setEnabled });
 
-    const { container } = render(<DaintreeAssistantSettingsTab />);
+    const { container } = render(
+      <SettingsValidationProvider>
+        <DaintreeAssistantSettingsTab />
+      </SettingsValidationProvider>
+    );
     await waitForContent(container, "Daintree control");
 
     fireEvent.click(screen.getByLabelText("Allow the assistant to call Daintree control tools"));
@@ -328,7 +373,11 @@ describe("DaintreeAssistantSettingsTab", () => {
   });
 
   it("audit retention select offers off / 7 / 30 day options and persists changes", async () => {
-    const { container } = render(<DaintreeAssistantSettingsTab />);
+    const { container } = render(
+      <SettingsValidationProvider>
+        <DaintreeAssistantSettingsTab />
+      </SettingsValidationProvider>
+    );
     await waitForContent(container, "Audit log retention");
 
     const select = screen.getByLabelText("Audit log retention") as HTMLSelectElement;
@@ -345,7 +394,11 @@ describe("DaintreeAssistantSettingsTab", () => {
   });
 
   it("renders an agent dropdown listing assistant-supported agents", async () => {
-    const { container } = render(<DaintreeAssistantSettingsTab />);
+    const { container } = render(
+      <SettingsValidationProvider>
+        <DaintreeAssistantSettingsTab />
+      </SettingsValidationProvider>
+    );
     await waitForContent(container, "Agent");
 
     const select = screen.getByRole("combobox", { name: "Agent" }) as HTMLSelectElement;
@@ -354,7 +407,11 @@ describe("DaintreeAssistantSettingsTab", () => {
   });
 
   it("calls helpPanelStore.setPreferredAgent when the agent dropdown changes", async () => {
-    const { container } = render(<DaintreeAssistantSettingsTab />);
+    const { container } = render(
+      <SettingsValidationProvider>
+        <DaintreeAssistantSettingsTab />
+      </SettingsValidationProvider>
+    );
     await waitForContent(container, "Agent");
 
     const select = screen.getByRole("combobox", { name: "Agent" }) as HTMLSelectElement;
@@ -374,7 +431,11 @@ describe("DaintreeAssistantSettingsTab", () => {
       }),
     });
 
-    const { container } = render(<DaintreeAssistantSettingsTab />);
+    const { container } = render(
+      <SettingsValidationProvider>
+        <DaintreeAssistantSettingsTab />
+      </SettingsValidationProvider>
+    );
     await waitForContent(container, "Custom CLI args");
 
     const input = screen.getByLabelText("Custom CLI args") as HTMLInputElement;
@@ -382,7 +443,11 @@ describe("DaintreeAssistantSettingsTab", () => {
   });
 
   it("persists customArgs via setSettings on input change", async () => {
-    const { container } = render(<DaintreeAssistantSettingsTab />);
+    const { container } = render(
+      <SettingsValidationProvider>
+        <DaintreeAssistantSettingsTab />
+      </SettingsValidationProvider>
+    );
     await waitForContent(container, "Custom CLI args");
 
     const input = screen.getByLabelText("Custom CLI args") as HTMLInputElement;
@@ -406,7 +471,11 @@ describe("DaintreeAssistantSettingsTab", () => {
       }),
     });
 
-    const { container } = render(<DaintreeAssistantSettingsTab />);
+    const { container } = render(
+      <SettingsValidationProvider>
+        <DaintreeAssistantSettingsTab />
+      </SettingsValidationProvider>
+    );
     await waitForContent(container, "Custom CLI args");
 
     const input = screen.getByLabelText("Custom CLI args") as HTMLInputElement;

--- a/src/components/Settings/__tests__/GitHubSettingsTab.a11y.test.tsx
+++ b/src/components/Settings/__tests__/GitHubSettingsTab.a11y.test.tsx
@@ -2,6 +2,7 @@
 import { describe, it, expect, vi, beforeEach, afterEach } from "vitest";
 import { render, screen, fireEvent } from "@testing-library/react";
 import { GitHubSettingsTab } from "../GitHubSettingsTab";
+import { SettingsValidationProvider } from "../SettingsValidationRegistry";
 
 vi.mock("@/store", () => ({
   useGitHubConfigStore: vi.fn(),
@@ -41,7 +42,11 @@ describe("GitHubSettingsTab accessibility", () => {
   });
 
   it("password input has an accessible name and autoComplete", () => {
-    render(<GitHubSettingsTab />);
+    render(
+      <SettingsValidationProvider>
+        <GitHubSettingsTab />
+      </SettingsValidationProvider>
+    );
     const input = screen.getByLabelText(/github personal access token/i);
     expect(input).toBeTruthy();
     expect(input.getAttribute("type")).toBe("password");
@@ -49,21 +54,33 @@ describe("GitHubSettingsTab accessibility", () => {
   });
 
   it("Test button has aria-label and aria-busy=false when idle", () => {
-    render(<GitHubSettingsTab />);
+    render(
+      <SettingsValidationProvider>
+        <GitHubSettingsTab />
+      </SettingsValidationProvider>
+    );
     const btn = screen.getByRole("button", { name: "Test token" });
     expect(btn).toBeTruthy();
     expect(btn.getAttribute("aria-busy")).toBe("false");
   });
 
   it("Save button has aria-label and aria-busy=false when idle", () => {
-    render(<GitHubSettingsTab />);
+    render(
+      <SettingsValidationProvider>
+        <GitHubSettingsTab />
+      </SettingsValidationProvider>
+    );
     const btn = screen.getByRole("button", { name: "Save token" });
     expect(btn).toBeTruthy();
     expect(btn.getAttribute("aria-busy")).toBe("false");
   });
 
   it("decorative icons inside idle buttons have aria-hidden", () => {
-    render(<GitHubSettingsTab />);
+    render(
+      <SettingsValidationProvider>
+        <GitHubSettingsTab />
+      </SettingsValidationProvider>
+    );
     const testBtn = screen.getByRole("button", { name: "Test token" });
     const svgs = testBtn.querySelectorAll("svg");
     expect(svgs.length).toBeGreaterThan(0);
@@ -73,7 +90,11 @@ describe("GitHubSettingsTab accessibility", () => {
   });
 
   it("Test button shows aria-busy=true and retains accessible name during loading", () => {
-    render(<GitHubSettingsTab />);
+    render(
+      <SettingsValidationProvider>
+        <GitHubSettingsTab />
+      </SettingsValidationProvider>
+    );
     const input = screen.getByLabelText(/github personal access token/i);
     fireEvent.change(input, { target: { value: "ghp_test123" } });
 
@@ -91,7 +112,11 @@ describe("GitHubSettingsTab accessibility", () => {
   });
 
   it("Save button shows aria-busy=true and retains accessible name during loading", () => {
-    render(<GitHubSettingsTab />);
+    render(
+      <SettingsValidationProvider>
+        <GitHubSettingsTab />
+      </SettingsValidationProvider>
+    );
     const input = screen.getByLabelText(/github personal access token/i);
     fireEvent.change(input, { target: { value: "ghp_test123" } });
 
@@ -109,7 +134,11 @@ describe("GitHubSettingsTab accessibility", () => {
   });
 
   it("Create Token button opens GitHub with correct description", () => {
-    render(<GitHubSettingsTab />);
+    render(
+      <SettingsValidationProvider>
+        <GitHubSettingsTab />
+      </SettingsValidationProvider>
+    );
     const btn = screen.getByRole("button", { name: /create token on github/i });
     fireEvent.click(btn);
 

--- a/src/components/Settings/__tests__/GitHubSettingsTab.tokenSave.test.tsx
+++ b/src/components/Settings/__tests__/GitHubSettingsTab.tokenSave.test.tsx
@@ -2,6 +2,7 @@
 import { describe, it, expect, vi, beforeEach } from "vitest";
 import { render, screen, fireEvent, waitFor } from "@testing-library/react";
 import { GitHubSettingsTab } from "../GitHubSettingsTab";
+import { SettingsValidationProvider } from "../SettingsValidationRegistry";
 
 vi.mock("@/store", () => ({
   useGitHubConfigStore: vi.fn(),
@@ -63,7 +64,11 @@ describe("GitHubSettingsTab handleSaveToken", () => {
       return { ok: true, result: undefined } as never;
     });
 
-    render(<GitHubSettingsTab />);
+    render(
+      <SettingsValidationProvider>
+        <GitHubSettingsTab />
+      </SettingsValidationProvider>
+    );
 
     fireEvent.change(screen.getByLabelText(/github personal access token/i), {
       target: { value: "ghp_valid_token" },
@@ -96,7 +101,11 @@ describe("GitHubSettingsTab handleSaveToken", () => {
       return { ok: true, result: undefined } as never;
     });
 
-    render(<GitHubSettingsTab />);
+    render(
+      <SettingsValidationProvider>
+        <GitHubSettingsTab />
+      </SettingsValidationProvider>
+    );
 
     fireEvent.change(screen.getByLabelText(/github personal access token/i), {
       target: { value: "ghp_invalid" },
@@ -127,7 +136,11 @@ describe("GitHubSettingsTab handleSaveToken", () => {
       return { ok: true, result: undefined } as never;
     });
 
-    render(<GitHubSettingsTab />);
+    render(
+      <SettingsValidationProvider>
+        <GitHubSettingsTab />
+      </SettingsValidationProvider>
+    );
 
     fireEvent.change(screen.getByLabelText(/github personal access token/i), {
       target: { value: "ghp_token" },

--- a/src/components/Settings/__tests__/McpServerSettingsTab.test.tsx
+++ b/src/components/Settings/__tests__/McpServerSettingsTab.test.tsx
@@ -2,6 +2,7 @@
 import { render, screen, fireEvent, waitFor } from "@testing-library/react";
 import { describe, expect, it, vi, beforeEach } from "vitest";
 import { McpServerSettingsTab } from "../McpServerSettingsTab";
+import { SettingsValidationProvider } from "../SettingsValidationRegistry";
 import { notify } from "@/lib/notify";
 import { logError } from "@/utils/logger";
 
@@ -69,7 +70,11 @@ describe("McpServerSettingsTab", () => {
     );
 
   it("renders API key in a non-input display element", async () => {
-    const { container } = render(<McpServerSettingsTab />);
+    const { container } = render(
+      <SettingsValidationProvider>
+        <McpServerSettingsTab />
+      </SettingsValidationProvider>
+    );
     await waitForContent(container, "API key active");
 
     const displayArea = container.querySelector(".bg-surface-disabled");
@@ -81,7 +86,11 @@ describe("McpServerSettingsTab", () => {
   });
 
   it("shows masked bullets by default, reveals key on toggle", async () => {
-    const { container } = render(<McpServerSettingsTab />);
+    const { container } = render(
+      <SettingsValidationProvider>
+        <McpServerSettingsTab />
+      </SettingsValidationProvider>
+    );
     await waitForContent(container, "API key active");
 
     const displayArea = container.querySelector(".bg-surface-disabled")!;
@@ -100,7 +109,11 @@ describe("McpServerSettingsTab", () => {
   });
 
   it("copy button writes unmasked key to clipboard", async () => {
-    const { container } = render(<McpServerSettingsTab />);
+    const { container } = render(
+      <SettingsValidationProvider>
+        <McpServerSettingsTab />
+      </SettingsValidationProvider>
+    );
     await waitForContent(container, "API key active");
 
     fireEvent.click(screen.getByLabelText("Copy API key"));
@@ -110,7 +123,11 @@ describe("McpServerSettingsTab", () => {
   });
 
   it("copy button shows Copied! feedback", async () => {
-    const { container } = render(<McpServerSettingsTab />);
+    const { container } = render(
+      <SettingsValidationProvider>
+        <McpServerSettingsTab />
+      </SettingsValidationProvider>
+    );
     await waitForContent(container, "API key active");
 
     fireEvent.click(screen.getByLabelText("Copy API key"));
@@ -122,7 +139,11 @@ describe("McpServerSettingsTab", () => {
   });
 
   it("Rotate calls rotateApiKey and surfaces the new key", async () => {
-    const { container } = render(<McpServerSettingsTab />);
+    const { container } = render(
+      <SettingsValidationProvider>
+        <McpServerSettingsTab />
+      </SettingsValidationProvider>
+    );
     await waitForContent(container, "API key active");
 
     fireEvent.click(screen.getByTitle("Rotate API key"));
@@ -137,7 +158,11 @@ describe("McpServerSettingsTab", () => {
   });
 
   it("does not render a Remove button — the key is mandatory", async () => {
-    const { container } = render(<McpServerSettingsTab />);
+    const { container } = render(
+      <SettingsValidationProvider>
+        <McpServerSettingsTab />
+      </SettingsValidationProvider>
+    );
     await waitForContent(container, "API key active");
 
     expect(screen.queryByRole("button", { name: /^remove$/i })).toBeNull();
@@ -148,7 +173,11 @@ describe("McpServerSettingsTab", () => {
       getStatus: vi.fn().mockRejectedValue(new Error("IPC down")),
     });
 
-    const { container } = render(<McpServerSettingsTab />);
+    const { container } = render(
+      <SettingsValidationProvider>
+        <McpServerSettingsTab />
+      </SettingsValidationProvider>
+    );
 
     await waitForContent(container, "IPC down");
 
@@ -166,7 +195,11 @@ describe("McpServerSettingsTab", () => {
       }),
     });
 
-    const { container } = render(<McpServerSettingsTab />);
+    const { container } = render(
+      <SettingsValidationProvider>
+        <McpServerSettingsTab />
+      </SettingsValidationProvider>
+    );
     await waitForContent(container, "MCP server is off");
 
     expect(screen.getByRole("button", { name: /turn on mcp server/i })).toBeTruthy();
@@ -189,7 +222,11 @@ describe("McpServerSettingsTab", () => {
       setEnabled: setEnabledMock,
     });
 
-    const { container } = render(<McpServerSettingsTab />);
+    const { container } = render(
+      <SettingsValidationProvider>
+        <McpServerSettingsTab />
+      </SettingsValidationProvider>
+    );
     await waitForContent(container, "MCP server is off");
 
     fireEvent.click(screen.getByRole("button", { name: /turn on mcp server/i }));
@@ -205,12 +242,20 @@ describe("McpServerSettingsTab", () => {
       getStatus: vi.fn().mockReturnValue(new Promise(() => {})),
     });
 
-    render(<McpServerSettingsTab />);
+    render(
+      <SettingsValidationProvider>
+        <McpServerSettingsTab />
+      </SettingsValidationProvider>
+    );
     expect(screen.queryByText("MCP server is off")).toBeNull();
   });
 
   it("hides the empty state once MCP is enabled", async () => {
-    const { container } = render(<McpServerSettingsTab />);
+    const { container } = render(
+      <SettingsValidationProvider>
+        <McpServerSettingsTab />
+      </SettingsValidationProvider>
+    );
     await waitForContent(container, "API key active");
 
     expect(screen.queryByText("MCP server is off")).toBeNull();
@@ -221,7 +266,11 @@ describe("McpServerSettingsTab", () => {
       getStatus: vi.fn().mockRejectedValue(new Error("IPC down")),
     });
 
-    const { container } = render(<McpServerSettingsTab />);
+    const { container } = render(
+      <SettingsValidationProvider>
+        <McpServerSettingsTab />
+      </SettingsValidationProvider>
+    );
 
     await waitForContent(container, "IPC down");
 
@@ -245,7 +294,11 @@ describe("McpServerSettingsTab", () => {
       setEnabled: setEnabledMock,
     });
 
-    const { container } = render(<McpServerSettingsTab />);
+    const { container } = render(
+      <SettingsValidationProvider>
+        <McpServerSettingsTab />
+      </SettingsValidationProvider>
+    );
     await waitForContent(container, "MCP server is off");
 
     fireEvent.click(screen.getByRole("button", { name: /turn on mcp server/i }));
@@ -260,7 +313,11 @@ describe("McpServerSettingsTab", () => {
       setEnabled: vi.fn().mockRejectedValue(new Error("toggle failed")),
     });
 
-    const { container } = render(<McpServerSettingsTab />);
+    const { container } = render(
+      <SettingsValidationProvider>
+        <McpServerSettingsTab />
+      </SettingsValidationProvider>
+    );
     await waitForContent(container, "MCP Server");
 
     fireEvent.click(screen.getByLabelText("Enable MCP server"));
@@ -271,7 +328,11 @@ describe("McpServerSettingsTab", () => {
   });
 
   it("shows inline error for invalid audit max records instead of notifying", async () => {
-    const { container } = render(<McpServerSettingsTab />);
+    const { container } = render(
+      <SettingsValidationProvider>
+        <McpServerSettingsTab />
+      </SettingsValidationProvider>
+    );
     await waitForContent(container, "API key active");
 
     const maxRecordsInput = container.querySelector("#mcp-audit-max-records") as HTMLInputElement;
@@ -289,7 +350,11 @@ describe("McpServerSettingsTab", () => {
       setAuditEnabled: vi.fn().mockRejectedValue(new Error("audit toggle failed")),
     });
 
-    const { container } = render(<McpServerSettingsTab />);
+    const { container } = render(
+      <SettingsValidationProvider>
+        <McpServerSettingsTab />
+      </SettingsValidationProvider>
+    );
     await waitForContent(container, "API key active");
 
     fireEvent.click(screen.getByRole("button", { name: /capture on/i }));
@@ -316,7 +381,11 @@ describe("McpServerSettingsTab", () => {
       ]),
     });
 
-    const { container } = render(<McpServerSettingsTab />);
+    const { container } = render(
+      <SettingsValidationProvider>
+        <McpServerSettingsTab />
+      </SettingsValidationProvider>
+    );
     await waitForContent(container, "files.read");
 
     fireEvent.click(screen.getByRole("button", { name: /clear log/i }));
@@ -340,7 +409,11 @@ describe("McpServerSettingsTab", () => {
       clearAuditLog: vi.fn().mockRejectedValue(new Error("clear failed")),
     });
 
-    const { container } = render(<McpServerSettingsTab />);
+    const { container } = render(
+      <SettingsValidationProvider>
+        <McpServerSettingsTab />
+      </SettingsValidationProvider>
+    );
     await waitForContent(container, "files.read");
 
     fireEvent.click(screen.getByRole("button", { name: /clear log/i }));
@@ -364,7 +437,11 @@ describe("McpServerSettingsTab", () => {
       ]),
     });
 
-    const { container } = render(<McpServerSettingsTab />);
+    const { container } = render(
+      <SettingsValidationProvider>
+        <McpServerSettingsTab />
+      </SettingsValidationProvider>
+    );
     await waitForContent(container, "files.read");
 
     fireEvent.click(screen.getByRole("button", { name: /copy all as json/i }));
@@ -405,7 +482,11 @@ describe("McpServerSettingsTab", () => {
       ]),
     });
 
-    const { container } = render(<McpServerSettingsTab />);
+    const { container } = render(
+      <SettingsValidationProvider>
+        <McpServerSettingsTab />
+      </SettingsValidationProvider>
+    );
     await waitForContent(container, "files.read");
 
     fireEvent.click(screen.getByRole("button", { name: /copy all as json/i }));


### PR DESCRIPTION
## Summary

- Wires `GitHubSettingsTab`, `McpServerSettingsTab`, `DaintreeAssistantSettingsTab`, and `VoiceInputSettingsTab` into `useSettingsTabValidation` so persistent errors roll up to the sidebar warning dot — matching the pattern already in place for the `Environment`, `Portal`, `Worktree`, and `TerminalAppearance` tabs.
- Fixed a latent infinite-loop bug in `SettingsValidationRegistry` where broad effect deps caused the registry to thrash whenever any tab reported an error; narrowing the deps to the specific values that matter stops this cold.
- Transient auto-clearing signals (`GitHubSettingsTab` 5 s `validationResult`, `VoiceInputSettingsTab` `ApiKeyRow.validation`) are intentionally excluded — the dot is for persistent, user-actionable errors only.

Resolves #6888

## Changes

- `GitHubSettingsTab.tsx` — `Boolean(loadError) || loadTimedOut` passed to the hook
- `McpServerSettingsTab.tsx` — `Boolean(error)` passed to the hook
- `DaintreeAssistantSettingsTab.tsx` — `Boolean(error)` passed to the hook
- `VoiceInputSettingsTab.tsx` — `loadState === "error"` passed to the hook
- `SettingsValidationRegistry.tsx` — narrow `useEffect` deps to break the infinite-loop
- `GitHubSettingsTab.tokenSave.test.tsx`, `GitHubSettingsTab.a11y.test.tsx`, `McpServerSettingsTab.test.tsx`, `DaintreeAssistantSettingsTab.test.tsx` — wrap renders in `SettingsValidationRegistryProvider`

## Testing

- 53 unit tests across 5 test files, all passing
- Typecheck, lint (baseline 2722 unchanged), and format all clean