### PR TITLE
fix(project-stats): race guard and cold-start defer for ProjectStatsService

### DIFF
--- a/electron/ipc/handlers/__tests__/project.bulkStats.test.ts
+++ b/electron/ipc/handlers/__tests__/project.bulkStats.test.ts
@@ -86,10 +86,16 @@ vi.mock("../../../window/portDistribution.js", () => ({
   distributePortsToView: vi.fn(),
 }));
 
+vi.mock("../../../window/deferredInitQueue.js", () => ({
+  registerDeferredTask: vi.fn(),
+}));
+
 import { ipcMain } from "electron";
 import { CHANNELS } from "../../channels.js";
 import { registerProjectCrudHandlers } from "../projectCrud/index.js";
 import type { HandlerDependencies } from "../../types.js";
+import { registerDeferredTask } from "../../../window/deferredInitQueue.js";
+import { projectStore } from "../../../services/ProjectStore.js";
 
 function makePtyClient(overrides: Record<string, unknown> = {}) {
   return {
@@ -560,5 +566,55 @@ describe("handleProjectGetBulkStats", () => {
     >;
 
     expect(result["proj-a"].activeAgentCount).toBe(1); // only t2
+  });
+});
+
+describe("registerProjectStatsHandlers — deferred initial compute", () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+  });
+
+  it("defers the initial compute via registerDeferredTask instead of firing it eagerly", async () => {
+    (projectStore.getAllProjects as ReturnType<typeof vi.fn>).mockReturnValue([{ id: "p1" }]);
+    const ptyClient = makePtyClient();
+    const cleanup = registerProjectCrudHandlers(makeDeps(ptyClient));
+
+    expect(ptyClient.getAllTerminalsAsync).not.toHaveBeenCalled();
+    expect(ptyClient.getProjectStats).not.toHaveBeenCalled();
+
+    const mock = registerDeferredTask as unknown as ReturnType<typeof vi.fn>;
+    const taskCall = mock.mock.calls.find(
+      ([t]) => (t as { name?: string } | undefined)?.name === "project-stats-initial-compute"
+    );
+    expect(taskCall).toBeDefined();
+    const task = taskCall![0] as { name: string; run: () => void };
+
+    task.run();
+    await Promise.resolve();
+    await Promise.resolve();
+
+    expect(ptyClient.getAllTerminalsAsync).toHaveBeenCalledTimes(1);
+
+    cleanup();
+  });
+
+  it("deferred initial compute is a no-op once the service has stopped", async () => {
+    (projectStore.getAllProjects as ReturnType<typeof vi.fn>).mockReturnValue([{ id: "p1" }]);
+    const ptyClient = makePtyClient();
+    const cleanup = registerProjectCrudHandlers(makeDeps(ptyClient));
+
+    const mock = registerDeferredTask as unknown as ReturnType<typeof vi.fn>;
+    const task = (mock.mock.calls.find(
+      ([t]) => (t as { name?: string } | undefined)?.name === "project-stats-initial-compute"
+    )?.[0] ?? null) as { name: string; run: () => void } | null;
+    expect(task).not.toBeNull();
+
+    cleanup();
+
+    task!.run();
+    await Promise.resolve();
+    await Promise.resolve();
+
+    expect(ptyClient.getAllTerminalsAsync).not.toHaveBeenCalled();
   });
 });

--- a/electron/ipc/handlers/projectCrud/stats.ts
+++ b/electron/ipc/handlers/projectCrud/stats.ts
@@ -3,6 +3,7 @@ import { checkRateLimit, typedHandle } from "../../utils.js";
 import type { HandlerDependencies } from "../../types.js";
 import type { BulkProjectStats } from "../../../../shared/types/ipc/project.js";
 import { ProjectStatsService } from "../../../services/ProjectStatsService.js";
+import { registerDeferredTask } from "../../../window/deferredInitQueue.js";
 
 let projectStatsServiceInstance: ProjectStatsService | null = null;
 
@@ -16,6 +17,15 @@ export function registerProjectStatsHandlers(deps: HandlerDependencies): () => v
   const projectStatsService = new ProjectStatsService(deps.ptyClient);
   projectStatsServiceInstance = projectStatsService;
   projectStatsService.start();
