### PR TITLE
fix(quarantine): expand cleanup coverage and fix correctness defects

### DIFF
--- a/electron/services/ProjectStore.ts
+++ b/electron/services/ProjectStore.ts
@@ -29,7 +29,11 @@ import { ProjectStateManager, type ProjectStateReadResult } from "./ProjectState
 import { ProjectFileStore } from "./ProjectFileStore.js";
 import { GlobalFileStore } from "./GlobalFileStore.js";
 import { ProjectIdentityFiles } from "./ProjectIdentityFiles.js";
-import { cleanupQuarantinedProjectFiles } from "./projectQuarantineCleanup.js";
+import {
+  cleanupQuarantinedProjectFiles,
+  cleanupGlobalQuarantineFiles,
+  cleanupUserDataRootQuarantineFiles,
+} from "./projectQuarantineCleanup.js";
 import { safeRecipeFilename } from "../utils/recipeFilename.js";
 
 import { computeFrecencyScore, FRECENCY_COLD_START } from "./frecency.js";
@@ -60,6 +64,8 @@ function rowToProject(row: ProjectRow): Project {
 
 export class ProjectStore {
   private projectsConfigDir: string;
+  private globalConfigDir: string;
+  private userDataDir: string;
   private settingsManager: ProjectSettingsManager;
   private stateManager: ProjectStateManager;
   private fileStore: ProjectFileStore;
@@ -67,12 +73,13 @@ export class ProjectStore {
   private identityFiles: ProjectIdentityFiles;
 
   constructor() {
-    this.projectsConfigDir = path.join(app.getPath("userData"), "projects");
-    const globalConfigDir = path.join(app.getPath("userData"), "global");
+    this.userDataDir = app.getPath("userData");
+    this.projectsConfigDir = path.join(this.userDataDir, "projects");
+    this.globalConfigDir = path.join(this.userDataDir, "global");
     this.settingsManager = new ProjectSettingsManager(this.projectsConfigDir, store);
     this.stateManager = new ProjectStateManager(this.projectsConfigDir);
     this.fileStore = new ProjectFileStore(this.projectsConfigDir);
-    this.globalFileStore = new GlobalFileStore(globalConfigDir);
+    this.globalFileStore = new GlobalFileStore(this.globalConfigDir);
     this.identityFiles = new ProjectIdentityFiles();
   }
 
@@ -82,6 +89,12 @@ export class ProjectStore {
     }
     void cleanupQuarantinedProjectFiles(this.projectsConfigDir).catch((err) =>
       logError("[ProjectStore] Quarantine cleanup failed", err)
+    );
+    void cleanupGlobalQuarantineFiles(this.globalConfigDir).catch((err) =>
+      logError("[GlobalFileStore] Quarantine cleanup failed", err)
+    );
+    void cleanupUserDataRootQuarantineFiles(this.userDataDir).catch((err) =>
+      logError("[Store] Quarantine cleanup failed", err)
     );
   }
 

--- a/electron/services/__tests__/projectQuarantineCleanup.test.ts
+++ b/electron/services/__tests__/projectQuarantineCleanup.test.ts
@@ -2,7 +2,11 @@ import { describe, it, expect, beforeEach, afterEach } from "vitest";
 import fs from "fs/promises";
 import path from "path";
 import os from "os";
-import { cleanupQuarantinedProjectFiles } from "../projectQuarantineCleanup.js";
+import {
+  cleanupQuarantinedProjectFiles,
+  cleanupGlobalQuarantineFiles,
+  cleanupUserDataRootQuarantineFiles,
+} from "../projectQuarantineCleanup.js";
 
 const THIRTY_ONE_DAYS_MS = 31 * 24 * 60 * 60 * 1000;
 const TWENTY_NINE_DAYS_MS = 29 * 24 * 60 * 60 * 1000;
@@ -223,5 +227,172 @@ describe("cleanupQuarantinedProjectFiles", () => {
     const deleted = await cleanupQuarantinedProjectFiles(tmpDir, futureNow);
     expect(deleted).toBe(1);
     await expect(fs.access(filePath)).rejects.toThrow();
+  });
+
+  it("deletes state.json.future-v<N> files older than 30 days", async () => {
+    const projectDir = await createProjectDir(VALID_PROJECT_ID);
+    const futureV2 = await createCorruptedFile(
+      projectDir,
+      "state.json.future-v2",
+      THIRTY_ONE_DAYS_MS,
+      NOW
+    );
+    const futureV2Stamped = await createCorruptedFile(
+      projectDir,
+      "state.json.future-v2.1234567890",
+      THIRTY_ONE_DAYS_MS,
+      NOW
+    );
+    const futureV999999 = await createCorruptedFile(
+      projectDir,
+      "state.json.future-v999999",
+      THIRTY_ONE_DAYS_MS,
+      NOW
+    );
+
+    const deleted = await cleanupQuarantinedProjectFiles(tmpDir, NOW);
+    expect(deleted).toBe(3);
+    await expect(fs.access(futureV2)).rejects.toThrow();
+    await expect(fs.access(futureV2Stamped)).rejects.toThrow();
+    await expect(fs.access(futureV999999)).rejects.toThrow();
+  });
+
+  it("preserves fresh state.json.future-v<N> files", async () => {
+    const projectDir = await createProjectDir(VALID_PROJECT_ID);
+    const filePath = await createCorruptedFile(
+      projectDir,
+      "state.json.future-v2",
+      TWENTY_NINE_DAYS_MS,
+      NOW
+    );
+
+    const deleted = await cleanupQuarantinedProjectFiles(tmpDir, NOW);
+    expect(deleted).toBe(0);
+    await expect(fs.access(filePath)).resolves.toBeUndefined();
+  });
+
+  it("preserves files with future mtime (clock-skew safety)", async () => {
+    const projectDir = await createProjectDir(VALID_PROJECT_ID);
+    const filePath = path.join(projectDir, "state.json.corrupted.1234567890");
+    await fs.writeFile(filePath, "data");
+    // mtime in the future relative to NOW
+    const futureMtime = new Date(NOW + 7 * 24 * 60 * 60 * 1000);
+    await fs.utimes(filePath, futureMtime, futureMtime);
+
+    const deleted = await cleanupQuarantinedProjectFiles(tmpDir, NOW);
+    expect(deleted).toBe(0);
+    await expect(fs.access(filePath)).resolves.toBeUndefined();
+  });
+});
+
+describe("cleanupGlobalQuarantineFiles", () => {
+  const NOW = Math.floor(Date.now() / 1000) * 1000;
+
+  it("deletes recipes.json.corrupted.* older than 30 days", async () => {
+    const filePath = path.join(tmpDir, "recipes.json.corrupted.1234567890");
+    await fs.writeFile(filePath, "data");
+    const oldTime = new Date(NOW - THIRTY_ONE_DAYS_MS);
+    await fs.utimes(filePath, oldTime, oldTime);
+
+    const deleted = await cleanupGlobalQuarantineFiles(tmpDir, NOW);
+    expect(deleted).toBe(1);
+    await expect(fs.access(filePath)).rejects.toThrow();
+  });
+
+  it("preserves fresh recipes.json.corrupted.* files", async () => {
+    const filePath = path.join(tmpDir, "recipes.json.corrupted.1234567890");
+    await fs.writeFile(filePath, "data");
+    const recentTime = new Date(NOW - TWENTY_NINE_DAYS_MS);
+    await fs.utimes(filePath, recentTime, recentTime);
+
+    const deleted = await cleanupGlobalQuarantineFiles(tmpDir, NOW);
+    expect(deleted).toBe(0);
+    await expect(fs.access(filePath)).resolves.toBeUndefined();
+  });
+
+  it("ignores the live recipes.json file and other unrelated files", async () => {
+    const liveFile = path.join(tmpDir, "recipes.json");
+    const unrelatedFile = path.join(tmpDir, "other.json");
+    await fs.writeFile(liveFile, "live");
+    await fs.writeFile(unrelatedFile, "data");
+    const oldTime = new Date(NOW - THIRTY_ONE_DAYS_MS);
+    await fs.utimes(liveFile, oldTime, oldTime);
+    await fs.utimes(unrelatedFile, oldTime, oldTime);
+
+    const deleted = await cleanupGlobalQuarantineFiles(tmpDir, NOW);
+    expect(deleted).toBe(0);
+    await expect(fs.access(liveFile)).resolves.toBeUndefined();
+    await expect(fs.access(unrelatedFile)).resolves.toBeUndefined();
+  });
+
+  it("returns 0 when global config dir is missing", async () => {
+    const nonexistent = path.join(tmpDir, "does-not-exist");
+    const deleted = await cleanupGlobalQuarantineFiles(nonexistent, NOW);
+    expect(deleted).toBe(0);
+  });
+});
+
+describe("cleanupUserDataRootQuarantineFiles", () => {
+  const NOW = Math.floor(Date.now() / 1000) * 1000;
+
+  it("deletes config.json.corrupted.* older than 30 days", async () => {
+    const filePath = path.join(tmpDir, "config.json.corrupted.1234567890");
+    await fs.writeFile(filePath, "data");
+    const oldTime = new Date(NOW - THIRTY_ONE_DAYS_MS);
+    await fs.utimes(filePath, oldTime, oldTime);
+
+    const deleted = await cleanupUserDataRootQuarantineFiles(tmpDir, NOW);
+    expect(deleted).toBe(1);
+    await expect(fs.access(filePath)).rejects.toThrow();
+  });
+
+  it("preserves fresh config.json.corrupted.* files", async () => {
+    const filePath = path.join(tmpDir, "config.json.corrupted.1234567890");
+    await fs.writeFile(filePath, "data");
+    const recentTime = new Date(NOW - TWENTY_NINE_DAYS_MS);
+    await fs.utimes(filePath, recentTime, recentTime);
+
+    const deleted = await cleanupUserDataRootQuarantineFiles(tmpDir, NOW);
+    expect(deleted).toBe(0);
+    await expect(fs.access(filePath)).resolves.toBeUndefined();
+  });
+
+  it("does not recurse into Chromium-managed subdirectories", async () => {
+    const localStorageDir = path.join(tmpDir, "Local Storage");
+    const indexedDbDir = path.join(tmpDir, "IndexedDB");
+    await fs.mkdir(localStorageDir, { recursive: true });
+    await fs.mkdir(indexedDbDir, { recursive: true });
+
+    const nestedQuarantine = path.join(localStorageDir, "config.json.corrupted.1234567890");
+    await fs.writeFile(nestedQuarantine, "data");
+    const oldTime = new Date(NOW - THIRTY_ONE_DAYS_MS);
+    await fs.utimes(nestedQuarantine, oldTime, oldTime);
+
+    const deleted = await cleanupUserDataRootQuarantineFiles(tmpDir, NOW);
+    expect(deleted).toBe(0);
+    await expect(fs.access(nestedQuarantine)).resolves.toBeUndefined();
+    await expect(fs.access(localStorageDir)).resolves.toBeUndefined();
+    await expect(fs.access(indexedDbDir)).resolves.toBeUndefined();
+  });
+
+  it("ignores the live config.json file and other unrelated files", async () => {
+    const liveConfig = path.join(tmpDir, "config.json");
+    const unrelatedFile = path.join(tmpDir, "Preferences");
+    await fs.writeFile(liveConfig, "{}");
+    await fs.writeFile(unrelatedFile, "data");
+    const oldTime = new Date(NOW - THIRTY_ONE_DAYS_MS);
+    await fs.utimes(liveConfig, oldTime, oldTime);
+    await fs.utimes(unrelatedFile, oldTime, oldTime);
+
+    const deleted = await cleanupUserDataRootQuarantineFiles(tmpDir, NOW);
+    expect(deleted).toBe(0);
+    await expect(fs.access(liveConfig)).resolves.toBeUndefined();
+    await expect(fs.access(unrelatedFile)).resolves.toBeUndefined();
+  });
+
+  it("returns 0 when userData dir is missing", async () => {
+    const nonexistent = path.join(tmpDir, "does-not-exist");
+    const deleted = await cleanupUserDataRootQuarantineFiles(nonexistent, NOW);
+    expect(deleted).toBe(0);
   });
 });

