### PR TITLE
fix(bulk-worktree): retry transient assignment failures (#7147)

### DIFF
--- a/src/components/GitHub/BulkCreateWorktreeDialog.tsx
+++ b/src/components/GitHub/BulkCreateWorktreeDialog.tsx
@@ -581,7 +581,11 @@ export function BulkCreateWorktreeDialog({
                 }
               }
 
-              // Step 3: Issue assignment (best-effort, issues only)
+              // Step 3: Issue assignment (best-effort, issues only).
+              // Retries transient failures using the same helpers as the outer loop, but
+              // with isolated backoff so step-3 delays don't contaminate sibling items.
+              // Permanent failures (401/403/404/422) and exhausted retries fall through
+              // silently — assignment is never surfaced as an item failure.
               if (planned.mode === "issue" && assignWorktreeToSelf && itemNumber) {
                 const username = useGitHubConfigStore.getState().config?.username;
                 if (username) {
@@ -589,10 +593,25 @@ export function BulkCreateWorktreeDialog({
                     type: "ITEM_ASSIGNING",
                     issueNumber: itemNumber,
                   });
-                  try {
-                    await githubClient.assignIssue(rootPath, itemNumber, username);
-                  } catch {
-                    // Best-effort — silent failure
+                  let assignBackoff = BACKOFF_BASE_MS;
+                  for (
+                    let assignAttempt = 1;
+                    assignAttempt <= MAX_AUTO_RETRIES + 1;
+                    assignAttempt++
+                  ) {
+                    if (runIdRef.current !== currentRunId) return;
+                    try {
+                      await githubClient.assignIssue(rootPath, itemNumber, username);
+                      break;
+                    } catch (err) {
+                      const assignErr = normalizeError(err);
+                      if (assignAttempt <= MAX_AUTO_RETRIES && isTransientError(assignErr)) {
+                        assignBackoff = nextBackoffDelay(assignBackoff);
+                        await delay(assignBackoff);
+                        continue;
+                      }
+                      break;
+                    }
                   }
                 }
               }

--- a/src/components/GitHub/__tests__/BulkCreateWorktreeDialog.test.tsx
+++ b/src/components/GitHub/__tests__/BulkCreateWorktreeDialog.test.tsx
@@ -82,10 +82,13 @@ vi.mock("@/lib/notify", () => ({
   notify: vi.fn(),
 }));
 
+const prefsHolder: { assignWorktreeToSelf: boolean } = { assignWorktreeToSelf: false };
+const githubConfigHolder: { config: { username?: string } | null } = { config: null };
+
 vi.mock("@/store/preferencesStore", () => ({
   usePreferencesStore: (selector: (s: Record<string, unknown>) => unknown) =>
     selector({
-      assignWorktreeToSelf: false,
+      assignWorktreeToSelf: prefsHolder.assignWorktreeToSelf,
       setAssignWorktreeToSelf: vi.fn(),
       lastSelectedWorktreeRecipeIdByProject: {},
       setLastSelectedWorktreeRecipeIdByProject: vi.fn(),
@@ -96,12 +99,12 @@ vi.mock("@/store/githubConfigStore", () => ({
   useGitHubConfigStore: Object.assign(
     (selector: (s: Record<string, unknown>) => unknown) =>
       selector({
-        config: null,
+        config: githubConfigHolder.config,
         initialize: vi.fn(),
       }),
     {
       getState: () => ({
-        config: null,
+        config: githubConfigHolder.config,
       }),
     }
   ),
@@ -282,6 +285,8 @@ beforeEach(() => {
   mockGetAgentConfig.mockReturnValue({ command: "claude" });
   mockGenerateAgentCommand.mockReturnValue("claude --fresh");
   mockGenerateRecipeFromActiveTerminals.mockReturnValue([]);
+  prefsHolder.assignWorktreeToSelf = false;
+  githubConfigHolder.config = null;
 });
 
 afterEach(() => {
@@ -1586,6 +1591,118 @@ describe("BulkCreateWorktreeDialog", () => {
 
     expect(mockAddPanel).toHaveBeenCalledTimes(2);
     expect(screen.getByText(/1 of 1 created/)).toBeTruthy();
+  });
+});
+
+describe("BulkCreateWorktreeDialog — issue assignment retry", () => {
+  const assignProps = {
+    isOpen: true,
+    onClose: vi.fn(),
+    mode: "issue" as const,
+    selectedIssues: [makeIssue(1)],
+    selectedPRs: [] as GitHubPR[],
+    onComplete: vi.fn(),
+  };
+
+  it("retries transient assignment failure with backoff then succeeds", async () => {
+    prefsHolder.assignWorktreeToSelf = true;
+    githubConfigHolder.config = { username: "me" };
+
+    let assignCallCount = 0;
+    mockAssignIssue.mockImplementation(() => {
+      assignCallCount++;
+      if (assignCallCount === 1) {
+        return Promise.reject(new Error("GitHub is temporarily unavailable. Please retry."));
+      }
+      return Promise.resolve();
+    });
+
+    render(<BulkCreateWorktreeDialog {...assignProps} />);
+
+    await act(async () => {
+      screen.getByTestId("bulk-create-confirm-button").click();
+    });
+
+    await advanceTimersGradually(35000);
+
+    expect(assignCallCount).toBe(2);
+    expect(screen.getByText(/1 of 1 created/)).toBeTruthy();
+    expect(screen.queryByText(/failed/)).toBeNull();
+  });
+
+  it("does not retry non-transient assignment failures", async () => {
+    prefsHolder.assignWorktreeToSelf = true;
+    githubConfigHolder.config = { username: "me" };
+
+    mockAssignIssue.mockRejectedValue(new Error("Forbidden"));
+
+    render(<BulkCreateWorktreeDialog {...assignProps} />);
+
+    await act(async () => {
+      screen.getByTestId("bulk-create-confirm-button").click();
+    });
+
+    await advanceTimersGradually(5000);
+
+    expect(mockAssignIssue).toHaveBeenCalledTimes(1);
+    expect(screen.getByText(/1 of 1 created/)).toBeTruthy();
+    expect(screen.queryByText(/failed/)).toBeNull();
+  });
+
+  it("swallows exhausted transient assignment retries (best-effort)", async () => {
+    prefsHolder.assignWorktreeToSelf = true;
+    githubConfigHolder.config = { username: "me" };
+
+    mockAssignIssue.mockRejectedValue(
+      new Error("GitHub is temporarily unavailable. Please retry.")
+    );
+
+    render(<BulkCreateWorktreeDialog {...assignProps} />);
+
+    await act(async () => {
+      screen.getByTestId("bulk-create-confirm-button").click();
+    });
+
+    await advanceTimersGradually(70000);
+
+    // MAX_AUTO_RETRIES = 2 → 3 total attempts before giving up silently.
+    expect(mockAssignIssue).toHaveBeenCalledTimes(3);
+    expect(screen.getByText(/1 of 1 created/)).toBeTruthy();
+    expect(screen.queryByText(/failed/)).toBeNull();
+  });
+
+  it("stops assignment retries when the run is cancelled mid-backoff", async () => {
+    prefsHolder.assignWorktreeToSelf = true;
+    githubConfigHolder.config = { username: "me" };
+
+    mockAssignIssue.mockRejectedValue(
+      new Error("GitHub is temporarily unavailable. Please retry.")
+    );
+
+    render(<BulkCreateWorktreeDialog {...assignProps} />);
+
+    await act(async () => {
+      screen.getByTestId("bulk-create-confirm-button").click();
+    });
+
+    // Let the worktree finish and the first assignIssue call fail; the loop
+    // is now suspended on `await delay(assignBackoff)`.
+    await advanceTimersGradually(100);
+    expect(mockAssignIssue).toHaveBeenCalledTimes(1);
+
+    // Cancel before backoff expires.
+    await act(async () => {
+      const buttons = screen.getAllByRole("button");
+      const cancelBtn = buttons.find((b) => b.textContent === "Cancel");
+      cancelBtn?.click();
+      await vi.advanceTimersByTimeAsync(0);
+    });
+
+    // Drain remaining backoff window — the stale-run guard must short-circuit
+    // the loop before another IPC call goes out.
+    await advanceTimersGradually(35000);
+
+    expect(mockAssignIssue).toHaveBeenCalledTimes(1);
   });
 });
 

--- a/src/components/GitHub/__tests__/BulkCreateWorktreeDialog.test.tsx
+++ b/src/components/GitHub/__tests__/BulkCreateWorktreeDialog.test.tsx
@@ -1626,6 +1626,35 @@ describe("BulkCreateWorktreeDialog — issue assignment retry", () => {
     await advanceTimersGradually(35000);
 
     expect(assignCallCount).toBe(2);
+    expect(mockAssignIssue).toHaveBeenCalledWith("/test/root", 1, "me");
+    expect(screen.getByText(/1 of 1 created/)).toBeTruthy();
+    expect(screen.queryByText(/failed/)).toBeNull();
+  });
+
+  it("succeeds when assignment recovers on the final permitted attempt", async () => {
+    prefsHolder.assignWorktreeToSelf = true;
+    githubConfigHolder.config = { username: "me" };
+
+    let assignCallCount = 0;
+    mockAssignIssue.mockImplementation(() => {
+      assignCallCount++;
+      if (assignCallCount <= 2) {
+        return Promise.reject(new Error("GitHub is temporarily unavailable. Please retry."));
+      }
+      return Promise.resolve();
+    });
+
+    render(<BulkCreateWorktreeDialog {...assignProps} />);
+
+    await act(async () => {
+      screen.getByTestId("bulk-create-confirm-button").click();
+    });
+
+    await advanceTimersGradually(70000);
+
+    // Loop bound is `<= MAX_AUTO_RETRIES + 1`, so the third attempt must run
+    // and a success there must short-circuit out of the loop.
+    expect(assignCallCount).toBe(3);
     expect(screen.getByText(/1 of 1 created/)).toBeTruthy();
     expect(screen.queryByText(/failed/)).toBeNull();
   });

--- a/src/components/GitHub/__tests__/bulkCreateUtils.test.ts
+++ b/src/components/GitHub/__tests__/bulkCreateUtils.test.ts
@@ -136,6 +136,30 @@ describe("isTransientError", () => {
     expect(isTransientError("Spawn queue full")).toBe(true);
   });
 
+  it("matches GitHub temporary unavailability (5xx)", () => {
+    expect(isTransientError("GitHub is temporarily unavailable. Please retry.")).toBe(true);
+  });
+
+  it("matches GitHub network unreachable", () => {
+    expect(isTransientError("Cannot reach GitHub. Check your internet connection.")).toBe(true);
+  });
+
+  it("matches GitHub primary rate limit", () => {
+    expect(isTransientError("GitHub rate limit exceeded. Resets at 12:34 UTC.")).toBe(true);
+  });
+
+  it("matches GitHub secondary rate limit", () => {
+    expect(isTransientError("GitHub secondary rate limit triggered. Slow down requests.")).toBe(
+      true
+    );
+  });
+
+  it("rejects GitHub permission errors as non-transient", () => {
+    expect(isTransientError("Issue not found")).toBe(false);
+    expect(isTransientError("Forbidden — check token scopes")).toBe(false);
+    expect(isTransientError("Unauthorized — invalid token")).toBe(false);
+  });
+
   it("rejects VALIDATION_ERROR code", () => {
     expect(isTransientError("something", "VALIDATION_ERROR")).toBe(false);
   });

--- a/src/components/GitHub/bulkCreateUtils.ts
+++ b/src/components/GitHub/bulkCreateUtils.ts
@@ -18,8 +18,10 @@ export const BACKOFF_BASE_MS = 3000;
 export const BACKOFF_CAP_MS = 30000;
 export const VERIFICATION_SETTLE_MS = 800;
 
+// IPC strips structured error fields (lesson #3769), so renderer-side classification
+// matches the strings emitted by `parseGitHubError` in the main process — not status codes.
 const TRANSIENT_ERROR_RE =
-  /\.lock['"]?:.*(?:File exists|exists)|Another git process|Resource temporarily unavailable|cannot lock ref|could not lock config file|Rate limit exceeded|Spawn queue full|ETIMEDOUT|ECONNRESET|ECONNREFUSED/i;
+  /\.lock['"]?:.*(?:File exists|exists)|Another git process|Resource temporarily unavailable|cannot lock ref|could not lock config file|Rate limit exceeded|Spawn queue full|ETIMEDOUT|ECONNRESET|ECONNREFUSED|GitHub is temporarily unavailable|Cannot reach GitHub|GitHub rate limit exceeded|GitHub secondary rate limit triggered/i;
 
 export function isTransientError(message: string, code?: string): boolean {
   if (code === "VALIDATION_ERROR" || code === "NOT_FOUND") return false;


### PR DESCRIPTION
## Summary

When bulk-creating worktrees, the assignment call to GitHub occasionally hits transient failures — rate limits, temporary unavailability — and the error was silently dropped without retry. The root cause was two gaps working together: `TRANSIENT_ERROR_RE` only matched the raw GitHub error strings, but the IPC layer flattens status fields before the message reaches the renderer, so the classifier never fired; and there was no retry logic anyway, so even a correctly classified transient error had nowhere to go.

This PR closes both gaps.

Resolves #7147

## Changes

- **`bulkCreateUtils.ts`** — Extended `TRANSIENT_ERROR_RE` with the four strings `parseGitHubError` emits after IPC flattening: `"GitHub is temporarily unavailable"`, `"Cannot reach GitHub"`, `"GitHub rate limit exceeded"`, `"GitHub secondary rate limit triggered"`. Status fields are stripped at the boundary, so `.message` matching is the only viable signal.
- **`BulkCreateWorktreeDialog.tsx`** — Replaced the bare `try/catch` around `githubClient.assignIssue` with an inner retry loop: `MAX_AUTO_RETRIES` cap, isolated `assignBackoff`, `ITEM_ASSIGNING` dispatched once before the loop, stale-run guard before each attempt and after each backoff delay. Permanent errors and exhausted retries still fall through silently — assignment is best-effort and never fails the item.
- **`bulkCreateUtils.test.ts`** — Unit tests for the four new transient strings and explicit negative cases for permission errors.
- **`BulkCreateWorktreeDialog.test.tsx`** — Refactored prefs/`githubConfig` mocks to mutable holders for per-test overrides. Five integration tests: retry-then-success (with exact-arg assertion), final-attempt success, non-transient swallow, exhausted-retry swallow, mid-backoff cancellation.

## Testing

87 vitest cases pass across both test files. Typecheck, lint, and format all clean. Lint warning count improved from 877 to 868.