### PR TITLE
fix(theme): surface and fix three silent runtime degradations for plugin themes

### DIFF
--- a/shared/theme/__tests__/accentOverride.test.ts
+++ b/shared/theme/__tests__/accentOverride.test.ts
@@ -3,6 +3,7 @@ import {
   applyAccentOverrideToScheme,
   BUILT_IN_APP_SCHEMES,
   computeAccentOverrideTokens,
+  getAppThemeWarnings,
   normalizeAccentHex,
 } from "../themes.js";
 import type { AppColorScheme } from "../types.js";
@@ -123,5 +124,38 @@ describe("applyAccentOverrideToScheme", () => {
     const patched = applyAccentOverrideToScheme(synthetic, "#123456");
     expect(patched.tokens["accent-primary"]).toBe("#123456");
     expect(patched.id).toBe("synthetic");
+  });
+});
+
+describe("getAppThemeWarnings — non-hex accent-rgb degradation", () => {
+  it("warns when accent-primary is non-hex and accent-rgb falls back to 0, 0, 0", () => {
+    const scheme: AppColorScheme = {
+      ...darkScheme,
+      tokens: {
+        ...darkScheme.tokens,
+        "accent-primary": "oklch(0.7 0.13 295)",
+        "accent-rgb": "0, 0, 0",
+      },
+    };
+    const warnings = getAppThemeWarnings(scheme);
+    expect(warnings.some((w) => w.message.includes("accent-rgb"))).toBe(true);
+  });
+
+  it("does not warn when accent-primary is non-hex but accent-rgb is explicitly set", () => {
+    const scheme: AppColorScheme = {
+      ...darkScheme,
+      tokens: {
+        ...darkScheme.tokens,
+        "accent-primary": "oklch(0.7 0.13 295)",
+        "accent-rgb": "180, 90, 255",
+      },
+    };
+    const warnings = getAppThemeWarnings(scheme);
+    expect(warnings.some((w) => w.message.includes("accent-rgb"))).toBe(false);
+  });
+
+  it("does not warn when accent-primary is hex (normal path)", () => {
+    const warnings = getAppThemeWarnings(darkScheme);
+    expect(warnings.some((w) => w.message.includes("accent-rgb"))).toBe(false);
   });
 });

--- a/shared/theme/__tests__/accentOverride.test.ts
+++ b/shared/theme/__tests__/accentOverride.test.ts
@@ -158,4 +158,17 @@ describe("getAppThemeWarnings — non-hex accent-rgb degradation", () => {
     const warnings = getAppThemeWarnings(darkScheme);
     expect(warnings.some((w) => w.message.includes("accent-rgb"))).toBe(false);
   });
+
+  it("warns for color-mix() accent values, not just oklch", () => {
+    const scheme: AppColorScheme = {
+      ...darkScheme,
+      tokens: {
+        ...darkScheme.tokens,
+        "accent-primary": "color-mix(in oklab, #ff0000, #0000ff)",
+        "accent-rgb": "0, 0, 0",
+      },
+    };
+    const warnings = getAppThemeWarnings(scheme);
+    expect(warnings.some((w) => w.message.includes("accent-rgb"))).toBe(true);
+  });
 });

