### PR TITLE
fix(types): consolidate IPC type drifts and fix directing state gap

### DIFF
--- a/electron/ipc/handlers/terminal/__tests__/snapshots.poolInspection.test.ts
+++ b/electron/ipc/handlers/terminal/__tests__/snapshots.poolInspection.test.ts
@@ -253,7 +253,7 @@ describe("terminal pool inspection handlers", () => {
       ) => Promise<unknown[]>;
 
       await expect(handler({}, "invalid")).rejects.toThrow(
-        "Failed to get terminals by state: Invalid state: must be one of idle, working, waiting, completed"
+        "Failed to get terminals by state: Invalid state: must be one of idle, working, waiting, directing, completed, exited"
       );
       expect(ptyClient.getTerminalsByStateAsync).not.toHaveBeenCalled();
     });

--- a/electron/ipc/handlers/terminal/snapshots.ts
+++ b/electron/ipc/handlers/terminal/snapshots.ts
@@ -285,7 +285,7 @@ export function registerTerminalSnapshotHandlers(deps: HandlerDependencies): () 
         throw new Error("Invalid state: must be a non-empty string");
       }
 
-      const validStates = ["idle", "working", "waiting", "completed", "exited"];
+      const validStates = ["idle", "working", "waiting", "directing", "completed", "exited"];
       if (!validStates.includes(state)) {
         throw new Error(`Invalid state: must be one of ${validStates.join(", ")}`);
       }

--- a/electron/services/GitService.ts
+++ b/electron/services/GitService.ts
@@ -4,6 +4,7 @@ import { existsSync } from "fs";
 import { readFile, stat } from "fs/promises";
 import { logDebug, logError, logWarn } from "../utils/logger.js";
 import type { GitStatus, WorktreeChanges } from "../../shared/types/index.js";
+import type { BranchInfo, CreateWorktreeOptions } from "../../shared/types/git.js";
 import { WorktreeRemovedError, GitError, toGitOperationError } from "../utils/errorTypes.js";
 import type { CrossWorktreeDiffResult, CrossWorktreeFile } from "../../shared/types/ipc/git.js";
 import { createHardenedGit } from "../utils/hardenedGit.js";
