### PR TITLE
feat(mcp): expose waitingReason on terminal state output

### DIFF
--- a/electron/services/AgentAvailabilityStore.ts
+++ b/electron/services/AgentAvailabilityStore.ts
@@ -8,7 +8,7 @@
  */
 
 import { events } from "./events.js";
-import type { AgentState } from "../../shared/types/agent.js";
+import type { AgentState, WaitingReason } from "../../shared/types/agent.js";
 
 export interface AgentAvailabilityInfo {
   agentId: string;
@@ -28,6 +28,7 @@ function isAvailableState(state: AgentState): boolean {
 
 export class AgentAvailabilityStore {
   private agentStates: Map<string, AgentState> = new Map();
+  private waitingReasons: Map<string, WaitingReason> = new Map();
   private concurrentTasks: Map<string, number> = new Map();
   private lastStateChange: Map<string, number> = new Map();
   private taskToAgent: Map<string, string> = new Map();
@@ -123,11 +124,17 @@ export class AgentAvailabilityStore {
     agentId?: string;
     state: AgentState;
     timestamp: number;
+    waitingReason?: WaitingReason;
   }): void {
     if (!payload.agentId) return;
 
     this.agentStates.set(payload.agentId, payload.state);
     this.lastStateChange.set(payload.agentId, payload.timestamp);
+    if (payload.state === "waiting" && payload.waitingReason) {
+      this.waitingReasons.set(payload.agentId, payload.waitingReason);
+    } else {
+      this.waitingReasons.delete(payload.agentId);
+    }
   }
 
   private incrementConcurrentTasks(agentId: string): void {
@@ -154,6 +161,17 @@ export class AgentAvailabilityStore {
    */
   getState(agentId: string): AgentState | undefined {
     return this.agentStates.get(agentId);
+  }
+
+  /**
+   * Get the most recent waitingReason for an agent, if it is currently waiting.
+   * Returns undefined if the agent is not in waiting state or has no classified reason.
+   * Note: keyed by agentId; for terminals that share an agentId (e.g. two "claude"
+   * panels) this reflects whichever waiting agent emitted last — same limitation as
+   * agentToTerminal mapping.
+   */
+  getWaitingReason(agentId: string): WaitingReason | undefined {
+    return this.waitingReasons.get(agentId);
   }
 
   /**
@@ -254,6 +272,7 @@ export class AgentAvailabilityStore {
    */
   unregisterAgent(agentId: string): void {
     this.agentStates.delete(agentId);
+    this.waitingReasons.delete(agentId);
     this.concurrentTasks.delete(agentId);
     this.lastStateChange.delete(agentId);
     const terminalId = this.agentToTerminal.get(agentId);
@@ -272,6 +291,7 @@ export class AgentAvailabilityStore {
    */
   clear(): void {
     this.agentStates.clear();
+    this.waitingReasons.clear();
     this.concurrentTasks.clear();
     this.lastStateChange.clear();
     this.taskToAgent.clear();

--- a/electron/services/__tests__/McpServerService.test.ts
+++ b/electron/services/__tests__/McpServerService.test.ts
@@ -4584,6 +4584,40 @@ describe("McpServerService", () => {
       expect(payload.waitingReason).toBe("prompt");
     });
 
+    it("omits waitingReason on working→waiting transitions without a classified reason", async () => {
+      const { events } = await import("../events.js");
+      const { terminalId, agentId } = nextIds();
+      await seedTerminalAgent(terminalId, agentId, "working");
+
+      const { window } = createMockWindow({ getManifest: () => [] });
+      await service.start(window);
+      const { client, transport } = await connectClient(service.currentPort!);
+      transports.push(transport);
+
+      const callPromise = client.callTool({
+        name: "terminal.waitUntilIdle",
+        arguments: { terminalId },
+      }) as Promise<TextToolResult & { structuredContent?: Record<string, unknown> }>;
+
+      await new Promise((r) => setTimeout(r, 30));
+
+      events.emit("agent:state-changed", {
+        agentId,
+        terminalId,
+        state: "waiting",
+        previousState: "working",
+        trigger: "output",
+        confidence: 1,
+        timestamp: Date.now(),
+      });
+
+      const result = await callPromise;
+      const payload = JSON.parse(result.content[0]!.text);
+      expect(payload.idleReason).toBe("waiting_for_user");
+      expect(payload.waitingReason).toBeUndefined();
+      expect(result.structuredContent?.waitingReason).toBeUndefined();
+    });
+
     it("returns the stored waitingReason for a terminal already in waiting state", async () => {
       const { terminalId, agentId } = nextIds();
       // Seed the terminal directly into "waiting" with a classified reason.

--- a/electron/services/__tests__/McpServerService.test.ts
+++ b/electron/services/__tests__/McpServerService.test.ts
@@ -4079,6 +4079,34 @@ describe("McpServerService", () => {
       expect(JSON.parse(missingContent.text)).toEqual({ agentId: "agent-missing", state: null });
     });
 
+    it("readResource for an agent in waiting state surfaces waitingReason", async () => {
+      const { events } = await import("../events.js");
+      const { getAgentAvailabilityStore } = await import("../AgentAvailabilityStore.js");
+      getAgentAvailabilityStore();
+      events.emit("agent:state-changed", {
+        agentId: "agent-waiting",
+        state: "waiting",
+        previousState: "working",
+        trigger: "output",
+        confidence: 1,
+        waitingReason: "question",
+        timestamp: Date.now(),
+      });
+
+      const { window } = createMockWindow({ getManifest: manifestForResources });
+      await service.start(window);
+      const { client, transport } = await connectClient(service.currentPort!);
+      transports.push(transport);
+
+      const result = await client.readResource({ uri: "daintree://agent/agent-waiting/state" });
+      const content = result.contents[0] as { uri: string; mimeType: string; text: string };
+      expect(JSON.parse(content.text)).toEqual({
+        agentId: "agent-waiting",
+        state: "waiting",
+        waitingReason: "question",
+      });
+    });
+
     it("readResource on an unknown URI rejects as InvalidRequest", async () => {
       const { window } = createMockWindow({ getManifest: manifestForResources });
       await service.start(window);
@@ -4319,7 +4347,8 @@ describe("McpServerService", () => {
     const seedTerminalAgent = async (
       terminalId: string,
       agentId: string,
-      state: "idle" | "working" | "waiting" | "completed" | "exited" = "idle"
+      state: "idle" | "working" | "waiting" | "completed" | "exited" = "idle",
+      waitingReason?: "prompt" | "question"
     ) => {
       const { events } = await import("../events.js");
       const { getAgentAvailabilityStore } = await import("../AgentAvailabilityStore.js");
@@ -4338,6 +4367,7 @@ describe("McpServerService", () => {
         trigger: "output",
         confidence: 1,
         timestamp: Date.now(),
+        ...(state === "waiting" && waitingReason ? { waitingReason } : {}),
       });
     };
 
@@ -4466,6 +4496,119 @@ describe("McpServerService", () => {
         idleReason: "completed",
         previousBusyState: "working",
         lastTransitionAt: transitionTs,
+        timedOut: false,
+      });
+      // waitingReason is only present when idleReason === "waiting_for_user".
+      expect(payload.waitingReason).toBeUndefined();
+    });
+
+    it("surfaces waitingReason='question' on a working→waiting transition", async () => {
+      const { events } = await import("../events.js");
+      const { terminalId, agentId } = nextIds();
+      await seedTerminalAgent(terminalId, agentId, "working");
+
+      const { window } = createMockWindow({ getManifest: () => [] });
+      await service.start(window);
+      const { client, transport } = await connectClient(service.currentPort!);
+      transports.push(transport);
+
+      const callPromise = client.callTool({
+        name: "terminal.waitUntilIdle",
+        arguments: { terminalId },
+      }) as Promise<TextToolResult & { structuredContent?: Record<string, unknown> }>;
+
+      await new Promise((r) => setTimeout(r, 30));
+
+      const transitionTs = Date.now();
+      events.emit("agent:state-changed", {
+        agentId,
+        terminalId,
+        state: "waiting",
+        previousState: "working",
+        trigger: "output",
+        confidence: 1,
+        waitingReason: "question",
+        timestamp: transitionTs,
+      });
+
+      const result = await callPromise;
+      expect(result.isError).toBeFalsy();
+      const payload = JSON.parse(result.content[0]!.text);
+      expect(payload).toMatchObject({
+        terminalId,
+        agentId,
+        busyState: "idle",
+        idleReason: "waiting_for_user",
+        waitingReason: "question",
+        previousBusyState: "working",
+        lastTransitionAt: transitionTs,
+        timedOut: false,
+      });
+      expect(result.structuredContent).toMatchObject({
+        idleReason: "waiting_for_user",
+        waitingReason: "question",
+      });
+    });
+
+    it("surfaces waitingReason='prompt' on a working→waiting transition", async () => {
+      const { events } = await import("../events.js");
+      const { terminalId, agentId } = nextIds();
+      await seedTerminalAgent(terminalId, agentId, "working");
+
+      const { window } = createMockWindow({ getManifest: () => [] });
+      await service.start(window);
+      const { client, transport } = await connectClient(service.currentPort!);
+      transports.push(transport);
+
+      const callPromise = client.callTool({
+        name: "terminal.waitUntilIdle",
+        arguments: { terminalId },
+      }) as Promise<TextToolResult>;
+
+      await new Promise((r) => setTimeout(r, 30));
+
+      events.emit("agent:state-changed", {
+        agentId,
+        terminalId,
+        state: "waiting",
+        previousState: "working",
+        trigger: "output",
+        confidence: 1,
+        waitingReason: "prompt",
+        timestamp: Date.now(),
+      });
+
+      const result = await callPromise;
+      const payload = JSON.parse(result.content[0]!.text);
+      expect(payload.idleReason).toBe("waiting_for_user");
+      expect(payload.waitingReason).toBe("prompt");
+    });
+
+    it("returns the stored waitingReason for a terminal already in waiting state", async () => {
+      const { terminalId, agentId } = nextIds();
+      // Seed the terminal directly into "waiting" with a classified reason.
+      // The already-idle path must read waitingReason from the store, since no
+      // new agent:state-changed event fires for the snapshot case.
+      await seedTerminalAgent(terminalId, agentId, "waiting", "question");
+
+      const { window } = createMockWindow({ getManifest: () => [] });
+      await service.start(window);
+      const { client, transport } = await connectClient(service.currentPort!);
+      transports.push(transport);
+
+      const result = (await client.callTool({
+        name: "terminal.waitUntilIdle",
+        arguments: { terminalId },
+      })) as TextToolResult;
+
+      expect(result.isError).toBeFalsy();
+      const payload = JSON.parse(result.content[0]!.text);
+      expect(payload).toMatchObject({
+        terminalId,
+        agentId,
+        busyState: "idle",
+        idleReason: "waiting_for_user",
+        waitingReason: "question",
         timedOut: false,
       });
     });

--- a/electron/services/mcp-server/sessionServer.ts
+++ b/electron/services/mcp-server/sessionServer.ts
@@ -537,8 +537,14 @@ async function readResourceContents(
     return { uri, mimeType: "text/plain", text: truncateText(text) };
   }
   if (parsed.kind === "agentState") {
-    const state = getAgentAvailabilityStore().getState(parsed.id);
-    const text = JSON.stringify({ agentId: parsed.id, state: state ?? null });
+    const store = getAgentAvailabilityStore();
+    const state = store.getState(parsed.id);
+    const waitingReason = state === "waiting" ? store.getWaitingReason(parsed.id) : undefined;
+    const text = JSON.stringify({
+      agentId: parsed.id,
+      state: state ?? null,
+      ...(waitingReason ? { waitingReason } : {}),
+    });
     return { uri, mimeType: "application/json", text };
   }
   if (parsed.kind === "issues") {

--- a/electron/services/mcp-server/shared.ts
+++ b/electron/services/mcp-server/shared.ts
@@ -7,7 +7,7 @@ import type {
   McpRuntimeState,
 } from "../../../shared/types/ipc/mcpServer.js";
 import type { HelpAssistantTier } from "../../../shared/types/ipc/maps.js";
-import type { AgentState } from "../../../shared/types/agent.js";
+import type { AgentState, WaitingReason } from "../../../shared/types/agent.js";
 
 export type McpAuthClass = "external" | HelpAssistantTier;
 export type HelpTokenValidator = (token: string) => HelpAssistantTier | false;
@@ -35,6 +35,12 @@ export type WaitUntilIdleResult = {
   agentId?: string;
   busyState: "working" | "idle";
   idleReason?: "idle" | "waiting_for_user" | "completed" | "exited" | "unknown";
+  /**
+   * Only present when `idleReason === "waiting_for_user"`. Distinguishes a safe
+   * auto-drive moment (`"prompt"` — empty input prompt) from an agent actively
+   * asking the user a question (`"question"`).
+   */
+  waitingReason?: WaitingReason;
   previousBusyState?: "working" | "idle";
   lastTransitionAt?: number;
   timedOut: boolean;
@@ -68,6 +74,12 @@ export const WAIT_UNTIL_IDLE_OUTPUT_SCHEMA: Record<string, unknown> = {
       type: "string",
       enum: ["idle", "waiting_for_user", "completed", "exited", "unknown"],
     },
+    waitingReason: {
+      type: "string",
+      enum: ["prompt", "question"],
+      description:
+        "Present only when idleReason is 'waiting_for_user'. 'prompt' = empty input prompt (safe to auto-drive); 'question' = agent is asking the user a question.",
+    },
     previousBusyState: { type: "string", enum: ["working", "idle"] },
     lastTransitionAt: { type: "number" },
     timedOut: { type: "boolean" },
@@ -76,7 +88,7 @@ export const WAIT_UNTIL_IDLE_OUTPUT_SCHEMA: Record<string, unknown> = {
 };
 
 export const WAIT_UNTIL_IDLE_DESCRIPTION =
-  "[terminal] Wait until idle: blocks until the agent in the given terminal transitions out of the `working` state, or until the timeout elapses. Resolves immediately if the agent is already non-working or no agent is attached. Honours client cancellation. When orchestrating multiple terminals, call with `timeoutMs: 0` in parallel for snapshots — do not issue concurrent default-timeout waits, which race unpredictably and can each block for 30 minutes.";
+  "[terminal] Wait until idle: blocks until the agent in the given terminal transitions out of the `working` state, or until the timeout elapses. Resolves immediately if the agent is already non-working or no agent is attached. When the agent settles in `waiting_for_user`, the result also includes `waitingReason` (`prompt` = empty input prompt, safe to auto-drive; `question` = agent is asking the user a question). Honours client cancellation. When orchestrating multiple terminals, call with `timeoutMs: 0` in parallel for snapshots — do not issue concurrent default-timeout waits, which race unpredictably and can each block for 30 minutes.";
 
 export function mapAgentStateToBusyState(state: AgentState | undefined): "working" | "idle" {
   return state === "working" ? "working" : "idle";

--- a/electron/services/mcp-server/waitUntilIdle.ts
+++ b/electron/services/mcp-server/waitUntilIdle.ts
@@ -1,7 +1,7 @@
 import { McpError, ErrorCode } from "@modelcontextprotocol/sdk/types.js";
 import { getAgentAvailabilityStore } from "../AgentAvailabilityStore.js";
 import { events } from "../events.js";
-import type { AgentState } from "../../../shared/types/agent.js";
+import type { AgentState, WaitingReason } from "../../../shared/types/agent.js";
 import {
   type WaitUntilIdleResult,
   DEFAULT_WAIT_UNTIL_IDLE_TIMEOUT_MS,
@@ -96,8 +96,9 @@ export async function handleWaitUntilIdle(
         state: AgentState;
         previousState: AgentState;
         timestamp: number;
+        waitingReason?: WaitingReason;
       }
-    | { kind: "already-idle"; state: AgentState }
+    | { kind: "already-idle"; state: AgentState; waitingReason?: WaitingReason }
     | { kind: "timeout" }
     | { kind: "abort" };
 
@@ -119,12 +120,17 @@ export async function handleWaitUntilIdle(
           state: payload.state,
           previousState: payload.previousState,
           timestamp: payload.timestamp,
+          waitingReason: payload.waitingReason,
         });
       });
 
       const currentState = store.getState(agentId);
       if (currentState !== "working") {
-        settle({ kind: "already-idle", state: currentState ?? "idle" });
+        settle({
+          kind: "already-idle",
+          state: currentState ?? "idle",
+          waitingReason: store.getWaitingReason(agentId),
+        });
         return;
       }
 
@@ -154,22 +160,30 @@ export async function handleWaitUntilIdle(
     }
 
     if (settlement.kind === "transition") {
+      const idleReason = mapAgentStateToIdleReason(settlement.state);
       return {
         terminalId,
         agentId,
         busyState: mapAgentStateToBusyState(settlement.state),
-        idleReason: mapAgentStateToIdleReason(settlement.state),
+        idleReason,
+        ...(idleReason === "waiting_for_user" && settlement.waitingReason
+          ? { waitingReason: settlement.waitingReason }
+          : {}),
         previousBusyState: mapAgentStateToBusyState(settlement.previousState),
         lastTransitionAt: settlement.timestamp,
         timedOut: false,
       };
     }
 
+    const idleReason = mapAgentStateToIdleReason(settlement.state);
     return {
       terminalId,
       agentId,
       busyState: mapAgentStateToBusyState(settlement.state),
-      idleReason: mapAgentStateToIdleReason(settlement.state),
+      idleReason,
+      ...(idleReason === "waiting_for_user" && settlement.waitingReason
+        ? { waitingReason: settlement.waitingReason }
+        : {}),
       previousBusyState: mapAgentStateToBusyState(previousState),
       lastTransitionAt: store.getLastStateChange(agentId),
       timedOut: false,

--- a/src/services/actions/definitions/__tests__/agentActions.adversarial.test.ts
+++ b/src/services/actions/definitions/__tests__/agentActions.adversarial.test.ts
@@ -256,6 +256,7 @@ describe("agentActions adversarial", () => {
     expect(result).toEqual({
       agentId: "codex",
       state: "idle",
+      waitingReason: null,
       lastTransitionAt: 1717000005000,
       terminalId: "term-b",
       found: true,
@@ -282,6 +283,7 @@ describe("agentActions adversarial", () => {
     expect(result).toEqual({
       agentId: "claude",
       state: "working",
+      waitingReason: null,
       lastTransitionAt: 1717000009000,
       terminalId: "term-runtime",
       found: true,
@@ -303,6 +305,7 @@ describe("agentActions adversarial", () => {
     expect(result).toEqual({
       agentId: "gemini",
       state: null,
+      waitingReason: null,
       lastTransitionAt: null,
       terminalId: null,
       found: false,
@@ -350,6 +353,7 @@ describe("agentActions adversarial", () => {
     expect(result).toEqual({
       agentId: "claude",
       state: null,
+      waitingReason: null,
       lastTransitionAt: null,
       terminalId: "term-a",
       found: true,

--- a/src/services/actions/definitions/agentActions.ts
+++ b/src/services/actions/definitions/agentActions.ts
@@ -197,7 +197,7 @@ export function registerAgentActions(actions: ActionRegistry, callbacks: ActionC
     id: "agent.getState",
     title: "Get Agent State",
     description:
-      "Query agent state by agentId; returns agentId, state, lastTransitionAt, terminalId, found",
+      "Query agent state by agentId; returns agentId, state, waitingReason, lastTransitionAt, terminalId, found. waitingReason ('prompt' | 'question') is non-null only when state is 'waiting'.",
     category: "agent",
     kind: "query",
     danger: "safe",
@@ -222,6 +222,7 @@ export function registerAgentActions(actions: ActionRegistry, callbacks: ActionC
           return {
             agentId,
             state: panel.agentState ?? null,
+            waitingReason: panel.waitingReason ?? null,
             lastTransitionAt: panel.lastStateChange ?? null,
             terminalId: panel.id,
             found: true,
@@ -231,6 +232,7 @@ export function registerAgentActions(actions: ActionRegistry, callbacks: ActionC
       return {
         agentId,
         state: null,
+        waitingReason: null,
         lastTransitionAt: null,
         terminalId: null,
         found: false,

--- a/src/services/actions/definitions/agentActions.ts
+++ b/src/services/actions/definitions/agentActions.ts
@@ -197,7 +197,7 @@ export function registerAgentActions(actions: ActionRegistry, callbacks: ActionC
     id: "agent.getState",
     title: "Get Agent State",
     description:
-      "Query agent state by agentId; returns agentId, state, waitingReason, lastTransitionAt, terminalId, found. waitingReason ('prompt' | 'question') is non-null only when state is 'waiting'.",
+      "Query agent state; returns state, waitingReason ('prompt'|'question', non-null when waiting), terminalId, found.",
     category: "agent",
     kind: "query",
     danger: "safe",

--- a/src/services/actions/definitions/agentActions.ts
+++ b/src/services/actions/definitions/agentActions.ts
@@ -222,7 +222,7 @@ export function registerAgentActions(actions: ActionRegistry, callbacks: ActionC
           return {
             agentId,
             state: panel.agentState ?? null,
-            waitingReason: panel.waitingReason ?? null,
+            waitingReason: panel.agentState === "waiting" ? (panel.waitingReason ?? null) : null,
             lastTransitionAt: panel.lastStateChange ?? null,
             terminalId: panel.id,
             found: true,


### PR DESCRIPTION
## Summary

- When a terminal enters `waiting_for_user` state, orchestrators previously had no way to distinguish a standard agent prompt from an agent actively asking a question — both came back as `waiting_for_user` with no further detail
- `WaitingReasonClassifier` already makes that call internally (`prompt` vs `question`), but the result never reached the MCP output schema
- This PR surfaces the classification as `waitingReason: "prompt" | "question"` on `waitUntilIdle` and the session state endpoint, and updates `AgentAvailabilityStore` to propagate the field

Resolves #6960

## Changes

- `electron/services/mcp-server/shared.ts` — added `waitingReason` to the output schema alongside `idleReason`
- `electron/services/mcp-server/waitUntilIdle.ts` — includes `waitingReason` in the resolved value
- `electron/services/mcp-server/sessionServer.ts` — exposes `waitingReason` on the session state endpoint
- `electron/services/AgentAvailabilityStore.ts` — propagates `waitingReason` from the terminal state
- `src/services/actions/definitions/agentActions.ts` — minor type alignment
- `electron/services/__tests__/McpServerService.test.ts` — unit tests covering `waitingReason` in both `waiting_for_user` sub-states and the fallback case where no reason is classified

## Testing

Unit tests cover the `prompt` and `question` variants of `waitingReason`, and the case where a terminal is in `waiting_for_user` but `waitingReason` is `null` (field omitted from output). Typecheck, lint, and format all pass.