### PR TITLE
fix(ipc): validate sender frame on recovery reload IPCs

### DIFF
--- a/electron/ipc/handlers/__tests__/recovery.handlers.test.ts
+++ b/electron/ipc/handlers/__tests__/recovery.handlers.test.ts
@@ -102,8 +102,13 @@ describe("registerRecoveryHandlers", () => {
     collectDiagnosticsMock.mockResolvedValue({ version: "test", platform: "darwin" });
   });
 
-  it("registers export-diagnostics and open-logs via typedHandleWithContext", () => {
+  it("registers all four recovery channels via typedHandleWithContext", () => {
     registerRecoveryHandlers(deps);
+    expect(ipcMainMock.handle).toHaveBeenCalledWith("recovery:reload-app", expect.any(Function));
+    expect(ipcMainMock.handle).toHaveBeenCalledWith(
+      "recovery:reset-and-reload",
+      expect.any(Function)
+    );
     expect(ipcMainMock.handle).toHaveBeenCalledWith(
       "recovery:export-diagnostics",
       expect.any(Function)
@@ -114,8 +119,175 @@ describe("registerRecoveryHandlers", () => {
   it("cleanup removes the handlers", () => {
     const cleanup = registerRecoveryHandlers(deps);
     cleanup();
+    expect(ipcMainMock.removeHandler).toHaveBeenCalledWith("recovery:reload-app");
+    expect(ipcMainMock.removeHandler).toHaveBeenCalledWith("recovery:reset-and-reload");
     expect(ipcMainMock.removeHandler).toHaveBeenCalledWith("recovery:export-diagnostics");
     expect(ipcMainMock.removeHandler).toHaveBeenCalledWith("recovery:open-logs");
+  });
+
+  describe("recovery:reload-app", () => {
+    function buildWindow() {
+      return {
+        isDestroyed: vi.fn(() => false),
+        loadURL: vi.fn(),
+      } as unknown as { isDestroyed: () => boolean; loadURL: ReturnType<typeof vi.fn> };
+    }
+
+    it("rejects untrusted sender and does not call loadURL", async () => {
+      const win = buildWindow();
+      const localDeps = { mainWindow: win } as unknown as HandlerDependencies;
+      registerRecoveryHandlers(localDeps);
+      const handler = getHandlerFn("recovery:reload-app");
+
+      await expect(handler(buildEvent(UNTRUSTED_URL))).rejects.toThrow(
+        "recovery:reload-app rejected: untrusted sender"
+      );
+      expect(win.loadURL).not.toHaveBeenCalled();
+    });
+
+    it("rejects the main renderer URL (not the recovery page)", async () => {
+      const win = buildWindow();
+      const localDeps = { mainWindow: win } as unknown as HandlerDependencies;
+      registerRecoveryHandlers(localDeps);
+      const handler = getHandlerFn("recovery:reload-app");
+
+      await expect(handler(buildEvent(MAIN_RENDERER_URL))).rejects.toThrow(
+        "recovery:reload-app rejected: untrusted sender"
+      );
+      expect(win.loadURL).not.toHaveBeenCalled();
+    });
+
+    it("rejects missing senderFrame", async () => {
+      const win = buildWindow();
+      const localDeps = { mainWindow: win } as unknown as HandlerDependencies;
+      registerRecoveryHandlers(localDeps);
+      const handler = getHandlerFn("recovery:reload-app");
+
+      await expect(handler(buildEvent(null))).rejects.toThrow(
+        "recovery:reload-app rejected: untrusted sender"
+      );
+      expect(win.loadURL).not.toHaveBeenCalled();
+    });
+
+    it("calls loadURL on the primary window when sender is the recovery page", async () => {
+      const win = buildWindow();
+      const localDeps = { mainWindow: win } as unknown as HandlerDependencies;
+      registerRecoveryHandlers(localDeps);
+      const handler = getHandlerFn("recovery:reload-app");
+
+      await handler(buildEvent(TRUSTED_RECOVERY_URL));
+
+      expect(win.loadURL).toHaveBeenCalledTimes(1);
+    });
+
+    it("is a no-op when the window is destroyed", async () => {
+      const win = buildWindow();
+      win.isDestroyed = vi.fn(() => true);
+      const localDeps = { mainWindow: win } as unknown as HandlerDependencies;
+      registerRecoveryHandlers(localDeps);
+      const handler = getHandlerFn("recovery:reload-app");
+
+      await expect(handler(buildEvent(TRUSTED_RECOVERY_URL))).resolves.toBeUndefined();
+      expect(win.loadURL).not.toHaveBeenCalled();
+    });
+
+    it("is a no-op when no window is available", async () => {
+      registerRecoveryHandlers(deps);
+      const handler = getHandlerFn("recovery:reload-app");
+
+      await expect(handler(buildEvent(TRUSTED_RECOVERY_URL))).resolves.toBeUndefined();
+    });
+  });
+
+  describe("recovery:reset-and-reload", () => {
+    function buildWindow() {
+      return {
+        isDestroyed: vi.fn(() => false),
+        loadURL: vi.fn(),
+      } as unknown as { isDestroyed: () => boolean; loadURL: ReturnType<typeof vi.fn> };
+    }
+
+    it("rejects untrusted sender and does not reset state or reload", async () => {
+      const { getCrashRecoveryService: getCrash } =
+        await import("../../../services/CrashRecoveryService.js");
+      const resetMock = vi.fn();
+      vi.mocked(getCrash).mockReturnValue({
+        resetToFresh: resetMock,
+      } as unknown as ReturnType<typeof getCrash>);
+
+      const win = buildWindow();
+      const localDeps = { mainWindow: win } as unknown as HandlerDependencies;
+      registerRecoveryHandlers(localDeps);
+      const handler = getHandlerFn("recovery:reset-and-reload");
+
+      await expect(handler(buildEvent(UNTRUSTED_URL))).rejects.toThrow(
+        "recovery:reset-and-reload rejected: untrusted sender"
+      );
+      expect(resetMock).not.toHaveBeenCalled();
+      expect(win.loadURL).not.toHaveBeenCalled();
+    });
+
+    it("rejects the main renderer URL (not the recovery page)", async () => {
+      const win = buildWindow();
+      const localDeps = { mainWindow: win } as unknown as HandlerDependencies;
+      registerRecoveryHandlers(localDeps);
+      const handler = getHandlerFn("recovery:reset-and-reload");
+
+      await expect(handler(buildEvent(MAIN_RENDERER_URL))).rejects.toThrow(
+        "recovery:reset-and-reload rejected: untrusted sender"
+      );
+      expect(win.loadURL).not.toHaveBeenCalled();
+    });
+
+    it("rejects missing senderFrame", async () => {
+      const win = buildWindow();
+      const localDeps = { mainWindow: win } as unknown as HandlerDependencies;
+      registerRecoveryHandlers(localDeps);
+      const handler = getHandlerFn("recovery:reset-and-reload");
+
+      await expect(handler(buildEvent(null))).rejects.toThrow(
+        "recovery:reset-and-reload rejected: untrusted sender"
+      );
+      expect(win.loadURL).not.toHaveBeenCalled();
+    });
+
+    it("resets state then reloads the app when sender is the recovery page", async () => {
+      const { getCrashRecoveryService: getCrash } =
+        await import("../../../services/CrashRecoveryService.js");
+      const resetMock = vi.fn();
+      vi.mocked(getCrash).mockReturnValue({
+        resetToFresh: resetMock,
+      } as unknown as ReturnType<typeof getCrash>);
+
+      const win = buildWindow();
+      const localDeps = { mainWindow: win } as unknown as HandlerDependencies;
+      registerRecoveryHandlers(localDeps);
+      const handler = getHandlerFn("recovery:reset-and-reload");
+
+      await handler(buildEvent(TRUSTED_RECOVERY_URL));
+
+      expect(resetMock).toHaveBeenCalledTimes(1);
+      expect(win.loadURL).toHaveBeenCalledTimes(1);
+    });
+
+    it("is a no-op when the window is destroyed", async () => {
+      const { getCrashRecoveryService: getCrash } =
+        await import("../../../services/CrashRecoveryService.js");
+      const resetMock = vi.fn();
+      vi.mocked(getCrash).mockReturnValue({
+        resetToFresh: resetMock,
+      } as unknown as ReturnType<typeof getCrash>);
+
+      const win = buildWindow();
+      win.isDestroyed = vi.fn(() => true);
+      const localDeps = { mainWindow: win } as unknown as HandlerDependencies;
+      registerRecoveryHandlers(localDeps);
+      const handler = getHandlerFn("recovery:reset-and-reload");
+
+      await expect(handler(buildEvent(TRUSTED_RECOVERY_URL))).resolves.toBeUndefined();
+      expect(resetMock).not.toHaveBeenCalled();
+      expect(win.loadURL).not.toHaveBeenCalled();
+    });
   });
 
   describe("recovery:export-diagnostics", () => {

--- a/electron/ipc/handlers/__tests__/recovery.handlers.test.ts
+++ b/electron/ipc/handlers/__tests__/recovery.handlers.test.ts
@@ -67,6 +67,16 @@ vi.mock("../../../utils/logger.js", () => ({
   getLogFilePath: vi.fn(() => "/tmp/daintree/logs/main.log"),
 }));
 
+vi.mock("../../../../shared/config/devServer.js", async () => {
+  const actual = await vi.importActual<typeof import("../../../../shared/config/devServer.js")>(
+    "../../../../shared/config/devServer.js"
+  );
+  return {
+    ...actual,
+    getDevServerUrl: vi.fn(() => "http://localhost:5173"),
+  };
+});
+
 import { registerRecoveryHandlers } from "../recovery.js";
 import type { HandlerDependencies } from "../../types.js";
 
@@ -178,6 +188,7 @@ describe("registerRecoveryHandlers", () => {
       await handler(buildEvent(TRUSTED_RECOVERY_URL));
 
       expect(win.loadURL).toHaveBeenCalledTimes(1);
+      expect(win.loadURL).toHaveBeenCalledWith("http://localhost:5173");
     });
 
     it("is a no-op when the window is destroyed", async () => {
@@ -228,6 +239,13 @@ describe("registerRecoveryHandlers", () => {
     });
 
     it("rejects the main renderer URL (not the recovery page)", async () => {
+      const { getCrashRecoveryService: getCrash } =
+        await import("../../../services/CrashRecoveryService.js");
+      const resetMock = vi.fn();
+      vi.mocked(getCrash).mockReturnValue({
+        resetToFresh: resetMock,
+      } as unknown as ReturnType<typeof getCrash>);
+
       const win = buildWindow();
       const localDeps = { mainWindow: win } as unknown as HandlerDependencies;
       registerRecoveryHandlers(localDeps);
@@ -236,10 +254,18 @@ describe("registerRecoveryHandlers", () => {
       await expect(handler(buildEvent(MAIN_RENDERER_URL))).rejects.toThrow(
         "recovery:reset-and-reload rejected: untrusted sender"
       );
+      expect(resetMock).not.toHaveBeenCalled();
       expect(win.loadURL).not.toHaveBeenCalled();
     });
 
     it("rejects missing senderFrame", async () => {
+      const { getCrashRecoveryService: getCrash } =
+        await import("../../../services/CrashRecoveryService.js");
+      const resetMock = vi.fn();
+      vi.mocked(getCrash).mockReturnValue({
+        resetToFresh: resetMock,
+      } as unknown as ReturnType<typeof getCrash>);
+
       const win = buildWindow();
       const localDeps = { mainWindow: win } as unknown as HandlerDependencies;
       registerRecoveryHandlers(localDeps);
@@ -248,6 +274,7 @@ describe("registerRecoveryHandlers", () => {
       await expect(handler(buildEvent(null))).rejects.toThrow(
         "recovery:reset-and-reload rejected: untrusted sender"
       );
+      expect(resetMock).not.toHaveBeenCalled();
       expect(win.loadURL).not.toHaveBeenCalled();
     });
 
@@ -268,6 +295,10 @@ describe("registerRecoveryHandlers", () => {
 
       expect(resetMock).toHaveBeenCalledTimes(1);
       expect(win.loadURL).toHaveBeenCalledTimes(1);
+      expect(win.loadURL).toHaveBeenCalledWith("http://localhost:5173");
+      expect(resetMock.mock.invocationCallOrder[0]).toBeLessThan(
+        win.loadURL.mock.invocationCallOrder[0]
+      );
     });
 
     it("is a no-op when the window is destroyed", async () => {

--- a/electron/ipc/handlers/recovery.ts
+++ b/electron/ipc/handlers/recovery.ts
@@ -10,7 +10,7 @@ import { isRecoveryPageUrl } from "../../../shared/utils/trustedRenderer.js";
 // by user action — keeps DiagnosticsCollector and its archiver/v8 deps out
 // of the eager-import graph).
 import { getLogFilePath } from "../../utils/logger.js";
-import { typedHandle, typedHandleWithContext } from "../utils.js";
+import { typedHandleWithContext } from "../utils.js";
 
 function getAppUrl(): string {
   if (process.env.NODE_ENV === "development") {
@@ -19,11 +19,22 @@ function getAppUrl(): string {
   return "app://daintree/index.html";
 }
 
+// All four recovery handlers validate event.senderFrame.url synchronously
+// (before any await) to accept calls only from recovery.html — not the main
+// renderer or arbitrary frames. typedHandleWithContext exposes the event via
+// ctx so the origin check runs before any side effects.
 export function registerRecoveryHandlers(deps: HandlerDependencies): () => void {
   const handlers: Array<() => void> = [];
 
   handlers.push(
-    typedHandle(CHANNELS.RECOVERY_RELOAD_APP, () => {
+    typedHandleWithContext(CHANNELS.RECOVERY_RELOAD_APP, async (ctx): Promise<void> => {
+      const senderUrl = ctx.event.senderFrame?.url;
+      if (!senderUrl || !isRecoveryPageUrl(senderUrl)) {
+        throw new Error(
+          `recovery:reload-app rejected: untrusted sender (url=${senderUrl ?? "unknown"})`
+        );
+      }
+
       const win = deps.windowRegistry?.getPrimary()?.browserWindow ?? deps.mainWindow;
       if (win && !win.isDestroyed()) {
         console.log("[MAIN] Recovery: reloading app");
@@ -33,7 +44,14 @@ export function registerRecoveryHandlers(deps: HandlerDependencies): () => void 
   );
 
   handlers.push(
-    typedHandle(CHANNELS.RECOVERY_RESET_AND_RELOAD, () => {
+    typedHandleWithContext(CHANNELS.RECOVERY_RESET_AND_RELOAD, async (ctx): Promise<void> => {
+      const senderUrl = ctx.event.senderFrame?.url;
+      if (!senderUrl || !isRecoveryPageUrl(senderUrl)) {
+        throw new Error(
+          `recovery:reset-and-reload rejected: untrusted sender (url=${senderUrl ?? "unknown"})`
+        );
+      }
+
       const win = deps.windowRegistry?.getPrimary()?.browserWindow ?? deps.mainWindow;
       if (win && !win.isDestroyed()) {
         console.log("[MAIN] Recovery: resetting state and reloading app");
@@ -43,10 +61,6 @@ export function registerRecoveryHandlers(deps: HandlerDependencies): () => void 
     })
   );
 
-  // These two handlers validate event.senderFrame.url synchronously (before any
-  // await) to accept calls only from recovery.html — not the main renderer or
-  // arbitrary frames. Using typedHandleWithContext keeps type safety while
-  // exposing the event via ctx for the origin check.
   handlers.push(
     typedHandleWithContext(CHANNELS.RECOVERY_EXPORT_DIAGNOSTICS, async (ctx): Promise<boolean> => {
       const senderUrl = ctx.event.senderFrame?.url;


### PR DESCRIPTION
## Summary

`RECOVERY_RESET_AND_RELOAD` and `RECOVERY_RELOAD_APP` in `recovery.ts` were missing the `senderFrame` validation that `RECOVERY_EXPORT_DIAGNOSTICS` and `RECOVERY_OPEN_LOGS` already had. Minor asymmetry, but `RECOVERY_RESET_AND_RELOAD` is destructive, so it's worth closing.

Applied the existing pattern to both: switched from `typedHandle` to `typedHandleWithContext`, added the `isRecoveryPageUrl` guard, and throw on rejection so untrusted callers can't trigger either action.

Resolves #7144

## Changes

- `recovery.ts`: `RECOVERY_RELOAD_APP` and `RECOVERY_RESET_AND_RELOAD` now use `typedHandleWithContext` with the `isRecoveryPageUrl` guard, matching the other two handlers in the file
- `recovery.handlers.test.ts`: expanded to cover all four channels — registration parity, cleanup parity, sender-frame rejection (untrusted URL, main renderer, missing frame), and happy-path side effects (`loadURL` target, `resetToFresh`-before-`loadURL` ordering)

## Testing

28 tests pass via vitest. Typecheck, lint, and format all clean.