### PR TITLE
chore(git): harden IPC argv against leading-dash refs and textconv execution

### DIFF
--- a/electron/ipc/handlers/__tests__/git-write.commit.test.ts
+++ b/electron/ipc/handlers/__tests__/git-write.commit.test.ts
@@ -39,7 +39,7 @@ type FakeStatusFile = { path: string; index: string; working_dir: string };
 type FakeGit = {
   status: ReturnType<typeof vi.fn>;
   diff: ReturnType<typeof vi.fn>;
-  show: ReturnType<typeof vi.fn>;
+  raw: ReturnType<typeof vi.fn>;
   commit: ReturnType<typeof vi.fn>;
 };
 
@@ -47,7 +47,7 @@ function makeFakeGit(overrides: Partial<FakeGit> = {}): FakeGit {
   return {
     status: vi.fn().mockResolvedValue({ files: [] as FakeStatusFile[] }),
     diff: vi.fn().mockResolvedValue(""),
-    show: vi.fn().mockResolvedValue(""),
+    raw: vi.fn().mockResolvedValue(""),
     commit: vi.fn().mockResolvedValue({
       commit: "abc123",
       summary: { changes: 1, insertions: 1, deletions: 0 },
@@ -70,16 +70,16 @@ describe("scanStagedFilesForConflictMarkers", () => {
   it("passes through a clean staged file", async () => {
     const git = makeFakeGit({
       status: vi.fn().mockResolvedValue({ files: [stagedFile("src/foo.ts")] }),
-      show: vi.fn().mockResolvedValue("export const foo = 1;\n"),
+      raw: vi.fn().mockResolvedValue("export const foo = 1;\n"),
     });
     await expect(scanStagedFilesForConflictMarkers(git as never)).resolves.toBeUndefined();
-    expect(git.show).toHaveBeenCalledWith([":src/foo.ts"]);
+    expect(git.raw).toHaveBeenCalledWith(["cat-file", "blob", "--end-of-options", ":src/foo.ts"]);
   });
 
   it("throws when a staged file contains <<<<<<< markers", async () => {
     const git = makeFakeGit({
       status: vi.fn().mockResolvedValue({ files: [stagedFile("src/foo.ts")] }),
-      show: vi
+      raw: vi
         .fn()
         .mockResolvedValue("line1\n<<<<<<< HEAD\nours\n=======\ntheirs\n>>>>>>> branch\n"),
     });
@@ -96,7 +96,7 @@ describe("scanStagedFilesForConflictMarkers", () => {
   ])("throws for the %s marker line", async (markerLine) => {
     const git = makeFakeGit({
       status: vi.fn().mockResolvedValue({ files: [stagedFile("f.txt")] }),
-      show: vi.fn().mockResolvedValue(`head\n${markerLine}\ntail\n`),
+      raw: vi.fn().mockResolvedValue(`head\n${markerLine}\ntail\n`),
     });
     await expect(scanStagedFilesForConflictMarkers(git as never)).rejects.toThrow(
       /Unresolved conflict markers/
@@ -108,17 +108,17 @@ describe("scanStagedFilesForConflictMarkers", () => {
     // in CONFLICT_MARKER_RE is doing its job.
     const git = makeFakeGit({
       status: vi.fn().mockResolvedValue({ files: [stagedFile("doc.md")] }),
-      show: vi.fn().mockResolvedValue("  =======\ninline <<<<<<< text\n"),
+      raw: vi.fn().mockResolvedValue("  =======\ninline <<<<<<< text\n"),
     });
     await expect(scanStagedFilesForConflictMarkers(git as never)).resolves.toBeUndefined();
   });
 
-  it("skips deleted staged entries without calling git.show", async () => {
+  it("skips deleted staged entries without reading any blobs", async () => {
     const git = makeFakeGit({
       status: vi.fn().mockResolvedValue({ files: [stagedFile("gone.ts", "D")] }),
     });
     await expect(scanStagedFilesForConflictMarkers(git as never)).resolves.toBeUndefined();
-    expect(git.show).not.toHaveBeenCalled();
+    expect(git.raw).not.toHaveBeenCalled();
     expect(git.diff).not.toHaveBeenCalled();
   });
 
@@ -128,14 +128,14 @@ describe("scanStagedFilesForConflictMarkers", () => {
       diff: vi.fn().mockResolvedValue("-\t-\timage.png\n"),
     });
     await expect(scanStagedFilesForConflictMarkers(git as never)).resolves.toBeUndefined();
-    expect(git.show).not.toHaveBeenCalled();
+    expect(git.raw).not.toHaveBeenCalled();
   });
 
   it("skips files over the 1 MB cap", async () => {
     const huge = "a".repeat(1_000_001);
     const git = makeFakeGit({
       status: vi.fn().mockResolvedValue({ files: [stagedFile("big.txt")] }),
-      show: vi.fn().mockResolvedValue(huge),
+      raw: vi.fn().mockResolvedValue(huge),
     });
     await expect(scanStagedFilesForConflictMarkers(git as never)).resolves.toBeUndefined();
   });
@@ -144,16 +144,32 @@ describe("scanStagedFilesForConflictMarkers", () => {
     const git = makeFakeGit();
     await expect(scanStagedFilesForConflictMarkers(git as never)).resolves.toBeUndefined();
     expect(git.diff).not.toHaveBeenCalled();
-    expect(git.show).not.toHaveBeenCalled();
+    expect(git.raw).not.toHaveBeenCalled();
   });
 
-  it("uses --no-ext-diff for the numstat probe", async () => {
+  it("uses --no-ext-diff and --no-textconv for the numstat probe", async () => {
     const git = makeFakeGit({
       status: vi.fn().mockResolvedValue({ files: [stagedFile("a.ts")] }),
-      show: vi.fn().mockResolvedValue("ok\n"),
+      raw: vi.fn().mockResolvedValue("ok\n"),
     });
     await scanStagedFilesForConflictMarkers(git as never);
-    expect(git.diff).toHaveBeenCalledWith(["--no-ext-diff", "--cached", "--numstat"]);
+    expect(git.diff).toHaveBeenCalledWith([
+      "--no-ext-diff",
+      "--no-textconv",
+      "--cached",
+      "--numstat",
+    ]);
+  });
+
+  it("guards leading-dash filenames in the index reference via --end-of-options", async () => {
+    // A file named `-danger.ts` would otherwise produce `:-danger.ts`, which
+    // an unprotected argv parser could see as a flag-like token.
+    const git = makeFakeGit({
+      status: vi.fn().mockResolvedValue({ files: [stagedFile("-danger.ts")] }),
+      raw: vi.fn().mockResolvedValue("clean content\n"),
+    });
+    await expect(scanStagedFilesForConflictMarkers(git as never)).resolves.toBeUndefined();
+    expect(git.raw).toHaveBeenCalledWith(["cat-file", "blob", "--end-of-options", ":-danger.ts"]);
   });
 
   it("stops on the first offending file and identifies it", async () => {
@@ -161,21 +177,21 @@ describe("scanStagedFilesForConflictMarkers", () => {
       status: vi.fn().mockResolvedValue({
         files: [stagedFile("clean.ts"), stagedFile("bad.ts"), stagedFile("other.ts")],
       }),
-      show: vi.fn(async (args: string[]) => {
-        if (args[0] === ":bad.ts") return "<<<<<<< HEAD\n";
+      raw: vi.fn(async (args: string[]) => {
+        if (args.includes(":bad.ts")) return "<<<<<<< HEAD\n";
         return "clean content\n";
       }),
     });
     await expect(scanStagedFilesForConflictMarkers(git as never)).rejects.toThrow(
       /Unresolved conflict markers found in bad\.ts/
     );
-    expect(git.show).not.toHaveBeenCalledWith([":other.ts"]);
+    expect(git.raw).not.toHaveBeenCalledWith(["cat-file", "blob", "--end-of-options", ":other.ts"]);
   });
 
   it("blocks a first-line marker that follows a UTF-8 BOM", async () => {
     const git = makeFakeGit({
       status: vi.fn().mockResolvedValue({ files: [stagedFile("bom.txt")] }),
-      show: vi.fn().mockResolvedValue("\uFEFF<<<<<<< HEAD\nours\n=======\ntheirs\n>>>>>>> b\n"),
+      raw: vi.fn().mockResolvedValue("\uFEFF<<<<<<< HEAD\nours\n=======\ntheirs\n>>>>>>> b\n"),
     });
     await expect(scanStagedFilesForConflictMarkers(git as never)).rejects.toThrow(
       /Unresolved conflict markers found in bom\.txt/
@@ -189,7 +205,7 @@ describe("scanStagedFilesForConflictMarkers", () => {
     const content = markerLine + "a".repeat(1_000_000 - markerLine.length);
     const git = makeFakeGit({
       status: vi.fn().mockResolvedValue({ files: [stagedFile("edge.txt")] }),
-      show: vi.fn().mockResolvedValue(content),
+      raw: vi.fn().mockResolvedValue(content),
     });
     expect(Buffer.byteLength(content, "utf8")).toBe(1_000_000);
     await expect(scanStagedFilesForConflictMarkers(git as never)).rejects.toThrow(
@@ -202,16 +218,16 @@ describe("scanStagedFilesForConflictMarkers", () => {
     const content = "<<<<<<< HEAD\n" + "a".repeat(1_000_001 - "<<<<<<< HEAD\n".length);
     const git = makeFakeGit({
       status: vi.fn().mockResolvedValue({ files: [stagedFile("huge.txt")] }),
-      show: vi.fn().mockResolvedValue(content),
+      raw: vi.fn().mockResolvedValue(content),
     });
     expect(Buffer.byteLength(content, "utf8")).toBe(1_000_001);
     await expect(scanStagedFilesForConflictMarkers(git as never)).resolves.toBeUndefined();
   });
 
-  it("propagates git.show rejections (does not silently permit)", async () => {
+  it("propagates cat-file rejections (does not silently permit)", async () => {
     const git = makeFakeGit({
       status: vi.fn().mockResolvedValue({ files: [stagedFile("src/foo.ts")] }),
-      show: vi.fn().mockRejectedValue(new Error("fatal: bad revision")),
+      raw: vi.fn().mockRejectedValue(new Error("fatal: bad revision")),
     });
     await expect(scanStagedFilesForConflictMarkers(git as never)).rejects.toThrow(/bad revision/);
   });
@@ -219,12 +235,17 @@ describe("scanStagedFilesForConflictMarkers", () => {
   it("handles paths with spaces", async () => {
     const git = makeFakeGit({
       status: vi.fn().mockResolvedValue({ files: [stagedFile("dir/merge notes.ts")] }),
-      show: vi.fn().mockResolvedValue("<<<<<<< HEAD\n"),
+      raw: vi.fn().mockResolvedValue("<<<<<<< HEAD\n"),
     });
     await expect(scanStagedFilesForConflictMarkers(git as never)).rejects.toThrow(
       /Unresolved conflict markers found in dir\/merge notes\.ts/
     );
-    expect(git.show).toHaveBeenCalledWith([":dir/merge notes.ts"]);
+    expect(git.raw).toHaveBeenCalledWith([
+      "cat-file",
+      "blob",
+      "--end-of-options",
+      ":dir/merge notes.ts",
+    ]);
   });
 });
 
@@ -237,7 +258,7 @@ describe("git:commit handler", () => {
   it("invokes git.commit when staged content is clean", async () => {
     const git = makeFakeGit({
       status: vi.fn().mockResolvedValue({ files: [stagedFile("src/foo.ts")] }),
-      show: vi.fn().mockResolvedValue("clean\n"),
+      raw: vi.fn().mockResolvedValue("clean\n"),
     });
     createHardenedGitMock.mockReturnValue(git);
     registerGitWriteHandlers({} as Parameters<typeof registerGitWriteHandlers>[0]);
@@ -254,7 +275,7 @@ describe("git:commit handler", () => {
   it("blocks the commit when a staged file carries conflict markers", async () => {
     const git = makeFakeGit({
       status: vi.fn().mockResolvedValue({ files: [stagedFile("src/foo.ts")] }),
-      show: vi.fn().mockResolvedValue("<<<<<<< HEAD\nours\n=======\ntheirs\n>>>>>>> branch\n"),
+      raw: vi.fn().mockResolvedValue("<<<<<<< HEAD\nours\n=======\ntheirs\n>>>>>>> branch\n"),
     });
     createHardenedGitMock.mockReturnValue(git);
     registerGitWriteHandlers({} as Parameters<typeof registerGitWriteHandlers>[0]);

--- a/electron/ipc/handlers/__tests__/git-write.commit.test.ts
+++ b/electron/ipc/handlers/__tests__/git-write.commit.test.ts
@@ -287,3 +287,55 @@ describe("git:commit handler", () => {
     expect(git.commit).not.toHaveBeenCalled();
   });
 });
+
+describe("git:get-working-diff handler", () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+    _resetRateLimitQueuesForTest();
+  });
+
+  it("passes --no-ext-diff and --no-textconv for unstaged diff", async () => {
+    const git = makeFakeGit({ diff: vi.fn().mockResolvedValue("diff content\n") });
+    createHardenedGitMock.mockReturnValue(git);
+    registerGitWriteHandlers({} as Parameters<typeof registerGitWriteHandlers>[0]);
+    const handler = getHandler("git:get-working-diff");
+
+    await handler(null, { cwd: "/tmp/repo", type: "unstaged" });
+
+    expect(git.diff).toHaveBeenCalledWith(["--no-ext-diff", "--no-textconv"]);
+  });
+
+  it("passes --no-ext-diff and --no-textconv for staged diff", async () => {
+    const git = makeFakeGit({ diff: vi.fn().mockResolvedValue("diff content\n") });
+    createHardenedGitMock.mockReturnValue(git);
+    registerGitWriteHandlers({} as Parameters<typeof registerGitWriteHandlers>[0]);
+    const handler = getHandler("git:get-working-diff");
+
+    await handler(null, { cwd: "/tmp/repo", type: "staged" });
+
+    expect(git.diff).toHaveBeenCalledWith(["--no-ext-diff", "--no-textconv", "--cached"]);
+  });
+
+  it("passes --no-ext-diff and --no-textconv for HEAD diff", async () => {
+    const git = makeFakeGit({ diff: vi.fn().mockResolvedValue("diff content\n") });
+    createHardenedGitMock.mockReturnValue(git);
+    registerGitWriteHandlers({} as Parameters<typeof registerGitWriteHandlers>[0]);
+    const handler = getHandler("git:get-working-diff");
+
+    await handler(null, { cwd: "/tmp/repo", type: "head" });
+
+    expect(git.diff).toHaveBeenCalledWith(["--no-ext-diff", "--no-textconv", "HEAD"]);
+  });
+
+  it("rejects an invalid diff type without invoking git", async () => {
+    const git = makeFakeGit();
+    createHardenedGitMock.mockReturnValue(git);
+    registerGitWriteHandlers({} as Parameters<typeof registerGitWriteHandlers>[0]);
+    const handler = getHandler("git:get-working-diff");
+
+    await expect(handler(null, { cwd: "/tmp/repo", type: "garbage" })).rejects.toThrow(
+      /Invalid diff type/
+    );
+    expect(git.diff).not.toHaveBeenCalled();
+  });
+});

--- a/electron/ipc/handlers/git-write.ts
+++ b/electron/ipc/handlers/git-write.ts
@@ -188,9 +188,10 @@ function parseBinaryPathsFromNumstat(raw: string): Set<string> {
 /**
  * Block commits that would include unresolved merge conflict markers. Reads
  * the staged (index) blob for each non-binary, non-deleted file via
- * `git show :<path>`, which works on both normal and unborn branches. Throws
- * a descriptive `Error` naming the first offending file; the IPC layer
- * surfaces `.message` directly to the UI.
+ * `git cat-file blob :<path>`, which works on both normal and unborn branches
+ * and bypasses smudge/textconv filter machinery (`git show` would still apply
+ * smudge filters depending on git version). Throws a descriptive `Error`
+ * naming the first offending file; the IPC layer surfaces `.message` directly.
  */
 export async function scanStagedFilesForConflictMarkers(git: SimpleGit): Promise<void> {
   const status = await git.status();
@@ -205,14 +206,17 @@ export async function scanStagedFilesForConflictMarkers(git: SimpleGit): Promise
   if (candidates.length === 0) return;
 
   // `--no-ext-diff` is mandatory: without it, a user-configured `diff.external`
-  // tool can break the numstat call (lesson #4221). Matches the pattern in
-  // handleGetWorkingDiff and utils/git.ts.
-  const numstatRaw = await git.diff(["--no-ext-diff", "--cached", "--numstat"]);
+  // tool can break the numstat call (lesson #4221). `--no-textconv` blocks
+  // user-defined diff drivers that would execute arbitrary binaries via
+  // `.gitattributes` textconv mappings.
+  const numstatRaw = await git.diff(["--no-ext-diff", "--no-textconv", "--cached", "--numstat"]);
   const binaryPaths = parseBinaryPathsFromNumstat(numstatRaw);
 
   for (const filePath of candidates) {
     if (binaryPaths.has(filePath)) continue;
-    const content = await git.show([`:${filePath}`]);
+    // `--end-of-options` so a leading-dash path inside the index reference
+    // (e.g. `:-foo.txt`) cannot be parsed as a flag.
+    const content = await git.raw(["cat-file", "blob", "--end-of-options", `:${filePath}`]);
     if (typeof content !== "string") continue;
     // Compare against the UTF-8 byte length so a multibyte file isn't
     // misclassified against a character-count cap.
@@ -583,13 +587,13 @@ export function registerGitWriteHandlers(_deps: HandlerDependencies): () => void
     let raw: string;
     switch (diffType) {
       case "unstaged":
-        raw = await git.diff(["--no-ext-diff"]);
+        raw = await git.diff(["--no-ext-diff", "--no-textconv"]);
         break;
       case "staged":
-        raw = await git.diff(["--no-ext-diff", "--cached"]);
+        raw = await git.diff(["--no-ext-diff", "--no-textconv", "--cached"]);
         break;
       case "head":
-        raw = await git.diff(["--no-ext-diff", "HEAD"]);
+        raw = await git.diff(["--no-ext-diff", "--no-textconv", "HEAD"]);
         break;
     }
 

--- a/electron/services/GitService.ts
+++ b/electron/services/GitService.ts
@@ -6,7 +6,7 @@ import { logDebug, logError, logWarn } from "../utils/logger.js";
 import type { GitStatus, WorktreeChanges } from "../../shared/types/index.js";
 import { WorktreeRemovedError, GitError, toGitOperationError } from "../utils/errorTypes.js";
 import type { CrossWorktreeDiffResult, CrossWorktreeFile } from "../../shared/types/ipc/git.js";
-import { createHardenedGit } from "../utils/hardenedGit.js";
+import { createHardenedGit, validateBranchName } from "../utils/hardenedGit.js";
 import { formatErrorMessage } from "../../shared/utils/errorMessage.js";
 
 function escapeRegex(str: string): string {
@@ -100,6 +100,9 @@ export class GitService {
       fromRemote: options.fromRemote,
     });
 
+    validateBranchName(newBranch);
+    validateBranchName(baseBranch);
+
     const pathValidation = this.validatePath(path);
     if (!pathValidation.valid) {
       throw new Error(pathValidation.error);
@@ -118,7 +121,18 @@ export class GitService {
           remoteBranch: baseBranch,
         });
 
-        await this.git.raw(["worktree", "add", "-b", newBranch, "--track", path, baseBranch]);
+        // `--end-of-options` after the subcommand flags so any leading-dash
+        // ref or path that slipped past validation is treated as positional.
+        await this.git.raw([
+          "worktree",
+          "add",
+          "-b",
+          newBranch,
+          "--track",
+          "--end-of-options",
+          path,
+          baseBranch,
+        ]);
       } else {
         logDebug("Creating worktree with new branch", {
           path,
@@ -126,7 +140,15 @@ export class GitService {
           baseBranch,
         });
 
-        await this.git.raw(["worktree", "add", "-b", newBranch, path, baseBranch]);
+        await this.git.raw([
+          "worktree",
+          "add",
+          "-b",
+          newBranch,
+          "--end-of-options",
+          path,
+          baseBranch,
+        ]);
       }
 
       logDebug("Worktree created successfully", { path, newBranch });
@@ -255,9 +277,12 @@ ${lines.map((l) => "+" + l).join("\n")}`;
     }
 
     try {
+      // `--no-textconv` blocks user-defined diff drivers that would otherwise
+      // execute arbitrary binaries via `.gitattributes` textconv mappings.
       const diff = await this.git.diff([
         "HEAD",
         "--no-ext-diff",
+        "--no-textconv",
         "--no-color",
         "--",
         normalizedPath,
@@ -295,7 +320,18 @@ ${lines.map((l) => "+" + l).join("\n")}`;
       return filePath ? "NO_CHANGES" : { branch1, branch2, files: [] };
     }
 
-    const range = useMergeBase ? `${branch1}...${branch2}` : `${branch1}..${branch2}`;
+    validateBranchName(branch1);
+    validateBranchName(branch2);
+
+    // Expand to fully qualified `refs/heads/` so a leading-dash branch name
+    // can never appear at the start of the range token. `--end-of-options`
+    // alone is insufficient — git's revision parser sees `branch1..branch2`
+    // as a single argument and re-parses dashes inside it as flags.
+    // Worktree branches surface as short names (`refs/heads/` is stripped in
+    // `listWorktrees`), so this prefix is always correct.
+    const ref1 = `refs/heads/${branch1}`;
+    const ref2 = `refs/heads/${branch2}`;
+    const range = useMergeBase ? `${ref1}...${ref2}` : `${ref1}..${ref2}`;
 
     if (filePath) {
       // Return the unified diff for a specific file
@@ -303,7 +339,9 @@ ${lines.map((l) => "+" + l).join("\n")}`;
         const diff = await this.git.raw([
           "diff",
           "--no-ext-diff",
+          "--no-textconv",
           "--no-color",
+          "--end-of-options",
           range,
           "--",
           filePath,
@@ -335,7 +373,14 @@ ${lines.map((l) => "+" + l).join("\n")}`;
 
     // Return the list of changed files
     try {
-      const output = await this.git.raw(["diff", "--no-ext-diff", "--name-status", range]);
+      const output = await this.git.raw([
+        "diff",
+        "--no-ext-diff",
+        "--no-textconv",
+        "--name-status",
+        "--end-of-options",
+        range,
+      ]);
       const files: CrossWorktreeFile[] = [];
 
       for (const line of output.split("\n")) {
@@ -433,7 +478,9 @@ ${lines.map((l) => "+" + l).join("\n")}`;
     if (force) {
       args.push("--force");
     }
-    args.push(worktreePath);
+    // `--end-of-options` so a leading-dash worktree path is treated as
+    // positional rather than parsed as a flag.
+    args.push("--end-of-options", worktreePath);
 
     return this.handleGitOperation(async () => {
       await this.git.raw(args);

--- a/electron/services/GitService.ts
+++ b/electron/services/GitService.ts
@@ -316,12 +316,15 @@ ${lines.map((l) => "+" + l).join("\n")}`;
     filePath?: string,
     useMergeBase?: boolean
   ): Promise<CrossWorktreeDiffResult | string> {
+    // Validate before the equality fast-path so an invalid argv-shaped name
+    // is rejected unconditionally — not silently accepted when both inputs
+    // happen to match.
+    validateBranchName(branch1);
+    validateBranchName(branch2);
+
     if (branch1 === branch2) {
       return filePath ? "NO_CHANGES" : { branch1, branch2, files: [] };
     }
-
-    validateBranchName(branch1);
-    validateBranchName(branch2);
 
     // Expand to fully qualified `refs/heads/` so a leading-dash branch name
     // can never appear at the start of the range token. `--end-of-options`

--- a/electron/services/__tests__/GitService.test.ts
+++ b/electron/services/__tests__/GitService.test.ts
@@ -197,6 +197,17 @@ describe("GitService", () => {
       expect(gitClientMock.raw).not.toHaveBeenCalled();
     });
 
+    it("rejects an invalid name even when both branches are equal", async () => {
+      // The equality fast-path must not mask validation; otherwise a caller
+      // could pass `--exec=evil` for both args and get a silent OK back.
+      const service = new GitService(tempDir);
+
+      await expect(service.compareWorktrees("--exec=evil", "--exec=evil")).rejects.toThrow(
+        "must not start with '-'"
+      );
+      expect(gitClientMock.raw).not.toHaveBeenCalled();
+    });
+
     it("passes --no-textconv to defeat user-defined textconv drivers", async () => {
       gitClientMock.raw.mockResolvedValue("");
 

--- a/electron/services/__tests__/GitService.test.ts
+++ b/electron/services/__tests__/GitService.test.ts
@@ -15,9 +15,15 @@ const createHardenedGitMock = vi.hoisted(() => vi.fn());
 const logWarnMock = vi.hoisted(() => vi.fn());
 const logErrorMock = vi.hoisted(() => vi.fn());
 
-vi.mock("../../utils/hardenedGit.js", () => ({
-  createHardenedGit: createHardenedGitMock,
-}));
+vi.mock("../../utils/hardenedGit.js", async () => {
+  const actual = await vi.importActual<typeof import("../../utils/hardenedGit.js")>(
+    "../../utils/hardenedGit.js"
+  );
+  return {
+    ...actual,
+    createHardenedGit: createHardenedGitMock,
+  };
+});
 
 vi.mock("../../utils/logger.js", () => ({
   logDebug: vi.fn(),
@@ -160,26 +166,57 @@ describe("GitService", () => {
   });
 
   describe("compareWorktrees", () => {
-    it("uses two-dot range by default", async () => {
+    it("expands branches to refs/heads/ in two-dot range by default", async () => {
       gitClientMock.raw.mockResolvedValue("");
 
       const service = new GitService(tempDir);
       await service.compareWorktrees("main", "feature/test");
 
       expect(gitClientMock.raw).toHaveBeenCalledWith(
-        expect.arrayContaining(["main..feature/test"])
+        expect.arrayContaining(["refs/heads/main..refs/heads/feature/test"])
       );
     });
 
-    it("uses three-dot range when useMergeBase is true", async () => {
+    it("expands branches to refs/heads/ in three-dot range when useMergeBase is true", async () => {
       gitClientMock.raw.mockResolvedValue("");
 
       const service = new GitService(tempDir);
       await service.compareWorktrees("main", "feature/test", undefined, true);
 
       expect(gitClientMock.raw).toHaveBeenCalledWith(
-        expect.arrayContaining(["main...feature/test"])
+        expect.arrayContaining(["refs/heads/main...refs/heads/feature/test"])
       );
+    });
+
+    it("rejects leading-dash branch names before invoking git", async () => {
+      const service = new GitService(tempDir);
+
+      await expect(service.compareWorktrees("--exec=evil", "main")).rejects.toThrow(
+        "must not start with '-'"
+      );
+      expect(gitClientMock.raw).not.toHaveBeenCalled();
+    });
+
+    it("passes --no-textconv to defeat user-defined textconv drivers", async () => {
+      gitClientMock.raw.mockResolvedValue("");
+
+      const service = new GitService(tempDir);
+      await service.compareWorktrees("main", "feature/test");
+
+      expect(gitClientMock.raw).toHaveBeenCalledWith(expect.arrayContaining(["--no-textconv"]));
+    });
+
+    it("places --end-of-options before the range to defuse stray flag-like tokens", async () => {
+      gitClientMock.raw.mockResolvedValue("");
+
+      const service = new GitService(tempDir);
+      await service.compareWorktrees("main", "feature/test", "src/app.ts");
+
+      const args = gitClientMock.raw.mock.calls[0][0] as string[];
+      const eooIdx = args.indexOf("--end-of-options");
+      const rangeIdx = args.indexOf("refs/heads/main..refs/heads/feature/test");
+      expect(eooIdx).toBeGreaterThanOrEqual(0);
+      expect(rangeIdx).toBeGreaterThan(eooIdx);
     });
 
     it("returns file list for two-dot range", async () => {
@@ -249,8 +286,110 @@ describe("GitService", () => {
       await service.compareWorktrees("main", "feature/test", "src/app.ts", true);
 
       expect(gitClientMock.raw).toHaveBeenCalledWith(
-        expect.arrayContaining(["main...feature/test", "--", "src/app.ts"])
+        expect.arrayContaining(["refs/heads/main...refs/heads/feature/test", "--", "src/app.ts"])
       );
+    });
+  });
+
+  describe("createWorktree hardening", () => {
+    it("rejects a leading-dash newBranch before any git call", async () => {
+      const service = new GitService(tempDir);
+
+      const target = path.join(tempDir, "new-wt-1");
+      await expect(
+        service.createWorktree({
+          baseBranch: "main",
+          newBranch: "--exec=touch /tmp/x",
+          path: target,
+        })
+      ).rejects.toThrow("must not start with '-'");
+      expect(gitClientMock.raw).not.toHaveBeenCalled();
+    });
+
+    it("rejects a leading-dash baseBranch before any git call", async () => {
+      const service = new GitService(tempDir);
+
+      const target = path.join(tempDir, "new-wt-2");
+      await expect(
+        service.createWorktree({
+          baseBranch: "-upload-pack=evil",
+          newBranch: "feature/x",
+          path: target,
+        })
+      ).rejects.toThrow("must not start with '-'");
+      expect(gitClientMock.raw).not.toHaveBeenCalled();
+    });
+
+    it("places --end-of-options between subcommand flags and positionals (local)", async () => {
+      const service = new GitService(tempDir);
+      const target = path.join(tempDir, "new-wt-local");
+
+      await service.createWorktree({
+        baseBranch: "main",
+        newBranch: "feature/x",
+        path: target,
+      });
+
+      const args = gitClientMock.raw.mock.calls[0][0] as string[];
+      const eooIdx = args.indexOf("--end-of-options");
+      const pathIdx = args.indexOf(target);
+      const baseIdx = args.indexOf("main");
+      const branchIdx = args.indexOf("feature/x");
+      expect(eooIdx).toBeGreaterThanOrEqual(0);
+      // EOO must come after the -b <branch> pair and before the positionals
+      expect(branchIdx).toBeLessThan(eooIdx);
+      expect(eooIdx).toBeLessThan(pathIdx);
+      expect(eooIdx).toBeLessThan(baseIdx);
+    });
+
+    it("places --end-of-options after --track for fromRemote worktrees", async () => {
+      const service = new GitService(tempDir);
+      const target = path.join(tempDir, "new-wt-remote");
+
+      await service.createWorktree({
+        baseBranch: "origin/main",
+        newBranch: "feature/x",
+        path: target,
+        fromRemote: true,
+      });
+
+      const args = gitClientMock.raw.mock.calls[0][0] as string[];
+      expect(args).toContain("--track");
+      const trackIdx = args.indexOf("--track");
+      const eooIdx = args.indexOf("--end-of-options");
+      const pathIdx = args.indexOf(target);
+      expect(trackIdx).toBeLessThan(eooIdx);
+      expect(eooIdx).toBeLessThan(pathIdx);
+    });
+  });
+
+  describe("removeWorktree hardening", () => {
+    it("places --end-of-options before the worktree path", async () => {
+      const service = new GitService(tempDir);
+      const target = path.join(tempDir, "old-wt");
+
+      await service.removeWorktree(target);
+
+      const args = gitClientMock.raw.mock.calls[0][0] as string[];
+      const eooIdx = args.indexOf("--end-of-options");
+      const pathIdx = args.indexOf(target);
+      expect(eooIdx).toBeGreaterThanOrEqual(0);
+      expect(pathIdx).toBeGreaterThan(eooIdx);
+    });
+
+    it("keeps --end-of-options after --force when force is true", async () => {
+      const service = new GitService(tempDir);
+      const target = path.join(tempDir, "old-wt-force");
+
+      await service.removeWorktree(target, true);
+
+      const args = gitClientMock.raw.mock.calls[0][0] as string[];
+      expect(args).toContain("--force");
+      const forceIdx = args.indexOf("--force");
+      const eooIdx = args.indexOf("--end-of-options");
+      const pathIdx = args.indexOf(target);
+      expect(forceIdx).toBeLessThan(eooIdx);
+      expect(eooIdx).toBeLessThan(pathIdx);
     });
   });
 
@@ -261,6 +400,15 @@ describe("GitService", () => {
     await service.getFileDiff("foo.ts", "modified");
 
     expect(gitClientMock.diff).toHaveBeenCalledWith(expect.arrayContaining(["--no-ext-diff"]));
+  });
+
+  it("passes --no-textconv to git.diff for modified files", async () => {
+    gitClientMock.diff.mockResolvedValue("diff --git a/foo.ts b/foo.ts\n+change");
+
+    const service = new GitService(tempDir);
+    await service.getFileDiff("foo.ts", "modified");
+
+    expect(gitClientMock.diff).toHaveBeenCalledWith(expect.arrayContaining(["--no-textconv"]));
   });
 
   it("passes --no-ext-diff to git.raw for cross-worktree file diff", async () => {

--- a/electron/utils/__tests__/hardenedGit.test.ts
+++ b/electron/utils/__tests__/hardenedGit.test.ts
@@ -16,6 +16,7 @@ vi.mock("simple-git", () => ({
 
 import {
   validateCwd,
+  validateBranchName,
   createHardenedGit,
   createAuthenticatedGit,
   createBackgroundFetchGit,
@@ -65,6 +66,83 @@ describe("validateCwd", () => {
 
   it("does not throw for root path", () => {
     expect(() => validateCwd("/")).not.toThrow();
+  });
+});
+
+describe("validateBranchName", () => {
+  it("accepts simple branch names", () => {
+    expect(() => validateBranchName("main")).not.toThrow();
+    expect(() => validateBranchName("develop")).not.toThrow();
+    expect(() => validateBranchName("feature/login")).not.toThrow();
+    expect(() => validateBranchName("bugfix-7046")).not.toThrow();
+    expect(() => validateBranchName("user.name/topic_1")).not.toThrow();
+  });
+
+  it("accepts non-ASCII unicode names that git allows", () => {
+    expect(() => validateBranchName("café")).not.toThrow();
+    expect(() => validateBranchName("功能/登录")).not.toThrow();
+  });
+
+  it("rejects empty string", () => {
+    expect(() => validateBranchName("")).toThrow("Branch name is required");
+  });
+
+  it("rejects non-string input", () => {
+    expect(() => validateBranchName(123 as unknown as string)).toThrow("Branch name is required");
+    expect(() => validateBranchName(null as unknown as string)).toThrow("Branch name is required");
+    expect(() => validateBranchName(undefined as unknown as string)).toThrow(
+      "Branch name is required"
+    );
+  });
+
+  it("rejects leading-dash names that argv parsers treat as flags", () => {
+    expect(() => validateBranchName("-c")).toThrow("must not start with '-'");
+    expect(() => validateBranchName("--exec=touch /tmp/x")).toThrow("must not start with '-'");
+    expect(() => validateBranchName("-upload-pack=evil")).toThrow("must not start with '-'");
+  });
+
+  it("rejects '..' anywhere in the name", () => {
+    expect(() => validateBranchName("foo..bar")).toThrow("must not contain '..'");
+    expect(() => validateBranchName("..bar")).toThrow("must not contain '..'");
+  });
+
+  it("rejects '@{' (reflog token)", () => {
+    expect(() => validateBranchName("foo@{1}")).toThrow("must not contain '@{'");
+  });
+
+  it("rejects forbidden ref-format characters", () => {
+    expect(() => validateBranchName("a b")).toThrow("invalid characters");
+    expect(() => validateBranchName("a:b")).toThrow("invalid characters");
+    expect(() => validateBranchName("a?b")).toThrow("invalid characters");
+    expect(() => validateBranchName("a*b")).toThrow("invalid characters");
+    expect(() => validateBranchName("a[b")).toThrow("invalid characters");
+    expect(() => validateBranchName("a\\b")).toThrow("invalid characters");
+    expect(() => validateBranchName("a~b")).toThrow("invalid characters");
+    expect(() => validateBranchName("a^b")).toThrow("invalid characters");
+  });
+
+  it("rejects control characters", () => {
+    expect(() => validateBranchName("a\x00b")).toThrow("invalid characters");
+    expect(() => validateBranchName("a\nb")).toThrow("invalid characters");
+    expect(() => validateBranchName("a\tb")).toThrow("invalid characters");
+    expect(() => validateBranchName("a\x7fb")).toThrow("invalid characters");
+  });
+
+  it("rejects names ending with '.'", () => {
+    expect(() => validateBranchName("trailing.")).toThrow("must not end with '.'");
+  });
+
+  it("rejects names ending with '.lock'", () => {
+    expect(() => validateBranchName("foo.lock")).toThrow("must not end with '.lock'");
+  });
+
+  it("rejects names that begin or end with '/'", () => {
+    expect(() => validateBranchName("/leading")).toThrow("must not start or end with '/'");
+    expect(() => validateBranchName("trailing/")).toThrow("must not start or end with '/'");
+  });
+
+  it("rejects consecutive slashes", () => {
+    expect(() => validateBranchName("double//slash")).toThrow("must not contain '//'");
   });
 });
 

--- a/electron/utils/__tests__/hardenedGit.test.ts
+++ b/electron/utils/__tests__/hardenedGit.test.ts
@@ -133,7 +133,12 @@ describe("validateBranchName", () => {
   });
 
   it("rejects names ending with '.lock'", () => {
-    expect(() => validateBranchName("foo.lock")).toThrow("must not end with '.lock'");
+    expect(() => validateBranchName("foo.lock")).toThrow("'.lock' component");
+  });
+
+  it("rejects '.lock' on a non-final path component", () => {
+    expect(() => validateBranchName("foo.lock/bar")).toThrow("'.lock' component");
+    expect(() => validateBranchName("a/b.lock/c")).toThrow("'.lock' component");
   });
 
   it("rejects names that begin or end with '/'", () => {

--- a/electron/utils/hardenedGit.ts
+++ b/electron/utils/hardenedGit.ts
@@ -50,6 +50,45 @@ export function validateCwd(cwd: unknown): asserts cwd is string {
   }
 }
 
+// eslint-disable-next-line no-control-regex
+const BRANCH_NAME_FORBIDDEN_CHARS = /[\x00-\x1f\x7f ~^:?*[\\]/;
+
+/**
+ * Validate a branch name as a strict subset of `git check-ref-format --branch`.
+ * Primarily blocks leading-dash names that git's argv parser would treat as
+ * flags (e.g. `--exec=touch /tmp/x`); also rejects control chars and other
+ * git-special sequences. Throws on invalid input.
+ */
+export function validateBranchName(branchName: unknown): asserts branchName is string {
+  if (typeof branchName !== "string" || branchName.length === 0) {
+    throw new Error("Branch name is required");
+  }
+  if (branchName.startsWith("-")) {
+    throw new Error("Branch name must not start with '-'");
+  }
+  if (BRANCH_NAME_FORBIDDEN_CHARS.test(branchName)) {
+    throw new Error("Branch name contains invalid characters");
+  }
+  if (branchName.includes("..")) {
+    throw new Error("Branch name must not contain '..'");
+  }
+  if (branchName.includes("@{")) {
+    throw new Error("Branch name must not contain '@{'");
+  }
+  if (branchName.endsWith(".")) {
+    throw new Error("Branch name must not end with '.'");
+  }
+  if (branchName.endsWith(".lock")) {
+    throw new Error("Branch name must not end with '.lock'");
+  }
+  if (branchName.startsWith("/") || branchName.endsWith("/")) {
+    throw new Error("Branch name must not start or end with '/'");
+  }
+  if (branchName.includes("//")) {
+    throw new Error("Branch name must not contain '//'");
+  }
+}
+
 export const GIT_BLOCK_TIMEOUT_MS = 30_000;
 
 /**

--- a/electron/utils/hardenedGit.ts
+++ b/electron/utils/hardenedGit.ts
@@ -78,14 +78,18 @@ export function validateBranchName(branchName: unknown): asserts branchName is s
   if (branchName.endsWith(".")) {
     throw new Error("Branch name must not end with '.'");
   }
-  if (branchName.endsWith(".lock")) {
-    throw new Error("Branch name must not end with '.lock'");
-  }
   if (branchName.startsWith("/") || branchName.endsWith("/")) {
     throw new Error("Branch name must not start or end with '/'");
   }
   if (branchName.includes("//")) {
     throw new Error("Branch name must not contain '//'");
+  }
+  // `.lock` is forbidden on every path component, not only the final one —
+  // git rejects `foo.lock/bar` for the same reason it rejects `foo.lock`.
+  for (const component of branchName.split("/")) {
+    if (component.endsWith(".lock")) {
+      throw new Error("Branch name must not contain a '.lock' component");
+    }
   }
 }
 

--- a/electron/workspace-host/WorkspaceService.ts
+++ b/electron/workspace-host/WorkspaceService.ts
@@ -4,7 +4,11 @@ import { stat, readFile, access } from "fs/promises";
 import { resolve as pathResolve, isAbsolute } from "path";
 import { generateProjectId, settingsFilePath } from "../services/projectStorePaths.js";
 import { SimpleGit, BranchSummary } from "simple-git";
-import { createHardenedGit, createAuthenticatedGit } from "../utils/hardenedGit.js";
+import {
+  createHardenedGit,
+  createAuthenticatedGit,
+  validateBranchName,
+} from "../utils/hardenedGit.js";
 import { classifyGitError, getGitRecoveryAction } from "../../shared/utils/gitOperationErrors.js";
 import type { Worktree } from "../../shared/types/worktree.js";
 import type {
@@ -928,6 +932,11 @@ export class WorkspaceService {
       let { newBranch } = options;
       let { fromRemote = false, useExistingBranch = false } = options;
 
+      // Reject branch names that argv parsers would treat as flags (leading
+      // dash) or that contain git-special characters before any git call.
+      validateBranchName(newBranch);
+      validateBranchName(baseBranch);
+
       // #6463: when not explicitly reusing a branch, guard against a stale
       // local branch with the same name. Without this, `git worktree add -b`
       // hits "fatal: a branch named '...' already exists" whenever a previous
@@ -978,17 +987,37 @@ export class WorkspaceService {
         }
       }
 
+      // `--end-of-options` after the subcommand flags so any leading-dash ref
+      // or path that slipped past validation is treated as positional.
       if (useExistingBranch) {
-        await git.raw(["worktree", "add", path, newBranch]);
+        await git.raw(["worktree", "add", "--end-of-options", path, newBranch]);
       } else if (fromRemote) {
-        await git.raw(["worktree", "add", "-b", newBranch, "--track", path, baseBranch]);
+        await git.raw([
+          "worktree",
+          "add",
+          "-b",
+          newBranch,
+          "--track",
+          "--end-of-options",
+          path,
+          baseBranch,
+        ]);
       } else {
         // --no-track: local-base branches shouldn't auto-track a local ref even
         // when the user has branch.autoSetupMerge=always. Skipping tracking also
         // avoids a .git/config.lock acquisition, cutting contention under bulk
         // creation. PR-mode (fromRemote) keeps --track — ahead/behind badges
         // at WorktreeMonitor.ts:1092 depend on @{u} resolving.
-        await git.raw(["worktree", "add", "-b", newBranch, "--no-track", path, baseBranch]);
+        await git.raw([
+          "worktree",
+          "add",
+          "-b",
+          newBranch,
+          "--no-track",
+          "--end-of-options",
+          path,
+          baseBranch,
+        ]);
       }
 
       const absolutePath = isAbsolute(path) ? path : pathResolve(rootPath, path);
@@ -1536,7 +1565,9 @@ export class WorkspaceService {
           if (force) {
             args.push("--force");
           }
-          args.push(monitor.path);
+          // `--end-of-options` so a leading-dash worktree path is treated as
+          // positional rather than parsed as a flag.
+          args.push("--end-of-options", monitor.path);
           try {
             await this.git.raw(args);
           } catch (removeError) {
@@ -1758,7 +1789,16 @@ ${lines.map((l) => "+" + l).join("\n")}`;
         return;
       }
 
-      const diff = await git.diff(["HEAD", "--no-ext-diff", "--no-color", "--", normalizedPath]);
+      // `--no-textconv` blocks user-defined diff drivers that would otherwise
+      // execute arbitrary binaries via `.gitattributes` textconv mappings.
+      const diff = await git.diff([
+        "HEAD",
+        "--no-ext-diff",
+        "--no-textconv",
+        "--no-color",
+        "--",
+        normalizedPath,
+      ]);
 
       if (diff.includes("Binary files")) {
         this.sendEvent({ type: "get-file-diff-result", requestId, diff: "BINARY_FILE" });

--- a/electron/workspace-host/__tests__/WorkspaceService.adversarial.test.ts
+++ b/electron/workspace-host/__tests__/WorkspaceService.adversarial.test.ts
@@ -21,6 +21,7 @@ vi.mock("../../utils/fs.js", () => ({
 vi.mock("../../utils/hardenedGit.js", () => ({
   createHardenedGit: vi.fn(() => mockSimpleGit),
   createAuthenticatedGit: vi.fn(() => mockSimpleGit),
+  validateBranchName: vi.fn(),
 }));
 
 vi.mock("../../utils/git.js", () => ({

--- a/electron/workspace-host/__tests__/WorkspaceService.createWorktree.test.ts
+++ b/electron/workspace-host/__tests__/WorkspaceService.createWorktree.test.ts
@@ -19,6 +19,7 @@ vi.mock("../../utils/fs.js", () => ({
 vi.mock("../../utils/hardenedGit.js", () => ({
   createHardenedGit: vi.fn(() => mockSimpleGit),
   validateCwd: vi.fn(),
+  validateBranchName: vi.fn(),
   getGitLocaleEnv: vi.fn().mockReturnValue({}),
 }));
 
@@ -175,6 +176,7 @@ describe("WorkspaceService.createWorktree", () => {
       "-b",
       "feature/test",
       "--no-track",
+      "--end-of-options",
       "/test/worktree",
       "main",
     ]);
@@ -218,6 +220,7 @@ describe("WorkspaceService.createWorktree", () => {
     expect(mockSimpleGit.raw).toHaveBeenCalledWith([
       "worktree",
       "add",
+      "--end-of-options",
       "/test/worktree2",
       "existing-branch",
     ]);
@@ -244,6 +247,7 @@ describe("WorkspaceService.createWorktree", () => {
       "-b",
       "feature/remote",
       "--track",
+      "--end-of-options",
       "/test/worktree3",
       "origin/main",
     ]);
@@ -476,6 +480,7 @@ describe("WorkspaceService.createWorktree", () => {
     expect(worktreeAddCall![0]).toEqual([
       "worktree",
       "add",
+      "--end-of-options",
       "/test/worktree-reuse",
       "bugfix/issue-6463",
     ]);
@@ -532,6 +537,7 @@ describe("WorkspaceService.createWorktree", () => {
       "-b",
       "feature/foo-2",
       "--no-track",
+      "--end-of-options",
       "/test/worktree-foo",
       "main",
     ]);
@@ -588,6 +594,7 @@ describe("WorkspaceService.createWorktree", () => {
       "-b",
       "feature/foo-4",
       "--no-track",
+      "--end-of-options",
       "/test/worktree-foo-new",
       "main",
     ]);
@@ -626,6 +633,7 @@ describe("WorkspaceService.createWorktree", () => {
       "-b",
       "feature/foo-2",
       "--no-track",
+      "--end-of-options",
       "/test/worktree-foo-fail",
       "main",
     ]);
@@ -669,6 +677,7 @@ describe("WorkspaceService.createWorktree", () => {
       "-b",
       "pr-9999-feature-2",
       "--track",
+      "--end-of-options",
       "/test/worktree-pr",
       "origin/pr-9999-feature",
     ]);
@@ -775,6 +784,7 @@ describe("WorkspaceService.createWorktree", () => {
       "-b",
       "feature/brand-new",
       "--no-track",
+      "--end-of-options",
       "/test/worktree-new",
       "main",
     ]);
@@ -800,6 +810,7 @@ describe("WorkspaceService.createWorktree", () => {
     expect(mockSimpleGit.raw).toHaveBeenCalledWith([
       "worktree",
       "add",
+      "--end-of-options",
       "/test/worktree-explicit",
       "existing-branch",
     ]);

--- a/electron/workspace-host/__tests__/WorkspaceService.deleteWorktree.test.ts
+++ b/electron/workspace-host/__tests__/WorkspaceService.deleteWorktree.test.ts
@@ -22,6 +22,7 @@ vi.mock("../../utils/fs.js", () => ({
 vi.mock("../../utils/hardenedGit.js", () => ({
   createHardenedGit: vi.fn(() => mockSimpleGit),
   validateCwd: vi.fn(),
+  validateBranchName: vi.fn(),
 }));
 
 vi.mock("../../utils/git.js", () => ({
@@ -204,6 +205,12 @@ describe("WorkspaceService.deleteWorktree", () => {
       (c) => Array.isArray(c[0]) && c[0][0] === "worktree" && c[0][1] === "remove"
     );
     expect(removeCalls.length).toBe(1);
+    // Defuses leading-dash worktree paths so they cannot be parsed as flags.
+    const removeArgs = removeCalls[0][0] as string[];
+    const eooIdx = removeArgs.indexOf("--end-of-options");
+    const pathIdx = removeArgs.indexOf("/test/worktree");
+    expect(eooIdx).toBeGreaterThanOrEqual(0);
+    expect(pathIdx).toBeGreaterThan(eooIdx);
   });
 
   it("sends error result for unknown worktreeId", async () => {

--- a/electron/workspace-host/__tests__/WorkspaceService.externalRemoval.test.ts
+++ b/electron/workspace-host/__tests__/WorkspaceService.externalRemoval.test.ts
@@ -21,6 +21,7 @@ vi.mock("../../utils/fs.js", () => ({
 vi.mock("../../utils/hardenedGit.js", () => ({
   createHardenedGit: vi.fn(() => mockSimpleGit),
   validateCwd: vi.fn(),
+  validateBranchName: vi.fn(),
 }));
 
 vi.mock("../../utils/git.js", () => ({

--- a/electron/workspace-host/__tests__/WorkspaceService.fetchPRBranch.test.ts
+++ b/electron/workspace-host/__tests__/WorkspaceService.fetchPRBranch.test.ts
@@ -20,6 +20,7 @@ vi.mock("../../utils/hardenedGit.js", () => ({
   createHardenedGit: vi.fn(() => mockSimpleGit),
   createAuthenticatedGit: vi.fn(() => mockSimpleGit),
   validateCwd: vi.fn(),
+  validateBranchName: vi.fn(),
 }));
 
 vi.mock("../../utils/git.js", () => ({

--- a/electron/workspace-host/__tests__/WorkspaceService.getFileDiff.test.ts
+++ b/electron/workspace-host/__tests__/WorkspaceService.getFileDiff.test.ts
@@ -20,6 +20,7 @@ vi.mock("../../utils/fs.js", () => ({
 vi.mock("../../utils/hardenedGit.js", () => ({
   createHardenedGit: vi.fn(() => mockSimpleGit),
   validateCwd: vi.fn(),
+  validateBranchName: vi.fn(),
 }));
 
 vi.mock("../../utils/git.js", () => ({
@@ -200,5 +201,12 @@ describe("WorkspaceService.getFileDiff", () => {
         error: "Absolute paths are not allowed",
       })
     );
+  });
+
+  it("passes --no-textconv on the modified-file diff to defeat textconv drivers", async () => {
+    mockSimpleGit.diff.mockResolvedValueOnce("diff --git a/foo.ts b/foo.ts\n+change");
+    await service.getFileDiff("req-6", "/test/repo", "foo.ts", "modified");
+
+    expect(mockSimpleGit.diff).toHaveBeenCalledWith(expect.arrayContaining(["--no-textconv"]));
   });
 });

--- a/electron/workspace-host/__tests__/WorkspaceService.lfs.test.ts
+++ b/electron/workspace-host/__tests__/WorkspaceService.lfs.test.ts
@@ -23,6 +23,7 @@ vi.mock("../../utils/hardenedGit.js", () => ({
   createHardenedGit: vi.fn(),
   createAuthenticatedGit: vi.fn(),
   validateCwd: vi.fn(),
+  validateBranchName: vi.fn(),
   getGitLocaleEnv: vi.fn(() => ({ LC_CTYPE: "C.UTF-8" })),
 }));
 vi.mock("../../services/events.js", () => ({ events: { on: vi.fn(), off: vi.fn() } }));

--- a/electron/workspace-host/__tests__/WorkspaceService.pauseResume.test.ts
+++ b/electron/workspace-host/__tests__/WorkspaceService.pauseResume.test.ts
@@ -20,6 +20,7 @@ vi.mock("../../utils/fs.js", () => ({
 vi.mock("../../utils/hardenedGit.js", () => ({
   createHardenedGit: vi.fn(() => mockSimpleGit),
   validateCwd: vi.fn(),
+  validateBranchName: vi.fn(),
 }));
 
 vi.mock("../../utils/git.js", () => ({

--- a/electron/workspace-host/__tests__/WorkspaceService.resource.test.ts
+++ b/electron/workspace-host/__tests__/WorkspaceService.resource.test.ts
@@ -25,6 +25,7 @@ vi.mock("../../utils/fs.js", () => ({
 vi.mock("../../utils/hardenedGit.js", () => ({
   createHardenedGit: vi.fn(() => mockSimpleGit),
   validateCwd: vi.fn(),
+  validateBranchName: vi.fn(),
 }));
 
 vi.mock("../../utils/git.js", () => ({


### PR DESCRIPTION
## Summary

- Adds `validateBranchName` in `electron/utils/hardenedGit.ts` — regex-based, rejects leading-dash names, control chars, ref-format-forbidden chars, `..`, `@{`, trailing `.`, `.lock` on any path component, and leading/trailing `/` or `//`.
- Hardens all IPC-reachable git command paths: `--end-of-options` before positionals in `worktree add`/`remove`, `--no-textconv` on every diff call site, `git cat-file blob` replacing `git show` in the conflict-marker scanner (bypasses smudge/textconv machinery entirely), and `refs/heads/<branch>` expansion in `compareWorktrees`.
- `validateBranchName` now runs before the equality fast-path in `compareWorktrees`, so an invalid name is rejected even when the two sides are identical.

Resolves #7046

## Changes

- `electron/utils/hardenedGit.ts` — new `validateBranchName` utility
- `electron/services/GitService.ts` — `createWorktree`, `removeWorktree`, `compareWorktrees`, `getFileDiff` hardened
- `electron/workspace-host/WorkspaceService.ts` — same hardening on the live IPC-reachable surface (`createWorktree`, `deleteWorktree`, `getFileDiff`)
- `electron/ipc/handlers/git-write.ts` — `--no-textconv` on all three diff branches in `handleGetWorkingDiff`; `scanStagedFilesForConflictMarkers` switched to `git cat-file blob --end-of-options`

## Testing

- New unit tests: `validateBranchName` (valid names + every rejection class), `--end-of-options` ordering for `createWorktree` (local, `fromRemote`, `useExistingBranch`) and `removeWorktree` (with/without `--force`), `refs/heads/` range expansion, `--no-textconv` on every diff call site, leading-dash filename in `cat-file` argv, equal-but-invalid name rejection in `compareWorktrees`, `.lock`-component validator gap, `handleGetWorkingDiff` argv shape (previously zero coverage).
- Updated: `WorkspaceService` test mocks wired up to expose `validateBranchName`; argv assertions updated across `createWorktree`, `deleteWorktree`, `getFileDiff`, `lfs`, `pauseResume`, `resource`, `externalRemoval`, and `fetchPRBranch` suites.
- 7410 tests across 385 files pass. Typecheck, lint, and format clean.