### PR TITLE
test(e2e): roll out test.step phase labels across core specs and preset helpers

### DIFF
--- a/e2e/core/core-first-run-onboarding.spec.ts
+++ b/e2e/core/core-first-run-onboarding.spec.ts
@@ -27,62 +27,81 @@ test.describe.serial("First-run onboarding flow", () => {
   });
 
   test("welcome screen is non-blocking on first launch and agent setup is opt-in", async () => {
-    ctx = await launchApp({
-      userDataDir,
-      env: FIRST_RUN_ENV,
-      waitForSelector: SEL.firstRun.welcomeTitle,
+    await test.step("Launch with first-run env and verify welcome screen + interactive toolbar", async () => {
+      ctx = await launchApp({
+        userDataDir,
+        env: FIRST_RUN_ENV,
+        waitForSelector: SEL.firstRun.welcomeTitle,
+      });
+      const { window } = ctx;
+
+      // The welcome screen should render and the toolbar should be interactive
+      // simultaneously — no blocking modal prevents access to the app.
+      await expect(window.locator(SEL.firstRun.welcomeTitle)).toBeVisible({ timeout: T_MEDIUM });
+      await expect(window.locator(SEL.toolbar.openSettings)).toBeVisible({ timeout: T_MEDIUM });
+      await expect(window.locator(SEL.toolbar.openSettings)).toBeEnabled();
     });
-    const { window } = ctx;
 
-    // The welcome screen should render and the toolbar should be interactive
-    // simultaneously — no blocking modal prevents access to the app.
-    await expect(window.locator(SEL.firstRun.welcomeTitle)).toBeVisible({ timeout: T_MEDIUM });
-    await expect(window.locator(SEL.toolbar.openSettings)).toBeVisible({ timeout: T_MEDIUM });
-    await expect(window.locator(SEL.toolbar.openSettings)).toBeEnabled();
+    await test.step("Verify wizard does not auto-open and banner is visible", async () => {
+      const { window } = ctx!;
 
-    // The wizard must NOT auto-open — it is opt-in via the banner CTA.
-    await expect(window.locator(SEL.firstRun.agentSetupTitle)).not.toBeVisible();
+      // The wizard must NOT auto-open — it is opt-in via the banner CTA.
+      await expect(window.locator(SEL.firstRun.agentSetupTitle)).not.toBeVisible();
 
-    // The setup banner is visible and invites the user in.
-    await expect(window.locator(SEL.firstRun.agentSetupBanner)).toBeVisible({ timeout: T_MEDIUM });
-
-    // Clicking the banner CTA opens the wizard on demand.
-    await window.locator(SEL.firstRun.agentSetupBannerCta).click();
-    await expect(window.locator(SEL.firstRun.agentSetupTitle)).toBeVisible({ timeout: T_MEDIUM });
-
-    // Skip closes the wizard and the toolbar remains interactive.
-    await window.locator('button:has-text("Skip")').click();
-    await expect(window.locator(SEL.firstRun.agentSetupTitle)).not.toBeVisible({
-      timeout: T_SETTLE,
+      // The setup banner is visible and invites the user in.
+      await expect(window.locator(SEL.firstRun.agentSetupBanner)).toBeVisible({
+        timeout: T_MEDIUM,
+      });
     });
-    await expect(window.locator(SEL.toolbar.openSettings)).toBeVisible();
 
-    // Clean close for persistence across the second-launch test below.
-    const pid = ctx.app.process().pid!;
-    await closeApp(ctx.app);
-    await waitForProcessExit(pid);
-    ctx = null;
+    await test.step("Open wizard via banner CTA, then skip and verify dismissal", async () => {
+      const { window } = ctx!;
+
+      // Clicking the banner CTA opens the wizard on demand.
+      await window.locator(SEL.firstRun.agentSetupBannerCta).click();
+      await expect(window.locator(SEL.firstRun.agentSetupTitle)).toBeVisible({ timeout: T_MEDIUM });
+
+      // Skip closes the wizard and the toolbar remains interactive.
+      await window.locator('button:has-text("Skip")').click();
+      await expect(window.locator(SEL.firstRun.agentSetupTitle)).not.toBeVisible({
+        timeout: T_SETTLE,
+      });
+      await expect(window.locator(SEL.toolbar.openSettings)).toBeVisible();
+    });
+
+    await test.step("Close app cleanly to persist onboarding state for the next test", async () => {
+      const pid = ctx!.app.process().pid!;
+      await closeApp(ctx!.app);
+      await waitForProcessExit(pid);
+      ctx = null;
+    });
   });
 
   test("second launch does not reshow the banner or auto-open the wizard", async () => {
-    ctx = await launchApp({
-      userDataDir,
-      env: FIRST_RUN_ENV,
+    await test.step("Relaunch with same userDataDir and confirm toolbar is ready", async () => {
+      ctx = await launchApp({
+        userDataDir,
+        env: FIRST_RUN_ENV,
+      });
+      const { window } = ctx;
+
+      // Toolbar should be visible (first-run completed previously).
+      await expect(window.locator(SEL.toolbar.openSettings)).toBeVisible({ timeout: T_MEDIUM });
+
+      // Allow onboarding hydration to complete.
+      await window.waitForTimeout(T_SETTLE);
     });
-    const { window } = ctx;
 
-    // Toolbar should be visible (first-run completed previously).
-    await expect(window.locator(SEL.toolbar.openSettings)).toBeVisible({ timeout: T_MEDIUM });
+    await test.step("Verify first-run banner and wizard remain hidden", async () => {
+      const { window } = ctx!;
 
-    // Allow onboarding hydration to complete.
-    await window.waitForTimeout(T_SETTLE);
+      // The first-run banner must NOT reappear: the user completed the wizard
+      // on first launch, which persists the onboarding-complete flag.
+      await expect(window.locator(SEL.firstRun.agentSetupBanner)).not.toBeVisible();
 
-    // The first-run banner must NOT reappear: the user completed the wizard
-    // on first launch, which persists the onboarding-complete flag.
-    await expect(window.locator(SEL.firstRun.agentSetupBanner)).not.toBeVisible();
-
-    // The wizard must not auto-open either — the old returning-user
-    // auto-open effect is gone.
-    await expect(window.locator(SEL.firstRun.agentSetupTitle)).not.toBeVisible();
+      // The wizard must not auto-open either — the old returning-user
+      // auto-open effect is gone.
+      await expect(window.locator(SEL.firstRun.agentSetupTitle)).not.toBeVisible();
+    });
   });
 });

--- a/e2e/core/core-persistence.spec.ts
+++ b/e2e/core/core-persistence.spec.ts
@@ -28,46 +28,50 @@ test.describe.serial("Persistence: Settings across restart", () => {
   });
 
   test("performance mode toggle survives app restart", async () => {
-    // Session 1: Launch, toggle performance mode on, close
-    ctx = await launchApp({ userDataDir });
-    const { window: w1 } = ctx;
+    await test.step("Session 1: launch and toggle performance mode on", async () => {
+      ctx = await launchApp({ userDataDir });
+      const { window: w1 } = ctx;
 
-    await openSettings(w1);
-    await expect(w1.locator(SEL.settings.heading)).toBeVisible({ timeout: T_MEDIUM });
+      await openSettings(w1);
+      await expect(w1.locator(SEL.settings.heading)).toBeVisible({ timeout: T_MEDIUM });
 
-    const panelGridTab = w1.locator(`${SEL.settings.navSidebar} button:has-text("Panel Grid")`);
-    await panelGridTab.click();
+      const panelGridTab = w1.locator(`${SEL.settings.navSidebar} button:has-text("Panel Grid")`);
+      await panelGridTab.click();
 
-    const toggle = w1.locator(SEL.settings.performanceModeToggle);
-    await toggle.scrollIntoViewIfNeeded();
-    await expect(toggle).toHaveAttribute("aria-checked", "false", { timeout: T_MEDIUM });
+      const toggle = w1.locator(SEL.settings.performanceModeToggle);
+      await toggle.scrollIntoViewIfNeeded();
+      await expect(toggle).toHaveAttribute("aria-checked", "false", { timeout: T_MEDIUM });
 
-    await toggle.click();
-    await expect(toggle).toHaveAttribute("aria-checked", "true", { timeout: T_MEDIUM });
+      await toggle.click();
+      await expect(toggle).toHaveAttribute("aria-checked", "true", { timeout: T_MEDIUM });
 
-    await w1.keyboard.press("Escape");
-    await w1.waitForTimeout(T_SETTLE);
+      await w1.keyboard.press("Escape");
+      await w1.waitForTimeout(T_SETTLE);
+    });
 
-    const pid = ctx.app.process().pid!;
-    await closeApp(ctx.app);
-    await waitForProcessExit(pid);
-    ctx = null;
+    await test.step("Close app and wait for the process to exit", async () => {
+      const pid = ctx!.app.process().pid!;
+      await closeApp(ctx!.app);
+      await waitForProcessExit(pid);
+      ctx = null;
+    });
 
-    // Session 2: Relaunch with same userDataDir, verify toggle persisted
-    ctx = await launchApp({ userDataDir });
-    const { window: w2 } = ctx;
+    await test.step("Session 2: relaunch and verify toggle persisted", async () => {
+      ctx = await launchApp({ userDataDir });
+      const { window: w2 } = ctx;
 
-    await openSettings(w2);
-    await expect(w2.locator(SEL.settings.heading)).toBeVisible({ timeout: T_MEDIUM });
+      await openSettings(w2);
+      await expect(w2.locator(SEL.settings.heading)).toBeVisible({ timeout: T_MEDIUM });
 
-    const panelGridTab2 = w2.locator(`${SEL.settings.navSidebar} button:has-text("Panel Grid")`);
-    await panelGridTab2.click();
+      const panelGridTab2 = w2.locator(`${SEL.settings.navSidebar} button:has-text("Panel Grid")`);
+      await panelGridTab2.click();
 
-    const toggle2 = w2.locator(SEL.settings.performanceModeToggle);
-    await toggle2.scrollIntoViewIfNeeded();
-    await expect(toggle2).toHaveAttribute("aria-checked", "true", { timeout: T_MEDIUM });
+      const toggle2 = w2.locator(SEL.settings.performanceModeToggle);
+      await toggle2.scrollIntoViewIfNeeded();
+      await expect(toggle2).toHaveAttribute("aria-checked", "true", { timeout: T_MEDIUM });
 
-    await w2.keyboard.press("Escape");
+      await w2.keyboard.press("Escape");
+    });
   });
 });
 
@@ -93,25 +97,29 @@ test.describe.serial("Persistence: Project memory across restart", () => {
   });
 
   test("previously onboarded project appears after restart", async () => {
-    // Session 1: Launch, onboard project, close
-    ctx = await launchApp({ userDataDir });
-    ctx.window = await openAndOnboardProject(ctx.app, ctx.window, fixtureDir, "Persistence Test");
+    await test.step("Session 1: launch and onboard fixture project", async () => {
+      ctx = await launchApp({ userDataDir });
+      ctx.window = await openAndOnboardProject(ctx.app, ctx.window, fixtureDir, "Persistence Test");
 
-    const trigger = ctx.window.locator(SEL.toolbar.projectSwitcherTrigger);
-    await expect(trigger).toBeVisible({ timeout: T_MEDIUM });
-    await expect(trigger).toContainText("persistence-test", { timeout: T_SHORT });
+      const trigger = ctx.window.locator(SEL.toolbar.projectSwitcherTrigger);
+      await expect(trigger).toBeVisible({ timeout: T_MEDIUM });
+      await expect(trigger).toContainText("persistence-test", { timeout: T_SHORT });
+    });
 
-    const pid = ctx.app.process().pid!;
-    await closeApp(ctx.app);
-    await waitForProcessExit(pid);
-    ctx = null;
+    await test.step("Close app and wait for the process to exit", async () => {
+      const pid = ctx!.app.process().pid!;
+      await closeApp(ctx!.app);
+      await waitForProcessExit(pid);
+      ctx = null;
+    });
 
-    // Session 2: Relaunch with same userDataDir, verify project is remembered
-    ctx = await launchApp({ userDataDir });
-    const { window: w2 } = ctx;
+    await test.step("Session 2: relaunch and verify project is remembered", async () => {
+      ctx = await launchApp({ userDataDir });
+      const { window: w2 } = ctx;
 
-    const trigger2 = w2.locator(SEL.toolbar.projectSwitcherTrigger);
-    await expect(trigger2).toBeVisible({ timeout: T_MEDIUM });
-    await expect(trigger2).toContainText("persistence-test", { timeout: T_MEDIUM });
+      const trigger2 = w2.locator(SEL.toolbar.projectSwitcherTrigger);
+      await expect(trigger2).toBeVisible({ timeout: T_MEDIUM });
+      await expect(trigger2).toContainText("persistence-test", { timeout: T_MEDIUM });
+    });
   });
 });

--- a/e2e/core/core-process-badge.spec.ts
+++ b/e2e/core/core-process-badge.spec.ts
@@ -27,55 +27,64 @@ test.describe.serial("Core: Process Icon Badge", () => {
 
   test("node process running a timed script surfaces the node badge, then clears on exit", async () => {
     const { window } = ctx;
-    await openTerminal(window);
-    const panel = getFirstGridPanel(window);
-    await expect(panel).toBeVisible({ timeout: T_LONG });
+    let panelId: string | null = null;
 
-    const panelId = await panel.getAttribute("data-panel-id");
-    expect(panelId).toBeTruthy();
+    const panel = await test.step("Open a terminal and capture its panel id", async () => {
+      await openTerminal(window);
+      const p = getFirstGridPanel(window);
+      await expect(p).toBeVisible({ timeout: T_LONG });
+      panelId = await p.getAttribute("data-panel-id");
+      expect(panelId).toBeTruthy();
+      return p;
+    });
 
-    // Run a bounded `node` process — `node` is in PROCESS_ICON_MAP, so
-    // either the process-tree detector or the shell-command fallback should
-    // commit the "node" icon within the hysteresis window (~3s baseline).
-    // SENTINEL_READY lets us confirm the script is actually executing.
-    await runTerminalCommand(
-      window,
-      panel,
-      `node -e "console.log('SENTINEL_READY'); setTimeout(()=>{}, 8000)"`
-    );
-    await waitForTerminalText(panel, "SENTINEL_READY", T_LONG);
+    await test.step("Run a bounded node script and wait for SENTINEL_READY", async () => {
+      // Run a bounded `node` process — `node` is in PROCESS_ICON_MAP, so
+      // either the process-tree detector or the shell-command fallback should
+      // commit the "node" icon within the hysteresis window (~3s baseline).
+      // SENTINEL_READY lets us confirm the script is actually executing.
+      await runTerminalCommand(
+        window,
+        panel,
+        `node -e "console.log('SENTINEL_READY'); setTimeout(()=>{}, 8000)"`
+      );
+      await waitForTerminalText(panel, "SENTINEL_READY", T_LONG);
+    });
 
-    // Badge appears. T_LONG accommodates CI slowness plus the 1500ms-poll
-    // × 2-poll hysteresis baseline.
-    await expect
-      .poll(
-        async () => {
-          return await window.evaluate(
-            (id) =>
-              document
-                .querySelector(`[data-panel-id="${id}"]`)
-                ?.getAttribute("data-detected-process-id"),
-            panelId
-          );
-        },
-        { timeout: T_LONG, intervals: [500] }
-      )
-      .toBe("node");
+    await test.step("Verify node badge appears on the panel", async () => {
+      // Badge appears. T_LONG accommodates CI slowness plus the 1500ms-poll
+      // × 2-poll hysteresis baseline.
+      await expect
+        .poll(
+          async () => {
+            return await window.evaluate(
+              (id) =>
+                document
+                  .querySelector(`[data-panel-id="${id}"]`)
+                  ?.getAttribute("data-detected-process-id"),
+              panelId
+            );
+          },
+          { timeout: T_LONG, intervals: [500] }
+        )
+        .toBe("node");
+    });
 
-    // Badge clears after the process exits.
-    await expect
-      .poll(
-        async () => {
-          return await window.evaluate(
-            (id) =>
-              document
-                .querySelector(`[data-panel-id="${id}"]`)
-                ?.getAttribute("data-detected-process-id"),
-            panelId
-          );
-        },
-        { timeout: T_LONG, intervals: [500] }
-      )
-      .toBeNull();
+    await test.step("Verify badge clears after the process exits", async () => {
+      await expect
+        .poll(
+          async () => {
+            return await window.evaluate(
+              (id) =>
+                document
+                  .querySelector(`[data-panel-id="${id}"]`)
+                  ?.getAttribute("data-detected-process-id"),
+              panelId
+            );
+          },
+          { timeout: T_LONG, intervals: [500] }
+        )
+        .toBeNull();
+    });
   });
 });

