### PR TITLE
fix(tasks): task orchestration durability and lifecycle polish

### DIFF
--- a/electron/lifecycle/__tests__/shutdown.test.ts
+++ b/electron/lifecycle/__tests__/shutdown.test.ts
@@ -64,6 +64,14 @@ vi.mock("../../services/TaskOrchestrator.js", () => ({
   disposeTaskOrchestrator: vi.fn(),
 }));
 
+const taskQueueServiceMock = vi.hoisted(() => ({
+  flushPersistence: vi.fn(() => Promise.resolve()),
+}));
+
+vi.mock("../../services/TaskQueueService.js", () => ({
+  taskQueueService: taskQueueServiceMock,
+}));
+
 vi.mock("../../services/PtyClient.js", () => ({
   disposePtyClient: vi.fn(),
 }));
@@ -290,8 +298,11 @@ describe("registerShutdownHandler", () => {
   });
 
   describe("SQLite connection close", () => {
-    it("calls closeSharedDb after DatabaseMaintenanceService.dispose", async () => {
+    it("flushes task persistence before dispose and closeSharedDb", async () => {
       const callOrder: string[] = [];
+      taskQueueServiceMock.flushPersistence.mockImplementation(async () => {
+        callOrder.push("flushPersistence");
+      });
       dbMaintenanceMock.dispose.mockImplementation(async () => {
         callOrder.push("dispose");
       });
@@ -306,7 +317,26 @@ describe("registerShutdownHandler", () => {
         expect(appMock.exit).toHaveBeenCalledWith(0);
       });
 
-      expect(callOrder).toEqual(["dispose", "closeSharedDb"]);
+      expect(callOrder).toEqual(["flushPersistence", "dispose", "closeSharedDb"]);
+    });
+
+    it("still closes the database and exits when flushPersistence rejects", async () => {
+      taskQueueServiceMock.flushPersistence.mockRejectedValueOnce(new Error("flush boom"));
+      const warnSpy = vi.spyOn(console, "warn").mockImplementation(() => {});
+
+      const { beforeQuitCb } = await setup({});
+      await beforeQuitCb(makeEvent());
+
+      await vi.waitFor(() => {
+        expect(appMock.exit).toHaveBeenCalledWith(0);
+      });
+
+      expect(closeSharedDbMock.closeSharedDb).toHaveBeenCalled();
+      expect(warnSpy).toHaveBeenCalledWith(
+        "[MAIN] Failed to flush task persistence:",
+        expect.any(Error)
+      );
+      warnSpy.mockRestore();
     });
 
     it("still calls closeSharedDb and exits when dispose fails", async () => {

--- a/electron/lifecycle/shutdown.ts
+++ b/electron/lifecycle/shutdown.ts
@@ -11,6 +11,7 @@ import { disposePowerSaveBlockerService } from "../services/PowerSaveBlockerServ
 import { disposeAgentRouter } from "../services/AgentRouter.js";
 
 import { disposeTaskOrchestrator } from "../services/TaskOrchestrator.js";
+import { taskQueueService } from "../services/TaskQueueService.js";
 import { disposePtyClient } from "../services/PtyClient.js";
 import { disposeWorkspaceClient } from "../services/WorkspaceClient.js";
 import { disposeMainProcessWatchdog } from "../services/MainProcessWatchdogClient.js";
@@ -193,6 +194,12 @@ export function registerShutdownHandler(deps: ShutdownDeps): void {
         if (stopDisk) {
           stopDisk();
           deps.setStopDiskSpaceMonitor(null);
+        }
+
+        try {
+          await taskQueueService.flushPersistence();
+        } catch (error) {
+          console.warn("[MAIN] Failed to flush task persistence:", error);
         }
 
         try {

--- a/electron/services/TaskOrchestrator.ts
+++ b/electron/services/TaskOrchestrator.ts
@@ -487,7 +487,7 @@ export class TaskOrchestrator {
     if (task && task.status === "running" && task.runId === runId) {
       try {
         await this.queueService.markCompleted(taskId, {
-          summary: `Completed by agent ${task.assignedAgentId ?? "unknown"}`,
+          summary: `Agent process exited (${task.assignedAgentId ?? "unknown"})`,
         });
       } catch (err) {
         console.error(

--- a/electron/services/TaskQueueService.ts
+++ b/electron/services/TaskQueueService.ts
@@ -841,11 +841,12 @@ export class TaskQueueService {
       }
     }
 
-    // Fourth pass: crash recovery - normalize task states
+    // Fourth pass: crash recovery - normalize task states.
     // Tasks in "running" state are reset to "queued" or "blocked" after restart.
     // Use transitionToQueued/Blocked so task:state-changed events fire and the
     // orchestrator (subscribed before initialize() runs) wakes to dispatch
     // recovered tasks.
+    let recoveredAny = false;
     for (const task of this.tasks.values()) {
       if (task.status === "running") {
         console.warn(
@@ -862,7 +863,15 @@ export class TaskQueueService {
         } else {
           await this.transitionToQueued(task);
         }
+        recoveredAny = true;
       }
+    }
+
+    // If we recovered any tasks, persist the normalized state so a subsequent
+    // crash (or quit before assignment) doesn't replay the same recovery loop
+    // — the on-disk row would otherwise stay "running" forever.
+    if (recoveredAny) {
+      await this.schedulePersist();
     }
 
     console.log(`[TaskQueueService] Loaded ${this.tasks.size} tasks for project ${projectId}`);

--- a/electron/services/TaskQueueService.ts
+++ b/electron/services/TaskQueueService.ts
@@ -669,14 +669,24 @@ export class TaskQueueService {
    * Handle upstream task failure by marking dependent tasks.
    * Policy: dependents are marked as failed or cancelled (same as upstream).
    * Cascades to all non-terminal states (draft, blocked, queued, running).
+   *
+   * Uses iterative BFS keyed by task id with a visited set so deep chains
+   * don't blow the call stack and accidental cycles (e.g. from corrupted
+   * data) terminate. Diamond dependency graphs visit each task once.
    */
   private async handleUpstreamFailure(
     failedTask: TaskRecord,
     failureState: "failed" | "cancelled"
   ): Promise<void> {
-    const dependents = failedTask.dependents ?? [];
+    const visited = new Set<string>([failedTask.id]);
+    const queue: string[] = [...(failedTask.dependents ?? [])];
 
-    for (const depId of dependents) {
+    // Index pointer instead of Array.shift() — O(1) advance, avoids O(n²).
+    for (let i = 0; i < queue.length; i++) {
+      const depId = queue[i];
+      if (visited.has(depId)) continue;
+      visited.add(depId);
+
       const depTask = this.tasks.get(depId);
       if (!depTask) continue;
 
@@ -715,8 +725,9 @@ export class TaskQueueService {
         });
       }
 
-      // Recursively handle this task's dependents
-      await this.handleUpstreamFailure(depTask, failureState);
+      for (const nextId of depTask.dependents ?? []) {
+        if (!visited.has(nextId)) queue.push(nextId);
+      }
     }
   }
 
@@ -831,7 +842,10 @@ export class TaskQueueService {
     }
 
     // Fourth pass: crash recovery - normalize task states
-    // Tasks in "running" state are reset to "queued" or "blocked" after restart
+    // Tasks in "running" state are reset to "queued" or "blocked" after restart.
+    // Use transitionToQueued/Blocked so task:state-changed events fire and the
+    // orchestrator (subscribed before initialize() runs) wakes to dispatch
+    // recovered tasks.
     for (const task of this.tasks.values()) {
       if (task.status === "running") {
         console.warn(
@@ -843,11 +857,10 @@ export class TaskQueueService {
         task.runId = undefined;
         task.startedAt = undefined;
 
-        // Move to queued or blocked based on dependencies
         if (task.blockedBy && task.blockedBy.length > 0) {
-          task.status = "blocked";
+          await this.transitionToBlocked(task);
         } else {
-          task.status = "queued";
+          await this.transitionToQueued(task);
         }
       }
     }

--- a/electron/services/__tests__/TaskOrchestrator.test.ts
+++ b/electron/services/__tests__/TaskOrchestrator.test.ts
@@ -615,6 +615,64 @@ describe("TaskOrchestrator", () => {
       // No assertion needed beyond "did not throw". The test passes the
       // guard implicitly by reaching this point without error.
     });
+
+    it("records a distinct summary for agent:exited vs agent:completed", async () => {
+      const exitTask = await queueService.createTask({ title: "Exit task" });
+      const completeTask = await queueService.createTask({ title: "Complete task" });
+
+      mockPtyClient.getAvailableTerminalsAsync.mockResolvedValueOnce([
+        {
+          id: "term-exit",
+          kind: "terminal",
+          detectedAgentId: "claude",
+          agentState: "idle",
+        },
+      ]);
+
+      await queueService.enqueueTask(exitTask.id);
+      await settle();
+
+      const runningExit = await queueService.getTask(exitTask.id);
+      expect(runningExit?.status).toBe("running");
+
+      events.emit("agent:exited", {
+        terminalId: "term-exit",
+        agentType: "claude",
+        timestamp: Date.now(),
+      });
+      await settle();
+
+      const exited = await queueService.getTask(exitTask.id);
+      expect(exited?.status).toBe("completed");
+      expect(exited?.result?.summary).toMatch(/exited/i);
+      expect(exited?.result?.summary).not.toMatch(/Completed by agent/i);
+
+      mockPtyClient.getAvailableTerminalsAsync.mockResolvedValueOnce([
+        {
+          id: "term-complete",
+          kind: "terminal",
+          launchAgentId: "claude",
+          agentState: "idle",
+        },
+      ]);
+
+      await queueService.enqueueTask(completeTask.id);
+      await settle();
+
+      events.emit("agent:completed", {
+        agentId: "claude",
+        terminalId: "term-complete",
+        exitCode: 0,
+        duration: 1000,
+        timestamp: Date.now(),
+      });
+      await settle();
+
+      const completed = await queueService.getTask(completeTask.id);
+      expect(completed?.status).toBe("completed");
+      expect(completed?.result?.summary).toMatch(/Completed by agent/);
+      expect(completed?.result?.summary).not.toMatch(/exited/i);
+    });
   });
 
   describe("worktree removal handling", () => {

--- a/electron/services/__tests__/TaskOrchestrator.test.ts
+++ b/electron/services/__tests__/TaskOrchestrator.test.ts
@@ -644,8 +644,7 @@ describe("TaskOrchestrator", () => {
 
       const exited = await queueService.getTask(exitTask.id);
       expect(exited?.status).toBe("completed");
-      expect(exited?.result?.summary).toMatch(/exited/i);
-      expect(exited?.result?.summary).not.toMatch(/Completed by agent/i);
+      expect(exited?.result?.summary).toBe("Agent process exited (claude)");
 
       mockPtyClient.getAvailableTerminalsAsync.mockResolvedValueOnce([
         {
@@ -670,8 +669,7 @@ describe("TaskOrchestrator", () => {
 
       const completed = await queueService.getTask(completeTask.id);
       expect(completed?.status).toBe("completed");
-      expect(completed?.result?.summary).toMatch(/Completed by agent/);
-      expect(completed?.result?.summary).not.toMatch(/exited/i);
+      expect(completed?.result?.summary).toBe("Completed by agent claude");
     });
   });
 

--- a/electron/services/__tests__/TaskQueueService.test.ts
+++ b/electron/services/__tests__/TaskQueueService.test.ts
@@ -14,6 +14,8 @@ vi.mock("electron", () => ({
 
 import { TaskQueueService } from "../TaskQueueService.js";
 import { events } from "../events.js";
+import { taskPersistence } from "../persistence/TaskPersistence.js";
+import type { TaskRecord } from "../../../shared/types/task.js";
 
 describe("TaskQueueService", () => {
   let service: TaskQueueService;
@@ -709,10 +711,197 @@ describe("TaskQueueService", () => {
       await service.createTask({ title: "Task 1" });
       await service.createTask({ title: "Task 2" });
 
+      const tasks = await service.listTasks();
+      expect(tasks).toHaveLength(2);
+
       service.clear();
 
-      const tasks = await service.listTasks();
-      expect(tasks).toHaveLength(0);
+      const cleared = await service.listTasks();
+      expect(cleared).toHaveLength(0);
+    });
+  });
+
+  describe("crash recovery", () => {
+    function makeRunningTask(overrides: Partial<TaskRecord> = {}): TaskRecord {
+      const now = Date.now();
+      return {
+        id: overrides.id ?? "task-running-1",
+        title: overrides.title ?? "Running task",
+        status: "running",
+        priority: 0,
+        createdAt: now,
+        updatedAt: now,
+        dependencies: overrides.dependencies ?? [],
+        dependents: [],
+        assignedAgentId: "agent-1",
+        runId: "run-1",
+        startedAt: now,
+        ...overrides,
+      };
+    }
+
+    it("emits task:state-changed for running tasks reset to queued", async () => {
+      const recovery = new TaskQueueService();
+      const loadSpy = vi
+        .spyOn(taskPersistence, "load")
+        .mockResolvedValue([makeRunningTask({ id: "t-1" })]);
+      const saveSpy = vi.spyOn(taskPersistence, "save").mockResolvedValue();
+      const emitSpy = vi.spyOn(events, "emit");
+
+      try {
+        await recovery.initialize("project-recovery");
+
+        const queuedEvents = emitSpy.mock.calls.filter(
+          ([name, payload]) =>
+            name === "task:state-changed" &&
+            (payload as { taskId: string; state: string }).taskId === "t-1" &&
+            (payload as { taskId: string; state: string }).state === "queued"
+        );
+        expect(queuedEvents).toHaveLength(1);
+        expect(queuedEvents[0][1]).toMatchObject({
+          taskId: "t-1",
+          state: "queued",
+          previousState: "running",
+        });
+
+        const recovered = await recovery.getTask("t-1");
+        expect(recovered?.status).toBe("queued");
+        expect(recovered?.assignedAgentId).toBeUndefined();
+        expect(recovered?.runId).toBeUndefined();
+        expect(recovered?.startedAt).toBeUndefined();
+      } finally {
+        loadSpy.mockRestore();
+        saveSpy.mockRestore();
+      }
+    });
+
+    it("emits task:state-changed for running tasks with unmet dependencies reset to blocked", async () => {
+      const recovery = new TaskQueueService();
+      const dep: TaskRecord = {
+        id: "dep-1",
+        title: "Dependency",
+        status: "queued",
+        priority: 0,
+        createdAt: Date.now(),
+        updatedAt: Date.now(),
+        dependencies: [],
+        dependents: [],
+      };
+      const loadSpy = vi
+        .spyOn(taskPersistence, "load")
+        .mockResolvedValue([dep, makeRunningTask({ id: "t-blocked", dependencies: ["dep-1"] })]);
+      const saveSpy = vi.spyOn(taskPersistence, "save").mockResolvedValue();
+      const emitSpy = vi.spyOn(events, "emit");
+
+      try {
+        await recovery.initialize("project-blocked");
+
+        const blockedEvents = emitSpy.mock.calls.filter(
+          ([name, payload]) =>
+            name === "task:state-changed" &&
+            (payload as { taskId: string; state: string }).taskId === "t-blocked" &&
+            (payload as { taskId: string; state: string }).state === "blocked"
+        );
+        expect(blockedEvents).toHaveLength(1);
+
+        const recovered = await recovery.getTask("t-blocked");
+        expect(recovered?.status).toBe("blocked");
+      } finally {
+        loadSpy.mockRestore();
+        saveSpy.mockRestore();
+      }
+    });
+  });
+
+  describe("upstream failure cascade", () => {
+    it("cascades through a deep linear chain without stack overflow", async () => {
+      // 1000 tasks: t0 -> t1 -> t2 -> ... -> t999. Recursion would blow the
+      // call stack on long chains; iterative BFS handles this in linear time.
+      const ids: string[] = [];
+      let prev: { id: string } | null = null;
+      for (let i = 0; i < 1000; i++) {
+        const task = await service.createTask({
+          title: `Task ${i}`,
+          dependencies: prev ? [prev.id] : [],
+        });
+        ids.push(task.id);
+        prev = task;
+      }
+
+      for (const id of ids) {
+        await service.enqueueTask(id);
+      }
+
+      await service.markRunning(ids[0], "agent-1", "run-1");
+      await service.markFailed(ids[0], "Root failure");
+
+      // All downstream tasks must be marked failed.
+      for (const id of ids.slice(1)) {
+        const task = await service.getTask(id);
+        expect(task?.status).toBe("failed");
+      }
+    });
+
+    it("processes diamond dependencies exactly once", async () => {
+      // Diamond: A -> B, A -> C, B -> D, C -> D. D appears in both B's and
+      // C's dependents. The visited set must prevent double-processing.
+      const taskA = await service.createTask({ title: "A" });
+      const taskB = await service.createTask({ title: "B", dependencies: [taskA.id] });
+      const taskC = await service.createTask({ title: "C", dependencies: [taskA.id] });
+      const taskD = await service.createTask({
+        title: "D",
+        dependencies: [taskB.id, taskC.id],
+      });
+
+      await service.enqueueTask(taskA.id);
+      await service.enqueueTask(taskB.id);
+      await service.enqueueTask(taskC.id);
+      await service.enqueueTask(taskD.id);
+
+      const emitSpy = vi.spyOn(events, "emit");
+
+      await service.markRunning(taskA.id, "agent-1", "run-1");
+      await service.markFailed(taskA.id, "A failed");
+
+      const dStateChanges = emitSpy.mock.calls.filter(
+        ([name, payload]) =>
+          name === "task:state-changed" &&
+          (payload as { taskId: string; state: string }).taskId === taskD.id &&
+          (payload as { taskId: string; state: string }).state === "failed"
+      );
+      expect(dStateChanges).toHaveLength(1);
+
+      expect((await service.getTask(taskD.id))?.status).toBe("failed");
+    });
+
+    it("terminates safely on a cyclic dependents graph (corrupted state)", async () => {
+      // Build a normal DAG, then corrupt the in-memory dependents to form a
+      // cycle: A.dependents = [B], B.dependents = [A]. Validation prevents
+      // creating this through the public API, but a corrupted persisted state
+      // could in theory reproduce it.
+      const corruptService = new TaskQueueService();
+      corruptService.setPersistenceEnabled(false);
+
+      const taskA = await corruptService.createTask({ title: "A" });
+      const taskB = await corruptService.createTask({
+        title: "B",
+        dependencies: [taskA.id],
+      });
+
+      // Force a cycle in the runtime dependents graph.
+      const internal = (corruptService as unknown as { tasks: Map<string, TaskRecord> }).tasks;
+      const a = internal.get(taskA.id)!;
+      const b = internal.get(taskB.id)!;
+      b.dependents = [a.id];
+
+      await corruptService.enqueueTask(taskA.id);
+      await corruptService.enqueueTask(taskB.id);
+      await corruptService.markRunning(taskA.id, "agent-1", "run-1");
+
+      // Must terminate (no stack overflow, no infinite loop).
+      await corruptService.markFailed(taskA.id, "A failed");
+
+      expect((await corruptService.getTask(taskB.id))?.status).toBe("failed");
     });
   });
 });

--- a/electron/services/__tests__/TaskQueueService.test.ts
+++ b/electron/services/__tests__/TaskQueueService.test.ts
@@ -740,7 +740,7 @@ describe("TaskQueueService", () => {
       };
     }
 
-    it("emits task:state-changed for running tasks reset to queued", async () => {
+    it("emits task:state-changed for running tasks reset to queued and persists normalized state", async () => {
       const recovery = new TaskQueueService();
       const loadSpy = vi
         .spyOn(taskPersistence, "load")
@@ -769,6 +769,41 @@ describe("TaskQueueService", () => {
         expect(recovered?.assignedAgentId).toBeUndefined();
         expect(recovered?.runId).toBeUndefined();
         expect(recovered?.startedAt).toBeUndefined();
+
+        // Critical: normalized state must be persisted so a subsequent crash
+        // doesn't replay the same recovery loop forever.
+        expect(saveSpy).toHaveBeenCalled();
+        const lastSave = saveSpy.mock.calls.at(-1);
+        expect(lastSave?.[0]).toBe("project-recovery");
+        const persistedTasks = lastSave?.[1] as TaskRecord[];
+        const persistedT1 = persistedTasks.find((t) => t.id === "t-1");
+        expect(persistedT1?.status).toBe("queued");
+        expect(persistedT1?.assignedAgentId).toBeUndefined();
+        expect(persistedT1?.runId).toBeUndefined();
+      } finally {
+        loadSpy.mockRestore();
+        saveSpy.mockRestore();
+      }
+    });
+
+    it("does not schedule a save when no tasks need recovery", async () => {
+      const recovery = new TaskQueueService();
+      const cleanTask: TaskRecord = {
+        id: "t-clean",
+        title: "Clean",
+        status: "queued",
+        priority: 0,
+        createdAt: Date.now(),
+        updatedAt: Date.now(),
+        dependencies: [],
+        dependents: [],
+      };
+      const loadSpy = vi.spyOn(taskPersistence, "load").mockResolvedValue([cleanTask]);
+      const saveSpy = vi.spyOn(taskPersistence, "save").mockResolvedValue();
+
+      try {
+        await recovery.initialize("project-clean");
+        expect(saveSpy).not.toHaveBeenCalled();
       } finally {
         loadSpy.mockRestore();
         saveSpy.mockRestore();


### PR DESCRIPTION
## Summary

Four targeted fixes in the task orchestration subsystem — no structural rewrites, just closing gaps that could cause silent data loss or stuck queues.

- Wires `flushPersistence` into the shutdown chain before `closeSharedDb`, so debounced SQLite writes aren't silently dropped on quit
- Emits `task:state-changed` from crash recovery so the orchestrator actually wakes on recovered tasks instead of sitting idle until the next unrelated event
- Rewrites `handleUpstreamFailure` as iterative BFS with a visited-set guard — prevents stack overflow on deep dependency chains and repeated work on diamond-shaped DAGs
- Differentiates the `agent:exited` summary string from `agent:completed` so process crashes don't surface as successful completions

Resolves #7037

## Changes

- `electron/lifecycle/shutdown.ts` — `flushPersistence` wired in before `closeSharedDb`
- `electron/services/TaskQueueService.ts` — crash recovery emits `task:state-changed`; `handleUpstreamFailure` rewritten as iterative BFS with visited set; `schedulePersist` called after recovery loop
- `electron/services/TaskOrchestrator.ts` — `agent:exited` summary string differentiated from `agent:completed`

## Testing

New tests cover: shutdown ordering (`flushPersistence` → `dispose` → `closeSharedDb`) and flush-failure tolerance; crash recovery emits and persists normalized state; no-op when nothing to recover; 1000-task cascade without stack overflow; diamond DAG processed exactly once; cyclic-dependents corruption terminates safely; `agent:exited` summary distinct from `agent:completed`.