### PR TITLE
fix(terminal): differentiate resource-exhaustion spawn errors

### DIFF
--- a/electron/ipc/errorHandlers.ts
+++ b/electron/ipc/errorHandlers.ts
@@ -202,6 +202,12 @@ function getRecoveryHint(error: unknown): string | undefined {
       return "Check your network connection and try again.";
     case "ECONNRESET":
       return "The connection was reset — try again in a moment.";
+    case "EMFILE":
+      return "Close some terminals to free up file descriptors and retry.";
+    case "ENOMEM":
+      return "Close other applications to free up memory and retry.";
+    case "ENXIO":
+      return "Close some terminals to free PTY resources and retry.";
     case "EBUSY":
       return "Close other applications using this file and retry.";
     case "EAGAIN":

--- a/electron/pty-host/spawnErrors.ts
+++ b/electron/pty-host/spawnErrors.ts
@@ -13,6 +13,16 @@ export function parseSpawnError(error: unknown): SpawnError {
       code = "ENOTDIR";
     } else if (nodeErr.code === "EIO") {
       code = "EIO";
+    } else if (nodeErr.code === "EMFILE") {
+      code = "EMFILE";
+    } else if (nodeErr.code === "EAGAIN") {
+      code = "EAGAIN";
+    } else if (nodeErr.code === "ENOMEM") {
+      code = "ENOMEM";
+    } else if (nodeErr.code === "ENXIO") {
+      code = "ENXIO";
+    } else if (nodeErr.code === "EBUSY") {
+      code = "EBUSY";
     }
 
     return {

--- a/electron/utils/errorTypes.ts
+++ b/electron/utils/errorTypes.ts
@@ -153,6 +153,8 @@ export function isNotFoundError(error: unknown): boolean {
 export function isTransientError(error: unknown): boolean {
   if (!error || typeof error !== "object") return false;
   const code = (error as NodeJS.ErrnoException).code;
+  // EMFILE, ENOMEM, ENXIO intentionally excluded — resource exhaustion
+  // requires user remediation before retry (close terminals, free memory).
   return ["EBUSY", "EAGAIN", "ETIMEDOUT", "ECONNRESET", "ENOTFOUND"].includes(code || "");
 }
 

--- a/shared/types/pty-host.ts
+++ b/shared/types/pty-host.ts
@@ -418,6 +418,11 @@ export type SpawnErrorCode =
   | "EACCES" // Permission denied
   | "ENOTDIR" // Working directory does not exist (or path component is not a directory)
   | "EIO" // I/O error (e.g., PTY allocation failure)
+  | "EMFILE" // Per-process file descriptor limit reached
+  | "EAGAIN" // Process limit reached (fork failed)
+  | "ENOMEM" // Out of memory at spawn time
+  | "ENXIO" // PTY pool exhausted on macOS
+  | "EBUSY" // Terminal device busy
   | "DISCONNECTED" // Terminal process no longer exists in backend (e.g., after project switch)
   | "PENDING_SPAWNS_CAPPED" // PtyClient.pendingSpawns admission cap hit (restart-storm guard)
   | "UNKNOWN"; // Unknown error

--- a/src/components/Terminal/SpawnErrorBanner.tsx
+++ b/src/components/Terminal/SpawnErrorBanner.tsx
@@ -23,6 +23,16 @@ function getErrorTitle(code: SpawnError["code"]): string {
       return "Invalid working directory";
     case "EIO":
       return "Couldn't allocate terminal";
+    case "EMFILE":
+      return "File descriptor limit reached";
+    case "EAGAIN":
+      return "Process limit reached";
+    case "ENOMEM":
+      return "Out of memory";
+    case "ENXIO":
+      return "PTY pool exhausted";
+    case "EBUSY":
+      return "Terminal device busy";
     case "DISCONNECTED":
       return "Terminal disconnected";
     default:
@@ -43,6 +53,16 @@ function getErrorDescription(error: SpawnError, cwd?: string): string {
       return `The working directory isn't valid: ${cwd || "(unknown)"}`;
     case "EIO":
       return "Couldn't allocate a terminal session. The system may be running low on resources.";
+    case "EMFILE":
+      return "The per-process file descriptor limit was reached. Try closing some terminals to free up descriptors.";
+    case "EAGAIN":
+      return "The system process limit was hit (fork failed). Wait a moment and retry, or close some terminals.";
+    case "ENOMEM":
+      return "The system is out of memory. Try closing other applications to free up memory.";
+    case "ENXIO":
+      return "The pseudo-terminal pool is exhausted. Try closing some terminals and retrying.";
+    case "EBUSY":
+      return "The terminal device is busy. Retry or close the conflicting terminal.";
     case "DISCONNECTED":
       return "The terminal process is no longer running.";
     default:


### PR DESCRIPTION
## Summary
A small, tightly scoped fix that gives users specific messages and recovery hints when terminals fail from resource exhaustion, instead of a generic "couldn't start terminal" message.

Resolves #7013.

## Changes
- Added `EMFILE`, `EAGAIN`, `ENOMEM`, `ENXIO`, and `EBUSY` to the `SpawnErrorCode` union in `shared/types/pty-host.ts`
- Parsed these codes from Node.js errno exceptions in `electron/pty-host/spawnErrors.ts` so they don't fall through to the `UNKNOWN` bucket
- Added user-facing error titles and descriptions in `src/components/Terminal/SpawnErrorBanner.tsx` with recovery-specific guidance (close terminals, free memory, retry)
- Added recovery hint strings in `electron/ipc/errorHandlers.ts` for the broader error-handling path
- Excluded resource-exhaustion codes (`EMFILE`, `ENOMEM`, `ENXIO`) from `isTransientError` in `electron/utils/errorTypes.ts` since they need user remediation before a retry makes sense

## Testing
Manual verification that each error code routes to the correct title, description, and recovery hint. Typecheck passes clean.