### PR TITLE
fix(project-add): tighten validation, NFC identity, error routing

### DIFF
--- a/electron/ipc/handlers/projectCrud/gitClone.ts
+++ b/electron/ipc/handlers/projectCrud/gitClone.ts
@@ -14,6 +14,7 @@ import type {
   CloneRepoProgressEvent,
 } from "../../../../shared/types/ipc/gitClone.js";
 import { formatErrorMessage } from "../../../../shared/utils/errorMessage.js";
+import { validateFolderName } from "../../../../shared/utils/folderName.js";
 import { AppError } from "../../../utils/errorTypes.js";
 
 export function registerGitCloneHandlers(): () => void {
@@ -45,19 +46,15 @@ export function registerGitCloneHandlers(): () => void {
     if (!path.isAbsolute(parentPath)) {
       throw new Error("Parent path must be absolute");
     }
-    if (typeof folderName !== "string" || !folderName.trim()) {
+    if (typeof folderName !== "string") {
       throw new Error("Folder name is required");
     }
 
-    const trimmedFolder = folderName.trim();
-    if (
-      trimmedFolder.includes("/") ||
-      trimmedFolder.includes("\\") ||
-      trimmedFolder === ".." ||
-      trimmedFolder === "."
-    ) {
-      throw new Error("Folder name must not contain path separators or dot segments");
+    const folderNameError = validateFolderName(folderName);
+    if (folderNameError) {
+      throw new Error(folderNameError);
     }
+    const trimmedFolder = folderName.trim();
 
     const targetPath = path.join(parentPath, trimmedFolder);
     const normalizedParent = path.resolve(parentPath);

--- a/electron/ipc/handlers/projectCrud/settings.ts
+++ b/electron/ipc/handlers/projectCrud/settings.ts
@@ -19,6 +19,7 @@ async function getRunCommandDetector(): Promise<
   return cachedRunCommandDetector;
 }
 import { typedHandle } from "../../utils.js";
+import { validateFolderName } from "../../../../shared/utils/folderName.js";
 import type { ProjectSettings } from "../../../types/index.js";
 
 export function registerProjectSettingsHandlers(): () => void {
@@ -103,18 +104,18 @@ export function registerProjectSettingsHandlers(): () => void {
     if (typeof parentPath !== "string" || !parentPath.trim()) {
       throw new Error("Invalid parent path");
     }
-    if (typeof folderName !== "string" || !folderName.trim()) {
+    if (typeof folderName !== "string") {
       throw new Error("Folder name is required");
     }
     if (!path.isAbsolute(parentPath)) {
       throw new Error("Parent path must be absolute");
     }
 
-    const trimmed = folderName.trim();
-
-    if (trimmed.includes("/") || trimmed.includes("\\") || trimmed === ".." || trimmed === ".") {
-      throw new Error("Folder name must not contain path separators or dot segments");
+    const folderNameError = validateFolderName(folderName);
+    if (folderNameError) {
+      throw new Error(folderNameError);
     }
+    const trimmed = folderName.trim();
 
     const fs = await import("fs");
 

--- a/electron/services/ProjectStore.ts
+++ b/electron/services/ProjectStore.ts
@@ -12,7 +12,7 @@ import fs from "fs/promises";
 import { existsSync } from "fs";
 import { app } from "electron";
 import { GitService } from "./GitService.js";
-import { isDaintreeError } from "../utils/errorTypes.js";
+import { AppError, isDaintreeError } from "../utils/errorTypes.js";
 import { logError } from "../utils/logger.js";
 import { formatErrorMessage } from "../../shared/utils/errorMessage.js";
 import { store } from "../store.js";
@@ -167,13 +167,20 @@ export class ProjectStore {
       }
 
       if (lower.includes("not a git repository")) {
-        throw new Error(`Not a git repository: ${projectPath}`);
+        throw new AppError({
+          code: "NOT_A_GIT_REPO",
+          message: `Not a git repository: ${projectPath}`,
+        });
       }
 
       throw new Error(combined || "Failed to open project");
     }
 
-    const normalizedPath = path.normalize(gitRoot);
+    // NFC-normalize for dedup so a Finder-dragged NFD path and a typed NFC
+    // path map to the same project row on macOS. `path.normalize` only
+    // handles separator/segment normalization; Unicode normalization is
+    // independent.
+    const normalizedPath = path.normalize(gitRoot).normalize("NFC");
 
     const existing = await this.getProjectByPath(normalizedPath);
     if (existing) {
@@ -354,7 +361,7 @@ export class ProjectStore {
   }
 
   async getProjectByPath(projectPath: string): Promise<Project | null> {
-    const normalizedPath = path.normalize(projectPath);
+    const normalizedPath = path.normalize(projectPath).normalize("NFC");
     const db = getSharedDb();
     const row = db.select().from(projectsTable).where(eq(projectsTable.path, normalizedPath)).get();
     return row ? rowToProject(row) : null;

--- a/shared/types/appError.ts
+++ b/shared/types/appError.ts
@@ -11,6 +11,7 @@ export type AppErrorCode =
   | "FILE_TOO_LARGE"
   | "LFS_POINTER"
   | "NOT_FOUND"
+  | "NOT_A_GIT_REPO"
   | "CLIPBOARD_EMPTY"
   | "CLIPBOARD_INVALID"
   | "UNSUPPORTED"

--- a/shared/utils/__tests__/folderName.test.ts
+++ b/shared/utils/__tests__/folderName.test.ts
@@ -1,0 +1,148 @@
+import { describe, it, expect } from "vitest";
+import { validateFolderName } from "../folderName.js";
+
+describe("validateFolderName", () => {
+  describe("accepts valid names", () => {
+    it("plain name", () => {
+      expect(validateFolderName("my-project")).toBeNull();
+    });
+
+    it("name with internal dot", () => {
+      expect(validateFolderName("my.project")).toBeNull();
+    });
+
+    it("unicode name", () => {
+      expect(validateFolderName("café")).toBeNull();
+    });
+
+    it("CJK name", () => {
+      expect(validateFolderName("项目")).toBeNull();
+    });
+
+    it("name at length boundary (255)", () => {
+      expect(validateFolderName("a".repeat(255))).toBeNull();
+    });
+
+    it("name starting with underscore", () => {
+      expect(validateFolderName("_internal")).toBeNull();
+    });
+
+    it("hidden-style name with leading dot", () => {
+      expect(validateFolderName(".github")).toBeNull();
+    });
+  });
+
+  describe("rejects empty / blank / dot segments", () => {
+    it("empty string", () => {
+      expect(validateFolderName("")).toBe("Folder name is required");
+    });
+
+    it("whitespace only", () => {
+      expect(validateFolderName("   ")).toBe("Folder name is required");
+    });
+
+    it("non-string input", () => {
+      expect(validateFolderName(undefined as unknown as string)).toBe("Folder name is required");
+    });
+
+    it("single dot", () => {
+      expect(validateFolderName(".")).toBe("Invalid folder name");
+    });
+
+    it("double dot", () => {
+      expect(validateFolderName("..")).toBe("Invalid folder name");
+    });
+  });
+
+  describe("rejects path separators", () => {
+    it("forward slash", () => {
+      expect(validateFolderName("foo/bar")).toBe("Folder name must not contain path separators");
+    });
+
+    it("backslash", () => {
+      expect(validateFolderName("foo\\bar")).toBe("Folder name must not contain path separators");
+    });
+  });
+
+  describe("rejects control characters", () => {
+    it("null byte", () => {
+      expect(validateFolderName("foo\x00bar")).toBe(
+        "Folder name must not contain control characters"
+      );
+    });
+
+    it("tab", () => {
+      expect(validateFolderName("foo\tbar")).toBe(
+        "Folder name must not contain control characters"
+      );
+    });
+
+    it("0x1F", () => {
+      expect(validateFolderName("foo\x1Fbar")).toBe(
+        "Folder name must not contain control characters"
+      );
+    });
+  });
+
+  describe("rejects Win32-illegal chars", () => {
+    it.each(["<", ">", ":", '"', "|", "?", "*"])("rejects %s", (ch) => {
+      expect(validateFolderName(`foo${ch}bar`)).toBe(
+        'Folder name must not contain < > : " | ? or *'
+      );
+    });
+  });
+
+  describe("rejects trailing dot or space (Win32 silently strips)", () => {
+    it("trailing dot", () => {
+      expect(validateFolderName("foo.")).toBe("Folder name must not end with a space or period");
+    });
+
+    it("trailing space", () => {
+      expect(validateFolderName("foo ")).toBe("Folder name must not end with a space or period");
+    });
+  });
+
+  describe("rejects leading dash", () => {
+    it("leading dash", () => {
+      expect(validateFolderName("-flag")).toBe("Folder name must not start with '-'");
+    });
+  });
+
+  describe("rejects Windows reserved device names", () => {
+    it.each([
+      "CON",
+      "PRN",
+      "AUX",
+      "NUL",
+      "COM0",
+      "COM1",
+      "COM9",
+      "LPT0",
+      "LPT1",
+      "LPT9",
+      "con",
+      "Nul",
+    ])("rejects bare %s", (name) => {
+      expect(validateFolderName(name)).toMatch(/Windows-reserved/);
+    });
+
+    it.each(["CON.txt", "NUL.log", "COM1.anything", "lpt9.json"])(
+      "rejects %s (extension still triggers)",
+      (name) => {
+        expect(validateFolderName(name)).toMatch(/Windows-reserved/);
+      }
+    );
+
+    it("does not reject names that merely contain reserved substrings", () => {
+      expect(validateFolderName("console")).toBeNull();
+      expect(validateFolderName("auxiliary")).toBeNull();
+      expect(validateFolderName("complete")).toBeNull();
+    });
+  });
+
+  describe("rejects names that are too long", () => {
+    it("256 chars", () => {
+      expect(validateFolderName("a".repeat(256))).toBe("Folder name is too long");
+    });
+  });
+});

--- a/shared/utils/folderName.ts
+++ b/shared/utils/folderName.ts
@@ -1,0 +1,56 @@
+import { WINDOWS_RESERVED_NAMES } from "./pathPattern.js";
+
+const CONTROL_CHARS = /[\x00-\x1F]/;
+const WIN32_ILLEGAL_CHARS = /[<>:"|?*]/;
+const PATH_SEPARATORS = /[/\\]/;
+const TRAILING_DOT_OR_SPACE = /[. ]$/;
+
+/**
+ * Validate a single folder-name segment for project creation. Returns a
+ * user-facing error string if invalid, or `null` if the name is acceptable.
+ *
+ * Used by both renderer dialogs and main-process IPC handlers so all three
+ * project-add paths apply the same rules. Pure string logic — no Node APIs —
+ * so it imports cleanly from either side of the contextBridge.
+ */
+export function validateFolderName(name: string): string | null {
+  if (typeof name !== "string") return "Folder name is required";
+  const trimmed = name.trim();
+  if (!trimmed) return "Folder name is required";
+  if (trimmed === "." || trimmed === "..") return "Invalid folder name";
+
+  if (trimmed.length > 255) return "Folder name is too long";
+
+  if (PATH_SEPARATORS.test(trimmed)) {
+    return "Folder name must not contain path separators";
+  }
+  if (CONTROL_CHARS.test(trimmed)) {
+    return "Folder name must not contain control characters";
+  }
+  if (WIN32_ILLEGAL_CHARS.test(trimmed)) {
+    return 'Folder name must not contain < > : " | ? or *';
+  }
+
+  // Win32 silently strips trailing dot/space at creation, which can collapse
+  // distinct names or produce reserved-name collisions; reject on the raw
+  // input so a user-typed `foo ` isn't quietly normalized to `foo`.
+  if (TRAILING_DOT_OR_SPACE.test(name) || TRAILING_DOT_OR_SPACE.test(trimmed)) {
+    return "Folder name must not end with a space or period";
+  }
+
+  // Leading dash is a tooling hazard — argv parsers (git, shells) treat it as
+  // a flag.
+  if (trimmed.startsWith("-")) {
+    return "Folder name must not start with '-'";
+  }
+
+  // Win32 reserved-name check: strip extension and compare the stem
+  // case-insensitively. CON, NUL.txt, COM1.log, etc. are all blocked.
+  const dotIndex = trimmed.indexOf(".");
+  const stem = dotIndex === -1 ? trimmed : trimmed.slice(0, dotIndex);
+  if (WINDOWS_RESERVED_NAMES.has(stem.toUpperCase())) {
+    return `Folder name uses Windows-reserved name '${stem}'`;
+  }
+
+  return null;
+}

--- a/shared/utils/folderName.ts
+++ b/shared/utils/folderName.ts
@@ -1,5 +1,6 @@
 import { WINDOWS_RESERVED_NAMES } from "./pathPattern.js";
 
+// eslint-disable-next-line no-control-regex
 const CONTROL_CHARS = /[\x00-\x1F]/;
 const WIN32_ILLEGAL_CHARS = /[<>:"|?*]/;
 const PATH_SEPARATORS = /[/\\]/;

--- a/shared/utils/pathPattern.ts
+++ b/shared/utils/pathPattern.ts
@@ -144,7 +144,7 @@ export function generateWorktreePath(
 // Windows reserved device names (case-insensitive). Microsoft added COM0/LPT0
 // in Windows 10 1803, so the set covers 0–9 for both COM and LPT. Match
 // against each path component after stripping any extension (e.g. NUL.txt).
-const WINDOWS_RESERVED_NAMES = new Set([
+export const WINDOWS_RESERVED_NAMES = new Set([
   "CON",
   "PRN",
   "AUX",

--- a/src/components/Project/CloneRepoDialog.tsx
+++ b/src/components/Project/CloneRepoDialog.tsx
@@ -6,6 +6,7 @@ import { Spinner } from "@/components/ui/Spinner";
 import { FolderGit2 } from "@/components/icons";
 import { projectClient } from "@/clients";
 import { formatErrorMessage } from "@shared/utils/errorMessage";
+import { validateFolderName } from "@shared/utils/folderName";
 import type { CloneRepoProgressEvent } from "@shared/types/ipc/gitClone";
 
 interface CloneRepoDialogProps {
@@ -156,7 +157,16 @@ export function CloneRepoDialog({ isOpen, onSuccess, onCancel }: CloneRepoDialog
     }
   };
 
-  const canClone = isValidCloneUrl(url) && parentPath.trim() !== "" && folderName.trim() !== "";
+  // Show validation errors only after the user has touched the field or the
+  // URL-derived name is non-empty — keeps the empty-state quiet while ensuring
+  // a bad auto-derived name (e.g. URL ending in "con.git") still surfaces.
+  const folderNameError =
+    folderNameEdited || folderName.trim() !== "" ? validateFolderName(folderName) : null;
+  const canClone =
+    isValidCloneUrl(url) &&
+    parentPath.trim() !== "" &&
+    folderName.trim() !== "" &&
+    folderNameError === null;
   const showProgress = isCloning || progressEvents.length > 0;
 
   return (
@@ -216,8 +226,14 @@ export function CloneRepoDialog({ isOpen, onSuccess, onCancel }: CloneRepoDialog
               setFolderNameEdited(true);
             }}
             disabled={isCloning || isComplete}
-            className="w-full rounded-md border border-daintree-border bg-daintree-bg px-3 py-2 text-sm text-daintree-text placeholder:text-daintree-text/40 focus:outline-hidden focus:ring-2 focus:ring-daintree-accent/50 disabled:opacity-50"
+            aria-invalid={folderNameError != null}
+            className="w-full rounded-md border border-daintree-border bg-daintree-bg px-3 py-2 text-sm text-daintree-text placeholder:text-daintree-text/40 focus:outline-hidden focus:ring-2 focus:ring-daintree-accent/50 disabled:opacity-50 aria-invalid:border-status-error"
           />
+          {folderNameError && (
+            <p role="alert" className="text-xs text-status-error">
+              {folderNameError}
+            </p>
+          )}
         </div>
 
         {/* Shallow Clone */}

--- a/src/components/Project/CreateProjectFolderDialog.tsx
+++ b/src/components/Project/CreateProjectFolderDialog.tsx
@@ -5,19 +5,11 @@ import { FolderPlus, FolderOpen } from "lucide-react";
 import { projectClient } from "@/clients";
 import { useProjectStore } from "@/store/projectStore";
 import { formatErrorMessage } from "@shared/utils/errorMessage";
+import { validateFolderName } from "@shared/utils/folderName";
 
 interface CreateProjectFolderDialogProps {
   isOpen: boolean;
   onClose: () => void;
-}
-
-function validateFolderName(name: string): string | null {
-  const trimmed = name.trim();
-  if (!trimmed) return "Folder name is required";
-  if (trimmed === ".." || trimmed === ".") return "Invalid folder name";
-  if (trimmed.includes("/") || trimmed.includes("\\"))
-    return "Folder name must not contain path separators";
-  return null;
 }
 
 export function CreateProjectFolderDialog({ isOpen, onClose }: CreateProjectFolderDialogProps) {

--- a/src/store/projectStore.ts
+++ b/src/store/projectStore.ts
@@ -13,6 +13,7 @@ import { panelPersistence, panelToSnapshot } from "./persistence/panelPersistenc
 import { useTerminalInputStore } from "./terminalInputStore";
 import { isSmokeTestTerminalId } from "@shared/utils/smokeTestTerminals";
 import { formatErrorMessage } from "@shared/utils/errorMessage";
+import { isClientAppError } from "@/utils/clientAppError";
 import type { ProjectSwitchOutgoingState } from "@shared/types/ipc/project";
 import type { TerminalInstance, TabGroup } from "@shared/types";
 
@@ -195,6 +196,10 @@ function isDubiousOwnershipError(error: unknown): boolean {
 }
 
 function getProjectOpenErrorMessage(error: unknown): string {
+  if (isClientAppError(error) && error.code === "NOT_A_GIT_REPO") {
+    return "The selected directory is not a Git repository.";
+  }
+
   const message = formatErrorMessage(error, "");
   const lower = message.toLowerCase();
 
@@ -215,6 +220,14 @@ function getProjectOpenErrorMessage(error: unknown): string {
 
   if (message.includes("Project path must be absolute")) {
     return "Project path must be an absolute path.";
+  }
+
+  if (message.includes("ELOOP")) {
+    return "The selected directory contains a symbolic link loop and cannot be opened.";
+  }
+
+  if (message.includes("ENAMETOOLONG")) {
+    return "The path is too long. Shorten the directory name or move it closer to the filesystem root.";
   }
 
   if (message.includes("ENOENT")) {
@@ -277,7 +290,10 @@ const createProjectStore: StateCreator<ProjectState> = (set, get) => ({
       const isAbsolutePath = (p: string) =>
         p.startsWith("/") || p.startsWith("\\\\") || /^[a-zA-Z]:[\\/]/.test(p);
 
-      if (errorMessage.includes("Not a git repository")) {
+      const isNotAGitRepo =
+        (isClientAppError(error) && error.code === "NOT_A_GIT_REPO") ||
+        errorMessage.includes("Not a git repository");
+      if (isNotAGitRepo) {
         const gitInitPath =
           resolvedPath || path.trim() || errorMessage.match(/Not a git repository: (.+)/)?.[1];
         if (gitInitPath && isAbsolutePath(gitInitPath)) {
@@ -345,6 +361,10 @@ const createProjectStore: StateCreator<ProjectState> = (set, get) => ({
       }
 
       const message = getProjectOpenErrorMessage(error);
+      // Capture a frozen snapshot of the actually-resolved path so the retry
+      // re-attempts the directory the user picked, not the empty argument
+      // value the dialog flow was originally invoked with.
+      const retryPath = resolvedPath ?? path.trim();
       notify({
         type: "error",
         title: "Failed to add project",
@@ -354,7 +374,7 @@ const createProjectStore: StateCreator<ProjectState> = (set, get) => ({
             label: "Try again",
             variant: "primary",
             onClick: () => {
-              void get().addProjectByPath(path);
+              void get().addProjectByPath(retryPath);
             },
           },
         ],


### PR DESCRIPTION
## Summary

- Consolidates folder-name validation into `shared/utils/folderName.ts` with full coverage: Win32 reserved names, control characters, trailing dots/spaces, and leading dashes. Renderer (`CloneRepoDialog`) and both backend handlers now share the same validator.
- Adds NFC normalisation in `ProjectStore.addProject` so macOS paths that differ only by Unicode form are treated as the same project — no more duplicate rows.
- Replaces string-matched error routing with a typed `NOT_A_GIT_REPO` `AppError` code, so `GitInitDialog` routing is wording-change-proof. Extends `getProjectOpenErrorMessage` to cover `ELOOP` and `ENAMETOOLONG`.
- Fixes the "Try again" toast action so it retries the actual path the user selected rather than re-opening the native dialog.

Resolves #7225

## Changes

- `shared/utils/folderName.ts` — new shared validator with `validateFolderName()` and `sanitiseFolderName()`
- `shared/utils/__tests__/folderName.test.ts` — unit tests covering all validation branches
- `shared/utils/pathPattern.ts` — exports `WINDOWS_RESERVED_NAMES`
- `shared/types/appError.ts` — adds `NOT_A_GIT_REPO` error code
- `electron/ipc/handlers/projectCrud/gitClone.ts` — uses shared validator, throws typed error
- `electron/ipc/handlers/projectCrud/settings.ts` — uses shared validator, throws typed error
- `electron/services/ProjectStore.ts` — NFC normalise path before dedup check
- `src/components/Project/CreateProjectFolderDialog.tsx` — uses shared validator
- `src/components/Project/CloneRepoDialog.tsx` — validates folder name in renderer before submit
- `src/store/projectStore.ts` — fix retry path capture, handle typed `NOT_A_GIT_REPO`, map `ELOOP`/`ENAMETOOLONG`

## Testing

- Unit tests in `shared/utils/__tests__/folderName.test.ts` cover all validation branches including Win32 reserved names, control characters, boundary cases
- Manually verified duplicate-row fix by adding the same repo path with both NFC and NFD forms
- Verified "Try again" retries the selected path rather than reopening the dialog