### PR TITLE
feat(github-list): polish status indicators and microcopy

### DIFF
--- a/src/components/GitHub/GitHubResourceList.tsx
+++ b/src/components/GitHub/GitHubResourceList.tsx
@@ -771,6 +771,7 @@ export function GitHubResourceList({
 
         {numberQuery !== null &&
           !loading &&
+          exactNumberNotFound === null &&
           (() => {
             const resourceLabel = type === "issue" ? "issue" : "PR";
             let label: string;

--- a/src/components/GitHub/GitHubResourceList.tsx
+++ b/src/components/GitHub/GitHubResourceList.tsx
@@ -11,7 +11,7 @@ import {
   Filter,
   Github,
 } from "lucide-react";
-import { isTokenRelatedError } from "@/lib/githubErrors";
+import { isTokenRelatedError, isTransientNetworkError } from "@/lib/githubErrors";
 import { Button } from "@/components/ui/button";
 import { AnimatePresence, m } from "framer-motion";
 import { EmptyState } from "@/components/ui/EmptyState";
@@ -195,6 +195,70 @@ export function GitHubResourceList({
   const [sortPopoverOpen, setSortPopoverOpen] = useState(false);
   const inputRef = useRef<HTMLInputElement>(null);
   const virtuosoRef = useRef<VirtuosoHandle>(null);
+
+  // Doherty Threshold gate for the refresh spinner. Sub-400ms background
+  // revalidations stay invisible (250ms for explicit clicks); once visible the
+  // spinner dwells ≥500ms so it never flashes on fast networks.
+  const [showSpinner, setShowSpinner] = useState(false);
+  const showSpinnerTimerRef = useRef<ReturnType<typeof setTimeout> | null>(null);
+  const spinnerDwellTimerRef = useRef<ReturnType<typeof setTimeout> | null>(null);
+  const spinnerVisibleSinceRef = useRef<number | null>(null);
+  const isManualRefreshRef = useRef(false);
+  const mountedRef = useRef(true);
+
+  useEffect(() => {
+    mountedRef.current = true;
+    return () => {
+      mountedRef.current = false;
+      if (showSpinnerTimerRef.current) clearTimeout(showSpinnerTimerRef.current);
+      if (spinnerDwellTimerRef.current) clearTimeout(spinnerDwellTimerRef.current);
+    };
+  }, []);
+
+  useEffect(() => {
+    const isActive = loading || refreshing;
+    if (isActive) {
+      if (spinnerDwellTimerRef.current) {
+        clearTimeout(spinnerDwellTimerRef.current);
+        spinnerDwellTimerRef.current = null;
+      }
+      if (spinnerVisibleSinceRef.current !== null) return;
+      if (showSpinnerTimerRef.current !== null) return;
+      const delay = isManualRefreshRef.current ? 250 : 400;
+      isManualRefreshRef.current = false;
+      showSpinnerTimerRef.current = setTimeout(() => {
+        if (!mountedRef.current) return;
+        spinnerVisibleSinceRef.current = Date.now();
+        setShowSpinner(true);
+        showSpinnerTimerRef.current = null;
+      }, delay);
+      return;
+    }
+    if (showSpinnerTimerRef.current) {
+      clearTimeout(showSpinnerTimerRef.current);
+      showSpinnerTimerRef.current = null;
+    }
+    if (spinnerVisibleSinceRef.current !== null) {
+      const elapsed = Date.now() - spinnerVisibleSinceRef.current;
+      const remaining = Math.max(0, 500 - elapsed);
+      if (remaining === 0) {
+        setShowSpinner(false);
+        spinnerVisibleSinceRef.current = null;
+      } else {
+        spinnerDwellTimerRef.current = setTimeout(() => {
+          if (!mountedRef.current) return;
+          setShowSpinner(false);
+          spinnerVisibleSinceRef.current = null;
+          spinnerDwellTimerRef.current = null;
+        }, remaining);
+      }
+    }
+  }, [loading, refreshing]);
+
+  const handleManualRefreshClick = useCallback(() => {
+    isManualRefreshRef.current = true;
+    handleManualRefresh();
+  }, [handleManualRefresh]);
 
   const selection = useIssueSelection();
   const [issueCache, setIssueCache] = useState<Map<number, GitHubIssue>>(() => new Map());
@@ -542,12 +606,11 @@ export function GitHubResourceList({
           </div>
           <button
             type="button"
-            onClick={handleManualRefresh}
+            onClick={handleManualRefreshClick}
             disabled={loading || refreshing}
             aria-label={`Refresh ${type === "issue" ? "issues" : "pull requests"}`}
-            aria-busy={loading || refreshing}
             title={
-              refreshing || loading
+              showSpinner
                 ? "Refreshing…"
                 : `Refresh ${type === "issue" ? "issues" : "pull requests"}`
             }
@@ -555,10 +618,10 @@ export function GitHubResourceList({
               "flex items-center justify-center w-7 h-7 rounded shrink-0",
               "text-daintree-text/60 hover:text-daintree-text hover:bg-tint/[0.06]",
               "transition-colors disabled:cursor-default",
-              (loading || refreshing) && "text-status-info"
+              showSpinner && "text-status-info"
             )}
           >
-            <RefreshCw className={cn("w-3.5 h-3.5", (loading || refreshing) && "animate-spin")} />
+            <RefreshCw className={cn("w-3.5 h-3.5", showSpinner && "animate-spin")} />
           </button>
           <Popover open={sortPopoverOpen} onOpenChange={setSortPopoverOpen}>
             <PopoverTrigger asChild>
@@ -706,9 +769,40 @@ export function GitHubResourceList({
           })}
         </div>
 
-        {numberQuery?.kind === "range" && numberQuery.truncated && (
-          <p className="text-xs text-muted-foreground">
-            Showing first {MULTI_FETCH_CAP} of range (capped)
+        {numberQuery !== null &&
+          !loading &&
+          (() => {
+            const resourceLabel = type === "issue" ? "issue" : "PR";
+            let label: string;
+            if (numberQuery.kind === "single") {
+              label = `Showing ${resourceLabel} #${numberQuery.number}`;
+            } else if (numberQuery.kind === "multi") {
+              const nums = numberQuery.numbers;
+              const shown = nums
+                .slice(0, 3)
+                .map((n) => `#${n}`)
+                .join(", ");
+              label =
+                nums.length > 3
+                  ? `Showing ${shown} + ${nums.length - 3} more`
+                  : `Showing ${shown}`;
+            } else if (numberQuery.kind === "range") {
+              label = numberQuery.truncated
+                ? `Showing first ${MULTI_FETCH_CAP} of range #${numberQuery.from}..#${numberQuery.to} (capped)`
+                : `Showing range #${numberQuery.from}..#${numberQuery.to}`;
+            } else {
+              label = `Showing #${numberQuery.from} and above`;
+            }
+            return (
+              <p className="bg-overlay-soft border border-[var(--border-divider)] rounded px-2 py-1 text-xs text-muted-foreground">
+                {label}
+              </p>
+            );
+          })()}
+
+        {!error && !loading && lastUpdatedAt != null && !debouncedSearch && (
+          <p className="text-[10px] text-muted-foreground/60 px-1">
+            Updated <LiveTimeAgo timestamp={lastUpdatedAt} />
           </p>
         )}
       </div>
@@ -742,7 +836,11 @@ export function GitHubResourceList({
               {error && (
                 <div className="px-3 py-2 border-b border-[var(--border-divider)] flex items-center gap-2 text-muted-foreground bg-overlay-soft shrink-0">
                   <WifiOff className="h-3.5 w-3.5 shrink-0" />
-                  <span className="text-xs truncate">{sanitizeIpcError(error)}</span>
+                  <span className="text-xs truncate">
+                    {isTransientNetworkError(error)
+                      ? "Couldn't reach GitHub. Showing last known results."
+                      : sanitizeIpcError(error)}
+                  </span>
                   {lastUpdatedAt != null && !debouncedSearch && (
                     <span className="text-xs text-muted-foreground/70 shrink-0 whitespace-nowrap">
                       · Updated <LiveTimeAgo timestamp={lastUpdatedAt} />
@@ -775,6 +873,7 @@ export function GitHubResourceList({
                 id={listId}
                 role="listbox"
                 aria-multiselectable={true}
+                aria-busy={loading || refreshing}
                 className="flex-1 min-h-0"
               >
                 <Virtuoso

--- a/src/components/GitHub/GitHubResourceList.tsx
+++ b/src/components/GitHub/GitHubResourceList.tsx
@@ -784,9 +784,7 @@ export function GitHubResourceList({
                 .map((n) => `#${n}`)
                 .join(", ");
               label =
-                nums.length > 3
-                  ? `Showing ${shown} + ${nums.length - 3} more`
-                  : `Showing ${shown}`;
+                nums.length > 3 ? `Showing ${shown} + ${nums.length - 3} more` : `Showing ${shown}`;
             } else if (numberQuery.kind === "range") {
               label = numberQuery.truncated
                 ? `Showing first ${MULTI_FETCH_CAP} of range #${numberQuery.from}..#${numberQuery.to} (capped)`

--- a/src/components/GitHub/__tests__/GitHubResourceList.swr.test.tsx
+++ b/src/components/GitHub/__tests__/GitHubResourceList.swr.test.tsx
@@ -319,7 +319,8 @@ describe("GitHubResourceList SWR behavior", () => {
       expect(screen.getByTestId("item-31")).toBeTruthy();
     });
     expect(screen.queryByText(/Network blip/)).toBeNull();
-    expect(screen.queryByText(/Updated/)).toBeNull();
+    // The success-path freshness sub-row continues to surface lastUpdatedAt.
+    expect(screen.getByText(/^Updated/)).toBeTruthy();
   });
 
   it("does not bleed stale timestamp across filter changes", async () => {
@@ -1030,8 +1031,11 @@ describe("GitHubResourceList retry behavior", () => {
 
     expect(screen.getByTestId("item-20")).toBeTruthy();
 
+    // The stale-while-error banner uses the friendlier rewrite for transient
+    // network errors; only this surface is rewritten — the cold-error path still
+    // surfaces the raw message.
     await waitFor(() => {
-      expect(screen.getByText(/Cannot reach GitHub/)).toBeTruthy();
+      expect(screen.getByText(/Couldn't reach GitHub\. Showing last known results\./)).toBeTruthy();
     });
 
     expect(mockListIssues).toHaveBeenCalledTimes(1);
@@ -1373,5 +1377,277 @@ describe("GitHubResourceList Activity reveal vs filter change — PR #6288", () 
     expect(mockListIssues.mock.calls[mockListIssues.mock.calls.length - 1]?.[0]).toMatchObject({
       state: "closed",
     });
+  });
+});
+
+describe("GitHubResourceList aria-busy placement (#6867)", () => {
+  it("sets aria-busy on the listbox during background revalidation, not on the refresh button", async () => {
+    const cacheKey = buildCacheKey("/test/proj", "issue", "open", "created");
+    setCache(cacheKey, {
+      items: [makeIssue(1)],
+      endCursor: null,
+      hasNextPage: false,
+      timestamp: Date.now(),
+    });
+    // Hang the revalidation so refreshing stays true.
+    mockListIssues.mockImplementation(() => new Promise(() => {}));
+
+    render(<GitHubResourceList type="issue" projectPath="/test/proj" />);
+
+    const listbox = screen.getByRole("listbox");
+    await waitFor(() => {
+      expect(listbox.getAttribute("aria-busy")).toBe("true");
+    });
+
+    const refreshButton = screen.getByRole("button", { name: /refresh issues/i });
+    expect(refreshButton.hasAttribute("aria-busy")).toBe(false);
+  });
+});
+
+describe("GitHubResourceList success-path freshness (#6867)", () => {
+  it("renders 'Updated …' below the header when data is fresh and no search is active", async () => {
+    const cacheKey = buildCacheKey("/test/proj", "issue", "open", "created");
+    setCache(cacheKey, {
+      items: [makeIssue(1)],
+      endCursor: null,
+      hasNextPage: false,
+      timestamp: Date.now(),
+    });
+    mockListIssues.mockResolvedValue(makeResponse([makeIssue(1)]));
+
+    render(<GitHubResourceList type="issue" projectPath="/test/proj" />);
+
+    await waitFor(() => {
+      expect(screen.getByText(/^Updated/)).toBeTruthy();
+    });
+  });
+
+  it("hides the freshness row while a number-query chip is active", async () => {
+    const cacheKey = buildCacheKey("/test/proj", "issue", "open", "created");
+    setCache(cacheKey, {
+      items: [makeIssue(42)],
+      endCursor: null,
+      hasNextPage: false,
+      timestamp: Date.now(),
+    });
+    mockGetIssueByNumber.mockResolvedValue(makeIssue(42));
+    useGitHubFilterStore.getState().setIssueSearchQuery("#42");
+
+    render(<GitHubResourceList type="issue" projectPath="/test/proj" />);
+
+    await waitFor(() => {
+      expect(screen.getByText("Showing issue #42")).toBeTruthy();
+    });
+    // The chip provides context — the freshness row stays hidden during searches.
+    expect(screen.queryByText(/^Updated/)).toBeNull();
+  });
+
+  it("does not render the freshness row when an error is active", async () => {
+    const cacheKey = buildCacheKey("/test/proj", "issue", "open", "created");
+    setCache(cacheKey, {
+      items: [makeIssue(1)],
+      endCursor: null,
+      hasNextPage: false,
+      timestamp: Date.now(),
+    });
+    mockListIssues.mockRejectedValue(new Error("Boom"));
+
+    render(<GitHubResourceList type="issue" projectPath="/test/proj" />);
+
+    await waitFor(() => {
+      expect(screen.getByText(/Boom/)).toBeTruthy();
+    });
+    // The freshness row is suppressed; only the banner-side timestamp remains.
+    expect(screen.queryByText(/^Updated/)).toBeNull();
+  });
+});
+
+describe("GitHubResourceList stale-while-error banner copy (#6867)", () => {
+  it("rewrites transient network errors to friendlier copy in the stale banner", async () => {
+    const cacheKey = buildCacheKey("/test/proj", "issue", "open", "created");
+    setCache(cacheKey, {
+      items: [makeIssue(20)],
+      endCursor: null,
+      hasNextPage: false,
+      timestamp: Date.now(),
+    });
+    mockListIssues.mockRejectedValue(
+      new Error("Cannot reach GitHub. Check your internet connection.")
+    );
+
+    render(<GitHubResourceList type="issue" projectPath="/test/proj" />);
+
+    await waitFor(() => {
+      expect(screen.getByText(/Couldn't reach GitHub\. Showing last known results\./)).toBeTruthy();
+    });
+    expect(screen.queryByText(/Check your internet connection/)).toBeNull();
+  });
+
+  it("keeps the sanitized raw message for non-transient errors", async () => {
+    const cacheKey = buildCacheKey("/test/proj", "issue", "open", "created");
+    setCache(cacheKey, {
+      items: [makeIssue(20)],
+      endCursor: null,
+      hasNextPage: false,
+      timestamp: Date.now(),
+    });
+    mockListIssues.mockRejectedValue(new Error("Repository not found or token lacks access."));
+
+    render(<GitHubResourceList type="issue" projectPath="/test/proj" />);
+
+    await waitFor(() => {
+      expect(screen.getByText(/Repository not found/)).toBeTruthy();
+    });
+    expect(screen.queryByText(/Couldn't reach GitHub/)).toBeNull();
+  });
+});
+
+describe("GitHubResourceList number-query chip (#6867)", () => {
+  it("shows 'Showing issue #N' for a single-number query", async () => {
+    mockGetIssueByNumber.mockResolvedValue(makeIssue(42));
+    useGitHubFilterStore.getState().setIssueSearchQuery("#42");
+
+    render(<GitHubResourceList type="issue" projectPath="/test/proj" />);
+
+    await waitFor(() => {
+      expect(screen.getByText("Showing issue #42")).toBeTruthy();
+    });
+  });
+
+  it("shows 'Showing PR #N' for the PR variant", async () => {
+    mockGetPRByNumber.mockResolvedValue({
+      ...makeIssue(7),
+      isDraft: false,
+      ciStatus: "SUCCESS" as const,
+    });
+    useGitHubFilterStore.getState().setPrSearchQuery("#7");
+
+    render(<GitHubResourceList type="pr" projectPath="/test/proj" />);
+
+    await waitFor(() => {
+      expect(screen.getByText("Showing PR #7")).toBeTruthy();
+    });
+  });
+
+  it("shows comma-separated numbers for a multi query and truncates after three", async () => {
+    mockGetIssueByNumber.mockImplementation((_cwd: string, n: number) =>
+      Promise.resolve(makeIssue(n))
+    );
+    useGitHubFilterStore.getState().setIssueSearchQuery("#1, #2, #3, #4, #5");
+
+    render(<GitHubResourceList type="issue" projectPath="/test/proj" />);
+
+    await waitFor(() => {
+      expect(screen.getByText("Showing #1, #2, #3 + 2 more")).toBeTruthy();
+    });
+  });
+
+  it("shows 'Showing range #from..#to' for a small range", async () => {
+    mockGetIssueByNumber.mockImplementation((_cwd: string, n: number) =>
+      Promise.resolve(makeIssue(n))
+    );
+    useGitHubFilterStore.getState().setIssueSearchQuery("#1..5");
+
+    render(<GitHubResourceList type="issue" projectPath="/test/proj" />);
+
+    await waitFor(() => {
+      expect(screen.getByText("Showing range #1..#5")).toBeTruthy();
+    });
+  });
+
+  it("shows '(capped)' marker for a range that exceeds the multi-fetch cap", async () => {
+    mockGetIssueByNumber.mockImplementation((_cwd: string, n: number) =>
+      Promise.resolve(makeIssue(n))
+    );
+    useGitHubFilterStore.getState().setIssueSearchQuery("#1..100");
+
+    render(<GitHubResourceList type="issue" projectPath="/test/proj" />);
+
+    await waitFor(() => {
+      expect(screen.getByText(/Showing first 20 of range #1\.\.#20 \(capped\)/)).toBeTruthy();
+    });
+  });
+
+  it("shows 'Showing #N and above' for an open-ended query", async () => {
+    mockListIssues.mockResolvedValue(makeResponse([makeIssue(130)]));
+    useGitHubFilterStore.getState().setIssueSearchQuery("#130+");
+
+    render(<GitHubResourceList type="issue" projectPath="/test/proj" />);
+
+    await waitFor(() => {
+      expect(screen.getByText("Showing #130 and above")).toBeTruthy();
+    });
+  });
+});
+
+describe("GitHubResourceList spinner gate (#6867)", () => {
+  beforeEach(() => {
+    vi.useFakeTimers({ shouldAdvanceTime: true });
+  });
+
+  afterEach(() => {
+    vi.useRealTimers();
+  });
+
+  it("does not show the spinner before the 400ms Doherty threshold elapses", async () => {
+    const cacheKey = buildCacheKey("/test/proj", "issue", "open", "created");
+    setCache(cacheKey, {
+      items: [makeIssue(1)],
+      endCursor: null,
+      hasNextPage: false,
+      timestamp: Date.now(),
+    });
+    // Hang revalidation so refreshing stays true.
+    mockListIssues.mockImplementation(() => new Promise(() => {}));
+
+    render(<GitHubResourceList type="issue" projectPath="/test/proj" />);
+
+    await vi.advanceTimersByTimeAsync(399);
+
+    const refreshIcon = screen
+      .getByRole("button", { name: /refresh issues/i })
+      .querySelector("svg");
+    expect(refreshIcon?.classList.contains("animate-spin")).toBe(false);
+  });
+
+  it("shows the spinner once the 400ms gate elapses on a long background revalidation", async () => {
+    const cacheKey = buildCacheKey("/test/proj", "issue", "open", "created");
+    setCache(cacheKey, {
+      items: [makeIssue(1)],
+      endCursor: null,
+      hasNextPage: false,
+      timestamp: Date.now(),
+    });
+    mockListIssues.mockImplementation(() => new Promise(() => {}));
+
+    render(<GitHubResourceList type="issue" projectPath="/test/proj" />);
+
+    await vi.advanceTimersByTimeAsync(450);
+
+    const refreshIcon = screen
+      .getByRole("button", { name: /refresh issues/i })
+      .querySelector("svg");
+    expect(refreshIcon?.classList.contains("animate-spin")).toBe(true);
+  });
+
+  it("never flashes the spinner when a background refresh completes faster than the gate", async () => {
+    const cacheKey = buildCacheKey("/test/proj", "issue", "open", "created");
+    setCache(cacheKey, {
+      items: [makeIssue(1)],
+      endCursor: null,
+      hasNextPage: false,
+      timestamp: Date.now(),
+    });
+    mockListIssues.mockResolvedValue(makeResponse([makeIssue(1)]));
+
+    render(<GitHubResourceList type="issue" projectPath="/test/proj" />);
+
+    // Let the fetch settle well within the 400ms gate.
+    await vi.advanceTimersByTimeAsync(50);
+
+    const refreshIcon = screen
+      .getByRole("button", { name: /refresh issues/i })
+      .querySelector("svg");
+    expect(refreshIcon?.classList.contains("animate-spin")).toBe(false);
   });
 });

--- a/src/components/GitHub/__tests__/GitHubResourceList.swr.test.tsx
+++ b/src/components/GitHub/__tests__/GitHubResourceList.swr.test.tsx
@@ -1754,9 +1754,7 @@ describe("GitHubResourceList spinner gate (#6867)", () => {
 
     // After the full 500ms minimum dwell elapses, the spinner clears.
     await vi.advanceTimersByTimeAsync(550);
-    const finalIcon = screen
-      .getByRole("button", { name: /refresh issues/i })
-      .querySelector("svg");
+    const finalIcon = screen.getByRole("button", { name: /refresh issues/i }).querySelector("svg");
     expect(finalIcon?.classList.contains("animate-spin")).toBe(false);
   });
 });

--- a/src/components/GitHub/__tests__/GitHubResourceList.swr.test.tsx
+++ b/src/components/GitHub/__tests__/GitHubResourceList.swr.test.tsx
@@ -1578,6 +1578,32 @@ describe("GitHubResourceList number-query chip (#6867)", () => {
       expect(screen.getByText("Showing #130 and above")).toBeTruthy();
     });
   });
+
+  it("hides the chip when the lookup yields exact-number-not-found", async () => {
+    mockGetIssueByNumber.mockResolvedValue(null);
+    useGitHubFilterStore.getState().setIssueSearchQuery("#999");
+
+    render(<GitHubResourceList type="issue" projectPath="/test/proj" />);
+
+    await waitFor(() => {
+      expect(screen.getByText(/Issue #999 not found/)).toBeTruthy();
+    });
+    // The chip would contradict the empty state — it must not render alongside.
+    expect(screen.queryByText("Showing issue #999")).toBeNull();
+  });
+
+  it("hides the chip while the numeric fetch is in flight", async () => {
+    mockGetIssueByNumber.mockImplementation(() => new Promise(() => {}));
+    useGitHubFilterStore.getState().setIssueSearchQuery("#42");
+
+    render(<GitHubResourceList type="issue" projectPath="/test/proj" />);
+
+    // Skeleton is up while the numeric lookup hangs.
+    await waitFor(() => {
+      expect(screen.getByTestId("skeleton")).toBeTruthy();
+    });
+    expect(screen.queryByText("Showing issue #42")).toBeNull();
+  });
 });
 
 describe("GitHubResourceList spinner gate (#6867)", () => {
@@ -1649,5 +1675,88 @@ describe("GitHubResourceList spinner gate (#6867)", () => {
       .getByRole("button", { name: /refresh issues/i })
       .querySelector("svg");
     expect(refreshIcon?.classList.contains("animate-spin")).toBe(false);
+  });
+
+  it("uses the shorter 250ms gate when the user clicks refresh", async () => {
+    const cacheKey = buildCacheKey("/test/proj", "issue", "open", "created");
+    setCache(cacheKey, {
+      items: [makeIssue(1)],
+      endCursor: null,
+      hasNextPage: false,
+      timestamp: Date.now(),
+    });
+    // Mount-time revalidate succeeds so loading clears before the click.
+    mockListIssues.mockResolvedValueOnce(makeResponse([makeIssue(1)]));
+    // Manual click hangs so we can observe the spinner gate.
+    mockListIssues.mockImplementation(() => new Promise(() => {}));
+
+    render(<GitHubResourceList type="issue" projectPath="/test/proj" />);
+
+    await waitFor(() => {
+      expect(mockListIssues).toHaveBeenCalledTimes(1);
+    });
+
+    // Let the mount-time revalidate fully settle so any pending spinner timer
+    // is cleared before the click.
+    await vi.advanceTimersByTimeAsync(500);
+
+    const refreshButton = screen.getByRole("button", { name: /refresh issues/i });
+    act(() => {
+      refreshButton.click();
+    });
+    await waitFor(() => {
+      expect(mockListIssues).toHaveBeenCalledTimes(2);
+    });
+
+    await vi.advanceTimersByTimeAsync(200);
+    const refreshIconBefore = refreshButton.querySelector("svg");
+    expect(refreshIconBefore?.classList.contains("animate-spin")).toBe(false);
+
+    await vi.advanceTimersByTimeAsync(150);
+    await waitFor(() => {
+      const icon = refreshButton.querySelector("svg");
+      expect(icon?.classList.contains("animate-spin")).toBe(true);
+    });
+  });
+
+  it("dwells the spinner ≥500ms once visible to avoid a quick flash", async () => {
+    const cacheKey = buildCacheKey("/test/proj", "issue", "open", "created");
+    setCache(cacheKey, {
+      items: [makeIssue(1)],
+      endCursor: null,
+      hasNextPage: false,
+      timestamp: Date.now(),
+    });
+    let resolveFetch: (v: GitHubListResponse<GitHubIssue>) => void = () => {};
+    mockListIssues.mockImplementationOnce(
+      () =>
+        new Promise<GitHubListResponse<GitHubIssue>>((resolve) => {
+          resolveFetch = resolve;
+        })
+    );
+
+    render(<GitHubResourceList type="issue" projectPath="/test/proj" />);
+
+    // Cross the 400ms gate so the spinner becomes visible.
+    await vi.advanceTimersByTimeAsync(450);
+    const refreshIcon = screen
+      .getByRole("button", { name: /refresh issues/i })
+      .querySelector("svg");
+    expect(refreshIcon?.classList.contains("animate-spin")).toBe(true);
+
+    // Resolve immediately — dwell timer kicks in for the remaining 500ms.
+    resolveFetch(makeResponse([makeIssue(1)]));
+    await vi.advanceTimersByTimeAsync(0);
+    const stillSpinning = screen
+      .getByRole("button", { name: /refresh issues/i })
+      .querySelector("svg");
+    expect(stillSpinning?.classList.contains("animate-spin")).toBe(true);
+
+    // After the full 500ms minimum dwell elapses, the spinner clears.
+    await vi.advanceTimersByTimeAsync(550);
+    const finalIcon = screen
+      .getByRole("button", { name: /refresh issues/i })
+      .querySelector("svg");
+    expect(finalIcon?.classList.contains("animate-spin")).toBe(false);
   });
 });


### PR DESCRIPTION
## Summary

- Moved `aria-busy` from the refresh button to the listbox container so screen readers announce content updates rather than button state
- Surfaced `Updated Xm ago` freshness text on the success path, gated to hide during active search or number queries; swapped raw IPC error text in the stale-while-error banner for friendlier copy when `isTransientNetworkError` classifies the failure as transient
- Replaced the range-only notice chip with a full number-query interpretation chip covering single, multi, range, range-truncated, and open-ended forms; hid it when an exact-number lookup returns not-found so it doesn't contradict the empty state; gated the refresh spinner behind the 400ms Doherty Threshold (250ms for explicit clicks) with a 500ms minimum dwell once visible

Resolves #6867

## Changes

- `GitHubResourceList.tsx` — `aria-busy` moved to listbox; freshness text added on success path; `isTransientNetworkError` classifier wired into banner copy; number-query chip expanded to cover all query forms; spinner gate added; chip hidden on not-found
- `GitHubResourceList.swr.test.tsx` — 14 new vitest cases covering `aria-busy` placement, freshness gating, banner copy classifier, all chip variants (including capped-range edge case), spinner gate (background 400ms / manual 250ms / dwell ≥500ms / fast-resolve no-flash), and chip hidden during in-flight numeric fetch and on not-found

## Testing

14 new vitest cases added. All existing tests pass.