### PR TITLE
fix(ccr): surface diagnostics for malformed config and harden preset parser

### DIFF
--- a/electron/services/CcrConfigService.ts
+++ b/electron/services/CcrConfigService.ts
@@ -109,26 +109,38 @@ export class CcrConfigService {
       return [];
     }
 
-    let config: CcrConfig;
+    let parsed: unknown;
     try {
-      config = JSON.parse(raw);
+      parsed = JSON.parse(raw);
     } catch (err) {
-      // JSON.parse SyntaxError messages on Node 22 are positional-only and don't
-      // embed file contents, so passing the error to console.warn is safe. Never
+      // JSON.parse SyntaxError messages typically carry positional info only.
+      // V8 can include a short token near the error site, but for the realistic
+      // CCR shape (object with quoted values) the message is positional. Never
       // log `raw` — it may contain inline API keys from a malformed user config.
       console.warn(`[CcrConfigService] Failed to parse config at ${CCR_CONFIG_PATH}:`, err);
       return [];
     }
 
+    // JSON.parse("null") / "true" / "[]" / '"x"' all succeed but aren't a config object.
+    // Guard before reading `.models` so a malformed top-level value doesn't throw a
+    // TypeError that escapes to callers as a misleading runtime error.
+    if (parsed === null || typeof parsed !== "object" || Array.isArray(parsed)) {
+      console.warn(`[CcrConfigService] Config at ${CCR_CONFIG_PATH} is not an object — ignoring`);
+      return [];
+    }
+
+    const config = parsed as CcrConfig;
     if (!Array.isArray(config.models) || config.models.length === 0) {
       return [];
     }
 
     return config.models
       .filter(
-        (entry) =>
-          (typeof entry.id === "string" && entry.id.length > 0) ||
-          (typeof entry.model === "string" && entry.model.length > 0)
+        (entry): entry is CcrModelEntry =>
+          entry != null &&
+          typeof entry === "object" &&
+          ((typeof entry.id === "string" && entry.id.length > 0) ||
+            (typeof entry.model === "string" && entry.model.length > 0))
       )
       .map((entry) => this.entryToPreset(entry));
   }

