### PR TITLE
fix(pty-host): close three ResourceGovernor correctness gaps

### DIFF
--- a/electron/pty-host/ResourceGovernor.ts
+++ b/electron/pty-host/ResourceGovernor.ts
@@ -188,7 +188,9 @@ export class ResourceGovernor {
     this.deps.sendEvent({
       type: "host-throttled",
       isThrottled: false,
+      reason: `High memory usage: ${Math.round(currentUsageMb)}MB (${percent.toFixed(1)}%)`,
       duration,
+      forced,
       timestamp: Date.now(),
     });
   }
@@ -197,6 +199,13 @@ export class ResourceGovernor {
     if (this.checkInterval) {
       clearInterval(this.checkInterval);
       this.checkInterval = null;
+    }
+    if (this.isThrottling) {
+      for (const id of this.deps.getTerminalIds()) {
+        this.deps.getPauseCoordinator(id)?.resume("resource-governor");
+      }
+      this.isThrottling = false;
+      this.throttleStartTime = 0;
     }
     this.killedPids.clear();
     console.log("[ResourceGovernor] Disposed");

--- a/electron/pty-host/__tests__/ResourceGovernor.test.ts
+++ b/electron/pty-host/__tests__/ResourceGovernor.test.ts
@@ -188,6 +188,126 @@ describe("ResourceGovernor", () => {
 
       governor.dispose();
     });
+
+    it("emits forced: false on threshold-cleared resume", () => {
+      const { coordinator } = createMockCoordinator();
+      const deps = createMockDeps({
+        getTerminalIds: vi.fn().mockReturnValue(["t1"]),
+        getPauseCoordinator: vi.fn().mockReturnValue(coordinator),
+      });
+
+      vi.spyOn(process, "memoryUsage").mockReturnValue({
+        heapUsed: 900 * 1024 * 1024,
+        rss: 1024 * 1024 * 1024,
+        external: 0,
+        arrayBuffers: 0,
+      } as ReturnType<typeof process.memoryUsage>);
+
+      const governor = new ResourceGovernor(deps);
+      governor.start();
+      vi.advanceTimersByTime(2000);
+
+      // Drop memory below resume threshold
+      vi.spyOn(process, "memoryUsage").mockReturnValue({
+        heapUsed: 500 * 1024 * 1024,
+        rss: 1024 * 1024 * 1024,
+        external: 0,
+        arrayBuffers: 0,
+      } as ReturnType<typeof process.memoryUsage>);
+      vi.advanceTimersByTime(2000);
+
+      const event = (deps.sendEvent as ReturnType<typeof vi.fn>).mock.calls.find(
+        (c: unknown[]) =>
+          (c[0] as Record<string, unknown>)?.type === "host-throttled" &&
+          (c[0] as Record<string, unknown>)?.isThrottled === false
+      )?.[0] as Record<string, unknown> | undefined;
+
+      expect(event).toBeDefined();
+      expect(event?.forced).toBe(false);
+      expect(event?.reason).toContain("High memory usage");
+      expect(event?.duration).toBeGreaterThan(0);
+
+      governor.dispose();
+    });
+
+    it("emits forced: true on force-resume timeout", () => {
+      const { coordinator } = createMockCoordinator();
+      const deps = createMockDeps({
+        getTerminalIds: vi.fn().mockReturnValue(["t1"]),
+        getPauseCoordinator: vi.fn().mockReturnValue(coordinator),
+      });
+
+      vi.spyOn(process, "memoryUsage").mockReturnValue({
+        heapUsed: 900 * 1024 * 1024,
+        rss: 1024 * 1024 * 1024,
+        external: 0,
+        arrayBuffers: 0,
+      } as ReturnType<typeof process.memoryUsage>);
+
+      const governor = new ResourceGovernor(deps);
+      governor.start();
+      vi.advanceTimersByTime(2000);
+
+      // Keep memory above resume threshold past force-resume timeout
+      vi.advanceTimersByTime(12000);
+
+      const event = (deps.sendEvent as ReturnType<typeof vi.fn>).mock.calls.find(
+        (c: unknown[]) =>
+          (c[0] as Record<string, unknown>)?.type === "host-throttled" &&
+          (c[0] as Record<string, unknown>)?.isThrottled === false
+      )?.[0] as Record<string, unknown> | undefined;
+
+      expect(event).toBeDefined();
+      expect(event?.forced).toBe(true);
+      expect(event?.reason).toContain("High memory usage");
+
+      governor.dispose();
+    });
+  });
+
+  describe("dispose", () => {
+    it("releases resource-governor token from coordinators when throttling", () => {
+      const { coordinator, raw } = createMockCoordinator();
+      const deps = createMockDeps({
+        getTerminalIds: vi.fn().mockReturnValue(["t1"]),
+        getPauseCoordinator: vi.fn().mockReturnValue(coordinator),
+      });
+
+      vi.spyOn(process, "memoryUsage").mockReturnValue({
+        heapUsed: 900 * 1024 * 1024,
+        rss: 1024 * 1024 * 1024,
+        external: 0,
+        arrayBuffers: 0,
+      } as ReturnType<typeof process.memoryUsage>);
+
+      const governor = new ResourceGovernor(deps);
+      governor.start();
+      vi.advanceTimersByTime(2000);
+
+      expect(coordinator.hasToken("resource-governor")).toBe(true);
+      raw.resume.mockClear();
+
+      governor.dispose();
+
+      expect(coordinator.hasToken("resource-governor")).toBe(false);
+      expect(raw.resume).toHaveBeenCalled();
+    });
+
+    it("does not throw when not throttling", () => {
+      const deps = createMockDeps();
+      const governor = new ResourceGovernor(deps);
+      governor.start();
+
+      expect(() => governor.dispose()).not.toThrow();
+    });
+
+    it("double dispose does not throw", () => {
+      const deps = createMockDeps();
+      const governor = new ResourceGovernor(deps);
+      governor.start();
+      governor.dispose();
+      expect(() => governor.dispose()).not.toThrow();
+    });
   });
 
   describe("coordination with other managers", () => {

--- a/electron/pty-host/handlers/__tests__/lifecycle.test.ts
+++ b/electron/pty-host/handlers/__tests__/lifecycle.test.ts
@@ -1,0 +1,225 @@
+import { describe, it, expect, vi, beforeEach, afterEach } from "vitest";
+import { createPtyHostMessageDispatcher } from "../index.js";
+import type { HostContext } from "../types.js";
+
+function makeCtx(overrides: Partial<HostContext> = {}): HostContext {
+  const ptyManager = {
+    getTerminal: vi.fn(() => undefined),
+    getAvailableTerminals: vi.fn(() => []),
+    getTerminalsByState: vi.fn(() => []),
+    getAll: vi.fn(() => []),
+    getTerminalsForProject: vi.fn(() => []),
+    getTerminalInfo: vi.fn(() => ({})),
+    getAllTerminalSnapshots: vi.fn(() => []),
+    getSerializedStateAsync: vi.fn(async () => "state-payload"),
+    getSerializedState: vi.fn(() => "state-payload"),
+    isInTrash: vi.fn(() => false),
+    getActivityTier: vi.fn(() => "active" as const),
+    setAnalysisEnabled: vi.fn(),
+    setSabMode: vi.fn(),
+    isSabMode: vi.fn(() => false),
+    write: vi.fn(),
+    submit: vi.fn(),
+    resize: vi.fn(),
+    spawn: vi.fn(),
+    kill: vi.fn(),
+    trash: vi.fn(),
+    restore: vi.fn(),
+    killByProject: vi.fn(() => 0),
+    gracefulKill: vi.fn(async () => undefined),
+    gracefulKillByProject: vi.fn(async () => []),
+    getProjectStats: vi.fn(() => ({
+      terminalCount: 0,
+      processIds: [],
+      terminalTypes: [],
+    })),
+    markChecked: vi.fn(),
+    updateObservedTitle: vi.fn(),
+    transitionState: vi.fn(() => true),
+    trimScrollback: vi.fn(),
+    setActivityMonitorTier: vi.fn(),
+    setProcessTreeCache: vi.fn(),
+    setPtyPool: vi.fn(),
+    acknowledgeData: vi.fn(),
+    flushAgentSnapshot: vi.fn(),
+    tryWrite: vi.fn(() => ({ ok: true })),
+    on: vi.fn(),
+  } as unknown as HostContext["ptyManager"];
+
+  const resourceGovernor = {
+    trackKilledPid: vi.fn(),
+  } as unknown as HostContext["resourceGovernor"];
+
+  return {
+    ptyManager,
+    processTreeCache: { setPollInterval: vi.fn() } as unknown as HostContext["processTreeCache"],
+    terminalResourceMonitor: {
+      setEnabled: vi.fn(),
+    } as unknown as HostContext["terminalResourceMonitor"],
+    backpressureManager: {
+      isPaused: vi.fn(() => false),
+      hasPendingSegments: vi.fn(() => false),
+      setActivityTier: vi.fn(),
+      clearSuspended: vi.fn(),
+      clearPendingVisual: vi.fn(),
+      getPausedInterval: vi.fn(() => undefined),
+      deletePausedInterval: vi.fn(),
+      getPauseStartTime: vi.fn(() => undefined),
+      deletePauseStartTime: vi.fn(),
+      emitTerminalStatus: vi.fn(),
+      emitReliabilityMetric: vi.fn(),
+    } as unknown as HostContext["backpressureManager"],
+    ipcQueueManager: {
+      removeBytes: vi.fn(),
+      tryResume: vi.fn(),
+      clearQueue: vi.fn(),
+    } as unknown as HostContext["ipcQueueManager"],
+    resourceGovernor,
+    packetFramer: {} as HostContext["packetFramer"],
+    pauseCoordinators: new Map(),
+    rendererConnections: new Map(),
+    windowProjectMap: new Map(),
+    ipcDataMirrorTerminals: new Set(),
+    visualBuffers: [],
+    visualSignalView: null,
+    analysisBuffer: null,
+    ptyPool: null,
+    sendEvent: vi.fn(),
+    getPauseCoordinator: vi.fn(),
+    getOrCreatePauseCoordinator: vi.fn(),
+    disconnectWindow: vi.fn(),
+    recomputeActivityTiers: vi.fn(),
+    tryReplayAndResume: vi.fn(),
+    resumePausedTerminal: vi.fn(),
+    createPortQueueManager: vi.fn(),
+    ...overrides,
+  };
+}
+
+function termInfo(pid?: number) {
+  return { ptyProcess: { pid } };
+}
+
+describe("lifecycle kill handlers — trackKilledPid", () => {
+  beforeEach(() => {
+    vi.spyOn(console, "error").mockImplementation(() => {});
+    vi.spyOn(console, "warn").mockImplementation(() => {});
+  });
+
+  afterEach(() => {
+    vi.restoreAllMocks();
+  });
+
+  it("kill tracks PID", () => {
+    const ctx = makeCtx();
+    (ctx.ptyManager.getTerminal as ReturnType<typeof vi.fn>).mockReturnValue(termInfo(1234));
+    const dispatch = createPtyHostMessageDispatcher(ctx);
+
+    dispatch({ type: "kill", id: "t1", reason: "test" });
+
+    expect(ctx.ptyManager.kill).toHaveBeenCalledWith("t1", "test");
+    expect(ctx.resourceGovernor.trackKilledPid).toHaveBeenCalledWith(1234);
+  });
+
+  it("kill does not track when PID is undefined", () => {
+    const ctx = makeCtx();
+    (ctx.ptyManager.getTerminal as ReturnType<typeof vi.fn>).mockReturnValue(termInfo());
+    const dispatch = createPtyHostMessageDispatcher(ctx);
+
+    dispatch({ type: "kill", id: "t1", reason: "test" });
+
+    expect(ctx.ptyManager.kill).toHaveBeenCalledWith("t1", "test");
+    expect(ctx.resourceGovernor.trackKilledPid).not.toHaveBeenCalled();
+  });
+
+  it("kill-by-project tracks all PIDs", () => {
+    const ctx = makeCtx();
+    (ctx.ptyManager.getTerminalsForProject as ReturnType<typeof vi.fn>).mockReturnValue([
+      "t1",
+      "t2",
+      "t3",
+    ]);
+    (ctx.ptyManager.getTerminal as ReturnType<typeof vi.fn>)
+      .mockReturnValueOnce(termInfo(100))
+      .mockReturnValueOnce(termInfo(200))
+      .mockReturnValueOnce(termInfo()); // t3 has no PID
+    (ctx.ptyManager.killByProject as ReturnType<typeof vi.fn>).mockReturnValue(3);
+    const dispatch = createPtyHostMessageDispatcher(ctx);
+
+    dispatch({ type: "kill-by-project", projectId: "proj-1", requestId: "r1" });
+
+    expect(ctx.ptyManager.killByProject).toHaveBeenCalledWith("proj-1");
+    expect(ctx.resourceGovernor.trackKilledPid).toHaveBeenCalledTimes(2);
+    expect(ctx.resourceGovernor.trackKilledPid).toHaveBeenCalledWith(100);
+    expect(ctx.resourceGovernor.trackKilledPid).toHaveBeenCalledWith(200);
+  });
+
+  it("kill-by-project handles empty project", () => {
+    const ctx = makeCtx();
+    (ctx.ptyManager.getTerminalsForProject as ReturnType<typeof vi.fn>).mockReturnValue([]);
+    (ctx.ptyManager.killByProject as ReturnType<typeof vi.fn>).mockReturnValue(0);
+    const dispatch = createPtyHostMessageDispatcher(ctx);
+
+    dispatch({ type: "kill-by-project", projectId: "empty-proj", requestId: "r1" });
+
+    expect(ctx.ptyManager.killByProject).toHaveBeenCalledWith("empty-proj");
+    expect(ctx.resourceGovernor.trackKilledPid).not.toHaveBeenCalled();
+  });
+
+  it("graceful-kill tracks PID", async () => {
+    const ctx = makeCtx();
+    (ctx.ptyManager.getTerminal as ReturnType<typeof vi.fn>).mockReturnValue(termInfo(5678));
+    (ctx.ptyManager.gracefulKill as ReturnType<typeof vi.fn>).mockResolvedValue("sess-1");
+    const dispatch = createPtyHostMessageDispatcher(ctx);
+
+    await dispatch({ type: "graceful-kill", id: "t1", requestId: "r1" });
+
+    expect(ctx.ptyManager.gracefulKill).toHaveBeenCalledWith("t1");
+    expect(ctx.resourceGovernor.trackKilledPid).toHaveBeenCalledWith(5678);
+  });
+
+  it("graceful-kill does not track when PID is undefined", async () => {
+    const ctx = makeCtx();
+    (ctx.ptyManager.getTerminal as ReturnType<typeof vi.fn>).mockReturnValue(termInfo());
+    (ctx.ptyManager.gracefulKill as ReturnType<typeof vi.fn>).mockResolvedValue("sess-1");
+    const dispatch = createPtyHostMessageDispatcher(ctx);
+
+    await dispatch({ type: "graceful-kill", id: "t1", requestId: "r1" });
+
+    expect(ctx.resourceGovernor.trackKilledPid).not.toHaveBeenCalled();
+  });
+
+  it("graceful-kill-by-project tracks all PIDs", async () => {
+    const ctx = makeCtx();
+    (ctx.ptyManager.getTerminalsForProject as ReturnType<typeof vi.fn>).mockReturnValue([
+      "t1",
+      "t2",
+    ]);
+    (ctx.ptyManager.getTerminal as ReturnType<typeof vi.fn>)
+      .mockReturnValueOnce(termInfo(300))
+      .mockReturnValueOnce(termInfo(400));
+    (ctx.ptyManager.gracefulKillByProject as ReturnType<typeof vi.fn>).mockResolvedValue([
+      { id: "t1", agentSessionId: "s1" },
+      { id: "t2", agentSessionId: "s2" },
+    ]);
+    const dispatch = createPtyHostMessageDispatcher(ctx);
+
+    await dispatch({ type: "graceful-kill-by-project", projectId: "proj-1", requestId: "r1" });
+
+    expect(ctx.ptyManager.gracefulKillByProject).toHaveBeenCalledWith("proj-1");
+    expect(ctx.resourceGovernor.trackKilledPid).toHaveBeenCalledTimes(2);
+    expect(ctx.resourceGovernor.trackKilledPid).toHaveBeenCalledWith(300);
+    expect(ctx.resourceGovernor.trackKilledPid).toHaveBeenCalledWith(400);
+  });
+
+  it("graceful-kill-by-project handles empty project", async () => {
+    const ctx = makeCtx();
+    (ctx.ptyManager.getTerminalsForProject as ReturnType<typeof vi.fn>).mockReturnValue([]);
+    (ctx.ptyManager.gracefulKillByProject as ReturnType<typeof vi.fn>).mockResolvedValue([]);
+    const dispatch = createPtyHostMessageDispatcher(ctx);
+
+    await dispatch({ type: "graceful-kill-by-project", projectId: "empty", requestId: "r1" });
+
+    expect(ctx.resourceGovernor.trackKilledPid).not.toHaveBeenCalled();
+  });
+});

--- a/electron/pty-host/handlers/lifecycle.ts
+++ b/electron/pty-host/handlers/lifecycle.ts
@@ -64,12 +64,25 @@ export function createLifecycleHandlers(ctx: HostContext): HandlerMap {
     },
 
     "kill-by-project": (msg) => {
+      const terminalIds = ptyManager.getTerminalsForProject(msg.projectId);
+      const pids: number[] = [];
+      for (const id of terminalIds) {
+        const pid = ptyManager.getTerminal(id)?.ptyProcess.pid;
+        if (pid !== undefined) pids.push(pid);
+      }
       const killed = ptyManager.killByProject(msg.projectId);
+      for (const pid of pids) {
+        resourceGovernor.trackKilledPid(pid);
+      }
       sendEvent({ type: "kill-by-project-result", requestId: msg.requestId, killed });
     },
 
     "graceful-kill": async (msg) => {
+      const killedPid = ptyManager.getTerminal(msg.id)?.ptyProcess.pid;
       const agentSessionId = await ptyManager.gracefulKill(msg.id);
+      if (killedPid !== undefined) {
+        resourceGovernor.trackKilledPid(killedPid);
+      }
       sendEvent({
         type: "graceful-kill-result",
         requestId: msg.requestId,
@@ -79,7 +92,16 @@ export function createLifecycleHandlers(ctx: HostContext): HandlerMap {
     },
 
     "graceful-kill-by-project": async (msg) => {
+      const terminalIds = ptyManager.getTerminalsForProject(msg.projectId);
+      const pids: number[] = [];
+      for (const id of terminalIds) {
+        const pid = ptyManager.getTerminal(id)?.ptyProcess.pid;
+        if (pid !== undefined) pids.push(pid);
+      }
       const results = await ptyManager.gracefulKillByProject(msg.projectId);
+      for (const pid of pids) {
+        resourceGovernor.trackKilledPid(pid);
+      }
       sendEvent({
         type: "graceful-kill-by-project-result",
         requestId: msg.requestId,

--- a/electron/services/pty/PtyEventsBridge.ts
+++ b/electron/services/pty/PtyEventsBridge.ts
@@ -26,6 +26,7 @@ export interface PtyEventsBridgeConfig {
     isThrottled: boolean;
     reason?: string;
     duration?: number;
+    forced?: boolean;
     timestamp: number;
   }) => void;
 }
@@ -142,6 +143,7 @@ export function bridgePtyEvent(event: PtyHostEvent, config?: PtyEventsBridgeConf
         isThrottled: event.isThrottled,
         reason: event.reason,
         duration: event.duration,
+        forced: event.forced,
         timestamp: event.timestamp,
       });
       return true;

--- a/shared/types/pty-host.ts
+++ b/shared/types/pty-host.ts
@@ -261,6 +261,7 @@ export type PtyHostEvent =
       isThrottled: boolean;
       reason?: string;
       duration?: number;
+      forced?: boolean;
       timestamp: number;
     }
   | {

--- a/shared/types/pty-host.ts
+++ b/shared/types/pty-host.ts
@@ -487,6 +487,7 @@ export interface HostThrottlePayload {
   isThrottled: boolean;
   reason?: string;
   duration?: number;
+  forced?: boolean;
   timestamp: number;
 }
 


### PR DESCRIPTION
## Summary
- The `host-throttled` resume event now carries `forced` and `reason`, so dashboards can distinguish threshold-cleared resumes from force-resume timeouts.
- `ResourceGovernor.dispose()` now releases throttle state and pause tokens, making the governor safely re-entrant for tests or any caller that disposes without full host cleanup.
- `kill-by-project`, `graceful-kill`, and `graceful-kill-by-project` handlers now call `trackKilledPid`, so orphan-PID warnings cover project-level and graceful kills, not just direct kills.

Resolves #7019.

## Changes
- `electron/pty-host/ResourceGovernor.ts` — propagate `forced` in resume events; release throttle state + pause coordinators in `dispose()`
- `electron/pty-host/handlers/lifecycle.ts` — call `trackKilledPid` from all four kill handlers
- `electron/services/pty/PtyEventsBridge.ts` — forward `forced` through the bridge
- `shared/types/pty-host.ts` — add `forced` to the event and payload types
- Tests: `ResourceGovernor.test.ts` (resume event fields, dispose idempotency/re-entrancy) and `lifecycle.test.ts` (trackKilledPid from every kill path)

## Testing
- Unit tests confirm `forced` is `false` on threshold-cleared resume, `true` on force-resume timeout
- Unit tests confirm `dispose()` clears `resource-governor` tokens and is safe to double-call
- Unit tests confirm `trackKilledPid` is called from all four kill paths, with correct PID counts, and handles missing PIDs and empty projects cleanly