### PR TITLE
fix(workspace-host): polish ResourcePollTimer and ResourceActionExecutor

### DIFF
--- a/electron/workspace-host/ResourceActionExecutor.ts
+++ b/electron/workspace-host/ResourceActionExecutor.ts
@@ -7,6 +7,19 @@ import { WorktreeLifecycleService } from "./WorktreeLifecycleService.js";
 import { applyResourceConfigToMonitor } from "./resourceConfigHelpers.js";
 import { formatErrorMessage } from "../../shared/utils/errorMessage.js";
 
+const READY_STATUSES = new Set(["ready", "running", "healthy", "up"]);
+const RESUMABLE_STATUSES = new Set(["paused", "stopped"]);
+// "stopped" kept only to gracefully handle a transient read from a CLI
+// that hasn't switched to "paused" yet; the schema/UI no longer emit it.
+
+const DEFAULT_TIMEOUT_MS = {
+  provision: 300_000,
+  teardown: 300_000,
+  resume: 120_000,
+  pause: 120_000,
+  status: 120_000,
+} as const;
+
 /**
  * Narrow context interface that the executor needs from the owning
  * `WorkspaceService`. Mutable workspace state (e.g. `projectRootPath`) is
@@ -120,12 +133,7 @@ export class ResourceActionExecutor {
     let effectiveAction = action;
     if (action === "provision") {
       const currentStatus = monitor.resourceStatus?.lastStatus?.toLowerCase();
-      if (
-        currentStatus === "ready" ||
-        currentStatus === "running" ||
-        currentStatus === "healthy" ||
-        currentStatus === "up"
-      ) {
+      if (currentStatus && READY_STATUSES.has(currentStatus)) {
         console.log(
           `[WorktreeLifecycle] Provision no-op for worktree ${worktreeId}: already ${currentStatus}`
         );
@@ -137,9 +145,7 @@ export class ResourceActionExecutor {
         });
         return { success: true, output: `Resource is already ${currentStatus}` };
       }
-      if (currentStatus === "paused" || currentStatus === "stopped") {
-        // "stopped" kept here only to gracefully handle a transient read from a CLI
-        // that hasn't switched to "paused" yet; the schema/UI no longer emit it.
+      if (currentStatus && RESUMABLE_STATUSES.has(currentStatus)) {
         console.log(
           `[WorktreeLifecycle] Provision routing to resume for worktree ${worktreeId}: currently ${currentStatus}`
         );
@@ -274,19 +280,12 @@ export class ResourceActionExecutor {
     }
 
     const phase = `resource-${effectiveAction}` as const;
-    const DEFAULT_TIMEOUT: Record<string, number> = {
-      provision: 300_000,
-      teardown: 300_000,
-      resume: 120_000,
-      pause: 120_000,
-      status: 120_000,
-    };
     const configTimeoutSec =
       resourceConfig.timeouts?.[effectiveAction as keyof typeof resourceConfig.timeouts];
     const timeoutMs =
       configTimeoutSec != null
         ? configTimeoutSec * 1000
-        : (DEFAULT_TIMEOUT[effectiveAction] ?? 120_000);
+        : (DEFAULT_TIMEOUT_MS[effectiveAction] ?? 120_000);
 
     monitor.setLifecycleStatus({
       phase,

--- a/electron/workspace-host/ResourceActionExecutor.ts
+++ b/electron/workspace-host/ResourceActionExecutor.ts
@@ -132,7 +132,7 @@ export class ResourceActionExecutor {
     // Idempotent provision: route to resume when paused, no-op when already running.
     let effectiveAction = action;
     if (action === "provision") {
-      const currentStatus = monitor.resourceStatus?.lastStatus?.toLowerCase();
+      const currentStatus = monitor.resourceStatus?.lastStatus?.toLowerCase().trim();
       if (currentStatus && READY_STATUSES.has(currentStatus)) {
         console.log(
           `[WorktreeLifecycle] Provision no-op for worktree ${worktreeId}: already ${currentStatus}`

--- a/electron/workspace-host/ResourcePollTimer.ts
+++ b/electron/workspace-host/ResourcePollTimer.ts
@@ -6,6 +6,8 @@
  * tiers via the host interface.
  */
 
