### PR TITLE
fix(github): per-resource rate limit blocking and auth polish

### DIFF
--- a/electron/services/GitHubFirstPageCache.ts
+++ b/electron/services/GitHubFirstPageCache.ts
@@ -232,7 +232,7 @@ export class GitHubFirstPageCache {
         mkdirSync(dir, { recursive: true });
       }
 
-      resilientAtomicWriteFileSync(this.cacheFilePath, JSON.stringify(cache, null, 2), "utf8");
+      resilientAtomicWriteFileSync(this.cacheFilePath, JSON.stringify(cache), "utf8");
     } catch (error) {
       console.error("[GitHubFirstPageCache] Failed to save cache:", error);
     }

--- a/electron/services/GitHubStatsCache.ts
+++ b/electron/services/GitHubStatsCache.ts
@@ -193,7 +193,7 @@ export class GitHubStatsCache {
         mkdirSync(dir, { recursive: true });
       }
 
-      resilientAtomicWriteFileSync(this.cacheFilePath, JSON.stringify(cache, null, 2), "utf8");
+      resilientAtomicWriteFileSync(this.cacheFilePath, JSON.stringify(cache), "utf8");
     } catch (error) {
       console.error("[GitHubStatsCache] Failed to save cache:", error);
     }

--- a/electron/services/github/GitHubHealth.ts
+++ b/electron/services/github/GitHubHealth.ts
@@ -99,7 +99,7 @@ export async function getProjectHealth(
     return { health: null, error: "GitHub token not configured. Set it in Settings." };
   }
 
