### PR TITLE
fix(quarantine): tidy quarantine prefix list and add per-file reap logging

### DIFF
--- a/electron/services/__tests__/projectQuarantineCleanup.test.ts
+++ b/electron/services/__tests__/projectQuarantineCleanup.test.ts
@@ -1,8 +1,9 @@
-import { describe, it, expect, beforeEach, afterEach } from "vitest";
+import { describe, it, expect, beforeEach, afterEach, vi } from "vitest";
 import fs from "fs/promises";
 import path from "path";
 import os from "os";
 import { cleanupQuarantinedProjectFiles } from "../projectQuarantineCleanup.js";
+import * as logger from "../../utils/logger.js";
 
 const THIRTY_ONE_DAYS_MS = 31 * 24 * 60 * 60 * 1000;
 const TWENTY_NINE_DAYS_MS = 29 * 24 * 60 * 60 * 1000;
@@ -14,7 +15,6 @@ const QUARANTINE_FILES = [
   "state.json.corrupted.1234567890",
   "settings.json.corrupted.1234567890",
   "recipes.json.corrupted.1234567890",
-  "workflows.json.corrupted.1234567890",
 ];
 
 let tmpDir: string;
@@ -80,14 +80,14 @@ describe("cleanupQuarantinedProjectFiles", () => {
     await expect(fs.access(filePath)).resolves.toBeUndefined();
   });
 
-  it("deletes all four known quarantine file types when old", async () => {
+  it("deletes all three known quarantine file types when old", async () => {
     const projectDir = await createProjectDir(VALID_PROJECT_ID);
     for (const filename of QUARANTINE_FILES) {
       await createCorruptedFile(projectDir, filename, THIRTY_ONE_DAYS_MS, NOW);
     }
 
     const deleted = await cleanupQuarantinedProjectFiles(tmpDir, NOW);
-    expect(deleted).toBe(4);
+    expect(deleted).toBe(3);
 
     for (const filename of QUARANTINE_FILES) {
       await expect(fs.access(path.join(projectDir, filename))).rejects.toThrow();
@@ -223,5 +223,30 @@ describe("cleanupQuarantinedProjectFiles", () => {
     const deleted = await cleanupQuarantinedProjectFiles(tmpDir, futureNow);
     expect(deleted).toBe(1);
     await expect(fs.access(filePath)).rejects.toThrow();
+  });
+
+  it("logs per-file reap info after successful unlink", async () => {
+    const logInfoSpy = vi.spyOn(logger, "logInfo");
+
+    const projectDir = await createProjectDir(VALID_PROJECT_ID);
+    await createCorruptedFile(
+      projectDir,
+      "state.json.corrupted.1234567890",
+      THIRTY_ONE_DAYS_MS,
+      NOW
+    );
+
+    await cleanupQuarantinedProjectFiles(tmpDir, NOW);
+
+    expect(logInfoSpy).toHaveBeenCalledWith(
+      "projectQuarantine.reaped",
+      expect.objectContaining({
+        projectId: VALID_PROJECT_ID,
+        filename: "state.json.corrupted.1234567890",
+        ageDays: expect.any(Number),
+      })
+    );
+
+    logInfoSpy.mockRestore();
   });
 });

--- a/electron/services/projectQuarantineCleanup.ts
+++ b/electron/services/projectQuarantineCleanup.ts
@@ -5,23 +5,18 @@ import { resilientUnlink } from "../utils/fs.js";
 import { logInfo, logError } from "../utils/logger.js";
 
 const QUARANTINE_MAX_AGE_MS = 30 * 24 * 60 * 60 * 1000;
+const DAY_MS = 24 * 60 * 60 * 1000;
 
 const QUARANTINE_PREFIXES = [
   "state.json.corrupted.",
-  "state.json.corrupted",
   "settings.json.corrupted.",
-  "settings.json.corrupted",
   "recipes.json.corrupted.",
-  "recipes.json.corrupted",
-  "workflows.json.corrupted.",
-  "workflows.json.corrupted",
 ];
 
 export async function cleanupQuarantinedProjectFiles(
   projectsConfigDir: string,
   now: number = Date.now()
 ): Promise<number> {
-  const threshold = now - QUARANTINE_MAX_AGE_MS;
   let deletedCount = 0;
 
   let entries: import("fs").Dirent[];
@@ -52,9 +47,15 @@ export async function cleanupQuarantinedProjectFiles(
       const filePath = path.join(projectDir, dirent.name);
       try {
         const stats = await fs.stat(filePath);
-        if (stats.mtimeMs < threshold) {
+        const ageMs = now - stats.mtimeMs;
+        if (ageMs > QUARANTINE_MAX_AGE_MS) {
           await resilientUnlink(filePath);
           deletedCount++;
+          logInfo("projectQuarantine.reaped", {
+            projectId: entry.name,
+            filename: dirent.name,
+            ageDays: Math.floor(ageMs / DAY_MS),
+          });
         }
       } catch (err) {
         const code = (err as NodeJS.ErrnoException).code;


### PR DESCRIPTION
## Summary
- Removes the dead `workflows.json.corrupted` prefix and drops redundant no-dot variants from `QUARANTINE_PREFIXES`
- Adds per-file `projectQuarantine.reaped` logging so cleanup deletions leave a forensic trail
- Tightens the age comparison to compute `ageMs` once and reuse it

Resolves #7106

## Changes
- `electron/services/projectQuarantineCleanup.ts` — trimmed prefix list from 8 entries to 3, added per-reap logging, cleaned up age computation
- `electron/services/__tests__/projectQuarantineCleanup.test.ts` — updated existing assertions, added spy-based test for per-file log output

## Testing
- All existing quarantine unit tests pass (adjusted for the reduced prefix count)
- New test verifies `logInfo` is called with `projectQuarantine.reaped` and the correct payload shape