### PR TITLE
fix(global-file-store): tighten getRecipes read path and quarantine

### DIFF
--- a/electron/services/GlobalFileStore.ts
+++ b/electron/services/GlobalFileStore.ts
@@ -1,6 +1,5 @@
 import type { TerminalRecipe } from "../types/index.js";
 import fs from "fs/promises";
-import { existsSync } from "fs";
 import path from "path";
 import { resilientRename, resilientAtomicWriteFile } from "../utils/fs.js";
 import { TerminalRecipeSchema, filterValidTerminalEntries } from "../schemas/ipc.js";
@@ -15,24 +14,23 @@ export class GlobalFileStore {
   }
 
   async getRecipes(): Promise<TerminalRecipe[]> {
-    if (!existsSync(this.recipesPath)) {
-      return [];
-    }
-
     try {
       const content = await fs.readFile(this.recipesPath, "utf-8");
       const parsed = JSON.parse(content);
 
       if (!Array.isArray(parsed)) {
-        console.warn("[GlobalFileStore] Invalid recipes format, expected array");
-        return [];
+        throw new Error("recipes is not an array");
       }
 
       return filterValidTerminalEntries(parsed, TerminalRecipeSchema, "GlobalFileStore");
     } catch (error) {
+      if (error instanceof Error && "code" in error && error.code === "ENOENT") {
+        return [];
+      }
       console.error("[GlobalFileStore] Failed to load recipes:", error);
       try {
-        const quarantinePath = `${this.recipesPath}.corrupted.${Date.now()}`;
+        const suffix = `${Date.now()}-${Math.random().toString(36).slice(2, 8)}`;
+        const quarantinePath = `${this.recipesPath}.corrupted.${suffix}`;
         await resilientRename(this.recipesPath, quarantinePath);
         console.warn(`[GlobalFileStore] Corrupted recipes file moved to ${quarantinePath}`);
       } catch {

--- a/electron/services/__tests__/GlobalFileStore.adversarial.test.ts
+++ b/electron/services/__tests__/GlobalFileStore.adversarial.test.ts
@@ -149,9 +149,7 @@ describe("GlobalFileStore adversarial", () => {
   });
 
   it("getRecipes returns [] when file doesn't exist", async () => {
-    fsMock.readFile.mockRejectedValue(
-      Object.assign(new Error("ENOENT"), { code: "ENOENT" })
-    );
+    fsMock.readFile.mockRejectedValue(Object.assign(new Error("ENOENT"), { code: "ENOENT" }));
     const result = await store.getRecipes();
     expect(result).toEqual([]);
     expect(utilsMock.resilientRename).not.toHaveBeenCalled();
@@ -163,10 +161,7 @@ describe("GlobalFileStore adversarial", () => {
 
     const result = await store.getRecipes();
     expect(result).toEqual([]);
-    expect(utilsMock.resilientRename).toHaveBeenCalledWith(
-      RECIPES_FILE,
-      expect.any(String)
-    );
+    expect(utilsMock.resilientRename).toHaveBeenCalledWith(RECIPES_FILE, expect.any(String));
   });
 
   it("addRecipe loads + appends + saves without mutating the loaded array for caller", async () => {

--- a/electron/services/__tests__/GlobalFileStore.adversarial.test.ts
+++ b/electron/services/__tests__/GlobalFileStore.adversarial.test.ts
@@ -72,6 +72,7 @@ describe("GlobalFileStore adversarial", () => {
 
     const result = await store.getRecipes();
     expect(result.map((r) => r.id)).toEqual(["r1", "r3"]);
+    expect(utilsMock.resilientRename).not.toHaveBeenCalled();
   });
 
   it("saveRecipes ENOENT triggers mkdir + retry", async () => {
@@ -162,6 +163,10 @@ describe("GlobalFileStore adversarial", () => {
 
     const result = await store.getRecipes();
     expect(result).toEqual([]);
+    expect(utilsMock.resilientRename).toHaveBeenCalledWith(
+      RECIPES_FILE,
+      expect.any(String)
+    );
   });
 
   it("addRecipe loads + appends + saves without mutating the loaded array for caller", async () => {

--- a/electron/services/__tests__/GlobalFileStore.adversarial.test.ts
+++ b/electron/services/__tests__/GlobalFileStore.adversarial.test.ts
@@ -6,15 +6,12 @@ const fsMock = vi.hoisted(() => ({
   mkdir: vi.fn(),
 }));
 
-const fsSyncMock = vi.hoisted(() => ({ existsSync: vi.fn() }));
-
 const utilsMock = vi.hoisted(() => ({
   resilientRename: vi.fn(),
   resilientAtomicWriteFile: vi.fn(),
 }));
 
 vi.mock("fs/promises", () => ({ default: fsMock, ...fsMock }));
-vi.mock("fs", () => ({ ...fsSyncMock }));
 vi.mock("../../utils/fs.js", () => utilsMock);
 
 import { GlobalFileStore } from "../GlobalFileStore.js";
@@ -38,31 +35,30 @@ describe("GlobalFileStore adversarial", () => {
   });
 
   it("corrupted JSON returns [] and quarantines the file", async () => {
-    fsSyncMock.existsSync.mockReturnValue(true);
     fsMock.readFile.mockResolvedValue("{ not json");
 
     const result = await store.getRecipes();
 
     expect(result).toEqual([]);
-    const escapedFile = RECIPES_FILE.replace(/[.*+?^${}()|[\]\\]/g, "\\$&");
     expect(utilsMock.resilientRename).toHaveBeenCalledWith(
       RECIPES_FILE,
-      expect.stringMatching(new RegExp(`^${escapedFile}\\.corrupted\\.\\d+$`))
+      expect.stringMatching(/^\/tmp\/daintree-global\/recipes\.json\.corrupted\.\d+-[a-z0-9]{6}$/)
     );
   });
 
-  it("non-array JSON returns [] without quarantining", async () => {
-    fsSyncMock.existsSync.mockReturnValue(true);
+  it("non-array JSON returns [] and quarantines the file", async () => {
     fsMock.readFile.mockResolvedValue(JSON.stringify({ wrong: "shape" }));
 
     const result = await store.getRecipes();
 
     expect(result).toEqual([]);
-    expect(utilsMock.resilientRename).not.toHaveBeenCalled();
+    expect(utilsMock.resilientRename).toHaveBeenCalledWith(
+      RECIPES_FILE,
+      expect.stringMatching(/^\/tmp\/daintree-global\/recipes\.json\.corrupted\.\d+-[a-z0-9]{6}$/)
+    );
   });
 
   it("filters invalid entries but keeps valid ones", async () => {
-    fsSyncMock.existsSync.mockReturnValue(true);
     fsMock.readFile.mockResolvedValue(
       JSON.stringify([
         { id: "r1", name: "valid", terminals: [], createdAt: 1000 },
@@ -99,7 +95,6 @@ describe("GlobalFileStore adversarial", () => {
   });
 
   it("updateRecipe on missing id throws and does not write", async () => {
-    fsSyncMock.existsSync.mockReturnValue(true);
     fsMock.readFile.mockResolvedValue("[]");
 
     await expect(store.updateRecipe("missing", { name: "x" })).rejects.toThrow(/not found/);
@@ -107,7 +102,6 @@ describe("GlobalFileStore adversarial", () => {
   });
 
   it("updateRecipe does not let the patch overwrite id/projectId/createdAt", async () => {
-    fsSyncMock.existsSync.mockReturnValue(true);
     fsMock.readFile.mockResolvedValue(
       JSON.stringify([
         {
@@ -138,7 +132,6 @@ describe("GlobalFileStore adversarial", () => {
   });
 
   it("deleteRecipe removes only the matching entry", async () => {
-    fsSyncMock.existsSync.mockReturnValue(true);
     fsMock.readFile.mockResolvedValue(
       JSON.stringify([
         { id: "keep", name: "k", terminals: [], createdAt: 1000 },
@@ -154,15 +147,16 @@ describe("GlobalFileStore adversarial", () => {
     expect(payload.map((r) => r.id)).toEqual(["keep"]);
   });
 
-  it("getRecipes returns [] when file doesn't exist (no readFile attempt)", async () => {
-    fsSyncMock.existsSync.mockReturnValue(false);
+  it("getRecipes returns [] when file doesn't exist", async () => {
+    fsMock.readFile.mockRejectedValue(
+      Object.assign(new Error("ENOENT"), { code: "ENOENT" })
+    );
     const result = await store.getRecipes();
     expect(result).toEqual([]);
-    expect(fsMock.readFile).not.toHaveBeenCalled();
+    expect(utilsMock.resilientRename).not.toHaveBeenCalled();
   });
 
   it("quarantine rename failure is soft — getRecipes still returns []", async () => {
-    fsSyncMock.existsSync.mockReturnValue(true);
     fsMock.readFile.mockResolvedValue("bad json");
     utilsMock.resilientRename.mockRejectedValueOnce(new Error("EBUSY"));
 
@@ -171,7 +165,6 @@ describe("GlobalFileStore adversarial", () => {
   });
 
   it("addRecipe loads + appends + saves without mutating the loaded array for caller", async () => {
-    fsSyncMock.existsSync.mockReturnValue(true);
     fsMock.readFile.mockResolvedValue(JSON.stringify([]));
 
     await store.addRecipe({


### PR DESCRIPTION
## Summary

- Drops the sync `existsSync` pre-check; `ENOENT` from `readFile` is now the empty-state path, closing the TOCTOU window
- Non-array JSON now quarantines rather than warn-looping on every read, matching the existing parse-failure path
- Quarantine filenames use a `${Date.now()}-${random}` suffix (matching the idiom in `electron/utils/fs.ts:46`) to avoid millisecond collisions

Resolves #7141

## Changes

- `electron/services/GlobalFileStore.ts`: removed sync `existsSync` call; `ENOENT` early-returns `[]`; non-array branch now throws to trigger quarantine; quarantine suffix is collision-resistant
- `electron/services/__tests__/GlobalFileStore.adversarial.test.ts`: removed `fsSyncMock` / `vi.mock("fs")`; migrated missing-file test to `readFile` rejecting with `{ code: "ENOENT" }`; inverted non-array assertion to expect quarantine; updated suffix regex; added explicit quarantine/no-quarantine assertions

## Testing

11/11 adversarial tests pass. Typecheck, lint, and format all green.