### PR TITLE
fix(portal): cancel stale polls, shared debounce, aria-controls, drop favicon fetch

### DIFF
--- a/src/components/Layout/__tests__/AppLayout.landmarks.test.ts
+++ b/src/components/Layout/__tests__/AppLayout.landmarks.test.ts
@@ -88,5 +88,9 @@ describe("ARIA page landmarks — issue #5416", () => {
     it("keeps tabIndex=-1 so the macro-focus cycler can target it", () => {
       expect(source).toMatch(/<aside[\s\S]*?tabIndex=\{-1\}/);
     });
+
+    it("links the resize separator to the panel it controls via aria-controls", () => {
+      expect(source).toMatch(/role="separator"[\s\S]*?aria-controls="portal-placeholder"/);
+    });
   });
 });

--- a/src/components/Portal/PortalDock.tsx
+++ b/src/components/Portal/PortalDock.tsx
@@ -442,11 +442,15 @@ export function PortalDock() {
             onReloadTab={handleReloadTab}
             enabledLinks={enabledLinks}
           />
-          <div ref={contentRef} className="flex-1 flex flex-col min-h-0 relative">
+          <div
+            ref={contentRef}
+            id="portal-placeholder"
+            className="flex-1 flex flex-col min-h-0 relative"
+          >
             {showLaunchpad ? (
               <PortalLaunchpad links={enabledLinks} onOpenUrl={handleOpenUrl} />
             ) : (
-              <div className="flex-1 bg-daintree-sidebar" id="portal-placeholder" />
+              <div className="flex-1 bg-daintree-sidebar" />
             )}
           </div>
         </aside>

--- a/src/components/Portal/PortalDock.tsx
+++ b/src/components/Portal/PortalDock.tsx
@@ -23,6 +23,7 @@ import {
   ContextMenuTrigger,
 } from "@/components/ui/context-menu";
 import { getElementBoundsAsDip } from "@/lib/portalBounds";
+import { debounce } from "@/utils/debounce";
 
 export function PortalDock() {
   const { width, activeTabId, tabs, links, setWidth, setOpen, defaultNewTabUrl } = usePortalStore(
@@ -82,6 +83,7 @@ export function PortalDock() {
     return () => {
       observer.disconnect();
       window.removeEventListener("resize", debouncedSync);
+      debouncedSync.cancel();
     };
   }, [activeTabId, syncBounds]);
 
@@ -396,6 +398,7 @@ export function PortalDock() {
             role="separator"
             aria-label="Resize portal panel"
             aria-orientation="vertical"
+            aria-controls="portal-placeholder"
             aria-valuenow={Math.round(width)}
             aria-valuemin={PORTAL_MIN_WIDTH}
             aria-valuemax={PORTAL_MAX_WIDTH}
@@ -532,12 +535,4 @@ export function PortalDock() {
       </ContextMenuContent>
     </ContextMenu>
   );
-}
-
-function debounce<T extends (...args: unknown[]) => void>(fn: T, ms: number): T {
-  let timeoutId: ReturnType<typeof setTimeout> | null = null;
-  return ((...args: unknown[]) => {
-    if (timeoutId) clearTimeout(timeoutId);
-    timeoutId = setTimeout(() => fn(...args), ms);
-  }) as T;
 }

--- a/src/components/Portal/PortalIcon.tsx
+++ b/src/components/Portal/PortalIcon.tsx
@@ -1,4 +1,3 @@
-import { useState, useEffect } from "react";
 import { Globe, Search } from "lucide-react";
 import { getAgentConfig, isRegisteredAgent } from "@/config/agents";
 import { BrandMark } from "@/components/icons";
@@ -6,28 +5,19 @@ import { BrandMark } from "@/components/icons";
 interface PortalIconProps {
   icon: string;
   size?: "tab" | "launchpad";
-  url?: string;
-  type?: "system" | "user";
 }
 
-export function PortalIcon({ icon, size = "launchpad", url, type }: PortalIconProps) {
-  const [showFallback, setShowFallback] = useState(false);
+export function PortalIcon({ icon, size = "launchpad" }: PortalIconProps) {
   const iconClass = size === "launchpad" ? "w-8 h-8" : "w-3 h-3";
 
-  useEffect(() => {
-    setShowFallback(false);
-  }, [icon, url]);
-
-  if (showFallback || icon === "globe") {
+  if (icon === "globe") {
     return <Globe className={iconClass} />;
   }
 
-  // Handle special cases
   if (icon === "search") {
     return <Search className={iconClass} />;
   }
 
-  // Try to get agent config from registry
   if (isRegisteredAgent(icon)) {
     const config = getAgentConfig(icon);
     if (config) {
@@ -41,18 +31,7 @@ export function PortalIcon({ icon, size = "launchpad", url, type }: PortalIconPr
     }
   }
 
-  // Fallback for user-defined links with URL
-  if (type === "user" && url) {
-    try {
-      const domain = new URL(url).hostname;
-      const faviconUrl = `https://www.google.com/s2/favicons?domain=${domain}&sz=64`;
-      return (
-        <img src={faviconUrl} alt="" className={iconClass} onError={() => setShowFallback(true)} />
-      );
-    } catch {
-      return <Globe className={iconClass} />;
-    }
-  }
-
+  // User-defined links render Globe — never fetch favicons from third-party services
+  // (e.g. google.com/s2/favicons) since that would leak hostnames the user opened.
   return <Globe className={iconClass} />;
 }

--- a/src/components/Portal/PortalLaunchpad.tsx
+++ b/src/components/Portal/PortalLaunchpad.tsx
@@ -63,7 +63,7 @@ export function PortalLaunchpad({ links, onOpenUrl }: PortalLaunchpadProps) {
               className="flex items-center gap-4 p-4 rounded-[var(--radius-xl)] bg-daintree-border hover:bg-daintree-border/80 border border-daintree-border hover:border-daintree-border transition-colors group focus-visible:outline focus-visible:outline-2 focus-visible:outline-daintree-accent focus-visible:outline-offset-2"
             >
               <div className="w-8 h-8 flex items-center justify-center text-foreground group-hover:text-daintree-text transition-colors">
-                <PortalIcon icon={link.icon} size="launchpad" url={link.url} type={link.type} />
+                <PortalIcon icon={link.icon} size="launchpad" />
               </div>
               <div className="text-left min-w-0">
                 <div className="font-medium text-foreground group-hover:text-daintree-text transition-colors">

--- a/src/components/Portal/PortalToolbar.tsx
+++ b/src/components/Portal/PortalToolbar.tsx
@@ -112,7 +112,7 @@ const SortableTab = memo(function SortableTab({
         >
           {tab.icon && (
             <div className="flex-shrink-0">
-              <PortalIcon icon={tab.icon} size="tab" url={tab.url ?? undefined} />
+              <PortalIcon icon={tab.icon} size="tab" />
             </div>
           )}
           <span className="truncate max-w-[120px]">{tab.title}</span>

--- a/src/components/Portal/PortalVisibilityController.tsx
+++ b/src/components/Portal/PortalVisibilityController.tsx
@@ -21,6 +21,7 @@ export function PortalVisibilityController(): null {
   const hasOverlays = overlayClaimsSize > 0;
   const isRestoringRef = useRef(false);
   const pendingRestoreRef = useRef<{ tabId: string; tabUrl: string } | null>(null);
+  const isMountedRef = useRef(true);
 
   const prevHasOverlaysRef = useRef(hasOverlays);
   const prevPortalOpenRef = useRef(portalOpen);
@@ -57,12 +58,18 @@ export function PortalVisibilityController(): null {
         let attempts = 0;
         while (!bounds && attempts < 20) {
           await new Promise((resolve) => setTimeout(resolve, 50));
+          if (!isMountedRef.current) break;
+          if (pendingRestoreRef.current && pendingRestoreRef.current.tabId !== tabId) break;
           bounds = getBounds();
           attempts++;
         }
 
         if (!bounds) {
           isRestoringRef.current = false;
+          return;
+        }
+
+        if (!isMountedRef.current) {
           return;
         }
 
@@ -83,7 +90,7 @@ export function PortalVisibilityController(): null {
       } finally {
         isRestoringRef.current = false;
         const pending = pendingRestoreRef.current as { tabId: string; tabUrl: string } | null;
-        if (pending) {
+        if (pending && isMountedRef.current) {
           pendingRestoreRef.current = null;
           void ensureTabAndRestore(pending.tabId, pending.tabUrl);
         }
@@ -168,6 +175,13 @@ export function PortalVisibilityController(): null {
       }
     }
   }, [portalOpen, activeTabId, tabs, hasOverlays, ensureTabAndRestore]);
+
+  // Mark unmounted so in-flight bounds polling and pending queue work bails out.
+  useEffect(() => {
+    return () => {
+      isMountedRef.current = false;
+    };
+  }, []);
 
   return null;
 }

--- a/src/components/Portal/PortalVisibilityController.tsx
+++ b/src/components/Portal/PortalVisibilityController.tsx
@@ -59,7 +59,8 @@ export function PortalVisibilityController(): null {
         while (!bounds && attempts < 20) {
           await new Promise((resolve) => setTimeout(resolve, 50));
           if (!isMountedRef.current) break;
-          if (pendingRestoreRef.current && pendingRestoreRef.current.tabId !== tabId) break;
+          const pending = pendingRestoreRef.current as { tabId: string; tabUrl: string } | null;
+          if (pending && pending.tabId !== tabId) break;
           bounds = getBounds();
           attempts++;
         }

--- a/src/components/Portal/PortalVisibilityController.tsx
+++ b/src/components/Portal/PortalVisibilityController.tsx
@@ -177,7 +177,10 @@ export function PortalVisibilityController(): null {
   }, [portalOpen, activeTabId, tabs, hasOverlays, ensureTabAndRestore]);
 
   // Mark unmounted so in-flight bounds polling and pending queue work bails out.
+  // The body re-asserts true so React 19 StrictMode's effect re-run (cleanup then
+  // body) leaves the live component flagged as mounted; production runs once.
   useEffect(() => {
+    isMountedRef.current = true;
     return () => {
       isMountedRef.current = false;
     };

--- a/src/components/Portal/__tests__/PortalIcon.test.tsx
+++ b/src/components/Portal/__tests__/PortalIcon.test.tsx
@@ -1,0 +1,24 @@
+// @vitest-environment jsdom
+import { cleanup, render } from "@testing-library/react";
+import { afterEach, describe, expect, it } from "vitest";
+import { PortalIcon } from "../PortalIcon";
+
+describe("PortalIcon — privacy", () => {
+  afterEach(() => {
+    cleanup();
+  });
+
+  it("renders Globe (no img) for unknown icons regardless of url, so user-added link hostnames never leak to a third party", () => {
+    const { container } = render(<PortalIcon icon="some-custom-icon" size="launchpad" />);
+
+    expect(container.querySelector("img")).toBeNull();
+    expect(container.querySelector("svg")).not.toBeNull();
+  });
+
+  it("renders Globe explicitly when icon === 'globe'", () => {
+    const { container } = render(<PortalIcon icon="globe" size="tab" />);
+
+    expect(container.querySelector("img")).toBeNull();
+    expect(container.querySelector("svg")).not.toBeNull();
+  });
+});

--- a/src/components/Portal/__tests__/PortalVisibilityController.test.tsx
+++ b/src/components/Portal/__tests__/PortalVisibilityController.test.tsx
@@ -1,4 +1,5 @@
 // @vitest-environment jsdom
+import { StrictMode } from "react";
 import { act, cleanup, render } from "@testing-library/react";
 import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
 import { PortalVisibilityController } from "../PortalVisibilityController";
@@ -302,6 +303,38 @@ describe("PortalVisibilityController", () => {
     });
 
     expect(portal.show).not.toHaveBeenCalled();
+  });
+
+  it("still restores tabs after StrictMode's effect cleanup-then-rerun cycle (mount ref must reset to true)", async () => {
+    vi.spyOn(document, "getElementById").mockReturnValue({
+      getBoundingClientRect: () => createPlaceholderRect(),
+    } as unknown as HTMLElement);
+
+    render(
+      <StrictMode>
+        <PortalVisibilityController />
+      </StrictMode>
+    );
+
+    act(() => {
+      usePortalStore.setState({
+        isOpen: true,
+        activeTabId: "tab-1",
+        tabs: [{ id: "tab-1", title: "Docs", url: "https://example.com/docs" }],
+        createdTabs: new Set<string>(),
+      });
+    });
+
+    await act(async () => {
+      await vi.runAllTimersAsync();
+    });
+
+    // If the unmount-tracking ref was permanently flipped to false by StrictMode's
+    // double-invoke, the bounds-checked guard would skip portal.show.
+    expect(portal.show).toHaveBeenCalledWith({
+      tabId: "tab-1",
+      bounds: { x: 10, y: 21, width: 301, height: 401 },
+    });
   });
 
   it("removes tab from createdTabs when eviction event fires", () => {

--- a/src/components/Portal/__tests__/PortalVisibilityController.test.tsx
+++ b/src/components/Portal/__tests__/PortalVisibilityController.test.tsx
@@ -261,6 +261,49 @@ describe("PortalVisibilityController", () => {
     });
   });
 
+  it("stops polling and skips show() if the controller unmounts during the bounds wait", async () => {
+    // Bounds null for the first few lookups, then valid: without the unmount guard
+    // the in-flight async would continue polling past unmount, find bounds, and
+    // call show() against a torn-down component. With the guard it breaks on the
+    // first post-await tick.
+    let calls = 0;
+    vi.spyOn(document, "getElementById").mockImplementation((id) => {
+      if (id !== "portal-placeholder") return null;
+      calls += 1;
+      if (calls < 5) return null;
+      return { getBoundingClientRect: () => createPlaceholderRect() } as unknown as HTMLElement;
+    });
+
+    const view = render(<PortalVisibilityController />);
+
+    act(() => {
+      usePortalStore.setState({
+        isOpen: true,
+        activeTabId: "tab-1",
+        tabs: [{ id: "tab-1", title: "Docs", url: "https://example.com/docs" }],
+        createdTabs: new Set<string>(),
+      });
+    });
+
+    // Let create() resolve and the first poll await be scheduled.
+    await act(async () => {
+      await Promise.resolve();
+      await Promise.resolve();
+    });
+
+    expect(portal.create).toHaveBeenCalledTimes(1);
+    expect(portal.show).not.toHaveBeenCalled();
+
+    // Unmount mid-poll — every subsequent post-await tick must bail.
+    view.unmount();
+
+    await act(async () => {
+      await vi.runAllTimersAsync();
+    });
+
+    expect(portal.show).not.toHaveBeenCalled();
+  });
+
   it("removes tab from createdTabs when eviction event fires", () => {
     usePortalStore.setState({
       isOpen: true,


### PR DESCRIPTION
## Summary

- Cancels in-flight bounds polling in `PortalVisibilityController` on unmount and on stale tab detection, so the loop doesn't burn up to 20 timers it no longer needs.
- Replaces the inline debounce in `PortalDock` with the shared utility from `src/utils/debounce.ts` (which has `cancel()` and `flush()` helpers), and cancels any pending invocation on effect cleanup.
- Adds `aria-controls` to the `role="separator"` resize handle and anchors `id=portal-placeholder` to the always-rendered content container so screen readers can resolve the relationship regardless of launchpad/active-tab state.
- Drops the `google.com/s2/favicons` fetch from `PortalIcon` for user-defined links entirely. The component already has a `Globe` fallback — no reason to send user hostnames to a third party. Removes the now-dead `url`/`type` props and `showFallback` state, and updates both call sites.
- Fixes a React 19 StrictMode trap where the unmount-tracking ref got permanently flipped to `false` by the dev-mode cleanup-then-rerun cycle, silently breaking portal restoration in development.

Resolves #7266

## Changes

- `PortalVisibilityController.tsx` — `isMountedRef` initialised to `true` and restored in the effect body (StrictMode fix); `pendingRestoreRef.tabId` mismatch break added inside the existing `while` loop so `try/finally` still drains queued restores.
- `PortalDock.tsx` — inline debounce replaced with import from `src/utils/debounce.ts`; cleanup cancels pending invocation.
- `PortalIcon.tsx` — favicon fetch removed; `Globe` rendered directly for unregistered/user-defined icons; dead props dropped.
- `PortalLaunchpad.tsx`, `PortalToolbar.tsx` — updated `PortalIcon` call sites.
- `AppLayout.landmarks.test.ts` — asserts `aria-controls` on the separator.
- `PortalIcon.test.tsx` (new) — asserts no `<img>` renders for unknown icons or `icon=globe`.
- `PortalVisibilityController.test.tsx` (new) — covers mid-poll unmount no-show and StrictMode mount-ref restoration.

## Testing

- New unit tests for `PortalIcon` (no `<img>` for unknown/globe icons) and `PortalVisibilityController` (unmount during active poll, StrictMode double-mount cycle).
- Existing `AppLayout.landmarks` test extended with the `aria-controls` assertion.
- `npm run check` passes clean; lint ratchet decreased by 9 warnings after rebase.