### PR TITLE
fix(keybindings): listener hygiene + React 19 concurrent safety

### DIFF
--- a/src/hooks/__tests__/useKeybinding.test.tsx
+++ b/src/hooks/__tests__/useKeybinding.test.tsx
@@ -1,0 +1,124 @@
+// @vitest-environment jsdom
+import { describe, expect, it, vi, beforeEach } from "vitest";
+import { renderHook, act } from "@testing-library/react";
+
+const subscribers = new Set<() => void>();
+const overrides = new Map<string, string | undefined>();
+const displayOverrides = new Map<string, string>();
+
+vi.mock("@/services/KeybindingService", () => ({
+  keybindingService: {
+    subscribe: vi.fn((listener: () => void) => {
+      subscribers.add(listener);
+      return () => {
+        subscribers.delete(listener);
+      };
+    }),
+    getEffectiveCombo: vi.fn((actionId: string) => overrides.get(actionId)),
+    getDisplayCombo: vi.fn((actionId: string) => displayOverrides.get(actionId) ?? ""),
+  },
+}));
+
+import { useEffectiveCombo, useKeybindingDisplay } from "../useKeybinding";
+import { keybindingService } from "@/services/KeybindingService";
+
+function notifyAll(): void {
+  for (const listener of Array.from(subscribers)) {
+    listener();
+  }
+}
+
+describe("useEffectiveCombo", () => {
+  beforeEach(() => {
+    subscribers.clear();
+    overrides.clear();
+    displayOverrides.clear();
+    vi.clearAllMocks();
+  });
+
+  it("returns the current combo synchronously on mount", () => {
+    overrides.set("agent.claude", "Cmd+Shift+C");
+    const { result } = renderHook(() => useEffectiveCombo("agent.claude"));
+    expect(result.current).toBe("Cmd+Shift+C");
+  });
+
+  it("returns undefined when no binding exists", () => {
+    const { result } = renderHook(() => useEffectiveCombo("agent.unknown"));
+    expect(result.current).toBeUndefined();
+  });
+
+  it("re-renders when subscribers are notified and the value changes", () => {
+    overrides.set("agent.claude", "Cmd+Shift+C");
+    const { result } = renderHook(() => useEffectiveCombo("agent.claude"));
+    expect(result.current).toBe("Cmd+Shift+C");
+
+    overrides.set("agent.claude", "Cmd+Shift+X");
+    act(() => notifyAll());
+    expect(result.current).toBe("Cmd+Shift+X");
+  });
+
+  it("re-subscribes when actionId changes", () => {
+    overrides.set("agent.claude", "Cmd+Shift+C");
+    overrides.set("agent.gemini", "Cmd+Shift+G");
+
+    const { result, rerender } = renderHook(({ id }) => useEffectiveCombo(id), {
+      initialProps: { id: "agent.claude" },
+    });
+    expect(result.current).toBe("Cmd+Shift+C");
+
+    rerender({ id: "agent.gemini" });
+    expect(result.current).toBe("Cmd+Shift+G");
+  });
+
+  it("unsubscribes on unmount", () => {
+    const { unmount } = renderHook(() => useEffectiveCombo("agent.claude"));
+    expect(subscribers.size).toBe(1);
+
+    unmount();
+    expect(subscribers.size).toBe(0);
+  });
+
+  it("uses a stable subscribe reference across renders (no churn)", () => {
+    const { rerender } = renderHook(() => useEffectiveCombo("agent.claude"));
+    const callsAfterMount = (keybindingService.subscribe as ReturnType<typeof vi.fn>).mock.calls
+      .length;
+
+    rerender();
+    rerender();
+    rerender();
+
+    expect((keybindingService.subscribe as ReturnType<typeof vi.fn>).mock.calls.length).toBe(
+      callsAfterMount
+    );
+  });
+});
+
+describe("useKeybindingDisplay", () => {
+  beforeEach(() => {
+    subscribers.clear();
+    overrides.clear();
+    displayOverrides.clear();
+    vi.clearAllMocks();
+  });
+
+  it("returns the formatted display combo synchronously on mount", () => {
+    displayOverrides.set("agent.claude", "⌘+⇧+C");
+    const { result } = renderHook(() => useKeybindingDisplay("agent.claude"));
+    expect(result.current).toBe("⌘+⇧+C");
+  });
+
+  it("returns an empty string when no binding exists", () => {
+    const { result } = renderHook(() => useKeybindingDisplay("agent.unknown"));
+    expect(result.current).toBe("");
+  });
+
+  it("re-renders when subscribers are notified and the display changes", () => {
+    displayOverrides.set("agent.claude", "⌘+⇧+C");
+    const { result } = renderHook(() => useKeybindingDisplay("agent.claude"));
+    expect(result.current).toBe("⌘+⇧+C");
+
+    displayOverrides.set("agent.claude", "⌘+⇧+X");
+    act(() => notifyAll());
+    expect(result.current).toBe("⌘+⇧+X");
+  });
+});

