### PR TITLE
refactor(palette): migrate consumers onto unified SearchablePalette shell

### DIFF
--- a/src/components/ActionPalette/ActionPalette.tsx
+++ b/src/components/ActionPalette/ActionPalette.tsx
@@ -1,5 +1,6 @@
 import { useCallback } from "react";
 import { SearchablePalette } from "@/components/ui/SearchablePalette";
+import { useEffectiveCombo } from "@/hooks/useKeybinding";
 import { ActionPaletteItem } from "./ActionPaletteItem";
 import type {
   ActionPaletteItem as ActionPaletteItemType,
@@ -51,6 +52,8 @@ export function ActionPalette({
     [executeAction]
   );
 
+  const actionPaletteShortcut = useEffectiveCombo("action.palette.open");
+
   return (
     <SearchablePalette<ActionPaletteItemType>
       isOpen={isOpen}
@@ -75,7 +78,7 @@ export function ActionPalette({
         />
       )}
       label="Actions"
-      keyHint="⇧⇧"
+      shortcut={actionPaletteShortcut}
       ariaLabel="Action palette"
       searchPlaceholder="Find an action"
       searchAriaLabel="Search actions"

--- a/src/components/Commands/CommandPicker.tsx
+++ b/src/components/Commands/CommandPicker.tsx
@@ -1,7 +1,6 @@
 import { useState, useMemo, useEffect, useCallback, useDeferredValue } from "react";
 import { cn } from "@/lib/utils";
 import { SearchablePalette } from "@/components/ui/SearchablePalette";
-import { Spinner } from "@/components/ui/Spinner";
 import type { CommandManifestEntry, CommandCategory } from "@shared/types/commands";
 
 interface CommandPickerProps {
@@ -147,37 +146,6 @@ export function CommandPicker({
     }
   }, [flatCommands, selectedIndex, onSelect, isStale]);
 
-  if (isLoading) {
-    return (
-      <SearchablePalette<CommandManifestEntry>
-        isOpen={isOpen}
-        query={query}
-        results={[]}
-        selectedIndex={0}
-        onQueryChange={setQuery}
-        onSelectPrevious={handleSelectPrevious}
-        onSelectNext={handleSelectNext}
-        onConfirm={handleConfirm}
-        onClose={onDismiss}
-        getItemId={(cmd) => cmd.id}
-        renderItem={() => null}
-        label="Commands"
-        keyHint="⌘K"
-        ariaLabel="Command picker"
-        searchPlaceholder="Search commands"
-        searchAriaLabel="Search commands"
-        listId="command-list"
-        itemIdPrefix="command"
-        renderBody={() => (
-          <div className="flex flex-col items-center justify-center py-8 space-y-2">
-            <Spinner size="xl" className="text-daintree-text/40" />
-            <p className="text-sm text-daintree-text/50">Loading commands...</p>
-          </div>
-        )}
-      />
-    );
-  }
-
   return (
     <SearchablePalette<CommandManifestEntry>
       isOpen={isOpen}
@@ -190,6 +158,7 @@ export function CommandPicker({
       onConfirm={handleConfirm}
       onClose={onDismiss}
       getItemId={(cmd) => cmd.id}
+      isLoading={isLoading}
       isFiltering={isStale}
       renderItem={(cmd, index, isSelected) => {
         const category = categoryStarts.get(cmd.id);
@@ -243,7 +212,6 @@ export function CommandPicker({
         );
       }}
       label="Commands"
-      keyHint="⌘K"
       ariaLabel="Command picker"
       searchPlaceholder="Search commands"
       searchAriaLabel="Search commands"

--- a/src/components/PanelPalette/PanelPalette.tsx
+++ b/src/components/PanelPalette/PanelPalette.tsx
@@ -209,15 +209,19 @@ export function PanelPalette({
       </AppPaletteDialog.Header>
 
       <AppPaletteDialog.Body>
-        <div id="panel-list" role="listbox" aria-label="Panel types">
-          {results.length === 0 ? (
-            <div className="px-3 py-8 text-center text-daintree-text/50 text-sm">{`No panel types match "${query}"`}</div>
-          ) : isSearching ? (
-            results.map((kind, index) => renderOption(kind, index))
-          ) : (
-            renderSectionedList()
-          )}
-        </div>
+        {results.length === 0 ? (
+          <AppPaletteDialog.Empty
+            query={query}
+            emptyMessage="No panel types available"
+            noMatchMessage={`No panel types match "${query.length > 40 ? query.slice(0, 40) + "…" : query}"`}
+          />
+        ) : (
+          <div id="panel-list" role="listbox" aria-label="Panel types">
+            {isSearching
+              ? results.map((kind, index) => renderOption(kind, index))
+              : renderSectionedList()}
+          </div>
+        )}
         {totalResults != null && (
           <PaletteOverflowNotice shown={results.length} total={totalResults} />
         )}

--- a/src/components/Project/ProjectSwitcherPalette.tsx
+++ b/src/components/Project/ProjectSwitcherPalette.tsx
@@ -21,7 +21,7 @@ import {
 } from "lucide-react";
 import { cn } from "@/lib/utils";
 import { getProjectGradient } from "@/lib/colorUtils";
-import { AppPaletteDialog } from "@/components/ui/AppPaletteDialog";
+import { AppPaletteDialog, KBD_CLASS } from "@/components/ui/AppPaletteDialog";
 import { Popover, PopoverContent, PopoverTrigger } from "@/components/ui/popover";
 import {
   ContextMenu,
@@ -644,9 +644,6 @@ function ScratchSection({
     </div>
   );
 }
-
-const KBD_CLASS =
-  "px-1.5 py-0.5 rounded-[var(--radius-sm)] bg-daintree-border text-daintree-text/60";
 
 function ProjectSwitcherFooter({ mode }: { mode?: ProjectSwitcherMode }) {
   const modifiers = useModifierKeys();

--- a/src/components/Project/__tests__/ProjectSwitcherPalette.keyboard.test.tsx
+++ b/src/components/Project/__tests__/ProjectSwitcherPalette.keyboard.test.tsx
@@ -72,7 +72,10 @@ vi.mock("@/components/ui/AppPaletteDialog", () => {
   Dialog.Body = Body;
   Dialog.Footer = Footer;
 
-  return { AppPaletteDialog: Dialog };
+  return {
+    AppPaletteDialog: Dialog,
+    KBD_CLASS: "px-1.5 py-0.5 rounded-[var(--radius-sm)] bg-daintree-border text-daintree-text/60",
+  };
 });
 
 vi.mock("@/components/ui/popover", () => ({

--- a/src/components/Project/__tests__/ProjectSwitcherPalette.render.test.tsx
+++ b/src/components/Project/__tests__/ProjectSwitcherPalette.render.test.tsx
@@ -72,7 +72,10 @@ vi.mock("@/components/ui/AppPaletteDialog", () => {
   Dialog.Body = Body;
   Dialog.Footer = Footer;
 
-  return { AppPaletteDialog: Dialog };
+  return {
+    AppPaletteDialog: Dialog,
+    KBD_CLASS: "px-1.5 py-0.5 rounded-[var(--radius-sm)] bg-daintree-border text-daintree-text/60",
+  };
 });
 
 vi.mock("@/components/ui/popover", () => ({

--- a/src/components/QuickSwitcher/QuickSwitcher.tsx
+++ b/src/components/QuickSwitcher/QuickSwitcher.tsx
@@ -1,6 +1,6 @@
 import { useCallback, useId } from "react";
 import { SearchablePalette } from "@/components/ui/SearchablePalette";
-import { PaletteFooterHints } from "@/components/ui/AppPaletteDialog";
+import { KBD_CLASS, PaletteFooterHints } from "@/components/ui/AppPaletteDialog";
 import { QuickSwitcherItem } from "./QuickSwitcherItem";
 import { useKeybindingDisplay, useEffectiveCombo } from "@/hooks/useKeybinding";
 import type {
@@ -121,11 +121,7 @@ export function QuickSwitcher({
         <p className="mt-2 text-xs text-daintree-text/40">
           {newTerminalShortcut ? (
             <>
-              Press{" "}
-              <kbd className="px-1.5 py-0.5 rounded-[var(--radius-sm)] bg-daintree-border text-daintree-text/60">
-                {newTerminalShortcut}
-              </kbd>{" "}
-              to create a terminal.
+              Press <kbd className={KBD_CLASS}>{newTerminalShortcut}</kbd> to create a terminal.
             </>
           ) : (
             "Create a terminal to get started."

--- a/src/components/Terminal/SendToAgentPalette.tsx
+++ b/src/components/Terminal/SendToAgentPalette.tsx
@@ -1,6 +1,7 @@
 import React, { useCallback } from "react";
 import { cn } from "@/lib/utils";
 import { SearchablePalette } from "@/components/ui/SearchablePalette";
+import { KBD_CLASS } from "@/components/ui/AppPaletteDialog";
 import { TerminalIcon } from "@/components/Terminal/TerminalIcon";
 import { Lock } from "lucide-react";
 import { useKeybindingDisplay, useEffectiveCombo } from "@/hooks/useKeybinding";
@@ -125,11 +126,7 @@ export function SendToAgentPalette({
         <p className="mt-2 text-xs text-daintree-text/40">
           {newTerminalShortcut ? (
             <>
-              Press{" "}
-              <kbd className="px-1.5 py-0.5 rounded-[var(--radius-sm)] bg-daintree-border text-daintree-text/60">
-                {newTerminalShortcut}
-              </kbd>{" "}
-              to create a new terminal.
+              Press <kbd className={KBD_CLASS}>{newTerminalShortcut}</kbd> to create a new terminal.
             </>
           ) : (
             "Create another terminal to send selections."

--- a/src/components/Worktree/WorktreePalette.tsx
+++ b/src/components/Worktree/WorktreePalette.tsx
@@ -1,5 +1,6 @@
 import { cn } from "@/lib/utils";
 import { SearchablePalette } from "@/components/ui/SearchablePalette";
+import { KBD_CLASS } from "@/components/ui/AppPaletteDialog";
 import { useKeybindingDisplay, useEffectiveCombo } from "@/hooks/useKeybinding";
 import { useTruncationDetection } from "@/hooks/useTruncationDetection";
 import { TruncatedTooltip } from "@/components/ui/TruncatedTooltip";
@@ -123,11 +124,7 @@ export function WorktreePalette({
         <p className="mt-2 text-xs text-daintree-text/40">
           {createWorktreeShortcut ? (
             <>
-              Press{" "}
-              <kbd className="px-1.5 py-0.5 rounded-[var(--radius-sm)] bg-daintree-border text-daintree-text/60">
-                {createWorktreeShortcut}
-              </kbd>{" "}
-              to create a worktree.
+              Press <kbd className={KBD_CLASS}>{createWorktreeShortcut}</kbd> to create a worktree.
             </>
           ) : (
             "Create a worktree to get started."

--- a/src/components/ui/AppPaletteDialog.tsx
+++ b/src/components/ui/AppPaletteDialog.tsx
@@ -222,8 +222,7 @@ export function AppPaletteDialog({
 
 interface AppPaletteHeaderProps {
   label: string;
-  keyHint?: string;
-  /** Canonical shortcut string rendered via KbdChord (e.g. "Cmd+N"). Takes precedence over keyHint. */
+  /** Canonical shortcut string rendered via KbdChord (e.g. "Cmd+N"). */
   shortcut?: string;
   children: React.ReactNode;
   className?: string;
@@ -237,7 +236,6 @@ interface AppPaletteHeaderProps {
 
 AppPaletteDialog.Header = function AppPaletteHeader({
   label,
-  keyHint,
   shortcut,
   children,
   className,
@@ -252,11 +250,7 @@ AppPaletteDialog.Header = function AppPaletteHeader({
     >
       <div className="flex justify-between items-center mb-1.5 text-[11px] text-daintree-text/50">
         <span>{label}</span>
-        {shortcut ? (
-          <KbdChord shortcut={shortcut} />
-        ) : keyHint ? (
-          <span className="font-mono">{keyHint}</span>
-        ) : null}
+        {shortcut ? <KbdChord shortcut={shortcut} /> : null}
       </div>
       {children}
       <div

--- a/src/components/ui/Kbd.tsx
+++ b/src/components/ui/Kbd.tsx
@@ -35,7 +35,7 @@ export interface KbdChordProps {
  * Renders a keyboard chord as per-key pills using the neutral overlay surface.
  * macOS uses glyph keys with no `+` separator; Win/Linux uses spelled-out keys
  * separated by a small `+` character. Two-step chords (`Cmd+K T`) are joined
- * by a comma+space, matching the `keyHint` convention used elsewhere.
+ * by a comma+space.
  */
 export function KbdChord({
   shortcut,

--- a/src/components/ui/SearchablePalette.tsx
+++ b/src/components/ui/SearchablePalette.tsx
@@ -45,9 +45,7 @@ export interface SearchablePaletteProps<T> {
 
   /** Label shown above the search input */
   label: string;
-  /** Keyboard hint displayed in header (e.g. "⌘P") */
-  keyHint?: string;
-  /** Canonical shortcut rendered via KbdChord pills. Takes precedence over keyHint. */
+  /** Canonical shortcut rendered via KbdChord pills. */
   shortcut?: string;
   /** ARIA label for the dialog */
   ariaLabel: string;
@@ -152,7 +150,6 @@ export function SearchablePalette<T>({
   onHoverIndex,
   matchesById,
   label,
-  keyHint,
   shortcut,
   ariaLabel,
   searchPlaceholder = "Search",
@@ -288,7 +285,6 @@ export function SearchablePalette<T>({
     <AppPaletteDialog isOpen={isOpen} onClose={onClose} ariaLabel={ariaLabel}>
       <AppPaletteDialog.Header
         label={label}
-        keyHint={keyHint}
         shortcut={shortcut}
         className={headerClassName}
         isLoading={isLoading}

--- a/src/components/ui/SearchablePalette.tsx
+++ b/src/components/ui/SearchablePalette.tsx
@@ -311,14 +311,20 @@ export function SearchablePalette<T>({
           <>
             {beforeList}
             {results.length === 0 ? (
-              <AppPaletteDialog.Empty
-                query={query}
-                emptyMessage={emptyMessage}
-                noMatchMessage={noMatchMessage}
-                noMatchContent={noMatchContent}
-              >
-                {resolvedEmptyContent}
-              </AppPaletteDialog.Empty>
+              // While loading, suppress the empty state so the header progress
+              // bar is the only signal — otherwise the user sees "no results"
+              // and the loading bar at the same time. The body keeps its
+              // min-height so the modal doesn't collapse before data arrives.
+              isLoading ? null : (
+                <AppPaletteDialog.Empty
+                  query={query}
+                  emptyMessage={emptyMessage}
+                  noMatchMessage={noMatchMessage}
+                  noMatchContent={noMatchContent}
+                >
+                  {resolvedEmptyContent}
+                </AppPaletteDialog.Empty>
+              )
             ) : (
               <div
                 ref={listRef}

--- a/src/components/ui/__tests__/AppPaletteDialogHeader.test.tsx
+++ b/src/components/ui/__tests__/AppPaletteDialogHeader.test.tsx
@@ -98,12 +98,12 @@ describe("AppPaletteDialog.Header loading bar", () => {
 
   it("still renders header label and child input", () => {
     render(
-      <AppPaletteDialog.Header label="Quick switch" keyHint="⌘P" isLoading>
+      <AppPaletteDialog.Header label="Quick switch" shortcut="Cmd+P" isLoading>
         <input aria-label="Search terminals" />
       </AppPaletteDialog.Header>
     );
     expect(screen.getByText("Quick switch")).toBeTruthy();
-    expect(screen.getByText("⌘P")).toBeTruthy();
+    expect(screen.getByTestId("kbd-chord")).toBeTruthy();
     expect(screen.getByLabelText("Search terminals")).toBeTruthy();
   });
 
@@ -118,27 +118,7 @@ describe("AppPaletteDialog.Header loading bar", () => {
     expect(chord.dataset.shortcut).toBe("Cmd+P");
   });
 
-  it("prefers shortcut over keyHint when both are provided", () => {
-    render(
-      <AppPaletteDialog.Header label="Quick switch" shortcut="Cmd+P" keyHint="⌘P">
-        <input aria-label="Search" />
-      </AppPaletteDialog.Header>
-    );
-    expect(screen.getByTestId("kbd-chord")).toBeTruthy();
-    expect(screen.queryByText("⌘P")).toBeNull();
-  });
-
-  it("falls back to keyHint when shortcut is undefined", () => {
-    render(
-      <AppPaletteDialog.Header label="Quick switch" keyHint="⇧⇧">
-        <input aria-label="Search" />
-      </AppPaletteDialog.Header>
-    );
-    expect(screen.getByText("⇧⇧")).toBeTruthy();
-    expect(screen.queryByTestId("kbd-chord")).toBeNull();
-  });
-
-  it("renders nothing when neither shortcut nor keyHint is provided", () => {
+  it("renders nothing when shortcut is not provided", () => {
     render(
       <AppPaletteDialog.Header label="Quick switch">
         <input aria-label="Search" />
@@ -149,13 +129,12 @@ describe("AppPaletteDialog.Header loading bar", () => {
     expect(screen.getByText("Quick switch")).toBeTruthy();
   });
 
-  it("falls back to keyHint when shortcut is empty string", () => {
+  it("renders nothing when shortcut is empty string", () => {
     render(
-      <AppPaletteDialog.Header label="Quick switch" shortcut="" keyHint="⌘P">
+      <AppPaletteDialog.Header label="Quick switch" shortcut="">
         <input aria-label="Search" />
       </AppPaletteDialog.Header>
     );
-    expect(screen.getByText("⌘P")).toBeTruthy();
     expect(screen.queryByTestId("kbd-chord")).toBeNull();
   });
 });

--- a/src/components/ui/__tests__/SearchablePalette.loading.test.tsx
+++ b/src/components/ui/__tests__/SearchablePalette.loading.test.tsx
@@ -1,0 +1,84 @@
+// @vitest-environment jsdom
+import { render, screen } from "@testing-library/react";
+import { beforeAll, describe, expect, it, vi } from "vitest";
+
+class ResizeObserverStub {
+  observe() {}
+  unobserve() {}
+  disconnect() {}
+}
+
+beforeAll(() => {
+  if (typeof globalThis.ResizeObserver === "undefined") {
+    globalThis.ResizeObserver = ResizeObserverStub as typeof ResizeObserver;
+  }
+});
+
+vi.mock("@/lib/utils", () => ({
+  cn: (...args: unknown[]) => args.filter(Boolean).join(" "),
+}));
+
+vi.mock("@/hooks", () => ({
+  useEscapeStack: () => {},
+  useOverlayState: () => {},
+}));
+
+vi.mock("@/store/paletteStore", () => ({
+  usePaletteStore: { getState: () => ({ activePaletteId: null }) },
+}));
+
+import { SearchablePalette } from "../SearchablePalette";
+
+interface Item {
+  id: string;
+}
+
+function renderPalette({ isLoading, results }: { isLoading?: boolean; results: Item[] }) {
+  return render(
+    <SearchablePalette<Item>
+      isOpen
+      query=""
+      results={results}
+      selectedIndex={0}
+      onQueryChange={() => {}}
+      onSelectPrevious={() => {}}
+      onSelectNext={() => {}}
+      onConfirm={() => {}}
+      onClose={() => {}}
+      getItemId={(item) => item.id}
+      renderItem={(item) => <div key={item.id}>{item.id}</div>}
+      label="Test"
+      ariaLabel="Test palette"
+      emptyMessage="No items available"
+      isLoading={isLoading}
+    />
+  );
+}
+
+describe("SearchablePalette loading + empty state", () => {
+  it("suppresses the empty state while isLoading is true and results are empty", () => {
+    renderPalette({ isLoading: true, results: [] });
+    expect(screen.queryByText("No items available")).toBeNull();
+    // The header progress bar is the only loading affordance — assert it's
+    // present and marked active so a screen reader doesn't get a misleading
+    // empty-state announcement layered on top.
+    const bar = document.querySelector<HTMLElement>(".palette-loading-bar");
+    expect(bar?.dataset.loading).toBe("true");
+  });
+
+  it("shows the empty state when isLoading is false and results are empty", () => {
+    renderPalette({ isLoading: false, results: [] });
+    expect(screen.getByText("No items available")).toBeTruthy();
+  });
+
+  it("shows the empty state when isLoading is omitted (default false)", () => {
+    renderPalette({ results: [] });
+    expect(screen.getByText("No items available")).toBeTruthy();
+  });
+
+  it("renders the listbox normally when isLoading is true but results exist", () => {
+    renderPalette({ isLoading: true, results: [{ id: "a" }] });
+    expect(screen.getByRole("listbox")).toBeTruthy();
+    expect(screen.queryByText("No items available")).toBeNull();
+  });
+});


### PR DESCRIPTION
## Summary

- Converges palette consumers onto the shared `SearchablePalette` shell, eliminating five recurring drift patterns across 10+ palette components
- Removes `keyHint` from the public API, deduplicates inline `KBD_CLASS` strings, replaces `CommandPicker`'s centered spinner with the header progress bar, and fixes the empty state showing during a loading pass
- Sub-task 5 (`emptyShortcut`, `emptyEntityName`, `getActionLabel` sugar) is intentionally deferred until #6936 lands to keep that dependency isolated

Resolves #6937

## Changes

- **`CommandPicker`** — drops the centered `<Spinner />` branch; passes `isLoading` straight through so the header progress bar is the sole loading affordance
- **`SearchablePalette`** — suppresses the empty-state branch while `isLoading` is true (fixes the contradiction between the no-results message and a live progress bar)
- **`keyHint` prop removed** from `AppPaletteDialog.Header` and `SearchablePalette`; `ActionPalette` migrated to `useEffectiveCombo("action.palette.open")`; `CommandPicker` drops its static `"⌘K"` label (no registered keybinding)
- **`KBD_CLASS` deduplication** — `WorktreePalette`, `QuickSwitcher`, `SendToAgentPalette`, `ProjectSwitcherPalette` all import the canonical export from `AppPaletteDialog` instead of restating the 6-class string inline
- **`PanelPalette`** — no-match state moved to `AppPaletteDialog.Empty`, placed outside `role="listbox"` to avoid nesting `role="status"` inside a listbox

## Testing

- `AppPaletteDialogHeader` tests rewritten to cover shortcut-only rendering behavior
- New `SearchablePalette.loading.test.tsx` covers all four `isLoading × results` permutations
- Typecheck, lint, and build all pass; lint ratchet improved by 4 vs baseline