### PR TITLE
fix(terminal): sanitize and bound spawned-process error text in banners

### DIFF
--- a/src/components/Settings/AgentHelpOutput.tsx
+++ b/src/components/Settings/AgentHelpOutput.tsx
@@ -8,20 +8,13 @@ import type { AgentHelpResult } from "@shared/types/ipc/agent";
 import type { AgentAvailabilityState } from "@shared/types";
 import { isAgentInstalled, isAgentMissing } from "../../../shared/utils/agentAvailability";
 import { formatErrorMessage } from "@shared/utils/errorMessage";
+import { sanitizeErrorText } from "@/utils/errorText";
 import { logError } from "@/utils/logger";
 
 interface AgentHelpOutputProps {
   agentId: string;
   agentName: string;
   usageUrl?: string;
-}
-
-function stripAnsi(text: string): string {
-  return text.replace(
-    // eslint-disable-next-line no-control-regex
-    /[\u001b\u009b][[()#;?]*(?:[0-9]{1,4}(?:;[0-9]{0,4})*)?[0-9A-ORZcf-nqry=><]/g,
-    ""
-  );
 }
 
 export function AgentHelpOutput({ agentId, agentName, usageUrl }: AgentHelpOutputProps) {
@@ -94,7 +87,7 @@ export function AgentHelpOutput({ agentId, agentName, usageUrl }: AgentHelpOutpu
   const handleCopy = useCallback(async () => {
     if (!helpResult) return;
 
-    const textToCopy = stripAnsi(
+    const textToCopy = sanitizeErrorText(
       [helpResult.stdout, helpResult.stderr].filter(Boolean).join("\n\n")
     );
 
@@ -123,8 +116,8 @@ export function AgentHelpOutput({ agentId, agentName, usageUrl }: AgentHelpOutpu
   const renderOutput = () => {
     if (!helpResult) return null;
 
-    const cleanStdout = stripAnsi(helpResult.stdout);
-    const cleanStderr = stripAnsi(helpResult.stderr);
+    const cleanStdout = sanitizeErrorText(helpResult.stdout);
+    const cleanStderr = sanitizeErrorText(helpResult.stderr);
     const hasError = helpResult.exitCode !== 0 || helpResult.timedOut;
 
     return (

--- a/src/components/Terminal/InlineStatusBanner.tsx
+++ b/src/components/Terminal/InlineStatusBanner.tsx
@@ -20,7 +20,7 @@ export interface InlineStatusBannerProps {
   icon: React.ComponentType<{ className?: string; style?: CSSProperties }>;
   title: React.ReactNode;
   description?: React.ReactNode;
-  contextLine?: React.ReactNode;
+  contextLine?: string;
   severity?: "error" | "warning";
   animated?: boolean;
   className?: string;
@@ -136,7 +136,7 @@ function InlineStatusBannerComponent({
             </span>
             {description && (
               <p
-                className="text-xs mt-0.5"
+                className="text-xs mt-0.5 break-words"
                 style={{ color: `color-mix(in oklab, var(${colorVar}) 80%, transparent)` }}
               >
                 {description}
@@ -146,6 +146,7 @@ function InlineStatusBannerComponent({
               <p
                 className="text-xs font-mono mt-1 truncate"
                 style={{ color: `color-mix(in oklab, var(${colorVar}) 60%, transparent)` }}
+                title={contextLine}
               >
                 {contextLine}
               </p>

--- a/src/components/Terminal/ReconnectErrorBanner.tsx
+++ b/src/components/Terminal/ReconnectErrorBanner.tsx
@@ -1,6 +1,7 @@
 import React from "react";
 import { Clock, RotateCcw, AlertTriangle } from "lucide-react";
 import { InlineStatusBanner } from "./InlineStatusBanner";
+import { boundedErrorText } from "@/utils/errorText";
 import type { TerminalReconnectError } from "@/types";
 
 export interface ReconnectErrorBannerProps {
@@ -54,7 +55,7 @@ function ReconnectErrorBannerComponent({
     <InlineStatusBanner
       icon={getErrorIcon(error.type)}
       title={getErrorTitle(error.type)}
-      description={error.message}
+      description={boundedErrorText(error.message)}
       severity={getErrorSeverity(error.type)}
       actions={[
         {

--- a/src/components/Terminal/SpawnErrorBanner.tsx
+++ b/src/components/Terminal/SpawnErrorBanner.tsx
@@ -1,6 +1,7 @@
 import React from "react";
 import { AlertTriangle, RotateCcw, FolderEdit, Trash2 } from "lucide-react";
 import { InlineStatusBanner, type BannerAction } from "./InlineStatusBanner";
+import { sanitizeErrorText, boundedErrorText } from "@/utils/errorText";
 import type { SpawnError } from "@/types";
 
 export interface SpawnErrorBannerProps {
@@ -41,16 +42,18 @@ function getErrorTitle(code: SpawnError["code"]): string {
 }
 
 function getErrorDescription(error: SpawnError, cwd?: string): string {
+  const safePath = error.path ? boundedErrorText(error.path) : "";
+  const safeCwd = cwd ? boundedErrorText(cwd) : "";
   switch (error.code) {
     case "ENOENT":
-      if (error.path) {
-        return `Couldn't find: ${error.path}`;
+      if (safePath) {
+        return `Couldn't find: ${safePath}`;
       }
-      return error.message;
+      return boundedErrorText(error.message);
     case "EACCES":
-      return `Couldn't execute ${error.path || "the shell"} — check permissions`;
+      return `Couldn't execute ${safePath || "the shell"} — check permissions`;
     case "ENOTDIR":
-      return `The working directory isn't valid: ${cwd || "(unknown)"}`;
+      return `The working directory isn't valid: ${safeCwd || "(unknown)"}`;
     case "EIO":
       return "Couldn't allocate a terminal session. The system may be running low on resources.";
     case "EMFILE":
@@ -66,7 +69,7 @@ function getErrorDescription(error: SpawnError, cwd?: string): string {
     case "DISCONNECTED":
       return "The terminal process is no longer running.";
     default:
-      return error.message;
+      return boundedErrorText(error.message);
   }
 }
 
@@ -119,7 +122,7 @@ function SpawnErrorBannerComponent({
       icon={AlertTriangle}
       title={getErrorTitle(error.code)}
       description={getErrorDescription(error, cwd)}
-      contextLine={cwd && `Directory: ${cwd}`}
+      contextLine={cwd ? `Directory: ${sanitizeErrorText(cwd)}` : undefined}
       severity="error"
       actions={actions}
       className={className}

--- a/src/components/Terminal/TerminalErrorBanner.tsx
+++ b/src/components/Terminal/TerminalErrorBanner.tsx
@@ -1,6 +1,7 @@
 import React from "react";
 import { AlertTriangle, RotateCcw, FolderEdit, Trash2 } from "lucide-react";
 import { InlineStatusBanner, type BannerAction } from "./InlineStatusBanner";
+import { sanitizeErrorText, boundedErrorText } from "@/utils/errorText";
 import type { TerminalRestartError } from "@/types";
 
 export interface TerminalErrorBannerProps {
@@ -59,8 +60,12 @@ function TerminalErrorBannerComponent({
     <InlineStatusBanner
       icon={AlertTriangle}
       title="Terminal restart failed"
-      description={error.message}
-      contextLine={error.context?.failedCwd && `Directory: ${error.context.failedCwd}`}
+      description={boundedErrorText(error.message)}
+      contextLine={
+        error.context?.failedCwd
+          ? `Directory: ${sanitizeErrorText(error.context.failedCwd)}`
+          : undefined
+      }
       severity="error"
       actions={actions}
       className={className}

--- a/src/utils/__tests__/errorText.test.ts
+++ b/src/utils/__tests__/errorText.test.ts
@@ -54,6 +54,27 @@ describe("sanitizeErrorText", () => {
     expect(sanitizeErrorText("a\x1b=b")).toBe("ab");
   });
 
+  it("strips unterminated OSC payloads (no terminator)", () => {
+    expect(sanitizeErrorText("\x1b]0;injected text with no terminator")).toBe("");
+    expect(sanitizeErrorText("before\x1b]0;hidden")).toBe("before");
+  });
+
+  it("strips unterminated DCS/APC/PM/SOS payloads", () => {
+    expect(sanitizeErrorText("\x1bP1;2;3qpayload")).toBe("");
+    expect(sanitizeErrorText("\x1b^apc payload")).toBe("");
+    expect(sanitizeErrorText("\x1b_pm payload")).toBe("");
+    expect(sanitizeErrorText("\x1bXsos payload")).toBe("");
+  });
+
+  it("strips unterminated sequence followed by valid sequence", () => {
+    expect(sanitizeErrorText("\x1b]0;leak\x1b[31mred\x1b[0m")).toBe("red");
+  });
+
+  it("strips 8-bit CSI sequences (parameter text included)", () => {
+    expect(sanitizeErrorText("\x9b31mred\x9b0m")).toBe("red");
+    expect(sanitizeErrorText("\x9b2J\x9bH")).toBe("");
+  });
+
   it("strips C0 control characters (excluding HT/LF/CR)", () => {
     expect(sanitizeErrorText("a\x00b\x07c\x08d")).toBe("abcd");
     expect(sanitizeErrorText("a\x0bb\x0cc")).toBe("abc");
@@ -112,6 +133,15 @@ describe("boundedErrorText", () => {
     expect(result).toContain("...");
     expect(result.startsWith("a")).toBe(true);
     expect(result.endsWith("a")).toBe(true);
+  });
+
+  it("preserves both ends when middle-truncating", () => {
+    const text = "PREFIX_" + "x".repeat(240) + "_SUFFIX";
+    const result = boundedErrorText(text, 200);
+    expect(result.length).toBeLessThanOrEqual(200);
+    expect(result.startsWith("PREFIX_")).toBe(true);
+    expect(result.endsWith("_SUFFIX")).toBe(true);
+    expect(result).toContain("...");
   });
 
   it("uses default limit of 200", () => {

--- a/src/utils/__tests__/errorText.test.ts
+++ b/src/utils/__tests__/errorText.test.ts
@@ -1,0 +1,146 @@
+import { describe, it, expect } from "vitest";
+import { sanitizeErrorText, boundedErrorText } from "../errorText";
+
+describe("sanitizeErrorText", () => {
+  it("returns empty string for empty input", () => {
+    expect(sanitizeErrorText("")).toBe("");
+  });
+
+  it("preserves plain ASCII text", () => {
+    expect(sanitizeErrorText("hello world")).toBe("hello world");
+  });
+
+  it("preserves printable Unicode (CJK, emoji, accents)", () => {
+    expect(sanitizeErrorText("café 日本語 🚀")).toBe("café 日本語 🚀");
+  });
+
+  it("preserves whitespace HT/LF/CR", () => {
+    expect(sanitizeErrorText("a\tb\nc\rd")).toBe("a\tb\nc\rd");
+  });
+
+  it("strips CSI sequences (SGR color codes)", () => {
+    expect(sanitizeErrorText("\x1b[31mred\x1b[0m")).toBe("red");
+  });
+
+  it("strips CSI cursor movement", () => {
+    expect(sanitizeErrorText("a\x1b[2Jb\x1b[H")).toBe("ab");
+  });
+
+  it("strips OSC sequences with BEL terminator (window title)", () => {
+    expect(sanitizeErrorText("\x1b]0;owned\x07hello")).toBe("hello");
+  });
+
+  it("strips OSC sequences with ST terminator (hyperlink)", () => {
+    expect(sanitizeErrorText("\x1b]8;;https://evil.example\x1b\\link\x1b]8;;\x1b\\")).toBe("link");
+  });
+
+  it("strips DCS sequences", () => {
+    expect(sanitizeErrorText("\x1bP1;2;3qdata\x1b\\after")).toBe("after");
+  });
+
+  it("strips APC/PM/SOS sequences", () => {
+    expect(sanitizeErrorText("\x1b^apc\x1b\\")).toBe("");
+    expect(sanitizeErrorText("\x1b_pm\x1b\\")).toBe("");
+    expect(sanitizeErrorText("\x1bXsos\x1b\\")).toBe("");
+  });
+
+  it("strips 8-bit C1 OSC and DCS", () => {
+    expect(sanitizeErrorText("\x9d0;owned\x9chello")).toBe("hello");
+    expect(sanitizeErrorText("\x90data\x9cafter")).toBe("after");
+  });
+
+  it("strips lone ESC and Fe escape sequences", () => {
+    expect(sanitizeErrorText("a\x1bMb")).toBe("ab");
+    expect(sanitizeErrorText("a\x1b=b")).toBe("ab");
+  });
+
+  it("strips C0 control characters (excluding HT/LF/CR)", () => {
+    expect(sanitizeErrorText("a\x00b\x07c\x08d")).toBe("abcd");
+    expect(sanitizeErrorText("a\x0bb\x0cc")).toBe("abc");
+    expect(sanitizeErrorText("a\x1fb")).toBe("ab");
+  });
+
+  it("strips DEL (0x7F)", () => {
+    expect(sanitizeErrorText("a\x7fb")).toBe("ab");
+  });
+
+  it("strips orphaned C1 control bytes", () => {
+    expect(sanitizeErrorText("a\x80b\x9fc")).toBe("abc");
+  });
+
+  it("strips RTL override (U+202E)", () => {
+    expect(sanitizeErrorText("safe‮malicious")).toBe("safemalicious");
+  });
+
+  it("strips Bidi marks and embeddings (U+200E/F, U+202A-E)", () => {
+    expect(sanitizeErrorText("a‎b‏c‪d‫e‬f‭g‮h")).toBe("abcdefgh");
+  });
+
+  it("strips Bidi isolates (U+2066-U+2069)", () => {
+    expect(sanitizeErrorText("a⁦b⁧c⁨d⁩e")).toBe("abcde");
+  });
+
+  it("strips line/paragraph separators (U+2028, U+2029)", () => {
+    expect(sanitizeErrorText("a b c")).toBe("abc");
+  });
+
+  it("strips BOM (U+FEFF)", () => {
+    expect(sanitizeErrorText("﻿hello")).toBe("hello");
+  });
+
+  it("is idempotent (sanitizing twice == once)", () => {
+    const dirty = "\x1b[31m\x07a‮b\x1b]0;t\x07c";
+    const once = sanitizeErrorText(dirty);
+    expect(sanitizeErrorText(once)).toBe(once);
+  });
+
+  it("strips a realistic injection attempt (window title + ANSI + RTL)", () => {
+    const malicious = "\x1b]0;You are owned\x07\x1b[2J\x1b[Hspawn ENOENT ‮/etc/passwd";
+    expect(sanitizeErrorText(malicious)).toBe("spawn ENOENT /etc/passwd");
+  });
+});
+
+describe("boundedErrorText", () => {
+  it("returns sanitized text unchanged when under limit", () => {
+    expect(boundedErrorText("short error", 200)).toBe("short error");
+  });
+
+  it("middle-truncates when over limit", () => {
+    const long = "a".repeat(250);
+    const result = boundedErrorText(long, 200);
+    expect(result.length).toBeLessThanOrEqual(200);
+    expect(result).toContain("...");
+    expect(result.startsWith("a")).toBe(true);
+    expect(result.endsWith("a")).toBe(true);
+  });
+
+  it("uses default limit of 200", () => {
+    const long = "a".repeat(300);
+    const result = boundedErrorText(long);
+    expect(result.length).toBeLessThanOrEqual(200);
+  });
+
+  it("strips before truncating (escape sequences don't inflate budget)", () => {
+    // 50 chars of CSI noise + 50 chars of content. After strip: 50 chars.
+    const noisy = "\x1b[31m".repeat(10) + "x".repeat(50);
+    const result = boundedErrorText(noisy, 100);
+    expect(result).toBe("x".repeat(50));
+    expect(result).not.toContain("\x1b");
+  });
+
+  it("respects custom limit", () => {
+    const long = "abcdefghij".repeat(20); // 200 chars
+    const result = boundedErrorText(long, 50);
+    expect(result.length).toBeLessThanOrEqual(50);
+    expect(result).toContain("...");
+  });
+
+  it("returns empty string for empty input", () => {
+    expect(boundedErrorText("")).toBe("");
+  });
+
+  it("preserves text exactly at limit", () => {
+    const exact = "a".repeat(200);
+    expect(boundedErrorText(exact, 200)).toBe(exact);
+  });
+});

--- a/src/utils/errorText.ts
+++ b/src/utils/errorText.ts
@@ -1,0 +1,53 @@
+import { middleTruncate } from "./textParsing";
+
+/* eslint-disable no-control-regex */
+const OSC_7BIT = /\x1b\][\s\S]*?(?:\x07|\x1b\\)/g;
+const OSC_8BIT = /\x9d[\s\S]*?(?:\x07|\x9c)/g;
+const DCS_SOS_PM_APC_7BIT = /\x1b[PX^_][\s\S]*?\x1b\\/g;
+const DCS_SOS_PM_APC_8BIT = /[\x90\x98\x9e\x9f][\s\S]*?\x9c/g;
+const CSI = /\x1b\[[\x30-\x3f]*[\x20-\x2f]*[\x40-\x7e]/g;
+const FE_ESCAPE = /\x1b[\x20-\x2f]*[\x30-\x7e]/g;
+const C0_AND_DEL = /[\x00-\x08\x0b\x0c\x0e-\x1f\x7f]/g;
+const C1 = /[\x80-\x9f]/g;
+/* eslint-enable no-control-regex */
+// Bidi marks/embeddings/overrides/isolates: U+200E, U+200F, U+202A-U+202E,
+// U+2066-U+2069. Line/paragraph separators: U+2028, U+2029. BOM: U+FEFF.
+const BIDI_AND_SEPARATORS = new RegExp(
+  "[" +
+    "‎" + // LRM (Left-to-Right Mark)
+    "‏" + // RLM (Right-to-Left Mark)
+    "‪‫‬‭‮" + // LRE, RLE, PDF, LRO, RLO
+    "  " + // Line/Paragraph separators
+    "⁦⁧⁨⁩" + // LRI, RLI, FSI, PDI
+    "﻿" + // BOM
+    "]",
+  "g"
+);
+
+/**
+ * Strips terminal escape sequences and dangerous control/Unicode characters
+ * from untrusted error text before rendering. Preserves printable text plus
+ * HT (0x09), LF (0x0A), CR (0x0D).
+ */
+export function sanitizeErrorText(text: string): string {
+  if (!text) return "";
+  return text
+    .replace(OSC_7BIT, "")
+    .replace(OSC_8BIT, "")
+    .replace(DCS_SOS_PM_APC_7BIT, "")
+    .replace(DCS_SOS_PM_APC_8BIT, "")
+    .replace(CSI, "")
+    .replace(FE_ESCAPE, "")
+    .replace(C0_AND_DEL, "")
+    .replace(C1, "")
+    .replace(BIDI_AND_SEPARATORS, "");
+}
+
+/**
+ * Sanitizes then length-bounds an error string. Strip-then-truncate order
+ * matters — escape sequences inflate raw character counts and truncating
+ * first can leave dangling partial sequences.
+ */
+export function boundedErrorText(text: string, limit: number = 200): string {
+  return middleTruncate(sanitizeErrorText(text), limit);
+}

--- a/src/utils/errorText.ts
+++ b/src/utils/errorText.ts
@@ -5,7 +5,12 @@ const OSC_7BIT = /\x1b\][\s\S]*?(?:\x07|\x1b\\)/g;
 const OSC_8BIT = /\x9d[\s\S]*?(?:\x07|\x9c)/g;
 const DCS_SOS_PM_APC_7BIT = /\x1b[PX^_][\s\S]*?\x1b\\/g;
 const DCS_SOS_PM_APC_8BIT = /[\x90\x98\x9e\x9f][\s\S]*?\x9c/g;
-const CSI = /\x1b\[[\x30-\x3f]*[\x20-\x2f]*[\x40-\x7e]/g;
+// Catches unterminated OSC/DCS/SOS/PM/APC payloads that escaped the strict
+// patterns above. Runs before CSI/FE_ESCAPE so the introducer + payload are
+// dropped together rather than leaving the payload as visible text.
+const UNTERMINATED_STRING_SEQ = /\x1b[\]PX^_][^\x07\x1b]*/g;
+const CSI_7BIT = /\x1b\[[\x30-\x3f]*[\x20-\x2f]*[\x40-\x7e]/g;
+const CSI_8BIT = /\x9b[\x30-\x3f]*[\x20-\x2f]*[\x40-\x7e]/g;
 const FE_ESCAPE = /\x1b[\x20-\x2f]*[\x30-\x7e]/g;
 const C0_AND_DEL = /[\x00-\x08\x0b\x0c\x0e-\x1f\x7f]/g;
 const C1 = /[\x80-\x9f]/g;
@@ -36,7 +41,9 @@ export function sanitizeErrorText(text: string): string {
     .replace(OSC_8BIT, "")
     .replace(DCS_SOS_PM_APC_7BIT, "")
     .replace(DCS_SOS_PM_APC_8BIT, "")
-    .replace(CSI, "")
+    .replace(UNTERMINATED_STRING_SEQ, "")
+    .replace(CSI_7BIT, "")
+    .replace(CSI_8BIT, "")
     .replace(FE_ESCAPE, "")
     .replace(C0_AND_DEL, "")
     .replace(C1, "")


### PR DESCRIPTION
## Summary

- Adds `src/utils/errorText.ts` with `sanitizeErrorText` and `boundedErrorText` — a shared, renderer-safe utility that strips CSI/OSC/DCS/SOS/PM/APC sequences (7-bit and 8-bit), C0/C1 controls, DEL, Unicode bidi overrides, line/paragraph separators, and BOM, then middle-truncates to a configurable limit (default 200 chars)
- Applies sanitization across `SpawnErrorBanner`, `TerminalErrorBanner`, and `ReconnectErrorBanner`, covering path, message, and cwd fields — same class of issue as CVE-2021-25743 and CVE-2003-0063
- Replaces the narrow private `stripAnsi` in `AgentHelpOutput` with the shared helper; narrows `InlineStatusBanner`'s `contextLine` prop from `React.ReactNode` to `string` and adds `break-words` + a `title` attribute to the truncated path

Resolves #7231

## Changes

- `src/utils/errorText.ts` — new shared utility (`sanitizeErrorText`, `boundedErrorText`)
- `src/utils/__tests__/errorText.test.ts` — 34 vitest cases covering all escape classes, idempotency, realistic injection, unterminated sequences, and 8-bit CSI
- `SpawnErrorBanner`, `TerminalErrorBanner`, `ReconnectErrorBanner` — sanitized inputs
- `InlineStatusBanner` — `contextLine: string`, `break-words` on description, `title` on truncated path
- `AgentHelpOutput` — private `stripAnsi` removed, replaced with `sanitizeErrorText`

## Testing

- 34 unit tests, all passing
- `tsc --noEmit` clean
- Lint and format clean (net 8 fewer warnings from removing the private helper)