+import { formatErrorMessage } from "../../shared/utils/errorMessage.js";
+
 export interface ResourcePollTimerHost {
   readonly isRunning: boolean;
   readonly hasResourceConfig: boolean;
@@ -18,6 +20,13 @@ export interface ResourcePollTimerHost {
    * — provider-specific failure recovery is the callback's responsibility.
    */
   onResourceStatusPoll(worktreeId: string): Promise<unknown> | void;
+}
+
+const RESOURCE_POLL_JITTER_FACTOR = 0.1;
+
+function randomBetween(minMs: number, maxMs: number): number {
+  if (maxMs <= minMs) return minMs;
+  return minMs + Math.floor(Math.random() * (maxMs - minMs));
 }
 
 export class ResourcePollTimer {
@@ -36,6 +45,9 @@ export class ResourcePollTimer {
     if (this.host.resourcePollIntervalMs <= 0) return;
     if (!this.host.hasResourceConfig || !this.host.hasStatusCommand) return;
 
+    const baseInterval = this.host.resourcePollIntervalMs;
+    const delay =
+      baseInterval + randomBetween(0, Math.floor(baseInterval * RESOURCE_POLL_JITTER_FACTOR));
     this.timer = setTimeout(async () => {
       this.timer = null;
       if (this.disposed) return;
@@ -51,13 +63,16 @@ export class ResourcePollTimer {
       }
       try {
         await this.host.onResourceStatusPoll(this.host.worktreeId);
-      } catch {
-        // Poll callback failure — swallowed intentionally; provider state
-        // recovery is the callback's responsibility.
+      } catch (err) {
+        console.warn(
+          `[ResourcePollTimer] Poll callback failed for ${this.host.worktreeId}:`,
+          formatErrorMessage(err, "Resource status poll failed")
+        );
       }
       if (this.disposed || !this.host.isRunning) return;
       this.schedule();
-    }, this.host.resourcePollIntervalMs);
+    }, delay);
+    this.timer.unref();
   }
 
   /** Cancel any armed timer without disposing — used by focus flips and pause. */

