### PR TITLE
fix(dnd): block drag activation on inline worktree-card triggers

### DIFF
--- a/src/components/DragDrop/DndProvider.tsx
+++ b/src/components/DragDrop/DndProvider.tsx
@@ -124,7 +124,7 @@ export function isNoDndTarget(target: EventTarget | null): boolean {
 // MouseSensor variant that refuses to activate when the mousedown originates
 // inside a [data-no-dnd] subtree. Mirrors the upstream MouseSensor.activators
 // shape exactly so options like activationConstraint flow through unchanged.
-class NoDndMouseSensor extends MouseSensor {
+export class NoDndMouseSensor extends MouseSensor {
   static activators: {
     eventName: "onMouseDown";
     handler: (event: ReactMouseEvent, options: MouseSensorOptions) => boolean;

--- a/src/components/DragDrop/DndProvider.tsx
+++ b/src/components/DragDrop/DndProvider.tsx
@@ -6,6 +6,7 @@ import {
   createContext,
   useContext,
   useEffect,
+  type MouseEvent as ReactMouseEvent,
 } from "react";
 import {
   DndContext,
@@ -26,6 +27,7 @@ import {
   type Modifier,
   type Announcements,
   type MeasuringConfiguration,
+  type MouseSensorOptions,
 } from "@dnd-kit/core";
 import {
   usePanelStore,
@@ -106,6 +108,38 @@ export function useIsWorktreeSortDragging() {
 // Minimum distance (px) pointer must move before drag starts
 // This allows clicks to work for popovers without triggering drag
 const DRAG_ACTIVATION_DISTANCE = 8;
+
+// Right-click button index for MouseEvent.button (matches dnd-kit upstream).
+const MOUSE_RIGHT_CLICK = 2;
+
+// Returns true when the event target sits inside an opt-out subtree marked
+// with [data-no-dnd]. Used by NoDndMouseSensor to short-circuit drag activation
+// for inline interactive elements (popover triggers, dropdown menus, badges,
+// etc.) that share a sortable's drag surface. Pattern from
+// https://github.com/clauderic/dnd-kit/issues/477.
+export function isNoDndTarget(target: EventTarget | null): boolean {
+  return target instanceof Element && target.closest("[data-no-dnd]") !== null;
+}
+
+// MouseSensor variant that refuses to activate when the mousedown originates
+// inside a [data-no-dnd] subtree. Mirrors the upstream MouseSensor.activators
+// shape exactly so options like activationConstraint flow through unchanged.
+class NoDndMouseSensor extends MouseSensor {
+  static activators: {
+    eventName: "onMouseDown";
+    handler: (event: ReactMouseEvent, options: MouseSensorOptions) => boolean;
+  }[] = [
+    {
+      eventName: "onMouseDown",
+      handler: ({ nativeEvent: event }, { onActivation }) => {
+        if (event.button === MOUSE_RIGHT_CLICK) return false;
+        if (isNoDndTarget(event.target)) return false;
+        onActivation?.({ event });
+        return true;
+      },
+    },
+  ];
+}
 
 // Cursor offset from top of preview (positions cursor in title bar area)
 const TITLE_BAR_CURSOR_OFFSET = 12;
@@ -343,7 +377,7 @@ export function DndProvider({ children }: DndProviderProps) {
 
   // Configure sensors with activation constraint so clicks work for popovers
   const sensors = useSensors(
-    useSensor(MouseSensor, {
+    useSensor(NoDndMouseSensor, {
       activationConstraint: { distance: DRAG_ACTIVATION_DISTANCE },
     }),
     useSensor(TouchSensor, {

--- a/src/components/DragDrop/__tests__/noDndSensor.test.ts
+++ b/src/components/DragDrop/__tests__/noDndSensor.test.ts
@@ -1,0 +1,51 @@
+// @vitest-environment jsdom
+// Tests for the `isNoDndTarget` predicate that gates `NoDndMouseSensor`
+// activation. The predicate is the integration seam — testing it directly
+// avoids mounting `DndProvider` (which requires mocking 10+ modules).
+import { afterEach, describe, expect, it } from "vitest";
+import { isNoDndTarget } from "../DndProvider";
+
+describe("isNoDndTarget", () => {
+  afterEach(() => {
+    document.body.innerHTML = "";
+  });
+
+  it("returns true when the target itself carries [data-no-dnd]", () => {
+    const button = document.createElement("button");
+    button.setAttribute("data-no-dnd", "");
+    document.body.appendChild(button);
+
+    expect(isNoDndTarget(button)).toBe(true);
+  });
+
+  it("returns true when an ancestor carries [data-no-dnd]", () => {
+    const wrapper = document.createElement("div");
+    wrapper.setAttribute("data-no-dnd", "");
+    const inner = document.createElement("span");
+    wrapper.appendChild(inner);
+    document.body.appendChild(wrapper);
+
+    expect(isNoDndTarget(inner)).toBe(true);
+  });
+
+  it("returns false when no ancestor carries [data-no-dnd]", () => {
+    const button = document.createElement("button");
+    document.body.appendChild(button);
+
+    expect(isNoDndTarget(button)).toBe(false);
+  });
+
+  it("returns false for a null target", () => {
+    expect(isNoDndTarget(null)).toBe(false);
+  });
+
+  it("returns false for non-Element targets (e.g. document, window)", () => {
+    expect(isNoDndTarget(document)).toBe(false);
+    expect(isNoDndTarget(window)).toBe(false);
+  });
+
+  it("returns false for detached Element nodes that lack [data-no-dnd]", () => {
+    const detached = document.createElement("button");
+    expect(isNoDndTarget(detached)).toBe(false);
+  });
+});

--- a/src/components/DragDrop/__tests__/noDndSensor.test.ts
+++ b/src/components/DragDrop/__tests__/noDndSensor.test.ts
@@ -2,8 +2,17 @@
 // Tests for the `isNoDndTarget` predicate that gates `NoDndMouseSensor`
 // activation. The predicate is the integration seam — testing it directly
 // avoids mounting `DndProvider` (which requires mocking 10+ modules).
-import { afterEach, describe, expect, it } from "vitest";
-import { isNoDndTarget } from "../DndProvider";
+import type { MouseEvent as ReactMouseEvent } from "react";
+import { afterEach, describe, expect, it, vi } from "vitest";
+import { isNoDndTarget, NoDndMouseSensor } from "../DndProvider";
+
+type Activator = (typeof NoDndMouseSensor.activators)[number];
+
+function buildSyntheticEvent(target: EventTarget | null, button = 0): ReactMouseEvent {
+  return {
+    nativeEvent: { target, button } as unknown as MouseEvent,
+  } as ReactMouseEvent;
+}
 
 describe("isNoDndTarget", () => {
   afterEach(() => {
@@ -47,5 +56,66 @@ describe("isNoDndTarget", () => {
   it("returns false for detached Element nodes that lack [data-no-dnd]", () => {
     const detached = document.createElement("button");
     expect(isNoDndTarget(detached)).toBe(false);
+  });
+
+  it("returns true for detached Element nodes that carry [data-no-dnd]", () => {
+    const detached = document.createElement("button");
+    detached.setAttribute("data-no-dnd", "");
+    expect(isNoDndTarget(detached)).toBe(true);
+  });
+});
+
+describe("NoDndMouseSensor.activators handler", () => {
+  const activator = NoDndMouseSensor.activators[0] as Activator;
+
+  afterEach(() => {
+    document.body.innerHTML = "";
+  });
+
+  it("targets the onMouseDown synthetic event", () => {
+    expect(activator.eventName).toBe("onMouseDown");
+  });
+
+  it("returns false and does not call onActivation when target is inside [data-no-dnd]", () => {
+    const wrapper = document.createElement("div");
+    wrapper.setAttribute("data-no-dnd", "");
+    const button = document.createElement("button");
+    wrapper.appendChild(button);
+    document.body.appendChild(wrapper);
+
+    const onActivation = vi.fn();
+    const result = activator.handler(buildSyntheticEvent(button), { onActivation });
+
+    expect(result).toBe(false);
+    expect(onActivation).not.toHaveBeenCalled();
+  });
+
+  it("returns true and calls onActivation for a normal left-click target", () => {
+    const button = document.createElement("button");
+    document.body.appendChild(button);
+
+    const onActivation = vi.fn();
+    const result = activator.handler(buildSyntheticEvent(button), { onActivation });
+
+    expect(result).toBe(true);
+    expect(onActivation).toHaveBeenCalledTimes(1);
+  });
+
+  it("returns false and does not call onActivation for a right-click", () => {
+    const button = document.createElement("button");
+    document.body.appendChild(button);
+
+    const onActivation = vi.fn();
+    const result = activator.handler(buildSyntheticEvent(button, 2), { onActivation });
+
+    expect(result).toBe(false);
+    expect(onActivation).not.toHaveBeenCalled();
+  });
+
+  it("does not throw when onActivation is undefined on a normal click", () => {
+    const button = document.createElement("button");
+    document.body.appendChild(button);
+
+    expect(() => activator.handler(buildSyntheticEvent(button), {})).not.toThrow();
   });
 });

--- a/src/components/Worktree/WorktreeCard/EnvironmentPopover.tsx
+++ b/src/components/Worktree/WorktreeCard/EnvironmentPopover.tsx
@@ -89,6 +89,7 @@ export function EnvironmentPopover({
     <Popover>
       <PopoverTrigger asChild>
         <button
+          data-no-dnd
           className="shrink-0 rounded focus-visible:outline-hidden focus-visible:ring-1 focus-visible:ring-daintree-accent"
           aria-label={`${worktreeMode} environment status`}
         >

--- a/src/components/Worktree/WorktreeCard/IssueBadge.tsx
+++ b/src/components/Worktree/WorktreeCard/IssueBadge.tsx
@@ -44,6 +44,7 @@ export const IssueBadge = memo(function IssueBadge({
         <button
           type="button"
           onClick={handleClick}
+          data-no-dnd
           className={cn(
             "flex items-center gap-1.5 text-left cursor-pointer transition-colors focus-visible:outline focus-visible:outline-2 focus-visible:outline-daintree-accent min-w-0",
             isHeadline ? "text-[13px]" : "text-xs",

--- a/src/components/Worktree/WorktreeCard/NonMainSecondaryRow.tsx
+++ b/src/components/Worktree/WorktreeCard/NonMainSecondaryRow.tsx
@@ -83,6 +83,7 @@ export function NonMainSecondaryRow({
           onClick={() => {
             if (isActive) badges.onOpenPlan?.();
           }}
+          data-no-dnd
           className="flex items-center gap-1 text-xs text-left cursor-pointer transition-colors text-daintree-text/70 hover:text-daintree-text focus-visible:outline focus-visible:outline-2 focus-visible:outline-daintree-accent"
           aria-disabled={!isActive || undefined}
           aria-label="View agent plan file"

--- a/src/components/Worktree/WorktreeCard/PRBadge.tsx
+++ b/src/components/Worktree/WorktreeCard/PRBadge.tsx
@@ -53,6 +53,7 @@ export const PRBadge = memo(function PRBadge({
         <button
           type="button"
           onClick={handleClick}
+          data-no-dnd
           className={cn(
             "flex items-center gap-1 text-xs text-left cursor-pointer transition-colors focus-visible:outline focus-visible:outline-2 focus-visible:outline-daintree-accent min-w-0",
             missingToken && "opacity-60"

--- a/src/components/Worktree/WorktreeCard/UpstreamSyncBadge.tsx
+++ b/src/components/Worktree/WorktreeCard/UpstreamSyncBadge.tsx
@@ -57,6 +57,7 @@ export function UpstreamSyncBadge({
           <button
             type="button"
             onClick={handleSignInClick}
+            data-no-dnd
             className="flex items-center text-[10px] text-status-warning/80 hover:text-status-warning transition-colors focus-visible:outline focus-visible:outline-2 focus-visible:outline-daintree-accent rounded-sm cursor-pointer"
             data-testid="upstream-sync-auth-cta"
           >

--- a/src/components/Worktree/WorktreeCard/WorktreeActionsToolbar.tsx
+++ b/src/components/Worktree/WorktreeCard/WorktreeActionsToolbar.tsx
@@ -136,6 +136,7 @@ export function WorktreeActionsToolbar({
                 e.stopPropagation();
                 onCleanupWorktree();
               }}
+              data-no-dnd
               className="sidebar-action-button p-1.5 text-status-error/70 hover:text-status-error rounded transition-colors focus-visible:outline focus-visible:outline-2 focus-visible:outline-daintree-accent"
               aria-label="Delete worktree"
               data-testid="worktree-cleanup-button"
@@ -149,6 +150,7 @@ export function WorktreeActionsToolbar({
       {canCollapse && (
         <button
           onClick={onToggleCollapse}
+          data-no-dnd
           className="sidebar-action-button p-1.5 text-daintree-text/60 hover:text-text-primary rounded transition-colors focus-visible:outline focus-visible:outline-2 focus-visible:outline-daintree-accent"
           aria-expanded={!isCollapsed}
           aria-controls={isCollapsed ? undefined : contentId}
@@ -169,6 +171,7 @@ export function WorktreeActionsToolbar({
             <DropdownMenuTrigger asChild>
               <button
                 onClick={(e) => e.stopPropagation()}
+                data-no-dnd
                 className="sidebar-action-button p-1.5 text-daintree-text/60 hover:text-text-primary rounded transition-colors focus-visible:outline focus-visible:outline-2 focus-visible:outline-daintree-accent"
                 aria-label="More actions"
                 data-testid="worktree-actions-menu"


### PR DESCRIPTION
## Summary

- Inline buttons inside worktree cards (popovers, dropdowns, badges, plan-file button) shared the same `MouseSensor` activation surface as the card's sortable drag. A sloppy click travelling >8px during `mousedown` could register as a drag start instead of activating the button.
- Fixes this with the dnd-kit community `data-no-dnd` subtree pattern: a custom `NoDndMouseSensor` extends `MouseSensor` and short-circuits when the `mousedown` target is inside a `[data-no-dnd]` subtree or the event is a right-click.
- Eight inline triggers annotated with `data-no-dnd` across 6 files in `src/components/Worktree/WorktreeCard/`. The grip handle stays un-annotated — it's the only legitimate drag activator.

Resolves #6865

## Changes

- `src/components/DragDrop/DndProvider.tsx` — adds `NoDndMouseSensor` and exported `isNoDndTarget` helper; swaps `MouseSensor` for `NoDndMouseSensor` in the sensor config
- `src/components/Worktree/WorktreeCard/EnvironmentPopover.tsx` — `data-no-dnd` on popover trigger
- `src/components/Worktree/WorktreeCard/WorktreeActionsToolbar.tsx` — `data-no-dnd` on 3 toolbar buttons
- `src/components/Worktree/WorktreeCard/IssueBadge.tsx` — `data-no-dnd` on badge
- `src/components/Worktree/WorktreeCard/PRBadge.tsx` — `data-no-dnd` on badge
- `src/components/Worktree/WorktreeCard/UpstreamSyncBadge.tsx` — `data-no-dnd` on sign-in CTA
- `src/components/Worktree/WorktreeCard/NonMainSecondaryRow.tsx` — `data-no-dnd` on plan-file button
- `src/components/DragDrop/__tests__/noDndSensor.test.ts` — 12 unit tests covering `isNoDndTarget` (7 cases) and `NoDndMouseSensor` activator handler (5 cases)

## Testing

- Unit tests verify the sensor blocks events from `[data-no-dnd]` subtrees and right-clicks, passes normal clicks through (calling `onActivation`), and handles undefined `onActivation` gracefully.
- Manually confirmed the grip handle still initiates drag on press-and-move; all inline buttons activate without triggering drag even with deliberate pointer drift during `mousedown`.