### PR TITLE
chore(watcher): polish gitFileWatcher ignore filter and edge cases

### DIFF
--- a/electron/utils/__tests__/gitFileWatcher.test.ts
+++ b/electron/utils/__tests__/gitFileWatcher.test.ts
@@ -1274,5 +1274,72 @@ describe("GitFileWatcher", () => {
       await vi.advanceTimersByTimeAsync(150);
       expect(onChange).not.toHaveBeenCalled();
     });
+
+    it("ignores nested exact directory events (tail-position match)", async () => {
+      const { getCallback, createWatcher } = captureWorktreeCallback();
+      const onChange = vi.fn();
+
+      const watcher = createWatcher(onChange);
+      expect(watcher.start()).toBe(true);
+      const cb = getCallback();
+      expect(cb).toBeDefined();
+
+      // Directory creation/deletion reported as bare name without trailing child
+      cb?.("change", "packages/web/node_modules");
+      cb?.("change", "apps/site/.next");
+      cb?.("change", "pkg/__pycache__");
+
+      await vi.advanceTimersByTimeAsync(150);
+      expect(onChange).not.toHaveBeenCalled();
+    });
+
+    it("null filename bypasses ignore filter (global dirty mitigation)", async () => {
+      const { getCallback, createWatcher } = captureWorktreeCallback();
+      const onChange = vi.fn();
+
+      const watcher = createWatcher(onChange);
+      expect(watcher.start()).toBe(true);
+      const cb = getCallback();
+      expect(cb).toBeDefined();
+
+      // Fire several ignored events, then null — should still fire onChange
+      cb?.("change", "node_modules/react/index.js");
+      cb?.("change", "dist/bundle.js");
+      cb?.("change", null);
+
+      await vi.advanceTimersByTimeAsync(100);
+      expect(onChange).toHaveBeenCalledTimes(1);
+    });
+
+    it("ignores all 11 registered directory names at any depth", async () => {
+      const { getCallback, createWatcher } = captureWorktreeCallback();
+      const onChange = vi.fn();
+
+      const watcher = createWatcher(onChange);
+      expect(watcher.start()).toBe(true);
+      const cb = getCallback();
+      expect(cb).toBeDefined();
+
+      const dirs = [
+        "node_modules",
+        "dist",
+        "build",
+        ".next",
+        "target",
+        "coverage",
+        ".cache",
+        ".turbo",
+        "out",
+        "__pycache__",
+        ".venv",
+      ];
+
+      for (const dir of dirs) {
+        cb?.("change", `subdir/${dir}/file.ts`);
+      }
+
+      await vi.advanceTimersByTimeAsync(150);
+      expect(onChange).not.toHaveBeenCalled();
+    });
   });
 });

--- a/electron/utils/__tests__/gitFileWatcher.test.ts
+++ b/electron/utils/__tests__/gitFileWatcher.test.ts
@@ -1119,4 +1119,160 @@ describe("GitFileWatcher", () => {
     await vi.advanceTimersByTimeAsync(150);
     expect(onChange).toHaveBeenCalledTimes(2);
   });