--- a/electron/workspace-host/WorktreeMonitor.ts
+++ b/electron/workspace-host/WorktreeMonitor.ts
@@ -432,9 +432,7 @@ export class WorktreeMonitor {
       // collided with explicit user values that happened to match a default
       // (e.g. `statusInterval: 300` matching the new 300s background default).
       if (!this.resourcePollIntervalExplicit) {
-        this.resourcePollIntervalMs = value
-          ? RESOURCE_POLL_DEFAULT_ACTIVE_MS
-          : RESOURCE_POLL_DEFAULT_BACKGROUND_MS;
+        this.applyDefaultResourcePollInterval();
         this.clearResourcePollTimer();
         this.scheduleResourcePoll();
       }
@@ -571,9 +569,7 @@ export class WorktreeMonitor {
     this._hasResourceConfig = has;
     if (has && this._hasStatusCommand && this._isRunning) {
       if (this.resourcePollIntervalMs === 0) {
-        this.resourcePollIntervalMs = this._isCurrent
-          ? RESOURCE_POLL_DEFAULT_ACTIVE_MS
-          : RESOURCE_POLL_DEFAULT_BACKGROUND_MS;
+        this.applyDefaultResourcePollInterval();
       }
       this.scheduleResourcePoll();
     } else if (!has) {
@@ -622,9 +618,7 @@ export class WorktreeMonitor {
     if (has && this._hasResourceConfig && this._isRunning) {
       // If no explicit interval was set, apply default based on isCurrent
       if (this.resourcePollIntervalMs === 0) {
-        this.resourcePollIntervalMs = this._isCurrent
-          ? RESOURCE_POLL_DEFAULT_ACTIVE_MS
-          : RESOURCE_POLL_DEFAULT_BACKGROUND_MS;
+        this.applyDefaultResourcePollInterval();
       }
       this.scheduleResourcePoll();
     } else if (!has) {
@@ -642,6 +636,14 @@ export class WorktreeMonitor {
     this.clearResourcePollTimer();
     if (ms > 0 && this._hasResourceConfig && this._isRunning) {
       this.scheduleResourcePoll();
+    }
+  }
+
+  private applyDefaultResourcePollInterval(): void {
+    if (this.resourcePollIntervalMs === 0) {
+      this.resourcePollIntervalMs = this._isCurrent
+        ? RESOURCE_POLL_DEFAULT_ACTIVE_MS
+        : RESOURCE_POLL_DEFAULT_BACKGROUND_MS;
     }
   }
 

--- a/electron/workspace-host/WorktreeMonitor.ts
+++ b/electron/workspace-host/WorktreeMonitor.ts
@@ -432,7 +432,9 @@ export class WorktreeMonitor {
       // collided with explicit user values that happened to match a default
       // (e.g. `statusInterval: 300` matching the new 300s background default).
       if (!this.resourcePollIntervalExplicit) {
-        this.applyDefaultResourcePollInterval();
+        this.resourcePollIntervalMs = value
+          ? RESOURCE_POLL_DEFAULT_ACTIVE_MS
+          : RESOURCE_POLL_DEFAULT_BACKGROUND_MS;
         this.clearResourcePollTimer();
         this.scheduleResourcePoll();
       }
@@ -632,7 +634,7 @@ export class WorktreeMonitor {
    */
   setResourcePollInterval(ms: number): void {
     this.resourcePollIntervalMs = ms;
-    this.resourcePollIntervalExplicit = ms > 0;
+    this.resourcePollIntervalExplicit = true;
     this.clearResourcePollTimer();
     if (ms > 0 && this._hasResourceConfig && this._isRunning) {
       this.scheduleResourcePoll();

--- a/electron/workspace-host/__tests__/ResourcePollTimer.test.ts
+++ b/electron/workspace-host/__tests__/ResourcePollTimer.test.ts
@@ -25,10 +25,12 @@ function makeHost(overrides: Partial<MutableHost> = {}): MutableHost {
 describe("ResourcePollTimer", () => {
   beforeEach(() => {
     vi.useFakeTimers();
+    vi.spyOn(Math, "random").mockReturnValue(0);
   });
 
   afterEach(() => {
     vi.useRealTimers();
+    vi.restoreAllMocks();
   });
 
   it("schedules at the configured interval", async () => {
@@ -153,6 +155,7 @@ describe("ResourcePollTimer", () => {
   });
 
   it("swallows callback exceptions and continues rescheduling", async () => {
+    const warnSpy = vi.spyOn(console, "warn").mockImplementation(() => {});
     let callCount = 0;
     const host = makeHost({
       resourcePollIntervalMs: 5_000,
@@ -167,6 +170,7 @@ describe("ResourcePollTimer", () => {
     timer.schedule();
     await vi.advanceTimersByTimeAsync(5_001);
     expect(host.onResourceStatusPoll).toHaveBeenCalledTimes(1);
+    expect(warnSpy).toHaveBeenCalledTimes(1);
 
     // After error, next round should still run.
     await vi.advanceTimersByTimeAsync(5_001);

--- a/electron/workspace-host/__tests__/WorktreeMonitor.test.ts
+++ b/electron/workspace-host/__tests__/WorktreeMonitor.test.ts
@@ -173,6 +173,7 @@ function makeCallbacks(overrides?: Partial<WorktreeMonitorCallbacks>): WorktreeM
 describe("WorktreeMonitor", () => {
   beforeEach(() => {
     vi.useFakeTimers();
+    vi.spyOn(Math, "random").mockReturnValue(0);
     vi.clearAllMocks();
     mockCategorizeWorktree.mockReturnValue("stable");
     mockWatcherStartResult = false;
@@ -191,6 +192,7 @@ describe("WorktreeMonitor", () => {
 
   afterEach(() => {
     vi.useRealTimers();
+    vi.restoreAllMocks();
   });
 
   it("calls onRemoved and stops polling when WorktreeRemovedError is thrown", async () => {


### PR DESCRIPTION
## Summary
A pre-release polish pass on the workspace-host resource polling loop. Six small items across three files, plus review follow-ups. No new behavior -- just bringing these patterns in line with conventions already established elsewhere in the codebase.

- Adds proportional jitter (`RESOURCE_POLL_JITTER_FACTOR = 0.1`) to each `ResourcePollTimer` fire so polling across worktrees doesn't land in lockstep. Same pattern `FetchScheduler` already uses.
- Replaces the bare `catch {}` with a Tier 0 `console.warn` via `formatErrorMessage`, matching the precedent set by the FD-leak warning.
- Hoists `DEFAULT_TIMEOUT_MS` to module level as an `as const` map so it isn't rebuilt on every `execute()` call.
- Calls `.unref()` on the poll timer. The workspace-host's loop pins are `parentPort` and signal handlers -- a 5-minute background timer should not block exit.
- Switches four chained `===` checks to `Set` lookups (`READY_STATUSES`, `RESUMABLE_STATUSES`).
- Extracts the duplicated default-interval block into a private `applyDefaultResourcePollInterval()` helper.

Resolves #7036

## Changes
- `electron/workspace-host/ResourcePollTimer.ts` -- jitter, `.unref()`, Tier 0 warn
- `electron/workspace-host/ResourceActionExecutor.ts` -- hoisted timeout const, Set-based lookups
- `electron/workspace-host/WorktreeMonitor.ts` -- extracted private helper, explicit disable guard, reverted isCurrent retiering regression
- `__tests__/ResourcePollTimer.test.ts` -- `Math.random` mock, warn spy assertion
- `__tests__/WorktreeMonitor.test.ts` -- `Math.random` mock

## Testing
Existing test suite passes. `Math.random` stubbed to `mockReturnValue(0)` so jitter collapses to zero and existing timer-advance assertions hold their invariants.