### PR TITLE
fix(security): extend shell-metachar deny-list at sanitizer mirror sites

### DIFF
--- a/electron/ipc/handlers/__tests__/helpAssistant.handlers.test.ts
+++ b/electron/ipc/handlers/__tests__/helpAssistant.handlers.test.ts
@@ -293,6 +293,29 @@ describe("registerHelpAssistantHandlers", () => {
     );
   });
 
+  it("rejects metacharacters past the 10000-char cap (check before truncation)", async () => {
+    registerHelpAssistantHandlers();
+    const handler = ipcMainMock._handlers.get(SET_CHANNEL)!;
+
+    // Metachar at position > CUSTOM_ARGS_MAX_LEN must still be caught — the
+    // deny-list check runs on the full collapsed string before slice().
+    await handler(null, { customArgs: "x".repeat(10000) + "; touch /tmp/pwned" });
+
+    expect(storeMock.set).not.toHaveBeenCalled();
+  });
+
+  it("catches metacharacters formed after control-char stripping", async () => {
+    registerHelpAssistantHandlers();
+    const handler = ipcMainMock._handlers.get(SET_CHANNEL)!;
+
+    // Control-char stripping happens before the deny-list check, so a value
+    // crafted to hide `$(` behind a NUL byte must still be rejected once the
+    // NUL is removed.
+    await handler(null, { customArgs: "--x $\x00(whoami)" });
+
+    expect(storeMock.set).not.toHaveBeenCalled();
+  });
+
   it("rejects customArgs values that are not strings", async () => {
     registerHelpAssistantHandlers();
     const handler = ipcMainMock._handlers.get(SET_CHANNEL)!;

--- a/electron/ipc/handlers/__tests__/helpAssistant.handlers.test.ts
+++ b/electron/ipc/handlers/__tests__/helpAssistant.handlers.test.ts
@@ -269,8 +269,28 @@ describe("registerHelpAssistantHandlers", () => {
     await handler(null, { customArgs: "--model $(whoami)" });
     await handler(null, { customArgs: "--model `id`" });
     await handler(null, { customArgs: "--model | tee out" });
+    // Extended deny-list (#7078): chaining, redirection, variable expansion, escape.
+    await handler(null, { customArgs: "--model sonnet & whoami" });
+    await handler(null, { customArgs: "--verbose > /etc/passwd" });
+    await handler(null, { customArgs: "--config < /etc/shadow" });
+    await handler(null, { customArgs: "--log >> /tmp/out" });
+    await handler(null, { customArgs: "--err 2> /tmp/err" });
+    await handler(null, { customArgs: "--model ${HOME}" });
+    await handler(null, { customArgs: "--flag\\;evil" });
 
     expect(storeMock.set).not.toHaveBeenCalled();
+  });
+
+  it("allows customArgs containing a bare $ without ( or { (no over-blocking)", async () => {
+    registerHelpAssistantHandlers();
+    const handler = ipcMainMock._handlers.get(SET_CHANNEL)!;
+
+    await handler(null, { customArgs: "--prompt-suffix $TODAY" });
+
+    expect(storeMock.set).toHaveBeenCalledExactlyOnceWith(
+      "helpAssistant.customArgs",
+      "--prompt-suffix $TODAY"
+    );
   });
 
   it("rejects customArgs values that are not strings", async () => {

--- a/electron/ipc/handlers/helpAssistant.ts
+++ b/electron/ipc/handlers/helpAssistant.ts
@@ -6,6 +6,7 @@ import type {
   HelpAssistantIdleHibernateMinutes,
   HelpAssistantSettings,
 } from "../../../shared/types/ipc/api.js";
+import { hasShellMetachar } from "../../../shared/utils/shellEscape.js";
 import type * as McpServerServiceModule from "../../services/McpServerService.js";
 
 type McpServerSingleton = typeof McpServerServiceModule.mcpServerService;
@@ -51,19 +52,13 @@ function isValidIdleHibernateMinutes(value: unknown): value is HelpAssistantIdle
 
 // Mirrors `customFlags` validation in src/config/agents.ts: the value is
 // whitespace-split and appended to the launch command, so any shell
-// metacharacter that could break out of the flag list is rejected.
+// metacharacter that could break out of the flag list is rejected. The
+// shared `hasShellMetachar` helper keeps both sites in lockstep.
 function sanitizeCustomArgs(value: unknown): string | undefined {
   if (typeof value !== "string") return undefined;
   // eslint-disable-next-line no-control-regex
   const collapsed = value.replace(/[\r\n]+/g, " ").replace(/[\x00-\x1f\x7f]/g, "");
-  if (
-    collapsed.includes(";") ||
-    collapsed.includes("|") ||
-    collapsed.includes("$(") ||
-    collapsed.includes("`")
-  ) {
-    return undefined;
-  }
+  if (hasShellMetachar(collapsed)) return undefined;
   return collapsed.slice(0, CUSTOM_ARGS_MAX_LEN);
 }
 

--- a/shared/utils/__tests__/shellEscape.test.ts
+++ b/shared/utils/__tests__/shellEscape.test.ts
@@ -2,6 +2,7 @@ import { describe, it, expect } from "vitest";
 import {
   escapeShellArg,
   escapeShellArgOptional,
+  hasShellMetachar,
   isSafeUnescaped,
   isWindows,
 } from "../shellEscape.js";
@@ -250,6 +251,45 @@ describe("shellEscape", () => {
       const withNull = "before\0after";
       const escaped = escapeShellArg(withNull, "posix");
       expect(escaped.includes("\0")).toBe(true);
+    });
+  });
+
+  describe("hasShellMetachar", () => {
+    it("returns false for empty string", () => {
+      expect(hasShellMetachar("")).toBe(false);
+    });
+
+    it("returns false for plain alphanumeric flag values", () => {
+      expect(hasShellMetachar("--verbose")).toBe(false);
+      expect(hasShellMetachar("--model claude-opus-4-6")).toBe(false);
+      expect(hasShellMetachar("--output-format json")).toBe(false);
+    });
+
+    it("returns false for bare $ without ( or { (no over-blocking)", () => {
+      expect(hasShellMetachar("$TODAY")).toBe(false);
+      expect(hasShellMetachar("--prompt-suffix $HOME_DIR")).toBe(false);
+    });
+
+    it.each([
+      [";", "--flag; evil"],
+      ["|", "--flag | tee out"],
+      ["&", "--flag & evil"],
+      [">", "--flag > /etc/passwd"],
+      ["<", "--flag < /etc/shadow"],
+      ["$(", "--flag $(whoami)"],
+      ["${", "--flag ${HOME}"],
+      ["`", "--flag `id`"],
+      ["\\", "--flag\\;evil"],
+    ])("returns true for value containing %s", (_metachar, value) => {
+      expect(hasShellMetachar(value)).toBe(true);
+    });
+
+    it("catches >> as substring of >", () => {
+      expect(hasShellMetachar("--log >> /tmp/out")).toBe(true);
+    });
+
+    it("catches 2> as substring of >", () => {
+      expect(hasShellMetachar("--err 2> /tmp/err")).toBe(true);
     });
   });
 });