--- a/electron/services/__tests__/projectQuarantineCleanup.test.ts
+++ b/electron/services/__tests__/projectQuarantineCleanup.test.ts
@@ -1,4 +1,4 @@
-import { describe, it, expect, beforeEach, afterEach } from "vitest";
+import { describe, it, expect, beforeEach, afterEach, vi } from "vitest";
 import fs from "fs/promises";
 import path from "path";
 import os from "os";
@@ -282,6 +282,35 @@ describe("cleanupQuarantinedProjectFiles", () => {
     const deleted = await cleanupQuarantinedProjectFiles(tmpDir, NOW);
     expect(deleted).toBe(0);
     await expect(fs.access(filePath)).resolves.toBeUndefined();
+  });
+
+  it("isolates per-project sweep failures (one bad dir does not abort others)", async () => {
+    const dir1 = await createProjectDir(VALID_PROJECT_ID);
+    const dir2 = await createProjectDir(VALID_PROJECT_ID_2);
+    const oldFile2 = await createCorruptedFile(
+      dir2,
+      "state.json.corrupted.1234567890",
+      THIRTY_ONE_DAYS_MS,
+      NOW
+    );
+
+    const realReaddir = fs.readdir;
+    const spy = vi.spyOn(fs, "readdir").mockImplementation(((p: string, opts?: unknown) => {
+      if (p === dir1) {
+        const err = new Error("EACCES: permission denied") as NodeJS.ErrnoException;
+        err.code = "EACCES";
+        return Promise.reject(err);
+      }
+      return (realReaddir as (p: string, opts?: unknown) => Promise<unknown>)(p, opts);
+    }) as typeof fs.readdir);
+
+    try {
+      const deleted = await cleanupQuarantinedProjectFiles(tmpDir, NOW);
+      expect(deleted).toBe(1);
+      await expect(fs.access(oldFile2)).rejects.toThrow();
+    } finally {
+      spy.mockRestore();
+    }
   });
 });
 

