### PR TITLE
fix(appAgent): bound error text, timeout constant, drop redundant guard

### DIFF
--- a/electron/ipc/handlers/appAgent.ts
+++ b/electron/ipc/handlers/appAgent.ts
@@ -30,7 +30,7 @@ export function registerAppAgentHandlers(_deps: HandlerDependencies): () => void
   handlers.push(typedHandle(CHANNELS.APP_AGENT_HAS_API_KEY, handleHasApiKey));
 
   const handleTestApiKey = async (apiKey: string) => {
-    if (!apiKey || typeof apiKey !== "string") {
+    if (!apiKey || typeof apiKey !== "string" || !apiKey.trim()) {
       throw new Error("Invalid API key");
     }
     return appAgentService.testApiKey(apiKey.trim());
@@ -38,7 +38,7 @@ export function registerAppAgentHandlers(_deps: HandlerDependencies): () => void
   handlers.push(typedHandle(CHANNELS.APP_AGENT_TEST_API_KEY, handleTestApiKey));
 
   const handleTestModel = async (model: string) => {
-    if (!model || typeof model !== "string") {
+    if (!model || typeof model !== "string" || !model.trim()) {
       throw new Error("Invalid model");
     }
     return appAgentService.testModel(model.trim());

--- a/electron/ipc/handlers/appAgent.ts
+++ b/electron/ipc/handlers/appAgent.ts
@@ -14,10 +14,6 @@ export function registerAppAgentHandlers(_deps: HandlerDependencies): () => void
   handlers.push(typedHandle(CHANNELS.APP_AGENT_GET_CONFIG, handleGetConfig));
 
   const handleSetConfig = async (config: Partial<AppAgentConfig>) => {
-    if (!config || typeof config !== "object") {
-      throw new Error("Invalid config");
-    }
-
     const configResult = AppAgentConfigSchema.partial().safeParse(config);
     if (!configResult.success) {
       throw new Error(`Invalid config: ${configResult.error.message}`);

--- a/electron/services/AppAgentService.ts
+++ b/electron/services/AppAgentService.ts
@@ -78,29 +78,32 @@ export class AppAgentService {
         signal: abortController.signal,
       });
 
-      clearTimeout(timeoutId);
-
       if (response.ok) {
+        clearTimeout(timeoutId);
         return { valid: true };
       }
 
       if (response.status === 401) {
+        clearTimeout(timeoutId);
         return { valid: false, error: "Invalid API key" };
       }
 
       if (response.status === 403) {
+        clearTimeout(timeoutId);
         return { valid: false, error: "API key does not have access to this model" };
       }
 
       if (response.status === 429) {
+        clearTimeout(timeoutId);
         // Rate limited but key is valid
         return { valid: true };
       }
 
       const errorText = await response.text().catch(() => "");
+      clearTimeout(timeoutId);
       return {
         valid: false,
-        error: `API error: ${response.status} ${formatApiErrorText(errorText)}`,
+        error: `API error: ${response.status} ${formatApiErrorText(errorText)}`.trim(),
       };
     } catch (error) {
       clearTimeout(timeoutId);
@@ -150,29 +153,32 @@ export class AppAgentService {
         signal: abortController.signal,
       });
 
-      clearTimeout(timeoutId);
-
       if (response.ok) {
+        clearTimeout(timeoutId);
         return { valid: true };
       }
 
       if (response.status === 401) {
+        clearTimeout(timeoutId);
         return { valid: false, error: "API key is invalid" };
       }
 
       if (response.status === 404) {
+        clearTimeout(timeoutId);
         return { valid: false, error: "Model not found" };
       }
 
       if (response.status === 429) {
+        clearTimeout(timeoutId);
         // Rate limited but model is valid
         return { valid: true };
       }
 
       const errorText = await response.text().catch(() => "");
+      clearTimeout(timeoutId);
       return {
         valid: false,
-        error: `API error: ${response.status} ${formatApiErrorText(errorText)}`,
+        error: `API error: ${response.status} ${formatApiErrorText(errorText)}`.trim(),
       };
     } catch (error) {
       clearTimeout(timeoutId);

--- a/electron/services/AppAgentService.ts
+++ b/electron/services/AppAgentService.ts
@@ -3,6 +3,31 @@ import type { AppAgentConfig } from "../../shared/types/appAgent.js";
 import { formatErrorMessage } from "../../shared/utils/errorMessage.js";
 
 const FIREWORKS_BASE_URL = "https://api.fireworks.ai/inference/v1";
+export const API_TEST_TIMEOUT_MS = 15_000;
+
+function formatApiErrorText(rawText: string): string {
+  const MAX_CHARS = 200;
+
+  let message = rawText;
+  try {
+    const parsed = JSON.parse(rawText);
+    if (
+      parsed &&
+      typeof parsed === "object" &&
+      parsed.error &&
+      typeof parsed.error.message === "string"
+    ) {
+      message = parsed.error.message;
+    }
+  } catch {
+    // Not JSON, use raw text
+  }
+
+  if (message.length > MAX_CHARS) {
+    return message.slice(0, MAX_CHARS) + "...";
+  }
+  return message;
+}
 
 export class AppAgentService {
   getConfig(): Omit<AppAgentConfig, "apiKey"> {
@@ -36,7 +61,7 @@ export class AppAgentService {
     }
 
     const abortController = new AbortController();
-    const timeoutId = setTimeout(() => abortController.abort(), 15000);
+    const timeoutId = setTimeout(() => abortController.abort(), API_TEST_TIMEOUT_MS);
 
     try {
       const response = await fetch(url.toString(), {
@@ -73,7 +98,10 @@ export class AppAgentService {
       }
 
       const errorText = await response.text().catch(() => "");
-      return { valid: false, error: `API error: ${response.status} ${errorText}`.trim() };
+      return {
+        valid: false,
+        error: `API error: ${response.status} ${formatApiErrorText(errorText)}`,
+      };
     } catch (error) {
       clearTimeout(timeoutId);
 
@@ -105,7 +133,7 @@ export class AppAgentService {
     }
 
     const abortController = new AbortController();
-    const timeoutId = setTimeout(() => abortController.abort(), 15000);
+    const timeoutId = setTimeout(() => abortController.abort(), API_TEST_TIMEOUT_MS);
 
     try {
       const response = await fetch(url.toString(), {
@@ -142,7 +170,10 @@ export class AppAgentService {
       }
 
       const errorText = await response.text().catch(() => "");
-      return { valid: false, error: `API error: ${response.status} ${errorText}`.trim() };
+      return {
+        valid: false,
+        error: `API error: ${response.status} ${formatApiErrorText(errorText)}`,
+      };
     } catch (error) {
       clearTimeout(timeoutId);
 

--- a/electron/services/__tests__/AppAgentService.adversarial.test.ts
+++ b/electron/services/__tests__/AppAgentService.adversarial.test.ts
@@ -107,7 +107,7 @@ describe("AppAgentService adversarial", () => {
     mockFetch(vi.fn(async () => ({ ok: false, status: 403 })) as unknown as typeof fetch);
     const result = await new AppAgentService().testApiKey("k");
     expect(result.valid).toBe(false);
-    expect(result.error).toContain("access");
+    expect(result.error).toEqual("API key does not have access to this model");
   });
 
   it("testApiKey wraps other non-ok responses with status and error text", async () => {

--- a/electron/services/__tests__/AppAgentService.adversarial.test.ts
+++ b/electron/services/__tests__/AppAgentService.adversarial.test.ts
@@ -7,7 +7,7 @@ const storeMock = vi.hoisted(() => ({
 
 vi.mock("../../store.js", () => ({ store: storeMock }));
 
-import { AppAgentService } from "../AppAgentService.js";
+import { AppAgentService, API_TEST_TIMEOUT_MS } from "../AppAgentService.js";
 
 function setConfig(config: Record<string, unknown>) {
   storeMock.get.mockImplementation((key: string) => {
@@ -156,7 +156,7 @@ describe("AppAgentService adversarial", () => {
     expect(result).toEqual({ valid: false, error: "Model not found" });
   });
 
-  it("testApiKey aborts after 15s timeout and returns 'Request timed out'", async () => {
+  it("testApiKey aborts after timeout and returns 'Request timed out'", async () => {
     vi.useFakeTimers();
     mockFetch(
       vi.fn(
@@ -172,9 +172,103 @@ describe("AppAgentService adversarial", () => {
     );
 
     const pending = new AppAgentService().testApiKey("k");
-    await vi.advanceTimersByTimeAsync(15_000);
+    await vi.advanceTimersByTimeAsync(API_TEST_TIMEOUT_MS);
     const result = await pending;
 
     expect(result).toEqual({ valid: false, error: "Request timed out" });
+  });
+
+  it("testApiKey truncates large raw error text to 200 chars", async () => {
+    const longText = "x".repeat(500);
+    mockFetch(
+      vi.fn(
+        async () =>
+          ({
+            ok: false,
+            status: 500,
+            text: async () => longText,
+          }) as unknown as Response
+      ) as unknown as typeof fetch
+    );
+
+    const result = await new AppAgentService().testApiKey("k");
+    expect(result.valid).toBe(false);
+    expect(result.error).toMatch(/^API error: 500 /);
+    const providerPart = result.error!.replace("API error: 500 ", "");
+    expect(providerPart.length).toBe(203);
+    expect(providerPart.endsWith("...")).toBe(true);
+  });
+
+  it("testApiKey extracts JSON error.message and truncates when long", async () => {
+    const longMessage = "e".repeat(300);
+    const jsonBody = JSON.stringify({ error: { message: longMessage } });
+    mockFetch(
+      vi.fn(
+        async () =>
+          ({
+            ok: false,
+            status: 500,
+            text: async () => jsonBody,
+          }) as unknown as Response
+      ) as unknown as typeof fetch
+    );
+
+    const result = await new AppAgentService().testApiKey("k");
+    expect(result.valid).toBe(false);
+    const providerPart = result.error!.replace("API error: 500 ", "");
+    expect(providerPart).toBe(longMessage.slice(0, 200) + "...");
+  });
+
+  it("testApiKey uses JSON error.message directly when under 200 chars", async () => {
+    const jsonBody = JSON.stringify({ error: { message: "short message" } });
+    mockFetch(
+      vi.fn(
+        async () =>
+          ({
+            ok: false,
+            status: 500,
+            text: async () => jsonBody,
+          }) as unknown as Response
+      ) as unknown as typeof fetch
+    );
+
+    const result = await new AppAgentService().testApiKey("k");
+    expect(result.error).toBe("API error: 500 short message");
+  });
+
+  it("testApiKey falls back to raw text when JSON lacks error.message", async () => {
+    const jsonBody = JSON.stringify({ foo: "bar" });
+    mockFetch(
+      vi.fn(
+        async () =>
+          ({
+            ok: false,
+            status: 500,
+            text: async () => jsonBody,
+          }) as unknown as Response
+      ) as unknown as typeof fetch
+    );
+
+    const result = await new AppAgentService().testApiKey("k");
+    expect(result.error).toBe('API error: 500 {"foo":"bar"}');
+  });
+
+  it("testApiKey truncates malformed JSON as raw text", async () => {
+    const notJson = "not json{{{".repeat(40);
+    mockFetch(
+      vi.fn(
+        async () =>
+          ({
+            ok: false,
+            status: 500,
+            text: async () => notJson,
+          }) as unknown as Response
+      ) as unknown as typeof fetch
+    );
+
+    const result = await new AppAgentService().testApiKey("k");
+    expect(result.valid).toBe(false);
+    const providerPart = result.error!.replace("API error: 500 ", "");
+    expect(providerPart).toBe(notJson.slice(0, 200) + "...");
   });
 });


### PR DESCRIPTION
## Summary
- Error response text from the Fireworks API is now bounded to 200 characters, preventing unbounded messages from reaching the UI. JSON-structured errors get unwrapped before truncation.
- A shared API_TEST_TIMEOUT_MS constant replaces the two hardcoded 15s timeout values.
- Removed a redundant Zod pre-guard in the IPC handler -- safeParse already validates the shape.

Resolves #7077

## Changes
- formatApiErrorText() in AppAgentService.ts -- extracts error.message from JSON responses, falls back to raw text when parsing fails, and truncates at 200 characters with an ellipsis.
- API_TEST_TIMEOUT_MS exported constant replaces both inline 15000 values.
- Removed the typeof config !== "object" guard in appAgent.ts handlers.
- Whitespace-only apiKey and model values are now rejected by the IPC handler guards.

## Testing
- Truncation of large raw text (500 chars) to 200 chars with ellipsis.
- JSON extraction of error.message with truncation when long.
- JSON error.message used directly when under 200 chars.
- Fallback to raw text when JSON lacks error.message.
- Malformed JSON treated as raw text and truncated.
- Timeout test uses API_TEST_TIMEOUT_MS instead of a hardcoded value.