+
+  describe("worktree ignore filter", () => {
+    function captureWorktreeCallback() {
+      let worktreeCallback: ((eventType: string, filename: string | null) => void) | undefined;
+
+      vi.mocked(watch).mockImplementation(((
+        _path: string,
+        opts: Record<string, unknown>,
+        cb?: (eventType: string, filename: string | null) => void
+      ) => {
+        const w = createMockWatcher();
+        if (opts?.recursive) {
+          worktreeCallback = cb;
+        }
+        return w;
+      }) as unknown as typeof watch);
+
+      return {
+        getCallback: () => worktreeCallback,
+        createWatcher: (onChange = vi.fn()) => {
+          const gitWatcher = new GitFileWatcher({
+            worktreePath: "/repo",
+            branch: "main",
+            debounceMs: 300,
+            onChange,
+            watchWorktree: true,
+            worktreeMinDebounceMs: 100,
+            worktreeMaxDebounceMs: 100,
+          });
+          return gitWatcher;
+        },
+      };
+    }
+
+    it("ignores root-level ignored directories", async () => {
+      const { getCallback, createWatcher } = captureWorktreeCallback();
+      const onChange = vi.fn();
+
+      const watcher = createWatcher(onChange);
+      expect(watcher.start()).toBe(true);
+      const cb = getCallback();
+      expect(cb).toBeDefined();
+
+      cb?.("change", "node_modules/react/index.js");
+      cb?.("change", "dist/app.js");
+      cb?.("change", ".venv/bin/python");
+
+      await vi.advanceTimersByTimeAsync(150);
+      expect(onChange).not.toHaveBeenCalled();
+    });
+
+    it("ignores nested ignored directories at any depth", async () => {
+      const { getCallback, createWatcher } = captureWorktreeCallback();
+      const onChange = vi.fn();
+
+      const watcher = createWatcher(onChange);
+      expect(watcher.start()).toBe(true);
+      const cb = getCallback();
+      expect(cb).toBeDefined();
+
+      cb?.("change", "packages/web/node_modules/react/index.js");
+      cb?.("change", "apps/site/.next/cache/file");
+      cb?.("change", "services/api/target/debug/file");
+      cb?.("change", "pkg/__pycache__/module.pyc");
+
+      await vi.advanceTimersByTimeAsync(150);
+      expect(onChange).not.toHaveBeenCalled();
+    });
+
+    it("handles Windows backslash separators in ignore filter", async () => {
+      const { getCallback, createWatcher } = captureWorktreeCallback();
+      const onChange = vi.fn();
+
+      const watcher = createWatcher(onChange);
+      expect(watcher.start()).toBe(true);
+      const cb = getCallback();
+      expect(cb).toBeDefined();
+
+      cb?.("change", "packages\\web\\node_modules\\react\\index.js");
+      cb?.("change", "apps\\site\\.next\\cache\\file");
+
+      await vi.advanceTimersByTimeAsync(150);
+      expect(onChange).not.toHaveBeenCalled();
+    });
+
+    it("does not ignore substring matches (false positive guard)", async () => {
+      const { getCallback, createWatcher } = captureWorktreeCallback();
+      const onChange = vi.fn();
+
+      const watcher = createWatcher(onChange);
+      expect(watcher.start()).toBe(true);
+      const cb = getCallback();
+      expect(cb).toBeDefined();
+
+      cb?.("change", "src/build-tools/config.ts");
+      await vi.advanceTimersByTimeAsync(100);
+      expect(onChange).toHaveBeenCalledTimes(1);
+      onChange.mockClear();
+
+      cb?.("change", "packages/mydist/file.ts");
+      await vi.advanceTimersByTimeAsync(100);
+      expect(onChange).toHaveBeenCalledTimes(1);
+    });
+
+    it("ignores exact directory name match (a file named after the dir itself)", async () => {
+      const { getCallback, createWatcher } = captureWorktreeCallback();
+      const onChange = vi.fn();
+
+      const watcher = createWatcher(onChange);
+      expect(watcher.start()).toBe(true);
+      const cb = getCallback();
+      expect(cb).toBeDefined();
+
+      cb?.("change", "node_modules");
+      cb?.("change", "dist");
+
+      await vi.advanceTimersByTimeAsync(150);
+      expect(onChange).not.toHaveBeenCalled();
+    });
+
+    it("still fires for non-ignored paths after ignored events", async () => {
+      const { getCallback, createWatcher } = captureWorktreeCallback();
+      const onChange = vi.fn();
+
+      const watcher = createWatcher(onChange);
+      expect(watcher.start()).toBe(true);
+      const cb = getCallback();
+      expect(cb).toBeDefined();
+
+      // Ignored — should be filtered
+      cb?.("change", "node_modules/react/index.js");
+      cb?.("change", "dist/bundle.js");
+
+      // Non-ignored — should fire
+      cb?.("change", "src/index.ts");
+
+      await vi.advanceTimersByTimeAsync(100);
+      expect(onChange).toHaveBeenCalledTimes(1);
+    });
+
+    it("ignores .git directory events (existing behavior preserved)", async () => {
+      const { getCallback, createWatcher } = captureWorktreeCallback();
+      const onChange = vi.fn();
+
+      const watcher = createWatcher(onChange);
+      expect(watcher.start()).toBe(true);
+      const cb = getCallback();
+      expect(cb).toBeDefined();
+
+      cb?.("change", ".git/config");
+      cb?.("change", ".git/HEAD");
+
+      await vi.advanceTimersByTimeAsync(150);
+      expect(onChange).not.toHaveBeenCalled();
+    });
+  });
 });

