### PR TITLE
fix(error-boundary): polish top-level fallback for release

### DIFF
--- a/e2e/full/core-error-boundaries.spec.ts
+++ b/e2e/full/core-error-boundaries.spec.ts
@@ -36,12 +36,12 @@ test.describe.serial("Core: Error Boundaries", () => {
     await expect(window.locator(SEL.errorBoundary.title)).toContainText(
       "Daintree hit an unrecoverable error"
     );
-    await expect(window.locator(SEL.errorBoundary.restartButton)).toContainText("Reload window");
+    await expect(window.locator(SEL.errorBoundary.restartButton)).toContainText("Try again");
     await expect(window.locator(SEL.errorBoundary.reportButton)).toBeVisible();
     await expect(window.locator(SEL.errorBoundary.logsButton)).toBeVisible();
   });
 
-  test("Reload window button recovers the app", async () => {
+  test("Try again button recovers the app", async () => {
     const { window } = ctx;
 
     // Fallback should still be visible from previous test

--- a/src/components/ErrorBoundary/ErrorBoundary.tsx
+++ b/src/components/ErrorBoundary/ErrorBoundary.tsx
@@ -27,11 +27,15 @@ interface ErrorBoundaryState {
   error: Error | null;
   errorInfo: React.ErrorInfo | null;
   incidentId: string | null;
+  reportInFlight: boolean;
 }
 
 export class ErrorBoundary extends Component<ErrorBoundaryProps, ErrorBoundaryState> {
-  // Guards against double-fire when the user clicks "Report Issue" twice
-  // before the async clipboard/openExternal chain completes.
+  // Synchronous guard against same-tick double-clicks on "Report issue".
+  // setState is batched, so two clicks in one event tick can both observe
+  // `state.reportInFlight === false`. The class field flips synchronously
+  // and prevents the underlying async chain from firing twice; the React
+  // state drives the visible `disabled` prop on the button.
   private reportInFlight = false;
 
   constructor(props: ErrorBoundaryProps) {
@@ -41,6 +45,7 @@ export class ErrorBoundary extends Component<ErrorBoundaryProps, ErrorBoundarySt
       error: null,
       errorInfo: null,
       incidentId: null,
+      reportInFlight: false,
     };
   }
 
@@ -54,10 +59,6 @@ export class ErrorBoundary extends Component<ErrorBoundaryProps, ErrorBoundarySt
   componentDidCatch(error: Error, errorInfo: React.ErrorInfo): void {
     const { onError, context, componentName } = this.props;
     const componentStack = errorInfo.componentStack || "";
-
-    this.setState({
-      errorInfo,
-    });
 
     const correlationId = crypto.randomUUID();
 
@@ -110,8 +111,6 @@ export class ErrorBoundary extends Component<ErrorBoundaryProps, ErrorBoundarySt
       componentStack,
       incidentId,
     });
-
-    logError("ErrorBoundary caught error", error, { errorInfo });
   }
 
   componentDidUpdate(prevProps: ErrorBoundaryProps): void {
@@ -146,12 +145,14 @@ export class ErrorBoundary extends Component<ErrorBoundaryProps, ErrorBoundarySt
       error: null,
       errorInfo: null,
       incidentId: null,
+      reportInFlight: false,
     });
   };
 
   handleReport = async (): Promise<void> => {
     if (this.reportInFlight) return;
     this.reportInFlight = true;
+    this.setState({ reportInFlight: true });
     try {
       const { error, errorInfo, incidentId } = this.state;
       const { componentName, context } = this.props;
@@ -210,11 +211,12 @@ export class ErrorBoundary extends Component<ErrorBoundaryProps, ErrorBoundarySt
       }
     } finally {
       this.reportInFlight = false;
+      this.setState({ reportInFlight: false });
     }
   };
 
   render(): ReactNode {
-    const { hasError, error, errorInfo, incidentId } = this.state;
+    const { hasError, error, errorInfo, incidentId, reportInFlight } = this.state;
     const { children, fallback: FallbackComponent, variant, componentName } = this.props;
 
     if (hasError && error) {
@@ -229,6 +231,7 @@ export class ErrorBoundary extends Component<ErrorBoundaryProps, ErrorBoundarySt
           componentName={componentName}
           incidentId={incidentId}
           onReport={variant !== "component" ? this.handleReport : undefined}
+          reportInFlight={reportInFlight}
         />
       );
     }

