### PR TITLE
fix(file-search): polish FileSearchService indexing and ranking (#7138)

### DIFF
--- a/electron/services/FileSearchService.ts
+++ b/electron/services/FileSearchService.ts
@@ -2,22 +2,60 @@ import * as fs from "fs/promises";
 import * as path from "path";
 import { createHardenedGit } from "../utils/hardenedGit.js";
 import { Cache } from "../utils/cache.js";
+import { logWarn } from "../utils/logger.js";
 import type { Dirent } from "fs";
 
 interface FileListCacheEntry {
   files: string[];
+  sortedFiles: string[];
 }
 
 const FILE_LIST_CACHE = new Cache<string, FileListCacheEntry>({
   maxSize: 30,
   defaultTTL: 10_000, // 10 seconds (reduced from 30s for faster worktree updates)
 });
-const FILE_LIST_IN_FLIGHT = new Map<string, Promise<string[]>>();
+const FILE_LIST_IN_FLIGHT = new Map<string, Promise<FileListCacheEntry>>();
 const FILE_LIST_EPOCHS = new Map<string, number>();
 
 const MAX_RESULTS_DEFAULT = 50;
 const MAX_QUERY_LENGTH = 256;
 const MAX_FALLBACK_FILES = 20_000;
+
+// Names hard-skipped by the fallback walker only. Git mode honours .gitignore via
+// --exclude-standard, so these are unnecessary there. Includes a few well-known
+// noise files (.DS_Store) alongside dirs.
+const FALLBACK_SKIP_NAMES = new Set<string>([
+  ".git",
+  ".svn",
+  ".hg",
+  "node_modules",
+  "bower_components",
+  ".venv",
+  ".virtualenv",
+  "venv",
+  "__pycache__",
+  ".pytest_cache",
+  ".mypy_cache",
+  "dist",
+  "build",
+  "out",
+  "target",
+  "bin",
+  "obj",
+  ".next",
+  ".nuxt",
+  ".svelte-kit",
+  ".turbo",
+  ".parcel-cache",
+  ".cache",
+  "coverage",
+  ".nyc_output",
+  ".DS_Store",
+]);
+
+// One-shot per-cwd cap warnings; persists for process lifetime so a 20k-file
+// repo logs once at startup, not once per file-watcher invalidation.
+const FALLBACK_CAP_WARNED = new Set<string>();
 
 function toPosixPath(p: string): string {
   return p.split(path.sep).join("/");
@@ -36,12 +74,11 @@ function normalizeQuery(rawQuery: string): string {
   return normalized.replace(/\/+/g, "/");
 }
 
-function scorePath(queryLower: string, file: string): number | null {
-  if (queryLower.length === 0) return 0;
+function scorePath(normalizedQuery: string, file: string): number | null {
+  if (normalizedQuery.length === 0) return 0;
 
   const fileLower = file.toLowerCase();
-  const normalizedQuery = queryLower.replace(/\/$/, "");
-  const normalizedFile = fileLower.replace(/\/$/, "");
+  const normalizedFile = fileLower.endsWith("/") ? fileLower.slice(0, -1) : fileLower;
   const basename = normalizedFile.slice(normalizedFile.lastIndexOf("/") + 1);
 
   if (basename === normalizedQuery) return 0;
@@ -57,23 +94,21 @@ function scorePath(queryLower: string, file: string): number | null {
   return null;
 }
 
-function pickTopMatches(files: string[], query: string, limit: number): string[] {
+function pickTopMatches(entry: FileListCacheEntry, query: string, limit: number): string[] {
   const queryLower = normalizeQuery(query).toLowerCase();
+  const normalizedQuery = queryLower.endsWith("/") ? queryLower.slice(0, -1) : queryLower;
   const effectiveLimit = clampInt(limit, 1, 100, MAX_RESULTS_DEFAULT);
 
-  if (queryLower.length === 0) {
-    return files
-      .slice()
-      .sort((a, b) => a.length - b.length || a.localeCompare(b))
-      .slice(0, effectiveLimit);
+  if (normalizedQuery.length === 0) {
+    return entry.sortedFiles.slice(0, effectiveLimit);
   }
 
   const best: Array<{ file: string; score: number }> = [];
   let worstIdx = -1;
   let worstScore = -Infinity;
 
-  for (const file of files) {
-    const score = scorePath(queryLower, file);
+  for (const file of entry.files) {
+    const score = scorePath(normalizedQuery, file);
     if (score === null) continue;
 
     if (best.length < effectiveLimit) {
@@ -118,10 +153,12 @@ async function loadFilesFromDisk(cwd: string): Promise<string[]> {
     }
 
     for (const entry of entries) {
-      if (entry.name === ".git" || entry.name === "node_modules") continue;
+      if (FALLBACK_SKIP_NAMES.has(entry.name)) continue;
       const absolute = path.join(dir, entry.name);
       const relative = path.relative(cwd, absolute);
-      const relativePosix = toPosixPath(relative);
+      // APFS stores filenames as NFD on macOS; normalise to match the NFC paths
+      // git produces via core.precomposeunicode.
+      const relativePosix = toPosixPath(relative).normalize("NFC");
 
       if (entry.isDirectory()) {
         results.push(`${relativePosix}/`);
@@ -134,6 +171,14 @@ async function loadFilesFromDisk(cwd: string): Promise<string[]> {
       results.push(relativePosix);
       if (results.length >= MAX_FALLBACK_FILES) break;
     }
+  }
+
+  if (results.length >= MAX_FALLBACK_FILES && !FALLBACK_CAP_WARNED.has(cwd)) {
+    FALLBACK_CAP_WARNED.add(cwd);
+    logWarn("[FileSearchService] loadFilesFromDisk: hit fallback cap", {
+      cwd,
+      cap: MAX_FALLBACK_FILES,
+    });
   }
 
   return results.sort((a, b) => a.localeCompare(b));
@@ -151,7 +196,16 @@ async function loadGitFiles(cwd: string): Promise<string[]> {
   const relativeToRoot = toPosixPath(path.relative(gitRoot, cwd));
   const pathspec = relativeToRoot && relativeToRoot !== "." ? relativeToRoot : null;
 
-  const args = ["ls-files", "--cached", "--others", "--exclude-standard"] as string[];
+  // -z: NUL-delimited output. Required to round-trip filenames containing tabs,
+  // newlines, or backslashes; core.quotepath=false alone only suppresses high-bit
+  // quoting.
+  // No --recurse-submodules: submodules surface as a single gitlink and recursing
+  // would require a separate ls-files invocation per submodule and break the
+  // root-relative path mapping below.
+  // No -t / skip-worktree filtering: skip-worktree entries appear as phantoms in
+  // the index but are intentionally surfaced so users can still search files they
+  // chose not to check out.
+  const args = ["ls-files", "-z", "--cached", "--others", "--exclude-standard"] as string[];
   if (pathspec) {
     args.push("--", pathspec);
   }
@@ -160,9 +214,8 @@ async function loadGitFiles(cwd: string): Promise<string[]> {
   const prefix = pathspec ? `${pathspec.replace(/\/$/, "")}/` : "";
 
   const files = output
-    .split("\n")
-    .map((line) => line.trim())
-    .filter(Boolean)
+    .split("\0")
+    .filter((p) => p.length > 0)
     .map((p) => (prefix && p.startsWith(prefix) ? p.slice(prefix.length) : p))
     .filter((p) => p.length > 0);
 
@@ -202,6 +255,8 @@ function splitCamelCase(name: string): string[] {
   return name
     .replace(/([a-z])([A-Z])/g, "$1 $2")
     .replace(/([A-Z]+)([A-Z][a-z])/g, "$1 $2")
+    .replace(/([a-zA-Z])([0-9])/g, "$1 $2")
+    .replace(/([0-9])([a-zA-Z])/g, "$1 $2")
     .split(/[\s_\-./]+/)
     .filter(Boolean)
     .map((w) => w.toLowerCase());
@@ -217,7 +272,11 @@ function scorePathNaturalLanguage(tokens: string[], file: string): number | null
 
   let matched = 0;
   for (const token of tokens) {
-    if (words.some((w) => w === token || w.startsWith(token) || token.startsWith(w))) {
+    if (
+      words.some(
+        (w) => w === token || (token.length >= 3 && (w.startsWith(token) || token.startsWith(w)))
+      )
+    ) {
       matched++;
     }
   }
@@ -256,9 +315,9 @@ export class FileSearchService {
       const resolvedCwd = path.resolve(payload.cwd);
       const limit = clampInt(payload.limit, 1, 100, MAX_RESULTS_DEFAULT);
 
-      const files = await this.getFiles(resolvedCwd);
+      const entry = await this.getFiles(resolvedCwd);
 
-      return pickTopMatches(files, payload.query, limit);
+      return pickTopMatches(entry, payload.query, limit);
     } catch {
       return [];
     }
@@ -273,9 +332,9 @@ export class FileSearchService {
       const resolvedCwd = path.resolve(payload.cwd);
       const limit = clampInt(payload.limit, 1, 100, 20);
 
-      const files = await this.getFiles(resolvedCwd);
+      const entry = await this.getFiles(resolvedCwd);
 
-      return pickTopNaturalLanguageMatches(files, payload.description, limit);
+      return pickTopNaturalLanguageMatches(entry.files, payload.description, limit);
     } catch {
       return [];
     }
@@ -310,10 +369,10 @@ export class FileSearchService {
     return loadFilesFromDisk(cwd);
   }
 
-  private async getFiles(resolvedCwd: string): Promise<string[]> {
+  private async getFiles(resolvedCwd: string): Promise<FileListCacheEntry> {
     const cached = FILE_LIST_CACHE.get(resolvedCwd);
     if (cached) {
-      return cached.files;
+      return cached;
     }
 
     const existing = FILE_LIST_IN_FLIGHT.get(resolvedCwd);
@@ -322,12 +381,14 @@ export class FileSearchService {
     }
 
     const epoch = FILE_LIST_EPOCHS.get(resolvedCwd) ?? 0;
-    const loadPromise = this.loadFileList(resolvedCwd)
+    const loadPromise: Promise<FileListCacheEntry> = this.loadFileList(resolvedCwd)
       .then((loaded) => {
+        const sortedFiles = [...loaded].sort((a, b) => a.length - b.length || a.localeCompare(b));
+        const entry: FileListCacheEntry = { files: loaded, sortedFiles };
         if ((FILE_LIST_EPOCHS.get(resolvedCwd) ?? 0) === epoch) {
-          FILE_LIST_CACHE.set(resolvedCwd, { files: loaded });
+          FILE_LIST_CACHE.set(resolvedCwd, entry);
         }
-        return loaded;
+        return entry;
       })
       .finally(() => {
         if (FILE_LIST_IN_FLIGHT.get(resolvedCwd) === loadPromise) {

--- a/electron/services/FileSearchService.ts
+++ b/electron/services/FileSearchService.ts
@@ -274,7 +274,9 @@ function scorePathNaturalLanguage(tokens: string[], file: string): number | null
   for (const token of tokens) {
     if (
       words.some(
-        (w) => w === token || (token.length >= 3 && (w.startsWith(token) || token.startsWith(w)))
+        (w) =>
+          w === token ||
+          (token.length >= 3 && w.length >= 3 && (w.startsWith(token) || token.startsWith(w)))
       )
     ) {
       matched++;
@@ -293,7 +295,8 @@ function pickTopNaturalLanguageMatches(
   const rawTokens = description
     .toLowerCase()
     .split(/\s+/)
-    .filter((t) => t.length > 0 && !NL_STOP_WORDS.has(t));
+    .filter((t) => t.length > 0 && !NL_STOP_WORDS.has(t))
+    .flatMap((t) => splitCamelCase(t));
 
   if (rawTokens.length === 0) return [];
 

--- a/electron/services/VoiceFileLinkResolver.ts
+++ b/electron/services/VoiceFileLinkResolver.ts
@@ -90,13 +90,19 @@ export class VoiceFileLinkResolver {
     const words = nameWithoutExt
       .replace(/([a-z])([A-Z])/g, "$1 $2")
       .replace(/([A-Z]+)([A-Z][a-z])/g, "$1 $2")
+      .replace(/([a-zA-Z])([0-9])/g, "$1 $2")
+      .replace(/([0-9])([a-zA-Z])/g, "$1 $2")
       .split(/[\s_\-./]+/)
       .filter(Boolean)
       .map((w) => w.toLowerCase());
 
     let matched = 0;
     for (const token of tokens) {
-      if (words.some((w) => w === token || w.startsWith(token) || token.startsWith(w))) {
+      if (
+        words.some(
+          (w) => w === token || (token.length >= 3 && (w.startsWith(token) || token.startsWith(w)))
+        )
+      ) {
         matched++;
       }
     }

--- a/electron/services/VoiceFileLinkResolver.ts
+++ b/electron/services/VoiceFileLinkResolver.ts
@@ -77,7 +77,14 @@ export class VoiceFileLinkResolver {
     return description
       .toLowerCase()
       .split(/\s+/)
-      .filter((t) => t.length > 0 && !stopWords.has(t));
+      .filter((t) => t.length > 0 && !stopWords.has(t))
+      .flatMap((t) =>
+        t
+          .replace(/([a-z])([0-9])/g, "$1 $2")
+          .replace(/([0-9])([a-z])/g, "$1 $2")
+          .split(/[\s_\-./]+/)
+          .filter(Boolean)
+      );
   }
 
   private computeScore(description: string, file: string): number | null {
@@ -100,7 +107,9 @@ export class VoiceFileLinkResolver {
     for (const token of tokens) {
       if (
         words.some(
-          (w) => w === token || (token.length >= 3 && (w.startsWith(token) || token.startsWith(w)))
+          (w) =>
+            w === token ||
+            (token.length >= 3 && w.length >= 3 && (w.startsWith(token) || token.startsWith(w)))
         )
       ) {
         matched++;

--- a/electron/services/__tests__/FileSearchService.adversarial.test.ts
+++ b/electron/services/__tests__/FileSearchService.adversarial.test.ts
@@ -67,7 +67,7 @@ describe("FileSearchService adversarial", () => {
     const checkDeferred = createDeferred<boolean>();
     gitClient.checkIsRepo.mockReturnValue(checkDeferred.promise);
     gitClient.revparse.mockResolvedValue(`${dir}\n`);
-    gitClient.raw.mockResolvedValue("README.md\nsrc/main.ts\n");
+    gitClient.raw.mockResolvedValue("README.md\0src/main.ts\0");
     createHardenedGitMock.mockReturnValue(gitClient);
 
     const service = await createService();
@@ -88,14 +88,14 @@ describe("FileSearchService adversarial", () => {
     const rawDeferred = createDeferred<string>();
     gitClient.checkIsRepo.mockResolvedValue(true);
     gitClient.revparse.mockResolvedValue(`${dir}\n`);
-    gitClient.raw.mockReturnValueOnce(rawDeferred.promise).mockResolvedValueOnce("beta.ts\n");
+    gitClient.raw.mockReturnValueOnce(rawDeferred.promise).mockResolvedValueOnce("beta.ts\0");
     createHardenedGitMock.mockReturnValue(gitClient);
 
     const service = await createService();
     const first = service.search({ cwd: dir, query: "alpha", limit: 5 });
 
     service.invalidate(dir);
-    rawDeferred.resolve("alpha.ts\n");
+    rawDeferred.resolve("alpha.ts\0");
 
     await expect(first).resolves.toEqual(["alpha.ts"]);
     await expect(service.search({ cwd: dir, query: "beta", limit: 5 })).resolves.toEqual([
@@ -143,7 +143,7 @@ describe("FileSearchService adversarial", () => {
     fs.mkdirSync(cwd, { recursive: true });
 
     const repoClient = createGitClient();
-    repoClient.raw.mockResolvedValue("packages/app/src/main.ts\npackages/app/src/utils.ts\n");
+    repoClient.raw.mockResolvedValue("packages/app/src/main.ts\0packages/app/src/utils.ts\0");
     const cwdClient = createGitClient();
     cwdClient.checkIsRepo.mockResolvedValue(true);
     cwdClient.revparse.mockResolvedValue(`${repoRoot}\n`);
@@ -161,6 +161,7 @@ describe("FileSearchService adversarial", () => {
     expect(result).toEqual(["src/main.ts"]);
     expect(repoClient.raw).toHaveBeenCalledWith([
       "ls-files",
+      "-z",
       "--cached",
       "--others",
       "--exclude-standard",
@@ -199,7 +200,7 @@ describe("FileSearchService adversarial", () => {
     const gitClient = createGitClient();
     gitClient.checkIsRepo.mockResolvedValue(true);
     gitClient.revparse.mockResolvedValue(`${dir}\n`);
-    gitClient.raw.mockResolvedValue("a.ts\nsrc/index.ts\npkg/tool.ts\n");
+    gitClient.raw.mockResolvedValue("a.ts\0src/index.ts\0pkg/tool.ts\0");
     createHardenedGitMock.mockReturnValue(gitClient);
 
     const service = await createService();
@@ -219,5 +220,45 @@ describe("FileSearchService adversarial", () => {
       "pkg/tool.ts",
       "src/index.ts",
     ]);
+  });
+
+  it("skips well-known noise dirs in the fallback walker", async () => {
+    const dir = fs.mkdtempSync(path.join(os.tmpdir(), "file-search-adv-"));
+    tempDirs.push(dir);
+    createHardenedGitMock.mockReturnValue(createGitClient());
+
+    writeFile(path.join(dir, "src", "real.ts"));
+    writeFile(path.join(dir, "dist", "bundle.js"));
+    writeFile(path.join(dir, ".next", "page.js"));
+    writeFile(path.join(dir, ".cache", "blob.bin"));
+    writeFile(path.join(dir, "__pycache__", "mod.pyc"));
+    writeFile(path.join(dir, "coverage", "report.html"));
+
+    const service = await createService();
+    const result = await service.search({ cwd: dir, query: "", limit: 99 });
+
+    expect(result).toContain("src/real.ts");
+    expect(result.some((p) => p.startsWith("dist"))).toBe(false);
+    expect(result.some((p) => p.startsWith(".next"))).toBe(false);
+    expect(result.some((p) => p.startsWith(".cache"))).toBe(false);
+    expect(result.some((p) => p.startsWith("__pycache__"))).toBe(false);
+    expect(result.some((p) => p.startsWith("coverage"))).toBe(false);
+  });
+
+  it("normalises NFD filenames to NFC in the fallback walker", async () => {
+    const dir = fs.mkdtempSync(path.join(os.tmpdir(), "file-search-adv-"));
+    tempDirs.push(dir);
+    createHardenedGitMock.mockReturnValue(createGitClient());
+
+    // "café.ts" using NFD: e + combining acute (́)
+    const nfdName = "café.ts";
+    writeFile(path.join(dir, nfdName));
+
+    const service = await createService();
+    const result = await service.search({ cwd: dir, query: "", limit: 5 });
+
+    // Result should be NFC form (single composed é = é)
+    expect(result).toContain("café.ts");
+    expect(result).not.toContain(nfdName);
   });
 });

--- a/electron/services/__tests__/FileSearchService.test.ts
+++ b/electron/services/__tests__/FileSearchService.test.ts
@@ -93,7 +93,7 @@ describe("FileSearchService", () => {
     tempDirs.push(dir);
     gitClientMock.checkIsRepo.mockResolvedValue(true);
     gitClientMock.revparse.mockResolvedValue(`${dir}\n`);
-    gitClientMock.raw.mockResolvedValue("README.md\nsrc/main.ts\nsrc/components/Button.tsx\n");
+    gitClientMock.raw.mockResolvedValue("README.md\0src/main.ts\0src/components/Button.tsx\0");
 
     const service = await createService();
     const result = await service.search({ cwd: dir, query: "read", limit: 5 });
@@ -107,7 +107,7 @@ describe("FileSearchService", () => {
     tempDirs.push(dir);
     gitClientMock.checkIsRepo.mockResolvedValue(true);
     gitClientMock.revparse.mockResolvedValue(`${dir}\n`);
-    gitClientMock.raw.mockResolvedValue("src/components/Button.tsx\nsrc/components/Input.tsx\n");
+    gitClientMock.raw.mockResolvedValue("src/components/Button.tsx\0src/components/Input.tsx\0");
 
     const service = await createService();
     const result = await service.search({ cwd: dir, query: "./src//components//button", limit: 5 });
@@ -120,7 +120,7 @@ describe("FileSearchService", () => {
     tempDirs.push(dir);
     gitClientMock.checkIsRepo.mockResolvedValue(true);
     gitClientMock.revparse.mockResolvedValue(`${dir}\n`);
-    gitClientMock.raw.mockResolvedValue("README.md\nsrc/main.ts\npackage.json\n");
+    gitClientMock.raw.mockResolvedValue("README.md\0src/main.ts\0package.json\0");
 
     const service = await createService();
     const first = await service.search({ cwd: dir, query: "src", limit: 5 });
@@ -137,7 +137,7 @@ describe("FileSearchService", () => {
     tempDirs.push(dir);
     gitClientMock.checkIsRepo.mockResolvedValue(true);
     gitClientMock.revparse.mockResolvedValue(`${dir}\n`);
-    gitClientMock.raw.mockResolvedValue("src/components/Button.tsx\na.ts\nREADME.md\n");
+    gitClientMock.raw.mockResolvedValue("src/components/Button.tsx\0a.ts\0README.md\0");
 
     const service = await createService();
     const result = await service.search({ cwd: dir, query: "", limit: 3 });
@@ -152,7 +152,7 @@ describe("FileSearchService", () => {
       gitClientMock.checkIsRepo.mockResolvedValue(true);
       gitClientMock.revparse.mockResolvedValue(`${dir}\n`);
       gitClientMock.raw.mockResolvedValue(
-        "src/components/HybridInputBar.tsx\nsrc/components/Button.tsx\nsrc/App.tsx\n"
+        "src/components/HybridInputBar.tsx\0src/components/Button.tsx\0src/App.tsx\0"
       );
 
       const service = await createService();
@@ -171,7 +171,7 @@ describe("FileSearchService", () => {
       gitClientMock.checkIsRepo.mockResolvedValue(true);
       gitClientMock.revparse.mockResolvedValue(`${dir}\n`);
       gitClientMock.raw.mockResolvedValue(
-        "src/components/AppLayout.tsx\nsrc/App.tsx\nsrc/layout/Sidebar.tsx\n"
+        "src/components/AppLayout.tsx\0src/App.tsx\0src/layout/Sidebar.tsx\0"
       );
 
       const service = await createService();
@@ -189,7 +189,7 @@ describe("FileSearchService", () => {
       tempDirs.push(dir);
       gitClientMock.checkIsRepo.mockResolvedValue(true);
       gitClientMock.revparse.mockResolvedValue(`${dir}\n`);
-      gitClientMock.raw.mockResolvedValue("src/App.tsx\n");
+      gitClientMock.raw.mockResolvedValue("src/App.tsx\0");
 
       const service = await createService();
       const result = await service.searchNaturalLanguage({
@@ -206,7 +206,7 @@ describe("FileSearchService", () => {
       tempDirs.push(dir);
       gitClientMock.checkIsRepo.mockResolvedValue(true);
       gitClientMock.revparse.mockResolvedValue(`${dir}\n`);
-      gitClientMock.raw.mockResolvedValue("src/App.tsx\n");
+      gitClientMock.raw.mockResolvedValue("src/App.tsx\0");
 
       const service = await createService();
       const result = await service.searchNaturalLanguage({
@@ -223,7 +223,7 @@ describe("FileSearchService", () => {
       tempDirs.push(dir);
       gitClientMock.checkIsRepo.mockResolvedValue(true);
       gitClientMock.revparse.mockResolvedValue(`${dir}\n`);
-      gitClientMock.raw.mockResolvedValue("src/app/App.tsx\n");
+      gitClientMock.raw.mockResolvedValue("src/app/App.tsx\0");
 
       const service = await createService();
       const result = await service.searchNaturalLanguage({
@@ -242,7 +242,7 @@ describe("FileSearchService", () => {
       gitClientMock.checkIsRepo.mockResolvedValue(true);
       gitClientMock.revparse.mockResolvedValue(`${dir}\n`);
       gitClientMock.raw.mockResolvedValue(
-        "src/voice_recording_service.ts\nsrc/file-search-service.ts\nsrc/other.ts\n"
+        "src/voice_recording_service.ts\0src/file-search-service.ts\0src/other.ts\0"
       );
 
       const service = await createService();
@@ -253,6 +253,73 @@ describe("FileSearchService", () => {
       });
 
       expect(result[0]).toBe("src/voice_recording_service.ts");
+    });
+
+    it("does not match short tokens against unrelated longer words", async () => {
+      const dir = makeTempDir();
+      tempDirs.push(dir);
+      gitClientMock.checkIsRepo.mockResolvedValue(true);
+      gitClientMock.revparse.mockResolvedValue(`${dir}\n`);
+      gitClientMock.raw.mockResolvedValue("src/useEffect.tsx\0src/UserSettings.tsx\0");
+
+      const service = await createService();
+      const result = await service.searchNaturalLanguage({
+        cwd: dir,
+        description: "us settings",
+        limit: 5,
+      });
+
+      // "us" is short and must not loose-match "useEffect"; only "settings" matches
+      // "Settings" in UserSettings (1/2 = 0.5 score), useEffect has no matches.
+      expect(result).toEqual(["src/UserSettings.tsx"]);
+    });
+
+    it("splits digit boundaries so S3Client matches 's3 client'", async () => {
+      const dir = makeTempDir();
+      tempDirs.push(dir);
+      gitClientMock.checkIsRepo.mockResolvedValue(true);
+      gitClientMock.revparse.mockResolvedValue(`${dir}\n`);
+      gitClientMock.raw.mockResolvedValue("src/S3Client.ts\0src/Other.ts\0");
+
+      const service = await createService();
+      const result = await service.searchNaturalLanguage({
+        cwd: dir,
+        description: "s3 client",
+        limit: 5,
+      });
+
+      expect(result[0]).toBe("src/S3Client.ts");
+    });
+  });
+
+  describe("git ls-files NUL handling", () => {
+    it("preserves filenames containing newlines and tabs via NUL-delimited output", async () => {
+      const dir = makeTempDir();
+      tempDirs.push(dir);
+      gitClientMock.checkIsRepo.mockResolvedValue(true);
+      gitClientMock.revparse.mockResolvedValue(`${dir}\n`);
+      gitClientMock.raw.mockResolvedValue("src/weird\nname.ts\0src/with\ttab.ts\0clean.ts\0");
+
+      const service = await createService();
+      const result = await service.search({ cwd: dir, query: "", limit: 99 });
+
+      expect(result).toContain("src/weird\nname.ts");
+      expect(result).toContain("src/with\ttab.ts");
+      expect(result).toContain("clean.ts");
+    });
+
+    it("passes -z to git ls-files", async () => {
+      const dir = makeTempDir();
+      tempDirs.push(dir);
+      gitClientMock.checkIsRepo.mockResolvedValue(true);
+      gitClientMock.revparse.mockResolvedValue(`${dir}\n`);
+      gitClientMock.raw.mockResolvedValue("a.ts\0");
+
+      const service = await createService();
+      await service.search({ cwd: dir, query: "a", limit: 5 });
+
+      const callArgs = gitClientMock.raw.mock.calls[0][0];
+      expect(callArgs).toContain("-z");
     });
   });
 });

--- a/electron/services/__tests__/FileSearchService.test.ts
+++ b/electron/services/__tests__/FileSearchService.test.ts
@@ -290,6 +290,46 @@ describe("FileSearchService", () => {
 
       expect(result[0]).toBe("src/S3Client.ts");
     });
+
+    it("ranks S3Client.ts above Client.ts when query is 's3 client'", async () => {
+      const dir = makeTempDir();
+      tempDirs.push(dir);
+      gitClientMock.checkIsRepo.mockResolvedValue(true);
+      gitClientMock.revparse.mockResolvedValue(`${dir}\n`);
+      gitClientMock.raw.mockResolvedValue("src/Client.ts\0src/S3Client.ts\0");
+
+      const service = await createService();
+      const result = await service.searchNaturalLanguage({
+        cwd: dir,
+        description: "s3 client",
+        limit: 5,
+      });
+
+      // Without query-side digit splitting, "s3" never matches and Client.ts
+      // ties or beats S3Client.ts on path length. After the fix, query tokens
+      // become ["s", "3", "client"] which fully match S3Client's words.
+      expect(result[0]).toBe("src/S3Client.ts");
+    });
+
+    it("ranks AppLayout.tsx above ALayout.tsx when query is 'app layout'", async () => {
+      const dir = makeTempDir();
+      tempDirs.push(dir);
+      gitClientMock.checkIsRepo.mockResolvedValue(true);
+      gitClientMock.revparse.mockResolvedValue(`${dir}\n`);
+      gitClientMock.raw.mockResolvedValue("src/ALayout.tsx\0src/AppLayout.tsx\0");
+
+      const service = await createService();
+      const result = await service.searchNaturalLanguage({
+        cwd: dir,
+        description: "app layout",
+        limit: 5,
+      });
+
+      // Without the word-length guard, "app".startsWith("a") would falsely
+      // match ALayout's "a" word, tying it with AppLayout and winning on
+      // pathLen. The w.length >= 3 guard suppresses these false positives.
+      expect(result[0]).toBe("src/AppLayout.tsx");
+    });
   });
 
   describe("git ls-files NUL handling", () => {

--- a/electron/services/__tests__/VoiceFileLinkResolver.test.ts
+++ b/electron/services/__tests__/VoiceFileLinkResolver.test.ts
@@ -210,4 +210,22 @@ describe("VoiceFileLinkResolver", () => {
 
     expect(result).toBeNull();
   });
+
+  it("does not high-confidence-match short tokens against longer words", async () => {
+    // Before the >=3 length gate, "us ef" prefix-matched both "use" and "effect"
+    // in useEffect.tsx → score 1.0, returned directly. After the gate, neither
+    // 2-char token matches → falls through to AI rerank.
+    searchNaturalLanguageMock.mockResolvedValue(["src/useEffect.tsx"]);
+
+    const fetchMock = vi.fn().mockResolvedValue({
+      ok: true,
+      json: async () => ({ output_text: JSON.stringify({ matched_file: null }) }),
+    } as unknown as Response);
+    vi.stubGlobal("fetch", fetchMock);
+
+    const resolver = new VoiceFileLinkResolver();
+    await resolver.resolve({ ...BASE_PAYLOAD, description: "us ef" });
+
+    expect(fetchMock).toHaveBeenCalled();
+  });
 });


### PR DESCRIPTION
Fixes #7138.

## Summary

Polishes `electron/services/FileSearchService.ts` (and its duplicated NL logic in `VoiceFileLinkResolver.ts`) across three correctness gaps and a handful of smaller quality items called out in the issue.

### Correctness

- **NUL-delimited git output** — `loadGitFiles` now passes `-z` to `git ls-files` and splits on `\0` instead of `\n`, so paths containing tabs, newlines, or backslashes round-trip cleanly. `core.quotepath=false` only suppresses high-bit quoting; without `-z`, those characters silently corrupted the file list.
- **Wider fallback skip-list + NFC normalization** — the fallback walker now skips a canonical set of build-output and tooling directories (\`dist\`, \`build\`, \`out\`, \`.next\`, \`.cache\`, \`__pycache__\`, \`.venv\`, \`coverage\`, etc.) and normalizes paths to NFC. Git mode is unchanged because \`--exclude-standard\` already honours \`.gitignore\`, and \`core.precomposeunicode=true\` already produces NFC paths there.
- **Tier-0 cap log** — when the fallback walker hits its 20,000-entry cap, the truncation now logs once per cwd via `logWarn` instead of being silent.

### Tokeniser & ranking

- **Digit-boundary splitting** in `splitCamelCase` so `S3Client` tokenises as `s/3/client`, plus the same logic mirrored into the duplicated NL scorer in `VoiceFileLinkResolver.computeScore`.
- **Query-side digit splitting** — query tokens go through the same digit-boundary splitting before scoring, so `"s3 client"` actually matches `S3Client.ts` (without this, `s3` was a 2-char token that failed the prefix-match length gate).
- **Length-gated prefix matching** — both directions of the loose prefix match now require `token.length >= 3` AND `w.length >= 3`. `"us"` no longer loose-matches `useEffect`, and `"app"` no longer loose-matches the `a` in `ALayout`. Exact matches are always allowed.

### Performance

- **Sorted-view cache** — the empty-query branch in `pickTopMatches` now reads from a `sortedFiles` array computed once at cache fill instead of re-sorting all entries on every keystroke.
- **Hoisted query trim** — the trailing-slash strip in `scorePath` is now done once per query in `pickTopMatches`, not once per file.

### Comments

- `loadGitFiles` documents why `--recurse-submodules` and skip-worktree filtering are intentionally not used.

## Test plan

- [x] Tests updated and added across `FileSearchService.test.ts`, `FileSearchService.adversarial.test.ts`, and `VoiceFileLinkResolver.test.ts`.
- [x] 35 tests pass locally.
- [x] `npm run check` clean (typecheck, lint, format, build).