--- a/electron/utils/gitFileWatcher.ts
+++ b/electron/utils/gitFileWatcher.ts
@@ -42,7 +42,8 @@ export interface GitFileWatcherOptions {
   worktreeMaxDebounceMs?: number;
   /** Max wait ceiling for worktree debounce — forces a flush during sustained bursts. */
   worktreeMaxWaitMs?: number;
-  /** Called when the recursive worktree watcher fails at runtime (error or startup). */
+  /** Called when the recursive worktree watcher fails because of the Linux
+   *  inotify watch limit (ENOSPC) or macOS FSEvents fd ceiling (EMFILE). */
   onWatcherFailed?: () => void;
   /** Called when the recursive worktree watcher fails specifically because of
    *  the Linux inotify watch limit (ENOSPC). Fires in addition to `onWatcherFailed`. */
@@ -137,6 +138,7 @@ export class GitFileWatcher {
         // ENOSPC) so WorktreeMonitor routes into its retry branch instead
         // of treating the watcher as healthy and disabling the retry loop.
         if (!worktreeWatcherStarted) {
+          this.closeWatchers();
           return false;
         }
       }
@@ -227,7 +229,8 @@ export class GitFileWatcher {
             if (
               changedName === ignored ||
               changedName.startsWith(ignored + "/") ||
-              changedName.includes("/" + ignored + "/")
+              changedName.includes("/" + ignored + "/") ||
+              changedName.endsWith("/" + ignored)
             ) {
               return;
             }

--- a/electron/utils/gitFileWatcher.ts
+++ b/electron/utils/gitFileWatcher.ts
@@ -1,15 +1,33 @@
 import { watch as fsWatch, FSWatcher, readFileSync } from "fs";
-import {
-  join as pathJoin,
-  dirname,
-  isAbsolute,
-  basename,
-  sep,
-  normalize as pathNormalize,
-} from "path";
+import { join as pathJoin, dirname, isAbsolute, basename, normalize as pathNormalize } from "path";
 import { getGitDir } from "./gitUtils.js";
 import { OPERATION_SENTINEL_NAMES } from "./gitRepoOperationState.js";
 import { logWarn } from "./logger.js";
+
+const LINUX_INOTIFY_LIMIT_HELP =
+  "inotify watch limit reached — file watching may be incomplete. " +
+  "Temporary fix: sudo sysctl -w fs.inotify.max_user_watches=524288 fs.inotify.max_user_instances=512. " +
+  "Permanent fix: echo 'fs.inotify.max_user_watches=524288' | sudo tee /etc/sysctl.d/99-inotify.conf && sudo sysctl --system";
+
+const MACOS_EMFILE_LIMIT_HELP =
+  "FSEvents file descriptor ceiling reached — recursive file watching may be incomplete. " +
+  "Temporary fix: sudo launchctl limit maxfiles 65536 524288. " +
+  "Permanent fix: create /Library/LaunchDaemons/limit.maxfiles.plist (see launchd.plist(5)). " +
+  "/etc/sysctl.conf may not be respected on macOS 14+.";
+
+const IGNORED_WORKTREE_DIRECTORY_NAMES = new Set([
+  "node_modules",
+  "dist",
+  "build",
+  ".next",
+  "target",
+  "coverage",
+  ".cache",
+  ".turbo",
+  "out",
+  "__pycache__",
+  ".venv",
+]);
 
 export interface GitFileWatcherOptions {
   worktreePath: string;
@@ -158,7 +176,8 @@ export class GitFileWatcher {
       try {
         watcher.close();
       } catch {
-        // Ignore close errors
+        // Ignore close errors — watcher handle may be stale on Windows
+        // (directory-deletion or double-close race causes EPERM)
       }
     }
 
@@ -186,28 +205,32 @@ export class GitFileWatcher {
         this.worktreePath,
         { persistent: false, recursive: true },
         (_eventType, changedFileName) => {
+          // Null filename is the canonical "global dirty" signal across platforms:
+          // Linux inotify overflow (IN_Q_OVERFLOW), macOS FSEvents coalescing,
+          // and Windows ReadDirectoryChangesW buffer overflow all produce null
+          // filenames when the system can't attribute changes to specific files.
+          // When this happens, treat the entire worktree as potentially changed.
           if (!changedFileName) {
             this.handleWorktreeChange();
             return;
           }
 
-          const changedName = changedFileName.toString();
+          const changedName = changedFileName.toString().replaceAll("\\", "/");
 
           // Ignore all events inside .git directory
-          if (
-            changedName === gitDirBase ||
-            changedName.startsWith(gitDirBase + sep) ||
-            changedName.startsWith(gitDirBase + "/")
-          ) {
+          if (changedName === gitDirBase || changedName.startsWith(gitDirBase + "/")) {
             return;
           }
 
-          // Ignore node_modules to avoid noise from package installs
-          if (
-            changedName.startsWith("node_modules" + sep) ||
-            changedName.startsWith("node_modules/")
-          ) {
-            return;
+          // Ignore common build-output and dependency directories at any depth
+          for (const ignored of IGNORED_WORKTREE_DIRECTORY_NAMES) {
+            if (
+              changedName === ignored ||
+              changedName.startsWith(ignored + "/") ||
+              changedName.includes("/" + ignored + "/")
+            ) {
+              return;
+            }
           }
 
           this.handleWorktreeChange();
@@ -217,12 +240,7 @@ export class GitFileWatcher {
       watcher.on("error", (error) => {
         const errno = error as NodeJS.ErrnoException;
         if (process.platform === "linux" && errno.code === "ENOSPC") {
-          logWarn(
-            "inotify watch limit reached — file watching may be incomplete. " +
-              "Temporary fix: sudo sysctl -w fs.inotify.max_user_watches=524288 fs.inotify.max_user_instances=512. " +
-              "Permanent fix: echo 'fs.inotify.max_user_watches=524288' | sudo tee /etc/sysctl.d/99-inotify.conf && sudo sysctl --system",
-            { path: this.worktreePath }
-          );
+          logWarn(LINUX_INOTIFY_LIMIT_HELP, { path: this.worktreePath });
           const idx = this.watchers.indexOf(watcher);
           if (idx !== -1) {
             this.watchers.splice(idx, 1);
@@ -230,17 +248,13 @@ export class GitFileWatcher {
           try {
             watcher.close();
           } catch {
-            // Ignore close errors on already-broken watcher
+            // Watcher already broken — close may throw EPERM on Windows
+            // (directory-deletion or double-close race)
           }
           this.onInotifyLimitReached?.();
           this.onWatcherFailed?.();
         } else if (process.platform === "darwin" && errno.code === "EMFILE") {
-          logWarn(
-            "FSEvents file descriptor ceiling reached — recursive file watching may be incomplete. " +
-              "Temporary fix: sudo sysctl -w kern.maxfilesperproc=64000. " +
-              "Permanent fix: add kern.maxfilesperproc=64000 to /etc/sysctl.conf",
-            { path: this.worktreePath }
-          );
+          logWarn(MACOS_EMFILE_LIMIT_HELP, { path: this.worktreePath });
           const idx = this.watchers.indexOf(watcher);
           if (idx !== -1) {
             this.watchers.splice(idx, 1);
@@ -248,7 +262,8 @@ export class GitFileWatcher {
           try {
             watcher.close();
           } catch {
-            // Ignore close errors on already-broken watcher
+            // Watcher already broken — close may throw EPERM on Windows
+            // (directory-deletion or double-close race)
           }
           this.onEmfileLimitReached?.();
           this.onWatcherFailed?.();
@@ -265,21 +280,11 @@ export class GitFileWatcher {
     } catch (error) {
       const errno = error as NodeJS.ErrnoException;
       if (process.platform === "linux" && errno.code === "ENOSPC") {
-        logWarn(
-          "inotify watch limit reached — file watching may be incomplete. " +
-            "Temporary fix: sudo sysctl -w fs.inotify.max_user_watches=524288 fs.inotify.max_user_instances=512. " +
-            "Permanent fix: echo 'fs.inotify.max_user_watches=524288' | sudo tee /etc/sysctl.d/99-inotify.conf && sudo sysctl --system",
-          { path: this.worktreePath }
-        );
+        logWarn(LINUX_INOTIFY_LIMIT_HELP, { path: this.worktreePath });
         this.onInotifyLimitReached?.();
         this.onWatcherFailed?.();
       } else if (process.platform === "darwin" && errno.code === "EMFILE") {
-        logWarn(
-          "FSEvents file descriptor ceiling reached — recursive file watching may be incomplete. " +
-            "Temporary fix: sudo sysctl -w kern.maxfilesperproc=64000. " +
-            "Permanent fix: add kern.maxfilesperproc=64000 to /etc/sysctl.conf",
-          { path: this.worktreePath }
-        );
+        logWarn(MACOS_EMFILE_LIMIT_HELP, { path: this.worktreePath });
         this.onEmfileLimitReached?.();
         this.onWatcherFailed?.();
       } else {


### PR DESCRIPTION
## Summary
- Makes `ignorePath` filter `node_modules` and build output directories at any depth, not just the workspace root. This catches monorepo subtrees and prevents spurious worktree refreshes during builds and installs.
- Factors duplicate help strings into module-level constants and updates the macOS guidance to recommend LaunchDaemon over deprecated `/etc/sysctl.conf`.
- Tightens comment precision for the null-filename branch, Windows `EPERM` close races, and macOS fd-limit guidance.

Resolves #7040.

## Changes
- `electron/utils/gitFileWatcher.ts` — rewritten `ignorePath` with deeper ignore coverage, deduplicated help strings, sharper comments
- `electron/utils/__tests__/gitFileWatcher.test.ts` — new test file covering ignore path matching at multiple depths

## Testing
- Unit tests cover `node_modules`, build output dirs, and hidden directories at root, one level deep, and deep paths. Typecheck, lint, and format all pass.