### PR TITLE
fix(voice): bound keyterm assembly and clean up race timers

### DIFF
--- a/electron/services/__tests__/voiceContextKeyterms.test.ts
+++ b/electron/services/__tests__/voiceContextKeyterms.test.ts
@@ -160,12 +160,45 @@ describe("assembleKeyterms", () => {
     expect(result.filter((t) => t.toLowerCase() === "daintree").length).toBe(1);
   });
 
-  it("caps at 80 keyterms", async () => {
+  it("caps at 96 keyterms", async () => {
     const dictionary = Array.from({ length: 100 }, (_, i) => `customTerm${i}`);
     const result = await assembleKeyterms({
       customDictionary: dictionary,
     });
-    expect(result.length).toBeLessThanOrEqual(80);
+    expect(result.length).toBe(96);
+  });
+
+  it("caps terminal lines at 200 (tail slice preserves newest content)", async () => {
+    // 4 terminals × 60 lines = 240 total. Identifiers in oldest 40 lines
+    // should be dropped by the 200-line cap.
+    const snapshots = Array.from({ length: 4 }, (_, termIdx) => ({
+      id: `t${termIdx}`,
+      lines: Array.from({ length: 60 }, (_, lineIdx) => {
+        const globalLine = termIdx * 60 + lineIdx;
+        return `term${termIdx}_ident_${globalLine}`;
+      }),
+      lastInputTime: 0,
+      lastOutputTime: 0,
+      lastCheckTime: 0,
+      spawnedAt: 0,
+    }));
+    const ptyClient = {
+      getAllTerminalSnapshots: vi.fn().mockResolvedValue(snapshots),
+    } as unknown as PtyClient;
+    const result = await assembleKeyterms({
+      customDictionary: [],
+      ptyClient,
+    });
+    // Identifiers from first 40 lines (globally 0-39) dropped by tail slice
+    expect(result).not.toContain("term0_ident_0");
+    expect(result).not.toContain("term0_ident_39");
+    // Identifiers from the 200-line window (globally 40+) appear, but cap at 96.
+    // First window identifier is at global line 40; last to fit is at ~line 135.
+    expect(result).toContain("term0_ident_40");
+    expect(result).toContain("term2_ident_132");
+    // Identifiers after the 96 cap (global line > ~135) are excluded
+    expect(result).not.toContain("term2_ident_180");
+    expect(result).not.toContain("term3_ident_239");
   });
 
   it("falls back gracefully when git fails", async () => {

--- a/electron/services/__tests__/voiceContextKeyterms.test.ts
+++ b/electron/services/__tests__/voiceContextKeyterms.test.ts
@@ -240,6 +240,11 @@ describe("assembleKeyterms", () => {
     });
     const customIdx = result.indexOf("CustomFirst");
     const projectIdx = result.indexOf("ProjectSecond");
+    // Branch mock is "feature/auth-login-service" → tokens: feature, auth, login, service
+    const branchIdx = result.indexOf("auth");
+    const terminalIdx = result.indexOf("terminalIdent");
     expect(customIdx).toBeLessThan(projectIdx);
+    expect(projectIdx).toBeLessThan(branchIdx);
+    expect(branchIdx).toBeLessThan(terminalIdx);
   });
 });

