### PR TITLE
fix(pty): replace WriteQueue polling with resolvers, add submit timeout

### DIFF
--- a/electron/services/pty/WriteQueue.ts
+++ b/electron/services/pty/WriteQueue.ts
@@ -1,6 +1,8 @@
 import { WRITE_INTERVAL_MS } from "./types.js";
 import { chunkInput } from "./terminalInput.js";
 
+const SUBMIT_TIMEOUT_MS = 3000;
+
 export interface WriteQueueOptions {
   /** Raw byte sink for paced chunks. May throw on PTY errors. */
   writeToPty: (data: string) => void;
@@ -37,6 +39,7 @@ export interface OutputSettleOptions {
 export class WriteQueue {
   private inputWriteQueue: string[] = [];
   private inputWriteTimeout: NodeJS.Timeout | null = null;
+  private inputWriteDrainResolve: (() => void) | null = null;
   private submitQueue: string[] = [];
   private submitInFlight = false;
   private disposed = false;
@@ -76,26 +79,14 @@ export class WriteQueue {
 
   /**
    * Resolves once the chunked input queue is fully drained, the PTY has
-   * exited, or the queue has been disposed. Polling preserves the existing
-   * semantics; the `disposed` check is the teardown termination condition
-   * that prevents `performSubmit` from deadlocking when `dispose()` fires
-   * mid-drain.
+   * exited, or the queue has been disposed. Uses a stored Promise resolver
+   * triggered from `startWrite` end-of-flight, `dispose()`, and the
+   * `isExited()` sync gate so no polling is needed.
    */
   async waitForInputWriteDrain(): Promise<void> {
-    if (!this.hasPendingWrites()) return;
+    if (this.disposed || this.options.isExited() || !this.hasPendingWrites()) return;
     await new Promise<void>((resolve) => {
-      const check = (): void => {
-        if (this.disposed || this.options.isExited()) {
-          resolve();
-          return;
-        }
-        if (!this.hasPendingWrites()) {
-          resolve();
-          return;
-        }
-        setTimeout(check, 0);
-      };
-      check();
+      this.inputWriteDrainResolve = resolve;
     });
   }
 
@@ -133,11 +124,17 @@ export class WriteQueue {
     }
     this.inputWriteQueue = [];
     this.submitQueue = [];
+    this.inputWriteDrainResolve?.();
+    this.inputWriteDrainResolve = null;
   }
 
   private startWrite(): void {
     if (this.disposed) return;
     if (this.inputWriteTimeout !== null || this.inputWriteQueue.length === 0) {
+      if (this.inputWriteQueue.length === 0 && this.inputWriteTimeout === null) {
+        this.inputWriteDrainResolve?.();
+        this.inputWriteDrainResolve = null;
+      }
       return;
     }
 
@@ -149,6 +146,9 @@ export class WriteQueue {
         this.inputWriteTimeout = null;
         this.startWrite();
       }, WRITE_INTERVAL_MS);
+    } else {
+      this.inputWriteDrainResolve?.();
+      this.inputWriteDrainResolve = null;
     }
   }
 
@@ -172,10 +172,26 @@ export class WriteQueue {
         const next = this.submitQueue.shift();
         if (next === undefined) continue;
         try {
-          await this.options.performSubmit(next);
+          const work = this.options.performSubmit(next);
+          let timedOut = false;
+          let timeoutId: NodeJS.Timeout | undefined;
+          const timeoutPromise = new Promise<void>((_, reject) => {
+            timeoutId = setTimeout(() => {
+              timedOut = true;
+              reject(new Error(`performSubmit timed out after ${SUBMIT_TIMEOUT_MS}ms`));
+            }, SUBMIT_TIMEOUT_MS);
+          });
+          try {
+            await Promise.race([work, timeoutPromise]);
+          } finally {
+            clearTimeout(timeoutId);
+          }
+          if (timedOut) {
+            work.catch(() => {
+              // Absorb post-timeout rejection — already routed to onWriteError.
+            });
+          }
         } catch (error) {
-          // Don't let a single submit failure abandon the rest of the queue
-          // or escape as an unhandled rejection from the void caller above.
           this.options.onWriteError?.(error, { operation: "performSubmit" });
         }
       }

--- a/electron/services/pty/WriteQueue.ts
+++ b/electron/services/pty/WriteQueue.ts
@@ -39,7 +39,7 @@ export interface OutputSettleOptions {
 export class WriteQueue {
   private inputWriteQueue: string[] = [];
   private inputWriteTimeout: NodeJS.Timeout | null = null;
-  private inputWriteDrainResolve: (() => void) | null = null;
+  private inputWriteDrainResolvers: Array<() => void> = [];
   private submitQueue: string[] = [];
   private submitInFlight = false;
   private disposed = false;
@@ -86,7 +86,7 @@ export class WriteQueue {
   async waitForInputWriteDrain(): Promise<void> {
     if (this.disposed || this.options.isExited() || !this.hasPendingWrites()) return;
     await new Promise<void>((resolve) => {
-      this.inputWriteDrainResolve = resolve;
+      this.inputWriteDrainResolvers.push(resolve);
     });
   }
 
@@ -124,16 +124,20 @@ export class WriteQueue {
     }
     this.inputWriteQueue = [];
     this.submitQueue = [];
-    this.inputWriteDrainResolve?.();
-    this.inputWriteDrainResolve = null;
+    for (const resolve of this.inputWriteDrainResolvers) {
+      resolve();
+    }
+    this.inputWriteDrainResolvers = [];
   }
 
   private startWrite(): void {
     if (this.disposed) return;
     if (this.inputWriteTimeout !== null || this.inputWriteQueue.length === 0) {
       if (this.inputWriteQueue.length === 0 && this.inputWriteTimeout === null) {
-        this.inputWriteDrainResolve?.();
-        this.inputWriteDrainResolve = null;
+        for (const resolve of this.inputWriteDrainResolvers) {
+          resolve();
+        }
+        this.inputWriteDrainResolvers = [];
       }
       return;
     }
@@ -147,8 +151,10 @@ export class WriteQueue {
         this.startWrite();
       }, WRITE_INTERVAL_MS);
     } else {
-      this.inputWriteDrainResolve?.();
-      this.inputWriteDrainResolve = null;
+      for (const resolve of this.inputWriteDrainResolvers) {
+        resolve();
+      }
+      this.inputWriteDrainResolvers = [];
     }
   }
 
@@ -184,12 +190,12 @@ export class WriteQueue {
           try {
             await Promise.race([work, timeoutPromise]);
           } finally {
+            if (timedOut) {
+              work.catch(() => {
+                // Absorb post-timeout rejection — already routed to onWriteError.
+              });
+            }
             clearTimeout(timeoutId);
-          }
-          if (timedOut) {
-            work.catch(() => {
-              // Absorb post-timeout rejection — already routed to onWriteError.
-            });
           }
         } catch (error) {
           this.options.onWriteError?.(error, { operation: "performSubmit" });

--- a/electron/services/pty/__tests__/WriteQueue.test.ts
+++ b/electron/services/pty/__tests__/WriteQueue.test.ts
@@ -245,10 +245,48 @@ describe("WriteQueue.waitForInputWriteDrain", () => {
     });
 
     wq.dispose();
-    // The polling loop uses setTimeout(check, 0). Flush microtasks + the
-    // 0-ms timer so the resolver runs.
-    await vi.advanceTimersByTimeAsync(1);
+    await vi.advanceTimersByTimeAsync(0);
     expect(resolved).toBe(true);
+  });
+
+  it("resolves immediately when isExited turns true with queued chunks", async () => {
+    const m = makeOptions();
+    const wq = new WriteQueue(m.options);
+    wq.enqueueChunked("x".repeat(WRITE_MAX_CHUNK_SIZE * 3));
+
+    m.isExited.value = true;
+
+    // Should resolve immediately despite queued chunks.
+    await expect(wq.waitForInputWriteDrain()).resolves.toBeUndefined();
+  });
+
+  it("supports a second drain cycle after the first resolves", async () => {
+    const m = makeOptions();
+    const wq = new WriteQueue(m.options);
+
+    // First drain: enqueue and wait for it to empty.
+    wq.enqueueChunked("x".repeat(WRITE_MAX_CHUNK_SIZE * 2));
+    await vi.runAllTimersAsync();
+    await expect(wq.waitForInputWriteDrain()).resolves.toBeUndefined();
+
+    // Second drain: enqueue again and verify a fresh resolver lifecycle.
+    wq.enqueueChunked("y".repeat(WRITE_MAX_CHUNK_SIZE * 2));
+    await vi.runAllTimersAsync();
+    await expect(wq.waitForInputWriteDrain()).resolves.toBeUndefined();
+  });
+
+  it("does not schedule polling timers during drain", async () => {
+    const m = makeOptions();
+    const wq = new WriteQueue(m.options);
+    wq.enqueueChunked("x".repeat(WRITE_MAX_CHUNK_SIZE * 5));
+
+    const timerCountBefore = vi.getTimerCount();
+    await vi.runAllTimersAsync();
+
+    // After draining all chunks, the only remaining timer should be the
+    // pacing timer (cleared on last chunk). No polling timers added.
+    // With the Promise-based approach, drain() produces no extra timers.
+    expect(vi.getTimerCount()).toBeLessThanOrEqual(timerCountBefore);
   });
 });
 
