### PR TITLE
perf(git): dedupe safe.directory writes and replace byte-by-byte null scans

### DIFF
--- a/electron/ipc/handlers/__tests__/gitMarkSafeDirectory.test.ts
+++ b/electron/ipc/handlers/__tests__/gitMarkSafeDirectory.test.ts
@@ -20,9 +20,9 @@ const execFileMock = vi.hoisted(() =>
       _cmd: string,
       _args: readonly string[],
       _opts: unknown,
-      cb: (err: Error | null, stdout: string, stderr: string) => void
+      cb: (err: Error | null, result: { stdout: string; stderr: string }) => void
     ) => {
-      cb(null, "", "");
+      cb(null, { stdout: "", stderr: "" });
     }
   )
 );
@@ -168,5 +168,153 @@ describe("git:mark-safe-directory handler", () => {
     registerGitWriteHandlers({} as Parameters<typeof registerGitWriteHandlers>[0]);
     const handler = getHandler("git:mark-safe-directory");
     await expect(handler(null, "/Users/foo/repo")).rejects.toThrow(/git not found/);
+  });
+
+  it("skips --add when the canonicalized path is already in safe.directory", async () => {
+    const repoPath = "/Users/foo/my repo";
+    const normalized = resolvedSlashed(repoPath);
+    // First call: --get-all returns the same path (already configured).
+    execFileMock.mockImplementationOnce(
+      (
+        _cmd: string,
+        args: readonly string[],
+        _opts: unknown,
+        cb: (err: Error | null, stdout: string, stderr: string) => void
+      ) => {
+        if (args.includes("--get-all")) {
+          cb(null, { stdout: normalized + "\n", stderr: "" });
+        } else {
+          cb(null, { stdout: "", stderr: "" });
+        }
+      }
+    );
+    registerGitWriteHandlers({} as Parameters<typeof registerGitWriteHandlers>[0]);
+    const handler = getHandler("git:mark-safe-directory");
+    await handler(null, repoPath);
+
+    const calls = execFileMock.mock.calls as [string, string[], unknown, unknown][];
+    const addCall = calls.find(
+      ([, args]) => Array.isArray(args) && args.includes("--add"),
+    );
+    expect(addCall).toBeUndefined();
+  });
+
+  it("writes --add when --get-all fails with exit code 1 (no entries)", async () => {
+    const repoPath = "/Users/foo/my repo";
+    const normalized = resolvedSlashed(repoPath);
+    // First call: --get-all fails with exit code 1 (no safe.directory set).
+    execFileMock.mockImplementationOnce(
+      (
+        _cmd: string,
+        args: readonly string[],
+        _opts: unknown,
+        cb: (err: Error | null, stdout: string, stderr: string) => void
+      ) => {
+        if (args.includes("--get-all")) {
+          const err = new Error("Command failed") as Error & { code: number };
+          err.code = 1;
+          cb(err, "", "error: invalid key: safe.directory\n");
+        } else {
+          cb(null, { stdout: "", stderr: "" });
+        }
+      }
+    );
+    registerGitWriteHandlers({} as Parameters<typeof registerGitWriteHandlers>[0]);
+    const handler = getHandler("git:mark-safe-directory");
+    await handler(null, repoPath);
+
+    const calls = execFileMock.mock.calls as [string, string[], unknown, unknown][];
+    const addCall = calls.find(
+      ([, args]) => Array.isArray(args) && args.includes("--add"),
+    );
+    expect(addCall).toBeDefined();
+    expect(addCall![1]).toEqual(["config", "--global", "--add", "safe.directory", normalized]);
+  });
+
+  it("writes --add when the path is not in existing safe.directory entries", async () => {
+    const repoPath = "/Users/foo/my repo";
+    const normalized = resolvedSlashed(repoPath);
+    // --get-all returns a different path.
+    execFileMock.mockImplementationOnce(
+      (
+        _cmd: string,
+        args: readonly string[],
+        _opts: unknown,
+        cb: (err: Error | null, stdout: string, stderr: string) => void
+      ) => {
+        if (args.includes("--get-all")) {
+          cb(null, { stdout: "/other/repo\n/another/repo\n", stderr: "" });
+        } else {
+          cb(null, { stdout: "", stderr: "" });
+        }
+      }
+    );
+    registerGitWriteHandlers({} as Parameters<typeof registerGitWriteHandlers>[0]);
+    const handler = getHandler("git:mark-safe-directory");
+    await handler(null, repoPath);
+
+    const calls = execFileMock.mock.calls as [string, string[], unknown, unknown][];
+    const addCall = calls.find(
+      ([, args]) => Array.isArray(args) && args.includes("--add"),
+    );
+    expect(addCall).toBeDefined();
+    expect(addCall![1]).toEqual(["config", "--global", "--add", "safe.directory", normalized]);
+  });
+
+  it("propagates non-exit-code-1 --get-all failures", async () => {
+    execFileMock.mockImplementationOnce(
+      (
+        _cmd: string,
+        args: readonly string[],
+        _opts: unknown,
+        cb: (err: Error | null, stdout: string, stderr: string) => void
+      ) => {
+        if (args.includes("--get-all")) {
+          const err = new Error("git not found") as Error & { code: number };
+          err.code = 128;
+          cb(err, "", "fatal: unable to read config file\n");
+        } else {
+          cb(null, { stdout: "", stderr: "" });
+        }
+      }
+    );
+    registerGitWriteHandlers({} as Parameters<typeof registerGitWriteHandlers>[0]);
+    const handler = getHandler("git:mark-safe-directory");
+    await expect(handler(null, "/Users/foo/repo")).rejects.toThrow(/git not found/);
+  });
+
+  it("matches a symlinked safe.directory entry against a symlinked path", async () => {
+    // Both the candidate and the stored entry go through realpath to the
+    // same canonical target, so the dedup fires even though the raw strings differ.
+    const repoPath = "/Users/foo/link-to-repo";
+    const realTarget = "/Users/foo/real-repo";
+    realpathMock.mockImplementation(async (p: string) => {
+      if (p.includes("link-to-repo") || p.includes("stored-link")) return realTarget;
+      return p;
+    });
+    // --get-all returns a path that resolves to the same real target.
+    execFileMock.mockImplementationOnce(
+      (
+        _cmd: string,
+        args: readonly string[],
+        _opts: unknown,
+        cb: (err: Error | null, stdout: string, stderr: string) => void
+      ) => {
+        if (args.includes("--get-all")) {
+          cb(null, { stdout: "/Users/foo/stored-link\n", stderr: "" });
+        } else {
+          cb(null, { stdout: "", stderr: "" });
+        }
+      }
+    );
+    registerGitWriteHandlers({} as Parameters<typeof registerGitWriteHandlers>[0]);
+    const handler = getHandler("git:mark-safe-directory");
+    await handler(null, repoPath);
+
+    const calls = execFileMock.mock.calls as [string, string[], unknown, unknown][];
+    const addCall = calls.find(
+      ([, args]) => Array.isArray(args) && args.includes("--add"),
+    );
+    expect(addCall).toBeUndefined();
   });
 });

