### PR TITLE
feat(recipes): polish project-recipe empty-state copy and CTAs

### DIFF
--- a/src/components/Project/RecipesTab.tsx
+++ b/src/components/Project/RecipesTab.tsx
@@ -191,12 +191,7 @@ export function RecipesTab({
             </div>
           ) : recipes.length === 0 ? (
             <div className="border border-dashed border-daintree-border rounded-[var(--radius-md)]">
-              <EmptyState
-                variant="zero-data"
-                icon={<Workflow />}
-                title="No recipes configured yet"
-                description="Create a recipe to spawn multiple terminals with predefined commands and settings."
-              />
+              <EmptyState variant="zero-data" icon={<Workflow />} title="No recipes" />
             </div>
           ) : (
             <div className="border border-daintree-border rounded-[var(--radius-md)] divide-y divide-daintree-border">

--- a/src/components/TerminalRecipe/RecipeManager.tsx
+++ b/src/components/TerminalRecipe/RecipeManager.tsx
@@ -369,23 +369,25 @@ export function RecipeManager({
                   title="No project recipes"
                   description="Project recipes stay private to this machine until you save them to the repo."
                   action={
-                    <div className="flex flex-wrap gap-2 justify-center">
+                    <div className="flex flex-col items-center gap-2">
                       <Button variant="outline" size="sm" onClick={() => onCreateRecipe("project")}>
                         <Plus className="h-3 w-3" />
                         New project recipe
                       </Button>
-                      <Button variant="outline" size="sm" onClick={() => setShowImportDialog(true)}>
-                        <FileDown className="h-3 w-3" />
-                        Import from clipboard
-                      </Button>
-                      <Button
-                        variant="outline"
-                        size="sm"
-                        onClick={() => void importRecipeFromFile(currentProject?.id)}
-                      >
-                        <FileUp className="h-3 w-3" />
-                        Import from file
-                      </Button>
+                      <div className="flex gap-2">
+                        <Button variant="ghost" size="sm" onClick={() => setShowImportDialog(true)}>
+                          <FileDown className="h-3 w-3" />
+                          Import from clipboard
+                        </Button>
+                        <Button
+                          variant="ghost"
+                          size="sm"
+                          onClick={() => void importRecipeFromFile(currentProject?.id)}
+                        >
+                          <FileUp className="h-3 w-3" />
+                          Import from file
+                        </Button>
+                      </div>
                     </div>
                   }
                 />

--- a/src/components/TerminalRecipe/RecipeManager.tsx
+++ b/src/components/TerminalRecipe/RecipeManager.tsx
@@ -374,7 +374,7 @@ export function RecipeManager({
                         <Plus className="h-3 w-3" />
                         New project recipe
                       </Button>
-                      <div className="flex gap-2">
+                      <div className="flex flex-wrap justify-center gap-2">
                         <Button variant="ghost" size="sm" onClick={() => setShowImportDialog(true)}>
                           <FileDown className="h-3 w-3" />
                           Import from clipboard


### PR DESCRIPTION
## Summary

- `RecipeManager.tsx` — the project-recipes empty state previously rendered three equal-weight outline buttons (create + two import paths). Now the primary "New project recipe" button stands alone as an outline button, with the import paths demoted to ghost-variant secondary buttons in a flex-wrap row below. Matches the global-recipes empty state pattern already in the same file.
- `RecipesTab.tsx` — title shortened from "No recipes configured yet" to "No recipes"; redundant description removed because it duplicated the section paragraph immediately above it. The persistent Add/Import button row below already covers recovery.

Both changes apply the CLAUDE.md rule: empty states drive a single concrete action.

Resolves #6986

## Changes

- `src/components/TerminalRecipe/RecipeManager.tsx` — demote import CTAs to ghost variant, restructure empty-state layout
- `src/components/Project/RecipesTab.tsx` — tighten title, drop duplicate description

## Testing

- Typecheck: pass
- Lint: pass
- Format: pass
- Build: pass (28s)
- Visually confirmed project-recipe and global-recipe empty states render correctly