### PR TITLE
fix(clone-dialog): polish interaction, progress, and error handling

### DIFF
--- a/electron/ipc/handlers/projectCrud/gitClone.ts
+++ b/electron/ipc/handlers/projectCrud/gitClone.ts
@@ -128,7 +128,12 @@ export function registerGitCloneHandlers(): () => void {
         .then(() => true)
         .catch(() => false);
       if (partialExists) {
-        await fs.promises.rm(targetPath, { recursive: true, force: true }).catch(() => {});
+        await fs.promises.rm(targetPath, { recursive: true, force: true }).catch((rmErr) => {
+          // Don't escalate — the original clone error is what the user sees.
+          // But surface this in logs so partial-cleanup failures (e.g. Windows
+          // antivirus locks) are diagnosable instead of silently swallowed.
+          console.warn("[gitClone] Failed to clean up partial clone at", targetPath, rmErr);
+        });
       }
 
       if (wasCancelled) {

--- a/src/components/Project/CloneRepoDialog.tsx
+++ b/src/components/Project/CloneRepoDialog.tsx
@@ -23,7 +23,7 @@ function extractFolderName(url: string): string {
     .replace(/[/\\]+$/, "")
     .replace(/\.git$/, "");
   const lastSegment = trimmed.split(/[/\\]/).filter(Boolean).pop() ?? "";
-  return lastSegment.replace(/[^\p{L}\p{N}\p{M}_.\-]/gu, "");
+  return lastSegment.replace(/[^\p{L}\p{N}\p{M}_.-]/gu, "");
 }
 
 function isOwnerRepoShorthand(input: string): boolean {

--- a/src/components/Project/CloneRepoDialog.tsx
+++ b/src/components/Project/CloneRepoDialog.tsx
@@ -1,7 +1,7 @@
 import { useState, useEffect, useRef, useCallback } from "react";
 import { Button } from "@/components/ui/button";
 import { AppDialog } from "@/components/ui/AppDialog";
-import { Check, AlertCircle, FolderOpen } from "lucide-react";
+import { Check, AlertCircle, FolderOpen, X } from "lucide-react";
 import { Spinner } from "@/components/ui/Spinner";
 import { FolderGit2 } from "@/components/icons";
 import { projectClient } from "@/clients";
@@ -177,7 +177,9 @@ export function CloneRepoDialog({ isOpen, onSuccess, onCancel }: CloneRepoDialog
   const showProgress = isCloning || progressEvents.length > 0;
 
   const handleKeyDown = (e: React.KeyboardEvent<HTMLInputElement>) => {
-    if (e.key === "Enter" && canClone && !isCloning && !isComplete && !error) {
+    // Enter acts as Retry too — startClone resets `error` internally, so this
+    // matches the on-screen Retry button instead of going dead after a failure.
+    if (e.key === "Enter" && canClone && !isCloning && !isComplete) {
       e.preventDefault();
       void startClone();
     }
@@ -289,6 +291,8 @@ export function CloneRepoDialog({ isOpen, onSuccess, onCancel }: CloneRepoDialog
                   <Check className="h-4 w-4 text-status-success shrink-0 mt-0.5" />
                 ) : event.stage === "error" ? (
                   <AlertCircle className="h-4 w-4 text-status-error shrink-0 mt-0.5" />
+                ) : event.stage === "cancelled" ? (
+                  <X className="h-4 w-4 text-muted-foreground shrink-0 mt-0.5" />
                 ) : (
                   <Spinner size="md" className="text-status-info shrink-0" />
                 )}
@@ -298,7 +302,9 @@ export function CloneRepoDialog({ isOpen, onSuccess, onCancel }: CloneRepoDialog
                       ? "text-status-error"
                       : event.stage === "complete"
                         ? "text-status-success"
-                        : "text-foreground"
+                        : event.stage === "cancelled"
+                          ? "text-muted-foreground"
+                          : "text-foreground"
                   }
                 >
                   {event.message}

--- a/src/components/Project/CloneRepoDialog.tsx
+++ b/src/components/Project/CloneRepoDialog.tsx
@@ -15,15 +15,15 @@ interface CloneRepoDialogProps {
   onCancel: () => void;
 }
 
-const AUTO_CLOSE_DELAY_MS = 800;
+const AUTO_CLOSE_DELAY_MS = 2000;
 
 function extractFolderName(url: string): string {
   const trimmed = url
     .trim()
-    .replace(/\/+$/, "")
+    .replace(/[/\\]+$/, "")
     .replace(/\.git$/, "");
-  const lastSegment = trimmed.split("/").pop() || "";
-  return lastSegment.replace(/[^\w.-]/g, "") || "";
+  const lastSegment = trimmed.split(/[/\\]/).filter(Boolean).pop() ?? "";
+  return lastSegment.replace(/[^\p{L}\p{N}\p{M}_.\-]/gu, "");
 }
 
 function isOwnerRepoShorthand(input: string): boolean {
@@ -84,7 +84,14 @@ export function CloneRepoDialog({ isOpen, onSuccess, onCancel }: CloneRepoDialog
     }
 
     const cleanup = projectClient.onCloneProgress((event) => {
-      setProgressEvents((prev) => [...prev, event]);
+      setProgressEvents((prev) => {
+        // Dedup by stage so a long clone (hundreds of byte-count updates per
+        // stage) shows one live-updating row per stage instead of an unbounded
+        // log. Final `complete`/`error`/`cancelled` events also dedup.
+        const merged = new Map(prev.map((e) => [e.stage, e]));
+        merged.set(event.stage, event);
+        return [...merged.values()];
+      });
     });
 
     return cleanup;
@@ -169,6 +176,13 @@ export function CloneRepoDialog({ isOpen, onSuccess, onCancel }: CloneRepoDialog
     folderNameError === null;
   const showProgress = isCloning || progressEvents.length > 0;
 
+  const handleKeyDown = (e: React.KeyboardEvent<HTMLInputElement>) => {
+    if (e.key === "Enter" && canClone && !isCloning && !isComplete && !error) {
+      e.preventDefault();
+      void startClone();
+    }
+  };
+
   return (
     <AppDialog isOpen={isOpen} onClose={handleClose} size="md" dismissible={!isCloning}>
       <AppDialog.Header>
@@ -186,6 +200,7 @@ export function CloneRepoDialog({ isOpen, onSuccess, onCancel }: CloneRepoDialog
             type="text"
             value={url}
             onChange={(e) => setUrl(e.target.value)}
+            onKeyDown={handleKeyDown}
             placeholder="owner/repo or https://github.com/user/repo.git"
             disabled={isCloning || isComplete}
             className="w-full rounded-md border border-daintree-border bg-daintree-bg px-3 py-2 text-sm text-daintree-text placeholder:text-daintree-text/40 focus:outline-hidden focus:ring-2 focus:ring-daintree-accent/50 disabled:opacity-50"
@@ -222,9 +237,13 @@ export function CloneRepoDialog({ isOpen, onSuccess, onCancel }: CloneRepoDialog
             type="text"
             value={folderName}
             onChange={(e) => {
-              setFolderName(e.target.value);
-              setFolderNameEdited(true);
+              const next = e.target.value;
+              setFolderName(next);
+              // Clearing the field re-enables URL-derived auto-suggest so the
+              // user can recover after a manual edit they no longer want.
+              setFolderNameEdited(next !== "");
             }}
+            onKeyDown={handleKeyDown}
             disabled={isCloning || isComplete}
             aria-invalid={folderNameError != null}
             className="w-full rounded-md border border-daintree-border bg-daintree-bg px-3 py-2 text-sm text-daintree-text placeholder:text-daintree-text/40 focus:outline-hidden focus:ring-2 focus:ring-daintree-accent/50 disabled:opacity-50 aria-invalid:border-status-error"
@@ -237,16 +256,22 @@ export function CloneRepoDialog({ isOpen, onSuccess, onCancel }: CloneRepoDialog
         </div>
 
         {/* Shallow Clone */}
-        <label className="flex items-center gap-2 cursor-pointer">
-          <input
-            type="checkbox"
-            checked={shallowClone}
-            onChange={(e) => setShallowClone(e.target.checked)}
-            disabled={isCloning || isComplete}
-            className="rounded border-daintree-border accent-daintree-accent"
-          />
-          <span className="text-sm text-daintree-text/70">Shallow clone (--depth 1)</span>
-        </label>
+        <div className="space-y-1">
+          <label className="flex items-center gap-2 cursor-pointer">
+            <input
+              type="checkbox"
+              checked={shallowClone}
+              onChange={(e) => setShallowClone(e.target.checked)}
+              disabled={isCloning || isComplete}
+              className="rounded border-daintree-border accent-daintree-accent"
+            />
+            <span className="text-sm text-daintree-text/70">Shallow clone (--depth 1)</span>
+          </label>
+          <p className="ml-6 text-xs text-daintree-text/50">
+            Only fetches the latest commit — faster for large repos, but limits history and some
+            push paths.
+          </p>
+        </div>
 
         {/* Progress Log */}
         {showProgress && (
@@ -318,7 +343,7 @@ export function CloneRepoDialog({ isOpen, onSuccess, onCancel }: CloneRepoDialog
                 variant="outline"
                 onClick={isCloning ? () => void projectClient.cancelClone() : onCancel}
               >
-                Cancel
+                {isCloning ? "Stop clone" : "Cancel"}
               </Button>
               <Button onClick={() => void startClone()} disabled={!canClone || isCloning}>
                 {isCloning ? (

--- a/src/components/Project/GitInitDialog.tsx
+++ b/src/components/Project/GitInitDialog.tsx
@@ -15,7 +15,7 @@ interface GitInitDialogProps {
   onCancel: () => void;
 }
 
-const AUTO_CLOSE_DELAY_MS = 800;
+const AUTO_CLOSE_DELAY_MS = 2000;
 
 export function GitInitDialog({ isOpen, directoryPath, onSuccess, onCancel }: GitInitDialogProps) {
   const [progressEvents, setProgressEvents] = useState<GitInitProgressEvent[]>([]);

--- a/src/components/Project/__tests__/CloneRepoDialog.test.tsx
+++ b/src/components/Project/__tests__/CloneRepoDialog.test.tsx
@@ -206,7 +206,11 @@ describe("CloneRepoDialog", () => {
       expect(screen.getByText("Open Project")).toBeTruthy();
     });
 
-    await waitFor(() => expect(onSuccess).toHaveBeenCalledWith("/tmp/my-repo"));
+    // Auto-close runs after AUTO_CLOSE_DELAY_MS (2s) — extend the waitFor
+    // timeout so the assertion outlives the dialog's read-the-log delay.
+    await waitFor(() => expect(onSuccess).toHaveBeenCalledWith("/tmp/my-repo"), {
+      timeout: 3000,
+    });
   });
 
   it("shows error and retry button on clone failure", async () => {
@@ -329,7 +333,7 @@ describe("CloneRepoDialog", () => {
     );
   });
 
-  it("Cancel button calls cancelClone during active clone", async () => {
+  it("Stop clone button calls cancelClone during active clone", async () => {
     cancelCloneMock.mockResolvedValue(undefined);
     cloneRepoMock.mockImplementation(() => new Promise(() => {}));
 
@@ -348,11 +352,14 @@ describe("CloneRepoDialog", () => {
       fireEvent.click(cloneBtn);
     });
 
-    const cancelBtn = screen.getByText("Cancel");
-    expect((cancelBtn as HTMLButtonElement).disabled).toBe(false);
+    // While cloning, the secondary button label switches from "Cancel" (close
+    // dialog) to "Stop clone" (abort in-flight work) to disambiguate intent.
+    expect(screen.queryByText("Cancel")).toBeNull();
+    const stopBtn = screen.getByText("Stop clone");
+    expect((stopBtn as HTMLButtonElement).disabled).toBe(false);
 
     await act(async () => {
-      fireEvent.click(cancelBtn);
+      fireEvent.click(stopBtn);
     });
 
     expect(cancelCloneMock).toHaveBeenCalled();
@@ -381,6 +388,113 @@ describe("CloneRepoDialog", () => {
     await waitFor(() => {
       expect(screen.queryByText("Clone Failed")).toBeNull();
     });
+  });
+
+  it("preserves Unicode characters in derived folder name", () => {
+    render(<CloneRepoDialog isOpen={true} onSuccess={vi.fn()} onCancel={vi.fn()} />);
+
+    const urlInput = screen.getByPlaceholderText("owner/repo or https://github.com/user/repo.git");
+    fireEvent.change(urlInput, { target: { value: "https://github.com/foo/café.git" } });
+
+    const inputs = screen.getAllByRole("textbox") as HTMLInputElement[];
+    const folderInput = inputs.find((i) => i.value === "café");
+    expect(folderInput).toBeDefined();
+  });
+
+  it("re-enables auto-derive when manually-edited folder name is cleared", () => {
+    render(<CloneRepoDialog isOpen={true} onSuccess={vi.fn()} onCancel={vi.fn()} />);
+
+    const urlInput = screen.getByPlaceholderText("owner/repo or https://github.com/user/repo.git");
+    fireEvent.change(urlInput, { target: { value: "https://github.com/user/first.git" } });
+
+    let inputs = screen.getAllByRole("textbox") as HTMLInputElement[];
+    let folderInput = inputs.find((i) => i.value === "first");
+    expect(folderInput).toBeDefined();
+
+    // Manually edit, then clear — clear should re-enable auto-derive.
+    fireEvent.change(folderInput!, { target: { value: "manual-name" } });
+    fireEvent.change(folderInput!, { target: { value: "" } });
+
+    // Now changing the URL should refill the folder name.
+    fireEvent.change(urlInput, { target: { value: "https://github.com/user/second.git" } });
+
+    inputs = screen.getAllByRole("textbox") as HTMLInputElement[];
+    folderInput = inputs.find((i) => i.value === "second");
+    expect(folderInput).toBeDefined();
+  });
+
+  it("submits clone when Enter is pressed in URL input", async () => {
+    cloneRepoMock.mockImplementation(() => new Promise(() => {}));
+
+    render(<CloneRepoDialog isOpen={true} onSuccess={vi.fn()} onCancel={vi.fn()} />);
+
+    const urlInput = screen.getByPlaceholderText("owner/repo or https://github.com/user/repo.git");
+    fireEvent.change(urlInput, { target: { value: "https://github.com/user/repo.git" } });
+
+    const browseBtn = screen.getByText("Browse");
+    await act(async () => {
+      fireEvent.click(browseBtn);
+    });
+
+    await act(async () => {
+      fireEvent.keyDown(urlInput, { key: "Enter" });
+    });
+
+    expect(cloneRepoMock).toHaveBeenCalledWith(
+      expect.objectContaining({ url: "https://github.com/user/repo.git" })
+    );
+  });
+
+  it("does not submit on Enter when form is invalid", async () => {
+    render(<CloneRepoDialog isOpen={true} onSuccess={vi.fn()} onCancel={vi.fn()} />);
+
+    const urlInput = screen.getByPlaceholderText("owner/repo or https://github.com/user/repo.git");
+    // No parent path picked yet — canClone is false.
+    fireEvent.change(urlInput, { target: { value: "https://github.com/user/repo.git" } });
+
+    await act(async () => {
+      fireEvent.keyDown(urlInput, { key: "Enter" });
+    });
+
+    expect(cloneRepoMock).not.toHaveBeenCalled();
+  });
+
+  it("dedups progress events by stage so a single stage shows one row", async () => {
+    cloneRepoMock.mockImplementation(() => new Promise(() => {}));
+
+    render(<CloneRepoDialog isOpen={true} onSuccess={vi.fn()} onCancel={vi.fn()} />);
+
+    const urlInput = screen.getByPlaceholderText("owner/repo or https://github.com/user/repo.git");
+    fireEvent.change(urlInput, { target: { value: "https://github.com/user/repo.git" } });
+
+    const browseBtn = screen.getByText("Browse");
+    await act(async () => {
+      fireEvent.click(browseBtn);
+    });
+
+    const cloneBtn = screen.getByText("Clone");
+    await act(async () => {
+      fireEvent.click(cloneBtn);
+    });
+
+    await waitFor(() => expect(progressHandler).not.toBeNull());
+
+    act(() => {
+      for (let pct = 0; pct <= 100; pct += 10) {
+        progressHandler?.({
+          stage: "receiving",
+          progress: pct,
+          message: `receiving: ${pct}%`,
+          timestamp: Date.now(),
+        });
+      }
+    });
+
+    // Only the latest message for the `receiving` stage should remain — the
+    // earlier 10–90% rows are deduped out, leaving a single live row.
+    expect(screen.queryByText("receiving: 0%")).toBeNull();
+    expect(screen.queryByText("receiving: 50%")).toBeNull();
+    expect(screen.getByText("receiving: 100%")).toBeTruthy();
   });
 
   it("does not treat full URLs as owner/repo shorthand", async () => {

--- a/src/components/Project/__tests__/CloneRepoDialog.test.tsx
+++ b/src/components/Project/__tests__/CloneRepoDialog.test.tsx
@@ -459,6 +459,139 @@ describe("CloneRepoDialog", () => {
     expect(cloneRepoMock).not.toHaveBeenCalled();
   });
 
+  it("dedup keeps distinct stages while collapsing repeats within a stage", async () => {
+    cloneRepoMock.mockImplementation(() => new Promise(() => {}));
+
+    render(<CloneRepoDialog isOpen={true} onSuccess={vi.fn()} onCancel={vi.fn()} />);
+
+    const urlInput = screen.getByPlaceholderText("owner/repo or https://github.com/user/repo.git");
+    fireEvent.change(urlInput, { target: { value: "https://github.com/user/repo.git" } });
+
+    const browseBtn = screen.getByText("Browse");
+    await act(async () => {
+      fireEvent.click(browseBtn);
+    });
+
+    const cloneBtn = screen.getByText("Clone");
+    await act(async () => {
+      fireEvent.click(cloneBtn);
+    });
+
+    await waitFor(() => expect(progressHandler).not.toBeNull());
+
+    act(() => {
+      progressHandler?.({
+        stage: "counting",
+        progress: 100,
+        message: "counting: 100%",
+        timestamp: Date.now(),
+      });
+      progressHandler?.({
+        stage: "receiving",
+        progress: 10,
+        message: "receiving: 10%",
+        timestamp: Date.now(),
+      });
+      progressHandler?.({
+        stage: "checkout",
+        progress: 0,
+        message: "checkout: 0%",
+        timestamp: Date.now(),
+      });
+      progressHandler?.({
+        stage: "receiving",
+        progress: 80,
+        message: "receiving: 80%",
+        timestamp: Date.now(),
+      });
+    });
+
+    // counting and checkout (one each) survive; receiving collapses to its
+    // latest value. A broken implementation that simply replaced the entire
+    // list with each new event would lose counting/checkout.
+    expect(screen.getByText("counting: 100%")).toBeTruthy();
+    expect(screen.getByText("checkout: 0%")).toBeTruthy();
+    expect(screen.queryByText("receiving: 10%")).toBeNull();
+    expect(screen.getByText("receiving: 80%")).toBeTruthy();
+  });
+
+  it("Enter retries after a failed clone (matches Retry button behavior)", async () => {
+    // First call rejects, second resolves — simulates the user pressing Enter
+    // again after seeing an error.
+    cloneRepoMock
+      .mockRejectedValueOnce(
+        Object.assign(new Error("Auth failed"), { name: "AppError", code: "INTERNAL" })
+      )
+      .mockImplementationOnce(() => new Promise(() => {}));
+
+    render(<CloneRepoDialog isOpen={true} onSuccess={vi.fn()} onCancel={vi.fn()} />);
+
+    const urlInput = screen.getByPlaceholderText("owner/repo or https://github.com/user/repo.git");
+    fireEvent.change(urlInput, { target: { value: "https://github.com/user/repo.git" } });
+
+    const browseBtn = screen.getByText("Browse");
+    await act(async () => {
+      fireEvent.click(browseBtn);
+    });
+
+    const cloneBtn = screen.getByText("Clone");
+    await act(async () => {
+      fireEvent.click(cloneBtn);
+    });
+
+    await waitFor(() => expect(screen.getByText("Clone Failed")).toBeTruthy());
+
+    // Press Enter — should fire a second clone attempt without requiring the
+    // user to click Retry, since the form fields are still valid.
+    await act(async () => {
+      fireEvent.keyDown(urlInput, { key: "Enter" });
+    });
+
+    expect(cloneRepoMock).toHaveBeenCalledTimes(2);
+  });
+
+  it("renders cancelled stage with non-spinning icon", async () => {
+    cloneRepoMock.mockImplementation(() => new Promise(() => {}));
+
+    render(<CloneRepoDialog isOpen={true} onSuccess={vi.fn()} onCancel={vi.fn()} />);
+
+    const urlInput = screen.getByPlaceholderText("owner/repo or https://github.com/user/repo.git");
+    fireEvent.change(urlInput, { target: { value: "https://github.com/user/repo.git" } });
+
+    const browseBtn = screen.getByText("Browse");
+    await act(async () => {
+      fireEvent.click(browseBtn);
+    });
+
+    const cloneBtn = screen.getByText("Clone");
+    await act(async () => {
+      fireEvent.click(cloneBtn);
+    });
+
+    await waitFor(() => expect(progressHandler).not.toBeNull());
+
+    act(() => {
+      progressHandler?.({
+        stage: "receiving",
+        progress: 50,
+        message: "receiving: 50%",
+        timestamp: Date.now(),
+      });
+      progressHandler?.({
+        stage: "cancelled",
+        progress: 0,
+        message: "Clone cancelled",
+        timestamp: Date.now(),
+      });
+    });
+
+    // The cancelled message is visible alongside its specific (non-spinner)
+    // icon — confirms it doesn't fall through to the in-progress Spinner.
+    const cancelledRow = screen.getByText("Clone cancelled").closest("div");
+    expect(cancelledRow).toBeTruthy();
+    expect(cancelledRow!.querySelector('[data-testid="spinner"]')).toBeNull();
+  });
+
   it("dedups progress events by stage so a single stage shows one row", async () => {
     cloneRepoMock.mockImplementation(() => new Promise(() => {}));
 

--- a/src/components/Project/__tests__/GitInitDialog.test.tsx
+++ b/src/components/Project/__tests__/GitInitDialog.test.tsx
@@ -134,6 +134,8 @@ describe("GitInitDialog", () => {
       });
     });
 
-    await waitFor(() => expect(onSuccess).toHaveBeenCalledTimes(1));
+    // Auto-close runs after AUTO_CLOSE_DELAY_MS (2s) — extend the waitFor
+    // timeout so the assertion outlives the dialog's read-the-log delay.
+    await waitFor(() => expect(onSuccess).toHaveBeenCalledTimes(1), { timeout: 3000 });
   });
 });


### PR DESCRIPTION
## Summary

Eight polish fixes to the Clone Repository dialog, plus the matching auto-close bump for `GitInitDialog` and a quieter cleanup error path in `gitClone.ts`.

Closes #7211

## Changes

### Unicode-safe folder name derivation

`extractFolderName` now uses a Unicode property escape regex and a cross-platform path split:

```ts
return lastSegment.replace(/[^\p{L}\p{N}\p{M}_.-]/gu, "");
```

Cloning `https://github.com/foo/café.git` now suggests `café` instead of `caf`. The split also handles backslashes (lesson from #4979).

### Folder name auto-derive resumes when cleared

If the user manually edits the folder name and then clears it, `folderNameEdited` resets to `false` so the URL-based suggestion takes over again. No need to reopen the dialog.

### `Cancel` becomes `Stop clone` while cloning

The button's behaviour switches from closing the dialog to aborting in-flight work and removing the partial directory, so the label switches with it. Verb-noun, per the destructive-button rule in `CLAUDE.md`.

### Shallow-clone helper text

A muted one-liner under the toggle: *Only fetches the latest commit — faster for large repos, but limits history and some push paths.*

### Progress events dedup by stage

`simple-git` fires the progress callback on every stderr chunk, so a multi-GB clone accumulates hundreds of byte-count rows. The reducer now keeps a `Map` keyed on `event.stage`, so each stage shows one live-updating row instead of growing unbounded:

```ts
setProgressEvents((prev) => {
  const merged = new Map(prev.map((e) => [e.stage, e]));
  merged.set(event.stage, event);
  return [...merged.values()];
});
```

The `cancelled` stage also gets its own neutral `X` icon, instead of falling through to the in-progress spinner alongside *Clone cancelled* text.

### Enter submits (and retries)

`onKeyDown` on the URL and folder-name inputs triggers `startClone` when the form is valid. The guard intentionally does not include `!error`, so pressing Enter after a failure acts as Retry. `startClone` clears the error state internally.

### Auto-close delay 800ms → 2000ms

Long enough to read the final progress line before the dialog dismisses. Same bump applied to `GitInitDialog`, since it shares the symptom.

### Surface partial-clone cleanup failures

`fs.promises.rm(...).catch(() => {})` was swallowing real failures (Windows antivirus locks, denied permissions). Replaced with `console.warn` so the cleanup trace lands in logs, while the original clone error is still what the user sees.

## Test plan

- [x] `npx vitest run src/components/Project/__tests__/CloneRepoDialog.test.tsx src/components/Project/__tests__/GitInitDialog.test.tsx` (25 tests)
- [x] `npm run check` (typecheck + lint + format)
- [ ] Manual: clone `https://github.com/foo/café.git` and verify the folder field reads `café`
- [ ] Manual: edit folder name, clear it, then change the URL and verify the suggestion re-derives
- [ ] Manual: start a large clone, watch the progress log update one row per stage instead of growing unbounded
- [ ] Manual: press `Stop clone` mid-clone, verify the abort path renders the cancelled row with the X icon
- [ ] Manual: press Enter from the URL field with valid input, verify the clone starts
- [ ] Manual: complete a clone, verify the dialog stays open ~2s before closing