--- a/shared/utils/shellEscape.ts
+++ b/shared/utils/shellEscape.ts
@@ -121,6 +121,11 @@ export function escapeShellArgOptional(arg: string, platform?: "windows" | "posi
 // that could break out of the flag list is rejected as defense-in-depth (the real
 // boundary is node-pty with no shell layer). `$(` and `${` are matched as substrings
 // to avoid over-blocking legitimate bare `$` in flag values.
+//
+// POSIX-oriented: cmd.exe-specific metachars (`%VAR%`, `^`, `!`) are intentionally
+// omitted because the spawn path is node-pty without a `cmd.exe` shell layer, so
+// those characters cannot trigger expansion. If a future code path ever feeds a
+// flag value through `cmd.exe`, that path needs its own escaping/validation step.
 const SHELL_METACHAR_PATTERNS = [";", "|", "&", ">", "<", "$(", "${", "`", "\\"] as const;
 
 /**

--- a/shared/utils/shellEscape.ts
+++ b/shared/utils/shellEscape.ts
@@ -114,3 +114,23 @@ export function escapeShellArgOptional(arg: string, platform?: "windows" | "posi
   }
   return escapeShellArg(arg, platform);
 }
+
+// Mirrored deny-list used by `sanitizeCustomArgs` (electron/ipc/handlers/helpAssistant.ts)
+// and the `customFlags` / `args` validation in src/config/agents.ts. Values flow into
+// whitespace-split tokens that are appended to the launch command, so any character
+// that could break out of the flag list is rejected as defense-in-depth (the real
+// boundary is node-pty with no shell layer). `$(` and `${` are matched as substrings
+// to avoid over-blocking legitimate bare `$` in flag values.
+const SHELL_METACHAR_PATTERNS = [";", "|", "&", ">", "<", "$(", "${", "`", "\\"] as const;
+
+/**
+ * Returns `true` if the value contains any shell metacharacter that could
+ * break out of an argv-style flag list (command separators, redirection,
+ * substitution, or backslash escapes).
+ */
+export function hasShellMetachar(value: string): boolean {
+  for (const pattern of SHELL_METACHAR_PATTERNS) {
+    if (value.includes(pattern)) return true;
+  }
+  return false;
+}

--- a/src/config/__tests__/agents-adversarial.test.ts
+++ b/src/config/__tests__/agents-adversarial.test.ts
@@ -226,6 +226,64 @@ describe("Adversarial: customFlags shell injection (Bug — missing sanitization
     ]);
     expect(result[0]!.customFlags).toBeUndefined();
   });
