### PR TITLE
fix(error-boundary): make Report-Issue deeplink reliable for real stacks

### DIFF
--- a/src/components/ErrorBoundary/ErrorBoundary.tsx
+++ b/src/components/ErrorBoundary/ErrorBoundary.tsx
@@ -29,6 +29,10 @@ interface ErrorBoundaryState {
 }
 
 export class ErrorBoundary extends Component<ErrorBoundaryProps, ErrorBoundaryState> {
+  // Guards against double-fire when the user clicks "Report Issue" twice
+  // before the async clipboard/openExternal chain completes.
+  private reportInFlight = false;
+
   constructor(props: ErrorBoundaryProps) {
     super(props);
     this.state = {
@@ -145,53 +149,62 @@ export class ErrorBoundary extends Component<ErrorBoundaryProps, ErrorBoundarySt
   };
 
   handleReport = async (): Promise<void> => {
-    const { error, errorInfo, incidentId } = this.state;
-    const { componentName, context } = this.props;
-
-    if (!error) return;
-
-    const { url, fullBody, usedClipboardFallback } = buildReportIssueUrl({
-      incidentId,
-      componentName,
-      message: error.message,
-      stack: error.stack ?? "",
-      componentStack: errorInfo?.componentStack ?? "",
-      context,
-    });
-
-    if (usedClipboardFallback) {
-      let clipboardOk = false;
-      try {
-        await window.electron?.clipboard?.writeText?.(fullBody);
-        clipboardOk = true;
-      } catch (clipboardError) {
-        logError("Failed to copy crash report to clipboard", clipboardError);
-      }
-      notify({
-        type: "info",
-        title: clipboardOk ? "Error details copied" : "Error details too long",
-        message: clipboardOk
-          ? "The full crash report was copied to your clipboard — paste it into the issue body."
-          : "Couldn't copy the full report. Paste what you can; we'll match it to the incident ID.",
-        inboxMessage: clipboardOk
-          ? "Crash report copied to clipboard for the issue body."
-          : "Couldn't copy crash report to clipboard.",
-      });
-    }
-
-    if (!window.electron?.system?.openExternal) return;
-
+    if (this.reportInFlight) return;
+    this.reportInFlight = true;
     try {
-      const result = await actionService.dispatch(
-        "system.openExternal",
-        { url },
-        { source: "user" }
-      );
-      if (!result.ok) {
-        window.electron.system.openExternal(url);
+      const { error, errorInfo, incidentId } = this.state;
+      const { componentName, context } = this.props;
+
+      if (!error) return;
+
+      const { url, fullBody, usedClipboardFallback } = buildReportIssueUrl({
+        incidentId,
+        componentName,
+        message: error.message,
+        stack: error.stack ?? "",
+        componentStack: errorInfo?.componentStack ?? "",
+        context,
+      });
+
+      if (usedClipboardFallback) {
+        const writeText = window.electron?.clipboard?.writeText;
+        let clipboardOk = false;
+        if (writeText) {
+          try {
+            await writeText(fullBody);
+            clipboardOk = true;
+          } catch (clipboardError) {
+            logError("Failed to copy crash report to clipboard", clipboardError);
+          }
+        }
+        notify({
+          type: "info",
+          title: clipboardOk ? "Error details copied" : "Error details too long",
+          message: clipboardOk
+            ? "The full crash report was copied to your clipboard — paste it into the issue body."
+            : "Couldn't copy the full report. Quote the Error ID shown above when filing the issue.",
+          inboxMessage: clipboardOk
+            ? "Crash report copied to clipboard for the issue body."
+            : "Couldn't copy crash report to clipboard.",
+        });
       }
-    } catch {
-      window.electron.system.openExternal(url);
+
+      if (!window.electron?.system?.openExternal) return;
+
+      try {
+        const result = await actionService.dispatch(
+          "system.openExternal",
+          { url },
+          { source: "user" }
+        );
+        if (!result.ok) {
+          void window.electron.system.openExternal(url);
+        }
+      } catch {
+        void window.electron.system.openExternal(url);
+      }
+    } finally {
+      this.reportInFlight = false;
     }
   };
 

--- a/src/components/ErrorBoundary/ErrorBoundary.tsx
+++ b/src/components/ErrorBoundary/ErrorBoundary.tsx
@@ -4,6 +4,7 @@ import { useErrorStore } from "@/store/errorStore";
 import { actionService } from "@/services/ActionService";
 import { logError } from "@/utils/logger";
 import { captureRendererException } from "@/utils/rendererSentry";
+import { safeFireAndForget } from "@/utils/safeFireAndForget";
 import { buildReportIssueUrl } from "./buildReportIssueUrl";
 import { notify } from "@/lib/notify";
 
@@ -198,10 +199,14 @@ export class ErrorBoundary extends Component<ErrorBoundaryProps, ErrorBoundarySt
           { source: "user" }
         );
         if (!result.ok) {
-          void window.electron.system.openExternal(url);
+          safeFireAndForget(window.electron.system.openExternal(url), {
+            context: "ErrorBoundary.handleReport openExternal fallback",
+          });
         }
       } catch {
-        void window.electron.system.openExternal(url);
+        safeFireAndForget(window.electron.system.openExternal(url), {
+          context: "ErrorBoundary.handleReport openExternal fallback",
+        });
       }
     } finally {
       this.reportInFlight = false;

--- a/src/components/ErrorBoundary/ErrorBoundary.tsx
+++ b/src/components/ErrorBoundary/ErrorBoundary.tsx
@@ -4,6 +4,8 @@ import { useErrorStore } from "@/store/errorStore";
 import { actionService } from "@/services/ActionService";
 import { logError } from "@/utils/logger";
 import { captureRendererException } from "@/utils/rendererSentry";
+import { buildReportIssueUrl } from "./buildReportIssueUrl";
+import { notify } from "@/lib/notify";
 
 interface ErrorBoundaryProps {
   children: ReactNode;
@@ -54,7 +56,7 @@ export class ErrorBoundary extends Component<ErrorBoundaryProps, ErrorBoundarySt
 
     const correlationId = crypto.randomUUID();
 
-    captureRendererException(error, {
+    const sentryEventId = captureRendererException(error, {
       tags: {
         source: "react-error-boundary",
         component: componentName ?? "ErrorBoundary",
@@ -63,9 +65,9 @@ export class ErrorBoundary extends Component<ErrorBoundaryProps, ErrorBoundarySt
       extra: { correlationId, ...(context ?? {}) },
     });
 
-    let incidentId: string | null = null;
+    let storeIncidentId: string | null = null;
     try {
-      incidentId = useErrorStore.getState().addError({
+      storeIncidentId = useErrorStore.getState().addError({
         type: "unknown",
         message: error.message || "Component rendering error",
         details: `${error.stack || ""}\n\nComponent Stack:${componentStack}`,
@@ -77,6 +79,11 @@ export class ErrorBoundary extends Component<ErrorBoundaryProps, ErrorBoundarySt
     } catch (storeError) {
       logError("Failed to add error to store", storeError);
     }
+
+    // Prefer the Sentry event ID for the user-visible "Error ID" — engineers
+    // can search Sentry by it directly. Fall back to the error-store ID when
+    // Sentry isn't initialized so users always have *something* to quote.
+    const incidentId = sentryEventId ?? storeIncidentId;
 
     this.setState({
       errorInfo,
@@ -137,34 +144,54 @@ export class ErrorBoundary extends Component<ErrorBoundaryProps, ErrorBoundarySt
     });
   };
 
-  handleReport = (): void => {
+  handleReport = async (): Promise<void> => {
     const { error, errorInfo, incidentId } = this.state;
     const { componentName, context } = this.props;
 
-    const issueBody = encodeURIComponent(
-      `## Error Report\n\n` +
-        `**Component:** ${componentName || "Unknown"}\n` +
-        `**Incident ID:** ${incidentId ?? "unknown"}\n` +
-        `**Message:** ${error?.message || "Unknown error"}\n\n` +
-        `**Context:**\n` +
-        `${context ? JSON.stringify(context, null, 2) : "None"}\n\n` +
-        `**Stack Trace:**\n\`\`\`\n${error?.stack || "No stack trace"}\n\`\`\`\n\n` +
-        `**Component Stack:**\n\`\`\`\n${errorInfo?.componentStack || "No component stack"}\n\`\`\``
-    );
+    if (!error) return;
 
-    const issueUrl = `https://github.com/daintreehq/daintree/issues/new?title=${encodeURIComponent(`Component Error: ${error?.message || "Unknown"}`)}&body=${issueBody}`;
+    const { url, fullBody, usedClipboardFallback } = buildReportIssueUrl({
+      incidentId,
+      componentName,
+      message: error.message,
+      stack: error.stack ?? "",
+      componentStack: errorInfo?.componentStack ?? "",
+      context,
+    });
 
-    if (window.electron?.system?.openExternal) {
-      actionService
-        .dispatch("system.openExternal", { url: issueUrl }, { source: "user" })
-        .then((result) => {
-          if (!result.ok) {
-            window.electron.system.openExternal(issueUrl);
-          }
-        })
-        .catch(() => {
-          window.electron.system.openExternal(issueUrl);
-        });
+    if (usedClipboardFallback) {
+      let clipboardOk = false;
+      try {
+        await window.electron?.clipboard?.writeText?.(fullBody);
+        clipboardOk = true;
+      } catch (clipboardError) {
+        logError("Failed to copy crash report to clipboard", clipboardError);
+      }
+      notify({
+        type: "info",
+        title: clipboardOk ? "Error details copied" : "Error details too long",
+        message: clipboardOk
+          ? "The full crash report was copied to your clipboard — paste it into the issue body."
+          : "Couldn't copy the full report. Paste what you can; we'll match it to the incident ID.",
+        inboxMessage: clipboardOk
+          ? "Crash report copied to clipboard for the issue body."
+          : "Couldn't copy crash report to clipboard.",
+      });
+    }
+
+    if (!window.electron?.system?.openExternal) return;
+
+    try {
+      const result = await actionService.dispatch(
+        "system.openExternal",
+        { url },
+        { source: "user" }
+      );
+      if (!result.ok) {
+        window.electron.system.openExternal(url);
+      }
+    } catch {
+      window.electron.system.openExternal(url);
     }
   };
 

--- a/src/components/ErrorBoundary/ErrorFallback.tsx
+++ b/src/components/ErrorBoundary/ErrorFallback.tsx
@@ -9,7 +9,7 @@ export interface ErrorFallbackProps {
   variant?: "fullscreen" | "section" | "component";
   componentName?: string;
   incidentId?: string | null;
-  onReport?: () => void;
+  onReport?: () => void | Promise<void>;
 }
 
 const VARIANT_STYLES = {

--- a/src/components/ErrorBoundary/__tests__/ErrorBoundary.test.tsx
+++ b/src/components/ErrorBoundary/__tests__/ErrorBoundary.test.tsx
@@ -32,7 +32,12 @@ vi.mock("@/lib/utils", () => ({
 
 interface ElectronMock {
   system: { openExternal: ReturnType<typeof vi.fn> };
-  clipboard: { writeText: ReturnType<typeof vi.fn> };
+  clipboard?: { writeText: ReturnType<typeof vi.fn> };
+}
+
+function getElectronMock(): ElectronMock {
+  // eslint-disable-next-line @typescript-eslint/no-unsafe-return, @typescript-eslint/no-explicit-any
+  return (window as any).electron;
 }
 
 function installElectronMock(): ElectronMock {
@@ -40,7 +45,8 @@ function installElectronMock(): ElectronMock {
     system: { openExternal: vi.fn().mockResolvedValue(undefined) },
     clipboard: { writeText: vi.fn().mockResolvedValue(undefined) },
   };
-  (window as unknown as { electron: ElectronMock }).electron = mock;
+  // eslint-disable-next-line @typescript-eslint/no-explicit-any
+  vi.stubGlobal("electron", mock as any);
   return mock;
 }
 
@@ -63,7 +69,7 @@ describe("ErrorBoundary", () => {
   afterEach(() => {
     vi.unstubAllEnvs();
     vi.restoreAllMocks();
-    delete (window as unknown as { electron?: unknown }).electron;
+    vi.unstubAllGlobals();
   });
 
   it("renders children when no error", () => {
@@ -225,8 +231,8 @@ describe("ErrorBoundary", () => {
     await Promise.resolve();
     await Promise.resolve();
 
-    const electron = (window as unknown as { electron: ElectronMock }).electron;
-    expect(electron.clipboard.writeText).not.toHaveBeenCalled();
+    const electron = getElectronMock();
+    expect(electron.clipboard?.writeText).not.toHaveBeenCalled();
     expect(notify).not.toHaveBeenCalled();
 
     expect(actionService.dispatch).toHaveBeenCalledWith(
@@ -259,9 +265,10 @@ describe("ErrorBoundary", () => {
     await Promise.resolve();
     await Promise.resolve();
 
-    const electron = (window as unknown as { electron: ElectronMock }).electron;
-    expect(electron.clipboard.writeText).toHaveBeenCalledTimes(1);
-    const clipboardArg = electron.clipboard.writeText.mock.calls[0]![0] as string;
+    const electron = getElectronMock();
+    expect(electron.clipboard?.writeText).toHaveBeenCalledTimes(1);
+    // eslint-disable-next-line @typescript-eslint/no-unsafe-type-assertion
+    const clipboardArg = electron.clipboard!.writeText.mock.calls[0]![0] as string;
     expect(clipboardArg).toContain("**Component:**");
     expect(clipboardArg).toContain("Component blew up");
 
@@ -282,8 +289,9 @@ describe("ErrorBoundary", () => {
   });
 
   it("still opens the stub URL when clipboard write fails", async () => {
-    const electron = (window as unknown as { electron: ElectronMock }).electron;
-    electron.clipboard.writeText.mockRejectedValue(new Error("clipboard busy"));
+    const electron = getElectronMock();
+    // eslint-disable-next-line @typescript-eslint/no-unsafe-type-assertion, @typescript-eslint/no-explicit-any
+    (electron.clipboard!.writeText as any).mockRejectedValue(new Error("clipboard busy"));
 
     function ThrowGiantStack(): React.ReactElement {
       const error = new Error("Component blew up");
@@ -304,7 +312,7 @@ describe("ErrorBoundary", () => {
     await Promise.resolve();
     await Promise.resolve();
 
-    expect(electron.clipboard.writeText).toHaveBeenCalled();
+    expect(electron.clipboard?.writeText).toHaveBeenCalled();
     expect(notify).toHaveBeenCalledWith(
       expect.objectContaining({
         type: "info",
@@ -317,9 +325,9 @@ describe("ErrorBoundary", () => {
   });
 
   it("flags clipboard fallback as failed when the clipboard API is absent", async () => {
-    const electron = (window as unknown as { electron: ElectronMock }).electron;
+    const mockElectron = getElectronMock();
     // Simulate a context where clipboard IPC is unavailable.
-    delete (electron as unknown as { clipboard?: unknown }).clipboard;
+    delete mockElectron.clipboard;
 
     function ThrowGiantStack(): React.ReactElement {
       const error = new Error("Component blew up");
@@ -370,13 +378,13 @@ describe("ErrorBoundary", () => {
     await Promise.resolve();
     await Promise.resolve();
 
-    const electron = (window as unknown as { electron: ElectronMock }).electron;
-    expect(electron.clipboard.writeText).toHaveBeenCalledTimes(1);
+    const electron = getElectronMock();
+    expect(electron.clipboard?.writeText).toHaveBeenCalledTimes(1);
     expect(actionService.dispatch).toHaveBeenCalledTimes(1);
   });
 
   it("does nothing when window.electron is unavailable entirely", async () => {
-    delete (window as unknown as { electron?: unknown }).electron;
+    vi.unstubAllGlobals();
 
     render(
       <ErrorBoundary variant="section">

--- a/src/components/ErrorBoundary/__tests__/ErrorBoundary.test.tsx
+++ b/src/components/ErrorBoundary/__tests__/ErrorBoundary.test.tsx
@@ -316,6 +316,82 @@ describe("ErrorBoundary", () => {
     });
   });
 
+  it("flags clipboard fallback as failed when the clipboard API is absent", async () => {
+    const electron = (window as unknown as { electron: ElectronMock }).electron;
+    // Simulate a context where clipboard IPC is unavailable.
+    delete (electron as unknown as { clipboard?: unknown }).clipboard;
+
+    function ThrowGiantStack(): React.ReactElement {
+      const error = new Error("Component blew up");
+      error.stack =
+        "Error: Component blew up\n" +
+        Array.from({ length: 30 }, (_, i) => `    at frame${i} ${"x".repeat(800)}`).join("\n");
+      throw error;
+    }
+
+    render(
+      <ErrorBoundary variant="section">
+        <ThrowGiantStack />
+      </ErrorBoundary>
+    );
+
+    fireEvent.click(screen.getByText("Report Issue"));
+    await Promise.resolve();
+    await Promise.resolve();
+    await Promise.resolve();
+
+    expect(notify).toHaveBeenCalledWith(
+      expect.objectContaining({
+        type: "info",
+        title: "Error details too long",
+      })
+    );
+  });
+
+  it("deduplicates rapid double-clicks on Report Issue", async () => {
+    function ThrowGiantStack(): React.ReactElement {
+      const error = new Error("Component blew up");
+      error.stack =
+        "Error: Component blew up\n" +
+        Array.from({ length: 30 }, (_, i) => `    at frame${i} ${"x".repeat(800)}`).join("\n");
+      throw error;
+    }
+
+    render(
+      <ErrorBoundary variant="section">
+        <ThrowGiantStack />
+      </ErrorBoundary>
+    );
+
+    const button = screen.getByText("Report Issue");
+    fireEvent.click(button);
+    fireEvent.click(button); // second click while first is in-flight
+    await Promise.resolve();
+    await Promise.resolve();
+    await Promise.resolve();
+
+    const electron = (window as unknown as { electron: ElectronMock }).electron;
+    expect(electron.clipboard.writeText).toHaveBeenCalledTimes(1);
+    expect(actionService.dispatch).toHaveBeenCalledTimes(1);
+  });
+
+  it("does nothing when window.electron is unavailable entirely", async () => {
+    delete (window as unknown as { electron?: unknown }).electron;
+
+    render(
+      <ErrorBoundary variant="section">
+        <ThrowingChild shouldThrow={true} />
+      </ErrorBoundary>
+    );
+
+    fireEvent.click(screen.getByText("Report Issue"));
+    await Promise.resolve();
+    await Promise.resolve();
+
+    expect(actionService.dispatch).not.toHaveBeenCalled();
+    expect(notify).not.toHaveBeenCalled();
+  });
+
   it("hides technical details in production mode", () => {
     vi.stubEnv("DEV", false);
 

--- a/src/components/ErrorBoundary/__tests__/ErrorBoundary.test.tsx
+++ b/src/components/ErrorBoundary/__tests__/ErrorBoundary.test.tsx
@@ -1,8 +1,12 @@
 // @vitest-environment jsdom
+import type React from "react";
 import { render, screen, fireEvent } from "@testing-library/react";
 import { describe, expect, it, vi, beforeEach, afterEach } from "vitest";
 import { ErrorBoundary, withErrorBoundary } from "../ErrorBoundary";
 import { useErrorStore } from "@/store/errorStore";
+import { captureRendererException } from "@/utils/rendererSentry";
+import { notify } from "@/lib/notify";
+import { actionService } from "@/services/ActionService";
 
 vi.mock("@/services/ActionService", () => ({
   actionService: {
@@ -14,9 +18,31 @@ vi.mock("@/utils/logger", () => ({
   logError: vi.fn(),
 }));
 
+vi.mock("@/utils/rendererSentry", () => ({
+  captureRendererException: vi.fn(),
+}));
+
+vi.mock("@/lib/notify", () => ({
+  notify: vi.fn(),
+}));
+
 vi.mock("@/lib/utils", () => ({
   cn: (...args: unknown[]) => args.filter(Boolean).join(" "),
 }));
+
+interface ElectronMock {
+  system: { openExternal: ReturnType<typeof vi.fn> };
+  clipboard: { writeText: ReturnType<typeof vi.fn> };
+}
+
+function installElectronMock(): ElectronMock {
+  const mock: ElectronMock = {
+    system: { openExternal: vi.fn().mockResolvedValue(undefined) },
+    clipboard: { writeText: vi.fn().mockResolvedValue(undefined) },
+  };
+  (window as unknown as { electron: ElectronMock }).electron = mock;
+  return mock;
+}
 
 function ThrowingChild({ shouldThrow }: { shouldThrow: boolean }) {
   if (shouldThrow) throw new Error("Test render error");
@@ -29,11 +55,15 @@ describe("ErrorBoundary", () => {
     vi.clearAllMocks();
     useErrorStore.getState().reset();
     vi.spyOn(console, "error").mockImplementation(() => {});
+    // Default: Sentry SDK not initialized → null. Individual tests override.
+    vi.mocked(captureRendererException).mockReturnValue(null);
+    installElectronMock();
   });
 
   afterEach(() => {
     vi.unstubAllEnvs();
     vi.restoreAllMocks();
+    delete (window as unknown as { electron?: unknown }).electron;
   });
 
   it("renders children when no error", () => {
@@ -54,7 +84,7 @@ describe("ErrorBoundary", () => {
     expect(screen.getByText("Section stopped working")).toBeTruthy();
   });
 
-  it("captures incidentId from addError and passes to fallback", () => {
+  it("still adds the error to the store for cross-referencing", () => {
     render(
       <ErrorBoundary variant="section">
         <ThrowingChild shouldThrow={true} />
@@ -65,8 +95,6 @@ describe("ErrorBoundary", () => {
     expect(errors.length).toBe(1);
 
     const storeId = errors[0]!.id;
-    // In dev mode, incident ID is not displayed (only in prod)
-    // but we can verify the error was added to the store
     expect(storeId).toMatch(
       /^error-[0-9a-f]{8}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{12}$/i
     );
@@ -153,8 +181,26 @@ describe("ErrorBoundary", () => {
     expect(screen.queryByTestId("error-fallback-logs")).toBeNull();
   });
 
-  it("renders incident ID in production mode for section variant", () => {
+  it("renders Sentry event ID as Error ID in production mode for section variant", () => {
     vi.stubEnv("DEV", false);
+    vi.mocked(captureRendererException).mockReturnValue("sentry-event-deadbeef");
+
+    render(
+      <ErrorBoundary variant="section">
+        <ThrowingChild shouldThrow={true} />
+      </ErrorBoundary>
+    );
+
+    expect(screen.getByText("Error ID: sentry-event-deadbeef")).toBeTruthy();
+    expect(screen.queryByText("Test render error")).toBeNull();
+    expect(
+      screen.getByText("This pane crashed but the rest of Daintree is still running.")
+    ).toBeTruthy();
+  });
+
+  it("falls back to store incident ID when Sentry returns null", () => {
+    vi.stubEnv("DEV", false);
+    vi.mocked(captureRendererException).mockReturnValue(null);
 
     render(
       <ErrorBoundary variant="section">
@@ -164,12 +210,110 @@ describe("ErrorBoundary", () => {
 
     const errors = useErrorStore.getState().errors;
     const storeId = errors[0]!.id;
-
     expect(screen.getByText(`Error ID: ${storeId}`)).toBeTruthy();
-    expect(screen.queryByText("Test render error")).toBeNull();
-    expect(
-      screen.getByText("This pane crashed but the rest of Daintree is still running.")
-    ).toBeTruthy();
+  });
+
+  it("dispatches a full-body deeplink when the report fits the URL budget", async () => {
+    render(
+      <ErrorBoundary variant="section">
+        <ThrowingChild shouldThrow={true} />
+      </ErrorBoundary>
+    );
+
+    fireEvent.click(screen.getByText("Report Issue"));
+    // Wait a microtask so the async handler resolves.
+    await Promise.resolve();
+    await Promise.resolve();
+
+    const electron = (window as unknown as { electron: ElectronMock }).electron;
+    expect(electron.clipboard.writeText).not.toHaveBeenCalled();
+    expect(notify).not.toHaveBeenCalled();
+
+    expect(actionService.dispatch).toHaveBeenCalledWith(
+      "system.openExternal",
+      expect.objectContaining({
+        url: expect.stringContaining("github.com/daintreehq/daintree/issues/new"),
+      }),
+      { source: "user" }
+    );
+  });
+
+  it("copies full report to clipboard and notifies when payload exceeds URL budget", async () => {
+    function ThrowGiantStack(): React.ReactElement {
+      const error = new Error("Component blew up");
+      // Force the encoded body well past 7000 even after stack truncation.
+      error.stack =
+        "Error: Component blew up\n" +
+        Array.from({ length: 30 }, (_, i) => `    at frame${i} ${"x".repeat(800)}`).join("\n");
+      throw error;
+    }
+
+    render(
+      <ErrorBoundary variant="section">
+        <ThrowGiantStack />
+      </ErrorBoundary>
+    );
+
+    fireEvent.click(screen.getByText("Report Issue"));
+    await Promise.resolve();
+    await Promise.resolve();
+    await Promise.resolve();
+
+    const electron = (window as unknown as { electron: ElectronMock }).electron;
+    expect(electron.clipboard.writeText).toHaveBeenCalledTimes(1);
+    const clipboardArg = electron.clipboard.writeText.mock.calls[0]![0] as string;
+    expect(clipboardArg).toContain("**Component:**");
+    expect(clipboardArg).toContain("Component blew up");
+
+    expect(notify).toHaveBeenCalledWith(
+      expect.objectContaining({
+        type: "info",
+        title: "Error details copied",
+      })
+    );
+
+    expect(actionService.dispatch).toHaveBeenCalledWith(
+      "system.openExternal",
+      expect.objectContaining({
+        url: expect.stringContaining("copied%20to%20your%20clipboard"),
+      }),
+      { source: "user" }
+    );
+  });
+
+  it("still opens the stub URL when clipboard write fails", async () => {
+    const electron = (window as unknown as { electron: ElectronMock }).electron;
+    electron.clipboard.writeText.mockRejectedValue(new Error("clipboard busy"));
+
+    function ThrowGiantStack(): React.ReactElement {
+      const error = new Error("Component blew up");
+      error.stack =
+        "Error: Component blew up\n" +
+        Array.from({ length: 30 }, (_, i) => `    at frame${i} ${"x".repeat(800)}`).join("\n");
+      throw error;
+    }
+
+    render(
+      <ErrorBoundary variant="section">
+        <ThrowGiantStack />
+      </ErrorBoundary>
+    );
+
+    fireEvent.click(screen.getByText("Report Issue"));
+    await Promise.resolve();
+    await Promise.resolve();
+    await Promise.resolve();
+
+    expect(electron.clipboard.writeText).toHaveBeenCalled();
+    expect(notify).toHaveBeenCalledWith(
+      expect.objectContaining({
+        type: "info",
+        title: "Error details too long",
+      })
+    );
+    expect(actionService.dispatch).toHaveBeenCalledWith("system.openExternal", expect.any(Object), {
+      source: "user",
+    });
   });
 
   it("hides technical details in production mode", () => {

--- a/src/components/ErrorBoundary/__tests__/buildReportIssueUrl.test.ts
+++ b/src/components/ErrorBoundary/__tests__/buildReportIssueUrl.test.ts
@@ -1,0 +1,145 @@
+import { describe, expect, it } from "vitest";
+import {
+  buildReportIssueUrl,
+  URL_BODY_BUDGET,
+  type ReportIssueInput,
+} from "../buildReportIssueUrl";
+
+function getEncodedBodyLength(url: string): number {
+  const bodyParam = new URL(url).searchParams.get("body") ?? "";
+  return encodeURIComponent(bodyParam).length;
+}
+
+function makeInput(overrides: Partial<ReportIssueInput> = {}): ReportIssueInput {
+  return {
+    incidentId: "abc123",
+    componentName: "TerminalPane",
+    message: "boom",
+    stack: "Error: boom\n  at thrower (file.ts:1)\n  at React.render (react.js:1)",
+    componentStack: "  in TerminalPane\n  in PanelGrid",
+    context: { worktreeId: "wt-1" },
+    ...overrides,
+  };
+}
+
+describe("buildReportIssueUrl", () => {
+  it("includes all sections and stays under budget for short input", () => {
+    const result = buildReportIssueUrl(makeInput());
+
+    expect(result.usedClipboardFallback).toBe(false);
+    expect(result.fullBody).toContain("**Component:** TerminalPane");
+    expect(result.fullBody).toContain("**Incident ID:** abc123");
+    expect(result.fullBody).toContain("**Message:** boom");
+    expect(result.fullBody).toContain("Error: boom");
+    expect(result.fullBody).toContain("in TerminalPane");
+    expect(result.url).toContain("github.com/daintreehq/daintree/issues/new");
+    expect(getEncodedBodyLength(result.url)).toBeLessThanOrEqual(URL_BODY_BUDGET);
+  });
+
+  it("encodes title and body so URL is safe to navigate", () => {
+    const result = buildReportIssueUrl(
+      makeInput({ message: "Cannot read property 'foo' of undefined & friends" })
+    );
+    const parsed = new URL(result.url);
+    expect(parsed.searchParams.get("title")).toBe(
+      "Component Error: Cannot read property 'foo' of undefined & friends"
+    );
+    expect(parsed.searchParams.get("body")).toContain("Cannot read property 'foo'");
+  });
+
+  it("falls back to placeholder values when fields are empty", () => {
+    const result = buildReportIssueUrl({
+      incidentId: null,
+      componentName: undefined,
+      message: "",
+      stack: "",
+      componentStack: "",
+      context: undefined,
+    });
+
+    expect(result.fullBody).toContain("**Component:** Unknown");
+    expect(result.fullBody).toContain("**Incident ID:** unknown");
+    expect(result.fullBody).toContain("**Message:** Unknown error");
+    expect(result.fullBody).toContain("No stack trace");
+    expect(result.fullBody).toContain("No component stack");
+    expect(result.usedClipboardFallback).toBe(false);
+  });
+
+  it("drops componentStack when full body exceeds budget", () => {
+    // Component stack > budget on its own; error stack stays small.
+    const longComponentStack = Array.from({ length: 800 }, (_, i) => `  in Comp${i}`).join("\n");
+    const result = buildReportIssueUrl(makeInput({ componentStack: longComponentStack }));
+
+    expect(result.usedClipboardFallback).toBe(false);
+    expect(getEncodedBodyLength(result.url)).toBeLessThanOrEqual(URL_BODY_BUDGET);
+    // The placeholder should sit where the stack used to be.
+    expect(decodeURIComponent(new URL(result.url).searchParams.get("body") ?? "")).toContain(
+      "component stack omitted"
+    );
+    // fullBody (clipboard payload) still has the original.
+    expect(result.fullBody).toContain("in Comp0");
+    expect(result.fullBody).toContain("in Comp799");
+  });
+
+  it("middle-truncates the error stack when componentStack omission isn't enough", () => {
+    const longStack = Array.from({ length: 1500 }, (_, i) => `  at frame${i} (file.ts:${i})`).join(
+      "\n"
+    );
+    const longComponentStack = Array.from({ length: 200 }, (_, i) => `  in Comp${i}`).join("\n");
+    const result = buildReportIssueUrl(
+      makeInput({ stack: longStack, componentStack: longComponentStack })
+    );
+
+    expect(getEncodedBodyLength(result.url)).toBeLessThanOrEqual(URL_BODY_BUDGET);
+    const body = decodeURIComponent(new URL(result.url).searchParams.get("body") ?? "");
+    expect(body).toContain("middle frames truncated");
+    // First frames preserved.
+    expect(body).toContain("at frame0 (file.ts:0)");
+    // Last frames preserved.
+    expect(body).toContain("at frame1499 (file.ts:1499)");
+    // Middle frame dropped.
+    expect(body).not.toContain("at frame750 (file.ts:750)");
+    // fullBody (clipboard payload) still has everything.
+    expect(result.fullBody).toContain("at frame750 (file.ts:750)");
+    expect(result.usedClipboardFallback).toBe(false);
+  });
+
+  it("falls back to clipboard stub when even truncated body exceeds budget", () => {
+    // Build a single error message + first/last frames that, even when
+    // middle-truncated, still blow the budget. Use very long lines.
+    const longLine = "x".repeat(1200);
+    const stack = Array.from({ length: 25 }, () => longLine).join("\n");
+    const componentStack = Array.from({ length: 10 }, () => longLine).join("\n");
+    const result = buildReportIssueUrl(makeInput({ stack, componentStack }));
+
+    expect(result.usedClipboardFallback).toBe(true);
+    expect(getEncodedBodyLength(result.url)).toBeLessThanOrEqual(URL_BODY_BUDGET);
+
+    const body = decodeURIComponent(new URL(result.url).searchParams.get("body") ?? "");
+    expect(body).toContain("copied to your clipboard");
+    expect(body).toContain("**Incident ID:** abc123");
+    expect(body).toContain("**Message:** boom");
+    // Stub URL should NOT contain the giant stack.
+    expect(body).not.toContain(longLine);
+    // Full payload preserved for clipboard write.
+    expect(result.fullBody).toContain(longLine);
+    expect(result.fullBody).toContain("**Component:** TerminalPane");
+  });
+
+  it("respects budget exactly at boundary", () => {
+    // Construct input that lands just under the budget.
+    const padding = "a".repeat(URL_BODY_BUDGET - 500); // ASCII chars are 1:1 in encodeURIComponent
+    const result = buildReportIssueUrl(makeInput({ stack: padding }));
+    expect(result.usedClipboardFallback).toBe(false);
+    expect(getEncodedBodyLength(result.url)).toBeLessThanOrEqual(URL_BODY_BUDGET);
+  });
+
+  it("URL is parseable and points at the right repo", () => {
+    const result = buildReportIssueUrl(makeInput());
+    const url = new URL(result.url);
+    expect(url.host).toBe("github.com");
+    expect(url.pathname).toBe("/daintreehq/daintree/issues/new");
+    expect(url.searchParams.has("title")).toBe(true);
+    expect(url.searchParams.has("body")).toBe(true);
+  });
+});

--- a/src/components/ErrorBoundary/__tests__/buildReportIssueUrl.test.ts
+++ b/src/components/ErrorBoundary/__tests__/buildReportIssueUrl.test.ts
@@ -142,4 +142,49 @@ describe("buildReportIssueUrl", () => {
     expect(url.searchParams.has("title")).toBe(true);
     expect(url.searchParams.has("body")).toBe(true);
   });
+
+  it("keeps total URL length under 8192 across every truncation stage", () => {
+    // Each stage corresponds to a different input size class.
+    const inputs = [
+      makeInput(), // small — full body fits
+      makeInput({
+        // medium — componentStack omitted
+        componentStack: Array.from({ length: 800 }, (_, i) => `  in Comp${i}`).join("\n"),
+      }),
+      makeInput({
+        // large — stack middle-truncated
+        stack: Array.from({ length: 1500 }, (_, i) => `  at frame${i} (file.ts:${i})`).join("\n"),
+        componentStack: Array.from({ length: 200 }, (_, i) => `  in Comp${i}`).join("\n"),
+      }),
+      makeInput({
+        // huge — clipboard fallback
+        stack: Array.from({ length: 25 }, () => "x".repeat(1200)).join("\n"),
+        componentStack: Array.from({ length: 10 }, () => "x".repeat(1200)).join("\n"),
+      }),
+    ];
+    for (const input of inputs) {
+      const result = buildReportIssueUrl(input);
+      expect(result.url.length).toBeLessThanOrEqual(8192);
+    }
+  });
+
+  it("caps title length when the error message is enormous", () => {
+    // 700 emojis encode to 700×4 = 2800 bytes — well past the 8192 cap on
+    // its own. The title cap keeps the URL safe.
+    const result = buildReportIssueUrl(makeInput({ message: "😀".repeat(700) }));
+    const title = new URL(result.url).searchParams.get("title") ?? "";
+    expect(title.endsWith("…")).toBe(true);
+    expect(result.url.length).toBeLessThanOrEqual(8192);
+    // The full message should still appear in the body / clipboard payload.
+    expect(result.fullBody).toContain("😀");
+  });
+
+  it("caps title for very long ASCII messages", () => {
+    const longMessage = "A".repeat(5000);
+    const result = buildReportIssueUrl(makeInput({ message: longMessage }));
+    expect(result.url.length).toBeLessThanOrEqual(8192);
+    const title = new URL(result.url).searchParams.get("title") ?? "";
+    expect(title.length).toBeLessThan(longMessage.length);
+    expect(title.endsWith("…")).toBe(true);
+  });
 });

--- a/src/components/ErrorBoundary/buildReportIssueUrl.ts
+++ b/src/components/ErrorBoundary/buildReportIssueUrl.ts
@@ -6,6 +6,10 @@ const REPO_ISSUE_URL = "https://github.com/daintreehq/daintree/issues/new";
 // and backticks inflate 1→3 bytes.
 export const URL_BODY_BUDGET = 7000;
 
+// Cap the encoded title separately so a multi-kilobyte error message can't
+// blow the URL hard cap from the title side, even when the body fits.
+const TITLE_ENCODED_BUDGET = 200;
+
 // When the stack must be middle-truncated we keep the top frames (where the
 // throw originates) and the tail (where it bubbled up through React). 15+5
 // fits a typical render-error stack while leaving the truncation visible.
@@ -61,23 +65,60 @@ function truncateStackMiddle(stack: string): string {
   return [...head, STACK_MIDDLE_PLACEHOLDER, ...tail].join("\n");
 }
 
+function capMessageForStub(message: string): string {
+  // The stub body fits inside the URL, so we cap the message line just like
+  // the title — a multi-kilobyte message would otherwise blow the budget.
+  const STUB_MESSAGE_BUDGET = 1000;
+  if (encodeURIComponent(message).length <= STUB_MESSAGE_BUDGET) return message;
+  const ellipsis = "…";
+  const ellipsisLen = encodeURIComponent(ellipsis).length;
+  const chars = Array.from(message);
+  while (chars.length > 0) {
+    const trimmed = chars.join("");
+    if (encodeURIComponent(trimmed).length + ellipsisLen <= STUB_MESSAGE_BUDGET) {
+      return trimmed + ellipsis;
+    }
+    chars.pop();
+  }
+  return ellipsis;
+}
+
 function buildStubBody(params: {
   componentName: string | undefined;
   incidentId: string | null;
   message: string;
 }): string {
   const { componentName, incidentId, message } = params;
+  const cappedMessage = capMessageForStub(message || "Unknown error");
   return (
     `## Error Report\n\n` +
     `The full error details were copied to your clipboard — please paste them below.\n\n` +
     `**Component:** ${componentName || "Unknown"}\n` +
     `**Incident ID:** ${incidentId ?? "unknown"}\n` +
-    `**Message:** ${message || "Unknown error"}\n`
+    `**Message:** ${cappedMessage}\n`
   );
 }
 
+function capTitle(title: string): string {
+  if (encodeURIComponent(title).length <= TITLE_ENCODED_BUDGET) return title;
+  // Trim character-by-character until the encoded form fits, leaving room
+  // for the ellipsis. Walking by character avoids slicing into a multi-byte
+  // surrogate pair.
+  const ellipsis = "…";
+  const ellipsisLen = encodeURIComponent(ellipsis).length;
+  const chars = Array.from(title);
+  while (chars.length > 0) {
+    const trimmed = chars.join("");
+    if (encodeURIComponent(trimmed).length + ellipsisLen <= TITLE_ENCODED_BUDGET) {
+      return trimmed + ellipsis;
+    }
+    chars.pop();
+  }
+  return ellipsis;
+}
+
 function makeUrl(title: string, body: string): string {
-  return `${REPO_ISSUE_URL}?title=${encodeURIComponent(title)}&body=${encodeURIComponent(body)}`;
+  return `${REPO_ISSUE_URL}?title=${encodeURIComponent(capTitle(title))}&body=${encodeURIComponent(body)}`;
 }
 
 /**

--- a/src/components/ErrorBoundary/buildReportIssueUrl.ts
+++ b/src/components/ErrorBoundary/buildReportIssueUrl.ts
@@ -1,0 +1,146 @@
+const REPO_ISSUE_URL = "https://github.com/daintreehq/daintree/issues/new";
+
+// GitHub's Nginx fronts the issue form at an 8 KiB URL hard cap. Reserve
+// ~1 KiB for base URL + title + percent-encoding fudge, leaving ~7 KB for
+// the encoded body. Measured against `encodeURIComponent` because newlines
+// and backticks inflate 1→3 bytes.
+export const URL_BODY_BUDGET = 7000;
+
+// When the stack must be middle-truncated we keep the top frames (where the
+// throw originates) and the tail (where it bubbled up through React). 15+5
+// fits a typical render-error stack while leaving the truncation visible.
+export const STACK_HEAD_LINES = 15;
+export const STACK_TAIL_LINES = 5;
+
+const COMPONENT_STACK_PLACEHOLDER =
+  "<!-- component stack omitted — exceeded URL budget; full report copied to clipboard -->";
+const STACK_MIDDLE_PLACEHOLDER =
+  "  ... [middle frames truncated — see clipboard for full stack] ...";
+
+export interface ReportIssueInput {
+  incidentId: string | null;
+  componentName: string | undefined;
+  message: string;
+  stack: string;
+  componentStack: string;
+  context: Record<string, unknown> | undefined;
+}
+
+export interface ReportIssueResult {
+  url: string;
+  fullBody: string;
+  usedClipboardFallback: boolean;
+}
+
+function formatBody(params: {
+  componentName: string | undefined;
+  incidentId: string | null;
+  message: string;
+  context: Record<string, unknown> | undefined;
+  stack: string;
+  componentStack: string;
+}): string {
+  const { componentName, incidentId, message, context, stack, componentStack } = params;
+  return (
+    `## Error Report\n\n` +
+    `**Component:** ${componentName || "Unknown"}\n` +
+    `**Incident ID:** ${incidentId ?? "unknown"}\n` +
+    `**Message:** ${message || "Unknown error"}\n\n` +
+    `**Context:**\n` +
+    `${context ? JSON.stringify(context, null, 2) : "None"}\n\n` +
+    `**Stack Trace:**\n\`\`\`\n${stack || "No stack trace"}\n\`\`\`\n\n` +
+    `**Component Stack:**\n\`\`\`\n${componentStack || "No component stack"}\n\`\`\``
+  );
+}
+
+function truncateStackMiddle(stack: string): string {
+  const lines = stack.split("\n");
+  if (lines.length <= STACK_HEAD_LINES + STACK_TAIL_LINES) return stack;
+  const head = lines.slice(0, STACK_HEAD_LINES);
+  const tail = lines.slice(-STACK_TAIL_LINES);
+  return [...head, STACK_MIDDLE_PLACEHOLDER, ...tail].join("\n");
+}
+
+function buildStubBody(params: {
+  componentName: string | undefined;
+  incidentId: string | null;
+  message: string;
+}): string {
+  const { componentName, incidentId, message } = params;
+  return (
+    `## Error Report\n\n` +
+    `The full error details were copied to your clipboard — please paste them below.\n\n` +
+    `**Component:** ${componentName || "Unknown"}\n` +
+    `**Incident ID:** ${incidentId ?? "unknown"}\n` +
+    `**Message:** ${message || "Unknown error"}\n`
+  );
+}
+
+function makeUrl(title: string, body: string): string {
+  return `${REPO_ISSUE_URL}?title=${encodeURIComponent(title)}&body=${encodeURIComponent(body)}`;
+}
+
+/**
+ * Build the GitHub issue URL for a captured render error, applying a
+ * staged truncation strategy so the encoded body always fits within the
+ * URL budget. When even truncation isn't enough, the caller is told to
+ * write `fullBody` to the clipboard and use the short stub URL.
+ */
+export function buildReportIssueUrl(input: ReportIssueInput): ReportIssueResult {
+  const title = `Component Error: ${input.message || "Unknown"}`;
+  const fullBody = formatBody({
+    componentName: input.componentName,
+    incidentId: input.incidentId,
+    message: input.message,
+    context: input.context,
+    stack: input.stack,
+    componentStack: input.componentStack,
+  });
+
+  if (encodeURIComponent(fullBody).length <= URL_BODY_BUDGET) {
+    return { url: makeUrl(title, fullBody), fullBody, usedClipboardFallback: false };
+  }
+
+  const withoutComponentStack = formatBody({
+    componentName: input.componentName,
+    incidentId: input.incidentId,
+    message: input.message,
+    context: input.context,
+    stack: input.stack,
+    componentStack: COMPONENT_STACK_PLACEHOLDER,
+  });
+
+  if (encodeURIComponent(withoutComponentStack).length <= URL_BODY_BUDGET) {
+    return {
+      url: makeUrl(title, withoutComponentStack),
+      fullBody,
+      usedClipboardFallback: false,
+    };
+  }
+
+  const truncatedStack = truncateStackMiddle(input.stack);
+  const withTruncatedStack = formatBody({
+    componentName: input.componentName,
+    incidentId: input.incidentId,
+    message: input.message,
+    context: input.context,
+    stack: truncatedStack,
+    componentStack: COMPONENT_STACK_PLACEHOLDER,
+  });
+
+  if (encodeURIComponent(withTruncatedStack).length <= URL_BODY_BUDGET) {
+    return {
+      url: makeUrl(title, withTruncatedStack),
+      fullBody,
+      usedClipboardFallback: false,
+    };
+  }
+
+  const stubBody = buildStubBody({
+    componentName: input.componentName,
+    incidentId: input.incidentId,
+    message: input.message,
+  });
+
+  return { url: makeUrl(title, stubBody), fullBody, usedClipboardFallback: true };
+}

--- a/src/utils/__tests__/rendererSentry.test.ts
+++ b/src/utils/__tests__/rendererSentry.test.ts
@@ -143,6 +143,38 @@ describe("rendererSentry", () => {
     expect(mod.getRendererSentryConsent()).toEqual({ level: "off", hasSeenPrompt: true });
   });
 
+  it("captureRendererException returns the Sentry event ID when capture succeeds", async () => {
+    const sentry = await import("@sentry/electron/renderer");
+    vi.mocked(sentry.captureException).mockReturnValueOnce("evt-deadbeef");
+
+    const mod = await import("../rendererSentry");
+    const eventId = mod.captureRendererException(new Error("boom"));
+    expect(eventId).toBe("evt-deadbeef");
+  });
+
+  it("captureRendererException returns null when Sentry returns an empty string", async () => {
+    const sentry = await import("@sentry/electron/renderer");
+    vi.mocked(sentry.captureException).mockReturnValueOnce("");
+
+    const mod = await import("../rendererSentry");
+    const eventId = mod.captureRendererException(new Error("boom"));
+    expect(eventId).toBeNull();
+  });
+
+  it("captureRendererException returns null and logs when Sentry throws", async () => {
+    const sentry = await import("@sentry/electron/renderer");
+    vi.mocked(sentry.captureException).mockImplementationOnce(() => {
+      throw new Error("Sentry transport down");
+    });
+    const consoleErr = vi.spyOn(console, "error").mockImplementation(() => {});
+
+    const mod = await import("../rendererSentry");
+    const eventId = mod.captureRendererException(new Error("boom"));
+    expect(eventId).toBeNull();
+    expect(consoleErr).toHaveBeenCalled();
+    consoleErr.mockRestore();
+  });
+
   it("updateRendererSentryConsent also flips the gate", async () => {
     getConsentState.mockResolvedValueOnce({ level: "off", hasSeenPrompt: false });
     const mod = await import("../rendererSentry");

--- a/src/utils/rendererSentry.ts
+++ b/src/utils/rendererSentry.ts
@@ -70,15 +70,22 @@ export interface CaptureOptions {
 /** Report an exception to Sentry. Safe to call from UI components — wraps
  * the renderer SDK so components don't import from the restricted
  * `@sentry/electron/renderer` module directly.
+ *
+ * Returns the Sentry event ID (a 32-char hex string) so callers can surface
+ * it as a user-visible identifier engineers can look up in Sentry. Returns
+ * `null` if the SDK isn't initialized (Sentry returns `""` in that case) or
+ * if capture itself throws.
  */
-export function captureRendererException(error: unknown, options?: CaptureOptions): void {
+export function captureRendererException(error: unknown, options?: CaptureOptions): string | null {
   try {
     const err = error instanceof Error ? error : new Error(String(error));
-    Sentry.captureException(err, options);
+    const eventId = Sentry.captureException(err, options);
+    return eventId || null;
   } catch (sentryError) {
     // Last-resort sink: Sentry capture failed; logger/IPC may share the fault.
     // eslint-disable-next-line no-console
     console.error("[Renderer] Failed to report error to Sentry:", sentryError);
+    return null;
   }
 }
 


### PR DESCRIPTION
## Summary

- The Report Issue deeplink in the error boundary wasn't reliable for crashes with real stacks — long component stacks and full error messages routinely pushed the URL past browser limits, resulting in a broken or truncated prefill.
- Adds `buildReportIssueUrl` (`src/components/ErrorBoundary/buildReportIssueUrl.ts`), a pure URL builder with staged truncation: full body → componentStack-omitted → middle-truncated stack (head 15 + tail 5) → short stub. When even the stub exceeds the budget, it falls back to writing the full body to the clipboard and notifies with a microcopy-compliant toast.
- Wires the Sentry event ID as the displayed incident ID when available, falling back to the store-generated ID.

Resolves #6884

## Changes

- `src/utils/rendererSentry.ts` — `captureRendererException` now returns `string | null` (Sentry event ID, or `null` when SDK is uninitialised or capture throws).
- `src/components/ErrorBoundary/buildReportIssueUrl.ts` (new) — URL body budget 7000 encoded bytes, title capped at 200 encoded bytes. Four truncation stages; stub signals `usedClipboardFallback`.
- `src/components/ErrorBoundary/ErrorBoundary.tsx` — `handleReport` is async and guarded against double-clicks. Calls `buildReportIssueUrl`; on clipboard fallback writes full body via `window.electron.clipboard.writeText` with graceful handling for missing API and write failures.
- `src/components/ErrorBoundary/ErrorFallback.tsx` — `onReport` prop widened to `() => void | Promise<void>`.

## Testing

- 11 unit tests in `buildReportIssueUrl.test.ts`: short input, encoding, empty fields, componentStack truncation, stack middle truncation, clipboard fallback trigger, budget boundary, URL parseability, total URL ≤ 8192 across all stages, emoji-heavy title cap, long-message title cap.
- 8 new tests in `ErrorBoundary.test.tsx`: Sentry ID as Error ID, store-ID fallback, full-body deeplink under budget, clipboard-fallback notify, clipboard-write-failure path, missing clipboard API, double-click dedupe, missing `window.electron`.
- 3 new tests in `rendererSentry.test.ts` covering the return contract.
- `npm run check` passes clean.

### Manual test plan

- Trigger an `ErrorBoundary` crash and click Report Issue — verify the URL fits and the GitHub issue prefill works end to end.
- Trigger a crash with a synthetic >8 KB stack — verify the clipboard receives the full report and the "Error details copied" toast appears.
- Trigger a crash where the clipboard API is unavailable — verify the toast says "Error details too long".
- Verify the displayed Error ID matches the Sentry event ID in production builds with consent enabled.