@@ -343,5 +381,70 @@ describe("WriteQueue.waitForOutputSettle", () => {
       await vi.advanceTimersByTimeAsync(30);
     }
     expect(resolved).toBe(true);
+  });
+});
+
+describe("WriteQueue.submit timeout", () => {
+  beforeEach(() => {
+    vi.useFakeTimers();
+  });
+
+  afterEach(() => {
+    vi.useRealTimers();
+  });
+
+  it("routes a stuck performSubmit to onWriteError after SUBMIT_TIMEOUT_MS", async () => {
+    const m = makeOptions();
+    // A performSubmit that never settles.
+    m.performSubmit.mockImplementation(() => new Promise(() => {}));
+    const wq = new WriteQueue(m.options);
+
+    wq.submit("stuck");
+
+    await vi.advanceTimersByTimeAsync(3000);
+
+    expect(m.onWriteError).toHaveBeenCalled();
+    const err = m.onWriteError.mock.calls[0]?.[0] as Error;
+    expect(err.message).toContain("timed out");
+  });
+
+  it("continues processing remaining submits after a timeout", async () => {
+    const m = makeOptions();
+    const seen: string[] = [];
+    m.performSubmit.mockImplementation(async (text) => {
+      seen.push(text);
+      if (text === "stuck") {
+        // Never resolve.
+        return new Promise(() => {});
+      }
+    });
+    const wq = new WriteQueue(m.options);
+
+    wq.submit("stuck");
+    wq.submit("after");
+
+    // Advance past the timeout for the first stuck submit.
+    await vi.advanceTimersByTimeAsync(3000);
+    // Let the second submit drain.
+    await vi.runAllTimersAsync();
+
+    expect(seen).toEqual(["stuck", "after"]);
+    expect(m.onWriteError).toHaveBeenCalled();
+  });
+
+  it("clears submitInFlight after timeout so later submits work", async () => {
+    const m = makeOptions();
+    m.performSubmit.mockImplementation(() => new Promise(() => {}));
+    const wq = new WriteQueue(m.options);
+
+    wq.submit("stuck");
+    await vi.advanceTimersByTimeAsync(3000);
+
+    // After the timeout, the queue should accept new submits.
+    m.performSubmit.mockImplementation(async () => {});
+    wq.submit("fresh");
+    await vi.runAllTimersAsync();
+
+    expect(m.performSubmit).toHaveBeenCalledWith("fresh");
   });
 });

