### PR TITLE
fix(setup): a11y attrs and re-check flicker in agent setup wizard

### DIFF
--- a/src/components/Setup/AgentCliStep.tsx
+++ b/src/components/Setup/AgentCliStep.tsx
@@ -329,28 +329,29 @@ export function AgentCliStep({ availability, selections, onInstallComplete }: Ag
               {isError && (
                 <div className="pl-14 pt-1.5 pb-1 space-y-1">
                   {errorLog && (
-                    <button
-                      type="button"
-                      onClick={() => toggleErrorExpanded(agentId)}
-                      aria-expanded={isErrorExpanded ?? false}
-                      aria-controls={`error-log-${agentId}`}
-                      className="inline-flex items-center gap-1 text-[11px] text-daintree-text/50 hover:text-daintree-text/80 transition-colors"
-                    >
-                      {isErrorExpanded ? (
-                        <ChevronDown className="w-3 h-3" />
-                      ) : (
-                        <ChevronRight className="w-3 h-3" />
-                      )}
-                      Show error log
-                    </button>
-                  )}
-                  {isErrorExpanded && errorLog && (
-                    <pre
-                      id={`error-log-${agentId}`}
-                      className="text-[10px] text-status-error/80 bg-daintree-bg border border-daintree-border rounded-[var(--radius-sm)] p-2 max-h-[120px] overflow-y-auto whitespace-pre-wrap font-mono"
-                    >
-                      {errorLog}
-                    </pre>
+                    <>
+                      <button
+                        type="button"
+                        onClick={() => toggleErrorExpanded(agentId)}
+                        aria-expanded={isErrorExpanded ?? false}
+                        aria-controls={`error-log-${agentId}`}
+                        className="inline-flex items-center gap-1 text-[11px] text-daintree-text/50 hover:text-daintree-text/80 transition-colors"
+                      >
+                        {isErrorExpanded ? (
+                          <ChevronDown className="w-3 h-3" />
+                        ) : (
+                          <ChevronRight className="w-3 h-3" />
+                        )}
+                        Show error log
+                      </button>
+                      <pre
+                        id={`error-log-${agentId}`}
+                        hidden={!isErrorExpanded}
+                        className="text-[10px] text-status-error/80 bg-daintree-bg border border-daintree-border rounded-[var(--radius-sm)] p-2 max-h-[120px] overflow-y-auto whitespace-pre-wrap font-mono"
+                      >
+                        {errorLog}
+                      </pre>
+                    </>
                   )}
                   {currentBlock?.commands && (
                     <div className="space-y-1">

--- a/src/components/Setup/AgentCliStep.tsx
+++ b/src/components/Setup/AgentCliStep.tsx
@@ -250,19 +250,14 @@ export function AgentCliStep({ availability, selections, onInstallComplete }: Ag
                 </div>
                 <div className="flex items-center gap-2 shrink-0">
                   {config.install?.docsUrl && (
-                    <span
-                      role="link"
-                      tabIndex={0}
+                    <button
+                      type="button"
                       className="text-daintree-text/30 hover:text-daintree-text transition-colors p-0.5 cursor-pointer"
                       onClick={() => systemClient.openExternal(config.install!.docsUrl!)}
-                      onKeyDown={(e) => {
-                        if (e.key === "Enter" || e.key === " ")
-                          systemClient.openExternal(config.install!.docsUrl!);
-                      }}
                       title="View documentation"
                     >
                       <ExternalLink className="w-3 h-3" />
-                    </span>
+                    </button>
                   )}
                   {isInstalled ? (
                     <span className="inline-flex items-center gap-1 text-[11px] text-status-success font-medium">
@@ -337,6 +332,8 @@ export function AgentCliStep({ availability, selections, onInstallComplete }: Ag
                     <button
                       type="button"
                       onClick={() => toggleErrorExpanded(agentId)}
+                      aria-expanded={isErrorExpanded ?? false}
+                      aria-controls={`error-log-${agentId}`}
                       className="inline-flex items-center gap-1 text-[11px] text-daintree-text/50 hover:text-daintree-text/80 transition-colors"
                     >
                       {isErrorExpanded ? (
@@ -348,7 +345,10 @@ export function AgentCliStep({ availability, selections, onInstallComplete }: Ag
                     </button>
                   )}
                   {isErrorExpanded && errorLog && (
-                    <pre className="text-[10px] text-status-error/80 bg-daintree-bg border border-daintree-border rounded-[var(--radius-sm)] p-2 max-h-[120px] overflow-y-auto whitespace-pre-wrap font-mono">
+                    <pre
+                      id={`error-log-${agentId}`}
+                      className="text-[10px] text-status-error/80 bg-daintree-bg border border-daintree-border rounded-[var(--radius-sm)] p-2 max-h-[120px] overflow-y-auto whitespace-pre-wrap font-mono"
+                    >
                       {errorLog}
                     </pre>
                   )}

--- a/src/components/Setup/SystemRequirementsSection.tsx
+++ b/src/components/Setup/SystemRequirementsSection.tsx
@@ -71,6 +71,8 @@ export function SystemRequirementsSection({
       <button
         type="button"
         onClick={() => setUserExpanded((v) => !v)}
+        aria-expanded={isExpanded}
+        aria-controls="system-requirements-panel"
         className="flex items-center gap-2.5 w-full px-3 py-2.5 text-left"
       >
         <ChevronDown
@@ -108,6 +110,7 @@ export function SystemRequirementsSection({
       </button>
 
       <m.div
+        id="system-requirements-panel"
         animate={{ height: isExpanded ? "auto" : 0 }}
         initial={false}
         transition={

--- a/src/components/Setup/SystemToolsStep.tsx
+++ b/src/components/Setup/SystemToolsStep.tsx
@@ -55,6 +55,8 @@ export function PrerequisiteCard({ spec, state }: { spec: PrerequisiteSpec; stat
               <button
                 type="button"
                 onClick={() => setExpanded((v) => !v)}
+                aria-expanded={expanded}
+                aria-controls={`install-panel-${spec.tool}`}
                 className="inline-flex items-center gap-1 text-[11px] text-text-secondary hover:text-daintree-text underline-offset-2 hover:underline shrink-0"
               >
                 {expanded ? (
@@ -85,7 +87,7 @@ export function PrerequisiteCard({ spec, state }: { spec: PrerequisiteSpec; stat
         ) : null}
       </div>
       {expanded && installBlocks && (
-        <div className="px-3 pb-3 space-y-2">
+        <div id={`install-panel-${spec.tool}`} className="px-3 pb-3 space-y-2">
           {installBlocks.map((block, i) => (
             <InstallBlock key={i} block={block} />
           ))}

--- a/src/components/Setup/SystemToolsStep.tsx
+++ b/src/components/Setup/SystemToolsStep.tsx
@@ -86,8 +86,8 @@ export function PrerequisiteCard({ spec, state }: { spec: PrerequisiteSpec; stat
           <span className="text-[11px] text-daintree-text/40 shrink-0">Installed</span>
         ) : null}
       </div>
-      {expanded && installBlocks && (
-        <div id={`install-panel-${spec.tool}`} className="px-3 pb-3 space-y-2">
+      {installBlocks && (
+        <div id={`install-panel-${spec.tool}`} hidden={!expanded} className="px-3 pb-3 space-y-2">
           {installBlocks.map((block, i) => (
             <InstallBlock key={i} block={block} />
           ))}

--- a/src/components/Setup/__tests__/useSystemHealthCheck.test.ts
+++ b/src/components/Setup/__tests__/useSystemHealthCheck.test.ts
@@ -108,6 +108,48 @@ describe("useSystemHealthCheck — focus re-check", () => {
     expect(removeWinListenerSpy).toHaveBeenCalledWith("focus", expect.any(Function));
   });
 
+  it("preserves prior specs and checkStates across a re-check until new specs resolve", async () => {
+    // First check resolves normally with git available.
+    mockGetSpecs.mockResolvedValueOnce([makeSpec("git")]);
+    mockCheckTool.mockResolvedValueOnce(makeResult("git"));
+
+    const { result } = renderHook(() => useSystemHealthCheck());
+
+    await waitFor(() => {
+      expect(result.current.checkStates.git).toMatchObject({ available: true });
+    });
+
+    // Second check: pause getHealthCheckSpecs so we can observe state mid-flight.
+    let resolveSpecs: (value: unknown) => void;
+    const pendingSpecs = new Promise((resolve) => {
+      resolveSpecs = resolve;
+    });
+    mockGetSpecs.mockReturnValueOnce(pendingSpecs);
+    mockCheckTool.mockResolvedValueOnce(makeResult("git"));
+
+    vi.spyOn(document, "hasFocus").mockReturnValue(true);
+
+    await act(async () => {
+      window.dispatchEvent(new Event("focus"));
+    });
+
+    // Mid-flight (specs not yet resolved): prior data must still be visible.
+    expect(result.current.specs).toHaveLength(1);
+    expect(result.current.specs[0]?.tool).toBe("git");
+    expect(result.current.checkStates.git).toMatchObject({ available: true });
+
+    // Resolve the second specs call and let the check settle.
+    await act(async () => {
+      resolveSpecs!([makeSpec("git")]);
+      await Promise.resolve();
+    });
+
+    await waitFor(() => {
+      expect(result.current.checkStates.git).toMatchObject({ available: true });
+      expect(result.current.isChecking).toBe(false);
+    });
+  });
+
   it("does not start a parallel check if one is already in flight (isCheckingRef guard)", async () => {
     let resolveSpecs: (value: unknown) => void;
     const pending = new Promise((resolve) => {

--- a/src/components/Setup/__tests__/useSystemHealthCheck.test.ts
+++ b/src/components/Setup/__tests__/useSystemHealthCheck.test.ts
@@ -150,6 +150,82 @@ describe("useSystemHealthCheck — focus re-check", () => {
     });
   });
 
+  it("preserves prior checkStates while checkTool reruns for tools still in the spec list", async () => {
+    // First check completes with git available.
+    mockGetSpecs.mockResolvedValueOnce([makeSpec("git")]);
+    mockCheckTool.mockResolvedValueOnce(makeResult("git"));
+
+    const { result } = renderHook(() => useSystemHealthCheck());
+
+    await waitFor(() => {
+      expect(result.current.checkStates.git).toMatchObject({ available: true });
+      expect(result.current.isChecking).toBe(false);
+    });
+
+    // Second check: getHealthCheckSpecs resolves immediately with the same
+    // spec list, but checkTool stays pending so we can observe the per-card
+    // window between specs resolving and tools reporting.
+    mockGetSpecs.mockResolvedValueOnce([makeSpec("git")]);
+    let resolveTool: (value: unknown) => void;
+    const pendingTool = new Promise((resolve) => {
+      resolveTool = resolve;
+    });
+    mockCheckTool.mockReturnValueOnce(pendingTool);
+
+    vi.spyOn(document, "hasFocus").mockReturnValue(true);
+
+    await act(async () => {
+      window.dispatchEvent(new Event("focus"));
+    });
+
+    // Specs have re-resolved. While checkTool is still pending, the prior
+    // resolved result must remain in checkStates — not flash back to loading.
+    await waitFor(() => {
+      expect(mockGetSpecs).toHaveBeenCalledTimes(2);
+    });
+    expect(result.current.checkStates.git).toMatchObject({ available: true });
+
+    // Let the tool result resolve and the check settle.
+    await act(async () => {
+      resolveTool!(makeResult("git"));
+      await Promise.resolve();
+    });
+
+    await waitFor(() => {
+      expect(result.current.isChecking).toBe(false);
+    });
+  });
+
+  it("drops checkStates entries for tools removed from the spec list on re-check", async () => {
+    // First check has git + node. Both available.
+    mockGetSpecs.mockResolvedValueOnce([makeSpec("git"), makeSpec("node")]);
+    mockCheckTool.mockResolvedValueOnce(makeResult("git"));
+    mockCheckTool.mockResolvedValueOnce(makeResult("node"));
+
+    const { result } = renderHook(() => useSystemHealthCheck());
+
+    await waitFor(() => {
+      expect(result.current.checkStates.git).toMatchObject({ available: true });
+      expect(result.current.checkStates.node).toMatchObject({ available: true });
+    });
+
+    // Second check returns only git — node is gone from the spec list.
+    mockGetSpecs.mockResolvedValueOnce([makeSpec("git")]);
+    mockCheckTool.mockResolvedValueOnce(makeResult("git"));
+
+    vi.spyOn(document, "hasFocus").mockReturnValue(true);
+
+    await act(async () => {
+      window.dispatchEvent(new Event("focus"));
+    });
+
+    await waitFor(() => {
+      expect(mockGetSpecs).toHaveBeenCalledTimes(2);
+      expect(result.current.checkStates.node).toBeUndefined();
+      expect(result.current.checkStates.git).toMatchObject({ available: true });
+    });
+  });
+
   it("does not start a parallel check if one is already in flight (isCheckingRef guard)", async () => {
     let resolveSpecs: (value: unknown) => void;
     const pending = new Promise((resolve) => {

--- a/src/components/Setup/useSystemHealthCheck.ts
+++ b/src/components/Setup/useSystemHealthCheck.ts
@@ -51,9 +51,16 @@ export function useSystemHealthCheck(): SystemHealthCheckState {
       if (!activeRef.current) return;
 
       setSpecs(resolvedSpecs);
-      setCheckStates(() =>
-        Object.fromEntries(resolvedSpecs.map((s) => [s.tool, "loading" as const]))
-      );
+      // Stale-while-revalidate: keep prior results for tools still in the spec
+      // list, drop entries for tools no longer present, mark net-new tools as
+      // loading. Per-card results are then overwritten as runPool completes.
+      setCheckStates((prev) => {
+        const next: Record<string, CheckState> = {};
+        for (const s of resolvedSpecs) {
+          next[s.tool] = prev[s.tool] ?? "loading";
+        }
+        return next;
+      });
 
       await runPool(resolvedSpecs, POOL_CONCURRENCY, async (spec) => {
         try {

--- a/src/components/Setup/useSystemHealthCheck.ts
+++ b/src/components/Setup/useSystemHealthCheck.ts
@@ -45,15 +45,15 @@ export function useSystemHealthCheck(): SystemHealthCheckState {
     isCheckingRef.current = true;
     setIsChecking(true);
     setError(null);
-    setSpecs([]);
-    setCheckStates({});
 
     try {
       const resolvedSpecs = await systemClient.getHealthCheckSpecs();
       if (!activeRef.current) return;
 
       setSpecs(resolvedSpecs);
-      setCheckStates(Object.fromEntries(resolvedSpecs.map((s) => [s.tool, "loading" as const])));
+      setCheckStates(() =>
+        Object.fromEntries(resolvedSpecs.map((s) => [s.tool, "loading" as const]))
+      );
 
       await runPool(resolvedSpecs, POOL_CONCURRENCY, async (spec) => {
         try {


### PR DESCRIPTION
## Summary

- Three accordion buttons in the setup wizard were missing `aria-expanded`, breaking the screen-reader disclosure pattern
- The docs link in `AgentCliStep` used `<span role="link">` with a manual `onKeyDown` polyfill — replaced with a real `<button>`
- `useSystemHealthCheck` blanked `specs` and `checkStates` at the top of every `runCheck` call, so window-focus re-checks caused all prerequisite cards to flash empty for one render cycle

Resolves #7261

## Changes

- `useSystemHealthCheck.ts` — stale-while-revalidate: prior `checkStates` are merged in rather than cleared on re-check
- `SystemRequirementsSection.tsx` — `aria-expanded` + `aria-controls` on the section accordion button, matching `id` on the panel
- `SystemToolsStep.tsx` — `aria-expanded` + `aria-controls` on each "How to install" toggle; install panel always rendered when `installBlocks` is truthy, visibility toggled via `hidden`
- `AgentCliStep.tsx` — `<span role="link">` replaced with `<button>`; `aria-expanded` + `aria-controls` on "Show error log"; `<pre>` always rendered when `errorLog` is truthy, toggled via `hidden`
- `useSystemHealthCheck.test.ts` — three new regression tests covering `checkStates` preservation across `getHealthCheckSpecs` and `checkTool` windows, and correct dropping of removed tools

## Testing

- `npm run check` passes (typecheck, prettier, lint, channel drift, build)
- Vitest: 8 tests pass (5 existing + 3 new) in `useSystemHealthCheck.test.ts`
- Lint warning count: 865 (down 12 from baseline)