### PR TITLE
fix(recipes): polish in-repo identity-file recipe loader

### DIFF
--- a/electron/services/ProjectIdentityFiles.ts
+++ b/electron/services/ProjectIdentityFiles.ts
@@ -266,8 +266,7 @@ export class ProjectIdentityFiles {
           parsed.id = `inrepo-${entry.name.replace(/\.json$/, "")}`;
         }
         if (typeof parsed.createdAt !== "number") {
-          const ts =
-            typeof parsed.createdAt === "string" ? Date.parse(parsed.createdAt) : NaN;
+          const ts = typeof parsed.createdAt === "string" ? Date.parse(parsed.createdAt) : NaN;
           parsed.createdAt = Number.isFinite(ts) ? ts : 0;
         }
         const result = TerminalRecipeSchema.safeParse(parsed);
@@ -280,10 +279,7 @@ export class ProjectIdentityFiles {
         }
         recipes.push(result.data);
       } catch (error) {
-        console.warn(
-          `[ProjectIdentityFiles] Skipping malformed recipe file: ${entry.name}`,
-          error
-        );
+        console.warn(`[ProjectIdentityFiles] Skipping malformed recipe file: ${entry.name}`, error);
       }
     }
     return recipes;
@@ -345,11 +341,7 @@ export class ProjectIdentityFiles {
                 ? { id: parsed.id, name: parsed.name, keys: Object.keys(parsed) }
                 : {
                     type:
-                      parsed === null
-                        ? "null"
-                        : Array.isArray(parsed)
-                          ? "array"
-                          : typeof parsed,
+                      parsed === null ? "null" : Array.isArray(parsed) ? "array" : typeof parsed,
                   };
             console.warn(
               `[ProjectIdentityFiles] Skipping invalid preset: ${agentId}/${entry.name}`,

--- a/electron/services/ProjectIdentityFiles.ts
+++ b/electron/services/ProjectIdentityFiles.ts
@@ -337,9 +337,23 @@ export class ProjectIdentityFiles {
             !parsed.id ||
             !parsed.name
           ) {
+            // Don't log `parsed` directly: presets can carry an `env` map
+            // with secret values. Summarize structurally so contributors
+            // can diagnose without leaking secrets to logs.
+            const summary =
+              parsed !== null && typeof parsed === "object" && !Array.isArray(parsed)
+                ? { id: parsed.id, name: parsed.name, keys: Object.keys(parsed) }
+                : {
+                    type:
+                      parsed === null
+                        ? "null"
+                        : Array.isArray(parsed)
+                          ? "array"
+                          : typeof parsed,
+                  };
             console.warn(
               `[ProjectIdentityFiles] Skipping invalid preset: ${agentId}/${entry.name}`,
-              parsed
+              summary
             );
             continue;
           }
@@ -357,7 +371,7 @@ export class ProjectIdentityFiles {
           presets.push(parsed as AgentPreset);
         } catch (error) {
           console.warn(
-            `[ProjectIdentityFiles] Skipping malformed preset file: ${entry.name}`,
+            `[ProjectIdentityFiles] Skipping malformed preset file: ${agentId}/${entry.name}`,
             error
           );
         }

--- a/electron/services/ProjectIdentityFiles.ts
+++ b/electron/services/ProjectIdentityFiles.ts
@@ -262,11 +262,13 @@ export class ProjectIdentityFiles {
         if (typeof parsed !== "object" || parsed === null) {
           continue;
         }
-        if (!parsed.id) {
+        if (typeof parsed.id !== "string" || !parsed.id) {
           parsed.id = `inrepo-${entry.name.replace(/\.json$/, "")}`;
         }
         if (typeof parsed.createdAt !== "number") {
-          parsed.createdAt = 0;
+          const ts =
+            typeof parsed.createdAt === "string" ? Date.parse(parsed.createdAt) : NaN;
+          parsed.createdAt = Number.isFinite(ts) ? ts : 0;
         }
         const result = TerminalRecipeSchema.safeParse(parsed);
         if (!result.success) {
@@ -277,8 +279,11 @@ export class ProjectIdentityFiles {
           continue;
         }
         recipes.push(result.data);
-      } catch {
-        console.warn(`[ProjectIdentityFiles] Skipping malformed recipe file: ${entry.name}`);
+      } catch (error) {
+        console.warn(
+          `[ProjectIdentityFiles] Skipping malformed recipe file: ${entry.name}`,
+          error
+        );
       }
     }
     return recipes;
@@ -333,7 +338,8 @@ export class ProjectIdentityFiles {
             !parsed.name
           ) {
             console.warn(
-              `[ProjectIdentityFiles] Skipping invalid preset: ${agentId}/${entry.name}`
+              `[ProjectIdentityFiles] Skipping invalid preset: ${agentId}/${entry.name}`,
+              parsed
             );
             continue;
           }
@@ -349,8 +355,11 @@ export class ProjectIdentityFiles {
           }
           seenIds.add(parsed.id);
           presets.push(parsed as AgentPreset);
-        } catch {
-          console.warn(`[ProjectIdentityFiles] Skipping malformed preset file: ${entry.name}`);
+        } catch (error) {
+          console.warn(
+            `[ProjectIdentityFiles] Skipping malformed preset file: ${entry.name}`,
+            error
+          );
         }
       }
 

--- a/electron/services/__tests__/writeInRepoFiles.test.ts
+++ b/electron/services/__tests__/writeInRepoFiles.test.ts
@@ -607,6 +607,29 @@ describe("readInRepoPresets", () => {
     warnSpy.mockRestore();
   });
 
+  it("does not leak env values when warning about a shape-invalid preset", async () => {
+    const agentDir = path.join(tmpDir, PRESETS_DIR, "claude");
+    await fs.mkdir(agentDir, { recursive: true });
+    await fs.writeFile(
+      path.join(agentDir, "leaky.json"),
+      JSON.stringify({ id: 42, name: "Bad ID Type", env: { API_KEY: "sk-live-secret-xyz" } })
+    );
+
+    const warnSpy = vi.spyOn(console, "warn").mockImplementation(() => {});
+    await identityFiles.readInRepoPresets(tmpDir);
+
+    const allWarnArgs = warnSpy.mock.calls.flat();
+    const serialized = allWarnArgs
+      .map((a) => (typeof a === "string" ? a : JSON.stringify(a)))
+      .join(" ");
+    expect(serialized).not.toContain("sk-live-secret-xyz");
+    expect(warnSpy).toHaveBeenCalledWith(
+      expect.stringContaining("Skipping invalid preset"),
+      expect.anything()
+    );
+    warnSpy.mockRestore();
+  });
+
   it("rejects unsafe agent subdirectory names", async () => {
     const presetsDir = path.join(tmpDir, PRESETS_DIR);
     await fs.mkdir(presetsDir, { recursive: true });

--- a/electron/services/__tests__/writeInRepoFiles.test.ts
+++ b/electron/services/__tests__/writeInRepoFiles.test.ts
@@ -370,6 +370,60 @@ describe("readInRepoRecipes", () => {
     expect(recipes[0]!.createdAt).toBe(0);
   });
 
+  it("assigns stable ID from filename when id is a non-string truthy value", async () => {
+    const recipesDir = path.join(tmpDir, DAINTREE_RECIPES_DIR);
+    await fs.mkdir(recipesDir, { recursive: true });
+    await fs.writeFile(
+      path.join(recipesDir, "numeric-id.json"),
+      JSON.stringify({
+        id: 42,
+        name: "Numeric ID",
+        terminals: [{ type: "terminal" }],
+        createdAt: 100,
+      }),
+      "utf-8"
+    );
+    const recipes = await identityFiles.readInRepoRecipes(tmpDir);
+    expect(recipes).toHaveLength(1);
+    expect(recipes[0]!.id).toBe("inrepo-numeric-id");
+  });
+
+  it("parses ISO 8601 string createdAt to a millisecond timestamp", async () => {
+    const recipesDir = path.join(tmpDir, DAINTREE_RECIPES_DIR);
+    await fs.mkdir(recipesDir, { recursive: true });
+    await fs.writeFile(
+      path.join(recipesDir, "iso-date.json"),
+      JSON.stringify({
+        id: "r1",
+        name: "ISO Date",
+        terminals: [{ type: "terminal" }],
+        createdAt: "2025-01-15T10:30:00Z",
+      }),
+      "utf-8"
+    );
+    const recipes = await identityFiles.readInRepoRecipes(tmpDir);
+    expect(recipes).toHaveLength(1);
+    expect(recipes[0]!.createdAt).toBe(Date.parse("2025-01-15T10:30:00Z"));
+  });
+
+  it("falls back to 0 when createdAt is an unparseable string", async () => {
+    const recipesDir = path.join(tmpDir, DAINTREE_RECIPES_DIR);
+    await fs.mkdir(recipesDir, { recursive: true });
+    await fs.writeFile(
+      path.join(recipesDir, "bad-date.json"),
+      JSON.stringify({
+        id: "r1",
+        name: "Bad Date",
+        terminals: [{ type: "terminal" }],
+        createdAt: "not-a-date",
+      }),
+      "utf-8"
+    );
+    const recipes = await identityFiles.readInRepoRecipes(tmpDir);
+    expect(recipes).toHaveLength(1);
+    expect(recipes[0]!.createdAt).toBe(0);
+  });
+
   it("skips recipes with invalid terminal entries", async () => {
     const recipesDir = path.join(tmpDir, DAINTREE_RECIPES_DIR);
     await fs.mkdir(recipesDir, { recursive: true });


### PR DESCRIPTION
## Summary

- Tighten the `parsed.id` guard so non-string truthy values (e.g. `42` from a hand-edited file) get coerced to the deterministic `inrepo-<filename>` fallback instead of slipping through to a silent `safeParse` drop
- Add ISO 8601 date string parsing via `Date.parse` before zeroing `createdAt` — a hand-written `"2025-01-15T10:30:00Z"` now survives instead of being clobbered
- Replace raw-object logging on preset shape rejection with a redacted structural summary (`id`/`name`/`keys`) so env secrets don't leak into logs

Resolves #7118

## Changes

- `electron/services/ProjectIdentityFiles.ts` — three guard fixes across `readInRepoRecipes` and `readInRepoPresets`; `JSON.parse` catch blocks now log the caught error; `agentId` included in the preset malformed-JSON warning
- `electron/services/__tests__/writeInRepoFiles.test.ts` — four new tests: non-string truthy id fallback, ISO 8601 `createdAt` parsing, unparseable `createdAt` fallback, env-secret redaction in shape-rejection logs

## Testing

Targeted vitest run covering the 43 tests in this file — all pass. Typecheck, lint, and format clean.