--- a/src/components/ErrorBoundary/ErrorBoundary.tsx
+++ b/src/components/ErrorBoundary/ErrorBoundary.tsx
@@ -140,6 +140,10 @@ export class ErrorBoundary extends Component<ErrorBoundaryProps, ErrorBoundarySt
       }
     }
 
+    // Reset the synchronous class-field guard alongside state so a hung
+    // report from the previous error session doesn't permanently disable
+    // the Report issue button after recovery.
+    this.reportInFlight = false;
     this.setState({
       hasError: false,
       error: null,

--- a/src/components/ErrorBoundary/ErrorFallback.tsx
+++ b/src/components/ErrorBoundary/ErrorFallback.tsx
@@ -1,5 +1,6 @@
 import { cn } from "@/lib/utils";
 import { actionService } from "@/services/ActionService";
+import { useCopyWithFeedback } from "@/hooks/useCopyWithFeedback";
 import { TriangleAlert } from "lucide-react";
 
 export interface ErrorFallbackProps {
@@ -10,6 +11,7 @@ export interface ErrorFallbackProps {
   componentName?: string;
   incidentId?: string | null;
   onReport?: () => void | Promise<void>;
+  reportInFlight?: boolean;
 }
 
 const VARIANT_STYLES = {
@@ -48,18 +50,36 @@ export function ErrorFallback({
   componentName,
   incidentId,
   onReport,
+  reportInFlight = false,
 }: ErrorFallbackProps) {
   const sizes = VARIANT_SIZES[variant];
+  const { copied: incidentIdCopied, copy: copyIncidentId } = useCopyWithFeedback({
+    announcement: "Error ID copied",
+  });
 
   const handleOpenLogs = () => {
     void actionService.dispatch("logs.openFile", undefined, { source: "user" });
   };
+
+  const handleCopyIncidentId = () => {
+    if (!incidentId) return;
+    void copyIncidentId(incidentId);
+  };
+
+  const isFullscreen = variant === "fullscreen";
 
   return (
     <div
       className={cn(VARIANT_STYLES[variant])}
       data-testid="error-fallback"
       data-variant={variant}
+      {...(isFullscreen
+        ? {
+            role: "alertdialog",
+            "aria-modal": true,
+            "aria-labelledby": "error-fallback-title",
+          }
+        : {})}
     >
       <div className="flex flex-col items-center gap-4 max-w-2xl">
         <TriangleAlert className={cn("text-status-error", sizes.icon)} />
@@ -68,6 +88,7 @@ export function ErrorFallback({
           <h2
             className={cn("font-semibold text-status-error", sizes.title)}
             data-testid="error-fallback-title"
+            {...(isFullscreen ? { id: "error-fallback-title" } : {})}
           >
             {variant === "fullscreen" && "Daintree hit an unrecoverable error"}
             {variant === "section" && `${componentName || "Section"} stopped working`}
@@ -86,7 +107,16 @@ export function ErrorFallback({
 
           {!import.meta.env.DEV && incidentId && variant !== "component" && (
             <p className={cn("text-daintree-text/50 font-mono break-all", sizes.message)}>
-              Error ID: {incidentId}
+              Error ID:{" "}
+              <button
+                type="button"
+                onClick={handleCopyIncidentId}
+                aria-label="Copy error ID"
+                data-testid="error-fallback-copy-id"
+                className="cursor-copy hover:text-daintree-text/80 transition-colors text-left break-all"
+              >
+                {incidentIdCopied ? "Copied" : incidentId}
+              </button>
             </p>
           )}
         </div>
@@ -96,13 +126,14 @@ export function ErrorFallback({
             type="button"
             onClick={resetError}
             data-testid="error-fallback-restart"
+            autoFocus={isFullscreen}
             className={cn(
               "bg-status-error hover:bg-[color-mix(in_oklab,var(--color-status-error)_85%,transparent)] text-daintree-bg rounded transition-colors",
               sizes.button
             )}
           >
             {variant === "fullscreen"
-              ? "Reload window"
+              ? "Try again"
               : variant === "section"
                 ? "Reload pane"
                 : "Try again"}
@@ -112,9 +143,11 @@ export function ErrorFallback({
             <button
               type="button"
               onClick={onReport}
+              disabled={reportInFlight}
               data-testid="error-fallback-report"
               className={cn(
                 "bg-daintree-border hover:bg-daintree-border/80 text-daintree-text rounded transition-colors",
+                "disabled:opacity-60 disabled:cursor-not-allowed",
                 sizes.button
               )}
             >

--- a/src/components/ErrorBoundary/__tests__/ErrorBoundary.test.tsx
+++ b/src/components/ErrorBoundary/__tests__/ErrorBoundary.test.tsx
@@ -418,6 +418,67 @@ describe("ErrorBoundary", () => {
     await waitFor(() => expect(button.disabled).toBe(false));
   });
 
+  it("clears the in-flight guard on reset so a new report can fire after recovery", async () => {
+    // Pin actionService.dispatch to a never-resolving promise — simulates a
+    // hung report. Without the field reset, the second click after recovery
+    // would be silently swallowed by the still-true class-field guard.
+    let resolveFirst: ((value: { ok: boolean }) => void) | undefined;
+    vi.mocked(actionService.dispatch)
+      .mockImplementationOnce(
+        () =>
+          new Promise<{ ok: boolean }>((resolve) => {
+            resolveFirst = resolve;
+          })
+      )
+      .mockResolvedValueOnce({ ok: true });
+
+    let shouldThrow = true;
+    function ConditionalThrow() {
+      if (shouldThrow) {
+        const error = new Error("Component blew up");
+        error.stack =
+          "Error: Component blew up\n" +
+          Array.from({ length: 30 }, (_, i) => `    at frame${i} ${"x".repeat(800)}`).join("\n");
+        throw error;
+      }
+      return <div>Recovered</div>;
+    }
+
+    const { rerender } = render(
+      <ErrorBoundary variant="section">
+        <ConditionalThrow />
+      </ErrorBoundary>
+    );
+
+    fireEvent.click(screen.getByText("Report issue")); // first click — hangs
+    await Promise.resolve();
+    await Promise.resolve();
+    expect(actionService.dispatch).toHaveBeenCalledTimes(1);
+
+    // User gives up and recovers the pane while the first report is still in flight.
+    shouldThrow = false;
+    fireEvent.click(screen.getByText("Reload pane"));
+    expect(screen.getByText("Recovered")).toBeTruthy();
+
+    // Re-arm the throw and re-render to bring the fallback back.
+    shouldThrow = true;
+    rerender(
+      <ErrorBoundary variant="section">
+        <ConditionalThrow />
+      </ErrorBoundary>
+    );
+    expect(screen.getByText("Section stopped working")).toBeTruthy();
+
+    // Second click should now fire — the class-field guard was cleared on reset.
+    fireEvent.click(screen.getByText("Report issue"));
+    await Promise.resolve();
+    await Promise.resolve();
+    await Promise.resolve();
+    expect(actionService.dispatch).toHaveBeenCalledTimes(2);
+
+    resolveFirst?.({ ok: true });
+  });
+
   it("does not log the duplicate 'ErrorBoundary caught error' message", async () => {
     const { logError } = await import("@/utils/logger");
 

--- a/src/components/ErrorBoundary/__tests__/ErrorBoundary.test.tsx
+++ b/src/components/ErrorBoundary/__tests__/ErrorBoundary.test.tsx
@@ -386,10 +386,10 @@ describe("ErrorBoundary", () => {
   });
 
   it("disables the Report issue button while the report is in flight", async () => {
-    let resolveDispatch: ((value: { ok: boolean }) => void) | undefined;
+    let resolveDispatch: ((value: { ok: true; result: undefined }) => void) | undefined;
     vi.mocked(actionService.dispatch).mockImplementationOnce(
       () =>
-        new Promise<{ ok: boolean }>((resolve) => {
+        new Promise<{ ok: true; result: undefined }>((resolve) => {
           resolveDispatch = resolve;
         })
     );
@@ -414,7 +414,7 @@ describe("ErrorBoundary", () => {
     fireEvent.click(button);
     await waitFor(() => expect(button.disabled).toBe(true));
 
-    resolveDispatch?.({ ok: true });
+    resolveDispatch?.({ ok: true, result: undefined });
     await waitFor(() => expect(button.disabled).toBe(false));
   });
 
@@ -422,15 +422,15 @@ describe("ErrorBoundary", () => {
     // Pin actionService.dispatch to a never-resolving promise — simulates a
     // hung report. Without the field reset, the second click after recovery
     // would be silently swallowed by the still-true class-field guard.
-    let resolveFirst: ((value: { ok: boolean }) => void) | undefined;
+    let resolveFirst: ((value: { ok: true; result: undefined }) => void) | undefined;
     vi.mocked(actionService.dispatch)
       .mockImplementationOnce(
         () =>
-          new Promise<{ ok: boolean }>((resolve) => {
+          new Promise<{ ok: true; result: undefined }>((resolve) => {
             resolveFirst = resolve;
           })
       )
-      .mockResolvedValueOnce({ ok: true });
+      .mockResolvedValueOnce({ ok: true, result: undefined });
 
     let shouldThrow = true;
     function ConditionalThrow() {
@@ -476,7 +476,7 @@ describe("ErrorBoundary", () => {
     await Promise.resolve();
     expect(actionService.dispatch).toHaveBeenCalledTimes(2);
 
-    resolveFirst?.({ ok: true });
+    resolveFirst?.({ ok: true, result: undefined });
   });
 
   it("does not log the duplicate 'ErrorBoundary caught error' message", async () => {

--- a/src/components/ErrorBoundary/__tests__/ErrorBoundary.test.tsx
+++ b/src/components/ErrorBoundary/__tests__/ErrorBoundary.test.tsx
@@ -1,6 +1,6 @@
 // @vitest-environment jsdom
 import type React from "react";
-import { render, screen, fireEvent } from "@testing-library/react";
+import { render, screen, fireEvent, waitFor } from "@testing-library/react";
 import { describe, expect, it, vi, beforeEach, afterEach } from "vitest";
 import { ErrorBoundary, withErrorBoundary } from "../ErrorBoundary";
 import { useErrorStore } from "@/store/errorStore";
@@ -197,7 +197,8 @@ describe("ErrorBoundary", () => {
       </ErrorBoundary>
     );
 
-    expect(screen.getByText("Error ID: sentry-event-deadbeef")).toBeTruthy();
+    const copyButton = screen.getByTestId("error-fallback-copy-id");
+    expect(copyButton.textContent).toBe("sentry-event-deadbeef");
     expect(screen.queryByText("Test render error")).toBeNull();
     expect(
       screen.getByText("This pane crashed but the rest of Daintree is still running.")
@@ -216,7 +217,8 @@ describe("ErrorBoundary", () => {
 
     const errors = useErrorStore.getState().errors;
     const storeId = errors[0]!.id;
-    expect(screen.getByText(`Error ID: ${storeId}`)).toBeTruthy();
+    const copyButton = screen.getByTestId("error-fallback-copy-id");
+    expect(copyButton.textContent).toBe(storeId);
   });
 
   it("dispatches a full-body deeplink when the report fits the URL budget", async () => {
@@ -381,6 +383,55 @@ describe("ErrorBoundary", () => {
     const electron = getElectronMock();
     expect(electron.clipboard?.writeText).toHaveBeenCalledTimes(1);
     expect(actionService.dispatch).toHaveBeenCalledTimes(1);
+  });
+
+  it("disables the Report issue button while the report is in flight", async () => {
+    let resolveDispatch: ((value: { ok: boolean }) => void) | undefined;
+    vi.mocked(actionService.dispatch).mockImplementationOnce(
+      () =>
+        new Promise<{ ok: boolean }>((resolve) => {
+          resolveDispatch = resolve;
+        })
+    );
+
+    function ThrowGiantStack(): React.ReactElement {
+      const error = new Error("Component blew up");
+      error.stack =
+        "Error: Component blew up\n" +
+        Array.from({ length: 30 }, (_, i) => `    at frame${i} ${"x".repeat(800)}`).join("\n");
+      throw error;
+    }
+
+    render(
+      <ErrorBoundary variant="section">
+        <ThrowGiantStack />
+      </ErrorBoundary>
+    );
+
+    const button = screen.getByTestId("error-fallback-report") as HTMLButtonElement;
+    expect(button.disabled).toBe(false);
+
+    fireEvent.click(button);
+    await waitFor(() => expect(button.disabled).toBe(true));
+
+    resolveDispatch?.({ ok: true });
+    await waitFor(() => expect(button.disabled).toBe(false));
+  });
+
+  it("does not log the duplicate 'ErrorBoundary caught error' message", async () => {
+    const { logError } = await import("@/utils/logger");
+
+    render(
+      <ErrorBoundary variant="section">
+        <ThrowingChild shouldThrow={true} />
+      </ErrorBoundary>
+    );
+
+    expect(logError).not.toHaveBeenCalledWith(
+      "ErrorBoundary caught error",
+      expect.anything(),
+      expect.anything()
+    );
   });
 
   it("does nothing when window.electron is unavailable entirely", async () => {

--- a/src/components/ErrorBoundary/__tests__/ErrorFallback.test.tsx
+++ b/src/components/ErrorBoundary/__tests__/ErrorFallback.test.tsx
@@ -1,8 +1,9 @@
 // @vitest-environment jsdom
-import { render, screen, fireEvent } from "@testing-library/react";
+import { render, screen, fireEvent, waitFor } from "@testing-library/react";
 import { describe, expect, it, vi, beforeEach, afterEach } from "vitest";
 import { ErrorFallback } from "../ErrorFallback";
 import { actionService } from "@/services/ActionService";
+import { useAnnouncerStore } from "@/store/accessibilityAnnouncerStore";
 
 vi.mock("@/services/ActionService", () => ({
   actionService: {
@@ -13,6 +14,15 @@ vi.mock("@/services/ActionService", () => ({
 vi.mock("@/lib/utils", () => ({
   cn: (...args: unknown[]) => args.filter(Boolean).join(" "),
 }));
+
+function installClipboardMock(): { writeText: ReturnType<typeof vi.fn> } {
+  const writeText = vi.fn().mockResolvedValue(undefined);
+  Object.defineProperty(navigator, "clipboard", {
+    configurable: true,
+    value: { writeText },
+  });
+  return { writeText };
+}
 
 describe("ErrorFallback", () => {
   const baseProps = {
@@ -28,6 +38,8 @@ describe("ErrorFallback", () => {
 
   beforeEach(() => {
     vi.clearAllMocks();
+    installClipboardMock();
+    useAnnouncerStore.setState({ polite: null, assertive: null });
   });
 
   afterEach(() => {
@@ -51,9 +63,11 @@ describe("ErrorFallback", () => {
       ).toBeTruthy();
     });
 
-    it("displays full incident ID", () => {
+    it("displays full incident ID inside a copy button", () => {
       render(<ErrorFallback {...baseProps} variant="section" />);
-      expect(screen.getByText("Error ID: error-1710000000000-a3f7b2x")).toBeTruthy();
+      const copyButton = screen.getByTestId("error-fallback-copy-id");
+      expect(copyButton.textContent).toBe("error-1710000000000-a3f7b2x");
+      expect(copyButton.getAttribute("aria-label")).toBe("Copy error ID");
     });
 
     it("does not render technical details", () => {
@@ -158,10 +172,112 @@ describe("ErrorFallback", () => {
       });
     });
 
-    it("shows Reload window text for fullscreen variant", () => {
+    it("shows Try again text for fullscreen variant", () => {
       vi.stubEnv("DEV", false);
       render(<ErrorFallback {...baseProps} variant="fullscreen" />);
-      expect(screen.getByText("Reload window")).toBeTruthy();
+      const restart = screen.getByTestId("error-fallback-restart");
+      expect(restart.textContent).toBe("Try again");
+    });
+
+    it("disables Report issue button while reportInFlight is true", () => {
+      vi.stubEnv("DEV", false);
+      const onReport = vi.fn();
+      render(
+        <ErrorFallback {...baseProps} variant="section" onReport={onReport} reportInFlight={true} />
+      );
+      const button = screen.getByTestId("error-fallback-report") as HTMLButtonElement;
+      expect(button.disabled).toBe(true);
+    });
+
+    it("enables Report issue button when reportInFlight is false", () => {
+      vi.stubEnv("DEV", false);
+      const onReport = vi.fn();
+      render(
+        <ErrorFallback
+          {...baseProps}
+          variant="section"
+          onReport={onReport}
+          reportInFlight={false}
+        />
+      );
+      const button = screen.getByTestId("error-fallback-report") as HTMLButtonElement;
+      expect(button.disabled).toBe(false);
+    });
+  });
+
+  describe("fullscreen accessibility", () => {
+    beforeEach(() => {
+      vi.stubEnv("DEV", false);
+    });
+
+    it("renders alertdialog role and aria-modal on the fullscreen container", () => {
+      render(<ErrorFallback {...baseProps} variant="fullscreen" />);
+      const container = screen.getByTestId("error-fallback");
+      expect(container.getAttribute("role")).toBe("alertdialog");
+      expect(container.getAttribute("aria-modal")).toBe("true");
+      expect(container.getAttribute("aria-labelledby")).toBe("error-fallback-title");
+      const title = screen.getByTestId("error-fallback-title");
+      expect(title.id).toBe("error-fallback-title");
+    });
+
+    it("does not apply alertdialog role to section variant", () => {
+      render(<ErrorFallback {...baseProps} variant="section" />);
+      const container = screen.getByTestId("error-fallback");
+      expect(container.getAttribute("role")).toBeNull();
+      expect(container.getAttribute("aria-modal")).toBeNull();
+      expect(container.getAttribute("aria-labelledby")).toBeNull();
+    });
+
+    it("does not apply alertdialog role to component variant", () => {
+      render(<ErrorFallback {...baseProps} variant="component" />);
+      const container = screen.getByTestId("error-fallback");
+      expect(container.getAttribute("role")).toBeNull();
+    });
+
+    it("does not assign id to the title for section variant (avoids duplicate IDs)", () => {
+      render(<ErrorFallback {...baseProps} variant="section" />);
+      const title = screen.getByTestId("error-fallback-title");
+      expect(title.id).toBe("");
+    });
+
+    it("auto-focuses the primary action button on fullscreen variant", () => {
+      render(<ErrorFallback {...baseProps} variant="fullscreen" />);
+      expect(document.activeElement).toBe(screen.getByTestId("error-fallback-restart"));
+    });
+  });
+
+  describe("copy error ID button", () => {
+    beforeEach(() => {
+      vi.stubEnv("DEV", false);
+    });
+
+    it("writes the incident ID to the clipboard on click", async () => {
+      const { writeText } = installClipboardMock();
+      render(<ErrorFallback {...baseProps} variant="section" />);
+      fireEvent.click(screen.getByTestId("error-fallback-copy-id"));
+      await waitFor(() => {
+        expect(writeText).toHaveBeenCalledWith("error-1710000000000-a3f7b2x");
+      });
+    });
+
+    it("flips the visible label to 'Copied' after a successful copy", async () => {
+      render(<ErrorFallback {...baseProps} variant="section" />);
+      const button = screen.getByTestId("error-fallback-copy-id");
+      fireEvent.click(button);
+      await waitFor(() => {
+        expect(button.textContent).toBe("Copied");
+      });
+    });
+
+    it("keeps aria-label constant on the copy button (avoids double-announce)", async () => {
+      render(<ErrorFallback {...baseProps} variant="section" />);
+      const button = screen.getByTestId("error-fallback-copy-id");
+      expect(button.getAttribute("aria-label")).toBe("Copy error ID");
+      fireEvent.click(button);
+      await waitFor(() => {
+        expect(button.textContent).toBe("Copied");
+      });
+      expect(button.getAttribute("aria-label")).toBe("Copy error ID");
     });
   });
 


### PR DESCRIPTION
## Summary

- Adds `role="alertdialog"`, `aria-modal`, `aria-labelledby`, and `autoFocus` to the fullscreen variant so screen readers announce it correctly and focus lands in the dialog on mount
- Renames the primary action from `Reload window` to `Try again` per microcopy rules; adds a copy-to-clipboard button for the Error ID using `useCopyWithFeedback`
- Moves `reportInFlight` to React state so the Report Issue button correctly renders disabled while the async chain runs; removes a redundant `setState` and a duplicate `logError` call in `componentDidCatch`

Resolves #7240

## Changes

- `ErrorFallback.tsx` — ARIA role/attributes and `autoFocus` on fullscreen variant; `Try again` label; copy-to-clipboard Error ID button
- `ErrorBoundary.tsx` — `reportInFlight` promoted to state; sync guard still a class field; `resetError` clears both; redundant `setState` and duplicate `logError` removed from `componentDidCatch`
- `__tests__/ErrorBoundary.test.tsx`, `__tests__/ErrorFallback.test.tsx` — 72 passing; new coverage for ARIA attributes, `autoFocus`, copy button, disabled state, sync guard reset, and duplicate-log absence
- `e2e/full/core-error-boundaries.spec.ts` — updated selector to match `Try again`

## Testing

Unit test suite passes (72 tests). E2e spec updated to match the new button label. Accessibility changes follow the WAI-ARIA alertdialog pattern.