### PR TITLE
chore(workspace-host): tighten shutdown and lifecycle hygiene

### DIFF
--- a/electron/workspace-host/FetchScheduler.ts
+++ b/electron/workspace-host/FetchScheduler.ts
@@ -98,15 +98,6 @@ export class FetchScheduler {
     }
   }
 
-  /**
-   * Permanently disable. Any in-flight fetch resolves naturally; its
-   * `.finally` hook checks `disposed` before re-arming, so no leaks.
-   */
-  dispose(): void {
-    this.disposed = true;
-    this.clearTimer();
-  }
-
   private async run(force: boolean): Promise<void> {
     if (this.disposed || !this.host.isRunning) return;
     if (!this.host.hasFetchCallback) return;

--- a/electron/workspace-host/ResourcePollTimer.ts
+++ b/electron/workspace-host/ResourcePollTimer.ts
@@ -67,5 +67,4 @@ export class ResourcePollTimer {
       this.timer = null;
     }
   }
-
 }

--- a/electron/workspace-host/ResourcePollTimer.ts
+++ b/electron/workspace-host/ResourcePollTimer.ts
@@ -68,9 +68,4 @@ export class ResourcePollTimer {
     }
   }
 
-  /** Permanently disable. Late callbacks short-circuit on the disposed flag. */
-  dispose(): void {
-    this.disposed = true;
-    this.clear();
-  }
 }

--- a/electron/workspace-host/WatcherController.ts
+++ b/electron/workspace-host/WatcherController.ts
@@ -324,7 +324,7 @@ export class WatcherController {
         this.gitWatcherMode = "none";
         this.start("recursive");
       }
-    }, WATCHER_RETRY_INTERVAL_MS);
+    }, WATCHER_RETRY_INTERVAL_MS).unref();
   }
 
   private handleGitFileChange(): void {
@@ -355,9 +355,4 @@ export class WatcherController {
     this.flushPendingIfReady();
   }
 
-  /** Permanently disable. Late timers and callbacks short-circuit on disposed. */
-  dispose(): void {
-    this.disposed = true;
-    this.stop(true);
-  }
 }

--- a/electron/workspace-host/WatcherController.ts
+++ b/electron/workspace-host/WatcherController.ts
@@ -354,5 +354,4 @@ export class WatcherController {
 
     this.flushPendingIfReady();
   }
-
 }

--- a/electron/workspace-host/WorkspaceService.ts
+++ b/electron/workspace-host/WorkspaceService.ts
@@ -1923,6 +1923,7 @@ ${lines.map((l) => "+" + l).join("\n")}`;
     // project's monitors get a clean coordinator and stale completions are
     // discarded by the generation guard.
     this.fetchCoordinator.destroy();
+    this.pollQueue.clear();
 
     this.activeWorktreeId = null;
     this.mainBranch = "main";

--- a/electron/workspace-host/WorkspaceService.ts
+++ b/electron/workspace-host/WorkspaceService.ts
@@ -1929,6 +1929,7 @@ ${lines.map((l) => "+" + l).join("\n")}`;
     this.git = null;
     this.projectRootPath = null;
     this.projectEnvVars = {};
+    this.wslDefaultDistroPromise = null;
 
     clearGitDirCache();
     clearGitCommonDirCache();
