### PR TITLE
fix(worktree): separate hover, focus, and drop-target onto distinct visual axes

### DIFF
--- a/src/components/Worktree/WorktreeCard.tsx
+++ b/src/components/Worktree/WorktreeCard.tsx
@@ -565,12 +565,10 @@ export function WorktreeCard({
             isActive && variant !== "sidebar" && "bg-surface-panel-elevated",
             !isActive &&
               variant === "grid" &&
-              "hover:bg-overlay-subtle hover:shadow-[var(--theme-shadow-ambient)]",
+              "hover:bg-overlay-subtle hover:shadow-[var(--theme-shadow-ambient)] [html[data-dragging='true']_&]:hover:bg-transparent [html[data-dragging='true']_&]:hover:shadow-none",
             variant === "sidebar" && !isActive && "bg-transparent",
             isFocused && !isActive && variant === "grid" && "bg-overlay-soft",
-            isOver &&
-              !isActive &&
-              "ring-2 ring-overlay bg-overlay-soft border-overlay transition-colors",
+            isOver && !isActive && "ring-2 ring-inset ring-border-default",
             worktree.isCurrent &&
               "before:absolute before:left-0 before:top-2 before:bottom-2 before:w-[2px] before:rounded-r before:bg-daintree-accent before:content-['']"
           )}
@@ -594,14 +592,6 @@ export function WorktreeCard({
             )}
             aria-label={`Select worktree: ${worktree.issueTitle ?? branchLabel}${worktree.issueTitle ? ` (${branchLabel})` : ""}`}
           />
