### PR TITLE
fix(diagnostics): tighten bundle PII redaction and on-disk perms (#7105)

### DIFF
--- a/electron/ipc/handlers/__tests__/diagnostics.handlers.test.ts
+++ b/electron/ipc/handlers/__tests__/diagnostics.handlers.test.ts
@@ -95,9 +95,12 @@ vi.mock("electron", () => ({
   },
 }));
 
+const chmodMock = vi.hoisted(() => vi.fn(() => Promise.resolve()));
+
 vi.mock("node:fs", () => ({
   promises: {
     readFile: vi.fn(() => Promise.resolve("")),
+    chmod: chmodMock,
   },
   createWriteStream: createWriteStreamMock,
   existsSync: vi.fn(() => false),
@@ -366,6 +369,61 @@ describe("registerDiagnosticsHandlers", () => {
       expect(zipPath).toBe("/tmp/diagnostics.zip");
       expect(options).toEqual({ mode: 0o600 });
       expect(shellMock.showItemInFolder).toHaveBeenCalledWith("/tmp/diagnostics.zip");
+    });
+
+    it("ZIP_BUNDLE_CHMODS_AFTER_CLOSE_FOR_OVERWRITE_CASE", async () => {
+      // createWriteStream's `mode` is only applied to newly-created files;
+      // overwrite of an existing 0o644 file would otherwise preserve that mode.
+      // The handler must explicitly chmod after close on POSIX platforms.
+      const originalPlatform = process.platform;
+      Object.defineProperty(process, "platform", { value: "darwin", configurable: true });
+      try {
+        dialogMock.showSaveDialog.mockResolvedValueOnce({
+          filePath: "/tmp/diagnostics-overwrite.zip",
+          canceled: false,
+        });
+        registerDiagnosticsHandlers(deps);
+        const handler = getHandlerFn("system:save-diagnostics-bundle");
+
+        await handler(
+          {},
+          {
+            payload: { metadata: {} },
+            enabledSections: { metadata: true, logs: false },
+            replacements: [],
+          }
+        );
+
+        expect(chmodMock).toHaveBeenCalledWith("/tmp/diagnostics-overwrite.zip", 0o600);
+      } finally {
+        Object.defineProperty(process, "platform", { value: originalPlatform, configurable: true });
+      }
+    });
+
+    it("ZIP_BUNDLE_SKIPS_CHMOD_ON_WINDOWS", async () => {
+      const originalPlatform = process.platform;
+      Object.defineProperty(process, "platform", { value: "win32", configurable: true });
+      try {
+        dialogMock.showSaveDialog.mockResolvedValueOnce({
+          filePath: "C:/Users/Public/diagnostics.zip",
+          canceled: false,
+        });
+        registerDiagnosticsHandlers(deps);
+        const handler = getHandlerFn("system:save-diagnostics-bundle");
+
+        await handler(
+          {},
+          {
+            payload: { metadata: {} },
+            enabledSections: { metadata: true, logs: false },
+            replacements: [],
+          }
+        );
+
+        expect(chmodMock).not.toHaveBeenCalled();
+      } finally {
+        Object.defineProperty(process, "platform", { value: originalPlatform, configurable: true });
+      }
     });
   });
 });

--- a/electron/ipc/handlers/__tests__/diagnostics.handlers.test.ts
+++ b/electron/ipc/handlers/__tests__/diagnostics.handlers.test.ts
@@ -9,6 +9,56 @@ const dialogMock = vi.hoisted(() => ({
   showSaveDialog: vi.fn(),
 }));
 
