### PR TITLE
fix(workspace-client): route cancelContext to owning host, dedup limit toasts, drop dead casts

### DIFF
--- a/electron/services/WorkspaceHostProcess.ts
+++ b/electron/services/WorkspaceHostProcess.ts
@@ -676,6 +676,8 @@ export class WorkspaceHostProcess extends EventEmitter {
       case "issue-detected":
       case "issue-not-found":
       case "copytree:progress":
+      case "inotify-limit-reached":
+      case "emfile-limit-reached":
         this.emit("host-event", event);
         break;
 

--- a/electron/services/__tests__/WorkspaceHostProcess.test.ts
+++ b/electron/services/__tests__/WorkspaceHostProcess.test.ts
@@ -182,4 +182,42 @@ describe("WorkspaceHostProcess", () => {
 
     host.dispose();
   });
+
+  it("routes inotify-limit-reached as host-event (spontaneous event)", async () => {
+    const { WorkspaceHostProcess } = await loadModule();
+    const host = new WorkspaceHostProcess("/tmp/project", {
+      maxRestartAttempts: 3,
+      healthCheckIntervalMs: 30000,
+    } as any);
+    host.waitForReady().catch(() => {});
+
+    const onHostEvent = vi.fn();
+    host.on("host-event", onHostEvent);
+
+    const child = mockChildren[0] as MockUtilityChild;
+    child.emit("message", { type: "inotify-limit-reached" });
+
+    expect(onHostEvent).toHaveBeenCalledWith({ type: "inotify-limit-reached" });
+
+    host.dispose();
+  });
+
+  it("routes emfile-limit-reached as host-event (spontaneous event)", async () => {
+    const { WorkspaceHostProcess } = await loadModule();
+    const host = new WorkspaceHostProcess("/tmp/project", {
+      maxRestartAttempts: 3,
+      healthCheckIntervalMs: 30000,
+    } as any);
+    host.waitForReady().catch(() => {});
+
+    const onHostEvent = vi.fn();
+    host.on("host-event", onHostEvent);
+
+    const child = mockChildren[0] as MockUtilityChild;
+    child.emit("message", { type: "emfile-limit-reached" });
+
+    expect(onHostEvent).toHaveBeenCalledWith({ type: "emfile-limit-reached" });
+
+    host.dispose();
+  });
 });

