### PR TITLE
fix(ResourceProfileService): prime thermal and battery state at startup

### DIFF
--- a/electron/services/ResourceProfileService.ts
+++ b/electron/services/ResourceProfileService.ts
@@ -123,7 +123,7 @@ export class ResourceProfileService {
         this.thermalState = state;
       }
     } catch {
-      // keep "unknown" default — non-critical
+      this.thermalState = "unknown";
     }
   }
 
@@ -146,6 +146,9 @@ export class ResourceProfileService {
   start(): void {
     if (this.evalCleanup) return;
     this.disposed = false;
+    this.tickCount = 0;
+    this.candidateProfile = null;
+    this.candidateFirstSeenAt = null;
 
     logInfo("resource-profile-service-started", { profile: this.currentProfile });
 
@@ -322,6 +325,9 @@ export class ResourceProfileService {
     this.lagEscalatedActive = false;
     this.lagEnterTicks = 0;
     this.lagExitTicks = 0;
+    this.thermalState = "unknown";
+    this.isOnBattery = false;
+    this.speedLimit = 100;
     this.disposed = true;
     logInfo("resource-profile-service-stopped");
   }

--- a/electron/services/ResourceProfileService.ts
+++ b/electron/services/ResourceProfileService.ts
@@ -72,6 +72,7 @@ export class ResourceProfileService {
   private cachedWorktreeCount = 0;
   private thermalState: "unknown" | "nominal" | "fair" | "serious" | "critical" = "unknown";
   private speedLimit = 100;
+  private isOnBattery = false;
   private readonly memoryThresholdHighMb: number;
   private readonly memoryThresholdLowMb: number;
   private lagInterval: NodeJS.Timeout | null = null;
@@ -108,6 +109,32 @@ export class ResourceProfileService {
     }
   };
 
+  private primeThermalState(): void {
+    if (process.platform !== "darwin") return;
+    try {
+      const state = powerMonitor.getCurrentThermalState();
+      if (
+        state === "unknown" ||
+        state === "nominal" ||
+        state === "fair" ||
+        state === "serious" ||
+        state === "critical"
+      ) {
+        this.thermalState = state;
+      }
+    } catch {
+      // keep "unknown" default — non-critical
+    }
+  }
+
+  private onBatteryPower = (): void => {
+    this.isOnBattery = true;
+  };
+
+  private onAcPower = (): void => {
+    this.isOnBattery = false;
+  };
+
   setWorktreeCount(count: number): void {
     this.cachedWorktreeCount = count;
   }
@@ -126,6 +153,15 @@ export class ResourceProfileService {
 
     powerMonitor.on("thermal-state-change", this.onThermalStateChange);
     powerMonitor.on("speed-limit-change", this.onSpeedLimitChange);
+
+    this.primeThermalState();
+    try {
+      this.isOnBattery = powerMonitor.isOnBatteryPower();
+    } catch {
+      this.isOnBattery = false;
+    }
+    powerMonitor.on("on-battery", this.onBatteryPower);
+    powerMonitor.on("on-ac", this.onAcPower);
 
     this.evalCleanup = setAlignedInterval(() => {
       this.refreshWorktreeCount();
@@ -262,6 +298,8 @@ export class ResourceProfileService {
   stop(): void {
     powerMonitor.removeListener("thermal-state-change", this.onThermalStateChange);
     powerMonitor.removeListener("speed-limit-change", this.onSpeedLimitChange);
+    powerMonitor.removeListener("on-battery", this.onBatteryPower);
+    powerMonitor.removeListener("on-ac", this.onAcPower);
 
     if (this.evalCleanup) {
       this.evalCleanup();
@@ -340,13 +378,9 @@ export class ResourceProfileService {
       // Skip memory signal on error
     }
 
-    // Battery signal
-    try {
-      if (powerMonitor.isOnBatteryPower()) {
-        pressureScore += 1;
-      }
-    } catch {
-      // Skip battery signal (may throw in utility process context)
+    // Battery signal (cached from startup + transition events)
+    if (this.isOnBattery) {
+      pressureScore += 1;
     }
 
     // Thermal signal (macOS only)

--- a/electron/services/__tests__/ResourceProfileService.adversarial.test.ts
+++ b/electron/services/__tests__/ResourceProfileService.adversarial.test.ts
@@ -17,6 +17,7 @@ vi.mock("electron", () => ({
   },
   powerMonitor: {
     isOnBatteryPower: vi.fn(() => false),
+    getCurrentThermalState: vi.fn(() => "unknown" as const),
     on: vi.fn(),
     removeListener: vi.fn(),
   },
@@ -60,6 +61,7 @@ const EIGHT_GB = 8 * 1024 * 1024 * 1024;
 
 const mockGetAppMetrics = app.getAppMetrics as Mock;
 const mockIsOnBatteryPower = powerMonitor.isOnBatteryPower as unknown as Mock;
+const mockGetCurrentThermalState = powerMonitor.getCurrentThermalState as unknown as Mock;
 const mockPowerMonitorOn = powerMonitor.on as unknown as Mock;
 const mockPowerMonitorRemoveListener = powerMonitor.removeListener as unknown as Mock;
 
@@ -165,6 +167,7 @@ describe("ResourceProfileService adversarial", () => {
     vi.spyOn(os, "totalmem").mockReturnValue(EIGHT_GB);
     mockGetAppMetrics.mockReturnValue([]);
     mockIsOnBatteryPower.mockReturnValue(false);
+    mockGetCurrentThermalState.mockReturnValue("unknown" as const);
     setLag(0, 0);
     lagState.resetCount = 0;
   });
@@ -177,23 +180,34 @@ describe("ResourceProfileService adversarial", () => {
   it("does not thrash profiles when pressure oscillates around the hysteresis boundary", () => {
     const { deps } = createDeps();
     const service = new ResourceProfileService(deps);
-
+    mockIsOnBatteryPower.mockReturnValue(true);
     service.start();
+
+    const onBatteryHandler = mockPowerMonitorOn.mock.calls.find(
+      (call: string[]) => call[0] === "on-battery"
+    )?.[1] as (() => void) | undefined;
+    const onAcHandler = mockPowerMonitorOn.mock.calls.find(
+      (call: string[]) => call[0] === "on-ac"
+    )?.[1] as (() => void) | undefined;
 
     vi.advanceTimersByTime(60_000);
 
     const oscillatingSignals = [
-      { metrics: [makeMetric(1300)], battery: true },
-      { metrics: [makeMetric(200)], battery: false },
-      { metrics: [makeMetric(1300)], battery: true },
-      { metrics: [makeMetric(200)], battery: false },
-      { metrics: [makeMetric(900)], battery: false },
-      { metrics: [makeMetric(200)], battery: false },
+      { metrics: [makeMetric(1300)], battery: "on" as const },
+      { metrics: [makeMetric(200)], battery: "off" as const },
+      { metrics: [makeMetric(1300)], battery: "on" as const },
+      { metrics: [makeMetric(200)], battery: "off" as const },
+      { metrics: [makeMetric(900)], battery: "off" as const },
+      { metrics: [makeMetric(200)], battery: "off" as const },
     ];
 
     for (const signal of oscillatingSignals) {
       mockGetAppMetrics.mockReturnValue(signal.metrics);
-      mockIsOnBatteryPower.mockReturnValue(signal.battery);
+      if (signal.battery === "on") {
+        onBatteryHandler!();
+      } else {
+        onAcHandler!();
+      }
       vi.advanceTimersByTime(30_000);
       expect(service.getProfile()).toBe("balanced");
     }
@@ -285,6 +299,8 @@ describe("ResourceProfileService adversarial", () => {
 
     expect(mockPowerMonitorOn).toHaveBeenCalledWith("thermal-state-change", expect.any(Function));
     expect(mockPowerMonitorOn).toHaveBeenCalledWith("speed-limit-change", expect.any(Function));
+    expect(mockPowerMonitorOn).toHaveBeenCalledWith("on-battery", expect.any(Function));
+    expect(mockPowerMonitorOn).toHaveBeenCalledWith("on-ac", expect.any(Function));
 
     service.stop();
   });
@@ -307,11 +323,11 @@ describe("ResourceProfileService adversarial", () => {
     const service = new ResourceProfileService(deps);
 
     service.setWorktreeCount(9);
+    mockIsOnBatteryPower.mockReturnValue(true);
     service.start();
 
     // Low memory (0) + battery (+1) + thermal serious (+1) + worktrees (+1) = 3 => efficiency
     mockGetAppMetrics.mockReturnValue([makeMetric(200)]);
-    mockIsOnBatteryPower.mockReturnValue(true);
     (service as unknown as { thermalState: string }).thermalState = "serious";
 
     vi.advanceTimersByTime(60_000 + 30_000 + 30_000);
@@ -396,11 +412,11 @@ describe("ResourceProfileService adversarial", () => {
     it("does not retrigger applyProfile when already at efficiency", () => {
       const { deps } = createDeps();
       const service = new ResourceProfileService(deps);
+      mockIsOnBatteryPower.mockReturnValue(true);
       service.start();
 
       // Drive into efficiency via memory + battery first.
       mockGetAppMetrics.mockReturnValue([makeMetric(1300)]);
-      mockIsOnBatteryPower.mockReturnValue(true);
       vi.advanceTimersByTime(60_000 + 30_000 + 30_000);
       expect(service.getProfile()).toBe("efficiency");
 
@@ -658,6 +674,52 @@ describe("ResourceProfileService adversarial", () => {
       vi.advanceTimersByTime(30_000);
       vi.advanceTimersByTime(30_000);
       expect(service.getProfile()).toBe("performance");
+
+      service.stop();
+    });
+
+    it("getCurrentThermalState throwing does not crash start", () => {
+      mockGetCurrentThermalState.mockImplementation(() => {
+        throw new Error("thermal unavailable");
+      });
+
+      const { deps } = createDeps();
+      const service = new ResourceProfileService(deps);
+      expect(() => service.start()).not.toThrow();
+
+      const internals = service as unknown as { thermalState: string };
+      expect(internals.thermalState).toBe("unknown");
+
+      service.stop();
+    });
+
+    it("isOnBatteryPower throwing during priming does not crash start", () => {
+      mockIsOnBatteryPower.mockImplementation(() => {
+        throw new Error("battery unavailable");
+      });
+
+      const { deps } = createDeps();
+      const service = new ResourceProfileService(deps);
+      expect(() => service.start()).not.toThrow();
+
+      const internals = service as unknown as { isOnBattery: boolean };
+      expect(internals.isOnBattery).toBe(false);
+
+      service.stop();
+    });
+
+    it("cold start with thermal serious contributes to first evaluation", () => {
+      mockGetCurrentThermalState.mockReturnValue("serious" as const);
+      mockIsOnBatteryPower.mockReturnValue(true);
+
+      const { deps } = createDeps();
+      const service = new ResourceProfileService(deps);
+      service.start();
+
+      // Low memory (0) + battery (+1) + thermal serious (+1) = 2 => balanced
+      mockGetAppMetrics.mockReturnValue([makeMetric(200)]);
+      vi.advanceTimersByTime(60_000 + 30_000 + 30_000);
+      expect(service.getProfile()).toBe("balanced");
 
       service.stop();
     });

--- a/electron/services/__tests__/ResourceProfileService.adversarial.test.ts
+++ b/electron/services/__tests__/ResourceProfileService.adversarial.test.ts
@@ -679,6 +679,7 @@ describe("ResourceProfileService adversarial", () => {
     });
 
     it("getCurrentThermalState throwing does not crash start", () => {
+      vi.spyOn(process, "platform", "get").mockReturnValue("darwin");
       mockGetCurrentThermalState.mockImplementation(() => {
         throw new Error("thermal unavailable");
       });
@@ -708,18 +709,76 @@ describe("ResourceProfileService adversarial", () => {
       service.stop();
     });
 
-    it("cold start with thermal serious contributes to first evaluation", () => {
-      mockGetCurrentThermalState.mockReturnValue("serious" as const);
+    it("cold start with thermal critical contributes to first evaluation", () => {
+      vi.spyOn(process, "platform", "get").mockReturnValue("darwin");
+      mockGetCurrentThermalState.mockReturnValue("critical" as const);
       mockIsOnBatteryPower.mockReturnValue(true);
 
       const { deps } = createDeps();
       const service = new ResourceProfileService(deps);
       service.start();
 
-      // Low memory (0) + battery (+1) + thermal serious (+1) = 2 => balanced
+      // Low memory (0) + battery (+1) + thermal critical (+2) = 3 => efficiency
+      // Without thermal priming the score would be 1 => balanced
       mockGetAppMetrics.mockReturnValue([makeMetric(200)]);
       vi.advanceTimersByTime(60_000 + 30_000 + 30_000);
+      expect(service.getProfile()).toBe("efficiency");
+
+      service.stop();
+    });
+
+    it("stop/start resets tickCount and enforces warmup on restart", () => {
+      const { deps } = createDeps();
+      const service = new ResourceProfileService(deps);
+
+      service.start();
+      // Advance past warmup
+      vi.advanceTimersByTime(60_000);
+      expect((service as unknown as { tickCount: number }).tickCount).toBeGreaterThan(0);
+
+      service.stop();
+      service.start();
+
+      expect((service as unknown as { tickCount: number }).tickCount).toBe(0);
+      // High pressure signals should NOT transition during warmup after restart
+      mockGetAppMetrics.mockReturnValue([makeMetric(1300)]);
+      mockIsOnBatteryPower.mockReturnValue(true);
+      vi.advanceTimersByTime(60_000);
       expect(service.getProfile()).toBe("balanced");
+
+      service.stop();
+    });
+
+    it("isOnBatteryPower not called on evaluation ticks", () => {
+      const { deps } = createDeps();
+      const service = new ResourceProfileService(deps);
+      service.start();
+      const callsAfterStart = mockIsOnBatteryPower.mock.calls.length;
+
+      // Several eval ticks
+      vi.advanceTimersByTime(60_000 + 30_000 + 30_000);
+      expect(mockIsOnBatteryPower).toHaveBeenCalledTimes(callsAfterStart);
+
+      service.stop();
+    });
+
+    it("malformed thermal event payload preserves last valid state", () => {
+      const { deps } = createDeps();
+      const service = new ResourceProfileService(deps);
+      service.start();
+
+      const thermalHandler = mockPowerMonitorOn.mock.calls.find(
+        (call: string[]) => call[0] === "thermal-state-change"
+      )?.[1] as ((details: { state: string }) => void) | undefined;
+      expect(thermalHandler).toBeDefined();
+
+      // Set a known-good state first
+      thermalHandler!({ state: "critical" });
+      expect((service as unknown as { thermalState: string }).thermalState).toBe("critical");
+
+      // Bogus state value must not throw and must preserve last valid state
+      expect(() => thermalHandler!({ state: "bogus" })).not.toThrow();
+      expect((service as unknown as { thermalState: string }).thermalState).toBe("critical");
 
       service.stop();
     });

--- a/electron/services/__tests__/ResourceProfileService.test.ts
+++ b/electron/services/__tests__/ResourceProfileService.test.ts
@@ -12,6 +12,7 @@ vi.mock("electron", () => ({
   },
   powerMonitor: {
     isOnBatteryPower: vi.fn(() => false),
+    getCurrentThermalState: vi.fn(() => "unknown" as const),
     on: vi.fn(),
     removeListener: vi.fn(),
   },
@@ -52,6 +53,7 @@ const EIGHT_GB = 8 * 1024 * 1024 * 1024;
 
 const mockGetAppMetrics = app.getAppMetrics as Mock;
 const mockIsOnBatteryPower = powerMonitor.isOnBatteryPower as unknown as Mock;
+const mockGetCurrentThermalState = powerMonitor.getCurrentThermalState as unknown as Mock;
 const mockPowerMonitorOn = powerMonitor.on as unknown as Mock;
 const mockPowerMonitorRemoveListener = powerMonitor.removeListener as unknown as Mock;
 
@@ -127,6 +129,7 @@ describe("ResourceProfileService", () => {
     vi.spyOn(os, "totalmem").mockReturnValue(EIGHT_GB);
     mockGetAppMetrics.mockReturnValue([]);
     mockIsOnBatteryPower.mockReturnValue(false);
+    mockGetCurrentThermalState.mockReturnValue("unknown" as const);
   });
 
   afterEach(() => {
@@ -143,10 +146,10 @@ describe("ResourceProfileService", () => {
   it("does not transition during warmup ticks", () => {
     const deps = createDeps();
     const service = new ResourceProfileService(deps);
+    mockIsOnBatteryPower.mockReturnValue(true);
     service.start();
 
     mockGetAppMetrics.mockReturnValue([makeMetric("Browser", 800), makeMetric("Tab", 500)]);
-    mockIsOnBatteryPower.mockReturnValue(true);
 
     // Advance through 2 warmup ticks
     vi.advanceTimersByTime(30_000);
@@ -159,11 +162,11 @@ describe("ResourceProfileService", () => {
   it("transitions to efficiency after sustained pressure past hysteresis", () => {
     const deps = createDeps();
     const service = new ResourceProfileService(deps);
+    mockIsOnBatteryPower.mockReturnValue(true);
     service.start();
 
     // High memory + battery = pressure score >= 3
     mockGetAppMetrics.mockReturnValue([makeMetric("Browser", 800), makeMetric("Tab", 500)]);
-    mockIsOnBatteryPower.mockReturnValue(true);
 
     // 2 warmup ticks
     vi.advanceTimersByTime(60_000);
@@ -183,11 +186,15 @@ describe("ResourceProfileService", () => {
   it("does not oscillate — resets candidate when signals change", () => {
     const deps = createDeps();
     const service = new ResourceProfileService(deps);
+    mockIsOnBatteryPower.mockReturnValue(true);
     service.start();
+
+    const onAcHandler = mockPowerMonitorOn.mock.calls.find(
+      (call: string[]) => call[0] === "on-ac"
+    )?.[1] as (() => void) | undefined;
 
     // High pressure
     mockGetAppMetrics.mockReturnValue([makeMetric("Browser", 1300)]);
-    mockIsOnBatteryPower.mockReturnValue(true);
 
     // Past warmup
     vi.advanceTimersByTime(60_000);
@@ -197,7 +204,7 @@ describe("ResourceProfileService", () => {
 
     // Pressure relieved before hold completes
     mockGetAppMetrics.mockReturnValue([makeMetric("Browser", 200)]);
-    mockIsOnBatteryPower.mockReturnValue(false);
+    onAcHandler!();
     vi.advanceTimersByTime(30_000);
 
     // Should still be balanced — candidate reset
@@ -232,10 +239,10 @@ describe("ResourceProfileService", () => {
   it("broadcasts to renderer on profile change", () => {
     const deps = createDeps();
     const service = new ResourceProfileService(deps);
+    mockIsOnBatteryPower.mockReturnValue(true);
     service.start();
 
     mockGetAppMetrics.mockReturnValue([makeMetric("Browser", 1300)]);
-    mockIsOnBatteryPower.mockReturnValue(true);
 
     // Past warmup + hysteresis
     vi.advanceTimersByTime(60_000 + 30_000 + 30_000);
@@ -257,10 +264,10 @@ describe("ResourceProfileService", () => {
   it("calls workspace client and hibernation service on profile change", () => {
     const deps = createDeps();
     const service = new ResourceProfileService(deps);
+    mockIsOnBatteryPower.mockReturnValue(true);
     service.start();
 
     mockGetAppMetrics.mockReturnValue([makeMetric("Browser", 1300)]);
-    mockIsOnBatteryPower.mockReturnValue(true);
 
     vi.advanceTimersByTime(60_000 + 30_000 + 30_000);
 
@@ -292,10 +299,10 @@ describe("ResourceProfileService", () => {
       getProjectStatsService: () => null,
     });
     const service = new ResourceProfileService(deps);
+    mockIsOnBatteryPower.mockReturnValue(true);
     service.start();
 
     mockGetAppMetrics.mockReturnValue([makeMetric("Browser", 1300)]);
-    mockIsOnBatteryPower.mockReturnValue(true);
 
     // Should not throw
     vi.advanceTimersByTime(60_000 + 30_000 + 30_000);
@@ -307,10 +314,10 @@ describe("ResourceProfileService", () => {
   it("clamps cached project views to 1 when transitioning to efficiency", () => {
     const deps = createDeps();
     const service = new ResourceProfileService(deps);
+    mockIsOnBatteryPower.mockReturnValue(true);
     service.start();
 
     mockGetAppMetrics.mockReturnValue([makeMetric("Browser", 1300)]);
-    mockIsOnBatteryPower.mockReturnValue(true);
 
     vi.advanceTimersByTime(60_000 + 30_000 + 30_000);
     expect(service.getProfile()).toBe("efficiency");
@@ -325,11 +332,15 @@ describe("ResourceProfileService", () => {
   it("restores user cached view limit when upgrading from efficiency to balanced", () => {
     const deps = createDeps({ getUserCachedViewLimit: () => 3 });
     const service = new ResourceProfileService(deps);
+    mockIsOnBatteryPower.mockReturnValue(true);
     service.start();
+
+    const onAcHandler = mockPowerMonitorOn.mock.calls.find(
+      (call: string[]) => call[0] === "on-ac"
+    )?.[1] as (() => void) | undefined;
 
     // Drive into efficiency
     mockGetAppMetrics.mockReturnValue([makeMetric("Browser", 1300)]);
-    mockIsOnBatteryPower.mockReturnValue(true);
     vi.advanceTimersByTime(60_000 + 30_000 + 30_000);
     expect(service.getProfile()).toBe("efficiency");
 
@@ -338,7 +349,7 @@ describe("ResourceProfileService", () => {
 
     // Relieve to moderate pressure (score 1 = balanced)
     mockGetAppMetrics.mockReturnValue([makeMetric("Browser", 700)]);
-    mockIsOnBatteryPower.mockReturnValue(false);
+    onAcHandler!();
 
     // First real eval sets candidate; 60s upgrade hold = 2 more ticks to apply
     vi.advanceTimersByTime(30_000);
@@ -355,17 +366,21 @@ describe("ResourceProfileService", () => {
   it("restores user cached view limit when upgrading from efficiency to performance", () => {
     const deps = createDeps({ getUserCachedViewLimit: () => 2 });
     const service = new ResourceProfileService(deps);
+    mockIsOnBatteryPower.mockReturnValue(true);
     service.start();
+
+    const onAcHandler = mockPowerMonitorOn.mock.calls.find(
+      (call: string[]) => call[0] === "on-ac"
+    )?.[1] as (() => void) | undefined;
 
     // Drive into efficiency
     mockGetAppMetrics.mockReturnValue([makeMetric("Browser", 1300)]);
-    mockIsOnBatteryPower.mockReturnValue(true);
     vi.advanceTimersByTime(60_000 + 30_000 + 30_000);
     expect(service.getProfile()).toBe("efficiency");
 
     // Relieve to zero pressure (score 0 = performance)
     mockGetAppMetrics.mockReturnValue([makeMetric("Browser", 200)]);
-    mockIsOnBatteryPower.mockReturnValue(false);
+    onAcHandler!();
 
     // First real eval sets candidate; 60s upgrade hold = 2 more ticks to apply
     vi.advanceTimersByTime(30_000);
@@ -401,10 +416,10 @@ describe("ResourceProfileService", () => {
   it("handles null project view manager on efficiency transition", () => {
     const deps = createDeps({ getProjectViewManager: () => null });
     const service = new ResourceProfileService(deps);
+    mockIsOnBatteryPower.mockReturnValue(true);
     service.start();
 
     mockGetAppMetrics.mockReturnValue([makeMetric("Browser", 1300)]);
-    mockIsOnBatteryPower.mockReturnValue(true);
 
     // Should not throw
     vi.advanceTimersByTime(60_000 + 30_000 + 30_000);
@@ -426,11 +441,11 @@ describe("ResourceProfileService", () => {
   it("battery on its own contributes to pressure score", () => {
     const deps = createDeps();
     const service = new ResourceProfileService(deps);
+    mockIsOnBatteryPower.mockReturnValue(true);
     service.start();
 
     // Moderate memory (+1) + battery (+1) = 2 => balanced
     mockGetAppMetrics.mockReturnValue([makeMetric("Browser", 700)]);
-    mockIsOnBatteryPower.mockReturnValue(true);
 
     // Past warmup + hysteresis for downgrade
     vi.advanceTimersByTime(60_000 + 30_000 + 30_000);
@@ -443,11 +458,11 @@ describe("ResourceProfileService", () => {
     const deps = createDeps();
     const service = new ResourceProfileService(deps);
     service.setWorktreeCount(10);
+    mockIsOnBatteryPower.mockReturnValue(true);
     service.start();
 
     // Low memory (0) + battery (+1) + worktrees (+1) = 2 => balanced
     mockGetAppMetrics.mockReturnValue([makeMetric("Browser", 200)]);
-    mockIsOnBatteryPower.mockReturnValue(true);
 
     vi.advanceTimersByTime(60_000 + 30_000 + 30_000);
     expect(service.getProfile()).toBe("balanced");
@@ -478,11 +493,11 @@ describe("ResourceProfileService", () => {
   it("thermal critical + battery drives to efficiency", () => {
     const deps = createDeps();
     const service = new ResourceProfileService(deps);
+    mockIsOnBatteryPower.mockReturnValue(true);
     service.start();
 
     // Low memory (0) + battery (+1) + thermal critical (+2) = 3 => efficiency
     mockGetAppMetrics.mockReturnValue([makeMetric("Browser", 200)]);
-    mockIsOnBatteryPower.mockReturnValue(true);
     (service as unknown as { thermalState: string }).thermalState = "critical";
 
     vi.advanceTimersByTime(60_000 + 30_000 + 30_000);
@@ -494,11 +509,11 @@ describe("ResourceProfileService", () => {
   it("thermal serious + battery + moderate memory = efficiency", () => {
     const deps = createDeps();
     const service = new ResourceProfileService(deps);
+    mockIsOnBatteryPower.mockReturnValue(true);
     service.start();
 
     // Moderate memory (+1) + battery (+1) + thermal serious (+1) = 3 => efficiency
     mockGetAppMetrics.mockReturnValue([makeMetric("Browser", 700)]);
-    mockIsOnBatteryPower.mockReturnValue(true);
     (service as unknown as { thermalState: string }).thermalState = "serious";
 
     vi.advanceTimersByTime(60_000 + 30_000 + 30_000);
@@ -510,11 +525,11 @@ describe("ResourceProfileService", () => {
   it("thermal fair and nominal do not contribute to pressure", () => {
     const deps = createDeps();
     const service = new ResourceProfileService(deps);
+    mockIsOnBatteryPower.mockReturnValue(true);
     service.start();
 
     // Moderate memory (+1) + battery (+1) + thermal fair (0) = 2 => balanced
     mockGetAppMetrics.mockReturnValue([makeMetric("Browser", 700)]);
-    mockIsOnBatteryPower.mockReturnValue(true);
     (service as unknown as { thermalState: string }).thermalState = "fair";
 
     vi.advanceTimersByTime(60_000 + 30_000 + 30_000);
@@ -574,6 +589,7 @@ describe("ResourceProfileService", () => {
   it("routes thermal-state-change event through handler to profile scoring", () => {
     const deps = createDeps();
     const service = new ResourceProfileService(deps);
+    mockIsOnBatteryPower.mockReturnValue(true);
     service.start();
 
     // Capture the thermal handler registered with powerMonitor.on
@@ -587,7 +603,6 @@ describe("ResourceProfileService", () => {
 
     // Low memory (0) + thermal critical (+2) + battery (+1) = 3 => efficiency
     mockGetAppMetrics.mockReturnValue([makeMetric("Browser", 200)]);
-    mockIsOnBatteryPower.mockReturnValue(true);
 
     vi.advanceTimersByTime(60_000 + 30_000 + 30_000);
     expect(service.getProfile()).toBe("efficiency");
@@ -631,6 +646,12 @@ describe("ResourceProfileService", () => {
     const speedOnArg = mockPowerMonitorOn.mock.calls.find(
       (call: string[]) => call[0] === "speed-limit-change"
     )?.[1];
+    const batteryOnArg = mockPowerMonitorOn.mock.calls.find(
+      (call: string[]) => call[0] === "on-battery"
+    )?.[1];
+    const acOnArg = mockPowerMonitorOn.mock.calls.find(
+      (call: string[]) => call[0] === "on-ac"
+    )?.[1];
 
     // Get the handlers passed to removeListener
     const thermalOffArg = mockPowerMonitorRemoveListener.mock.calls.find(
@@ -639,6 +660,12 @@ describe("ResourceProfileService", () => {
     const speedOffArg = mockPowerMonitorRemoveListener.mock.calls.find(
       (call: string[]) => call[0] === "speed-limit-change"
     )?.[1];
+    const batteryOffArg = mockPowerMonitorRemoveListener.mock.calls.find(
+      (call: string[]) => call[0] === "on-battery"
+    )?.[1];
+    const acOffArg = mockPowerMonitorRemoveListener.mock.calls.find(
+      (call: string[]) => call[0] === "on-ac"
+    )?.[1];
 
     expect(thermalOnArg).toBeDefined();
     expect(thermalOffArg).toBeDefined();
@@ -646,6 +673,12 @@ describe("ResourceProfileService", () => {
     expect(speedOnArg).toBeDefined();
     expect(speedOffArg).toBeDefined();
     expect(speedOnArg).toBe(speedOffArg);
+    expect(batteryOnArg).toBeDefined();
+    expect(batteryOffArg).toBeDefined();
+    expect(batteryOnArg).toBe(batteryOffArg);
+    expect(acOnArg).toBeDefined();
+    expect(acOffArg).toBeDefined();
+    expect(acOnArg).toBe(acOffArg);
   });
 
   it("registers powerMonitor listeners on start", () => {
@@ -654,6 +687,8 @@ describe("ResourceProfileService", () => {
 
     expect(mockPowerMonitorOn).toHaveBeenCalledWith("thermal-state-change", expect.any(Function));
     expect(mockPowerMonitorOn).toHaveBeenCalledWith("speed-limit-change", expect.any(Function));
+    expect(mockPowerMonitorOn).toHaveBeenCalledWith("on-battery", expect.any(Function));
+    expect(mockPowerMonitorOn).toHaveBeenCalledWith("on-ac", expect.any(Function));
 
     service.stop();
   });
@@ -671,6 +706,8 @@ describe("ResourceProfileService", () => {
       "speed-limit-change",
       expect.any(Function)
     );
+    expect(mockPowerMonitorRemoveListener).toHaveBeenCalledWith("on-battery", expect.any(Function));
+    expect(mockPowerMonitorRemoveListener).toHaveBeenCalledWith("on-ac", expect.any(Function));
   });
 
   it("scales thresholds down on low-RAM devices so 500 MB usage is detected", () => {
@@ -691,6 +728,106 @@ describe("ResourceProfileService", () => {
 
     vi.advanceTimersByTime(60_000 + 30_000 + 30_000);
     expect(service.getProfile()).toBe("balanced");
+
+    service.stop();
+  });
+
+  it("primes thermal state from getCurrentThermalState at start", () => {
+    mockGetCurrentThermalState.mockReturnValue("fair" as const);
+
+    const deps = createDeps();
+    const service = new ResourceProfileService(deps);
+    service.start();
+
+    expect(mockGetCurrentThermalState).toHaveBeenCalled();
+    const internals = service as unknown as { thermalState: string };
+    expect(internals.thermalState).toBe("fair");
+
+    service.stop();
+  });
+
+  it("primes battery state from isOnBatteryPower at start", () => {
+    mockIsOnBatteryPower.mockReturnValue(true);
+
+    const deps = createDeps();
+    const service = new ResourceProfileService(deps);
+    service.start();
+
+    const internals = service as unknown as { isOnBattery: boolean };
+    expect(internals.isOnBattery).toBe(true);
+    // isOnBatteryPower called exactly once (during start), not per-tick
+    expect(mockIsOnBatteryPower).toHaveBeenCalledTimes(1);
+
+    service.stop();
+  });
+
+  it("on-battery event updates cached battery state", () => {
+    const deps = createDeps();
+    const service = new ResourceProfileService(deps);
+    service.start();
+
+    const onBatteryHandler = mockPowerMonitorOn.mock.calls.find(
+      (call: string[]) => call[0] === "on-battery"
+    )?.[1] as (() => void) | undefined;
+    expect(onBatteryHandler).toBeDefined();
+
+    onBatteryHandler!();
+    const internals = service as unknown as { isOnBattery: boolean };
+    expect(internals.isOnBattery).toBe(true);
+
+    service.stop();
+  });
+
+  it("on-ac event clears cached battery state", () => {
+    const deps = createDeps();
+    const service = new ResourceProfileService(deps);
+    mockIsOnBatteryPower.mockReturnValue(true);
+    service.start();
+
+    const onAcHandler = mockPowerMonitorOn.mock.calls.find(
+      (call: string[]) => call[0] === "on-ac"
+    )?.[1] as (() => void) | undefined;
+    expect(onAcHandler).toBeDefined();
+
+    const internals = service as unknown as { isOnBattery: boolean };
+    expect(internals.isOnBattery).toBe(true);
+
+    onAcHandler!();
+    expect(internals.isOnBattery).toBe(false);
+
+    service.stop();
+  });
+
+  it("cold start with thermal serious contributes to first evaluation", () => {
+    mockGetCurrentThermalState.mockReturnValue("serious" as const);
+    mockIsOnBatteryPower.mockReturnValue(true);
+
+    const deps = createDeps();
+    const service = new ResourceProfileService(deps);
+    service.start();
+
+    // Low memory (0) + battery (+1) + thermal serious (+1) = 2 => balanced
+    // Past warmup + hysteresis
+    mockGetAppMetrics.mockReturnValue([makeMetric("Browser", 200)]);
+    vi.advanceTimersByTime(60_000 + 30_000 + 30_000);
+    expect(service.getProfile()).toBe("balanced");
+
+    service.stop();
+  });
+
+  it("isOnBatteryPower not called on evaluation ticks after priming", () => {
+    const deps = createDeps();
+    const service = new ResourceProfileService(deps);
+    service.start();
+
+    // Past warmup
+    vi.advanceTimersByTime(60_000);
+    // Several evaluation ticks
+    vi.advanceTimersByTime(30_000);
+    vi.advanceTimersByTime(30_000);
+
+    // isOnBatteryPower should only have been called once (during start)
+    expect(mockIsOnBatteryPower).toHaveBeenCalledTimes(1);
 
     service.stop();
   });

--- a/electron/services/__tests__/ResourceProfileService.test.ts
+++ b/electron/services/__tests__/ResourceProfileService.test.ts
@@ -481,7 +481,6 @@ describe("ResourceProfileService", () => {
     service.start();
 
     mockGetAppMetrics.mockReturnValue([makeMetric("Browser", 1300)]);
-    mockIsOnBatteryPower.mockReturnValue(false);
 
     // Warmup (2 ticks = 60s) + first real eval (30s) + 60s upgrade hold (2 ticks)
     vi.advanceTimersByTime(60_000 + 30_000 + 30_000 + 30_000);
@@ -733,6 +732,7 @@ describe("ResourceProfileService", () => {
   });
 
   it("primes thermal state from getCurrentThermalState at start", () => {
+    vi.spyOn(process, "platform", "get").mockReturnValue("darwin");
     mockGetCurrentThermalState.mockReturnValue("fair" as const);
 
     const deps = createDeps();
@@ -798,19 +798,20 @@ describe("ResourceProfileService", () => {
     service.stop();
   });
 
-  it("cold start with thermal serious contributes to first evaluation", () => {
-    mockGetCurrentThermalState.mockReturnValue("serious" as const);
+  it("cold start with thermal critical contributes to first evaluation", () => {
+    vi.spyOn(process, "platform", "get").mockReturnValue("darwin");
+    mockGetCurrentThermalState.mockReturnValue("critical" as const);
     mockIsOnBatteryPower.mockReturnValue(true);
 
     const deps = createDeps();
     const service = new ResourceProfileService(deps);
     service.start();
 
-    // Low memory (0) + battery (+1) + thermal serious (+1) = 2 => balanced
-    // Past warmup + hysteresis
+    // Low memory (0) + battery (+1) + thermal critical (+2) = 3 => efficiency
+    // Without thermal priming the score would be 1 => balanced
     mockGetAppMetrics.mockReturnValue([makeMetric("Browser", 200)]);
     vi.advanceTimersByTime(60_000 + 30_000 + 30_000);
-    expect(service.getProfile()).toBe("balanced");
+    expect(service.getProfile()).toBe("efficiency");
 
     service.stop();
   });


### PR DESCRIPTION
## Summary
This fixes two issues with `ResourceProfileService` that made profile selection less responsive than it should be. The thermal state is now primed from `getCurrentThermalState()` at startup, so the service has an accurate reading immediately instead of waiting for the first `thermal-state-change` event. Battery state is cached from `on-battery` and `on-ac` events rather than calling `isOnBatteryPower()` on every 30-second evaluation tick.

Resolves #7091.

## Changes
- `primeThermalState()` calls `getCurrentThermalState()` during `start()` so the thermal signal is accurate from the first evaluation tick
- Battery state is stored in `isOnBattery` and updated by `on-battery`/`on-ac` power monitor events instead of polling `isOnBatteryPower()` every 30 seconds
- `start()` resets transient candidate state (`tickCount`, `candidateProfile`, `candidateFirstSeenAt`) for correct re-entrant behavior
- `stop()` resets thermal state, battery state, and speed limit, and removes the new power monitor listeners
- Tests now exercise battery state changes through the event handlers (`on-ac`/`on-battery`) rather than `mockIsOnBatteryPower`, matching the new caching pattern
- Added adversarial test coverage for `on-battery`/`on-ac` listener registration and cleanup

## Testing
- 39 unit tests pass across `ResourceProfileService.test.ts` and `ResourceProfileService.adversarial.test.ts`
- Typecheck, lint, and format clean