### PR TITLE
chore(git): harden environment variables on simple-git factories

### DIFF
--- a/electron/utils/__tests__/hardenedGit.test.ts
+++ b/electron/utils/__tests__/hardenedGit.test.ts
@@ -703,6 +703,20 @@ describe("createWslHardenedGit", () => {
     expect(envArg.LANGUAGE).toBe("");
   });
 
+  it("applies the same env hardening as createHardenedGit (Linux git inside WSL)", () => {
+    createWslHardenedGit({
+      distro: "Ubuntu",
+      uncPath: "\\\\wsl$\\Ubuntu\\home\\user\\proj",
+      posixPath: "/home/user/proj",
+    });
+
+    const envArg = mockGitInstance.env.mock.calls[0][0];
+    expect(envArg.GIT_OPTIONAL_LOCKS).toBe("0");
+    expect(envArg.GIT_TERMINAL_PROMPT).toBe("0");
+    expect(envArg.GIT_ASKPASS).toBe("true");
+    expect(envArg.GCM_INTERACTIVE).toBe("Never");
+  });
+
   it("forwards abort signal when provided", () => {
     const controller = new AbortController();
     createWslHardenedGit(

--- a/electron/utils/__tests__/hardenedGit.test.ts
+++ b/electron/utils/__tests__/hardenedGit.test.ts
@@ -239,6 +239,54 @@ describe("createHardenedGit", () => {
       else process.env.LANGUAGE = origLanguage;
     }
   });
+
+  it("suppresses optional .git/index.lock writes via GIT_OPTIONAL_LOCKS=0", () => {
+    createHardenedGit("/test/repo");
+
+    const envArg = mockGitInstance.env.mock.calls[0][0];
+    expect(envArg.GIT_OPTIONAL_LOCKS).toBe("0");
+  });
+
+  it("blocks interactive credential prompts via GIT_TERMINAL_PROMPT=0", () => {
+    createHardenedGit("/test/repo");
+
+    const envArg = mockGitInstance.env.mock.calls[0][0];
+    expect(envArg.GIT_TERMINAL_PROMPT).toBe("0");
+  });
+
+  it("disables Windows GCM interactive dialogs via GCM_INTERACTIVE=Never", () => {
+    createHardenedGit("/test/repo");
+
+    const envArg = mockGitInstance.env.mock.calls[0][0];
+    expect(envArg.GCM_INTERACTIVE).toBe("Never");
+  });
+
+  it("sets GIT_ASKPASS=true on POSIX so credential helpers fail fast", () => {
+    createHardenedGit("/test/repo", undefined, "darwin");
+
+    const envArg = mockGitInstance.env.mock.calls[0][0];
+    expect(envArg.GIT_ASKPASS).toBe("true");
+  });
+
+  it("sets GIT_ASKPASS=true on linux", () => {
+    createHardenedGit("/test/repo", undefined, "linux");
+
+    const envArg = mockGitInstance.env.mock.calls[0][0];
+    expect(envArg.GIT_ASKPASS).toBe("true");
+  });
+
+  it("does not set GIT_ASKPASS on Windows (no `true` binary on PATH)", () => {
+    const origAskpass = process.env.GIT_ASKPASS;
+    delete process.env.GIT_ASKPASS;
+    try {
+      createHardenedGit("/test/repo", undefined, "win32");
+
+      const envArg = mockGitInstance.env.mock.calls[0][0];
+      expect(envArg.GIT_ASKPASS).toBeUndefined();
+    } finally {
+      if (origAskpass !== undefined) process.env.GIT_ASKPASS = origAskpass;
+    }
+  });
 });
 
 describe("createAuthenticatedGit", () => {
@@ -289,6 +337,33 @@ describe("createAuthenticatedGit", () => {
           "ssh -o StrictHostKeyChecking=accept-new -o BatchMode=yes -o ConnectTimeout=15",
       })
     );
+  });
+
+  it("sets GIT_OPTIONAL_LOCKS=0 to suppress incidental lock writes", () => {
+    createAuthenticatedGit("/test/repo");
+
+    const envArg = mockGitInstance.env.mock.calls[0][0];
+    expect(envArg.GIT_OPTIONAL_LOCKS).toBe("0");
+  });
+
+  it("sets GCM_INTERACTIVE=Never to prevent Windows GCM dialogs", () => {
+    createAuthenticatedGit("/test/repo");
+
+    const envArg = mockGitInstance.env.mock.calls[0][0];
+    expect(envArg.GCM_INTERACTIVE).toBe("Never");
+  });
+
+  it("does NOT set GIT_ASKPASS so legitimate credential helpers can resolve", () => {
+    const origAskpass = process.env.GIT_ASKPASS;
+    delete process.env.GIT_ASKPASS;
+    try {
+      createAuthenticatedGit("/test/repo");
+
+      const envArg = mockGitInstance.env.mock.calls[0][0];
+      expect(envArg.GIT_ASKPASS).toBeUndefined();
+    } finally {
+      if (origAskpass !== undefined) process.env.GIT_ASKPASS = origAskpass;
+    }
   });
 
   it("sets LC_MESSAGES=C and LANGUAGE empty via .env()", () => {
@@ -466,6 +541,20 @@ describe("createBackgroundFetchGit", () => {
     const lastEnv = mockGitInstance.env.mock.calls[mockGitInstance.env.mock.calls.length - 1][0];
     expect(lastEnv.GIT_ASKPASS).toBe("true");
     expect(lastEnv.GIT_TERMINAL_PROMPT).toBe("0");
+  });
+
+  it("re-states GIT_OPTIONAL_LOCKS and GCM_INTERACTIVE in the POSIX second .env() call", () => {
+    const controller = new AbortController();
+    createBackgroundFetchGit("/test/repo", {
+      signal: controller.signal,
+      platform: "darwin",
+    });
+
+    // The second .env() replaces (not merges) the first call's env, so the
+    // hardening flags from createAuthenticatedGit must be re-asserted here.
+    const lastEnv = mockGitInstance.env.mock.calls[mockGitInstance.env.mock.calls.length - 1][0];
+    expect(lastEnv.GIT_OPTIONAL_LOCKS).toBe("0");
+    expect(lastEnv.GCM_INTERACTIVE).toBe("Never");
   });
 
   it("does not set GIT_ASKPASS on Windows (no `true` binary on PATH)", () => {

--- a/electron/utils/hardenedGit.ts
+++ b/electron/utils/hardenedGit.ts
@@ -71,7 +71,11 @@ export function getGitLocaleEnv(
   return { LC_CTYPE: "C.UTF-8" };
 }
 
-export function createHardenedGit(cwd: string, signal?: AbortSignal): SimpleGit {
+export function createHardenedGit(
+  cwd: string,
+  signal?: AbortSignal,
+  platform: NodeJS.Platform = process.platform
+): SimpleGit {
   return simpleGit({
     baseDir: cwd,
     config: [...HARDENED_GIT_CONFIG],
@@ -80,13 +84,33 @@ export function createHardenedGit(cwd: string, signal?: AbortSignal): SimpleGit 
     unsafe: UNSAFE_FLAGS,
   }).env({
     ...process.env,
-    ...getGitLocaleEnv(),
+    ...getGitLocaleEnv(platform),
     // Clear inherited LC_ALL so the more specific LC_CTYPE / LC_MESSAGES
     // values above actually take effect. POSIX locale resolution gives LC_ALL
     // priority over every other LC_* variable.
     LC_ALL: "",
     LC_MESSAGES: "C",
     LANGUAGE: "",
+    // Suppress optional .git/index.lock writes during status-only reads. Only
+    // affects opportunistic locks (stat-cache refresh); mandatory locks for
+    // git add/commit are unaffected, so this is safe even when the hardened
+    // factory is used for write paths.
+    GIT_OPTIONAL_LOCKS: "0",
+    // Block git's built-in TTY prompt for credentials/passphrases. Some
+    // commands (clone, fetch, push) still touch credential helpers even
+    // through the hardened factory's `-c credential.helper=` blank, and an
+    // interactive prompt in the Electron main process hangs forever.
+    GIT_TERMINAL_PROMPT: "0",
+    // Defense in depth: some credential helpers ignore GIT_TERMINAL_PROMPT
+    // and still invoke an ASKPASS binary. `true` exits 0 with empty stdout,
+    // so git treats it as an empty credential and fails fast instead of
+    // hanging. `true` is not on PATH on Windows; GIT_TERMINAL_PROMPT=0 plus
+    // GCM_INTERACTIVE=Never below cover that platform.
+    ...(platform !== "win32" ? { GIT_ASKPASS: "true" } : {}),
+    // Windows-only: prevent Git Credential Manager from spawning GUI auth
+    // dialogs in background processes where no user can interact. No effect
+    // on POSIX or on local read operations.
+    GCM_INTERACTIVE: "Never",
   });
 }
 
@@ -193,6 +217,11 @@ export function createAuthenticatedGit(cwd: string, opts: AuthenticatedGitOption
     GIT_TERMINAL_PROMPT: "0",
     GIT_SSH_COMMAND:
       "ssh -o StrictHostKeyChecking=accept-new -o BatchMode=yes -o ConnectTimeout=15",
+    // Same lock-suppression and Windows-GCM hardening as createHardenedGit.
+    // GIT_ASKPASS is intentionally NOT set here — credentialed commands
+    // (clone/push) need legitimate ASKPASS resolution.
+    GIT_OPTIONAL_LOCKS: "0",
+    GCM_INTERACTIVE: "Never",
   });
 }
 
@@ -253,6 +282,11 @@ export function createBackgroundFetchGit(cwd: string, opts: BackgroundFetchGitOp
       GIT_SSH_COMMAND:
         "ssh -o StrictHostKeyChecking=accept-new -o BatchMode=yes -o ConnectTimeout=15",
       GIT_ASKPASS: "true",
+      // simple-git's .env() replaces the env wholesale, so the hardening
+      // flags from createAuthenticatedGit's first .env() call must be
+      // re-stated here or they will be lost on POSIX.
+      GIT_OPTIONAL_LOCKS: "0",
+      GCM_INTERACTIVE: "Never",
     });
   }
   return git;

--- a/electron/utils/hardenedGit.ts
+++ b/electron/utils/hardenedGit.ts
@@ -190,6 +190,15 @@ export function createWslHardenedGit(
     // this env var present makes diagnostic output unambiguous if the user
     // captures process state during a hang.
     WSL_DISTRO_NAME: distro,
+    // The git binary inside WSL is Linux git, so the same non-interactive +
+    // lock-suppression hardening that createHardenedGit applies on POSIX
+    // must reach the WSL distro too. GCM_INTERACTIVE is harmless inside
+    // WSL (no GCM there) but kept for defense in depth in case wsl.exe ever
+    // surfaces it back to the host credential helper chain.
+    GIT_OPTIONAL_LOCKS: "0",
+    GIT_TERMINAL_PROMPT: "0",
+    GIT_ASKPASS: "true",
+    GCM_INTERACTIVE: "Never",
   });
 }
 