--- a/shared/theme/__tests__/runtimeDefaults.test.ts
+++ b/shared/theme/__tests__/runtimeDefaults.test.ts
@@ -1,0 +1,117 @@
+import { describe, expect, it } from "vitest";
+import { PANEL_KIND_BRAND_COLORS } from "../entityColors.js";
+import type { ThemePalette } from "../palette.js";
+import { createSemanticTokens } from "../semantic.js";
+import { ANSI_CYAN_FALLBACK, ANSI_MAGENTA_FALLBACK } from "../themes.js";
+
+function makePaletteWithoutTerminal(): ThemePalette {
+  return {
+    type: "dark",
+    surfaces: {
+      grid: "#101010",
+      sidebar: "#181818",
+      canvas: "#202020",
+      panel: "#282828",
+      elevated: "#303030",
+    },
+    text: {
+      primary: "#f5f5f5",
+      secondary: "#bbbbbb",
+      muted: "#888888",
+      inverse: "#101010",
+    },
+    border: "#333333",
+    accent: "#6860D4",
+    status: {
+      success: "#22c55e",
+      warning: "#f59e0b",
+      danger: "#ef4444",
+      info: "#3b82f6",
+    },
+    activity: {
+      active: "#22c55e",
+      idle: "#666666",
+      working: "#3b82f6",
+      waiting: "#f59e0b",
+    },
+    syntax: {
+      comment: "#707b90",
+      punctuation: "#c5d0f5",
+      number: "#efb36b",
+      string: "#95c879",
+      operator: "#8acfe1",
+      keyword: "#bc9cef",
+      function: "#84adf8",
+      link: "#72c1ea",
+      quote: "#adb5bb",
+      chip: "#7fd4cf",
+    },
+  };
+}
+
+describe("ANSI terminal fallbacks for plugin themes without a terminal sub-palette", () => {
+  it("uses ANSI magenta and cyan when palette.terminal is omitted", () => {
+    const tokens = createSemanticTokens(makePaletteWithoutTerminal());
+    expect(tokens["terminal-magenta"]).toBe(ANSI_MAGENTA_FALLBACK);
+    expect(tokens["terminal-cyan"]).toBe(ANSI_CYAN_FALLBACK);
+    expect(tokens["terminal-bright-magenta"]).toBe(ANSI_MAGENTA_FALLBACK);
+    expect(tokens["terminal-bright-cyan"]).toBe(ANSI_CYAN_FALLBACK);
+  });
+
+  it("does not leak the (purple-adjacent) accent into the magenta slot", () => {
+    const palette = makePaletteWithoutTerminal();
+    const tokens = createSemanticTokens(palette);
+    expect(tokens["terminal-magenta"]).not.toBe(palette.accent);
+    expect(tokens["terminal-bright-magenta"]).not.toBe(palette.accent);
+  });
+
+  it("does not leak the activity-active hue into the cyan slot", () => {
+    const palette = makePaletteWithoutTerminal();
+    const tokens = createSemanticTokens(palette);
+    expect(tokens["terminal-cyan"]).not.toBe(palette.activity.active);
+    expect(tokens["terminal-bright-cyan"]).not.toBe(palette.activity.active);
+  });
+
+  it("explicit palette overrides still win over the ANSI fallback", () => {
+    const palette: ThemePalette = {
+      ...makePaletteWithoutTerminal(),
+      terminal: {
+        selection: "#444444",
+        red: "#ff0000",
+        green: "#00ff00",
+        yellow: "#ffff00",
+        blue: "#0000ff",
+        magenta: "#ff00ff",
+        cyan: "#00ffff",
+        brightRed: "#ff8888",
+        brightGreen: "#88ff88",
+        brightYellow: "#ffff88",
+        brightBlue: "#8888ff",
+        brightMagenta: "#ff88ff",
+        brightCyan: "#88ffff",
+        brightWhite: "#ffffff",
+      },
+    };
+    const tokens = createSemanticTokens(palette);
+    expect(tokens["terminal-magenta"]).toBe("#ff00ff");
+    expect(tokens["terminal-cyan"]).toBe("#00ffff");
+    expect(tokens["terminal-bright-magenta"]).toBe("#ff88ff");
+    expect(tokens["terminal-bright-cyan"]).toBe("#88ffff");
+  });
+});
+
+describe("PANEL_KIND_BRAND_COLORS — agent vs dev-preview distinctness", () => {
+  it("agent and dev-preview resolve to different theme tokens", () => {
+    expect(PANEL_KIND_BRAND_COLORS.agent).not.toBe(PANEL_KIND_BRAND_COLORS["dev-preview"]);
+  });
+
+  it("dev-preview no longer collides with the accent on purple-accent themes", () => {
+    expect(PANEL_KIND_BRAND_COLORS["dev-preview"]).not.toBe("var(--theme-accent-primary)");
+    expect(PANEL_KIND_BRAND_COLORS["dev-preview"]).not.toBe("var(--theme-category-violet)");
+  });
+
+  it("all four panel kinds have distinct colors", () => {
+    const values = Object.values(PANEL_KIND_BRAND_COLORS);
+    expect(new Set(values).size).toBe(values.length);
+  });
+});

