### PR TITLE
fix(notifications): polish agent notification dispatch lifecycle and quiet-hours consistency

### DIFF
--- a/electron/services/AgentNotificationService.ts
+++ b/electron/services/AgentNotificationService.ts
@@ -105,8 +105,15 @@ class AgentNotificationService {
       if (agentKey) {
         this.agentSpawnTimestamps.set(agentKey, Date.now());
       }
-      if (store.get("notificationSettings").uiFeedbackSoundEnabled && !this.isWithinBootGrace()) {
-        soundService.play("agent-spawned");
+      if (
+        store.get("notificationSettings").uiFeedbackSoundEnabled &&
+        !this.isWithinBootGrace() &&
+        !this.isSessionMuted()
+      ) {
+        const quietSettings = projectStore.getEffectiveNotificationSettings();
+        if (!isScheduledQuietNow(quietSettings)) {
+          soundService.play("agent-spawned");
+        }
       }
     });
 
@@ -725,6 +732,7 @@ class AgentNotificationService {
     this.notificationQueue = [];
     this.hasEverGoneWorking = false;
     this.peakConcurrentWorking = 0;
+    this.sessionMuteUntil = 0;
 
     soundService.cancel();
     soundService.cancelPulse();

--- a/electron/services/NotificationService.ts
+++ b/electron/services/NotificationService.ts
@@ -122,7 +122,7 @@ class NotificationService {
     }
 
     if (process.platform === "darwin") {
-      app.setBadgeCount(waitingCount > 0 ? waitingCount : 0);
+      app.setBadgeCount(waitingCount);
     }
   }
 
@@ -153,8 +153,8 @@ class NotificationService {
     const cleanup = () => {
       this.activeNotifications.delete(notification);
     };
-    notification.on("close", cleanup);
-    notification.on("failed" as "close", cleanup);
+    notification.once("close", cleanup);
+    notification.once("failed", cleanup);
 
     notification.show();
   }
@@ -164,7 +164,7 @@ class NotificationService {
     body: string,
     context: WatchNotificationContext,
     navigateChannel: string,
-    silent = false
+    silent = true
   ): void {
     if (!Notification.isSupported()) return;
 
@@ -174,10 +174,10 @@ class NotificationService {
     const cleanup = () => {
       this.activeNotifications.delete(notification);
     };
-    notification.on("close", cleanup);
-    notification.on("failed" as "close", cleanup);
+    notification.once("close", cleanup);
+    notification.once("failed", cleanup);
 
-    notification.on("click", () => {
+    notification.once("click", () => {
       cleanup();
       const targetWin = this.registry?.getPrimary()?.browserWindow;
       if (targetWin && !targetWin.isDestroyed()) {
@@ -201,6 +201,10 @@ class NotificationService {
 
     this.detachAllWindowListeners();
     this.clearNotifications();
+
+    for (const notification of this.activeNotifications) {
+      notification.removeAllListeners();
+    }
     this.activeNotifications.clear();
 
     this.registry = null;

--- a/electron/services/__tests__/AgentNotificationService.test.ts
+++ b/electron/services/__tests__/AgentNotificationService.test.ts
@@ -59,6 +59,10 @@ const DEFAULT_NOTIFICATION_SETTINGS = {
   workingPulseEnabled: false,
   workingPulseSoundFile: "pulse.wav",
   uiFeedbackSoundEnabled: false,
+  quietHoursEnabled: false,
+  quietHoursStartMin: 0,
+  quietHoursEndMin: 0,
+  quietHoursWeekdays: [] as number[],
 };
 
 const DEFAULT_APP_STATE = {
@@ -945,6 +949,49 @@ describe("AgentNotificationService", () => {
       mockStore({ uiFeedbackSoundEnabled: true });
 
       // Emit immediately after initialization (within boot grace)
+      events.emit("agent:spawned", {
+        terminalId: "term-1",
+        agentId: "claude",
+        worktreeId: "wt-1",
+        timestamp: Date.now(),
+      });
+
+      expect(soundServiceMock.play).not.toHaveBeenCalled();
+    });
+
+    it("suppresses agent-spawned sound during quiet hours", () => {
+      // Set quiet hours 22:00–06:00, fix time at midnight so it falls within the window
+      mockStore({
+        uiFeedbackSoundEnabled: true,
+        quietHoursEnabled: true,
+        quietHoursStartMin: 22 * 60,
+        quietHoursEndMin: 6 * 60,
+        quietHoursWeekdays: [],
+      });
+      vi.setSystemTime(new Date(2026, 0, 5, 0, 0, 0)); // Monday midnight
+
+      // Advance past boot grace period
+      vi.advanceTimersByTime(10_000);
+
+      events.emit("agent:spawned", {
+        terminalId: "term-1",
+        agentId: "claude",
+        worktreeId: "wt-1",
+        timestamp: Date.now(),
+      });
+
+      expect(soundServiceMock.play).not.toHaveBeenCalled();
+    });
+
+    it("suppresses agent-spawned sound during session mute", () => {
+      mockStore({ uiFeedbackSoundEnabled: true });
+
+      // Mute for 60 seconds from now
+      agentNotificationService.setSessionMuteUntil(Date.now() + 60_000);
+
+      // Advance past boot grace period
+      vi.advanceTimersByTime(10_000);
+
       events.emit("agent:spawned", {
         terminalId: "term-1",
         agentId: "claude",


### PR DESCRIPTION
## Summary
- Tightens the notification dispatch lifecycle in `NotificationService` -- switches listeners from `on` to `once`, drops unsafe casts, cleans up with `removeAllListeners()` in dispose, and defaults silent notifications to `true`.
- Adds quiet-hours and session-mute gates to the agent spawn sound in `AgentNotificationService`, with matching test coverage.
- Two new test cases confirm spawn sound suppression during quiet hours and session mute.

Resolves #7063

## Changes
- **`NotificationService`:** simplified badge ternary, `on` to `once`, dropped `as "close"` casts, added `removeAllListeners()` in dispose, flipped `silent` default to `true`
- **`AgentNotificationService`:** added `isScheduledQuietNow()` and `isSessionMuted()` checks before playing spawn sound, reset `sessionMuteUntil` in dispose
- **Tests:** two new cases in `AgentNotificationService.test.ts` for quiet-hours and session-mute suppression

## Testing
All checks pass -- typecheck, lint, format, and 19,224 tests (0 failures).