### PR TITLE
chore(pty): polish SustainedChangeTracker allocation and hash clarity

### DIFF
--- a/electron/services/pty/SustainedChangeTracker.ts
+++ b/electron/services/pty/SustainedChangeTracker.ts
@@ -97,7 +97,7 @@ export class SustainedChangeTracker {
 
   reset(): void {
     this.lastChangedAt = undefined;
-    this.samples = [];
+    this.samples.length = 0;
   }
 
   private resetIfQuiet(now: number): void {
@@ -142,6 +142,8 @@ export class SustainedChangeTracker {
   }
 }
 
+const HASH_UNIT_SEPARATOR = 10; // LF byte — delimiter between string units in the FNV-1a hash stream
+
 export function hashStrings(values: readonly string[]): number {
   let hash = 0x811c9dc5;
   for (const value of values) {
@@ -149,7 +151,7 @@ export function hashStrings(values: readonly string[]): number {
       hash ^= value.charCodeAt(i);
       hash = Math.imul(hash, 0x01000193);
     }
-    hash ^= 10;
+    hash ^= HASH_UNIT_SEPARATOR;
     hash = Math.imul(hash, 0x01000193);
   }
   return hash >>> 0;
@@ -232,14 +234,12 @@ function isSuffixOf(needle: readonly string[], haystack: readonly string[]): boo
 }
 
 function normalizeTextUnits(text: string): string[] {
-  return collapseRepeatedUnits(
-    Array.from(text)
-      .filter((char) => !/\s/u.test(char))
-      .map((char) => ({
-        key: char,
-        collapsible: isCollapsibleFillText(char),
-      }))
-  );
+  const units: NormalizedVisibleUnit[] = [];
+  for (const char of text) {
+    if (/\s/u.test(char)) continue;
+    units.push({ key: char, collapsible: isCollapsibleFillText(char) });
+  }
+  return collapseRepeatedUnits(units);
 }
 
 function normalizeCellUnits(rows: readonly (readonly VisibleContentCell[])[]): string[] {


### PR DESCRIPTION
## Summary
- Collapsed `normalizeTextUnits` from a three-array `Array.from().filter().map()` chain into a single-pass `for` loop — this runs on the 50ms polling cadence for every active terminal, so intermediate allocations add up.
- Replaced `this.samples = []` with `this.samples.length = 0` in `reset()` to reuse the backing array store, avoiding hidden-class transitions on quiet-gap detection resets.
- Extracted the magic `10` in `hashStrings` to a named `HASH_UNIT_SEPARATOR` constant with a comment documenting it as the LF byte code — makes the FNV-1a mixer readable alongside its existing named magic constants.

Resolves #7014

## Changes
- `electron/services/pty/SustainedChangeTracker.ts` — three targeted cleanups

## Testing
- Existing vitest suite at `electron/services/pty/__tests__/SustainedChangeTracker.test.ts` covers the behaviors touched (hash stability, sample reset, text normalization), so no regressions expected.