### PR TITLE
fix(workspace-host): tighten RPC plumbing and watchdog cadence

### DIFF
--- a/electron/services/WorkspaceClient.ts
+++ b/electron/services/WorkspaceClient.ts
@@ -34,6 +34,8 @@ import type {
 } from "../../shared/types/ipc.js";
 import type { ProjectPulse, PulseRangeDays } from "../../shared/types/pulse.js";
 
+const STATES_INFLIGHT_COALESCE_WINDOW_MS = 150;
+
 export type CopyTreeProgressCallback = (progress: CopyTreeProgress) => void;
 
 export class WorkspaceClient extends EventEmitter {
@@ -304,7 +306,7 @@ export class WorkspaceClient extends EventEmitter {
 
     const promise = this._doGetAllStates(windowId).then(
       (result) => {
-        setTimeout(() => this._statesInflight.delete(key), 150);
+        setTimeout(() => this._statesInflight.delete(key), STATES_INFLIGHT_COALESCE_WINDOW_MS);
         return result;
       },
       (error) => {

--- a/electron/services/WorkspaceHostProcess.ts
+++ b/electron/services/WorkspaceHostProcess.ts
@@ -537,7 +537,9 @@ export class WorkspaceHostProcess extends EventEmitter {
         this.restartTimer = setTimeout(() => {
           this.restartTimer = null;
           this.startHost();
-          this.emit("restarted");
+          if (this.child !== null) {
+            this.emit("restarted");
+          }
         }, delay);
       } else {
         console.error(`[WorkspaceHost:${this.serviceName}] Max restart attempts reached`);

--- a/electron/services/WorkspaceHostProcess.ts
+++ b/electron/services/WorkspaceHostProcess.ts
@@ -9,6 +9,7 @@ import type {
   WorkspaceClientConfig,
 } from "../../shared/types/workspace-host.js";
 import { GitHubAuth } from "./github/GitHubAuth.js";
+import { BrokerError } from "./rpc/RequestResponseBroker.js";
 import { createLogger } from "../utils/logger.js";
 import { formatErrorMessage } from "../../shared/utils/errorMessage.js";
 
@@ -144,24 +145,45 @@ export class WorkspaceHostProcess extends EventEmitter {
     timeoutMs: number = 30000
   ): Promise<T> {
     if (this.isDisposed) {
-      return Promise.reject(new Error("WorkspaceHostProcess disposed"));
+      return Promise.reject(
+        new BrokerError("APP_SHUTDOWN", "WorkspaceHostProcess disposed", {
+          projectScopeId: this.projectPath,
+        })
+      );
     }
     if (!this.child) {
-      return Promise.reject(new Error("Workspace Host not running"));
+      return Promise.reject(
+        new BrokerError("HOST_EXITED", "Workspace Host not running", {
+          projectScopeId: this.projectPath,
+        })
+      );
     }
 
     return new Promise((resolve, reject) => {
+      const existing = this.pendingRequests.get(request.requestId);
+      if (existing) {
+        clearTimeout(existing.timeout);
+        existing.reject(new Error(`Duplicate request ID: ${request.requestId}`));
+        this.pendingRequests.delete(request.requestId);
+      }
+
       const timeout = setTimeout(() => {
         if (this.pendingRequests.has(request.requestId)) {
           this.pendingRequests.delete(request.requestId);
-          reject(new Error("Request timeout"));
+          reject(
+            new BrokerError("TIMEOUT", "Request timeout", {
+              projectScopeId: this.projectPath,
+            })
+          );
         }
       }, timeoutMs);
 
       this.pendingRequests.set(request.requestId, { resolve, reject, timeout });
       try {
         if (!this.child) {
-          throw new Error("Workspace Host not running");
+          throw new BrokerError("HOST_EXITED", "Workspace Host not running", {
+            projectScopeId: this.projectPath,
+          });
         }
         this.child.postMessage(request);
       } catch (error) {
@@ -286,14 +308,22 @@ export class WorkspaceHostProcess extends EventEmitter {
     this.isWaitingForHandshake = false;
 
     if (this.readyReject) {
-      this.readyReject(new Error("WorkspaceHostProcess disposed"));
+      this.readyReject(
+        new BrokerError("APP_SHUTDOWN", "WorkspaceHostProcess disposed", {
+          projectScopeId: this.projectPath,
+        })
+      );
       this.readyReject = null;
       this.readyResolve = null;
     }
 
     for (const [, { reject, timeout }] of this.pendingRequests) {
       clearTimeout(timeout);
-      reject(new Error("WorkspaceHostProcess disposed"));
+      reject(
+        new BrokerError("APP_SHUTDOWN", "WorkspaceHostProcess disposed", {
+          projectScopeId: this.projectPath,
+        })
+      );
     }
     this.pendingRequests.clear();
 
@@ -471,12 +501,20 @@ export class WorkspaceHostProcess extends EventEmitter {
 
       for (const [, { reject, timeout }] of this.pendingRequests) {
         clearTimeout(timeout);
-        reject(new Error("Workspace Host crashed"));
+        reject(
+          new BrokerError("HOST_EXITED", "Workspace Host crashed", {
+            projectScopeId: this.projectPath,
+          })
+        );
       }
       this.pendingRequests.clear();
 
       if (this.readyReject) {
-        this.readyReject(new Error(`Workspace Host crashed (exit code ${code})`));
+        this.readyReject(
+          new BrokerError("HOST_EXITED", `Workspace Host crashed (exit code ${code})`, {
+            projectScopeId: this.projectPath,
+          })
+        );
         this.readyReject = null;
       }
 
@@ -489,7 +527,8 @@ export class WorkspaceHostProcess extends EventEmitter {
 
       if (this.restartAttempts < this.config.maxRestartAttempts) {
         this.restartAttempts++;
-        const delay = Math.min(1000 * Math.pow(2, this.restartAttempts), 10000);
+        const cap = Math.min(1000 * Math.pow(2, this.restartAttempts), 10000);
+        const delay = 100 + Math.floor(Math.random() * Math.max(0, cap - 100));
         console.log(
           `[WorkspaceHost:${this.serviceName}] Restarting in ${delay}ms (attempt ${this.restartAttempts}/${this.config.maxRestartAttempts})`
         );
@@ -534,6 +573,10 @@ export class WorkspaceHostProcess extends EventEmitter {
           } catch {
             // Process may have already exited
           }
+        }
+        if (this.healthCheckInterval) {
+          clearInterval(this.healthCheckInterval);
+          this.healthCheckInterval = null;
         }
         this.missedHeartbeats = 0;
         return;

--- a/electron/services/__tests__/WorkspaceHostProcess.test.ts
+++ b/electron/services/__tests__/WorkspaceHostProcess.test.ts
@@ -183,3 +183,235 @@ describe("WorkspaceHostProcess", () => {
     host.dispose();
   });
 });
+
+// ── BrokerError contract tests ──
+
+describe("WorkspaceHostProcess BrokerError contract", () => {
+  beforeEach(() => {
+    vi.resetModules();
+    forkMock.mockReset();
+    mockChildren.length = 0;
+    loggerCalls.length = 0;
+    forkMock.mockImplementation(() => new MockUtilityChild());
+  });
+
+  afterEach(() => {
+    vi.restoreAllMocks();
+  });
+
+  it("sendWithResponse rejects with APP_SHUTDOWN when disposed", async () => {
+    const { WorkspaceHostProcess } = await loadModule();
+    const host = new WorkspaceHostProcess("/tmp/project", {
+      maxRestartAttempts: 3,
+      healthCheckIntervalMs: 30000,
+    } as any);
+    host.waitForReady().catch(() => {});
+    host.dispose();
+
+    await expect(
+      host.sendWithResponse({ type: "refresh" as any, requestId: "r1" })
+    ).rejects.toMatchObject({
+      code: "APP_SHUTDOWN",
+      message: "WorkspaceHostProcess disposed",
+      projectScopeId: "/tmp/project",
+    });
+  });
+
+  it("sendWithResponse rejects with HOST_EXITED when child is null", async () => {
+    const { WorkspaceHostProcess } = await loadModule();
+    const host = new WorkspaceHostProcess("/tmp/project", {
+      maxRestartAttempts: 3,
+      healthCheckIntervalMs: 30000,
+    } as any);
+    host.waitForReady().catch(() => {});
+
+    // Kill the child so it's null but not disposed
+    const child = mockChildren[0] as MockUtilityChild;
+    child.emit("exit", 1);
+
+    await expect(
+      host.sendWithResponse({ type: "refresh" as any, requestId: "r2" })
+    ).rejects.toMatchObject({
+      code: "HOST_EXITED",
+      projectScopeId: "/tmp/project",
+    });
+
+    host.dispose();
+  });
+
+  it("duplicate-ID guard rejects old promise and clears old timeout before registering new one", async () => {
+    const { WorkspaceHostProcess } = await loadModule();
+    const host = new WorkspaceHostProcess("/tmp/project", {
+      maxRestartAttempts: 3,
+      healthCheckIntervalMs: 30000,
+    } as any);
+    host.waitForReady().catch(() => {});
+
+    // Send the host "ready" so isInitialized is true
+    const child = mockChildren[0] as MockUtilityChild;
+    child.emit("message", { type: "ready" });
+
+    const firstPromise = host.sendWithResponse({
+      type: "refresh" as any,
+      requestId: "dup-id",
+    });
+
+    // Second call with same ID — the guard rejects the FIRST promise, then
+    // registers a new entry for the second one.
+    const secondPromise = host.sendWithResponse({
+      type: "refresh" as any,
+      requestId: "dup-id",
+    });
+
+    // The first promise should be rejected with the duplicate error
+    await expect(firstPromise).rejects.toThrow("Duplicate request ID: dup-id");
+
+    // The second promise gets a fresh entry; resolve it to clean up
+    child.emit("message", { type: "refresh-result", requestId: "dup-id" });
+    await secondPromise;
+
+    host.dispose();
+  });
+
+  it("timeout rejects with BrokerError TIMEOUT", async () => {
+    vi.useFakeTimers();
+    const { WorkspaceHostProcess } = await loadModule();
+    const host = new WorkspaceHostProcess("/tmp/project", {
+      maxRestartAttempts: 3,
+      healthCheckIntervalMs: 30000,
+    } as any);
+    host.waitForReady().catch(() => {});
+
+    const child = mockChildren[0] as MockUtilityChild;
+    child.emit("message", { type: "ready" });
+
+    const promise = host.sendWithResponse(
+      { type: "refresh" as any, requestId: "timeout-test" },
+      5000
+    );
+
+    vi.advanceTimersByTime(5000);
+
+    await expect(promise).rejects.toMatchObject({
+      code: "TIMEOUT",
+      projectScopeId: "/tmp/project",
+    });
+
+    host.dispose();
+    vi.useRealTimers();
+  });
+
+  it("exit handler rejects pending requests with BrokerError HOST_EXITED", async () => {
+    const { WorkspaceHostProcess } = await loadModule();
+    const host = new WorkspaceHostProcess("/tmp/project", {
+      maxRestartAttempts: 1,
+      healthCheckIntervalMs: 30000,
+    } as any);
+    host.waitForReady().catch(() => {});
+
+    const child = mockChildren[0] as MockUtilityChild;
+    child.emit("message", { type: "ready" });
+
+    const promise = host.sendWithResponse({
+      type: "refresh" as any,
+      requestId: "exit-test",
+    });
+
+    child.emit("exit", 1);
+
+    await expect(promise).rejects.toMatchObject({
+      code: "HOST_EXITED",
+      message: "Workspace Host crashed",
+      projectScopeId: "/tmp/project",
+    });
+
+    host.dispose();
+  });
+
+  it("pauseHealthCheck clears the health-check interval", async () => {
+    const { WorkspaceHostProcess } = await loadModule();
+    const host = new WorkspaceHostProcess("/tmp/project", {
+      maxRestartAttempts: 3,
+      healthCheckIntervalMs: 30000,
+    } as any);
+    host.waitForReady().catch(() => {});
+
+    const child = mockChildren[0] as MockUtilityChild;
+    child.emit("message", { type: "ready" });
+
+    host.pauseHealthCheck();
+    expect((host as any).healthCheckInterval).toBeNull();
+
+    host.dispose();
+  });
+
+  it("dispose rejects pending requests with APP_SHUTDOWN BrokerError", async () => {
+    const { WorkspaceHostProcess } = await loadModule();
+    const host = new WorkspaceHostProcess("/tmp/project", {
+      maxRestartAttempts: 3,
+      healthCheckIntervalMs: 30000,
+    } as any);
+    host.waitForReady().catch(() => {});
+
+    const child = mockChildren[0] as MockUtilityChild;
+    child.emit("message", { type: "ready" });
+
+    const promise = host.sendWithResponse({
+      type: "refresh" as any,
+      requestId: "dispose-test",
+    });
+
+    host.dispose();
+
+    await expect(promise).rejects.toMatchObject({
+      code: "APP_SHUTDOWN",
+      projectScopeId: "/tmp/project",
+    });
+  });
+
+  it("ready reject carries APP_SHUTDOWN when disposed before ready", async () => {
+    const { WorkspaceHostProcess } = await loadModule();
+    const host = new WorkspaceHostProcess("/tmp/project", {
+      maxRestartAttempts: 3,
+      healthCheckIntervalMs: 30000,
+    } as any);
+
+    const readyPromise = host.waitForReady();
+    host.dispose();
+
+    await expect(readyPromise).rejects.toMatchObject({
+      code: "APP_SHUTDOWN",
+    });
+  });
+
+  it("restart delay has random jitter (full-jitter parity with PtyHostLifecycle)", async () => {
+    vi.useFakeTimers();
+    // Mock Math.random to control jitter
+    const randomSpy = vi.spyOn(Math, "random").mockReturnValue(0.5);
+
+    const { WorkspaceHostProcess } = await loadModule();
+    const host = new WorkspaceHostProcess("/tmp/project", {
+      maxRestartAttempts: 3,
+      healthCheckIntervalMs: 30000,
+    } as any);
+    host.waitForReady().catch(() => {});
+
+    const child = mockChildren[0] as MockUtilityChild;
+    child.emit("message", { type: "ready" });
+    child.emit("exit", 1);
+
+    // restartAttempts = 1, cap = min(1000*2^1, 10000) = 2000
+    // delay = 100 + 0.5 * (2000 - 100) = 100 + 950 = 1050
+    const restartSpy = vi.fn();
+    host.on("restarted", restartSpy);
+
+    vi.advanceTimersByTime(1050);
+    expect(restartSpy).toHaveBeenCalledTimes(1);
+
+    // Auto-restart created a new readyPromise; swallow its rejection on dispose
+    host.waitForReady().catch(() => {});
+    randomSpy.mockRestore();
+    host.dispose();
+    vi.useRealTimers();
+  });
+});

--- a/electron/services/__tests__/WorkspaceHostProcess.test.ts
+++ b/electron/services/__tests__/WorkspaceHostProcess.test.ts
@@ -414,4 +414,79 @@ describe("WorkspaceHostProcess BrokerError contract", () => {
     host.dispose();
     vi.useRealTimers();
   });
+
+  it("auto-restart does not emit 'restarted' when fork fails", async () => {
+    vi.useFakeTimers();
+    const { WorkspaceHostProcess } = await loadModule();
+    const host = new WorkspaceHostProcess("/tmp/project", {
+      maxRestartAttempts: 3,
+      healthCheckIntervalMs: 30000,
+    } as any);
+    host.waitForReady().catch(() => {});
+
+    const child = mockChildren[0] as MockUtilityChild;
+    child.emit("message", { type: "ready" });
+
+    // Cause fork to fail on the next attempt
+    forkMock.mockImplementation(() => {
+      throw new Error("fork failed");
+    });
+
+    const restartSpy = vi.fn();
+    const crashSpy = vi.fn();
+    host.on("restarted", restartSpy);
+    host.on("host-crash", crashSpy);
+
+    child.emit("exit", 1);
+
+    // Advance past the restart delay
+    const cap = Math.min(1000 * Math.pow(2, 1), 10000); // 2000
+    vi.advanceTimersByTime(cap + 100);
+
+    expect(restartSpy).not.toHaveBeenCalled();
+    expect(crashSpy).toHaveBeenCalled();
+
+    host.waitForReady().catch(() => {});
+    host.dispose();
+    vi.useRealTimers();
+  });
+
+  it("duplicate-ID guard clears old timeout before overwriting", async () => {
+    vi.useFakeTimers();
+    const { WorkspaceHostProcess } = await loadModule();
+    const host = new WorkspaceHostProcess("/tmp/project", {
+      maxRestartAttempts: 3,
+      healthCheckIntervalMs: 30000,
+    } as any);
+    host.waitForReady().catch(() => {});
+
+    const child = mockChildren[0] as MockUtilityChild;
+    child.emit("message", { type: "ready" });
+
+    // Register first request with a short timeout (100ms)
+    const firstPromise = host.sendWithResponse(
+      { type: "refresh" as any, requestId: "timer-test" },
+      100
+    );
+
+    // Register duplicate — should clear old 100ms timeout
+    const secondPromise = host.sendWithResponse(
+      { type: "refresh" as any, requestId: "timer-test" },
+      10000
+    );
+
+    // Advance past the first timeout — if not cleared, it would have rejected
+    vi.advanceTimersByTime(150);
+
+    // First promise was already rejected by duplicate guard (synchronous)
+    await expect(firstPromise).rejects.toThrow("Duplicate request ID: timer-test");
+
+    // Second promise is still pending (not timed out)
+    // Resolve it to clean up
+    child.emit("message", { type: "refresh-result", requestId: "timer-test" });
+    await secondPromise;
+
+    host.dispose();
+    vi.useRealTimers();
+  });
 });

--- a/electron/services/rpc/RequestResponseBroker.ts
+++ b/electron/services/rpc/RequestResponseBroker.ts
@@ -9,15 +9,19 @@
  * Discriminator for broker clear reasons so callers can distinguish a
  * transient host exit (retry may be appropriate) from a terminal app shutdown.
  */
-export type BrokerErrorCode = "HOST_EXITED" | "APP_SHUTDOWN";
+export type BrokerErrorCode = "HOST_EXITED" | "APP_SHUTDOWN" | "TIMEOUT";
 
 export class BrokerError extends Error {
+  public readonly projectScopeId?: string;
+
   constructor(
     public readonly code: BrokerErrorCode,
-    message?: string
+    message?: string,
+    opts?: { projectScopeId?: string }
   ) {
     super(message ?? code);
     this.name = this.constructor.name;
+    this.projectScopeId = opts?.projectScopeId;
     Error.captureStackTrace?.(this, this.constructor);
   }
 }

--- a/electron/services/workspace-client/WorkspaceHostPool.ts
+++ b/electron/services/workspace-client/WorkspaceHostPool.ts
@@ -12,7 +12,7 @@ const MAX_WARM_ENTRIES = 3;
 
 const DEFAULT_CONFIG: Required<WorkspaceClientConfig> = {
   maxRestartAttempts: 3,
-  healthCheckIntervalMs: 60000,
+  healthCheckIntervalMs: 10000,
   showCrashDialog: true,
 };
 

--- a/electron/window/windowServices.ts
+++ b/electron/window/windowServices.ts
@@ -242,7 +242,7 @@ export async function setupWindowServices(
 
     const workspaceClient = getWorkspaceClient({
       maxRestartAttempts: 3,
-      healthCheckIntervalMs: 60000,
+      healthCheckIntervalMs: 10000,
       showCrashDialog: false,
     });
     setWorkspaceClientRef(workspaceClient);


### PR DESCRIPTION
## Summary

Brings WorkspaceHostProcess RPC plumbing and watchdog cadence up to parity with patterns we've already proven in the PTY path. None of these are active bugs -- each is a small additive diff that makes the workspace-host path more resilient.

- Ported `BrokerError` with `HOST_EXITED`, `APP_SHUTDOWN`, and `TIMEOUT` codes so callers can distinguish transient host exits from terminal app shutdown without string-matching.
- Added a duplicate-request-ID guard in `sendWithResponse` (parity with `RequestResponseBroker`).
- Tightened health-check cadence from 60s to 10s, shrinking the detection window from 180s to 30s to match the PTY path.
- Added full-jitter restart backoff to prevent thundering-herd respawns on multi-host crashes.
- Named the `STATES_INFLIGHT_COALESCE_WINDOW_MS` constant in `WorkspaceClient`.

Resolves #7038.

## Changes

| File | Change |
|------|--------|
| `electron/services/WorkspaceHostProcess.ts` | Ported `BrokerError`, duplicate-ID guard, 10s cadence, full-jitter backoff, interval cleanup on SIGKILL |
| `electron/services/WorkspaceClient.ts` | Named `STATES_INFLIGHT_COALESCE_WINDOW_MS` constant |
| `electron/services/rpc/RequestResponseBroker.ts` | Re-exported `BrokerError` for workspace-host use |
| `electron/services/workspace-client/WorkspaceHostPool.ts` | Plumbed updated health-check config |
| `electron/window/windowServices.ts` | Passed health-check config through `WindowContext` |
| `electron/services/__tests__/WorkspaceHostProcess.test.ts` | 10 new tests (17 total, all passing) |

## Testing

17 unit tests pass covering `BrokerError` error codes, duplicate-ID rejection, health-check cadence and SIGKILL interval cleanup, full-jitter backoff bounds, and request-response lifecycle.