### PR TITLE
fix(worktree): remove accent hover from overview modal cards

### DIFF
--- a/src/components/Worktree/WorktreeOverviewModal.tsx
+++ b/src/components/Worktree/WorktreeOverviewModal.tsx
@@ -586,7 +586,7 @@ export function WorktreeOverviewModal({
                           "border border-divider",
                           "bg-daintree-sidebar/50",
                           "transition duration-150",
-                          "hover:border-daintree-accent/50 hover:shadow-lg hover:shadow-daintree-accent/5"
+                          "hover:bg-overlay-subtle hover:shadow-[var(--theme-shadow-ambient)]"
                         )}
                       >
                         <OverviewWorktreeCard
@@ -631,7 +631,7 @@ export function WorktreeOverviewModal({
                     "border border-divider",
                     "bg-daintree-sidebar/50",
                     "transition duration-150",
-                    "hover:border-daintree-accent/50 hover:shadow-lg hover:shadow-daintree-accent/5"
+                    "hover:bg-overlay-subtle hover:shadow-[var(--theme-shadow-ambient)]"
                   )}
                 >
                   <OverviewWorktreeCard

--- a/src/config/__tests__/accentGuard.contract.test.ts
+++ b/src/config/__tests__/accentGuard.contract.test.ts
@@ -262,7 +262,6 @@ const ALLOWLIST_BY_ISSUE: Record<string, string[]> = {
     "src/components/Worktree/WorktreeCard/WorktreeTerminalSection.tsx",
     "src/components/Worktree/WorktreeDeleteDialog.tsx",
     "src/components/Worktree/WorktreeFilterPopover.tsx",
-    "src/components/Worktree/WorktreeOverviewModal.tsx",
     "src/components/Worktree/WorktreePalette.tsx",
     "src/hooks/useUpdateListener.tsx",
     "src/components/agents/AgentCard.tsx",


### PR DESCRIPTION
## Summary

- The overview modal card wrappers were using `hover:border-daintree-accent/50 hover:shadow-lg hover:shadow-daintree-accent/5` on every card in the grid — accent noise across the whole surface, violating the one-signal rule.
- Replaces those classes with neutral hover styling (`hover:bg-overlay-subtle`), consistent with how `WorktreeCard` handles hover in the grid context.
- The `before:` accent left-bar on `worktree.isCurrent` is untouched — that one is genuinely load-bearing.

Resolves #6864

## Changes

- `src/components/Worktree/WorktreeOverviewModal.tsx` — swap accent hover classes for neutral on both the grouped-section and flat-grid card wrappers
- `src/config/__tests__/accentGuard.contract.test.ts` — remove `WorktreeOverviewModal` from the allowlist since it no longer needs an exception

## Testing

- Verified neutral hover renders correctly across both grouped-by-type and flat-grid layouts
- Confirmed `isCurrent` accent left-bar still renders on the active worktree
- Accent guard contract test passes clean with `WorktreeOverviewModal` off the allowlist