--- a/electron/services/pty/__tests__/WriteQueue.test.ts
+++ b/electron/services/pty/__tests__/WriteQueue.test.ts
@@ -469,7 +469,7 @@ describe("WriteQueue.submit timeout", () => {
 
   it("does not cause unhandled rejection when work rejects after timeout", async () => {
     const m = makeOptions();
-    let lateReject!: () => void;
+    let lateReject!: (reason?: unknown) => void;
     m.performSubmit.mockImplementation(
       () =>
         new Promise<void>((_, reject) => {

--- a/electron/services/pty/__tests__/WriteQueue.test.ts
+++ b/electron/services/pty/__tests__/WriteQueue.test.ts
@@ -288,6 +288,25 @@ describe("WriteQueue.waitForInputWriteDrain", () => {
     // With the Promise-based approach, drain() produces no extra timers.
     expect(vi.getTimerCount()).toBeLessThanOrEqual(timerCountBefore);
   });
+
+  it("resolves all concurrent drain waiters", async () => {
+    const m = makeOptions();
+    const wq = new WriteQueue(m.options);
+    wq.enqueueChunked("x".repeat(WRITE_MAX_CHUNK_SIZE * 3));
+
+    let firstResolved = false;
+    let secondResolved = false;
+    void wq.waitForInputWriteDrain().then(() => {
+      firstResolved = true;
+    });
+    void wq.waitForInputWriteDrain().then(() => {
+      secondResolved = true;
+    });
+
+    await vi.runAllTimersAsync();
+    expect(firstResolved).toBe(true);
+    expect(secondResolved).toBe(true);
+  });
 });
 
 describe("WriteQueue.dispose", () => {
@@ -446,5 +465,32 @@ describe("WriteQueue.submit timeout", () => {
     await vi.runAllTimersAsync();
 
     expect(m.performSubmit).toHaveBeenCalledWith("fresh");
+  });
+
+  it("does not cause unhandled rejection when work rejects after timeout", async () => {
+    const m = makeOptions();
+    let lateReject!: () => void;
+    m.performSubmit.mockImplementation(
+      () =>
+        new Promise<void>((_, reject) => {
+          lateReject = reject;
+        })
+    );
+    const wq = new WriteQueue(m.options);
+
+    wq.submit("late-reject");
+
+    // Fire the timeout.
+    await vi.advanceTimersByTimeAsync(3000);
+
+    // Now reject the original performSubmit after the timeout.
+    lateReject(new Error("PTY write failed"));
+    await vi.runAllTimersAsync();
+
+    // onWriteError should be called exactly once (the timeout error,
+    // not the late rejection).
+    expect(m.onWriteError).toHaveBeenCalledTimes(1);
+    const err = m.onWriteError.mock.calls[0]?.[0] as Error;
+    expect(err.message).toContain("timed out");
   });
 });


### PR DESCRIPTION
Fixes #7012.

Two changes to `WriteQueue`:

**`waitForInputWriteDrain`** no longer polls with `setTimeout(0)`. It stores Promise resolvers and fires them from the natural completion points -- `startWrite` end-of-flight, `dispose()`, and the `isExited()` sync gate. This is cheaper and cleaner than spinning N timer reschedules for an N-chunk drain.

**`drainSubmitQueue`** now has a 3-second `Promise.race` timeout on each `performSubmit` call. A stuck shell or misjudged settle could previously hold the queue indefinitely because the existing `disposed` short-circuit only covers teardown, not steady-state wedges. After the timeout fires, the rejection routes to `onWriteError` and the queue drains normally. Post-timeout rejections from the original work promise are absorbed so they don't surface as unhandled rejections.

## Changes
- `electron/services/pty/WriteQueue.ts` -- replace `setTimeout` polling with resolver array; add `SUBMIT_TIMEOUT_MS` (3000ms) with `Promise.race` in `drainSubmitQueue`
- `electron/services/pty/__tests__/WriteQueue.test.ts` -- new tests for resolvers (concurrent waiters, multi-cycle, exited gate, zero-timer assertion) and timeout (stuck submit routing, queue continuation, `submitInFlight` clearing, late-rejection absorption)

## Testing
All existing `WriteQueue` tests pass. New tests cover the resolver lifecycle and the timeout path including the edge case where `performSubmit` rejects after the timeout has already fired.