### PR TITLE
fix(agent-help): polish registry and help service layer

### DIFF
--- a/electron/services/AgentHelpService.ts
+++ b/electron/services/AgentHelpService.ts
@@ -2,6 +2,7 @@ import { execFile } from "child_process";
 import { promisify } from "util";
 import { getEffectiveAgentConfig } from "../../shared/config/agentRegistry.js";
 import type { AgentHelpResult } from "../../shared/types/ipc/agent.js";
+import { SAFE_AGENT_ID_PATTERN } from "../../shared/types/index.js";
 import { buildProbeEnv } from "../utils/spawnEnv.js";
 import { scrubSecrets } from "../utils/secretScrubber.js";
 
@@ -48,13 +49,7 @@ export class AgentHelpService {
   }
 
   private isValidCommand(command: string): boolean {
-    if (typeof command !== "string" || !command.trim()) {
-      return false;
-    }
-    if (command.includes("&&") || command.includes(";") || command.includes("|")) {
-      return false;
-    }
-    return true;
+    return typeof command === "string" && SAFE_AGENT_ID_PATTERN.test(command);
   }
 
   private async executeHelp(command: string, args: string[]): Promise<AgentHelpResult> {

--- a/electron/services/AgentHelpService.ts
+++ b/electron/services/AgentHelpService.ts
@@ -33,7 +33,7 @@ export class AgentHelpService {
     if (!refresh && cached) {
       const age = Date.now() - cached.timestamp;
       if (age < this.CACHE_TTL_MS) {
-        return cached.result;
+        return { ...cached.result };
       }
     }
 
@@ -45,7 +45,7 @@ export class AgentHelpService {
       timestamp: Date.now(),
     });
 
-    return result;
+    return { ...result };
   }
 
   private isValidCommand(command: string): boolean {

--- a/electron/services/HelpService.ts
+++ b/electron/services/HelpService.ts
@@ -2,15 +2,23 @@ import fs from "fs";
 import path from "path";
 import { app } from "electron";
 
+let cachedHelpFolderPath: string | null | undefined = undefined;
+
 export function getHelpFolderPath(): string | null {
+  if (cachedHelpFolderPath !== undefined) {
+    return cachedHelpFolderPath;
+  }
+
   const folderPath = app.isPackaged
     ? path.join(process.resourcesPath, "help")
     : path.join(app.getAppPath(), "help");
 
   if (!fs.existsSync(folderPath)) {
-    console.warn(`[HelpService] Help folder not found: ${folderPath}`);
+    console.warn(`[HelpService] Help folder not found: ${folderPath} (packaged=${app.isPackaged})`);
+    cachedHelpFolderPath = null;
     return null;
   }
 
+  cachedHelpFolderPath = folderPath;
   return folderPath;
 }

--- a/electron/services/UserAgentRegistryService.ts
+++ b/electron/services/UserAgentRegistryService.ts
@@ -1,10 +1,6 @@
 import { store } from "../store.js";
 import type { UserAgentRegistry, UserAgentConfig } from "../../shared/types/index.js";
-import {
-  UserAgentConfigSchema,
-  UserAgentRegistrySchema,
-  SAFE_AGENT_ID_PATTERN,
-} from "../../shared/types/index.js";
+import { UserAgentConfigSchema, SAFE_AGENT_ID_PATTERN } from "../../shared/types/index.js";
 import { setUserRegistry, isBuiltInAgent } from "../../shared/config/agentRegistry.js";
 import { formatErrorMessage } from "../../shared/utils/errorMessage.js";
 
@@ -29,24 +25,16 @@ export class UserAgentRegistryService {
   private loadRegistry(): void {
     try {
       const stored = store.get("userAgentRegistry", {});
-      const validation = UserAgentRegistrySchema.safeParse(stored);
-
-      if (!validation.success) {
-        console.error("[UserAgentRegistryService] Invalid stored registry:", validation.error);
+      if (typeof stored !== "object" || stored === null || Array.isArray(stored)) {
+        console.warn("[UserAgentRegistryService] Stored registry is not an object, resetting");
         this.registry = {};
         return;
       }
 
       const sanitized: UserAgentRegistry = {};
-      for (const [id, config] of Object.entries(validation.data)) {
+      for (const [id, config] of Object.entries(stored)) {
         if (RESERVED_REGISTRY_KEYS.has(id)) {
           console.warn(`[UserAgentRegistryService] Skipping reserved registry key: ${id}`);
-          continue;
-        }
-        if (config.id !== id) {
-          console.warn(
-            `[UserAgentRegistryService] Skipping registry entry with mismatched id: key=${id}, config.id=${config.id}`
-          );
           continue;
         }
         if (!SAFE_AGENT_ID_PATTERN.test(id)) {
@@ -59,7 +47,25 @@ export class UserAgentRegistryService {
           );
           continue;
         }
-        sanitized[id] = cloneConfig(config);
+
+        const entryValidation = UserAgentConfigSchema.safeParse(config);
+        if (!entryValidation.success) {
+          console.warn(
+            `[UserAgentRegistryService] Skipping invalid registry entry "${id}":`,
+            entryValidation.error.message
+          );
+          continue;
+        }
+
+        const validated = entryValidation.data;
+        if (validated.id !== id) {
+          console.warn(
+            `[UserAgentRegistryService] Skipping registry entry with mismatched id: key=${id}, config.id=${validated.id}`
+          );
+          continue;
+        }
+
+        sanitized[id] = cloneConfig(validated);
       }
 
       this.registry = sanitized;
@@ -72,7 +78,11 @@ export class UserAgentRegistryService {
   private saveRegistry(nextRegistry: UserAgentRegistry): { success: boolean; error?: string } {
     try {
       store.set("userAgentRegistry", nextRegistry);
-      setUserRegistry(nextRegistry);
+      const sharedClone: UserAgentRegistry = {};
+      for (const [id, config] of Object.entries(nextRegistry)) {
+        sharedClone[id] = cloneConfig(config);
+      }
+      setUserRegistry(sharedClone);
       return { success: true };
     } catch (error) {
       const message = formatErrorMessage(error, "Failed to save user agent registry");

--- a/electron/services/UserAgentRegistryService.ts
+++ b/electron/services/UserAgentRegistryService.ts
@@ -1,11 +1,14 @@
 import { store } from "../store.js";
 import type { UserAgentRegistry, UserAgentConfig } from "../../shared/types/index.js";
-import { UserAgentConfigSchema, UserAgentRegistrySchema } from "../../shared/types/index.js";
+import {
+  UserAgentConfigSchema,
+  UserAgentRegistrySchema,
+  SAFE_AGENT_ID_PATTERN,
+} from "../../shared/types/index.js";
 import { setUserRegistry, isBuiltInAgent } from "../../shared/config/agentRegistry.js";
 import { formatErrorMessage } from "../../shared/utils/errorMessage.js";
 
 const RESERVED_REGISTRY_KEYS = new Set(["__proto__", "constructor", "prototype"]);
-const SAFE_AGENT_ID_PATTERN = /^[a-zA-Z0-9._-]+$/;
 
 function hasOwnKey(record: Record<string, unknown>, key: string): boolean {
   return Object.prototype.hasOwnProperty.call(record, key);
@@ -66,10 +69,10 @@ export class UserAgentRegistryService {
     }
   }
 
-  private saveRegistry(): { success: boolean; error?: string } {
+  private saveRegistry(nextRegistry: UserAgentRegistry): { success: boolean; error?: string } {
     try {
-      store.set("userAgentRegistry", this.getRegistry());
-      this.syncToSharedRegistry();
+      store.set("userAgentRegistry", nextRegistry);
+      setUserRegistry(nextRegistry);
       return { success: true };
     } catch (error) {
       const message = formatErrorMessage(error, "Failed to save user agent registry");
@@ -111,7 +114,7 @@ export class UserAgentRegistryService {
       };
     }
 
-    if (!/^[a-zA-Z0-9._-]+$/.test(config.command)) {
+    if (!SAFE_AGENT_ID_PATTERN.test(config.command)) {
       return {
         success: false,
         error: `Command "${config.command}" contains invalid characters. Only alphanumeric, dots, dashes, and underscores are allowed.`,
@@ -131,8 +134,12 @@ export class UserAgentRegistryService {
       };
     }
 
-    this.registry[config.id] = cloneConfig(config);
-    return this.saveRegistry();
+    const nextRegistry = { ...this.registry, [config.id]: cloneConfig(config) };
+    const result = this.saveRegistry(nextRegistry);
+    if (result.success) {
+      this.registry = nextRegistry;
+    }
+    return result;
   }
 
   updateAgent(id: string, config: UserAgentConfig): { success: boolean; error?: string } {
@@ -158,7 +165,7 @@ export class UserAgentRegistryService {
       };
     }
 
-    if (!/^[a-zA-Z0-9._-]+$/.test(config.command)) {
+    if (!SAFE_AGENT_ID_PATTERN.test(config.command)) {
       return {
         success: false,
         error: `Command "${config.command}" contains invalid characters. Only alphanumeric, dots, dashes, and underscores are allowed.`,
@@ -171,18 +178,15 @@ export class UserAgentRegistryService {
       };
     }
 
-    this.registry[id] = cloneConfig(config);
-    return this.saveRegistry();
+    const nextRegistry = { ...this.registry, [id]: cloneConfig(config) };
+    const result = this.saveRegistry(nextRegistry);
+    if (result.success) {
+      this.registry = nextRegistry;
+    }
+    return result;
   }
 
   removeAgent(id: string): { success: boolean; error?: string } {
-    if (isBuiltInAgent(id)) {
-      return {
-        success: false,
-        error: `Cannot remove built-in agent "${id}"`,
-      };
-    }
-
     if (!hasOwnKey(this.registry, id)) {
       return {
         success: false,
@@ -190,7 +194,19 @@ export class UserAgentRegistryService {
       };
     }
 
-    delete this.registry[id];
-    return this.saveRegistry();
+    if (isBuiltInAgent(id)) {
+      return {
+        success: false,
+        error: `Cannot remove built-in agent "${id}"`,
+      };
+    }
+
+    const nextRegistry = { ...this.registry };
+    delete nextRegistry[id];
+    const result = this.saveRegistry(nextRegistry);
+    if (result.success) {
+      this.registry = nextRegistry;
+    }
+    return result;
   }
 }

--- a/electron/services/__tests__/AgentHelpService.test.ts
+++ b/electron/services/__tests__/AgentHelpService.test.ts
@@ -167,7 +167,22 @@ describe("AgentHelpService", () => {
       expect(mockedExecFile).toHaveBeenCalledTimes(2);
     });
 
-    it("respects cache TTL", async () => {
+    it("returns cached result defensively cloned so mutation cannot corrupt cache", async () => {
+      mockedExecFile.mockImplementation((_cmd, _args, _opts, callback: any) => {
+        callback(null, { stdout: "Original", stderr: "" });
+        return {} as any;
+      });
+
+      const first = await service.getHelp("claude");
+      expect(first.stdout).toBe("Original");
+
+      first.stdout = "Mutated";
+
+      const second = await service.getHelp("claude");
+      expect(second.stdout).toBe("Original");
+    });
+
+    it("expires cache after TTL", async () => {
       mockedExecFile.mockImplementation((_cmd, _args, _opts, callback: any) => {
         callback(null, { stdout: "Output", stderr: "" });
         return {} as any;
@@ -176,7 +191,7 @@ describe("AgentHelpService", () => {
       await service.getHelp("claude");
       expect(mockedExecFile).toHaveBeenCalledTimes(1);
 
-      vi.advanceTimersByTime(11 * 60 * 1000);
+      vi.advanceTimersByTime(10 * 60 * 1000 + 1);
 
       await service.getHelp("claude");
       expect(mockedExecFile).toHaveBeenCalledTimes(2);

--- a/electron/services/__tests__/AgentHelpService.test.ts
+++ b/electron/services/__tests__/AgentHelpService.test.ts
@@ -246,7 +246,7 @@ describe("AgentHelpService", () => {
       delete (AGENT_REGISTRY as any)["empty"];
     });
 
-    it("rejects command with invalid characters", async () => {
+    it("rejects command with shell metacharacters", async () => {
       vi.doUnmock("../../../shared/config/agentRegistry.js");
       const { AGENT_REGISTRY } = await import("../../../shared/config/agentRegistry.js");
       (AGENT_REGISTRY as any)["bad"] = {
@@ -258,6 +258,20 @@ describe("AgentHelpService", () => {
       await expect(service.getHelp("bad")).rejects.toThrow("Invalid command");
 
       delete (AGENT_REGISTRY as any)["bad"];
+    });
+
+    it("rejects command with subshell syntax that denylist would have missed", async () => {
+      vi.doUnmock("../../../shared/config/agentRegistry.js");
+      const { AGENT_REGISTRY } = await import("../../../shared/config/agentRegistry.js");
+      (AGENT_REGISTRY as any)["subshell"] = {
+        id: "subshell",
+        name: "Subshell",
+        command: "$(whoami)",
+      };
+
+      await expect(service.getHelp("subshell")).rejects.toThrow("Invalid command");
+
+      delete (AGENT_REGISTRY as any)["subshell"];
     });
   });
 });

--- a/electron/services/__tests__/HelpService.test.ts
+++ b/electron/services/__tests__/HelpService.test.ts
@@ -93,4 +93,48 @@ describe("HelpService", () => {
     );
     warnSpy.mockRestore();
   });
+
+  it("caches the result and does not call existsSync on subsequent calls", async () => {
+    fsMock.existsSync.mockReturnValue(true);
+
+    const { getHelpFolderPath } = await import("../HelpService.js");
+
+    const first = getHelpFolderPath();
+    const second = getHelpFolderPath();
+
+    expect(first).toBe(second);
+    expect(fsMock.existsSync).toHaveBeenCalledTimes(1);
+  });
+
+  it("caches null when folder is missing and warns only once", async () => {
+    fsMock.existsSync.mockReturnValue(false);
+    const warnSpy = vi.spyOn(console, "warn").mockImplementation(() => {});
+
+    const { getHelpFolderPath } = await import("../HelpService.js");
+
+    const first = getHelpFolderPath();
+    expect(first).toBeNull();
+    expect(warnSpy).toHaveBeenCalledTimes(1);
+
+    warnSpy.mockClear();
+
+    const second = getHelpFolderPath();
+    expect(second).toBeNull();
+    expect(warnSpy).not.toHaveBeenCalled();
+    expect(fsMock.existsSync).toHaveBeenCalledTimes(1);
+
+    warnSpy.mockRestore();
+  });
+
+  it("includes isPackaged in the warning message", async () => {
+    appMock.app.isPackaged = true;
+    fsMock.existsSync.mockReturnValue(false);
+    const warnSpy = vi.spyOn(console, "warn").mockImplementation(() => {});
+
+    const { getHelpFolderPath } = await import("../HelpService.js");
+    getHelpFolderPath();
+
+    expect(warnSpy).toHaveBeenCalledWith(expect.stringContaining("(packaged=true)"));
+    warnSpy.mockRestore();
+  });
 });

--- a/electron/services/__tests__/UserAgentRegistryService.test.ts
+++ b/electron/services/__tests__/UserAgentRegistryService.test.ts
@@ -237,4 +237,26 @@ describe("removeAgent error ordering", () => {
     expect(result.error).toContain("not found");
     expect(result.error).not.toContain("built-in");
   });
+
+  it("preserves valid entries when a single entry fails per-entry validation", () => {
+    (storeMock.get as Mock).mockReturnValue({
+      good: createConfig("good"),
+      bad: {
+        id: "bad",
+        command: "/usr/local/bin/broken",
+        name: "Bad",
+        color: "#112233",
+        iconId: "terminal",
+        supportsContextInjection: true,
+      },
+    });
+
+    const service = new UserAgentRegistryService();
+    const registry = service.getRegistry();
+
+    expect(registry).toEqual({
+      good: expect.objectContaining({ id: "good" }),
+    });
+    expect(registry.bad).toBeUndefined();
+  });
 });

--- a/electron/services/__tests__/UserAgentRegistryService.test.ts
+++ b/electron/services/__tests__/UserAgentRegistryService.test.ts
@@ -161,3 +161,80 @@ describe("UserAgentRegistryService", () => {
     );
   });
 });
+
+describe("persist-before-mutate ordering", () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+    (storeMock.get as Mock).mockReturnValue({});
+    (storeMock.set as Mock).mockImplementation(() => {});
+  });
+
+  it("addAgent does not mutate in-memory registry when store.set throws", () => {
+    (storeMock.set as Mock).mockImplementation(() => {
+      throw new Error("ENOSPC: disk full");
+    });
+
+    const service = new UserAgentRegistryService();
+
+    const result = service.addAgent(createConfig("custom"));
+
+    expect(result.success).toBe(false);
+    expect(result.error).toContain("Failed to save");
+    expect(service.getRegistry()).toEqual({});
+  });
+
+  it("updateAgent does not mutate in-memory registry when store.set throws", () => {
+    (storeMock.get as Mock).mockReturnValue({
+      alpha: createConfig("alpha"),
+    });
+
+    const service = new UserAgentRegistryService();
+
+    (storeMock.set as Mock).mockImplementation(() => {
+      throw new Error("ENOSPC: disk full");
+    });
+
+    const updatedConfig = createConfig("alpha", { name: "Alpha Updated" });
+    const result = service.updateAgent("alpha", updatedConfig);
+
+    expect(result.success).toBe(false);
+    expect(result.error).toContain("Failed to save");
+    expect(service.getAgent("alpha")?.name).toBe("Agent alpha");
+  });
+
+  it("removeAgent does not mutate in-memory registry when store.set throws", () => {
+    (storeMock.get as Mock).mockReturnValue({
+      alpha: createConfig("alpha"),
+    });
+
+    const service = new UserAgentRegistryService();
+
+    (storeMock.set as Mock).mockImplementation(() => {
+      throw new Error("ENOSPC: disk full");
+    });
+
+    const result = service.removeAgent("alpha");
+
+    expect(result.success).toBe(false);
+    expect(result.error).toContain("Failed to save");
+    expect(service.getAgent("alpha")).toBeDefined();
+  });
+});
+
+describe("removeAgent error ordering", () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+    (storeMock.get as Mock).mockReturnValue({});
+    (storeMock.set as Mock).mockImplementation(() => {});
+  });
+
+  it("returns 'not found' for built-in agent ID when it is not in the user registry", () => {
+    const service = new UserAgentRegistryService();
+
+    const result = service.removeAgent("claude");
+
+    expect(result.success).toBe(false);
+    expect(result.error).toContain("not found");
+    expect(result.error).not.toContain("built-in");
+  });
+});

--- a/shared/types/index.ts
+++ b/shared/types/index.ts
@@ -309,7 +309,11 @@ export {
 
 // User agent registry types - user-defined agent configuration
 export type { UserAgentConfig, UserAgentRegistry } from "./userAgentRegistry.js";
-export { UserAgentConfigSchema, UserAgentRegistrySchema } from "./userAgentRegistry.js";
+export {
+  UserAgentConfigSchema,
+  UserAgentRegistrySchema,
+  SAFE_AGENT_ID_PATTERN,
+} from "./userAgentRegistry.js";
 
 // Per-service connectivity helpers
 export { CONNECTIVITY_SERVICE_KEYS } from "./ipc/connectivity.js";

--- a/shared/types/userAgentRegistry.ts
+++ b/shared/types/userAgentRegistry.ts
@@ -3,11 +3,18 @@ import { AgentRoutingConfigSchema } from "./agentSettings.js";
 
 const RESERVED_KEYS = ["__proto__", "constructor", "prototype"];
 
+export const SAFE_AGENT_ID_PATTERN = /^[a-zA-Z0-9._-]+$/;
+
 export const UserAgentConfigSchema = z
   .object({
     id: z.string().min(1),
     name: z.string().min(1),
-    command: z.string().min(1),
+    command: z
+      .string()
+      .regex(
+        SAFE_AGENT_ID_PATTERN,
+        "Command may only contain alphanumeric characters, dots, dashes, and underscores"
+      ),
     args: z
       .array(
         z


### PR DESCRIPTION
## Summary
- Tightened validation by deduplicating `SAFE_AGENT_ID_PATTERN` across the registry service, help service, and Zod schema. The denylist in `AgentHelpService.isValidCommand` is replaced by the same allowlist the registry uses, and the schema now enforces it so no manual config edit can slip a shell metacharacter past the service layer.
- Fixed ordering bugs: `saveRegistry` persists atomically before mutating in-memory state, so a store failure (`ENOSPC`, `EBUSY`) leaves the registry clean. `removeAgent` checks membership before the built-in guard, so `removeAgent("claude")` returns "not found" instead of an impossible "cannot remove built-in" error.
- Eliminated caching footguns: `AgentHelpService.getHelp` returns a defensive clone so callers can't corrupt the cache. `getHelpFolderPath` memoizes its result and warns exactly once, with `isPackaged` in the message.

Resolves #7071

## Changes
- **`UserAgentRegistryService`** — atomic persist-before-mutate for `addAgent`/`updateAgent`/`removeAgent`, permissive load with per-entry Zod validation, deduplicated `SAFE_AGENT_ID_PATTERN`, `removeAgent` error ordering fix
- **`AgentHelpService`** — denylist replaced with `SAFE_AGENT_ID_PATTERN` allowlist, defensive clones on cache returns
- **`HelpService`** — `getHelpFolderPath` result memoized so the warning fires once, `isPackaged` included in the warning
- **Schema (`userAgentRegistry.ts`)** — `SAFE_AGENT_ID_PATTERN` exported as a shared constant, `command` field validated with `.regex()` at the Zod schema level
- **Tests** — persist-before-mutate ordering (store throw leaves in-memory unchanged), `removeAgent` error hierarchy (built-in not-in-registry returns "not found"), permissive load (preserves valid entries when one fails validation), cache clone defense, TTL boundary fix, subshell syntax that the old denylist would have missed

## Testing
Typecheck passed (`tsc --noEmit` across renderer, electron, and preload). ESLint clean with no new warnings. Prettier applied with no diffs. All existing tests pass, plus new test coverage for each of the ordering, validation, caching, and permissive-load fixes.