@@ -2120,6 +2121,8 @@ ${lines.map((l) => "+" + l).join("\n")}`;
       monitor.stop();
     }
     this.monitors.clear();
+    this.fetchCoordinator.destroy();
+    this.pollQueue.clear();
     this.listService.invalidateCache();
   }
 }

--- a/electron/workspace-host/WorktreeMonitor.ts
+++ b/electron/workspace-host/WorktreeMonitor.ts
@@ -749,7 +749,6 @@ export class WorktreeMonitor {
   stop(): void {
     this._isRunning = false;
     this._pollAbortController.abort();
-    this._pollAbortController = new AbortController();
     this.clearTimers();
     this.watcherController.stop();
   }
@@ -996,7 +995,7 @@ export class WorktreeMonitor {
       }
 
       void this.poll();
-    }, delayMs);
+    }, delayMs).unref();
   }
 
   private async forceRefreshAfterGap(): Promise<void> {

--- a/electron/workspace-host/__tests__/FetchScheduler.test.ts
+++ b/electron/workspace-host/__tests__/FetchScheduler.test.ts
@@ -240,26 +240,26 @@ describe("FetchScheduler", () => {
     expect(host.onExecuteFetch).toHaveBeenLastCalledWith(true);
   });
 
-  it("dispose() prevents further fetches even if a timer fires", async () => {
+  it("does not execute fetch when host is not running", async () => {
     const host = makeHost();
     const scheduler = new FetchScheduler(host as FetchSchedulerHost);
 
+    host.isRunning = false;
     scheduler.schedule(true);
-    scheduler.dispose();
     await vi.advanceTimersByTimeAsync(10_000);
 
     expect(host.onExecuteFetch).not.toHaveBeenCalled();
   });
 
-  it("dispose() prevents post-completion rescheduling", async () => {
+  it("does not reschedule after completion when host is not running", async () => {
     const host = makeHost();
     const scheduler = new FetchScheduler(host as FetchSchedulerHost);
 
     const triggered = scheduler.triggerNow();
-    scheduler.dispose();
+    host.isRunning = false;
     await triggered;
 
-    // After completion + dispose, no new timer should be armed.
+    // After completion with isRunning false, no new timer should be armed.
     await vi.advanceTimersByTimeAsync(60_000);
     expect(host.onExecuteFetch).toHaveBeenCalledTimes(1);
   });

--- a/electron/workspace-host/__tests__/ResourcePollTimer.test.ts
+++ b/electron/workspace-host/__tests__/ResourcePollTimer.test.ts
@@ -128,18 +128,18 @@ describe("ResourcePollTimer", () => {
     expect(host.onResourceStatusPoll).toHaveBeenCalledTimes(1);
   });
 
-  it("dispose() prevents further callbacks even if a timer fires", async () => {
+  it("clear() prevents further callbacks even if a timer fires", async () => {
     const host = makeHost({ resourcePollIntervalMs: 5_000 });
     const timer = new ResourcePollTimer(host as ResourcePollTimerHost);
 
     timer.schedule();
-    timer.dispose();
+    timer.clear();
     await vi.advanceTimersByTimeAsync(60_000);
 
     expect(host.onResourceStatusPoll).not.toHaveBeenCalled();
   });
 
-  it("dispose() prevents post-callback rescheduling", async () => {
+  it("clear() prevents post-callback rescheduling", async () => {
     const host = makeHost({ resourcePollIntervalMs: 5_000 });
     const timer = new ResourcePollTimer(host as ResourcePollTimerHost);
 
@@ -147,7 +147,7 @@ describe("ResourcePollTimer", () => {
     await vi.advanceTimersByTimeAsync(5_001);
     expect(host.onResourceStatusPoll).toHaveBeenCalledTimes(1);
 
-    timer.dispose();
+    timer.clear();
     await vi.advanceTimersByTimeAsync(60_000);
     expect(host.onResourceStatusPoll).toHaveBeenCalledTimes(1);
   });

--- a/electron/workspace-host/__tests__/WatcherController.test.ts
+++ b/electron/workspace-host/__tests__/WatcherController.test.ts
@@ -409,25 +409,25 @@ describe("WatcherController", () => {
     expect(ctrl.hasWatcher).toBe(true);
   });
 
-  it("dispose() prevents future start() calls", () => {
+  it("stop(true) clears watcher and retry state", () => {
     mockWatcherStartResult = true;
     const host = makeHost();
     const ctrl = new WatcherController(host as WatcherControllerHost);
 
-    ctrl.dispose();
     ctrl.start();
-    expect(watcherStartCallCount).toBe(0);
+    ctrl.stop(true);
     expect(ctrl.hasWatcher).toBe(false);
+    expect(ctrl.currentMode).toBe("none");
   });
 
-  it("dispose() cancels pending retry timers", () => {
+  it("stop(true) cancels pending retry timers", () => {
     mockRecursiveStartResult = false;
     mockGitOnlyStartResult = true;
     const host = makeHost({ isCurrent: true });
     const ctrl = new WatcherController(host as WatcherControllerHost);
 
     ctrl.start();
-    ctrl.dispose();
+    ctrl.stop(true);
     mockRecursiveStartResult = true;
     vi.advanceTimersByTime(120_000);
     // No retry should have run.


### PR DESCRIPTION
## Summary
This PR fixes up six small lifecycle gaps in the workspace-host's shutdown path. None of them fail in production today -- the `isRunning` getter rescues correctness -- but the shutdown contract is one consistent pass away from clean and they share a single reviewer pass.

- `dispose()` now matches `onProjectSwitch` in teardown thoroughness: it destroys the fetch coordinator and clears the poll queue so no in-flight fetches race against a cleared monitor map.
- Dead `dispose()` methods on `WatcherController`, `FetchScheduler`, and `ResourcePollTimer` are removed. They were never called, and their `disposed` flags were silently inert behind the `host.isRunning` guard.
- A wasted `AbortController` reallocation in `WorktreeMonitor.stop()` is dropped -- `start()` already reallocates on every fresh start.
- The WSL distro cache (`wslDefaultDistroPromise`) is cleared on project switch so a mid-session install/removal of a WSL distro doesn't leave stale `wslGitEligible` flags until restart.
- Long-running timers (the heartbeat poll and the watcher retry timer) are `.unref()`'d so they don't block the event loop on a SIGTERM-with-timeout shutdown.

## Changes
- `WorkspaceService.ts` -- destroy fetch coordinator and clear poll queue in `dispose()`; clear WSL distro cache in `onProjectSwitch`
- `WorktreeMonitor.ts` -- remove dead `AbortController` reallocation in `stop()`; unref heartbeat poll timer
- `WatcherController.ts` -- remove dead `dispose()` method; unref recursive-arm retry timer
- `FetchScheduler.ts` -- remove dead `dispose()` method
- `ResourcePollTimer.ts` -- remove dead `dispose()` method
- Updated corresponding test files for the removed methods

## Testing
Typecheck, lint, and prettier all pass. Unit tests updated to reflect the removed sub-controller `dispose()` methods.