### PR TITLE
test(svgSanitizer): lock in behavior with bypass test vectors

### DIFF
--- a/shared/utils/__tests__/svgSanitizer.test.ts
+++ b/shared/utils/__tests__/svgSanitizer.test.ts
@@ -576,6 +576,25 @@ describe("sanitizeSvg", () => {
       }
     });
 
+    it("should strip namespace-prefixed SMIL elements bound to the SVG namespace", () => {
+      // A prefix like `s` bound via xmlns:s="http://www.w3.org/2000/svg" makes
+      // <s:animate> resolve to the same element as <animate> in a namespace-aware
+      // SVG parser. The sanitizer must catch the prefixed form too.
+      const svg = `<svg xmlns="http://www.w3.org/2000/svg" xmlns:s="http://www.w3.org/2000/svg">
+        <rect width="100" height="100">
+          <s:animate attributeName="onbegin" values="alert(1)"/>
+        </rect>
+      </svg>`;
+      const result = sanitizeSvg(svg);
+      expect(result.ok).toBe(true);
+      if (result.ok) {
+        expect(result.svg).not.toContain("s:animate");
+        expect(result.svg).not.toContain("alert");
+        expect(result.svg).toContain("rect");
+        expect(result.modified).toBe(true);
+      }
+    });
+
     it("should strip self-closing and paired SMIL element forms together", () => {
       const svg = `<svg xmlns="http://www.w3.org/2000/svg">
         <rect width="100" height="100">
@@ -624,6 +643,22 @@ describe("sanitizeSvg", () => {
         expect(result.svg).not.toContain("javascript:");
         expect(result.svg).not.toContain("alert");
         expect(result.svg).toContain('alias:href=""');
+        expect(result.modified).toBe(true);
+      }
+    });
+
+    it("should neutralize hyphenated prefix bound to xlink (foo-bar:href)", () => {
+      // XML NCName prefixes can include hyphens and dots. A prefix like `foo-bar`
+      // bound to the xlink namespace makes `foo-bar:href` exploitable; the pattern
+      // must accept full NCName characters in the prefix.
+      const svg = `<svg xmlns="http://www.w3.org/2000/svg" xmlns:foo-bar="http://www.w3.org/1999/xlink">
+        <use foo-bar:href="https://evil.com/sprites.svg#icon"/>
+      </svg>`;
+      const result = sanitizeSvg(svg);
+      expect(result.ok).toBe(true);
+      if (result.ok) {
+        expect(result.svg).not.toContain("https://evil.com");
+        expect(result.svg).toContain('foo-bar:href=""');
         expect(result.modified).toBe(true);
       }
     });
@@ -837,5 +872,21 @@ describe("isSvgSafe", () => {
       <use alias:href="#icon"/>
     </svg>`;
     expect(isSvgSafe(svg)).toBe(true);
+  });
+
+  it("should return false for namespace-prefixed SMIL element", () => {
+    const svg = `<svg xmlns="http://www.w3.org/2000/svg" xmlns:s="http://www.w3.org/2000/svg">
+      <rect width="100" height="100">
+        <s:animate attributeName="onbegin" values="alert(1)"/>
+      </rect>
+    </svg>`;
+    expect(isSvgSafe(svg)).toBe(false);
+  });
+
+  it("should return false for hyphenated prefix bound to xlink", () => {
+    const svg = `<svg xmlns="http://www.w3.org/2000/svg" xmlns:foo-bar="http://www.w3.org/1999/xlink">
+      <use foo-bar:href="https://evil.com/sprites.svg#icon"/>
+    </svg>`;
+    expect(isSvgSafe(svg)).toBe(false);
   });
 });

--- a/shared/utils/__tests__/svgSanitizer.test.ts
+++ b/shared/utils/__tests__/svgSanitizer.test.ts
@@ -512,6 +512,204 @@ describe("sanitizeSvg", () => {
       }
     });
   });
