### PR TITLE
feat(notify): add transient flag so confirmation toasts skip the inbox

### DIFF
--- a/src/components/Notifications/NotificationCenter.tsx
+++ b/src/components/Notifications/NotificationCenter.tsx
@@ -274,6 +274,7 @@ export function NotificationCenter({ open, onClose }: NotificationCenterProps) {
       priority: "high",
       duration: 3000,
       urgent: true,
+      transient: true,
     });
   };
 
@@ -286,6 +287,7 @@ export function NotificationCenter({ open, onClose }: NotificationCenterProps) {
       priority: "high",
       duration: 3000,
       urgent: true,
+      transient: true,
     });
   };
 

--- a/src/components/Project/ProjectSwitcher.tsx
+++ b/src/components/Project/ProjectSwitcher.tsx
@@ -88,7 +88,13 @@ export function ProjectSwitcher() {
 
   const handleCopyPath = useCallback((path: string) => {
     void navigator.clipboard.writeText(path);
-    notify({ type: "info", title: "Path copied", message: path, duration: 2000 });
+    notify({
+      type: "info",
+      title: "Path copied",
+      message: path,
+      duration: 2000,
+      transient: true,
+    });
   }, []);
 
   const handleSelectBackground = useCallback(

--- a/src/components/Settings/KeybindingProfileActions.tsx
+++ b/src/components/Settings/KeybindingProfileActions.tsx
@@ -22,6 +22,7 @@ export function KeybindingProfileActions({ onImportComplete }: KeybindingProfile
           type: "success",
           title: "Shortcuts exported",
           message: "Keybinding profile saved successfully.",
+          transient: true,
         });
       }
     } catch {
@@ -60,6 +61,7 @@ export function KeybindingProfileActions({ onImportComplete }: KeybindingProfile
           result.applied > 0
             ? `Applied ${result.applied} shortcut${result.applied !== 1 ? "s" : ""}.`
             : "No shortcuts were applied.",
+        transient: true,
       });
     } catch {
       notify({

--- a/src/hooks/app/useGettingStartedChecklist.ts
+++ b/src/hooks/app/useGettingStartedChecklist.ts
@@ -108,6 +108,7 @@ export function useGettingStartedChecklist(isStateLoaded: boolean): GettingStart
         title: "Checklist complete!",
         message: "You're all set! Open the Action Palette (Cmd+K) to explore shortcuts.",
         duration: 5000,
+        transient: true,
       });
       setShowCelebration(true);
       safeFireAndForget(window.electron.onboarding.markChecklistCelebrationShown(), {

--- a/src/lib/__tests__/notify.test.ts
+++ b/src/lib/__tests__/notify.test.ts
@@ -291,6 +291,92 @@ describe("notify()", () => {
     });
   });
 
+  describe("transient — toast only, no inbox entry", () => {
+    it("skips history entry when transient is true", () => {
+      vi.spyOn(document, "hasFocus").mockReturnValue(true);
+      notify({
+        type: "info",
+        title: "Path copied",
+        message: "/Users/me/project",
+        transient: true,
+      });
+      expect(useNotificationHistoryStore.getState().entries).toHaveLength(0);
+      expect(useNotificationHistoryStore.getState().unreadCount).toBe(0);
+    });
+
+    it("still shows the toast when transient is true", () => {
+      vi.spyOn(document, "hasFocus").mockReturnValue(true);
+      notify({
+        type: "success",
+        title: "Shortcuts exported",
+        message: "Saved.",
+        transient: true,
+      });
+      expect(useNotificationStore.getState().notifications).toHaveLength(1);
+      expect(useNotificationStore.getState().notifications[0]!.historyEntryId).toBeUndefined();
+    });
+
+    it("skips history for grid-bar placement when transient", () => {
+      vi.spyOn(document, "hasFocus").mockReturnValue(true);
+      notify({
+        type: "info",
+        message: "Inline confirmation",
+        placement: "grid-bar",
+        transient: true,
+      });
+      expect(useNotificationHistoryStore.getState().entries).toHaveLength(0);
+      expect(useNotificationStore.getState().notifications).toHaveLength(1);
+    });
+
+    it("still writes history when transient is false or omitted", () => {
+      vi.spyOn(document, "hasFocus").mockReturnValue(true);
+      notify({ type: "success", message: "Default behavior" });
+      expect(useNotificationHistoryStore.getState().entries).toHaveLength(1);
+    });
+  });
+
+  describe("dev guard — error notifications without actions", () => {
+    it("warns when type is error and no actions are provided", () => {
+      vi.spyOn(document, "hasFocus").mockReturnValue(true);
+      const consoleSpy = vi.spyOn(console, "warn").mockImplementation(() => {});
+      notify({ type: "error", title: "Build failed", message: "Compile error." });
+      expect(consoleSpy).toHaveBeenCalledWith(
+        expect.stringContaining("[notify] error notification has no actions"),
+        expect.any(Object)
+      );
+      consoleSpy.mockRestore();
+    });
+
+    it("does not warn when type is error and an action is provided", () => {
+      vi.spyOn(document, "hasFocus").mockReturnValue(true);
+      const consoleSpy = vi.spyOn(console, "warn").mockImplementation(() => {});
+      notify({
+        type: "error",
+        title: "Build failed",
+        message: "Compile error.",
+        action: { label: "Retry", onClick: () => {} },
+      });
+      expect(consoleSpy).not.toHaveBeenCalledWith(
+        expect.stringContaining("[notify] error notification has no actions"),
+        expect.any(Object)
+      );
+      consoleSpy.mockRestore();
+    });
+
+    it("does not warn for non-error types without actions", () => {
+      vi.spyOn(document, "hasFocus").mockReturnValue(true);
+      const consoleSpy = vi.spyOn(console, "warn").mockImplementation(() => {});
+      notify({ type: "info", message: "Informational" });
+      notify({ type: "success", message: "Done" });
+      notify({ type: "warning", message: "Heads up" });
+      expect(consoleSpy).not.toHaveBeenCalledWith(
+        expect.stringContaining("[notify] error notification has no actions"),
+        expect.any(Object)
+      );
+      consoleSpy.mockRestore();
+    });
+  });
+
   describe("routing — focused + high → toast only", () => {
     it("adds toast notification when focused + high", () => {
       vi.spyOn(document, "hasFocus").mockReturnValue(true);

--- a/src/lib/__tests__/notify.test.ts
+++ b/src/lib/__tests__/notify.test.ts
@@ -333,6 +333,68 @@ describe("notify()", () => {
       notify({ type: "success", message: "Default behavior" });
       expect(useNotificationHistoryStore.getState().entries).toHaveLength(1);
     });
+
+    it("transient + priority: 'low' is a silent no-op", () => {
+      vi.spyOn(document, "hasFocus").mockReturnValue(true);
+      const consoleSpy = vi.spyOn(console, "warn").mockImplementation(() => {});
+      notify({ type: "info", message: "Nope", priority: "low", transient: true });
+      expect(useNotificationStore.getState().notifications).toHaveLength(0);
+      expect(useNotificationHistoryStore.getState().entries).toHaveLength(0);
+      expect(consoleSpy).toHaveBeenCalledWith(
+        expect.stringContaining("transient: true with priority: 'low'")
+      );
+      consoleSpy.mockRestore();
+    });
+
+    it("transient + priority: 'watch' still fires native with no inbox", () => {
+      vi.spyOn(document, "hasFocus").mockReturnValue(true);
+      notify({ type: "warning", message: "Watch me", priority: "watch", transient: true });
+      expect(useNotificationStore.getState().notifications).toHaveLength(1);
+      expect(useNotificationHistoryStore.getState().entries).toHaveLength(0);
+      expect(mockShowNative).toHaveBeenCalledOnce();
+    });
+
+    it("transient + urgent during quiet period still fires the toast", () => {
+      vi.spyOn(document, "hasFocus").mockReturnValue(true);
+      _setQuietUntil(Date.now() + 10_000);
+      notify({
+        type: "info",
+        message: "Mute confirmation",
+        priority: "high",
+        transient: true,
+        urgent: true,
+      });
+      expect(useNotificationStore.getState().notifications).toHaveLength(1);
+      expect(useNotificationHistoryStore.getState().entries).toHaveLength(0);
+    });
+
+    it("warns and drops silently when transient is paired with a visible origin context", () => {
+      vi.spyOn(document, "hasFocus").mockReturnValue(true);
+      const consoleSpy = vi.spyOn(console, "warn").mockImplementation(() => {});
+      setActiveContextAccessors({
+        getActiveWorktreeId: () => "wt-1",
+        getFocusedPanelId: () => null,
+        subscribeActiveContext: () => () => {},
+      });
+      try {
+        notify({
+          type: "info",
+          message: "Origin visible",
+          priority: "high",
+          transient: true,
+          context: { worktreeId: "wt-1" },
+        });
+        expect(useNotificationStore.getState().notifications).toHaveLength(0);
+        expect(useNotificationHistoryStore.getState().entries).toHaveLength(0);
+        expect(consoleSpy).toHaveBeenCalledWith(
+          expect.stringContaining("transient: true with context")
+        );
+      } finally {
+        _resetActiveContextAccessorsForTest();
+        _resetPendingSuppressedForTest();
+        consoleSpy.mockRestore();
+      }
+    });
   });
 
   describe("dev guard — error notifications without actions", () => {
@@ -342,7 +404,7 @@ describe("notify()", () => {
       notify({ type: "error", title: "Build failed", message: "Compile error." });
       expect(consoleSpy).toHaveBeenCalledWith(
         expect.stringContaining("[notify] error notification has no actions"),
-        expect.any(Object)
+        expect.objectContaining({ type: "error", title: "Build failed" })
       );
       consoleSpy.mockRestore();
     });

--- a/src/lib/notify.ts
+++ b/src/lib/notify.ts
@@ -384,7 +384,12 @@ export function isScheduledQuietHours(now: Date = new Date()): boolean {
  * `transient: true` skips step 1 — no history entry, no badge tick. Use it
  * only for one-shot confirmations whose result is already visible elsewhere
  * (clipboard, file dialog, in-place UI). It is stronger than `countable:
- * false`, which still writes the entry but suppresses the badge.
+ * false`, which still writes the entry but suppresses the badge. Constraints:
+ * combine with `priority: "high"` (or default) only — `priority: "low"` is a
+ * no-op (no toast and no inbox), and `priority: "watch"` still fires the OS
+ * native banner with no inbox fallback. Don't pair with `context` either:
+ * the active-context suppression-grace path needs an inbox entry to fall
+ * back to and silently drops the event when one isn't written.
  *
  * Only call for events the user could not otherwise observe: completion, failure,
  * or required action. Don't duplicate in-place UI state changes — those are
@@ -418,6 +423,25 @@ export function notify(payload: NotifyPayload): string {
     console.error(
       "[notify] ReactNode message without inboxMessage — persistent inbox history will be dropped. Provide inboxMessage for WCAG 2.2.1 compliance."
     );
+  }
+
+  if (import.meta.env.DEV && payload.transient) {
+    // transient bypasses the inbox, so combinations that depend on the inbox
+    // as a fallback (priority="low" routes only to inbox; context-suppression
+    // promotes the inbox entry on navigate-away) collapse to a silent drop.
+    // Surface here so the contradictory shape is caught at write-time.
+    if (priority === "low") {
+      // eslint-disable-next-line no-console
+      console.warn(
+        "[notify] transient: true with priority: 'low' is a silent no-op — low priority skips the toast and transient skips the inbox."
+      );
+    }
+    if (context) {
+      // eslint-disable-next-line no-console
+      console.warn(
+        "[notify] transient: true with context drops the event when the origin surface is visible — the suppression-grace path needs an inbox entry to fall back to."
+      );
+    }
   }
 
   const historyMessage = inboxMessage ?? (typeof message === "string" ? message : undefined);

--- a/src/lib/notify.ts
+++ b/src/lib/notify.ts
@@ -92,6 +92,14 @@ export interface NotifyPayload {
   coalesce?: CoalesceOptions;
   /** When false, the history entry exists but does not increment the unread badge. Defaults to true. */
   countable?: boolean;
+  /**
+   * When true, the notification is shown as a toast only — no history entry is
+   * written and no unread badge increments. Use only for one-shot confirmations
+   * where the result is already visible elsewhere (clipboard write, file dialog
+   * outcome, in-place UI state). Stronger than `countable: false`, which still
+   * writes the entry; `transient` skips the inbox entirely.
+   */
+  transient?: boolean;
   /** When true, the notification bypasses the startup quiet period gate */
   urgent?: boolean;
   /** Fires exactly once when the user explicitly dismisses the toast via the close or action button */
@@ -373,6 +381,11 @@ export function isScheduledQuietHours(now: Date = new Date()): boolean {
  *
  * The `grid-bar` placement bypasses priority routing and always renders inline.
  *
+ * `transient: true` skips step 1 — no history entry, no badge tick. Use it
+ * only for one-shot confirmations whose result is already visible elsewhere
+ * (clipboard, file dialog, in-place UI). It is stronger than `countable:
+ * false`, which still writes the entry but suppresses the badge.
+ *
  * Only call for events the user could not otherwise observe: completion, failure,
  * or required action. Don't duplicate in-place UI state changes — those are
  * already visible without a notification.
@@ -411,6 +424,19 @@ export function notify(payload: NotifyPayload): string {
 
   const allActions = [...(payload.actions ?? []), ...(payload.action ? [payload.action] : [])];
 
+  if (import.meta.env.DEV && type === "error" && allActions.length === 0) {
+    // CLAUDE.md microcopy contract: error toasts use Title-Message-Action and
+    // need at least one action when there's a real recovery path. Surfaced
+    // here so callers find the gap during development. Not a runtime crash —
+    // some errors are genuinely action-free, but the prompt nudges authors to
+    // confirm before shipping.
+    // eslint-disable-next-line no-console
+    console.warn(
+      "[notify] error notification has no actions — provide at least one action for the Title-Message-Action contract, or confirm there is no recovery path.",
+      payload
+    );
+  }
+
   // Action-bearing toasts persist by default so users can act; toaster's 3s fallback would otherwise dismiss them.
   if (payload.duration === undefined && allActions.length > 0) {
     payload = { ...payload, duration: 0 };
@@ -440,18 +466,19 @@ export function notify(payload: NotifyPayload): string {
   const isQuiet = !payload.urgent && (Date.now() < _quietUntil || isScheduledQuietHours());
 
   if (placement === "grid-bar") {
-    const entryId = historyMessage
-      ? useNotificationHistoryStore.getState().addEntry({
-          type,
-          title,
-          message: historyMessage,
-          correlationId,
-          seenAsToast: !isQuiet,
-          countable: payload.countable,
-          actions: historyActions.length > 0 ? historyActions : undefined,
-          context,
-        })
-      : undefined;
+    const entryId =
+      historyMessage && !payload.transient
+        ? useNotificationHistoryStore.getState().addEntry({
+            type,
+            title,
+            message: historyMessage,
+            correlationId,
+            seenAsToast: !isQuiet,
+            countable: payload.countable,
+            actions: historyActions.length > 0 ? historyActions : undefined,
+            context,
+          })
+        : undefined;
     if (!notificationsEnabled || isQuiet) return "";
     return useNotificationStore.getState().addNotification({
       ...payload,
@@ -466,18 +493,19 @@ export function notify(payload: NotifyPayload): string {
   const shouldToast = priority === "watch" || (priority === "high" && isFocused && !originVisible);
   const shouldNative = priority === "watch";
 
-  const historyEntryId = historyMessage
-    ? useNotificationHistoryStore.getState().addEntry({
-        type,
-        title,
-        message: historyMessage,
-        correlationId,
-        seenAsToast: !isQuiet && notificationsEnabled && (shouldToast || originVisible),
-        countable: payload.countable,
-        actions: historyActions.length > 0 ? historyActions : undefined,
-        context,
-      })
-    : undefined;
+  const historyEntryId =
+    historyMessage && !payload.transient
+      ? useNotificationHistoryStore.getState().addEntry({
+          type,
+          title,
+          message: historyMessage,
+          correlationId,
+          seenAsToast: !isQuiet && notificationsEnabled && (shouldToast || originVisible),
+          countable: payload.countable,
+          actions: historyActions.length > 0 ? historyActions : undefined,
+          context,
+        })
+      : undefined;
 
   if (!notificationsEnabled || isQuiet) return "";
 

--- a/src/lib/notify.ts
+++ b/src/lib/notify.ts
@@ -431,13 +431,11 @@ export function notify(payload: NotifyPayload): string {
     // promotes the inbox entry on navigate-away) collapse to a silent drop.
     // Surface here so the contradictory shape is caught at write-time.
     if (priority === "low") {
-      // eslint-disable-next-line no-console
       console.warn(
         "[notify] transient: true with priority: 'low' is a silent no-op — low priority skips the toast and transient skips the inbox."
       );
     }
     if (context) {
-      // eslint-disable-next-line no-console
       console.warn(
         "[notify] transient: true with context drops the event when the origin surface is visible — the suppression-grace path needs an inbox entry to fall back to."
       );
@@ -454,7 +452,6 @@ export function notify(payload: NotifyPayload): string {
     // here so callers find the gap during development. Not a runtime crash —
     // some errors are genuinely action-free, but the prompt nudges authors to
     // confirm before shipping.
-    // eslint-disable-next-line no-console
     console.warn(
       "[notify] error notification has no actions — provide at least one action for the Title-Message-Action contract, or confirm there is no recovery path.",
       payload


### PR DESCRIPTION
## Summary

- Every `notify()` call was writing an inbox entry, including one-shot confirmations like `Path copied` and mute state toasts that have no reason to be revisited. The unread badge was ticking up for noise.
- Adds `transient?: boolean` to `NotifyPayload` that gates the `addEntry()` call entirely — the toast fires but nothing touches the inbox or badge.
- Migrated 6 confirmed one-shot call sites: `ProjectSwitcher` (path copy), `KeybindingProfileActions` (export/import success), `NotificationCenter` (mute confirmations x2), and `useGettingStartedChecklist` (checklist complete). Error and action-bearing toasts are untouched.

Resolves #6890

## Changes

- `src/lib/notify.ts` — `transient` field on `NotifyPayload`, JSDoc, two ternary gates on both `addEntry` paths (grid-bar and main), DEV-only `console.warn` for `type: "error"` with no `actions` (Title-Message-Action contract enforcement at write-time), DEV-only guards for `transient + priority: "low"` (silent no-op) and `transient + context` (suppression-grace bypass)
- `src/lib/__tests__/notify.test.ts` — 11 new tests covering transient behaviour and DEV guard warnings
- 4 call-site files updated to `transient: true`

## Testing

- 156 tests pass (11 new)
- `npm run check` clean — lint at baseline 2722, typecheck clean, format clean