### PR TITLE
fix(updater): disable electron-updater on all Windows builds

### DIFF
--- a/electron/menu.ts
+++ b/electron/menu.ts
@@ -454,7 +454,7 @@ export function createApplicationMenu(
             await shell.openExternal("https://github.com/daintreehq/daintree");
           },
         },
-        ...(process.platform !== "darwin" && app.isPackaged
+        ...(process.platform !== "darwin" && process.platform !== "win32" && app.isPackaged
           ? [
               { type: "separator" as const },
               {

--- a/electron/preload.cts
+++ b/electron/preload.cts
@@ -11,6 +11,7 @@
 
 import { contextBridge, ipcRenderer, webFrame, webUtils } from "electron";
 import { isTrustedRendererUrl } from "../shared/utils/trustedRenderer.js";
+import { isElectronUpdaterSupported } from "../shared/config/platform.js";
 import { isIpcEnvelope } from "../shared/types/ipc/errors.js";
 import { deserializeError } from "../shared/utils/ipcErrorSerialization.js";
 import type { AppErrorCode } from "../shared/types/appError.js";
@@ -2042,6 +2043,8 @@ const api: ElectronAPI = {
 
   // Auto-Update API
   update: {
+    isSupported: isElectronUpdaterSupported(),
+
     onUpdateAvailable: (callback: (info: { version: string }) => void) =>
       _typedOn(CHANNELS.UPDATE_AVAILABLE, callback),
 

--- a/electron/services/AutoUpdaterService.ts
+++ b/electron/services/AutoUpdaterService.ts
@@ -11,6 +11,7 @@ import { getSystemSleepService } from "./SystemSleepService.js";
 import { store } from "../store.js";
 import { PRODUCT_NAME } from "../utils/productBranding.js";
 import { isTrustedRendererUrl } from "../../shared/utils/trustedRenderer.js";
+import { isElectronUpdaterSupported } from "../../shared/config/platform.js";
 
 const CHECK_INTERVAL_MS = 4 * 60 * 60 * 1000; // 4 hours
 const DISMISS_COOLDOWN_MS = 24 * 60 * 60 * 1000; // 24 hours
@@ -415,8 +416,8 @@ class AutoUpdaterService {
       return;
     }
 
-    if (process.platform === "win32" && process.env.PORTABLE_EXECUTABLE_FILE) {
-      console.log("[MAIN] Auto-updater disabled for Windows portable builds");
+    if (!isElectronUpdaterSupported()) {
+      console.log("[MAIN] Auto-updater disabled for Windows builds");
       return;
     }
 

--- a/electron/services/__tests__/AutoUpdaterService.test.ts
+++ b/electron/services/__tests__/AutoUpdaterService.test.ts
@@ -494,14 +494,14 @@ describe("AutoUpdaterService", () => {
       expect(fsMock.existsSync).not.toHaveBeenCalled();
     });
 
-    it("does not affect non-Linux platforms", () => {
+    it("Windows also returns early (electron-updater unsupported on win32)", () => {
       Object.defineProperty(process, "platform", { value: "win32", configurable: true });
 
       autoUpdaterService.initialize();
       vi.advanceTimersByTime(STARTUP_JITTER_MAX_MS);
 
-      expect(autoUpdaterMock.on).toHaveBeenCalled();
-      expect(autoUpdaterMock.checkForUpdatesAndNotify).toHaveBeenCalledTimes(1);
+      expect(autoUpdaterMock.on).not.toHaveBeenCalled();
+      expect(autoUpdaterMock.checkForUpdatesAndNotify).not.toHaveBeenCalled();
     });
   });
 
@@ -552,10 +552,9 @@ describe("AutoUpdaterService", () => {
     });
   });
 
-  describe("Windows portable guard", () => {
-    it("registers only channel-preference IPC handlers on Windows portable", () => {
+  describe("Windows unsupported gate", () => {
+    it("registers only channel-preference IPC handlers on Windows", () => {
       Object.defineProperty(process, "platform", { value: "win32", configurable: true });
-      process.env.PORTABLE_EXECUTABLE_FILE = "C:\\portable\\daintree.exe";
 
       autoUpdaterService.initialize();
 
@@ -564,6 +563,8 @@ describe("AutoUpdaterService", () => {
       expect(registeredChannels).toContain(CHANNELS.UPDATE_SET_CHANNEL);
       expect(registeredChannels).not.toContain(CHANNELS.UPDATE_QUIT_AND_INSTALL);
       expect(registeredChannels).not.toContain(CHANNELS.UPDATE_CHECK_FOR_UPDATES);
+      expect(autoUpdaterMock.on).not.toHaveBeenCalled();
+      expect(autoUpdaterMock.checkForUpdatesAndNotify).not.toHaveBeenCalled();
     });
   });
 

--- a/shared/config/__tests__/platform.test.ts
+++ b/shared/config/__tests__/platform.test.ts
@@ -1,0 +1,22 @@
+import { describe, it, expect } from "vitest";
+import { isElectronUpdaterSupported } from "../platform";
+
+describe("isElectronUpdaterSupported", () => {
+  it("returns false for win32", () => {
+    expect(isElectronUpdaterSupported("win32")).toBe(false);
+  });
+
+  it("returns true for darwin", () => {
+    expect(isElectronUpdaterSupported("darwin")).toBe(true);
+  });
+
+  it("returns true for linux", () => {
+    expect(isElectronUpdaterSupported("linux")).toBe(true);
+  });
+
+  it("defaults to process.platform when no argument", () => {
+    // Runtime test — verifies the no-arg form doesn't throw
+    const result = isElectronUpdaterSupported();
+    expect(typeof result).toBe("boolean");
+  });
+});

--- a/shared/config/__tests__/platform.test.ts
+++ b/shared/config/__tests__/platform.test.ts
@@ -1,5 +1,5 @@
 import { describe, it, expect } from "vitest";
-import { isElectronUpdaterSupported } from "../platform";
+import { isElectronUpdaterSupported } from "../platform.js";
 
 describe("isElectronUpdaterSupported", () => {
   it("returns false for win32", () => {

--- a/shared/config/platform.ts
+++ b/shared/config/platform.ts
@@ -1,0 +1,3 @@
+export function isElectronUpdaterSupported(platform?: NodeJS.Platform): boolean {
+  return (platform ?? process.platform) !== "win32";
+}

--- a/shared/types/ipc/api.ts
+++ b/shared/types/ipc/api.ts
@@ -1008,6 +1008,7 @@ export interface ElectronAPI {
     getSoundDir(): Promise<string>;
   };
   update: {
+    readonly isSupported: boolean;
     onUpdateAvailable(callback: (info: { version: string }) => void): () => void;
     onDownloadProgress(callback: (info: { percent: number }) => void): () => void;
     onUpdateDownloaded(callback: (info: { version: string }) => void): () => void;

--- a/src/components/Settings/GeneralTab.tsx
+++ b/src/components/Settings/GeneralTab.tsx
@@ -143,6 +143,7 @@ export function GeneralTab({
   const reduceAnimations = usePreferencesStore((s) => s.reduceAnimations);
 
   useEffect(() => {
+    if (!window.electron?.update?.isSupported) return;
     let cancelled = false;
     window.electron.update
       .getChannel()
@@ -581,41 +582,43 @@ export function GeneralTab({
             )}
           </SettingsSection>
 
-          <SettingsSection
-            icon={RefreshCw}
-            title="Update Channel"
-            description="Choose between stable releases and nightly builds."
-            id="general-update-channel"
-          >
-            <div className="flex gap-2">
-              {(["stable", "nightly"] as const).map((ch) => (
-                <button
-                  key={ch}
-                  disabled={channelSaving || updateChannel === null}
-                  onClick={() => void handleChannelChange(ch)}
-                  className={cn(
-                    "px-3 py-1.5 rounded-[var(--radius-md)] text-xs font-medium transition-colors capitalize",
-                    updateChannel === ch
-                      ? "bg-overlay-selected border border-border-strong text-daintree-text font-medium"
-                      : "border border-daintree-border hover:bg-tint/5 text-daintree-text/70"
-                  )}
-                >
-                  {ch}
-                </button>
-              ))}
-            </div>
-            {updateChannel === "nightly" && (
-              <p className="text-xs text-status-warning/80">
-                Nightly builds may contain unstable features. You can switch back to stable at any
-                time.
-              </p>
-            )}
-            {lastUpdateCheck && (
-              <p className="text-xs text-text-secondary">
-                Last checked: {formatTimeAgo(lastUpdateCheck)}
-              </p>
-            )}
-          </SettingsSection>
+          {window.electron?.update?.isSupported && (
+            <SettingsSection
+              icon={RefreshCw}
+              title="Update Channel"
+              description="Choose between stable releases and nightly builds."
+              id="general-update-channel"
+            >
+              <div className="flex gap-2">
+                {(["stable", "nightly"] as const).map((ch) => (
+                  <button
+                    key={ch}
+                    disabled={channelSaving || updateChannel === null}
+                    onClick={() => void handleChannelChange(ch)}
+                    className={cn(
+                      "px-3 py-1.5 rounded-[var(--radius-md)] text-xs font-medium transition-colors capitalize",
+                      updateChannel === ch
+                        ? "bg-overlay-selected border border-border-strong text-daintree-text font-medium"
+                        : "border border-daintree-border hover:bg-tint/5 text-daintree-text/70"
+                    )}
+                  >
+                    {ch}
+                  </button>
+                ))}
+              </div>
+              {updateChannel === "nightly" && (
+                <p className="text-xs text-status-warning/80">
+                  Nightly builds may contain unstable features. You can switch back to stable at any
+                  time.
+                </p>
+              )}
+              {lastUpdateCheck && (
+                <p className="text-xs text-text-secondary">
+                  Last checked: {formatTimeAgo(lastUpdateCheck)}
+                </p>
+              )}
+            </SettingsSection>
+          )}
 
           <SettingsSection
             icon={Keyboard}

--- a/src/components/Settings/GeneralTab.tsx
+++ b/src/components/Settings/GeneralTab.tsx
@@ -160,6 +160,7 @@ export function GeneralTab({
   }, []);
 
   useEffect(() => {
+    if (!window.electron?.update?.isSupported) return;
     let cancelled = false;
 
     const loadLastCheck = () => {

--- a/src/hooks/__tests__/useUpdateListener.test.tsx
+++ b/src/hooks/__tests__/useUpdateListener.test.tsx
@@ -120,6 +120,7 @@ describe("useUpdateListener", () => {
 
     window.electron = {
       update: {
+        isSupported: true,
         onUpdateAvailable: vi.fn((cb: AvailableCallback) => {
           capturedAvailable = cb;
           return cleanupAvailable;

--- a/src/hooks/__tests__/useUpdateListener.test.tsx
+++ b/src/hooks/__tests__/useUpdateListener.test.tsx
@@ -511,3 +511,45 @@ describe("useUpdateListener", () => {
     );
   });
 });
+
+describe("useUpdateListener — Windows gating", () => {
+  beforeEach(() => {
+    notifyMock.mockClear();
+    vi.clearAllMocks();
+    storeState.notifications = [];
+
+    window.electron = {
+      update: {
+        isSupported: false,
+        onUpdateAvailable: vi.fn(),
+        onDownloadProgress: vi.fn(),
+        onUpdateDownloaded: vi.fn(),
+        quitAndInstall: vi.fn(),
+        checkForUpdates: vi.fn(),
+        notifyDismiss: notifyDismissMock,
+      },
+    } as unknown as typeof window.electron;
+  });
+
+  afterEach(() => {
+    // eslint-disable-next-line @typescript-eslint/no-explicit-any
+    delete (window as any).electron;
+  });
+
+  it("does not subscribe to any update events when isSupported is false", () => {
+    const { unmount } = renderHook(() => useUpdateListener());
+
+    expect(window.electron!.update.onUpdateAvailable).not.toHaveBeenCalled();
+    expect(window.electron!.update.onDownloadProgress).not.toHaveBeenCalled();
+    expect(window.electron!.update.onUpdateDownloaded).not.toHaveBeenCalled();
+
+    unmount();
+  });
+
+  it("does not emit any notify() calls when isSupported is false", () => {
+    const { unmount } = renderHook(() => useUpdateListener());
+    unmount();
+
+    expect(notifyMock).not.toHaveBeenCalled();
+  });
+});

--- a/src/hooks/useUpdateListener.tsx
+++ b/src/hooks/useUpdateListener.tsx
@@ -93,7 +93,7 @@ export function useUpdateListener(suppressToasts = false): void {
   }, [suppressToasts]);
 
   useEffect(() => {
-    if (!window.electron?.update) return;
+    if (!window.electron?.update?.isSupported) return;
 
     const cleanupAvailable = window.electron.update.onUpdateAvailable((info) => {
       if (suppressRef.current) {


### PR DESCRIPTION
## Summary
- Disables electron-updater on all Windows builds, not just portable builds. A shared `isElectronUpdaterSupported()` helper in `shared/config/platform.ts` gates everywhere.
- The update channel settings section in `GeneralTab` is hidden on Windows, and the updater hook skips event subscriptions when unsupported.
- Tests updated across the board for the new gate -- platform helper, the updater service, and the UI hook.

Resolves #7199

## Changes
- New `isElectronUpdaterSupported()` helper in `shared/config/platform.ts` with tests
- `AutoUpdaterService` uses the helper instead of checking `PORTABLE_EXECUTABLE_FILE`
- `preload.cts` exposes `update.isSupported` to the renderer
- Menu hides "Check for Updates" on Windows
- `GeneralTab` conditionally renders the Update Channel section and skips channel/last-check fetches
- `useUpdateListener` skips event subscriptions when `isSupported` is false

## Testing
- Unit tests for `isElectronUpdaterSupported` covering all platforms
- Updated `AutoUpdaterService` tests for the Windows gate
- New `useUpdateListener` tests verifying no subscriptions or notifications when unsupported