### PR TITLE
chore(pty): remove dead regex and stale comment, fix shared-reference bug

### DIFF
--- a/electron/services/pty/AgentPatternDetector.ts
+++ b/electron/services/pty/AgentPatternDetector.ts
@@ -79,7 +79,6 @@ export function stripAnsi(text: string): string {
     .replace(/\x1b[=>]/g, "") // Keypad mode
     .replace(/\x1b[78]/g, "") // Save/restore cursor
     .replace(/\x1b[DME]/g, "") // Line control
-    .replace(/\x1b\[[\d;]*m/g, "") // SGR (colors/styles) - catch-all
     .replace(/\x1b[@-Z\\-_]/g, ""); // 7-bit C1 escapes
   /* eslint-enable no-control-regex */
 }

--- a/electron/services/pty/OutputVolumeDetector.ts
+++ b/electron/services/pty/OutputVolumeDetector.ts
@@ -48,8 +48,7 @@ export class OutputVolumeDetector {
 
   // Time after a fire-event that the consumer should still consider output
   // "recent" — derived as the time it takes to drain a full bucket from the
-  // activation threshold. Replaces the old windowMs getter on line-672 of
-  // ActivityMonitor's hasRecentOutputActivity check.
+  // activation threshold. Consumed by ActivityMonitor.runPollingCycle.
   get recencyWindowMs(): number {
     return this.activationThreshold / this.leakRatePerMs;
   }

--- a/electron/services/pty/SynchronizedFrameDetector.ts
+++ b/electron/services/pty/SynchronizedFrameDetector.ts
@@ -144,7 +144,7 @@ export class SynchronizedFrameDetector {
     for (let y = startY; y < viewportBottom; y++) {
       const line = buffer.getLine(y);
       if (!line) {
-        rows.push(new Array<FrameCell>(terminal.cols).fill({ code: 0, width: 1 }));
+        rows.push(Array.from({ length: terminal.cols }, () => ({ code: 0, width: 1 })));
         continue;
       }
       const cols: FrameCell[] = new Array(terminal.cols);


### PR DESCRIPTION
## Summary
- Removed a dead SGR regex in `stripAnsi` that was unreachable — the catch-all CSI regex earlier in the chain already strips every SGR sequence.
- Fixed a shared-reference bug in `SynchronizedFrameDetector` where `Array.fill` placed the same object reference into every slot, which would silently corrupt all cells if anyone wrote through them later.
- Updated a stale line-number comment in `OutputVolumeDetector` that referenced code that moved months ago.

Resolves #7022

## Changes
- `electron/services/pty/AgentPatternDetector.ts` — removed unreachable SGR regex from `stripAnsi`
- `electron/services/pty/SynchronizedFrameDetector.ts` — replaced `Array.fill` shared-reference with `Array.from` factory per slot
- `electron/services/pty/OutputVolumeDetector.ts` — updated stale line-number comment to reference current consumer

## Testing
No behavior change, pure cleanup. All checks pass.