-          {isOver && !isActive && (
-            <div
-              className={cn(
-                "absolute inset-0 z-50 bg-overlay-soft border-2 border-overlay pointer-events-none animate-in fade-in duration-150",
-                variant === "grid" && "rounded-lg"
-              )}
-            />
-          )}
           {flashKey > 0 && (
             <div
               key={flashKey}
@@ -665,7 +655,7 @@ export function WorktreeCard({
                 ref={dragHandleActivatorRef}
                 data-worktree-row-drag-handle=""
                 className={cn(
-                  "shrink-0 w-4 flex items-center justify-center cursor-grab active:cursor-grabbing touch-none select-none transition-colors motion-reduce:transition-none",
+                  "shrink-0 w-4 flex items-center justify-center cursor-grab active:cursor-grabbing touch-none select-none transition-colors group-hover/card:delay-[50ms] motion-reduce:transition-none",
                   isDraggingSort
                     ? "bg-overlay-emphasis text-text-primary"
                     : "text-transparent group-hover/card:text-text-primary/30 group-hover/card:bg-overlay-soft"

--- a/src/components/Worktree/WorktreeCard.tsx
+++ b/src/components/Worktree/WorktreeCard.tsx
@@ -565,7 +565,7 @@ export function WorktreeCard({
             isActive && variant !== "sidebar" && "bg-surface-panel-elevated",
             !isActive &&
               variant === "grid" &&
-              "hover:bg-overlay-subtle hover:shadow-[var(--theme-shadow-ambient)] [html[data-dragging='true']_&]:hover:bg-transparent [html[data-dragging='true']_&]:hover:shadow-none",
+              "hover:bg-overlay-subtle hover:shadow-[var(--theme-shadow-ambient)] [html[data-dragging='true']_&]:hover:shadow-none",
             variant === "sidebar" && !isActive && "bg-transparent",
             isFocused && !isActive && variant === "grid" && "bg-overlay-soft",
             isOver && !isActive && "ring-2 ring-inset ring-border-default",

--- a/src/components/Worktree/WorktreeCard/__tests__/WorktreeCardInteraction.test.tsx
+++ b/src/components/Worktree/WorktreeCard/__tests__/WorktreeCardInteraction.test.tsx
@@ -35,18 +35,18 @@ describe("WorktreeCard interaction-state axes (issue #6963)", () => {
     expect(cardSource).not.toContain('z-50 bg-overlay-soft border-2 border-overlay');
   });
 
-  it("suppresses grid hover background while a drag is active", () => {
-    expect(cardSource).toContain(
-      "[html[data-dragging='true']_&]:hover:bg-transparent"
-    );
+  it("suppresses the grid hover-shadow lift while a drag is active", () => {
     expect(cardSource).toContain(
       "[html[data-dragging='true']_&]:hover:shadow-none"
     );
   });
 
-  it("suppresses sidebar hover background while a drag is active", () => {
+  it("suppresses sidebar hover background while a drag is active for both hover paths", () => {
     expect(sidebarCss).toMatch(
-      /html\[data-dragging="true"\]\s+\.sidebar-worktree-card\[data-hoverable="true"\]:hover\s*\{[^}]*background:\s*transparent/
+      /html\[data-dragging="true"\][^{]*\.sidebar-worktree-card\[data-hoverable="true"\]:hover/
+    );
+    expect(sidebarCss).toMatch(
+      /html\[data-dragging="true"\][^{]*\.sidebar-worktree-card\[data-hovered="true"\]/
     );
   });
 

--- a/src/components/Worktree/WorktreeCard/__tests__/WorktreeCardInteraction.test.tsx
+++ b/src/components/Worktree/WorktreeCard/__tests__/WorktreeCardInteraction.test.tsx
@@ -1,0 +1,56 @@
+// @vitest-environment jsdom
+import { describe, it, expect } from "vitest";
+import { readFileSync } from "fs";
+import { resolve } from "path";
+
+// Issue #6963 — three interaction states (hover, focus, drop-target) on the
+// worktree row used the same overlay-background axis and stacked into a muddy
+// tint. The fix moves drop-target to a ring-inset axis, removes the redundant
+// absolute overlay div, and suppresses hover background while a drag is active.
+
+const cardSource = readFileSync(
+  resolve(__dirname, "../../WorktreeCard.tsx"),
+  "utf-8"
+);
+const sidebarCss = readFileSync(
+  resolve(__dirname, "../../../../styles/components/sidebar.css"),
+  "utf-8"
+);
+
+describe("WorktreeCard interaction-state axes (issue #6963)", () => {
+  it("uses ring-inset (no background) for the isOver drop-target", () => {
+    expect(cardSource).toMatch(
+      /isOver\s*&&\s*!isActive\s*&&\s*"ring-2 ring-inset ring-border-default"/
+    );
+  });
+
+  it("does not stack bg-overlay-soft on the isOver branch", () => {
+    expect(cardSource).not.toMatch(
+      /isOver\s*&&[^,]*bg-overlay-(soft|subtle|strong|emphasis)/
+    );
+  });
+
+  it("does not render the redundant absolute isOver overlay div", () => {
+    expect(cardSource).not.toMatch(/isOver && !isActive && \(\s*<div/);
+    expect(cardSource).not.toContain('z-50 bg-overlay-soft border-2 border-overlay');
+  });
+
+  it("suppresses grid hover background while a drag is active", () => {
+    expect(cardSource).toContain(
+      "[html[data-dragging='true']_&]:hover:bg-transparent"
+    );
+    expect(cardSource).toContain(
+      "[html[data-dragging='true']_&]:hover:shadow-none"
+    );
+  });
+
+  it("suppresses sidebar hover background while a drag is active", () => {
+    expect(sidebarCss).toMatch(
+      /html\[data-dragging="true"\]\s+\.sidebar-worktree-card\[data-hoverable="true"\]:hover\s*\{[^}]*background:\s*transparent/
+    );
+  });
+
+  it("delays the drag-handle hover reveal to filter fast cursor sweeps", () => {
+    expect(cardSource).toContain("group-hover/card:delay-[50ms]");
+  });
+});

--- a/src/components/Worktree/WorktreeCard/__tests__/WorktreeCardInteraction.test.tsx
+++ b/src/components/Worktree/WorktreeCard/__tests__/WorktreeCardInteraction.test.tsx
@@ -8,10 +8,7 @@ import { resolve } from "path";
 // tint. The fix moves drop-target to a ring-inset axis, removes the redundant
 // absolute overlay div, and suppresses hover background while a drag is active.
 
-const cardSource = readFileSync(
-  resolve(__dirname, "../../WorktreeCard.tsx"),
-  "utf-8"
-);
+const cardSource = readFileSync(resolve(__dirname, "../../WorktreeCard.tsx"), "utf-8");
 const sidebarCss = readFileSync(
   resolve(__dirname, "../../../../styles/components/sidebar.css"),
   "utf-8"
@@ -25,20 +22,16 @@ describe("WorktreeCard interaction-state axes (issue #6963)", () => {
   });
 
   it("does not stack bg-overlay-soft on the isOver branch", () => {
-    expect(cardSource).not.toMatch(
-      /isOver\s*&&[^,]*bg-overlay-(soft|subtle|strong|emphasis)/
-    );
+    expect(cardSource).not.toMatch(/isOver\s*&&[^,]*bg-overlay-(soft|subtle|strong|emphasis)/);
   });
 
   it("does not render the redundant absolute isOver overlay div", () => {
     expect(cardSource).not.toMatch(/isOver && !isActive && \(\s*<div/);
-    expect(cardSource).not.toContain('z-50 bg-overlay-soft border-2 border-overlay');
+    expect(cardSource).not.toContain("z-50 bg-overlay-soft border-2 border-overlay");
   });
 
   it("suppresses the grid hover-shadow lift while a drag is active", () => {
-    expect(cardSource).toContain(
-      "[html[data-dragging='true']_&]:hover:shadow-none"
-    );
+    expect(cardSource).toContain("[html[data-dragging='true']_&]:hover:shadow-none");
   });
 
   it("suppresses sidebar hover background while a drag is active for both hover paths", () => {

--- a/src/styles/components/sidebar.css
+++ b/src/styles/components/sidebar.css
@@ -19,6 +19,10 @@
   background: var(--sidebar-hover-bg, rgba(255, 255, 255, 0.015));
 }
 
+html[data-dragging="true"] .sidebar-worktree-card[data-hoverable="true"]:hover {
+  background: transparent;
+}
+
 .sidebar-worktree-card:has(> button:focus-visible) {
   box-shadow: inset 0 0 0 2px var(--sidebar-ring);
 }

--- a/src/styles/components/sidebar.css
+++ b/src/styles/components/sidebar.css
@@ -19,7 +19,8 @@
   background: var(--sidebar-hover-bg, rgba(255, 255, 255, 0.015));
 }
 
-html[data-dragging="true"] .sidebar-worktree-card[data-hoverable="true"]:hover {
+html[data-dragging="true"] .sidebar-worktree-card[data-hoverable="true"]:hover,
+html[data-dragging="true"] .sidebar-worktree-card[data-hovered="true"] {
   background: transparent;
 }
 


### PR DESCRIPTION
## Summary

- Hover, focus, and drag-drop states were all painting the same overlay tint, stacking into a muddy fill when they coincided; each is now on a separate visual axis
- Drop target uses an inset ring only; hover shadow is suppressed during drag via `[html[data-dragging='true']_&]` selectors in both Tailwind and `sidebar.css`; the redundant `z-50` overlay div is removed
- Drag handle reveal gets a 50ms entry delay to filter fast cursor sweeps, with an instant exit

Resolves #6963

## Changes

- `WorktreeCard.tsx` — drop target changed from background overlay to `ring-inset`, hover shadow suppressed during drag, redundant `isOver` overlay div removed, drag handle reveal delayed 50ms
- `sidebar.css` — matching hover-shadow suppression for `:hover` and `[data-hovered="true"]` paths (sidebar hover lives in plain CSS, unreachable from Tailwind)
- `WorktreeCardInteraction.test.tsx` — source-text regression test matching the existing `ContentDock`/`TrashContainer` pattern

## Testing

- `vitest` — 544/544 pass (Worktree directory)
- Typecheck, lint, and format all clean; lint baseline unchanged at 876