--- a/electron/ipc/handlers/__tests__/gitMarkSafeDirectory.test.ts
+++ b/electron/ipc/handlers/__tests__/gitMarkSafeDirectory.test.ts
@@ -160,9 +160,9 @@ describe("git:mark-safe-directory handler", () => {
         _cmd: string,
         _args: readonly string[],
         _opts: unknown,
-        cb: (err: Error | null, stdout: string, stderr: string) => void
+        cb: (err: Error | null, result: { stdout: string; stderr: string }) => void
       ) => {
-        cb(new Error("git not found"), "", "git not found");
+        cb(new Error("git not found"), { stdout: "", stderr: "git not found" });
       }
     );
     registerGitWriteHandlers({} as Parameters<typeof registerGitWriteHandlers>[0]);
@@ -179,7 +179,7 @@ describe("git:mark-safe-directory handler", () => {
         _cmd: string,
         args: readonly string[],
         _opts: unknown,
-        cb: (err: Error | null, stdout: string, stderr: string) => void
+        cb: (err: Error | null, result: { stdout: string; stderr: string }) => void
       ) => {
         if (args.includes("--get-all")) {
           cb(null, { stdout: normalized + "\n", stderr: "" });
@@ -193,9 +193,7 @@ describe("git:mark-safe-directory handler", () => {
     await handler(null, repoPath);
 
     const calls = execFileMock.mock.calls as [string, string[], unknown, unknown][];
-    const addCall = calls.find(
-      ([, args]) => Array.isArray(args) && args.includes("--add"),
-    );
+    const addCall = calls.find(([, args]) => Array.isArray(args) && args.includes("--add"));
     expect(addCall).toBeUndefined();
   });
 
@@ -208,12 +206,12 @@ describe("git:mark-safe-directory handler", () => {
         _cmd: string,
         args: readonly string[],
         _opts: unknown,
-        cb: (err: Error | null, stdout: string, stderr: string) => void
+        cb: (err: Error | null, result: { stdout: string; stderr: string }) => void
       ) => {
         if (args.includes("--get-all")) {
           const err = new Error("Command failed") as Error & { code: number };
           err.code = 1;
-          cb(err, "", "error: invalid key: safe.directory\n");
+          cb(err, { stdout: "", stderr: "error: invalid key: safe.directory\n" });
         } else {
           cb(null, { stdout: "", stderr: "" });
         }
@@ -224,9 +222,7 @@ describe("git:mark-safe-directory handler", () => {
     await handler(null, repoPath);
 
     const calls = execFileMock.mock.calls as [string, string[], unknown, unknown][];
-    const addCall = calls.find(
-      ([, args]) => Array.isArray(args) && args.includes("--add"),
-    );
+    const addCall = calls.find(([, args]) => Array.isArray(args) && args.includes("--add"));
     expect(addCall).toBeDefined();
     expect(addCall![1]).toEqual(["config", "--global", "--add", "safe.directory", normalized]);
   });
@@ -240,7 +236,7 @@ describe("git:mark-safe-directory handler", () => {
         _cmd: string,
         args: readonly string[],
         _opts: unknown,
-        cb: (err: Error | null, stdout: string, stderr: string) => void
+        cb: (err: Error | null, result: { stdout: string; stderr: string }) => void
       ) => {
         if (args.includes("--get-all")) {
           cb(null, { stdout: "/other/repo\n/another/repo\n", stderr: "" });
@@ -254,9 +250,7 @@ describe("git:mark-safe-directory handler", () => {
     await handler(null, repoPath);
 
     const calls = execFileMock.mock.calls as [string, string[], unknown, unknown][];
-    const addCall = calls.find(
-      ([, args]) => Array.isArray(args) && args.includes("--add"),
-    );
+    const addCall = calls.find(([, args]) => Array.isArray(args) && args.includes("--add"));
     expect(addCall).toBeDefined();
     expect(addCall![1]).toEqual(["config", "--global", "--add", "safe.directory", normalized]);
   });
@@ -267,12 +261,12 @@ describe("git:mark-safe-directory handler", () => {
         _cmd: string,
         args: readonly string[],
         _opts: unknown,
-        cb: (err: Error | null, stdout: string, stderr: string) => void
+        cb: (err: Error | null, result: { stdout: string; stderr: string }) => void
       ) => {
         if (args.includes("--get-all")) {
           const err = new Error("git not found") as Error & { code: number };
           err.code = 128;
-          cb(err, "", "fatal: unable to read config file\n");
+          cb(err, { stdout: "", stderr: "fatal: unable to read config file\n" });
         } else {
           cb(null, { stdout: "", stderr: "" });
         }
@@ -298,7 +292,7 @@ describe("git:mark-safe-directory handler", () => {
         _cmd: string,
         args: readonly string[],
         _opts: unknown,
-        cb: (err: Error | null, stdout: string, stderr: string) => void
+        cb: (err: Error | null, result: { stdout: string; stderr: string }) => void
       ) => {
         if (args.includes("--get-all")) {
           cb(null, { stdout: "/Users/foo/stored-link\n", stderr: "" });
@@ -312,9 +306,7 @@ describe("git:mark-safe-directory handler", () => {
     await handler(null, repoPath);
 
     const calls = execFileMock.mock.calls as [string, string[], unknown, unknown][];
-    const addCall = calls.find(
-      ([, args]) => Array.isArray(args) && args.includes("--add"),
-    );
+    const addCall = calls.find(([, args]) => Array.isArray(args) && args.includes("--add"));
     expect(addCall).toBeUndefined();
   });
 });

--- a/electron/ipc/handlers/git-write.ts
+++ b/electron/ipc/handlers/git-write.ts
@@ -676,7 +676,7 @@ export function registerGitWriteHandlers(_deps: HandlerDependencies): () => void
       const { stdout } = await execFileAsync(
         "git",
         ["config", "--global", "--get-all", "safe.directory"],
-        { env: { ...process.env, LC_ALL: "C" } },
+        { env: { ...process.env, LC_ALL: "C" } }
       );
       const entries = stdout
         .split("\n")

--- a/electron/ipc/handlers/git-write.ts
+++ b/electron/ipc/handlers/git-write.ts
@@ -639,6 +639,19 @@ export function registerGitWriteHandlers(_deps: HandlerDependencies): () => void
   };
   handlers.push(typedHandle(CHANNELS.GIT_SNAPSHOT_DELETE, handleSnapshotDelete));
 
+  // Normalizes a path for comparison against git config safe.directory entries:
+  // resolve → realpath (fall back to resolved) → forward slashes.
+  const canonicalizeSafeDirectoryPath = async (p: string): Promise<string> => {
+    const resolved = path.resolve(p);
+    let canonical: string;
+    try {
+      canonical = await realpath(resolved);
+    } catch {
+      canonical = resolved;
+    }
+    return canonical.replace(/\\/g, "/");
+  };
+
   // Resolves the "fatal: detected dubious ownership" error (CVE-2022-24765) by
   // adding the repo path to the user's global safe.directory list. The caller
   // is expected to retry the original operation after this succeeds.
@@ -653,25 +666,41 @@ export function registerGitWriteHandlers(_deps: HandlerDependencies): () => void
     if (!path.isAbsolute(repoPath)) {
       throw new Error("Invalid path: must be absolute");
     }
-    // Git compares safe.directory against the canonical repo path. If the
-    // user opened a symlinked repo, writing the link path would leave the
-    // error unresolved. realpath() reconciles the two; if it fails (e.g., the
-    // path no longer exists), fall back to the resolved path so the user
-    // still gets a deterministic write.
-    const resolved = path.resolve(repoPath);
-    let canonical: string;
+    const normalized = await canonicalizeSafeDirectoryPath(repoPath);
+
+    // Check whether the path is already configured to avoid unbounded
+    // duplicate entries in ~/.gitconfig. Exit code 1 (no entries set) is
+    // expected for first-time users and must not propagate as an error.
+    let alreadyConfigured = false;
     try {
-      canonical = await realpath(resolved);
-    } catch {
-      canonical = resolved;
+      const { stdout } = await execFileAsync(
+        "git",
+        ["config", "--global", "--get-all", "safe.directory"],
+        { env: { ...process.env, LC_ALL: "C" } },
+      );
+      const entries = stdout
+        .split("\n")
+        .map((e) => e.trim())
+        .filter(Boolean);
+      for (const entry of entries) {
+        const canonicalized = await canonicalizeSafeDirectoryPath(entry);
+        if (canonicalized === normalized) {
+          alreadyConfigured = true;
+          break;
+        }
+      }
+    } catch (err) {
+      if ((err as { code?: number }).code !== 1) {
+        throw err;
+      }
+      // Exit code 1: no safe.directory entries exist — not configured.
     }
-    // Git for Windows (MSYS2) expects forward-slash Win32 paths like
-    // `C:/Users/foo/repo`. Backslashes or POSIX-prefixed `/c/...` paths can be
-    // misinterpreted relative to the Git installation root.
-    const normalized = canonical.replace(/\\/g, "/");
-    await execFileAsync("git", ["config", "--global", "--add", "safe.directory", normalized], {
-      env: { ...process.env, LC_ALL: "C" },
-    });
+
+    if (!alreadyConfigured) {
+      await execFileAsync("git", ["config", "--global", "--add", "safe.directory", normalized], {
+        env: { ...process.env, LC_ALL: "C" },
+      });
+    }
   };
   handlers.push(typedHandle(CHANNELS.GIT_MARK_SAFE_DIRECTORY, handleMarkSafeDirectory));
 

--- a/electron/services/GitService.ts
+++ b/electron/services/GitService.ts
@@ -423,22 +423,21 @@ ${lines.map((l) => "+" + l).join("\n")}`;
 
   private isBinaryBuffer(buffer: Buffer): boolean {
     const checkLength = Math.min(buffer.length, 8192);
+    if (checkLength === 0) return false;
 
-    for (let i = 0; i < checkLength; i++) {
-      if (buffer[i] === 0) {
-        return true;
-      }
-    }
+    const sample = buffer.subarray(0, checkLength);
+
+    if (sample.indexOf(0) !== -1) return true;
 
     let nonPrintable = 0;
     for (let i = 0; i < checkLength; i++) {
-      const byte = buffer[i];
+      const byte = sample[i];
       if (!(byte >= 0x20 && byte <= 0x7e) && byte !== 0x09 && byte !== 0x0a && byte !== 0x0d) {
         nonPrintable++;
       }
     }
 
-    return checkLength > 0 && nonPrintable / checkLength > 0.3;
+    return nonPrintable / checkLength > 0.3;
   }
 
   async getRemoteUrl(repoPath: string): Promise<string | null> {

--- a/electron/services/__tests__/GitService.test.ts
+++ b/electron/services/__tests__/GitService.test.ts
@@ -95,6 +95,38 @@ describe("GitService", () => {
     expect(diff).toBe("BINARY_FILE");
   });
 
+  it("returns BINARY_FILE when null byte is at position 0", async () => {
+    const filePath = path.join(tempDir, "null-at-0.bin");
+    await fs.writeFile(filePath, Buffer.from([0x00, 0x41, 0x42, 0x43]));
+
+    const service = new GitService(tempDir);
+    const diff = await service.getFileDiff("null-at-0.bin", "untracked");
+
+    expect(diff).toBe("BINARY_FILE");
+  });
+
+  it("returns a diff (not BINARY_FILE) for an empty file", async () => {
+    const filePath = path.join(tempDir, "empty.txt");
+    await fs.writeFile(filePath, Buffer.from([]));
+
+    const service = new GitService(tempDir);
+    const diff = await service.getFileDiff("empty.txt", "untracked");
+
+    expect(diff).not.toBe("BINARY_FILE");
+    expect(diff).toContain("diff --git");
+  });
+
+  it("returns a diff (not BINARY_FILE) for a text file", async () => {
+    const filePath = path.join(tempDir, "readme.txt");
+    await fs.writeFile(filePath, Buffer.from("hello world\n"));
+
+    const service = new GitService(tempDir);
+    const diff = await service.getFileDiff("readme.txt", "untracked");
+
+    expect(diff).not.toBe("BINARY_FILE");
+    expect(diff).toContain("diff --git");
+  });
+
   it("finds next local branch suffix while ignoring remote-only conflicts", async () => {
     gitClientMock.branch.mockResolvedValue({
       branches: {

--- a/electron/utils/__tests__/git.test.ts
+++ b/electron/utils/__tests__/git.test.ts
@@ -8,6 +8,8 @@ const mockGit = {
   revparse: vi.fn(),
 };
 
+const readFileMock = vi.hoisted(() => vi.fn().mockResolvedValue(Buffer.from("line1\nline2\n")));
+
 vi.mock("../hardenedGit.js", () => ({
   createHardenedGit: vi.fn(() => mockGit),
 }));
@@ -21,6 +23,7 @@ vi.mock("fs", async (importOriginal) => {
       ...(actual as { promises: Record<string, unknown> }).promises,
       access: vi.fn().mockResolvedValue(undefined),
       stat: vi.fn().mockResolvedValue({ mtimeMs: 1000, size: 512 }),
+      readFile: readFileMock,
     },
   };
 });
@@ -666,6 +669,70 @@ describe("getWorktreeChangesWithStats per-file diff cache", () => {
     expect(mockGit.diff).toHaveBeenCalledTimes(1);
     expect(result.totalInsertions).toBe(6);
     expect(result.totalDeletions).toBe(4);
+  });
+});
+
+describe("getWorktreeChangesWithStats binary file handling", () => {
+  const emptyStatus = {
+    modified: [],
+    created: [],
+    deleted: [],
+    renamed: [],
+    staged: [],
+    conflicted: [],
+    not_added: [],
+  };
+
+  beforeEach(() => {
+    vi.clearAllMocks();
+    __clearPerFileDiffStatCacheForTesting();
+    (fs.access as ReturnType<typeof vi.fn>).mockResolvedValue(undefined);
+    (fs.stat as ReturnType<typeof vi.fn>).mockResolvedValue({ mtimeMs: 1000, size: 512 });
+    readFileMock.mockResolvedValue(Buffer.from("line1\nline2\n"));
+    mockGit.raw.mockResolvedValue("");
+    mockGit.diff.mockResolvedValue("");
+  });
+
+  it("returns insertions: null for untracked binary files (null byte detected)", async () => {
+    const cwd = "/binary-untracked/" + Math.random();
+    mockGit.revparse.mockImplementation((args: string[]) => {
+      if (Array.isArray(args) && args[0] === "HEAD") {
+        return Promise.resolve("head-oid\n");
+      }
+      return Promise.resolve(`${cwd}\n`);
+    });
+    mockGit.status.mockResolvedValue({
+      ...emptyStatus,
+      not_added: ["blob.bin"],
+    });
+    readFileMock.mockResolvedValue(Buffer.from([0x00, 0xff, 0xfe, 0xfd]));
+
+    const result = await getWorktreeChangesWithStats(cwd, true);
+
+    expect(result.totalInsertions).toBe(0);
+    expect(result.changes).toHaveLength(1);
+    expect(result.changes[0].insertions).toBeNull();
+  });
+
+  it("returns line count for untracked text files", async () => {
+    const cwd = "/text-untracked/" + Math.random();
+    mockGit.revparse.mockImplementation((args: string[]) => {
+      if (Array.isArray(args) && args[0] === "HEAD") {
+        return Promise.resolve("head-oid\n");
+      }
+      return Promise.resolve(`${cwd}\n`);
+    });
+    mockGit.status.mockResolvedValue({
+      ...emptyStatus,
+      not_added: ["readme.txt"],
+    });
+    readFileMock.mockResolvedValue(Buffer.from("line1\nline2\nline3\n"));
+
+    const result = await getWorktreeChangesWithStats(cwd, true);
+
+    expect(result.totalInsertions).toBe(3);
+    expect(result.changes).toHaveLength(1);
+    expect(result.changes[0].insertions).toBe(3);
   });
 });
 

--- a/electron/utils/git.ts
+++ b/electron/utils/git.ts
@@ -431,10 +431,8 @@ export async function getWorktreeChangesWithStats(
           const buffer = await fs.readFile(filePath);
 
           const sampleSize = Math.min(buffer.length, 8192);
-          for (let i = 0; i < sampleSize; i++) {
-            if (buffer[i] === 0) {
-              return null;
-            }
+          if (buffer.subarray(0, sampleSize).indexOf(0) !== -1) {
+            return null;
           }
 
           const content = buffer.toString("utf-8");


### PR DESCRIPTION
## Summary
Two independent fixes in the git layer that clean up config writes and speed up file-type detection.

- `handleMarkSafeDirectory` now queries `--get-all` before `--add` so duplicate entries don't accumulate in `~/.gitconfig` on repeated dubious-ownership recoveries.
- `isBinaryBuffer` and `countFileLines` replace byte-by-byte null scans with `Buffer.indexOf` on a subarray view, moving from V8 byte-by-byte indexing to a native C++ scan.

Resolves #7047

## Changes
- **`electron/ipc/handlers/git-write.ts`:** Query existing `safe.directory` entries via `--get-all` and skip `--add` when the canonicalized path is already present.
- **`electron/services/GitService.ts`:** `isBinaryBuffer` uses `Buffer.indexOf(0)` on a bounded subarray instead of a `for` loop.
- **`electron/utils/git.ts`:** `countFileLines` binary check uses the same `Buffer.indexOf` pattern.
- **Tests:** Expanded test coverage for the dedupe logic, binary detection, and line-count paths.

## Testing
- Unit tests pass for `handleMarkSafeDirectory`, `isBinaryBuffer`, and `countFileLines`.
- `npx eslint` and `npx prettier` clean on all changed files.