### PR TITLE
fix(sidebar): slide worktree sidebar under the grid on toggle

### DIFF
--- a/src/components/Layout/AppLayout.tsx
+++ b/src/components/Layout/AppLayout.tsx
@@ -435,13 +435,25 @@ export function AppLayout({
           className="flex-1 flex overflow-hidden relative"
           style={{ flex: 1, display: "flex", overflow: "hidden", position: "relative" }}
         >
-          {currentProject != null && (
-            <ErrorBoundary variant="section" componentName="Sidebar">
-              <Sidebar width={effectiveSidebarWidth} onResize={handleSidebarResize}>
-                {sidebarContent}
-              </Sidebar>
-            </ErrorBoundary>
-          )}
+          <div
+            className={cn(
+              "relative h-full shrink-0 overflow-clip",
+              !reduceAnimations &&
+                "transition-[width] duration-[var(--duration-250)] ease-[var(--ease-out-expo)] motion-reduce:transition-none",
+              !showSidebar && "pointer-events-none"
+            )}
+            style={{ width: effectiveSidebarWidth, overflowClipMargin: "6px" }}
+          >
+            <div className="absolute top-0 left-0 h-full" style={{ width: sidebarWidth }}>
+              {currentProject != null && (
+                <ErrorBoundary variant="section" componentName="Sidebar">
+                  <Sidebar width={sidebarWidth} onResize={handleSidebarResize}>
+                    {sidebarContent}
+                  </Sidebar>
+                </ErrorBoundary>
+              )}
+            </div>
+          </div>
           <ErrorBoundary variant="section" componentName="MainContent">
             <main
               aria-label="Content"

--- a/src/components/Layout/AppLayout.tsx
+++ b/src/components/Layout/AppLayout.tsx
@@ -372,7 +372,7 @@ export function AppLayout({
     onSettings?.();
   }, [onSettings]);
 
-  const effectiveSidebarWidth = layout.gestureSidebarHidden ? 0 : sidebarWidth;
+  const effectiveSidebarWidth = showSidebar ? sidebarWidth : 0;
 
   useEffect(() => {
     const portalOffset = layout.portalOpen ? layout.portalWidth : 0;
@@ -447,7 +447,11 @@ export function AppLayout({
             <div className="absolute top-0 left-0 h-full" style={{ width: sidebarWidth }}>
               {currentProject != null && (
                 <ErrorBoundary variant="section" componentName="Sidebar">
-                  <Sidebar width={sidebarWidth} onResize={handleSidebarResize}>
+                  <Sidebar
+                    width={sidebarWidth}
+                    onResize={handleSidebarResize}
+                    isVisible={showSidebar}
+                  >
                     {sidebarContent}
                   </Sidebar>
                 </ErrorBoundary>

--- a/src/components/Layout/Sidebar.tsx
+++ b/src/components/Layout/Sidebar.tsx
@@ -24,6 +24,7 @@ import {
 interface SidebarProps {
   width: number;
   onResize: (width: number) => void;
+  isVisible?: boolean;
   children?: ReactNode;
   className?: string;
 }
@@ -32,7 +33,7 @@ const RESIZE_STEP = 10;
 
 const ICON_CLASS = "w-3.5 h-3.5 mr-2 shrink-0";
 
-export function Sidebar({ width, onResize, children, className }: SidebarProps) {
+export function Sidebar({ width, onResize, isVisible = true, children, className }: SidebarProps) {
   const [isResizing, setIsResizing] = useState(false);
   const sidebarRef = useRef<HTMLElement>(null);
   const currentProject = useProjectStore((state) => state.currentProject);
@@ -102,6 +103,11 @@ export function Sidebar({ width, onResize, children, className }: SidebarProps) 
           ref={sidebarRef}
           tabIndex={-1}
           aria-label="Sidebar"
+          aria-hidden={!isVisible}
+          // `inert` removes descendant buttons from the focus / a11y tree while
+          // the sidebar is slid out — `aria-hidden` alone leaves them
+          // focusable, which axe flags as `aria-hidden-focus` (WCAG 2.2 AA).
+          inert={!isVisible || undefined}
           data-macro-focus={isMacroFocused ? "true" : undefined}
           className={cn(
             "sidebar-root",
@@ -125,8 +131,8 @@ export function Sidebar({ width, onResize, children, className }: SidebarProps) 
             aria-valuenow={width}
             aria-valuemin={200}
             aria-valuemax={600}
-            tabIndex={width === 0 ? -1 : 0}
-            aria-hidden={width === 0 ? "true" : undefined}
+            tabIndex={isVisible ? 0 : -1}
+            aria-hidden={!isVisible ? "true" : undefined}
             className={cn(
               "group absolute top-0 -right-1.5 w-3 h-full cursor-col-resize flex items-center justify-center z-50",
               "hover:bg-overlay-soft transition-colors focus-visible:outline-hidden focus-visible:bg-overlay-medium focus-visible:ring-1 focus-visible:ring-daintree-accent/50",

--- a/src/components/Layout/Sidebar.tsx
+++ b/src/components/Layout/Sidebar.tsx
@@ -3,7 +3,6 @@ import { cn } from "@/lib/utils";
 import { ProjectResourceBadge, QuickRun } from "@/components/Project";
 import { useProjectStore } from "@/store/projectStore";
 import { useMacroFocusStore } from "@/store/macroFocusStore";
-import { usePreferencesStore } from "@/store";
 import { DEFAULT_SIDEBAR_WIDTH } from "./AppLayout";
 import { actionService } from "@/services/ActionService";
 import {
@@ -38,8 +37,6 @@ export function Sidebar({ width, onResize, children, className }: SidebarProps) 
   const sidebarRef = useRef<HTMLElement>(null);
   const currentProject = useProjectStore((state) => state.currentProject);
   const isMacroFocused = useMacroFocusStore((state) => state.focusedRegion === "sidebar");
-  const reduceAnimations = usePreferencesStore((s) => s.reduceAnimations);
-  const animateWidth = !isResizing && !reduceAnimations;
 
   useEffect(() => {
     useMacroFocusStore.getState().setRegionRef("sidebar", sidebarRef.current);
@@ -108,16 +105,12 @@ export function Sidebar({ width, onResize, children, className }: SidebarProps) 
           data-macro-focus={isMacroFocused ? "true" : undefined}
           className={cn(
             "sidebar-root",
-            "relative shrink-0 flex flex-col outline-hidden overflow-hidden",
+            "relative w-full h-full flex flex-col outline-hidden overflow-hidden",
             "surface-chrome",
             "border-r border-divider",
             "data-[macro-focus=true]:ring-2 data-[macro-focus=true]:ring-daintree-accent/60 data-[macro-focus=true]:ring-inset",
-            animateWidth &&
-              "transition-[width] duration-[var(--duration-250)] ease-[var(--ease-out-expo)] motion-reduce:transition-none",
-            width === 0 && "pointer-events-none",
             className
           )}
-          style={{ width }}
         >
           <div className="flex-1 min-h-0 overflow-hidden">{children}</div>
 


### PR DESCRIPTION
## Summary

- When toggling the worktree sidebar, it now slides underneath the panel grid — matching the assistant panel behaviour. Previously the `aside` took the animating width directly, so its content got compressed during the transition.
- The fix wraps the sidebar in an outer `div` that takes the animated width, with the `Sidebar` rendered at its full resolved `sidebarWidth` inside an absolutely positioned inner `div`. The grid slides over it on the way out, uncovers it on the way in.
- Drag-to-resize is unchanged — `sidebarWidth` still drives the resize handle and the inner content width.

Resolves #6956

## Changes

- `AppLayout.tsx`: replaced direct `<Sidebar width={effectiveSidebarWidth}>` with a wrapper/inner pattern mirroring the assistant panel. `effectiveSidebarWidth` now drives the slot width; `sidebarWidth` is passed to `Sidebar` as the fixed render width. Also fixed `effectiveSidebarWidth` to derive from `showSidebar` instead of `gestureSidebarHidden`.
- `Sidebar.tsx`: accepts `isVisible` prop; sets `aria-hidden` and `inert` when not visible (fixes `aria-hidden-focus` axe violation). Removed the internal width animation — that now lives entirely on the wrapper. Removed the `usePreferencesStore` import that was only needed for the now-removed `animateWidth` logic.

## Testing

- Toggle sidebar open/closed — grid slides over it cleanly with no content compression.
- Drag-to-resize still resizes the sidebar as expected.
- Sidebar is inert and hidden from the a11y tree while collapsed.