--- a/e2e/core/core-worktree-lifecycle.spec.ts
+++ b/e2e/core/core-worktree-lifecycle.spec.ts
@@ -43,87 +43,103 @@ test.describe.serial("Core: Worktree Lifecycle", () => {
   test("create new worktree via UI", async () => {
     const { window } = ctx;
 
-    const newBtn = window.locator('button[aria-label="Create new worktree"]');
-    await newBtn.click();
+    await test.step("Open create-worktree dialog and fill branch name", async () => {
+      const newBtn = window.locator('button[aria-label="Create new worktree"]');
+      await newBtn.click();
 
-    const branchInput = window.locator(SEL.worktree.branchNameInput);
-    await expect(branchInput).toBeVisible({ timeout: T_MEDIUM });
-    await branchInput.fill(BRANCH);
+      const branchInput = window.locator(SEL.worktree.branchNameInput);
+      await expect(branchInput).toBeVisible({ timeout: T_MEDIUM });
+      await branchInput.fill(BRANCH);
+    });
 
-    const pathInput = window.locator('[data-testid="worktree-path-input"]');
-    await expect
-      .poll(
-        async () => {
-          const val = await pathInput.inputValue();
-          return val.trim().length;
-        },
-        { timeout: T_LONG, message: "Worktree path should auto-populate" }
-      )
-      .toBeGreaterThan(0);
+    await test.step("Wait for path field to auto-populate and capture the directory name", async () => {
+      const pathInput = window.locator('[data-testid="worktree-path-input"]');
+      await expect
+        .poll(
+          async () => {
+            const val = await pathInput.inputValue();
+            return val.trim().length;
+          },
+          { timeout: T_LONG, message: "Worktree path should auto-populate" }
+        )
+        .toBeGreaterThan(0);
 
-    // Capture the worktree directory name for later pwd verification
-    const worktreePath = await pathInput.inputValue();
-    worktreeDirName = path.basename(worktreePath.trim());
+      // Capture the worktree directory name for later pwd verification
+      const worktreePath = await pathInput.inputValue();
+      worktreeDirName = path.basename(worktreePath.trim());
+    });
 
-    const createBtn = window.locator(SEL.worktree.createButton);
-    await createBtn.click();
+    await test.step("Submit create form and verify the new worktree card appears", async () => {
+      const createBtn = window.locator(SEL.worktree.createButton);
+      await createBtn.click();
 
-    const newCard = window.locator(SEL.worktree.card(BRANCH));
-    await expect(newCard).toBeVisible({ timeout: 30_000 });
+      const newCard = window.locator(SEL.worktree.card(BRANCH));
+      await expect(newCard).toBeVisible({ timeout: 30_000 });
+    });
   });
 
   test("switch to new worktree and verify terminal pwd", async () => {
     const { window } = ctx;
 
-    const newCard = window.locator(SEL.worktree.card(BRANCH));
-    await newCard.click({ position: { x: 10, y: 10 } });
+    await test.step("Click new worktree card and verify selection swaps from main", async () => {
+      const newCard = window.locator(SEL.worktree.card(BRANCH));
+      await newCard.click({ position: { x: 10, y: 10 } });
 
-    await expect
-      .poll(() => newCard.getAttribute("aria-label"), {
-        timeout: T_LONG,
-        message: "New worktree card should become selected",
-      })
-      .toContain("selected");
+      await expect
+        .poll(() => newCard.getAttribute("aria-label"), {
+          timeout: T_LONG,
+          message: "New worktree card should become selected",
+        })
+        .toContain("selected");
 
-    const mainCard = window.locator(SEL.worktree.card(mainBranch));
-    await expect
-      .poll(() => mainCard.getAttribute("aria-label"), {
-        timeout: T_MEDIUM,
-        message: "Main card should lose selection",
-      })
-      .not.toContain("selected");
+      const mainCard = window.locator(SEL.worktree.card(mainBranch));
+      await expect
+        .poll(() => mainCard.getAttribute("aria-label"), {
+          timeout: T_MEDIUM,
+          message: "Main card should lose selection",
+        })
+        .not.toContain("selected");
+    });
 
-    const panel = await spawnTerminalAndVerify(window);
-    await runTerminalCommand(window, panel, "pwd");
-    await waitForTerminalText(panel, worktreeDirName);
+    await test.step("Spawn terminal and verify pwd reports the new worktree directory", async () => {
+      const panel = await spawnTerminalAndVerify(window);
+      await runTerminalCommand(window, panel, "pwd");
+      await waitForTerminalText(panel, worktreeDirName);
+    });
   });
 
   test("delete active worktree auto-switches to main", async () => {
     const { window } = ctx;
-
     const newCard = window.locator(SEL.worktree.card(BRANCH));
-    const actionsBtn = newCard.locator(SEL.worktree.actionsMenu);
-    await ensureWindowFocused(ctx.app);
-    await actionsBtn.click();
 
-    const deleteItem = window.getByRole("menuitem", { name: /delete/i });
-    await expect(deleteItem).toBeVisible({ timeout: T_SHORT });
-    await deleteItem.hover();
-    await deleteItem.click();
+    await test.step("Open actions menu on the new worktree card and choose Delete", async () => {
+      const actionsBtn = newCard.locator(SEL.worktree.actionsMenu);
+      await ensureWindowFocused(ctx.app);
+      await actionsBtn.click();
 
-    const confirmBtn = window.locator(SEL.worktree.deleteConfirm);
-    await expect(confirmBtn).toBeVisible({ timeout: T_MEDIUM });
-    await confirmBtn.click();
+      const deleteItem = window.getByRole("menuitem", { name: /delete/i });
+      await expect(deleteItem).toBeVisible({ timeout: T_SHORT });
+      await deleteItem.hover();
+      await deleteItem.click();
+    });
 
-    await expect(newCard).not.toBeVisible({ timeout: T_LONG });
+    await test.step("Confirm deletion and verify card disappears", async () => {
+      const confirmBtn = window.locator(SEL.worktree.deleteConfirm);
+      await expect(confirmBtn).toBeVisible({ timeout: T_MEDIUM });
+      await confirmBtn.click();
 
-    const mainCard = window.locator(SEL.worktree.card(mainBranch));
-    await expect
-      .poll(() => mainCard.getAttribute("aria-label"), {
-        timeout: T_LONG,
-        message: "Main card should become selected after deleting active worktree",
-      })
-      .toContain("selected");
+      await expect(newCard).not.toBeVisible({ timeout: T_LONG });
+    });
+
+    await test.step("Verify main card auto-selects after active worktree deletion", async () => {
+      const mainCard = window.locator(SEL.worktree.card(mainBranch));
+      await expect
+        .poll(() => mainCard.getAttribute("aria-label"), {
+          timeout: T_LONG,
+          message: "Main card should become selected after deleting active worktree",
+        })
+        .toContain("selected");
+    });
   });
 
   test("worktree card removed from sidebar after deletion", async () => {

--- a/e2e/full/core-action-palette-commands.spec.ts
+++ b/e2e/full/core-action-palette-commands.spec.ts
@@ -46,56 +46,67 @@ test.describe.serial("Core: Action Palette, Command Picker & Quick Switcher", ()
     test("search input is focused and filters results", async () => {
       const { window } = ctx;
 
-      await expectPaletteFocused(window, "action", T_SHORT);
+      await test.step("Verify search input is focused on open", async () => {
+        await expectPaletteFocused(window, "action", T_SHORT);
+      });
 
       const searchInput = window.locator(SEL.actionPalette.searchInput);
       const options = window.locator(SEL.actionPalette.options);
+      let unfilteredCount = 0;
 
-      // Empty query shows only recently-used actions; on a fresh project
-      // that list is empty. Type a broad query to populate the list, then
-      // narrow it.
-      await searchInput.fill("panel");
-      await window.waitForTimeout(T_SETTLE);
-      await expect(options.first()).toBeVisible({ timeout: T_MEDIUM });
-      const unfilteredCount = await options.count();
+      await test.step("Type broad query and capture unfiltered count", async () => {
+        // Empty query shows only recently-used actions; on a fresh project
+        // that list is empty. Type a broad query to populate the list, then
+        // narrow it.
+        await searchInput.fill("panel");
+        await window.waitForTimeout(T_SETTLE);
+        await expect(options.first()).toBeVisible({ timeout: T_MEDIUM });
+        unfilteredCount = await options.count();
+      });
 
-      await searchInput.fill("toggle sidebar");
-      await window.waitForTimeout(T_SETTLE);
+      await test.step("Narrow query and verify result count drops", async () => {
+        await searchInput.fill("toggle sidebar");
+        await window.waitForTimeout(T_SETTLE);
 
-      const filteredCount = await options.count();
-      expect(filteredCount).toBeGreaterThanOrEqual(1);
-      expect(filteredCount).toBeLessThan(unfilteredCount);
+        const filteredCount = await options.count();
+        expect(filteredCount).toBeGreaterThanOrEqual(1);
+        expect(filteredCount).toBeLessThan(unfilteredCount);
+      });
     });
 
     test("arrow key navigation changes selection", async () => {
       const { window } = ctx;
-
       const searchInput = window.locator(SEL.actionPalette.searchInput);
-
-      // A broad query produces multiple results to navigate through
-      // (an empty query would only show recently-used, which is empty
-      // on a fresh project).
-      await searchInput.fill("panel");
-      await window.waitForTimeout(T_SETTLE);
-
       const options = window.locator(SEL.actionPalette.options);
-      await expect(options.first()).toBeVisible({ timeout: T_MEDIUM });
-      const count = await options.count();
-      expect(count).toBeGreaterThanOrEqual(2);
+      let initialDescendant: string | null = null;
 
-      const initialDescendant = await searchInput.getAttribute("aria-activedescendant");
+      await test.step("Type broad query to populate at least two results", async () => {
+        // A broad query produces multiple results to navigate through
+        // (an empty query would only show recently-used, which is empty
+        // on a fresh project).
+        await searchInput.fill("panel");
+        await window.waitForTimeout(T_SETTLE);
 
-      await searchInput.press("ArrowDown");
+        await expect(options.first()).toBeVisible({ timeout: T_MEDIUM });
+        const count = await options.count();
+        expect(count).toBeGreaterThanOrEqual(2);
 
-      // Poll until the selection changes — the React state update from
-      // selectNext may take a render cycle to flush to the DOM.
-      await expect
-        .poll(() => searchInput.getAttribute("aria-activedescendant"), { timeout: T_MEDIUM })
-        .not.toBe(initialDescendant);
+        initialDescendant = await searchInput.getAttribute("aria-activedescendant");
+      });
 
-      const newDescendant = await searchInput.getAttribute("aria-activedescendant");
-      expect(newDescendant).toBeTruthy();
-      expect(newDescendant).toMatch(/^action-option-/);
+      await test.step("Press ArrowDown and verify active descendant updates", async () => {
+        await searchInput.press("ArrowDown");
+
+        // Poll until the selection changes — the React state update from
+        // selectNext may take a render cycle to flush to the DOM.
+        await expect
+          .poll(() => searchInput.getAttribute("aria-activedescendant"), { timeout: T_MEDIUM })
+          .not.toBe(initialDescendant);
+
+        const newDescendant = await searchInput.getAttribute("aria-activedescendant");
+        expect(newDescendant).toBeTruthy();
+        expect(newDescendant).toMatch(/^action-option-/);
+      });
     });
 
     test("closes via Escape", async () => {
@@ -160,20 +171,23 @@ test.describe.serial("Core: Action Palette, Command Picker & Quick Switcher", ()
       const searchInput = window.locator(SEL.quickSwitcher.searchInput);
       const options = window.locator(SEL.quickSwitcher.options);
 
-      // Type a nonsense query — results should disappear
-      await searchInput.fill("nonexistent-query-xyz");
-      await window.waitForTimeout(T_SETTLE);
+      await test.step("Type nonsense query and verify zero results", async () => {
+        await searchInput.fill("nonexistent-query-xyz");
+        await window.waitForTimeout(T_SETTLE);
 
-      const filteredCount = await options.count();
-      expect(filteredCount).toBe(0);
+        const filteredCount = await options.count();
+        expect(filteredCount).toBe(0);
+      });
 
-      // First Escape clears the search query (two-step escape behavior)
-      await window.keyboard.press("Escape");
-      // Second Escape closes the dialog
-      await window.keyboard.press("Escape");
+      await test.step("Press Escape twice to clear query and close dialog", async () => {
+        // First Escape clears the search query (two-step escape behavior)
+        await window.keyboard.press("Escape");
+        // Second Escape closes the dialog
+        await window.keyboard.press("Escape");
 
-      const dialog = window.locator(SEL.quickSwitcher.dialog);
-      await expect(dialog).not.toBeVisible({ timeout: T_SHORT });
+        const dialog = window.locator(SEL.quickSwitcher.dialog);
+        await expect(dialog).not.toBeVisible({ timeout: T_SHORT });
+      });
     });
   });
 
@@ -203,28 +217,41 @@ test.describe.serial("Core: Action Palette, Command Picker & Quick Switcher", ()
     test("opens via button click on agent panel", async () => {
       const { window } = ctx;
 
-      // Agent panel requires CLI availability — skip if not present
       const startBtn = window.locator(SEL.agent.startButton);
-      if (!(await startBtn.isVisible().catch(() => false))) {
+      const skipped =
+        await test.step("Start an agent panel (skip if CLI is unavailable)", async () => {
+          // Agent panel requires CLI availability — skip if not present
+          if (!(await startBtn.isVisible().catch(() => false))) {
+            return true;
+          }
+
+          await startBtn.click();
+          await window.waitForTimeout(T_SETTLE);
+          return false;
+        });
+      if (skipped) {
         test.skip();
         return;
       }
 
-      await startBtn.click();
-      await window.waitForTimeout(T_SETTLE);
-
-      // HybridInputBar's command picker button only renders on agent panels
       const openPickerBtn = window.locator(SEL.commandPicker.openButton);
-      if (!(await openPickerBtn.isVisible({ timeout: T_LONG }).catch(() => false))) {
+      const pickerMissing =
+        await test.step("Wait for command picker open button to appear", async () => {
+          // HybridInputBar's command picker button only renders on agent panels
+          return !(await openPickerBtn.isVisible({ timeout: T_LONG }).catch(() => false));
+        });
+      if (pickerMissing) {
         test.skip();
         return;
       }
 
-      await openPickerBtn.click();
+      await test.step("Open command picker dialog and verify visibility", async () => {
+        await openPickerBtn.click();
 
-      const dialog = window.locator(SEL.commandPicker.dialog);
-      await expect(dialog).toBeVisible({ timeout: T_MEDIUM });
-      commandPickerAvailable = true;
+        const dialog = window.locator(SEL.commandPicker.dialog);
+        await expect(dialog).toBeVisible({ timeout: T_MEDIUM });
+        commandPickerAvailable = true;
+      });
     });
 
     test("search filters commands and Escape closes", async () => {
@@ -234,30 +261,37 @@ test.describe.serial("Core: Action Palette, Command Picker & Quick Switcher", ()
       }
 
       const { window } = ctx;
-
-      const list = window.locator(SEL.commandPicker.list);
-      await expect(list).toBeVisible({ timeout: T_MEDIUM });
-
       const options = window.locator(SEL.commandPicker.options);
-      const unfilteredCount = await options.count();
+      let unfilteredCount = 0;
 
-      const searchInput = window.locator(SEL.commandPicker.searchInput);
-      await searchInput.fill("git");
-      await window.waitForTimeout(T_SETTLE);
+      await test.step("Verify command list renders and capture unfiltered count", async () => {
+        const list = window.locator(SEL.commandPicker.list);
+        await expect(list).toBeVisible({ timeout: T_MEDIUM });
 
-      const filteredCount = await options.count();
-      expect(filteredCount).toBeGreaterThanOrEqual(1);
-      if (unfilteredCount > 1) {
-        expect(filteredCount).toBeLessThanOrEqual(unfilteredCount);
-      }
+        unfilteredCount = await options.count();
+      });
 
-      // First Escape clears the search query (two-step escape behavior)
-      await window.keyboard.press("Escape");
-      // Second Escape closes the dialog
-      await window.keyboard.press("Escape");
+      await test.step("Filter by 'git' and verify result count narrows", async () => {
+        const searchInput = window.locator(SEL.commandPicker.searchInput);
+        await searchInput.fill("git");
+        await window.waitForTimeout(T_SETTLE);
 
-      const dialog = window.locator(SEL.commandPicker.dialog);
-      await expect(dialog).not.toBeVisible({ timeout: T_SHORT });
+        const filteredCount = await options.count();
+        expect(filteredCount).toBeGreaterThanOrEqual(1);
+        if (unfilteredCount > 1) {
+          expect(filteredCount).toBeLessThanOrEqual(unfilteredCount);
+        }
+      });
+
+      await test.step("Press Escape twice to clear query and close dialog", async () => {
+        // First Escape clears the search query (two-step escape behavior)
+        await window.keyboard.press("Escape");
+        // Second Escape closes the dialog
+        await window.keyboard.press("Escape");
+
+        const dialog = window.locator(SEL.commandPicker.dialog);
+        await expect(dialog).not.toBeVisible({ timeout: T_SHORT });
+      });
     });
   });
 });

--- a/e2e/full/core-agent-preset-icon-color.spec.ts
+++ b/e2e/full/core-agent-preset-icon-color.spec.ts
@@ -308,40 +308,52 @@ test.describe.serial("Core: Agent preset icon color", () => {
   test("preset color tints launch, survives app restart, and reapplies after quit/restart", async () => {
     test.setTimeout(180_000);
 
-    const disableHybrid = await dispatchAction(
-      ctx.window,
-      "terminalConfig.setHybridInputEnabled",
-      { enabled: false },
-      { source: "user" }
-    );
-    expect(disableHybrid.ok, disableHybrid.error?.message).toBe(true);
+    await test.step("Disable hybrid input so /quit reaches the fake agent stdin", async () => {
+      const disableHybrid = await dispatchAction(
+        ctx.window,
+        "terminalConfig.setHybridInputEnabled",
+        { enabled: false },
+        { source: "user" }
+      );
+      expect(disableHybrid.ok, disableHybrid.error?.message).toBe(true);
+    });
 
-    await expectPersistedPresetColor(ctx.window, "claude", CLAUDE_PRESET_ID, CLAUDE_COLOR);
-    const claude = await launchPreset(ctx.window, "claude", CLAUDE_PRESET_ID);
-    await expectAgentIconColor(claude.panel, "claude", CLAUDE_COLOR);
-    // Wait for the fake script to finish its startup logs before sending /quit —
-    // without this, keystrokes typed during the shell→script handover can be
-    // dropped, leaving the agent runtime alive and stalling the demote.
-    // FAKE_CLAUDE_MANUAL is the script's last startup line; once it prints the
-    // stdin handler is bound and the buffer reader still sees it after reflow.
-    await waitForTerminalText(claude.panel, "FAKE_CLAUDE_MANUAL=", T_LONG);
+    let claude!: Awaited<ReturnType<typeof launchPreset>>;
+    await test.step("Launch Claude preset and verify icon color tints with preset color", async () => {
+      await expectPersistedPresetColor(ctx.window, "claude", CLAUDE_PRESET_ID, CLAUDE_COLOR);
+      claude = await launchPreset(ctx.window, "claude", CLAUDE_PRESET_ID);
+      await expectAgentIconColor(claude.panel, "claude", CLAUDE_COLOR);
+      // Wait for the fake script to finish its startup logs before sending /quit —
+      // without this, keystrokes typed during the shell→script handover can be
+      // dropped, leaving the agent runtime alive and stalling the demote.
+      // FAKE_CLAUDE_MANUAL is the script's last startup line; once it prints the
+      // stdin handler is bound and the buffer reader still sees it after reflow.
+      await waitForTerminalText(claude.panel, "FAKE_CLAUDE_MANUAL=", T_LONG);
+    });
 
-    await quitAgentOrWaitForDemotion(ctx.window, claude.panel);
-    await restartTerminal(ctx.window, claude.id, claude.panel);
-    await runTerminalCommand(
-      ctx.window,
-      claude.panel,
-      `DAINTREE_E2E_MANUAL_RUN=1 ${fakeAgentCommand("claude")}`
-    );
-    await waitForTerminalText(claude.panel, "FAKE_CLAUDE_MANUAL=1", T_LONG);
-    await waitForTerminalText(claude.panel, `FAKE_CLAUDE_COLOR=${CLAUDE_COLOR}`, T_LONG);
-    await expectAgentIconColor(claude.panel, "claude", CLAUDE_COLOR);
+    await test.step("Quit Claude and verify runtime demotes to none", async () => {
+      await quitAgentOrWaitForDemotion(ctx.window, claude.panel);
+    });
 
-    const codex = await launchPreset(ctx.window, "codex", CODEX_PRESET_ID);
-    await expectAgentIconColor(codex.panel, "codex", CODEX_COLOR);
-    await waitForTerminalText(codex.panel, "FAKE_CODEX_READY", T_LONG);
-    await waitForTerminalText(codex.panel, `FAKE_CODEX_COLOR=${CODEX_COLOR}`, T_LONG);
-    await waitForTerminalText(codex.panel, "FAKE_CODEX_PROVIDER=green-provider", T_LONG);
-    expect(CODEX_COLOR).not.toBe(CLAUDE_COLOR);
+    await test.step("Restart terminal and manual-run Claude — verify color reapplies", async () => {
+      await restartTerminal(ctx.window, claude.id, claude.panel);
+      await runTerminalCommand(
+        ctx.window,
+        claude.panel,
+        `DAINTREE_E2E_MANUAL_RUN=1 ${fakeAgentCommand("claude")}`
+      );
+      await waitForTerminalText(claude.panel, "FAKE_CLAUDE_MANUAL=1", T_LONG);
+      await waitForTerminalText(claude.panel, `FAKE_CLAUDE_COLOR=${CLAUDE_COLOR}`, T_LONG);
+      await expectAgentIconColor(claude.panel, "claude", CLAUDE_COLOR);
+    });
+
+    await test.step("Launch Codex preset and verify color and provider isolation", async () => {
+      const codex = await launchPreset(ctx.window, "codex", CODEX_PRESET_ID);
+      await expectAgentIconColor(codex.panel, "codex", CODEX_COLOR);
+      await waitForTerminalText(codex.panel, "FAKE_CODEX_READY", T_LONG);
+      await waitForTerminalText(codex.panel, `FAKE_CODEX_COLOR=${CODEX_COLOR}`, T_LONG);
+      await waitForTerminalText(codex.panel, "FAKE_CODEX_PROVIDER=green-provider", T_LONG);
+      expect(CODEX_COLOR).not.toBe(CLAUDE_COLOR);
+    });
   });
 });

--- a/e2e/full/core-diagnostics-notifications.spec.ts
+++ b/e2e/full/core-diagnostics-notifications.spec.ts
@@ -35,29 +35,33 @@ test.describe.serial("Core: Diagnostics & Notifications", () => {
 
     test("switches between tabs", async () => {
       const { window } = ctx;
-
       const logsTab = window.locator(SEL.diagnostics.tab("logs"));
-      await logsTab.click();
-      await expect(logsTab).toHaveAttribute("aria-selected", "true", {
-        timeout: T_SHORT,
-      });
-      await expect(window.locator(SEL.diagnostics.tab("problems"))).toHaveAttribute(
-        "aria-selected",
-        "false"
-      );
-
-      const logsPanel = window.locator(SEL.diagnostics.panel("logs"));
-      await expect(logsPanel).toBeVisible({ timeout: T_SHORT });
-
       const eventsTab = window.locator(SEL.diagnostics.tab("events"));
-      await eventsTab.click();
-      await expect(eventsTab).toHaveAttribute("aria-selected", "true", {
-        timeout: T_SHORT,
-      });
-      await expect(logsTab).toHaveAttribute("aria-selected", "false");
 
-      const eventsPanel = window.locator(SEL.diagnostics.panel("events"));
-      await expect(eventsPanel).toBeVisible({ timeout: T_SHORT });
+      await test.step("Switch from Problems to Logs tab and verify selection", async () => {
+        await logsTab.click();
+        await expect(logsTab).toHaveAttribute("aria-selected", "true", {
+          timeout: T_SHORT,
+        });
+        await expect(window.locator(SEL.diagnostics.tab("problems"))).toHaveAttribute(
+          "aria-selected",
+          "false"
+        );
+
+        const logsPanel = window.locator(SEL.diagnostics.panel("logs"));
+        await expect(logsPanel).toBeVisible({ timeout: T_SHORT });
+      });
+
+      await test.step("Switch from Logs to Events tab and verify selection", async () => {
+        await eventsTab.click();
+        await expect(eventsTab).toHaveAttribute("aria-selected", "true", {
+          timeout: T_SHORT,
+        });
+        await expect(logsTab).toHaveAttribute("aria-selected", "false");
+
+        const eventsPanel = window.locator(SEL.diagnostics.panel("events"));
+        await expect(eventsPanel).toBeVisible({ timeout: T_SHORT });
+      });
     });
 
     test("events tab shows captured events", async () => {
@@ -101,33 +105,34 @@ test.describe.serial("Core: Diagnostics & Notifications", () => {
 
     test("logs tab renders log entries", async () => {
       const { window } = ctx;
-
-      // Switch to logs tab
       const logsTab = window.locator(SEL.diagnostics.tab("logs"));
-      await logsTab.click();
-      await expect(logsTab).toHaveAttribute("aria-selected", "true", {
-        timeout: T_SHORT,
-      });
-
       const logsPanel = window.locator(SEL.diagnostics.panel("logs"));
-      await expect(logsPanel).toBeVisible({ timeout: T_SHORT });
 
-      // Seed a log entry via IPC to ensure at least one exists
-      await window.evaluate(() => {
-        type W = {
-          electron: { logs: { write: (level: string, message: string) => Promise<void> } };
-        };
-        return (window as unknown as W).electron.logs.write("info", "E2E diagnostics test log");
+      await test.step("Switch to Logs tab and verify panel is visible", async () => {
+        await logsTab.click();
+        await expect(logsTab).toHaveAttribute("aria-selected", "true", {
+          timeout: T_SHORT,
+        });
+        await expect(logsPanel).toBeVisible({ timeout: T_SHORT });
       });
 
-      // Verify logs loaded into the panel (Virtuoso renders items)
-      await expect
-        .poll(() => logsPanel.locator('[data-testid="virtuoso-item-list"] > *').count(), {
-          timeout: T_MEDIUM,
-        })
-        .toBeGreaterThanOrEqual(1);
+      await test.step("Seed a log entry via IPC and verify it renders", async () => {
+        await window.evaluate(() => {
+          type W = {
+            electron: { logs: { write: (level: string, message: string) => Promise<void> } };
+          };
+          return (window as unknown as W).electron.logs.write("info", "E2E diagnostics test log");
+        });
 
-      await expect(logsPanel.getByText("No logs yet")).not.toBeVisible();
+        // Verify logs loaded into the panel (Virtuoso renders items)
+        await expect
+          .poll(() => logsPanel.locator('[data-testid="virtuoso-item-list"] > *').count(), {
+            timeout: T_MEDIUM,
+          })
+          .toBeGreaterThanOrEqual(1);
+
+        await expect(logsPanel.getByText("No logs yet")).not.toBeVisible();
+      });
     });
 
     test("resizes via keyboard", async () => {
@@ -158,16 +163,19 @@ test.describe.serial("Core: Diagnostics & Notifications", () => {
     test("reopens via toggle shortcut", async () => {
       const { window } = ctx;
 
-      await window.keyboard.press(`${mod}+Shift+D`);
+      await test.step("Reopen diagnostics dock via toggle shortcut", async () => {
+        await window.keyboard.press(`${mod}+Shift+D`);
 
-      await expect(window.locator(SEL.diagnostics.dock)).toBeVisible({
-        timeout: T_MEDIUM,
+        await expect(window.locator(SEL.diagnostics.dock)).toBeVisible({
+          timeout: T_MEDIUM,
+        });
       });
 
-      // Clean up: close dock for subsequent tests
-      await window.locator(SEL.diagnostics.closeButton).click();
-      await expect(window.locator(SEL.diagnostics.dock)).not.toBeVisible({
-        timeout: T_SHORT,
+      await test.step("Close dock to leave clean state for subsequent tests", async () => {
+        await window.locator(SEL.diagnostics.closeButton).click();
+        await expect(window.locator(SEL.diagnostics.dock)).not.toBeVisible({
+          timeout: T_SHORT,
+        });
       });
     });
   });

--- a/e2e/full/core-fleet-broadcast.spec.ts
+++ b/e2e/full/core-fleet-broadcast.spec.ts
@@ -180,80 +180,104 @@ test.describe.serial("Core: Fleet terminal broadcast", () => {
     test.setTimeout(180_000);
 
     const { window } = ctx;
-    const disableHybrid = await dispatchAction(
-      window,
-      "terminalConfig.setHybridInputEnabled",
-      { enabled: false },
-      { source: "user" }
-    );
-    expect(disableHybrid.ok, disableHybrid.error?.message).toBe(true);
 
-    const agents = [
-      await startClaudeAgentFromTerminal(window),
-      await startClaudeAgentFromTerminal(window),
-      await startClaudeAgentFromTerminal(window),
-    ];
-    const terminalIds = agents.map((agent) => agent.id);
-    expect(new Set(terminalIds).size).toBe(3);
+    await test.step("Disable hybrid input so xterm typing reaches the PTY directly", async () => {
+      const disableHybrid = await dispatchAction(
+        window,
+        "terminalConfig.setHybridInputEnabled",
+        { enabled: false },
+        { source: "user" }
+      );
+      expect(disableHybrid.ok, disableHybrid.error?.message).toBe(true);
+    });
 
-    await armFleet(window, terminalIds);
+    let agents: Array<{ id: string; panel: Locator }> = [];
+    let terminalIds: string[] = [];
+    await test.step("Start three fake Claude agents in fresh terminals", async () => {
+      agents = [
+        await startClaudeAgentFromTerminal(window),
+        await startClaudeAgentFromTerminal(window),
+        await startClaudeAgentFromTerminal(window),
+      ];
+      terminalIds = agents.map((agent) => agent.id);
+      expect(new Set(terminalIds).size).toBe(3);
+    });
+
+    await test.step("Arm the fleet across all three terminals", async () => {
+      await armFleet(window, terminalIds);
+    });
 
     const command = `fleet-direct-${Date.now()}`;
-    await typeDirectlyIntoTerminal(window, agents[0]!.panel, agents[0]!.id, command);
+    await test.step("Type directly into the first armed terminal and verify all three respond", async () => {
+      await typeDirectlyIntoTerminal(window, agents[0]!.panel, agents[0]!.id, command);
 
-    for (const { panel } of agents) {
-      await waitForTerminalText(panel, `FLEET_RESPONSE`, T_LONG);
-      await waitForTerminalText(panel, `text=${command}`, T_LONG);
-      await waitForTerminalText(panel, `FLEET_DONE ${command}`, T_LONG);
-    }
-
-    await expect(window.locator('[data-testid="fleet-arming-ribbon"]')).toBeVisible({
-      timeout: T_MEDIUM,
+      for (const { panel } of agents) {
+        await waitForTerminalText(panel, `FLEET_RESPONSE`, T_LONG);
+        await waitForTerminalText(panel, `text=${command}`, T_LONG);
+        await waitForTerminalText(panel, `FLEET_DONE ${command}`, T_LONG);
+      }
     });
-    await expect(agents[0]!.panel.locator(SEL.terminal.cmEditor)).toHaveCount(0);
+
+    await test.step("Verify arming ribbon stays and HybridInputBar is absent", async () => {
+      await expect(window.locator('[data-testid="fleet-arming-ribbon"]')).toBeVisible({
+        timeout: T_MEDIUM,
+      });
+      await expect(agents[0]!.panel.locator(SEL.terminal.cmEditor)).toHaveCount(0);
+    });
   });
 
   test("Cmd+Alt+Arrow cycles focus across the fleet grid (#5989)", async () => {
     test.setTimeout(60_000);
 
     const { window } = ctx;
+    let fleetIds: string[] = [];
+    let firstId = "";
 
-    // Self-contained: arm whatever grid panels exist (idempotent if a prior
-    // test already armed them) so this test passes when run in isolation
-    // (e.g., `playwright test --grep "#5989"`).
-    const gridIds = await getGridPanelIds(window);
-    expect(gridIds.length).toBeGreaterThanOrEqual(2);
-    for (const id of gridIds) {
-      await dispatchAction(window, "terminal.arm", { terminalId: id }, { source: "user" });
-    }
+    await test.step("Arm existing grid panels and enter fleet scope", async () => {
+      // Self-contained: arm whatever grid panels exist (idempotent if a prior
+      // test already armed them) so this test passes when run in isolation
+      // (e.g., `playwright test --grep "#5989"`).
+      const gridIds = await getGridPanelIds(window);
+      expect(gridIds.length).toBeGreaterThanOrEqual(2);
+      for (const id of gridIds) {
+        await dispatchAction(window, "terminal.arm", { terminalId: id }, { source: "user" });
+      }
 
-    // Activate fleet scope so ContentGrid renders the flat fleet grid —
-    // the path where useGridNavigation regressed in #5989.
-    const enter = await dispatchAction(window, "fleet.scope.enter", undefined, { source: "user" });
-    expect(enter.ok, enter.error?.message).toBe(true);
+      // Activate fleet scope so ContentGrid renders the flat fleet grid —
+      // the path where useGridNavigation regressed in #5989.
+      const enter = await dispatchAction(window, "fleet.scope.enter", undefined, {
+        source: "user",
+      });
+      expect(enter.ok, enter.error?.message).toBe(true);
 
-    const fleetIds = await getGridPanelIds(window);
-    expect(fleetIds.length).toBeGreaterThanOrEqual(2);
-
-    // Click the first fleet panel to anchor focus.
-    const firstId = fleetIds[0]!;
-    await getPanelById(window, firstId).click();
-    await expect
-      .poll(() => getFocusedPanelId(window), { timeout: T_MEDIUM, intervals: [100, 250] })
-      .toBe(firstId);
-
-    // Pre-fix, this dispatch was a silent no-op because the nav model was
-    // built from the active worktree's tab groups, not the fleet armOrder.
-    const right = await dispatchAction(window, "terminal.focusRight", undefined, {
-      source: "keybinding",
+      fleetIds = await getGridPanelIds(window);
+      expect(fleetIds.length).toBeGreaterThanOrEqual(2);
     });
-    expect(right.ok, right.error?.message).toBe(true);
 
-    await expect
-      .poll(() => getFocusedPanelId(window), { timeout: T_MEDIUM, intervals: [100, 250] })
-      .toBe(fleetIds[1]!);
+    await test.step("Click first fleet panel to anchor focus", async () => {
+      firstId = fleetIds[0]!;
+      await getPanelById(window, firstId).click();
+      await expect
+        .poll(() => getFocusedPanelId(window), { timeout: T_MEDIUM, intervals: [100, 250] })
+        .toBe(firstId);
+    });
 
-    const exit = await dispatchAction(window, "fleet.scope.exit", undefined, { source: "user" });
-    expect(exit.ok, exit.error?.message).toBe(true);
+    await test.step("Dispatch terminal.focusRight and verify focus moves to next fleet panel", async () => {
+      // Pre-fix, this dispatch was a silent no-op because the nav model was
+      // built from the active worktree's tab groups, not the fleet armOrder.
+      const right = await dispatchAction(window, "terminal.focusRight", undefined, {
+        source: "keybinding",
+      });
+      expect(right.ok, right.error?.message).toBe(true);
+
+      await expect
+        .poll(() => getFocusedPanelId(window), { timeout: T_MEDIUM, intervals: [100, 250] })
+        .toBe(fleetIds[1]!);
+    });
+
+    await test.step("Exit fleet scope", async () => {
+      const exit = await dispatchAction(window, "fleet.scope.exit", undefined, { source: "user" });
+      expect(exit.ok, exit.error?.message).toBe(true);
+    });
   });
 });

--- a/e2e/full/core-focus-management.spec.ts
+++ b/e2e/full/core-focus-management.spec.ts
@@ -35,143 +35,174 @@ test.describe.serial("Core: Focus Management", () => {
     const { window } = ctx;
     await ensureWindowFocused(ctx.app);
 
-    // Click the main content area to ensure the app has keyboard focus
-    await window.locator("main").click({ force: true });
-    await window.waitForTimeout(200);
+    let panel: ReturnType<typeof getFirstGridPanel>;
 
-    const before = await getGridPanelCount(window);
-    await window.keyboard.press(`${mod}+Alt+t`);
-    await expect.poll(() => getGridPanelCount(window), { timeout: T_LONG }).toBe(before + 1);
-    await window
-      .locator(SEL.terminal.xtermRows)
-      .first()
-      .waitFor({ state: "visible", timeout: T_LONG });
+    await test.step("Open a terminal and focus it", async () => {
+      // Click the main content area to ensure the app has keyboard focus
+      await window.locator("main").click({ force: true });
+      await window.waitForTimeout(200);
 
-    const panel = getFirstGridPanel(window);
-    await panel.locator(SEL.terminal.xtermRows).click();
-    await expectTerminalFocused(panel);
+      const before = await getGridPanelCount(window);
+      await window.keyboard.press(`${mod}+Alt+t`);
+      await expect.poll(() => getGridPanelCount(window), { timeout: T_LONG }).toBe(before + 1);
+      await window
+        .locator(SEL.terminal.xtermRows)
+        .first()
+        .waitFor({ state: "visible", timeout: T_LONG });
 
-    await window.keyboard.press(`${mod}+Shift+P`);
-    await expect(window.locator(SEL.actionPalette.dialog)).toBeVisible({ timeout: T_MEDIUM });
-    await expect(window.locator(SEL.actionPalette.searchInput)).toBeFocused({ timeout: T_SHORT });
-    // Settle to let any delayed menu IPC arrive before dismissing
-    await window.waitForTimeout(T_SETTLE);
+      panel = getFirstGridPanel(window);
+      await panel.locator(SEL.terminal.xtermRows).click();
+      await expectTerminalFocused(panel);
+    });
 
-    await window.keyboard.press("Escape");
-    await expect(window.locator(SEL.actionPalette.dialog)).not.toBeVisible({ timeout: T_MEDIUM });
-    await expectTerminalFocused(panel, T_MEDIUM);
+    await test.step("Open action palette and verify search input is focused", async () => {
+      await window.keyboard.press(`${mod}+Shift+P`);
+      await expect(window.locator(SEL.actionPalette.dialog)).toBeVisible({ timeout: T_MEDIUM });
+      await expect(window.locator(SEL.actionPalette.searchInput)).toBeFocused({ timeout: T_SHORT });
+      // Settle to let any delayed menu IPC arrive before dismissing
+      await window.waitForTimeout(T_SETTLE);
+    });
+
+    await test.step("Dismiss palette and verify terminal focus is restored", async () => {
+      await window.keyboard.press("Escape");
+      await expect(window.locator(SEL.actionPalette.dialog)).not.toBeVisible({ timeout: T_MEDIUM });
+      await expectTerminalFocused(panel!, T_MEDIUM);
+    });
   });
 
   test("quick switcher dismiss restores terminal focus", async () => {
     const { window } = ctx;
     await ensureWindowFocused(ctx.app);
-
     const panel = getFirstGridPanel(window);
-    await panel.locator(SEL.terminal.xtermRows).click();
-    await expectTerminalFocused(panel);
 
-    await window.keyboard.press(`${mod}+P`);
-    await expect(window.locator(SEL.quickSwitcher.dialog)).toBeVisible({ timeout: T_MEDIUM });
-    await expect(window.locator(SEL.quickSwitcher.searchInput)).toBeFocused({ timeout: T_SHORT });
-    // Settle to let any delayed menu IPC arrive before dismissing
-    await window.waitForTimeout(T_SETTLE);
+    await test.step("Focus terminal panel", async () => {
+      await panel.locator(SEL.terminal.xtermRows).click();
+      await expectTerminalFocused(panel);
+    });
 
-    await window.keyboard.press("Escape");
-    await expect(window.locator(SEL.quickSwitcher.dialog)).not.toBeVisible({ timeout: T_MEDIUM });
-    await expectTerminalFocused(panel, T_MEDIUM);
+    await test.step("Open quick switcher and verify search input is focused", async () => {
+      await window.keyboard.press(`${mod}+P`);
+      await expect(window.locator(SEL.quickSwitcher.dialog)).toBeVisible({ timeout: T_MEDIUM });
+      await expect(window.locator(SEL.quickSwitcher.searchInput)).toBeFocused({ timeout: T_SHORT });
+      // Settle to let any delayed menu IPC arrive before dismissing
+      await window.waitForTimeout(T_SETTLE);
+    });
+
+    await test.step("Dismiss switcher and verify terminal focus is restored", async () => {
+      await window.keyboard.press("Escape");
+      await expect(window.locator(SEL.quickSwitcher.dialog)).not.toBeVisible({ timeout: T_MEDIUM });
+      await expectTerminalFocused(panel, T_MEDIUM);
+    });
   });
 
   test("F6 cycles focus between macro regions", async () => {
     const { window } = ctx;
     await ensureWindowFocused(ctx.app);
-
     const panel = getFirstGridPanel(window);
-    await panel.locator(SEL.terminal.xtermRows).click();
-    await expectTerminalFocused(panel);
-
-    // First F6 from terminal: focusedRegion is null → targets "grid" (first visible region)
-    await window.keyboard.press("F6");
-    // The grid region may have aria-label "Panel grid" or "Panel grid region"
     const grid = window.locator('[role="region"]').filter({
       has: window.locator('[data-grid-container="true"]'),
     });
-    await expect(grid).toBeFocused({ timeout: T_MEDIUM });
-
-    // Second F6: grid → sidebar
-    await window.keyboard.press("F6");
     const sidebar = window.locator('[aria-label="Sidebar"]');
-    await expect(sidebar).toBeFocused({ timeout: T_MEDIUM });
 
-    // Third F6: sidebar → grid (wraps around)
-    await window.keyboard.press("F6");
-    await expect(grid).toBeFocused({ timeout: T_MEDIUM });
+    await test.step("Focus terminal panel as starting region", async () => {
+      await panel.locator(SEL.terminal.xtermRows).click();
+      await expectTerminalFocused(panel);
+    });
+
+    await test.step("First F6: terminal → grid region", async () => {
+      // First F6 from terminal: focusedRegion is null → targets "grid" (first visible region)
+      await window.keyboard.press("F6");
+      // The grid region may have aria-label "Panel grid" or "Panel grid region"
+      await expect(grid).toBeFocused({ timeout: T_MEDIUM });
+    });
+
+    await test.step("Second F6: grid → sidebar", async () => {
+      await window.keyboard.press("F6");
+      await expect(sidebar).toBeFocused({ timeout: T_MEDIUM });
+    });
+
+    await test.step("Third F6: sidebar → grid (wraps around)", async () => {
+      await window.keyboard.press("F6");
+      await expect(grid).toBeFocused({ timeout: T_MEDIUM });
+    });
   });
 
   test("clicking panels changes focused panel ID", async () => {
     const { window } = ctx;
     await ensureWindowFocused(ctx.app);
+    let before = 0;
 
-    const before = await getGridPanelCount(window);
-    await window.keyboard.press(`${mod}+Alt+t`);
-    await expect.poll(() => getGridPanelCount(window), { timeout: T_LONG }).toBe(before + 1);
-    await window
-      .locator(SEL.panel.gridPanel)
-      .last()
-      .locator(SEL.terminal.xtermRows)
-      .waitFor({ state: "visible", timeout: T_LONG });
+    await test.step("Open a second terminal so two panels are present", async () => {
+      before = await getGridPanelCount(window);
+      await window.keyboard.press(`${mod}+Alt+t`);
+      await expect.poll(() => getGridPanelCount(window), { timeout: T_LONG }).toBe(before + 1);
+      await window
+        .locator(SEL.panel.gridPanel)
+        .last()
+        .locator(SEL.terminal.xtermRows)
+        .waitFor({ state: "visible", timeout: T_LONG });
 
-    const ids = await getGridPanelIds(window);
-    expect(ids.length).toBeGreaterThanOrEqual(2);
+      const ids = await getGridPanelIds(window);
+      expect(ids.length).toBeGreaterThanOrEqual(2);
+    });
 
-    // Click the first panel and verify it's focused
-    const firstPanel = window.locator(SEL.panel.gridPanel).first();
-    await firstPanel.locator(SEL.terminal.xtermRows).click();
-    await expectTerminalFocused(firstPanel);
-    const firstId = await getFocusedPanelId(window);
-    expect(firstId).toBeTruthy();
+    let firstId: string | null = null;
+    await test.step("Click first panel and capture focused panel id", async () => {
+      const firstPanel = window.locator(SEL.panel.gridPanel).first();
+      await firstPanel.locator(SEL.terminal.xtermRows).click();
+      await expectTerminalFocused(firstPanel);
+      firstId = await getFocusedPanelId(window);
+      expect(firstId).toBeTruthy();
+    });
 
-    // Click the second panel and verify focus moves
-    const secondPanel = window.locator(SEL.panel.gridPanel).last();
-    await secondPanel.locator(SEL.terminal.xtermRows).click();
-    await expectTerminalFocused(secondPanel);
-    const secondId = await getFocusedPanelId(window);
-    expect(secondId).toBeTruthy();
-    expect(secondId).not.toBe(firstId);
+    await test.step("Click second panel and verify focused panel id changes", async () => {
+      const secondPanel = window.locator(SEL.panel.gridPanel).last();
+      await secondPanel.locator(SEL.terminal.xtermRows).click();
+      await expectTerminalFocused(secondPanel);
+      const secondId = await getFocusedPanelId(window);
+      expect(secondId).toBeTruthy();
+      expect(secondId).not.toBe(firstId);
+    });
 
-    // Clean up: close the extra panel
-    const panelToClose = window.locator(SEL.panel.gridPanel).last();
-    await panelToClose.locator(SEL.panel.close).first().click({ force: true });
-    await expect.poll(() => getGridPanelCount(window), { timeout: T_MEDIUM }).toBe(before);
+    await test.step("Clean up extra panel created during this test", async () => {
+      const panelToClose = window.locator(SEL.panel.gridPanel).last();
+      await panelToClose.locator(SEL.panel.close).first().click({ force: true });
+      await expect.poll(() => getGridPanelCount(window), { timeout: T_MEDIUM }).toBe(before);
+    });
   });
 
   test("Escape pops layered overlays in LIFO order", async () => {
     const { window } = ctx;
     await ensureWindowFocused(ctx.app);
-
     const panel = getFirstGridPanel(window);
-    await panel.locator(SEL.terminal.xtermRows).click();
-    await expectTerminalFocused(panel);
 
-    // Open Settings first (bottom of stack)
-    await window.keyboard.press(`${mod}+,`);
-    await expect(window.locator(SEL.settings.heading)).toBeVisible({ timeout: T_MEDIUM });
+    await test.step("Focus terminal as the underlying focus target", async () => {
+      await panel.locator(SEL.terminal.xtermRows).click();
+      await expectTerminalFocused(panel);
+    });
 
-    // Open Action Palette on top (top of stack)
-    await window.keyboard.press(`${mod}+Shift+P`);
-    await expect(window.locator(SEL.actionPalette.dialog)).toBeVisible({ timeout: T_MEDIUM });
-    // Settle to let any delayed menu IPC arrive before dismissing
-    await window.waitForTimeout(T_SETTLE);
+    await test.step("Open Settings (bottom of stack), then Action Palette (top)", async () => {
+      await window.keyboard.press(`${mod}+,`);
+      await expect(window.locator(SEL.settings.heading)).toBeVisible({ timeout: T_MEDIUM });
 
-    // First Escape: palette closes, settings stays
-    await window.keyboard.press("Escape");
-    await expect(window.locator(SEL.actionPalette.dialog)).not.toBeVisible({ timeout: T_MEDIUM });
-    await expect(window.locator(SEL.settings.heading)).toBeVisible({ timeout: T_SHORT });
+      await window.keyboard.press(`${mod}+Shift+P`);
+      await expect(window.locator(SEL.actionPalette.dialog)).toBeVisible({ timeout: T_MEDIUM });
+      // Settle to let any delayed menu IPC arrive before dismissing
+      await window.waitForTimeout(T_SETTLE);
+    });
 
-    // Second Escape: settings closes
-    await window.keyboard.press("Escape");
-    await expect(window.locator(SEL.settings.heading)).not.toBeVisible({ timeout: T_SHORT });
+    await test.step("First Escape pops palette only — settings remains", async () => {
+      await window.keyboard.press("Escape");
+      await expect(window.locator(SEL.actionPalette.dialog)).not.toBeVisible({ timeout: T_MEDIUM });
+      await expect(window.locator(SEL.settings.heading)).toBeVisible({ timeout: T_SHORT });
+    });
 
-    // Focus restored to terminal
-    await expectTerminalFocused(panel, T_MEDIUM);
+    await test.step("Second Escape closes settings and restores terminal focus", async () => {
+      await window.keyboard.press("Escape");
+      await expect(window.locator(SEL.settings.heading)).not.toBeVisible({ timeout: T_SHORT });
+
+      // Focus restored to terminal
+      await expectTerminalFocused(panel, T_MEDIUM);
+    });
   });
 });

--- a/e2e/full/core-panel-tab-groups.spec.ts
+++ b/e2e/full/core-panel-tab-groups.spec.ts
@@ -109,20 +109,26 @@ test.describe.serial("Core: Panel Tab Groups", () => {
       const { window } = ctx;
       const panel = getFirstGridPanel(window);
 
-      const maximizeBtn = panel.locator(SEL.panel.maximize).first();
-      await maximizeBtn.click();
+      await test.step("Maximize the panel and verify exit-focus button appears", async () => {
+        const maximizeBtn = panel.locator(SEL.panel.maximize).first();
+        await maximizeBtn.click();
 
-      const exitFocus = window.locator(SEL.panel.exitFocus).first();
-      await expect(exitFocus).toBeVisible({ timeout: T_SHORT });
+        const exitFocus = window.locator(SEL.panel.exitFocus).first();
+        await expect(exitFocus).toBeVisible({ timeout: T_SHORT });
+      });
 
-      await exitFocus.click();
-      await expect(exitFocus).not.toBeVisible({ timeout: T_SHORT });
+      await test.step("Restore from maximize via exit-focus button", async () => {
+        const exitFocus = window.locator(SEL.panel.exitFocus).first();
+        await exitFocus.click();
+        await expect(exitFocus).not.toBeVisible({ timeout: T_SHORT });
+      });
 
-      // Tab list should still be visible with 2 tabs
-      const tabList = panel.locator(SEL.panel.tabList);
-      await expect(tabList).toBeVisible({ timeout: T_SHORT });
-      const tabs = tabList.locator(SEL.panel.tab);
-      await expect(tabs).toHaveCount(2, { timeout: T_SHORT });
+      await test.step("Verify tab list still shows both tabs after restore", async () => {
+        const tabList = panel.locator(SEL.panel.tabList);
+        await expect(tabList).toBeVisible({ timeout: T_SHORT });
+        const tabs = tabList.locator(SEL.panel.tab);
+        await expect(tabs).toHaveCount(2, { timeout: T_SHORT });
+      });
     });
 
     test("closing one tab keeps panel open and removes tab bar", async () => {
@@ -158,73 +164,84 @@ test.describe.serial("Core: Panel Tab Groups", () => {
   test.describe.serial("Overflow Menu & Restart", () => {
     test("overflow menu shows expected actions", async () => {
       const { window } = ctx;
+      let panel: ReturnType<typeof getFirstGridPanel>;
 
-      // Open a fresh terminal
-      await openTerminal(window);
-      const panel = getFirstGridPanel(window);
-      await expect(panel).toBeVisible({ timeout: T_LONG });
+      await test.step("Open a fresh terminal and wait for it to settle", async () => {
+        await openTerminal(window);
+        panel = getFirstGridPanel(window);
+        await expect(panel).toBeVisible({ timeout: T_LONG });
 
-      // Wait for terminal to be ready
-      await window.waitForTimeout(T_SETTLE);
+        await window.waitForTimeout(T_SETTLE);
+      });
 
-      // Open overflow menu
-      await panel.hover();
-      const overflowBtn = panel.locator(SEL.panel.overflowMenu).first();
-      await overflowBtn.click();
+      await test.step("Open the panel overflow menu", async () => {
+        await panel!.hover();
+        const overflowBtn = panel!.locator(SEL.panel.overflowMenu).first();
+        await overflowBtn.click();
+      });
 
-      // Verify expected menu items are visible (scoped to window since Radix portals to body)
-      const expectedItems = ["Restart Session", "Rename", "Duplicate", "Lock Input", "Trash"];
+      await test.step("Verify expected menu items are present and removed item is absent", async () => {
+        // Verify expected menu items are visible (scoped to window since Radix portals to body)
+        const expectedItems = ["Restart Session", "Rename", "Duplicate", "Lock Input", "Trash"];
 
-      for (const itemName of expectedItems) {
-        await expect(window.getByRole("menuitem", { name: itemName })).toBeVisible({
-          timeout: T_SHORT,
-        });
-      }
+        for (const itemName of expectedItems) {
+          await expect(window.getByRole("menuitem", { name: itemName })).toBeVisible({
+            timeout: T_SHORT,
+          });
+        }
 
-      // Removed in #5957 — guard against accidental re-introduction
-      await expect(window.getByRole("menuitem", { name: "View Terminal Info" })).toHaveCount(0);
+        // Removed in #5957 — guard against accidental re-introduction
+        await expect(window.getByRole("menuitem", { name: "View Terminal Info" })).toHaveCount(0);
+      });
 
-      // Close the menu and wait for it to fully unmount. Without this assertion
-      // the next test races against Radix's close animation: the menu's
-      // FocusScope keeps focus and its typeahead handler swallows the keys
-      // typed by `runTerminalCommand`, so the command never reaches the PTY.
-      await window.keyboard.press("Escape");
-      await expect(window.locator('[role="menu"]')).toHaveCount(0, { timeout: T_SHORT });
+      await test.step("Close the menu and confirm it fully unmounts", async () => {
+        // Close the menu and wait for it to fully unmount. Without this assertion
+        // the next test races against Radix's close animation: the menu's
+        // FocusScope keeps focus and its typeahead handler swallows the keys
+        // typed by `runTerminalCommand`, so the command never reaches the PTY.
+        await window.keyboard.press("Escape");
+        await expect(window.locator('[role="menu"]')).toHaveCount(0, { timeout: T_SHORT });
+      });
     });
 
     test("restart confirmation flow works", async () => {
       const { window } = ctx;
       const panel = getFirstGridPanel(window);
 
-      // Settle after the previous test's menu close so xterm input handlers
-      // are wired before we start typing.
-      await window.waitForTimeout(T_SETTLE);
+      await test.step("Run a pre-restart marker command", async () => {
+        // Settle after the previous test's menu close so xterm input handlers
+        // are wired before we start typing.
+        await window.waitForTimeout(T_SETTLE);
 
-      // Run a marker before restart
-      await runTerminalCommand(window, panel, "node -e \"console.log('PRE_RESTART')\"");
-      await waitForTerminalText(panel, "PRE_RESTART", T_LONG);
+        await runTerminalCommand(window, panel, "node -e \"console.log('PRE_RESTART')\"");
+        await waitForTerminalText(panel, "PRE_RESTART", T_LONG);
+      });
 
-      // Open overflow menu and click Restart
-      await panel.hover();
-      const overflowBtn = panel.locator(SEL.panel.overflowMenu).first();
-      await overflowBtn.click();
+      await test.step("Open overflow menu and arm Restart Session", async () => {
+        await panel.hover();
+        const overflowBtn = panel.locator(SEL.panel.overflowMenu).first();
+        await overflowBtn.click();
 
-      const restartBtn = window.locator(SEL.panel.restart).first();
-      await expect(restartBtn).toBeVisible({ timeout: T_SHORT });
-      await restartBtn.click();
+        const restartBtn = window.locator(SEL.panel.restart).first();
+        await expect(restartBtn).toBeVisible({ timeout: T_SHORT });
+        await restartBtn.click();
+      });
 
-      // Confirm the restart (2-click armed pattern)
-      const confirmBtn = window.locator(SEL.panel.restartConfirm).first();
-      await expect(confirmBtn).toBeVisible({ timeout: T_SHORT });
-      await confirmBtn.click();
+      await test.step("Confirm the restart and verify the panel survives", async () => {
+        // Confirm the restart (2-click armed pattern)
+        const confirmBtn = window.locator(SEL.panel.restartConfirm).first();
+        await expect(confirmBtn).toBeVisible({ timeout: T_SHORT });
+        await confirmBtn.click();
 
-      // Panel should remain visible after restart
-      await expect(panel).toBeVisible({ timeout: T_LONG });
+        // Panel should remain visible after restart
+        await expect(panel).toBeVisible({ timeout: T_LONG });
+      });
 
-      // Wait for the new shell to be ready, then verify PTY is functional
-      await window.waitForTimeout(T_SETTLE);
-      await runTerminalCommand(window, panel, "node -e \"console.log('POST_RESTART_OK')\"");
-      await waitForTerminalText(panel, "POST_RESTART_OK", T_LONG);
+      await test.step("Verify the new shell accepts a post-restart marker command", async () => {
+        await window.waitForTimeout(T_SETTLE);
+        await runTerminalCommand(window, panel, "node -e \"console.log('POST_RESTART_OK')\"");
+        await waitForTerminalText(panel, "POST_RESTART_OK", T_LONG);
+      });
     });
 
     test.afterAll(async () => {

--- a/e2e/full/core-perf-list-mount-budget.spec.ts
+++ b/e2e/full/core-perf-list-mount-budget.spec.ts
@@ -59,65 +59,71 @@ test.describe.serial("Core: List Mount Perf Budget", () => {
     const lastFileName = `bulk-unstaged/file-${FILE_COUNT}.txt`;
     const midFileName = `bulk-unstaged/file-0500.txt`;
 
-    // Snapshot baseline DOM node count before opening the hub
-    const beforeNodeCount = await window.evaluate(() => document.getElementsByTagName("*").length);
-
-    // Install a PerformanceObserver for long-animation-frames before triggering
-    // the mount. Do NOT use buffered: true — it captures startup noise.
-    const observerInstalled = await window.evaluate(() => {
-      if (!("PerformanceObserver" in window)) return false;
-      const supported = PerformanceObserver.supportedEntryTypes ?? [];
-      if (!supported.includes("long-animation-frame")) return false;
-
-      const win = window as unknown as E2EPerfWindow;
-      win.__daintreeE2ePerfEntries = [];
-      try {
-        const obs = new PerformanceObserver((list) => {
-          for (const entry of list.getEntries()) {
-            win.__daintreeE2ePerfEntries!.push(entry.toJSON());
-          }
-        });
-        obs.observe({ type: "long-animation-frame", durationThreshold: 100 });
-        win.__daintreeE2ePerfObserver = obs;
-      } catch {
-        return false;
-      }
-      return true;
+    let beforeNodeCount = 0;
+    await test.step("Snapshot baseline DOM node count before mount", async () => {
+      beforeNodeCount = await window.evaluate(() => document.getElementsByTagName("*").length);
     });
 
-    // Record mount start time for entry filtering
-    await window.evaluate(() => {
-      (window as unknown as E2EPerfWindow).__daintreeE2eMountStart = performance.now();
+    let observerInstalled = false;
+    await test.step("Install long-animation-frame PerformanceObserver and record mount start", async () => {
+      // Install a PerformanceObserver for long-animation-frames before triggering
+      // the mount. Do NOT use buffered: true — it captures startup noise.
+      observerInstalled = await window.evaluate(() => {
+        if (!("PerformanceObserver" in window)) return false;
+        const supported = PerformanceObserver.supportedEntryTypes ?? [];
+        if (!supported.includes("long-animation-frame")) return false;
+
+        const win = window as unknown as E2EPerfWindow;
+        win.__daintreeE2ePerfEntries = [];
+        try {
+          const obs = new PerformanceObserver((list) => {
+            for (const entry of list.getEntries()) {
+              win.__daintreeE2ePerfEntries!.push(entry.toJSON());
+            }
+          });
+          obs.observe({ type: "long-animation-frame", durationThreshold: 100 });
+          win.__daintreeE2ePerfObserver = obs;
+        } catch {
+          return false;
+        }
+        return true;
+      });
+
+      // Record mount start time for entry filtering
+      await window.evaluate(() => {
+        (window as unknown as E2EPerfWindow).__daintreeE2eMountStart = performance.now();
+      });
     });
 
-    // Open the ReviewHub
-    const reviewBtn = window.locator(SEL.worktree.reviewHubButton);
-    await reviewBtn.first().click();
+    await test.step("Open ReviewHub and verify list span renders end-to-end", async () => {
+      const reviewBtn = window.locator(SEL.worktree.reviewHubButton);
+      await reviewBtn.first().click();
 
-    const hub = window.locator(SEL.reviewHub.container);
-    await expect(hub).toBeVisible({ timeout: T_LONG });
+      const hub = window.locator(SEL.reviewHub.container);
+      await expect(hub).toBeVisible({ timeout: T_LONG });
 
-    // Confirm the hub is showing file data, not an empty state
-    await expect(hub.locator(SEL.reviewHub.cleanState)).not.toBeVisible({ timeout: T_SHORT });
-    await expect(hub.locator(SEL.reviewHub.noUnstagedChanges)).not.toBeVisible({
-      timeout: T_SHORT,
+      // Confirm the hub is showing file data, not an empty state
+      await expect(hub.locator(SEL.reviewHub.cleanState)).not.toBeVisible({ timeout: T_SHORT });
+      await expect(hub.locator(SEL.reviewHub.noUnstagedChanges)).not.toBeVisible({
+        timeout: T_SHORT,
+      });
+
+      // Wait for both last and mid-range rows — confirms full list span
+      const lastStageBtn = hub.locator(SEL.reviewHub.stageButton(lastFileName));
+      const midStageBtn = hub.locator(SEL.reviewHub.stageButton(midFileName));
+      await expect(lastStageBtn).toBeVisible({ timeout: T_LONG });
+      await expect(midStageBtn).toBeVisible({ timeout: T_SHORT });
+
+      // Allow a brief settle for final paints and observer callbacks
+      await window.waitForTimeout(T_SETTLE);
     });
 
-    // Wait for both last and mid-range rows — confirms full list span
-    const lastStageBtn = hub.locator(SEL.reviewHub.stageButton(lastFileName));
-    const midStageBtn = hub.locator(SEL.reviewHub.stageButton(midFileName));
-    await expect(lastStageBtn).toBeVisible({ timeout: T_LONG });
-    await expect(midStageBtn).toBeVisible({ timeout: T_SHORT });
+    let afterNodeCount = 0;
+    let longTaskEntries: Array<{ duration: number; startTime: number }> = [];
+    await test.step("Collect post-mount DOM count and long-animation-frame entries", async () => {
+      afterNodeCount = await window.evaluate(() => document.getElementsByTagName("*").length);
 
-    // Allow a brief settle for final paints and observer callbacks
-    await window.waitForTimeout(T_SETTLE);
-
-    // Snapshot post-mount DOM node count
-    const afterNodeCount = await window.evaluate(() => document.getElementsByTagName("*").length);
-
-    // Collect longtask entries, filtering to post-click timestamps
-    const longTaskEntries: Array<{ duration: number; startTime: number }> = await window.evaluate(
-      () => {
+      longTaskEntries = await window.evaluate(() => {
         const win = window as unknown as E2EPerfWindow;
         win.__daintreeE2ePerfObserver?.disconnect();
         const mountStart = win.__daintreeE2eMountStart ?? 0;
@@ -128,24 +134,24 @@ test.describe.serial("Core: List Mount Perf Budget", () => {
         delete win.__daintreeE2ePerfEntries;
         delete win.__daintreeE2eMountStart;
         return entries;
+      });
+    });
+
+    await test.step("Assert DOM delta and long-animation-frame budgets", async () => {
+      const domDelta = afterNodeCount - beforeNodeCount;
+      console.log(
+        `[perf-budget] DOM delta: ${domDelta} (before=${beforeNodeCount}, after=${afterNodeCount})`
+      );
+      expect(domDelta).toBeLessThanOrEqual(MAX_DOM_DELTA);
+
+      if (observerInstalled) {
+        const longTaskCount = longTaskEntries.length;
+        console.log(`[perf-budget] Long-animation-frames: ${longTaskCount}`);
+        expect(longTaskCount).toBeLessThanOrEqual(MAX_LONG_TASKS);
+      } else {
+        // Fail rather than skip — a release gate must not silently drop coverage
+        throw new Error("long-animation-frame API must be supported for the perf budget gate");
       }
-    );
-
-    // Assert DOM delta
-    const domDelta = afterNodeCount - beforeNodeCount;
-    console.log(
-      `[perf-budget] DOM delta: ${domDelta} (before=${beforeNodeCount}, after=${afterNodeCount})`
-    );
-    expect(domDelta).toBeLessThanOrEqual(MAX_DOM_DELTA);
-
-    // Assert longtask count
-    if (observerInstalled) {
-      const longTaskCount = longTaskEntries.length;
-      console.log(`[perf-budget] Long-animation-frames: ${longTaskCount}`);
-      expect(longTaskCount).toBeLessThanOrEqual(MAX_LONG_TASKS);
-    } else {
-      // Fail rather than skip — a release gate must not silently drop coverage
-      throw new Error("long-animation-frame API must be supported for the perf budget gate");
-    }
+    });
   });
 });

--- a/e2e/full/core-settings-load.spec.ts
+++ b/e2e/full/core-settings-load.spec.ts
@@ -21,15 +21,20 @@ test.describe.serial("Core: Settings Pages Load", () => {
 
   test("General tab: Overview loads without hanging", async () => {
     const { window } = ctx;
-    await openSettings(window);
-    await expect(window.locator(SEL.settings.heading)).toBeVisible({ timeout: T_MEDIUM });
 
-    // General is the default tab
-    await expect(window.locator("h3", { hasText: "General" })).toBeVisible({ timeout: T_SHORT });
+    await test.step("Open settings dialog", async () => {
+      await openSettings(window);
+      await expect(window.locator(SEL.settings.heading)).toBeVisible({ timeout: T_MEDIUM });
+    });
 
-    // Overview subtab should show the System Status section
-    const dialog = window.locator('[role="dialog"]');
-    await expect(dialog.locator("text=System Status")).toBeVisible({ timeout: T_SHORT });
+    await test.step("Verify General Overview content renders", async () => {
+      // General is the default tab
+      await expect(window.locator("h3", { hasText: "General" })).toBeVisible({ timeout: T_SHORT });
+
+      // Overview subtab should show the System Status section
+      const dialog = window.locator('[role="dialog"]');
+      await expect(dialog.locator("text=System Status")).toBeVisible({ timeout: T_SHORT });
+    });
   });
 
   test("General tab: Hibernation subtab loads", async () => {
@@ -64,22 +69,25 @@ test.describe.serial("Core: Settings Pages Load", () => {
   test("Appearance tab loads with subtabs", async () => {
     const { window } = ctx;
 
-    await window.locator(`${SEL.settings.navSidebar} button`, { hasText: "Appearance" }).click();
-    await expect(window.locator("h3", { hasText: "Appearance" })).toBeVisible({
-      timeout: T_SHORT,
+    await test.step("Open Appearance tab and verify App subtab content", async () => {
+      await window.locator(`${SEL.settings.navSidebar} button`, { hasText: "Appearance" }).click();
+      await expect(window.locator("h3", { hasText: "Appearance" })).toBeVisible({
+        timeout: T_SHORT,
+      });
+
+      // App subtab (default) should show the accent color section
+      const settingsPanel = window.locator('[role="dialog"]');
+      await expect(settingsPanel.locator('section[aria-label="Accent color"]')).toBeVisible({
+        timeout: T_SHORT,
+      });
     });
 
-    // App subtab (default) should show the accent color section
-    const settingsPanel = window.locator('[role="dialog"]');
-    await expect(settingsPanel.locator('section[aria-label="Accent color"]')).toBeVisible({
-      timeout: T_SHORT,
+    await test.step("Switch to Terminal subtab and verify content", async () => {
+      await window
+        .locator(`${SEL.settings.subtabNav} button[role="tab"]`, { hasText: "Terminal" })
+        .click();
+      await expect(window.locator(SEL.settings.fontSizeInput)).toBeVisible({ timeout: T_SHORT });
     });
-
-    // Switch to Terminal subtab
-    await window
-      .locator(`${SEL.settings.subtabNav} button[role="tab"]`, { hasText: "Terminal" })
-      .click();
-    await expect(window.locator(SEL.settings.fontSizeInput)).toBeVisible({ timeout: T_SHORT });
   });
 
   test("Keyboard tab loads", async () => {
@@ -116,53 +124,59 @@ test.describe.serial("Core: Settings Pages Load", () => {
   test("Privacy & Data tab loads with subtabs", async () => {
     const { window } = ctx;
 
-    await window
-      .locator(`${SEL.settings.navSidebar} button`, { hasText: "Privacy & Data" })
-      .click();
-    await expect(window.locator("h3", { hasText: "Privacy & Data" })).toBeVisible({
-      timeout: T_SHORT,
+    await test.step("Open Privacy & Data tab and verify Telemetry subtab", async () => {
+      await window
+        .locator(`${SEL.settings.navSidebar} button`, { hasText: "Privacy & Data" })
+        .click();
+      await expect(window.locator("h3", { hasText: "Privacy & Data" })).toBeVisible({
+        timeout: T_SHORT,
+      });
+
+      // Telemetry subtab (default) - verify telemetry options
+      await expect(window.locator("text=No data is collected").first()).toBeVisible({
+        timeout: T_SHORT,
+      });
     });
 
-    // Telemetry subtab (default) - verify telemetry options
-    await expect(window.locator("text=No data is collected").first()).toBeVisible({
-      timeout: T_SHORT,
-    });
-
-    // Switch to Data & Storage subtab
-    await window
-      .locator(`${SEL.settings.subtabNav} button[role="tab"]`, { hasText: "Data & Storage" })
-      .click();
-    await expect(window.locator("button", { hasText: "Clear Cache" })).toBeVisible({
-      timeout: T_SHORT,
+    await test.step("Switch to Data & Storage subtab and verify content", async () => {
+      await window
+        .locator(`${SEL.settings.subtabNav} button[role="tab"]`, { hasText: "Data & Storage" })
+        .click();
+      await expect(window.locator("button", { hasText: "Clear Cache" })).toBeVisible({
+        timeout: T_SHORT,
+      });
     });
   });
 
   test("Panel Grid tab loads with subtabs", async () => {
     const { window } = ctx;
 
-    await window.locator(`${SEL.settings.navSidebar} button`, { hasText: "Panel Grid" }).click();
-    await expect(window.locator("h3", { hasText: "Panel Grid" })).toBeVisible({
-      timeout: T_SHORT,
+    await test.step("Open Panel Grid tab and verify Performance subtab", async () => {
+      await window.locator(`${SEL.settings.navSidebar} button`, { hasText: "Panel Grid" }).click();
+      await expect(window.locator("h3", { hasText: "Panel Grid" })).toBeVisible({
+        timeout: T_SHORT,
+      });
+
+      // Performance subtab (default) should show Performance Mode toggle
+      await expect(window.locator(SEL.settings.performanceModeToggle)).toBeVisible({
+        timeout: T_SHORT,
+      });
     });
 
-    // Performance subtab (default) should show Performance Mode toggle
-    await expect(window.locator(SEL.settings.performanceModeToggle)).toBeVisible({
-      timeout: T_SHORT,
+    await test.step("Cycle remaining subtabs and verify each becomes selected", async () => {
+      const subtabs = ["Input", "Layout", "Scrollback", "Accessibility"];
+      for (const subtab of subtabs) {
+        await window
+          .locator(`${SEL.settings.subtabNav} button[role="tab"]`, { hasText: subtab })
+          .click();
+        // Verify the subtab button becomes selected
+        await expect(
+          window.locator(`${SEL.settings.subtabNav} button[role="tab"][aria-selected="true"]`, {
+            hasText: subtab,
+          })
+        ).toBeVisible({ timeout: T_SHORT });
+      }
     });
-
-    // Switch through remaining subtabs to verify they render content
-    const subtabs = ["Input", "Layout", "Scrollback", "Accessibility"];
-    for (const subtab of subtabs) {
-      await window
-        .locator(`${SEL.settings.subtabNav} button[role="tab"]`, { hasText: subtab })
-        .click();
-      // Verify the subtab button becomes selected
-      await expect(
-        window.locator(`${SEL.settings.subtabNav} button[role="tab"][aria-selected="true"]`, {
-          hasText: subtab,
-        })
-      ).toBeVisible({ timeout: T_SHORT });
-    }
   });
 
   test("Worktree tab loads", async () => {
@@ -297,62 +311,76 @@ test.describe.serial("Core: Settings Pages Load", () => {
 
   test("Project Variables tab loads", async () => {
     const { window } = ctx;
-    await openSettings(window);
-    await expect(window.locator(SEL.settings.heading)).toBeVisible({ timeout: T_MEDIUM });
 
-    // Switch to Project scope (Radix Select)
-    await window.locator('[aria-label="Settings scope"]').click();
-    await window.locator('[role="option"]', { hasText: "Project" }).click();
-    await window.waitForTimeout(T_SETTLE);
+    await test.step("Open settings and switch to Project scope", async () => {
+      await openSettings(window);
+      await expect(window.locator(SEL.settings.heading)).toBeVisible({ timeout: T_MEDIUM });
 
-    // Click Variables tab
-    await window.locator(`${SEL.settings.navSidebar} button`, { hasText: "Variables" }).click();
-
-    // The EnvironmentVariablesEditor heading should appear
-    await expect(window.locator("h3", { hasText: "Environment Variables" })).toBeVisible({
-      timeout: T_SHORT,
+      // Switch to Project scope (Radix Select)
+      await window.locator('[aria-label="Settings scope"]').click();
+      await window.locator('[role="option"]', { hasText: "Project" }).click();
+      await window.waitForTimeout(T_SETTLE);
     });
 
-    // Add Variable button should be visible. Two Environment Variables editors
-    // can render (one under Environment tab, one under Variables tab); check
-    // that at least one Add Variable button is present.
-    await expect(window.getByRole("button", { name: "Add Variable" }).first()).toBeVisible({
-      timeout: T_SHORT,
+    await test.step("Open Variables tab and verify editor renders", async () => {
+      await window.locator(`${SEL.settings.navSidebar} button`, { hasText: "Variables" }).click();
+
+      // The EnvironmentVariablesEditor heading should appear
+      await expect(window.locator("h3", { hasText: "Environment Variables" })).toBeVisible({
+        timeout: T_SHORT,
+      });
+
+      // Add Variable button should be visible. Two Environment Variables editors
+      // can render (one under Environment tab, one under Variables tab); check
+      // that at least one Add Variable button is present.
+      await expect(window.getByRole("button", { name: "Add Variable" }).first()).toBeVisible({
+        timeout: T_SHORT,
+      });
     });
 
-    await window.keyboard.press("Escape");
-    await expect(window.locator(SEL.settings.heading)).not.toBeVisible({ timeout: T_SHORT });
+    await test.step("Close settings dialog", async () => {
+      await window.keyboard.press("Escape");
+      await expect(window.locator(SEL.settings.heading)).not.toBeVisible({ timeout: T_SHORT });
+    });
   });
 
   // ── Project Settings: Resources tab loads ─────────────────
 
   test("Project Resources tab loads", async () => {
     const { window } = ctx;
-    await openSettings(window);
-    await expect(window.locator(SEL.settings.heading)).toBeVisible({ timeout: T_MEDIUM });
 
-    // Switch to Project scope (Radix Select)
-    await window.locator('[aria-label="Settings scope"]').click();
-    await window.locator('[role="option"]', { hasText: "Project" }).click();
-    await window.waitForTimeout(T_SETTLE);
+    await test.step("Open settings and switch to Project scope", async () => {
+      await openSettings(window);
+      await expect(window.locator(SEL.settings.heading)).toBeVisible({ timeout: T_MEDIUM });
 
-    // Click Worktree Setup tab (resources are now embedded here)
-    await window
-      .locator(`${SEL.settings.navSidebar} button`, { hasText: "Worktree Setup" })
-      .click();
-
-    // The Resource Environments heading should appear (scoped to the automation panel)
-    const automationPanel = window.locator("#settings-panel-project\\:automation");
-    await expect(automationPanel.locator("h2", { hasText: "Resource Environments" })).toBeVisible({
-      timeout: T_SHORT,
+      // Switch to Project scope (Radix Select)
+      await window.locator('[aria-label="Settings scope"]').click();
+      await window.locator('[role="option"]', { hasText: "Project" }).click();
+      await window.waitForTimeout(T_SETTLE);
     });
 
-    // Default Worktree Mode section should be visible (scoped to automation panel)
-    await expect(automationPanel.locator("text=Default Worktree Mode")).toBeVisible({
-      timeout: T_SHORT,
+    await test.step("Open Worktree Setup tab and verify Resource Environments", async () => {
+      await window
+        .locator(`${SEL.settings.navSidebar} button`, { hasText: "Worktree Setup" })
+        .click();
+
+      // The Resource Environments heading should appear (scoped to the automation panel)
+      const automationPanel = window.locator("#settings-panel-project\\:automation");
+      await expect(automationPanel.locator("h2", { hasText: "Resource Environments" })).toBeVisible(
+        {
+          timeout: T_SHORT,
+        }
+      );
+
+      // Default Worktree Mode section should be visible (scoped to automation panel)
+      await expect(automationPanel.locator("text=Default Worktree Mode")).toBeVisible({
+        timeout: T_SHORT,
+      });
     });
 
-    await window.keyboard.press("Escape");
-    await expect(window.locator(SEL.settings.heading)).not.toBeVisible({ timeout: T_SHORT });
+    await test.step("Close settings dialog", async () => {
+      await window.keyboard.press("Escape");
+      await expect(window.locator(SEL.settings.heading)).not.toBeVisible({ timeout: T_SHORT });
+    });
   });
 });

--- a/e2e/full/core-shell-settings.spec.ts
+++ b/e2e/full/core-shell-settings.spec.ts
@@ -175,14 +175,17 @@ test.describe.serial("Core: Shell & Settings", () => {
 
     test("Cmd+W closes remaining terminal", async () => {
       const { window } = ctx;
-      let before = 0;
+
+      // Skip-decision belongs outside test.step — calling test.skip() inside a
+      // step throws TestSkipError, which records the step as errored in trace
+      // rather than cleanly skipped.
+      let before = await getGridPanelCount(window);
+      if (before === 0) {
+        test.skip();
+        return;
+      }
 
       await test.step("Ensure at least 2 panels so Cmd+W doesn't quit the app", async () => {
-        before = await getGridPanelCount(window);
-        if (before === 0) {
-          test.skip();
-          return;
-        }
         if (before === 1) {
           await window.keyboard.press(`${mod}+Alt+t`);
           await expect.poll(() => getGridPanelCount(window), { timeout: T_LONG }).toBe(2);

--- a/e2e/full/core-shell-settings.spec.ts
+++ b/e2e/full/core-shell-settings.spec.ts
@@ -49,43 +49,48 @@ test.describe.serial("Core: Shell & Settings", () => {
 
     test("settings opens, navigates all tabs, closes via Escape", async () => {
       const { window } = ctx;
-
-      await openSettings(window);
-
       const heading = window.locator("h2", { hasText: "Settings" });
-      await expect(heading).toBeVisible({ timeout: T_MEDIUM });
 
-      const defaultTab = window.locator("h3", { hasText: "General" });
-      await expect(defaultTab).toBeVisible({ timeout: T_SHORT });
+      await test.step("Open settings and verify default General tab", async () => {
+        await openSettings(window);
 
-      // Verify all settings nav tabs are clickable and load their content
-      const navButtons = [
-        "Keyboard",
-        "Notifications",
-        "Panel Grid",
-        "Worktree",
-        "Toolbar",
-        "Appearance",
-        "CLI Agents",
-        "GitHub",
-        "Integrations",
-        "Portal",
-        "MCP Server",
-        "Privacy & Data",
-        "Environment",
-        "Troubleshooting",
-      ];
+        await expect(heading).toBeVisible({ timeout: T_MEDIUM });
 
-      for (const nav of navButtons) {
-        const btn = window.locator(`${SEL.settings.navSidebar} button`, { hasText: nav });
-        await expect(btn).toBeVisible({ timeout: T_SHORT });
-        await btn.click();
-        // Brief settle to confirm tab content loads without error
-        await window.waitForTimeout(200);
-      }
+        const defaultTab = window.locator("h3", { hasText: "General" });
+        await expect(defaultTab).toBeVisible({ timeout: T_SHORT });
+      });
 
-      await window.keyboard.press("Escape");
-      await expect(heading).not.toBeVisible({ timeout: T_SHORT });
+      await test.step("Cycle through all settings nav tabs and confirm each renders", async () => {
+        const navButtons = [
+          "Keyboard",
+          "Notifications",
+          "Panel Grid",
+          "Worktree",
+          "Toolbar",
+          "Appearance",
+          "CLI Agents",
+          "GitHub",
+          "Integrations",
+          "Portal",
+          "MCP Server",
+          "Privacy & Data",
+          "Environment",
+          "Troubleshooting",
+        ];
+
+        for (const nav of navButtons) {
+          const btn = window.locator(`${SEL.settings.navSidebar} button`, { hasText: nav });
+          await expect(btn).toBeVisible({ timeout: T_SHORT });
+          await btn.click();
+          // Brief settle to confirm tab content loads without error
+          await window.waitForTimeout(200);
+        }
+      });
+
+      await test.step("Close settings via Escape", async () => {
+        await window.keyboard.press("Escape");
+        await expect(heading).not.toBeVisible({ timeout: T_SHORT });
+      });
     });
   });
 
@@ -170,25 +175,29 @@ test.describe.serial("Core: Shell & Settings", () => {
 
     test("Cmd+W closes remaining terminal", async () => {
       const { window } = ctx;
+      let before = 0;
 
-      // Ensure at least 2 panels so Cmd+W doesn't close the last one (which quits the app)
-      let before = await getGridPanelCount(window);
-      if (before === 0) {
-        test.skip();
-        return;
-      }
-      if (before === 1) {
-        await window.keyboard.press(`${mod}+Alt+t`);
-        await expect.poll(() => getGridPanelCount(window), { timeout: T_LONG }).toBe(2);
-        before = 2;
-      }
+      await test.step("Ensure at least 2 panels so Cmd+W doesn't quit the app", async () => {
+        before = await getGridPanelCount(window);
+        if (before === 0) {
+          test.skip();
+          return;
+        }
+        if (before === 1) {
+          await window.keyboard.press(`${mod}+Alt+t`);
+          await expect.poll(() => getGridPanelCount(window), { timeout: T_LONG }).toBe(2);
+          before = 2;
+        }
+      });
 
-      const panel = window.locator(SEL.panel.gridPanel).first();
-      await panel.click();
-      await window.waitForTimeout(T_SETTLE);
+      await test.step("Focus first panel and dispatch Cmd+W to close it", async () => {
+        const panel = window.locator(SEL.panel.gridPanel).first();
+        await panel.click();
+        await window.waitForTimeout(T_SETTLE);
 
-      await window.keyboard.press(`${mod}+w`);
-      await expect.poll(() => getGridPanelCount(window), { timeout: T_MEDIUM }).toBe(before - 1);
+        await window.keyboard.press(`${mod}+w`);
+        await expect.poll(() => getGridPanelCount(window), { timeout: T_MEDIUM }).toBe(before - 1);
+      });
     });
   });
 
@@ -205,98 +214,118 @@ test.describe.serial("Core: Shell & Settings", () => {
     test("General tab: toggle Project Pulse off", async () => {
       const { window } = ctx;
 
-      const generalTab = window.locator(`${SEL.settings.navSidebar} button:has-text("General")`);
-      await generalTab.click();
+      await test.step("Navigate to General › Display subtab", async () => {
+        const generalTab = window.locator(`${SEL.settings.navSidebar} button:has-text("General")`);
+        await generalTab.click();
 
-      const displaySubtab = window.locator(
-        '#settings-panel-general button[role="tab"]:has-text("Display")'
-      );
-      await displaySubtab.click();
+        const displaySubtab = window.locator(
+          '#settings-panel-general button[role="tab"]:has-text("Display")'
+        );
+        await displaySubtab.click();
+      });
 
-      const toggle = window.locator(SEL.settings.projectPulseToggle);
-      await expect(toggle).toBeVisible({ timeout: T_MEDIUM });
-      await expect(toggle).toHaveAttribute("aria-checked", "true", { timeout: T_MEDIUM });
+      await test.step("Toggle Project Pulse off and verify state", async () => {
+        const toggle = window.locator(SEL.settings.projectPulseToggle);
+        await expect(toggle).toBeVisible({ timeout: T_MEDIUM });
+        await expect(toggle).toHaveAttribute("aria-checked", "true", { timeout: T_MEDIUM });
 
-      await toggle.click();
-      await expect(toggle).toHaveAttribute("aria-checked", "false", { timeout: T_MEDIUM });
+        await toggle.click();
+        await expect(toggle).toHaveAttribute("aria-checked", "false", { timeout: T_MEDIUM });
+      });
     });
 
     test("Terminal tab: toggle Performance Mode on", async () => {
       const { window } = ctx;
 
-      const terminalTab = window.locator(
-        `${SEL.settings.navSidebar} button:has-text("Panel Grid")`
-      );
-      await terminalTab.click();
+      await test.step("Navigate to Panel Grid tab", async () => {
+        const terminalTab = window.locator(
+          `${SEL.settings.navSidebar} button:has-text("Panel Grid")`
+        );
+        await terminalTab.click();
+      });
 
-      const toggle = window.locator(SEL.settings.performanceModeToggle);
-      await toggle.scrollIntoViewIfNeeded();
-      await expect(toggle).toBeVisible({ timeout: T_MEDIUM });
-      await expect(toggle).toHaveAttribute("aria-checked", "false", { timeout: T_MEDIUM });
+      await test.step("Toggle Performance Mode on and verify state", async () => {
+        const toggle = window.locator(SEL.settings.performanceModeToggle);
+        await toggle.scrollIntoViewIfNeeded();
+        await expect(toggle).toBeVisible({ timeout: T_MEDIUM });
+        await expect(toggle).toHaveAttribute("aria-checked", "false", { timeout: T_MEDIUM });
 
-      await toggle.click();
-      await expect(toggle).toHaveAttribute("aria-checked", "true", { timeout: T_MEDIUM });
+        await toggle.click();
+        await expect(toggle).toHaveAttribute("aria-checked", "true", { timeout: T_MEDIUM });
+      });
     });
 
     test("Appearance tab: change font family", async () => {
       const { window } = ctx;
 
-      const appearanceTab = window.locator(
-        `${SEL.settings.navSidebar} button:has-text("Appearance")`
-      );
-      await appearanceTab.click();
+      await test.step("Navigate to Appearance › Terminal subtab", async () => {
+        const appearanceTab = window.locator(
+          `${SEL.settings.navSidebar} button:has-text("Appearance")`
+        );
+        await appearanceTab.click();
 
-      const terminalSubtab = window.locator(
-        '#settings-panel-terminalAppearance button[role="tab"]:has-text("Terminal")'
-      );
-      await terminalSubtab.click();
+        const terminalSubtab = window.locator(
+          '#settings-panel-terminalAppearance button[role="tab"]:has-text("Terminal")'
+        );
+        await terminalSubtab.click();
+      });
 
-      const fontSelect = window.locator(SEL.settings.fontFamilySelect);
-      await expect(fontSelect).toBeVisible({ timeout: T_MEDIUM });
-      await expect(fontSelect).toContainText("JetBrains Mono", { timeout: T_MEDIUM });
+      await test.step("Change font family from JetBrains Mono to System monospace", async () => {
+        const fontSelect = window.locator(SEL.settings.fontFamilySelect);
+        await expect(fontSelect).toBeVisible({ timeout: T_MEDIUM });
+        await expect(fontSelect).toContainText("JetBrains Mono", { timeout: T_MEDIUM });
 
-      await fontSelect.click();
-      await window.locator('[role="option"]', { hasText: "System monospace" }).click();
-      await expect(fontSelect).toContainText("System monospace", { timeout: T_MEDIUM });
+        await fontSelect.click();
+        await window.locator('[role="option"]', { hasText: "System monospace" }).click();
+        await expect(fontSelect).toContainText("System monospace", { timeout: T_MEDIUM });
+      });
     });
 
     test("close and reopen settings — changes persist", async () => {
       const { window } = ctx;
-
-      await window.keyboard.press("Escape");
       const heading = window.locator(SEL.settings.heading);
-      await expect(heading).not.toBeVisible({ timeout: T_SHORT });
 
-      await openSettings(window);
-      await expect(heading).toBeVisible({ timeout: T_MEDIUM });
+      await test.step("Close and reopen settings dialog", async () => {
+        await window.keyboard.press("Escape");
+        await expect(heading).not.toBeVisible({ timeout: T_SHORT });
 
-      const generalTab = window.locator(`${SEL.settings.navSidebar} button:has-text("General")`);
-      await generalTab.click();
-      const displaySubtab = window.locator(
-        '#settings-panel-general button[role="tab"]:has-text("Display")'
-      );
-      await displaySubtab.click();
-      const pulseToggle = window.locator(SEL.settings.projectPulseToggle);
-      await expect(pulseToggle).toHaveAttribute("aria-checked", "false", { timeout: T_MEDIUM });
+        await openSettings(window);
+        await expect(heading).toBeVisible({ timeout: T_MEDIUM });
+      });
 
-      const terminalTab = window.locator(
-        `${SEL.settings.navSidebar} button:has-text("Panel Grid")`
-      );
-      await terminalTab.click();
-      const perfToggle = window.locator(SEL.settings.performanceModeToggle);
-      await perfToggle.scrollIntoViewIfNeeded();
-      await expect(perfToggle).toHaveAttribute("aria-checked", "true", { timeout: T_MEDIUM });
+      await test.step("Verify Project Pulse remained off", async () => {
+        const generalTab = window.locator(`${SEL.settings.navSidebar} button:has-text("General")`);
+        await generalTab.click();
+        const displaySubtab = window.locator(
+          '#settings-panel-general button[role="tab"]:has-text("Display")'
+        );
+        await displaySubtab.click();
+        const pulseToggle = window.locator(SEL.settings.projectPulseToggle);
+        await expect(pulseToggle).toHaveAttribute("aria-checked", "false", { timeout: T_MEDIUM });
+      });
 
-      const appearanceTab = window.locator(
-        `${SEL.settings.navSidebar} button:has-text("Appearance")`
-      );
-      await appearanceTab.click();
-      const terminalSubtab = window.locator(
-        '#settings-panel-terminalAppearance button[role="tab"]:has-text("Terminal")'
-      );
-      await terminalSubtab.click();
-      const fontSelect = window.locator(SEL.settings.fontFamilySelect);
-      await expect(fontSelect).toContainText("System monospace", { timeout: T_MEDIUM });
+      await test.step("Verify Performance Mode remained on", async () => {
+        const terminalTab = window.locator(
+          `${SEL.settings.navSidebar} button:has-text("Panel Grid")`
+        );
+        await terminalTab.click();
+        const perfToggle = window.locator(SEL.settings.performanceModeToggle);
+        await perfToggle.scrollIntoViewIfNeeded();
+        await expect(perfToggle).toHaveAttribute("aria-checked", "true", { timeout: T_MEDIUM });
+      });
+
+      await test.step("Verify font family remained System monospace", async () => {
+        const appearanceTab = window.locator(
+          `${SEL.settings.navSidebar} button:has-text("Appearance")`
+        );
+        await appearanceTab.click();
+        const terminalSubtab = window.locator(
+          '#settings-panel-terminalAppearance button[role="tab"]:has-text("Terminal")'
+        );
+        await terminalSubtab.click();
+        const fontSelect = window.locator(SEL.settings.fontFamilySelect);
+        await expect(fontSelect).toContainText("System monospace", { timeout: T_MEDIUM });
+      });
 
       await window.keyboard.press("Escape");
     });
@@ -308,22 +337,26 @@ test.describe.serial("Core: Shell & Settings", () => {
     test("open project settings via project switcher", async () => {
       const { window } = ctx;
 
-      await window.locator(SEL.toolbar.projectSwitcherTrigger).click();
+      await test.step("Open project switcher and click Project Settings", async () => {
+        await window.locator(SEL.toolbar.projectSwitcherTrigger).click();
 
-      const palette = window.locator(SEL.projectSwitcher.palette);
-      await expect(palette).toBeVisible({ timeout: T_MEDIUM });
+        const palette = window.locator(SEL.projectSwitcher.palette);
+        await expect(palette).toBeVisible({ timeout: T_MEDIUM });
 
-      const settingsBtn = palette.locator("button", { hasText: /Project Settings/ });
-      await expect(settingsBtn).toBeVisible({ timeout: T_SHORT });
-      await settingsBtn.click();
+        const settingsBtn = palette.locator("button", { hasText: /Project Settings/ });
+        await expect(settingsBtn).toBeVisible({ timeout: T_SHORT });
+        await settingsBtn.click();
+      });
 
-      // Settings dialog opens in project scope
-      const heading = window.locator('h2:has-text("Settings")');
-      await expect(heading).toBeVisible({ timeout: T_MEDIUM });
+      await test.step("Verify settings opens in project scope", async () => {
+        // Settings dialog opens in project scope
+        const heading = window.locator('h2:has-text("Settings")');
+        await expect(heading).toBeVisible({ timeout: T_MEDIUM });
 
-      // Verify project scope is selected
-      const scopeTrigger = window.locator('[aria-label="Settings scope"]');
-      await expect(scopeTrigger).toContainText("Project", { timeout: T_SHORT });
+        // Verify project scope is selected
+        const scopeTrigger = window.locator('[aria-label="Settings scope"]');
+        await expect(scopeTrigger).toContainText("Project", { timeout: T_SHORT });
+      });
     });
 
     test("project name is displayed", async () => {

--- a/e2e/full/core-terminal-layout-operations.spec.ts
+++ b/e2e/full/core-terminal-layout-operations.spec.ts
@@ -102,33 +102,41 @@ test.describe.serial("Core: Terminal Layout Operations", () => {
   test.describe.serial("Layout Undo/Redo", () => {
     test("undo restores previous panel order", async () => {
       const { window } = ctx;
+      let idsBefore: string[] = [];
 
-      const idsBefore = await getGridPanelIds(window);
-      await focusPanel(window, idsBefore[0]);
-      await dispatchAction(window, "terminal.moveRight");
+      await test.step("Move first panel right and verify reorder", async () => {
+        idsBefore = await getGridPanelIds(window);
+        await focusPanel(window, idsBefore[0]);
+        await dispatchAction(window, "terminal.moveRight");
 
-      await expect
-        .poll(() => getGridPanelIds(window), { timeout: T_MEDIUM })
-        .toEqual([idsBefore[1], idsBefore[0], idsBefore[2]]);
+        await expect
+          .poll(() => getGridPanelIds(window), { timeout: T_MEDIUM })
+          .toEqual([idsBefore[1], idsBefore[0], idsBefore[2]]);
+      });
 
-      await dispatchAction(window, "layout.undo");
-
-      await expect.poll(() => getGridPanelIds(window), { timeout: T_MEDIUM }).toEqual(idsBefore);
+      await test.step("Dispatch layout.undo and verify original order is restored", async () => {
+        await dispatchAction(window, "layout.undo");
+        await expect.poll(() => getGridPanelIds(window), { timeout: T_MEDIUM }).toEqual(idsBefore);
+      });
     });
 
     test("redo re-applies the layout change", async () => {
       const { window } = ctx;
+      let idsBefore: string[] = [];
 
-      const idsBefore = await getGridPanelIds(window);
-      await dispatchAction(window, "layout.redo");
+      await test.step("Dispatch layout.redo and verify reorder reapplies", async () => {
+        idsBefore = await getGridPanelIds(window);
+        await dispatchAction(window, "layout.redo");
 
-      await expect
-        .poll(() => getGridPanelIds(window), { timeout: T_MEDIUM })
-        .toEqual([idsBefore[1], idsBefore[0], idsBefore[2]]);
+        await expect
+          .poll(() => getGridPanelIds(window), { timeout: T_MEDIUM })
+          .toEqual([idsBefore[1], idsBefore[0], idsBefore[2]]);
+      });
 
-      // Undo to restore original order for subsequent tests
-      await dispatchAction(window, "layout.undo");
-      await expect.poll(() => getGridPanelIds(window), { timeout: T_MEDIUM }).toEqual(idsBefore);
+      await test.step("Undo back to original order for subsequent tests", async () => {
+        await dispatchAction(window, "layout.undo");
+        await expect.poll(() => getGridPanelIds(window), { timeout: T_MEDIUM }).toEqual(idsBefore);
+      });
     });
   });
 
@@ -207,77 +215,94 @@ test.describe.serial("Core: Terminal Layout Operations", () => {
 
     test("dock preview opens and restores while grid remains active", async () => {
       const { window } = ctx;
+      let dockedId = "";
 
-      const gridIds = await getGridPanelIds(window);
-      expect(gridIds.length).toBeGreaterThanOrEqual(3);
-      const dockedId = gridIds[0]!;
+      await test.step("Move first grid panel to dock and verify counts", async () => {
+        const gridIds = await getGridPanelIds(window);
+        expect(gridIds.length).toBeGreaterThanOrEqual(3);
+        dockedId = gridIds[0]!;
 
-      await dispatchAction(window, "terminal.moveToDock", { terminalId: dockedId });
+        await dispatchAction(window, "terminal.moveToDock", { terminalId: dockedId });
 
-      await expect.poll(() => getGridPanelCount(window), { timeout: T_MEDIUM }).toBe(2);
-      await expect.poll(() => getDockPanelCount(window), { timeout: T_MEDIUM }).toBe(1);
-      await expect(window.locator(`[data-dock-portal-target="${dockedId}"]`)).toBeVisible({
-        timeout: T_MEDIUM,
+        await expect.poll(() => getGridPanelCount(window), { timeout: T_MEDIUM }).toBe(2);
+        await expect.poll(() => getDockPanelCount(window), { timeout: T_MEDIUM }).toBe(1);
+        await expect(window.locator(`[data-dock-portal-target="${dockedId}"]`)).toBeVisible({
+          timeout: T_MEDIUM,
+        });
       });
 
-      await dispatchAction(window, "terminal.moveToGrid", { terminalId: dockedId });
+      await test.step("Move docked panel back to grid and verify restoration", async () => {
+        await dispatchAction(window, "terminal.moveToGrid", { terminalId: dockedId });
 
-      await expect.poll(() => getGridPanelCount(window), { timeout: T_MEDIUM }).toBe(3);
-      await expect.poll(() => getDockPanelCount(window), { timeout: T_MEDIUM }).toBe(0);
-      await expect
-        .poll(() => getDockPanelIds(window), { timeout: T_MEDIUM })
-        .not.toContain(dockedId);
+        await expect.poll(() => getGridPanelCount(window), { timeout: T_MEDIUM }).toBe(3);
+        await expect.poll(() => getDockPanelCount(window), { timeout: T_MEDIUM }).toBe(0);
+        await expect
+          .poll(() => getDockPanelIds(window), { timeout: T_MEDIUM })
+          .not.toContain(dockedId);
+      });
     });
 
     test("creating a new dock terminal while another panel is docked keeps both rendered", async () => {
       const { window } = ctx;
+      let dockedId = "";
+      let newDockId = "";
 
-      const gridIds = await getGridPanelIds(window);
-      expect(gridIds.length).toBeGreaterThanOrEqual(3);
-      const dockedId = gridIds[0]!;
+      await test.step("Dock first grid panel as the existing docked terminal", async () => {
+        const gridIds = await getGridPanelIds(window);
+        expect(gridIds.length).toBeGreaterThanOrEqual(3);
+        dockedId = gridIds[0]!;
 
-      await dispatchAction(window, "terminal.moveToDock", { terminalId: dockedId });
-      await expect.poll(() => getDockPanelCount(window), { timeout: T_MEDIUM }).toBe(1);
+        await dispatchAction(window, "terminal.moveToDock", { terminalId: dockedId });
+        await expect.poll(() => getDockPanelCount(window), { timeout: T_MEDIUM }).toBe(1);
+      });
 
-      const launchResult = (await dispatchAction(window, "agent.launch", {
-        agentId: "terminal",
-        location: "dock",
-        cwd: fixtureDir,
-      })) as { ok?: boolean; result?: { terminalId?: string | null } };
-      expect(launchResult.ok).toBe(true);
-      const newDockId = launchResult.result?.terminalId ?? "";
-      expect(newDockId).not.toBe("");
+      await test.step("Launch a new dock terminal and verify both ids appear", async () => {
+        const launchResult = (await dispatchAction(window, "agent.launch", {
+          agentId: "terminal",
+          location: "dock",
+          cwd: fixtureDir,
+        })) as { ok?: boolean; result?: { terminalId?: string | null } };
+        expect(launchResult.ok).toBe(true);
+        newDockId = launchResult.result?.terminalId ?? "";
+        expect(newDockId).not.toBe("");
 
-      await expect
-        .poll(() => getDockPanelIds(window), { timeout: T_MEDIUM })
-        .toEqual(expect.arrayContaining([dockedId, newDockId]));
+        await expect
+          .poll(() => getDockPanelIds(window), { timeout: T_MEDIUM })
+          .toEqual(expect.arrayContaining([dockedId, newDockId]));
+      });
 
-      await dispatchAction(
-        window,
-        "terminal.kill",
-        { terminalId: newDockId },
-        { source: "user", confirmed: true }
-      );
-      await dispatchAction(window, "terminal.moveToGrid", { terminalId: dockedId });
+      await test.step("Kill the new dock terminal and restore the original docked panel to grid", async () => {
+        await dispatchAction(
+          window,
+          "terminal.kill",
+          { terminalId: newDockId },
+          { source: "user", confirmed: true }
+        );
+        await dispatchAction(window, "terminal.moveToGrid", { terminalId: dockedId });
 
-      await expect.poll(() => getGridPanelCount(window), { timeout: T_MEDIUM }).toBe(3);
-      await expect.poll(() => getDockPanelCount(window), { timeout: T_MEDIUM }).toBe(0);
+        await expect.poll(() => getGridPanelCount(window), { timeout: T_MEDIUM }).toBe(3);
+        await expect.poll(() => getDockPanelCount(window), { timeout: T_MEDIUM }).toBe(0);
+      });
     });
 
     test("move all panels to dock", async () => {
       const { window } = ctx;
 
-      const gridIds = await getGridPanelIds(window);
-      for (const id of gridIds) {
-        await dispatchAction(window, "terminal.moveToDock", { terminalId: id });
-        await window.waitForTimeout(T_SETTLE);
-      }
+      await test.step("Move every grid panel to dock", async () => {
+        const gridIds = await getGridPanelIds(window);
+        for (const id of gridIds) {
+          await dispatchAction(window, "terminal.moveToDock", { terminalId: id });
+          await window.waitForTimeout(T_SETTLE);
+        }
+      });
 
-      await expect.poll(() => getGridPanelCount(window), { timeout: T_MEDIUM }).toBe(0);
-      await expect.poll(() => getDockPanelCount(window), { timeout: T_MEDIUM }).toBe(3);
+      await test.step("Verify grid is empty and dock holds all 3 panels", async () => {
+        await expect.poll(() => getGridPanelCount(window), { timeout: T_MEDIUM }).toBe(0);
+        await expect.poll(() => getDockPanelCount(window), { timeout: T_MEDIUM }).toBe(3);
 
-      dockIds = await getDockPanelIds(window);
-      expect(dockIds).toHaveLength(3);
+        dockIds = await getDockPanelIds(window);
+        expect(dockIds).toHaveLength(3);
+      });
     });
 
     // Emptying the grid triggers the app to close the project view and show

--- a/e2e/full/core-terminal-search.spec.ts
+++ b/e2e/full/core-terminal-search.spec.ts
@@ -140,169 +140,166 @@ test.describe.serial("Core: Terminal Search & Scrollback", () => {
     test("case sensitivity toggle changes search behavior", async () => {
       const { window } = ctx;
       const panel = getFirstGridPanel(window);
-
-      // Open search
-      await panel.locator(SEL.terminal.xtermRows).click();
-      await window.waitForTimeout(T_SETTLE);
-      await window.evaluate(() => window.dispatchEvent(new CustomEvent("daintree:find-in-panel")));
       const input = panel.locator(SEL.terminal.searchInput);
-      await expect(input).toBeVisible({ timeout: T_MEDIUM });
-
       const caseToggle = panel.locator(SEL.terminal.searchCaseToggle);
 
-      // Default: case insensitive (aria-pressed=false)
-      await expect(caseToggle).toHaveAttribute("aria-pressed", "false");
+      await test.step("Open search bar in focused terminal", async () => {
+        await panel.locator(SEL.terminal.xtermRows).click();
+        await window.waitForTimeout(T_SETTLE);
+        await window.evaluate(() =>
+          window.dispatchEvent(new CustomEvent("daintree:find-in-panel"))
+        );
+        await expect(input).toBeVisible({ timeout: T_MEDIUM });
 
-      // Search lowercase variant — case-insensitive finds CaseMark_Upper
-      await input.fill("casemark_upper");
-      await window.waitForTimeout(T_SETTLE);
-      await expect(panel.locator(SEL.terminal.searchStatus)).toHaveText(
-        /^(?:\d+ of \d+\+?|\d+\+? matches|Found)$/,
-        {
-          timeout: T_SHORT,
-        }
-      );
-
-      // Toggle case ON
-      await caseToggle.click();
-      await expect(caseToggle).toHaveAttribute("aria-pressed", "true");
-
-      // Case-sensitive: lowercase "casemark_upper" should not match "CaseMark_Upper"
-      await window.waitForTimeout(T_SETTLE);
-      await expect(panel.locator(SEL.terminal.searchStatus)).toHaveText("No matches", {
-        timeout: T_SHORT,
+        // Default: case insensitive (aria-pressed=false)
+        await expect(caseToggle).toHaveAttribute("aria-pressed", "false");
       });
 
-      // Exact case match should still work
-      await input.fill("CaseMark_Upper");
-      await window.waitForTimeout(T_SETTLE);
-      await expect(panel.locator(SEL.terminal.searchStatus)).toHaveText(
-        /^(?:\d+ of \d+\+?|\d+\+? matches|Found)$/,
-        {
-          timeout: T_SHORT,
-        }
-      );
+      await test.step("Case-insensitive search matches mixed-case text", async () => {
+        // Search lowercase variant — case-insensitive finds CaseMark_Upper
+        await input.fill("casemark_upper");
+        await window.waitForTimeout(T_SETTLE);
+        await expect(panel.locator(SEL.terminal.searchStatus)).toHaveText(
+          /^(?:\d+ of \d+\+?|\d+\+? matches|Found)$/,
+          { timeout: T_SHORT }
+        );
+      });
 
-      // Toggle case OFF and close
-      await caseToggle.click();
-      await expect(caseToggle).toHaveAttribute("aria-pressed", "false");
-      await window.keyboard.press("Escape");
-      await expect(input).not.toBeVisible({ timeout: T_SHORT });
+      await test.step("Enable case-sensitive mode and verify lowercase no longer matches", async () => {
+        await caseToggle.click();
+        await expect(caseToggle).toHaveAttribute("aria-pressed", "true");
+
+        // Case-sensitive: lowercase "casemark_upper" should not match "CaseMark_Upper"
+        await window.waitForTimeout(T_SETTLE);
+        await expect(panel.locator(SEL.terminal.searchStatus)).toHaveText("No matches", {
+          timeout: T_SHORT,
+        });
+      });
+
+      await test.step("Exact-case query still matches with case-sensitive mode on", async () => {
+        await input.fill("CaseMark_Upper");
+        await window.waitForTimeout(T_SETTLE);
+        await expect(panel.locator(SEL.terminal.searchStatus)).toHaveText(
+          /^(?:\d+ of \d+\+?|\d+\+? matches|Found)$/,
+          { timeout: T_SHORT }
+        );
+      });
+
+      await test.step("Disable case-sensitive mode and close search", async () => {
+        await caseToggle.click();
+        await expect(caseToggle).toHaveAttribute("aria-pressed", "false");
+        await window.keyboard.press("Escape");
+        await expect(input).not.toBeVisible({ timeout: T_SHORT });
+      });
     });
 
     test("regex toggle matches patterns and detects invalid regex", async () => {
       const { window } = ctx;
       const panel = getFirstGridPanel(window);
-
-      // Open search
-      await panel.locator(SEL.terminal.xtermRows).click();
-      await window.waitForTimeout(T_SETTLE);
-      await window.evaluate(() => window.dispatchEvent(new CustomEvent("daintree:find-in-panel")));
       const input = panel.locator(SEL.terminal.searchInput);
-      await expect(input).toBeVisible({ timeout: T_MEDIUM });
-
       const regexToggle = panel.locator(SEL.terminal.searchRegexToggle);
 
-      // Default: regex off
-      await expect(regexToggle).toHaveAttribute("aria-pressed", "false");
+      await test.step("Open search bar in focused terminal", async () => {
+        await panel.locator(SEL.terminal.xtermRows).click();
+        await window.waitForTimeout(T_SETTLE);
+        await window.evaluate(() =>
+          window.dispatchEvent(new CustomEvent("daintree:find-in-panel"))
+        );
+        await expect(input).toBeVisible({ timeout: T_MEDIUM });
 
-      // Enable regex
-      await regexToggle.click();
-      await expect(regexToggle).toHaveAttribute("aria-pressed", "true");
+        // Default: regex off
+        await expect(regexToggle).toHaveAttribute("aria-pressed", "false");
+      });
 
-      // Regex pattern matches item1_found, item2_found, item3_found
-      await input.fill("item\\d+_found");
-      await window.waitForTimeout(T_SETTLE);
-      await expect(panel.locator(SEL.terminal.searchStatus)).toHaveText(
-        /^(?:\d+ of \d+\+?|\d+\+? matches|Found)$/,
-        {
+      await test.step("Enable regex and verify pattern matches", async () => {
+        await regexToggle.click();
+        await expect(regexToggle).toHaveAttribute("aria-pressed", "true");
+
+        // Regex pattern matches item1_found, item2_found, item3_found
+        await input.fill("item\\d+_found");
+        await window.waitForTimeout(T_SETTLE);
+        await expect(panel.locator(SEL.terminal.searchStatus)).toHaveText(
+          /^(?:\d+ of \d+\+?|\d+\+? matches|Found)$/,
+          { timeout: T_SHORT }
+        );
+      });
+
+      await test.step("Disable regex and verify literal pattern no longer matches", async () => {
+        await regexToggle.click();
+        await expect(regexToggle).toHaveAttribute("aria-pressed", "false");
+        await window.waitForTimeout(T_SETTLE);
+        await expect(panel.locator(SEL.terminal.searchStatus)).toHaveText("No matches", {
           timeout: T_SHORT,
-        }
-      );
-
-      // Disable regex — literal "item\d+_found" doesn't exist
-      await regexToggle.click();
-      await expect(regexToggle).toHaveAttribute("aria-pressed", "false");
-      await window.waitForTimeout(T_SETTLE);
-      await expect(panel.locator(SEL.terminal.searchStatus)).toHaveText("No matches", {
-        timeout: T_SHORT,
+        });
       });
 
-      // Re-enable regex for invalid regex test
-      await regexToggle.click();
-      await input.fill("[broken");
-      await window.waitForTimeout(T_SETTLE);
-      await expect(panel.locator(SEL.terminal.searchStatus)).toHaveText("Invalid regex", {
-        timeout: T_SHORT,
+      await test.step("Re-enable regex with invalid pattern and verify error status", async () => {
+        await regexToggle.click();
+        await input.fill("[broken");
+        await window.waitForTimeout(T_SETTLE);
+        await expect(panel.locator(SEL.terminal.searchStatus)).toHaveText("Invalid regex", {
+          timeout: T_SHORT,
+        });
       });
 
-      // Clean up: disable regex and close
-      await regexToggle.click();
-      await window.keyboard.press("Escape");
-      await expect(input).not.toBeVisible({ timeout: T_SHORT });
+      await test.step("Disable regex and close search", async () => {
+        await regexToggle.click();
+        await window.keyboard.press("Escape");
+        await expect(input).not.toBeVisible({ timeout: T_SHORT });
+      });
     });
 
     test("next and previous buttons cycle through matches", async () => {
       const { window } = ctx;
       const panel = getFirstGridPanel(window);
-
-      // Open search
-      await panel.locator(SEL.terminal.xtermRows).click();
-      await window.waitForTimeout(T_SETTLE);
-      await window.evaluate(() => window.dispatchEvent(new CustomEvent("daintree:find-in-panel")));
       const input = panel.locator(SEL.terminal.searchInput);
-      await expect(input).toBeVisible({ timeout: T_MEDIUM });
-
-      // Search for a term with multiple matches
-      await input.fill("item");
-      await window.waitForTimeout(T_SETTLE);
-      await expect(panel.locator(SEL.terminal.searchStatus)).toHaveText(
-        /^(?:\d+ of \d+\+?|\d+\+? matches|Found)$/,
-        {
-          timeout: T_SHORT,
-        }
-      );
-
-      // Click Next multiple times — status stays "Found"
       const nextBtn = panel.locator(SEL.terminal.searchNext);
       const prevBtn = panel.locator(SEL.terminal.searchPrevious);
+      const foundRegex = /^(?:\d+ of \d+\+?|\d+\+? matches|Found)$/;
 
-      await nextBtn.click();
-      await expect(panel.locator(SEL.terminal.searchStatus)).toHaveText(
-        /^(?:\d+ of \d+\+?|\d+\+? matches|Found)$/,
-        {
+      await test.step("Open search bar and seed query with multiple matches", async () => {
+        await panel.locator(SEL.terminal.xtermRows).click();
+        await window.waitForTimeout(T_SETTLE);
+        await window.evaluate(() =>
+          window.dispatchEvent(new CustomEvent("daintree:find-in-panel"))
+        );
+        await expect(input).toBeVisible({ timeout: T_MEDIUM });
+
+        await input.fill("item");
+        await window.waitForTimeout(T_SETTLE);
+        await expect(panel.locator(SEL.terminal.searchStatus)).toHaveText(foundRegex, {
           timeout: T_SHORT,
-        }
-      );
+        });
+      });
 
-      await nextBtn.click();
-      await expect(panel.locator(SEL.terminal.searchStatus)).toHaveText(
-        /^(?:\d+ of \d+\+?|\d+\+? matches|Found)$/,
-        {
+      await test.step("Click Next twice and verify status remains Found", async () => {
+        await nextBtn.click();
+        await expect(panel.locator(SEL.terminal.searchStatus)).toHaveText(foundRegex, {
           timeout: T_SHORT,
-        }
-      );
+        });
 
-      // Click Previous — status stays "Found"
-      await prevBtn.click();
-      await expect(panel.locator(SEL.terminal.searchStatus)).toHaveText(
-        /^(?:\d+ of \d+\+?|\d+\+? matches|Found)$/,
-        {
+        await nextBtn.click();
+        await expect(panel.locator(SEL.terminal.searchStatus)).toHaveText(foundRegex, {
           timeout: T_SHORT,
-        }
-      );
+        });
+      });
 
-      await prevBtn.click();
-      await expect(panel.locator(SEL.terminal.searchStatus)).toHaveText(
-        /^(?:\d+ of \d+\+?|\d+\+? matches|Found)$/,
-        {
+      await test.step("Click Previous twice and verify status remains Found", async () => {
+        await prevBtn.click();
+        await expect(panel.locator(SEL.terminal.searchStatus)).toHaveText(foundRegex, {
           timeout: T_SHORT,
-        }
-      );
+        });
 
-      // Close search
-      await window.keyboard.press("Escape");
-      await expect(input).not.toBeVisible({ timeout: T_SHORT });
+        await prevBtn.click();
+        await expect(panel.locator(SEL.terminal.searchStatus)).toHaveText(foundRegex, {
+          timeout: T_SHORT,
+        });
+      });
+
+      await test.step("Close search via Escape", async () => {
+        await window.keyboard.press("Escape");
+        await expect(input).not.toBeVisible({ timeout: T_SHORT });
+      });
     });
   });
 

--- a/e2e/full/core-worktree-cards.spec.ts
+++ b/e2e/full/core-worktree-cards.spec.ts
@@ -125,54 +125,65 @@ test.describe.serial("Core: Worktree Cards", () => {
   test.describe.serial("Actions Menu", () => {
     test("actions menu opens and shows expected items", async () => {
       const { window } = ctx;
-
-      // Switch to feature card first — it has the richest menu (Pin, Delete)
       const featureCard = window.locator(SEL.worktree.card(FEATURE));
-      await featureCard.click({ position: { x: 10, y: 10 } });
-      await expect
-        .poll(() => featureCard.getAttribute("aria-label"), { timeout: T_LONG })
-        .toContain("selected");
 
-      const actionsBtn = featureCard.locator(SEL.worktree.actionsMenu);
-      await actionsBtn.click();
+      await test.step("Select feature card and open its actions menu", async () => {
+        // Switch to feature card first — it has the richest menu (Pin, Delete)
+        await featureCard.click({ position: { x: 10, y: 10 } });
+        await expect
+          .poll(() => featureCard.getAttribute("aria-label"), { timeout: T_LONG })
+          .toContain("selected");
 
-      // Verify top-level items/submenus are visible
-      await expect(window.getByRole("menuitem", { name: "Launch" })).toBeVisible({
-        timeout: T_SHORT,
+        const actionsBtn = featureCard.locator(SEL.worktree.actionsMenu);
+        await actionsBtn.click();
       });
-      await expect(window.getByRole("menuitem", { name: "Sessions" })).toBeVisible();
-      await expect(window.getByRole("menuitem", { name: "Open in Editor" })).toBeVisible();
-      await expect(window.getByRole("menuitem", { name: "Reveal in Finder" })).toBeVisible();
 
-      // Feature-only items (not shown on main worktree card)
-      await expect(window.getByRole("menuitem", { name: "Pin to Top" })).toBeVisible();
-      await expect(window.getByRole("menuitem", { name: /Delete Worktree/i })).toBeVisible();
+      await test.step("Verify expected menu items are visible", async () => {
+        await expect(window.getByRole("menuitem", { name: "Launch" })).toBeVisible({
+          timeout: T_SHORT,
+        });
+        await expect(window.getByRole("menuitem", { name: "Sessions" })).toBeVisible();
+        await expect(window.getByRole("menuitem", { name: "Open in Editor" })).toBeVisible();
+        await expect(window.getByRole("menuitem", { name: "Reveal in Finder" })).toBeVisible();
 
-      // Close the menu
-      await window.keyboard.press("Escape");
-      await expect(window.locator('[role="menu"]')).toHaveCount(0, { timeout: T_SHORT });
+        // Feature-only items (not shown on main worktree card)
+        await expect(window.getByRole("menuitem", { name: "Pin to Top" })).toBeVisible();
+        await expect(window.getByRole("menuitem", { name: /Delete Worktree/i })).toBeVisible();
+      });
+
+      await test.step("Close the menu via Escape", async () => {
+        await window.keyboard.press("Escape");
+        await expect(window.locator('[role="menu"]')).toHaveCount(0, { timeout: T_SHORT });
+      });
     });
 
     test("Launch submenu opens on hover and Open Terminal creates a panel", async () => {
       const { window } = ctx;
-
-      const panelsBefore = await getGridPanelCount(window);
-
+      let panelsBefore = 0;
       const featureCard = window.locator(SEL.worktree.card(FEATURE));
-      const actionsBtn = featureCard.locator(SEL.worktree.actionsMenu);
-      await actionsBtn.click();
 
-      const launchTrigger = window.getByRole("menuitem", { name: "Launch" });
-      await expect(launchTrigger).toBeVisible({ timeout: T_SHORT });
-      await launchTrigger.hover();
+      await test.step("Capture panel count and open actions menu", async () => {
+        panelsBefore = await getGridPanelCount(window);
 
-      const openTerminal = window.getByRole("menuitem", { name: "Open Terminal" });
-      await expect(openTerminal).toBeVisible({ timeout: T_SHORT });
-      await openTerminal.click();
+        const actionsBtn = featureCard.locator(SEL.worktree.actionsMenu);
+        await actionsBtn.click();
+      });
 
-      await expect
-        .poll(() => getGridPanelCount(window), { timeout: T_LONG })
-        .toBe(panelsBefore + 1);
+      await test.step("Hover Launch submenu and click Open Terminal", async () => {
+        const launchTrigger = window.getByRole("menuitem", { name: "Launch" });
+        await expect(launchTrigger).toBeVisible({ timeout: T_SHORT });
+        await launchTrigger.hover();
+
+        const openTerminal = window.getByRole("menuitem", { name: "Open Terminal" });
+        await expect(openTerminal).toBeVisible({ timeout: T_SHORT });
+        await openTerminal.click();
+      });
+
+      await test.step("Verify panel count increased by one", async () => {
+        await expect
+          .poll(() => getGridPanelCount(window), { timeout: T_LONG })
+          .toBe(panelsBefore + 1);
+      });
     });
 
     test("Escape dismisses the menu without side effects", async () => {
@@ -204,36 +215,40 @@ test.describe.serial("Core: Worktree Cards", () => {
   test.describe.serial("Panel Isolation", () => {
     test("switching worktrees isolates grid panels", async () => {
       const { window } = ctx;
-
-      // Feature card should have at least 1 panel from the Open Terminal test
       const featureCard = window.locator(SEL.worktree.card(FEATURE));
-      await featureCard.click({ position: { x: 10, y: 10 } });
-      await expect
-        .poll(() => featureCard.getAttribute("aria-label"), { timeout: T_LONG })
-        .toContain("selected");
-
-      await expect
-        .poll(() => getGridPanelCount(window), { timeout: T_LONG })
-        .toBeGreaterThanOrEqual(1);
-
-      // Switch to main — should have 0 panels
       const mainCard = window.locator(SEL.worktree.mainCard);
-      await mainCard.click({ position: { x: 10, y: 10 } });
-      await expect
-        .poll(() => mainCard.getAttribute("aria-label"), { timeout: T_LONG })
-        .toContain("selected");
 
-      await expect.poll(() => getGridPanelCount(window), { timeout: T_LONG }).toBe(0);
+      await test.step("Select feature worktree and confirm panels are present", async () => {
+        // Feature card should have at least 1 panel from the Open Terminal test
+        await featureCard.click({ position: { x: 10, y: 10 } });
+        await expect
+          .poll(() => featureCard.getAttribute("aria-label"), { timeout: T_LONG })
+          .toContain("selected");
 
-      // Switch back to feature — panels should reappear
-      await featureCard.click({ position: { x: 10, y: 10 } });
-      await expect
-        .poll(() => featureCard.getAttribute("aria-label"), { timeout: T_LONG })
-        .toContain("selected");
+        await expect
+          .poll(() => getGridPanelCount(window), { timeout: T_LONG })
+          .toBeGreaterThanOrEqual(1);
+      });
 
-      await expect
-        .poll(() => getGridPanelCount(window), { timeout: T_LONG })
-        .toBeGreaterThanOrEqual(1);
+      await test.step("Switch to main worktree and verify panels are hidden", async () => {
+        await mainCard.click({ position: { x: 10, y: 10 } });
+        await expect
+          .poll(() => mainCard.getAttribute("aria-label"), { timeout: T_LONG })
+          .toContain("selected");
+
+        await expect.poll(() => getGridPanelCount(window), { timeout: T_LONG }).toBe(0);
+      });
+
+      await test.step("Switch back to feature and verify panels reappear", async () => {
+        await featureCard.click({ position: { x: 10, y: 10 } });
+        await expect
+          .poll(() => featureCard.getAttribute("aria-label"), { timeout: T_LONG })
+          .toContain("selected");
+
+        await expect
+          .poll(() => getGridPanelCount(window), { timeout: T_LONG })
+          .toBeGreaterThanOrEqual(1);
+      });
     });
   });
 });

--- a/e2e/helpers/presets.ts
+++ b/e2e/helpers/presets.ts
@@ -1,7 +1,7 @@
 import { writeFileSync, mkdirSync, rmSync, existsSync, mkdtempSync } from "fs";
 import { join } from "path";
 import { tmpdir } from "os";
-import { expect } from "@playwright/test";
+import { test, expect } from "@playwright/test";
 import { SEL } from "./selectors";
 
 // Each test process gets its own CCR config file so parallel workers don't
@@ -37,39 +37,47 @@ export async function navigateToAgentSettings(
   window: import("@playwright/test").Page,
   agentId: string
 ): Promise<void> {
-  const heading = window.locator(SEL.settings.heading);
-  if (!(await heading.isVisible().catch(() => false))) {
-    const { openSettings } = await import("./panels");
-    await openSettings(window);
-  }
+  await test.step(
+    `Navigate to agent settings "${agentId}"`,
+    async () => {
+      const heading = window.locator(SEL.settings.heading);
+      if (!(await heading.isVisible().catch(() => false))) {
+        const { openSettings } = await import("./panels");
+        await openSettings(window);
+      }
 
-  const cliButton = window.locator(`${SEL.settings.navSidebar} button`, { hasText: "CLI Agents" });
-  await expect(cliButton).toBeVisible({ timeout: 10000 });
+      const cliButton = window.locator(`${SEL.settings.navSidebar} button`, {
+        hasText: "CLI Agents",
+      });
+      await expect(cliButton).toBeVisible({ timeout: 10000 });
 
-  try {
-    await cliButton.click({ timeout: 5000 });
-  } catch {
-    await window.keyboard.press("Escape");
-    await window.waitForTimeout(500);
-    const { openSettings } = await import("./panels");
-    await openSettings(window);
-    await cliButton.click({ timeout: 5000 });
-  }
+      try {
+        await cliButton.click({ timeout: 5000 });
+      } catch {
+        await window.keyboard.press("Escape");
+        await window.waitForTimeout(500);
+        const { openSettings } = await import("./panels");
+        await openSettings(window);
+        await cliButton.click({ timeout: 5000 });
+      }
 
-  const agentsPanel = window.locator("#settings-panel-agents");
-  const dropdownTrigger = agentsPanel.locator('[data-testid="agent-selector-trigger"]');
-  await expect(dropdownTrigger).toBeVisible({ timeout: 5000 });
+      const agentsPanel = window.locator("#settings-panel-agents");
+      const dropdownTrigger = agentsPanel.locator('[data-testid="agent-selector-trigger"]');
+      await expect(dropdownTrigger).toBeVisible({ timeout: 5000 });
 
-  const displayName = agentId.charAt(0).toUpperCase() + agentId.slice(1);
-  const currentText = await dropdownTrigger.textContent();
-  if (currentText?.trim() === displayName) return;
+      const displayName = agentId.charAt(0).toUpperCase() + agentId.slice(1);
+      const currentText = await dropdownTrigger.textContent();
+      if (currentText?.trim() === displayName) return;
 
-  await dropdownTrigger.click();
-  const listbox = window.locator('[role="listbox"]#agent-selector-list');
-  await expect(listbox).toBeVisible({ timeout: 5000 });
-  const option = listbox.locator('[role="option"]', { hasText: displayName });
-  await option.click();
-  await expect(listbox).not.toBeVisible({ timeout: 5000 });
+      await dropdownTrigger.click();
+      const listbox = window.locator('[role="listbox"]#agent-selector-list');
+      await expect(listbox).toBeVisible({ timeout: 5000 });
+      const option = listbox.locator('[role="option"]', { hasText: displayName });
+      await option.click();
+      await expect(listbox).not.toBeVisible({ timeout: 5000 });
+    },
+    { box: true }
+  );
 }
 
 /**
@@ -82,34 +90,40 @@ export async function getPresetRowByName(
   window: import("@playwright/test").Page,
   name: string
 ): Promise<import("@playwright/test").Locator> {
-  const trigger = window.locator(SEL.preset.selectorTrigger);
-  await trigger.waitFor({ state: "visible", timeout: 10_000 });
-  // Playwright recommends hover() before click() for Radix Popover triggers
-  // — prevents race on Windows where focus events can close the popover
-  // mid-click.
-  await trigger.hover();
-  await trigger.click();
+  return await test.step(
+    `Select preset "${name}"`,
+    async () => {
+      const trigger = window.locator(SEL.preset.selectorTrigger);
+      await trigger.waitFor({ state: "visible", timeout: 10_000 });
+      // Playwright recommends hover() before click() for Radix Popover triggers
+      // — prevents race on Windows where focus events can close the popover
+      // mid-click.
+      await trigger.hover();
+      await trigger.click();
 
-  const listbox = window.locator(SEL.preset.selectorListbox);
-  await expect(listbox).toBeVisible({ timeout: 5000 });
+      const listbox = window.locator(SEL.preset.selectorListbox);
+      await expect(listbox).toBeVisible({ timeout: 5000 });
 
-  // Match options by substring rather than exact text — CCR options also
-  // render a "CCR" badge span inside the option, so the option's full
-  // textContent looks like "UI DebugCCR". Substring matching is sufficient
-  // because option labels within a single agent are unique.
-  const option = listbox.locator('[role="option"]', {
-    hasText: name,
-  });
-  await option.first().hover();
-  await option.first().click();
-  await expect(listbox).not.toBeVisible({ timeout: 5000 });
+      // Match options by substring rather than exact text — CCR options also
+      // render a "CCR" badge span inside the option, so the option's full
+      // textContent looks like "UI DebugCCR". Substring matching is sufficient
+      // because option labels within a single agent are unique.
+      const option = listbox.locator('[role="option"]', {
+        hasText: name,
+      });
+      await option.first().hover();
+      await option.first().click();
+      await expect(listbox).not.toBeVisible({ timeout: 5000 });
 
-  // Return the detail-view panel (the first bordered panel below the selector).
-  return window
-    .locator(
-      `${SEL.preset.section} .rounded-\\[var\\(--radius-md\\)\\].border.border-daintree-border`
-    )
-    .first();
+      // Return the detail-view panel (the first bordered panel below the selector).
+      return window
+        .locator(
+          `${SEL.preset.section} .rounded-\\[var\\(--radius-md\\)\\].border.border-daintree-border`
+        )
+        .first();
+    },
+    { box: true }
+  );
 }
 
 /**
@@ -124,23 +138,29 @@ export async function getSelectedPresetLabel(
 }
 
 export async function addCustomPreset(window: import("@playwright/test").Page): Promise<void> {
-  const section = window.locator(SEL.preset.section);
-  // Capture preset count before the dialog flow so we can poll until the new
-  // preset has actually landed in the listbox (replaces a fixed 350ms wait).
-  const countBefore = await countPresetOptions(window);
-  await section.locator(SEL.preset.addButton).click();
-  // The Add button now opens an "Add Preset" dialog with a Start-from chooser.
-  // Click Create to accept the default "Blank" choice and create the preset.
-  const dialog = window.locator('[data-testid="add-preset-dialog"]');
-  await expect(dialog).toBeVisible({ timeout: 5000 });
-  await dialog.locator('button:has-text("Create")').click();
-  await expect(dialog).not.toBeVisible({ timeout: 5000 });
-  // Poll until the new preset surfaces in the listbox — this is the
-  // observable signal that the IPC round-trip has settled and the store
-  // has the new entry. Each probe opens/counts/closes the popover.
-  await expect
-    .poll(() => countPresetOptions(window), { timeout: 5_000, intervals: [100, 200, 400] })
-    .toBe(countBefore + 1);
+  await test.step(
+    "Add custom preset",
+    async () => {
+      const section = window.locator(SEL.preset.section);
+      // Capture preset count before the dialog flow so we can poll until the new
+      // preset has actually landed in the listbox (replaces a fixed 350ms wait).
+      const countBefore = await countPresetOptions(window);
+      await section.locator(SEL.preset.addButton).click();
+      // The Add button now opens an "Add Preset" dialog with a Start-from chooser.
+      // Click Create to accept the default "Blank" choice and create the preset.
+      const dialog = window.locator('[data-testid="add-preset-dialog"]');
+      await expect(dialog).toBeVisible({ timeout: 5000 });
+      await dialog.locator('button:has-text("Create")').click();
+      await expect(dialog).not.toBeVisible({ timeout: 5000 });
+      // Poll until the new preset surfaces in the listbox — this is the
+      // observable signal that the IPC round-trip has settled and the store
+      // has the new entry. Each probe opens/counts/closes the popover.
+      await expect
+        .poll(() => countPresetOptions(window), { timeout: 5_000, intervals: [100, 200, 400] })
+        .toBe(countBefore + 1);
+    },
+    { box: true }
+  );
 }
 
 /**
@@ -149,14 +169,20 @@ export async function addCustomPreset(window: import("@playwright/test").Page): 
  * listbox is only mounted while open.
  */
 export async function countPresetOptions(window: import("@playwright/test").Page): Promise<number> {
-  const trigger = window.locator(SEL.preset.selectorTrigger);
-  await trigger.click();
-  const listbox = window.locator(SEL.preset.selectorListbox);
-  await expect(listbox).toBeVisible({ timeout: 5000 });
-  const n = await listbox.locator('[role="option"]').count();
-  await window.keyboard.press("Escape");
-  await expect(listbox).not.toBeVisible({ timeout: 5000 });
-  return n;
+  return await test.step(
+    "Count preset options",
+    async () => {
+      const trigger = window.locator(SEL.preset.selectorTrigger);
+      await trigger.click();
+      const listbox = window.locator(SEL.preset.selectorListbox);
+      await expect(listbox).toBeVisible({ timeout: 5000 });
+      const n = await listbox.locator('[role="option"]').count();
+      await window.keyboard.press("Escape");
+      await expect(listbox).not.toBeVisible({ timeout: 5000 });
+      return n;
+    },
+    { box: true }
+  );
 }
 
 /**
@@ -166,12 +192,18 @@ export async function countPresetOptions(window: import("@playwright/test").Page
 export async function getPresetOptionLabels(
   window: import("@playwright/test").Page
 ): Promise<string[]> {
-  const trigger = window.locator(SEL.preset.selectorTrigger);
-  await trigger.click();
-  const listbox = window.locator(SEL.preset.selectorListbox);
-  await expect(listbox).toBeVisible({ timeout: 5000 });
-  const labels = await listbox.locator('[role="option"]').allTextContents();
-  await window.keyboard.press("Escape");
-  await expect(listbox).not.toBeVisible({ timeout: 5000 });
-  return labels.map((s) => s.trim());
+  return await test.step(
+    "Get preset option labels",
+    async () => {
+      const trigger = window.locator(SEL.preset.selectorTrigger);
+      await trigger.click();
+      const listbox = window.locator(SEL.preset.selectorListbox);
+      await expect(listbox).toBeVisible({ timeout: 5000 });
+      const labels = await listbox.locator('[role="option"]').allTextContents();
+      await window.keyboard.press("Escape");
+      await expect(listbox).not.toBeVisible({ timeout: 5000 });
+      return labels.map((s) => s.trim());
+    },
+    { box: true }
+  );
 }


### PR DESCRIPTION
## Summary

- Pure structural rollout of `test.step` phase labels across all 16 release-gating Playwright core specs and the 5 helper functions in `presets.ts`. No logic, selector, or timing changes.
- Helpers in `presets.ts` (`navigateToAgentSettings`, `addCustomPreset`, `getPresetRowByName`, `countPresetOptions`, `getPresetOptionLabels`) get `{ box: true }` so failures bubble to the call site rather than pointing inside the helper. Multi-phase tests get unboxed `test.step` wraps for named phase anchors in CI traces.
- One minor correctness fix: `test.skip()` in `core-shell-settings` was sitting inside a `test.step()` call, which isn't valid — hoisted it out.

Resolves #7295

## Changes

- `e2e/helpers/presets.ts` — all 5 helpers wrapped with `test.step({ box: true })`
- `e2e/core/*.spec.ts` (16 files) — multi-phase tests wrapped with unboxed `test.step` phase labels
- `e2e/core/core-shell-settings.spec.ts` — `test.skip()` hoisted above its enclosing `test.step()`

## Testing

Typecheck, lint, format, and build all pass. ESLint warning count dropped from 877 to 866 (lint ratchet confirmed improvement, no regressions).