### PR TITLE
fix(browser): polish toolbar and load-state visuals

### DIFF
--- a/src/components/Browser/BrowserPane.tsx
+++ b/src/components/Browser/BrowserPane.tsx
@@ -38,6 +38,8 @@ import { useProjectStore } from "@/store";
 import { useProjectSettingsStore } from "@/store/projectSettingsStore";
 import { useProjectSettings } from "@/hooks/useProjectSettings";
 import { useFindInPage } from "@/hooks/useFindInPage";
+import { useDeferredLoading } from "@/hooks/useDeferredLoading";
+import { UI_DOHERTY_THRESHOLD } from "@/lib/animationUtils";
 import { logError } from "@/utils/logger";
 
 export interface BrowserPaneProps extends BasePanelProps {
@@ -167,6 +169,8 @@ export function BrowserPane({
   });
 
   const [isLoading, setIsLoading] = useState(true);
+  // Doherty 400ms gate: skip loading affordances on fast loads to prevent flicker.
+  const showLoadingOverlay = useDeferredLoading(isLoading, UI_DOHERTY_THRESHOLD);
   const [loadError, setLoadError] = useState<LoadError | null>(null);
   const [blockedNav, setBlockedNav] = useState<{
     url: string;
@@ -601,7 +605,7 @@ export function BrowserPane({
       url={currentUrl}
       canGoBack={canGoBack}
       canGoForward={canGoForward}
-      isLoading={isLoading}
+      isLoading={showLoadingOverlay}
       zoomFactor={zoomFactor}
       isConsoleOpen={isConsoleOpen}
       isWebviewReady={isWebviewReady}
@@ -828,7 +832,7 @@ export function BrowserPane({
             )}
             <div className="relative flex-1 min-h-0">
               {isDragging && <div className="absolute inset-0 z-10 bg-transparent" />}
-              {isLoading && (
+              {showLoadingOverlay && (
                 <div className="absolute inset-0 flex flex-col items-center justify-center bg-daintree-bg z-10 gap-3">
                   <Spinner size="2xl" className="text-status-info" />
                   {isSlowLoad && (

--- a/src/components/Browser/BrowserToolbar.tsx
+++ b/src/components/Browser/BrowserToolbar.tsx
@@ -7,6 +7,7 @@ import {
   Copy,
   Check,
   Globe,
+  Lock,
   ZoomIn,
   ZoomOut,
   Camera,
@@ -277,6 +278,14 @@ export function BrowserToolbar({
   const canZoomOut = zoomFactor > minZoom + 0.001;
   const canZoomIn = zoomFactor < maxZoom - 0.001;
 
+  const isHttps = useMemo(() => {
+    try {
+      return new URL(url).protocol === "https:";
+    } catch {
+      return false;
+    }
+  }, [url]);
+
   const buttonClass =
     "p-1.5 rounded hover:bg-overlay-medium disabled:opacity-30 disabled:cursor-not-allowed transition-colors";
 
@@ -465,7 +474,17 @@ export function BrowserToolbar({
       <div ref={containerRef} className="relative flex-1 min-w-0">
         <form onSubmit={handleSubmit}>
           <div className="relative flex items-center">
-            <Globe className="absolute left-2 w-3.5 h-3.5 text-daintree-text/40 pointer-events-none" />
+            {isHttps ? (
+              <Lock
+                data-testid="browser-url-scheme-lock"
+                className="absolute left-2 w-3.5 h-3.5 text-daintree-text/40 pointer-events-none"
+              />
+            ) : (
+              <Globe
+                data-testid="browser-url-scheme-globe"
+                className="absolute left-2 w-3.5 h-3.5 text-daintree-text/40 pointer-events-none"
+              />
+            )}
             <input
               ref={inputRef}
               type="text"
@@ -489,6 +508,7 @@ export function BrowserToolbar({
               onBlur={handleBlur}
               onKeyDown={handleKeyDown}
               autoComplete="off"
+              spellCheck={false}
               className={cn(
                 "w-full pl-7 pr-2 py-1 text-xs rounded",
                 "bg-daintree-bg border border-overlay",

--- a/src/components/Browser/__tests__/BrowserToolbar.test.tsx
+++ b/src/components/Browser/__tests__/BrowserToolbar.test.tsx
@@ -357,3 +357,45 @@ describe("BrowserToolbar ARIA semantics", () => {
     expect(label).toMatch(/^Remove .+ from history$/);
   });
 });
+
+describe("BrowserToolbar address-bar scheme icon and input", () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+  });
+
+  it("renders Lock icon when URL scheme is https", () => {
+    const { queryByTestId } = renderToolbar({ url: "https://example.com/" });
+    expect(queryByTestId("browser-url-scheme-lock")).toBeTruthy();
+    expect(queryByTestId("browser-url-scheme-globe")).toBeFalsy();
+  });
+
+  it("renders Globe icon when URL scheme is http", () => {
+    const { queryByTestId } = renderToolbar({ url: "http://localhost:3000/" });
+    expect(queryByTestId("browser-url-scheme-globe")).toBeTruthy();
+    expect(queryByTestId("browser-url-scheme-lock")).toBeFalsy();
+  });
+
+  it("renders Globe icon for malformed URL without throwing", () => {
+    const { queryByTestId } = renderToolbar({ url: "" });
+    expect(queryByTestId("browser-url-scheme-globe")).toBeTruthy();
+    expect(queryByTestId("browser-url-scheme-lock")).toBeFalsy();
+  });
+
+  it("URL input has spellCheck disabled", () => {
+    const { getByTestId } = renderToolbar();
+    const input = getByTestId("browser-address-bar");
+    expect(input.getAttribute("spellcheck")).toBe("false");
+  });
+
+  it("reload button has animate-spin when isLoading is true", () => {
+    const { getByTestId } = renderToolbar({ isLoading: true });
+    const reload = getByTestId("browser-reload");
+    expect(reload.className).toContain("animate-spin");
+  });
+
+  it("reload button does not have animate-spin when isLoading is false", () => {
+    const { getByTestId } = renderToolbar({ isLoading: false });
+    const reload = getByTestId("browser-reload");
+    expect(reload.className).not.toContain("animate-spin");
+  });
+});


### PR DESCRIPTION
## Summary

- Full-pane spinner in `BrowserPane.tsx` is now gated behind the 400ms Doherty threshold via `useDeferredLoading`. Sub-400ms loads show nothing, matching `CLAUDE.md` policy exactly.
- The gated value flows through to `BrowserToolbar`'s `isLoading` prop, keeping the reload button's `animate-spin` and the overlay in sync.
- Address bar leading icon is now conditional: `Lock` for `https:` URLs, `Globe` for everything else. Both at `text-daintree-text/40` — no accent color.
- Added `spellCheck={false}` to the URL input, matching `FindBar.tsx`.

Resolves #7227

## Changes

- `BrowserPane.tsx` — wrap `isLoading` with `useDeferredLoading(isLoading, UI_DOHERTY_THRESHOLD)` before passing to toolbar and spinner
- `BrowserToolbar.tsx` — conditional `Lock`/`Globe` leading icon based on URL scheme; `spellCheck={false}` on URL input
- `BrowserToolbar.test.tsx` — 6 new tests: `Lock`/`Globe` scheme switching, malformed URL fallback, `spellCheck`, `animate-spin` presence on `isLoading`

## Testing

Vitest 16/16 pass. `tsc --noEmit` clean. Lint clean (ratchet down 11 warnings).