### PR TITLE
fix(crash-recovery): gate GPU relaunches on crash loop guard and use cached snapshot for panel summaries

### DIFF
--- a/electron/services/CrashRecoveryService.ts
+++ b/electron/services/CrashRecoveryService.ts
@@ -300,9 +300,19 @@ export class CrashRecoveryService {
 
   private extractPanelSummaries(crashTimestamp: number): PanelSummary[] {
     try {
-      if (!fs.existsSync(this.backupPath)) return [];
-      const raw = fs.readFileSync(this.backupPath, "utf8");
-      const snapshot = JSON.parse(raw) as SessionSnapshot;
+      // Prefer the snapshot cached by consumeMarker — startBackupTimer can
+      // overwrite this.backupPath on disk between marker consumption and
+      // here, which would silently swap pre-crash panels for an empty
+      // post-crash session. Fall back to disk only when the cache failed
+      // to populate (read or parse error in consumeMarker's try block).
+      let snapshot: SessionSnapshot;
+      if (this.cachedBackupSnapshot) {
+        snapshot = this.cachedBackupSnapshot;
+      } else {
+        if (!fs.existsSync(this.backupPath)) return [];
+        const raw = fs.readFileSync(this.backupPath, "utf8");
+        snapshot = JSON.parse(raw) as SessionSnapshot;
+      }
       if (!snapshot.appState) return [];
 
       const appState = snapshot.appState as Record<string, unknown>;

--- a/electron/services/CrashRecoveryService.ts
+++ b/electron/services/CrashRecoveryService.ts
@@ -183,13 +183,19 @@ export class CrashRecoveryService {
       }
 
       if (panelIds !== undefined && panelIds.length > 0 && snapshot.appState) {
-        const appState = snapshot.appState as Record<string, unknown>;
+        // Filter onto a shallow copy so we don't mutate cachedBackupSnapshot.
+        // If applySessionSnapshot below throws and the user retries the
+        // restore (with or without a different filter), the cache must
+        // still hold the full pre-crash terminal list — mutating it in
+        // place permanently drops panels from any retry path.
+        const appState = { ...(snapshot.appState as Record<string, unknown>) };
         if (Array.isArray(appState.terminals)) {
           const idSet = new Set(panelIds);
           appState.terminals = (appState.terminals as Array<{ id: string }>).filter((t) =>
             idSet.has(t.id)
           );
         }
+        snapshot = { ...snapshot, appState };
       }
 
       if (!hasRestorableSnapshotContent(snapshot)) {

--- a/electron/services/GpuCrashMonitorService.ts
+++ b/electron/services/GpuCrashMonitorService.ts
@@ -3,6 +3,7 @@ import fs from "node:fs";
 import path from "node:path";
 import { store } from "../store.js";
 import { closeTelemetry } from "./TelemetryService.js";
+import { getCrashLoopGuard } from "./CrashLoopGuardService.js";
 
 const GPU_DISABLED_FLAG = "gpu-disabled.flag";
 const GPU_ANGLE_FALLBACK_FLAG = "gpu-angle-fallback.flag";
@@ -85,6 +86,15 @@ class GpuCrashMonitorService {
           return;
         }
         this.relaunching = true;
+        // Honor the crash-loop hard stop even when GPU crashes are the
+        // trigger — otherwise back-to-back GPU crashes can blow past the
+        // process-wide HARD_STOP_THRESHOLD that globalErrorHandlers respects.
+        if (!getCrashLoopGuard().shouldRelaunch()) {
+          console.error("[GPU] Crash loop hard stop reached — not relaunching (ANGLE fallback)");
+          await closeTelemetry();
+          app.exit(0);
+          return;
+        }
         console.error("[GPU] First GPU crash — wrote ANGLE fallback flag, relaunching");
         app.relaunch();
         await closeTelemetry();
@@ -104,6 +114,12 @@ class GpuCrashMonitorService {
           return;
         }
         this.relaunching = true;
+        if (!getCrashLoopGuard().shouldRelaunch()) {
+          console.error("[GPU] Crash loop hard stop reached — not relaunching (nuclear disable)");
+          await closeTelemetry();
+          app.exit(0);
+          return;
+        }
         console.error(
           `[GPU] ${GPU_CRASH_THRESHOLD} GPU crashes detected — wrote disable flag, relaunching`
         );

--- a/electron/services/__tests__/CrashRecoveryService.adversarial.test.ts
+++ b/electron/services/__tests__/CrashRecoveryService.adversarial.test.ts
@@ -149,6 +149,58 @@ describe("CrashRecoveryService adversarial", () => {
     });
   });
 
+  it("PANEL_SUMMARIES_USE_CACHED_SNAPSHOT", () => {
+    // Bug #7113: extractPanelSummaries used to re-read backupPath from disk
+    // even though consumeMarker had already populated cachedBackupSnapshot
+    // for exactly this purpose. If anything overwrote the file between those
+    // reads (concurrent backup, external process, racy test fixtures), the
+    // pending crash's panel summaries diverged from the snapshot restoreBackup
+    // would later use. Both paths must see the same cached snapshot.
+    writeBackup(tmpDir, {
+      capturedAt: Date.now(),
+      appState: {
+        terminals: [{ id: "agent-1", kind: "terminal", title: "Pre-Crash" }],
+      },
+    });
+    writeMarker(tmpDir);
+
+    const realRead = fs.readFileSync.bind(fs);
+    let backupReadCount = 0;
+    const readSpy = vi.spyOn(fs, "readFileSync").mockImplementation(((
+      target: fs.PathOrFileDescriptor,
+      options?: unknown
+    ) => {
+      if (typeof target === "string" && target.endsWith("session-state.json")) {
+        backupReadCount++;
+        if (backupReadCount > 1) {
+          // Any *re-read* of the backup must come back with overwritten
+          // content. If production code re-reads the file here, the
+          // panels assertion below will see empty terminals.
+          return JSON.stringify({
+            capturedAt: Date.now(),
+            appState: { terminals: [] },
+          });
+        }
+      }
+      return (realRead as (...a: unknown[]) => string | Buffer)(target, options);
+    }) as typeof fs.readFileSync);
+
+    const service = makeService();
+    service.initialize();
+
+    expect(backupReadCount).toBe(1);
+    const pending = service.getPendingCrash();
+    expect(pending).not.toBeNull();
+    expect(pending!.panels).toBeDefined();
+    expect(pending!.panels!.length).toBe(1);
+    expect(pending!.panels![0]).toMatchObject({
+      id: "agent-1",
+      title: "Pre-Crash",
+    });
+
+    readSpy.mockRestore();
+  });
+
   it("STARTBACKUPTIMER_IDEMPOTENT", () => {
     const service = makeService();
     const takeBackup = vi.spyOn(service, "takeBackup").mockImplementation(() => {});

--- a/electron/services/__tests__/CrashRecoveryService.adversarial.test.ts
+++ b/electron/services/__tests__/CrashRecoveryService.adversarial.test.ts
@@ -201,6 +201,45 @@ describe("CrashRecoveryService adversarial", () => {
     readSpy.mockRestore();
   });
 
+  it("FILTERED_RESTORE_DOES_NOT_NARROW_CACHE_ON_FAILURE", () => {
+    // restoreBackup applies a panelIds filter when the user picks a subset
+    // to restore. The filter must operate on a copy of the cached snapshot
+    // — otherwise a failed applySessionSnapshot leaves the cache narrowed
+    // and a retry (different filter, or no filter) silently drops panels
+    // that were never restored.
+    writeBackup(tmpDir, {
+      capturedAt: Date.now(),
+      appState: {
+        terminals: [
+          { id: "a", kind: "terminal", title: "Alpha" },
+          { id: "b", kind: "terminal", title: "Bravo" },
+        ],
+      },
+    });
+    writeMarker(tmpDir);
+
+    const service = makeService();
+    service.initialize();
+
+    // First restore filters to just "a" but the underlying store.set
+    // throws, simulating a partial-write or transient failure.
+    storeMock.set.mockImplementationOnce(() => {
+      throw new Error("transient store failure");
+    });
+    expect(service.restoreBackup(["a"])).toBe(false);
+
+    // Retry without a filter — must still see both panels because the
+    // cache was not destructively narrowed by the failed first attempt.
+    storeMock.set.mockImplementation(() => {});
+    expect(service.restoreBackup()).toBe(true);
+    expect(storeMock.set).toHaveBeenLastCalledWith("appState", {
+      terminals: [
+        { id: "a", kind: "terminal", title: "Alpha" },
+        { id: "b", kind: "terminal", title: "Bravo" },
+      ],
+    });
+  });
+
   it("STARTBACKUPTIMER_IDEMPOTENT", () => {
     const service = makeService();
     const takeBackup = vi.spyOn(service, "takeBackup").mockImplementation(() => {});

--- a/electron/services/__tests__/GpuCrashMonitorService.test.ts
+++ b/electron/services/__tests__/GpuCrashMonitorService.test.ts
@@ -35,6 +35,14 @@ const telemetryServiceMock = vi.hoisted(() => ({
 
 vi.mock("../TelemetryService.js", () => telemetryServiceMock);
 
+const crashLoopGuardMock = vi.hoisted(() => ({
+  shouldRelaunch: vi.fn(() => true),
+}));
+
+vi.mock("../CrashLoopGuardService.js", () => ({
+  getCrashLoopGuard: () => crashLoopGuardMock,
+}));
+
 import {
   isGpuDisabledByFlag,
   writeGpuDisabledFlag,
@@ -52,6 +60,7 @@ describe("GpuCrashMonitorService", () => {
     Object.keys(appListeners).forEach((k) => delete appListeners[k]);
     tmpDir = fs.mkdtempSync(path.join(os.tmpdir(), "gpu-crash-test-"));
     appMock.getPath.mockReturnValue(tmpDir);
+    crashLoopGuardMock.shouldRelaunch.mockReturnValue(true);
     vi.spyOn(console, "log").mockImplementation(() => {});
     vi.spyOn(console, "warn").mockImplementation(() => {});
     vi.spyOn(console, "error").mockImplementation(() => {});
@@ -348,6 +357,71 @@ describe("GpuCrashMonitorService", () => {
       mod.initializeGpuCrashMonitor();
       const listenerCount = (appListeners["child-process-gone"] ?? []).length;
       expect(listenerCount).toBe(1);
+    });
+
+    describe("crash-loop guard integration", () => {
+      it("ANGLE path: does not relaunch when guard hard-stops, but exits cleanly", async () => {
+        crashLoopGuardMock.shouldRelaunch.mockReturnValue(false);
+        await loadAndInit();
+        emitGpuCrash();
+        await vi.waitFor(() => {
+          expect(appMock.exit).toHaveBeenCalledWith(0);
+        });
+        expect(appMock.relaunch).not.toHaveBeenCalled();
+        // The fallback flag is still written — the next session starts cold
+        // with ANGLE active so a restored launch (after the guard resets)
+        // doesn't immediately repeat the original Vulkan crash.
+        expect(isGpuAngleFallbackByFlag(tmpDir)).toBe(true);
+        expect(console.error).toHaveBeenCalledWith(
+          expect.stringContaining("Crash loop hard stop reached")
+        );
+      });
+
+      it("ANGLE path: relaunches when guard allows", async () => {
+        crashLoopGuardMock.shouldRelaunch.mockReturnValue(true);
+        await loadAndInit();
+        emitGpuCrash();
+        await vi.waitFor(() => {
+          expect(appMock.exit).toHaveBeenCalledWith(0);
+        });
+        expect(appMock.relaunch).toHaveBeenCalledTimes(1);
+      });
+
+      it("Nuclear path: does not relaunch when guard hard-stops, but exits cleanly", async () => {
+        writeGpuAngleFallbackFlag(tmpDir);
+        crashLoopGuardMock.shouldRelaunch.mockReturnValue(false);
+        await loadAndInit();
+        emitGpuCrash();
+        emitGpuCrash();
+        emitGpuCrash();
+        await vi.waitFor(() => {
+          expect(appMock.exit).toHaveBeenCalledWith(0);
+        });
+        expect(appMock.relaunch).not.toHaveBeenCalled();
+        // Disable flag and store flip still happen — once the guard window
+        // clears the user gets booted into software-rendering mode rather
+        // than back into the crashing GPU stack.
+        expect(isGpuDisabledByFlag(tmpDir)).toBe(true);
+        expect(storeMock.set).toHaveBeenCalledWith("gpu", {
+          hardwareAccelerationDisabled: true,
+        });
+        expect(console.error).toHaveBeenCalledWith(
+          expect.stringContaining("Crash loop hard stop reached")
+        );
+      });
+
+      it("Nuclear path: relaunches when guard allows", async () => {
+        writeGpuAngleFallbackFlag(tmpDir);
+        crashLoopGuardMock.shouldRelaunch.mockReturnValue(true);
+        await loadAndInit();
+        emitGpuCrash();
+        emitGpuCrash();
+        emitGpuCrash();
+        await vi.waitFor(() => {
+          expect(appMock.exit).toHaveBeenCalledWith(0);
+        });
+        expect(appMock.relaunch).toHaveBeenCalledTimes(1);
+      });
     });
   });
 });


### PR DESCRIPTION
## Summary

- `GpuCrashMonitorService` now checks `getCrashLoopGuard().shouldRelaunch()` before calling `app.relaunch()` on both the ANGLE-fallback and nuclear GPU-disabled paths, matching the pattern already in `globalErrorHandlers.ts`. When the guard hard-stops, it logs, closes telemetry, and calls `app.exit(0)` cleanly. Flag writes (`writeGpuAngleFallbackFlag`, `writeGpuDisabledFlag`) happen before the guard check so a manual restart after the hard-stop window boots into the right mode.
- `extractPanelSummaries` in `CrashRecoveryService` now prefers `this.cachedBackupSnapshot` when non-null rather than re-reading from disk, closing the race window that `cachedBackupSnapshot` was introduced to prevent in the first place.
- `restoreBackup` shallow-copies `appState` before filtering `panelIds` so a failed restore attempt doesn't permanently narrow the cached snapshot for retries.

Resolves #7113

## Changes

- `electron/services/GpuCrashMonitorService.ts` — guard both relaunch paths on crash loop guard; clean exit when suppressed
- `electron/services/CrashRecoveryService.ts` — prefer cached snapshot in `extractPanelSummaries`; copy before filter in `restoreBackup`
- `electron/services/__tests__/GpuCrashMonitorService.test.ts` — 4 new tests covering ANGLE and nuclear paths against guard suppressed and guard allowed
- `electron/services/__tests__/CrashRecoveryService.adversarial.test.ts` — 2 new adversarial tests: cache hit on `extractPanelSummaries` and retry resilience on filtered restore

## Testing

All 30 `GpuCrashMonitorService` tests and 56 `CrashRecoveryService` tests pass. Typecheck, lint, format, and build all clean.