### PR TITLE
chore(ci): add Playwright browser cache, drop npm cache clean

### DIFF
--- a/.github/workflows/e2e-core.yml
+++ b/.github/workflows/e2e-core.yml
@@ -113,6 +113,16 @@ jobs:
       - name: Check out repository
         uses: actions/checkout@v6
 
+      - name: Cache Playwright browsers
+        id: cache-playwright
+        uses: actions/cache@v5
+        with:
+          path: |
+            ~/.cache/ms-playwright
+            ~/Library/Caches/ms-playwright
+            ~/AppData/Local/ms-playwright
+          key: ${{ runner.os }}-${{ runner.arch }}-playwright-${{ hashFiles('package-lock.json') }}
+
       - name: Set up Node.js
         uses: actions/setup-node@v6
         with:

--- a/.github/workflows/e2e-nightly.yml
+++ b/.github/workflows/e2e-nightly.yml
@@ -75,6 +75,16 @@ jobs:
       - name: Check out repository
         uses: actions/checkout@v6
 
+      - name: Cache Playwright browsers
+        id: cache-playwright
+        uses: actions/cache@v5
+        with:
+          path: |
+            ~/.cache/ms-playwright
+            ~/Library/Caches/ms-playwright
+            ~/AppData/Local/ms-playwright
+          key: ${{ runner.os }}-${{ runner.arch }}-playwright-${{ hashFiles('package-lock.json') }}
+
       - name: Set up Node.js
         uses: actions/setup-node@v6
         with:

--- a/.github/workflows/e2e-online.yml
+++ b/.github/workflows/e2e-online.yml
@@ -85,6 +85,16 @@ jobs:
       - name: Check out repository
         uses: actions/checkout@v6
 
+      - name: Cache Playwright browsers
+        id: cache-playwright
+        uses: actions/cache@v5
+        with:
+          path: |
+            ~/.cache/ms-playwright
+            ~/Library/Caches/ms-playwright
+            ~/AppData/Local/ms-playwright
+          key: ${{ runner.os }}-${{ runner.arch }}-playwright-${{ hashFiles('package-lock.json') }}
+
       - name: Set up Node.js
         uses: actions/setup-node@v6
         with:

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -133,9 +133,6 @@ jobs:
           node-version: ${{ env.NODE_VERSION }}
           cache: npm
 
-      - name: Clean npm cache
-        run: npm cache clean --force
-
       - name: Install dependencies (Windows)
         if: matrix.os == 'windows-latest'
         run: npm ci


### PR DESCRIPTION
## Summary
- Adds Playwright browser caching to all three E2E workflows (core, nightly, online) so we stop re-downloading 400-600MB of browser binaries per matrix entry.
- Drops `npm cache clean --force` from `release.yml`, a cargo-culted step that forced every release to fetch packages fresh from the registry.

Resolves #7296

## Changes
- Added `actions/cache@v5` step to `.github/workflows/e2e-core.yml`, `e2e-nightly.yml`, and `e2e-online.yml`, caching `ms-playwright` directories across Linux, macOS, and Windows, keyed on `runner.os` + `runner.arch` + `package-lock.json`.
- Removed `npm cache clean --force` step from `.github/workflows/release.yml`.

## Testing
- CI workflows will validate on push. The cache step is placed before `setup-node` and `npm ci` in each workflow, matching the expected ordering.