### PR TITLE
fix(process-detector): filter zombies, enforce UTF-8, handle deeper wrapper stacks

### DIFF
--- a/electron/services/ProcessDetector/ProcessDetector.ts
+++ b/electron/services/ProcessDetector/ProcessDetector.ts
@@ -497,7 +497,8 @@ export class ProcessDetector {
     }
 
     const children = this.cache.getChildren(this.ptyPid);
-    const isBusy = children.length > 0;
+    const liveChildren = children.filter((c) => !c.command.includes("<defunct>"));
+    const isBusy = liveChildren.length > 0;
 
     // Distinguish "no evidence" from "negative evidence". When the process
     // tree cache is currently in an error state and reports zero children,
@@ -527,7 +528,7 @@ export class ProcessDetector {
       return this.mergeWithShellEvidence(null, { isBusy: false, currentCommand: undefined });
     }
 
-    const processes: ChildProcess[] = children.map((p) => ({
+    const processes: ChildProcess[] = liveChildren.map((p) => ({
       pid: p.pid,
       name: p.comm,
       command: p.command,
@@ -548,7 +549,7 @@ export class ProcessDetector {
     // worker processes when the claude parent renamed its comm. Covers real
     // nesting: `zsh → npm → node /path/to/claude` for `npm run claude`.
     if (!bestMatch || bestMatch.priority > 0) {
-      for (const child of children.slice(0, 10)) {
+      for (const child of liveChildren.slice(0, 10)) {
         const grandchildren = this.cache.getChildren(child.pid);
         for (const grandchild of grandchildren) {
           const candidate = buildDetectedCandidate(

--- a/electron/services/ProcessDetector/ProcessDetector.ts
+++ b/electron/services/ProcessDetector/ProcessDetector.ts
@@ -551,7 +551,8 @@ export class ProcessDetector {
     if (!bestMatch || bestMatch.priority > 0) {
       for (const child of liveChildren.slice(0, 10)) {
         const grandchildren = this.cache.getChildren(child.pid);
-        for (const grandchild of grandchildren) {
+        const liveGrandchildren = grandchildren.filter((gc) => !gc.command.includes("<defunct>"));
+        for (const grandchild of liveGrandchildren) {
           const candidate = buildDetectedCandidate(
             grandchild.comm,
             grandchild.command || grandchild.comm,

--- a/electron/services/ProcessDetector/commandParser.ts
+++ b/electron/services/ProcessDetector/commandParser.ts
@@ -70,15 +70,16 @@ export function extractCommandNameCandidates(command: string | undefined): strin
   if (!command) return [];
   const parts = splitShellLikeCommand(command);
   const candidates: string[] = [];
-  for (let i = 0; i < parts.length && candidates.length < 3; i++) {
+  for (let i = 0; i < parts.length && candidates.length < 5; i++) {
     const arg = parts[i];
     if (!arg || arg.startsWith("-")) continue;
+    if (/^-?\d+(\.\d+)?$/.test(arg)) continue;
     if (/^[A-Za-z_][A-Za-z0-9_]*=/.test(arg)) continue;
     const basename = arg.split(/[\\/]/).pop();
     if (!basename) continue;
     const withoutExt = basename
       .replace(/\.exe$/i, "")
-      .replace(/\.(m?js|cjs|ts|py|rb|php|pl)$/i, "");
+      .replace(/\.(m?jsx?|cjs|tsx?|py|rb|php|pl)$/i, "");
     if (withoutExt) candidates.push(withoutExt);
   }
   return candidates;

--- a/electron/services/ProcessDetector/registries.ts
+++ b/electron/services/ProcessDetector/registries.ts
@@ -47,6 +47,7 @@ export const PROCESS_ICON_MAP: Record<string, string> = {
   // Package managers
   npm: "npm",
   npx: "npm",
+  bunx: "bun",
   yarn: "yarn",
   pnpm: "pnpm",
   bun: "bun",
@@ -55,6 +56,7 @@ export const PROCESS_ICON_MAP: Record<string, string> = {
   python: "python",
   python3: "python",
   node: "node",
+  tsx: "node",
   deno: "deno",
   ruby: "ruby",
   rails: "ruby",

--- a/electron/services/ProcessTreeCache.ts
+++ b/electron/services/ProcessTreeCache.ts
@@ -194,7 +194,8 @@ export class ProcessTreeCache {
     // Include %cpu for activity detection
     const { stdout } = await execAsync("ps -eo pid,ppid,%cpu,rss,comm,command", {
       timeout: 5000,
-      maxBuffer: 10 * 1024 * 1024, // 10MB to handle systems with many processes
+      maxBuffer: 10 * 1024 * 1024,
+      env: { ...process.env, LC_ALL: process.platform === "darwin" ? "en_US.UTF-8" : "C.UTF-8" },
     });
 
     const newCache = new Map<number, ProcessInfo>();
@@ -262,6 +263,8 @@ export class ProcessTreeCache {
     const psCommand =
       'powershell -NoProfile -NonInteractive -NoLogo -Command "' +
       "$ErrorActionPreference = 'SilentlyContinue'; " +
+      "[Console]::OutputEncoding = [System.Text.UTF8Encoding]::new($false); " +
+      "$OutputEncoding = [System.Text.UTF8Encoding]::new($false); " +
       "Get-CimInstance Win32_Process | Select-Object ProcessId,ParentProcessId,Name,CommandLine," +
       "@{N='KernelModeTime';E={[string]$_.KernelModeTime}}," +
       "@{N='UserModeTime';E={[string]$_.UserModeTime}}," +

--- a/electron/services/__tests__/ProcessDetector.test.ts
+++ b/electron/services/__tests__/ProcessDetector.test.ts
@@ -1190,6 +1190,80 @@ describe("ProcessDetector", () => {
       );
     });
   });
+
+  describe("zombie child filtering", () => {
+    it("does not set isBusy when children are all defunct", () => {
+      const cache = createCacheMock();
+      cache.setChildren(100, [{ pid: 200, comm: "node", command: "<defunct>" }]);
+      const callback = vi.fn();
+      const detector = new ProcessDetector(
+        "terminal-zombie-only",
+        Date.now(),
+        100,
+        callback,
+        cache as never
+      );
+      detector.start();
+      cache.emitRefresh();
+      // No children after filtering → should be no_agent (negative evidence)
+      expect(callback).toHaveBeenCalledWith(
+        expect.objectContaining({
+          detected: false,
+          detectionState: "no_agent",
+        }),
+        expect.any(Number)
+      );
+    });
+
+    it("reports isBusy: true with mixed live and defunct children", () => {
+      const cache = createCacheMock();
+      cache.setChildren(100, [
+        { pid: 200, comm: "node", command: "<defunct>" },
+        { pid: 201, comm: "claude", command: "claude --resume" },
+      ]);
+      const callback = vi.fn();
+      const detector = new ProcessDetector(
+        "terminal-mixed-defunct",
+        Date.now(),
+        100,
+        callback,
+        cache as never
+      );
+      detector.start();
+      cache.emitRefresh();
+      expect(callback).toHaveBeenCalledWith(
+        expect.objectContaining({
+          detected: true,
+          detectionState: "agent",
+        }),
+        expect.any(Number)
+      );
+    });
+
+    it("unmatched-children diagnostic skips defunct entries", () => {
+      const cache = createCacheMock();
+      cache.setChildren(100, [{ pid: 200, comm: "bash", command: "<defunct>" }]);
+      const callback = vi.fn();
+      const detector = new ProcessDetector(
+        "terminal-defunct-diag",
+        Date.now(),
+        100,
+        callback,
+        cache as never
+      );
+      detector.start();
+      cache.emitRefresh();
+      // No live children → no_agent. The defunct child is filtered before
+      // the processes mapping, so the diagnostic never sees it.
+      expect(callback).toHaveBeenCalledWith(
+        expect.objectContaining({
+          detected: false,
+          detectionState: "no_agent",
+        }),
+        expect.any(Number)
+      );
+    });
+  });
 });
 
 describe("extractScriptBasenameFromCommand", () => {
@@ -1205,11 +1279,14 @@ describe("extractScriptBasenameFromCommand", () => {
     );
   });
 
-  it("strips .js / .mjs / .cjs / .ts / .py / .rb extensions", () => {
+  it("strips .js / .mjs / .cjs / .ts / .py / .rb / .tsx / .jsx extensions", () => {
     expect(extractScriptBasenameFromCommand("node /path/to/gemini.mjs")).toBe("gemini");
     expect(extractScriptBasenameFromCommand("python3 /opt/script.py")).toBe("script");
     expect(extractScriptBasenameFromCommand("ruby /opt/tool.rb")).toBe("tool");
     expect(extractScriptBasenameFromCommand("deno /opt/thing.ts")).toBe("thing");
+    expect(extractScriptBasenameFromCommand("node /path/to/claude.tsx --flag")).toBe("claude");
+    expect(extractScriptBasenameFromCommand("node /path/to/claude.jsx --flag")).toBe("claude");
+    expect(extractScriptBasenameFromCommand("node /path/to/claude.mjsx --flag")).toBe("claude");
   });
 
   it("extracts command basenames from quoted absolute launch paths", () => {
@@ -1235,6 +1312,23 @@ describe("extractScriptBasenameFromCommand", () => {
 
   it("skips leading flags", () => {
     expect(extractScriptBasenameFromCommand("node --inspect /path/to/claude")).toBe("claude");
+  });
+
+  it("bumps candidate cap to 5 and skips pure-numeric tokens", () => {
+    expect(extractCommandNameCandidates("time nice -n 10 claude")).toContain("claude");
+    expect(extractCommandNameCandidates("time nice -n 10 claude")).not.toContain("10");
+    expect(extractCommandNameCandidates("time nice -n 10 -adjust 3.14 npx claude")).toEqual([
+      "time",
+      "nice",
+      "npx",
+      "claude",
+    ]);
+  });
+
+  it("preserves names containing digits (not pure-numeric)", () => {
+    const candidates = extractCommandNameCandidates("node20 /path/to/claude2 --flag");
+    expect(candidates).toContain("node20");
+    expect(candidates).toContain("claude2");
   });
 
   it("returns null for a bare runtime (no argv[1])", () => {

--- a/electron/services/__tests__/ProcessDetector.test.ts
+++ b/electron/services/__tests__/ProcessDetector.test.ts
@@ -1325,6 +1325,14 @@ describe("extractScriptBasenameFromCommand", () => {
     ]);
   });
 
+  it("fills all 5 candidate slots from a deep wrapper stack", () => {
+    // 6 non-flag, non-numeric tokens before the agent — cap of 5 verified
+    // (slot 6 'codex' should be excluded by the cap)
+    const candidates = extractCommandNameCandidates("env FOO=bar direnv exec mise x npx codex");
+    expect(candidates).toHaveLength(5);
+    expect(candidates).toEqual(["env", "direnv", "exec", "mise", "x"]);
+  });
+
   it("preserves names containing digits (not pure-numeric)", () => {
     const candidates = extractCommandNameCandidates("node20 /path/to/claude2 --flag");
     expect(candidates).toContain("node20");

--- a/electron/services/__tests__/ProcessTreeCache.test.ts
+++ b/electron/services/__tests__/ProcessTreeCache.test.ts
@@ -1,6 +1,15 @@
 import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
 import { ProcessTreeCache, type ProcessInfo } from "../ProcessTreeCache.js";
 
+const { mockExec } = vi.hoisted(() => {
+  const mockExec = vi.fn();
+  return { mockExec };
+});
+
+vi.mock("child_process", () => ({
+  exec: mockExec,
+}));
+
 type CpuSnapshot = { kernelTicks: bigint; userTicks: bigint; wallMs: number };
 type CacheInternals = {
   cache: Map<number, ProcessInfo>;
@@ -473,5 +482,71 @@ describe("poll scheduling and adaptive backoff", () => {
     await vi.advanceTimersByTimeAsync(0);
     // After first unchanged refresh, should be base * 1.5
     expect(cache.getCurrentIntervalMs()).toBe(Math.ceil(2500 * 1.5));
+  });
+});
+
+describe("ProcessTreeCache command/env construction", () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+  });
+
+  it("sets LC_ALL in env on Unix ps exec", async () => {
+    // Pass {stdout, stderr} as the single callback success value so generic
+    // promisify (lost the exec-specific symbol via mocking) resolves to an
+    // object that destructures correctly.
+    mockExec.mockImplementation(
+      (
+        _cmd: string,
+        _opts: unknown,
+        cb: (err: null, result: { stdout: string; stderr: string }) => void
+      ) => {
+        cb(null, {
+          stdout: "  PID  PPID %CPU   RSS COMM COMMAND\n    1    0  0.0  1000 init  init",
+          stderr: "",
+        });
+      }
+    );
+
+    const cache = new ProcessTreeCache(2500);
+    const internals = cache as unknown as {
+      isWindows: boolean;
+      refreshUnix: () => Promise<boolean>;
+    };
+    internals.isWindows = false;
+    await internals.refreshUnix();
+
+    expect(mockExec).toHaveBeenCalledTimes(1);
+    const callOpts = mockExec.mock.calls[0][1] as { env?: Record<string, string> };
+    expect(callOpts.env).toBeDefined();
+    expect(callOpts.env!.LC_ALL).toMatch(/^(en_US\.UTF-8|C\.UTF-8)$/);
+    // LANG is inherited from process.env, not explicitly overridden
+    expect(callOpts.env!.LANG).toBe(process.env.LANG);
+  });
+
+  it("prepends UTF-8 encoding directives to PowerShell command", async () => {
+    mockExec.mockImplementation(
+      (
+        _cmd: string,
+        _opts: unknown,
+        cb: (err: null, result: { stdout: string; stderr: string }) => void
+      ) => {
+        cb(null, { stdout: "[]", stderr: "" });
+      }
+    );
+
+    const cache = new ProcessTreeCache(2500);
+    const internals = cache as unknown as {
+      isWindows: boolean;
+      refreshWindows: () => Promise<boolean>;
+    };
+    internals.isWindows = true;
+    await internals.refreshWindows();
+
+    expect(mockExec).toHaveBeenCalledTimes(1);
+    const psCommand = mockExec.mock.calls[0][0] as string;
+    expect(psCommand).toContain(
+      "[Console]::OutputEncoding = [System.Text.UTF8Encoding]::new($false)"
+    );
+    expect(psCommand).toContain("$OutputEncoding = [System.Text.UTF8Encoding]::new($false)");
   });
 });


### PR DESCRIPTION
## Summary
A few focused fixes that make the ProcessDetector more accurate and robust.

- Filters out defunct/zombie processes from child and grandchild detection so they do not inflate the busy-state signal.
- Enforces UTF-8 encoding for ps output on both Unix and Windows, so non-ASCII process names parse correctly.
- Extends script extension stripping to .tsx, .jsx, and .mjsx, bumps the candidate cap from 3 to 5 for deeper wrapper stacks, and skips pure-numeric tokens.

Resolves #7108.

## Changes
- ProcessDetector.ts -- filter defunct entries from getChildren() before mapping candidates and computing isBusy; applies to both direct children and grandchildren.
- commandParser.ts -- widen extension stripping regex and raise the candidate ceiling; skip numeric-only tokens.
- registries.ts -- add icon mappings for bunx and tsx.
- ProcessTreeCache.ts -- set LC_ALL on Unix and [Console]::OutputEncoding on Windows so non-ASCII command lines survive the ps roundtrip.
- Tests -- zombie-filtering cases for ProcessDetector, UTF-8 env/encoding assertions for ProcessTreeCache, and candidate-cap/extension coverage for the parser.

## Testing
Unit tests pass locally. Verified that defunct-only children correctly produce no_agent state, mixed live/defunct children still detect the agent, and the candidate parser handles 5-slot fills, numeric skip, and name-digit preservation.