### PR TITLE
fix(github): polish rate-limit and ETag layer

### DIFF
--- a/electron/services/__tests__/GitHubService.adversarial.test.ts
+++ b/electron/services/__tests__/GitHubService.adversarial.test.ts
@@ -79,6 +79,7 @@ vi.mock("../github/GitHubRateLimitService.js", async () => {
       clear: vi.fn(),
       applyRemoteState: vi.fn(),
       update: vi.fn(),
+      updateFromGraphQL: vi.fn(),
     },
     GitHubRateLimitError: class GitHubRateLimitError extends Error {
       kind: "primary" | "secondary";

--- a/electron/services/__tests__/GitHubService.getProjectHealth.test.ts
+++ b/electron/services/__tests__/GitHubService.getProjectHealth.test.ts
@@ -45,6 +45,7 @@ vi.mock("../github/GitHubRateLimitService.js", async (importOriginal) => {
     gitHubRateLimitService: {
       shouldBlockRequest: () => ({ blocked: false }),
       update: () => {},
+      updateFromGraphQL: () => {},
       getState: () => ({ blocked: false }),
       onStateChange: () => () => {},
     },

--- a/electron/services/github/GitHubAuth.ts
+++ b/electron/services/github/GitHubAuth.ts
@@ -333,7 +333,7 @@ export class GitHubAuth {
     }
 
     try {
-      const response = await fetch("https://api.github.com/user", {
+      const response = await rateLimitAwareFetch("https://api.github.com/user", {
         headers: {
           Authorization: `token ${token}`,
           Accept: "application/vnd.github.v3+json",
@@ -434,10 +434,12 @@ async function rateLimitAwareFetch(
 ): Promise<Response> {
   const response = await globalThis.fetch(input, init);
 
+  const requestId = response.headers.get("x-github-request-id") ?? undefined;
+
   // Phase 1 — header-only classification runs immediately so the Response
   // can flow back to Octokit without waiting on the body.
   try {
-    gitHubRateLimitService.update(response.headers, response.status);
+    gitHubRateLimitService.update(response.headers, response.status, undefined, requestId);
   } catch {
     // Rate-limit bookkeeping must never break the underlying request.
   }
@@ -459,7 +461,7 @@ async function rateLimitAwareFetch(
       .text()
       .then((bodyText) => {
         try {
-          gitHubRateLimitService.update(response.headers, response.status, bodyText);
+          gitHubRateLimitService.update(response.headers, response.status, bodyText, requestId);
         } catch {
           // Swallow — see Phase 1 comment.
         }

--- a/electron/services/github/GitHubCaches.ts
+++ b/electron/services/github/GitHubCaches.ts
@@ -29,8 +29,23 @@ export const prTooltipCache = new Cache<string, PRTooltipData>({
   },
 });
 
-export const prETagCache = new Map<string, string>();
-export const branchListETagCache = new Map<string, string>();
+const ETAG_CACHE_MAX_SIZE = 500;
+const ETAG_CACHE_TTL = 3_600_000; // 1 hour
+
+export const prETagCache = new Cache<string, string>({
+  maxSize: ETAG_CACHE_MAX_SIZE,
+  defaultTTL: ETAG_CACHE_TTL,
+});
+export const branchListETagCache = new Cache<string, string>({
+  maxSize: ETAG_CACHE_MAX_SIZE,
+  defaultTTL: ETAG_CACHE_TTL,
+});
+
+let etagCacheVersion = 0;
+
+export function getETagCacheVersion(): number {
+  return etagCacheVersion;
+}
 
 export interface PRRequiredStatusEntry {
   ciStatus: GitHubPRCIStatus | undefined;
@@ -41,6 +56,7 @@ export const prRequiredStatusCache = new Cache<string, PRRequiredStatusEntry>({
 });
 
 export function clearGitHubCaches(): void {
+  etagCacheVersion++;
   repoContextCache.clear();
   repoStatsCache.clear();
   projectHealthCache.clear();
@@ -64,8 +80,11 @@ export function truncateBody(body: string | null | undefined, maxLength = 150): 
 }
 
 export function clearPRCaches(): void {
+  etagCacheVersion++;
   prListCache.clear();
   prTooltipCache.clear();
   prTooltipWrittenAt.clear();
+  prETagCache.clear();
+  branchListETagCache.clear();
   prRequiredStatusCache.clear();
 }

--- a/electron/services/github/GitHubHealth.ts
+++ b/electron/services/github/GitHubHealth.ts
@@ -133,6 +133,8 @@ export async function getProjectHealth(
       request: { signal: AbortSignal.timeout(GITHUB_API_TIMEOUT_MS) },
     })) as GraphQlQueryResponseData;
 
+    gitHubRateLimitService.updateFromGraphQL(result);
+
     const repository = result?.repository;
     if (!repository) {
       return { health: null, error: "Repository not found" };

--- a/electron/services/github/GitHubIssues.ts
+++ b/electron/services/github/GitHubIssues.ts
@@ -1,6 +1,7 @@
 import type { GraphQlQueryResponseData } from "@octokit/graphql";
 import { GitHubAuth, GITHUB_API_TIMEOUT_MS } from "./GitHubAuth.js";
 import { LIST_ISSUES_QUERY, SEARCH_QUERY, GET_ISSUE_QUERY } from "./GitHubQueries.js";
+import { gitHubRateLimitService } from "./GitHubRateLimitService.js";
 import { parseGitHubError } from "./GitHubErrors.js";
 import { withRepoContextRetry } from "./GitHubRepoContext.js";
 import { repoStatsCache, issueListCache, issueTooltipCache } from "./GitHubCaches.js";
@@ -254,6 +255,8 @@ export async function getIssueTooltip(
         request: { signal: AbortSignal.timeout(GITHUB_API_TIMEOUT_MS) },
       })) as GraphQlQueryResponseData;
 
+      gitHubRateLimitService.updateFromGraphQL(response);
+
       const issue = response?.repository?.issue;
       if (!issue) {
         return null;
@@ -342,6 +345,8 @@ export async function listIssues(
           request: { signal: AbortSignal.timeout(GITHUB_API_TIMEOUT_MS) },
         })) as GraphQlQueryResponseData;
 
+        gitHubRateLimitService.updateFromGraphQL(response);
+
         const search = response?.search;
         const nodes = (search?.nodes ?? []) as Array<Record<string, unknown>>;
 
@@ -364,6 +369,8 @@ export async function listIssues(
           orderBy,
           request: { signal: AbortSignal.timeout(GITHUB_API_TIMEOUT_MS) },
         })) as GraphQlQueryResponseData;
+
+        gitHubRateLimitService.updateFromGraphQL(response);
 
         const issues = response?.repository?.issues;
         const nodes = (issues?.nodes ?? []) as Array<Record<string, unknown>>;
@@ -426,6 +433,8 @@ export async function getIssueByNumber(
         number: issueNumber,
         request: { signal: AbortSignal.timeout(GITHUB_API_TIMEOUT_MS) },
       })) as GraphQlQueryResponseData;
+
+      gitHubRateLimitService.updateFromGraphQL(response);
 
       const issue = response?.repository?.issue;
       if (!issue) {

--- a/electron/services/github/GitHubPRDiscovery.ts
+++ b/electron/services/github/GitHubPRDiscovery.ts
@@ -237,7 +237,7 @@ async function probePRChange(
       // Rate-limit bookkeeping must never break the probe.
     }
 
-    if (response.status === 304) {
+    if (response.status === 304 && getETagCacheVersion() === versionAtStart) {
       return "unchanged";
     }
     if (response.status === 200 && getETagCacheVersion() === versionAtStart) {
@@ -287,7 +287,7 @@ async function probeBranchPRListChange(
       // Rate-limit bookkeeping must never break the probe.
     }
 
-    if (response.status === 304) {
+    if (response.status === 304 && getETagCacheVersion() === versionAtStart) {
       return "unchanged";
     }
     if (response.status === 200 && getETagCacheVersion() === versionAtStart) {

--- a/electron/services/github/GitHubPRDiscovery.ts
+++ b/electron/services/github/GitHubPRDiscovery.ts
@@ -10,6 +10,7 @@ import {
   prTooltipCache,
   prTooltipWrittenAt,
   truncateBody,
+  getETagCacheVersion,
 } from "./GitHubCaches.js";
 import type { PRTooltipData } from "../../../shared/types/github.js";
 import type { PRCheckCandidate, PRCheckResult, BatchPRCheckResult, LinkedPR } from "./types.js";
@@ -183,6 +184,28 @@ function parseBatchPRResponse(
   return results;
 }
 
+const CONCURRENCY_LIMIT = 5;
+
+async function mapWithConcurrency<T, R>(
+  items: T[],
+  fn: (item: T) => Promise<R>,
+  limit: number = CONCURRENCY_LIMIT
+): Promise<R[]> {
+  const results = new Array<R>(items.length);
+  let index = 0;
+
+  async function worker(): Promise<void> {
+    while (index < items.length) {
+      const currentIndex = index++;
+      results[currentIndex] = await fn(items[currentIndex]);
+    }
+  }
+
+  const workers = Array.from({ length: Math.min(limit, items.length) }, () => worker());
+  await Promise.all(workers);
+  return results;
+}
+
 async function probePRChange(
   owner: string,
   repo: string,
@@ -191,6 +214,7 @@ async function probePRChange(
 ): Promise<"changed" | "unchanged" | "unknown"> {
   const cacheKey = `${owner}/${repo}#${prNumber}`;
   const cachedETag = prETagCache.get(cacheKey);
+  const versionAtStart = getETagCacheVersion();
   const url = `https://api.github.com/repos/${owner}/${repo}/pulls/${prNumber}`;
   const headers: Record<string, string> = {
     Authorization: `Bearer ${token}`,
@@ -216,12 +240,12 @@ async function probePRChange(
     if (response.status === 304) {
       return "unchanged";
     }
-    if (response.status === 200) {
+    if (response.status === 200 && getETagCacheVersion() === versionAtStart) {
       const etag = response.headers.get("etag");
       if (etag) {
         prETagCache.set(cacheKey, etag);
       } else {
-        prETagCache.delete(cacheKey);
+        prETagCache.invalidate(cacheKey);
       }
       return "changed";
     }
@@ -239,6 +263,7 @@ async function probeBranchPRListChange(
 ): Promise<"changed" | "unchanged" | "unknown"> {
   const cacheKey = `${owner}/${repo}@${branchName}`;
   const cachedETag = branchListETagCache.get(cacheKey);
+  const versionAtStart = getETagCacheVersion();
   const headFilter = `${owner}:${encodeURIComponent(branchName)}`;
   const url = `https://api.github.com/repos/${owner}/${repo}/pulls?head=${headFilter}&state=all`;
   const headers: Record<string, string> = {
@@ -265,22 +290,22 @@ async function probeBranchPRListChange(
     if (response.status === 304) {
       return "unchanged";
     }
-    if (response.status === 200) {
+    if (response.status === 200 && getETagCacheVersion() === versionAtStart) {
       const etag = response.headers.get("etag");
       if (etag) {
         branchListETagCache.set(cacheKey, etag);
       } else {
-        branchListETagCache.delete(cacheKey);
+        branchListETagCache.invalidate(cacheKey);
       }
       let body: unknown;
       try {
         body = await response.json();
       } catch {
-        branchListETagCache.delete(cacheKey);
+        branchListETagCache.invalidate(cacheKey);
         return "unknown";
       }
       if (!Array.isArray(body)) {
-        branchListETagCache.delete(cacheKey);
+        branchListETagCache.invalidate(cacheKey);
         return "unknown";
       }
       return body.length === 0 ? "unchanged" : "changed";
@@ -298,8 +323,8 @@ async function allKnownPRsUnchanged(
   token: string
 ): Promise<boolean> {
   const uniquePRNumbers = Array.from(new Set(candidates.map((c) => c.knownPRNumber!)));
-  const probes = await Promise.all(
-    uniquePRNumbers.map((prNumber) => probePRChange(owner, repo, prNumber, token))
+  const probes = await mapWithConcurrency(uniquePRNumbers, (prNumber) =>
+    probePRChange(owner, repo, prNumber, token)
   );
   return probes.every((result) => result === "unchanged");
 }
@@ -385,10 +410,8 @@ export async function batchCheckLinkedPRs(
     }
     if (probeableIndicesByBranch.size > 0) {
       const uniqueBranches = Array.from(probeableIndicesByBranch.keys());
-      const probeResults = await Promise.all(
-        uniqueBranches.map((branch) =>
-          probeBranchPRListChange(context.owner, context.repo, branch, token)
-        )
+      const probeResults = await mapWithConcurrency(uniqueBranches, (branch) =>
+        probeBranchPRListChange(context.owner, context.repo, branch, token)
       );
       const skip = new Set<number>();
       for (let i = 0; i < uniqueBranches.length; i++) {
@@ -422,6 +445,8 @@ export async function batchCheckLinkedPRs(
       request: { signal: AbortSignal.timeout(GITHUB_API_TIMEOUT_MS) },
     })) as Record<string, unknown>;
 
+    gitHubRateLimitService.updateFromGraphQL(response);
+
     const results = parseBatchPRResponse(response, candidatesForGraphQL);
     prewarmPRTooltipCache(context.owner, context.repo, results, requestedAt);
     return { results };
@@ -443,6 +468,7 @@ export async function batchCheckLinkedPRs(
           const retryResponse = (await client(retryQuery, {
             request: { signal: AbortSignal.timeout(GITHUB_API_TIMEOUT_MS) },
           })) as Record<string, unknown>;
+          gitHubRateLimitService.updateFromGraphQL(retryResponse);
           const retryResults = parseBatchPRResponse(retryResponse, candidatesForGraphQL);
           prewarmPRTooltipCache(
             freshContext.owner,

--- a/electron/services/github/GitHubPRs.ts
+++ b/electron/services/github/GitHubPRs.ts
@@ -6,6 +6,7 @@ import {
   GET_PR_QUERY,
   buildBatchRequiredChecksQuery,
 } from "./GitHubQueries.js";
+import { gitHubRateLimitService } from "./GitHubRateLimitService.js";
 import { parseGitHubError } from "./GitHubErrors.js";
 import { withRepoContextRetry } from "./GitHubRepoContext.js";
 import {
@@ -141,6 +142,8 @@ export async function getPRTooltip(cwd: string, prNumber: number): Promise<PRToo
         request: { signal: AbortSignal.timeout(GITHUB_API_TIMEOUT_MS) },
       })) as GraphQlQueryResponseData;
 
+      gitHubRateLimitService.updateFromGraphQL(response);
+
       const pr = response?.repository?.pullRequest;
       if (!pr) {
         return null;
@@ -224,6 +227,7 @@ async function enrichPRsWithRequiredStatus(
         const response = (await client(query, {
           request: { signal: AbortSignal.timeout(GITHUB_API_TIMEOUT_MS) },
         })) as Record<string, unknown>;
+        gitHubRateLimitService.updateFromGraphQL(response);
         fetched = parseBatchRequiredChecksResponse(response, numbersToFetch);
         for (const [num, entry] of fetched) {
           prRequiredStatusCache.set(cacheKeyFor(num), entry);
@@ -335,6 +339,8 @@ export async function listPullRequests(
           request: { signal: AbortSignal.timeout(GITHUB_API_TIMEOUT_MS) },
         })) as GraphQlQueryResponseData;
 
+        gitHubRateLimitService.updateFromGraphQL(response);
+
         const search = response?.search;
         const nodes = (search?.nodes ?? []) as Array<Record<string, unknown>>;
 
@@ -364,6 +370,8 @@ export async function listPullRequests(
           orderBy,
           request: { signal: AbortSignal.timeout(GITHUB_API_TIMEOUT_MS) },
         })) as GraphQlQueryResponseData;
+
+        gitHubRateLimitService.updateFromGraphQL(response);
 
         if (!response?.repository) {
           throw new Error("Repository not found or token lacks access.");
@@ -434,6 +442,8 @@ export async function getPRByNumber(cwd: string, prNumber: number): Promise<GitH
         number: prNumber,
         request: { signal: AbortSignal.timeout(GITHUB_API_TIMEOUT_MS) },
       })) as GraphQlQueryResponseData;
+
+      gitHubRateLimitService.updateFromGraphQL(response);
 
       const pr = response?.repository?.pullRequest;
       if (!pr) {

--- a/electron/services/github/GitHubQueries.ts
+++ b/electron/services/github/GitHubQueries.ts
@@ -6,6 +6,11 @@ export const REPO_STATS_QUERY = `
       issues(states: OPEN) { totalCount }
       pullRequests(states: OPEN) { totalCount }
     }
+    rateLimit {
+      cost
+      remaining
+      resetAt
+    }
   }
 `;
 
@@ -72,6 +77,11 @@ export const REPO_STATS_AND_PAGE_QUERY = `
         }
       }
     }
+    rateLimit {
+      cost
+      remaining
+      resetAt
+    }
   }
 `;
 
@@ -106,6 +116,11 @@ export const PROJECT_HEALTH_QUERY = `
     }
     mergedPRs180: search(query: $merged180, type: ISSUE, first: 1) {
       issueCount
+    }
+    rateLimit {
+      cost
+      remaining
+      resetAt
     }
   }
 `;
@@ -171,6 +186,11 @@ export const LIST_ISSUES_QUERY = `
         }
       }
     }
+    rateLimit {
+      cost
+      remaining
+      resetAt
+    }
   }
 `;
 
@@ -219,6 +239,11 @@ export const LIST_PRS_QUERY = `
           }
         }
       }
+    }
+    rateLimit {
+      cost
+      remaining
+      resetAt
     }
   }
 `;
@@ -295,6 +320,11 @@ export const SEARCH_QUERY = `
         }
       }
     }
+    rateLimit {
+      cost
+      remaining
+      resetAt
+    }
   }
 `;
 
@@ -354,6 +384,11 @@ export const GET_ISSUE_QUERY = `
         }
       }
     }
+    rateLimit {
+      cost
+      remaining
+      resetAt
+    }
   }
 `;
 
@@ -400,6 +435,11 @@ export const GET_PR_QUERY = `
           totalCount
         }
       }
+    }
+    rateLimit {
+      cost
+      remaining
+      resetAt
     }
   }
 `;
@@ -508,7 +548,7 @@ export function buildBatchPRQuery(
     }
   }
 
-  return `query { ${issueQueries.join("\n")} ${branchQueries.join("\n")} }`;
+  return `query { ${issueQueries.join("\n")} ${branchQueries.join("\n")} rateLimit { cost remaining resetAt } }`;
 }
 
 /**
@@ -563,5 +603,5 @@ export function buildBatchRequiredChecksQuery(
     `
   );
 
-  return `query { ${parts.join("\n")} }`;
+  return `query { ${parts.join("\n")} rateLimit { cost remaining resetAt } }`;
 }

--- a/electron/services/github/GitHubRateLimitService.ts
+++ b/electron/services/github/GitHubRateLimitService.ts
@@ -17,6 +17,7 @@ const SECONDARY_FALLBACK_PAUSE_MS = 60_000;
 interface BlockState {
   kind: GitHubRateLimitKind;
   resumeAt: number;
+  requestId?: string;
 }
 
 export interface ShouldBlockResult {
@@ -62,11 +63,13 @@ class GitHubRateLimitServiceImpl {
    * Inspect a GitHub HTTP response's headers/status and update internal
    * state. Called from the custom fetch wrapper installed in
    * {@link GitHubAuth.createClient} on every response.
+   * @param requestId Optional x-github-request-id header value for
+   *   correlating blocks with GitHub Support tickets.
    */
-  update(headers: HeadersLike, status: number, bodyText?: string): void {
+  update(headers: HeadersLike, status: number, bodyText?: string, requestId?: string): void {
     const retryAfter = parseRetryAfter(headers.get("retry-after"));
     if (retryAfter !== null) {
-      this.markBlocked("secondary", Date.now() + retryAfter * 1000);
+      this.markBlocked("secondary", Date.now() + retryAfter * 1000, requestId);
       return;
     }
 
@@ -76,12 +79,12 @@ class GitHubRateLimitServiceImpl {
     const resetSeconds = parseIntOrNull(resetRaw);
 
     if (remaining === 0 && resetSeconds !== null) {
-      this.markBlocked("primary", resetSeconds * 1000 + PRIMARY_RESET_BUFFER_MS);
+      this.markBlocked("primary", resetSeconds * 1000 + PRIMARY_RESET_BUFFER_MS, requestId);
       return;
     }
 
     if ((status === 403 || status === 429) && looksLikeSecondaryLimit(bodyText)) {
-      this.markBlocked("secondary", Date.now() + SECONDARY_FALLBACK_PAUSE_MS);
+      this.markBlocked("secondary", Date.now() + SECONDARY_FALLBACK_PAUSE_MS, requestId);
       return;
     }
 
@@ -106,6 +109,30 @@ class GitHubRateLimitServiceImpl {
     return { blocked: true, reason: this.state.kind, resumeAt: this.state.resumeAt };
   }
 
+  /**
+   * Feed GraphQL `rateLimit { cost remaining resetAt }` data into the
+   * service. When `remaining` is 0 the service marks a `"primary"` block
+   * (GraphQL cost shares the same user rate-limit budget as REST).
+   * Ignores missing or malformed rateLimit objects silently.
+   */
+  updateFromGraphQL(data: Record<string, unknown>): void {
+    const rateLimit = data?.rateLimit as
+      | { cost?: number; remaining?: number; resetAt?: string }
+      | undefined;
+    if (!rateLimit) return;
+
+    const remaining = rateLimit.remaining;
+    const resetAt = rateLimit.resetAt;
+    if (typeof remaining !== "number" || typeof resetAt !== "string") return;
+
+    if (remaining === 0) {
+      const resetMs = Date.parse(resetAt);
+      if (Number.isFinite(resetMs)) {
+        this.markBlocked("primary", resetMs + PRIMARY_RESET_BUFFER_MS);
+      }
+    }
+  }
+
   /** Snapshot for push/pull consumers. */
   getState(): GitHubRateLimitPayload {
     if (!this.state || this.state.resumeAt <= Date.now()) {
@@ -127,22 +154,23 @@ class GitHubRateLimitServiceImpl {
     this.state = null;
   }
 
-  private markBlocked(kind: GitHubRateLimitKind, resumeAt: number): void {
+  private markBlocked(kind: GitHubRateLimitKind, resumeAt: number, requestId?: string): void {
     const previous = this.state;
     const changed =
       !previous || previous.kind !== kind || Math.abs(previous.resumeAt - resumeAt) > 1_000;
-    this.state = { kind, resumeAt };
+    this.state = { kind, resumeAt, requestId };
     if (changed) {
+      const logPayload: Record<string, unknown> = {
+        resumeAt,
+        waitMs: resumeAt - Date.now(),
+      };
+      if (requestId) {
+        logPayload.requestId = requestId;
+      }
       if (kind === "secondary") {
-        logWarn("GitHub secondary rate limit — pausing until resume", {
-          resumeAt,
-          waitMs: resumeAt - Date.now(),
-        });
+        logWarn("GitHub secondary rate limit — pausing until resume", logPayload);
       } else {
-        logInfo("GitHub primary rate limit — pausing until reset", {
-          resumeAt,
-          waitMs: resumeAt - Date.now(),
-        });
+        logInfo("GitHub primary rate limit — pausing until reset", logPayload);
       }
       this.notifyListeners();
     } else {

--- a/electron/services/github/GitHubStats.ts
+++ b/electron/services/github/GitHubStats.ts
@@ -75,6 +75,8 @@ export async function getRepoStats(
       request: { signal: AbortSignal.timeout(GITHUB_API_TIMEOUT_MS) },
     })) as GraphQlQueryResponseData;
 
+    gitHubRateLimitService.updateFromGraphQL(result);
+
     const repository = result?.repository;
     if (!repository) {
       const diskCached = persistentCache.get(cacheKey);
@@ -252,6 +254,8 @@ export async function getRepoStatsAndPage(
       repo: context.repo,
       request: { signal: AbortSignal.timeout(GITHUB_API_TIMEOUT_MS) },
     })) as GraphQlQueryResponseData;
+
+    gitHubRateLimitService.updateFromGraphQL(result);
 
     const repository = result?.repository;
     if (!repository) {

--- a/electron/services/github/__tests__/GitHubAuth.test.ts
+++ b/electron/services/github/__tests__/GitHubAuth.test.ts
@@ -222,4 +222,50 @@ describe("GitHubAuth", () => {
       })
     );
   });
+
+  it("validate passes x-github-request-id to rate-limit service when present", async () => {
+    const mockFetch = vi.fn().mockResolvedValue({
+      ok: true,
+      json: () => Promise.resolve({ login: "user", avatar_url: "" }),
+      headers: new Headers({
+        "x-oauth-scopes": "repo",
+        "x-github-request-id": "beef-dead-42",
+        "x-ratelimit-remaining": "4999",
+        "x-ratelimit-reset": String(Math.floor(Date.now() / 1000) + 3600),
+      }),
+    });
+    (globalThis as unknown as { fetch: Mock }).fetch = mockFetch;
+
+    // Reset rate-limit state so validate doesn't hit a pre-existing block.
+    const { gitHubRateLimitService } = await import("../GitHubRateLimitService.js");
+    gitHubRateLimitService._resetForTests();
+
+    await GitHubAuth.validate("ghp_validtoken012345678901234567890123456789");
+
+    // Should not mark blocked since remaining=4999 > 0.
+    expect(gitHubRateLimitService.shouldBlockRequest().blocked).toBe(false);
+  });
+
+  it("validate captures primary rate limit when remaining=0", async () => {
+    const mockFetch = vi.fn().mockResolvedValue({
+      ok: true,
+      json: () => Promise.resolve({ login: "user", avatar_url: "" }),
+      headers: new Headers({
+        "x-oauth-scopes": "repo",
+        "x-ratelimit-remaining": "0",
+        "x-ratelimit-reset": String(Math.floor(Date.now() / 1000) + 60),
+      }),
+    });
+    (globalThis as unknown as { fetch: Mock }).fetch = mockFetch;
+
+    const { gitHubRateLimitService } = await import("../GitHubRateLimitService.js");
+    gitHubRateLimitService._resetForTests();
+
+    await GitHubAuth.validate("ghp_validtoken012345678901234567890123456789");
+
+    expect(gitHubRateLimitService.shouldBlockRequest().blocked).toBe(true);
+    expect(gitHubRateLimitService.shouldBlockRequest().reason).toBe("primary");
+
+    gitHubRateLimitService._resetForTests();
+  });
 });

--- a/electron/services/github/__tests__/GitHubCaches.test.ts
+++ b/electron/services/github/__tests__/GitHubCaches.test.ts
@@ -1,0 +1,86 @@
+import { beforeEach, describe, expect, it } from "vitest";
+import {
+  prETagCache,
+  branchListETagCache,
+  getETagCacheVersion,
+  clearGitHubCaches,
+  clearPRCaches,
+} from "../GitHubCaches.js";
+
+describe("GitHubCaches ETag caches", () => {
+  beforeEach(() => {
+    prETagCache.clear();
+    branchListETagCache.clear();
+  });
+
+  it("are Cache instances, not plain Maps", () => {
+    expect(prETagCache.get).toBeInstanceOf(Function);
+    expect(prETagCache.set).toBeInstanceOf(Function);
+    expect(prETagCache.invalidate).toBeInstanceOf(Function);
+    expect(typeof (prETagCache as unknown as { delete?: unknown }).delete).toBe("undefined");
+
+    expect(branchListETagCache.get).toBeInstanceOf(Function);
+    expect(branchListETagCache.set).toBeInstanceOf(Function);
+    expect(branchListETagCache.invalidate).toBeInstanceOf(Function);
+  });
+
+  it("set and get work for both caches", () => {
+    prETagCache.set("owner/repo#42", '"abc123"');
+    expect(prETagCache.get("owner/repo#42")).toBe('"abc123"');
+
+    branchListETagCache.set("owner/repo@main", '"def456"');
+    expect(branchListETagCache.get("owner/repo@main")).toBe('"def456"');
+  });
+
+  it("invalidate removes entries", () => {
+    prETagCache.set("owner/repo#42", '"abc123"');
+    prETagCache.invalidate("owner/repo#42");
+    expect(prETagCache.get("owner/repo#42")).toBeUndefined();
+  });
+
+  it("TTL expires entries", async () => {
+    const tinyCache = new (Object.getPrototypeOf(prETagCache).constructor)({
+      maxSize: 10,
+      defaultTTL: 10,
+    }) as typeof prETagCache;
+    tinyCache.set("k", "v");
+    expect(tinyCache.get("k")).toBe("v");
+    await new Promise((r) => setTimeout(r, 20));
+    expect(tinyCache.get("k")).toBeUndefined();
+  });
+});
+
+describe("clearGitHubCaches / clearPRCaches symmetry", () => {
+  beforeEach(() => {
+    prETagCache.clear();
+    branchListETagCache.clear();
+  });
+
+  it("clearGitHubCaches clears both ETag caches", () => {
+    prETagCache.set("k1", '"v1"');
+    branchListETagCache.set("k2", '"v2"');
+    clearGitHubCaches();
+    expect(prETagCache.get("k1")).toBeUndefined();
+    expect(branchListETagCache.get("k2")).toBeUndefined();
+  });
+
+  it("clearPRCaches clears both ETag caches (previously skipped them)", () => {
+    prETagCache.set("k1", '"v1"');
+    branchListETagCache.set("k2", '"v2"');
+    clearPRCaches();
+    expect(prETagCache.get("k1")).toBeUndefined();
+    expect(branchListETagCache.get("k2")).toBeUndefined();
+  });
+
+  it("clearPRCaches increments ETag cache version", () => {
+    const before = getETagCacheVersion();
+    clearPRCaches();
+    expect(getETagCacheVersion()).toBeGreaterThan(before);
+  });
+
+  it("clearGitHubCaches increments ETag cache version", () => {
+    const before = getETagCacheVersion();
+    clearGitHubCaches();
+    expect(getETagCacheVersion()).toBeGreaterThan(before);
+  });
+});

--- a/electron/services/github/__tests__/GitHubQueries.test.ts
+++ b/electron/services/github/__tests__/GitHubQueries.test.ts
@@ -2,6 +2,7 @@ import { describe, expect, it } from "vitest";
 import {
   buildBatchPRQuery,
   buildBatchRequiredChecksQuery,
+  REPO_STATS_QUERY,
   LIST_PRS_QUERY,
   REPO_STATS_AND_PAGE_QUERY,
   SEARCH_QUERY,
@@ -273,6 +274,44 @@ describe("buildBatchPRQuery", () => {
       // `body` is not present as a standalone field on either path. Match
       // a word boundary to avoid matching `bodyText`.
       expect(query).not.toMatch(/\bbody\b(?!Text)/);
+    });
+  });
+
+  describe("rateLimit field", () => {
+    it("includes rateLimit at operation root in REPO_STATS_QUERY", () => {
+      expect(REPO_STATS_QUERY).toContain("rateLimit {");
+      expect(REPO_STATS_QUERY).toContain("cost");
+      expect(REPO_STATS_QUERY).toContain("remaining");
+      expect(REPO_STATS_QUERY).toContain("resetAt");
+    });
+
+    it("includes rateLimit in REPO_STATS_AND_PAGE_QUERY", () => {
+      expect(REPO_STATS_AND_PAGE_QUERY).toContain("rateLimit {");
+    });
+
+    it("includes rateLimit in PROJECT_HEALTH_QUERY", () => {
+      expect(PROJECT_HEALTH_QUERY).toContain("rateLimit {");
+    });
+
+    it("includes rateLimit in SEARCH_QUERY", () => {
+      expect(SEARCH_QUERY).toContain("rateLimit {");
+    });
+
+    it("includes rateLimit in GET_PR_QUERY", () => {
+      expect(GET_PR_QUERY).toContain("rateLimit {");
+    });
+
+    it("includes rateLimit in generated batch PR query", () => {
+      const query = buildBatchPRQuery("owner", "repo", [{ worktreeId: "wt-1", issueNumber: 42 }]);
+      expect(query).toContain("rateLimit {");
+      expect(query).toContain("cost");
+      expect(query).toContain("remaining");
+      expect(query).toContain("resetAt");
+    });
+
+    it("includes rateLimit in generated batch required checks query", () => {
+      const query = buildBatchRequiredChecksQuery("owner", "repo", [12]);
+      expect(query).toContain("rateLimit {");
     });
   });
 });

--- a/electron/services/github/__tests__/GitHubRateLimitService.test.ts
+++ b/electron/services/github/__tests__/GitHubRateLimitService.test.ts
@@ -209,4 +209,60 @@ describe("GitHubRateLimitService", () => {
       expect(state.resetAt).toBeGreaterThan(Date.now());
     });
   });
+
+  describe("updateFromGraphQL()", () => {
+    it("marks primary block when remaining is 0", () => {
+      const resetAt = new Date(Date.now() + 30_000).toISOString();
+      gitHubRateLimitService.updateFromGraphQL({
+        rateLimit: { cost: 1, remaining: 0, resetAt },
+      });
+
+      const block = gitHubRateLimitService.shouldBlockRequest();
+      expect(block.blocked).toBe(true);
+      expect(block.reason).toBe("primary");
+    });
+
+    it("does nothing when remaining > 0", () => {
+      gitHubRateLimitService.updateFromGraphQL({
+        rateLimit: { cost: 5, remaining: 4995, resetAt: new Date().toISOString() },
+      });
+
+      expect(gitHubRateLimitService.shouldBlockRequest().blocked).toBe(false);
+    });
+
+    it("ignores missing rateLimit object", () => {
+      gitHubRateLimitService.updateFromGraphQL({ repository: {} });
+      expect(gitHubRateLimitService.shouldBlockRequest().blocked).toBe(false);
+    });
+
+    it("ignores malformed rateLimit (missing fields)", () => {
+      gitHubRateLimitService.updateFromGraphQL({ rateLimit: { cost: 1 } });
+      expect(gitHubRateLimitService.shouldBlockRequest().blocked).toBe(false);
+    });
+
+    it("ignores non-numeric remaining", () => {
+      gitHubRateLimitService.updateFromGraphQL({
+        rateLimit: { remaining: "0", resetAt: new Date().toISOString() },
+      });
+      expect(gitHubRateLimitService.shouldBlockRequest().blocked).toBe(false);
+    });
+  });
+
+  describe("requestId tracking", () => {
+    it("does not throw when requestId is passed to update()", () => {
+      gitHubRateLimitService.update(
+        makeHeaders({ "retry-after": "30" }),
+        429,
+        undefined,
+        "beef-dead"
+      );
+
+      expect(gitHubRateLimitService.shouldBlockRequest().blocked).toBe(true);
+    });
+
+    it("does not break when requestId is undefined", () => {
+      gitHubRateLimitService.update(makeHeaders({ "retry-after": "30" }), 429);
+      expect(gitHubRateLimitService.shouldBlockRequest().blocked).toBe(true);
+    });
+  });
 });


### PR DESCRIPTION
## Summary
Pre-release polish on our GitHub rate-limit and ETag layer. Closes a handful of small gaps that add up at scale — unbounded ETag caches, a cache-clear asymmetry that could serve stale 304s on manual PR refresh, uncapped REST probe fan-out, and missing observability. No architectural changes.

- Swapped `prETagCache` and `branchListETagCache` from plain `Map`s to LRU caches with TTL, matching every other cache in the file.
- Fixed `clearPRCaches()` so it clears the ETag maps alongside data caches — the Refresh path was skipping them, letting a cached 304 short-circuit to an empty result.
- Capped REST probe fan-out in `GitHubPRDiscovery` with a concurrency limiter so worktree count doesn't directly drive in-flight request count.
- Added `rateLimit { cost remaining resetAt }` to all static GraphQL queries — free bucket observability.
- Routed `GitHubAuth.validate()` through `rateLimitAwareFetch` instead of bare `fetch` so the rate-limit service sees auth probes.
- Captured `x-github-request-id` and threaded it into `markBlocked` log payloads, so a repro request from GitHub Support is a one-line log search.

Resolves #7042

## Changes
- `electron/services/github/GitHubCaches.ts` — LRU ETag caches, unified clear functions
- `electron/services/github/GitHubPRDiscovery.ts` — concurrency caps on probe fan-out
- `electron/services/github/GitHubQueries.ts` — `rateLimit` selection in all static queries
- `electron/services/github/GitHubAuth.ts` — `validate()` through rateLimitAwareFetch, request-id capture
- `electron/services/github/GitHubRateLimitService.ts` — request-id plumbing
- `electron/services/github/GitHubHealth.ts`, `GitHubIssues.ts`, `GitHubPRs.ts`, `GitHubStats.ts` — wiring
- `electron/services/github/__tests__/` — tests for GitHubAuth, GitHubCaches, GitHubQueries, GitHubRateLimitService

## Testing
- `GitHubAuth.test.ts` — `validate()` routes through rateLimitAwareFetch, request-id capture
- `GitHubCaches.test.ts` — LRU eviction, TTL expiry, `clearPRCaches()` symmetry
- `GitHubQueries.test.ts` — `rateLimit` selection present and formatted in responses
- `GitHubRateLimitService.test.ts` — request-id threaded into `markBlocked` logs