### PR TITLE
fix(dnd): prevent inline button clicks from starting worktree card drags

### DIFF
--- a/src/components/DragDrop/DndProvider.tsx
+++ b/src/components/DragDrop/DndProvider.tsx
@@ -13,7 +13,6 @@ import {
   useDndMonitor,
   useSensors,
   useSensor,
-  MouseSensor,
   TouchSensor,
   closestCenter,
   rectIntersection,
@@ -27,6 +26,7 @@ import {
   type Announcements,
   type MeasuringConfiguration,
 } from "@dnd-kit/core";
+import { NoDndMouseSensor } from "./NoDndMouseSensor";
 import {
   usePanelStore,
   useLayoutConfigStore,
@@ -343,7 +343,7 @@ export function DndProvider({ children }: DndProviderProps) {
 
   // Configure sensors with activation constraint so clicks work for popovers
   const sensors = useSensors(
-    useSensor(MouseSensor, {
+    useSensor(NoDndMouseSensor, {
       activationConstraint: { distance: DRAG_ACTIVATION_DISTANCE },
     }),
     useSensor(TouchSensor, {

--- a/src/components/DragDrop/NoDndMouseSensor.ts
+++ b/src/components/DragDrop/NoDndMouseSensor.ts
@@ -1,4 +1,4 @@
-import { MouseSensor } from "@dnd-kit/core";
+import { MouseSensor, type MouseSensorOptions } from "@dnd-kit/core";
 import type { MouseEvent as ReactMouseEvent } from "react";
 
 const RIGHT_MOUSE_BUTTON = 2;
@@ -11,11 +11,13 @@ export function isNoDndTarget(event: MouseEvent): boolean {
 }
 
 export class NoDndMouseSensor extends MouseSensor {
-  static activators = [
+  static activators: typeof MouseSensor.activators = [
     {
-      eventName: "onMouseDown" as const,
-      handler: ({ nativeEvent: event }: ReactMouseEvent) => {
-        return !isNoDndTarget(event);
+      eventName: "onMouseDown",
+      handler: ({ nativeEvent: event }: ReactMouseEvent, { onActivation }: MouseSensorOptions) => {
+        if (isNoDndTarget(event)) return false;
+        onActivation?.({ event });
+        return true;
       },
     },
   ];

--- a/src/components/DragDrop/NoDndMouseSensor.ts
+++ b/src/components/DragDrop/NoDndMouseSensor.ts
@@ -1,0 +1,22 @@
+import { MouseSensor } from "@dnd-kit/core";
+import type { MouseEvent as ReactMouseEvent } from "react";
+
+const RIGHT_MOUSE_BUTTON = 2;
+
+export function isNoDndTarget(event: MouseEvent): boolean {
+  if (event.button === RIGHT_MOUSE_BUTTON) return true;
+  const target = event.target;
+  if (!(target instanceof Element)) return false;
+  return target.closest("[data-no-dnd]") !== null;
+}
+
+export class NoDndMouseSensor extends MouseSensor {
+  static activators = [
+    {
+      eventName: "onMouseDown" as const,
+      handler: ({ nativeEvent: event }: ReactMouseEvent) => {
+        return !isNoDndTarget(event);
+      },
+    },
+  ];
+}

--- a/src/components/DragDrop/NoDndMouseSensor.ts
+++ b/src/components/DragDrop/NoDndMouseSensor.ts
@@ -15,8 +15,8 @@ export class NoDndMouseSensor extends MouseSensor {
     {
       eventName: "onMouseDown",
       handler: ({ nativeEvent: event }: ReactMouseEvent, { onActivation }: MouseSensorOptions) => {
-        if (isNoDndTarget(event)) return false;
-        onActivation?.({ event });
+        if (isNoDndTarget(event as MouseEvent)) return false;
+        onActivation?.({ event: event as MouseEvent });
         return true;
       },
     },

--- a/src/components/DragDrop/__tests__/NoDndMouseSensor.test.ts
+++ b/src/components/DragDrop/__tests__/NoDndMouseSensor.test.ts
@@ -12,6 +12,7 @@ function mouseEvent(target: EventTarget | null, button = 0): MouseEvent {
 }
 
 function syntheticEvent(target: EventTarget | null, button = 0): ReactMouseEvent {
+  // eslint-disable-next-line @typescript-eslint/no-unsafe-type-assertion
   return { nativeEvent: mouseEvent(target, button) } as ReactMouseEvent;
 }
 

--- a/src/components/DragDrop/__tests__/NoDndMouseSensor.test.ts
+++ b/src/components/DragDrop/__tests__/NoDndMouseSensor.test.ts
@@ -1,0 +1,81 @@
+// @vitest-environment jsdom
+import { describe, it, expect } from "vitest";
+import { isNoDndTarget, NoDndMouseSensor } from "../NoDndMouseSensor";
+
+function mouseEvent(target: EventTarget | null, button = 0): MouseEvent {
+  const event = new MouseEvent("mousedown", { button, bubbles: true });
+  if (target) {
+    Object.defineProperty(event, "target", { value: target });
+  }
+  return event;
+}
+
+describe("isNoDndTarget", () => {
+  it("returns false for a plain element with no data-no-dnd ancestor", () => {
+    const el = document.createElement("div");
+    expect(isNoDndTarget(mouseEvent(el))).toBe(false);
+  });
+
+  it("returns true when target itself has data-no-dnd", () => {
+    const el = document.createElement("button");
+    el.setAttribute("data-no-dnd", "");
+    expect(isNoDndTarget(mouseEvent(el))).toBe(true);
+  });
+
+  it("returns true when an ancestor has data-no-dnd", () => {
+    const wrapper = document.createElement("div");
+    wrapper.setAttribute("data-no-dnd", "");
+    const child = document.createElement("span");
+    wrapper.appendChild(child);
+    expect(isNoDndTarget(mouseEvent(child))).toBe(true);
+  });
+
+  it("returns true for right-click (button === 2) regardless of target", () => {
+    const el = document.createElement("div");
+    expect(isNoDndTarget(mouseEvent(el, 2))).toBe(true);
+  });
+
+  it("returns false for a non-Element target (e.g., document)", () => {
+    expect(isNoDndTarget(mouseEvent(document))).toBe(false);
+  });
+
+  it("returns false when target is null", () => {
+    expect(isNoDndTarget(mouseEvent(null))).toBe(false);
+  });
+});
+
+describe("NoDndMouseSensor.activators", () => {
+  it("exposes a single onMouseDown activator", () => {
+    expect(NoDndMouseSensor.activators).toHaveLength(1);
+    expect(NoDndMouseSensor.activators[0]?.eventName).toBe("onMouseDown");
+  });
+
+  it("activator returns true for a plain target (drag activates)", () => {
+    const el = document.createElement("div");
+    const handler = NoDndMouseSensor.activators[0]!.handler;
+    // dnd-kit passes a React synthetic event with `nativeEvent`. We pass the
+    // minimum shape the handler reads.
+    // eslint-disable-next-line @typescript-eslint/no-explicit-any
+    const synthetic = { nativeEvent: mouseEvent(el) } as any;
+    expect(handler(synthetic, { active: { id: "x" } })).toBe(true);
+  });
+
+  it("activator returns false when target is inside a [data-no-dnd] subtree", () => {
+    const wrapper = document.createElement("div");
+    wrapper.setAttribute("data-no-dnd", "");
+    const button = document.createElement("button");
+    wrapper.appendChild(button);
+    const handler = NoDndMouseSensor.activators[0]!.handler;
+    // eslint-disable-next-line @typescript-eslint/no-explicit-any
+    const synthetic = { nativeEvent: mouseEvent(button) } as any;
+    expect(handler(synthetic, { active: { id: "x" } })).toBe(false);
+  });
+
+  it("activator returns false for right-click", () => {
+    const el = document.createElement("div");
+    const handler = NoDndMouseSensor.activators[0]!.handler;
+    // eslint-disable-next-line @typescript-eslint/no-explicit-any
+    const synthetic = { nativeEvent: mouseEvent(el, 2) } as any;
+    expect(handler(synthetic, { active: { id: "x" } })).toBe(false);
+  });
+});

--- a/src/components/DragDrop/__tests__/NoDndMouseSensor.test.ts
+++ b/src/components/DragDrop/__tests__/NoDndMouseSensor.test.ts
@@ -1,5 +1,6 @@
 // @vitest-environment jsdom
-import { describe, it, expect } from "vitest";
+import { describe, it, expect, vi } from "vitest";
+import type { MouseEvent as ReactMouseEvent } from "react";
 import { isNoDndTarget, NoDndMouseSensor } from "../NoDndMouseSensor";
 
 function mouseEvent(target: EventTarget | null, button = 0): MouseEvent {
@@ -8,6 +9,10 @@ function mouseEvent(target: EventTarget | null, button = 0): MouseEvent {
     Object.defineProperty(event, "target", { value: target });
   }
   return event;
+}
+
+function syntheticEvent(target: EventTarget | null, button = 0): ReactMouseEvent {
+  return { nativeEvent: mouseEvent(target, button) } as ReactMouseEvent;
 }
 
 describe("isNoDndTarget", () => {
@@ -30,9 +35,26 @@ describe("isNoDndTarget", () => {
     expect(isNoDndTarget(mouseEvent(child))).toBe(true);
   });
 
+  it("returns true when an inner SVG path is the target inside [data-no-dnd]", () => {
+    // Real-world case: clicking a Lucide icon inside a button reports
+    // `event.target` as the inner <path>, not the button.
+    const button = document.createElement("button");
+    button.setAttribute("data-no-dnd", "");
+    const svg = document.createElementNS("http://www.w3.org/2000/svg", "svg");
+    const path = document.createElementNS("http://www.w3.org/2000/svg", "path");
+    svg.appendChild(path);
+    button.appendChild(svg);
+    expect(isNoDndTarget(mouseEvent(path))).toBe(true);
+  });
+
   it("returns true for right-click (button === 2) regardless of target", () => {
     const el = document.createElement("div");
     expect(isNoDndTarget(mouseEvent(el, 2))).toBe(true);
+  });
+
+  it("returns false for middle-click (button === 1) on a plain target", () => {
+    const el = document.createElement("div");
+    expect(isNoDndTarget(mouseEvent(el, 1))).toBe(false);
   });
 
   it("returns false for a non-Element target (e.g., document)", () => {
@@ -53,11 +75,7 @@ describe("NoDndMouseSensor.activators", () => {
   it("activator returns true for a plain target (drag activates)", () => {
     const el = document.createElement("div");
     const handler = NoDndMouseSensor.activators[0]!.handler;
-    // dnd-kit passes a React synthetic event with `nativeEvent`. We pass the
-    // minimum shape the handler reads.
-    // eslint-disable-next-line @typescript-eslint/no-explicit-any
-    const synthetic = { nativeEvent: mouseEvent(el) } as any;
-    expect(handler(synthetic, { active: { id: "x" } })).toBe(true);
+    expect(handler(syntheticEvent(el), {})).toBe(true);
   });
 
   it("activator returns false when target is inside a [data-no-dnd] subtree", () => {
@@ -66,16 +84,31 @@ describe("NoDndMouseSensor.activators", () => {
     const button = document.createElement("button");
     wrapper.appendChild(button);
     const handler = NoDndMouseSensor.activators[0]!.handler;
-    // eslint-disable-next-line @typescript-eslint/no-explicit-any
-    const synthetic = { nativeEvent: mouseEvent(button) } as any;
-    expect(handler(synthetic, { active: { id: "x" } })).toBe(false);
+    expect(handler(syntheticEvent(button), {})).toBe(false);
   });
 
   it("activator returns false for right-click", () => {
     const el = document.createElement("div");
     const handler = NoDndMouseSensor.activators[0]!.handler;
-    // eslint-disable-next-line @typescript-eslint/no-explicit-any
-    const synthetic = { nativeEvent: mouseEvent(el, 2) } as any;
-    expect(handler(synthetic, { active: { id: "x" } })).toBe(false);
+    expect(handler(syntheticEvent(el, 2), {})).toBe(false);
+  });
+
+  it("activator invokes onActivation with the native event when drag activates", () => {
+    const el = document.createElement("div");
+    const handler = NoDndMouseSensor.activators[0]!.handler;
+    const onActivation = vi.fn();
+    const synthetic = syntheticEvent(el);
+    expect(handler(synthetic, { onActivation })).toBe(true);
+    expect(onActivation).toHaveBeenCalledTimes(1);
+    expect(onActivation).toHaveBeenCalledWith({ event: synthetic.nativeEvent });
+  });
+
+  it("activator does not call onActivation when blocked by [data-no-dnd]", () => {
+    const button = document.createElement("button");
+    button.setAttribute("data-no-dnd", "");
+    const handler = NoDndMouseSensor.activators[0]!.handler;
+    const onActivation = vi.fn();
+    expect(handler(syntheticEvent(button), { onActivation })).toBe(false);
+    expect(onActivation).not.toHaveBeenCalled();
   });
 });

--- a/src/components/Worktree/WorktreeCard/EnvironmentPopover.tsx
+++ b/src/components/Worktree/WorktreeCard/EnvironmentPopover.tsx
@@ -89,6 +89,7 @@ export function EnvironmentPopover({
     <Popover>
       <PopoverTrigger asChild>
         <button
+          data-no-dnd=""
           className="shrink-0 rounded focus-visible:outline-hidden focus-visible:ring-1 focus-visible:ring-daintree-accent"
           aria-label={`${worktreeMode} environment status`}
         >

--- a/src/components/Worktree/WorktreeCard/IssueBadge.tsx
+++ b/src/components/Worktree/WorktreeCard/IssueBadge.tsx
@@ -44,6 +44,7 @@ export const IssueBadge = memo(function IssueBadge({
         <button
           type="button"
           onClick={handleClick}
+          data-no-dnd=""
           className={cn(
             "flex items-center gap-1.5 text-left cursor-pointer transition-colors focus-visible:outline focus-visible:outline-2 focus-visible:outline-daintree-accent min-w-0",
             isHeadline ? "text-[13px]" : "text-xs",

--- a/src/components/Worktree/WorktreeCard/NonMainSecondaryRow.tsx
+++ b/src/components/Worktree/WorktreeCard/NonMainSecondaryRow.tsx
@@ -83,6 +83,7 @@ export function NonMainSecondaryRow({
           onClick={() => {
             if (isActive) badges.onOpenPlan?.();
           }}
+          data-no-dnd=""
           className="flex items-center gap-1 text-xs text-left cursor-pointer transition-colors text-daintree-text/70 hover:text-daintree-text focus-visible:outline focus-visible:outline-2 focus-visible:outline-daintree-accent"
           aria-disabled={!isActive || undefined}
           aria-label="View agent plan file"

--- a/src/components/Worktree/WorktreeCard/PRBadge.tsx
+++ b/src/components/Worktree/WorktreeCard/PRBadge.tsx
@@ -53,6 +53,7 @@ export const PRBadge = memo(function PRBadge({
         <button
           type="button"
           onClick={handleClick}
+          data-no-dnd=""
           className={cn(
             "flex items-center gap-1 text-xs text-left cursor-pointer transition-colors focus-visible:outline focus-visible:outline-2 focus-visible:outline-daintree-accent min-w-0",
             missingToken && "opacity-60"

--- a/src/components/Worktree/WorktreeCard/UpstreamSyncBadge.tsx
+++ b/src/components/Worktree/WorktreeCard/UpstreamSyncBadge.tsx
@@ -57,6 +57,7 @@ export function UpstreamSyncBadge({
           <button
             type="button"
             onClick={handleSignInClick}
+            data-no-dnd=""
             className="flex items-center text-[10px] text-status-warning/80 hover:text-status-warning transition-colors focus-visible:outline focus-visible:outline-2 focus-visible:outline-daintree-accent rounded-sm cursor-pointer"
             data-testid="upstream-sync-auth-cta"
           >

--- a/src/components/Worktree/WorktreeCard/WorktreeActionsToolbar.tsx
+++ b/src/components/Worktree/WorktreeCard/WorktreeActionsToolbar.tsx
@@ -116,6 +116,7 @@ export function WorktreeActionsToolbar({
     <div
       data-testid="worktree-actions-wrapper"
       data-worktree-row-toolbar=""
+      data-no-dnd=""
       role="toolbar"
       aria-label="Worktree actions"
       className={cn(


### PR DESCRIPTION
## Summary

- Inline button clicks inside worktree cards (popovers, badges, action toolbar) could accidentally register as drag starts when the pointer moved slightly during the click. The grip handle is supposed to be the only legitimate drag activator — this makes it so.
- Introduces `NoDndMouseSensor` (`src/components/DragDrop/NoDndMouseSensor.ts`), a `MouseSensor` subclass that bails out when the event target is inside a `[data-no-dnd]` subtree. It also guards against right-clicks, and passes through `onActivation` correctly.
- Replaces `MouseSensor` with `NoDndMouseSensor` in `DndProvider.tsx`, then adds `data-no-dnd` to `WorktreeActionsToolbar`, `EnvironmentPopover`, `IssueBadge`, `PRBadge`, `UpstreamSyncBadge`, and the plan-file button in `NonMainSecondaryRow`.

Resolves #6865

## Changes

- `src/components/DragDrop/NoDndMouseSensor.ts` — new sensor subclass with `[data-no-dnd]` check and right-click guard
- `src/components/DragDrop/DndProvider.tsx` — swap `MouseSensor` for `NoDndMouseSensor`
- `WorktreeActionsToolbar`, `EnvironmentPopover`, `IssueBadge`, `PRBadge`, `UpstreamSyncBadge`, `NonMainSecondaryRow` — `data-no-dnd` added to wrapper/trigger elements
- `src/components/DragDrop/__tests__/NoDndMouseSensor.test.ts` — 14 unit tests covering the sensor logic

## Testing

- 14 new unit tests in `NoDndMouseSensor.test.ts` — all pass
- All 646 existing `DragDrop`/`Worktree` tests pass
- Typecheck and lint clean