### PR TITLE
fix(ui): remove WifiOff icon from toolbar stat pills

### DIFF
--- a/src/components/Layout/FreshnessUtils.tsx
+++ b/src/components/Layout/FreshnessUtils.tsx
@@ -1,4 +1,4 @@
-import { Clock, WifiOff } from "lucide-react";
+import { Clock } from "lucide-react";
 import type { FreshnessLevel } from "@/hooks/useRepositoryStats";
 
 export function freshnessOpacityClass(level: FreshnessLevel): string {
@@ -18,9 +18,6 @@ export function freshnessOpacityClass(level: FreshnessLevel): string {
 export function FreshnessGlyph({ level }: { level: FreshnessLevel }) {
   if (level === "stale-disk") {
     return <Clock className="h-3 w-3 text-muted-foreground" aria-hidden="true" />;
-  }
-  if (level === "errored") {
-    return <WifiOff className="h-3 w-3 text-muted-foreground" aria-hidden="true" />;
   }
   return null;
 }

--- a/src/components/Layout/GitHubStatsToolbarButton.tsx
+++ b/src/components/Layout/GitHubStatsToolbarButton.tsx
@@ -126,6 +126,8 @@ export const GitHubStatsToolbarButton = memo(
       return Date.now();
     }, [tick]);
 
+    const commitFreshnessLevel = freshnessLevel === "errored" ? "fresh" : freshnessLevel;
+
     const activeWorktreeId = useWorktreeSelectionStore((state) => state.activeWorktreeId);
     const activeWorktree = useWorktreeStore((state) =>
       activeWorktreeId ? state.worktrees.get(activeWorktreeId) : null
@@ -817,17 +819,17 @@ export const GitHubStatsToolbarButton = memo(
           open={commitsOpen}
           count={commitCount}
           animKey={commitAnimKey}
-          ariaLabel={`${commitCount ?? "—"} commits${freshnessSuffix(freshnessLevel, lastUpdated, now)}`}
+          ariaLabel={`${commitCount ?? "—"} commits${freshnessSuffix(commitFreshnessLevel, lastUpdated, now)}`}
           tooltipContent={
-            freshnessLevel === "fresh"
+            commitFreshnessLevel === "fresh"
               ? "Browse Git Commits"
-              : `${commitCount ?? "—"} commits${freshnessSuffix(freshnessLevel, lastUpdated, now)}`
+              : `${commitCount ?? "—"} commits${freshnessSuffix(commitFreshnessLevel, lastUpdated, now)}`
           }
           icon={GitCommit}
           openRingClassName="ring-1 ring-border-strong"
           className={cn(
             stats?.commitCount === 0 && "opacity-50",
-            freshnessOpacityClass(freshnessLevel)
+            freshnessOpacityClass(commitFreshnessLevel)
           )}
           dropdownContent={
             CommitListComponent ? (
@@ -865,7 +867,7 @@ export const GitHubStatsToolbarButton = memo(
             setCommitsOpen(open);
             if (!open) commitsButtonRef.current?.focus();
           }}
-          freshnessGlyph={<FreshnessGlyph level={freshnessLevel} />}
+          freshnessGlyph={<FreshnessGlyph level={commitFreshnessLevel} />}
         />
         <GitHubStatusIndicator
           status={getGitHubIndicatorStatus()}

--- a/src/components/Layout/__tests__/GitHubStatsToolbarButton.freshness.test.ts
+++ b/src/components/Layout/__tests__/GitHubStatsToolbarButton.freshness.test.ts
@@ -38,16 +38,23 @@ describe("GitHubStatsToolbarButton freshness wiring", () => {
   });
 
   it("uses freshnessOpacityClass in className for all three pills", () => {
-    const matches = source.match(/freshnessOpacityClass\(freshnessLevel\)/g);
-    expect(matches).not.toBeNull();
-    expect(matches?.length).toBe(3);
+    // Commits uses commitFreshnessLevel (errored→fresh); issues + PRs use freshnessLevel.
+    const commitsMatch = source.match(/freshnessOpacityClass\(commitFreshnessLevel\)/g);
+    const sharedMatch = source.match(/freshnessOpacityClass\(freshnessLevel\)/g);
+    expect(commitsMatch).not.toBeNull();
+    expect(commitsMatch?.length).toBe(1);
+    expect(sharedMatch).not.toBeNull();
+    expect(sharedMatch?.length).toBe(2);
   });
 
   it("uses freshnessSuffix in ariaLabel and tooltipContent for freshness-aware copy", () => {
-    const matches = source.match(/freshnessSuffix\(freshnessLevel/g);
-    expect(matches).not.toBeNull();
-    // At least 3 (ariaLabel) + 3 (tooltipContent) = 6 occurrences
-    expect(matches!.length).toBeGreaterThanOrEqual(6);
+    // Commits uses commitFreshnessLevel; issues + PRs use freshnessLevel.
+    const commitsMatch = source.match(/freshnessSuffix\(commitFreshnessLevel/g);
+    const sharedMatch = source.match(/freshnessSuffix\(freshnessLevel/g);
+    expect(commitsMatch).not.toBeNull();
+    expect(commitsMatch?.length).toBe(2); // ariaLabel + tooltipContent
+    expect(sharedMatch).not.toBeNull();
+    expect(sharedMatch!.length).toBeGreaterThanOrEqual(4); // 2 issues + 2 PRs
   });
 
   it("applies animate-badge-bump via animKey prop on all three GitHubStatPill instances", () => {
@@ -70,6 +77,15 @@ describe("GitHubStatsToolbarButton freshness wiring", () => {
     expect(source).toContain('from "@/hooks/useGlobalMinuteTicker"');
     expect(source).toMatch(/const\s+tick\s*=\s*useGlobalMinuteTicker\(\)/);
     expect(source).toMatch(/useMemo\(\s*\(\)\s*=>\s*\{[\s\S]*?Date\.now\(\)/);
+  });
+
+  it("derives commitFreshnessLevel that maps errored to fresh for the commits pill", () => {
+    // Commits are from git, not GitHub — GitHub connectivity errors shouldn't
+    // degrade the commits pill.
+    expect(source).toContain("commitFreshnessLevel");
+    expect(source).toMatch(
+      /commitFreshnessLevel\s*=\s*freshnessLevel\s*===\s*"errored"\s*\?\s*"fresh"\s*:\s*freshnessLevel/
+    );
   });
 
   it("only bumps animation keys when the displayed count actually changes", () => {


### PR DESCRIPTION
## Summary

The toolbar stat pills (Issues, PRs, Commits) all showed a `WifiOff` icon from `FreshnessGlyph` when the GitHub API was unreachable. Two problems:

- **Commits incorrectly reflected GitHub connectivity.** Commits are read from `git log`, not GitHub — the error indicator was misleading.
- **`WifiOff` was redundant for Issues/PRs.** The rate limit countdown and greyed-out pill styling already communicate degraded state.

## Changes

- Removed `WifiOff` rendering from `FreshnessGlyph` (only consumer was this toolbar)
- Derived `commitFreshnessLevel` that maps `errored` → `fresh` so GitHub failures don't degrade the commits pill
- The `Clock` icon for `stale-disk` and all remaining freshness tiers continue to work as before

## Test plan

- [x] `FreshnessUtils.test.tsx` — 16/16 pass
- [x] `GitHubStatsToolbarButton.freshness.test.ts` — 10/10 pass (updated for commit-specific derivation)
- [x] Typecheck passes
- [x] Format check passes

Closes #7193

🤖 Generated with [Claude Code](https://claude.com/claude-code)