### PR TITLE
feat(auto-updater): surface lifecycle state in application menu

### DIFF
--- a/electron/__tests__/menu.test.ts
+++ b/electron/__tests__/menu.test.ts
@@ -1,4 +1,4 @@
-import { beforeEach, describe, expect, it, vi } from "vitest";
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
 
 const mockWebContents = vi.hoisted(() => ({
   toggleDevTools: vi.fn(),
@@ -36,13 +36,34 @@ const mockBrowserWindow = vi.hoisted(() => ({
 
 let capturedTemplate: Electron.MenuItemConstructorOptions[] = [];
 
+const menuItemRegistry = vi.hoisted(() => new Map<string, { label: string; enabled: boolean }>());
+const mockApplicationMenu = vi.hoisted(() => ({
+  getMenuItemById: vi.fn((id: string) => menuItemRegistry.get(id) ?? null),
+}));
+
 vi.mock("electron", () => ({
   Menu: {
     buildFromTemplate: vi.fn((template: Electron.MenuItemConstructorOptions[]) => {
       capturedTemplate = template;
-      return {};
+      menuItemRegistry.clear();
+      const collect = (items: Electron.MenuItemConstructorOptions[]): void => {
+        for (const item of items) {
+          if (item.id && typeof item.label === "string") {
+            menuItemRegistry.set(item.id, {
+              label: item.label,
+              enabled: item.enabled ?? true,
+            });
+          }
+          if (Array.isArray(item.submenu)) {
+            collect(item.submenu as Electron.MenuItemConstructorOptions[]);
+          }
+        }
+      };
+      collect(template);
+      return mockApplicationMenu;
     }),
     setApplicationMenu: vi.fn(),
+    getApplicationMenu: vi.fn(() => mockApplicationMenu),
   },
   dialog: { showOpenDialog: vi.fn() },
   BrowserWindow: vi.fn(),
@@ -92,8 +113,21 @@ vi.mock("../window/windowRef.js", () => ({
   getProjectViewManager: vi.fn(() => null),
 }));
 
+const autoUpdaterServiceMock = vi.hoisted(() => {
+  let menuState: "idle" | "checking" | "ready" = "idle";
+  return {
+    checkForUpdatesManually: vi.fn(),
+    quitAndInstallIfReady: vi.fn(),
+    getMenuState: vi.fn(() => menuState),
+    onMenuStateChange: vi.fn(() => vi.fn()),
+    __setMenuState: (state: "idle" | "checking" | "ready") => {
+      menuState = state;
+    },
+  };
+});
+
 vi.mock("../services/AutoUpdaterService.js", () => ({
-  autoUpdaterService: { checkForUpdatesManually: vi.fn() },
+  autoUpdaterService: autoUpdaterServiceMock,
 }));
 
 vi.mock("../services/pluginMenuRegistry.js", () => ({
@@ -105,7 +139,7 @@ vi.mock("../window/webContentsRegistry.js", () => ({
 }));
 
 import { createApplicationMenu } from "../menu.js";
-import { webContents } from "electron";
+import { webContents, app, Menu } from "electron";
 
 function findMenuItem(
   template: Electron.MenuItemConstructorOptions[],
@@ -249,6 +283,197 @@ describe("createApplicationMenu", () => {
       const item = findMenuItem(capturedTemplate, "View", "Zoom In");
       item!.click!({} as Electron.MenuItem, undefined, {} as Electron.KeyboardEvent);
       expect(mockWebContents.setZoomLevel).toHaveBeenCalledWith(1.5);
+    });
+  });
+});
+
+describe("update menu lifecycle", () => {
+  const originalPlatform = process.platform;
+
+  beforeEach(() => {
+    vi.clearAllMocks();
+    capturedTemplate = [];
+    autoUpdaterServiceMock.__setMenuState("idle");
+  });
+
+  afterEach(() => {
+    Object.defineProperty(process, "platform", { value: originalPlatform, configurable: true });
+    app.isPackaged = false;
+  });
+
+  function findUpdateItem(
+    template: Electron.MenuItemConstructorOptions[],
+    id: string
+  ): Electron.MenuItemConstructorOptions | undefined {
+    for (const top of template) {
+      if (Array.isArray(top.submenu)) {
+        for (const item of top.submenu as Electron.MenuItemConstructorOptions[]) {
+          if (item.id === id) return item;
+        }
+      }
+    }
+    return undefined;
+  }
+
+  describe("on macOS (packaged)", () => {
+    beforeEach(() => {
+      Object.defineProperty(process, "platform", { value: "darwin", configurable: true });
+      app.isPackaged = true;
+      createApplicationMenu(mockBrowserWindow as unknown as Electron.BrowserWindow);
+    });
+
+    it("emits a Daintree-menu Check for Updates item with the canonical id", () => {
+      const item = findUpdateItem(capturedTemplate, "check-for-updates-mac");
+      expect(item).toBeDefined();
+      expect(item!.label).toBe("Check for Updates…");
+    });
+
+    it("does NOT emit a Help-menu Check for Updates item on darwin", () => {
+      const item = findUpdateItem(capturedTemplate, "check-for-updates-help");
+      expect(item).toBeUndefined();
+    });
+
+    it("registers a menu-state listener after Menu.setApplicationMenu", () => {
+      expect(autoUpdaterServiceMock.onMenuStateChange).toHaveBeenCalled();
+    });
+
+    it("applies the current state immediately after rebuild (sticky Ready)", () => {
+      autoUpdaterServiceMock.__setMenuState("ready");
+      capturedTemplate = [];
+      menuItemRegistry.clear();
+
+      createApplicationMenu(mockBrowserWindow as unknown as Electron.BrowserWindow);
+
+      const item = menuItemRegistry.get("check-for-updates-mac");
+      expect(item).toBeDefined();
+      expect(item!.label).toBe("Restart to Install Update");
+      expect(item!.enabled).toBe(true);
+    });
+
+    it("disposes the previous listener when createApplicationMenu is called again", () => {
+      const firstUnsubscribe = vi.fn();
+      const secondUnsubscribe = vi.fn();
+      autoUpdaterServiceMock.onMenuStateChange.mockReturnValueOnce(firstUnsubscribe);
+      autoUpdaterServiceMock.onMenuStateChange.mockReturnValueOnce(secondUnsubscribe);
+
+      createApplicationMenu(mockBrowserWindow as unknown as Electron.BrowserWindow);
+      createApplicationMenu(mockBrowserWindow as unknown as Electron.BrowserWindow);
+
+      expect(firstUnsubscribe).toHaveBeenCalledTimes(1);
+      expect(secondUnsubscribe).not.toHaveBeenCalled();
+    });
+  });
+
+  describe("on linux/win (packaged)", () => {
+    beforeEach(() => {
+      Object.defineProperty(process, "platform", { value: "linux", configurable: true });
+      app.isPackaged = true;
+      createApplicationMenu(mockBrowserWindow as unknown as Electron.BrowserWindow);
+    });
+
+    it("emits a Help-menu Check for Updates item with the canonical id", () => {
+      const item = findUpdateItem(capturedTemplate, "check-for-updates-help");
+      expect(item).toBeDefined();
+      expect(item!.label).toBe("Check for Updates…");
+    });
+
+    it("does NOT emit a Daintree-menu Check for Updates item on non-darwin", () => {
+      const item = findUpdateItem(capturedTemplate, "check-for-updates-mac");
+      expect(item).toBeUndefined();
+    });
+  });
+
+  describe("click handler branching", () => {
+    beforeEach(() => {
+      Object.defineProperty(process, "platform", { value: "darwin", configurable: true });
+      app.isPackaged = true;
+      createApplicationMenu(mockBrowserWindow as unknown as Electron.BrowserWindow);
+    });
+
+    it("calls checkForUpdatesManually when state is idle", () => {
+      autoUpdaterServiceMock.__setMenuState("idle");
+      const item = findUpdateItem(capturedTemplate, "check-for-updates-mac");
+
+      item!.click!(
+        {} as Electron.MenuItem,
+        mockBrowserWindow as unknown as Electron.BaseWindow,
+        {} as Electron.KeyboardEvent
+      );
+
+      expect(autoUpdaterServiceMock.checkForUpdatesManually).toHaveBeenCalledTimes(1);
+      expect(autoUpdaterServiceMock.quitAndInstallIfReady).not.toHaveBeenCalled();
+    });
+
+    it("calls checkForUpdatesManually when state is checking (defensive — item is also disabled)", () => {
+      autoUpdaterServiceMock.__setMenuState("checking");
+      const item = findUpdateItem(capturedTemplate, "check-for-updates-mac");
+
+      item!.click!(
+        {} as Electron.MenuItem,
+        mockBrowserWindow as unknown as Electron.BaseWindow,
+        {} as Electron.KeyboardEvent
+      );
+
+      expect(autoUpdaterServiceMock.checkForUpdatesManually).toHaveBeenCalledTimes(1);
+      expect(autoUpdaterServiceMock.quitAndInstallIfReady).not.toHaveBeenCalled();
+    });
+
+    it("calls quitAndInstallIfReady when state is ready", () => {
+      autoUpdaterServiceMock.__setMenuState("ready");
+      const item = findUpdateItem(capturedTemplate, "check-for-updates-mac");
+
+      item!.click!(
+        {} as Electron.MenuItem,
+        mockBrowserWindow as unknown as Electron.BaseWindow,
+        {} as Electron.KeyboardEvent
+      );
+
+      expect(autoUpdaterServiceMock.quitAndInstallIfReady).toHaveBeenCalledTimes(1);
+      expect(autoUpdaterServiceMock.checkForUpdatesManually).not.toHaveBeenCalled();
+    });
+  });
+
+  describe("applyUpdateMenuState (via the registered listener)", () => {
+    let dispatchUpdate: (state: "idle" | "checking" | "ready") => void;
+
+    beforeEach(() => {
+      Object.defineProperty(process, "platform", { value: "darwin", configurable: true });
+      app.isPackaged = true;
+      createApplicationMenu(mockBrowserWindow as unknown as Electron.BrowserWindow);
+
+      // The most-recent createApplicationMenu call registers the listener via
+      // onMenuStateChange; pull it back out of the mock's call history.
+      const calls = autoUpdaterServiceMock.onMenuStateChange.mock.calls;
+      if (calls.length === 0) throw new Error("expected onMenuStateChange to be called");
+      dispatchUpdate = calls[calls.length - 1][0] as (state: "idle" | "checking" | "ready") => void;
+    });
+
+    it("checking state sets disabled label", () => {
+      dispatchUpdate("checking");
+      const item = menuItemRegistry.get("check-for-updates-mac");
+      expect(item!.label).toBe("Checking for Updates…");
+      expect(item!.enabled).toBe(false);
+    });
+
+    it("ready state sets restart label", () => {
+      dispatchUpdate("ready");
+      const item = menuItemRegistry.get("check-for-updates-mac");
+      expect(item!.label).toBe("Restart to Install Update");
+      expect(item!.enabled).toBe(true);
+    });
+
+    it("idle state restores default label", () => {
+      dispatchUpdate("checking");
+      dispatchUpdate("idle");
+      const item = menuItemRegistry.get("check-for-updates-mac");
+      expect(item!.label).toBe("Check for Updates…");
+      expect(item!.enabled).toBe(true);
+    });
+
+    it("does not throw when getApplicationMenu returns null", () => {
+      vi.mocked(Menu.getApplicationMenu).mockReturnValueOnce(null as never);
+
+      expect(() => dispatchUpdate("checking")).not.toThrow();
     });
   });
 });

--- a/electron/__tests__/menu.test.ts
+++ b/electron/__tests__/menu.test.ts
@@ -298,7 +298,7 @@ describe("update menu lifecycle", () => {
 
   afterEach(() => {
     Object.defineProperty(process, "platform", { value: originalPlatform, configurable: true });
-    app.isPackaged = false;
+    Object.defineProperty(app, "isPackaged", { value: false, configurable: true });
   });
 
   function findUpdateItem(
@@ -318,7 +318,7 @@ describe("update menu lifecycle", () => {
   describe("on macOS (packaged)", () => {
     beforeEach(() => {
       Object.defineProperty(process, "platform", { value: "darwin", configurable: true });
-      app.isPackaged = true;
+      Object.defineProperty(app, "isPackaged", { value: true, configurable: true });
       createApplicationMenu(mockBrowserWindow as unknown as Electron.BrowserWindow);
     });
 
@@ -367,7 +367,7 @@ describe("update menu lifecycle", () => {
   describe("on linux/win (packaged)", () => {
     beforeEach(() => {
       Object.defineProperty(process, "platform", { value: "linux", configurable: true });
-      app.isPackaged = true;
+      Object.defineProperty(app, "isPackaged", { value: true, configurable: true });
       createApplicationMenu(mockBrowserWindow as unknown as Electron.BrowserWindow);
     });
 
@@ -386,7 +386,7 @@ describe("update menu lifecycle", () => {
   describe("click handler branching", () => {
     beforeEach(() => {
       Object.defineProperty(process, "platform", { value: "darwin", configurable: true });
-      app.isPackaged = true;
+      Object.defineProperty(app, "isPackaged", { value: true, configurable: true });
       createApplicationMenu(mockBrowserWindow as unknown as Electron.BrowserWindow);
     });
 
@@ -438,14 +438,16 @@ describe("update menu lifecycle", () => {
 
     beforeEach(() => {
       Object.defineProperty(process, "platform", { value: "darwin", configurable: true });
-      app.isPackaged = true;
+      Object.defineProperty(app, "isPackaged", { value: true, configurable: true });
       createApplicationMenu(mockBrowserWindow as unknown as Electron.BrowserWindow);
 
       // The most-recent createApplicationMenu call registers the listener via
       // onMenuStateChange; pull it back out of the mock's call history.
       const calls = autoUpdaterServiceMock.onMenuStateChange.mock.calls;
       if (calls.length === 0) throw new Error("expected onMenuStateChange to be called");
-      dispatchUpdate = calls[calls.length - 1][0] as (state: "idle" | "checking" | "ready") => void;
+      const lastCall = calls[calls.length - 1] as unknown[] | undefined;
+      if (!lastCall || !lastCall[0]) throw new Error("expected callback argument");
+      dispatchUpdate = lastCall[0] as (state: "idle" | "checking" | "ready") => void;
     });
 
     it("checking state sets disabled label", () => {

--- a/electron/__tests__/menu.test.ts
+++ b/electron/__tests__/menu.test.ts
@@ -346,7 +346,7 @@ describe("update menu lifecycle", () => {
 
       const item = menuItemRegistry.get("check-for-updates-mac");
       expect(item).toBeDefined();
-      expect(item!.label).toBe("Restart to Install Update");
+      expect(item!.label).toBe("Restart to install update");
       expect(item!.enabled).toBe(true);
     });
 
@@ -451,14 +451,14 @@ describe("update menu lifecycle", () => {
     it("checking state sets disabled label", () => {
       dispatchUpdate("checking");
       const item = menuItemRegistry.get("check-for-updates-mac");
-      expect(item!.label).toBe("Checking for Updates…");
+      expect(item!.label).toBe("Checking…");
       expect(item!.enabled).toBe(false);
     });
 
     it("ready state sets restart label", () => {
       dispatchUpdate("ready");
       const item = menuItemRegistry.get("check-for-updates-mac");
-      expect(item!.label).toBe("Restart to Install Update");
+      expect(item!.label).toBe("Restart to install update");
       expect(item!.enabled).toBe(true);
     });
 

--- a/electron/menu.ts
+++ b/electron/menu.ts
@@ -12,13 +12,8 @@ import {
   getWorktreePortBrokerRef,
 } from "./window/windowServices.js";
 import { distributePortsToView } from "./window/portDistribution.js";
-// Auto-updater is dynamically imported on click to keep it out of the eager
-// graph — the menu is built at startup but "Check for Updates" only fires on
-// user action.
-async function checkForUpdatesManually(): Promise<void> {
-  const { autoUpdaterService } = await import("./services/AutoUpdaterService.js");
-  autoUpdaterService.checkForUpdatesManually();
-}
+import { autoUpdaterService } from "./services/AutoUpdaterService.js";
+import type { UpdateMenuState } from "./services/AutoUpdaterService.js";
 import { getPluginMenuItems } from "./services/pluginMenuRegistry.js";
 import { getAppWebContents } from "./window/webContentsRegistry.js";
 import { PRODUCT_NAME, PRODUCT_WEBSITE, PRODUCT_COPYRIGHT_ORG } from "./utils/productBranding.js";
@@ -35,6 +30,48 @@ app.setAboutPanelOptions({
 function convertShortcutToAccelerator(shortcut: string): string {
   return shortcut.replace("Cmd/Ctrl", "CommandOrControl");
 }
+
+// IDs are scoped to each platform branch — Electron's getMenuItemById walks
+// the tree and returns the first match, so the macOS Daintree-menu copy and
+// the Win/Linux Help-menu copy must be addressable independently.
+const UPDATE_MENU_ITEM_IDS = ["check-for-updates-mac", "check-for-updates-help"] as const;
+
+const UPDATE_MENU_STATE_LABELS: Record<UpdateMenuState, { label: string; enabled: boolean }> = {
+  idle: { label: "Check for Updates…", enabled: true },
+  checking: { label: "Checking for Updates…", enabled: false },
+  ready: { label: "Restart to Install Update", enabled: true },
+};
+
+function applyUpdateMenuState(state: UpdateMenuState): void {
+  const menu = Menu.getApplicationMenu();
+  if (!menu) return;
+  const { label, enabled } = UPDATE_MENU_STATE_LABELS[state];
+  for (const id of UPDATE_MENU_ITEM_IDS) {
+    const item = menu.getMenuItemById(id);
+    if (!item) continue;
+    item.label = label;
+    item.enabled = enabled;
+  }
+}
+
+// MenuItem.click is baked at build time and is NOT live-mutable. The static
+// handler reads the current state at invocation time and branches: Ready
+// triggers quitAndInstall; everything else (Idle, Checking) initiates a
+// manual check. Checking is also disabled, so the click only fires for the
+// other two anyway.
+function handleUpdateMenuClick(): void {
+  if (autoUpdaterService.getMenuState() === "ready") {
+    autoUpdaterService.quitAndInstallIfReady();
+  } else {
+    autoUpdaterService.checkForUpdatesManually();
+  }
+}
+
+// Each createApplicationMenu rebuild allocates new MenuItem instances, so the
+// listener must be re-registered after Menu.setApplicationMenu. We track the
+// previous unsubscribe at module scope to avoid stacking listeners across
+// rebuilds — a stale listener would mutate items that no longer exist.
+let unsubscribeUpdateMenuState: (() => void) | null = null;
 
 export function createApplicationMenu(
   mainWindow: BrowserWindow,
@@ -421,12 +458,9 @@ export function createApplicationMenu(
           ? [
               { type: "separator" as const },
               {
-                label: "Check for Updates...",
-                click: () => {
-                  checkForUpdatesManually().catch((err) =>
-                    console.error("[menu] checkForUpdatesManually failed:", err)
-                  );
-                },
+                id: "check-for-updates-help",
+                label: "Check for Updates…",
+                click: handleUpdateMenuClick,
               },
             ]
           : []),
@@ -445,12 +479,9 @@ export function createApplicationMenu(
         ...(app.isPackaged
           ? [
               {
-                label: "Check for Updates...",
-                click: () => {
-                  checkForUpdatesManually().catch((err) =>
-                    console.error("[menu] checkForUpdatesManually failed:", err)
-                  );
-                },
+                id: "check-for-updates-mac",
+                label: "Check for Updates…",
+                click: handleUpdateMenuClick,
               },
             ]
           : []),
@@ -475,6 +506,13 @@ export function createApplicationMenu(
 
   const menu = Menu.buildFromTemplate(template);
   Menu.setApplicationMenu(menu);
+
+  unsubscribeUpdateMenuState?.();
+  unsubscribeUpdateMenuState = autoUpdaterService.onMenuStateChange(applyUpdateMenuState);
+  // Apply the current state immediately so a rebuild that completes mid-check
+  // (or with a downloaded update already staged) doesn't snap items back to
+  // the default "Check for Updates…" label.
+  applyUpdateMenuState(autoUpdaterService.getMenuState());
 }
 
 function buildRecentProjectsMenu(

--- a/electron/menu.ts
+++ b/electron/menu.ts
@@ -38,8 +38,8 @@ const UPDATE_MENU_ITEM_IDS = ["check-for-updates-mac", "check-for-updates-help"]
 
 const UPDATE_MENU_STATE_LABELS: Record<UpdateMenuState, { label: string; enabled: boolean }> = {
   idle: { label: "Check for Updates…", enabled: true },
-  checking: { label: "Checking for Updates…", enabled: false },
-  ready: { label: "Restart to Install Update", enabled: true },
+  checking: { label: "Checking…", enabled: false },
+  ready: { label: "Restart to install update", enabled: true },
 };
 
 function applyUpdateMenuState(state: UpdateMenuState): void {

--- a/electron/services/AutoUpdaterService.ts
+++ b/electron/services/AutoUpdaterService.ts
@@ -127,6 +127,12 @@ class AutoUpdaterService {
 
   quitAndInstallIfReady(): boolean {
     if (this.menuState !== "ready" || !this.updateDownloaded) return false;
+    // Flip both guards synchronously so a rapid double-click can't queue two
+    // setImmediate(quitAndInstall) calls — the second invocation reads idle
+    // and bails. Resetting menuState back to idle also gives instant visual
+    // feedback that the click registered.
+    this.updateDownloaded = false;
+    this.setMenuState("idle");
     try {
       getCrashRecoveryService().cleanupOnExit();
     } catch (err) {
@@ -321,7 +327,11 @@ class AutoUpdaterService {
 
       ipcMain.handle(CHANNELS.UPDATE_SET_CHANNEL, async (_event, channel: unknown) => {
         const validated: "stable" | "nightly" = channel === "nightly" ? "nightly" : "stable";
-        const previousChannel = store.get("updateChannel");
+        // Mirror the `?? "stable"` fallback that initialize() applies. Without
+        // it, a fresh install (no stored key) reads previousChannel as
+        // undefined and the same-channel guard never fires — saving "stable"
+        // would discard a validly-staged installer.
+        const previousChannel = store.get("updateChannel") ?? "stable";
         store.set("updateChannel", validated);
 
         // Same-channel re-save (e.g. user opens settings and clicks Save

--- a/electron/services/AutoUpdaterService.ts
+++ b/electron/services/AutoUpdaterService.ts
@@ -54,6 +54,12 @@ const { autoUpdater } = electronUpdater;
 
 const RESUME_CHECK_DELAY_MS = 7_000;
 
+// 400ms Doherty threshold gates the "Checking…" menu label so a fast CDN
+// round-trip (sub-threshold) never flickers a transient label change.
+const CHECKING_MENU_DELAY_MS = 400;
+
+export type UpdateMenuState = "idle" | "checking" | "ready";
+
 class AutoUpdaterService {
   private checkInterval: NodeJS.Timeout | null = null;
   private startupJitterTimeout: NodeJS.Timeout | null = null;
@@ -67,6 +73,9 @@ class AutoUpdaterService {
   private updateDownloaded = false;
   private isManualCheck = false;
   private lastBroadcastVersion: string | null = null;
+  private menuState: UpdateMenuState = "idle";
+  private checkingMenuTimeout: NodeJS.Timeout | null = null;
+  private menuStateListeners: Set<(state: UpdateMenuState) => void> = new Set();
   private checkingHandler: (() => void) | null = null;
   private availableHandler: ((info: UpdateInfo) => void) | null = null;
   private notAvailableHandler: ((info: UpdateInfo) => void) | null = null;
@@ -84,6 +93,49 @@ class AutoUpdaterService {
   private resetRetryState(): void {
     this.clearRetryTimeout();
     this.retryCount = 0;
+  }
+
+  private clearCheckingMenuTimeout(): void {
+    if (this.checkingMenuTimeout) {
+      clearTimeout(this.checkingMenuTimeout);
+      this.checkingMenuTimeout = null;
+    }
+  }
+
+  private setMenuState(state: UpdateMenuState): void {
+    if (this.menuState === state) return;
+    this.menuState = state;
+    for (const listener of this.menuStateListeners) {
+      try {
+        listener(state);
+      } catch (err) {
+        console.error("[MAIN] Update menu state listener threw:", err);
+      }
+    }
+  }
+
+  getMenuState(): UpdateMenuState {
+    return this.menuState;
+  }
+
+  onMenuStateChange(cb: (state: UpdateMenuState) => void): () => void {
+    this.menuStateListeners.add(cb);
+    return () => {
+      this.menuStateListeners.delete(cb);
+    };
+  }
+
+  quitAndInstallIfReady(): boolean {
+    if (this.menuState !== "ready" || !this.updateDownloaded) return false;
+    try {
+      getCrashRecoveryService().cleanupOnExit();
+    } catch (err) {
+      console.error("[MAIN] Crash recovery cleanup before quit-and-install failed:", err);
+    }
+    // setImmediate defers past the menu-close animation frame so the OS doesn't
+    // tear the click target while we're walking away (Windows-sensitive).
+    setImmediate(() => autoUpdater.quitAndInstall());
+    return true;
   }
 
   // electron-updater 6.3.x doesn't surface a categorized error type, so classify
@@ -223,15 +275,34 @@ class AutoUpdaterService {
       return;
     }
     this.isManualCheck = true;
+    // Doherty gate: only flip the menu to "Checking…" when the round-trip
+    // exceeds 400ms. Re-arming on a second click cancels the pending flip
+    // and restarts the window — the menu only transitions after the latest
+    // call passes the threshold.
+    this.clearCheckingMenuTimeout();
+    if (this.menuState !== "ready") {
+      this.checkingMenuTimeout = setTimeout(() => {
+        this.checkingMenuTimeout = null;
+        if (this.isManualCheck && this.menuState !== "ready") {
+          this.setMenuState("checking");
+        }
+      }, CHECKING_MENU_DELAY_MS);
+    }
     try {
       const result = autoUpdater.checkForUpdates();
       Promise.resolve(result).catch((err) => {
         console.error("[MAIN] Manual update check failed:", err);
         this.isManualCheck = false;
+        this.clearCheckingMenuTimeout();
+        // The check rejected without an `error` event — restore Idle so the
+        // menu doesn't get stuck on "Checking…". Ready persists.
+        if (this.menuState !== "ready") this.setMenuState("idle");
       });
     } catch (err) {
       console.error("[MAIN] Manual update check failed:", err);
       this.isManualCheck = false;
+      this.clearCheckingMenuTimeout();
+      if (this.menuState !== "ready") this.setMenuState("idle");
     }
   }
 
@@ -265,6 +336,11 @@ class AutoUpdaterService {
         this.updateDownloaded = false;
         this.lastBroadcastVersion = null;
         this.resetRetryState();
+        // The Ready label points at a now-discarded installer — drop it back
+        // to Idle in lockstep, and cancel any pending Doherty flip so a
+        // mid-check switch doesn't surface "Checking…" for the old channel.
+        this.clearCheckingMenuTimeout();
+        this.setMenuState("idle");
 
         if (this.initialized) {
           this.configureFeedForChannel(validated);
@@ -322,6 +398,10 @@ class AutoUpdaterService {
         // broadcast — the network round-tripped, so the transient condition
         // has cleared.
         this.resetRetryState();
+        // Update available, but the install isn't ready until download
+        // completes — let the downloaded handler flip to "ready".
+        this.clearCheckingMenuTimeout();
+        if (this.menuState !== "ready") this.setMenuState("idle");
         if (suppressed) return;
         this.lastBroadcastVersion = info.version;
         broadcastToRenderer(CHANNELS.UPDATE_AVAILABLE, { version: info.version });
@@ -331,6 +411,8 @@ class AutoUpdaterService {
       this.notAvailableHandler = (_info: UpdateInfo) => {
         console.log("[MAIN] Update not available");
         this.resetRetryState();
+        this.clearCheckingMenuTimeout();
+        if (this.menuState !== "ready") this.setMenuState("idle");
         if (this.isManualCheck) {
           this.isManualCheck = false;
           broadcastToRenderer(CHANNELS.NOTIFICATION_SHOW_TOAST, {
@@ -346,6 +428,8 @@ class AutoUpdaterService {
         console.error("[MAIN] Auto-updater error:", err);
         const wasManual = this.isManualCheck;
         this.isManualCheck = false;
+        this.clearCheckingMenuTimeout();
+        if (this.menuState !== "ready") this.setMenuState("idle");
         if (wasManual) {
           // Manual checks surface to the user immediately and offer a Retry
           // action — don't shadow that with background backoff, the user is
@@ -387,6 +471,8 @@ class AutoUpdaterService {
         console.log("[MAIN] Update downloaded:", info.version);
         this.updateDownloaded = true;
         this.resetRetryState();
+        this.clearCheckingMenuTimeout();
+        this.setMenuState("ready");
         broadcastToRenderer(CHANNELS.UPDATE_DOWNLOADED, { version: info.version });
       };
       autoUpdater.on("update-downloaded", this.downloadedHandler);
@@ -569,6 +655,12 @@ class AutoUpdaterService {
     this.lastBroadcastVersion = null;
     this.channelHandlersRegistered = false;
     this.initialized = false;
+    this.clearCheckingMenuTimeout();
+    // Reset menu state to idle BEFORE clearing listeners so any registered
+    // menu callback gets the final transition. After listener clearance any
+    // future setMenuState is a silent no-op.
+    if (this.menuState !== "idle") this.setMenuState("idle");
+    this.menuStateListeners.clear();
   }
 }
 

--- a/electron/services/__tests__/AutoUpdaterService.test.ts
+++ b/electron/services/__tests__/AutoUpdaterService.test.ts
@@ -94,6 +94,7 @@ import { CHANNELS } from "../../ipc/channels.js";
 
 const CHECK_INTERVAL_MS = 4 * 60 * 60 * 1000;
 const STARTUP_JITTER_MAX_MS = 60_000;
+const CHECKING_MENU_DELAY_MS = 400;
 
 describe("AutoUpdaterService", () => {
   const originalPlatform = process.platform;
@@ -1353,6 +1354,270 @@ describe("AutoUpdaterService", () => {
       vi.advanceTimersByTime(60_000);
 
       expect(autoUpdaterMock.checkForUpdatesAndNotify).not.toHaveBeenCalled();
+    });
+  });
+
+  describe("menu state lifecycle", () => {
+    let availableHandler: (info: { version: string }) => void;
+    let notAvailableHandler: (info: object) => void;
+    let errorHandler: (err: unknown) => void;
+    let downloadedHandler: (info: { version: string }) => void;
+    let setChannelHandler: (event: unknown, channel: unknown) => Promise<unknown>;
+
+    beforeEach(() => {
+      autoUpdaterService.initialize();
+      vi.advanceTimersByTime(STARTUP_JITTER_MAX_MS);
+
+      availableHandler = (autoUpdaterMock.on as Mock).mock.calls.find(
+        (args) => args[0] === "update-available"
+      )![1];
+      notAvailableHandler = (autoUpdaterMock.on as Mock).mock.calls.find(
+        (args) => args[0] === "update-not-available"
+      )![1];
+      errorHandler = (autoUpdaterMock.on as Mock).mock.calls.find(
+        (args) => args[0] === "error"
+      )![1];
+      downloadedHandler = (autoUpdaterMock.on as Mock).mock.calls.find(
+        (args) => args[0] === "update-downloaded"
+      )![1];
+      setChannelHandler = (ipcMainMock.handle as Mock).mock.calls.find(
+        (args) => args[0] === CHANNELS.UPDATE_SET_CHANNEL
+      )![1];
+
+      autoUpdaterMock.checkForUpdates.mockClear();
+    });
+
+    it("starts in idle state", () => {
+      expect(autoUpdaterService.getMenuState()).toBe("idle");
+    });
+
+    it("a fast manual check (resolves before 400ms) leaves menu state at idle", () => {
+      autoUpdaterService.checkForUpdatesManually();
+
+      // Round-trip resolves at 200ms with update-not-available — well inside
+      // the 400ms Doherty gate.
+      vi.advanceTimersByTime(200);
+      notAvailableHandler({});
+
+      // The 400ms timer would have fired at +400ms, but the check resolved
+      // first and cleared it.
+      vi.advanceTimersByTime(500);
+
+      expect(autoUpdaterService.getMenuState()).toBe("idle");
+    });
+
+    it("a slow manual check (still in flight at 400ms) flips menu state to checking", () => {
+      autoUpdaterService.checkForUpdatesManually();
+
+      vi.advanceTimersByTime(CHECKING_MENU_DELAY_MS);
+
+      expect(autoUpdaterService.getMenuState()).toBe("checking");
+
+      // After the round-trip eventually completes, state goes back to idle.
+      notAvailableHandler({});
+      expect(autoUpdaterService.getMenuState()).toBe("idle");
+    });
+
+    it("background polls do not show the checking state (only manual checks)", () => {
+      // Simulate the periodic checking-for-update event firing without a
+      // prior checkForUpdatesManually() call.
+      vi.advanceTimersByTime(CHECK_INTERVAL_MS + CHECKING_MENU_DELAY_MS * 2);
+
+      expect(autoUpdaterService.getMenuState()).toBe("idle");
+    });
+
+    it("update-available transitions to idle (not ready — only download completion is ready)", () => {
+      autoUpdaterService.checkForUpdatesManually();
+      vi.advanceTimersByTime(CHECKING_MENU_DELAY_MS);
+      expect(autoUpdaterService.getMenuState()).toBe("checking");
+
+      availableHandler({ version: "2.0.0" });
+
+      expect(autoUpdaterService.getMenuState()).toBe("idle");
+    });
+
+    it("update-downloaded transitions to ready", () => {
+      downloadedHandler({ version: "2.0.0" });
+
+      expect(autoUpdaterService.getMenuState()).toBe("ready");
+    });
+
+    it("ready persists past subsequent manual checks (no flicker back to idle)", () => {
+      downloadedHandler({ version: "2.0.0" });
+      expect(autoUpdaterService.getMenuState()).toBe("ready");
+
+      // A second manual check while staged must not unset Ready — the user
+      // can still restart-to-install while a probe is in flight.
+      autoUpdaterService.checkForUpdatesManually();
+      vi.advanceTimersByTime(CHECKING_MENU_DELAY_MS * 2);
+      expect(autoUpdaterService.getMenuState()).toBe("ready");
+
+      notAvailableHandler({});
+      // Even update-not-available shouldn't drop Ready — the staged
+      // installer is still valid for the current channel.
+      expect(autoUpdaterService.getMenuState()).toBe("ready");
+    });
+
+    it("channel switch resets ready state and cancels any pending Doherty flip", async () => {
+      downloadedHandler({ version: "2.0.0" });
+      expect(autoUpdaterService.getMenuState()).toBe("ready");
+
+      await setChannelHandler(null, "nightly");
+
+      expect(autoUpdaterService.getMenuState()).toBe("idle");
+    });
+
+    it("channel switch mid-check cancels the pending checking flip", async () => {
+      autoUpdaterService.checkForUpdatesManually();
+      // Don't advance past 400ms yet — channel switch should cancel.
+      vi.advanceTimersByTime(100);
+
+      await setChannelHandler(null, "nightly");
+
+      // Without the timer cancellation, this advance would flip state to
+      // "checking" against the now-discarded prior-channel feed.
+      vi.advanceTimersByTime(CHECKING_MENU_DELAY_MS * 2);
+      expect(autoUpdaterService.getMenuState()).toBe("idle");
+    });
+
+    it("error event resets menu state to idle", () => {
+      autoUpdaterService.checkForUpdatesManually();
+      vi.advanceTimersByTime(CHECKING_MENU_DELAY_MS);
+      expect(autoUpdaterService.getMenuState()).toBe("checking");
+
+      errorHandler(Object.assign(new Error("conn reset"), { code: "ECONNRESET" }));
+
+      expect(autoUpdaterService.getMenuState()).toBe("idle");
+    });
+
+    it("error event does NOT clobber Ready", () => {
+      downloadedHandler({ version: "2.0.0" });
+      expect(autoUpdaterService.getMenuState()).toBe("ready");
+
+      // A subsequent retry/error must not erase the user's restart-to-install
+      // affordance — the staged installer is still valid.
+      errorHandler(Object.assign(new Error("conn reset"), { code: "ECONNRESET" }));
+
+      expect(autoUpdaterService.getMenuState()).toBe("ready");
+    });
+
+    it("notifies registered listeners on each transition", () => {
+      const listener = vi.fn();
+      autoUpdaterService.onMenuStateChange(listener);
+
+      autoUpdaterService.checkForUpdatesManually();
+      vi.advanceTimersByTime(CHECKING_MENU_DELAY_MS);
+      expect(listener).toHaveBeenCalledWith("checking");
+
+      downloadedHandler({ version: "2.0.0" });
+      expect(listener).toHaveBeenLastCalledWith("ready");
+    });
+
+    it("does not notify listeners when state is unchanged (no-op dedup)", () => {
+      const listener = vi.fn();
+      autoUpdaterService.onMenuStateChange(listener);
+
+      // Already idle — these should not fire the listener.
+      notAvailableHandler({});
+      errorHandler(Object.assign(new Error("conn reset"), { code: "ECONNRESET" }));
+
+      expect(listener).not.toHaveBeenCalled();
+    });
+
+    it("onMenuStateChange returns an unsubscribe function", () => {
+      const listener = vi.fn();
+      const unsubscribe = autoUpdaterService.onMenuStateChange(listener);
+
+      unsubscribe();
+
+      downloadedHandler({ version: "2.0.0" });
+      expect(listener).not.toHaveBeenCalled();
+    });
+
+    it("a thrown listener does not block other listeners or state transitions", () => {
+      const throwing = vi.fn(() => {
+        throw new Error("listener boom");
+      });
+      const surviving = vi.fn();
+      autoUpdaterService.onMenuStateChange(throwing);
+      autoUpdaterService.onMenuStateChange(surviving);
+
+      downloadedHandler({ version: "2.0.0" });
+
+      expect(throwing).toHaveBeenCalled();
+      expect(surviving).toHaveBeenCalledWith("ready");
+      expect(autoUpdaterService.getMenuState()).toBe("ready");
+    });
+
+    it("dispose clears menu state and removes listeners", () => {
+      const listener = vi.fn();
+      autoUpdaterService.onMenuStateChange(listener);
+      downloadedHandler({ version: "2.0.0" });
+      listener.mockClear();
+
+      autoUpdaterService.dispose();
+
+      // The listener should have been called once with "idle" as the final
+      // transition before being cleared.
+      expect(listener).toHaveBeenCalledWith("idle");
+      expect(autoUpdaterService.getMenuState()).toBe("idle");
+    });
+  });
+
+  describe("quitAndInstallIfReady", () => {
+    let downloadedHandler: (info: { version: string }) => void;
+
+    beforeEach(() => {
+      autoUpdaterService.initialize();
+
+      downloadedHandler = (autoUpdaterMock.on as Mock).mock.calls.find(
+        (args) => args[0] === "update-downloaded"
+      )![1];
+    });
+
+    it("returns false and does nothing when state is idle", () => {
+      expect(autoUpdaterService.quitAndInstallIfReady()).toBe(false);
+      vi.advanceTimersByTime(0);
+
+      expect(autoUpdaterMock.quitAndInstall).not.toHaveBeenCalled();
+      expect(cleanupOnExitMock).not.toHaveBeenCalled();
+    });
+
+    it("returns false when state is checking (no install staged)", () => {
+      autoUpdaterService.checkForUpdatesManually();
+      vi.advanceTimersByTime(CHECKING_MENU_DELAY_MS);
+
+      expect(autoUpdaterService.quitAndInstallIfReady()).toBe(false);
+      vi.advanceTimersByTime(0);
+      expect(autoUpdaterMock.quitAndInstall).not.toHaveBeenCalled();
+    });
+
+    it("calls cleanupOnExit then quitAndInstall when ready, deferred via setImmediate", () => {
+      downloadedHandler({ version: "2.0.0" });
+
+      const result = autoUpdaterService.quitAndInstallIfReady();
+
+      expect(result).toBe(true);
+      expect(cleanupOnExitMock).toHaveBeenCalledTimes(1);
+      // setImmediate is faked by vi.useFakeTimers — it hasn't fired yet.
+      expect(autoUpdaterMock.quitAndInstall).not.toHaveBeenCalled();
+
+      // advanceTimersToNextTimer fires only the queued setImmediate; using
+      // runAllTimers would also drain the 4h periodic interval and recurse.
+      vi.advanceTimersToNextTimer();
+      expect(autoUpdaterMock.quitAndInstall).toHaveBeenCalledTimes(1);
+    });
+
+    it("still schedules quitAndInstall when cleanupOnExit throws", () => {
+      downloadedHandler({ version: "2.0.0" });
+      cleanupOnExitMock.mockImplementationOnce(() => {
+        throw new Error("cleanup failed");
+      });
+
+      expect(autoUpdaterService.quitAndInstallIfReady()).toBe(true);
+      vi.advanceTimersToNextTimer();
+
+      expect(autoUpdaterMock.quitAndInstall).toHaveBeenCalledTimes(1);
     });
   });
 });

--- a/electron/services/__tests__/AutoUpdaterService.test.ts
+++ b/electron/services/__tests__/AutoUpdaterService.test.ts
@@ -1297,6 +1297,25 @@ describe("AutoUpdaterService", () => {
 
       expect(autoUpdaterMock.quitAndInstall).toHaveBeenCalledTimes(1);
     });
+
+    it("treats a missing stored channel as 'stable' so save-stable is a no-op on fresh installs", async () => {
+      // Regression for fresh-install bug: initialize() reads the channel with
+      // a `?? "stable"` fallback, but UPDATE_SET_CHANNEL must mirror that
+      // fallback when computing previousChannel — otherwise saving "stable"
+      // on a fresh install (no stored key) would discard a validly-staged
+      // installer because `"stable" === undefined` is false.
+      downloadedHandler({ version: "2.0.0" });
+      downloadedUpdateHelperMock.clear.mockClear();
+      autoUpdaterMock.setFeedURL.mockClear();
+
+      // Store has no `updateChannel` key — get() returns undefined.
+      storeMock.get.mockImplementation(() => undefined);
+
+      const result = await setChannelHandler(null, "stable");
+      expect(result).toBe("stable");
+      expect(downloadedUpdateHelperMock.clear).not.toHaveBeenCalled();
+      expect(autoUpdaterMock.setFeedURL).not.toHaveBeenCalled();
+    });
   });
 
   describe("error classification edge cases", () => {
@@ -1617,6 +1636,23 @@ describe("AutoUpdaterService", () => {
       expect(autoUpdaterService.quitAndInstallIfReady()).toBe(true);
       vi.advanceTimersToNextTimer();
 
+      expect(autoUpdaterMock.quitAndInstall).toHaveBeenCalledTimes(1);
+    });
+
+    it("a rapid double-call only schedules a single quitAndInstall (idempotency)", () => {
+      downloadedHandler({ version: "2.0.0" });
+
+      // Two calls back-to-back — the second must read idle and bail before
+      // queuing a second setImmediate. Otherwise cleanupOnExit + quitAndInstall
+      // would fire twice on a double-click.
+      const first = autoUpdaterService.quitAndInstallIfReady();
+      const second = autoUpdaterService.quitAndInstallIfReady();
+
+      expect(first).toBe(true);
+      expect(second).toBe(false);
+      expect(cleanupOnExitMock).toHaveBeenCalledTimes(1);
+
+      vi.advanceTimersToNextTimer();
       expect(autoUpdaterMock.quitAndInstall).toHaveBeenCalledTimes(1);
     });
   });


### PR DESCRIPTION
## Summary

- The \"Check for Updates...\" menu item now reflects the full update lifecycle: idle, checking, and ready states
- The checking state is Doherty 400ms gated so sub-threshold round-trips don't produce a visible flicker
- The ready state persists across toast eviction and dismissal, and resets on channel switch in lockstep with `lastBroadcastVersion`

Resolves #6866

## Changes

- `AutoUpdaterService` gains a public `updateMenuState` getter and emits `update-menu-state-changed` events when state transitions occur
- `createApplicationMenu` reads the current state and renders the appropriate label: `Check for Updates...` (idle), `Checking...` (disabled, delay-gated), or `Restart to install update` (invokes `quitAndInstall`)
- Menu rebuilds on each state change event
- Channel switch resets the ready state alongside the existing `lastBroadcastVersion` reset
- Unit tests added for `AutoUpdaterService` state transitions and menu label rendering across all three states

## Testing

- Unit tests cover all three menu item states, the 400ms delay gate, channel-switch state reset, and `quitAndInstall` invocation
- Manually verified idle → checking → ready flow and channel-switch reset behaviour