### PR TITLE
fix(persistence): force IMMEDIATE transaction mode on write-only db.transaction calls

### DIFF
--- a/electron/services/ProjectStore.ts
+++ b/electron/services/ProjectStore.ts
@@ -536,31 +536,34 @@ export class ProjectStore {
           now
         );
 
-    db.transaction((tx) => {
-      if (previousProjectId && previousProjectId !== projectId) {
-        console.log(`[ProjectStore] Marking previous project ${previousProjectId} as background`);
-        tx.update(projectsTable)
-          .set({ status: "background" })
-          .where(eq(projectsTable.id, previousProjectId))
+    db.transaction(
+      (tx) => {
+        if (previousProjectId && previousProjectId !== projectId) {
+          console.log(`[ProjectStore] Marking previous project ${previousProjectId} as background`);
+          tx.update(projectsTable)
+            .set({ status: "background" })
+            .where(eq(projectsTable.id, previousProjectId))
+            .run();
+        }
+        tx.insert(appStateTable)
+          .values({ key: "currentProjectId", value: projectId })
+          .onConflictDoUpdate({ target: appStateTable.key, set: { value: projectId } })
           .run();
-      }
-      tx.insert(appStateTable)
-        .values({ key: "currentProjectId", value: projectId })
-        .onConflictDoUpdate({ target: appStateTable.key, set: { value: projectId } })
-        .run();
-      const activeUpdate: {
-        status: "active";
-        lastOpened?: number;
-        frecencyScore?: number;
-        lastAccessedAt?: number;
-      } = { status: "active" };
-      if (!writesSuppressed && newScore !== null) {
-        activeUpdate.lastOpened = now;
-        activeUpdate.frecencyScore = newScore;
-        activeUpdate.lastAccessedAt = now;
-      }
-      tx.update(projectsTable).set(activeUpdate).where(eq(projectsTable.id, projectId)).run();
-    });
+        const activeUpdate: {
+          status: "active";
+          lastOpened?: number;
+          frecencyScore?: number;
+          lastAccessedAt?: number;
+        } = { status: "active" };
+        if (!writesSuppressed && newScore !== null) {
+          activeUpdate.lastOpened = now;
+          activeUpdate.frecencyScore = newScore;
+          activeUpdate.lastAccessedAt = now;
+        }
+        tx.update(projectsTable).set(activeUpdate).where(eq(projectsTable.id, projectId)).run();
+      },
+      { behavior: "immediate" }
+    );
 
     if (process.env.DAINTREE_VERBOSE) {
       const updatedPrevious = previousProjectId ? this.getProjectById(previousProjectId) : null;

--- a/electron/services/ScratchStore.ts
+++ b/electron/services/ScratchStore.ts
@@ -228,19 +228,22 @@ export class ScratchStore {
     }
     const now = Date.now();
     const db = getSharedDb();
-    db.transaction((tx) => {
-      tx.insert(appStateTable)
-        .values({ key: CURRENT_SCRATCH_KEY, value: scratchId })
-        .onConflictDoUpdate({
-          target: appStateTable.key,
-          set: { value: scratchId },
-        })
-        .run();
-      tx.update(scratchesTable)
-        .set({ lastOpened: now })
-        .where(eq(scratchesTable.id, scratchId))
-        .run();
-    });
+    db.transaction(
+      (tx) => {
+        tx.insert(appStateTable)
+          .values({ key: CURRENT_SCRATCH_KEY, value: scratchId })
+          .onConflictDoUpdate({
+            target: appStateTable.key,
+            set: { value: scratchId },
+          })
+          .run();
+        tx.update(scratchesTable)
+          .set({ lastOpened: now })
+          .where(eq(scratchesTable.id, scratchId))
+          .run();
+      },
+      { behavior: "immediate" }
+    );
     return { ...scratch, lastOpened: now };
   }
 

