### PR TITLE
perf(console): cut ConsolePanel render-path allocations

### DIFF
--- a/src/components/Browser/ConsolePanel.tsx
+++ b/src/components/Browser/ConsolePanel.tsx
@@ -1,4 +1,4 @@
-import { useState, useCallback, useEffect, useRef, useMemo } from "react";
+import { memo, useState, useCallback, useEffect, useRef, useMemo } from "react";
 import { Trash2, ChevronDown } from "lucide-react";
 import { cn } from "@/lib/utils";
 import {
@@ -6,6 +6,7 @@ import {
   type ConsoleLevel,
   type ConsoleMessage,
   EMPTY_MESSAGES,
+  ZERO_COUNTS,
 } from "@/store/consoleCaptureStore";
 import { Tooltip, TooltipContent, TooltipTrigger } from "@/components/ui/tooltip";
 import { ObjectInspector } from "./ObjectInspector";
@@ -49,19 +50,7 @@ const FILTER_BUTTONS: { filter: LevelFilter; label: string }[] = [
   { filter: "log", label: "Log" },
 ];
 
-function formatTime(ts: number): string {
-  const d = new Date(ts);
-  const h = String(d.getHours()).padStart(2, "0");
-  const m = String(d.getMinutes()).padStart(2, "0");
-  const s = String(d.getSeconds()).padStart(2, "0");
-  const ms = String(d.getMilliseconds()).padStart(3, "0");
-  return `${h}:${m}:${s}.${ms}`;
-}
-
-// Group types that act as headers
-const GROUP_HEADER_TYPES = new Set(["startGroup", "startGroupCollapsed"]);
-
-function ConsoleRow({
+const ConsoleRow = memo(function ConsoleRow({
   msg,
   webContentsId,
   isGroupCollapsed,
@@ -70,11 +59,11 @@ function ConsoleRow({
   msg: ConsoleMessage;
   webContentsId?: number;
   isGroupCollapsed?: boolean;
-  onToggleGroup?: () => void;
+  onToggleGroup?: (msgId: number) => void;
 }) {
   const style = LEVEL_STYLES[msg.level];
-  const isGroupHeader = GROUP_HEADER_TYPES.has(msg.cdpType);
   const indentPx = msg.groupDepth * 12;
+  const handleToggle = useCallback(() => onToggleGroup?.(msg.id), [onToggleGroup, msg.id]);
 
   return (
     <div
@@ -85,7 +74,7 @@ function ConsoleRow({
       style={indentPx > 0 ? { paddingLeft: `${8 + indentPx}px` } : undefined}
     >
       <span className="shrink-0 text-daintree-text/30 select-none tabular-nums">
-        {formatTime(msg.timestamp)}
+        {msg.timeLabel}
       </span>
       <span
         className={cn(
@@ -97,10 +86,10 @@ function ConsoleRow({
       </span>
       <div className="min-w-0 flex-1">
         <div className="break-all whitespace-pre-wrap select-text">
-          {isGroupHeader && onToggleGroup && (
+          {msg.isGroupHeader && onToggleGroup && (
             <button
               type="button"
-              onClick={onToggleGroup}
+              onClick={handleToggle}
               className="text-daintree-text/40 mr-1 select-none hover:text-daintree-text/60"
             >
               {isGroupCollapsed ? "▶" : "▼"}
@@ -121,7 +110,7 @@ function ConsoleRow({
       </div>
     </div>
   );
-}
+});
 
 export function ConsolePanel({ paneId, height = 200, webContentsId }: ConsolePanelProps) {
   const [levelFilter, setLevelFilter] = useState<LevelFilter>("all");
@@ -130,33 +119,36 @@ export function ConsolePanel({ paneId, height = 200, webContentsId }: ConsolePan
   const [collapsedGroups, setCollapsedGroups] = useState<Set<number>>(new Set());
   const scrollRef = useRef<HTMLDivElement>(null);
   const prevLastIdRef = useRef<number | null>(null);
+  const lastSeenIndexRef = useRef(0);
 
   const allMessages = useConsoleCaptureStore(
     (state) => state.messages.get(paneId) ?? EMPTY_MESSAGES
   );
+  const counts = useConsoleCaptureStore((state) => state.counters.get(paneId) ?? ZERO_COUNTS);
   const clearMessages = useConsoleCaptureStore((state) => state.clearMessages);
 
   // Apply level and search filters, then handle group collapsing
   const filtered = useMemo(() => {
+    const lowerSearch = search ? search.toLowerCase() : "";
+
     // First pass: filter by level and search
     let result = allMessages.filter((msg) => {
       // Always show group headers regardless of level filter
-      if (GROUP_HEADER_TYPES.has(msg.cdpType)) return true;
+      if (msg.isGroupHeader) return true;
 
       if (levelFilter !== "all") {
         if (levelFilter === "warning" && msg.level !== "warning") return false;
         if (levelFilter === "error" && msg.level !== "error") return false;
         if (levelFilter === "log" && msg.level !== "log" && msg.level !== "info") return false;
       }
-      if (search) {
-        return msg.summaryText.toLowerCase().includes(search.toLowerCase());
+      if (lowerSearch) {
+        return msg.summaryText.toLowerCase().includes(lowerSearch);
       }
       return true;
     });
 
     // Second pass: hide children of collapsed groups
     if (collapsedGroups.size > 0) {
-      const hidden = new Set<number>();
       let skipDepth: number | null = null;
 
       result = result.filter((msg) => {
@@ -165,49 +157,57 @@ export function ConsolePanel({ paneId, height = 200, webContentsId }: ConsolePan
           skipDepth = null;
         }
 
-        if (GROUP_HEADER_TYPES.has(msg.cdpType) && collapsedGroups.has(msg.id)) {
+        if (msg.isGroupHeader && collapsedGroups.has(msg.id)) {
           skipDepth = msg.groupDepth;
           return true; // Show the header, hide children
         }
 
-        return !hidden.has(msg.id);
+        return true;
       });
     }
 
     return result;
   }, [allMessages, levelFilter, search, collapsedGroups]);
 
-  // Auto-collapse startGroupCollapsed entries
+  // Reset auto-collapse tracking when the pane changes
   useEffect(() => {
-    const newCollapsed = new Set<number>();
-    for (const msg of allMessages) {
+    lastSeenIndexRef.current = 0;
+    setCollapsedGroups(new Set());
+  }, [paneId]);
+
+  // Auto-collapse startGroupCollapsed entries — scan only the tail since last seen
+  useEffect(() => {
+    if (allMessages.length < lastSeenIndexRef.current) {
+      // List shrank (clearMessages or pane swap mid-render): rescan from start
+      lastSeenIndexRef.current = 0;
+    }
+    if (lastSeenIndexRef.current >= allMessages.length) return;
+
+    let newIds: number[] | null = null;
+    for (let i = lastSeenIndexRef.current; i < allMessages.length; i++) {
+      const msg = allMessages[i]!;
       if (msg.cdpType === "startGroupCollapsed") {
-        newCollapsed.add(msg.id);
+        (newIds ??= []).push(msg.id);
       }
     }
-    if (newCollapsed.size > 0) {
-      setCollapsedGroups((prev) => {
-        const merged = new Set(prev);
-        let changed = false;
-        for (const id of newCollapsed) {
-          if (!merged.has(id)) {
-            merged.add(id);
-            changed = true;
-          }
+    lastSeenIndexRef.current = allMessages.length;
+
+    if (newIds === null) return;
+    const ids = newIds;
+    setCollapsedGroups((prev) => {
+      const merged = new Set(prev);
+      let changed = false;
+      for (const id of ids) {
+        if (!merged.has(id)) {
+          merged.add(id);
+          changed = true;
         }
-        return changed ? merged : prev;
-      });
-    }
+      }
+      return changed ? merged : prev;
+    });
   }, [allMessages]);
 
-  const errorCount = useMemo(
-    () => allMessages.filter((m) => m.level === "error").length,
-    [allMessages]
-  );
-  const warnCount = useMemo(
-    () => allMessages.filter((m) => m.level === "warning").length,
-    [allMessages]
-  );
+  const { errorCount, warnCount } = counts;
 
   const handleScroll = useCallback(() => {
     const el = scrollRef.current;
@@ -344,9 +344,7 @@ export function ConsolePanel({ paneId, height = 200, webContentsId }: ConsolePan
               msg={msg}
               webContentsId={webContentsId}
               isGroupCollapsed={collapsedGroups.has(msg.id)}
-              onToggleGroup={
-                GROUP_HEADER_TYPES.has(msg.cdpType) ? () => toggleGroup(msg.id) : undefined
-              }
+              onToggleGroup={msg.isGroupHeader ? toggleGroup : undefined}
             />
           ))
         )}

--- a/src/components/Browser/ConsolePanel.tsx
+++ b/src/components/Browser/ConsolePanel.tsx
@@ -119,7 +119,7 @@ export function ConsolePanel({ paneId, height = 200, webContentsId }: ConsolePan
   const [collapsedGroups, setCollapsedGroups] = useState<Set<number>>(new Set());
   const scrollRef = useRef<HTMLDivElement>(null);
   const prevLastIdRef = useRef<number | null>(null);
-  const lastSeenIndexRef = useRef(0);
+  const lastSeenTailIdRef = useRef<number | null>(null);
 
   const allMessages = useConsoleCaptureStore(
     (state) => state.messages.get(paneId) ?? EMPTY_MESSAGES
@@ -171,26 +171,44 @@ export function ConsolePanel({ paneId, height = 200, webContentsId }: ConsolePan
 
   // Reset auto-collapse tracking when the pane changes
   useEffect(() => {
-    lastSeenIndexRef.current = 0;
+    lastSeenTailIdRef.current = null;
     setCollapsedGroups(new Set());
   }, [paneId]);
 
-  // Auto-collapse startGroupCollapsed entries — scan only the tail since last seen
+  // Auto-collapse startGroupCollapsed entries — scan only newly-arrived messages.
+  // Track the last-seen tail message id (not array index) so the cursor survives
+  // 500-cap eviction, where the array length stays the same but new ids land at the end.
   useEffect(() => {
-    if (allMessages.length < lastSeenIndexRef.current) {
-      // List shrank (clearMessages or pane swap mid-render): rescan from start
-      lastSeenIndexRef.current = 0;
+    if (allMessages.length === 0) {
+      lastSeenTailIdRef.current = null;
+      // Drop any stale collapsed-group ids from the prior session
+      setCollapsedGroups((prev) => (prev.size === 0 ? prev : new Set()));
+      return;
     }
-    if (lastSeenIndexRef.current >= allMessages.length) return;
+
+    const newTail = allMessages[allMessages.length - 1]!;
+    if (newTail.id === lastSeenTailIdRef.current) return;
+
+    const lastSeenTailId = lastSeenTailIdRef.current;
+    let firstNewIdx = allMessages.length;
+    if (lastSeenTailId === null) {
+      firstNewIdx = 0;
+    } else {
+      while (firstNewIdx > 0 && allMessages[firstNewIdx - 1]!.id > lastSeenTailId) {
+        firstNewIdx--;
+      }
+    }
+    lastSeenTailIdRef.current = newTail.id;
+
+    if (firstNewIdx >= allMessages.length) return;
 
     let newIds: number[] | null = null;
-    for (let i = lastSeenIndexRef.current; i < allMessages.length; i++) {
+    for (let i = firstNewIdx; i < allMessages.length; i++) {
       const msg = allMessages[i]!;
       if (msg.cdpType === "startGroupCollapsed") {
         (newIds ??= []).push(msg.id);
       }
     }
-    lastSeenIndexRef.current = allMessages.length;
 
     if (newIds === null) return;
     const ids = newIds;

--- a/src/store/__tests__/consoleCaptureStore.test.ts
+++ b/src/store/__tests__/consoleCaptureStore.test.ts
@@ -1,5 +1,5 @@
 import { describe, it, expect, beforeEach } from "vitest";
-import { useConsoleCaptureStore, EMPTY_MESSAGES } from "../consoleCaptureStore";
+import { useConsoleCaptureStore, EMPTY_MESSAGES, ZERO_COUNTS } from "../consoleCaptureStore";
 import type { SerializedConsoleRow } from "@shared/types/ipc/webviewConsole";
 
 function makeRow(overrides: Partial<SerializedConsoleRow> = {}): SerializedConsoleRow {
@@ -19,7 +19,7 @@ function makeRow(overrides: Partial<SerializedConsoleRow> = {}): SerializedConso
 
 describe("consoleCaptureStore", () => {
   beforeEach(() => {
-    useConsoleCaptureStore.setState({ messages: new Map() });
+    useConsoleCaptureStore.setState({ messages: new Map(), counters: new Map() });
   });
 
   it("adds a structured message with correct level", () => {
@@ -182,5 +182,142 @@ describe("consoleCaptureStore", () => {
     expect(msg!.stackTrace).toBeDefined();
     expect(msg!.stackTrace!.callFrames).toHaveLength(1);
     expect(msg!.stackTrace!.callFrames[0]!.functionName).toBe("foo");
+  });
+
+  describe("precomputed fields", () => {
+    it("precomputes timeLabel as HH:MM:SS.mmm at insert time", () => {
+      const store = useConsoleCaptureStore.getState();
+      // 2024-06-15 14:30:25.123 in UTC; rendered using local time
+      const ts = new Date(2024, 5, 15, 14, 30, 25, 123).getTime();
+      store.addStructuredMessage(makeRow({ id: 1, timestamp: ts }));
+
+      const [msg] = useConsoleCaptureStore.getState().getMessages("pane1");
+      expect(msg!.timeLabel).toBe("14:30:25.123");
+    });
+
+    it("sets isGroupHeader true for startGroup and startGroupCollapsed, false otherwise", () => {
+      const store = useConsoleCaptureStore.getState();
+      store.addStructuredMessage(makeRow({ id: 1, cdpType: "startGroup" }));
+      store.addStructuredMessage(makeRow({ id: 2, cdpType: "startGroupCollapsed" }));
+      store.addStructuredMessage(makeRow({ id: 3, cdpType: "log" }));
+      store.addStructuredMessage(makeRow({ id: 4, cdpType: "error", level: "error" }));
+
+      const messages = useConsoleCaptureStore.getState().getMessages("pane1");
+      expect(messages[0]!.isGroupHeader).toBe(true);
+      expect(messages[1]!.isGroupHeader).toBe(true);
+      expect(messages[2]!.isGroupHeader).toBe(false);
+      expect(messages[3]!.isGroupHeader).toBe(false);
+    });
+  });
+
+  describe("error/warn counters", () => {
+    it("returns ZERO_COUNTS for an unknown pane", () => {
+      const counts = useConsoleCaptureStore.getState().getCounts("nope");
+      expect(counts).toBe(ZERO_COUNTS);
+      expect(counts).toEqual({ errorCount: 0, warnCount: 0 });
+    });
+
+    it("increments counts for error and warning levels only", () => {
+      const store = useConsoleCaptureStore.getState();
+      store.addStructuredMessage(makeRow({ id: 1, level: "log" }));
+      store.addStructuredMessage(makeRow({ id: 2, level: "info" }));
+      store.addStructuredMessage(makeRow({ id: 3, level: "warning" }));
+      store.addStructuredMessage(makeRow({ id: 4, level: "error" }));
+      store.addStructuredMessage(makeRow({ id: 5, level: "error" }));
+
+      const counts = useConsoleCaptureStore.getState().getCounts("pane1");
+      expect(counts.errorCount).toBe(2);
+      expect(counts.warnCount).toBe(1);
+    });
+
+    it("keeps counts isolated per pane", () => {
+      const store = useConsoleCaptureStore.getState();
+      store.addStructuredMessage(makeRow({ id: 1, paneId: "pane1", level: "error" }));
+      store.addStructuredMessage(makeRow({ id: 2, paneId: "pane2", level: "warning" }));
+
+      expect(useConsoleCaptureStore.getState().getCounts("pane1")).toEqual({
+        errorCount: 1,
+        warnCount: 0,
+      });
+      expect(useConsoleCaptureStore.getState().getCounts("pane2")).toEqual({
+        errorCount: 0,
+        warnCount: 1,
+      });
+    });
+
+    it("decrements counts when an error/warning message is evicted by the cap", () => {
+      const store = useConsoleCaptureStore.getState();
+      // First 100 messages are errors; the rest are logs that will push them out
+      for (let i = 0; i < 100; i++) {
+        store.addStructuredMessage(makeRow({ id: i, level: "error" }));
+      }
+      expect(useConsoleCaptureStore.getState().getCounts("pane1").errorCount).toBe(100);
+
+      // Add 500 logs to push every error message out of the 500-cap window
+      for (let i = 100; i < 600; i++) {
+        store.addStructuredMessage(makeRow({ id: i, level: "log" }));
+      }
+
+      const counts = useConsoleCaptureStore.getState().getCounts("pane1");
+      const messages = useConsoleCaptureStore.getState().getMessages("pane1");
+      expect(messages).toHaveLength(500);
+      expect(counts.errorCount).toBe(0);
+      expect(counts.warnCount).toBe(0);
+    });
+
+    it("does not decrement counts when an evicted message was log/info", () => {
+      const store = useConsoleCaptureStore.getState();
+      // Start with a log that will be the first to be evicted
+      store.addStructuredMessage(makeRow({ id: 0, level: "log" }));
+      // Then add 500 errors to fill the cap and evict the leading log
+      for (let i = 1; i <= 500; i++) {
+        store.addStructuredMessage(makeRow({ id: i, level: "error" }));
+      }
+
+      const counts = useConsoleCaptureStore.getState().getCounts("pane1");
+      const messages = useConsoleCaptureStore.getState().getMessages("pane1");
+      expect(messages).toHaveLength(500);
+      expect(counts.errorCount).toBe(500);
+    });
+
+    it("resets counts to zero after clearMessages and leaves other panes untouched", () => {
+      const store = useConsoleCaptureStore.getState();
+      store.addStructuredMessage(makeRow({ id: 1, paneId: "pane1", level: "error" }));
+      store.addStructuredMessage(makeRow({ id: 2, paneId: "pane2", level: "warning" }));
+
+      useConsoleCaptureStore.getState().clearMessages("pane1");
+
+      expect(useConsoleCaptureStore.getState().getCounts("pane1")).toBe(ZERO_COUNTS);
+      expect(useConsoleCaptureStore.getState().getCounts("pane2")).toEqual({
+        errorCount: 0,
+        warnCount: 1,
+      });
+    });
+
+    it("drops the counter entry on removePane", () => {
+      const store = useConsoleCaptureStore.getState();
+      store.addStructuredMessage(makeRow({ id: 1, paneId: "pane1", level: "error" }));
+      useConsoleCaptureStore.getState().removePane("pane1");
+
+      const state = useConsoleCaptureStore.getState();
+      expect(state.counters.has("pane1")).toBe(false);
+      expect(state.getCounts("pane1")).toBe(ZERO_COUNTS);
+    });
+
+    it("keeps the counters Map reference stable across non-counting inserts (selector-stability)", () => {
+      const store = useConsoleCaptureStore.getState();
+      // Establish a baseline counters entry
+      store.addStructuredMessage(makeRow({ id: 1, level: "error" }));
+      const beforeCounters = useConsoleCaptureStore.getState().counters;
+      const beforeCounts = beforeCounters.get("pane1");
+
+      // Adding only log/info messages should NOT churn the counters Map reference
+      store.addStructuredMessage(makeRow({ id: 2, level: "log" }));
+      store.addStructuredMessage(makeRow({ id: 3, level: "info" }));
+
+      const afterCounters = useConsoleCaptureStore.getState().counters;
+      expect(afterCounters).toBe(beforeCounters);
+      expect(afterCounters.get("pane1")).toBe(beforeCounts);
+    });
   });
 });

--- a/src/store/__tests__/consoleCaptureStore.test.ts
+++ b/src/store/__tests__/consoleCaptureStore.test.ts
@@ -319,5 +319,57 @@ describe("consoleCaptureStore", () => {
       expect(afterCounters).toBe(beforeCounters);
       expect(afterCounters.get("pane1")).toBe(beforeCounts);
     });
+
+    it("keeps the counters Map reference stable on log-evicts-log inserts at the cap", () => {
+      const store = useConsoleCaptureStore.getState();
+      // Fill exactly to the 500-cap with log messages — no counter activity
+      for (let i = 0; i < 500; i++) {
+        store.addStructuredMessage(makeRow({ id: i, level: "log" }));
+      }
+      const beforeCounters = useConsoleCaptureStore.getState().counters;
+
+      // Eviction: this insert pushes one log out and adds one log; net delta is zero
+      store.addStructuredMessage(makeRow({ id: 500, level: "log" }));
+
+      const afterCounters = useConsoleCaptureStore.getState().counters;
+      expect(afterCounters).toBe(beforeCounters);
+    });
+
+    it("handles mixed eviction deltas correctly under realistic sequences", () => {
+      const store = useConsoleCaptureStore.getState();
+      // 498 logs + 1 warning + 1 error = 500 total, in that order
+      for (let i = 0; i < 498; i++) {
+        store.addStructuredMessage(makeRow({ id: i, level: "log" }));
+      }
+      store.addStructuredMessage(makeRow({ id: 498, level: "warning" }));
+      store.addStructuredMessage(makeRow({ id: 499, level: "error" }));
+      expect(useConsoleCaptureStore.getState().getCounts("pane1")).toEqual({
+        errorCount: 1,
+        warnCount: 1,
+      });
+
+      // Add an error (evicts log 0): error+1, no decrement
+      store.addStructuredMessage(makeRow({ id: 500, level: "error" }));
+      expect(useConsoleCaptureStore.getState().getCounts("pane1")).toEqual({
+        errorCount: 2,
+        warnCount: 1,
+      });
+
+      // Add a warning (evicts log 1): warning+1, no decrement
+      store.addStructuredMessage(makeRow({ id: 501, level: "warning" }));
+      expect(useConsoleCaptureStore.getState().getCounts("pane1")).toEqual({
+        errorCount: 2,
+        warnCount: 2,
+      });
+
+      // Add 497 more logs to push every log out — eventually evicts the original warning at id 498
+      for (let i = 502; i < 502 + 497; i++) {
+        store.addStructuredMessage(makeRow({ id: i, level: "log" }));
+      }
+      expect(useConsoleCaptureStore.getState().getCounts("pane1")).toEqual({
+        errorCount: 2,
+        warnCount: 1,
+      });
+    });
   });
 });

--- a/src/store/consoleCaptureStore.ts
+++ b/src/store/consoleCaptureStore.ts
@@ -5,27 +5,55 @@ export type ConsoleLevel = "log" | "info" | "warning" | "error";
 
 export interface ConsoleMessage extends SerializedConsoleRow {
   isStale: boolean;
+  timeLabel: string;
+  isGroupHeader: boolean;
+}
+
+export interface ConsoleCounts {
+  errorCount: number;
+  warnCount: number;
 }
 
 // Stable empty array to prevent unnecessary selector rerenders for panes with no messages
 export const EMPTY_MESSAGES: ConsoleMessage[] = [];
 
+// Stable zero counts to prevent unnecessary selector rerenders for panes with no counts
+export const ZERO_COUNTS: ConsoleCounts = Object.freeze({
+  errorCount: 0,
+  warnCount: 0,
+}) as ConsoleCounts;
+
 const MAX_MESSAGES = 500;
 
 interface ConsoleCaptureState {
   messages: Map<string, ConsoleMessage[]>;
+  counters: Map<string, ConsoleCounts>;
   addStructuredMessage(row: SerializedConsoleRow): void;
   markStale(paneId: string, navigationGeneration: number): void;
   clearMessages(paneId: string): void;
   getMessages(paneId: string): ConsoleMessage[];
+  getCounts(paneId: string): ConsoleCounts;
   removePane(paneId: string): void;
 }
 
 // Types that should not be rendered as visible rows
 const HIDDEN_TYPES: Set<CdpConsoleType> = new Set(["endGroup"]);
 
+// Group types that act as headers
+const GROUP_HEADER_TYPES: Set<CdpConsoleType> = new Set(["startGroup", "startGroupCollapsed"]);
+
+function formatConsoleTime(ts: number): string {
+  const d = new Date(ts);
+  const h = String(d.getHours()).padStart(2, "0");
+  const m = String(d.getMinutes()).padStart(2, "0");
+  const s = String(d.getSeconds()).padStart(2, "0");
+  const ms = String(d.getMilliseconds()).padStart(3, "0");
+  return `${h}:${m}:${s}.${ms}`;
+}
+
 export const useConsoleCaptureStore = create<ConsoleCaptureState>()((set, get) => ({
   messages: new Map(),
+  counters: new Map(),
 
   addStructuredMessage(row: SerializedConsoleRow) {
     if (HIDDEN_TYPES.has(row.cdpType)) return;
@@ -33,14 +61,38 @@ export const useConsoleCaptureStore = create<ConsoleCaptureState>()((set, get) =
     const msg: ConsoleMessage = {
       ...row,
       isStale: false,
+      timeLabel: formatConsoleTime(row.timestamp),
+      isGroupHeader: GROUP_HEADER_TYPES.has(row.cdpType),
     };
 
     set((state) => {
       const existing = state.messages.get(row.paneId) ?? [];
-      const updated = [...existing, msg].slice(-MAX_MESSAGES);
-      const next = new Map(state.messages);
-      next.set(row.paneId, updated);
-      return { messages: next };
+      const willEvict = existing.length >= MAX_MESSAGES;
+      const updated = willEvict ? [...existing.slice(1), msg] : [...existing, msg];
+
+      const nextMessages = new Map(state.messages);
+      nextMessages.set(row.paneId, updated);
+
+      let errorDelta = msg.level === "error" ? 1 : 0;
+      let warnDelta = msg.level === "warning" ? 1 : 0;
+      if (willEvict) {
+        const evicted = existing[0]!;
+        if (evicted.level === "error") errorDelta -= 1;
+        if (evicted.level === "warning") warnDelta -= 1;
+      }
+
+      let nextCounters = state.counters;
+      if (errorDelta !== 0 || warnDelta !== 0) {
+        const current = state.counters.get(row.paneId) ?? ZERO_COUNTS;
+        const updatedCounts: ConsoleCounts = {
+          errorCount: current.errorCount + errorDelta,
+          warnCount: current.warnCount + warnDelta,
+        };
+        nextCounters = new Map(state.counters);
+        nextCounters.set(row.paneId, updatedCounts);
+      }
+
+      return { messages: nextMessages, counters: nextCounters };
     });
   },
 
@@ -62,9 +114,16 @@ export const useConsoleCaptureStore = create<ConsoleCaptureState>()((set, get) =
 
   clearMessages(paneId: string) {
     set((state) => {
-      const next = new Map(state.messages);
-      next.set(paneId, []);
-      return { messages: next };
+      const nextMessages = new Map(state.messages);
+      nextMessages.set(paneId, []);
+
+      let nextCounters = state.counters;
+      if (state.counters.has(paneId)) {
+        nextCounters = new Map(state.counters);
+        nextCounters.delete(paneId);
+      }
+
+      return { messages: nextMessages, counters: nextCounters };
     });
   },
 
@@ -72,11 +131,22 @@ export const useConsoleCaptureStore = create<ConsoleCaptureState>()((set, get) =
     return get().messages.get(paneId) ?? [];
   },
 
+  getCounts(paneId: string) {
+    return get().counters.get(paneId) ?? ZERO_COUNTS;
+  },
+
   removePane(paneId: string) {
     set((state) => {
-      const next = new Map(state.messages);
-      next.delete(paneId);
-      return { messages: next };
+      const nextMessages = new Map(state.messages);
+      nextMessages.delete(paneId);
+
+      let nextCounters = state.counters;
+      if (state.counters.has(paneId)) {
+        nextCounters = new Map(state.counters);
+        nextCounters.delete(paneId);
+      }
+
+      return { messages: nextMessages, counters: nextCounters };
     });
   },
 }));


### PR DESCRIPTION
## Summary

- Precompute `timeLabel` and `isGroupHeader` on `ConsoleMessage` at insert time, eliminating per-row `formatTime` calls and `GROUP_HEADER_TYPES.has` checks on every render.
- Move error/warn counters into the store with eviction-aware math and counter-Map reference stability, replacing two O(n) `useMemo` filter passes per render with scalar reads.
- Track the auto-collapse cursor by tail message id rather than array index, keeping it monotonic across 500-cap eviction; wrap `ConsoleRow` in `React.memo` with a stable `toggleGroup` callback so unchanged rows bail out of reconciliation when a new message lands.

Resolves #7232

## Changes

- `consoleCaptureStore.ts` — precomputed fields on insert; per-pane error/warn counters with eviction adjustments; `lastSeenTailIdRef` cursor; stale `collapsedGroups` cleanup on `clearMessages`
- `ConsolePanel.tsx` — `search.toLowerCase()` hoisted outside filter callback; `ConsoleRow` wrapped in `React.memo`; `toggleGroup` stabilised via `useCallback`
- `consoleCaptureStore.test.ts` — 26 unit tests covering precomputed fields, counter math (increment/decrement across the 500-cap boundary), and counter-Map reference stability for selector equality

## Testing

26 store unit tests pass, including new coverage for all the eviction-boundary counter scenarios and reference-stability checks.