### PR TITLE
chore(github-commands): polish createIssue and workIssue hygiene

### DIFF
--- a/electron/services/commands/__tests__/githubCreateIssue.test.ts
+++ b/electron/services/commands/__tests__/githubCreateIssue.test.ts
@@ -75,4 +75,72 @@ describe("githubCreateIssueCommand", () => {
     expect(result.success).toBe(false);
     expect(result.error?.code).toBe("NETWORK_ERROR");
   });
+
+  it("sends a Daintree-Electron User-Agent header", async () => {
+    const fetchMock = vi.fn().mockResolvedValue({
+      ok: true,
+      json: vi.fn().mockResolvedValue({
+        html_url: "https://github.com/daintree/app/issues/1",
+        number: 1,
+        title: "ok",
+      }),
+    });
+    (globalThis as unknown as { fetch: Mock }).fetch = fetchMock;
+
+    await githubCreateIssueCommand.execute({ cwd: "/repo" } as never, {
+      title: "ok",
+    });
+
+    const headers = fetchMock.mock.calls[0]?.[1]?.headers as Record<string, string>;
+    expect(headers["User-Agent"]).toBe("Daintree-Electron");
+  });
+
+  it("strips trailing carriage return when synthesizing title from CRLF body", async () => {
+    const fetchMock = vi.fn().mockResolvedValue({
+      ok: true,
+      json: vi.fn().mockResolvedValue({
+        html_url: "https://github.com/daintree/app/issues/2",
+        number: 2,
+        title: "First line",
+      }),
+    });
+    (globalThis as unknown as { fetch: Mock }).fetch = fetchMock;
+
+    await githubCreateIssueCommand.execute({ cwd: "/repo" } as never, {
+      body: "First line\r\nSecond line",
+    });
+
+    const requestBody = JSON.parse(fetchMock.mock.calls[0]?.[1]?.body as string) as {
+      title: string;
+    };
+    expect(requestBody.title).toBe("First line");
+  });
+
+  it("classifies AbortSignal.timeout TimeoutError as TIMEOUT_ERROR", async () => {
+    const timeoutError = new Error("The operation was aborted due to timeout");
+    timeoutError.name = "TimeoutError";
+    (globalThis as unknown as { fetch: Mock }).fetch = vi.fn().mockRejectedValue(timeoutError);
+
+    const result = await githubCreateIssueCommand.execute({ cwd: "/repo" } as never, {
+      title: "Timeout test",
+    });
+
+    expect(result.success).toBe(false);
+    expect(result.error?.code).toBe("TIMEOUT_ERROR");
+    expect(result.error?.message).toContain("Timed out");
+  });
+
+  it("classifies fetch errors with cause.code as NETWORK_ERROR", async () => {
+    const transportError = Object.assign(new TypeError("fetch failed"), {
+      cause: { code: "ENOTFOUND" },
+    });
+    (globalThis as unknown as { fetch: Mock }).fetch = vi.fn().mockRejectedValue(transportError);
+
+    const result = await githubCreateIssueCommand.execute({ cwd: "/repo" } as never, {
+      title: "Network cause test",
+    });
+
+    expect(result.success).toBe(false);
+    expect(result.error?.code).toBe("NETWORK_ERROR");
+  });
 });

--- a/electron/services/commands/__tests__/githubWorkIssue.test.ts
+++ b/electron/services/commands/__tests__/githubWorkIssue.test.ts
@@ -130,4 +130,97 @@ describe("githubWorkIssueCommand", () => {
     expect(result.success).toBe(true);
     expect(result.data?.issueUrl).toBe("https://github.com/daintree/app/issues/55");
   });
