### PR TITLE
fix(panelKindRegistry): protect built-in kinds from plugin overwrite

### DIFF
--- a/shared/config/__tests__/panelKindRegistry.test.ts
+++ b/shared/config/__tests__/panelKindRegistry.test.ts
@@ -1,6 +1,7 @@
 import { afterEach, beforeEach, describe, it, expect, vi } from "vitest";
 import {
   BUILT_IN_PANEL_KINDS,
+  getPanelKindColor,
   getPanelKindConfig,
   getExtensionFallbackDefaults,
   getPanelKindIds,
@@ -344,5 +345,93 @@ describe("registry event listeners", () => {
     expect(goodListener).toHaveBeenCalledTimes(1);
     expect(errorSpy).toHaveBeenCalled();
     errorSpy.mockRestore();
+  });
+});
+
+describe("registerPanelKind collision guard", () => {
+  afterEach(() => {
+    clearPanelKindRegistry();
+  });
+
+  it("refuses to overwrite a built-in with a plugin config", () => {
+    const errorSpy = vi.spyOn(console, "error").mockImplementation(() => {});
+    const listener = vi.fn();
+    const unsubscribe = onPanelKindRegistered(listener);
+
+    const original = getPanelKindConfig("terminal");
+    expect(original?.extensionId).toBeUndefined();
+
+    registerPanelKind({
+      id: "terminal",
+      name: "Hijacked",
+      iconId: "skull",
+      color: "#ff0000",
+      hasPty: false,
+      canRestart: false,
+      canConvert: false,
+      extensionId: "evil-plugin",
+    });
+
+    const after = getPanelKindConfig("terminal");
+    expect(after).toBe(original);
+    expect(after?.name).toBe(original?.name);
+    expect(after?.extensionId).toBeUndefined();
+    expect(errorSpy).toHaveBeenCalledTimes(1);
+    expect(listener).not.toHaveBeenCalled();
+
+    unsubscribe();
+    errorSpy.mockRestore();
+  });
+
+  it("allows built-in re-registration (init hook re-patching)", () => {
+    const errorSpy = vi.spyOn(console, "error").mockImplementation(() => {});
+    const listener = vi.fn();
+    const unsubscribe = onPanelKindRegistered(listener);
+
+    registerPanelKind({
+      id: "terminal",
+      name: "Terminal",
+      iconId: "terminal",
+      color: "#000",
+      hasPty: true,
+      canRestart: true,
+      canConvert: true,
+    });
+
+    expect(getPanelKindConfig("terminal")?.extensionId).toBeUndefined();
+    expect(errorSpy).not.toHaveBeenCalled();
+    expect(listener).not.toHaveBeenCalled();
+
+    unsubscribe();
+    errorSpy.mockRestore();
+  });
+
+  it("allows a plugin to re-register its own kind (reconciliation)", () => {
+    const listener = vi.fn();
+    const unsubscribe = onPanelKindRegistered(listener);
+
+    registerPanelKind(makeExtensionConfig("ext-a.viewer", "ext-a"));
+    registerPanelKind({ ...makeExtensionConfig("ext-a.viewer", "ext-a"), name: "Updated" });
+
+    expect(getPanelKindConfig("ext-a.viewer")?.name).toBe("Updated");
+    expect(listener).toHaveBeenCalledTimes(2);
+
+    unsubscribe();
+  });
+});
+
+describe("getPanelKindColor fallback", () => {
+  afterEach(() => {
+    clearPanelKindRegistry();
+  });
+
+  it("returns built-in brand color for known kinds", () => {
+    const terminal = getPanelKindColor("terminal");
+    expect(terminal).toBeDefined();
+    expect(terminal).toBe(getPanelKindConfig("terminal")?.color);
+  });
+
+  it("returns a neutral text token for unrecognized kinds", () => {
+    expect(getPanelKindColor("totally-unknown-kind")).toBe("var(--theme-text-secondary)");
   });
 });

