### PR TITLE
fix(panel-header): drop preventDefault on double-click mousedown

### DIFF
--- a/src/components/Panel/PanelHeader.tsx
+++ b/src/components/Panel/PanelHeader.tsx
@@ -359,20 +359,6 @@ function PanelHeaderComponent({
     }
   };
 
-  const handleContainerMouseDown = (e: React.MouseEvent<HTMLDivElement>) => {
-    // Forward to dnd-kit's mousedown listener first — it bails out if
-    // `defaultPrevented` is already set, so our preventDefault must come after.
-    dragListeners?.onMouseDown?.(e);
-    // Suppress the browser's word-selection default on the second mousedown
-    // of a double-click. Without this, toggling focus mode mid-gesture lets
-    // the second mousedown land on a sibling pane (revealed by the slide
-    // animation) and select its text — issue #6978. Skip when the target is
-    // an editable element so title-rename word-selection still works.
-    if (e.detail >= 2 && !(e.target as HTMLElement).closest("input, textarea")) {
-      e.preventDefault();
-    }
-  };
-
   const getAriaLabel = () => {
     if (kind === "browser") return "Edit browser title";
     if (!chrome.isAgent && kind === "terminal") return "Edit terminal title";
@@ -567,7 +553,6 @@ function PanelHeaderComponent({
         isPinged && !isMaximized && "animate-terminal-header-ping",
         isDragging && "pointer-events-none"
       )}
-      onMouseDown={handleContainerMouseDown}
       onDoubleClick={handleHeaderDoubleClick}
     >
       {/* Tab bar - shown when there are multiple tabs */}

--- a/src/components/Panel/__tests__/PanelHeader.test.tsx
+++ b/src/components/Panel/__tests__/PanelHeader.test.tsx
@@ -567,42 +567,21 @@ describe("PanelHeader", () => {
     });
   });
 
-  describe("mousedown selection guard (#6978)", () => {
-    it("calls preventDefault on the second mousedown of a double-click", () => {
+  describe("mousedown handling", () => {
+    it("does not call preventDefault on a double-click mousedown (#7279)", () => {
+      // Calling preventDefault on the second mousedown of a double-click
+      // suppressed the resulting click and left armed-fleet panels stuck
+      // unclickable. Text-selection prevention is handled by the `select-none`
+      // CSS class on the container instead — see #6978 / #7279.
       const { container } = render(<PanelHeader {...makeProps({ location: "grid" })} />);
       const header = container.firstElementChild as HTMLElement;
       const event = new MouseEvent("mousedown", { bubbles: true, cancelable: true, detail: 2 });
-      const preventDefault = vi.spyOn(event, "preventDefault");
       header.dispatchEvent(event);
-      expect(preventDefault).toHaveBeenCalled();
+      expect(event.defaultPrevented).toBe(false);
     });
 
-    it("does not call preventDefault on a single mousedown", () => {
-      const { container } = render(<PanelHeader {...makeProps({ location: "grid" })} />);
-      const header = container.firstElementChild as HTMLElement;
-      const event = new MouseEvent("mousedown", { bubbles: true, cancelable: true, detail: 1 });
-      const preventDefault = vi.spyOn(event, "preventDefault");
-      header.dispatchEvent(event);
-      expect(preventDefault).not.toHaveBeenCalled();
-    });
-
-    it("calls preventDefault on triple-click mousedowns as well", () => {
-      const { container } = render(<PanelHeader {...makeProps({ location: "grid" })} />);
-      const header = container.firstElementChild as HTMLElement;
-      const event = new MouseEvent("mousedown", { bubbles: true, cancelable: true, detail: 3 });
-      const preventDefault = vi.spyOn(event, "preventDefault");
-      header.dispatchEvent(event);
-      expect(preventDefault).toHaveBeenCalled();
-    });
-
-    it("forwards mousedown to the dnd-kit drag listener before preventDefault runs", () => {
-      // Order is load-bearing: dnd-kit's MouseSensor bails on `defaultPrevented`,
-      // so our preventDefault must come after. Capture `defaultPrevented` at the
-      // moment dnd-kit sees the event to lock that contract in place.
-      const seenDefaultPrevented: boolean[] = [];
-      const dragMouseDown = vi.fn((e: unknown) => {
-        seenDefaultPrevented.push((e as { defaultPrevented: boolean }).defaultPrevented);
-      });
+    it("forwards all mousedowns to the dnd-kit drag listener", () => {
+      const dragMouseDown = vi.fn();
       mockDragHandle = { listeners: { onMouseDown: dragMouseDown } };
       try {
         const { container } = render(<PanelHeader {...makeProps({ location: "grid" })} />);
@@ -610,39 +589,12 @@ describe("PanelHeader", () => {
         fireEvent.mouseDown(header, { detail: 1 });
         fireEvent.mouseDown(header, { detail: 2 });
         expect(dragMouseDown).toHaveBeenCalledTimes(2);
-        expect(seenDefaultPrevented).toEqual([false, false]);
       } finally {
         mockDragHandle = null;
       }
     });
 
-    it("does not preventDefault on double-click inside an input (title rename)", () => {
-      // Word-selection inside the title-rename input must still work — the
-      // selection-suppression guard only applies to the chrome itself.
-      const onEditingValueChange = vi.fn();
-      const onTitleSave = vi.fn();
-      const onTitleInputKeyDown = vi.fn();
-      const { container } = render(
-        <PanelHeader
-          {...makeProps({
-            location: "grid",
-            isEditingTitle: true,
-            editingValue: "Some title",
-            onEditingValueChange,
-            onTitleSave,
-            onTitleInputKeyDown,
-          })}
-        />
-      );
-      const input = container.querySelector("input[type='text']") as HTMLInputElement;
-      expect(input).not.toBeNull();
-      const event = new MouseEvent("mousedown", { bubbles: true, cancelable: true, detail: 2 });
-      const preventDefault = vi.spyOn(event, "preventDefault");
-      input.dispatchEvent(event);
-      expect(preventDefault).not.toHaveBeenCalled();
-    });
-
-    it("applies select-none to the header container", () => {
+    it("applies select-none to the header container (#6978 selection guard)", () => {
       const { container } = render(<PanelHeader {...makeProps({ location: "grid" })} />);
       const header = container.firstElementChild as HTMLElement;
       expect(header.className).toContain("select-none");


### PR DESCRIPTION
## Summary

- `handleContainerMouseDown` in `PanelHeader.tsx` called `e.preventDefault()` when `e.detail >= 2`, which suppressed the resulting click event and left dnd-kit in a wedged state — making the double-clicked panel unclickable for the rest of the session.
- The handler was added for #6978 to suppress text selection during the focus-mode slide animation. The `select-none` class on the container already handles that at the CSS level, so `preventDefault` was never needed.
- Deleted the handler entirely. Tests updated: removed the four `preventDefault`-asserting specs, added a #7279 regression guard confirming `defaultPrevented === false` on a simulated double-click mousedown.

Resolves #7279

## Changes

- `src/components/Panel/PanelHeader.tsx` — deleted `handleContainerMouseDown` (13 lines) and removed the `onMouseDown` prop; `{...dragListeners}` already provides the correct `onMouseDown`.
- `src/components/Panel/__tests__/PanelHeader.test.tsx` — replaced the four `preventDefault` tests with a single regression guard; kept the `select-none` class assertion as the #6978 selection guard.

## Testing

- `npx vitest run src/components/Panel/__tests__/PanelHeader.test.tsx` — all 48 tests pass.
- `npm run check` — clean (typecheck, lint, format, build).