### PR TITLE
fix(github): polish PR discovery and required-CI status layer

### DIFF
--- a/electron/services/__tests__/GitHubService.adversarial.test.ts
+++ b/electron/services/__tests__/GitHubService.adversarial.test.ts
@@ -617,6 +617,47 @@ describe("GitHubService adversarial", () => {
     expect(shared.graphqlClient).toHaveBeenCalledTimes(1);
   });
 
+  it("BATCHCHECK_DISCOVERY_BRANCH_SELECTS_NEWEST_WITHIN_TIER", async () => {
+    // Branch-query orders DESC (newest-first). Within the open tier, the
+    // newest PR must be selected, not the oldest.
+    vi.mocked(global.fetch).mockResolvedValueOnce(
+      createBranchListResponse(200, {
+        etag: 'W/"discovered"',
+        body: [{ number: 200 }, { number: 100 }],
+      })
+    );
+    shared.graphqlClient.mockResolvedValueOnce({
+      wt_0_branch: {
+        pullRequests: {
+          nodes: [
+            {
+              number: 200,
+              title: "Newer",
+              url: "https://github.com/owner/repo/pull/200",
+              state: "OPEN",
+              updatedAt: "2026-02-01T00:00:00Z",
+              merged: false,
+            },
+            {
+              number: 100,
+              title: "Older",
+              url: "https://github.com/owner/repo/pull/100",
+              state: "OPEN",
+              updatedAt: "2026-01-01T00:00:00Z",
+              merged: false,
+            },
+          ],
+        },
+      },
+    });
+
+    const result = await github.batchCheckLinkedPRs("/repo", [
+      { worktreeId: "wt-1", branchName: "feature/reused" },
+    ]);
+    expect(result.results.size).toBe(1);
+    expect(result.results.get("wt-1")?.pr?.number).toBe(200);
+  });
+
   it("BATCHCHECK_DISCOVERY_BRANCH_PROBE_SENDS_IF_NONE_MATCH", async () => {
     // Cycle 1 seeds the branch-list ETag.
     vi.mocked(global.fetch).mockResolvedValueOnce(

--- a/electron/services/__tests__/GitHubService.parsePRNode.test.ts
+++ b/electron/services/__tests__/GitHubService.parsePRNode.test.ts
@@ -1,8 +1,8 @@
 import { describe, it, expect } from "vitest";
 
-// parsePRNode is not exported — test via the public listPullRequests surface
-// by verifying that the fields are correctly extracted from raw GraphQL node data.
-// We test the transformation logic directly by duplicating the function shape.
+// parsePRNode is exported from GitHubPRs.ts — tested via the public listPullRequests surface,
+// but we duplicate the transformation logic here to keep tests self-contained.
+// When parsePRNode changes, keep this inline copy in sync.
 
 type GitHubPRCIStatus = "SUCCESS" | "FAILURE" | "ERROR" | "PENDING" | "EXPECTED";
 
@@ -27,6 +27,24 @@ interface RawPRNode {
   };
 }
 
+// Inline normalizeRawState from prRequiredCIStatus.ts to keep tests self-contained
+function normalizeRawState(
+  rawRollupState: string | null | undefined
+): GitHubPRCIStatus | undefined {
+  if (!rawRollupState) return undefined;
+  const upper = rawRollupState.toUpperCase();
+  if (
+    upper === "SUCCESS" ||
+    upper === "FAILURE" ||
+    upper === "ERROR" ||
+    upper === "PENDING" ||
+    upper === "EXPECTED"
+  ) {
+    return upper;
+  }
+  return undefined;
+}
+
 // Inline the logic from parsePRNode to keep tests self-contained
 function parsePRNode(node: RawPRNode) {
   const author = node.author;
@@ -46,9 +64,7 @@ function parsePRNode(node: RawPRNode) {
   const baseName = baseRepo?.nameWithOwner;
   const isFork = headName && baseName ? headName !== baseName : undefined;
 
-  const ciStatus = node.commits?.nodes?.[0]?.commit?.statusCheckRollup?.state as
-    | GitHubPRCIStatus
-    | undefined;
+  const ciStatus = normalizeRawState(node.commits?.nodes?.[0]?.commit?.statusCheckRollup?.state);
 
   return {
     number: node.number,
@@ -227,6 +243,22 @@ describe("parsePRNode", () => {
   it("sets ciStatus to undefined when commits field is absent", () => {
     const result = parsePRNode(baseNode);
     expect(result.ciStatus).toBeUndefined();
+  });
+
+  it("sets ciStatus to undefined for unrecognized rollup state", () => {
+    const result = parsePRNode({
+      ...baseNode,
+      commits: { nodes: [{ commit: { statusCheckRollup: { state: "SKIPPED" } } }] },
+    });
+    expect(result.ciStatus).toBeUndefined();
+  });
+
+  it("normalizes lowercase rollup state to uppercase", () => {
+    const result = parsePRNode({
+      ...baseNode,
+      commits: { nodes: [{ commit: { statusCheckRollup: { state: "success" } } }] },
+    });
+    expect(result.ciStatus).toBe("SUCCESS");
   });
 
   it("extracts commentCount from comments totalCount", () => {

--- a/electron/services/github/GitHubPRDiscovery.ts
+++ b/electron/services/github/GitHubPRDiscovery.ts
@@ -159,11 +159,11 @@ function parseBatchPRResponse(
 
         let chosen: { pr: LinkedPR; raw: BatchPRRawNode } | undefined;
         if (openPRs.length > 0) {
-          chosen = openPRs[openPRs.length - 1];
+          chosen = openPRs[0];
         } else if (mergedPRs.length > 0) {
-          chosen = mergedPRs[mergedPRs.length - 1];
+          chosen = mergedPRs[0];
         } else if (closedPRs.length > 0) {
-          chosen = closedPRs[closedPRs.length - 1];
+          chosen = closedPRs[0];
         }
         if (chosen) {
           foundPR = chosen.pr;

--- a/electron/services/github/GitHubPRs.ts
+++ b/electron/services/github/GitHubPRs.ts
@@ -19,7 +19,7 @@ import {
   type PRRequiredStatusEntry,
 } from "./GitHubCaches.js";
 import { GitHubStatsCache } from "../GitHubStatsCache.js";
-import { deriveRequiredCIStatus } from "./prRequiredCIStatus.js";
+import { deriveRequiredCIStatus, normalizeRawState } from "./prRequiredCIStatus.js";
 import type { RollupContextNode } from "./prRequiredCIStatus.js";
 import type {
   GitHubPR,
@@ -89,9 +89,7 @@ export function parsePRNode(node: Record<string, unknown>): GitHubPR {
   const commitsData = node.commits as
     | { nodes?: Array<{ commit?: { statusCheckRollup?: { state?: string } | null } | null }> }
     | undefined;
-  const ciStatus = commitsData?.nodes?.[0]?.commit?.statusCheckRollup?.state as
-    | GitHubPRCIStatus
-    | undefined;
+  const ciStatus = normalizeRawState(commitsData?.nodes?.[0]?.commit?.statusCheckRollup?.state);
 
   return {
     number: node.number as number,

--- a/electron/services/github/GitHubPRs.ts
+++ b/electron/services/github/GitHubPRs.ts
@@ -23,7 +23,6 @@ import { deriveRequiredCIStatus, normalizeRawState } from "./prRequiredCIStatus.
 import type { RollupContextNode } from "./prRequiredCIStatus.js";
 import type {
   GitHubPR,
-  GitHubPRCIStatus,
   GitHubListOptions,
   GitHubListResponse,
   PRTooltipData,

--- a/electron/services/github/GitHubQueries.ts
+++ b/electron/services/github/GitHubQueries.ts
@@ -579,7 +579,7 @@ export function buildBatchRequiredChecksQuery(
               commit {
                 statusCheckRollup {
                   state
-                  contexts(first: 50) {
+                  contexts(first: 100) {
                     pageInfo { hasNextPage }
                     nodes {
                       __typename

--- a/electron/services/github/__tests__/GitHubQueries.test.ts
+++ b/electron/services/github/__tests__/GitHubQueries.test.ts
@@ -170,7 +170,7 @@ describe("buildBatchPRQuery", () => {
     expect(query).toContain("pullRequest(number: 34)");
     expect(query).toContain("isRequired(pullRequestNumber: 12)");
     expect(query).toContain("isRequired(pullRequestNumber: 34)");
-    expect(query).toContain("contexts(first: 50)");
+    expect(query).toContain("contexts(first: 100)");
     expect(query).toContain("... on CheckRun");
     expect(query).toContain("... on StatusContext");
     expect(query).toContain("hasNextPage");

--- a/electron/services/github/__tests__/prRequiredCIStatus.test.ts
+++ b/electron/services/github/__tests__/prRequiredCIStatus.test.ts
@@ -1,5 +1,5 @@
 import { describe, expect, it } from "vitest";
-import { deriveRequiredCIStatus } from "../prRequiredCIStatus.js";
+import { deriveRequiredCIStatus, normalizeRawState } from "../prRequiredCIStatus.js";
 
 describe("deriveRequiredCIStatus", () => {
   it("returns raw status and no summary when contexts is null", () => {
@@ -206,5 +206,36 @@ describe("deriveRequiredCIStatus", () => {
     );
     expect(r.ciStatus).toBe("FAILURE");
     expect(r.ciSummary).toEqual({ requiredTotal: 2, requiredFailing: 1, requiredPending: 1 });
+  });
+});
+
+describe("normalizeRawState", () => {
+  it("returns SUCCESS FAILURE ERROR PENDING EXPECTED as-is", () => {
+    expect(normalizeRawState("SUCCESS")).toBe("SUCCESS");
+    expect(normalizeRawState("FAILURE")).toBe("FAILURE");
+    expect(normalizeRawState("ERROR")).toBe("ERROR");
+    expect(normalizeRawState("PENDING")).toBe("PENDING");
+    expect(normalizeRawState("EXPECTED")).toBe("EXPECTED");
+  });
+
+  it("uppercases lowercase valid states", () => {
+    expect(normalizeRawState("success")).toBe("SUCCESS");
+    expect(normalizeRawState("failure")).toBe("FAILURE");
+    expect(normalizeRawState("pending")).toBe("PENDING");
+  });
+
+  it("returns undefined for null or undefined input", () => {
+    expect(normalizeRawState(null)).toBeUndefined();
+    expect(normalizeRawState(undefined)).toBeUndefined();
+  });
+
+  it("returns undefined for empty string", () => {
+    expect(normalizeRawState("")).toBeUndefined();
+  });
+
+  it("returns undefined for unrecognized values", () => {
+    expect(normalizeRawState("SKIPPED")).toBeUndefined();
+    expect(normalizeRawState("STALE")).toBeUndefined();
+    expect(normalizeRawState("IN_PROGRESS")).toBeUndefined();
   });
 });

--- a/electron/services/github/prRequiredCIStatus.ts
+++ b/electron/services/github/prRequiredCIStatus.ts
@@ -42,7 +42,7 @@ export interface DerivedCIResult {
   ciSummary: GitHubPRCISummary | undefined;
 }
 
-function normalizeRawState(
+export function normalizeRawState(
   rawRollupState: string | null | undefined
 ): GitHubPRCIStatus | undefined {
   if (!rawRollupState) return undefined;


### PR DESCRIPTION
## Summary
A polish pass on GitHub PR discovery and the required-CI status layer. Fixes a handful of small but load-bearing issues that were causing incorrect PR selection and missed CI checks.

Resolves #7068

## Changes
- PR discovery now selects the newest PR within each tier (open, merged, closed) instead of the oldest. The branch query already orders results DESC, but we were picking the last element in the open/merged/closed arrays rather than the first.
- Raw CI rollup state is normalized through a shared `normalizeRawState` function that rejects unrecognized values instead of casting them directly to the `GitHubPRCIStatus` type, preventing garbage state strings from leaking into the UI.
- Bumped the GraphQL batch check `contexts(first:)` from 50 to 100 to avoid missing required checks on repos with a lot of check runs and status contexts.
- Removed a dead `GitHubPRCIStatus` import leftover after the `normalizeRawState` refactor.

## Testing
- Tier-selection ordering: new adversarial test confirms the newest PR is selected when two open PRs match the same branch.
- State normalization: `normalizeRawState` unit tests cover uppercase passthrough, lowercase normalization, null/undefined/empty rejection, and unrecognized value filtering.
- Contexts limit: existing query test updated to expect `contexts(first: 100)`.