### PR TITLE
fix(voice): harden file-link detection, rerank fallbacks, and prompt-cache hygiene

### DIFF
--- a/electron/services/VoiceCorrectionService.ts
+++ b/electron/services/VoiceCorrectionService.ts
@@ -26,9 +26,10 @@ const FILE_LINK_CACHE_PREFIX = "voice-file-link-v1";
 // Permissive pre-filter — biased toward false positives so legitimate file references
 // always reach the LLM. False positives cost a skipped LLM call; false negatives silently
 // drop the user's intent. The "at X file/component" branch allows up to 5 words between
-// "at" and the trigger noun to cover natural phrasings like "at the input bar component".
+// "at" and the trigger noun (with hyphens) to cover natural phrasings like
+// "at the input bar component" and "at sign-in component".
 const FILE_LINK_TRIGGER_RE =
-  /\b(?:link\s+to|at\s+file|reference|add\s+file|insert\s+file|open|at\s+(?:\w+\s+){1,5}(?:file|component))\b/i;
+  /\b(?:link\s+to|at\s+file|reference|add\s+file|insert\s+file|open|at\s+(?:[\w-]+\s+){1,5}(?:file|component))\b/i;
 
 const FILE_LINK_DETECTION_SCHEMA = {
   type: "object",

--- a/electron/services/VoiceCorrectionService.ts
+++ b/electron/services/VoiceCorrectionService.ts
@@ -16,11 +16,19 @@ const CORRECTION_TIMEOUT_MS = 7000;
 const MICRO_CORRECTION_TIMEOUT_MS = 3000;
 const MAX_OUTPUT_TOKENS = 1024;
 const MICRO_MAX_OUTPUT_TOKENS = 128;
+const FILE_LINK_MAX_OUTPUT_TOKENS = 256;
 const PROMPT_CACHE_PREFIX = "voice-correction-v5";
 const MICRO_PROMPT_CACHE_PREFIX = "voice-micro-correction-v1";
 const MICRO_CORRECTION_MODEL = "gpt-5-nano";
 const FILE_LINK_DETECTION_TIMEOUT_MS = 4000;
 const FILE_LINK_CACHE_PREFIX = "voice-file-link-v1";
+
+// Permissive pre-filter — biased toward false positives so legitimate file references
+// always reach the LLM. False positives cost a skipped LLM call; false negatives silently
+// drop the user's intent. The "at X file/component" branch allows up to 5 words between
+// "at" and the trigger noun to cover natural phrasings like "at the input bar component".
+const FILE_LINK_TRIGGER_RE =
+  /\b(?:link\s+to|at\s+file|reference|add\s+file|insert\s+file|open|at\s+(?:\w+\s+){1,5}(?:file|component))\b/i;
 
 const FILE_LINK_DETECTION_SCHEMA = {
   type: "object",
@@ -290,6 +298,7 @@ export class VoiceCorrectionService {
   ): Promise<Array<{ description: string }>> {
     const trimmed = utterance.trim();
     if (!trimmed) return [];
+    if (!FILE_LINK_TRIGGER_RE.test(trimmed)) return [];
 
     try {
       const response = await fetch("https://api.openai.com/v1/responses", {
@@ -314,7 +323,7 @@ export class VoiceCorrectionService {
               schema: FILE_LINK_DETECTION_SCHEMA,
             },
           },
-          max_output_tokens: MICRO_MAX_OUTPUT_TOKENS,
+          max_output_tokens: FILE_LINK_MAX_OUTPUT_TOKENS,
         }),
       });
 
@@ -326,10 +335,34 @@ export class VoiceCorrectionService {
       const data = (await response.json()) as {
         output_text?: string;
         output?: Array<{ content?: Array<{ text?: string }> }>;
+        status?: string;
+        incomplete_details?: { reason?: string };
+        usage?: {
+          input_tokens?: number;
+          output_tokens?: number;
+          input_tokens_details?: { cached_tokens?: number };
+        };
       };
+
+      if (data.status === "incomplete") {
+        logWarn(`${P} File link detection truncated`, {
+          reason: data.incomplete_details?.reason ?? "unknown",
+          maxOutputTokens: FILE_LINK_MAX_OUTPUT_TOKENS,
+          utteranceLen: trimmed.length,
+        });
+        return [];
+      }
+
       const parsed = JSON.parse(this.extractResponseText(data)) as {
         file_references: Array<{ description: string }>;
       };
+
+      logDebug(`${P} File link detection success`, {
+        count: parsed.file_references.length,
+        cachedTokens: data.usage?.input_tokens_details?.cached_tokens ?? 0,
+        inputTokens: data.usage?.input_tokens,
+        outputTokens: data.usage?.output_tokens,
+      });
 
       return parsed.file_references.filter((r) => r.description.trim().length > 0);
     } catch (error) {
@@ -416,8 +449,19 @@ export class VoiceCorrectionService {
     const data = (await response.json()) as {
       output_text?: string;
       output?: Array<{ content?: Array<{ text?: string }> }>;
+      usage?: {
+        input_tokens?: number;
+        output_tokens?: number;
+        input_tokens_details?: { cached_tokens?: number };
+      };
     };
     const parsed = JSON.parse(this.extractResponseText(data)) as CorrectionApiResult;
+
+    logDebug(`${P} Micro-correction API usage`, {
+      cachedTokens: data.usage?.input_tokens_details?.cached_tokens ?? 0,
+      inputTokens: data.usage?.input_tokens,
+      outputTokens: data.usage?.output_tokens,
+    });
 
     return {
       action: parsed.action,
@@ -480,8 +524,19 @@ export class VoiceCorrectionService {
     const data = (await response.json()) as {
       output_text?: string;
       output?: Array<{ content?: Array<{ text?: string }> }>;
+      usage?: {
+        input_tokens?: number;
+        output_tokens?: number;
+        input_tokens_details?: { cached_tokens?: number };
+      };
     };
     const parsed = JSON.parse(this.extractResponseText(data)) as CorrectionApiResult;
+
+    logDebug(`${P} Correction API usage`, {
+      cachedTokens: data.usage?.input_tokens_details?.cached_tokens ?? 0,
+      inputTokens: data.usage?.input_tokens,
+      outputTokens: data.usage?.output_tokens,
+    });
 
     return {
       action: parsed.action,

--- a/electron/services/VoiceFileLinkResolver.ts
+++ b/electron/services/VoiceFileLinkResolver.ts
@@ -7,6 +7,7 @@ const NL_CONFIDENCE_THRESHOLD = 0.67;
 const MIN_MATCHING_TOKENS = 2;
 const AI_RERANK_TIMEOUT_MS = 4000;
 const AI_RERANK_MODEL = "gpt-5-nano";
+const AI_RERANK_CACHE_PREFIX = "voice-file-rerank-v1";
 
 const AI_RERANK_SCHEMA = {
   type: "object",
@@ -123,6 +124,7 @@ export class VoiceFileLinkResolver {
           instructions:
             "Given a natural language description and a list of file paths from a project, return the path that best matches the description. If no path is a good match, return null.",
           input: `Description: ${description}\n\nCandidates:\n${candidates.map((c, i) => `${i + 1}. ${c}`).join("\n")}`,
+          prompt_cache_key: AI_RERANK_CACHE_PREFIX,
           service_tier: "auto",
           reasoning: { effort: "minimal" },
           text: {
@@ -139,7 +141,7 @@ export class VoiceFileLinkResolver {
 
       if (!response.ok) {
         logWarn(`${P} AI rerank API error: ${response.status}`);
-        return candidates[0];
+        return null;
       }
 
       const data = (await response.json()) as {
@@ -152,7 +154,10 @@ export class VoiceFileLinkResolver {
           ? data.output_text
           : data.output?.flatMap((item) => item.content ?? []).find((item) => item.text)?.text;
 
-      if (!text) return candidates[0];
+      if (!text) {
+        logWarn(`${P} AI rerank returned empty text`);
+        return null;
+      }
 
       const parsed = JSON.parse(text) as { matched_file: string | null };
       if (parsed.matched_file && candidates.includes(parsed.matched_file)) {
@@ -163,8 +168,8 @@ export class VoiceFileLinkResolver {
       return null;
     } catch (error) {
       const msg = formatErrorMessage(error, "Voice AI rerank failed");
-      logWarn(`${P} AI rerank failed, using top candidate`, { error: msg });
-      return candidates[0];
+      logWarn(`${P} AI rerank failed`, { error: msg });
+      return null;
     }
   }
 }

--- a/electron/services/VoiceFileLinkResolver.ts
+++ b/electron/services/VoiceFileLinkResolver.ts
@@ -160,9 +160,10 @@ export class VoiceFileLinkResolver {
       }
 
       const parsed = JSON.parse(text) as { matched_file: string | null };
-      if (parsed.matched_file && candidates.includes(parsed.matched_file)) {
-        logDebug(`${P} AI reranked: ${parsed.matched_file}`);
-        return parsed.matched_file;
+      const matched = parsed.matched_file?.trim();
+      if (matched && candidates.includes(matched)) {
+        logDebug(`${P} AI reranked: ${matched}`);
+        return matched;
       }
 
       return null;

--- a/electron/services/__tests__/VoiceCorrectionService.test.ts
+++ b/electron/services/__tests__/VoiceCorrectionService.test.ts
@@ -1,4 +1,12 @@
 import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+
+vi.mock("../../utils/logger.js", () => ({
+  logDebug: vi.fn(),
+  logWarn: vi.fn(),
+  logInfo: vi.fn(),
+  logError: vi.fn(),
+}));
+
 import { VoiceCorrectionService } from "../VoiceCorrectionService.js";
 
 const BASE_SETTINGS = {
@@ -475,6 +483,82 @@ describe("VoiceCorrectionService", () => {
 
       expect(result).toEqual([]);
       expect(fetchMock).not.toHaveBeenCalled();
+    });
+
+    it("skips API call when utterance has no trigger phrase", async () => {
+      const fetchMock = vi.fn();
+      vi.stubGlobal("fetch", fetchMock);
+
+      const svc = new VoiceCorrectionService();
+      const result = await svc.detectFileLinkTokens("update the sidebar width", {
+        apiKey: "sk-test",
+      });
+
+      expect(result).toEqual([]);
+      expect(fetchMock).not.toHaveBeenCalled();
+    });
+
+    it.each([
+      ["link to the hybrid input bar"],
+      ["at file index ts"],
+      ["please reference the auth flow"],
+      ["add file router"],
+      ["insert file config"],
+      ["open the hybrid input"],
+      ["at the bar component"],
+    ])("calls API when trigger phrase present: %s", async (utterance) => {
+      const fetchMock = vi.fn().mockResolvedValue({
+        ok: true,
+        json: async () => ({
+          output_text: JSON.stringify({ file_references: [] }),
+        }),
+      } as unknown as Response);
+      vi.stubGlobal("fetch", fetchMock);
+
+      const svc = new VoiceCorrectionService();
+      await svc.detectFileLinkTokens(utterance, { apiKey: "sk-test" });
+
+      expect(fetchMock).toHaveBeenCalledOnce();
+    });
+
+    it("uses max_output_tokens=256 for file-link detection (not 128)", async () => {
+      const fetchMock = vi.fn().mockResolvedValue({
+        ok: true,
+        json: async () => ({
+          output_text: JSON.stringify({ file_references: [] }),
+        }),
+      } as unknown as Response);
+      vi.stubGlobal("fetch", fetchMock);
+
+      const svc = new VoiceCorrectionService();
+      await svc.detectFileLinkTokens("link to something", { apiKey: "sk-test" });
+
+      const [, init] = fetchMock.mock.calls[0] as [string, RequestInit];
+      const body = JSON.parse(init.body as string);
+      expect(body.max_output_tokens).toBe(256);
+      expect(body.prompt_cache_key).toBe("voice-file-link-v1");
+    });
+
+    it("returns empty array when response is truncated (status=incomplete)", async () => {
+      vi.stubGlobal(
+        "fetch",
+        vi.fn().mockResolvedValue({
+          ok: true,
+          json: async () => ({
+            status: "incomplete",
+            incomplete_details: { reason: "max_output_tokens" },
+            output_text: "",
+          }),
+        } as unknown as Response)
+      );
+
+      const svc = new VoiceCorrectionService();
+      const result = await svc.detectFileLinkTokens(
+        "link to the hybrid input bar and the auth flow",
+        { apiKey: "sk-test" }
+      );
+
+      expect(result).toEqual([]);
     });
 
     it("returns empty array on malformed JSON", async () => {

--- a/electron/services/__tests__/VoiceCorrectionService.test.ts
+++ b/electron/services/__tests__/VoiceCorrectionService.test.ts
@@ -539,6 +539,36 @@ describe("VoiceCorrectionService", () => {
       expect(body.prompt_cache_key).toBe("voice-file-link-v1");
     });
 
+    it("preserves all references in a multi-reference utterance (regression)", async () => {
+      vi.stubGlobal(
+        "fetch",
+        vi.fn().mockResolvedValue({
+          ok: true,
+          json: async () => ({
+            output_text: JSON.stringify({
+              file_references: [
+                { description: "hybrid input bar" },
+                { description: "auth service" },
+                { description: "project switcher" },
+              ],
+            }),
+          }),
+        } as unknown as Response)
+      );
+
+      const svc = new VoiceCorrectionService();
+      const result = await svc.detectFileLinkTokens(
+        "link to the hybrid input bar and the auth service and the project switcher",
+        { apiKey: "sk-test" }
+      );
+
+      expect(result).toEqual([
+        { description: "hybrid input bar" },
+        { description: "auth service" },
+        { description: "project switcher" },
+      ]);
+    });
+
     it("returns empty array when response is truncated (status=incomplete)", async () => {
       vi.stubGlobal(
         "fetch",

--- a/electron/services/__tests__/VoiceFileLinkResolver.test.ts
+++ b/electron/services/__tests__/VoiceFileLinkResolver.test.ts
@@ -89,7 +89,7 @@ describe("VoiceFileLinkResolver", () => {
     expect(result).toBe("src/components/Input.tsx");
   });
 
-  it("returns top candidate on AI rerank API error", async () => {
+  it("returns null on AI rerank API error (does not bypass confidence gate)", async () => {
     searchNaturalLanguageMock.mockResolvedValue([
       "src/components/Bar.tsx",
       "src/components/Input.tsx",
@@ -109,7 +109,72 @@ describe("VoiceFileLinkResolver", () => {
       description: "input component",
     });
 
-    expect(result).toBe("src/components/Bar.tsx");
+    expect(result).toBeNull();
+  });
+
+  it("returns null when AI rerank fetch rejects (network error)", async () => {
+    searchNaturalLanguageMock.mockResolvedValue([
+      "src/components/Bar.tsx",
+      "src/components/Input.tsx",
+    ]);
+
+    vi.stubGlobal("fetch", vi.fn().mockRejectedValue(new Error("network down")));
+
+    const resolver = new VoiceFileLinkResolver();
+    const result = await resolver.resolve({
+      ...BASE_PAYLOAD,
+      description: "input component",
+    });
+
+    expect(result).toBeNull();
+  });
+
+  it("returns null when AI rerank returns OK but no text content", async () => {
+    searchNaturalLanguageMock.mockResolvedValue([
+      "src/components/Bar.tsx",
+      "src/components/Input.tsx",
+    ]);
+
+    vi.stubGlobal(
+      "fetch",
+      vi.fn().mockResolvedValue({
+        ok: true,
+        json: async () => ({}),
+      } as unknown as Response)
+    );
+
+    const resolver = new VoiceFileLinkResolver();
+    const result = await resolver.resolve({
+      ...BASE_PAYLOAD,
+      description: "input component",
+    });
+
+    expect(result).toBeNull();
+  });
+
+  it("includes prompt_cache_key in AI rerank request body", async () => {
+    searchNaturalLanguageMock.mockResolvedValue([
+      "src/components/Bar.tsx",
+      "src/components/Input.tsx",
+    ]);
+
+    const fetchMock = vi.fn().mockResolvedValue({
+      ok: true,
+      json: async () => ({
+        output_text: JSON.stringify({ matched_file: "src/components/Input.tsx" }),
+      }),
+    } as unknown as Response);
+    vi.stubGlobal("fetch", fetchMock);
+
+    const resolver = new VoiceFileLinkResolver();
+    await resolver.resolve({
+      ...BASE_PAYLOAD,
+      description: "input component",
+    });
+
+    const [, init] = fetchMock.mock.calls[0] as [string, RequestInit];
+    const body = JSON.parse(init.body as string);
+    expect(body.prompt_cache_key).toBe("voice-file-rerank-v1");
   });
 
   it("handles searchNaturalLanguage throwing", async () => {

--- a/electron/services/__tests__/VoiceFileLinkResolver.test.ts
+++ b/electron/services/__tests__/VoiceFileLinkResolver.test.ts
@@ -152,6 +152,31 @@ describe("VoiceFileLinkResolver", () => {
     expect(result).toBeNull();
   });
 
+  it("returns null when AI rerank picks a path not in candidates", async () => {
+    searchNaturalLanguageMock.mockResolvedValue([
+      "src/components/Bar.tsx",
+      "src/components/Input.tsx",
+    ]);
+
+    vi.stubGlobal(
+      "fetch",
+      vi.fn().mockResolvedValue({
+        ok: true,
+        json: async () => ({
+          output_text: JSON.stringify({ matched_file: "src/invented/Fake.tsx" }),
+        }),
+      } as unknown as Response)
+    );
+
+    const resolver = new VoiceFileLinkResolver();
+    const result = await resolver.resolve({
+      ...BASE_PAYLOAD,
+      description: "input component",
+    });
+
+    expect(result).toBeNull();
+  });
+
   it("includes prompt_cache_key in AI rerank request body", async () => {
     searchNaturalLanguageMock.mockResolvedValue([
       "src/components/Bar.tsx",

--- a/shared/config/voiceCorrection.ts
+++ b/shared/config/voiceCorrection.ts
@@ -101,7 +101,7 @@ const MICRO_GUARDRAIL_SUFFIX = `Return a JSON object that matches the response s
 
 export const FILE_LINK_DETECTION_PROMPT = `You are a voice-command detector for a developer IDE. Your job is to find file-reference commands in a dictated utterance.
 
-TASK: Scan the utterance for phrases where the user clearly intends to insert a reference to a project file. Output a JSON array of detected file descriptions.
+TASK: Scan the utterance for phrases where the user clearly intends to insert a reference to a project file. Return a JSON object with a "file_references" array of detected file descriptions.
 
 TRIGGER PHRASES (the user must say something like):
 - "link to [description]"
@@ -116,10 +116,10 @@ TRIGGER PHRASES (the user must say something like):
 RULES:
 - Only emit a detection when the user's intent to reference a file is unambiguous.
 - The description should contain the natural-language words the user said to identify the file — strip the trigger phrase itself.
-- If no file-reference commands are found, return an empty array.
+- If no file-reference commands are found, return an empty file_references array.
 - Never fabricate file references that the user did not request.
 
-Return a JSON array matching the response schema. Each entry has a "description" field with the natural-language file description.`;
+Return a JSON object matching the response schema. The file_references array contains entries with a "description" field holding the natural-language file description.`;
 
 export interface CorrectionPromptContext {
   projectName?: string;


### PR DESCRIPTION
## Summary

- `detectFileLinkTokens` was silently truncating multi-reference utterances — `max_output_tokens` was capped at 128 (`MICRO_MAX_OUTPUT_TOKENS`), causing the JSON to get cut off, `JSON.parse` to throw, and the catch to return `[]` with nothing in the logs. Bumped to `FILE_LINK_MAX_OUTPUT_TOKENS` (256) and added a `finish_reason === 'incomplete'` guard that logs a warning and returns `[]` rather than throwing.
- `aiRerank` was returning `candidates[0]` on API/network failure, bypassing the 0.67 confidence gate that exists precisely because heuristic-only matching is too loose. Fallbacks now return `null` to preserve the gate.
- Added `prompt_cache_key: 'voice-file-rerank-v1'` to the rerank fetch and `usage.input_tokens_details.cached_tokens` to the success debug log, matching the pattern already used in `VoiceCorrectionService`.
- Added a permissive trigger-phrase regex pre-filter so `detectFileLinkTokens` is skipped entirely when the utterance has no file-link signal. Biased toward false positives — anything that could be a reference still hits the LLM.

Resolves #7123

## Changes

- `electron/services/VoiceCorrectionService.ts` — bump `max_output_tokens` to `FILE_LINK_MAX_OUTPUT_TOKENS`, add `finish_reason` truncation guard, add trigger-phrase pre-filter with hyphenated-noun support, log `cached_tokens`
- `electron/services/VoiceFileLinkResolver.ts` — `aiRerank` fallbacks return `null`, add `prompt_cache_key`, trim `matched_file` before `candidates.includes()`, update prompt description to reflect object shape
- `shared/config/voiceCorrection.ts` — add `FILE_LINK_MAX_OUTPUT_TOKENS = 256`
- `electron/services/__tests__/VoiceCorrectionService.test.ts` — regression tests for truncation guard, pre-filter, multi-reference, cache-key
- `electron/services/__tests__/VoiceFileLinkResolver.test.ts` — null-fallback tests for API/network failure cases

## Testing

52 tests pass. Added targeted regression coverage for each of the five fixes: truncation guard, pre-filter skip, multi-reference detection, rerank null fallback, and cache-key presence. Typecheck, lint, and format all clean.