### PR TITLE
perf(pty): skip per-frame visible-cell snapshot for plain terminals

### DIFF
--- a/electron/services/pty/TerminalProcess.ts
+++ b/electron/services/pty/TerminalProcess.ts
@@ -1405,7 +1405,9 @@ export class TerminalProcess {
       }
 
       terminal.lastOutputTime = Date.now();
-      const beforeContentSnapshot = this.getAgentOutputContentSnapshot();
+      const beforeContentSnapshot = this.isAgentLive
+        ? this.getAgentOutputContentSnapshot()
+        : undefined;
 
       if (this.activityMonitor) {
         this.activityMonitor.onData(data);

--- a/electron/services/pty/__tests__/TerminalProcess.lifecycle.test.ts
+++ b/electron/services/pty/__tests__/TerminalProcess.lifecycle.test.ts
@@ -759,6 +759,69 @@ describe("TerminalProcess — observer-driven exit handlers", () => {
   });
 });
 
+describe("TerminalProcess — plain-terminal snapshot gate (#7004)", () => {
+  it("does not capture a visible-cell snapshot on PTY data for plain terminals", async () => {
+    vi.useFakeTimers();
+    vi.setSystemTime(1000);
+    const pty = createControllablePty();
+    const terminal = createTerminal(pty, { kind: "terminal" }, undefined, "t-plain-no-snapshot");
+
+    try {
+      const getVisibleActivitySnapshot = vi.spyOn(terminal, "getVisibleActivitySnapshot");
+
+      await emitDataAndFlush(pty, "build watcher: 12 files compiled\n");
+      await emitDataAndFlush(pty, "[hmr] update applied\n");
+
+      expect(getVisibleActivitySnapshot).not.toHaveBeenCalled();
+    } finally {
+      terminal.dispose();
+      vi.useRealTimers();
+    }
+  });
+
+  it("does not transition agent state on the warm-up tick after plain→agent-live promotion", async () => {
+    vi.useFakeTimers();
+    vi.setSystemTime(1000);
+    const pty = createControllablePty();
+    const handleActivityState = vi.fn();
+    const terminal = createTerminal(
+      pty,
+      { kind: "terminal" },
+      {
+        agentStateService: {
+          handleActivityState,
+          updateAgentState: () => {},
+          emitAgentKilled: () => {},
+          emitAgentCompleted: () => {},
+        } as unknown as TerminalProcessDeps["agentStateService"],
+      },
+      "t-promotion-warmup"
+    );
+
+    try {
+      terminal.stopActivityMonitor();
+
+      // Promote a plain terminal to agent-live (mirrors TerminalAgentDetection
+      // setting detectedAgentId mid-session). agentState seeds to "idle" on
+      // detection, which is one of the states noteAgentOutputActivity acts on.
+      const info = terminal.getInfo();
+      info.detectedAgentId = "claude";
+      info.agentState = "idle";
+
+      // First live tick — beforeSnapshot is undefined (plain terminal skipped
+      // capture) AND agentOutputContentSnapshot is undefined (never set while
+      // plain). hadFallbackBaseline is false → observeDelta({changedChars: 0})
+      // → handleActivityState must NOT fire.
+      await expect(emitDataAndFlush(pty, "claude > thinking…\n")).resolves.not.toThrow();
+
+      expect(handleActivityState).not.toHaveBeenCalled();
+    } finally {
+      terminal.dispose();
+      vi.useRealTimers();
+    }
+  });
+});
+
 describe("TerminalProcess — getPublicState lifecycle derivation", () => {
   it("reflects hasPty=false after dispose() even without prior kill", () => {
     const pty = createControllablePty();

--- a/electron/services/pty/__tests__/TerminalProcess.lifecycle.test.ts
+++ b/electron/services/pty/__tests__/TerminalProcess.lifecycle.test.ts
@@ -808,13 +808,39 @@ describe("TerminalProcess — plain-terminal snapshot gate (#7004)", () => {
       info.detectedAgentId = "claude";
       info.agentState = "idle";
 
-      // First live tick — beforeSnapshot is undefined (plain terminal skipped
-      // capture) AND agentOutputContentSnapshot is undefined (never set while
-      // plain). hadFallbackBaseline is false → observeDelta({changedChars: 0})
-      // → handleActivityState must NOT fire.
+      // First live tick — isAgentLive is now true so beforeContentSnapshot IS
+      // captured, but agentOutputContentSnapshot is still undefined (never set
+      // while plain). hadFallbackBaseline is false at L1382, so the warm-up
+      // path fires observeDelta({changedChars: 0}) and returns without
+      // promoting the agent to "busy".
       await expect(emitDataAndFlush(pty, "claude > thinking…\n")).resolves.not.toThrow();
 
       expect(handleActivityState).not.toHaveBeenCalled();
+    } finally {
+      terminal.dispose();
+      vi.useRealTimers();
+    }
+  });
+
+  it("still captures a visible-cell snapshot on PTY data for active launch-agent terminals", async () => {
+    vi.useFakeTimers();
+    vi.setSystemTime(1000);
+    const pty = createControllablePty();
+    const terminal = createTerminal(
+      pty,
+      { kind: "terminal", launchAgentId: "claude" },
+      undefined,
+      "t-launch-agent-still-scans"
+    );
+
+    try {
+      terminal.stopActivityMonitor();
+      terminal.getInfo().agentState = "idle";
+      const getVisibleActivitySnapshot = vi.spyOn(terminal, "getVisibleActivitySnapshot");
+
+      await emitDataAndFlush(pty, "claude > working…\n");
+
+      expect(getVisibleActivitySnapshot).toHaveBeenCalled();
     } finally {
       terminal.dispose();
       vi.useRealTimers();


### PR DESCRIPTION
## Summary

- Adds a one-line ternary gate in `TerminalProcess.setupPtyHandlers` so `getAgentOutputContentSnapshot()` is only called when `this.isAgentLive` — plain terminals skip the `cols × rows` buffer scan entirely on every `onData` tick
- The consumer (`noteAgentOutputActivity`) already short-circuits at its top with `if (!this.isAgentLive) return`, and handles `undefined beforeSnapshot` via its existing fallback, so no downstream changes needed
- Plain-to-agent-live promotion is safe: `hadFallbackBaseline` is `false` on first tick, which triggers the existing one-tick warm-up before any busy-transition fires

Resolves #7004

## Changes

- `electron/services/pty/TerminalProcess.ts`: replace unconditional `getAgentOutputContentSnapshot()` call with `this.isAgentLive ? this.getAgentOutputContentSnapshot() : undefined`
- `electron/__tests__/TerminalProcess.lifecycle.test.ts`: three new regression tests — plain-terminal snapshot skip, promotion warm-up no-busy-transition, and inverse-direction guard (active `launchAgentId` still scans)

## Testing

24 lifecycle tests pass; full PTY suite (951 tests) passes clean. `npm run check` passes with no new warnings — lint ratchet down 6.