### PR TITLE
perf(app): memoize per-process GPU status reads in hydration

### DIFF
--- a/electron/ipc/handlers/app/state.ts
+++ b/electron/ipc/handlers/app/state.ts
@@ -9,7 +9,7 @@ import {
 } from "../../../schemas/ipc.js";
 import { getCrashRecoveryService } from "../../../services/CrashRecoveryService.js";
 
-import { isWebGLHardwareAccelerated } from "../../../utils/gpuDetection.js";
+import { getGpuFeatureStatus, isWebGLHardwareAccelerated } from "../../../utils/gpuDetection.js";
 import { isGpuDisabledByFlag } from "../../../services/GpuCrashMonitorService.js";
 import { getCrashLoopGuard } from "../../../services/CrashLoopGuardService.js";
 import { closeTelemetry } from "../../../services/TelemetryService.js";
@@ -236,7 +236,7 @@ export function registerAppStateHandlers(): () => void {
       `[AppHydrate] Project: ${currentProject?.name ?? "none"} - terminals from ${terminalsSource} (${terminalsToUse.length} valid), focusMode: ${focusModeToUse}`
     );
 
-    const gpuStatus = app.getGPUFeatureStatus();
+    const gpuStatus = getGpuFeatureStatus();
     const gpuWebGLHardware = isWebGLHardwareAccelerated(gpuStatus.webgl2);
     if (!gpuWebGLHardware) {
       console.warn(

--- a/electron/services/AppHydrationService.ts
+++ b/electron/services/AppHydrationService.ts
@@ -2,7 +2,7 @@ import { app } from "electron";
 import { store } from "../store.js";
 import { projectStore } from "./ProjectStore.js";
 import { TerminalSnapshotSchema, filterValidTerminalEntries } from "../schemas/ipc.js";
-import { isWebGLHardwareAccelerated } from "../utils/gpuDetection.js";
+import { getGpuFeatureStatus, isWebGLHardwareAccelerated } from "../utils/gpuDetection.js";
 import { isGpuDisabledByFlag } from "./GpuCrashMonitorService.js";
 import { getCrashLoopGuard } from "./CrashLoopGuardService.js";
 import type { HydrateResult } from "../../shared/types/ipc/app.js";
@@ -74,7 +74,7 @@ export async function buildSwitchHydrateResult(projectId: string): Promise<Hydra
     focusPanelState: focusPanelStateToUse,
   };
 
-  const gpuStatus = app.getGPUFeatureStatus();
+  const gpuStatus = getGpuFeatureStatus();
   const gpuWebGLHardware = isWebGLHardwareAccelerated(gpuStatus.webgl2);
 
   return {

--- a/electron/services/GpuCrashMonitorService.ts
+++ b/electron/services/GpuCrashMonitorService.ts
@@ -9,8 +9,16 @@ const GPU_DISABLED_FLAG = "gpu-disabled.flag";
 const GPU_ANGLE_FALLBACK_FLAG = "gpu-angle-fallback.flag";
 const GPU_CRASH_THRESHOLD = 3;
 
+let cachedGpuDisabledByFlag: boolean | null = null;
+let cachedUserDataPath: string | null = null;
+
 export function isGpuDisabledByFlag(userDataPath: string): boolean {
-  return fs.existsSync(path.join(userDataPath, GPU_DISABLED_FLAG));
+  if (cachedGpuDisabledByFlag !== null && cachedUserDataPath === userDataPath) {
+    return cachedGpuDisabledByFlag;
+  }
+  cachedGpuDisabledByFlag = fs.existsSync(path.join(userDataPath, GPU_DISABLED_FLAG));
+  cachedUserDataPath = userDataPath;
+  return cachedGpuDisabledByFlag;
 }
 
 export function writeGpuDisabledFlag(userDataPath: string): void {

--- a/electron/services/__tests__/AppHydrationService.adversarial.test.ts
+++ b/electron/services/__tests__/AppHydrationService.adversarial.test.ts
@@ -86,9 +86,15 @@ vi.mock("../CrashLoopGuardService.js", () => ({
   }),
 }));
 
-vi.mock("../../utils/gpuDetection.js", () => ({
-  isWebGLHardwareAccelerated: isWebGLHardwareAcceleratedMock,
-}));
+vi.mock("../../utils/gpuDetection.js", async () => {
+  const actual = await vi.importActual<typeof import("../../utils/gpuDetection.js")>(
+    "../../utils/gpuDetection.js"
+  );
+  return {
+    ...actual,
+    isWebGLHardwareAccelerated: isWebGLHardwareAcceleratedMock,
+  };
+});
 
 vi.mock("../GpuCrashMonitorService.js", () => ({
   isGpuDisabledByFlag: isGpuDisabledByFlagMock,

--- a/electron/utils/gpuDetection.ts
+++ b/electron/utils/gpuDetection.ts
@@ -1,8 +1,18 @@
+import { app } from "electron";
 import fs from "node:fs";
 
 export function isWebGLHardwareAccelerated(webgl2: unknown): boolean {
   if (typeof webgl2 !== "string") return true;
   return webgl2.startsWith("enabled") && webgl2 !== "enabled_readback";
+}
+
+let cachedGpuFeatureStatus: ReturnType<typeof app.getGPUFeatureStatus> | null = null;
+
+export function getGpuFeatureStatus(): ReturnType<typeof app.getGPUFeatureStatus> {
+  if (!cachedGpuFeatureStatus) {
+    cachedGpuFeatureStatus = app.getGPUFeatureStatus();
+  }
+  return cachedGpuFeatureStatus;
 }
 
 const VENDOR_NVIDIA = "0x10de";


### PR DESCRIPTION
## Summary
`app.getGPUFeatureStatus()` and `isGpuDisabledByFlag()` are per-process reads of GPU status. Neither value changes within a process lifetime, but both were getting called on every project switch and every cold hydrate.

I added module-scoped memoization to both so they compute once on the first call and return the cached value for all subsequent calls. The test mock was updated to a partial mock so the real memoized functions flow through.

Resolves #7110

## Changes
- New `getGpuFeatureStatus()` wrapper in `electron/utils/gpuDetection.ts` -- calls `app.getGPUFeatureStatus()` once, caches the result.
- Memoization in `isGpuDisabledByFlag()` in `electron/services/GpuCrashMonitorService.ts`. Cached per `userDataPath`, which is stable per process.
- Updated call sites in `buildSwitchHydrateResult` and `handleAppHydrate` to use the memoized wrappers.
- Partial mock in `AppHydrationService.adversarial.test.ts` so `getGpuFeatureStatus` flows through while `isWebGLHardwareAccelerated` stays mocked.

## Testing
- Typecheck passes.
- Existing adversarial tests pass with the updated partial mock.