### PR TITLE
fix(SystemSleepService): clear stale bookkeeping on reinitialize

### DIFF
--- a/electron/services/SystemSleepService.ts
+++ b/electron/services/SystemSleepService.ts
@@ -55,6 +55,9 @@ class SystemSleepService {
       return;
     }
 
+    // Clear bookkeeping carried over from a prior lifecycle so reinitialize starts clean.
+    this.reset();
+
     // Remove any existing listeners to prevent stacking on re-initialization
     powerMonitor.off("suspend", this.handleSuspend);
     powerMonitor.off("resume", this.handleResume);

--- a/electron/services/__tests__/SystemSleepService.test.ts
+++ b/electron/services/__tests__/SystemSleepService.test.ts
@@ -72,6 +72,24 @@ describe("SystemSleepService", () => {
     expect(service.getMetrics().sleepPeriods).toEqual([]);
   });
 
+  it("preserves accumulated sleep metrics after dispose for post-mortem inspection", () => {
+    const service = new SystemSleepService();
+    service.initialize();
+
+    const suspendHandler = getLatestRegisteredHandler("suspend");
+    suspendHandler();
+
+    vi.setSystemTime(new Date("2026-01-01T00:00:05Z"));
+    const resumeHandler = getLatestRegisteredHandler("resume");
+    resumeHandler();
+
+    service.dispose();
+
+    expect(service.getMetrics().sleepPeriods).toHaveLength(1);
+    expect(service.getTotalSleepTime()).toBe(5000);
+    expect(service.isSleeping()).toBe(false);
+  });
+
   it("clears accumulated sleep periods and totals after dispose and reinitialize", () => {
     const service = new SystemSleepService();
     service.initialize();

--- a/electron/services/__tests__/SystemSleepService.test.ts
+++ b/electron/services/__tests__/SystemSleepService.test.ts
@@ -71,4 +71,45 @@ describe("SystemSleepService", () => {
     expect(service.getTotalSleepTime()).toBe(0);
     expect(service.getMetrics().sleepPeriods).toEqual([]);
   });
+
+  it("clears accumulated sleep periods and totals after dispose and reinitialize", () => {
+    const service = new SystemSleepService();
+    service.initialize();
+
+    const suspendHandler = getLatestRegisteredHandler("suspend");
+    suspendHandler();
+
+    vi.setSystemTime(new Date("2026-01-01T00:00:05Z"));
+    const resumeHandler = getLatestRegisteredHandler("resume");
+    resumeHandler();
+
+    expect(service.getMetrics().sleepPeriods).toHaveLength(1);
+    expect(service.getTotalSleepTime()).toBe(5000);
+
+    service.dispose();
+    service.initialize();
+
+    expect(service.getMetrics().sleepPeriods).toEqual([]);
+    expect(service.getTotalSleepTime()).toBe(0);
+  });
+
+  it("does not erase live metrics when initialize is called again without dispose", () => {
+    const service = new SystemSleepService();
+    service.initialize();
+
+    const suspendHandler = getLatestRegisteredHandler("suspend");
+    suspendHandler();
+
+    vi.setSystemTime(new Date("2026-01-01T00:00:05Z"));
+    const resumeHandler = getLatestRegisteredHandler("resume");
+    resumeHandler();
+
+    expect(service.getMetrics().sleepPeriods).toHaveLength(1);
+    expect(service.getTotalSleepTime()).toBe(5000);
+
+    service.initialize();
+
+    expect(service.getMetrics().sleepPeriods).toHaveLength(1);
+    expect(service.getTotalSleepTime()).toBe(5000);
+  });
 });


### PR DESCRIPTION
## Summary

- `dispose()` cleared listeners and `sleepStart` but left `sleepPeriods`, `totalSleepMs`, and `serviceStartTime` intact, so a reinitialized service inherited stale totals from the prior session
- Fix calls `reset()` at the top of `initialize()` (after the idempotency guard) so reinitializing always starts clean
- Placed in `initialize()` rather than `dispose()` to preserve the post-mortem inspection contract — a disposed service should still be inspectable by telemetry and crash reporters

Resolves #7117

## Changes

- `electron/services/SystemSleepService.ts`: call `this.reset()` at the top of `initialize()`, after the idempotency guard
- `electron/services/__tests__/SystemSleepService.test.ts`: three regression tests covering the completed-period dispose+reinit path, idempotent `initialize()` (live metrics are not reset on a second call), and the post-mortem contract (`dispose()` alone preserves metrics)

## Testing

All three regression tests pass. Existing unit tests unaffected. Typecheck, lint, and format clean.