### PR TITLE
fix(recipes): polish recipe IPC validation parity (#7131)

### DIFF
--- a/electron/ipc/handlers/__tests__/globalRecipes.adversarial.test.ts
+++ b/electron/ipc/handlers/__tests__/globalRecipes.adversarial.test.ts
@@ -103,6 +103,33 @@ describe("globalRecipes IPC adversarial", () => {
     ).rejects.toThrow(/worktreeId/);
   });
 
+  it("addRecipe rejects non-finite lastUsedAt", async () => {
+    await expect(
+      getHandler(CHANNELS.GLOBAL_ADD_RECIPE)(fakeEvent(), {
+        recipe: { ...validRecipe(), lastUsedAt: Number.POSITIVE_INFINITY },
+      })
+    ).rejects.toThrow(/lastUsedAt/);
+    expect(projectStoreMock.addGlobalRecipe).not.toHaveBeenCalled();
+  });
+
+  it("addRecipe rejects usageHistory exceeding the 20-entry cap", async () => {
+    await expect(
+      getHandler(CHANNELS.GLOBAL_ADD_RECIPE)(fakeEvent(), {
+        recipe: { ...validRecipe(), usageHistory: Array.from({ length: 21 }, (_v, i) => i + 1) },
+      })
+    ).rejects.toThrow(/usageHistory/);
+    expect(projectStoreMock.addGlobalRecipe).not.toHaveBeenCalled();
+  });
+
+  it("addRecipe rejects non-finite usageHistory entry", async () => {
+    await expect(
+      getHandler(CHANNELS.GLOBAL_ADD_RECIPE)(fakeEvent(), {
+        recipe: { ...validRecipe(), usageHistory: [1, Number.NaN] },
+      })
+    ).rejects.toThrow(/usageHistory/);
+    expect(projectStoreMock.addGlobalRecipe).not.toHaveBeenCalled();
+  });
+
   it("addRecipe accepts a well-formed recipe and forwards it to the project store", async () => {
     const recipe = validRecipe();
     await getHandler(CHANNELS.GLOBAL_ADD_RECIPE)(fakeEvent(), { recipe });
@@ -158,12 +185,43 @@ describe("globalRecipes IPC adversarial", () => {
     expect(projectStoreMock.updateGlobalRecipe).not.toHaveBeenCalled();
   });
 
+  it("updateRecipe rejects non-finite lastUsedAt patch", async () => {
+    await expect(
+      getHandler(CHANNELS.GLOBAL_UPDATE_RECIPE)(fakeEvent(), {
+        recipeId: "r1",
+        updates: { lastUsedAt: Number.POSITIVE_INFINITY } as unknown as Record<string, unknown>,
+      })
+    ).rejects.toThrow(/lastUsedAt/);
+    expect(projectStoreMock.updateGlobalRecipe).not.toHaveBeenCalled();
+  });
+
+  it("updateRecipe rejects usageHistory patch exceeding the 20-entry cap", async () => {
+    await expect(
+      getHandler(CHANNELS.GLOBAL_UPDATE_RECIPE)(fakeEvent(), {
+        recipeId: "r1",
+        updates: {
+          usageHistory: Array.from({ length: 21 }, (_v, i) => i + 1),
+        } as unknown as Record<string, unknown>,
+      })
+    ).rejects.toThrow(/usageHistory/);
+    expect(projectStoreMock.updateGlobalRecipe).not.toHaveBeenCalled();
+  });
+
   it("updateRecipe forwards a clean rename patch", async () => {
     await getHandler(CHANNELS.GLOBAL_UPDATE_RECIPE)(fakeEvent(), {
       recipeId: "r1",
       updates: { name: "New Name" },
     });
     expect(projectStoreMock.updateGlobalRecipe).toHaveBeenCalledWith("r1", { name: "New Name" });
+  });
+
+  it("updateRecipe accepts usageHistory at the 20-entry cap", async () => {
+    const usageHistory = Array.from({ length: 20 }, (_v, i) => i + 1);
+    await getHandler(CHANNELS.GLOBAL_UPDATE_RECIPE)(fakeEvent(), {
+      recipeId: "r1",
+      updates: { usageHistory },
+    });
+    expect(projectStoreMock.updateGlobalRecipe).toHaveBeenCalledWith("r1", { usageHistory });
   });
 
   it("deleteRecipe rejects empty recipeId", async () => {

--- a/electron/ipc/handlers/__tests__/globalRecipes.adversarial.test.ts
+++ b/electron/ipc/handlers/__tests__/globalRecipes.adversarial.test.ts
@@ -138,6 +138,16 @@ describe("globalRecipes IPC adversarial", () => {
     ).rejects.toThrow(/immutable|createdAt/i);
   });
 
+  it("updateRecipe rejects patches with worktreeId", async () => {
+    await expect(
+      getHandler(CHANNELS.GLOBAL_UPDATE_RECIPE)(fakeEvent(), {
+        recipeId: "r1",
+        updates: { worktreeId: "wt-1" } as unknown as Record<string, unknown>,
+      })
+    ).rejects.toThrow(/immutable|worktreeId/i);
+    expect(projectStoreMock.updateGlobalRecipe).not.toHaveBeenCalled();
+  });
+
   it("updateRecipe rejects non-array terminals", async () => {
     await expect(
       getHandler(CHANNELS.GLOBAL_UPDATE_RECIPE)(fakeEvent(), {

--- a/electron/ipc/handlers/__tests__/projectRecipes.adversarial.test.ts
+++ b/electron/ipc/handlers/__tests__/projectRecipes.adversarial.test.ts
@@ -109,6 +109,36 @@ describe("projectRecipes IPC adversarial", () => {
     expect(projectStoreMock.addRecipe).not.toHaveBeenCalled();
   });
 
+  it("addRecipe rejects non-finite lastUsedAt", async () => {
+    await expect(
+      getHandler(CHANNELS.PROJECT_ADD_RECIPE)(fakeEvent(), {
+        projectId: "p1",
+        recipe: { ...validRecipe(), lastUsedAt: Number.NaN },
+      })
+    ).rejects.toThrow(/lastUsedAt/);
+    expect(projectStoreMock.addRecipe).not.toHaveBeenCalled();
+  });
+
+  it("addRecipe rejects usageHistory exceeding the 20-entry cap", async () => {
+    await expect(
+      getHandler(CHANNELS.PROJECT_ADD_RECIPE)(fakeEvent(), {
+        projectId: "p1",
+        recipe: { ...validRecipe(), usageHistory: Array.from({ length: 21 }, (_v, i) => i + 1) },
+      })
+    ).rejects.toThrow(/usageHistory/);
+    expect(projectStoreMock.addRecipe).not.toHaveBeenCalled();
+  });
+
+  it("addRecipe rejects non-finite usageHistory entry", async () => {
+    await expect(
+      getHandler(CHANNELS.PROJECT_ADD_RECIPE)(fakeEvent(), {
+        projectId: "p1",
+        recipe: { ...validRecipe(), usageHistory: [1, Number.POSITIVE_INFINITY] },
+      })
+    ).rejects.toThrow(/usageHistory/);
+    expect(projectStoreMock.addRecipe).not.toHaveBeenCalled();
+  });
+
   it("addRecipe accepts a well-formed recipe and forwards it to the project store", async () => {
     const recipe = validRecipe();
     await getHandler(CHANNELS.PROJECT_ADD_RECIPE)(fakeEvent(), { projectId: "p1", recipe });
@@ -170,6 +200,30 @@ describe("projectRecipes IPC adversarial", () => {
     expect(projectStoreMock.updateRecipe).not.toHaveBeenCalled();
   });
 
+  it("updateRecipe rejects non-finite lastUsedAt patch", async () => {
+    await expect(
+      getHandler(CHANNELS.PROJECT_UPDATE_RECIPE)(fakeEvent(), {
+        projectId: "p1",
+        recipeId: "r1",
+        updates: { lastUsedAt: Number.NaN } as unknown as Record<string, unknown>,
+      })
+    ).rejects.toThrow(/lastUsedAt/);
+    expect(projectStoreMock.updateRecipe).not.toHaveBeenCalled();
+  });
+
+  it("updateRecipe rejects usageHistory patch exceeding the 20-entry cap", async () => {
+    await expect(
+      getHandler(CHANNELS.PROJECT_UPDATE_RECIPE)(fakeEvent(), {
+        projectId: "p1",
+        recipeId: "r1",
+        updates: {
+          usageHistory: Array.from({ length: 21 }, (_v, i) => i + 1),
+        } as unknown as Record<string, unknown>,
+      })
+    ).rejects.toThrow(/usageHistory/);
+    expect(projectStoreMock.updateRecipe).not.toHaveBeenCalled();
+  });
+
   it("updateRecipe forwards a clean rename patch", async () => {
     await getHandler(CHANNELS.PROJECT_UPDATE_RECIPE)(fakeEvent(), {
       projectId: "p1",
@@ -177,6 +231,16 @@ describe("projectRecipes IPC adversarial", () => {
       updates: { name: "New Name" },
     });
     expect(projectStoreMock.updateRecipe).toHaveBeenCalledWith("p1", "r1", { name: "New Name" });
+  });
+
+  it("updateRecipe accepts usageHistory at the 20-entry cap", async () => {
+    const usageHistory = Array.from({ length: 20 }, (_v, i) => i + 1);
+    await getHandler(CHANNELS.PROJECT_UPDATE_RECIPE)(fakeEvent(), {
+      projectId: "p1",
+      recipeId: "r1",
+      updates: { usageHistory },
+    });
+    expect(projectStoreMock.updateRecipe).toHaveBeenCalledWith("p1", "r1", { usageHistory });
   });
 
   it("deleteRecipe rejects empty recipeId", async () => {

--- a/electron/ipc/handlers/__tests__/projectRecipes.adversarial.test.ts
+++ b/electron/ipc/handlers/__tests__/projectRecipes.adversarial.test.ts
@@ -1,0 +1,201 @@
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+
+const ipcHandlers = vi.hoisted(() => new Map<string, unknown>());
+const ipcMainMock = vi.hoisted(() => ({
+  handle: vi.fn((channel: string, fn: unknown) => ipcHandlers.set(channel, fn)),
+  removeHandler: vi.fn((channel: string) => ipcHandlers.delete(channel)),
+}));
+
+const projectStoreMock = vi.hoisted(() => ({
+  getProjectById: vi.fn(() => undefined),
+  getRecipes: vi.fn(() => []),
+  saveRecipes: vi.fn(),
+  addRecipe: vi.fn(),
+  updateRecipe: vi.fn(),
+  deleteRecipe: vi.fn(),
+  readInRepoRecipes: vi.fn(() => []),
+  writeInRepoRecipe: vi.fn(),
+  deleteInRepoRecipe: vi.fn(),
+  reconcileProjectRecipes: vi.fn(),
+}));
+
+vi.mock("electron", () => ({ ipcMain: ipcMainMock, dialog: {} }));
+vi.mock("../../../services/ProjectStore.js", () => ({ projectStore: projectStoreMock }));
+
+import { registerProjectRecipesHandlers } from "../projectRecipes.js";
+import { CHANNELS } from "../../channels.js";
+import type { HandlerDependencies } from "../../types.js";
+
+type Handler = (event: Electron.IpcMainInvokeEvent, ...args: unknown[]) => Promise<unknown>;
+
+function getHandler(channel: string): Handler {
+  const fn = ipcHandlers.get(channel);
+  if (!fn) throw new Error(`handler not registered: ${channel}`);
+  return fn as Handler;
+}
+
+function fakeEvent(): Electron.IpcMainInvokeEvent {
+  return { sender: {} as Electron.WebContents } as Electron.IpcMainInvokeEvent;
+}
+
+const validRecipe = () => ({
+  id: "r1",
+  name: "My Recipe",
+  projectId: "p1",
+  terminals: [],
+  createdAt: 1000,
+});
+
+describe("projectRecipes IPC adversarial", () => {
+  let cleanup: () => void;
+
+  beforeEach(() => {
+    ipcHandlers.clear();
+    vi.clearAllMocks();
+    cleanup = registerProjectRecipesHandlers({} as HandlerDependencies);
+  });
+
+  afterEach(() => {
+    cleanup();
+  });
+
+  it("addRecipe rejects non-finite createdAt (NaN)", async () => {
+    await expect(
+      getHandler(CHANNELS.PROJECT_ADD_RECIPE)(fakeEvent(), {
+        projectId: "p1",
+        recipe: { ...validRecipe(), createdAt: Number.NaN },
+      })
+    ).rejects.toThrow(/createdAt/);
+    expect(projectStoreMock.addRecipe).not.toHaveBeenCalled();
+  });
+
+  it("addRecipe rejects non-finite createdAt (Infinity)", async () => {
+    await expect(
+      getHandler(CHANNELS.PROJECT_ADD_RECIPE)(fakeEvent(), {
+        projectId: "p1",
+        recipe: { ...validRecipe(), createdAt: Number.POSITIVE_INFINITY },
+      })
+    ).rejects.toThrow(/createdAt/);
+    expect(projectStoreMock.addRecipe).not.toHaveBeenCalled();
+  });
+
+  it("addRecipe rejects whitespace-only name", async () => {
+    await expect(
+      getHandler(CHANNELS.PROJECT_ADD_RECIPE)(fakeEvent(), {
+        projectId: "p1",
+        recipe: { ...validRecipe(), name: "   " },
+      })
+    ).rejects.toThrow(/required fields|name/i);
+    expect(projectStoreMock.addRecipe).not.toHaveBeenCalled();
+  });
+
+  it("addRecipe rejects whitespace-only id", async () => {
+    await expect(
+      getHandler(CHANNELS.PROJECT_ADD_RECIPE)(fakeEvent(), {
+        projectId: "p1",
+        recipe: { ...validRecipe(), id: "  \t " },
+      })
+    ).rejects.toThrow(/required fields|id/i);
+    expect(projectStoreMock.addRecipe).not.toHaveBeenCalled();
+  });
+
+  it("addRecipe rejects projectId mismatch", async () => {
+    await expect(
+      getHandler(CHANNELS.PROJECT_ADD_RECIPE)(fakeEvent(), {
+        projectId: "p1",
+        recipe: { ...validRecipe(), projectId: "p2" },
+      })
+    ).rejects.toThrow(/projectId/);
+    expect(projectStoreMock.addRecipe).not.toHaveBeenCalled();
+  });
+
+  it("addRecipe accepts a well-formed recipe and forwards it to the project store", async () => {
+    const recipe = validRecipe();
+    await getHandler(CHANNELS.PROJECT_ADD_RECIPE)(fakeEvent(), { projectId: "p1", recipe });
+    expect(projectStoreMock.addRecipe).toHaveBeenCalledWith("p1", recipe);
+  });
+
+  it("updateRecipe rejects patches that attempt to rewrite immutable id", async () => {
+    await expect(
+      getHandler(CHANNELS.PROJECT_UPDATE_RECIPE)(fakeEvent(), {
+        projectId: "p1",
+        recipeId: "r1",
+        updates: { id: "new-id" } as unknown as Record<string, unknown>,
+      })
+    ).rejects.toThrow(/immutable|id/i);
+    expect(projectStoreMock.updateRecipe).not.toHaveBeenCalled();
+  });
+
+  it("updateRecipe rejects patches with projectId", async () => {
+    await expect(
+      getHandler(CHANNELS.PROJECT_UPDATE_RECIPE)(fakeEvent(), {
+        projectId: "p1",
+        recipeId: "r1",
+        updates: { projectId: "p2" } as unknown as Record<string, unknown>,
+      })
+    ).rejects.toThrow(/immutable|projectId/i);
+    expect(projectStoreMock.updateRecipe).not.toHaveBeenCalled();
+  });
+
+  it("updateRecipe rejects patches with createdAt", async () => {
+    await expect(
+      getHandler(CHANNELS.PROJECT_UPDATE_RECIPE)(fakeEvent(), {
+        projectId: "p1",
+        recipeId: "r1",
+        updates: { createdAt: 999 } as unknown as Record<string, unknown>,
+      })
+    ).rejects.toThrow(/immutable|createdAt/i);
+    expect(projectStoreMock.updateRecipe).not.toHaveBeenCalled();
+  });
+
+  it("updateRecipe rejects non-array terminals", async () => {
+    await expect(
+      getHandler(CHANNELS.PROJECT_UPDATE_RECIPE)(fakeEvent(), {
+        projectId: "p1",
+        recipeId: "r1",
+        updates: { terminals: "oops" } as unknown as Record<string, unknown>,
+      })
+    ).rejects.toThrow(/terminals/i);
+    expect(projectStoreMock.updateRecipe).not.toHaveBeenCalled();
+  });
+
+  it("updateRecipe rejects array updates payload", async () => {
+    await expect(
+      getHandler(CHANNELS.PROJECT_UPDATE_RECIPE)(fakeEvent(), {
+        projectId: "p1",
+        recipeId: "r1",
+        updates: [] as unknown as Record<string, unknown>,
+      })
+    ).rejects.toThrow(/Invalid updates/);
+    expect(projectStoreMock.updateRecipe).not.toHaveBeenCalled();
+  });
+
+  it("updateRecipe forwards a clean rename patch", async () => {
+    await getHandler(CHANNELS.PROJECT_UPDATE_RECIPE)(fakeEvent(), {
+      projectId: "p1",
+      recipeId: "r1",
+      updates: { name: "New Name" },
+    });
+    expect(projectStoreMock.updateRecipe).toHaveBeenCalledWith("p1", "r1", { name: "New Name" });
+  });
+
+  it("deleteRecipe rejects empty recipeId", async () => {
+    await expect(
+      getHandler(CHANNELS.PROJECT_DELETE_RECIPE)(fakeEvent(), { projectId: "p1", recipeId: "" })
+    ).rejects.toThrow(/Invalid recipe ID/);
+    expect(projectStoreMock.deleteRecipe).not.toHaveBeenCalled();
+  });
+
+  it("deleteRecipe rejects empty projectId", async () => {
+    await expect(
+      getHandler(CHANNELS.PROJECT_DELETE_RECIPE)(fakeEvent(), { projectId: "", recipeId: "r1" })
+    ).rejects.toThrow(/Invalid project ID/);
+    expect(projectStoreMock.deleteRecipe).not.toHaveBeenCalled();
+  });
+
+  it("cleanup removes all eleven handlers", () => {
+    expect(ipcHandlers.size).toBe(11);
+    cleanup();
+    expect(ipcHandlers.size).toBe(0);
+  });
+});

--- a/electron/ipc/handlers/globalRecipes.ts
+++ b/electron/ipc/handlers/globalRecipes.ts
@@ -56,7 +56,7 @@ export function registerGlobalRecipesHandlers(_deps: HandlerDependencies): () =>
     if (!updates || typeof updates !== "object" || Array.isArray(updates)) {
       throw new Error("Invalid updates");
     }
-    const immutableKeys = ["id", "projectId", "createdAt"] as const;
+    const immutableKeys = ["id", "projectId", "createdAt", "worktreeId"] as const;
     for (const key of immutableKeys) {
       if (key in updates) {
         throw new Error(`Cannot update immutable field: ${key}`);

--- a/electron/ipc/handlers/globalRecipes.ts
+++ b/electron/ipc/handlers/globalRecipes.ts
@@ -3,6 +3,7 @@ import { projectStore } from "../../services/ProjectStore.js";
 import type { HandlerDependencies } from "../types.js";
 import type { TerminalRecipe } from "../../types/index.js";
 import { typedHandle } from "../utils.js";
+import { assertRecipeUsageFields } from "./recipeValidation.js";
 
 export function registerGlobalRecipesHandlers(_deps: HandlerDependencies): () => void {
   const handlers: Array<() => void> = [];
@@ -38,13 +39,14 @@ export function registerGlobalRecipesHandlers(_deps: HandlerDependencies): () =>
     if (!Number.isFinite(recipe.createdAt)) {
       throw new Error("Recipe createdAt must be a finite number");
     }
+    assertRecipeUsageFields(recipe);
     return projectStore.addGlobalRecipe(recipe);
   };
   handlers.push(typedHandle(CHANNELS.GLOBAL_ADD_RECIPE, handleAddRecipe));
 
   const handleUpdateRecipe = async (payload: {
     recipeId: string;
-    updates: Partial<Omit<TerminalRecipe, "id" | "projectId" | "createdAt">>;
+    updates: Partial<Omit<TerminalRecipe, "id" | "projectId" | "createdAt" | "worktreeId">>;
   }): Promise<void> => {
     if (!payload || typeof payload !== "object") {
       throw new Error("Invalid payload");
@@ -66,6 +68,7 @@ export function registerGlobalRecipesHandlers(_deps: HandlerDependencies): () =>
     if ("terminals" in patch && !Array.isArray(patch.terminals)) {
       throw new Error("Invalid updates: terminals must be an array");
     }
+    assertRecipeUsageFields(patch);
     return projectStore.updateGlobalRecipe(recipeId, updates);
   };
   handlers.push(typedHandle(CHANNELS.GLOBAL_UPDATE_RECIPE, handleUpdateRecipe));

--- a/electron/ipc/handlers/projectRecipes.ts
+++ b/electron/ipc/handlers/projectRecipes.ts
@@ -62,11 +62,17 @@ export function registerProjectRecipesHandlers(_deps: HandlerDependencies): () =
     if (recipe.projectId !== projectId) {
       throw new Error("Recipe projectId does not match target project");
     }
-    if (!recipe.id || !recipe.name || !Array.isArray(recipe.terminals)) {
+    if (
+      typeof recipe.id !== "string" ||
+      !recipe.id.trim() ||
+      typeof recipe.name !== "string" ||
+      !recipe.name.trim() ||
+      !Array.isArray(recipe.terminals)
+    ) {
       throw new Error("Recipe missing required fields (id, name, terminals)");
     }
-    if (typeof recipe.createdAt !== "number") {
-      throw new Error("Recipe createdAt must be a number");
+    if (!Number.isFinite(recipe.createdAt)) {
+      throw new Error("Recipe createdAt must be a finite number");
     }
     return projectStore.addRecipe(projectId, recipe);
   };
@@ -87,8 +93,18 @@ export function registerProjectRecipesHandlers(_deps: HandlerDependencies): () =
     if (typeof recipeId !== "string" || !recipeId) {
       throw new Error("Invalid recipe ID");
     }
-    if (!updates || typeof updates !== "object") {
+    if (!updates || typeof updates !== "object" || Array.isArray(updates)) {
       throw new Error("Invalid updates");
+    }
+    const immutableKeys = ["id", "projectId", "createdAt"] as const;
+    for (const key of immutableKeys) {
+      if (key in updates) {
+        throw new Error(`Cannot update immutable field: ${key}`);
+      }
+    }
+    const patch = updates as Record<string, unknown>;
+    if ("terminals" in patch && !Array.isArray(patch.terminals)) {
+      throw new Error("Invalid updates: terminals must be an array");
     }
     return projectStore.updateRecipe(projectId, recipeId, updates);
   };

--- a/electron/ipc/handlers/projectRecipes.ts
+++ b/electron/ipc/handlers/projectRecipes.ts
@@ -7,6 +7,7 @@ import { stableInRepoId } from "../../../shared/utils/recipeFilename.js";
 import type { HandlerDependencies } from "../types.js";
 import type { TerminalRecipe } from "../../types/index.js";
 import { typedHandle, typedHandleWithContext } from "../utils.js";
+import { assertRecipeUsageFields } from "./recipeValidation.js";
 
 export function registerProjectRecipesHandlers(_deps: HandlerDependencies): () => void {
   const handlers: Array<() => void> = [];
@@ -74,6 +75,7 @@ export function registerProjectRecipesHandlers(_deps: HandlerDependencies): () =
     if (!Number.isFinite(recipe.createdAt)) {
       throw new Error("Recipe createdAt must be a finite number");
     }
+    assertRecipeUsageFields(recipe);
     return projectStore.addRecipe(projectId, recipe);
   };
   handlers.push(typedHandle(CHANNELS.PROJECT_ADD_RECIPE, handleProjectAddRecipe));
@@ -106,6 +108,7 @@ export function registerProjectRecipesHandlers(_deps: HandlerDependencies): () =
     if ("terminals" in patch && !Array.isArray(patch.terminals)) {
       throw new Error("Invalid updates: terminals must be an array");
     }
+    assertRecipeUsageFields(patch);
     return projectStore.updateRecipe(projectId, recipeId, updates);
   };
   handlers.push(typedHandle(CHANNELS.PROJECT_UPDATE_RECIPE, handleProjectUpdateRecipe));

--- a/electron/ipc/handlers/recipeValidation.ts
+++ b/electron/ipc/handlers/recipeValidation.ts
@@ -1,0 +1,23 @@
+const USAGE_HISTORY_LIMIT = 20;
+
+export function assertRecipeUsageFields(value: {
+  lastUsedAt?: unknown;
+  usageHistory?: unknown;
+}): void {
+  if (value.lastUsedAt !== undefined && !Number.isFinite(value.lastUsedAt)) {
+    throw new Error("Recipe lastUsedAt must be a finite number");
+  }
+  if (value.usageHistory !== undefined) {
+    if (!Array.isArray(value.usageHistory)) {
+      throw new Error("Recipe usageHistory must be an array");
+    }
+    if (value.usageHistory.length > USAGE_HISTORY_LIMIT) {
+      throw new Error(`Recipe usageHistory must not exceed ${USAGE_HISTORY_LIMIT} entries`);
+    }
+    for (const entry of value.usageHistory) {
+      if (!Number.isFinite(entry)) {
+        throw new Error("Recipe usageHistory entries must be finite numbers");
+      }
+    }
+  }
+}

--- a/electron/schemas/__tests__/terminalEntryValidation.test.ts
+++ b/electron/schemas/__tests__/terminalEntryValidation.test.ts
@@ -827,6 +827,70 @@ describe("Recipe Validation Schemas", () => {
         expect(result.data).toHaveProperty("unknownField", "kept");
       }
     });
+
+    it("rejects recipe with NaN createdAt", () => {
+      const result = TerminalRecipeSchema.safeParse({
+        id: "r1",
+        name: "Recipe",
+        terminals: [],
+        createdAt: Number.NaN,
+      });
+      expect(result.success).toBe(false);
+    });
+
+    it("rejects recipe with Infinity createdAt", () => {
+      const result = TerminalRecipeSchema.safeParse({
+        id: "r1",
+        name: "Recipe",
+        terminals: [],
+        createdAt: Number.POSITIVE_INFINITY,
+      });
+      expect(result.success).toBe(false);
+    });
+
+    it("rejects recipe with NaN lastUsedAt", () => {
+      const result = TerminalRecipeSchema.safeParse({
+        id: "r1",
+        name: "Recipe",
+        terminals: [],
+        createdAt: 0,
+        lastUsedAt: Number.NaN,
+      });
+      expect(result.success).toBe(false);
+    });
+
+    it("rejects recipe with non-finite usageHistory entry", () => {
+      const result = TerminalRecipeSchema.safeParse({
+        id: "r1",
+        name: "Recipe",
+        terminals: [],
+        createdAt: 0,
+        usageHistory: [1700000000000, Number.POSITIVE_INFINITY],
+      });
+      expect(result.success).toBe(false);
+    });
+
+    it("accepts usageHistory at the 20-entry cap", () => {
+      const result = TerminalRecipeSchema.safeParse({
+        id: "r1",
+        name: "Recipe",
+        terminals: [],
+        createdAt: 0,
+        usageHistory: Array.from({ length: 20 }, (_v, i) => i + 1),
+      });
+      expect(result.success).toBe(true);
+    });
+
+    it("rejects usageHistory exceeding the 20-entry cap", () => {
+      const result = TerminalRecipeSchema.safeParse({
+        id: "r1",
+        name: "Recipe",
+        terminals: [],
+        createdAt: 0,
+        usageHistory: Array.from({ length: 21 }, (_v, i) => i + 1),
+      });
+      expect(result.success).toBe(false);
+    });
   });
 
   describe("filterValidTerminalEntries with TerminalRecipeSchema", () => {

--- a/electron/schemas/ipc.ts
+++ b/electron/schemas/ipc.ts
@@ -208,10 +208,10 @@ export const TerminalRecipeSchema = z
     projectId: z.string().optional(),
     worktreeId: z.string().optional(),
     terminals: z.array(RecipeTerminalSchema),
-    createdAt: z.number(),
+    createdAt: z.number().finite(),
     showInEmptyState: z.boolean().optional(),
-    lastUsedAt: z.number().optional(),
-    usageHistory: z.array(z.number()).optional(),
+    lastUsedAt: z.number().finite().optional(),
+    usageHistory: z.array(z.number().finite()).max(20).optional(),
     autoAssign: z.enum(["always", "never", "prompt"]).optional(),
   })
   .passthrough();

--- a/electron/services/GlobalFileStore.ts
+++ b/electron/services/GlobalFileStore.ts
@@ -87,6 +87,7 @@ export class GlobalFileStore {
       id: _id,
       projectId: _pid,
       createdAt: _ca,
+      worktreeId: _wid,
       ...safeUpdates
     } = updates as Record<string, unknown>;
     recipes[index] = { ...recipes[index], ...safeUpdates };

--- a/shared/types/ipc/api.ts
+++ b/shared/types/ipc/api.ts
@@ -614,7 +614,7 @@ export interface ElectronAPI {
     addRecipe(recipe: TerminalRecipe): Promise<void>;
     updateRecipe(
       recipeId: string,
-      updates: Partial<Omit<TerminalRecipe, "id" | "projectId" | "createdAt">>
+      updates: Partial<Omit<TerminalRecipe, "id" | "projectId" | "createdAt" | "worktreeId">>
     ): Promise<void>;
     deleteRecipe(recipeId: string): Promise<void>;
   };


### PR DESCRIPTION
## Summary

- Closes a silent-data-loss path: `lastUsedAt` and `usageHistory` are now validated at the IPC boundary for both project and global recipe handlers, not just passed through unchecked.
- Tightens `TerminalRecipeSchema` with `.finite()` per element and `.max(20)` on `usageHistory`, matching the JSDoc contract and closing the unbounded-growth vector.
- Adds immutable-key guards (`id`, `projectId`, `createdAt`) to the project update handler to match the global side; adds `worktreeId` to the global update handler's immutable keys to preserve the `projectId === undefined && worktreeId === undefined` invariant.

Resolves #7131

## Changes

- `electron/ipc/handlers/recipeValidation.ts` — new shared `assertRecipeUsageFields` helper applied at add and update in both `projectRecipes.ts` and `globalRecipes.ts`
- `electron/ipc/handlers/projectRecipes.ts` — finite `createdAt` check on add; immutable-key guard on update; usage fields validated at both callsites
- `electron/ipc/handlers/globalRecipes.ts` — `worktreeId` added to `immutableKeys`; usage fields validated at both callsites; `GlobalFileStore` strip updated to match
- `electron/schemas/ipc.ts` — `TerminalRecipeSchema` tightened: `.finite()` on numeric fields, `.max(20)` on `usageHistory`
- `shared/types/ipc/api.ts` — `Omit` widened to include `worktreeId`
- New adversarial boundary tests: `projectRecipes.adversarial.test.ts`, `globalRecipes.adversarial.test.ts`, `terminalEntryValidation.test.ts`

## Testing

118 unit tests pass across the three target test files. Typecheck, lint (9 fewer warnings), format, and build all clean.