+const shellMock = vi.hoisted(() => ({
+  showItemInFolder: vi.fn(),
+}));
+
+const createWriteStreamMock = vi.hoisted(() =>
+  vi.fn(() => {
+    const listeners: Record<string, Array<(...args: unknown[]) => void>> = {};
+    const stream = {
+      on: vi.fn((event: string, fn: (...args: unknown[]) => void) => {
+        listeners[event] ??= [];
+        listeners[event].push(fn);
+        return stream;
+      }),
+      emit: (event: string, ...args: unknown[]) => {
+        listeners[event]?.forEach((fn) => {
+          fn(...args);
+        });
+      },
+      end: vi.fn(),
+    };
+    return stream;
+  })
+);
+
+const archiverMock = vi.hoisted(() => {
+  const archiveListeners: Record<string, Array<(...args: unknown[]) => void>> = {};
+  const archive = {
+    on: vi.fn((event: string, fn: (...args: unknown[]) => void) => {
+      archiveListeners[event] ??= [];
+      archiveListeners[event].push(fn);
+      return archive;
+    }),
+    pipe: vi.fn((output: { emit: (event: string, ...args: unknown[]) => void }) => {
+      // Mirror archiver's behavior of closing the output stream after finalize.
+      queueMicrotask(() => {
+        output.emit("close");
+      });
+    }),
+    append: vi.fn(),
+    finalize: vi.fn(() => Promise.resolve()),
+  };
+  return vi.fn(() => archive);
+});
+
+const resilientAtomicWriteFileMock = vi.hoisted(() => vi.fn(() => Promise.resolve()));
+
+const collectDiagnosticsWithKeysMock = vi.hoisted(() =>
+  vi.fn(() => Promise.resolve({ payload: { metadata: {} }, sectionKeys: ["metadata"] }))
+);
+
 const appMock = vi.hoisted(() => ({
   getAppMetrics: vi.fn(() => [
     {
@@ -39,9 +89,26 @@ vi.mock("electron", () => ({
   ipcMain: ipcMainMock,
   app: appMock,
   dialog: dialogMock,
+  shell: shellMock,
   BrowserWindow: {
     fromWebContents: vi.fn(() => null),
   },
+}));
+
+vi.mock("node:fs", () => ({
+  promises: {
+    readFile: vi.fn(() => Promise.resolve("")),
+  },
+  createWriteStream: createWriteStreamMock,
+  existsSync: vi.fn(() => false),
+}));
+
+vi.mock("archiver", () => ({
+  default: archiverMock,
+}));
+
+vi.mock("../../../utils/fs.js", () => ({
+  resilientAtomicWriteFile: resilientAtomicWriteFileMock,
 }));
 
 vi.mock("node:v8", () => ({
@@ -69,6 +136,7 @@ vi.mock("node:perf_hooks", () => ({
 
 vi.mock("../../../services/DiagnosticsCollector.js", () => ({
   collectDiagnostics: vi.fn(() => Promise.resolve({})),
+  collectDiagnosticsWithKeys: collectDiagnosticsWithKeysMock,
 }));
 
 const recordBlinkSampleMock = vi.hoisted(() => vi.fn());
@@ -239,6 +307,65 @@ describe("registerDiagnosticsHandlers", () => {
         sampleWindowMs: 1000,
       });
       expect(recordEluSampleMock).not.toHaveBeenCalled();
+    });
+  });
+
+  describe("diagnostics file write modes", () => {
+    it("JSON_EXPORT_USES_0o600_ATOMIC_WRITE", async () => {
+      dialogMock.showSaveDialog.mockResolvedValueOnce({
+        filePath: "/tmp/diagnostics.json",
+        canceled: false,
+      });
+      registerDiagnosticsHandlers(deps);
+      const handler = getHandlerFn("system:download-diagnostics");
+
+      const result = (await handler()) as boolean;
+
+      expect(result).toBe(true);
+      expect(resilientAtomicWriteFileMock).toHaveBeenCalledTimes(1);
+      const [filePath, , encoding, options] = resilientAtomicWriteFileMock.mock.calls[0];
+      expect(filePath).toBe("/tmp/diagnostics.json");
+      expect(encoding).toBe("utf-8");
+      expect(options).toEqual({ mode: 0o600 });
+    });
+
+    it("JSON_EXPORT_RESPECTS_DIALOG_CANCEL", async () => {
+      dialogMock.showSaveDialog.mockResolvedValueOnce({
+        filePath: undefined,
+        canceled: true,
+      });
+      registerDiagnosticsHandlers(deps);
+      const handler = getHandlerFn("system:download-diagnostics");
+
+      const result = (await handler()) as boolean;
+
+      expect(result).toBe(false);
+      expect(resilientAtomicWriteFileMock).not.toHaveBeenCalled();
+    });
+
+    it("ZIP_BUNDLE_USES_0o600_MODE", async () => {
+      dialogMock.showSaveDialog.mockResolvedValueOnce({
+        filePath: "/tmp/diagnostics.zip",
+        canceled: false,
+      });
+      registerDiagnosticsHandlers(deps);
+      const handler = getHandlerFn("system:save-diagnostics-bundle");
+
+      const result = (await handler(
+        {},
+        {
+          payload: { metadata: {} },
+          enabledSections: { metadata: true, logs: false },
+          replacements: [],
+        }
+      )) as boolean;
+
+      expect(result).toBe(true);
+      expect(createWriteStreamMock).toHaveBeenCalledTimes(1);
+      const [zipPath, options] = createWriteStreamMock.mock.calls[0];
+      expect(zipPath).toBe("/tmp/diagnostics.zip");
+      expect(options).toEqual({ mode: 0o600 });
+      expect(shellMock.showItemInFolder).toHaveBeenCalledWith("/tmp/diagnostics.zip");
     });
   });
 });

--- a/electron/ipc/handlers/__tests__/diagnostics.handlers.test.ts
+++ b/electron/ipc/handlers/__tests__/diagnostics.handlers.test.ts
@@ -326,7 +326,8 @@ describe("registerDiagnosticsHandlers", () => {
 
       expect(result).toBe(true);
       expect(resilientAtomicWriteFileMock).toHaveBeenCalledTimes(1);
-      const [filePath, , encoding, options] = resilientAtomicWriteFileMock.mock.calls[0];
+      const [filePath, , encoding, options] = resilientAtomicWriteFileMock.mock
+        .calls[0] as unknown[];
       expect(filePath).toBe("/tmp/diagnostics.json");
       expect(encoding).toBe("utf-8");
       expect(options).toEqual({ mode: 0o600 });
@@ -365,7 +366,7 @@ describe("registerDiagnosticsHandlers", () => {
 
       expect(result).toBe(true);
       expect(createWriteStreamMock).toHaveBeenCalledTimes(1);
-      const [zipPath, options] = createWriteStreamMock.mock.calls[0];
+      const [zipPath, options] = createWriteStreamMock.mock.calls[0] as unknown[];
       expect(zipPath).toBe("/tmp/diagnostics.zip");
       expect(options).toEqual({ mode: 0o600 });
       expect(shellMock.showItemInFolder).toHaveBeenCalledWith("/tmp/diagnostics.zip");

--- a/electron/ipc/handlers/diagnostics.ts
+++ b/electron/ipc/handlers/diagnostics.ts
@@ -68,11 +68,13 @@ async function writeBundleZip(
     }
   }
 
-  return new Promise((resolve, reject) => {
+  await new Promise<void>((resolve, reject) => {
     const output = createWriteStream(zipPath, { mode: 0o600 });
     const archive = archiver("zip", { zlib: { level: 6 } });
 
-    output.on("close", resolve);
+    output.on("close", () => {
+      resolve();
+    });
     output.on("error", reject);
     archive.on("error", reject);
 
@@ -85,6 +87,13 @@ async function writeBundleZip(
 
     void archive.finalize();
   });
+
+  // Belt-and-suspenders: createWriteStream's `mode` is only applied when the
+  // file is freshly created. If the user picked an existing path, the prior
+  // mode (e.g. 0o644) survives. POSIX-only — chmod is a no-op on Windows.
+  if (process.platform !== "win32") {
+    await fs.chmod(zipPath, 0o600);
+  }
 }
 
 function ensureEventLoopHistogram(): IntervalHistogram {

--- a/electron/ipc/handlers/diagnostics.ts
+++ b/electron/ipc/handlers/diagnostics.ts
@@ -7,6 +7,7 @@ import { existsSync } from "node:fs";
 import path from "node:path";
 import archiver from "archiver";
 import { CHANNELS } from "../channels.js";
+import { resilientAtomicWriteFile } from "../../utils/fs.js";
 import type { HandlerDependencies } from "../types.js";
 import type {
   AppMetricsSummary,
@@ -68,7 +69,7 @@ async function writeBundleZip(
   }
 
   return new Promise((resolve, reject) => {
-    const output = createWriteStream(zipPath);
+    const output = createWriteStream(zipPath, { mode: 0o600 });
     const archive = archiver("zip", { zlib: { level: 6 } });
 
     output.on("close", resolve);
@@ -232,7 +233,7 @@ export function registerDiagnosticsHandlers(deps: HandlerDependencies): () => vo
 
     if (canceled || !filePath) return false;
 
-    await fs.writeFile(filePath, json, "utf-8");
+    await resilientAtomicWriteFile(filePath, json, "utf-8", { mode: 0o600 });
     return true;
   };
   handlers.push(typedHandle(CHANNELS.SYSTEM_DOWNLOAD_DIAGNOSTICS, handleDownloadDiagnostics));

--- a/electron/services/DiagnosticsCollector.ts
+++ b/electron/services/DiagnosticsCollector.ts
@@ -55,6 +55,52 @@ function redactDeep(value: unknown): unknown {
   return value;
 }
 
+// Reconstructs `process.report.getReport().header` with PII removed. Whitelist
+// over spread: `networkInterfaces` carries real MAC/IP addresses not caught by
+// any redaction pass, `host` is the system hostname, `cwd`/`filename` embed
+// the username, and `commandLine` may contain secret flags.
+function redactReportHeader(header: unknown): Record<string, unknown> | unknown {
+  if (!header || typeof header !== "object") return header;
+  const h = header as Record<string, unknown>;
+  const safe: Record<string, unknown> = {};
+  const passthroughKeys = [
+    "reportVersion",
+    "event",
+    "trigger",
+    "dumpEventTime",
+    "dumpEventTimeStamp",
+    "processId",
+    "threadId",
+    "nodejsVersion",
+    "wordSize",
+    "arch",
+    "platform",
+    "componentVersions",
+    "release",
+    "osName",
+    "osRelease",
+    "osVersion",
+    "osMachine",
+    "cpus",
+    "glibcVersionRuntime",
+    "glibcVersionCompiler",
+  ];
+  for (const key of passthroughKeys) {
+    if (key in h) safe[key] = h[key];
+  }
+  safe.host = "<hostname>";
+  if (typeof h.cwd === "string") safe.cwd = sanitizePath(h.cwd);
+  if (typeof h.filename === "string") safe.filename = sanitizePath(h.filename);
+  if (Array.isArray(h.commandLine)) {
+    safe.commandLine = h.commandLine.map((entry) =>
+      typeof entry === "string" ? sanitizeString(entry) : entry
+    );
+  } else if (typeof h.commandLine === "string") {
+    safe.commandLine = sanitizeString(h.commandLine);
+  }
+  return safe;
+}
+
 function truncateDiagnosticString(value: string): string {
   if (value.length <= MAX_DIAGNOSTIC_STRING_LENGTH) {
     return value;
@@ -128,7 +174,7 @@ async function collectRuntime() {
     temp: sanitizePath(app.getPath("temp")),
     pid: process.pid,
     uptime: process.uptime(),
-    argv: process.argv.map(sanitizePath),
+    argv: process.argv.map(sanitizeString),
     env: {
       NODE_ENV: process.env.NODE_ENV ?? null,
       DAINTREE_DEBUG: process.env.DAINTREE_DEBUG ?? null,
@@ -230,7 +276,7 @@ async function collectProcess() {
     if (report && typeof report === "object") {
       const r = report as Record<string, unknown>;
       result.nodeReport = {
-        header: r.header,
+        header: redactReportHeader(r.header),
         resourceUsage: r.resourceUsage,
         libuv: r.libuv,
         environmentVariables: "<redacted>",

--- a/electron/services/__tests__/DiagnosticsCollector.adversarial.test.ts
+++ b/electron/services/__tests__/DiagnosticsCollector.adversarial.test.ts
@@ -438,7 +438,10 @@ describe("DiagnosticsCollector adversarial", () => {
       expect(header.host).toBe("<hostname>");
       expect(header.cwd).not.toContain("/Users/joe");
       expect(header.filename).not.toContain("/Users/joe");
-      expect(header.commandLine?.join(" ")).not.toContain("ghp_secret123");
+      expect(header.commandLine?.join(" ")).not.toContain("ghp_");
+      expect(header.commandLine?.join(" ")).not.toContain(
+        "ABCDEFGHIJKLMNOPQRSTUVWXYZabcdef0123456"
+      );
       expect(header.commandLine?.join(" ")).not.toContain("/Users/joe");
       expect(header.networkInterfaces).toBeUndefined();
       // Safe metadata preserved.

--- a/electron/services/__tests__/DiagnosticsCollector.adversarial.test.ts
+++ b/electron/services/__tests__/DiagnosticsCollector.adversarial.test.ts
@@ -391,6 +391,115 @@ describe("DiagnosticsCollector adversarial", () => {
     expect(msg).toContain("[REDACTED]");
   });
 
+  it("PROCESS_REPORT_HEADER_PII_REDACTED", async () => {
+    const reportSpy = vi.spyOn(process, "report", "get").mockReturnValue({
+      getReport: () =>
+        ({
+          header: {
+            reportVersion: 5,
+            event: "JavaScript API",
+            trigger: "GetReport",
+            nodejsVersion: "v20.0.0",
+            arch: "arm64",
+            platform: "darwin",
+            host: "Joes-MacBook.local",
+            cwd: "/Users/joe/project",
+            filename: "/Users/joe/report.json",
+            commandLine: [
+              "node",
+              "/Users/joe/app.js",
+              "--token=ghp_ABCDEFGHIJKLMNOPQRSTUVWXYZabcdef0123456",
+            ],
+            networkInterfaces: [{ mac: "aa:bb:cc:dd:ee:ff", address: "192.168.1.10" }],
+          },
+          resourceUsage: {},
+          libuv: [],
+        }) as unknown as ReturnType<NonNullable<typeof process.report>["getReport"]>,
+    } as unknown as typeof process.report);
+
+    try {
+      const payload = (await diagnostics.collectDiagnostics(createDeps())) as {
+        process: {
+          nodeReport: {
+            header: {
+              host?: string;
+              cwd?: string;
+              filename?: string;
+              commandLine?: string[];
+              networkInterfaces?: unknown;
+              nodejsVersion?: string;
+              arch?: string;
+            };
+          };
+        };
+      };
+
+      const header = payload.process.nodeReport.header;
+      expect(header.host).toBe("<hostname>");
+      expect(header.cwd).not.toContain("/Users/joe");
+      expect(header.filename).not.toContain("/Users/joe");
+      expect(header.commandLine?.join(" ")).not.toContain("ghp_secret123");
+      expect(header.commandLine?.join(" ")).not.toContain("/Users/joe");
+      expect(header.networkInterfaces).toBeUndefined();
+      // Safe metadata preserved.
+      expect(header.nodejsVersion).toBe("v20.0.0");
+      expect(header.arch).toBe("arm64");
+    } finally {
+      reportSpy.mockRestore();
+    }
+  });
+
+  it("PROCESS_REPORT_HEADER_TOLERATES_MISSING_FIELDS", async () => {
+    const reportSpy = vi.spyOn(process, "report", "get").mockReturnValue({
+      getReport: () =>
+        ({
+          header: {
+            reportVersion: 5,
+            nodejsVersion: "v20.0.0",
+          },
+          resourceUsage: {},
+          libuv: [],
+        }) as unknown as ReturnType<NonNullable<typeof process.report>["getReport"]>,
+    } as unknown as typeof process.report);
+
+    try {
+      const payload = (await diagnostics.collectDiagnostics(createDeps())) as {
+        process: {
+          nodeReport: { header: { host?: string; cwd?: string } };
+        };
+      };
+
+      // No throw, host overlay still applied, omitted fields absent.
+      expect(payload.process.nodeReport.header.host).toBe("<hostname>");
+      expect(payload.process.nodeReport.header.cwd).toBeUndefined();
+    } finally {
+      reportSpy.mockRestore();
+    }
+  });
+
+  it("ARGV_SECRET_SCRUBBED_AT_CAPTURE_SITE", async () => {
+    const argvSpy = vi
+      .spyOn(process, "argv", "get")
+      .mockReturnValue([
+        "node",
+        "/Users/alice/app.js",
+        "--token=ghp_ABCDEFGHIJKLMNOPQRSTUVWXYZabcdef0123456",
+      ]);
+
+    try {
+      const payload = (await diagnostics.collectDiagnostics(createDeps())) as {
+        runtime: { argv: string[] };
+      };
+
+      const joined = payload.runtime.argv.join(" ");
+      expect(joined).not.toContain("ghp_ABCDEFGHIJKLMNOPQRSTUVWXYZabcdef0123456");
+      expect(joined).not.toContain("/Users/alice");
+      expect(joined).toContain("[REDACTED]");
+    } finally {
+      argvSpy.mockRestore();
+    }
+  });
+
   it("FREE_TEXT_PEM_BLOCK_SCRUBBED", async () => {
     shared.logEntries = [
       {


### PR DESCRIPTION
## Summary

Three independent fixes to the diagnostics bundle, all sharing the same privacy theme.

- **Process report header whitelist** -- `collectProcess` previously passed `report.header` through whole; the `redactDeep` pass doesn't know to scrub `host` (raw hostname), `cwd`, or `commandLine`. A new `redactReportHeader()` function applies a safe-key whitelist and replaces anything outside it with a redacted placeholder, consistent with what `collectOs` already does for hostname.
- **Owner-only file permissions** -- the zip `writeStream` now opens at mode `0o600`, with an explicit `chmod 0o600` after `close` to cover the existing-file overwrite case (where `createWriteStream` mode is ignored). The JSON-only export path uses `resilientAtomicWriteFile`, matching the pattern already established in `HelpSessionService` and `McpPaneConfigService`.
- **`process.argv` scrubbed at the capture site** -- `collectRuntime` previously called `sanitizePath` only, relying on the late `redactDeep` pass for secret coverage. Switching to `sanitizeString` (path + secret) collapses the implicit two-step guarantee into a single, explicit one.

Closes #7105

## Changes

- `DiagnosticsCollector.ts` -- adds `redactReportHeader()` with an explicit safe-key whitelist; `collectProcess` uses it; `collectRuntime` argv switched to `sanitizeString`
- `diagnostics.ts` (IPC handler) -- `createWriteStream({ mode: 0o600 })` for zip; explicit `chmod 0o600` after close; `resilientAtomicWriteFile` for the JSON export path
- `DiagnosticsCollector.adversarial.test.ts` -- 3 new tests covering header redaction (hostname, non-allowlisted keys, safe keys pass through)
- `diagnostics.handlers.test.ts` -- 5 new tests covering the file-mode guarantee (new file, overwrite, JSON export)

## Testing

28 tests across the two suites all pass. The adversarial suite specifically verifies that `host` is replaced with `<hostname>`, that arbitrary non-allowlisted keys are redacted, and that safe keys (`nodeName`, `processId`, etc.) are preserved. The handler tests verify `0o600` on both the new-file and overwrite paths, and on the JSON export.