### PR TITLE
fix(ui): polish primitive consistency across Avatar, Button, Tooltip, Select

### DIFF
--- a/src/components/ui/Avatar.tsx
+++ b/src/components/ui/Avatar.tsx
@@ -36,7 +36,7 @@ export function Avatar({ src, alt, title, className }: AvatarProps) {
             "absolute inset-0 rounded-full flex items-center justify-center",
             error
               ? "bg-muted-foreground/30 ring-2 ring-inset ring-muted-foreground/50"
-              : "bg-muted animate-pulse"
+              : "bg-muted animate-pulse-delayed"
           )}
         >
           {error && (

--- a/src/components/ui/__tests__/Avatar.test.tsx
+++ b/src/components/ui/__tests__/Avatar.test.tsx
@@ -20,7 +20,7 @@ describe("Avatar", () => {
     const img = container.querySelector("img");
     expect(img).toBeTruthy();
     expect(img!.style.opacity).toBe("0");
-    const skeleton = container.querySelector(".animate-pulse");
+    const skeleton = container.querySelector(".animate-pulse-delayed");
     expect(skeleton).toBeTruthy();
   });
 
@@ -46,7 +46,7 @@ describe("Avatar", () => {
       expect(img).toBeTruthy();
       // naturalWidth=0 means a broken cached image — skeleton should remain
       expect(img!.style.opacity).toBe("0");
-      expect(container.querySelector(".animate-pulse")).toBeTruthy();
+      expect(container.querySelector(".animate-pulse-delayed")).toBeTruthy();
     } finally {
       if (origComplete) {
         Object.defineProperty(HTMLImageElement.prototype, "complete", origComplete);
@@ -81,7 +81,7 @@ describe("Avatar", () => {
       const img = container.querySelector("img");
       expect(img).toBeTruthy();
       expect(img!.style.opacity).toBe("1");
-      expect(container.querySelector(".animate-pulse")).toBeFalsy();
+      expect(container.querySelector(".animate-pulse-delayed")).toBeFalsy();
     } finally {
       if (origComplete) {
         Object.defineProperty(HTMLImageElement.prototype, "complete", origComplete);
@@ -119,7 +119,7 @@ describe("Avatar", () => {
     rerender(<Avatar src="second.jpg" alt="Second" />);
     const newImg = container.querySelector("img")!;
     expect(newImg.style.opacity).toBe("0");
-    expect(container.querySelector(".animate-pulse")).toBeTruthy();
+    expect(container.querySelector(".animate-pulse-delayed")).toBeTruthy();
   });
 
   it("renders tooltip wrapper when title is provided", () => {
@@ -152,7 +152,7 @@ describe("Avatar", () => {
       rerender(<Avatar src="b.jpg" alt="B" />);
       // Src change resets state and effect re-probes the reused img node
       expect(container.querySelector("img")!.style.opacity).toBe("1");
-      expect(container.querySelector(".animate-pulse")).toBeFalsy();
+      expect(container.querySelector(".animate-pulse-delayed")).toBeFalsy();
     } finally {
       if (origComplete) {
         Object.defineProperty(HTMLImageElement.prototype, "complete", origComplete);

--- a/src/components/ui/__tests__/Avatar.test.tsx
+++ b/src/components/ui/__tests__/Avatar.test.tsx
@@ -82,6 +82,7 @@ describe("Avatar", () => {
       expect(img).toBeTruthy();
       expect(img!.style.opacity).toBe("1");
       expect(container.querySelector(".animate-pulse-delayed")).toBeFalsy();
+      expect(container.querySelector(".animate-pulse")).toBeFalsy();
     } finally {
       if (origComplete) {
         Object.defineProperty(HTMLImageElement.prototype, "complete", origComplete);
@@ -153,6 +154,7 @@ describe("Avatar", () => {
       // Src change resets state and effect re-probes the reused img node
       expect(container.querySelector("img")!.style.opacity).toBe("1");
       expect(container.querySelector(".animate-pulse-delayed")).toBeFalsy();
+      expect(container.querySelector(".animate-pulse")).toBeFalsy();
     } finally {
       if (origComplete) {
         Object.defineProperty(HTMLImageElement.prototype, "complete", origComplete);

--- a/src/components/ui/__tests__/radix-animation-classes.test.tsx
+++ b/src/components/ui/__tests__/radix-animation-classes.test.tsx
@@ -179,5 +179,6 @@ describe("Radix overlay animation classes — wrapper source", () => {
   it("tooltip.tsx contains palette enter/exit set with palette durations", () => {
     const src = readWrapperSource("tooltip.tsx");
     expectAllInString(src, TOOLTIP_CLASSES, "tooltip.tsx");
+    expect(src).toContain("var(--radix-tooltip-content-transform-origin)");
   });
 });

--- a/src/components/ui/button.tsx
+++ b/src/components/ui/button.tsx
@@ -55,11 +55,11 @@ export interface ButtonProps
 }
 
 const Button = React.forwardRef<HTMLButtonElement, ButtonProps>(
-  ({ className, variant, size, asChild = false, ...props }, ref) => {
+  ({ className, variant, size, asChild = false, type, ...props }, ref) => {
     const Comp = asChild ? Slot : "button";
     return (
       <Comp
-        type={asChild ? undefined : (props.type ?? "button")}
+        type={asChild ? undefined : (type ?? "button")}
         className={cn(buttonVariants({ variant, size, className }))}
         ref={ref}
         {...props}

--- a/src/components/ui/button.tsx
+++ b/src/components/ui/button.tsx
@@ -58,7 +58,12 @@ const Button = React.forwardRef<HTMLButtonElement, ButtonProps>(
   ({ className, variant, size, asChild = false, ...props }, ref) => {
     const Comp = asChild ? Slot : "button";
     return (
-      <Comp className={cn(buttonVariants({ variant, size, className }))} ref={ref} {...props} />
+      <Comp
+        type={asChild ? undefined : (props.type ?? "button")}
+        className={cn(buttonVariants({ variant, size, className }))}
+        ref={ref}
+        {...props}
+      />
     );
   }
 );

--- a/src/components/ui/select.tsx
+++ b/src/components/ui/select.tsx
@@ -37,7 +37,7 @@ const SelectScrollUpButton = React.forwardRef<
 >(({ className, ...props }, ref) => (
   <SelectPrimitive.ScrollUpButton
     ref={ref}
-    className={cn("flex cursor-default items-center justify-center py-1", className)}
+    className={cn("flex cursor-pointer items-center justify-center py-1", className)}
     {...props}
   >
     <ChevronUp className="h-4 w-4" aria-hidden="true" />
@@ -51,7 +51,7 @@ const SelectScrollDownButton = React.forwardRef<
 >(({ className, ...props }, ref) => (
   <SelectPrimitive.ScrollDownButton
     ref={ref}
-    className={cn("flex cursor-default items-center justify-center py-1", className)}
+    className={cn("flex cursor-pointer items-center justify-center py-1", className)}
     {...props}
   >
     <ChevronDown className="h-4 w-4" aria-hidden="true" />

--- a/src/components/ui/tooltip.tsx
+++ b/src/components/ui/tooltip.tsx
@@ -11,11 +11,12 @@ const TooltipTrigger = TooltipPrimitive.Trigger;
 const TooltipContent = React.forwardRef<
   React.ElementRef<typeof TooltipPrimitive.Content>,
   React.ComponentPropsWithoutRef<typeof TooltipPrimitive.Content>
->(({ className, sideOffset = 4, ...props }, ref) => (
+>(({ className, sideOffset = 4, style, ...props }, ref) => (
   <TooltipPrimitive.Portal>
     <TooltipPrimitive.Content
       ref={ref}
       sideOffset={sideOffset}
+      style={{ transformOrigin: "var(--radix-tooltip-content-transform-origin)", ...style }}
       className={cn(
         "z-[var(--z-popover)] overflow-hidden rounded-[var(--radius-md)] surface-overlay shadow-overlay px-3 py-1.5 text-xs text-daintree-text",
         "animate-in fade-in-0 zoom-in-95 duration-150 data-[state=closed]:animate-out data-[state=closed]:duration-[100ms] data-[state=closed]:fade-out-0 data-[state=closed]:zoom-out-95 data-[side=bottom]:slide-in-from-top-2 data-[side=left]:slide-in-from-right-2 data-[side=right]:slide-in-from-left-2 data-[side=top]:slide-in-from-bottom-2",


### PR DESCRIPTION
## Summary

- `Avatar` skeleton swapped from `animate-pulse` to `animate-pulse-delayed` so it respects the Doherty gate and `prefers-reduced-motion`
- `Button` defaults to `type="button"` to prevent accidental form submission; `asChild` slots are left untouched
- `TooltipContent` gets the `--radix-tooltip-content-transform-origin` style var that every other Radix wrapper already sets, so tooltips animate from the anchor edge rather than the center
- `SelectScrollUpButton` and `SelectScrollDownButton` cursor changed from `cursor-default` to `cursor-pointer` to match `DropdownMenuItem` and `ContextMenuItem`

Resolves #7257

## Changes

- `src/components/ui/Avatar.tsx` — `animate-pulse` → `animate-pulse-delayed`
- `src/components/ui/button.tsx` — default `type="button"`, skip on `asChild`
- `src/components/ui/tooltip.tsx` — add `transformOrigin` style spread
- `src/components/ui/select.tsx` — `cursor-default` → `cursor-pointer` on scroll buttons
- `src/components/ui/__tests__/Avatar.test.tsx` — updated selectors to match new class
- `src/components/ui/__tests__/radix-animation-classes.test.tsx` — added `TooltipContent` to the transform-origin guard

## Testing

- Vitest: 16 affected tests pass
- Lint and typecheck clean