### PR TITLE
fix(recipes): bring ProjectFileStore to ProjectStateManager parity

### DIFF
--- a/electron/services/ProjectFileStore.ts
+++ b/electron/services/ProjectFileStore.ts
@@ -5,6 +5,8 @@ import { resilientRename, resilientAtomicWriteFile } from "../utils/fs.js";
 import { getProjectStateDir, recipesFilePath } from "./projectStorePaths.js";
 import { TerminalRecipeSchema, filterValidTerminalEntries } from "../schemas/ipc.js";
 
+export const RECIPES_SCHEMA_VERSION = 1;
+
 export class ProjectFileStore {
   constructor(private projectsConfigDir: string) {}
 
@@ -12,26 +14,26 @@ export class ProjectFileStore {
 
   async getRecipes(projectId: string): Promise<TerminalRecipe[]> {
     const filePath = recipesFilePath(this.projectsConfigDir, projectId);
-    if (!filePath || !existsSync(filePath)) {
+    if (!filePath) {
       return [];
     }
 
+    let content: string;
     try {
-      const content = await fs.readFile(filePath, "utf-8");
-      const parsed = JSON.parse(content);
-
-      if (!Array.isArray(parsed)) {
-        console.warn(`[ProjectFileStore] Invalid recipes format for ${projectId}, expected array`);
+      content = await fs.readFile(filePath, "utf-8");
+    } catch (error) {
+      if (error instanceof Error && "code" in error && error.code === "ENOENT") {
         return [];
       }
+      console.error(`[ProjectFileStore] Failed to read recipes for ${projectId}:`, error);
+      return [];
+    }
 
-      return filterValidTerminalEntries(
-        parsed,
-        TerminalRecipeSchema,
-        `ProjectFileStore(${projectId})`
-      );
-    } catch (error) {
-      console.error(`[ProjectFileStore] Failed to load recipes for ${projectId}:`, error);
+    let parsed: unknown;
+    try {
+      parsed = JSON.parse(content);
+    } catch {
+      console.error(`[ProjectFileStore] Failed to parse recipes JSON for project ${projectId}`);
       try {
         const quarantinePath = `${filePath}.corrupted.${Date.now()}`;
         await resilientRename(filePath, quarantinePath);
@@ -41,6 +43,83 @@ export class ProjectFileStore {
       }
       return [];
     }
+
+    // Envelope: {"_schemaVersion": N, "recipes": [...]}
+    if (
+      parsed &&
+      typeof parsed === "object" &&
+      !Array.isArray(parsed) &&
+      "_schemaVersion" in parsed
+    ) {
+      const record = parsed as Record<string, unknown>;
+      const rawVersion = record._schemaVersion;
+      const onDiskVersion =
+        typeof rawVersion === "number" && Number.isInteger(rawVersion) && rawVersion >= 0
+          ? rawVersion
+          : 0;
+
+      if (onDiskVersion > RECIPES_SCHEMA_VERSION) {
+        let quarantinePath = `${filePath}.future-v${onDiskVersion}`;
+        if (existsSync(quarantinePath)) {
+          quarantinePath = `${quarantinePath}.${Date.now()}`;
+        }
+        try {
+          await resilientRename(filePath, quarantinePath);
+          console.warn(
+            `[ProjectFileStore] recipes.json for ${projectId} was written by a newer app (v${onDiskVersion} > v${RECIPES_SCHEMA_VERSION}); quarantined to ${quarantinePath}`
+          );
+        } catch (renameError) {
+          console.error(
+            `[ProjectFileStore] Failed to quarantine future-version recipes for ${projectId}:`,
+            renameError
+          );
+        }
+        return [];
+      }
+
+      const recipesArray = record.recipes;
+      if (!Array.isArray(recipesArray)) {
+        console.warn(
+          `[ProjectFileStore] Invalid recipes envelope for ${projectId}, expected recipes array`
+        );
+        try {
+          const quarantinePath = `${filePath}.corrupted.${Date.now()}`;
+          await resilientRename(filePath, quarantinePath);
+          console.warn(`[ProjectFileStore] Corrupted recipes file moved to ${quarantinePath}`);
+        } catch {
+          // Ignore
+        }
+        return [];
+      }
+
+      return filterValidTerminalEntries(
+        recipesArray,
+        TerminalRecipeSchema,
+        `ProjectFileStore(${projectId})`
+      );
+    }
+
+    // Legacy bare-array format
+    if (Array.isArray(parsed)) {
+      return filterValidTerminalEntries(
+        parsed,
+        TerminalRecipeSchema,
+        `ProjectFileStore(${projectId})`
+      );
+    }
+
+    // Root-shape failure — non-array, non-envelope
+    console.warn(
+      `[ProjectFileStore] Invalid recipes format for ${projectId}, expected array or envelope`
+    );
+    try {
+      const quarantinePath = `${filePath}.corrupted.${Date.now()}`;
+      await resilientRename(filePath, quarantinePath);
+      console.warn(`[ProjectFileStore] Corrupted recipes file moved to ${quarantinePath}`);
+    } catch {
+      // Ignore
+    }
+    return [];
   }
 
   async saveRecipes(projectId: string, recipes: TerminalRecipe[]): Promise<void> {
@@ -54,11 +133,13 @@ export class ProjectFileStore {
       throw new Error(`Invalid project ID: ${projectId}`);
     }
 
+    const jsonString = JSON.stringify({ _schemaVersion: RECIPES_SCHEMA_VERSION, recipes }, null, 2);
+
     const attemptSave = async (ensureDir: boolean): Promise<void> => {
       if (ensureDir) {
         await fs.mkdir(stateDir, { recursive: true });
       }
-      await resilientAtomicWriteFile(filePath, JSON.stringify(recipes, null, 2), "utf-8");
+      await resilientAtomicWriteFile(filePath, jsonString, "utf-8");
     };
 
     try {

--- a/electron/services/ProjectFileStore.ts
+++ b/electron/services/ProjectFileStore.ts
@@ -26,7 +26,7 @@ export class ProjectFileStore {
         return [];
       }
       console.error(`[ProjectFileStore] Failed to read recipes for ${projectId}:`, error);
-      return [];
+      throw error;
     }
 
     let parsed: unknown;

--- a/electron/services/__tests__/ProjectFileStore.adversarial.test.ts
+++ b/electron/services/__tests__/ProjectFileStore.adversarial.test.ts
@@ -19,13 +19,23 @@ vi.mock("fs/promises", () => ({ default: fsMock, ...fsMock }));
 vi.mock("fs", () => ({ ...fsSyncMock }));
 vi.mock("../../utils/fs.js", () => utilsMock);
 
-import { ProjectFileStore } from "../ProjectFileStore.js";
+import { ProjectFileStore, RECIPES_SCHEMA_VERSION } from "../ProjectFileStore.js";
 
 const VALID_ID = "a".repeat(64);
 const INVALID_ID_TRAVERSAL = "../../../etc/passwd";
 const CONFIG_DIR = path.normalize("/tmp/daintree-projects");
 const EXPECTED_STATE_DIR = path.join(CONFIG_DIR, VALID_ID);
 const EXPECTED_RECIPES_FILE = path.join(EXPECTED_STATE_DIR, "recipes.json");
+
+function quarantineRegex(basePath: string, suffix: string): RegExp {
+  const escaped = basePath.replace(/[.*+?^${}()|[\]\\]/g, "\\$&");
+  return new RegExp(`^${escaped}${suffix}$`);
+}
+
+function quarantineSuffixRegex(basePath: string, suffix: string): RegExp {
+  const escaped = basePath.replace(/[.*+?^${}()|[\]\\]/g, "\\$&");
+  return new RegExp(`^${escaped}${suffix}\\d+$`);
+}
 
 describe("ProjectFileStore adversarial", () => {
   let store: ProjectFileStore;
@@ -57,31 +67,30 @@ describe("ProjectFileStore adversarial", () => {
   });
 
   it("corrupted JSON is quarantined by renaming to .corrupted and returns []", async () => {
-    fsSyncMock.existsSync.mockReturnValue(true);
     fsMock.readFile.mockResolvedValue("{ not valid json");
 
     const result = await store.getRecipes(VALID_ID);
 
     expect(result).toEqual([]);
-    const escapedFile = EXPECTED_RECIPES_FILE.replace(/[.*+?^${}()|[\]\\]/g, "\\$&");
     expect(utilsMock.resilientRename).toHaveBeenCalledWith(
       EXPECTED_RECIPES_FILE,
-      expect.stringMatching(new RegExp(`^${escapedFile}\\.corrupted\\.\\d+$`))
+      expect.stringMatching(quarantineSuffixRegex(EXPECTED_RECIPES_FILE, "\\.corrupted\\."))
     );
   });
 
-  it("non-array JSON is tolerated — returns [] without quarantining (recoverable state preserved)", async () => {
-    fsSyncMock.existsSync.mockReturnValue(true);
+  it("non-array, non-envelope JSON is quarantined and returns []", async () => {
     fsMock.readFile.mockResolvedValue(JSON.stringify({ notAnArray: true }));
 
     const result = await store.getRecipes(VALID_ID);
 
     expect(result).toEqual([]);
-    expect(utilsMock.resilientRename).not.toHaveBeenCalled();
+    expect(utilsMock.resilientRename).toHaveBeenCalledWith(
+      EXPECTED_RECIPES_FILE,
+      expect.stringMatching(quarantineSuffixRegex(EXPECTED_RECIPES_FILE, "\\.corrupted\\."))
+    );
   });
 
   it("malformed recipe entries are filtered out — only structurally valid entries survive", async () => {
-    fsSyncMock.existsSync.mockReturnValue(true);
     fsMock.readFile.mockResolvedValue(
       JSON.stringify([
         { id: "r1", name: "valid", terminals: [], createdAt: 1000 },
@@ -99,7 +108,6 @@ describe("ProjectFileStore adversarial", () => {
   });
 
   it("filters out recipes with deeply malformed terminal entries", async () => {
-    fsSyncMock.existsSync.mockReturnValue(true);
     fsMock.readFile.mockResolvedValue(
       JSON.stringify([
         { id: "r1", name: "valid", terminals: [{ type: "terminal" }], createdAt: 1 },
@@ -131,7 +139,6 @@ describe("ProjectFileStore adversarial", () => {
   });
 
   it("filters out recipes with missing terminal type", async () => {
-    fsSyncMock.existsSync.mockReturnValue(true);
     fsMock.readFile.mockResolvedValue(
       JSON.stringify([
         { id: "r1", name: "valid", terminals: [{ type: "terminal" }], createdAt: 1 },
@@ -167,7 +174,6 @@ describe("ProjectFileStore adversarial", () => {
   });
 
   it("updateRecipe on a missing recipe id throws and does not write", async () => {
-    fsSyncMock.existsSync.mockReturnValue(true);
     fsMock.readFile.mockResolvedValue(JSON.stringify([]));
 
     await expect(store.updateRecipe(VALID_ID, "missing", { name: "x" })).rejects.toThrow(
@@ -176,17 +182,17 @@ describe("ProjectFileStore adversarial", () => {
     expect(utilsMock.resilientAtomicWriteFile).not.toHaveBeenCalled();
   });
 
-  it("getRecipes returns [] when the recipes file doesn't exist (no readFile attempt)", async () => {
-    fsSyncMock.existsSync.mockReturnValue(false);
+  it("getRecipes returns [] when the recipes file doesn't exist (ENOENT handled gracefully)", async () => {
+    const enoent = Object.assign(new Error("ENOENT"), { code: "ENOENT" });
+    fsMock.readFile.mockRejectedValue(enoent);
 
     const result = await store.getRecipes(VALID_ID);
 
     expect(result).toEqual([]);
-    expect(fsMock.readFile).not.toHaveBeenCalled();
+    expect(utilsMock.resilientRename).not.toHaveBeenCalled();
   });
 
   it("quarantine rename failure does not throw — getRecipes still returns []", async () => {
-    fsSyncMock.existsSync.mockReturnValue(true);
     fsMock.readFile.mockResolvedValue("{ not valid json");
     utilsMock.resilientRename.mockRejectedValueOnce(new Error("EBUSY"));
 
@@ -194,8 +200,7 @@ describe("ProjectFileStore adversarial", () => {
     expect(result).toEqual([]);
   });
 
-  it("deleteRecipe filters the target out and writes the remaining recipes", async () => {
-    fsSyncMock.existsSync.mockReturnValue(true);
+  it("deleteRecipe filters the target out and writes the remaining recipes in envelope format", async () => {
     fsMock.readFile.mockResolvedValue(
       JSON.stringify([
         { id: "keep", name: "k", terminals: [], createdAt: 1000 },
@@ -208,6 +213,168 @@ describe("ProjectFileStore adversarial", () => {
     const write = utilsMock.resilientAtomicWriteFile.mock.calls[0];
     expect(write[0]).toBe(EXPECTED_RECIPES_FILE);
     const payload = JSON.parse(write[1] as string);
-    expect(payload.map((r: { id: string }) => r.id)).toEqual(["keep"]);
+    expect(payload._schemaVersion).toBe(RECIPES_SCHEMA_VERSION);
+    expect(payload.recipes.map((r: { id: string }) => r.id)).toEqual(["keep"]);
+  });
+
+  it("legacy bare-array recipes.json is read correctly", async () => {
+    fsMock.readFile.mockResolvedValue(
+      JSON.stringify([{ id: "r1", name: "legacy recipe", terminals: [], createdAt: 1000 }])
+    );
+
+    const result = await store.getRecipes(VALID_ID);
+
+    expect(result).toHaveLength(1);
+    expect(result[0]!.id).toBe("r1");
+    expect(utilsMock.resilientRename).not.toHaveBeenCalled();
+  });
+
+  it("envelope format recipes.json is read correctly", async () => {
+    fsMock.readFile.mockResolvedValue(
+      JSON.stringify({
+        _schemaVersion: 1,
+        recipes: [{ id: "r1", name: "envelope recipe", terminals: [], createdAt: 1000 }],
+      })
+    );
+
+    const result = await store.getRecipes(VALID_ID);
+
+    expect(result).toHaveLength(1);
+    expect(result[0]!.id).toBe("r1");
+    expect(utilsMock.resilientRename).not.toHaveBeenCalled();
+  });
+
+  it("saveRecipes always writes envelope format", async () => {
+    await store.saveRecipes(VALID_ID, [{ id: "r1", name: "test", terminals: [], createdAt: 1000 }]);
+
+    const write = utilsMock.resilientAtomicWriteFile.mock.calls[0];
+    const payload = JSON.parse(write[1] as string);
+    expect(payload._schemaVersion).toBe(RECIPES_SCHEMA_VERSION);
+    expect(payload.recipes).toHaveLength(1);
+    expect(payload.recipes[0].id).toBe("r1");
+  });
+
+  it("malformed envelope (missing recipes array) is quarantined", async () => {
+    fsMock.readFile.mockResolvedValue(JSON.stringify({ _schemaVersion: 1, notRecipes: "bad" }));
+
+    const result = await store.getRecipes(VALID_ID);
+
+    expect(result).toEqual([]);
+    expect(utilsMock.resilientRename).toHaveBeenCalledWith(
+      EXPECTED_RECIPES_FILE,
+      expect.stringMatching(quarantineSuffixRegex(EXPECTED_RECIPES_FILE, "\\.corrupted\\."))
+    );
+  });
+
+  it("malformed envelope (recipes is not an array) is quarantined", async () => {
+    fsMock.readFile.mockResolvedValue(
+      JSON.stringify({ _schemaVersion: 1, recipes: "not-an-array" })
+    );
+
+    const result = await store.getRecipes(VALID_ID);
+
+    expect(result).toEqual([]);
+    expect(utilsMock.resilientRename).toHaveBeenCalledWith(
+      EXPECTED_RECIPES_FILE,
+      expect.stringMatching(quarantineSuffixRegex(EXPECTED_RECIPES_FILE, "\\.corrupted\\."))
+    );
+  });
+
+  it("future-version envelope is quarantined to .future-v{N}", async () => {
+    fsMock.readFile.mockResolvedValue(JSON.stringify({ _schemaVersion: 999, recipes: [] }));
+
+    const result = await store.getRecipes(VALID_ID);
+
+    expect(result).toEqual([]);
+    expect(utilsMock.resilientRename).toHaveBeenCalledWith(
+      EXPECTED_RECIPES_FILE,
+      expect.stringMatching(quarantineRegex(EXPECTED_RECIPES_FILE, "\\.future-v999"))
+    );
+  });
+
+  it("future-version quarantine uses timestamp suffix when destination exists", async () => {
+    fsMock.readFile.mockResolvedValue(JSON.stringify({ _schemaVersion: 999, recipes: [] }));
+    fsSyncMock.existsSync.mockImplementation((p: string) => (p as string).endsWith(".future-v999"));
+
+    const result = await store.getRecipes(VALID_ID);
+
+    expect(result).toEqual([]);
+    expect(utilsMock.resilientRename).toHaveBeenCalledWith(
+      EXPECTED_RECIPES_FILE,
+      expect.stringMatching(quarantineSuffixRegex(EXPECTED_RECIPES_FILE, "\\.future-v999\\."))
+    );
+  });
+
+  it("envelope with non-integer _schemaVersion is coerced to 0 and read normally", async () => {
+    fsMock.readFile.mockResolvedValue(
+      JSON.stringify({
+        _schemaVersion: "not-a-number",
+        recipes: [{ id: "r1", name: "still valid", terminals: [], createdAt: 1000 }],
+      })
+    );
+
+    const result = await store.getRecipes(VALID_ID);
+
+    expect(result).toHaveLength(1);
+    expect(result[0]!.id).toBe("r1");
+  });
+
+  it("envelope with negative _schemaVersion is read normally", async () => {
+    fsMock.readFile.mockResolvedValue(
+      JSON.stringify({
+        _schemaVersion: -1,
+        recipes: [{ id: "r1", name: "valid", terminals: [], createdAt: 1000 }],
+      })
+    );
+
+    const result = await store.getRecipes(VALID_ID);
+
+    expect(result).toHaveLength(1);
+    expect(result[0]!.id).toBe("r1");
+  });
+
+  it("round-trip: legacy bare array → read → save → read envelope", async () => {
+    // First read: legacy bare array
+    fsMock.readFile.mockResolvedValueOnce(
+      JSON.stringify([{ id: "r1", name: "legacy", terminals: [], createdAt: 1000 }])
+    );
+    const recipes = await store.getRecipes(VALID_ID);
+    expect(recipes).toHaveLength(1);
+    expect(recipes[0]!.id).toBe("r1");
+
+    // Save: should write envelope
+    await store.saveRecipes(VALID_ID, recipes);
+    const write = utilsMock.resilientAtomicWriteFile.mock.calls[0];
+    const writtenPayload = JSON.parse(write[1] as string);
+    expect(writtenPayload._schemaVersion).toBe(RECIPES_SCHEMA_VERSION);
+    expect(writtenPayload.recipes).toHaveLength(1);
+
+    // Second read: envelope comes back for the read
+    fsMock.readFile.mockResolvedValueOnce(JSON.stringify(writtenPayload));
+    const recipes2 = await store.getRecipes(VALID_ID);
+    expect(recipes2).toHaveLength(1);
+    expect(recipes2[0]!.id).toBe("r1");
+  });
+
+  it("ENOENT on readFile does not quarantine (file genuinely absent)", async () => {
+    const enoent = Object.assign(new Error("ENOENT"), { code: "ENOENT" });
+    fsMock.readFile.mockRejectedValue(enoent);
+    fsSyncMock.existsSync.mockReturnValue(false);
+
+    const result = await store.getRecipes(VALID_ID);
+
+    expect(result).toEqual([]);
+    expect(utilsMock.resilientRename).not.toHaveBeenCalled();
+  });
+
+  it("non-ENOENT read errors return [] without quarantine", async () => {
+    const eacces = Object.assign(new Error("EACCES"), { code: "EACCES" });
+    fsMock.readFile.mockRejectedValue(eacces);
+
+    const result = await store.getRecipes(VALID_ID);
+
+    expect(result).toEqual([]);
+    // Can't quarantine on read failure — we can't even read the file
+    expect(utilsMock.resilientRename).not.toHaveBeenCalled();
   });
 });

--- a/electron/services/__tests__/ProjectFileStore.adversarial.test.ts
+++ b/electron/services/__tests__/ProjectFileStore.adversarial.test.ts
@@ -367,14 +367,29 @@ describe("ProjectFileStore adversarial", () => {
     expect(utilsMock.resilientRename).not.toHaveBeenCalled();
   });
 
-  it("non-ENOENT read errors return [] without quarantine", async () => {
+  it("non-ENOENT read errors throw (so mutators don't destroy data)", async () => {
     const eacces = Object.assign(new Error("EACCES"), { code: "EACCES" });
     fsMock.readFile.mockRejectedValue(eacces);
 
-    const result = await store.getRecipes(VALID_ID);
-
-    expect(result).toEqual([]);
-    // Can't quarantine on read failure — we can't even read the file
+    await expect(store.getRecipes(VALID_ID)).rejects.toThrow("EACCES");
     expect(utilsMock.resilientRename).not.toHaveBeenCalled();
+  });
+
+  it("deleteRecipe does not write when getRecipes fails with non-ENOENT", async () => {
+    const eacces = Object.assign(new Error("EACCES"), { code: "EACCES" });
+    fsMock.readFile.mockRejectedValue(eacces);
+
+    await expect(store.deleteRecipe(VALID_ID, "any")).rejects.toThrow("EACCES");
+    expect(utilsMock.resilientAtomicWriteFile).not.toHaveBeenCalled();
+  });
+
+  it("addRecipe does not write when getRecipes fails with non-ENOENT", async () => {
+    const eio = Object.assign(new Error("EIO"), { code: "EIO" });
+    fsMock.readFile.mockRejectedValue(eio);
+
+    await expect(
+      store.addRecipe(VALID_ID, { id: "r1", name: "test", terminals: [], createdAt: 1000 })
+    ).rejects.toThrow("EIO");
+    expect(utilsMock.resilientAtomicWriteFile).not.toHaveBeenCalled();
   });
 });

--- a/electron/services/projectQuarantineCleanup.ts
+++ b/electron/services/projectQuarantineCleanup.ts
@@ -11,6 +11,7 @@ const QUARANTINE_PREFIXES = [
   "state.json.future-v",
   "settings.json.corrupted.",
   "recipes.json.corrupted.",
+  "recipes.json.future-v",
 ];
 
 const GLOBAL_RECIPES_QUARANTINE_PREFIXES = ["recipes.json.corrupted."];


### PR DESCRIPTION
## Summary
- Adds schema version tracking so older Daintree builds don't silently strip fields from `recipes.json` on read-modify-write
- Quarantines corrupted, future-version, and malformed-root-shape files instead of silently overwriting them
- Removes the TOCTOU race between `existsSync` and `readFile` by catching `ENOENT` directly

Resolves #7093

## Changes
- `electron/services/ProjectFileStore.ts` — envelope format with `_schemaVersion`/`recipes`, legacy bare-array migration, root-shape quarantine, future-version quarantine, and TOCTOU-safe reads
- `electron/services/__tests__/ProjectFileStore.adversarial.test.ts` — adversarial tests covering schema version downgrade, corruption recovery, file removal races, and malformed root shapes
- `electron/services/projectQuarantineCleanup.ts` — registers `*.future-vN` patterns for cleanup

## Testing
- Unit tests pass for read/write/parse edge cases
- Adversarial tests cover downgrade, corruption, TOCTOU, and root-shape failure scenarios