### PR TITLE
fix(onboarding): redirect first-success moments toward launching an agent

### DIFF
--- a/src/components/Onboarding/CelebrationConfetti.tsx
+++ b/src/components/Onboarding/CelebrationConfetti.tsx
@@ -1,4 +1,4 @@
-import { useState } from "react";
+import { useEffect, useState } from "react";
 import { createPortal } from "react-dom";
 import { AnimatePresence, m } from "framer-motion";
 
@@ -45,16 +45,59 @@ function generateParticles(): Particle[] {
   });
 }
 
+function isReducedMotion(): boolean {
+  if (typeof window === "undefined") return false;
+  if (window.matchMedia("(prefers-reduced-motion: reduce)").matches) return true;
+  if (typeof document !== "undefined") {
+    return document.body.getAttribute("data-reduce-animations") === "true";
+  }
+  return false;
+}
+
+// Falls back to viewport center if the checklist isn't mounted (e.g. user
+// dismissed it before the 4th item completed).
+function readAnchor(): { x: number; y: number } {
+  if (typeof document === "undefined" || typeof window === "undefined") {
+    return { x: 0, y: 0 };
+  }
+  const el = document.querySelector("[data-getting-started-checklist]");
+  if (el instanceof HTMLElement) {
+    const rect = el.getBoundingClientRect();
+    if (rect.width > 0 || rect.height > 0) {
+      return { x: rect.left + rect.width / 2, y: rect.top + rect.height / 2 };
+    }
+  }
+  return { x: window.innerWidth / 2, y: window.innerHeight / 2 };
+}
+
 export function CelebrationConfetti() {
-  const reducedMotion =
-    typeof window !== "undefined" && window.matchMedia("(prefers-reduced-motion: reduce)").matches;
-
+  const [reducedMotion] = useState(isReducedMotion);
   const [particles] = useState(generateParticles);
+  const [anchor, setAnchor] = useState<{ x: number; y: number } | null>(null);
 
-  if (reducedMotion) return null;
+  useEffect(() => {
+    if (reducedMotion) return;
+    setAnchor(readAnchor());
+  }, [reducedMotion]);
+
+  if (reducedMotion) {
+    return createPortal(
+      <div
+        aria-hidden="true"
+        className="fixed inset-0 pointer-events-none z-[var(--z-toast)] bg-status-success/15 animate-checklist-complete-flash"
+      />,
+      document.body
+    );
+  }
+
+  if (!anchor) return null;
 
   return createPortal(
-    <div className="fixed inset-0 pointer-events-none z-[var(--z-toast)] flex items-center justify-center">
+    <div
+      aria-hidden="true"
+      className="fixed pointer-events-none z-[var(--z-toast)]"
+      style={{ left: anchor.x, top: anchor.y, width: 0, height: 0 }}
+    >
       <AnimatePresence>
         {particles.map((p) => (
           <m.div

--- a/src/components/Onboarding/GettingStartedChecklist.tsx
+++ b/src/components/Onboarding/GettingStartedChecklist.tsx
@@ -33,6 +33,7 @@ export function GettingStartedChecklist({
 
   return createPortal(
     <div
+      data-getting-started-checklist=""
       className={cn(
         "fixed bottom-4 z-[var(--z-toast)] pointer-events-none p-4",
         "flex justify-end w-full max-w-[320px]"

--- a/src/components/Onboarding/GettingStartedChecklist.tsx
+++ b/src/components/Onboarding/GettingStartedChecklist.tsx
@@ -33,7 +33,6 @@ export function GettingStartedChecklist({
 
   return createPortal(
     <div
-      data-getting-started-checklist=""
       className={cn(
         "fixed bottom-4 z-[var(--z-toast)] pointer-events-none p-4",
         "flex justify-end w-full max-w-[320px]"
@@ -41,6 +40,7 @@ export function GettingStartedChecklist({
       style={{ right: "calc(var(--right-obstruction-offset, 0px))" }}
     >
       <div
+        data-getting-started-checklist=""
         className={cn(
           "pointer-events-auto relative w-full",
           "rounded-[var(--radius-sm)] border",

--- a/src/components/Onboarding/__tests__/CelebrationConfetti.test.tsx
+++ b/src/components/Onboarding/__tests__/CelebrationConfetti.test.tsx
@@ -43,7 +43,9 @@ function stubMatchMedia(matches: boolean) {
   );
 }
 
-function mountChecklistAnchor(rect: Partial<DOMRect> = { left: 1000, top: 800, width: 280, height: 120 }) {
+function mountChecklistAnchor(
+  rect: Partial<DOMRect> = { left: 1000, top: 800, width: 280, height: 120 }
+) {
   const div = document.createElement("div");
   div.setAttribute("data-getting-started-checklist", "");
   Object.defineProperty(div, "getBoundingClientRect", {

--- a/src/components/Onboarding/__tests__/CelebrationConfetti.test.tsx
+++ b/src/components/Onboarding/__tests__/CelebrationConfetti.test.tsx
@@ -1,7 +1,7 @@
 // @vitest-environment jsdom
 import React from "react";
-import { render } from "@testing-library/react";
-import { describe, expect, it, vi, beforeEach } from "vitest";
+import { render, cleanup } from "@testing-library/react";
+import { describe, expect, it, vi, beforeEach, afterEach } from "vitest";
 
 vi.mock("framer-motion", () => {
   const MotionDiv = React.forwardRef(
@@ -43,33 +43,105 @@ function stubMatchMedia(matches: boolean) {
   );
 }
 
+function mountChecklistAnchor(rect: Partial<DOMRect> = { left: 1000, top: 800, width: 280, height: 120 }) {
+  const div = document.createElement("div");
+  div.setAttribute("data-getting-started-checklist", "");
+  Object.defineProperty(div, "getBoundingClientRect", {
+    value: () => ({
+      left: rect.left ?? 0,
+      top: rect.top ?? 0,
+      width: rect.width ?? 0,
+      height: rect.height ?? 0,
+      right: (rect.left ?? 0) + (rect.width ?? 0),
+      bottom: (rect.top ?? 0) + (rect.height ?? 0),
+      x: rect.left ?? 0,
+      y: rect.top ?? 0,
+      toJSON: () => ({}),
+    }),
+  });
+  document.body.appendChild(div);
+  return div;
+}
+
 describe("CelebrationConfetti", () => {
   beforeEach(() => {
     stubMatchMedia(false);
+    document.body.removeAttribute("data-reduce-animations");
+  });
+
+  afterEach(() => {
+    cleanup();
+    document.body.innerHTML = "";
+    document.body.removeAttribute("data-reduce-animations");
+    vi.unstubAllGlobals();
   });
 
   it("renders particles when reduced motion is not active", () => {
+    mountChecklistAnchor();
     render(<CelebrationConfetti />);
     const particles = document.body.querySelectorAll("[class*='rounded-full']");
     expect(particles.length).toBeGreaterThanOrEqual(6);
     expect(particles.length).toBeLessThanOrEqual(8);
   });
 
-  it("renders nothing when prefers-reduced-motion is active", () => {
+  it("renders a flash overlay when prefers-reduced-motion is active (no particles)", () => {
     stubMatchMedia(true);
 
     render(<CelebrationConfetti />);
     const particles = document.body.querySelectorAll("[class*='rounded-full']");
     expect(particles.length).toBe(0);
+
+    const flash = document.body.querySelector(".animate-checklist-complete-flash");
+    expect(flash).not.toBeNull();
+  });
+
+  it("renders a flash overlay when body[data-reduce-animations='true'] is set", () => {
+    document.body.setAttribute("data-reduce-animations", "true");
+
+    render(<CelebrationConfetti />);
+    const particles = document.body.querySelectorAll("[class*='rounded-full']");
+    expect(particles.length).toBe(0);
+
+    const flash = document.body.querySelector(".animate-checklist-complete-flash");
+    expect(flash).not.toBeNull();
   });
 
   it("renders with pointer-events-none container", () => {
+    mountChecklistAnchor();
     render(<CelebrationConfetti />);
     const overlay = document.body.querySelector(".pointer-events-none");
     expect(overlay).not.toBeNull();
   });
 
+  it("anchors particles to the checklist's bounding rect when present", () => {
+    mountChecklistAnchor({ left: 1000, top: 800, width: 280, height: 120 });
+
+    render(<CelebrationConfetti />);
+
+    // Origin element is the only fixed-positioned non-anchor element in the portal
+    const origin = Array.from(
+      document.body.querySelectorAll<HTMLElement>(".fixed.pointer-events-none")
+    ).find((el) => !el.hasAttribute("data-getting-started-checklist"));
+    expect(origin).toBeDefined();
+    // 1000 + 280/2 = 1140, 800 + 120/2 = 860
+    expect(origin?.style.left).toBe("1140px");
+    expect(origin?.style.top).toBe("860px");
+  });
+
+  it("falls back to viewport center when checklist anchor is absent", () => {
+    Object.defineProperty(window, "innerWidth", { configurable: true, value: 1600 });
+    Object.defineProperty(window, "innerHeight", { configurable: true, value: 900 });
+
+    render(<CelebrationConfetti />);
+
+    const origin = document.body.querySelector<HTMLElement>(".fixed.pointer-events-none");
+    expect(origin).not.toBeNull();
+    expect(origin?.style.left).toBe("800px");
+    expect(origin?.style.top).toBe("450px");
+  });
+
   it("uses theme CSS custom properties for particle colors", () => {
+    mountChecklistAnchor();
     const themeColors: Record<string, string> = {
       "--theme-accent-primary": "#ff0000",
       "--theme-status-success": "#00ff00",
@@ -93,6 +165,7 @@ describe("CelebrationConfetti", () => {
   });
 
   it("falls back to hardcoded colors when CSS variables are empty", () => {
+    mountChecklistAnchor();
     vi.spyOn(window, "getComputedStyle").mockReturnValue({
       getPropertyValue: () => "",
     } as unknown as CSSStyleDeclaration);

--- a/src/components/Onboarding/__tests__/GettingStartedChecklist.test.tsx
+++ b/src/components/Onboarding/__tests__/GettingStartedChecklist.test.tsx
@@ -125,12 +125,12 @@ describe("GettingStartedChecklist", () => {
     });
   });
 
-  it("dispatches worktree.createDialog.open when 'Run two agents in parallel' is clicked and does NOT mark the item (auto-marked by useGettingStartedChecklist when 2+ agents run concurrently)", () => {
+  it("dispatches panel.palette when 'Run two agents in parallel' is clicked and does NOT mark the item (auto-marked by useGettingStartedChecklist when 2+ agents run concurrently)", () => {
     render(<GettingStartedChecklist {...defaultProps} checklist={allIncomplete} />);
 
     fireEvent.click(screen.getByRole("button", { name: /run two agents in parallel/i }));
     expect(dispatchMock).toHaveBeenCalledTimes(1);
-    expect(dispatchMock).toHaveBeenCalledWith("worktree.createDialog.open", undefined, {
+    expect(dispatchMock).toHaveBeenCalledWith("panel.palette", undefined, {
       source: "user",
     });
     expect(defaultProps.onMarkItem).not.toHaveBeenCalled();

--- a/src/components/Onboarding/checklistItems.ts
+++ b/src/components/Onboarding/checklistItems.ts
@@ -42,6 +42,6 @@ export const CHECKLIST_ITEMS: ChecklistItemDef[] = [
     description:
       "Kick off a second agent while the first keeps working — that's the Daintree superpower.",
     icon: Plug,
-    actionId: "worktree.createDialog.open",
+    actionId: "panel.palette",
   },
 ];

--- a/src/components/Setup/AgentSetupWizard.tsx
+++ b/src/components/Setup/AgentSetupWizard.tsx
@@ -634,7 +634,9 @@ export function AgentSetupWizard({
                   }}
                 />
               )}
-              {state.step.type === "complete" && <CompleteStep installedAgents={installedAgents} />}
+              {state.step.type === "complete" && (
+                <CompleteStep installedAgents={installedAgents} onClose={onClose} />
+              )}
             </m.div>
           </AnimatePresence>
         </div>
@@ -921,7 +923,20 @@ function SelectionStep({
 
 // --- Complete step ---
 
-function CompleteStep({ installedAgents }: { installedAgents: string[] }) {
+export function CompleteStep({
+  installedAgents,
+  onClose,
+}: {
+  installedAgents: string[];
+  onClose: () => void;
+}) {
+  const hasAgents = installedAgents.length > 0;
+
+  const handleLaunch = useCallback(() => {
+    void actionService.dispatch("panel.palette", undefined, { source: "user" });
+    onClose();
+  }, [onClose]);
+
   return (
     <div className="space-y-6 text-center py-4">
       <div>
@@ -930,13 +945,13 @@ function CompleteStep({ installedAgents }: { installedAgents: string[] }) {
         </div>
         <h3 className="text-base font-semibold text-daintree-text mb-2">Setup Complete</h3>
         <p className="text-sm text-daintree-text/60">
-          {installedAgents.length > 0
+          {hasAgents
             ? `You have ${installedAgents.length} agent${installedAgents.length === 1 ? "" : "s"} ready to use. Launch them from the toolbar or with keyboard shortcuts.`
             : "No agents were installed. You can install them later from Settings > Agents."}
         </p>
       </div>
 
-      {installedAgents.length > 0 && (
+      {hasAgents && (
         <div className="space-y-2">
           {installedAgents.map((id) => {
             const agent = AGENT_REGISTRY[id];
@@ -969,6 +984,15 @@ function CompleteStep({ installedAgents }: { installedAgents: string[] }) {
               </div>
             );
           })}
+        </div>
+      )}
+
+      {hasAgents && (
+        <div className="flex justify-center">
+          <Button onClick={handleLaunch} data-testid="complete-step-launch-agent">
+            <Sparkles className="w-4 h-4 mr-1" />
+            Launch an agent
+          </Button>
         </div>
       )}
 

--- a/src/components/Setup/__tests__/CompleteStepLaunchCta.test.tsx
+++ b/src/components/Setup/__tests__/CompleteStepLaunchCta.test.tsx
@@ -61,7 +61,9 @@ vi.mock("@/store/appThemeStore", () => ({
 }));
 
 vi.mock("@/clients", () => ({ cliAvailabilityClient: { refresh: () => Promise.resolve({}) } }));
-vi.mock("@/clients/appThemeClient", () => ({ appThemeClient: { setColorScheme: () => Promise.resolve() } }));
+vi.mock("@/clients/appThemeClient", () => ({
+  appThemeClient: { setColorScheme: () => Promise.resolve() },
+}));
 vi.mock("../useAgentSetupPoll", () => ({ useAgentSetupPoll: () => undefined }));
 vi.mock("@/lib/notify", () => ({ notify: vi.fn() }));
 vi.mock("../SystemRequirementsSection", () => ({ SystemRequirementsSection: () => null }));

--- a/src/components/Setup/__tests__/CompleteStepLaunchCta.test.tsx
+++ b/src/components/Setup/__tests__/CompleteStepLaunchCta.test.tsx
@@ -1,0 +1,131 @@
+// @vitest-environment jsdom
+import React from "react";
+import { describe, it, expect, vi, beforeEach } from "vitest";
+import { render, fireEvent, screen } from "@testing-library/react";
+
+const { dispatchMock, getDisplayComboMock } = vi.hoisted(() => ({
+  dispatchMock: vi.fn(() => Promise.resolve()),
+  getDisplayComboMock: vi.fn<(actionId: string) => string>(() => ""),
+}));
+
+vi.mock("@/services/ActionService", () => ({
+  actionService: { dispatch: dispatchMock },
+}));
+
+vi.mock("@/services/KeybindingService", () => ({
+  keybindingService: { getDisplayCombo: getDisplayComboMock },
+}));
+
+vi.mock("@/components/icons", () => ({
+  Plug: () => null,
+  BrandMark: ({ children }: { children: React.ReactNode }) => <>{children}</>,
+}));
+
+vi.mock("@/components/ui/button", () => ({
+  Button: ({
+    children,
+    onClick,
+    "data-testid": testId,
+  }: {
+    children: React.ReactNode;
+    onClick?: () => void;
+    "data-testid"?: string;
+  }) => (
+    <button onClick={onClick} data-testid={testId}>
+      {children}
+    </button>
+  ),
+}));
+
+vi.mock("@/config/agents", () => ({
+  AGENT_REGISTRY: {
+    claude: {
+      name: "Claude",
+      icon: () => <span data-testid="agent-icon-claude" />,
+      color: "#abcabc",
+      presets: [],
+    },
+  },
+}));
+
+vi.mock("@/store", () => ({
+  useAgentSettingsStore: () => ({}),
+}));
+
+vi.mock("@/store/cliAvailabilityStore", () => ({
+  useCliAvailabilityStore: () => ({}),
+}));
+
+vi.mock("@/store/appThemeStore", () => ({
+  useAppThemeStore: () => ({}),
+}));
+
+vi.mock("@/clients", () => ({ cliAvailabilityClient: { refresh: () => Promise.resolve({}) } }));
+vi.mock("@/clients/appThemeClient", () => ({ appThemeClient: { setColorScheme: () => Promise.resolve() } }));
+vi.mock("../useAgentSetupPoll", () => ({ useAgentSetupPoll: () => undefined }));
+vi.mock("@/lib/notify", () => ({ notify: vi.fn() }));
+vi.mock("../SystemRequirementsSection", () => ({ SystemRequirementsSection: () => null }));
+vi.mock("../AgentCliStep", () => ({ AgentCliStep: () => null }));
+vi.mock("@/components/agents/AgentCard", () => ({ AgentCard: () => null }));
+
+vi.mock("framer-motion", () => {
+  const Passthrough = React.forwardRef<HTMLDivElement, React.PropsWithChildren<unknown>>(
+    ({ children }, _ref) => <>{children}</>
+  );
+  return {
+    AnimatePresence: ({ children }: React.PropsWithChildren<unknown>) => <>{children}</>,
+    LazyMotion: ({ children }: React.PropsWithChildren<unknown>) => <>{children}</>,
+    domAnimation: {},
+    domMax: {},
+    LayoutGroup: ({ children }: React.PropsWithChildren<unknown>) => <>{children}</>,
+    useReducedMotion: () => false,
+    m: { div: Passthrough },
+    motion: { div: Passthrough },
+  };
+});
+
+vi.mock("@/components/ui/AppDialog", () => {
+  const Dialog = ({ isOpen, children }: { isOpen: boolean; children: React.ReactNode }) =>
+    isOpen ? <div>{children}</div> : null;
+  const passthrough = ({ children }: { children: React.ReactNode }) => <div>{children}</div>;
+  Dialog.Header = passthrough;
+  Dialog.Body = passthrough;
+  Dialog.Footer = passthrough;
+  Dialog.Title = passthrough;
+  Dialog.CloseButton = () => null;
+  return { AppDialog: Dialog };
+});
+
+vi.mock("@/components/ui/Spinner", () => ({ Spinner: () => null }));
+
+import { CompleteStep } from "../AgentSetupWizard";
+
+describe("CompleteStep launch CTA", () => {
+  beforeEach(() => {
+    dispatchMock.mockClear();
+    getDisplayComboMock.mockReset();
+    getDisplayComboMock.mockReturnValue("");
+  });
+
+  it("renders 'Launch an agent' button when at least one agent is installed", () => {
+    render(<CompleteStep installedAgents={["claude"]} onClose={vi.fn()} />);
+    expect(screen.getByTestId("complete-step-launch-agent")).toBeTruthy();
+    expect(screen.getByRole("button", { name: /launch an agent/i })).toBeTruthy();
+  });
+
+  it("does NOT render the launch button when no agents are installed (skip path)", () => {
+    render(<CompleteStep installedAgents={[]} onClose={vi.fn()} />);
+    expect(screen.queryByTestId("complete-step-launch-agent")).toBeNull();
+  });
+
+  it("dispatches panel.palette and calls onClose when the launch CTA is clicked", () => {
+    const onClose = vi.fn();
+    render(<CompleteStep installedAgents={["claude"]} onClose={onClose} />);
+
+    fireEvent.click(screen.getByTestId("complete-step-launch-agent"));
+
+    expect(dispatchMock).toHaveBeenCalledTimes(1);
+    expect(dispatchMock).toHaveBeenCalledWith("panel.palette", undefined, { source: "user" });
+    expect(onClose).toHaveBeenCalledTimes(1);
+  });
+});

--- a/src/hooks/app/__tests__/useGettingStartedChecklist.test.tsx
+++ b/src/hooks/app/__tests__/useGettingStartedChecklist.test.tsx
@@ -12,6 +12,7 @@ const onboardingMock = {
         openedProject: false,
         launchedAgent: false,
         createdWorktree: false,
+        ranSecondParallelAgent: false,
       },
       dismissed: false,
       celebrationShown: false,
@@ -29,7 +30,25 @@ vi.stubGlobal("window", {
   removeEventListener: vi.fn(),
 });
 
-vi.mock("@/lib/notify", () => ({ notify: vi.fn(() => "") }));
+interface NotifyArgs {
+  type: string;
+  title: string;
+  message: string;
+  duration?: number;
+  transient?: boolean;
+}
+const { notifyMock, getDisplayComboMock } = vi.hoisted(() => ({
+  notifyMock: vi.fn<(args: NotifyArgs) => string>(() => ""),
+  getDisplayComboMock: vi.fn<(actionId: string) => string>(() => ""),
+}));
+
+vi.mock("@/lib/notify", () => ({ notify: notifyMock }));
+
+vi.mock("@/services/KeybindingService", () => ({
+  keybindingService: {
+    getDisplayCombo: getDisplayComboMock,
+  },
+}));
 
 vi.mock("../../useElectron", () => ({
   isElectronAvailable: () => true,
@@ -109,7 +128,12 @@ describe("useGettingStartedChecklist", () => {
     worktreeSubscribers = [];
     onboardingMock.get.mockResolvedValue({ completed: true });
     onboardingMock.getChecklist.mockResolvedValue({
-      items: { openedProject: false, launchedAgent: false, createdWorktree: false },
+      items: {
+        openedProject: false,
+        launchedAgent: false,
+        createdWorktree: false,
+        ranSecondParallelAgent: false,
+      },
       dismissed: false,
       celebrationShown: false,
     });
@@ -254,5 +278,70 @@ describe("useGettingStartedChecklist", () => {
     });
 
     expect(onboardingMock.markChecklistItem).toHaveBeenCalledWith("createdWorktree");
+  });
+
+  describe("completion toast", () => {
+    beforeEach(() => {
+      // Use real timers so Promise.all hydration microtasks resolve naturally.
+      vi.useRealTimers();
+      onboardingMock.getChecklist.mockResolvedValue({
+        items: {
+          openedProject: true,
+          launchedAgent: true,
+          createdWorktree: true,
+          ranSecondParallelAgent: false,
+        },
+        dismissed: false,
+        celebrationShown: false,
+      });
+    });
+
+    async function flushHydration() {
+      // Two microtask rounds for Promise.all + .then chain, then act flush.
+      await act(async () => {
+        await Promise.resolve();
+        await Promise.resolve();
+        await Promise.resolve();
+      });
+    }
+
+    it("includes the panel.palette keybinding in the completion toast when bound", async () => {
+      getDisplayComboMock.mockReturnValue("⌘+N");
+
+      const { result } = renderHook(() => useGettingStartedChecklist(true));
+      await flushHydration();
+
+      expect(result.current.checklist).not.toBeNull();
+      expect(result.current.checklist?.items.ranSecondParallelAgent).toBe(false);
+
+      await act(async () => {
+        result.current.markItem("ranSecondParallelAgent");
+      });
+
+      expect(onboardingMock.markChecklistItem).toHaveBeenCalledWith("ranSecondParallelAgent");
+      expect(getDisplayComboMock).toHaveBeenCalledWith("panel.palette");
+      expect(notifyMock).toHaveBeenCalledTimes(1);
+      const args = notifyMock.mock.calls[0]![0];
+      expect(args.type).toBe("success");
+      expect(args.title).toBe("Checklist complete!");
+      expect(args.message).toBe("You're all set. Open the panel palette (⌘+N) to launch an agent");
+      expect(args.transient).toBe(true);
+    });
+
+    it("omits the keybinding parens when panel.palette is unbound", async () => {
+      getDisplayComboMock.mockReturnValue("");
+
+      const { result } = renderHook(() => useGettingStartedChecklist(true));
+      await flushHydration();
+
+      await act(async () => {
+        result.current.markItem("ranSecondParallelAgent");
+      });
+
+      expect(notifyMock).toHaveBeenCalledTimes(1);
+      const args = notifyMock.mock.calls[0]![0];
+      expect(args.message).toBe("You're all set. Open the panel palette to launch an agent");
+      expect(args.message).not.toContain("(");
+    });
   });
 });

--- a/src/hooks/app/useGettingStartedChecklist.ts
+++ b/src/hooks/app/useGettingStartedChecklist.ts
@@ -4,6 +4,7 @@ import { useProjectStore } from "@/store/projectStore";
 import { usePanelStore } from "@/store/panelStore";
 import { getCurrentViewStore } from "@/store/createWorktreeStore";
 import { notify } from "@/lib/notify";
+import { keybindingService } from "@/services/KeybindingService";
 import { logError } from "@/utils/logger";
 import { safeFireAndForget } from "@/utils/safeFireAndForget";
 import type { ChecklistState, ChecklistItemId } from "@shared/types/ipc/maps";
@@ -80,40 +81,43 @@ export function useGettingStartedChecklist(isStateLoaded: boolean): GettingStart
     safeFireAndForget(window.electron.onboarding.markChecklistItem(item), {
       context: "Marking onboarding checklist item",
     });
-    let shouldCelebrate = false;
-    let shouldDismiss = false;
-    setChecklist((prev) => {
-      if (!prev) return prev;
-      if (prev.items[item]) return prev;
-      const updated: ChecklistState = {
-        ...prev,
-        items: { ...prev.items, [item]: true },
-      };
-      const allDone = Object.values(updated.items).every(Boolean);
-      if (allDone) {
-        shouldCelebrate = !prev.celebrationShown;
-        shouldDismiss = true;
-        return { ...updated, dismissed: true, celebrationShown: true };
-      }
-      return updated;
-    });
-    if (shouldDismiss) {
+
+    // Decide side effects against the latest committed state via the ref so
+    // we never depend on React running the updater synchronously inside the
+    // dispatch (it doesn't, in concurrent mode).
+    const prev = checklistRef.current;
+    if (!prev || prev.items[item]) return;
+
+    const updatedItems = { ...prev.items, [item]: true };
+    const allDone = Object.values(updatedItems).every(Boolean);
+    const next: ChecklistState = allDone
+      ? { ...prev, items: updatedItems, dismissed: true, celebrationShown: true }
+      : { ...prev, items: updatedItems };
+
+    setChecklist(next);
+    checklistRef.current = next;
+
+    if (allDone) {
       safeFireAndForget(window.electron.onboarding.dismissChecklist(), {
         context: "Dismissing onboarding checklist",
       });
-    }
-    if (shouldCelebrate) {
-      notify({
-        type: "success",
-        title: "Checklist complete!",
-        message: "You're all set! Open the Action Palette (Cmd+K) to explore shortcuts.",
-        duration: 5000,
-        transient: true,
-      });
-      setShowCelebration(true);
-      safeFireAndForget(window.electron.onboarding.markChecklistCelebrationShown(), {
-        context: "Marking onboarding celebration shown",
-      });
+      if (!prev.celebrationShown) {
+        const paletteCombo = keybindingService.getDisplayCombo("panel.palette");
+        const message = paletteCombo
+          ? `You're all set. Open the panel palette (${paletteCombo}) to launch an agent`
+          : "You're all set. Open the panel palette to launch an agent";
+        notify({
+          type: "success",
+          title: "Checklist complete!",
+          message,
+          duration: 5000,
+          transient: true,
+        });
+        setShowCelebration(true);
+        safeFireAndForget(window.electron.onboarding.markChecklistCelebrationShown(), {
+          context: "Marking onboarding celebration shown",
+        });
+      }
     }
   }, []);
 

--- a/src/hooks/app/useGettingStartedChecklist.ts
+++ b/src/hooks/app/useGettingStartedChecklist.ts
@@ -156,17 +156,24 @@ export function useGettingStartedChecklist(isStateLoaded: boolean): GettingStart
     if (!isElectronAvailable() || !window.electron?.onboarding?.onChecklistPush) return;
     return window.electron.onboarding.onChecklistPush((next) => {
       setChecklist((prev) => {
-        if (!prev) return next;
+        if (!prev) {
+          // Sync the ref synchronously so a markItem firing before React
+          // commits doesn't read a stale null value.
+          checklistRef.current = next;
+          return next;
+        }
         const mergedItems = { ...prev.items } as typeof prev.items;
         for (const key of Object.keys(next.items) as Array<keyof typeof next.items>) {
           if (next.items[key] || prev.items[key]) mergedItems[key] = true;
         }
-        return {
+        const merged: ChecklistState = {
           ...next,
           items: mergedItems,
           dismissed: prev.dismissed || next.dismissed,
           celebrationShown: prev.celebrationShown || next.celebrationShown,
         };
+        checklistRef.current = merged;
+        return merged;
       });
     });
   }, []);

--- a/src/index.css
+++ b/src/index.css
@@ -1286,6 +1286,26 @@ body,
   will-change: opacity;
 }
 
+/* Onboarding checklist completion — short opacity flash that replaces the
+ * confetti for users who opt out of motion. Subtler than all-clear because
+ * this is a one-off milestone, not an ambient signal. */
+@keyframes checklist-complete-flash {
+  0% {
+    opacity: 0;
+  }
+  20% {
+    opacity: 0.18;
+  }
+  100% {
+    opacity: 0;
+  }
+}
+
+.animate-checklist-complete-flash {
+  animation: checklist-complete-flash 180ms ease-out forwards;
+  will-change: opacity;
+}
+
 /* Label crossfade — used by AnimatedLabel for text/number swaps. Outgoing
  * label fades out & lifts up + slight blur; incoming rises in from below.
  * Container holds both spans in a CSS grid cell so width is the natural max


### PR DESCRIPTION
## Summary

- Five gaps in the onboarding first-success flow left users stranded after setup completed, with no clear next action pointing them toward starting an agent
- Fixes a copy-paste bug in checklist item 4 (`worktree.createDialog.open` → `panel.palette`), resolves the live keybinding via `keybindingService` instead of hardcoded `Cmd+K`, and hardens `markItem` against stale closures under React concurrent updates
- Adds a "Launch an agent" CTA to the wizard's `CompleteStep`, re-anchors `CelebrationConfetti` to the checklist card, and replaces the reduced-motion early-return with a 180ms `checklist-complete-flash` opacity pulse

Resolves #6876

## Changes

- `checklistItems.ts` — item 4 `actionId` corrected from `worktree.createDialog.open` to `panel.palette`
- `useGettingStartedChecklist.ts` — completion toast reads live keybinding from `keybindingService`; `markItem` rewritten to read from `checklistRef.current` inside the updater; ref sync tightened in `onChecklistPush` so a same-tick `markItem` call can't read a stale ref
- `AgentSetupWizard.tsx` — `CompleteStep` gains a "Launch an agent" button that dispatches `panel.palette` and closes the wizard; degrades gracefully to the existing skip-path when no agents are installed
- `CelebrationConfetti.tsx` — particles now originate from the `[data-getting-started-checklist]` card via `getBoundingClientRect()`, falling back to viewport center when absent
- `GettingStartedChecklist.tsx` — `data-getting-started-checklist` attribute added to the card root
- `src/index.css` — new `checklist-complete-flash` keyframe; reduced-motion users get an opacity flash instead of `return null`

## Testing

- 30 targeted unit tests pass across `useGettingStartedChecklist`, `CelebrationConfetti`, and the new `CompleteStepLaunchCta` suite
- Typecheck, lint ratchet, channel drift, format, and build all green