### PR TITLE
fix(processtreecache): swap to os.availableParallelism() for cpuPercent

### DIFF
--- a/electron/services/ProcessTreeCache.ts
+++ b/electron/services/ProcessTreeCache.ts
@@ -301,7 +301,7 @@ export class ProcessTreeCache {
     const newCache = new Map<number, ProcessInfo>();
     const newChildrenMap = new Map<number, number[]>();
     const now = Date.now();
-    const numCpus = Math.max(os.cpus().length, 1);
+    const numCpus = Math.max(os.availableParallelism(), 1);
     const activeSnapshotKeys = new Set<string>();
 
     for (const p of processes) {


### PR DESCRIPTION
## Summary
A single-line fix in `ProcessTreeCache`. `os.cpus().length` returns the host CPU count even inside containers and VMs with vCPU pinning, so the capacity divisor is overstated and per-process `cpuPercent` reads low. `os.availableParallelism()` respects cgroup restrictions and VM vCPU limits.

Node's docs are explicit that `os.cpus().length` should not be used for parallelism math. `os.availableParallelism()` has been available since Node 19.4 and the project already requires >=22.13.0.

Resolves #7092

## Changes
- `electron/services/ProcessTreeCache.ts:304` -- `os.cpus().length` -> `os.availableParallelism()`

## Testing
All 37 existing tests pass.