@@ -12,20 +13,6 @@ import { formatErrorMessage } from "../../shared/utils/errorMessage.js";
 
 function escapeRegex(str: string): string {
   return str.replace(/[.*+?^${}()|[\]\\]/g, "\\$&");
-}
-
-export interface BranchInfo {
-  name: string;
-  current: boolean;
-  commit: string;
-  remote?: string;
-}
-
-export interface CreateWorktreeOptions {
-  baseBranch: string;
-  newBranch: string;
-  path: string;
-  fromRemote?: boolean;
 }
 
 export class GitService {

--- a/shared/types/git.ts
+++ b/shared/types/git.ts
@@ -102,3 +102,24 @@ export interface StagingStatus {
   /** When `repoState === "REBASING"`, the total step count. Null otherwise. */
   rebaseTotalSteps: number | null;
 }
+
+/** Branch information from git */
+export interface BranchInfo {
+  name: string;
+  current: boolean;
+  commit: string;
+  remote?: string;
+}
+
+/** Options for creating a new worktree */
+export interface CreateWorktreeOptions {
+  baseBranch: string;
+  newBranch: string;
+  path: string;
+  fromRemote?: boolean;
+  useExistingBranch?: boolean;
+  /** Opt-in flag to run resource.provision after setup */
+  provisionResource?: boolean;
+  /** Worktree environment mode ("local" or an environment key from resourceEnvironments) */
+  worktreeMode?: string;
+}

--- a/shared/types/ipc/agent.ts
+++ b/shared/types/ipc/agent.ts
@@ -1,4 +1,6 @@
-import type { AgentId, WaitingReason } from "../agent.js";
+import type { AgentId, AgentState, AgentStateChangeTrigger, WaitingReason } from "../agent.js";
+
+export type { AgentState, AgentStateChangeTrigger };
 
 /** An artifact extracted from an agent session */
 export interface Artifact {
@@ -15,20 +17,6 @@ export interface Artifact {
   /** Timestamp when extracted */
   extractedAt: number;
 }
-
-/** Agent state change trigger */
-export type AgentStateChangeTrigger =
-  | "input"
-  | "output"
-  | "heuristic"
-  | "ai-classification"
-  | "timeout"
-  | "exit"
-  | "activity"
-  | "title";
-
-/** Agent state */
-export type AgentState = "idle" | "working" | "waiting" | "directing" | "completed" | "exited";
 
 /** Payload for agent state change events */
 export interface AgentStateChangePayload {

--- a/shared/types/ipc/errors.ts
+++ b/shared/types/ipc/errors.ts
@@ -1,3 +1,5 @@
+import type { ActionId } from "../actions.js";
+
 /** Serialized error that survives Electron's structured clone algorithm */
 export interface SerializedError {
   name: string;
@@ -129,7 +131,7 @@ export type GitOperationReason =
  */
 export interface RecoveryAction {
   label: string;
-  actionId: string;
+  actionId: ActionId;
   args?: Record<string, unknown>;
 }
 

--- a/shared/types/ipc/files.ts
+++ b/shared/types/ipc/files.ts
@@ -1,3 +1,5 @@
+import type { AppErrorCode } from "../appError.js";
+
 export interface FileSearchPayload {
   cwd: string;
   query: string;
@@ -17,14 +19,22 @@ export interface FileReadPayload {
  * Subset of `AppErrorCode` thrown by `files:read`. Renderer consumers narrow
  * caught `AppError`s with `if (e.code === "BINARY_FILE") { ... }` style checks.
  */
-export type FileReadErrorCode =
+// `_AssertSubset<T, U>` constrains `U extends T` and returns `U`. Wrapping
+// `FileReadErrorCode` in it makes the subset relationship a hard compile-time
+// guarantee — if any member is dropped from `AppErrorCode`, this fails to
+// typecheck.
+type _AssertSubset<T, U extends T> = U;
+
+export type FileReadErrorCode = _AssertSubset<
+  AppErrorCode,
   | "BINARY_FILE"
   | "FILE_TOO_LARGE"
   | "LFS_POINTER"
   | "NOT_FOUND"
   | "OUTSIDE_ROOT"
   | "INVALID_PATH"
-  | "PERMISSION";
+  | "PERMISSION"
+>;
 
 export interface FileReadResult {
   content: string;

--- a/shared/types/ipc/maps.ts
+++ b/shared/types/ipc/maps.ts
@@ -1,5 +1,6 @@
 import type { StagingStatus } from "../git.js";
-import type { AgentId } from "../agent.js";
+import type { AgentId, AgentState } from "../agent.js";
+import type { VoiceInputStatus } from "../voice.js";
 import type { TabGroup } from "../panel.js";
 import type { WorktreeState } from "../worktree.js";
 import type {
@@ -2270,7 +2271,7 @@ export interface IpcInvokeMap {
     result: BackendTerminalInfo[];
   };
   "terminal:get-by-state": {
-    args: [state: string];
+    args: [state: AgentState];
     result: BackendTerminalInfo[];
   };
   "terminal:graceful-kill": {
@@ -2514,7 +2515,7 @@ export interface IpcEventMap {
     resolved: boolean;
   };
   "voice-input:error": string;
-  "voice-input:status": "idle" | "connecting" | "recording" | "error";
+  "voice-input:status": VoiceInputStatus;
 
   // Demo mode events (main → renderer command forwarding)
   "demo:exec-move-to": DemoMoveToPayload;

--- a/shared/types/ipc/worktree.ts
+++ b/shared/types/ipc/worktree.ts
@@ -16,24 +16,7 @@ export interface WorktreeDeletePayload {
   deleteBranch?: boolean;
 }
 
-export interface BranchInfo {
-  name: string;
-  current: boolean;
-  commit: string;
-  remote?: string;
-}
-
-export interface CreateWorktreeOptions {
-  baseBranch: string;
-  newBranch: string;
-  path: string;
-  fromRemote?: boolean;
-  useExistingBranch?: boolean;
-  /** Opt-in flag to run resource.provision after setup */
-  provisionResource?: boolean;
-  /** Worktree environment mode ("local" or an environment key from resourceEnvironments) */
-  worktreeMode?: string;
-}
+export type { BranchInfo, CreateWorktreeOptions } from "../git.js";
 
 /** Worktree path pattern configuration */
 export interface WorktreeConfig {

--- a/shared/types/pty-host.ts
+++ b/shared/types/pty-host.ts
@@ -11,7 +11,7 @@ import type { AgentState, AgentId, WaitingReason } from "./agent.js";
 import type { PanelKind, TerminalFlowStatus, PanelTitleMode } from "./panel.js";
 import type { ResourceProfile } from "./resourceProfile.js";
 import type { BuiltInAgentId } from "../config/agentIds.js";
-import type { SemanticSearchMatch } from "./ipc/terminal.js";
+import type { SemanticSearchMatch, TerminalInfoPayload } from "./ipc/terminal.js";
 
 export type { TerminalFlowStatus };
 
@@ -237,7 +237,7 @@ export type PtyHostEvent =
   | { type: "terminal-info"; requestId: string; terminal: PtyHostTerminalInfo | null }
   | { type: "replay-history-result"; requestId: string; replayed: number }
   | { type: "serialized-state"; requestId: string; id: string; state: string | null }
-  | { type: "terminal-diagnostic-info"; requestId: string; info: any }
+  | { type: "terminal-diagnostic-info"; requestId: string; info: TerminalInfoPayload | null }
   | { type: "available-terminals"; requestId: string; terminals: PtyHostTerminalInfo[] }
   | { type: "terminals-by-state"; requestId: string; terminals: PtyHostTerminalInfo[] }
   | { type: "all-terminals"; requestId: string; terminals: PtyHostTerminalInfo[] }

--- a/shared/types/workspace-host.ts
+++ b/shared/types/workspace-host.ts
@@ -11,7 +11,12 @@
  * All types are serializable (no functions, no circular refs) for IPC transport.
  */
 
-import type { FileChangeDetail, WorktreeChanges } from "./git.js";
+import type {
+  BranchInfo,
+  CreateWorktreeOptions,
+  FileChangeDetail,
+  WorktreeChanges,
+} from "./git.js";
 import type {
   Worktree,
   WorktreeMood,
@@ -27,26 +32,7 @@ import type {
 } from "./ipc.js";
 import type { ProjectPulse, PulseRangeDays } from "./pulse.js";
 
-/** Options for creating a new worktree */
-export interface CreateWorktreeOptions {
-  baseBranch: string;
-  newBranch: string;
-  path: string;
-  fromRemote?: boolean;
-  useExistingBranch?: boolean;
-  /** Opt-in flag to run resource.provision after setup */
-  provisionResource?: boolean;
-  /** Worktree environment mode ("local" or an environment key from resourceEnvironments) */
-  worktreeMode?: string;
-}
-
-/** Branch information from git */
-export interface BranchInfo {
-  name: string;
-  current: boolean;
-  commit: string;
-  remote?: string;
-}
+export type { BranchInfo, CreateWorktreeOptions } from "./git.js";
 
 /** Pull request service status */
 export interface PRServiceStatus {


### PR DESCRIPTION
## Summary

- Several IPC type declarations had drifted from their canonical sources or were duplicated outright — `AgentState`, `BranchInfo`, `CreateWorktreeOptions`, and others. Consolidated them to single sources of truth so a change in one place doesn't silently leave copies behind.
- The `terminal:get-by-state` handler in `snapshots.ts` was missing `"directing"` from its `validStates` allowlist. `PtyManager` already supported the state; the handler just wasn't accepting it. That's a live gap, not just a type issue.
- `voice-input:status` in `IpcEventMap` was missing the `"finishing"` state — it was a 4-state union when `VoiceInputStatus` has 5. Swapped the inline union for the canonical `VoiceInputStatus` type.
- `RecoveryAction.actionId` narrowed from `string` to `ActionId` (no flexibility lost — `ActionId` already accepts arbitrary plugin strings via `BuiltInActionId | (string & {})`), and `FileReadErrorCode` now has a compile-time `_AssertSubset` guard to keep it honest against `AppErrorCode`.

Resolves #7280

## Changes

- `shared/types/git.ts` — canonical home for `BranchInfo` and `CreateWorktreeOptions`
- `shared/types/workspace-host.ts`, `shared/types/ipc/worktree.ts` — re-export from `git.ts` (previously copy-pasted)
- `electron/services/GitService.ts` — imports from `shared/types/git.ts`
- `shared/types/pty-host.ts` — `terminal-diagnostic-info` payload `any` → `TerminalInfoPayload | null`
- `shared/types/ipc/agent.ts` — re-exports `AgentState`/`AgentStateChangeTrigger` from canonical `agent.ts`
- `shared/types/ipc/errors.ts` — `RecoveryAction.actionId` `string` → `ActionId`
- `shared/types/ipc/maps.ts` — `voice-input:status` uses `VoiceInputStatus`; `terminal:get-by-state` uses `AgentState`
- `shared/types/ipc/files.ts` — `_AssertSubset` guard on `FileReadErrorCode`
- `electron/ipc/handlers/terminal/snapshots.ts` — `"directing"` added to `validStates`
- `electron/ipc/handlers/terminal/__tests__/snapshots.poolInspection.test.ts` — assertion updated to match

## Testing

- `npm run typecheck` — pass
- `npm run check:channels` — pass
- `npm run lint:ratchet` — pass (warnings 877 → 868, -9)
- `npm run format:check` — pass
- `npm run build` — pass
- `shared/types` unit tests — 87 pass
- `snapshots.poolInspection.test.ts` — 13 pass