--- a/shared/config/__tests__/panelKindRegistry.test.ts
+++ b/shared/config/__tests__/panelKindRegistry.test.ts
@@ -375,6 +375,11 @@ describe("registerPanelKind collision guard", () => {
     const after = getPanelKindConfig("terminal");
     expect(after).toBe(original);
     expect(after?.name).toBe(original?.name);
+    expect(after?.iconId).toBe(original?.iconId);
+    expect(after?.color).toBe(original?.color);
+    expect(after?.hasPty).toBe(original?.hasPty);
+    expect(after?.canRestart).toBe(original?.canRestart);
+    expect(after?.showInPalette).toBe(original?.showInPalette);
     expect(after?.extensionId).toBeUndefined();
     expect(errorSpy).toHaveBeenCalledTimes(1);
     expect(listener).not.toHaveBeenCalled();
@@ -433,5 +438,13 @@ describe("getPanelKindColor fallback", () => {
 
   it("returns a neutral text token for unrecognized kinds", () => {
     expect(getPanelKindColor("totally-unknown-kind")).toBe("var(--theme-text-secondary)");
+  });
+
+  it("returns the neutral fallback after a plugin kind is unregistered", () => {
+    registerPanelKind(makeExtensionConfig("ext-a.viewer", "ext-a"));
+    expect(getPanelKindColor("ext-a.viewer")).toBe("#123456");
+
+    unregisterPluginPanelKinds("ext-a");
+    expect(getPanelKindColor("ext-a.viewer")).toBe("var(--theme-text-secondary)");
   });
 });

--- a/shared/config/panelKindRegistry.ts
+++ b/shared/config/panelKindRegistry.ts
@@ -178,7 +178,14 @@ function emitUnregistered(kindId: string): void {
  * @param config - The panel kind configuration to register
  */
 export function registerPanelKind(config: PanelKindConfig): void {
-  if (PANEL_KIND_REGISTRY[config.id]) {
+  const existing = PANEL_KIND_REGISTRY[config.id];
+  if (existing && existing.extensionId === undefined && config.extensionId !== undefined) {
+    console.error(
+      `[panelKindRegistry] Refusing to overwrite built-in panel kind "${config.id}" with extension "${config.extensionId}"`
+    );
+    return;
+  }
+  if (existing) {
     console.warn(`Panel kind "${config.id}" already registered, overwriting`);
   }
   PANEL_KIND_REGISTRY[config.id] = config;
@@ -308,8 +315,9 @@ export function getPanelKindColor(kind: PanelKind, agentId?: string): string {
   const config = getPanelKindConfig(kind);
   if (config) return config.color;
 
-  // Fallback for unknown kinds
-  return PANEL_KIND_BRAND_COLORS.terminal;
+  // Neutral fallback for unrecognized kinds — avoids visually impersonating
+  // a built-in (terminal teal) for an unknown extension panel.
+  return "var(--theme-text-secondary)";
 }
 
 /**

--- a/src/panels/__tests__/registry.adversarial.test.ts
+++ b/src/panels/__tests__/registry.adversarial.test.ts
@@ -174,7 +174,8 @@ describe("panel registry adversarial", () => {
     // subscribers re-render without any actual change.
     expect(getPanelKindDefinitionsSnapshot()).toBe(snapshotBefore);
     expect(errorSpy).toHaveBeenCalledWith(
-      expect.stringContaining('Refusing to overwrite built-in panel kind definition "browser"')
+      expect.stringContaining('Refusing to overwrite built-in panel kind definition "browser"'),
+      expect.anything()
     );
     errorSpy.mockRestore();
   });
@@ -230,8 +231,8 @@ describe("panel registry adversarial", () => {
     expect(throwingListener).toHaveBeenCalledTimes(1);
     expect(goodListener).toHaveBeenCalledTimes(1);
     expect(errorSpy).toHaveBeenCalledWith(
-      "[panelKindRegistry] definition listener threw:",
-      expect.any(Error)
+      expect.stringContaining("[panelKindRegistry] definition listener threw"),
+      expect.anything()
     );
 
     off1();

--- a/src/panels/__tests__/registry.adversarial.test.ts
+++ b/src/panels/__tests__/registry.adversarial.test.ts
@@ -142,4 +142,95 @@ describe("panel registry adversarial", () => {
       expect(registry.getPanelKindDefinition(kind)).toBeDefined();
     }
   });
+
+  it("PLUGIN_DEFINITION_CANNOT_OVERWRITE_BUILTIN", async () => {
+    mockRegistryImports();
+    const errorSpy = vi.spyOn(console, "error").mockImplementation(() => {});
+    const { getPanelKindDefinition, registerPanelKindDefinition } = await import("../registry");
+
+    const original = getPanelKindDefinition("browser");
+    expect(original?.extensionId).toBeUndefined();
+    const malicious = (() => null) as MinimalComponent;
+
+    registerPanelKindDefinition({
+      id: "browser",
+      name: "Hijacked",
+      iconId: "skull",
+      color: "#ff0000",
+      hasPty: false,
+      canRestart: false,
+      canConvert: false,
+      extensionId: "evil-plugin",
+      component: malicious,
+    });
+
+    const after = getPanelKindDefinition("browser");
+    expect(after?.component).toBe(original?.component);
+    expect(after?.extensionId).toBeUndefined();
+    expect(after?.name).toBe(original?.name);
+    expect(errorSpy).toHaveBeenCalledWith(
+      expect.stringContaining('Refusing to overwrite built-in panel kind definition "browser"')
+    );
+    errorSpy.mockRestore();
+  });
+
+  it("UNREGISTER_PLUGIN_DEFINITION_SUCCEEDS", async () => {
+    mockRegistryImports();
+    const { registerPanelKindDefinition, unregisterPanelKindDefinition, getPanelKindDefinition } =
+      await import("../registry");
+
+    const component = (() => null) as MinimalComponent;
+    registerPanelKindDefinition({
+      id: "ext-a.viewer",
+      name: "Viewer",
+      iconId: "eye",
+      color: "#123456",
+      hasPty: false,
+      canRestart: false,
+      canConvert: false,
+      extensionId: "ext-a",
+      component,
+    });
+
+    expect(getPanelKindDefinition("ext-a.viewer")).toBeDefined();
+    expect(unregisterPanelKindDefinition("ext-a.viewer")).toBe(true);
+    expect(getPanelKindDefinition("ext-a.viewer")).toBeUndefined();
+  });
+
+  it("DEFINITION_LISTENER_ERROR_LOGGED_AT_ERROR_LEVEL", async () => {
+    mockRegistryImports();
+    const errorSpy = vi.spyOn(console, "error").mockImplementation(() => {});
+    const { registerPanelKindDefinition, subscribeToPanelKindDefinitions } =
+      await import("../registry");
+
+    const throwingListener = vi.fn(() => {
+      throw new Error("listener boom");
+    });
+    const goodListener = vi.fn();
+    const off1 = subscribeToPanelKindDefinitions(throwingListener);
+    const off2 = subscribeToPanelKindDefinitions(goodListener);
+
+    registerPanelKindDefinition({
+      id: "ext-a.viewer",
+      name: "Viewer",
+      iconId: "eye",
+      color: "#123456",
+      hasPty: false,
+      canRestart: false,
+      canConvert: false,
+      extensionId: "ext-a",
+      component: (() => null) as MinimalComponent,
+    });
+
+    expect(throwingListener).toHaveBeenCalledTimes(1);
+    expect(goodListener).toHaveBeenCalledTimes(1);
+    expect(errorSpy).toHaveBeenCalledWith(
+      "[panelKindRegistry] definition listener threw:",
+      expect.any(Error)
+    );
+
+    off1();
+    off2();
+    errorSpy.mockRestore();
+  });
 });

--- a/src/panels/__tests__/registry.adversarial.test.ts
+++ b/src/panels/__tests__/registry.adversarial.test.ts
@@ -146,10 +146,12 @@ describe("panel registry adversarial", () => {
   it("PLUGIN_DEFINITION_CANNOT_OVERWRITE_BUILTIN", async () => {
     mockRegistryImports();
     const errorSpy = vi.spyOn(console, "error").mockImplementation(() => {});
-    const { getPanelKindDefinition, registerPanelKindDefinition } = await import("../registry");
+    const { getPanelKindDefinition, getPanelKindDefinitionsSnapshot, registerPanelKindDefinition } =
+      await import("../registry");
 
     const original = getPanelKindDefinition("browser");
     expect(original?.extensionId).toBeUndefined();
+    const snapshotBefore = getPanelKindDefinitionsSnapshot();
     const malicious = (() => null) as MinimalComponent;
 
     registerPanelKindDefinition({
@@ -168,6 +170,9 @@ describe("panel registry adversarial", () => {
     expect(after?.component).toBe(original?.component);
     expect(after?.extensionId).toBeUndefined();
     expect(after?.name).toBe(original?.name);
+    // Rejected registration must not invalidate the snapshot — otherwise React
+    // subscribers re-render without any actual change.
+    expect(getPanelKindDefinitionsSnapshot()).toBe(snapshotBefore);
     expect(errorSpy).toHaveBeenCalledWith(
       expect.stringContaining('Refusing to overwrite built-in panel kind definition "browser"')
     );

--- a/src/panels/registry.tsx
+++ b/src/panels/registry.tsx
@@ -216,7 +216,13 @@ export function registerPanelKindDefinition(
       );
       return;
     }
-    definition = { ...config, component: component! };
+    if (!component) {
+      console.error(
+        `[panelKindRegistry] registerPanelKindDefinition("${definitionOrKindId}") called without a component`
+      );
+      return;
+    }
+    definition = { ...config, component };
   } else {
     definition = definitionOrKindId;
   }

--- a/src/panels/registry.tsx
+++ b/src/panels/registry.tsx
@@ -13,6 +13,7 @@ import { TerminalPane } from "@/components/Terminal/TerminalPane";
 import { ErrorBoundary } from "@/components/ErrorBoundary";
 import { BrowserPaneSkeleton } from "@/components/Browser/BrowserPaneSkeleton";
 import { ContentFadeIn } from "@/components/ui/ContentFadeIn";
+import { logError } from "@/utils/logger";
 
 import { serializePtyPanel } from "./terminal/serializer";
 import { createTerminalDefaults } from "./terminal/defaults";
@@ -165,7 +166,7 @@ function notifyDefinitionListeners(): void {
     try {
       listener();
     } catch (err) {
-      console.error("[panelKindRegistry] definition listener threw:", err);
+      logError("[panelKindRegistry] definition listener threw", err);
     }
   }
 }
@@ -217,7 +218,7 @@ export function registerPanelKindDefinition(
       return;
     }
     if (!component) {
-      console.error(
+      logError(
         `[panelKindRegistry] registerPanelKindDefinition("${definitionOrKindId}") called without a component`
       );
       return;
@@ -229,7 +230,7 @@ export function registerPanelKindDefinition(
 
   const existing = PANEL_KIND_DEFINITION_REGISTRY[definition.id];
   if (existing && existing.extensionId === undefined && definition.extensionId !== undefined) {
-    console.error(
+    logError(
       `[panelKindRegistry] Refusing to overwrite built-in panel kind definition "${definition.id}" with extension "${definition.extensionId}"`
     );
     return;

--- a/src/panels/registry.tsx
+++ b/src/panels/registry.tsx
@@ -165,7 +165,7 @@ function notifyDefinitionListeners(): void {
     try {
       listener();
     } catch (err) {
-      console.warn("[panelKindRegistry] definition listener threw:", err);
+      console.error("[panelKindRegistry] definition listener threw:", err);
     }
   }
 }
@@ -221,7 +221,14 @@ export function registerPanelKindDefinition(
     definition = definitionOrKindId;
   }
 
-  if (PANEL_KIND_DEFINITION_REGISTRY[definition.id]) {
+  const existing = PANEL_KIND_DEFINITION_REGISTRY[definition.id];
+  if (existing && existing.extensionId === undefined && definition.extensionId !== undefined) {
+    console.error(
+      `[panelKindRegistry] Refusing to overwrite built-in panel kind definition "${definition.id}" with extension "${definition.extensionId}"`
+    );
+    return;
+  }
+  if (existing) {
     console.warn(`Panel kind definition "${definition.id}" already registered, overwriting`);
   }
   PANEL_KIND_DEFINITION_REGISTRY[definition.id] = definition;
@@ -233,9 +240,10 @@ export function registerPanelKindDefinition(
  * `getPanelKindDefinition` falls back to `undefined` and panel components
  * render their `PluginMissingPanel` placeholder again.
  *
- * Built-in kinds (`terminal`, `browser`, `dev-preview`) are never removable —
- * their components are wired at module load and unregistering would leave
- * panels orphaned with no recovery path.
+ * Built-in kinds (entries with no `extensionId`) are never removable — their
+ * components are wired at module load and unregistering would leave panels
+ * orphaned with no recovery path. Mirrors the `extensionId === undefined`
+ * guard used by `unregisterPanelKind` in the shared registry.
  */
 export function unregisterPanelKindDefinition(kindId: string): boolean {
   if (isBuiltInPanelKind(kindId)) {


### PR DESCRIPTION
## Summary

- There was nothing stopping a plugin from replacing a built-in panel entry just by registering the same kind string — the registry warned and overwrote silently.
- `unregisterPanelKindDefinition` was comparing against a hardcoded list of kind strings instead of checking `extensionId`, so adding a fourth built-in kind would have left it unprotected.
- `getPanelKindColor` was returning the terminal brand color as its unknown-kind fallback, making unrecognised extension kinds look like terminals.

Resolves #7283

## Changes

- Added a cross-category collision guard to `registerPanelKind` and `registerPanelKindDefinition` — if one entry has no `extensionId` and the other does, the overwrite is refused with an error.
- `unregisterPanelKindDefinition` now uses the `extensionId === undefined` check (matching the shared registry) instead of a hardcoded kind-string allowlist.
- Listener error logging promoted from `console.warn` to `logError`. Listeners drive `useSyncExternalStore` — a thrown listener can leave the UI stale, which warrants the stronger signal.
- `getPanelKindColor` fallback changed from terminal brand color to `var(--theme-text-secondary)`.

## Testing

41 tests added across `shared/config/__tests__/panelKindRegistry.test.ts` and `src/panels/__tests__/registry.adversarial.test.ts` covering collision guards, color fallback, snapshot identity preservation, and listener error level.