+  // Defer the initial compute off the first-interactive critical path. The
+  // 5s aligned poll and agent-state debounce armed in start() continue to
+  // fire normally; this just keeps cold-start work off first paint.
+  registerDeferredTask({
+    name: "project-stats-initial-compute",
+    run: () => {
+      if (projectStatsService.isStarted) projectStatsService.refresh();
+    },
+  });
   handlers.push(() => {
     projectStatsService.stop();
     projectStatsServiceInstance = null;

--- a/electron/services/ProjectStatsService.ts
+++ b/electron/services/ProjectStatsService.ts
@@ -17,14 +17,18 @@ export class ProjectStatsService {
   private started = false;
   private lastBroadcast: ProjectStatusMap = {};
   private pollIntervalMs = DEFAULT_POLL_INTERVAL_MS;
+  private generation = 0;
 
   constructor(private ptyClient: PtyClient | undefined | null) {}
+
+  get isStarted(): boolean {
+    return this.started;
+  }
 
   start(): void {
     if (this.started) return;
     this.started = true;
 
-    void this.computeAndBroadcast();
     this.armPollInterval();
 
     this.unsubscribeAgentState = events.on("agent:state-changed", () => {
@@ -46,6 +50,9 @@ export class ProjectStatsService {
 
   stop(): void {
     if (!this.started) return;
+    // Bump generation first so any in-flight computeAndBroadcast that's
+    // already past its await is invalidated before we tear down state.
+    this.generation++;
     this.started = false;
 
     this.intervalSlot.clear();
@@ -100,10 +107,13 @@ export class ProjectStatsService {
   private async computeAndBroadcast(): Promise<void> {
     if (!this.ptyClient) return;
 
+    const gen = ++this.generation;
+
     try {
       const allProjects = projectStore.getAllProjects();
       const projectIds = allProjects.map((p) => p.id);
       if (projectIds.length === 0) {
+        if (this.generation !== gen) return;
         typedBroadcast<"project:stats-updated">(CHANNELS.PROJECT_STATS_UPDATED, {});
         return;
       }
@@ -114,6 +124,8 @@ export class ProjectStatsService {
           projectIds.map((id) => this.ptyClient!.getProjectStats(id).then((s) => [id, s] as const))
         ),
       ]);
+
+      if (this.generation !== gen) return;
 
       const agentCounts = new Map<string, { active: number; waiting: number }>();
       for (const id of projectIds) {

--- a/electron/services/ProjectStatsService.ts
+++ b/electron/services/ProjectStatsService.ts
@@ -49,10 +49,11 @@ export class ProjectStatsService {
   }
 
   stop(): void {
-    if (!this.started) return;
-    // Bump generation first so any in-flight computeAndBroadcast that's
-    // already past its await is invalidated before we tear down state.
+    // Always bump generation so an in-flight computeAndBroadcast — including
+    // one started by a pre-start refresh() — is invalidated before any
+    // post-stop write or broadcast can fire.
     this.generation++;
+    if (!this.started) return;
     this.started = false;
 
     this.intervalSlot.clear();
@@ -114,6 +115,10 @@ export class ProjectStatsService {
       const projectIds = allProjects.map((p) => p.id);
       if (projectIds.length === 0) {
         if (this.generation !== gen) return;
+        // Track the empty broadcast so a later non-empty result with the
+        // same shape as the prior non-empty broadcast still fires
+        // (shallowEqual would otherwise suppress it).
+        this.lastBroadcast = {};
         typedBroadcast<"project:stats-updated">(CHANNELS.PROJECT_STATS_UPDATED, {});
         return;
       }

--- a/electron/services/__tests__/ProjectStatsService.adversarial.test.ts
+++ b/electron/services/__tests__/ProjectStatsService.adversarial.test.ts
@@ -61,7 +61,6 @@ describe("ProjectStatsService adversarial", () => {
     const ptyClient = makePtyClient();
     const svc = new ProjectStatsService(ptyClient as never);
     svc.start();
-    await Promise.resolve(); // flush initial compute microtask
 
     eventEmitter.emit("agent:state-changed");
     svc.stop();
@@ -80,9 +79,6 @@ describe("ProjectStatsService adversarial", () => {
     projectStoreMock.getAllProjects.mockReturnValue([{ id: "p1" }]);
     const svc = new ProjectStatsService(ptyClient as never);
     svc.start();
-    // Flush initial compute microtask
-    await Promise.resolve();
-    await Promise.resolve();
 
     svc.updatePollInterval(1_000);
     ptyClient.getAllTerminalsAsync.mockClear();
@@ -205,8 +201,6 @@ describe("ProjectStatsService adversarial", () => {
     projectStoreMock.getAllProjects.mockReturnValue([{ id: "p1" }]);
     const svc = new ProjectStatsService(ptyClient as never);
     svc.start();
-    await Promise.resolve();
-    await Promise.resolve();
     ptyClient.getAllTerminalsAsync.mockClear();
 
     for (let i = 0; i < 10; i++) {
@@ -269,6 +263,101 @@ describe("ProjectStatsService adversarial", () => {
     const svc = new ProjectStatsService(null);
     svc.refresh();
     await vi.runAllTimersAsync();
+    expect(broadcastMock).not.toHaveBeenCalled();
+  });
+
+  it("start() does not fire an eager initial compute (deferred to first-interactive)", async () => {
+    const ptyClient = makePtyClient();
+    projectStoreMock.getAllProjects.mockReturnValue([{ id: "p1" }]);
+
+    const svc = new ProjectStatsService(ptyClient as never);
+    svc.start();
+    await vi.advanceTimersByTimeAsync(0);
+    await Promise.resolve();
+    await Promise.resolve();
+
+    expect(ptyClient.getAllTerminalsAsync).not.toHaveBeenCalled();
+    expect(ptyClient.getProjectStats).not.toHaveBeenCalled();
+    expect(broadcastMock).not.toHaveBeenCalled();
+    svc.stop();
+  });
+
+  it("race guard: a slow older compute does not overwrite a newer broadcast", async () => {
+    const ptyClient = makePtyClient();
+    projectStoreMock.getAllProjects.mockReturnValue([{ id: "p1" }]);
+
+    let resolveOldTerminals!: (terms: unknown[]) => void;
+    let resolveNewTerminals!: (terms: unknown[]) => void;
+    const oldTerminalsPromise = new Promise<unknown[]>((r) => {
+      resolveOldTerminals = r;
+    });
+    const newTerminalsPromise = new Promise<unknown[]>((r) => {
+      resolveNewTerminals = r;
+    });
+
+    ptyClient.getAllTerminalsAsync
+      .mockReturnValueOnce(oldTerminalsPromise)
+      .mockReturnValueOnce(newTerminalsPromise);
+
+    let statsCallCount = 0;
+    ptyClient.getProjectStats.mockImplementation(async (id: string) => {
+      statsCallCount += 1;
+      // First call carries stale data (terminalCount: 99), second the truth (1)
+      return { projectId: id, terminalCount: statsCallCount === 1 ? 99 : 1 };
+    });
+
+    const svc = new ProjectStatsService(ptyClient as never);
+    svc.refresh(); // older compute — generation 1
+    await Promise.resolve();
+    svc.refresh(); // newer compute — generation 2
+    await Promise.resolve();
+
+    // Resolve newer first → newer broadcast commits
+    resolveNewTerminals([]);
+    await vi.runAllTimersAsync();
+    await Promise.resolve();
+
+    expect(broadcastMock).toHaveBeenCalled();
+    const broadcastsAfterNew = broadcastMock.mock.calls.length;
+    const lastPayload = broadcastMock.mock.calls.at(-1)![1] as Record<
+      string,
+      { processCount: number }
+    >;
+    expect(lastPayload.p1.processCount).toBe(1);
+
+    // Now resolve the older compute — it must NOT broadcast the stale 99
+    resolveOldTerminals([]);
+    await vi.runAllTimersAsync();
+    await Promise.resolve();
+
+    expect(broadcastMock.mock.calls.length).toBe(broadcastsAfterNew);
+    svc.stop();
+  });
+
+  it("stop() invalidates an in-flight compute — no broadcast after teardown", async () => {
+    const ptyClient = makePtyClient();
+    projectStoreMock.getAllProjects.mockReturnValue([{ id: "p1" }]);
+
+    let resolvePty!: (terms: unknown[]) => void;
+    ptyClient.getAllTerminalsAsync.mockReturnValueOnce(
+      new Promise<unknown[]>((r) => {
+        resolvePty = r;
+      })
+    );
+
+    const svc = new ProjectStatsService(ptyClient as never);
+    svc.start();
+    svc.refresh(); // arms the in-flight compute
+    await Promise.resolve();
+
+    broadcastMock.mockClear();
+
+    svc.stop();
+
+    resolvePty([]);
+    await vi.runAllTimersAsync();
+    await Promise.resolve();
+
     expect(broadcastMock).not.toHaveBeenCalled();
   });
 });

--- a/electron/services/__tests__/ProjectStatsService.adversarial.test.ts
+++ b/electron/services/__tests__/ProjectStatsService.adversarial.test.ts
@@ -334,6 +334,38 @@ describe("ProjectStatsService adversarial", () => {
     svc.stop();
   });
 
+  it("empty broadcast resets lastBroadcast so a same-shape non-empty result still fires", async () => {
+    const ptyClient = makePtyClient();
+    ptyClient.getProjectStats.mockResolvedValue({ projectId: "p1", terminalCount: 3 });
+
+    const svc = new ProjectStatsService(ptyClient as never);
+
+    // 1) Non-empty broadcast — lastBroadcast = { p1: {processCount: 3, ...} }
+    projectStoreMock.getAllProjects.mockReturnValue([{ id: "p1" }]);
+    svc.refresh();
+    await vi.runAllTimersAsync();
+    const afterFirst = broadcastMock.mock.calls.length;
+    expect(afterFirst).toBeGreaterThanOrEqual(1);
+
+    // 2) Projects removed — empty broadcast fires; must reset lastBroadcast
+    projectStoreMock.getAllProjects.mockReturnValue([]);
+    svc.refresh();
+    await vi.runAllTimersAsync();
+
+    // 3) Same project re-added with identical stats — must broadcast
+    // (would be suppressed by shallowEqual if lastBroadcast still held it)
+    projectStoreMock.getAllProjects.mockReturnValue([{ id: "p1" }]);
+    svc.refresh();
+    await vi.runAllTimersAsync();
+
+    const lastPayload = broadcastMock.mock.calls.at(-1)![1] as Record<
+      string,
+      { processCount: number }
+    >;
+    expect(lastPayload.p1?.processCount).toBe(3);
+    svc.stop();
+  });
+
   it("stop() invalidates an in-flight compute — no broadcast after teardown", async () => {
     const ptyClient = makePtyClient();
     projectStoreMock.getAllProjects.mockReturnValue([{ id: "p1" }]);


### PR DESCRIPTION
## Summary

- Adds a generation token race guard to `computeAndBroadcast()` so a stale in-flight result can't clobber fresher state when the 5s poll and the 200ms-debounced `agent:state-changed` listener interleave. `stop()` also unconditionally bumps the generation to invalidate any in-flight compute.
- Moves the cold-start initial compute out of `start()` and into a `registerDeferredTask` call (`project-stats-initial-compute`) so it fires after first-interactive rather than on the critical IPC path. A `isStarted` getter gates the deferred fire so a post-`stop()` trigger is a no-op.
- Fixes the empty-project broadcast path to reset `lastBroadcast = {}` so a subsequent non-empty result with the same shape as the prior non-empty broadcast still fires (previously `shallowEqual` suppressed it).

Resolves #7101

## Changes

- `electron/services/ProjectStatsService.ts` — generation token, `isStarted` getter, `lastBroadcast` reset on empty broadcast, eager compute removed from `start()`
- `electron/ipc/handlers/projectCrud/stats.ts` — registers `project-stats-initial-compute` deferred task
- 6 new tests in `adversarial` and `bulkStats` suites: race guard, stop-during-flight, no-eager-compute-on-start, empty→non-empty same-shape regression, deferred-task registration, deferred-task-after-stop no-op

## Testing

30 tests pass. Lint warnings dropped by 9. Typecheck clean.