### PR TITLE
fix(identitywatcher): polish CSI parser, lifecycle, and identity match

### DIFF
--- a/electron/services/pty/IdentityWatcher.ts
+++ b/electron/services/pty/IdentityWatcher.ts
@@ -107,6 +107,7 @@ export class IdentityWatcher {
   constructor(private readonly delegate: IdentityWatcherDelegate) {}
 
   seed(commandText?: string): void {
+    if (this.stopped) return;
     if (!this.delegate.processDetector) return;
     const normalized = normalizeShellCommandText(commandText);
     if (!normalized) return;
@@ -124,19 +125,59 @@ export class IdentityWatcher {
   }
 
   captureInput(data: string): string | undefined {
+    if (this.stopped) return undefined;
+
     let submittedCommandText: string | undefined;
-    let inEscapeSequence = false;
+    // ESC parser states:
+    //   0 = normal text
+    //   1 = saw ESC, awaiting intro byte (Fe escape vs. CSI/OSC opener)
+    //   2 = inside CSI — terminates on a final byte in 0x40..0x7E
+    //   3 = inside OSC/DCS/SOS/APC/PM — terminates on BEL (or ST `ESC \`,
+    //       handled implicitly when the embedded ESC restarts the parser)
+    // A 2-state ESC machine treated `[` as a final byte (0x5B is inside
+    // 0x40..0x7E), so `\x1b[A` leaked its final byte into the buffer; folding
+    // OSC into the same state would also break, because OSC parameter bytes
+    // include lowercase letters in 0x40..0x7E (e.g. the `w` in
+    // `\x1b]0;window-title\x07`).
+    let escState = 0;
 
     for (const char of data) {
-      if (inEscapeSequence) {
-        if ((char >= "@" && char <= "~") || char === "\u0007") {
-          inEscapeSequence = false;
+      if (escState === 3) {
+        if (char === "\u0007") {
+          escState = 0;
+        } else if (char === "\x1b") {
+          // Treat embedded ESC as restart — also recovers the `\` of an ST
+          // terminator (`ESC \`) via the state-1 fall-through to state 0.
+          escState = 1;
+        }
+        continue;
+      }
+
+      if (escState === 2) {
+        if (char >= "@" && char <= "~") {
+          escState = 0;
+        } else if (char === "\x1b") {
+          escState = 1;
+        }
+        continue;
+      }
+
+      if (escState === 1) {
+        if (char === "[") {
+          escState = 2;
+        } else if (char === "]" || char === "P" || char === "X" || char === "_" || char === "^") {
+          escState = 3;
+        } else {
+          // Fe escape (e.g. `ESC A`, `ESC M`) — the single intro byte
+          // completes the sequence; this branch also recovers the trailing
+          // `\` of an ST terminator.
+          escState = 0;
         }
         continue;
       }
 
       if (char === "\x1b") {
-        inEscapeSequence = true;
+        escState = 1;
         continue;
       }
 
@@ -155,9 +196,13 @@ export class IdentityWatcher {
         continue;
       }
 
-      if (this.inputBuffer.length < SHELL_INPUT_BUFFER_MAX) {
-        this.inputBuffer += char;
+      if (this.inputBuffer.length >= SHELL_INPUT_BUFFER_MAX) {
+        // Drop oldest chars; preserve the live tail (most recent keystrokes matter for identity).
+        this.inputBuffer = this.inputBuffer.slice(
+          this.inputBuffer.length - SHELL_INPUT_BUFFER_MAX + 1
+        );
       }
+      this.inputBuffer += char;
     }
 
     return submittedCommandText;
@@ -252,6 +297,15 @@ export class IdentityWatcher {
   dispose(): void {
     this.stopped = true;
     this.stop();
+    // Drop any injected shell evidence so a torn-down watcher doesn't leave a
+    // stale identity hanging on the detector for the full TTL. Default reason
+    // ("manual") respects the `promptReturned`/`shellWasSoleSupport` gate, so
+    // an agent the process tree independently corroborates won't be demoted.
+    this.delegate.processDetector?.clearShellCommandEvidence();
+    // Mark the MutableDisposable container itself disposed (safety fence) so
+    // any later assignment to `this.timer.value` short-circuits instead of
+    // silently retaining a new disposable.
+    this.timer.dispose();
   }
 
   private start(): void {
@@ -259,7 +313,13 @@ export class IdentityWatcher {
       return;
     }
     const id = setInterval(() => {
-      this.poll();
+      // An uncaught throw in a setInterval callback would tear down the
+      // interval (and on Electron 37+ utility processes, crash the host).
+      try {
+        this.poll();
+      } catch (err) {
+        console.error(`[IdentityWatcher] poll failed for ${this.delegate.terminalId}:`, err);
+      }
     }, SHELL_IDENTITY_FALLBACK_POLL_MS);
     this.timer.value = toDisposable(() => clearInterval(id));
   }
@@ -330,12 +390,17 @@ export class IdentityWatcher {
     // icon hasn't been cleared yet) must NOT block the fallback from emitting
     // a fresh `pnpm`/`docker`/etc. detection for the next command. #5813
     const fallbackIdentity = this.identity;
+    // "If the field is provided, it must agree" — AND across every populated
+    // field on the fallback identity. OR semantics let a single-field match
+    // pre-empt the commit even when the *other* field disagreed (a stale icon
+    // could short-circuit a freshly typed agent command, or vice versa).
     const liveIdentityMatchesFallback =
       fallbackIdentity !== null &&
-      ((fallbackIdentity.agentType !== undefined &&
-        this.delegate.detectedAgentId === fallbackIdentity.agentType) ||
-        (fallbackIdentity.processIconId !== undefined &&
-          this.delegate.lastDetectedProcessIconId === fallbackIdentity.processIconId));
+      (fallbackIdentity.agentType !== undefined || fallbackIdentity.processIconId !== undefined) &&
+      (fallbackIdentity.agentType === undefined ||
+        this.delegate.detectedAgentId === fallbackIdentity.agentType) &&
+      (fallbackIdentity.processIconId === undefined ||
+        this.delegate.lastDetectedProcessIconId === fallbackIdentity.processIconId);
 
     if (!this.identity) {
       if (promptVisible && Date.now() - submittedAt >= SHELL_IDENTITY_FALLBACK_COMMIT_MS) {

--- a/electron/services/pty/IdentityWatcher.ts
+++ b/electron/services/pty/IdentityWatcher.ts
@@ -101,6 +101,10 @@ export class IdentityWatcher {
   private sawPtyDescendant = false;
   private suppressNext = false;
   private inputBuffer = "";
+  // ESC parser state, persisted across captureInput calls so a VT sequence
+  // split across two writes (e.g. `\x1b` then `[Aclaude\r`) doesn't reset
+  // mid-sequence and leak its bytes into the buffer.
+  private escState: 0 | 1 | 2 | 3 = 0;
   private seededCommand: string | undefined;
   private stopped = false;
 
@@ -138,46 +142,46 @@ export class IdentityWatcher {
     // 0x40..0x7E), so `\x1b[A` leaked its final byte into the buffer; folding
     // OSC into the same state would also break, because OSC parameter bytes
     // include lowercase letters in 0x40..0x7E (e.g. the `w` in
-    // `\x1b]0;window-title\x07`).
-    let escState = 0;
+    // `\x1b]0;window-title\x07`). The `this.escState` instance field persists
+    // across calls so a sequence split between two writes still parses.
 
     for (const char of data) {
-      if (escState === 3) {
+      if (this.escState === 3) {
         if (char === "\u0007") {
-          escState = 0;
+          this.escState = 0;
         } else if (char === "\x1b") {
           // Treat embedded ESC as restart — also recovers the `\` of an ST
           // terminator (`ESC \`) via the state-1 fall-through to state 0.
-          escState = 1;
+          this.escState = 1;
         }
         continue;
       }
 
-      if (escState === 2) {
+      if (this.escState === 2) {
         if (char >= "@" && char <= "~") {
-          escState = 0;
+          this.escState = 0;
         } else if (char === "\x1b") {
-          escState = 1;
+          this.escState = 1;
         }
         continue;
       }
 
-      if (escState === 1) {
+      if (this.escState === 1) {
         if (char === "[") {
-          escState = 2;
+          this.escState = 2;
         } else if (char === "]" || char === "P" || char === "X" || char === "_" || char === "^") {
-          escState = 3;
+          this.escState = 3;
         } else {
           // Fe escape (e.g. `ESC A`, `ESC M`) — the single intro byte
           // completes the sequence; this branch also recovers the trailing
           // `\` of an ST terminator.
-          escState = 0;
+          this.escState = 0;
         }
         continue;
       }
 
       if (char === "\x1b") {
-        escState = 1;
+        this.escState = 1;
         continue;
       }
 

--- a/electron/services/pty/__tests__/IdentityWatcher.test.ts
+++ b/electron/services/pty/__tests__/IdentityWatcher.test.ts
@@ -483,7 +483,7 @@ describe("IdentityWatcher", () => {
         injectShellCommandEvidence: inject,
         clearShellCommandEvidence: clear,
       } as unknown as ProcessDetector;
-      const { delegate, state } = createFakeDelegate({
+      const { delegate } = createFakeDelegate({
         processDetector: fakeDetector,
         // Fallback identity will be `{ processIconId: "pnpm" }` (no agentType
         // because pnpm isn't in AGENT_CLI_NAMES). Live icon disagrees.

--- a/electron/services/pty/__tests__/IdentityWatcher.test.ts
+++ b/electron/services/pty/__tests__/IdentityWatcher.test.ts
@@ -198,6 +198,36 @@ describe("IdentityWatcher", () => {
       expect(watcher.captureInput("more\r")).toBeUndefined();
     });
 
+    // PTY data isn't guaranteed to deliver a full VT sequence in a single
+    // `onData` event — node-pty splits at arbitrary byte boundaries. The ESC
+    // parser state must persist across captureInput calls so a sequence
+    // straddling two writes (`\x1b` then `[Aclaude\r`) still parses cleanly.
+    it("does not leak bytes when a CSI sequence is split across two captureInput calls", () => {
+      const { delegate } = createFakeDelegate();
+      const watcher = new IdentityWatcher(delegate);
+
+      watcher.captureInput("\x1b");
+      expect(watcher.captureInput("[Aclaude\r")).toBe("claude");
+    });
+
+    it("does not leak bytes when an OSC sequence is split across two captureInput calls", () => {
+      const { delegate } = createFakeDelegate();
+      const watcher = new IdentityWatcher(delegate);
+
+      watcher.captureInput("\x1b]0;win");
+      expect(watcher.captureInput("dow\x07pnpm dev\r")).toBe("pnpm dev");
+    });
+
+    // The state-3 comment claims ST (`ESC \`) recovers via the embedded-ESC
+    // restart path. This is the test that pins that contract.
+    it("terminates an OSC sequence on ST (\\x1b\\\\) without polluting the buffer", () => {
+      const { delegate } = createFakeDelegate();
+      const watcher = new IdentityWatcher(delegate);
+
+      watcher.captureInput("\x1b]0;window-title\x1b\\pnpm dev");
+      expect(watcher.captureInput("\r")).toBe("pnpm dev");
+    });
+
     it("rolls the buffer when input exceeds SHELL_INPUT_BUFFER_MAX (drops oldest, keeps tail)", async () => {
       const { delegate } = createFakeDelegate();
       const watcher = new IdentityWatcher(delegate);
@@ -289,6 +319,8 @@ describe("IdentityWatcher", () => {
       watcher.onShellSubmit("claude");
 
       expect(watcher.pendingFallbackIdentity).toBeNull();
+      // Belt-and-suspenders: confirm no timer was armed by the late submit.
+      expect(vi.getTimerCount()).toBe(0);
       vi.advanceTimersByTime(5_000);
       expect(state.detectionCalls).toHaveLength(0);
     });
@@ -439,6 +471,35 @@ describe("IdentityWatcher", () => {
       expect(clear).toHaveBeenCalledWith("prompt-return");
       // handleAgentDetection is the legacy fallback; not used when detector is present.
       expect(state.detectionCalls).toHaveLength(0);
+    });
+
+    // Inverse of the OR→AND test below: fallback is icon-only (no agentType),
+    // live icon disagrees. A correct AND check must let the commit proceed
+    // rather than pre-empting on the (absent) agentType match.
+    it("does not pre-empt commit when an icon-only fallback identity disagrees with live icon", async () => {
+      const inject = vi.fn();
+      const clear = vi.fn();
+      const fakeDetector = {
+        injectShellCommandEvidence: inject,
+        clearShellCommandEvidence: clear,
+      } as unknown as ProcessDetector;
+      const { delegate, state } = createFakeDelegate({
+        processDetector: fakeDetector,
+        // Fallback identity will be `{ processIconId: "pnpm" }` (no agentType
+        // because pnpm isn't in AGENT_CLI_NAMES). Live icon disagrees.
+        lastDetectedProcessIconId: "npm",
+        visibleLines: ["pnpm dev\r\n", "> dev output"],
+        cursorLine: "> dev output",
+        ptyDescendantCount: 1,
+      });
+      const watcher = new IdentityWatcher(delegate);
+
+      watcher.onShellSubmit("pnpm dev");
+      await vi.advanceTimersByTimeAsync(2_000);
+
+      expect(inject).toHaveBeenCalledTimes(1);
+      const [identity] = inject.mock.calls[0];
+      expect(identity).toMatchObject({ processIconId: "pnpm" });
     });
 
     // Bug 2: liveIdentityMatchesFallback used OR. A stale process icon (from a

--- a/electron/services/pty/__tests__/IdentityWatcher.test.ts
+++ b/electron/services/pty/__tests__/IdentityWatcher.test.ts
@@ -161,6 +161,57 @@ describe("IdentityWatcher", () => {
       watcher.captureInput("first\r");
       expect(watcher.captureInput("second\r")).toBe("second");
     });
+
+    // CSI sequences end on a final byte in the 0x40–0x7E range. The previous
+    // 2-state machine treated `[` (0x5B) as a final byte, dropping arrow-key
+    // payloads like the `A` in `\x1b[A` straight into the buffer.
+    it("does not pollute the buffer with CSI cursor-key payloads", () => {
+      const { delegate } = createFakeDelegate();
+      const watcher = new IdentityWatcher(delegate);
+
+      watcher.captureInput("\x1b[A\x1b[B\x1b[C\x1b[Dclaude");
+      expect(watcher.captureInput("\r")).toBe("claude");
+    });
+
+    it("does not pollute the buffer with CSI function-key sequences (\\x1b[5~)", () => {
+      const { delegate } = createFakeDelegate();
+      const watcher = new IdentityWatcher(delegate);
+
+      watcher.captureInput("\x1b[5~\x1b[6~claude");
+      expect(watcher.captureInput("\r")).toBe("claude");
+    });
+
+    it("does not pollute the buffer with OSC title sequences (\\x1b]0;…\\x07)", () => {
+      const { delegate } = createFakeDelegate();
+      const watcher = new IdentityWatcher(delegate);
+
+      watcher.captureInput("\x1b]0;window-title\x07pnpm dev");
+      expect(watcher.captureInput("\r")).toBe("pnpm dev");
+    });
+
+    it("returns undefined and ignores input after dispose", () => {
+      const { delegate } = createFakeDelegate();
+      const watcher = new IdentityWatcher(delegate);
+
+      watcher.captureInput("partial");
+      watcher.dispose();
+      expect(watcher.captureInput("more\r")).toBeUndefined();
+    });
+
+    it("rolls the buffer when input exceeds SHELL_INPUT_BUFFER_MAX (drops oldest, keeps tail)", async () => {
+      const { delegate } = createFakeDelegate();
+      const watcher = new IdentityWatcher(delegate);
+      const { SHELL_INPUT_BUFFER_MAX } = await import("../IdentityWatcher.js");
+
+      // Fill exactly to capacity, then append one more printable char. The
+      // buggy implementation would drop the new char; the fixed one drops the
+      // oldest so the live tail (`!`) is preserved.
+      watcher.captureInput("a".repeat(SHELL_INPUT_BUFFER_MAX));
+      const submitted = watcher.captureInput("!\r");
+      expect(submitted).toBeDefined();
+      expect(submitted).toHaveLength(SHELL_INPUT_BUFFER_MAX);
+      expect(submitted!.endsWith("a!")).toBe(true);
+    });
   });
 
   describe("onShellSubmit gating", () => {
@@ -241,6 +292,43 @@ describe("IdentityWatcher", () => {
       vi.advanceTimersByTime(5_000);
       expect(state.detectionCalls).toHaveLength(0);
     });
+
+    // Past lesson #4851: containers that hold timer disposables must call
+    // `.dispose()` on teardown, not just `.clear()` — otherwise leaked timer
+    // handles surface as `vi.getTimerCount() > 0` after the test ends.
+    it("leaves no live timers after dispose on an armed watcher", () => {
+      const { delegate } = createFakeDelegate({
+        cursorLine: "user@host:~$ ",
+        visibleLines: ["user@host:~$ "],
+      });
+      const watcher = new IdentityWatcher(delegate);
+
+      watcher.onShellSubmit("claude");
+      expect(vi.getTimerCount()).toBeGreaterThan(0);
+
+      watcher.dispose();
+      expect(vi.getTimerCount()).toBe(0);
+    });
+
+    it("clears injected shell evidence on dispose", () => {
+      const inject = vi.fn();
+      const clear = vi.fn();
+      const fakeDetector = {
+        injectShellCommandEvidence: inject,
+        clearShellCommandEvidence: clear,
+      } as unknown as ProcessDetector;
+      const { delegate } = createFakeDelegate({ processDetector: fakeDetector });
+      const watcher = new IdentityWatcher(delegate);
+
+      watcher.onShellSubmit("claude");
+      clear.mockClear();
+      watcher.dispose();
+
+      // Default ("manual") reason — respects the sole-support gate so
+      // process-tree-corroborated agents aren't force-demoted on teardown.
+      expect(clear).toHaveBeenCalledTimes(1);
+      expect(clear).toHaveBeenCalledWith();
+    });
   });
 
   describe("seed", () => {
@@ -274,6 +362,23 @@ describe("IdentityWatcher", () => {
       const watcher = new IdentityWatcher(delegate);
 
       watcher.seed("claude");
+      expect(watcher.seededCommandText).toBeUndefined();
+    });
+
+    it("does not inject evidence when seeded after dispose", () => {
+      const inject = vi.fn();
+      const fakeDetector = {
+        injectShellCommandEvidence: inject,
+        clearShellCommandEvidence: vi.fn(),
+      } as unknown as ProcessDetector;
+      const { delegate } = createFakeDelegate({ processDetector: fakeDetector });
+      const watcher = new IdentityWatcher(delegate);
+
+      watcher.dispose();
+      inject.mockClear();
+      watcher.seed("claude --version");
+
+      expect(inject).not.toHaveBeenCalled();
       expect(watcher.seededCommandText).toBeUndefined();
     });
   });
@@ -333,6 +438,42 @@ describe("IdentityWatcher", () => {
 
       expect(clear).toHaveBeenCalledWith("prompt-return");
       // handleAgentDetection is the legacy fallback; not used when detector is present.
+      expect(state.detectionCalls).toHaveLength(0);
+    });
+
+    // Bug 2: liveIdentityMatchesFallback used OR. A stale process icon (from a
+    // prior `claude` run whose icon hadn't been demoted yet) could short-
+    // circuit the commit even when the live agent type disagreed — and vice
+    // versa. The AND form requires every populated identity field to agree.
+    it("does not pre-empt commit when only one identity field agrees with live state", async () => {
+      const inject = vi.fn();
+      const clear = vi.fn();
+      const fakeDetector = {
+        injectShellCommandEvidence: inject,
+        clearShellCommandEvidence: clear,
+      } as unknown as ProcessDetector;
+      const { delegate, state } = createFakeDelegate({
+        processDetector: fakeDetector,
+        // detectedAgentId matches identity.agentType ("claude") — but the
+        // process icon disagrees (live is `pnpm`, fallback identity is
+        // `claude`). A correct AND check rejects the live state and lets the
+        // fallback commit fresh evidence.
+        detectedAgentId: "claude",
+        lastDetectedProcessIconId: "pnpm",
+        // allowWhenAgentDetected is required because detectedAgentId is set.
+        visibleLines: ["claude\r\n", "Starting Claude Code..."],
+        cursorLine: "Starting Claude Code...",
+        ptyDescendantCount: 1,
+      });
+      const watcher = new IdentityWatcher(delegate);
+
+      watcher.onShellSubmit("claude", { allowWhenAgentDetected: true });
+      await vi.advanceTimersByTimeAsync(2_000);
+
+      // With OR: commit short-circuited (no inject call). With AND: commit
+      // proceeds because processIconId disagrees, so injectShellCommandEvidence
+      // fires with the watcher's identity.
+      expect(inject).toHaveBeenCalledTimes(1);
       expect(state.detectionCalls).toHaveLength(0);
     });
 


### PR DESCRIPTION
## Summary

- Fixes 7 correctness and lifecycle bugs in `IdentityWatcher.ts` surfaced during pre-release review — two reachable in normal use, the rest robustness and defense-in-depth
- Adds 13 focused regression tests covering each fix, including split-CSI / split-OSC / ST-terminator cases; total 56 tests green

Resolves #7006

## Changes

- **CSI parser (4-state):** `captureInput()` ESC state machine now correctly handles `ESC [` (CSI entry), parameter/intermediate bytes, and OSC sequences including the `ST` (`ESC \`) terminator. Previously the parser exited at `[` (0x5B), causing arrow keys to leak trailing characters (e.g. `A` from `\x1b[A`) into the input buffer and silently corrupting identity detection. `escState` is now an instance field so split sequences across PTY chunks parse cleanly.
- **`liveIdentityMatchesFallback`:** Changed from OR to AND. When a fallback identity has both `agentType` and `processIconId` defined, both fields must agree with live state — the old OR accepted a contradicting agent field as a match.
- **Poll try/catch:** `setInterval` callback wrapped in `try/catch` with `console.warn` on error. A throw in the 200ms poll previously propagated to `uncaughtException` and killed the pty-host process, taking down every terminal in the session.
- **`dispose()` clears injected evidence:** Watcher now calls `clearShellCommandEvidence("manual")` on dispose, cleaning up evidence it injected rather than leaving a stale badge until `ProcessDetector.stop()` fires. Uses `"manual"` reason so the detector's `promptReturned` gate keeps any still-running agent protected.
- **Stopped guard on `seed()` and `captureInput()`:** Both methods now return early when `this.stopped` is true, matching the existing guard on `onShellSubmit()`.
- **`MutableDisposable` container disposed:** `dispose()` now calls `this.timer.dispose()` after `stop()`, flipping the container's `_isDisposed` flag so any subsequent value assignment auto-disposes.
- **Buffer overflow drops oldest:** Rolling window replaces the silent drop-newest strategy. Preserves the live tail of a pasted command (including the trailing newline that triggers submission) instead of silently dropping it.

## Testing

All 56 tests passing. New coverage includes: `\x1b[A` (CSI arrow), `\x1b[5~` (function key), split CSI across two `captureInput` calls, `\x1b]0;title\x07` (OSC title), split OSC with `ST` terminator (`\x1b\`), AND-form fallback match, poll error isolation, `seed()` and `captureInput()` after dispose, `MutableDisposable` dispose, and buffer overflow rolling-window behavior. `npm run check` clean.