### PR TITLE
fix(voice): cancel in-flight OpenAI calls on dictation stop

### DIFF
--- a/electron/ipc/handlers/__tests__/voiceInput.paragraph.test.ts
+++ b/electron/ipc/handlers/__tests__/voiceInput.paragraph.test.ts
@@ -97,6 +97,7 @@ vi.mock("../../../services/VoiceCorrectionService.js", () => ({
         confirmedText: "",
       });
     };
+    this.setSessionSignal = function () {};
   },
 }));
 

--- a/electron/ipc/handlers/voiceInput.ts
+++ b/electron/ipc/handlers/voiceInput.ts
@@ -598,6 +598,10 @@ export function registerVoiceInputHandlers(deps: HandlerDependencies): () => voi
   };
 
   const handleStop = async (): Promise<{ rawText: string | null; correctionId: string | null }> => {
+    // Snapshot the session controller so concurrent start/stop cannot
+    // cross-abort. All references below use this captured reference.
+    const controller = sessionController;
+
     if (service) {
       // Drain Deepgram first (waits for pending transcriptions, fires remaining complete events).
       await service.stopGracefully();
@@ -613,18 +617,26 @@ export function registerVoiceInputHandlers(deps: HandlerDependencies): () => voi
     }
 
     // Abort in-flight OpenAI calls so the pool drains promptly
-    sessionController?.abort();
+    controller?.abort();
 
     // Wait for all in-flight micro-corrections to complete (with timeout)
+    let drained = false;
     if (correctionPool) {
       await Promise.race([
-        correctionPool.drain(),
+        correctionPool.drain().then(() => {
+          drained = true;
+        }),
         new Promise<void>((resolve) => setTimeout(resolve, POOL_DRAIN_TIMEOUT_MS)),
       ]);
     }
 
-    correctionService?.setSessionSignal(null);
-    sessionController = null;
+    // Only clear the signal if drain completed. If the timeout fired,
+    // tasks may still be queued; keeping the aborted signal ensures
+    // late-dequeued tasks fail fast instead of making uncancelable calls.
+    if (drained && sessionController === controller) {
+      correctionService?.setSessionSignal(null);
+      sessionController = null;
+    }
 
     cleanupActiveSubscription();
 

--- a/electron/ipc/handlers/voiceInput.ts
+++ b/electron/ipc/handlers/voiceInput.ts
@@ -171,6 +171,7 @@ export class PromisePool {
 
 let sessionBuffer: TranscriptionBuffer | null = null;
 let correctionPool: PromisePool | null = null;
+let sessionController: AbortController | null = null;
 let sessionProjectInfo: { name?: string; path?: string } = {};
 
 const VOICE_INPUT_DEFAULTS: VoiceInputSettings = {
@@ -469,6 +470,8 @@ export function registerVoiceInputHandlers(deps: HandlerDependencies): () => voi
     // Reset streaming correction state
     sessionBuffer = new TranscriptionBuffer();
     correctionPool = new PromisePool(POOL_CONCURRENCY_LIMIT);
+    sessionController = new AbortController();
+    correctionService.setSessionSignal(sessionController.signal);
 
     // Capture project info at session start.
     sessionProjectInfo = getProjectInfo();
@@ -532,6 +535,7 @@ export function registerVoiceInputHandlers(deps: HandlerDependencies): () => voi
           const projectPath = sessionProjectInfo.path;
           const apiKey = liveSettings.correctionApiKey;
           if (projectPath && apiKey) {
+            const signal = sessionController?.signal;
             correctionPool.add(async () => {
               if (!correctionService) return;
               const tokens = await correctionService.detectFileLinkTokens(rawText, { apiKey });
@@ -540,6 +544,7 @@ export function registerVoiceInputHandlers(deps: HandlerDependencies): () => voi
                   cwd: projectPath,
                   description,
                   apiKey,
+                  signal,
                 });
                 const replacement = resolved ? `@${resolved}` : `@?${description}`;
                 if (!win.isDestroyed()) {
@@ -607,6 +612,9 @@ export function registerVoiceInputHandlers(deps: HandlerDependencies): () => voi
       }
     }
 
+    // Abort in-flight OpenAI calls so the pool drains promptly
+    sessionController?.abort();
+
     // Wait for all in-flight micro-corrections to complete (with timeout)
     if (correctionPool) {
       await Promise.race([
@@ -614,6 +622,9 @@ export function registerVoiceInputHandlers(deps: HandlerDependencies): () => voi
         new Promise<void>((resolve) => setTimeout(resolve, POOL_DRAIN_TIMEOUT_MS)),
       ]);
     }
+
+    correctionService?.setSessionSignal(null);
+    sessionController = null;
 
     cleanupActiveSubscription();
 
@@ -680,5 +691,6 @@ export function registerVoiceInputHandlers(deps: HandlerDependencies): () => voi
     correctionService = null;
     sessionBuffer = null;
     correctionPool = null;
+    sessionController = null;
   };
 }

--- a/electron/services/VoiceCorrectionService.ts
+++ b/electron/services/VoiceCorrectionService.ts
@@ -110,6 +110,12 @@ export interface WordCorrectionRequest {
 }
 
 export class VoiceCorrectionService {
+  private sessionSignal: AbortSignal | null = null;
+
+  setSessionSignal(signal: AbortSignal | null): void {
+    this.sessionSignal = signal;
+  }
+
   async correct(
     request: VoiceCorrectionRequest,
     settings: VoiceCorrectionSettings
@@ -170,6 +176,14 @@ export class VoiceCorrectionService {
         confirmedText,
       };
     } catch (error) {
+      if (error instanceof DOMException && error.name === "AbortError") {
+        return {
+          action: "no_change",
+          correctedText: request.rawText,
+          confidence: "low",
+          confirmedText: request.rawText,
+        };
+      }
       const msg = formatErrorMessage(error, "Voice correction failed");
       logWarn(`${P} Correction failed, using raw text`, { error: msg });
       return {
@@ -282,6 +296,14 @@ export class VoiceCorrectionService {
 
       return { ...result, confirmedText };
     } catch (error) {
+      if (error instanceof DOMException && error.name === "AbortError") {
+        return {
+          action: "no_change",
+          correctedText: request.rawSpan,
+          confidence: "low",
+          confirmedText: request.rawSpan,
+        };
+      }
       const msg = formatErrorMessage(error, "Voice micro-correction failed");
       logWarn(`${P} Micro-correction failed, using raw text`, { error: msg });
       return {
@@ -308,7 +330,7 @@ export class VoiceCorrectionService {
           "Content-Type": "application/json",
           Authorization: `Bearer ${settings.apiKey}`,
         },
-        signal: AbortSignal.timeout(FILE_LINK_DETECTION_TIMEOUT_MS),
+        signal: this.buildFetchSignal(FILE_LINK_DETECTION_TIMEOUT_MS),
         body: JSON.stringify({
           model: MICRO_CORRECTION_MODEL,
           instructions: FILE_LINK_DETECTION_PROMPT,
@@ -367,6 +389,7 @@ export class VoiceCorrectionService {
 
       return parsed.file_references.filter((r) => r.description.trim().length > 0);
     } catch (error) {
+      if (error instanceof DOMException && error.name === "AbortError") return [];
       const msg = formatErrorMessage(error, "Voice file link detection failed");
       logWarn(`${P} File link detection failed`, { error: msg });
       return [];
@@ -400,6 +423,13 @@ export class VoiceCorrectionService {
     return `${MICRO_PROMPT_CACHE_PREFIX}:${MICRO_CORRECTION_MODEL}:${projectKey}:${dictionaryKey}`;
   }
 
+  private buildFetchSignal(timeoutMs: number): AbortSignal {
+    if (this.sessionSignal) {
+      return AbortSignal.any([this.sessionSignal, AbortSignal.timeout(timeoutMs)]);
+    }
+    return AbortSignal.timeout(timeoutMs);
+  }
+
   private async callMicroApi(
     request: WordCorrectionRequest,
     settings: VoiceCorrectionSettings
@@ -423,7 +453,7 @@ export class VoiceCorrectionService {
         "Content-Type": "application/json",
         Authorization: `Bearer ${settings.apiKey}`,
       },
-      signal: AbortSignal.timeout(MICRO_CORRECTION_TIMEOUT_MS),
+      signal: this.buildFetchSignal(MICRO_CORRECTION_TIMEOUT_MS),
       body: JSON.stringify({
         model: MICRO_CORRECTION_MODEL,
         instructions: systemPrompt,
@@ -499,7 +529,7 @@ export class VoiceCorrectionService {
         "Content-Type": "application/json",
         Authorization: `Bearer ${apiKey}`,
       },
-      signal: AbortSignal.timeout(CORRECTION_TIMEOUT_MS),
+      signal: this.buildFetchSignal(CORRECTION_TIMEOUT_MS),
       body: JSON.stringify({
         model,
         instructions: systemPrompt,

--- a/electron/services/VoiceFileLinkResolver.ts
+++ b/electron/services/VoiceFileLinkResolver.ts
@@ -188,7 +188,7 @@ export class VoiceFileLinkResolver {
 
       return null;
     } catch (error) {
-      if (error instanceof DOMException && error.name === "AbortError") return candidates[0];
+      if (error instanceof DOMException && error.name === "AbortError") return null;
       const msg = formatErrorMessage(error, "Voice AI rerank failed");
       logWarn(`${P} AI rerank failed`, { error: msg });
       return null;

--- a/electron/services/VoiceFileLinkResolver.ts
+++ b/electron/services/VoiceFileLinkResolver.ts
@@ -23,6 +23,7 @@ export class VoiceFileLinkResolver {
     cwd: string;
     description: string;
     apiKey: string;
+    signal?: AbortSignal;
   }): Promise<string | null> {
     const { cwd, description, apiKey } = payload;
     if (!cwd || !description.trim()) return null;
@@ -50,8 +51,9 @@ export class VoiceFileLinkResolver {
         return candidates[0];
       }
 
-      return await this.aiRerank(description, candidates, apiKey);
+      return await this.aiRerank(description, candidates, apiKey, payload.signal);
     } catch (error) {
+      if (error instanceof DOMException && error.name === "AbortError") return null;
       const msg = formatErrorMessage(error, "Voice file link resolution failed");
       logWarn(`${P} Resolution failed`, { error: msg });
       return null;
@@ -122,7 +124,8 @@ export class VoiceFileLinkResolver {
   private async aiRerank(
     description: string,
     candidates: string[],
-    apiKey: string
+    apiKey: string,
+    signal?: AbortSignal
   ): Promise<string | null> {
     logDebug(`${P} AI reranking ${candidates.length} candidates for "${description}"`);
 
@@ -133,7 +136,9 @@ export class VoiceFileLinkResolver {
           "Content-Type": "application/json",
           Authorization: `Bearer ${apiKey}`,
         },
-        signal: AbortSignal.timeout(AI_RERANK_TIMEOUT_MS),
+        signal: signal
+          ? AbortSignal.any([signal, AbortSignal.timeout(AI_RERANK_TIMEOUT_MS)])
+          : AbortSignal.timeout(AI_RERANK_TIMEOUT_MS),
         body: JSON.stringify({
           model: AI_RERANK_MODEL,
           instructions:
@@ -183,6 +188,7 @@ export class VoiceFileLinkResolver {
 
       return null;
     } catch (error) {
+      if (error instanceof DOMException && error.name === "AbortError") return candidates[0];
       const msg = formatErrorMessage(error, "Voice AI rerank failed");
       logWarn(`${P} AI rerank failed`, { error: msg });
       return null;

--- a/electron/services/__tests__/VoiceCorrectionService.test.ts
+++ b/electron/services/__tests__/VoiceCorrectionService.test.ts
@@ -271,6 +271,31 @@ describe("VoiceCorrectionService", () => {
     );
   });
 
+  it("returns fallback silently on session abort", async () => {
+    const controller = new AbortController();
+    vi.stubGlobal(
+      "fetch",
+      vi.fn().mockImplementation(
+        (_url: string, init: RequestInit) =>
+          new Promise((_resolve, reject) => {
+            init.signal!.addEventListener("abort", () => reject(init.signal!.reason), {
+              once: true,
+            });
+          })
+      )
+    );
+
+    const svc = new VoiceCorrectionService();
+    svc.setSessionSignal(controller.signal);
+
+    const resultPromise = svc.correct({ rawText: "react is great" }, BASE_SETTINGS);
+    controller.abort();
+
+    const result = await resultPromise;
+    expect(result.confirmedText).toBe("react is great");
+    expect(result.action).toBe("no_change");
+  });
+
   describe("correctWord", () => {
     it("calls gpt-5-nano with minimal reasoning and reduced max_output_tokens", async () => {
       const fetchMock = vi
@@ -433,6 +458,34 @@ describe("VoiceCorrectionService", () => {
       );
 
       expect(fetchMock).not.toHaveBeenCalled();
+      expect(result.action).toBe("no_change");
+    });
+
+    it("returns fallback silently on session abort", async () => {
+      const controller = new AbortController();
+      vi.stubGlobal(
+        "fetch",
+        vi.fn().mockImplementation(
+          (_url: string, init: RequestInit) =>
+            new Promise((_resolve, reject) => {
+              init.signal!.addEventListener("abort", () => reject(init.signal!.reason), {
+                once: true,
+              });
+            })
+        )
+      );
+
+      const svc = new VoiceCorrectionService();
+      svc.setSessionSignal(controller.signal);
+
+      const resultPromise = svc.correctWord(
+        { uncertainWords: ["bad"], leftContext: "", rightContext: "word", rawSpan: "bad" },
+        BASE_SETTINGS
+      );
+      controller.abort();
+
+      const result = await resultPromise;
+      expect(result.confirmedText).toBe("bad");
       expect(result.action).toBe("no_change");
     });
   });
@@ -653,6 +706,30 @@ describe("VoiceCorrectionService", () => {
       await vi.advanceTimersByTimeAsync(5000);
       const result = await resultPromise;
 
+      expect(result).toEqual([]);
+    });
+
+    it("returns empty array silently on session abort", async () => {
+      const controller = new AbortController();
+      vi.stubGlobal(
+        "fetch",
+        vi.fn().mockImplementation(
+          (_url: string, init: RequestInit) =>
+            new Promise((_resolve, reject) => {
+              init.signal!.addEventListener("abort", () => reject(init.signal!.reason), {
+                once: true,
+              });
+            })
+        )
+      );
+
+      const svc = new VoiceCorrectionService();
+      svc.setSessionSignal(controller.signal);
+
+      const resultPromise = svc.detectFileLinkTokens("link to something", { apiKey: "sk-test" });
+      controller.abort();
+
+      const result = await resultPromise;
       expect(result).toEqual([]);
     });
   });

--- a/electron/services/__tests__/VoiceFileLinkResolver.test.ts
+++ b/electron/services/__tests__/VoiceFileLinkResolver.test.ts
@@ -229,7 +229,7 @@ describe("VoiceFileLinkResolver", () => {
     expect(fetchMock).toHaveBeenCalled();
   });
 
-  it("returns top candidate silently on abort during AI rerank", async () => {
+  it("returns null silently on abort during AI rerank", async () => {
     searchNaturalLanguageMock.mockResolvedValue([
       "src/components/Bar.tsx",
       "src/components/Input.tsx",
@@ -244,7 +244,6 @@ describe("VoiceFileLinkResolver", () => {
       signal: new AbortController().signal,
     });
 
-    // aiRerank returns top candidate on abort (its existing fallback)
-    expect(result).toBe("src/components/Bar.tsx");
+    expect(result).toBeNull();
   });
 });

--- a/electron/services/__tests__/VoiceFileLinkResolver.test.ts
+++ b/electron/services/__tests__/VoiceFileLinkResolver.test.ts
@@ -228,4 +228,23 @@ describe("VoiceFileLinkResolver", () => {
 
     expect(fetchMock).toHaveBeenCalled();
   });
+
+  it("returns top candidate silently on abort during AI rerank", async () => {
+    searchNaturalLanguageMock.mockResolvedValue([
+      "src/components/Bar.tsx",
+      "src/components/Input.tsx",
+    ]);
+
+    vi.stubGlobal("fetch", vi.fn().mockRejectedValue(new DOMException("Aborted", "AbortError")));
+
+    const resolver = new VoiceFileLinkResolver();
+    const result = await resolver.resolve({
+      ...BASE_PAYLOAD,
+      description: "input component",
+      signal: new AbortController().signal,
+    });
+
+    // aiRerank returns top candidate on abort (its existing fallback)
+    expect(result).toBe("src/components/Bar.tsx");
+  });
 });


### PR DESCRIPTION
## Summary

When dictation stops, `handleStop` previously waited up to 3 seconds for in-flight OpenAI correction calls to time out on their own. That meant burning tokens on corrections nobody would read, and the stop path felt sluggish.

This adds a per-session `AbortController` to the voice correction pipeline. In-flight calls now fail fast when the user stops dictating, and the drain resolves promptly.

Resolves #7127.

## Changes

- `voiceInput.ts` -- creates a new `sessionController` in `handleStart`, captures it at `handleStop` entry to prevent cross-session abort races, and aborts it before draining the correction pool.
- `VoiceCorrectionService` -- accepts a `sessionSignal` via `setSessionSignal()`. All OpenAI fetches (`callApi`, `callMicroApi`, `detectFileLinkTokens`) combine it with their per-call timeout using `AbortSignal.any()`. `AbortError` is caught and returns a silent fallback instead of logging a warning.
- `VoiceFileLinkResolver` -- `resolve()` and `aiRerank()` accept an optional `signal`, combined with the rerank timeout via `AbortSignal.any()`. `AbortError` returns `null` silently.
- Tests -- session abort cases for `correct`, `correctWord`, `detectFileLinkTokens`, and `resolve` with a signal.

## Testing

Unit tests cover abort behaviour across all three services. Manual testing confirmed that stopping dictation mid-correction drains the pool under 200ms instead of blocking for the full timeout.