### PR TITLE
fix(audit): use monotonic clock for action duration measurement

### DIFF
--- a/electron/services/CrashRecoveryService.ts
+++ b/electron/services/CrashRecoveryService.ts
@@ -412,7 +412,6 @@ export class CrashRecoveryService {
     this.enrichWithEnvironmentMetadata(entry);
     const backupAppState = this.cachedBackupSnapshot?.appState;
     this.enrichWithPanelData(entry, backupAppState);
-    this.enrichWithRecentActions(entry);
 
     return entry;
   }

--- a/src/services/ActionService.ts
+++ b/src/services/ActionService.ts
@@ -230,11 +230,13 @@ export class ActionService {
       return { ok: false, error };
     }
 
-    const startMs = Date.now();
+    const wallClockStartMs = Date.now();
+    const monotonicStartMs = typeof performance !== "undefined" ? performance.now() : Date.now();
 
     try {
       const result = await definition.run(validatedArgs, context);
-      const durationMs = Date.now() - startMs;
+      const durationMs =
+        (typeof performance !== "undefined" ? performance.now() : Date.now()) - monotonicStartMs;
       if (
         REPEATABLE_SOURCES.has(source) &&
         !definition.nonRepeatable &&
@@ -250,7 +252,7 @@ export class ActionService {
         args: this.redactSensitiveArgs(args),
         context,
         source,
-        timestamp: startMs,
+        timestamp: wallClockStartMs,
         category: definition.category,
         durationMs,
         safeArgs: this.extractSafeBreadcrumbArgs(args, definition),


### PR DESCRIPTION
## Summary
- Switch action duration measurement to `performance.now()` so system clock jumps can't produce negative or inflated values
- Drop a dead `enrichWithRecentActions` call in `CrashRecoveryService` that runs before the breadcrumb ring is initialized

Resolves #7089

## Changes
- `src/services/ActionService.ts` — split wall-clock `timestamp` (still `Date.now()`) from monotonic `durationMs` (now `performance.now()`)
- `electron/services/CrashRecoveryService.ts` — remove `enrichWithRecentActions` from the marker-crash path; the breadcrumb ring is always empty at that point in startup

## Testing
- Typecheck and lint pass
- Existing audit trail behavior is unchanged on the happy path
- Duration can no longer go negative on clock jumps (validated by the IPC normalizer's existing `>= 0` clamp which was added specifically for this case)