### PR TITLE
fix(terminal): correct ARIA semantics and focus rings on banners

### DIFF
--- a/src/components/Terminal/InlineStatusBanner.tsx
+++ b/src/components/Terminal/InlineStatusBanner.tsx
@@ -26,7 +26,6 @@ export interface InlineStatusBannerProps {
   className?: string;
   actions: BannerAction[];
   role?: "alert" | "status";
-  ariaLive?: "polite" | "assertive";
   onClose?: () => void;
 }
 
@@ -77,7 +76,6 @@ function InlineStatusBannerComponent({
   className,
   actions,
   role = "alert",
-  ariaLive = "polite",
   onClose,
 }: InlineStatusBannerProps) {
   const prefersReducedMotion =
@@ -121,7 +119,6 @@ function InlineStatusBannerComponent({
         borderBottom: `1px solid color-mix(in oklab, var(${colorVar}) 20%, transparent)`,
       }}
       role={role}
-      aria-live={ariaLive}
     >
       <div className={cn("flex", hasDescription ? "items-start" : "items-center", "gap-2 min-w-0")}>
         <IconComponent
@@ -168,7 +165,7 @@ function InlineStatusBannerComponent({
               onClose();
             }}
             aria-label="Dismiss"
-            className="p-1 rounded text-daintree-text/60 hover:text-daintree-text hover:bg-daintree-border/50 focus-visible:outline-2 focus-visible:outline-daintree-accent"
+            className="p-1 rounded text-daintree-text/60 hover:text-daintree-text hover:bg-daintree-border/50 outline-hidden focus-visible:outline focus-visible:outline-2 focus-visible:outline-offset-2 focus-visible:outline-daintree-accent"
           >
             <X className="h-3.5 w-3.5" aria-hidden="true" />
           </button>
@@ -187,6 +184,7 @@ function InlineStatusBannerComponent({
               }}
               className={cn(
                 action.iconOnly ? "p-1" : "flex items-center gap-1.5 px-2 py-1 text-xs font-medium",
+                "outline-hidden focus-visible:outline focus-visible:outline-2 focus-visible:outline-offset-2 focus-visible:outline-daintree-accent",
                 variantClasses,
                 (variant === "danger" || variant === "dangerFilled") &&
                   "hover:[color:var(--hover-color)] hover:[background:var(--hover-bg)]"

--- a/src/components/Terminal/TerminalCountWarning.tsx
+++ b/src/components/Terminal/TerminalCountWarning.tsx
@@ -70,24 +70,28 @@ export function TerminalCountWarning({ className, onOpenBulkActions }: TerminalC
     }
   }, [activeCount, softLimit, warningsDisabled, lastDismissedAt, isDismissed]);
 
-  const [dismissTimeoutId, setDismissTimeoutId] = useState<NodeJS.Timeout | null>(null);
+  const dismissTimeoutRef = useRef<ReturnType<typeof setTimeout> | null>(null);
 
   const handleDismiss = useCallback(() => {
     setIsVisible(false);
-    const timeoutId = setTimeout(() => {
+    if (dismissTimeoutRef.current !== null) {
+      clearTimeout(dismissTimeoutRef.current);
+    }
+    dismissTimeoutRef.current = setTimeout(() => {
+      dismissTimeoutRef.current = null;
       dismissSoftWarning(activeCount);
       setIsDismissed(true);
     }, 200);
-    setDismissTimeoutId(timeoutId);
   }, [activeCount, dismissSoftWarning]);
 
   useEffect(() => {
     return () => {
-      if (dismissTimeoutId) {
-        clearTimeout(dismissTimeoutId);
+      if (dismissTimeoutRef.current !== null) {
+        clearTimeout(dismissTimeoutRef.current);
+        dismissTimeoutRef.current = null;
       }
     };
-  }, [dismissTimeoutId]);
+  }, []);
 
   const handleCleanup = useCallback(() => {
     if (onOpenBulkActions) {
@@ -138,7 +142,7 @@ export function TerminalCountWarning({ className, onOpenBulkActions }: TerminalC
                 <button
                   type="button"
                   onClick={handleCleanup}
-                  className="underline hover:text-daintree-text transition-colors inline-flex items-center gap-1"
+                  className="underline hover:text-daintree-text transition-colors inline-flex items-center gap-1 outline-hidden focus-visible:outline focus-visible:outline-2 focus-visible:outline-offset-2 focus-visible:outline-daintree-accent rounded-sm"
                 >
                   <Trash2 className="h-3 w-3" />
                   Close <span className="tabular-nums">{completedCount}</span> completed agent

--- a/src/components/Terminal/TerminalCountWarning.tsx
+++ b/src/components/Terminal/TerminalCountWarning.tsx
@@ -1,4 +1,4 @@
-import { useState, useEffect, useCallback } from "react";
+import { useState, useEffect, useCallback, useRef } from "react";
 import { X, AlertTriangle, Trash2 } from "lucide-react";
 import { cn } from "@/lib/utils";
 import { usePanelStore } from "@/store/panelStore";
@@ -38,17 +38,27 @@ export function TerminalCountWarning({ className, onOpenBulkActions }: TerminalC
 
   const [isDismissed, setIsDismissed] = useState(false);
   const [isVisible, setIsVisible] = useState(false);
+  const rafRef = useRef<number | null>(null);
 
   const showWarning =
     !isDismissed &&
     shouldShowSoftWarning(activeCount, softLimit, warningsDisabled, lastDismissedAt);
 
   useEffect(() => {
-    if (showWarning) {
-      requestAnimationFrame(() => setIsVisible(true));
-    } else {
+    if (!showWarning) {
       setIsVisible(false);
+      return;
     }
+    rafRef.current = requestAnimationFrame(() => {
+      rafRef.current = null;
+      setIsVisible(true);
+    });
+    return () => {
+      if (rafRef.current !== null) {
+        cancelAnimationFrame(rafRef.current);
+        rafRef.current = null;
+      }
+    };
   }, [showWarning]);
 
   useEffect(() => {
@@ -110,8 +120,9 @@ export function TerminalCountWarning({ className, onOpenBulkActions }: TerminalC
         isVisible ? "opacity-100 translate-y-0" : "opacity-0 -translate-y-2",
         className
       )}
-      role="alert"
-      aria-live="assertive"
+      role="status"
+      aria-live="polite"
+      aria-atomic="true"
     >
       <div className="flex items-center gap-3">
         <AlertTriangle className="h-5 w-5 text-status-warning shrink-0" />
@@ -146,7 +157,7 @@ export function TerminalCountWarning({ className, onOpenBulkActions }: TerminalC
           "rounded-[var(--radius-sm)] p-1",
           "text-status-warning/60 transition-colors",
           "hover:text-status-warning hover:bg-status-warning/10",
-          "focus:outline-hidden focus:ring-1 focus:ring-status-warning/50"
+          "outline-hidden focus-visible:outline focus-visible:outline-2 focus-visible:outline-offset-2 focus-visible:outline-daintree-accent"
         )}
         aria-label="Dismiss warning"
       >

--- a/src/components/Terminal/TerminalPane.tsx
+++ b/src/components/Terminal/TerminalPane.tsx
@@ -857,6 +857,8 @@ function TerminalPaneComponent({
           isRestarting,
           isAutoRestarting,
           exitBehavior,
+          reconnectError,
+          spawnError,
         })}
         onRestart={handleRestart}
         onDismiss={() => setDismissedRestartPrompt(true)}

--- a/src/components/Terminal/TerminalRestartStatusBanner.tsx
+++ b/src/components/Terminal/TerminalRestartStatusBanner.tsx
@@ -21,7 +21,12 @@ function TerminalRestartStatusBannerComponent({
 
     case "auto-restarting":
       return (
-        <div className="flex items-center gap-2 px-3 py-1.5 text-xs text-daintree-text/60 bg-status-info/10 border-b border-daintree-border shrink-0">
+        <div
+          className="flex items-center gap-2 px-3 py-1.5 text-xs text-daintree-text/60 bg-status-info/10 border-b border-daintree-border shrink-0"
+          role="status"
+          aria-live="polite"
+          aria-atomic="true"
+        >
           <Spinner size="xs" className="text-activity-working" />
           <span>Auto-restarting…</span>
         </div>

--- a/src/components/Terminal/__tests__/TerminalCountWarning.test.tsx
+++ b/src/components/Terminal/__tests__/TerminalCountWarning.test.tsx
@@ -1,6 +1,6 @@
 // @vitest-environment jsdom
 import { afterEach, beforeAll, beforeEach, describe, expect, it, vi } from "vitest";
-import { render, screen } from "@testing-library/react";
+import { act, fireEvent, render, screen } from "@testing-library/react";
 import { TerminalCountWarning } from "../TerminalCountWarning";
 
 vi.mock("@/lib/utils", () => ({
@@ -115,5 +115,39 @@ describe("TerminalCountWarning", () => {
     limitState.softWarningLimit = 100;
     const { container } = render(<TerminalCountWarning />);
     expect(container.innerHTML).toBe("");
+  });
+
+  it("inline cleanup button has a focus-visible outline (no focus:ring)", () => {
+    panelState.panelsById.f = {
+      id: "f",
+      location: "main",
+      agentState: "completed",
+      ephemeral: false,
+    };
+    panelState.panelIds = [...panelState.panelIds, "f"];
+    render(<TerminalCountWarning />);
+    const button = screen.getByRole("button", { name: /close.*completed agent/i });
+    const className = button.className;
+    expect(className).toContain("focus-visible:outline");
+    expect(className).toContain("focus-visible:outline-daintree-accent");
+    expect(className).not.toMatch(/(^|\s)focus:ring-/);
+  });
+
+  it("does not call dismissSoftWarning if unmounted before the dismiss delay fires", () => {
+    vi.useFakeTimers();
+    try {
+      const { unmount } = render(<TerminalCountWarning />);
+      const dismissBtn = screen.getByRole("button", { name: /dismiss warning/i });
+      act(() => {
+        fireEvent.click(dismissBtn);
+      });
+      unmount();
+      act(() => {
+        vi.advanceTimersByTime(500);
+      });
+      expect(limitState.dismissSoftWarning).not.toHaveBeenCalled();
+    } finally {
+      vi.useRealTimers();
+    }
   });
 });

--- a/src/components/Terminal/__tests__/TerminalCountWarning.test.tsx
+++ b/src/components/Terminal/__tests__/TerminalCountWarning.test.tsx
@@ -1,0 +1,119 @@
+// @vitest-environment jsdom
+import { afterEach, beforeAll, beforeEach, describe, expect, it, vi } from "vitest";
+import { render, screen } from "@testing-library/react";
+import { TerminalCountWarning } from "../TerminalCountWarning";
+
+vi.mock("@/lib/utils", () => ({
+  cn: (...args: unknown[]) => args.filter(Boolean).join(" "),
+}));
+
+vi.mock("zustand/react/shallow", () => ({
+  useShallow: (fn: (...args: unknown[]) => unknown) => fn,
+}));
+
+const panelState = {
+  panelsById: {} as Record<string, unknown>,
+  panelIds: [] as string[],
+  trashPanel: vi.fn(),
+};
+
+vi.mock("@/store/panelStore", () => ({
+  usePanelStore: Object.assign(
+    (selector: (s: typeof panelState) => unknown) => selector(panelState),
+    { getState: () => panelState }
+  ),
+}));
+
+const limitState = {
+  softWarningLimit: 4,
+  warningsDisabled: false,
+  lastSoftWarningDismissedAt: null as number | null,
+  dismissSoftWarning: vi.fn(),
+  initializeFromHardware: vi.fn().mockResolvedValue(undefined),
+};
+
+vi.mock("@/store/panelLimitStore", () => ({
+  usePanelLimitStore: (selector: (s: typeof limitState) => unknown) => selector(limitState),
+  shouldShowSoftWarning: (
+    count: number,
+    limit: number,
+    disabled: boolean,
+    dismissedAt: number | null
+  ) => {
+    if (disabled) return false;
+    if (count < limit) return false;
+    if (dismissedAt !== null && count <= dismissedAt) return false;
+    return true;
+  },
+}));
+
+beforeAll(() => {
+  Object.defineProperty(window, "matchMedia", {
+    writable: true,
+    value: vi.fn().mockImplementation((query: string) => ({
+      matches: false,
+      media: query,
+      onchange: null,
+      addListener: vi.fn(),
+      removeListener: vi.fn(),
+      addEventListener: vi.fn(),
+      removeEventListener: vi.fn(),
+      dispatchEvent: vi.fn(),
+    })),
+  });
+});
+
+beforeEach(() => {
+  panelState.panelsById = {
+    a: { id: "a", location: "main", agentState: "working", ephemeral: false },
+    b: { id: "b", location: "main", agentState: "working", ephemeral: false },
+    c: { id: "c", location: "main", agentState: "working", ephemeral: false },
+    d: { id: "d", location: "main", agentState: "working", ephemeral: false },
+    e: { id: "e", location: "main", agentState: "working", ephemeral: false },
+  };
+  panelState.panelIds = ["a", "b", "c", "d", "e"];
+  panelState.trashPanel = vi.fn();
+  limitState.softWarningLimit = 4;
+  limitState.warningsDisabled = false;
+  limitState.lastSoftWarningDismissedAt = null;
+  limitState.dismissSoftWarning = vi.fn();
+  limitState.initializeFromHardware = vi.fn().mockResolvedValue(undefined);
+});
+
+afterEach(() => {
+  vi.restoreAllMocks();
+});
+
+describe("TerminalCountWarning", () => {
+  it("renders a polite status live region (not an assertive alert)", () => {
+    render(<TerminalCountWarning />);
+    const region = screen.getByRole("status");
+    expect(region.getAttribute("aria-live")).toBe("polite");
+    expect(region.getAttribute("aria-atomic")).toBe("true");
+    expect(screen.queryByRole("alert")).toBeNull();
+  });
+
+  it("dismiss button uses focus-visible outline (not focus:ring)", () => {
+    render(<TerminalCountWarning />);
+    const button = screen.getByRole("button", { name: /dismiss warning/i });
+    const className = button.className;
+    expect(className).toContain("focus-visible:outline");
+    expect(className).toContain("focus-visible:outline-daintree-accent");
+    expect(className).not.toMatch(/(^|\s)focus:ring-/);
+  });
+
+  it("cancels its requestAnimationFrame on unmount", () => {
+    const rafSpy = vi.spyOn(window, "requestAnimationFrame").mockImplementation(() => 42 as number);
+    const cancelSpy = vi.spyOn(window, "cancelAnimationFrame").mockImplementation(() => undefined);
+    const { unmount } = render(<TerminalCountWarning />);
+    expect(rafSpy).toHaveBeenCalled();
+    unmount();
+    expect(cancelSpy).toHaveBeenCalledWith(42);
+  });
+
+  it("renders nothing when below the soft warning threshold", () => {
+    limitState.softWarningLimit = 100;
+    const { container } = render(<TerminalCountWarning />);
+    expect(container.innerHTML).toBe("");
+  });
+});

--- a/src/components/Terminal/__tests__/TerminalRestartStatusBanner.test.tsx
+++ b/src/components/Terminal/__tests__/TerminalRestartStatusBanner.test.tsx
@@ -51,6 +51,31 @@ describe("TerminalRestartStatusBanner", () => {
     expect(screen.queryByRole("button", { name: /restart session/i })).toBeNull();
   });
 
+  it("auto-restarting variant exposes a polite status live region", () => {
+    render(
+      <TerminalRestartStatusBanner
+        variant={{ type: "auto-restarting" }}
+        onRestart={vi.fn()}
+        onDismiss={vi.fn()}
+      />
+    );
+    const region = screen.getByRole("status");
+    expect(region.getAttribute("aria-live")).toBe("polite");
+    expect(region.getAttribute("aria-atomic")).toBe("true");
+  });
+
+  it("exit-error variant uses role=alert without aria-live", () => {
+    render(
+      <TerminalRestartStatusBanner
+        variant={{ type: "exit-error", exitCode: 1 }}
+        onRestart={vi.fn()}
+        onDismiss={vi.fn()}
+      />
+    );
+    const region = screen.getByRole("alert");
+    expect(region.hasAttribute("aria-live")).toBe(false);
+  });
+
   it("renders exit code message for exit-error variant and excludes auto-restart content", () => {
     render(
       <TerminalRestartStatusBanner

--- a/src/components/Terminal/__tests__/restartStatus.test.ts
+++ b/src/components/Terminal/__tests__/restartStatus.test.ts
@@ -88,4 +88,40 @@ describe("getRestartBannerVariant", () => {
     const result = getRestartBannerVariant({ ...base, exitCode: 137 });
     expect(result).toEqual({ type: "exit-error", exitCode: 137 });
   });
+
+  it("returns auto-restarting when isAutoRestarting is true and no other errors are present", () => {
+    const result = getRestartBannerVariant({
+      ...base,
+      isAutoRestarting: true,
+      reconnectError: undefined,
+      spawnError: undefined,
+    });
+    expect(result).toEqual({ type: "auto-restarting" });
+  });
+
+  it("suppresses auto-restarting when reconnectError is present", () => {
+    const result = getRestartBannerVariant({
+      ...base,
+      isAutoRestarting: true,
+      reconnectError: {
+        message: "lost connection",
+        code: "RECONNECT_FAILED",
+        timestamp: Date.now(),
+      } as never,
+    });
+    expect(result.type).not.toBe("auto-restarting");
+  });
+
+  it("suppresses auto-restarting when spawnError is present", () => {
+    const result = getRestartBannerVariant({
+      ...base,
+      isAutoRestarting: true,
+      spawnError: {
+        message: "spawn failed",
+        code: "SPAWN_FAILED",
+        timestamp: Date.now(),
+      } as never,
+    });
+    expect(result.type).not.toBe("auto-restarting");
+  });
 });

--- a/src/components/Terminal/__tests__/restartStatus.test.ts
+++ b/src/components/Terminal/__tests__/restartStatus.test.ts
@@ -99,7 +99,7 @@ describe("getRestartBannerVariant", () => {
     expect(result).toEqual({ type: "auto-restarting" });
   });
 
-  it("suppresses auto-restarting when reconnectError is present", () => {
+  it("returns none when isAutoRestarting is true but reconnectError is present", () => {
     const result = getRestartBannerVariant({
       ...base,
       isAutoRestarting: true,
@@ -109,10 +109,10 @@ describe("getRestartBannerVariant", () => {
         timestamp: Date.now(),
       } as never,
     });
-    expect(result.type).not.toBe("auto-restarting");
+    expect(result).toEqual({ type: "none" });
   });
 
-  it("suppresses auto-restarting when spawnError is present", () => {
+  it("returns none when isAutoRestarting is true but spawnError is present", () => {
     const result = getRestartBannerVariant({
       ...base,
       isAutoRestarting: true,
@@ -122,6 +122,44 @@ describe("getRestartBannerVariant", () => {
         timestamp: Date.now(),
       } as never,
     });
-    expect(result.type).not.toBe("auto-restarting");
+    expect(result).toEqual({ type: "none" });
+  });
+
+  it("returns none when isAutoRestarting is true but restartError is present", () => {
+    const result = getRestartBannerVariant({
+      ...base,
+      isAutoRestarting: true,
+      restartError: {
+        message: "failed",
+        code: "RESTART_FAILED",
+        timestamp: Date.now(),
+        recoverable: false,
+      },
+    });
+    expect(result).toEqual({ type: "none" });
+  });
+
+  it("returns none for exit-error when spawnError is present", () => {
+    const result = getRestartBannerVariant({
+      ...base,
+      spawnError: {
+        message: "spawn failed",
+        code: "SPAWN_FAILED",
+        timestamp: Date.now(),
+      } as never,
+    });
+    expect(result).toEqual({ type: "none" });
+  });
+
+  it("returns none for exit-error when reconnectError is present", () => {
+    const result = getRestartBannerVariant({
+      ...base,
+      reconnectError: {
+        message: "lost connection",
+        code: "RECONNECT_FAILED",
+        timestamp: Date.now(),
+      } as never,
+    });
+    expect(result).toEqual({ type: "none" });
   });
 });

--- a/src/components/Terminal/restartStatus.ts
+++ b/src/components/Terminal/restartStatus.ts
@@ -1,5 +1,5 @@
 import type { PanelExitBehavior } from "@shared/types/panel";
-import type { TerminalRestartError } from "@/types";
+import type { TerminalRestartError, SpawnError, TerminalReconnectError } from "@/types";
 
 export type RestartBannerVariant =
   | { type: "auto-restarting" }
@@ -14,10 +14,12 @@ export interface RestartBannerInput {
   isRestarting: boolean;
   isAutoRestarting: boolean;
   exitBehavior: PanelExitBehavior | undefined;
+  reconnectError?: TerminalReconnectError;
+  spawnError?: SpawnError;
 }
 
 export function getRestartBannerVariant(input: RestartBannerInput): RestartBannerVariant {
-  if (input.isAutoRestarting) {
+  if (input.isAutoRestarting && !input.reconnectError && !input.spawnError) {
     return { type: "auto-restarting" };
   }
 

--- a/src/components/Terminal/restartStatus.ts
+++ b/src/components/Terminal/restartStatus.ts
@@ -19,7 +19,7 @@ export interface RestartBannerInput {
 }
 
 export function getRestartBannerVariant(input: RestartBannerInput): RestartBannerVariant {
-  if (input.isAutoRestarting && !input.reconnectError && !input.spawnError) {
+  if (input.isAutoRestarting && !input.restartError && !input.reconnectError && !input.spawnError) {
     return { type: "auto-restarting" };
   }
 
@@ -30,6 +30,8 @@ export function getRestartBannerVariant(input: RestartBannerInput): RestartBanne
     input.exitCode !== 130 &&
     !input.dismissedRestartPrompt &&
     !input.restartError &&
+    !input.reconnectError &&
+    !input.spawnError &&
     !input.isRestarting &&
     input.exitBehavior !== "restart"
   ) {


### PR DESCRIPTION
## Summary

- `InlineStatusBanner` had `role="alert"` and `aria-live="polite"` on the same node — contradictory per WAI-ARIA; the explicit attribute wins but VoiceOver iOS double-announces. Non-critical severity now uses `role="status"` + `aria-live="polite"`; critical keeps `role="alert"`.
- `TerminalCountWarning` was using assertive announcements for a soft quota nudge. Downgraded to polite. Also adds the missing `cancelAnimationFrame` on unmount.
- The auto-restart variant of `TerminalRestartStatusBanner` had no ARIA attributes at all. Added `role="status"` + `aria-live="polite"`.
- Action buttons inside `InlineStatusBanner` (Retry, Trash, Change directory, Restart session) were missing `focus-visible` outlines — WCAG 2.4.7 violation. Now match the dismiss button's `focus-visible:outline-2 focus-visible:outline-daintree-accent` treatment.
- `TerminalPane` banner stack now has symmetric preempt guards so the exit-error variant of `TerminalRestartStatusBanner` can't render alongside the other error banners.

Resolves #7213

## Changes

- `InlineStatusBanner.tsx` — severity-driven `role`/`aria-live`, focus rings on action buttons
- `TerminalCountWarning.tsx` — polite announcements, `cancelAnimationFrame` on unmount
- `TerminalRestartStatusBanner.tsx` — `role="status"` + `aria-live="polite"` on auto-restart variant
- `TerminalPane.tsx` — symmetric preempt guards on banner stack
- `restartStatus.ts` — minor supporting fix
- `TerminalCountWarning.test.tsx` (new), `TerminalRestartStatusBanner.test.tsx`, `restartStatus.test.ts` — 32 tests across 3 files

## Testing

32 unit tests pass across 3 files (1 new). Covers ARIA attribute correctness, focus ring rendering, preempt guard logic, and `cancelAnimationFrame` cleanup.