### PR TITLE
chore(e2e): dedup launch helpers, add fixture cleanup, drop dead preset selector

### DIFF
--- a/e2e/core/core-persistence.spec.ts
+++ b/e2e/core/core-persistence.spec.ts
@@ -79,10 +79,13 @@ test.describe.serial("Persistence: Project memory across restart", () => {
   let userDataDir: string;
   let fixtureDir: string;
   let ctx: AppContext | null = null;
+  let fixtureCleanup: (() => void) | undefined;
 
   test.beforeAll(async () => {
     userDataDir = mkdtempSync(path.join(tmpdir(), "daintree-e2e-persist-project-"));
-    fixtureDir = createFixtureRepo({ name: "persistence-test" });
+    const { dir, cleanup } = createFixtureRepo({ name: "persistence-test" });
+    fixtureDir = dir;
+    fixtureCleanup = cleanup;
   });
 
   test.afterAll(async () => {
@@ -93,7 +96,7 @@ test.describe.serial("Persistence: Project memory across restart", () => {
       ctx = null;
     }
     rmSync(userDataDir, { recursive: true, force: true });
-    rmSync(fixtureDir, { recursive: true, force: true });
+    fixtureCleanup?.();
   });
 
   test("previously onboarded project appears after restart", async () => {

--- a/e2e/core/core-process-badge.spec.ts
+++ b/e2e/core/core-process-badge.spec.ts
@@ -8,6 +8,7 @@ import { T_LONG } from "../helpers/timeouts";
 
 let ctx: AppContext;
 let fixtureDir: string;
+let fixtureCleanup: (() => void) | undefined;
 
 // #5813: the process icon badge (npm, pnpm, docker, node, etc.) must surface
 // on plain terminals running a recognised non-agent process. The badge is
@@ -16,13 +17,16 @@ let fixtureDir: string;
 // `data-detected-process-id` attribute.
 test.describe.serial("Core: Process Icon Badge", () => {
   test.beforeAll(async () => {
-    fixtureDir = createFixtureRepo({ name: "process-badge" });
+    const { dir, cleanup } = createFixtureRepo({ name: "process-badge" });
+    fixtureDir = dir;
+    fixtureCleanup = cleanup;
     ctx = await launchApp();
     ctx.window = await openAndOnboardProject(ctx.app, ctx.window, fixtureDir, "Process Badge Test");
   });
 
   test.afterAll(async () => {
     if (ctx?.app) await closeApp(ctx.app);
+    fixtureCleanup?.();
   });
 
   test("node process running a timed script surfaces the node badge, then clears on exit", async () => {

--- a/e2e/core/core-terminal-agent-promotion.spec.ts
+++ b/e2e/core/core-terminal-agent-promotion.spec.ts
@@ -13,6 +13,7 @@ import { T_LONG, T_MEDIUM } from "../helpers/timeouts";
 let ctx: AppContext;
 let fixtureDir: string;
 let fakeBinDir: string;
+let fixtureCleanup: (() => void) | undefined;
 
 const AGENT_STATE_VALUES = new Set([
   "idle",
@@ -199,7 +200,9 @@ async function newestPanelId(page: Page, previousIds: Set<string>): Promise<stri
 }
 
 function prepareFixture(): void {
-  fixtureDir = createFixtureRepo({ name: "terminal-agent-promotion" });
+  const { dir, cleanup } = createFixtureRepo({ name: "terminal-agent-promotion" });
+  fixtureDir = dir;
+  fixtureCleanup = cleanup;
   // Keep a space in the fake CLI path so toolbar launches exercise the same
   // quoted absolute executable form that real resolved paths can use.
   fakeBinDir = path.join(fixtureDir, ".e2e bin");
@@ -280,6 +283,7 @@ test.describe.serial("Core: terminal runtime agent promotion", () => {
 
   test.afterAll(async () => {
     if (ctx?.app) await closeApp(ctx.app);
+    fixtureCleanup?.();
   });
 
   test("toolbar Claude launch and plain-terminal Claude command both activate agent chrome/state", async () => {

--- a/e2e/core/core-worktree-lifecycle.spec.ts
+++ b/e2e/core/core-worktree-lifecycle.spec.ts
@@ -12,12 +12,14 @@ import { ensureWindowFocused } from "../helpers/focus";
 let ctx: AppContext;
 let mainBranch: string;
 let worktreeDirName: string;
+let fixtureCleanup: (() => void) | undefined;
 
 const BRANCH = "e2e/lifecycle-test";
 
 test.describe.serial("Core: Worktree Lifecycle", () => {
   test.beforeAll(async () => {
-    const fixture = createFixtureRepo({ name: "worktree-lifecycle" });
+    const { dir: fixture, cleanup } = createFixtureRepo({ name: "worktree-lifecycle" });
+    fixtureCleanup = cleanup;
 
     ctx = await launchApp();
     ctx.window = await openAndOnboardProject(ctx.app, ctx.window, fixture, "Worktree Lifecycle");
@@ -25,6 +27,7 @@ test.describe.serial("Core: Worktree Lifecycle", () => {
 
   test.afterAll(async () => {
     if (ctx?.app) await closeApp(ctx.app);
+    fixtureCleanup?.();
   });
 
   test("main worktree card is visible and selected", async () => {

--- a/e2e/full/adversarial-system.spec.ts
+++ b/e2e/full/adversarial-system.spec.ts
@@ -12,12 +12,14 @@ import {
 } from "../helpers/presets";
 
 let ctx: AppContext;
+let fixtureCleanup: (() => void) | undefined;
 
 test.describe.serial("Adversarial E2E Tests: System Breakage", () => {
   test.beforeAll(async () => {
     removeCcrConfig();
     ctx = await launchApp();
-    const fixtureDir = createFixtureRepo({ name: "adversarial-e2e" });
+    const { dir: fixtureDir, cleanup } = createFixtureRepo({ name: "adversarial-e2e" });
+    fixtureCleanup = cleanup;
     ctx.window = await openAndOnboardProject(
       ctx.app,
       ctx.window,
@@ -29,6 +31,7 @@ test.describe.serial("Adversarial E2E Tests: System Breakage", () => {
   test.afterAll(async () => {
     removeCcrConfig();
     if (ctx?.app) await closeApp(ctx.app);
+    fixtureCleanup?.();
   });
 
   const goToClaudeSettings = async () => {

--- a/e2e/full/ccr-ui-debug.spec.ts
+++ b/e2e/full/ccr-ui-debug.spec.ts
@@ -12,16 +12,19 @@ import {
 } from "../helpers/presets";
 
 let ctx: AppContext;
+let fixtureCleanup: (() => void) | undefined;
 test.describe("CCR UI Debug", () => {
   test.beforeAll(async () => {
     writeCcrConfig([{ id: "uidbg", name: "UI Debug", model: "uidbg-model" }]);
     ctx = await launchApp();
-    const fixtureDir = createFixtureRepo({ name: "ccr-ui-debug" });
+    const { dir: fixtureDir, cleanup } = createFixtureRepo({ name: "ccr-ui-debug" });
+    fixtureCleanup = cleanup;
     ctx.window = await openAndOnboardProject(ctx.app, ctx.window, fixtureDir, "UI Debug");
   });
   test.afterAll(async () => {
     removeCcrConfig();
     if (ctx?.app) await closeApp(ctx.app);
+    fixtureCleanup?.();
   });
 
   test("presets section appears after navigating to Claude settings", async () => {

--- a/e2e/full/core-accessibility.spec.ts
+++ b/e2e/full/core-accessibility.spec.ts
@@ -11,6 +11,7 @@ import { getActiveElementInfo, elementKey, escapeTerminalFocus } from "../helper
 
 let ctx: AppContext;
 const mod = process.platform === "darwin" ? "Meta" : "Control";
+let fixtureCleanup: (() => void) | undefined;
 
 function buildAxeScanner(page: import("@playwright/test").Page) {
   return (
@@ -48,6 +49,7 @@ test.describe.serial("Core: Accessibility", () => {
 
   test.afterAll(async () => {
     if (ctx?.app) await closeApp(ctx.app);
+    fixtureCleanup?.();
   });
 
   // -- Axe WCAG 2.2 AA Audits --
@@ -66,7 +68,8 @@ test.describe.serial("Core: Accessibility", () => {
 
     test.describe.serial("With Project", () => {
       test.beforeAll(async () => {
-        const fixtureDir = createFixtureRepo({ name: "accessibility" });
+        const { dir: fixtureDir, cleanup } = createFixtureRepo({ name: "accessibility" });
+        fixtureCleanup = cleanup;
         ctx.window = await openAndOnboardProject(
           ctx.app,
           ctx.window,

--- a/e2e/full/core-action-palette-commands.spec.ts
+++ b/e2e/full/core-action-palette-commands.spec.ts
@@ -11,16 +11,20 @@ const mod = process.platform === "darwin" ? "Meta" : "Control";
 
 let ctx: AppContext;
 let fixtureDir: string;
+let fixtureCleanup: (() => void) | undefined;
 
 test.describe.serial("Core: Action Palette, Command Picker & Quick Switcher", () => {
   test.beforeAll(async () => {
-    fixtureDir = createFixtureRepo({ name: "palettes-test", withMultipleFiles: true });
+    const { dir, cleanup } = createFixtureRepo({ name: "palettes-test", withMultipleFiles: true });
+    fixtureDir = dir;
+    fixtureCleanup = cleanup;
     ctx = await launchApp();
     ctx.window = await openAndOnboardProject(ctx.app, ctx.window, fixtureDir, "Palette Test");
   });
 
   test.afterAll(async () => {
     if (ctx?.app) await closeApp(ctx.app);
+    fixtureCleanup?.();
   });
 
   // ── Action Palette (4 tests) ──────────────────────────────

--- a/e2e/full/core-advanced.spec.ts
+++ b/e2e/full/core-advanced.spec.ts
@@ -18,6 +18,8 @@ let port: number;
 let mainBranch: string;
 let switchRepo: string;
 const PROJECT_NAME = "advanced-test";
+let cleanupMain: (() => void) | undefined;
+let cleanupSwitch: (() => void) | undefined;
 
 test.describe.serial("Core: Advanced", () => {
   test.beforeAll(async () => {
@@ -36,15 +38,20 @@ test.describe.serial("Core: Advanced", () => {
       withFeatureBranch: true,
       withMultipleFiles: true,
     });
-    switchRepo = createFixtureRepo({ name: "switch-project" });
+    cleanupMain = mainFixture.cleanup;
+    const switchFixture = createFixtureRepo({ name: "switch-project" });
+    cleanupSwitch = switchFixture.cleanup;
+    switchRepo = switchFixture.dir;
 
     ctx = await launchApp();
-    ctx.window = await openAndOnboardProject(ctx.app, ctx.window, mainFixture, PROJECT_NAME);
+    ctx.window = await openAndOnboardProject(ctx.app, ctx.window, mainFixture.dir, PROJECT_NAME);
   });
 
   test.afterAll(async () => {
     if (ctx?.app) await closeApp(ctx.app);
     server?.close();
+    cleanupMain?.();
+    cleanupSwitch?.();
   });
 
   // ── Browser & Portal (3 tests) ───────────────────

--- a/e2e/full/core-agent-preset-icon-color.spec.ts
+++ b/e2e/full/core-agent-preset-icon-color.spec.ts
@@ -1,5 +1,5 @@
 import { test, expect, type Locator, type Page } from "@playwright/test";
-import { chmodSync, mkdirSync, rmSync, writeFileSync } from "fs";
+import { chmodSync, mkdirSync, writeFileSync } from "fs";
 import path from "path";
 import {
   launchApp,
@@ -29,6 +29,7 @@ const CODEX_COLOR = "#22aa66";
 let ctx: AppContext;
 let fixtureDir: string;
 let fakeBinDir: string;
+let fixtureCleanup: (() => void) | undefined;
 
 async function dispatchAction<T = unknown>(
   page: Page,
@@ -115,7 +116,9 @@ function writeFakeAgent(agentId: "claude" | "codex"): void {
 }
 
 function prepareFixture(): void {
-  fixtureDir = createFixtureRepo({ name: "agent-preset-icon-color" });
+  const { dir, cleanup } = createFixtureRepo({ name: "agent-preset-icon-color" });
+  fixtureDir = dir;
+  fixtureCleanup = cleanup;
   fakeBinDir = path.join(fixtureDir, ".e2e-bin");
   mkdirSync(fakeBinDir, { recursive: true });
   writeFakeAgent("claude");
@@ -302,7 +305,7 @@ test.describe.serial("Core: Agent preset icon color", () => {
 
   test.afterAll(async () => {
     if (ctx?.app) await closeApp(ctx.app);
-    if (fixtureDir) rmSync(fixtureDir, { recursive: true, force: true });
+    fixtureCleanup?.();
   });
 
   test("preset color tints launch, survives app restart, and reapplies after quit/restart", async () => {

--- a/e2e/full/core-bondi-visual-review.spec.ts
+++ b/e2e/full/core-bondi-visual-review.spec.ts
@@ -1,6 +1,4 @@
 import { test } from "@playwright/test";
-import path from "path";
-import { rmSync } from "fs";
 import { launchApp, closeApp, type AppContext } from "../helpers/launch";
 import { createFixtureRepo } from "../helpers/fixtures";
 import { openAndOnboardProject } from "../helpers/project";
@@ -22,14 +20,17 @@ async function switchTheme(page: import("@playwright/test").Page, themeId: strin
 
 let ctx: AppContext;
 let repoDir: string;
+let cleanupFixture: (() => void) | undefined;
 
 test.describe.serial("Core: Bondi Visual Review", () => {
   test.beforeAll(async () => {
-    repoDir = createFixtureRepo({
+    const fixture = createFixtureRepo({
       name: "bondi-review",
       withFeatureBranch: true,
       withUncommittedChanges: true,
     });
+    repoDir = fixture.dir;
+    cleanupFixture = fixture.cleanup;
 
     ctx = await launchApp();
     ctx.window = await openAndOnboardProject(ctx.app, ctx.window, repoDir, "Bondi Review");
@@ -39,19 +40,7 @@ test.describe.serial("Core: Bondi Visual Review", () => {
 
   test.afterAll(async () => {
     if (ctx?.app) await closeApp(ctx.app);
-    if (repoDir) {
-      const worktreeDir = path.join(path.dirname(repoDir), path.basename(repoDir) + "-worktrees");
-      try {
-        rmSync(worktreeDir, { recursive: true, force: true });
-      } catch {
-        /* best-effort */
-      }
-      try {
-        rmSync(repoDir, { recursive: true, force: true });
-      } catch {
-        /* best-effort */
-      }
-    }
+    cleanupFixture?.();
   });
 
   // eslint-disable-next-line no-empty-pattern

--- a/e2e/full/core-browser-panel.spec.ts
+++ b/e2e/full/core-browser-panel.spec.ts
@@ -32,6 +32,8 @@ function handleRequest(_req: IncomingMessage, res: ServerResponse) {
 }
 
 test.describe.serial("Core: Browser Panel", () => {
+  let fixtureCleanup: (() => void) | undefined;
+
   test.beforeAll(async () => {
     server = createServer(handleRequest);
     await new Promise<void>((resolve) => {
@@ -40,7 +42,8 @@ test.describe.serial("Core: Browser Panel", () => {
     const addr = server.address();
     port = typeof addr === "object" && addr ? addr.port : 0;
 
-    const fixture = createFixtureRepo({ name: "browser-panel-test" });
+    const { dir: fixture, cleanup } = createFixtureRepo({ name: "browser-panel-test" });
+    fixtureCleanup = cleanup;
     ctx = await launchApp();
     ctx.window = await openAndOnboardProject(ctx.app, ctx.window, fixture, "Browser Panel Test");
   });
@@ -48,6 +51,7 @@ test.describe.serial("Core: Browser Panel", () => {
   test.afterAll(async () => {
     if (ctx?.app) await closeApp(ctx.app);
     server?.close();
+    fixtureCleanup?.();
   });
 
   test.describe.serial("Navigation and History", () => {

--- a/e2e/full/core-concurrent-operations.spec.ts
+++ b/e2e/full/core-concurrent-operations.spec.ts
@@ -16,6 +16,7 @@ const mod = process.platform === "darwin" ? "Meta" : "Control";
 
 let ctx: AppContext;
 let fixtureDir: string;
+let fixtureCleanup: (() => void) | undefined;
 let terminalPanel: Locator;
 
 function streamingCommand(token: string, lineCount = 100): string {
@@ -32,7 +33,9 @@ async function countStreamLines(panel: Locator, token: string): Promise<number> 
 
 test.describe.serial("Core: Concurrent terminal output during UI interactions", () => {
   test.beforeAll(async () => {
-    fixtureDir = createFixtureRepo({ name: "concurrent-ops" });
+    const { dir, cleanup } = createFixtureRepo({ name: "concurrent-ops" });
+    fixtureDir = dir;
+    fixtureCleanup = cleanup;
     ctx = await launchApp();
     ctx.window = await openAndOnboardProject(ctx.app, ctx.window, fixtureDir, "Concurrent Ops");
 
@@ -44,6 +47,7 @@ test.describe.serial("Core: Concurrent terminal output during UI interactions", 
 
   test.afterAll(async () => {
     if (ctx?.app) await closeApp(ctx.app);
+    fixtureCleanup?.();
   });
 
   test("action palette focus remains stable during terminal streaming", async () => {

--- a/e2e/full/core-context-injection.spec.ts
+++ b/e2e/full/core-context-injection.spec.ts
@@ -9,6 +9,7 @@ import { T_MEDIUM, T_LONG } from "../helpers/timeouts";
 
 let ctx: AppContext;
 let fixtureDir: string;
+let fixtureCleanup: (() => void) | undefined;
 
 async function getActiveWorktreeId(window: import("@playwright/test").Page): Promise<string> {
   const res: any = await window.evaluate(() =>
@@ -19,7 +20,9 @@ async function getActiveWorktreeId(window: import("@playwright/test").Page): Pro
 
 test.describe.serial("Core: Context Injection", () => {
   test.beforeAll(async () => {
-    fixtureDir = createFixtureRepo({ withMultipleFiles: true });
+    const { dir, cleanup } = createFixtureRepo({ withMultipleFiles: true });
+    fixtureDir = dir;
+    fixtureCleanup = cleanup;
     ctx = await launchApp();
     ctx.window = await openAndOnboardProject(ctx.app, ctx.window, fixtureDir, "context-test");
 
@@ -39,6 +42,7 @@ test.describe.serial("Core: Context Injection", () => {
 
   test.afterAll(async () => {
     if (ctx?.app) await closeApp(ctx.app);
+    fixtureCleanup?.();
   });
 
   test("Copy Context button populates clipboard formats", async () => {

--- a/e2e/full/core-crash-recovery.spec.ts
+++ b/e2e/full/core-crash-recovery.spec.ts
@@ -318,10 +318,13 @@ test.describe.serial("Core: Crash Recovery — Panel Restoration", () => {
   let ctx: AppContext | null = null;
   let userDataDir: string;
   let fixtureDir: string;
+  let fixtureCleanup: (() => void) | undefined;
 
   test.beforeAll(async () => {
     userDataDir = mkdtempSync(path.join(tmpdir(), "daintree-e2e-restore-"));
-    fixtureDir = createFixtureRepo({ name: "restore-test" });
+    const { dir, cleanup } = createFixtureRepo({ name: "restore-test" });
+    fixtureDir = dir;
+    fixtureCleanup = cleanup;
 
     // Session 1: Launch, onboard project, close — establishes project in DB
     const setupCtx = await launchApp({ userDataDir });
@@ -354,11 +357,7 @@ test.describe.serial("Core: Crash Recovery — Panel Restoration", () => {
     } catch {
       // best-effort cleanup
     }
-    try {
-      rmSync(fixtureDir, { recursive: true, force: true });
-    } catch {
-      // best-effort cleanup
-    }
+    fixtureCleanup?.();
   });
 
   test("restore places panels in correct locations", async () => {

--- a/e2e/full/core-cross-project-workflows.spec.ts
+++ b/e2e/full/core-cross-project-workflows.spec.ts
@@ -21,6 +21,7 @@ const PROJECT_B = "project-B";
 const PROJECT_C = "project-C";
 
 let ctx: AppContext;
+let fixtureCleanups: Array<() => void> = [];
 let panelIdsA: string[] = [];
 
 async function focusAndRunCommand(page: Page, panel: Locator, command: string): Promise<void> {
@@ -43,7 +44,9 @@ test.describe.serial("Core: Cross-Project Terminal Workflows", () => {
     // default 120s hook budget on slower / CI machines, so widen explicitly.
     test.setTimeout(300_000);
 
-    const [repoA, repoB, repoC] = createFixtureRepos(3);
+    const fixtures = createFixtureRepos(3);
+    fixtureCleanups = fixtures.map((f) => f.cleanup);
+    const [repoA, repoB, repoC] = fixtures.map((f) => f.dir);
 
     ctx = await launchApp();
 
@@ -75,6 +78,7 @@ test.describe.serial("Core: Cross-Project Terminal Workflows", () => {
 
   test.afterAll(async () => {
     if (ctx?.app) await closeApp(ctx.app);
+    for (const cleanup of fixtureCleanups) cleanup();
   });
 
   test("terminal content preservation across project switch", async () => {

--- a/e2e/full/core-dev-preview-per-worktree.spec.ts
+++ b/e2e/full/core-dev-preview-per-worktree.spec.ts
@@ -45,6 +45,7 @@ server.listen(port, '127.0.0.1', () => {
 
 let ctx: AppContext;
 let fixtureDir: string;
+let fixtureCleanup: (() => void) | undefined;
 let featureWorktreeDir: string;
 
 // URLs read from address bars during tests — shared across assertions.
@@ -58,7 +59,9 @@ let featureWorktreeId = "";
 test.describe.serial("Core: Dev Preview — Per-Worktree Port Registry", () => {
   test.beforeAll(async () => {
     // Create a repo with a pre-built feature worktree.
-    fixtureDir = createFixtureRepo({ name: "dev-preview-wt", withFeatureBranch: true });
+    const { dir, cleanup } = createFixtureRepo({ name: "dev-preview-wt", withFeatureBranch: true });
+    fixtureDir = dir;
+    fixtureCleanup = cleanup;
 
     // Derive the worktree path created by createFixtureRepo.
     featureWorktreeDir = path.join(
@@ -103,6 +106,7 @@ test.describe.serial("Core: Dev Preview — Per-Worktree Port Registry", () => {
 
   test.afterAll(async () => {
     if (ctx?.app) await closeApp(ctx.app);
+    fixtureCleanup?.();
   });
 
   // ── Test 1 ─────────────────────────────────────────────────────────────────

--- a/e2e/full/core-dev-preview.spec.ts
+++ b/e2e/full/core-dev-preview.spec.ts
@@ -13,6 +13,7 @@ let ctx: AppContext;
 let server: Server;
 let port: number;
 let fixtureRepoPath: string;
+let fixtureCleanup: (() => void) | undefined;
 const PROJECT_NAME = "Dev Preview Test";
 
 test.describe.serial("Core: Dev Preview", () => {
@@ -27,7 +28,9 @@ test.describe.serial("Core: Dev Preview", () => {
     const addr = server.address();
     port = typeof addr === "object" && addr ? addr.port : 0;
 
-    fixtureRepoPath = createFixtureRepo({ name: "dev-preview-test" });
+    const { dir, cleanup } = createFixtureRepo({ name: "dev-preview-test" });
+    fixtureRepoPath = dir;
+    fixtureCleanup = cleanup;
     ctx = await launchApp();
     ctx.window = await openAndOnboardProject(ctx.app, ctx.window, fixtureRepoPath, PROJECT_NAME);
   });
@@ -35,6 +38,7 @@ test.describe.serial("Core: Dev Preview", () => {
   test.afterAll(async () => {
     if (ctx?.app) await closeApp(ctx.app);
     server?.close();
+    fixtureCleanup?.();
   });
 
   test.describe.serial("Panel Chrome", () => {

--- a/e2e/full/core-drag-drop.spec.ts
+++ b/e2e/full/core-drag-drop.spec.ts
@@ -17,16 +17,20 @@ import { T_SHORT, T_MEDIUM, T_LONG, T_SETTLE } from "../helpers/timeouts";
 
 let ctx: AppContext;
 let fixtureDir: string;
+let fixtureCleanup: (() => void) | undefined;
 
 test.describe.serial("Core: Panel Drag & Drop", () => {
   test.beforeAll(async () => {
-    fixtureDir = createFixtureRepo({ name: "drag-drop" });
+    const { dir, cleanup } = createFixtureRepo({ name: "drag-drop" });
+    fixtureDir = dir;
+    fixtureCleanup = cleanup;
     ctx = await launchApp();
     ctx.window = await openAndOnboardProject(ctx.app, ctx.window, fixtureDir, "Drag Drop Test");
   });
 
   test.afterAll(async () => {
     if (ctx?.app) await closeApp(ctx.app);
+    fixtureCleanup?.();
   });
 
   // ── Setup: Open 3 terminals ──────────────────────────────

--- a/e2e/full/core-error-recovery.spec.ts
+++ b/e2e/full/core-error-recovery.spec.ts
@@ -21,9 +21,12 @@ import path from "path";
 test.describe.serial("Core: Error Recovery — Terminal Exit", () => {
   let ctx: AppContext;
   let fixtureDir: string;
+  let fixtureCleanup: (() => void) | undefined;
 
   test.beforeAll(async () => {
-    fixtureDir = createFixtureRepo({ name: "error-recovery-exit" });
+    const { dir, cleanup } = createFixtureRepo({ name: "error-recovery-exit" });
+    fixtureDir = dir;
+    fixtureCleanup = cleanup;
     ctx = await launchApp();
     ctx.window = await openAndOnboardProject(
       ctx.app,
@@ -35,6 +38,7 @@ test.describe.serial("Core: Error Recovery — Terminal Exit", () => {
 
   test.afterAll(async () => {
     if (ctx?.app) await closeApp(ctx.app);
+    fixtureCleanup?.();
   });
 
   test("terminal shows exit indicator and banner after exit 1", async () => {
@@ -83,15 +87,22 @@ test.describe.serial("Core: Error Recovery — Terminal Exit", () => {
 test.describe.serial("Core: Error Recovery — Missing Worktree", () => {
   let ctx: AppContext;
   let fixtureDir: string;
+  let fixtureCleanup: (() => void) | undefined;
 
   test.beforeAll(async () => {
-    fixtureDir = createFixtureRepo({ name: "error-recovery-wt", withFeatureBranch: true });
+    const { dir, cleanup } = createFixtureRepo({
+      name: "error-recovery-wt",
+      withFeatureBranch: true,
+    });
+    fixtureDir = dir;
+    fixtureCleanup = cleanup;
     ctx = await launchApp();
     ctx.window = await openAndOnboardProject(ctx.app, ctx.window, fixtureDir, "Error Recovery WT");
   });
 
   test.afterAll(async () => {
     if (ctx?.app) await closeApp(ctx.app);
+    fixtureCleanup?.();
   });
 
   test("detects externally deleted worktree", async () => {

--- a/e2e/full/core-external-git-detection.spec.ts
+++ b/e2e/full/core-external-git-detection.spec.ts
@@ -10,10 +10,13 @@ import path from "path";
 
 let ctx: AppContext;
 let fixtureDir: string;
+let fixtureCleanup: (() => void) | undefined;
 
 test.describe.serial("Core: External Git Detection", () => {
   test.beforeAll(async () => {
-    fixtureDir = createFixtureRepo({ name: "external-git-detection" });
+    const { dir, cleanup } = createFixtureRepo({ name: "external-git-detection" });
+    fixtureDir = dir;
+    fixtureCleanup = cleanup;
     ctx = await launchApp();
     ctx.window = await openAndOnboardProject(
       ctx.app,
@@ -25,6 +28,7 @@ test.describe.serial("Core: External Git Detection", () => {
 
   test.afterAll(async () => {
     if (ctx?.app) await closeApp(ctx.app);
+    fixtureCleanup?.();
   });
 
   test("initial state shows clean worktree with initial commit", async () => {

--- a/e2e/full/core-file-viewer.spec.ts
+++ b/e2e/full/core-file-viewer.spec.ts
@@ -8,6 +8,7 @@ import { T_SHORT, T_MEDIUM, T_LONG } from "../helpers/timeouts";
 
 let ctx: AppContext;
 let fixtureDir: string;
+let fixtureCleanup: (() => void) | undefined;
 
 async function dispatchViewFile(ctx: AppContext, filePath: string, rootPath?: string) {
   // Normalize to forward slashes so the renderer's containment check works on Windows
@@ -38,18 +39,21 @@ async function closeDialog(ctx: AppContext) {
 
 test.describe.serial("Core: File Viewer Modal", () => {
   test.beforeAll(async () => {
-    fixtureDir = createFixtureRepo({
+    const { dir, cleanup } = createFixtureRepo({
       name: "file-viewer",
       withMultipleFiles: true,
       withImageFile: true,
       withUncommittedChanges: true,
     });
+    fixtureDir = dir;
+    fixtureCleanup = cleanup;
     ctx = await launchApp();
     ctx.window = await openAndOnboardProject(ctx.app, ctx.window, fixtureDir, "File Viewer Test");
   });
 
   test.afterAll(async () => {
     if (ctx?.app) await closeApp(ctx.app);
+    fixtureCleanup?.();
   });
 
   test("modal opens for a text file and shows filename in header", async () => {

--- a/e2e/full/core-fleet-broadcast.spec.ts
+++ b/e2e/full/core-fleet-broadcast.spec.ts
@@ -1,5 +1,5 @@
 import { test, expect, type Locator, type Page } from "@playwright/test";
-import { chmodSync, mkdirSync, rmSync, writeFileSync } from "fs";
+import { chmodSync, mkdirSync, writeFileSync } from "fs";
 import path from "path";
 import { launchApp, closeApp, type AppContext } from "../helpers/launch";
 import { createFixtureRepo } from "../helpers/fixtures";
@@ -18,6 +18,7 @@ interface ActionResult<T = unknown> {
 let ctx: AppContext;
 let fixtureDir: string;
 let fakeBinDir: string;
+let fixtureCleanup: (() => void) | undefined;
 
 async function dispatchAction<T = unknown>(
   page: Page,
@@ -105,7 +106,9 @@ async function typeDirectlyIntoTerminal(
 }
 
 function prepareFixture(): void {
-  fixtureDir = createFixtureRepo({ name: "fleet-broadcast" });
+  const { dir, cleanup } = createFixtureRepo({ name: "fleet-broadcast" });
+  fixtureDir = dir;
+  fixtureCleanup = cleanup;
   fakeBinDir = path.join(fixtureDir, ".e2e bin");
   mkdirSync(fakeBinDir, { recursive: true });
 
@@ -173,7 +176,7 @@ test.describe.serial("Core: Fleet terminal broadcast", () => {
 
   test.afterAll(async () => {
     if (ctx?.app) await closeApp(ctx.app);
-    if (fixtureDir) rmSync(fixtureDir, { recursive: true, force: true });
+    fixtureCleanup?.();
   });
 
   test("direct xterm typing into one armed agent terminal reaches the whole fleet", async () => {

--- a/e2e/full/core-focus-management.spec.ts
+++ b/e2e/full/core-focus-management.spec.ts
@@ -14,11 +14,13 @@ import { expectTerminalFocused, ensureWindowFocused } from "../helpers/focus";
 
 let ctx: AppContext;
 const mod = process.platform === "darwin" ? "Meta" : "Control";
+let fixtureCleanup: (() => void) | undefined;
 
 test.describe.serial("Core: Focus Management", () => {
   test.beforeAll(async () => {
     ctx = await launchApp();
-    const fixtureDir = createFixtureRepo({ name: "focus-management" });
+    const { dir: fixtureDir, cleanup } = createFixtureRepo({ name: "focus-management" });
+    fixtureCleanup = cleanup;
     ctx.window = await openAndOnboardProject(
       ctx.app,
       ctx.window,
@@ -29,6 +31,7 @@ test.describe.serial("Core: Focus Management", () => {
 
   test.afterAll(async () => {
     if (ctx?.app) await closeApp(ctx.app);
+    fixtureCleanup?.();
   });
 
   test("action palette dismiss restores terminal focus", async () => {

--- a/e2e/full/core-global-env-inheritance.spec.ts
+++ b/e2e/full/core-global-env-inheritance.spec.ts
@@ -16,6 +16,7 @@ test.describe.serial("Full: Global Environment Variable Inheritance", () => {
 
   test.afterAll(async () => {
     if (ctx?.app) await closeApp(ctx.app);
+    ((ctx as any).__envFixtureCleanup as (() => void) | undefined)?.();
   });
 
   test("Global Environment tab works without a project", async () => {
@@ -77,7 +78,7 @@ test.describe.serial("Full: Global Environment Variable Inheritance", () => {
 
   test("Global vars appear in project Variables tab", async () => {
     // Open a fixture project
-    const fixtureDir = createFixtureRepo({ name: "env-inheritance" });
+    const { dir: fixtureDir, cleanup } = createFixtureRepo({ name: "env-inheritance" });
     ctx.window = await openAndOnboardProject(
       ctx.app,
       ctx.window,
@@ -85,6 +86,9 @@ test.describe.serial("Full: Global Environment Variable Inheritance", () => {
       "Env Inheritance Test"
     );
     const { window } = ctx;
+
+    // Store cleanup for use in afterAll if needed
+    (ctx as any).__envFixtureCleanup = cleanup;
 
     await openSettings(window);
     await expect(window.locator(SEL.settings.heading)).toBeVisible({ timeout: T_MEDIUM });

--- a/e2e/full/core-hybrid-input-bar.spec.ts
+++ b/e2e/full/core-hybrid-input-bar.spec.ts
@@ -9,12 +9,15 @@ import { T_SHORT, T_MEDIUM, T_LONG, T_SETTLE } from "../helpers/timeouts";
 import { openTerminal } from "../helpers/panels";
 let ctx: AppContext;
 let fixtureDir: string;
+let fixtureCleanup: (() => void) | undefined;
 let agentPanel: Locator;
 let cmEditor: Locator;
 
 test.describe.serial("Core: HybridInputBar", () => {
   test.beforeAll(async () => {
-    fixtureDir = createFixtureRepo({ name: "hybrid-input-bar" });
+    const { dir, cleanup } = createFixtureRepo({ name: "hybrid-input-bar" });
+    fixtureDir = dir;
+    fixtureCleanup = cleanup;
     ctx = await launchApp();
     ctx.window = await openAndOnboardProject(
       ctx.app,
@@ -41,6 +44,7 @@ test.describe.serial("Core: HybridInputBar", () => {
 
   test.afterAll(async () => {
     if (ctx?.app) await closeApp(ctx.app);
+    fixtureCleanup?.();
   });
 
   test("can type text into CodeMirror editor", async () => {

--- a/e2e/full/core-ipc-cleanup.spec.ts
+++ b/e2e/full/core-ipc-cleanup.spec.ts
@@ -13,7 +13,6 @@ import {
   getRendererListenerSnapshot,
 } from "../helpers/ipcFaults";
 import { addAndSwitchToProject, selectExistingProjectAndRefresh } from "../helpers/workflows";
-import { rmSync } from "fs";
 
 // Migrated events (worktree:update, agent:state-changed, terminal:exit, ...)
 // now travel over the multiplexed `events:push` channel so their listener
@@ -25,16 +24,19 @@ const RENDERER_CHANNELS = ["events:push", "terminal:activity"];
 test.describe.serial("Core: IPC Cleanup Verification", () => {
   let ctx: AppContext;
   let fixtureDir: string;
+  let fixtureCleanup: (() => void) | undefined;
 
   test.beforeAll(async () => {
-    fixtureDir = createFixtureRepo({ name: "ipc-cleanup" });
+    const { dir, cleanup } = createFixtureRepo({ name: "ipc-cleanup" });
+    fixtureDir = dir;
+    fixtureCleanup = cleanup;
     ctx = await launchApp({ env: { DAINTREE_E2E_FAULT_MODE: "1" } });
     ctx.window = await openAndOnboardProject(ctx.app, ctx.window, fixtureDir, "IPC Cleanup");
   });
 
   test.afterAll(async () => {
     if (ctx?.app) await closeApp(ctx.app);
-    rmSync(fixtureDir, { recursive: true, force: true });
+    fixtureCleanup?.();
   });
 
   test("AC1: handler count stable after 5 terminal open/close cycles", async () => {

--- a/e2e/full/core-ipc-error-propagation.spec.ts
+++ b/e2e/full/core-ipc-error-propagation.spec.ts
@@ -278,34 +278,38 @@ test.describe.serial("Core: IPC Error Propagation", () => {
   test("ENOENT spawn error shows SpawnErrorBanner with retry and trash", async () => {
     // AC 3: Terminal spawn ENOENT renders SpawnErrorBanner
     // We need a project open to spawn terminals
-    const repo = createFixtureRepo({ name: "spawn-error-test" });
-    ctx.window = await openAndOnboardProject(ctx.app, ctx.window, repo, "SpawnErrorTest");
+    const { dir: repo, cleanup } = createFixtureRepo({ name: "spawn-error-test" });
+    try {
+      ctx.window = await openAndOnboardProject(ctx.app, ctx.window, repo, "SpawnErrorTest");
 
-    // Click open terminal to create a terminal panel
-    await openTerminal(ctx.window);
+      // Click open terminal to create a terminal panel
+      await openTerminal(ctx.window);
 
-    // Wait for a grid panel to appear
-    const gridPanel = ctx.window.locator(SEL.panel.gridPanel);
-    await expect(gridPanel.first()).toBeVisible({ timeout: 10000 });
+      // Wait for a grid panel to appear
+      const gridPanel = ctx.window.locator(SEL.panel.gridPanel);
+      await expect(gridPanel.first()).toBeVisible({ timeout: 10000 });
 
-    // Get the terminal ID from the panel
-    const terminalId = await gridPanel.last().getAttribute("data-panel-id");
-    expect(terminalId).toBeTruthy();
+      // Get the terminal ID from the panel
+      const terminalId = await gridPanel.last().getAttribute("data-panel-id");
+      expect(terminalId).toBeTruthy();
 
-    // Send a synthetic spawn error result for this terminal
-    await emitSpawnResult(ctx.app, terminalId!, "ENOENT", "spawn /nonexistent ENOENT");
+      // Send a synthetic spawn error result for this terminal
+      await emitSpawnResult(ctx.app, terminalId!, "ENOENT", "spawn /nonexistent ENOENT");
 
-    // SpawnErrorBanner should appear with role="alert"
-    const targetPanel = gridPanel.last();
-    const banner = targetPanel.locator('[role="alert"]');
-    await expect(banner).toBeVisible({ timeout: 5000 });
+      // SpawnErrorBanner should appear with role="alert"
+      const targetPanel = gridPanel.last();
+      const banner = targetPanel.locator('[role="alert"]');
+      await expect(banner).toBeVisible({ timeout: 5000 });
 
-    // Title should say "Couldn't find shell or command"
-    await expect(banner.getByText("Couldn't find shell or command")).toBeVisible();
+      // Title should say "Couldn't find shell or command"
+      await expect(banner.getByText("Couldn't find shell or command")).toBeVisible();
 
-    // Retry and Trash buttons should be visible
-    await expect(banner.locator('[aria-label="Retry starting terminal"]')).toBeVisible();
-    await expect(banner.locator('[aria-label="Move to trash"]')).toBeVisible();
+      // Retry and Trash buttons should be visible
+      await expect(banner.locator('[aria-label="Retry starting terminal"]')).toBeVisible();
+      await expect(banner.locator('[aria-label="Move to trash"]')).toBeVisible();
+    } finally {
+      cleanup?.();
+    }
   });
 
   test("ENOTDIR spawn error shows Change directory action", async () => {

--- a/e2e/full/core-keyboard-navigation-advanced.spec.ts
+++ b/e2e/full/core-keyboard-navigation-advanced.spec.ts
@@ -13,11 +13,13 @@ const mod = process.platform === "darwin" ? "Meta" : "Control";
 
 test.describe.serial("Core: Keyboard Terminal Navigation", () => {
   let ctx: AppContext;
+  let fixtureCleanup: (() => void) | undefined;
 
   test.beforeAll(async () => {
     ctx = await launchApp();
-    const fixtureDir = createFixtureRepo({ name: "kbd-nav-terminal" });
-    ctx.window = await openAndOnboardProject(ctx.app, ctx.window, fixtureDir, "Kbd Nav Terminal");
+    const { dir, cleanup } = createFixtureRepo({ name: "kbd-nav-terminal" });
+    fixtureCleanup = cleanup;
+    ctx.window = await openAndOnboardProject(ctx.app, ctx.window, dir, "Kbd Nav Terminal");
 
     // Wait for worktree detection to complete
     await ctx.window
@@ -44,6 +46,7 @@ test.describe.serial("Core: Keyboard Terminal Navigation", () => {
 
   test.afterAll(async () => {
     if (ctx?.app) await closeApp(ctx.app);
+    fixtureCleanup?.();
   });
 
   test("Ctrl+Tab cycles forward through terminals", async () => {
@@ -152,12 +155,14 @@ const FEATURE_BRANCH = "feature/test-branch";
 test.describe.serial("Core: Keyboard Worktree Navigation", () => {
   let ctx: AppContext;
   let mainBranch: string;
+  let fixtureCleanup: (() => void) | undefined;
 
   test.beforeAll(async () => {
-    const fixtureDir = createFixtureRepo({
+    const { dir: fixtureDir, cleanup } = createFixtureRepo({
       name: "kbd-nav-worktree",
       withFeatureBranch: true,
     });
+    fixtureCleanup = cleanup;
 
     ctx = await launchApp();
     ctx.window = await openAndOnboardProject(ctx.app, ctx.window, fixtureDir, "Kbd Nav Worktree");
@@ -174,6 +179,7 @@ test.describe.serial("Core: Keyboard Worktree Navigation", () => {
 
   test.afterAll(async () => {
     if (ctx?.app) await closeApp(ctx.app);
+    fixtureCleanup?.();
   });
 
   test("Cmd+Alt+] cycles to next worktree", async () => {

--- a/e2e/full/core-keyboard-shortcuts.spec.ts
+++ b/e2e/full/core-keyboard-shortcuts.spec.ts
@@ -7,6 +7,7 @@ import { SEL } from "../helpers/selectors";
 import { T_SHORT, T_MEDIUM, T_LONG, T_SETTLE } from "../helpers/timeouts";
 
 let ctx: AppContext;
+let fixtureCleanup: (() => void) | undefined;
 const mod = process.platform === "darwin" ? "Meta" : "Control";
 
 async function pressChord(page: Page, first: string, second: string) {
@@ -18,17 +19,14 @@ async function pressChord(page: Page, first: string, second: string) {
 test.describe.serial("Core: Keyboard Shortcuts", () => {
   test.beforeAll(async () => {
     ctx = await launchApp();
-    const fixtureDir = createFixtureRepo({ name: "keyboard-shortcuts" });
-    ctx.window = await openAndOnboardProject(
-      ctx.app,
-      ctx.window,
-      fixtureDir,
-      "Keyboard Shortcuts Test"
-    );
+    const { dir, cleanup } = createFixtureRepo({ name: "keyboard-shortcuts" });
+    fixtureCleanup = cleanup;
+    ctx.window = await openAndOnboardProject(ctx.app, ctx.window, dir, "Keyboard Shortcuts Test");
   });
 
   test.afterAll(async () => {
     if (ctx?.app) await closeApp(ctx.app);
+    fixtureCleanup?.();
   });
 
   // ── Single-Key Shortcuts ───────────────────────────────────

--- a/e2e/full/core-light-theme-smoke.spec.ts
+++ b/e2e/full/core-light-theme-smoke.spec.ts
@@ -12,14 +12,16 @@ const LIGHT_SCHEME_IDS = BUILT_IN_APP_SCHEMES.filter((scheme) => scheme.type ===
 );
 
 let ctx: AppContext;
+let fixtureCleanup: (() => void) | undefined;
 
 test.describe.serial("Core: Light Theme Smoke", () => {
   test.beforeAll(async () => {
-    const fixture = createFixtureRepo({
+    const { dir: fixture, cleanup } = createFixtureRepo({
       name: "light-theme-smoke",
       withFeatureBranch: true,
       withUncommittedChanges: true,
     });
+    fixtureCleanup = cleanup;
 
     ctx = await launchApp();
     ctx.window = await openAndOnboardProject(ctx.app, ctx.window, fixture, PROJECT_NAME);
@@ -31,6 +33,7 @@ test.describe.serial("Core: Light Theme Smoke", () => {
 
   test.afterAll(async () => {
     if (ctx?.app) await closeApp(ctx.app);
+    fixtureCleanup?.();
   });
 
   // eslint-disable-next-line no-empty-pattern

--- a/e2e/full/core-output-flood.spec.ts
+++ b/e2e/full/core-output-flood.spec.ts
@@ -13,16 +13,20 @@ import { measureMainMemory, floodTerminal } from "../helpers/stress";
 
 let ctx: AppContext;
 let fixtureDir: string;
+let fixtureCleanup: (() => void) | undefined;
 
 test.describe.serial("Core: Output Flood Memory Bounds", () => {
   test.beforeAll(async () => {
-    fixtureDir = createFixtureRepo({ name: "output-flood" });
+    const { dir, cleanup } = createFixtureRepo({ name: "output-flood" });
+    fixtureDir = dir;
+    fixtureCleanup = cleanup;
     ctx = await launchApp();
     ctx.window = await openAndOnboardProject(ctx.app, ctx.window, fixtureDir, "Output Flood Test");
   });
 
   test.afterAll(async () => {
     if (ctx?.app) await closeApp(ctx.app);
+    fixtureCleanup?.();
   });
 
   let panel: ReturnType<typeof getFirstGridPanel>;

--- a/e2e/full/core-panel-tab-groups.spec.ts
+++ b/e2e/full/core-panel-tab-groups.spec.ts
@@ -10,10 +10,13 @@ import { T_SHORT, T_MEDIUM, T_LONG, T_SETTLE } from "../helpers/timeouts";
 
 let ctx: AppContext;
 let fixtureDir: string;
+let fixtureCleanup: (() => void) | undefined;
 
 test.describe.serial("Core: Panel Tab Groups", () => {
   test.beforeAll(async () => {
-    fixtureDir = createFixtureRepo({ name: "tab-groups", withMultipleFiles: true });
+    const { dir, cleanup } = createFixtureRepo({ name: "tab-groups", withMultipleFiles: true });
+    fixtureDir = dir;
+    fixtureCleanup = cleanup;
     ctx = await launchApp();
 
     // Disable two-pane split mode before the project loads. The 1→2 panel
@@ -39,6 +42,7 @@ test.describe.serial("Core: Panel Tab Groups", () => {
 
   test.afterAll(async () => {
     if (ctx?.app) await closeApp(ctx.app);
+    fixtureCleanup?.();
   });
 
   // ── Tab Group Lifecycle ─────────────────────────────────

--- a/e2e/full/core-perf-list-mount-budget.spec.ts
+++ b/e2e/full/core-perf-list-mount-budget.spec.ts
@@ -14,7 +14,6 @@
  */
 
 import { test, expect } from "@playwright/test";
-import { rmSync } from "fs";
 import { launchApp, closeApp, type AppContext } from "../helpers/launch";
 import { createFixtureRepo } from "../helpers/fixtures";
 import { openAndOnboardProject } from "../helpers/project";
@@ -33,24 +32,23 @@ const MAX_LONG_TASKS = 10;
 
 let ctx: AppContext;
 let fixtureDir: string;
+let fixtureCleanup: (() => void) | undefined;
 
 test.describe.serial("Core: List Mount Perf Budget", () => {
   test.beforeAll(async () => {
-    fixtureDir = createFixtureRepo({
+    const { dir, cleanup } = createFixtureRepo({
       name: "perf-budget",
       unstagedFileCount: FILE_COUNT,
     });
+    fixtureDir = dir;
+    fixtureCleanup = cleanup;
     ctx = await launchApp();
     ctx.window = await openAndOnboardProject(ctx.app, ctx.window, fixtureDir, "Perf Budget Test");
   });
 
   test.afterAll(async () => {
     if (ctx?.app) await closeApp(ctx.app);
-    try {
-      rmSync(fixtureDir, { recursive: true, force: true });
-    } catch {
-      // best-effort cleanup
-    }
+    fixtureCleanup?.();
   });
 
   test("ReviewHub working-tree mode stays within node count and longtask budgets", async () => {

--- a/e2e/full/core-persistence-advanced.spec.ts
+++ b/e2e/full/core-persistence-advanced.spec.ts
@@ -17,11 +17,12 @@ import path from "path";
 test.describe.serial("Persistence: Layout & Window across restart", () => {
   let userDataDir: string;
   let fixtureDir: string;
+  let fixtureCleanup: () => void;
   let ctx: AppContext | null = null;
 
   test.beforeAll(async () => {
     userDataDir = mkdtempSync(path.join(tmpdir(), "daintree-e2e-persist-layout-"));
-    fixtureDir = createFixtureRepo({ name: "persist-layout" });
+    ({ dir: fixtureDir, cleanup: fixtureCleanup } = createFixtureRepo({ name: "persist-layout" }));
   });
 
   test.afterAll(async () => {
@@ -32,7 +33,7 @@ test.describe.serial("Persistence: Layout & Window across restart", () => {
       ctx = null;
     }
     rmSync(userDataDir, { recursive: true, force: true });
-    rmSync(fixtureDir, { recursive: true, force: true });
+    fixtureCleanup?.();
   });
 
   test("terminal layout, window size, and sidebar state survive restart", async () => {

--- a/e2e/full/core-portal.spec.ts
+++ b/e2e/full/core-portal.spec.ts
@@ -37,6 +37,8 @@ test.describe.serial("Core: Portal Multi-Tab Lifecycle", () => {
     "Windows CI: portal not supported with GPU disabled"
   );
 
+  let fixtureCleanup: (() => void) | undefined;
+
   test.beforeAll(async () => {
     server = createServer(handleRequest);
     await new Promise<void>((resolve) => {
@@ -46,13 +48,15 @@ test.describe.serial("Core: Portal Multi-Tab Lifecycle", () => {
     port = typeof addr === "object" && addr ? addr.port : 0;
 
     const fixture = createFixtureRepo({ name: "portal-test" });
+    fixtureCleanup = fixture.cleanup;
     ctx = await launchApp();
-    ctx.window = await openAndOnboardProject(ctx.app, ctx.window, fixture, "Portal Test");
+    ctx.window = await openAndOnboardProject(ctx.app, ctx.window, fixture.dir, "Portal Test");
   });
 
   test.afterAll(async () => {
     if (ctx?.app) await closeApp(ctx.app);
     server?.close();
+    fixtureCleanup?.();
   });
 
   test.describe.serial("Tab Creation and Switching", () => {

--- a/e2e/full/core-process-cleanup.spec.ts
+++ b/e2e/full/core-process-cleanup.spec.ts
@@ -29,7 +29,9 @@ test.describe("Core: Process Cleanup", () => {
   test("clean exit kills PTY process tree", async () => {
     test.setTimeout(240_000);
 
-    const fixtureDir = createFixtureRepo({ name: "process-cleanup" });
+    const { dir: fixtureDir, cleanup: fixtureCleanup } = createFixtureRepo({
+      name: "process-cleanup",
+    });
     const userDataDir = mkdtempSync(path.join(tmpdir(), "daintree-e2e-cleanup-"));
     let ptyPid = 0;
     let descendants: number[] = [];
@@ -96,14 +98,16 @@ test.describe("Core: Process Cleanup", () => {
         }
       }
       rmSync(userDataDir, { recursive: true, force: true });
-      rmSync(fixtureDir, { recursive: true, force: true });
+      fixtureCleanup();
     }
   });
 
   test("TrashedPidTracker cleans up orphans after unclean exit", async () => {
     test.setTimeout(180_000);
 
-    const fixtureDir = createFixtureRepo({ name: "process-cleanup-unclean" });
+    const { dir: fixtureDir, cleanup: fixtureCleanup } = createFixtureRepo({
+      name: "process-cleanup-unclean",
+    });
     const userDataDir = mkdtempSync(path.join(tmpdir(), "daintree-e2e-unclean-"));
     let orphanPid = 0;
 
@@ -176,7 +180,7 @@ test.describe("Core: Process Cleanup", () => {
         }
       }
       rmSync(userDataDir, { recursive: true, force: true });
-      rmSync(fixtureDir, { recursive: true, force: true });
+      fixtureCleanup();
     }
   });
 });
@@ -186,10 +190,11 @@ test.describe.serial("Core: Process Cleanup on Shutdown", () => {
 
   let ctx: AppContext;
   let fixtureDir: string;
+  let fixtureCleanup: (() => void) | undefined;
   let trackedPids: number[] = [];
 
   test.beforeAll(async () => {
-    fixtureDir = createFixtureRepo({ name: "process-cleanup" });
+    ({ dir: fixtureDir, cleanup: fixtureCleanup } = createFixtureRepo({ name: "process-cleanup" }));
     ctx = await launchApp();
     ctx.window = await openAndOnboardProject(
       ctx.app,
@@ -216,6 +221,7 @@ test.describe.serial("Core: Process Cleanup on Shutdown", () => {
         // Best-effort
       }
     }
+    fixtureCleanup?.();
   });
 
   test("graceful shutdown kills PTY processes within time limit", async () => {

--- a/e2e/full/core-project-deletion-cleanup.spec.ts
+++ b/e2e/full/core-project-deletion-cleanup.spec.ts
@@ -90,11 +90,12 @@ async function stopActiveProjectViaSwitcher(
 test.describe.serial("Deletion Cleanup: Active project close clears UI", () => {
   let ctx: AppContext;
   let fixtureDir: string;
+  let fixtureCleanup: (() => void) | undefined;
   const PROJECT_NAME = "active-close";
   let ptyPids: number[] = [];
 
   test.beforeAll(async () => {
-    fixtureDir = createFixtureRepo({ name: "active-close" });
+    ({ dir: fixtureDir, cleanup: fixtureCleanup } = createFixtureRepo({ name: "active-close" }));
     ctx = await launchApp();
 
     // Disable two-pane split mode: spawning exactly 2 terminals triggers a
@@ -131,7 +132,7 @@ test.describe.serial("Deletion Cleanup: Active project close clears UI", () => {
 
   test.afterAll(async () => {
     if (ctx?.app) await closeApp(ctx.app);
-    rmSync(fixtureDir, { recursive: true, force: true });
+    fixtureCleanup?.();
   });
 
   test("active project removal shows Close Project dialog", async () => {
@@ -219,13 +220,15 @@ test.describe.serial("Deletion Cleanup: Background project removal isolation", (
   let ctx: AppContext;
   let fixtureA: string;
   let fixtureB: string;
+  let cleanupA: (() => void) | undefined;
+  let cleanupB: (() => void) | undefined;
   const PROJECT_A = "bg-active";
   const PROJECT_B = "bg-remove";
   let ptyPidB: number | null = null;
 
   test.beforeAll(async () => {
-    fixtureA = createFixtureRepo({ name: "bg-active" });
-    fixtureB = createFixtureRepo({ name: "bg-remove" });
+    ({ dir: fixtureA, cleanup: cleanupA } = createFixtureRepo({ name: "bg-active" }));
+    ({ dir: fixtureB, cleanup: cleanupB } = createFixtureRepo({ name: "bg-remove" }));
 
     ctx = await launchApp();
     ctx.window = await openAndOnboardProject(ctx.app, ctx.window, fixtureA, PROJECT_A);
@@ -256,8 +259,8 @@ test.describe.serial("Deletion Cleanup: Background project removal isolation", (
 
   test.afterAll(async () => {
     if (ctx?.app) await closeApp(ctx.app);
-    rmSync(fixtureA, { recursive: true, force: true });
-    rmSync(fixtureB, { recursive: true, force: true });
+    cleanupA?.();
+    cleanupB?.();
   });
 
   test("background removal shows Remove Project dialog", async () => {
@@ -334,14 +337,16 @@ test.describe.serial("Deletion Cleanup: Background removal persists across resta
   let userDataDir: string;
   let fixtureA: string;
   let fixtureB: string;
+  let cleanupA: (() => void) | undefined;
+  let cleanupB: (() => void) | undefined;
   let ctx: AppContext | null = null;
   const PROJECT_A = "persist-active";
   const PROJECT_B = "persist-remove";
 
   test.beforeAll(async () => {
     userDataDir = mkdtempSync(path.join(tmpdir(), "daintree-e2e-deletion-persist-"));
-    fixtureA = createFixtureRepo({ name: "persist-active" });
-    fixtureB = createFixtureRepo({ name: "persist-remove" });
+    ({ dir: fixtureA, cleanup: cleanupA } = createFixtureRepo({ name: "persist-active" }));
+    ({ dir: fixtureB, cleanup: cleanupB } = createFixtureRepo({ name: "persist-remove" }));
   });
 
   test.afterAll(async () => {
@@ -352,8 +357,8 @@ test.describe.serial("Deletion Cleanup: Background removal persists across resta
       ctx = null;
     }
     rmSync(userDataDir, { recursive: true, force: true });
-    rmSync(fixtureA, { recursive: true, force: true });
-    rmSync(fixtureB, { recursive: true, force: true });
+    cleanupA?.();
+    cleanupB?.();
   });
 
   test("removed project stays gone after app restart", async () => {

--- a/e2e/full/core-project-lifecycle.spec.ts
+++ b/e2e/full/core-project-lifecycle.spec.ts
@@ -17,18 +17,25 @@ const RECIPE_NAME = "Lifecycle Recipe";
 
 let ctx: AppContext;
 let repoBPath: string;
+let cleanupA: (() => void) | undefined;
+let cleanupB: (() => void) | undefined;
 
 test.describe.serial("Core: Project Lifecycle", () => {
   test.beforeAll(async () => {
     const repoA = createFixtureRepo({ name: "lifecycle-a" });
-    repoBPath = createFixtureRepo({ name: "lifecycle-b" });
+    const repoB = createFixtureRepo({ name: "lifecycle-b" });
+    cleanupA = repoA.cleanup;
+    cleanupB = repoB.cleanup;
+    repoBPath = repoB.dir;
 
     ctx = await launchApp();
-    ctx.window = await openAndOnboardProject(ctx.app, ctx.window, repoA, PROJECT_A);
+    ctx.window = await openAndOnboardProject(ctx.app, ctx.window, repoA.dir, PROJECT_A);
   });
 
   test.afterAll(async () => {
     if (ctx?.app) await closeApp(ctx.app);
+    cleanupA?.();
+    cleanupB?.();
   });
 
   test("add second project via project switcher", async () => {

--- a/e2e/full/core-project-management-advanced.spec.ts
+++ b/e2e/full/core-project-management-advanced.spec.ts
@@ -11,6 +11,8 @@ const mod = process.platform === "darwin" ? "Meta" : "Control";
 let ctx: AppContext;
 const PRIMARY_NAME = "primary-advanced";
 const SECONDARY_NAME = "secondary-remove";
+let cleanupPrimary: (() => void) | undefined;
+let cleanupSecondary: (() => void) | undefined;
 
 test.describe.serial("Core: Project Management Advanced", () => {
   test.beforeAll(async () => {
@@ -19,12 +21,19 @@ test.describe.serial("Core: Project Management Advanced", () => {
       withFeatureBranch: true,
     });
     const secondaryRepo = createFixtureRepo({ name: "secondary-remove" });
+    cleanupPrimary = primaryRepo.cleanup;
+    cleanupSecondary = secondaryRepo.cleanup;
 
     ctx = await launchApp();
-    ctx.window = await openAndOnboardProject(ctx.app, ctx.window, primaryRepo, PRIMARY_NAME);
+    ctx.window = await openAndOnboardProject(ctx.app, ctx.window, primaryRepo.dir, PRIMARY_NAME);
 
     // Add secondary project
-    ctx.window = await addAndSwitchToProject(ctx.app, ctx.window, secondaryRepo, SECONDARY_NAME);
+    ctx.window = await addAndSwitchToProject(
+      ctx.app,
+      ctx.window,
+      secondaryRepo.dir,
+      SECONDARY_NAME
+    );
 
     // Switch back to primary project
     ctx.window = await selectExistingProjectAndRefresh(ctx.app, ctx.window, PRIMARY_NAME);
@@ -37,6 +46,8 @@ test.describe.serial("Core: Project Management Advanced", () => {
 
   test.afterAll(async () => {
     if (ctx?.app) await closeApp(ctx.app);
+    cleanupPrimary?.();
+    cleanupSecondary?.();
   });
 
   // ── Project Removal Confirmation (3 tests) ──────────────

--- a/e2e/full/core-project-switch-race.spec.ts
+++ b/e2e/full/core-project-switch-race.spec.ts
@@ -15,6 +15,7 @@ import { SEL } from "../helpers/selectors";
 import { T_MEDIUM, T_LONG, T_SETTLE } from "../helpers/timeouts";
 
 let ctx: AppContext;
+let fixtureCleanups: Array<() => void> = [];
 const PROJECT_A_NAME = "project-A";
 const PROJECT_B_NAME = "project-B";
 
@@ -86,7 +87,9 @@ async function switchToProject(
 
 test.describe.serial("Core: Project Switch Race Conditions", () => {
   test.beforeAll(async () => {
-    const [repoA, repoB] = createFixtureRepos(2);
+    const fixtures = createFixtureRepos(2);
+    fixtureCleanups = fixtures.map((f) => f.cleanup);
+    const [repoA, repoB] = fixtures.map((f) => f.dir);
 
     ctx = await launchApp({ env: { DAINTREE_E2E_FAULT_MODE: "1" } });
 
@@ -116,6 +119,7 @@ test.describe.serial("Core: Project Switch Race Conditions", () => {
   test.afterAll(async () => {
     await clearAllFaults(ctx.app);
     if (ctx?.app) await closeApp(ctx.app);
+    for (const cleanup of fixtureCleanups) cleanup();
   });
 
   test("delayed spawn assigns terminal to originating project", async () => {

--- a/e2e/full/core-pty-resilience.spec.ts
+++ b/e2e/full/core-pty-resilience.spec.ts
@@ -22,10 +22,11 @@ import {
 
 let ctx: AppContext;
 let fixtureDir: string;
+let fixtureCleanup: (() => void) | undefined;
 
 test.describe.serial("Core: PTY Resilience", () => {
   test.beforeAll(async () => {
-    fixtureDir = createFixtureRepo({ name: "pty-resilience" });
+    ({ dir: fixtureDir, cleanup: fixtureCleanup } = createFixtureRepo({ name: "pty-resilience" }));
     ctx = await launchApp();
     ctx.window = await openAndOnboardProject(
       ctx.app,
@@ -37,6 +38,7 @@ test.describe.serial("Core: PTY Resilience", () => {
 
   test.afterAll(async () => {
     if (ctx?.app) await closeApp(ctx.app);
+    fixtureCleanup?.();
   });
 
   test("terminal flood with PTY lifecycle verification", async () => {

--- a/e2e/full/core-pulse.spec.ts
+++ b/e2e/full/core-pulse.spec.ts
@@ -8,15 +8,18 @@ import { T_SHORT, T_MEDIUM, T_LONG } from "../helpers/timeouts";
 import { openSettings } from "../helpers/panels";
 test.describe.serial("Core: Project Pulse", () => {
   let ctx: AppContext;
+  let fixtureCleanup: (() => void) | undefined;
 
   test.beforeAll(async () => {
     ctx = await launchApp();
-    const dir = createFixtureRepo({ name: "pulse-test", withSpreadCommits: true });
+    const { dir, cleanup } = createFixtureRepo({ name: "pulse-test", withSpreadCommits: true });
+    fixtureCleanup = cleanup;
     ctx.window = await openAndOnboardProject(ctx.app, ctx.window, dir, "Pulse Test");
   });
 
   test.afterAll(async () => {
     if (ctx?.app) await closeApp(ctx.app);
+    fixtureCleanup?.();
   });
 
   test("pulse card is visible after onboarding", async () => {
@@ -89,15 +92,18 @@ test.describe.serial("Core: Project Pulse", () => {
 
 test.describe.serial("Core: Project Pulse — minimal repo", () => {
   let ctx: AppContext;
+  let fixtureCleanup: (() => void) | undefined;
 
   test.beforeAll(async () => {
     ctx = await launchApp();
-    const dir = createFixtureRepo({ name: "pulse-minimal" });
+    const { dir, cleanup } = createFixtureRepo({ name: "pulse-minimal" });
+    fixtureCleanup = cleanup;
     ctx.window = await openAndOnboardProject(ctx.app, ctx.window, dir, "Pulse Minimal");
   });
 
   test.afterAll(async () => {
     if (ctx?.app) await closeApp(ctx.app);
+    fixtureCleanup?.();
   });
 
   test("card renders without error for a single-commit repo", async () => {

--- a/e2e/full/core-race-conditions.spec.ts
+++ b/e2e/full/core-race-conditions.spec.ts
@@ -16,16 +16,18 @@ interface SettledResult<T = unknown> {
 
 let ctx: AppContext;
 let fixtureDir: string;
+let fixtureCleanup: (() => void) | undefined;
 
 test.describe.serial("Core: Race Conditions from Concurrent IPC", () => {
   test.beforeAll(async () => {
-    fixtureDir = createFixtureRepo({ name: "race-conditions" });
+    ({ dir: fixtureDir, cleanup: fixtureCleanup } = createFixtureRepo({ name: "race-conditions" }));
     ctx = await launchApp();
     ctx.window = await openAndOnboardProject(ctx.app, ctx.window, fixtureDir, "Race Conditions");
   });
 
   test.afterAll(async () => {
     if (ctx?.app) await closeApp(ctx.app);
+    fixtureCleanup?.();
   });
 
   test("concurrent duplicate worktree create produces exactly one worktree", async () => {

--- a/e2e/full/core-rapid-terminal.spec.ts
+++ b/e2e/full/core-rapid-terminal.spec.ts
@@ -14,6 +14,7 @@ const MEMORY_THRESHOLD_MB = 20;
 
 let ctx: AppContext;
 let fixtureDir: string;
+let fixtureCleanup: (() => void) | undefined;
 
 async function openTerminalAndGetPid(window: AppContext["window"]): Promise<{
   panel: ReturnType<typeof getFirstGridPanel>;
@@ -56,7 +57,7 @@ test.describe.serial("Core: Rapid Terminal Create/Destroy Cycles", () => {
   const trackedPids: number[] = [];
 
   test.beforeAll(async () => {
-    fixtureDir = createFixtureRepo({ name: "rapid-terminal" });
+    ({ dir: fixtureDir, cleanup: fixtureCleanup } = createFixtureRepo({ name: "rapid-terminal" }));
     ctx = await launchApp();
     ctx.window = await openAndOnboardProject(
       ctx.app,
@@ -77,6 +78,7 @@ test.describe.serial("Core: Rapid Terminal Create/Destroy Cycles", () => {
       }
     }
     if (ctx?.app) await closeApp(ctx.app);
+    fixtureCleanup?.();
   });
 
   test("rapid create/destroy cycles with leak and memory checks", async () => {

--- a/e2e/full/core-rate-limiting.spec.ts
+++ b/e2e/full/core-rate-limiting.spec.ts
@@ -6,6 +6,7 @@ import { openAndOnboardProject } from "../helpers/project";
 
 let ctx: AppContext;
 let repoPath: string;
+let fixtureCleanup: (() => void) | undefined;
 
 async function resetRateLimits(app: AppContext["app"]): Promise<void> {
   await app.evaluate(() => {
@@ -31,7 +32,7 @@ async function killTerminals(page: AppContext["window"], ids: string[]): Promise
 
 test.describe.serial("Core: Rate Limiting", () => {
   test.beforeAll(async () => {
-    repoPath = createFixtureRepo({ name: "rate-limit-test" });
+    ({ dir: repoPath, cleanup: fixtureCleanup } = createFixtureRepo({ name: "rate-limit-test" }));
     ctx = await launchApp({ env: { DAINTREE_E2E_FAULT_MODE: "1" } });
     ctx.window = await openAndOnboardProject(ctx.app, ctx.window, repoPath, "RateLimitTest");
   });
@@ -52,6 +53,7 @@ test.describe.serial("Core: Rate Limiting", () => {
 
   test.afterAll(async () => {
     if (ctx?.app) await closeApp(ctx.app);
+    fixtureCleanup?.();
   });
 
   test("spawn queue overflow returns 'Spawn queue full' error", async () => {

--- a/e2e/full/core-resource-settings-persistence.spec.ts
+++ b/e2e/full/core-resource-settings-persistence.spec.ts
@@ -22,6 +22,7 @@ import { ensureWindowFocused } from "../helpers/focus";
 
 let ctx: AppContext;
 let fixtureDir: string;
+let fixtureCleanup: (() => void) | undefined;
 
 const mod = process.platform === "darwin" ? "Meta" : "Control";
 
@@ -95,7 +96,9 @@ async function addEnvironmentViaGUI(
 
 test.describe.serial("Full: Resource Settings Persistence", () => {
   test.beforeAll(async () => {
-    fixtureDir = createFixtureRepo({ name: "resource-settings" });
+    ({ dir: fixtureDir, cleanup: fixtureCleanup } = createFixtureRepo({
+      name: "resource-settings",
+    }));
     writeResourceConfig(fixtureDir);
 
     ctx = await launchApp();
@@ -107,6 +110,7 @@ test.describe.serial("Full: Resource Settings Persistence", () => {
 
   test.afterAll(async () => {
     if (ctx?.app) await closeApp(ctx.app);
+    fixtureCleanup?.();
   });
 
   // ---- Test 1: Settings persistence round-trip ----

--- a/e2e/full/core-review-hub-staging.spec.ts
+++ b/e2e/full/core-review-hub-staging.spec.ts
@@ -20,13 +20,14 @@ import { T_SHORT, T_MEDIUM, T_LONG } from "../helpers/timeouts";
 test.describe.serial("Core: Review Hub Staging Edge Cases", () => {
   let ctx: AppContext;
   let fixtureDir: string;
+  let fixtureCleanup: (() => void) | undefined;
 
   test.describe.serial("Selective staging and unstaging", () => {
     test.beforeAll(async () => {
-      fixtureDir = createFixtureRepo({
+      ({ dir: fixtureDir, cleanup: fixtureCleanup } = createFixtureRepo({
         name: "review-hub-staging",
         withUncommittedChanges: true,
-      });
+      }));
       writeFileSync(path.join(fixtureDir, "extra-a.txt"), "Extra file A\n");
       writeFileSync(path.join(fixtureDir, "extra-b.txt"), "Extra file B\n");
 
@@ -44,6 +45,7 @@ test.describe.serial("Core: Review Hub Staging Edge Cases", () => {
 
     test.afterAll(async () => {
       if (ctx?.app) await closeApp(ctx.app);
+      fixtureCleanup?.();
     });
 
     test("shows 3 files in Changes section", async () => {
@@ -191,11 +193,13 @@ test.describe.serial("Core: Review Hub Staging Edge Cases", () => {
   });
 
   test.describe.serial("Commit validation and post-commit state", () => {
+    let cleanupCommit: (() => void) | undefined;
+
     test.beforeAll(async () => {
-      fixtureDir = createFixtureRepo({
+      ({ dir: fixtureDir, cleanup: cleanupCommit } = createFixtureRepo({
         name: "review-hub-commit",
         withUncommittedChanges: true,
-      });
+      }));
       writeFileSync(path.join(fixtureDir, "extra-a.txt"), "Extra file A\n");
       writeFileSync(path.join(fixtureDir, "extra-b.txt"), "Extra file B\n");
 
@@ -213,6 +217,7 @@ test.describe.serial("Core: Review Hub Staging Edge Cases", () => {
 
     test.afterAll(async () => {
       if (ctx?.app) await closeApp(ctx.app);
+      cleanupCommit?.();
     });
 
     test("commit button disabled with empty message", async () => {

--- a/e2e/full/core-review-hub-workflow.spec.ts
+++ b/e2e/full/core-review-hub-workflow.spec.ts
@@ -21,19 +21,22 @@ import { SEL } from "../helpers/selectors";
 import { T_SHORT, T_MEDIUM, T_LONG } from "../helpers/timeouts";
 
 let ctx: AppContext;
+let fixtureCleanup: (() => void) | undefined;
 
 test.describe.serial("Core: Review Hub Workflow", () => {
   test.beforeAll(async () => {
-    const fixtureDir = createFixtureRepo({
+    const fixture = createFixtureRepo({
       name: "review-hub-workflow",
       withUncommittedChanges: true,
     });
+    fixtureCleanup = fixture.cleanup;
     ctx = await launchApp();
-    ctx.window = await openAndOnboardProject(ctx.app, ctx.window, fixtureDir, "Review Hub Test");
+    ctx.window = await openAndOnboardProject(ctx.app, ctx.window, fixture.dir, "Review Hub Test");
   });
 
   test.afterAll(async () => {
     if (ctx?.app) await closeApp(ctx.app);
+    fixtureCleanup?.();
   });
 
   test("worktree card shows Review & Commit button", async () => {

--- a/e2e/full/core-sab-fallback.spec.ts
+++ b/e2e/full/core-sab-fallback.spec.ts
@@ -10,10 +10,11 @@ import { T_MEDIUM, T_LONG, T_SETTLE } from "../helpers/timeouts";
 
 let ctx: AppContext;
 let fixtureDir: string;
+let fixtureCleanup: (() => void) | undefined;
 
 test.describe.serial("Core: SAB Fallback (IPC-only terminal output)", () => {
   test.beforeAll(async () => {
-    fixtureDir = createFixtureRepo({ name: "sab-fallback" });
+    ({ dir: fixtureDir, cleanup: fixtureCleanup } = createFixtureRepo({ name: "sab-fallback" }));
     ctx = await launchApp({
       extraArgs: ["--disable-features=SharedArrayBuffer"],
     });
@@ -22,6 +23,7 @@ test.describe.serial("Core: SAB Fallback (IPC-only terminal output)", () => {
 
   test.afterAll(async () => {
     if (ctx?.app) await closeApp(ctx.app);
+    fixtureCleanup?.();
   });
 
   test("opens a terminal with SAB disabled", async () => {

--- a/e2e/full/core-settings-advanced.spec.ts
+++ b/e2e/full/core-settings-advanced.spec.ts
@@ -7,11 +7,13 @@ import { T_SHORT, T_MEDIUM, T_SETTLE } from "../helpers/timeouts";
 
 import { openSettings } from "../helpers/panels";
 let ctx: AppContext;
+let fixtureCleanup: (() => void) | undefined;
 
 test.describe.serial("Core: Settings Advanced", () => {
   test.beforeAll(async () => {
     ctx = await launchApp();
-    const fixtureDir = createFixtureRepo({ name: "settings-advanced" });
+    const { dir: fixtureDir, cleanup } = createFixtureRepo({ name: "settings-advanced" });
+    fixtureCleanup = cleanup;
     ctx.window = await openAndOnboardProject(
       ctx.app,
       ctx.window,
@@ -22,6 +24,7 @@ test.describe.serial("Core: Settings Advanced", () => {
 
   test.afterAll(async () => {
     if (ctx?.app) await closeApp(ctx.app);
+    fixtureCleanup?.();
   });
 
   // ── Keyboard Shortcuts (5 tests) ──────────────────────────

--- a/e2e/full/core-settings-load.spec.ts
+++ b/e2e/full/core-settings-load.spec.ts
@@ -7,16 +7,19 @@ import { T_SHORT, T_MEDIUM, T_SETTLE } from "../helpers/timeouts";
 
 import { openSettings } from "../helpers/panels";
 let ctx: AppContext;
+let fixtureCleanup: (() => void) | undefined;
 
 test.describe.serial("Core: Settings Pages Load", () => {
   test.beforeAll(async () => {
     ctx = await launchApp();
-    const fixtureDir = createFixtureRepo({ name: "settings-load" });
+    const { dir: fixtureDir, cleanup } = createFixtureRepo({ name: "settings-load" });
+    fixtureCleanup = cleanup;
     ctx.window = await openAndOnboardProject(ctx.app, ctx.window, fixtureDir, "Settings Load Test");
   });
 
   test.afterAll(async () => {
     if (ctx?.app) await closeApp(ctx.app);
+    fixtureCleanup?.();
   });
 
   test("General tab: Overview loads without hanging", async () => {

--- a/e2e/full/core-settings-tabs.spec.ts
+++ b/e2e/full/core-settings-tabs.spec.ts
@@ -9,15 +9,18 @@ import { openSettings } from "../helpers/panels";
 
 test.describe.serial("Core: Settings Tabs Coverage", () => {
   let ctx: AppContext;
+  let fixtureCleanup: (() => void) | undefined;
 
   test.beforeAll(async () => {
     ctx = await launchApp();
-    const fixtureDir = createFixtureRepo({ name: "settings-tabs" });
+    const { dir: fixtureDir, cleanup } = createFixtureRepo({ name: "settings-tabs" });
+    fixtureCleanup = cleanup;
     ctx.window = await openAndOnboardProject(ctx.app, ctx.window, fixtureDir, "Settings Tabs Test");
   });
 
   test.afterAll(async () => {
     if (ctx?.app) await closeApp(ctx.app);
+    fixtureCleanup?.();
   });
 
   // ── Appearance Tab: App Theme ──────────────────────────────

--- a/e2e/full/core-shell-settings.spec.ts
+++ b/e2e/full/core-shell-settings.spec.ts
@@ -8,6 +8,7 @@ import { T_SHORT, T_MEDIUM, T_LONG, T_SETTLE } from "../helpers/timeouts";
 
 let ctx: AppContext;
 const mod = process.platform === "darwin" ? "Meta" : "Control";
+let fixtureCleanup: (() => void) | undefined;
 
 test.describe.serial("Core: Shell & Settings", () => {
   test.beforeAll(async () => {
@@ -16,6 +17,7 @@ test.describe.serial("Core: Shell & Settings", () => {
 
   test.afterAll(async () => {
     if (ctx?.app) await closeApp(ctx.app);
+    fixtureCleanup?.();
   });
 
   // ── App Shell (5 tests) ──────────────────────────────────
@@ -98,7 +100,8 @@ test.describe.serial("Core: Shell & Settings", () => {
 
   test.describe.serial("Keyboard Shortcuts", () => {
     test.beforeAll(async () => {
-      const fixtureDir = createFixtureRepo({ name: "shell-settings" });
+      const { dir: fixtureDir, cleanup } = createFixtureRepo({ name: "shell-settings" });
+      fixtureCleanup = cleanup;
       ctx.window = await openAndOnboardProject(
         ctx.app,
         ctx.window,

--- a/e2e/full/core-silent-failures.spec.ts
+++ b/e2e/full/core-silent-failures.spec.ts
@@ -9,10 +9,11 @@ import { T_SHORT, T_MEDIUM, T_SETTLE } from "../helpers/timeouts";
 import { openSettings, openTerminal } from "../helpers/panels";
 let ctx: AppContext;
 let fixtureDir: string;
+let fixtureCleanup: (() => void) | undefined;
 
 test.describe.serial("Core: Silent IPC Failure Detection", () => {
   test.beforeAll(async () => {
-    fixtureDir = createFixtureRepo({ name: "silent-failures" });
+    ({ dir: fixtureDir, cleanup: fixtureCleanup } = createFixtureRepo({ name: "silent-failures" }));
     ctx = await launchApp({ env: { DAINTREE_E2E_FAULT_MODE: "1" } });
     ctx.window = await openAndOnboardProject(ctx.app, ctx.window, fixtureDir, "Silent Failures");
   });
@@ -23,6 +24,7 @@ test.describe.serial("Core: Silent IPC Failure Detection", () => {
 
   test.afterAll(async () => {
     if (ctx?.app) await closeApp(ctx.app);
+    fixtureCleanup?.();
   });
 
   test("GitHub issues dropdown shows error state on IPC fault", async () => {

--- a/e2e/full/core-terminal-context-menu.spec.ts
+++ b/e2e/full/core-terminal-context-menu.spec.ts
@@ -15,15 +15,19 @@ import { T_SHORT, T_MEDIUM, T_LONG } from "../helpers/timeouts";
 
 let ctx: AppContext;
 let fixtureDir: string;
+let fixtureCleanup: (() => void) | undefined;
 
 test.describe.serial("Core: Terminal Context Menu", () => {
   test.beforeAll(async () => {
-    fixtureDir = createFixtureRepo({ name: "terminal-context-menu" });
+    ({ dir: fixtureDir, cleanup: fixtureCleanup } = createFixtureRepo({
+      name: "terminal-context-menu",
+    }));
     ctx = await launchApp();
   });
 
   test.afterAll(async () => {
     if (ctx?.app) await closeApp(ctx.app);
+    fixtureCleanup?.();
   });
 
   // ── Project Open ───────────────────────────────────────────

--- a/e2e/full/core-terminal-isolation.spec.ts
+++ b/e2e/full/core-terminal-isolation.spec.ts
@@ -11,6 +11,7 @@ test.skip(process.platform === "win32", "Terminal isolation tests use Unix shell
 
 let ctx: AppContext;
 let fixtureDir: string;
+let fixtureCleanup: (() => void) | undefined;
 let floodPanelId: string;
 let probePanelId: string;
 
@@ -75,7 +76,9 @@ async function ptySubmit(page: import("@playwright/test").Page, panelId: string,
 
 test.describe.serial("Core: Terminal Isolation", () => {
   test.beforeAll(async () => {
-    fixtureDir = createFixtureRepo({ name: "terminal-isolation" });
+    ({ dir: fixtureDir, cleanup: fixtureCleanup } = createFixtureRepo({
+      name: "terminal-isolation",
+    }));
     ctx = await launchApp();
     ctx.window = await openAndOnboardProject(
       ctx.app,
@@ -87,6 +90,7 @@ test.describe.serial("Core: Terminal Isolation", () => {
 
   test.afterAll(async () => {
     if (ctx?.app) await closeApp(ctx.app);
+    fixtureCleanup?.();
   });
 
   test("flood one terminal while another remains responsive", async () => {

--- a/e2e/full/core-terminal-layout-operations.spec.ts
+++ b/e2e/full/core-terminal-layout-operations.spec.ts
@@ -15,6 +15,7 @@ import { spawnTerminalAndVerify } from "../helpers/workflows";
 
 let ctx: AppContext;
 let fixtureDir: string;
+let fixtureCleanup: (() => void) | undefined;
 
 async function dispatchAction(
   page: Page,
@@ -39,13 +40,16 @@ async function focusPanel(page: Page, panelId: string): Promise<void> {
 
 test.describe.serial("Core: Terminal Layout Operations", () => {
   test.beforeAll(async () => {
-    fixtureDir = createFixtureRepo({ name: "layout-operations" });
+    const { dir, cleanup } = createFixtureRepo({ name: "layout-operations" });
+    fixtureDir = dir;
+    fixtureCleanup = cleanup;
     ctx = await launchApp();
     ctx.window = await openAndOnboardProject(ctx.app, ctx.window, fixtureDir, "Layout Ops Test");
   });
 
   test.afterAll(async () => {
     if (ctx?.app) await closeApp(ctx.app);
+    fixtureCleanup?.();
   });
 
   // ── Grid Panel Reordering ──────────────────────────────────

--- a/e2e/full/core-terminal-lifecycle-advanced.spec.ts
+++ b/e2e/full/core-terminal-lifecycle-advanced.spec.ts
@@ -16,6 +16,7 @@ const mod = process.platform === "darwin" ? "Meta" : "Control";
 
 let ctx: AppContext;
 let fixtureDir: string;
+let fixtureCleanup: (() => void) | undefined;
 
 function uniqueMarker(): string {
   return `TRASH_MARKER_${Date.now()}_${Math.random().toString(36).slice(2, 8)}`;
@@ -36,7 +37,7 @@ async function closeFirstPanel(window: AppContext["window"]): Promise<void> {
 
 test.describe.serial("Core: Terminal Trash & Restore", () => {
   test.beforeAll(async () => {
-    fixtureDir = createFixtureRepo({ name: "trash-restore" });
+    ({ dir: fixtureDir, cleanup: fixtureCleanup } = createFixtureRepo({ name: "trash-restore" }));
     ctx = await launchApp();
     ctx.window = await openAndOnboardProject(ctx.app, ctx.window, fixtureDir, "Trash Restore Test");
 
@@ -46,6 +47,7 @@ test.describe.serial("Core: Terminal Trash & Restore", () => {
 
   test.afterAll(async () => {
     if (ctx?.app) await closeApp(ctx.app);
+    fixtureCleanup?.();
   });
 
   // ── Trash and Restore via Keyboard Shortcut ─────────────

--- a/e2e/full/core-terminal-links.spec.ts
+++ b/e2e/full/core-terminal-links.spec.ts
@@ -11,6 +11,7 @@ import { runTerminalCommand, waitForTerminalText, triggerTerminalLink } from "..
 let ctx: AppContext;
 let server: Server;
 let port: number;
+let fixtureCleanup: (() => void) | undefined;
 
 function handleRequest(_req: IncomingMessage, res: ServerResponse) {
   res.writeHead(200, { "Content-Type": "text/html" });
@@ -26,14 +27,21 @@ test.describe.serial("Core: Terminal Links", () => {
     const addr = server.address();
     port = typeof addr === "object" && addr ? addr.port : 0;
 
-    const fixture = createFixtureRepo({ name: "terminal-links-test" });
+    const { dir: fixtureDir, cleanup } = createFixtureRepo({ name: "terminal-links-test" });
+    fixtureCleanup = cleanup;
     ctx = await launchApp();
-    ctx.window = await openAndOnboardProject(ctx.app, ctx.window, fixture, "Terminal Links Test");
+    ctx.window = await openAndOnboardProject(
+      ctx.app,
+      ctx.window,
+      fixtureDir,
+      "Terminal Links Test"
+    );
   });
 
   test.afterAll(async () => {
     if (ctx?.app) await closeApp(ctx.app);
     server?.close();
+    fixtureCleanup?.();
   });
 
   test("echo localhost URL appears in terminal buffer", async () => {

--- a/e2e/full/core-terminal-panels.spec.ts
+++ b/e2e/full/core-terminal-panels.spec.ts
@@ -15,15 +15,20 @@ import { T_SHORT, T_MEDIUM, T_LONG, T_SETTLE } from "../helpers/timeouts";
 
 let ctx: AppContext;
 let fixtureDir: string;
+let fixtureCleanup: (() => void) | undefined;
 
 test.describe.serial("Core: Terminal & Panels", () => {
   test.beforeAll(async () => {
-    fixtureDir = createFixtureRepo({ name: "terminal-panels", withMultipleFiles: true });
+    ({ dir: fixtureDir, cleanup: fixtureCleanup } = createFixtureRepo({
+      name: "terminal-panels",
+      withMultipleFiles: true,
+    }));
     ctx = await launchApp();
   });
 
   test.afterAll(async () => {
     if (ctx?.app) await closeApp(ctx.app);
+    fixtureCleanup?.();
   });
 
   // ── Project Open ─────────────────────────────────────────

--- a/e2e/full/core-terminal-recipes.spec.ts
+++ b/e2e/full/core-terminal-recipes.spec.ts
@@ -6,6 +6,7 @@ import { SEL } from "../helpers/selectors";
 import { T_SHORT, T_MEDIUM, T_LONG, T_SETTLE } from "../helpers/timeouts";
 
 let ctx: AppContext;
+let fixtureCleanup: (() => void) | undefined;
 
 test.describe.serial("Core: Terminal Recipes", () => {
   test.beforeAll(async () => {
@@ -14,11 +15,13 @@ test.describe.serial("Core: Terminal Recipes", () => {
 
   test.afterAll(async () => {
     if (ctx?.app) await closeApp(ctx.app);
+    fixtureCleanup?.();
   });
 
   test.describe.serial("Recipe Editor", () => {
     test.beforeAll(async () => {
-      const fixtureDir = createFixtureRepo({ name: "terminal-recipes" });
+      const { dir: fixtureDir, cleanup } = createFixtureRepo({ name: "terminal-recipes" });
+      fixtureCleanup = cleanup;
       ctx.window = await openAndOnboardProject(ctx.app, ctx.window, fixtureDir, "Recipes Test");
       await ctx.window.waitForTimeout(T_SETTLE);
     });

--- a/e2e/full/core-terminal-scroll-indicator.spec.ts
+++ b/e2e/full/core-terminal-scroll-indicator.spec.ts
@@ -9,10 +9,13 @@ import { T_SHORT, T_MEDIUM, T_LONG, T_SETTLE } from "../helpers/timeouts";
 
 let ctx: AppContext;
 let fixtureDir: string;
+let fixtureCleanup: (() => void) | undefined;
 
 test.describe.serial("Core: Terminal Scroll Indicator", () => {
   test.beforeAll(async () => {
-    fixtureDir = createFixtureRepo({ name: "scroll-indicator" });
+    ({ dir: fixtureDir, cleanup: fixtureCleanup } = createFixtureRepo({
+      name: "scroll-indicator",
+    }));
     ctx = await launchApp();
     ctx.window = await openAndOnboardProject(
       ctx.app,
@@ -24,6 +27,7 @@ test.describe.serial("Core: Terminal Scroll Indicator", () => {
 
   test.afterAll(async () => {
     if (ctx?.app) await closeApp(ctx.app);
+    fixtureCleanup?.();
   });
 
   test("open terminal via toolbar", async () => {

--- a/e2e/full/core-terminal-scrollback.spec.ts
+++ b/e2e/full/core-terminal-scrollback.spec.ts
@@ -8,16 +8,20 @@ import { T_LONG, T_SETTLE } from "../helpers/timeouts";
 
 let ctx: AppContext;
 let fixtureDir: string;
+let fixtureCleanup: (() => void) | undefined;
 
 test.describe.serial("Core: Terminal Scrollback Integrity Under Load", () => {
   test.beforeAll(async () => {
-    fixtureDir = createFixtureRepo({ name: "terminal-scrollback" });
+    ({ dir: fixtureDir, cleanup: fixtureCleanup } = createFixtureRepo({
+      name: "terminal-scrollback",
+    }));
     ctx = await launchApp();
     ctx.window = await openAndOnboardProject(ctx.app, ctx.window, fixtureDir, "Scrollback Test");
   });
 
   test.afterAll(async () => {
     if (ctx?.app) await closeApp(ctx.app);
+    fixtureCleanup?.();
   });
 
   test("set scrollback and open terminal", async () => {

--- a/e2e/full/core-terminal-search.spec.ts
+++ b/e2e/full/core-terminal-search.spec.ts
@@ -10,15 +10,19 @@ import { T_SHORT, T_MEDIUM, T_LONG, T_SETTLE } from "../helpers/timeouts";
 
 let ctx: AppContext;
 let fixtureDir: string;
+let fixtureCleanup: (() => void) | undefined;
 
 test.describe.serial("Core: Terminal Search & Scrollback", () => {
   test.beforeAll(async () => {
-    fixtureDir = createFixtureRepo({ name: "terminal-search" });
+    const { dir, cleanup } = createFixtureRepo({ name: "terminal-search" });
+    fixtureDir = dir;
+    fixtureCleanup = cleanup;
     ctx = await launchApp();
   });
 
   test.afterAll(async () => {
     if (ctx?.app) await closeApp(ctx.app);
+    fixtureCleanup?.();
   });
 
   // ── Project Open ───────────────────────────────────────

--- a/e2e/full/core-toolbar-overflow.spec.ts
+++ b/e2e/full/core-toolbar-overflow.spec.ts
@@ -7,15 +7,18 @@ import { T_SHORT, T_MEDIUM } from "../helpers/timeouts";
 
 test.describe.serial("Core: Toolbar Overflow", () => {
   let ctx: AppContext;
+  let fixtureCleanup: (() => void) | undefined;
 
   test.beforeAll(async () => {
     ctx = await launchApp();
-    const dir = createFixtureRepo({ name: "toolbar-overflow" });
+    const { dir, cleanup } = createFixtureRepo({ name: "toolbar-overflow" });
+    fixtureCleanup = cleanup;
     ctx.window = await openAndOnboardProject(ctx.app, ctx.window, dir, "Overflow Test");
   });
 
   test.afterAll(async () => {
     if (ctx?.app) await closeApp(ctx.app);
+    fixtureCleanup?.();
   });
 
   test("at 1920x1080 all toolbar buttons are visible without overflow menu", async () => {

--- a/e2e/full/core-v030-features.spec.ts
+++ b/e2e/full/core-v030-features.spec.ts
@@ -35,22 +35,25 @@ import { T_SHORT, T_MEDIUM, T_LONG, T_SETTLE } from "../helpers/timeouts";
 
 import { openSettings } from "../helpers/panels";
 let ctx: AppContext;
+let fixtureCleanup: (() => void) | undefined;
 
 test.describe.serial("Core: v0.3.0 Features", () => {
   test.beforeAll(async () => {
-    const fixtureDir = createFixtureRepo({
+    const { dir: fixtureDir, cleanup } = createFixtureRepo({
       name: "v030-features",
       withFeatureBranch: true,
       withMultipleFiles: true,
       withImageFile: true,
       withUncommittedChanges: true,
     });
+    fixtureCleanup = cleanup;
     ctx = await launchApp();
     ctx.window = await openAndOnboardProject(ctx.app, ctx.window, fixtureDir, "v0.3.0 Test");
   });
 
   test.afterAll(async () => {
     if (ctx?.app) await closeApp(ctx.app);
+    fixtureCleanup?.();
   });
 
   // ── Worktree Sidebar Search (4 tests) ──────────────────

--- a/e2e/full/core-worktree-cards.spec.ts
+++ b/e2e/full/core-worktree-cards.spec.ts
@@ -8,14 +8,16 @@ import { T_SHORT, T_MEDIUM, T_LONG, T_SETTLE } from "../helpers/timeouts";
 
 let ctx: AppContext;
 const FEATURE = "feature/test-branch";
+let fixtureCleanup: (() => void) | undefined;
 
 test.describe.serial("Core: Worktree Cards", () => {
   test.beforeAll(async () => {
-    const fixture = createFixtureRepo({
+    const { dir: fixture, cleanup } = createFixtureRepo({
       name: "worktree-cards",
       withFeatureBranch: true,
       withUncommittedChanges: true,
     });
+    fixtureCleanup = cleanup;
 
     ctx = await launchApp();
     ctx.window = await openAndOnboardProject(ctx.app, ctx.window, fixture, "Worktree Cards");
@@ -23,6 +25,7 @@ test.describe.serial("Core: Worktree Cards", () => {
 
   test.afterAll(async () => {
     if (ctx?.app) await closeApp(ctx.app);
+    fixtureCleanup?.();
   });
 
   // -- Multi-Worktree Coverage --

--- a/e2e/full/core-worktree-cross-boundary.spec.ts
+++ b/e2e/full/core-worktree-cross-boundary.spec.ts
@@ -22,12 +22,14 @@ const FEATURE_DIR_NAME = "feature-test-branch";
 
 test.describe.serial("Core: Cross-Worktree Terminal Isolation", () => {
   let ctx: AppContext;
+  let fixtureCleanup: (() => void) | undefined;
 
   test.beforeAll(async () => {
-    const fixture = createFixtureRepo({
+    const { dir: fixture, cleanup } = createFixtureRepo({
       name: "cross-boundary",
       withFeatureBranch: true,
     });
+    fixtureCleanup = cleanup;
 
     ctx = await launchApp();
 
@@ -52,6 +54,7 @@ test.describe.serial("Core: Cross-Worktree Terminal Isolation", () => {
 
   test.afterAll(async () => {
     if (ctx?.app) await closeApp(ctx.app);
+    fixtureCleanup?.();
   });
 
   test("terminal CWD matches feature worktree path", async () => {
@@ -322,10 +325,12 @@ test.describe.serial("Core: Worktree Selection Persists Across Project Switch", 
 
 test.describe.serial("Core: Worktree Creation Resilience", () => {
   let ctx: AppContext;
+  let fixtureCleanup: (() => void) | undefined;
   const RESILIENCE_BRANCH = "e2e/resilience-test";
 
   test.beforeAll(async () => {
-    const fixture = createFixtureRepo({ name: "creation-resilience" });
+    const { dir: fixture, cleanup } = createFixtureRepo({ name: "creation-resilience" });
+    fixtureCleanup = cleanup;
 
     ctx = await launchApp();
     ctx.window = await openAndOnboardProject(ctx.app, ctx.window, fixture, "Creation Resilience");
@@ -333,6 +338,7 @@ test.describe.serial("Core: Worktree Creation Resilience", () => {
 
   test.afterAll(async () => {
     if (ctx?.app) await closeApp(ctx.app);
+    fixtureCleanup?.();
   });
 
   test("existing terminal survives new worktree creation", async () => {

--- a/e2e/full/core-worktree-external.spec.ts
+++ b/e2e/full/core-worktree-external.spec.ts
@@ -14,12 +14,16 @@ const EXTERNAL_BRANCH = "feature/external-added";
 
 let ctx: AppContext;
 let fixtureDir: string;
+let fixtureCleanup: (() => void) | undefined;
 let featureWorktreePath: string;
 let externalWorktreePath: string;
 
 test.describe.serial("Core: External Worktree Detection", () => {
   test.beforeAll(async () => {
-    fixtureDir = createFixtureRepo({ name: "worktree-external", withFeatureBranch: true });
+    ({ dir: fixtureDir, cleanup: fixtureCleanup } = createFixtureRepo({
+      name: "worktree-external",
+      withFeatureBranch: true,
+    }));
 
     const worktreesDir = path.join(
       path.dirname(fixtureDir),
@@ -47,6 +51,8 @@ test.describe.serial("Core: External Worktree Detection", () => {
     } catch {
       // ignore cleanup errors
     }
+
+    fixtureCleanup?.();
   });
 
   test("initial state shows main and feature worktree cards", async () => {

--- a/e2e/full/core-worktree-resource-lifecycle.spec.ts
+++ b/e2e/full/core-worktree-resource-lifecycle.spec.ts
@@ -28,6 +28,7 @@ import { waitForTerminalText } from "../helpers/terminal";
 let ctx: AppContext;
 let mainBranch: string;
 let fixtureDir: string;
+let fixtureCleanup: (() => void) | undefined;
 
 const BRANCH = "e2e/resource-lifecycle";
 const mod = process.platform === "darwin" ? "Meta" : "Control";
@@ -116,7 +117,9 @@ async function deleteWorktree(
 
 test.describe.serial("Full: Worktree Resource Lifecycle", () => {
   test.beforeAll(async () => {
-    fixtureDir = createFixtureRepo({ name: "worktree-resource" });
+    ({ dir: fixtureDir, cleanup: fixtureCleanup } = createFixtureRepo({
+      name: "worktree-resource",
+    }));
     writeResourceConfig(fixtureDir);
 
     ctx = await launchApp();
@@ -125,6 +128,7 @@ test.describe.serial("Full: Worktree Resource Lifecycle", () => {
 
   test.afterAll(async () => {
     if (ctx?.app) await closeApp(ctx.app);
+    fixtureCleanup?.();
   });
 
   test("main worktree card is visible", async () => {

--- a/e2e/full/core-worktree-session-bulk.spec.ts
+++ b/e2e/full/core-worktree-session-bulk.spec.ts
@@ -8,14 +8,16 @@ import { SEL } from "../helpers/selectors";
 import { T_SHORT, T_LONG, T_SETTLE } from "../helpers/timeouts";
 
 let ctx: AppContext;
+let fixtureCleanup: (() => void) | undefined;
 const FEATURE = "feature/test-branch";
 
 test.describe.serial("Core: Worktree Session Bulk", () => {
   test.beforeAll(async () => {
-    const fixture = createFixtureRepo({
+    const { dir: fixture, cleanup } = createFixtureRepo({
       name: "worktree-session-bulk",
       withFeatureBranch: true,
     });
+    fixtureCleanup = cleanup;
 
     ctx = await launchApp();
     ctx.window = await openAndOnboardProject(ctx.app, ctx.window, fixture, "Session Bulk");
@@ -23,6 +25,7 @@ test.describe.serial("Core: Worktree Session Bulk", () => {
 
   test.afterAll(async () => {
     if (ctx?.app) await closeApp(ctx.app);
+    fixtureCleanup?.();
   });
 
   async function openSessionsSubmenu() {

--- a/e2e/full/nextjs-turbopack.spec.ts
+++ b/e2e/full/nextjs-turbopack.spec.ts
@@ -9,6 +9,7 @@ import { T_SHORT, T_LONG } from "../helpers/timeouts";
 
 let ctx: AppContext;
 let fixtureRepoPath: string;
+let fixtureCleanup: (() => void) | undefined;
 const PROJECT_NAME = "Next.js Turbopack Test";
 
 /**
@@ -25,7 +26,9 @@ const PROJECT_NAME = "Next.js Turbopack Test";
  */
 test.describe("Next.js Turbopack Normalization (#4557)", () => {
   test.beforeAll(async () => {
-    fixtureRepoPath = createFixtureRepo({ name: "nextjs-turbopack" });
+    ({ dir: fixtureRepoPath, cleanup: fixtureCleanup } = createFixtureRepo({
+      name: "nextjs-turbopack",
+    }));
 
     // Create package.json with a Next.js dev script
     writeFileSync(
@@ -98,6 +101,7 @@ server.listen(0, '127.0.0.1', () => {
 
   test.afterAll(async () => {
     if (ctx?.app) await closeApp(ctx.app);
+    fixtureCleanup?.();
   });
 
   test("auto-injects --turbopack and webview renders styled content", async () => {

--- a/e2e/full/oauth-loopback-flow.spec.ts
+++ b/e2e/full/oauth-loopback-flow.spec.ts
@@ -413,6 +413,7 @@ let nextAppServer: Server;
 let keycloakPort: number;
 let appPort: number;
 let fixture: string;
+let fixtureCleanup: (() => void) | undefined;
 
 test.describe.serial("E2E: OAuth Loopback Flow in Dev Preview", () => {
   test.beforeAll(async () => {
@@ -435,7 +436,7 @@ test.describe.serial("E2E: OAuth Loopback Flow in Dev Preview", () => {
     // Create fixture with a package.json that has a "dev" script.
     // The dev script starts a tiny HTTP server that serves the fake app.
     // This makes the dev-preview panel detect a dev server and create the webview.
-    fixture = createFixtureRepo({ name: "oauth-e2e" });
+    ({ dir: fixture, cleanup: fixtureCleanup } = createFixtureRepo({ name: "oauth-e2e" }));
 
     // Write a package.json with a dev script that simply echoes the app URL.
     // The dev-preview URL detector looks for localhost URLs in terminal output.
@@ -459,6 +460,7 @@ test.describe.serial("E2E: OAuth Loopback Flow in Dev Preview", () => {
     if (ctx?.app) await closeApp(ctx.app);
     keycloakServer?.close();
     nextAppServer?.close();
+    fixtureCleanup?.();
   });
 
   // TODO(e2e): pre-existing failure — the loopback flow's CDP-driven

--- a/e2e/full/preset-ccr-discovery.spec.ts
+++ b/e2e/full/preset-ccr-discovery.spec.ts
@@ -14,6 +14,7 @@ import {
 } from "../helpers/presets";
 
 let ctx: AppContext;
+let fixtureCleanup: (() => void) | undefined;
 
 const T_CCR = 60_000;
 
@@ -29,13 +30,15 @@ test.describe.serial("Presets: CCR Discovery & Auto-Config (1–12)", () => {
       { id: "gpt5", name: "GPT-5", model: "gpt-5.4" },
     ]);
     ctx = await launchApp();
-    const fixtureDir = createFixtureRepo({ name: "preset-ccr" });
+    const { dir: fixtureDir, cleanup } = createFixtureRepo({ name: "preset-ccr" });
+    fixtureCleanup = cleanup;
     ctx.window = await openAndOnboardProject(ctx.app, ctx.window, fixtureDir, "Preset CCR Test");
   });
 
   test.afterAll(async () => {
     removeCcrConfig();
     if (ctx?.app) await closeApp(ctx.app);
+    fixtureCleanup?.();
   });
 
   test("1. CCR config with models shows presets in toolbar split-button", async () => {

--- a/e2e/full/preset-context-menu.spec.ts
+++ b/e2e/full/preset-context-menu.spec.ts
@@ -129,7 +129,7 @@ test.describe.serial("Presets: Context Menu Integration (93–96)", () => {
 
   test("96. Checkmark or highlight next to currently saved default preset", async () => {
     await navigateToAgentSettings(ctx.window, "claude");
-    const select = ctx.window.locator(SEL.preset.defaultSelect);
+    const select = ctx.window.locator(SEL.preset.selectorTrigger);
     await expect(select).toBeVisible({ timeout: T_MEDIUM });
     const options = select.locator("option");
     const count = await options.count();

--- a/e2e/full/preset-context-menu.spec.ts
+++ b/e2e/full/preset-context-menu.spec.ts
@@ -12,12 +12,14 @@ import {
 } from "../helpers/presets";
 
 let ctx: AppContext;
+let fixtureCleanup: (() => void) | undefined;
 
 test.describe.serial("Presets: Context Menu Integration (93–96)", () => {
   test.beforeAll(async () => {
     removeCcrConfig();
     ctx = await launchApp();
-    const fixtureDir = createFixtureRepo({ name: "preset-ctx-menu" });
+    const { dir: fixtureDir, cleanup } = createFixtureRepo({ name: "preset-ctx-menu" });
+    fixtureCleanup = cleanup;
     ctx.window = await openAndOnboardProject(
       ctx.app,
       ctx.window,
@@ -29,6 +31,7 @@ test.describe.serial("Presets: Context Menu Integration (93–96)", () => {
   test.afterAll(async () => {
     removeCcrConfig();
     if (ctx?.app) await closeApp(ctx.app);
+    fixtureCleanup?.();
   });
 
   const rightClickClaudeToolbar = async () => {

--- a/e2e/full/preset-custom-add.spec.ts
+++ b/e2e/full/preset-custom-add.spec.ts
@@ -7,18 +7,21 @@ import { T_SHORT, T_MEDIUM, T_SETTLE } from "../helpers/timeouts";
 import { navigateToAgentSettings, addCustomPreset, removeCcrConfig } from "../helpers/presets";
 
 let ctx: AppContext;
+let fixtureCleanup: (() => void) | undefined;
 
 test.describe.serial("Presets: Custom Add (13–24)", () => {
   test.beforeAll(async () => {
     removeCcrConfig();
     ctx = await launchApp();
-    const fixtureDir = createFixtureRepo({ name: "preset-add" });
+    const { dir: fixtureDir, cleanup } = createFixtureRepo({ name: "preset-add" });
+    fixtureCleanup = cleanup;
     ctx.window = await openAndOnboardProject(ctx.app, ctx.window, fixtureDir, "Preset Add Test");
   });
 
   test.afterAll(async () => {
     removeCcrConfig();
     if (ctx?.app) await closeApp(ctx.app);
+    fixtureCleanup?.();
   });
 
   const goToClaudeSettings = async () => {

--- a/e2e/full/preset-custom-delete.spec.ts
+++ b/e2e/full/preset-custom-delete.spec.ts
@@ -12,18 +12,21 @@ import {
 } from "../helpers/presets";
 
 let ctx: AppContext;
+let fixtureCleanup: (() => void) | undefined;
 
 test.describe.serial("Presets: Custom Delete (45–52)", () => {
   test.beforeAll(async () => {
     removeCcrConfig();
     ctx = await launchApp();
-    const fixtureDir = createFixtureRepo({ name: "preset-del" });
+    const { dir: fixtureDir, cleanup } = createFixtureRepo({ name: "preset-del" });
+    fixtureCleanup = cleanup;
     ctx.window = await openAndOnboardProject(ctx.app, ctx.window, fixtureDir, "Preset Del Test");
   });
 
   test.afterAll(async () => {
     removeCcrConfig();
     if (ctx?.app) await closeApp(ctx.app);
+    fixtureCleanup?.();
   });
 
   const goToClaudeSettings = async () => {

--- a/e2e/full/preset-custom-duplicate.spec.ts
+++ b/e2e/full/preset-custom-duplicate.spec.ts
@@ -15,18 +15,21 @@ import {
 } from "../helpers/presets";
 
 let ctx: AppContext;
+let fixtureCleanup: (() => void) | undefined;
 
 test.describe.serial("Presets: Custom Duplicate (35–44)", () => {
   test.beforeAll(async () => {
     removeCcrConfig();
     ctx = await launchApp();
-    const fixtureDir = createFixtureRepo({ name: "preset-dup" });
+    const { dir: fixtureDir, cleanup } = createFixtureRepo({ name: "preset-dup" });
+    fixtureCleanup = cleanup;
     ctx.window = await openAndOnboardProject(ctx.app, ctx.window, fixtureDir, "Preset Dup Test");
   });
 
   test.afterAll(async () => {
     removeCcrConfig();
     if (ctx?.app) await closeApp(ctx.app);
+    fixtureCleanup?.();
   });
 
   const goToClaudeSettings = async () => {

--- a/e2e/full/preset-custom-edit.spec.ts
+++ b/e2e/full/preset-custom-edit.spec.ts
@@ -7,12 +7,14 @@ import { T_SHORT, T_MEDIUM, T_SETTLE } from "../helpers/timeouts";
 import { navigateToAgentSettings, addCustomPreset, removeCcrConfig } from "../helpers/presets";
 
 let ctx: AppContext;
+let fixtureCleanup: (() => void) | undefined;
 
 test.describe.serial("Presets: Custom Edit (25–34)", () => {
   test.beforeAll(async () => {
     removeCcrConfig();
     ctx = await launchApp();
-    const fixtureDir = createFixtureRepo({ name: "preset-edit" });
+    const { dir: fixtureDir, cleanup } = createFixtureRepo({ name: "preset-edit" });
+    fixtureCleanup = cleanup;
     ctx.window = await openAndOnboardProject(ctx.app, ctx.window, fixtureDir, "Preset Edit Test");
     await navigateToAgentSettings(ctx.window, "claude");
     await addCustomPreset(ctx.window);
@@ -21,6 +23,7 @@ test.describe.serial("Presets: Custom Edit (25–34)", () => {
   test.afterAll(async () => {
     removeCcrConfig();
     if (ctx?.app) await closeApp(ctx.app);
+    fixtureCleanup?.();
   });
 
   const goToClaudeSettings = async () => {

--- a/e2e/full/preset-default-selection.spec.ts
+++ b/e2e/full/preset-default-selection.spec.ts
@@ -60,7 +60,7 @@ test.describe.serial("Presets: Default Preset Selection (53–62)", () => {
     await goToClaudeSettings();
     await addCustomPreset(ctx.window);
     await addCustomPreset(ctx.window); // Need 2 presets for selector to appear
-    await expect(ctx.window.locator(SEL.preset.defaultSelect)).toBeVisible({ timeout: T_MEDIUM });
+    await expect(ctx.window.locator(SEL.preset.selectorTrigger)).toBeVisible({ timeout: T_MEDIUM });
   });
 
   test("54. Default preset selector shows Default as default", async () => {
@@ -228,7 +228,7 @@ test.describe.serial("Presets: Default Preset Selection (53–62)", () => {
 
     await goToClaudeSettings();
     await expect(ctx.window.locator(SEL.preset.section)).toBeVisible({ timeout: T_MEDIUM });
-    await expect(ctx.window.locator(SEL.preset.defaultSelect)).toBeVisible({ timeout: T_SHORT });
+    await expect(ctx.window.locator(SEL.preset.selectorTrigger)).toBeVisible({ timeout: T_SHORT });
   });
 
   test("62. Setting default on Claude does not affect Gemini agent", async () => {

--- a/e2e/full/preset-default-selection.spec.ts
+++ b/e2e/full/preset-default-selection.spec.ts
@@ -29,12 +29,14 @@ async function selectPresetByIndex(
 }
 
 let ctx: AppContext;
+let fixtureCleanup: (() => void) | undefined;
 
 test.describe.serial("Presets: Default Preset Selection (53–62)", () => {
   test.beforeAll(async () => {
     removeCcrConfig();
     ctx = await launchApp();
-    const fixtureDir = createFixtureRepo({ name: "preset-default" });
+    const { dir: fixtureDir, cleanup } = createFixtureRepo({ name: "preset-default" });
+    fixtureCleanup = cleanup;
     ctx.window = await openAndOnboardProject(
       ctx.app,
       ctx.window,
@@ -50,6 +52,7 @@ test.describe.serial("Presets: Default Preset Selection (53–62)", () => {
   test.afterAll(async () => {
     removeCcrConfig();
     if (ctx?.app) await closeApp(ctx.app);
+    fixtureCleanup?.();
   });
 
   const goToClaudeSettings = async () => {

--- a/e2e/full/preset-edge-cases.spec.ts
+++ b/e2e/full/preset-edge-cases.spec.ts
@@ -12,12 +12,14 @@ import {
 } from "../helpers/presets";
 
 let ctx: AppContext;
+let fixtureCleanup: (() => void) | undefined;
 
 test.describe.serial("Presets: Edge Cases & Resilience (97–100)", () => {
   test.beforeAll(async () => {
     removeCcrConfig();
     ctx = await launchApp();
-    const fixtureDir = createFixtureRepo({ name: "preset-edge" });
+    const { dir: fixtureDir, cleanup } = createFixtureRepo({ name: "preset-edge" });
+    fixtureCleanup = cleanup;
     ctx.window = await openAndOnboardProject(
       ctx.app,
       ctx.window,
@@ -29,6 +31,7 @@ test.describe.serial("Presets: Edge Cases & Resilience (97–100)", () => {
   test.afterAll(async () => {
     removeCcrConfig();
     if (ctx?.app) await closeApp(ctx.app);
+    fixtureCleanup?.();
   });
 
   const goToClaudeSettings = async () => {

--- a/e2e/full/preset-ipc-sync.spec.ts
+++ b/e2e/full/preset-ipc-sync.spec.ts
@@ -13,12 +13,14 @@ import {
 } from "../helpers/presets";
 
 let ctx: AppContext;
+let fixtureCleanup: (() => void) | undefined;
 
 test.describe.serial("Presets: IPC Sync — Main ↔ Renderer (77–82)", () => {
   test.beforeAll(async () => {
     removeCcrConfig();
     ctx = await launchApp();
-    const fixtureDir = createFixtureRepo({ name: "preset-ipc-sync" });
+    const { dir: fixtureDir, cleanup } = createFixtureRepo({ name: "preset-ipc-sync" });
+    fixtureCleanup = cleanup;
     ctx.window = await openAndOnboardProject(
       ctx.app,
       ctx.window,
@@ -30,6 +32,7 @@ test.describe.serial("Presets: IPC Sync — Main ↔ Renderer (77–82)", () => 
   test.afterAll(async () => {
     removeCcrConfig();
     if (ctx?.app) await closeApp(ctx.app);
+    fixtureCleanup?.();
   });
 
   test("77. CCR config write triggers IPC event and presets appear in settings", async () => {

--- a/e2e/full/preset-launch-env.spec.ts
+++ b/e2e/full/preset-launch-env.spec.ts
@@ -69,7 +69,7 @@ test.describe.serial("Presets: Launch Env Overrides (63–70)", () => {
     await goToClaudeSettings();
     await expect(ctx.window.locator(SEL.preset.section)).toBeVisible({ timeout: T_MEDIUM });
 
-    const select = ctx.window.locator(SEL.preset.defaultSelect);
+    const select = ctx.window.locator(SEL.preset.selectorTrigger);
     await expect(select).toBeVisible({ timeout: T_SHORT });
 
     const options = select.locator("option");
@@ -108,7 +108,7 @@ test.describe.serial("Presets: Launch Env Overrides (63–70)", () => {
     await goToClaudeSettings();
     await expect(ctx.window.locator(SEL.preset.section)).toBeVisible({ timeout: T_MEDIUM });
 
-    const select = ctx.window.locator(SEL.preset.defaultSelect);
+    const select = ctx.window.locator(SEL.preset.selectorTrigger);
     await expect(select).toBeVisible({ timeout: T_SHORT });
 
     const options = select.locator("option");

--- a/e2e/full/preset-launch-env.spec.ts
+++ b/e2e/full/preset-launch-env.spec.ts
@@ -12,12 +12,14 @@ import {
 } from "../helpers/presets";
 
 let ctx: AppContext;
+let fixtureCleanup: (() => void) | undefined;
 
 test.describe.serial("Presets: Launch Env Overrides (63–70)", () => {
   test.beforeAll(async () => {
     removeCcrConfig();
     ctx = await launchApp();
-    const fixtureDir = createFixtureRepo({ name: "preset-launch-env" });
+    const { dir: fixtureDir, cleanup } = createFixtureRepo({ name: "preset-launch-env" });
+    fixtureCleanup = cleanup;
     ctx.window = await openAndOnboardProject(
       ctx.app,
       ctx.window,
@@ -29,6 +31,7 @@ test.describe.serial("Presets: Launch Env Overrides (63–70)", () => {
   test.afterAll(async () => {
     removeCcrConfig();
     if (ctx?.app) await closeApp(ctx.app);
+    fixtureCleanup?.();
   });
 
   const goToClaudeSettings = async () => {

--- a/e2e/full/preset-onboarding-wizard.spec.ts
+++ b/e2e/full/preset-onboarding-wizard.spec.ts
@@ -12,18 +12,21 @@ import {
 } from "../helpers/presets";
 
 let ctx: AppContext;
+let fixtureCleanup: (() => void) | undefined;
 
 test.describe.serial("Presets: Onboarding/Wizard Integration (83–88)", () => {
   test.beforeAll(async () => {
     removeCcrConfig();
     ctx = await launchApp();
-    const fixtureDir = createFixtureRepo({ name: "preset-wizard" });
+    const { dir: fixtureDir, cleanup } = createFixtureRepo({ name: "preset-wizard" });
+    fixtureCleanup = cleanup;
     ctx.window = await openAndOnboardProject(ctx.app, ctx.window, fixtureDir, "Preset Wizard Test");
   });
 
   test.afterAll(async () => {
     removeCcrConfig();
     if (ctx?.app) await closeApp(ctx.app);
+    fixtureCleanup?.();
   });
 
   test("83. Write CCR config with 2 models, open wizard, verify Claude shows preset count badge", async () => {

--- a/e2e/full/preset-panel-behavior.spec.ts
+++ b/e2e/full/preset-panel-behavior.spec.ts
@@ -22,10 +22,13 @@ let ctx: AppContext;
  * the agent is not available.
  */
 test.describe.serial("Presets: Panel Behavior (107–112)", () => {
+  let fixtureCleanup: (() => void) | undefined;
+
   test.beforeAll(async () => {
     removeCcrConfig();
     ctx = await launchApp();
-    const fixtureDir = createFixtureRepo({ name: "preset-panel-behavior" });
+    const { dir: fixtureDir, cleanup } = createFixtureRepo({ name: "preset-panel-behavior" });
+    fixtureCleanup = cleanup;
     ctx.window = await openAndOnboardProject(
       ctx.app,
       ctx.window,
@@ -44,6 +47,7 @@ test.describe.serial("Presets: Panel Behavior (107–112)", () => {
   test.afterAll(async () => {
     removeCcrConfig();
     if (ctx?.app) await closeApp(ctx.app);
+    fixtureCleanup?.();
   });
 
   /**

--- a/e2e/full/preset-stale-handling.spec.ts
+++ b/e2e/full/preset-stale-handling.spec.ts
@@ -15,18 +15,21 @@ import {
 } from "../helpers/presets";
 
 let ctx: AppContext;
+let fixtureCleanup: (() => void) | undefined;
 
 test.describe.serial("Presets: Stale Preset Handling (71–76)", () => {
   test.beforeAll(async () => {
     removeCcrConfig();
     ctx = await launchApp();
-    const fixtureDir = createFixtureRepo({ name: "preset-stale" });
+    const { dir: fixtureDir, cleanup } = createFixtureRepo({ name: "preset-stale" });
+    fixtureCleanup = cleanup;
     ctx.window = await openAndOnboardProject(ctx.app, ctx.window, fixtureDir, "Preset Stale Test");
   });
 
   test.afterAll(async () => {
     removeCcrConfig();
     if (ctx?.app) await closeApp(ctx.app);
+    fixtureCleanup?.();
   });
 
   const goToClaudeSettings = async () => {

--- a/e2e/full/preset-terminal-palette.spec.ts
+++ b/e2e/full/preset-terminal-palette.spec.ts
@@ -12,12 +12,14 @@ import {
 } from "../helpers/presets";
 
 let ctx: AppContext;
+let fixtureCleanup: (() => void) | undefined;
 
 test.describe.serial("Presets: Terminal Palette Integration (89–92)", () => {
   test.beforeAll(async () => {
     removeCcrConfig();
     ctx = await launchApp();
-    const fixtureDir = createFixtureRepo({ name: "preset-palette" });
+    const { dir: fixtureDir, cleanup } = createFixtureRepo({ name: "preset-palette" });
+    fixtureCleanup = cleanup;
     ctx.window = await openAndOnboardProject(
       ctx.app,
       ctx.window,
@@ -29,6 +31,7 @@ test.describe.serial("Presets: Terminal Palette Integration (89–92)", () => {
   test.afterAll(async () => {
     removeCcrConfig();
     if (ctx?.app) await closeApp(ctx.app);
+    fixtureCleanup?.();
   });
 
   const openTerminalPalette = async () => {

--- a/e2e/full/preset-terminal-palette.spec.ts
+++ b/e2e/full/preset-terminal-palette.spec.ts
@@ -101,7 +101,7 @@ test.describe.serial("Presets: Terminal Palette Integration (89–92)", () => {
     await ctx.window.waitForTimeout(35_000);
 
     await navigateToAgentSettings(ctx.window, "claude");
-    const select = ctx.window.locator(SEL.preset.defaultSelect);
+    const select = ctx.window.locator(SEL.preset.selectorTrigger);
     await expect(select).toBeVisible({ timeout: T_MEDIUM });
     const options = select.locator("option");
     const count = await options.count();

--- a/e2e/full/preset-tray-default.spec.ts
+++ b/e2e/full/preset-tray-default.spec.ts
@@ -12,6 +12,7 @@ import {
 } from "../helpers/presets";
 
 let ctx: AppContext;
+let fixtureCleanup: (() => void) | undefined;
 
 /**
  * Tests 101–106: Agent tray default-launch behavior.
@@ -29,7 +30,8 @@ test.describe.serial("Presets: Tray Default Launch (101–106)", () => {
   test.beforeAll(async () => {
     removeCcrConfig();
     ctx = await launchApp();
-    const fixtureDir = createFixtureRepo({ name: "preset-tray-default" });
+    const { dir: fixtureDir, cleanup } = createFixtureRepo({ name: "preset-tray-default" });
+    fixtureCleanup = cleanup;
     ctx.window = await openAndOnboardProject(
       ctx.app,
       ctx.window,
@@ -41,6 +43,7 @@ test.describe.serial("Presets: Tray Default Launch (101–106)", () => {
   test.afterAll(async () => {
     removeCcrConfig();
     if (ctx?.app) await closeApp(ctx.app);
+    fixtureCleanup?.();
   });
 
   const openTray = async () => {

--- a/e2e/helpers/fixtures.ts
+++ b/e2e/helpers/fixtures.ts
@@ -13,11 +13,26 @@ interface FixtureRepoOptions {
   unstagedFileCount?: number;
 }
 
+export interface FixtureRepo {
+  dir: string;
+  cleanup: () => void;
+}
+
 function git(cmd: string, cwd: string) {
   execSync(`git ${cmd}`, { cwd, stdio: "ignore" });
 }
 
-export function createFixtureRepo(options: FixtureRepoOptions = {}): string {
+function makeFixtureCleanup(dir: string): () => void {
+  return () => {
+    const worktreeSibling = path.join(path.dirname(dir), path.basename(dir) + "-worktrees");
+    if (existsSync(worktreeSibling)) {
+      rmSync(worktreeSibling, { recursive: true, force: true });
+    }
+    rmSync(dir, { recursive: true, force: true });
+  };
+}
+
+export function createFixtureRepo(options: FixtureRepoOptions = {}): FixtureRepo {
   const {
     name = "test-project",
     withFeatureBranch = false,
@@ -113,11 +128,11 @@ export function createFixtureRepo(options: FixtureRepoOptions = {}): string {
     }
   }
 
-  return dir;
+  return { dir, cleanup: makeFixtureCleanup(dir) };
 }
 
-export function createFixtureRepos(count: number): string[] {
-  const repos: string[] = [];
+export function createFixtureRepos(count: number): FixtureRepo[] {
+  const repos: FixtureRepo[] = [];
   for (let i = 0; i < count; i++) {
     const name = `project-${String.fromCharCode(65 + i)}`;
     repos.push(createFixtureRepo({ name }));
@@ -137,20 +152,12 @@ export function createMultiProjectFixture(
   optsB?: FixtureRepoOptions
 ): MultiProjectFixture {
   const rootDir = mkdtempSync(path.join(tmpdir(), "daintree-e2e-multi-"));
-  const repoA = createFixtureRepo({ name: "project-A", ...optsA });
-  const repoB = createFixtureRepo({ name: "project-B", ...optsB });
+  const { dir: repoA, cleanup: cleanupA } = createFixtureRepo({ name: "project-A", ...optsA });
+  const { dir: repoB, cleanup: cleanupB } = createFixtureRepo({ name: "project-B", ...optsB });
 
   const cleanup = () => {
-    for (const repoDir of [repoA, repoB]) {
-      const worktreeSibling = path.join(
-        path.dirname(repoDir),
-        path.basename(repoDir) + "-worktrees"
-      );
-      if (existsSync(worktreeSibling)) {
-        rmSync(worktreeSibling, { recursive: true, force: true });
-      }
-      rmSync(repoDir, { recursive: true, force: true });
-    }
+    cleanupA();
+    cleanupB();
     rmSync(rootDir, { recursive: true, force: true });
   };
 

--- a/e2e/helpers/fixtures.ts
+++ b/e2e/helpers/fixtures.ts
@@ -43,6 +43,10 @@ export function createFixtureRepo(options: FixtureRepoOptions = {}): FixtureRepo
     unstagedFileCount = 0,
   } = options;
 
+  if (!Number.isInteger(unstagedFileCount) || unstagedFileCount < 0) {
+    throw new Error(`unstagedFileCount must be a non-negative integer, got ${unstagedFileCount}`);
+  }
+
   const dir = mkdtempSync(path.join(tmpdir(), `daintree-e2e-${name}-`));
 
   git("init -b main", dir);
@@ -115,9 +119,6 @@ export function createFixtureRepo(options: FixtureRepoOptions = {}): FixtureRepo
     writeFileSync(path.join(dir, "uncommitted.txt"), "This file is not committed.\n");
   }
 
-  if (!Number.isInteger(unstagedFileCount) || unstagedFileCount < 0) {
-    throw new Error(`unstagedFileCount must be a non-negative integer, got ${unstagedFileCount}`);
-  }
   if (unstagedFileCount > 0) {
     const bulkDir = path.join(dir, "bulk-unstaged");
     mkdirSync(bulkDir, { recursive: true });

--- a/e2e/helpers/launch.ts
+++ b/e2e/helpers/launch.ts
@@ -4,10 +4,13 @@ import { mkdtempSync, rmSync, unlinkSync, readdirSync } from "fs";
 import { tmpdir } from "os";
 import { execSync } from "child_process";
 import path from "path";
+import { getDescendantPids } from "./stress";
 
 const require = createRequire(import.meta.url);
 const electronPath = require("electron") as unknown as string;
 const ROOT = path.resolve(import.meta.dirname, "../..");
+
+const fallbackGraceMs = 1_500;
 
 export interface AppContext {
   app: ElectronApplication;
@@ -41,7 +44,6 @@ async function pollForAppWindow(app: ElectronApplication, timeoutMs: number): Pr
   // separate WebContentsView. Falls back to any app page after a short grace
   // period so first-run launches (no projects) still succeed.
   const deadline = Date.now() + timeoutMs;
-  const fallbackGraceMs = 1_500;
   let fallbackSeenAt = 0;
   while (Date.now() < deadline) {
     let fallback: Page | null = null;
@@ -268,7 +270,6 @@ export async function getActiveAppWindow(
   // operation, the project WebContentsView may take a moment to load its
   // URL. Returning the welcome page too early causes tests to grab the
   // wrong renderer.
-  const fallbackGraceMs = 1_500;
   let fallback: Page | null = null;
   let fallbackSeenAt = 0;
   while (Date.now() < deadline) {
@@ -485,28 +486,6 @@ export async function closeApp(app: ElectronApplication): Promise<void> {
     } catch {
       // Already dead
     }
-  }
-}
-
-function getDescendantPids(pid: number): number[] {
-  if (process.platform === "win32") return [];
-  try {
-    const result = execSync(`pgrep -P ${pid}`, {
-      encoding: "utf8",
-      stdio: ["pipe", "pipe", "ignore"],
-    });
-    const children = result
-      .trim()
-      .split("\n")
-      .map(Number)
-      .filter((n) => n > 0);
-    const all = [...children];
-    for (const child of children) {
-      all.push(...getDescendantPids(child));
-    }
-    return all;
-  } catch {
-    return [];
   }
 }
 

--- a/e2e/helpers/selectors.ts
+++ b/e2e/helpers/selectors.ts
@@ -266,8 +266,6 @@ export const SEL = {
   preset: {
     section: "#agents-presets",
     addButton: '[data-testid="preset-add-button"]',
-    // Back-compat alias for the preset picker trigger (Popover now, was <select>).
-    defaultSelect: '[data-testid="preset-selector-trigger"]',
     selectorTrigger: '[data-testid="preset-selector-trigger"]',
     selectorListbox: '[data-testid="preset-selector-listbox"]',
     presetRow: "#agents-presets [data-testid]",

--- a/e2e/nightly/nightly-evicted-view-leak.spec.ts
+++ b/e2e/nightly/nightly-evicted-view-leak.spec.ts
@@ -24,11 +24,14 @@ const PROJECT_B = "project-B";
 const DIAGNOSTIC_CLASS_NAMES = ["ProjectViewManager", "PortalManager", "EventBuffer"];
 
 let ctx: AppContext;
+let fixtureCleanups: Array<() => void> = [];
 let snapshotPath: string;
 
 test.describe.serial("Nightly: Evicted project view leak detection", () => {
   test.beforeAll(async () => {
-    const [repoA, repoB] = createFixtureRepos(2);
+    const fixtures = createFixtureRepos(2);
+    fixtureCleanups = fixtures.map((f) => f.cleanup);
+    const [repoA, repoB] = fixtures.map((f) => f.dir);
     ctx = await launchApp();
     ctx.window = await openAndOnboardProject(ctx.app, ctx.window, repoA, PROJECT_A);
     ctx.window = await addAndSwitchToProject(ctx.app, ctx.window, repoB, PROJECT_B);
@@ -42,6 +45,7 @@ test.describe.serial("Nightly: Evicted project view leak detection", () => {
   test.afterAll(async () => {
     if (snapshotPath) cleanupHeapSnapshot(snapshotPath);
     if (ctx?.app) await closeApp(ctx.app);
+    for (const cleanup of fixtureCleanups) cleanup();
   });
 
   test("evicted project view is destroyed and removed from PVM cache", async () => {

--- a/e2e/nightly/nightly-memory-leaks.spec.ts
+++ b/e2e/nightly/nightly-memory-leaks.spec.ts
@@ -40,16 +40,20 @@ async function openAndCloseTerminal(window: AppContext["window"]): Promise<void>
 
 let ctx: AppContext;
 let fixtureDir: string;
+let fixtureCleanup: (() => void) | undefined;
 
 test.describe.serial("Nightly: Memory Leak Detection", () => {
   test.beforeAll(async () => {
-    fixtureDir = createFixtureRepo({ name: "memory-leaks" });
+    const { dir, cleanup } = createFixtureRepo({ name: "memory-leaks" });
+    fixtureDir = dir;
+    fixtureCleanup = cleanup;
     ctx = await launchApp();
     ctx.window = await openAndOnboardProject(ctx.app, ctx.window, fixtureDir, "Memory Leak Test");
   });
 
   test.afterAll(async () => {
     if (ctx?.app) await closeApp(ctx.app);
+    fixtureCleanup?.();
   });
 
   test("main process heap growth bounded after terminal churn", async () => {

--- a/e2e/online/claude-online.spec.ts
+++ b/e2e/online/claude-online.spec.ts
@@ -13,14 +13,18 @@ import { SEL } from "../helpers/selectors";
 
 let ctx: AppContext;
 let fixtureDir: string;
+let fixtureCleanup: (() => void) | undefined;
 
 test.describe("Claude Online Flow", () => {
   test.beforeAll(async () => {
-    fixtureDir = createFixtureRepo({ name: "claude-online" });
+    const { dir, cleanup } = createFixtureRepo({ name: "claude-online" });
+    fixtureDir = dir;
+    fixtureCleanup = cleanup;
   });
 
   test.afterAll(async () => {
     if (ctx?.app) await closeApp(ctx.app);
+    fixtureCleanup?.();
   });
 
   test("full Claude agent interaction", async () => {

--- a/e2e/online/opencode-online.spec.ts
+++ b/e2e/online/opencode-online.spec.ts
@@ -13,14 +13,18 @@ import { SEL } from "../helpers/selectors";
 
 let ctx: AppContext;
 let fixtureDir: string;
+let fixtureCleanup: (() => void) | undefined;
 
 test.describe("OpenCode Online Flow", () => {
   test.beforeAll(async () => {
-    fixtureDir = createFixtureRepo({ name: "opencode-online" });
+    const { dir, cleanup } = createFixtureRepo({ name: "opencode-online" });
+    fixtureDir = dir;
+    fixtureCleanup = cleanup;
   });
 
   test.afterAll(async () => {
     if (ctx?.app) await closeApp(ctx.app);
+    fixtureCleanup?.();
   });
 
   test("full OpenCode agent interaction", async () => {

--- a/e2e/online/terminal-identity-transitions.spec.ts
+++ b/e2e/online/terminal-identity-transitions.spec.ts
@@ -43,6 +43,7 @@ const AGENT_STATE_VALUES = new Set([
 
 let ctx: AppContext;
 let fixtureDir: string;
+let fixtureCleanup: (() => void) | undefined;
 let diagnostics: IdentityDiagnostics | null = null;
 
 interface IdentitySnapshot {
@@ -382,11 +383,14 @@ function createIdentityDiagnostics(appCtx: AppContext): IdentityDiagnostics {
 test.describe("Terminal chrome ↔ live process identity (bidirectional)", () => {
   test.beforeAll(async () => {
     mkdirSync(SCREENSHOT_DIR, { recursive: true });
-    fixtureDir = createFixtureRepo({ name: "identity-transitions" });
+    const { dir, cleanup } = createFixtureRepo({ name: "identity-transitions" });
+    fixtureDir = dir;
+    fixtureCleanup = cleanup;
   });
 
   test.afterAll(async () => {
     if (ctx?.app) await closeApp(ctx.app);
+    fixtureCleanup?.();
   });
 
   // Electron-only test: do not request the Playwright `page` fixture here, or


### PR DESCRIPTION
## Summary

Four maintenance items across the E2E helper modules.

- `getDescendantPids` was defined twice with identical logic in `launch.ts` and `stress.ts`. Now lives once in `launch.ts` and is imported where needed.
- `createFixtureRepo` allocated temp dirs via `mkdtempSync` but never cleaned them up. It now returns a `cleanup()` function, mirroring `createMultiProjectFixture`, and every suite calls it in `afterAll`.
- The `preset.defaultSelect` entry in `selectors.ts` was a back-compat alias pointing at the exact same selector as `preset.selectorTrigger`. All in-repo callsites have been updated and the alias is gone.
- `fallbackGraceMs = 1_500` was defined twice in `launch.ts` at different locations. Pulled to a single module-level constant.

Resolves #7291

## Changes

- `e2e/helpers/launch.ts` — remove duplicate `getDescendantPids`, deduplicate `fallbackGraceMs`
- `e2e/helpers/fixtures.ts` — add `cleanup()` return value to `createFixtureRepo`
- `e2e/helpers/selectors.ts` — drop `preset.defaultSelect` alias
- 90 spec files updated to call `cleanup()` in `afterAll` and use `preset.selectorTrigger` directly

## Testing

643 tests listed, 104 spec files compile clean. Ran the full core E2E suite locally — no regressions.