### PR TITLE
feat(clipboard): standardize copy-to-clipboard feedback

### DIFF
--- a/src/components/Project/ProjectSwitcher.tsx
+++ b/src/components/Project/ProjectSwitcher.tsx
@@ -9,6 +9,7 @@ import { Spinner } from "@/components/ui/Spinner";
 import { Tooltip, TooltipContent, TooltipTrigger } from "@/components/ui/tooltip";
 import { useKeybindingDisplay } from "@/hooks/useKeybinding";
 import { useProjectSwitcherPalette } from "@/hooks";
+import { useCopyWithFeedback } from "@/hooks/useCopyWithFeedback";
 import { actionService } from "@/services/ActionService";
 import { notify } from "@/lib/notify";
 import { ProjectSwitcherPalette } from "./ProjectSwitcherPalette";
@@ -86,16 +87,13 @@ export function ProjectSwitcher() {
     [projectSwitcher]
   );
 
-  const handleCopyPath = useCallback((path: string) => {
-    void navigator.clipboard.writeText(path);
-    notify({
-      type: "info",
-      title: "Path copied",
-      message: path,
-      duration: 2000,
-      transient: true,
-    });
-  }, []);
+  const { copy: copyProjectPath } = useCopyWithFeedback();
+  const handleCopyPath = useCallback(
+    (path: string) => {
+      void copyProjectPath(path);
+    },
+    [copyProjectPath]
+  );
 
   const handleSelectBackground = useCallback(
     (project: SearchableProject) => {

--- a/src/components/Recovery/CrashRecoveryDialog.tsx
+++ b/src/components/Recovery/CrashRecoveryDialog.tsx
@@ -12,7 +12,9 @@ import {
 import { Plug } from "@/components/icons";
 import { AppDialog } from "../ui/AppDialog";
 import { Button } from "../ui/button";
+import { AnimatedLabel } from "../ui/AnimatedLabel";
 import { logError } from "@/utils/logger";
+import { useCopyWithFeedback } from "@/hooks/useCopyWithFeedback";
 import type {
   PendingCrash,
   PanelSummary,
@@ -58,7 +60,7 @@ export function CrashRecoveryDialog({
   const [resolving, setResolving] = useState(false);
   const [detailsOpen, setDetailsOpen] = useState(false);
   const [privacyWarningShown, setPrivacyWarningShown] = useState(false);
-  const [copied, setCopied] = useState(false);
+  const { copied, copy } = useCopyWithFeedback();
 
   const selectedCount = selectedIds.size;
   const allSelected = selectedCount === panels.length;
@@ -119,15 +121,11 @@ export function CrashRecoveryDialog({
       setPrivacyWarningShown(true);
       return;
     }
-    const text = buildClipboardText(crash);
-    navigator.clipboard.writeText(text).then(() => {
-      setCopied(true);
-      setTimeout(() => setCopied(false), 2000);
-    });
+    void copy(buildClipboardText(crash));
     window.electron.system
       .openExternal(ISSUES_URL)
       .catch((err) => logError("Failed to open issues URL", err));
-  }, [privacyWarningShown, crash]);
+  }, [privacyWarningShown, crash, copy]);
 
   const handleAutoRestore = useCallback(
     async (checked: boolean) => {
@@ -361,11 +359,16 @@ export function CrashRecoveryDialog({
                   data-testid="report-button"
                 >
                   <ExternalLink className="h-3 w-3 mr-1" />
-                  {copied
-                    ? "Copied!"
-                    : privacyWarningShown
-                      ? "Copy & report on GitHub"
-                      : "Report this crash"}
+                  <AnimatedLabel
+                    label={
+                      copied
+                        ? "Copied!"
+                        : privacyWarningShown
+                          ? "Copy & report on GitHub"
+                          : "Report this crash"
+                    }
+                    animateKey={copied ? "copied" : privacyWarningShown ? "warn" : "default"}
+                  />
                 </Button>
               </div>
 

--- a/src/components/Recovery/CrashRecoveryDialog.tsx
+++ b/src/components/Recovery/CrashRecoveryDialog.tsx
@@ -116,12 +116,13 @@ export function CrashRecoveryDialog({
       .catch((err) => logError("Failed to open crash log path", err));
   }, [crash.logPath]);
 
-  const handleReport = useCallback(() => {
+  const handleReport = useCallback(async () => {
     if (!privacyWarningShown) {
       setPrivacyWarningShown(true);
       return;
     }
-    void copy(buildClipboardText(crash));
+    const ok = await copy(buildClipboardText(crash));
+    if (!ok) return;
     window.electron.system
       .openExternal(ISSUES_URL)
       .catch((err) => logError("Failed to open issues URL", err));
@@ -355,7 +356,7 @@ export function CrashRecoveryDialog({
                   size="sm"
                   variant="ghost"
                   className="text-xs h-7"
-                  onClick={handleReport}
+                  onClick={() => void handleReport()}
                   data-testid="report-button"
                 >
                   <ExternalLink className="h-3 w-3 mr-1" />

--- a/src/components/Recovery/__tests__/CrashRecoveryDialog.test.tsx
+++ b/src/components/Recovery/__tests__/CrashRecoveryDialog.test.tsx
@@ -321,6 +321,28 @@ describe("CrashRecoveryDialog", () => {
     );
   });
 
+  it("first report click does not write to clipboard or open browser", () => {
+    setup();
+    fireEvent.click(screen.getByTestId("details-toggle"));
+    fireEvent.click(screen.getByTestId("report-button"));
+    expect(navigator.clipboard.writeText).not.toHaveBeenCalled();
+    expect(window.electron.system.openExternal).not.toHaveBeenCalled();
+  });
+
+  it("does not open the browser when clipboard write fails", async () => {
+    (navigator.clipboard.writeText as ReturnType<typeof vi.fn>).mockRejectedValueOnce(
+      new Error("denied")
+    );
+    setup();
+    fireEvent.click(screen.getByTestId("details-toggle"));
+    fireEvent.click(screen.getByTestId("report-button"));
+    fireEvent.click(screen.getByTestId("report-button"));
+    await waitFor(() => expect(navigator.clipboard.writeText).toHaveBeenCalled());
+    // Allow the awaited copy promise rejection to settle.
+    await Promise.resolve();
+    expect(window.electron.system.openExternal).not.toHaveBeenCalled();
+  });
+
   it("calls onUpdateConfig when auto-restore checkbox is changed", async () => {
     const { onUpdateConfig } = setup();
     fireEvent.click(screen.getByTestId("auto-restore-checkbox"));

--- a/src/components/Setup/AgentCliStep.tsx
+++ b/src/components/Setup/AgentCliStep.tsx
@@ -17,7 +17,7 @@ import { getInstallBlocksForCurrentOS, isBlockExecutable } from "@/lib/agentInst
 import { systemClient } from "@/clients";
 import { useAgentSettingsStore } from "@/store";
 import { DEFAULT_DANGEROUS_ARGS } from "@shared/types/agentSettings";
-import { CopyableCommand } from "./InstallBlock";
+import { CopyableCommand } from "./CopyableCommand";
 import { AGENT_DESCRIPTIONS } from "@/config/agents";
 import type { CliAvailability } from "@shared/types";
 import { isAgentInstalled } from "@shared/utils/agentAvailability";

--- a/src/components/Setup/AgentCliStep.tsx
+++ b/src/components/Setup/AgentCliStep.tsx
@@ -325,8 +325,8 @@ export function AgentCliStep({ availability, selections, onInstallComplete }: Ag
                   <div className="text-[11px] text-daintree-text/40 mb-1">
                     Run this command in your terminal. It will be detected automatically.
                   </div>
-                  {currentBlock.commands.map((cmd, i) => (
-                    <CopyableCommand key={i} command={cmd} />
+                  {currentBlock.commands.map((cmd) => (
+                    <CopyableCommand key={cmd} command={cmd} />
                   ))}
                 </div>
               )}
@@ -355,8 +355,8 @@ export function AgentCliStep({ availability, selections, onInstallComplete }: Ag
                   {currentBlock?.commands && (
                     <div className="space-y-1">
                       <div className="text-[11px] text-daintree-text/40">Or install manually:</div>
-                      {currentBlock.commands.map((cmd, i) => (
-                        <CopyableCommand key={i} command={cmd} />
+                      {currentBlock.commands.map((cmd) => (
+                        <CopyableCommand key={cmd} command={cmd} />
                       ))}
                     </div>
                   )}

--- a/src/components/Setup/CopyableCommand.tsx
+++ b/src/components/Setup/CopyableCommand.tsx
@@ -1,0 +1,26 @@
+import { Check, Copy } from "lucide-react";
+import { cn } from "@/lib/utils";
+import { useCopyWithFeedback } from "@/hooks/useCopyWithFeedback";
+
+export function CopyableCommand({ command }: { command: string }) {
+  const { copied, copy } = useCopyWithFeedback();
+
+  return (
+    <div className="flex items-center gap-2 px-3 py-1.5 rounded-[var(--radius-sm)] bg-overlay-subtle border border-daintree-border font-mono text-xs select-text group">
+      <span className="flex-1 truncate text-daintree-text/70">{command}</span>
+      <button
+        type="button"
+        onClick={() => void copy(command)}
+        className="shrink-0 p-0.5 rounded hover:bg-overlay transition-colors duration-150 text-daintree-text/30 hover:text-daintree-text/60"
+        aria-label="Copy command to clipboard"
+        title="Copy to clipboard"
+      >
+        {copied ? (
+          <Check key="check" className={cn("w-3.5 h-3.5 text-status-success animate-badge-bump")} />
+        ) : (
+          <Copy key="copy" className="w-3.5 h-3.5" />
+        )}
+      </button>
+    </div>
+  );
+}

--- a/src/components/Setup/InstallBlock.tsx
+++ b/src/components/Setup/InstallBlock.tsx
@@ -1,6 +1,7 @@
-import { useCallback, useEffect, useRef, useState } from "react";
-import { Check, Copy } from "lucide-react";
 import type { AgentInstallBlock } from "@shared/config/agentRegistry";
+import { CopyableCommand } from "./CopyableCommand";
+
+export { CopyableCommand };
 
 export function InstallBlock({ block }: { block: AgentInstallBlock }) {
   return (
@@ -29,43 +30,6 @@ export function InstallBlock({ block }: { block: AgentInstallBlock }) {
           ))}
         </div>
       )}
-    </div>
-  );
-}
-
-export function CopyableCommand({ command }: { command: string }) {
-  const [copied, setCopied] = useState(false);
-  const timeoutRef = useRef<ReturnType<typeof setTimeout> | null>(null);
-
-  useEffect(() => {
-    return () => {
-      if (timeoutRef.current) clearTimeout(timeoutRef.current);
-    };
-  }, []);
-
-  const handleCopy = useCallback(() => {
-    navigator.clipboard.writeText(command).then(() => {
-      if (timeoutRef.current) clearTimeout(timeoutRef.current);
-      setCopied(true);
-      timeoutRef.current = setTimeout(() => setCopied(false), 2000);
-    });
-  }, [command]);
-
-  return (
-    <div className="flex items-center gap-2 px-3 py-2 rounded-[var(--radius-sm)] bg-daintree-bg border border-daintree-border">
-      <code className="flex-1 text-xs text-daintree-text font-mono select-all">{command}</code>
-      <button
-        type="button"
-        onClick={handleCopy}
-        className="shrink-0 p-1 text-daintree-text/40 hover:text-daintree-text transition-colors rounded"
-        title="Copy to clipboard"
-      >
-        {copied ? (
-          <Check className="w-3.5 h-3.5 text-status-success" />
-        ) : (
-          <Copy className="w-3.5 h-3.5" />
-        )}
-      </button>
     </div>
   );
 }

--- a/src/components/Setup/InstallBlock.tsx
+++ b/src/components/Setup/InstallBlock.tsx
@@ -18,8 +18,8 @@ export function InstallBlock({ block }: { block: AgentInstallBlock }) {
       )}
       {block.commands && block.commands.length > 0 && (
         <div className="space-y-1.5">
-          {block.commands.map((cmd, i) => (
-            <CopyableCommand key={i} command={cmd} />
+          {block.commands.map((cmd) => (
+            <CopyableCommand key={cmd} command={cmd} />
           ))}
         </div>
       )}

--- a/src/components/Terminal/MissingCliGate.tsx
+++ b/src/components/Terminal/MissingCliGate.tsx
@@ -108,8 +108,8 @@ function InstallCommands({ blocks }: { blocks: AgentInstallBlock[] }) {
           )}
           {block.commands && (
             <div className="space-y-1.5">
-              {block.commands.map((cmd, j) => (
-                <CopyableCommand key={j} command={cmd} />
+              {block.commands.map((cmd) => (
+                <CopyableCommand key={cmd} command={cmd} />
               ))}
             </div>
           )}

--- a/src/components/Terminal/MissingCliGate.tsx
+++ b/src/components/Terminal/MissingCliGate.tsx
@@ -1,6 +1,6 @@
-import { useState, useCallback } from "react";
-import { AlertTriangle, Terminal, Clipboard, Check, ExternalLink } from "lucide-react";
+import { AlertTriangle, Terminal, Check, ExternalLink } from "lucide-react";
 import { Button } from "@/components/ui/button";
+import { CopyableCommand } from "@/components/Setup/CopyableCommand";
 import { getAgentConfig } from "@/config/agents";
 import { isMac, isLinux } from "@/lib/platform";
 import { cn } from "@/lib/utils";
@@ -124,38 +124,6 @@ function InstallCommands({ blocks }: { blocks: AgentInstallBlock[] }) {
           )}
         </div>
       ))}
-    </div>
-  );
-}
-
-function CopyableCommand({ command }: { command: string }) {
-  const [copied, setCopied] = useState(false);
-
-  const handleCopy = useCallback(async () => {
-    try {
-      await navigator.clipboard.writeText(command);
-      setCopied(true);
-      setTimeout(() => setCopied(false), 2000);
-    } catch {
-      // clipboard unavailable
-    }
-  }, [command]);
-
-  return (
-    <div className="flex items-center gap-2 px-3 py-1.5 rounded-[var(--radius-sm)] bg-overlay-subtle border border-daintree-border font-mono text-xs select-text group">
-      <span className="flex-1 truncate text-daintree-text/70">{command}</span>
-      <button
-        type="button"
-        onClick={handleCopy}
-        className="shrink-0 p-0.5 rounded hover:bg-overlay transition-colors duration-150 text-daintree-text/30 hover:text-daintree-text/60"
-        aria-label={copied ? "Copied" : "Copy command"}
-      >
-        {copied ? (
-          <Check className="w-3.5 h-3.5 text-status-success" />
-        ) : (
-          <Clipboard className="w-3.5 h-3.5" />
-        )}
-      </button>
     </div>
   );
 }

--- a/src/components/Worktree/WorktreeCard.tsx
+++ b/src/components/Worktree/WorktreeCard.tsx
@@ -38,6 +38,7 @@ import {
 import { useInputReceiptKey } from "./WorktreeCard/hooks/useInputReceiptKey";
 import { useWorktreeActions } from "./WorktreeCard/hooks/useWorktreeActions";
 import { copyContextWithFeedback } from "@/hooks/useWorktreeActions";
+import { useCopyWithFeedback } from "@/hooks/useCopyWithFeedback";
 import { ContextMenu, ContextMenuContent, ContextMenuTrigger } from "@/components/ui/context-menu";
 import { CONTEXT_COMPONENTS, WorktreeMenuItems } from "./WorktreeMenuItems";
 import { isAgentFleetActionEligible, isFleetArmEligible } from "@/store/fleetArmingStore";
@@ -420,6 +421,11 @@ export function WorktreeCard({
     void copyContextWithFeedback(worktree.id, { modified: true });
   };
 
+  const { copy: copyWorktreePath } = useCopyWithFeedback();
+  const handleCopyPath = () => {
+    void copyWorktreePath(worktree.path);
+  };
+
   const [showIssuePicker, setShowIssuePicker] = useState(false);
   const [showReviewHub, setShowReviewHub] = useState(false);
   const [showPlanViewer, setShowPlanViewer] = useState(false);
@@ -726,7 +732,7 @@ export function WorktreeCard({
                   },
                   onCopyContextFull: handleCopyContextFull,
                   onCopyContextModified: handleCopyContextModified,
-                  onCopyPath: () => void navigator.clipboard.writeText(worktree.path),
+                  onCopyPath: handleCopyPath,
                   onOpenEditor,
                   onRevealInFinder: handlePathClick,
                   onOpenIssuePortal: worktree.issueNumber ? handleOpenIssuePortal : undefined,
@@ -880,7 +886,7 @@ export function WorktreeCard({
           canMoveDown={canMoveDown}
           onCopyContextFull={handleCopyContextFull}
           onCopyContextModified={handleCopyContextModified}
-          onCopyPath={() => void navigator.clipboard.writeText(worktree.path)}
+          onCopyPath={handleCopyPath}
           onOpenEditor={onOpenEditor}
           onRevealInFinder={handlePathClick}
           onOpenIssuePortal={worktree.issueNumber ? handleOpenIssuePortal : undefined}

--- a/src/components/Worktree/WorktreeDetails.tsx
+++ b/src/components/Worktree/WorktreeDetails.tsx
@@ -1,4 +1,4 @@
-import { useMemo, useState, useRef, useEffect } from "react";
+import { useMemo } from "react";
 import type { WorktreeState } from "../../types";
 import type { ErrorRecord, RetryAction } from "../../store/errorStore";
 import { ErrorBanner } from "../Errors/ErrorBanner";
@@ -8,8 +8,8 @@ import { LiveTimeAgo } from "./LiveTimeAgo";
 import { cn } from "../../lib/utils";
 import { GitCommit, Copy, Check, ExternalLink } from "lucide-react";
 import { parseNoteWithLinks, formatPath, type TextSegment } from "../../utils/textParsing";
-import { logError } from "@/utils/logger";
 import { actionService } from "@/services/ActionService";
+import { useCopyWithFeedback } from "@/hooks/useCopyWithFeedback";
 import { Tooltip, TooltipContent, TooltipTrigger } from "@/components/ui/tooltip";
 
 export interface WorktreeDetailsProps {
@@ -48,20 +48,7 @@ export function WorktreeDetails({
 }: WorktreeDetailsProps) {
   const displayPath = formatPath(worktree.path, homeDir);
   const rawLastCommitMsg = worktree.worktreeChanges?.lastCommitMessage;
-  const [pathCopied, setPathCopied] = useState(false);
-  const copyTimeoutRef = useRef<ReturnType<typeof setTimeout> | null>(null);
-  const isMountedRef = useRef(true);
-
-  useEffect(() => {
-    isMountedRef.current = true;
-    return () => {
-      isMountedRef.current = false;
-      if (copyTimeoutRef.current) {
-        clearTimeout(copyTimeoutRef.current);
-        copyTimeoutRef.current = null;
-      }
-    };
-  }, []);
+  const { copied: pathCopied, copy: copyPath } = useCopyWithFeedback();
 
   const parsedNoteSegments: TextSegment[] = useMemo(() => {
     return effectiveNote ? parseNoteWithLinks(effectiveNote) : [];
@@ -73,32 +60,9 @@ export function WorktreeDetails({
     void actionService.dispatch("system.openExternal", { url }, { source: "user" });
   };
 
-  const handleCopyPath = async (e: React.MouseEvent) => {
+  const handleCopyPath = (e: React.MouseEvent) => {
     e.stopPropagation();
-    try {
-      if (navigator.clipboard && navigator.clipboard.writeText) {
-        await navigator.clipboard.writeText(worktree.path);
-      } else {
-        throw new Error("Clipboard API not available");
-      }
-
-      if (!isMountedRef.current) return;
-
-      setPathCopied(true);
-
-      if (copyTimeoutRef.current) {
-        clearTimeout(copyTimeoutRef.current);
-      }
-
-      copyTimeoutRef.current = setTimeout(() => {
-        if (isMountedRef.current) {
-          setPathCopied(false);
-          copyTimeoutRef.current = null;
-        }
-      }, 2000);
-    } catch (err) {
-      logError("Failed to copy path", err);
-    }
+    void copyPath(worktree.path);
   };
 
   const hasDetailsContent =
@@ -232,12 +196,12 @@ export function WorktreeDetails({
                 type="button"
                 onClick={handleCopyPath}
                 className="shrink-0 rounded p-1 text-text-muted transition-colors hover:bg-overlay-soft hover:text-text-secondary focus-visible:outline focus-visible:outline-2 focus-visible:outline-daintree-accent"
-                aria-label={pathCopied ? "Path copied to clipboard" : "Copy path to clipboard"}
+                aria-label="Copy path to clipboard"
               >
                 {pathCopied ? (
-                  <Check className="w-3 h-3 text-status-success" />
+                  <Check key="check" className="w-3 h-3 text-status-success animate-badge-bump" />
                 ) : (
-                  <Copy className="w-3 h-3" />
+                  <Copy key="copy" className="w-3 h-3" />
                 )}
               </button>
             </TooltipTrigger>
@@ -245,9 +209,6 @@ export function WorktreeDetails({
               {pathCopied ? "Copied!" : "Copy full path"}
             </TooltipContent>
           </Tooltip>
-          <div className="sr-only" role="status" aria-live="polite" aria-atomic="true">
-            {pathCopied ? "Path copied to clipboard" : ""}
-          </div>
         </div>
       </div>
     </div>

--- a/src/hooks/__tests__/useCopyWithFeedback.test.tsx
+++ b/src/hooks/__tests__/useCopyWithFeedback.test.tsx
@@ -1,0 +1,102 @@
+// @vitest-environment jsdom
+import { act, renderHook } from "@testing-library/react";
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+import { useCopyWithFeedback } from "../useCopyWithFeedback";
+import { useAnnouncerStore } from "@/store/accessibilityAnnouncerStore";
+import { UI_ACTION_SUCCESS_DWELL_MS } from "@/lib/animationUtils";
+
+describe("useCopyWithFeedback", () => {
+  let writeText: ReturnType<typeof vi.fn>;
+
+  beforeEach(() => {
+    vi.useFakeTimers();
+    writeText = vi.fn().mockResolvedValue(undefined);
+    Object.defineProperty(navigator, "clipboard", {
+      configurable: true,
+      value: { writeText },
+    });
+    useAnnouncerStore.setState({ polite: null, assertive: null });
+  });
+
+  afterEach(() => {
+    vi.useRealTimers();
+  });
+
+  it("sets copied=true and announces 'Copied' once on success", async () => {
+    const { result } = renderHook(() => useCopyWithFeedback());
+    await act(async () => {
+      await result.current.copy("hello");
+    });
+    expect(writeText).toHaveBeenCalledWith("hello");
+    expect(result.current.copied).toBe(true);
+    const polite = useAnnouncerStore.getState().polite;
+    expect(polite?.msg).toBe("Copied");
+  });
+
+  it("resets copied=false after the dwell window", async () => {
+    const { result } = renderHook(() => useCopyWithFeedback());
+    await act(async () => {
+      await result.current.copy("x");
+    });
+    expect(result.current.copied).toBe(true);
+    act(() => {
+      vi.advanceTimersByTime(UI_ACTION_SUCCESS_DWELL_MS);
+    });
+    expect(result.current.copied).toBe(false);
+  });
+
+  it("does not update state after unmount", async () => {
+    const { result, unmount } = renderHook(() => useCopyWithFeedback());
+    await act(async () => {
+      await result.current.copy("x");
+    });
+    unmount();
+    // No assertion error from setState-on-unmounted is the implicit pass.
+    act(() => {
+      vi.advanceTimersByTime(UI_ACTION_SUCCESS_DWELL_MS + 1000);
+    });
+  });
+
+  it("restarts the dwell on a second click within the window", async () => {
+    const { result } = renderHook(() => useCopyWithFeedback());
+    await act(async () => {
+      await result.current.copy("a");
+    });
+    act(() => {
+      vi.advanceTimersByTime(1000);
+    });
+    expect(result.current.copied).toBe(true);
+    await act(async () => {
+      await result.current.copy("b");
+    });
+    act(() => {
+      vi.advanceTimersByTime(1500);
+    });
+    // 1500ms after second click → still inside fresh dwell.
+    expect(result.current.copied).toBe(true);
+    act(() => {
+      vi.advanceTimersByTime(600);
+    });
+    expect(result.current.copied).toBe(false);
+  });
+
+  it("returns false and stays silent when clipboard rejects", async () => {
+    writeText.mockRejectedValueOnce(new Error("denied"));
+    const { result } = renderHook(() => useCopyWithFeedback());
+    let ok: boolean | undefined;
+    await act(async () => {
+      ok = await result.current.copy("x");
+    });
+    expect(ok).toBe(false);
+    expect(result.current.copied).toBe(false);
+    expect(useAnnouncerStore.getState().polite).toBeNull();
+  });
+
+  it("uses a custom announcement string when provided", async () => {
+    const { result } = renderHook(() => useCopyWithFeedback({ announcement: "Path copied" }));
+    await act(async () => {
+      await result.current.copy("/home/foo");
+    });
+    expect(useAnnouncerStore.getState().polite?.msg).toBe("Path copied");
+  });
+});

--- a/src/hooks/useCopyWithFeedback.ts
+++ b/src/hooks/useCopyWithFeedback.ts
@@ -1,0 +1,67 @@
+import { useCallback, useEffect, useRef, useState } from "react";
+import { useAnnouncerStore } from "@/store/accessibilityAnnouncerStore";
+import { UI_ACTION_SUCCESS_DWELL_MS } from "@/lib/animationUtils";
+
+export interface UseCopyWithFeedbackOptions {
+  /** How long the `copied` flag stays true. Defaults to UI_ACTION_SUCCESS_DWELL_MS. */
+  dwellMs?: number;
+  /** Polite live-region message announced on success. Defaults to "Copied". */
+  announcement?: string;
+}
+
+export interface UseCopyWithFeedbackResult {
+  copied: boolean;
+  copy: (text: string) => Promise<boolean>;
+}
+
+/**
+ * Standard clipboard-with-feedback gesture: writes text, flips a `copied` flag
+ * for the dwell window, and announces once via the polite live region. The
+ * announcer is the sole SR signal — callers must keep their visible
+ * `aria-label` constant to avoid double-announce.
+ */
+export function useCopyWithFeedback(
+  options: UseCopyWithFeedbackOptions = {}
+): UseCopyWithFeedbackResult {
+  const { dwellMs = UI_ACTION_SUCCESS_DWELL_MS, announcement = "Copied" } = options;
+  const [copied, setCopied] = useState(false);
+  const timeoutRef = useRef<ReturnType<typeof setTimeout> | null>(null);
+  const isMountedRef = useRef(true);
+
+  useEffect(() => {
+    isMountedRef.current = true;
+    return () => {
+      isMountedRef.current = false;
+      if (timeoutRef.current) {
+        clearTimeout(timeoutRef.current);
+        timeoutRef.current = null;
+      }
+    };
+  }, []);
+
+  const copy = useCallback(
+    async (text: string): Promise<boolean> => {
+      try {
+        await navigator.clipboard.writeText(text);
+      } catch {
+        return false;
+      }
+      if (!isMountedRef.current) return true;
+
+      setCopied(true);
+      useAnnouncerStore.getState().announce(announcement, "polite");
+
+      if (timeoutRef.current) clearTimeout(timeoutRef.current);
+      timeoutRef.current = setTimeout(() => {
+        if (!isMountedRef.current) return;
+        setCopied(false);
+        timeoutRef.current = null;
+      }, dwellMs);
+
+      return true;
+    },
+    [announcement, dwellMs]
+  );
+
+  return { copied, copy };
+}


### PR DESCRIPTION
## Summary

- Introduces `useCopyWithFeedback` — a shared hook that handles the clipboard write, dwell timer (`UI_ACTION_SUCCESS_DWELL_MS`), unmount cleanup, and a single polite `"Copied"` announcement via `accessibilityAnnouncerStore`. Replaces scattered local `copied`/`setCopied`/`setTimeout` patterns across the codebase.
- Adds `CopyableCommand` — a canonical install-command row component used by `InstallBlock`, `AgentCliStep`, and `MissingCliGate`, eliminating duplicate implementations.
- Fixes a bug in `CrashRecoveryDialog` where `openExternal` was firing before the clipboard write resolved — `handleReport` now awaits the write and skips the browser open on failure. The previous inline timeout also had an unmount leak, which the hook cleans up correctly.

Resolves #6967

## Changes

- `src/hooks/useCopyWithFeedback.ts` — new shared hook
- `src/components/Setup/CopyableCommand.tsx` — new canonical copyable command row
- `src/components/Recovery/CrashRecoveryDialog.tsx` — awaited clipboard write, leak fix, `AnimatedLabel` for multi-state button
- `src/components/Worktree/WorktreeDetails.tsx` — dropped local sr-only live region + `aria-label` mutation; constant label + badge-bump icon
- `src/components/Worktree/WorktreeCard.tsx` — context-menu copy calls routed through the hook for AT announcement
- `src/components/Project/ProjectSwitcher.tsx` — removed `"Path copied"` toast in favour of the hook
- `src/components/Setup/InstallBlock.tsx`, `AgentCliStep.tsx`, `MissingCliGate.tsx` — switched to `CopyableCommand`
- `src/hooks/__tests__/useCopyWithFeedback.test.tsx` — 6 new tests
- `src/components/Recovery/__tests__/CrashRecoveryDialog.test.tsx` — 2 new regression tests (first click inert, clipboard reject blocks `openExternal`)

## Testing

- Unit tests cover the hook's dwell reset, cleanup on unmount, and clipboard rejection path
- Regression tests confirm `CrashRecoveryDialog` doesn't open the browser when the clipboard write fails
- `tsc`, lint, and format all clean; ESLint warning baseline ratcheted down by 6