### PR TITLE
fix(scripts): replace deprecated Image.LANCZOS for Pillow 10 compatibility

### DIFF
--- a/scripts/generate-icons.sh
+++ b/scripts/generate-icons.sh
@@ -1,10 +1,10 @@
-#!/bin/bash
+#!/usr/bin/env bash
 # Icon Generation Script for Daintree
 # Usage: ./scripts/generate-icons.sh <source-image.png>
 #
 # Requires:
 # - Source image should be at least 1024x1024 PNG (full-bleed square)
-# - Python 3 with Pillow and NumPy (pip3 install Pillow numpy)
+# - Python 3 with Pillow and NumPy (pip3 install 'Pillow>=9.1' numpy)
 # - macOS: iconutil (built-in)
 # - Windows: ImageMagick (brew install imagemagick)
 #
@@ -18,11 +18,13 @@
 # (compiled via actool) gets auto-masked. The .icns is used for DMG volume icons,
 # older macOS versions, and contexts where Assets.car isn't recognized.
 
-set -e
+set -euo pipefail
 
 SCRIPT_DIR="$(cd "$(dirname "$0")" && pwd)"
 SOURCE_IMAGE="${1:-icon-source.png}"
 BUILD_DIR="build"
+TMP_DIR="$(mktemp -d)"
+trap 'rm -rf "$TMP_DIR"' EXIT
 
 if [ ! -f "$SOURCE_IMAGE" ]; then
     echo "Error: Source image not found: $SOURCE_IMAGE"
@@ -34,10 +36,14 @@ mkdir -p "$BUILD_DIR"
 
 echo "Generating icons from: $SOURCE_IMAGE"
 
+# Initialize optional-skip flags (set -u requires they exist before conditional assignment)
+SKIP_ICNS=""
+SKIP_ICO=""
+
 # Check for required tools
 if ! python3 -c "from PIL import Image; import numpy" 2>/dev/null; then
     echo "Error: Python 3 with Pillow and NumPy required."
-    echo "Install with: pip3 install Pillow numpy"
+    echo "Install with: pip3 install 'Pillow>=9.1' numpy"
     exit 1
 fi
 
@@ -61,13 +67,18 @@ fi
 
 # --- Linux icon (rounded corners, transparent, no shadow) ---
 echo "Generating Linux icon with rounded corners..."
-python3 -c "
+python3 - "$SOURCE_IMAGE" "$BUILD_DIR" <<'EOF'
+import sys
+import os
 from PIL import Image, ImageDraw
 import numpy as np
 
-src = Image.open('$SOURCE_IMAGE').convert('RGBA')
+src_path = sys.argv[1]
+output_dir = sys.argv[2]
+
+src = Image.open(src_path).convert('RGBA')
 if src.size != (1024, 1024):
-    src = src.resize((1024, 1024), Image.LANCZOS)
+    src = src.resize((1024, 1024), Image.Resampling.LANCZOS)
 
 # Apply rounded rectangle mask (~18% radius for Fluent-style rounding)
 size = 1024
@@ -81,33 +92,36 @@ draw.rounded_rectangle([(0, 0), (size - 1, size - 1)], radius=radius, fill=255)
 mask_hires = Image.new('L', (size * 4, size * 4), 0)
 draw_hires = ImageDraw.Draw(mask_hires)
 draw_hires.rounded_rectangle([(0, 0), (size * 4 - 1, size * 4 - 1)], radius=radius * 4, fill=255)
-mask = mask_hires.resize((size, size), Image.LANCZOS)
+mask = mask_hires.resize((size, size), Image.Resampling.LANCZOS)
 
 result = Image.new('RGBA', (size, size), (0, 0, 0, 0))
 result.paste(src, (0, 0), mask)
-result.save('$BUILD_DIR/icon.png', 'PNG')
-print('  Created: $BUILD_DIR/icon.png (rounded, transparent)')
-"
+result.save(os.path.join(output_dir, 'icon.png'), 'PNG')
+print(f'  Created: {output_dir}/icon.png (rounded, transparent)')
+EOF
 
 # --- macOS icon (.icns with superellipse mask + drop shadow) ---
 if [ -z "$SKIP_ICNS" ]; then
     echo "Generating macOS icon with Apple superellipse mask..."
 
     # Step 1: Apply superellipse mask and drop shadow to source
-    MASKED_ICON="$BUILD_DIR/.icon-masked-1024.png"
+    MASKED_ICON="$TMP_DIR/.icon-masked-1024.png"
     python3 "$SCRIPT_DIR/generate-macos-icon.py" "$SOURCE_IMAGE" "$MASKED_ICON"
 
     # Step 2: Generate iconset from masked source
-    ICONSET_DIR="$BUILD_DIR/icon.iconset"
+    ICONSET_DIR="$TMP_DIR/icon.iconset"
     mkdir -p "$ICONSET_DIR"
 
     # Generate all required sizes from the masked 1024x1024
-    python3 -c "
-from PIL import Image
+    python3 - "$MASKED_ICON" "$ICONSET_DIR" <<'EOF'
+import sys
 import os
+from PIL import Image
 
