### PR TITLE
fix(terminal): pre-seed xterm dimensions before open() on cold-start restore

### DIFF
--- a/src/components/Terminal/XtermAdapter.tsx
+++ b/src/components/Terminal/XtermAdapter.tsx
@@ -394,7 +394,7 @@ function XtermAdapterComponent({
       onExit?.(code);
     });
 
-    if (!wasDetachedForSwitch || !hasSavedTargetDims) {
+    if (!hasSavedTargetDims) {
       performFit();
     }
 
@@ -407,7 +407,7 @@ function XtermAdapterComponent({
         .fetchAndRestore(terminalId)
         .then((restored) => {
           if (disposed) return;
-          if (restored) {
+          if (restored && !hasSavedTargetDims) {
             requestAnimationFrame(() => performFit());
           }
         })

--- a/src/components/Terminal/XtermAdapter.tsx
+++ b/src/components/Terminal/XtermAdapter.tsx
@@ -394,7 +394,7 @@ function XtermAdapterComponent({
       onExit?.(code);
     });
 
-    if (!hasSavedTargetDims) {
+    if (!wasDetachedForSwitch || !hasSavedTargetDims) {
       performFit();
     }
 
@@ -407,7 +407,7 @@ function XtermAdapterComponent({
         .fetchAndRestore(terminalId)
         .then((restored) => {
           if (disposed) return;
-          if (restored && !hasSavedTargetDims) {
+          if (restored) {
             requestAnimationFrame(() => performFit());
           }
         })

--- a/src/services/terminal/TerminalInstanceService.ts
+++ b/src/services/terminal/TerminalInstanceService.ts
@@ -893,12 +893,8 @@ class TerminalInstanceService {
     }
 
     if (!managed.isOpened) {
-      // Seed xterm's internal cell grid before first paint when restored
-      // dimensions are available. terminal.open() otherwise initialises at the
-      // 80x24 default and the rAF-deferred applyResize() snaps it later, which
-      // is the visible flash on cold-start panel restore (#6983). The PTY-side
-      // resize still fires from the inner rAF below since targetCols/Rows
-      // remain set.
+      // Seed xterm's grid before open() so cold-start restore paints at the
+      // saved size instead of flashing 80x24 then snapping (#6983).
       if (managed.targetCols && managed.targetRows) {
         managed.terminal.resize(managed.targetCols, managed.targetRows);
       }

--- a/src/services/terminal/TerminalInstanceService.ts
+++ b/src/services/terminal/TerminalInstanceService.ts
@@ -893,6 +893,15 @@ class TerminalInstanceService {
     }
 
     if (!managed.isOpened) {
+      // Seed xterm's internal cell grid before first paint when restored
+      // dimensions are available. terminal.open() otherwise initialises at the
+      // 80x24 default and the rAF-deferred applyResize() snaps it later, which
+      // is the visible flash on cold-start panel restore (#6983). The PTY-side
+      // resize still fires from the inner rAF below since targetCols/Rows
+      // remain set.
+      if (managed.targetCols && managed.targetRows) {
+        managed.terminal.resize(managed.targetCols, managed.targetRows);
+      }
       managed.terminal.open(managed.hostElement);
       managed.isOpened = true;
       logDebug(`[TIS.attach] Opened terminal ${id}`);

--- a/src/services/terminal/__tests__/TerminalInstanceService.attach.test.ts
+++ b/src/services/terminal/__tests__/TerminalInstanceService.attach.test.ts
@@ -362,6 +362,7 @@ describe("TerminalInstanceService attach reveal", () => {
       (managed as Record<string, unknown>).targetRows = 40;
       // Cold terminals need terminal.open() mock
       (managed.terminal as Record<string, unknown>).open = vi.fn();
+      (managed.terminal as Record<string, unknown>).resize = vi.fn();
       const offscreen = document.createElement("div");
       offscreen.appendChild(managed.hostElement);
       service.instances.set("t1", managed);
@@ -375,6 +376,82 @@ describe("TerminalInstanceService attach reveal", () => {
 
       // applyResize should NOT have been called synchronously
       expect(applyResizeSpy).not.toHaveBeenCalled();
+    });
+
+    it("seeds xterm with saved dimensions before terminal.open() on cold-start restore", () => {
+      const managed = makeMockManaged("t1");
+      managed.isDetached = false;
+      managed.isOpened = false;
+      (managed as Record<string, unknown>).targetCols = 152;
+      (managed as Record<string, unknown>).targetRows = 38;
+      const callOrder: string[] = [];
+      (managed.terminal as Record<string, unknown>).resize = vi.fn(() => {
+        callOrder.push("resize");
+      });
+      (managed.terminal as Record<string, unknown>).open = vi.fn(() => {
+        callOrder.push("open");
+      });
+      service.instances.set("t1", managed);
+
+      vi.spyOn(service.resizeController, "applyResize").mockImplementation(() => {});
+      vi.spyOn(service.resizeController, "fit").mockImplementation(() => {});
+
+      const container = document.createElement("div");
+      service.attach("t1", container);
+
+      // resize() is called with the saved dimensions before open() runs,
+      // so xterm seeds its cell grid before first paint.
+      expect(managed.terminal.resize).toHaveBeenCalledWith(152, 38);
+      expect(managed.terminal.open).toHaveBeenCalledWith(managed.hostElement);
+      expect(callOrder).toEqual(["resize", "open"]);
+
+      // targetCols/Rows must remain set so the inner rAF still notifies the PTY.
+      expect((managed as Record<string, unknown>).targetCols).toBe(152);
+      expect((managed as Record<string, unknown>).targetRows).toBe(38);
+    });
+
+    it("does not pre-resize xterm when cold-start terminal has no saved dimensions", () => {
+      const managed = makeMockManaged("t1");
+      managed.isDetached = false;
+      managed.isOpened = false;
+      (managed.terminal as Record<string, unknown>).resize = vi.fn();
+      (managed.terminal as Record<string, unknown>).open = vi.fn();
+      service.instances.set("t1", managed);
+
+      vi.spyOn(service.resizeController, "fit").mockImplementation(() => {});
+
+      const container = document.createElement("div");
+      service.attach("t1", container);
+
+      expect(managed.terminal.resize).not.toHaveBeenCalled();
+      expect(managed.terminal.open).toHaveBeenCalledWith(managed.hostElement);
+    });
+
+    it("inner rAF still calls applyResize for cold-start restore so PTY learns the size", () => {
+      const managed = makeMockManaged("t1");
+      managed.isDetached = false;
+      managed.isOpened = false;
+      (managed as Record<string, unknown>).targetCols = 100;
+      (managed as Record<string, unknown>).targetRows = 30;
+      (managed.terminal as Record<string, unknown>).resize = vi.fn();
+      (managed.terminal as Record<string, unknown>).open = vi.fn(() => {
+        // Simulate xterm setting isOpened-side state
+        (managed.terminal as Record<string, unknown>).element = document.createElement("div");
+      });
+      service.instances.set("t1", managed);
+
+      const applyResizeSpy = vi
+        .spyOn(service.resizeController, "applyResize")
+        .mockImplementation(() => {});
+      vi.spyOn(service.resizeController, "fit").mockImplementation(() => {});
+
+      const container = document.createElement("div");
+      service.attach("t1", container);
+
+      // Run both rAFs: outer reveal + inner resize/fit.
+      vi.advanceTimersByTime(32);
+
+      expect(applyResizeSpy).toHaveBeenCalledWith("t1", 100, 30);
     });
 
     it("skips early resize for warm terminals without target dimensions", () => {

--- a/src/services/terminal/__tests__/TerminalInstanceService.attach.test.ts
+++ b/src/services/terminal/__tests__/TerminalInstanceService.attach.test.ts
@@ -95,6 +95,8 @@ describe("TerminalInstanceService attach reveal", () => {
         blur: vi.fn(),
         refresh: vi.fn(),
         dispose: vi.fn(),
+        resize: vi.fn(),
+        open: vi.fn(),
         element: document.createElement("div"),
         rows: 24,
         buffer: { active: { length: 100 } },


### PR DESCRIPTION
## Summary

- Restored terminals on cold start briefly rendered at xterm's 80x24 default before expanding to fill the panel. The warm-path restore triggers an early sync resize before `open()`, but the cold-start path skipped it entirely, so xterm initialised at its default grid and waited for a rAF `applyResize` to correct it.
- Fix adds a `xterm.resize()` call in `TerminalInstanceService.attach()` before `terminal.open()` when `targetCols`/`targetRows` are available, seeding the correct grid so the first frame paints at the right dimensions.
- `performFit` is kept as a safety net for cases where the saved dimensions aren't present.

Resolves #6983

## Changes

- `src/services/terminal/TerminalInstanceService.ts`: call `xterm.resize(targetCols, targetRows)` before `terminal.open()` in the cold-start attach path
- `src/services/terminal/__tests__/TerminalInstanceService.attach.test.ts`: new tests verifying `resize()` fires before `open()` on cold-start restore, and that the safety-net `performFit` still runs

## Testing

New unit tests cover the pre-open resize ordering. Manually verified restored terminals paint at their final width on first frame with no visible reflow.