### PR TITLE
perf(git): reduce lock contention and deduplicate work in worktree status poll (#7041)

### DIFF
--- a/electron/utils/__tests__/git.test.ts
+++ b/electron/utils/__tests__/git.test.ts
@@ -165,11 +165,11 @@ describe("getWorktreeChangesWithStats --no-ext-diff", () => {
     (fs.stat as ReturnType<typeof vi.fn>).mockResolvedValue({ mtimeMs: 1000, size: 512 });
   });
 
-  it("passes --no-ext-diff in numstat diff call", async () => {
+  it("passes --no-ext-diff, --no-renames, and --numstat in diff call", async () => {
     await getWorktreeChangesWithStats("/test/path", true);
 
     expect(mockGit.diff).toHaveBeenCalledWith(
-      expect.arrayContaining(["--no-ext-diff", "--numstat"])
+      expect.arrayContaining(["--no-ext-diff", "--no-renames", "--numstat"])
     );
   });
 });
@@ -493,11 +493,11 @@ describe("getWorktreeChangesWithStats per-file diff cache", () => {
   };
 
   function setupRevparse(cwd: string, headOid: string) {
-    mockGit.revparse.mockImplementation((args: string[]) => {
-      if (Array.isArray(args) && args[0] === "HEAD") {
-        return Promise.resolve(`${headOid}\n`) as ReturnType<typeof mockGit.revparse>;
+    mockGit.raw.mockImplementation((args: string[]) => {
+      if (Array.isArray(args) && args[0] === "rev-parse") {
+        return Promise.resolve(`${headOid}\n${cwd}`);
       }
-      return Promise.resolve(`${cwd}\n`) as ReturnType<typeof mockGit.revparse>;
+      return Promise.resolve("");
     });
   }
 
@@ -523,6 +523,7 @@ describe("getWorktreeChangesWithStats per-file diff cache", () => {
     expect(mockGit.diff).toHaveBeenCalledTimes(1);
     expect(mockGit.diff).toHaveBeenCalledWith([
       "--no-ext-diff",
+      "--no-renames",
       "--numstat",
       "HEAD",
       "--",
@@ -580,6 +581,7 @@ describe("getWorktreeChangesWithStats per-file diff cache", () => {
     expect(mockGit.diff).toHaveBeenCalledTimes(1);
     expect(mockGit.diff).toHaveBeenCalledWith([
       "--no-ext-diff",
+      "--no-renames",
       "--numstat",
       "HEAD",
       "--",
@@ -612,6 +614,7 @@ describe("getWorktreeChangesWithStats per-file diff cache", () => {
     expect(mockGit.diff).toHaveBeenCalledTimes(1);
     expect(mockGit.diff).toHaveBeenCalledWith([
       "--no-ext-diff",
+      "--no-renames",
       "--numstat",
       "HEAD",
       "--",
@@ -641,6 +644,7 @@ describe("getWorktreeChangesWithStats per-file diff cache", () => {
     expect(mockGit.diff).toHaveBeenCalledTimes(1);
     expect(mockGit.diff).toHaveBeenCalledWith([
       "--no-ext-diff",
+      "--no-renames",
       "--numstat",
       "HEAD",
       "--",

--- a/electron/utils/__tests__/hardenedGit.test.ts
+++ b/electron/utils/__tests__/hardenedGit.test.ts
@@ -245,13 +245,14 @@ describe("createHardenedGit", () => {
     expect(options).not.toHaveProperty("abort");
   });
 
-  it("sets LC_MESSAGES=C and LANGUAGE empty via .env()", () => {
+  it("sets LC_MESSAGES=C, LANGUAGE empty, and GIT_OPTIONAL_LOCKS=0 via .env()", () => {
     createHardenedGit("/test/repo");
 
     expect(mockGitInstance.env).toHaveBeenCalledWith(
       expect.objectContaining({
         LC_MESSAGES: "C",
         LANGUAGE: "",
+        GIT_OPTIONAL_LOCKS: "0",
       })
     );
   });
@@ -410,7 +411,7 @@ describe("createAuthenticatedGit", () => {
     expect(options.config).toContain("core.precomposeunicode=true");
   });
 
-  it("sets GIT_TERMINAL_PROMPT and hardened GIT_SSH_COMMAND via .env()", () => {
+  it("sets GIT_TERMINAL_PROMPT, hardened GIT_SSH_COMMAND, and GIT_OPTIONAL_LOCKS=0 via .env()", () => {
     createAuthenticatedGit("/test/repo");
 
     expect(mockGitInstance.env).toHaveBeenCalledWith(
@@ -418,6 +419,7 @@ describe("createAuthenticatedGit", () => {
         GIT_TERMINAL_PROMPT: "0",
         GIT_SSH_COMMAND:
           "ssh -o StrictHostKeyChecking=accept-new -o BatchMode=yes -o ConnectTimeout=15",
+        GIT_OPTIONAL_LOCKS: "0",
       })
     );
   });
@@ -449,13 +451,14 @@ describe("createAuthenticatedGit", () => {
     }
   });
 
-  it("sets LC_MESSAGES=C and LANGUAGE empty via .env()", () => {
+  it("sets LC_MESSAGES=C, LANGUAGE empty, and GIT_OPTIONAL_LOCKS=0 via .env()", () => {
     createAuthenticatedGit("/test/repo");
 
     expect(mockGitInstance.env).toHaveBeenCalledWith(
       expect.objectContaining({
         LC_MESSAGES: "C",
         LANGUAGE: "",
+        GIT_OPTIONAL_LOCKS: "0",
       })
     );
   });
@@ -624,6 +627,7 @@ describe("createBackgroundFetchGit", () => {
     const lastEnv = mockGitInstance.env.mock.calls[mockGitInstance.env.mock.calls.length - 1][0];
     expect(lastEnv.GIT_ASKPASS).toBe("true");
     expect(lastEnv.GIT_TERMINAL_PROMPT).toBe("0");
+    expect(lastEnv.GIT_OPTIONAL_LOCKS).toBe("0");
   });
 
   it("re-states GIT_OPTIONAL_LOCKS and GCM_INTERACTIVE in the POSIX second .env() call", () => {
@@ -773,7 +777,7 @@ describe("createWslHardenedGit", () => {
     expect(options.config).toHaveLength(HARDENED_GIT_CONFIG.length);
   });
 
-  it("sets WSL_DISTRO_NAME in env for diagnostics", () => {
+  it("sets WSL_DISTRO_NAME and GIT_OPTIONAL_LOCKS=0 in env for diagnostics", () => {
     createWslHardenedGit({
       distro: "Ubuntu",
       uncPath: "\\\\wsl$\\Ubuntu\\home\\user\\proj",
@@ -784,6 +788,7 @@ describe("createWslHardenedGit", () => {
     expect(envArg.WSL_DISTRO_NAME).toBe("Ubuntu");
     expect(envArg.LC_MESSAGES).toBe("C");
     expect(envArg.LANGUAGE).toBe("");
+    expect(envArg.GIT_OPTIONAL_LOCKS).toBe("0");
   });
 
   it("applies the same env hardening as createHardenedGit (Linux git inside WSL)", () => {
@@ -833,22 +838,25 @@ describe("createWslHardenedGit", () => {
 });
 
 describe("getGitLocaleEnv", () => {
-  it("returns LC_CTYPE=C.UTF-8 and LANG=C.UTF-8 on win32", () => {
+  it("returns LC_CTYPE=C.UTF-8, LANG=C.UTF-8, and GIT_OPTIONAL_LOCKS=0 on win32", () => {
     expect(getGitLocaleEnv("win32")).toEqual({
       LC_CTYPE: "C.UTF-8",
       LANG: "C.UTF-8",
+      GIT_OPTIONAL_LOCKS: "0",
     });
   });
 
-  it("returns LC_CTYPE=en_US.UTF-8 on darwin (macOS lacks C.UTF-8)", () => {
+  it("returns LC_CTYPE=en_US.UTF-8 and GIT_OPTIONAL_LOCKS=0 on darwin (macOS lacks C.UTF-8)", () => {
     expect(getGitLocaleEnv("darwin")).toEqual({
       LC_CTYPE: "en_US.UTF-8",
+      GIT_OPTIONAL_LOCKS: "0",
     });
   });
 
-  it("returns LC_CTYPE=C.UTF-8 on linux", () => {
+  it("returns LC_CTYPE=C.UTF-8 and GIT_OPTIONAL_LOCKS=0 on linux", () => {
     expect(getGitLocaleEnv("linux")).toEqual({
       LC_CTYPE: "C.UTF-8",
+      GIT_OPTIONAL_LOCKS: "0",
     });
   });
 

--- a/electron/utils/__tests__/hardenedGit.test.ts
+++ b/electron/utils/__tests__/hardenedGit.test.ts
@@ -777,7 +777,7 @@ describe("createWslHardenedGit", () => {
     expect(options.config).toHaveLength(HARDENED_GIT_CONFIG.length);
   });
 
-  it("sets WSL_DISTRO_NAME and GIT_OPTIONAL_LOCKS=0 in env for diagnostics", () => {
+  it("sets WSL_DISTRO_NAME, GIT_OPTIONAL_LOCKS=0, and locale in env for diagnostics", () => {
     createWslHardenedGit({
       distro: "Ubuntu",
       uncPath: "\\\\wsl$\\Ubuntu\\home\\user\\proj",
@@ -786,6 +786,8 @@ describe("createWslHardenedGit", () => {
 
     const envArg = mockGitInstance.env.mock.calls[0][0];
     expect(envArg.WSL_DISTRO_NAME).toBe("Ubuntu");
+    expect(envArg.LC_CTYPE).toBe("C.UTF-8");
+    expect(envArg.LC_ALL).toBe("");
     expect(envArg.LC_MESSAGES).toBe("C");
     expect(envArg.LANGUAGE).toBe("");
     expect(envArg.GIT_OPTIONAL_LOCKS).toBe("0");

--- a/electron/utils/git.ts
+++ b/electron/utils/git.ts
@@ -50,20 +50,8 @@ export function __clearPerFileDiffStatCacheForTesting(): void {
   PER_FILE_DIFF_STAT_CACHE.clear();
 }
 
-const NUMSTAT_PATH_SPLITTERS = ["=>", "->"];
-
 function normalizeNumstatPath(rawPath: string): string {
-  const trimmed = rawPath.trim();
-  for (const splitter of NUMSTAT_PATH_SPLITTERS) {
-    const idx = trimmed.lastIndexOf(splitter);
-    if (idx !== -1) {
-      return trimmed
-        .slice(idx + splitter.length)
-        .replace(/[{}]/g, "")
-        .trim();
-    }
-  }
-  return trimmed.replace(/[{}]/g, "");
+  return rawPath.trim().replace(/[{}]/g, "");
 }
 
 function parseNumstat(diffOutput: string, gitRoot: string): Map<string, DiffStat> {
@@ -265,14 +253,21 @@ export async function getWorktreeChangesWithStats(
       const git: SimpleGit = gitForChanges(cwd, options);
       const status: StatusResult = await git.status();
 
-      // Parallelise revparse + log lookups; HEAD/log are non-critical and may
-      // legitimately fail (e.g. empty repo, no commits yet) — fall back gracefully.
-      const [toplevelRaw, headOid, logOutput] = await Promise.all([
-        git.revparse(["--show-toplevel"]),
-        git
-          .revparse(["HEAD"])
-          .then((s) => s.trim())
-          .catch(() => ""),
+      // Consolidate rev-parse into a single spawn; HEAD may not exist in empty
+      // repos — fall back to a solo --show-toplevel call when it doesn't.
+      const revParsePromise = git
+        .raw(["rev-parse", "HEAD", "--show-toplevel"])
+        .then((output) => {
+          const lines = output.trim().split("\n");
+          return { headOid: lines[0]?.trim() ?? "", toplevelRaw: lines[1]?.trim() ?? "" };
+        })
+        .catch(async () => {
+          const toplevelRaw = await git.revparse(["--show-toplevel"]);
+          return { headOid: "", toplevelRaw };
+        });
+
+      const [{ toplevelRaw, headOid }, logOutput] = await Promise.all([
+        revParsePromise,
         git.raw(["log", "-1", "--format=%ct%n%s"]).catch(() => ""),
       ]);
 
@@ -315,6 +310,7 @@ export async function getWorktreeChangesWithStats(
         string,
         { absolutePath: string; mtimeMs: number; size: number }
       >();
+      const absPathToMeta = new Map<string, { mtimeMs: number; size: number }>();
 
       if (useScopedDiff) {
         const statResults = await Promise.allSettled(
@@ -331,6 +327,7 @@ export async function getWorktreeChangesWithStats(
           const mtimeMs = result.value.mtimeMs;
           const size = result.value.size;
           fileMetaByRel.set(rel, { absolutePath, mtimeMs, size });
+          absPathToMeta.set(absolutePath, { mtimeMs, size });
           const cached = PER_FILE_DIFF_STAT_CACHE.get(
             makeFileStatCacheKey(headOid, absolutePath, mtimeMs, size)
           );
@@ -357,6 +354,7 @@ export async function getWorktreeChangesWithStats(
           const limitedFiles = trackedChangedFiles.slice(0, MAX_FILES_FOR_NUMSTAT);
           diffOutput = await git.diff([
             "--no-ext-diff",
+            "--no-renames",
             "--numstat",
             "HEAD",
             "--",
@@ -370,6 +368,7 @@ export async function getWorktreeChangesWithStats(
         } else {
           diffOutput = await git.diff([
             "--no-ext-diff",
+            "--no-renames",
             "--numstat",
             "HEAD",
             "--",
@@ -548,6 +547,11 @@ export async function getWorktreeChangesWithStats(
 
       const mtimes = await Promise.all(
         Array.from(changesMap.values()).map(async (change) => {
+          const earlyMeta = absPathToMeta.get(change.path);
+          if (earlyMeta !== undefined) {
+            change.mtimeMs = earlyMeta.mtimeMs;
+            return earlyMeta.mtimeMs;
+          }
           const targetPath = change.status === "deleted" ? dirname(change.path) : change.path;
 
           try {

--- a/electron/utils/git.ts
+++ b/electron/utils/git.ts
@@ -51,7 +51,7 @@ export function __clearPerFileDiffStatCacheForTesting(): void {
 }
 
 function normalizeNumstatPath(rawPath: string): string {
-  return rawPath.trim().replace(/[{}]/g, "");
+  return rawPath.trim();
 }
 
 function parseNumstat(diffOutput: string, gitRoot: string): Map<string, DiffStat> {

--- a/electron/utils/gitUtils.ts
+++ b/electron/utils/gitUtils.ts
@@ -1,9 +1,10 @@
 import { execSync } from "child_process";
 import { isAbsolute, join as pathJoin } from "path";
 import { logWarn } from "./logger.js";
+import { Cache } from "./cache.js";
 
-const gitDirCache = new Map<string, string | null>();
-const gitCommonDirCache = new Map<string, string | null>();
+const gitDirCache = new Cache<string, string | null>({ maxSize: 200, defaultTTL: 600_000 });
+const gitCommonDirCache = new Cache<string, string | null>({ maxSize: 200, defaultTTL: 600_000 });
 
 export interface GitDirOptions {
   cache?: boolean;
@@ -99,7 +100,7 @@ export function getGitCommonDir(worktreePath: string, options: GitDirOptions = {
 
 export function clearGitDirCache(worktreePath?: string): void {
   if (worktreePath) {
-    gitDirCache.delete(worktreePath);
+    gitDirCache.invalidate(worktreePath);
   } else {
     gitDirCache.clear();
   }
@@ -107,7 +108,7 @@ export function clearGitDirCache(worktreePath?: string): void {
 
 export function clearGitCommonDirCache(worktreePath?: string): void {
   if (worktreePath) {
-    gitCommonDirCache.delete(worktreePath);
+    gitCommonDirCache.invalidate(worktreePath);
   } else {
     gitCommonDirCache.clear();
   }

--- a/electron/utils/hardenedGit.ts
+++ b/electron/utils/hardenedGit.ts
@@ -226,6 +226,8 @@ export function createWslHardenedGit(
     unsafe: UNSAFE_FLAGS,
   }).env({
     ...process.env,
+    LC_CTYPE: "C.UTF-8",
+    LC_ALL: "",
     LC_MESSAGES: "C",
     LANGUAGE: "",
     GIT_OPTIONAL_LOCKS: "0",

--- a/electron/utils/hardenedGit.ts
+++ b/electron/utils/hardenedGit.ts
@@ -106,12 +106,12 @@ export function getGitLocaleEnv(
   platform: NodeJS.Platform = process.platform
 ): Record<string, string> {
   if (platform === "win32") {
-    return { LC_CTYPE: "C.UTF-8", LANG: "C.UTF-8" };
+    return { LC_CTYPE: "C.UTF-8", LANG: "C.UTF-8", GIT_OPTIONAL_LOCKS: "0" };
   }
   if (platform === "darwin") {
-    return { LC_CTYPE: "en_US.UTF-8" };
+    return { LC_CTYPE: "en_US.UTF-8", GIT_OPTIONAL_LOCKS: "0" };
   }
-  return { LC_CTYPE: "C.UTF-8" };
+  return { LC_CTYPE: "C.UTF-8", GIT_OPTIONAL_LOCKS: "0" };
 }
 
 export function createHardenedGit(
@@ -228,6 +228,7 @@ export function createWslHardenedGit(
     ...process.env,
     LC_MESSAGES: "C",
     LANGUAGE: "",
+    GIT_OPTIONAL_LOCKS: "0",
     // Surface the targeted distro to wsl.exe via env. wsl.exe doesn't honour
     // WSL_DISTRO_NAME for selection (it uses the default distro), but having
     // this env var present makes diagnostic output unambiguous if the user

--- a/electron/workspace-host/WorktreeMonitor.ts
+++ b/electron/workspace-host/WorktreeMonitor.ts
@@ -1,6 +1,5 @@
-import { readFile } from "fs/promises";
+import { readFile, access } from "fs/promises";
 import { join as pathJoin } from "path";
-import { existsSync } from "fs";
 import { createHardenedGit, createWslHardenedGit } from "../utils/hardenedGit.js";
 import type { WslGitInvocation } from "../utils/hardenedGit.js";
 import type PQueue from "p-queue";
@@ -1030,7 +1029,9 @@ export class WorktreeMonitor {
     if (!this._isRunning) return;
 
     if (!force && this.pollingStrategy.isCircuitBreakerTripped()) {
-      if (!existsSync(this.path)) {
+      try {
+        await access(this.path);
+      } catch {
         this.callbacks.onExternalRemoval?.(this.id);
       }
       return;
@@ -1164,8 +1165,11 @@ export class WorktreeMonitor {
       const nextAheadCount = hasUpstream ? (newChanges.ahead ?? 0) : undefined;
       const nextBehindCount = hasUpstream ? (newChanges.behind ?? 0) : undefined;
 
-      const detectedPlanFile = PLAN_FILE_CANDIDATES.find((candidate) =>
-        existsSync(pathJoin(this.path, candidate))
+      const planResults = await Promise.allSettled(
+        PLAN_FILE_CANDIDATES.map((candidate) => access(pathJoin(this.path, candidate)))
+      );
+      const detectedPlanFile = PLAN_FILE_CANDIDATES.find(
+        (_, i) => planResults[i].status === "fulfilled"
       );
       const nextHasPlanFile = detectedPlanFile !== undefined;
       const nextPlanFilePath = detectedPlanFile;

--- a/electron/workspace-host/worktreeUtils.ts
+++ b/electron/workspace-host/worktreeUtils.ts
@@ -73,13 +73,12 @@ export function escapeBranchRegex(name: string): string {
  * than imported from `../services/github/...` to keep the workspace-host's
  * dependency direction one-way (workspace-host → utils, never → main services).
  */
+const GITHUB_REMOTE_URL_PATTERN =
+  /^(?:https?:\/\/(?:[^@/]+@)?github\.com\/|git@github\.com:|ssh:\/\/git@github\.com\/)/i;
+
 export function isGitHubRemoteUrl(url: string | undefined): boolean {
   if (!url) return false;
-  // Hostname is case-insensitive per RFC 3986 — normalize before matching so
-  // `https://GitHub.com/...` and `git@GITHUB.COM:...` are correctly detected.
-  return /^(?:https?:\/\/(?:[^@/]+@)?github\.com\/|git@github\.com:|ssh:\/\/git@github\.com\/)/i.test(
-    url.trim()
-  );
+  return GITHUB_REMOTE_URL_PATTERN.test(url.trim());
 }
 
 export function parseCheckedOutBranches(porcelainOutput: string): Set<string> {


### PR DESCRIPTION
## Summary
Pre-release polish for the per-worktree git status poll. Mostly small, low-risk refinements -- a few pulled from the git docs, the rest cleaning up code-shape gaps that had real runtime cost over thousands of polls.

- `GIT_OPTIONAL_LOCKS=0` in every git invocation's locale env suppresses the index stat-cache write `git status` does as a side effect. That reduces `.git/index.lock` contention with foreground git in the embedded terminals.
- `--no-renames` on the `numstat` diff calls skips the rename similarity work git does on every poll. Rename info already comes from `git status --porcelain -b`, not from numstat.

Resolves #7041

## Changes
- Folded two separate `git rev-parse` calls into a single `git rev-parse HEAD --show-toplevel` spawn -- saves a process spawn per poll per worktree
- Deduplicated per-file `fs.stat` calls in the status path -- the early stat now feeds the snapshot's mtime directly instead of statting a second time
- Replaced the sync `existsSync` loop with an async `Promise.all`/`access` pattern for plan-file detection
- Bounded `gitDirCache` and `gitCommonDirCache` Maps with the existing LRU+TTL `Cache` utility (was unbounded in production, slow leak on long-running sessions)
- Hoisted `GITHUB_REMOTE_URL_PATTERN` regex to module scope
- Dropped the dead rename-arrow handling in `parseNumstat` -- `--no-renames` suppresses the arrow form, so the splitter loop is no longer reachable

## Testing
Unit tests updated to cover `GIT_OPTIONAL_LOCKS`, `--no-renames`, the consolidated rev-parse call, and the WSL locale additions.