### PR TITLE
feat(ErrorBoundary): add onReset callback for upstream state invalidation

### DIFF
--- a/src/components/ErrorBoundary/ErrorBoundary.tsx
+++ b/src/components/ErrorBoundary/ErrorBoundary.tsx
@@ -9,6 +9,7 @@ interface ErrorBoundaryProps {
   children: ReactNode;
   fallback?: React.ComponentType<ErrorFallbackProps>;
   onError?: (error: Error, errorInfo: React.ErrorInfo) => void;
+  onReset?: () => void;
   resetKeys?: Array<string | number>;
   variant?: "fullscreen" | "section" | "component";
   componentName?: string;
@@ -118,6 +119,16 @@ export class ErrorBoundary extends Component<ErrorBoundaryProps, ErrorBoundarySt
   }
 
   resetError = (): void => {
+    const { onReset } = this.props;
+
+    if (onReset) {
+      try {
+        onReset();
+      } catch (error) {
+        logError("Error in onReset handler", error);
+      }
+    }
+
     this.setState({
       hasError: false,
       error: null,
@@ -188,6 +199,7 @@ export interface WithErrorBoundaryOptions {
     worktreeId?: string;
     terminalId?: string;
   };
+  onReset?: () => void;
   resetKeys?: Array<string | number>;
 }
 
@@ -200,6 +212,7 @@ export function withErrorBoundary<P extends object>(
       variant={options.variant || "component"}
       componentName={options.componentName || Component.displayName || Component.name}
       context={options.context}
+      onReset={options.onReset}
       resetKeys={options.resetKeys}
     >
       <Component {...props} />

--- a/src/components/ErrorBoundary/__tests__/ErrorBoundary.test.tsx
+++ b/src/components/ErrorBoundary/__tests__/ErrorBoundary.test.tsx
@@ -247,42 +247,33 @@ describe("ErrorBoundary", () => {
     expect(screen.getByText("Recovered")).toBeTruthy();
   });
 
-  it("calls onReset before setState causes re-render", () => {
-    let onResetCalledBeforeReset = false;
-    let stateHasReset = false;
+  it("calls onReset before rendering recovered children", () => {
+    const events: string[] = [];
+    let shouldThrow = true;
 
     const onReset = vi.fn(() => {
-      onResetCalledBeforeReset = !stateHasReset;
+      shouldThrow = false;
+      events.push("onReset");
     });
 
-    let shouldThrow = true;
     function ConditionalThrow() {
+      events.push("child-render");
       if (shouldThrow) throw new Error("Test render error");
       return <div>Recovered</div>;
     }
 
     render(
-      <ErrorBoundary
-        variant="section"
-        onReset={onReset}
-        fallback={({ error: _error, resetError }) => {
-          stateHasReset = false;
-          return (
-            <div>
-              <div>Error fallback</div>
-              <button onClick={() => resetError()}>Reload</button>
-            </div>
-          );
-        }}
-      >
+      <ErrorBoundary variant="section" onReset={onReset}>
         <ConditionalThrow />
       </ErrorBoundary>
     );
 
-    shouldThrow = false;
-    fireEvent.click(screen.getByText("Reload"));
+    expect(screen.getByText("Section stopped working")).toBeTruthy();
 
-    expect(onResetCalledBeforeReset).toBe(true);
+    events.length = 0;
+    fireEvent.click(screen.getByText("Reload pane"));
+
+    expect(events).toEqual(["onReset", "child-render"]);
     expect(screen.getByText("Recovered")).toBeTruthy();
   });
 

--- a/src/components/ErrorBoundary/__tests__/ErrorBoundary.test.tsx
+++ b/src/components/ErrorBoundary/__tests__/ErrorBoundary.test.tsx
@@ -1,7 +1,7 @@
 // @vitest-environment jsdom
 import { render, screen, fireEvent } from "@testing-library/react";
 import { describe, expect, it, vi, beforeEach, afterEach } from "vitest";
-import { ErrorBoundary } from "../ErrorBoundary";
+import { ErrorBoundary, withErrorBoundary } from "../ErrorBoundary";
 import { useErrorStore } from "@/store/errorStore";
 
 vi.mock("@/services/ActionService", () => ({
@@ -220,6 +220,156 @@ describe("ErrorBoundary", () => {
       </ErrorBoundary>
     );
 
+    expect(screen.getByText("Recovered at key 1")).toBeTruthy();
+  });
+
+  it("calls onReset callback when reload button is clicked", () => {
+    const onReset = vi.fn();
+    let shouldThrow = true;
+    function ConditionalThrow() {
+      if (shouldThrow) throw new Error("Test render error");
+      return <div>Recovered</div>;
+    }
+
+    render(
+      <ErrorBoundary variant="section" onReset={onReset}>
+        <ConditionalThrow />
+      </ErrorBoundary>
+    );
+
+    expect(screen.getByText("Section stopped working")).toBeTruthy();
+    expect(onReset).not.toHaveBeenCalled();
+
+    shouldThrow = false;
+    fireEvent.click(screen.getByText("Reload pane"));
+
+    expect(onReset).toHaveBeenCalledTimes(1);
+    expect(screen.getByText("Recovered")).toBeTruthy();
+  });
+
+  it("calls onReset before setState causes re-render", () => {
+    let onResetCalledBeforeReset = false;
+    let stateHasReset = false;
+
+    const onReset = vi.fn(() => {
+      onResetCalledBeforeReset = !stateHasReset;
+    });
+
+    let shouldThrow = true;
+    function ConditionalThrow() {
+      if (shouldThrow) throw new Error("Test render error");
+      return <div>Recovered</div>;
+    }
+
+    render(
+      <ErrorBoundary
+        variant="section"
+        onReset={onReset}
+        fallback={({ error: _error, resetError }) => {
+          stateHasReset = false;
+          return (
+            <div>
+              <div>Error fallback</div>
+              <button onClick={() => resetError()}>Reload</button>
+            </div>
+          );
+        }}
+      >
+        <ConditionalThrow />
+      </ErrorBoundary>
+    );
+
+    shouldThrow = false;
+    fireEvent.click(screen.getByText("Reload"));
+
+    expect(onResetCalledBeforeReset).toBe(true);
+    expect(screen.getByText("Recovered")).toBeTruthy();
+  });
+
+  it("logs error when onReset throws but still recovers", async () => {
+    const { logError } = await import("@/utils/logger");
+    const onReset = vi.fn(() => {
+      throw new Error("onReset failed");
+    });
+    let shouldThrow = true;
+    function ConditionalThrow() {
+      if (shouldThrow) throw new Error("Test render error");
+      return <div>Recovered</div>;
+    }
+
+    render(
+      <ErrorBoundary variant="section" onReset={onReset}>
+        <ConditionalThrow />
+      </ErrorBoundary>
+    );
+
+    expect(screen.getByText("Section stopped working")).toBeTruthy();
+
+    shouldThrow = false;
+    fireEvent.click(screen.getByText("Reload pane"));
+
+    expect(onReset).toHaveBeenCalled();
+    expect(logError).toHaveBeenCalledWith("Error in onReset handler", expect.any(Error));
+    expect(screen.getByText("Recovered")).toBeTruthy();
+  });
+
+  it("withErrorBoundary forwards onReset option", () => {
+    const onReset = vi.fn();
+    let shouldThrow = true;
+
+    function TestComponent() {
+      if (shouldThrow) throw new Error("Test error");
+      return <div>Test component</div>;
+    }
+
+    const WrappedComponent = withErrorBoundary(TestComponent, {
+      variant: "component",
+      onReset,
+    });
+
+    const { rerender } = render(<WrappedComponent />);
+
+    expect(screen.getByText("Test error")).toBeTruthy();
+
+    shouldThrow = false;
+    rerender(<WrappedComponent />);
+
+    // Click the "Try again" button from the error fallback (component variant)
+    fireEvent.click(screen.getByText("Try again"));
+
+    expect(onReset).toHaveBeenCalledTimes(1);
+    expect(screen.getByText("Test component")).toBeTruthy();
+  });
+
+  it("onReset is called when resetKeys change", () => {
+    const onReset = vi.fn();
+    let key = 0;
+    let shouldThrow = true;
+
+    function ConditionalNumericThrow({ resetKey }: { resetKey: number }) {
+      if (shouldThrow) throw new Error(`Test error at key ${resetKey}`);
+      return <div>Recovered at key {resetKey}</div>;
+    }
+
+    const { rerender } = render(
+      <ErrorBoundary variant="component" resetKeys={[key]} onReset={onReset}>
+        <ConditionalNumericThrow resetKey={key} />
+      </ErrorBoundary>
+    );
+
+    expect(screen.getByText("Test error at key 0")).toBeTruthy();
+    expect(onReset).not.toHaveBeenCalled();
+
+    // Change key to trigger reset
+    key = 1;
+    shouldThrow = false;
+    rerender(
+      <ErrorBoundary variant="component" resetKeys={[key]} onReset={onReset}>
+        <ConditionalNumericThrow resetKey={key} />
+      </ErrorBoundary>
+    );
+
+    expect(onReset).toHaveBeenCalledTimes(1);
     expect(screen.getByText("Recovered at key 1")).toBeTruthy();
   });
 });


### PR DESCRIPTION
## Summary
- Adds optional `onReset` callback to `ErrorBoundary` that fires before `setState` in `resetError`
- Lets call sites invalidate upstream state (drop stale records, invalidate caches, increment retry counters) when recovering from errors
- Mirrors the existing `onError` shape and forwards the option through the `withErrorBoundary` HOC

Resolves #6886

## Changes
- Added `onReset?: () => void` to `ErrorBoundaryProps`, `ErrorBoundaryContext`, and `WithErrorBoundaryOptions`
- Implemented callback invocation in `resetError`, wrapped in try-catch to prevent errors during reset
- Forwarded the option through `withErrorBoundary` HOC for per-call-site usage
- Added 5 comprehensive tests covering callback invocation, timing, error handling, HOC forwarding, and resetKeys integration

## Testing
- Added 5 new test cases in `ErrorBoundary.test.tsx`
- Verified callback fires synchronously before `setState` is called
- Verified callback errors are caught and don't prevent reset
- Verified option is properly forwarded through HOC
- Verified callback fires when `resetKeys` change