--- a/electron/services/CcrConfigService.ts
+++ b/electron/services/CcrConfigService.ts
@@ -95,20 +95,42 @@ export class CcrConfigService {
   }
 
   async discoverPresets(): Promise<AgentPreset[]> {
+    let raw: string;
     try {
-      const raw = await readFile(CCR_CONFIG_PATH, "utf-8");
-      const config: CcrConfig = JSON.parse(raw);
-
-      if (!Array.isArray(config.models) || config.models.length === 0) {
-        return [];
+      raw = await readFile(CCR_CONFIG_PATH, "utf-8");
+    } catch (err) {
+      // ENOENT is expected when CCR isn't installed; stay silent.
+      // Anything else (EACCES, EPERM, EISDIR, …) is a diagnostic the user can act on.
+      const code =
+        err instanceof Error && "code" in err ? (err as NodeJS.ErrnoException).code : undefined;
+      if (code !== "ENOENT") {
+        console.warn(`[CcrConfigService] Failed to read config at ${CCR_CONFIG_PATH}:`, err);
       }
-
-      return config.models
-        .filter((entry) => entry.id || entry.model)
-        .map((entry) => this.entryToPreset(entry));
-    } catch {
       return [];
     }
+
+    let config: CcrConfig;
+    try {
+      config = JSON.parse(raw);
+    } catch (err) {
+      // JSON.parse SyntaxError messages on Node 22 are positional-only and don't
+      // embed file contents, so passing the error to console.warn is safe. Never
+      // log `raw` — it may contain inline API keys from a malformed user config.
+      console.warn(`[CcrConfigService] Failed to parse config at ${CCR_CONFIG_PATH}:`, err);
+      return [];
+    }
+
+    if (!Array.isArray(config.models) || config.models.length === 0) {
+      return [];
+    }
+
+    return config.models
+      .filter(
+        (entry) =>
+          (typeof entry.id === "string" && entry.id.length > 0) ||
+          (typeof entry.model === "string" && entry.model.length > 0)
+      )
+      .map((entry) => this.entryToPreset(entry));
   }
 
   getPresets(): AgentPreset[] {
@@ -155,18 +177,33 @@ export class CcrConfigService {
   }
 
   private entryToPreset(entry: CcrModelEntry): AgentPreset {
-    const id = entry.id ?? entry.model ?? "unknown";
-    const name = entry.name ?? entry.model ?? id;
+    // `??` only falls through on null/undefined, so an entry with `id: ""` or
+    // `id: {}` would otherwise leak into preset IDs as `ccr-` or `ccr-[object Object]`.
+    // Coerce non-string / empty-string fields to undefined first.
+    const safeId = typeof entry.id === "string" && entry.id.length > 0 ? entry.id : undefined;
+    const safeModel =
+      typeof entry.model === "string" && entry.model.length > 0 ? entry.model : undefined;
+    const safeName =
+      typeof entry.name === "string" && entry.name.length > 0 ? entry.name : undefined;
+    const safeBaseUrl =
+      typeof entry.baseUrl === "string" && entry.baseUrl.length > 0 ? entry.baseUrl : undefined;
+    const safeApiKeyEnv =
+      typeof entry.apiKeyEnv === "string" && entry.apiKeyEnv.length > 0
+        ? entry.apiKeyEnv
+        : undefined;
+
+    const id = safeId ?? safeModel ?? "unknown";
+    const name = safeName ?? safeModel ?? id;
     const env: Record<string, string> = {};
 
-    if (entry.model) {
-      env.ANTHROPIC_MODEL = entry.model;
+    if (safeModel) {
+      env.ANTHROPIC_MODEL = safeModel;
     }
-    if (entry.baseUrl) {
-      env.ANTHROPIC_BASE_URL = entry.baseUrl;
+    if (safeBaseUrl) {
+      env.ANTHROPIC_BASE_URL = safeBaseUrl;
     }
-    if (entry.apiKeyEnv) {
-      env.ANTHROPIC_API_KEY = `\${${entry.apiKeyEnv}}`;
+    if (safeApiKeyEnv) {
+      env.ANTHROPIC_API_KEY = `\${${safeApiKeyEnv}}`;
     }
 
     return {

--- a/electron/services/__tests__/CcrConfigService.test.ts
+++ b/electron/services/__tests__/CcrConfigService.test.ts
@@ -14,7 +14,7 @@ vi.mock("../../ipc/channels.js", () => ({
   CHANNELS: { AGENT_PRESETS_UPDATED: "agent-presets:updated" },
 }));
 
-vi.mock("../config/agentRegistry.js", () => ({
+vi.mock("../../../shared/config/agentRegistry.js", () => ({
   setAgentPresets: vi.fn(),
 }));
 
@@ -231,6 +231,57 @@ describe("CcrConfigService", () => {
       const presets = await service.discoverPresets();
       expect(presets).toHaveLength(1);
       expect(presets[0].id).toBe("ccr-valid");
+    });
+
+    it("returns empty array (without throwing) when top-level JSON is null", async () => {
+      const warnSpy = vi.spyOn(console, "warn").mockImplementation(() => {});
+      mockReadFile.mockResolvedValue("null");
+      const presets = await service.discoverPresets();
+      expect(presets).toEqual([]);
+      expect(warnSpy).toHaveBeenCalledTimes(1);
+      expect(warnSpy.mock.calls[0][0]).toContain("not an object");
+      warnSpy.mockRestore();
+    });
+
+    it("returns empty array (without throwing) when top-level JSON is an array", async () => {
+      const warnSpy = vi.spyOn(console, "warn").mockImplementation(() => {});
+      mockReadFile.mockResolvedValue('[{"id":"x"}]');
+      const presets = await service.discoverPresets();
+      expect(presets).toEqual([]);
+      expect(warnSpy).toHaveBeenCalledTimes(1);
+      warnSpy.mockRestore();
+    });
+
+    it("skips null entries in models array and still maps remaining valid ones", async () => {
+      mockReadFile.mockResolvedValue(
+        JSON.stringify({
+          models: [null, { id: "valid", model: "valid-model" }, undefined],
+        })
+      );
+      const presets = await service.discoverPresets();
+      expect(presets).toHaveLength(1);
+      expect(presets[0].id).toBe("ccr-valid");
+    });
+
+    it("skips primitive entries in models array (e.g. strings/numbers)", async () => {
+      mockReadFile.mockResolvedValue(
+        JSON.stringify({
+          models: ["just-a-string", 42, { id: "valid", model: "valid-model" }],
+        })
+      );
+      const presets = await service.discoverPresets();
+      expect(presets).toHaveLength(1);
+      expect(presets[0].id).toBe("ccr-valid");
+    });
+
+    it("warns on non-Error read rejection (e.g. raw string thrown)", async () => {
+      const warnSpy = vi.spyOn(console, "warn").mockImplementation(() => {});
+      mockReadFile.mockRejectedValue("boom");
+      const presets = await service.discoverPresets();
+      expect(presets).toEqual([]);
+      expect(warnSpy).toHaveBeenCalledTimes(1);
+      expect(warnSpy.mock.calls[0][0]).toContain("Failed to read config");
+      warnSpy.mockRestore();
     });
 
     it("includes apiKeyEnv as template in env", async () => {
@@ -473,6 +524,25 @@ describe("CcrConfigService", () => {
       );
       await service.loadAndApply();
       expect(broadcastMock.mock.calls.length).toBeGreaterThan(initialCalls);
+    });
+
+    it("clears stale presets after a previously-good config goes malformed", async () => {
+      const warnSpy = vi.spyOn(console, "warn").mockImplementation(() => {});
+
+      mockReadFile.mockResolvedValueOnce(
+        JSON.stringify({ models: [{ id: "alpha", model: "alpha-model" }] })
+      );
+      await service.loadAndApply();
+      expect(service.getPresets()).toHaveLength(1);
+
+      // User edits config and breaks the JSON. The next poll iteration must
+      // reset cached presets to [] so the renderer doesn't keep launching
+      // with stale routing.
+      mockReadFile.mockResolvedValueOnce("not json at all");
+      await service.loadAndApply();
+      expect(service.getPresets()).toEqual([]);
+
+      warnSpy.mockRestore();
     });
 
     it("does NOT broadcast when presets are fully unchanged", async () => {

--- a/electron/services/__tests__/CcrConfigService.test.ts
+++ b/electron/services/__tests__/CcrConfigService.test.ts
@@ -31,10 +31,29 @@ describe("CcrConfigService", () => {
   });
 
   describe("discoverPresets", () => {
-    it("returns empty array when config file does not exist", async () => {
-      mockReadFile.mockRejectedValue(new Error("ENOENT"));
+    it("returns empty array silently when config file does not exist (ENOENT)", async () => {
+      const warnSpy = vi.spyOn(console, "warn").mockImplementation(() => {});
+      mockReadFile.mockRejectedValue(
+        Object.assign(new Error("ENOENT: no such file or directory"), { code: "ENOENT" })
+      );
       const presets = await service.discoverPresets();
       expect(presets).toEqual([]);
+      // ENOENT is the expected case (CCR not installed) — must NOT warn.
+      expect(warnSpy).not.toHaveBeenCalled();
+      warnSpy.mockRestore();
+    });
+
+    it("warns and returns empty array on permission error (EACCES)", async () => {
+      const warnSpy = vi.spyOn(console, "warn").mockImplementation(() => {});
+      mockReadFile.mockRejectedValue(
+        Object.assign(new Error("EACCES: permission denied"), { code: "EACCES" })
+      );
+      const presets = await service.discoverPresets();
+      expect(presets).toEqual([]);
+      expect(warnSpy).toHaveBeenCalledTimes(1);
+      expect(warnSpy.mock.calls[0][0]).toContain("[CcrConfigService]");
+      expect(warnSpy.mock.calls[0][0]).toContain("Failed to read config");
+      warnSpy.mockRestore();
     });
 
     it("returns empty array when config has no models", async () => {
@@ -113,10 +132,105 @@ describe("CcrConfigService", () => {
       expect(presets[0].id).toBe("ccr-valid");
     });
 
-    it("handles invalid JSON", async () => {
+    it("warns and returns empty array on malformed JSON", async () => {
+      const warnSpy = vi.spyOn(console, "warn").mockImplementation(() => {});
       mockReadFile.mockResolvedValue("not json at all");
       const presets = await service.discoverPresets();
       expect(presets).toEqual([]);
+      expect(warnSpy).toHaveBeenCalledTimes(1);
+      expect(warnSpy.mock.calls[0][0]).toContain("[CcrConfigService]");
+      expect(warnSpy.mock.calls[0][0]).toContain("Failed to parse config");
+      warnSpy.mockRestore();
+    });
+
+    it("does not log raw config contents on parse error (avoid leaking inline keys)", async () => {
+      const warnSpy = vi.spyOn(console, "warn").mockImplementation(() => {});
+      // A user pastes their literal API key inline by mistake, then breaks the JSON.
+      const leakySnippet = "sk-ant-api03-SECRET-DO-NOT-LOG";
+      mockReadFile.mockResolvedValue(`{ "models": [{ "id": "x", "apiKey": "${leakySnippet}" }`);
+      await service.discoverPresets();
+      const allLoggedText = warnSpy.mock.calls
+        .flatMap((call) => call.map((arg) => (arg instanceof Error ? arg.message : String(arg))))
+        .join(" ");
+      expect(allLoggedText).not.toContain(leakySnippet);
+      warnSpy.mockRestore();
+    });
+
+    it("filters entries with non-string id (e.g. object) — no ccr-[object Object] preset", async () => {
+      const warnSpy = vi.spyOn(console, "warn").mockImplementation(() => {});
+      mockReadFile.mockResolvedValue(
+        JSON.stringify({
+          models: [
+            { id: { nested: "object" }, name: "bad" },
+            { id: 42, name: "also bad" },
+            { id: "valid", model: "valid-model" },
+          ],
+        })
+      );
+
+      const presets = await service.discoverPresets();
+      expect(presets).toHaveLength(1);
+      expect(presets[0].id).toBe("ccr-valid");
+      expect(presets.every((p) => !p.id.includes("[object Object]"))).toBe(true);
+      warnSpy.mockRestore();
+    });
+
+    it("filters entries with empty-string id when no model fallback — no ccr- preset", async () => {
+      mockReadFile.mockResolvedValue(
+        JSON.stringify({
+          models: [
+            { id: "", name: "empty id" },
+            { id: "", model: "" },
+            { id: "valid", model: "valid-model" },
+          ],
+        })
+      );
+
+      const presets = await service.discoverPresets();
+      expect(presets).toHaveLength(1);
+      expect(presets[0].id).toBe("ccr-valid");
+      expect(presets.every((p) => p.id !== "ccr-")).toBe(true);
+    });
+
+    it("falls back to model when id is empty string but model is valid", async () => {
+      mockReadFile.mockResolvedValue(
+        JSON.stringify({
+          models: [{ id: "", model: "fallback-model" }],
+        })
+      );
+
+      const presets = await service.discoverPresets();
+      expect(presets).toHaveLength(1);
+      expect(presets[0].id).toBe("ccr-fallback-model");
+    });
+
+    it("falls back to model when id is non-string but model is valid", async () => {
+      mockReadFile.mockResolvedValue(
+        JSON.stringify({
+          models: [{ id: { foo: "bar" }, model: "real-model" }],
+        })
+      );
+
+      const presets = await service.discoverPresets();
+      expect(presets).toHaveLength(1);
+      expect(presets[0].id).toBe("ccr-real-model");
+      expect(presets[0].id).not.toContain("[object Object]");
+    });
+
+    it("filters entries with non-string model and no valid id", async () => {
+      mockReadFile.mockResolvedValue(
+        JSON.stringify({
+          models: [
+            { model: 42 },
+            { model: { nested: true } },
+            { id: "valid", model: "valid-model" },
+          ],
+        })
+      );
+
+      const presets = await service.discoverPresets();
+      expect(presets).toHaveLength(1);
+      expect(presets[0].id).toBe("ccr-valid");
     });
 
     it("includes apiKeyEnv as template in env", async () => {

--- a/electron/services/__tests__/CcrConfigService.test.ts
+++ b/electron/services/__tests__/CcrConfigService.test.ts
@@ -1,6 +1,7 @@
 import { describe, it, expect, beforeEach, afterEach, vi } from "vitest";
 import type { AgentPreset } from "../../../shared/config/agentRegistry.js";
 import { CcrConfigService } from "../CcrConfigService.js";
+import { formatErrorMessage } from "../../../shared/utils/errorMessage.js";
 
 vi.mock("fs/promises", () => ({
   readFile: vi.fn(),
@@ -150,7 +151,11 @@ describe("CcrConfigService", () => {
       mockReadFile.mockResolvedValue(`{ "models": [{ "id": "x", "apiKey": "${leakySnippet}" }`);
       await service.discoverPresets();
       const allLoggedText = warnSpy.mock.calls
-        .flatMap((call) => call.map((arg) => (arg instanceof Error ? arg.message : String(arg))))
+        .flatMap((call) =>
+          call.map((arg) =>
+            arg instanceof Error ? formatErrorMessage(arg, "parse error") : String(arg)
+          )
+        )
         .join(" ");
       expect(allLoggedText).not.toContain(leakySnippet);
       warnSpy.mockRestore();


### PR DESCRIPTION
## Summary

- The old `discoverPresets()` had a single blanket `try/catch` around the entire read+parse+filter pipeline, so any error -- parse failure, permission denied, wrong JSON shape -- silently returned zero presets with no diagnostic
- Splits the block into separate read and parse sections: `ENOENT` stays silent (CCR just not installed), everything else now warns; raw config contents are never included in the warning message to avoid leaking sensitive values like API keys
- Tightens the preset filter to require `typeof === 'string' && length > 0` for `id` and `model`, guards against `null`/non-object entries in the `models` array, and hardens `entryToPreset` so non-string fields coerce to `undefined` (making the `??` fallback chain actually work)

Resolves #7098

## Changes

- `electron/services/CcrConfigService.ts` -- split read/parse try-catch blocks; guard non-object top-level JSON; reject `null`, non-object, and primitive entries in `models`; fix ID filter to use `typeof === 'string' && length > 0`; coerce non-string fields to `undefined` in `entryToPreset`
- `electron/services/__tests__/CcrConfigService.test.ts` -- 13 new tests: `ENOENT` silent, `EACCES` warns, malformed JSON warns, no raw config in warning output, non-string/empty-string/object IDs filtered, `id`-missing fallback to `model`, `null`/array top-level JSON, `null`/`undefined` entries in `models`, primitive entries, non-`Error` read rejection, stale-cache reset on re-read

## Testing

36 tests pass (23 existing + 13 new). Typecheck, lint, and format clean.