### PR TITLE
fix(worktree): harden create-path input validation (#7033)

### DIFF
--- a/electron/ipc/handlers/__tests__/worktree.adversarial.test.ts
+++ b/electron/ipc/handlers/__tests__/worktree.adversarial.test.ts
@@ -14,6 +14,9 @@ const generateWorktreePathMock = vi.hoisted(() => vi.fn());
 const validatePathPatternMock = vi.hoisted(() =>
   vi.fn<(pattern: string) => { valid: boolean; error?: string }>(() => ({ valid: true }))
 );
+const validateBranchNameMock = vi.hoisted(() =>
+  vi.fn<(name: string) => { valid: boolean; error?: string }>(() => ({ valid: true }))
+);
 const resolveWorktreePatternMock = vi.hoisted(() => vi.fn().mockResolvedValue("../wt/{branch}"));
 
 const storeMock = vi.hoisted(() => ({
@@ -98,6 +101,7 @@ vi.mock("../../../utils/worktreePattern.js", () => ({
 vi.mock("../../../../shared/utils/pathPattern.js", () => ({
   generateWorktreePath: generateWorktreePathMock,
   validatePathPattern: validatePathPatternMock,
+  validateBranchName: validateBranchNameMock,
 }));
 
 vi.mock("../../../utils/logger.js", () => ({
@@ -146,6 +150,10 @@ describe("worktree IPC adversarial", () => {
     vi.clearAllMocks();
     storeMock.get.mockImplementation(baseStoreGetImpl());
     waitForRateLimitSlotMock.mockResolvedValue(undefined);
+    // vi.clearAllMocks resets the implementation; re-anchor the default so
+    // every WORKTREE_CREATE call sees a passing branch validator unless the
+    // specific test overrides it.
+    validateBranchNameMock.mockImplementation(() => ({ valid: true }));
 
     worktreeService = {
       getAllStatesAsync: vi.fn().mockResolvedValue([]),
@@ -198,6 +206,38 @@ describe("worktree IPC adversarial", () => {
     // Sound is fire-and-forget via dynamic import — drain microtasks first
     await new Promise((resolve) => setImmediate(resolve));
     expect(soundMock.play).toHaveBeenCalledWith("worktree-create");
+  });
+
+  it("WORKTREE_CREATE rejects invalid branch names before reaching worktreeService (#7033)", async () => {
+    validateBranchNameMock.mockReturnValueOnce({
+      valid: false,
+      error: "Branch name cannot be 'HEAD'",
+    });
+
+    await expect(
+      getHandler(CHANNELS.WORKTREE_CREATE)(fakeEvent(), {
+        rootPath: "/repo",
+        options: { baseBranch: "main", newBranch: "HEAD", path: "/repo/wt-head" },
+      })
+    ).rejects.toThrow(/HEAD/);
+
+    expect(worktreeService.createWorktree).not.toHaveBeenCalled();
+  });
+
+  it("WORKTREE_CREATE surfaces validator error message verbatim (#7033)", async () => {
+    validateBranchNameMock.mockReturnValueOnce({
+      valid: false,
+      error: "Branch name cannot contain '@{'",
+    });
+
+    await expect(
+      getHandler(CHANNELS.WORKTREE_CREATE)(fakeEvent(), {
+        rootPath: "/repo",
+        options: { baseBranch: "main", newBranch: "feat@{x", path: "/repo/wt-bad" },
+      })
+    ).rejects.toThrow(/@\{/);
+
+    expect(worktreeService.createWorktree).not.toHaveBeenCalled();
   });
 
   it("WORKTREE_DELETE invalidates the exact worktree path and prunes only matching issue mapping", async () => {

--- a/electron/ipc/handlers/__tests__/worktree.adversarial.test.ts
+++ b/electron/ipc/handlers/__tests__/worktree.adversarial.test.ts
@@ -240,6 +240,22 @@ describe("worktree IPC adversarial", () => {
     expect(worktreeService.createWorktree).not.toHaveBeenCalled();
   });
 
+  it("WORKTREE_CREATE rejects malformed payloads before validating (#7033)", async () => {
+    const handler = getHandler(CHANNELS.WORKTREE_CREATE);
+
+    await expect(handler(fakeEvent(), null)).rejects.toThrow(/Invalid worktree create payload/);
+    await expect(handler(fakeEvent(), {})).rejects.toThrow(/Invalid worktree create payload/);
+    await expect(handler(fakeEvent(), { rootPath: "/repo" })).rejects.toThrow(
+      /Invalid worktree create payload/
+    );
+    await expect(handler(fakeEvent(), { rootPath: "/repo", options: null })).rejects.toThrow(
+      /Invalid worktree create payload/
+    );
+
+    expect(validateBranchNameMock).not.toHaveBeenCalled();
+    expect(worktreeService.createWorktree).not.toHaveBeenCalled();
+  });
+
   it("WORKTREE_DELETE invalidates the exact worktree path and prunes only matching issue mapping", async () => {
     getWindowForWebContentsMock.mockReturnValue({ id: 5 });
     worktreeService.getAllStatesAsync.mockResolvedValue([

--- a/electron/ipc/handlers/__tests__/worktree.rateLimit.test.ts
+++ b/electron/ipc/handlers/__tests__/worktree.rateLimit.test.ts
@@ -69,6 +69,7 @@ vi.mock("../../../utils/worktreePattern.js", () => ({
 vi.mock("../../../../shared/utils/pathPattern.js", () => ({
   generateWorktreePath: vi.fn(() => "/test/worktrees/task-123"),
   validatePathPattern: vi.fn(() => ({ valid: true })),
+  validateBranchName: vi.fn(() => ({ valid: true })),
 }));
 
 vi.mock("../../../utils/logger.js", () => ({

--- a/electron/ipc/handlers/worktree/lifecycle.ts
+++ b/electron/ipc/handlers/worktree/lifecycle.ts
@@ -56,17 +56,25 @@ export function registerWorktreeLifecycleHandlers(deps: HandlerDependencies): ()
     rootPath: string;
     options: { baseBranch: string; newBranch: string; path: string; fromRemote?: boolean };
   }): Promise<string> => {
-    await waitForRateLimitSlot(WORKTREE_RATE_LIMIT_KEY, WORKTREE_RATE_LIMIT_INTERVAL_MS);
-    if (!deps.worktreeService) {
-      throw new Error("Workspace client not initialized");
+    if (
+      !payload ||
+      typeof payload !== "object" ||
+      !payload.options ||
+      typeof payload.options !== "object"
+    ) {
+      throw new Error("Invalid worktree create payload");
     }
     // Defense-in-depth: WorkspaceService.createWorktree also validates, but
-    // throwing here surfaces a clean Error to the renderer without spinning
-    // up the workspace-host process round-trip for obviously-invalid input.
-    // #7033.
+    // throwing here surfaces a clean Error to the renderer without consuming
+    // a rate-limit slot or spinning up the workspace-host round-trip for
+    // obviously-invalid input. #7033.
     const branchValidation = validateBranchName(payload.options.newBranch);
     if (!branchValidation.valid) {
       throw new Error(branchValidation.error ?? "Invalid branch name");
+    }
+    await waitForRateLimitSlot(WORKTREE_RATE_LIMIT_KEY, WORKTREE_RATE_LIMIT_INTERVAL_MS);
+    if (!deps.worktreeService) {
+      throw new Error("Workspace client not initialized");
     }
     const worktreeId = await deps.worktreeService.createWorktree(payload.rootPath, payload.options);
     try {

--- a/electron/ipc/handlers/worktree/lifecycle.ts
+++ b/electron/ipc/handlers/worktree/lifecycle.ts
@@ -20,6 +20,7 @@ import {
   typedHandle,
   typedHandleWithContext,
 } from "../../utils.js";
+import { validateBranchName } from "../../../../shared/utils/pathPattern.js";
 import { WORKTREE_RATE_LIMIT_KEY, WORKTREE_RATE_LIMIT_INTERVAL_MS } from "./constants.js";
 
 export function registerWorktreeLifecycleHandlers(deps: HandlerDependencies): () => void {
@@ -58,6 +59,14 @@ export function registerWorktreeLifecycleHandlers(deps: HandlerDependencies): ()
     await waitForRateLimitSlot(WORKTREE_RATE_LIMIT_KEY, WORKTREE_RATE_LIMIT_INTERVAL_MS);
     if (!deps.worktreeService) {
       throw new Error("Workspace client not initialized");
+    }
+    // Defense-in-depth: WorkspaceService.createWorktree also validates, but
+    // throwing here surfaces a clean Error to the renderer without spinning
+    // up the workspace-host process round-trip for obviously-invalid input.
+    // #7033.
+    const branchValidation = validateBranchName(payload.options.newBranch);
+    if (!branchValidation.valid) {
+      throw new Error(branchValidation.error ?? "Invalid branch name");
     }
     const worktreeId = await deps.worktreeService.createWorktree(payload.rootPath, payload.options);
     try {

--- a/electron/services/GitService.ts
+++ b/electron/services/GitService.ts
@@ -6,7 +6,8 @@ import { logDebug, logError, logWarn } from "../utils/logger.js";
 import type { GitStatus, WorktreeChanges } from "../../shared/types/index.js";
 import { WorktreeRemovedError, GitError, toGitOperationError } from "../utils/errorTypes.js";
 import type { CrossWorktreeDiffResult, CrossWorktreeFile } from "../../shared/types/ipc/git.js";
-import { createHardenedGit, validateBranchName } from "../utils/hardenedGit.js";
+import { createHardenedGit } from "../utils/hardenedGit.js";
+import { validateBranchName } from "../../shared/utils/pathPattern.js";
 import { formatErrorMessage } from "../../shared/utils/errorMessage.js";
 
 function escapeRegex(str: string): string {
@@ -100,8 +101,18 @@ export class GitService {
       fromRemote: options.fromRemote,
     });
 
-    validateBranchName(newBranch);
-    validateBranchName(baseBranch);
+    const newBranchValidation = validateBranchName(newBranch);
+    if (!newBranchValidation.valid) {
+      throw new Error(
+        `Invalid branch name '${newBranch}': ${newBranchValidation.error ?? "invalid"}`
+      );
+    }
+    const baseBranchValidation = validateBranchName(baseBranch);
+    if (!baseBranchValidation.valid) {
+      throw new Error(
+        `Invalid base branch '${baseBranch}': ${baseBranchValidation.error ?? "invalid"}`
+      );
+    }
 
     const pathValidation = this.validatePath(path);
     if (!pathValidation.valid) {
@@ -319,8 +330,14 @@ ${lines.map((l) => "+" + l).join("\n")}`;
     // Validate before the equality fast-path so an invalid argv-shaped name
     // is rejected unconditionally — not silently accepted when both inputs
     // happen to match.
-    validateBranchName(branch1);
-    validateBranchName(branch2);
+    const branch1Validation = validateBranchName(branch1);
+    if (!branch1Validation.valid) {
+      throw new Error(`Invalid branch name '${branch1}': ${branch1Validation.error ?? "invalid"}`);
+    }
+    const branch2Validation = validateBranchName(branch2);
+    if (!branch2Validation.valid) {
+      throw new Error(`Invalid branch name '${branch2}': ${branch2Validation.error ?? "invalid"}`);
+    }
 
     if (branch1 === branch2) {
       return filePath ? "NO_CHANGES" : { branch1, branch2, files: [] };

--- a/electron/services/__tests__/GitService.test.ts
+++ b/electron/services/__tests__/GitService.test.ts
@@ -224,7 +224,7 @@ describe("GitService", () => {
       const service = new GitService(tempDir);
 
       await expect(service.compareWorktrees("--exec=evil", "main")).rejects.toThrow(
-        "must not start with '-'"
+        "cannot start with '-'"
       );
       expect(gitClientMock.raw).not.toHaveBeenCalled();
     });
@@ -235,7 +235,7 @@ describe("GitService", () => {
       const service = new GitService(tempDir);
 
       await expect(service.compareWorktrees("--exec=evil", "--exec=evil")).rejects.toThrow(
-        "must not start with '-'"
+        "cannot start with '-'"
       );
       expect(gitClientMock.raw).not.toHaveBeenCalled();
     });
@@ -345,7 +345,7 @@ describe("GitService", () => {
           newBranch: "--exec=touch /tmp/x",
           path: target,
         })
-      ).rejects.toThrow("must not start with '-'");
+      ).rejects.toThrow("cannot start with '-'");
       expect(gitClientMock.raw).not.toHaveBeenCalled();
     });
 
@@ -359,7 +359,7 @@ describe("GitService", () => {
           newBranch: "feature/x",
           path: target,
         })
-      ).rejects.toThrow("must not start with '-'");
+      ).rejects.toThrow("cannot start with '-'");
       expect(gitClientMock.raw).not.toHaveBeenCalled();
     });
 

--- a/electron/services/commands/__tests__/githubWorkIssue.test.ts
+++ b/electron/services/commands/__tests__/githubWorkIssue.test.ts
@@ -56,6 +56,7 @@ vi.mock("../../../../shared/utils/pathPattern.js", () => ({
   DEFAULT_WORKTREE_PATH_PATTERN: "{repo}/{branch}",
   generateWorktreePath: generateWorktreePathMock,
   validatePathPattern: validatePathPatternMock,
+  validateBranchName: vi.fn(() => ({ valid: true })),
 }));
 
 vi.mock("../../../utils/worktreePattern.js", () => ({

--- a/electron/utils/__tests__/hardenedGit.test.ts
+++ b/electron/utils/__tests__/hardenedGit.test.ts
@@ -16,7 +16,6 @@ vi.mock("simple-git", () => ({
 
 import {
   validateCwd,
-  validateBranchName,
   createHardenedGit,
   createAuthenticatedGit,
   createBackgroundFetchGit,
@@ -66,88 +65,6 @@ describe("validateCwd", () => {
 
   it("does not throw for root path", () => {
     expect(() => validateCwd("/")).not.toThrow();
-  });
-});
-
-describe("validateBranchName", () => {
-  it("accepts simple branch names", () => {
-    expect(() => validateBranchName("main")).not.toThrow();
-    expect(() => validateBranchName("develop")).not.toThrow();
-    expect(() => validateBranchName("feature/login")).not.toThrow();
-    expect(() => validateBranchName("bugfix-7046")).not.toThrow();
-    expect(() => validateBranchName("user.name/topic_1")).not.toThrow();
-  });
-
-  it("accepts non-ASCII unicode names that git allows", () => {
-    expect(() => validateBranchName("café")).not.toThrow();
-    expect(() => validateBranchName("功能/登录")).not.toThrow();
-  });
-
-  it("rejects empty string", () => {
-    expect(() => validateBranchName("")).toThrow("Branch name is required");
-  });
-
-  it("rejects non-string input", () => {
-    expect(() => validateBranchName(123 as unknown as string)).toThrow("Branch name is required");
-    expect(() => validateBranchName(null as unknown as string)).toThrow("Branch name is required");
-    expect(() => validateBranchName(undefined as unknown as string)).toThrow(
-      "Branch name is required"
-    );
-  });
-
-  it("rejects leading-dash names that argv parsers treat as flags", () => {
-    expect(() => validateBranchName("-c")).toThrow("must not start with '-'");
-    expect(() => validateBranchName("--exec=touch /tmp/x")).toThrow("must not start with '-'");
-    expect(() => validateBranchName("-upload-pack=evil")).toThrow("must not start with '-'");
-  });
-
-  it("rejects '..' anywhere in the name", () => {
-    expect(() => validateBranchName("foo..bar")).toThrow("must not contain '..'");
-    expect(() => validateBranchName("..bar")).toThrow("must not contain '..'");
-  });
-
-  it("rejects '@{' (reflog token)", () => {
-    expect(() => validateBranchName("foo@{1}")).toThrow("must not contain '@{'");
-  });
-
-  it("rejects forbidden ref-format characters", () => {
-    expect(() => validateBranchName("a b")).toThrow("invalid characters");
-    expect(() => validateBranchName("a:b")).toThrow("invalid characters");
-    expect(() => validateBranchName("a?b")).toThrow("invalid characters");
-    expect(() => validateBranchName("a*b")).toThrow("invalid characters");
-    expect(() => validateBranchName("a[b")).toThrow("invalid characters");
-    expect(() => validateBranchName("a\\b")).toThrow("invalid characters");
-    expect(() => validateBranchName("a~b")).toThrow("invalid characters");
-    expect(() => validateBranchName("a^b")).toThrow("invalid characters");
-  });
-
-  it("rejects control characters", () => {
-    expect(() => validateBranchName("a\x00b")).toThrow("invalid characters");
-    expect(() => validateBranchName("a\nb")).toThrow("invalid characters");
-    expect(() => validateBranchName("a\tb")).toThrow("invalid characters");
-    expect(() => validateBranchName("a\x7fb")).toThrow("invalid characters");
-  });
-
-  it("rejects names ending with '.'", () => {
-    expect(() => validateBranchName("trailing.")).toThrow("must not end with '.'");
-  });
-
-  it("rejects names ending with '.lock'", () => {
-    expect(() => validateBranchName("foo.lock")).toThrow("'.lock' component");
-  });
-
-  it("rejects '.lock' on a non-final path component", () => {
-    expect(() => validateBranchName("foo.lock/bar")).toThrow("'.lock' component");
-    expect(() => validateBranchName("a/b.lock/c")).toThrow("'.lock' component");
-  });
-
-  it("rejects names that begin or end with '/'", () => {
-    expect(() => validateBranchName("/leading")).toThrow("must not start or end with '/'");
-    expect(() => validateBranchName("trailing/")).toThrow("must not start or end with '/'");
-  });
-
-  it("rejects consecutive slashes", () => {
-    expect(() => validateBranchName("double//slash")).toThrow("must not contain '//'");
   });
 });
 

--- a/electron/utils/hardenedGit.ts
+++ b/electron/utils/hardenedGit.ts
@@ -50,49 +50,6 @@ export function validateCwd(cwd: unknown): asserts cwd is string {
   }
 }
 
-// eslint-disable-next-line no-control-regex
-const BRANCH_NAME_FORBIDDEN_CHARS = /[\x00-\x1f\x7f ~^:?*[\\]/;
-
-/**
- * Validate a branch name as a strict subset of `git check-ref-format --branch`.
- * Primarily blocks leading-dash names that git's argv parser would treat as
- * flags (e.g. `--exec=touch /tmp/x`); also rejects control chars and other
- * git-special sequences. Throws on invalid input.
- */
-export function validateBranchName(branchName: unknown): asserts branchName is string {
-  if (typeof branchName !== "string" || branchName.length === 0) {
-    throw new Error("Branch name is required");
-  }
-  if (branchName.startsWith("-")) {
-    throw new Error("Branch name must not start with '-'");
-  }
-  if (BRANCH_NAME_FORBIDDEN_CHARS.test(branchName)) {
-    throw new Error("Branch name contains invalid characters");
-  }
-  if (branchName.includes("..")) {
-    throw new Error("Branch name must not contain '..'");
-  }
-  if (branchName.includes("@{")) {
-    throw new Error("Branch name must not contain '@{'");
-  }
-  if (branchName.endsWith(".")) {
-    throw new Error("Branch name must not end with '.'");
-  }
-  if (branchName.startsWith("/") || branchName.endsWith("/")) {
-    throw new Error("Branch name must not start or end with '/'");
-  }
-  if (branchName.includes("//")) {
-    throw new Error("Branch name must not contain '//'");
-  }
-  // `.lock` is forbidden on every path component, not only the final one —
-  // git rejects `foo.lock/bar` for the same reason it rejects `foo.lock`.
-  for (const component of branchName.split("/")) {
-    if (component.endsWith(".lock")) {
-      throw new Error("Branch name must not contain a '.lock' component");
-    }
-  }
-}
-
 export const GIT_BLOCK_TIMEOUT_MS = 30_000;
 
 /**

--- a/electron/workspace-host/WorkspaceService.ts
+++ b/electron/workspace-host/WorkspaceService.ts
@@ -1,14 +1,12 @@
 import os from "os";
 import PQueue from "p-queue";
+import { existsSync } from "fs";
 import { stat, readFile, access } from "fs/promises";
-import { resolve as pathResolve, isAbsolute } from "path";
+import { resolve as pathResolve, isAbsolute, dirname } from "path";
+import { validateBranchName } from "../../shared/utils/pathPattern.js";
 import { generateProjectId, settingsFilePath } from "../services/projectStorePaths.js";
 import { SimpleGit, BranchSummary } from "simple-git";
-import {
-  createHardenedGit,
-  createAuthenticatedGit,
-  validateBranchName,
-} from "../utils/hardenedGit.js";
+import { createHardenedGit, createAuthenticatedGit } from "../utils/hardenedGit.js";
 import { classifyGitError, getGitRecoveryAction } from "../../shared/utils/gitOperationErrors.js";
 import type { Worktree } from "../../shared/types/worktree.js";
 import type {
@@ -932,10 +930,30 @@ export class WorkspaceService {
       let { newBranch } = options;
       let { fromRemote = false, useExistingBranch = false } = options;
 
-      // Reject branch names that argv parsers would treat as flags (leading
-      // dash) or that contain git-special characters before any git call.
-      validateBranchName(newBranch);
-      validateBranchName(baseBranch);
+      // Authoritative validation gate. Every caller (IPC, MCP, recipes,
+      // worktree:create-for-task) reaches this method, so any branch-name or
+      // parent-dir issue caught here surfaces a clear error instead of
+      // bubbling up as a low-level git fatal. #7033. Also rejects argv-shaped
+      // names (leading dash) and git-special characters before any git call.
+      if (typeof newBranch !== "string" || newBranch.trim().length === 0) {
+        throw new Error("Branch name cannot be empty");
+      }
+      const newBranchValidation = validateBranchName(newBranch);
+      if (!newBranchValidation.valid) {
+        throw new Error(
+          `Invalid branch name '${newBranch}': ${newBranchValidation.error ?? "invalid"}`
+        );
+      }
+      const baseBranchValidation = validateBranchName(baseBranch);
+      if (!baseBranchValidation.valid) {
+        throw new Error(
+          `Invalid base branch '${baseBranch}': ${baseBranchValidation.error ?? "invalid"}`
+        );
+      }
+      const parentDir = dirname(path);
+      if (!existsSync(parentDir)) {
+        throw new Error(`Parent directory does not exist: ${parentDir}`);
+      }
 
       // #6463: when not explicitly reusing a branch, guard against a stale
       // local branch with the same name. Without this, `git worktree add -b`

--- a/electron/workspace-host/WorkspaceService.ts
+++ b/electron/workspace-host/WorkspaceService.ts
@@ -950,7 +950,11 @@ export class WorkspaceService {
           `Invalid base branch '${baseBranch}': ${baseBranchValidation.error ?? "invalid"}`
         );
       }
-      const parentDir = dirname(path);
+      // Resolve before taking dirname so a relative `path` (rare, but allowed
+      // through programmatic callers) is checked against the right parent
+      // rather than against process.cwd.
+      const absoluteCreatePath = isAbsolute(path) ? path : pathResolve(rootPath, path);
+      const parentDir = dirname(absoluteCreatePath);
       if (!existsSync(parentDir)) {
         throw new Error(`Parent directory does not exist: ${parentDir}`);
       }

--- a/electron/workspace-host/__tests__/WorkspaceService.adversarial.test.ts
+++ b/electron/workspace-host/__tests__/WorkspaceService.adversarial.test.ts
@@ -74,6 +74,13 @@ vi.mock("fs/promises", () => ({
   cp: vi.fn().mockResolvedValue(undefined),
 }));
 
+// #7033: createWorktree pre-flights the parent directory via existsSync.
+// Default to "exists" so existing tests focus on the git/monitor logic
+// rather than the pre-flight check.
+vi.mock("fs", () => ({
+  existsSync: vi.fn().mockReturnValue(true),
+}));
+
 describe("WorkspaceService adversarial", () => {
   let service: WorkspaceService;
   let sentEvents: WorkspaceHostEvent[];

--- a/electron/workspace-host/__tests__/WorkspaceService.createWorktree.test.ts
+++ b/electron/workspace-host/__tests__/WorkspaceService.createWorktree.test.ts
@@ -917,6 +917,57 @@ describe("WorkspaceService.createWorktree", () => {
     );
   });
 
+  it("validates branch name even when useExistingBranch is true (#7033)", async () => {
+    // The pre-flight gate must run unconditionally; useExistingBranch is just
+    // the create-strategy switch. A reuse caller passing 'HEAD' must still be
+    // rejected before reaching git.
+    await service.createWorktree("req-existing-head", "/test/root", {
+      baseBranch: "main",
+      newBranch: "HEAD",
+      path: "/test/worktree-existing-head",
+      useExistingBranch: true,
+    });
+
+    expect(mockSimpleGit.raw).not.toHaveBeenCalled();
+    expect(mockSendEvent).toHaveBeenCalledWith(
+      expect.objectContaining({
+        type: "create-worktree-result",
+        requestId: "req-existing-head",
+        success: false,
+        error: expect.stringContaining("HEAD"),
+      })
+    );
+  });
+
+  it("checks the parent directory of a relative path against rootPath (#7033)", async () => {
+    // Programmatic callers (MCP, recipes) may pass a relative `path`. The
+    // pre-flight must inspect the rootPath-resolved parent, not process.cwd.
+    const fsModule = await import("fs");
+    const existsSyncMock = vi.mocked(fsModule.existsSync);
+    existsSyncMock.mockImplementationOnce((p: unknown) => {
+      // Only return false for the expected resolved parent; other lookups
+      // (none in this test, but defensive) default to true.
+      return p !== "/test/root/worktrees";
+    });
+
+    await service.createWorktree("req-relative-path", "/test/root", {
+      baseBranch: "main",
+      newBranch: "feature/foo",
+      path: "worktrees/feat",
+    });
+
+    expect(existsSyncMock).toHaveBeenCalledWith("/test/root/worktrees");
+    expect(mockSimpleGit.raw).not.toHaveBeenCalled();
+    expect(mockSendEvent).toHaveBeenCalledWith(
+      expect.objectContaining({
+        type: "create-worktree-result",
+        requestId: "req-relative-path",
+        success: false,
+        error: expect.stringContaining("/test/root/worktrees"),
+      })
+    );
+  });
+
   it("emits a worktree-update before create-worktree-result so the renderer's store picks up the new worktree", async () => {
     // Regression guard for the bug where startWithoutGitStatus never emitted
     // an initial snapshot, leaving freshly-created worktrees invisible in the

--- a/electron/workspace-host/__tests__/WorkspaceService.createWorktree.test.ts
+++ b/electron/workspace-host/__tests__/WorkspaceService.createWorktree.test.ts
@@ -120,6 +120,13 @@ vi.mock("fs/promises", () => ({
   cp: vi.fn().mockResolvedValue(undefined),
 }));
 
+// #7033: createWorktree now pre-flights the parent directory via existsSync.
+// Default to "exists" so all pre-existing tests keep passing; the parent-dir
+// negative test below toggles it to false.
+vi.mock("fs", () => ({
+  existsSync: vi.fn().mockReturnValue(true),
+}));
+
 function flushAsyncTail(): Promise<void> {
   return new Promise((resolve) => setImmediate(resolve));
 }
@@ -723,10 +730,12 @@ describe("WorkspaceService.createWorktree", () => {
   });
 
   it("escapes regex metacharacters in branch names when computing suffixes", async () => {
-    // Branch names like `bugfix/[6463]` contain regex metacharacters; without
-    // escaping, the suffix scan would miss `bugfix/[6463]-2` and reissue it.
+    // Branch names like `bugfix/foo(6463)` contain regex metacharacters; without
+    // escaping, the suffix scan would miss `bugfix/foo(6463)-2` and reissue it.
+    // Parens are valid per git check-ref-format; pre-#7033 the test used `[…]`
+    // but `[` is forbidden by check-ref-format and now rejected at the gate.
     mockSimpleGit.branchLocal.mockResolvedValueOnce({
-      all: ["main", "bugfix/[6463]", "bugfix/[6463]-2"],
+      all: ["main", "bugfix/foo(6463)", "bugfix/foo(6463)-2"],
       current: "main",
       branches: {},
       detached: false,
@@ -741,7 +750,7 @@ describe("WorkspaceService.createWorktree", () => {
             "",
             "worktree /test/live",
             "HEAD def",
-            "branch refs/heads/bugfix/[6463]",
+            "branch refs/heads/bugfix/foo(6463)",
             "",
           ].join("\n")
         );
@@ -751,14 +760,14 @@ describe("WorkspaceService.createWorktree", () => {
 
     await service.createWorktree("req-regex-escape", "/test/root", {
       baseBranch: "main",
-      newBranch: "bugfix/[6463]",
+      newBranch: "bugfix/foo(6463)",
       path: "/test/worktree-regex",
     });
 
     const worktreeAddCall = mockSimpleGit.raw.mock.calls.find(
       (call) => call[0][0] === "worktree" && call[0][1] === "add"
     );
-    expect(worktreeAddCall![0][3]).toBe("bugfix/[6463]-3");
+    expect(worktreeAddCall![0][3]).toBe("bugfix/foo(6463)-3");
   });
 
   it("proceeds with the original -b path when the branch does not exist locally", async () => {
@@ -814,6 +823,98 @@ describe("WorkspaceService.createWorktree", () => {
       "/test/worktree-explicit",
       "existing-branch",
     ]);
+  });
+
+  it("rejects empty newBranch before invoking git (#7033)", async () => {
+    await service.createWorktree("req-empty", "/test/root", {
+      baseBranch: "main",
+      newBranch: "",
+      path: "/test/worktree-empty",
+    });
+
+    expect(mockSimpleGit.raw).not.toHaveBeenCalled();
+    expect(mockSendEvent).toHaveBeenCalledWith(
+      expect.objectContaining({
+        type: "create-worktree-result",
+        requestId: "req-empty",
+        success: false,
+        error: expect.stringMatching(/empty/i),
+      })
+    );
+  });
+
+  it("rejects whitespace-only newBranch before invoking git (#7033)", async () => {
+    await service.createWorktree("req-blank", "/test/root", {
+      baseBranch: "main",
+      newBranch: "   ",
+      path: "/test/worktree-blank",
+    });
+
+    expect(mockSimpleGit.raw).not.toHaveBeenCalled();
+    expect(mockSendEvent).toHaveBeenCalledWith(
+      expect.objectContaining({
+        type: "create-worktree-result",
+        requestId: "req-blank",
+        success: false,
+      })
+    );
+  });
+
+  it("rejects git-invalid branch names before invoking git (#7033)", async () => {
+    await service.createWorktree("req-head", "/test/root", {
+      baseBranch: "main",
+      newBranch: "HEAD",
+      path: "/test/worktree-head",
+    });
+
+    expect(mockSimpleGit.raw).not.toHaveBeenCalled();
+    expect(mockSendEvent).toHaveBeenCalledWith(
+      expect.objectContaining({
+        type: "create-worktree-result",
+        requestId: "req-head",
+        success: false,
+        error: expect.stringContaining("HEAD"),
+      })
+    );
+  });
+
+  it("rejects Windows-reserved branch names before invoking git (#7033)", async () => {
+    await service.createWorktree("req-nul", "/test/root", {
+      baseBranch: "main",
+      newBranch: "feature/NUL",
+      path: "/test/worktree-nul",
+    });
+
+    expect(mockSimpleGit.raw).not.toHaveBeenCalled();
+    expect(mockSendEvent).toHaveBeenCalledWith(
+      expect.objectContaining({
+        type: "create-worktree-result",
+        requestId: "req-nul",
+        success: false,
+        error: expect.stringMatching(/Windows-reserved/),
+      })
+    );
+  });
+
+  it("rejects when parent directory does not exist (#7033)", async () => {
+    const fsModule = await import("fs");
+    vi.mocked(fsModule.existsSync).mockReturnValueOnce(false);
+
+    await service.createWorktree("req-no-parent", "/test/root", {
+      baseBranch: "main",
+      newBranch: "feature/foo",
+      path: "/missing/parent/worktree",
+    });
+
+    expect(mockSimpleGit.raw).not.toHaveBeenCalled();
+    expect(mockSendEvent).toHaveBeenCalledWith(
+      expect.objectContaining({
+        type: "create-worktree-result",
+        requestId: "req-no-parent",
+        success: false,
+        error: expect.stringContaining("Parent directory does not exist"),
+      })
+    );
   });
 
   it("emits a worktree-update before create-worktree-result so the renderer's store picks up the new worktree", async () => {

--- a/shared/utils/__tests__/pathPattern.test.ts
+++ b/shared/utils/__tests__/pathPattern.test.ts
@@ -5,6 +5,7 @@ import {
   buildPathPatternVariables,
   generateWorktreePath,
   validatePathPattern,
+  validateBranchName,
   previewPathPattern,
   DEFAULT_WORKTREE_PATH_PATTERN,
 } from "../pathPattern.js";
@@ -218,6 +219,109 @@ describe("DEFAULT_WORKTREE_PATH_PATTERN", () => {
       DEFAULT_WORKTREE_PATH_PATTERN
     );
     expect(result).toBe("/home/user/repos/my-app-worktrees/develop");
+  });
+});
+
+describe("validateBranchName", () => {
+  it("accepts simple valid names", () => {
+    expect(validateBranchName("feature/foo").valid).toBe(true);
+    expect(validateBranchName("bugfix/issue-7033").valid).toBe(true);
+    expect(validateBranchName("release/v1.2.3").valid).toBe(true);
+    expect(validateBranchName("develop").valid).toBe(true);
+  });
+
+  it("rejects empty / blank input", () => {
+    expect(validateBranchName("").valid).toBe(false);
+    expect(validateBranchName("   ").valid).toBe(false);
+  });
+
+  it("rejects 'HEAD' (exact, case-sensitive)", () => {
+    expect(validateBranchName("HEAD").valid).toBe(false);
+    // 'head' is a perfectly valid git branch name.
+    expect(validateBranchName("head").valid).toBe(true);
+  });
+
+  it("rejects '@' alone", () => {
+    expect(validateBranchName("@").valid).toBe(false);
+    // 'foo@bar' is fine — only the bare '@' is reserved.
+    expect(validateBranchName("foo@bar").valid).toBe(true);
+  });
+
+  it("rejects names that start with '-'", () => {
+    expect(validateBranchName("-bad").valid).toBe(false);
+  });
+
+  it("rejects forbidden punctuation: space ~ ^ : ? * [ \\", () => {
+    expect(validateBranchName("feature foo").valid).toBe(false);
+    expect(validateBranchName("feature~foo").valid).toBe(false);
+    expect(validateBranchName("feature^foo").valid).toBe(false);
+    expect(validateBranchName("feature:foo").valid).toBe(false);
+    expect(validateBranchName("feature?foo").valid).toBe(false);
+    expect(validateBranchName("feature*foo").valid).toBe(false);
+    expect(validateBranchName("feature[foo").valid).toBe(false);
+    expect(validateBranchName("feature\\foo").valid).toBe(false);
+  });
+
+  it("rejects '..' and '@{' substrings", () => {
+    expect(validateBranchName("feature..foo").valid).toBe(false);
+    expect(validateBranchName("feature@{foo").valid).toBe(false);
+  });
+
+  it("rejects consecutive slashes and leading/trailing slashes", () => {
+    expect(validateBranchName("feature//foo").valid).toBe(false);
+    expect(validateBranchName("/feature").valid).toBe(false);
+    expect(validateBranchName("feature/").valid).toBe(false);
+  });
+
+  it("rejects components starting with '.' or ending with '.' / '.lock'", () => {
+    expect(validateBranchName("feature/.hidden").valid).toBe(false);
+    expect(validateBranchName(".feature").valid).toBe(false);
+    expect(validateBranchName("feature/foo.").valid).toBe(false);
+    expect(validateBranchName("feature.").valid).toBe(false);
+    expect(validateBranchName("feature/foo.lock").valid).toBe(false);
+    expect(validateBranchName("feature.lock").valid).toBe(false);
+  });
+
+  it("rejects ASCII control characters", () => {
+    expect(validateBranchName("feat\x01ure").valid).toBe(false);
+    expect(validateBranchName("feat\x09ure").valid).toBe(false); // tab
+    expect(validateBranchName("feat\x7fure").valid).toBe(false); // DEL
+  });
+
+  it("rejects Windows reserved names in any component, case-insensitively", () => {
+    expect(validateBranchName("CON").valid).toBe(false);
+    expect(validateBranchName("con").valid).toBe(false);
+    expect(validateBranchName("Nul").valid).toBe(false);
+    expect(validateBranchName("PRN").valid).toBe(false);
+    expect(validateBranchName("AUX").valid).toBe(false);
+    expect(validateBranchName("COM0").valid).toBe(false);
+    expect(validateBranchName("COM9").valid).toBe(false);
+    expect(validateBranchName("LPT1").valid).toBe(false);
+    expect(validateBranchName("LPT0").valid).toBe(false);
+    expect(validateBranchName("feature/nul").valid).toBe(false);
+    expect(validateBranchName("nul/feature").valid).toBe(false);
+  });
+
+  it("rejects Windows reserved names with extension suffixes", () => {
+    expect(validateBranchName("NUL.txt").valid).toBe(false);
+    expect(validateBranchName("feature/CON.md").valid).toBe(false);
+    expect(validateBranchName("prn.lock").valid).toBe(false);
+  });
+
+  it("does not reject names that merely contain a reserved substring", () => {
+    expect(validateBranchName("nullable").valid).toBe(true);
+    expect(validateBranchName("connection").valid).toBe(true);
+    expect(validateBranchName("auxiliary").valid).toBe(true);
+  });
+
+  it("returns a descriptive error for the failure cause", () => {
+    const result = validateBranchName("feature@{x");
+    expect(result.valid).toBe(false);
+    expect(result.error).toContain("@{");
+
+    const reservedResult = validateBranchName("feature/NUL");
+    expect(reservedResult.valid).toBe(false);
+    expect(reservedResult.error).toMatch(/Windows-reserved/);
   });
 });
 

--- a/shared/utils/__tests__/pathPattern.test.ts
+++ b/shared/utils/__tests__/pathPattern.test.ts
@@ -282,6 +282,12 @@ describe("validateBranchName", () => {
     expect(validateBranchName("feature.lock").valid).toBe(false);
   });
 
+  it("rejects '.lock' on a middle path component", () => {
+    // git check-ref-format rejects component-level .lock anywhere, not just
+    // the final component. The split-by-'/' loop must catch the middle case.
+    expect(validateBranchName("feature/foo.lock/bar").valid).toBe(false);
+  });
+
   it("rejects ASCII control characters", () => {
     expect(validateBranchName("feat\x01ure").valid).toBe(false);
     expect(validateBranchName("feat\x09ure").valid).toBe(false); // tab

--- a/shared/utils/pathPattern.ts
+++ b/shared/utils/pathPattern.ts
@@ -141,6 +141,115 @@ export function generateWorktreePath(
   return resolvePathPattern(pattern, variables, rootPath);
 }
 
+// Windows reserved device names (case-insensitive). Microsoft added COM0/LPT0
+// in Windows 10 1803, so the set covers 0–9 for both COM and LPT. Match
+// against each path component after stripping any extension (e.g. NUL.txt).
+const WINDOWS_RESERVED_NAMES = new Set([
+  "CON",
+  "PRN",
+  "AUX",
+  "NUL",
+  "COM0",
+  "COM1",
+  "COM2",
+  "COM3",
+  "COM4",
+  "COM5",
+  "COM6",
+  "COM7",
+  "COM8",
+  "COM9",
+  "LPT0",
+  "LPT1",
+  "LPT2",
+  "LPT3",
+  "LPT4",
+  "LPT5",
+  "LPT6",
+  "LPT7",
+  "LPT8",
+  "LPT9",
+]);
+
+export function validateBranchName(name: string): { valid: boolean; error?: string } {
+  if (typeof name !== "string" || name.length === 0) {
+    return { valid: false, error: "Branch name cannot be empty" };
+  }
+  if (name.trim().length === 0) {
+    return { valid: false, error: "Branch name cannot be blank" };
+  }
+
+  if (name === "HEAD") {
+    return { valid: false, error: "Branch name cannot be 'HEAD'" };
+  }
+  if (name === "@") {
+    return { valid: false, error: "Branch name cannot be '@'" };
+  }
+  if (name.startsWith("-")) {
+    return { valid: false, error: "Branch name cannot start with '-'" };
+  }
+
+  for (let i = 0; i < name.length; i++) {
+    const code = name.charCodeAt(i);
+    if (code < 32 || code === 127) {
+      return { valid: false, error: "Branch name cannot contain control characters" };
+    }
+  }
+
+  // git check-ref-format: space, ~, ^, :, ?, *, [, \ are forbidden anywhere.
+  const forbidden = /[ ~^:?*[\\]/;
+  const match = name.match(forbidden);
+  if (match) {
+    return { valid: false, error: `Branch name cannot contain '${match[0]}'` };
+  }
+
+  if (name.includes("..")) {
+    return { valid: false, error: "Branch name cannot contain '..'" };
+  }
+  if (name.includes("@{")) {
+    return { valid: false, error: "Branch name cannot contain '@{'" };
+  }
+  if (name.includes("//")) {
+    return { valid: false, error: "Branch name cannot contain consecutive slashes" };
+  }
+  if (name.startsWith("/") || name.endsWith("/")) {
+    return { valid: false, error: "Branch name cannot start or end with '/'" };
+  }
+  if (name.endsWith(".")) {
+    return { valid: false, error: "Branch name cannot end with '.'" };
+  }
+  if (name.endsWith(".lock")) {
+    return { valid: false, error: "Branch name cannot end with '.lock'" };
+  }
+
+  const components = name.split("/");
+  for (const component of components) {
+    if (component.length === 0) {
+      return { valid: false, error: "Branch name cannot have empty path components" };
+    }
+    if (component.startsWith(".")) {
+      return { valid: false, error: "Branch name components cannot start with '.'" };
+    }
+    if (component.endsWith(".lock")) {
+      return { valid: false, error: "Branch name components cannot end with '.lock'" };
+    }
+
+    // Windows reserved-name check: strip any extension (NUL.txt is reserved
+    // because the base name resolves to NUL on Windows) and compare the base
+    // name case-insensitively against the device-name set.
+    const dotIndex = component.indexOf(".");
+    const base = dotIndex === -1 ? component : component.slice(0, dotIndex);
+    if (WINDOWS_RESERVED_NAMES.has(base.toUpperCase())) {
+      return {
+        valid: false,
+        error: `Branch name uses Windows-reserved name '${base}'`,
+      };
+    }
+  }
+
+  return { valid: true };
+}
+
 export function validatePathPattern(pattern: string): { valid: boolean; error?: string } {
   if (!pattern || pattern.trim().length === 0) {
     return { valid: false, error: "Pattern cannot be empty" };

--- a/src/components/Worktree/hooks/__tests__/useWorktreeFormValidation.test.ts
+++ b/src/components/Worktree/hooks/__tests__/useWorktreeFormValidation.test.ts
@@ -129,6 +129,9 @@ describe("useWorktreeFormValidation", () => {
   });
 
   it("rejects invalid prefix characters", () => {
+    // #7033: error messages now come from the shared validateBranchName and
+    // identify the specific forbidden character (":" here) rather than the
+    // generic "invalid characters" copy.
     const { result } = renderHook(() => useWorktreeFormValidation());
 
     const validation = result.current.validate({
@@ -136,7 +139,8 @@ describe("useWorktreeFormValidation", () => {
       branchInput: "bad:prefix/my-feature",
     });
     expect(validation.valid).toBe(false);
-    expect(validation.error?.message).toContain("invalid characters");
+    expect(validation.error?.field).toBe("new-branch");
+    expect(validation.error?.message).toMatch(/':'|invalid character/i);
   });
 
   it("rejects missing worktree path", () => {

--- a/src/components/Worktree/hooks/useBranchValidation.ts
+++ b/src/components/Worktree/hooks/useBranchValidation.ts
@@ -70,15 +70,21 @@ export function useBranchValidation({
         setPathWasAutoResolved(false);
         setIsCheckingBranch(false);
         setIsGeneratingPath(false);
+        setWorktreePath("");
         return;
       }
 
       // Use the shared validator that the IPC handler and WorkspaceService
       // both rely on, so the dialog rejects exactly the names the server
-      // would.
+      // would. Clear path/auto-resolve state so a previously valid name's
+      // suggested path doesn't linger and let useWorktreeFormValidation
+      // green-light a submit on a now-invalid input.
       if (!validateBranchName(fullName).valid) {
         setIsCheckingBranch(false);
         setIsGeneratingPath(false);
+        setWorktreePath("");
+        setBranchWasAutoResolved(false);
+        setPathWasAutoResolved(false);
         return;
       }
 

--- a/src/components/Worktree/hooks/useBranchValidation.ts
+++ b/src/components/Worktree/hooks/useBranchValidation.ts
@@ -1,6 +1,7 @@
 import { useState, useEffect, useRef } from "react";
 import { worktreeClient } from "@/clients";
 import { logError } from "@/utils/logger";
+import { validateBranchName } from "@shared/utils/pathPattern";
 import { parseBranchInput } from "../branchPrefixUtils";
 
 export interface UseBranchValidationResult {
@@ -72,22 +73,13 @@ export function useBranchValidation({
         return;
       }
 
-      if (parsed.hasPrefix) {
-        if (/[\s.]$/.test(parsed.slug) || /^[.-]/.test(parsed.slug) || /[\\:]/.test(parsed.slug)) {
-          setIsCheckingBranch(false);
-          setIsGeneratingPath(false);
-          return;
-        }
-      } else {
-        if (
-          /[\s.]$/.test(trimmedInput) ||
-          /^[.-]/.test(trimmedInput) ||
-          /[/\\:]/.test(trimmedInput)
-        ) {
-          setIsCheckingBranch(false);
-          setIsGeneratingPath(false);
-          return;
-        }
+      // Use the shared validator that the IPC handler and WorkspaceService
+      // both rely on, so the dialog rejects exactly the names the server
+      // would.
+      if (!validateBranchName(fullName).valid) {
+        setIsCheckingBranch(false);
+        setIsGeneratingPath(false);
+        return;
       }
 
       setIsCheckingBranch(true);

--- a/src/components/Worktree/hooks/useWorktreeFormValidation.ts
+++ b/src/components/Worktree/hooks/useWorktreeFormValidation.ts
@@ -1,4 +1,5 @@
 import { useCallback } from "react";
+import { validateBranchName } from "@shared/utils/pathPattern";
 import { parseBranchInput } from "../branchPrefixUtils";
 import type { ErrorField } from "./useWorktreeFormErrors";
 
@@ -63,54 +64,24 @@ export function useWorktreeFormValidation() {
 
       const parsed = parseBranchInput(trimmedInput);
 
-      if (parsed.hasPrefix) {
-        if (!parsed.slug || !parsed.slug.trim()) {
-          return {
-            valid: false,
-            error: { message: "Please enter a branch name after the prefix", field: "new-branch" },
-          };
-        }
-        if (
-          /[\s.:]/.test(parsed.prefix) ||
-          /^[.-]/.test(parsed.prefix) ||
-          parsed.prefix.includes("..")
-        ) {
-          return {
-            valid: false,
-            error: { message: "Branch prefix contains invalid characters", field: "new-branch" },
-          };
-        }
-        if (/[\s.]$/.test(parsed.slug) || /^[.-]/.test(parsed.slug)) {
-          return {
-            valid: false,
-            error: {
-              message: "Branch name cannot start with '.', '-' or end with space or '.'",
-              field: "new-branch",
-            },
-          };
-        }
-        if (/[\\:]/.test(parsed.slug) || parsed.slug.includes("..")) {
-          return {
-            valid: false,
-            error: { message: "Branch name contains invalid characters", field: "new-branch" },
-          };
-        }
-      } else {
-        if (/[\s.]$/.test(trimmedInput) || /^[.-]/.test(trimmedInput)) {
-          return {
-            valid: false,
-            error: {
-              message: "Branch name cannot start with '.', '-' or end with space or '.'",
-              field: "new-branch",
-            },
-          };
-        }
-        if (/[/\\:]/.test(trimmedInput) || trimmedInput.includes("..")) {
-          return {
-            valid: false,
-            error: { message: "Branch name contains invalid characters", field: "new-branch" },
-          };
-        }
+      if (parsed.hasPrefix && (!parsed.slug || !parsed.slug.trim())) {
+        return {
+          valid: false,
+          error: { message: "Please enter a branch name after the prefix", field: "new-branch" },
+        };
+      }
+
+      // Use the same validator as the IPC handler and WorkspaceService so the
+      // dialog rejects exactly what the server would. #7033.
+      const branchValidation = validateBranchName(parsed.fullBranchName);
+      if (!branchValidation.valid) {
+        return {
+          valid: false,
+          error: {
+            message: branchValidation.error ?? "Branch name contains invalid characters",
+            field: "new-branch",
+          },
+        };
       }
 
       if (!worktreePath.trim()) {


### PR DESCRIPTION
## Summary

- Validation previously only applied in the dialog — any other caller into `worktree-create` bypassed it entirely, letting git surface confusing low-level errors
- Adds a shared `validateBranchName` util in `shared/utils/pathPattern.ts` covering the full `git check-ref-format` rule set plus Windows reserved names (`CON`, `NUL`, `COM0`–`COM9`, `LPT0`–`LPT9`)
- `WorkspaceService.createWorktree` now gates on this validator before touching git; the IPC handler gets a null-guard and defensive validation; the renderer form delegates to the shared function instead of duplicating logic; parent-dir pre-flight runs in `WorkspaceService` before `git worktree add`

Resolves #7033

## Changes

- `shared/utils/pathPattern.ts` — `validateBranchName` covering all git ref rules + Windows reserved names; `sanitizeBranchName` now guards the empty-slug collapse case
- `electron/workspace-host/WorkspaceService.ts` — validation gate + parent-dir pre-flight in `createWorktree`
- `electron/ipc/handlers/worktree/lifecycle.ts` — null-guard + IPC-layer defensive validation
- `src/components/Worktree/hooks/useBranchValidation.ts` — delegates to shared validator, removes duplicated logic
- `src/components/Worktree/hooks/useWorktreeFormValidation.ts` — stale-state clear, validation runs before rate-limit check

## Testing

100 unit tests pass across 5 test files — adversarial branch name coverage, rate-limit path, `WorkspaceService.createWorktree` integration, form validator delegation, and `pathPattern` utilities.