### PR TITLE
feat(assistant): hibernate idle Daintree Assistant by capturing Claude resume code

### DIFF
--- a/electron/ipc/handlers/__tests__/helpAssistant.handlers.test.ts
+++ b/electron/ipc/handlers/__tests__/helpAssistant.handlers.test.ts
@@ -215,7 +215,9 @@ describe("registerHelpAssistantHandlers", () => {
   });
 
   it("rejects an out-of-range stored idleHibernateMinutes and falls back to default", async () => {
-    storeMock.get.mockReturnValue({ idleHibernateMinutes: 999 });
+    storeMock.get.mockReturnValue({
+      idleHibernateMinutes: 999,
+    } as unknown as Partial<HelpAssistantSettings>);
     registerHelpAssistantHandlers();
     const handler = ipcMainMock._handlers.get(GET_CHANNEL)!;
 

--- a/electron/ipc/handlers/__tests__/helpAssistant.handlers.test.ts
+++ b/electron/ipc/handlers/__tests__/helpAssistant.handlers.test.ts
@@ -58,6 +58,7 @@ describe("registerHelpAssistantHandlers", () => {
       skipPermissions: false,
       auditRetention: 7,
       customArgs: "",
+      idleHibernateMinutes: 30,
     });
   });
 
@@ -73,6 +74,7 @@ describe("registerHelpAssistantHandlers", () => {
       skipPermissions: true,
       auditRetention: 30,
       customArgs: "",
+      idleHibernateMinutes: 30,
     });
   });
 
@@ -171,7 +173,54 @@ describe("registerHelpAssistantHandlers", () => {
       skipPermissions: false,
       auditRetention: 7,
       customArgs: "",
+      idleHibernateMinutes: 30,
     });