+
+  it("normalizes accented Latin characters in slugified branch names", async () => {
+    createClientMock.mockReturnValue(
+      vi.fn().mockResolvedValue({
+        repository: {
+          issue: {
+            number: 55,
+            title: "Café résumé",
+            url: "https://github.com/daintree/app/issues/55",
+            state: "OPEN",
+          },
+        },
+      })
+    );
+
+    const result = await githubWorkIssueCommand.execute({ cwd: "/repo" } as never, {
+      issueNumber: 55,
+    });
+
+    expect(result.success).toBe(true);
+    expect(findAvailableBranchNameMock).toHaveBeenCalledWith("issue-55-cafe-resume");
+  });
+
+  it("normalizes naïve to naive in slugified branch names", async () => {
+    createClientMock.mockReturnValue(
+      vi.fn().mockResolvedValue({
+        repository: {
+          issue: {
+            number: 7,
+            title: "Fix naïve approach",
+            url: "https://github.com/daintree/app/issues/7",
+            state: "OPEN",
+          },
+        },
+      })
+    );
+
+    const result = await githubWorkIssueCommand.execute({ cwd: "/repo" } as never, {
+      issueNumber: 7,
+    });
+
+    expect(result.success).toBe(true);
+    expect(findAvailableBranchNameMock).toHaveBeenCalledWith("issue-7-fix-naive-approach");
+  });
+
+  it("prefers trunk over main when develop is absent", async () => {
+    listBranchesMock.mockResolvedValue([
+      { name: "trunk", remote: false },
+      { name: "main", remote: false },
+    ]);
+
+    const result = await githubWorkIssueCommand.execute({ cwd: "/repo" } as never, {
+      issueNumber: 55,
+    });
+
+    expect(result.success).toBe(true);
+    const workspaceClient = getWorkspaceClientMock.mock.results[0]?.value as {
+      createWorktree: ReturnType<typeof vi.fn>;
+    };
+    expect(workspaceClient.createWorktree).toHaveBeenCalledWith(
+      "/repo",
+      expect.objectContaining({ baseBranch: "trunk" })
+    );
+  });
+
+  it("maps GraphQL TimeoutError to GITHUB_ERROR with timeout message", async () => {
+    const timeoutError = new Error("The operation was aborted due to timeout");
+    timeoutError.name = "TimeoutError";
+    createClientMock.mockReturnValue(vi.fn().mockRejectedValue(timeoutError));
+
+    const result = await githubWorkIssueCommand.execute({ cwd: "/repo" } as never, {
+      issueNumber: 55,
+    });
+
+    expect(result.success).toBe(false);
+    expect(result.error?.code).toBe("GITHUB_ERROR");
+    expect(result.error?.message).toContain("Timed out");
+  });
+
+  it("maps GraphQL fetch errors with cause.code to GITHUB_ERROR with network message", async () => {
+    const transportError = Object.assign(new TypeError("fetch failed"), {
+      cause: { code: "ECONNREFUSED" },
+    });
+    createClientMock.mockReturnValue(vi.fn().mockRejectedValue(transportError));
+
+    const result = await githubWorkIssueCommand.execute({ cwd: "/repo" } as never, {
+      issueNumber: 55,
+    });
+
+    expect(result.success).toBe(false);
+    expect(result.error?.code).toBe("GITHUB_ERROR");
+    expect(result.error?.message).toContain("Network error");
+  });
 });

--- a/electron/services/commands/githubCreateIssue.ts
+++ b/electron/services/commands/githubCreateIssue.ts
@@ -3,6 +3,14 @@ import { getGitHubToken, getRepoContext, clearGitHubCaches } from "../GitHubServ
 import { GITHUB_API_TIMEOUT_MS } from "../github/index.js";
 import { formatErrorMessage } from "../../../shared/utils/errorMessage.js";
 
+const NETWORK_ERROR_CODES = new Set([
+  "ENOTFOUND",
+  "ECONNREFUSED",
+  "ETIMEDOUT",
+  "ECONNRESET",
+  "EAI_AGAIN",
+]);
+
 interface CreateIssueArgs {
   title?: string;
   body?: string;
@@ -161,7 +169,7 @@ export const githubCreateIssueCommand: DaintreeCommand<CreateIssueArgs, CreateIs
     }
 
     // Use body as title if title is missing (agent-style behavior)
-    const issueTitle = title || body.split("\n")[0].slice(0, 100);
+    const issueTitle = title || body.split("\n")[0].replace(/\r$/, "").slice(0, 100);
     const issueBody = body || title;
 
     const requestBody: Record<string, unknown> = {
@@ -187,6 +195,7 @@ export const githubCreateIssueCommand: DaintreeCommand<CreateIssueArgs, CreateIs
           Accept: "application/vnd.github+json",
           "X-GitHub-Api-Version": "2022-11-28",
           "Content-Type": "application/json",
+          "User-Agent": "Daintree-Electron",
         },
         body: JSON.stringify(requestBody),
         signal: AbortSignal.timeout(GITHUB_API_TIMEOUT_MS),
