### PR TITLE
docs(mcp): document multi-terminal polling pattern

### DIFF
--- a/electron/services/mcp-server/shared.ts
+++ b/electron/services/mcp-server/shared.ts
@@ -51,7 +51,7 @@ export const WAIT_UNTIL_IDLE_INPUT_SCHEMA: Record<string, unknown> = {
       type: "integer",
       minimum: 0,
       maximum: MAX_WAIT_UNTIL_IDLE_TIMEOUT_MS,
-      description: `Maximum time to block in milliseconds. Defaults to ${DEFAULT_WAIT_UNTIL_IDLE_TIMEOUT_MS} ms (${DEFAULT_WAIT_UNTIL_IDLE_TIMEOUT_MS / 60_000} minutes); clamped to ${MAX_WAIT_UNTIL_IDLE_TIMEOUT_MS} ms (${MAX_WAIT_UNTIL_IDLE_TIMEOUT_MS / 60_000 / 60} hours). Use 0 for an immediate snapshot.`,
+      description: `Pass 0 for an immediate non-blocking snapshot — the recommended mode when polling multiple terminals in parallel. Otherwise, the maximum time to block in milliseconds; defaults to ${DEFAULT_WAIT_UNTIL_IDLE_TIMEOUT_MS} ms (${DEFAULT_WAIT_UNTIL_IDLE_TIMEOUT_MS / 60_000} minutes) and clamped to ${MAX_WAIT_UNTIL_IDLE_TIMEOUT_MS} ms (${MAX_WAIT_UNTIL_IDLE_TIMEOUT_MS / 60_000 / 60} hours).`,
     },
   },
   required: ["terminalId"],
@@ -76,7 +76,7 @@ export const WAIT_UNTIL_IDLE_OUTPUT_SCHEMA: Record<string, unknown> = {
 };
 
 export const WAIT_UNTIL_IDLE_DESCRIPTION =
