### PR TITLE
chore(shared): pre-release fixes across utils and config

### DIFF
--- a/shared/config/scrollback.ts
+++ b/shared/config/scrollback.ts
@@ -13,6 +13,10 @@ export function normalizeScrollbackLines(value: unknown): number {
 
   const intValue = Math.trunc(coerced);
 
+  // Both -1 and 0 are "use max" sentinels: -1 is the explicit user intent for
+  // "unlimited", and 0 is a backwards-compatible alias preserved because
+  // earlier persisted configs may still contain it. xterm.js itself rejects 0
+  // as a scrollback value, so we never pass either through unchanged.
   if (intValue === -1 || intValue === 0) {
     return SCROLLBACK_MAX;
   }

--- a/shared/config/voiceCorrection.ts
+++ b/shared/config/voiceCorrection.ts
@@ -4,6 +4,28 @@ export const CONFIDENCE_SKIP_THRESHOLD = 0.85;
 /** Tag words below this confidence with <uncertain> in the LLM prompt. */
 export const CONFIDENCE_TAG_THRESHOLD = 0.8;
 
+const SHARED_TERMS_BLOCK = `<terms>
+racked/react: React
+type script: TypeScript
+next jess: Next.js
+get hub: GitHub
+cube netties: Kubernetes
+post gress: Postgres
+graph cue el: GraphQL
+engine ex: Nginx
+web pack: Webpack
+pie test: pytest
+see eye: CI
+node jess: Node.js
+vie test: Vitest
+tail wind: Tailwind
+zoo stand: Zustand
+prism a: Prisma
+rediss: Redis
+E S lint: ESLint
+docker compose: Docker Compose
+</terms>`;
+
 export const CORE_CORRECTION_PROMPT = `You are a speech-to-text correction engine for a developer dictating to AI coding agents.
 
 TASK: Clean up the CURRENT TARGET only. Treat it as the full dictated passage for this recording stop. Do not repeat or modify anything outside the target.
@@ -29,27 +51,7 @@ CORRECTION PRIORITY:
 
 PRESERVE: Keep the speaker's meaning, ordering, and phrasing intact. You may lightly restructure punctuation and paragraph breaks so the dictated passage reads cleanly, but do not turn it into polished prose, add new information, or rewrite it stylistically. If the target is already clean enough, return it character-for-character without any modification.
 
-<terms>
-racked/react: React
-type script: TypeScript
-next jess: Next.js
-get hub: GitHub
-cube netties: Kubernetes
-post gress: Postgres
-graph cue el: GraphQL
-engine ex: Nginx
-web pack: Webpack
-pie test: pytest
-see eye: CI
-node jess: Node.js
-vie test: Vitest
-tail wind: Tailwind
-zoo stand: Zustand
-prism a: Prisma
-rediss: Redis
-E S lint: ESLint
-docker compose: Docker Compose
-</terms>`;
+${SHARED_TERMS_BLOCK}`;
 
 const GUARDRAIL_SUFFIX = `Return a JSON object that matches the response schema.
 - Use "no_change" when the input should remain exactly as-is.
@@ -72,27 +74,7 @@ PHONETIC MATCHING PRIORITY:
 2. TECHNICAL TERMS — Correct misheard programming terms using the dictionary below.
 3. HOMOPHONES — Fix their/there, its/it's when context makes the correct form unambiguous.
 
-<terms>
-racked/react: React
-type script: TypeScript
-next jess: Next.js
-get hub: GitHub
-cube netties: Kubernetes
-post gress: Postgres
-graph cue el: GraphQL
-engine ex: Nginx
-web pack: Webpack
-pie test: pytest
-see eye: CI
-node jess: Node.js
-vie test: Vitest
-tail wind: Tailwind
-zoo stand: Zustand
-prism a: Prisma
-rediss: Redis
-E S lint: ESLint
-docker compose: Docker Compose
-</terms>`;
+${SHARED_TERMS_BLOCK}`;
 
 const MICRO_GUARDRAIL_SUFFIX = `Return a JSON object that matches the response schema.
 - Use "no_change" when the uncertain word(s) are correct as-is in context.

--- a/shared/utils/__tests__/artifactParser.test.ts
+++ b/shared/utils/__tests__/artifactParser.test.ts
@@ -122,4 +122,9 @@ describe("artifactParser", () => {
     const cleaned = stripAnsiCodes("before\x90payload\x9cafter");
     expect(cleaned).toBe("beforeafter");
   });
+
+  it("strips 8-bit CSI sequences (C1 introducer 0x9B)", () => {
+    const cleaned = stripAnsiCodes("\x9b31mError:\x9b0m failed");
+    expect(cleaned).toBe("Error: failed");
+  });
 });

--- a/shared/utils/__tests__/artifactParser.test.ts
+++ b/shared/utils/__tests__/artifactParser.test.ts
@@ -112,4 +112,14 @@ describe("artifactParser", () => {
     const cleaned = stripAnsiCodes(input);
     expect(cleaned).toBe("https://youtube.com/watch?v=abc12345678");
   });
+
+  it("strips DCS sequences (Kitty graphics / Sixel / tmux passthrough)", () => {
+    const cleaned = stripAnsiCodes("before\x1bPpayload\x1b\\after");
+    expect(cleaned).toBe("beforeafter");
+  });
+
+  it("strips 8-bit C1 string sequences (DCS/SOS/PM/APC)", () => {
+    const cleaned = stripAnsiCodes("before\x90payload\x9cafter");
+    expect(cleaned).toBe("beforeafter");
+  });
 });

--- a/shared/utils/__tests__/envVars.test.ts
+++ b/shared/utils/__tests__/envVars.test.ts
@@ -14,6 +14,16 @@ describe("isSensitiveEnvKey", () => {
     expect(isSensitiveEnvKey("DB_SECRET_VALUE")).toBe(true);
   });
 
+  it("matches credential and passphrase patterns", () => {
+    expect(isSensitiveEnvKey("GOOGLE_APPLICATION_CREDENTIALS")).toBe(true);
+    expect(isSensitiveEnvKey("AWS_CREDENTIAL_EXPIRATION")).toBe(true);
+    expect(isSensitiveEnvKey("CREDENTIAL")).toBe(true);
+    expect(isSensitiveEnvKey("CREDENTIALS")).toBe(true);
+    expect(isSensitiveEnvKey("SSH_PASSPHRASE")).toBe(true);
+    expect(isSensitiveEnvKey("GPG_PASSPHRASE")).toBe(true);
+    expect(isSensitiveEnvKey("PASSPHRASE")).toBe(true);
+  });
+
   it("matches lowercase variants (case-insensitive)", () => {
     expect(isSensitiveEnvKey("api_key")).toBe(true);
     expect(isSensitiveEnvKey("my_token")).toBe(true);

--- a/shared/utils/__tests__/recipeFilename.test.ts
+++ b/shared/utils/__tests__/recipeFilename.test.ts
@@ -28,6 +28,14 @@ describe("safeRecipeFilename", () => {
     const filename = safeRecipeFilename(longName);
     expect(filename).toBe("a".repeat(200) + ".json");
   });
+
+  it("strips a trailing hyphen exposed by truncation", () => {
+    // 199 chars + a space → space becomes hyphen at position 199; slice cuts
+    // exactly at position 200, so the trailing hyphen must be stripped after.
+    const filename = safeRecipeFilename("a".repeat(199) + " more text here");
+    expect(filename).toBe("a".repeat(199) + ".json");
+    expect(filename).not.toContain("-.");
+  });
 });
 
 describe("stableInRepoId", () => {

--- a/shared/utils/artifactParser.ts
+++ b/shared/utils/artifactParser.ts
@@ -3,6 +3,8 @@
  * Used by browser/worker artifact extraction.
  */
 
+import { stripAnsiAndOscCodes } from "./urlUtils.js";
+
 export interface CodeBlock {
   language: string;
   content: string;
@@ -122,12 +124,5 @@ export function suggestFilename(language: string, content: string): string | und
 }
 
 export function stripAnsiCodes(text: string): string {
-  /* eslint-disable no-control-regex */
-  let result = text.replace(
-    /[\u001b\u009b][[()#;?]*(?:[0-9]{1,4}(?:;[0-9]{0,4})*)?[0-9A-ORZcf-nqry=><]/g,
-    ""
-  );
-  result = result.replace(/\x1b\]8;[^;]*;[^\x1b\x07]*(?:\x1b\\|\x07)/g, "");
-  /* eslint-enable no-control-regex */
-  return result;
+  return stripAnsiAndOscCodes(text);
 }

--- a/shared/utils/envVars.ts
+++ b/shared/utils/envVars.ts
@@ -2,7 +2,8 @@
  * Shared utilities for environment variable handling
  */
 
-const SENSITIVE_ENV_KEY_RE = /(?<![A-Za-z])(?:KEY|SECRET|TOKEN|PASSWORD)(?![A-Za-z])/i;
+const SENSITIVE_ENV_KEY_RE =
+  /(?<![A-Za-z])(?:KEY|SECRET|TOKEN|PASSWORD|CREDENTIALS?|PASSPHRASE)(?![A-Za-z])/i;
 
 /**
  * Determines if an environment variable key should be stored securely

--- a/shared/utils/frecency.ts
+++ b/shared/utils/frecency.ts
@@ -1,4 +1,8 @@
 export const FRECENCY_HALF_LIFE_MS = 5 * 24 * 60 * 60 * 1000;
+// Exploration bias for never-accessed items: ~3 half-lives of stickiness so a
+// new item can accrue real frequency before decay buries it under a single
+// recent access of an older item. Without this seed, one click on a stale
+// favourite would drop a cold item below it for days.
 export const FRECENCY_COLD_START = 3.0;
 export const FRECENCY_INCREMENT = 1.0;
 

--- a/shared/utils/recipeFilename.ts
+++ b/shared/utils/recipeFilename.ts
@@ -11,9 +11,11 @@ export function safeRecipeFilename(name: string): string {
       .replace(/[\\/:*?"<>|]/g, "") // strip OS-forbidden chars
       .replace(/\s+/g, "-") // spaces → hyphens
       .replace(/-+/g, "-") // collapse consecutive hyphens
-      .replace(/^[-.]+|[-.]+$/g, "") // no leading/trailing hyphens or dots
       .toLowerCase()
-      .slice(0, 200) || "recipe";
+      .slice(0, 200)
+      // Trailing-strip runs after slice so a hyphen or dot left dangling at
+      // position 200 (e.g. interior whitespace at char 199) is removed.
+      .replace(/^[-.]+|[-.]+$/g, "") || "recipe";
 
   return `${base}.json`;
 }

--- a/shared/utils/urlUtils.ts
+++ b/shared/utils/urlUtils.ts
@@ -181,7 +181,8 @@ export function stripAnsiAndOscCodes(text: string): string {
       .replace(/\x9d[^\x9c\x07]*[\x9c\x07]/g, "")
       // CSI sequences: parameter bytes (0x30-0x3F), optional intermediate bytes
       // (0x20-0x2F), and a final byte (0x40-0x7E covers A-Z, a-z, @, ~, etc.).
-      .replace(/\x1b\[[\x30-\x3f]*[\x20-\x2f]*[\x40-\x7e]/g, "")
+      // Accept both the 7-bit introducer (ESC [) and the 8-bit C1 form (0x9B).
+      .replace(/(?:\x1b\[|\x9b)[\x30-\x3f]*[\x20-\x2f]*[\x40-\x7e]/g, "")
   );
 }
 


### PR DESCRIPTION
## Summary

- Six small pre-release fixes across shared utilities and config: deduplicating a terms constant in `voiceCorrection.ts`, delegating to the more thorough `stripAnsiAndOscCodes` in `artifactParser.ts`, fixing trailing-punctuation stripping order in `recipeFilename.ts`, adding `CREDENTIAL` and `PASSPHRASE` patterns to `envVars.ts`, and adding explanatory comments to `scrollback.ts` and `frecency.ts`
- Also strips the 8-bit CSI introducer (`0x9B`) in `urlUtils.ts`, which was missed by the original regex coverage
- Tests added for all affected utils

Resolves #7302

## Changes

- `shared/config/voiceCorrection.ts` — duplicated 19-line terms block extracted to a shared `VOICE_CORRECTION_TERMS` constant; both prompts reference it
- `shared/utils/artifactParser.ts` — `stripAnsiCodes` replaced with a call to `stripAnsiAndOscCodes` from `urlUtils.ts`, which covers DCS/SOS/PM/APC, C1 controls, and 8-bit C1 equivalents
- `shared/utils/recipeFilename.ts` — `.slice(0, 200)` moved before the trailing-punctuation strip so interior punctuation can't become trailing
- `shared/utils/envVars.ts` — `CREDENTIAL` and `PASSPHRASE` added to the sensitive-key pattern
- `shared/config/scrollback.ts` — comment added explaining the `0` and `-1` sentinels
- `shared/utils/frecency.ts` — comment added explaining the exploration-bias intent of `FRECENCY_COLD_START`
- `shared/utils/urlUtils.ts` — `0x9B` (8-bit CSI introducer) added to the ANSI strip regex
- Tests added in `shared/utils/__tests__/` for `artifactParser`, `envVars`, and `recipeFilename`

## Testing

- Existing unit test suites pass
- New unit tests added covering the `artifactParser` ANSI delegation, `envVars` pattern matching for `CREDENTIAL` and `PASSPHRASE`, and the `recipeFilename` slice-then-strip ordering