+
+  // Extended deny-list (#7078): chaining, redirection, variable expansion, escape.
+
+  it("rejects customFlags containing & — chaining/background", () => {
+    const result = getMergedPresets("claude", [
+      { id: "f1", name: "Amp", customFlags: "--flag & evil" },
+    ]);
+    expect(result[0]!.customFlags).toBeUndefined();
+  });
+
+  it("rejects customFlags containing > — redirection", () => {
+    const result = getMergedPresets("claude", [
+      { id: "f1", name: "Redir", customFlags: "--verbose > /etc/passwd" },
+    ]);
+    expect(result[0]!.customFlags).toBeUndefined();
+  });
+
+  it("rejects customFlags containing >> — append redirection", () => {
+    const result = getMergedPresets("claude", [
+      { id: "f1", name: "Append", customFlags: "--log >> /tmp/out" },
+    ]);
+    expect(result[0]!.customFlags).toBeUndefined();
+  });
+
+  it("rejects customFlags containing 2> — stderr redirection", () => {
+    const result = getMergedPresets("claude", [
+      { id: "f1", name: "Stderr", customFlags: "--err 2> /tmp/err" },
+    ]);
+    expect(result[0]!.customFlags).toBeUndefined();
+  });
+
+  it("rejects customFlags containing < — input redirection", () => {
+    const result = getMergedPresets("claude", [
+      { id: "f1", name: "InRedir", customFlags: "--config < /etc/shadow" },
+    ]);
+    expect(result[0]!.customFlags).toBeUndefined();
+  });
+
+  it("rejects customFlags containing ${VAR} — variable expansion", () => {
+    const result = getMergedPresets("claude", [
+      { id: "f1", name: "VarExp", customFlags: "--model ${HOME}" },
+    ]);
+    expect(result[0]!.customFlags).toBeUndefined();
+  });
+
+  it("rejects customFlags containing backslash — escape sequence", () => {
+    const result = getMergedPresets("claude", [
+      { id: "f1", name: "Escape", customFlags: "--flag\\;evil" },
+    ]);
+    expect(result[0]!.customFlags).toBeUndefined();
+  });
+
+  it("allows customFlags with bare $ without ( or { (no over-blocking)", () => {
+    const result = getMergedPresets("claude", [
+      { id: "f1", name: "BareDollar", customFlags: "--prompt-suffix $TODAY" },
+    ]);
+    expect(result[0]!.customFlags).toBe("--prompt-suffix $TODAY");
+  });
 });
 
 // ── adversarial: preset.args injection (Bug — args array passes through unvalidated) ──
@@ -348,7 +406,7 @@ describe("Adversarial: sanitizeArgs length cap (Bug — no per-arg limit)", () =
   });
 });
 