-  "[terminal] Wait until idle: blocks until the agent in the given terminal transitions out of the `working` state, or until the timeout elapses. Resolves immediately if the agent is already non-working or no agent is attached. Honours client cancellation.";
+  "[terminal] Wait until idle: blocks until the agent in the given terminal transitions out of the `working` state, or until the timeout elapses. Resolves immediately if the agent is already non-working or no agent is attached. Honours client cancellation. When orchestrating multiple terminals, call with `timeoutMs: 0` in parallel for snapshots — do not issue concurrent default-timeout waits, which race unpredictably and can each block for 30 minutes.";
 
 export function mapAgentStateToBusyState(state: AgentState | undefined): "working" | "idle" {
   return state === "working" ? "working" : "idle";

--- a/help/CLAUDE.md
+++ b/help/CLAUDE.md
@@ -35,7 +35,7 @@ When choosing what to do, prefer the least-privileged path. If the user asks you
 
 **Recipe:**
 
-1. **Snapshot in parallel.** Call `terminal.waitUntilIdle` with `timeoutMs: 0` for each terminal you're watching. Each call returns immediately with `busyState`, `idleReason`, and `lastTransitionAt`. The `timedOut` field is always `false` for snapshots.
+1. **Snapshot in parallel.** Call `terminal.waitUntilIdle` with `timeoutMs: 0` for each terminal you're watching. Each call returns immediately with `busyState`, `idleReason`, `lastTransitionAt`, and `timedOut`. With `timeoutMs: 0`, `timedOut` is `true` when the agent is still `working` (the zero-length wait elapsed) and `false` when the agent is already idle or no agent is attached — treat it as a busy/idle indicator on the snapshot path, not an error.
 2. **Skip working terminals.** When `busyState === "working"` the agent is mid-task — there's nothing to act on this round.
 3. **Skip already-handled transitions.** Track the last `lastTransitionAt` you acted on per terminal and skip when it hasn't advanced. `lastTransitionAt` is `undefined` for terminals that have never transitioned — treat that as "no transition yet," not as "changed."
 4. **Act on `idleReason`** when `busyState === "idle"`:
@@ -49,12 +49,14 @@ When choosing what to do, prefer the least-privileged path. If the user asks you
 Sketch:
 
 ```ts
-const snapshots = await Promise.all(
+const results = await Promise.allSettled(
   terminalIds.map((id) => waitUntilIdle({ terminalId: id, timeoutMs: 0 }))
 );
-for (const s of snapshots) {
+for (const r of results) {
+  if (r.status === "rejected") continue; // log and move on
+  const s = r.value;
   if (s.busyState === "working") continue;
-  if (s.lastTransitionAt && s.lastTransitionAt === lastSeen[s.terminalId]) continue;
+  if (s.lastTransitionAt !== undefined && s.lastTransitionAt === lastSeen[s.terminalId]) continue;
   switch (s.idleReason) {
     case "completed":
       /* dispatch next step */ break;
@@ -63,10 +65,12 @@ for (const s of snapshots) {
     case "waiting_for_user":
       /* verify, then act or ask */ break;
   }
-  if (s.lastTransitionAt) lastSeen[s.terminalId] = s.lastTransitionAt;
+  if (s.lastTransitionAt !== undefined) lastSeen[s.terminalId] = s.lastTransitionAt;
 }
 // then: ScheduleWakeup({ delaySeconds: 30, ... });
 ```
+
+`Promise.allSettled` keeps a single bad terminalId from killing the whole round; bare `Promise.all` would discard every other snapshot.
 
 For a single terminal a normal blocking `waitUntilIdle` call is fine.
 

--- a/help/CLAUDE.md
+++ b/help/CLAUDE.md
@@ -29,6 +29,47 @@ When choosing what to do, prefer the least-privileged path. If the user asks you
 5. **Be concise.** Quick, actionable answers. No essays.
 6. **Keybindings use macOS notation (Cmd).** On Windows/Linux, substitute Ctrl for Cmd.
 
+## Watching Multiple Agent Terminals
+
+`terminal.waitUntilIdle` blocks for up to 30 minutes by default — fine for a single terminal, harmful when polling several at once. Concurrent default-timeout waits race unpredictably, tie up the orchestrator, and make ordering non-deterministic. Use a non-blocking snapshot loop instead.
+
+**Recipe:**
+
+1. **Snapshot in parallel.** Call `terminal.waitUntilIdle` with `timeoutMs: 0` for each terminal you're watching. Each call returns immediately with `busyState`, `idleReason`, and `lastTransitionAt`. The `timedOut` field is always `false` for snapshots.
+2. **Skip working terminals.** When `busyState === "working"` the agent is mid-task — there's nothing to act on this round.
+3. **Skip already-handled transitions.** Track the last `lastTransitionAt` you acted on per terminal and skip when it hasn't advanced. `lastTransitionAt` is `undefined` for terminals that have never transitioned — treat that as "no transition yet," not as "changed."
+4. **Act on `idleReason`** when `busyState === "idle"`:
+   - `completed` — agent finished its task; record the result and dispatch the next step.
+   - `exited` — agent process exited; surface to the user, the terminal won't recover on its own.
+   - `waiting_for_user` — agent paused, likely needing input. Currently ambiguous (a generic prompt vs. a specific question — see #6960); verify against terminal output before auto-replying.
+   - `idle` — agent is settling between subtasks; skip and re-poll.
+   - `unknown` — no agent attached or unrecognized state; treat as still busy.
+5. **Pace the next round with `ScheduleWakeup`.** Don't busy-loop. `ScheduleWakeup` resumes the orchestrator after a delay without holding a blocking call open, so it stays responsive to user interrupts.
+
+Sketch:
+
+```ts
+const snapshots = await Promise.all(
+  terminalIds.map((id) => waitUntilIdle({ terminalId: id, timeoutMs: 0 }))
+);
+for (const s of snapshots) {
+  if (s.busyState === "working") continue;
+  if (s.lastTransitionAt && s.lastTransitionAt === lastSeen[s.terminalId]) continue;
+  switch (s.idleReason) {
+    case "completed":
+      /* dispatch next step */ break;
+    case "exited":
+      /* surface to user */ break;
+    case "waiting_for_user":
+      /* verify, then act or ask */ break;
+  }
+  if (s.lastTransitionAt) lastSeen[s.terminalId] = s.lastTransitionAt;
+}
+// then: ScheduleWakeup({ delaySeconds: 30, ... });
+```
+
+For a single terminal a normal blocking `waitUntilIdle` call is fine.
+
 ## Topics You Can Help With
 
 - Getting started and first-run setup


### PR DESCRIPTION
## Summary

- Updates the `terminal.waitUntilIdle` tool description and `timeoutMs` property description in the MCP server to warn against parallel long-timeout calls and recommend the `timeoutMs: 0` snapshot pattern when watching multiple terminals
- Promotes `Pass 0 for an immediate non-blocking snapshot` to the front of the `timeoutMs` description so it's the first thing an assistant reads
- Adds a new `## Watching Multiple Agent Terminals` section to `help/CLAUDE.md` with a parallel-snapshot recipe, `idleReason`/`lastTransitionAt` filtering, `ScheduleWakeup` pacing, an action table for all `idleReason` values, and a `Promise.allSettled`-based TypeScript sketch

Resolves #6961

## Changes

- `electron/services/mcp-server/shared.ts` — updated `WAIT_UNTIL_IDLE_DESCRIPTION` and `timeoutMs` property description
- `help/CLAUDE.md` — added multi-terminal watch recipe section

## Testing

Documentation-only changes. Typecheck, `lint:ratchet`, `format:check`, and build all pass. A Codex review caught one factual error (`timedOut` semantics for snapshots) and two robustness gaps in the sketch (`lastTransitionAt` truthiness check; `Promise.all` → `Promise.allSettled`), both fixed before this PR.

- [ ] Verify the `terminal.waitUntilIdle` description change shows up in MCP client tool listings when an external Claude Code session connects to the local Daintree MCP server
- [ ] Verify the `timeoutMs` property description ordering in MCP schema introspection
- [ ] Verify `help/CLAUDE.md` renders correctly when shipped as the help assistant system prompt