### PR TITLE
fix(settings): replace decorative accent colors with neutrals in search results

### DIFF
--- a/src/components/Settings/SettingsDialog.tsx
+++ b/src/components/Settings/SettingsDialog.tsx
@@ -1194,7 +1194,7 @@ function MatchBadge({ count }: { count: number }) {
   return (
     <span
       aria-hidden="true"
-      className="ml-auto text-[10px] font-medium tabular-nums px-1.5 py-0.5 rounded-full bg-daintree-accent/20 text-daintree-accent leading-none"
+      className="ml-auto text-[10px] font-medium tabular-nums px-1.5 py-0.5 rounded-full bg-daintree-text/10 text-daintree-text/70 leading-none"
     >
       {count}
     </span>
@@ -1266,7 +1266,7 @@ function SearchResults({
           className={cn(
             "group w-full text-left p-3 rounded-[var(--radius-md)] border transition-colors",
             index === activeIndex
-              ? "bg-overlay-soft border-daintree-accent/30"
+              ? "bg-overlay-soft border-daintree-border"
               : "border-transparent hover:bg-overlay-soft hover:border-daintree-border",
             "focus-visible:outline focus-visible:outline-2 focus-visible:outline-daintree-accent focus-visible:outline-offset-2"
           )}
@@ -1274,7 +1274,7 @@ function SearchResults({
           <div className="flex items-center gap-3">
             <div className="flex-1 min-w-0">
               <div className="flex items-center gap-2 mb-0.5">
-                <span className="text-[10px] font-medium text-daintree-accent/80 uppercase tracking-wide">
+                <span className="text-[10px] font-medium text-daintree-text/60 tracking-wide">
                   {result.tabLabel}
                 </span>
                 {result.subtabLabel && (
@@ -1303,7 +1303,7 @@ function SearchResults({
               className={cn(
                 "w-4 h-4 text-daintree-text/20 shrink-0 transition",
                 index === activeIndex
-                  ? "text-daintree-accent/60 translate-x-0.5"
+                  ? "text-daintree-text/40 translate-x-0.5"
                   : "group-hover:text-daintree-text/40"
               )}
             />


### PR DESCRIPTION
## Summary
- Replaces 4 decorative accent color treatments with neutral colors in the settings dialog search results
- Fixes MatchBadge, active result border, breadcrumb labels, and active chevron to use neutral treatments
- Reserves accent color for the dialog's three legitimate nav-state signals (search focus ring, sidebar active rail, subtab active border)

Resolves #6879

## Changes
- `MatchBadge`: `bg-daintree-accent/20 text-daintree-accent` → `bg-daintree-text/10 text-daintree-text/70`
- Active result border: `border-daintree-accent/30` → `border-daintree-border`
- Breadcrumb tab label: `text-daintree-accent/80` → `text-daintree-text/60`
- Active chevron: `text-daintree-accent/60` → `text-daintree-text/40`

## Testing
- Verified the settings dialog search results panel displays correctly with neutral colors
- Confirmed the three legitimate accent signals (search focus, sidebar rail, subtab border) remain unchanged
- Checked hover and active states on search result rows work as expected