### PR TITLE
fix(assistant): close + New session dock-leak race (#6951)

### DIFF
--- a/src/components/HelpPanel/HelpPanel.tsx
+++ b/src/components/HelpPanel/HelpPanel.tsx
@@ -206,6 +206,13 @@ export function HelpPanel({ width: effectiveWidth, isVisible: isVisibleProp }: H
   // from a project switch without this flag (issue #6758).
   const isSystemSuspendedRef = useRef(false);
 
+  // Tracks an id reserved by doNewSession / handleRunAnyway that has been
+  // pre-recorded in helpPanelStore *before* addPanel commits the new panel
+  // to panelsById. Without this, the cleanup effect below would observe
+  // `terminalId && !terminal` during the provision/spawn await and wipe the
+  // reservation — re-opening the dock-filter gap that #6951 is closing.
+  const pendingNewTerminalIdRef = useRef<string | null>(null);
+
   const revokePendingSession = useCallback(() => {
     const pending = pendingSessionIdRef.current;
     if (pending) {
@@ -216,10 +223,12 @@ export function HelpPanel({ width: effectiveWidth, isVisible: isVisibleProp }: H
 
   // Revoke the bound help session if the underlying PTY panel disappears from
   // the panel store. addPanel puts the placeholder in panelsById before
-  // setTerminal records the id here, so a missing entry means the process
-  // exited and removePanel was called from elsewhere.
+  // setTerminal records the id here, so a missing entry usually means the
+  // process exited and removePanel was called from elsewhere — except during
+  // the brief window where the +New session / Run-anyway flows have reserved
+  // the id but addPanel has not yet committed it (guarded by the ref).
   useEffect(() => {
-    if (terminalId && !terminal) {
+    if (terminalId && !terminal && terminalId !== pendingNewTerminalIdRef.current) {
       const { sessionId } = useHelpPanelStore.getState();
       revokeHelpSession(sessionId);
       clearTerminal();
@@ -589,7 +598,10 @@ export function HelpPanel({ width: effectiveWidth, isVisible: isVisibleProp }: H
     // `addPanel` commits the new panel — not one microtask later. Without
     // this, the gap between `addPanel` resolving and `setTerminal` running
     // leaves a stray help terminal visible in the dock for one render.
+    // The ref tells the line-221 cleanup effect to leave the reservation
+    // alone while addPanel is still in flight (panelsById[newId] absent).
     const newId = `terminal-${crypto.randomUUID()}`;
+    pendingNewTerminalIdRef.current = newId;
 
     isLaunchingRef.current = true;
     removePanel(terminalId);
@@ -604,6 +616,7 @@ export function HelpPanel({ width: effectiveWidth, isVisible: isVisibleProp }: H
         try {
           const outcome = await provisionHelpSession();
           if (outcome && !outcome.ok) {
+            pendingNewTerminalIdRef.current = null;
             useHelpPanelStore.getState().clearTerminal();
             if (outcome.code === "MCP_NOT_READY") {
               notifyMcpNotReady(outcome.message);
@@ -636,6 +649,7 @@ export function HelpPanel({ width: effectiveWidth, isVisible: isVisibleProp }: H
           });
 
           if (!returnedId) {
+            pendingNewTerminalIdRef.current = null;
             useHelpPanelStore.getState().clearTerminal();
             revokeHelpSession(session?.sessionId ?? null);
             logError("Help new-session returned no terminal id", { agentId: launchAgentId });
@@ -643,6 +657,7 @@ export function HelpPanel({ width: effectiveWidth, isVisible: isVisibleProp }: H
             return;
           }
 
+          pendingNewTerminalIdRef.current = null;
           useHelpPanelStore
             .getState()
             .setTerminal(newId, launchAgentId, session?.sessionId ?? null);
@@ -650,6 +665,7 @@ export function HelpPanel({ width: effectiveWidth, isVisible: isVisibleProp }: H
             logError("Failed to mark help terminal", err);
           });
         } catch (error) {
+          pendingNewTerminalIdRef.current = null;
           useHelpPanelStore.getState().clearTerminal();
           revokeHelpSession(session?.sessionId ?? null);
           logError("Help new-session failed", error);
@@ -721,12 +737,15 @@ export function HelpPanel({ width: effectiveWidth, isVisible: isVisibleProp }: H
 
     // Reserve the new terminal id synchronously so the dock filter is
     // active the instant `addPanel` commits — see doNewSession for the full
-    // rationale; this path has the identical race.
+    // rationale; this path has the identical race. The ref guards the
+    // line-221 cleanup effect during the in-flight window.
     const newId = `terminal-${crypto.randomUUID()}`;
+    pendingNewTerminalIdRef.current = newId;
 
     isLaunchingRef.current = true;
     removePanel(terminalId);
     revokeHelpSession(previousSessionId);
+    revokePendingSession();
     clearTerminal();
     useHelpPanelStore.getState().setTerminal(newId, launchAgentId, null);
 
@@ -736,6 +755,7 @@ export function HelpPanel({ width: effectiveWidth, isVisible: isVisibleProp }: H
         try {
           const outcome = await provisionHelpSession();
           if (outcome && !outcome.ok) {
+            pendingNewTerminalIdRef.current = null;
             useHelpPanelStore.getState().clearTerminal();
             if (outcome.code === "MCP_NOT_READY") {
               notifyMcpNotReady(outcome.message);
@@ -768,6 +788,7 @@ export function HelpPanel({ width: effectiveWidth, isVisible: isVisibleProp }: H
           });
 
           if (!returnedId) {
+            pendingNewTerminalIdRef.current = null;
             useHelpPanelStore.getState().clearTerminal();
             revokeHelpSession(session?.sessionId ?? null);
             logError("Help run-anyway returned no terminal id", { agentId: launchAgentId });
@@ -775,6 +796,7 @@ export function HelpPanel({ width: effectiveWidth, isVisible: isVisibleProp }: H
             return;
           }
 
+          pendingNewTerminalIdRef.current = null;
           useHelpPanelStore
             .getState()
             .setTerminal(newId, launchAgentId, session?.sessionId ?? null);
@@ -782,6 +804,7 @@ export function HelpPanel({ width: effectiveWidth, isVisible: isVisibleProp }: H
             logError("Failed to mark help terminal", err);
           });
         } catch (error) {
+          pendingNewTerminalIdRef.current = null;
           useHelpPanelStore.getState().clearTerminal();
           revokeHelpSession(session?.sessionId ?? null);
           logError("Help run-anyway failed", error);
@@ -792,7 +815,7 @@ export function HelpPanel({ width: effectiveWidth, isVisible: isVisibleProp }: H
       })(),
       { context: "Help: run-anyway re-launch" }
     );
-  }, [terminalId, agentId, removePanel, clearTerminal]);
+  }, [terminalId, agentId, removePanel, clearTerminal, revokePendingSession]);
 
   const getRefreshTier = useMemo(() => {
     return () => {

--- a/src/components/HelpPanel/HelpPanel.tsx
+++ b/src/components/HelpPanel/HelpPanel.tsx
@@ -584,11 +584,19 @@ export function HelpPanel({ width: effectiveWidth, isVisible: isVisibleProp }: H
     const launchAgentId = agentId;
     const previousSessionId = useHelpPanelStore.getState().sessionId;
 
+    // Reserve the new terminal id synchronously so the dock filter
+    // (`helpTerminalId` exclusion in ContentDock) is active the moment
+    // `addPanel` commits the new panel — not one microtask later. Without
+    // this, the gap between `addPanel` resolving and `setTerminal` running
+    // leaves a stray help terminal visible in the dock for one render.
+    const newId = `terminal-${crypto.randomUUID()}`;
+
     isLaunchingRef.current = true;
     removePanel(terminalId);
     revokeHelpSession(previousSessionId);
     revokePendingSession();
     clearTerminal();
+    useHelpPanelStore.getState().setTerminal(newId, launchAgentId, null);
 
     safeFireAndForget(
       (async () => {
@@ -596,6 +604,7 @@ export function HelpPanel({ width: effectiveWidth, isVisible: isVisibleProp }: H
         try {
           const outcome = await provisionHelpSession();
           if (outcome && !outcome.ok) {
+            useHelpPanelStore.getState().clearTerminal();
             if (outcome.code === "MCP_NOT_READY") {
               notifyMcpNotReady(outcome.message);
             } else {
@@ -610,7 +619,7 @@ export function HelpPanel({ width: effectiveWidth, isVisible: isVisibleProp }: H
           const env: Record<string, string> | undefined =
             helpEnv || presetEnv ? { ...(presetEnv ?? {}), ...(helpEnv ?? {}) } : undefined;
 
-          const newId = await usePanelStore.getState().addPanel({
+          const returnedId = await usePanelStore.getState().addPanel({
             kind: "terminal",
             launchAgentId,
             command: panel.command,
@@ -622,9 +631,12 @@ export function HelpPanel({ width: effectiveWidth, isVisible: isVisibleProp }: H
             agentModelId: panel.agentModelId,
             agentPresetId: panel.agentPresetId,
             env,
+            requestedId: newId,
+            activateDockOnCreate: true,
           });
 
-          if (!newId) {
+          if (!returnedId) {
+            useHelpPanelStore.getState().clearTerminal();
             revokeHelpSession(session?.sessionId ?? null);
             logError("Help new-session returned no terminal id", { agentId: launchAgentId });
             notifyLaunchFailed(launchAgentId, "The agent didn't start. Try again.");
@@ -638,6 +650,7 @@ export function HelpPanel({ width: effectiveWidth, isVisible: isVisibleProp }: H
             logError("Failed to mark help terminal", err);
           });
         } catch (error) {
+          useHelpPanelStore.getState().clearTerminal();
           revokeHelpSession(session?.sessionId ?? null);
           logError("Help new-session failed", error);
           notifyLaunchFailed(launchAgentId, "The agent didn't start. Try again.");
@@ -706,10 +719,16 @@ export function HelpPanel({ width: effectiveWidth, isVisible: isVisibleProp }: H
     const launchAgentId = agentId;
     const previousSessionId = useHelpPanelStore.getState().sessionId;
 
+    // Reserve the new terminal id synchronously so the dock filter is
+    // active the instant `addPanel` commits — see doNewSession for the full
+    // rationale; this path has the identical race.
+    const newId = `terminal-${crypto.randomUUID()}`;
+
     isLaunchingRef.current = true;
     removePanel(terminalId);
     revokeHelpSession(previousSessionId);
     clearTerminal();
+    useHelpPanelStore.getState().setTerminal(newId, launchAgentId, null);
 
     safeFireAndForget(
       (async () => {
@@ -717,6 +736,7 @@ export function HelpPanel({ width: effectiveWidth, isVisible: isVisibleProp }: H
         try {
           const outcome = await provisionHelpSession();
           if (outcome && !outcome.ok) {
+            useHelpPanelStore.getState().clearTerminal();
             if (outcome.code === "MCP_NOT_READY") {
               notifyMcpNotReady(outcome.message);
             } else {
@@ -731,7 +751,7 @@ export function HelpPanel({ width: effectiveWidth, isVisible: isVisibleProp }: H
           const env: Record<string, string> | undefined =
             helpEnv || presetEnv ? { ...(presetEnv ?? {}), ...(helpEnv ?? {}) } : undefined;
 
-          const newId = await usePanelStore.getState().addPanel({
+          const returnedId = await usePanelStore.getState().addPanel({
             kind: "terminal",
             launchAgentId,
             command: panel.command,
@@ -743,9 +763,12 @@ export function HelpPanel({ width: effectiveWidth, isVisible: isVisibleProp }: H
             agentModelId: panel.agentModelId,
             agentPresetId: panel.agentPresetId,
             env,
+            requestedId: newId,
+            activateDockOnCreate: true,
           });
 
-          if (!newId) {
+          if (!returnedId) {
+            useHelpPanelStore.getState().clearTerminal();
             revokeHelpSession(session?.sessionId ?? null);
             logError("Help run-anyway returned no terminal id", { agentId: launchAgentId });
             notifyLaunchFailed(launchAgentId, "The agent didn't start. Try again.");
@@ -759,6 +782,7 @@ export function HelpPanel({ width: effectiveWidth, isVisible: isVisibleProp }: H
             logError("Failed to mark help terminal", err);
           });
         } catch (error) {
+          useHelpPanelStore.getState().clearTerminal();
           revokeHelpSession(session?.sessionId ?? null);
           logError("Help run-anyway failed", error);
           notifyLaunchFailed(launchAgentId, "The agent didn't start. Try again.");

--- a/src/components/HelpPanel/__tests__/HelpPanel.helpLaunch.test.tsx
+++ b/src/components/HelpPanel/__tests__/HelpPanel.helpLaunch.test.tsx
@@ -1602,6 +1602,68 @@ describe("HelpPanel — + New session destructive reset", () => {
     expect(setCalls.length).toBe(1);
     expect(helpPanelState.clearTerminal).toHaveBeenCalled();
   });
+
+  it("does NOT wipe the reservation when the cleanup effect re-runs mid-launch", async () => {
+    // Regression: without the pendingNewTerminalIdRef guard in the cleanup
+    // effect at HelpPanel.tsx:221, a re-render fired while
+    // `terminalId === newId` but `panelsById[newId]` is not yet committed
+    // would observe `terminalId && !terminal` and call clearTerminal —
+    // re-opening the dock-leak gap that #6951 closes. This test wires up a
+    // stateful setTerminal/clearTerminal so React actually sees the
+    // intermediate state (the standard mocks are vi.fn() and don't mutate).
+    setupBoundTerminal({ agentState: "idle", conversationTouched: false });
+
+    helpPanelState.setTerminal = vi
+      .fn()
+      .mockImplementation((tId: string, aId: string, sId: string | null) => {
+        helpPanelState.terminalId = tId;
+        helpPanelState.agentId = aId;
+        helpPanelState.sessionId = sId;
+      });
+    helpPanelState.clearTerminal = vi.fn().mockImplementation(() => {
+      helpPanelState.terminalId = null;
+      helpPanelState.agentId = null;
+      helpPanelState.sessionId = null;
+    });
+
+    // Hold provisionHelpSession to keep us in the in-flight window.
+    let resolveProvision: ((value: unknown) => void) | undefined;
+    mockProvisionSession.mockImplementation(
+      () =>
+        new Promise((r) => {
+          resolveProvision = r;
+        })
+    );
+
+    panelStoreState.addPanel = vi
+      .fn()
+      .mockImplementation((opts: { requestedId?: string }) =>
+        Promise.resolve(opts.requestedId ?? "fresh")
+      );
+
+    const { container, rerender } = render(<HelpPanel width={380} />);
+
+    await act(async () => {
+      fireEvent.click(container.querySelector('button[aria-label="Start new session"]')!);
+    });
+
+    // We're in the in-flight window. Force a re-render so the cleanup
+    // effect re-evaluates: terminalId is the reserved id, panelsById has
+    // no entry for it yet. The ref guard must suppress the cleanup.
+    await act(async () => {
+      rerender(<HelpPanel width={380} />);
+    });
+
+    // Exactly one clearTerminal call (the explicit synchronous reset
+    // before the pre-set). If the effect had fired, we'd see 2+.
+    expect(helpPanelState.clearTerminal).toHaveBeenCalledTimes(1);
+    expect(helpPanelState.terminalId).toMatch(/^terminal-/);
+
+    // Drain the pending promise so vitest's act() doesn't warn.
+    await act(async () => {
+      resolveProvision?.(null);
+    });
+  });
 });
 
 describe("HelpPanel — visibilitychange teardown vs. system sleep (issue #6758)", () => {

--- a/src/components/HelpPanel/__tests__/HelpPanel.helpLaunch.test.tsx
+++ b/src/components/HelpPanel/__tests__/HelpPanel.helpLaunch.test.tsx
@@ -688,7 +688,11 @@ describe("HelpPanel — handleRunAnyway", () => {
     cliAvailabilityState.details = {
       claude: { state: "missing", resolvedPath: null, via: null },
     };
-    panelStoreState.addPanel = vi.fn().mockResolvedValue("restarted-term");
+    panelStoreState.addPanel = vi
+      .fn()
+      .mockImplementation((opts: { requestedId?: string }) =>
+        Promise.resolve(opts.requestedId ?? "restarted-term")
+      );
 
     const { getByTestId } = render(<HelpPanel width={380} />);
 
@@ -698,13 +702,23 @@ describe("HelpPanel — handleRunAnyway", () => {
 
     expect(panelStoreState.removePanel).toHaveBeenCalledWith("gate-1");
     expect(panelStoreState.addPanel).toHaveBeenCalledWith(
-      expect.objectContaining({ kind: "terminal", launchAgentId: "claude", cwd: "/help" })
+      expect.objectContaining({
+        kind: "terminal",
+        launchAgentId: "claude",
+        cwd: "/help",
+        requestedId: expect.stringMatching(/^terminal-/),
+        activateDockOnCreate: true,
+      })
     );
-    expect(helpPanelState.setTerminal).toHaveBeenCalledWith("restarted-term", "claude", null);
-    expect(mockMarkTerminal).toHaveBeenCalledWith("restarted-term");
+    expect(helpPanelState.setTerminal).toHaveBeenCalledWith(
+      expect.stringMatching(/^terminal-/),
+      "claude",
+      null
+    );
+    expect(mockMarkTerminal).toHaveBeenCalledWith(expect.stringMatching(/^terminal-/));
   });
 
-  it("notifies on addPanel rejection", async () => {
+  it("notifies and reverts the reserved help-terminal id on addPanel rejection", async () => {
     helpPanelState.terminalId = "gate-1";
     helpPanelState.agentId = "claude";
     panelStoreState.panelsById = {
@@ -729,10 +743,95 @@ describe("HelpPanel — handleRunAnyway", () => {
       fireEvent.click(getByTestId("run-anyway"));
     });
 
-    expect(helpPanelState.setTerminal).not.toHaveBeenCalled();
+    // The pre-set fired once (reserving the slot), then clearTerminal reverted it
+    // when addPanel rejected — so no second setTerminal call carrying a session id.
+    expect(helpPanelState.setTerminal).toHaveBeenCalledTimes(1);
+    expect(helpPanelState.setTerminal).toHaveBeenCalledWith(
+      expect.stringMatching(/^terminal-/),
+      "claude",
+      null
+    );
+    expect(helpPanelState.clearTerminal).toHaveBeenCalled();
     expect(mockNotify).toHaveBeenCalledWith(
       expect.objectContaining({ type: "error", title: "Assistant launch failed" })
     );
+  });
+
+  it("reserves the new help-terminal id BEFORE addPanel resolves (race fix for #6951)", async () => {
+    helpPanelState.terminalId = "gate-1";
+    helpPanelState.agentId = "claude";
+    panelStoreState.panelsById = {
+      "gate-1": {
+        id: "gate-1",
+        kind: "terminal",
+        spawnStatus: "missing-cli",
+        cwd: "/help",
+        title: "Claude",
+        command: "claude",
+        location: "dock",
+      },
+    };
+    cliAvailabilityState.details = {
+      claude: { state: "missing", resolvedPath: null, via: null },
+    };
+
+    // Hold addPanel resolution until after we've inspected store state.
+    let resolveAdd: (value: string) => void = () => {};
+    let capturedRequestedId: string | undefined;
+    panelStoreState.addPanel = vi.fn().mockImplementation((opts: { requestedId?: string }) => {
+      capturedRequestedId = opts.requestedId;
+      return new Promise<string>((r) => {
+        resolveAdd = r;
+      });
+    });
+
+    const { getByTestId } = render(<HelpPanel width={380} />);
+
+    await act(async () => {
+      fireEvent.click(getByTestId("run-anyway"));
+    });
+
+    // setTerminal fired with the pre-generated id while addPanel is still pending.
+    expect(capturedRequestedId).toMatch(/^terminal-/);
+    expect(helpPanelState.setTerminal).toHaveBeenCalledWith(capturedRequestedId, "claude", null);
+
+    await act(async () => {
+      resolveAdd(capturedRequestedId!);
+    });
+  });
+
+  it("reverts the reserved id when provisionHelpSession returns a non-ok outcome", async () => {
+    helpPanelState.terminalId = "gate-1";
+    helpPanelState.agentId = "claude";
+    panelStoreState.panelsById = {
+      "gate-1": {
+        id: "gate-1",
+        kind: "terminal",
+        spawnStatus: "missing-cli",
+        cwd: "/help",
+        title: "Claude",
+        command: "claude",
+        location: "dock",
+      },
+    };
+    cliAvailabilityState.details = {
+      claude: { state: "missing", resolvedPath: null, via: null },
+    };
+    projectStoreState.currentProject = { id: "proj-1", path: "/repo" };
+    const mcpErr = new Error("MCP server not ready") as Error & { code: string };
+    mcpErr.code = "MCP_NOT_READY";
+    mockProvisionSession.mockRejectedValueOnce(mcpErr);
+
+    const { getByTestId } = render(<HelpPanel width={380} />);
+
+    await act(async () => {
+      fireEvent.click(getByTestId("run-anyway"));
+    });
+
+    // Pre-set fired, then was reverted by the !outcome.ok branch.
+    expect(helpPanelState.setTerminal).toHaveBeenCalledTimes(1);
+    expect(helpPanelState.clearTerminal).toHaveBeenCalled();
+    expect(panelStoreState.addPanel).not.toHaveBeenCalled();
   });
 
   it("revokes the freshly-provisioned session when addPanel throws (regression: leaked token)", async () => {
@@ -1288,7 +1387,11 @@ describe("HelpPanel — + New session destructive reset", () => {
 
   it("resets immediately without a confirm when the agent is idle and conversation is untouched", async () => {
     setupBoundTerminal({ agentState: "idle", conversationTouched: false });
-    panelStoreState.addPanel = vi.fn().mockResolvedValue("fresh-term");
+    panelStoreState.addPanel = vi
+      .fn()
+      .mockImplementation((opts: { requestedId?: string }) =>
+        Promise.resolve(opts.requestedId ?? "fresh-term")
+      );
     mockProvisionSession.mockResolvedValue({
       sessionId: "sess-fresh",
       sessionPath: "/sessions/fresh",
@@ -1308,9 +1411,18 @@ describe("HelpPanel — + New session destructive reset", () => {
     expect(mockRevokeSession).toHaveBeenCalledWith("sess-bound");
     expect(helpPanelState.clearTerminal).toHaveBeenCalled();
     expect(panelStoreState.addPanel).toHaveBeenCalledWith(
-      expect.objectContaining({ kind: "terminal", launchAgentId: "claude" })
+      expect.objectContaining({
+        kind: "terminal",
+        launchAgentId: "claude",
+        requestedId: expect.stringMatching(/^terminal-/),
+        activateDockOnCreate: true,
+      })
     );
-    expect(helpPanelState.setTerminal).toHaveBeenCalledWith("fresh-term", "claude", "sess-fresh");
+    expect(helpPanelState.setTerminal).toHaveBeenCalledWith(
+      expect.stringMatching(/^terminal-/),
+      "claude",
+      "sess-fresh"
+    );
   });
 
   it("shows the confirm dialog when the agent is working", () => {
@@ -1353,7 +1465,11 @@ describe("HelpPanel — + New session destructive reset", () => {
 
   it("runs the destructive teardown and relaunches when the user confirms", async () => {
     setupBoundTerminal({ agentState: "working", conversationTouched: true });
-    panelStoreState.addPanel = vi.fn().mockResolvedValue("fresh-term");
+    panelStoreState.addPanel = vi
+      .fn()
+      .mockImplementation((opts: { requestedId?: string }) =>
+        Promise.resolve(opts.requestedId ?? "fresh-term")
+      );
     mockProvisionSession.mockResolvedValue({
       sessionId: "sess-fresh",
       sessionPath: "/sessions/fresh",
@@ -1372,7 +1488,119 @@ describe("HelpPanel — + New session destructive reset", () => {
     expect(panelStoreState.removePanel).toHaveBeenCalledWith("term-1");
     expect(mockRevokeSession).toHaveBeenCalledWith("sess-bound");
     expect(helpPanelState.clearTerminal).toHaveBeenCalled();
-    expect(helpPanelState.setTerminal).toHaveBeenCalledWith("fresh-term", "claude", "sess-fresh");
+    expect(helpPanelState.setTerminal).toHaveBeenCalledWith(
+      expect.stringMatching(/^terminal-/),
+      "claude",
+      "sess-fresh"
+    );
+  });
+
+  it("reserves the new help-terminal id BEFORE addPanel resolves (race fix for #6951)", async () => {
+    setupBoundTerminal({ agentState: "idle", conversationTouched: false });
+    mockProvisionSession.mockResolvedValue({
+      sessionId: "sess-fresh",
+      sessionPath: "/sessions/fresh",
+      token: "tok-fresh",
+      tier: "action",
+      mcpUrl: null,
+      windowId: 1,
+    });
+
+    let resolveAdd: (value: string) => void = () => {};
+    let capturedRequestedId: string | undefined;
+    panelStoreState.addPanel = vi.fn().mockImplementation((opts: { requestedId?: string }) => {
+      capturedRequestedId = opts.requestedId;
+      return new Promise<string>((r) => {
+        resolveAdd = r;
+      });
+    });
+
+    const { container } = render(<HelpPanel width={380} />);
+    await act(async () => {
+      fireEvent.click(container.querySelector('button[aria-label="Start new session"]')!);
+    });
+
+    // Pre-set already fired with the same id we passed as requestedId.
+    expect(capturedRequestedId).toMatch(/^terminal-/);
+    expect(helpPanelState.setTerminal).toHaveBeenCalledWith(capturedRequestedId, "claude", null);
+
+    await act(async () => {
+      resolveAdd(capturedRequestedId!);
+    });
+  });
+
+  it("forwards requestedId and activateDockOnCreate to addPanel", async () => {
+    setupBoundTerminal({ agentState: "idle", conversationTouched: false });
+    panelStoreState.addPanel = vi
+      .fn()
+      .mockImplementation((opts: { requestedId?: string }) =>
+        Promise.resolve(opts.requestedId ?? "fresh")
+      );
+    mockProvisionSession.mockResolvedValue({
+      sessionId: "sess-fresh",
+      sessionPath: "/sessions/fresh",
+      token: "tok-fresh",
+      tier: "action",
+      mcpUrl: null,
+      windowId: 1,
+    });
+
+    const { container } = render(<HelpPanel width={380} />);
+    await act(async () => {
+      fireEvent.click(container.querySelector('button[aria-label="Start new session"]')!);
+    });
+
+    expect(panelStoreState.addPanel).toHaveBeenCalledWith(
+      expect.objectContaining({
+        requestedId: expect.stringMatching(/^terminal-/),
+        activateDockOnCreate: true,
+      })
+    );
+  });
+
+  it("reverts the reserved id when addPanel rejects (no ghost helpTerminalId)", async () => {
+    setupBoundTerminal({ agentState: "idle", conversationTouched: false });
+    mockProvisionSession.mockResolvedValue({
+      sessionId: "sess-fresh",
+      sessionPath: "/sessions/fresh",
+      token: "tok-fresh",
+      tier: "action",
+      mcpUrl: null,
+      windowId: 1,
+    });
+    panelStoreState.addPanel = vi.fn().mockRejectedValue(new Error("spawn failed"));
+
+    const { container } = render(<HelpPanel width={380} />);
+    await act(async () => {
+      fireEvent.click(container.querySelector('button[aria-label="Start new session"]')!);
+    });
+
+    // setTerminal called once (pre-set), then clearTerminal reverted it on catch.
+    // setTerminal must NOT be called again with a session id.
+    const setCalls = (helpPanelState.setTerminal as ReturnType<typeof vi.fn>).mock.calls;
+    expect(setCalls.length).toBe(1);
+    expect(setCalls[0]?.[2]).toBeNull();
+    expect(helpPanelState.clearTerminal).toHaveBeenCalled();
+    expect(mockNotify).toHaveBeenCalledWith(
+      expect.objectContaining({ type: "error", title: "Assistant launch failed" })
+    );
+  });
+
+  it("reverts the reserved id when provisionHelpSession returns a non-ok outcome", async () => {
+    setupBoundTerminal({ agentState: "idle", conversationTouched: false });
+    const mcpErr = new Error("MCP server not ready") as Error & { code: string };
+    mcpErr.code = "MCP_NOT_READY";
+    mockProvisionSession.mockRejectedValueOnce(mcpErr);
+
+    const { container } = render(<HelpPanel width={380} />);
+    await act(async () => {
+      fireEvent.click(container.querySelector('button[aria-label="Start new session"]')!);
+    });
+
+    expect(panelStoreState.addPanel).not.toHaveBeenCalled();
+    const setCalls = (helpPanelState.setTerminal as ReturnType<typeof vi.fn>).mock.calls;
+    expect(setCalls.length).toBe(1);
+    expect(helpPanelState.clearTerminal).toHaveBeenCalled();
   });
 });
 


### PR DESCRIPTION
## Summary

- The `+ New session` button occasionally left a stray terminal in the dock due to a race between `addPanel` resolving and `setTerminal` updating `helpPanelStore` — during that window, the dock filter didn't have the new id yet and rendered the panel unfiltered
- Fix pre-generates the panel id and synchronously registers it in `helpPanelStore` before calling `addPanel`, so the dock filter always has the id in time; all failure paths call `clearTerminal` to clean up the reservation
- A `pendingNewTerminalIdRef` guards the cleanup effect so it can't wipe the reservation during the in-flight window; `handleRunAnyway` gets the same `revokePendingSession()` call for parity with `doNewSession`

Resolves #6951

## Changes

- `src/components/HelpPanel/HelpPanel.tsx` — pre-generate panel id via `generatePanelId()`, synchronously set `helpPanelStore.terminalId`, forward `requestedId` + `activateDockOnCreate: false` to `addPanel`, revert with `clearTerminal` on every failure path; `pendingNewTerminalIdRef` gates the line-221 cleanup effect; `handleRunAnyway` gets `revokePendingSession()`
- `src/components/HelpPanel/__tests__/HelpPanel.helpLaunch.test.tsx` — new regression test covering the cleanup-effect race; 68 tests pass

## Testing

- `HelpPanel.helpLaunch.test.tsx` — 68 tests pass, including the new regression for the cleanup-effect race
- `ContentDock.test.tsx` — 8 tests pass
- Typecheck, lint, and format all clean