### PR TITLE
fix(gemini): tighten GeminiConfigService error handling and add tests

### DIFF
--- a/electron/__tests__/GeminiConfigService.test.ts
+++ b/electron/__tests__/GeminiConfigService.test.ts
@@ -1,0 +1,195 @@
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+import { mkdir, rm, writeFile } from "node:fs/promises";
+import { mkdtempSync } from "node:fs";
+import { tmpdir } from "node:os";
+import path from "node:path";
+import { readFile } from "node:fs/promises";
+
+const testDir = mkdtempSync(path.join(tmpdir(), "gemini-config-test-"));
+
+vi.mock("node:os", async (importOriginal) => {
+  const actual = (await importOriginal()) as typeof import("node:os");
+  return { ...actual, homedir: () => testDir };
+});
+
+// Dynamic import so the mock applies before the module loads.
+const { GeminiConfigService } = await import("../services/gemini/GeminiConfigService.js");
+
+function createService(): GeminiConfigService {
+  return new GeminiConfigService();
+}
+
+function configPath(): string {
+  return path.join(testDir, ".gemini", "settings.json");
+}
+
+async function writeConfigFile(content: string): Promise<void> {
+  const dir = path.dirname(configPath());
+  await mkdir(dir, { recursive: true });
+  await writeFile(configPath(), content, "utf8");
+}
+
+async function readConfigFile(): Promise<string> {
+  return readFile(configPath(), "utf8");
+}
+
+describe("GeminiConfigService", () => {
+  beforeEach(async () => {
+    await rm(testDir, { recursive: true, force: true });
+  });
+
+  afterEach(async () => {
+    await rm(testDir, { recursive: true, force: true });
+  });
+
+  describe("readConfig", () => {
+    it("returns null when no config file exists", async () => {
+      const service = createService();
+      const config = await service.readConfig();
+      expect(config).toBeNull();
+    });
+
+    it("returns parsed config when file exists", async () => {
+      await writeConfigFile(JSON.stringify({ ui: { useAlternateBuffer: true } }));
+      const service = createService();
+      const config = await service.readConfig();
+      expect(config).toEqual({ ui: { useAlternateBuffer: true } });
+    });
+
+    it("returns empty object for empty JSON file", async () => {
+      await writeConfigFile("{}");
+      const service = createService();
+      const config = await service.readConfig();
+      expect(config).toEqual({});
+    });
+
+    it("throws SyntaxError for malformed JSON", async () => {
+      await writeConfigFile("{invalid}");
+      const service = createService();
+      await expect(service.readConfig()).rejects.toBeInstanceOf(SyntaxError);
+    });
+
+    it("throws SyntaxError for empty file", async () => {
+      await writeConfigFile("");
+      const service = createService();
+      await expect(service.readConfig()).rejects.toBeInstanceOf(SyntaxError);
+    });
+
+    it("preserves unrelated keys in config", async () => {
+      await writeConfigFile(
+        JSON.stringify({ ui: { useAlternateBuffer: false }, otherKey: "value" })
+      );
+      const service = createService();
+      const config = await service.readConfig();
+      expect(config).toEqual({
+        ui: { useAlternateBuffer: false },
+        otherKey: "value",
+      });
+    });
+  });
+
+  describe("getStatus", () => {
+    it("reports exists:false when no file", async () => {
+      const service = createService();
+      const status = await service.getStatus();
+      expect(status).toEqual({ exists: false, alternateBufferEnabled: false });
+    });
+
+    it("reports exists:true with alternateBufferEnabled:true", async () => {
+      await writeConfigFile(JSON.stringify({ ui: { useAlternateBuffer: true } }));
+      const service = createService();
+      const status = await service.getStatus();
+      expect(status).toEqual({ exists: true, alternateBufferEnabled: true });
+    });
+
+    it("reports exists:true with alternateBufferEnabled:false when not set", async () => {
+      await writeConfigFile("{}");
+      const service = createService();
+      const status = await service.getStatus();
+      expect(status).toEqual({ exists: true, alternateBufferEnabled: false });
+    });
+
+    it("reports error for malformed JSON", async () => {
+      await writeConfigFile("{broken}");
+      const service = createService();
+      const status = await service.getStatus();
+      expect(status.exists).toBe(true);
+      expect(status.alternateBufferEnabled).toBe(false);
+      expect(status.error).toBeDefined();
+    });
+  });
+
+  describe("enableAlternateBuffer", () => {
+    it("creates file when none exists", async () => {
+      const service = createService();
+      await service.enableAlternateBuffer();
+      const raw = await readConfigFile();
+      const parsed = JSON.parse(raw);
+      expect(parsed.ui?.useAlternateBuffer).toBe(true);
+    });
+
+    it("sets useAlternateBuffer:true on existing config", async () => {
+      await writeConfigFile(JSON.stringify({ ui: { incrementalRendering: true } }));
+      const service = createService();
+      await service.enableAlternateBuffer();
+      const raw = await readConfigFile();
+      const parsed = JSON.parse(raw);
+      expect(parsed.ui?.useAlternateBuffer).toBe(true);
+      expect(parsed.ui?.incrementalRendering).toBe(true);
+    });
+
+    it("self-heals malformed JSON by overwriting", async () => {
+      await writeConfigFile("garbage{not}json");
+      const service = createService();
+      await service.enableAlternateBuffer();
+      const raw = await readConfigFile();
+      const parsed = JSON.parse(raw);
+      expect(parsed.ui?.useAlternateBuffer).toBe(true);
+    });
+
+    it("preserves unrelated keys", async () => {
+      await writeConfigFile(JSON.stringify({ otherKey: "value" }));
+      const service = createService();
+      await service.enableAlternateBuffer();
+      const raw = await readConfigFile();
+      const parsed = JSON.parse(raw);
+      expect(parsed.otherKey).toBe("value");
+      expect(parsed.ui?.useAlternateBuffer).toBe(true);
+    });
+
+    it("is idempotent", async () => {
+      const service = createService();
+      await service.enableAlternateBuffer();
+      const first = await readConfigFile();
+      await service.enableAlternateBuffer();
+      const second = await readConfigFile();
+      expect(second).toBe(first);
+    });
+
+    it("creates .gemini directory if missing", async () => {
+      const service = createService();
+      await service.enableAlternateBuffer();
+      const raw = await readConfigFile();
+      expect(JSON.parse(raw).ui?.useAlternateBuffer).toBe(true);
+    });
+  });
+
+  describe("isAlternateBufferEnabled", () => {
+    it("returns false when no file", async () => {
+      const service = createService();
+      expect(await service.isAlternateBufferEnabled()).toBe(false);
+    });
+
+    it("returns true when enabled", async () => {
+      await writeConfigFile(JSON.stringify({ ui: { useAlternateBuffer: true } }));
+      const service = createService();
+      expect(await service.isAlternateBufferEnabled()).toBe(true);
+    });
+
+    it("returns false when malformed", async () => {
+      await writeConfigFile("{broken}");
+      const service = createService();
+      expect(await service.isAlternateBufferEnabled()).toBe(false);
+    });
+  });
+});

