### PR TITLE
fix(detector): polish RunCommandDetector for Bun 1.2 lockfile and Taskfile defaults

### DIFF
--- a/electron/services/RunCommandDetector.ts
+++ b/electron/services/RunCommandDetector.ts
@@ -6,6 +6,16 @@ import type { RunCommand } from "../types/index.js";
 import { Cache } from "../utils/cache.js";
 
 const RESERVED_SCRIPT_NAMES = new Set(["__proto__", "constructor", "prototype"]);
+const COMPOSER_LIFECYCLE_SCRIPTS = new Set([
+  "pre-install-cmd",
+  "post-install-cmd",
+  "pre-update-cmd",
+  "post-update-cmd",
+  "post-autoload-dump",
+  "pre-autoload-dump",
+  "post-root-package-install",
+  "post-create-project-cmd",
+]);
 const SAFE_SCRIPT_NAME_PATTERN = /^[A-Za-z0-9][A-Za-z0-9:_./-]*$/;
 
 function isSafeScriptName(name: string): boolean {
@@ -50,7 +60,9 @@ export class RunCommandDetector {
       if (!pkg.scripts || typeof pkg.scripts !== "object") return [];
 
       let runner = "npm run";
-      if (existsSync(path.join(root, "bun.lockb"))) {
+      if (existsSync(path.join(root, "bun.lock"))) {
+        runner = "bun run";
+      } else if (existsSync(path.join(root, "bun.lockb"))) {
         runner = "bun run";
       } else if (existsSync(path.join(root, "pnpm-lock.yaml"))) {
         runner = "pnpm run";
@@ -178,7 +190,16 @@ export class RunCommandDetector {
   }
 
   private async detectTaskfile(root: string): Promise<RunCommand[]> {
-    const variants = ["Taskfile.yml", "taskfile.yml", "Taskfile.yaml", "taskfile.yaml"];
+    const variants = [
+      "Taskfile.yml",
+      "taskfile.yml",
+      "Taskfile.yaml",
+      "taskfile.yaml",
+      "Taskfile.dist.yml",
+      "taskfile.dist.yml",
+      "Taskfile.dist.yaml",
+      "taskfile.dist.yaml",
+    ];
     let taskfilePath: string | null = null;
     for (const name of variants) {
       const candidate = path.join(root, name);
@@ -251,17 +272,7 @@ export class RunCommandDetector {
 
       return Object.keys(json.scripts)
         .filter((name) => {
-          const lifecycleScripts = [
-            "pre-install-cmd",
-            "post-install-cmd",
-            "pre-update-cmd",
-            "post-update-cmd",
-            "post-autoload-dump",
-            "pre-autoload-dump",
-            "post-root-package-install",
-            "post-create-project-cmd",
-          ];
-          if (lifecycleScripts.includes(name)) {
+          if (COMPOSER_LIFECYCLE_SCRIPTS.has(name)) {
             return false;
           }
           if (!isSafeScriptName(name)) {

--- a/electron/services/__tests__/RunCommandDetector.test.ts
+++ b/electron/services/__tests__/RunCommandDetector.test.ts
@@ -71,6 +71,23 @@ describe("RunCommandDetector", () => {
     ]);
   });
 
+  it("prefers bun.lock over pnpm-lock.yaml when both exist", async () => {
+    await fs.writeFile(
+      path.join(tempDir, "package.json"),
+      JSON.stringify({ name: "test", scripts: { dev: "vite" } }),
+      "utf-8"
+    );
+    await fs.writeFile(path.join(tempDir, "bun.lock"), "", "utf-8");
+    await fs.writeFile(path.join(tempDir, "pnpm-lock.yaml"), "", "utf-8");
+
+    const commands = await detector.detect(tempDir);
+    const npmCommands = commands.filter((cmd) => cmd.id.startsWith("npm-"));
+
+    expect(npmCommands).toEqual([
+      expect.objectContaining({ id: "npm-dev", command: "bun run dev" }),
+    ]);
+  });
+
   it("filters composer scripts with unsafe names", async () => {
     const scripts: Record<string, string> = {
       test: "phpunit",
@@ -450,6 +467,38 @@ describe("RunCommandDetector", () => {
           description: "Run CI checks",
         }),
       ]);
+    });
+
+    it("prefers Taskfile.yml over Taskfile.dist.yml when both exist", async () => {
+      await fs.writeFile(
+        path.join(tempDir, "Taskfile.yml"),
+        [
+          "version: '3'",
+          "tasks:",
+          "  build:",
+          "    desc: Local build",
+          "    cmds:",
+          "      - go build .",
+        ].join("\n"),
+        "utf-8"
+      );
+      await fs.writeFile(
+        path.join(tempDir, "Taskfile.dist.yml"),
+        [
+          "version: '3'",
+          "tasks:",
+          "  ci:",
+          "    desc: CI checks",
+          "    cmds:",
+          "      - go test ./...",
+        ].join("\n"),
+        "utf-8"
+      );
+
+      const commands = await detector.detect(tempDir);
+      const taskCommands = commands.filter((cmd) => cmd.id.startsWith("task-"));
+
+      expect(taskCommands.map((cmd) => cmd.id)).toEqual(["task-build"]);
     });
 
     it("returns empty for empty tasks object", async () => {

--- a/electron/services/__tests__/RunCommandDetector.test.ts
+++ b/electron/services/__tests__/RunCommandDetector.test.ts
@@ -38,6 +38,39 @@ describe("RunCommandDetector", () => {
     expect(npmCommands.some((cmd) => cmd.command.includes(";"))).toBe(false);
   });
 
+  it("uses bun runner when bun.lock (text format) is present", async () => {
+    await fs.writeFile(
+      path.join(tempDir, "package.json"),
+      JSON.stringify({ name: "test", scripts: { dev: "vite" } }),
+      "utf-8"
+    );
+    await fs.writeFile(path.join(tempDir, "bun.lock"), "", "utf-8");
+
+    const commands = await detector.detect(tempDir);
+    const npmCommands = commands.filter((cmd) => cmd.id.startsWith("npm-"));
+
+    expect(npmCommands).toEqual([
+      expect.objectContaining({ id: "npm-dev", command: "bun run dev" }),
+    ]);
+  });
+
+  it("prefers bun.lock over bun.lockb when both exist", async () => {
+    await fs.writeFile(
+      path.join(tempDir, "package.json"),
+      JSON.stringify({ name: "test", scripts: { dev: "vite" } }),
+      "utf-8"
+    );
+    await fs.writeFile(path.join(tempDir, "bun.lock"), "", "utf-8");
+    await fs.writeFile(path.join(tempDir, "bun.lockb"), "", "utf-8");
+
+    const commands = await detector.detect(tempDir);
+    const npmCommands = commands.filter((cmd) => cmd.id.startsWith("npm-"));
+
+    expect(npmCommands).toEqual([
+      expect.objectContaining({ id: "npm-dev", command: "bun run dev" }),
+    ]);
+  });
+
   it("filters composer scripts with unsafe names", async () => {
     const scripts: Record<string, string> = {
       test: "phpunit",
@@ -389,6 +422,32 @@ describe("RunCommandDetector", () => {
           id: "task-lint",
           command: "task lint",
           description: "Run linter",
+        }),
+      ]);
+    });
+
+    it("detects Taskfile.dist.yml variant", async () => {
+      await fs.writeFile(
+        path.join(tempDir, "Taskfile.dist.yml"),
+        [
+          "version: '3'",
+          "tasks:",
+          "  ci:",
+          "    desc: Run CI checks",
+          "    cmds:",
+          "      - go test ./...",
+        ].join("\n"),
+        "utf-8"
+      );
+
+      const commands = await detector.detect(tempDir);
+      const taskCommands = commands.filter((cmd) => cmd.id.startsWith("task-"));
+
+      expect(taskCommands).toEqual([
+        expect.objectContaining({
+          id: "task-ci",
+          command: "task ci",
+          description: "Run CI checks",
         }),
       ]);
     });


### PR DESCRIPTION
## Summary

- `bun.lock` (the text-format default since Bun 1.2) is now detected in `RunCommandDetector` before `bun.lockb`, so modern Bun projects get `bun run` instead of silently falling through to `npm run`
- `Taskfile.dist.yml` and `Taskfile.dist.yaml` added in priority order — these are Task's canonical shared/checked-in variants and were missing entirely
- Composer lifecycle script names hoisted from a per-iteration array literal to a module-level `Set<string>`, matching the existing `RESERVED_SCRIPT_NAMES` pattern and turning the membership check into an O(1) `Set.has()`

Resolves #7136

## Changes

- `electron/services/RunCommandDetector.ts` — `bun.lock` detection before `bun.lockb`; `Taskfile.dist.{yml,yaml}` in the variants list; `COMPOSER_LIFECYCLE_SCRIPT_NAMES` hoisted to module level
- `electron/services/__tests__/RunCommandDetector.test.ts` — 5 new tests: `bun.lock` detection, `bun.lock` over `bun.lockb` priority, `bun.lock` over `pnpm-lock.yaml` priority, `Taskfile.dist.yml` detection, `Taskfile.yml` over `Taskfile.dist.yml` priority

## Testing

All 42 unit tests pass. Typecheck, lint, and format clean.