--- a/electron/services/workspace-client/WorkspaceCopyTreeClient.ts
+++ b/electron/services/workspace-client/WorkspaceCopyTreeClient.ts
@@ -14,7 +14,7 @@ export class WorkspaceCopyTreeClient {
   private iterateEntries: () => IterableIterator<ProcessEntry>;
 
   readonly copyTreeProgressCallbacks = new Map<string, CopyTreeProgressCallback>();
-  readonly activeCopyTreeOperations = new Map<string, string>();
+  readonly activeCopyTreeOperations = new Map<string, string>(); // operationId → rootPath
 
   constructor(deps: WorkspaceCopyTreeClientDeps) {
     this.resolveHostForPath = deps.resolveHostForPath;
@@ -35,7 +35,7 @@ export class WorkspaceCopyTreeClient {
     if (onProgress) {
       this.copyTreeProgressCallbacks.set(operationId, onProgress);
     }
-    this.activeCopyTreeOperations.set(operationId, requestId);
+    this.activeCopyTreeOperations.set(operationId, rootPath);
 
     try {
       const result = await host.sendWithResponse<{ result: CopyTreeResult }>(
@@ -56,8 +56,10 @@ export class WorkspaceCopyTreeClient {
   }
 
   cancelContext(operationId: string): void {
-    for (const entry of this.iterateEntries()) {
-      entry.host.send({ type: "copytree:cancel", operationId });
+    const rootPath = this.activeCopyTreeOperations.get(operationId);
+    if (rootPath) {
+      const host = this.resolveHostForPath(rootPath);
+      host?.send({ type: "copytree:cancel", operationId });
     }
 
     this.copyTreeProgressCallbacks.delete(operationId);

--- a/electron/services/workspace-client/WorkspaceHostEventRouter.ts
+++ b/electron/services/workspace-client/WorkspaceHostEventRouter.ts
@@ -22,6 +22,8 @@ export class WorkspaceHostEventRouter {
   private copyTreeProgressCallbacks: Map<string, CopyTreeProgressCallback>;
 
   private githubTokenChangeAt = 0;
+  private inotifyLimitToastSent = false;
+  private emfileLimitToastSent = false;
 
   constructor(deps: WorkspaceHostEventRouterDeps) {
     this.emit = deps.emit;
@@ -48,30 +50,7 @@ export class WorkspaceHostEventRouter {
           worktree,
           projectPath: entry.projectPath,
         });
-        events.emit("sys:worktree:update", {
-          id: worktree.id,
-          path: worktree.path,
-          name: worktree.name,
-          branch: worktree.branch,
-          isCurrent: worktree.isCurrent,
-          isMainWorktree: worktree.isMainWorktree,
-          gitDir: worktree.gitDir,
-          summary: worktree.summary,
-          modifiedCount: worktree.modifiedCount,
-          changes: worktree.changes,
-          mood: worktree.mood,
-          lastActivityTimestamp: worktree.lastActivityTimestamp ?? null,
-          createdAt: worktree.createdAt,
-          aiNote: worktree.aiNote,
-          aiNoteTimestamp: worktree.aiNoteTimestamp,
-          issueNumber: worktree.issueNumber,
-          prNumber: worktree.prNumber,
-          prUrl: worktree.prUrl,
-          prState: worktree.prState,
-          worktreeChanges: worktree.worktreeChanges,
-          worktreeId: worktree.worktreeId,
-          timestamp: worktree.timestamp,
-        } as any);
+        events.emit("sys:worktree:update", worktree);
         break;
       }
 
@@ -156,6 +135,8 @@ export class WorkspaceHostEventRouter {
       }
 
       case "inotify-limit-reached": {
+        if (this.inotifyLimitToastSent) break;
+        this.inotifyLimitToastSent = true;
         broadcastToRenderer(CHANNELS.NOTIFICATION_SHOW_TOAST, {
           type: "warning",
           title: "File watching degraded",
@@ -171,6 +152,8 @@ export class WorkspaceHostEventRouter {
       }
 
       case "emfile-limit-reached": {
+        if (this.emfileLimitToastSent) break;
+        this.emfileLimitToastSent = true;
         broadcastToRenderer(CHANNELS.NOTIFICATION_SHOW_TOAST, {
           type: "warning",
           title: "File watching degraded",

--- a/electron/services/workspace-client/__tests__/WorkspaceCopyTreeClient.test.ts
+++ b/electron/services/workspace-client/__tests__/WorkspaceCopyTreeClient.test.ts
@@ -1,0 +1,120 @@
+import { beforeEach, describe, expect, it, vi } from "vitest";
+import { WorkspaceCopyTreeClient } from "../WorkspaceCopyTreeClient.js";
+import type { WorkspaceHostProcess } from "../../WorkspaceHostProcess.js";
+import type { ProcessEntry } from "../types.js";
+
+function makeHost(overrides: Partial<WorkspaceHostProcess> = {}): WorkspaceHostProcess {
+  return {
+    generateRequestId: () => "req-1",
+    send: vi.fn(),
+    sendWithResponse: vi.fn(),
+    dispose: vi.fn(),
+    ...overrides,
+  } as unknown as WorkspaceHostProcess;
+}
+
+function makeEntry(host: WorkspaceHostProcess, projectPath: string): ProcessEntry {
+  return {
+    host,
+    refCount: 1,
+    initPromise: Promise.resolve(),
+    currentReadyPromise: Promise.resolve(),
+    cleanupTimeout: null,
+    windowIds: new Set(),
+    projectPath,
+    directPortViews: new Map(),
+  };
+}
+
+describe("WorkspaceCopyTreeClient", () => {
+  let client: WorkspaceCopyTreeClient;
+  let hostA: WorkspaceHostProcess;
+  let hostB: WorkspaceHostProcess;
+  let entries: ProcessEntry[];
+
+  beforeEach(() => {
+    hostA = makeHost();
+    hostB = makeHost();
+    entries = [makeEntry(hostA, "/project/a"), makeEntry(hostB, "/project/b")];
+
+    client = new WorkspaceCopyTreeClient({
+      resolveHostForPath: (targetPath: string) =>
+        entries.find((e) => targetPath.startsWith(e.projectPath))?.host,
+      iterateEntries: () => entries.values(),
+    });
+  });
+
+  describe("cancelContext", () => {
+    it("routes cancel to the host that owns the operation", () => {
+      client.activeCopyTreeOperations.set("op-1", "/project/a");
+
+      client.cancelContext("op-1");
+
+      expect(hostA.send).toHaveBeenCalledWith({ type: "copytree:cancel", operationId: "op-1" });
+      expect(hostB.send).not.toHaveBeenCalled();
+    });
+
+    it("silently no-ops when operationId is not found", () => {
+      client.cancelContext("nonexistent");
+
+      expect(hostA.send).not.toHaveBeenCalled();
+      expect(hostB.send).not.toHaveBeenCalled();
+    });
+
+    it("cleans up both maps after cancel", () => {
+      client.copyTreeProgressCallbacks.set("op-2", vi.fn());
+      client.activeCopyTreeOperations.set("op-2", "/project/a");
+
+      client.cancelContext("op-2");
+
+      expect(client.activeCopyTreeOperations.has("op-2")).toBe(false);
+      expect(client.copyTreeProgressCallbacks.has("op-2")).toBe(false);
+    });
+
+    it("silently no-ops when rootPath is set but host no longer resolves", () => {
+      client.activeCopyTreeOperations.set("op-3", "/nonexistent");
+
+      expect(() => client.cancelContext("op-3")).not.toThrow();
+      expect(hostA.send).not.toHaveBeenCalled();
+      expect(hostB.send).not.toHaveBeenCalled();
+    });
+  });
+
+  describe("cancelAllContext", () => {
+    it("broadcasts cancel to all hosts for every active operation", () => {
+      client.activeCopyTreeOperations.set("op-1", "/project/a");
+      client.activeCopyTreeOperations.set("op-2", "/project/b");
+
+      client.cancelAllContext();
+
+      expect(hostA.send).toHaveBeenCalledWith({ type: "copytree:cancel", operationId: "op-1" });
+      expect(hostA.send).toHaveBeenCalledWith({ type: "copytree:cancel", operationId: "op-2" });
+      expect(hostB.send).toHaveBeenCalledWith({ type: "copytree:cancel", operationId: "op-1" });
+      expect(hostB.send).toHaveBeenCalledWith({ type: "copytree:cancel", operationId: "op-2" });
+    });
+
+    it("clears both maps", () => {
+      const cb = vi.fn();
+      client.copyTreeProgressCallbacks.set("op-1", cb);
+      client.activeCopyTreeOperations.set("op-1", "/project/a");
+
+      client.cancelAllContext();
+
+      expect(client.activeCopyTreeOperations.size).toBe(0);
+      expect(client.copyTreeProgressCallbacks.size).toBe(0);
+    });
+  });
+
+  describe("dispose", () => {
+    it("clears both maps", () => {
+      const cb = vi.fn();
+      client.copyTreeProgressCallbacks.set("op-1", cb);
+      client.activeCopyTreeOperations.set("op-1", "/project/a");
+
+      client.dispose();
+
+      expect(client.activeCopyTreeOperations.size).toBe(0);
+      expect(client.copyTreeProgressCallbacks.size).toBe(0);
+    });
+  });
+});

--- a/electron/services/workspace-client/__tests__/WorkspaceHostEventRouter.test.ts
+++ b/electron/services/workspace-client/__tests__/WorkspaceHostEventRouter.test.ts
@@ -38,7 +38,9 @@ function makeEntry(overrides: Partial<ProcessEntry> = {}): ProcessEntry {
   };
 }
 
-function makeWorktreeUpdateEvent(overrides: Record<string, unknown> = {}): WorkspaceHostEvent {
+function makeWorktreeUpdateEvent(
+  overrides: Record<string, unknown> = {}
+): Extract<WorkspaceHostEvent, { type: "worktree-update" }> {
   return {
     type: "worktree-update",
     worktree: {

--- a/electron/services/workspace-client/__tests__/WorkspaceHostEventRouter.test.ts
+++ b/electron/services/workspace-client/__tests__/WorkspaceHostEventRouter.test.ts
@@ -1,0 +1,145 @@
+import { beforeEach, describe, expect, it, vi } from "vitest";
+import { WorkspaceHostEventRouter } from "../WorkspaceHostEventRouter.js";
+import type { WorkspaceHostEvent } from "../../../../shared/types/workspace-host.js";
+import type { ProcessEntry, CopyTreeProgressCallback } from "../types.js";
+import type { WorkspaceHostProcess } from "../../WorkspaceHostProcess.js";
+
+vi.mock("../../../ipc/utils.js", () => ({
+  broadcastToRenderer: vi.fn(),
+}));
+
+vi.mock("../../events.js", () => ({
+  events: { emit: vi.fn() },
+}));
+
+vi.mock("../../github/index.js", () => ({
+  gitHubRateLimitService: { applyRemoteState: vi.fn() },
+}));
+
+import { broadcastToRenderer } from "../../../ipc/utils.js";
+import { events } from "../../events.js";
+
+function makeEntry(overrides: Partial<ProcessEntry> = {}): ProcessEntry {
+  return {
+    host: {
+      generateRequestId: () => "r",
+      send: vi.fn(),
+      sendWithResponse: vi.fn(),
+      dispose: vi.fn(),
+    } as unknown as WorkspaceHostProcess,
+    refCount: 1,
+    initPromise: Promise.resolve(),
+    currentReadyPromise: Promise.resolve(),
+    cleanupTimeout: null,
+    windowIds: new Set(),
+    projectPath: "/project/test",
+    directPortViews: new Map(),
+    ...overrides,
+  };
+}
+
+function makeWorktreeUpdateEvent(overrides: Record<string, unknown> = {}): WorkspaceHostEvent {
+  return {
+    type: "worktree-update",
+    worktree: {
+      id: "wt-1",
+      path: "/project/test",
+      name: "test-worktree",
+      isCurrent: true,
+      worktreeId: "wt-1",
+      ...overrides,
+    },
+  };
+}
+
+describe("WorkspaceHostEventRouter", () => {
+  let router: WorkspaceHostEventRouter;
+  let copyTreeCallbacks: Map<string, CopyTreeProgressCallback>;
+
+  beforeEach(() => {
+    vi.clearAllMocks();
+    copyTreeCallbacks = new Map();
+    router = new WorkspaceHostEventRouter({
+      emit: vi.fn(),
+      worktreePathToProject: new Map(),
+      copyTreeProgressCallbacks: copyTreeCallbacks,
+    });
+  });
+
+  describe("inotify-limit-reached dedup", () => {
+    it("fires toast on first emit", () => {
+      const entry = makeEntry();
+      router.routeHostEvent(entry, { type: "inotify-limit-reached" });
+
+      expect(broadcastToRenderer).toHaveBeenCalledTimes(1);
+      expect(broadcastToRenderer).toHaveBeenCalledWith(
+        expect.any(String),
+        expect.objectContaining({ type: "warning" })
+      );
+    });
+
+    it("suppresses duplicate toasts from subsequent hosts", () => {
+      const entryA = makeEntry({ projectPath: "/a" });
+      const entryB = makeEntry({ projectPath: "/b" });
+
+      router.routeHostEvent(entryA, { type: "inotify-limit-reached" });
+      router.routeHostEvent(entryB, { type: "inotify-limit-reached" });
+
+      expect(broadcastToRenderer).toHaveBeenCalledTimes(1);
+    });
+
+    it("suppresses duplicate toasts from the same host", () => {
+      const entry = makeEntry();
+
+      router.routeHostEvent(entry, { type: "inotify-limit-reached" });
+      router.routeHostEvent(entry, { type: "inotify-limit-reached" });
+
+      expect(broadcastToRenderer).toHaveBeenCalledTimes(1);
+    });
+  });
+
+  describe("emfile-limit-reached dedup", () => {
+    it("fires toast on first emit", () => {
+      const entry = makeEntry();
+      router.routeHostEvent(entry, { type: "emfile-limit-reached" });
+
+      expect(broadcastToRenderer).toHaveBeenCalledTimes(1);
+      expect(broadcastToRenderer).toHaveBeenCalledWith(
+        expect.any(String),
+        expect.objectContaining({ type: "warning" })
+      );
+    });
+
+    it("suppresses duplicate toasts from subsequent hosts", () => {
+      const entryA = makeEntry({ projectPath: "/a" });
+      const entryB = makeEntry({ projectPath: "/b" });
+
+      router.routeHostEvent(entryA, { type: "emfile-limit-reached" });
+      router.routeHostEvent(entryB, { type: "emfile-limit-reached" });
+
+      expect(broadcastToRenderer).toHaveBeenCalledTimes(1);
+    });
+  });
+
+  describe("inotify and emfile are independent", () => {
+    it("allows both limit types to fire independently", () => {
+      const entry = makeEntry();
+
+      router.routeHostEvent(entry, { type: "inotify-limit-reached" });
+      router.routeHostEvent(entry, { type: "emfile-limit-reached" });
+
+      expect(broadcastToRenderer).toHaveBeenCalledTimes(2);
+    });
+  });
+
+  describe("sys:worktree:update", () => {
+    it("emits the full worktree object directly", () => {
+      const entry = makeEntry();
+      const event = makeWorktreeUpdateEvent({ branch: "feature/foo", prTitle: "My PR" });
+
+      router.routeHostEvent(entry, event);
+
+      expect(events.emit).toHaveBeenCalledWith("sys:worktree:update", event.worktree);
+    });
+  });
+});

--- a/electron/workspace-host/WorkspaceService.ts
+++ b/electron/workspace-host/WorkspaceService.ts
@@ -630,7 +630,7 @@ export class WorkspaceService {
       type: "worktree-update",
       worktree: snapshot,
     });
-    events.emit("sys:worktree:update", snapshot as any);
+    events.emit("sys:worktree:update", snapshot);
   }
 
   private emitUpdate(monitor: WorktreeMonitor): void {
@@ -639,7 +639,7 @@ export class WorkspaceService {
       type: "worktree-update",
       worktree: snapshot,
     });
-    events.emit("sys:worktree:update", snapshot as any);
+    events.emit("sys:worktree:update", snapshot);
   }
 
   /**


### PR DESCRIPTION
## Summary
- `cancelContext` was broadcasting to every host via `iterateEntries` instead of routing to the one that owns the operation. The `activeCopyTreeOperations` map already held the `rootPath` as a dead value -- repurposed it for host resolution.
- `inotify-limit-reached` and `emfile-limit-reached` toasts had no dedup. Every host hitting the file-descriptor ceiling fired its own toast back-to-back. Added per-router sentinel guards, following the same pattern already used for `github-rate-limit-changed`.
- Three identical `as any` casts on `sys:worktree:update` after the `WorktreeState` type had already been aligned. Dropped all three.

Resolves #7039

## Changes
- `WorkspaceCopyTreeClient`: store `rootPath` instead of `requestId` in `activeCopyTreeOperations`; route `cancelContext` through `resolveHostForPath`; preserve broadcast in `cancelAllContext`
- `WorkspaceHostEventRouter`: add `inotifyLimitToastSent` / `emfileLimitToastSent` boolean guards, drop `as any` cast on `sys:worktree:update` emit, remove dead inlined object spread
- `WorkspaceService`: drop two `as any` casts on `sys:worktree:update`
- `WorkspaceHostProcess`: forward `inotify-limit-reached` / `emfile-limit-reached` events through `processHostEvent`
- Tests: `cancelContext` routing coverage, dedup guard coverage, regression coverage for `processHostEvent` forwarding

## Testing
- Unit tests added for `WorkspaceCopyTreeClient.cancelContext` routing and `cancelAllContext` broadcast behavior
- Unit tests added for `WorkspaceHostEventRouter` dedup guards (second fire is suppressed)
- Unit tests added for `WorkspaceHostProcess` event forwarding of `inotify-limit-reached` / `emfile-limit-reached`