### PR TITLE
chore(types): extract IPC inline shapes, label tuple args, add high-frequency exclusion guard

### DIFF
--- a/shared/types/__tests__/ipcEnvelopeConstraint.test.ts
+++ b/shared/types/__tests__/ipcEnvelopeConstraint.test.ts
@@ -1,5 +1,7 @@
-import { describe, it, expectTypeOf } from "vitest";
+import { describe, it, expect, expectTypeOf } from "vitest";
+import { isIpcEnvelope } from "../ipc/errors.js";
 import type { ForbidIpcEnvelopeKeys, IpcHandlerEnvelopeViolation } from "../ipc/errors.js";
+import type { _IpcEventBusMapExcludesHighFrequency } from "../ipc/maps.js";
 
 describe("ForbidIpcEnvelopeKeys", () => {
   it("passes through primitive results unchanged", () => {
@@ -73,5 +75,58 @@ describe("ForbidIpcEnvelopeKeys", () => {
     // so `tsc` surfaces it directly: 'Property "...message..." is missing'.
     type Hint = keyof IpcHandlerEnvelopeViolation;
     expectTypeOf<Hint>().toEqualTypeOf<"IPC handler must throw new AppError(...) instead of returning {ok|success: ...} — see #6020">();
+  });
+});
+
+describe("IpcEventBusMap high-frequency exclusion", () => {
+  it("rejects high-frequency channels (terminal:data, terminal:resource-metrics, logs:batch)", () => {
+    // Compile-time guard — collapses to `never` if any banned key appears in
+    // IpcEventBusMap, breaking this assertion.
+    expectTypeOf<_IpcEventBusMapExcludesHighFrequency>().toEqualTypeOf<true>();
+  });
+});
+
+describe("isIpcEnvelope", () => {
+  it("accepts a well-formed success envelope (data: undefined for void results)", () => {
+    expect(isIpcEnvelope({ __daintreeIpcEnvelope: true, ok: true, data: undefined })).toBe(true);
+    expect(isIpcEnvelope({ __daintreeIpcEnvelope: true, ok: true, data: 42 })).toBe(true);
+  });
+
+  it("accepts a well-formed error envelope", () => {
+    expect(
+      isIpcEnvelope({
+        __daintreeIpcEnvelope: true,
+        ok: false,
+        error: { name: "Error", message: "boom" },
+      })
+    ).toBe(true);
+  });
+
+  it("rejects envelopes missing the boolean ok discriminator", () => {
+    expect(isIpcEnvelope({ __daintreeIpcEnvelope: true, data: 1 })).toBe(false);
+    expect(isIpcEnvelope({ __daintreeIpcEnvelope: true, ok: "true", data: 1 })).toBe(false);
+  });
+
+  it("rejects envelopes missing the matching payload field for the discriminator", () => {
+    expect(isIpcEnvelope({ __daintreeIpcEnvelope: true, ok: true })).toBe(false);
+    expect(isIpcEnvelope({ __daintreeIpcEnvelope: true, ok: false })).toBe(false);
+  });
+
+  it("rejects cross-discriminator envelopes (ok mismatched with payload field)", () => {
+    expect(
+      isIpcEnvelope({
+        __daintreeIpcEnvelope: true,
+        ok: true,
+        error: { name: "Error", message: "boom" },
+      })
+    ).toBe(false);
+    expect(isIpcEnvelope({ __daintreeIpcEnvelope: true, ok: false, data: 1 })).toBe(false);
+  });
+
+  it("rejects non-object inputs", () => {
+    expect(isIpcEnvelope(null)).toBe(false);
+    expect(isIpcEnvelope(undefined)).toBe(false);
+    expect(isIpcEnvelope("envelope")).toBe(false);
+    expect(isIpcEnvelope(42)).toBe(false);
   });
 });

--- a/shared/types/ipc/errors.ts
+++ b/shared/types/ipc/errors.ts
@@ -25,8 +25,17 @@ export interface SerializedError {
   errno?: number;
   syscall?: string;
   path?: string;
+  /**
+   * Free-form diagnostic context. Values must be structured-clone-safe —
+   * primitives, plain objects, arrays, or `null`. Map, Set, Date, and class
+   * instances are not preserved across the IPC boundary.
+   */
   context?: Record<string, unknown>;
   cause?: SerializedError;
+  /**
+   * Additional error fields copied from the original Error subclass. Same
+   * structured-clone-safe constraint as {@link SerializedError.context}.
+   */
   properties?: Record<string, unknown>;
 }
 
@@ -45,11 +54,14 @@ export interface IpcErrorEnvelope {
 export type IpcEnvelope<T = unknown> = IpcSuccessEnvelope<T> | IpcErrorEnvelope;
 
 export function isIpcEnvelope(value: unknown): value is IpcEnvelope {
-  return (
-    value !== null &&
-    typeof value === "object" &&
-    (value as Record<string, unknown>).__daintreeIpcEnvelope === true
-  );
+  if (value === null || typeof value !== "object") {
+    return false;
+  }
+  const candidate = value as Record<string, unknown>;
+  if (candidate.__daintreeIpcEnvelope !== true || typeof candidate.ok !== "boolean") {
+    return false;
+  }
+  return candidate.ok ? "data" in candidate : "error" in candidate;
 }
 
 /**

--- a/shared/types/ipc/maps.ts
+++ b/shared/types/ipc/maps.ts
@@ -538,11 +538,11 @@ export interface IpcInvokeMap {
     result: AgentUpdateSettings;
   };
   "system:set-agent-update-settings": {
-    args: [AgentUpdateSettings];
+    args: [settings: AgentUpdateSettings];
     result: void;
   };
   "system:start-agent-update": {
-    args: [StartAgentUpdatePayload];
+    args: [payload: StartAgentUpdatePayload];
     result: StartAgentUpdateResult;
   };
   "setup:agent-install": {
@@ -563,7 +563,7 @@ export interface IpcInvokeMap {
     result: DiagnosticsReviewPayload;
   };
   "system:save-diagnostics-bundle": {
-    args: [DiagnosticsBundleSavePayload];
+    args: [payload: DiagnosticsBundleSavePayload];
     result: boolean;
   };
   "system:get-app-metrics": {
@@ -1500,40 +1500,18 @@ export interface IpcInvokeMap {
   // Notification settings channels
   "notification:settings-get": {
     args: [];
-    result: {
-      completedEnabled: boolean;
-      waitingEnabled: boolean;
-      soundEnabled: boolean;
-      completedSoundFile: string;
-      waitingSoundFile: string;
-      escalationSoundFile: string;
-      waitingEscalationEnabled: boolean;
-      waitingEscalationDelayMs: number;
-      uiFeedbackSoundEnabled: boolean;
-    };
+    result: NotificationSettings;
   };
   "notification:settings-set": {
-    args: [
-      Partial<{
-        completedEnabled: boolean;
-        waitingEnabled: boolean;
-        soundEnabled: boolean;
-        completedSoundFile: string;
-        waitingSoundFile: string;
-        escalationSoundFile: string;
-        waitingEscalationEnabled: boolean;
-        waitingEscalationDelayMs: number;
-        uiFeedbackSoundEnabled: boolean;
-      }>,
-    ];
+    args: [settings: Partial<NotificationSettings>];
     result: void;
   };
   "notification:play-sound": {
-    args: [string];
+    args: [soundFile: string];
     result: void;
   };
   "sound:play-ui-event": {
-    args: [string];
+    args: [eventId: string];
     result: void;
   };
 
@@ -1802,30 +1780,15 @@ export interface IpcInvokeMap {
   // MCP Server channels
   "mcp-server:get-status": {
     args: [];
-    result: {
-      enabled: boolean;
-      port: number | null;
-      configuredPort: number | null;
-      apiKey: string;
-    };
+    result: import("./mcpServer.js").McpServerStatusSnapshot;
   };
   "mcp-server:set-enabled": {
     args: [enabled: boolean];
-    result: {
-      enabled: boolean;
-      port: number | null;
-      configuredPort: number | null;
-      apiKey: string;
-    };
+    result: import("./mcpServer.js").McpServerStatusSnapshot;
   };
   "mcp-server:set-port": {
     args: [port: number | null];
-    result: {
-      enabled: boolean;
-      port: number | null;
-      configuredPort: number | null;
-      apiKey: string;
-    };
+    result: import("./mcpServer.js").McpServerStatusSnapshot;
   };
   "mcp-server:rotate-api-key": {
     args: [];
@@ -2648,6 +2611,21 @@ export type IpcEventBusMap = Pick<
   | "terminal:reliability-metric"
   | "terminal:status"
 >;
+
+/**
+ * Compile-time guard: high-frequency / binary-payload channels documented above
+ * as excluded by design must never end up in {@link IpcEventBusMap}. Resolves
+ * to `true` when the exclusion holds; flips to `never` (and breaks the
+ * dependent test in `__tests__/ipcEnvelopeConstraint.test.ts`) the moment one
+ * of the banned keys is added to the `Pick<>` list above.
+ */
+export type _IpcEventBusMapExcludesHighFrequency =
+  Extract<
+    keyof IpcEventBusMap,
+    "terminal:data" | "terminal:resource-metrics" | "logs:batch"
+  > extends never
+    ? true
+    : never;
 
 /**
  * Envelope carried on CHANNELS.EVENTS_PUSH. Discriminated by `name` so the

--- a/shared/types/ipc/mcpServer.ts
+++ b/shared/types/ipc/mcpServer.ts
@@ -85,3 +85,17 @@ export interface McpRuntimeSnapshot {
   /** Most recent failure reason, if any. Cleared on successful start. */
   lastError: string | null;
 }
+
+/**
+ * Compact status snapshot returned by the synchronous `mcp-server:get-status`,
+ * `mcp-server:set-enabled`, and `mcp-server:set-port` IPC channels. Distinct
+ * from {@link McpRuntimeSnapshot} (which carries the coarse readiness state
+ * surfaced via the async event stream): this shape conveys just the persisted
+ * configuration plus the currently bound port.
+ */
+export interface McpServerStatusSnapshot {
+  enabled: boolean;
+  port: number | null;
+  configuredPort: number | null;
+  apiKey: string;
+}

--- a/shared/types/terminal-output-worker-messages.ts
+++ b/shared/types/terminal-output-worker-messages.ts
@@ -1,4 +1,4 @@
-export type WorkerInboundMessage =
+export type TerminalOutputWorkerInboundMessage =
   | {
       type: "INIT_BUFFER";
       buffers: SharedArrayBuffer[];
@@ -8,7 +8,7 @@ export type WorkerInboundMessage =
   | { type: "RESET_TERMINAL"; id: string }
   | { type: "STOP" };
 
-export type WorkerOutboundMessage = {
+export type TerminalOutputWorkerOutboundMessage = {
   type: "OUTPUT_BATCH";
   batches: Array<{ id: string; data: string | Uint8Array }>;
 };

--- a/shared/types/worker-messages.ts
+++ b/shared/types/worker-messages.ts
@@ -50,7 +50,7 @@ export interface WorkerPongMessage {
 }
 
 /** All messages from worker to main thread */
-export type WorkerOutboundMessage =
+export type SemanticWorkerOutboundMessage =
   | WorkerArtifactDetectedMessage
   | WorkerStateChangedMessage
   | WorkerReadyMessage
@@ -101,7 +101,7 @@ export interface MainResetMessage {
 }
 
 /** All messages from main thread to worker */
-export type WorkerInboundMessage =
+export type SemanticWorkerInboundMessage =
   | MainInitBufferMessage
   | MainRegisterTerminalMessage
   | MainUnregisterTerminalMessage

--- a/src/services/SemanticAnalysisService.ts
+++ b/src/services/SemanticAnalysisService.ts
@@ -8,8 +8,8 @@
 import type { AgentState } from "../../shared/types/agent.js";
 import type { Artifact } from "../../shared/types/ipc.js";
 import type {
-  WorkerOutboundMessage,
-  WorkerInboundMessage,
+  SemanticWorkerOutboundMessage,
+  SemanticWorkerInboundMessage,
 } from "../../shared/types/worker-messages.js";
 import { logDebug, logWarn, logError } from "@/utils/logger";
 import { formatErrorMessage } from "@shared/utils/errorMessage";
@@ -120,7 +120,7 @@ class SemanticAnalysisService {
   private setupMessageHandler(): void {
     if (!this.worker) return;
 
-    this.worker.onmessage = (event: MessageEvent<WorkerOutboundMessage>) => {
+    this.worker.onmessage = (event: MessageEvent<SemanticWorkerOutboundMessage>) => {
       const message = event.data;
 
       switch (message.type) {
@@ -219,7 +219,7 @@ class SemanticAnalysisService {
   /**
    * Post a message to the worker.
    */
-  private postMessage(message: WorkerInboundMessage): void {
+  private postMessage(message: SemanticWorkerInboundMessage): void {
     if (!this.worker) {
       logWarn("[SemanticAnalysisService] Cannot post message — worker not initialized");
       return;

--- a/src/services/terminal/TerminalOutputIngestService.ts
+++ b/src/services/terminal/TerminalOutputIngestService.ts
@@ -1,4 +1,4 @@
-import type { WorkerInboundMessage } from "@shared/types/terminal-output-worker-messages";
+import type { TerminalOutputWorkerInboundMessage } from "@shared/types/terminal-output-worker-messages";
 import { PERF_MARKS } from "@shared/perf/marks";
 import { markRendererPerformance } from "@/utils/performance";
 import { logDebug } from "@/utils/logger";
@@ -80,7 +80,7 @@ export class TerminalOutputIngestService {
   public resetForTerminal(id: string): void {
     this.clearQueue(id);
     if (!this.pollingActive || !this.worker) return;
-    const message: WorkerInboundMessage = {
+    const message: TerminalOutputWorkerInboundMessage = {
       type: "RESET_TERMINAL",
       id,
     };
@@ -90,7 +90,7 @@ export class TerminalOutputIngestService {
   public flushForTerminal(id: string): void {
     this.forceDrain(id);
     if (!this.pollingActive || !this.worker) return;
-    const message: WorkerInboundMessage = {
+    const message: TerminalOutputWorkerInboundMessage = {
       type: "FLUSH_TERMINAL",
       id,
     };
@@ -104,7 +104,7 @@ export class TerminalOutputIngestService {
     this.pollingActive = false;
     this.sabAvailable = false;
     if (!this.worker) return;
-    const message: WorkerInboundMessage = {
+    const message: TerminalOutputWorkerInboundMessage = {
       type: "STOP",
     };
     this.worker.postMessage(message);

--- a/src/workers/semantic.worker.ts
+++ b/src/workers/semantic.worker.ts
@@ -15,8 +15,8 @@ import {
   type AgentEvent,
 } from "./WorkerAgentStateService.js";
 import type {
-  WorkerInboundMessage,
-  WorkerOutboundMessage,
+  SemanticWorkerInboundMessage,
+  SemanticWorkerOutboundMessage,
   WorkerTerminalState,
 } from "../../shared/types/worker-messages.js";
 import { formatErrorMessage } from "../../shared/utils/errorMessage.js";
@@ -34,7 +34,7 @@ let isPolling = false;
 /**
  * Send a typed message to the main thread.
  */
-function postTypedMessage(message: WorkerOutboundMessage): void {
+function postTypedMessage(message: SemanticWorkerOutboundMessage): void {
   self.postMessage(message);
 }
 
@@ -179,7 +179,7 @@ function startPolling(): void {
 /**
  * Handle messages from the main thread.
  */
-self.onmessage = (event: MessageEvent<WorkerInboundMessage>) => {
+self.onmessage = (event: MessageEvent<SemanticWorkerInboundMessage>) => {
   const message = event.data;
 
   switch (message.type) {


### PR DESCRIPTION
## Summary

Pure type-system cleanup in `shared/types/ipc/` — no runtime behavior changes except a tightened `isIpcEnvelope` guard. Extracts named types from inline shapes, labels unlabeled tuple args, renames clashing worker message unions, and adds compile-time + runtime safeguards.

Resolves #7281

## Changes

- Extract `McpServerStatusSnapshot` in `shared/types/ipc/mcpServer.ts` and reference it from the three `mcp-server:*` channels in `maps.ts` — was three identical inline 4-field shapes
- Replace drifted inline 9-field shapes for `notification:settings-get` (result) and `notification:settings-set` (args) with `NotificationSettings` and `Partial<NotificationSettings>` — the handler already returned/accepted the full 21-field type; this corrects the type-side drift
- Add labels to 5 unlabeled tuple args: `system:set-agent-update-settings`, `system:start-agent-update`, `system:save-diagnostics-bundle`, `notification:play-sound`, `sound:play-ui-event`
- Rename clashing worker message unions to prevent future barrel collision: `WorkerInboundMessage`/`WorkerOutboundMessage` → `SemanticWorker*Message` (`shared/types/worker-messages.ts`) and `TerminalOutputWorker*Message` (`shared/types/terminal-output-worker-messages.ts`); 3 import sites updated
- Strengthen `isIpcEnvelope` runtime guard with `typeof ok === "boolean"` plus cross-discriminator validation (`ok: true` requires `data`, `ok: false` requires `error`)
- Add exported `_IpcEventBusMapExcludesHighFrequency` compile-time guard in `maps.ts` asserting `terminal:data`, `terminal:resource-metrics`, `logs:batch` cannot enter the multiplexed event bus
- Add JSDoc to `SerializedError.context`/`.properties` documenting the structured-clone-safe value constraint
- Add 6 new vitest cases covering the strengthened guard + the compile-time exclusion assertion (15 total in `ipcEnvelopeConstraint.test.ts`)

## Testing

- `npm run typecheck` exits clean
- `npx vitest run shared/types/__tests__/ipcEnvelopeConstraint.test.ts` — 15 tests pass
- No new lint warnings (ratchet check: 869 vs 877 baseline)
- No worker rename leftovers (`grep -rn "\bWorkerInboundMessage\b\|\bWorkerOutboundMessage\b"` returns zero matches)
- Manual smoke: notification settings round-trip through IPC; MCP server status channels return snapshot