### PR TITLE
fix(telemetry): close PII and crash-flush gaps in main-process Sentry capture

### DIFF
--- a/electron/services/TelemetryService.ts
+++ b/electron/services/TelemetryService.ts
@@ -28,7 +28,14 @@ export interface SentryEvent {
     values?: Array<{
       value?: string;
       stacktrace?: {
-        frames?: Array<{ filename?: string; abs_path?: string }>;
+        frames?: Array<{
+          filename?: string;
+          abs_path?: string;
+          context_line?: string;
+          pre_context?: string[];
+          post_context?: string[];
+          vars?: Record<string, unknown>;
+        }>;
       };
     }>;
   };
@@ -101,6 +108,23 @@ export function sanitizeEvent(event: SentryEvent): SentryEvent | null {
             if (!frame || typeof frame !== "object") continue;
             if (frame.filename) frame.filename = sanitizeString(frame.filename);
             if (frame.abs_path) frame.abs_path = sanitizeString(frame.abs_path);
+            // contextLinesIntegration and localVariablesIntegration (default
+            // integrations in @sentry/electron) populate these fields with
+            // raw source lines and local variable values before beforeSend
+            // fires. Source lines may contain string literals with user paths;
+            // local variable values may hold paths, tokens, or transcripts.
+            if (typeof frame.context_line === "string") {
+              frame.context_line = sanitizeString(frame.context_line);
+            }
+            if (Array.isArray(frame.pre_context)) {
+              frame.pre_context = sanitizeStringsDeep(frame.pre_context) as string[];
+            }
+            if (Array.isArray(frame.post_context)) {
+              frame.post_context = sanitizeStringsDeep(frame.post_context) as string[];
+            }
+            if (frame.vars && typeof frame.vars === "object") {
+              frame.vars = sanitizeStringsDeep(frame.vars) as Record<string, unknown>;
+            }
           }
         }
         if (ex.value) ex.value = sanitizeString(ex.value);
@@ -302,6 +326,11 @@ function buildAnalyticsSentryEvent(
     level: "info" as unknown as undefined,
     extra: { ...properties, timestamp },
     tags: { kind: "analytics" },
+    // Pin grouping to the analytics event name so issue-tracking stays stable
+    // across SDK upgrades. Sentry's default fingerprint hash is unstable —
+    // without this, two analytics events with the same name can land in
+    // different groups after a fingerprint-algorithm change.
+    fingerprint: ["analytics", event],
   } as SentryEvent;
 }
 

--- a/electron/services/__tests__/TelemetryService.test.ts
+++ b/electron/services/__tests__/TelemetryService.test.ts
@@ -899,6 +899,18 @@ describe("setTelemetryLevel with buffer", () => {
     expect(captureEventMock).toHaveBeenCalledTimes(2);
     expect(_getPreConsentBufferLength()).toBe(0);
 
+    // Replayed buffered events must carry the same stable fingerprint as
+    // direct sends — otherwise pre-consent and post-consent events for the
+    // same name would land in different Sentry groups.
+    expect(captureEventMock).toHaveBeenNthCalledWith(
+      1,
+      expect.objectContaining({ fingerprint: ["analytics", "onboarding_step_viewed"] })
+    );
+    expect(captureEventMock).toHaveBeenNthCalledWith(
+      2,
+      expect.objectContaining({ fingerprint: ["analytics", "onboarding_step_viewed"] })
+    );
+
     process.env.SENTRY_DSN = original;
   });
 
