### PR TITLE
fix(onboarding): polish checklist completion beat

### DIFF
--- a/src/components/Onboarding/CelebrationConfetti.tsx
+++ b/src/components/Onboarding/CelebrationConfetti.tsx
@@ -49,7 +49,10 @@ function isReducedMotion(): boolean {
   if (typeof window === "undefined") return false;
   if (window.matchMedia("(prefers-reduced-motion: reduce)").matches) return true;
   if (typeof document !== "undefined") {
-    return document.body.getAttribute("data-reduce-animations") === "true";
+    if (document.body.getAttribute("data-reduce-animations") === "true") return true;
+    // Performance mode skips the spring-driven particle system; the CSS
+    // flash overlay below is the lightweight fallback.
+    if (document.body.getAttribute("data-performance-mode") === "true") return true;
   }
   return false;
 }

--- a/src/components/Onboarding/CelebrationConfetti.tsx
+++ b/src/components/Onboarding/CelebrationConfetti.tsx
@@ -75,7 +75,9 @@ function readAnchor(): { x: number; y: number } {
 
 export function CelebrationConfetti() {
   const [reducedMotion] = useState(isReducedMotion);
-  const [particles] = useState(generateParticles);
+  // Skip the spring-particle setup work entirely under reduced-motion or
+  // performance-mode — the flash overlay below is the only thing we render.
+  const [particles] = useState<Particle[]>(() => (reducedMotion ? [] : generateParticles()));
   const [anchor, setAnchor] = useState<{ x: number; y: number } | null>(null);
 
   useEffect(() => {

--- a/src/components/Onboarding/GettingStartedChecklist.tsx
+++ b/src/components/Onboarding/GettingStartedChecklist.tsx
@@ -3,6 +3,7 @@ import { createPortal } from "react-dom";
 import { Check, ChevronDown, ChevronUp, X } from "lucide-react";
 import { cn } from "@/lib/utils";
 import { actionService } from "@/services/ActionService";
+import { AnimatedLabel } from "@/components/ui/AnimatedLabel";
 import type { ChecklistState, ChecklistItemId } from "@shared/types/ipc/maps";
 import { CHECKLIST_ITEMS } from "./checklistItems";
 
@@ -30,6 +31,9 @@ export function GettingStartedChecklist({
 
   const completedCount = Object.values(checklist.items).filter(Boolean).length;
   const totalCount = CHECKLIST_ITEMS.length;
+  const allComplete = completedCount === totalCount;
+  const counterLabel = allComplete ? "All done" : `${completedCount}/${totalCount}`;
+  const counterAnimateKey = allComplete ? "all-done" : String(completedCount);
 
   return createPortal(
     <div
@@ -63,9 +67,11 @@ export function GettingStartedChecklist({
             <h4 className="font-medium leading-tight tracking-tight text-xs font-mono text-daintree-accent">
               Getting Started
             </h4>
-            <span className="text-[10px] text-daintree-text/50 font-mono tabular-nums">
-              {completedCount}/{totalCount}
-            </span>
+            <AnimatedLabel
+              label={counterLabel}
+              animateKey={counterAnimateKey}
+              textClassName="text-[10px] text-daintree-text/50 font-mono tabular-nums"
+            />
             {collapsed ? (
               <ChevronUp className="h-3 w-3 text-daintree-text/50 shrink-0" />
             ) : (

--- a/src/components/Onboarding/__tests__/CelebrationConfetti.test.tsx
+++ b/src/components/Onboarding/__tests__/CelebrationConfetti.test.tsx
@@ -69,12 +69,14 @@ describe("CelebrationConfetti", () => {
   beforeEach(() => {
     stubMatchMedia(false);
     document.body.removeAttribute("data-reduce-animations");
+    document.body.removeAttribute("data-performance-mode");
   });
 
   afterEach(() => {
     cleanup();
     document.body.innerHTML = "";
     document.body.removeAttribute("data-reduce-animations");
+    document.body.removeAttribute("data-performance-mode");
     vi.unstubAllGlobals();
   });
 
@@ -99,6 +101,17 @@ describe("CelebrationConfetti", () => {
 
   it("renders a flash overlay when body[data-reduce-animations='true'] is set", () => {
     document.body.setAttribute("data-reduce-animations", "true");
+
+    render(<CelebrationConfetti />);
+    const particles = document.body.querySelectorAll("[class*='rounded-full']");
+    expect(particles.length).toBe(0);
+
+    const flash = document.body.querySelector(".animate-checklist-complete-flash");
+    expect(flash).not.toBeNull();
+  });
+
+  it("renders a flash overlay when body[data-performance-mode='true'] is set", () => {
+    document.body.setAttribute("data-performance-mode", "true");
 
     render(<CelebrationConfetti />);
     const particles = document.body.querySelectorAll("[class*='rounded-full']");

--- a/src/components/Onboarding/__tests__/GettingStartedChecklist.test.tsx
+++ b/src/components/Onboarding/__tests__/GettingStartedChecklist.test.tsx
@@ -150,4 +150,16 @@ describe("GettingStartedChecklist", () => {
     expect(defaultProps.onDismiss).not.toHaveBeenCalled();
     expect(defaultProps.onToggleCollapse).not.toHaveBeenCalled();
   });
+
+  it("renders the n/n counter while the checklist is incomplete", () => {
+    render(<GettingStartedChecklist {...defaultProps} checklist={mixedState} />);
+    expect(screen.getByText("1/4")).toBeTruthy();
+    expect(screen.queryByText("All done")).toBeNull();
+  });
+
+  it("renders the 'All done' milestone label when every item is complete", () => {
+    render(<GettingStartedChecklist {...defaultProps} checklist={allComplete} />);
+    expect(screen.getByText("All done")).toBeTruthy();
+    expect(screen.queryByText("4/4")).toBeNull();
+  });
 });

--- a/src/hooks/app/__tests__/useGettingStartedChecklist.test.tsx
+++ b/src/hooks/app/__tests__/useGettingStartedChecklist.test.tsx
@@ -439,6 +439,48 @@ describe("useGettingStartedChecklist", () => {
       }
     });
 
+    it("applies onChecklistPush(dismissed:true) immediately when no hold is active", async () => {
+      let pushHandler: ((next: ChecklistStateLike) => void) | null = null;
+      const onChecklistPushMock = vi.fn((fn: (next: ChecklistStateLike) => void) => {
+        pushHandler = fn;
+        return () => {};
+      });
+      const augmentedMock = onboardingMock as typeof onboardingMock & {
+        onChecklistPush: typeof onChecklistPushMock;
+      };
+      augmentedMock.onChecklistPush = onChecklistPushMock;
+
+      try {
+        const { result } = renderHook(() => useGettingStartedChecklist(true));
+        await act(async () => {
+          await vi.advanceTimersByTimeAsync(0);
+        });
+
+        expect(result.current.visible).toBe(true);
+        expect(pushHandler).not.toBeNull();
+
+        // No markItem(allDone), so pendingDismissRef is false. The push gate
+        // must be inactive and dismissed:true must take effect immediately.
+        await act(async () => {
+          pushHandler!({
+            items: {
+              openedProject: true,
+              launchedAgent: true,
+              createdWorktree: true,
+              ranSecondParallelAgent: true,
+            },
+            dismissed: true,
+            celebrationShown: false,
+          });
+        });
+
+        expect(result.current.checklist?.dismissed).toBe(true);
+        expect(result.current.visible).toBe(false);
+      } finally {
+        delete (augmentedMock as Partial<typeof augmentedMock>).onChecklistPush;
+      }
+    });
+
     it("manual dismiss() during the hold dismisses the panel immediately", async () => {
       const { result } = renderHook(() => useGettingStartedChecklist(true));
       await act(async () => {

--- a/src/hooks/app/__tests__/useGettingStartedChecklist.test.tsx
+++ b/src/hooks/app/__tests__/useGettingStartedChecklist.test.tsx
@@ -323,7 +323,7 @@ describe("useGettingStartedChecklist", () => {
       expect(notifyMock).toHaveBeenCalledTimes(1);
       const args = notifyMock.mock.calls[0]![0];
       expect(args.type).toBe("success");
-      expect(args.title).toBe("Checklist complete!");
+      expect(args.title).toBe("Checklist complete");
       expect(args.message).toBe("You're all set. Open the panel palette (⌘+N) to launch an agent");
       expect(args.transient).toBe(true);
     });
@@ -344,4 +344,135 @@ describe("useGettingStartedChecklist", () => {
       expect(args.message).not.toContain("(");
     });
   });
+
+  describe("milestone-beat hold", () => {
+    beforeEach(() => {
+      onboardingMock.getChecklist.mockResolvedValue({
+        items: {
+          openedProject: true,
+          launchedAgent: true,
+          createdWorktree: true,
+          ranSecondParallelAgent: false,
+        },
+        dismissed: false,
+        celebrationShown: false,
+      });
+    });
+
+    it("keeps panel visible during the hold, then dismisses after 800ms", async () => {
+      const { result } = renderHook(() => useGettingStartedChecklist(true));
+      await act(async () => {
+        await vi.advanceTimersByTimeAsync(0);
+      });
+
+      await act(async () => {
+        result.current.markItem("ranSecondParallelAgent");
+      });
+
+      // IPC dismiss fires immediately for restart safety.
+      expect(onboardingMock.dismissChecklist).toHaveBeenCalledTimes(1);
+      // Panel stays visible during the hold.
+      expect(result.current.visible).toBe(true);
+      expect(result.current.checklist?.dismissed).toBe(false);
+
+      await act(async () => {
+        await vi.advanceTimersByTimeAsync(799);
+      });
+      expect(result.current.visible).toBe(true);
+
+      await act(async () => {
+        await vi.advanceTimersByTimeAsync(1);
+      });
+      expect(result.current.visible).toBe(false);
+      expect(result.current.checklist?.dismissed).toBe(true);
+    });
+
+    it("ignores onChecklistPush(dismissed:true) during the hold window", async () => {
+      let pushHandler: ((next: ChecklistStateLike) => void) | null = null;
+      const onChecklistPushMock = vi.fn((fn: (next: ChecklistStateLike) => void) => {
+        pushHandler = fn;
+        return () => {};
+      });
+      const augmentedMock = onboardingMock as typeof onboardingMock & {
+        onChecklistPush: typeof onChecklistPushMock;
+      };
+      augmentedMock.onChecklistPush = onChecklistPushMock;
+
+      try {
+        const { result } = renderHook(() => useGettingStartedChecklist(true));
+        await act(async () => {
+          await vi.advanceTimersByTimeAsync(0);
+        });
+
+        await act(async () => {
+          result.current.markItem("ranSecondParallelAgent");
+        });
+
+        expect(result.current.visible).toBe(true);
+        expect(pushHandler).not.toBeNull();
+
+        // Main process broadcasts the persisted dismissed:true mid-hold;
+        // the panel must stay visible until the local timer fires.
+        await act(async () => {
+          pushHandler!({
+            items: {
+              openedProject: true,
+              launchedAgent: true,
+              createdWorktree: true,
+              ranSecondParallelAgent: true,
+            },
+            dismissed: true,
+            celebrationShown: true,
+          });
+        });
+
+        expect(result.current.visible).toBe(true);
+        expect(result.current.checklist?.dismissed).toBe(false);
+
+        await act(async () => {
+          await vi.advanceTimersByTimeAsync(800);
+        });
+        expect(result.current.visible).toBe(false);
+        expect(result.current.checklist?.dismissed).toBe(true);
+      } finally {
+        delete (augmentedMock as Partial<typeof augmentedMock>).onChecklistPush;
+      }
+    });
+
+    it("manual dismiss() during the hold dismisses the panel immediately", async () => {
+      const { result } = renderHook(() => useGettingStartedChecklist(true));
+      await act(async () => {
+        await vi.advanceTimersByTimeAsync(0);
+      });
+
+      await act(async () => {
+        result.current.markItem("ranSecondParallelAgent");
+      });
+      expect(result.current.visible).toBe(true);
+
+      await act(async () => {
+        result.current.dismiss();
+      });
+
+      expect(result.current.visible).toBe(false);
+      expect(result.current.checklist?.dismissed).toBe(true);
+
+      // Pending timer must be a no-op after manual dismiss.
+      await act(async () => {
+        await vi.advanceTimersByTimeAsync(800);
+      });
+      expect(result.current.visible).toBe(false);
+    });
+  });
 });
+
+interface ChecklistStateLike {
+  items: {
+    openedProject: boolean;
+    launchedAgent: boolean;
+    createdWorktree: boolean;
+    ranSecondParallelAgent: boolean;
+  };
+  dismissed: boolean;
+  celebrationShown: boolean;
+}

--- a/src/hooks/app/useGettingStartedChecklist.ts
+++ b/src/hooks/app/useGettingStartedChecklist.ts
@@ -65,13 +65,22 @@ function reconcileCurrentState(
   }
 }
 
+// Hold the panel visible briefly after the final tick so AnimatedLabel can
+// crossfade the counter to a milestone label before the panel exits.
+const PENDING_DISMISS_HOLD_MS = 800;
+
 export function useGettingStartedChecklist(isStateLoaded: boolean): GettingStartedChecklistState {
   const [checklist, setChecklist] = useState<ChecklistState | null>(null);
   const [onboardingCompleted, setOnboardingCompleted] = useState(false);
   const [collapsed, setCollapsed] = useState(false);
   const [forceShow, setForceShow] = useState(false);
   const [showCelebration, setShowCelebration] = useState(false);
+  const [pendingDismiss, setPendingDismiss] = useState(false);
   const checklistRef = useRef(checklist);
+  // Mirror pendingDismiss into a ref so the onChecklistPush merge (which runs
+  // inside a setChecklist functional updater and can't read React state) can
+  // gate the incoming dismissed:true during the hold window.
+  const pendingDismissRef = useRef(false);
   useEffect(() => {
     checklistRef.current = checklist;
   }, [checklist]);
@@ -90,14 +99,19 @@ export function useGettingStartedChecklist(isStateLoaded: boolean): GettingStart
 
     const updatedItems = { ...prev.items, [item]: true };
     const allDone = Object.values(updatedItems).every(Boolean);
+    // Defer local `dismissed: true` until the hold timer fires so the panel
+    // can show the milestone beat. Persistence via dismissChecklist() runs
+    // immediately for restart safety.
     const next: ChecklistState = allDone
-      ? { ...prev, items: updatedItems, dismissed: true, celebrationShown: true }
+      ? { ...prev, items: updatedItems, celebrationShown: true }
       : { ...prev, items: updatedItems };
 
     setChecklist(next);
     checklistRef.current = next;
 
     if (allDone) {
+      pendingDismissRef.current = true;
+      setPendingDismiss(true);
       safeFireAndForget(window.electron.onboarding.dismissChecklist(), {
         context: "Dismissing onboarding checklist",
       });
@@ -108,7 +122,7 @@ export function useGettingStartedChecklist(isStateLoaded: boolean): GettingStart
           : "You're all set. Open the panel palette to launch an agent";
         notify({
           type: "success",
-          title: "Checklist complete!",
+          title: "Checklist complete",
           message,
           duration: 5000,
           transient: true,
@@ -126,6 +140,8 @@ export function useGettingStartedChecklist(isStateLoaded: boolean): GettingStart
     safeFireAndForget(window.electron.onboarding.dismissChecklist(), {
       context: "Dismissing onboarding checklist (user action)",
     });
+    pendingDismissRef.current = false;
+    setPendingDismiss(false);
     setChecklist((prev) => (prev ? { ...prev, dismissed: true } : prev));
     setForceShow(false);
   }, []);
@@ -166,10 +182,13 @@ export function useGettingStartedChecklist(isStateLoaded: boolean): GettingStart
         for (const key of Object.keys(next.items) as Array<keyof typeof next.items>) {
           if (next.items[key] || prev.items[key]) mergedItems[key] = true;
         }
+        // Suppress incoming dismissed:true during the milestone-beat hold —
+        // the timer below applies the local dismissal once the beat finishes.
+        const incomingDismissed = pendingDismissRef.current ? false : next.dismissed;
         const merged: ChecklistState = {
           ...next,
           items: mergedItems,
-          dismissed: prev.dismissed || next.dismissed,
+          dismissed: prev.dismissed || incomingDismissed,
           celebrationShown: prev.celebrationShown || next.celebrationShown,
         };
         checklistRef.current = merged;
@@ -268,9 +287,22 @@ export function useGettingStartedChecklist(isStateLoaded: boolean): GettingStart
     return () => clearTimeout(timer);
   }, [showCelebration]);
 
+  // Hold the panel for a brief milestone beat after the final tick, then
+  // commit the local dismissal so the panel exits.
+  useEffect(() => {
+    if (!pendingDismiss) return;
+    const timer = setTimeout(() => {
+      pendingDismissRef.current = false;
+      setPendingDismiss(false);
+      setChecklist((prev) => (prev ? { ...prev, dismissed: true } : prev));
+    }, PENDING_DISMISS_HOLD_MS);
+    return () => clearTimeout(timer);
+  }, [pendingDismiss]);
+
   const allDone = checklist ? Object.values(checklist.items).every(Boolean) : false;
   const visible =
-    checklist !== null && (forceShow || (onboardingCompleted && !checklist.dismissed && !allDone));
+    checklist !== null &&
+    (forceShow || (onboardingCompleted && !checklist.dismissed && (!allDone || pendingDismiss)));
 
   return {
     visible,

--- a/src/hooks/app/useGettingStartedChecklist.ts
+++ b/src/hooks/app/useGettingStartedChecklist.ts
@@ -295,6 +295,10 @@ export function useGettingStartedChecklist(isStateLoaded: boolean): GettingStart
       pendingDismissRef.current = false;
       setPendingDismiss(false);
       setChecklist((prev) => (prev ? { ...prev, dismissed: true } : prev));
+      // forceShow keeps `visible` true even after `dismissed:true`. If the
+      // user reached completion via Help > Getting Started, clear it here
+      // so the panel exits with the rest of the beat.
+      setForceShow(false);
     }, PENDING_DISMISS_HOLD_MS);
     return () => clearTimeout(timer);
   }, [pendingDismiss]);


### PR DESCRIPTION
## Summary

- The checklist panel now holds for 800ms after the final item is ticked, giving `AnimatedLabel` time to crossfade the `n/n` counter to an **All done** milestone label before the panel exits. `dismissChecklist()` IPC fires immediately for restart safety; a `pendingDismissRef` gates the `onChecklistPush` merge so `dismissed: true` can't re-apply during the hold window. Manual dismiss short-circuits the timer.
- `CelebrationConfetti` now honours `data-performance-mode`, falling back to the CSS flash overlay and skipping `generateParticles()` entirely when reduced motion is active. Mirrors the `AllClearOverlay` precedent.
- Success toast title drops the exclamation mark to match house microcopy style.

Resolves #6962

## Changes

- `useGettingStartedChecklist.ts` — 800ms hold timer, `pendingDismissRef` gate, `forceShow` clear on hold expiry
- `CelebrationConfetti.tsx` — `data-performance-mode` check in `isReducedMotion`, early return before particle setup
- `GettingStartedChecklist.tsx` — **All done** milestone label wired into `AnimatedLabel`
- Tests — 3 milestone-beat-hold tests, 1 `onChecklistPush` gate regression, 2 counter/All-done label tests, 1 performance-mode flash fallback, updated toast-title assertion

## Testing

34 targeted tests pass across `useGettingStartedChecklist.test.tsx`, `GettingStartedChecklist.test.tsx`, and `CelebrationConfetti.test.tsx`. Typecheck, channel-drift check, lint ratchet (876 baseline), format, and build all clean.