### PR TITLE
fix(github): reclaim wasted row in issues/PRs dropdown

### DIFF
--- a/src/components/GitHub/GitHubDropdownSkeletons.tsx
+++ b/src/components/GitHub/GitHubDropdownSkeletons.tsx
@@ -113,12 +113,13 @@ export function GitHubResourceListSkeleton({
       </div>
 
       {/* Footer — matches GitHubResourceList */}
-      <div className="p-3 border-t border-[var(--border-divider)] flex items-center justify-between shrink-0">
-        <div className="flex items-center gap-1.5 text-xs text-muted-foreground">
+      <div className="p-3 border-t border-[var(--border-divider)] grid grid-cols-[1fr_auto_1fr] items-center shrink-0">
+        <div className="flex items-center gap-1.5 text-xs text-muted-foreground justify-self-start">
           <ExternalLink className="h-3.5 w-3.5" />
-          View on GitHub
+          GitHub
         </div>
-        <div className="flex items-center gap-1.5 text-xs text-muted-foreground">
+        <span aria-hidden="true" />
+        <div className="flex items-center gap-1.5 text-xs text-muted-foreground justify-self-end">
           <Plus className="h-3.5 w-3.5" />
           New
         </div>

--- a/src/components/GitHub/GitHubResourceList.tsx
+++ b/src/components/GitHub/GitHubResourceList.tsx
@@ -798,12 +798,6 @@ export function GitHubResourceList({
               </p>
             );
           })()}
-
-        {!error && !loading && lastUpdatedAt != null && !debouncedSearch && (
-          <p className="text-[10px] text-muted-foreground/60 px-1">
-            Updated <LiveTimeAgo timestamp={lastUpdatedAt} />
-          </p>
-        )}
       </div>
 
       <div className="flex-1 min-h-0 flex flex-col relative">
@@ -941,21 +935,28 @@ export function GitHubResourceList({
         {!loading && !error && !data.length && renderEmpty()}
       </div>
 
-      <div className="p-3 border-t border-[var(--border-divider)] flex items-center justify-between shrink-0">
+      <div className="p-3 border-t border-[var(--border-divider)] grid grid-cols-[1fr_auto_1fr] items-center shrink-0">
         <Button
           variant="ghost"
           size="sm"
           onClick={handleOpenInGitHub}
-          className="text-muted-foreground hover:text-daintree-text gap-1.5"
+          className="text-muted-foreground hover:text-daintree-text gap-1.5 justify-self-start"
         >
           <ExternalLink className="h-3.5 w-3.5" />
-          View on GitHub
+          GitHub
         </Button>
+        {!error && !loading && lastUpdatedAt != null && !debouncedSearch ? (
+          <p className="text-[10px] text-muted-foreground/60 whitespace-nowrap text-center">
+            Updated <LiveTimeAgo timestamp={lastUpdatedAt} />
+          </p>
+        ) : (
+          <span aria-hidden="true" />
+        )}
         <Button
           variant="ghost"
           size="sm"
           onClick={handleCreateNew}
-          className="text-muted-foreground hover:text-daintree-text gap-1.5"
+          className="text-muted-foreground hover:text-daintree-text gap-1.5 justify-self-end"
         >
           <Plus className="h-3.5 w-3.5" />
           New


### PR DESCRIPTION
## Summary

- Removes the dedicated `Updated <time>` row above the GitHub issues/PRs list and moves the timestamp into the footer, centred between the two buttons
- Renames the left footer button from `View on GitHub` to `GitHub` — the external-link icon already signals the destination, so the longer label is redundant
- Footer layout changes from `flex justify-between` to `grid grid-cols-[1fr_auto_1fr] items-center` to hold the three elements in place; skeleton component mirrors the same grid structure

Resolves #6950

## Changes

- `src/components/GitHub/GitHubResourceList.tsx` — removed standalone freshness row, converted footer to three-column grid, centred conditional `<p>Updated <LiveTimeAgo /></p>` with empty `<span aria-hidden />` placeholder when unavailable
- `src/components/GitHub/GitHubDropdownSkeletons.tsx` — mirrored grid restructure with empty centre placeholder; renamed button label

## Testing

82 vitest tests across the two relevant test files pass. Full check suite (typecheck + lint + format + build) clean. The inline error banner's `· Updated <time>` span is deliberately untouched — that's a different surface showing staleness alongside an error, not the steady-state freshness row.