### PR TITLE
fix(a11y): omit aria-keyshortcuts for chord combos, surface Cmd+Shift+= zoom-in

### DIFF
--- a/src/lib/__tests__/kbdShortcut.test.ts
+++ b/src/lib/__tests__/kbdShortcut.test.ts
@@ -337,18 +337,21 @@ describe("comboToAriaKeyshortcuts — special key names", () => {
 });
 
 describe("comboToAriaKeyshortcuts — chord sequences", () => {
-  it("preserves space between chord steps", () => {
-    expect(comboToAriaKeyshortcuts("Cmd+K T", true)).toBe("Meta+K T");
-    expect(comboToAriaKeyshortcuts("Cmd+K T", false)).toBe("Control+K T");
+  // ARIA uses spaces to separate alternative shortcuts, not chord steps.
+  // The function returns undefined so the attribute is omitted entirely
+  // rather than mislabelling the binding as a list of alternatives.
+  it("returns undefined for two-step chords", () => {
+    expect(comboToAriaKeyshortcuts("Cmd+K T", true)).toBeUndefined();
+    expect(comboToAriaKeyshortcuts("Cmd+K T", false)).toBeUndefined();
   });
 
-  it("handles two-step chords with shared prefix", () => {
-    expect(comboToAriaKeyshortcuts("Cmd+K Cmd+W", true)).toBe("Meta+K Meta+W");
-    expect(comboToAriaKeyshortcuts("Cmd+K Cmd+W", false)).toBe("Control+K Control+W");
+  it("returns undefined for two-step chords with shared prefix", () => {
+    expect(comboToAriaKeyshortcuts("Cmd+K Cmd+W", true)).toBeUndefined();
+    expect(comboToAriaKeyshortcuts("Cmd+K Cmd+W", false)).toBeUndefined();
   });
 
-  it("collapses extra whitespace between steps", () => {
-    expect(comboToAriaKeyshortcuts("Cmd+K   T", true)).toBe("Meta+K T");
+  it("returns undefined for chords with extra whitespace between steps", () => {
+    expect(comboToAriaKeyshortcuts("Cmd+K   T", true)).toBeUndefined();
   });
 });
 
@@ -366,11 +369,11 @@ describe("comboToAriaKeyshortcuts — real default-combo round-trips", () => {
     expect(comboToAriaKeyshortcuts("Cmd+Alt+P", false)).toBe("Control+Alt+P");
   });
 
-  it("maps two-step chord families (Cmd+K Cmd+S, Cmd+K T)", () => {
-    expect(comboToAriaKeyshortcuts("Cmd+K Cmd+S", true)).toBe("Meta+K Meta+S");
-    expect(comboToAriaKeyshortcuts("Cmd+K Cmd+S", false)).toBe("Control+K Control+S");
-    expect(comboToAriaKeyshortcuts("Cmd+K T", true)).toBe("Meta+K T");
-    expect(comboToAriaKeyshortcuts("Cmd+K T", false)).toBe("Control+K T");
+  it("returns undefined for two-step chord families (Cmd+K Cmd+S, Cmd+K T)", () => {
+    expect(comboToAriaKeyshortcuts("Cmd+K Cmd+S", true)).toBeUndefined();
+    expect(comboToAriaKeyshortcuts("Cmd+K Cmd+S", false)).toBeUndefined();
+    expect(comboToAriaKeyshortcuts("Cmd+K T", true)).toBeUndefined();
+    expect(comboToAriaKeyshortcuts("Cmd+K T", false)).toBeUndefined();
   });
 });
 

--- a/src/lib/__tests__/kbdShortcut.test.ts
+++ b/src/lib/__tests__/kbdShortcut.test.ts
@@ -369,6 +369,11 @@ describe("comboToAriaKeyshortcuts — real default-combo round-trips", () => {
     expect(comboToAriaKeyshortcuts("Cmd+Alt+P", false)).toBe("Control+Alt+P");
   });
 
+  it("maps the Cmd+Shift+= zoom-in alias (issue #7304)", () => {
+    expect(comboToAriaKeyshortcuts("Cmd+Shift+=", true)).toBe("Meta+Shift+=");
+    expect(comboToAriaKeyshortcuts("Cmd+Shift+=", false)).toBe("Control+Shift+=");
+  });
+
   it("returns undefined for two-step chord families (Cmd+K Cmd+S, Cmd+K T)", () => {
     expect(comboToAriaKeyshortcuts("Cmd+K Cmd+S", true)).toBeUndefined();
     expect(comboToAriaKeyshortcuts("Cmd+K Cmd+S", false)).toBeUndefined();

--- a/src/lib/kbdShortcut.ts
+++ b/src/lib/kbdShortcut.ts
@@ -249,12 +249,15 @@ function mapAriaToken(rawToken: string, modifiers: Record<string, string>): stri
  * grammar. Returns `undefined` for empty/nullish input so the attribute can
  * be omitted entirely rather than rendered as an empty string.
  *
+ * Multi-step chord sequences (e.g. `Cmd+K T`) also return `undefined`: ARIA
+ * uses spaces to separate alternative shortcuts, not chord steps, so emitting
+ * the joined form mislabels the binding for assistive tech.
+ *
  * @example
- * comboToAriaKeyshortcuts("Cmd+K T", true)   // "Meta+K T"
- * comboToAriaKeyshortcuts("Cmd+K T", false)  // "Control+K T"
  * comboToAriaKeyshortcuts("Cmd+Shift+P", true)  // "Meta+Shift+P"
- * comboToAriaKeyshortcuts("Ctrl++", false)   // "Control++"
- * comboToAriaKeyshortcuts(undefined, true)   // undefined
+ * comboToAriaKeyshortcuts("Ctrl++", false)      // "Control++"
+ * comboToAriaKeyshortcuts("Cmd+K T", true)      // undefined (chord)
+ * comboToAriaKeyshortcuts(undefined, true)      // undefined
  */
 export function comboToAriaKeyshortcuts(
   combo: string | null | undefined,
@@ -272,7 +275,8 @@ export function comboToAriaKeyshortcuts(
     .map((tokens) => tokens.map((token) => mapAriaToken(token, modifiers)).join("+"));
 
   if (steps.length === 0) return undefined;
-  return steps.join(" ");
+  if (steps.length > 1) return undefined;
+  return steps[0];
 }
 
 export function normalizeQuery(query: string): string {

--- a/src/services/__tests__/KeybindingService.test.ts
+++ b/src/services/__tests__/KeybindingService.test.ts
@@ -621,4 +621,23 @@ describe("KeybindingService", () => {
       expect(missing).toEqual([]);
     });
   });
+
+  describe("window.zoomIn discoverability alias — issue #7304", () => {
+    it("registers both Cmd+= and Cmd+Shift+= as defaults for window.zoomIn", () => {
+      const combos = DEFAULT_KEYBINDINGS.filter((b) => b.actionId === "window.zoomIn").map(
+        (b) => b.combo
+      );
+      expect(combos).toEqual(expect.arrayContaining(["Cmd+=", "Cmd+Shift+="]));
+      expect(combos).toHaveLength(2);
+    });
+
+    it("resolves Cmd+Shift+= to window.zoomIn at runtime", () => {
+      setPlatform("MacIntel");
+      const service = new KeybindingService();
+      const match = service.findMatchingAction(
+        createKeyboardEvent({ key: "+", code: "Equal", metaKey: true, shiftKey: true })
+      );
+      expect(match?.actionId).toBe("window.zoomIn");
+    });
+  });
 });

--- a/src/services/__tests__/KeybindingService.test.ts
+++ b/src/services/__tests__/KeybindingService.test.ts
@@ -608,12 +608,17 @@ describe("KeybindingService", () => {
       expect(display.toUpperCase()).toContain("N");
     });
 
-    it("registers worktree.createDialog.open in the BuiltInKeyAction value set", async () => {
-      // Registry completeness: every action with a default binding should
-      // appear in KEY_ACTION_VALUES so introspection (settings UI, conflict
-      // detection, etc.) sees it.
+    it("registers every default-binding actionId in KEY_ACTION_VALUES", async () => {
+      // KEY_ACTION_VALUES is hand-maintained alongside the BuiltInKeyAction
+      // open union (BuiltInKeyAction | (string & {})), so the compiler can't
+      // catch drift. Iterate DEFAULT_KEYBINDINGS so any new action without a
+      // matching value entry fails the build instead of silently falling out
+      // of introspection (settings UI, conflict detection, etc.).
       const { KEY_ACTION_VALUES } = await import("@shared/types/keymap");
-      expect(KEY_ACTION_VALUES.has("worktree.createDialog.open")).toBe(true);
+      const missing = DEFAULT_KEYBINDINGS.map((b) => b.actionId).filter(
+        (id) => !KEY_ACTION_VALUES.has(id)
+      );
+      expect(missing).toEqual([]);
     });
   });
 });

--- a/src/services/defaultKeybindings.ts
+++ b/src/services/defaultKeybindings.ts
@@ -884,6 +884,16 @@ export const DEFAULT_KEYBINDINGS: KeybindingConfig[] = [
     category: "View",
   },
   {
+    // Discoverability alias — many users press Cmd+Shift+= for zoom-in even
+    // though the physical-key matcher already accepts it via Cmd+=.
+    actionId: "window.zoomIn",
+    combo: "Cmd+Shift+=",
+    scope: "global",
+    priority: 0,
+    description: "Zoom in",
+    category: "View",
+  },
+  {
     actionId: "window.zoomOut",
     combo: "Cmd+-",
     scope: "global",


### PR DESCRIPTION
## Summary

- `comboToAriaKeyshortcuts` now returns `undefined` for multi-step chord combos. WAI-ARIA uses spaces to separate *alternative* shortcuts, not chord steps — the previous space-joined output mislabelled chord bindings to assistive tech. No valid ARIA representation exists for a sequence, so `undefined` is the correct output.
- Added `Cmd+Shift+=` as a second binding for `window.zoomIn`. On US/UK layouts the printed `+` requires Shift, so `Cmd+=` alone misses what hands actually press. Chrome, Safari, and VS Code all register both.
- Added a runtime drift assertion to `KeybindingService` tests: every `actionId` in `DEFAULT_KEYBINDINGS` must be present in `KEY_ACTION_VALUES`. The compile-time check is blocked by the open-union pattern on `BuiltInKeyAction`, so this test fills the gap.

Resolves #7304

## Changes

- `src/lib/kbdShortcut.ts` — `comboToAriaKeyshortcuts` returns `undefined` when the parsed combo has more than one step
- `src/services/defaultKeybindings.ts` — `Cmd+Shift+=` alias added for `window.zoomIn`
- `src/lib/__tests__/kbdShortcut.test.ts` — chord-undefined behaviour locked in
- `src/services/__tests__/KeybindingService.test.ts` — `KEY_ACTION_VALUES` drift assertion, `Cmd+Shift+=` alias coverage

## Testing

119 unit tests pass. Typecheck, lint, and format all clean.