### PR TITLE
fix(pty-host): release pause holds and stale byte state in queue managers

### DIFF
--- a/electron/pty-host/__tests__/ipcQueue.adversarial.test.ts
+++ b/electron/pty-host/__tests__/ipcQueue.adversarial.test.ts
@@ -128,7 +128,10 @@ describe("IpcQueueManager adversarial", () => {
     expect(endMetric?.[0].durationMs).toBeGreaterThanOrEqual(IPC_MAX_PAUSE_MS);
   });
 
-  it("clearQueue cancels a pending safety-timeout force-resume", () => {
+  it("clearQueue when paused releases the coordinator hold and cancels the safety-timeout (#7008)", () => {
+    // clearQueue must release the coordinator hold it owns. Without this,
+    // force-resume paths (renderer reload, view eviction) clear queue maps
+    // but leak the "ipc-queue" pause token, wedging the PTY indefinitely.
     mgr.addBytes("t1", HIGH_BYTES);
     mgr.applyBackpressure("t1", mgr.getUtilization("t1"));
     expect(mgr.isPaused("t1")).toBe(true);
@@ -136,11 +139,45 @@ describe("IpcQueueManager adversarial", () => {
 
     mgr.clearQueue("t1");
     expect(mgr.isPaused("t1")).toBe(false);
+    expect(coord.resume).toHaveBeenCalledTimes(1);
+    expect(coord.resume).toHaveBeenCalledWith("ipc-queue");
 
+    // The cancelled safety timeout must not fire later and double-resume.
+    coord.resume.mockClear();
     vi.advanceTimersByTime(IPC_MAX_PAUSE_MS * 2);
+    expect(coord.resume).not.toHaveBeenCalled();
+    expect(mgr.getQueuedBytes("t1")).toBe(0);
+  });
+
+  it("clearQueue when not paused does not call coordinator.resume", () => {
+    mgr.addBytes("t1", 100);
+    coord.resume.mockClear();
+
+    mgr.clearQueue("t1");
 
     expect(coord.resume).not.toHaveBeenCalled();
     expect(mgr.getQueuedBytes("t1")).toBe(0);
+  });
+
+  it("safety timeout clears stale queuedBytes so next byte does not re-pause (#7008)", () => {
+    // Mirrors the port-path #6244 regression: when ack-driven resume fails
+    // and the safety timeout fires, queuedBytes must be cleared along with
+    // pause maps. Otherwise the next addBytes immediately re-paints the
+    // queue above the high watermark and applyBackpressure re-triggers.
+    mgr.addBytes("t1", HIGH_BYTES);
+    mgr.applyBackpressure("t1", mgr.getUtilization("t1"));
+
+    vi.advanceTimersByTime(IPC_MAX_PAUSE_MS);
+
+    expect(mgr.getQueuedBytes("t1")).toBe(0);
+    const pauseCallsAfterTimeout = coord.pause.mock.calls.length;
+
+    mgr.addBytes("t1", 1);
+    const result = mgr.applyBackpressure("t1", mgr.getUtilization("t1"));
+
+    expect(result).toBe(false);
+    expect(mgr.isPaused("t1")).toBe(false);
+    expect(coord.pause.mock.calls.length).toBe(pauseCallsAfterTimeout);
   });
 
   it("applyBackpressure without a pause coordinator returns false and does not enter paused state", () => {

--- a/electron/pty-host/__tests__/portQueue.test.ts
+++ b/electron/pty-host/__tests__/portQueue.test.ts
@@ -189,18 +189,55 @@ describe("PortQueueManager", () => {
     );
   });
 
-  it("clearQueue clears all state for a terminal", () => {
+  it("clearQueue when paused releases the coordinator hold (#7008)", () => {
+    // Without coordinator.resume, the "port-queue" pause token leaks across
+    // disconnectWindow / force-resume paths, wedging the PTY indefinitely.
     const deps = createMockDeps();
     const mgr = new PortQueueManager(deps);
 
     const highWatermark = (IPC_MAX_QUEUE_BYTES * IPC_HIGH_WATERMARK_PERCENT) / 100;
     mgr.addBytes("t1", highWatermark + 1);
     mgr.applyBackpressure("t1", mgr.getUtilization("t1"));
+    const coordinator = deps.getPauseCoordinator("t1");
+    vi.mocked(coordinator!.resume).mockClear();
 
     mgr.clearQueue("t1");
 
     expect(mgr.getQueuedBytes("t1")).toBe(0);
     expect(mgr.isPaused("t1")).toBe(false);
+    expect(coordinator!.resume).toHaveBeenCalledTimes(1);
+    expect(coordinator!.resume).toHaveBeenCalledWith("port-queue");
+  });
+
+  it("clearQueue when not paused does not call coordinator.resume", () => {
+    const deps = createMockDeps();
+    const mgr = new PortQueueManager(deps);
+
+    mgr.addBytes("t1", 1000);
+    const coordinator = deps.getPauseCoordinator("t1");
+    vi.mocked(coordinator!.resume).mockClear();
+
+    mgr.clearQueue("t1");
+
+    expect(coordinator!.resume).not.toHaveBeenCalled();
+    expect(mgr.getQueuedBytes("t1")).toBe(0);
+  });
+
+  it("clearQueue with a custom pauseToken releases that exact token", () => {
+    // Per-window port queue managers use unique tokens (e.g. "port-queue-7").
+    // The release must match the token the manager held, not a hardcoded value.
+    const deps = createMockDeps();
+    const mgr = new PortQueueManager({ ...deps, pauseToken: "port-queue-7" });
+
+    const highWatermark = (IPC_MAX_QUEUE_BYTES * IPC_HIGH_WATERMARK_PERCENT) / 100;
+    mgr.addBytes("t1", highWatermark + 1);
+    mgr.applyBackpressure("t1", mgr.getUtilization("t1"));
+    const coordinator = deps.getPauseCoordinator("t1");
+    vi.mocked(coordinator!.resume).mockClear();
+
+    mgr.clearQueue("t1");
+
+    expect(coordinator!.resume).toHaveBeenCalledWith("port-queue-7");
   });
 
   it("dispose clears all terminals", () => {

--- a/electron/pty-host/handlers/__tests__/backpressure.test.ts
+++ b/electron/pty-host/handlers/__tests__/backpressure.test.ts
@@ -1,0 +1,144 @@
+import { describe, it, expect, vi, beforeEach, afterEach } from "vitest";
+import { createBackpressureHandlers } from "../backpressure.js";
+import type { HostContext, RendererConnection } from "../types.js";
+
+function makeCoordinator() {
+  const coord = {
+    pause: vi.fn(),
+    resume: vi.fn(),
+    forceReleaseAll: vi.fn(),
+    isPaused: false,
+  };
+  return coord;
+}
+
+function makeRendererConnection(): RendererConnection {
+  return {
+    port: {} as RendererConnection["port"],
+    handler: vi.fn(),
+    portQueueManager: {
+      clearQueue: vi.fn(),
+    } as unknown as RendererConnection["portQueueManager"],
+    batcher: {} as RendererConnection["batcher"],
+  };
+}
+
+function makeCtx(overrides: Partial<HostContext> = {}): HostContext {
+  return {
+    ptyManager: {
+      getTerminal: vi.fn(() => undefined),
+      getAll: vi.fn(() => []),
+      setActivityMonitorTier: vi.fn(),
+      acknowledgeData: vi.fn(),
+      getSerializedStateAsync: vi.fn(async () => null),
+      getSerializedState: vi.fn(() => null),
+    } as unknown as HostContext["ptyManager"],
+    processTreeCache: {} as HostContext["processTreeCache"],
+    terminalResourceMonitor: {} as HostContext["terminalResourceMonitor"],
+    backpressureManager: {
+      isPaused: vi.fn(() => false),
+      hasPendingSegments: vi.fn(() => false),
+      setActivityTier: vi.fn(),
+      clearSuspended: vi.fn(),
+      clearPendingVisual: vi.fn(),
+      getPausedInterval: vi.fn(() => undefined),
+      deletePausedInterval: vi.fn(),
+      getPauseStartTime: vi.fn(() => undefined),
+      deletePauseStartTime: vi.fn(),
+      emitTerminalStatus: vi.fn(),
+      emitReliabilityMetric: vi.fn(),
+    } as unknown as HostContext["backpressureManager"],
+    ipcQueueManager: {
+      removeBytes: vi.fn(),
+      tryResume: vi.fn(),
+      clearQueue: vi.fn(),
+    } as unknown as HostContext["ipcQueueManager"],
+    resourceGovernor: {} as HostContext["resourceGovernor"],
+    packetFramer: {} as HostContext["packetFramer"],
+    pauseCoordinators: new Map(),
+    rendererConnections: new Map(),
+    windowProjectMap: new Map(),
+    ipcDataMirrorTerminals: new Set(),
+    visualBuffers: [],
+    visualSignalView: null,
+    analysisBuffer: null,
+    ptyPool: null,
+    sendEvent: vi.fn(),
+    getPauseCoordinator: vi.fn(),
+    getOrCreatePauseCoordinator: vi.fn(),
+    disconnectWindow: vi.fn(),
+    recomputeActivityTiers: vi.fn(),
+    tryReplayAndResume: vi.fn(),
+    resumePausedTerminal: vi.fn(),
+    createPortQueueManager: vi.fn(),
+    ...overrides,
+  };
+}
+
+describe("force-resume handler", () => {
+  beforeEach(() => {
+    vi.spyOn(console, "warn").mockImplementation(() => {});
+    vi.spyOn(console, "log").mockImplementation(() => {});
+  });
+
+  afterEach(() => {
+    vi.restoreAllMocks();
+  });
+
+  it("drains every per-window portQueueManager so port-path pause holds don't leak (#7008)", () => {
+    // disconnectWindow handles the normal lifecycle by calling resumeAll +
+    // dispose on each connection's manager. force-resume bypasses that path
+    // and previously cleared only ipcQueueManager state, leaving stale
+    // pausedTerminals + queuedBytes in every per-window port queue manager.
+    const coord = makeCoordinator();
+    const conn1 = makeRendererConnection();
+    const conn2 = makeRendererConnection();
+    const rendererConnections = new Map<number, RendererConnection>([
+      [1, conn1],
+      [2, conn2],
+    ]);
+    const ctx = makeCtx({
+      rendererConnections,
+      getPauseCoordinator: vi.fn(() => coord as never),
+    });
+
+    const handlers = createBackpressureHandlers(ctx);
+    handlers["force-resume"]({ type: "force-resume", id: "term-1" });
+
+    expect(coord.forceReleaseAll).toHaveBeenCalledTimes(1);
+    expect(ctx.ipcQueueManager.clearQueue).toHaveBeenCalledWith("term-1");
+    expect(conn1.portQueueManager.clearQueue).toHaveBeenCalledWith("term-1");
+    expect(conn2.portQueueManager.clearQueue).toHaveBeenCalledWith("term-1");
+  });
+
+  it("calls portQueueManager.clearQueue on every connection even when none currently track the terminal", () => {
+    // clearQueue is a no-op for terminals not in the manager's maps, so the
+    // handler iterates unconditionally rather than tracking which manager
+    // owns which terminal.
+    const coord = makeCoordinator();
+    const conn = makeRendererConnection();
+    const ctx = makeCtx({
+      rendererConnections: new Map([[1, conn]]),
+      getPauseCoordinator: vi.fn(() => coord as never),
+    });
+
+    const handlers = createBackpressureHandlers(ctx);
+    handlers["force-resume"]({ type: "force-resume", id: "untracked-terminal" });
+
+    expect(conn.portQueueManager.clearQueue).toHaveBeenCalledWith("untracked-terminal");
+  });
+
+  it("returns early when the pause coordinator is missing", () => {
+    const conn = makeRendererConnection();
+    const ctx = makeCtx({
+      rendererConnections: new Map([[1, conn]]),
+      getPauseCoordinator: vi.fn(() => undefined),
+    });
+
+    const handlers = createBackpressureHandlers(ctx);
+    handlers["force-resume"]({ type: "force-resume", id: "term-1" });
+
+    expect(ctx.ipcQueueManager.clearQueue).not.toHaveBeenCalled();
+    expect(conn.portQueueManager.clearQueue).not.toHaveBeenCalled();
+  });
+});

--- a/electron/pty-host/handlers/backpressure.ts
+++ b/electron/pty-host/handlers/backpressure.ts
@@ -183,6 +183,14 @@ export function createBackpressureHandlers(ctx: HostContext): HandlerMap {
       // Also clear IPC queue backpressure state
       ipcQueueManager.clearQueue(msg.id);
 
+      // Drain every per-window port queue manager so stale pause maps and
+      // queuedBytes don't leak across the disconnectWindow lifecycle that
+      // force-resume bypasses (#7008). clearQueue is a no-op when the
+      // terminal isn't tracked by that manager.
+      for (const conn of ctx.rendererConnections.values()) {
+        conn.portQueueManager.clearQueue(msg.id);
+      }
+
       // Emit resume status (uses current visualBuffers via ctx getter)
       const buffers = ctx.visualBuffers;
       const utilization =

--- a/electron/pty-host/ipcQueue.ts
+++ b/electron/pty-host/ipcQueue.ts
@@ -105,11 +105,18 @@ export class IpcQueueManager {
       // Safety timeout: if ack-driven resume doesn't clear backpressure in time,
       // force resume to prevent permanent stall
       const safetyTimeout = setTimeout(() => {
-        this.pausedTerminals.delete(id);
-        this.pauseStartTimes.delete(id);
-
+        // Capture utilization BEFORE clearing queuedBytes so the reliability
+        // metric reports the at-resume queue depth, not the post-clear 0%.
         const currentUtilization = this.getUtilization(id);
         const pauseDuration = Date.now() - pauseStartTime;
+
+        this.pausedTerminals.delete(id);
+        this.pauseStartTimes.delete(id);
+        // Drop stale byte accounting alongside the pause maps. Without this,
+        // the next addBytes call immediately re-triggers applyBackpressure
+        // and the pause loop wedges across the entire renderer reload
+        // (mirrors the port-path fix in #6244).
+        this.queuedBytes.delete(id);
 
         const coordinator = this.deps.getPauseCoordinator(id);
         if (coordinator) {
@@ -174,12 +181,20 @@ export class IpcQueueManager {
   }
 
   clearQueue(id: string): void {
-    this.queuedBytes.delete(id);
+    const wasPaused = this.pausedTerminals.has(id);
     const safetyTimeout = this.pausedTerminals.get(id);
     if (safetyTimeout) {
       clearTimeout(safetyTimeout);
-      this.pausedTerminals.delete(id);
     }
+    // Release the coordinator hold before clearing internal maps so any
+    // re-entrant applyBackpressure sees a clean state. resume() is a no-op
+    // when the token isn't held, so guarding on wasPaused is purely an
+    // optimization to avoid a useless coordinator lookup. See #7008.
+    if (wasPaused) {
+      this.deps.getPauseCoordinator(id)?.resume("ipc-queue");
+    }
+    this.queuedBytes.delete(id);
+    this.pausedTerminals.delete(id);
     this.pauseStartTimes.delete(id);
   }
 

--- a/electron/pty-host/portQueue.ts
+++ b/electron/pty-host/portQueue.ts
@@ -182,12 +182,20 @@ export class PortQueueManager {
   }
 
   clearQueue(id: string): void {
-    this.queuedBytes.delete(id);
+    const wasPaused = this.pausedTerminals.has(id);
     const safetyTimeout = this.pausedTerminals.get(id);
     if (safetyTimeout) {
       clearTimeout(safetyTimeout);
-      this.pausedTerminals.delete(id);
     }
+    // Release the coordinator hold before clearing internal maps so any
+    // re-entrant applyBackpressure sees a clean state. resume() is a no-op
+    // when the token isn't held, so guarding on wasPaused is purely an
+    // optimization to avoid a useless coordinator lookup. See #7008.
+    if (wasPaused) {
+      this.deps.getPauseCoordinator(id)?.resume(this.pauseToken);
+    }
+    this.queuedBytes.delete(id);
+    this.pausedTerminals.delete(id);
     this.pauseStartTimes.delete(id);
   }
 


### PR DESCRIPTION
## Summary

- `ipcQueue.ts` safety-timeout closure now drops stale `queuedBytes` accounting before force-resuming, matching the fix already applied to `portQueue.ts` in #6244. Without this, a force-resume could be undone immediately when the next `addBytes` call re-triggered `applyBackpressure` on stale totals.
- Force-resume IPC handler now iterates `rendererConnections` and calls `portQueueManager.clearQueue` per window. Previously it cleared only the IPC path, leaving stale `pausedTerminals` entries with live safety timeouts that would later fire and emit spurious `pause-end` reliability metrics.
- Both `clearQueue` methods now call `coordinator.resume` to release the pause hold token when the terminal was paused. The two existing callers happened to release the coordinator separately, so it worked in practice, but any new caller inherited a wedged coordinator. `PtyPauseCoordinator.resume` for an already-released token is a no-op, so self-release inside `clearQueue` is safe.

Resolves #7008

## Changes

- `electron/pty-host/ipcQueue.ts` -- drop `queuedBytes` in safety-timeout closure; release coordinator pause hold in `clearQueue`
- `electron/pty-host/portQueue.ts` -- release coordinator pause hold in `clearQueue`
- `electron/pty-host/handlers/backpressure.ts` -- iterate `rendererConnections` and clear per-window port queues in force-resume handler
- `electron/pty-host/__tests__/ipcQueue.adversarial.test.ts` -- stale-byte regression test, updated `clearQueue` resume assertion
- `electron/pty-host/__tests__/portQueue.test.ts` -- not-paused + custom-token coverage, updated `clearQueue` resume assertion
- `electron/pty-host/handlers/__tests__/backpressure.test.ts` -- new handler test exercising real `createBackpressureHandlers` with multi-window `rendererConnections`

## Testing

32 tests passing across 3 files. New regression test in `ipcQueue.adversarial.test.ts` covers the stale-bytes re-pause scenario. `backpressure.test.ts` exercises the multi-window force-resume path end-to-end with real handler wiring.