-describe("Adversarial: sanitizeArgs ampersand injection (Bug — & not blocked)", () => {
+describe("Adversarial: sanitizeArgs extended metacharacter deny-list (#7078)", () => {
   it("rejects args containing & — shell background operator", () => {
     const result = getMergedPresets("claude", [
       { id: "f1", name: "Amp", args: ["--model=foo&evil"] },
@@ -361,6 +419,34 @@ describe("Adversarial: sanitizeArgs ampersand injection (Bug — & not blocked)"
       { id: "f1", name: "Redir", args: ["--output>/etc/passwd"] },
     ]);
     expect(result[0]!.args).toBeUndefined();
+  });
+
+  it("rejects args containing < — input redirection", () => {
+    const result = getMergedPresets("claude", [
+      { id: "f1", name: "InRedir", args: ["--config</etc/shadow"] },
+    ]);
+    expect(result[0]!.args).toBeUndefined();
+  });
+
+  it("rejects args containing ${VAR} — variable expansion", () => {
+    const result = getMergedPresets("claude", [
+      { id: "f1", name: "VarExp", args: ["--model=${HOME}"] },
+    ]);
+    expect(result[0]!.args).toBeUndefined();
+  });
+
+  it("rejects args containing backslash — escape sequence", () => {
+    const result = getMergedPresets("claude", [
+      { id: "f1", name: "Escape", args: ["--flag\\;evil"] },
+    ]);
+    expect(result[0]!.args).toBeUndefined();
+  });
+
+  it("allows args with bare $ without ( or { (no over-blocking)", () => {
+    const result = getMergedPresets("claude", [
+      { id: "f1", name: "BareDollar", args: ["--prompt-suffix=$TODAY"] },
+    ]);
+    expect(result[0]!.args).toEqual(["--prompt-suffix=$TODAY"]);
   });
 });
 

--- a/src/config/agents.ts
+++ b/src/config/agents.ts
@@ -11,6 +11,7 @@ import {
   getAgentDisplayTitle,
   getAssistantSupportedAgentIds,
 } from "../../shared/config/agentRegistry";
+import { hasShellMetachar } from "../../shared/utils/shellEscape";
 
 export { getAgentDisplayTitle, getAssistantSupportedAgentIds };
 export type { AgentPreset, AgentProviderTemplate };
@@ -116,16 +117,7 @@ export function getMergedPresets(
     const sanitizeArgs = (args?: string[]): string[] | undefined => {
       if (!Array.isArray(args)) return undefined;
       const safe = args.filter(
-        (a) =>
-          typeof a === "string" &&
-          a.length > 0 &&
-          a.length <= 10000 &&
-          !a.includes(";") &&
-          !a.includes("|") &&
-          !a.includes("$(") &&
-          !a.includes("`") &&
-          !a.includes("&") &&
-          !a.includes(">")
+        (a) => typeof a === "string" && a.length > 0 && a.length <= 10000 && !hasShellMetachar(a)
       );
       return safe.length > 0 ? safe : undefined;
     };
@@ -156,11 +148,7 @@ export function getMergedPresets(
       dangerousEnabled:
         typeof preset.dangerousEnabled === "boolean" ? preset.dangerousEnabled : undefined,
       customFlags:
-        typeof preset.customFlags === "string" &&
-        !preset.customFlags.includes(";") &&
-        !preset.customFlags.includes("|") &&
-        !preset.customFlags.includes("$(") &&
-        !preset.customFlags.includes("`")
+        typeof preset.customFlags === "string" && !hasShellMetachar(preset.customFlags)
           ? preset.customFlags.slice(0, 10000)
           : undefined,
       inlineMode: typeof preset.inlineMode === "boolean" ? preset.inlineMode : undefined,


### PR DESCRIPTION
## Summary

- Extracted a shared `hasShellMetachar()` helper in `shared/utils/shellEscape.ts` so both mirror sanitizer sites (`helpAssistant.ts` and `agents.ts`) share a single deny-list — they can't drift out of sync again
- Expanded the deny-list from 4 patterns to 9: added `&`, `>`, `<`, `${`, and `\` alongside the existing `;`, `|`, `$(`, and backtick
- `${` is matched as a substring (same logic as the existing `$(` check); bare `$` is still allowed

Resolves #7078

## Changes

- `shared/utils/shellEscape.ts` — new `hasShellMetachar()` helper, single source of truth
- `electron/ipc/handlers/helpAssistant.ts` — `sanitizeCustomArgs` now delegates to the helper
- `src/config/agents.ts` — `customFlags` and `sanitizeArgs` now delegate to the helper
- Tests across three files: `shared/utils/__tests__/shellEscape.test.ts`, `electron/ipc/handlers/__tests__/helpAssistant.handlers.test.ts`, `src/config/__tests__/agents-adversarial.test.ts`

## Testing

156 tests pass. New tests cover each added metacharacter explicitly (both sites), positive cases like bare `$` and `--flag=value`, and ordering invariants to prevent future partial-list drift. Typecheck, lint, and format all clean.