### PR TITLE
fix(pty): exit pty host on fatal errors and tighten heartbeat interval

### DIFF
--- a/electron/pty-host.ts
+++ b/electron/pty-host.ts
@@ -79,6 +79,9 @@ process.on("uncaughtException", (err) => {
   } catch {
     // ignore
   }
+  // Exit on next tick so Mojo IPC can flush the error event before the process dies.
+  // Without this, the parent never sees `child-process-gone` and the host stays a zombie.
+  setImmediate(() => process.exit(1));
 });
 
 process.on("unhandledRejection", (reason) => {
@@ -93,6 +96,9 @@ process.on("unhandledRejection", (reason) => {
   } catch {
     // ignore
   }
+  // Electron 37+ no longer crashes on unhandled rejection by default — exit explicitly
+  // so the parent's child-process-gone supervision path triggers.
+  setImmediate(() => process.exit(1));
 });
 
 const ptyManager = new PtyManager();
@@ -847,11 +853,12 @@ async function initialize(): Promise<void> {
   } catch (error) {
     console.error("[PtyHost] Initialization failed:", error);
     emergencyLogFatal("INIT_ERROR", error);
-    // Even on error, we might want to stay alive to report it
+    setImmediate(() => process.exit(1));
   }
 }
 
 initialize().catch((err) => {
   console.error("[PtyHost] Fatal initialization error:", err);
   emergencyLogFatal("FATAL_INIT_ERROR", err);
+  setImmediate(() => process.exit(1));
 });

--- a/electron/services/PtyClient.ts
+++ b/electron/services/PtyClient.ts
@@ -119,8 +119,10 @@ export interface PtyClientConfig {
 
 const DEFAULT_CONFIG: Required<PtyClientConfig> = {
   maxRestartAttempts: 3,
-  // 5s × 3 missed pongs = ~15s detection window (matches VS Code's PTY host).
-  // Was 30s × 3 = ~90s, which left users staring at frozen terminals.
+  // 5s heartbeat. Watchdog checks the missed-pong count before incrementing,
+  // so SIGKILL fires on the tick after 3 consecutive missed pongs — ~20s
+  // worst-case detection. Was 30s (~90s detection), which left users staring
+  // at frozen terminals long enough to assume the app had hung.
   healthCheckIntervalMs: 5000,
   showCrashDialog: true,
   memoryLimitMb: 512,

--- a/electron/services/PtyClient.ts
+++ b/electron/services/PtyClient.ts
@@ -119,7 +119,9 @@ export interface PtyClientConfig {
 
 const DEFAULT_CONFIG: Required<PtyClientConfig> = {
   maxRestartAttempts: 3,
-  healthCheckIntervalMs: 30000,
+  // 5s × 3 missed pongs = ~15s detection window (matches VS Code's PTY host).
+  // Was 30s × 3 = ~90s, which left users staring at frozen terminals.
+  healthCheckIntervalMs: 5000,
   showCrashDialog: true,
   memoryLimitMb: 512,
 };

--- a/electron/window/perWindowInit.ts
+++ b/electron/window/perWindowInit.ts
@@ -113,7 +113,7 @@ export function initPerWindowServices(
 
     ptyClient = new PtyClient({
       maxRestartAttempts: 3,
-      healthCheckIntervalMs: 30000,
+      healthCheckIntervalMs: 5000,
       showCrashDialog: false,
     });
     setPtyClientRef(ptyClient);


### PR DESCRIPTION
## Summary

- Wires up `process.exit(1)` (via `setImmediate`) in the `uncaughtException` and `unhandledRejection` handlers and both initialization error paths in `electron/pty-host.ts` — the host now actually dies when it panics rather than staying alive in an undefined state.
- Drops `PtyClient`'s `healthCheckIntervalMs` from 30 s to 5 s, collapsing the watchdog detection window from ~90 s to ~20 s for hangs, and to under a second for panics now that exit is wired up.
- Updated the `DEFAULT_CONFIG` comment to accurately describe the ~20 s detection window.

Resolves #6881

## Changes

- `electron/pty-host.ts` — `setImmediate(() => process.exit(1))` added to `uncaughtException`, `unhandledRejection`, `initialize()` inner catch, and `initialize().catch()`. Placed outside try/catch so it always fires; `setImmediate` gives Mojo IPC one tick to flush the system error event before the process exits.
- `electron/services/PtyClient.ts` — `DEFAULT_CONFIG.healthCheckIntervalMs` 30000 → 5000. Comment updated.
- `electron/window/perWindowInit.ts` — `healthCheckIntervalMs` 30000 → 5000 at construction site.

## Testing

43/43 unit tests pass across `PtyClient.watchdog.test.ts` and `PtyHostLifecycle.test.ts`. Typecheck, lint ratchet (2722 baseline), and format check all pass.