### PR TITLE
fix(sounds): remove stale .wav files before regeneration

### DIFF
--- a/scripts/generate-sounds.mjs
+++ b/scripts/generate-sounds.mjs
@@ -10,6 +10,7 @@
  */
 
 import { writeFileSync, mkdirSync } from "fs";
+import { cleanupStaleWavs } from "./sound-cleanup.mjs";
 import { join, dirname } from "path";
 import { fileURLToPath } from "url";
 
@@ -1421,7 +1422,7 @@ const staticSounds = {
 for (const [name, samples] of Object.entries(staticSounds)) {
   const filePath = join(outDir, `${name}.wav`);
   writeWav(samples, filePath);
-  const sizeKB = (Buffer.byteLength(Buffer.alloc(44 + samples.length * 2)) / 1024).toFixed(1);
+  const sizeKB = ((44 + samples.length * 2) / 1024).toFixed(1);
   const durationMs = ((samples.length / SAMPLE_RATE) * 1000).toFixed(0);
   console.log(`  ${name}.wav  ${durationMs}ms  ${sizeKB}KB`);
 }
@@ -1440,6 +1441,19 @@ const variantGenerators = {
   "context-injected": genContextInjected,
 };
 
+// Build expected filename set and remove any stale .wav files before regeneration
+const expectedFilenames = new Set();
+for (const name of Object.keys(staticSounds)) {
+  expectedFilenames.add(`${name}.wav`);
+}
+for (const name of Object.keys(variantGenerators)) {
+  expectedFilenames.add(`${name}.wav`);
+  for (let v = 1; v < VARIANT_COUNT; v++) {
+    expectedFilenames.add(`${name}.v${v}.wav`);
+  }
+}
+cleanupStaleWavs(outDir, expectedFilenames);
+
 for (const [name, generator] of Object.entries(variantGenerators)) {
   for (let v = 0; v < VARIANT_COUNT; v++) {
     // Each variant gets a unique seed offset so the PRNG produces different
@@ -1450,7 +1464,7 @@ for (const [name, generator] of Object.entries(variantGenerators)) {
     const suffix = v === 0 ? "" : `.v${v}`;
     const filePath = join(outDir, `${name}${suffix}.wav`);
     writeWav(samples, filePath);
-    const sizeKB = (Buffer.byteLength(Buffer.alloc(44 + samples.length * 2)) / 1024).toFixed(1);
+    const sizeKB = ((44 + samples.length * 2) / 1024).toFixed(1);
     const durationMs = ((samples.length / SAMPLE_RATE) * 1000).toFixed(0);
     console.log(`  ${name}${suffix}.wav  ${durationMs}ms  ${sizeKB}KB`);
   }

--- a/scripts/sound-cleanup.mjs
+++ b/scripts/sound-cleanup.mjs
@@ -1,0 +1,16 @@
+import { readdirSync, unlinkSync } from "fs";
+import { join } from "path";
+
+export function cleanupStaleWavs(outDir, expectedFilenames) {
+  const entries = readdirSync(outDir, { withFileTypes: true });
+  let removed = 0;
+  for (const entry of entries) {
+    if (entry.isFile() && entry.name.endsWith(".wav") && !expectedFilenames.has(entry.name)) {
+      unlinkSync(join(outDir, entry.name));
+      removed++;
+    }
+  }
+  if (removed > 0) {
+    console.log(`  Removed ${removed} stale .wav file${removed > 1 ? "s" : ""}`);
+  }
+}

--- a/scripts/sound-cleanup.test.ts
+++ b/scripts/sound-cleanup.test.ts
@@ -4,7 +4,7 @@ import { join } from "path";
 import { tmpdir } from "os";
 import { cleanupStaleWavs } from "./sound-cleanup.mjs";
 
-let tempDirs: string[] = [];
+const tempDirs: string[] = [];
 
 function makeTempDir() {
   const dir = mkdtempSync(join(realpathSync(tmpdir()), "sound-cleanup-test-"));

--- a/scripts/sound-cleanup.test.ts
+++ b/scripts/sound-cleanup.test.ts
@@ -1,0 +1,121 @@
+import { describe, it, expect, afterEach } from "vitest";
+import { mkdirSync, mkdtempSync, writeFileSync, readdirSync, realpathSync, rmSync } from "fs";
+import { join } from "path";
+import { tmpdir } from "os";
+import { cleanupStaleWavs } from "./sound-cleanup.mjs";
+
+let tempDirs: string[] = [];
+
+function makeTempDir() {
+  const dir = mkdtempSync(join(realpathSync(tmpdir()), "sound-cleanup-test-"));
+  tempDirs.push(dir);
+  return dir;
+}
+
+afterEach(() => {
+  for (const dir of tempDirs.splice(0)) {
+    rmSync(dir, { recursive: true, force: true });
+  }
+});
+
+function touch(dir: string, name: string) {
+  writeFileSync(join(dir, name), "");
+}
+
+function listFiles(dir: string): string[] {
+  return readdirSync(dir, { withFileTypes: true })
+    .filter((d) => d.isFile())
+    .map((d) => d.name);
+}
+
+describe("cleanupStaleWavs", () => {
+  it("deletes orphaned .wav files not in the expected set", () => {
+    const dir = makeTempDir();
+    touch(dir, "error.wav");
+    touch(dir, "stale-orphan.wav");
+    const expected = new Set(["error.wav", "chime.wav", "chime.v1.wav"]);
+
+    cleanupStaleWavs(dir, expected);
+
+    expect(listFiles(dir).sort()).toEqual(["error.wav"]);
+  });
+
+  it("preserves all expected .wav files", () => {
+    const dir = makeTempDir();
+    touch(dir, "error.wav");
+    touch(dir, "chime.wav");
+    touch(dir, "chime.v1.wav");
+    touch(dir, "chime.v2.wav");
+    const expected = new Set(["error.wav", "chime.wav", "chime.v1.wav", "chime.v2.wav"]);
+
+    cleanupStaleWavs(dir, expected);
+
+    expect(listFiles(dir).sort()).toEqual([
+      "chime.v1.wav",
+      "chime.v2.wav",
+      "chime.wav",
+      "error.wav",
+    ]);
+  });
+
+  it("preserves non-.wav files", () => {
+    const dir = makeTempDir();
+    touch(dir, "error.wav");
+    touch(dir, ".gitkeep");
+    touch(dir, "notes.txt");
+    const expected = new Set(["error.wav"]);
+
+    cleanupStaleWavs(dir, expected);
+
+    expect(listFiles(dir).sort()).toEqual([".gitkeep", "error.wav", "notes.txt"]);
+  });
+
+  it("preserves files with .wav-like extension but different case (.Wav)", () => {
+    const dir = makeTempDir();
+    touch(dir, "error.Wav");
+    touch(dir, "chime.wav");
+    const expected = new Set(["chime.wav"]);
+
+    cleanupStaleWavs(dir, expected);
+
+    // error.Wav does not end with lowercase ".wav" — should be preserved
+    expect(listFiles(dir).sort()).toEqual(["chime.wav", "error.Wav"]);
+  });
+
+  it("does not unlink a directory named something.wav", () => {
+    const dir = makeTempDir();
+    mkdirSync(join(dir, "trap.wav"));
+    touch(dir, "error.wav");
+    const expected = new Set(["error.wav"]);
+
+    // should not throw
+    cleanupStaleWavs(dir, expected);
+
+    const entries = readdirSync(dir, { withFileTypes: true });
+    const dirs = entries.filter((d) => d.isDirectory()).map((d) => d.name);
+    expect(dirs).toContain("trap.wav");
+  });
+
+  it("is idempotent — running twice has the same result", () => {
+    const dir = makeTempDir();
+    touch(dir, "error.wav");
+    touch(dir, "chime.wav");
+    const expected = new Set(["chime.wav"]);
+
+    cleanupStaleWavs(dir, expected);
+    cleanupStaleWavs(dir, expected);
+
+    expect(listFiles(dir)).toEqual(["chime.wav"]);
+  });
+
+  it("deletes all .wav when expected set is empty", () => {
+    const dir = makeTempDir();
+    touch(dir, "error.wav");
+    touch(dir, "chime.wav");
+    const expected = new Set<string>();
+
+    cleanupStaleWavs(dir, expected);
+
+    expect(listFiles(dir)).toEqual([]);
+  });
+});


### PR DESCRIPTION
## Summary
- Adds a cleanup helper that removes stale `.wav` sound files before regeneration so orphaned files from previous runs don't ship to users.
- Fixes wasted `Buffer.alloc` calls in the size calculation.

Resolves #7137

## Changes
- `scripts/sound-cleanup.mjs` — new `cleanupStaleWavs` helper that deletes `.wav` files not in the expected set
- `scripts/sound-cleanup.test.ts` — unit tests covering orphans, idempotency, non-`.wav` preservation, case sensitivity, and directory safety
- `scripts/generate-sounds.mjs` — builds the expected filename set before generation, calls the cleanup helper, and replaces `Buffer.byteLength(Buffer.alloc(...))` with a direct size computation

## Testing
- Unit tests pass for the cleanup helper (7 test cases)
- `npm run generate-sounds` verified locally — stale files are removed and expected files are generated correctly