### PR TITLE
fix(agent-fsm): exhaustiveness ratchets, monotonic hysteresis, fail-first validation

### DIFF
--- a/electron/services/pty/AgentStateService.ts
+++ b/electron/services/pty/AgentStateService.ts
@@ -98,8 +98,10 @@ export class AgentStateService {
         return "activity";
       case "watchdog-timeout":
         return "timeout";
-      default:
-        return "output";
+      default: {
+        const _exhaustive: never = event.type;
+        return _exhaustive;
+      }
     }
   }
 
@@ -167,14 +169,14 @@ export class AgentStateService {
     const previousState = terminal.agentState || "idle";
     const newState = nextAgentState(previousState, event);
 
+    if (newState === previousState) {
+      return false;
+    }
+
     const inferredTrigger = trigger ?? this.inferTrigger(event);
     const inferredConfidence = this.normalizeConfidence(
       confidence ?? this.inferConfidence(event, inferredTrigger)
     );
-
-    if (newState === previousState) {
-      return false;
-    }
 
     // Hysteresis guard: drop opposite-direction low-confidence transitions
     // that arrive shortly after a high-confidence transition settled the
@@ -182,7 +184,7 @@ export class AgentStateService {
     // always pass through.
     if (
       terminal.hysteresisLockedUntil !== undefined &&
-      Date.now() < terminal.hysteresisLockedUntil &&
+      performance.now() < terminal.hysteresisLockedUntil &&
       !isLifecycleEvent(event) &&
       inferredConfidence < HIGH_CONFIDENCE_THRESHOLD &&
       isOppositeDirectionTransition(previousState, newState)
@@ -197,35 +199,12 @@ export class AgentStateService {
       return false;
     }
 
-    terminal.agentState = newState;
-    terminal.lastStateChange = getStateChangeTimestamp();
-
-    // Refresh the hysteresis lock only when a high-confidence transition
-    // actually crosses the active/passive boundary. Passive→passive shifts
-    // (e.g., respawn exited→idle, or the FSM's working→completed→waiting
-    // chain) shouldn't lock out a subsequent low-confidence active signal —
-    // the window protects fresh active/passive settling, not session resets
-    // or sequential passive-state observations.
-    if (
-      inferredConfidence >= HIGH_CONFIDENCE_THRESHOLD &&
-      isOppositeDirectionTransition(previousState, newState)
-    ) {
-      terminal.hysteresisLockedUntil = Date.now() + HYSTERESIS_WINDOW_MS;
-    }
-
-    // Store/clear waitingReason on terminal
-    if (newState === "waiting") {
-      terminal.waitingReason = waitingReason;
-    } else {
-      terminal.waitingReason = undefined;
-    }
-
-    // Build and validate state change payload
+    // Build and validate state change payload BEFORE mutating terminal state.
     const stateChangePayload = {
       agentId: effectiveAgentId,
       state: newState,
       previousState,
-      timestamp: terminal.lastStateChange,
+      timestamp: getStateChangeTimestamp(),
       traceId: terminal.traceId,
       terminalId: terminal.id,
       cwd: terminal.cwd,
@@ -241,16 +220,37 @@ export class AgentStateService {
     };
 
     const validatedStateChange = AgentStateChangedSchema.safeParse(stateChangePayload);
-    if (validatedStateChange.success) {
-      events.emit("agent:state-changed", validatedStateChange.data);
-    } else {
+    if (!validatedStateChange.success) {
       console.error(
         "[AgentStateService] Invalid agent:state-changed payload:",
         validatedStateChange.error.format()
       );
+      return false;
     }
 
-    // Emit terminal activity event for UI headline updates
+    // Commit all mutations atomically.
+    terminal.agentState = newState;
+    terminal.lastStateChange = getStateChangeTimestamp();
+
+    // Refresh the hysteresis lock only when a high-confidence transition
+    // actually crosses the active/passive boundary. Lifecycle events clear
+    // the lock to prevent cross-session leakage.
+    if (isLifecycleEvent(event)) {
+      terminal.hysteresisLockedUntil = undefined;
+    } else if (
+      inferredConfidence >= HIGH_CONFIDENCE_THRESHOLD &&
+      isOppositeDirectionTransition(previousState, newState)
+    ) {
+      terminal.hysteresisLockedUntil = performance.now() + HYSTERESIS_WINDOW_MS;
+    }
+
+    if (newState === "waiting") {
+      terminal.waitingReason = waitingReason;
+    } else {
+      terminal.waitingReason = undefined;
+    }
+
+    events.emit("agent:state-changed", validatedStateChange.data);
     this.emitTerminalActivity(terminal);
 
     return true;

--- a/electron/services/pty/AgentStateService.ts
+++ b/electron/services/pty/AgentStateService.ts
@@ -200,11 +200,12 @@ export class AgentStateService {
     }
 
     // Build and validate state change payload BEFORE mutating terminal state.
+    const timestamp = getStateChangeTimestamp();
     const stateChangePayload = {
       agentId: effectiveAgentId,
       state: newState,
       previousState,
-      timestamp: getStateChangeTimestamp(),
+      timestamp,
       traceId: terminal.traceId,
       terminalId: terminal.id,
       cwd: terminal.cwd,
@@ -230,7 +231,7 @@ export class AgentStateService {
 
     // Commit all mutations atomically.
     terminal.agentState = newState;
-    terminal.lastStateChange = getStateChangeTimestamp();
+    terminal.lastStateChange = timestamp;
 
     // Refresh the hysteresis lock only when a high-confidence transition
     // actually crosses the active/passive boundary. Lifecycle events clear

--- a/electron/services/pty/AgentStateService.ts
+++ b/electron/services/pty/AgentStateService.ts
@@ -99,7 +99,7 @@ export class AgentStateService {
       case "watchdog-timeout":
         return "timeout";
       default: {
-        const _exhaustive: never = event.type;
+        const _exhaustive: never = event;
         return _exhaustive;
       }
     }

--- a/electron/services/pty/__tests__/AgentStateService.test.ts
+++ b/electron/services/pty/__tests__/AgentStateService.test.ts
@@ -462,7 +462,7 @@ describe("AgentStateService", () => {
       expect(stateChanges).toHaveLength(1);
 
       // 100ms later, watchdog timeout fires → would normally flip working → waiting
-      vi.setSystemTime(Date.now() + 100);
+      vi.advanceTimersByTime(100);
       const changed = service.handleActivityState(terminal, "idle", { trigger: "timeout" });
 
       expect(terminal.agentState).toBe("working");
@@ -484,7 +484,7 @@ describe("AgentStateService", () => {
       expect(terminal.agentState).toBe("working");
 
       // 200ms later, prompt heuristic at 0.75 → suppressed
-      vi.setSystemTime(Date.now() + 200);
+      vi.advanceTimersByTime(200);
       const changed = service.transitionState(
         terminal,
         { type: "prompt" },
@@ -506,7 +506,7 @@ describe("AgentStateService", () => {
       expect(terminal.agentState).toBe("working");
 
       // 501ms later — past the 500ms window
-      vi.setSystemTime(Date.now() + 501);
+      vi.advanceTimersByTime(501);
       const changed = service.handleActivityState(terminal, "idle", { trigger: "timeout" });
 
       expect(changed).toBeUndefined();
@@ -521,7 +521,7 @@ describe("AgentStateService", () => {
       expect(terminal.agentState).toBe("working");
 
       // Within the window, an explicit high-confidence prompt (1.0) wins
-      vi.setSystemTime(Date.now() + 100);
+      vi.advanceTimersByTime(100);
       const changed = service.transitionState(
         terminal,
         { type: "prompt" },
@@ -541,7 +541,7 @@ describe("AgentStateService", () => {
       service.updateAgentState(terminal, { type: "input" });
       expect(terminal.agentState).toBe("working");
 
-      vi.setSystemTime(Date.now() + 100);
+      vi.advanceTimersByTime(100);
       const changed = service.updateAgentState(terminal, { type: "exit", code: 0 });
 
       expect(changed).toBe(true);
@@ -560,7 +560,7 @@ describe("AgentStateService", () => {
       // A same-state input at t=200 produces no state change (working → working)
       // and therefore must NOT shift the lock — hysteresis is anchored to actual
       // direction-changing high-confidence transitions, not no-ops.
-      vi.setSystemTime(Date.now() + 200);
+      vi.advanceTimersByTime(200);
       service.updateAgentState(terminal, { type: "input" });
       expect(terminal.hysteresisLockedUntil).toBe(lockAfterFirst);
     });
@@ -593,7 +593,7 @@ describe("AgentStateService", () => {
       expect(terminal.agentState).toBe("idle");
       expect(terminal.hysteresisLockedUntil).toBeUndefined();
 
-      vi.setSystemTime(Date.now() + 100);
+      vi.advanceTimersByTime(100);
       const changed = service.handleActivityState(terminal, "busy", {
         trigger: "pattern",
         patternConfidence: 0.7,
@@ -631,7 +631,7 @@ describe("AgentStateService", () => {
       events.on("agent:state-changed", (payload) => stateChanges.push(payload));
       events.on("terminal:activity", (payload) => activityEvents.push(payload));
 
-      vi.setSystemTime(Date.now() + 100);
+      vi.advanceTimersByTime(100);
       const changed = service.handleActivityState(terminal, "idle", { trigger: "timeout" });
 
       expect(changed).toBeUndefined();
@@ -652,13 +652,13 @@ describe("AgentStateService", () => {
       expect(lockedUntil).toBeDefined();
 
       // Strictly inside the window — `now < lockedUntil` is true.
-      vi.setSystemTime((lockedUntil ?? 0) - 1);
+      vi.advanceTimersByTime((lockedUntil ?? 0) - 1);
       let changed = service.handleActivityState(terminal, "idle", { trigger: "timeout" });
       expect(changed).toBeUndefined();
       expect(terminal.agentState).toBe("working");
 
       // At the boundary — `now < lockedUntil` is false, transition allowed.
-      vi.setSystemTime(lockedUntil ?? 0);
+      vi.advanceTimersByTime(1);
       changed = service.handleActivityState(terminal, "idle", { trigger: "timeout" });
       expect(changed).toBeUndefined();
       expect(terminal.agentState).toBe("waiting");
@@ -690,7 +690,7 @@ describe("AgentStateService", () => {
 
       // Within the lock armed by t1's 0.85 transition, an opposite-direction
       // 0.849 event MUST be suppressed.
-      vi.setSystemTime(Date.now() + 100);
+      vi.advanceTimersByTime(100);
       const changedSuppressed = a.transitionState(
         t1,
         { type: "prompt" },

--- a/electron/services/pty/types.ts
+++ b/electron/services/pty/types.ts
@@ -131,7 +131,7 @@ export interface TerminalInfo extends TerminalPublicState {
   /** @deprecated Use serialization methods */
   rawOutputBuffer?: string;
   /**
-   * Runtime-only hysteresis bookkeeping. Timestamp (`Date.now()`) until which
+   * Runtime-only hysteresis bookkeeping. Timestamp (`performance.now()`) until which
    * opposite-direction low-confidence transitions are suppressed after a
    * recent high-confidence transition. Not persisted, not crossed over IPC.
    * See `AgentStateService` for the suppression policy.

--- a/shared/utils/agentFsm.ts
+++ b/shared/utils/agentFsm.ts
@@ -119,6 +119,11 @@ export function nextAgentState(current: AgentState, event: AgentEvent): AgentSta
         return "idle";
       }
       break;
+
+    default: {
+      const _exhaustive: never = event.type;
+      return _exhaustive;
+    }
   }
 
   return current;

--- a/shared/utils/agentFsm.ts
+++ b/shared/utils/agentFsm.ts
@@ -121,8 +121,8 @@ export function nextAgentState(current: AgentState, event: AgentEvent): AgentSta
       break;
 
     default: {
-      const _exhaustive: never = event.type;
-      return current;
+      const _exhaustive: never = event;
+      return _exhaustive;
     }
   }
 

--- a/shared/utils/agentFsm.ts
+++ b/shared/utils/agentFsm.ts
@@ -122,7 +122,7 @@ export function nextAgentState(current: AgentState, event: AgentEvent): AgentSta
 
     default: {
       const _exhaustive: never = event.type;
-      return _exhaustive;
+      return current;
     }
   }
 


### PR DESCRIPTION
## Summary
- Added `never`-type exhaustiveness checks in `inferTrigger` and `nextAgentState` so new event or state variants cause compile errors instead of silent fallthrough.
- Restructured `transitionState` to validate the payload before mutating terminal state -- no partial writes when the payload doesn't parse.
- Switched the hysteresis clock from `Date.now()` to `performance.now()` for a monotonic source, and clear the lock on lifecycle events so it doesn't leak across agent sessions.

Resolves #7064

## Changes
- `electron/services/pty/AgentStateService.ts` -- fail-first ordering, `performance.now()` hysteresis, lifecycle-event lock clearing, `never` ratchet in `inferTrigger`
- `shared/utils/agentFsm.ts` -- `never` exhaustiveness ratchet in `nextAgentState`
- `electron/services/pty/types.ts` -- doc update for `performance.now()`
- Tests switched from `vi.setSystemTime(Date.now() + N)` to `vi.advanceTimersByTime(N)` for correct fake-timer advancement

## Testing
- All existing `AgentStateService` tests pass with updated timer calls
- Hysteresis boundary and lock-clearing behaviour verified
- Typecheck passes clean