### PR TITLE
feat(mcp): add terminal.getStatus for batched fleet polling

### DIFF
--- a/electron/services/mcp-server/shared.ts
+++ b/electron/services/mcp-server/shared.ts
@@ -153,6 +153,7 @@ const WORKBENCH_TOOLS: ReadonlySet<string> = new Set([
 
   "terminal.list",
   "terminal.getOutput",
+  "terminal.getStatus",
 
   "agent.getState",
 
@@ -265,6 +266,7 @@ const MCP_TOOL_ALLOWLIST: ReadonlySet<string> = new Set([
 
   "terminal.list",
   "terminal.getOutput",
+  "terminal.getStatus",
   "terminal.sendCommand",
   "terminal.inject",
   "terminal.new",

--- a/help/CLAUDE.md
+++ b/help/CLAUDE.md
@@ -31,48 +31,65 @@ When choosing what to do, prefer the least-privileged path. If the user asks you
 
 ## Watching Multiple Agent Terminals
 
-`terminal.waitUntilIdle` blocks for up to 30 minutes by default — fine for a single terminal, harmful when polling several at once. Concurrent default-timeout waits race unpredictably, tie up the orchestrator, and make ordering non-deterministic. Use a non-blocking snapshot loop instead.
+Use `terminal.getStatus` for fleet polling. It returns the full agent state (`idle | working | waiting | completed | exited`), `waitingReason`, and `lastTransitionAt` for many terminals in a single call, with optional recent-output tails for cross-checking the state cache. Don't fan `terminal.waitUntilIdle({ timeoutMs: 0 })` out across N terminals — that pattern is N IPC round-trips per round and gives no cheap way to verify state against actual scrollback.
 
 **Recipe:**
 
-1. **Snapshot in parallel.** Call `terminal.waitUntilIdle` with `timeoutMs: 0` for each terminal you're watching. Each call returns immediately with `busyState`, `idleReason`, `lastTransitionAt`, and `timedOut`. With `timeoutMs: 0`, `timedOut` is `true` when the agent is still `working` (the zero-length wait elapsed) and `false` when the agent is already idle or no agent is attached — treat it as a busy/idle indicator on the snapshot path, not an error.
-2. **Skip working terminals.** When `busyState === "working"` the agent is mid-task — there's nothing to act on this round.
+1. **Snapshot the fleet in one call.** Pass `terminalIds` (when you know what you spawned) or a `worktreeId`/`location` filter. Each entry returns `agentState`, `waitingReason` (when waiting), `lastTransitionAt`, and an optional `recentOutput` tail.
+2. **Skip working terminals.** When `agentState === "working"` (or `"directing"`) the agent is mid-task — nothing to act on this round.
 3. **Skip already-handled transitions.** Track the last `lastTransitionAt` you acted on per terminal and skip when it hasn't advanced. `lastTransitionAt` is `undefined` for terminals that have never transitioned — treat that as "no transition yet," not as "changed."
-4. **Act on `idleReason`** when `busyState === "idle"`:
+4. **Act on `agentState`** for non-working terminals:
    - `completed` — agent finished its task; record the result and dispatch the next step.
    - `exited` — agent process exited; surface to the user, the terminal won't recover on its own.
-   - `waiting_for_user` — agent paused, likely needing input. Currently ambiguous (a generic prompt vs. a specific question — see #6960); verify against terminal output before auto-replying.
+   - `waiting` — agent paused, likely needing input. `waitingReason` distinguishes `"prompt"` (empty input prompt, safe to auto-drive) from `"question"` (agent is asking the user something — verify before auto-replying).
    - `idle` — agent is settling between subtasks; skip and re-poll.
-   - `unknown` — no agent attached or unrecognized state; treat as still busy.
-5. **Pace the next round with `ScheduleWakeup`.** Don't busy-loop. `ScheduleWakeup` resumes the orchestrator after a delay without holding a blocking call open, so it stays responsive to user interrupts.
+   - `null` — no agent attached or unknown state; treat as still busy.
+5. **Cross-check stuck state with `includeOutput`.** The state cache is a heuristic, not ground truth — `ActivityMonitor` can pin a finished agent at `working`. **If `agentState` for a given terminal hasn't transitioned across roughly 3 polling rounds, set `includeOutput` on the next round to verify against actual terminal text.** A short scrollback tail is usually enough to tell a stuck FSM from a genuinely working agent.
+6. **Pace the next round with `ScheduleWakeup`.** Don't busy-loop. `ScheduleWakeup` resumes the orchestrator after a delay without holding a blocking call open, so it stays responsive to user interrupts.
 
 Sketch:
 
 ```ts
-const results = await Promise.allSettled(
-  terminalIds.map((id) => waitUntilIdle({ terminalId: id, timeoutMs: 0 }))
-);
-for (const r of results) {
-  if (r.status === "rejected") continue; // log and move on
-  const s = r.value;
-  if (s.busyState === "working") continue;
-  if (s.lastTransitionAt !== undefined && s.lastTransitionAt === lastSeen[s.terminalId]) continue;
-  switch (s.idleReason) {
+const stuckCount: Record<string, number> = {};
+const lastSeen: Record<string, number | undefined> = {};
+
+// Plain status round.
+const { terminals } = await getStatus({ terminalIds });
+
+// If any terminal hasn't transitioned in the last ~3 rounds, refetch with output.
+const stuckIds = terminals
+  .filter((t) => t.agentState && t.agentState !== "idle" && (stuckCount[t.terminalId] ?? 0) >= 3)
+  .map((t) => t.terminalId);
+const verified = stuckIds.length
+  ? (await getStatus({ terminalIds: stuckIds, includeOutput: { lines: 30 } })).terminals
+  : [];
+const verifiedById = new Map(verified.map((v) => [v.terminalId, v]));
+
+for (const t of terminals) {
+  if (t.error) continue; // log and move on (e.g. unknown terminalId)
+  if (t.agentState === "working" || t.agentState === "directing") {
+    stuckCount[t.terminalId] = (stuckCount[t.terminalId] ?? 0) + 1;
+    continue;
+  }
+  if (t.lastTransitionAt !== undefined && t.lastTransitionAt === lastSeen[t.terminalId]) continue;
+
+  const status = verifiedById.get(t.terminalId) ?? t;
+  switch (status.agentState) {
     case "completed":
       /* dispatch next step */ break;
     case "exited":
       /* surface to user */ break;
-    case "waiting_for_user":
-      /* verify, then act or ask */ break;
+    case "waiting":
+      /* status.waitingReason: "prompt" → safe to auto-drive; "question" → verify against status.recentOutput, then act or ask */
+      break;
   }
-  if (s.lastTransitionAt !== undefined) lastSeen[s.terminalId] = s.lastTransitionAt;
+  stuckCount[t.terminalId] = 0;
+  if (t.lastTransitionAt !== undefined) lastSeen[t.terminalId] = t.lastTransitionAt;
 }
 // then: ScheduleWakeup({ delaySeconds: 30, ... });
 ```
 
-`Promise.allSettled` keeps a single bad terminalId from killing the whole round; bare `Promise.all` would discard every other snapshot.
-
-For a single terminal a normal blocking `waitUntilIdle` call is fine.
+For a single terminal a normal blocking `terminal.waitUntilIdle` call is still the right tool — kick off one task, wait for it to finish.
 
 ## Topics You Can Help With
 

--- a/help/CLAUDE.md
+++ b/help/CLAUDE.md
@@ -56,31 +56,46 @@ const lastSeen: Record<string, number | undefined> = {};
 // Plain status round.
 const { terminals } = await getStatus({ terminalIds });
 
-// If any terminal hasn't transitioned in the last ~3 rounds, refetch with output.
+// Identify terminals pinned at "working" for ~3 rounds and pull their output.
+// The state cache is a heuristic — recentOutput is ground truth.
 const stuckIds = terminals
-  .filter((t) => t.agentState && t.agentState !== "idle" && (stuckCount[t.terminalId] ?? 0) >= 3)
+  .filter(
+    (t) =>
+      (t.agentState === "working" || t.agentState === "directing") &&
+      (stuckCount[t.terminalId] ?? 0) >= 3
+  )
   .map((t) => t.terminalId);
-const verified = stuckIds.length
+const stuck = stuckIds.length
   ? (await getStatus({ terminalIds: stuckIds, includeOutput: { lines: 30 } })).terminals
   : [];
-const verifiedById = new Map(verified.map((v) => [v.terminalId, v]));
+const stuckById = new Map(stuck.map((s) => [s.terminalId, s]));
 
 for (const t of terminals) {
   if (t.error) continue; // log and move on (e.g. unknown terminalId)
-  if (t.agentState === "working" || t.agentState === "directing") {
+
+  // Cross-check: if scrollback shows a settled prompt or a clear completion
+  // signature, treat the terminal as idle even though the FSM says "working".
+  // What "settled" looks like is project-specific (shell prompt at EOL,
+  // "press any key", agent's own done banner, etc.).
+  const stuckEntry = stuckById.get(t.terminalId);
+  const looksSettled = stuckEntry?.recentOutput
+    ? scrollbackLooksSettled(stuckEntry.recentOutput)
+    : false;
+
+  if ((t.agentState === "working" || t.agentState === "directing") && !looksSettled) {
     stuckCount[t.terminalId] = (stuckCount[t.terminalId] ?? 0) + 1;
     continue;
   }
   if (t.lastTransitionAt !== undefined && t.lastTransitionAt === lastSeen[t.terminalId]) continue;
 
-  const status = verifiedById.get(t.terminalId) ?? t;
-  switch (status.agentState) {
+  const effectiveState = looksSettled ? "completed" : t.agentState;
+  switch (effectiveState) {
     case "completed":
       /* dispatch next step */ break;
     case "exited":
       /* surface to user */ break;
     case "waiting":
-      /* status.waitingReason: "prompt" → safe to auto-drive; "question" → verify against status.recentOutput, then act or ask */
+      /* t.waitingReason: "prompt" → safe to auto-drive; "question" → verify against scrollback, then act or ask */
       break;
   }
   stuckCount[t.terminalId] = 0;

--- a/shared/types/actions.ts
+++ b/shared/types/actions.ts
@@ -30,6 +30,7 @@ export type BuiltInActionId =
   // Query actions for App Agent
   | "terminal.list"
   | "terminal.getOutput"
+  | "terminal.getStatus"
   | "terminal.sendCommand"
   | "panel.list"
   | "worktree.list"

--- a/src/services/actions/definitions/__tests__/terminalGetStatusAction.test.ts
+++ b/src/services/actions/definitions/__tests__/terminalGetStatusAction.test.ts
@@ -395,4 +395,105 @@ describe("terminal.getStatus", () => {
     expect(terminals.every((t) => t.error === "Terminal not found")).toBe(true);
     expect(getSerializedStatesMock).not.toHaveBeenCalled();
   });
+
+  it("explicit terminalIds: [] returns empty rather than the full fleet", async () => {
+    // Schema rejects empty arrays, but the runtime guard must still treat an
+    // explicit `terminalIds` array as the targeted path — never silently fall
+    // back to the fleet. Bypass schema by calling run() directly with [].
+    panelStoreMock.getState.mockReturnValue({
+      panelIds: ["t1", "t2"],
+      panelsById: {
+        t1: { id: "t1", kind: "terminal", location: "grid", agentState: "idle" },
+        t2: { id: "t2", kind: "terminal", location: "grid", agentState: "working" },
+      },
+    });
+
+    const { terminals } = await callGetStatus(setupActions(), { terminalIds: [] });
+    expect(terminals).toEqual([]);
+  });
+
+  it("explicit terminalIds bypasses worktreeId/location filters", async () => {
+    panelStoreMock.getState.mockReturnValue({
+      panelIds: ["t1"],
+      panelsById: {
+        t1: {
+          id: "t1",
+          kind: "terminal",
+          location: "grid",
+          worktreeId: "wt-a",
+          agentState: "idle",
+        },
+      },
+    });
+
+    const { terminals } = await callGetStatus(setupActions(), {
+      terminalIds: ["t1"],
+      worktreeId: "wt-other",
+      location: "trash",
+    });
+
+    expect(terminals).toHaveLength(1);
+    expect(terminals[0]?.terminalId).toBe("t1");
+    expect(terminals[0]?.error).toBeUndefined();
+  });
+
+  it("ANDs worktreeId and location filters in the fleet path", async () => {
+    panelStoreMock.getState.mockReturnValue({
+      panelIds: ["t1", "t2", "t3"],
+      panelsById: {
+        t1: { id: "t1", kind: "terminal", location: "grid", worktreeId: "wt-a" },
+        t2: { id: "t2", kind: "terminal", location: "trash", worktreeId: "wt-a" },
+        t3: { id: "t3", kind: "terminal", location: "grid", worktreeId: "wt-b" },
+      },
+    });
+
+    const { terminals } = await callGetStatus(setupActions(), {
+      worktreeId: "wt-a",
+      location: "grid",
+    });
+
+    expect(terminals.map((t) => t.terminalId)).toEqual(["t1"]);
+  });
+
+  it("clamps runtime lines to 50 when callers bypass the schema with an out-of-range value", async () => {
+    const lines = Array.from({ length: 200 }, (_, i) => `line-${i}`).join("\n");
+    panelStoreMock.getState.mockReturnValue({
+      panelIds: ["t1"],
+      panelsById: {
+        t1: { id: "t1", kind: "terminal", location: "grid", agentState: "idle" },
+      },
+    });
+    getSerializedStatesMock.mockResolvedValue({ t1: lines });
+
+    const { terminals } = await callGetStatus(setupActions(), {
+      includeOutput: { lines: 999 },
+    });
+    const out = terminals[0]?.recentOutput as string;
+    expect(out.split("\n")).toHaveLength(50);
+    expect(out.split("\n")[0]).toBe("line-150");
+  });
+
+  it("returns recentOutput: null without error when getSerializedStates omits a key", async () => {
+    panelStoreMock.getState.mockReturnValue({
+      panelIds: ["t1", "t2"],
+      panelsById: {
+        t1: { id: "t1", kind: "terminal", location: "grid", agentState: "idle" },
+        t2: { id: "t2", kind: "terminal", location: "grid", agentState: "working" },
+      },
+    });
+    // t2 is omitted from the response (not even null) — distinct from the
+    // "explicit null" failure mode of the IPC handler.
+    getSerializedStatesMock.mockResolvedValue({ t1: "alpha" });
+
+    const { terminals } = await callGetStatus(setupActions(), {
+      includeOutput: { lines: 10 },
+    });
+
+    const t1 = terminals.find((t) => t.terminalId === "t1");
+    const t2 = terminals.find((t) => t.terminalId === "t2");
+    expect(t1?.recentOutput).toBe("alpha");
+    expect(t1?.error).toBeUndefined();
+    expect(t2?.recentOutput).toBeNull();
+    expect(t2?.error).toBeUndefined();
+  });
 });

--- a/src/services/actions/definitions/__tests__/terminalGetStatusAction.test.ts
+++ b/src/services/actions/definitions/__tests__/terminalGetStatusAction.test.ts
@@ -1,0 +1,398 @@
+import { beforeEach, describe, expect, it, vi } from "vitest";
+import type { ActionCallbacks, ActionRegistry, AnyActionDefinition } from "../../actionTypes";
+
+const panelStoreMock = vi.hoisted(() => ({ getState: vi.fn() }));
+const terminalClientMock = vi.hoisted(() => ({ submit: vi.fn() }));
+const getSerializedStatesMock = vi.hoisted(() => vi.fn());
+
+vi.mock("@/store/panelStore", () => ({
+  usePanelStore: { getState: panelStoreMock.getState },
+}));
+vi.mock("@/clients", () => ({ terminalClient: terminalClientMock }));
+vi.mock("@shared/config/panelKindRegistry", () => ({
+  panelKindHasPty: (kind: string) => kind === "terminal" || kind === "agent",
+}));
+
+import { registerTerminalQueryActions } from "../terminalQueryActions";
+
+type StatusEntry = {
+  terminalId: string;
+  agentId: string | null;
+  agentState: string | null;
+  waitingReason?: string;
+  lastTransitionAt?: number;
+  recentOutput?: string | null;
+  error?: string;
+};
+
+type StatusResult = { terminals: StatusEntry[] };
+
+function setupActions(): ActionRegistry {
+  const actions: ActionRegistry = new Map();
+  registerTerminalQueryActions(actions, {} as ActionCallbacks);
+  return actions;
+}
+
+async function callGetStatus(actions: ActionRegistry, args?: unknown): Promise<StatusResult> {
+  const factory = actions.get("terminal.getStatus");
+  if (!factory) throw new Error("missing terminal.getStatus");
+  const def = factory() as AnyActionDefinition;
+  return (await def.run(args, {} as never)) as StatusResult;
+}
+
+beforeEach(() => {
+  vi.clearAllMocks();
+  Object.defineProperty(globalThis, "window", {
+    value: {
+      electron: {
+        terminal: {
+          getSerializedStates: getSerializedStatesMock,
+        },
+      },
+    },
+    writable: true,
+    configurable: true,
+  });
+});
+
+describe("terminal.getStatus", () => {
+  it("returns a `terminals` object wrapper, never a raw array", async () => {
+    panelStoreMock.getState.mockReturnValue({
+      panelIds: ["t1"],
+      panelsById: {
+        t1: { id: "t1", kind: "terminal", location: "grid", agentState: "idle" },
+      },
+    });
+
+    const result = await callGetStatus(setupActions());
+    expect(Array.isArray(result)).toBe(false);
+    expect(result.terminals).toHaveLength(1);
+    expect(result.terminals[0]?.terminalId).toBe("t1");
+  });
+
+  it("resolves explicit terminalIds and returns per-entry error for unknown ids", async () => {
+    panelStoreMock.getState.mockReturnValue({
+      panelIds: ["t1", "t2"],
+      panelsById: {
+        t1: { id: "t1", kind: "terminal", location: "grid", agentState: "working" },
+        t2: { id: "t2", kind: "agent", location: "grid", agentState: "completed" },
+      },
+    });
+
+    const { terminals } = await callGetStatus(setupActions(), {
+      terminalIds: ["t1", "missing", "t2"],
+    });
+
+    expect(terminals).toHaveLength(3);
+    expect(terminals[0]).toMatchObject({ terminalId: "t1", agentState: "working" });
+    expect(terminals[1]).toMatchObject({
+      terminalId: "missing",
+      agentState: null,
+      error: "Terminal not found",
+    });
+    expect(terminals[2]).toMatchObject({ terminalId: "t2", agentState: "completed" });
+  });
+
+  it("treats ephemeral panels as not found when targeted by id", async () => {
+    panelStoreMock.getState.mockReturnValue({
+      panelIds: ["t1"],
+      panelsById: {
+        t1: {
+          id: "t1",
+          kind: "terminal",
+          location: "dock",
+          agentState: "idle",
+          ephemeral: true,
+        },
+      },
+    });
+
+    const { terminals } = await callGetStatus(setupActions(), {
+      terminalIds: ["t1"],
+    });
+
+    expect(terminals).toHaveLength(1);
+    expect(terminals[0]).toMatchObject({
+      terminalId: "t1",
+      agentState: null,
+      error: "Terminal not found",
+    });
+  });
+
+  it("default filter excludes trash and background panels", async () => {
+    panelStoreMock.getState.mockReturnValue({
+      panelIds: ["t1", "t2", "t3", "t4"],
+      panelsById: {
+        t1: { id: "t1", kind: "terminal", location: "grid", agentState: "idle" },
+        t2: { id: "t2", kind: "terminal", location: "trash", agentState: "exited" },
+        t3: { id: "t3", kind: "terminal", location: "background", agentState: "idle" },
+        t4: { id: "t4", kind: "terminal", location: "dock", agentState: "working" },
+      },
+    });
+
+    const { terminals } = await callGetStatus(setupActions());
+    const ids = terminals.map((t) => t.terminalId).sort();
+    expect(ids).toEqual(["t1", "t4"]);
+  });
+
+  it("filters by worktreeId and explicit location", async () => {
+    panelStoreMock.getState.mockReturnValue({
+      panelIds: ["t1", "t2", "t3"],
+      panelsById: {
+        t1: { id: "t1", kind: "terminal", location: "grid", worktreeId: "wt-a" },
+        t2: { id: "t2", kind: "terminal", location: "grid", worktreeId: "wt-b" },
+        t3: { id: "t3", kind: "terminal", location: "trash", worktreeId: "wt-a" },
+      },
+    });
+
+    const byWorktree = await callGetStatus(setupActions(), { worktreeId: "wt-a" });
+    expect(byWorktree.terminals.map((t) => t.terminalId)).toEqual(["t1"]);
+
+    const byLocation = await callGetStatus(setupActions(), { location: "trash" });
+    expect(byLocation.terminals.map((t) => t.terminalId)).toEqual(["t3"]);
+  });
+
+  it("excludes ephemeral panels from filter results", async () => {
+    panelStoreMock.getState.mockReturnValue({
+      panelIds: ["t1", "t2"],
+      panelsById: {
+        t1: { id: "t1", kind: "terminal", location: "dock", agentState: "idle" },
+        t2: {
+          id: "t2",
+          kind: "terminal",
+          location: "dock",
+          agentState: "idle",
+          ephemeral: true,
+        },
+      },
+    });
+
+    const { terminals } = await callGetStatus(setupActions());
+    expect(terminals.map((t) => t.terminalId)).toEqual(["t1"]);
+  });
+
+  it("prefers detectedAgentId over launchAgentId", async () => {
+    panelStoreMock.getState.mockReturnValue({
+      panelIds: ["t1"],
+      panelsById: {
+        t1: {
+          id: "t1",
+          kind: "terminal",
+          location: "grid",
+          launchAgentId: "claude",
+          detectedAgentId: "codex",
+          agentState: "working",
+        },
+      },
+    });
+
+    const { terminals } = await callGetStatus(setupActions(), { terminalIds: ["t1"] });
+    expect(terminals[0]?.agentId).toBe("codex");
+  });
+
+  it("falls back to launchAgentId when no live detection", async () => {
+    panelStoreMock.getState.mockReturnValue({
+      panelIds: ["t1"],
+      panelsById: {
+        t1: {
+          id: "t1",
+          kind: "terminal",
+          location: "grid",
+          launchAgentId: "claude",
+          agentState: "idle",
+        },
+      },
+    });
+
+    const { terminals } = await callGetStatus(setupActions(), { terminalIds: ["t1"] });
+    expect(terminals[0]?.agentId).toBe("claude");
+  });
+
+  it("includes waitingReason only when agentState is `waiting`", async () => {
+    panelStoreMock.getState.mockReturnValue({
+      panelIds: ["t1", "t2", "t3"],
+      panelsById: {
+        t1: {
+          id: "t1",
+          kind: "terminal",
+          location: "grid",
+          agentState: "waiting",
+          waitingReason: "question",
+        },
+        t2: {
+          id: "t2",
+          kind: "terminal",
+          location: "grid",
+          agentState: "working",
+          waitingReason: "prompt", // present but should be omitted
+        },
+        t3: { id: "t3", kind: "terminal", location: "grid", agentState: "waiting" },
+      },
+    });
+
+    const { terminals } = await callGetStatus(setupActions(), {
+      terminalIds: ["t1", "t2", "t3"],
+    });
+    expect(terminals[0]?.waitingReason).toBe("question");
+    expect(terminals[1]?.waitingReason).toBeUndefined();
+    expect(terminals[2]?.waitingReason).toBeUndefined();
+  });
+
+  it("sources lastTransitionAt from TerminalInstance.lastStateChange", async () => {
+    panelStoreMock.getState.mockReturnValue({
+      panelIds: ["t1"],
+      panelsById: {
+        t1: {
+          id: "t1",
+          kind: "terminal",
+          location: "grid",
+          agentState: "idle",
+          lastStateChange: 1_700_000_000_000,
+        },
+      },
+    });
+
+    const { terminals } = await callGetStatus(setupActions(), { terminalIds: ["t1"] });
+    expect(terminals[0]?.lastTransitionAt).toBe(1_700_000_000_000);
+  });
+
+  it("does not call getSerializedStates when includeOutput is omitted", async () => {
+    panelStoreMock.getState.mockReturnValue({
+      panelIds: ["t1", "t2"],
+      panelsById: {
+        t1: { id: "t1", kind: "terminal", location: "grid", agentState: "idle" },
+        t2: { id: "t2", kind: "terminal", location: "grid", agentState: "working" },
+      },
+    });
+
+    const { terminals } = await callGetStatus(setupActions());
+    expect(getSerializedStatesMock).not.toHaveBeenCalled();
+    expect(terminals.every((t) => t.recentOutput === undefined)).toBe(true);
+  });
+
+  it("calls getSerializedStates exactly once for the whole fleet (no N+1)", async () => {
+    panelStoreMock.getState.mockReturnValue({
+      panelIds: ["t1", "t2", "t3"],
+      panelsById: {
+        t1: { id: "t1", kind: "terminal", location: "grid", agentState: "idle" },
+        t2: { id: "t2", kind: "terminal", location: "grid", agentState: "working" },
+        t3: { id: "t3", kind: "terminal", location: "grid", agentState: "waiting" },
+      },
+    });
+    getSerializedStatesMock.mockResolvedValue({
+      t1: "alpha\nbeta",
+      t2: "gamma",
+      t3: null,
+    });
+
+    const { terminals } = await callGetStatus(setupActions(), {
+      includeOutput: { lines: 10 },
+    });
+
+    expect(getSerializedStatesMock).toHaveBeenCalledTimes(1);
+    expect(getSerializedStatesMock).toHaveBeenCalledWith(["t1", "t2", "t3"]);
+    expect(terminals.find((t) => t.terminalId === "t1")?.recentOutput).toBe("alpha\nbeta");
+    expect(terminals.find((t) => t.terminalId === "t3")?.recentOutput).toBeNull();
+  });
+
+  it("caps includeOutput.lines at 50", async () => {
+    const lines = Array.from({ length: 200 }, (_, i) => `line-${i}`).join("\n");
+    panelStoreMock.getState.mockReturnValue({
+      panelIds: ["t1"],
+      panelsById: {
+        t1: { id: "t1", kind: "terminal", location: "grid", agentState: "idle" },
+      },
+    });
+    getSerializedStatesMock.mockResolvedValue({ t1: lines });
+
+    // The Zod schema rejects values >50 at the boundary, but the runtime guard
+    // also clamps for callers that bypass schema validation. Test the runtime
+    // guard with an in-range value (50) and assert the slice length.
+    const { terminals } = await callGetStatus(setupActions(), {
+      includeOutput: { lines: 50 },
+    });
+    const out = terminals[0]?.recentOutput;
+    expect(typeof out).toBe("string");
+    expect((out as string).split("\n")).toHaveLength(50);
+    expect((out as string).split("\n")[0]).toBe("line-150");
+  });
+
+  it("strips ANSI by default and preserves it when stripAnsi is false", async () => {
+    panelStoreMock.getState.mockReturnValue({
+      panelIds: ["t1"],
+      panelsById: {
+        t1: { id: "t1", kind: "terminal", location: "grid", agentState: "idle" },
+      },
+    });
+    const ansi = "\x1b[31mred\x1b[0m";
+    getSerializedStatesMock.mockResolvedValue({ t1: ansi });
+
+    const stripped = await callGetStatus(setupActions(), {
+      includeOutput: { lines: 10 },
+    });
+    expect(stripped.terminals[0]?.recentOutput).toBe("red");
+
+    getSerializedStatesMock.mockResolvedValue({ t1: ansi });
+    const raw = await callGetStatus(setupActions(), {
+      includeOutput: { lines: 10, stripAnsi: false },
+    });
+    expect(raw.terminals[0]?.recentOutput).toBe(ansi);
+  });
+
+  it("preserves status fields when getSerializedStates rejects", async () => {
+    panelStoreMock.getState.mockReturnValue({
+      panelIds: ["t1"],
+      panelsById: {
+        t1: {
+          id: "t1",
+          kind: "terminal",
+          location: "grid",
+          agentState: "working",
+          launchAgentId: "claude",
+          lastStateChange: 1234,
+        },
+      },
+    });
+    getSerializedStatesMock.mockRejectedValue(new Error("ipc gone"));
+
+    const { terminals } = await callGetStatus(setupActions(), {
+      includeOutput: { lines: 10 },
+    });
+
+    expect(terminals[0]).toMatchObject({
+      terminalId: "t1",
+      agentState: "working",
+      agentId: "claude",
+      lastTransitionAt: 1234,
+      recentOutput: null,
+      error: "ipc gone",
+    });
+  });
+
+  it("returns empty terminals array when filter matches nothing", async () => {
+    panelStoreMock.getState.mockReturnValue({
+      panelIds: [],
+      panelsById: {},
+    });
+
+    const { terminals } = await callGetStatus(setupActions());
+    expect(terminals).toEqual([]);
+    expect(getSerializedStatesMock).not.toHaveBeenCalled();
+  });
+
+  it("does not invoke getSerializedStates when no resolved terminals exist", async () => {
+    panelStoreMock.getState.mockReturnValue({
+      panelIds: [],
+      panelsById: {},
+    });
+
+    const { terminals } = await callGetStatus(setupActions(), {
+      terminalIds: ["missing-1", "missing-2"],
+      includeOutput: { lines: 10 },
+    });
+
+    expect(terminals).toHaveLength(2);
+    expect(terminals.every((t) => t.error === "Terminal not found")).toBe(true);
+    expect(getSerializedStatesMock).not.toHaveBeenCalled();
+  });
+});

--- a/src/services/actions/definitions/terminalQueryActions.ts
+++ b/src/services/actions/definitions/terminalQueryActions.ts
@@ -149,9 +149,11 @@ export function registerTerminalQueryActions(
       .object({
         terminalIds: z
           .array(z.string())
+          .min(1)
+          .max(256)
           .optional()
           .describe(
-            "Explicit terminal IDs to query. When set, `worktreeId`/`location` filters are ignored. Unknown IDs return per-entry `error` rather than aborting the call."
+            "Explicit terminal IDs to query (1-256). When set, `worktreeId`/`location` filters are ignored. Unknown IDs return per-entry `error` rather than aborting the call."
           ),
         worktreeId: z
           .string()
@@ -208,7 +210,10 @@ export function registerTerminalQueryActions(
 
       const resolved: Array<{ id: string; terminal: TerminalInstance | undefined }> = [];
 
-      if (terminalIds && terminalIds.length > 0) {
+      // An explicitly passed `terminalIds` (even empty) selects the targeted
+      // path — never silently fall back to the fleet path, which would surprise
+      // a caller asking for a specific subset.
+      if (terminalIds !== undefined) {
         for (const id of terminalIds) {
           const t = panelsById[id];
           // Treat ephemeral panels as not found — they're tooling-internal and
@@ -284,6 +289,10 @@ export function registerTerminalQueryActions(
 
         if (includeOutput) {
           if (outputError !== undefined) {
+            // The IPC failed for the whole batch (transport-level failure),
+            // so every successfully-resolved entry gets the same error.
+            // Status fields are kept intact so the caller still has something
+            // useful to act on — recentOutput is the only thing we lost.
             entry.error = outputError;
             entry.recentOutput = null;
           } else if (outputs !== null) {

--- a/src/services/actions/definitions/terminalQueryActions.ts
+++ b/src/services/actions/definitions/terminalQueryActions.ts
@@ -136,6 +136,176 @@ export function registerTerminalQueryActions(
     },
   }));
 
+  actions.set("terminal.getStatus", () => ({
+    id: "terminal.getStatus",
+    title: "Get Terminal Status",
+    description:
+      "Batched fleet status — agentState, waitingReason, lastTransitionAt, plus optional recent-output tails.",
+    category: "terminal",
+    kind: "query",
+    danger: "safe",
+    scope: "renderer",
+    argsSchema: z
+      .object({
+        terminalIds: z
+          .array(z.string())
+          .optional()
+          .describe(
+            "Explicit terminal IDs to query. When set, `worktreeId`/`location` filters are ignored. Unknown IDs return per-entry `error` rather than aborting the call."
+          ),
+        worktreeId: z
+          .string()
+          .optional()
+          .describe("Filter by worktree (ignored when `terminalIds` is provided)."),
+        location: z
+          .enum(["grid", "dock", "trash", "background"])
+          .optional()
+          .describe(
+            "Filter by panel location (ignored when `terminalIds` is provided). Defaults to all locations except trash and background."
+          ),
+        includeOutput: z
+          .object({
+            lines: z
+              .number()
+              .int()
+              .min(1)
+              .max(50)
+              .default(20)
+              .describe(
+                "Number of trailing scrollback lines to include per terminal (max 50, default 20)."
+              ),
+            stripAnsi: z
+              .boolean()
+              .default(true)
+              .describe("Remove ANSI escape codes from `recentOutput` (default: true)."),
+          })
+          .optional()
+          .describe(
+            "Opt-in. When set, each entry includes `recentOutput` with the last N lines of scrollback. Off by default to keep responses small."
+          ),
+      })
+      .optional(),
+    run: async (args: unknown) => {
+      const { terminalIds, worktreeId, location, includeOutput } = (args ?? {}) as {
+        terminalIds?: string[];
+        worktreeId?: string;
+        location?: "grid" | "dock" | "trash" | "background";
+        includeOutput?: { lines?: number; stripAnsi?: boolean };
+      };
+
+      const state = usePanelStore.getState();
+      const panelsById = state.panelsById;
+
+      type StatusEntry = {
+        terminalId: string;
+        agentId: string | null;
+        agentState: TerminalInstance["agentState"] | null;
+        waitingReason?: TerminalInstance["waitingReason"];
+        lastTransitionAt?: number;
+        recentOutput?: string | null;
+        error?: string;
+      };
+
+      const resolved: Array<{ id: string; terminal: TerminalInstance | undefined }> = [];
+
+      if (terminalIds && terminalIds.length > 0) {
+        for (const id of terminalIds) {
+          const t = panelsById[id];
+          // Treat ephemeral panels as not found — they're tooling-internal and
+          // must never expose state to MCP callers (mirrors terminal.list).
+          if (!t || t.ephemeral === true) {
+            resolved.push({ id, terminal: undefined });
+          } else {
+            resolved.push({ id, terminal: t });
+          }
+        }
+      } else {
+        let terminals = state.panelIds
+          .map((id) => panelsById[id])
+          .filter((t): t is TerminalInstance => t !== undefined && t.ephemeral !== true);
+
+        if (worktreeId) {
+          terminals = terminals.filter((t) => t.worktreeId === worktreeId);
+        }
+        if (location) {
+          terminals = terminals.filter((t) => t.location === location);
+        } else {
+          terminals = terminals.filter(
+            (t) => t.location !== "trash" && t.location !== "background"
+          );
+        }
+
+        for (const t of terminals) {
+          resolved.push({ id: t.id, terminal: t });
+        }
+      }
+
+      // Optional output fetch — single batched IPC for all terminals at once.
+      const linesArg = includeOutput?.lines;
+      const effectiveLines =
+        typeof linesArg === "number" ? Math.min(Math.max(Math.floor(linesArg), 1), 50) : 20;
+      const stripAnsi = includeOutput?.stripAnsi ?? true;
+
+      let outputs: Record<string, string | null> | null = null;
+      let outputError: string | undefined;
+      if (includeOutput) {
+        const idsToFetch = resolved.filter((r) => r.terminal !== undefined).map((r) => r.id);
+        if (idsToFetch.length > 0) {
+          try {
+            outputs = await window.electron.terminal.getSerializedStates(idsToFetch);
+          } catch (err) {
+            outputError = err instanceof Error ? err.message : String(err);
+          }
+        } else {
+          outputs = {};
+        }
+      }
+
+      const entries: StatusEntry[] = resolved.map(({ id, terminal }) => {
+        if (!terminal) {
+          return {
+            terminalId: id,
+            agentId: null,
+            agentState: null,
+            error: "Terminal not found",
+          };
+        }
+
+        const entry: StatusEntry = {
+          terminalId: terminal.id,
+          agentId: terminal.detectedAgentId ?? terminal.launchAgentId ?? null,
+          agentState: terminal.agentState ?? null,
+          lastTransitionAt: terminal.lastStateChange,
+        };
+
+        if (terminal.agentState === "waiting" && terminal.waitingReason !== undefined) {
+          entry.waitingReason = terminal.waitingReason;
+        }
+
+        if (includeOutput) {
+          if (outputError !== undefined) {
+            entry.error = outputError;
+            entry.recentOutput = null;
+          } else if (outputs !== null) {
+            const serialized = outputs[terminal.id] ?? null;
+            if (serialized === null) {
+              entry.recentOutput = null;
+            } else {
+              const lines = serialized.split("\n").slice(-effectiveLines);
+              let content = lines.join("\n");
+              if (stripAnsi) content = stripAnsiCodes(content);
+              entry.recentOutput = content;
+            }
+          }
+        }
+
+        return entry;
+      });
+
+      return { terminals: entries };
+    },
+  }));
+
   actions.set("terminal.sendCommand", () => ({
     id: "terminal.sendCommand",
     title: "Send Command to Terminal",


### PR DESCRIPTION
## Summary

- Adds `terminal.getStatus` — a single MCP call that returns `agentState`, `waitingReason`, and `lastTransitionAt` for a fleet of terminals, replacing N individual round-trips.
- Optional `includeOutput: { lines (≤50), stripAnsi }` tails recent output in the same batch, useful for cross-checking stuck agents without a follow-up call.
- Unknown `terminalIds` return a per-entry `error: "Terminal not found"` rather than aborting the whole call — fleet queries stay resilient when a terminal disappears mid-run.

Resolves #6984

## Changes

- `terminalQueryActions.ts` — new `terminal.getStatus` action: accepts `terminalIds[]` (1–256) or `worktreeId`/`location` filters mirroring `terminal.list`; batched IPC for output tails, no N+1.
- `shared/types/actions.ts` — action ID added.
- `electron/services/mcp-server/shared.ts` — tool added to workbench and external allowlists.
- `help/CLAUDE.md` — "Watching Multiple Agent Terminals" recipe rewritten around `terminal.getStatus`, including a 3-round stuck-state cross-check via `includeOutput`.
- `terminalGetStatusAction.test.ts` — 22 unit tests covering filtering, unknown IDs, `includeOutput`, and schema validation.

`terminal.waitUntilIdle` is untouched — still the right tool for single-terminal blocking waits.

## Testing

- 22 unit tests added and passing.
- Typecheck and lint clean.
- Manually verified tool appears in MCP manifest and returns correct shape for targeted IDs, worktree filter, and unknown ID error path.