### PR TITLE
fix(migrations): harden DB migrations against partial-failure replay

### DIFF
--- a/electron/services/__tests__/StoreMigrations.test.ts
+++ b/electron/services/__tests__/StoreMigrations.test.ts
@@ -875,24 +875,24 @@ describe("MigrationRunner", () => {
       expect((store.data.appState as Record<string, unknown>).recipes).toEqual([]);
     });
 
-    it("swallows errors from saveRecipes and preserves legacy recipes", async () => {
+    it("rethrows saveRecipes failures so MigrationRunner can restore the backup", async () => {
       const recipes = [{ id: "r1", name: "Recipe", terminals: [] }];
       const store = createMockStore(storePath, { appState: { recipes } });
       mockProjectStore.getCurrentProjectId.mockReturnValue("proj-1");
       mockProjectStore.getProjectById.mockReturnValue({ id: "proj-1" });
       mockProjectStore.getRecipes.mockResolvedValue([]);
       mockProjectStore.saveRecipes.mockRejectedValue(new Error("disk full"));
-      await expect(migration003.up(store as never)).resolves.toBeUndefined();
+      await expect(migration003.up(store as never)).rejects.toThrow("disk full");
       expect((store.data.appState as Record<string, unknown>).recipes).toEqual(recipes);
     });
 
-    it("swallows errors from getRecipes and preserves legacy recipes without saving", async () => {
+    it("rethrows getRecipes failures and never reaches saveRecipes", async () => {
       const recipes = [{ id: "r1", name: "Recipe", terminals: [] }];
       const store = createMockStore(storePath, { appState: { recipes } });
       mockProjectStore.getCurrentProjectId.mockReturnValue("proj-1");
       mockProjectStore.getProjectById.mockReturnValue({ id: "proj-1" });
       mockProjectStore.getRecipes.mockRejectedValue(new Error("sqlite locked"));
-      await expect(migration003.up(store as never)).resolves.toBeUndefined();
+      await expect(migration003.up(store as never)).rejects.toThrow("sqlite locked");
       expect(mockProjectStore.saveRecipes).not.toHaveBeenCalled();
       expect((store.data.appState as Record<string, unknown>).recipes).toEqual(recipes);
     });

--- a/electron/services/migrations/003-migrate-recipes-to-project.ts
+++ b/electron/services/migrations/003-migrate-recipes-to-project.ts
@@ -35,62 +35,62 @@ export const migration003: Migration = {
       `[Migration 003] Migrating ${appState.recipes.length} recipe(s) to project ${currentProjectId}`
     );
 
-    try {
-      // Load existing project recipes to merge (avoid overwriting)
-      const existingRecipes = await projectStore.getRecipes(currentProjectId);
-      const existingIds = new Set(existingRecipes.map((r) => r.id));
+    // Load existing project recipes to merge (avoid overwriting)
+    const existingRecipes = await projectStore.getRecipes(currentProjectId);
+    const existingIds = new Set(existingRecipes.map((r) => r.id));
 
-      console.log(`[Migration 003] Found ${existingRecipes.length} existing recipe(s) in project`);
+    console.log(`[Migration 003] Found ${existingRecipes.length} existing recipe(s) in project`);
 
-      // Convert legacy recipes to new format with projectId, filtering out duplicates
-      const migratedRecipes: TerminalRecipe[] = appState.recipes
-        .filter((legacyRecipe) => {
-          if (existingIds.has(legacyRecipe.id)) {
-            console.log(`[Migration 003] Skipping duplicate recipe: ${legacyRecipe.id}`);
-            return false;
-          }
-          return true;
-        })
-        .map((legacyRecipe) => {
-          const terminals: RecipeTerminal[] = (legacyRecipe.terminals || []).map((t) => ({
-            type: (t.launchAgentId ?? "terminal") as RecipeTerminal["type"],
-            title: t.title,
-            command: t.command,
-            env: t.env,
-          }));
+    // Convert legacy recipes to new format with projectId, filtering out duplicates
+    const migratedRecipes: TerminalRecipe[] = appState.recipes
+      .filter((legacyRecipe) => {
+        if (existingIds.has(legacyRecipe.id)) {
+          console.log(`[Migration 003] Skipping duplicate recipe: ${legacyRecipe.id}`);
+          return false;
+        }
+        return true;
+      })
+      .map((legacyRecipe) => {
+        const terminals: RecipeTerminal[] = (legacyRecipe.terminals || []).map((t) => ({
+          type: (t.launchAgentId ?? "terminal") as RecipeTerminal["type"],
+          title: t.title,
+          command: t.command,
+          env: t.env,
+        }));
 
-          return {
-            id: legacyRecipe.id,
-            name: legacyRecipe.name,
-            projectId: currentProjectId,
-            worktreeId: legacyRecipe.worktreeId,
-            terminals,
-            createdAt: legacyRecipe.createdAt || Date.now(),
-            showInEmptyState: legacyRecipe.showInEmptyState,
-            lastUsedAt: legacyRecipe.lastUsedAt,
-          };
-        });
+        return {
+          id: legacyRecipe.id,
+          name: legacyRecipe.name,
+          projectId: currentProjectId,
+          worktreeId: legacyRecipe.worktreeId,
+          terminals,
+          createdAt: legacyRecipe.createdAt || Date.now(),
+          showInEmptyState: legacyRecipe.showInEmptyState,
+          lastUsedAt: legacyRecipe.lastUsedAt,
+        };
+      });
 
-      if (migratedRecipes.length === 0) {
-        console.log("[Migration 003] No new recipes to migrate (all already exist)");
-      } else {
-        // Merge with existing recipes
-        const mergedRecipes = [...existingRecipes, ...migratedRecipes];
+    if (migratedRecipes.length === 0) {
+      console.log("[Migration 003] No new recipes to migrate (all already exist)");
+    } else {
+      // Merge with existing recipes
+      const mergedRecipes = [...existingRecipes, ...migratedRecipes];
 
-        // Save merged recipes to project-scoped storage
+      // Rethrow on save failure so MigrationRunner activates the backup-restore
+      // path; legacy recipes stay in `appState` until the retry succeeds.
+      try {
         await projectStore.saveRecipes(currentProjectId, mergedRecipes);
-
-        console.log(
-          `[Migration 003] Successfully migrated ${migratedRecipes.length} new recipe(s), total now ${mergedRecipes.length}`
-        );
+      } catch (error) {
+        console.error(`[Migration 003] saveRecipes failed for project ${currentProjectId}:`, error);
+        throw error;
       }
 
-      // Clear global recipes only after successful migration
-      store.set("appState", { ...appState, recipes: [] });
-    } catch (error) {
-      console.error("[Migration 003] Failed to migrate recipes:", error);
-      // Don't throw and don't clear global recipes - let the app continue
-      // The global recipes will remain and can be manually migrated later
+      console.log(
+        `[Migration 003] Successfully migrated ${migratedRecipes.length} new recipe(s), total now ${mergedRecipes.length}`
+      );
     }
+
+    // Clear global recipes only after successful migration
+    store.set("appState", { ...appState, recipes: [] });
   },
 };

--- a/electron/services/migrations/008-split-notification-sounds.ts
+++ b/electron/services/migrations/008-split-notification-sounds.ts
@@ -5,11 +5,16 @@ export const migration008: Migration = {
   description: "Split soundFile into per-event notification sound fields",
   up: (store) => {
     const settings = store.get("notificationSettings") as
-      | { soundFile?: string; [key: string]: unknown }
+      | { soundFile?: string; completedSoundFile?: string; [key: string]: unknown }
       | undefined;
 
     if (!settings) {
       console.log("[Migration 008] No notificationSettings found, skipping");
+      return;
+    }
+
+    if (settings.completedSoundFile !== undefined) {
+      console.log("[Migration 008] completedSoundFile already present, skipping");
       return;
     }
 

--- a/electron/services/migrations/012-default-pin-agents.ts
+++ b/electron/services/migrations/012-default-pin-agents.ts
@@ -12,7 +12,8 @@ interface LegacyAgentSettings {
   [key: string]: unknown;
 }
 
-function entryNeedsMigration(entry: LegacyAgentEntry): boolean {
+function entryNeedsMigration(entry: LegacyAgentEntry | null | undefined): boolean {
+  if (!entry || typeof entry !== "object") return false;
   return "selected" in entry || "enabled" in entry || !("pinned" in entry);
 }
 

--- a/electron/services/migrations/012-default-pin-agents.ts
+++ b/electron/services/migrations/012-default-pin-agents.ts
@@ -3,12 +3,17 @@ import type { Migration } from "../StoreMigrations.js";
 interface LegacyAgentEntry {
   selected?: boolean;
   enabled?: boolean;
+  pinned?: boolean;
   [key: string]: unknown;
 }
 
 interface LegacyAgentSettings {
   agents?: Record<string, LegacyAgentEntry>;
   [key: string]: unknown;
+}
+
+function entryNeedsMigration(entry: LegacyAgentEntry): boolean {
+  return "selected" in entry || "enabled" in entry || !("pinned" in entry);
 }
 
 export const migration012: Migration = {
@@ -19,8 +24,14 @@ export const migration012: Migration = {
     if (!agentSettings?.agents) return;
 
     const updatedAgents: Record<string, Record<string, unknown>> = {};
+    let changed = false;
 
     for (const [id, entry] of Object.entries(agentSettings.agents)) {
+      if (!entryNeedsMigration(entry)) {
+        updatedAgents[id] = entry;
+        continue;
+      }
+
       // Grandfather v0.6.0 visibility: anything that wasn't explicitly
       // unselected becomes pinned. v0.6.0 normalization stayed in-memory and
       // never persisted `selected: true` for default-visible agents, so
@@ -29,7 +40,10 @@ export const migration012: Migration = {
 
       const { selected: _s, enabled: _e, ...rest } = entry;
       updatedAgents[id] = { ...rest, pinned };
+      changed = true;
     }
+
+    if (!changed) return;
 
     store.set("agentSettings", { ...agentSettings, agents: updatedAgents });
   },

--- a/electron/services/migrations/__tests__/003-migrate-recipes-to-project.test.ts
+++ b/electron/services/migrations/__tests__/003-migrate-recipes-to-project.test.ts
@@ -1,0 +1,149 @@
+import { beforeEach, describe, expect, it, vi } from "vitest";
+
+const projectStoreMock = vi.hoisted(() => ({
+  getCurrentProjectId: vi.fn<[], string | null>(() => "proj-1"),
+  getProjectById: vi.fn<[string], unknown>(() => ({ id: "proj-1" })),
+  getRecipes: vi.fn<[string], Promise<unknown[]>>(async () => []),
+  saveRecipes: vi.fn<[string, unknown[]], Promise<void>>(async () => {}),
+}));
+
+vi.mock("../../ProjectStore.js", () => ({ projectStore: projectStoreMock }));
+
+import { migration003 } from "../003-migrate-recipes-to-project.js";
+
+function makeStoreMock(data: Record<string, unknown>) {
+  return {
+    get: vi.fn((key: string) => data[key]),
+    set: vi.fn((key: string, value: unknown) => {
+      data[key] = value;
+    }),
+  } as unknown as Parameters<typeof migration003.up>[0];
+}
+
+const legacyRecipe = {
+  id: "r1",
+  name: "Recipe One",
+  worktreeId: "wt-1",
+  terminals: [{ launchAgentId: "claude", title: "Agent", command: "go", env: {} }],
+  createdAt: 1000,
+};
+
+describe("migration003 — migrate global recipes to project", () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+    projectStoreMock.getCurrentProjectId.mockReturnValue("proj-1");
+    projectStoreMock.getProjectById.mockReturnValue({ id: "proj-1" });
+    projectStoreMock.getRecipes.mockResolvedValue([]);
+    projectStoreMock.saveRecipes.mockResolvedValue(undefined);
+  });
+
+  it("has version 3", () => {
+    expect(migration003.version).toBe(3);
+  });
+
+  it("rethrows when saveRecipes fails and preserves legacy recipes", async () => {
+    const data: Record<string, unknown> = {
+      appState: { recipes: [legacyRecipe] },
+    };
+    const store = makeStoreMock(data);
+    const saveError = new Error("disk full");
+    projectStoreMock.saveRecipes.mockRejectedValueOnce(saveError);
+
+    await expect(migration003.up(store)).rejects.toThrow("disk full");
+
+    // Legacy recipes must NOT be cleared so the next migration retry sees them
+    const after = data.appState as { recipes: unknown[] };
+    expect(after.recipes).toEqual([legacyRecipe]);
+    expect(store.set).not.toHaveBeenCalledWith(
+      "appState",
+      expect.objectContaining({ recipes: [] })
+    );
+  });
+
+  it("rethrows when getRecipes fails and preserves legacy recipes", async () => {
+    const data: Record<string, unknown> = {
+      appState: { recipes: [legacyRecipe] },
+    };
+    const store = makeStoreMock(data);
+    projectStoreMock.getRecipes.mockRejectedValueOnce(new Error("read failure"));
+
+    await expect(migration003.up(store)).rejects.toThrow("read failure");
+
+    const after = data.appState as { recipes: unknown[] };
+    expect(after.recipes).toEqual([legacyRecipe]);
+    expect(store.set).not.toHaveBeenCalledWith(
+      "appState",
+      expect.objectContaining({ recipes: [] })
+    );
+    expect(projectStoreMock.saveRecipes).not.toHaveBeenCalled();
+  });
+
+  it("clears legacy recipes after a successful save", async () => {
+    const data: Record<string, unknown> = {
+      appState: { recipes: [legacyRecipe], otherField: "keep" },
+    };
+    const store = makeStoreMock(data);
+
+    await migration003.up(store);
+
+    expect(projectStoreMock.saveRecipes).toHaveBeenCalledTimes(1);
+    expect(store.set).toHaveBeenCalledWith("appState", { recipes: [], otherField: "keep" });
+  });
+
+  it("no-op when there are no global recipes", async () => {
+    const data: Record<string, unknown> = { appState: { recipes: [] } };
+    const store = makeStoreMock(data);
+
+    await migration003.up(store);
+
+    expect(projectStoreMock.getRecipes).not.toHaveBeenCalled();
+    expect(projectStoreMock.saveRecipes).not.toHaveBeenCalled();
+    expect(store.set).not.toHaveBeenCalled();
+  });
+
+  it("no-op when no current project is set (preserves recipes for later)", async () => {
+    projectStoreMock.getCurrentProjectId.mockReturnValueOnce(null);
+    const data: Record<string, unknown> = { appState: { recipes: [legacyRecipe] } };
+    const store = makeStoreMock(data);
+
+    await migration003.up(store);
+
+    expect(projectStoreMock.getRecipes).not.toHaveBeenCalled();
+    expect(store.set).not.toHaveBeenCalled();
+    const after = data.appState as { recipes: unknown[] };
+    expect(after.recipes).toEqual([legacyRecipe]);
+  });
+
+  it("no-op when current project ID is not in project list", async () => {
+    projectStoreMock.getProjectById.mockReturnValueOnce(null);
+    const data: Record<string, unknown> = { appState: { recipes: [legacyRecipe] } };
+    const store = makeStoreMock(data);
+
+    await migration003.up(store);
+
+    expect(projectStoreMock.getRecipes).not.toHaveBeenCalled();
+    expect(projectStoreMock.saveRecipes).not.toHaveBeenCalled();
+    expect(store.set).not.toHaveBeenCalled();
+  });
+
+  it("dedupes recipes already present in the project", async () => {
+    projectStoreMock.getRecipes.mockResolvedValueOnce([
+      {
+        id: "r1",
+        name: "Already Present",
+        projectId: "proj-1",
+        terminals: [],
+        createdAt: 500,
+      },
+    ]);
+    const data: Record<string, unknown> = { appState: { recipes: [legacyRecipe] } };
+    const store = makeStoreMock(data);
+
+    await migration003.up(store);
+
+    // No new recipes to save (the only legacy recipe was a duplicate),
+    // but legacy storage is still cleared since the source-of-truth is the project.
+    expect(projectStoreMock.saveRecipes).not.toHaveBeenCalled();
+    expect(store.set).toHaveBeenCalledWith("appState", expect.objectContaining({ recipes: [] }));
+  });
+});

--- a/electron/services/migrations/__tests__/003-migrate-recipes-to-project.test.ts
+++ b/electron/services/migrations/__tests__/003-migrate-recipes-to-project.test.ts
@@ -1,10 +1,10 @@
 import { beforeEach, describe, expect, it, vi } from "vitest";
 
 const projectStoreMock = vi.hoisted(() => ({
-  getCurrentProjectId: vi.fn<[], string | null>(() => "proj-1"),
-  getProjectById: vi.fn<[string], unknown>(() => ({ id: "proj-1" })),
-  getRecipes: vi.fn<[string], Promise<unknown[]>>(async () => []),
-  saveRecipes: vi.fn<[string, unknown[]], Promise<void>>(async () => {}),
+  getCurrentProjectId: vi.fn<() => string | null>(() => "proj-1"),
+  getProjectById: vi.fn<(id: string) => unknown>(() => ({ id: "proj-1" })),
+  getRecipes: vi.fn<(id: string) => Promise<unknown[]>>(async () => []),
+  saveRecipes: vi.fn<(id: string, recipes: unknown[]) => Promise<void>>(async () => {}),
 }));
 
 vi.mock("../../ProjectStore.js", () => ({ projectStore: projectStoreMock }));

--- a/electron/services/migrations/__tests__/003-migrate-recipes-to-project.test.ts
+++ b/electron/services/migrations/__tests__/003-migrate-recipes-to-project.test.ts
@@ -101,6 +101,17 @@ describe("migration003 — migrate global recipes to project", () => {
     expect(store.set).not.toHaveBeenCalled();
   });
 
+  it("no-op when recipes is null (defensive)", async () => {
+    const data: Record<string, unknown> = { appState: { recipes: null } };
+    const store = makeStoreMock(data);
+
+    await migration003.up(store);
+
+    expect(projectStoreMock.getRecipes).not.toHaveBeenCalled();
+    expect(projectStoreMock.saveRecipes).not.toHaveBeenCalled();
+    expect(store.set).not.toHaveBeenCalled();
+  });
+
   it("no-op when no current project is set (preserves recipes for later)", async () => {
     projectStoreMock.getCurrentProjectId.mockReturnValueOnce(null);
     const data: Record<string, unknown> = { appState: { recipes: [legacyRecipe] } };

--- a/electron/services/migrations/__tests__/008-split-notification-sounds.test.ts
+++ b/electron/services/migrations/__tests__/008-split-notification-sounds.test.ts
@@ -1,0 +1,108 @@
+import { describe, expect, it, vi } from "vitest";
+import { migration008 } from "../008-split-notification-sounds.js";
+
+function makeStoreMock(data: Record<string, unknown>) {
+  return {
+    get: vi.fn((key: string) => data[key]),
+    set: vi.fn((key: string, value: unknown) => {
+      data[key] = value;
+    }),
+  } as unknown as Parameters<typeof migration008.up>[0];
+}
+
+describe("migration008 — split notification sounds", () => {
+  it("has version 8", () => {
+    expect(migration008.version).toBe(8);
+  });
+
+  it("migrates soundFile to completedSoundFile and adds defaults", () => {
+    const data: Record<string, unknown> = {
+      notificationSettings: {
+        enabled: true,
+        soundFile: "custom.wav",
+      },
+    };
+    const store = makeStoreMock(data);
+    migration008.up(store);
+
+    expect(store.set).toHaveBeenCalledWith("notificationSettings", {
+      enabled: true,
+      completedSoundFile: "custom.wav",
+      waitingSoundFile: "waiting.wav",
+      escalationSoundFile: "ping.wav",
+    });
+  });
+
+  it("falls back to chime.wav when soundFile is missing on first run", () => {
+    const data: Record<string, unknown> = {
+      notificationSettings: { enabled: true },
+    };
+    const store = makeStoreMock(data);
+    migration008.up(store);
+
+    const after = data.notificationSettings as Record<string, unknown>;
+    expect(after.completedSoundFile).toBe("chime.wav");
+    expect(after.waitingSoundFile).toBe("waiting.wav");
+    expect(after.escalationSoundFile).toBe("ping.wav");
+  });
+
+  it("is idempotent — running twice does not re-apply", () => {
+    const data: Record<string, unknown> = {
+      notificationSettings: { soundFile: "custom.wav" },
+    };
+    const store = makeStoreMock(data);
+    migration008.up(store);
+    const firstCallCount = (store.set as ReturnType<typeof vi.fn>).mock.calls.length;
+
+    migration008.up(store);
+    const secondCallCount = (store.set as ReturnType<typeof vi.fn>).mock.calls.length;
+
+    expect(secondCallCount).toBe(firstCallCount);
+    const after = data.notificationSettings as Record<string, unknown>;
+    expect(after.completedSoundFile).toBe("custom.wav");
+  });
+
+  it("preserves user-customized sounds on replay", () => {
+    const data: Record<string, unknown> = {
+      notificationSettings: {
+        enabled: true,
+        completedSoundFile: "user-completed.wav",
+        waitingSoundFile: "user-waiting.wav",
+        escalationSoundFile: "user-escalation.wav",
+      },
+    };
+    const store = makeStoreMock(data);
+    migration008.up(store);
+
+    expect(store.set).not.toHaveBeenCalled();
+    const after = data.notificationSettings as Record<string, unknown>;
+    expect(after.completedSoundFile).toBe("user-completed.wav");
+    expect(after.waitingSoundFile).toBe("user-waiting.wav");
+    expect(after.escalationSoundFile).toBe("user-escalation.wav");
+  });
+
+  it("no-op when notificationSettings is missing", () => {
+    const store = makeStoreMock({});
+    migration008.up(store);
+    expect(store.set).not.toHaveBeenCalled();
+  });
+
+  it("preserves unrelated fields during migration", () => {
+    const data: Record<string, unknown> = {
+      notificationSettings: {
+        enabled: true,
+        completedEnabled: true,
+        soundFile: "chime.wav",
+        customField: "keep-me",
+      },
+    };
+    const store = makeStoreMock(data);
+    migration008.up(store);
+
+    const after = data.notificationSettings as Record<string, unknown>;
+    expect(after.enabled).toBe(true);
+    expect(after.completedEnabled).toBe(true);
+    expect(after.customField).toBe("keep-me");
+    expect(after).not.toHaveProperty("soundFile");
+  });
+});

--- a/electron/services/migrations/__tests__/012-default-pin-agents.test.ts
+++ b/electron/services/migrations/__tests__/012-default-pin-agents.test.ts
@@ -103,4 +103,64 @@ describe("migration012 — default-pin agents", () => {
       },
     });
   });
+
+  it("replay leaves pinned: false untouched (regression guard)", () => {
+    const data: Record<string, unknown> = {
+      agentSettings: {
+        agents: {
+          claude: { pinned: true, customFlags: "--verbose" },
+          gemini: { pinned: false },
+        },
+      },
+    };
+    const store = makeStoreMock(data);
+    migration012.up(store);
+
+    expect(store.set).not.toHaveBeenCalled();
+    const after = data.agentSettings as { agents: Record<string, Record<string, unknown>> };
+    expect(after.agents.claude).toEqual({ pinned: true, customFlags: "--verbose" });
+    expect(after.agents.gemini).toEqual({ pinned: false });
+  });
+
+  it("is idempotent — running twice does not modify already-migrated data", () => {
+    const data: Record<string, unknown> = {
+      agentSettings: {
+        agents: {
+          claude: { selected: true },
+          gemini: { selected: false },
+        },
+      },
+    };
+    const store = makeStoreMock(data);
+    migration012.up(store);
+    const firstCallCount = (store.set as ReturnType<typeof vi.fn>).mock.calls.length;
+
+    migration012.up(store);
+    const secondCallCount = (store.set as ReturnType<typeof vi.fn>).mock.calls.length;
+
+    expect(secondCallCount).toBe(firstCallCount);
+    const after = data.agentSettings as { agents: Record<string, Record<string, unknown>> };
+    expect(after.agents.claude).toEqual({ pinned: true });
+    expect(after.agents.gemini).toEqual({ pinned: false });
+  });
+
+  it("migrates legacy entries while leaving already-migrated entries untouched", () => {
+    const data: Record<string, unknown> = {
+      agentSettings: {
+        agents: {
+          claude: { pinned: false }, // already migrated, explicit unpin
+          gemini: { selected: false }, // legacy, needs migration
+          codex: { pinned: true, customFlags: "" }, // already migrated
+        },
+      },
+    };
+    const store = makeStoreMock(data);
+    migration012.up(store);
+
+    expect(store.set).toHaveBeenCalledTimes(1);
+    const after = data.agentSettings as { agents: Record<string, Record<string, unknown>> };
+    expect(after.agents.claude).toEqual({ pinned: false });
+    expect(after.agents.gemini).toEqual({ pinned: false });
+    expect(after.agents.codex).toEqual({ pinned: true, customFlags: "" });
+  });
 });

--- a/electron/services/migrations/__tests__/012-default-pin-agents.test.ts
+++ b/electron/services/migrations/__tests__/012-default-pin-agents.test.ts
@@ -144,6 +144,25 @@ describe("migration012 — default-pin agents", () => {
     expect(after.agents.gemini).toEqual({ pinned: false });
   });
 
+  it("does not crash on null/non-object entries (defensive)", () => {
+    const data: Record<string, unknown> = {
+      agentSettings: {
+        agents: {
+          claude: { selected: true },
+          broken: null as unknown as Record<string, unknown>,
+          alsoBroken: "not-an-object" as unknown as Record<string, unknown>,
+        },
+      },
+    };
+    const store = makeStoreMock(data);
+    expect(() => migration012.up(store)).not.toThrow();
+
+    const after = data.agentSettings as { agents: Record<string, unknown> };
+    expect(after.agents.claude).toEqual({ pinned: true });
+    expect(after.agents.broken).toBeNull();
+    expect(after.agents.alsoBroken).toBe("not-an-object");
+  });
+
   it("migrates legacy entries while leaving already-migrated entries untouched", () => {
     const data: Record<string, unknown> = {
       agentSettings: {

--- a/electron/services/migrations/index.ts
+++ b/electron/services/migrations/index.ts
@@ -23,6 +23,7 @@ export const migrations: Migration[] = [
   migration003,
   migration004,
   migration005,
+  // migration006 removed in #5150
   migration007,
   migration008,
   migration009,

--- a/electron/services/persistence/migrations/0001_add_scratches.sql
+++ b/electron/services/persistence/migrations/0001_add_scratches.sql
@@ -1,4 +1,4 @@
-CREATE TABLE `scratches` (
+CREATE TABLE IF NOT EXISTS `scratches` (
 	`id` text PRIMARY KEY NOT NULL,
 	`path` text NOT NULL,
 	`name` text NOT NULL,


### PR DESCRIPTION
## Summary

- Five surgical fixes across the SQLite/Drizzle and electron-store migration paths to close replay-safety gaps that surface as data corruption or boot failure when a migration is interrupted between its body completing and the `_schemaVersion` write.
- New test suites for migrations 003 and 008; extended 012 tests with replay, idempotency, and null-guard cases; `StoreMigrations.test.ts` updated to assert the rethrow contract.
- Time-sensitive: the `0001_add_scratches.sql` edit must land before the next release tag — Drizzle SHA-256-checks every `.sql` file and throws on mismatch once it ships in a tagged release.

Resolves #7100

## Changes

1. `0001_add_scratches.sql` — `CREATE TABLE` → `CREATE TABLE IF NOT EXISTS` to prevent a fatal crash when Drizzle replays the file after a partial run.
2. Migration 008 — adds a `completedSoundFile` presence guard (Pattern A) so replay doesn't overwrite sound settings the user has changed since the first run.
3. Migration 012 — adds a per-entry predicate and a `changed` flag so replayed runs skip entries that were already correctly migrated, and adds a defensive null guard.
4. Migration 003 — narrows the `catch` block to only wrap `saveRecipes`; rethrows on failure so `MigrationRunner`'s backup-and-restore flow activates rather than silently bumping `_schemaVersion` with orphaned data.
5. `migrations/index.ts` — adds a one-line comment for the missing slot 6 (removed in #5150) so it doesn't look like an accidental gap to future contributors.

## Testing

- 104/104 migration tests pass.
- New suites: `003-migrate-recipes-to-project.test.ts`, `008-split-notification-sounds.test.ts`.
- Extended: `012-default-pin-agents.test.ts` with replay, idempotency, and null-guard cases.
- `StoreMigrations.test.ts` updated to assert the rethrow contract on migration 003.