--- a/electron/services/projectQuarantineCleanup.ts
+++ b/electron/services/projectQuarantineCleanup.ts
@@ -76,12 +76,16 @@ export async function cleanupQuarantinedProjectFiles(
     if (!entry.isDirectory() || !isValidProjectId(entry.name)) continue;
 
     const projectDir = path.join(projectsConfigDir, entry.name);
-    deletedCount += await sweepDirectoryForPrefixes(
-      projectDir,
-      QUARANTINE_PREFIXES,
-      now,
-      "ProjectStore"
-    );
+    try {
+      deletedCount += await sweepDirectoryForPrefixes(
+        projectDir,
+        QUARANTINE_PREFIXES,
+        now,
+        "ProjectStore"
+      );
+    } catch (err) {
+      logError(`[ProjectStore] Failed to sweep quarantine in ${projectDir}`, err);
+    }
   }
 
   if (deletedCount > 0) {

--- a/electron/services/projectQuarantineCleanup.ts
+++ b/electron/services/projectQuarantineCleanup.ts
@@ -9,6 +9,7 @@ const QUARANTINE_MAX_AGE_MS = 30 * 24 * 60 * 60 * 1000;
 const QUARANTINE_PREFIXES = [
   "state.json.corrupted.",
   "state.json.corrupted",
+  "state.json.future-v",
   "settings.json.corrupted.",
   "settings.json.corrupted",
   "recipes.json.corrupted.",
@@ -17,13 +18,51 @@ const QUARANTINE_PREFIXES = [
   "workflows.json.corrupted",
 ];
 
+const GLOBAL_RECIPES_QUARANTINE_PREFIXES = ["recipes.json.corrupted."];
+const ROOT_CONFIG_QUARANTINE_PREFIXES = ["config.json.corrupted."];
+
+async function sweepDirectoryForPrefixes(
+  dir: string,
+  prefixes: readonly string[],
+  now: number,
+  logScope: string
+): Promise<number> {
+  let entries: import("fs").Dirent[];
+  try {
+    entries = await fs.readdir(dir, { withFileTypes: true });
+  } catch (err) {
+    if ((err as NodeJS.ErrnoException).code === "ENOENT") return 0;
+    throw err;
+  }
+
+  let deletedCount = 0;
+  for (const dirent of entries) {
+    if (!dirent.isFile()) continue;
+    const matches = prefixes.some((prefix) => dirent.name.startsWith(prefix));
+    if (!matches) continue;
+
+    const filePath = path.join(dir, dirent.name);
+    try {
+      const stats = await fs.lstat(filePath);
+      const ageMs = Math.max(0, now - stats.mtimeMs);
+      if (ageMs > QUARANTINE_MAX_AGE_MS) {
+        await resilientUnlink(filePath);
+        deletedCount++;
+      }
+    } catch (err) {
+      const code = (err as NodeJS.ErrnoException).code;
+      if (code === "ENOENT") continue;
+      logError(`[${logScope}] Failed to clean quarantine file: ${filePath}`, err);
+    }
+  }
+
+  return deletedCount;
+}
+
 export async function cleanupQuarantinedProjectFiles(
   projectsConfigDir: string,
   now: number = Date.now()
 ): Promise<number> {
-  const threshold = now - QUARANTINE_MAX_AGE_MS;
-  let deletedCount = 0;
-
   let entries: import("fs").Dirent[];
   try {
     entries = await fs.readdir(projectsConfigDir, { withFileTypes: true });
@@ -32,40 +71,57 @@ export async function cleanupQuarantinedProjectFiles(
     throw err;
   }
 
+  let deletedCount = 0;
   for (const entry of entries) {
     if (!entry.isDirectory() || !isValidProjectId(entry.name)) continue;
 
     const projectDir = path.join(projectsConfigDir, entry.name);
-
-    let dirEntries: import("fs").Dirent[];
-    try {
-      dirEntries = await fs.readdir(projectDir, { withFileTypes: true });
-    } catch {
-      continue;
-    }
-
-    for (const dirent of dirEntries) {
-      if (!dirent.isFile()) continue;
-      const matches = QUARANTINE_PREFIXES.some((prefix) => dirent.name.startsWith(prefix));
-      if (!matches) continue;
-
-      const filePath = path.join(projectDir, dirent.name);
-      try {
-        const stats = await fs.stat(filePath);
-        if (stats.mtimeMs < threshold) {
-          await resilientUnlink(filePath);
-          deletedCount++;
-        }
-      } catch (err) {
-        const code = (err as NodeJS.ErrnoException).code;
-        if (code === "ENOENT") continue;
-        logError(`[ProjectStore] Failed to clean quarantine file: ${filePath}`, err);
-      }
-    }
+    deletedCount += await sweepDirectoryForPrefixes(
+      projectDir,
+      QUARANTINE_PREFIXES,
+      now,
+      "ProjectStore"
+    );
   }
 
   if (deletedCount > 0) {
     logInfo(`[ProjectStore] Cleaned up ${deletedCount} quarantined file(s)`);
+  }
+
+  return deletedCount;
+}
+
+export async function cleanupGlobalQuarantineFiles(
+  globalConfigDir: string,
+  now: number = Date.now()
+): Promise<number> {
+  const deletedCount = await sweepDirectoryForPrefixes(
+    globalConfigDir,
+    GLOBAL_RECIPES_QUARANTINE_PREFIXES,
+    now,
+    "GlobalFileStore"
+  );
+
+  if (deletedCount > 0) {
+    logInfo(`[GlobalFileStore] Cleaned up ${deletedCount} quarantined file(s)`);
+  }
+
+  return deletedCount;
+}
+
+export async function cleanupUserDataRootQuarantineFiles(
+  userDataDir: string,
+  now: number = Date.now()
+): Promise<number> {
+  const deletedCount = await sweepDirectoryForPrefixes(
+    userDataDir,
+    ROOT_CONFIG_QUARANTINE_PREFIXES,
+    now,
+    "Store"
+  );
+
+  if (deletedCount > 0) {
+    logInfo(`[Store] Cleaned up ${deletedCount} quarantined config file(s)`);
   }
 
   return deletedCount;


### PR DESCRIPTION
## Summary

Three coverage gaps meant quarantine files from certain producers were never swept: `state.json.future-v*` files from downgrade quarantines, `recipes.json.corrupted.*` files under `${userData}/global/`, and `config.json.corrupted.*` files at the `userData` root. Two correctness defects also existed: `fs.stat` follows symlinks when making the age decision, and there was no clamp handling files with a future `mtimeMs` (clock-skew or corrected system clock).

Resolves #7102

## Changes

- Add `"state.json.future-v"` to `QUARANTINE_PREFIXES`
- Extract `sweepDirectoryForPrefixes` helper with `fs.lstat` and `Math.max(0, now - mtimeMs)` clock-skew clamp
- Add `cleanupGlobalQuarantineFiles()` sweeping `${userData}/global/recipes.json.corrupted.*`
- Add `cleanupUserDataRootQuarantineFiles()` sweeping `${userData}/config.json.corrupted.*` (shallow `readdir`, no recursion into Chromium-managed siblings)
- Wire both new sweeps into `ProjectStore.initialize()` as fire-and-forget
- Wrap per-project sweep calls in `try/catch` so an `EACCES` on one project doesn't abort the rest
- 26 unit tests covering all new paths, including the isolated-failure case via `vi.spyOn`'d `readdir`

## Testing

All 26 unit tests pass. Typecheck and lint clean. Build clean.