### PR TITLE
fix(panel): suppress text selection on title bar double-click

### DIFF
--- a/src/components/Panel/PanelHeader.tsx
+++ b/src/components/Panel/PanelHeader.tsx
@@ -359,6 +359,19 @@ function PanelHeaderComponent({
     }
   };
 
+  const handleContainerMouseDown = (e: React.MouseEvent<HTMLDivElement>) => {
+    // Forward to dnd-kit's mousedown listener first — it bails out if
+    // `defaultPrevented` is already set, so our preventDefault must come after.
+    dragListeners?.onMouseDown?.(e);
+    // Suppress the browser's word-selection default on the second mousedown
+    // of a double-click. Without this, toggling focus mode mid-gesture lets
+    // the second mousedown land on a sibling pane (revealed by the slide
+    // animation) and select its text — issue #6978.
+    if (e.detail >= 2) {
+      e.preventDefault();
+    }
+  };
+
   const getAriaLabel = () => {
     if (kind === "browser") return "Edit browser title";
     if (!chrome.isAgent && kind === "terminal") return "Edit terminal title";
@@ -527,7 +540,7 @@ function PanelHeaderComponent({
       data-fleet-previewed={isFleetPreviewed || undefined}
       data-pane-chrome=""
       className={cn(
-        "flex items-center justify-between px-3 shrink-0 text-xs transition-colors relative overflow-hidden group",
+        "flex items-center justify-between px-3 shrink-0 text-xs transition-colors relative overflow-hidden group select-none",
         "h-8 border-b border-divider",
         isMaximized
           ? "h-10 bg-daintree-sidebar border-daintree-border"
@@ -553,6 +566,7 @@ function PanelHeaderComponent({
         isPinged && !isMaximized && "animate-terminal-header-ping",
         isDragging && "pointer-events-none"
       )}
+      onMouseDown={handleContainerMouseDown}
       onDoubleClick={handleHeaderDoubleClick}
     >
       {/* Tab bar - shown when there are multiple tabs */}

--- a/src/components/Panel/PanelHeader.tsx
+++ b/src/components/Panel/PanelHeader.tsx
@@ -366,8 +366,9 @@ function PanelHeaderComponent({
     // Suppress the browser's word-selection default on the second mousedown
     // of a double-click. Without this, toggling focus mode mid-gesture lets
     // the second mousedown land on a sibling pane (revealed by the slide
-    // animation) and select its text — issue #6978.
-    if (e.detail >= 2) {
+    // animation) and select its text — issue #6978. Skip when the target is
+    // an editable element so title-rename word-selection still works.
+    if (e.detail >= 2 && !(e.target as HTMLElement).closest("input, textarea")) {
       e.preventDefault();
     }
   };

--- a/src/components/Panel/__tests__/PanelHeader.test.tsx
+++ b/src/components/Panel/__tests__/PanelHeader.test.tsx
@@ -600,8 +600,8 @@ describe("PanelHeader", () => {
       // so our preventDefault must come after. Capture `defaultPrevented` at the
       // moment dnd-kit sees the event to lock that contract in place.
       const seenDefaultPrevented: boolean[] = [];
-      const dragMouseDown = vi.fn((e: { defaultPrevented: boolean }) => {
-        seenDefaultPrevented.push(e.defaultPrevented);
+      const dragMouseDown = vi.fn((e: unknown) => {
+        seenDefaultPrevented.push((e as { defaultPrevented: boolean }).defaultPrevented);
       });
       mockDragHandle = { listeners: { onMouseDown: dragMouseDown } };
       try {

--- a/src/components/Panel/__tests__/PanelHeader.test.tsx
+++ b/src/components/Panel/__tests__/PanelHeader.test.tsx
@@ -595,19 +595,51 @@ describe("PanelHeader", () => {
       expect(preventDefault).toHaveBeenCalled();
     });
 
-    it("forwards mousedown to the dnd-kit drag listener", () => {
-      const dragMouseDown = vi.fn();
+    it("forwards mousedown to the dnd-kit drag listener before preventDefault runs", () => {
+      // Order is load-bearing: dnd-kit's MouseSensor bails on `defaultPrevented`,
+      // so our preventDefault must come after. Capture `defaultPrevented` at the
+      // moment dnd-kit sees the event to lock that contract in place.
+      const seenDefaultPrevented: boolean[] = [];
+      const dragMouseDown = vi.fn((e: { defaultPrevented: boolean }) => {
+        seenDefaultPrevented.push(e.defaultPrevented);
+      });
       mockDragHandle = { listeners: { onMouseDown: dragMouseDown } };
       try {
         const { container } = render(<PanelHeader {...makeProps({ location: "grid" })} />);
         const header = container.firstElementChild as HTMLElement;
         fireEvent.mouseDown(header, { detail: 1 });
-        expect(dragMouseDown).toHaveBeenCalledTimes(1);
         fireEvent.mouseDown(header, { detail: 2 });
         expect(dragMouseDown).toHaveBeenCalledTimes(2);
+        expect(seenDefaultPrevented).toEqual([false, false]);
       } finally {
         mockDragHandle = null;
       }
+    });
+
+    it("does not preventDefault on double-click inside an input (title rename)", () => {
+      // Word-selection inside the title-rename input must still work — the
+      // selection-suppression guard only applies to the chrome itself.
+      const onEditingValueChange = vi.fn();
+      const onTitleSave = vi.fn();
+      const onTitleInputKeyDown = vi.fn();
+      const { container } = render(
+        <PanelHeader
+          {...makeProps({
+            location: "grid",
+            isEditingTitle: true,
+            editingValue: "Some title",
+            onEditingValueChange,
+            onTitleSave,
+            onTitleInputKeyDown,
+          })}
+        />
+      );
+      const input = container.querySelector("input[type='text']") as HTMLInputElement;
+      expect(input).not.toBeNull();
+      const event = new MouseEvent("mousedown", { bubbles: true, cancelable: true, detail: 2 });
+      const preventDefault = vi.spyOn(event, "preventDefault");
+      input.dispatchEvent(event);
+      expect(preventDefault).not.toHaveBeenCalled();
     });
 
     it("applies select-none to the header container", () => {

--- a/src/components/Panel/__tests__/PanelHeader.test.tsx
+++ b/src/components/Panel/__tests__/PanelHeader.test.tsx
@@ -48,8 +48,10 @@ vi.mock("@/hooks", () => ({
   useAriaKeyshortcuts: () => undefined,
 }));
 
+let mockDragHandle: { listeners: Record<string, (e: unknown) => void> | undefined } | null = null;
+
 vi.mock("@/components/DragDrop/DragHandleContext", () => ({
-  useDragHandle: () => null,
+  useDragHandle: () => mockDragHandle,
 }));
 
 const mockWatchPanel = vi.fn();
@@ -562,6 +564,56 @@ describe("PanelHeader", () => {
       const closeButton = screen.getByTestId("panel-close");
       fireEvent.dblClick(closeButton);
       expect(mockDispatch).not.toHaveBeenCalledWith("nav.toggleFocusMode");
+    });
+  });
+
+  describe("mousedown selection guard (#6978)", () => {
+    it("calls preventDefault on the second mousedown of a double-click", () => {
+      const { container } = render(<PanelHeader {...makeProps({ location: "grid" })} />);
+      const header = container.firstElementChild as HTMLElement;
+      const event = new MouseEvent("mousedown", { bubbles: true, cancelable: true, detail: 2 });
+      const preventDefault = vi.spyOn(event, "preventDefault");
+      header.dispatchEvent(event);
+      expect(preventDefault).toHaveBeenCalled();
+    });
+
+    it("does not call preventDefault on a single mousedown", () => {
+      const { container } = render(<PanelHeader {...makeProps({ location: "grid" })} />);
+      const header = container.firstElementChild as HTMLElement;
+      const event = new MouseEvent("mousedown", { bubbles: true, cancelable: true, detail: 1 });
+      const preventDefault = vi.spyOn(event, "preventDefault");
+      header.dispatchEvent(event);
+      expect(preventDefault).not.toHaveBeenCalled();
+    });
+
+    it("calls preventDefault on triple-click mousedowns as well", () => {
+      const { container } = render(<PanelHeader {...makeProps({ location: "grid" })} />);
+      const header = container.firstElementChild as HTMLElement;
+      const event = new MouseEvent("mousedown", { bubbles: true, cancelable: true, detail: 3 });
+      const preventDefault = vi.spyOn(event, "preventDefault");
+      header.dispatchEvent(event);
+      expect(preventDefault).toHaveBeenCalled();
+    });
+
+    it("forwards mousedown to the dnd-kit drag listener", () => {
+      const dragMouseDown = vi.fn();
+      mockDragHandle = { listeners: { onMouseDown: dragMouseDown } };
+      try {
+        const { container } = render(<PanelHeader {...makeProps({ location: "grid" })} />);
+        const header = container.firstElementChild as HTMLElement;
+        fireEvent.mouseDown(header, { detail: 1 });
+        expect(dragMouseDown).toHaveBeenCalledTimes(1);
+        fireEvent.mouseDown(header, { detail: 2 });
+        expect(dragMouseDown).toHaveBeenCalledTimes(2);
+      } finally {
+        mockDragHandle = null;
+      }
+    });
+
+    it("applies select-none to the header container", () => {
+      const { container } = render(<PanelHeader {...makeProps({ location: "grid" })} />);
+      const header = container.firstElementChild as HTMLElement;
+      expect(header.className).toContain("select-none");
     });
   });
 


### PR DESCRIPTION
## Summary

- Double-clicking an agent panel title bar was causing text in the adjacent Daintree assistant pane to appear selected -- a glitchy side-effect of native double-click word selection landing on content that slides into view during the focus-mode transition
- Added an `onMouseDown` handler on `PanelHeader` that calls `preventDefault()` when `e.detail >= 2`, stopping the browser from initiating a word-selection gesture on double-click; `input` and `textarea` targets are exempted so the title-rename workflow still works
- Added `select-none` to the header root as a defensive backstop

Resolves #6978

## Changes

- `src/components/Panel/PanelHeader.tsx` -- composed `onMouseDown` handler forwarding to dnd-kit's drag listener, then `preventDefault` on multi-click; `select-none` on the root div
- `src/components/Panel/__tests__/PanelHeader.test.tsx` -- 6 new cases under "mousedown selection guard (#6978)" covering `detail=1/2/3`, drag listener call ordering, `input`/`textarea` exemption, and `select-none` class presence

## Testing

- Unit tests pass (`npx vitest run` on the test file)
- Manually verified double-clicking the title bar no longer leaves text selected in the assistant pane