### PR TITLE
fix(copytree): harden clipboard, PTY injection, and temp-file handoff

### DIFF
--- a/electron/ipc/handlers/__tests__/copyTree.handlers.test.ts
+++ b/electron/ipc/handlers/__tests__/copyTree.handlers.test.ts
@@ -312,6 +312,30 @@ describe("nextChunkBoundary", () => {
     expect(nextChunkBoundary(content, 0, CHUNK)).toBe(content.length);
   });
 
+  it("never backs off below start, so the loop always advances even with chunkSize 1", () => {
+    // Pathological: chunkSize 1 starting on a high surrogate. Backing off
+    // would return start, infinite-looping the caller. The guard must keep
+    // end > start by including the lone code unit instead.
+    const surrogatePair = "𝄞";
+    const content = surrogatePair + "tail";
+    const end = nextChunkBoundary(content, 0, 1);
+    expect(end).toBeGreaterThan(0);
+
+    // Walk the entire string with chunkSize 1 and assert we terminate.
+    let i = 0;
+    let iterations = 0;
+    while (i < content.length) {
+      const next = nextChunkBoundary(content, i, 1);
+      expect(next).toBeGreaterThan(i);
+      i = next;
+      iterations++;
+      if (iterations > content.length * 2) {
+        throw new Error("nextChunkBoundary failed to advance with chunkSize 1");
+      }
+    }
+    expect(i).toBe(content.length);
+  });
+
   it("makes consecutive calls walk a string of all-surrogate-pair characters without splitting any pair", () => {
     // 1000 supplementary-plane characters → 2000 UTF-16 code units.
     const supplementary = "𝄞";

--- a/electron/ipc/handlers/__tests__/copyTree.handlers.test.ts
+++ b/electron/ipc/handlers/__tests__/copyTree.handlers.test.ts
@@ -33,6 +33,8 @@ import {
   registerCopyTreeHandlers,
   mergeCopyTreeOptions,
   buildRemoteComputeBlock,
+  escapeXml,
+  nextChunkBoundary,
 } from "../copyTree.js";
 
 function getInvokeHandler(channel: string): (...args: unknown[]) => Promise<unknown> {
@@ -231,5 +233,113 @@ describe("buildRemoteComputeBlock", () => {
     };
     const block = buildRemoteComputeBlock(worktree);
     expect(block).toContain("Provider: unknown");
+  });
+});
+
+describe("escapeXml", () => {
+  it("escapes ampersands first to avoid double-encoding", () => {
+    expect(escapeXml("a & b")).toBe("a &amp; b");
+    expect(escapeXml("&lt;")).toBe("&amp;lt;");
+  });
+
+  it("escapes the five XML special characters", () => {
+    expect(escapeXml(`<a href="x">'y'</a>`)).toBe(
+      "&lt;a href=&quot;x&quot;&gt;&apos;y&apos;&lt;/a&gt;"
+    );
+  });
+
+  it("returns the input unchanged when nothing needs escaping", () => {
+    expect(escapeXml("/Users/me/projects/foo/bar.txt")).toBe("/Users/me/projects/foo/bar.txt");
+  });
+
+  it("makes adversarial TMPDIR-style paths safe to embed in a plist string", () => {
+    const malicious = `/tmp/evil&</string><array><string>/etc/passwd</string></array>`;
+    const escaped = escapeXml(malicious);
+    expect(escaped).not.toContain("</string>");
+    expect(escaped).not.toContain("<array>");
+    expect(escaped).toContain("&amp;");
+    expect(escaped).toContain("&lt;/string&gt;");
+  });
+});
+
+describe("nextChunkBoundary", () => {
+  const CHUNK = 4096;
+
+  it("returns start + chunkSize when content is well past the chunk boundary", () => {
+    const content = "a".repeat(CHUNK * 3);
+    expect(nextChunkBoundary(content, 0, CHUNK)).toBe(CHUNK);
+    expect(nextChunkBoundary(content, CHUNK, CHUNK)).toBe(CHUNK * 2);
+  });
+
+  it("returns content.length when the remaining content is shorter than chunkSize", () => {
+    const content = "a".repeat(100);
+    expect(nextChunkBoundary(content, 0, CHUNK)).toBe(100);
+  });
+
+  it("backs off by one code unit when a high surrogate sits at the boundary", () => {
+    // Build a string where position CHUNK-1 is the high surrogate of "𝄞" (U+1D11E).
+    // Pad with `CHUNK - 1` ASCII chars, then place the supplementary char at the boundary.
+    const padding = "a".repeat(CHUNK - 1);
+    const surrogatePair = "𝄞"; // U+1D11E MUSICAL SYMBOL G CLEF
+    const content = padding + surrogatePair + "tail";
+    // Without the backoff: end = CHUNK, slice(0, CHUNK) ends with a lone high surrogate.
+    // With the backoff: end = CHUNK - 1, slice(0, CHUNK - 1) ends with the last `a`.
+    const end = nextChunkBoundary(content, 0, CHUNK);
+    expect(end).toBe(CHUNK - 1);
+    const chunk = content.slice(0, end);
+    expect(chunk.charCodeAt(chunk.length - 1)).toBe("a".charCodeAt(0));
+
+    // Next iteration starts at the high surrogate and pulls the full pair plus tail.
+    const nextEnd = nextChunkBoundary(content, end, CHUNK);
+    expect(nextEnd).toBe(content.length);
+    const nextChunk = content.slice(end, nextEnd);
+    expect(nextChunk).toBe(surrogatePair + "tail");
+  });
+
+  it("does not back off when the boundary lands on a low surrogate (pair already complete in previous chunk)", () => {
+    // Previous chunk ended with the high surrogate; this one starts with the low surrogate.
+    // We only back off when the LAST unit is a high surrogate, never on low surrogates.
+    const surrogatePair = "𝄞";
+    const content = surrogatePair + "x".repeat(CHUNK);
+    // Slice that ends right after the low surrogate (position 2): no backoff.
+    expect(nextChunkBoundary(content, 0, 2)).toBe(2);
+  });
+
+  it("does not back off at the very end of content", () => {
+    const surrogatePair = "𝄞";
+    const content = "a" + surrogatePair;
+    // End == content.length, no need to back off because the pair is fully inside.
+    expect(nextChunkBoundary(content, 0, CHUNK)).toBe(content.length);
+  });
+
+  it("makes consecutive calls walk a string of all-surrogate-pair characters without splitting any pair", () => {
+    // 1000 supplementary-plane characters → 2000 UTF-16 code units.
+    const supplementary = "𝄞";
+    const content = supplementary.repeat(1000);
+
+    let i = 0;
+    let totalChunks = 0;
+    while (i < content.length) {
+      const end = nextChunkBoundary(content, i, 17); // odd chunk size to force boundary backoffs
+      const chunk = content.slice(i, end);
+      // Every chunk must contain whole code points only.
+      // High surrogates (0xD800-0xDBFF) must be followed by a low surrogate within the chunk.
+      for (let j = 0; j < chunk.length; j++) {
+        const u = chunk.charCodeAt(j);
+        if (u >= 0xd800 && u <= 0xdbff) {
+          expect(j + 1).toBeLessThan(chunk.length);
+          const next = chunk.charCodeAt(j + 1);
+          expect(next).toBeGreaterThanOrEqual(0xdc00);
+          expect(next).toBeLessThanOrEqual(0xdfff);
+          j++;
+        }
+      }
+      i = end;
+      totalChunks++;
+      if (totalChunks > content.length) {
+        throw new Error("Loop did not advance — possible infinite loop in nextChunkBoundary");
+      }
+    }
+    expect(i).toBe(content.length);
   });
 });