@@ -1306,5 +1318,53 @@ describe("beforeSend wrapper (end-to-end via initializeTelemetry)", () => {
     expect(headers.authorization).toBe("Bearer [REDACTED]");
     expect(out?.extra?.note).not.toContain("sk-ant-");
     expect(out?.extra?.note).toContain("[REDACTED]");
+  });
+
+  it("scrubs frame.context_line, pre_context, post_context, and vars through the registered beforeSend hook", async () => {
+    const mod = await loadFreshModule();
+    await mod.initializeTelemetry();
+    const init = sentryInitMock.mock.calls[0]?.[0] as {
+      beforeSend?: (event: unknown) => unknown;
+    };
+    expect(typeof init.beforeSend).toBe("function");
+
+    const pat = "ghp_ABCDEFGHIJKLMNOPQRSTUVWXYZabcdef0123456";
+    const input = {
+      exception: {
+        values: [
+          {
+            stacktrace: {
+              frames: [
+                {
+                  filename: "/Users/alice/app/src/auth.ts",
+                  abs_path: "/Users/alice/app/src/auth.ts",
+                  context_line: `  const token = "${pat}";`,
+                  pre_context: [`  const home = "/Users/alice/Projects";`],
+                  post_context: [`  fetch(url, { headers: { Authorization: "Bearer ${pat}" } });`],
+                  vars: {
+                    apiToken: pat,
+                    headers: { authorization: `Bearer ${pat}` },
+                    retries: 3,
+                  },
+                },
+              ],
+            },
+          },
+        ],
+      },
+    };
+    const out = init.beforeSend?.(input) as typeof input | null;
+
+    expect(out).not.toBeNull();
+    const serialized = JSON.stringify(out);
+    expect(serialized).not.toContain(pat);
+    expect(serialized).not.toContain("/Users/alice/");
+    expect(serialized).toContain("[REDACTED]");
+    // non-string vars survive
+    const vars = out?.exception?.values?.[0]?.stacktrace?.frames?.[0]?.vars as Record<
+      string,
+      unknown
+    >;
+    expect(vars.retries).toBe(3);
   });
 });

--- a/electron/services/__tests__/TelemetryService.test.ts
+++ b/electron/services/__tests__/TelemetryService.test.ts
@@ -375,6 +375,97 @@ describe("sanitizeEvent", () => {
     } as unknown as SentryEvent;
     expect(sanitizeEvent(event)).toBeNull();
   });
