### PR TITLE
fix(panel): make terminal close near-instant; cancel queued fade on rapid Cmd+W/X

### DIFF
--- a/src/hooks/__tests__/usePanelHandlers.test.ts
+++ b/src/hooks/__tests__/usePanelHandlers.test.ts
@@ -145,6 +145,59 @@ describe("usePanelHandlers", () => {
     expect(lifecycle.timeoutRef.current).toBeUndefined();
   });
 
+  it("trashes synchronously when reduce-animations is enabled (CSS+JS parity)", () => {
+    document.body.dataset.reduceAnimations = "true";
+    const lifecycle = makeLifecycle();
+    const { result } = renderHook(() => usePanelHandlers({ terminalId: "p1", lifecycle }));
+
+    act(() => {
+      result.current.handleClose();
+    });
+
+    expect(trashPanelGroupMock).toHaveBeenCalledWith("p1");
+    expect(lifecycle.setIsTrashing).not.toHaveBeenCalled();
+    delete document.body.dataset.reduceAnimations;
+  });
+
+  it("triple-close on the same panel only trashes once", () => {
+    const lifecycle = makeLifecycle();
+    const onAfterClose = vi.fn();
+    const { result } = renderHook(() =>
+      usePanelHandlers({ terminalId: "p1", lifecycle, onAfterClose })
+    );
+
+    // 1st: schedules timer.
+    act(() => result.current.handleClose());
+    // 2nd: cancels timer, flushes.
+    act(() => result.current.handleClose());
+    // 3rd: panel already trashed — no-op.
+    act(() => result.current.handleClose());
+
+    expect(trashPanelGroupMock).toHaveBeenCalledTimes(1);
+    expect(onAfterClose).toHaveBeenCalledTimes(1);
+  });
+
+  it("force-close cancels a pending normal-close timer", () => {
+    const lifecycle = makeLifecycle();
+    const onAfterClose = vi.fn();
+    const { result } = renderHook(() =>
+      usePanelHandlers({ terminalId: "p1", lifecycle, onAfterClose })
+    );
+
+    act(() => result.current.handleClose()); // normal close → 50ms timer
+    expect(lifecycle.timeoutRef.current).toBeDefined();
+
+    act(() => result.current.handleClose(true)); // force close before timer fires
+
+    expect(removePanelMock).toHaveBeenCalledWith("p1");
+    expect(lifecycle.timeoutRef.current).toBeUndefined();
+
+    // The original 50ms timer must not fire trashPanelGroup.
+    act(() => vi.advanceTimersByTime(100));
+    expect(trashPanelGroupMock).not.toHaveBeenCalled();
+    expect(onAfterClose).toHaveBeenCalledTimes(1);
+  });
+
   it("skips setIsTrashing(false) when the panel unmounted before the timer fires", () => {
     const lifecycle = makeLifecycle();
     const { result } = renderHook(() => usePanelHandlers({ terminalId: "p1", lifecycle }));

--- a/src/hooks/__tests__/usePanelHandlers.test.ts
+++ b/src/hooks/__tests__/usePanelHandlers.test.ts
@@ -1,0 +1,209 @@
+// @vitest-environment jsdom
+import { act, renderHook } from "@testing-library/react";
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+
+vi.mock("@/utils/logger", () => ({
+  logError: vi.fn(),
+  logWarn: vi.fn(),
+}));
+
+const { setFocusedMock, trashPanelGroupMock, removePanelMock, updateTitleMock } = vi.hoisted(
+  () => ({
+    setFocusedMock: vi.fn(),
+    trashPanelGroupMock: vi.fn(),
+    removePanelMock: vi.fn(),
+    updateTitleMock: vi.fn(),
+  })
+);
+
+vi.mock("@/store", () => {
+  type StoreShape = {
+    setFocused: typeof setFocusedMock;
+    trashPanelGroup: typeof trashPanelGroupMock;
+    removePanel: typeof removePanelMock;
+    updateTitle: typeof updateTitleMock;
+  };
+  const state: StoreShape = {
+    setFocused: setFocusedMock,
+    trashPanelGroup: trashPanelGroupMock,
+    removePanel: removePanelMock,
+    updateTitle: updateTitleMock,
+  };
+  return {
+    usePanelStore: (selector: (s: StoreShape) => unknown) => selector(state),
+  };
+});
+
+import { usePanelHandlers } from "../usePanelHandlers";
+import type { PanelLifecycle } from "../usePanelLifecycle";
+
+function makeLifecycle(): PanelLifecycle & { setIsTrashing: ReturnType<typeof vi.fn> } {
+  return {
+    mountedRef: { current: true },
+    timeoutRef: { current: undefined },
+    isTrashing: false,
+    setIsTrashing: vi.fn(),
+  };
+}
+
+describe("usePanelHandlers", () => {
+  beforeEach(() => {
+    vi.useFakeTimers();
+    setFocusedMock.mockClear();
+    trashPanelGroupMock.mockClear();
+    removePanelMock.mockClear();
+    updateTitleMock.mockClear();
+    delete document.body.dataset.performanceMode;
+  });
+
+  afterEach(() => {
+    vi.useRealTimers();
+    delete document.body.dataset.performanceMode;
+  });
+
+  it("force-close calls removePanel synchronously", () => {
+    const lifecycle = makeLifecycle();
+    const onAfterClose = vi.fn();
+    const { result } = renderHook(() =>
+      usePanelHandlers({ terminalId: "p1", lifecycle, onAfterClose })
+    );
+
+    act(() => {
+      result.current.handleClose(true);
+    });
+
+    expect(removePanelMock).toHaveBeenCalledWith("p1");
+    expect(onAfterClose).toHaveBeenCalledTimes(1);
+    expect(trashPanelGroupMock).not.toHaveBeenCalled();
+    expect(lifecycle.setIsTrashing).not.toHaveBeenCalled();
+  });
+
+  it("schedules trash after the animation duration", () => {
+    const lifecycle = makeLifecycle();
+    const { result } = renderHook(() => usePanelHandlers({ terminalId: "p1", lifecycle }));
+
+    act(() => {
+      result.current.handleClose();
+    });
+
+    expect(lifecycle.setIsTrashing).toHaveBeenCalledWith(true);
+    expect(trashPanelGroupMock).not.toHaveBeenCalled();
+
+    act(() => {
+      vi.advanceTimersByTime(50);
+    });
+
+    expect(trashPanelGroupMock).toHaveBeenCalledWith("p1");
+    expect(lifecycle.setIsTrashing).toHaveBeenLastCalledWith(false);
+  });
+
+  it("flushes immediately when handleClose is called again on a panel already trashing", () => {
+    const lifecycle = makeLifecycle();
+    const onAfterClose = vi.fn();
+    const { result } = renderHook(() =>
+      usePanelHandlers({ terminalId: "p1", lifecycle, onAfterClose })
+    );
+
+    act(() => {
+      result.current.handleClose();
+    });
+    expect(trashPanelGroupMock).not.toHaveBeenCalled();
+    expect(lifecycle.timeoutRef.current).toBeDefined();
+
+    // Second close before the timer fires — should cancel the timer and flush.
+    act(() => {
+      result.current.handleClose();
+    });
+
+    expect(trashPanelGroupMock).toHaveBeenCalledTimes(1);
+    expect(trashPanelGroupMock).toHaveBeenCalledWith("p1");
+    expect(onAfterClose).toHaveBeenCalledTimes(1);
+    expect(lifecycle.timeoutRef.current).toBeUndefined();
+
+    // Original timer should now be a no-op (cancelled).
+    act(() => {
+      vi.advanceTimersByTime(100);
+    });
+    expect(trashPanelGroupMock).toHaveBeenCalledTimes(1);
+  });
+
+  it("trashes synchronously without setIsTrashing in performance mode", () => {
+    document.body.dataset.performanceMode = "true";
+    const lifecycle = makeLifecycle();
+    const onAfterClose = vi.fn();
+    const { result } = renderHook(() =>
+      usePanelHandlers({ terminalId: "p1", lifecycle, onAfterClose })
+    );
+
+    act(() => {
+      result.current.handleClose();
+    });
+
+    expect(trashPanelGroupMock).toHaveBeenCalledWith("p1");
+    expect(lifecycle.setIsTrashing).not.toHaveBeenCalled();
+    expect(onAfterClose).toHaveBeenCalledTimes(1);
+    expect(lifecycle.timeoutRef.current).toBeUndefined();
+  });
+
+  it("skips setIsTrashing(false) when the panel unmounted before the timer fires", () => {
+    const lifecycle = makeLifecycle();
+    const { result } = renderHook(() => usePanelHandlers({ terminalId: "p1", lifecycle }));
+
+    act(() => {
+      result.current.handleClose();
+    });
+
+    // Simulate unmount between schedule and fire.
+    lifecycle.mountedRef.current = false;
+    lifecycle.setIsTrashing.mockClear();
+
+    act(() => {
+      vi.advanceTimersByTime(50);
+    });
+
+    expect(trashPanelGroupMock).toHaveBeenCalledWith("p1");
+    expect(lifecycle.setIsTrashing).not.toHaveBeenCalled();
+  });
+
+  it("logs but does not throw when trashPanelGroup raises", () => {
+    trashPanelGroupMock.mockImplementationOnce(() => {
+      throw new Error("boom");
+    });
+    const lifecycle = makeLifecycle();
+    const { result } = renderHook(() => usePanelHandlers({ terminalId: "p1", lifecycle }));
+
+    act(() => {
+      result.current.handleClose();
+    });
+
+    expect(() => {
+      act(() => {
+        vi.advanceTimersByTime(50);
+      });
+    }).not.toThrow();
+
+    expect(lifecycle.setIsTrashing).toHaveBeenLastCalledWith(false);
+  });
+
+  it("handleFocus delegates to setFocused", () => {
+    const lifecycle = makeLifecycle();
+    const { result } = renderHook(() => usePanelHandlers({ terminalId: "p1", lifecycle }));
+
+    act(() => {
+      result.current.handleFocus();
+    });
+
+    expect(setFocusedMock).toHaveBeenCalledWith("p1");
+  });
+
+  it("handleTitleChange delegates to updateTitle", () => {
+    const lifecycle = makeLifecycle();
+    const { result } = renderHook(() => usePanelHandlers({ terminalId: "p1", lifecycle }));
+
+    act(() => {
+      result.current.handleTitleChange("New title");
+    });
+
+    expect(updateTitleMock).toHaveBeenCalledWith("p1", "New title");
+  });
+});

--- a/src/hooks/__tests__/usePanelHandlers.test.ts
+++ b/src/hooks/__tests__/usePanelHandlers.test.ts
@@ -1,6 +1,6 @@
 // @vitest-environment jsdom
 import { act, renderHook } from "@testing-library/react";
-import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+import { afterEach, beforeEach, describe, expect, it, vi, type Mock } from "vitest";
 
 vi.mock("@/utils/logger", () => ({
   logError: vi.fn(),
@@ -37,7 +37,9 @@ vi.mock("@/store", () => {
 import { usePanelHandlers } from "../usePanelHandlers";
 import type { PanelLifecycle } from "../usePanelLifecycle";
 
-function makeLifecycle(): PanelLifecycle & { setIsTrashing: ReturnType<typeof vi.fn> } {
+type LifecycleHarness = Omit<PanelLifecycle, "setIsTrashing"> & { setIsTrashing: Mock };
+
+function makeLifecycle(): LifecycleHarness {
   return {
     mountedRef: { current: true },
     timeoutRef: { current: undefined },

--- a/src/hooks/usePanelHandlers.ts
+++ b/src/hooks/usePanelHandlers.ts
@@ -26,9 +26,13 @@ export function usePanelHandlers({
   const removePanel = usePanelStore((state) => state.removePanel);
   const updateTitle = usePanelStore((state) => state.updateTitle);
 
-  // Synchronous guard for repeat closes on the same panel. useState would be
-  // batched and read stale on rapid Cmd+W; a ref mutates on the same tick.
+  // Synchronous guards. useState would be batched and read stale on rapid
+  // Cmd+W; refs mutate on the same tick.
+  // - inFlightRef: a trash timer is currently scheduled.
+  // - trashedRef: trash has fired; further close calls are no-ops so a third
+  //   click in the 50ms window can't double-trash or fire onAfterClose twice.
   const inFlightRef = useRef(false);
+  const trashedRef = useRef(false);
 
   const handleFocus = useCallback(() => {
     setFocused(terminalId);
@@ -36,13 +40,26 @@ export function usePanelHandlers({
 
   const handleClose = useCallback(
     (force?: boolean) => {
+      if (trashedRef.current) return;
+
+      const cancelPendingTimer = () => {
+        if (lifecycle.timeoutRef.current) {
+          clearTimeout(lifecycle.timeoutRef.current);
+          lifecycle.timeoutRef.current = undefined;
+        }
+      };
+
       if (force) {
+        cancelPendingTimer();
+        trashedRef.current = true;
+        inFlightRef.current = false;
         removePanel(terminalId);
         onAfterClose?.();
         return;
       }
 
       const trashNow = () => {
+        trashedRef.current = true;
         try {
           trashPanelGroup(terminalId);
         } catch (error) {
@@ -56,10 +73,7 @@ export function usePanelHandlers({
       // playing — cancel the queued timer and flush now so rapid Cmd+W
       // doesn't serialize behind a tower of pending setTimeouts.
       if (inFlightRef.current) {
-        if (lifecycle.timeoutRef.current) {
-          clearTimeout(lifecycle.timeoutRef.current);
-          lifecycle.timeoutRef.current = undefined;
-        }
+        cancelPendingTimer();
         inFlightRef.current = false;
         if (lifecycle.mountedRef.current) {
           lifecycle.setIsTrashing(false);
@@ -70,7 +84,7 @@ export function usePanelHandlers({
 
       const duration = getTerminalAnimationDuration();
       if (duration === 0) {
-        // Performance mode — skip the animation and the setIsTrashing churn.
+        // Performance / reduced-motion — no animation, no setIsTrashing churn.
         trashNow();
         return;
       }

--- a/src/hooks/usePanelHandlers.ts
+++ b/src/hooks/usePanelHandlers.ts
@@ -1,4 +1,4 @@
-import { useCallback } from "react";
+import { useCallback, useRef } from "react";
 import { usePanelStore } from "@/store";
 import { logError } from "@/utils/logger";
 import { getTerminalAnimationDuration } from "@/lib/animationUtils";
@@ -26,6 +26,10 @@ export function usePanelHandlers({
   const removePanel = usePanelStore((state) => state.removePanel);
   const updateTitle = usePanelStore((state) => state.updateTitle);
 
+  // Synchronous guard for repeat closes on the same panel. useState would be
+  // batched and read stale on rapid Cmd+W; a ref mutates on the same tick.
+  const inFlightRef = useRef(false);
+
   const handleFocus = useCallback(() => {
     setFocused(terminalId);
   }, [setFocused, terminalId]);
@@ -35,22 +39,52 @@ export function usePanelHandlers({
       if (force) {
         removePanel(terminalId);
         onAfterClose?.();
-      } else {
-        const duration = getTerminalAnimationDuration();
-        lifecycle.setIsTrashing(true);
-        lifecycle.timeoutRef.current = setTimeout(() => {
-          try {
-            trashPanelGroup(terminalId);
-          } catch (error) {
-            logError("Failed to trash terminal", error);
-          } finally {
-            if (lifecycle.mountedRef.current) {
-              lifecycle.setIsTrashing(false);
-            }
-            onAfterClose?.();
-          }
-        }, duration);
+        return;
       }
+
+      const trashNow = () => {
+        try {
+          trashPanelGroup(terminalId);
+        } catch (error) {
+          logError("Failed to trash terminal", error);
+        } finally {
+          onAfterClose?.();
+        }
+      };
+
+      // Repeat close on the same panel while its trash animation is still
+      // playing — cancel the queued timer and flush now so rapid Cmd+W
+      // doesn't serialize behind a tower of pending setTimeouts.
+      if (inFlightRef.current) {
+        if (lifecycle.timeoutRef.current) {
+          clearTimeout(lifecycle.timeoutRef.current);
+          lifecycle.timeoutRef.current = undefined;
+        }
+        inFlightRef.current = false;
+        if (lifecycle.mountedRef.current) {
+          lifecycle.setIsTrashing(false);
+        }
+        trashNow();
+        return;
+      }
+
+      const duration = getTerminalAnimationDuration();
+      if (duration === 0) {
+        // Performance mode — skip the animation and the setIsTrashing churn.
+        trashNow();
+        return;
+      }
+
+      inFlightRef.current = true;
+      lifecycle.setIsTrashing(true);
+      lifecycle.timeoutRef.current = setTimeout(() => {
+        lifecycle.timeoutRef.current = undefined;
+        inFlightRef.current = false;
+        if (lifecycle.mountedRef.current) {
+          lifecycle.setIsTrashing(false);
+        }
+        trashNow();
+      }, duration);
     },
     [removePanel, trashPanelGroup, terminalId, onAfterClose, lifecycle]
   );

--- a/src/index.css
+++ b/src/index.css
@@ -632,7 +632,7 @@ code.hljs {
 
   --animation-duration: 150ms;
   --transition-duration: 150ms;
-  --terminal-animation-duration: 150ms;
+  --terminal-animation-duration: 50ms;
   --focus-transition-duration: 150ms;
   --focus-transition-easing: cubic-bezier(0.4, 0, 0.2, 1);
   --background: var(--theme-surface-canvas);

--- a/src/lib/__tests__/animationUtils.test.ts
+++ b/src/lib/__tests__/animationUtils.test.ts
@@ -11,10 +11,12 @@ import {
   EASE_SNAPPY,
   EASE_SPRING_CRITICAL,
   getPanelTransitionDuration,
+  getTerminalAnimationDuration,
   getUiAnimationDuration,
   getUiTransitionDuration,
   PANEL_MINIMIZE_DURATION,
   PANEL_RESTORE_DURATION,
+  TERMINAL_ANIMATION_DURATION,
   UI_ANIMATION_DURATION,
   UI_ENTER_DURATION,
   UI_EXIT_DURATION,
@@ -96,6 +98,26 @@ describe("getUiTransitionDuration", () => {
     document.body.dataset.performanceMode = "true";
     expect(getUiTransitionDuration("enter")).toBe(0);
     expect(getUiTransitionDuration("exit")).toBe(0);
+  });
+});
+
+describe("getTerminalAnimationDuration", () => {
+  beforeEach(() => {
+    document.body.dataset.performanceMode = "false";
+  });
+
+  afterEach(() => {
+    delete document.body.dataset.performanceMode;
+  });
+
+  it("returns the terminal animation token (50ms — near-instant for high-volume close churn)", () => {
+    expect(getTerminalAnimationDuration()).toBe(TERMINAL_ANIMATION_DURATION);
+    expect(getTerminalAnimationDuration()).toBe(50);
+  });
+
+  it("returns 0 when performance mode is active (skip-timer signal)", () => {
+    document.body.dataset.performanceMode = "true";
+    expect(getTerminalAnimationDuration()).toBe(0);
   });
 });
 

--- a/src/lib/__tests__/animationUtils.test.ts
+++ b/src/lib/__tests__/animationUtils.test.ts
@@ -119,6 +119,15 @@ describe("getTerminalAnimationDuration", () => {
     document.body.dataset.performanceMode = "true";
     expect(getTerminalAnimationDuration()).toBe(0);
   });
+
+  it("returns 0 when data-reduce-animations is set (CSS+JS parity)", () => {
+    document.body.dataset.reduceAnimations = "true";
+    try {
+      expect(getTerminalAnimationDuration()).toBe(0);
+    } finally {
+      delete document.body.dataset.reduceAnimations;
+    }
+  });
 });
 
 describe("getUiAnimationDuration", () => {

--- a/src/lib/animationUtils.ts
+++ b/src/lib/animationUtils.ts
@@ -24,8 +24,13 @@ export function getTerminalAnimationDuration(): number {
     return TERMINAL_ANIMATION_DURATION;
   }
 
-  const performanceMode = document.body.dataset.performanceMode === "true";
-  return performanceMode ? 0 : TERMINAL_ANIMATION_DURATION;
+  // Match what the CSS does: both `body[data-reduce-animations="true"]` and
+  // `body[data-performance-mode="true"]` suppress the trash keyframe in
+  // src/index.css, so JS must skip the 50ms wait too — otherwise the panel
+  // sits on screen for 50ms with no animation playing.
+  const ds = document.body.dataset;
+  if (ds.performanceMode === "true" || ds.reduceAnimations === "true") return 0;
+  return TERMINAL_ANIMATION_DURATION;
 }
 
 export function getUiAnimationDuration(): number {

--- a/src/lib/animationUtils.ts
+++ b/src/lib/animationUtils.ts
@@ -16,11 +16,16 @@ export const EASE_SPRING_CRITICAL =
   "linear(0, 0.007, 0.029 2.2%, 0.118 4.7%, 0.625 14.4%, 0.826 19%, 0.902 24%, 0.962 29.8%, 0.984 33.3%, 1.004 37.8%, 1.01 42.4%, 1.011 52.2%, 1.001)";
 export const EASE_OUT_EXPO = "cubic-bezier(0.16, 1, 0.3, 1)";
 
-export const TERMINAL_ANIMATION_DURATION = DURATION_150;
+export const TERMINAL_ANIMATION_DURATION = 50;
 export const UI_ANIMATION_DURATION = DURATION_150;
 
 export function getTerminalAnimationDuration(): number {
-  return TERMINAL_ANIMATION_DURATION;
+  if (typeof window === "undefined" || typeof document === "undefined") {
+    return TERMINAL_ANIMATION_DURATION;
+  }
+
+  const performanceMode = document.body.dataset.performanceMode === "true";
+  return performanceMode ? 0 : TERMINAL_ANIMATION_DURATION;
 }
 
 export function getUiAnimationDuration(): number {


### PR DESCRIPTION
## Summary

- At high terminal counts, clicking the X button to close an agent terminal lagged ~1 second. The root cause was `usePanelHandlers.handleClose` waiting the full `TERMINAL_ANIMATION_DURATION` (150ms) before calling `trashPanelGroup()`, and rapid repeat clicks piling up as separate queued timers rather than registering as discrete closes.
- Reduced `TERMINAL_ANIMATION_DURATION` from 150ms to 50ms in lockstep across the CSS variable and the JS constant. Added a per-panel `inFlightRef` so each new close cancels any pending timer and fires immediately, a permanent `trashedRef` latch to prevent triple-click double-fires, and a zero-duration fast path that skips `setIsTrashing` churn entirely.
- `getTerminalAnimationDuration()` now respects both `performanceMode` and `data-reduce-animations`, matching the CSS suppression rules already in `src/index.css`.

Resolves #7276

## Changes

- `src/lib/animationUtils.ts` — `TERMINAL_ANIMATION_DURATION` 150 → 50; `getTerminalAnimationDuration()` checks `data-reduce-animations` alongside `performanceMode`
- `src/index.css` — `--terminal-animation-duration` CSS variable updated to match
- `src/hooks/usePanelHandlers.ts` — `inFlightRef` cancels pending close timer on repeat click; `trashedRef` permanent latch blocks double-fire; force-close cancels any queued normal-close; zero-duration path skips animation state entirely
- `src/hooks/__tests__/usePanelHandlers.test.ts` — 8 new cases: force, queued, repeat-flush, performance-mode, reduce-animations, triple-close, force-after-normal, unmount
- `src/lib/__tests__/animationUtils.test.ts` — extended with `getTerminalAnimationDuration` default, performance-mode, and reduce-animations cases

## Notes

The issue mentions Cmd+W, but `terminal.close` dispatches directly to `state.trashPanel` in `terminalLifecycleActions.ts` — that path is already synchronous with no animation timer. This PR addresses the X-button close path the issue body explicitly called out at `usePanelHandlers.ts:33-56`.

## Testing

- New unit tests cover all edge cases; run with `npx vitest run src/hooks/__tests__/usePanelHandlers.test.ts src/lib/__tests__/animationUtils.test.ts`
- Manually verified: at 15+ open agent terminals, X-button closes now feel instant and rapid clicks each register discretely