--- a/electron/workspace-host/RepoFetchCoordinator.ts
+++ b/electron/workspace-host/RepoFetchCoordinator.ts
@@ -239,7 +239,11 @@ export class RepoFetchCoordinator {
       const git = createBackgroundFetchGit(opts.worktreePath, {
         signal: controller.signal,
       });
-      await git.raw(["fetch", "origin", "--no-auto-gc", "--prune"]);
+      // --no-write-fetch-head: skip writing FETCH_HEAD on background fetches
+      // so concurrent foreground operations (status polls, user pushes) don't
+      // contend on the same file. Requires Git ≥ 2.29 — all supported platforms
+      // ship ≥ 2.34, so no version guard is needed.
+      await git.raw(["fetch", "origin", "--no-auto-gc", "--prune", "--no-write-fetch-head"]);
 
       const state = this.states.get(commonDir);
       if (!state || state.generation !== generationAtStart) {

--- a/electron/workspace-host/__tests__/RepoFetchCoordinator.test.ts
+++ b/electron/workspace-host/__tests__/RepoFetchCoordinator.test.ts
@@ -54,6 +54,22 @@ describe("RepoFetchCoordinator", () => {
     expect(result.authFailed).toBe(false);
   });
 
+  it("passes --no-write-fetch-head to background fetches to avoid FETCH_HEAD contention", async () => {
+    mockGetGitCommonDir.mockReturnValue("/repo/.git");
+    const mockGit = makeMockGit(() => Promise.resolve());
+    mockCreateBackgroundFetchGit.mockReturnValue(mockGit);
+
+    const coord = new RepoFetchCoordinator();
+    await coord.fetchForWorktree({
+      worktreeId: "wt1",
+      worktreePath: "/repo",
+    });
+
+    expect(mockGit.raw).toHaveBeenCalledTimes(1);
+    const args = mockGit.raw.mock.calls[0][0];
+    expect(args).toEqual(["fetch", "origin", "--no-auto-gc", "--prune", "--no-write-fetch-head"]);
+  });
+
   it("propagates authFailed=true via FetchResult on auth-class failures and skips", async () => {
     mockGetGitCommonDir.mockReturnValue("/repo/.git");
     mockCreateBackgroundFetchGit.mockReturnValue(


### PR DESCRIPTION
## Summary

- Adds `GIT_OPTIONAL_LOCKS=0` to the read-mostly factory to cut `index.lock` contention during status polling
- Adds `GIT_TERMINAL_PROMPT=0` / `GIT_ASKPASS` across all factories to prevent interactive credential prompts, and `GCM_INTERACTIVE=Never` on the auth and background-fetch factories for Windows Git Credential Manager
- Passes `--no-write-fetch-head` on background fetches to eliminate cross-process contention on `FETCH_HEAD`

Resolves #7045

## Changes

- `electron/utils/hardenedGit.ts` — new env vars on `createHardenedGit`, `createAuthenticatedGit`, `createBackgroundFetchGit`; `--no-write-fetch-head` flag on fetch args
- `electron/workspace-host/RepoFetchCoordinator.ts` — `createWslHardenedGit` gets the same hardening
- `electron/utils/__tests__/hardenedGit.test.ts` — coverage for all new env vars and the fetch flag
- `electron/workspace-host/__tests__/RepoFetchCoordinator.test.ts` — coverage for WSL factory env vars

## Testing

Unit tests cover all new env vars and `--no-write-fetch-head`. Verified no regressions on existing hardenedGit test suite.