### PR TITLE
feat(terminal): add schema-version header to .restore files

### DIFF
--- a/electron/services/pty/__tests__/terminalSessionPersistence.test.ts
+++ b/electron/services/pty/__tests__/terminalSessionPersistence.test.ts
@@ -81,8 +81,8 @@ describe("terminalSessionPersistence", () => {
     const syncPath = path.join(sessionDir, "term-rt-sync.restore");
     const asyncPath = path.join(sessionDir, "term-rt-async.restore");
 
-    expect(fs.readFileSync(syncPath, "utf8")).toBe("sync payload");
-    expect(fs.readFileSync(asyncPath, "utf8")).toBe("async payload");
+    expect(fs.readFileSync(syncPath, "utf8")).toBe("DAINTREE_SESSION_v1\nsync payload");
+    expect(fs.readFileSync(asyncPath, "utf8")).toBe("DAINTREE_SESSION_v1\nasync payload");
 
     // The atomic helpers must not leave temp files behind
     const stragglers = fs.readdirSync(sessionDir).filter((name) => name.endsWith(".tmp"));
@@ -92,6 +92,62 @@ describe("terminalSessionPersistence", () => {
     const result = restoreSessionFromFile(headless as never, "term-rt-sync");
     expect(result.restored).toBe(true);
     expect(headless.write).toHaveBeenCalledWith("sync payload");
+  });
+
+  it("restores a headerless legacy snapshot as v0", async () => {
+    const sessionDir = path.join(userDataDir, "terminal-sessions");
+    await fsp.mkdir(sessionDir, { recursive: true });
+
+    const legacyPath = path.join(sessionDir, "term-legacy.restore");
+    await fsp.writeFile(legacyPath, "legacy content", "utf8");
+
+    const headless = createMockHeadless();
+    const result = restoreSessionFromFile(headless as never, "term-legacy");
+
+    expect(result.restored).toBe(true);
+    expect(headless.write).toHaveBeenCalledWith("legacy content");
+  });
+
+  it("rejects a future schema version header", async () => {
+    const sessionDir = path.join(userDataDir, "terminal-sessions");
+    await fsp.mkdir(sessionDir, { recursive: true });
+
+    const futurePath = path.join(sessionDir, "term-future.restore");
+    await fsp.writeFile(futurePath, "DAINTREE_SESSION_v2\ncontent", "utf8");
+
+    const headless = createMockHeadless();
+    const result = restoreSessionFromFile(headless as never, "term-future");
+
+    expect(result.restored).toBe(false);
+    expect(headless.write).not.toHaveBeenCalled();
+  });
+
+  it("rejects a truncated header prefix", async () => {
+    const sessionDir = path.join(userDataDir, "terminal-sessions");
+    await fsp.mkdir(sessionDir, { recursive: true });
+
+    const truncatedPath = path.join(sessionDir, "term-truncated.restore");
+    await fsp.writeFile(truncatedPath, "DAINTREE_SES", "utf8");
+
+    const headless = createMockHeadless();
+    const result = restoreSessionFromFile(headless as never, "term-truncated");
+
+    expect(result.restored).toBe(false);
+    expect(headless.write).not.toHaveBeenCalled();
+  });
+
+  it("restores empty file as empty content", async () => {
+    const sessionDir = path.join(userDataDir, "terminal-sessions");
+    await fsp.mkdir(sessionDir, { recursive: true });
+
+    const emptyPath = path.join(sessionDir, "term-empty.restore");
+    await fsp.writeFile(emptyPath, "", "utf8");
+
+    const headless = createMockHeadless();
+    const result = restoreSessionFromFile(headless as never, "term-empty");
+
+    expect(result.restored).toBe(true);
+    expect(headless.write).toHaveBeenCalledWith("");
   });
 
   it("restores valid snapshot and injects separator banner", async () => {

--- a/electron/services/pty/terminalSessionPersistence.ts
+++ b/electron/services/pty/terminalSessionPersistence.ts
@@ -30,6 +30,28 @@ export const SESSION_EVICTION_MAX_BYTES = 100 * 1024 * 1024; // 100 MB
 const EVICTION_TTL_BUFFER_MS = 30_000; // 30s clock-skew safety buffer
 const STAT_CHUNK_SIZE = 10;
 
+const SESSION_HEADER = "DAINTREE_SESSION_v1\n";
+const SESSION_HEADER_BYTES = Buffer.byteLength(SESSION_HEADER, "utf8");
+
+function extractSessionContent(raw: string): string | null {
+  if (!raw) return raw;
+
+  if (raw.startsWith(SESSION_HEADER)) {
+    return raw.slice(SESSION_HEADER_BYTES);
+  }
+
+  if (raw.startsWith("DAINTREE_SESSION_")) {
+    console.warn(`[terminalSessionPersistence] Unknown session file version, rejecting restore`);
+    return null;
+  }
+
+  if (raw.length < SESSION_HEADER_BYTES && "DAINTREE_SESSION_".startsWith(raw)) {
+    return null;
+  }
+
+  return raw;
+}
+
 export function getSessionDir(): string | null {
   const userData = process.env.DAINTREE_USER_DATA;
   if (!userData) return null;
@@ -79,7 +101,9 @@ export function restoreSessionFromFile(
 
   try {
     if (!existsSync(sessionPath)) return NULL_RESTORE;
-    const content = readFileSync(sessionPath, "utf8");
+    const raw = readFileSync(sessionPath, "utf8");
+    const content = extractSessionContent(raw);
+    if (content === null) return NULL_RESTORE;
     if (Buffer.byteLength(content, "utf8") > SESSION_SNAPSHOT_MAX_BYTES) {
       return NULL_RESTORE;
     }
@@ -133,7 +157,7 @@ export function persistSessionSnapshotSync(terminalId: string, state: string): v
   if (Buffer.byteLength(state, "utf8") > SESSION_SNAPSHOT_MAX_BYTES) return;
 
   mkdirSync(dir, { recursive: true });
-  resilientAtomicWriteFileSync(sessionPath, state, "utf8");
+  resilientAtomicWriteFileSync(sessionPath, SESSION_HEADER + state, "utf8");
 }
 
 export async function persistSessionSnapshotAsync(
@@ -146,7 +170,7 @@ export async function persistSessionSnapshotAsync(
   if (Buffer.byteLength(state, "utf8") > SESSION_SNAPSHOT_MAX_BYTES) return;
 
   await mkdir(dir, { recursive: true });
-  await resilientAtomicWriteFile(sessionPath, state, "utf8");
+  await resilientAtomicWriteFile(sessionPath, SESSION_HEADER + state, "utf8");
 }
 
 export async function deleteSessionFile(terminalId: string): Promise<void> {


### PR DESCRIPTION
## Summary
- Writes a `DAINTREE_SESSION_v1\n` header on every terminal session persist so format changes from `@xterm/addon-serialize` won't silently produce scrambled restores.
- Headerless legacy files restore as v0 for backward compatibility with existing sessions in the wild.
- Unknown future versions, truncated prefixes, and empty files are all handled cleanly -- nothing slips through.

Resolves #7016.

## Changes
- `electron/services/pty/terminalSessionPersistence.ts` -- prepends `DAINTREE_SESSION_v1\n` on persist (both sync and async paths), strips it on restore with an `extractSessionContent` parser that rejects unknown versions and truncated prefixes.
- `electron/services/pty/__tests__/terminalSessionPersistence.test.ts` -- coverage for header write, legacy v0 fallback, future version rejection, truncated prefix rejection, and empty file restore.

## Testing
- Unit tests cover all parser branches: valid header, legacy headerless, future version, truncated prefix, and empty file.
- Existing persist/restore tests updated to expect the new header in the file payload.