--- a/electron/services/__tests__/ProjectStore.diskPressure.test.ts
+++ b/electron/services/__tests__/ProjectStore.diskPressure.test.ts
@@ -230,3 +230,54 @@ describe("ProjectStore disk pressure suppression", () => {
     expect(result.lastAccessedAt ?? 0).toBeGreaterThanOrEqual(seededLastAccessedAt);
   });
 });
+
+describe("ProjectStore transaction mode", () => {
+  let store: ProjectStore;
+  let projectId: string;
+  let seededLastAccessedAt: number;
+  let seededLastOpened: number;
+  const seededFrecencyScore = 7.5;
+
+  beforeEach(async () => {
+    const alphaDir = fs.mkdtempSync(path.join(os.tmpdir(), "daintree-ps-tx-"));
+    const { generateProjectId } = await import("../projectStorePaths.js");
+    const alphaCanonical = await fs.promises.realpath(alphaDir);
+    projectId = generateProjectId(alphaCanonical);
+
+    seededLastAccessedAt = Date.now() - 60_000;
+    seededLastOpened = seededLastAccessedAt;
+
+    sqlite = new Database(":memory:");
+    sqlite.exec(CREATE_TABLES_SQL);
+    db = drizzle(sqlite, { schema });
+
+    db.insert(schema.projects)
+      .values({
+        id: projectId,
+        path: alphaCanonical,
+        name: "Alpha",
+        emoji: "🌲",
+        lastOpened: seededLastOpened,
+        status: "closed",
+        frecencyScore: seededFrecencyScore,
+        lastAccessedAt: seededLastAccessedAt,
+      })
+      .run();
+
+    db.insert(schema.appState).values({ key: "currentProjectId", value: projectId }).run();
+
+    store = new ProjectStore();
+  });
+
+  afterEach(() => {
+    resetWritesSuppressedForTesting();
+    sqlite.close();
+  });
+
+  it("runs setCurrentProject transaction in IMMEDIATE mode", async () => {
+    const spy = vi.spyOn(db, "transaction");
+    await store.setCurrentProject(projectId);
+    expect(spy).toHaveBeenCalledWith(expect.any(Function), { behavior: "immediate" });
+    spy.mockRestore();
+  });
+});