+
+  describe("SMIL animation element removal", () => {
+    // Defense-in-depth: Chromium 146 already blocks animation of on* attributes,
+    // but SMIL elements give attackers tag-based vectors (animating href, attributeName
+    // injection, future browser bugs). The sanitizer must strip them outright.
+    it("should strip <animate> elements", () => {
+      const svg = `<svg xmlns="http://www.w3.org/2000/svg">
+        <rect width="100" height="100">
+          <animate attributeName="onbegin" values="alert(1)"/>
+        </rect>
+      </svg>`;
+      const result = sanitizeSvg(svg);
+      expect(result.ok).toBe(true);
+      if (result.ok) {
+        expect(result.svg).not.toContain("<animate");
+        expect(result.svg).not.toContain("alert");
+        expect(result.svg).toContain("rect");
+        expect(result.modified).toBe(true);
+      }
+    });
+
+    it("should strip <set> elements", () => {
+      const svg = `<svg xmlns="http://www.w3.org/2000/svg">
+        <rect width="100" height="100">
+          <set attributeName="onmouseover" to="alert(1)"/>
+        </rect>
+      </svg>`;
+      const result = sanitizeSvg(svg);
+      expect(result.ok).toBe(true);
+      if (result.ok) {
+        expect(result.svg).not.toContain("<set");
+        expect(result.svg).not.toContain("alert");
+        expect(result.modified).toBe(true);
+      }
+    });
+
+    it("should strip <animateTransform> elements", () => {
+      const svg = `<svg xmlns="http://www.w3.org/2000/svg">
+        <rect width="100" height="100">
+          <animateTransform attributeName="transform" type="rotate" values="0;360"/>
+        </rect>
+      </svg>`;
+      const result = sanitizeSvg(svg);
+      expect(result.ok).toBe(true);
+      if (result.ok) {
+        expect(result.svg).not.toContain("<animateTransform");
+        expect(result.modified).toBe(true);
+      }
+    });
+
+    it("should strip <animateMotion> elements", () => {
+      const svg = `<svg xmlns="http://www.w3.org/2000/svg">
+        <circle cx="50" cy="50" r="20">
+          <animateMotion path="M0,0 L100,100"/>
+        </circle>
+      </svg>`;
+      const result = sanitizeSvg(svg);
+      expect(result.ok).toBe(true);
+      if (result.ok) {
+        expect(result.svg).not.toContain("<animateMotion");
+        expect(result.modified).toBe(true);
+      }
+    });
+
+    it("should strip self-closing and paired SMIL element forms together", () => {
+      const svg = `<svg xmlns="http://www.w3.org/2000/svg">
+        <rect width="100" height="100">
+          <animate attributeName="x" from="0" to="100" dur="1s"></animate>
+          <set attributeName="fill" to="red"/>
+        </rect>
+      </svg>`;
+      const result = sanitizeSvg(svg);
+      expect(result.ok).toBe(true);
+      if (result.ok) {
+        expect(result.svg).not.toContain("<animate");
+        expect(result.svg).not.toContain("<set");
+        expect(result.svg).toContain("rect");
+        expect(result.modified).toBe(true);
+      }
+    });
+  });
+
+  describe("namespace-prefixed href sanitization", () => {
+    // Chromium's SVG parser is namespace-URI-aware: any prefix bound to the xlink
+    // namespace (e.g. xmlns:alias="http://www.w3.org/1999/xlink") makes
+    // alias:href behave identically to xlink:href. The sanitizer must catch
+    // arbitrary `*:href` prefixes, not just the literal "xlink:" form.
+    it("should neutralize external alias-prefixed href references", () => {
+      const svg = `<svg xmlns="http://www.w3.org/2000/svg" xmlns:alias="http://www.w3.org/1999/xlink">
+        <use alias:href="https://evil.com/sprites.svg#icon"/>
+      </svg>`;
+      const result = sanitizeSvg(svg);
+      expect(result.ok).toBe(true);
+      if (result.ok) {
+        expect(result.svg).not.toContain("https://evil.com");
+        expect(result.svg).toContain('alias:href=""');
+        expect(result.modified).toBe(true);
+      }
+    });
+
+    it("should neutralize javascript: URLs in alias-prefixed href", () => {
+      const svg = `<svg xmlns="http://www.w3.org/2000/svg" xmlns:alias="http://www.w3.org/1999/xlink">
+        <a alias:href="javascript:alert('xss')">
+          <circle cx="50" cy="50" r="40"/>
+        </a>
+      </svg>`;
+      const result = sanitizeSvg(svg);
+      expect(result.ok).toBe(true);
+      if (result.ok) {
+        expect(result.svg).not.toContain("javascript:");
+        expect(result.svg).not.toContain("alert");
+        expect(result.svg).toContain('alias:href=""');
+        expect(result.modified).toBe(true);
+      }
+    });
+
+    it("should preserve safe local references for any prefix", () => {
+      const svg = `<svg xmlns="http://www.w3.org/2000/svg" xmlns:alias="http://www.w3.org/1999/xlink">
+        <defs>
+          <symbol id="icon"><circle cx="50" cy="50" r="40"/></symbol>
+        </defs>
+        <use href="#icon"/>
+        <use xlink:href="#icon"/>
+        <use alias:href="#icon"/>
+      </svg>`;
+      const result = sanitizeSvg(svg);
+      expect(result.ok).toBe(true);
+      if (result.ok) {
+        expect(result.svg).toContain('href="#icon"');
+        expect(result.svg).toContain('xlink:href="#icon"');
+        expect(result.svg).toContain('alias:href="#icon"');
+        expect(result.modified).toBe(false);
+      }
+    });
+  });
+
+  describe("control-character encoded javascript URLs in prefixed href", () => {
+    // When a namespace-prefixed href carries a javascript: URL with a control
+    // character splitting "javascript", the literal-keyword scan misses it.
+    // The widened HREF_ATTRIBUTE_PATTERN routes the value through entity
+    // decoding + isLocalReference, which treats anything not starting with
+    // "#" as unsafe and zeroes the attribute.
+    it("should neutralize tab-encoded javascript: in alias:href (executable in Chromium 146)", () => {
+      const svg = `<svg xmlns="http://www.w3.org/2000/svg" xmlns:alias="http://www.w3.org/1999/xlink">
+        <a alias:href="j&#9;avascript:alert(1)"><circle cx="50" cy="50" r="40"/></a>
+      </svg>`;
+      const result = sanitizeSvg(svg);
+      expect(result.ok).toBe(true);
+      if (result.ok) {
+        expect(result.svg).not.toContain("alert(1)");
+        expect(result.svg).toContain('alias:href=""');
+        expect(result.modified).toBe(true);
+      }
+    });
+
+    it("should neutralize newline-encoded javascript: in alias:href (executable in Chromium 146)", () => {
+      const svg = `<svg xmlns="http://www.w3.org/2000/svg" xmlns:alias="http://www.w3.org/1999/xlink">
+        <a alias:href="j&#10;avascript:alert(1)"><circle cx="50" cy="50" r="40"/></a>
+      </svg>`;
+      const result = sanitizeSvg(svg);
+      expect(result.ok).toBe(true);
+      if (result.ok) {
+        expect(result.svg).not.toContain("alert(1)");
+        expect(result.svg).toContain('alias:href=""');
+        expect(result.modified).toBe(true);
+      }
+    });
+
+    it("should neutralize CR-encoded javascript: in alias:href (executable in Chromium 146)", () => {
+      const svg = `<svg xmlns="http://www.w3.org/2000/svg" xmlns:alias="http://www.w3.org/1999/xlink">
+        <a alias:href="j&#13;avascript:alert(1)"><circle cx="50" cy="50" r="40"/></a>
+      </svg>`;
+      const result = sanitizeSvg(svg);
+      expect(result.ok).toBe(true);
+      if (result.ok) {
+        expect(result.svg).not.toContain("alert(1)");
+        expect(result.svg).toContain('alias:href=""');
+        expect(result.modified).toBe(true);
+      }
+    });
+
+    it("should neutralize null-byte-encoded javascript: in alias:href (defense in depth; not executable in Chromium 146)", () => {
+      // U+0000 invalidates URL scheme parsing in Chromium 146 per WHATWG URL
+      // spec, so this is not an active execution bypass in this engine. The
+      // sanitizer still strips it conservatively as a guard against other
+      // parsers and future engine changes.
+      const svg = `<svg xmlns="http://www.w3.org/2000/svg" xmlns:alias="http://www.w3.org/1999/xlink">
+        <a alias:href="j&#0;avascript:alert(1)"><circle cx="50" cy="50" r="40"/></a>
+      </svg>`;
+      const result = sanitizeSvg(svg);
+      expect(result.ok).toBe(true);
+      if (result.ok) {
+        expect(result.svg).not.toContain("alert(1)");
+        expect(result.svg).toContain('alias:href=""');
+        expect(result.modified).toBe(true);
+      }
+    });
+  });
 });
 
 describe("validateSvg", () => {
@@ -581,5 +779,63 @@ describe("isSvgSafe", () => {
 
   it("should return false for non-SVG content", () => {
     expect(isSvgSafe("<html></html>")).toBe(false);
+  });
+
+  it("should return false for SVG with <animate>", () => {
+    const svg = `<svg xmlns="http://www.w3.org/2000/svg">
+      <rect width="100" height="100">
+        <animate attributeName="onbegin" values="alert(1)"/>
+      </rect>
+    </svg>`;
+    expect(isSvgSafe(svg)).toBe(false);
+  });
+
+  it("should return false for SVG with <set>", () => {
+    const svg = `<svg xmlns="http://www.w3.org/2000/svg">
+      <rect width="100" height="100">
+        <set attributeName="onmouseover" to="alert(1)"/>
+      </rect>
+    </svg>`;
+    expect(isSvgSafe(svg)).toBe(false);
+  });
+
+  it("should return false for SVG with <animateTransform>", () => {
+    const svg = `<svg xmlns="http://www.w3.org/2000/svg">
+      <rect width="100" height="100">
+        <animateTransform attributeName="transform" type="rotate" values="0;360"/>
+      </rect>
+    </svg>`;
+    expect(isSvgSafe(svg)).toBe(false);
+  });
+
+  it("should return false for SVG with <animateMotion>", () => {
+    const svg = `<svg xmlns="http://www.w3.org/2000/svg">
+      <circle cx="50" cy="50" r="20">
+        <animateMotion path="M0,0 L100,100"/>
+      </circle>
+    </svg>`;
+    expect(isSvgSafe(svg)).toBe(false);
+  });
+
+  it("should return false for external alias-prefixed href", () => {
+    const svg = `<svg xmlns="http://www.w3.org/2000/svg" xmlns:alias="http://www.w3.org/1999/xlink">
+      <use alias:href="https://evil.com/sprites.svg#icon"/>
+    </svg>`;
+    expect(isSvgSafe(svg)).toBe(false);
+  });
+
+  it("should return false for control-character javascript: in alias:href", () => {
+    const svg = `<svg xmlns="http://www.w3.org/2000/svg" xmlns:alias="http://www.w3.org/1999/xlink">
+      <a alias:href="j&#10;avascript:alert(1)"><circle cx="50" cy="50" r="40"/></a>
+    </svg>`;
+    expect(isSvgSafe(svg)).toBe(false);
+  });
+
+  it("should return true for safe local alias-prefixed href", () => {
+    const svg = `<svg xmlns="http://www.w3.org/2000/svg" xmlns:alias="http://www.w3.org/1999/xlink">
+      <defs><symbol id="icon"><circle cx="50" cy="50" r="40"/></symbol></defs>
+      <use alias:href="#icon"/>
+    </svg>`;
+    expect(isSvgSafe(svg)).toBe(true);
   });
 });

--- a/shared/utils/svgSanitizer.ts
+++ b/shared/utils/svgSanitizer.ts
@@ -41,7 +41,7 @@ const JAVASCRIPT_URL_PATTERN = /\bjavascript\s*:/gi;
 const DATA_URL_PATTERN = /\bdata\s*:/gi;
 
 /** Pattern to match href/xlink:href and any namespace-prefixed href attribute with quoted or unquoted values */
-const HREF_ATTRIBUTE_PATTERN = /(^|\s)(\w+:)?href\s*=\s*(?:"([^"]*)"|'([^']*)'|([^\s>]+))/gi;
+const HREF_ATTRIBUTE_PATTERN = /(^|\s)([\w.-]+:)?href\s*=\s*(?:"([^"]*)"|'([^']*)'|([^\s>]+))/gi;
 
 /** Pattern to match url() functions in CSS */
 const URL_FUNC_PATTERN = /\burl\s*\(\s*([^)]+)\)/gi;