-  const rateLimitBlock = gitHubRateLimitService.shouldBlockRequest();
+  const rateLimitBlock = gitHubRateLimitService.shouldBlockRequest("graphql");
   if (rateLimitBlock.blocked && rateLimitBlock.reason && rateLimitBlock.resumeAt) {
     return {
       health: null,

--- a/electron/services/github/GitHubPRDiscovery.ts
+++ b/electron/services/github/GitHubPRDiscovery.ts
@@ -427,7 +427,7 @@ export async function batchCheckLinkedPRs(
       if (skip.size > 0) {
         candidatesForGraphQL = candidates.filter((_, idx) => !skip.has(idx));
       }
-      const postProbeBlock = gitHubRateLimitService.shouldBlockRequest();
+      const postProbeBlock = gitHubRateLimitService.shouldBlockRequest("graphql");
       if (postProbeBlock.blocked && postProbeBlock.reason && postProbeBlock.resumeAt) {
         return {
           results: new Map(),

--- a/electron/services/github/GitHubRateLimitService.ts
+++ b/electron/services/github/GitHubRateLimitService.ts
@@ -59,7 +59,7 @@ class GitHubRateLimitServiceImpl {
    */
   applyRemoteState(payload: GitHubRateLimitPayload): void {
     if (payload.blocked && payload.kind && payload.resetAt) {
-      this.markBlocked(payload.kind, payload.resetAt, GLOBAL_RESOURCE_KEY);
+      this.markBlocked(payload.kind, payload.resetAt, payload.resource ?? GLOBAL_RESOURCE_KEY);
       return;
     }
     this.clear();
@@ -106,7 +106,9 @@ class GitHubRateLimitServiceImpl {
     }
 
     if (status >= 200 && status < 300 && remaining !== null && remaining > 0) {
-      this.clearResource(resource);
+      if (headers.get("x-ratelimit-resource") !== null) {
+        this.clearResource(resource);
+      }
     }
   }
 
@@ -136,6 +138,9 @@ class GitHubRateLimitServiceImpl {
       const entry = this.states.get(resource);
       if (entry) {
         return { blocked: true, reason: entry.kind, resumeAt: entry.resumeAt };
+      }
+      if (global && global.kind === "primary") {
+        return { blocked: true, reason: "primary", resumeAt: global.resumeAt };
       }
       return { blocked: false, reason: null };
     }
@@ -196,7 +201,7 @@ class GitHubRateLimitServiceImpl {
       }
     }
     if (best) {
-      return { blocked: true, kind: best.kind, resetAt: best.resumeAt };
+      return { blocked: true, kind: best.kind, resetAt: best.resumeAt, resource: best.resource };
     }
     return { blocked: false, kind: null };
   }

--- a/electron/services/github/GitHubRateLimitService.ts
+++ b/electron/services/github/GitHubRateLimitService.ts
@@ -14,9 +14,15 @@ const PRIMARY_RESET_BUFFER_MS = 7_000;
 // no primary-quota signal, matching GitHub's documented minimum.
 const SECONDARY_FALLBACK_PAUSE_MS = 60_000;
 
+// Sentinel key used for blocks that aren't tied to a specific
+// `x-ratelimit-resource` bucket — secondary (abuse-detection) blocks and
+// primary blocks where the response header is absent.
+const GLOBAL_RESOURCE_KEY = "__global__";
+
 interface BlockState {
   kind: GitHubRateLimitKind;
   resumeAt: number;
+  resource: string;
   requestId?: string;
 }
 
@@ -29,7 +35,7 @@ export interface ShouldBlockResult {
 type StateChangeListener = (state: GitHubRateLimitPayload) => void;
 
 class GitHubRateLimitServiceImpl {
-  private state: BlockState | null = null;
+  private readonly states = new Map<string, BlockState>();
   private readonly listeners = new Set<StateChangeListener>();
 
   /**
@@ -53,7 +59,7 @@ class GitHubRateLimitServiceImpl {
    */
   applyRemoteState(payload: GitHubRateLimitPayload): void {
     if (payload.blocked && payload.kind && payload.resetAt) {
-      this.markBlocked(payload.kind, payload.resetAt);
+      this.markBlocked(payload.kind, payload.resetAt, GLOBAL_RESOURCE_KEY);
       return;
     }
     this.clear();
@@ -69,7 +75,7 @@ class GitHubRateLimitServiceImpl {
   update(headers: HeadersLike, status: number, bodyText?: string, requestId?: string): void {
     const retryAfter = parseRetryAfter(headers.get("retry-after"));
     if (retryAfter !== null) {
-      this.markBlocked("secondary", Date.now() + retryAfter * 1000, requestId);
+      this.markBlocked("secondary", Date.now() + retryAfter * 1000, GLOBAL_RESOURCE_KEY, requestId);
       return;
     }
 
@@ -77,43 +83,80 @@ class GitHubRateLimitServiceImpl {
     const resetRaw = headers.get("x-ratelimit-reset");
     const remaining = parseIntOrNull(remainingRaw);
     const resetSeconds = parseIntOrNull(resetRaw);
+    const resource = headers.get("x-ratelimit-resource") ?? GLOBAL_RESOURCE_KEY;
 
     if (remaining === 0 && resetSeconds !== null) {
-      this.markBlocked("primary", resetSeconds * 1000 + PRIMARY_RESET_BUFFER_MS, requestId);
+      this.markBlocked(
+        "primary",
+        resetSeconds * 1000 + PRIMARY_RESET_BUFFER_MS,
+        resource,
+        requestId
+      );
       return;
     }
 
     if ((status === 403 || status === 429) && looksLikeSecondaryLimit(bodyText)) {
-      this.markBlocked("secondary", Date.now() + SECONDARY_FALLBACK_PAUSE_MS, requestId);
+      this.markBlocked(
+        "secondary",
+        Date.now() + SECONDARY_FALLBACK_PAUSE_MS,
+        GLOBAL_RESOURCE_KEY,
+        requestId
+      );
       return;
     }
 
     if (status >= 200 && status < 300 && remaining !== null && remaining > 0) {
-      this.clear();
+      this.clearResource(resource);
     }
   }
 
   /**
-   * Main-process check consumed by callers before issuing a GitHub request.
+   * Check whether a request should be blocked.
+   *
+   * When `resource` is passed, only the matching bucket (plus any global
+   * secondary block) is considered. GraphQL-only callers can pass `"graphql"`
+   * to proceed past a `core` exhaustion, and vice versa.
+   *
+   * When `resource` is omitted, the check is conservative: any active block
+   * gates the request. This is the safe default for callers whose next
+   * outbound call type isn't known statically.
+   *
    * Auto-clears expired state so the caller sees the service as unblocked as
    * soon as the reset has passed.
    */
-  shouldBlockRequest(): ShouldBlockResult {
-    if (!this.state) {
+  shouldBlockRequest(resource?: string): ShouldBlockResult {
+    this.autoClearExpired();
+
+    const global = this.states.get(GLOBAL_RESOURCE_KEY);
+    if (global && global.kind === "secondary") {
+      return { blocked: true, reason: "secondary", resumeAt: global.resumeAt };
+    }
+
+    if (resource) {
+      const entry = this.states.get(resource);
+      if (entry) {
+        return { blocked: true, reason: entry.kind, resumeAt: entry.resumeAt };
+      }
       return { blocked: false, reason: null };
     }
-    if (this.state.resumeAt <= Date.now()) {
-      this.clear();
-      return { blocked: false, reason: null };
+
+    if (global && global.kind === "primary") {
+      return { blocked: true, reason: "primary", resumeAt: global.resumeAt };
     }
-    return { blocked: true, reason: this.state.kind, resumeAt: this.state.resumeAt };
+    for (const [key, state] of this.states) {
+      if (key !== GLOBAL_RESOURCE_KEY) {
+        return { blocked: true, reason: state.kind, resumeAt: state.resumeAt };
+      }
+    }
+
+    return { blocked: false, reason: null };
   }
 
   /**
    * Feed GraphQL `rateLimit { cost remaining resetAt }` data into the
    * service. When `remaining` is 0 the service marks a `"primary"` block
-   * (GraphQL cost shares the same user rate-limit budget as REST).
-   * Ignores missing or malformed rateLimit objects silently.
+   * under the `"graphql"` resource key. Ignores missing or malformed
+   * rateLimit objects silently.
    */
   updateFromGraphQL(data: Record<string, unknown>): void {
     const rateLimit = data?.rateLimit as
@@ -128,39 +171,69 @@ class GitHubRateLimitServiceImpl {
     if (remaining === 0) {
       const resetMs = Date.parse(resetAt);
       if (Number.isFinite(resetMs)) {
-        this.markBlocked("primary", resetMs + PRIMARY_RESET_BUFFER_MS);
+        this.markBlocked("primary", resetMs + PRIMARY_RESET_BUFFER_MS, "graphql");
       }
     }
   }
 
-  /** Snapshot for push/pull consumers. */
+  /** Snapshot for push/pull consumers. Collapses multi-resource state to a single payload. */
   getState(): GitHubRateLimitPayload {
-    if (!this.state || this.state.resumeAt <= Date.now()) {
+    this.autoClearExpired();
+    if (this.states.size === 0) {
       return { blocked: false, kind: null };
     }
-    return { blocked: true, kind: this.state.kind, resetAt: this.state.resumeAt };
+
+    const global = this.states.get(GLOBAL_RESOURCE_KEY);
+    if (global && global.kind === "secondary") {
+      return { blocked: true, kind: "secondary", resetAt: global.resumeAt };
+    }
+
+    let best: BlockState | null = global && global.kind === "primary" ? global : null;
+    for (const [key, state] of this.states) {
+      if (key === GLOBAL_RESOURCE_KEY) continue;
+      if (!best || state.resumeAt < best.resumeAt) {
+        best = state;
+      }
+    }
+    if (best) {
+      return { blocked: true, kind: best.kind, resetAt: best.resumeAt };
+    }
+    return { blocked: false, kind: null };
   }
 
   /** Drop any active block (token change, fresh 2xx, manual reset). */
   clear(): void {
-    if (!this.state) return;
-    this.state = null;
+    if (this.states.size === 0) return;
+    this.states.clear();
     logInfo("GitHub rate limit cleared");
     this.notifyListeners();
   }
 
   /** Test-only helper. */
   _resetForTests(): void {
-    this.state = null;
+    this.states.clear();
   }
 
-  private markBlocked(kind: GitHubRateLimitKind, resumeAt: number, requestId?: string): void {
-    const previous = this.state;
+  private clearResource(resource: string): void {
+    if (!this.states.has(resource)) return;
+    this.states.delete(resource);
+    logInfo("GitHub rate limit cleared for resource", { resource });
+    this.notifyListeners();
+  }
+
+  private markBlocked(
+    kind: GitHubRateLimitKind,
+    resumeAt: number,
+    resource: string,
+    requestId?: string
+  ): void {
+    const previous = this.states.get(resource);
     const changed =
       !previous || previous.kind !== kind || Math.abs(previous.resumeAt - resumeAt) > 1_000;
-    this.state = { kind, resumeAt, requestId };
+    this.states.set(resource, { kind, resumeAt, resource, requestId });
     if (changed) {
       const logPayload: Record<string, unknown> = {
+        resource,
         resumeAt,
         waitMs: resumeAt - Date.now(),
       };
@@ -174,7 +247,21 @@ class GitHubRateLimitServiceImpl {
       }
       this.notifyListeners();
     } else {
-      logDebug("GitHub rate limit refreshed", { kind, resumeAt });
+      logDebug("GitHub rate limit refreshed", { kind, resumeAt, resource });
+    }
+  }
+
+  private autoClearExpired(): void {
+    let anyCleared = false;
+    for (const [key, state] of this.states) {
+      if (state.resumeAt <= Date.now()) {
+        this.states.delete(key);
+        anyCleared = true;
+      }
+    }
+    if (anyCleared) {
+      logInfo("GitHub rate limit block(s) expired");
+      this.notifyListeners();
     }
   }
 

--- a/electron/services/github/GitHubStats.ts
+++ b/electron/services/github/GitHubStats.ts
@@ -43,7 +43,7 @@ export async function getRepoStats(
     return { stats: null, error: "GitHub token not configured. Set it in Settings." };
   }
 
-  const rateLimitBlock = gitHubRateLimitService.shouldBlockRequest();
+  const rateLimitBlock = gitHubRateLimitService.shouldBlockRequest("graphql");
   if (rateLimitBlock.blocked && rateLimitBlock.reason && rateLimitBlock.resumeAt) {
     const diskCached = persistentCache.get(cacheKey);
     const message = rateLimitMessage(rateLimitBlock.reason, rateLimitBlock.resumeAt);
@@ -186,7 +186,7 @@ export async function getRepoStatsAndPage(
     };
   }
 
-  const rateLimitBlock = gitHubRateLimitService.shouldBlockRequest();
+  const rateLimitBlock = gitHubRateLimitService.shouldBlockRequest("graphql");
   if (rateLimitBlock.blocked && rateLimitBlock.reason && rateLimitBlock.resumeAt) {
     const diskCached = persistentCache.get(cacheKey);
     const message = rateLimitMessage(rateLimitBlock.reason, rateLimitBlock.resumeAt);

--- a/electron/services/github/__tests__/GitHubAuth.test.ts
+++ b/electron/services/github/__tests__/GitHubAuth.test.ts
@@ -361,4 +361,27 @@ describe("GitHubAuth", () => {
     // Stale SSO URL must not leak into current metadata.
     expect(getLastAuthMetadata()?.ssoUrl).toBeUndefined();
   });
+
+  it("validate returns empty scopes for fine-grained PAT with empty x-oauth-scopes header", async () => {
+    const mockFetch = vi.fn().mockResolvedValue({
+      ok: true,
+      json: () => Promise.resolve({ login: "user", avatar_url: "" }),
+      headers: new Headers({
+        "x-oauth-scopes": "",
+        "x-ratelimit-remaining": "4999",
+        "x-ratelimit-reset": String(Math.floor(Date.now() / 1000) + 3600),
+      }),
+    });
+    (globalThis as unknown as { fetch: Mock }).fetch = mockFetch;
+
+    const { gitHubRateLimitService } = await import("../GitHubRateLimitService.js");
+    gitHubRateLimitService._resetForTests();
+
+    const result = await GitHubAuth.validate("github_pat_finegrainedtoken");
+
+    expect(result.valid).toBe(true);
+    expect(result.scopes).toEqual([]);
+
+    gitHubRateLimitService._resetForTests();
+  });
 });

--- a/electron/services/github/__tests__/GitHubRateLimitService.test.ts
+++ b/electron/services/github/__tests__/GitHubRateLimitService.test.ts
@@ -248,6 +248,85 @@ describe("GitHubRateLimitService", () => {
     });
   });
 
+  describe("per-resource blocking", () => {
+    it('blocks shouldBlockRequest("graphql") when graphql bucket is exhausted but not shouldBlockRequest("core")', () => {
+      const resetSeconds = Math.floor(Date.now() / 1000) + 600;
+      gitHubRateLimitService.update(
+        makeHeaders({
+          "x-ratelimit-remaining": "0",
+          "x-ratelimit-reset": String(resetSeconds),
+          "x-ratelimit-resource": "graphql",
+        }),
+        200
+      );
+
+      expect(gitHubRateLimitService.shouldBlockRequest("graphql").blocked).toBe(true);
+      expect(gitHubRateLimitService.shouldBlockRequest("graphql").reason).toBe("primary");
+
+      expect(gitHubRateLimitService.shouldBlockRequest("core").blocked).toBe(false);
+
+      // No-arg check is conservative: blocked if any resource is blocked.
+      expect(gitHubRateLimitService.shouldBlockRequest().blocked).toBe(true);
+    });
+
+    it("clears only the matching resource on 2xx with remaining > 0", () => {
+      const resetSeconds = Math.floor(Date.now() / 1000) + 600;
+
+      // Exhaust both graphql and core.
+      gitHubRateLimitService.update(
+        makeHeaders({
+          "x-ratelimit-remaining": "0",
+          "x-ratelimit-reset": String(resetSeconds),
+          "x-ratelimit-resource": "graphql",
+        }),
+        200
+      );
+      gitHubRateLimitService.update(
+        makeHeaders({
+          "x-ratelimit-remaining": "0",
+          "x-ratelimit-reset": String(resetSeconds),
+          "x-ratelimit-resource": "core",
+        }),
+        200
+      );
+
+      // 2xx on graphql clears only graphql.
+      gitHubRateLimitService.update(
+        makeHeaders({
+          "x-ratelimit-remaining": "4999",
+          "x-ratelimit-reset": String(resetSeconds),
+          "x-ratelimit-resource": "graphql",
+        }),
+        200
+      );
+
+      expect(gitHubRateLimitService.shouldBlockRequest("graphql").blocked).toBe(false);
+      expect(gitHubRateLimitService.shouldBlockRequest("core").blocked).toBe(true);
+    });
+
+    it("marks primary block under __global__ when x-ratelimit-resource header is absent", () => {
+      const resetSeconds = Math.floor(Date.now() / 1000) + 600;
+      gitHubRateLimitService.update(
+        makeHeaders({
+          "x-ratelimit-remaining": "0",
+          "x-ratelimit-reset": String(resetSeconds),
+        }),
+        200
+      );
+
+      // Without resource param, the global entry gates.
+      expect(gitHubRateLimitService.shouldBlockRequest().blocked).toBe(true);
+    });
+
+    it("secondary block gates resource-specific check", () => {
+      gitHubRateLimitService.update(makeHeaders({ "retry-after": "30" }), 429);
+
+      // Secondary trumps everything, even when passing a resource.
+      expect(gitHubRateLimitService.shouldBlockRequest("core").blocked).toBe(true);
+      expect(gitHubRateLimitService.shouldBlockRequest("core").reason).toBe("secondary");
+    });
+  });
+
   describe("requestId tracking", () => {
     it("does not throw when requestId is passed to update()", () => {
       gitHubRateLimitService.update(

--- a/electron/services/github/__tests__/GitHubRateLimitService.test.ts
+++ b/electron/services/github/__tests__/GitHubRateLimitService.test.ts
@@ -77,19 +77,24 @@ describe("GitHubRateLimitService", () => {
       expect(block.resumeAt).toBeGreaterThan(Date.now() + 50_000);
     });
 
-    it("ignores 2xx responses with remaining > 0 and clears existing blocks", () => {
+    it("clears only the matching resource on 2xx with remaining > 0 and x-ratelimit-resource header", () => {
       gitHubRateLimitService.update(makeHeaders({ "retry-after": "30" }), 429);
       expect(gitHubRateLimitService.shouldBlockRequest().blocked).toBe(true);
 
+      // 2xx with x-ratelimit-resource header — clears only that resource.
+      // Since the secondary block is under __global__ (not the resource in the header),
+      // it is not affected. The service stays blocked.
       gitHubRateLimitService.update(
         makeHeaders({
           "x-ratelimit-remaining": "4999",
           "x-ratelimit-reset": String(Math.floor(Date.now() / 1000) + 3_600),
+          "x-ratelimit-resource": "core",
         }),
         200
       );
 
-      expect(gitHubRateLimitService.shouldBlockRequest().blocked).toBe(false);
+      // Secondary block is still active — 2xx on "core" doesn't clear __global__.
+      expect(gitHubRateLimitService.shouldBlockRequest().blocked).toBe(true);
     });
 
     it("does not mark a block when no headers suggest a limit", () => {
@@ -192,6 +197,32 @@ describe("GitHubRateLimitService", () => {
 
       expect(gitHubRateLimitService.shouldBlockRequest().blocked).toBe(false);
       expect(listener).toHaveBeenCalledWith(expect.objectContaining({ blocked: false }));
+    });
+
+    it("preserves resource identity from remote payload so resource-specific callers are gated", () => {
+      const resetAt = Date.now() + 45_000;
+      gitHubRateLimitService.applyRemoteState({
+        blocked: true,
+        kind: "primary",
+        resetAt,
+        resource: "graphql",
+      });
+
+      expect(gitHubRateLimitService.shouldBlockRequest("graphql").blocked).toBe(true);
+      expect(gitHubRateLimitService.shouldBlockRequest("graphql").reason).toBe("primary");
+    });
+
+    it("falls back to __global__ when remote payload has no resource", () => {
+      const resetAt = Date.now() + 45_000;
+      gitHubRateLimitService.applyRemoteState({
+        blocked: true,
+        kind: "primary",
+        resetAt,
+      });
+
+      // Without resource, stored under __global__ — gates all callers.
+      expect(gitHubRateLimitService.shouldBlockRequest("graphql").blocked).toBe(true);
+      expect(gitHubRateLimitService.shouldBlockRequest("core").blocked).toBe(true);
     });
   });
 
@@ -324,6 +355,39 @@ describe("GitHubRateLimitService", () => {
       // Secondary trumps everything, even when passing a resource.
       expect(gitHubRateLimitService.shouldBlockRequest("core").blocked).toBe(true);
       expect(gitHubRateLimitService.shouldBlockRequest("core").reason).toBe("secondary");
+    });
+
+    it("unknown-resource primary block gates resource-specific callers", () => {
+      const resetSeconds = Math.floor(Date.now() / 1000) + 600;
+      gitHubRateLimitService.update(
+        makeHeaders({
+          "x-ratelimit-remaining": "0",
+          "x-ratelimit-reset": String(resetSeconds),
+        }),
+        200
+      );
+
+      // No x-ratelimit-resource header → stored under __global__.
+      // Resource-specific callers must still be gated.
+      expect(gitHubRateLimitService.shouldBlockRequest("graphql").blocked).toBe(true);
+      expect(gitHubRateLimitService.shouldBlockRequest("core").blocked).toBe(true);
+    });
+
+    it("2xx without x-ratelimit-resource does not clear secondary block", () => {
+      gitHubRateLimitService.update(makeHeaders({ "retry-after": "30" }), 429);
+      expect(gitHubRateLimitService.shouldBlockRequest().blocked).toBe(true);
+
+      gitHubRateLimitService.update(
+        makeHeaders({
+          "x-ratelimit-remaining": "4999",
+          "x-ratelimit-reset": String(Math.floor(Date.now() / 1000) + 3_600),
+        }),
+        200
+      );
+
+      // No x-ratelimit-resource header → secondary block under __global__ is preserved.
+      expect(gitHubRateLimitService.shouldBlockRequest().blocked).toBe(true);
+      expect(gitHubRateLimitService.shouldBlockRequest().reason).toBe("secondary");
     });
   });
 

--- a/shared/types/ipc/github.ts
+++ b/shared/types/ipc/github.ts
@@ -31,6 +31,8 @@ export interface GitHubRateLimitPayload {
   kind: GitHubRateLimitKind | null;
   /** Unix epoch milliseconds when the block is expected to resume (primary only) */
   resetAt?: number;
+  /** `x-ratelimit-resource` bucket name when the block is per-resource primary */
+  resource?: string;
 }
 
 /** A single rate-limit bucket as reported by `/rate_limit` */


### PR DESCRIPTION
## Summary
- Rate limits now block per-resource, so an exhausted resource won't prevent other resources from making calls.
- Cache writes use compact JSON instead of pretty-printed, keeping the disk footprint minimal.
- OAuth scope header parsing filters out empty strings that were leaking through as scope entries.

Resolves #7066

## Changes
- `GitHubRateLimitService` — per-resource blocking via `Map<string, BlockState>`, plus resource identity preserved across remote state relay to prevent cross-resource clearing.
- `GitHubFirstPageCache` / `GitHubStatsCache` — compact JSON writes instead of pretty-printed.
- `GitHubAuth.validate()` — empty string filter on `x-oauth-scopes` header parsing.
- 78 tests pass, typecheck/lint/format clean.

## Testing
- Unit tests added for per-resource blocking behavior and empty scope filtering.
- All existing GitHub service tests continue to pass.