### PR TITLE
fix(scratch): tombstone-first delete ordering for scratch removal

### DIFF
--- a/electron/services/ScratchCleanupService.ts
+++ b/electron/services/ScratchCleanupService.ts
@@ -55,17 +55,19 @@ export async function runScratchCleanup(
 
   const cutoff = now - SCRATCH_CLEANUP_TTL_MS;
   const currentScratchId = store.getCurrentScratchId();
+  // Only protect the live current scratch — a tombstoned row whose ID still
+  // matches `currentScratchId` is the exact crash-recovery case (tombstone
+  // succeeded, `clearCurrentScratch` didn't), and the sweep must finish it.
   const candidates = store
     .getStaleScratchCandidates(cutoff)
-    .filter((row) => row.id !== currentScratchId);
+    .filter((row) => !(row.id === currentScratchId && row.deletedAt == null));
   result.candidates = candidates.length;
 
   for (const row of candidates) {
-    // Lesson #3721: never treat a falsy `lastOpened` as maximally stale —
-    // skip rather than tombstone. The schema declares NOT NULL, but a
-    // hand-edited DB or a future migration could relax that, and we'd rather
-    // skip a row than nuke it on bad data.
-    if (!row.lastOpened) continue;
+    // Lesson #3721: never treat a falsy `lastOpened` on a live row as
+    // maximally stale — skip rather than tombstone. Tombstoned rows aren't
+    // subject to this check; they've already been chosen for deletion.
+    if (!row.lastOpened && row.deletedAt == null) continue;
 
     if (row.deletedAt == null) {
       try {

--- a/electron/services/ScratchCleanupService.ts
+++ b/electron/services/ScratchCleanupService.ts
@@ -3,16 +3,16 @@
  *
  * A scratch whose `lastOpened` predates `now - SCRATCH_CLEANUP_TTL_MS` has
  * its filesystem directory removed and its DB row tombstoned (`deleted_at`
- * set). Tombstoned rows are filtered out of every renderer-facing query in
- * `ScratchStore`, so the renderer never sees them again. The current scratch
- * (per `app_state.currentScratchId`) is always excluded so an actively-open
+ * set), then hard-deleted once `fs.rm` succeeds. Tombstoned rows are
+ * filtered out of every renderer-facing query in `ScratchStore`, so the
+ * renderer never sees them again. The current scratch (per
+ * `app_state.currentScratchId`) is always excluded so an actively-open
  * workspace can never disappear under the user.
  *
- * Tombstoning is one-way — orphaned directories left by a failed `fs.rm`
- * stay on disk (logged, not retried). Accepting that orphan rate is
- * deliberate: the alternative (re-sweeping tombstoned rows) would require a
- * second query and could surprise users who manually re-create folders at
- * the same path.
+ * The sweep also retries already-tombstoned rows whose directory is still
+ * present — this is the recovery path for a `removeScratch` that crashed
+ * between tombstone and `fs.rm`. The row is hard-deleted once the directory
+ * is gone.
  *
  * Mirrors the fire-and-forget pattern of `initializeTrashedPidCleanup`:
  * called once at app boot, never awaited, never throws — a cleanup failure
@@ -27,9 +27,9 @@ import { SCRATCH_CLEANUP_TTL_MS } from "../../shared/config/scratchCleanup.js";
 export { SCRATCH_CLEANUP_TTL_MS as SCRATCH_TTL_MS } from "../../shared/config/scratchCleanup.js";
 
 export interface ScratchCleanupResult {
-  /** Total rows examined as candidates (predate cutoff, not yet tombstoned). */
+  /** Total rows examined as candidates (live-stale plus already-tombstoned). */
   candidates: number;
-  /** Rows actually tombstoned during this sweep. */
+  /** Rows actually tombstoned during this sweep (excludes pre-tombstoned rows). */
   tombstoned: number;
   /** Directories successfully removed (or already absent). */
   directoriesRemoved: number;
@@ -67,34 +67,35 @@ export async function runScratchCleanup(
     // skip a row than nuke it on bad data.
     if (!row.lastOpened) continue;
 
+    if (row.deletedAt == null) {
+      try {
+        store.tombstoneScratch(row.id, now);
+        result.tombstoned += 1;
+      } catch (error) {
+        logError(`[ScratchCleanup] Failed to tombstone scratch ${row.id}`, error);
+        continue;
+      }
+    }
+
+    if (row.path && existsSync(row.path)) {
+      try {
+        await fs.rm(row.path, { recursive: true, force: true });
+      } catch (error) {
+        result.directoriesFailed += 1;
+        logError(`[ScratchCleanup] Failed to remove scratch directory ${row.path}`, error);
+        continue;
+      }
+    }
+
+    result.directoriesRemoved += 1;
     try {
-      store.tombstoneScratch(row.id, now);
-      result.tombstoned += 1;
+      store.hardDeleteScratch(row.id);
     } catch (error) {
-      logError(`[ScratchCleanup] Failed to tombstone scratch ${row.id}`, error);
-      continue;
-    }
-
-    if (!row.path) {
-      result.directoriesRemoved += 1;
-      continue;
-    }
-
-    if (!existsSync(row.path)) {
-      result.directoriesRemoved += 1;
-      continue;
-    }
-
-    try {
-      await fs.rm(row.path, { recursive: true, force: true });
-      result.directoriesRemoved += 1;
-    } catch (error) {
-      result.directoriesFailed += 1;
-      logError(`[ScratchCleanup] Failed to remove scratch directory ${row.path}`, error);
+      logError(`[ScratchCleanup] Failed to hard-delete scratch ${row.id}`, error);
     }
   }
 
-  if (result.tombstoned > 0 || result.directoriesFailed > 0) {
+  if (result.tombstoned > 0 || result.directoriesRemoved > 0 || result.directoriesFailed > 0) {
     logInfo(
       `[ScratchCleanup] sweep complete: ${result.tombstoned} tombstoned, ` +
         `${result.directoriesRemoved} directories removed, ${result.directoriesFailed} failed`

--- a/electron/services/ScratchStore.ts
+++ b/electron/services/ScratchStore.ts
@@ -1,7 +1,7 @@
 import fs from "fs/promises";
 import { existsSync } from "fs";
 import { randomUUID } from "crypto";
-import { eq, desc, and, isNull, lt } from "drizzle-orm";
+import { eq, desc, and, isNull, isNotNull, lt, or } from "drizzle-orm";
 import type { Scratch } from "../../shared/types/scratch.js";
 import { getSharedDb } from "./persistence/db.js";
 import {
@@ -108,16 +108,22 @@ export class ScratchStore {
   }
 
   /**
-   * Returns raw rows of scratches whose `last_opened` predates the cutoff and
-   * which have not yet been tombstoned. Used by the startup cleanup sweep —
-   * exposes `path` directly so the sweep does not have to re-derive it.
+   * Returns raw rows the cleanup sweep should consider: live rows whose
+   * `last_opened` predates the cutoff, plus any already-tombstoned rows. The
+   * tombstoned set is included so a `removeScratch` that crashed between
+   * tombstone and `fs.rm` is retried on next startup.
    */
   getStaleScratchCandidates(cutoffMs: number): ScratchRow[] {
     const db = getSharedDb();
     return db
       .select()
       .from(scratchesTable)
-      .where(and(lt(scratchesTable.lastOpened, cutoffMs), isNull(scratchesTable.deletedAt)))
+      .where(
+        or(
+          and(lt(scratchesTable.lastOpened, cutoffMs), isNull(scratchesTable.deletedAt)),
+          isNotNull(scratchesTable.deletedAt)
+        )
+      )
       .all();
   }
 
@@ -131,6 +137,19 @@ export class ScratchStore {
     }
     const db = getSharedDb();
     db.update(scratchesTable).set({ deletedAt }).where(eq(scratchesTable.id, scratchId)).run();
+  }
+
+  /**
+   * Removes a scratch row outright. Called only after the on-disk directory
+   * has been confirmed gone — the tombstone is the recovery anchor between
+   * those two steps.
+   */
+  hardDeleteScratch(scratchId: string): void {
+    if (!isValidScratchId(scratchId)) {
+      throw new Error(`Invalid scratch ID: ${scratchId}`);
+    }
+    const db = getSharedDb();
+    db.delete(scratchesTable).where(eq(scratchesTable.id, scratchId)).run();
   }
 
   updateScratch(
@@ -167,8 +186,11 @@ export class ScratchStore {
     if (!isValidScratchId(scratchId)) {
       throw new Error(`Invalid scratch ID: ${scratchId}`);
     }
-    const db = getSharedDb();
-    db.delete(scratchesTable).where(eq(scratchesTable.id, scratchId)).run();
+
+    this.tombstoneScratch(scratchId, Date.now());
+    if (this.getCurrentScratchId() === scratchId) {
+      this.clearCurrentScratch();
+    }
 
     const dir = getScratchDir(this.rootDir(), scratchId);
     if (dir && existsSync(dir)) {
@@ -176,12 +198,11 @@ export class ScratchStore {
         await fs.rm(dir, { recursive: true, force: true });
       } catch (error) {
         logError(`[ScratchStore] Failed to remove scratch directory for ${scratchId}`, error);
+        return;
       }
     }
 
-    if (this.getCurrentScratchId() === scratchId) {
-      this.clearCurrentScratch();
-    }
+    this.hardDeleteScratch(scratchId);
   }
 
   getCurrentScratchId(): string | null {

--- a/electron/services/__tests__/ScratchCleanupService.test.ts
+++ b/electron/services/__tests__/ScratchCleanupService.test.ts
@@ -15,6 +15,7 @@ interface FakeStore {
   currentScratchId: string | null;
   getStaleScratchCandidates: (cutoffMs: number) => ScratchRow[];
   tombstoneScratch: (scratchId: string, deletedAt: number) => void;
+  hardDeleteScratch: (scratchId: string) => void;
   getCurrentScratchId: () => string | null;
 }
 
@@ -23,12 +24,19 @@ function makeStore(rows: ScratchRow[], currentScratchId: string | null = null): 
     rows,
     currentScratchId,
     getStaleScratchCandidates(cutoffMs: number) {
-      return store.rows.filter((r) => r.lastOpened < cutoffMs && r.deletedAt == null);
+      return store.rows.filter(
+        (r) => (r.lastOpened < cutoffMs && r.deletedAt == null) || r.deletedAt != null
+      );
     },
     tombstoneScratch(scratchId: string, deletedAt: number) {
       const r = store.rows.find((x) => x.id === scratchId);
       if (!r) throw new Error(`not found: ${scratchId}`);
       r.deletedAt = deletedAt;
+    },
+    hardDeleteScratch(scratchId: string) {
+      const idx = store.rows.findIndex((x) => x.id === scratchId);
+      if (idx === -1) throw new Error(`not found: ${scratchId}`);
+      store.rows.splice(idx, 1);
     },
     getCurrentScratchId() {
       return store.currentScratchId;
@@ -93,11 +101,11 @@ describe("runScratchCleanup", () => {
 
     expect(result.tombstoned).toBe(1);
     expect(result.directoriesRemoved).toBe(1);
-    expect(store.rows[0]!.deletedAt).toBe(NOW);
+    expect(store.rows).toHaveLength(0);
     await expect(fs.access(dir)).rejects.toBeDefined();
   });
 
-  it("is idempotent — already-tombstoned rows are skipped", async () => {
+  it("hard-deletes already-tombstoned rows whose directory is missing", async () => {
     const store = makeStore([
       row({
         id: "tombstoned",
@@ -112,8 +120,10 @@ describe("runScratchCleanup", () => {
       store as unknown as Parameters<typeof runScratchCleanup>[1]
     );
 
-    expect(result.candidates).toBe(0);
+    expect(result.candidates).toBe(1);
     expect(result.tombstoned).toBe(0);
+    expect(result.directoriesRemoved).toBe(1);
+    expect(store.rows).toHaveLength(0);
   });
 
   it("treats a missing directory as removed (no failure)", async () => {
@@ -184,17 +194,17 @@ describe("runScratchCleanup", () => {
 
     expect(result.tombstoned).toBe(1);
     expect(store.rows.find((r) => r.id === "active")!.deletedAt).toBeNull();
-    expect(store.rows.find((r) => r.id === "other")!.deletedAt).toBe(NOW);
+    expect(store.rows.find((r) => r.id === "other")).toBeUndefined();
     await expect(fs.access(activeDir)).resolves.toBeUndefined();
     await expect(fs.access(otherDir)).rejects.toBeDefined();
   });
 
-  it("does not retry tombstoned rows even when their directory still exists", async () => {
+  it("retries tombstoned rows whose directory still exists", async () => {
     const ghost = path.join(tmpDir, "ghost-dir");
     await fs.mkdir(ghost, { recursive: true });
-    // Simulate a previous sweep that tombstoned the row but failed to remove
-    // the directory. The current implementation accepts this orphan rather
-    // than re-trying — guard the contract so future changes are deliberate.
+    await fs.writeFile(path.join(ghost, "left.txt"), "leftover");
+    // A prior sweep (or a `removeScratch` call) tombstoned the row but failed
+    // to remove the directory. The next sweep must finish the job.
     const store = makeStore([
       row({
         id: "ghost",
@@ -209,8 +219,48 @@ describe("runScratchCleanup", () => {
       store as unknown as Parameters<typeof runScratchCleanup>[1]
     );
 
-    expect(result.candidates).toBe(0);
+    expect(result.candidates).toBe(1);
     expect(result.tombstoned).toBe(0);
-    await expect(fs.access(ghost)).resolves.toBeUndefined();
+    expect(result.directoriesRemoved).toBe(1);
+    expect(result.directoriesFailed).toBe(0);
+    expect(store.rows).toHaveLength(0);
+    await expect(fs.access(ghost)).rejects.toBeDefined();
+  });
+
+  it("leaves the row tombstoned when fs.rm fails, then completes on a retry sweep", async () => {
+    const dir = path.join(tmpDir, "retry");
+    await fs.mkdir(dir, { recursive: true });
+    await fs.writeFile(path.join(dir, "x.txt"), "data");
+    const store = makeStore([
+      row({ id: "retry", path: dir, lastOpened: NOW - 2 * SCRATCH_TTL_MS }),
+    ]);
+
+    const rmSpy = vi.spyOn(fs, "rm").mockRejectedValueOnce(new Error("EPERM"));
+
+    const first = await runScratchCleanup(
+      NOW,
+      store as unknown as Parameters<typeof runScratchCleanup>[1]
+    );
+
+    expect(first.tombstoned).toBe(1);
+    expect(first.directoriesRemoved).toBe(0);
+    expect(first.directoriesFailed).toBe(1);
+    expect(store.rows).toHaveLength(1);
+    expect(store.rows[0]!.deletedAt).toBe(NOW);
+    await expect(fs.access(dir)).resolves.toBeUndefined();
+
+    rmSpy.mockRestore();
+
+    const second = await runScratchCleanup(
+      NOW + 1,
+      store as unknown as Parameters<typeof runScratchCleanup>[1]
+    );
+
+    expect(second.candidates).toBe(1);
+    expect(second.tombstoned).toBe(0);
+    expect(second.directoriesRemoved).toBe(1);
+    expect(second.directoriesFailed).toBe(0);
+    expect(store.rows).toHaveLength(0);
+    await expect(fs.access(dir)).rejects.toBeDefined();
   });
 });

--- a/electron/services/__tests__/ScratchCleanupService.test.ts
+++ b/electron/services/__tests__/ScratchCleanupService.test.ts
@@ -174,6 +174,37 @@ describe("runScratchCleanup", () => {
     expect(store.rows[0]!.deletedAt).toBeNull();
   });
 
+  it("finishes a tombstoned-current scratch when removeScratch crashed mid-flight", async () => {
+    // removeScratch tombstones, then clears the current pointer, then rms.
+    // If the process dies between the tombstone and clearCurrentScratch, the
+    // next sweep sees a tombstoned row whose ID still equals currentScratchId.
+    // It must NOT be excluded by the active-scratch guard — the user already
+    // asked for it gone.
+    const dir = path.join(tmpDir, "stranded");
+    await fs.mkdir(dir, { recursive: true });
+    const store = makeStore(
+      [
+        row({
+          id: "stranded",
+          path: dir,
+          lastOpened: NOW - 1000,
+          deletedAt: NOW - 500,
+        }),
+      ],
+      "stranded"
+    );
+
+    const result = await runScratchCleanup(
+      NOW,
+      store as unknown as Parameters<typeof runScratchCleanup>[1]
+    );
+
+    expect(result.candidates).toBe(1);
+    expect(result.directoriesRemoved).toBe(1);
+    expect(store.rows).toHaveLength(0);
+    await expect(fs.access(dir)).rejects.toBeDefined();
+  });
+
   it("never deletes the active scratch even when stale", async () => {
     const activeDir = path.join(tmpDir, "active");
     await fs.mkdir(activeDir, { recursive: true });


### PR DESCRIPTION
## Summary

- `removeScratch` was deleting the SQL row before calling `fs.rm` — a crash between the two left the on-disk directory permanently orphaned with no row for a retry pass to find
- Fix applies tombstone-first ordering: tombstone the row, run `fs.rm`, hard-delete the row only on success; failures leave a tombstoned row the sweep can retry
- Cleanup sweep widened to pick up tombstoned rows whose directory still exists; `active-scratch` and `lastOpened` guards scoped to live rows only so they don't block the retry path

Closes #7124

## Changes

- `ScratchStore.removeScratch` — rewritten as tombstone → `fs.rm` → `hardDeleteScratch`; new `hardDeleteScratch` method added
- `ScratchStore.getStaleScratchCandidates` — query widened with `or(stale-untombstoned, tombstoned)` so previously tombstoned rows are included in sweep candidates
- `ScratchCleanupService.runScratchCleanup` — sweep retries tombstoned rows; hard-deletes after successful `fs.rm`; `active-scratch` and `lastOpened` guards constrained to live rows

## Testing

- Vitest suite passes (10 tests in `ScratchCleanupService.test.ts`)
- New failure-then-retry test mocks `fs.rm` to throw on first call, asserts row remains tombstoned with directory intact, then re-runs sweep and asserts hard-delete and directory removal
- Regression test covering the tombstoned-current-scratch crash path
- `npm run check` clean (no errors)