@@ -259,6 +268,27 @@ export const githubCreateIssueCommand: DaintreeCommand<CreateIssueArgs, CreateIs
         },
       };
     } catch (error) {
+      if (error instanceof Error && error.name === "TimeoutError") {
+        return {
+          success: false,
+          error: {
+            code: "TIMEOUT_ERROR",
+            message: "Timed out reaching GitHub. Try again.",
+          },
+        };
+      }
+
+      const causeCode = (error as { cause?: { code?: unknown } } | undefined)?.cause?.code;
+      if (typeof causeCode === "string" && NETWORK_ERROR_CODES.has(causeCode)) {
+        return {
+          success: false,
+          error: {
+            code: "NETWORK_ERROR",
+            message: "Cannot reach GitHub. Check your internet connection.",
+          },
+        };
+      }
+
       const message = formatErrorMessage(error, "Failed to create GitHub issue");
 
       if (

--- a/electron/services/commands/githubWorkIssue.ts
+++ b/electron/services/commands/githubWorkIssue.ts
@@ -49,6 +49,14 @@ export interface GitHubWorkIssueResult {
   issueUrl: string;
 }
 
+const NETWORK_ERROR_CODES = new Set([
+  "ENOTFOUND",
+  "ECONNREFUSED",
+  "ETIMEDOUT",
+  "ECONNRESET",
+  "EAI_AGAIN",
+]);
+
 /**
  * Slugify an issue title for use in a branch name.
  *
@@ -61,6 +69,8 @@ export interface GitHubWorkIssueResult {
  */
 function slugifyTitle(title: string): string {
   let slug = title
+    .normalize("NFKD")
+    .replace(/[\u0300-\u036f]/g, "")
     .toLowerCase()
     .replace(/[^a-z0-9]+/g, "-")
     .replace(/-+/g, "-")
@@ -109,6 +119,15 @@ async function fetchIssueDetails(cwd: string, issueNumber: number): Promise<Issu
       number: issueNumber,
     })) as GraphQlQueryResponseData;
   } catch (error) {
+    if (error instanceof Error && error.name === "TimeoutError") {
+      throw new Error("Timed out reaching GitHub. Try again.");
+    }
+
+    const causeCode = (error as { cause?: { code?: unknown } } | undefined)?.cause?.code;
+    if (typeof causeCode === "string" && NETWORK_ERROR_CODES.has(causeCode)) {
+      throw new Error("Network error connecting to GitHub.");
+    }
+
     // Handle GraphQL errors (auth, rate limit, network)
     const message = formatErrorMessage(error, "Failed to fetch GitHub issue");
     if (message.includes("401") || message.includes("Unauthorized")) {
@@ -161,8 +180,8 @@ async function detectBaseBranch(
     return { exists: false, fromRemote: false, branch: name };
   };
 
-  // Check develop, then main, then master
-  for (const branchName of ["develop", "main", "master"]) {
+  // Check develop, then trunk, then main, then master
+  for (const branchName of ["develop", "trunk", "main", "master"]) {
     const result = checkBranch(branchName);
     if (result.exists) {
       return { branch: result.branch, fromRemote: result.fromRemote };

--- a/electron/services/commands/githubWorkIssue.ts
+++ b/electron/services/commands/githubWorkIssue.ts
@@ -220,7 +220,7 @@ export const githubWorkIssueCommand: DaintreeCommand<GitHubWorkIssueArgs, GitHub
       name: "baseBranch",
       type: "string",
       description:
-        "Base branch to branch from. Auto-detects: prefers 'develop' if exists, otherwise tries 'main', then 'master'. " +
+        "Base branch to branch from. Auto-detects: prefers 'develop' if exists, otherwise tries 'trunk', 'main', then 'master'. " +
         "For hotfixes, use 'main' explicitly.",
       required: false,
     },
@@ -261,7 +261,7 @@ export const githubWorkIssueCommand: DaintreeCommand<GitHubWorkIssueArgs, GitHub
             type: "text",
             placeholder: "develop",
             helpText:
-              "Branch to start from. Auto-detects: uses 'develop' if it exists, otherwise tries 'main', then 'master'. " +
+              "Branch to start from. Auto-detects: uses 'develop' if it exists, otherwise tries 'trunk', 'main', then 'master'. " +
               "Override for hotfixes (use 'main') or feature branches (use specific branch).",
           },
         ],


### PR DESCRIPTION
## Summary

Small hygiene pass across `githubCreateIssue.ts` and `githubWorkIssue.ts` — a handful of independent fixes, none of them load-bearing on their own but collectively tightening up error handling, title synthesis, and branch detection.

- Adds `User-Agent: Daintree-Electron` to the raw fetch in `githubCreateIssue` — same string `AgentVersionService` already uses, explicit is safer than relying on undici's default
- Improves network error classification to check `error?.cause?.code` first, with the existing substring chain as fallback; also catches `AbortError` from `AbortSignal.timeout` and surfaces it as `TIMEOUT_ERROR` with a clear "Timed out reaching GitHub" message rather than a generic failure
- Trims stray `\r` from the synthesized issue title (Windows clipboard `\r\n` splitting on `\n` leaves a carriage return the user sees but GitHub silently drops)
- Fixes `slugifyTitle` to NFKD-normalize before the ASCII collapse, so "Café reorganization" becomes `cafe-reorganization` instead of `caf-reorganization`; CJK still falls through to the existing `issue-{number}` fallback
- Adds `trunk` to the `detectBaseBranch` candidate list alongside `develop`, `main`, and `master`

Resolves #7142

## Changes

- `electron/services/commands/githubCreateIssue.ts` — `User-Agent` header, `cause.code` network classification, `AbortError` → `TIMEOUT_ERROR`, `\r` trim
- `electron/services/commands/githubWorkIssue.ts` — `cause.code` network classification, NFKD slugify, `trunk` in base branch list
- `electron/services/commands/__tests__/githubCreateIssue.test.ts` — tests for the new error paths and title trim
- `electron/services/commands/__tests__/githubWorkIssue.test.ts` — tests for NFKD slugify and `trunk` detection

## Testing

14 unit tests pass covering all new paths — `AbortError` timeout, `cause.code` network error, `\r` title trim, accented slug normalization, and `trunk` base branch detection.