@@ -147,7 +147,7 @@ const stripUnsafeUrlFunctions = (svg: string): string => {
  */
 const hasUnsafeHrefAttributes = (svg: string): boolean => {
   let unsafe = false;
-  svg.replace(HREF_ATTRIBUTE_PATTERN, (_match, _prefix, _xlink, dquoted, squoted, unquoted) => {
+  svg.replace(HREF_ATTRIBUTE_PATTERN, (_match, _prefix, _nsPrefix, dquoted, squoted, unquoted) => {
     const rawValue = dquoted ?? squoted ?? unquoted ?? "";
     if (!isLocalReference(rawValue)) {
       unsafe = true;
@@ -216,14 +216,20 @@ export function sanitizeSvg(svgText: string): SvgSanitizeOutcome {
 
   const originalSvg = svg;
 
-  // Remove dangerous elements completely (including their content)
+  // Remove dangerous elements completely (including their content). The optional
+  // ([\w.-]+:)? prefix segment also catches namespace-prefixed forms like
+  // <s:animate> (where s binds to the SVG namespace), which a parser treats as
+  // identical to the bare element.
   for (const element of DANGEROUS_ELEMENTS) {
     // Match opening tag through closing tag (handles nested content)
-    const openClosePattern = new RegExp(`<${element}\\b[^>]*>[\\s\\S]*?<\\/${element}>`, "gi");
+    const openClosePattern = new RegExp(
+      `<(?:[\\w.-]+:)?${element}\\b[^>]*>[\\s\\S]*?<\\/(?:[\\w.-]+:)?${element}>`,
+      "gi",
+    );
     svg = svg.replace(openClosePattern, "");
 
     // Also handle self-closing variants
-    const selfClosingPattern = new RegExp(`<${element}\\b[^>]*\\/?>`, "gi");
+    const selfClosingPattern = new RegExp(`<(?:[\\w.-]+:)?${element}\\b[^>]*\\/?>`, "gi");
     svg = svg.replace(selfClosingPattern, "");
   }
 
@@ -301,9 +307,9 @@ export function isSvgSafe(svgText: string): boolean {
     return false;
   }
 
-  // Check for dangerous elements
+  // Check for dangerous elements (including namespace-prefixed forms)
   for (const element of DANGEROUS_ELEMENTS) {
-    const pattern = new RegExp(`<${element}\\b`, "i");
+    const pattern = new RegExp(`<(?:[\\w.-]+:)?${element}\\b`, "i");
     if (testPattern(pattern, svg)) {
       return false;
     }

--- a/shared/utils/svgSanitizer.ts
+++ b/shared/utils/svgSanitizer.ts
@@ -14,7 +14,19 @@
 const MAX_SVG_SIZE_BYTES = 250 * 1024; // 250KB
 
 /** Elements that must be completely removed (case-insensitive) */
-const DANGEROUS_ELEMENTS = ["script", "foreignObject", "iframe", "embed", "object", "meta", "link"];
+const DANGEROUS_ELEMENTS = [
+  "script",
+  "foreignObject",
+  "iframe",
+  "embed",
+  "object",
+  "meta",
+  "link",
+  "animate",
+  "set",
+  "animateTransform",
+  "animateMotion",
+];
 
 /** Event handler attributes to remove (matched with on* pattern) */
 const EVENT_HANDLER_PATTERN = /\s+on\w+\s*=\s*["'][^"']*["']/gi;
@@ -28,8 +40,8 @@ const JAVASCRIPT_URL_PATTERN = /\bjavascript\s*:/gi;
 /** data: URLs (can embed scripts via data:text/html) */
 const DATA_URL_PATTERN = /\bdata\s*:/gi;
 
-/** Pattern to match href/xlink:href attributes with quoted or unquoted values */
-const HREF_ATTRIBUTE_PATTERN = /(^|\s)(xlink:)?href\s*=\s*(?:"([^"]*)"|'([^']*)'|([^\s>]+))/gi;
+/** Pattern to match href/xlink:href and any namespace-prefixed href attribute with quoted or unquoted values */
+const HREF_ATTRIBUTE_PATTERN = /(^|\s)(\w+:)?href\s*=\s*(?:"([^"]*)"|'([^']*)'|([^\s>]+))/gi;
 
 /** Pattern to match url() functions in CSS */
 const URL_FUNC_PATTERN = /\burl\s*\(\s*([^)]+)\)/gi;
@@ -109,13 +121,12 @@ const isLocalReference = (value: string): boolean => {
  * Strip unsafe href/xlink:href attributes, allowing only local references
  */
 const stripUnsafeHrefAttributes = (svg: string): string => {
-  return svg.replace(HREF_ATTRIBUTE_PATTERN, (match, prefix, xlink, dquoted, squoted, unquoted) => {
+  return svg.replace(HREF_ATTRIBUTE_PATTERN, (match, prefix, nsPrefix, dquoted, squoted, unquoted) => {
     const rawValue = dquoted ?? squoted ?? unquoted ?? "";
     if (isLocalReference(rawValue)) {
       return match;
     }
-    const attrName = xlink ? "xlink:href" : "href";
-    return `${prefix}${attrName}=""`;
+    return `${prefix}${nsPrefix ?? ""}href=""`;
   });
 };
 
@@ -164,6 +175,12 @@ const hasUnsafeUrlFunctions = (svg: string): boolean => {
  * Sanitize SVG content by removing dangerous elements and attributes.
  * Returns the cleaned SVG or an error if the input is invalid.
  *
+ * @warning The returned SVG is safe to embed only via DOM APIs that do not
+ *   re-parse it as HTML. Assigning the output through `innerHTML` (or any
+ *   path that re-tokenizes HTML) can resurrect mutation-XSS vectors that
+ *   the regex sanitizer cannot model. Prefer `svgToDataUrl()` and an
+ *   `<img src=...>` tag, or insert the parsed SVG via `DOMParser`.
+ *
  * @param svgText - Raw SVG content to sanitize
  * @returns Sanitized SVG or error
  */
@@ -178,7 +195,7 @@ export function sanitizeSvg(svgText: string): SvgSanitizeOutcome {
   }
 
   // Check size limit
-  const sizeBytes = new Blob([svg]).size;
+  const sizeBytes = new TextEncoder().encode(svg).byteLength;
   if (sizeBytes > MAX_SVG_SIZE_BYTES) {
     const sizeMB = (sizeBytes / 1024 / 1024).toFixed(2);
     return {
@@ -279,7 +296,7 @@ export function isSvgSafe(svgText: string): boolean {
   }
 
   // Check size
-  const sizeBytes = new Blob([svg]).size;
+  const sizeBytes = new TextEncoder().encode(svg).byteLength;
   if (sizeBytes > MAX_SVG_SIZE_BYTES) {
     return false;
   }

--- a/shared/utils/svgSanitizer.ts
+++ b/shared/utils/svgSanitizer.ts
@@ -121,13 +121,16 @@ const isLocalReference = (value: string): boolean => {
  * Strip unsafe href/xlink:href attributes, allowing only local references
  */
 const stripUnsafeHrefAttributes = (svg: string): string => {
-  return svg.replace(HREF_ATTRIBUTE_PATTERN, (match, prefix, nsPrefix, dquoted, squoted, unquoted) => {
-    const rawValue = dquoted ?? squoted ?? unquoted ?? "";
-    if (isLocalReference(rawValue)) {
-      return match;
+  return svg.replace(
+    HREF_ATTRIBUTE_PATTERN,
+    (match, prefix, nsPrefix, dquoted, squoted, unquoted) => {
+      const rawValue = dquoted ?? squoted ?? unquoted ?? "";
+      if (isLocalReference(rawValue)) {
+        return match;
+      }
+      return `${prefix}${nsPrefix ?? ""}href=""`;
     }
-    return `${prefix}${nsPrefix ?? ""}href=""`;
-  });
+  );
 };
 
 /**
@@ -224,7 +227,7 @@ export function sanitizeSvg(svgText: string): SvgSanitizeOutcome {
     // Match opening tag through closing tag (handles nested content)
     const openClosePattern = new RegExp(
       `<(?:[\\w.-]+:)?${element}\\b[^>]*>[\\s\\S]*?<\\/(?:[\\w.-]+:)?${element}>`,
-      "gi",
+      "gi"
     );
     svg = svg.replace(openClosePattern, "");
 


### PR DESCRIPTION
## Summary

Adds test coverage for bypass vectors in `shared/utils/svgSanitizer.ts` — the cases the existing suite wasn't exercising.

Resolves #7300

## Changes

**Sanitizer fixes (defense-in-depth):**

- `animate`, `set`, `animateTransform`, and `animateMotion` added to `DANGEROUS_ELEMENTS` — Chromium 146 already blocks SMIL animation of `on*` attributes, but stripping the elements outright closes the tag-based vector class
- `HREF_ATTRIBUTE_PATTERN` widened from `(xlink:)?` to `([\w.-]+:)?` to cover the full XML NCName prefix syntax; same widening applied to dangerous-element detection so namespace-prefixed forms like `<s:animate>` are caught
- Original namespace prefix preserved when zeroing unsafe `href` values (was dropping the prefix, making the attribute unrecognisable to consumers)
- `new Blob([svg]).size` → `new TextEncoder().encode(svg).byteLength` — no behavior change, removes the unnecessary Blob allocation
- `@warning` JSDoc added to `sanitizeSvg` flagging the innerHTML mutation XSS risk for callers

**Tests:**

- 23 new test cases: SMIL element removal, namespace-prefixed `href` sanitization (including hyphenated NCName prefixes like `foo-bar:href`), namespace-prefixed SMIL elements (`<s:animate>` bound to SVG namespace), and control-character encoded `javascript:` URLs
- Null-byte bypass case included as defense-in-depth (commented as not currently executable in Chromium 146)
- Total: 45 → 68 tests

## Testing

All 68 tests pass. Typecheck clean, lint and format passing (`lint:ratchet` dropped from 877 → 869 warnings).