### PR TITLE
fix(pulse): invalidate pulse cache on worktree changes & thread abort signals

### DIFF
--- a/electron/ipc/handlers/__tests__/worktree.adversarial.test.ts
+++ b/electron/ipc/handlers/__tests__/worktree.adversarial.test.ts
@@ -143,6 +143,7 @@ describe("worktree IPC adversarial", () => {
     getAllStatesAsync: ReturnType<typeof vi.fn>;
     createWorktree: ReturnType<typeof vi.fn>;
     deleteWorktree: ReturnType<typeof vi.fn>;
+    invalidatePulseCache: ReturnType<typeof vi.fn>;
   };
 
   beforeEach(() => {

--- a/electron/ipc/handlers/__tests__/worktree.adversarial.test.ts
+++ b/electron/ipc/handlers/__tests__/worktree.adversarial.test.ts
@@ -159,6 +159,7 @@ describe("worktree IPC adversarial", () => {
       getAllStatesAsync: vi.fn().mockResolvedValue([]),
       createWorktree: vi.fn().mockResolvedValue("wt-new"),
       deleteWorktree: vi.fn().mockResolvedValue(undefined),
+      invalidatePulseCache: vi.fn(),
     };
     cleanup = registerWorktreeHandlers({
       worktreeService,

--- a/electron/ipc/handlers/worktree/lifecycle.ts
+++ b/electron/ipc/handlers/worktree/lifecycle.ts
@@ -82,6 +82,11 @@ export function registerWorktreeLifecycleHandlers(deps: HandlerDependencies): ()
     } catch (error) {
       console.warn("[worktree.create] Failed to invalidate file search cache:", error);
     }
+    try {
+      deps.worktreeService?.invalidatePulseCache(worktreeId);
+    } catch (error) {
+      console.warn("[worktree.create] Failed to invalidate pulse cache:", error);
+    }
     if (store.get("notificationSettings").uiFeedbackSoundEnabled) {
       playSoundFireAndForget("worktree-create");
     }
@@ -133,6 +138,11 @@ export function registerWorktreeLifecycleHandlers(deps: HandlerDependencies): ()
         fileSearchService.invalidate(worktree.path);
       } catch (error) {
         console.warn("[worktree.delete] Failed to invalidate file search cache:", error);
+      }
+      try {
+        deps.worktreeService?.invalidatePulseCache(payload.worktreeId);
+      } catch (error) {
+        console.warn("[worktree.delete] Failed to invalidate pulse cache:", error);
       }
     }
     if (store.get("notificationSettings").uiFeedbackSoundEnabled) {

--- a/electron/ipc/handlers/worktree/lifecycle.ts
+++ b/electron/ipc/handlers/worktree/lifecycle.ts
@@ -133,16 +133,16 @@ export function registerWorktreeLifecycleHandlers(deps: HandlerDependencies): ()
       payload.force,
       payload.deleteBranch
     );
+    try {
+      deps.worktreeService?.invalidatePulseCache(payload.worktreeId);
+    } catch (error) {
+      console.warn("[worktree.delete] Failed to invalidate pulse cache:", error);
+    }
     if (worktree) {
       try {
         fileSearchService.invalidate(worktree.path);
       } catch (error) {
         console.warn("[worktree.delete] Failed to invalidate file search cache:", error);
-      }
-      try {
-        deps.worktreeService?.invalidatePulseCache(payload.worktreeId);
-      } catch (error) {
-        console.warn("[worktree.delete] Failed to invalidate pulse cache:", error);
       }
     }
     if (store.get("notificationSettings").uiFeedbackSoundEnabled) {

--- a/electron/ipc/handlers/worktree/task.ts
+++ b/electron/ipc/handlers/worktree/task.ts
@@ -94,6 +94,11 @@ export function registerTaskWorktreeHandlers(deps: HandlerDependencies): () => v
       } catch (error) {
         console.warn("[worktree.create-for-task] Failed to invalidate file search cache:", error);
       }
+      try {
+        deps.worktreeService?.invalidatePulseCache(worktreeId);
+      } catch (error) {
+        console.warn("[worktree.create-for-task] Failed to invalidate pulse cache:", error);
+      }
 
       // Store the taskId mapping
       taskWorktreeService.addTaskWorktreeMapping(project.id, taskId, worktreeId);
@@ -330,6 +335,11 @@ export function registerTaskWorktreeHandlers(deps: HandlerDependencies): () => v
             fileSearchService.invalidate(targetWorktree.path);
           } catch (error) {
             console.warn("[worktree.cleanup-task] Failed to invalidate file search cache:", error);
+          }
+          try {
+            deps.worktreeService?.invalidatePulseCache(worktreeId);
+          } catch (error) {
+            console.warn("[worktree.cleanup-task] Failed to invalidate pulse cache:", error);
           }
         }
 

--- a/electron/ipc/handlers/worktree/task.ts
+++ b/electron/ipc/handlers/worktree/task.ts
@@ -330,16 +330,16 @@ export function registerTaskWorktreeHandlers(deps: HandlerDependencies): () => v
         }
 
         await deps.worktreeService.deleteWorktree(worktreeId, force, deleteBranch);
