### PR TITLE
fix(shutdown): correct crash marker misclassification for hard-timeout and post-rejection exits

### DIFF
--- a/electron/lifecycle/__tests__/shutdown.test.ts
+++ b/electron/lifecycle/__tests__/shutdown.test.ts
@@ -191,12 +191,12 @@ describe("registerShutdownHandler", () => {
     // Should still preventDefault and run cleanup
     expect(event.preventDefault).toHaveBeenCalled();
     expect(quitWarningMock.showQuitWarning).not.toHaveBeenCalled();
-    expect(crashRecoveryMock.cleanupOnExit).toHaveBeenCalled();
 
     // Wait for cleanup promise chain to settle
     await vi.waitFor(() => {
       expect(appMock.exit).toHaveBeenCalledWith(0);
     });
+    expect(crashRecoveryMock.cleanupOnExit).toHaveBeenCalled();
   });
 
   it("runs cleanup without dialog on signal shutdown even with active agents", async () => {
@@ -214,11 +214,11 @@ describe("registerShutdownHandler", () => {
 
     expect(event.preventDefault).toHaveBeenCalled();
     expect(quitWarningMock.showQuitWarning).not.toHaveBeenCalled();
-    expect(crashRecoveryMock.cleanupOnExit).toHaveBeenCalled();
 
     await vi.waitFor(() => {
       expect(appMock.exit).toHaveBeenCalledWith(0);
     });
+    expect(crashRecoveryMock.cleanupOnExit).toHaveBeenCalled();
   });
 
   it("shows dialog when window exists, agents active, and user cancels", async () => {
@@ -254,11 +254,11 @@ describe("registerShutdownHandler", () => {
     await beforeQuitCb(event);
 
     expect(quitWarningMock.showQuitWarning).toHaveBeenCalled();
-    expect(crashRecoveryMock.cleanupOnExit).toHaveBeenCalled();
 
     await vi.waitFor(() => {
       expect(appMock.exit).toHaveBeenCalledWith(0);
     });
+    expect(crashRecoveryMock.cleanupOnExit).toHaveBeenCalled();
   });
 
   it("skips dialog when window exists but no active agents", async () => {
@@ -274,11 +274,11 @@ describe("registerShutdownHandler", () => {
     await beforeQuitCb(event);
 
     expect(quitWarningMock.showQuitWarning).not.toHaveBeenCalled();
-    expect(crashRecoveryMock.cleanupOnExit).toHaveBeenCalled();
 
     await vi.waitFor(() => {
       expect(appMock.exit).toHaveBeenCalledWith(0);
     });
+    expect(crashRecoveryMock.cleanupOnExit).toHaveBeenCalled();
   });
 
   it("runs cleanup when no window and signal shutdown", async () => {
@@ -290,11 +290,11 @@ describe("registerShutdownHandler", () => {
 
     expect(event.preventDefault).toHaveBeenCalled();
     expect(quitWarningMock.showQuitWarning).not.toHaveBeenCalled();
-    expect(crashRecoveryMock.cleanupOnExit).toHaveBeenCalled();
 
     await vi.waitFor(() => {
       expect(appMock.exit).toHaveBeenCalledWith(0);
     });
+    expect(crashRecoveryMock.cleanupOnExit).toHaveBeenCalled();
   });
 
   describe("SQLite connection close", () => {
@@ -449,7 +449,7 @@ describe("registerShutdownHandler", () => {
       vi.useRealTimers();
     });
 
-    it("calls app.exit(1) when cleanup hangs past hard timeout", async () => {
+    it("calls app.exit(1) when cleanup hangs past hard timeout and leaves the crash marker on disk", async () => {
       mcpServerMock.stop.mockReturnValue(new Promise(() => {}));
       const consoleSpy = vi.spyOn(console, "error").mockImplementation(() => {});
 
@@ -458,10 +458,16 @@ describe("registerShutdownHandler", () => {
       await beforeQuitCb(event);
 
       await vi.advanceTimersByTimeAsync(10_000);
+      // Drain the post-timeout async chain (closeTelemetry await + app.exit).
+      await vi.runAllTimersAsync();
 
       expect(appMock.exit).toHaveBeenCalledWith(1);
       expect(appMock.exit).toHaveBeenCalledTimes(1);
       expect(closeTelemetryMock).toHaveBeenCalled();
+      // Critical: a hard-timeout exit must NOT mark itself clean. The intact
+      // marker file is the dirty-exit signal the next launch reads.
+      expect(crashRecoveryMock.cleanupOnExit).not.toHaveBeenCalled();
+      expect(crashLoopGuardMock.markCleanExit).not.toHaveBeenCalled();
       expect(consoleSpy).toHaveBeenCalledWith(
         "[MAIN] Error during cleanup:",
         expect.objectContaining({
@@ -476,6 +482,44 @@ describe("registerShutdownHandler", () => {
       );
 
       consoleSpy.mockRestore();
+    });
+
+    it("calls cleanupOnExit and markCleanExit only after the cleanup chain resolves on a clean shutdown", async () => {
+      mcpServerMock.stop.mockReturnValue(Promise.resolve());
+
+      const { beforeQuitCb } = await setup({});
+      const event = makeEvent();
+      await beforeQuitCb(event);
+
+      // Immediately after before-quit returns, the cleanup chain hasn't resolved
+      // yet — markers must not have been touched.
+      expect(crashRecoveryMock.cleanupOnExit).not.toHaveBeenCalled();
+      expect(crashLoopGuardMock.markCleanExit).not.toHaveBeenCalled();
+
+      await vi.advanceTimersByTimeAsync(100);
+
+      // Now the chain has resolved and the success branch has marked clean.
+      expect(crashRecoveryMock.cleanupOnExit).toHaveBeenCalledTimes(1);
+      expect(crashLoopGuardMock.markCleanExit).toHaveBeenCalledTimes(1);
+      expect(appMock.exit).toHaveBeenCalledWith(0);
+    });
+
+    it("still marks clean exit and exits with 0 when closeTelemetry rejects (telemetry must not gate marker cleanup)", async () => {
+      mcpServerMock.stop.mockReturnValue(Promise.resolve());
+      closeTelemetryMock.mockReturnValueOnce(Promise.reject(new Error("telemetry boom")));
+      const warnSpy = vi.spyOn(console, "warn").mockImplementation(() => {});
+
+      const { beforeQuitCb } = await setup({});
+      await beforeQuitCb(makeEvent());
+
+      await vi.advanceTimersByTimeAsync(100);
+
+      expect(crashRecoveryMock.cleanupOnExit).toHaveBeenCalledTimes(1);
+      expect(crashLoopGuardMock.markCleanExit).toHaveBeenCalledTimes(1);
+      expect(appMock.exit).toHaveBeenCalledWith(0);
+      expect(warnSpy).toHaveBeenCalledWith("[MAIN] closeTelemetry failed:", expect.any(Error));
+
+      warnSpy.mockRestore();
     });
 
     it("normal cleanup exits with code 0 and timeout does not fire", async () => {

--- a/electron/lifecycle/__tests__/shutdown.test.ts
+++ b/electron/lifecycle/__tests__/shutdown.test.ts
@@ -504,6 +504,29 @@ describe("registerShutdownHandler", () => {
       expect(appMock.exit).toHaveBeenCalledWith(0);
     });
 
+    it("still calls markCleanExit and exits with 0 when cleanupOnExit throws (independent failure modes)", async () => {
+      mcpServerMock.stop.mockReturnValue(Promise.resolve());
+      crashRecoveryMock.cleanupOnExit.mockImplementationOnce(() => {
+        throw new Error("delete marker boom");
+      });
+      const warnSpy = vi.spyOn(console, "warn").mockImplementation(() => {});
+
+      const { beforeQuitCb } = await setup({});
+      await beforeQuitCb(makeEvent());
+
+      await vi.advanceTimersByTimeAsync(100);
+
+      expect(crashRecoveryMock.cleanupOnExit).toHaveBeenCalledTimes(1);
+      expect(crashLoopGuardMock.markCleanExit).toHaveBeenCalledTimes(1);
+      expect(appMock.exit).toHaveBeenCalledWith(0);
+      expect(warnSpy).toHaveBeenCalledWith(
+        "[MAIN] CrashRecoveryService.cleanupOnExit failed:",
+        expect.any(Error)
+      );
+
+      warnSpy.mockRestore();
+    });
+
     it("still marks clean exit and exits with 0 when closeTelemetry rejects (telemetry must not gate marker cleanup)", async () => {
       mcpServerMock.stop.mockReturnValue(Promise.resolve());
       closeTelemetryMock.mockReturnValueOnce(Promise.reject(new Error("telemetry boom")));

--- a/electron/lifecycle/shutdown.ts
+++ b/electron/lifecycle/shutdown.ts
@@ -91,8 +91,6 @@ export function registerShutdownHandler(deps: ShutdownDeps): void {
     console.log("[MAIN] Starting graceful shutdown...");
     const { drainRateLimitQueues } = await import("../ipc/utils.js");
     drainRateLimitQueues();
-    getCrashRecoveryService().cleanupOnExit();
-    getCrashLoopGuard().markCleanExit();
 
     const ptyClient = deps.getPtyClient();
     const workspaceClient = deps.getWorkspaceClient();
@@ -232,7 +230,19 @@ export function registerShutdownHandler(deps: ShutdownDeps): void {
         exitCalled = true;
         clearTimeout(hardTimer);
         console.log("[MAIN] Graceful shutdown complete");
-        await closeTelemetry();
+        // Mark the exit clean BEFORE telemetry — telemetry is best-effort and
+        // a closeTelemetry failure must never make the next launch think we crashed.
+        try {
+          getCrashRecoveryService().cleanupOnExit();
+          getCrashLoopGuard().markCleanExit();
+        } catch (err) {
+          console.warn("[MAIN] Marker cleanup on clean exit failed:", err);
+        }
+        try {
+          await closeTelemetry();
+        } catch (err) {
+          console.warn("[MAIN] closeTelemetry failed:", err);
+        }
         app.exit(0);
       })
       .catch(async (error) => {
@@ -240,7 +250,13 @@ export function registerShutdownHandler(deps: ShutdownDeps): void {
         exitCalled = true;
         clearTimeout(hardTimer);
         console.error("[MAIN] Error during cleanup:", error);
-        await closeTelemetry();
+        // Intentionally do NOT clean up the marker on the error/timeout path —
+        // leaving running.lock on disk is the dirty-exit signal for next launch.
+        try {
+          await closeTelemetry();
+        } catch (err) {
+          console.warn("[MAIN] closeTelemetry failed:", err);
+        }
         app.exit(1);
       });
   });

--- a/electron/lifecycle/shutdown.ts
+++ b/electron/lifecycle/shutdown.ts
@@ -232,11 +232,16 @@ export function registerShutdownHandler(deps: ShutdownDeps): void {
         console.log("[MAIN] Graceful shutdown complete");
         // Mark the exit clean BEFORE telemetry — telemetry is best-effort and
         // a closeTelemetry failure must never make the next launch think we crashed.
+        // Independent try blocks so a failure in one marker write doesn't skip the other.
         try {
           getCrashRecoveryService().cleanupOnExit();
+        } catch (err) {
+          console.warn("[MAIN] CrashRecoveryService.cleanupOnExit failed:", err);
+        }
+        try {
           getCrashLoopGuard().markCleanExit();
         } catch (err) {
-          console.warn("[MAIN] Marker cleanup on clean exit failed:", err);
+          console.warn("[MAIN] CrashLoopGuard.markCleanExit failed:", err);
         }
         try {
           await closeTelemetry();

--- a/electron/setup/__tests__/globalErrorHandlers.test.ts
+++ b/electron/setup/__tests__/globalErrorHandlers.test.ts
@@ -269,11 +269,11 @@ describe("globalErrorHandlers", () => {
       expect(appMock.relaunch).not.toHaveBeenCalled();
     });
 
-    it("calls CrashRecoveryService.recordCrash with the reason", () => {
+    it("does NOT call CrashRecoveryService.recordCrash (transient rejections must not poison the crash marker)", () => {
       const reason = new Error("rejected");
       rejectionHandler(reason);
 
-      expect(crashRecoveryMock.recordCrash).toHaveBeenCalledWith(reason);
+      expect(crashRecoveryMock.recordCrash).not.toHaveBeenCalled();
     });
 
     it("persists error to pendingErrors store with UNHANDLED_REJECTION payload", () => {
@@ -303,14 +303,6 @@ describe("globalErrorHandlers", () => {
         "pendingErrors",
         expect.arrayContaining([expect.objectContaining({ fromPreviousSession: true })])
       );
-    });
-
-    it("does not throw when recordCrash throws", () => {
-      crashRecoveryMock.recordCrash.mockImplementation(() => {
-        throw new Error("record failed");
-      });
-
-      expect(() => rejectionHandler(new Error("rejected"))).not.toThrow();
     });
 
     it("handles non-Error rejection reasons", () => {

--- a/electron/setup/globalErrorHandlers.ts
+++ b/electron/setup/globalErrorHandlers.ts
@@ -119,11 +119,10 @@ export function registerGlobalErrorHandlers(): void {
       // silent
     }
 
-    try {
-      getCrashRecoveryService().recordCrash(reason);
-    } catch {
-      // silent
-    }
+    // Do NOT call recordCrash here. The app keeps running after an unhandled
+    // rejection (no app.exit follows), so writing a crash marker would poison
+    // every subsequent clean Cmd-Q on the next launch. Only uncaughtException
+    // — which terminates the process — should mark the crash.
 
     const appError = buildFatalErrorRecord("UNHANDLED_REJECTION", reason);
 


### PR DESCRIPTION
## Summary

- Hard-timeout shutdowns (`app.exit(1)` after the 10s cleanup chain) were being recorded as clean exits because `cleanupOnExit()` and `markCleanExit()` ran too early in `before-quit`, before the cleanup chain had a chance to time out.
- Transient `unhandledRejection` events called `recordCrash()`, setting `crashRecorded = true` and writing the marker without exiting the app -- so any subsequent clean Cmd-Q looked like a crash on next launch. Aligned the handler with `uncaughtException`, which already does not record crashes for non-fatal rejections.
- Split the cleanup `try` block so a `cleanupOnExit()` failure cannot silently skip `markCleanExit()`.

Resolves #7111

## Changes

- `electron/lifecycle/shutdown.ts` -- moved `cleanupOnExit()` / `markCleanExit()` calls to after the cleanup chain settles; split try blocks
- `electron/setup/globalErrorHandlers.ts` -- removed `recordCrash()` from the `unhandledRejection` handler
- `electron/lifecycle/__tests__/shutdown.test.ts` -- added coverage for hard-timeout and post-rejection exit paths
- `electron/setup/__tests__/globalErrorHandlers.test.ts` -- updated to reflect the handler change

## Testing

- Unit tests added for both misclassification paths; existing tests updated where behaviour changed.
- Ran `npm run check` clean.