### PR TITLE
fix(db-maintenance): use TRUNCATE checkpoint on idle tick and run PRAGMA optimize on dispose

### DIFF
--- a/electron/services/DatabaseMaintenanceService.ts
+++ b/electron/services/DatabaseMaintenanceService.ts
@@ -75,7 +75,7 @@ class DatabaseMaintenanceService {
     await this.runBackup();
     this.optimize();
     this.checkpoint("TRUNCATE");
-    console.log("[DatabaseMaintenance] Disposed — final backup + checkpoint complete");
+    console.log("[DatabaseMaintenance] Disposed — optimize + checkpoint complete");
   }
 
   private tick(): void {

--- a/electron/services/DatabaseMaintenanceService.ts
+++ b/electron/services/DatabaseMaintenanceService.ts
@@ -73,6 +73,7 @@ class DatabaseMaintenanceService {
     // Final backup + TRUNCATE checkpoint (DB is NOT closed here —
     // shutdown.ts may still need it for project state saves afterward)
     await this.runBackup();
+    this.optimize();
     this.checkpoint("TRUNCATE");
     console.log("[DatabaseMaintenance] Disposed — final backup + checkpoint complete");
   }
@@ -89,7 +90,7 @@ class DatabaseMaintenanceService {
     const sqlite = getSharedSqlite();
     if (!sqlite) return;
 
-    this.checkpoint("PASSIVE");
+    this.checkpoint("TRUNCATE");
     this.backupPromise = this.runBackup();
   }
 
@@ -101,6 +102,17 @@ class DatabaseMaintenanceService {
       sqlite.pragma(`wal_checkpoint(${mode})`);
     } catch (error) {
       console.warn(`[DatabaseMaintenance] WAL checkpoint (${mode}) failed:`, error);
+    }
+  }
+
+  private optimize(): void {
+    const sqlite = getSharedSqlite();
+    if (!sqlite) return;
+
+    try {
+      sqlite.pragma("optimize");
+    } catch (error) {
+      console.warn("[DatabaseMaintenance] PRAGMA optimize failed:", error);
     }
   }
 

--- a/electron/services/__tests__/DatabaseMaintenanceService.adversarial.test.ts
+++ b/electron/services/__tests__/DatabaseMaintenanceService.adversarial.test.ts
@@ -123,8 +123,9 @@ describe("DatabaseMaintenanceService adversarial", () => {
 
     expect(mockSqlite.backup).toHaveBeenCalledTimes(2);
     expect(mockSqlite.pragma.mock.calls).toEqual([
-      ["wal_checkpoint(PASSIVE)"],
-      ["wal_checkpoint(PASSIVE)"],
+      ["wal_checkpoint(TRUNCATE)"],
+      ["wal_checkpoint(TRUNCATE)"],
+      ["optimize"],
       ["wal_checkpoint(TRUNCATE)"],
     ]);
     expect(mockSqlite.pragma.mock.invocationCallOrder.at(-1)).toBeGreaterThan(
@@ -190,7 +191,7 @@ describe("DatabaseMaintenanceService adversarial", () => {
 
     expect(mockSqlite.backup).toHaveBeenCalledTimes(1);
     expect(mockSqlite.pragma.mock.calls).toEqual([
-      ["wal_checkpoint(PASSIVE)"],
+      ["wal_checkpoint(TRUNCATE)"],
       ["wal_checkpoint(PASSIVE)"],
     ]);
 

--- a/electron/services/__tests__/DatabaseMaintenanceService.test.ts
+++ b/electron/services/__tests__/DatabaseMaintenanceService.test.ts
@@ -169,6 +169,11 @@ describe("DatabaseMaintenanceService", () => {
     expect(mockSqlite.backup).toHaveBeenCalled();
     expect(mockSqlite.pragma).toHaveBeenCalledWith("optimize");
     expect(mockSqlite.pragma).toHaveBeenCalledWith("wal_checkpoint(TRUNCATE)");
+
+    const backupOrder = mockSqlite.backup.mock.invocationCallOrder.at(-1)!;
+    const [optimizeOrder, truncateOrder] = mockSqlite.pragma.mock.invocationCallOrder.slice(-2);
+    expect(backupOrder).toBeLessThan(optimizeOrder);
+    expect(optimizeOrder).toBeLessThan(truncateOrder);
   });
 
   it("dispose is idempotent", async () => {

--- a/electron/services/__tests__/DatabaseMaintenanceService.test.ts
+++ b/electron/services/__tests__/DatabaseMaintenanceService.test.ts
@@ -130,7 +130,7 @@ describe("DatabaseMaintenanceService", () => {
     // Advance past tick interval (5 minutes)
     vi.advanceTimersByTime(5 * 60 * 1000 + 100);
 
-    expect(mockSqlite.pragma).toHaveBeenCalledWith("wal_checkpoint(PASSIVE)");
+    expect(mockSqlite.pragma).toHaveBeenCalledWith("wal_checkpoint(TRUNCATE)");
     expect(mockSqlite.backup).toHaveBeenCalled();
     void service.dispose();
   });
@@ -167,6 +167,7 @@ describe("DatabaseMaintenanceService", () => {
     await service.dispose();
 
     expect(mockSqlite.backup).toHaveBeenCalled();
+    expect(mockSqlite.pragma).toHaveBeenCalledWith("optimize");
     expect(mockSqlite.pragma).toHaveBeenCalledWith("wal_checkpoint(TRUNCATE)");
   });
 


### PR DESCRIPTION
## Summary
- The 5-minute idle tick now runs `wal_checkpoint(TRUNCATE)` instead of `PASSIVE`, producing smaller backup artifacts and faster restores.
- `PRAGMA optimize` runs on dispose so the SQLite planner starts the next session with fresh statistics.

Resolves #7103

## Changes
- `DatabaseMaintenanceService.ts`: tick checkpoint mode changed from `PASSIVE` to `TRUNCATE`; new `optimize()` method called from `dispose()`
- `DatabaseMaintenanceService.test.ts`: updated tick checkpoint assertion and added dispose ordering test (backup before optimize before checkpoint)
- `DatabaseMaintenanceService.adversarial.test.ts`: updated expected PRAGMA call sequences to match the new behavior

## Testing
- Unit tests verify the tick checkpoint mode, the optimize call during dispose, and the correct ordering of backup -> optimize -> checkpoint on dispose
- Adversarial tests updated to match the new PRAGMA call expectations