--- a/electron/__tests__/GeminiConfigService.test.ts
+++ b/electron/__tests__/GeminiConfigService.test.ts
@@ -15,7 +15,7 @@ vi.mock("node:os", async (importOriginal) => {
 // Dynamic import so the mock applies before the module loads.
 const { GeminiConfigService } = await import("../services/gemini/GeminiConfigService.js");
 
-function createService(): GeminiConfigService {
+function createService() {
   return new GeminiConfigService();
 }
 

--- a/electron/__tests__/GeminiConfigService.test.ts
+++ b/electron/__tests__/GeminiConfigService.test.ts
@@ -115,7 +115,8 @@ describe("GeminiConfigService", () => {
       const status = await service.getStatus();
       expect(status.exists).toBe(true);
       expect(status.alternateBufferEnabled).toBe(false);
-      expect(status.error).toBeDefined();
+      expect(typeof status.error).toBe("string");
+      expect(status.error!.length).toBeGreaterThan(0);
     });
   });
 

--- a/electron/services/gemini/GeminiConfigService.ts
+++ b/electron/services/gemini/GeminiConfigService.ts
@@ -1,4 +1,3 @@
-import { existsSync } from "node:fs";
 import { mkdir, readFile } from "node:fs/promises";
 import { resilientAtomicWriteFile } from "../../utils/fs.js";
 import { homedir } from "node:os";
@@ -38,26 +37,25 @@ export class GeminiConfigService {
 
   async readConfig(): Promise<GeminiConfig | null> {
     try {
-      if (!existsSync(this.configPath)) {
-        return null;
-      }
       const content = await readFile(this.configPath, "utf8");
       return JSON.parse(content) as GeminiConfig;
     } catch (error) {
+      if (error instanceof Error && (error as NodeJS.ErrnoException).code === "ENOENT") {
+        return null;
+      }
+      if (error instanceof SyntaxError) {
+        throw error;
+      }
       const message = formatErrorMessage(error, "Failed to read Gemini config");
-      throw new Error(`Failed to read Gemini config: ${message}`);
+      throw new Error(`Failed to read Gemini config: ${message}`, { cause: error });
     }
   }
 
   async getStatus(): Promise<GeminiConfigStatus> {
-    if (!existsSync(this.configPath)) {
-      return { exists: false, alternateBufferEnabled: false };
-    }
-
     try {
       const config = await this.readConfig();
       if (!config) {
-        return { exists: true, alternateBufferEnabled: false };
+        return { exists: false, alternateBufferEnabled: false };
       }
       return {
         exists: true,
@@ -87,12 +85,9 @@ export class GeminiConfigService {
         existingConfig = config;
       }
     } catch (error) {
-      if (error instanceof Error && error.message.includes("ENOENT")) {
-        // File doesn't exist - will create new
-      } else if (error instanceof SyntaxError) {
+      if (error instanceof SyntaxError) {
         // JSON parse error - will repair by creating new config
       } else {
-        // Other errors (permissions, I/O) should surface
         throw error;
       }
     }

--- a/electron/services/gemini/GeminiConfigService.ts
+++ b/electron/services/gemini/GeminiConfigService.ts
@@ -110,7 +110,7 @@ export class GeminiConfigService {
       await resilientAtomicWriteFile(this.configPath, content, "utf8");
     } catch (error) {
       const message = formatErrorMessage(error, "Failed to write Gemini config");
-      throw new Error(`Failed to write Gemini config: ${message}`);
+      throw new Error(`Failed to write Gemini config: ${message}`, { cause: error });
     }
   }
 }


### PR DESCRIPTION
## Summary
- Replaced the sync `existsSync` check in `readConfig` with an async `ENOENT` catch after the read attempt, removing a TOCTOU race.
- Both `readConfig` and `writeConfig` now chain the original error as `cause` instead of discarding it for a generic message.
- Added 19 tests covering `readConfig`, `getStatus`, `enableAlternateBuffer`, and `isAlternateBufferEnabled`, including edge cases for malformed JSON, empty files, self-healing, idempotency, and directory creation.

Resolves #7074

## Changes
- `readConfig`: replaced `existsSync` with `ENOENT` / `SyntaxError` handling after the read attempt
- `readConfig` and `writeConfig`: both now pass the original error as `{ cause: error }`
- `enableAlternateBuffer`: simplified error handling (dead `ENOENT` path removed since `readConfig` returns `null` for missing files)
- New test suite: `electron/__tests__/GeminiConfigService.test.ts`

## Testing
- All 19 tests pass
- Typecheck clean
- Lint and format clean