### PR TITLE
fix(pty): three small teardown fixes

### DIFF
--- a/electron/services/pty/ProcessTreeKiller.ts
+++ b/electron/services/pty/ProcessTreeKiller.ts
@@ -65,8 +65,14 @@ export class ProcessTreeKiller {
     for (const pid of descendants) {
       try {
         process.kill(pid, "SIGTERM");
-      } catch {
-        // ESRCH: process already exited
+      } catch (err) {
+        const code = (err as NodeJS.ErrnoException).code;
+        // ESRCH: process already exited — silent. Anything else (e.g. EPERM
+        // on an elevated subprocess) means the survivor stays alive and the
+        // operator needs to know.
+        if (code !== "ESRCH") {
+          console.warn(`[ProcessTreeKiller] SIGTERM pid=${pid}: ${(err as Error).message}`);
+        }
       }
     }
 
@@ -107,8 +113,11 @@ export class ProcessTreeKiller {
     for (const pid of allPids) {
       try {
         process.kill(pid, "SIGKILL");
-      } catch {
-        // ESRCH: process already exited
+      } catch (err) {
+        const code = (err as NodeJS.ErrnoException).code;
+        if (code !== "ESRCH") {
+          console.warn(`[ProcessTreeKiller] SIGKILL pid=${pid}: ${(err as Error).message}`);
+        }
       }
     }
   }

--- a/electron/services/pty/TerminalGracefulShutdown.ts
+++ b/electron/services/pty/TerminalGracefulShutdown.ts
@@ -68,10 +68,22 @@ export async function gracefulShutdown(host: TerminalGracefulShutdownHost): Prom
   let resolved = false;
 
   return new Promise<string | null>((resolve) => {
+    // Pre-declared so finish() can dispose them centrally (forward reference).
+    // No-op sentinel keeps disposal safe even on synchronous early-exit paths
+    // before assignment. node-pty's IDisposable scan is idempotent, so the
+    // existing branch-local dispose calls remain harmless double-disposes.
+    let origOnData: { dispose(): void } = { dispose() {} };
+    let origOnExit: { dispose(): void } = { dispose() {} };
+
     const finish = (sessionId: string | null) => {
       if (resolved) return;
       resolved = true;
       clearTimeout(timer);
+
+      // Dispose listeners before kill() so a synchronous onExit during teardown
+      // can't re-enter this path. Lesson from #4974: order matters in shutdown.
+      origOnData.dispose();
+      origOnExit.dispose();
 
       if (sessionId) {
         terminal.agentSessionId = sessionId;
@@ -83,7 +95,7 @@ export async function gracefulShutdown(host: TerminalGracefulShutdownHost): Prom
 
     const timer = setTimeout(() => finish(null), GRACEFUL_SHUTDOWN_TIMEOUT_MS);
 
-    const origOnData = terminal.ptyProcess.onData((data: string) => {
+    origOnData = terminal.ptyProcess.onData((data: string) => {
       if (resolved) return;
       if (!pattern) return;
 
@@ -95,15 +107,11 @@ export async function gracefulShutdown(host: TerminalGracefulShutdownHost): Prom
       const stripped = stripAnsiCodes(shutdownBuffer);
       const match = pattern.exec(stripped);
       if (match?.[1]) {
-        origOnData.dispose();
         finish(match[1]);
       }
     });
 
-    const origOnExit = terminal.ptyProcess.onExit(() => {
-      origOnExit.dispose();
-      origOnData.dispose();
-
+    origOnExit = terminal.ptyProcess.onExit(() => {
       if (!pattern) {
         finish(null);
         return;

--- a/electron/services/pty/TerminalProcess.ts
+++ b/electron/services/pty/TerminalProcess.ts
@@ -948,12 +948,12 @@ export class TerminalProcess {
       this.deps.agentStateService.emitAgentKilled(terminal, reason);
     }
 
-    // Capture forensic tail before disposeHeadless() clears the buffer so
-    // any subscriber that runs synchronously after the natural-exit
-    // emit-path can still read it. The kill path emits no `terminal:exited`
-    // here — natural onExit will fire (or `dispose()` will emit if it
-    // doesn't), carrying `reason: "kill"` through the exit-reason carried
-    // by the state machine.
+    // Tear down the headless terminal model (xterm instance, synchronized
+    // frame detector, headless responder). The forensic buffer lives on
+    // `this.forensicsBuffer` and is *not* touched by disposeHeadless(); the
+    // natural onExit handler (or dispose() if onExit never fires) reads
+    // `forensicsBuffer.getRecentOutput()` and emits `terminal:exited` with
+    // `reason: "kill"` carried through the lifecycle state machine.
     this.disposeHeadless();
 
     this.processTreeKiller.execute(false);

--- a/electron/services/pty/__tests__/ProcessTreeKiller.test.ts
+++ b/electron/services/pty/__tests__/ProcessTreeKiller.test.ts
@@ -76,8 +76,8 @@ describe("ProcessTreeKiller — kill() error discrimination", () => {
     killer.execute(true);
 
     const sigtermWarnings = warnSpy.mock.calls
-      .map((c) => String(c[0]))
-      .filter((m) => m.includes("SIGTERM"));
+      .map((c: unknown[]) => String(c[0]))
+      .filter((m: string) => m.includes("SIGTERM"));
     expect(sigtermWarnings).toHaveLength(2);
     expect(sigtermWarnings[0]).toContain("[ProcessTreeKiller]");
     expect(sigtermWarnings[0]).toContain("pid=1001");
@@ -100,12 +100,12 @@ describe("ProcessTreeKiller — kill() error discrimination", () => {
     killer.execute(true);
 
     const sigkillWarnings = warnSpy.mock.calls
-      .map((c) => String(c[0]))
-      .filter((m) => m.includes("SIGKILL"));
+      .map((c: unknown[]) => String(c[0]))
+      .filter((m: string) => m.includes("SIGKILL"));
     // sweep iterates [...descendants, shellPid] = [2001, 2000]
     expect(sigkillWarnings).toHaveLength(2);
-    expect(sigkillWarnings.some((m) => m.includes("pid=2001"))).toBe(true);
-    expect(sigkillWarnings.some((m) => m.includes("pid=2000"))).toBe(true);
+    expect(sigkillWarnings.some((m: string) => m.includes("pid=2001"))).toBe(true);
+    expect(sigkillWarnings.some((m: string) => m.includes("pid=2000"))).toBe(true);
   });
 
   it("does not warn on ESRCH during SIGKILL sweep", () => {
@@ -123,8 +123,8 @@ describe("ProcessTreeKiller — kill() error discrimination", () => {
     killer.execute(true);
 
     const sigkillWarnings = warnSpy.mock.calls
-      .map((c) => String(c[0]))
-      .filter((m) => m.includes("SIGKILL"));
+      .map((c: unknown[]) => String(c[0]))
+      .filter((m: string) => m.includes("SIGKILL"));
     expect(sigkillWarnings).toHaveLength(0);
   });
 });

--- a/electron/services/pty/__tests__/ProcessTreeKiller.test.ts
+++ b/electron/services/pty/__tests__/ProcessTreeKiller.test.ts
@@ -1,0 +1,130 @@
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+import type { IPty } from "node-pty";
+import type { ProcessTreeCache } from "../../ProcessTreeCache.js";
+import { ProcessTreeKiller } from "../ProcessTreeKiller.js";
+
+function makePty(pid: number): IPty {
+  return {
+    pid,
+    cols: 80,
+    rows: 24,
+    write: () => {},
+    resize: () => {},
+    kill: vi.fn(),
+    pause: () => {},
+    resume: () => {},
+    onData: () => ({ dispose: () => {} }),
+    onExit: () => ({ dispose: () => {} }),
+  } as unknown as IPty;
+}
+
+function makeTreeCache(descendants: number[]): ProcessTreeCache {
+  return {
+    getDescendantPids: () => descendants,
+  } as unknown as ProcessTreeCache;
+}
+
+function makeErrnoError(code: string, message?: string): NodeJS.ErrnoException {
+  const err = new Error(message ?? code) as NodeJS.ErrnoException;
+  err.code = code;
+  return err;
+}
+
+describe("ProcessTreeKiller — kill() error discrimination", () => {
+  let warnSpy: ReturnType<typeof vi.spyOn>;
+  let killSpy: ReturnType<typeof vi.spyOn>;
+
+  beforeEach(() => {
+    warnSpy = vi.spyOn(console, "warn").mockImplementation(() => {});
+    vi.useFakeTimers();
+  });
+
+  afterEach(() => {
+    killSpy?.mockRestore();
+    warnSpy.mockRestore();
+    vi.useRealTimers();
+  });
+
+  it("silently ignores ESRCH from descendant SIGTERM", () => {
+    if (process.platform === "win32") {
+      // SIGTERM loop is Unix-only; Windows uses taskkill.
+      return;
+    }
+    killSpy = vi.spyOn(process, "kill").mockImplementation((_pid, _sig) => {
+      throw makeErrnoError("ESRCH", "kill ESRCH");
+    });
+
+    const killer = new ProcessTreeKiller(makePty(1000), makeTreeCache([1001, 1002]));
+    killer.execute(true);
+
+    expect(warnSpy).not.toHaveBeenCalled();
+  });
+
+  it("warns once per pid when SIGTERM fails with EPERM", () => {
+    if (process.platform === "win32") {
+      return;
+    }
+    killSpy = vi.spyOn(process, "kill").mockImplementation((_pid, sig) => {
+      if (sig === "SIGTERM") {
+        throw makeErrnoError("EPERM", "kill EPERM");
+      }
+      // Let SIGKILL succeed silently.
+      return true;
+    });
+
+    const killer = new ProcessTreeKiller(makePty(1000), makeTreeCache([1001, 1002]));
+    killer.execute(true);
+
+    const sigtermWarnings = warnSpy.mock.calls
+      .map((c) => String(c[0]))
+      .filter((m) => m.includes("SIGTERM"));
+    expect(sigtermWarnings).toHaveLength(2);
+    expect(sigtermWarnings[0]).toContain("[ProcessTreeKiller]");
+    expect(sigtermWarnings[0]).toContain("pid=1001");
+    expect(sigtermWarnings[1]).toContain("pid=1002");
+  });
+
+  it("warns once per pid when SIGKILL sweep fails with EPERM", () => {
+    if (process.platform === "win32") {
+      return;
+    }
+    killSpy = vi.spyOn(process, "kill").mockImplementation((_pid, sig) => {
+      if (sig === "SIGKILL") {
+        throw makeErrnoError("EPERM", "kill EPERM");
+      }
+      // Let SIGTERM succeed silently.
+      return true;
+    });
+
+    const killer = new ProcessTreeKiller(makePty(2000), makeTreeCache([2001]));
+    killer.execute(true);
+
+    const sigkillWarnings = warnSpy.mock.calls
+      .map((c) => String(c[0]))
+      .filter((m) => m.includes("SIGKILL"));
+    // sweep iterates [...descendants, shellPid] = [2001, 2000]
+    expect(sigkillWarnings).toHaveLength(2);
+    expect(sigkillWarnings.some((m) => m.includes("pid=2001"))).toBe(true);
+    expect(sigkillWarnings.some((m) => m.includes("pid=2000"))).toBe(true);
+  });
+
+  it("does not warn on ESRCH during SIGKILL sweep", () => {
+    if (process.platform === "win32") {
+      return;
+    }
+    killSpy = vi.spyOn(process, "kill").mockImplementation((_pid, sig) => {
+      if (sig === "SIGKILL") {
+        throw makeErrnoError("ESRCH");
+      }
+      return true;
+    });
+
+    const killer = new ProcessTreeKiller(makePty(3000), makeTreeCache([3001]));
+    killer.execute(true);
+
+    const sigkillWarnings = warnSpy.mock.calls
+      .map((c) => String(c[0]))
+      .filter((m) => m.includes("SIGKILL"));
+    expect(sigkillWarnings).toHaveLength(0);
+  });
+});

--- a/electron/services/pty/__tests__/TerminalProcess.gracefulShutdown.test.ts
+++ b/electron/services/pty/__tests__/TerminalProcess.gracefulShutdown.test.ts
@@ -14,6 +14,8 @@ interface MockPtyHandles {
   writeMock: ReturnType<typeof vi.fn<(data: string) => void>>;
   emitData: (data: string) => void;
   emitExit: (exitCode: number, signal?: number) => void;
+  onDataDispose: ReturnType<typeof vi.fn>;
+  onExitDispose: ReturnType<typeof vi.fn>;
 }
 
 function createMockPty(writeOverride?: (data: string) => void): MockPtyHandles {
@@ -21,6 +23,12 @@ function createMockPty(writeOverride?: (data: string) => void): MockPtyHandles {
   let exitCallback: ((event: { exitCode: number; signal?: number }) => void) | null = null;
 
   const writeMock = vi.fn<(data: string) => void>();
+  const onDataDispose = vi.fn(() => {
+    dataCallback = null;
+  });
+  const onExitDispose = vi.fn(() => {
+    exitCallback = null;
+  });
 
   const pty: Partial<IPty> = {
     pid: 123,
@@ -36,19 +44,11 @@ function createMockPty(writeOverride?: (data: string) => void): MockPtyHandles {
     resume: () => {},
     onData: (cb: (data: string) => void) => {
       dataCallback = cb;
-      return {
-        dispose: () => {
-          dataCallback = null;
-        },
-      };
+      return { dispose: onDataDispose };
     },
     onExit: (cb: (e: { exitCode: number; signal?: number }) => void) => {
       exitCallback = cb;
-      return {
-        dispose: () => {
-          exitCallback = null;
-        },
-      };
+      return { dispose: onExitDispose };
     },
   };
 
@@ -57,6 +57,8 @@ function createMockPty(writeOverride?: (data: string) => void): MockPtyHandles {
     writeMock,
     emitData: (data: string) => dataCallback?.(data),
     emitExit: (exitCode: number, signal?: number) => exitCallback?.({ exitCode, signal }),
+    onDataDispose,
+    onExitDispose,
   };
 }
 
@@ -400,5 +402,63 @@ describe("TerminalProcess.gracefulShutdown — input-clear prelude", () => {
 
     await expect(shutdownPromise).resolves.toBeNull();
     expect(terminal.getInfo().agentSessionId).toBeUndefined();
+  });
+});
+
+describe("TerminalProcess.gracefulShutdown — listener disposal", () => {
+  beforeEach(() => {
+    vi.useFakeTimers();
+  });
+
+  afterEach(() => {
+    vi.useRealTimers();
+  });
+
+  it("disposes both onData and onExit observers when the timeout fires", async () => {
+    // Pre-fix the timeout path leaked both listeners — `finish()` only
+    // cleared the timer and called host.kill(). Now disposal is centralized
+    // in `finish()` so every resolution path frees the observers.
+    const handles = createMockPty();
+    const terminal = createAgentTerminal(handles);
+
+    const shutdownPromise = terminal.gracefulShutdown();
+    await vi.advanceTimersByTimeAsync(GRACEFUL_SHUTDOWN_TIMEOUT_MS);
+
+    await expect(shutdownPromise).resolves.toBeNull();
+
+    expect(handles.onDataDispose).toHaveBeenCalled();
+    expect(handles.onExitDispose).toHaveBeenCalled();
+  });
+
+  it("disposes both observers when the session-ID pattern matches", async () => {
+    // Pre-fix the pattern-match path disposed only `origOnData`; `origOnExit`
+    // remained registered until the PTY was GC'd. The centralized
+    // `finish()` now disposes both.
+    const handles = createMockPty();
+    const terminal = createAgentTerminal(handles);
+
+    const shutdownPromise = terminal.gracefulShutdown();
+    await vi.advanceTimersByTimeAsync(GRACEFUL_SHUTDOWN_CLEAR_DELAY_MS);
+
+    handles.emitData("claude --resume captured-session\n");
+    await expect(shutdownPromise).resolves.toBe("captured-session");
+
+    expect(handles.onDataDispose).toHaveBeenCalled();
+    expect(handles.onExitDispose).toHaveBeenCalled();
+  });
+
+  it("disposes both observers when the PTY exits naturally", async () => {
+    const handles = createMockPty();
+    const terminal = createAgentTerminal(handles);
+
+    const shutdownPromise = terminal.gracefulShutdown();
+    await Promise.resolve();
+    await Promise.resolve();
+
+    handles.emitExit(0);
+    await expect(shutdownPromise).resolves.toBeNull();
+
+    expect(handles.onDataDispose).toHaveBeenCalled();
+    expect(handles.onExitDispose).toHaveBeenCalled();
   });
 });


### PR DESCRIPTION
## Summary

- `gracefulShutdown` leaked its `onData`/`onExit` observers when the timeout or pattern-match paths fired — only the natural-exit path was disposing both. Centralised disposal in a `finish()` helper so all three resolution paths clean up.
- `ProcessTreeKiller` was swallowing `EPERM` in the same empty `catch {}` as `ESRCH`. `ESRCH` stays silent (process already gone), but `EPERM` now logs a `console.warn` with the signal name and pid so elevated subprocesses that survive teardown actually surface in the logs.
- Stale comment in `TerminalProcess.kill()` claimed `disposeHeadless()` clears the forensic buffer. It doesn't — corrected to describe what the call actually does.

Resolves #7009

## Changes

- `electron/services/pty/TerminalGracefulShutdown.ts` — `finish()` helper disposes both listeners on all resolution paths; no-op sentinel guards the forward reference
- `electron/services/pty/ProcessTreeKiller.ts` — discriminated `ESRCH`/`EPERM` handling in both the `SIGTERM` loop and `SIGKILL` sweep
- `electron/services/pty/TerminalProcess.ts` — comment correction only, no behaviour change
- `electron/services/pty/__tests__/TerminalProcess.gracefulShutdown.test.ts` — 3 new listener-disposal tests
- `electron/services/pty/__tests__/ProcessTreeKiller.test.ts` — new file, 4 tests covering `ESRCH`/`EPERM` on both signal paths

## Testing

All 20 tests pass via vitest. Typecheck, `check:channels`, `lint:ratchet` (warnings -6), and `format:check` all pass.