### PR TITLE
fix(layout): suppress grid resize observers during sidebar transition

### DIFF
--- a/src/components/Terminal/useContentGridContext.tsx
+++ b/src/components/Terminal/useContentGridContext.tsx
@@ -26,6 +26,10 @@ import {
   GRID_TRANSITION_DURATION_MS,
   GRID_FIT_DELAY_MS,
 } from "@/lib/terminalLayout";
+import {
+  isSidebarLayoutTransitionLocked,
+  subscribeSidebarLayoutTransitionUnlock,
+} from "@/lib/layoutTransitionLock";
 import { useWorktrees } from "@/hooks/useWorktrees";
 import { useProjectBranding } from "@/hooks";
 import { useCliAvailabilityStore } from "@/store/cliAvailabilityStore";
@@ -355,6 +359,7 @@ export function useContentGridContext({
 
     let rafId: number | null = null;
     let latestEntry: ResizeObserverEntry | null = null;
+    let finalRafId: number | null = null;
 
     const observer = new ResizeObserver((entries) => {
       const entry = entries[0];
@@ -365,6 +370,10 @@ export function useContentGridContext({
         rafId = null;
         const entry = latestEntry;
         latestEntry = null;
+        // Skip mid-transition widths — the flex parent is reflowing every
+        // frame and committing fractional widths into `grid-template-columns`
+        // produces visible jitter on the panel grid edge (#6979).
+        if (isSidebarLayoutTransitionLocked()) return;
         if (entry) {
           const { width, height } = entry.contentRect;
           setGridWidth((prev) => (prev === width ? prev : width));
@@ -377,9 +386,29 @@ export function useContentGridContext({
     setGridWidth(container.clientWidth);
     setGridDimensions({ width: container.clientWidth, height: container.clientHeight });
 
+    // Force a single measurement after the sidebar transition completes so
+    // the grid lands at its post-transition size even if no further RO entry
+    // fires (the geometry may already be settled by the time we unlock).
+    const unsubscribe = subscribeSidebarLayoutTransitionUnlock(() => {
+      const node = gridContainerRef.current;
+      if (!node) return;
+      if (finalRafId !== null) cancelAnimationFrame(finalRafId);
+      finalRafId = requestAnimationFrame(() => {
+        finalRafId = null;
+        const measureNode = gridContainerRef.current;
+        if (!measureNode) return;
+        const width = measureNode.clientWidth;
+        const height = measureNode.clientHeight;
+        setGridWidth((prev) => (prev === width ? prev : width));
+        setGridDimensions({ width, height });
+      });
+    });
+
     return () => {
       observer.disconnect();
       if (rafId !== null) cancelAnimationFrame(rafId);
+      if (finalRafId !== null) cancelAnimationFrame(finalRafId);
+      unsubscribe();
       setGridDimensions(null);
     };
   }, [setGridDimensions, gridTerminals.length, maximizedId, twoPaneSplitEnabled, showPlaceholder]);

--- a/src/components/Terminal/useContentGridContext.tsx
+++ b/src/components/Terminal/useContentGridContext.tsx
@@ -383,8 +383,15 @@ export function useContentGridContext({
     });
 
     observer.observe(container);
-    setGridWidth(container.clientWidth);
-    setGridDimensions({ width: container.clientWidth, height: container.clientHeight });
+    // If the effect re-mounts mid-transition (e.g., a dep like
+    // `gridTerminals.length` changes during the lock window), skip the
+    // initial measurement — a mid-animation `<main>` width would re-snap
+    // `grid-template-columns` and reintroduce jitter. The unlock subscriber
+    // below will sync the grid once the transition completes.
+    if (!isSidebarLayoutTransitionLocked()) {
+      setGridWidth(container.clientWidth);
+      setGridDimensions({ width: container.clientWidth, height: container.clientHeight });
+    }
 
     // Force a single measurement after the sidebar transition completes so
     // the grid lands at its post-transition size even if no further RO entry
@@ -395,6 +402,10 @@ export function useContentGridContext({
       if (finalRafId !== null) cancelAnimationFrame(finalRafId);
       finalRafId = requestAnimationFrame(() => {
         finalRafId = null;
+        // Re-check the lock — a second toggle may have started in the ~16ms
+        // between unlock and this rAF, in which case our measurement would
+        // capture a mid-animation width from the new transition.
+        if (isSidebarLayoutTransitionLocked()) return;
         const measureNode = gridContainerRef.current;
         if (!measureNode) return;
         const width = measureNode.clientWidth;

--- a/src/hooks/useGridNavigation.ts
+++ b/src/hooks/useGridNavigation.ts
@@ -4,6 +4,10 @@ import { useFleetArmingStore } from "@/store/fleetArmingStore";
 import { useFleetScopeFlagStore } from "@/store/fleetScopeFlagStore";
 import { useShallow } from "zustand/react/shallow";
 import { computeGridColumns } from "@/lib/terminalLayout";
+import {
+  isSidebarLayoutTransitionLocked,
+  subscribeSidebarLayoutTransitionUnlock,
+} from "@/lib/layoutTransitionLock";
 import { buildFleetPanels } from "@/components/Terminal/contentGridFleetPanels";
 
 export type NavigationDirection = "up" | "down" | "left" | "right";
@@ -85,31 +89,51 @@ export function useGridNavigation(options: UseGridNavigationOptions = {}) {
   const isFleetScopeRender = isFleetScopeEnabled && fleetPanels.length > 0;
 
   useEffect(() => {
+    let observedContainer: Element | null = null;
+
     const findAndObserve = () => {
       const container = document.querySelector(containerSelector);
       if (!container) return null;
 
       const observer = new ResizeObserver((entries) => {
         const entry = entries[0];
-        if (entry) {
-          const newWidth = entry.contentRect.width;
-          setGridWidth((prev) => (prev === newWidth ? prev : newWidth));
-        }
+        if (!entry) return;
+        // Skip mid-transition widths so keyboard-nav column count doesn't
+        // briefly snap to a different grid layout while sidebars animate
+        // (#6979).
+        if (isSidebarLayoutTransitionLocked()) return;
+        const newWidth = entry.contentRect.width;
+        setGridWidth((prev) => (prev === newWidth ? prev : newWidth));
       });
 
       observer.observe(container);
+      observedContainer = container;
       setGridWidth(container.clientWidth);
 
       return observer;
     };
 
     const observer = findAndObserve();
+
+    const unsubscribe = subscribeSidebarLayoutTransitionUnlock(() => {
+      const node = observedContainer ?? document.querySelector(containerSelector);
+      if (!node) return;
+      const width = node.clientWidth;
+      setGridWidth((prev) => (prev === width ? prev : width));
+    });
+
     if (!observer) {
       const retryTimer = setTimeout(findAndObserve, 100);
-      return () => clearTimeout(retryTimer);
+      return () => {
+        clearTimeout(retryTimer);
+        unsubscribe();
+      };
     }
 
-    return () => observer.disconnect();
+    return () => {
+      observer.disconnect();
+      unsubscribe();
+    };
     // isFleetScopeRender is a dep because ContentGrid swaps the rendered tree
     // (different React key) when fleet scope toggles, which detaches the old
     // #panel-grid node. Re-running the effect re-binds the observer to the

--- a/src/hooks/useGridNavigation.ts
+++ b/src/hooks/useGridNavigation.ts
@@ -108,7 +108,11 @@ export function useGridNavigation(options: UseGridNavigationOptions = {}) {
 
       observer.observe(container);
       observedContainer = container;
-      setGridWidth(container.clientWidth);
+      // Skip initial measurement during a sidebar lock — the unlock
+      // subscriber below will resync once the transition completes.
+      if (!isSidebarLayoutTransitionLocked()) {
+        setGridWidth(container.clientWidth);
+      }
 
       return observer;
     };

--- a/src/lib/__tests__/layoutTransitionLock.test.ts
+++ b/src/lib/__tests__/layoutTransitionLock.test.ts
@@ -129,6 +129,23 @@ describe("layoutTransitionLock", () => {
     expect(b).toHaveBeenCalledTimes(1);
   });
 
+  it("notifies subscribers exactly once when re-locked before expiry (covers rapid double-toggle)", () => {
+    const listener = vi.fn();
+    subscribeSidebarLayoutTransitionUnlock(listener);
+
+    lockSidebarLayoutTransition(250);
+    vi.advanceTimersByTime(200);
+    lockSidebarLayoutTransition(250);
+
+    vi.advanceTimersByTime(200);
+    expect(listener).not.toHaveBeenCalled();
+    expect(isSidebarLayoutTransitionLocked()).toBe(true);
+
+    vi.advanceTimersByTime(50);
+    expect(listener).toHaveBeenCalledTimes(1);
+    expect(isSidebarLayoutTransitionLocked()).toBe(false);
+  });
+
   it("__resetSidebarLayoutTransitionLockForTests clears the lock and listeners", () => {
     const listener = vi.fn();
     subscribeSidebarLayoutTransitionUnlock(listener);

--- a/src/lib/__tests__/layoutTransitionLock.test.ts
+++ b/src/lib/__tests__/layoutTransitionLock.test.ts
@@ -1,0 +1,144 @@
+// @vitest-environment jsdom
+import { describe, it, expect, vi, beforeEach, afterEach } from "vitest";
+import {
+  __resetSidebarLayoutTransitionLockForTests,
+  isSidebarLayoutTransitionLocked,
+  lockSidebarLayoutTransition,
+  subscribeSidebarLayoutTransitionUnlock,
+} from "../layoutTransitionLock";
+
+describe("layoutTransitionLock", () => {
+  beforeEach(() => {
+    vi.useFakeTimers();
+    __resetSidebarLayoutTransitionLockForTests();
+  });
+
+  afterEach(() => {
+    __resetSidebarLayoutTransitionLockForTests();
+    vi.useRealTimers();
+  });
+
+  it("starts unlocked", () => {
+    expect(isSidebarLayoutTransitionLocked()).toBe(false);
+  });
+
+  it("becomes locked synchronously and unlocks after the duration", () => {
+    lockSidebarLayoutTransition(250);
+    expect(isSidebarLayoutTransitionLocked()).toBe(true);
+
+    vi.advanceTimersByTime(249);
+    expect(isSidebarLayoutTransitionLocked()).toBe(true);
+
+    vi.advanceTimersByTime(1);
+    expect(isSidebarLayoutTransitionLocked()).toBe(false);
+  });
+
+  it("resets the timer when locked again before expiry", () => {
+    lockSidebarLayoutTransition(250);
+    vi.advanceTimersByTime(200);
+    expect(isSidebarLayoutTransitionLocked()).toBe(true);
+
+    lockSidebarLayoutTransition(250);
+    vi.advanceTimersByTime(200);
+    expect(isSidebarLayoutTransitionLocked()).toBe(true);
+
+    vi.advanceTimersByTime(50);
+    expect(isSidebarLayoutTransitionLocked()).toBe(false);
+  });
+
+  it("notifies subscribers when the lock expires", () => {
+    const listener = vi.fn();
+    subscribeSidebarLayoutTransitionUnlock(listener);
+
+    lockSidebarLayoutTransition(100);
+    expect(listener).not.toHaveBeenCalled();
+
+    vi.advanceTimersByTime(100);
+    expect(listener).toHaveBeenCalledTimes(1);
+    expect(isSidebarLayoutTransitionLocked()).toBe(false);
+  });
+
+  it("does not invoke listeners on the lock call itself, only on unlock", () => {
+    const listener = vi.fn();
+    subscribeSidebarLayoutTransitionUnlock(listener);
+
+    lockSidebarLayoutTransition(100);
+    lockSidebarLayoutTransition(100);
+    lockSidebarLayoutTransition(100);
+    expect(listener).not.toHaveBeenCalled();
+
+    vi.advanceTimersByTime(100);
+    expect(listener).toHaveBeenCalledTimes(1);
+  });
+
+  it("notifies multiple subscribers", () => {
+    const a = vi.fn();
+    const b = vi.fn();
+    subscribeSidebarLayoutTransitionUnlock(a);
+    subscribeSidebarLayoutTransitionUnlock(b);
+
+    lockSidebarLayoutTransition(50);
+    vi.advanceTimersByTime(50);
+
+    expect(a).toHaveBeenCalledTimes(1);
+    expect(b).toHaveBeenCalledTimes(1);
+  });
+
+  it("unsubscribe prevents the callback from firing", () => {
+    const listener = vi.fn();
+    const unsubscribe = subscribeSidebarLayoutTransitionUnlock(listener);
+    unsubscribe();
+
+    lockSidebarLayoutTransition(50);
+    vi.advanceTimersByTime(50);
+
+    expect(listener).not.toHaveBeenCalled();
+  });
+
+  it("survives a listener that throws and still notifies the others", () => {
+    const ok = vi.fn();
+    subscribeSidebarLayoutTransitionUnlock(() => {
+      throw new Error("boom");
+    });
+    subscribeSidebarLayoutTransitionUnlock(ok);
+
+    lockSidebarLayoutTransition(50);
+    vi.advanceTimersByTime(50);
+
+    expect(ok).toHaveBeenCalledTimes(1);
+    expect(isSidebarLayoutTransitionLocked()).toBe(false);
+  });
+
+  it("tolerates a subscriber that unsubscribes from inside its own callback", () => {
+    const a = vi.fn();
+    const unsubscribeA = vi.fn(() => unsubscribeAFn());
+    let unsubscribeAFn: () => void = () => {};
+
+    unsubscribeAFn = subscribeSidebarLayoutTransitionUnlock(() => {
+      a();
+      unsubscribeA();
+    });
+
+    const b = vi.fn();
+    subscribeSidebarLayoutTransitionUnlock(b);
+
+    lockSidebarLayoutTransition(50);
+    vi.advanceTimersByTime(50);
+
+    expect(a).toHaveBeenCalledTimes(1);
+    expect(b).toHaveBeenCalledTimes(1);
+  });
+
+  it("__resetSidebarLayoutTransitionLockForTests clears the lock and listeners", () => {
+    const listener = vi.fn();
+    subscribeSidebarLayoutTransitionUnlock(listener);
+    lockSidebarLayoutTransition(250);
+    expect(isSidebarLayoutTransitionLocked()).toBe(true);
+
+    __resetSidebarLayoutTransitionLockForTests();
+    expect(isSidebarLayoutTransitionLocked()).toBe(false);
+
+    vi.advanceTimersByTime(250);
+    expect(listener).not.toHaveBeenCalled();
+  });
+});

--- a/src/lib/__tests__/sidebarToggle.test.ts
+++ b/src/lib/__tests__/sidebarToggle.test.ts
@@ -2,6 +2,7 @@
 import { beforeEach, describe, expect, it, vi } from "vitest";
 
 const suppressMock = vi.hoisted(() => vi.fn());
+const lockMock = vi.hoisted(() => vi.fn());
 const getPanelStateMock = vi.hoisted(() => vi.fn());
 const getWorktreeSelectionStateMock = vi.hoisted(() => vi.fn());
 
@@ -17,6 +18,10 @@ vi.mock("@/store/panelStore", () => ({
 
 vi.mock("@/store/worktreeStore", () => ({
   useWorktreeSelectionStore: { getState: getWorktreeSelectionStateMock },
+}));
+
+vi.mock("../layoutTransitionLock", () => ({
+  lockSidebarLayoutTransition: lockMock,
 }));
 
 import { suppressSidebarResizes } from "../sidebarToggle";
@@ -104,5 +109,14 @@ describe("suppressSidebarResizes", () => {
 
     expect(() => suppressSidebarResizes()).not.toThrow();
     expect(suppressMock).toHaveBeenCalledWith([], SIDEBAR_TOGGLE_LOCK_MS);
+  });
+
+  it("locks the sidebar layout transition for the same window", () => {
+    setup([{ id: "p-1", location: "grid", worktreeId: "wt-a" }], "wt-a");
+
+    suppressSidebarResizes();
+
+    expect(lockMock).toHaveBeenCalledTimes(1);
+    expect(lockMock).toHaveBeenCalledWith(SIDEBAR_TOGGLE_LOCK_MS);
   });
 });

--- a/src/lib/layoutTransitionLock.ts
+++ b/src/lib/layoutTransitionLock.ts
@@ -1,0 +1,62 @@
+/**
+ * Process-wide signal that a sidebar slot is currently animating its width.
+ * During the lock window the panel-grid `<main flex:1>` reflows every frame
+ * as the flex container redistributes available space. Any consumer that
+ * derives geometry from a ResizeObserver (grid width, grid dimensions,
+ * keyboard-nav column count) must skip its updates while this lock is active
+ * — otherwise React commits mid-animation widths into `grid-template-columns`
+ * and the grid edge visibly jitters (regression of #5735, tracked in #6979).
+ *
+ * The lock complements the per-PTY suppression in
+ * `TerminalInstanceService.suppressResizesDuringLayoutTransition`: that one
+ * stops xterm from resizing the PTY host; this one stops React renders that
+ * would re-snap the visual grid layout. Both are needed because xterm
+ * suppression doesn't address layout-driven re-renders.
+ *
+ * Single renderer = single lock. Module-level state is safe — each project
+ * view is a distinct WebContentsView with its own V8 context (see
+ * `ProjectViewManager`), so there is exactly one grid per module scope.
+ */
+
+let locked = false;
+let timer: number | undefined;
+const listeners = new Set<() => void>();
+
+export function isSidebarLayoutTransitionLocked(): boolean {
+  return locked;
+}
+
+export function lockSidebarLayoutTransition(durationMs: number): void {
+  locked = true;
+  if (timer !== undefined) {
+    clearTimeout(timer);
+  }
+  timer = window.setTimeout(() => {
+    timer = undefined;
+    locked = false;
+    // Snapshot listeners — a callback may unsubscribe during iteration.
+    for (const listener of Array.from(listeners)) {
+      try {
+        listener();
+      } catch {
+        // Swallow per-listener errors so one bad subscriber can't block others.
+      }
+    }
+  }, durationMs);
+}
+
+export function subscribeSidebarLayoutTransitionUnlock(listener: () => void): () => void {
+  listeners.add(listener);
+  return () => {
+    listeners.delete(listener);
+  };
+}
+
+export function __resetSidebarLayoutTransitionLockForTests(): void {
+  if (timer !== undefined) {
+    clearTimeout(timer);
+    timer = undefined;
+  }
+  locked = false;
+  listeners.clear();
+}

--- a/src/lib/sidebarToggle.ts
+++ b/src/lib/sidebarToggle.ts
@@ -2,6 +2,7 @@ import { terminalInstanceService } from "@/services/terminal/TerminalInstanceSer
 import { useHelpPanelStore } from "@/store/helpPanelStore";
 import { usePanelStore } from "@/store/panelStore";
 import { useWorktreeSelectionStore } from "@/store/worktreeStore";
+import { lockSidebarLayoutTransition } from "./layoutTransitionLock";
 import { SIDEBAR_TOGGLE_LOCK_MS } from "./terminalLayout";
 
 /**
@@ -32,4 +33,8 @@ export function suppressSidebarResizes(): void {
     ids.push(assistantTerminalId);
   }
   terminalInstanceService.suppressResizesDuringLayoutTransition(ids, SIDEBAR_TOGGLE_LOCK_MS);
+  // Block ResizeObserver-driven grid-width re-renders for the same window.
+  // PTY suppression alone leaves the visual grid jittering as `<main flex:1>`
+  // reflows every frame against the animating sidebar slot (see #6979).
+  lockSidebarLayoutTransition(SIDEBAR_TOGGLE_LOCK_MS);
 }


### PR DESCRIPTION
## Summary

- Fixes the panel grid edge jitter that occurs when toggling focus mode via the sidebar. After #6619 and #6956, `<main>` became a flex sibling that reflows every frame as the sidebar slot animates its width.
- The existing `suppressSidebarResizes()` gate was correctly blocking PTY `fit()`/`SIGWINCH` calls, but the React ResizeObservers in `useContentGridContext` and `useGridNavigation` — which derive `gridWidth`/`gridDimensions` from `<main>` — were not gated. Mid-transition widths were flowing straight into `computeGridColumns()` and re-snapping `grid-template-columns` mid-animation.
- Fix: new `layoutTransitionLock` module that `suppressSidebarResizes()` activates for the duration of the transition. ResizeObservers in both hooks skip state updates while locked and resync via an unlock subscriber when the transition ends.

Closes #6979

## Changes

- `src/lib/layoutTransitionLock.ts` (new) — module-level lock with `subscribe`/unlock, fail-safe listener iteration, and a test reset hook
- `src/lib/sidebarToggle.ts` — calls `lockSidebarLayoutTransition(SIDEBAR_TOGGLE_LOCK_MS)` after PTY suppression
- `src/components/Terminal/useContentGridContext.tsx` — ResizeObserver guarded while locked; initial mount measurement guarded; unlock subscriber fires a rAF-deferred final measurement
- `src/hooks/useGridNavigation.ts` — same pattern: ResizeObserver guarded, initial mount guarded, unlock subscriber syncs synchronously
- `src/lib/__tests__/layoutTransitionLock.test.ts` (new) — 11 unit tests covering rapid-double-toggle re-lock semantics
- `src/lib/__tests__/sidebarToggle.test.ts` — one additional test confirming the lock is invoked

## Testing

- Vitest: 47/47 pass across `layoutTransitionLock`, `sidebarToggle`, and `useGridNavigation`
- `tsc --noEmit`: clean across renderer, main, and preload
- ESLint: warnings only, no errors
- `npm run check` and `npm run build`: both pass

**Manual:** toggle focus mode with one or more panels in the grid and watch both the left and right grid edges — they should stay anchored for the full duration of the transition with no snap or jitter.