### PR TITLE
fix(diagnostics): tighten logs and event-inspector perf

### DIFF
--- a/src/components/Diagnostics/EventsContent.tsx
+++ b/src/components/Diagnostics/EventsContent.tsx
@@ -79,11 +79,7 @@ export function EventsContent({ className }: EventsContentProps) {
 
   return (
     <div className={cn("flex flex-col h-full", className)}>
-      <EventFilters
-        events={events}
-        filters={filters}
-        onFiltersChange={(newFilters) => setFilters(newFilters)}
-      />
+      <EventFilters events={events} filters={filters} onFiltersChange={setFilters} />
 
       <div className="flex-1 flex min-h-0">
         <div className="w-1/2 border-r overflow-hidden">

--- a/src/components/Diagnostics/LogsContent.tsx
+++ b/src/components/Diagnostics/LogsContent.tsx
@@ -1,9 +1,14 @@
-import { useEffect, useMemo, useRef, useState, useCallback } from "react";
+import { memo, useCallback, useDeferredValue, useEffect, useMemo, useRef, useState } from "react";
 import { useShallow } from "zustand/react/shallow";
-import { Virtuoso, VirtuosoHandle } from "react-virtuoso";
+import { Virtuoso, type VirtuosoHandle } from "react-virtuoso";
 import { cn } from "@/lib/utils";
 import { Button } from "@/components/ui/button";
-import { useLogsStore, filterLogs, collapseConsecutiveDuplicates } from "@/store";
+import {
+  useLogsStore,
+  filterLogs,
+  collapseConsecutiveDuplicates,
+  type DisplayEntry,
+} from "@/store";
 import { LogEntry, type LogEntryCopyMeta } from "../Logs/LogEntry";
 import { LogFilters } from "../Logs/LogFilters";
 import type { LogEntry as LogEntryType, LogLevel } from "@/types";
@@ -31,6 +36,34 @@ function extractElectronVersion(): string {
     return "unknown";
   }
 }
+
+interface LogEntryRowProps {
+  display: DisplayEntry;
+  copyMeta: LogEntryCopyMeta;
+  isExpanded: boolean;
+  toggleExpanded: (id: string) => void;
+}
+
+const LogEntryRow = memo(function LogEntryRow({
+  display,
+  copyMeta,
+  isExpanded,
+  toggleExpanded,
+}: LogEntryRowProps) {
+  const onToggle = useCallback(
+    () => toggleExpanded(display.entry.id),
+    [toggleExpanded, display.entry.id]
+  );
+  return (
+    <LogEntry
+      entry={display.entry}
+      count={display.count}
+      copyMeta={copyMeta}
+      isExpanded={isExpanded}
+      onToggle={onToggle}
+    />
+  );
+});
 
 export function LogsContent({ className, onSourcesChange }: LogsContentProps) {
   const {
@@ -164,6 +197,7 @@ export function LogsContent({ className, onSourcesChange }: LogsContentProps) {
   );
 
   const displayEntries = useMemo(() => collapseConsecutiveDuplicates(mainLogs), [mainLogs]);
+  const deferredDisplayEntries = useDeferredValue(displayEntries);
 
   const handleAtBottomChange = useCallback(
     (bottom: boolean) => {
@@ -237,17 +271,16 @@ export function LogsContent({ className, onSourcesChange }: LogsContentProps) {
         ) : (
           <Virtuoso
             ref={virtuosoRef}
-            data={displayEntries}
+            data={deferredDisplayEntries}
             followOutput={autoScroll ? "smooth" : false}
             atBottomStateChange={handleAtBottomChange}
             computeItemKey={(_index, display) => display.entry.id}
             itemContent={(_index, display) => (
-              <LogEntry
-                entry={display.entry}
-                count={display.count}
+              <LogEntryRow
+                display={display}
                 copyMeta={copyMeta}
                 isExpanded={expandedIds.has(display.entry.id)}
-                onToggle={() => toggleExpanded(display.entry.id)}
+                toggleExpanded={toggleExpanded}
               />
             )}
             className="absolute inset-0 overflow-y-auto overflow-x-hidden font-mono"

--- a/src/components/EventInspector/EventDetail.tsx
+++ b/src/components/EventInspector/EventDetail.tsx
@@ -1,4 +1,4 @@
-import { useState, useEffect, useRef } from "react";
+import { useState, useEffect, useMemo, useRef } from "react";
 import { cn } from "@/lib/utils";
 import { useEventStore, type EventRecord, type EventFilterOptions } from "@/store/eventStore";
 import { Copy, Check, ChevronDown, ChevronRight, Filter, X } from "lucide-react";
@@ -68,6 +68,11 @@ export function EventDetail({ event, className }: EventDetailProps) {
     setFilters({ [key]: newValue });
   };
 
+  const formattedPayload = useMemo(
+    () => (event ? JSON.stringify(event.payload, null, 2) : ""),
+    [event]
+  );
+
   useEffect(() => {
     setCopied(false);
     if (copyTimeoutRef.current) {
@@ -103,8 +108,7 @@ export function EventDetail({ event, className }: EventDetailProps) {
 
   const copyPayload = async () => {
     try {
-      const payloadStr = JSON.stringify(event.payload, null, 2);
-      await navigator.clipboard.writeText(payloadStr);
+      await navigator.clipboard.writeText(formattedPayload);
       setCopied(true);
 
       if (copyTimeoutRef.current) {
@@ -231,7 +235,7 @@ export function EventDetail({ event, className }: EventDetailProps) {
         {expandedSections.has("payload") && (
           <div className="flex-1 overflow-auto px-4 pb-3">
             <pre className="text-xs font-mono bg-muted/50 p-3 rounded overflow-x-auto select-text">
-              {JSON.stringify(event.payload, null, 2)}
+              {formattedPayload}
             </pre>
           </div>
         )}

--- a/src/components/EventInspector/EventFilters.tsx
+++ b/src/components/EventInspector/EventFilters.tsx
@@ -38,6 +38,24 @@ export function EventFilters({ events, filters, onFiltersChange, className }: Ev
     setTraceIdInput(filters.traceId || "");
   }, [filters.traceId]);
 
+  useEffect(() => {
+    const next = searchInput || undefined;
+    if (next === filters.search) return;
+    const timer = setTimeout(() => {
+      onFiltersChange({ ...filters, search: next });
+    }, 200);
+    return () => clearTimeout(timer);
+  }, [searchInput, filters, onFiltersChange]);
+
+  useEffect(() => {
+    const next = traceIdInput.trim().toLowerCase() || undefined;
+    if (next === filters.traceId) return;
+    const timer = setTimeout(() => {
+      onFiltersChange({ ...filters, traceId: next });
+    }, 200);
+    return () => clearTimeout(timer);
+  }, [traceIdInput, filters, onFiltersChange]);
+
   const categoryCounts = useMemo(() => {
     const counts = new Map<EventCategory, number>();
     events.forEach((event) => {
@@ -95,24 +113,18 @@ export function EventFilters({ events, filters, onFiltersChange, className }: Ev
 
   const handleSearchChange = (value: string) => {
     setSearchInput(value);
-    onFiltersChange({ ...filters, search: value || undefined });
   };
 
   const clearSearch = () => {
     setSearchInput("");
-    onFiltersChange({ ...filters, search: undefined });
   };
 
   const handleTraceIdChange = (value: string) => {
     setTraceIdInput(value);
-    // Normalize: trim whitespace and lowercase for more forgiving matching
-    const normalized = value.trim().toLowerCase();
-    onFiltersChange({ ...filters, traceId: normalized || undefined });
   };
 
   const clearTraceId = () => {
     setTraceIdInput("");
-    onFiltersChange({ ...filters, traceId: undefined });
   };
 
   const toggleCategoryFilter = (category: EventCategory) => {

--- a/src/components/EventInspector/EventTimeline.tsx
+++ b/src/components/EventInspector/EventTimeline.tsx
@@ -1,5 +1,5 @@
-import { useRef, useCallback, useState } from "react";
-import { Virtuoso, VirtuosoHandle } from "react-virtuoso";
+import { memo, useCallback, useEffect, useRef, useState } from "react";
+import { Virtuoso, type VirtuosoHandle } from "react-virtuoso";
 import { cn } from "@/lib/utils";
 import type { EventRecord, EventCategory } from "@/store/eventStore";
 import { Circle } from "lucide-react";
@@ -16,6 +16,93 @@ interface EventTimelineProps {
   className?: string;
 }
 
+interface CategoryStyle {
+  label: string;
+  color: string;
+}
+
+function formatTimestamp(timestamp: number): string {
+  const date = new Date(timestamp);
+  const hours = date.getHours().toString().padStart(2, "0");
+  const minutes = date.getMinutes().toString().padStart(2, "0");
+  const seconds = date.getSeconds().toString().padStart(2, "0");
+  const ms = date.getMilliseconds().toString().padStart(3, "0");
+  return `${hours}:${minutes}:${seconds}.${ms}`;
+}
+
+function getCategoryStyle(category: EventCategory): CategoryStyle {
+  const style = EVENT_CATEGORY_STYLES[category];
+  if (!style) {
+    return {
+      label: "???",
+      color: "bg-daintree-border/20 text-daintree-text/60 border-daintree-border/30",
+    };
+  }
+  return { label: style.shortLabel, color: style.color };
+}
+
+function getPayloadSummary(event: EventRecord): string {
+  const { payload } = event;
+  if (!payload || typeof payload !== "object") return "";
+
+  const parts: string[] = [];
+  if (payload.worktreeId) parts.push(`worktree: ${String(payload.worktreeId).substring(0, 8)}`);
+  if (payload.agentId) parts.push(`agent: ${String(payload.agentId).substring(0, 8)}`);
+  if (payload.taskId) parts.push(`task: ${String(payload.taskId).substring(0, 8)}`);
+  if (payload.runId) parts.push(`run: ${String(payload.runId).substring(0, 8)}`);
+  if (payload.terminalId) parts.push(`terminal: ${String(payload.terminalId).substring(0, 8)}`);
+
+  return parts.length > 0 ? parts.join(" • ") : "";
+}
+
+interface EventRowProps {
+  event: EventRecord;
+  isSelected: boolean;
+  onSelect: (id: string) => void;
+}
+
+const EventRow = memo(function EventRow({ event, isSelected, onSelect }: EventRowProps) {
+  const categoryStyle = getCategoryStyle(event.category);
+  const summary = getPayloadSummary(event);
+  const handleClick = useCallback(() => onSelect(event.id), [onSelect, event.id]);
+
+  return (
+    <button
+      onClick={handleClick}
+      className={cn(
+        "w-full text-left px-3 py-2 hover:bg-muted/50 transition-colors",
+        "border-l-2 border-transparent",
+        isSelected && "bg-muted border-l-primary"
+      )}
+    >
+      <div className="flex items-start gap-2">
+        <Tooltip>
+          <TooltipTrigger asChild>
+            <span
+              className={cn(
+                "flex-shrink-0 inline-flex items-center justify-center w-8 px-1 py-0.5 rounded text-[11px] font-medium border",
+                categoryStyle.color
+              )}
+            >
+              {categoryStyle.label}
+            </span>
+          </TooltipTrigger>
+          <TooltipContent side="bottom">{event.category}</TooltipContent>
+        </Tooltip>
+        <div className="flex-1 min-w-0 space-y-1">
+          <div className="flex items-center gap-2">
+            <span className="font-mono text-xs text-muted-foreground">
+              {formatTimestamp(event.timestamp)}
+            </span>
+            <span className="text-xs font-mono text-foreground truncate">{event.type}</span>
+          </div>
+          {summary && <p className="text-xs text-muted-foreground font-mono truncate">{summary}</p>}
+        </div>
+      </div>
+    </button>
+  );
+});
+
 export function EventTimeline({
   events,
   selectedId,
@@ -26,58 +113,46 @@ export function EventTimeline({
 }: EventTimelineProps) {
   const virtuosoRef = useRef<VirtuosoHandle>(null);
   const [atBottom, setAtBottom] = useState(true);
+  const [newCount, setNewCount] = useState(0);
+  const pauseBoundaryTsRef = useRef<number | undefined>(undefined);
 
   const handleAtBottomChange = useCallback(
     (bottom: boolean) => {
       setAtBottom(bottom);
-      if (!bottom && autoScroll) {
-        onAutoScrollChange?.(false);
+      if (bottom) {
+        setNewCount(0);
+        pauseBoundaryTsRef.current = undefined;
+      } else {
+        pauseBoundaryTsRef.current = events[events.length - 1]?.timestamp;
+        if (autoScroll) onAutoScrollChange?.(false);
       }
     },
-    [autoScroll, onAutoScrollChange]
+    [autoScroll, onAutoScrollChange, events]
   );
+
+  useEffect(() => {
+    if (atBottom) return;
+    const boundaryTs = pauseBoundaryTsRef.current;
+    if (boundaryTs === undefined) {
+      setNewCount(0);
+      return;
+    }
+    let count = 0;
+    for (const event of events) {
+      if (event.timestamp > boundaryTs) count++;
+    }
+    setNewCount(count);
+  }, [events, atBottom]);
 
   const scrollToBottom = useCallback(() => {
     onAutoScrollChange?.(true);
+    setNewCount(0);
+    pauseBoundaryTsRef.current = undefined;
     virtuosoRef.current?.scrollToIndex({
       index: "LAST",
       behavior: "smooth",
     });
   }, [onAutoScrollChange]);
-
-  const formatTimestamp = (timestamp: number) => {
-    const date = new Date(timestamp);
-    const hours = date.getHours().toString().padStart(2, "0");
-    const minutes = date.getMinutes().toString().padStart(2, "0");
-    const seconds = date.getSeconds().toString().padStart(2, "0");
-    const ms = date.getMilliseconds().toString().padStart(3, "0");
-    return `${hours}:${minutes}:${seconds}.${ms}`;
-  };
-
-  const getCategoryStyle = (category: EventCategory) => {
-    const style = EVENT_CATEGORY_STYLES[category];
-    if (!style)
-      return {
-        label: "???",
-        color: "bg-daintree-border/20 text-daintree-text/60 border-daintree-border/30",
-      };
-    return { label: style.shortLabel, color: style.color };
-  };
-
-  const getPayloadSummary = (event: EventRecord): string => {
-    const { payload } = event;
-    if (!payload || typeof payload !== "object") return "";
-
-    // Extract relevant IDs for display
-    const parts: string[] = [];
-    if (payload.worktreeId) parts.push(`worktree: ${String(payload.worktreeId).substring(0, 8)}`);
-    if (payload.agentId) parts.push(`agent: ${String(payload.agentId).substring(0, 8)}`);
-    if (payload.taskId) parts.push(`task: ${String(payload.taskId).substring(0, 8)}`);
-    if (payload.runId) parts.push(`run: ${String(payload.runId).substring(0, 8)}`);
-    if (payload.terminalId) parts.push(`terminal: ${String(payload.terminalId).substring(0, 8)}`);
-
-    return parts.length > 0 ? parts.join(" • ") : "";
-  };
 
   if (events.length === 0) {
     return (
@@ -96,59 +171,17 @@ export function EventTimeline({
     );
   }
 
-  const renderEvent = (_index: number, event: EventRecord) => {
-    const categoryStyle = getCategoryStyle(event.category);
-    const isSelected = event.id === selectedId;
-    const summary = getPayloadSummary(event);
-
-    return (
-      <button
-        key={event.id}
-        onClick={() => onSelectEvent(event.id)}
-        className={cn(
-          "w-full text-left px-3 py-2 hover:bg-muted/50 transition-colors",
-          "border-l-2 border-transparent",
-          isSelected && "bg-muted border-l-primary"
-        )}
-      >
-        <div className="flex items-start gap-2">
-          <Tooltip>
-            <TooltipTrigger asChild>
-              <span
-                className={cn(
-                  "flex-shrink-0 inline-flex items-center justify-center w-8 px-1 py-0.5 rounded text-[11px] font-medium border",
-                  categoryStyle.color
-                )}
-              >
-                {categoryStyle.label}
-              </span>
-            </TooltipTrigger>
-            <TooltipContent side="bottom">{event.category}</TooltipContent>
-          </Tooltip>
-          <div className="flex-1 min-w-0 space-y-1">
-            <div className="flex items-center gap-2">
-              <span className="font-mono text-xs text-muted-foreground">
-                {formatTimestamp(event.timestamp)}
-              </span>
-              <span className="text-xs font-mono text-foreground truncate">{event.type}</span>
-            </div>
-            {summary && (
-              <p className="text-xs text-muted-foreground font-mono truncate">{summary}</p>
-            )}
-          </div>
-        </div>
-      </button>
-    );
-  };
-
   return (
     <div className={cn("flex-1 relative", className)}>
       <Virtuoso
         ref={virtuosoRef}
         data={events}
+        computeItemKey={(_index, event) => event.id}
         followOutput={autoScroll ? "smooth" : false}
         atBottomStateChange={handleAtBottomChange}
-        itemContent={renderEvent}
+        itemContent={(_index, event) => (
+          <EventRow event={event} isSelected={event.id === selectedId} onSelect={onSelectEvent} />
+        )}
         className="h-full"
       />
 
@@ -156,10 +189,11 @@ export function EventTimeline({
         <Button
           variant="info"
           size="sm"
-          className="absolute bottom-4 right-4 rounded-full shadow-[var(--theme-shadow-floating)]"
+          className="absolute bottom-4 right-4 rounded-full shadow-[var(--theme-shadow-floating)] tabular-nums"
           onClick={scrollToBottom}
+          aria-label={newCount > 0 ? `Resume tail, ${newCount} new` : "Scroll to bottom"}
         >
-          Scroll to bottom
+          {newCount > 0 ? `↓ ${newCount} new` : "Scroll to bottom"}
         </Button>
       )}
     </div>

--- a/src/store/__tests__/logsStore.test.ts
+++ b/src/store/__tests__/logsStore.test.ts
@@ -139,15 +139,29 @@ describe("filterLogs — search tokens", () => {
     expect(result.map((l) => l.id)).toEqual(["log-10"]);
   });
 
-  it("leaves hyphenated context keys in the remainder text", () => {
+  it("matches hyphenated context keys via context.<path>: tokens", () => {
     const hyphenLogs: LogEntry[] = [
       makeLogExplicit(0, {
         level: "info",
-        message: "context.request-id:abc123 payload received",
+        message: "request handled",
+        context: { "request-id": "abc123" },
       }),
-      makeLogExplicit(1, { level: "info", message: "other event" }),
+      makeLogExplicit(1, {
+        level: "info",
+        message: "request handled",
+        context: { "request-id": "xyz789" },
+      }),
     ];
     const result = filterLogs(hyphenLogs, { search: "context.request-id:abc123" });
+    expect(result.map((l) => l.id)).toEqual(["log-0"]);
+  });
+
+  it("strips all occurrences of duplicated tokens from the remainder text", () => {
+    const dupLogs: LogEntry[] = [
+      makeLogExplicit(0, { level: "error", message: "boom" }),
+      makeLogExplicit(1, { level: "error", message: "level:error inside the message" }),
+    ];
+    const result = filterLogs(dupLogs, { search: "level:error level:error boom" });
     expect(result.map((l) => l.id)).toEqual(["log-0"]);
   });
 });

--- a/src/store/logsStore.ts
+++ b/src/store/logsStore.ts
@@ -16,16 +16,13 @@ interface ParsedSearch {
   text: string;
 }
 
-// Keys are `\w+` only (alphanumerics + underscore). Hyphenated keys like `request-id`
-// won't be captured — `context.request-id:val` would parse as `id:val` and fall through
-// the unknown-key branch, leaving the full token in the remainder text.
-const TOKEN_REGEX = /(\w+(?:\.\w+)*):("[^"]*"|\S+)/g;
+const TOKEN_REGEX = /([\w-]+(?:\.[\w-]+)*):("[^"]*"|\S+)/g;
 
 function parseSearchTokens(search: string): ParsedSearch {
   const levels: LogLevel[] = [];
   const sources: string[] = [];
   const contextMatchers: { path: string[]; value: string }[] = [];
-  let text = search;
+  const consumed: { start: number; end: number }[] = [];
 
   const matches = [...search.matchAll(TOKEN_REGEX)];
   for (const match of matches) {
@@ -46,7 +43,15 @@ function parseSearchTokens(search: string): ParsedSearch {
     } else {
       continue;
     }
-    text = text.replace(match[0], "");
+    if (match.index !== undefined) {
+      consumed.push({ start: match.index, end: match.index + match[0].length });
+    }
+  }
+
+  let text = search;
+  consumed.sort((a, b) => b.start - a.start);
+  for (const span of consumed) {
+    text = text.slice(0, span.start) + text.slice(span.end);
   }
 
   return {


### PR DESCRIPTION
## Summary

- Adds `computeItemKey` and a memo'd row component to `EventTimeline` so `.slice(-MAX_EVENTS)` trimming no longer remounts visible rows, and mirrors the "↓ N new" counter from `LogsContent` onto the timeline scroll button.
- `LogsContent` now wraps filtered output in `useDeferredValue` and routes rows through a memo'd `LogEntryRow` with a stable per-id `onToggle` from the Zustand action — cutting per-expand re-renders across all visible rows.
- `EventFilters` adds a 200ms debounce on search and trace-ID inputs (matching `LogFilters`), so `getFilteredEvents` — which `JSON.stringify`s payload per event — no longer fires on every keystroke; `EventsContent` passes `setFilters` (the Zustand action) directly instead of an inline arrow so the debounce timers actually complete.
- `EventDetail` memoizes `JSON.stringify(event.payload, null, 2)` so render and clipboard share one cached string; `logsStore.parseSearchTokens` now accepts hyphens in token keys (`context.request-id:val` parses correctly) and splices matched tokens by reverse index to prevent duplicates leaking into the remainder.

Resolves #7267

## Changes

- `EventTimeline.tsx` — `computeItemKey`, memo'd `EventRow`, "↓ N new" counter, `VirtuosoHandle` type-only import
- `LogsContent.tsx` — `useDeferredValue`, memo'd `LogEntryRow` with stable `onToggle`, `VirtuosoHandle` type-only import
- `EventFilters.tsx` — 200ms debounce on search + trace-ID inputs
- `EventsContent.tsx` — pass `setFilters` directly (no inline arrow)
- `EventDetail.tsx` — `useMemo` on `JSON.stringify` call
- `logsStore.ts` — hyphen support in token-key regex, reverse-index splice for matched tokens
- `logsStore.test.ts` — replace hyphen assertion with context-match, add duplicate-token stripping test

## Testing

- Unit tests pass (`parseSearchTokens` hyphen + duplicate cases covered by new assertions)
- Manual spot-check: rapid typing in event filter search no longer blocks the UI; expand-toggle on a log entry no longer re-renders sibling rows; front-trimmed event list keeps row identity stable