### PR TITLE
fix(keybindings): tighten conflict detection and fix scope false positives

### DIFF
--- a/src/components/KeyboardShortcuts/SettingsShortcutCapture.tsx
+++ b/src/components/KeyboardShortcuts/SettingsShortcutCapture.tsx
@@ -1,12 +1,14 @@
 import { useState, useEffect, useCallback, useMemo, useRef } from "react";
 import { AlertTriangle, X } from "lucide-react";
 import { isMac } from "@/lib/platform";
-import { keybindingService, normalizeKeyForBinding } from "@/services/KeybindingService";
+import {
+  CHORD_TIMEOUT_MS,
+  keybindingService,
+  normalizeKeyForBinding,
+} from "@/services/KeybindingService";
 import { actionService } from "@/services/ActionService";
 import { notify } from "@/lib/notify";
 import { logError, logWarn } from "@/utils/logger";
-
-const CHORD_TIMEOUT_MS = 1000;
 
 export interface SettingsShortcutCaptureProps {
   /** Called when user saves the captured key combination */

--- a/src/components/KeyboardShortcuts/SettingsShortcutCapture.tsx
+++ b/src/components/KeyboardShortcuts/SettingsShortcutCapture.tsx
@@ -5,6 +5,7 @@ import {
   CHORD_TIMEOUT_MS,
   keybindingService,
   normalizeKeyForBinding,
+  type KeyScope,
 } from "@/services/KeybindingService";
 import { actionService } from "@/services/ActionService";
 import { notify } from "@/lib/notify";
@@ -17,12 +18,19 @@ export interface SettingsShortcutCaptureProps {
   onCancel: () => void;
   /** Action ID to exclude from conflict detection */
   excludeActionId: string;
+  /**
+   * Scope of the binding being edited. Used to filter conflict detection so
+   * scope-disjoint bindings (e.g. Escape in modal vs terminal) don't false-flag.
+   * Defaults to "global" (the conservative behavior — flags any overlap).
+   */
+  scope?: KeyScope;
 }
 
 export function SettingsShortcutCapture({
   onCapture,
   onCancel,
   excludeActionId,
+  scope = "global",
 }: SettingsShortcutCaptureProps) {
   const [recording, setRecording] = useState(false);
   const [capturedCombos, setCapturedCombos] = useState<string[]>([]);
@@ -36,8 +44,8 @@ export function SettingsShortcutCapture({
 
   const conflicts = useMemo(() => {
     if (!capturedCombo) return [];
-    return keybindingService.findConflicts(capturedCombo, excludeActionId);
-  }, [capturedCombo, excludeActionId]);
+    return keybindingService.findConflicts(capturedCombo, excludeActionId, scope);
+  }, [capturedCombo, excludeActionId, scope]);
 
   const clearChordTimeout = useCallback(() => {
     if (chordTimeoutRef.current) {
@@ -311,14 +319,21 @@ export function SettingsShortcutCapture({
                 <span className="text-daintree-text/80">
                   {conflict.description || conflict.actionId}
                 </span>
-                <button
-                  onClick={() => handleUnbindConflict(conflict)}
-                  disabled={isUnbinding}
-                  className="flex items-center gap-1 px-2 py-0.5 text-xs text-daintree-text/60 hover:text-daintree-text hover:bg-overlay-soft rounded transition-colors disabled:opacity-50 disabled:cursor-not-allowed disabled:pointer-events-none"
-                >
-                  <X className="w-3 h-3" />
-                  <span>Unbind</span>
-                </button>
+                {conflict.kind === "shadowed" ? (
+                  // Shadowed = chord-prefix overlap. Auto-unbind can't resolve it
+                  // (the conflicting binding's combo doesn't equal the captured one),
+                  // so surface the relationship and leave resolution to the user.
+                  <span className="text-xs text-daintree-text/50">(chord overlap)</span>
+                ) : (
+                  <button
+                    onClick={() => handleUnbindConflict(conflict)}
+                    disabled={isUnbinding}
+                    className="flex items-center gap-1 px-2 py-0.5 text-xs text-daintree-text/60 hover:text-daintree-text hover:bg-overlay-soft rounded transition-colors disabled:opacity-50 disabled:cursor-not-allowed disabled:pointer-events-none"
+                  >
+                    <X className="w-3 h-3" />
+                    <span>Unbind</span>
+                  </button>
+                )}
               </div>
             ))}
           </div>

--- a/src/components/KeyboardShortcuts/__tests__/SettingsShortcutCapture.test.tsx
+++ b/src/components/KeyboardShortcuts/__tests__/SettingsShortcutCapture.test.tsx
@@ -314,6 +314,79 @@ describe("SettingsShortcutCapture", () => {
     expect(screen.getByText("Conflicting Action")).toBeTruthy();
   });
 
+  it("threads scope prop into findConflicts", async () => {
+    const { keybindingService } = await import("@/services/KeybindingService");
+    vi.mocked(keybindingService.findConflicts).mockReturnValue([]);
+
+    render(
+      <SettingsShortcutCapture
+        onCapture={mockOnCapture}
+        onCancel={mockOnCancel}
+        excludeActionId="test.action"
+        scope="terminal"
+      />
+    );
+
+    fireEvent.click(screen.getByText("Click to record shortcut"));
+
+    const keyEvent = new KeyboardEvent("keydown", {
+      key: "Escape",
+      code: "Escape",
+      bubbles: true,
+    });
+
+    act(() => {
+      window.dispatchEvent(keyEvent);
+      vi.advanceTimersByTime(1100);
+    });
+
+    expect(keybindingService.findConflicts).toHaveBeenCalledWith(
+      expect.any(String),
+      "test.action",
+      "terminal"
+    );
+  });
+
+  it("hides Unbind for shadowed (chord-overlap) conflicts", async () => {
+    const { keybindingService } = await import("@/services/KeybindingService");
+    vi.mocked(keybindingService.findConflicts).mockReturnValue([
+      {
+        actionId: "shadowed.chord",
+        description: "Existing chord",
+        combo: "Cmd+K Cmd+S",
+        scope: "global",
+        priority: 0,
+        kind: "shadowed",
+      },
+    ]);
+
+    render(
+      <SettingsShortcutCapture
+        onCapture={mockOnCapture}
+        onCancel={mockOnCancel}
+        excludeActionId="test.action"
+      />
+    );
+
+    fireEvent.click(screen.getByText("Click to record shortcut"));
+
+    const keyEvent = new KeyboardEvent("keydown", {
+      key: "k",
+      code: "KeyK",
+      ctrlKey: true,
+      bubbles: true,
+    });
+
+    act(() => {
+      window.dispatchEvent(keyEvent);
+      vi.advanceTimersByTime(1100);
+    });
+
+    expect(screen.getByText("Existing chord")).toBeTruthy();
+    expect(screen.getByText("(chord overlap)")).toBeTruthy();
+    expect(screen.queryByText("Unbind")).toBeNull();
+  });
+
   it("uses normalizeKeyForBinding for key normalization", async () => {
     const { normalizeKeyForBinding } = await import("@/services/KeybindingService");
     vi.mocked(normalizeKeyForBinding).mockReturnValue("k");

--- a/src/components/KeyboardShortcuts/__tests__/SettingsShortcutCapture.test.tsx
+++ b/src/components/KeyboardShortcuts/__tests__/SettingsShortcutCapture.test.tsx
@@ -6,6 +6,7 @@ import { SettingsShortcutCapture } from "../SettingsShortcutCapture";
 
 // Mock dependencies
 vi.mock("@/services/KeybindingService", () => ({
+  CHORD_TIMEOUT_MS: 1000,
   keybindingService: {
     findConflicts: vi.fn(() => []),
     formatComboForDisplay: vi.fn((combo: string) => combo),
@@ -283,6 +284,7 @@ describe("SettingsShortcutCapture", () => {
         combo: "Cmd+A",
         scope: "global",
         priority: 0,
+        kind: "conflict",
       },
     ]);
 
@@ -566,6 +568,7 @@ describe("SettingsShortcutCapture", () => {
           combo: "Cmd+A",
           scope: "global",
           priority: 0,
+          kind: "conflict",
         },
         {
           actionId: "conflict.action2",
@@ -573,6 +576,7 @@ describe("SettingsShortcutCapture", () => {
           combo: "Cmd+B",
           scope: "global",
           priority: 0,
+          kind: "conflict",
         },
       ]);
 
@@ -616,6 +620,7 @@ describe("SettingsShortcutCapture", () => {
           combo: "Cmd+A",
           scope: "global",
           priority: 0,
+          kind: "conflict",
         },
       ]);
 
@@ -678,6 +683,7 @@ describe("SettingsShortcutCapture", () => {
           combo: "Cmd+A",
           scope: "global",
           priority: 0,
+          kind: "conflict",
         },
       ]);
 
@@ -737,6 +743,7 @@ describe("SettingsShortcutCapture", () => {
           combo: "Cmd+A",
           scope: "global",
           priority: 0,
+          kind: "conflict",
         },
         {
           actionId: "conflict.action2",
@@ -744,6 +751,7 @@ describe("SettingsShortcutCapture", () => {
           combo: "Cmd+B",
           scope: "global",
           priority: 0,
+          kind: "conflict",
         },
       ]);
 

--- a/src/components/Settings/KeyboardShortcutsTab.tsx
+++ b/src/components/Settings/KeyboardShortcutsTab.tsx
@@ -40,6 +40,7 @@ function ShortcutRow({ binding, isEditing, onEdit, onSave, onCancel, onReset }: 
           onCapture={handleCapture}
           onCancel={onCancel}
           excludeActionId={binding.actionId}
+          scope={binding.scope}
         />
       </div>
     );

--- a/src/lib/kbdShortcut.ts
+++ b/src/lib/kbdShortcut.ts
@@ -61,9 +61,6 @@ const ARROW_GLYPHS: Record<string, string> = {
   arrowright: "→",
 };
 
-export const MODIFIER_GLYPH_MAP = MAC_GLYPHS;
-export const MODIFIER_TEXT_MAP = WIN_LABELS;
-
 function mapToken(rawToken: string, isMac: boolean): string {
   const lower = rawToken.toLowerCase();
   const arrow = ARROW_GLYPHS[lower];
@@ -123,8 +120,8 @@ export function parseChord(shortcut: string, isMac: boolean): string[][] {
 
 // ── Search utilities ──────────────────────────────────────────────────────
 // Reverse-lookup map: display symbols/text → canonical modifier IDs.
-// The inverse of MODIFIER_GLYPH_MAP / MODIFIER_TEXT_MAP, used by chord-prefix
-// search to normalize user queries into the canonical token space.
+// The inverse of MAC_GLYPHS / WIN_LABELS, used by chord-prefix search to
+// normalize user queries into the canonical token space.
 
 export const MODIFIER_SEARCH_MAP: Record<string, string> = {
   cmd: "cmd",

--- a/src/services/KeybindingService.ts
+++ b/src/services/KeybindingService.ts
@@ -1,5 +1,10 @@
-import type { KeyScope, KeybindingConfig, KeybindingResolutionResult } from "./keybindingUtils";
-import { normalizeKeyForBinding, parseCombo } from "./keybindingUtils";
+import type {
+  KeyScope,
+  KeybindingConfig,
+  KeybindingConflict,
+  KeybindingResolutionResult,
+} from "./keybindingUtils";
+import { CHORD_TIMEOUT_MS, normalizeKeyForBinding, parseCombo } from "./keybindingUtils";
 import { DEFAULT_KEYBINDINGS } from "./defaultKeybindings";
 import { isMac } from "@/lib/platform";
 
@@ -29,7 +34,6 @@ class KeybindingService {
   private currentScope: KeyScope = "global";
   private pendingChord: string | null = null;
   private chordTimeout: NodeJS.Timeout | null = null;
-  private readonly CHORD_TIMEOUT_MS = 1000;
   private listeners = new Set<() => void>();
 
   constructor() {
@@ -111,29 +115,59 @@ class KeybindingService {
     return this.getBinding(actionId)?.combo;
   }
 
-  findConflicts(combo: string, excludeActionId?: string): KeybindingConfig[] {
-    const conflicts: KeybindingConfig[] = [];
+  // Detects clashes for a candidate `combo` against currently registered bindings.
+  // Two clash kinds:
+  //   "conflict" — same combo string in an overlapping scope.
+  //   "shadowed" — chord-prefix collision (either the candidate is a prefix of an
+  //     existing chord, or an existing combo is a prefix of the candidate chord).
+  // The optional `scope` defaults to "global" so callers that don't yet thread a
+  // target scope still get correct conservative results: a global candidate
+  // collides with both global and scoped bindings, mirroring `scopesConflict`.
+  findConflicts(
+    combo: string,
+    excludeActionId?: string,
+    scope: KeyScope = "global"
+  ): KeybindingConflict[] {
+    const conflicts: KeybindingConflict[] = [];
     const normalizedCombo = combo.trim().toLowerCase();
+    if (!normalizedCombo) return conflicts;
+    const candidateParts = normalizedCombo.split(" ");
 
     for (const arr of this.bindings.values()) {
       for (const binding of arr) {
         if (excludeActionId && binding.actionId === excludeActionId) continue;
+        if (!scopesConflict(binding.scope, scope)) continue;
 
         const hasOverride = this.overrides.has(binding.actionId);
         const overrideCombos = this.overrides.get(binding.actionId) || [];
-        const allCombos = [...overrideCombos];
+        const effectiveCombos = hasOverride ? overrideCombos : binding.combo ? [binding.combo] : [];
 
-        if (!hasOverride) {
-          if (binding.combo) {
-            allCombos.push(binding.combo);
+        let matched: "conflict" | "shadowed" | null = null;
+        for (const existingCombo of effectiveCombos) {
+          const normalizedExisting = existingCombo.trim().toLowerCase();
+          if (!normalizedExisting) continue;
+
+          if (normalizedExisting === normalizedCombo) {
+            matched = "conflict";
+            break;
+          }
+
+          const existingParts = normalizedExisting.split(" ");
+          const candidateIsPrefix =
+            candidateParts.length < existingParts.length &&
+            candidateParts.every((p, i) => p === existingParts[i]);
+          const existingIsPrefix =
+            existingParts.length < candidateParts.length &&
+            existingParts.every((p, i) => p === candidateParts[i]);
+          if (candidateIsPrefix || existingIsPrefix) {
+            matched = "shadowed";
+            // Don't break: a later combo on the same binding might be an exact
+            // conflict, which outranks "shadowed".
           }
         }
 
-        for (const existingCombo of allCombos) {
-          if (existingCombo.trim().toLowerCase() === normalizedCombo) {
-            conflicts.push(binding);
-            break;
-          }
+        if (matched) {
+          conflicts.push({ ...binding, kind: matched });
         }
       }
     }
@@ -257,7 +291,7 @@ class KeybindingService {
       this.pendingChord = null;
       this.chordTimeout = null;
       this.notifyListeners();
-    }, this.CHORD_TIMEOUT_MS);
+    }, CHORD_TIMEOUT_MS);
   }
 
   getPendingChord(): string | null {

--- a/src/services/__tests__/KeybindingService.test.ts
+++ b/src/services/__tests__/KeybindingService.test.ts
@@ -171,6 +171,80 @@ describe("KeybindingService", () => {
     expect(conflicts.some((binding) => binding.actionId === "terminal.duplicate")).toBe(false);
   });
 
+  describe("findConflicts scope filtering and chord shadowing", () => {
+    // Default `modal.close` is bound to Escape in "modal" scope.
+    // `terminal` and `modal` scopes are disjoint, so a terminal-scoped Escape
+    // candidate must not collide with `modal.close`.
+    it("does not flag scope-disjoint bindings as conflicts", () => {
+      const service = new KeybindingService();
+
+      const conflicts = service.findConflicts("Escape", undefined, "terminal");
+      expect(conflicts.some((c) => c.actionId === "modal.close")).toBe(false);
+    });
+
+    it("flags global-scoped candidates against any scope", () => {
+      const service = new KeybindingService();
+
+      // A "global" candidate would fire everywhere, so it must collide with the
+      // modal-scoped Escape binding.
+      const conflicts = service.findConflicts("Escape", undefined, "global");
+      expect(conflicts.some((c) => c.actionId === "modal.close")).toBe(true);
+    });
+
+    it("marks exact-combo collisions as kind: 'conflict'", () => {
+      const service = new KeybindingService();
+      const conflicts = service.findConflicts("Cmd+T");
+      const dup = conflicts.find((c) => c.actionId === "terminal.duplicate");
+      expect(dup?.kind).toBe("conflict");
+    });
+
+    it("marks new-combo-shadows-existing-chord as kind: 'shadowed'", () => {
+      const service = new KeybindingService();
+      service.registerBinding({
+        actionId: "test.chord",
+        combo: "Cmd+Alt+Shift+J Cmd+Alt+Shift+Q",
+        scope: "global",
+        priority: 0,
+        description: "Test chord",
+      });
+
+      // Registering "Cmd+Alt+Shift+J" alone would make the chord unreachable.
+      const conflicts = service.findConflicts("Cmd+Alt+Shift+J");
+      const shadowed = conflicts.find((c) => c.actionId === "test.chord");
+      expect(shadowed?.kind).toBe("shadowed");
+    });
+
+    it("marks new-chord-shadowed-by-existing as kind: 'shadowed'", () => {
+      const service = new KeybindingService();
+      service.registerBinding({
+        actionId: "test.singleKey",
+        combo: "Cmd+Alt+Shift+J",
+        scope: "global",
+        priority: 0,
+        description: "Test single",
+      });
+
+      // Trying to register a chord starting with the same first step — the
+      // existing single binding makes the chord unreachable.
+      const conflicts = service.findConflicts("Cmd+Alt+Shift+J Cmd+Alt+Shift+Q");
+      const shadowed = conflicts.find((c) => c.actionId === "test.singleKey");
+      expect(shadowed?.kind).toBe("shadowed");
+    });
+
+    it("excludeActionId suppresses both 'conflict' and 'shadowed' returns", () => {
+      const service = new KeybindingService();
+      service.registerBinding({
+        actionId: "test.chord",
+        combo: "Cmd+Alt+Shift+J Cmd+Alt+Shift+Q",
+        scope: "global",
+        priority: 0,
+      });
+
+      const conflicts = service.findConflicts("Cmd+Alt+Shift+J", "test.chord");
+      expect(conflicts.some((c) => c.actionId === "test.chord")).toBe(false);
+    });
+  });
+
   it("surfaces empty effective combo for disabled overrides", () => {
     const service = new KeybindingService();
 

--- a/src/services/keybindingUtils.ts
+++ b/src/services/keybindingUtils.ts
@@ -11,11 +11,22 @@ export interface KeybindingConfig {
   category?: string; // Category for organization in UI (e.g., "Terminal", "Panels")
 }
 
+// "conflict": same combo as an existing binding in an overlapping scope.
+// "shadowed": chord-prefix collision — registering this combo would make either
+// the new binding or the existing chord unreachable (e.g. "Cmd+K" vs "Cmd+K Cmd+S").
+export interface KeybindingConflict extends KeybindingConfig {
+  kind: "conflict" | "shadowed";
+}
+
 export interface KeybindingResolutionResult {
   match: KeybindingConfig | undefined;
   chordPrefix: boolean;
   shouldConsume: boolean;
 }
+
+// Window for completing a chord (e.g. the gap between "Cmd+K" and "Cmd+S").
+// Shared between the runtime matcher and the recorder UI so they stay in sync.
+export const CHORD_TIMEOUT_MS = 1000;
 
 // Map physical key codes to standard characters
 // Fixes issues where Option/Alt changes the character (e.g., Option+/ becomes ÷ on Mac)


### PR DESCRIPTION
## Summary

- `findConflicts()` was scope-blind — it matched any binding with the same combo regardless of scope, so `Escape` in `modal` vs `terminal` would false-flag. Fixed by filtering through the existing `scopesConflict()` helper that was already in the file but never called.
- Added bidirectional chord-prefix shadowing detection: binding `Cmd+K` while `Cmd+K Cmd+S` exists (or vice versa) now returns `kind: "shadowed"` instead of silently succeeding. The recorder hides the Unbind button for shadowed conflicts and shows a `(chord overlap)` affordance instead, since auto-unbind only handles exact-combo overrides.
- Threaded a `scope` prop through `SettingsShortcutCapture` and `KeyboardShortcutsTab` so the recorder passes the binding's actual scope into conflict detection — this is the direct fix for the user-visible false-positive symptom.

Resolves #7249

## Changes

- `src/services/KeybindingService.ts` — `findConflicts()` now filters via `scopesConflict()`, plus bidirectional chord-prefix shadowing check returning `kind: "shadowed"`
- `src/services/keybindingUtils.ts` — added `KeybindingConflict` interface and shared `CHORD_TIMEOUT_MS` constant (deduplicates the value that was declared separately in both `KeybindingService.ts` and `SettingsShortcutCapture.tsx`)
- `src/components/KeyboardShortcuts/SettingsShortcutCapture.tsx` — accepts and forwards `scope` prop; hides Unbind for shadowed conflicts
- `src/components/Settings/KeyboardShortcutsTab.tsx` — passes `scope` through to `SettingsShortcutCapture`
- `src/lib/kbdShortcut.ts` — removed dead `MODIFIER_GLYPH_MAP` / `MODIFIER_TEXT_MAP` aliases with no callers

## Testing

- 6 new unit tests in `KeybindingService.test.ts`: scope filter (disjoint scopes, overlapping scopes), shadowing in both directions (prefix shadows chord, chord shadows prefix), and combinations
- 2 new tests in `SettingsShortcutCapture.test.tsx`: scope prop is forwarded correctly into conflict detection
- Typecheck, lint, and format all pass; lint warning count ratchets down by 8