### PR TITLE
fix(sidebar): migrate empty states to EmptyState primitive

### DIFF
--- a/src/components/Sidebar/SidebarContent.tsx
+++ b/src/components/Sidebar/SidebarContent.tsx
@@ -9,7 +9,8 @@ import {
   useState,
   useTransition,
 } from "react";
-import { FolderOpen, FilterX, LayoutGrid, Plus, RefreshCw, Zap } from "lucide-react";
+import { FolderOpen, LayoutGrid, Plus, RefreshCw, Zap } from "lucide-react";
+import { EmptyState } from "@/components/ui/EmptyState";
 import { ScrollIndicator } from "@/components/Worktree/ScrollIndicator";
 import {
   useAgentLauncher,
@@ -151,7 +152,6 @@ function SidebarContent({ onOpenOverview }: SidebarContentProps) {
   const collapsedWorktrees = useWorktreeFilterStore((state) => state.collapsedWorktrees);
   const expandWorktree = useWorktreeFilterStore((state) => state.expandWorktree);
   const setQuickStateFilter = useWorktreeFilterStore((state) => state.setQuickStateFilter);
-  const clearQuickStateFilter = useWorktreeFilterStore((state) => state.clearQuickStateFilter);
 
   // Terminal store for derived metadata
   const panelsById = usePanelStore((state) => state.panelsById);
@@ -514,18 +514,20 @@ function SidebarContent({ onOpenOverview }: SidebarContentProps) {
             <h2 className="text-daintree-text font-semibold text-sm tracking-wide">Worktrees</h2>
           </div>
 
-          <div className="flex flex-col items-center justify-center py-12 px-4 text-center flex-1">
-            <FolderOpen className="w-8 h-8 text-daintree-text/60 mb-3" aria-hidden="true" />
-
-            <h3 className="text-daintree-text font-medium mb-2">No worktrees yet</h3>
-
-            <p className="text-sm text-daintree-text/60 max-w-xs">
-              Open a Git repository to get started. Use{" "}
-              <kbd className="px-1.5 py-0.5 bg-tint/[0.06] rounded text-xs">
-                File → Open Directory
-              </kbd>
-            </p>
-          </div>
+          <EmptyState
+            variant="zero-data"
+            icon={<FolderOpen />}
+            title="Open a Git repository to get started"
+            description={
+              <>
+                Use{" "}
+                <kbd className="px-1.5 py-0.5 bg-tint/[0.06] rounded text-xs">
+                  File → Open Directory
+                </kbd>
+              </>
+            }
+            className="flex-1"
+          />
         </div>
         {newWorktreeDialogElement}
       </>
@@ -768,46 +770,34 @@ function SidebarContent({ onOpenOverview }: SidebarContentProps) {
                 />
               )}
               {showQuickStateEmptyState ? (
-                <div className="flex flex-col items-center justify-center py-12 px-4 text-center">
-                  <FilterX className="w-10 h-10 text-daintree-text/40 mb-3" />
-                  <p className="text-sm text-daintree-text/80 mb-1">
-                    No {quickStateFilter} worktrees
-                  </p>
-                  <p className="text-xs text-daintree-text/50 mb-3">
-                    {hasPopoverFilters
-                      ? "Try a different state, or clear your other filters"
-                      : "Try a different state to see the rest"}
-                  </p>
-                  <div className="flex items-center gap-2">
+                <EmptyState
+                  variant="filtered-empty"
+                  title={`No ${quickStateFilter} worktrees`}
+                  description={
+                    hasPopoverFilters ? "Clear filters to show every worktree" : undefined
+                  }
+                  action={
                     <button
-                      onClick={clearQuickStateFilter}
-                      className="text-xs px-3 py-1.5 text-accent-primary hover:bg-overlay-soft rounded transition-colors font-medium"
+                      onClick={clearAllFilters}
+                      className="text-xs px-3 py-1.5 text-daintree-text/60 hover:text-daintree-text hover:bg-overlay-soft rounded transition-colors"
                     >
-                      Show all states
+                      Clear filters
                     </button>
-                    {hasPopoverFilters ? (
-                      <button
-                        onClick={clearAllFilters}
-                        className="text-xs px-3 py-1.5 text-daintree-text/60 hover:text-daintree-text hover:bg-overlay-soft rounded transition-colors"
-                      >
-                        Clear all filters
-                      </button>
-                    ) : null}
-                  </div>
-                </div>
+                  }
+                />
               ) : filteredWorktrees.length === 0 && hasFilters && hasNonMainWorktrees ? (
-                <div className="flex flex-col items-center justify-center py-12 px-4 text-center">
-                  <FilterX className="w-10 h-10 text-daintree-text/40 mb-3" />
-                  <p className="text-sm text-daintree-text/60 mb-3">
-                    No worktrees match your filters
-                  </p>
-                  <button
-                    onClick={clearAllFilters}
-                    className="text-xs px-3 py-1.5 text-daintree-text/60 hover:text-daintree-text hover:bg-overlay-soft rounded transition-colors"
-                  >
-                    Clear filters
-                  </button>
-                </div>
+                <EmptyState
+                  variant="filtered-empty"
+                  title="No worktrees match your filters"
+                  action={
+                    <button
+                      onClick={clearAllFilters}
+                      className="text-xs px-3 py-1.5 text-daintree-text/60 hover:text-daintree-text hover:bg-overlay-soft rounded transition-colors"
+                    >
+                      Clear filters
+                    </button>
+                  }
+                />
               ) : groupedSections ? (
                 <div className="flex flex-col">
                   {groupedSections.map((section) => (

--- a/src/components/Sidebar/__tests__/SidebarContent.emptyState.test.ts
+++ b/src/components/Sidebar/__tests__/SidebarContent.emptyState.test.ts
@@ -118,12 +118,28 @@ describe("SidebarContent quick-state empty state — issue #6333 (CTA collapsed 
       expect(branch).toMatch(/onClick=\{clearAllFilters\}[\s\S]*?>\s*Clear filters\s*</);
       expect(branch).not.toContain("Show all states");
       expect(branch).not.toContain("clearQuickStateFilter");
+      // Exactly one button — guards against the dual-CTA pattern returning by
+      // any other shape (e.g. an additional secondary action being added).
+      const buttonMatches = branch.match(/<button\b/g) ?? [];
+      expect(buttonMatches).toHaveLength(1);
     });
 
     it("does not render two recovery CTAs side-by-side in the quick-state branch", () => {
       // Regression guard against the dual-button anti-pattern returning.
       expect(source).not.toContain("Show all states");
       expect(source).not.toContain("Clear all filters");
+    });
+
+    it("gates the description on hasPopoverFilters so the no-popover-filters case stays quiet", () => {
+      // When only the quick-state filter is active, the title and single
+      // CTA already convey everything; an additional descriptive line would
+      // be redundant noise. The description prop passes `undefined` in that
+      // path, which the EmptyState primitive treats as "no description".
+      const branchStart = source.indexOf("showQuickStateEmptyState ?");
+      const branchEnd = source.indexOf("filteredWorktrees.length === 0 && hasFilters", branchStart);
+      const branch = source.slice(branchStart, branchEnd);
+      expect(branch).toMatch(/description=\{[\s\S]*?hasPopoverFilters[\s\S]*?\}/);
+      expect(branch).toContain("undefined");
     });
 
     it("preserves the 'No worktrees match your filters' branch via the EmptyState primitive", () => {
@@ -240,5 +256,16 @@ describe("SidebarContent zero-worktrees taxonomy alignment — issue #6934", () 
     const importLine = source.match(/import \{[^}]*\} from "lucide-react"/);
     expect(importLine).not.toBeNull();
     expect(importLine![0]).not.toContain("FilterX");
+  });
+
+  it("does not render a button in the zero-worktrees branch", () => {
+    // The zero-worktrees state's only action is in the application menu,
+    // communicated via the <kbd>File → Open Directory</kbd> hint — there is
+    // no inline button. Guards against a future regression that adds a
+    // create-worktree CTA back into this branch.
+    const branchStart = source.indexOf("if (worktrees.length === 0) {");
+    const branchEnd = source.indexOf("const hasNonMainWorktrees", branchStart);
+    const branch = source.slice(branchStart, branchEnd);
+    expect(branch).not.toContain("<button");
   });
 });

--- a/src/components/Sidebar/__tests__/SidebarContent.emptyState.test.ts
+++ b/src/components/Sidebar/__tests__/SidebarContent.emptyState.test.ts
@@ -4,7 +4,7 @@ import path from "path";
 
 const SIDEBAR_CONTENT_PATH = path.resolve(__dirname, "../SidebarContent.tsx");
 
-describe("SidebarContent quick-state empty state — issue #6333", () => {
+describe("SidebarContent quick-state empty state — issue #6333 (CTA collapsed by #6934)", () => {
   let source: string;
 
   beforeAll(async () => {
@@ -12,10 +12,14 @@ describe("SidebarContent quick-state empty state — issue #6333", () => {
   });
 
   describe("store wiring", () => {
-    it("subscribes to clearQuickStateFilter from the filter store", () => {
+    it("subscribes to clearAll from the filter store as clearAllFilters", () => {
       expect(source).toMatch(
-        /const clearQuickStateFilter = useWorktreeFilterStore\(\(state\) => state\.clearQuickStateFilter\)/
+        /const clearAllFilters = useWorktreeFilterStore\(\(state\) => state\.clearAll\)/
       );
+    });
+
+    it("does not subscribe to clearQuickStateFilter (single-CTA shape since #6934)", () => {
+      expect(source).not.toContain("state.clearQuickStateFilter");
     });
   });
 
@@ -89,31 +93,49 @@ describe("SidebarContent quick-state empty state — issue #6333", () => {
       expect(quickStateIdx).toBeLessThan(genericIdx);
     });
 
-    it("titles the empty state with the active quick-state label", () => {
-      expect(source).toContain("No {quickStateFilter} worktrees");
+    it("titles the quick-state empty state with the active filter label via the EmptyState primitive", () => {
+      expect(source).toMatch(/title=\{`No \$\{quickStateFilter\} worktrees`\}/);
     });
 
-    it("primary CTA resets only the quick-state filter", () => {
-      const block = source.match(
-        /onClick=\{clearQuickStateFilter\}[\s\S]*?>\s*Show all states\s*</
+    it("uses the EmptyState filtered-empty variant for the quick-state branch", () => {
+      // The quick-state empty state migrated from raw markup to the canonical
+      // EmptyState primitive (#6934). The variant carries role=status and
+      // aria-live=polite at the component level.
+      const branchStart = source.indexOf("showQuickStateEmptyState ?");
+      const branchEnd = source.indexOf("filteredWorktrees.length === 0 && hasFilters", branchStart);
+      const branch = source.slice(branchStart, branchEnd);
+      expect(branch).toContain("<EmptyState");
+      expect(branch).toContain('variant="filtered-empty"');
+    });
+
+    it("collapses the quick-state empty state to a single 'Clear filters' CTA wired to clearAllFilters", () => {
+      // #6934: the dual-CTA shape ('Show all states' + conditional 'Clear all filters')
+      // was an empty-state anti-pattern. clearAll() resets every dimension including
+      // quickStateFilter, so a single button is the natural recovery shape.
+      const branchStart = source.indexOf("showQuickStateEmptyState ?");
+      const branchEnd = source.indexOf("filteredWorktrees.length === 0 && hasFilters", branchStart);
+      const branch = source.slice(branchStart, branchEnd);
+      expect(branch).toMatch(/onClick=\{clearAllFilters\}[\s\S]*?>\s*Clear filters\s*</);
+      expect(branch).not.toContain("Show all states");
+      expect(branch).not.toContain("clearQuickStateFilter");
+    });
+
+    it("does not render two recovery CTAs side-by-side in the quick-state branch", () => {
+      // Regression guard against the dual-button anti-pattern returning.
+      expect(source).not.toContain("Show all states");
+      expect(source).not.toContain("Clear all filters");
+    });
+
+    it("preserves the 'No worktrees match your filters' branch via the EmptyState primitive", () => {
+      const branchStart = source.indexOf(
+        "filteredWorktrees.length === 0 && hasFilters && hasNonMainWorktrees ?"
       );
-      expect(block).not.toBeNull();
-    });
-
-    it("only renders the secondary 'Clear all filters' CTA when popover filters are active", () => {
-      // The secondary button is gated on hasPopoverFilters so it doesn't
-      // appear when the quick-state filter is the *only* active filter
-      // (otherwise users see two buttons that appear to do the same thing).
-      const block = source.match(
-        /\{hasPopoverFilters \?[\s\S]*?onClick=\{clearAllFilters\}[\s\S]*?Clear all filters[\s\S]*?: null\}/
-      );
-      expect(block).not.toBeNull();
-    });
-
-    it("preserves the existing 'No worktrees match your filters' branch for popover-only cases", () => {
-      expect(source).toContain("No worktrees match your filters");
-      // Original Clear filters button is still wired to clearAllFilters
-      expect(source).toMatch(/onClick=\{clearAllFilters\}[\s\S]*?>\s*Clear filters\s*</);
+      const branchEnd = source.indexOf("groupedSections ?", branchStart);
+      const branch = source.slice(branchStart, branchEnd);
+      expect(branch).toContain("<EmptyState");
+      expect(branch).toContain('variant="filtered-empty"');
+      expect(branch).toContain('title="No worktrees match your filters"');
+      expect(branch).toMatch(/onClick=\{clearAllFilters\}[\s\S]*?>\s*Clear filters\s*</);
     });
   });
 });
@@ -178,5 +200,45 @@ describe("SidebarContent zero-worktrees empty state — issue #6752 (supersedes 
     expect(dialogIdx).toBeGreaterThan(0);
     expect(firstEarlyReturnIdx).toBeGreaterThan(0);
     expect(dialogIdx).toBeLessThan(firstEarlyReturnIdx);
+  });
+});
+
+describe("SidebarContent zero-worktrees taxonomy alignment — issue #6934", () => {
+  let source: string;
+
+  beforeAll(async () => {
+    source = await fs.readFile(SIDEBAR_CONTENT_PATH, "utf-8");
+  });
+
+  it("uses the EmptyState primitive with the zero-data variant", () => {
+    const branchStart = source.indexOf("if (worktrees.length === 0) {");
+    const branchEnd = source.indexOf("const hasNonMainWorktrees", branchStart);
+    const branch = source.slice(branchStart, branchEnd);
+    expect(branch).toContain("<EmptyState");
+    expect(branch).toContain('variant="zero-data"');
+  });
+
+  it("names the action in the title slot, not the absence", () => {
+    // CLAUDE.md "Empty States" rule: first-run empty states name what the user
+    // can do next. Migrating from "No worktrees yet" (the absence) to the
+    // action sentence as the title fixes the slot-swap drift.
+    const branchStart = source.indexOf("if (worktrees.length === 0) {");
+    const branchEnd = source.indexOf("const hasNonMainWorktrees", branchStart);
+    const branch = source.slice(branchStart, branchEnd);
+    expect(branch).toContain('title="Open a Git repository to get started"');
+    expect(branch).not.toContain("No worktrees yet");
+  });
+
+  it("imports the EmptyState primitive", () => {
+    expect(source).toMatch(/import \{ EmptyState \} from "@\/components\/ui\/EmptyState"/);
+  });
+
+  it("removes FilterX from lucide-react imports (no longer rendered after EmptyState migration)", () => {
+    // FilterX was the icon used in the raw filter-empty markup. The
+    // filtered-empty EmptyState variant intentionally omits icons, so the
+    // import becomes unused — keeping it would be dead code.
+    const importLine = source.match(/import \{[^}]*\} from "lucide-react"/);
+    expect(importLine).not.toBeNull();
+    expect(importLine![0]).not.toContain("FilterX");
   });
 });


### PR DESCRIPTION
## Summary

- Migrates three sidebar empty-state surfaces to the canonical `EmptyState` primitive (`zero-data` and `filtered-empty` variants), aligning with the taxonomy in `CLAUDE.md`.
- Zero-worktrees state: action sentence ("Open a Git repository to get started") moves to the title slot where it belongs; `File → Open Directory` stays as the description.
- Quick-state filter-empty branch: dual-CTA anti-pattern ("Show all states" + "Clear all filters") collapsed to a single "Clear filters" button wired to `clearAll()`, which already resets every filter dimension.

Resolves #6934

## Changes

- `SidebarContent.tsx`: three empty-state branches migrated to `<EmptyState>`, unused `FilterX` import and `clearQuickStateFilter` selector dropped.
- `SidebarContent.emptyState.test.ts`: source-text assertions updated; new `#6934` describe block adds 4 taxonomy-alignment guards plus 3 regression guards (exactly-one-CTA in quick-state branch, description gated on `hasPopoverFilters`, zero-worktrees branch has no `<button>`).

## Testing

- Vitest: `src/components/Sidebar/__tests__/SidebarContent.emptyState.test.ts` — 25 tests pass.
- Manual: zero-worktrees state shows the action title, `kbd` pill, and `FolderOpen` icon; quick-state filter-empty shows single "Clear filters" button with no description when only a quick-state filter is active, and with the description when popover filters are also active; `No worktrees match your filters` branch shows correctly for popover-only filters.