### PR TITLE
perf(project-switch): parallelize outgoing state save with SQLite ops

### DIFF
--- a/electron/services/ProjectSwitchService.ts
+++ b/electron/services/ProjectSwitchService.ts
@@ -59,14 +59,13 @@ export class ProjectSwitchService {
       return project;
     }
 
-    // Save the current active worktree to the outgoing project's per-project state
-    // This ensures the worktree selection is remembered when switching back
-    if (previousProjectId) {
-      await this.saveOutgoingProjectWorktreeState(previousProjectId);
-    }
+    // Fire the outgoing save early so the electron-store fs write overlaps
+    // with the SQLite ops below. The method catches its own errors.
+    const saveOutgoingPromise = previousProjectId
+      ? this.saveOutgoingProjectWorktreeState(previousProjectId)
+      : Promise.resolve();
 
     try {
-      await this.cleanupWorktreeService();
       const cleanupPromise = withPerformanceSpan(
         PERF_MARKS.PROJECT_SWITCH_CLEANUP,
         () => this.cleanupSupportingServices(projectId, previousProjectId ?? null, project.path),
@@ -86,7 +85,8 @@ export class ProjectSwitchService {
         throw new Error(`Project not found after update: ${projectId}`);
       }
 
-      const [, loadResult] = await Promise.all([
+      const [, , loadResult] = await Promise.all([
+        saveOutgoingPromise,
         cleanupPromise,
         withPerformanceSpan(
           PERF_MARKS.PROJECT_SWITCH_LOAD_PROJECT,
@@ -178,11 +178,6 @@ export class ProjectSwitchService {
       // Non-fatal: log but don't block the switch
       console.error("[ProjectSwitch] Failed to save outgoing project worktree state:", error);
     }
-  }
-
-  private async cleanupWorktreeService(): Promise<void> {
-    // No-op: blue-green swap in WorkspaceClient.loadProject() handles
-    // the old host release atomically after the new host is ready.
   }
 
   private async cleanupSupportingServices(

--- a/electron/services/ProjectSwitchService.ts
+++ b/electron/services/ProjectSwitchService.ts
@@ -122,6 +122,9 @@ export class ProjectSwitchService {
       console.log("[ProjectSwitch] Project switch complete, switchId:", switchId);
       return updatedProject;
     } catch (error) {
+      // Drain the in-flight save so it can't race with a subsequent switch's
+      // write to the same outgoing project state file.
+      await saveOutgoingPromise.catch(() => {});
       console.error("[ProjectSwitch] Project switch failed, rolling back:", error);
       try {
         if (previousProjectId) {

--- a/electron/services/__tests__/ProjectSwitchService.test.ts
+++ b/electron/services/__tests__/ProjectSwitchService.test.ts
@@ -340,6 +340,82 @@ describe("ProjectSwitchService", () => {
     expect(payload.switchId).toBe("switch-id-1");
   });
 
+  it("initiates outgoing project state save before setCurrentProject completes", async () => {
+    let resolveSave!: () => void;
+    const savePromise = new Promise<void>((resolve) => {
+      resolveSave = resolve;
+    });
+    projectStoreMock.saveProjectState.mockReturnValueOnce(savePromise);
+
+    const { service } = createService();
+
+    const switchPromise = service.switchProject("project-new");
+
+    for (let i = 0; i < 20 && projectStoreMock.setCurrentProject.mock.calls.length === 0; i += 1) {
+      await Promise.resolve();
+    }
+
+    expect(projectStoreMock.setCurrentProject).toHaveBeenCalledWith("project-new");
+
+    resolveSave();
+    await expect(switchPromise).resolves.toMatchObject({ id: "project-new" });
+  });
+
+  it("does not resolve switch before outgoing project state save completes", async () => {
+    let resolveSave!: () => void;
+    const savePromise = new Promise<void>((resolve) => {
+      resolveSave = resolve;
+    });
+    projectStoreMock.saveProjectState.mockReturnValueOnce(savePromise);
+
+    const { service } = createService();
+
+    let resolved = false;
+    const switchPromise = service.switchProject("project-new");
+    const trackedPromise = switchPromise.then((result) => {
+      resolved = true;
+      return result;
+    });
+
+    for (let i = 0; i < 50; i += 1) {
+      await Promise.resolve();
+    }
+
+    expect(resolved).toBe(false);
+
+    resolveSave();
+    await expect(trackedPromise).resolves.toMatchObject({ id: "project-new" });
+    expect(resolved).toBe(true);
+  });
+
+  it("applies in-repo project identity during switch", async () => {
+    projectStoreMock.readInRepoProjectIdentity.mockResolvedValue({
+      found: true,
+      name: "Repo Name",
+      emoji: "📦",
+    });
+    // Set the project name to the default (path.basename) so the identity
+    // override fires: inRepo.name is set above and project.name === "new"
+    projectStoreMock.getProjectById.mockImplementation((id: string) => {
+      if (id === "project-new") {
+        return { id, name: "new", path: "/tmp/new", status: "active", emoji: "🌲" };
+      }
+      if (id === "project-old") {
+        return { id, name: "Old Project", path: "/tmp/old", status: "active" };
+      }
+      return null;
+    });
+
+    const { service } = createService();
+    await service.switchProject("project-new");
+
+    expect(projectStoreMock.readInRepoProjectIdentity).toHaveBeenCalledWith("/tmp/new");
+    expect(projectStoreMock.updateProject).toHaveBeenCalledWith(
+      "project-new",
+      expect.objectContaining({ name: "Repo Name", emoji: "📦" })
+    );
+  });
+
   it("preserves original switch error when rollback throws", async () => {
     const originalError = new Error("setCurrent failed");
     projectStoreMock.setCurrentProject.mockRejectedValue(originalError);

--- a/electron/services/__tests__/ProjectSwitchService.test.ts
+++ b/electron/services/__tests__/ProjectSwitchService.test.ts
@@ -7,7 +7,10 @@ const projectStoreMock = vi.hoisted(() => ({
   setCurrentProject: vi.fn<(id: string) => Promise<void>>(),
   getProjectState: vi.fn<(id: string) => Promise<Record<string, unknown>>>(),
   saveProjectState: vi.fn<(id: string, state: Record<string, unknown>) => Promise<void>>(),
-  readInRepoProjectIdentity: vi.fn<(p: string) => Promise<{ found: boolean }>>(),
+  readInRepoProjectIdentity:
+    vi.fn<
+      (p: string) => Promise<{ found: boolean; name?: string; emoji?: string; color?: string }>
+    >(),
   updateProject: vi.fn<(id: string, updates: Record<string, unknown>) => Record<string, unknown>>(),
 }));
 

--- a/electron/services/__tests__/ProjectSwitchService.test.ts
+++ b/electron/services/__tests__/ProjectSwitchService.test.ts
@@ -416,6 +416,75 @@ describe("ProjectSwitchService", () => {
     );
   });
 
+  it("proves save initiation precedes setCurrentProject via call-order log", async () => {
+    const callLog: string[] = [];
+    const getProjectStateOrig = projectStoreMock.getProjectState.getMockImplementation();
+    projectStoreMock.getProjectState.mockImplementation(async (id: string) => {
+      callLog.push("getProjectState");
+      return getProjectStateOrig!(id);
+    });
+    projectStoreMock.saveProjectState.mockImplementation(async () => {
+      callLog.push("saveProjectState");
+    });
+    projectStoreMock.setCurrentProject.mockImplementation(async () => {
+      callLog.push("setCurrentProject");
+    });
+
+    const { service } = createService();
+    await service.switchProject("project-new");
+
+    const getIdx = callLog.indexOf("getProjectState");
+    const setIdx = callLog.indexOf("setCurrentProject");
+    expect(getIdx).toBeLessThan(setIdx);
+    // saveProjectState fires in a microtask after getProjectState resolves;
+    // the key invariant is that save initiation (getProjectState) precedes setCurrentProject.
+  });
+
+  it("holds switchChain until pending save drains on failure path", async () => {
+    let resolveSave!: () => void;
+    const savePromise = new Promise<void>((resolve) => {
+      resolveSave = resolve;
+    });
+    projectStoreMock.saveProjectState.mockReturnValueOnce(savePromise);
+    projectStoreMock.setCurrentProject.mockRejectedValueOnce(new Error("setCurrent failed"));
+
+    const { service } = createService();
+
+    // First switch fails — catch block should await saveOutgoingPromise
+    const firstSwitch = service.switchProject("project-new");
+
+    // Give the catch block time to enter its await
+    for (let i = 0; i < 10; i += 1) {
+      await Promise.resolve();
+    }
+
+    // Second switch queues behind switchChain, which is held by the
+    // catch block's await on saveOutgoingPromise
+    projectStoreMock.getCurrentProjectId.mockReturnValue("project-new");
+    const secondSwitch = service.switchProject("project-old");
+
+    let secondResolved = false;
+    secondSwitch.then(
+      () => {
+        secondResolved = true;
+      },
+      () => {
+        secondResolved = true;
+      }
+    );
+
+    for (let i = 0; i < 10; i += 1) {
+      await Promise.resolve();
+    }
+    expect(secondResolved).toBe(false);
+
+    // Drain the save → catch block finishes → switchChain unblocks → second switch runs
+    resolveSave();
+    await firstSwitch.catch(() => {});
+    await secondSwitch;
+    expect(secondResolved).toBe(true);
+  });
+
   it("preserves original switch error when rollback throws", async () => {
     const originalError = new Error("setCurrent failed");
     projectStoreMock.setCurrentProject.mockRejectedValue(originalError);


### PR DESCRIPTION
## Summary

- Fires the outgoing project state save earlier so its filesystem write overlaps with SQLite operations instead of blocking sequentially. This reduces the wall-clock time for a project switch.
- Drains the in-flight save on the failure path to prevent a stale write from racing the next project switch, which would corrupt state.
- Removes an unused `cleanupWorktreeService` no-op that was misleading.

Resolves #7099

## Changes

- `ProjectSwitchService.ts` — initiates the outgoing save before `setCurrentProject`, runs it in a `Promise.all` alongside cleanup and project load, and drains it in the `catch` block.
- `ProjectSwitchService.test.ts` — 5 new tests covering parallelization ordering, save-completion gating, failure-path drain via `switchChain` blocking, in-repo identity application, and a call-order proof.

## Testing

- All 5 new tests pass. Existing test suite remains green.
- Typechecked clean (`tsc --noEmit` on renderer, electron, and preload configs).
- Verified manually that project switching completes successfully with the overlapping save.