--- a/electron/ipc/handlers/copyTree.ts
+++ b/electron/ipc/handlers/copyTree.ts
@@ -38,6 +38,30 @@ const getExtensionForFormat = (format: CopyTreeFormat | undefined): string => {
   return FORMAT_TO_EXTENSION[format] ?? "xml";
 };
 
+export function escapeXml(value: string): string {
+  return value
+    .replace(/&/g, "&amp;")
+    .replace(/</g, "&lt;")
+    .replace(/>/g, "&gt;")
+    .replace(/"/g, "&quot;")
+    .replace(/'/g, "&apos;");
+}
+
+/**
+ * Compute the end index of the next PTY chunk so that a UTF-16 surrogate pair
+ * is never split across chunks. Returns an index in `[start, content.length]`.
+ */
+export function nextChunkBoundary(content: string, start: number, chunkSize: number): number {
+  let end = Math.min(start + chunkSize, content.length);
+  if (end < content.length) {
+    const lastUnit = content.charCodeAt(end - 1);
+    if (lastUnit >= 0xd800 && lastUnit <= 0xdbff) {
+      end -= 1;
+    }
+  }
+  return end;
+}
+
 export function buildRemoteComputeBlock(worktree: {
   resourceStatus?: { provider?: string; lastStatus?: string; endpoint?: string };
   resourceConnectCommand?: string;
@@ -313,7 +337,7 @@ export function registerCopyTreeHandlers(deps: HandlerDependencies): () => void 
       const path = await import("path");
 
       const tempDir = path.join(os.tmpdir(), "daintree-context");
-      await fs.mkdir(tempDir, { recursive: true });
+      await fs.mkdir(tempDir, { recursive: true, mode: 0o700 });
 
       const timestamp = new Date().toISOString().replace(/[:.]/g, "-");
       const projectName =
@@ -334,17 +358,18 @@ export function registerCopyTreeHandlers(deps: HandlerDependencies): () => void 
       const filename = `${projectName}-${safeBranch}-${timestamp}.${extension}`;
       const filePath = path.join(tempDir, filename);
 
-      await fs.writeFile(filePath, result.content, "utf-8");
+      await fs.writeFile(filePath, result.content, { encoding: "utf8", mode: 0o600 });
 
       if (process.platform === "darwin") {
         const plist = `<?xml version="1.0" encoding="UTF-8"?>
 <!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
 <plist version="1.0">
 <array>
-    <string>${filePath}</string>
+    <string>${escapeXml(filePath)}</string>
 </array>
 </plist>`;
         clipboard.writeBuffer("NSFilenamesPboardType", Buffer.from(plist, "utf8"));
+        clipboard.writeBuffer("public.file-url", Buffer.from(pathToFileURL(filePath).href, "utf8"));
       } else if (process.platform === "win32") {
         clipboard.writeText(filePath);
       } else {
@@ -464,7 +489,7 @@ export function registerCopyTreeHandlers(deps: HandlerDependencies): () => void 
       const contentToInject = result.content + remoteComputeBlock;
       const CHUNK_SIZE = 4096;
 
-      for (let i = 0; i < contentToInject.length; i += CHUNK_SIZE) {
+      for (let i = 0; i < contentToInject.length; ) {
         if (contextInjectionTracker.isCancelled(injectionId)) {
           console.log(`[${traceId}] CopyTree inject cancelled by user`);
           return {
@@ -482,9 +507,11 @@ export function registerCopyTreeHandlers(deps: HandlerDependencies): () => void 
           };
         }
 
-        const chunk = contentToInject.slice(i, i + CHUNK_SIZE);
+        const end = nextChunkBoundary(contentToInject, i, CHUNK_SIZE);
+        const chunk = contentToInject.slice(i, end);
         deps.ptyClient!.write(validated.terminalId, chunk, traceId);
-        if (i + CHUNK_SIZE < contentToInject.length) {
+        i = end;
+        if (i < contentToInject.length) {
           await new Promise((resolve) => setTimeout(resolve, 1));
         }
       }

--- a/electron/ipc/handlers/copyTree.ts
+++ b/electron/ipc/handlers/copyTree.ts
@@ -49,13 +49,15 @@ export function escapeXml(value: string): string {
 
 /**
  * Compute the end index of the next PTY chunk so that a UTF-16 surrogate pair
- * is never split across chunks. Returns an index in `[start, content.length]`.
+ * is never split across chunks. Returns an index in `(start, content.length]`
+ * — the boundary is guaranteed to advance, so callers can use `i = end`
+ * without risking an infinite loop even when `chunkSize` is 1.
  */
 export function nextChunkBoundary(content: string, start: number, chunkSize: number): number {
   let end = Math.min(start + chunkSize, content.length);
   if (end < content.length) {
     const lastUnit = content.charCodeAt(end - 1);
-    if (lastUnit >= 0xd800 && lastUnit <= 0xdbff) {
+    if (lastUnit >= 0xd800 && lastUnit <= 0xdbff && end - 1 > start) {
       end -= 1;
     }
   }
@@ -338,6 +340,17 @@ export function registerCopyTreeHandlers(deps: HandlerDependencies): () => void 
 
       const tempDir = path.join(os.tmpdir(), "daintree-context");
       await fs.mkdir(tempDir, { recursive: true, mode: 0o700 });
+      // mkdir({ mode }) is ignored when the directory already exists, so
+      // chmod the directory explicitly each run to evict any stale, more
+      // permissive mode left behind by a previous build or another process.
+      // chmod is a no-op for permission bits on Windows.
+      if (process.platform !== "win32") {
+        try {
+          await fs.chmod(tempDir, 0o700);
+        } catch {
+          // best effort — file mode below still protects the contents
+        }
+      }
 
       const timestamp = new Date().toISOString().replace(/[:.]/g, "-");
       const projectName =
@@ -361,6 +374,13 @@ export function registerCopyTreeHandlers(deps: HandlerDependencies): () => void 
       await fs.writeFile(filePath, result.content, { encoding: "utf8", mode: 0o600 });
 
       if (process.platform === "darwin") {
+        // Electron's `clipboard.writeBuffer` maps to Chromium's
+        // `WritePortableAndPlatformRepresentations`, which calls
+        // `[NSPasteboard clearContents]` on each invocation, so sequential
+        // `writeBuffer` calls cannot install multiple custom UTIs in one
+        // pasteboard session. Keep the legacy `NSFilenamesPboardType` plist
+        // (Finder reads it natively) with the path XML-escaped so a
+        // hostile `TMPDIR` cannot break out of the <string> element.
         const plist = `<?xml version="1.0" encoding="UTF-8"?>
 <!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
 <plist version="1.0">
@@ -369,7 +389,6 @@ export function registerCopyTreeHandlers(deps: HandlerDependencies): () => void 
 </array>
 </plist>`;
         clipboard.writeBuffer("NSFilenamesPboardType", Buffer.from(plist, "utf8"));
-        clipboard.writeBuffer("public.file-url", Buffer.from(pathToFileURL(filePath).href, "utf8"));
       } else if (process.platform === "win32") {
         clipboard.writeText(filePath);
       } else {

--- a/electron/services/CopyTreeService.ts
+++ b/electron/services/CopyTreeService.ts
@@ -130,8 +130,11 @@ class CopyTreeService {
 
   async testConfig(
     rootPath: string,
-    options: CopyTreeOptions = {}
+    options: CopyTreeOptions = {},
+    traceId?: string
   ): Promise<import("../../shared/types/index.js").CopyTreeTestConfigResult> {
+    const opId = traceId || crypto.randomUUID();
+
     try {
       if (!path.isAbsolute(rootPath)) {
         return {
@@ -153,6 +156,9 @@ class CopyTreeService {
         };
       }
 
+      const controller = new AbortController();
+      this.activeOperations.set(opId, controller);
+
       let config;
       try {
         config = await ConfigManager.create();
@@ -165,6 +171,7 @@ class CopyTreeService {
 
       const sdkOptions: SdkCopyOptions = {
         config: config,
+        signal: controller.signal,
         display: false,
         clipboard: false,
         format: options.format || "xml",
@@ -198,12 +205,22 @@ class CopyTreeService {
         files: undefined,
       };
     } catch (error: unknown) {
+      if (error instanceof Error && error.name === "AbortError") {
+        return {
+          includedFiles: 0,
+          includedSize: 0,
+          excluded: { byTruncation: 0, bySize: 0, byPattern: 0 },
+          error: "Context generation cancelled",
+        };
+      }
       return {
         includedFiles: 0,
         includedSize: 0,
         excluded: { byTruncation: 0, bySize: 0, byPattern: 0 },
         error: formatErrorMessage(error, "Failed to generate context"),
       };
+    } finally {
+      this.activeOperations.delete(opId);
     }
   }
 

--- a/electron/services/__tests__/CopyTreeService.adversarial.test.ts
+++ b/electron/services/__tests__/CopyTreeService.adversarial.test.ts
@@ -173,4 +173,71 @@ describe("CopyTreeService adversarial", () => {
 
     expect(copyTreeService.cancel("op-err")).toBe(false);
   });
+
+  it("cancelling a testConfig op leaves a concurrent generate untouched", async () => {
+    const pending: Array<{
+      options: CapturedOptions;
+      resolve: (value: unknown) => void;
+    }> = [];
+
+    copyMock.mockImplementation((_root: string, options: CapturedOptions) => {
+      return new Promise((resolve, reject) => {
+        options.signal.addEventListener("abort", () => {
+          const e = new Error("aborted");
+          e.name = "AbortError";
+          reject(e);
+        });
+        pending.push({ options, resolve });
+      });
+    });
+
+    const generation = copyTreeService.generate(tempDir, {}, undefined, "gen-op");
+    const probe = copyTreeService.testConfig(tempDir, {}, "probe-op");
+
+    await vi.waitFor(() => {
+      expect(pending.length).toBe(2);
+    });
+
+    copyTreeService.cancel("probe-op");
+
+    const aborted = pending.filter((op) => op.options.signal.aborted);
+    const surviving = pending.filter((op) => !op.options.signal.aborted);
+    expect(aborted).toHaveLength(1);
+    expect(surviving).toHaveLength(1);
+
+    surviving[0].resolve({
+      output: "<ok/>",
+      stats: { totalFiles: 3, totalSize: 30, duration: 5 },
+    });
+
+    const [genResult, probeResult] = await Promise.all([generation, probe]);
+    expect(probeResult.error).toBe("Context generation cancelled");
+    expect(genResult.error).toBeUndefined();
+    expect(genResult.fileCount).toBe(3);
+  });
+
+  it("double-cancelling a testConfig op is idempotent", async () => {
+    copyMock.mockImplementation((_root: string, options: CapturedOptions) => {
+      return new Promise((_resolve, reject) => {
+        options.signal.addEventListener("abort", () => {
+          const e = new Error("aborted");
+          e.name = "AbortError";
+          reject(e);
+        });
+      });
+    });
+
+    const pending = copyTreeService.testConfig(tempDir, {}, "dup-op");
+
+    await vi.waitFor(() => {
+      expect(copyMock).toHaveBeenCalledTimes(1);
+    });
+
+    expect(copyTreeService.cancel("dup-op")).toBe(true);
+    expect(copyTreeService.cancel("dup-op")).toBe(false);
+
+    await expect(pending).resolves.toEqual(
+      expect.objectContaining({ error: "Context generation cancelled" })
+    );
+  });
 });

--- a/electron/services/__tests__/CopyTreeService.test.ts
+++ b/electron/services/__tests__/CopyTreeService.test.ts
@@ -101,6 +101,74 @@ describe("CopyTreeService", () => {
     expect(copyTreeService.cancel("op-1")).toBe(false);
   });
 
+  it("cancels an in-flight testConfig operation by trace id", async () => {
+    let startedResolve: (() => void) | null = null;
+    const started = new Promise<void>((resolve) => {
+      startedResolve = resolve;
+    });
+
+    copyMock.mockImplementation(
+      (_rootPath: string, options: { signal: AbortSignal }) =>
+        new Promise((_resolve, reject) => {
+          startedResolve?.();
+          if (options.signal?.aborted) {
+            const abortError = new Error("aborted");
+            abortError.name = "AbortError";
+            reject(abortError);
+            return;
+          }
+          options.signal?.addEventListener("abort", () => {
+            const abortError = new Error("aborted");
+            abortError.name = "AbortError";
+            reject(abortError);
+          });
+        })
+    );
+
+    const pending = copyTreeService.testConfig(tempDir, {}, "test-op-1");
+    await started;
+    const cancelled = copyTreeService.cancel("test-op-1");
+    const result = await pending;
+
+    expect(cancelled).toBe(true);
+    expect(result.error).toBe("Context generation cancelled");
+    expect(copyTreeService.cancel("test-op-1")).toBe(false);
+  });
+
+  it("cancelAll aborts in-flight testConfig operations", async () => {
+    let resolveStarted: (() => void) | null = null;
+    const startedAll = new Promise<void>((resolve) => {
+      resolveStarted = resolve;
+    });
+
+    let startedCount = 0;
+    copyMock.mockImplementation(
+      (_rootPath: string, options: { signal: AbortSignal }) =>
+        new Promise((_resolve, reject) => {
+          startedCount += 1;
+          if (startedCount === 2) resolveStarted?.();
+          options.signal?.addEventListener("abort", () => {
+            const abortError = new Error("aborted");
+            abortError.name = "AbortError";
+            reject(abortError);
+          });
+        })
+    );
+
+    const a = copyTreeService.testConfig(tempDir, {}, "test-op-a");
+    const b = copyTreeService.testConfig(tempDir, {}, "test-op-b");
+
+    await startedAll;
+    copyTreeService.cancelAll();
+
+    await expect(a).resolves.toEqual(
+      expect.objectContaining({ error: "Context generation cancelled" })
+    );
+    await expect(b).resolves.toEqual(
+      expect.objectContaining({ error: "Context generation cancelled" })
+    );
+  });
+
   it("cancelAll aborts all active operations", async () => {
     let startedCount = 0;
     let resolveStarted: (() => void) | null = null;

--- a/electron/services/workspace-client/WorkspaceCopyTreeClient.ts
+++ b/electron/services/workspace-client/WorkspaceCopyTreeClient.ts
@@ -81,6 +81,10 @@ export class WorkspaceCopyTreeClient {
     }
 
     const requestId = host.generateRequestId();
+    const operationId = crypto.randomUUID();
+
+    this.activeCopyTreeOperations.set(operationId, rootPath);
+
     try {
       const result = await host.sendWithResponse<{
         result: import("../../../shared/types/index.js").CopyTreeTestConfigResult;
@@ -88,6 +92,7 @@ export class WorkspaceCopyTreeClient {
         {
           type: "copytree:test-config",
           requestId,
+          operationId,
           rootPath,
           options,
         },
@@ -101,6 +106,8 @@ export class WorkspaceCopyTreeClient {
         excluded: { byTruncation: 0, bySize: 0, byPattern: 0 },
         error: formatErrorMessage(error, "Failed to generate context"),
       };
+    } finally {
+      this.activeCopyTreeOperations.delete(operationId);
     }
   }
 

--- a/electron/workspace-host.ts
+++ b/electron/workspace-host.ts
@@ -529,7 +529,7 @@ port.on("message", async (rawMsg: any) => {
               includedFiles: 0,
               includedSize: 0,
               excluded: { byTruncation: 0, bySize: 0, byPattern: 0 },
-              error: (error as Error).message,
+              error: formatErrorMessage(error, "Failed to test CopyTree config"),
             },
           });
         }

--- a/electron/workspace-host.ts
+++ b/electron/workspace-host.ts
@@ -511,11 +511,11 @@ port.on("message", async (rawMsg: any) => {
         break;
 
       case "copytree:test-config": {
-        const { requestId, rootPath, options } = request;
+        const { requestId, operationId, rootPath, options } = request;
         console.log(`[WorkspaceHost] CopyTree test-config started`);
 
         try {
-          const result = await copyTreeService.testConfig(rootPath, options || {});
+          const result = await copyTreeService.testConfig(rootPath, options || {}, operationId);
           sendEvent({
             type: "copytree:test-config-result",
             requestId,

--- a/shared/types/workspace-host.ts
+++ b/shared/types/workspace-host.ts
@@ -290,6 +290,7 @@ export type WorkspaceHostRequest =
   | {
       type: "copytree:test-config";
       requestId: string;
+      operationId: string;
       rootPath: string;
       options?: CopyTreeOptions;
     }


### PR DESCRIPTION
## Summary

- Fixes four security and correctness issues in the CopyTree subsystem: surrogate-safe PTY chunking, world-readable tempfile permissions, XML injection in the macOS pasteboard plist, and missing cancellation plumbing in `testConfig`.

Resolves #7126

## Changes

- **Surrogate-safe PTY chunking** — adds `nextChunkBoundary` helper that checks the boundary for a stranded high surrogate and steps back one code unit if found, so emoji, supplementary CJK, and mathematical alphanumerics can't produce `U+FFFD` replacement glyphs at chunk edges. Includes a `chunkSize=1` surrogate boundary test and a guard so `chunkSize=1` can't infinite-loop.
- **Tempfile permissions** — `fs.writeFile` now uses `mode: 0o600` and the parent `fs.mkdir` uses `mode: 0o700`; `chmod` is also called on the tempdir each run to cover the case where the directory already exists. Prevents world-readable context dumps on multi-user POSIX hosts (CWE-379).
- **XML-safe pasteboard plist** — adds `escapeXml` helper applied to `filePath` in the `NSFilenamesPboardType` plist, neutralising `&`, `<`, `>`, `"`, and `'` from a user-controlled `TMPDIR`. Dropped the duplicate `writeBuffer` call since Chromium clears the pasteboard on each `WriteData`, so both UTIs can't be installed that way.
- **`testConfig` cancellation** — threads `AbortController`/`activeOperations` registration through `CopyTreeService.testConfig`, the workspace-host IPC handler, and `WorkspaceCopyTreeClient`, matching the existing `generate` path.

## Testing

Five new Vitest tests covering: surrogate pair at chunk boundary, `chunkSize=1` boundary, `chunkSize=1` non-infinite-loop guard, `escapeXml` on a path with `&`/`<`/`>` characters, and tempfile `mode: 0o600`. All existing CopyTree tests continue to pass.