### PR TITLE
fix(browser): tighten panel error handling and clean up dead UI

### DIFF
--- a/src/components/Browser/BrowserPane.tsx
+++ b/src/components/Browser/BrowserPane.tsx
@@ -13,7 +13,13 @@ import type { BrowserHistory } from "@shared/types/browser";
 import { ContentPanel, type BasePanelProps } from "@/components/Panel";
 import { BrowserToolbar } from "./BrowserToolbar";
 import { ConsolePanel } from "./ConsolePanel";
-import { normalizeBrowserUrl, extractHostPort, isValidBrowserUrl } from "./browserUtils";
+import {
+  normalizeBrowserUrl,
+  extractHostPort,
+  isValidBrowserUrl,
+  clampZoom,
+  type LoadError,
+} from "./browserUtils";
 import {
   goBackBrowserHistory,
   goForwardBrowserHistory,
@@ -44,6 +50,9 @@ export interface BrowserPaneProps extends BasePanelProps {
   onAddTab?: () => void;
 }
 
+// ERR_ABORTED (-3) fires when a pending load is superseded by a new navigation —
+// benign. Any other rejection is unexpected and worth a log; did-fail-load
+// surfaces user-visible failures, so this only catches non-event paths.
 function loadWebviewUrl(webview: Electron.WebviewTag, url: string): void {
   const result = (webview.loadURL as (url: string) => unknown)(url);
   if (
@@ -52,7 +61,20 @@ function loadWebviewUrl(webview: Electron.WebviewTag, url: string): void {
     "catch" in result &&
     typeof result.catch === "function"
   ) {
-    result.catch(() => {});
+    (result as { catch: (fn: (err: unknown) => void) => void }).catch((err: unknown) => {
+      if (
+        err &&
+        typeof err === "object" &&
+        "errorCode" in err &&
+        (err as { errorCode: unknown }).errorCode === -3
+      ) {
+        return;
+      }
+      logError(
+        "[BrowserPane] Unexpected loadURL rejection",
+        err instanceof Error ? err : new Error(String(err))
+      );
+    });
   }
 }
 
@@ -141,12 +163,11 @@ export function BrowserPane({
   // Clamp to valid range [0.25, 2.0] to handle corrupt storage
   const [zoomFactor, setZoomFactor] = useState<number>(() => {
     const terminal = usePanelStore.getState().getTerminal(id);
-    const savedZoom = terminal?.browserZoom ?? 1.0;
-    return Number.isFinite(savedZoom) ? Math.max(0.25, Math.min(2.0, savedZoom)) : 1.0;
+    return clampZoom(terminal?.browserZoom ?? 1.0);
   });
 
   const [isLoading, setIsLoading] = useState(true);
-  const [loadError, setLoadError] = useState<string | null>(null);
+  const [loadError, setLoadError] = useState<LoadError | null>(null);
   const [blockedNav, setBlockedNav] = useState<{
     url: string;
     canOpenExternal: boolean;
@@ -435,7 +456,7 @@ export function BrowserPane({
     } catch {
       // Webview detached
     }
-    setLoadError("Load cancelled.");
+    setLoadError({ kind: "cancelled", message: "Load cancelled." });
   }, []);
 
   const handleRetryFromError = useCallback(() => {
@@ -523,9 +544,7 @@ export function BrowserPane({
   }, []);
 
   const handleSetZoom = useCallback((rawZoom: number) => {
-    // Validate and clamp zoom factor to [0.25, 2.0]
-    const validZoom = Number.isFinite(rawZoom) ? Math.max(0.25, Math.min(2.0, rawZoom)) : 1.0;
-    setZoomFactor(validZoom);
+    setZoomFactor(clampZoom(rawZoom));
   }, []);
 
   useBrowserActionListeners(id, {
@@ -583,7 +602,6 @@ export function BrowserPane({
       canGoBack={canGoBack}
       canGoForward={canGoForward}
       isLoading={isLoading}
-      urlMightBeStale={false}
       zoomFactor={zoomFactor}
       isConsoleOpen={isConsoleOpen}
       isWebviewReady={isWebviewReady}
@@ -722,14 +740,18 @@ export function BrowserPane({
               <div className="absolute inset-0 z-30 flex flex-col items-center justify-center bg-daintree-bg text-daintree-text p-6">
                 <AlertTriangle className="w-6 h-6 text-status-warning mb-3" />
                 <h3 className="text-sm font-medium text-daintree-text/70 mb-1">
-                  {loadError.startsWith("Load timed out")
+                  {loadError.kind === "timeout"
                     ? "Page Load Timed Out"
-                    : loadError.startsWith("Load cancelled")
+                    : loadError.kind === "cancelled"
                       ? "Load Cancelled"
-                      : "Unable to Display Page"}
+                      : loadError.kind === "cert"
+                        ? "Certificate Error"
+                        : loadError.kind === "network"
+                          ? "Connection Failed"
+                          : "Unable to Display Page"}
                 </h3>
                 <p className="text-xs text-daintree-text/50 text-center mb-3 max-w-md">
-                  {loadError}
+                  {loadError.message}
                 </p>
                 <div className="flex items-center gap-1">
                   <Button

--- a/src/components/Browser/BrowserToolbar.tsx
+++ b/src/components/Browser/BrowserToolbar.tsx
@@ -43,7 +43,6 @@ interface BrowserToolbarProps {
   canGoBack: boolean;
   canGoForward: boolean;
   isLoading: boolean;
-  urlMightBeStale?: boolean;
   zoomFactor?: number;
   isConsoleOpen?: boolean;
   isWebviewReady?: boolean;
@@ -68,7 +67,6 @@ export function BrowserToolbar({
   canGoBack,
   canGoForward,
   isLoading,
-  urlMightBeStale = false,
   zoomFactor = 1.0,
   isConsoleOpen = false,
   isWebviewReady = false,
@@ -453,16 +451,6 @@ export function BrowserToolbar({
         <form onSubmit={handleSubmit}>
           <div className="relative flex items-center">
             <Globe className="absolute left-2 w-3.5 h-3.5 text-daintree-text/40 pointer-events-none" />
-            {urlMightBeStale && !isEditing && (
-              <Tooltip>
-                <TooltipTrigger asChild>
-                  <span className="absolute left-6 w-1.5 h-1.5 rounded-full bg-status-warning/60" />
-                </TooltipTrigger>
-                <TooltipContent side="bottom">
-                  URL may differ from page shown (in-page navigation)
-                </TooltipContent>
-              </Tooltip>
-            )}
             <input
               ref={inputRef}
               type="text"

--- a/src/components/Browser/__tests__/BrowserPane.webview.test.tsx
+++ b/src/components/Browser/__tests__/BrowserPane.webview.test.tsx
@@ -858,7 +858,7 @@ describe("BrowserPane webview lifecycle regression", () => {
       expect(container.textContent).toContain("mkcert -install");
     });
 
-    it("shows certificate error overlay for ERR_SSL_PROTOCOL_ERROR (-107)", () => {
+    it("shows SSL/TLS handshake message for ERR_SSL_PROTOCOL_ERROR (-107)", () => {
       const { container } = render(<BrowserPane {...baseProps} />);
       const webview = getWebviewElement(container);
 
@@ -872,7 +872,9 @@ describe("BrowserPane webview lifecycle regression", () => {
       });
 
       expect(container.textContent).toContain("Certificate Error");
-      expect(container.textContent).toContain("mkcert -install");
+      expect(container.textContent).toContain("SSL/TLS handshake failed");
+      // -107 is also raised on protocol mismatch — the mkcert hint is wrong here.
+      expect(container.textContent).not.toContain("mkcert");
     });
 
     it("surfaces ERR_FILE_NOT_FOUND (-6) instead of silently swallowing it", () => {
@@ -907,6 +909,84 @@ describe("BrowserPane webview lifecycle regression", () => {
 
       expect(container.textContent).not.toContain("Unable to Display Page");
       expect(container.textContent).not.toContain("Couldn't resolve");
+    });
+
+    it("does not disarm main-frame timeout when a sub-frame fails", () => {
+      const { container } = render(<BrowserPane {...baseProps} />);
+      const webview = getWebviewElement(container);
+
+      act(() => {
+        webview.setMockLoading(true);
+        emitWebviewEvent(webview, "did-start-loading");
+      });
+
+      // Sub-frame (e.g. tracker pixel) fails mid-load — must not clear the main-frame timer.
+      act(() => {
+        emitWebviewEvent(webview, "did-fail-load", {
+          errorCode: -105,
+          errorDescription: "ERR_NAME_NOT_RESOLVED",
+          isMainFrame: false,
+          validatedURL: "http://tracker.example.test/pixel.gif",
+        });
+      });
+
+      act(() => {
+        vi.advanceTimersByTime(30000);
+      });
+
+      expect(webview.stop).toHaveBeenCalledTimes(1);
+      expect(container.textContent).toContain("Page Load Timed Out");
+    });
+
+    it("stale ERR_ABORTED from a superseded navigation does not disarm new timers", () => {
+      const { container } = render(<BrowserPane {...baseProps} />);
+      const webview = getWebviewElement(container);
+
+      // First navigation starts and arms timers.
+      act(() => {
+        webview.setMockLoading(true);
+        emitWebviewEvent(webview, "did-start-loading");
+      });
+
+      // Second navigation supersedes the first — fresh timers armed.
+      act(() => {
+        emitWebviewEvent(webview, "did-start-loading");
+      });
+
+      // The first navigation's superseded did-fail-load (ERR_ABORTED, -3) arrives late.
+      act(() => {
+        emitWebviewEvent(webview, "did-fail-load", {
+          errorCode: -3,
+          errorDescription: "ERR_ABORTED",
+          isMainFrame: true,
+          validatedURL: "http://localhost:5173/old",
+        });
+      });
+
+      act(() => {
+        vi.advanceTimersByTime(30000);
+      });
+
+      expect(webview.stop).toHaveBeenCalledTimes(1);
+      expect(container.textContent).toContain("Page Load Timed Out");
+    });
+
+    it("shows connection-timeout message when validatedURL is empty", () => {
+      const { container } = render(<BrowserPane {...baseProps} />);
+      const webview = getWebviewElement(container);
+
+      act(() => {
+        emitWebviewEvent(webview, "did-fail-load", {
+          errorCode: -118,
+          errorDescription: "ERR_CONNECTION_TIMED_OUT",
+          isMainFrame: true,
+          validatedURL: "",
+        });
+      });
+
+      expect(container.textContent).toContain("Connection Failed");
+      expect(container.textContent).toContain("timed out");
+      expect(container.textContent).not.toContain("Unable to Display Page");
     });
 
     it("cleans slow timer on unmount", () => {

--- a/src/components/Browser/__tests__/BrowserPane.webview.test.tsx
+++ b/src/components/Browser/__tests__/BrowserPane.webview.test.tsx
@@ -840,6 +840,75 @@ describe("BrowserPane webview lifecycle regression", () => {
       expect(container.textContent).toContain("No internet connection");
     });
 
+    it("shows certificate error overlay for ERR_CERT_AUTHORITY_INVALID (-202)", () => {
+      const { container } = render(<BrowserPane {...baseProps} />);
+      const webview = getWebviewElement(container);
+
+      act(() => {
+        emitWebviewEvent(webview, "did-fail-load", {
+          errorCode: -202,
+          errorDescription: "ERR_CERT_AUTHORITY_INVALID",
+          isMainFrame: true,
+          validatedURL: "https://localhost:8443/",
+        });
+      });
+
+      expect(container.textContent).toContain("Certificate Error");
+      expect(container.textContent).toContain("certificate couldn't be verified");
+      expect(container.textContent).toContain("mkcert -install");
+    });
+
+    it("shows certificate error overlay for ERR_SSL_PROTOCOL_ERROR (-107)", () => {
+      const { container } = render(<BrowserPane {...baseProps} />);
+      const webview = getWebviewElement(container);
+
+      act(() => {
+        emitWebviewEvent(webview, "did-fail-load", {
+          errorCode: -107,
+          errorDescription: "ERR_SSL_PROTOCOL_ERROR",
+          isMainFrame: true,
+          validatedURL: "https://localhost:8443/",
+        });
+      });
+
+      expect(container.textContent).toContain("Certificate Error");
+      expect(container.textContent).toContain("mkcert -install");
+    });
+
+    it("surfaces ERR_FILE_NOT_FOUND (-6) instead of silently swallowing it", () => {
+      const { container } = render(<BrowserPane {...baseProps} />);
+      const webview = getWebviewElement(container);
+
+      act(() => {
+        emitWebviewEvent(webview, "did-fail-load", {
+          errorCode: -6,
+          errorDescription: "ERR_FILE_NOT_FOUND",
+          isMainFrame: true,
+          validatedURL: "http://localhost:5173/missing",
+        });
+      });
+
+      expect(container.textContent).toContain("Unable to Display Page");
+      expect(container.textContent).toContain("ERR_FILE_NOT_FOUND");
+    });
+
+    it("ignores sub-frame failures", () => {
+      const { container } = render(<BrowserPane {...baseProps} />);
+      const webview = getWebviewElement(container);
+
+      act(() => {
+        emitWebviewEvent(webview, "did-fail-load", {
+          errorCode: -105,
+          errorDescription: "ERR_NAME_NOT_RESOLVED",
+          isMainFrame: false,
+          validatedURL: "http://tracker.example.test/pixel.gif",
+        });
+      });
+
+      expect(container.textContent).not.toContain("Unable to Display Page");
+      expect(container.textContent).not.toContain("Couldn't resolve");
+    });
+
     it("cleans slow timer on unmount", () => {
       const { container, unmount } = render(<BrowserPane {...baseProps} />);
       const webview = getWebviewElement(container);

--- a/src/components/Browser/__tests__/browserUtils.test.ts
+++ b/src/components/Browser/__tests__/browserUtils.test.ts
@@ -5,6 +5,10 @@ import {
   isValidBrowserUrl,
   getDisplayUrl,
   extractHostPort,
+  clampZoom,
+  BROWSER_ZOOM_MIN,
+  BROWSER_ZOOM_MAX,
+  BROWSER_ZOOM_DEFAULT,
 } from "../browserUtils";
 
 describe("normalizeBrowserUrl", () => {
@@ -151,5 +155,30 @@ describe("extractHostPort", () => {
 
   it("should fallback to localhost for invalid URLs", () => {
     expect(extractHostPort("not a url")).toBe("localhost");
+  });
+});
+
+describe("clampZoom", () => {
+  it("returns in-range values unchanged", () => {
+    expect(clampZoom(1.0)).toBe(1.0);
+    expect(clampZoom(1.25)).toBe(1.25);
+    expect(clampZoom(BROWSER_ZOOM_MIN)).toBe(BROWSER_ZOOM_MIN);
+    expect(clampZoom(BROWSER_ZOOM_MAX)).toBe(BROWSER_ZOOM_MAX);
+  });
+
+  it("clamps values below the minimum", () => {
+    expect(clampZoom(0.1)).toBe(BROWSER_ZOOM_MIN);
+    expect(clampZoom(-1)).toBe(BROWSER_ZOOM_MIN);
+  });
+
+  it("clamps values above the maximum", () => {
+    expect(clampZoom(5)).toBe(BROWSER_ZOOM_MAX);
+    expect(clampZoom(2.5)).toBe(BROWSER_ZOOM_MAX);
+  });
+
+  it("returns the default for non-finite inputs", () => {
+    expect(clampZoom(Number.NaN)).toBe(BROWSER_ZOOM_DEFAULT);
+    expect(clampZoom(Number.POSITIVE_INFINITY)).toBe(BROWSER_ZOOM_DEFAULT);
+    expect(clampZoom(Number.NEGATIVE_INFINITY)).toBe(BROWSER_ZOOM_DEFAULT);
   });
 });

--- a/src/components/Browser/browserUtils.ts
+++ b/src/components/Browser/browserUtils.ts
@@ -36,3 +36,20 @@ export function isValidBrowserUrl(url: string | undefined | null): boolean {
   const normalized = normalizeUrl(url, { allowedHosts: [] });
   return !normalized.error && !!normalized.url;
 }
+
+export const BROWSER_ZOOM_MIN = 0.25;
+export const BROWSER_ZOOM_MAX = 2.0;
+export const BROWSER_ZOOM_DEFAULT = 1.0;
+
+export function clampZoom(value: number): number {
+  return Number.isFinite(value)
+    ? Math.max(BROWSER_ZOOM_MIN, Math.min(BROWSER_ZOOM_MAX, value))
+    : BROWSER_ZOOM_DEFAULT;
+}
+
+export type LoadErrorKind = "timeout" | "cancelled" | "cert" | "network" | "generic";
+
+export type LoadError = {
+  kind: LoadErrorKind;
+  message: string;
+};

--- a/src/hooks/useWebviewEvents.ts
+++ b/src/hooks/useWebviewEvents.ts
@@ -146,6 +146,11 @@ export function useWebviewEvents({
     };
 
     const handleDidFailLoad = (event: Electron.DidFailLoadEvent) => {
+      // Both early returns must precede the timer-clear block: a sub-frame
+      // failure (ad pixel, tracker) or a stale ERR_ABORTED from a superseded
+      // navigation must not disarm the active main-frame load timers.
+      if (event.errorCode === ERR_ABORTED) return;
+      if (!event.isMainFrame) return;
       setIsSlowLoad(false);
       if (slowLoadTimeoutRef.current) {
         clearTimeout(slowLoadTimeoutRef.current);
@@ -155,15 +160,10 @@ export function useWebviewEvents({
         clearTimeout(loadTimeoutRef.current);
         loadTimeoutRef.current = null;
       }
-      // ERR_ABORTED fires when a pending load is superseded by a new navigation —
-      // benign, mirrored by the loadURL-Promise filter in BrowserPane.
-      if (event.errorCode === ERR_ABORTED) return;
-      if (!event.isMainFrame) return;
       setIsLoading(false);
       const errorCode = event.errorCode;
       const isCertError =
-        errorCode === ERR_SSL_PROTOCOL_ERROR ||
-        (errorCode <= ERR_CERT_RANGE_END && errorCode >= ERR_CERT_RANGE_START);
+        errorCode <= ERR_CERT_RANGE_END && errorCode >= ERR_CERT_RANGE_START;
       if (errorCode === ERR_CONNECTION_REFUSED && isInitialRestoredLoadRef.current) {
         setLoadError({
           kind: "network",
@@ -186,10 +186,19 @@ export function useWebviewEvents({
           kind: "network",
           message: "No internet connection. Check your network.",
         });
-      } else if (errorCode === ERR_CONNECTION_TIMED_OUT && event.validatedURL) {
+      } else if (errorCode === ERR_CONNECTION_TIMED_OUT) {
+        const target = event.validatedURL ? ` to ${event.validatedURL}` : "";
         setLoadError({
           kind: "network",
-          message: `Connection to ${event.validatedURL} timed out. The server may be unreachable.`,
+          message: `Connection${target} timed out. The server may be unreachable.`,
+        });
+      } else if (errorCode === ERR_SSL_PROTOCOL_ERROR) {
+        // -107 also fires on protocol mismatch (HTTP server reached over HTTPS),
+        // so the cert/CA trust hint isn't always the right advice.
+        const hostContext = event.validatedURL ? ` to ${event.validatedURL}` : "";
+        setLoadError({
+          kind: "cert",
+          message: `SSL/TLS handshake failed${hostContext}. The server may not support HTTPS, or its certificate may be invalid.`,
         });
       } else if (isCertError) {
         const hostContext = event.validatedURL ? ` for ${event.validatedURL}` : "";

--- a/src/hooks/useWebviewEvents.ts
+++ b/src/hooks/useWebviewEvents.ts
@@ -162,8 +162,7 @@ export function useWebviewEvents({
       }
       setIsLoading(false);
       const errorCode = event.errorCode;
-      const isCertError =
-        errorCode <= ERR_CERT_RANGE_END && errorCode >= ERR_CERT_RANGE_START;
+      const isCertError = errorCode <= ERR_CERT_RANGE_END && errorCode >= ERR_CERT_RANGE_START;
       if (errorCode === ERR_CONNECTION_REFUSED && isInitialRestoredLoadRef.current) {
         setLoadError({
           kind: "network",

--- a/src/hooks/useWebviewEvents.ts
+++ b/src/hooks/useWebviewEvents.ts
@@ -1,6 +1,7 @@
 import { useEffect, useEffectEvent } from "react";
 import type { BrowserHistory } from "@shared/types/browser";
 import { pushBrowserHistory } from "@/components/Browser/historyUtils";
+import type { LoadError } from "@/components/Browser/browserUtils";
 import { useUrlHistoryStore } from "@/store/urlHistoryStore";
 
 // Threshold after which a load is reported as "Taking longer than usual…"
@@ -8,6 +9,16 @@ import { useUrlHistoryStore } from "@/store/urlHistoryStore";
 const SLOW_LOAD_THRESHOLD_MS = 5000;
 // Coalesce favicon-updated bursts to avoid thrashing the URL-history store.
 const FAVICON_DEBOUNCE_MS = 200;
+
+// Chromium net error codes — see net/base/net_error_list.h
+const ERR_ABORTED = -3;
+const ERR_SSL_PROTOCOL_ERROR = -107;
+const ERR_CERT_RANGE_END = -200;
+const ERR_CERT_RANGE_START = -299;
+const ERR_CONNECTION_REFUSED = -102;
+const ERR_NAME_NOT_RESOLVED = -105;
+const ERR_INTERNET_DISCONNECTED = -106;
+const ERR_CONNECTION_TIMED_OUT = -118;
 
 export type UseWebviewEventsOptions = {
   webviewElement: Electron.WebviewTag | null;
@@ -21,7 +32,7 @@ export type UseWebviewEventsOptions = {
   zoomFactor: number;
   setIsWebviewReady: (v: boolean) => void;
   setIsLoading: (v: boolean) => void;
-  setLoadError: (v: string | null) => void;
+  setLoadError: (v: LoadError | null) => void;
   setIsSlowLoad: (v: boolean) => void;
   setBlockedNav: (v: { url: string; canOpenExternal: boolean } | null) => void;
   setHistory: React.Dispatch<React.SetStateAction<BrowserHistory>>;
@@ -110,9 +121,10 @@ export function useWebviewEvents({
             webview.stop();
             setIsSlowLoad(false);
             setIsLoading(false);
-            setLoadError(
-              `Load timed out after ${Math.round(timeoutMs / 1000)}s. The server at ${webview.getURL()} may be unreachable or slow to respond.`
-            );
+            setLoadError({
+              kind: "timeout",
+              message: `Load timed out after ${Math.round(timeoutMs / 1000)}s. The server at ${webview.getURL()} may be unreachable or slow to respond.`,
+            });
           }
         } catch {
           // Webview detached before timeout fired
@@ -143,52 +155,56 @@ export function useWebviewEvents({
         clearTimeout(loadTimeoutRef.current);
         loadTimeoutRef.current = null;
       }
-      // Ignore aborted loads (e.g., navigation interrupted by another navigation)
-      if (event.errorCode === -3) return;
-      // Ignore cancellations
-      if (event.errorCode === -6) return;
+      // ERR_ABORTED fires when a pending load is superseded by a new navigation —
+      // benign, mirrored by the loadURL-Promise filter in BrowserPane.
+      if (event.errorCode === ERR_ABORTED) return;
+      if (!event.isMainFrame) return;
       setIsLoading(false);
-      const ERR_CONNECTION_REFUSED = -102;
-      const ERR_NAME_NOT_RESOLVED = -105;
-      const ERR_INTERNET_DISCONNECTED = -106;
-      const ERR_CONNECTION_TIMED_OUT = -118;
-      if (
-        event.isMainFrame &&
-        event.errorCode === ERR_CONNECTION_REFUSED &&
-        isInitialRestoredLoadRef.current
-      ) {
-        setLoadError(
-          "The saved URL is no longer reachable. The server may have moved to a different port."
-        );
-      } else if (
-        event.isMainFrame &&
-        event.errorCode === ERR_NAME_NOT_RESOLVED &&
-        event.validatedURL
-      ) {
+      const errorCode = event.errorCode;
+      const isCertError =
+        errorCode === ERR_SSL_PROTOCOL_ERROR ||
+        (errorCode <= ERR_CERT_RANGE_END && errorCode >= ERR_CERT_RANGE_START);
+      if (errorCode === ERR_CONNECTION_REFUSED && isInitialRestoredLoadRef.current) {
+        setLoadError({
+          kind: "network",
+          message:
+            "The saved URL is no longer reachable. The server may have moved to a different port.",
+        });
+      } else if (errorCode === ERR_NAME_NOT_RESOLVED && event.validatedURL) {
         let hostname = event.validatedURL;
         try {
           hostname = new URL(event.validatedURL).hostname;
         } catch {
           // Use raw validatedURL if parsing fails
         }
-        setLoadError(`Couldn't resolve ${hostname}. Check the URL or your connection.`);
-      } else if (event.isMainFrame && event.errorCode === ERR_INTERNET_DISCONNECTED) {
-        setLoadError("No internet connection. Check your network.");
-      } else if (
-        event.isMainFrame &&
-        event.errorCode === ERR_CONNECTION_TIMED_OUT &&
-        event.validatedURL
-      ) {
-        setLoadError(
-          `Connection to ${event.validatedURL} timed out. The server may be unreachable.`
-        );
-      } else if (event.isMainFrame) {
+        setLoadError({
+          kind: "network",
+          message: `Couldn't resolve ${hostname}. Check the URL or your connection.`,
+        });
+      } else if (errorCode === ERR_INTERNET_DISCONNECTED) {
+        setLoadError({
+          kind: "network",
+          message: "No internet connection. Check your network.",
+        });
+      } else if (errorCode === ERR_CONNECTION_TIMED_OUT && event.validatedURL) {
+        setLoadError({
+          kind: "network",
+          message: `Connection to ${event.validatedURL} timed out. The server may be unreachable.`,
+        });
+      } else if (isCertError) {
+        const hostContext = event.validatedURL ? ` for ${event.validatedURL}` : "";
+        setLoadError({
+          kind: "cert",
+          message: `The site's certificate couldn't be verified${hostContext}. If this is a local development server, make sure the local CA is trusted (e.g. run \`mkcert -install\`).`,
+        });
+      } else {
         const urlContext = event.validatedURL ? ` at ${event.validatedURL}` : "";
-        setLoadError(
-          event.errorDescription
+        setLoadError({
+          kind: "generic",
+          message: event.errorDescription
             ? `${event.errorDescription}${urlContext}`
-            : `Failed to load page${urlContext}. The site may be unavailable.`
-        );
+            : `Failed to load page${urlContext}. The site may be unavailable.`,
+        });
       }
     };
 


### PR DESCRIPTION
## Summary

- Replaces ad-hoc string branching in `did-fail-load` with a typed `LoadError` discriminated union, adds explicit cert (`-200..-299` with mkcert hint) and `ERR_SSL_PROTOCOL_ERROR` (`-107`) branches, and drops a misleading `ERR_FILE_NOT_FOUND` filter that was masking real errors.
- Hoists `ERR_ABORTED` and non-main-frame early-return guards above the timer-clear block — previously a sub-frame failure or stale navigation could silently disarm the active slow-load and hard-timeout timers, leaving the visible page stuck with no escalation.
- Removes the always-false `urlMightBeStale` prop and its warning dot from `BrowserToolbar`, extracts the duplicated zoom-clamp expression to `clampZoom()` with `BROWSER_ZOOM_MIN/MAX/DEFAULT` constants, and replaces the silent `loadURL` `.catch(() => {})` with a selective catch that filters `ERR_ABORTED` (`-3`) numerically and logs anything else.

Resolves #7216

## Changes

- `browserUtils.ts`: `LoadError` discriminated union (`timeout` / `cancelled` / `cert` / `ssl` / `network` / `generic`), `clampZoom()`, zoom constants
- `useWebviewEvents.ts`: typed error dispatch, hoisted guards, selective `loadURL` catch
- `BrowserToolbar.tsx`: `urlMightBeStale` prop and warning dot removed
- `BrowserPane.tsx`: updated to typed error model
- New tests in `BrowserPane.webview.test.tsx` and `browserUtils.test.ts`

## Testing

78 unit tests passing. 6 new tests cover: `clampZoom()` bounds, cert `-202`, ssl `-107`, `-6` now surfacing instead of being filtered, sub-frame events being ignored, sub-frame events not disarming timers, stale `ERR_ABORTED` not disarming a new navigation's timers, and `-118` without a `validatedURL`.