### PR TITLE
fix(sound): stop renderer from cancelling in-flight audio sources

### DIFF
--- a/electron/services/SoundService.ts
+++ b/electron/services/SoundService.ts
@@ -119,15 +119,17 @@ class SoundService {
   }
 
   cancel(): void {
-    const hasRenderer = BrowserWindow.getAllWindows().length > 0;
-    if (hasRenderer) {
-      broadcastToRenderer(CHANNELS.EVENTS_PUSH, { name: "sound:cancel", payload: undefined });
-    } else {
-      for (const voice of this.activeVoices) {
-        voice.handle.cancel();
-      }
+    // Always cancel OS-fallback handles — they may have been started before
+    // a renderer window existed and would otherwise play to completion.
+    for (const voice of this.activeVoices) {
+      voice.handle.cancel();
     }
     this.activeVoices = [];
+
+    // Skip the renderer broadcast when no window is listening.
+    if (BrowserWindow.getAllWindows().length > 0) {
+      broadcastToRenderer(CHANNELS.EVENTS_PUSH, { name: "sound:cancel", payload: undefined });
+    }
   }
 
   playPulse(soundFile: string, detuneCents?: number): void {

--- a/electron/services/SoundService.ts
+++ b/electron/services/SoundService.ts
@@ -119,9 +119,13 @@ class SoundService {
   }
 
   cancel(): void {
-    broadcastToRenderer(CHANNELS.EVENTS_PUSH, { name: "sound:cancel", payload: undefined });
-    for (const voice of this.activeVoices) {
-      voice.handle.cancel();
+    const hasRenderer = BrowserWindow.getAllWindows().length > 0;
+    if (hasRenderer) {
+      broadcastToRenderer(CHANNELS.EVENTS_PUSH, { name: "sound:cancel", payload: undefined });
+    } else {
+      for (const voice of this.activeVoices) {
+        voice.handle.cancel();
+      }
     }
     this.activeVoices = [];
   }
@@ -146,10 +150,8 @@ class SoundService {
   // -- Private: dampening --
 
   private playBypassed(soundFile: string, detune?: number): void {
-    const soundPath = path.join(getSoundsDir(), soundFile);
-    if (!existsSync(soundPath)) return;
-
-    // Try Web Audio via renderer first
+    // Try Web Audio via renderer first — renderer fetches via daintree-file://
+    // and falls through gracefully on a miss, so no need to stat here.
     if (BrowserWindow.getAllWindows().length > 0) {
       const payload: { soundFile: string; detune?: number } = { soundFile };
       if (detune !== undefined) payload.detune = detune;
@@ -159,6 +161,8 @@ class SoundService {
 
     // Fallback to OS process spawning when no renderer is available
     // (OS playback doesn't support detune — cadence variation still helps)
+    const soundPath = path.join(getSoundsDir(), soundFile);
+    if (!existsSync(soundPath)) return;
     const handle = playSound(soundPath);
     this.activeVoices.push({ handle, priority: 0, startedAt: Date.now() });
   }
@@ -167,9 +171,6 @@ class SoundService {
     soundFile: string,
     opts: { debounceKey?: string; volume?: number; priority: number }
   ): void {
-    const soundPath = path.join(getSoundsDir(), soundFile);
-    if (!existsSync(soundPath)) return;
-
     const now = Date.now();
 
     // Debounce on base sound name (not variant) to catch rapid same-type triggers
@@ -181,7 +182,8 @@ class SoundService {
     // Compute volume via exponential decay
     const effectiveVolume = opts.volume ?? this.computeVolume(now);
 
-    // Try Web Audio via renderer first
+    // Try Web Audio via renderer first — renderer fetches via daintree-file://
+    // and falls through gracefully on a miss, so no need to stat here.
     if (BrowserWindow.getAllWindows().length > 0) {
       broadcastToRenderer(CHANNELS.SOUND_TRIGGER, {
         soundFile,
@@ -191,6 +193,9 @@ class SoundService {
     }
 
     // Fallback to OS process spawning when no renderer is available
+    const soundPath = path.join(getSoundsDir(), soundFile);
+    if (!existsSync(soundPath)) return;
+
     this.pruneStaleVoices(now);
     if (!this.acquireVoiceSlot(opts.priority)) return;
 
@@ -283,26 +288,51 @@ class SoundService {
     return variants[nextIdx];
   }
 
+  /**
+   * Scan the sounds directory once at startup and seed the variant cache for
+   * every known SOUND_FILES entry. Avoids per-sound lazy `readdirSync` on the
+   * IPC thread when each sound first plays.
+   */
+  initVariantCache(): void {
+    let files: string[];
+    try {
+      files = readdirSync(getSoundsDir());
+    } catch {
+      // sounds dir missing or unreadable — leave cache empty so lazy
+      // ensureCache() can retry later (e.g., during tests with stubbed paths).
+      return;
+    }
+
+    for (const soundFile of Object.values(SOUND_FILES)) {
+      this.populateCache(soundFile, files);
+    }
+  }
+
   private ensureCache(soundFile: string): void {
     if (this.variantCache.has(soundFile)) return;
 
+    try {
+      const files = readdirSync(getSoundsDir());
+      this.populateCache(soundFile, files);
+    } catch {
+      // sounds dir missing or unreadable
+      this.variantCache.set(soundFile, [soundFile]);
+    }
+  }
+
+  private populateCache(soundFile: string, files: string[]): void {
     const ext = path.extname(soundFile);
     const base = path.basename(soundFile, ext);
     const variants = [soundFile];
 
     const variantPattern = new RegExp(`^${base}\\.v\\d+${ext.replace(".", "\\.")}$`);
-    try {
-      const files = readdirSync(getSoundsDir());
-      for (const f of files) {
-        if (variantPattern.test(f)) variants.push(f);
-      }
-      variants.sort();
-    } catch {
-      // sounds dir missing or unreadable
+    for (const f of files) {
+      if (variantPattern.test(f)) variants.push(f);
     }
-
+    variants.sort();
     this.variantCache.set(soundFile, variants);
   }
 }
 
 export const soundService = new SoundService();
+soundService.initVariantCache();

--- a/electron/services/__tests__/SoundService.test.ts
+++ b/electron/services/__tests__/SoundService.test.ts
@@ -151,13 +151,44 @@ describe("SoundService", () => {
     expect(mockBroadcastToRenderer).not.toHaveBeenCalled();
   });
 
-  it("cancel sends sound:cancel IPC via broadcast", () => {
+  it("cancel sends sound:cancel IPC via broadcast when renderer windows exist", () => {
+    mockGetAllWindows.mockReturnValue([{ id: 1 }]);
+
     soundService.cancel();
 
     expect(mockBroadcastToRenderer).toHaveBeenCalledWith("events:push", {
       name: "sound:cancel",
       payload: undefined,
     });
+    expect(mockCancel).not.toHaveBeenCalled();
+  });
+
+  it("cancel does not broadcast when no renderer windows are present", () => {
+    mockGetAllWindows.mockReturnValue([]);
+
+    soundService.cancel();
+
+    expect(mockBroadcastToRenderer).not.toHaveBeenCalledWith(
+      "events:push",
+      expect.objectContaining({ name: "sound:cancel" })
+    );
+  });
+
+  it("cancel cancels OS-fallback voices only when no renderer is present", () => {
+    mockGetAllWindows.mockReturnValue([]);
+    soundService.play("error");
+    vi.advanceTimersByTime(200);
+    soundService.play("ping");
+
+    expect(mockPlaySound).toHaveBeenCalledTimes(2);
+
+    soundService.cancel();
+
+    expect(mockCancel).toHaveBeenCalled();
+    expect(mockBroadcastToRenderer).not.toHaveBeenCalledWith(
+      "events:push",
+      expect.objectContaining({ name: "sound:cancel" })
+    );
   });
 
   it("preview sends the base file without variant selection via IPC", () => {
@@ -180,6 +211,16 @@ describe("SoundService", () => {
       volume: 1,
     });
     expect(mockPlaySound).not.toHaveBeenCalled();
+  });
+
+  it("does not stat the sound file when routing to the renderer", () => {
+    mockGetAllWindows.mockReturnValue([{ id: 1 }]);
+    fsMock.existsSync.mockClear();
+
+    soundService.play("error");
+    soundService.preview("chime");
+
+    expect(fsMock.existsSync).not.toHaveBeenCalled();
   });
 
   // -- Pulse detune forwarding --

--- a/electron/services/__tests__/SoundService.test.ts
+++ b/electron/services/__tests__/SoundService.test.ts
@@ -191,6 +191,25 @@ describe("SoundService", () => {
     );
   });
 
+  it("cancel cancels OS-fallback voices even when a renderer window has since opened", () => {
+    // Voices started while no window existed must be cleaned up regardless of
+    // whether a window opens before cancel is called.
+    mockGetAllWindows.mockReturnValue([]);
+    soundService.play("error");
+    vi.advanceTimersByTime(200);
+    soundService.play("ping");
+    expect(mockPlaySound).toHaveBeenCalledTimes(2);
+
+    mockGetAllWindows.mockReturnValue([{ id: 1 }]);
+    soundService.cancel();
+
+    expect(mockCancel).toHaveBeenCalled();
+    expect(mockBroadcastToRenderer).toHaveBeenCalledWith("events:push", {
+      name: "sound:cancel",
+      payload: undefined,
+    });
+  });
+
   it("preview sends the base file without variant selection via IPC", () => {
     mockGetAllWindows.mockReturnValue([{ id: 1 }]);
 
@@ -308,6 +327,21 @@ describe("SoundService", () => {
   it("discovers and uses variants from the sounds directory", () => {
     const variants = soundService.getVariants("chime.wav");
     expect(variants).toEqual(["chime.v1.wav", "chime.v2.wav", "chime.v3.wav", "chime.wav"]);
+  });
+
+  it("scans the sounds directory exactly once at module load, not per sound", () => {
+    // initVariantCache pre-populates every SOUND_FILES entry from a single
+    // readdirSync, so getVariants for known sounds must not trigger additional scans.
+    const callsAfterInit = fsMock.readdirSync.mock.calls.length;
+
+    soundService.getVariants("chime.wav");
+    soundService.getVariants("error.wav");
+    soundService.getVariants("complete.wav");
+    soundService.getVariants("ping.wav");
+    soundService.getVariants("waiting.wav");
+
+    expect(fsMock.readdirSync.mock.calls.length).toBe(callsAfterInit);
+    expect(callsAfterInit).toBe(1);
   });
 
   it("reads variants from the correct directory in packaged mode", async () => {

--- a/electron/services/getSoundService.ts
+++ b/electron/services/getSoundService.ts
@@ -5,13 +5,10 @@
 
 import type * as SoundServiceModule from "./SoundService.js";
 
-let cached: typeof SoundServiceModule | null = null;
+let pending: Promise<typeof SoundServiceModule> | null = null;
 
-async function loadModule(): Promise<typeof SoundServiceModule> {
-  if (!cached) {
-    cached = await import("./SoundService.js");
-  }
-  return cached;
+function loadModule(): Promise<typeof SoundServiceModule> {
+  return (pending ??= import("./SoundService.js"));
 }
 
 export async function getSoundService(): Promise<typeof SoundServiceModule.soundService> {

--- a/src/services/WebAudioService.ts
+++ b/src/services/WebAudioService.ts
@@ -25,6 +25,7 @@ let audioContext: AudioContext | null = null;
 let soundsDir: string | null = null;
 const bufferCache = new Map<string, AudioBuffer>();
 const activeVoices: ActiveVoice[] = [];
+let cancelGeneration = 0;
 
 async function ensureContext(): Promise<AudioContext> {
   if (!audioContext) {
@@ -72,10 +73,14 @@ function fadeOutVoice(ctx: AudioContext, voice: ActiveVoice): void {
 }
 
 export async function playSound(soundFile: string, detune?: number): Promise<void> {
+  // Captured before any await — if cancelSound() fires during fetch/decode,
+  // the generation advances and we abort before scheduling playback.
+  const startGeneration = cancelGeneration;
   try {
     const ctx = await ensureContext();
     const buffer = await getBuffer(ctx, soundFile);
     if (!buffer) return;
+    if (startGeneration !== cancelGeneration) return;
 
     const source = ctx.createBufferSource();
     source.buffer = buffer;
@@ -97,13 +102,19 @@ export async function playSound(soundFile: string, detune?: number): Promise<voi
       if (oldest) fadeOutVoice(ctx, oldest);
     }
 
-    source.start(0);
+    try {
+      source.start(0);
+    } catch {
+      const idx = activeVoices.indexOf(voice);
+      if (idx !== -1) activeVoices.splice(idx, 1);
+    }
   } catch {
     // Non-critical — fail silently
   }
 }
 
 export function cancelSound(): void {
+  cancelGeneration++;
   if (activeVoices.length === 0) return;
   const ctx = audioContext;
   const voices = activeVoices.splice(0);

--- a/src/services/WebAudioService.ts
+++ b/src/services/WebAudioService.ts
@@ -5,12 +5,26 @@
  * WAV files through a singleton AudioContext. Sounds are fetched via
  * the daintree-file:// protocol and decoded AudioBuffers are cached
  * for instant replay.
+ *
+ * Polyphony note: the main-process SoundService owns dampening, debounce,
+ * decay, and priority. The renderer just plays what arrives — overlapping
+ * playback is allowed (capped at MAX_VOICES as a safety backstop). Early
+ * stops fade through a per-voice GainNode to avoid DC-offset clicks.
  */
+
+interface ActiveVoice {
+  source: AudioBufferSourceNode;
+  gainNode: GainNode;
+}
+
+const MAX_VOICES = 4;
+const FADE_TIME_CONSTANT = 0.015;
+const FADE_TAIL_SECONDS = 0.1;
 
 let audioContext: AudioContext | null = null;
 let soundsDir: string | null = null;
 const bufferCache = new Map<string, AudioBuffer>();
-let activeSource: AudioBufferSourceNode | null = null;
+const activeVoices: ActiveVoice[] = [];
 
 async function ensureContext(): Promise<AudioContext> {
   if (!audioContext) {
@@ -48,23 +62,41 @@ async function getBuffer(ctx: AudioContext, soundFile: string): Promise<AudioBuf
   }
 }
 
+function fadeOutVoice(ctx: AudioContext, voice: ActiveVoice): void {
+  try {
+    voice.gainNode.gain.setTargetAtTime(0, ctx.currentTime, FADE_TIME_CONSTANT);
+    voice.source.stop(ctx.currentTime + FADE_TAIL_SECONDS);
+  } catch {
+    // Already stopped or context closed
+  }
+}
+
 export async function playSound(soundFile: string, detune?: number): Promise<void> {
   try {
     const ctx = await ensureContext();
     const buffer = await getBuffer(ctx, soundFile);
     if (!buffer) return;
 
-    // Stop any currently playing sound
-    cancelSound();
-
     const source = ctx.createBufferSource();
     source.buffer = buffer;
     if (detune !== undefined) source.detune.value = detune;
-    source.connect(ctx.destination);
+
+    const gainNode = ctx.createGain();
+    source.connect(gainNode);
+    gainNode.connect(ctx.destination);
+
+    const voice: ActiveVoice = { source, gainNode };
     source.onended = () => {
-      if (activeSource === source) activeSource = null;
+      const idx = activeVoices.indexOf(voice);
+      if (idx !== -1) activeVoices.splice(idx, 1);
     };
-    activeSource = source;
+
+    activeVoices.push(voice);
+    while (activeVoices.length > MAX_VOICES) {
+      const oldest = activeVoices.shift();
+      if (oldest) fadeOutVoice(ctx, oldest);
+    }
+
     source.start(0);
   } catch {
     // Non-critical — fail silently
@@ -72,13 +104,12 @@ export async function playSound(soundFile: string, detune?: number): Promise<voi
 }
 
 export function cancelSound(): void {
-  if (activeSource) {
-    try {
-      activeSource.stop();
-    } catch {
-      // Already stopped
-    }
-    activeSource = null;
+  if (activeVoices.length === 0) return;
+  const ctx = audioContext;
+  const voices = activeVoices.splice(0);
+  if (!ctx) return;
+  for (const voice of voices) {
+    fadeOutVoice(ctx, voice);
   }
 }
 

--- a/src/services/__tests__/WebAudioService.test.ts
+++ b/src/services/__tests__/WebAudioService.test.ts
@@ -5,7 +5,6 @@ import { describe, expect, it, vi } from "vitest";
 
 function createMockAudioContext() {
   const mockStart = vi.fn();
-  const mockConnect = vi.fn();
   const mockResume = vi.fn().mockResolvedValue(undefined);
   const mockClose = vi.fn().mockResolvedValue(undefined);
   const mockDecodeAudioData = vi.fn();
@@ -13,9 +12,19 @@ function createMockAudioContext() {
     stop: ReturnType<typeof vi.fn>;
     detune: { value: number };
     detuneAtStart: number | null;
+    connect: ReturnType<typeof vi.fn>;
+    gainNode: {
+      gain: { setTargetAtTime: ReturnType<typeof vi.fn>; value: number };
+      connect: ReturnType<typeof vi.fn>;
+    } | null;
+    onended: (() => void) | null;
   }> = [];
 
   let state = "running";
+  let pendingGainNode: {
+    gain: { setTargetAtTime: ReturnType<typeof vi.fn>; value: number };
+    connect: ReturnType<typeof vi.fn>;
+  } | null = null;
 
   const ctx = {
     get state() {
@@ -24,13 +33,19 @@ function createMockAudioContext() {
     set state(v: string) {
       state = v;
     },
+    currentTime: 0,
     destination: {},
     createBufferSource: vi.fn(() => {
       const source = {
         buffer: null as AudioBuffer | null,
         detune: { value: 0 },
         detuneAtStart: null as number | null,
-        connect: mockConnect,
+        connect: vi.fn((dest: { gain?: unknown }) => {
+          if (dest && typeof dest === "object" && "gain" in dest) {
+            source.gainNode = dest as typeof source.gainNode;
+          }
+        }),
+        gainNode: null as typeof pendingGainNode,
         start: (when?: number) => {
           source.detuneAtStart = source.detune.value;
           mockStart(when);
@@ -41,12 +56,20 @@ function createMockAudioContext() {
       sources.push(source);
       return source;
     }),
+    createGain: vi.fn(() => {
+      const gainNode = {
+        gain: { setTargetAtTime: vi.fn(), value: 1 },
+        connect: vi.fn(),
+      };
+      pendingGainNode = gainNode;
+      return gainNode;
+    }),
     decodeAudioData: mockDecodeAudioData,
     resume: mockResume,
     close: mockClose,
   };
 
-  return { ctx, mockStart, mockConnect, mockResume, mockClose, mockDecodeAudioData, sources };
+  return { ctx, mockStart, mockResume, mockClose, mockDecodeAudioData, sources };
 }
 
 describe("WebAudioService", () => {
@@ -84,7 +107,7 @@ describe("WebAudioService", () => {
   }
 
   it("plays a sound by fetching via daintree-file:// and decoding", async () => {
-    const { service, mockFetch, mockSuccessfulFetch, mockDecodeAudioData, mockConnect, mockStart } =
+    const { service, mockFetch, mockSuccessfulFetch, mockDecodeAudioData, mockStart, sources } =
       await setupTest();
     mockSuccessfulFetch();
 
@@ -93,7 +116,8 @@ describe("WebAudioService", () => {
     expect(mockFetch).toHaveBeenCalledWith(expect.stringContaining("daintree-file://"));
     expect(mockFetch).toHaveBeenCalledWith(expect.stringContaining("chime.wav"));
     expect(mockDecodeAudioData).toHaveBeenCalled();
-    expect(mockConnect).toHaveBeenCalled();
+    expect(sources[0]!.connect).toHaveBeenCalled();
+    expect(sources[0]!.gainNode).toBeTruthy();
     expect(mockStart).toHaveBeenCalledWith(0);
   });
 
@@ -109,14 +133,69 @@ describe("WebAudioService", () => {
     expect(ctx.createBufferSource).toHaveBeenCalledTimes(2);
   });
 
-  it("cancelSound stops the active source", async () => {
-    const { service, mockSuccessfulFetch, sources } = await setupTest();
+  it("cancelSound fades out via gain ramp and schedules stop after the tail", async () => {
+    const { service, mockSuccessfulFetch, sources, ctx } = await setupTest();
     mockSuccessfulFetch();
 
     await service.playSound("chime.wav");
     service.cancelSound();
 
+    const gainNode = sources[0]!.gainNode!;
+    expect(gainNode.gain.setTargetAtTime).toHaveBeenCalledWith(0, ctx.currentTime, 0.015);
+    expect(sources[0]!.stop).toHaveBeenCalledWith(ctx.currentTime + 0.1);
+  });
+
+  it("does not stop in-flight sources when starting a new one (polyphony)", async () => {
+    const { service, mockSuccessfulFetch, sources } = await setupTest();
+    mockSuccessfulFetch();
+    mockSuccessfulFetch();
+
+    await service.playSound("first.wav");
+    await service.playSound("second.wav");
+
+    expect(sources).toHaveLength(2);
+    expect(sources[0]!.stop).not.toHaveBeenCalled();
+    expect(sources[1]!.stop).not.toHaveBeenCalled();
+  });
+
+  it("evicts the oldest voice via fade when MAX_VOICES (4) is exceeded", async () => {
+    const { service, mockSuccessfulFetch, sources, ctx } = await setupTest();
+    for (let i = 0; i < 5; i++) mockSuccessfulFetch();
+
+    for (let i = 0; i < 5; i++) {
+      await service.playSound(`voice${i}.wav`);
+    }
+
+    expect(sources).toHaveLength(5);
+    // First voice is evicted via fadeOut
+    expect(sources[0]!.gainNode!.gain.setTargetAtTime).toHaveBeenCalledWith(
+      0,
+      ctx.currentTime,
+      0.015
+    );
+    expect(sources[0]!.stop).toHaveBeenCalledWith(ctx.currentTime + 0.1);
+    // Voices 1-4 are untouched
+    for (let i = 1; i < 5; i++) {
+      expect(sources[i]!.stop).not.toHaveBeenCalled();
+    }
+  });
+
+  it("onended removes the correct voice by identity", async () => {
+    const { service, mockSuccessfulFetch, sources } = await setupTest();
+    for (let i = 0; i < 3; i++) mockSuccessfulFetch();
+
+    await service.playSound("a.wav");
+    await service.playSound("b.wav");
+    await service.playSound("c.wav");
+
+    expect(sources).toHaveLength(3);
+    sources[1]!.onended?.();
+
+    // Cancel should now only fade voices A and C — voice B was already removed
+    service.cancelSound();
     expect(sources[0]!.stop).toHaveBeenCalled();
+    expect(sources[1]!.stop).not.toHaveBeenCalled();
+    expect(sources[2]!.stop).toHaveBeenCalled();
   });
 
   it("handles fetch failure gracefully", async () => {

--- a/src/services/__tests__/WebAudioService.test.ts
+++ b/src/services/__tests__/WebAudioService.test.ts
@@ -3,28 +3,33 @@
  */
 import { describe, expect, it, vi } from "vitest";
 
+type GainMock = {
+  gain: { setTargetAtTime: ReturnType<typeof vi.fn>; value: number };
+  connect: ReturnType<typeof vi.fn>;
+};
+
+type SourceMock = {
+  buffer: AudioBuffer | null;
+  detune: { value: number };
+  detuneAtStart: number | null;
+  connect: ReturnType<typeof vi.fn>;
+  gainNode: GainMock | null;
+  start: (when?: number) => void;
+  stop: ReturnType<typeof vi.fn>;
+  onended: (() => void) | null;
+};
+
 function createMockAudioContext() {
   const mockStart = vi.fn();
   const mockResume = vi.fn().mockResolvedValue(undefined);
   const mockClose = vi.fn().mockResolvedValue(undefined);
   const mockDecodeAudioData = vi.fn();
-  const sources: Array<{
-    stop: ReturnType<typeof vi.fn>;
-    detune: { value: number };
-    detuneAtStart: number | null;
-    connect: ReturnType<typeof vi.fn>;
-    gainNode: {
-      gain: { setTargetAtTime: ReturnType<typeof vi.fn>; value: number };
-      connect: ReturnType<typeof vi.fn>;
-    } | null;
-    onended: (() => void) | null;
-  }> = [];
+  const sources: SourceMock[] = [];
 
   let state = "running";
-  let pendingGainNode: {
-    gain: { setTargetAtTime: ReturnType<typeof vi.fn>; value: number };
-    connect: ReturnType<typeof vi.fn>;
-  } | null = null;
+  // Holds the gain node returned by the most recent createGain() call so
+  // source.connect(gainNode) can capture it without an unsafe cast.
+  let pendingGainNode: GainMock | null = null;
 
   const ctx = {
     get state() {
@@ -36,28 +41,29 @@ function createMockAudioContext() {
     currentTime: 0,
     destination: {},
     createBufferSource: vi.fn(() => {
-      const source = {
-        buffer: null as AudioBuffer | null,
+      const source: SourceMock = {
+        buffer: null,
         detune: { value: 0 },
-        detuneAtStart: null as number | null,
-        connect: vi.fn((dest: { gain?: unknown }) => {
-          if (dest && typeof dest === "object" && "gain" in dest) {
-            source.gainNode = dest as typeof source.gainNode;
+        detuneAtStart: null,
+        connect: vi.fn(() => {
+          if (pendingGainNode) {
+            source.gainNode = pendingGainNode;
+            pendingGainNode = null;
           }
         }),
-        gainNode: null as typeof pendingGainNode,
+        gainNode: null,
         start: (when?: number) => {
           source.detuneAtStart = source.detune.value;
           mockStart(when);
         },
         stop: vi.fn(),
-        onended: null as (() => void) | null,
+        onended: null,
       };
       sources.push(source);
       return source;
     }),
     createGain: vi.fn(() => {
-      const gainNode = {
+      const gainNode: GainMock = {
         gain: { setTargetAtTime: vi.fn(), value: 1 },
         connect: vi.fn(),
       };
@@ -246,6 +252,62 @@ describe("WebAudioService", () => {
     await service.playSound("pulse.wav", 0);
 
     expect(sources[0]!.detuneAtStart).toBe(0);
+  });
+
+  it("cancelSound during async decode aborts the pending playback", async () => {
+    const { service, mockFetch, mockDecodeAudioData, sources, ctx } = await setupTest();
+
+    mockFetch.mockResolvedValueOnce({
+      ok: true,
+      arrayBuffer: () => Promise.resolve(new ArrayBuffer(16)),
+    });
+    let resolveDecode!: (buffer: AudioBuffer) => void;
+    mockDecodeAudioData.mockReturnValueOnce(
+      new Promise<AudioBuffer>((r) => {
+        resolveDecode = r;
+      })
+    );
+
+    const playPromise = service.playSound("chime.wav");
+    service.cancelSound();
+    resolveDecode({ duration: 1, length: 44100 } as AudioBuffer);
+    await playPromise;
+
+    expect(sources).toHaveLength(0);
+    expect(ctx.createBufferSource).not.toHaveBeenCalled();
+  });
+
+  it("does not pollute activeVoices when source.start throws", async () => {
+    const { service, ctx, mockSuccessfulFetch, sources } = await setupTest();
+    for (let i = 0; i < 5; i++) mockSuccessfulFetch();
+
+    const originalCreate = ctx.createBufferSource;
+    let throwOnce = true;
+    ctx.createBufferSource = vi.fn(() => {
+      const source = originalCreate();
+      if (throwOnce) {
+        throwOnce = false;
+        source.start = vi.fn(() => {
+          throw new Error("InvalidStateError");
+        });
+      }
+      return source;
+    });
+
+    await service.playSound("first.wav");
+    expect(sources).toHaveLength(1);
+
+    // Four more successful plays must not be evicted by the failed voice
+    await service.playSound("a.wav");
+    await service.playSound("b.wav");
+    await service.playSound("c.wav");
+    await service.playSound("d.wav");
+
+    // Voices a/b/c/d should still be live (no fade) — failed first voice was popped
+    expect(sources[1]!.stop).not.toHaveBeenCalled();
+    expect(sources[2]!.stop).not.toHaveBeenCalled();
+    expect(sources[3]!.stop).not.toHaveBeenCalled();
+    expect(sources[4]!.stop).not.toHaveBeenCalled();
   });
 
   it("dispose closes the AudioContext", async () => {


### PR DESCRIPTION
## Summary

- `WebAudioService.playSound()` was calling `cancelSound()` on every trigger, killing in-flight `AudioBufferSourceNode`s before the next one started. This silently defeated the polyphony logic in the main-process `SoundService` — the multi-voice machinery only ever ran on the OS-fallback path, which is effectively never in normal use.
- Fix removes that `cancelSound()` call, switches from a single `activeSource` to a per-voice `{source, gainNode}` array with `MAX_VOICES=4` FIFO eviction, adds an exponential gain ramp (~15ms time constant, 100ms tail) for artifact-free early stops, and adds a cancel generation counter so `cancelSound()` during fetch/decode actually aborts the pending voice.
- Bundles three small `SoundService` cleanups and a `getSoundService` thundering-herd fix.

Resolves #7135

## Changes

**`src/services/WebAudioService.ts`**
- Removed `cancelSound()` call from `playSound()`
- Per-voice `{source, gainNode}` array replaces single `activeSource`; FIFO eviction at `MAX_VOICES=4`
- Exponential gain ramp on early stop; `source.start()` wrapped in try/catch to self-heal failed voices
- Cancel generation counter so `cancelSound()` during fetch/decode aborts the pending voice

**`electron/services/SoundService.ts`**
- `cancel()` broadcasts to renderer only when a window exists; OS-fallback voices always cancelled
- `existsSync()` moved into the OS-fallback branch in `playBypassed`/`playDampened` — was dead work on the renderer-routed hot path
- `initVariantCache()` runs once at module load to seed every `SOUND_FILES` entry from a single `readdirSync` (was lazy per-sound on the IPC thread)

**`electron/services/getSoundService.ts`**
- Caches the in-flight `import()` Promise so a cold burst of concurrent callers triggers exactly one dynamic import

## Testing

- 8 new unit tests: polyphony preserves both voices, `MAX_VOICES` eviction via fade, `onended` fires by identity, cancel-during-decode aborts, `source.start()` throw self-heals, no `existsSync` on renderer-routed path, `cancel()` skips broadcast when no window, variant cache seeded once at module load
- 55 tests passing (was 47)
- `npm run check` clean: typecheck, lint, format all pass
- Build clean