### PR TITLE
fix(pty): restore Claude session-ID capture in graceful shutdown

### DIFF
--- a/electron/services/pty/TerminalGracefulShutdown.ts
+++ b/electron/services/pty/TerminalGracefulShutdown.ts
@@ -54,6 +54,7 @@ export async function gracefulShutdown(host: TerminalGracefulShutdownHost): Prom
   const quitSubmitEnterDelayMs = normalizeSubmitEnterDelay(
     agentConfig?.capabilities?.submitEnterDelayMs
   );
+  const quitSubmitMode = agentConfig?.capabilities?.quitSubmitMode ?? "split-write";
 
   // Only `session-id` triggers the post-quit pattern-match capture loop —
   // other kinds (rolling-history, named-target, project-scoped) just send
@@ -147,19 +148,28 @@ export async function gracefulShutdown(host: TerminalGracefulShutdownHost): Prom
           terminal.ptyProcess.write(shutdownKeySequence);
         }
         if (quitCommand) {
-          terminal.ptyProcess.write(quitCommand);
-          await new Promise<void>((r) => setTimeout(r, quitSubmitEnterDelayMs));
+          if (quitSubmitMode === "single-write") {
+            // Ink-based TUIs (e.g. Claude Code) require body + Enter in the
+            // same PTY write so the slash-command parser sees them in one
+            // event-loop tick. A non-zero gap is interpreted as deliberate
+            // slow typing, so the command never submits and the
+            // session-ID line is never echoed (issue #6981).
+            terminal.ptyProcess.write(quitCommand + "\r");
+          } else {
+            terminal.ptyProcess.write(quitCommand);
+            await new Promise<void>((r) => setTimeout(r, quitSubmitEnterDelayMs));
 
-          if (resolved) return;
+            if (resolved) return;
 
-          if (!host.isAgentLive) {
-            origOnData.dispose();
-            origOnExit.dispose();
-            finish(null);
-            return;
+            if (!host.isAgentLive) {
+              origOnData.dispose();
+              origOnExit.dispose();
+              finish(null);
+              return;
+            }
+
+            terminal.ptyProcess.write("\r");
           }
-
-          terminal.ptyProcess.write("\r");
         }
       } catch {
         origOnData.dispose();

--- a/electron/services/pty/__tests__/TerminalProcess.gracefulShutdown.test.ts
+++ b/electron/services/pty/__tests__/TerminalProcess.gracefulShutdown.test.ts
@@ -144,7 +144,6 @@ describe("TerminalProcess.gracefulShutdown — input-clear prelude", () => {
 
     const shutdownPromise = terminal.gracefulShutdown();
     await vi.advanceTimersByTimeAsync(GRACEFUL_SHUTDOWN_CLEAR_DELAY_MS);
-    await vi.advanceTimersByTimeAsync(SUBMIT_ENTER_DELAY_MS);
 
     // The CLI echoes back ANSI erase sequences in response to Ctrl-U before the real
     // session-ID line. stripAnsiCodes in the matcher should strip these cleanly.

--- a/electron/services/pty/__tests__/TerminalProcess.gracefulShutdown.test.ts
+++ b/electron/services/pty/__tests__/TerminalProcess.gracefulShutdown.test.ts
@@ -106,7 +106,11 @@ describe("TerminalProcess.gracefulShutdown — input-clear prelude", () => {
     vi.useRealTimers();
   });
 
-  it("writes Ctrl-E + Ctrl-U before submitting the quit command with a separate Enter", async () => {
+  it("writes Ctrl-E + Ctrl-U then submits Claude's /quit body and Enter as a single write", async () => {
+    // Issue #6981: Claude Code (Ink TUI) requires body + Enter in one PTY
+    // write — any gap between them is treated as deliberate slow typing
+    // and the slash-command parser never fires, so no session-ID line is
+    // ever echoed. Claude is configured with `quitSubmitMode: "single-write"`.
     const handles = createMockPty();
     const terminal = createAgentTerminal(handles);
 
@@ -120,16 +124,11 @@ describe("TerminalProcess.gracefulShutdown — input-clear prelude", () => {
     expect(handles.writeMock).toHaveBeenCalledTimes(1);
     expect(handles.writeMock.mock.calls[0]?.[0]).toBe("\x05\x15");
 
-    // Advance past the clear delay and the quit command body should fire.
+    // Advance past the clear delay and the combined quit+Enter write should fire.
     await vi.advanceTimersByTimeAsync(GRACEFUL_SHUTDOWN_CLEAR_DELAY_MS);
 
     expect(handles.writeMock).toHaveBeenCalledTimes(2);
-    expect(handles.writeMock.mock.calls[1]?.[0]).toBe("/quit");
-
-    // Enter is sent as a separate key after the same delay used by normal submit.
-    await vi.advanceTimersByTimeAsync(SUBMIT_ENTER_DELAY_MS);
-    expect(handles.writeMock).toHaveBeenCalledTimes(3);
-    expect(handles.writeMock.mock.calls[2]?.[0]).toBe("\r");
+    expect(handles.writeMock.mock.calls[1]?.[0]).toBe("/quit\r");
 
     // Emit the session-ID line and the promise should resolve with the captured ID.
     handles.emitData("claude --resume abc-123\n");
@@ -163,11 +162,10 @@ describe("TerminalProcess.gracefulShutdown — input-clear prelude", () => {
     await vi.advanceTimersByTimeAsync(GRACEFUL_SHUTDOWN_TIMEOUT_MS);
 
     await expect(shutdownPromise).resolves.toBeNull();
-    // Prelude, quit body, and Enter must all be attempted before timeout.
-    expect(handles.writeMock).toHaveBeenCalledTimes(3);
+    // Prelude and combined quit+Enter must both be attempted before timeout.
+    expect(handles.writeMock).toHaveBeenCalledTimes(2);
     expect(handles.writeMock.mock.calls[0]?.[0]).toBe("\x05\x15");
-    expect(handles.writeMock.mock.calls[1]?.[0]).toBe("/quit");
-    expect(handles.writeMock.mock.calls[2]?.[0]).toBe("\r");
+    expect(handles.writeMock.mock.calls[1]?.[0]).toBe("/quit\r");
   });
 
   it("skips the quit write when the PTY exits during the clear-delay window", async () => {
@@ -212,7 +210,7 @@ describe("TerminalProcess.gracefulShutdown — input-clear prelude", () => {
 
   it("resolves null when the quit-command write throws after a successful prelude", async () => {
     const handles = createMockPty((data: string) => {
-      if (data === "/quit") {
+      if (data === "/quit\r") {
         throw new Error("pty dead after prelude");
       }
     });
@@ -304,11 +302,7 @@ describe("TerminalProcess.gracefulShutdown — input-clear prelude", () => {
 
     expect(handles.writeMock).toHaveBeenCalledTimes(2);
     expect(handles.writeMock.mock.calls[0]?.[0]).toBe("\x05\x15");
-    expect(handles.writeMock.mock.calls[1]?.[0]).toBe("/quit");
-
-    await vi.advanceTimersByTimeAsync(SUBMIT_ENTER_DELAY_MS);
-    expect(handles.writeMock).toHaveBeenCalledTimes(3);
-    expect(handles.writeMock.mock.calls[2]?.[0]).toBe("\r");
+    expect(handles.writeMock.mock.calls[1]?.[0]).toBe("/quit\r");
 
     handles.emitData("claude --resume live-agent\n");
     await expect(shutdownPromise).resolves.toBe("live-agent");
@@ -334,9 +328,15 @@ describe("TerminalProcess.gracefulShutdown — input-clear prelude", () => {
     expect(terminal.getInfo().agentSessionId).toBe("codex-session-123");
   });
 
-  it("skips Enter when the agent demotes during the quit-submit delay", async () => {
+  it("skips Enter when the split-write agent demotes during the quit-submit delay", async () => {
+    // Mid-flight liveness guard for the split-write path only — Codex (and
+    // other Ratatui/readline CLIs) writes the body and Enter as separate
+    // PTY writes with a delay between them. If the agent demotes during
+    // that gap, the trailing Enter must be skipped so it doesn't land in a
+    // plain shell. Claude uses single-write so this guard isn't reachable
+    // for it; using `codex` keeps the split-write coverage explicit.
     const handles = createMockPty();
-    const terminal = createAgentTerminal(handles);
+    const terminal = createAgentTerminal(handles, "codex");
 
     const shutdownPromise = terminal.gracefulShutdown();
     await vi.advanceTimersByTimeAsync(GRACEFUL_SHUTDOWN_CLEAR_DELAY_MS);

--- a/shared/config/agentRegistry.ts
+++ b/shared/config/agentRegistry.ts
@@ -298,6 +298,16 @@ export interface AgentConfig {
     ignoredInputSequences?: string[];
     /** Delay in ms before sending Enter key after body write (default: 200) */
     submitEnterDelayMs?: number;
+    /**
+     * How the graceful-shutdown path submits the quit command to the agent
+     * PTY. Ink-based TUIs (Claude) treat any gap between the command body
+     * and Enter as deliberate slow typing and never submit the slash
+     * command, so they require a single combined write. Ratatui-based TUIs
+     * (Codex) read the PTY buffer atomically and conflate a combined write
+     * as a paste, so they require the body and Enter as separate writes.
+     * Default: split-write — safe for Codex and readline-based CLIs.
+     */
+    quitSubmitMode?: "single-write" | "split-write";
   };
   /**
    * Configuration for pattern-based working state detection.

--- a/shared/config/agents/claude.ts
+++ b/shared/config/agents/claude.ts
@@ -67,6 +67,7 @@ export const config: AgentConfig = {
     supportsBracketedPaste: true,
     softNewlineSequence: "\x1b\r",
     ignoredInputSequences: ["\x1b\r"],
+    quitSubmitMode: "single-write",
   },
   detection: {
     primaryPatterns: [


### PR DESCRIPTION
## Summary

- `acc38bd36` split the PTY quit write (body → 200ms → `\r`) to fix Codex paste-conflation, but that async gap means Claude's Ink TUI never submits `/quit` — the session-ID line is never echoed and graceful shutdown resolves `null`.
- Adds a `quitSubmitMode` capability (`"single-write"` | `"split-write"`) defaulting to `"split-write"` to preserve existing Codex behavior. Claude is set to `"single-write"` so `/quit\r` is sent in a single PTY call with no async gap.
- Codex, Gemini, and Copilot are intentionally left on `"split-write"` — no confirmed regression for them, and adding untested changes creates risk.

Resolves #6981

## Changes

- `shared/config/agentRegistry.ts` — adds `quitSubmitMode` to the capability schema, default `"split-write"`
- `shared/config/agents/claude.ts` — sets `quitSubmitMode: "single-write"`
- `electron/services/pty/TerminalGracefulShutdown.ts` — branches on `quitSubmitMode`; for `"single-write"` combines body + `\r` in one PTY write and skips the inter-write liveness guard (no async gap to guard against)
- `electron/services/pty/__tests__/TerminalProcess.gracefulShutdown.test.ts` — removes a now-spurious `vi.advanceTimersByTimeAsync` from the ANSI-erase test that was compensating for the split-write delay

## Testing

- 13/13 graceful shutdown unit tests passing
- Lint ratchet decreased by 6 warnings
- Typecheck, lint, format, and build all clean