+
+  it("scrubs frame.context_line, pre_context, post_context populated by contextLinesIntegration", () => {
+    const secret = "ghp_ABCDEFGHIJKLMNOPQRSTUVWXYZabcdef0123456";
+    const event: SentryEvent = {
+      exception: {
+        values: [
+          {
+            stacktrace: {
+              frames: [
+                {
+                  filename: "/Users/alice/app/src/auth.ts",
+                  context_line: `  const token = "${secret}";`,
+                  pre_context: ["  // load credentials", `  const home = "/Users/alice/Projects";`],
+                  post_context: [
+                    `  return fetch(url, { headers: { Authorization: "Bearer ${secret}" } });`,
+                    "}",
+                  ],
+                },
+              ],
+            },
+          },
+        ],
+      },
+    };
+    const result = sanitizeEvent(event);
+    const frame = result?.exception?.values?.[0]?.stacktrace?.frames?.[0];
+    expect(frame?.context_line).not.toContain(secret);
+    expect(frame?.context_line).toContain("[REDACTED]");
+    expect(frame?.pre_context?.[1]).toBe(`  const home = "/Users/USER/Projects";`);
+    expect(frame?.post_context?.[0]).not.toContain(secret);
+    expect(frame?.post_context?.[0]).toContain("[REDACTED]");
+    expect(JSON.stringify(result)).not.toContain(secret);
+    expect(JSON.stringify(result)).not.toContain("/Users/alice/");
+  });
+
+  it("scrubs frame.vars populated by localVariablesIntegration", () => {
+    const secret = "ghp_ABCDEFGHIJKLMNOPQRSTUVWXYZabcdef0123456";
+    const event: SentryEvent = {
+      exception: {
+        values: [
+          {
+            stacktrace: {
+              frames: [
+                {
+                  filename: "/Users/alice/app/src/auth.ts",
+                  vars: {
+                    apiToken: secret,
+                    homePath: "/Users/alice/Projects/daintree",
+                    retries: 3,
+                    nested: {
+                      headers: { authorization: `Bearer ${secret}` },
+                    },
+                  },
+                },
+              ],
+            },
+          },
+        ],
+      },
+    };
+    const result = sanitizeEvent(event);
+    const vars = result?.exception?.values?.[0]?.stacktrace?.frames?.[0]?.vars;
+    expect(vars?.apiToken).toBe("[REDACTED]");
+    expect(vars?.homePath).toBe("/Users/USER/Projects/daintree");
+    // non-string values pass through untouched (numeric variable preserved)
+    expect(vars?.retries).toBe(3);
+    expect(JSON.stringify(vars?.nested)).not.toContain(secret);
+    expect(JSON.stringify(vars?.nested)).toContain("[REDACTED]");
+  });
+
+  it("leaves frames without the new fields unchanged (back-compat)", () => {
+    const event: SentryEvent = {
+      exception: {
+        values: [
+          {
+            stacktrace: {
+              frames: [{ filename: "/Users/alice/app/src/auth.ts", abs_path: "/Users/alice/x" }],
+            },
+          },
+        ],
+      },
+    };
+    const result = sanitizeEvent(event);
+    const frame = result?.exception?.values?.[0]?.stacktrace?.frames?.[0];
+    expect(frame?.filename).toBe("/Users/USER/app/src/auth.ts");
+    expect(frame?.abs_path).toBe("/Users/USER/x");
+    expect(frame?.context_line).toBeUndefined();
+    expect(frame?.pre_context).toBeUndefined();
+    expect(frame?.post_context).toBeUndefined();
+    expect(frame?.vars).toBeUndefined();
+  });
 });
 
 describe("getTelemetryLevel", () => {
@@ -696,7 +787,29 @@ describe("trackEvent", () => {
       expect.objectContaining({
         message: "onboarding_completed",
         tags: { kind: "analytics" },
+        fingerprint: ["analytics", "onboarding_completed"],
       })
+    );
+    process.env.SENTRY_DSN = original;
+  });
+
+  it("stamps a stable fingerprint on every analytics event", async () => {
+    const original = process.env.SENTRY_DSN;
+    process.env.SENTRY_DSN = "https://test@sentry.io/123";
+    setPrivacy({ telemetryLevel: "full", hasSeenPrompt: true });
+    await initializeTelemetry();
+    captureEventMock.mockClear();
+
+    trackEvent("onboarding_step_viewed", { step: "telemetry" });
+    trackEvent("agent_launched", { agent: "claude" });
+
+    expect(captureEventMock).toHaveBeenNthCalledWith(
+      1,
+      expect.objectContaining({ fingerprint: ["analytics", "onboarding_step_viewed"] })
+    );
+    expect(captureEventMock).toHaveBeenNthCalledWith(
+      2,
+      expect.objectContaining({ fingerprint: ["analytics", "agent_launched"] })
     );
     process.env.SENTRY_DSN = original;
   });

--- a/electron/setup/__tests__/globalErrorHandlers.test.ts
+++ b/electron/setup/__tests__/globalErrorHandlers.test.ts
@@ -24,6 +24,8 @@ const crashLoopGuardMock = vi.hoisted(() => ({
   shouldRelaunch: vi.fn(() => true),
 }));
 
+const closeTelemetryMock = vi.hoisted(() => vi.fn(() => Promise.resolve()));
+
 vi.mock("electron", () => ({
   app: appMock,
 }));
@@ -38,6 +40,10 @@ vi.mock("../../utils/emergencyLog.js", () => ({
 
 vi.mock("../../services/CrashRecoveryService.js", () => ({
   getCrashRecoveryService: () => crashRecoveryMock,
+}));
+
+vi.mock("../../services/TelemetryService.js", () => ({
+  closeTelemetry: closeTelemetryMock,
 }));
 
 vi.mock("../../ipc/utils.js", () => ({
@@ -65,12 +71,24 @@ describe("globalErrorHandlers", () => {
     unhandledRejection: [] as NodeJS.UnhandledRejectionListener[],
   };
 
+  // The fatal handler now drains Sentry asynchronously before exiting, so
+  // observable state (app.exit, process.exit fallback) settles after the
+  // microtask queue flushes. flushMicrotasks() yields twice to cover the
+  // closeTelemetry().catch().finally() chain.
+  const flushMicrotasks = async () => {
+    await Promise.resolve();
+    await Promise.resolve();
+    await Promise.resolve();
+  };
+
   beforeEach(() => {
     vi.clearAllMocks();
     _resetHandlingFatalForTesting();
 
     // Reset mock return values
     storeMock.get.mockReturnValue([]);
+    closeTelemetryMock.mockReset();
+    closeTelemetryMock.mockReturnValue(Promise.resolve());
 
     // Save existing listeners
     originalListeners.uncaughtException = process.listeners(
@@ -171,46 +189,51 @@ describe("globalErrorHandlers", () => {
       );
     });
 
-    it("calls app.relaunch then app.exit(1)", () => {
+    it("calls app.relaunch then app.exit(1)", async () => {
       uncaughtHandler(new Error("crash"));
+      await flushMicrotasks();
 
       expect(appMock.relaunch).toHaveBeenCalled();
       expect(appMock.exit).toHaveBeenCalledWith(1);
     });
 
-    it("skips app.relaunch when crash loop guard disallows it", () => {
+    it("skips app.relaunch when crash loop guard disallows it", async () => {
       crashLoopGuardMock.shouldRelaunch.mockReturnValueOnce(false);
       _resetHandlingFatalForTesting();
       uncaughtHandler(new Error("crash"));
+      await flushMicrotasks();
 
       expect(appMock.relaunch).not.toHaveBeenCalled();
       expect(appMock.exit).toHaveBeenCalledWith(1);
     });
 
-    it("does not throw when emergencyLogMainFatal throws", () => {
+    it("does not throw when emergencyLogMainFatal throws", async () => {
       emergencyLogMock.emergencyLogMainFatal.mockImplementation(() => {
         throw new Error("log failed");
       });
 
       expect(() => uncaughtHandler(new Error("crash"))).not.toThrow();
+      await flushMicrotasks();
       expect(appMock.exit).toHaveBeenCalledWith(1);
     });
 
-    it("does not throw when recordCrash throws", () => {
+    it("does not throw when recordCrash throws", async () => {
       crashRecoveryMock.recordCrash.mockImplementation(() => {
         throw new Error("record failed");
       });
 
       expect(() => uncaughtHandler(new Error("crash"))).not.toThrow();
+      await flushMicrotasks();
       expect(appMock.exit).toHaveBeenCalledWith(1);
     });
 
-    it("does not throw when broadcast fails", () => {
+    it("does not throw when broadcast fails", async () => {
       broadcastToRendererMock.mockImplementation(() => {
         throw new Error("broadcast failed");
       });
 
       expect(() => uncaughtHandler(new Error("crash"))).not.toThrow();
+      await flushMicrotasks();
       expect(appMock.exit).toHaveBeenCalledWith(1);
     });
 
@@ -218,14 +241,64 @@ describe("globalErrorHandlers", () => {
       uncaughtHandler(new Error("first crash"));
       vi.clearAllMocks();
 
-      // Second call should hit the re-entrancy guard
+      // Second call hits the re-entrancy guard and exits synchronously —
+      // a second crash mid-flush should not wait another 2s for closeTelemetry.
       uncaughtHandler(new Error("second crash"));
 
       expect(emergencyLogMock.emergencyLogMainFatal).not.toHaveBeenCalled();
       expect(crashRecoveryMock.recordCrash).not.toHaveBeenCalled();
       expect(storeMock.set).not.toHaveBeenCalled();
       expect(appMock.relaunch).not.toHaveBeenCalled();
+      expect(closeTelemetryMock).not.toHaveBeenCalled();
       expect(appMock.exit).toHaveBeenCalledWith(1);
+    });
+
+    it("calls closeTelemetry before app.exit so Sentry can flush in-flight crash reports", async () => {
+      const order: string[] = [];
+      closeTelemetryMock.mockImplementationOnce(() => {
+        order.push("closeTelemetry");
+        return Promise.resolve();
+      });
+      appMock.exit.mockImplementationOnce(() => {
+        order.push("exit");
+      });
+
+      uncaughtHandler(new Error("crash"));
+      // exit must NOT have happened synchronously — it waits for the flush
+      expect(order).toEqual(["closeTelemetry"]);
+
+      await flushMicrotasks();
+      expect(order).toEqual(["closeTelemetry", "exit"]);
+      expect(appMock.exit).toHaveBeenCalledWith(1);
+    });
+
+    it("still exits when closeTelemetry rejects", async () => {
+      closeTelemetryMock.mockReturnValueOnce(Promise.reject(new Error("flush failed")));
+
+      uncaughtHandler(new Error("crash"));
+      await flushMicrotasks();
+
+      expect(closeTelemetryMock).toHaveBeenCalled();
+      expect(appMock.exit).toHaveBeenCalledWith(1);
+    });
+
+    it("falls back to process.exit(1) when app.exit throws", async () => {
+      // mockImplementationOnce so the throwing impl is consumed by this test
+      // and does not leak into subsequent tests (vi.clearAllMocks resets call
+      // history but not implementations).
+      appMock.exit.mockImplementationOnce(() => {
+        throw new Error("exit unavailable");
+      });
+      const processExitSpy = vi
+        .spyOn(process, "exit")
+        .mockImplementation(((_code?: number) => undefined) as never);
+
+      uncaughtHandler(new Error("crash"));
+      await flushMicrotasks();
+
+      expect(appMock.exit).toHaveBeenCalledWith(1);
+      expect(processExitSpy).toHaveBeenCalledWith(1);
+      processExitSpy.mockRestore();
     });
 
     it("builds AppError with correct message from Error", () => {

--- a/electron/setup/globalErrorHandlers.ts
+++ b/electron/setup/globalErrorHandlers.ts
@@ -2,6 +2,7 @@ import { app } from "electron";
 import { emergencyLogMainFatal } from "../utils/emergencyLog.js";
 import { getCrashRecoveryService } from "../services/CrashRecoveryService.js";
 import { getCrashLoopGuard } from "../services/CrashLoopGuardService.js";
+import { closeTelemetry } from "../services/TelemetryService.js";
 import { broadcastToRenderer } from "../ipc/utils.js";
 import { CHANNELS } from "../ipc/channels.js";
 import { store } from "../store.js";
@@ -103,11 +104,22 @@ export function registerGlobalErrorHandlers(): void {
       // silent
     }
 
-    try {
-      app.exit(1);
-    } catch {
-      process.exit(1);
-    }
+    // Drain Sentry's HTTP transport before terminating — this handler is
+    // registered before initializeTelemetry() and fires before Sentry's own
+    // onUncaughtExceptionIntegration, so a synchronous app.exit(1) would kill
+    // the process before any in-flight crash report could flush. closeTelemetry
+    // is idempotent, internally caps at SENTRY_CLOSE_TIMEOUT_MS (2000ms), and
+    // catches all errors. The re-entrant fatal path above keeps a synchronous
+    // exit — a second crash mid-flush should not wait another 2s.
+    closeTelemetry()
+      .catch(() => {})
+      .finally(() => {
+        try {
+          app.exit(1);
+        } catch {
+          process.exit(1);
+        }
+      });
   });
 
   process.on("unhandledRejection", (reason: unknown) => {


### PR DESCRIPTION
## Summary

- `sanitizeEvent`'s frame loop only walked `filename` and `abs_path` — `context_line`, `pre_context`, `post_context`, and `vars` were shipping raw. Extended the loop and the local `SentryEvent` frame type to cover all four fields.
- The `uncaughtException` fatal handler was calling `app.exit(1)` synchronously, racing ahead of Sentry's async HTTP transport. Replaced with `closeTelemetry().catch().finally(() => app.exit(1))` so the envelope has a chance to flush before the process dies.
- Analytics events built by `buildAnalyticsSentryEvent` had no explicit fingerprint. Added `fingerprint: ["analytics", event]` to lock grouping against future changes to Sentry's default algorithm.

Resolves #7095.

## Changes

- `electron/services/TelemetryService.ts` — widened `SentryEvent` frame projection; extended `sanitizeEvent` frame loop to scrub `context_line`, `pre_context`, `post_context`, and `vars`; added `fingerprint` to `buildAnalyticsSentryEvent`.
- `electron/setup/globalErrorHandlers.ts` — imported `closeTelemetry`; replaced synchronous `app.exit(1)` with async flush + exit. Re-entrant fatal path keeps synchronous exit by design.
- `electron/services/__tests__/TelemetryService.test.ts` — 4 new `sanitizeEvent` unit tests, 1 fingerprint test on direct send, 1 end-to-end test through `beforeSend`, 1 fingerprint replay assertion on buffered flush.
- `electron/setup/__tests__/globalErrorHandlers.test.ts` — converted 5 existing tests to async; added 3 new tests covering `closeTelemetry`-before-exit ordering, reject-still-exits, and `app.exit`-throws fallback to `process.exit`.

## Testing

103 tests pass (vitest, electron). Typecheck, lint, and format all clean.