### PR TITLE
fix(ActionPalette): stabilize row memoization and empty-state copy

### DIFF
--- a/src/components/ActionPalette/ActionPalette.test.tsx
+++ b/src/components/ActionPalette/ActionPalette.test.tsx
@@ -27,7 +27,13 @@ vi.mock("@/components/ui/SearchablePalette", () => ({
     return (
       <div data-testid="searchable-palette">
         {props.beforeList ?? null}
-        {showEmptyContent ? (props.emptyContent ?? null) : null}
+        {showEmptyContent ? (
+          props.emptyMessage ? (
+            <p>{props.emptyMessage as string}</p>
+          ) : (
+            (props.emptyContent ?? null)
+          )
+        ) : null}
       </div>
     );
   },
@@ -122,14 +128,10 @@ describe("ActionPalette", () => {
     );
 
     expect(screen.queryByText("Recently used")).toBeNull();
-    // The static hint must stay parked behind the recently-used flag — it's not
-    // a generic palette decoration and shouldn't leak into the no-match state.
-    expect(
-      screen.queryByText("Actions depend on the focused panel and current context.")
-    ).toBeNull();
+    expect(screen.queryByText("Type to search actions")).toBeNull();
   });
 
-  it("provides the static hint as emptyContent for SearchablePalette to render when no MRU exists", () => {
+  it("shows the empty message when no MRU exists and no query is typed", () => {
     render(
       <ActionPalette
         isOpen
@@ -150,9 +152,7 @@ describe("ActionPalette", () => {
     );
 
     expect(screen.queryByText("Recently used")).toBeNull();
-    expect(
-      screen.getByText("Actions depend on the focused panel and current context.")
-    ).toBeTruthy();
+    expect(screen.getByText("Type to search actions")).toBeTruthy();
   });
 
   it("forwards isStale to SearchablePalette as isFiltering", () => {

--- a/src/components/ActionPalette/ActionPalette.tsx
+++ b/src/components/ActionPalette/ActionPalette.tsx
@@ -72,9 +72,10 @@ export function ActionPalette({
         <ActionPaletteItem
           key={item.id}
           item={item}
+          index={index}
           isSelected={isSelected}
           onSelect={handleSelect}
-          onHover={() => onHoverIndex(index)}
+          onHoverIndex={onHoverIndex}
         />
       )}
       label="Actions"
@@ -84,17 +85,12 @@ export function ActionPalette({
       searchAriaLabel="Search actions"
       listId="action-palette-list"
       itemIdPrefix="action-option"
-      emptyMessage="No recently used actions"
+      emptyMessage="Type to search actions"
       totalResults={totalResults}
       beforeList={
         isShowingRecentlyUsed ? (
           <div className="px-3 pt-2 pb-1 text-xs text-daintree-text/40">Recently used</div>
         ) : null
-      }
-      emptyContent={
-        <p className="mt-2 text-xs text-daintree-text/40">
-          Actions depend on the focused panel and current context.
-        </p>
       }
     />
   );

--- a/src/components/ActionPalette/ActionPaletteItem.test.tsx
+++ b/src/components/ActionPalette/ActionPaletteItem.test.tsx
@@ -39,6 +39,7 @@ describe("ActionPaletteItem", () => {
     render(
       <ActionPaletteItem
         item={makeItem({ enabled: true })}
+        index={0}
         isSelected={false}
         onSelect={onSelect}
       />
@@ -53,6 +54,7 @@ describe("ActionPaletteItem", () => {
     render(
       <ActionPaletteItem
         item={makeItem({ enabled: false, disabledReason: "No focused terminal" })}
+        index={0}
         isSelected={false}
         onSelect={onSelect}
       />
@@ -70,6 +72,7 @@ describe("ActionPaletteItem", () => {
     const { container } = render(
       <ActionPaletteItem
         item={makeItem({ enabled: false })}
+        index={0}
         isSelected={false}
         onSelect={onSelect}
       />
@@ -84,6 +87,7 @@ describe("ActionPaletteItem", () => {
     const { container } = render(
       <ActionPaletteItem
         item={makeItem({ enabled: true, disabledReason: "Should not show" })}
+        index={0}
         isSelected={false}
         onSelect={onSelect}
       />
@@ -98,6 +102,7 @@ describe("ActionPaletteItem", () => {
     render(
       <ActionPaletteItem
         item={makeItem({ keybinding: "⌘K" })}
+        index={0}
         isSelected={false}
         onSelect={onSelect}
       />
@@ -108,7 +113,7 @@ describe("ActionPaletteItem", () => {
 
   it("applies selected styling with aria-selected and accent indicator", () => {
     const { container } = render(
-      <ActionPaletteItem item={makeItem()} isSelected={true} onSelect={onSelect} />
+      <ActionPaletteItem item={makeItem()} index={0} isSelected={true} onSelect={onSelect} />
     );
 
     const button = container.querySelector("button");
@@ -122,10 +127,10 @@ describe("ActionPaletteItem", () => {
 
   it("does not branch styling on isSelected — selection is purely aria-driven", () => {
     const { container: selectedContainer } = render(
-      <ActionPaletteItem item={makeItem()} isSelected={true} onSelect={onSelect} />
+      <ActionPaletteItem item={makeItem()} index={0} isSelected={true} onSelect={onSelect} />
     );
     const { container: unselectedContainer } = render(
-      <ActionPaletteItem item={makeItem()} isSelected={false} onSelect={onSelect} />
+      <ActionPaletteItem item={makeItem()} index={0} isSelected={false} onSelect={onSelect} />
     );
 
     const selectedClass = selectedContainer.querySelector("button")?.className;
@@ -138,6 +143,7 @@ describe("ActionPaletteItem", () => {
     const { container } = render(
       <ActionPaletteItem
         item={makeItem({ keybinding: "⌘K" })}
+        index={0}
         isSelected={true}
         onSelect={onSelect}
       />
@@ -149,29 +155,44 @@ describe("ActionPaletteItem", () => {
     expect(container.querySelector("button")?.className).toContain("group");
   });
 
-  it("calls onHover when the pointer moves over the item", () => {
-    const onHover = vi.fn();
+  it("calls onHoverIndex with index when pointer moves over the item", () => {
+    const onHoverIndex = vi.fn();
     const { container } = render(
       <ActionPaletteItem
         item={makeItem()}
+        index={3}
         isSelected={false}
         onSelect={onSelect}
-        onHover={onHover}
+        onHoverIndex={onHoverIndex}
       />
     );
 
     const button = container.querySelector("button");
     expect(button).toBeTruthy();
     fireEvent.pointerMove(button!);
-    expect(onHover).toHaveBeenCalledTimes(1);
+    expect(onHoverIndex).toHaveBeenCalledTimes(1);
+    expect(onHoverIndex).toHaveBeenCalledWith(3);
   });
 
-  it("does not throw when onHover is omitted", () => {
+  it("does not throw when onHoverIndex is omitted", () => {
     const { container } = render(
-      <ActionPaletteItem item={makeItem()} isSelected={false} onSelect={onSelect} />
+      <ActionPaletteItem item={makeItem()} index={0} isSelected={false} onSelect={onSelect} />
     );
 
     const button = container.querySelector("button");
     expect(() => fireEvent.pointerMove(button!)).not.toThrow();
+  });
+
+  it("calls onSelect when an enabled item is clicked", () => {
+    const item = makeItem({ enabled: true });
+    const { container } = render(
+      <ActionPaletteItem item={item} index={0} isSelected={false} onSelect={onSelect} />
+    );
+
+    const button = container.querySelector("button");
+    expect(button).toBeTruthy();
+    fireEvent.click(button!);
+    expect(onSelect).toHaveBeenCalledTimes(1);
+    expect(onSelect).toHaveBeenCalledWith(item);
   });
 });

--- a/src/components/ActionPalette/ActionPaletteItem.tsx
+++ b/src/components/ActionPalette/ActionPaletteItem.tsx
@@ -1,4 +1,4 @@
-import React from "react";
+import React, { useCallback } from "react";
 import { cn } from "@/lib/utils";
 import type { ActionPaletteItem as ActionPaletteItemType } from "@/hooks/useActionPalette";
 import { ACTION_CATEGORY_COLORS, ACTION_CATEGORY_DEFAULT_COLOR } from "@/config/categoryColors";
@@ -7,23 +7,29 @@ interface ActionPaletteItemProps {
   item: ActionPaletteItemType;
   isSelected: boolean;
   onSelect: (item: ActionPaletteItemType) => void;
-  onHover?: () => void;
+  index: number;
+  onHoverIndex?: (index: number) => void;
 }
 
 export const ActionPaletteItem = React.memo(function ActionPaletteItem({
   item,
   isSelected,
   onSelect,
-  onHover,
+  index,
+  onHoverIndex,
 }: ActionPaletteItemProps) {
   const categoryColor = ACTION_CATEGORY_COLORS[item.category] ?? ACTION_CATEGORY_DEFAULT_COLOR;
+
+  const handleHover = useCallback(() => {
+    onHoverIndex?.(index);
+  }, [onHoverIndex, index]);
 
   return (
     <button
       id={`action-option-${item.id}`}
       tabIndex={-1}
       onPointerDown={(e) => e.preventDefault()}
-      onPointerMove={onHover}
+      onPointerMove={handleHover}
       role="option"
       aria-selected={isSelected}
       aria-disabled={!item.enabled}
@@ -37,7 +43,7 @@ export const ActionPaletteItem = React.memo(function ActionPaletteItem({
         "aria-selected:before:w-[2px] aria-selected:before:rounded-r aria-selected:before:bg-daintree-accent aria-selected:before:content-['']",
         !item.enabled && "opacity-40 cursor-not-allowed"
       )}
-      onClick={() => item.enabled && onSelect(item)}
+      onClick={() => onSelect(item)}
     >
       <span
         className={cn(


### PR DESCRIPTION
## Summary
- Stabilizes `React.memo` on `ActionPaletteItem` by passing `index` and `onHoverIndex` as separate props instead of an inline closure that invalidated every row on every keystroke.
- Updates the empty-state copy to verb-led text (`"Type to search actions"`) and drops the descriptive paragraph that described what wasn't there.
- Removes the dead `item.enabled &&` guard from `onClick` — the `disabled` attribute already prevents the browser from dispatching click events.

Resolves #7271

## Changes
- **`ActionPaletteItem.tsx`**: `onHover` replaced with `index` + `onHoverIndex`; hover composed internally via `useCallback` so the reference is stable across renders that don't change `onHoverIndex` or `index`. Dropped the unreachable `item.enabled &&` guard from `onClick`.
- **`ActionPalette.tsx`**: `renderItem` passes `index` and `onHoverIndex` directly. Empty-state copy updated, `emptyContent` paragraph removed.
- **Tests**: Updated to match new props. Added coverage for click-on-enabled-item and verifying `onHoverIndex` receives the correct index.

## Testing
- Unit tests pass (ActionPalette + ActionPaletteItem suites).
- Manual verification: typing in the palette no longer triggers unnecessary row re-renders; disabled items do not fire selection; the empty-state shows the new verb-led message.