--- a/electron/services/__tests__/ProjectStore.diskPressure.test.ts
+++ b/electron/services/__tests__/ProjectStore.diskPressure.test.ts
@@ -234,15 +234,21 @@ describe("ProjectStore disk pressure suppression", () => {
 describe("ProjectStore transaction mode", () => {
   let store: ProjectStore;
   let projectId: string;
+  let otherProjectId: string;
+  let alphaDir: string;
+  let betaDir: string;
   let seededLastAccessedAt: number;
   let seededLastOpened: number;
   const seededFrecencyScore = 7.5;
 
   beforeEach(async () => {
-    const alphaDir = fs.mkdtempSync(path.join(os.tmpdir(), "daintree-ps-tx-"));
+    alphaDir = fs.mkdtempSync(path.join(os.tmpdir(), "daintree-ps-tx-a-"));
+    betaDir = fs.mkdtempSync(path.join(os.tmpdir(), "daintree-ps-tx-b-"));
     const { generateProjectId } = await import("../projectStorePaths.js");
     const alphaCanonical = await fs.promises.realpath(alphaDir);
+    const betaCanonical = await fs.promises.realpath(betaDir);
     projectId = generateProjectId(alphaCanonical);
+    otherProjectId = generateProjectId(betaCanonical);
 
     seededLastAccessedAt = Date.now() - 60_000;
     seededLastOpened = seededLastAccessedAt;
@@ -264,7 +270,21 @@ describe("ProjectStore transaction mode", () => {
       })
       .run();
 
-    db.insert(schema.appState).values({ key: "currentProjectId", value: projectId }).run();
+    db.insert(schema.projects)
+      .values({
+        id: otherProjectId,
+        path: betaCanonical,
+        name: "Beta",
+        emoji: "🌲",
+        lastOpened: seededLastOpened,
+        status: "active",
+        frecencyScore: 1.0,
+        lastAccessedAt: seededLastAccessedAt,
+      })
+      .run();
+
+    // Seed a different current project so the "mark previous as background" branch fires
+    db.insert(schema.appState).values({ key: "currentProjectId", value: otherProjectId }).run();
 
     store = new ProjectStore();
   });
@@ -272,6 +292,8 @@ describe("ProjectStore transaction mode", () => {
   afterEach(() => {
     resetWritesSuppressedForTesting();
     sqlite.close();
+    fs.rmSync(alphaDir, { recursive: true, force: true });
+    fs.rmSync(betaDir, { recursive: true, force: true });
   });
 
   it("runs setCurrentProject transaction in IMMEDIATE mode", async () => {

--- a/electron/services/__tests__/ScratchStore.test.ts
+++ b/electron/services/__tests__/ScratchStore.test.ts
@@ -1,0 +1,80 @@
+import { describe, it, expect, beforeEach, afterEach, vi } from "vitest";
+import { randomUUID } from "crypto";
+import Database from "better-sqlite3";
+import { drizzle } from "drizzle-orm/better-sqlite3";
+import * as schema from "../persistence/schema.js";
+
+const CREATE_TABLES_SQL = `
+  CREATE TABLE IF NOT EXISTS scratches (
+    id TEXT PRIMARY KEY,
+    path TEXT NOT NULL,
+    name TEXT NOT NULL,
+    created_at INTEGER NOT NULL,
+    last_opened INTEGER NOT NULL,
+    deleted_at INTEGER
+  );
+  CREATE TABLE IF NOT EXISTS app_state (
+    key TEXT PRIMARY KEY,
+    value TEXT NOT NULL
+  );
+`;
+
+let sqlite: Database.Database;
+let db: ReturnType<typeof drizzle<typeof schema>>;
+
+vi.mock("../persistence/db.js", () => ({
+  getSharedDb: () => db,
+  openDb: vi.fn(),
+}));
+
+vi.mock("../scratchStorePaths.js", async () => {
+  const actual =
+    await vi.importActual<typeof import("../scratchStorePaths.js")>("../scratchStorePaths.js");
+  return {
+    ...actual,
+    getScratchDir: (id: string) => `/tmp/daintree-scratch-test/${id}`,
+    getScratchesRoot: () => "/tmp/daintree-scratch-test",
+  };
+});
+
+vi.mock("../../utils/logger.js", () => ({
+  logError: vi.fn(),
+}));
+
+import { ScratchStore } from "../ScratchStore.js";
+
+describe("ScratchStore transaction mode", () => {
+  let store: ScratchStore;
+  let scratchId: string;
+
+  beforeEach(() => {
+    sqlite = new Database(":memory:");
+    sqlite.exec(CREATE_TABLES_SQL);
+    db = drizzle(sqlite, { schema });
+
+    const now = Date.now();
+    scratchId = randomUUID();
+    db.insert(schema.scratches)
+      .values({
+        id: scratchId,
+        path: "/tmp/daintree-scratch-test/" + scratchId,
+        name: "Test Scratch",
+        createdAt: now - 86_400_000,
+        lastOpened: now - 3600_000,
+      })
+      .run();
+
+    store = new ScratchStore();
+  });
+
+  afterEach(() => {
+    sqlite.close();
+  });
+
+  it("runs setCurrentScratch transaction in IMMEDIATE mode", () => {
+    const spy = vi.spyOn(db, "transaction");
+    store.setCurrentScratch(scratchId);
+    expect(spy).toHaveBeenCalledWith(expect.any(Function), { behavior: "immediate" });
+    spy.mockRestore();
+  });
+});

--- a/electron/services/__tests__/TaskPersistence.test.ts
+++ b/electron/services/__tests__/TaskPersistence.test.ts
@@ -276,6 +276,26 @@ describe("TaskPersistence", () => {
     });
   });
 
+  describe("transaction mode", () => {
+    it("runs saveSync in IMMEDIATE transaction", async () => {
+      const spy = vi.spyOn(db, "transaction");
+      await persistence.save(testProjectId, [createTestTask()]);
+      expect(spy).toHaveBeenCalledWith(expect.any(Function), { behavior: "immediate" });
+      spy.mockRestore();
+    });
+
+    it("runs flush in IMMEDIATE transaction when pending save exists", async () => {
+      const slowPersistence = new TaskPersistence(db, 5000);
+      const tasks = [createTestTask()];
+      slowPersistence.save(testProjectId, tasks);
+
+      const spy = vi.spyOn(db, "transaction");
+      await slowPersistence.flush(testProjectId);
+      expect(spy).toHaveBeenCalledWith(expect.any(Function), { behavior: "immediate" });
+      spy.mockRestore();
+    });
+  });
+
   describe("debounce coalescing", () => {
     it("last-write wins when multiple saves are queued for same project", async () => {
       const slowPersistence = new TaskPersistence(db, 5000);

--- a/electron/services/persistence/TaskPersistence.ts
+++ b/electron/services/persistence/TaskPersistence.ts
@@ -156,14 +156,17 @@ export class TaskPersistence {
   }
 
   private saveSync(projectId: string, tasks: TaskRecord[]): void {
-    this.db.transaction((tx) => {
-      tx.delete(schema.tasks).where(eq(schema.tasks.projectId, projectId)).run();
-      if (tasks.length > 0) {
-        tx.insert(schema.tasks)
-          .values(tasks.map((t) => toRow(t, projectId)))
-          .run();
-      }
-    });
+    this.db.transaction(
+      (tx) => {
+        tx.delete(schema.tasks).where(eq(schema.tasks.projectId, projectId)).run();
+        if (tasks.length > 0) {
+          tx.insert(schema.tasks)
+            .values(tasks.map((t) => toRow(t, projectId)))
+            .run();
+        }
+      },
+      { behavior: "immediate" }
+    );
 
     console.log(`[TaskPersistence] Saved ${tasks.length} tasks for project ${projectId}`);
   }


### PR DESCRIPTION
## Summary
- Three `db.transaction` call sites defaulted to DEFERRED mode, which takes a read lock first and upgrades to a write lock on the first write. That upgrade can fail with `SQLITE_BUSY_SNAPSHOT` when parallel writers are active.
- The fix adds `{ behavior: "immediate" }` to each call so the write lock is acquired upfront, before the transaction body runs.
- Tests in `ProjectStore`, `ScratchStore`, and `TaskPersistence` verify the IMMEDIATE parameter is plumbed through.

Resolves #7107

## Changes
- `electron/services/ProjectStore.ts` -- `setCurrentProject` transaction now uses IMMEDIATE mode
- `electron/services/ScratchStore.ts` -- `setCurrentScratch` transaction now uses IMMEDIATE mode
- `electron/services/persistence/TaskPersistence.ts` -- `saveSync` transaction now uses IMMEDIATE mode
- `electron/services/__tests__/ProjectStore.diskPressure.test.ts` -- new test verifying `setCurrentProject` calls `db.transaction` with `{ behavior: "immediate" }`
- `electron/services/__tests__/ScratchStore.test.ts` -- new test file verifying `setCurrentScratch` calls `db.transaction` with `{ behavior: "immediate" }`
- `electron/services/__tests__/TaskPersistence.test.ts` -- new tests verifying `saveSync` and `flush` call `db.transaction` with `{ behavior: "immediate" }`

## Testing
- Unit tests pass for all three stores, each verifying the transaction mode parameter via `vi.spyOn(db, "transaction")`.