### PR TITLE
fix(worktree-sidebar): polish quick-state pills and drag handle states

### DIFF
--- a/src/components/ErrorBoundary/__tests__/ErrorBoundary.test.tsx
+++ b/src/components/ErrorBoundary/__tests__/ErrorBoundary.test.tsx
@@ -36,7 +36,7 @@ interface ElectronMock {
 }
 
 function getElectronMock(): ElectronMock {
-  // eslint-disable-next-line @typescript-eslint/no-unsafe-return, @typescript-eslint/no-explicit-any
+  // eslint-disable-next-line @typescript-eslint/no-explicit-any
   return (window as any).electron;
 }
 

--- a/src/components/Worktree/QuickStateFilterBar.tsx
+++ b/src/components/Worktree/QuickStateFilterBar.tsx
@@ -33,10 +33,11 @@ export function QuickStateFilterBar({ value, onChange, counts }: QuickStateFilte
               "inline-flex items-center px-2 py-0.5 text-[11px] rounded-full transition-colors",
               isActive
                 ? "bg-tint/[0.12] text-daintree-text font-medium"
-                : "text-daintree-text/50 hover:text-daintree-text/70 hover:bg-tint/[0.04]"
+                : "text-daintree-text/60 hover:text-daintree-text hover:bg-tint/[0.04]"
             )}
           >
             {option.label}
+            {/* "All" has no count — quickStateCounts excludes main/integration worktrees, so the sum != the sidebar header's (N) total. */}
             {counts && option.value !== "all" && ` (${counts[option.value]})`}
           </button>
         );

--- a/src/components/Worktree/WorktreeCard.tsx
+++ b/src/components/Worktree/WorktreeCard.tsx
@@ -668,9 +668,7 @@ export function WorktreeCard({
                   "shrink-0 w-4 flex items-center justify-center cursor-grab active:cursor-grabbing touch-none select-none transition-colors motion-reduce:transition-none",
                   isDraggingSort
                     ? "bg-overlay-emphasis text-text-primary"
-                    : isWorktreeSortDragging
-                      ? "text-text-primary/30 hover:text-text-primary/50 hover:bg-overlay-soft"
-                      : "text-transparent group-hover/card:text-text-primary/30 group-hover/card:bg-overlay-soft"
+                    : "text-transparent group-hover/card:text-text-primary/30 group-hover/card:bg-overlay-soft"
                 )}
                 aria-label="Drag to reorder"
                 {...dragHandleListeners}


### PR DESCRIPTION
## Summary

- Lifts inactive `QuickStateFilterBar` pill text from `/50` to `/60` opacity, with a full-opacity hover — keeps the pills readable without encroaching on the active pill's `bg-tint/[0.12]` + `font-medium` signal, and matches the `/60`→`/80` pattern already used in `WorktreeFilterPopover`
- Drops the `isWorktreeSortDragging` middle branch from `WorktreeCard`'s drag-handle ternary — the old branch lit up every sibling row's handle at 30% during a sort drag, which was visual noise on top of `verticalListSortingStrategy`'s own position animation; the default hover reveal and `[data-worktree-row]:focus-within` keyboard rule both stay intact
- Adds a comment in `QuickStateFilterBar` explaining that the "All" pill intentionally has no count badge, so the next polish pass doesn't revisit the asymmetry

Resolves #6931

## Changes

- `src/components/Worktree/QuickStateFilterBar.tsx` — opacity bump `/50`→`/60`, hover lifted to full opacity, comment added
- `src/components/Worktree/WorktreeCard.tsx` — middle `isWorktreeSortDragging` branch removed from drag-handle ternary

## Testing

7 existing unit tests pass. `npm run check` clean (0 errors, warnings pre-existing on develop).