### PR TITLE
fix(settings): drop role=alert from field errors, wire env-row aria-invalid

### DIFF
--- a/src/components/Settings/EnvironmentSettingsTab.tsx
+++ b/src/components/Settings/EnvironmentSettingsTab.tsx
@@ -333,7 +333,11 @@ export function EnvironmentSettingsTab() {
           </Button>
         </div>
 
-        {saveError && <p className="text-xs text-status-error">{saveError}</p>}
+        {saveError && (
+          <p role="alert" className="text-xs text-status-error">
+            {saveError}
+          </p>
+        )}
 
         {isDirty && (
           <div className="flex items-center gap-2 pt-2">

--- a/src/components/Settings/EnvironmentSettingsTab.tsx
+++ b/src/components/Settings/EnvironmentSettingsTab.tsx
@@ -253,6 +253,7 @@ export function EnvironmentSettingsTab() {
               const isVisible = visibleEnvVars.has(envVar.id);
               const shouldMask = isSensitive && !isVisible;
               const error = rowErrors[envVar.id];
+              const errorId = error ? `${envVar.id}-error` : undefined;
 
               return (
                 <div key={envVar.id}>
@@ -271,6 +272,8 @@ export function EnvironmentSettingsTab() {
                       className="flex-1 bg-transparent border border-border-strong rounded px-2 py-1 text-sm text-daintree-text font-mono focus:outline-hidden focus:border-daintree-accent focus:ring-1 focus:ring-daintree-accent/30"
                       placeholder="VARIABLE_NAME"
                       aria-label="Environment variable name"
+                      aria-invalid={!!error || undefined}
+                      aria-describedby={errorId}
                     />
                     <span className="text-daintree-text/60">=</span>
                     <div className="flex-1 relative">
@@ -287,6 +290,7 @@ export function EnvironmentSettingsTab() {
                         )}
                         placeholder="e.g. /usr/local/bin"
                         aria-label="Environment variable value"
+                        aria-describedby={errorId}
                       />
                       {isSensitive && (
                         <button
@@ -313,7 +317,11 @@ export function EnvironmentSettingsTab() {
                       <Trash2 className="h-4 w-4 text-status-error" />
                     </button>
                   </div>
-                  {error && <p className="text-[11px] text-status-error mt-1 ml-1">{error}</p>}
+                  {error && (
+                    <p id={errorId} className="text-[11px] text-status-error mt-1 ml-1">
+                      {error}
+                    </p>
+                  )}
                 </div>
               );
             })

--- a/src/components/Settings/PortalSettingsTab.tsx
+++ b/src/components/Settings/PortalSettingsTab.tsx
@@ -377,7 +377,7 @@ export function PortalSettingsTab() {
           )}
 
           {customUrlError && (
-            <p id={customUrlErrorId} role="alert" className="text-xs text-status-error">
+            <p id={customUrlErrorId} className="text-xs text-status-error">
               {customUrlError}
             </p>
           )}
@@ -443,7 +443,7 @@ export function PortalSettingsTab() {
             </button>
           </div>
           {urlError && (
-            <p id={addLinkErrorId} role="alert" className="text-xs text-status-error">
+            <p id={addLinkErrorId} className="text-xs text-status-error">
               {urlError}
             </p>
           )}

--- a/src/components/Settings/SettingsCheckbox.tsx
+++ b/src/components/Settings/SettingsCheckbox.tsx
@@ -96,7 +96,7 @@ export function SettingsCheckbox({
             </p>
           )}
           {isError && (
-            <p id={errorId} role="alert" className="text-xs text-status-error mt-0.5">
+            <p id={errorId} className="text-xs text-status-error mt-0.5">
               {error}
             </p>
           )}

--- a/src/components/Settings/SettingsCheckbox.tsx
+++ b/src/components/Settings/SettingsCheckbox.tsx
@@ -61,7 +61,7 @@ export function SettingsCheckbox({
           }}
           disabled={disabled}
           aria-describedby={describedBy}
-          aria-invalid={isError}
+          aria-invalid={isError || undefined}
           className={cn(
             "relative flex shrink-0 w-4 h-4 mt-0.5 rounded border transition-colors duration-150",
             "bg-daintree-bg border-border-strong",

--- a/src/components/Settings/SettingsChoicebox.tsx
+++ b/src/components/Settings/SettingsChoicebox.tsx
@@ -224,7 +224,7 @@ export function SettingsChoicebox<T extends string = string>({
         </p>
       )}
       {error && (
-        <p id={errorId} role="alert" className="text-xs text-status-error">
+        <p id={errorId} className="text-xs text-status-error">
           {error}
         </p>
       )}

--- a/src/components/Settings/SettingsInput.tsx
+++ b/src/components/Settings/SettingsInput.tsx
@@ -95,7 +95,7 @@ export function SettingsInput({
         </p>
       )}
       {error && (
-        <p id={errorId} role="alert" className="text-xs text-status-error">
+        <p id={errorId} className="text-xs text-status-error">
           {error}
         </p>
       )}

--- a/src/components/Settings/SettingsSelect.tsx
+++ b/src/components/Settings/SettingsSelect.tsx
@@ -128,7 +128,7 @@ export function SettingsSelect({
         </p>
       )}
       {error && (
-        <p id={errorId} role="alert" className="text-xs text-status-error">
+        <p id={errorId} className="text-xs text-status-error">
           {error}
         </p>
       )}

--- a/src/components/Settings/SettingsTextarea.tsx
+++ b/src/components/Settings/SettingsTextarea.tsx
@@ -78,7 +78,7 @@ export function SettingsTextarea({
         </p>
       )}
       {error && (
-        <p id={errorId} role="alert" className="text-xs text-status-error">
+        <p id={errorId} className="text-xs text-status-error">
           {error}
         </p>
       )}

--- a/src/components/Settings/TerminalAppearanceTab.tsx
+++ b/src/components/Settings/TerminalAppearanceTab.tsx
@@ -215,7 +215,7 @@ export function TerminalAppearanceTab({
                 </span>
               </div>
               {fontSizeError && (
-                <p id={fontSizeErrorId} role="alert" className="text-xs text-status-error">
+                <p id={fontSizeErrorId} className="text-xs text-status-error">
                   {fontSizeError}
                 </p>
               )}

--- a/src/components/Settings/__tests__/EnvironmentSettingsTab.test.tsx
+++ b/src/components/Settings/__tests__/EnvironmentSettingsTab.test.tsx
@@ -132,6 +132,44 @@ describe("EnvironmentSettingsTab", () => {
     );
   });
 
+  it("wires aria-invalid and aria-describedby on row inputs when validation fails", async () => {
+    window.electron = {
+      globalEnv: {
+        get: vi.fn().mockResolvedValue({}),
+        set: vi.fn().mockResolvedValue(undefined),
+      },
+    } as unknown as typeof window.electron;
+
+    renderTab();
+
+    await waitFor(() => {
+      expect(screen.getByText("No environment variables configured yet")).toBeTruthy();
+    });
+
+    fireEvent.click(screen.getByRole("button", { name: /add variable/i }));
+
+    const nameInput = screen.getByLabelText("Environment variable name");
+    const valueInput = screen.getByLabelText("Environment variable value");
+    fireEvent.change(nameInput, { target: { value: "1BAD-NAME" } });
+    fireEvent.change(valueInput, { target: { value: "anything" } });
+
+    fireEvent.click(screen.getByRole("button", { name: /save/i }));
+
+    await waitFor(() => {
+      expect(nameInput.getAttribute("aria-invalid")).toBe("true");
+    });
+
+    const errorId = nameInput.getAttribute("aria-describedby");
+    expect(errorId).toBeTruthy();
+    expect(document.getElementById(errorId!)?.textContent).toContain("Invalid name");
+
+    expect(valueInput.getAttribute("aria-invalid")).toBeNull();
+    expect(valueInput.getAttribute("aria-describedby")).toBe(errorId);
+
+    expect(screen.queryByRole("alert")).toBeNull();
+    expect(window.electron.globalEnv.set).not.toHaveBeenCalled();
+  });
+
   it("adds new variable row and saves via globalEnv.set", async () => {
     window.electron = {
       globalEnv: {

--- a/src/components/Settings/__tests__/SettingsFormPrimitives.test.tsx
+++ b/src/components/Settings/__tests__/SettingsFormPrimitives.test.tsx
@@ -28,7 +28,9 @@ describe("SettingsInput", () => {
     render(<SettingsInput label="Port" error="Must be a number" />);
     const input = screen.getByLabelText("Port");
     expect(input.getAttribute("aria-invalid")).toBe("true");
-    expect(screen.getByRole("alert")?.textContent).toBe("Must be a number");
+    const errorId = input.getAttribute("aria-describedby")!;
+    expect(document.getElementById(errorId)?.textContent).toBe("Must be a number");
+    expect(screen.queryByRole("alert")).toBeNull();
   });
 
   it("hides description when error is shown", () => {
@@ -136,7 +138,9 @@ describe("SettingsSelect", () => {
     );
     const trigger = screen.getByLabelText("Lang");
     expect(trigger.getAttribute("aria-invalid")).toBe("true");
-    expect(screen.getByRole("alert")?.textContent).toBe("Required");
+    const errorId = trigger.getAttribute("aria-describedby")!;
+    expect(document.getElementById(errorId)?.textContent).toBe("Required");
+    expect(screen.queryByRole("alert")).toBeNull();
   });
 
   it("shows reset button when modified", () => {
@@ -178,6 +182,15 @@ describe("SettingsTextarea", () => {
     const descId = textarea.getAttribute("aria-describedby");
     expect(descId).toBeTruthy();
     expect(document.getElementById(descId!)?.textContent).toBe("Additional notes");
+  });
+
+  it("shows error and sets aria-invalid without role=alert", () => {
+    render(<SettingsTextarea label="Notes" error="Cannot be empty" />);
+    const textarea = screen.getByLabelText("Notes");
+    expect(textarea.getAttribute("aria-invalid")).toBe("true");
+    const errorId = textarea.getAttribute("aria-describedby")!;
+    expect(document.getElementById(errorId)?.textContent).toBe("Cannot be empty");
+    expect(screen.queryByRole("alert")).toBeNull();
   });
 
   it("forwards ref to the textarea element", () => {
@@ -271,7 +284,9 @@ describe("SettingsChoicebox", () => {
     );
     const group = screen.getByRole("radiogroup");
     expect(group.getAttribute("aria-invalid")).toBe("true");
-    expect(screen.getByRole("alert")?.textContent).toBe("Invalid selection");
+    const errorId = group.getAttribute("aria-describedby")!;
+    expect(document.getElementById(errorId)?.textContent).toBe("Invalid selection");
+    expect(screen.queryByRole("alert")).toBeNull();
   });
 
   it("hides description when error is shown", () => {
@@ -616,7 +631,9 @@ describe("SettingsCheckbox", () => {
     );
     const checkbox = screen.getByRole("checkbox");
     expect(checkbox.getAttribute("aria-invalid")).toBe("true");
-    expect(screen.getByRole("alert")?.textContent).toBe("Invalid state");
+    const errorId = checkbox.getAttribute("aria-describedby")!;
+    expect(document.getElementById(errorId)?.textContent).toBe("Invalid state");
+    expect(screen.queryByRole("alert")).toBeNull();
   });
 
   it("hides description when error is shown", () => {

--- a/src/components/Settings/__tests__/SettingsFormPrimitives.test.tsx
+++ b/src/components/Settings/__tests__/SettingsFormPrimitives.test.tsx
@@ -636,6 +636,19 @@ describe("SettingsCheckbox", () => {
     expect(screen.queryByRole("alert")).toBeNull();
   });
 
+  it("omits aria-invalid when no error is present", () => {
+    render(
+      <SettingsCheckbox
+        label="Test Setting"
+        description="A test description"
+        checked={false}
+        onChange={vi.fn()}
+      />
+    );
+    const checkbox = screen.getByRole("checkbox");
+    expect(checkbox.getAttribute("aria-invalid")).toBeNull();
+  });
+
   it("hides description when error is shown", () => {
     render(
       <SettingsCheckbox


### PR DESCRIPTION
## Summary

- `role="alert"` on inline field errors was double-announcing during typing — `aria-describedby` and `aria-invalid` already surface the error on focus, so the assertive live region is redundant and disruptive. Dropped it from all five shared primitives (`SettingsInput`, `SettingsTextarea`, `SettingsSelect`, `SettingsCheckbox`, `SettingsChoicebox`) and three ad-hoc sites (`TerminalAppearanceTab`, `PortalSettingsTab`, `SettingsDialog`).
- Form-level async error banners keep `role="alert"` — those are recovery-required interruptions arriving on events the user isn't actively engaged with.
- The raw `<input>` elements in `EnvironmentSettingsTab`'s env-var rows were rendering an error paragraph but never marking themselves invalid. Wired `aria-invalid` (key-only) and `aria-describedby` on both the name and value inputs so screen readers can announce the field as invalid on focus.

Resolves #6883

## Changes

- Drop `role="alert"` from `<p>` error elements in `SettingsInput`, `SettingsTextarea`, `SettingsSelect`, `SettingsChoicebox`
- Normalize `SettingsCheckbox` `aria-invalid` to `{isError || undefined}` (drops the `"true"` string, stays consistent with the other primitives)
- Drop `role="alert"` from ad-hoc field errors in `TerminalAppearanceTab` and `PortalSettingsTab`
- Restore `role="alert"` on the save-error banner in `SettingsDialog` (form-level, async — correct)
- Wire `aria-invalid` and shared `aria-describedby` onto env-var row inputs in `EnvironmentSettingsTab`
- Update 4 existing test assertions to use `aria-describedby` DOM lookup instead of `role="alert"` queries
- Add 3 new tests: textarea error a11y, checkbox no-error, env-row a11y regression

## Testing

Existing `SettingsFormPrimitives` tests updated and passing. New `EnvironmentSettingsTab` test suite covers the env-row `aria-invalid`/`aria-describedby` wiring. All assertions confirm the attributes are present on the correct elements with no `role="alert"` on field-level errors.