### PR TITLE
chore(mcp-server): remove dead exports, extract constants, harden probe

### DIFF
--- a/electron/ipc/channels.ts
+++ b/electron/ipc/channels.ts
@@ -516,9 +516,9 @@ export const CHANNELS = {
   MCP_SERVER_GET_RUNTIME_STATE: "mcp-server:get-runtime-state",
   /** Push channel for runtime-state transitions. */
   MCP_SERVER_RUNTIME_STATE_CHANGED: "mcp-server:runtime-state-changed",
-  /** Bridge: renderer requests the action manifest from the main process. */
+  /** Bridge: main process requests the action manifest from the renderer. */
   MCP_SERVER_GET_MANIFEST_REQUEST: "mcp:get-manifest-request",
-  /** Bridge: main process returns the action manifest to the renderer. */
+  /** Bridge: renderer returns the action manifest to the main process. */
   MCP_SERVER_GET_MANIFEST_RESPONSE: "mcp:get-manifest-response",
   /** Bridge: main process dispatches an action request to the renderer. */
   MCP_SERVER_DISPATCH_ACTION_REQUEST: "mcp:dispatch-action-request",

--- a/electron/ipc/channels.ts
+++ b/electron/ipc/channels.ts
@@ -516,6 +516,14 @@ export const CHANNELS = {
   MCP_SERVER_GET_RUNTIME_STATE: "mcp-server:get-runtime-state",
   /** Push channel for runtime-state transitions. */
   MCP_SERVER_RUNTIME_STATE_CHANGED: "mcp-server:runtime-state-changed",
+  /** Bridge: renderer requests the action manifest from the main process. */
+  MCP_SERVER_GET_MANIFEST_REQUEST: "mcp:get-manifest-request",
+  /** Bridge: main process returns the action manifest to the renderer. */
+  MCP_SERVER_GET_MANIFEST_RESPONSE: "mcp:get-manifest-response",
+  /** Bridge: main process dispatches an action request to the renderer. */
+  MCP_SERVER_DISPATCH_ACTION_REQUEST: "mcp:dispatch-action-request",
+  /** Bridge: renderer returns the action dispatch result to the main process. */
+  MCP_SERVER_DISPATCH_ACTION_RESPONSE: "mcp:dispatch-action-response",
 
   // Voice Input channels
   VOICE_INPUT_GET_SETTINGS: "voice-input:get-settings",

--- a/electron/preload.cts
+++ b/electron/preload.cts
@@ -2408,12 +2408,12 @@ const api: ElectronAPI = {
     onGetManifestRequest: (callback: (requestId: string) => void) => {
       const handler = (_event: Electron.IpcRendererEvent, payload: { requestId: string }) =>
         callback(payload.requestId);
-      ipcRenderer.on("mcp:get-manifest-request", handler);
-      return () => ipcRenderer.removeListener("mcp:get-manifest-request", handler);
+      ipcRenderer.on(CHANNELS.MCP_SERVER_GET_MANIFEST_REQUEST, handler);
+      return () => ipcRenderer.removeListener(CHANNELS.MCP_SERVER_GET_MANIFEST_REQUEST, handler);
     },
 
     sendGetManifestResponse: (requestId: string, manifest: unknown) => {
-      ipcRenderer.send("mcp:get-manifest-response", { requestId, manifest });
+      ipcRenderer.send(CHANNELS.MCP_SERVER_GET_MANIFEST_RESPONSE, { requestId, manifest });
     },
 
     onDispatchActionRequest: (
@@ -2428,8 +2428,8 @@ const api: ElectronAPI = {
         _event: Electron.IpcRendererEvent,
         payload: { requestId: string; actionId: string; args?: unknown; confirmed?: boolean }
       ) => callback(payload);
-      ipcRenderer.on("mcp:dispatch-action-request", handler);
-      return () => ipcRenderer.removeListener("mcp:dispatch-action-request", handler);
+      ipcRenderer.on(CHANNELS.MCP_SERVER_DISPATCH_ACTION_REQUEST, handler);
+      return () => ipcRenderer.removeListener(CHANNELS.MCP_SERVER_DISPATCH_ACTION_REQUEST, handler);
     },
 
     sendDispatchActionResponse: (payload: {
@@ -2437,7 +2437,7 @@ const api: ElectronAPI = {
       result: unknown;
       confirmationDecision?: "approved" | "rejected" | "timeout";
     }) => {
-      ipcRenderer.send("mcp:dispatch-action-response", payload);
+      ipcRenderer.send(CHANNELS.MCP_SERVER_DISPATCH_ACTION_RESPONSE, payload);
     },
   },
 

--- a/electron/services/__tests__/McpServerService.test.ts
+++ b/electron/services/__tests__/McpServerService.test.ts
@@ -17,6 +17,8 @@ import type {
   ActionKind,
   ActionDanger,
 } from "../../../shared/types/actions.js";
+import { CHANNELS } from "../../ipc/channels.js";
+import { ACTIONS_LIST_TOOL } from "../mcp-server/shared.js";
 
 const testHomeDir = vi.hoisted(
   () => `${process.cwd()}/.vitest-mcp-home-${Math.random().toString(36).slice(2)}`
@@ -219,10 +221,10 @@ function createMockWindow(options?: {
     isDestroyed: vi.fn(() => false),
     send: vi.fn(
       (channel: string, payload: { requestId: string; actionId?: string; args?: unknown }) => {
-        if (channel === "mcp:get-manifest-request") {
+        if (channel === CHANNELS.MCP_SERVER_GET_MANIFEST_REQUEST) {
           queueMicrotask(() => {
             electronMocks.ipcMain.emit(
-              "mcp:get-manifest-response",
+              CHANNELS.MCP_SERVER_GET_MANIFEST_RESPONSE,
               { sender: { id: senderId } },
               {
                 requestId: payload.requestId,
@@ -233,7 +235,7 @@ function createMockWindow(options?: {
           return;
         }
 
-        if (channel === "mcp:dispatch-action-request") {
+        if (channel === CHANNELS.MCP_SERVER_DISPATCH_ACTION_REQUEST) {
           queueMicrotask(() => {
             const dispatched = dispatchAction(payload as DispatchRequest);
             const isEnvelope =
@@ -245,7 +247,7 @@ function createMockWindow(options?: {
                 })
               : { result: dispatched as ActionDispatchResult };
             electronMocks.ipcMain.emit(
-              "mcp:dispatch-action-response",
+              CHANNELS.MCP_SERVER_DISPATCH_ACTION_RESPONSE,
               { sender: { id: senderId } },
               {
                 requestId: payload.requestId,
@@ -1714,13 +1716,13 @@ describe("McpServerService", () => {
 
     // Both windows' WebContents.send must have been invoked — and only for
     // the dispatch belonging to that window. (Each window also receives one
-    // `mcp:get-manifest-request` per session — that is fine because pinned
+    // `CHANNELS.MCP_SERVER_GET_MANIFEST_REQUEST` per session — that is fine because pinned
     // sessions explicitly bypass the shared manifest cache.)
     const sendsToA = winA.webContents.send.mock.calls.filter(
-      ([channel]) => channel === "mcp:dispatch-action-request"
+      ([channel]) => channel === CHANNELS.MCP_SERVER_DISPATCH_ACTION_REQUEST
     );
     const sendsToB = winB.webContents.send.mock.calls.filter(
-      ([channel]) => channel === "mcp:dispatch-action-request"
+      ([channel]) => channel === CHANNELS.MCP_SERVER_DISPATCH_ACTION_REQUEST
     );
     expect(sendsToA).toHaveLength(1);
     expect(sendsToB).toHaveLength(1);
@@ -1760,7 +1762,7 @@ describe("McpServerService", () => {
     expect(result.isError).toBe(true);
     expect(result.content[0].text).toMatch(/no longer available/);
     expect(winB.webContents.send).not.toHaveBeenCalledWith(
-      "mcp:dispatch-action-request",
+      CHANNELS.MCP_SERVER_DISPATCH_ACTION_REQUEST,
       expect.anything()
     );
   });
@@ -3244,7 +3246,7 @@ describe("McpServerService", () => {
         advanceTimeDelta: 50,
       });
       try {
-        await client.callTool({ name: "actions.list", arguments: {} });
+        await client.callTool({ name: ACTIONS_LIST_TOOL, arguments: {} });
         // Pending debounce timer is now set with the record in the buffer.
         (service as unknown as { clearAuditLog: () => void }).clearAuditLog();
         storeMocks.set.mockClear();
@@ -3338,7 +3340,7 @@ describe("McpServerService", () => {
     await requestManifest();
 
     expect(webContents.send).toHaveBeenCalledWith(
-      "mcp:get-manifest-request",
+      CHANNELS.MCP_SERVER_GET_MANIFEST_REQUEST,
       expect.objectContaining({ requestId: expect.any(String) })
     );
     expect(hostShellWebContents.send).not.toHaveBeenCalled();

--- a/electron/services/mcp-server/__tests__/readinessProbe.test.ts
+++ b/electron/services/mcp-server/__tests__/readinessProbe.test.ts
@@ -9,6 +9,7 @@ import {
   probeMcpServer,
   probeMcpSseServer,
 } from "../readinessProbe.js";
+import { ACTIONS_LIST_TOOL } from "../shared.js";
 
 interface CapturedRequest {
   method: string;
@@ -313,7 +314,7 @@ describe("probeMcpSseServer", () => {
               result: {
                 tools: [
                   {
-                    name: "actions.list",
+                    name: ACTIONS_LIST_TOOL,
                     description: "List available Daintree actions",
                     inputSchema: { type: "object", properties: {} },
                   },

--- a/electron/services/mcp-server/__tests__/rendererBridge.test.ts
+++ b/electron/services/mcp-server/__tests__/rendererBridge.test.ts
@@ -1,4 +1,5 @@
 import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+import { CHANNELS } from "../../../ipc/channels.js";
 
 const { mockIpcMain, mockWebContentsRegistry } = vi.hoisted(() => {
   class IpcMainMock {
@@ -108,10 +109,10 @@ describe("rendererBridge — per-session pinned dispatch (#7002)", () => {
 
     // Hook send to reply with a manifest tagged by id, so we can assert routing.
     wcA.send.mockImplementation((channel: string, payload: { requestId: string }) => {
-      if (channel !== "mcp:get-manifest-request") return;
+      if (channel !== CHANNELS.MCP_SERVER_GET_MANIFEST_REQUEST) return;
       queueMicrotask(() => {
         mockIpcMain.emit(
-          "mcp:get-manifest-response",
+          CHANNELS.MCP_SERVER_GET_MANIFEST_RESPONSE,
           { sender: { id: 101 } },
           {
             requestId: payload.requestId,
@@ -137,10 +138,10 @@ describe("rendererBridge — per-session pinned dispatch (#7002)", () => {
     mockWebContentsRegistry.set(302, wcB);
 
     wcA.send.mockImplementation((channel: string, payload: { requestId: string }) => {
-      if (channel !== "mcp:dispatch-action-request") return;
+      if (channel !== CHANNELS.MCP_SERVER_DISPATCH_ACTION_REQUEST) return;
       queueMicrotask(() => {
         mockIpcMain.emit(
-          "mcp:dispatch-action-response",
+          CHANNELS.MCP_SERVER_DISPATCH_ACTION_RESPONSE,
           { sender: { id: 301 } },
           {
             requestId: payload.requestId,

--- a/electron/services/mcp-server/__tests__/tierAuth.test.ts
+++ b/electron/services/mcp-server/__tests__/tierAuth.test.ts
@@ -16,6 +16,7 @@ vi.mock("../../McpPaneConfigService.js", () => ({
 import {
   extractBearerToken,
   isAuthorized,
+  parseToolArguments,
   precomputeApiKeyBearerHash,
   resolveTokenTier,
 } from "../tierAuth.js";
@@ -182,5 +183,45 @@ describe("resolveTokenTier", () => {
 
   it("falls back to workbench when the header has no whitespace after the scheme", () => {
     expect(resolveTokenTier("Bearerfoo", null, null)).toBe("workbench");
+  });
+});
+
+describe("parseToolArguments", () => {
+  it("passes through plain objects", () => {
+    expect(parseToolArguments({ key: "value" })).toEqual({ args: { key: "value" } });
+  });
+
+  it("strips _meta from plain objects", () => {
+    expect(parseToolArguments({ _meta: { hello: true }, action: "x" })).toEqual({
+      args: { action: "x" },
+    });
+  });
+
+  it("returns empty args when only _meta is present", () => {
+    expect(parseToolArguments({ _meta: { hello: true } })).toEqual({ args: {} });
+  });
+
+  it("coerces undefined to empty args", () => {
+    expect(parseToolArguments(undefined)).toEqual({ args: {} });
+  });
+
+  it("coerces null to empty args", () => {
+    expect(parseToolArguments(null)).toEqual({ args: {} });
+  });
+
+  it("coerces arrays to empty args", () => {
+    expect(parseToolArguments([1, 2, 3])).toEqual({ args: {} });
+  });
+
+  it("coerces strings to empty args", () => {
+    expect(parseToolArguments("hello")).toEqual({ args: {} });
+  });
+
+  it("coerces numbers to empty args", () => {
+    expect(parseToolArguments(42)).toEqual({ args: {} });
+  });
+
+  it("coerces booleans to empty args", () => {
+    expect(parseToolArguments(true)).toEqual({ args: {} });
   });
 });

--- a/electron/services/mcp-server/readinessProbe.ts
+++ b/electron/services/mcp-server/readinessProbe.ts
@@ -1,4 +1,5 @@
 import http from "node:http";
+import { ACTIONS_LIST_TOOL } from "./shared.js";
 
 export const PROBE_MAX_ATTEMPTS = 3;
 export const PROBE_BASE_DELAY_MS = 50;
@@ -62,6 +63,8 @@ export async function probeMcpServer(
       // Cleanup gets its own per-request timeout regardless of remaining
       // budget; failures are logged but never bubble up.
       void sendDelete(port, bearerToken, result.sessionId, requestTimeoutMs).catch((err) => {
+        const code = (err as NodeJS.ErrnoException).code;
+        if (code === "ECONNRESET" || code === "EPIPE") return;
         console.warn("[MCP] Readiness probe cleanup DELETE failed (non-fatal):", err);
       });
       return;
@@ -248,6 +251,10 @@ function sendDelete(
         (res) => {
           const status = res.statusCode ?? 0;
           res.resume();
+          if (status === 405) {
+            settle(() => resolve());
+            return;
+          }
           if (status < 200 || status >= 300) {
             settle(() => reject(new Error(`DELETE returned status ${status}`)));
             return;
@@ -423,7 +430,7 @@ function sendSseInitialize(port: number, bearerToken: string, timeoutMs: number)
         (tool) =>
           tool &&
           typeof tool === "object" &&
-          (tool as Record<string, unknown>).name === "actions.list"
+          (tool as Record<string, unknown>).name === ACTIONS_LIST_TOOL
       );
       if (!hasManifestBackedTool) {
         settle(() => reject(new Error("tools/list response missing actions.list")));

--- a/electron/services/mcp-server/rendererBridge.ts
+++ b/electron/services/mcp-server/rendererBridge.ts
@@ -3,7 +3,9 @@ import { randomUUID } from "node:crypto";
 import type { WindowRegistry } from "../../window/WindowRegistry.js";
 import { getProjectViewManager } from "../../window/windowRef.js";
 import type { ActionManifestEntry } from "../../../shared/types/actions.js";
+import { CHANNELS } from "../../ipc/channels.js";
 import type { PendingRequest, DispatchEnvelope } from "./shared.js";
+import { MCP_MANIFEST_REQUEST_TIMEOUT_MS, MCP_DISPATCH_TIMEOUT_MS } from "./shared.js";
 
 export function createRendererBridge(
   pendingManifests: Map<string, PendingRequest<ActionManifestEntry[]>>,
@@ -71,7 +73,7 @@ export function createRendererBridge(
         pending?.destroyedCleanup?.();
         pendingManifests.delete(requestId);
         reject(new Error("Manifest request timed out"));
-      }, 5000);
+      }, MCP_MANIFEST_REQUEST_TIMEOUT_MS);
 
       const onDestroyed = () => {
         const pending = pendingManifests.get(requestId);
@@ -101,7 +103,7 @@ export function createRendererBridge(
       });
 
       try {
-        webContents.send("mcp:get-manifest-request", { requestId });
+        webContents.send(CHANNELS.MCP_SERVER_GET_MANIFEST_REQUEST, { requestId });
       } catch (err) {
         clearTimeout(timer);
         destroyedCleanup();
@@ -133,7 +135,7 @@ export function createRendererBridge(
         pending?.destroyedCleanup?.();
         pendingDispatches.delete(requestId);
         reject(new Error(`Action dispatch timed out: ${actionId}`));
-      }, 30000);
+      }, MCP_DISPATCH_TIMEOUT_MS);
 
       const onDestroyed = () => {
         const pending = pendingDispatches.get(requestId);
@@ -160,7 +162,7 @@ export function createRendererBridge(
       });
 
       try {
-        webContents.send("mcp:dispatch-action-request", {
+        webContents.send(CHANNELS.MCP_SERVER_DISPATCH_ACTION_REQUEST, {
           requestId,
           actionId,
           args,
@@ -276,12 +278,12 @@ export function createRendererBridge(
   };
 
   function setupListeners(cleanupListeners: Array<() => void>): void {
-    ipcMain.on("mcp:get-manifest-response", manifestHandler);
-    ipcMain.on("mcp:dispatch-action-response", dispatchHandler);
+    ipcMain.on(CHANNELS.MCP_SERVER_GET_MANIFEST_RESPONSE, manifestHandler);
+    ipcMain.on(CHANNELS.MCP_SERVER_DISPATCH_ACTION_RESPONSE, dispatchHandler);
 
     cleanupListeners.push(
-      () => ipcMain.removeListener("mcp:get-manifest-response", manifestHandler),
-      () => ipcMain.removeListener("mcp:dispatch-action-response", dispatchHandler)
+      () => ipcMain.removeListener(CHANNELS.MCP_SERVER_GET_MANIFEST_RESPONSE, manifestHandler),
+      () => ipcMain.removeListener(CHANNELS.MCP_SERVER_DISPATCH_ACTION_RESPONSE, dispatchHandler)
     );
   }
 
@@ -295,7 +297,5 @@ export function createRendererBridge(
     clearCache: () => {
       cachedManifest = null;
     },
-    getActiveProjectWebContents,
-    normalizeError,
   };
 }

--- a/electron/services/mcp-server/sessionServer.ts
+++ b/electron/services/mcp-server/sessionServer.ts
@@ -48,7 +48,6 @@ import {
 import {
   shouldExposeTool,
   isTierPermitted,
-  buildToolDescription,
   buildToolInputSchema,
   buildAnnotations,
   buildToolOutputSchema,
@@ -114,7 +113,7 @@ export function createSessionServer(sessionId: string, deps: SessionServerDeps):
         const outputSchema = buildToolOutputSchema(entry);
         return {
           name: entry.id,
-          description: buildToolDescription(entry),
+          description: entry.description,
           inputSchema: buildToolInputSchema(entry),
           annotations: buildAnnotations(entry),
           ...(outputSchema ? { outputSchema } : {}),

--- a/electron/services/mcp-server/shared.ts
+++ b/electron/services/mcp-server/shared.ts
@@ -28,6 +28,11 @@ export const DEFAULT_PORT = 45454;
 export const MAX_PORT_RETRIES = 10;
 export const MCP_SSE_IDLE_TIMEOUT_MS = 30 * 60 * 1000;
 
+export const MCP_MANIFEST_REQUEST_TIMEOUT_MS = 5_000;
+export const MCP_DISPATCH_TIMEOUT_MS = 30_000;
+
+export const ACTIONS_LIST_TOOL = "actions.list";
+
 export const MAX_RESTART_ATTEMPTS = 5;
 export const RESTART_BASE_DELAY_MS = 500;
 export const RESTART_MAX_DELAY_MS = 15_000;
@@ -138,7 +143,7 @@ export const OPEN_WORLD_CATEGORIES: ReadonlySet<string> = new Set([
 export type McpTier = "workbench" | "action" | "system" | "external";
 
 const WORKBENCH_TOOLS: ReadonlySet<string> = new Set([
-  "actions.list",
+  ACTIONS_LIST_TOOL,
   "actions.getContext",
 
   "project.getAll",
@@ -258,7 +263,7 @@ export function unionSet(...sets: ReadonlySet<string>[]): ReadonlySet<string> {
 }
 
 const MCP_TOOL_ALLOWLIST: ReadonlySet<string> = new Set([
-  "actions.list",
+  ACTIONS_LIST_TOOL,
   "actions.getContext",
 
   "agent.launch",

--- a/electron/services/mcp-server/tierAuth.ts
+++ b/electron/services/mcp-server/tierAuth.ts
@@ -18,14 +18,6 @@ export function precomputeApiKeyBearerHash(apiKey: string | null): Buffer | null
   return createHash("sha256").update(`Bearer ${apiKey}`).digest();
 }
 
-export function resolveBearer(token: string): McpTier | null {
-  const paneTier = mcpPaneConfigService.getTierForToken(token);
-  if (paneTier === "workbench" || paneTier === "action" || paneTier === "system") {
-    return paneTier;
-  }
-  return null;
-}
-
 export function isAuthorized(
   authHeader: string,
   apiKeyBearerHash: Buffer | null,
@@ -113,10 +105,6 @@ export function isTierPermitted(
   return TIER_ALLOWLISTS[tier].has(actionId);
 }
 
-export function buildToolDescription(entry: ActionManifestEntry): string {
-  return entry.description;
-}
-
 export function buildToolInputSchema(entry: ActionManifestEntry): Record<string, unknown> {
   if (
     entry.inputSchema &&
@@ -173,7 +161,7 @@ export function buildStructuredContent(
 
 export function parseToolArguments(rawArgs: unknown): { args: unknown } {
   if (!rawArgs || typeof rawArgs !== "object" || Array.isArray(rawArgs)) {
-    return { args: rawArgs ?? {} };
+    return { args: {} };
   }
 
   const argsRecord = rawArgs as Record<string, unknown>;


### PR DESCRIPTION
## Summary
- Removes dead exports (`resolveBearer`, `buildToolDescription`, `getActiveProjectWebContents`, `normalizeError`) from the MCP server module.
- Extracts shared constants for timeout values, tool names, and bridge channel definitions so they aren't scattered as magic strings across the codebase.
- Hardens the readiness probe to handle `ECONNRESET` and `EPIPE` errors silently during cleanup and to accept `405` responses from DELETE.
- Adds unit tests for `parseToolArguments` covering the edge cases that were previously untested.

Resolves #7130

## Changes
- **`shared.ts`** — new constants: `MCP_MANIFEST_REQUEST_TIMEOUT_MS`, `MCP_DISPATCH_TIMEOUT_MS`, `ACTIONS_LIST_TOOL`
- **`channels.ts`** — four bridge channel constants with direction comments
- **`rendererBridge.ts`** — channel and timeout constants replace magic strings; dead exports removed
- **`tierAuth.ts`** — `resolveBearer` and `buildToolDescription` removed; `parseToolArguments` hardened for non-object args
- **`sessionServer.ts`** — uses `entry.description` directly instead of the one-liner wrapper
- **`readinessProbe.ts`** — DELETE handles `ECONNRESET`/`EPIPE` silently and accepts `405`; uses `ACTIONS_LIST_TOOL`
- **`preload.cts`** — channel constants replace string literals
- **All tests** updated to use the new constants; new `tierAuth.test.ts` with 9 cases for `parseToolArguments`

## Testing
- All existing MCP server tests pass (McpServerService, readinessProbe, rendererBridge, tierAuth)
- New `parseToolArguments` tests cover null, undefined, arrays, strings, numbers, booleans, and objects with `_meta`
- TypeScript typecheck passes with no errors