### PR TITLE
fix(pty-host): fsync emergency log writes, add 1MB size cap

### DIFF
--- a/electron/pty-host/__tests__/emergencyLog.test.ts
+++ b/electron/pty-host/__tests__/emergencyLog.test.ts
@@ -104,6 +104,7 @@ describe("pty-host emergencyLog", () => {
       expect(content).toContain("[UNCAUGHT_EXCEPTION]");
       expect(content).toContain('"name":"TestError"');
       expect(content).toContain('"message":"test error"');
+      expect(content).toContain('"stack":"TestError: test error');
     });
 
     it("scrubs known secret sigils from error.message and stack", () => {

--- a/electron/pty-host/__tests__/emergencyLog.test.ts
+++ b/electron/pty-host/__tests__/emergencyLog.test.ts
@@ -28,6 +28,15 @@ describe("pty-host emergencyLog", () => {
     it("returns path under DAINTREE_USER_DATA/logs", () => {
       expect(getEmergencyLogPath()).toBe(path.join(tmpDir, "logs", "pty-host.log"));
     });
+
+    it("returns path under cwd/logs when DAINTREE_USER_DATA is unset", () => {
+      delete process.env.DAINTREE_USER_DATA;
+      try {
+        expect(getEmergencyLogPath()).toBe(path.join(process.cwd(), "logs", "pty-host.log"));
+      } finally {
+        process.env.DAINTREE_USER_DATA = tmpDir;
+      }
+    });
   });
 
   describe("appendEmergencyLog", () => {
@@ -42,6 +51,41 @@ describe("pty-host emergencyLog", () => {
       appendEmergencyLog("b\n");
       const content = fs.readFileSync(getEmergencyLogPath(), "utf8");
       expect(content).toBe("a\nb\n");
+    });
+
+    it("appends when file is under the size limit", () => {
+      const logFile = getEmergencyLogPath();
+      const padding = "x".repeat(1024 * 1024 - 200);
+      fs.mkdirSync(path.dirname(logFile), { recursive: true });
+      fs.writeFileSync(logFile, padding, "utf8");
+      const statBefore = fs.statSync(logFile);
+      expect(statBefore.size).toBe(1024 * 1024 - 200);
+
+      appendEmergencyLog("new entry\n");
+      const content = fs.readFileSync(logFile, "utf8");
+      expect(content).toBe(padding + "new entry\n");
+    });
+
+    it("truncates and replaces when file is over the size limit", () => {
+      const logFile = getEmergencyLogPath();
+      const padding = "y".repeat(1024 * 1024 + 100);
+      fs.mkdirSync(path.dirname(logFile), { recursive: true });
+      fs.writeFileSync(logFile, padding, "utf8");
+
+      appendEmergencyLog("fresh start\n");
+      const content = fs.readFileSync(logFile, "utf8");
+      expect(content).toBe("fresh start\n");
+    });
+
+    it("appends when file is exactly at the size limit", () => {
+      const logFile = getEmergencyLogPath();
+      const padding = "z".repeat(1024 * 1024);
+      fs.mkdirSync(path.dirname(logFile), { recursive: true });
+      fs.writeFileSync(logFile, padding, "utf8");
+
+      appendEmergencyLog("boundary append\n");
+      const content = fs.readFileSync(logFile, "utf8");
+      expect(content).toBe(padding + "boundary append\n");
     });
 
     it("does not throw when fs operations fail", () => {

--- a/electron/pty-host/emergencyLog.ts
+++ b/electron/pty-host/emergencyLog.ts
@@ -36,10 +36,15 @@ export function emergencyLogFatal(kind: string, error: unknown): void {
   const pid = process.pid;
   const uptimeMs = Math.round(process.uptime() * 1000);
   const memory = process.memoryUsage();
-  const details =
-    error instanceof Error
-      ? { name: error.name, message: error.message, stack: error.stack }
-      : { message: String(error) };
+  let details: unknown;
+  try {
+    details =
+      error instanceof Error
+        ? { name: error.name, message: error.message, stack: error.stack }
+        : { message: String(error) };
+  } catch {
+    details = { message: "[unable to serialize error]" };
+  }
 
   appendEmergencyLog(
     scrubSecrets(

--- a/electron/pty-host/emergencyLog.ts
+++ b/electron/pty-host/emergencyLog.ts
@@ -1,14 +1,12 @@
-import { appendFileSync, mkdirSync } from "node:fs";
+import { appendFileSync, mkdirSync, statSync, writeFileSync } from "node:fs";
 import path from "node:path";
 import { scrubSecrets } from "../utils/secretScrubber.js";
 
+const MAX_LOG_SIZE = 1024 * 1024; // 1MB
+
 export function getEmergencyLogPath(): string {
   const userData = process.env.DAINTREE_USER_DATA;
-  const logDir = userData
-    ? path.join(userData, "logs")
-    : process.env.NODE_ENV === "development"
-      ? path.join(process.cwd(), "logs")
-      : path.join(process.cwd(), "logs");
+  const logDir = userData ? path.join(userData, "logs") : path.join(process.cwd(), "logs");
   return path.join(logDir, "pty-host.log");
 }
 
@@ -16,7 +14,18 @@ export function appendEmergencyLog(lines: string): void {
   try {
     const logFile = getEmergencyLogPath();
     mkdirSync(path.dirname(logFile), { recursive: true });
-    appendFileSync(logFile, lines, "utf8");
+
+    try {
+      const stat = statSync(logFile);
+      if (stat.size > MAX_LOG_SIZE) {
+        writeFileSync(logFile, lines, { encoding: "utf8", flush: true });
+        return;
+      }
+    } catch {
+      // File doesn't exist yet — will be created by appendFileSync
+    }
+
+    appendFileSync(logFile, lines, { encoding: "utf8", flush: true });
   } catch {
     // best-effort only
   }


### PR DESCRIPTION
## Summary
- Added `flush: true` to `appendFileSync` and `writeFileSync` in the pty-host emergency log, so writes survive a fatal crash instead of sitting in the OS page cache.
- Added a 1MB size cap with truncation to match the existing main-process emergency log writer.
- Removed a dead inner ternary in `getEmergencyLogPath` where both branches returned the same value.

Resolves #7018

## Changes
- `electron/pty-host/emergencyLog.ts` — fsync on writes, 1MB cap with truncation on overflow, collapsed dead ternary
- `electron/pty-host/__tests__/emergencyLog.test.ts` — tests for path resolution, append, size-boundary truncation, error resilience, fatal logging with stack assertion, and secret scrubbing

## Testing
- New unit tests pass in `emergencyLog.test.ts`
- Run with `npx vitest run electron/pty-host/__tests__/emergencyLog.test.ts`