+  });
+
+  it("rejects idleHibernateMinutes values outside the supported set", async () => {
+    registerHelpAssistantHandlers();
+    const handler = ipcMainMock._handlers.get(SET_CHANNEL)!;
+
+    await handler(null, { idleHibernateMinutes: 5 });
+    await handler(null, { idleHibernateMinutes: 45 });
+    await handler(null, { idleHibernateMinutes: -1 });
+    await handler(null, { idleHibernateMinutes: "30" });
+
+    expect(storeMock.set).not.toHaveBeenCalled();
+  });
+
+  it("accepts each valid idleHibernateMinutes value", async () => {
+    registerHelpAssistantHandlers();
+    const handler = ipcMainMock._handlers.get(SET_CHANNEL)!;
+
+    for (const minutes of [0, 15, 30, 60, 120]) {
+      await handler(null, { idleHibernateMinutes: minutes });
+    }
+
+    expect(storeMock.set).toHaveBeenCalledTimes(5);
+    expect(storeMock.set).toHaveBeenCalledWith("helpAssistant.idleHibernateMinutes", 0);
+    expect(storeMock.set).toHaveBeenCalledWith("helpAssistant.idleHibernateMinutes", 15);
+    expect(storeMock.set).toHaveBeenCalledWith("helpAssistant.idleHibernateMinutes", 30);
+    expect(storeMock.set).toHaveBeenCalledWith("helpAssistant.idleHibernateMinutes", 60);
+    expect(storeMock.set).toHaveBeenCalledWith("helpAssistant.idleHibernateMinutes", 120);
+  });
+
+  it("loads a valid stored idleHibernateMinutes from the store", async () => {
+    storeMock.get.mockReturnValue({ idleHibernateMinutes: 60 });
+    registerHelpAssistantHandlers();
+    const handler = ipcMainMock._handlers.get(GET_CHANNEL)!;
+
+    const result = await handler(null);
+    expect(result).toMatchObject({ idleHibernateMinutes: 60 });
+  });
+
+  it("rejects an out-of-range stored idleHibernateMinutes and falls back to default", async () => {
+    storeMock.get.mockReturnValue({ idleHibernateMinutes: 999 });
+    registerHelpAssistantHandlers();
+    const handler = ipcMainMock._handlers.get(GET_CHANNEL)!;
+
+    const result = await handler(null);
+    expect(result).toMatchObject({ idleHibernateMinutes: 30 });
   });
 
   it("persists a valid customArgs string", async () => {

--- a/electron/ipc/handlers/helpAssistant.ts
+++ b/electron/ipc/handlers/helpAssistant.ts
@@ -3,6 +3,7 @@ import { store } from "../../store.js";
 import { typedHandle } from "../utils.js";
 import type {
   HelpAssistantAuditRetention,
+  HelpAssistantIdleHibernateMinutes,
   HelpAssistantSettings,
 } from "../../../shared/types/ipc/api.js";
 import type * as McpServerServiceModule from "../../services/McpServerService.js";
@@ -26,6 +27,7 @@ const HELP_ASSISTANT_DEFAULTS: HelpAssistantSettings = {
   skipPermissions: false,
   auditRetention: 7,
   customArgs: "",
+  idleHibernateMinutes: 30,
 };
 
 const HELP_ASSISTANT_KEYS = [
@@ -34,12 +36,17 @@ const HELP_ASSISTANT_KEYS = [
   "skipPermissions",
   "auditRetention",
   "customArgs",
+  "idleHibernateMinutes",
 ] as const satisfies ReadonlyArray<keyof HelpAssistantSettings>;
 
 const KNOWN_KEYS: ReadonlySet<string> = new Set(HELP_ASSISTANT_KEYS);
 
 function isValidAuditRetention(value: unknown): value is HelpAssistantAuditRetention {
   return value === 0 || value === 7 || value === 30;
+}
+
+function isValidIdleHibernateMinutes(value: unknown): value is HelpAssistantIdleHibernateMinutes {
+  return value === 0 || value === 15 || value === 30 || value === 60 || value === 120;
 }
 
 // Mirrors `customFlags` validation in src/config/agents.ts: the value is
@@ -68,6 +75,9 @@ function sanitizeStored(stored: unknown): Partial<HelpAssistantSettings> {
   if (typeof record.daintreeControl === "boolean") out.daintreeControl = record.daintreeControl;
   if (typeof record.skipPermissions === "boolean") out.skipPermissions = record.skipPermissions;
   if (isValidAuditRetention(record.auditRetention)) out.auditRetention = record.auditRetention;
+  if (isValidIdleHibernateMinutes(record.idleHibernateMinutes)) {
+    out.idleHibernateMinutes = record.idleHibernateMinutes;
+  }
   const sanitizedArgs = sanitizeCustomArgs(record.customArgs);
   if (sanitizedArgs !== undefined) out.customArgs = sanitizedArgs;
   return out;
@@ -90,6 +100,7 @@ export function registerHelpAssistantHandlers(): () => void {
       if (value === undefined) continue;
       if (!KNOWN_KEYS.has(field)) continue;
       if (field === "auditRetention" && !isValidAuditRetention(value)) continue;
+      if (field === "idleHibernateMinutes" && !isValidIdleHibernateMinutes(value)) continue;
       if (
         (field === "docSearch" || field === "daintreeControl" || field === "skipPermissions") &&
         typeof value !== "boolean"

--- a/shared/types/index.ts
+++ b/shared/types/index.ts
@@ -237,6 +237,7 @@ export type {
   VoiceParagraphingStrategy,
   HelpAssistantSettings,
   HelpAssistantAuditRetention,
+  HelpAssistantIdleHibernateMinutes,
   MicPermissionStatus,
   BranchInfo,
   CreateWorktreeOptions,

--- a/shared/types/ipc/api.ts
+++ b/shared/types/ipc/api.ts
@@ -1491,6 +1491,8 @@ export interface VoiceInputSettings {
 
 export type HelpAssistantAuditRetention = 7 | 30 | 0;
 
+export type HelpAssistantIdleHibernateMinutes = 0 | 15 | 30 | 60 | 120;
+
 export interface HelpAssistantSettings {
   /** Allow the help assistant to search Daintree documentation. Defaults to true. */
   docSearch: boolean;
@@ -1502,4 +1504,10 @@ export interface HelpAssistantSettings {
   auditRetention: HelpAssistantAuditRetention;
   /** Whitespace-separated CLI flags appended at assistant launch (e.g. "--model sonnet"). Defaults to "". */
   customArgs: string;
+  /**
+   * Minutes the assistant panel must be continuously hidden before its PTY is
+   * gracefully shut down to capture the Claude resume session ID. 0 disables
+   * idle hibernation. Defaults to 30.
+   */
+  idleHibernateMinutes: HelpAssistantIdleHibernateMinutes;
 }

--- a/src/components/HelpPanel/HelpPanel.tsx
+++ b/src/components/HelpPanel/HelpPanel.tsx
@@ -394,82 +394,88 @@ export function HelpPanel({
       const sessionToRevoke = helpState.sessionId;
       const liveAgentId = helpState.agentId ?? initialAgentId;
 
-      void window.electron.terminal
-        .gracefulKill(initialTerminalId)
-        .then((capturedSessionId) => {
-          // State may have changed during the IPC round-trip. Don't act on
-          // stale captures.
-          const after = useHelpPanelStore.getState();
-          if (after.terminalId !== initialTerminalId) return;
-          // Critical race: user reopened the panel while gracefulKill was
-          // in flight. The terminal is still live and visible — don't tear
-          // it down out from under them. The captured session ID is also
-          // discarded; the next hibernation cycle will capture a fresh one.
-          if (after.isOpen) return;
-          if (capturedSessionId && projectId && liveAgentId && cwd) {
-            after.setHibernateSession(projectId, {
-              sessionId: capturedSessionId,
-              cwd,
-              agentId: liveAgentId,
-            });
-          } else if (projectId) {
-            // No session captured — make sure we don't try to resume from a
-            // stale entry on next open.
-            after.clearHibernateSession(projectId);
-          }
-          usePanelStore.getState().removePanel(initialTerminalId);
-          revokeHelpSession(sessionToRevoke);
-          useHelpPanelStore.getState().clearTerminal();
-        })
-        .catch((err) => {
-          // Mirror the .then race-guard: bail if the user has reopened the
-          // panel or the terminal id has been replaced during the IPC.
-          const after = useHelpPanelStore.getState();
-          if (after.terminalId !== initialTerminalId || after.isOpen) return;
-          logError("HelpPanel: gracefulKill during hibernate failed", err);
-          if (projectId) {
-            // Drop any prior hibernate entry so we don't auto-resume from a
-            // potentially stale one after a kill failure.
-            useHelpPanelStore.getState().clearHibernateSession(projectId);
-          }
-          // Fall back to direct removal so we don't leak a hidden PTY.
-          usePanelStore.getState().removePanel(initialTerminalId);
-          revokeHelpSession(sessionToRevoke);
-          useHelpPanelStore.getState().clearTerminal();
-        });
+      safeFireAndForget(
+        window.electron.terminal
+          .gracefulKill(initialTerminalId)
+          .then((capturedSessionId) => {
+            // State may have changed during the IPC round-trip. Don't act on
+            // stale captures.
+            const after = useHelpPanelStore.getState();
+            if (after.terminalId !== initialTerminalId) return;
+            // Critical race: user reopened the panel while gracefulKill was
+            // in flight. The terminal is still live and visible — don't tear
+            // it down out from under them. The captured session ID is also
+            // discarded; the next hibernation cycle will capture a fresh one.
+            if (after.isOpen) return;
+            if (capturedSessionId && projectId && liveAgentId && cwd) {
+              after.setHibernateSession(projectId, {
+                sessionId: capturedSessionId,
+                cwd,
+                agentId: liveAgentId,
+              });
+            } else if (projectId) {
+              // No session captured — make sure we don't try to resume from a
+              // stale entry on next open.
+              after.clearHibernateSession(projectId);
+            }
+            usePanelStore.getState().removePanel(initialTerminalId);
+            revokeHelpSession(sessionToRevoke);
+            useHelpPanelStore.getState().clearTerminal();
+          })
+          .catch((err) => {
+            // Mirror the .then race-guard: bail if the user has reopened the
+            // panel or the terminal id has been replaced during the IPC.
+            const after = useHelpPanelStore.getState();
+            if (after.terminalId !== initialTerminalId || after.isOpen) return;
+            logError("HelpPanel: gracefulKill during hibernate failed", err);
+            if (projectId) {
+              // Drop any prior hibernate entry so we don't auto-resume from a
+              // potentially stale one after a kill failure.
+              useHelpPanelStore.getState().clearHibernateSession(projectId);
+            }
+            // Fall back to direct removal so we don't leak a hidden PTY.
+            usePanelStore.getState().removePanel(initialTerminalId);
+            revokeHelpSession(sessionToRevoke);
+            useHelpPanelStore.getState().clearTerminal();
+          }),
+        { context: "HelpPanel:hibernate gracefulKill" }
+      );
     };
 
-    void window.electron.helpAssistant
-      .getSettings()
-      .then((settings) => {
-        if (cancelled) return;
-        const minutes = settings.idleHibernateMinutes;
-        if (
-          minutes !== 0 &&
-          minutes !== 15 &&
-          minutes !== 30 &&
-          minutes !== 60 &&
-          minutes !== 120
-        ) {
-          // Stored value out of range — fall back to the default rather than
-          // hibernating immediately.
+    safeFireAndForget(
+      window.electron.helpAssistant
+        .getSettings()
+        .then((settings) => {
+          if (cancelled) return;
+          const minutes = settings.idleHibernateMinutes;
+          if (
+            minutes !== 0 &&
+            minutes !== 15 &&
+            minutes !== 30 &&
+            minutes !== 60 &&
+            minutes !== 120
+          ) {
+            // Stored value out of range — fall back to the default rather than
+            // hibernating immediately.
+            hibernateMinutesRef.current = 30;
+          } else {
+            hibernateMinutesRef.current = minutes;
+          }
+          if (hibernateMinutesRef.current <= 0) return;
+          clearTimer();
+          hibernateTimerRef.current = setTimeout(fire, hibernateMinutesRef.current * 60 * 1000);
+        })
+        .catch((err) => {
+          if (cancelled) return;
+          logError("HelpPanel: failed to load idleHibernateMinutes", err);
+          // Fall back to the default so a settings IPC blip doesn't leave the
+          // assistant resident forever.
           hibernateMinutesRef.current = 30;
-        } else {
-          hibernateMinutesRef.current = minutes;
-        }
-        if (hibernateMinutesRef.current <= 0) return;
-        clearTimer();
-        hibernateTimerRef.current = setTimeout(fire, hibernateMinutesRef.current * 60 * 1000);
-      })
-      .catch((err) => {
-        if (cancelled) return;
-        logError("HelpPanel: failed to load idleHibernateMinutes", err);
-        // Fall back to the default so a settings IPC blip doesn't leave the
-        // assistant resident forever.
-        hibernateMinutesRef.current = 30;
-        clearTimer();
-        hibernateTimerRef.current = setTimeout(fire, 30 * 60 * 1000);
-      });
+          clearTimer();
+          hibernateTimerRef.current = setTimeout(fire, 30 * 60 * 1000);
+        }),
+      { context: "HelpPanel:hibernate getSettings" }
+    );
 
     return () => {
       cancelled = true;

--- a/src/components/HelpPanel/HelpPanel.tsx
+++ b/src/components/HelpPanel/HelpPanel.tsx
@@ -1,5 +1,5 @@
 import { Suspense, useCallback, useEffect, useRef, useState, useMemo } from "react";
-import { Settings2, ChevronRight, Plus } from "lucide-react";
+import { Settings2, ChevronRight, Plus, X } from "lucide-react";
 import { cn } from "@/lib/utils";
 import { DaintreeIcon } from "@/components/icons/DaintreeIcon";
 import { XtermAdapter } from "@/components/Terminal/XtermAdapter";
@@ -27,7 +27,8 @@ import { logError } from "@/utils/logger";
 import { formatErrorMessage } from "@shared/utils/errorMessage";
 import { notify } from "@/lib/notify";
 import { safeFireAndForget } from "@/utils/safeFireAndForget";
-import { CLOSE_CONFIRM_AGENT_STATES } from "@shared/types/agent";
+import { ACTIVE_AGENT_STATES, CLOSE_CONFIRM_AGENT_STATES } from "@shared/types/agent";
+import { buildResumeCommand } from "@shared/types/agentSettings";
 import { ConfirmDialog } from "@/components/ui/ConfirmDialog";
 
 const RESIZE_STEP = 10;
@@ -43,6 +44,16 @@ function notifyLaunchFailed(agentId: string, reason: string): void {
     message: `Couldn't start ${name}. ${reason}`,
   });
 }
+
+// Re-checks every 2 minutes while the agent is busy ("working" / "waiting" /
+// "directing"), so hibernation defers cleanly until the conversation is idle
+// without restarting the full hibernate countdown each time.
+const HIBERNATE_BUSY_RECHECK_MS = 2 * 60 * 1000;
+
+// Tier-1 ambient banner auto-dismiss for "Session resumed". The user will
+// usually see it for the moment they return to the panel; long-lived banners
+// distract from the conversation.
+const RESUME_BANNER_AUTO_DISMISS_MS = 10_000;
 
 function notifyMcpNotReady(reason: string): void {
   notify({
@@ -181,6 +192,7 @@ export function HelpPanel({
   const isMacroFocused = useMacroFocusStore((s) => s.focusedRegion === "assistant");
   const isVisible = isVisibleProp ?? effectiveWidth > 0;
   const [showNewSessionConfirm, setShowNewSessionConfirm] = useState(false);
+  const [showResumeBanner, setShowResumeBanner] = useState(false);
 
   const {
     isOpen,
@@ -233,6 +245,12 @@ export function HelpPanel({
   // `terminalId && !terminal` during the provision/spawn await and wipe the
   // reservation — re-opening the dock-filter gap that #6951 is closing.
   const pendingNewTerminalIdRef = useRef<string | null>(null);
+
+  // Last-loaded idle-hibernate setting in minutes (0 = disabled). Re-fetched
+  // each time the timer arms (panel hides) so a settings-tab change takes
+  // effect without remounting the panel.
+  const hibernateMinutesRef = useRef<number>(30);
+  const hibernateTimerRef = useRef<ReturnType<typeof setTimeout> | null>(null);
 
   const revokePendingSession = useCallback(() => {
     const pending = pendingSessionIdRef.current;
@@ -326,8 +344,177 @@ export function HelpPanel({
     }
   }, [terminalId, terminal?.agentState, markConversationStarted]);
 
+  // Idle-hibernate timer. When the panel is hidden with a live terminal,
+  // schedule a graceful kill that captures the agent's resume session ID.
+  // Reads store state via getState() in the callback to avoid stale closures
+  // (#5087 lesson). Defers if the agent is mid-turn so the user's work isn't
+  // interrupted. The hibernate-minutes setting is fetched at arm-time so a
+  // change in the settings tab takes effect on the next hide without a remount.
+  useEffect(() => {
+    const clearTimer = () => {
+      if (hibernateTimerRef.current) {
+        clearTimeout(hibernateTimerRef.current);
+        hibernateTimerRef.current = null;
+      }
+    };
+
+    if (isOpen || !terminalId) {
+      clearTimer();
+      return clearTimer;
+    }
+
+    const initialAgentId = agentId;
+    const initialTerminalId = terminalId;
+    let cancelled = false;
+
+    const fire = () => {
+      hibernateTimerRef.current = null;
+      if (cancelled) return;
+
+      // Re-validate: the terminal we armed for must still match the live one,
+      // and the OS must not be suspended (display-off must not fire teardown).
+      const helpState = useHelpPanelStore.getState();
+      if (helpState.terminalId !== initialTerminalId) return;
+      if (helpState.isOpen) return;
+      if (isSystemSuspendedRef.current) return;
+
+      const panelState = usePanelStore.getState();
+      const livePanel = panelState.panelsById[initialTerminalId];
+      if (!livePanel) return;
+      const agentState = livePanel.agentState;
+      if (agentState && ACTIVE_AGENT_STATES.has(agentState)) {
+        // Agent is mid-turn. Re-check shortly without restarting the full
+        // hibernate countdown — the user is presumably about to come back.
+        hibernateTimerRef.current = setTimeout(fire, HIBERNATE_BUSY_RECHECK_MS);
+        return;
+      }
+
+      const projectId = useProjectStore.getState().currentProject?.id ?? null;
+      const cwd = livePanel.cwd ?? "";
+      const sessionToRevoke = helpState.sessionId;
+      const liveAgentId = helpState.agentId ?? initialAgentId;
+
+      void window.electron.terminal
+        .gracefulKill(initialTerminalId)
+        .then((capturedSessionId) => {
+          // State may have changed during the IPC round-trip. Don't act on
+          // stale captures.
+          const after = useHelpPanelStore.getState();
+          if (after.terminalId !== initialTerminalId) return;
+          if (capturedSessionId && projectId && liveAgentId && cwd) {
+            after.setHibernateSession(projectId, {
+              sessionId: capturedSessionId,
+              cwd,
+              agentId: liveAgentId,
+            });
+          } else if (projectId) {
+            // No session captured — make sure we don't try to resume from a
+            // stale entry on next open.
+            after.clearHibernateSession(projectId);
+          }
+          usePanelStore.getState().removePanel(initialTerminalId);
+          revokeHelpSession(sessionToRevoke);
+          useHelpPanelStore.getState().clearTerminal();
+        })
+        .catch((err) => {
+          logError("HelpPanel: gracefulKill during hibernate failed", err);
+          // Fall back to direct removal so we don't leak a hidden PTY.
+          usePanelStore.getState().removePanel(initialTerminalId);
+          revokeHelpSession(sessionToRevoke);
+          useHelpPanelStore.getState().clearTerminal();
+        });
+    };
+
+    void window.electron.helpAssistant
+      .getSettings()
+      .then((settings) => {
+        if (cancelled) return;
+        const minutes = settings.idleHibernateMinutes;
+        if (
+          minutes !== 0 &&
+          minutes !== 15 &&
+          minutes !== 30 &&
+          minutes !== 60 &&
+          minutes !== 120
+        ) {
+          // Stored value out of range — fall back to the default rather than
+          // hibernating immediately.
+          hibernateMinutesRef.current = 30;
+        } else {
+          hibernateMinutesRef.current = minutes;
+        }
+        if (hibernateMinutesRef.current <= 0) return;
+        clearTimer();
+        hibernateTimerRef.current = setTimeout(fire, hibernateMinutesRef.current * 60 * 1000);
+      })
+      .catch((err) => {
+        if (cancelled) return;
+        logError("HelpPanel: failed to load idleHibernateMinutes", err);
+        // Fall back to the default so a settings IPC blip doesn't leave the
+        // assistant resident forever.
+        hibernateMinutesRef.current = 30;
+        clearTimer();
+        hibernateTimerRef.current = setTimeout(fire, 30 * 60 * 1000);
+      });
+
+    return () => {
+      cancelled = true;
+      clearTimer();
+    };
+  }, [isOpen, terminalId, agentId]);
+
+  // Auto-dismiss the resume banner. Also dismisses as soon as the user
+  // engages with the resumed conversation (conversationTouched flips true).
+  useEffect(() => {
+    if (!showResumeBanner) return;
+    if (conversationTouched) {
+      setShowResumeBanner(false);
+      return;
+    }
+    const id = setTimeout(() => setShowResumeBanner(false), RESUME_BANNER_AUTO_DISMISS_MS);
+    return () => clearTimeout(id);
+  }, [showResumeBanner, conversationTouched]);
+
+  // Spawn a resumed PTY directly via addPanel with a pre-built
+  // `--resume <id>` command, bypassing `agent.launch` (which has no
+  // command-override arg). Caller is responsible for provisioning the help
+  // session (so a single MCP failure doesn't notify twice) and for clearing
+  // the persisted hibernate entry on success/give-up. Returns the spawned
+  // terminalId, or null if either there's no resume config for the agent or
+  // the spawn returned no id (caller falls back to a fresh launch).
+  const spawnResumed = useCallback(
+    async (
+      launchAgentId: string,
+      hibernated: { sessionId: string; cwd: string },
+      session: HelpSessionRef | null,
+      folderPath: string
+    ): Promise<string | null> => {
+      const command = buildResumeCommand(launchAgentId, hibernated.sessionId);
+      if (!command) return null;
+
+      // Resumed sessions launch from the same sessionPath the previous run
+      // used, so Claude finds its `~/.claude/projects/<encoded-cwd>/` JSONL.
+      const cwd = session?.sessionPath ?? hibernated.cwd ?? folderPath;
+      const projectId = useProjectStore.getState().currentProject?.id ?? null;
+      const env = buildHelpEnv(session, projectId);
+
+      const newId = await usePanelStore.getState().addPanel({
+        kind: "terminal",
+        launchAgentId,
+        command,
+        cwd,
+        location: "dock",
+        ephemeral: true,
+        ...(env && { env }),
+      });
+      return newId ?? null;
+    },
+    []
+  );
+
   // Auto-launch preferred agent when panel opens without an active terminal.
-  // Always starts a new conversation (never resumes).
+  // If a hibernated session exists for the current project + agent, resumes
+  // that conversation; otherwise starts fresh.
   const hasAutoLaunched = useRef(false);
   useEffect(() => {
     if (
@@ -367,6 +554,39 @@ export function HelpPanel({
         pendingSessionIdRef.current = session.sessionId;
         const cwd = session.sessionPath;
         const env = buildHelpEnv(session, launchProject.id);
+
+        // Resume path: only if the persisted hibernate session was for this
+        // exact agent and project. A different agent (e.g. user changed
+        // preference) starts fresh.
+        const hibernated = useHelpPanelStore.getState().hibernateSessions[launchProject.id];
+        if (hibernated && hibernated.agentId === launchAgentId) {
+          const resumedId = await spawnResumed(launchAgentId, hibernated, session, folderPath);
+          if (resumedId) {
+            // Stale-launch guard: handleClose may have revoked the pending
+            // session while addPanel was in flight.
+            const expectedSessionId = session.sessionId;
+            if (pendingSessionIdRef.current !== expectedSessionId) {
+              usePanelStore.getState().removePanel(resumedId);
+              hasAutoLaunched.current = false;
+              return;
+            }
+            useHelpPanelStore.getState().clearHibernateSession(launchProject.id);
+            useHelpPanelStore
+              .getState()
+              .setTerminal(resumedId, launchAgentId, session.sessionId);
+            pendingSessionIdRef.current = null;
+            window.electron.help.markTerminal(resumedId).catch((err) => {
+              logError("Failed to mark help terminal", err);
+            });
+            setShowResumeBanner(true);
+            return;
+          }
+          // Resume failed (no resume config or addPanel returned null). Drop
+          // the stale entry so we don't loop, then fall through to fresh
+          // launch using the already-provisioned session.
+          useHelpPanelStore.getState().clearHibernateSession(launchProject.id);
+        }
+
         const customLaunchFlags = await loadCustomLaunchFlags();
 
         const result = await actionService.dispatch<{ terminalId: string | null }>(
@@ -427,7 +647,7 @@ export function HelpPanel({
       })(),
       { context: "Auto-launching preferred help agent" }
     );
-  }, [isOpen, isReadyToLaunch, currentProject, terminalId, preferredAgentId]);
+  }, [isOpen, isReadyToLaunch, currentProject, terminalId, preferredAgentId, spawnResumed]);
 
   // Reset auto-launch guard when panel closes
   useEffect(() => {
@@ -530,6 +750,33 @@ export function HelpPanel({
         pendingSessionIdRef.current = session.sessionId;
         const cwd = session.sessionPath;
         const env = buildHelpEnv(session, launchProject.id);
+
+        // Resume path: matches the auto-launch effect — if the persisted
+        // hibernate entry is for this exact project + agent, resume that
+        // conversation instead of starting fresh.
+        const hibernated = useHelpPanelStore.getState().hibernateSessions[launchProject.id];
+        if (hibernated && hibernated.agentId === selectedAgentId) {
+          const resumedId = await spawnResumed(selectedAgentId, hibernated, session, folderPath);
+          if (resumedId) {
+            const expectedSessionId = session.sessionId;
+            if (pendingSessionIdRef.current !== expectedSessionId) {
+              usePanelStore.getState().removePanel(resumedId);
+              return;
+            }
+            useHelpPanelStore.getState().clearHibernateSession(launchProject.id);
+            useHelpPanelStore
+              .getState()
+              .setTerminal(resumedId, selectedAgentId, session.sessionId);
+            pendingSessionIdRef.current = null;
+            window.electron.help.markTerminal(resumedId).catch((err) => {
+              logError("Failed to mark help terminal", err);
+            });
+            setShowResumeBanner(true);
+            return;
+          }
+          useHelpPanelStore.getState().clearHibernateSession(launchProject.id);
+        }
+
         const customLaunchFlags = await loadCustomLaunchFlags();
 
         const result = await actionService.dispatch<{ terminalId: string | null }>(
@@ -574,7 +821,7 @@ export function HelpPanel({
         isLaunchingRef.current = false;
       }
     },
-    [isReadyToLaunch, currentProject, removePanel, clearTerminal]
+    [isReadyToLaunch, currentProject, removePanel, clearTerminal, spawnResumed]
   );
 
   // Single-supported-agent auto-launch: when only one assistant-supported
@@ -642,6 +889,14 @@ export function HelpPanel({
     const launchAgentId = agentId;
     const launchProject = currentProject;
     const previousSessionId = useHelpPanelStore.getState().sessionId;
+    // The user explicitly chose to discard the conversation — drop any
+    // hibernated entry for this project so the next reopen starts fresh
+    // instead of resuming the just-discarded chat.
+    const projectIdForReset = useProjectStore.getState().currentProject?.id ?? null;
+    if (projectIdForReset) {
+      useHelpPanelStore.getState().clearHibernateSession(projectIdForReset);
+    }
+    setShowResumeBanner(false);
 
     // Reserve the new terminal id synchronously so the dock filter
     // (`helpTerminalId` exclusion in ContentDock) is active the moment
@@ -974,6 +1229,28 @@ export function HelpPanel({
             <>
               {!introDismissed && (
                 <HelpIntroBanner onDismiss={dismissIntro} onLinkClick={handleIntroLinkClick} />
+              )}
+              {showResumeBanner && (
+                <div
+                  role="status"
+                  aria-live="polite"
+                  className={cn(
+                    "flex items-start gap-2 px-3 py-2 mx-3 mt-3 mb-1",
+                    "rounded-[var(--radius-md)] bg-overlay-subtle border border-daintree-border",
+                    "text-xs text-daintree-text/80"
+                  )}
+                  data-testid="help-resume-banner"
+                >
+                  <span className="flex-1 select-text">Resumed your previous session.</span>
+                  <button
+                    type="button"
+                    onClick={() => setShowResumeBanner(false)}
+                    aria-label="Dismiss resume notice"
+                    className="text-daintree-text/50 hover:text-daintree-text transition-colors"
+                  >
+                    <X className="w-3 h-3" />
+                  </button>
+                </div>
               )}
               <div className="flex-1 relative min-h-0">
                 <Suspense fallback={null}>

--- a/src/components/HelpPanel/HelpPanel.tsx
+++ b/src/components/HelpPanel/HelpPanel.tsx
@@ -422,6 +422,10 @@ export function HelpPanel({
           useHelpPanelStore.getState().clearTerminal();
         })
         .catch((err) => {
+          // Mirror the .then race-guard: bail if the user has reopened the
+          // panel or the terminal id has been replaced during the IPC.
+          const after = useHelpPanelStore.getState();
+          if (after.terminalId !== initialTerminalId || after.isOpen) return;
           logError("HelpPanel: gracefulKill during hibernate failed", err);
           if (projectId) {
             // Drop any prior hibernate entry so we don't auto-resume from a

--- a/src/components/HelpPanel/HelpPanel.tsx
+++ b/src/components/HelpPanel/HelpPanel.tsx
@@ -401,6 +401,11 @@ export function HelpPanel({
           // stale captures.
           const after = useHelpPanelStore.getState();
           if (after.terminalId !== initialTerminalId) return;
+          // Critical race: user reopened the panel while gracefulKill was
+          // in flight. The terminal is still live and visible — don't tear
+          // it down out from under them. The captured session ID is also
+          // discarded; the next hibernation cycle will capture a fresh one.
+          if (after.isOpen) return;
           if (capturedSessionId && projectId && liveAgentId && cwd) {
             after.setHibernateSession(projectId, {
               sessionId: capturedSessionId,
@@ -418,6 +423,11 @@ export function HelpPanel({
         })
         .catch((err) => {
           logError("HelpPanel: gracefulKill during hibernate failed", err);
+          if (projectId) {
+            // Drop any prior hibernate entry so we don't auto-resume from a
+            // potentially stale one after a kill failure.
+            useHelpPanelStore.getState().clearHibernateSession(projectId);
+          }
           // Fall back to direct removal so we don't leak a hidden PTY.
           usePanelStore.getState().removePanel(initialTerminalId);
           revokeHelpSession(sessionToRevoke);
@@ -463,25 +473,28 @@ export function HelpPanel({
     };
   }, [isOpen, terminalId, agentId]);
 
-  // Auto-dismiss the resume banner. Also dismisses as soon as the user
-  // engages with the resumed conversation (conversationTouched flips true).
+  // Auto-dismiss the resume banner after a short window. Conversation-touched
+  // can't be the dismiss trigger here: a resumed Claude session immediately
+  // re-reads history and enters a non-idle state, which flips
+  // conversationTouched=true and would otherwise dismiss the banner before
+  // the user has a chance to see it. The user can also dismiss manually via
+  // the X button.
   useEffect(() => {
     if (!showResumeBanner) return;
-    if (conversationTouched) {
-      setShowResumeBanner(false);
-      return;
-    }
     const id = setTimeout(() => setShowResumeBanner(false), RESUME_BANNER_AUTO_DISMISS_MS);
     return () => clearTimeout(id);
-  }, [showResumeBanner, conversationTouched]);
+  }, [showResumeBanner]);
 
   // Spawn a resumed PTY directly via addPanel with a pre-built
   // `--resume <id>` command, bypassing `agent.launch` (which has no
   // command-override arg). Caller is responsible for provisioning the help
   // session (so a single MCP failure doesn't notify twice) and for clearing
-  // the persisted hibernate entry on success/give-up. Returns the spawned
-  // terminalId, or null if either there's no resume config for the agent or
-  // the spawn returned no id (caller falls back to a fresh launch).
+  // the persisted hibernate entry on success/give-up. The user's custom CLI
+  // flags are loaded here and threaded into both `buildResumeCommand` (so
+  // they're prepended before `--resume`) and `agentLaunchFlags` (so the
+  // panel records them for future restarts). Returns the spawned terminalId,
+  // or null if either there's no resume config for the agent or the spawn
+  // returned no id (caller falls back to a fresh launch).
   const spawnResumed = useCallback(
     async (
       launchAgentId: string,
@@ -489,7 +502,12 @@ export function HelpPanel({
       session: HelpSessionRef | null,
       folderPath: string
     ): Promise<string | null> => {
-      const command = buildResumeCommand(launchAgentId, hibernated.sessionId);
+      const customLaunchFlags = await loadCustomLaunchFlags();
+      const command = buildResumeCommand(
+        launchAgentId,
+        hibernated.sessionId,
+        customLaunchFlags.length > 0 ? customLaunchFlags : undefined
+      );
       if (!command) return null;
 
       // Resumed sessions launch from the same sessionPath the previous run
@@ -506,6 +524,7 @@ export function HelpPanel({
         location: "dock",
         ephemeral: true,
         ...(env && { env }),
+        ...(customLaunchFlags.length > 0 && { agentLaunchFlags: customLaunchFlags }),
       });
       return newId ?? null;
     },

--- a/src/components/HelpPanel/__tests__/HelpPanel.helpLaunch.test.tsx
+++ b/src/components/HelpPanel/__tests__/HelpPanel.helpLaunch.test.tsx
@@ -59,6 +59,7 @@ const {
     sessionId: null as string | null,
     introDismissed: true,
     conversationTouched: false,
+    hibernateSessions: {} as Record<string, { sessionId: string; cwd: string; agentId: string }>,
     markConversationStarted: vi.fn(),
     setWidth: vi.fn(),
     setOpen: vi.fn(),
@@ -66,6 +67,8 @@ const {
     setPreferredAgent: vi.fn(),
     setTerminal: vi.fn(),
     dismissIntro: vi.fn(),
+    setHibernateSession: vi.fn(),
+    clearHibernateSession: vi.fn(),
   },
   panelStoreState: {
     panelsById: {} as Record<string, unknown>,
@@ -258,6 +261,7 @@ function resetState() {
   helpPanelState.sessionId = null;
   helpPanelState.introDismissed = true;
   helpPanelState.conversationTouched = false;
+  helpPanelState.hibernateSessions = {};
   helpPanelState.markConversationStarted = vi.fn();
   helpPanelState.setTerminal = vi.fn();
   helpPanelState.setOpen = vi.fn();
@@ -265,6 +269,8 @@ function resetState() {
   helpPanelState.clearTerminal = vi.fn();
   helpPanelState.setPreferredAgent = vi.fn();
   helpPanelState.dismissIntro = vi.fn();
+  helpPanelState.setHibernateSession = vi.fn();
+  helpPanelState.clearHibernateSession = vi.fn();
 
   panelStoreState.panelsById = {};
   panelStoreState.removePanel = vi.fn();

--- a/src/components/HelpPanel/__tests__/HelpPanel.hibernate.test.tsx
+++ b/src/components/HelpPanel/__tests__/HelpPanel.hibernate.test.tsx
@@ -1,0 +1,598 @@
+// @vitest-environment jsdom
+import { render, fireEvent, act } from "@testing-library/react";
+import { beforeEach, describe, expect, it, vi } from "vitest";
+
+const {
+  mockDispatch,
+  mockNotify,
+  mockLogError,
+  mockGetFolderPath,
+  mockMarkTerminal,
+  mockProvisionSession,
+  mockRevokeSession,
+  mockGracefulKill,
+  mockBuildResumeCommand,
+  mockGetAssistantSupportedAgentIds,
+  mockGetHelpAssistantSettings,
+  mockSystemSleepGetMetrics,
+  mockSystemSleepOnSuspend,
+  mockSystemSleepOnWake,
+  systemSleepListeners,
+  helpPanelState,
+  panelStoreState,
+  cliAvailabilityState,
+  agentSettingsState,
+  projectStoreState,
+  preferencesState,
+} = vi.hoisted(() => ({
+  mockDispatch: vi.fn(),
+  mockNotify: vi.fn().mockReturnValue(""),
+  mockLogError: vi.fn(),
+  mockGetFolderPath: vi.fn(),
+  mockMarkTerminal: vi.fn().mockResolvedValue(undefined),
+  mockProvisionSession: vi.fn().mockResolvedValue(null),
+  mockRevokeSession: vi.fn().mockResolvedValue(undefined),
+  mockGracefulKill: vi.fn().mockResolvedValue(null),
+  mockBuildResumeCommand: vi.fn(),
+  mockGetAssistantSupportedAgentIds: vi.fn(() => ["claude"]),
+  mockGetHelpAssistantSettings: vi.fn().mockResolvedValue({
+    docSearch: true,
+    daintreeControl: true,
+    skipPermissions: false,
+    auditRetention: 7,
+    customArgs: "",
+    idleHibernateMinutes: 30,
+  }),
+  mockSystemSleepGetMetrics: vi.fn().mockResolvedValue({
+    totalSleepMs: 0,
+    sleepPeriods: [],
+    isCurrentlySleeping: false,
+    currentSleepStart: null,
+  }),
+  mockSystemSleepOnSuspend: vi.fn(),
+  mockSystemSleepOnWake: vi.fn(),
+  systemSleepListeners: {
+    suspend: [] as Array<() => void>,
+    wake: [] as Array<(sleepDurationMs: number) => void>,
+  },
+  helpPanelState: {
+    isOpen: true,
+    width: 380,
+    terminalId: null as string | null,
+    agentId: null as string | null,
+    preferredAgentId: null as string | null,
+    sessionId: null as string | null,
+    introDismissed: true,
+    conversationTouched: false,
+    hibernateSessions: {} as Record<string, { sessionId: string; cwd: string; agentId: string }>,
+    markConversationStarted: vi.fn(),
+    setWidth: vi.fn(),
+    setOpen: vi.fn(),
+    clearTerminal: vi.fn(),
+    setPreferredAgent: vi.fn(),
+    setTerminal: vi.fn(),
+    dismissIntro: vi.fn(),
+    setHibernateSession: vi.fn(),
+    clearHibernateSession: vi.fn(),
+  },
+  panelStoreState: {
+    panelsById: {} as Record<string, unknown>,
+    removePanel: vi.fn(),
+    addPanel: vi.fn().mockResolvedValue(""),
+  },
+  cliAvailabilityState: {
+    availability: { claude: "ready" } as Record<string, string>,
+    isInitialized: true,
+    hasRealData: true,
+    details: {} as Record<string, unknown>,
+  },
+  agentSettingsState: {
+    settings: { agents: {} as Record<string, unknown> },
+  },
+  projectStoreState: {
+    currentProject: null as { id: string; path: string } | null,
+  },
+  preferencesState: { reduceAnimations: false },
+}));
+
+vi.mock("@/lib/utils", () => ({ cn: (...args: unknown[]) => args.filter(Boolean).join(" ") }));
+
+vi.mock("@/components/ui/button", () => ({
+  Button: ({ children, onClick, ...rest }: React.PropsWithChildren<{ onClick?: () => void }>) => (
+    <button type="button" onClick={onClick} {...rest}>
+      {children}
+    </button>
+  ),
+}));
+
+vi.mock("@/components/icons/DaintreeIcon", () => ({
+  DaintreeIcon: () => null,
+}));
+
+vi.mock("@/components/Terminal/XtermAdapter", () => ({
+  XtermAdapter: () => <div data-testid="xterm-adapter" />,
+}));
+
+vi.mock("@/components/Terminal/MissingCliGate", () => ({
+  MissingCliGate: ({ agentId, onRunAnyway }: { agentId: string; onRunAnyway: () => void }) => (
+    <div data-testid="missing-cli-gate" data-agent={agentId}>
+      <button type="button" data-testid="run-anyway" onClick={onRunAnyway}>
+        Run anyway
+      </button>
+    </div>
+  ),
+}));
+
+vi.mock("@shared/config/agentIds", () => ({
+  BUILT_IN_AGENT_IDS: ["claude"],
+}));
+
+vi.mock("@/config/agents", () => ({
+  AGENT_REGISTRY: {
+    claude: { name: "Claude", iconId: "claude", color: "#000", icon: () => null },
+  },
+  getAgentConfig: () => ({ name: "Claude", icon: () => null, models: [] }),
+  getAssistantSupportedAgentIds: () => mockGetAssistantSupportedAgentIds(),
+}));
+
+vi.mock("@shared/types/agentSettings", () => ({
+  buildResumeCommand: (...args: unknown[]) => mockBuildResumeCommand(...args),
+}));
+
+vi.mock("@/services/ActionService", () => ({
+  actionService: { dispatch: (...args: unknown[]) => mockDispatch(...args) },
+}));
+
+vi.mock("@/lib/notify", () => ({
+  notify: (...args: unknown[]) => mockNotify(...args),
+}));
+
+vi.mock("@/utils/logger", () => ({
+  logError: (...args: unknown[]) => mockLogError(...args),
+}));
+
+vi.mock("@/utils/safeFireAndForget", () => ({
+  safeFireAndForget: (promise: Promise<unknown>) => promise,
+}));
+
+vi.mock("@/store/helpPanelStore", () => {
+  const store = (selector?: (state: typeof helpPanelState) => unknown) =>
+    selector ? selector(helpPanelState) : helpPanelState;
+  store.getState = () => helpPanelState;
+  return {
+    useHelpPanelStore: store,
+    HELP_PANEL_MIN_WIDTH: 320,
+    HELP_PANEL_MAX_WIDTH: 800,
+  };
+});
+
+vi.mock("@/store", () => {
+  const panelStore = (selector?: (state: typeof panelStoreState) => unknown) =>
+    selector ? selector(panelStoreState) : panelStoreState;
+  panelStore.getState = () => panelStoreState;
+
+  const cliStore = (selector?: (state: typeof cliAvailabilityState) => unknown) =>
+    selector ? selector(cliAvailabilityState) : cliAvailabilityState;
+  cliStore.getState = () => cliAvailabilityState;
+
+  const agentSettingsStore = (selector?: (state: typeof agentSettingsState) => unknown) =>
+    selector ? selector(agentSettingsState) : agentSettingsState;
+  agentSettingsStore.getState = () => agentSettingsState;
+
+  const projectStore = (selector?: (state: typeof projectStoreState) => unknown) =>
+    selector ? selector(projectStoreState) : projectStoreState;
+  projectStore.getState = () => projectStoreState;
+
+  const preferencesStore = (selector?: (state: typeof preferencesState) => unknown) =>
+    selector ? selector(preferencesState) : preferencesState;
+  preferencesStore.getState = () => preferencesState;
+
+  return {
+    usePanelStore: panelStore,
+    useCliAvailabilityStore: cliStore,
+    useAgentSettingsStore: agentSettingsStore,
+    useProjectStore: projectStore,
+    usePreferencesStore: preferencesStore,
+    getTerminalRefreshTier: () => 0,
+  };
+});
+
+vi.mock("@/store/macroFocusStore", () => {
+  const state = { focusedRegion: null, setRegionRef: vi.fn(), setVisibility: vi.fn() };
+  const store = (selector?: (s: typeof state) => unknown) => (selector ? selector(state) : state);
+  store.getState = () => state;
+  return { useMacroFocusStore: store };
+});
+
+vi.mock("@/lib/sidebarToggle", () => ({
+  suppressSidebarResizes: vi.fn(),
+}));
+
+vi.mock("@/components/ui/ConfirmDialog", () => ({
+  ConfirmDialog: ({
+    isOpen,
+    title,
+    onConfirm,
+    onClose,
+  }: {
+    isOpen: boolean;
+    title: React.ReactNode;
+    onConfirm: () => void;
+    onClose?: () => void;
+  }) =>
+    isOpen ? (
+      <div role="dialog" data-testid="confirm-dialog">
+        <h2>{title}</h2>
+        <button data-testid="dialog-cancel" onClick={onClose}>
+          Cancel
+        </button>
+        <button data-testid="dialog-confirm" onClick={onConfirm}>
+          Confirm
+        </button>
+      </div>
+    ) : null,
+}));
+
+vi.mock("@/hooks/useEscapeStack", () => ({
+  useEscapeStack: vi.fn(),
+}));
+
+vi.mock("@/types", () => ({
+  TerminalRefreshTier: { BACKGROUND: 0, ACTIVE: 1 },
+}));
+
+import { HelpPanel } from "../HelpPanel";
+
+function resetState() {
+  helpPanelState.isOpen = true;
+  helpPanelState.width = 380;
+  helpPanelState.terminalId = null;
+  helpPanelState.agentId = null;
+  helpPanelState.preferredAgentId = null;
+  helpPanelState.sessionId = null;
+  helpPanelState.introDismissed = true;
+  helpPanelState.conversationTouched = false;
+  helpPanelState.hibernateSessions = {};
+  helpPanelState.markConversationStarted = vi.fn();
+  helpPanelState.setTerminal = vi.fn();
+  helpPanelState.setOpen = vi.fn();
+  helpPanelState.setWidth = vi.fn();
+  helpPanelState.clearTerminal = vi.fn();
+  helpPanelState.setPreferredAgent = vi.fn();
+  helpPanelState.dismissIntro = vi.fn();
+  helpPanelState.setHibernateSession = vi.fn();
+  helpPanelState.clearHibernateSession = vi.fn();
+
+  panelStoreState.panelsById = {};
+  panelStoreState.removePanel = vi.fn();
+  panelStoreState.addPanel = vi.fn().mockResolvedValue("");
+
+  cliAvailabilityState.availability = { claude: "ready" };
+  cliAvailabilityState.isInitialized = true;
+  cliAvailabilityState.hasRealData = true;
+  cliAvailabilityState.details = {};
+
+  agentSettingsState.settings = { agents: {} };
+
+  projectStoreState.currentProject = null;
+  preferencesState.reduceAnimations = false;
+  mockProvisionSession.mockReset();
+  mockProvisionSession.mockResolvedValue(null);
+  mockRevokeSession.mockReset();
+  mockRevokeSession.mockResolvedValue(undefined);
+  mockGracefulKill.mockReset();
+  mockGracefulKill.mockResolvedValue(null);
+  mockBuildResumeCommand.mockReset();
+  mockBuildResumeCommand.mockReturnValue("claude --resume abc-123");
+  mockGetAssistantSupportedAgentIds.mockReset();
+  mockGetAssistantSupportedAgentIds.mockReturnValue(["claude"]);
+  mockGetHelpAssistantSettings.mockReset();
+  mockGetHelpAssistantSettings.mockResolvedValue({
+    docSearch: true,
+    daintreeControl: true,
+    skipPermissions: false,
+    auditRetention: 7,
+    customArgs: "",
+    idleHibernateMinutes: 30,
+  });
+}
+
+beforeEach(() => {
+  vi.clearAllMocks();
+  resetState();
+
+  systemSleepListeners.suspend.length = 0;
+  systemSleepListeners.wake.length = 0;
+  mockSystemSleepGetMetrics.mockReset();
+  mockSystemSleepGetMetrics.mockResolvedValue({
+    totalSleepMs: 0,
+    sleepPeriods: [],
+    isCurrentlySleeping: false,
+    currentSleepStart: null,
+  });
+  mockSystemSleepOnSuspend.mockReset();
+  mockSystemSleepOnSuspend.mockImplementation((cb: () => void) => {
+    systemSleepListeners.suspend.push(cb);
+    return () => {
+      const idx = systemSleepListeners.suspend.indexOf(cb);
+      if (idx >= 0) systemSleepListeners.suspend.splice(idx, 1);
+    };
+  });
+  mockSystemSleepOnWake.mockReset();
+  mockSystemSleepOnWake.mockImplementation((cb: (sleepDurationMs: number) => void) => {
+    systemSleepListeners.wake.push(cb);
+    return () => {
+      const idx = systemSleepListeners.wake.indexOf(cb);
+      if (idx >= 0) systemSleepListeners.wake.splice(idx, 1);
+    };
+  });
+
+  Object.defineProperty(globalThis, "window", {
+    value: {
+      electron: {
+        help: {
+          getFolderPath: mockGetFolderPath,
+          markTerminal: mockMarkTerminal,
+          provisionSession: mockProvisionSession,
+          revokeSession: mockRevokeSession,
+        },
+        helpAssistant: {
+          getSettings: mockGetHelpAssistantSettings,
+        },
+        systemSleep: {
+          getMetrics: mockSystemSleepGetMetrics,
+          onSuspend: mockSystemSleepOnSuspend,
+          onWake: mockSystemSleepOnWake,
+        },
+        terminal: {
+          gracefulKill: mockGracefulKill,
+        },
+      },
+      addEventListener: vi.fn(),
+      removeEventListener: vi.fn(),
+    },
+    writable: true,
+    configurable: true,
+  });
+
+  Object.defineProperty(document, "hidden", { configurable: true, get: () => false });
+});
+
+describe("HelpPanel — resume from hibernated session", () => {
+  it("auto-launch resumes via addPanel when hibernateSessions has a matching project + agent entry", async () => {
+    helpPanelState.preferredAgentId = "claude";
+    helpPanelState.hibernateSessions = {
+      "proj-1": { sessionId: "abc-123", cwd: "/tmp/help/proj-1", agentId: "claude" },
+    };
+    projectStoreState.currentProject = { id: "proj-1", path: "/tmp/proj-1" };
+    mockGetFolderPath.mockResolvedValue("/help");
+    mockProvisionSession.mockResolvedValue({
+      sessionId: "fresh-session",
+      sessionPath: "/tmp/help/proj-1",
+      token: "tok",
+      mcpUrl: "http://localhost:1234",
+      windowId: 1,
+    });
+    panelStoreState.addPanel = vi.fn().mockResolvedValue("resumed-term-1");
+
+    await act(async () => {
+      render(<HelpPanel width={380} />);
+    });
+
+    expect(mockBuildResumeCommand).toHaveBeenCalledWith("claude", "abc-123");
+    expect(panelStoreState.addPanel).toHaveBeenCalledWith(
+      expect.objectContaining({
+        kind: "terminal",
+        launchAgentId: "claude",
+        command: "claude --resume abc-123",
+        cwd: "/tmp/help/proj-1",
+        ephemeral: true,
+      })
+    );
+    // Resume bypasses the standard agent.launch dispatch.
+    expect(mockDispatch).not.toHaveBeenCalledWith(
+      "agent.launch",
+      expect.anything(),
+      expect.anything()
+    );
+    expect(helpPanelState.clearHibernateSession).toHaveBeenCalledWith("proj-1");
+    expect(helpPanelState.setTerminal).toHaveBeenCalledWith(
+      "resumed-term-1",
+      "claude",
+      "fresh-session"
+    );
+  });
+
+  it("renders the resume banner after a successful resume", async () => {
+    helpPanelState.preferredAgentId = "claude";
+    helpPanelState.hibernateSessions = {
+      "proj-1": { sessionId: "abc-123", cwd: "/tmp/help/proj-1", agentId: "claude" },
+    };
+    projectStoreState.currentProject = { id: "proj-1", path: "/tmp/proj-1" };
+    mockGetFolderPath.mockResolvedValue("/help");
+    mockProvisionSession.mockResolvedValue({
+      sessionId: "fresh-session",
+      sessionPath: "/tmp/help/proj-1",
+      token: "tok",
+      mcpUrl: null,
+      windowId: 1,
+    });
+    panelStoreState.addPanel = vi.fn().mockImplementation(async () => {
+      // After addPanel resolves, reflect the new terminal so the renderer
+      // shows the post-launch chrome (where the banner lives).
+      helpPanelState.terminalId = "resumed-term-1";
+      helpPanelState.agentId = "claude";
+      panelStoreState.panelsById = {
+        "resumed-term-1": {
+          id: "resumed-term-1",
+          kind: "terminal",
+          spawnStatus: "ready",
+          cwd: "/tmp/help/proj-1",
+        },
+      };
+      return "resumed-term-1";
+    });
+
+    const { findByTestId } = render(<HelpPanel width={380} />);
+
+    const banner = await findByTestId("help-resume-banner");
+    expect(banner.textContent).toContain("Resumed your previous session");
+  });
+
+  it("does not resume when the hibernated entry is for a different agent", async () => {
+    helpPanelState.preferredAgentId = "claude";
+    helpPanelState.hibernateSessions = {
+      "proj-1": { sessionId: "abc-123", cwd: "/tmp/help/proj-1", agentId: "gemini" },
+    };
+    projectStoreState.currentProject = { id: "proj-1", path: "/tmp/proj-1" };
+    mockGetFolderPath.mockResolvedValue("/help");
+    mockProvisionSession.mockResolvedValue({
+      sessionId: "fresh-session",
+      sessionPath: "/tmp/help/proj-1",
+      token: "tok",
+      mcpUrl: null,
+      windowId: 1,
+    });
+    mockDispatch.mockResolvedValue({ ok: true, result: { terminalId: "fresh-term" } });
+
+    await act(async () => {
+      render(<HelpPanel width={380} />);
+    });
+
+    expect(mockBuildResumeCommand).not.toHaveBeenCalled();
+    expect(mockDispatch).toHaveBeenCalledWith(
+      "agent.launch",
+      expect.objectContaining({ agentId: "claude" }),
+      { source: "user" }
+    );
+    expect(helpPanelState.clearHibernateSession).not.toHaveBeenCalled();
+  });
+
+  it("does not resume when no hibernated entry exists for the current project", async () => {
+    helpPanelState.preferredAgentId = "claude";
+    helpPanelState.hibernateSessions = {
+      "other-proj": { sessionId: "xyz", cwd: "/tmp/help/other", agentId: "claude" },
+    };
+    projectStoreState.currentProject = { id: "proj-1", path: "/tmp/proj-1" };
+    mockGetFolderPath.mockResolvedValue("/help");
+    mockProvisionSession.mockResolvedValue({
+      sessionId: "fresh-session",
+      sessionPath: "/tmp/help/proj-1",
+      token: "tok",
+      mcpUrl: null,
+      windowId: 1,
+    });
+    mockDispatch.mockResolvedValue({ ok: true, result: { terminalId: "fresh-term" } });
+
+    await act(async () => {
+      render(<HelpPanel width={380} />);
+    });
+
+    expect(mockBuildResumeCommand).not.toHaveBeenCalled();
+    expect(mockDispatch).toHaveBeenCalledWith(
+      "agent.launch",
+      expect.objectContaining({ agentId: "claude" }),
+      { source: "user" }
+    );
+  });
+
+  it("falls through to agent.launch when buildResumeCommand returns undefined", async () => {
+    helpPanelState.preferredAgentId = "claude";
+    helpPanelState.hibernateSessions = {
+      "proj-1": { sessionId: "abc-123", cwd: "/tmp/help/proj-1", agentId: "claude" },
+    };
+    projectStoreState.currentProject = { id: "proj-1", path: "/tmp/proj-1" };
+    mockGetFolderPath.mockResolvedValue("/help");
+    mockProvisionSession.mockResolvedValue({
+      sessionId: "fresh-session",
+      sessionPath: "/tmp/help/proj-1",
+      token: "tok",
+      mcpUrl: null,
+      windowId: 1,
+    });
+    // Agent has no resume config — buildResumeCommand returns undefined.
+    mockBuildResumeCommand.mockReturnValue(undefined);
+    mockDispatch.mockResolvedValue({ ok: true, result: { terminalId: "fresh-term" } });
+
+    await act(async () => {
+      render(<HelpPanel width={380} />);
+    });
+
+    expect(helpPanelState.clearHibernateSession).toHaveBeenCalledWith("proj-1");
+    expect(mockDispatch).toHaveBeenCalledWith(
+      "agent.launch",
+      expect.objectContaining({ agentId: "claude" }),
+      { source: "user" }
+    );
+  });
+
+  it("falls through to agent.launch when the resumed addPanel returns no id", async () => {
+    helpPanelState.preferredAgentId = "claude";
+    helpPanelState.hibernateSessions = {
+      "proj-1": { sessionId: "abc-123", cwd: "/tmp/help/proj-1", agentId: "claude" },
+    };
+    projectStoreState.currentProject = { id: "proj-1", path: "/tmp/proj-1" };
+    mockGetFolderPath.mockResolvedValue("/help");
+    mockProvisionSession.mockResolvedValue({
+      sessionId: "fresh-session",
+      sessionPath: "/tmp/help/proj-1",
+      token: "tok",
+      mcpUrl: null,
+      windowId: 1,
+    });
+    panelStoreState.addPanel = vi.fn().mockResolvedValue("");
+    mockDispatch.mockResolvedValue({ ok: true, result: { terminalId: "fresh-term" } });
+
+    await act(async () => {
+      render(<HelpPanel width={380} />);
+    });
+
+    expect(helpPanelState.clearHibernateSession).toHaveBeenCalledWith("proj-1");
+    expect(mockDispatch).toHaveBeenCalledWith(
+      "agent.launch",
+      expect.objectContaining({ agentId: "claude" }),
+      { source: "user" }
+    );
+  });
+});
+
+describe("HelpPanel — + New session clears hibernated entry", () => {
+  it("clearHibernateSession is called for the current project when starting a new session", async () => {
+    helpPanelState.terminalId = "live-term";
+    helpPanelState.agentId = "claude";
+    helpPanelState.conversationTouched = false;
+    helpPanelState.introDismissed = true;
+    projectStoreState.currentProject = { id: "proj-1", path: "/tmp/proj-1" };
+    panelStoreState.panelsById = {
+      "live-term": {
+        id: "live-term",
+        kind: "terminal",
+        spawnStatus: "ready",
+        cwd: "/tmp/help/proj-1",
+        title: "Claude",
+        command: "claude",
+        location: "dock",
+        agentState: "idle",
+      },
+    };
+    mockProvisionSession.mockResolvedValue({
+      sessionId: "new-session",
+      sessionPath: "/tmp/help/proj-1",
+      token: "tok",
+      mcpUrl: null,
+      windowId: 1,
+    });
+    panelStoreState.addPanel = vi.fn().mockResolvedValue("new-term");
+
+    const { container } = render(<HelpPanel width={380} />);
+
+    const newSessionBtn = container.querySelector('button[aria-label="Start new session"]')!;
+    expect(newSessionBtn).toBeTruthy();
+
+    await act(async () => {
+      fireEvent.click(newSessionBtn);
+    });
+
+    expect(helpPanelState.clearHibernateSession).toHaveBeenCalledWith("proj-1");
+  });
+});

--- a/src/components/HelpPanel/__tests__/HelpPanel.hibernate.test.tsx
+++ b/src/components/HelpPanel/__tests__/HelpPanel.hibernate.test.tsx
@@ -379,7 +379,7 @@ describe("HelpPanel — resume from hibernated session", () => {
       render(<HelpPanel width={380} />);
     });
 
-    expect(mockBuildResumeCommand).toHaveBeenCalledWith("claude", "abc-123");
+    expect(mockBuildResumeCommand).toHaveBeenCalledWith("claude", "abc-123", undefined);
     expect(panelStoreState.addPanel).toHaveBeenCalledWith(
       expect.objectContaining({
         kind: "terminal",
@@ -553,6 +553,274 @@ describe("HelpPanel — resume from hibernated session", () => {
       expect.objectContaining({ agentId: "claude" }),
       { source: "user" }
     );
+  });
+});
+
+describe("HelpPanel — resume preserves user-configured launch flags", () => {
+  it("threads customArgs into both buildResumeCommand and addPanel.agentLaunchFlags", async () => {
+    helpPanelState.preferredAgentId = "claude";
+    helpPanelState.hibernateSessions = {
+      "proj-1": { sessionId: "abc-123", cwd: "/tmp/help/proj-1", agentId: "claude" },
+    };
+    projectStoreState.currentProject = { id: "proj-1", path: "/tmp/proj-1" };
+    mockGetFolderPath.mockResolvedValue("/help");
+    mockProvisionSession.mockResolvedValue({
+      sessionId: "fresh-session",
+      sessionPath: "/tmp/help/proj-1",
+      token: "tok",
+      mcpUrl: null,
+      windowId: 1,
+    });
+    mockGetHelpAssistantSettings.mockResolvedValue({
+      docSearch: true,
+      daintreeControl: true,
+      skipPermissions: false,
+      auditRetention: 7,
+      customArgs: "--model claude-opus-4-5",
+      idleHibernateMinutes: 30,
+    });
+    panelStoreState.addPanel = vi.fn().mockResolvedValue("resumed-term-1");
+
+    await act(async () => {
+      render(<HelpPanel width={380} />);
+    });
+
+    expect(mockBuildResumeCommand).toHaveBeenCalledWith("claude", "abc-123", [
+      "--model",
+      "claude-opus-4-5",
+    ]);
+    expect(panelStoreState.addPanel).toHaveBeenCalledWith(
+      expect.objectContaining({
+        agentLaunchFlags: ["--model", "claude-opus-4-5"],
+      })
+    );
+  });
+});
+
+describe("HelpPanel — idle hibernation timer", () => {
+  it("does not remove the panel when the user reopens before gracefulKill resolves (critical race)", async () => {
+    vi.useFakeTimers({ shouldAdvanceTime: true });
+    try {
+      helpPanelState.isOpen = false;
+      helpPanelState.terminalId = "t1";
+      helpPanelState.agentId = "claude";
+      helpPanelState.sessionId = "live-session";
+      panelStoreState.panelsById = {
+        t1: {
+          id: "t1",
+          kind: "terminal",
+          spawnStatus: "ready",
+          cwd: "/help",
+          agentState: "idle",
+        },
+      };
+      projectStoreState.currentProject = { id: "proj-1", path: "/tmp/proj-1" };
+
+      let resolveGracefulKill: (v: string | null) => void = () => {};
+      mockGracefulKill.mockReturnValue(
+        new Promise<string | null>((resolve) => {
+          resolveGracefulKill = resolve;
+        })
+      );
+
+      await act(async () => {
+        render(<HelpPanel width={380} />);
+      });
+
+      // Let the settings IPC resolve so the timer arms.
+      await act(async () => {
+        await Promise.resolve();
+      });
+
+      // Fast-forward past the 30-minute hibernate threshold.
+      await act(async () => {
+        await vi.advanceTimersByTimeAsync(30 * 60 * 1000);
+      });
+
+      // gracefulKill is now in flight, awaiting our resolution.
+      expect(mockGracefulKill).toHaveBeenCalledWith("t1");
+
+      // User reopens the panel before the kill IPC returns.
+      helpPanelState.isOpen = true;
+
+      // Now resolve gracefulKill — the .then() must abort because isOpen=true.
+      await act(async () => {
+        resolveGracefulKill("captured-session");
+        await Promise.resolve();
+      });
+
+      expect(panelStoreState.removePanel).not.toHaveBeenCalled();
+      expect(helpPanelState.clearTerminal).not.toHaveBeenCalled();
+      expect(helpPanelState.setHibernateSession).not.toHaveBeenCalled();
+    } finally {
+      vi.useRealTimers();
+    }
+  });
+
+  it("captures the session and clears the terminal when the timer fires on an idle agent", async () => {
+    vi.useFakeTimers({ shouldAdvanceTime: true });
+    try {
+      helpPanelState.isOpen = false;
+      helpPanelState.terminalId = "t1";
+      helpPanelState.agentId = "claude";
+      helpPanelState.sessionId = "live-session";
+      panelStoreState.panelsById = {
+        t1: {
+          id: "t1",
+          kind: "terminal",
+          spawnStatus: "ready",
+          cwd: "/help",
+          agentState: "idle",
+        },
+      };
+      projectStoreState.currentProject = { id: "proj-1", path: "/tmp/proj-1" };
+      mockGracefulKill.mockResolvedValue("resume-token-xyz");
+
+      await act(async () => {
+        render(<HelpPanel width={380} />);
+      });
+
+      await act(async () => {
+        await Promise.resolve();
+      });
+
+      await act(async () => {
+        await vi.advanceTimersByTimeAsync(30 * 60 * 1000);
+      });
+
+      expect(mockGracefulKill).toHaveBeenCalledWith("t1");
+      expect(helpPanelState.setHibernateSession).toHaveBeenCalledWith("proj-1", {
+        sessionId: "resume-token-xyz",
+        cwd: "/help",
+        agentId: "claude",
+      });
+      expect(panelStoreState.removePanel).toHaveBeenCalledWith("t1");
+      expect(helpPanelState.clearTerminal).toHaveBeenCalled();
+    } finally {
+      vi.useRealTimers();
+    }
+  });
+
+  it("does not call gracefulKill while the agent is working — defers via the busy re-check", async () => {
+    vi.useFakeTimers({ shouldAdvanceTime: true });
+    try {
+      helpPanelState.isOpen = false;
+      helpPanelState.terminalId = "t1";
+      helpPanelState.agentId = "claude";
+      panelStoreState.panelsById = {
+        t1: {
+          id: "t1",
+          kind: "terminal",
+          spawnStatus: "ready",
+          cwd: "/help",
+          agentState: "working",
+        },
+      };
+      projectStoreState.currentProject = { id: "proj-1", path: "/tmp/proj-1" };
+      mockGracefulKill.mockResolvedValue("should-not-be-captured");
+
+      await act(async () => {
+        render(<HelpPanel width={380} />);
+      });
+
+      await act(async () => {
+        await Promise.resolve();
+      });
+
+      await act(async () => {
+        await vi.advanceTimersByTimeAsync(30 * 60 * 1000);
+      });
+
+      expect(mockGracefulKill).not.toHaveBeenCalled();
+      expect(helpPanelState.setHibernateSession).not.toHaveBeenCalled();
+    } finally {
+      vi.useRealTimers();
+    }
+  });
+
+  it("does not arm the timer when idleHibernateMinutes is 0", async () => {
+    vi.useFakeTimers({ shouldAdvanceTime: true });
+    try {
+      helpPanelState.isOpen = false;
+      helpPanelState.terminalId = "t1";
+      helpPanelState.agentId = "claude";
+      panelStoreState.panelsById = {
+        t1: {
+          id: "t1",
+          kind: "terminal",
+          spawnStatus: "ready",
+          cwd: "/help",
+          agentState: "idle",
+        },
+      };
+      projectStoreState.currentProject = { id: "proj-1", path: "/tmp/proj-1" };
+      mockGetHelpAssistantSettings.mockResolvedValue({
+        docSearch: true,
+        daintreeControl: true,
+        skipPermissions: false,
+        auditRetention: 7,
+        customArgs: "",
+        idleHibernateMinutes: 0,
+      });
+
+      await act(async () => {
+        render(<HelpPanel width={380} />);
+      });
+
+      await act(async () => {
+        await Promise.resolve();
+      });
+
+      // Advance way past any reasonable hibernate time.
+      await act(async () => {
+        await vi.advanceTimersByTimeAsync(2 * 60 * 60 * 1000);
+      });
+
+      expect(mockGracefulKill).not.toHaveBeenCalled();
+    } finally {
+      vi.useRealTimers();
+    }
+  });
+
+  it("clears the persisted entry when gracefulKill returns no session ID", async () => {
+    vi.useFakeTimers({ shouldAdvanceTime: true });
+    try {
+      helpPanelState.isOpen = false;
+      helpPanelState.terminalId = "t1";
+      helpPanelState.agentId = "claude";
+      // Pre-existing entry from a previous successful hibernate cycle.
+      helpPanelState.hibernateSessions = {
+        "proj-1": { sessionId: "old", cwd: "/help", agentId: "claude" },
+      };
+      panelStoreState.panelsById = {
+        t1: {
+          id: "t1",
+          kind: "terminal",
+          spawnStatus: "ready",
+          cwd: "/help",
+          agentState: "idle",
+        },
+      };
+      projectStoreState.currentProject = { id: "proj-1", path: "/tmp/proj-1" };
+      mockGracefulKill.mockResolvedValue(null);
+
+      await act(async () => {
+        render(<HelpPanel width={380} />);
+      });
+
+      await act(async () => {
+        await Promise.resolve();
+      });
+
+      await act(async () => {
+        await vi.advanceTimersByTimeAsync(30 * 60 * 1000);
+      });
+
+      expect(helpPanelState.setHibernateSession).not.toHaveBeenCalled();
+      expect(helpPanelState.clearHibernateSession).toHaveBeenCalledWith("proj-1");
+    } finally {
+      vi.useRealTimers();
+    }
   });
 });
 

--- a/src/components/Settings/DaintreeAssistantSettingsTab.tsx
+++ b/src/components/Settings/DaintreeAssistantSettingsTab.tsx
@@ -6,6 +6,7 @@ import {
   Check,
   Copy,
   KeyRound,
+  Moon,
   RefreshCw,
   ShieldAlert,
   Sliders,
@@ -33,6 +34,7 @@ const DEFAULT_SETTINGS: HelpAssistantSettings = {
   skipPermissions: false,
   auditRetention: 7,
   customArgs: "",
+  idleHibernateMinutes: 30,
 };
 
 interface McpStatusSnapshot {
@@ -45,6 +47,14 @@ const RETENTION_OPTIONS = [
   { value: "7", label: "7 days (default)" },
   { value: "30", label: "30 days" },
   { value: "0", label: "Off" },
+];
+
+const HIBERNATE_OPTIONS = [
+  { value: "0", label: "Off" },
+  { value: "15", label: "15 minutes" },
+  { value: "30", label: "30 minutes (default)" },
+  { value: "60", label: "1 hour" },
+  { value: "120", label: "2 hours" },
 ];
 
 export function DaintreeAssistantSettingsTab() {
@@ -165,6 +175,17 @@ export function DaintreeAssistantSettingsTab() {
     [persist]
   );
 
+  const setHibernateMinutes = useCallback(
+    (value: string) => {
+      const parsed = Number(value);
+      if (parsed !== 0 && parsed !== 15 && parsed !== 30 && parsed !== 60 && parsed !== 120) {
+        return;
+      }
+      void persist({ idleHibernateMinutes: parsed as 0 | 15 | 30 | 60 | 120 });
+    },
+    [persist]
+  );
+
   const handleAgentChange = useCallback(
     (value: string) => {
       setPreferredAgent(value || null);
@@ -275,6 +296,22 @@ export function DaintreeAssistantSettingsTab() {
           isEnabled={settings.daintreeControl}
           onChange={toggleDaintreeControl}
           ariaLabel="Allow the assistant to call Daintree control tools"
+          disabled={loading}
+        />
+      </SettingsSection>
+
+      {/* Hibernation */}
+      <SettingsSection
+        icon={Moon}
+        title="Hibernation"
+        description="Idle assistants release memory and capture a resume token, so reopening reconnects to the same Claude conversation."
+      >
+        <SettingsSelect
+          label="Hibernate after"
+          description="How long the panel stays hidden before the assistant gracefully shuts down. Off keeps it resident until you close it."
+          value={String(settings.idleHibernateMinutes)}
+          onValueChange={setHibernateMinutes}
+          options={HIBERNATE_OPTIONS}
           disabled={loading}
         />
       </SettingsSection>

--- a/src/store/__tests__/helpPanelStore.test.ts
+++ b/src/store/__tests__/helpPanelStore.test.ts
@@ -143,7 +143,7 @@ describe("helpPanelStore persistence migration", () => {
         introDismissed: boolean;
       };
     };
-    expect(parsed.version).toBe(2);
+    expect(parsed.version).toBe(3);
     expect(parsed.state.width).toBe(450);
     expect(parsed.state.preferredAgentId).toBeNull();
   });
@@ -205,7 +205,7 @@ describe("helpPanelStore persistence migration", () => {
     expect(written).toBeDefined();
     const parsed: unknown = JSON.parse(written!);
     expect(parsed).toMatchObject({
-      version: 2,
+      version: 3,
       state: { introDismissed: true },
     });
   });
@@ -260,7 +260,7 @@ describe("helpPanelStore persistence migration", () => {
       version: number;
       state: { isOpen: boolean };
     };
-    expect(parsed.version).toBe(2);
+    expect(parsed.version).toBe(3);
     expect(parsed.state.isOpen).toBe(true);
   });
 
@@ -356,5 +356,181 @@ describe("helpPanelStore persistence migration", () => {
     const { useHelpPanelStore: store } = await import("../helpPanelStore");
 
     expect(store.getState().conversationTouched).toBe(false);
+  });
+
+  describe("hibernateSessions", () => {
+    it("starts as an empty record on a fresh install", async () => {
+      installLocalStorage({});
+
+      const { useHelpPanelStore: store } = await import("../helpPanelStore");
+
+      expect(store.getState().hibernateSessions).toEqual({});
+    });
+
+    it("setHibernateSession adds an entry keyed by projectId", async () => {
+      installLocalStorage({});
+
+      const { useHelpPanelStore: store } = await import("../helpPanelStore");
+      store.getState().setHibernateSession("proj-1", {
+        sessionId: "abc-123",
+        cwd: "/tmp/help",
+        agentId: "claude",
+      });
+
+      expect(store.getState().hibernateSessions).toEqual({
+        "proj-1": { sessionId: "abc-123", cwd: "/tmp/help", agentId: "claude" },
+      });
+    });
+
+    it("setHibernateSession isolates entries by projectId", async () => {
+      installLocalStorage({});
+
+      const { useHelpPanelStore: store } = await import("../helpPanelStore");
+      store.getState().setHibernateSession("proj-a", {
+        sessionId: "session-a",
+        cwd: "/tmp/a",
+        agentId: "claude",
+      });
+      store.getState().setHibernateSession("proj-b", {
+        sessionId: "session-b",
+        cwd: "/tmp/b",
+        agentId: "claude",
+      });
+
+      expect(store.getState().hibernateSessions).toEqual({
+        "proj-a": { sessionId: "session-a", cwd: "/tmp/a", agentId: "claude" },
+        "proj-b": { sessionId: "session-b", cwd: "/tmp/b", agentId: "claude" },
+      });
+    });
+
+    it("clearHibernateSession removes only the named project entry", async () => {
+      installLocalStorage({});
+
+      const { useHelpPanelStore: store } = await import("../helpPanelStore");
+      store.getState().setHibernateSession("proj-a", {
+        sessionId: "session-a",
+        cwd: "/tmp/a",
+        agentId: "claude",
+      });
+      store.getState().setHibernateSession("proj-b", {
+        sessionId: "session-b",
+        cwd: "/tmp/b",
+        agentId: "claude",
+      });
+      store.getState().clearHibernateSession("proj-a");
+
+      expect(store.getState().hibernateSessions).toEqual({
+        "proj-b": { sessionId: "session-b", cwd: "/tmp/b", agentId: "claude" },
+      });
+    });
+
+    it("clearHibernateSession on an unknown projectId is a no-op", async () => {
+      installLocalStorage({});
+
+      const { useHelpPanelStore: store } = await import("../helpPanelStore");
+      store.getState().setHibernateSession("proj-a", {
+        sessionId: "session-a",
+        cwd: "/tmp/a",
+        agentId: "claude",
+      });
+      store.getState().clearHibernateSession("proj-unknown");
+
+      expect(store.getState().hibernateSessions).toEqual({
+        "proj-a": { sessionId: "session-a", cwd: "/tmp/a", agentId: "claude" },
+      });
+    });
+
+    it("persists hibernateSessions across rehydration", async () => {
+      const backing = installLocalStorage({});
+
+      let mod = await import("../helpPanelStore");
+      mod.useHelpPanelStore.getState().setHibernateSession("proj-a", {
+        sessionId: "session-a",
+        cwd: "/tmp/a",
+        agentId: "claude",
+      });
+
+      const written = backing.get(STORAGE_KEY);
+      expect(written).toBeDefined();
+      const parsed = JSON.parse(written!) as {
+        version: number;
+        state: { hibernateSessions: Record<string, unknown> };
+      };
+      expect(parsed.version).toBe(3);
+      expect(parsed.state.hibernateSessions).toEqual({
+        "proj-a": { sessionId: "session-a", cwd: "/tmp/a", agentId: "claude" },
+      });
+
+      vi.resetModules();
+      mod = await import("../helpPanelStore");
+      expect(mod.useHelpPanelStore.getState().hibernateSessions).toEqual({
+        "proj-a": { sessionId: "session-a", cwd: "/tmp/a", agentId: "claude" },
+      });
+    });
+
+    it("rejects malformed entries during rehydration (missing sessionId/cwd/agentId)", async () => {
+      const blob = JSON.stringify({
+        version: 3,
+        state: {
+          isOpen: false,
+          width: 400,
+          preferredAgentId: null,
+          introDismissed: false,
+          hibernateSessions: {
+            "good-proj": { sessionId: "abc", cwd: "/tmp", agentId: "claude" },
+            "no-session": { cwd: "/tmp", agentId: "claude" },
+            "no-cwd": { sessionId: "abc", agentId: "claude" },
+            "no-agent": { sessionId: "abc", cwd: "/tmp" },
+            "empty-session": { sessionId: "", cwd: "/tmp", agentId: "claude" },
+            "wrong-types": { sessionId: 1, cwd: 2, agentId: 3 },
+          },
+        },
+      });
+      installLocalStorage({ [STORAGE_KEY]: blob });
+
+      const { useHelpPanelStore: store } = await import("../helpPanelStore");
+
+      expect(store.getState().hibernateSessions).toEqual({
+        "good-proj": { sessionId: "abc", cwd: "/tmp", agentId: "claude" },
+      });
+    });
+
+    it("falls back to empty record when persisted hibernateSessions is not an object", async () => {
+      const blob = JSON.stringify({
+        version: 3,
+        state: {
+          isOpen: false,
+          width: 400,
+          preferredAgentId: null,
+          introDismissed: false,
+          hibernateSessions: "not-an-object",
+        },
+      });
+      installLocalStorage({ [STORAGE_KEY]: blob });
+
+      const { useHelpPanelStore: store } = await import("../helpPanelStore");
+
+      expect(store.getState().hibernateSessions).toEqual({});
+    });
+
+    it("starts with empty hibernateSessions when migrating from v2 (no field)", async () => {
+      const v2Blob = JSON.stringify({
+        version: 2,
+        state: {
+          isOpen: false,
+          width: 400,
+          preferredAgentId: "claude",
+          introDismissed: true,
+        },
+      });
+      installLocalStorage({ [STORAGE_KEY]: v2Blob });
+
+      const { useHelpPanelStore: store } = await import("../helpPanelStore");
+
+      expect(store.getState().hibernateSessions).toEqual({});
+      // Other fields still load correctly
+      expect(store.getState().preferredAgentId).toBe("claude");
+      expect(store.getState().introDismissed).toBe(true);
+    });
   });
 });

--- a/src/store/helpPanelStore.ts
+++ b/src/store/helpPanelStore.ts
@@ -12,6 +12,18 @@ export const HELP_PANEL_MIN_WIDTH = 320;
 export const HELP_PANEL_MAX_WIDTH = 800;
 export const HELP_PANEL_DEFAULT_WIDTH = 380;
 
+export interface HelpHibernateSession {
+  /** Captured agent session ID (e.g. Claude resume token) */
+  sessionId: string;
+  /** Working directory the resumed agent must launch from to find its transcript */
+  cwd: string;
+  /**
+   * Agent that produced this session. Resume only fires when the next launch
+   * targets the same agent — guards against agent switches between sleeps.
+   */
+  agentId: string;
+}
+
 interface HelpPanelState {
   isOpen: boolean;
   width: number;
@@ -21,6 +33,12 @@ interface HelpPanelState {
   sessionId: string | null;
   introDismissed: boolean;
   conversationTouched: boolean;
+  /**
+   * Per-project captured resume sessions, keyed by projectId. helpPanelStore
+   * is shared across all project views (single localStorage partition), so
+   * the assistant session for project A must not leak into project B.
+   */
+  hibernateSessions: Record<string, HelpHibernateSession>;
 }
 
 interface HelpPanelActions {
@@ -32,6 +50,11 @@ interface HelpPanelActions {
   setPreferredAgent: (agentId: string | null) => void;
   dismissIntro: () => void;
   markConversationStarted: () => void;
+  setHibernateSession: (
+    projectId: string,
+    entry: { sessionId: string; cwd: string; agentId: string }
+  ) => void;
+  clearHibernateSession: (projectId: string) => void;
 }
 
 const initialState: HelpPanelState = {
@@ -43,7 +66,23 @@ const initialState: HelpPanelState = {
   sessionId: null,
   introDismissed: false,
   conversationTouched: false,
+  hibernateSessions: {},
 };
+
+function sanitizeHibernateSessions(value: unknown): Record<string, HelpHibernateSession> {
+  if (!value || typeof value !== "object") return {};
+  const out: Record<string, HelpHibernateSession> = {};
+  for (const [projectId, entry] of Object.entries(value as Record<string, unknown>)) {
+    if (!projectId || typeof projectId !== "string") continue;
+    if (!entry || typeof entry !== "object") continue;
+    const e = entry as Record<string, unknown>;
+    if (typeof e.sessionId !== "string" || !e.sessionId) continue;
+    if (typeof e.cwd !== "string" || !e.cwd) continue;
+    if (typeof e.agentId !== "string" || !e.agentId) continue;
+    out[projectId] = { sessionId: e.sessionId, cwd: e.cwd, agentId: e.agentId };
+  }
+  return out;
+}
 
 export const useHelpPanelStore = create<HelpPanelState & HelpPanelActions>()(
   persist(
@@ -76,17 +115,34 @@ export const useHelpPanelStore = create<HelpPanelState & HelpPanelActions>()(
       dismissIntro: () => set({ introDismissed: true }),
 
       markConversationStarted: () => set({ conversationTouched: true }),
+
+      setHibernateSession: (projectId, entry) =>
+        set((s) => ({
+          hibernateSessions: {
+            ...s.hibernateSessions,
+            [projectId]: { sessionId: entry.sessionId, cwd: entry.cwd, agentId: entry.agentId },
+          },
+        })),
+
+      clearHibernateSession: (projectId) =>
+        set((s) => {
+          if (!(projectId in s.hibernateSessions)) return s;
+          const next = { ...s.hibernateSessions };
+          delete next[projectId];
+          return { hibernateSessions: next };
+        }),
     }),
     {
       name: "help-panel-storage",
       storage: createSafeJSONStorage(),
-      version: 2,
+      version: 3,
       migrate: (persistedState) => persistedState as HelpPanelState & HelpPanelActions,
       partialize: (state) => ({
         isOpen: state.isOpen,
         width: state.width,
         preferredAgentId: state.preferredAgentId,
         introDismissed: state.introDismissed,
+        hibernateSessions: state.hibernateSessions,
       }),
       merge: (persistedState: unknown, currentState) => {
         const persisted = persistedState as Partial<HelpPanelState>;
@@ -104,6 +160,7 @@ export const useHelpPanelStore = create<HelpPanelState & HelpPanelActions>()(
             typeof persisted.introDismissed === "boolean"
               ? persisted.introDismissed
               : currentState.introDismissed,
+          hibernateSessions: sanitizeHibernateSessions(persisted.hibernateSessions),
         };
       },
     }
@@ -114,5 +171,5 @@ registerPersistedStore({
   storeId: "helpPanelStore",
   store: useHelpPanelStore,
   persistedStateType:
-    "Pick<HelpPanelState, 'isOpen' | 'width' | 'preferredAgentId' | 'introDismissed'>",
+    "Pick<HelpPanelState, 'isOpen' | 'width' | 'preferredAgentId' | 'introDismissed' | 'hibernateSessions'>",
 });


### PR DESCRIPTION
## Summary

- After a configurable idle period (default 30 min; options: 0/15/30/60/120) of the panel being hidden and the agent being idle, the assistant PTY is gracefully shut down via the existing `TerminalGracefulShutdown` infrastructure to capture the Claude `--resume` token. On reopen, `buildResumeCommand` spawns a resumed PTY directly — no context lost.
- A tier-1 ambient banner ("Resumed your previous session.") confirms the resume and auto-dismisses after 10 seconds. Hibernation is deferred while the agent is working/waiting/directing, skipped when the OS is suspended, and the `+ New session` button clears the persisted token so the just-discarded chat isn't auto-resumed.
- `helpPanelStore` bumped to v3 with sanitized rehydration — persists a `Record<projectId, { sessionId, cwd, agentId }>`. Custom launch flags thread through `buildResumeCommand` and `agentLaunchFlags` so user CLI flags (e.g. `--model`) survive the round-trip.

Resolves #6949

## Changes

- `HelpPanel.tsx` — hibernate timer, graceful shutdown path, resume-spawn logic, ambient banner, OS-suspend guard, race-condition fix (panel reopened during `gracefulKill` no longer tears down the visible terminal once IPC resolves)
- `helpPanelStore.ts` — v3 store with `hibernateData` record, `idleHibernateMinutes` setting, sanitized `partialize`/rehydration
- `DaintreeAssistantSettingsTab.tsx` — idle hibernate minutes select (0/15/30/60/120)
- `helpAssistant.ts` IPC handler + `shared/types/ipc/api.ts` — `getHibernateData` / `setHibernateData` channels
- 13 hibernation component tests, 6 store tests, 6 settings handler tests (654 unit tests total, all passing)

## Testing

- Unit tests: 654 passing, including 25 new tests covering hibernation timer, defer-while-working, OS-suspend guard, race fix, resume-spawn path, store v3 migration, and settings handler
- Typecheck: clean
- Lint: clean