### PR TITLE
fix(urlHistoryStore): sanitize, dedupe, and bound URL history

### DIFF
--- a/src/store/__tests__/persistenceBoundaryHardening.test.ts
+++ b/src/store/__tests__/persistenceBoundaryHardening.test.ts
@@ -95,7 +95,7 @@ describe("persistence boundary hardening", () => {
 
     expect(useUrlHistoryStore.getState().entries["proj-1"]).toEqual([
       expect.objectContaining({
-        url: "https://example.com",
+        url: "https://example.com/",
         title: "Example",
         visitCount: 1,
       }),

--- a/src/store/__tests__/urlHistoryStore.test.ts
+++ b/src/store/__tests__/urlHistoryStore.test.ts
@@ -1,6 +1,11 @@
 // @vitest-environment jsdom
 import { afterEach, describe, it, expect, beforeEach, vi } from "vitest";
-import { useUrlHistoryStore, frecencyScore, getFrecencySuggestions } from "../urlHistoryStore";
+import {
+  useUrlHistoryStore,
+  frecencyScore,
+  getFrecencySuggestions,
+  sanitizeUrlForHistory,
+} from "../urlHistoryStore";
 import type { UrlHistoryEntry } from "@shared/types/browser";
 
 describe("urlHistoryStore", () => {
@@ -87,15 +92,19 @@ describe("urlHistoryStore", () => {
     expect(entries![0]!.favicon).toBe("https://example.com/favicon.ico");
   });
 
-  it("updateFavicon creates entry for non-existent URL", () => {
+  it("updateFavicon is a no-op for non-existent URL (no ghost entry created)", () => {
     const store = useUrlHistoryStore.getState();
     store.recordVisit("proj1", "http://localhost:3000/", "Title");
     store.updateFavicon("proj1", "http://localhost:5000/", "https://other.com/favicon.ico");
     const entries = useUrlHistoryStore.getState().entries["proj1"]!;
-    expect(entries).toHaveLength(2);
-    expect(entries.find((e) => e.url === "http://localhost:5000/")!.favicon).toBe(
-      "https://other.com/favicon.ico"
-    );
+    expect(entries).toHaveLength(1);
+    expect(entries[0]!.url).toBe("http://localhost:3000/");
+  });
+
+  it("updateFavicon is a no-op for an unknown project", () => {
+    const store = useUrlHistoryStore.getState();
+    store.updateFavicon("missing", "http://localhost:3000/", "favicon.ico");
+    expect(useUrlHistoryStore.getState().entries["missing"]).toBeUndefined();
   });
 
   it("removeUrl removes a specific entry by URL", () => {
@@ -152,6 +161,185 @@ describe("urlHistoryStore", () => {
     }
     const entries = useUrlHistoryStore.getState().entries["proj1"];
     expect(entries!.length).toBeLessThanOrEqual(500);
+  });
+
+  it("caps visitCount at 200 to prevent old high-frequency URLs from dominating forever", () => {
+    const store = useUrlHistoryStore.getState();
+    for (let i = 0; i < 250; i++) {
+      store.recordVisit("proj1", "http://localhost:3000/", "Home");
+    }
+    const entries = useUrlHistoryStore.getState().entries["proj1"];
+    expect(entries![0]!.visitCount).toBe(200);
+  });
+
+  it("dedupes recordVisit when only tracking parameters differ", () => {
+    const store = useUrlHistoryStore.getState();
+    store.recordVisit("proj1", "https://example.com/page?utm_source=a", "Page");
+    store.recordVisit("proj1", "https://example.com/page?utm_source=b", "Page");
+    store.recordVisit("proj1", "https://example.com/page?fbclid=xyz", "Page");
+    const entries = useUrlHistoryStore.getState().entries["proj1"]!;
+    expect(entries).toHaveLength(1);
+    expect(entries[0]!.url).toBe("https://example.com/page");
+    expect(entries[0]!.visitCount).toBe(3);
+  });
+
+  it("preserves non-tracking parameters and sorts them canonically", () => {
+    const store = useUrlHistoryStore.getState();
+    store.recordVisit("proj1", "https://example.com/search?q=foo&sort=date&utm_source=ads", "");
+    const entries = useUrlHistoryStore.getState().entries["proj1"]!;
+    expect(entries[0]!.url).toBe("https://example.com/search?q=foo&sort=date");
+  });
+
+  it("skips OAuth callback URLs (code + state)", () => {
+    const store = useUrlHistoryStore.getState();
+    store.recordVisit(
+      "proj1",
+      "https://app.com/callback?code=abc123&state=xyz789",
+      "Authenticating"
+    );
+    expect(useUrlHistoryStore.getState().entries["proj1"]).toBeUndefined();
+  });
+
+  it("skips URLs with token fragments", () => {
+    const store = useUrlHistoryStore.getState();
+    store.recordVisit("proj1", "https://app.com/#access_token=secret&token_type=Bearer", "");
+    expect(useUrlHistoryStore.getState().entries["proj1"]).toBeUndefined();
+  });
+
+  it("skips URLs with HTTP basic auth credentials", () => {
+    const store = useUrlHistoryStore.getState();
+    store.recordVisit("proj1", "https://user:pass@example.com/api", "");
+    expect(useUrlHistoryStore.getState().entries["proj1"]).toBeUndefined();
+  });
+
+  it("skips AWS pre-signed URLs", () => {
+    const store = useUrlHistoryStore.getState();
+    store.recordVisit(
+      "proj1",
+      "https://bucket.s3.amazonaws.com/file.pdf?X-Amz-Signature=abc&X-Amz-Credential=xyz",
+      "File"
+    );
+    expect(useUrlHistoryStore.getState().entries["proj1"]).toBeUndefined();
+  });
+
+  it("skips GCS signed URLs", () => {
+    const store = useUrlHistoryStore.getState();
+    store.recordVisit(
+      "proj1",
+      "https://storage.googleapis.com/bucket/file?X-Goog-Signature=abc",
+      ""
+    );
+    expect(useUrlHistoryStore.getState().entries["proj1"]).toBeUndefined();
+  });
+
+  it("skips Azure SAS URLs", () => {
+    const store = useUrlHistoryStore.getState();
+    store.recordVisit(
+      "proj1",
+      "https://account.blob.core.windows.net/container/file?sig=abc&se=2026&sv=2024",
+      ""
+    );
+    expect(useUrlHistoryStore.getState().entries["proj1"]).toBeUndefined();
+  });
+
+  it("preserves hash-router fragments unchanged", () => {
+    const store = useUrlHistoryStore.getState();
+    store.recordVisit("proj1", "http://localhost:3000/#/users/42?tab=profile", "Profile");
+    const entries = useUrlHistoryStore.getState().entries["proj1"]!;
+    expect(entries[0]!.url).toBe("http://localhost:3000/#/users/42?tab=profile");
+  });
+
+  it("prunes entries older than 90 days on the next recordVisit", () => {
+    const stale = Date.now() - 100 * 24 * 3600 * 1000;
+    useUrlHistoryStore.setState({
+      entries: {
+        proj1: [
+          { url: "http://localhost:3000/old", title: "Old", visitCount: 5, lastVisitAt: stale },
+        ],
+      },
+    });
+    useUrlHistoryStore.getState().recordVisit("proj1", "http://localhost:3000/new", "New");
+    const entries = useUrlHistoryStore.getState().entries["proj1"]!;
+    expect(entries).toHaveLength(1);
+    expect(entries[0]!.url).toBe("http://localhost:3000/new");
+  });
+});
+
+describe("sanitizeUrlForHistory", () => {
+  it("returns null for OAuth callbacks with code and state params", () => {
+    expect(sanitizeUrlForHistory("https://app.com/cb?code=abc&state=xyz")).toBeNull();
+  });
+
+  it("returns null for token fragments", () => {
+    expect(sanitizeUrlForHistory("https://app.com/#access_token=foo")).toBeNull();
+    expect(sanitizeUrlForHistory("https://app.com/#id_token=foo")).toBeNull();
+    expect(sanitizeUrlForHistory("https://app.com/#token_type=Bearer")).toBeNull();
+  });
+
+  it("returns null for basic-auth URLs", () => {
+    expect(sanitizeUrlForHistory("https://user:pass@example.com/")).toBeNull();
+    expect(sanitizeUrlForHistory("https://user@example.com/")).toBeNull();
+  });
+
+  it("returns null for AWS pre-signed URLs", () => {
+    expect(
+      sanitizeUrlForHistory("https://b.s3.amazonaws.com/f?X-Amz-Signature=abc&X-Amz-Date=z")
+    ).toBeNull();
+    expect(
+      sanitizeUrlForHistory("https://b.s3.amazonaws.com/f?x-amz-signature=abc")
+    ).toBeNull();
+  });
+
+  it("returns null for GCS signed URLs", () => {
+    expect(sanitizeUrlForHistory("https://s.googleapis.com/b/f?X-Goog-Signature=abc")).toBeNull();
+  });
+
+  it("returns null for Azure SAS URLs", () => {
+    expect(
+      sanitizeUrlForHistory("https://a.blob.core.windows.net/c/f?sig=abc&se=2026&sv=2024")
+    ).toBeNull();
+    expect(
+      sanitizeUrlForHistory("https://a.blob.core.windows.net/c/f?sig=abc&sv=2024")
+    ).toBeNull();
+  });
+
+  it("strips tracking params and sorts remaining params alphabetically", () => {
+    expect(sanitizeUrlForHistory("https://example.com/?utm_source=a&q=hello")).toBe(
+      "https://example.com/?q=hello"
+    );
+    expect(sanitizeUrlForHistory("https://example.com/?z=1&a=2&fbclid=xyz")).toBe(
+      "https://example.com/?a=2&z=1"
+    );
+  });
+
+  it("strips tracking params case-insensitively", () => {
+    expect(sanitizeUrlForHistory("https://example.com/?UTM_SOURCE=a&q=hello")).toBe(
+      "https://example.com/?q=hello"
+    );
+  });
+
+  it("lowercases scheme and host but preserves path case", () => {
+    expect(sanitizeUrlForHistory("HTTPS://Example.COM/Some/Path")).toBe(
+      "https://example.com/Some/Path"
+    );
+  });
+
+  it("preserves hash-router fragments verbatim", () => {
+    expect(sanitizeUrlForHistory("http://localhost:3000/#/users/42")).toBe(
+      "http://localhost:3000/#/users/42"
+    );
+    expect(sanitizeUrlForHistory("http://localhost:3000/#!/route")).toBe(
+      "http://localhost:3000/#!/route"
+    );
+  });
+
+  it("trims trailing slash on non-root paths only", () => {
+    expect(sanitizeUrlForHistory("https://example.com/")).toBe("https://example.com/");
+    expect(sanitizeUrlForHistory("https://example.com/foo/")).toBe("https://example.com/foo");
+  });
+
+  it("returns the input unchanged for unparseable URLs", () => {
+    expect(sanitizeUrlForHistory("not a url")).toBe("not a url");
   });
 });
 
@@ -219,6 +407,19 @@ describe("getFrecencySuggestions", () => {
     const results = getFrecencySuggestions(entries, "");
     expect(results.length).toBeGreaterThan(0);
     expect(results.length).toBeLessThanOrEqual(5);
+  });
+
+  it("sorts empty-query results by frecency, not insertion order", () => {
+    const now = Date.now();
+    const insertionOrdered: UrlHistoryEntry[] = [
+      { url: "http://a/", title: "a", visitCount: 1, lastVisitAt: now - 1000 },
+      { url: "http://b/", title: "b", visitCount: 10, lastVisitAt: now - 1000 },
+      { url: "http://c/", title: "c", visitCount: 3, lastVisitAt: now - 1000 },
+    ];
+    const results = getFrecencySuggestions(insertionOrdered, "");
+    expect(results[0]!.url).toBe("http://b/");
+    expect(results[1]!.url).toBe("http://c/");
+    expect(results[2]!.url).toBe("http://a/");
   });
 
   it("returns top entries for whitespace-only query", () => {
@@ -293,6 +494,7 @@ describe("urlHistoryStore persistence migration", () => {
   });
 
   it("rehydrates a legacy unversioned blob without discarding entries", async () => {
+    const recent = Date.now() - 1000;
     const legacyBlob = JSON.stringify({
       state: {
         entries: {
@@ -301,7 +503,7 @@ describe("urlHistoryStore persistence migration", () => {
               url: "http://localhost:3000/",
               title: "Legacy",
               visitCount: 3,
-              lastVisitAt: 1_700_000_000_000,
+              lastVisitAt: recent,
             },
           ],
         },
@@ -317,13 +519,12 @@ describe("urlHistoryStore persistence migration", () => {
     expect(entries![0]!.visitCount).toBe(3);
   });
 
-  it("writes version: 0 on the next persist after rehydration", async () => {
+  it("writes version: 1 on the next persist after rehydration", async () => {
+    const recent = Date.now() - 1000;
     const legacyBlob = JSON.stringify({
       state: {
         entries: {
-          proj1: [
-            { url: "http://a.test/", title: "A", visitCount: 1, lastVisitAt: 1_700_000_000_000 },
-          ],
+          proj1: [{ url: "http://a.test/", title: "A", visitCount: 1, lastVisitAt: recent }],
         },
       },
     });
@@ -338,9 +539,110 @@ describe("urlHistoryStore persistence migration", () => {
       version: number;
       state: { entries: Record<string, UrlHistoryEntry[]> };
     };
-    expect(parsed.version).toBe(0);
+    expect(parsed.version).toBe(1);
     expect(parsed.state.entries["proj1"]!.some((e) => e.url === "http://a.test/")).toBe(true);
     expect(parsed.state.entries["proj1"]!.some((e) => e.url === "http://b.test/")).toBe(true);
+  });
+
+  it("strips sensitive URLs from a legacy blob during migration", async () => {
+    const recent = Date.now() - 1000;
+    const legacyBlob = JSON.stringify({
+      state: {
+        entries: {
+          proj1: [
+            { url: "https://example.com/safe", title: "Safe", visitCount: 1, lastVisitAt: recent },
+            {
+              url: "https://app.com/cb?code=abc&state=xyz",
+              title: "OAuth",
+              visitCount: 1,
+              lastVisitAt: recent,
+            },
+            {
+              url: "https://b.s3.amazonaws.com/f?X-Amz-Signature=zzz",
+              title: "Signed",
+              visitCount: 1,
+              lastVisitAt: recent,
+            },
+          ],
+        },
+      },
+    });
+    installLocalStorage({ [STORAGE_KEY]: legacyBlob });
+
+    const { useUrlHistoryStore: store } = await import("../urlHistoryStore");
+    const entries = store.getState().entries["proj1"]!;
+    expect(entries).toHaveLength(1);
+    expect(entries[0]!.url).toBe("https://example.com/safe");
+  });
+
+  it("dedupes tracking-param variants during migration", async () => {
+    const recent = Date.now() - 1000;
+    const legacyBlob = JSON.stringify({
+      state: {
+        entries: {
+          proj1: [
+            {
+              url: "https://example.com/page?utm_source=a",
+              title: "Page",
+              visitCount: 2,
+              lastVisitAt: recent - 5000,
+            },
+            {
+              url: "https://example.com/page?utm_source=b",
+              title: "",
+              visitCount: 3,
+              lastVisitAt: recent,
+              favicon: "https://example.com/favicon.ico",
+            },
+          ],
+        },
+      },
+    });
+    installLocalStorage({ [STORAGE_KEY]: legacyBlob });
+
+    const { useUrlHistoryStore: store } = await import("../urlHistoryStore");
+    const entries = store.getState().entries["proj1"]!;
+    expect(entries).toHaveLength(1);
+    expect(entries[0]!.url).toBe("https://example.com/page");
+    expect(entries[0]!.visitCount).toBe(5);
+    expect(entries[0]!.lastVisitAt).toBe(recent);
+    expect(entries[0]!.title).toBe("Page");
+    expect(entries[0]!.favicon).toBe("https://example.com/favicon.ico");
+  });
+
+  it("prunes entries older than 90 days during migration", async () => {
+    const stale = Date.now() - 100 * 24 * 3600 * 1000;
+    const legacyBlob = JSON.stringify({
+      state: {
+        entries: {
+          proj1: [
+            { url: "https://example.com/old", title: "Old", visitCount: 1, lastVisitAt: stale },
+          ],
+        },
+      },
+    });
+    installLocalStorage({ [STORAGE_KEY]: legacyBlob });
+
+    const { useUrlHistoryStore: store } = await import("../urlHistoryStore");
+    expect(store.getState().entries["proj1"]).toBeUndefined();
+  });
+
+  it("caps visitCount during migration", async () => {
+    const recent = Date.now() - 1000;
+    const legacyBlob = JSON.stringify({
+      state: {
+        entries: {
+          proj1: [
+            { url: "https://example.com/", title: "", visitCount: 5000, lastVisitAt: recent },
+          ],
+        },
+      },
+    });
+    installLocalStorage({ [STORAGE_KEY]: legacyBlob });
+
+    const { useUrlHistoryStore: store } = await import("../urlHistoryStore");
+    const entries = store.getState().entries["proj1"]!;
+    expect(entries[0]!.visitCount).toBe(200);
   });
 });
 

--- a/src/store/__tests__/urlHistoryStore.test.ts
+++ b/src/store/__tests__/urlHistoryStore.test.ts
@@ -263,6 +263,87 @@ describe("urlHistoryStore", () => {
     expect(entries).toHaveLength(1);
     expect(entries[0]!.url).toBe("http://localhost:3000/new");
   });
+
+  it("recordVisit with a sensitive URL does not mutate existing safe history", () => {
+    const store = useUrlHistoryStore.getState();
+    store.recordVisit("proj1", "http://localhost:3000/", "Home");
+    const before = useUrlHistoryStore.getState().entries["proj1"]!;
+    store.recordVisit("proj1", "https://app.com/cb?code=abc&state=xyz", "OAuth");
+    const after = useUrlHistoryStore.getState().entries["proj1"]!;
+    expect(after).toHaveLength(1);
+    expect(after[0]!.url).toBe(before[0]!.url);
+    expect(after[0]!.title).toBe("Home");
+  });
+
+  it("updateTitle canonicalizes the lookup URL and updates the existing entry", () => {
+    const store = useUrlHistoryStore.getState();
+    store.recordVisit("proj1", "https://example.com/page", "Old");
+    store.updateTitle("proj1", "https://example.com/page?utm_source=email", "New");
+    const entries = useUrlHistoryStore.getState().entries["proj1"]!;
+    expect(entries).toHaveLength(1);
+    expect(entries[0]!.title).toBe("New");
+  });
+
+  it("updateFavicon canonicalizes the lookup URL and updates the existing entry", () => {
+    const store = useUrlHistoryStore.getState();
+    store.recordVisit("proj1", "https://example.com/page", "Page");
+    store.updateFavicon("proj1", "https://example.com/page?fbclid=xyz", "favicon.ico");
+    const entries = useUrlHistoryStore.getState().entries["proj1"]!;
+    expect(entries).toHaveLength(1);
+    expect(entries[0]!.favicon).toBe("favicon.ico");
+  });
+
+  it("retention boundary: entries just under 90 days survive, just over are pruned", () => {
+    const now = Date.now();
+    const ninetyDaysMs = 90 * 24 * 3600 * 1000;
+    useUrlHistoryStore.setState({
+      entries: {
+        proj1: [
+          {
+            url: "http://localhost:3000/just-old",
+            title: "Just Old",
+            visitCount: 1,
+            lastVisitAt: now - ninetyDaysMs + 1000,
+          },
+          {
+            url: "http://localhost:3000/too-old",
+            title: "Too Old",
+            visitCount: 1,
+            lastVisitAt: now - ninetyDaysMs - 1000,
+          },
+        ],
+      },
+    });
+    useUrlHistoryStore.getState().recordVisit("proj1", "http://localhost:3000/fresh", "Fresh");
+    const entries = useUrlHistoryStore.getState().entries["proj1"]!;
+    const urls = entries.map((e) => e.url).sort();
+    expect(urls).toEqual(["http://localhost:3000/fresh", "http://localhost:3000/just-old"]);
+  });
+
+  it("500-entry cap evicts low-frecency entries first", () => {
+    const store = useUrlHistoryStore.getState();
+    const now = Date.now();
+    const seeded: UrlHistoryEntry[] = [];
+    for (let i = 0; i < 500; i++) {
+      seeded.push({
+        url: `http://localhost:3000/seed-${i}`,
+        title: `Seed ${i}`,
+        visitCount: 1,
+        lastVisitAt: now - 1000,
+      });
+    }
+    seeded.push({
+      url: "http://localhost:3000/high-value",
+      title: "High",
+      visitCount: 50,
+      lastVisitAt: now - 1000,
+    });
+    useUrlHistoryStore.setState({ entries: { proj1: seeded } });
+    store.recordVisit("proj1", "http://localhost:3000/trigger-cap", "Trigger");
+    const entries = useUrlHistoryStore.getState().entries["proj1"]!;
+    expect(entries.length).toBeLessThanOrEqual(500);
+    expect(entries.find((e) => e.url === "http://localhost:3000/high-value")).toBeDefined();
+  });
 });
 
 describe("sanitizeUrlForHistory", () => {
@@ -276,6 +357,15 @@ describe("sanitizeUrlForHistory", () => {
     expect(sanitizeUrlForHistory("https://app.com/#token_type=Bearer")).toBeNull();
   });
 
+  it("returns null for tokens after `?` inside hash-router fragments (Angular/SPA implicit flow)", () => {
+    expect(sanitizeUrlForHistory("https://app.com/#/callback?access_token=secret")).toBeNull();
+    expect(sanitizeUrlForHistory("https://app.com/#/auth?id_token=eyJ&state=x")).toBeNull();
+  });
+
+  it("returns null for GCS signed URLs with uppercase param keys", () => {
+    expect(sanitizeUrlForHistory("https://s.googleapis.com/b/f?X-GOOG-SIGNATURE=abc")).toBeNull();
+  });
+
   it("returns null for basic-auth URLs", () => {
     expect(sanitizeUrlForHistory("https://user:pass@example.com/")).toBeNull();
     expect(sanitizeUrlForHistory("https://user@example.com/")).toBeNull();
@@ -285,9 +375,7 @@ describe("sanitizeUrlForHistory", () => {
     expect(
       sanitizeUrlForHistory("https://b.s3.amazonaws.com/f?X-Amz-Signature=abc&X-Amz-Date=z")
     ).toBeNull();
-    expect(
-      sanitizeUrlForHistory("https://b.s3.amazonaws.com/f?x-amz-signature=abc")
-    ).toBeNull();
+    expect(sanitizeUrlForHistory("https://b.s3.amazonaws.com/f?x-amz-signature=abc")).toBeNull();
   });
 
   it("returns null for GCS signed URLs", () => {
@@ -298,9 +386,7 @@ describe("sanitizeUrlForHistory", () => {
     expect(
       sanitizeUrlForHistory("https://a.blob.core.windows.net/c/f?sig=abc&se=2026&sv=2024")
     ).toBeNull();
-    expect(
-      sanitizeUrlForHistory("https://a.blob.core.windows.net/c/f?sig=abc&sv=2024")
-    ).toBeNull();
+    expect(sanitizeUrlForHistory("https://a.blob.core.windows.net/c/f?sig=abc&sv=2024")).toBeNull();
   });
 
   it("strips tracking params and sorts remaining params alphabetically", () => {

--- a/src/store/urlHistoryStore.ts
+++ b/src/store/urlHistoryStore.ts
@@ -5,6 +5,89 @@ import { createSafeJSONStorage } from "./persistence/safeStorage";
 import { registerPersistedStore } from "./persistence/persistedStoreRegistry";
 
 const MAX_ENTRIES_PER_PROJECT = 500;
+const MAX_VISIT_COUNT = 200;
+const HISTORY_RETENTION_MS = 90 * 24 * 3600 * 1000;
+
+const TRACKING_PARAMS = new Set<string>([
+  "gclid",
+  "dclid",
+  "gbraid",
+  "wbraid",
+  "_ga",
+  "_gl",
+  "fbclid",
+  "twclid",
+  "msclkid",
+  "_hsenc",
+  "_hsmi",
+  "mkt_tok",
+  "utm_source",
+  "utm_medium",
+  "utm_campaign",
+  "utm_term",
+  "utm_content",
+  "mc_eid",
+  "oly_anon_id",
+  "oly_enc_id",
+  "__s",
+  "vero_id",
+]);
+
+const TOKEN_FRAGMENT_RE = /[#&](?:access_token|id_token|token_type)=/i;
+
+function hasAnyAwsSignedParam(params: URLSearchParams): boolean {
+  for (const key of params.keys()) {
+    if (key.toLowerCase().startsWith("x-amz-")) return true;
+  }
+  return false;
+}
+
+function isAzureSasParams(params: URLSearchParams): boolean {
+  return params.has("sig") && (params.has("se") || params.has("sv"));
+}
+
+/**
+ * Sanitizes a URL for history storage. Returns `null` for sensitive URLs
+ * (OAuth callbacks, signed cloud-storage URLs, basic-auth) that must not
+ * be persisted. Returns a canonical form (lowercased scheme/host, tracking
+ * params stripped, remaining params sorted) for safe URLs. Hash fragments
+ * are preserved verbatim so hash-router routes (#/, #!) survive.
+ */
+export function sanitizeUrlForHistory(url: string): string | null {
+  let parsed: URL;
+  try {
+    parsed = new URL(url);
+  } catch {
+    return url;
+  }
+
+  if (parsed.username || parsed.password) return null;
+
+  if (TOKEN_FRAGMENT_RE.test(parsed.hash)) return null;
+
+  const params = parsed.searchParams;
+  if (params.has("code") && params.has("state")) return null;
+  if (hasAnyAwsSignedParam(params)) return null;
+  if (params.has("X-Goog-Signature") || params.has("x-goog-signature")) return null;
+  if (isAzureSasParams(params)) return null;
+
+  parsed.protocol = parsed.protocol.toLowerCase();
+  parsed.hostname = parsed.hostname.toLowerCase();
+
+  const keys = [...params.keys()];
+  for (const key of keys) {
+    if (TRACKING_PARAMS.has(key.toLowerCase())) {
+      params.delete(key);
+    }
+  }
+  params.sort();
+
+  if (parsed.pathname.length > 1 && parsed.pathname.endsWith("/")) {
+    parsed.pathname = parsed.pathname.replace(/\/+$/, "");
+  }
+
+  return parsed.toString();
+}
 
 const RECENCY_BUCKETS = [
   { maxAgeMs: 4 * 24 * 3600 * 1000, weight: 100 },
@@ -24,9 +107,13 @@ export function getFrecencySuggestions(
   query: string,
   limit = 5
 ): UrlHistoryEntry[] {
-  if (!query.trim()) return entries.slice(0, limit);
-  const lowerQuery = query.toLowerCase();
   const now = Date.now();
+  if (!query.trim()) {
+    return [...entries]
+      .sort((a, b) => frecencyScore(b, now) - frecencyScore(a, now))
+      .slice(0, limit);
+  }
+  const lowerQuery = query.toLowerCase();
   return entries
     .filter(
       (e) => e.url.toLowerCase().includes(lowerQuery) || e.title.toLowerCase().includes(lowerQuery)
@@ -44,6 +131,45 @@ interface UrlHistoryState {
   removeProjectHistory: (projectId: string) => void;
 }
 
+function pruneStaleEntries(entries: UrlHistoryEntry[], now: number): UrlHistoryEntry[] {
+  return entries.filter((e) => now - e.lastVisitAt <= HISTORY_RETENTION_MS);
+}
+
+function migrateEntries(
+  rawEntries: Record<string, UrlHistoryEntry[]>
+): Record<string, UrlHistoryEntry[]> {
+  const now = Date.now();
+  const result: Record<string, UrlHistoryEntry[]> = {};
+  for (const [projectId, projectEntries] of Object.entries(rawEntries)) {
+    if (!Array.isArray(projectEntries)) continue;
+    const merged = new Map<string, UrlHistoryEntry>();
+    for (const entry of projectEntries) {
+      if (!entry || typeof entry.url !== "string") continue;
+      const canonical = sanitizeUrlForHistory(entry.url);
+      if (canonical === null) continue;
+      const cappedVisits = Math.min(entry.visitCount ?? 0, MAX_VISIT_COUNT);
+      const existing = merged.get(canonical);
+      if (existing) {
+        existing.visitCount = Math.min(existing.visitCount + cappedVisits, MAX_VISIT_COUNT);
+        existing.lastVisitAt = Math.max(existing.lastVisitAt, entry.lastVisitAt ?? 0);
+        if (!existing.title && entry.title) existing.title = entry.title;
+        if (!existing.favicon && entry.favicon) existing.favicon = entry.favicon;
+      } else {
+        merged.set(canonical, {
+          url: canonical,
+          title: entry.title ?? "",
+          visitCount: cappedVisits,
+          lastVisitAt: entry.lastVisitAt ?? 0,
+          ...(entry.favicon ? { favicon: entry.favicon } : {}),
+        });
+      }
+    }
+    const pruned = pruneStaleEntries([...merged.values()], now);
+    if (pruned.length > 0) result[projectId] = pruned;
+  }
+  return result;
+}
+
 export const useUrlHistoryStore = create<UrlHistoryState>()(
   persist(
     (set) => ({
@@ -51,21 +177,23 @@ export const useUrlHistoryStore = create<UrlHistoryState>()(
 
       recordVisit: (projectId, url, title) =>
         set((state) => {
-          const projectEntries = [...(state.entries[projectId] ?? [])];
-          const existingIndex = projectEntries.findIndex((e) => e.url === url);
+          const canonical = sanitizeUrlForHistory(url);
+          if (canonical === null) return state;
           const now = Date.now();
+          const projectEntries = pruneStaleEntries(state.entries[projectId] ?? [], now).slice();
+          const existingIndex = projectEntries.findIndex((e) => e.url === canonical);
 
           if (existingIndex >= 0) {
             const existing = projectEntries[existingIndex]!;
             projectEntries[existingIndex] = {
               ...existing,
-              visitCount: existing.visitCount + 1,
+              visitCount: Math.min(existing.visitCount + 1, MAX_VISIT_COUNT),
               lastVisitAt: now,
               title: title || existing.title,
             };
           } else {
             projectEntries.push({
-              url,
+              url: canonical,
               title: title || "",
               visitCount: 1,
               lastVisitAt: now,
@@ -82,9 +210,11 @@ export const useUrlHistoryStore = create<UrlHistoryState>()(
 
       updateTitle: (projectId, url, title) =>
         set((state) => {
+          const canonical = sanitizeUrlForHistory(url);
+          if (canonical === null) return state;
           const projectEntries = state.entries[projectId];
           if (!projectEntries) return state;
-          const index = projectEntries.findIndex((e) => e.url === url);
+          const index = projectEntries.findIndex((e) => e.url === canonical);
           if (index < 0) return state;
           const updated = [...projectEntries];
           updated[index] = { ...updated[index]!, title };
@@ -93,14 +223,15 @@ export const useUrlHistoryStore = create<UrlHistoryState>()(
 
       updateFavicon: (projectId, url, favicon) =>
         set((state) => {
-          const projectEntries = [...(state.entries[projectId] ?? [])];
-          const index = projectEntries.findIndex((e) => e.url === url);
-          if (index >= 0) {
-            projectEntries[index] = { ...projectEntries[index]!, favicon };
-          } else {
-            projectEntries.push({ url, title: "", visitCount: 0, lastVisitAt: 0, favicon });
-          }
-          return { entries: { ...state.entries, [projectId]: projectEntries } };
+          const canonical = sanitizeUrlForHistory(url);
+          if (canonical === null) return state;
+          const projectEntries = state.entries[projectId];
+          if (!projectEntries) return state;
+          const index = projectEntries.findIndex((e) => e.url === canonical);
+          if (index < 0) return state;
+          const updated = [...projectEntries];
+          updated[index] = { ...updated[index]!, favicon };
+          return { entries: { ...state.entries, [projectId]: updated } };
         }),
 
       removeUrl: (projectId, url) =>
@@ -121,8 +252,19 @@ export const useUrlHistoryStore = create<UrlHistoryState>()(
     {
       name: "daintree-url-history",
       storage: createSafeJSONStorage(),
-      version: 0,
+      version: 1,
       migrate: (persistedState) => persistedState as UrlHistoryState,
+      merge: (persistedState, currentState) => {
+        if (typeof persistedState !== "object" || persistedState === null) {
+          return currentState;
+        }
+        const candidate = persistedState as { entries?: unknown };
+        const rawEntries =
+          candidate.entries && typeof candidate.entries === "object"
+            ? (candidate.entries as Record<string, UrlHistoryEntry[]>)
+            : {};
+        return { ...currentState, entries: migrateEntries(rawEntries) };
+      },
       partialize: (state) => ({ entries: state.entries }),
     }
   )

--- a/src/store/urlHistoryStore.ts
+++ b/src/store/urlHistoryStore.ts
@@ -33,11 +33,18 @@ const TRACKING_PARAMS = new Set<string>([
   "vero_id",
 ]);
 
-const TOKEN_FRAGMENT_RE = /[#&](?:access_token|id_token|token_type)=/i;
+const TOKEN_FRAGMENT_RE = /[#&?](?:access_token|id_token|token_type)=/i;
 
 function hasAnyAwsSignedParam(params: URLSearchParams): boolean {
   for (const key of params.keys()) {
     if (key.toLowerCase().startsWith("x-amz-")) return true;
+  }
+  return false;
+}
+
+function hasGcsSignedParam(params: URLSearchParams): boolean {
+  for (const key of params.keys()) {
+    if (key.toLowerCase() === "x-goog-signature") return true;
   }
   return false;
 }
@@ -68,7 +75,7 @@ export function sanitizeUrlForHistory(url: string): string | null {
   const params = parsed.searchParams;
   if (params.has("code") && params.has("state")) return null;
   if (hasAnyAwsSignedParam(params)) return null;
-  if (params.has("X-Goog-Signature") || params.has("x-goog-signature")) return null;
+  if (hasGcsSignedParam(params)) return null;
   if (isAzureSasParams(params)) return null;
 
   parsed.protocol = parsed.protocol.toLowerCase();
@@ -165,6 +172,10 @@ function migrateEntries(
       }
     }
     const pruned = pruneStaleEntries([...merged.values()], now);
+    if (pruned.length > MAX_ENTRIES_PER_PROJECT) {
+      pruned.sort((a, b) => frecencyScore(b, now) - frecencyScore(a, now));
+      pruned.length = MAX_ENTRIES_PER_PROJECT;
+    }
     if (pruned.length > 0) result[projectId] = pruned;
   }
   return result;


### PR DESCRIPTION
## Summary

- Sensitive URLs (OAuth callbacks, token/code fragments, signed AWS/GCS/Azure URLs, `user:pass@host` credentials) are now skipped entirely — nothing lands in `localStorage`
- Tracking params (`utm_*`, `fbclid`, `gclid`, `gbraid`, `wbraid`, `msclkid`, and ~10 more) are stripped before keying, so campaign-variant URLs stop producing duplicate entries
- `visitCount` is capped at 200, entries older than 90 days are pruned on hydration, empty-query suggestions sort by frecency, and `updateFavicon` no longer creates ghost entries with zero frecency

Resolves #7226

## Changes

- `sanitizeUrlForHistory` — new function that skips sensitive URLs and strips tracking params before storage/keying; applied in `recordVisit`, `updateTitle`, and `updateFavicon`
- `visitCount` cap at 200 in `recordVisit`; 90-day prune in `rehydrateState`; empty-query path in `getFrecencySuggestions` now sorts by frecency score
- `updateFavicon` guard: skips unknown URLs instead of creating zero-frecency ghost entries
- Zustand `merge` sanitizes/dedupes/prunes existing blobs on hydration (Zustand v5 only calls `migrate` on numeric version mismatches; unversioned blobs need the `merge` path); persist version bumped `0 → 1`
- `persistenceBoundaryHardening.test.ts` URL expectation updated for canonical trailing-slash on bare origin

## Testing

81 vitest cases covering: OAuth callback URLs in both query-string and hash-router fragment forms, signed AWS/GCS/Azure URL rejection, tracking-param deduplication keying, `visitCount` cap boundary, 90-day prune boundary (in/out), 500-entry eviction order, `updateTitle`/`updateFavicon` canonicalization, empty-query frecency ordering, and ghost-entry regression