### PR TITLE
fix(mcp): pin help-session transports to their minting WebContents

### DIFF
--- a/electron/services/HelpSessionService.ts
+++ b/electron/services/HelpSessionService.ts
@@ -116,6 +116,20 @@ export class HelpSessionService {
   }
 
   /**
+   * Looks up the renderer WebContents id pinned to a help-session bearer at
+   * provision time. The MCP server uses this at handshake to pin each
+   * transport session to the window that minted it, so a tool call from the
+   * assistant in window A can never be routed to window B's renderer (#7002).
+   * Returns null for unknown or revoked tokens.
+   */
+  getWebContentsIdForToken(token: string): number | null {
+    if (!token) return null;
+    const record = this.sessionsByToken.get(token);
+    if (!record || record.revoked) return null;
+    return record.projectViewWebContentsId;
+  }
+
+  /**
    * Provisions the per-project session directory for the Daintree Assistant
    * under userData/help-sessions/<projectPathHash>/. The dir is reused across
    * launches so Claude Code's per-folder workspace-trust prompt only fires
@@ -403,6 +417,9 @@ export class HelpSessionService {
     }
     const { mcpServerService } = await import("./McpServerService.js");
     mcpServerService.setHelpTokenValidator((token) => this.validateToken(token));
+    mcpServerService.setHelpSessionWebContentsResolver((token) =>
+      this.getWebContentsIdForToken(token)
+    );
     if (!mcpServerService.isEnabled()) {
       // setEnabled() will only call start() internally if it has its own
       // `registry` already set — which it doesn't on cold boot if the

--- a/electron/services/McpServerService.ts
+++ b/electron/services/McpServerService.ts
@@ -13,7 +13,12 @@ import { createRendererBridge } from "./mcp-server/rendererBridge.js";
 import { handleWaitUntilIdle } from "./mcp-server/waitUntilIdle.js";
 import { cleanupResourceSubscriptions } from "./mcp-server/sessionServer.js";
 import { HttpLifecycle } from "./mcp-server/httpLifecycle.js";
-import type { PendingRequest, DispatchEnvelope, HelpTokenValidator } from "./mcp-server/shared.js";
+import type {
+  PendingRequest,
+  DispatchEnvelope,
+  HelpTokenValidator,
+  HelpSessionWebContentsResolver,
+} from "./mcp-server/shared.js";
 import type { ActionManifestEntry } from "../../shared/types/actions.js";
 
 // Re-export types for backward compatibility with existing importers.
@@ -57,6 +62,9 @@ export class McpServerService {
       requestManifest: () => this.bridge.requestManifest(),
       dispatchAction: (actionId, args, confirmed) =>
         this.bridge.dispatchAction(actionId, args, confirmed),
+      requestManifestForWebContents: (id) => this.bridge.requestManifestForWebContents(id),
+      dispatchActionForWebContents: (id, actionId, args, confirmed) =>
+        this.bridge.dispatchActionForWebContents(id, actionId, args, confirmed),
       handleWaitUntilIdle: (rawArgs, signal) => handleWaitUntilIdle(rawArgs, signal),
       getCachedManifest: () => this.bridge.getCachedManifest(),
       clearCachedManifest: () => this.bridge.clearCache(),
@@ -98,6 +106,10 @@ export class McpServerService {
 
   setHelpTokenValidator(validator: HelpTokenValidator | null): void {
     this.httpLifecycle.setHelpTokenValidator(validator);
+  }
+
+  setHelpSessionWebContentsResolver(resolver: HelpSessionWebContentsResolver | null): void {
+    this.httpLifecycle.setHelpSessionWebContentsResolver(resolver);
   }
 
   private emitStatusChange(): void {

--- a/electron/services/__tests__/HelpSessionService.test.ts
+++ b/electron/services/__tests__/HelpSessionService.test.ts
@@ -25,6 +25,7 @@ const {
     start: vi.fn().mockResolvedValue(undefined),
     setEnabled: vi.fn().mockResolvedValue(undefined),
     setHelpTokenValidator: vi.fn(),
+    setHelpSessionWebContentsResolver: vi.fn(),
     getRuntimeState: vi.fn<
       () => import("../../../shared/types/ipc/mcpServer.js").McpRuntimeSnapshot
     >(() => ({
@@ -114,6 +115,7 @@ describe("HelpSessionService", () => {
     mockMcpServerService.start.mockClear();
     mockMcpServerService.setEnabled.mockClear();
     mockMcpServerService.setHelpTokenValidator.mockClear();
+    mockMcpServerService.setHelpSessionWebContentsResolver.mockClear();
     mockProbeMcpServer.mockReset();
     mockProbeMcpServer.mockResolvedValue(undefined);
     mockProbeMcpSseServer.mockReset();
@@ -243,6 +245,38 @@ describe("HelpSessionService", () => {
 
     await service.revokeSession(result.sessionId);
     expect(service.validateToken(result.token)).toBe(false);
+  });
+
+  it("getWebContentsIdForToken returns the pin set at provision time and null for unknown / revoked tokens (#7002)", async () => {
+    const result = await service.provisionSession({
+      ...provisionInput(),
+      projectViewWebContentsId: 4242,
+    });
+    if (!result) throw new Error("expected result");
+
+    expect(service.getWebContentsIdForToken(result.token)).toBe(4242);
+    expect(service.getWebContentsIdForToken("not-a-real-token")).toBeNull();
+    expect(service.getWebContentsIdForToken("")).toBeNull();
+
+    await service.revokeSession(result.sessionId);
+    expect(service.getWebContentsIdForToken(result.token)).toBeNull();
+  });
+
+  it("getWebContentsIdForToken returns the per-session pin when two sessions are minted from different views", async () => {
+    const a = await service.provisionSession({
+      ...provisionInput(),
+      projectPath: "/tmp/proj-a",
+      projectViewWebContentsId: 100,
+    });
+    const b = await service.provisionSession({
+      ...provisionInput(),
+      projectPath: "/tmp/proj-b",
+      projectViewWebContentsId: 200,
+    });
+    if (!a || !b) throw new Error("expected provisions");
+
+    expect(service.getWebContentsIdForToken(a.token)).toBe(100);
+    expect(service.getWebContentsIdForToken(b.token)).toBe(200);
   });
 
   it("preserves the per-project session dir on revoke so Claude's workspace-trust acceptance carries across launches", async () => {

--- a/electron/services/__tests__/McpServerService.test.ts
+++ b/electron/services/__tests__/McpServerService.test.ts
@@ -1765,6 +1765,61 @@ describe("McpServerService", () => {
     );
   });
 
+  it("pinned sessions with confirm-danger tools still trigger elicitation — manifest must not be cache-bypassed away (#7002)", async () => {
+    // Pinned sessions deliberately skip `cachedManifest`. `lookupManifestEntry`
+    // used to call `getCachedManifest()` *after* `await requestManifest()`,
+    // which would always be null for pinned sessions and silently drop the
+    // confirm-elicitation. This test guards that regression.
+    const dispatchMock = vi.fn((payload: DispatchRequest): ActionDispatchResult => {
+      if (!payload.confirmed) {
+        return { ok: false, error: { code: "CONFIRMATION_REQUIRED", message: "Need confirm" } };
+      }
+      return { ok: true, result: { deleted: true } };
+    });
+    const onElicit = vi.fn(async (): Promise<ElicitResult> => ({ action: "accept", content: {} }));
+
+    const winA = createMockWindow({
+      getManifest: () => [
+        createManifestEntry({
+          id: "worktree.delete" as ActionId,
+          title: "Delete Worktree",
+          description: "Delete a worktree",
+          danger: "confirm",
+        }),
+      ],
+      dispatchAction: dispatchMock,
+    });
+
+    await service.start(winA.window);
+    service.setHelpTokenValidator((token) => (token === "help-A" ? "system" : false));
+    service.setHelpSessionWebContentsResolver((token) =>
+      token === "help-A" ? winA.webContents.id : null
+    );
+
+    const { client, transport } = await connectClient(
+      service.currentPort!,
+      { Authorization: "Bearer help-A" },
+      {
+        capabilities: { elicitation: { form: {} } },
+        onElicit,
+      }
+    );
+    transports.push(transport);
+
+    const result = getTextResult(
+      await client.callTool({
+        name: "worktree.delete",
+        arguments: { worktreeId: "wt-123" },
+      })
+    );
+
+    expect(onElicit).toHaveBeenCalledTimes(1);
+    expect(result.isError).not.toBe(true);
+    expect(dispatchMock).toHaveBeenCalledWith(
+      expect.objectContaining({ actionId: "worktree.delete", confirmed: true })
+    );
+  });
+
   it("external (api-key) sessions keep most-recently-focused-view fallback even when help routing is wired (#7002)", async () => {
     storeState.mcpServer.apiKey = "external-secret";
     const winA = createMockWindow({

--- a/electron/services/__tests__/McpServerService.test.ts
+++ b/electron/services/__tests__/McpServerService.test.ts
@@ -60,9 +60,14 @@ const electronMocks = vi.hoisted(() => {
   }
 
   const ipcMain = new IpcMainMock();
+  // Lookup table that backs the mocked `webContents.fromId(id)` — populated by
+  // `createMockWindow` so per-session pinned dispatch (#7002) can resolve a
+  // specific WebContents at MCP tool-call time, the same way Electron does.
+  const webContentsById = new Map<number, unknown>();
 
   return {
     ipcMain,
+    webContentsById,
   };
 });
 
@@ -107,6 +112,9 @@ vi.mock("node:os", async (importOriginal) => {
 
 vi.mock("electron", () => ({
   ipcMain: electronMocks.ipcMain,
+  webContents: {
+    fromId: (id: number) => electronMocks.webContentsById.get(id),
+  },
   BrowserWindow: class BrowserWindow {},
   app: { getVersion: () => "0.0.0-test" },
 }));
@@ -301,11 +309,16 @@ function createMockWindow(options?: {
     size: 1,
   };
 
+  // Register the project-view WebContents in the shared lookup so per-session
+  // pinned dispatch (#7002) can resolve it via `webContents.fromId()`.
+  electronMocks.webContentsById.set(projectViewWcId, webContents);
+
   return {
     window: registry as never,
     webContents,
     hostShellWebContents,
     projectViewManager,
+    windowContext,
   };
 }
 
@@ -496,6 +509,7 @@ describe("McpServerService", () => {
     storeMocks.set.mockClear();
     paneTokenTiers.clear();
     electronMocks.ipcMain.removeAllListeners();
+    electronMocks.webContentsById.clear();
     electronMocks.ipcMain.handle.mockClear();
     electronMocks.ipcMain.removeHandler.mockClear();
     transports.length = 0;
@@ -1639,6 +1653,157 @@ describe("McpServerService", () => {
       Authorization: "Bearer rotating-token",
     });
     expect(after.status).toBe(401);
+  });
+
+  it("pins each help-session bearer to its own renderer WebContents — tool calls never cross windows (#7002)", async () => {
+    // Two windows, each with a distinct project-view WebContents. Two
+    // help-session bearers — one minted from each. Without per-session
+    // pinning, both sessions would dispatch into whatever the shared
+    // `getActiveProjectWebContents()` returns first; with the fix, each
+    // session routes to the WebContents that minted it.
+    const winA = createMockWindow({
+      getManifest: () => [
+        createManifestEntry({
+          id: "actions.list",
+          title: "List Actions",
+          description: "Read the action registry",
+          kind: "query",
+        }),
+      ],
+      dispatchAction: () => ({ ok: true, result: "from-window-A" }),
+    });
+    const winB = createMockWindow({
+      getManifest: () => [
+        createManifestEntry({
+          id: "actions.list",
+          title: "List Actions",
+          description: "Read the action registry",
+          kind: "query",
+        }),
+      ],
+      dispatchAction: () => ({ ok: true, result: "from-window-B" }),
+    });
+
+    const combinedRegistry = {
+      all: () => [winA.windowContext, winB.windowContext],
+      getPrimary: () => winA.windowContext,
+      getByWindowId: () => winA.windowContext,
+      getByWebContentsId: () => winA.windowContext,
+      size: 2,
+    } as never;
+
+    await service.start(combinedRegistry);
+
+    const tokenToWcId = new Map<string, number>([
+      ["help-A", winA.webContents.id],
+      ["help-B", winB.webContents.id],
+    ]);
+    service.setHelpTokenValidator((token) => (tokenToWcId.has(token) ? "action" : false));
+    service.setHelpSessionWebContentsResolver((token) => tokenToWcId.get(token) ?? null);
+
+    const a = await connectClient(service.currentPort!, { Authorization: "Bearer help-A" });
+    transports.push(a.transport);
+    const b = await connectClient(service.currentPort!, { Authorization: "Bearer help-B" });
+    transports.push(b.transport);
+
+    const resA = getTextResult(await a.client.callTool({ name: "actions.list", arguments: {} }));
+    const resB = getTextResult(await b.client.callTool({ name: "actions.list", arguments: {} }));
+
+    expect(resA.content[0].text).toBe('"from-window-A"');
+    expect(resB.content[0].text).toBe('"from-window-B"');
+
+    // Both windows' WebContents.send must have been invoked — and only for
+    // the dispatch belonging to that window. (Each window also receives one
+    // `mcp:get-manifest-request` per session — that is fine because pinned
+    // sessions explicitly bypass the shared manifest cache.)
+    const sendsToA = winA.webContents.send.mock.calls.filter(
+      ([channel]) => channel === "mcp:dispatch-action-request"
+    );
+    const sendsToB = winB.webContents.send.mock.calls.filter(
+      ([channel]) => channel === "mcp:dispatch-action-request"
+    );
+    expect(sendsToA).toHaveLength(1);
+    expect(sendsToB).toHaveLength(1);
+  });
+
+  it("fails closed when the pinned WebContents has been destroyed (#7002 — never silently re-routes)", async () => {
+    const winA = createMockWindow({
+      dispatchAction: () => ({ ok: true, result: "from-A" }),
+    });
+    const winB = createMockWindow({
+      dispatchAction: () => ({ ok: true, result: "from-B" }),
+    });
+
+    const combinedRegistry = {
+      all: () => [winA.windowContext, winB.windowContext],
+      getPrimary: () => winA.windowContext,
+      getByWindowId: () => winA.windowContext,
+      getByWebContentsId: () => winA.windowContext,
+      size: 2,
+    } as never;
+
+    await service.start(combinedRegistry);
+
+    service.setHelpTokenValidator((token) => (token === "help-A" ? "action" : false));
+    service.setHelpSessionWebContentsResolver((token) =>
+      token === "help-A" ? winA.webContents.id : null
+    );
+
+    const a = await connectClient(service.currentPort!, { Authorization: "Bearer help-A" });
+    transports.push(a.transport);
+
+    // Window A's view goes away — pinned session must NOT silently fall
+    // through to window B (the bug behind #7002).
+    electronMocks.webContentsById.delete(winA.webContents.id);
+
+    const result = getTextResult(await a.client.callTool({ name: "actions.list", arguments: {} }));
+    expect(result.isError).toBe(true);
+    expect(result.content[0].text).toMatch(/no longer available/);
+    expect(winB.webContents.send).not.toHaveBeenCalledWith(
+      "mcp:dispatch-action-request",
+      expect.anything()
+    );
+  });
+
+  it("external (api-key) sessions keep most-recently-focused-view fallback even when help routing is wired (#7002)", async () => {
+    storeState.mcpServer.apiKey = "external-secret";
+    const winA = createMockWindow({
+      dispatchAction: () => ({ ok: true, result: "from-A" }),
+    });
+    const winB = createMockWindow({
+      dispatchAction: () => ({ ok: true, result: "from-B" }),
+    });
+
+    const combinedRegistry = {
+      all: () => [winA.windowContext, winB.windowContext],
+      getPrimary: () => winA.windowContext,
+      getByWindowId: () => winA.windowContext,
+      getByWebContentsId: () => winA.windowContext,
+      size: 2,
+    } as never;
+
+    await service.start(combinedRegistry);
+
+    // Help routing is configured but the external bearer doesn't match it.
+    service.setHelpTokenValidator((token) => (token === "help-A" ? "action" : false));
+    service.setHelpSessionWebContentsResolver((token) =>
+      token === "help-A" ? winA.webContents.id : null
+    );
+
+    const ext = await connectClient(service.currentPort!, {
+      Authorization: "Bearer external-secret",
+    });
+    transports.push(ext.transport);
+
+    const result = getTextResult(
+      await ext.client.callTool({ name: "actions.list", arguments: {} })
+    );
+
+    // Falls through to getActiveProjectWebContents which returns winA (first
+    // in registry). The point of the assertion is that the external session
+    // is NOT failing closed and IS using the fallback path, regardless of
+    // which window happens to be first.
+    expect(result.content[0].text).toBe('"from-A"');
   });
 
   it("fails fast when the renderer bridge is unavailable", async () => {

--- a/electron/services/mcp-server/__tests__/rendererBridge.test.ts
+++ b/electron/services/mcp-server/__tests__/rendererBridge.test.ts
@@ -1,0 +1,196 @@
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+
+const { mockIpcMain, mockWebContentsRegistry } = vi.hoisted(() => {
+  class IpcMainMock {
+    private listeners = new Map<string, Set<(...args: unknown[]) => void>>();
+    on(event: string, listener: (...args: unknown[]) => void): this {
+      const set = this.listeners.get(event) ?? new Set();
+      set.add(listener);
+      this.listeners.set(event, set);
+      return this;
+    }
+    removeListener(event: string, listener: (...args: unknown[]) => void): this {
+      this.listeners.get(event)?.delete(listener);
+      return this;
+    }
+    emit(event: string, ...args: unknown[]): boolean {
+      const set = this.listeners.get(event);
+      if (!set) return false;
+      for (const fn of set) fn(...args);
+      return set.size > 0;
+    }
+    removeAllListeners(): this {
+      this.listeners.clear();
+      return this;
+    }
+  }
+  return {
+    mockIpcMain: new IpcMainMock(),
+    mockWebContentsRegistry: new Map<number, unknown>(),
+  };
+});
+
+vi.mock("electron", () => ({
+  ipcMain: mockIpcMain,
+  webContents: {
+    fromId: (id: number) => mockWebContentsRegistry.get(id),
+  },
+}));
+
+vi.mock("../../../window/windowRef.js", () => ({
+  getProjectViewManager: () => null,
+}));
+
+import { createRendererBridge } from "../rendererBridge.js";
+import type { PendingRequest, DispatchEnvelope } from "../shared.js";
+import type { ActionManifestEntry } from "../../../../shared/types/actions.js";
+
+interface FakeWebContents {
+  id: number;
+  isDestroyed: ReturnType<typeof vi.fn>;
+  send: ReturnType<typeof vi.fn>;
+  once: ReturnType<typeof vi.fn>;
+  removeListener: ReturnType<typeof vi.fn>;
+  triggerDestroyed: () => void;
+}
+
+function makeWebContents(
+  id: number,
+  options?: { onSend?: (channel: string, payload: any) => void }
+): FakeWebContents {
+  const destroyedListeners = new Set<() => void>();
+  const wc: FakeWebContents = {
+    id,
+    isDestroyed: vi.fn(() => false),
+    send: vi.fn((channel: string, payload: unknown) => {
+      options?.onSend?.(channel, payload);
+    }),
+    once: vi.fn((event: string, listener: () => void) => {
+      if (event === "destroyed") destroyedListeners.add(listener);
+    }),
+    removeListener: vi.fn((event: string, listener: () => void) => {
+      if (event === "destroyed") destroyedListeners.delete(listener);
+    }),
+    triggerDestroyed: () => {
+      const listeners = Array.from(destroyedListeners);
+      destroyedListeners.clear();
+      for (const l of listeners) l();
+    },
+  };
+  return wc;
+}
+
+describe("rendererBridge — per-session pinned dispatch (#7002)", () => {
+  let pendingManifests: Map<string, PendingRequest<ActionManifestEntry[]>>;
+  let pendingDispatches: Map<string, PendingRequest<DispatchEnvelope>>;
+  let bridge: ReturnType<typeof createRendererBridge>;
+
+  beforeEach(() => {
+    mockIpcMain.removeAllListeners();
+    mockWebContentsRegistry.clear();
+    pendingManifests = new Map();
+    pendingDispatches = new Map();
+    bridge = createRendererBridge(pendingManifests, pendingDispatches, () => null);
+    bridge.setupListeners([]);
+  });
+
+  afterEach(() => {
+    vi.useRealTimers();
+  });
+
+  it("requestManifestForWebContents routes to the pinned WebContents and never writes the shared cache", async () => {
+    const wcA = makeWebContents(101);
+    const wcB = makeWebContents(202);
+    mockWebContentsRegistry.set(101, wcA);
+    mockWebContentsRegistry.set(202, wcB);
+
+    expect(bridge.getCachedManifest()).toBeNull();
+
+    // Hook send to reply with a manifest tagged by id, so we can assert routing.
+    wcA.send.mockImplementation((channel: string, payload: { requestId: string }) => {
+      if (channel !== "mcp:get-manifest-request") return;
+      queueMicrotask(() => {
+        mockIpcMain.emit(
+          "mcp:get-manifest-response",
+          { sender: { id: 101 } },
+          {
+            requestId: payload.requestId,
+            manifest: [{ id: "from-A" }],
+          }
+        );
+      });
+    });
+
+    const manifest = await bridge.requestManifestForWebContents(101);
+    expect(manifest).toEqual([{ id: "from-A" }]);
+    // Pinned helpers must NOT touch the shared cache — caching window A's
+    // manifest and serving it to a session pinned to window B would re-leak.
+    expect(bridge.getCachedManifest()).toBeNull();
+    expect(wcA.send).toHaveBeenCalledTimes(1);
+    expect(wcB.send).not.toHaveBeenCalled();
+  });
+
+  it("dispatchActionForWebContents routes to the pinned WebContents — never the other window", async () => {
+    const wcA = makeWebContents(301);
+    const wcB = makeWebContents(302);
+    mockWebContentsRegistry.set(301, wcA);
+    mockWebContentsRegistry.set(302, wcB);
+
+    wcA.send.mockImplementation((channel: string, payload: { requestId: string }) => {
+      if (channel !== "mcp:dispatch-action-request") return;
+      queueMicrotask(() => {
+        mockIpcMain.emit(
+          "mcp:dispatch-action-response",
+          { sender: { id: 301 } },
+          {
+            requestId: payload.requestId,
+            result: { ok: true, result: "from-A" },
+          }
+        );
+      });
+    });
+
+    const envelope = await bridge.dispatchActionForWebContents(301, "actions.list", {}, false);
+    expect(envelope.result).toEqual({ ok: true, result: "from-A" });
+    expect(wcA.send).toHaveBeenCalledTimes(1);
+    expect(wcB.send).not.toHaveBeenCalled();
+  });
+
+  it("fails closed when the pinned view has been destroyed (#7002 — never silently re-routes)", async () => {
+    // No entry for id=999 → webContents.fromId returns undefined.
+    await expect(bridge.requestManifestForWebContents(999)).rejects.toThrow(
+      /MCP pinned view 999 no longer available/
+    );
+    await expect(
+      bridge.dispatchActionForWebContents(999, "actions.list", {}, false)
+    ).rejects.toThrow(/MCP pinned view 999 no longer available/);
+  });
+
+  it("fails closed when the pinned view exists but reports isDestroyed", async () => {
+    const wc = makeWebContents(404);
+    wc.isDestroyed.mockReturnValue(true);
+    mockWebContentsRegistry.set(404, wc);
+
+    await expect(bridge.requestManifestForWebContents(404)).rejects.toThrow(
+      /MCP pinned view 404 no longer available/
+    );
+    await expect(
+      bridge.dispatchActionForWebContents(404, "actions.list", {}, false)
+    ).rejects.toThrow(/MCP pinned view 404 no longer available/);
+    // Must not have attempted to send to a destroyed view.
+    expect(wc.send).not.toHaveBeenCalled();
+  });
+
+  it("rejects pending pinned dispatch when the pinned view emits 'destroyed' mid-flight", async () => {
+    const wc = makeWebContents(505);
+    mockWebContentsRegistry.set(505, wc);
+
+    // Send accepts but never replies — we'll trigger destroyed manually.
+    const promise = bridge.dispatchActionForWebContents(505, "actions.list", {}, false);
+    // Yield so the dispatch helper has registered the destroyed listener.
+    await Promise.resolve();
+    wc.triggerDestroyed();
+
+    await expect(promise).rejects.toThrow(/MCP renderer bridge destroyed/);
+  });
+});

--- a/electron/services/mcp-server/__tests__/sessionStore.test.ts
+++ b/electron/services/mcp-server/__tests__/sessionStore.test.ts
@@ -1,0 +1,113 @@
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+import { SessionStore } from "../sessionStore.js";
+import type { McpSseSession, McpHttpSession } from "../shared.js";
+
+function fakeSseSession(): McpSseSession {
+  return {
+    transport: {
+      close: vi.fn().mockResolvedValue(undefined),
+    } as unknown as McpSseSession["transport"],
+    idleTimer: setTimeout(() => {}, 1_000_000),
+  };
+}
+
+function fakeHttpSession(): McpHttpSession {
+  return {
+    transport: {
+      close: vi.fn().mockResolvedValue(undefined),
+    } as unknown as McpHttpSession["transport"],
+    server: {} as McpHttpSession["server"],
+    idleTimer: setTimeout(() => {}, 1_000_000),
+  };
+}
+
+describe("SessionStore.sessionWebContentsMap (#7002)", () => {
+  let store: SessionStore;
+  let resourceCleanups: string[];
+
+  beforeEach(() => {
+    vi.useFakeTimers();
+    resourceCleanups = [];
+    store = new SessionStore((sessionId) => {
+      resourceCleanups.push(sessionId);
+    });
+  });
+
+  afterEach(() => {
+    vi.useRealTimers();
+  });
+
+  it("drain() clears the pinned map alongside other session maps", () => {
+    store.sessions.set("a", fakeSseSession());
+    store.httpSessions.set("b", fakeHttpSession());
+    store.sessionTierMap.set("a", "action");
+    store.sessionTierMap.set("b", "action");
+    store.sessionWebContentsMap.set("a", 100);
+    store.sessionWebContentsMap.set("b", 200);
+
+    store.drain();
+
+    expect(store.sessions.size).toBe(0);
+    expect(store.httpSessions.size).toBe(0);
+    expect(store.sessionTierMap.size).toBe(0);
+    expect(store.sessionWebContentsMap.size).toBe(0);
+  });
+
+  it("SSE idle-timer expiry deletes the session's pin so an evicted session does not leak the WebContents id", () => {
+    const session = fakeSseSession();
+    const sessionId = "sse-1";
+    store.sessions.set(sessionId, session);
+    store.sessionTierMap.set(sessionId, "action");
+    store.sessionWebContentsMap.set(sessionId, 42);
+
+    // Replace with a fresh idle timer that we can fast-forward.
+    clearTimeout(session.idleTimer);
+    session.idleTimer = store.createIdleTimer(sessionId);
+
+    vi.runAllTimers();
+
+    expect(store.sessions.has(sessionId)).toBe(false);
+    expect(store.sessionTierMap.has(sessionId)).toBe(false);
+    expect(store.sessionWebContentsMap.has(sessionId)).toBe(false);
+    expect(resourceCleanups).toContain(sessionId);
+  });
+
+  it("Streamable-HTTP idle-timer expiry deletes the session's pin", () => {
+    const session = fakeHttpSession();
+    const sessionId = "http-1";
+    store.httpSessions.set(sessionId, session);
+    store.sessionTierMap.set(sessionId, "action");
+    store.sessionWebContentsMap.set(sessionId, 99);
+
+    clearTimeout(session.idleTimer);
+    session.idleTimer = store.createHttpIdleTimer(sessionId);
+
+    vi.runAllTimers();
+
+    expect(store.httpSessions.has(sessionId)).toBe(false);
+    expect(store.sessionTierMap.has(sessionId)).toBe(false);
+    expect(store.sessionWebContentsMap.has(sessionId)).toBe(false);
+    expect(resourceCleanups).toContain(sessionId);
+  });
+
+  it("idle-timer for a session that was already removed is a no-op (does not stomp another session's pin)", () => {
+    // Set up two sessions; one gets removed before its timer fires.
+    store.sessions.set("alive", fakeSseSession());
+    store.sessionWebContentsMap.set("alive", 1);
+    store.sessionWebContentsMap.set("evicted", 2);
+
+    const evictedSession = fakeSseSession();
+    store.sessions.set("evicted", evictedSession);
+    clearTimeout(evictedSession.idleTimer);
+    evictedSession.idleTimer = store.createIdleTimer("evicted");
+
+    // Caller removed it explicitly (e.g. transport.onclose).
+    store.sessions.delete("evicted");
+    store.sessionWebContentsMap.delete("evicted");
+
+    vi.runAllTimers();
+
+    // The other session's pin must remain untouched.
+    expect(store.sessionWebContentsMap.get("alive")).toBe(1);
+  });
+});

--- a/electron/services/mcp-server/httpLifecycle.ts
+++ b/electron/services/mcp-server/httpLifecycle.ts
@@ -8,7 +8,7 @@ import type { WindowRegistry } from "../../window/WindowRegistry.js";
 import { store } from "../../store.js";
 import { formatErrorMessage } from "../../../shared/utils/errorMessage.js";
 import { summarizeMcpArgs } from "../../../shared/utils/mcpArgsSummary.js";
-import type { HelpTokenValidator } from "./shared.js";
+import type { HelpTokenValidator, HelpSessionWebContentsResolver } from "./shared.js";
 import { isAuthorized, resolveTokenTier } from "./tierAuth.js";
 import { createSessionServer, cleanupResourceSubscriptions } from "./sessionServer.js";
 import type { SessionStore } from "./sessionStore.js";
@@ -29,6 +29,18 @@ export interface HttpLifecycleDeps {
   auditService: AuditService;
   requestManifest: () => Promise<import("../../../shared/types/actions.js").ActionManifestEntry[]>;
   dispatchAction: (
+    actionId: string,
+    args: unknown,
+    confirmed?: boolean
+  ) => Promise<import("./shared.js").DispatchEnvelope>;
+  // Pinned variants used for help-session bearers — route to the renderer
+  // WebContents that minted the bearer at provision time (#7002). Optional
+  // for backward-compat with test fixtures that don't wire help routing.
+  requestManifestForWebContents?: (
+    id: number
+  ) => Promise<import("../../../shared/types/actions.js").ActionManifestEntry[]>;
+  dispatchActionForWebContents?: (
+    id: number,
     actionId: string,
     args: unknown,
     confirmed?: boolean
@@ -64,6 +76,7 @@ export class HttpLifecycle {
   private startPromise: Promise<void> | null = null;
   private stopPromise: Promise<void> | null = null;
   private helpTokenValidator: HelpTokenValidator | null = null;
+  private helpSessionWebContentsResolver: HelpSessionWebContentsResolver | null = null;
   private lastError: string | null = null;
   private intentionalStop = false;
   private restartAttempts = 0;
@@ -110,6 +123,24 @@ export class HttpLifecycle {
 
   setHelpTokenValidator(validator: HelpTokenValidator | null): void {
     this.helpTokenValidator = validator;
+  }
+
+  setHelpSessionWebContentsResolver(resolver: HelpSessionWebContentsResolver | null): void {
+    this.helpSessionWebContentsResolver = resolver;
+  }
+
+  /**
+   * Parses a Bearer header and asks the help-session resolver for the
+   * pinned WebContents id. Returns null for non-help bearers (api-key /
+   * pane tokens) so external sessions keep the existing focused-window
+   * fallback in `buildSessionServerDeps`.
+   */
+  private resolvePinnedWebContentsId(authHeader: string): number | null {
+    if (!this.helpSessionWebContentsResolver) return null;
+    const match = /^Bearer\s+(.+)$/.exec(authHeader);
+    const token = match?.[1]?.trim();
+    if (!token) return null;
+    return this.helpSessionWebContentsResolver(token);
   }
 
   private getConfig() {
@@ -449,7 +480,12 @@ export class HttpLifecycle {
       const tier = resolveTokenTier(authHeader, this.apiKey, this.helpTokenValidator);
       this.deps.sessionStore.sessionTierMap.set(sessionId, tier);
 
-      const deps = this.buildSessionServerDeps();
+      const pinnedWebContentsId = this.resolvePinnedWebContentsId(authHeader);
+      if (pinnedWebContentsId !== null) {
+        this.deps.sessionStore.sessionWebContentsMap.set(sessionId, pinnedWebContentsId);
+      }
+
+      const deps = this.buildSessionServerDeps(sessionId);
       const server = createSessionServer(sessionId, deps);
 
       const idleTimer = this.deps.sessionStore.createIdleTimer(sessionId);
@@ -461,6 +497,7 @@ export class HttpLifecycle {
           this.deps.sessionStore.sessions.delete(sessionId);
         }
         this.deps.sessionStore.sessionTierMap.delete(sessionId);
+        this.deps.sessionStore.sessionWebContentsMap.delete(sessionId);
         cleanupResourceSubscriptions(sessionId, this.deps.sessionStore);
       };
 
@@ -522,7 +559,12 @@ export class HttpLifecycle {
     const tier = resolveTokenTier(authHeader, this.apiKey, this.helpTokenValidator);
     this.deps.sessionStore.sessionTierMap.set(newSessionId, tier);
 
-    const deps = this.buildSessionServerDeps();
+    const pinnedWebContentsId = this.resolvePinnedWebContentsId(authHeader);
+    if (pinnedWebContentsId !== null) {
+      this.deps.sessionStore.sessionWebContentsMap.set(newSessionId, pinnedWebContentsId);
+    }
+
+    const deps = this.buildSessionServerDeps(newSessionId);
     const server = createSessionServer(newSessionId, deps);
     const transport = new StreamableHTTPServerTransport({
       sessionIdGenerator: () => newSessionId,
@@ -545,6 +587,7 @@ export class HttpLifecycle {
         this.deps.sessionStore.httpSessions.delete(id);
       }
       this.deps.sessionStore.sessionTierMap.delete(id);
+      this.deps.sessionStore.sessionWebContentsMap.delete(id);
       cleanupResourceSubscriptions(id, this.deps.sessionStore);
     };
 
@@ -561,9 +604,11 @@ export class HttpLifecycle {
           this.deps.sessionStore.httpSessions.delete(id);
         }
         this.deps.sessionStore.sessionTierMap.delete(id);
+        this.deps.sessionStore.sessionWebContentsMap.delete(id);
         cleanupResourceSubscriptions(id, this.deps.sessionStore);
       } else {
         this.deps.sessionStore.sessionTierMap.delete(newSessionId);
+        this.deps.sessionStore.sessionWebContentsMap.delete(newSessionId);
         cleanupResourceSubscriptions(newSessionId, this.deps.sessionStore);
       }
       await transport.close().catch(() => {});
@@ -574,11 +619,55 @@ export class HttpLifecycle {
     }
   }
 
-  private buildSessionServerDeps(): import("./sessionServer.js").SessionServerDeps {
+  /**
+   * Builds per-session dispatch deps. When the session was pinned to a
+   * renderer WebContents at handshake (help-session bearers, #7002), routes
+   * through the pinned `*ForWebContents` helpers and forces a cache-free
+   * manifest lookup so window A's manifest can never be served to window B.
+   * Sessions without a pin (api-key / pane tokens) keep the existing shared
+   * dispatch + cached-manifest path.
+   */
+  private buildSessionServerDeps(
+    sessionId: string
+  ): import("./sessionServer.js").SessionServerDeps {
+    const pinnedDispatch = this.deps.dispatchActionForWebContents;
+    const pinnedManifest = this.deps.requestManifestForWebContents;
+
+    const requestManifest: import("./sessionServer.js").SessionServerDeps["requestManifest"] =
+      () => {
+        const id = this.deps.sessionStore.sessionWebContentsMap.get(sessionId);
+        if (id !== undefined && pinnedManifest) {
+          return pinnedManifest(id);
+        }
+        return this.deps.requestManifest();
+      };
+
+    const dispatchAction: import("./sessionServer.js").SessionServerDeps["dispatchAction"] = (
+      actionId,
+      args,
+      confirmed
+    ) => {
+      const id = this.deps.sessionStore.sessionWebContentsMap.get(sessionId);
+      if (id !== undefined && pinnedDispatch) {
+        return pinnedDispatch(id, actionId, args, confirmed);
+      }
+      return this.deps.dispatchAction(actionId, args, confirmed);
+    };
+
+    const getCachedManifest: import("./sessionServer.js").SessionServerDeps["getCachedManifest"] =
+      () => {
+        // Pinned sessions never read the shared manifest cache — see
+        // `requestManifestForWebContents` doc in rendererBridge.ts.
+        if (this.deps.sessionStore.sessionWebContentsMap.has(sessionId)) {
+          return null;
+        }
+        return this.deps.getCachedManifest();
+      };
+
     return {
       sessionStore: this.deps.sessionStore,
-      requestManifest: this.deps.requestManifest,
-      dispatchAction: this.deps.dispatchAction,
+      requestManifest,
+      dispatchAction,
       handleWaitUntilIdle: this.deps.handleWaitUntilIdle,
       appendAuditRecord: (input) => {
         this.deps.auditService.appendRecord({
@@ -586,7 +675,7 @@ export class HttpLifecycle {
           argsSummary: summarizeMcpArgs(input.args),
         });
       },
-      getCachedManifest: this.deps.getCachedManifest,
+      getCachedManifest,
       getFullToolSurface: () => this.getConfig().fullToolSurface === true,
     };
   }

--- a/electron/services/mcp-server/httpLifecycle.ts
+++ b/electron/services/mcp-server/httpLifecycle.ts
@@ -579,8 +579,10 @@ export class HttpLifecycle {
     });
 
     transport.onclose = () => {
-      const id = transport.sessionId;
-      if (id === undefined) return;
+      // Fall back to `newSessionId` when the transport closes before
+      // `onsessioninitialized` fires — otherwise the entries inserted under
+      // `newSessionId` (tier + pin) leak. Mirrors the catch-block path.
+      const id = transport.sessionId ?? newSessionId;
       const session = this.deps.sessionStore.httpSessions.get(id);
       if (session) {
         clearTimeout(session.idleTimer);

--- a/electron/services/mcp-server/rendererBridge.ts
+++ b/electron/services/mcp-server/rendererBridge.ts
@@ -1,4 +1,4 @@
-import { ipcMain } from "electron";
+import { ipcMain, webContents as electronWebContents } from "electron";
 import { randomUUID } from "node:crypto";
 import type { WindowRegistry } from "../../window/WindowRegistry.js";
 import { getProjectViewManager } from "../../window/windowRef.js";
@@ -33,15 +33,32 @@ export function createRendererBridge(
     throw new Error("MCP renderer bridge unavailable");
   }
 
+  /**
+   * Resolves a renderer WebContents by id, throwing if the view is missing or
+   * destroyed. Used by per-session pinned dispatch (#7002) so an MCP tool
+   * call from window A's assistant fails closed rather than silently routing
+   * to window B when window A's view has been torn down.
+   */
+  function getPinnedWebContents(id: number): Electron.WebContents {
+    const wc = electronWebContents.fromId(id);
+    if (!wc || wc.isDestroyed()) {
+      throw new Error(`MCP pinned view ${id} no longer available`);
+    }
+    return wc;
+  }
+
   function normalizeError(err: unknown, fallback: string): Error {
     return err instanceof Error ? err : new Error(fallback);
   }
 
-  function requestManifest(): Promise<ActionManifestEntry[]> {
+  function sendManifestRequest(
+    resolveWebContents: () => Electron.WebContents,
+    onResolved: (manifest: ActionManifestEntry[]) => void
+  ): Promise<ActionManifestEntry[]> {
     return new Promise((resolve, reject) => {
       let webContents: Electron.WebContents;
       try {
-        webContents = getActiveProjectWebContents();
+        webContents = resolveWebContents();
       } catch (err) {
         reject(normalizeError(err, "MCP renderer bridge unavailable"));
         return;
@@ -73,7 +90,10 @@ export function createRendererBridge(
       };
 
       pendingManifests.set(requestId, {
-        resolve,
+        resolve: (manifest) => {
+          onResolved(manifest);
+          resolve(manifest);
+        },
         reject,
         timer,
         webContentsId,
@@ -91,15 +111,16 @@ export function createRendererBridge(
     });
   }
 
-  function dispatchAction(
+  function sendDispatchRequest(
+    resolveWebContents: () => Electron.WebContents,
     actionId: string,
     args: unknown,
-    confirmed = false
+    confirmed: boolean
   ): Promise<DispatchEnvelope> {
     return new Promise((resolve, reject) => {
       let webContents: Electron.WebContents;
       try {
-        webContents = getActiveProjectWebContents();
+        webContents = resolveWebContents();
       } catch (err) {
         reject(normalizeError(err, "MCP renderer bridge unavailable"));
         return;
@@ -154,6 +175,54 @@ export function createRendererBridge(
     });
   }
 
+  function requestManifest(): Promise<ActionManifestEntry[]> {
+    return sendManifestRequest(
+      () => getActiveProjectWebContents(),
+      (manifest) => {
+        cachedManifest = manifest;
+      }
+    );
+  }
+
+  function dispatchAction(
+    actionId: string,
+    args: unknown,
+    confirmed = false
+  ): Promise<DispatchEnvelope> {
+    return sendDispatchRequest(() => getActiveProjectWebContents(), actionId, args, confirmed);
+  }
+
+  /**
+   * Manifest fetch pinned to a specific renderer WebContents (per-session
+   * routing for #7002). Bypasses `cachedManifest` because that cache is
+   * shared across all callers — caching window A's manifest and serving it
+   * to a session pinned to window B would re-introduce the cross-window
+   * leak this routing is meant to prevent.
+   */
+  function requestManifestForWebContents(id: number): Promise<ActionManifestEntry[]> {
+    return sendManifestRequest(
+      () => getPinnedWebContents(id),
+      () => {
+        // Intentionally do not write the shared cachedManifest.
+      }
+    );
+  }
+
+  /**
+   * Action dispatch pinned to a specific renderer WebContents (#7002).
+   * Throws fail-closed when the pinned view is destroyed so the assistant
+   * sees an explicit error rather than silently re-routing to the focused
+   * window.
+   */
+  function dispatchActionForWebContents(
+    id: number,
+    actionId: string,
+    args: unknown,
+    confirmed = false
+  ): Promise<DispatchEnvelope> {
+    return sendDispatchRequest(() => getPinnedWebContents(id), actionId, args, confirmed);
+  }
+
   const manifestHandler = (
     event: Electron.IpcMainEvent,
     payload: { requestId: string; manifest: unknown }
@@ -173,7 +242,10 @@ export function createRendererBridge(
     const manifest = Array.isArray(payload.manifest)
       ? (payload.manifest as ActionManifestEntry[])
       : [];
-    cachedManifest = manifest;
+    // The cache write happens inside the resolve wrapper attached at request
+    // time — non-pinned helpers populate `cachedManifest`, pinned helpers
+    // (#7002) deliberately do not, so window A's manifest can never be
+    // served to a session pinned to window B.
     pending.resolve(manifest);
   };
 
@@ -217,6 +289,8 @@ export function createRendererBridge(
     setupListeners,
     requestManifest,
     dispatchAction,
+    requestManifestForWebContents,
+    dispatchActionForWebContents,
     getCachedManifest: () => cachedManifest,
     clearCache: () => {
       cachedManifest = null;

--- a/electron/services/mcp-server/sessionServer.ts
+++ b/electron/services/mcp-server/sessionServer.ts
@@ -723,16 +723,18 @@ async function lookupManifestEntry(
   getCachedManifest: () => import("../../../shared/types/actions.js").ActionManifestEntry[] | null,
   requestManifest: () => Promise<import("../../../shared/types/actions.js").ActionManifestEntry[]>
 ): Promise<import("../../../shared/types/actions.js").ActionManifestEntry | undefined> {
-  let cached = getCachedManifest();
-  if (!cached) {
+  let manifest = getCachedManifest();
+  if (!manifest) {
     try {
-      await requestManifest();
-      cached = getCachedManifest();
+      // Use the value returned directly — pinned sessions (#7002) deliberately
+      // skip the shared `cachedManifest` so a re-read here would always return
+      // null and silently drop confirmation elicitation + structuredContent.
+      manifest = await requestManifest();
     } catch {
       return undefined;
     }
   }
-  return cached?.find((e) => e.id === actionId);
+  return manifest.find((e) => e.id === actionId);
 }
 
 async function runElicitationConfirmation(

--- a/electron/services/mcp-server/sessionStore.ts
+++ b/electron/services/mcp-server/sessionStore.ts
@@ -5,6 +5,10 @@ export class SessionStore {
   readonly sessions = new Map<string, McpSseSession>();
   readonly httpSessions = new Map<string, McpHttpSession>();
   readonly sessionTierMap = new Map<string, McpTier>();
+  // sessionId → renderer WebContents id pinned at handshake. Only populated
+  // for help-session bearers; api-key / pane-token sessions stay absent and
+  // fall through to the focused-window dispatch path. See #7002.
+  readonly sessionWebContentsMap = new Map<string, number>();
   readonly resourceSubscriptions = new Map<string, Map<string, () => void>>();
 
   private readonly cleanupResourceSubscriptionsFn: (sessionId: string) => void;
@@ -19,6 +23,7 @@ export class SessionStore {
       if (!session) return;
       this.sessions.delete(sessionId);
       this.sessionTierMap.delete(sessionId);
+      this.sessionWebContentsMap.delete(sessionId);
       this.cleanupResourceSubscriptionsFn(sessionId);
       session.transport.close().catch(() => {
         // ignore close errors during idle timeout cleanup
@@ -41,6 +46,7 @@ export class SessionStore {
       if (!session) return;
       this.httpSessions.delete(sessionId);
       this.sessionTierMap.delete(sessionId);
+      this.sessionWebContentsMap.delete(sessionId);
       this.cleanupResourceSubscriptionsFn(sessionId);
       session.transport.close().catch(() => {
         // ignore close errors during idle timeout cleanup
@@ -86,6 +92,7 @@ export class SessionStore {
     }
     this.httpSessions.clear();
     this.sessionTierMap.clear();
+    this.sessionWebContentsMap.clear();
 
     for (const bucket of this.resourceSubscriptions.values()) {
       for (const unsub of bucket.values()) {

--- a/electron/services/mcp-server/shared.ts
+++ b/electron/services/mcp-server/shared.ts
@@ -11,6 +11,15 @@ import type { AgentState, WaitingReason } from "../../../shared/types/agent.js";
 
 export type McpAuthClass = "external" | HelpAssistantTier;
 export type HelpTokenValidator = (token: string) => HelpAssistantTier | false;
+/**
+ * Resolver used at MCP transport handshake to pin a help-session bearer to
+ * the renderer WebContents that minted it. Returning a non-null id causes
+ * `httpLifecycle` to record the session in `sessionWebContentsMap` and route
+ * all of that session's tool calls through the pinned view rather than the
+ * "first live view" fallback. Returns null for non-help bearers (api-key /
+ * pane tokens), which keep the existing focused-window semantics.
+ */
+export type HelpSessionWebContentsResolver = (token: string) => number | null;
 export type { HelpAssistantTier };
 
 export const MCP_SERVER_KEY = "daintree";

--- a/electron/window/globalServicesInit.ts
+++ b/electron/window/globalServicesInit.ts
@@ -555,6 +555,9 @@ export async function initGlobalServices(
           mcpServerService.setHelpTokenValidator((token) =>
             helpSessionService.validateToken(token)
           );
+          mcpServerService.setHelpSessionWebContentsResolver((token) =>
+            helpSessionService.getWebContentsIdForToken(token)
+          );
           await mcpServerService.start(registryRef);
         } catch (err) {
           console.error("[MAIN] MCP server failed to start:", err);


### PR DESCRIPTION
## Summary

- The MCP server was routing tool calls to whichever window had focus rather than the window that minted the session bearer — with two or more windows open, assistant A could silently see project B's worktrees, terminals, and git state.
- Each transport session is now pinned to the `WebContents` that created its bearer at handshake time. A per-session dispatch closure uses `webContents.fromId()` at call time and fails closed if that view is destroyed, so there's no silent fallback to a random active window.
- A follow-up caught during review: `lookupManifestEntry` was re-reading the shared manifest cache after `requestManifest()` returned — broken for pinned sessions where the cache is `null` by design. Fixed to use the direct return value instead.

Resolves #7002

## Changes

- `HelpSessionService` — adds `getWebContentsIdForToken` and wires `ensureMcpServerReady` to the resolver.
- `McpServerService` — adds `setHelpSessionWebContentsResolver` and bridge helpers in `HttpLifecycleDeps`.
- `mcp-server/httpLifecycle.ts` — pins `webContentsId` onto each session at SSE / streamable-HTTP handshake; external api-key sessions keep the focused-window fallback explicitly.
- `mcp-server/rendererBridge.ts` — per-session dispatch closures; `getActiveProjectWebContents` retained for external sessions only.
- `mcp-server/sessionServer.ts` — `lookupManifestEntry` uses the direct `requestManifest()` result.
- `mcp-server/sessionStore.ts` / `shared.ts` — session-level `webContentsId` field.
- `globalServicesInit.ts` — deferred resolver wiring.

## Testing

New unit tests across four files: `rendererBridge.test.ts` (new), `sessionStore.test.ts` (new), `HelpSessionService.test.ts` (extended), `McpServerService.test.ts` (extended). Tests cover pinned dispatch, fail-closed on destroyed views, external session fallback, and the manifest direct-return path.