### PR TITLE
fix(slash-commands): polish service discovery and config-dir parity

### DIFF
--- a/electron/services/SlashCommandService.ts
+++ b/electron/services/SlashCommandService.ts
@@ -18,7 +18,7 @@ function stripWrappingQuotes(value: string): string {
   return trimmed;
 }
 
-async function readFrontmatterDescription(
+async function readYamlFrontmatter(
   filePath: string
 ): Promise<{ description: string | null; userInvocable: boolean }> {
   let handle: FileHandle | null = null;
@@ -32,7 +32,12 @@ async function readFrontmatterDescription(
     if (!normalized.startsWith("---")) return { description: null, userInvocable: true };
 
     const endIndex = normalized.indexOf("\n---", 3);
-    if (endIndex === -1) return { description: null, userInvocable: true };
+    if (endIndex === -1) {
+      console.warn(
+        `[SlashCommandService] frontmatter truncated: closing --- not found within ${FRONTMATTER_MAX_BYTES} bytes in ${filePath}`
+      );
+      return { description: null, userInvocable: true };
+    }
 
     const frontmatter = normalized.slice(3, endIndex);
 
@@ -101,13 +106,6 @@ async function scanCommandDirectory(
   agentId: SlashCommand["agentId"],
   isPromptDirectory = false
 ): Promise<SlashCommand[]> {
-  try {
-    const stats = await fs.stat(dirPath);
-    if (!stats.isDirectory()) return [];
-  } catch {
-    return [];
-  }
-
   const results: SlashCommand[] = [];
 
   const walk = async (currentDir: string): Promise<void> => {
@@ -136,7 +134,7 @@ async function scanCommandDirectory(
         const name = relNoExt.split(path.sep).join(":");
         const label = isPromptDirectory ? `/prompts:${name}` : `/${name}`;
         const id = isPromptDirectory ? `${scope}:prompts:${name}` : `${scope}:${name}`;
-        const { description: desc, userInvocable } = await readFrontmatterDescription(fullPath);
+        const { description: desc, userInvocable } = await readYamlFrontmatter(fullPath);
         if (!userInvocable) return;
         const description = desc ?? "Custom command";
 
@@ -162,13 +160,6 @@ async function scanTomlCommandDirectory(
   agentId: SlashCommand["agentId"],
   isPromptDirectory = false
 ): Promise<SlashCommand[]> {
-  try {
-    const stats = await fs.stat(dirPath);
-    if (!stats.isDirectory()) return [];
-  } catch {
-    return [];
-  }
-
   const results: SlashCommand[] = [];
 
   const walk = async (currentDir: string): Promise<void> => {
@@ -231,7 +222,10 @@ function getClaudeCommandSearchPaths(projectPath?: string): Array<{
   }
 
   const home = os.homedir();
-  dirs.push({ dirPath: path.join(home, ".claude", "commands"), scope: "user" });
+  const claudeHome = process.env.CLAUDE_CONFIG_DIR
+    ? path.resolve(process.env.CLAUDE_CONFIG_DIR)
+    : path.join(home, ".claude");
+  dirs.push({ dirPath: path.join(claudeHome, "commands"), scope: "user" });
 
   const xdgConfigHome = process.env.XDG_CONFIG_HOME;
   if (xdgConfigHome) {
@@ -273,54 +267,11 @@ function getClaudeCommandSearchPaths(projectPath?: string): Array<{
   });
 }
 
-async function readSkillFrontmatter(
-  filePath: string
-): Promise<{ description: string | null; userInvocable: boolean }> {
-  let handle: FileHandle | null = null;
-  try {
-    handle = await fs.open(filePath, "r");
-    const buffer = Buffer.alloc(FRONTMATTER_MAX_BYTES);
-    const { bytesRead } = await handle.read(buffer, 0, FRONTMATTER_MAX_BYTES, 0);
-    const text = buffer.subarray(0, bytesRead).toString("utf8");
-
-    const normalized = text.startsWith("\uFEFF") ? text.slice(1) : text;
-    if (!normalized.startsWith("---")) return { description: null, userInvocable: true };
-
-    const endIndex = normalized.indexOf("\n---", 3);
-    if (endIndex === -1) return { description: null, userInvocable: true };
-
-    const frontmatter = normalized.slice(3, endIndex);
-
-    const descMatch = frontmatter.match(/^description:\s*(.+)$/m);
-    const description = descMatch ? stripWrappingQuotes(descMatch[1] ?? "") : null;
-
-    const invocableMatch = frontmatter.match(/^user-invocable:\s*(.+)$/m);
-    let userInvocable = true;
-    if (invocableMatch) {
-      const val = stripWrappingQuotes(invocableMatch[1] ?? "").toLowerCase();
-      if (val === "false" || val === "no") userInvocable = false;
-    }
-
-    return { description, userInvocable };
-  } catch {
-    return { description: null, userInvocable: true };
-  } finally {
-    await handle?.close().catch(() => {});
-  }
-}
-
 async function scanSkillDirectory(
   dirPath: string,
   scope: SlashCommand["scope"],
   agentId: SlashCommand["agentId"]
 ): Promise<SlashCommand[]> {
-  try {
-    const stats = await fs.stat(dirPath);
-    if (!stats.isDirectory()) return [];
-  } catch {
-    return [];
-  }
-
   let entries: Array<import("fs").Dirent> = [];
   try {
     entries = await fs.readdir(dirPath, { withFileTypes: true });
@@ -343,7 +294,7 @@ async function scanSkillDirectory(
         return;
       }
 
-      const { description, userInvocable } = await readSkillFrontmatter(skillFile);
+      const { description, userInvocable } = await readYamlFrontmatter(skillFile);
       if (!userInvocable) return;
 
       const name = entry.name;
@@ -373,7 +324,10 @@ function getClaudeSkillSearchPaths(projectPath?: string): Array<{
   }
 
   const home = os.homedir();
-  dirs.push({ dirPath: path.join(home, ".claude", "skills"), scope: "user" });
+  const claudeHome = process.env.CLAUDE_CONFIG_DIR
+    ? path.resolve(process.env.CLAUDE_CONFIG_DIR)
+    : path.join(home, ".claude");
+  dirs.push({ dirPath: path.join(claudeHome, "skills"), scope: "user" });
 
   const xdgConfigHome = process.env.XDG_CONFIG_HOME;
   if (xdgConfigHome) {
@@ -426,7 +380,10 @@ function getGeminiCommandSearchPaths(projectPath?: string): Array<{
   }
 
   const home = os.homedir();
-  dirs.push({ dirPath: path.join(home, ".gemini", "commands"), scope: "user" });
+  const geminiHome = process.env.GEMINI_CONFIG_DIR
+    ? path.resolve(process.env.GEMINI_CONFIG_DIR)
+    : path.join(home, ".gemini");
+  dirs.push({ dirPath: path.join(geminiHome, "commands"), scope: "user" });
 
   const xdgConfigHome = process.env.XDG_CONFIG_HOME;
   if (xdgConfigHome) {

--- a/electron/services/__tests__/SlashCommandService.test.ts
+++ b/electron/services/__tests__/SlashCommandService.test.ts
@@ -1,4 +1,4 @@
-import { describe, expect, it } from "vitest";
+import { describe, expect, it, vi } from "vitest";
 import { promises as fs } from "fs";
 import * as os from "os";
 import * as path from "path";
@@ -721,6 +721,180 @@ Just some instructions without frontmatter.
       restoreHome(prev);
       await fs.rm(homeRoot, { recursive: true, force: true });
       await fs.rm(root, { recursive: true, force: true });
+    }
+  });
+
+  it("warns when frontmatter closing --- falls outside the 8 KiB read buffer", async () => {
+    const projectRoot = await makeTempDir();
+    const service = new SlashCommandService();
+    const warnSpy = vi.spyOn(console, "warn").mockImplementation(() => {});
+
+    try {
+      await fs.mkdir(path.join(projectRoot, ".git"));
+
+      const filler = "x".repeat(9 * 1024);
+      const cmdPath = path.join(projectRoot, ".claude", "commands", "huge.md");
+      await writeFile(
+        cmdPath,
+        `---
+description: "Huge frontmatter"
+filler: "${filler}"
+user-invocable: false
+---
+
+Body.
+`
+      );
+
+      const commands = await service.list("claude", projectRoot);
+      const huge = commands.find((c) => c.label === "/huge");
+
+      expect(huge).toBeDefined();
+      expect(huge?.description).toBe("Custom command");
+
+      expect(warnSpy).toHaveBeenCalledWith(
+        expect.stringContaining("[SlashCommandService] frontmatter truncated:")
+      );
+      expect(warnSpy).toHaveBeenCalledWith(expect.stringContaining(cmdPath));
+    } finally {
+      warnSpy.mockRestore();
+      await fs.rm(projectRoot, { recursive: true, force: true });
+    }
+  });
+
+  it("does not warn on ordinary Markdown without frontmatter", async () => {
+    const projectRoot = await makeTempDir();
+    const service = new SlashCommandService();
+    const warnSpy = vi.spyOn(console, "warn").mockImplementation(() => {});
+
+    try {
+      await fs.mkdir(path.join(projectRoot, ".git"));
+
+      await writeFile(
+        path.join(projectRoot, ".claude", "commands", "plain.md"),
+        `# Plain command
+
+No frontmatter at all.
+`
+      );
+
+      const commands = await service.list("claude", projectRoot);
+      const plain = commands.find((c) => c.label === "/plain");
+
+      expect(plain).toBeDefined();
+      expect(warnSpy).not.toHaveBeenCalled();
+    } finally {
+      warnSpy.mockRestore();
+      await fs.rm(projectRoot, { recursive: true, force: true });
+    }
+  });
+
+  it("honours CLAUDE_CONFIG_DIR for user command and skill discovery", async () => {
+    const homeRoot = await makeTempDir();
+    const claudeDir = await makeTempDir();
+    const projectRoot = await makeTempDir();
+    const service = new SlashCommandService();
+
+    const prevHome = process.env.HOME;
+    const prevUserprofile = process.env.USERPROFILE;
+    const prevClaudeConfigDir = process.env.CLAUDE_CONFIG_DIR;
+    const prevXdgConfigHome = process.env.XDG_CONFIG_HOME;
+
+    process.env.HOME = homeRoot;
+    process.env.USERPROFILE = homeRoot;
+    process.env.CLAUDE_CONFIG_DIR = claudeDir;
+    delete process.env.XDG_CONFIG_HOME;
+
+    try {
+      await fs.mkdir(path.join(projectRoot, ".git"));
+
+      await writeFile(
+        path.join(claudeDir, "commands", "relocated.md"),
+        `---
+description: "Relocated user command"
+---
+
+Relocated.
+`
+      );
+
+      await writeFile(
+        path.join(claudeDir, "skills", "relocated-skill", "SKILL.md"),
+        `---
+description: "Relocated user skill"
+---
+
+Skill body.
+`
+      );
+
+      const commands = await service.list("claude", projectRoot);
+      const cmd = commands.find((c) => c.label === "/relocated");
+      const skill = commands.find((c) => c.label === "/relocated-skill" && c.kind === "skill");
+
+      expect(cmd).toBeDefined();
+      expect(cmd?.scope).toBe("user");
+      expect(cmd?.description).toBe("Relocated user command");
+      expect(skill).toBeDefined();
+      expect(skill?.scope).toBe("user");
+      expect(skill?.description).toBe("Relocated user skill");
+    } finally {
+      if (prevHome !== undefined) process.env.HOME = prevHome;
+      else delete process.env.HOME;
+      if (prevUserprofile !== undefined) process.env.USERPROFILE = prevUserprofile;
+      else delete process.env.USERPROFILE;
+      if (prevClaudeConfigDir !== undefined) process.env.CLAUDE_CONFIG_DIR = prevClaudeConfigDir;
+      else delete process.env.CLAUDE_CONFIG_DIR;
+      if (prevXdgConfigHome !== undefined) process.env.XDG_CONFIG_HOME = prevXdgConfigHome;
+      await fs.rm(homeRoot, { recursive: true, force: true });
+      await fs.rm(claudeDir, { recursive: true, force: true });
+      await fs.rm(projectRoot, { recursive: true, force: true });
+    }
+  });
+
+  it("honours GEMINI_CONFIG_DIR for user command discovery", async () => {
+    const homeRoot = await makeTempDir();
+    const geminiDir = await makeTempDir();
+    const projectRoot = await makeTempDir();
+    const service = new SlashCommandService();
+
+    const prevHome = process.env.HOME;
+    const prevUserprofile = process.env.USERPROFILE;
+    const prevGeminiConfigDir = process.env.GEMINI_CONFIG_DIR;
+    const prevXdgConfigHome = process.env.XDG_CONFIG_HOME;
+
+    process.env.HOME = homeRoot;
+    process.env.USERPROFILE = homeRoot;
+    process.env.GEMINI_CONFIG_DIR = geminiDir;
+    delete process.env.XDG_CONFIG_HOME;
+
+    try {
+      await fs.mkdir(path.join(projectRoot, ".git"));
+
+      await writeFile(
+        path.join(geminiDir, "commands", "relocated.toml"),
+        `description = "Relocated Gemini command"
+prompt = "Do the thing"
+`
+      );
+
+      const commands = await service.list("gemini", projectRoot);
+      const cmd = commands.find((c) => c.label === "/relocated");
+
+      expect(cmd).toBeDefined();
+      expect(cmd?.scope).toBe("user");
+      expect(cmd?.description).toBe("Relocated Gemini command");
+    } finally {
+      if (prevHome !== undefined) process.env.HOME = prevHome;
+      else delete process.env.HOME;
+      if (prevUserprofile !== undefined) process.env.USERPROFILE = prevUserprofile;
+      else delete process.env.USERPROFILE;
+      if (prevGeminiConfigDir !== undefined) process.env.GEMINI_CONFIG_DIR = prevGeminiConfigDir;
+      else delete process.env.GEMINI_CONFIG_DIR;
+      if (prevXdgConfigHome !== undefined) process.env.XDG_CONFIG_HOME = prevXdgConfigHome;
+      await fs.rm(homeRoot, { recursive: true, force: true });
+      await fs.rm(geminiDir, { recursive: true, force: true });
+      await fs.rm(projectRoot, { recursive: true, force: true });
     }
   });
 

--- a/electron/services/__tests__/SlashCommandService.test.ts
+++ b/electron/services/__tests__/SlashCommandService.test.ts
@@ -18,10 +18,16 @@ function overrideHome(dir: string): Record<string, string | undefined> {
     HOME: process.env.HOME,
     USERPROFILE: process.env.USERPROFILE,
     XDG_CONFIG_HOME: process.env.XDG_CONFIG_HOME,
+    CLAUDE_CONFIG_DIR: process.env.CLAUDE_CONFIG_DIR,
+    GEMINI_CONFIG_DIR: process.env.GEMINI_CONFIG_DIR,
+    CODEX_HOME: process.env.CODEX_HOME,
   };
   process.env.HOME = dir;
   process.env.USERPROFILE = dir;
   delete process.env.XDG_CONFIG_HOME;
+  delete process.env.CLAUDE_CONFIG_DIR;
+  delete process.env.GEMINI_CONFIG_DIR;
+  delete process.env.CODEX_HOME;
   return prev;
 }
 
@@ -752,10 +758,10 @@ Body.
       expect(huge).toBeDefined();
       expect(huge?.description).toBe("Custom command");
 
-      expect(warnSpy).toHaveBeenCalledWith(
-        expect.stringContaining("[SlashCommandService] frontmatter truncated:")
-      );
-      expect(warnSpy).toHaveBeenCalledWith(expect.stringContaining(cmdPath));
+      expect(warnSpy).toHaveBeenCalledTimes(1);
+      const message = warnSpy.mock.calls[0]?.[0] as string;
+      expect(message).toContain("[SlashCommandService] frontmatter truncated:");
+      expect(message).toContain(cmdPath);
     } finally {
       warnSpy.mockRestore();
       await fs.rm(projectRoot, { recursive: true, force: true });


### PR DESCRIPTION
## Summary

- Fixes several small issues in `SlashCommandService.ts` — duplicate frontmatter readers, a silent misclassification on truncated YAML, redundant stat syscalls, and config-dir env-var gaps for Claude and Gemini
- Unified `readFrontmatterDescription` and `readSkillFrontmatter` into a single `readYamlFrontmatter` helper; added `console.warn` when YAML frontmatter has an opening `---` but the closing `---` falls outside the 8 KiB read buffer (was silently treated as `userInvocable: true`)
- Removed redundant outer `fs.stat` pre-checks from `scanCommandDirectory`, `scanTomlCommandDirectory`, and `scanSkillDirectory` (~36 syscalls per `list()` call); added `CLAUDE_CONFIG_DIR` support to `getClaudeCommandSearchPaths` and `getClaudeSkillSearchPaths`, and `GEMINI_CONFIG_DIR` support to `getGeminiCommandSearchPaths` — mirrors the existing `CODEX_HOME` pattern

Resolves #7134

## Changes

- `electron/services/SlashCommandService.ts` — deduplicated frontmatter reader, truncation warn, stat removal, `CLAUDE_CONFIG_DIR` + `GEMINI_CONFIG_DIR` support
- `electron/services/__tests__/SlashCommandService.test.ts` — 4 new tests (26 total): truncation warn, no-warn on plain markdown, `CLAUDE_CONFIG_DIR` override for commands and skills, `GEMINI_CONFIG_DIR` override; `overrideHome()` helper hardened to clear new env vars and `CODEX_HOME`

## Testing

Lint ratchet improved by 9. All 26 unit tests pass. Typecheck, lint, format, and build clean.