-src = Image.open('$MASKED_ICON').convert('RGBA')
-iconset = '$ICONSET_DIR'
+src_path = sys.argv[1]
+iconset = sys.argv[2]
+
+src = Image.open(src_path).convert('RGBA')
 
 sizes = [
     ('icon_16x16.png', 16),
@@ -123,16 +137,14 @@ sizes = [
 ]
 
 for name, size in sizes:
-    resized = src.resize((size, size), Image.LANCZOS)
+    resized = src.resize((size, size), Image.Resampling.LANCZOS)
     resized.save(os.path.join(iconset, name), 'PNG')
 
 print('  Generated iconset with', len(sizes), 'sizes')
-"
+EOF
 
     # Step 3: Compile .icns
     iconutil -c icns "$ICONSET_DIR" -o "$BUILD_DIR/icon.icns"
-    rm -rf "$ICONSET_DIR"
-    rm -f "$MASKED_ICON"
     echo "  Created: $BUILD_DIR/icon.icns"
 fi
 
@@ -143,17 +155,21 @@ if [ -z "$SKIP_ICO" ]; then
     echo "Generating Windows icon with rounded corners..."
 
     # Generate a rounded 256x256 PNG first (largest .ico layer uses PNG compression)
-    python3 -c "
-from PIL import Image, ImageDraw
+    python3 - "$SOURCE_IMAGE" "$BUILD_DIR" <<'EOF'
+import sys
 import os
+from PIL import Image, ImageDraw
 
-src = Image.open('$SOURCE_IMAGE').convert('RGBA')
+src_path = sys.argv[1]
+output_dir = sys.argv[2]
+
+src = Image.open(src_path).convert('RGBA')
 
 sizes = [256, 128, 64, 48, 32, 24, 16]
 ico_frames = []
 
 for size in sizes:
-    resized = src.resize((size, size), Image.LANCZOS)
+    resized = src.resize((size, size), Image.Resampling.LANCZOS)
 
     # Apply rounded rectangle mask (~18% radius)
     radius = max(int(size * 0.18), 2)
@@ -164,7 +180,7 @@ for size in sizes:
     mask_hires = Image.new('L', (mask_size, mask_size), 0)
     draw = ImageDraw.Draw(mask_hires)
     draw.rounded_rectangle([(0, 0), (mask_size - 1, mask_size - 1)], radius=radius * scale, fill=255)
-    mask = mask_hires.resize((size, size), Image.LANCZOS)
+    mask = mask_hires.resize((size, size), Image.Resampling.LANCZOS)
 
     result = Image.new('RGBA', (size, size), (0, 0, 0, 0))
     result.paste(resized, (0, 0), mask)
@@ -172,13 +188,13 @@ for size in sizes:
 
 # Save as .ico with all sizes
 ico_frames[0].save(
-    '$BUILD_DIR/icon.ico',
+    os.path.join(output_dir, 'icon.ico'),
     format='ICO',
     sizes=[(f.width, f.height) for f in ico_frames],
     append_images=ico_frames[1:]
 )
-print('  Created: $BUILD_DIR/icon.ico (rounded, transparent)')
-"
+print(f'  Created: {output_dir}/icon.ico (rounded, transparent)')
+EOF
 fi
 
 echo ""

--- a/scripts/generate-icons.sh
+++ b/scripts/generate-icons.sh
@@ -41,7 +41,7 @@ SKIP_ICNS=""
 SKIP_ICO=""
 
 # Check for required tools
-if ! python3 -c "from PIL import Image; import numpy" 2>/dev/null; then
+if ! python3 -c "from PIL.Image import Resampling; import numpy" 2>/dev/null; then
     echo "Error: Python 3 with Pillow and NumPy required."
     echo "Install with: pip3 install 'Pillow>=9.1' numpy"
     exit 1

--- a/scripts/generate-macos-icon.py
+++ b/scripts/generate-macos-icon.py
@@ -83,7 +83,7 @@ def main():
     # Load and ensure 1024x1024
     source = Image.open(source_path).convert("RGBA")
     if source.size != (CANVAS, CANVAS):
-        source = source.resize((CANVAS, CANVAS), Image.LANCZOS)
+        source = source.resize((CANVAS, CANVAS), Image.Resampling.LANCZOS)
 
     # Generate superellipse mask
     mask = generate_superellipse_mask(CANVAS, ICON_SIZE, SUPERELLIPSE_N)


### PR DESCRIPTION
## Summary

Fixes a compatibility issue with Pillow 10, which removed `Image.LANCZOS`. All six call sites across the icon generation scripts now use `Image.Resampling.LANCZOS`, introduced in Pillow 9.1. The shell script also gets a portability pass to harden it for CI and contributor environments.

Resolves #7270.

## Changes

- Replaced all 6 instances of `Image.LANCZOS` with `Image.Resampling.LANCZOS` in `scripts/generate-icons.sh` and `scripts/generate-macos-icon.py`
- Updated the preflight check to validate the replacement import directly (`from PIL.Image import Resampling`)
- Switched shebang to `#!/usr/bin/env bash` for cross-platform portability
- Tightened safety mode from `set -e` to `set -euo pipefail`
- Switched temp paths to `mktemp -d` with an `EXIT` trap instead of hardcoded strings under `$BUILD_DIR`
- Converted three Python heredocs to pass file paths via `sys.argv`, avoiding quoting traps with single-quote characters in filenames
- Updated the `pip3 install` hint to `'Pillow>=9.1'` so the Resampling import is guaranteed available
- Added `SKIP_ICNS`/`SKIP_ICO` pre-initialization so the script doesn't fail under `set -u` when those are set externally

## Testing

Ran `scripts/generate-icons.sh` on macOS with Pillow 11.2.0. All outputs produced without error: `icon.png` (Linux), `icon.icns` (macOS), and `icon.ico` (Windows). The preflight check correctly detects missing packages and exits cleanly.