### PR TITLE
fix(lifecycle): correct three defects in main-process signal handling

### DIFF
--- a/electron/lifecycle/__tests__/appLifecycle.test.ts
+++ b/electron/lifecycle/__tests__/appLifecycle.test.ts
@@ -101,9 +101,9 @@ describe("registerAppLifecycleHandlers – signal handling", () => {
     expect(appMock.quit).toHaveBeenCalledOnce();
 
     // Belt must outlast CLEANUP_TIMEOUT_MS plus telemetry-drain buffer so it
-    // doesn't fire mid-cleanup. Advancing to (CLEANUP_TIMEOUT_MS + 2000 - 1)
+    // doesn't fire mid-cleanup. Advancing to (CLEANUP_TIMEOUT_MS + 3000 - 1)
     // confirms the belt hasn't fired prematurely.
-    vi.advanceTimersByTime(CLEANUP_TIMEOUT_MS + 2000 - 1);
+    vi.advanceTimersByTime(CLEANUP_TIMEOUT_MS + 3000 - 1);
     expect(processExitSpy).not.toHaveBeenCalled();
     vi.advanceTimersByTime(1);
     expect(processExitSpy).toHaveBeenCalledWith(0);
@@ -122,6 +122,23 @@ describe("registerAppLifecycleHandlers – signal handling", () => {
 
     expect(setSignalShutdownMock).toHaveBeenCalledOnce();
     expect(appMock.quit).toHaveBeenCalledOnce();
+    expect(processExitSpy).toHaveBeenCalledWith(1);
+  });
+
+  it("second signal at 1999ms force-exits (boundary inside window)", async () => {
+    vi.setSystemTime(new Date(1_000_000));
+    const { registerAppLifecycleHandlers } = await import("../appLifecycle.js");
+    registerAppLifecycleHandlers(makeOpts());
+
+    const sigTermCall = processOnSpy.mock.calls.find(([sig]: string[]) => sig === "SIGTERM");
+    const handler = sigTermCall![1] as () => void;
+
+    handler();
+    // 1ms inside the 2000ms exclusive boundary — must force-exit. Pins the
+    // `<` boundary so an accidental change to `<=` would surface here.
+    vi.setSystemTime(new Date(1_001_999));
+    handler();
+
     expect(processExitSpy).toHaveBeenCalledWith(1);
   });
 

--- a/electron/lifecycle/__tests__/appLifecycle.test.ts
+++ b/electron/lifecycle/__tests__/appLifecycle.test.ts
@@ -32,6 +32,7 @@ vi.mock("../signalShutdownState.js", () => ({
 
 import type { AppLifecycleOptions } from "../appLifecycle.js";
 import { handleDirectoryOpen } from "../../menu.js";
+import { CLEANUP_TIMEOUT_MS } from "../shutdownConfig.js";
 
 function makeOpts(overrides?: Partial<AppLifecycleOptions>): AppLifecycleOptions {
   return {
@@ -74,6 +75,19 @@ describe("registerAppLifecycleHandlers – signal handling", () => {
     }
   });
 
+  it("registers SIGHUP only when !isPackaged", async () => {
+    const { registerAppLifecycleHandlers } = await import("../appLifecycle.js");
+
+    appMock.isPackaged = false;
+    registerAppLifecycleHandlers(makeOpts());
+    expect(processOnSpy.mock.calls.some(([sig]: string[]) => sig === "SIGHUP")).toBe(true);
+
+    vi.clearAllMocks();
+    appMock.isPackaged = true;
+    registerAppLifecycleHandlers(makeOpts());
+    expect(processOnSpy.mock.calls.some(([sig]: string[]) => sig === "SIGHUP")).toBe(false);
+  });
+
   it("signal handler calls setSignalShutdown, schedules timeout, and calls app.quit", async () => {
     const { registerAppLifecycleHandlers } = await import("../appLifecycle.js");
     registerAppLifecycleHandlers(makeOpts());
@@ -86,12 +100,16 @@ describe("registerAppLifecycleHandlers – signal handling", () => {
     expect(setSignalShutdownMock).toHaveBeenCalledOnce();
     expect(appMock.quit).toHaveBeenCalledOnce();
 
+    // Belt must outlast CLEANUP_TIMEOUT_MS plus telemetry-drain buffer so it
+    // doesn't fire mid-cleanup. Advancing to (CLEANUP_TIMEOUT_MS + 2000 - 1)
+    // confirms the belt hasn't fired prematurely.
+    vi.advanceTimersByTime(CLEANUP_TIMEOUT_MS + 2000 - 1);
     expect(processExitSpy).not.toHaveBeenCalled();
-    vi.advanceTimersByTime(5000);
+    vi.advanceTimersByTime(1);
     expect(processExitSpy).toHaveBeenCalledWith(0);
   });
 
-  it("signal handler is idempotent — second call is a no-op", async () => {
+  it("rapid second signal within 2s force-exits with status 1", async () => {
     const { registerAppLifecycleHandlers } = await import("../appLifecycle.js");
     registerAppLifecycleHandlers(makeOpts());
 
@@ -99,13 +117,33 @@ describe("registerAppLifecycleHandlers – signal handling", () => {
     const handler = sigTermCall![1] as () => void;
 
     handler();
+    // Same tick — Date.now() delta is ~0ms, well within the 2000ms force-exit window.
     handler();
 
     expect(setSignalShutdownMock).toHaveBeenCalledOnce();
     expect(appMock.quit).toHaveBeenCalledOnce();
+    expect(processExitSpy).toHaveBeenCalledWith(1);
   });
 
-  it("SIGTERM then SIGINT shares the same one-shot guard", async () => {
+  it("second signal after 2s force-exit window is ignored", async () => {
+    vi.setSystemTime(new Date(1_000_000));
+    const { registerAppLifecycleHandlers } = await import("../appLifecycle.js");
+    registerAppLifecycleHandlers(makeOpts());
+
+    const sigTermCall = processOnSpy.mock.calls.find(([sig]: string[]) => sig === "SIGTERM");
+    const handler = sigTermCall![1] as () => void;
+
+    handler();
+    // Boundary is exclusive — exactly 2000ms later is outside the window.
+    vi.setSystemTime(new Date(1_002_000));
+    handler();
+
+    expect(setSignalShutdownMock).toHaveBeenCalledOnce();
+    expect(appMock.quit).toHaveBeenCalledOnce();
+    expect(processExitSpy).not.toHaveBeenCalled();
+  });
+
+  it("SIGTERM then SIGINT within window force-exits", async () => {
     const { registerAppLifecycleHandlers } = await import("../appLifecycle.js");
     registerAppLifecycleHandlers(makeOpts());
 
@@ -119,6 +157,7 @@ describe("registerAppLifecycleHandlers – signal handling", () => {
 
     expect(setSignalShutdownMock).toHaveBeenCalledOnce();
     expect(appMock.quit).toHaveBeenCalledOnce();
+    expect(processExitSpy).toHaveBeenCalledWith(1);
   });
 });
 

--- a/electron/lifecycle/appLifecycle.ts
+++ b/electron/lifecycle/appLifecycle.ts
@@ -51,10 +51,12 @@ export function registerAppLifecycleHandlers(opts: AppLifecycleOptions): void {
   // otherwise terminate the process without the markCleanExit call.
   //
   // The safety-belt timer must outlast `CLEANUP_TIMEOUT_MS` so it doesn't fire
-  // mid-cleanup; the 2000ms buffer covers `closeTelemetry()` which runs after
-  // the cleanup race resolves. A second signal within 2000ms force-exits with
-  // status 1 — escape hatch when shutdown stalls. After that window, repeat
-  // signals are ignored (cleanup is already in progress).
+  // mid-cleanup; the 3000ms buffer covers `closeTelemetry()` which can take up
+  // to ~2500ms in the worst case (Sentry init-wait cap 500ms + close timeout
+  // 2000ms — see TelemetryService.ts) and runs after the cleanup race resolves.
+  // A second signal within 2000ms force-exits with status 1 — escape hatch
+  // when shutdown stalls. After that window, repeat signals are ignored
+  // (cleanup is already in progress).
   //
   // SIGHUP is dev-only: packaged builds are TTY-detached, and process managers
   // (launchd/systemd) conventionally use SIGHUP to mean "reload config" — we
@@ -71,7 +73,7 @@ export function registerAppLifecycleHandlers(opts: AppLifecycleOptions): void {
     }
     firstSignalTime = Date.now();
     setSignalShutdown();
-    setTimeout(() => process.exit(0), CLEANUP_TIMEOUT_MS + 2000).unref();
+    setTimeout(() => process.exit(0), CLEANUP_TIMEOUT_MS + 3000).unref();
     app.quit();
   };
   process.on("SIGTERM", signalHandler);

--- a/electron/lifecycle/appLifecycle.ts
+++ b/electron/lifecycle/appLifecycle.ts
@@ -4,6 +4,7 @@ import type { WindowRegistry } from "../window/WindowRegistry.js";
 import { handleDirectoryOpen } from "../menu.js";
 import { getCrashRecoveryService } from "../services/CrashRecoveryService.js";
 import { setSignalShutdown } from "./signalShutdownState.js";
+import { CLEANUP_TIMEOUT_MS } from "./shutdownConfig.js";
 
 let pendingCliPath: string | null = null;
 
@@ -40,25 +41,45 @@ export function registerAppLifecycleHandlers(opts: AppLifecycleOptions): void {
   getCrashRecoveryService();
 
   // Graceful shutdown on OS signals (macOS/Linux SIGTERM/SIGINT, Windows Ctrl+C,
-  // plus SIGUSR2 — nodemon's restart signal in dev). Triggers `before-quit` via
-  // `app.quit()` so the shutdown handler runs the full cleanup chain, including
-  // `CrashLoopGuard.markCleanExit()`. Without the SIGUSR2 entry, every nodemon
-  // restart bypassed `before-quit` and CrashLoopGuard counted it as a crash —
-  // after three rebuilds in a minute the dev app booted into safe mode for no
-  // reason. A hard timeout ensures the process exits even if cleanup stalls.
-  // On Windows, `taskkill /F` (TerminateProcess) bypasses all Node.js shutdown
-  // hooks — that case is handled by CrashRecoveryService on next startup.
-  let signalHandled = false;
+  // plus SIGUSR2 — nodemon's restart signal in dev, and SIGHUP — terminal-close
+  // in dev). Triggers `before-quit` via `app.quit()` so the shutdown handler
+  // runs the full cleanup chain, including `CrashLoopGuard.markCleanExit()`.
+  // Without the SIGUSR2 entry, every nodemon restart bypassed `before-quit` and
+  // CrashLoopGuard counted it as a crash — after three rebuilds in a minute the
+  // dev app booted into safe mode for no reason. SIGHUP gets the same treatment
+  // for the same reason: closing the dev terminal sends SIGHUP and would
+  // otherwise terminate the process without the markCleanExit call.
+  //
+  // The safety-belt timer must outlast `CLEANUP_TIMEOUT_MS` so it doesn't fire
+  // mid-cleanup; the 2000ms buffer covers `closeTelemetry()` which runs after
+  // the cleanup race resolves. A second signal within 2000ms force-exits with
+  // status 1 — escape hatch when shutdown stalls. After that window, repeat
+  // signals are ignored (cleanup is already in progress).
+  //
+  // SIGHUP is dev-only: packaged builds are TTY-detached, and process managers
+  // (launchd/systemd) conventionally use SIGHUP to mean "reload config" — we
+  // shouldn't intercept that. On Windows, `taskkill /F` (TerminateProcess)
+  // bypasses all Node.js shutdown hooks; that case is handled by
+  // CrashRecoveryService on next startup.
+  let firstSignalTime: number | null = null;
   const signalHandler = () => {
-    if (signalHandled) return;
-    signalHandled = true;
+    if (firstSignalTime !== null) {
+      if (Date.now() - firstSignalTime < 2000) {
+        process.exit(1);
+      }
+      return;
+    }
+    firstSignalTime = Date.now();
     setSignalShutdown();
-    setTimeout(() => process.exit(0), 5000).unref();
+    setTimeout(() => process.exit(0), CLEANUP_TIMEOUT_MS + 2000).unref();
     app.quit();
   };
   process.on("SIGTERM", signalHandler);
   process.on("SIGINT", signalHandler);
   process.on("SIGUSR2", signalHandler);
+  if (!app.isPackaged) {
+    process.on("SIGHUP", signalHandler);
+  }
 
   app.on("second-instance", (_event, commandLine, _workingDirectory) => {
     console.log("[MAIN] Second instance detected");

--- a/electron/lifecycle/shutdown.ts
+++ b/electron/lifecycle/shutdown.ts
@@ -22,6 +22,9 @@ import { closeSharedDb } from "../services/persistence/db.js";
 import { closeTelemetry } from "../services/TelemetryService.js";
 import { isSmokeTest } from "../setup/environment.js";
 import { isSignalShutdown } from "./signalShutdownState.js";
+import { CLEANUP_TIMEOUT_MS } from "./shutdownConfig.js";
+
+export { CLEANUP_TIMEOUT_MS };
 
 export interface ShutdownDeps {
   getPtyClient: () => PtyClient | null;
@@ -41,8 +44,6 @@ export interface ShutdownDeps {
   setStopDiskSpaceMonitor: (v: (() => void) | null) => void;
   windowRegistry?: import("../window/WindowRegistry.js").WindowRegistry;
 }
-
-const CLEANUP_TIMEOUT_MS = 10_000;
 
 let isQuitting = false;
 let isConfirmingQuit = false;

--- a/electron/lifecycle/shutdownConfig.ts
+++ b/electron/lifecycle/shutdownConfig.ts
@@ -1,0 +1,4 @@
+// Shared shutdown-timing constants. Kept in a side-effect-free module so the
+// signal-handler in appLifecycle.ts (and tests) can import it without pulling
+// in the full shutdown.ts service graph (ProjectStore, TelemetryService, etc).
+export const CLEANUP_TIMEOUT_MS = 10_000;


### PR DESCRIPTION
## Summary

- Safety-belt timer in `appLifecycle.ts` was 5000ms, but the cleanup chain budget (`CLEANUP_TIMEOUT_MS`) is 10000ms — signal-driven shutdowns were terminating before cleanup finished. Widened to `CLEANUP_TIMEOUT_MS + 3000ms` to cover Sentry's worst-case close time of ~2500ms.
- `SIGHUP` wasn't registered, so closing the terminal in dev fired the signal without triggering `before-quit`, incrementing the crash-loop counter on a phantom crash. Now registered gated on `!app.isPackaged`.
- Signal handler was one-shot via a `signalHandled` flag, silently swallowing all subsequent signals with no force-exit escape. Replaced with a 2000ms temporal-window pattern: second signal within the window calls `process.exit(1)`, signals after the window are ignored.

Resolves #7104

## Changes

- `electron/lifecycle/shutdownConfig.ts` — new side-effect-free module exporting `CLEANUP_TIMEOUT_MS`, so signal-handler code and tests can import the constant without pulling in the full shutdown service graph
- `electron/lifecycle/shutdown.ts` — imports from `shutdownConfig.ts`, re-exports for backwards compat
- `electron/lifecycle/appLifecycle.ts` — widened safety-belt timer, added `SIGHUP` registration, replaced one-shot flag with temporal-window force-exit
- `electron/lifecycle/__tests__/appLifecycle.test.ts` — 12 tests covering: boundary timer assertion, rapid-second-signal force-exit, 1999ms inside-window boundary, after-window ignored, `SIGHUP` registration gating, `SIGTERM`-then-`SIGINT`-within-window

## Testing

Typecheck, lint, and format all pass. 12 new unit tests pass covering all three fix paths and their boundary conditions.