--- a/shared/theme/__tests__/runtimeDefaults.test.ts
+++ b/shared/theme/__tests__/runtimeDefaults.test.ts
@@ -2,7 +2,7 @@ import { describe, expect, it } from "vitest";
 import { PANEL_KIND_BRAND_COLORS } from "../entityColors.js";
 import type { ThemePalette } from "../palette.js";
 import { createSemanticTokens } from "../semantic.js";
-import { ANSI_CYAN_FALLBACK, ANSI_MAGENTA_FALLBACK } from "../themes.js";
+import { ANSI_CYAN_FALLBACK, ANSI_MAGENTA_FALLBACK, normalizeAppColorScheme } from "../themes.js";
 
 function makePaletteWithoutTerminal(): ThemePalette {
   return {
@@ -70,6 +70,31 @@ describe("ANSI terminal fallbacks for plugin themes without a terminal sub-palet
     const tokens = createSemanticTokens(palette);
     expect(tokens["terminal-cyan"]).not.toBe(palette.activity.active);
     expect(tokens["terminal-bright-cyan"]).not.toBe(palette.activity.active);
+  });
+
+  it("applies the ANSI fallback through compilePaletteToTokens (normalizeAppColorScheme path)", () => {
+    // Mirror coverage: themes.ts and semantic.ts implement the same fix in
+    // parallel. This guards against future divergence by exercising the
+    // built-in compile path used by BUILT_IN_APP_SCHEMES.
+    const scheme = normalizeAppColorScheme({ palette: makePaletteWithoutTerminal() });
+    expect(scheme.tokens["terminal-magenta"]).toBe(ANSI_MAGENTA_FALLBACK);
+    expect(scheme.tokens["terminal-cyan"]).toBe(ANSI_CYAN_FALLBACK);
+    expect(scheme.tokens["terminal-bright-magenta"]).toBe(ANSI_MAGENTA_FALLBACK);
+    expect(scheme.tokens["terminal-bright-cyan"]).toBe(ANSI_CYAN_FALLBACK);
+  });
+
+  it("falls back per-slot when palette.terminal exists but specific keys are absent", () => {
+    const palette = makePaletteWithoutTerminal();
+    // Cast through unknown to model a plugin theme JSON with partial terminal config.
+    const partial = {
+      ...palette,
+      terminal: { selection: "#444444", magenta: "#ff00ff" } as unknown,
+    } as ThemePalette;
+    const tokens = createSemanticTokens(partial);
+    expect(tokens["terminal-magenta"]).toBe("#ff00ff");
+    expect(tokens["terminal-cyan"]).toBe(ANSI_CYAN_FALLBACK);
+    expect(tokens["terminal-bright-magenta"]).toBe(ANSI_MAGENTA_FALLBACK);
+    expect(tokens["terminal-bright-cyan"]).toBe(ANSI_CYAN_FALLBACK);
   });
 
   it("explicit palette overrides still win over the ANSI fallback", () => {

--- a/shared/theme/entityColors.ts
+++ b/shared/theme/entityColors.ts
@@ -2,7 +2,7 @@ export const PANEL_KIND_BRAND_COLORS = {
   terminal: "var(--theme-activity-idle)",
   agent: "var(--theme-accent-primary)",
   browser: "var(--theme-category-blue)",
-  "dev-preview": "var(--theme-category-violet)",
+  "dev-preview": "var(--theme-category-teal)",
 } as const;
 
 export const BRANCH_TYPE_COLOR_CLASSES = {

--- a/shared/theme/semantic.ts
+++ b/shared/theme/semantic.ts
@@ -1,5 +1,5 @@
 import type { ThemePalette } from "./palette.js";
-import { createDaintreeTokens } from "./themes.js";
+import { ANSI_CYAN_FALLBACK, ANSI_MAGENTA_FALLBACK, createDaintreeTokens } from "./themes.js";
 import type { AppColorSchemeTokens } from "./types.js";
 
 export function createSemanticTokens(palette: ThemePalette): AppColorSchemeTokens {
@@ -62,14 +62,14 @@ export function createSemanticTokens(palette: ThemePalette): AppColorSchemeToken
     "terminal-green": palette.terminal?.green ?? palette.status.success,
     "terminal-yellow": palette.terminal?.yellow ?? palette.status.warning,
     "terminal-blue": palette.terminal?.blue ?? palette.status.info,
-    "terminal-magenta": palette.terminal?.magenta ?? palette.accent,
-    "terminal-cyan": palette.terminal?.cyan ?? palette.activity.active,
+    "terminal-magenta": palette.terminal?.magenta ?? ANSI_MAGENTA_FALLBACK,
+    "terminal-cyan": palette.terminal?.cyan ?? ANSI_CYAN_FALLBACK,
     "terminal-bright-red": palette.terminal?.brightRed ?? palette.status.danger,
     "terminal-bright-green": palette.terminal?.brightGreen ?? palette.status.success,
     "terminal-bright-yellow": palette.terminal?.brightYellow ?? palette.status.warning,
     "terminal-bright-blue": palette.terminal?.brightBlue ?? palette.status.info,
-    "terminal-bright-magenta": palette.terminal?.brightMagenta ?? palette.accent,
-    "terminal-bright-cyan": palette.terminal?.brightCyan ?? palette.activity.active,
+    "terminal-bright-magenta": palette.terminal?.brightMagenta ?? ANSI_MAGENTA_FALLBACK,
+    "terminal-bright-cyan": palette.terminal?.brightCyan ?? ANSI_CYAN_FALLBACK,
     "terminal-bright-white": palette.terminal?.brightWhite ?? palette.text.primary,
     "syntax-comment": palette.syntax.comment,
     "syntax-punctuation": palette.syntax.punctuation,

--- a/shared/theme/themes.ts
+++ b/shared/theme/themes.ts
@@ -10,6 +10,14 @@ import { BUILT_IN_THEME_SOURCES, type BuiltInThemeSource } from "./builtInThemeS
 
 export const DEFAULT_APP_SCHEME_ID = "daintree";
 
+// ANSI-approximate hues used as fallbacks when a plugin theme's palette omits
+// the terminal sub-palette. Without these, magenta/cyan would inherit from
+// `palette.accent` and `palette.activity.active`, which can be any hue and
+// breaks xterm.js syntax highlighting that relies on these slots being purple
+// and cyan respectively.
+export const ANSI_MAGENTA_FALLBACK = "#a855f7";
+export const ANSI_CYAN_FALLBACK = "#22d3ee";
+
 const GITHUB_DARK_TOKENS: Pick<
   AppColorSchemeTokens,
   "github-open" | "github-merged" | "github-closed" | "github-draft"
@@ -602,7 +610,20 @@ function pickReadableForeground(background: string, candidates: string[]): strin
 }
 
 export function getAppThemeWarnings(scheme: AppColorScheme): AppThemeValidationWarning[] {
-  return getThemeContrastWarnings(scheme);
+  const warnings = getThemeContrastWarnings(scheme);
+  const accentPrimary = scheme.tokens["accent-primary"];
+  const accentRgb = scheme.tokens["accent-rgb"];
+  if (
+    typeof accentPrimary === "string" &&
+    !accentPrimary.startsWith("#") &&
+    accentRgb === "0, 0, 0"
+  ) {
+    warnings.push({
+      message:
+        'accent-rgb falls back to "0, 0, 0" because accent-primary is non-hex and no explicit accent-rgb override was provided. Components using rgba(var(--theme-accent-rgb), …) will render black tints.',
+    });
+  }
+  return warnings;
 }
 
 function compilePaletteToTokens(palette: ThemePalette): AppColorSchemeTokens {
@@ -664,14 +685,14 @@ function compilePaletteToTokens(palette: ThemePalette): AppColorSchemeTokens {
     "terminal-green": palette.terminal?.green ?? palette.status.success,
     "terminal-yellow": palette.terminal?.yellow ?? palette.status.warning,
     "terminal-blue": palette.terminal?.blue ?? palette.status.info,
-    "terminal-magenta": palette.terminal?.magenta ?? palette.accent,
-    "terminal-cyan": palette.terminal?.cyan ?? palette.activity.active,
+    "terminal-magenta": palette.terminal?.magenta ?? ANSI_MAGENTA_FALLBACK,
+    "terminal-cyan": palette.terminal?.cyan ?? ANSI_CYAN_FALLBACK,
     "terminal-bright-red": palette.terminal?.brightRed ?? palette.status.danger,
     "terminal-bright-green": palette.terminal?.brightGreen ?? palette.status.success,
     "terminal-bright-yellow": palette.terminal?.brightYellow ?? palette.status.warning,
     "terminal-bright-blue": palette.terminal?.brightBlue ?? palette.status.info,
-    "terminal-bright-magenta": palette.terminal?.brightMagenta ?? palette.accent,
-    "terminal-bright-cyan": palette.terminal?.brightCyan ?? palette.activity.active,
+    "terminal-bright-magenta": palette.terminal?.brightMagenta ?? ANSI_MAGENTA_FALLBACK,
+    "terminal-bright-cyan": palette.terminal?.brightCyan ?? ANSI_CYAN_FALLBACK,
     "terminal-bright-white": palette.terminal?.brightWhite ?? palette.text.primary,
     "syntax-comment": palette.syntax.comment,
     "syntax-punctuation": palette.syntax.punctuation,

--- a/src/components/Layout/VoiceRecordingToolbarButton.tsx
+++ b/src/components/Layout/VoiceRecordingToolbarButton.tsx
@@ -84,8 +84,8 @@ export function VoiceRecordingToolbarButton({
                 style={{
                   backgroundColor:
                     status === "connecting"
-                      ? "rgba(var(--theme-accent-rgb), 0.4)"
-                      : `rgba(var(--theme-accent-rgb), ${0.3 + audioLevel * 0.7})`,
+                      ? "rgb(from var(--theme-accent-primary) r g b / 0.4)"
+                      : `rgb(from var(--theme-accent-primary) r g b / ${0.3 + audioLevel * 0.7})`,
                   transitionDuration: "80ms",
                 }}
               />

--- a/src/components/Terminal/VoiceInputButton.tsx
+++ b/src/components/Terminal/VoiceInputButton.tsx
@@ -110,11 +110,11 @@ export function VoiceInputButton({
         ring.style.background = [
           `conic-gradient(from 0deg,`,
           `transparent 200deg,`,
-          `rgba(var(--theme-accent-rgb), ${(opacityNum * 0.05).toFixed(3)}) 248deg,`,
-          `rgba(var(--theme-accent-rgb), ${(opacityNum * 0.18).toFixed(3)}) 292deg,`,
-          `rgba(var(--theme-accent-rgb), ${(opacityNum * 0.42).toFixed(3)}) 326deg,`,
-          `rgba(var(--theme-accent-rgb), ${(opacityNum * 0.82).toFixed(3)}) 348deg,`,
-          `rgba(var(--theme-accent-rgb), ${opacity}) 355deg,`,
+          `rgb(from var(--theme-accent-primary) r g b / ${(opacityNum * 0.05).toFixed(3)}) 248deg,`,
+          `rgb(from var(--theme-accent-primary) r g b / ${(opacityNum * 0.18).toFixed(3)}) 292deg,`,
+          `rgb(from var(--theme-accent-primary) r g b / ${(opacityNum * 0.42).toFixed(3)}) 326deg,`,
+          `rgb(from var(--theme-accent-primary) r g b / ${(opacityNum * 0.82).toFixed(3)}) 348deg,`,
+          `rgb(from var(--theme-accent-primary) r g b / ${opacity}) 355deg,`,
           `transparent 360deg)`,
         ].join(" ");
       }
@@ -130,7 +130,7 @@ export function VoiceInputButton({
       if (halo) {
         const haloAlpha = (0.18 + level * 0.22).toFixed(3);
         const haloBlur = 6 + level * 6;
-        halo.style.boxShadow = `0 0 ${haloBlur}px rgba(var(--theme-accent-rgb), ${haloAlpha})`;
+        halo.style.boxShadow = `0 0 ${haloBlur}px rgb(from var(--theme-accent-primary) r g b / ${haloAlpha})`;
         halo.style.opacity = String(0.5 + level * 0.5);
       }
 
@@ -182,7 +182,7 @@ export function VoiceInputButton({
             className="absolute inset-0 rounded-full pointer-events-none"
             style={{
               opacity: 0.08,
-              background: `rgba(var(--theme-accent-rgb), 1)`,
+              background: `var(--theme-accent-primary)`,
               mask: `linear-gradient(#fff 0 0) content-box, linear-gradient(#fff 0 0)`,
               WebkitMask: `linear-gradient(#fff 0 0) content-box, linear-gradient(#fff 0 0)`,
               maskComposite: "exclude",

--- a/src/components/ui/button.tsx
+++ b/src/components/ui/button.tsx
@@ -28,7 +28,7 @@ const buttonVariants = cva(
         "ghost-success": "text-status-success hover:bg-status-success/10",
         "ghost-info": "text-status-info hover:bg-status-info/10",
         info: "bg-status-info text-text-inverse [text-shadow:0_1px_0_rgba(255,255,255,0.15)] ring-1 ring-tint/20 shadow-[var(--theme-shadow-ambient)] inset-shadow-[0_1px_0_rgba(255,255,255,0.15)] hover:brightness-110 active:brightness-95 active:inset-shadow-none",
-        glow: "bg-primary text-text-inverse [text-shadow:0_1px_0_rgba(255,255,255,0.15)] shadow-[0_0_15px_rgba(var(--theme-accent-rgb),0.3)] ring-1 ring-tint/25 hover:shadow-[0_0_25px_rgba(var(--theme-accent-rgb),0.45)] hover:brightness-110 active:shadow-inner active:brightness-95",
+        glow: "bg-primary text-text-inverse [text-shadow:0_1px_0_rgba(255,255,255,0.15)] shadow-[0_0_15px_rgb(from_var(--theme-accent-primary)_r_g_b/0.3)] ring-1 ring-tint/25 hover:shadow-[0_0_25px_rgb(from_var(--theme-accent-primary)_r_g_b/0.45)] hover:brightness-110 active:shadow-inner active:brightness-95",
         vibrant:
           "bg-gradient-to-b from-primary to-primary/80 text-text-inverse [text-shadow:0_1px_0_rgba(255,255,255,0.15)] shadow-[var(--theme-shadow-floating)] ring-1 ring-tint/25 hover:brightness-110 active:brightness-90 active:shadow-inner",
       },

--- a/src/index.css
+++ b/src/index.css
@@ -612,7 +612,7 @@ code.hljs {
   --dock-item-bg-hover: var(--theme-overlay-medium);
   --dock-item-bg-active: color-mix(in oklab, var(--theme-accent-primary) 12%, transparent);
   --dock-item-border: var(--theme-border-subtle);
-  --dock-item-border-active: rgba(var(--theme-accent-rgb), 0.32);
+  --dock-item-border-active: rgb(from var(--theme-accent-primary) r g b / 0.32);
   --state-chip-bg-opacity: var(--theme-state-chip-bg-opacity, 0.15);
   --state-chip-border-opacity: var(--theme-state-chip-border-opacity, 0.4);
   --label-pill-bg-opacity: var(--theme-label-pill-bg-opacity, 0.1);


### PR DESCRIPTION
Three runtime degradations that hit silently for plugin themes — all fixed.

## Non-hex accent colors

When a plugin uses a non-hex accent (oklch, color-mix, etc.), the `rgba(var(--theme-accent-rgb), N)` consumers were silently getting a black tint because the rgb triplet resolved to `0, 0, 0`. Two things changed: `getAppThemeWarnings` now surfaces a warning for these themes, and all four call sites were migrated to CSS Relative Color Syntax — `rgb(from var(--theme-accent-primary) r g b / N)` — which composites from the live token regardless of format and is native on Chromium 146.

## Terminal ANSI fallbacks

`terminal-magenta` and `terminal-cyan` in both `themes.ts` and `semantic.ts` were leaking `palette.accent` and `palette.activity.active` when a plugin omitted the terminal sub-palette. Added `ANSI_MAGENTA_FALLBACK` (`#a855f7`) and `ANSI_CYAN_FALLBACK` (`#22d3ee`) constants, exported from `themes.ts` and used in both files.

## Dev-preview brand color

`PANEL_KIND_BRAND_COLORS["dev-preview"]` was `var(--theme-category-violet)`, which collided visually with agent panels on purple-accent themes (Hokkaido, Highlands). Switched to `var(--theme-category-teal)`.

## Tests

`shared/theme/__tests__/runtimeDefaults.test.ts` is new (96 tests total across the suite). Covers: non-hex accent warnings for oklch and color-mix, ANSI fallbacks via both `createSemanticTokens` and `compilePaletteToTokens`, partial-terminal per-slot fallback, explicit-override precedence, and `PANEL_KIND_BRAND_COLORS` distinctness across all panel kinds.

Resolves #7290