### PR TITLE
perf(FileTreeService): parallelize lstat, memoize realpath, omit optional fields

### DIFF
--- a/electron/services/FileTreeService.ts
+++ b/electron/services/FileTreeService.ts
@@ -3,6 +3,23 @@ import * as path from "path";
 import { createHardenedGit } from "../utils/hardenedGit.js";
 import type { FileTreeNode } from "../../shared/types/ipc.js";
 
+const _baseRealpathCache = new Map<string, Promise<string>>();
+
+export function _resetBaseRealpathCacheForTests(): void {
+  _baseRealpathCache.clear();
+}
+
+function _getBaseRealpath(resolvedBasePath: string): Promise<string> {
+  const cached = _baseRealpathCache.get(resolvedBasePath);
+  if (cached) return cached;
+  const promise = fs.realpath(resolvedBasePath).catch((_err) => {
+    _baseRealpathCache.delete(resolvedBasePath);
+    return resolvedBasePath;
+  });
+  _baseRealpathCache.set(resolvedBasePath, promise);
+  return promise;
+}
+
 export class FileTreeService {
   async getFileTree(basePath: string, dirPath: string = ""): Promise<FileTreeNode[]> {
     const resolvedBasePath = path.resolve(basePath);
@@ -31,9 +48,7 @@ export class FileTreeService {
     }
 
     try {
-      const resolvedBaseRealPath = await fs
-        .realpath(resolvedBasePath)
-        .catch(() => resolvedBasePath);
+      const resolvedBaseRealPath = await _getBaseRealpath(resolvedBasePath);
       const targetRealPath = await fs.realpath(targetPath).catch(() => targetPath);
       const relativeRealTarget = path.relative(resolvedBaseRealPath, targetRealPath);
       if (relativeRealTarget.startsWith("..") || path.isAbsolute(relativeRealTarget)) {
@@ -48,7 +63,9 @@ export class FileTreeService {
       const entries = await fs.readdir(targetPath, { withFileTypes: true });
 
       const toGitPath = (p: string) => p.split(path.sep).join("/");
-      const pathsToCheck = entries.map((e) => toGitPath(path.join(relativeDirPath, e.name)));
+      const pathsToCheck = entries
+        .filter((e) => e.name !== ".git")
+        .map((e) => toGitPath(path.join(relativeDirPath, e.name)));
       const ignoredPaths = new Set<string>();
 
       try {
@@ -60,51 +77,43 @@ export class FileTreeService {
       } catch (_e) {
         // ignore
       }
+
+      const statResults = await Promise.all(
+        entries.map(async (entry) => {
+          if (entry.name === ".git") return null;
+          if (entry.isSymbolicLink()) return null;
+
+          const relativePath = path.join(relativeDirPath, entry.name);
+          const gitRelativePath = toGitPath(relativePath);
+
+          if (ignoredPaths.has(gitRelativePath)) return null;
+
+          const absolutePath = path.join(resolvedBasePath, relativePath);
+          try {
+            const fileStat = await fs.lstat(absolutePath);
+            return { fileStat, name: entry.name, gitRelativePath };
+          } catch {
+            return null;
+          }
+        })
+      );
+
       const nodes: FileTreeNode[] = [];
-
-      for (const entry of entries) {
-        const relativePath = path.join(relativeDirPath, entry.name);
-        const gitRelativePath = toGitPath(relativePath);
-        const absolutePath = path.join(resolvedBasePath, relativePath);
-
-        if (entry.name === ".git") {
-          continue;
-        }
-
-        if (ignoredPaths.has(gitRelativePath)) {
-          continue;
-        }
-
-        let fileStat: Awaited<ReturnType<typeof fs.lstat>>;
-        try {
-          fileStat = await fs.lstat(absolutePath);
-        } catch {
-          continue;
-        }
-        const isSymlink = fileStat.isSymbolicLink();
-
-        if (isSymlink) {
-          continue;
-        }
+      for (const result of statResults) {
+        if (!result) continue;
+        const { fileStat, name, gitRelativePath } = result;
 
         const isDirectory = fileStat.isDirectory();
-        let size = 0;
-
-        if (!isDirectory) {
-          try {
-            size = fileStat.size;
-          } catch {
-            continue;
-          }
+        if (isDirectory) {
+          nodes.push({ name, path: gitRelativePath, isDirectory });
+          continue;
         }
 
-        nodes.push({
-          name: entry.name,
-          path: gitRelativePath,
-          isDirectory,
-          size,
-          children: undefined,
-        });
+        try {
+          nodes.push({ name, path: gitRelativePath, isDirectory, size: fileStat.size });
+        } catch {
+          // skip entries where size read fails
+        }
       }
 
       nodes.sort((a, b) => {

--- a/electron/services/__tests__/FileTreeService.adversarial.test.ts
+++ b/electron/services/__tests__/FileTreeService.adversarial.test.ts
@@ -1,6 +1,6 @@
 import { beforeEach, describe, expect, it, vi } from "vitest";
 import type { Stats } from "node:fs";
-import { FileTreeService } from "../FileTreeService.js";
+import { FileTreeService, _resetBaseRealpathCacheForTests } from "../FileTreeService.js";
 
 const shared = vi.hoisted(() => ({
   realpath: vi.fn(),
@@ -25,6 +25,8 @@ vi.mock("../../utils/hardenedGit.js", () => ({
 
 interface DirEntry {
   name: string;
+  isSymbolicLink: () => boolean;
+  isDirectory: () => boolean;
 }
 
 interface MockStats extends Pick<Stats, "isDirectory" | "isSymbolicLink" | "size"> {
@@ -40,6 +42,14 @@ function createStats(options: {
     isDirectory: () => options.isDirectory ?? false,
     isSymbolicLink: () => options.isSymbolicLink ?? false,
     size: options.size ?? 0,
+  };
+}
+
+function d(name: string, opts?: { symlink?: boolean; dir?: boolean }): DirEntry {
+  return {
+    name,
+    isSymbolicLink: () => opts?.symlink ?? false,
+    isDirectory: () => opts?.dir ?? false,
   };
 }
 
@@ -64,6 +74,7 @@ describe("FileTreeService adversarial", () => {
 
   beforeEach(() => {
     vi.clearAllMocks();
+    _resetBaseRealpathCacheForTests();
     service = new FileTreeService();
 
     shared.realpath.mockImplementation(async (target: string) => target);
@@ -82,10 +93,7 @@ describe("FileTreeService adversarial", () => {
   });
 
   it("UNREADABLE_CHILD_DOES_NOT_POISON_DIR", async () => {
-    shared.readdir.mockResolvedValueOnce([
-      { name: "good.txt" },
-      { name: "secret.txt" },
-    ] as DirEntry[]);
+    shared.readdir.mockResolvedValueOnce([d("good.txt"), d("secret.txt")]);
     shared.lstat.mockImplementation(async (target: string) => {
       if (target.endsWith("secret.txt")) {
         throw eacces("EACCES: permission denied");
@@ -95,7 +103,6 @@ describe("FileTreeService adversarial", () => {
 
     await expect(service.getFileTree("/repo")).resolves.toEqual([
       {
-        children: undefined,
         isDirectory: false,
         name: "good.txt",
         path: "good.txt",
@@ -105,21 +112,20 @@ describe("FileTreeService adversarial", () => {
   });
 
   it("SYMLINK_OMITTED_WITHOUT_FOLLOW", async () => {
-    shared.readdir.mockResolvedValueOnce([{ name: "link" }] as DirEntry[]);
-    shared.lstat.mockResolvedValueOnce(createStats({ isSymbolicLink: true }));
+    shared.readdir.mockResolvedValueOnce([d("link", { symlink: true })]);
 
     await expect(service.getFileTree("/repo")).resolves.toEqual([]);
     expect(shared.stat).toHaveBeenCalledTimes(1);
+    expect(shared.lstat).not.toHaveBeenCalled();
   });
 
   it("GIT_IGNORE_FAILURE_FAILS_OPEN", async () => {
-    shared.readdir.mockResolvedValueOnce([{ name: "visible.txt" }] as DirEntry[]);
+    shared.readdir.mockResolvedValueOnce([d("visible.txt")]);
     shared.lstat.mockResolvedValueOnce(createStats({ size: 4 }));
     shared.checkIgnore.mockRejectedValueOnce(new Error("git unavailable"));
 
     await expect(service.getFileTree("/repo")).resolves.toEqual([
       {
-        children: undefined,
         isDirectory: false,
         name: "visible.txt",
         path: "visible.txt",
@@ -135,9 +141,9 @@ describe("FileTreeService adversarial", () => {
     shared.readdir.mockImplementation(async () => {
       readdirCall += 1;
       if (readdirCall === 1) {
-        return [{ name: "old.txt" }] as DirEntry[];
+        return [d("old.txt")];
       }
-      return [{ name: "new.txt" }] as DirEntry[];
+      return [d("new.txt")];
     });
 
     shared.lstat.mockImplementation((target: string) => {
@@ -156,7 +162,6 @@ describe("FileTreeService adversarial", () => {
 
     expect(first).toEqual([
       {
-        children: undefined,
         isDirectory: false,
         name: "old.txt",
         path: "old.txt",
@@ -165,7 +170,6 @@ describe("FileTreeService adversarial", () => {
     ]);
     expect(second).toEqual([
       {
-        children: undefined,
         isDirectory: false,
         name: "new.txt",
         path: "new.txt",
@@ -176,7 +180,7 @@ describe("FileTreeService adversarial", () => {
   });
 
   it("FILE_TYPE_CHANGE_NOT_CACHED", async () => {
-    shared.readdir.mockResolvedValue([{ name: "src" }] as DirEntry[]);
+    shared.readdir.mockResolvedValue([d("src")]);
     shared.lstat
       .mockResolvedValueOnce(createStats({ isDirectory: false, size: 10 }))
       .mockResolvedValueOnce(createStats({ isDirectory: true }));
@@ -185,11 +189,12 @@ describe("FileTreeService adversarial", () => {
     const second = await service.getFileTree("/repo");
 
     expect(first[0]).toMatchObject({ name: "src", isDirectory: false, size: 10 });
-    expect(second[0]).toMatchObject({ name: "src", isDirectory: true, size: 0 });
+    expect(second[0]).toMatchObject({ name: "src", isDirectory: true });
+    expect("size" in second[0]).toBe(false);
   });
 
   it("SIZE_CHANGE_NOT_CACHED", async () => {
-    shared.readdir.mockResolvedValue([{ name: "index.ts" }] as DirEntry[]);
+    shared.readdir.mockResolvedValue([d("index.ts")]);
     shared.lstat
       .mockResolvedValueOnce(createStats({ size: 10 }))
       .mockResolvedValueOnce(createStats({ size: 999 }));
@@ -202,10 +207,7 @@ describe("FileTreeService adversarial", () => {
   });
 
   it("WINDOWS_PATH_NORMALIZES_FOR_IGNORE", async () => {
-    shared.readdir.mockResolvedValueOnce([
-      { name: "ignored.txt" },
-      { name: "visible.txt" },
-    ] as DirEntry[]);
+    shared.readdir.mockResolvedValueOnce([d("ignored.txt"), d("visible.txt")]);
     shared.checkIgnore.mockImplementationOnce(async (paths: string[]) => {
       expect(paths).toEqual(["nested/dir/ignored.txt", "nested/dir/visible.txt"]);
       return ["nested/dir/ignored.txt"];
@@ -214,12 +216,50 @@ describe("FileTreeService adversarial", () => {
 
     await expect(service.getFileTree("/repo", "nested\\dir")).resolves.toEqual([
       {
-        children: undefined,
         isDirectory: false,
         name: "visible.txt",
         path: "nested/dir/visible.txt",
         size: 7,
       },
     ]);
+  });
+
+  it("DOT_GIT_EXCLUDED_FROM_CHECK_IGNORE", async () => {
+    shared.readdir.mockResolvedValueOnce([d(".git", { dir: true }), d("src", { dir: true })]);
+    shared.checkIgnore.mockImplementationOnce(async (paths: string[]) => {
+      expect(paths).toEqual(["src"]);
+      return [];
+    });
+    shared.lstat.mockResolvedValue(createStats({ isDirectory: true }));
+
+    await expect(service.getFileTree("/repo")).resolves.toEqual([
+      { name: "src", path: "src", isDirectory: true },
+    ]);
+  });
+
+  it("REALPATH_CACHE_SHARED_ACROSS_CALLS", async () => {
+    let realpathCalls = 0;
+    shared.realpath.mockImplementation(async (target: string) => {
+      realpathCalls += 1;
+      return target;
+    });
+
+    await service.getFileTree("/repo");
+    await service.getFileTree("/repo");
+
+    // 3 = 1 base-realpath (cached across calls) + 2 target-realpath (per-call)
+    expect(realpathCalls).toBe(3);
+  });
+
+  it("REALPATH_CACHE_ERROR_EVICTED", async () => {
+    // First call: base realpath fails, cache evicted, fallback returned
+    shared.realpath.mockRejectedValueOnce(new Error("EACCES"));
+    await expect(service.getFileTree("/repo")).resolves.toBeDefined();
+
+    // Second call: base realpath retried (cache was evicted)
+    await expect(service.getFileTree("/repo")).resolves.toBeDefined();
+
+    // 4 = (1 base fail + 1 target ok) × 2 calls
+    expect(shared.realpath).toHaveBeenCalledTimes(4);
   });
 });


### PR DESCRIPTION
## Summary

This is a set of optimizations to the per-call hot path in `FileTreeService.getFileTree`.

- **Parallelized `lstat`**: switched from a sequential `for` loop to `Promise.all` so all directory entries are statted concurrently.
- **Memoized base-path `realpath`**: the base path resolution now lives in a module-level cache that persists across `FileTreeService` instances, so repeated calls on the same path skip the work.
- **Filtered `.git` from `checkIgnore`**: `.git` entries are excluded from the pathspec before we hand it to git, so `checkIgnore` never processes them.
- **Skipped symlinks early**: symlinks are detected from `Dirent` type info and dropped before hitting the filesystem with `lstat`.
- **Omitted optional fields**: `children` and `size` for directories are no longer included in returned tree nodes.

Resolves #7140

## Changes

- `electron/services/FileTreeService.ts` — restructured the readdir-to-nodes pipeline: batch `lstat` with `Promise.all`, early-filter `.git` and symlinks, strip optional fields, and add the base-realpath cache.
- `electron/services/__tests__/FileTreeService.adversarial.test.ts` — added tests for dot-git exclusion from `checkIgnore`, realpath cache sharing and cache-error eviction, and the symlink-early-skip path. Updated existing assertions to reflect the dropped optional fields.

## Testing

All adversarial tests pass, including the new ones. Typecheck, lint, and format are clean.