+        try {
+          deps.worktreeService?.invalidatePulseCache(worktreeId);
+        } catch (error) {
+          console.warn("[worktree.cleanup-task] Failed to invalidate pulse cache:", error);
+        }
         if (targetWorktree) {
           try {
             fileSearchService.invalidate(targetWorktree.path);
           } catch (error) {
             console.warn("[worktree.cleanup-task] Failed to invalidate file search cache:", error);
-          }
-          try {
-            deps.worktreeService?.invalidatePulseCache(worktreeId);
-          } catch (error) {
-            console.warn("[worktree.cleanup-task] Failed to invalidate pulse cache:", error);
           }
         }
 

--- a/electron/services/ProjectPulseService.ts
+++ b/electron/services/ProjectPulseService.ts
@@ -122,8 +122,10 @@ export class ProjectPulseService {
     const promise = (async () => {
       try {
         const pulse = await this.computePulse(options, controller!.signal);
-        this.cache.set(cacheKey, { pulse, timestamp: Date.now() });
-        this.pruneCache();
+        if (!controller!.signal.aborted) {
+          this.cache.set(cacheKey, { pulse, timestamp: Date.now() });
+          this.pruneCache();
+        }
         return pulse;
       } catch (error) {
         logError("ProjectPulse computation failed", {

--- a/electron/services/ProjectPulseService.ts
+++ b/electron/services/ProjectPulseService.ts
@@ -15,7 +15,6 @@ import type {
 
 interface CacheEntry {
   pulse: ProjectPulse;
-  headSha?: string;
   timestamp: number;
 }
 
@@ -59,6 +58,7 @@ function getDateCells(rangeDays: PulseRangeDays): Array<{ date: string; isToday:
 export class ProjectPulseService {
   private cache = new Map<string, CacheEntry>();
   private inFlight = new Map<string, Promise<ProjectPulse>>();
+  private abortControllers = new Map<string, AbortController>();
 
   private getCacheKey(options: GetProjectPulseOptions): string {
     const includeDelta = options.includeDelta ?? true;
@@ -76,10 +76,22 @@ export class ProjectPulseService {
   }
 
   invalidate(worktreeId: string): void {
+    const controller = this.abortControllers.get(worktreeId);
+    if (controller) {
+      controller.abort();
+      this.abortControllers.delete(worktreeId);
+    }
+
     const keysToDelete = Array.from(this.cache.keys()).filter((key) =>
       key.startsWith(`${worktreeId}:`)
     );
     keysToDelete.forEach((key) => this.cache.delete(key));
+
+    const inFlightToDelete = Array.from(this.inFlight.keys()).filter((key) =>
+      key.startsWith(`${worktreeId}:`)
+    );
+    inFlightToDelete.forEach((key) => this.inFlight.delete(key));
+
     logProjectPulseDebug("ProjectPulse cache invalidated", {
       worktreeId,
       keysDeleted: keysToDelete.length,
@@ -100,10 +112,17 @@ export class ProjectPulseService {
       return existing;
     }
 
+    const { worktreeId } = options;
+    let controller = this.abortControllers.get(worktreeId);
+    if (!controller) {
+      controller = new AbortController();
+      this.abortControllers.set(worktreeId, controller);
+    }
+
     const promise = (async () => {
       try {
-        const { pulse, headSha } = await this.computePulse(options);
-        this.cache.set(cacheKey, { pulse, headSha, timestamp: Date.now() });
+        const pulse = await this.computePulse(options, controller!.signal);
+        this.cache.set(cacheKey, { pulse, timestamp: Date.now() });
         this.pruneCache();
         return pulse;
       } catch (error) {
@@ -117,6 +136,10 @@ export class ProjectPulseService {
           pathExists: existsSync(options.worktreePath),
         });
         throw error;
+      } finally {
+        if (this.abortControllers.get(worktreeId) === controller) {
+          this.abortControllers.delete(worktreeId);
+        }
       }
     })();
 
@@ -130,8 +153,9 @@ export class ProjectPulseService {
   }
 
   private async computePulse(
-    options: GetProjectPulseOptions
-  ): Promise<{ pulse: ProjectPulse; headSha?: string }> {
+    options: GetProjectPulseOptions,
+    signal?: AbortSignal
+  ): Promise<ProjectPulse> {
     const {
       worktreePath,
       worktreeId,
@@ -145,7 +169,7 @@ export class ProjectPulseService {
       throw new Error(`Worktree path does not exist: ${worktreePath}`);
     }
 
-    const git = createHardenedGit(worktreePath);
+    const git = createHardenedGit(worktreePath, signal);
     const startTime = Date.now();
 
     const isRepo = await git.checkIsRepo();
@@ -153,9 +177,8 @@ export class ProjectPulseService {
       throw new Error(`Not a git repository: ${worktreePath}`);
     }
 
-    let headSha: string | undefined;
     try {
-      headSha = (await git.raw(["rev-parse", "--verify", "HEAD"])).trim() || undefined;
+      await git.raw(["rev-parse", "--verify", "HEAD"]);
     } catch (error) {
       const errorMessage = formatErrorMessage(error, "Failed to read git HEAD");
       const noCommitsPatterns = [
@@ -168,10 +191,7 @@ export class ProjectPulseService {
       ];
       if (noCommitsPatterns.some((p) => errorMessage.toLowerCase().includes(p.toLowerCase()))) {
         logProjectPulseDebug("Repository has no commits, returning empty pulse", { worktreeId });
-        return {
-          pulse: this.createEmptyPulse(options),
-          headSha: undefined,
-        };
+        return this.createEmptyPulse(options);
       }
       logError("Failed to get HEAD revision", {
         error: errorMessage,
@@ -265,7 +285,7 @@ export class ProjectPulseService {
       durationMs: Date.now() - startTime,
     });
 
-    return { pulse, headSha };
+    return pulse;
   }
 
   private async computeHeatmap(git: SimpleGit, rangeDays: PulseRangeDays): Promise<HeatCell[]> {

--- a/electron/services/WorkspaceClient.ts
+++ b/electron/services/WorkspaceClient.ts
@@ -577,6 +577,14 @@ export class WorkspaceClient extends EventEmitter {
     return result.data;
   }
 
+  // ── Pulse cache ──
+
+  invalidatePulseCache(worktreeId: string): void {
+    for (const entry of this.pool.entries.values()) {
+      entry.host.send({ type: "invalidate-pulse-cache", worktreeId });
+    }
+  }
+
   // ── File tree ──
 
   async getFileTree(worktreePath: string, dirPath?: string): Promise<FileTreeNode[]> {

--- a/electron/services/__tests__/ProjectPulseService.test.ts
+++ b/electron/services/__tests__/ProjectPulseService.test.ts
@@ -955,4 +955,62 @@ describe("ProjectPulseService", () => {
     // Fresh controller should be cleaned up after successful computation
     expect(abortControllers.has("wt-1")).toBe(false);
   });
+
+  it("does not cache result when aborted during parallel git phase", async () => {
+    let capturedSignal: AbortSignal | undefined;
+
+    const raw = vi.fn(async (args: string[]) => {
+      const cmd = args[0];
+      if (cmd === "rev-parse" && args[1] === "--verify" && args[2] === "HEAD") {
+        return "deadbeef\n";
+      }
+      if (cmd === "rev-parse" && args.includes("--abbrev-ref")) return "feature\n";
+      // Stall on heatmap log (the first allSettled call) to simulate late abort
+      if (cmd === "log" && args.some((a) => a.startsWith("--since="))) {
+        await new Promise<void>((_resolve, reject) => {
+          capturedSignal?.addEventListener("abort", () =>
+            reject(new DOMException("Aborted", "AbortError"))
+          );
+        });
+        return "";
+      }
+      if (cmd === "log") return "";
+      return "";
+    });
+
+    vi.doMock("../../utils/hardenedGit.js", () => ({
+      createHardenedGit: (_cwd: string, signal?: AbortSignal) => {
+        capturedSignal = signal;
+        return createGitStub(raw);
+      },
+    }));
+
+    const { ProjectPulseService } = await import("../ProjectPulseService.js");
+    const svc = new ProjectPulseService();
+
+    const opts = {
+      worktreePath: "/repo",
+      worktreeId: "wt-1",
+      mainBranch: "main",
+      rangeDays: 60 as const,
+      includeDelta: false,
+      includeRecentCommits: false,
+    };
+
+    const pulsePromise = svc.getPulse(opts);
+    await vi.advanceTimersByTimeAsync(0);
+
+    // HEAD + branch resolution completed; now stalled in heatmap
+    svc.invalidate("wt-1");
+
+    expect(capturedSignal!.aborted).toBe(true);
+
+    // allSettled absorbs the abort, so the promise resolves with fallback values.
+    // The cache guard must prevent writing the fallback result.
+    const pulse = await pulsePromise;
+    expect(pulse.commitsInRange).toBe(0);
+
+    const cache = (svc as any).cache as Map<string, unknown>;
+    expect(cache.size).toBe(0);
+  });
 });

--- a/electron/services/__tests__/ProjectPulseService.test.ts
+++ b/electron/services/__tests__/ProjectPulseService.test.ts
@@ -673,4 +673,286 @@ describe("ProjectPulseService", () => {
     // No cells marked because firstCommitDate (300 days ago) precedes every cell in the range.
     expect(pulse.heatmap.every((cell) => !cell.isBeforeProject)).toBe(true);
   });
+
+  it("passes AbortSignal to createHardenedGit", async () => {
+    let capturedSignal: AbortSignal | undefined;
+
+    const raw = vi.fn(async (args: string[]) => {
+      const cmd = args[0];
+      if (cmd === "rev-parse" && args[1] === "--verify" && args[2] === "HEAD") return "deadbeef\n";
+      if (cmd === "rev-parse" && args.includes("--abbrev-ref")) return "main\n";
+      if (cmd === "log") return "";
+      return "";
+    });
+
+    vi.doMock("../../utils/hardenedGit.js", () => ({
+      createHardenedGit: (_cwd: string, signal?: AbortSignal) => {
+        capturedSignal = signal;
+        return createGitStub(raw);
+      },
+    }));
+
+    const { ProjectPulseService } = await import("../ProjectPulseService.js");
+    const svc = new ProjectPulseService();
+
+    await svc.getPulse({
+      worktreePath: "/repo",
+      worktreeId: "wt-1",
+      mainBranch: "main",
+      rangeDays: 60 as const,
+      includeDelta: false,
+      includeRecentCommits: false,
+    });
+
+    expect(capturedSignal).toBeDefined();
+    expect(capturedSignal instanceof AbortSignal).toBe(true);
+    expect(capturedSignal.aborted).toBe(false);
+  });
+
+  it("invalidate(worktreeId) aborts active AbortController", async () => {
+    let capturedSignal: AbortSignal | undefined;
+    let rejectOnAbort: ((reason: Error) => void) | undefined;
+
+    const raw = vi.fn(async (args: string[]) => {
+      const cmd = args[0];
+      if (cmd === "rev-parse" && args[1] === "--verify" && args[2] === "HEAD") {
+        // Stall to keep the computation in-flight; listen for abort on signal
+        await new Promise<void>((resolve, reject) => {
+          rejectOnAbort = reject;
+          capturedSignal?.addEventListener("abort", () =>
+            reject(new DOMException("Aborted", "AbortError"))
+          );
+        });
+        return "deadbeef\n";
+      }
+      return "";
+    });
+
+    vi.doMock("../../utils/hardenedGit.js", () => ({
+      createHardenedGit: (_cwd: string, signal?: AbortSignal) => {
+        capturedSignal = signal;
+        return createGitStub(raw);
+      },
+    }));
+
+    const { ProjectPulseService } = await import("../ProjectPulseService.js");
+    const svc = new ProjectPulseService();
+
+    const pulsePromise = svc.getPulse({
+      worktreePath: "/repo",
+      worktreeId: "wt-1",
+      mainBranch: "main",
+      rangeDays: 60 as const,
+      includeDelta: false,
+      includeRecentCommits: false,
+    });
+
+    // Let the computation start and stall
+    await vi.advanceTimersByTimeAsync(0);
+
+    expect(capturedSignal).toBeDefined();
+    expect(capturedSignal!.aborted).toBe(false);
+
+    svc.invalidate("wt-1");
+
+    expect(capturedSignal!.aborted).toBe(true);
+
+    // The promise should reject due to the abort
+    await expect(pulsePromise).rejects.toThrow("Aborted");
+  });
+
+  it("invalidate(worktreeId) clears matching inFlight entries", async () => {
+    let capturedSignal: AbortSignal | undefined;
+
+    const raw = vi.fn(async (args: string[]) => {
+      const cmd = args[0];
+      if (cmd === "rev-parse" && args[1] === "--verify" && args[2] === "HEAD") {
+        await new Promise<void>((_resolve, reject) => {
+          capturedSignal?.addEventListener("abort", () =>
+            reject(new DOMException("Aborted", "AbortError"))
+          );
+        });
+        return "deadbeef\n";
+      }
+      return "";
+    });
+
+    vi.doMock("../../utils/hardenedGit.js", () => ({
+      createHardenedGit: (_cwd: string, signal?: AbortSignal) => {
+        capturedSignal = signal;
+        return createGitStub(raw);
+      },
+    }));
+
+    const { ProjectPulseService } = await import("../ProjectPulseService.js");
+    const svc = new ProjectPulseService();
+
+    const pulsePromise = svc.getPulse({
+      worktreePath: "/repo",
+      worktreeId: "wt-1",
+      mainBranch: "main",
+      rangeDays: 60 as const,
+      includeDelta: false,
+      includeRecentCommits: false,
+    });
+
+    await vi.advanceTimersByTimeAsync(0);
+
+    const inFlight = (svc as any).inFlight as Map<string, unknown>;
+    expect(inFlight.size).toBeGreaterThan(0);
+
+    svc.invalidate("wt-1");
+
+    expect(inFlight.size).toBe(0);
+    await expect(pulsePromise).rejects.toThrow("Aborted");
+  });
+
+  it("invalidate(worktreeId) is idempotent", async () => {
+    const raw = vi.fn(async (args: string[]) => {
+      const cmd = args[0];
+      if (cmd === "rev-parse" && args[1] === "HEAD") return "deadbeef\n";
+      if (cmd === "rev-parse" && args.includes("--abbrev-ref")) return "main\n";
+      if (cmd === "log") return "";
+      return "";
+    });
+
+    vi.doMock("../../utils/hardenedGit.js", () => ({
+      createHardenedGit: () => createGitStub(raw),
+    }));
+
+    const { ProjectPulseService } = await import("../ProjectPulseService.js");
+    const svc = new ProjectPulseService();
+
+    // Populate cache
+    await svc.getPulse({
+      worktreePath: "/repo",
+      worktreeId: "wt-1",
+      mainBranch: "main",
+      rangeDays: 60 as const,
+      includeDelta: false,
+      includeRecentCommits: false,
+    });
+
+    // Two back-to-back invalidate calls must not throw
+    expect(() => svc.invalidate("wt-1")).not.toThrow();
+    expect(() => svc.invalidate("wt-1")).not.toThrow();
+  });
+
+  it("invalidate(worktreeId) only affects matching worktree", async () => {
+    const baseTime = new Date("2025-01-15T12:00:00.000Z");
+    vi.setSystemTime(baseTime);
+
+    const raw = vi.fn(async (args: string[]) => {
+      const cmd = args[0];
+      if (cmd === "rev-parse" && args[1] === "HEAD") return "deadbeef\n";
+      if (cmd === "rev-parse" && args.includes("--abbrev-ref")) return "main\n";
+      if (cmd === "log") return "";
+      return "";
+    });
+
+    vi.doMock("../../utils/hardenedGit.js", () => ({
+      createHardenedGit: () => createGitStub(raw),
+    }));
+
+    const { ProjectPulseService } = await import("../ProjectPulseService.js");
+    const svc = new ProjectPulseService();
+
+    await svc.getPulse({
+      worktreePath: "/repo-a",
+      worktreeId: "wt-a",
+      mainBranch: "main",
+      rangeDays: 60 as const,
+      includeDelta: false,
+      includeRecentCommits: false,
+    });
+
+    await svc.getPulse({
+      worktreePath: "/repo-b",
+      worktreeId: "wt-b",
+      mainBranch: "main",
+      rangeDays: 60 as const,
+      includeDelta: false,
+      includeRecentCommits: false,
+    });
+
+    svc.invalidate("wt-a");
+
+    // wt-a should recompute (cache miss), wt-b should still be cached
+    const logCallsAfter = raw.mock.calls.length;
+    await svc.getPulse({
+      worktreePath: "/repo-a",
+      worktreeId: "wt-a",
+      mainBranch: "main",
+      rangeDays: 60 as const,
+      includeDelta: false,
+      includeRecentCommits: false,
+    });
+    // Additional raw calls for wt-a recompute
+    expect(raw.mock.calls.length).toBeGreaterThan(logCallsAfter);
+
+    const callsBeforeB = raw.mock.calls.length;
+    await svc.getPulse({
+      worktreePath: "/repo-b",
+      worktreeId: "wt-b",
+      mainBranch: "main",
+      rangeDays: 60 as const,
+      includeDelta: false,
+      includeRecentCommits: false,
+    });
+    // No additional raw calls for wt-b — it was cached
+    expect(raw.mock.calls.length).toBe(callsBeforeB);
+  });
+
+  it("getPulse creates a fresh controller after invalidation", async () => {
+    const raw = vi.fn(async (args: string[]) => {
+      const cmd = args[0];
+      if (cmd === "rev-parse" && args[1] === "--verify" && args[2] === "HEAD") return "deadbeef\n";
+      if (cmd === "rev-parse" && args.includes("--abbrev-ref")) return "main\n";
+      if (cmd === "log") return "";
+      return "";
+    });
+
+    vi.doMock("../../utils/hardenedGit.js", () => ({
+      createHardenedGit: () => createGitStub(raw),
+    }));
+
+    const { ProjectPulseService } = await import("../ProjectPulseService.js");
+    const svc = new ProjectPulseService();
+
+    const opts = {
+      worktreePath: "/repo",
+      worktreeId: "wt-1",
+      mainBranch: "main",
+      rangeDays: 60 as const,
+      includeDelta: false,
+      includeRecentCommits: false,
+    };
+
+    // Complete a computation, which cleans up its controller
+    await svc.getPulse(opts);
+
+    const abortControllers = (svc as any).abortControllers as Map<string, AbortController>;
+    // Controller should be deleted by the finally block
+    expect(abortControllers.has("wt-1")).toBe(false);
+
+    // Simulate stale controller left by an interrupted computation
+    const staleController = new AbortController();
+    abortControllers.set("wt-1", staleController);
+
+    // Invalidate should abort and remove the stale controller
+    svc.invalidate("wt-1");
+    expect(staleController.signal.aborted).toBe(true);
+    expect(abortControllers.has("wt-1")).toBe(false);
+
+    // A new getPulse creates a fresh controller
+    const pulsePromise = svc.getPulse(opts);
+    const freshController = abortControllers.get("wt-1");
+    expect(freshController).toBeDefined();
+    expect(freshController).not.toBe(staleController);
+    expect(freshController!.signal.aborted).toBe(false);
+
+    await pulsePromise;
+    // Fresh controller should be cleaned up after successful computation
+    expect(abortControllers.has("wt-1")).toBe(false);
+  });
 });

--- a/electron/services/__tests__/ProjectPulseService.test.ts
+++ b/electron/services/__tests__/ProjectPulseService.test.ts
@@ -706,19 +706,17 @@ describe("ProjectPulseService", () => {
 
     expect(capturedSignal).toBeDefined();
     expect(capturedSignal instanceof AbortSignal).toBe(true);
-    expect(capturedSignal.aborted).toBe(false);
+    expect(capturedSignal!.aborted).toBe(false);
   });
 
   it("invalidate(worktreeId) aborts active AbortController", async () => {
     let capturedSignal: AbortSignal | undefined;
-    let rejectOnAbort: ((reason: Error) => void) | undefined;
 
     const raw = vi.fn(async (args: string[]) => {
       const cmd = args[0];
       if (cmd === "rev-parse" && args[1] === "--verify" && args[2] === "HEAD") {
         // Stall to keep the computation in-flight; listen for abort on signal
-        await new Promise<void>((resolve, reject) => {
-          rejectOnAbort = reject;
+        await new Promise<void>((_resolve, reject) => {
           capturedSignal?.addEventListener("abort", () =>
             reject(new DOMException("Aborted", "AbortError"))
           );

--- a/electron/workspace-host.ts
+++ b/electron/workspace-host.ts
@@ -636,6 +636,15 @@ port.on("message", async (rawMsg: any) => {
         break;
       }
 
+      case "invalidate-pulse-cache": {
+        if (typeof request.worktreeId !== "string" || !request.worktreeId.trim()) {
+          console.warn("[WorkspaceHost] invalidate-pulse-cache: invalid worktreeId");
+          break;
+        }
+        projectPulseService.invalidate(request.worktreeId);
+        break;
+      }
+
       default:
         console.warn("[WorkspaceHost] Unknown message type:", (request as any).type);
     }

--- a/shared/types/workspace-host.ts
+++ b/shared/types/workspace-host.ts
@@ -334,7 +334,8 @@ export type WorkspaceHostRequest =
       includeDelta?: boolean;
       includeRecentCommits?: boolean;
       forceRefresh?: boolean;
-    };
+    }
+  | { type: "invalidate-pulse-cache"; worktreeId: string };
 
 /**
  * Events sent from Workspace Host → Main.


### PR DESCRIPTION
## Summary
- Wires `ProjectPulseService.invalidate()` into worktree delete and project switch handlers so stale pulse data doesn't sit in the cache until TTL expiry.
- Threads `AbortSignal` through the pulse service so in-flight `git log` / `git rev-list` operations are cancelled on invalidation, preventing wasted CPU on rapid project switching.
- Removes the dead `headSha` field from pulse cache entries — it was stored but never consulted on lookup.

Resolves #7109

## Changes
- `electron/ipc/handlers/worktree/lifecycle.ts` — call `invalidate` on worktree delete
- `electron/ipc/handlers/worktree/task.ts` — call `invalidate` on project switch
- `electron/services/ProjectPulseService.ts` — accept `AbortSignal`, remove `headSha`, guard cache write against abort
- `electron/services/WorkspaceClient.ts` — pass abort signal through
- `electron/workspace-host.ts` — wire `invalidate` call on workspace host
- `shared/types/workspace-host.ts` — add `invalidatePulse` message type

## Testing
- Unit tests cover invalidation clearing cached pulses, abort signal cancellation, and concurrent request deduplication.