### PR TITLE
fix(github): typed-dispatch classifier for transient failures (#7034)

### DIFF
--- a/electron/services/github/GitHubAuth.ts
+++ b/electron/services/github/GitHubAuth.ts
@@ -343,10 +343,36 @@ export class GitHubAuth {
 
       if (!response.ok) {
         if (response.status === 401) {
-          return { valid: false, scopes: [], error: "Invalid or expired token" };
+          // Confirm a definitive revoked-token signal in the body before
+          // declaring the token bad — a brief auth-service incident can
+          // surface as a 401 with an HTML error page or unrelated JSON,
+          // and we don't want the Settings flow to flip a healthy token
+          // into "invalid" on a transient blip. Mirrors the classifier
+          // rule used by `parseGitHubError`.
+          let bodyText = "";
+          try {
+            bodyText = await response.text();
+          } catch {
+            // ignore — fall through to transient
+          }
+          if (bodyText.includes("Bad credentials")) {
+            return { valid: false, scopes: [], error: "Invalid or expired token" };
+          }
+          return {
+            valid: false,
+            scopes: [],
+            error: "GitHub is temporarily unavailable. Please retry.",
+          };
         }
         if (response.status === 403) {
           return { valid: false, scopes: [], error: "Token lacks required permissions" };
+        }
+        if (response.status >= 500 && response.status <= 599) {
+          return {
+            valid: false,
+            scopes: [],
+            error: "GitHub is temporarily unavailable. Please retry.",
+          };
         }
         return { valid: false, scopes: [], error: `GitHub API error: ${response.statusText}` };
       }

--- a/electron/services/github/GitHubAuth.ts
+++ b/electron/services/github/GitHubAuth.ts
@@ -55,6 +55,31 @@ export function parseSsoHeader(headerValue: string | null): string | null {
   }
 }
 
+export type SsoHeaderKind = "required" | "partial";
+
+/**
+ * Discriminate the form of an `X-GitHub-SSO` header.
+ *
+ * - `required` — the token must be re-authorized against the targeted org
+ *   before this request can succeed. A companion `url=` is usually present
+ *   and surfaced via {@link parseSsoHeader}.
+ * - `partial-results` — the token is fine globally; one or more named orgs
+ *   refused per-org SSO authorization, so the response carries partial data.
+ *   Treating this as a globally invalid token misclassifies a per-org
+ *   restriction as a token failure.
+ *
+ * Classification only — URL extraction and security validation remain in
+ * {@link parseSsoHeader} so callers that need a clickable URL go through
+ * the same hostname checks.
+ */
+export function parseSsoKind(headerValue: string | null): SsoHeaderKind | null {
+  if (!headerValue) return null;
+  const trimmed = headerValue.trim().toLowerCase();
+  if (trimmed.startsWith("partial-results")) return "partial";
+  if (trimmed.startsWith("required")) return "required";
+  return null;
+}
+
 function parseTokenExpirationHeader(headerValue: string | null): Date | null {
   if (!headerValue) return null;
   const ms = Date.parse(headerValue);

--- a/electron/services/github/GitHubErrors.ts
+++ b/electron/services/github/GitHubErrors.ts
@@ -156,6 +156,7 @@ export function parseGitHubError(error: unknown): string {
     message === "Invalid GitHub token. Please update in Settings." ||
     message === "Token lacks required permissions. Required scopes: repo, read:org" ||
     message === "Issue not found or you don't have access to this repository" ||
+    message === "Repository not found or token lacks access." ||
     message.startsWith("Cannot assign user ") ||
     message.startsWith("Assignment succeeded but user ") ||
     message.startsWith("Invalid GitHub API response:") ||
@@ -171,6 +172,30 @@ export function parseGitHubError(error: unknown): string {
 
   if (isAbortLike(error) || isNetworkLikeMessage(message)) {
     return "Cannot reach GitHub. Check your internet connection.";
+  }
+
+  // Legacy substring fallback — only fires for non-Octokit error sources
+  // (plain `new Error("...")` thrown by callers that pre-flatten a failure,
+  // or service-layer code that surfaces a synthetic string error). Typed
+  // Octokit errors are caught by the dispatch above, so the original
+  // misclassification bug — flattening a status-bearing RequestError and
+  // matching on a `"401"` / `"403"` substring — no longer fires here. The
+  // bare `"401"` match is intentionally omitted; only a definitive
+  // "Bad credentials" string maps to invalid-token in the fallback.
+  if (message.includes("rate limit") || message.includes("API rate limit")) {
+    return "GitHub rate limit exceeded. Try again in a few minutes.";
+  }
+  if (message.includes("Bad credentials")) {
+    return "Invalid GitHub token. Please update in Settings.";
+  }
+  if (message.includes("SAML") || message.includes("SSO")) {
+    return ssoMessage();
+  }
+  if (message.includes("403")) {
+    return "Token lacks required permissions. Required scopes: repo, read:org";
+  }
+  if (message.includes("404") || message.includes("Could not resolve")) {
+    return "Repository not found or token lacks access.";
   }
 
   return `GitHub API error: ${message}`;

--- a/electron/services/github/GitHubErrors.ts
+++ b/electron/services/github/GitHubErrors.ts
@@ -1,5 +1,7 @@
+import { RequestError } from "@octokit/request-error";
+import { GraphqlResponseError } from "@octokit/graphql";
 import { gitHubRateLimitService, GitHubRateLimitError } from "./GitHubRateLimitService.js";
-import { getLastAuthMetadata } from "./GitHubAuth.js";
+import { getLastAuthMetadata, parseSsoKind } from "./GitHubAuth.js";
 import { formatErrorMessage } from "../../../shared/utils/errorMessage.js";
 
 export function rateLimitMessage(kind: "primary" | "secondary", resumeAt: number): string {
@@ -24,57 +26,40 @@ function formatCountdown(totalSeconds: number): string {
   return remMinutes > 0 ? `${hours}h ${remMinutes}m` : `${hours}h`;
 }
 
-export function parseGitHubError(error: unknown): string {
-  if (error instanceof GitHubRateLimitError) {
-    return rateLimitMessage(error.kind, error.resumeAt);
-  }
-  const message = formatErrorMessage(error, "GitHub request failed");
-  const isTimeout = error instanceof Error && error.name === "TimeoutError";
+const TRANSIENT_API_MESSAGE = "GitHub is temporarily unavailable. Please retry.";
+const PARTIAL_RESULTS_MESSAGE =
+  "GitHub returned partial results — some organizations require SSO authorization.";
 
-  if (
-    message === "GitHub token not configured. Set it in Settings." ||
-    message === "Invalid GitHub token. Please update in Settings." ||
-    message === "Token lacks required permissions. Required scopes: repo, read:org" ||
-    message === "Issue not found or you don't have access to this repository" ||
-    message.startsWith("Cannot assign user ") ||
-    message.startsWith("Assignment succeeded but user ") ||
-    message.startsWith("Invalid GitHub API response:") ||
-    message === "Cannot reach GitHub. Check your internet connection."
-  ) {
-    return message;
-  }
+function getResponseHeader(error: RequestError, name: string): string | null {
+  const value = error.response?.headers?.[name];
+  if (typeof value === "string") return value;
+  if (typeof value === "number") return String(value);
+  return null;
+}
 
-  const blockState = gitHubRateLimitService.shouldBlockRequest();
-  if (blockState.blocked && blockState.reason && blockState.resumeAt) {
-    return rateLimitMessage(blockState.reason, blockState.resumeAt);
-  }
+function ssoMessage(): string {
+  const ssoUrl = getLastAuthMetadata()?.ssoUrl;
+  return ssoUrl
+    ? `SSO authorization required. Re-authorize at: ${ssoUrl}`
+    : "SSO authorization required. Re-authorize at github.com.";
+}
 
-  if (message.includes("rate limit") || message.includes("API rate limit")) {
-    return "GitHub rate limit exceeded. Try again in a few minutes.";
+function isAbortLike(error: unknown): boolean {
+  if (!(error instanceof Error)) return false;
+  if (error.name === "TimeoutError" || error.name === "AbortError") return true;
+  // `@octokit/request-error` re-wraps an aborted/timed-out fetch as a
+  // RequestError with `.cause` pointing at the original AbortError. Inspect
+  // the cause chain so timeouts surfaced through Octokit are still routed
+  // to the network-error copy. (Lesson #3747.)
+  const cause = (error as { cause?: unknown }).cause;
+  if (cause instanceof Error && (cause.name === "TimeoutError" || cause.name === "AbortError")) {
+    return true;
   }
+  return false;
+}
 
-  if (message.includes("401") || message.includes("Bad credentials")) {
-    return "Invalid GitHub token. Please update in Settings.";
-  }
-
-  if (message.includes("SAML") || message.includes("SSO")) {
-    const ssoUrl = getLastAuthMetadata()?.ssoUrl;
-    if (ssoUrl) {
-      return `SSO authorization required. Re-authorize at: ${ssoUrl}`;
-    }
-    return "SSO authorization required. Re-authorize at github.com.";
-  }
-
-  if (message.includes("403")) {
-    return "Token lacks required permissions. Required scopes: repo, read:org";
-  }
-
-  if (message.includes("404") || message.includes("Could not resolve")) {
-    return "Repository not found or token lacks access.";
-  }
-
-  if (
-    isTimeout ||
+function isNetworkLikeMessage(message: string): boolean {
+  return (
     message.includes("ENOTFOUND") ||
     message.includes("ETIMEDOUT") ||
     message.includes("ECONNREFUSED") ||
@@ -83,7 +68,108 @@ export function parseGitHubError(error: unknown): string {
     message.includes("network") ||
     message.includes("fetch failed") ||
     message.includes("timed out")
+  );
+}
+
+export function parseGitHubError(error: unknown): string {
+  if (error instanceof GitHubRateLimitError) {
+    return rateLimitMessage(error.kind, error.resumeAt);
+  }
+
+  // The rate-limit service's Phase 1 header observation runs in the custom
+  // fetch wrapper before Octokit wraps the error, so a triggered primary or
+  // secondary limit is already reflected here even when the throw site sees
+  // only a 403/429. Consulting the service first avoids substring-matching
+  // a rate-limit body into the wrong bucket.
+  const blockState = gitHubRateLimitService.shouldBlockRequest();
+  if (blockState.blocked && blockState.reason && blockState.resumeAt) {
+    return rateLimitMessage(blockState.reason, blockState.resumeAt);
+  }
+
+  if (error instanceof RequestError) {
+    // Pre-HTTP-response failures (DNS, connection refused, abort/timeout,
+    // network unreachable) are re-wrapped by Octokit with `status = 500`
+    // and no `response`. Distinguish on `response === undefined` so real
+    // server-side 5xx responses aren't conflated with a missing network.
+    if (!error.response) {
+      return "Cannot reach GitHub. Check your internet connection.";
+    }
+
+    const status = error.status;
+    const message = error.message;
+
+    if (status === 401) {
+      // GitHub's API contract returns "Bad credentials" for genuinely
+      // revoked or malformed tokens. Anything else at 401 is treated as a
+      // transient auth-service blip — `GitHubTokenHealthService`'s 30-min
+      // probe will independently confirm an unhealthy token if the failure
+      // persists, so we err on the side of not flipping the dropdown into
+      // reconnect-mode on a single ambiguous 401.
+      if (message.includes("Bad credentials")) {
+        return "Invalid GitHub token. Please update in Settings.";
+      }
+      return TRANSIENT_API_MESSAGE;
+    }
+
+    if (status === 403) {
+      // 403 with a `required` SSO challenge — the token is valid but the
+      // org demands re-authorization. Surface the captured URL when one is
+      // available (and still inside its 1-hour TTL).
+      const ssoKind = parseSsoKind(getResponseHeader(error, "x-github-sso"));
+      if (ssoKind === "required") return ssoMessage();
+      if (ssoKind === "partial") return PARTIAL_RESULTS_MESSAGE;
+      // Any remaining 403 is treated as a scope/permission failure. Rate
+      // limits and SSO challenges have already been peeled off above.
+      return "Token lacks required permissions. Required scopes: repo, read:org";
+    }
+
+    if (status === 404) {
+      return "Repository not found or token lacks access.";
+    }
+
+    if (status >= 500 && status <= 599) {
+      return TRANSIENT_API_MESSAGE;
+    }
+
+    return `GitHub API error: ${message}`;
+  }
+
+  if (error instanceof GraphqlResponseError) {
+    // Headers are captured even on 200-OK responses where the body's
+    // `errors` array forces Octokit to throw — partial-results SSO
+    // surfaces here.
+    const ssoHeader = error.headers?.["x-github-sso"];
+    const ssoKind = parseSsoKind(typeof ssoHeader === "string" ? ssoHeader : null);
+    if (ssoKind === "required") return ssoMessage();
+    if (ssoKind === "partial") return PARTIAL_RESULTS_MESSAGE;
+    const first = error.errors?.[0]?.message ?? error.message;
+    return `GitHub API error: ${first}`;
+  }
+
+  const message = formatErrorMessage(error, "GitHub request failed");
+
+  // Pre-classified strings — pass through verbatim so re-thrown errors
+  // (e.g. `throw new Error(parseGitHubError(error))` re-caught by an outer
+  // handler) don't get re-wrapped into `GitHub API error: ...`.
+  if (
+    message === "GitHub token not configured. Set it in Settings." ||
+    message === "Invalid GitHub token. Please update in Settings." ||
+    message === "Token lacks required permissions. Required scopes: repo, read:org" ||
+    message === "Issue not found or you don't have access to this repository" ||
+    message.startsWith("Cannot assign user ") ||
+    message.startsWith("Assignment succeeded but user ") ||
+    message.startsWith("Invalid GitHub API response:") ||
+    message === "Cannot reach GitHub. Check your internet connection." ||
+    message === TRANSIENT_API_MESSAGE ||
+    message === PARTIAL_RESULTS_MESSAGE ||
+    message.startsWith("SSO authorization required.") ||
+    message.startsWith("GitHub rate limit exceeded.") ||
+    message.startsWith("GitHub secondary rate limit triggered.")
   ) {
+    return message;
+  }
+
+  if (isAbortLike(error) || isNetworkLikeMessage(message)) {
     return "Cannot reach GitHub. Check your internet connection.";
   }
 

--- a/electron/services/github/__tests__/GitHubAuth.test.ts
+++ b/electron/services/github/__tests__/GitHubAuth.test.ts
@@ -65,6 +65,39 @@ describe("GitHubAuth", () => {
     expect(result.error).toBe("Cannot reach GitHub. Check your internet connection.");
   });
 
+  it("returns 'Invalid or expired token' for a 401 with 'Bad credentials' in the body", async () => {
+    (globalThis as unknown as { fetch: Mock }).fetch = vi
+      .fn()
+      .mockResolvedValue(new Response('{"message":"Bad credentials"}', { status: 401 }));
+
+    const result = await GitHubAuth.validate("ghp_validtoken012345678901234567890123456789");
+
+    expect(result.valid).toBe(false);
+    expect(result.error).toBe("Invalid or expired token");
+  });
+
+  it("returns the transient message for a 401 without 'Bad credentials' so a brief auth-service incident isn't reported as an invalid token", async () => {
+    (globalThis as unknown as { fetch: Mock }).fetch = vi
+      .fn()
+      .mockResolvedValue(new Response("<html>Service Disrupted</html>", { status: 401 }));
+
+    const result = await GitHubAuth.validate("ghp_validtoken012345678901234567890123456789");
+
+    expect(result.valid).toBe(false);
+    expect(result.error).toBe("GitHub is temporarily unavailable. Please retry.");
+  });
+
+  it("returns the transient message for a 5xx response", async () => {
+    (globalThis as unknown as { fetch: Mock }).fetch = vi
+      .fn()
+      .mockResolvedValue(new Response("Bad Gateway", { status: 502 }));
+
+    const result = await GitHubAuth.validate("ghp_validtoken012345678901234567890123456789");
+
+    expect(result.valid).toBe(false);
+    expect(result.error).toBe("GitHub is temporarily unavailable. Please retry.");
+  });
+
   describe("parseSsoHeader", () => {
     it("extracts the url= URL from a required-form header", () => {
       const url = parseSsoHeader(

--- a/electron/services/github/__tests__/GitHubAuth.test.ts
+++ b/electron/services/github/__tests__/GitHubAuth.test.ts
@@ -4,6 +4,7 @@ import {
   captureAuthMetadata,
   getLastAuthMetadata,
   parseSsoHeader,
+  parseSsoKind,
 } from "../GitHubAuth.js";
 
 function createStorage() {
@@ -98,6 +99,29 @@ describe("GitHubAuth", () => {
       expect(
         parseSsoHeader("required; url=https://www.github.com/orgs/acme/sso?authorization_request=x")
       ).toBe("https://www.github.com/orgs/acme/sso?authorization_request=x");
+    });
+  });
+
+  describe("parseSsoKind", () => {
+    it("classifies the required form as 'required'", () => {
+      expect(
+        parseSsoKind("required; url=https://github.com/orgs/acme/sso?authorization_request=abc123")
+      ).toBe("required");
+    });
+
+    it("classifies the partial-results form as 'partial'", () => {
+      expect(parseSsoKind("partial-results; organizations=123456,789012")).toBe("partial");
+    });
+
+    it("is case-insensitive at the prefix", () => {
+      expect(parseSsoKind("REQUIRED; url=https://github.com/orgs/acme/sso")).toBe("required");
+      expect(parseSsoKind("Partial-Results; organizations=12345")).toBe("partial");
+    });
+
+    it("returns null for null/empty/gibberish", () => {
+      expect(parseSsoKind(null)).toBeNull();
+      expect(parseSsoKind("")).toBeNull();
+      expect(parseSsoKind("gibberish")).toBeNull();
     });
   });
 

--- a/electron/services/github/__tests__/GitHubErrors.test.ts
+++ b/electron/services/github/__tests__/GitHubErrors.test.ts
@@ -1,0 +1,268 @@
+import { afterEach, beforeEach, describe, expect, it } from "vitest";
+import { RequestError } from "@octokit/request-error";
+import { GraphqlResponseError } from "@octokit/graphql";
+import type { RequestOptions, OctokitResponse } from "@octokit/types";
+
+import { parseGitHubError } from "../GitHubErrors.js";
+import { GitHubAuth, captureAuthMetadata } from "../GitHubAuth.js";
+import { gitHubRateLimitService } from "../GitHubRateLimitService.js";
+import { isTokenRelatedError, isTransientNetworkError } from "../../../../src/lib/githubErrors.js";
+
+function createStorage() {
+  let token: string | undefined;
+  return {
+    get: () => token,
+    set: (nextToken: string) => {
+      token = nextToken;
+    },
+    delete: () => {
+      token = undefined;
+    },
+  };
+}
+
+const REQUEST: RequestOptions = {
+  method: "POST",
+  url: "https://api.github.com/graphql",
+  headers: {},
+};
+
+function makeResponse(
+  status: number,
+  headers: Record<string, string> = {},
+  data: unknown = {}
+): OctokitResponse<unknown> {
+  return {
+    url: "https://api.github.com/graphql",
+    status,
+    headers,
+    data,
+  };
+}
+
+function makeRequestError(
+  message: string,
+  status: number,
+  response: OctokitResponse<unknown> | undefined,
+  cause?: Error
+): RequestError {
+  return new RequestError(message, status, {
+    request: REQUEST,
+    response,
+    cause,
+  });
+}
+
+function makeGraphqlResponseError(
+  headers: Record<string, string>,
+  errors: Array<{ message: string }> = [{ message: "boom" }]
+): GraphqlResponseError<unknown> {
+  return new GraphqlResponseError(
+    { method: "POST", url: "https://api.github.com/graphql", query: "" },
+    headers,
+    { data: null, errors: errors as never }
+  );
+}
+
+describe("parseGitHubError", () => {
+  beforeEach(() => {
+    GitHubAuth.initializeStorage(createStorage());
+    GitHubAuth.clearToken();
+    gitHubRateLimitService.clear();
+  });
+
+  afterEach(() => {
+    gitHubRateLimitService.clear();
+  });
+
+  describe("RequestError", () => {
+    it("classifies a 401 with 'Bad credentials' as an invalid token", () => {
+      const error = makeRequestError("Bad credentials", 401, makeResponse(401));
+      const message = parseGitHubError(error);
+      expect(message).toBe("Invalid GitHub token. Please update in Settings.");
+      expect(isTokenRelatedError(message)).toBe(true);
+      expect(isTransientNetworkError(message)).toBe(false);
+    });
+
+    it("classifies a 401 without 'Bad credentials' as transient", () => {
+      const error = makeRequestError("Unauthorized", 401, makeResponse(401));
+      const message = parseGitHubError(error);
+      expect(message).toBe("GitHub is temporarily unavailable. Please retry.");
+      expect(isTokenRelatedError(message)).toBe(false);
+      expect(isTransientNetworkError(message)).toBe(true);
+    });
+
+    it("classifies a 403 with x-github-sso 'required' as SSO authorization required", () => {
+      const error = makeRequestError(
+        "Resource protected by org SAML enforcement",
+        403,
+        makeResponse(403, {
+          "x-github-sso":
+            "required; url=https://github.com/orgs/acme/sso?authorization_request=abc",
+        })
+      );
+      const message = parseGitHubError(error);
+      expect(message).toContain("SSO authorization required.");
+      expect(isTokenRelatedError(message)).toBe(true);
+    });
+
+    it("includes the captured SSO URL when one is in the auth metadata cache", () => {
+      captureAuthMetadata(
+        new Headers({
+          "x-github-sso":
+            "required; url=https://github.com/orgs/acme/sso?authorization_request=xyz",
+        })
+      );
+      const error = makeRequestError(
+        "SAML enforcement",
+        403,
+        makeResponse(403, { "x-github-sso": "required; url=https://github.com/orgs/acme/sso" })
+      );
+      const message = parseGitHubError(error);
+      expect(message).toBe(
+        "SSO authorization required. Re-authorize at: https://github.com/orgs/acme/sso?authorization_request=xyz"
+      );
+    });
+
+    it("classifies a 403 with x-github-sso 'partial-results' as a non-token partial-results message", () => {
+      const error = makeRequestError(
+        "partial",
+        403,
+        makeResponse(403, { "x-github-sso": "partial-results; organizations=12345" })
+      );
+      const message = parseGitHubError(error);
+      expect(message).toBe(
+        "GitHub returned partial results — some organizations require SSO authorization."
+      );
+      expect(isTokenRelatedError(message)).toBe(false);
+      expect(isTransientNetworkError(message)).toBe(false);
+    });
+
+    it("classifies a plain 403 as a scope-missing error", () => {
+      const error = makeRequestError("Forbidden", 403, makeResponse(403));
+      const message = parseGitHubError(error);
+      expect(message).toBe("Token lacks required permissions. Required scopes: repo, read:org");
+      expect(isTokenRelatedError(message)).toBe(true);
+    });
+
+    it("classifies a 404 as repository-not-found", () => {
+      const error = makeRequestError("Not Found", 404, makeResponse(404));
+      expect(parseGitHubError(error)).toBe("Repository not found or token lacks access.");
+    });
+
+    it("classifies a 500 with a response present as transient (server-side)", () => {
+      const error = makeRequestError("Internal Server Error", 500, makeResponse(500));
+      const message = parseGitHubError(error);
+      expect(message).toBe("GitHub is temporarily unavailable. Please retry.");
+      expect(isTransientNetworkError(message)).toBe(true);
+      expect(isTokenRelatedError(message)).toBe(false);
+    });
+
+    it("classifies a 502 Bad Gateway as transient", () => {
+      const error = makeRequestError("Bad Gateway", 502, makeResponse(502));
+      const message = parseGitHubError(error);
+      expect(message).toBe("GitHub is temporarily unavailable. Please retry.");
+      expect(isTransientNetworkError(message)).toBe(true);
+    });
+
+    it("classifies a 503 Service Unavailable as transient", () => {
+      const error = makeRequestError("Service Unavailable", 503, makeResponse(503));
+      expect(parseGitHubError(error)).toBe("GitHub is temporarily unavailable. Please retry.");
+    });
+
+    it("classifies a network failure (no response) as a network error", () => {
+      const cause = new Error("getaddrinfo ENOTFOUND api.github.com");
+      const error = makeRequestError(cause.message, 500, undefined, cause);
+      const message = parseGitHubError(error);
+      expect(message).toBe("Cannot reach GitHub. Check your internet connection.");
+      expect(isTransientNetworkError(message)).toBe(true);
+    });
+
+    it("classifies an aborted fetch (RequestError wrapping AbortError) as a network error", () => {
+      const abort = new Error("The operation was aborted");
+      abort.name = "AbortError";
+      const error = makeRequestError("AbortError", 500, undefined, abort);
+      const message = parseGitHubError(error);
+      expect(message).toBe("Cannot reach GitHub. Check your internet connection.");
+    });
+  });
+
+  describe("GraphqlResponseError", () => {
+    it("classifies x-github-sso 'required' as SSO authorization required", () => {
+      const error = makeGraphqlResponseError({
+        "x-github-sso": "required; url=https://github.com/orgs/acme/sso?authorization_request=abc",
+      });
+      const message = parseGitHubError(error);
+      expect(message).toContain("SSO authorization required.");
+      expect(isTokenRelatedError(message)).toBe(true);
+    });
+
+    it("classifies x-github-sso 'partial-results' as a non-token partial-results message", () => {
+      const error = makeGraphqlResponseError({
+        "x-github-sso": "partial-results; organizations=12345",
+      });
+      const message = parseGitHubError(error);
+      expect(message).toBe(
+        "GitHub returned partial results — some organizations require SSO authorization."
+      );
+      expect(isTokenRelatedError(message)).toBe(false);
+    });
+
+    it("falls back to the first GraphQL error message when no SSO header is present", () => {
+      const error = makeGraphqlResponseError({}, [{ message: "Field 'unknown' doesn't exist" }]);
+      expect(parseGitHubError(error)).toBe("GitHub API error: Field 'unknown' doesn't exist");
+    });
+  });
+
+  describe("non-Octokit errors", () => {
+    it("passes through pre-classified strings verbatim (idempotent)", () => {
+      const original = new Error("Invalid GitHub token. Please update in Settings.");
+      expect(parseGitHubError(original)).toBe("Invalid GitHub token. Please update in Settings.");
+
+      const transient = new Error("GitHub is temporarily unavailable. Please retry.");
+      expect(parseGitHubError(transient)).toBe("GitHub is temporarily unavailable. Please retry.");
+
+      const partial = new Error(
+        "GitHub returned partial results — some organizations require SSO authorization."
+      );
+      expect(parseGitHubError(partial)).toBe(
+        "GitHub returned partial results — some organizations require SSO authorization."
+      );
+    });
+
+    it("classifies a TimeoutError as a network error", () => {
+      const timeout = new DOMException("Timed out", "TimeoutError");
+      expect(parseGitHubError(timeout)).toBe(
+        "Cannot reach GitHub. Check your internet connection."
+      );
+    });
+
+    it("classifies an ECONNRESET as a network error", () => {
+      const error = new Error("read ECONNRESET");
+      expect(parseGitHubError(error)).toBe("Cannot reach GitHub. Check your internet connection.");
+    });
+
+    it("falls through to the generic API error bucket for unknown errors", () => {
+      const error = new Error("Something else broke");
+      expect(parseGitHubError(error)).toBe("GitHub API error: Something else broke");
+    });
+  });
+
+  describe("rate-limit pre-emption", () => {
+    it("returns a rate-limit message when the rate-limit service is currently blocking", () => {
+      // Simulate a rate-limit response that the fetch wrapper has already
+      // recorded (Phase 1 / Phase 2 in `rateLimitAwareFetch`).
+      const resetAt = Math.floor((Date.now() + 60_000) / 1000).toString();
+      gitHubRateLimitService.update(
+        new Headers({
+          "x-ratelimit-remaining": "0",
+          "x-ratelimit-reset": resetAt,
+        }),
+        403
+      );
+      const error = makeRequestError("rate limit exceeded", 403, makeResponse(403));
+      const message = parseGitHubError(error);
+      expect(message).toMatch(/rate limit (exceeded|Reset)/i);
+    });
+  });
+});

--- a/electron/services/github/__tests__/GitHubErrors.test.ts
+++ b/electron/services/github/__tests__/GitHubErrors.test.ts
@@ -6,7 +6,28 @@ import type { RequestOptions, OctokitResponse } from "@octokit/types";
 import { parseGitHubError } from "../GitHubErrors.js";
 import { GitHubAuth, captureAuthMetadata } from "../GitHubAuth.js";
 import { gitHubRateLimitService } from "../GitHubRateLimitService.js";
-import { isTokenRelatedError, isTransientNetworkError } from "../../../../src/lib/githubErrors.js";
+
+// Mirror the renderer-side classifiers from `src/lib/githubErrors.ts`. The
+// renderer can't be imported here (Electron main/renderer boundary), so the
+// rules are duplicated locally and exercised against real `parseGitHubError`
+// outputs to confirm the cross-cutting contract: a token-related output
+// matches `isTokenRelatedError`, a transient output matches
+// `isTransientNetworkError`. Independent tests in
+// `src/lib/__tests__/githubErrors.test.ts` cover the renderer-side
+// implementation against the same canonical strings.
+function isTokenRelatedError(msg: string): boolean {
+  return (
+    msg.includes("GitHub token not configured") ||
+    msg.includes("Invalid GitHub token") ||
+    msg.includes("Token lacks required permissions") ||
+    msg.includes("SSO authorization required")
+  );
+}
+function isTransientNetworkError(msg: string): boolean {
+  return (
+    msg.startsWith("Cannot reach GitHub.") || msg.startsWith("GitHub is temporarily unavailable.")
+  );
+}
 
 function createStorage() {
   let token: string | undefined;

--- a/electron/services/github/__tests__/GitHubErrors.test.ts
+++ b/electron/services/github/__tests__/GitHubErrors.test.ts
@@ -178,12 +178,30 @@ describe("parseGitHubError", () => {
       expect(isTransientNetworkError(message)).toBe(true);
     });
 
-    it("classifies an aborted fetch (RequestError wrapping AbortError) as a network error", () => {
+    it("classifies a RequestError with no response (status=500 fallback) as a network error", () => {
+      // RequestError with `response: undefined` is the shape Octokit produces
+      // for any pre-HTTP-response failure (DNS, abort, unreachable host).
+      // Hitting the !error.response short-circuit, not the cause-chain.
       const abort = new Error("The operation was aborted");
       abort.name = "AbortError";
       const error = makeRequestError("AbortError", 500, undefined, abort);
-      const message = parseGitHubError(error);
-      expect(message).toBe("Cannot reach GitHub. Check your internet connection.");
+      expect(parseGitHubError(error)).toBe("Cannot reach GitHub. Check your internet connection.");
+    });
+  });
+
+  describe("non-Octokit error with AbortError cause chain", () => {
+    it("classifies a plain Error wrapping an AbortError as a network error", () => {
+      // This is the path `isAbortLike` actually exists for: a raw `fetch`
+      // failure thrown outside Octokit (e.g. from a code path that bypasses
+      // the GraphQL client). RequestError variants short-circuit before
+      // reaching the cause-chain inspector.
+      const abort = new Error("The operation was aborted");
+      abort.name = "AbortError";
+      const wrapper = new Error("fetch failed");
+      (wrapper as { cause?: unknown }).cause = abort;
+      expect(parseGitHubError(wrapper)).toBe(
+        "Cannot reach GitHub. Check your internet connection."
+      );
     });
   });
 
@@ -249,7 +267,7 @@ describe("parseGitHubError", () => {
   });
 
   describe("rate-limit pre-emption", () => {
-    it("returns a rate-limit message when the rate-limit service is currently blocking", () => {
+    it("returns the primary-rate-limit message when the rate-limit service is blocking on a quota reset", () => {
       // Simulate a rate-limit response that the fetch wrapper has already
       // recorded (Phase 1 / Phase 2 in `rateLimitAwareFetch`).
       const resetAt = Math.floor((Date.now() + 60_000) / 1000).toString();
@@ -262,7 +280,18 @@ describe("parseGitHubError", () => {
       );
       const error = makeRequestError("rate limit exceeded", 403, makeResponse(403));
       const message = parseGitHubError(error);
-      expect(message).toMatch(/rate limit (exceeded|Reset)/i);
+      // The canonical primary-bucket message — confirms we hit the
+      // rate-limit branch, not the 403 SSO/scope branch.
+      expect(message).toMatch(/^GitHub rate limit exceeded\. Resets in /);
+    });
+
+    it("returns the secondary-rate-limit message when retry-after fires the secondary-bucket path", () => {
+      // `retry-after` is the header GitHub sends for secondary limits.
+      gitHubRateLimitService.update(new Headers({ "retry-after": "60" }), 403);
+      const error = makeRequestError("Forbidden", 403, makeResponse(403));
+      expect(parseGitHubError(error)).toMatch(
+        /^GitHub secondary rate limit triggered\. Resuming in /
+      );
     });
   });
 });

--- a/knip.config.ts
+++ b/knip.config.ts
@@ -104,6 +104,8 @@ const config: KnipConfig = {
     "glob",
     "@babel/core",
     "@types/trusted-types",
+    "@octokit/request-error",
+    "@octokit/types",
   ],
 
   // why: the repo pre-dates knip and carries a ~150-entry backlog of unused

--- a/src/lib/__tests__/githubErrors.test.ts
+++ b/src/lib/__tests__/githubErrors.test.ts
@@ -21,6 +21,18 @@ describe("isTokenRelatedError", () => {
     expect(isTokenRelatedError("Repository not found or token lacks access.")).toBe(false);
   });
 
+  it("returns false for transient API errors so the dropdown stays out of reconnect-mode", () => {
+    expect(isTokenRelatedError("GitHub is temporarily unavailable. Please retry.")).toBe(false);
+  });
+
+  it("returns false for partial-results SSO so a per-org failure isn't treated as a globally bad token", () => {
+    expect(
+      isTokenRelatedError(
+        "GitHub returned partial results — some organizations require SSO authorization."
+      )
+    ).toBe(false);
+  });
+
   it("returns false for null/undefined/empty", () => {
     expect(isTokenRelatedError(null)).toBe(false);
     expect(isTokenRelatedError(undefined)).toBe(false);
@@ -38,6 +50,11 @@ describe("isTransientNetworkError", () => {
   it("matches any string starting with the canonical prefix", () => {
     expect(isTransientNetworkError("Cannot reach GitHub.")).toBe(true);
     expect(isTransientNetworkError("Cannot reach GitHub. Try again later.")).toBe(true);
+  });
+
+  it("matches the transient-API prefix for 5xx and ambiguous-401 outages", () => {
+    expect(isTransientNetworkError("GitHub is temporarily unavailable. Please retry.")).toBe(true);
+    expect(isTransientNetworkError("GitHub is temporarily unavailable.")).toBe(true);
   });
 
   it("returns false for token, rate-limit, and 404 errors", () => {

--- a/src/lib/githubErrors.ts
+++ b/src/lib/githubErrors.ts
@@ -10,5 +10,7 @@ export function isTokenRelatedError(msg: string | null | undefined): boolean {
 
 export function isTransientNetworkError(msg: string | null | undefined): boolean {
   if (!msg) return false;
-  return msg.startsWith("Cannot reach GitHub.");
+  return (
+    msg.startsWith("Cannot reach GitHub.") || msg.startsWith("GitHub is temporarily unavailable.")
+  );
 }


### PR DESCRIPTION
## Summary

- Transient GitHub blips (5xx, network errors, brief auth-service 401s) were being misclassified as token-invalid or SSO-required errors. Users were seeing reconnect banners during incidents that had nothing to do with their token.
- Root cause: `parseGitHubError` substring-matched `error.message` and discarded the typed `RequestError` / `GraphqlResponseError` objects that Octokit already provides, throwing away the HTTP status and response headers needed to classify correctly.
- Rewrote the classifier to dispatch on `instanceof` and read `.status`, `.response`, and `.response.headers` directly.

Resolves #7034

## Changes

**`electron/services/github/GitHubErrors.ts`** — full rewrite of `parseGitHubError`. Pre-HTTP `RequestError` (no response) routes to the network copy. `AbortError`-wrapped errors detected via `.cause` chain. `401` with `"Bad credentials"` body stays token-invalid; `401` without becomes transient. `5xx` → transient. `403` with `X-GitHub-SSO: required` → SSO required; `X-GitHub-SSO: partial-results` → scoped per-org failure, not a global token problem. Rate-limit service consulted first.

**`electron/services/github/GitHubAuth.ts`** — added `parseSsoKind` sibling to `parseSsoHeader` to discriminate `required` vs `partial-results` without changing `parseSsoHeader`'s URL-extraction contract. `validate()` now reads the `401` body to confirm `"Bad credentials"` before declaring a token invalid, and classifies `5xx` as transient — keeps the Settings "Test token" flow honest during incidents.

**`src/lib/githubErrors.ts`** — `isTransientNetworkError` now matches `startsWith("GitHub is temporarily unavailable.")` in addition to the existing `"Cannot reach GitHub."` prefix.

## Testing

New test file `electron/services/github/__tests__/GitHubErrors.test.ts` — 22 cases covering `RequestError` (401 Bad Credentials, 401 ambiguous, 403 SSO required + URL cache, 403 partial-results, 403 scope, 404, 500/502/503, network/no-response, `AbortError`-wrapped fall-through), `GraphqlResponseError` (SSO required, partial-results, generic), non-Octokit cause-chain `AbortError`, idempotent re-classification, and rate-limit pre-emption (primary + secondary).

`electron/services/github/__tests__/GitHubAuth.test.ts` — added `parseSsoKind` cases and `validate()` coverage for 401 Bad Credentials, 401 ambiguous, and 5xx.

`src/lib/__tests__/githubErrors.test.ts` — extended for the transient API prefix and partial-results non-token classification.

127 tests pass. The 5 pre-existing ESLint warnings on `GitHubIssues.ts` / `GitHubPRs.ts` (`preserve-caught-error` rule) are not introduced by this PR.