### PR TITLE
fix(keyboard-shortcuts): polish a11y, semantics, and unbound state

### DIFF
--- a/src/components/KeyboardShortcuts/SettingsShortcutCapture.tsx
+++ b/src/components/KeyboardShortcuts/SettingsShortcutCapture.tsx
@@ -275,7 +275,7 @@ export function SettingsShortcutCapture({
 
   return (
     <div className="bg-daintree-bg/50 border border-daintree-border rounded-[var(--radius-lg)] p-4 space-y-3">
-      <div className="flex items-center gap-2">
+      <div className="flex items-center gap-2" role="status" aria-live="polite" aria-atomic="true">
         {recording ? (
           <div className="flex-1 px-4 py-2 border border-daintree-accent rounded bg-daintree-accent/10 text-daintree-accent animate-pulse text-center">
             {chordStep === "first" ? (

--- a/src/components/KeyboardShortcuts/ShortcutReferenceDialog.tsx
+++ b/src/components/KeyboardShortcuts/ShortcutReferenceDialog.tsx
@@ -60,7 +60,7 @@ export function ShortcutReferenceDialog({ isOpen, onClose }: ShortcutReferenceDi
         effectiveCombo: binding.effectiveCombo,
         displayCombo,
         normalizedCombo,
-        keywords: [],
+        keywords: binding.effectiveCombo ? [] : ["unbound"],
       };
     });
   }, [allBindings]);
@@ -179,7 +179,10 @@ export function ShortcutReferenceDialog({ isOpen, onClose }: ShortcutReferenceDi
                       </dt>
                       <dd className="ml-4">
                         {binding.effectiveCombo ? (
-                          <KbdChord shortcut={binding.effectiveCombo} />
+                          <KbdChord
+                            shortcut={binding.effectiveCombo}
+                            aria-label={binding.displayCombo}
+                          />
                         ) : (
                           <span className="text-xs text-daintree-text/60 italic">unbound</span>
                         )}

--- a/src/components/KeyboardShortcuts/ShortcutReferenceDialog.tsx
+++ b/src/components/KeyboardShortcuts/ShortcutReferenceDialog.tsx
@@ -2,10 +2,21 @@ import { useState, useMemo, useEffect, useRef } from "react";
 import Fuse, { type IFuseOptions } from "fuse.js";
 import { AppDialog } from "@/components/ui/AppDialog";
 import { useOverlayState } from "@/hooks";
-import { KbdChord } from "@/components/ui/Kbd";
+import { Kbd, KbdChord } from "@/components/ui/Kbd";
 import { MODIFIER_SEARCH_MAP, isChordPrefix, normalizeQuery } from "@/lib/kbdShortcut";
 import { keybindingService } from "../../services/KeybindingService";
 import type { KeybindingConfig } from "../../services/KeybindingService";
+
+const CATEGORY_ORDER = [
+  "Terminal",
+  "Agents",
+  "Worktrees",
+  "Panels",
+  "Navigation",
+  "Help",
+  "System",
+  "Other",
+] as const;
 
 interface ShortcutReferenceDialogProps {
   isOpen: boolean;
@@ -104,28 +115,17 @@ export function ShortcutReferenceDialog({ isOpen, onClose }: ShortcutReferenceDi
     return groups;
   }, [filteredBindings]);
 
-  const categoryOrder = [
-    "Terminal",
-    "Agents",
-    "Worktrees",
-    "Panels",
-    "Navigation",
-    "Help",
-    "System",
-    "Other",
-  ];
-
   const sortedCategories = useMemo(() => {
     const categories = Object.keys(groupedBindings);
     return categories.sort((a, b) => {
-      const aIndex = categoryOrder.indexOf(a);
-      const bIndex = categoryOrder.indexOf(b);
+      const aIndex = CATEGORY_ORDER.indexOf(a as (typeof CATEGORY_ORDER)[number]);
+      const bIndex = CATEGORY_ORDER.indexOf(b as (typeof CATEGORY_ORDER)[number]);
       if (aIndex === -1 && bIndex === -1) return a.localeCompare(b);
       if (aIndex === -1) return 1;
       if (bIndex === -1) return -1;
       return aIndex - bIndex;
     });
-  }, [groupedBindings, categoryOrder]);
+  }, [groupedBindings]);
 
   useEffect(() => {
     if (isOpen) {
@@ -146,6 +146,7 @@ export function ShortcutReferenceDialog({ isOpen, onClose }: ShortcutReferenceDi
           placeholder="Search shortcuts..."
           value={searchQuery}
           onChange={(e) => setSearchQuery(e.target.value)}
+          aria-label="Search shortcuts"
           className="w-full px-4 py-2 bg-daintree-bg border border-daintree-border rounded-[var(--radius-md)] text-daintree-text placeholder:text-text-muted focus:outline-hidden focus:ring-2 focus:ring-daintree-accent"
         />
       </AppDialog.Header>
@@ -162,28 +163,30 @@ export function ShortcutReferenceDialog({ isOpen, onClose }: ShortcutReferenceDi
                 <h3 className="text-lg font-semibold text-daintree-text mb-3 pb-2 border-b border-daintree-border">
                   {category}
                 </h3>
-                <div className="space-y-2">
+                <dl className="space-y-2">
                   {groupedBindings[category]!.map((binding) => (
                     <div
                       key={binding.actionId}
                       className="flex items-center justify-between py-2 px-3 rounded hover:bg-daintree-border/50"
                     >
-                      <div className="flex-1">
+                      <dt className="flex-1">
                         <div className="text-daintree-text font-medium">{binding.description}</div>
                         {binding.scope !== "global" && (
                           <div className="text-xs text-daintree-text/60 mt-1">
                             Scope: {binding.scope}
                           </div>
                         )}
-                      </div>
-                      <div className="ml-4">
+                      </dt>
+                      <dd className="ml-4">
                         {binding.effectiveCombo ? (
                           <KbdChord shortcut={binding.effectiveCombo} />
-                        ) : null}
-                      </div>
+                        ) : (
+                          <span className="text-xs text-daintree-text/60 italic">unbound</span>
+                        )}
+                      </dd>
                     </div>
                   ))}
-                </div>
+                </dl>
               </div>
             ))}
           </div>
@@ -192,7 +195,7 @@ export function ShortcutReferenceDialog({ isOpen, onClose }: ShortcutReferenceDi
 
       <AppDialog.Footer className="justify-center bg-daintree-bg/50">
         <div className="text-sm text-daintree-text/60">
-          Press <kbd className="px-2 py-1 bg-daintree-border rounded text-xs">Esc</kbd> to close
+          Press <Kbd>Esc</Kbd> to close
         </div>
       </AppDialog.Footer>
     </AppDialog>

--- a/src/components/KeyboardShortcuts/__tests__/SettingsShortcutCapture.test.tsx
+++ b/src/components/KeyboardShortcuts/__tests__/SettingsShortcutCapture.test.tsx
@@ -83,6 +83,26 @@ describe("SettingsShortcutCapture", () => {
     expect(screen.getByText("Press key combination...")).toBeTruthy();
   });
 
+  it("status region announces recording state changes via aria-live", () => {
+    render(
+      <SettingsShortcutCapture
+        onCapture={mockOnCapture}
+        onCancel={mockOnCancel}
+        excludeActionId="test.action"
+      />
+    );
+
+    const status = screen.getByRole("status");
+    expect(status.getAttribute("aria-live")).toBe("polite");
+    expect(status.getAttribute("aria-atomic")).toBe("true");
+    expect(status.textContent).toContain("Click to record shortcut");
+
+    fireEvent.click(screen.getByText("Click to record shortcut"));
+
+    const updatedStatus = screen.getByRole("status");
+    expect(updatedStatus.textContent).toContain("Press key combination...");
+  });
+
   it("captures single key combination and displays it", async () => {
     render(
       <SettingsShortcutCapture

--- a/src/components/KeyboardShortcuts/__tests__/ShortcutReferenceDialog.test.tsx
+++ b/src/components/KeyboardShortcuts/__tests__/ShortcutReferenceDialog.test.tsx
@@ -59,6 +59,15 @@ const mockBindings: Array<KeybindingConfig & { effectiveCombo: string }> = [
     category: "System",
     effectiveCombo: "Cmd+Shift+P",
   },
+  {
+    actionId: "app.unboundAction",
+    combo: "",
+    scope: "global",
+    priority: 0,
+    description: "Unbound Action",
+    category: "System",
+    effectiveCombo: "",
+  },
 ];
 
 const mockDisplayCombos: Record<string, string> = {
@@ -67,6 +76,7 @@ const mockDisplayCombos: Record<string, string> = {
   "terminal.newPanel": "⌘T",
   "app.openSettings": "⌘,",
   "app.commandPalette": "⌘⇧P",
+  "app.unboundAction": "",
 };
 
 vi.mock("@/services/KeybindingService", () => {
@@ -280,5 +290,36 @@ describe("ShortcutReferenceDialog", () => {
       expect(screen.getByText("Command Palette")).toBeTruthy();
       expect(screen.queryByText("Toggle Sidebar")).toBeNull();
     });
+  });
+
+  it("search input has aria-label for assistive tech", () => {
+    render(<ShortcutReferenceDialog isOpen={true} onClose={vi.fn()} />);
+
+    expect(screen.getByLabelText("Search shortcuts")).toBeTruthy();
+  });
+
+  it("renders italic 'unbound' placeholder when binding has no effective combo", () => {
+    render(<ShortcutReferenceDialog isOpen={true} onClose={vi.fn()} />);
+
+    const unboundCell = screen.getByText("unbound");
+    expect(unboundCell).toBeTruthy();
+    expect(unboundCell.tagName.toLowerCase()).toBe("span");
+  });
+
+  it("uses dl/dt/dd semantics for shortcut rows", () => {
+    render(<ShortcutReferenceDialog isOpen={true} onClose={vi.fn()} />);
+
+    const dl = document.querySelector("dl");
+    expect(dl).toBeTruthy();
+    expect(document.querySelectorAll("dt").length).toBeGreaterThan(0);
+    expect(document.querySelectorAll("dd").length).toBeGreaterThan(0);
+  });
+
+  it("footer renders Esc inside a kbd element", () => {
+    render(<ShortcutReferenceDialog isOpen={true} onClose={vi.fn()} />);
+
+    const kbds = document.querySelectorAll("kbd");
+    const escKbd = Array.from(kbds).find((el) => el.textContent === "Esc");
+    expect(escKbd).toBeTruthy();
   });
 });

--- a/src/components/Settings/KeyboardShortcutsTab.tsx
+++ b/src/components/Settings/KeyboardShortcutsTab.tsx
@@ -47,7 +47,7 @@ function ShortcutRow({ binding, isEditing, onEdit, onSave, onCancel, onReset }: 
   }
 
   return (
-    <div className="flex items-center justify-between py-2 border-b border-daintree-border/50 group">
+    <div className="flex items-center justify-between py-2 border-b border-daintree-border/50 group/row">
       <span className="text-sm text-daintree-text">{binding.description || binding.actionId}</span>
       <div className="flex items-center gap-2">
         {binding.effectiveCombo ? (
@@ -66,7 +66,7 @@ function ShortcutRow({ binding, isEditing, onEdit, onSave, onCancel, onReset }: 
         )}
         <button
           onClick={onEdit}
-          className="px-2 py-0.5 text-xs text-daintree-text/60 hover:text-daintree-text opacity-0 group-hover:opacity-100 transition-opacity"
+          className="px-2 py-0.5 text-xs text-daintree-text/60 hover:text-daintree-text opacity-0 group-hover/row:opacity-100 group-focus-within/row:opacity-100 focus-visible:opacity-100 transition-opacity"
         >
           Edit
         </button>
@@ -75,7 +75,7 @@ function ShortcutRow({ binding, isEditing, onEdit, onSave, onCancel, onReset }: 
             <TooltipTrigger asChild>
               <button
                 onClick={onReset}
-                className="p-0.5 text-daintree-text/60 hover:text-daintree-text opacity-0 group-hover:opacity-100 transition-opacity"
+                className="p-0.5 text-daintree-text/60 hover:text-daintree-text opacity-0 group-hover/row:opacity-100 group-focus-within/row:opacity-100 focus-visible:opacity-100 transition-opacity"
                 aria-label="Reset to default"
               >
                 <RotateCcw className="w-3 h-3" />

--- a/src/components/ui/Kbd.tsx
+++ b/src/components/ui/Kbd.tsx
@@ -48,7 +48,7 @@ export function KbdChord({
   if (steps.length === 0) return null;
 
   return (
-    <span
+    <kbd
       className={cn("inline-flex items-center gap-1", className)}
       aria-label={ariaLabel ?? shortcut}
     >
@@ -68,6 +68,7 @@ export function KbdChord({
                   </span>
                 )}
                 <kbd
+                  aria-hidden="true"
                   className={cn(
                     "px-1.5 py-0.5 rounded text-xs font-mono leading-none",
                     "bg-overlay-subtle text-daintree-text/70",
@@ -81,6 +82,6 @@ export function KbdChord({
           </span>
         </Fragment>
       ))}
-    </span>
+    </kbd>
   );
 }

--- a/src/components/ui/__tests__/Kbd.test.tsx
+++ b/src/components/ui/__tests__/Kbd.test.tsx
@@ -1,0 +1,56 @@
+// @vitest-environment jsdom
+import { render } from "@testing-library/react";
+import { describe, expect, it, vi } from "vitest";
+import { Kbd, KbdChord } from "../Kbd";
+
+vi.mock("@/lib/platform", () => ({
+  isMac: vi.fn(() => false),
+}));
+
+vi.mock("@/lib/utils", () => ({
+  cn: (...args: unknown[]) => args.filter(Boolean).join(" "),
+}));
+
+describe("Kbd", () => {
+  it("renders children inside a kbd element", () => {
+    const { container } = render(<Kbd>Esc</Kbd>);
+    const kbd = container.querySelector("kbd");
+    expect(kbd).toBeTruthy();
+    expect(kbd?.textContent).toBe("Esc");
+  });
+});
+
+describe("KbdChord", () => {
+  it("outer wrapper is a kbd element (not span) for canonical multi-key markup", () => {
+    const { container } = render(<KbdChord shortcut="Cmd+S" />);
+    const root = container.firstElementChild;
+    expect(root?.tagName.toLowerCase()).toBe("kbd");
+  });
+
+  it("inner per-key kbd elements have aria-hidden to prevent AT double-announcement", () => {
+    const { container } = render(<KbdChord shortcut="Cmd+S" />);
+    const innerKbds = container.querySelectorAll("kbd kbd");
+    expect(innerKbds.length).toBeGreaterThan(0);
+    innerKbds.forEach((kbd) => {
+      expect(kbd.getAttribute("aria-hidden")).toBe("true");
+    });
+  });
+
+  it("propagates aria-label to the outer kbd", () => {
+    const { container } = render(<KbdChord shortcut="Cmd+S" aria-label="Save file" />);
+    const root = container.firstElementChild;
+    expect(root?.getAttribute("aria-label")).toBe("Save file");
+  });
+
+  it("falls back to shortcut string when aria-label is not provided", () => {
+    const { container } = render(<KbdChord shortcut="Cmd+S" />);
+    const root = container.firstElementChild;
+    expect(root?.getAttribute("aria-label")).toBe("Cmd+S");
+  });
+
+  it("renders chord with multiple steps", () => {
+    const { container } = render(<KbdChord shortcut="Cmd+K Cmd+S" />);
+    const innerKbds = container.querySelectorAll("kbd kbd");
+    expect(innerKbds.length).toBeGreaterThanOrEqual(4);
+  });
+});


### PR DESCRIPTION
## Summary

- Eight polish fixes across `KeyboardShortcutsTab`, `ShortcutReferenceDialog`, `SettingsShortcutCapture`, and `Kbd` — covering invisible focusable buttons, wrong HTML semantics, missing ARIA attributes, a stale `useMemo`, and visual gaps for unbound shortcuts.
- Adds tests for `Kbd`, `SettingsShortcutCapture`, and `ShortcutReferenceDialog`.

Resolves #7259

## Changes

- **Invisible buttons** — row Edit/Reset buttons used `opacity-0 group-hover:opacity-100`, making them unreachable for keyboard-only users. Now visible on focus (WCAG 2.4.7).
- **`KbdChord` outer element** — changed from `<span>` to `<kbd>` per MDN's canonical multi-key markup (`<kbd><kbd>Ctrl</kbd>+<kbd>S</kbd></kbd>`).
- **Recording-state `aria-live`** — added `role="status" aria-live="polite" aria-atomic="true"` to the status div in `SettingsShortcutCapture`, matching `ChordIndicator`'s existing pattern.
- **`categoryOrder` moved out of component** — was declared inside the body and listed as a `useMemo` dep, causing the memo to recompute every render. Now a module-level constant.
- **Search `aria-label`** — `ShortcutReferenceDialog`'s search input was label-less; now matches `KeyboardShortcutsTab`.
- **Unbound placeholder** — blank cells for shortcuts without a binding now show an italic "Unbound" label, consistent with `KeyboardShortcutsTab`.
- **Description list markup** — shortcut rows changed from flex `<div>`s to `<dl>/<dt>/<dd>`, carrying the name-to-shortcut relationship to AT users.
- **Footer `Kbd`** — hand-rolled `<kbd className="px-2 py-1 ...">Esc</kbd>` replaced with the shared `<Kbd>` component.

## Testing

- New unit tests: `Kbd.test.tsx`, `SettingsShortcutCapture.test.tsx`, `ShortcutReferenceDialog.test.tsx`
- Covers `aria-live` presence, `KbdChord` outer element tag, unbound placeholder rendering, `<dl>` structure, and `aria-label` on the search input