--- a/electron/services/voiceContextKeyterms.ts
+++ b/electron/services/voiceContextKeyterms.ts
@@ -299,8 +299,10 @@ export async function assembleKeyterms(opts: KeytermAssemblyOpts): Promise<strin
 
   // Priority 2: Project name tokens
   if (projectName) {
-    // Add the full project name if it's a single meaningful word
-    add(projectName);
+    const trimmed = projectName.trim();
+    if (trimmed.length >= 2 && !/^\d+$/.test(trimmed)) {
+      add(trimmed);
+    }
     for (const token of tokenizeProjectName(projectName)) {
       add(token);
     }

--- a/electron/services/voiceContextKeyterms.ts
+++ b/electron/services/voiceContextKeyterms.ts
@@ -4,9 +4,10 @@ import { logDebug } from "../utils/logger.js";
 
 const P = "[VoiceKeyterms]";
 
-const MAX_KEYTERMS = 80;
+const MAX_KEYTERMS = 96;
 const ASSEMBLY_TIMEOUT_MS = 500;
 const MIN_TERM_LENGTH = 4;
+const MAX_KEYTERM_LINES = 200;
 
 const BLOCKLIST = new Set([
   // Shell commands
@@ -267,7 +268,7 @@ async function getTerminalLines(ptyClient: PtyClient): Promise<string[]> {
     for (const snap of snapshots) {
       allLines.push(...snap.lines);
     }
-    return allLines;
+    return allLines.slice(-MAX_KEYTERM_LINES);
   } catch {
     logDebug(`${P} Failed to get terminal snapshots`);
     return [];
@@ -309,11 +310,13 @@ export async function assembleKeyterms(opts: KeytermAssemblyOpts): Promise<strin
   // Branch tokens run first (Priority 3), then terminal identifiers (Priority 4).
   // We await sequentially to preserve priority ordering for the dedup/cap logic.
   if (projectPath) {
+    let branchTimer: NodeJS.Timeout | undefined;
     try {
-      const branchName = await Promise.race([
-        getBranchName(projectPath),
-        new Promise<null>((resolve) => setTimeout(() => resolve(null), ASSEMBLY_TIMEOUT_MS)),
-      ]);
+      const timeoutPromise = new Promise<null>((resolve) => {
+        branchTimer = setTimeout(() => resolve(null), ASSEMBLY_TIMEOUT_MS);
+        branchTimer.unref();
+      });
+      const branchName = await Promise.race([getBranchName(projectPath), timeoutPromise]);
       if (branchName) {
         for (const token of tokenizeBranchName(branchName)) {
           add(token);
@@ -321,21 +324,27 @@ export async function assembleKeyterms(opts: KeytermAssemblyOpts): Promise<strin
       }
     } catch {
       logDebug(`${P} Branch name lookup failed`);
+    } finally {
+      if (branchTimer) clearTimeout(branchTimer);
     }
   }
 
   if (ptyClient) {
+    let linesTimer: NodeJS.Timeout | undefined;
     try {
-      const lines = await Promise.race([
-        getTerminalLines(ptyClient),
-        new Promise<string[]>((resolve) => setTimeout(() => resolve([]), ASSEMBLY_TIMEOUT_MS)),
-      ]);
+      const timeoutPromise = new Promise<string[]>((resolve) => {
+        linesTimer = setTimeout(() => resolve([]), ASSEMBLY_TIMEOUT_MS);
+        linesTimer.unref();
+      });
+      const lines = await Promise.race([getTerminalLines(ptyClient), timeoutPromise]);
       const identifiers = extractTerminalIdentifiers(lines);
       for (const id of identifiers) {
         add(id);
       }
     } catch {
       logDebug(`${P} Terminal identifier extraction failed`);
+    } finally {
+      if (linesTimer) clearTimeout(linesTimer);
     }
   }
 


### PR DESCRIPTION
## Summary
- Increased the keyterm cap from 80 to 96 so it lands just under Deepgram nova-3's 100-term ceiling
- Capped terminal line ingestion at 200 lines — previously unbounded, which could grow the payload with every transcription cycle
- Fixed two `Promise.race` timer leaks: `clearTimeout` now runs in `finally` blocks, and timers call `.unref()` so they don't keep the process alive
- Added `projectName` validation (trim + numeric/length guard) to match the check already applied to custom dictionaries
- Extended the priority test to assert all four tiers (custom > project > branch > terminal)

Resolves #7125

## Changes
- `electron/services/voiceContextKeyterms.ts` — `MAX_KEYTERMS` 80 to 96, new `MAX_KEYTERM_LINES` (200), `projectName` validated with `trim` + `!/^\d+$/` + length >= 2, both `Promise.race` calls wrapped with `clearTimeout` in `finally` + `.unref()`
- `electron/services/__tests__/voiceContextKeyterms.test.ts` — cap test updated to 96, added test for 200-line tail-slice behavior, priority test now asserts all four tiers

## Testing
20 unit tests pass. Typecheck, lint:ratchet, and format:check all clean.