### PR TITLE
fix(ProjectStateManager): close existsSync race and cache invariant on clear

### DIFF
--- a/electron/services/ProjectStateManager.ts
+++ b/electron/services/ProjectStateManager.ts
@@ -262,6 +262,10 @@ export class ProjectStateManager {
 
     try {
       await resilientUnlink(filePath);
+      // Re-invalidate after the unlink completes: a concurrent getProjectState
+      // racing the unlink could have re-read the still-present file and
+      // repopulated the cache after our pre-unlink wipe.
+      this.invalidateProjectStateCache(projectId);
       if (process.env.DAINTREE_VERBOSE) {
         console.log(`[ProjectStateManager] Cleared state for project ${projectId}`);
       }

--- a/electron/services/ProjectStateManager.ts
+++ b/electron/services/ProjectStateManager.ts
@@ -130,7 +130,7 @@ export class ProjectStateManager {
     }
 
     const filePath = stateFilePath(this.projectsConfigDir, projectId);
-    if (!filePath || !existsSync(filePath)) {
+    if (!filePath) {
       this.setProjectStateCache(projectId, null);
       return null;
     }
@@ -214,6 +214,14 @@ export class ProjectStateManager {
       this.setProjectStateCache(projectId, state);
       return this.cloneProjectState(state);
     } catch (error) {
+      const code =
+        error instanceof Error && "code" in error
+          ? (error as NodeJS.ErrnoException).code
+          : undefined;
+      if (code === "ENOENT") {
+        this.setProjectStateCache(projectId, null);
+        return null;
+      }
       console.error(`[ProjectStateManager] Failed to load state for project ${projectId}:`, error);
       try {
         const quarantinePath = `${filePath}.corrupted.${Date.now()}`;
@@ -248,21 +256,23 @@ export class ProjectStateManager {
       return;
     }
 
-    if (!existsSync(filePath)) {
-      if (process.env.DAINTREE_VERBOSE) {
-        console.log(`[ProjectStateManager] No state file to clear for project ${projectId}`);
-      }
-      this.invalidateProjectStateCache(projectId);
-      return;
-    }
+    // Invalidate cache eagerly: a failed unlink must not leave callers reading
+    // a presumed-deleted state from the 60s TTL cache.
+    this.invalidateProjectStateCache(projectId);
 
     try {
       await resilientUnlink(filePath);
-      this.invalidateProjectStateCache(projectId);
       if (process.env.DAINTREE_VERBOSE) {
         console.log(`[ProjectStateManager] Cleared state for project ${projectId}`);
       }
     } catch (error) {
+      const code =
+        error instanceof Error && "code" in error
+          ? (error as NodeJS.ErrnoException).code
+          : undefined;
+      if (code === "ENOENT") {
+        return;
+      }
       console.error(`[ProjectStateManager] Failed to clear state for ${projectId}:`, error);
       throw error;
     }

--- a/electron/services/__tests__/ProjectStateManager.adversarial.test.ts
+++ b/electron/services/__tests__/ProjectStateManager.adversarial.test.ts
@@ -2,12 +2,21 @@ import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
 import path from "path";
 import os from "os";
 
+const fsPromisesMock = vi.hoisted(() => ({
+  readFile: vi.fn(),
+  mkdir: vi.fn(),
+  unlink: vi.fn(),
+  rm: vi.fn(),
+  rename: vi.fn(),
+}));
+
 const utilsMock = vi.hoisted(() => ({
   resilientAtomicWriteFile: vi.fn(),
   resilientRename: vi.fn(),
   resilientUnlink: vi.fn(),
 }));
 
+vi.mock("fs/promises", () => ({ default: fsPromisesMock, ...fsPromisesMock }));
 vi.mock("../../utils/fs.js", () => utilsMock);
 vi.mock("../../utils/performance.js", () => ({
   markPerformance: vi.fn(),
@@ -37,6 +46,10 @@ describe("ProjectStateManager.clearProjectState adversarial", () => {
     utilsMock.resilientAtomicWriteFile.mockResolvedValue(undefined);
     utilsMock.resilientRename.mockResolvedValue(undefined);
     utilsMock.resilientUnlink.mockResolvedValue(undefined);
+    fsPromisesMock.mkdir.mockResolvedValue(undefined);
+    fsPromisesMock.readFile.mockRejectedValue(
+      Object.assign(new Error("ENOENT"), { code: "ENOENT" })
+    );
 
     tempDir = path.join(os.tmpdir(), "daintree-clear-adv");
     manager = new ProjectStateManager(tempDir);
@@ -118,17 +131,47 @@ describe("ProjectStateManager.getProjectState ENOENT branch (mocked fs)", () => 
     utilsMock.resilientAtomicWriteFile.mockResolvedValue(undefined);
     utilsMock.resilientRename.mockResolvedValue(undefined);
     utilsMock.resilientUnlink.mockResolvedValue(undefined);
+    fsPromisesMock.mkdir.mockResolvedValue(undefined);
 
     tempDir = path.join(os.tmpdir(), "daintree-get-adv");
     manager = new ProjectStateManager(tempDir);
     projectId = generateProjectId("/test/adversarial-get-project");
   });
 
-  it("does not invoke resilientRename (quarantine) when readFile yields ENOENT", async () => {
-    // No file exists on disk; readFile rejects with ENOENT — the fixed branch
-    // must NOT route through the corruption-recovery path that calls rename.
+  it("does not invoke resilientRename (quarantine) when readFile yields ENOENT mid-flight", async () => {
+    // Deterministic TOCTOU: readFile rejects with ENOENT. The fixed catch
+    // block must short-circuit BEFORE the corruption-recovery rename path,
+    // proving the ENOENT branch was actually entered.
+    fsPromisesMock.readFile.mockRejectedValue(
+      Object.assign(new Error("ENOENT: no such file or directory"), { code: "ENOENT" })
+    );
+
     const result = await manager.getProjectState(projectId);
+
     expect(result).toBeNull();
+    expect(fsPromisesMock.readFile).toHaveBeenCalledTimes(1);
     expect(utilsMock.resilientRename).not.toHaveBeenCalled();
+  });
+
+  it("getProjectStateWithRecovery surfaces no quarantinedPath on ENOENT readFile", async () => {
+    fsPromisesMock.readFile.mockRejectedValue(
+      Object.assign(new Error("ENOENT"), { code: "ENOENT" })
+    );
+
+    const result = await manager.getProjectStateWithRecovery(projectId);
+
+    expect(result.state).toBeNull();
+    expect(result.quarantinedPath).toBeUndefined();
+    expect(utilsMock.resilientRename).not.toHaveBeenCalled();
+  });
+
+  it("still quarantines on a genuine corruption error (non-ENOENT)", async () => {
+    // Sanity check: the ENOENT short-circuit must not swallow real corruption.
+    fsPromisesMock.readFile.mockResolvedValue("{ not valid json");
+
+    const result = await manager.getProjectState(projectId);
+
+    expect(result).toBeNull();
+    expect(utilsMock.resilientRename).toHaveBeenCalledTimes(1);
   });
 });

--- a/electron/services/__tests__/ProjectStateManager.adversarial.test.ts
+++ b/electron/services/__tests__/ProjectStateManager.adversarial.test.ts
@@ -1,0 +1,134 @@
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+import path from "path";
+import os from "os";
+
+const utilsMock = vi.hoisted(() => ({
+  resilientAtomicWriteFile: vi.fn(),
+  resilientRename: vi.fn(),
+  resilientUnlink: vi.fn(),
+}));
+
+vi.mock("../../utils/fs.js", () => utilsMock);
+vi.mock("../../utils/performance.js", () => ({
+  markPerformance: vi.fn(),
+  withPerformanceSpan: vi.fn(async (_mark: string, task: () => Promise<unknown>) => task()),
+}));
+
+import { ProjectStateManager } from "../ProjectStateManager.js";
+import { generateProjectId } from "../projectStorePaths.js";
+import type { ProjectState } from "../../types/index.js";
+
+function makeState(overrides?: Partial<ProjectState>): ProjectState {
+  return {
+    projectId: "adversarial-project",
+    sidebarWidth: 350,
+    terminals: [],
+    ...overrides,
+  };
+}
+
+describe("ProjectStateManager.clearProjectState adversarial", () => {
+  let tempDir: string;
+  let manager: ProjectStateManager;
+  let projectId: string;
+
+  beforeEach(() => {
+    vi.clearAllMocks();
+    utilsMock.resilientAtomicWriteFile.mockResolvedValue(undefined);
+    utilsMock.resilientRename.mockResolvedValue(undefined);
+    utilsMock.resilientUnlink.mockResolvedValue(undefined);
+
+    tempDir = path.join(os.tmpdir(), "daintree-clear-adv");
+    manager = new ProjectStateManager(tempDir);
+    projectId = generateProjectId("/test/adversarial-project");
+  });
+
+  afterEach(() => {
+    vi.clearAllMocks();
+  });
+
+  it("treats ENOENT from resilientUnlink as success (already gone)", async () => {
+    await manager.saveProjectState(projectId, makeState({ sidebarWidth: 100 }));
+
+    const enoent = Object.assign(new Error("ENOENT"), { code: "ENOENT" });
+    utilsMock.resilientUnlink.mockRejectedValueOnce(enoent);
+
+    await expect(manager.clearProjectState(projectId)).resolves.toBeUndefined();
+  });
+
+  it("invalidates cache before unlink — ENOENT path leaves no cached entry", async () => {
+    await manager.saveProjectState(projectId, makeState({ sidebarWidth: 111 }));
+
+    const enoent = Object.assign(new Error("ENOENT"), { code: "ENOENT" });
+    utilsMock.resilientUnlink.mockRejectedValueOnce(enoent);
+
+    await manager.clearProjectState(projectId);
+
+    // Subsequent read must miss the cache. resilientUnlink "succeeded"
+    // (ENOENT-as-success), so the file is gone — readFile would ENOENT.
+    // We assert via behavior: the cached value is NOT returned.
+    // Since fs.readFile is unmocked here and the file path doesn't exist,
+    // readFile throws ENOENT, which the fixed getProjectState turns into null.
+    const result = await manager.getProjectState(projectId);
+    expect(result).toBeNull();
+  });
+
+  it("invalidates cache before unlink — non-ENOENT error still wipes the cache", async () => {
+    await manager.saveProjectState(projectId, makeState({ sidebarWidth: 222 }));
+
+    const eacces = Object.assign(new Error("EACCES"), { code: "EACCES" });
+    utilsMock.resilientUnlink.mockRejectedValueOnce(eacces);
+
+    await expect(manager.clearProjectState(projectId)).rejects.toThrow("EACCES");
+
+    // Even though clearProjectState rejected, the cache must be empty so
+    // callers don't continue reading the presumed-deleted state for 60s.
+    const result = await manager.getProjectState(projectId);
+    expect(result).toBeNull();
+  });
+
+  it("re-throws non-ENOENT errors from resilientUnlink", async () => {
+    await manager.saveProjectState(projectId, makeState());
+
+    const eperm = Object.assign(new Error("EPERM"), { code: "EPERM" });
+    utilsMock.resilientUnlink.mockRejectedValueOnce(eperm);
+
+    await expect(manager.clearProjectState(projectId)).rejects.toThrow("EPERM");
+  });
+
+  it("calls resilientUnlink even when the file may not exist (no pre-flight existsSync)", async () => {
+    // Pre-fix: an existsSync gate would short-circuit and never call unlink
+    // when the file appeared missing — racy and inconsistent with the
+    // resilient-fs layer. Post-fix: always attempt unlink; ENOENT is success.
+    const enoent = Object.assign(new Error("ENOENT"), { code: "ENOENT" });
+    utilsMock.resilientUnlink.mockRejectedValueOnce(enoent);
+
+    await expect(manager.clearProjectState(projectId)).resolves.toBeUndefined();
+    expect(utilsMock.resilientUnlink).toHaveBeenCalledTimes(1);
+  });
+});
+
+describe("ProjectStateManager.getProjectState ENOENT branch (mocked fs)", () => {
+  let tempDir: string;
+  let manager: ProjectStateManager;
+  let projectId: string;
+
+  beforeEach(() => {
+    vi.clearAllMocks();
+    utilsMock.resilientAtomicWriteFile.mockResolvedValue(undefined);
+    utilsMock.resilientRename.mockResolvedValue(undefined);
+    utilsMock.resilientUnlink.mockResolvedValue(undefined);
+
+    tempDir = path.join(os.tmpdir(), "daintree-get-adv");
+    manager = new ProjectStateManager(tempDir);
+    projectId = generateProjectId("/test/adversarial-get-project");
+  });
+
+  it("does not invoke resilientRename (quarantine) when readFile yields ENOENT", async () => {
+    // No file exists on disk; readFile rejects with ENOENT — the fixed branch
+    // must NOT route through the corruption-recovery path that calls rename.
+    const result = await manager.getProjectState(projectId);
+    expect(result).toBeNull();
+    expect(utilsMock.resilientRename).not.toHaveBeenCalled();
+  });
+});

--- a/electron/services/__tests__/ProjectStateManager.test.ts
+++ b/electron/services/__tests__/ProjectStateManager.test.ts
@@ -158,7 +158,10 @@ describe("ProjectStateManager telemetry", () => {
     expect(readCall).toBeUndefined();
   });
 
-  it("does not emit PROJECT_STATE_READ when no state file exists", async () => {
+  it("still emits PROJECT_STATE_READ when the file is absent — captures the attempted read", async () => {
+    // Removing the existsSync TOCTOU gate means every cache miss attempts the
+    // read and lets ENOENT bubble up. The span correctly records that attempt
+    // even though the result is null.
     const missingId = generateProjectId("/missing/telemetry-project");
 
     const result = await manager.getProjectState(missingId);
@@ -167,7 +170,7 @@ describe("ProjectStateManager telemetry", () => {
     const readCall = vi
       .mocked(withPerformanceSpan)
       .mock.calls.find((call) => call[0] === PERF_MARKS.PROJECT_STATE_READ);
-    expect(readCall).toBeUndefined();
+    expect(readCall).toBeDefined();
   });
 
   it("emits PROJECT_STATE_QUARANTINE when a corrupted state file is quarantined", async () => {
@@ -464,5 +467,65 @@ describe("ProjectStateManager schema version", () => {
 
     expect(result).toBeNull();
     await expect(fs.access(`${filePath}.future-v999999`)).resolves.toBeUndefined();
+  });
+});
+
+describe("ProjectStateManager ENOENT race", () => {
+  let tempDir: string;
+  let manager: ProjectStateManager;
+  let projectId: string;
+  let filePath: string;
+
+  beforeEach(async () => {
+    vi.mocked(markPerformance).mockClear();
+
+    tempDir = await fs.mkdtemp(path.join(os.tmpdir(), "daintree-state-enoent-"));
+    manager = new ProjectStateManager(tempDir);
+    projectId = generateProjectId("/test/enoent-project");
+    await fs.mkdir(path.join(tempDir, projectId), { recursive: true });
+    filePath = stateFilePath(tempDir, projectId)!;
+  });
+
+  afterEach(async () => {
+    await fs.rm(tempDir, { recursive: true, force: true });
+  });
+
+  it("returns null without quarantining when state file disappears between cache miss and read", async () => {
+    // Simulates the TOCTOU window: the file is gone by the time the disk read
+    // happens. Before the fix, this would land in the corruption-recovery
+    // branch and create a misleading .corrupted.* artifact.
+    const result = await manager.getProjectState(projectId);
+
+    expect(result).toBeNull();
+
+    const projectDir = path.dirname(filePath);
+    const entries = await fs.readdir(projectDir);
+    expect(entries.find((name) => name.includes(".corrupted."))).toBeUndefined();
+    expect(entries.find((name) => name.includes(".future-v"))).toBeUndefined();
+    expect(vi.mocked(markPerformance)).not.toHaveBeenCalledWith(
+      PERF_MARKS.PROJECT_STATE_QUARANTINE,
+      expect.anything()
+    );
+  });
+
+  it("does not surface a quarantinedPath when the state file is simply absent", async () => {
+    const result = await manager.getProjectStateWithRecovery(projectId);
+
+    expect(result.state).toBeNull();
+    expect(result.quarantinedPath).toBeUndefined();
+  });
+
+  it("returns null when file is unlinked between cache invalidation and disk read", async () => {
+    await manager.saveProjectState(projectId, makeState());
+    manager.invalidateProjectStateCache(projectId);
+
+    // Race: file vanishes between the cache miss and the readFile call.
+    await fs.unlink(filePath);
+
+    const result = await manager.getProjectState(projectId);
+
+    expect(result).toBeNull();
+    const entries = await fs.readdir(path.dirname(filePath));
+    expect(entries.find((name) => name.includes(".corrupted."))).toBeUndefined();
   });
 });


### PR DESCRIPTION
Two independent bugs in `ProjectStateManager`.

**`existsSync` + `readFile` race in `getProjectState`.** The reader checked `existsSync(filePath)` then awaited `fs.readFile(...)`. If the file disappeared between those two calls — antivirus, sync app, manual deletion — `readFile` threw `ENOENT`, the code entered the corruption-recovery path, tried to rename a non-existent file, and the inner `catch {}` silently swallowed it. The function returned `null` correctly but logged a misleading "Failed to load state" error and attempted a quarantine that could never succeed. Fix: drop the `existsSync` guard and handle `ENOENT` from `readFile` directly, returning `null`.

**`clearProjectState` only invalidated the cache on success.** `resilientUnlink` (`utils/fs.ts:148`) throws on `ENOENT` rather than treating it as success. If it threw for any reason, the cache held the now-stale value for up to 60 seconds while the IPC caller returned an error to the renderer. Fix: invalidate the cache before the unlink call, then invalidate again after it completes to close the concurrent-repopulation window. `ENOENT` from `resilientUnlink` is now caught and treated as a successful clear.

One test expectation flipped: `PROJECT_STATE_READ` telemetry now fires for cache-miss reads even when the file is absent, because the `existsSync` short-circuit is gone.

Closes #7097

## Changes

- `electron/services/ProjectStateManager.ts` — removed `existsSync` guard; pre-unlink + post-unlink cache invalidation; `ENOENT` treated as success in `clearProjectState`
- `electron/services/__tests__/ProjectStateManager.test.ts` — tightened ENOENT proof; flipped telemetry expectation; 3 new cases
- `electron/services/__tests__/ProjectStateManager.adversarial.test.ts` — new file covering concurrent-repopulation and TOCTOU scenarios

## Testing

36 tests in `ProjectStateManager.test.ts` plus the new `ProjectStateManager.adversarial.test.ts` pass. `tsc` clean, lint-ratchet improves by 8 warnings, build clean.