### PR TITLE
fix(pty): banner-aware snapshot persist paths and cap-skip warn (#7015)

### DIFF
--- a/electron/services/pty/SessionSnapshotter.ts
+++ b/electron/services/pty/SessionSnapshotter.ts
@@ -1,6 +1,5 @@
 import {
   TERMINAL_SESSION_PERSISTENCE_ENABLED,
-  SESSION_SNAPSHOT_MAX_BYTES,
   SESSION_SNAPSHOT_DEBOUNCE_MS,
   persistSessionSnapshotSync,
   persistSessionSnapshotAsync,
@@ -121,7 +120,7 @@ export class SessionSnapshotter {
 
     try {
       const state = this.host.serializeForPersistence() ?? this.host.getSerializedState();
-      if (state && Buffer.byteLength(state, "utf8") <= SESSION_SNAPSHOT_MAX_BYTES) {
+      if (state) {
         persistSessionSnapshotSync(this.host.id, state);
         this.dirty = false;
       }

--- a/electron/services/pty/SessionSnapshotter.ts
+++ b/electron/services/pty/SessionSnapshotter.ts
@@ -63,9 +63,6 @@ export class SessionSnapshotter {
       // serialize would otherwise stomp the sync snapshot written from kill().
       if (this.disposed || this.host.wasKilled) return;
       if (!state) return;
-      if (Buffer.byteLength(state, "utf8") > SESSION_SNAPSHOT_MAX_BYTES) {
-        return;
-      }
       await persistSessionSnapshotAsync(this.host.id, state);
     } catch (error) {
       console.warn(`[TerminalProcess] Failed to persist session for ${this.host.id}:`, error);
@@ -87,9 +84,8 @@ export class SessionSnapshotter {
     if (now - this.lastEventDrivenFlushAt < EVENT_DRIVEN_SNAPSHOT_THROTTLE_MS) return;
     this.lastEventDrivenFlushAt = now;
 
-    const state = this.host.getSerializedState();
+    const state = this.host.serializeForPersistence();
     if (!state) return;
-    if (Buffer.byteLength(state, "utf8") > SESSION_SNAPSHOT_MAX_BYTES) return;
 
     persistSessionSnapshotAsync(this.host.id, state).catch((error) => {
       console.warn(`[TerminalProcess] Event-driven snapshot failed for ${this.host.id}:`, error);
@@ -97,16 +93,16 @@ export class SessionSnapshotter {
   }
 
   // Last-chance unconditional flush invoked by kill() before wasKilled is set.
-  // Mirrors the legacy inline block: plain sync serialize, no banner awareness,
-  // skipped only when persistence is disabled / suppressed / agent terminal.
+  // Banner-aware: uses serializeForPersistence() so a hibernate→restore→hibernate
+  // cycle doesn't bake the previous restore banner into the snapshot.
   flushSyncOnKill(): void {
     if (!TERMINAL_SESSION_PERSISTENCE_ENABLED) return;
     if (isSessionPersistSuppressed()) return;
     if (this.host.launchAgentId) return;
 
     try {
-      const state = this.host.getSerializedState();
-      if (state && Buffer.byteLength(state, "utf8") <= SESSION_SNAPSHOT_MAX_BYTES) {
+      const state = this.host.serializeForPersistence();
+      if (state) {
         persistSessionSnapshotSync(this.host.id, state);
       }
     } catch {

--- a/electron/services/pty/TerminalProcess.ts
+++ b/electron/services/pty/TerminalProcess.ts
@@ -211,7 +211,7 @@ export class TerminalProcess {
       }
 
       serializeForPersistence(): string | null {
-        return this.parent._serializeForPersistence();
+        return this.parent.serializeForPersistence();
       }
     }
 
@@ -1162,7 +1162,7 @@ export class TerminalProcess {
     return serializeTerminalAsync(this.id, this.terminalInfo);
   }
 
-  private _serializeForPersistence(): string | null {
+  serializeForPersistence(): string | null {
     return serializeForPersistence(
       this.terminalInfo,
       this._restoreBannerStart,

--- a/electron/services/pty/__tests__/SessionSnapshotter.test.ts
+++ b/electron/services/pty/__tests__/SessionSnapshotter.test.ts
@@ -143,17 +143,6 @@ describe("SessionSnapshotter", () => {
 
       expect(persistAsyncMock).not.toHaveBeenCalled();
     });
-
-    it("does not persist when serialized state exceeds max bytes", async () => {
-      const oversized = "x".repeat(6 * 1024 * 1024);
-      const host = createHost({ serializedStateAsync: oversized });
-      const snap = new SessionSnapshotter(host);
-
-      snap.schedule();
-      await vi.advanceTimersByTimeAsync(5000);
-
-      expect(persistAsyncMock).not.toHaveBeenCalled();
-    });
   });
 
   describe("dispose", () => {
@@ -246,14 +235,24 @@ describe("SessionSnapshotter", () => {
   });
 
   describe("flushEventDriven", () => {
-    it("persists with sync serialized state", () => {
+    it("persists using banner-aware serialization", () => {
       const host = createHost();
       const snap = new SessionSnapshotter(host);
 
       snap.flushEventDriven();
 
       expect(persistAsyncMock).toHaveBeenCalledTimes(1);
-      expect(persistAsyncMock).toHaveBeenCalledWith("t-test", "sync-state");
+      expect(persistAsyncMock).toHaveBeenCalledWith("t-test", "banner-state");
+    });
+
+    it("strips restore banner via serializeForPersistence when banner markers are present", () => {
+      const host = createHost({ bannerMarkers: true });
+      const snap = new SessionSnapshotter(host);
+
+      snap.flushEventDriven();
+
+      expect(persistAsyncMock).toHaveBeenCalledTimes(1);
+      expect(persistAsyncMock).toHaveBeenCalledWith("t-test", "banner-state");
     });
 
     it("throttles repeated calls within 2s", () => {
@@ -307,17 +306,7 @@ describe("SessionSnapshotter", () => {
     });
 
     it("skips when serialized state is null", () => {
-      const host = createHost({ serializedState: null });
-      const snap = new SessionSnapshotter(host);
-
-      snap.flushEventDriven();
-
-      expect(persistAsyncMock).not.toHaveBeenCalled();
-    });
-
-    it("skips when serialized state exceeds max bytes", () => {
-      const oversized = "x".repeat(6 * 1024 * 1024);
-      const host = createHost({ serializedState: oversized });
+      const host = createHost({ serializedForPersistence: null });
       const snap = new SessionSnapshotter(host);
 
       snap.flushEventDriven();
@@ -334,7 +323,7 @@ describe("SessionSnapshotter", () => {
       snap.flushSyncOnKill();
 
       expect(persistSyncMock).toHaveBeenCalledTimes(1);
-      expect(persistSyncMock).toHaveBeenCalledWith("t-test", "sync-state");
+      expect(persistSyncMock).toHaveBeenCalledWith("t-test", "banner-state");
     });
 
     it("skips for agent terminals", () => {
@@ -348,7 +337,7 @@ describe("SessionSnapshotter", () => {
 
     it("ignores serialize errors silently", () => {
       const host = createHost();
-      host.getSerializedState = () => {
+      host.serializeForPersistence = () => {
         throw new Error("serialize boom");
       };
       const snap = new SessionSnapshotter(host);
@@ -357,14 +346,26 @@ describe("SessionSnapshotter", () => {
       expect(persistSyncMock).not.toHaveBeenCalled();
     });
 
-    it("uses plain sync serialize (not banner-aware)", () => {
+    it("uses banner-aware serialize so restore banner is stripped before persist", () => {
+      // Hibernation calls flushSyncOnKill with banner markers present from a
+      // prior restore. The banner must NOT be baked into the snapshot or it
+      // will stack on the next hibernate→restore cycle.
       const host = createHost({ bannerMarkers: true });
       const snap = new SessionSnapshotter(host);
 
       snap.flushSyncOnKill();
 
       expect(persistSyncMock).toHaveBeenCalledTimes(1);
-      expect(persistSyncMock).toHaveBeenCalledWith("t-test", "sync-state");
+      expect(persistSyncMock).toHaveBeenCalledWith("t-test", "banner-state");
+    });
+
+    it("skips when serialized state is null", () => {
+      const host = createHost({ serializedForPersistence: null });
+      const snap = new SessionSnapshotter(host);
+
+      snap.flushSyncOnKill();
+
+      expect(persistSyncMock).not.toHaveBeenCalled();
     });
   });
 

--- a/electron/services/pty/__tests__/TerminalProcess.kill.test.ts
+++ b/electron/services/pty/__tests__/TerminalProcess.kill.test.ts
@@ -158,8 +158,10 @@ describe("TerminalProcess.kill — session persistence", () => {
   it("persists session snapshot synchronously for non-agent terminal on kill", () => {
     const terminal = createTerminal();
 
-    // Spy on getSerializedState to return known content
-    vi.spyOn(terminal, "getSerializedState").mockReturnValue("scrollback-data");
+    // Spy on serializeForPersistence (banner-aware) — the kill path uses this
+    // so a hibernate→restore→hibernate cycle doesn't bake the restore banner
+    // into the snapshot.
+    vi.spyOn(terminal, "serializeForPersistence").mockReturnValue("scrollback-data");
 
     terminal.kill("test");
 
@@ -169,7 +171,7 @@ describe("TerminalProcess.kill — session persistence", () => {
   it("does not persist session for agent terminals on kill", () => {
     const terminal = createTerminal({ kind: "terminal", launchAgentId: "claude" });
 
-    vi.spyOn(terminal, "getSerializedState").mockReturnValue("scrollback-data");
+    vi.spyOn(terminal, "serializeForPersistence").mockReturnValue("scrollback-data");
 
     terminal.kill("test");
 
@@ -179,19 +181,7 @@ describe("TerminalProcess.kill — session persistence", () => {
   it("handles null serialized state gracefully on kill", () => {
     const terminal = createTerminal();
 
-    vi.spyOn(terminal, "getSerializedState").mockReturnValue(null);
-
-    terminal.kill("test");
-
-    expect(persistSyncMock).not.toHaveBeenCalled();
-  });
-
-  it("skips persist when serialized state exceeds max bytes", () => {
-    const terminal = createTerminal();
-
-    // SESSION_SNAPSHOT_MAX_BYTES is 5MB — create oversized data
-    const oversized = "x".repeat(6 * 1024 * 1024);
-    vi.spyOn(terminal, "getSerializedState").mockReturnValue(oversized);
+    vi.spyOn(terminal, "serializeForPersistence").mockReturnValue(null);
 
     terminal.kill("test");
 
@@ -201,7 +191,7 @@ describe("TerminalProcess.kill — session persistence", () => {
   it("completes kill even if serialization throws", () => {
     const terminal = createTerminal();
 
-    vi.spyOn(terminal, "getSerializedState").mockImplementation(() => {
+    vi.spyOn(terminal, "serializeForPersistence").mockImplementation(() => {
       throw new Error("serialize failed");
     });
 

--- a/electron/services/pty/__tests__/TerminalProcess.snapshot.test.ts
+++ b/electron/services/pty/__tests__/TerminalProcess.snapshot.test.ts
@@ -84,7 +84,7 @@ describe("TerminalProcess.flushEventDrivenSnapshot", () => {
 
   it("calls persistSessionSnapshotAsync for agent terminals", () => {
     const terminal = createTerminal();
-    vi.spyOn(terminal, "getSerializedState").mockReturnValue("agent-scrollback");
+    vi.spyOn(terminal, "serializeForPersistence").mockReturnValue("agent-scrollback");
 
     terminal.flushEventDrivenSnapshot();
 
@@ -93,7 +93,7 @@ describe("TerminalProcess.flushEventDrivenSnapshot", () => {
 
   it("throttles rapid calls within 2 seconds", () => {
     const terminal = createTerminal();
-    vi.spyOn(terminal, "getSerializedState").mockReturnValue("data");
+    vi.spyOn(terminal, "serializeForPersistence").mockReturnValue("data");
 
     terminal.flushEventDrivenSnapshot();
     expect(persistAsyncMock).toHaveBeenCalledTimes(1);
@@ -105,18 +105,7 @@ describe("TerminalProcess.flushEventDrivenSnapshot", () => {
 
   it("does not flush when serialized state is null", () => {
     const terminal = createTerminal();
-    vi.spyOn(terminal, "getSerializedState").mockReturnValue(null);
-
-    terminal.flushEventDrivenSnapshot();
-
-    expect(persistAsyncMock).not.toHaveBeenCalled();
-  });
-
-  it("does not flush when serialized state exceeds max bytes", () => {
-    const terminal = createTerminal();
-    // SESSION_SNAPSHOT_MAX_BYTES is 5MB; create a string larger than that
-    const oversized = "x".repeat(6 * 1024 * 1024);
-    vi.spyOn(terminal, "getSerializedState").mockReturnValue(oversized);
+    vi.spyOn(terminal, "serializeForPersistence").mockReturnValue(null);
 
     terminal.flushEventDrivenSnapshot();
 
@@ -125,7 +114,7 @@ describe("TerminalProcess.flushEventDrivenSnapshot", () => {
 
   it("does not flush when terminal is killed", () => {
     const terminal = createTerminal();
-    vi.spyOn(terminal, "getSerializedState").mockReturnValue("data");
+    vi.spyOn(terminal, "serializeForPersistence").mockReturnValue("data");
 
     terminal.kill("test");
 

--- a/electron/services/pty/__tests__/terminalSessionPersistence.test.ts
+++ b/electron/services/pty/__tests__/terminalSessionPersistence.test.ts
@@ -61,8 +61,9 @@ describe("terminalSessionPersistence", () => {
     expect(getSessionPath("")).toBeNull();
   });
 
-  it("does not persist snapshots larger than max bytes", async () => {
+  it("does not persist snapshots larger than max bytes and warns", async () => {
     const oversized = "x".repeat(SESSION_SNAPSHOT_MAX_BYTES + 1);
+    const warnSpy = vi.spyOn(console, "warn").mockImplementation(() => {});
 
     persistSessionSnapshotSync("term-sync", oversized);
     await persistSessionSnapshotAsync("term-async", oversized);
@@ -71,6 +72,13 @@ describe("terminalSessionPersistence", () => {
     const asyncPath = path.join(userDataDir, "terminal-sessions", "term-async.restore");
     expect(fs.existsSync(syncPath)).toBe(false);
     expect(fs.existsSync(asyncPath)).toBe(false);
+
+    expect(warnSpy).toHaveBeenCalledTimes(2);
+    expect(warnSpy.mock.calls[0][0]).toMatch(/term-sync/);
+    expect(warnSpy.mock.calls[0][0]).toMatch(/exceeds cap/);
+    expect(warnSpy.mock.calls[1][0]).toMatch(/term-async/);
+
+    warnSpy.mockRestore();
   });
 
   it("persists and restores snapshots via the atomic write helpers", async () => {

--- a/electron/services/pty/terminalSessionPersistence.ts
+++ b/electron/services/pty/terminalSessionPersistence.ts
@@ -130,7 +130,13 @@ export function persistSessionSnapshotSync(terminalId: string, state: string): v
   const sessionPath = getSessionPath(terminalId);
   const dir = getSessionDir();
   if (!sessionPath || !dir) return;
-  if (Buffer.byteLength(state, "utf8") > SESSION_SNAPSHOT_MAX_BYTES) return;
+  const bytes = Buffer.byteLength(state, "utf8");
+  if (bytes > SESSION_SNAPSHOT_MAX_BYTES) {
+    console.warn(
+      `[terminalSessionPersistence] Snapshot for ${terminalId} exceeds cap (${bytes} > ${SESSION_SNAPSHOT_MAX_BYTES} bytes); skipping persist`
+    );
+    return;
+  }
 
   mkdirSync(dir, { recursive: true });
   resilientAtomicWriteFileSync(sessionPath, state, "utf8");
@@ -143,7 +149,13 @@ export async function persistSessionSnapshotAsync(
   const sessionPath = getSessionPath(terminalId);
   const dir = getSessionDir();
   if (!sessionPath || !dir) return;
-  if (Buffer.byteLength(state, "utf8") > SESSION_SNAPSHOT_MAX_BYTES) return;
+  const bytes = Buffer.byteLength(state, "utf8");
+  if (bytes > SESSION_SNAPSHOT_MAX_BYTES) {
+    console.warn(
+      `[terminalSessionPersistence] Snapshot for ${terminalId} exceeds cap (${bytes} > ${SESSION_SNAPSHOT_MAX_BYTES} bytes); skipping persist`
+    );
+    return;
+  }
 
   await mkdir(dir, { recursive: true });
   await resilientAtomicWriteFile(sessionPath, state, "utf8");


### PR DESCRIPTION
## Summary

- `flushSyncOnKill` and `flushEventDriven` were calling `getSerializedState()` instead of `serializeForPersistence()`, so the restore banner got baked into hibernation snapshots — after a few hibernate→restore cycles, banners stacked visibly at the top of the buffer
- Routes both paths through `serializeForPersistence()` (banner-aware, falls back to `addon.serialize()` when markers are invalid) and centralizes the byte-cap check in the callee, removing the redundant `Buffer.byteLength` walks at each call site
- Adds a `console.warn` in `persistSessionSnapshotSync` and `persistSessionSnapshotAsync` when a snapshot is skipped for exceeding `SESSION_SNAPSHOT_MAX_BYTES` — previously a silent failure with no signal that the session wouldn't restore

Resolves #7015

## Changes

- `SessionSnapshotter.ts`: `flushSyncOnKill` and `flushEventDriven` now call `host.serializeForPersistence()`; removed caller-side `Buffer.byteLength` cap checks from all three flush paths
- `terminalSessionPersistence.ts`: emit `console.warn` with terminal id, byte count, and cap before returning on size-cap skip
- `TerminalProcess.ts`: promoted `_serializeForPersistence` to `public serializeForPersistence` so tests can spy on the banner-aware path
- Tests updated across `SessionSnapshotter`, `terminalSessionPersistence`, `TerminalProcess.kill`, and `TerminalProcess.snapshot`

## Testing

100 tests passing across `SessionSnapshotter`, `terminalSessionPersistence`, `TerminalProcess.kill/lifecycle/snapshot/exit-cleanup`, and `TerminalSerializerService`. Typecheck, lint, and build all clean.