### PR TITLE
fix(dnd): animate DragOverlay dismissal on successful drops

### DIFF
--- a/src/components/DragDrop/DndProvider.tsx
+++ b/src/components/DragDrop/DndProvider.tsx
@@ -62,6 +62,7 @@ import {
   EASE_SNAPPY,
   PANEL_RESTORE_DURATION,
   EASE_OUT_EXPO,
+  getUiAnimationDuration,
 } from "@/lib/animationUtils";
 
 // Placeholder ID used when dragging from dock to grid
@@ -330,7 +331,7 @@ function DragOverlayWithCursorTracking({
       dropAnimation={
         isCancelDrop
           ? { duration: PANEL_RESTORE_DURATION, easing: EASE_OUT_EXPO, sideEffects: null }
-          : null
+          : { duration: getUiAnimationDuration(), easing: EASE_SNAPPY, sideEffects: null }
       }
       modifiers={activeModifiers}
     >

--- a/src/components/DragDrop/__tests__/DndProvider.dropAnimation.test.ts
+++ b/src/components/DragDrop/__tests__/DndProvider.dropAnimation.test.ts
@@ -1,0 +1,72 @@
+// @vitest-environment jsdom
+// Contract test for DragOverlay dropAnimation config in DndProvider.
+// Mirrors the inline ternary expression rendered for the DragOverlay's
+// dropAnimation prop so we can assert success and cancel branches use
+// the right motion tokens. Following the same harness pattern as
+// DndProvider.cancelDrop.test.ts and DndProvider.trashDrop.test.ts.
+import { afterEach, describe, expect, it } from "vitest";
+
+import {
+  EASE_OUT_EXPO,
+  EASE_SNAPPY,
+  PANEL_RESTORE_DURATION,
+  UI_ANIMATION_DURATION,
+  getUiAnimationDuration,
+} from "@/lib/animationUtils";
+
+// ── Branch replica (mirrors dropAnimation prop in DndProvider.tsx) ──
+
+type DropAnimationConfig = {
+  duration: number;
+  easing: string;
+  sideEffects: null;
+};
+
+/**
+ * Mirrors the inline ternary at the DragOverlay's dropAnimation prop.
+ * Must call getUiAnimationDuration() at invocation time so it reads the
+ * live `document.body.dataset.performanceMode` flag.
+ */
+function dropAnimation(isCancelDrop: boolean): DropAnimationConfig {
+  return isCancelDrop
+    ? { duration: PANEL_RESTORE_DURATION, easing: EASE_OUT_EXPO, sideEffects: null }
+    : { duration: getUiAnimationDuration(), easing: EASE_SNAPPY, sideEffects: null };
+}
+
+// ── Tests ────────────────────────────────────────────────
+
+describe("DragOverlay dropAnimation config", () => {
+  afterEach(() => {
+    delete document.body.dataset.performanceMode;
+  });
+
+  it("uses Tier 1 snap motion (150ms EASE_SNAPPY) on successful drops", () => {
+    const result = dropAnimation(false);
+    expect(result).toEqual({
+      duration: UI_ANIMATION_DURATION,
+      easing: EASE_SNAPPY,
+      sideEffects: null,
+    });
+  });
+
+  it("uses Tier 3 panel motion (200ms EASE_OUT_EXPO) on cancelled drops", () => {
+    const result = dropAnimation(true);
+    expect(result).toEqual({
+      duration: PANEL_RESTORE_DURATION,
+      easing: EASE_OUT_EXPO,
+      sideEffects: null,
+    });
+  });
+
+  it("returns a non-null config with duration 0 in performance mode", () => {
+    document.body.dataset.performanceMode = "true";
+    const result = dropAnimation(false);
+    // Non-null keeps dnd-kit's animation lifecycle alive (avoids unmount flash);
+    // duration 0 makes the motion functionally instant.
+    expect(result).toEqual({
+      duration: 0,
+      easing: EASE_SNAPPY,
+      sideEffects: null,
+    });
+  });
+});


### PR DESCRIPTION
## Summary

- On a successful drop, `DragOverlay` was removed with `dropAnimation={null}`, so it vanished mid-air instead of animating to its destination
- Replaces `null` with a Tier 1 snap animation using `getUiAnimationDuration` and `EASE_SNAPPY` from `@/lib/animationUtils` — the cancel path already animated correctly, so this makes the two branches coherent
- Adds contract tests covering the success, cancel, and performance-mode branches in `DndProvider.dropAnimation.test.ts`

Resolves #6930

## Changes

- `src/components/DragDrop/DndProvider.tsx` — replace `null` drop animation on success branch with `{ duration: getUiAnimationDuration(), easing: EASE_SNAPPY, sideEffects: null }`
- `src/components/DragDrop/__tests__/DndProvider.dropAnimation.test.ts` — 3 new contract tests

## Testing

- 16 vitest tests pass (`DndProvider.dropAnimation.test.ts` + existing `DndProvider.cancelDrop.test.ts`)
- Typecheck, lint, format, and build all clean