### PR TITLE
chore(pty): snapshot subsystem hygiene

### DIFF
--- a/electron/services/pty/__tests__/terminalSessionPersistence.test.ts
+++ b/electron/services/pty/__tests__/terminalSessionPersistence.test.ts
@@ -225,6 +225,38 @@ describe("terminalSessionPersistence", () => {
       expect(fs.existsSync(path.join(sessionDir, "term-4.restore"))).toBe(true);
     });
 
+    it("sweeps stale orphaned .restore.*.tmp files past the grace period", async () => {
+      const tmpName = "term-9.restore.1700000000000-abc123.tmp";
+      const sixMinutesMs = 6 * 60 * 1000;
+      await createFile(tmpName, "x".repeat(50), sixMinutesMs);
+      // Unrelated .tmp must not be touched even when stale
+      await createFile("unrelated.tmp", "leave me alone", sixMinutesMs);
+
+      const result = await evictSessionFiles({
+        ttlMs: 30 * 24 * 60 * 60 * 1000,
+        maxBytes: 1024 * 1024,
+      });
+
+      expect(result.deleted).toBe(1);
+      expect(result.bytesFreed).toBe(50);
+      expect(fs.existsSync(path.join(sessionDir, tmpName))).toBe(false);
+      expect(fs.existsSync(path.join(sessionDir, "unrelated.tmp"))).toBe(true);
+    });
+
+    it("preserves recent .restore.*.tmp files within the grace period", async () => {
+      const tmpName = "term-10.restore.1700000000000-def456.tmp";
+      // Within the 5-minute grace window — write may still be in progress
+      await createFile(tmpName, "in-flight write", 60_000);
+
+      const result = await evictSessionFiles({
+        ttlMs: 30 * 24 * 60 * 60 * 1000,
+        maxBytes: 1024 * 1024,
+      });
+
+      expect(result.deleted).toBe(0);
+      expect(fs.existsSync(path.join(sessionDir, tmpName))).toBe(true);
+    });
+
     it("deletes orphan files whose IDs are not in knownIds", async () => {
       await createFile("known-term.restore", "keep me");
       await createFile("orphan-term.restore", "delete me");

--- a/electron/services/pty/terminalSerialization.ts
+++ b/electron/services/pty/terminalSerialization.ts
@@ -61,7 +61,7 @@ export function serializeForPersistence(
         : "";
 
     if (beforePart && afterPart) return beforePart + "\r\n" + afterPart;
-    return beforePart || afterPart || addon.serialize();
+    return beforePart || afterPart || null;
   } catch {
     return addon.serialize();
   }

--- a/electron/services/pty/terminalSessionPersistence.ts
+++ b/electron/services/pty/terminalSessionPersistence.ts
@@ -29,6 +29,10 @@ export const SESSION_EVICTION_TTL_MS = 30 * 24 * 60 * 60 * 1000; // 30 days
 export const SESSION_EVICTION_MAX_BYTES = 100 * 1024 * 1024; // 100 MB
 const EVICTION_TTL_BUFFER_MS = 30_000; // 30s clock-skew safety buffer
 const STAT_CHUNK_SIZE = 10;
+// Grace period before sweeping orphaned atomic-write `.tmp` files. The atomic
+// write retry budget is 10s; 5min gives generous headroom while still reclaiming
+// crash artifacts on the next eviction sweep.
+const TMP_ORPHAN_TTL_MS = 5 * 60 * 1000;
 
 export function getSessionDir(): string | null {
   const userData = process.env.DAINTREE_USER_DATA;
@@ -189,11 +193,11 @@ export function readAndDeleteHibernatedMarker(terminalId: string): boolean {
   const markerPath = getHibernatedMarkerPath(terminalId);
   if (!markerPath) return false;
   try {
-    if (!existsSync(markerPath)) return false;
     unlinkSync(markerPath);
     return true;
-  } catch {
-    return false;
+  } catch (e) {
+    if ((e as NodeJS.ErrnoException).code === "ENOENT") return false;
+    throw e;
   }
 }
 
@@ -251,8 +255,13 @@ export async function evictSessionFiles(opts: {
   knownIds?: Set<string>;
 }): Promise<{ deleted: number; bytesFreed: number }> {
   const files = await scanSessionFiles();
+  const now = Date.now();
+  let deleted = 0;
+  let bytesFreed = 0;
 
-  // Clean up orphaned .hibernated markers that have no matching .restore file
+  // Clean up orphaned .hibernated markers and stale `.tmp` files left by
+  // crashed atomic writes. Both run before the .restore eviction passes so
+  // their sweep is opportunistic even when no .restore files exist.
   const dir = getSessionDir();
   if (dir) {
     try {
@@ -264,6 +273,29 @@ export async function evictSessionFiles(opts: {
           if (!restoreIds.has(id)) {
             await unlink(path.join(dir, entry)).catch(() => {});
           }
+          continue;
+        }
+        if (entry.includes(".restore.") && entry.endsWith(".tmp")) {
+          const tmpPath = path.join(dir, entry);
+          let size: number;
+          let mtimeMs: number;
+          try {
+            const s = await stat(tmpPath);
+            size = s.size;
+            mtimeMs = s.mtimeMs;
+          } catch {
+            continue;
+          }
+          if (now - mtimeMs < TMP_ORPHAN_TTL_MS) continue;
+          try {
+            await unlink(tmpPath);
+            deleted++;
+            bytesFreed += size;
+          } catch (e: unknown) {
+            if ((e as NodeJS.ErrnoException).code !== "ENOENT") {
+              console.warn(`[sessionEviction] Failed to delete ${tmpPath}:`, e);
+            }
+          }
         }
       }
     } catch {
@@ -271,12 +303,9 @@ export async function evictSessionFiles(opts: {
     }
   }
 
-  if (files.length === 0) return { deleted: 0, bytesFreed: 0 };
+  if (files.length === 0) return { deleted, bytesFreed };
 
-  const now = Date.now();
   const ttlCutoff = opts.ttlMs + EVICTION_TTL_BUFFER_MS;
-  let deleted = 0;
-  let bytesFreed = 0;
   const survivors: SessionFileInfo[] = [];
 
   // Pass 1: TTL + orphan eviction


### PR DESCRIPTION
## Summary

Three small fixes to the snapshot subsystem.

- `serializeForPersistence` returns `null` when both banner slices are empty instead of making a redundant `addon.serialize()` call — lets the `??` fallback in `SessionSnapshotter.dispose` work as intended
- `evictSessionFiles` now sweeps orphaned `.tmp` files older than a 5-minute grace period in the existing `readdir` loop, counting them toward the returned `{ deleted, bytesFreed }` stats
- `readAndDeleteHibernatedMarker` replaces the `existsSync` + `unlinkSync` two-step with a single try/catch on `unlinkSync`, swallowing `ENOENT` and rethrowing anything else

Resolves #7017

## Changes

- `electron/services/pty/terminalSerialization.ts` — return `null` on empty-banner path
- `electron/services/pty/terminalSessionPersistence.ts` — `.tmp` sweep in eviction loop; try/catch in hibernated-marker cleanup
- `electron/services/pty/__tests__/terminalSessionPersistence.test.ts` — 2 new tests: stale `.tmp` deleted + counted in stats; recent `.tmp` preserved

## Testing

Two new vitest tests cover the `.tmp` sweep (stale orphan deleted + stats; recent file preserved + filter scope). Full test suite passes (55 tests). Typecheck, lint, and build all clean.