### PR TITLE
fix(toaster): make success bump and count-change cue perceptible

### DIFF
--- a/src/components/ui/toaster.tsx
+++ b/src/components/ui/toaster.tsx
@@ -93,6 +93,7 @@ function Toast({ notification }: { notification: Notification }) {
   // intermediate announcements (#6427). Trailing 300ms inactivity window so
   // the final value is announced once the burst settles.
   const [isCountBusy, setIsCountBusy] = useState(false);
+  const [countBumpKey, setCountBumpKey] = useState(0);
   const prevCountRef = useRef(notification.count ?? 0);
 
   useEffect(() => {
@@ -111,6 +112,7 @@ function Toast({ notification }: { notification: Notification }) {
     if (next === prevCountRef.current) return;
     prevCountRef.current = next;
     setIsCountBusy(true);
+    setCountBumpKey((k) => k + 1);
     if (busyTimerRef.current) clearTimeout(busyTimerRef.current);
     busyTimerRef.current = setTimeout(() => {
       if (!mountedRef.current) return;
@@ -267,8 +269,13 @@ function Toast({ notification }: { notification: Notification }) {
               Number.isFinite(notification.count) &&
               notification.count > 1 && (
                 <span
+                  key={countBumpKey}
                   aria-label={formatNotificationCountAriaLabel(notification.count)}
-                  className="shrink-0 rounded-full bg-tint/10 px-1.5 py-0.5 text-[10px] font-medium leading-none text-daintree-text/60 tabular-nums min-w-[3.5ch] text-center"
+                  className={cn(
+                    "shrink-0 rounded-full bg-tint/10 px-1.5 py-0.5 text-[10px] font-medium leading-none text-daintree-text/60 tabular-nums min-w-[3.5ch] text-center",
+                    countBumpKey > 0 && "animate-badge-bump"
+                  )}
+                  style={{ animationDuration: "150ms" }}
                 >
                   {formatNotificationCountGlyph(notification.count, "×")}
                 </span>
@@ -279,8 +286,13 @@ function Toast({ notification }: { notification: Notification }) {
           notification.count > 1 ? (
           <div>
             <span
+              key={countBumpKey}
               aria-label={formatNotificationCountAriaLabel(notification.count)}
-              className="inline-block rounded-full bg-tint/10 px-1.5 py-0.5 text-[10px] font-medium leading-none text-daintree-text/60 tabular-nums min-w-[3.5ch] text-center"
+              className={cn(
+                "inline-block rounded-full bg-tint/10 px-1.5 py-0.5 text-[10px] font-medium leading-none text-daintree-text/60 tabular-nums min-w-[3.5ch] text-center",
+                countBumpKey > 0 && "animate-badge-bump"
+              )}
+              style={{ animationDuration: "150ms" }}
             >
               {formatNotificationCountGlyph(notification.count, "×")}
             </span>
@@ -382,9 +394,7 @@ function Toast({ notification }: { notification: Notification }) {
             <div
               className={cn(
                 "mt-1.5 flex flex-wrap gap-1.5",
-                isSuccess && "scale-[1.02]",
-                "transition-transform duration-[75ms]",
-                "motion-reduce:scale-100 motion-reduce:transition-none"
+                isSuccess && "animate-action-row-bump"
               )}
             >
               {actions.map((action, index) => {

--- a/src/components/ui/toaster.tsx
+++ b/src/components/ui/toaster.tsx
@@ -93,7 +93,11 @@ function Toast({ notification }: { notification: Notification }) {
   // intermediate announcements (#6427). Trailing 300ms inactivity window so
   // the final value is announced once the burst settles.
   const [isCountBusy, setIsCountBusy] = useState(false);
-  const [countBumpKey, setCountBumpKey] = useState(0);
+  // Transient flag: set on every count change, cleared by onAnimationEnd.
+  // Self-throttles bursts (next change during active animation is a no-op
+  // until the cycle completes) and avoids a stale class re-applying when
+  // the chip remounts across the title-present / title-absent branches.
+  const [isCountBumping, setIsCountBumping] = useState(false);
   const prevCountRef = useRef(notification.count ?? 0);
 
   useEffect(() => {
@@ -112,7 +116,7 @@ function Toast({ notification }: { notification: Notification }) {
     if (next === prevCountRef.current) return;
     prevCountRef.current = next;
     setIsCountBusy(true);
-    setCountBumpKey((k) => k + 1);
+    setIsCountBumping(true);
     if (busyTimerRef.current) clearTimeout(busyTimerRef.current);
     busyTimerRef.current = setTimeout(() => {
       if (!mountedRef.current) return;
@@ -269,13 +273,15 @@ function Toast({ notification }: { notification: Notification }) {
               Number.isFinite(notification.count) &&
               notification.count > 1 && (
                 <span
-                  key={countBumpKey}
                   aria-label={formatNotificationCountAriaLabel(notification.count)}
                   className={cn(
                     "shrink-0 rounded-full bg-tint/10 px-1.5 py-0.5 text-[10px] font-medium leading-none text-daintree-text/60 tabular-nums min-w-[3.5ch] text-center",
-                    countBumpKey > 0 && "animate-badge-bump"
+                    isCountBumping && "animate-badge-bump"
                   )}
                   style={{ animationDuration: "150ms" }}
+                  onAnimationEnd={(e) => {
+                    if (e.animationName === "badge-bump") setIsCountBumping(false);
+                  }}
                 >
                   {formatNotificationCountGlyph(notification.count, "×")}
                 </span>
@@ -286,13 +292,15 @@ function Toast({ notification }: { notification: Notification }) {
           notification.count > 1 ? (
           <div>
             <span
-              key={countBumpKey}
               aria-label={formatNotificationCountAriaLabel(notification.count)}
               className={cn(
                 "inline-block rounded-full bg-tint/10 px-1.5 py-0.5 text-[10px] font-medium leading-none text-daintree-text/60 tabular-nums min-w-[3.5ch] text-center",
-                countBumpKey > 0 && "animate-badge-bump"
+                isCountBumping && "animate-badge-bump"
               )}
               style={{ animationDuration: "150ms" }}
+              onAnimationEnd={(e) => {
+                if (e.animationName === "badge-bump") setIsCountBumping(false);
+              }}
             >
               {formatNotificationCountGlyph(notification.count, "×")}
             </span>

--- a/src/index.css
+++ b/src/index.css
@@ -1211,6 +1211,25 @@ body,
   will-change: transform;
 }
 
+/* Action-row success bump — tuned 3% peak for row-sized elements
+ * (the 6% in badge-bump reads as aggressive on a wider container). */
+@keyframes action-row-bump {
+  0% {
+    transform: scale(1);
+  }
+  35% {
+    transform: scale(1.03);
+  }
+  100% {
+    transform: scale(1);
+  }
+}
+
+.animate-action-row-bump {
+  animation: action-row-bump 200ms cubic-bezier(0.4, 0, 0.2, 1) both;
+  will-change: transform;
+}
+
 /* Diagnostics badge state transition flash - one-shot, no looping */
 @keyframes diagnostics-state-flash {
   0% {
@@ -1514,6 +1533,7 @@ body,
   .animate-hint-fade-in,
   .status-working,
   .animate-badge-bump,
+  .animate-action-row-bump,
   .animate-activity-blip,
   .animate-trash-pulse,
   .animate-all-clear-flash,
@@ -1651,6 +1671,7 @@ body[data-reduce-animations="true"]
     .animate-hint-fade-in,
     .status-working,
     .animate-badge-bump,
+    .animate-action-row-bump,
     .animate-activity-blip,
     .animate-trash-pulse,
     .animate-all-clear-flash,


### PR DESCRIPTION
## Summary

- The action-row success bump used `scale(1.02)` over `75ms` -- both below the just-noticeable-difference threshold. Replaced with a new `action-row-bump` keyframe that scales `1 → 1.03 → 1` over `200ms` cubic-bezier.
- Count chip text was swapping silently when coalescing same-entity events. A transient `isCountBumping` flag now triggers `animate-badge-bump` on count change, cleared via `onAnimationEnd`. The `badge-bump` keyframe was already in `index.css` -- it just wasn't wired to this surface.

Resolves #6965

## Changes

- `src/index.css` -- new `@keyframes action-row-bump` and `.animate-action-row-bump` utility, registered in both reduced-motion explicit class lists
- `src/components/ui/toaster.tsx` -- transient `isCountBumping` flag; `animate-badge-bump` applied conditionally on the count chip; success row swapped to `animate-action-row-bump`

## Testing

Verified both cues are visually perceptible: success bump reads as a discrete tactile event, count chip pulses on each coalesced increment. Reduced-motion: both animations stripped by the global catch-all in `index.css`. Typecheck, lint ratchet, and format check all pass.