### PR TITLE
fix(dock): remove misleading 'Preview terminal' tooltip and Cmd+Alt+D default

### DIFF
--- a/src/components/Layout/DockedTerminalItem.tsx
+++ b/src/components/Layout/DockedTerminalItem.tsx
@@ -30,8 +30,6 @@ import { getDockDisplayAgentState, useDockBlockedState } from "./useDockBlockedS
 import { handleDockInteractOutside, handleDockEscapeKeyDown } from "./dockPopoverGuard";
 import { usePreferencesStore } from "@/store";
 import { Tooltip, TooltipContent, TooltipTrigger } from "@/components/ui/tooltip";
-import { useKeybindingDisplay } from "@/hooks/useKeybinding";
-import { createTooltipContent } from "@/lib/tooltipShortcut";
 
 interface DockedTerminalItemProps {
   terminal: TerminalInstance;
@@ -271,7 +269,6 @@ export function DockedTerminalItem({ terminal }: DockedTerminalItemProps) {
   const isWaiting = agentState === "waiting";
   const isActive = isWorking || isWaiting;
   const commandText = terminal.activityHeadline || terminal.lastCommand;
-  const dockShortcut = useKeybindingDisplay("terminal.focusDock");
   const blockedState = useDockBlockedState(agentState);
   const showDockAgentHighlights = usePreferencesStore((s) => s.showDockAgentHighlights);
   // Use shortened title without command summary for dock items
@@ -287,93 +284,86 @@ export function DockedTerminalItem({ terminal }: DockedTerminalItemProps) {
   return (
     <Popover open={isOpen} onOpenChange={handleOpenChange}>
       <TerminalContextMenu terminalId={terminal.id} forceLocation="dock">
-        <Tooltip>
-          <TooltipTrigger asChild>
-            <PopoverTrigger asChild>
-              <button
-                className={cn(
-                  "flex items-center gap-1.5 px-3 h-[var(--dock-item-height)] rounded-[var(--radius-md)] text-xs border transition duration-150 max-w-[280px]",
-                  "bg-[var(--dock-item-bg)] border-[var(--dock-item-border)] text-daintree-text/70",
-                  "hover:text-daintree-text hover:bg-[var(--dock-item-bg-hover)]",
-                  "focus-visible:outline focus-visible:outline-2 focus-visible:outline-daintree-accent focus-visible:outline-offset-2",
-                  "cursor-grab active:cursor-grabbing",
-                  isOpen &&
-                    "bg-[var(--dock-item-bg-active)] text-daintree-text border-[var(--dock-item-border-active)] ring-1 ring-inset ring-daintree-accent/30",
-                  !isOpen &&
-                    showDockAgentHighlights &&
-                    blockedState === "waiting" &&
-                    "bg-[var(--dock-item-bg-waiting)] border-[var(--dock-item-border-waiting)]",
-                  isDeprioritized && "opacity-50"
-                )}
-                onClick={(e) => {
-                  e.preventDefault();
-                  e.stopPropagation();
-                  if (e.detail >= 2) return;
-                  if (isOpen) {
-                    closeDockTerminal();
-                  } else {
-                    openDockTerminal(terminal.id);
-                  }
-                }}
-                onDoubleClick={(e) => {
-                  e.preventDefault();
-                  e.stopPropagation();
-                  const moved = moveTerminalToGrid(terminal.id);
-                  if (moved) closeDockTerminal();
-                }}
-                aria-label={`${terminal.title} - Click to preview, double-click to move to grid, drag to reorder`}
-              >
-                <div className="flex items-center justify-center shrink-0">
-                  <TerminalIcon kind={terminal.kind} chrome={chrome} className="w-3.5 h-3.5" />
-                </div>
-                <span className="truncate min-w-[48px] max-w-[140px] font-sans font-medium">
-                  {displayTitle}
-                </span>
+        <PopoverTrigger asChild>
+          <button
+            className={cn(
+              "flex items-center gap-1.5 px-3 h-[var(--dock-item-height)] rounded-[var(--radius-md)] text-xs border transition duration-150 max-w-[280px]",
+              "bg-[var(--dock-item-bg)] border-[var(--dock-item-border)] text-daintree-text/70",
+              "hover:text-daintree-text hover:bg-[var(--dock-item-bg-hover)]",
+              "focus-visible:outline focus-visible:outline-2 focus-visible:outline-daintree-accent focus-visible:outline-offset-2",
+              "cursor-grab active:cursor-grabbing",
+              isOpen &&
+                "bg-[var(--dock-item-bg-active)] text-daintree-text border-[var(--dock-item-border-active)] ring-1 ring-inset ring-daintree-accent/30",
+              !isOpen &&
+                showDockAgentHighlights &&
+                blockedState === "waiting" &&
+                "bg-[var(--dock-item-bg-waiting)] border-[var(--dock-item-border-waiting)]",
+              isDeprioritized && "opacity-50"
+            )}
+            onClick={(e) => {
+              e.preventDefault();
+              e.stopPropagation();
+              if (e.detail >= 2) return;
+              if (isOpen) {
+                closeDockTerminal();
+              } else {
+                openDockTerminal(terminal.id);
+              }
+            }}
+            onDoubleClick={(e) => {
+              e.preventDefault();
+              e.stopPropagation();
+              const moved = moveTerminalToGrid(terminal.id);
+              if (moved) closeDockTerminal();
+            }}
+            aria-label={`${terminal.title} - Click to preview, double-click to move to grid, drag to reorder`}
+          >
+            <div className="flex items-center justify-center shrink-0">
+              <TerminalIcon kind={terminal.kind} chrome={chrome} className="w-3.5 h-3.5" />
+            </div>
+            <span className="truncate min-w-[48px] max-w-[140px] font-sans font-medium">
+              {displayTitle}
+            </span>
 
-                {isActive && commandText && (
-                  <>
-                    <div className="h-3 w-px bg-border-subtle shrink-0" aria-hidden="true" />
-                    <Tooltip>
-                      <TooltipTrigger asChild>
-                        <span className="truncate flex-1 min-w-0 text-[11px] text-daintree-text/50 font-mono">
-                          {commandText}
-                        </span>
-                      </TooltipTrigger>
-                      <TooltipContent side="bottom">{commandText}</TooltipContent>
-                    </Tooltip>
-                  </>
-                )}
+            {isActive && commandText && (
+              <>
+                <div className="h-3 w-px bg-border-subtle shrink-0" aria-hidden="true" />
+                <Tooltip>
+                  <TooltipTrigger asChild>
+                    <span className="truncate flex-1 min-w-0 text-[11px] text-daintree-text/50 font-mono">
+                      {commandText}
+                    </span>
+                  </TooltipTrigger>
+                  <TooltipContent side="bottom">{commandText}</TooltipContent>
+                </Tooltip>
+              </>
+            )}
 
-                {/* State icon (compact spacing from title) */}
-                {displayAgentState && StateIcon && (
-                  <Tooltip>
-                    <TooltipTrigger asChild>
-                      <div
-                        className={cn(
-                          "flex items-center shrink-0",
-                          getEffectiveStateColor(displayAgentState)
-                        )}
-                      >
-                        <StateIcon
-                          className={cn(
-                            "w-3.5 h-3.5",
-                            displayAgentState === "working" && "animate-spin-slow",
-                            "motion-reduce:animate-none"
-                          )}
-                          aria-hidden="true"
-                        />
-                      </div>
-                    </TooltipTrigger>
-                    <TooltipContent side="bottom">{`Agent ${displayAgentState}`}</TooltipContent>
-                  </Tooltip>
-                )}
-              </button>
-            </PopoverTrigger>
-          </TooltipTrigger>
-          <TooltipContent side="top">
-            {createTooltipContent("Preview terminal", dockShortcut)}
-          </TooltipContent>
-        </Tooltip>
+            {/* State icon (compact spacing from title) */}
+            {displayAgentState && StateIcon && (
+              <Tooltip>
+                <TooltipTrigger asChild>
+                  <div
+                    className={cn(
+                      "flex items-center shrink-0",
+                      getEffectiveStateColor(displayAgentState)
+                    )}
+                  >
+                    <StateIcon
+                      className={cn(
+                        "w-3.5 h-3.5",
+                        displayAgentState === "working" && "animate-spin-slow",
+                        "motion-reduce:animate-none"
+                      )}
+                      aria-hidden="true"
+                    />
+                  </div>
+                </TooltipTrigger>
+                <TooltipContent side="bottom">{`Agent ${displayAgentState}`}</TooltipContent>
+              </Tooltip>
+            )}
+          </button>
+        </PopoverTrigger>
       </TerminalContextMenu>
 
       <PopoverContent

--- a/src/components/Layout/__tests__/DockedTerminalItem.test.tsx
+++ b/src/components/Layout/__tests__/DockedTerminalItem.test.tsx
@@ -6,21 +6,6 @@ import { resolve } from "path";
 describe("DockedTerminalItem", () => {
   const content = readFileSync(resolve(__dirname, "../DockedTerminalItem.tsx"), "utf-8");
 
-  it("imports useKeybindingDisplay and createTooltipContent", () => {
-    expect(content).toContain('import { useKeybindingDisplay } from "@/hooks/useKeybinding"');
-    expect(content).toContain('import { createTooltipContent } from "@/lib/tooltipShortcut"');
-  });
-
-  it("calls useKeybindingDisplay with terminal.focusDock", () => {
-    expect(content).toContain('useKeybindingDisplay("terminal.focusDock")');
-  });
-
-  it("wraps the trigger in a Tooltip with Preview terminal text", () => {
-    expect(content).toContain("<Tooltip>");
-    expect(content).toContain('createTooltipContent("Preview terminal", dockShortcut)');
-    expect(content).toContain('<TooltipContent side="top">');
-  });
-
   it("preserves click/double-click handler structure through the new wrappers", () => {
     expect(content).toContain("onClick={");
     expect(content).toContain("onDoubleClick={");

--- a/src/services/defaultKeybindings.ts
+++ b/src/services/defaultKeybindings.ts
@@ -146,14 +146,6 @@ export const DEFAULT_KEYBINDINGS: KeybindingConfig[] = [
     category: "Terminal",
   },
   {
-    actionId: "terminal.focusDock",
-    combo: "Cmd+Alt+D",
-    scope: "global",
-    priority: 0,
-    description: "Focus active dock terminal",
-    category: "Terminal",
-  },
-  {
     actionId: "terminal.toggleDockAll",
     combo: "Cmd+Alt+Shift+M",
     scope: "global",


### PR DESCRIPTION
## Summary

- The docked terminal chip showed a tooltip labelled `Preview terminal` with `Cmd+Alt+D` as the shortcut. Both were wrong: macOS intercepts `Cmd+Alt+D` for Dock auto-hide so the app never sees it, and clicking the chip opens a popover preview while the keybinding (`terminal.focusDock`) does something else entirely.
- Drops the `Tooltip` wrapper on the chip and removes the `Cmd+Alt+D` default from `defaultKeybindings.ts`. The `terminal.focusDock` action stays registered and is still available in the command palette and remappable.
- Removes three tests that were exercising the now-deleted tooltip behaviour.

Resolves #7277

## Changes

- `src/components/Layout/DockedTerminalItem.tsx` — removed chip-level `Tooltip` wrapper, `dockShortcut` prop, and related imports
- `src/services/defaultKeybindings.ts` — removed `terminal.focusDock` default binding (`Cmd+Alt+D`)
- `src/components/Layout/__tests__/DockedTerminalItem.test.tsx` — removed 3 obsolete tooltip tests

## Testing

- `npm run check` passes clean (lint warnings unchanged, 0 errors)
- Unit tests pass with the three obsolete cases removed