### PR TITLE
fix(safe-mode): move crash diagnostics from headline to popover

### DIFF
--- a/src/components/Recovery/SafeModeBanner.tsx
+++ b/src/components/Recovery/SafeModeBanner.tsx
@@ -50,6 +50,8 @@ export function SafeModeBanner() {
   const skipped =
     typeof skippedPanelCount === "number" && skippedPanelCount > 0 ? skippedPanelCount : 0;
 
+  const hasCrashDiagnostics = typeof crashCount === "number" && crashCount > 0 && lastCrashAt;
+
   return (
     <div
       role="status"
@@ -57,10 +59,8 @@ export function SafeModeBanner() {
       className="flex items-center gap-3 px-4 py-2 bg-[var(--color-status-warning)]/15 border-b border-[var(--color-status-warning)]/30 text-[var(--color-status-warning)] text-sm shrink-0"
     >
       <AlertTriangle className="w-4 h-4 shrink-0" aria-hidden="true" />
-      <span className="flex-1">
-        Safe mode{summary}. Panels weren't restored to break the crash loop.
-      </span>
-      {skipped > 0 && (
+      <span className="flex-1">Safe mode — panels weren't restored to break the crash loop.</span>
+      {(skipped > 0 || hasCrashDiagnostics) && (
         <Popover>
           <PopoverTrigger
             type="button"
@@ -73,9 +73,12 @@ export function SafeModeBanner() {
             sideOffset={8}
             className="p-3 text-xs max-w-xs space-y-2 text-daintree-text"
           >
-            <p className="font-medium">
-              {skipped} {skipped === 1 ? "panel was" : "panels were"} skipped
-            </p>
+            {hasCrashDiagnostics && <p className="font-medium">{summaryParts.join(", ")}</p>}
+            {skipped > 0 && (
+              <p className="font-medium">
+                {skipped} {skipped === 1 ? "panel was" : "panels were"} skipped
+              </p>
+            )}
             <p className="text-daintree-text/70">
               Daintree booted in safe mode after repeated crashes. Saved panels weren't restored so
               you can recover the app.

--- a/src/components/Recovery/SafeModeBanner.tsx
+++ b/src/components/Recovery/SafeModeBanner.tsx
@@ -45,7 +45,6 @@ export function SafeModeBanner() {
   if (lastCrashAt) {
     summaryParts.push(`last ${formatRelativeTime(lastCrashAt)}`);
   }
-  const summary = summaryParts.length > 0 ? ` — ${summaryParts.join(", ")}` : "";
 
   const skipped =
     typeof skippedPanelCount === "number" && skippedPanelCount > 0 ? skippedPanelCount : 0;

--- a/src/components/Recovery/__tests__/SafeModeBanner.test.tsx
+++ b/src/components/Recovery/__tests__/SafeModeBanner.test.tsx
@@ -6,6 +6,24 @@ import { useSafeModeStore } from "@/store/safeModeStore";
 
 const resetAndRelaunch = vi.fn();
 
+// Render Popover children inline so jsdom doesn't need to wrestle Radix's
+// Portal / focus-trap machinery — we're asserting on the banner behavior,
+// not on portal mechanics.
+vi.mock("@/components/ui/popover", () => ({
+  Popover: ({ children }: { children: React.ReactNode }) => <>{children}</>,
+  PopoverTrigger: ({
+    children,
+    ...props
+  }: { children: React.ReactNode } & React.ButtonHTMLAttributes<HTMLButtonElement>) => (
+    <button type="button" {...props}>
+      {children}
+    </button>
+  ),
+  PopoverContent: ({ children }: { children: React.ReactNode }) => (
+    <div className="popover-content">{children}</div>
+  ),
+}));
+
 beforeEach(() => {
   resetAndRelaunch.mockReset();
   resetAndRelaunch.mockResolvedValue(undefined);
@@ -37,7 +55,7 @@ describe("SafeModeBanner", () => {
     expect(container.firstChild).toBeNull();
   });
 
-  it("renders crash count and relative time when meta is present", () => {
+  it("renders crash count and relative time in popover when meta is present", () => {
     useSafeModeStore.setState({
       safeMode: true,
       crashCount: 3,
@@ -45,12 +63,34 @@ describe("SafeModeBanner", () => {
     });
     render(<SafeModeBanner />);
     expect(screen.getByText(/Safe mode/)).toBeTruthy();
+    expect(screen.getByText(/to break the crash loop/)).toBeTruthy();
+    // Headline should be just the mitigation message
+    const headline = screen.getByText(/Safe mode/);
+    expect(headline.textContent).toBe(
+      "Safe mode — panels weren't restored to break the crash loop."
+    );
+    // Crash data should be in the popover (rendered inline due to mock)
     expect(screen.getByText(/3 crashes/)).toBeTruthy();
     expect(screen.getByText(/5m ago/)).toBeTruthy();
   });
 
-  it("hides Show details when no panels were skipped", () => {
-    useSafeModeStore.setState({ safeMode: true, skippedPanelCount: 0 });
+  it("shows Show details when crash data exists even with no skipped panels", () => {
+    useSafeModeStore.setState({
+      safeMode: true,
+      crashCount: 3,
+      lastCrashAt: Date.now() - 5 * 60_000,
+      skippedPanelCount: 0,
+    });
+    render(<SafeModeBanner />);
+    expect(screen.getByRole("button", { name: /Show details/i })).toBeTruthy();
+  });
+
+  it("hides Show details when no crash data and no panels were skipped", () => {
+    useSafeModeStore.setState({
+      safeMode: true,
+      crashCount: 0,
+      skippedPanelCount: 0,
+    });
     render(<SafeModeBanner />);
     expect(screen.queryByRole("button", { name: /Show details/i })).toBeNull();
   });
@@ -59,6 +99,21 @@ describe("SafeModeBanner", () => {
     useSafeModeStore.setState({ safeMode: true, skippedPanelCount: 4 });
     render(<SafeModeBanner />);
     expect(screen.getByRole("button", { name: /Show details/i })).toBeTruthy();
+    expect(screen.getByText(/4 panels were skipped/)).toBeTruthy();
+  });
+
+  it("shows both crash data and skipped panels in popover when both exist", () => {
+    useSafeModeStore.setState({
+      safeMode: true,
+      crashCount: 2,
+      lastCrashAt: Date.now() - 10 * 60_000,
+      skippedPanelCount: 4,
+    });
+    render(<SafeModeBanner />);
+    expect(screen.getByRole("button", { name: /Show details/i })).toBeTruthy();
+    expect(screen.getByText(/2 crashes/)).toBeTruthy();
+    expect(screen.getByText(/10m ago/)).toBeTruthy();
+    expect(screen.getByText(/4 panels were skipped/)).toBeTruthy();
   });
 
   it("calls resetAndRelaunch when Restart normally is clicked, and disables on subsequent clicks", () => {


### PR DESCRIPTION
## Summary
- Moved crash count and last-crash time from headline to the existing popover detail
- Headline now leads with the protective action: "Safe mode — panels weren't restored"
- Aligns with mature desktop app patterns that signal severity through state, not counts

Resolves #6872

## Changes
- Updated SafeModeBanner headline to lead with mitigation, not alarmist count
- Relocated crash diagnostics (count + relative time) into the popover
- Kept "Restart normally" CTA and resetAndRelaunch behavior unchanged
- Updated tests to reflect new headline structure

## Testing
- Verified banner renders correctly in safe mode state
- Confirmed popover shows crash count and timing on click
- Checked ARIA announcement still works with shorter headline
- Ran existing SafeModeBanner test suite