### PR TITLE
fix(ProjectStore): batch reconciliation writes in a transaction

### DIFF
--- a/electron/services/ProjectStore.ts
+++ b/electron/services/ProjectStore.ts
@@ -314,34 +314,44 @@ export class ProjectStore {
     const validStatuses: ProjectStatus[] = ["active", "background", "closed", "missing"];
     const currentProjectId = this.getCurrentProjectId();
 
-    for (const row of rows) {
-      if (row.id === currentProjectId) {
-        if (row.status !== "active") {
-          db.update(projectsTable)
-            .set({ status: "active" })
-            .where(eq(projectsTable.id, row.id))
-            .run();
-          row.status = "active";
+    db.transaction(
+      (tx) => {
+        for (const row of rows) {
+          if (row.id === currentProjectId) {
+            if (row.status !== "active") {
+              tx.update(projectsTable)
+                .set({ status: "active" })
+                .where(eq(projectsTable.id, row.id))
+                .run();
+              row.status = "active";
+            }
+          } else {
+            if (row.status === "active") {
+              if (process.env.DAINTREE_VERBOSE) {
+                console.warn(
+                  `[ProjectStore] Demoting incorrectly active project ${row.id} to background`
+                );
+              }
+              tx.update(projectsTable)
+                .set({ status: "background" })
+                .where(eq(projectsTable.id, row.id))
+                .run();
+              row.status = "background";
+            } else if (
+              row.status !== null &&
+              !validStatuses.includes(row.status as ProjectStatus)
+            ) {
+              tx.update(projectsTable)
+                .set({ status: "closed" })
+                .where(eq(projectsTable.id, row.id))
+                .run();
+              row.status = "closed";
+            }
+          }
         }
-      } else {
-        if (row.status === "active") {
-          console.warn(
-            `[ProjectStore] Demoting incorrectly active project ${row.id} to background`
-          );
-          db.update(projectsTable)
-            .set({ status: "background" })
-            .where(eq(projectsTable.id, row.id))
-            .run();
-          row.status = "background";
-        } else if (row.status !== null && !validStatuses.includes(row.status as ProjectStatus)) {
-          db.update(projectsTable)
-            .set({ status: "closed" })
-            .where(eq(projectsTable.id, row.id))
-            .run();
-          row.status = "closed";
-        }
-      }
-    }
+      },
+      { behavior: "immediate" }
+    );
 
     if (process.env.DAINTREE_VERBOSE) {
       console.log(

--- a/electron/services/__tests__/ProjectStore.test.ts
+++ b/electron/services/__tests__/ProjectStore.test.ts
@@ -1,4 +1,4 @@
-import { describe, it, expect } from "vitest";
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
 import path from "path";
 import { generateProjectId, isValidProjectId, getProjectStateDir } from "../projectStorePaths.js";
 
@@ -555,5 +555,253 @@ describe("relocateProject — ID derivation helpers (smoke tests only)", () => {
     expect(newStateDir).not.toBeNull();
     expect(newStateDir!.startsWith(projectsConfigDir)).toBe(true);
     expect(newStateDir).toBe(path.join(projectsConfigDir, newId));
+  });
+});
+
+// --- getAllProjects status reconciliation tests (DB-backed) ---
+
+import Database from "better-sqlite3";
+import { drizzle } from "drizzle-orm/better-sqlite3";
+import { eq } from "drizzle-orm";
+import fs from "fs";
+import os from "os";
+import * as schema from "../persistence/schema.js";
+
+const CREATE_TABLES_SQL = `
+  CREATE TABLE IF NOT EXISTS projects (
+    id TEXT PRIMARY KEY,
+    path TEXT NOT NULL,
+    name TEXT NOT NULL,
+    emoji TEXT NOT NULL,
+    last_opened INTEGER NOT NULL,
+    color TEXT,
+    status TEXT,
+    daintree_config_present INTEGER,
+    in_repo_settings INTEGER,
+    pinned INTEGER NOT NULL DEFAULT 0,
+    frecency_score REAL NOT NULL DEFAULT 3.0,
+    last_accessed_at INTEGER NOT NULL DEFAULT 0
+  );
+  CREATE TABLE IF NOT EXISTS app_state (
+    key TEXT PRIMARY KEY,
+    value TEXT NOT NULL
+  );
+`;
+
+let sqlite: Database.Database;
+let db: ReturnType<typeof drizzle<typeof schema>>;
+
+vi.mock("../persistence/db.js", () => ({
+  getSharedDb: () => db,
+  openDb: vi.fn(),
+}));
+
+vi.mock("electron", () => ({
+  app: { getPath: () => "/tmp/daintree-reconciliation-test" },
+}));
+
+vi.mock("../GitService.js", () => ({
+  GitService: class {
+    async getRepositoryRoot(p: string): Promise<string> {
+      return p;
+    }
+  },
+}));
+
+vi.mock("../ProjectSettingsManager.js", () => ({
+  ProjectSettingsManager: class {
+    deleteAllEnvForProject() {}
+    migrateEnvForProject() {}
+    getEffectiveNotificationSettings() {
+      return {};
+    }
+  },
+}));
+
+vi.mock("../ProjectStateManager.js", () => ({
+  ProjectStateManager: class {
+    invalidateProjectStateCache() {}
+  },
+}));
+
+vi.mock("../ProjectFileStore.js", () => ({
+  ProjectFileStore: class {},
+}));
+
+vi.mock("../GlobalFileStore.js", () => ({
+  GlobalFileStore: class {},
+}));
+
+vi.mock("../ProjectIdentityFiles.js", () => ({
+  ProjectIdentityFiles: class {
+    async readInRepoProjectIdentity() {
+      return { found: false };
+    }
+  },
+}));
+
+vi.mock("../projectQuarantineCleanup.js", () => ({
+  cleanupQuarantinedProjectFiles: vi.fn(),
+}));
+
+import { ProjectStore } from "../ProjectStore.js";
+
+describe("ProjectStore.getAllProjects reconciliation", () => {
+  let store: ProjectStore;
+  let alphaDir: string;
+  let betaDir: string;
+  let gammaDir: string;
+  let currentProjectId: string;
+  let staleActiveId: string;
+  let invalidStatusId: string;
+
+  beforeEach(async () => {
+    alphaDir = fs.mkdtempSync(path.join(os.tmpdir(), "daintree-rec-a-"));
+    betaDir = fs.mkdtempSync(path.join(os.tmpdir(), "daintree-rec-b-"));
+    gammaDir = fs.mkdtempSync(path.join(os.tmpdir(), "daintree-rec-c-"));
+    const { generateProjectId } = await import("../projectStorePaths.js");
+    const alphaCanonical = await fs.promises.realpath(alphaDir);
+    const betaCanonical = await fs.promises.realpath(betaDir);
+    const gammaCanonical = await fs.promises.realpath(gammaDir);
+    currentProjectId = generateProjectId(alphaCanonical);
+    staleActiveId = generateProjectId(betaCanonical);
+    invalidStatusId = generateProjectId(gammaCanonical);
+
+    sqlite = new Database(":memory:");
+    sqlite.exec(CREATE_TABLES_SQL);
+    db = drizzle(sqlite, { schema });
+
+    const now = Date.now();
+
+    // Current project — incorrectly marked as "closed"
+    db.insert(schema.projects)
+      .values({
+        id: currentProjectId,
+        path: alphaCanonical,
+        name: "Alpha",
+        emoji: "🌲",
+        lastOpened: now,
+        status: "closed",
+        frecencyScore: 10.0,
+        lastAccessedAt: now,
+      })
+      .run();
+
+    // Stale row — incorrectly marked as "active" (should be background)
+    db.insert(schema.projects)
+      .values({
+        id: staleActiveId,
+        path: betaCanonical,
+        name: "Beta",
+        emoji: "🌲",
+        lastOpened: now - 86_400_000,
+        status: "active",
+        frecencyScore: 5.0,
+        lastAccessedAt: now - 86_400_000,
+      })
+      .run();
+
+    // Row with invalid status (not in validStatuses)
+    db.insert(schema.projects)
+      .values({
+        id: invalidStatusId,
+        path: gammaCanonical,
+        name: "Gamma",
+        emoji: "🌲",
+        lastOpened: now - 172_800_000,
+        status: "bogus-status",
+        frecencyScore: 1.0,
+        lastAccessedAt: now - 172_800_000,
+      })
+      .run();
+
+    db.insert(schema.appState).values({ key: "currentProjectId", value: currentProjectId }).run();
+
+    store = new ProjectStore();
+  });
+
+  afterEach(() => {
+    sqlite.close();
+    fs.rmSync(alphaDir, { recursive: true, force: true });
+    fs.rmSync(betaDir, { recursive: true, force: true });
+    fs.rmSync(gammaDir, { recursive: true, force: true });
+  });
+
+  it("reconciles all three status categories and persists to DB", () => {
+    const projects = store.getAllProjects();
+
+    // Returned values are reconciled
+    const current = projects.find((p) => p.id === currentProjectId);
+    const stale = projects.find((p) => p.id === staleActiveId);
+    const invalid = projects.find((p) => p.id === invalidStatusId);
+
+    expect(current?.status).toBe("active");
+    expect(stale?.status).toBe("background");
+    expect(invalid?.status).toBe("closed");
+
+    // DB rows are persisted
+    const currentRow = db
+      .select()
+      .from(schema.projects)
+      .where(eq(schema.projects.id, currentProjectId))
+      .get();
+    expect(currentRow?.status).toBe("active");
+
+    const staleRow = db
+      .select()
+      .from(schema.projects)
+      .where(eq(schema.projects.id, staleActiveId))
+      .get();
+    expect(staleRow?.status).toBe("background");
+
+    const invalidRow = db
+      .select()
+      .from(schema.projects)
+      .where(eq(schema.projects.id, invalidStatusId))
+      .get();
+    expect(invalidRow?.status).toBe("closed");
+  });
+
+  it("runs reconciliation inside an IMMEDIATE transaction", () => {
+    const spy = vi.spyOn(db, "transaction");
+    store.getAllProjects();
+    expect(spy).toHaveBeenCalledWith(expect.any(Function), { behavior: "immediate" });
+    spy.mockRestore();
+  });
+
+  it("gates demotion warning behind DAINTREE_VERBOSE", () => {
+    const warnSpy = vi.spyOn(console, "warn");
+
+    // Without DAINTREE_VERBOSE — no warning
+    delete process.env.DAINTREE_VERBOSE;
+    store.getAllProjects();
+    expect(warnSpy).not.toHaveBeenCalled();
+
+    // Re-insert the stale active row so the warning has something to fire for
+    db.update(schema.projects)
+      .set({ status: "active" })
+      .where(eq(schema.projects.id, staleActiveId))
+      .run();
+
+    // With DAINTREE_VERBOSE — warning fires
+    process.env.DAINTREE_VERBOSE = "1";
+    store.getAllProjects();
+    expect(warnSpy).toHaveBeenCalledWith(
+      expect.stringContaining("Demoting incorrectly active project")
+    );
+
+    delete process.env.DAINTREE_VERBOSE;
+    warnSpy.mockRestore();
+  });
+
+  it("no-ops when all statuses are already correct (empty transaction)", () => {
+    // First call reconciles everything
+    store.getAllProjects();
+
+    // Second call should be a no-op — no writes needed
+    const updateSpy = vi.spyOn(db, "update");
+    store.getAllProjects();
+    expect(updateSpy).not.toHaveBeenCalled();
+    updateSpy.mockRestore();
   });
 });


### PR DESCRIPTION
## Summary
- Wraps the `getAllProjects` status reconciliation loop in a single `db.transaction()` with `IMMEDIATE` behavior, eliminating one fsync per row on the post-crash recovery path.
- Gates the "demoting incorrectly active project" warning behind `DAINTREE_VERBOSE` so it stops firing on every call.
- Adds DB-backed unit tests covering all three reconciliation categories, transaction wrapping, verbose gating, and the clean no-op path.

Resolves #7090

## Changes
- `electron/services/ProjectStore.ts` — wraps reconciliation writes in `db.transaction({ behavior: "immediate" })`; gates the demotion warning behind `DAINTREE_VERBOSE`
- `electron/services/__tests__/ProjectStore.test.ts` — four new tests using in-memory SQLite via better-sqlite3 + drizzle

## Testing
- Unit tests verify: correct status for current, stale, and invalid rows; DB persistence after reconciliation; `IMMEDIATE` transaction wrapping; `DAINTREE_VERBOSE` demotion-warning gating; and no-op on clean state.
- Typecheck, Prettier, and ESLint all pass clean.