### PR TITLE
fix(quarantine): remove dead prefixes and add per-file reap logging

### DIFF
--- a/electron/services/__tests__/projectQuarantineCleanup.test.ts
+++ b/electron/services/__tests__/projectQuarantineCleanup.test.ts
@@ -321,7 +321,7 @@ describe("cleanupQuarantinedProjectFiles", () => {
     }
   });
 
-  it("calls logInfo with quarantine-file-reaped when reaping old files", async () => {
+  it("logs quarantine-file-reaped with filename, ageMs, and projectId", async () => {
     logInfo.mockClear();
 
     const projectDir = await createProjectDir(VALID_PROJECT_ID);
@@ -339,26 +339,8 @@ describe("cleanupQuarantinedProjectFiles", () => {
       expect.objectContaining({
         filename: "state.json.corrupted.1234567890",
         ageMs: expect.any(Number),
+        projectId: VALID_PROJECT_ID,
       })
-    );
-  });
-
-  it("includes projectId in reap log context from project-scoped sweep", async () => {
-    logInfo.mockClear();
-
-    const projectDir = await createProjectDir(VALID_PROJECT_ID);
-    await createCorruptedFile(
-      projectDir,
-      "state.json.corrupted.1234567890",
-      THIRTY_ONE_DAYS_MS,
-      NOW
-    );
-
-    await cleanupQuarantinedProjectFiles(tmpDir, NOW);
-
-    expect(logInfo).toHaveBeenCalledWith(
-      "quarantine-file-reaped",
-      expect.objectContaining({ projectId: VALID_PROJECT_ID })
     );
   });
 

--- a/electron/services/__tests__/projectQuarantineCleanup.test.ts
+++ b/electron/services/__tests__/projectQuarantineCleanup.test.ts
@@ -1,5 +1,14 @@
 import { describe, it, expect, beforeEach, afterEach, vi } from "vitest";
 import fs from "fs/promises";
+
+const { logInfo } = vi.hoisted(() => ({
+  logInfo: vi.fn(),
+}));
+
+vi.mock("../../utils/logger.js", () => ({
+  logInfo,
+  logError: vi.fn(),
+}));
 import path from "path";
 import os from "os";
 import {
@@ -18,7 +27,6 @@ const QUARANTINE_FILES = [
   "state.json.corrupted.1234567890",
   "settings.json.corrupted.1234567890",
   "recipes.json.corrupted.1234567890",
-  "workflows.json.corrupted.1234567890",
 ];
 
 let tmpDir: string;
@@ -84,14 +92,14 @@ describe("cleanupQuarantinedProjectFiles", () => {
     await expect(fs.access(filePath)).resolves.toBeUndefined();
   });
 
-  it("deletes all four known quarantine file types when old", async () => {
+  it("deletes all three known quarantine file types when old", async () => {
     const projectDir = await createProjectDir(VALID_PROJECT_ID);
     for (const filename of QUARANTINE_FILES) {
       await createCorruptedFile(projectDir, filename, THIRTY_ONE_DAYS_MS, NOW);
     }
 
     const deleted = await cleanupQuarantinedProjectFiles(tmpDir, NOW);
-    expect(deleted).toBe(4);
+    expect(deleted).toBe(3);
 
     for (const filename of QUARANTINE_FILES) {
       await expect(fs.access(path.join(projectDir, filename))).rejects.toThrow();
@@ -311,6 +319,88 @@ describe("cleanupQuarantinedProjectFiles", () => {
     } finally {
       spy.mockRestore();
     }
+  });
+
+  it("calls logInfo with quarantine-file-reaped when reaping old files", async () => {
+    logInfo.mockClear();
+
+    const projectDir = await createProjectDir(VALID_PROJECT_ID);
+    await createCorruptedFile(
+      projectDir,
+      "state.json.corrupted.1234567890",
+      THIRTY_ONE_DAYS_MS,
+      NOW
+    );
+
+    await cleanupQuarantinedProjectFiles(tmpDir, NOW);
+
+    expect(logInfo).toHaveBeenCalledWith(
+      "quarantine-file-reaped",
+      expect.objectContaining({
+        filename: "state.json.corrupted.1234567890",
+        ageMs: expect.any(Number),
+      })
+    );
+  });
+
+  it("includes projectId in reap log context from project-scoped sweep", async () => {
+    logInfo.mockClear();
+
+    const projectDir = await createProjectDir(VALID_PROJECT_ID);
+    await createCorruptedFile(
+      projectDir,
+      "state.json.corrupted.1234567890",
+      THIRTY_ONE_DAYS_MS,
+      NOW
+    );
+
+    await cleanupQuarantinedProjectFiles(tmpDir, NOW);
+
+    expect(logInfo).toHaveBeenCalledWith(
+      "quarantine-file-reaped",
+      expect.objectContaining({ projectId: VALID_PROJECT_ID })
+    );
+  });
+
+  it("does not log reap for fresh files preserved by the age gate", async () => {
+    logInfo.mockClear();
+
+    const projectDir = await createProjectDir(VALID_PROJECT_ID);
+    await createCorruptedFile(
+      projectDir,
+      "state.json.corrupted.1234567890",
+      TWENTY_NINE_DAYS_MS,
+      NOW
+    );
+
+    await cleanupQuarantinedProjectFiles(tmpDir, NOW);
+
+    const reapCalls = logInfo.mock.calls.filter(
+      (call: unknown[]) => call[0] === "quarantine-file-reaped"
+    );
+    expect(reapCalls).toHaveLength(0);
+  });
+
+  it("reap log context does not contain absolute file path", async () => {
+    logInfo.mockClear();
+
+    const projectDir = await createProjectDir(VALID_PROJECT_ID);
+    await createCorruptedFile(
+      projectDir,
+      "state.json.corrupted.1234567890",
+      THIRTY_ONE_DAYS_MS,
+      NOW
+    );
+
+    await cleanupQuarantinedProjectFiles(tmpDir, NOW);
+
+    const reapCall = logInfo.mock.calls.find(
+      (call: unknown[]) => call[0] === "quarantine-file-reaped"
+    );
+    expect(reapCall).toBeDefined();
+    const context = reapCall![1] as Record<string, unknown>;
+    expect(JSON.stringify(context)).not.toContain(tmpDir);
+    expect(JSON.stringify(context)).not.toContain(os.homedir());
   });
 });
 

--- a/electron/services/projectQuarantineCleanup.ts
+++ b/electron/services/projectQuarantineCleanup.ts
@@ -8,14 +8,9 @@ const QUARANTINE_MAX_AGE_MS = 30 * 24 * 60 * 60 * 1000;
 
 const QUARANTINE_PREFIXES = [
   "state.json.corrupted.",
-  "state.json.corrupted",
   "state.json.future-v",
   "settings.json.corrupted.",
-  "settings.json.corrupted",
   "recipes.json.corrupted.",
-  "recipes.json.corrupted",
-  "workflows.json.corrupted.",
-  "workflows.json.corrupted",
 ];
 
 const GLOBAL_RECIPES_QUARANTINE_PREFIXES = ["recipes.json.corrupted."];
@@ -25,7 +20,8 @@ async function sweepDirectoryForPrefixes(
   dir: string,
   prefixes: readonly string[],
   now: number,
-  logScope: string
+  logScope: string,
+  projectId?: string
 ): Promise<number> {
   let entries: import("fs").Dirent[];
   try {
@@ -46,6 +42,11 @@ async function sweepDirectoryForPrefixes(
       const stats = await fs.lstat(filePath);
       const ageMs = Math.max(0, now - stats.mtimeMs);
       if (ageMs > QUARANTINE_MAX_AGE_MS) {
+        logInfo("quarantine-file-reaped", {
+          filename: dirent.name,
+          ageMs,
+          ...(projectId ? { projectId } : {}),
+        });
         await resilientUnlink(filePath);
         deletedCount++;
       }
@@ -81,7 +82,8 @@ export async function cleanupQuarantinedProjectFiles(
         projectDir,
         QUARANTINE_PREFIXES,
         now,
-        "ProjectStore"
+        "ProjectStore",
+        entry.name
       );
     } catch (err) {
       logError(`[ProjectStore] Failed to sweep quarantine in ${projectDir}`, err);


### PR DESCRIPTION
## Summary
- Stripped dead `workflows.json.corrupted` prefixes and redundant no-dot variants from the quarantine cleanup list. None of the five file write sites in the codebase produce these.
- Added per-file `quarantine-file-reaped` structured logging with filename, age, and project ID. Gives us a forensic trail when investigating cleanup bugs without leaking user home directory paths.
- Threaded optional `projectId` through `sweepDirectoryForPrefixes` so log context carries which project the file belonged to.

Resolves #7106

## Changes
- `electron/services/projectQuarantineCleanup.ts` — removed 4 dead/noop prefixes, added reap `logInfo` call before each unlink, added `projectId` param
- `electron/services/__tests__/projectQuarantineCleanup.test.ts` — dropped workflows fixture, updated count 4 to 3, added logger mock and 3 new tests (reap log, age gate, no-absolute-path)

## Testing
29 unit tests pass. Verified no producer writes the removed prefix variants by auditing state, settings, recipes, and global file store write sites.