### PR TITLE
chore(panel): reuse motion constants in tab indicator transitions

### DIFF
--- a/src/components/Panel/PanelTabList.tsx
+++ b/src/components/Panel/PanelTabList.tsx
@@ -3,6 +3,7 @@ import { LayoutGroup, AnimatePresence, m } from "framer-motion";
 import { Plus } from "lucide-react";
 import { cn } from "@/lib/utils";
 import { Tooltip, TooltipContent, TooltipTrigger } from "@/components/ui/tooltip";
+import { UI_ANIMATION_DURATION, EASE_OUT_EXPO_FM } from "@/lib/animationUtils";
 import type { TabInfo } from "./TabButton";
 
 export interface PanelTabListProps {
@@ -49,7 +50,7 @@ export function PanelTabList({
                   <m.div
                     key={tab.id}
                     layout="position"
-                    transition={{ duration: 0.15, ease: [0.16, 1, 0.3, 1] }}
+                    transition={{ duration: UI_ANIMATION_DURATION / 1000, ease: EASE_OUT_EXPO_FM }}
                   >
                     {renderTab(tab)}
                   </m.div>

--- a/src/components/Panel/TabButton.tsx
+++ b/src/components/Panel/TabButton.tsx
@@ -12,11 +12,7 @@ import {
 } from "@/components/Worktree/terminalStateConfig";
 import type { TerminalChromeDescriptor } from "@/utils/terminalChrome";
 import { getTerminalAgentDisplayState } from "@/utils/terminalAgentDisplayState";
-import {
-  UI_ANIMATION_DURATION,
-  DURATION_100,
-  EASE_OUT_EXPO_FM,
-} from "@/lib/animationUtils";
+import { UI_ANIMATION_DURATION, DURATION_100, EASE_OUT_EXPO_FM } from "@/lib/animationUtils";
 
 const RENAME_ERROR_TINT_HOLD_MS = 300;
 

--- a/src/components/Panel/TabButton.tsx
+++ b/src/components/Panel/TabButton.tsx
@@ -12,7 +12,11 @@ import {
 } from "@/components/Worktree/terminalStateConfig";
 import type { TerminalChromeDescriptor } from "@/utils/terminalChrome";
 import { getTerminalAgentDisplayState } from "@/utils/terminalAgentDisplayState";
-import { UI_ANIMATION_DURATION, DURATION_100 } from "@/lib/animationUtils";
+import {
+  UI_ANIMATION_DURATION,
+  DURATION_100,
+  EASE_OUT_EXPO_FM,
+} from "@/lib/animationUtils";
 
 const RENAME_ERROR_TINT_HOLD_MS = 300;
 
@@ -294,7 +298,7 @@ const TabButtonComponent = forwardRef<HTMLDivElement, TabButtonProps>(function T
               layoutId="panel-tab-indicator"
               layout="position"
               className="absolute inset-x-0 bottom-0 h-0.5 bg-daintree-accent pointer-events-none"
-              transition={{ duration: 0.15, ease: [0.16, 1, 0.3, 1] }}
+              transition={{ duration: UI_ANIMATION_DURATION / 1000, ease: EASE_OUT_EXPO_FM }}
               aria-hidden="true"
             />
           )}

--- a/src/lib/animationUtils.ts
+++ b/src/lib/animationUtils.ts
@@ -66,6 +66,7 @@ export const UI_EXIT_EASING = "cubic-bezier(0.2, 0, 0.7, 0)";
  *  Transition.ease to its own Easing type and rejects CSS string easings. */
 export const UI_ENTER_EASING_FM: [number, number, number, number] = [0.2, 0, 0, 1];
 export const UI_EXIT_EASING_FM: [number, number, number, number] = [0.2, 0, 0.7, 0];
+export const EASE_OUT_EXPO_FM: [number, number, number, number] = [0.16, 1, 0.3, 1];
 
 export function getUiTransitionDuration(direction: "enter" | "exit"): number {
   if (typeof window === "undefined" || typeof document === "undefined") {


### PR DESCRIPTION
## Summary

Pure cleanup — adds the `EASE_OUT_EXPO_FM` constant to `animationUtils.ts` and applies it alongside `UI_ANIMATION_DURATION` at `TabButton.tsx` and `PanelTabList.tsx`, replacing inline framer-motion transition objects. The convention was already half-applied in those files; this finishes the job.

Resolves #6966

## Changes

- `src/lib/animationUtils.ts` — export `EASE_OUT_EXPO_FM` tuple constant alongside the existing `UI_ENTER_EASING_FM` sibling
- `src/components/Panel/TabButton.tsx` — replace inline `{ duration: 0.15, ease: [0.16, 1, 0.3, 1] }` with `UI_ANIMATION_DURATION` + `EASE_OUT_EXPO_FM`
- `src/components/Panel/PanelTabList.tsx` — same replacement

## Testing

No behaviour change — the constants resolve to identical values. Verified with `npm run check`.