--- a/src/hooks/useKeybinding.ts
+++ b/src/hooks/useKeybinding.ts
@@ -1,7 +1,10 @@
-import { useEffect, useMemo, useState } from "react";
+import { useCallback, useEffect, useMemo, useSyncExternalStore } from "react";
 import { keybindingService, type KeyScope } from "../services/KeybindingService";
 import { comboToAriaKeyshortcuts } from "../lib/kbdShortcut";
 import { isMac } from "../lib/platform";
+
+const subscribeToKeybindings = (listener: () => void): (() => void) =>
+  keybindingService.subscribe(listener);
 
 export function useKeybindingScope(scope: KeyScope, active: boolean = true): void {
   useEffect(() => {
@@ -16,37 +19,13 @@ export function useKeybindingScope(scope: KeyScope, active: boolean = true): voi
 }
 
 export function useKeybindingDisplay(actionId: string): string {
-  const [displayCombo, setDisplayCombo] = useState(() =>
-    keybindingService.getDisplayCombo(actionId)
-  );
-
-  useEffect(() => {
-    const updateDisplay = () => {
-      setDisplayCombo(keybindingService.getDisplayCombo(actionId));
-    };
-
-    updateDisplay();
-    return keybindingService.subscribe(updateDisplay);
-  }, [actionId]);
-
-  return displayCombo;
+  const getSnapshot = useCallback(() => keybindingService.getDisplayCombo(actionId), [actionId]);
+  return useSyncExternalStore(subscribeToKeybindings, getSnapshot);
 }
 
 export function useEffectiveCombo(actionId: string): string | undefined {
-  const [combo, setCombo] = useState<string | undefined>(() =>
-    keybindingService.getEffectiveCombo(actionId)
-  );
-
-  useEffect(() => {
-    const update = () => {
-      setCombo(keybindingService.getEffectiveCombo(actionId));
-    };
-
-    update();
-    return keybindingService.subscribe(update);
-  }, [actionId]);
-
-  return combo;
+  const getSnapshot = useCallback(() => keybindingService.getEffectiveCombo(actionId), [actionId]);
+  return useSyncExternalStore(subscribeToKeybindings, getSnapshot);
 }
 
 /**

--- a/src/services/KeybindingService.ts
+++ b/src/services/KeybindingService.ts
@@ -18,7 +18,7 @@ class KeybindingService {
   private pendingChord: string | null = null;
   private chordTimeout: NodeJS.Timeout | null = null;
   private readonly CHORD_TIMEOUT_MS = 1000;
-  private listeners: Array<() => void> = [];
+  private listeners = new Set<() => void>();
 
   constructor() {
     DEFAULT_KEYBINDINGS.forEach((binding) => {
@@ -124,14 +124,21 @@ class KeybindingService {
   }
 
   subscribe(listener: () => void): () => void {
-    this.listeners.push(listener);
+    this.listeners.add(listener);
     return () => {
-      this.listeners = this.listeners.filter((l) => l !== listener);
+      this.listeners.delete(listener);
     };
   }
 
   private notifyListeners(): void {
-    this.listeners.forEach((listener) => listener());
+    const snapshot = Array.from(this.listeners);
+    for (const listener of snapshot) {
+      try {
+        listener();
+      } catch (error) {
+        console.error("[KeybindingService] listener threw", error);
+      }
+    }
   }
 
   setScope(scope: KeyScope): void {

--- a/src/services/KeybindingService.ts
+++ b/src/services/KeybindingService.ts
@@ -136,7 +136,7 @@ class KeybindingService {
       try {
         listener();
       } catch (error) {
-        console.error("[KeybindingService] listener threw", error);
+        console.warn("[KeybindingService] listener threw", error);
       }
     }
   }

--- a/src/services/__tests__/KeybindingService.test.ts
+++ b/src/services/__tests__/KeybindingService.test.ts
@@ -473,6 +473,96 @@ describe("KeybindingService", () => {
     });
   });
 
+  describe("listener hygiene", () => {
+    function triggerNotify(service: KeybindingService): void {
+      const cmdK = createKeyboardEvent({
+        key: "k",
+        code: "KeyK",
+        metaKey: true,
+      });
+      service.resolveKeybinding(cmdK);
+      service.popPendingChord();
+    }
+
+    it("isolates errors so a throwing listener does not stop subsequent listeners", () => {
+      setPlatform("MacIntel");
+      const service = new KeybindingService();
+      const errorSpy = vi.spyOn(console, "error").mockImplementation(() => {});
+      const before = vi.fn();
+      const thrower = vi.fn(() => {
+        throw new Error("listener boom");
+      });
+      const after = vi.fn();
+
+      service.subscribe(before);
+      service.subscribe(thrower);
+      service.subscribe(after);
+
+      triggerNotify(service);
+
+      expect(before).toHaveBeenCalled();
+      expect(thrower).toHaveBeenCalled();
+      expect(after).toHaveBeenCalled();
+      expect(after).toHaveBeenCalledTimes(before.mock.calls.length);
+      expect(errorSpy).toHaveBeenCalled();
+
+      errorSpy.mockRestore();
+    });
+
+    it("dedupes a listener subscribed twice via Set semantics", () => {
+      setPlatform("MacIntel");
+      const service = new KeybindingService();
+      const listener = vi.fn();
+
+      service.subscribe(listener);
+      service.subscribe(listener);
+
+      triggerNotify(service);
+
+      // Set dedup: the listener fires once per notification, not twice.
+      // triggerNotify produces 2 notifications (set + pop), so listener: 2 calls.
+      expect(listener).toHaveBeenCalledTimes(2);
+    });
+
+    it("safely handles a listener that unsubscribes itself during notification", () => {
+      setPlatform("MacIntel");
+      const service = new KeybindingService();
+      const after = vi.fn();
+      let unsubscribeSelf: (() => void) | null = null;
+
+      const selfRemover = vi.fn(() => {
+        unsubscribeSelf?.();
+      });
+
+      unsubscribeSelf = service.subscribe(selfRemover);
+      service.subscribe(after);
+
+      triggerNotify(service);
+
+      expect(selfRemover).toHaveBeenCalledTimes(1);
+      // `after` runs on both the set-pending and pop-pending notifications;
+      // mutating the underlying Set during notification must not break the
+      // current iteration's snapshot.
+      expect(after).toHaveBeenCalledTimes(2);
+    });
+
+    it("returns an unsubscribe that detaches the listener", () => {
+      setPlatform("MacIntel");
+      const service = new KeybindingService();
+      const listener = vi.fn();
+      const unsubscribe = service.subscribe(listener);
+
+      triggerNotify(service);
+      const initialCalls = listener.mock.calls.length;
+      expect(initialCalls).toBeGreaterThan(0);
+
+      unsubscribe();
+      triggerNotify(service);
+
+      expect(listener).toHaveBeenCalledTimes(initialCalls);
+    });
+  });
+
   describe("registerBinding collision detection", () => {
     it("warns and keeps incumbent when a different actionId tries to claim an existing combo", () => {
       const service = new KeybindingService();

--- a/src/services/__tests__/KeybindingService.test.ts
+++ b/src/services/__tests__/KeybindingService.test.ts
@@ -487,7 +487,7 @@ describe("KeybindingService", () => {
     it("isolates errors so a throwing listener does not stop subsequent listeners", () => {
       setPlatform("MacIntel");
       const service = new KeybindingService();
-      const errorSpy = vi.spyOn(console, "error").mockImplementation(() => {});
+      const warnSpy = vi.spyOn(console, "warn").mockImplementation(() => {});
       const before = vi.fn();
       const thrower = vi.fn(() => {
         throw new Error("listener boom");
@@ -504,9 +504,9 @@ describe("KeybindingService", () => {
       expect(thrower).toHaveBeenCalled();
       expect(after).toHaveBeenCalled();
       expect(after).toHaveBeenCalledTimes(before.mock.calls.length);
-      expect(errorSpy).toHaveBeenCalled();
+      expect(warnSpy).toHaveBeenCalled();
 
-      errorSpy.mockRestore();
+      warnSpy.mockRestore();
     });
 
     it("dedupes a listener subscribed twice via Set semantics", () => {


### PR DESCRIPTION
## Summary

- `listeners` in `KeybindingService` switched from `Array` to `Set`, giving O(1) unsubscribe. `notifyListeners` now snapshots via `Array.from` before iterating and wraps each call in `try/catch` — a throwing listener logs a `console.warn` and the rest still fire.
- `useEffectiveCombo` and `useKeybindingDisplay` migrated from `useState` + `useEffect` + `subscribe` to `useSyncExternalStore`, with a module-level `subscribeToKeybindings` constant and `useCallback`-wrapped `getSnapshot`. Fixes tearing under React 19 concurrent rendering.

Resolves #7285

## Changes

- `src/services/KeybindingService.ts` — `Set`-based listener store, snapshot + per-listener try/catch in `notifyListeners`
- `src/hooks/useKeybinding.ts` — `useSyncExternalStore` for both display hooks
- `src/services/__tests__/KeybindingService.test.ts` — 4 listener-hygiene tests
- `src/hooks/__tests__/useKeybinding.test.tsx` — 9 hook tests

## Testing

Unit tests cover: duplicate listener dedup, O(1) unsubscribe correctness, isolated error propagation (bad listener doesn't block others), `useSyncExternalStore` snapshot stability, and hook reactivity on override changes.