### PR TITLE
fix(a11y): tighten AccessibilityAnnouncer timer cleanup and channel isolation

### DIFF
--- a/src/components/Accessibility/AccessibilityAnnouncer.tsx
+++ b/src/components/Accessibility/AccessibilityAnnouncer.tsx
@@ -3,6 +3,40 @@ import { useAnnouncerStore } from "@/store/accessibilityAnnouncerStore";
 
 const ANNOUNCEMENT_DELAY_MS = 100;
 
+function announceToRegion(
+  entry: { msg: string; id: number } | null,
+  elRef: React.RefObject<HTMLDivElement | null>,
+  pendingRef: React.MutableRefObject<ReturnType<typeof setTimeout> | null>,
+  channel: "polite" | "assertive"
+) {
+  const el = elRef.current;
+  if (!el) return;
+
+  if (pendingRef.current) {
+    clearTimeout(pendingRef.current);
+    pendingRef.current = null;
+  }
+
+  const msg = entry?.msg ?? null;
+
+  if (!msg) {
+    el.textContent = "";
+    return;
+  }
+
+  const entryId = entry!.id;
+
+  el.textContent = "";
+  pendingRef.current = setTimeout(() => {
+    pendingRef.current = null;
+    const current = useAnnouncerStore.getState()[channel];
+    if (!current || current.id !== entryId) return;
+    if (elRef.current) {
+      elRef.current.textContent = msg;
+    }
+  }, ANNOUNCEMENT_DELAY_MS);
+}
+
 export function AccessibilityAnnouncer() {
   const polite = useAnnouncerStore((s) => s.polite);
   const assertive = useAnnouncerStore((s) => s.assertive);
@@ -14,54 +48,24 @@ export function AccessibilityAnnouncer() {
   const pendingAssertiveRef = useRef<ReturnType<typeof setTimeout> | null>(null);
 
   useEffect(() => {
-    const announce = (
-      entry: { msg: string; id: number } | null,
-      elRef: React.RefObject<HTMLDivElement | null>,
-      pendingRef: React.MutableRefObject<ReturnType<typeof setTimeout> | null>,
-      channel: "polite" | "assertive"
-    ) => {
-      const el = elRef.current;
-      if (!el) return;
-
-      if (pendingRef.current) {
-        clearTimeout(pendingRef.current);
-        pendingRef.current = null;
-      }
-
-      const msg = entry?.msg ?? null;
-
-      if (!msg) {
-        el.textContent = "";
-        return;
-      }
-
-      const entryId = entry!.id;
-
-      el.textContent = "";
-      pendingRef.current = setTimeout(() => {
-        pendingRef.current = null;
-        const current = useAnnouncerStore.getState()[channel];
-        if (!current || current.id !== entryId) return;
-        if (elRef.current) {
-          elRef.current.textContent = msg;
-        }
-      }, ANNOUNCEMENT_DELAY_MS);
-    };
-
-    announce(polite, politeRef, pendingPoliteRef, "polite");
-    announce(assertive, assertiveRef, pendingAssertiveRef, "assertive");
-
+    announceToRegion(polite, politeRef, pendingPoliteRef, "polite");
     return () => {
       if (pendingPoliteRef.current) {
         clearTimeout(pendingPoliteRef.current);
         pendingPoliteRef.current = null;
       }
+    };
+  }, [polite]);
+
+  useEffect(() => {
+    announceToRegion(assertive, assertiveRef, pendingAssertiveRef, "assertive");
+    return () => {
       if (pendingAssertiveRef.current) {
         clearTimeout(pendingAssertiveRef.current);
         pendingAssertiveRef.current = null;
       }
     };
-  }, [polite, assertive]);
+  }, [assertive]);
 
   return (
     <>

--- a/src/components/Accessibility/AccessibilityAnnouncer.tsx
+++ b/src/components/Accessibility/AccessibilityAnnouncer.tsx
@@ -1,6 +1,8 @@
 import { useEffect, useRef } from "react";
 import { useAnnouncerStore } from "@/store/accessibilityAnnouncerStore";
 
+const ANNOUNCEMENT_DELAY_MS = 100;
+
 export function AccessibilityAnnouncer() {
   const polite = useAnnouncerStore((s) => s.polite);
   const assertive = useAnnouncerStore((s) => s.assertive);
@@ -8,32 +10,55 @@ export function AccessibilityAnnouncer() {
   const politeRef = useRef<HTMLDivElement>(null);
   const assertiveRef = useRef<HTMLDivElement>(null);
 
-  const pendingSetRef = useRef<ReturnType<typeof setTimeout> | null>(null);
+  const pendingPoliteRef = useRef<ReturnType<typeof setTimeout> | null>(null);
+  const pendingAssertiveRef = useRef<ReturnType<typeof setTimeout> | null>(null);
 
   useEffect(() => {
-    const announce = (msg: string | null, ref: React.RefObject<HTMLDivElement | null>) => {
-      const el = ref.current;
+    const announce = (
+      entry: { msg: string; id: number } | null,
+      elRef: React.RefObject<HTMLDivElement | null>,
+      pendingRef: React.MutableRefObject<ReturnType<typeof setTimeout> | null>,
+      channel: "polite" | "assertive"
+    ) => {
+      const el = elRef.current;
       if (!el) return;
+
+      if (pendingRef.current) {
+        clearTimeout(pendingRef.current);
+        pendingRef.current = null;
+      }
+
+      const msg = entry?.msg ?? null;
 
       if (!msg) {
         el.textContent = "";
         return;
       }
 
+      const entryId = entry!.id;
+
       el.textContent = "";
-      pendingSetRef.current = setTimeout(() => {
-        if (ref.current) {
-          ref.current.textContent = msg;
+      pendingRef.current = setTimeout(() => {
+        pendingRef.current = null;
+        const current = useAnnouncerStore.getState()[channel];
+        if (!current || current.id !== entryId) return;
+        if (elRef.current) {
+          elRef.current.textContent = msg;
         }
-      }, 0);
+      }, ANNOUNCEMENT_DELAY_MS);
     };
 
-    announce(polite?.msg ?? null, politeRef);
-    announce(assertive?.msg ?? null, assertiveRef);
+    announce(polite, politeRef, pendingPoliteRef, "polite");
+    announce(assertive, assertiveRef, pendingAssertiveRef, "assertive");
 
     return () => {
-      if (pendingSetRef.current) {
-        clearTimeout(pendingSetRef.current);
+      if (pendingPoliteRef.current) {
+        clearTimeout(pendingPoliteRef.current);
+        pendingPoliteRef.current = null;
+      }
+      if (pendingAssertiveRef.current) {
+        clearTimeout(pendingAssertiveRef.current);
+        pendingAssertiveRef.current = null;
       }
     };
   }, [polite, assertive]);

--- a/src/components/Accessibility/__tests__/AccessibilityAnnouncer.test.tsx
+++ b/src/components/Accessibility/__tests__/AccessibilityAnnouncer.test.tsx
@@ -6,11 +6,12 @@ import { useAnnouncerStore } from "@/store/accessibilityAnnouncerStore";
 
 describe("AccessibilityAnnouncer", () => {
   beforeEach(() => {
-    useAnnouncerStore.setState({ polite: null, assertive: null });
+    useAnnouncerStore.setState({ polite: null, assertive: null, nextId: 1 });
     vi.useFakeTimers();
   });
 
   afterEach(() => {
+    vi.runAllTimers();
     vi.useRealTimers();
     cleanup();
   });
@@ -35,7 +36,7 @@ describe("AccessibilityAnnouncer", () => {
   it("displays polite announcement text", () => {
     useAnnouncerStore.setState({ polite: { msg: "Panel focused", id: 1 } });
     const { container } = render(<AccessibilityAnnouncer />);
-    vi.runAllTimers();
+    vi.advanceTimersByTime(100);
     const politeRegion = container.querySelector('[aria-live="polite"]');
     expect(politeRegion?.textContent).toBe("Panel focused");
   });
@@ -43,14 +44,14 @@ describe("AccessibilityAnnouncer", () => {
   it("displays assertive announcement text", () => {
     useAnnouncerStore.setState({ assertive: { msg: "Error occurred", id: 1 } });
     const { container } = render(<AccessibilityAnnouncer />);
-    vi.runAllTimers();
+    vi.advanceTimersByTime(100);
     const assertiveRegion = container.querySelector('[aria-live="assertive"]');
     expect(assertiveRegion?.textContent).toBe("Error occurred");
   });
 
   it("renders empty when no announcements", () => {
     const { container } = render(<AccessibilityAnnouncer />);
-    vi.runAllTimers();
+    vi.advanceTimersByTime(100);
     const politeRegion = container.querySelector('[aria-live="polite"]');
     const assertiveRegion = container.querySelector('[aria-live="assertive"]');
     expect(politeRegion?.textContent).toBe("");
@@ -60,12 +61,12 @@ describe("AccessibilityAnnouncer", () => {
   it("preserves DOM node identity across announcements", () => {
     useAnnouncerStore.setState({ polite: { msg: "First", id: 1 } });
     const { container, rerender } = render(<AccessibilityAnnouncer />);
-    vi.runAllTimers();
+    vi.advanceTimersByTime(100);
     const politeRegion = container.querySelector('[aria-live="polite"]');
 
     useAnnouncerStore.setState({ polite: { msg: "Second", id: 2 } });
     rerender(<AccessibilityAnnouncer />);
-    vi.runAllTimers();
+    vi.advanceTimersByTime(100);
     const politeRegionAfter = container.querySelector('[aria-live="polite"]');
 
     expect(politeRegion).toBe(politeRegionAfter);
@@ -74,12 +75,12 @@ describe("AccessibilityAnnouncer", () => {
   it("delivers duplicate messages via clear-then-set cycle", () => {
     useAnnouncerStore.setState({ polite: { msg: "Panel focused", id: 1 } });
     const { container, rerender } = render(<AccessibilityAnnouncer />);
-    vi.runAllTimers();
+    vi.advanceTimersByTime(100);
     const politeRegion = container.querySelector('[aria-live="polite"]');
 
     useAnnouncerStore.setState({ polite: { msg: "Panel focused", id: 2 } });
     rerender(<AccessibilityAnnouncer />);
-    vi.runAllTimers();
+    vi.advanceTimersByTime(100);
 
     expect(politeRegion?.textContent).toBe("Panel focused");
   });
@@ -102,7 +103,7 @@ describe("AccessibilityAnnouncer", () => {
   it("empty message clears the region", () => {
     useAnnouncerStore.setState({ polite: { msg: "Message", id: 1 } });
     const { container, rerender } = render(<AccessibilityAnnouncer />);
-    vi.runAllTimers();
+    vi.advanceTimersByTime(100);
     const politeRegion = container.querySelector('[aria-live="polite"]');
 
     useAnnouncerStore.setState({ polite: null });
@@ -117,11 +118,71 @@ describe("AccessibilityAnnouncer", () => {
       assertive: { msg: "Assertive message", id: 1 },
     });
     const { container } = render(<AccessibilityAnnouncer />);
-    vi.runAllTimers();
+    vi.advanceTimersByTime(100);
     const politeRegion = container.querySelector('[aria-live="polite"]');
     const assertiveRegion = container.querySelector('[aria-live="assertive"]');
 
     expect(politeRegion?.textContent).toBe("Polite message");
     expect(assertiveRegion?.textContent).toBe("Assertive message");
+  });
+
+  it("delivers both polite and assertive text when set simultaneously in same render", () => {
+    useAnnouncerStore.setState({
+      polite: { msg: "Info", id: 1 },
+      assertive: { msg: "Alert", id: 2 },
+    });
+    const { container } = render(<AccessibilityAnnouncer />);
+    vi.advanceTimersByTime(100);
+    const politeRegion = container.querySelector('[aria-live="polite"]');
+    const assertiveRegion = container.querySelector('[aria-live="assertive"]');
+
+    expect(politeRegion?.textContent).toBe("Info");
+    expect(assertiveRegion?.textContent).toBe("Alert");
+  });
+
+  it("leaves zero pending timers after unmount", () => {
+    useAnnouncerStore.setState({ polite: { msg: "Message", id: 1 } });
+    const { unmount } = render(<AccessibilityAnnouncer />);
+    unmount();
+
+    expect(vi.getTimerCount()).toBe(0);
+  });
+
+  it("suppresses stale callback when newer announcement supersedes pending timer", () => {
+    useAnnouncerStore.setState({ polite: { msg: "First", id: 1 } });
+    const { container, rerender } = render(<AccessibilityAnnouncer />);
+    const politeRegion = container.querySelector('[aria-live="polite"]');
+
+    // Advance only 50ms — not enough for the timer to fire
+    vi.advanceTimersByTime(50);
+
+    // Newer announcement clears pending timer and reschedules
+    useAnnouncerStore.setState({ polite: { msg: "Second", id: 2 } });
+    rerender(<AccessibilityAnnouncer />);
+    vi.advanceTimersByTime(100);
+
+    expect(politeRegion?.textContent).toBe("Second");
+  });
+
+  it("clears per-channel timers independently — polite update does not cancel assertive timer", () => {
+    useAnnouncerStore.setState({
+      polite: { msg: "Polite", id: 1 },
+      assertive: { msg: "Assertive", id: 2 },
+    });
+    const { container, rerender } = render(<AccessibilityAnnouncer />);
+
+    // Advance 50ms — neither timer has fired yet
+    vi.advanceTimersByTime(50);
+
+    // Update only polite — should cancel polite timer but not assertive
+    useAnnouncerStore.setState({ polite: { msg: "Polite updated", id: 3 } });
+    rerender(<AccessibilityAnnouncer />);
+    vi.advanceTimersByTime(100);
+
+    const politeRegion = container.querySelector('[aria-live="polite"]');
+    const assertiveRegion = container.querySelector('[aria-live="assertive"]');
+
+    expect(politeRegion?.textContent).toBe("Polite updated");
+    expect(assertiveRegion?.textContent).toBe("Assertive");
   });
 });

--- a/src/components/Accessibility/__tests__/AccessibilityAnnouncer.test.tsx
+++ b/src/components/Accessibility/__tests__/AccessibilityAnnouncer.test.tsx
@@ -1,6 +1,7 @@
 // @vitest-environment jsdom
 import { describe, it, expect, beforeEach, afterEach, vi } from "vitest";
 import { render, cleanup } from "@testing-library/react";
+import { StrictMode } from "react";
 import { AccessibilityAnnouncer } from "../AccessibilityAnnouncer";
 import { useAnnouncerStore } from "@/store/accessibilityAnnouncerStore";
 
@@ -77,11 +78,13 @@ describe("AccessibilityAnnouncer", () => {
     const { container, rerender } = render(<AccessibilityAnnouncer />);
     vi.advanceTimersByTime(100);
     const politeRegion = container.querySelector('[aria-live="polite"]');
+    expect(politeRegion?.textContent).toBe("Panel focused");
 
     useAnnouncerStore.setState({ polite: { msg: "Panel focused", id: 2 } });
     rerender(<AccessibilityAnnouncer />);
+    // Text should be cleared synchronously so AT registers the empty state
+    expect(politeRegion?.textContent).toBe("");
     vi.advanceTimersByTime(100);
-
     expect(politeRegion?.textContent).toBe("Panel focused");
   });
 
@@ -153,10 +156,8 @@ describe("AccessibilityAnnouncer", () => {
     const { container, rerender } = render(<AccessibilityAnnouncer />);
     const politeRegion = container.querySelector('[aria-live="polite"]');
 
-    // Advance only 50ms — not enough for the timer to fire
     vi.advanceTimersByTime(50);
 
-    // Newer announcement clears pending timer and reschedules
     useAnnouncerStore.setState({ polite: { msg: "Second", id: 2 } });
     rerender(<AccessibilityAnnouncer />);
     vi.advanceTimersByTime(100);
@@ -171,18 +172,37 @@ describe("AccessibilityAnnouncer", () => {
     });
     const { container, rerender } = render(<AccessibilityAnnouncer />);
 
-    // Advance 50ms — neither timer has fired yet
     vi.advanceTimersByTime(50);
 
-    // Update only polite — should cancel polite timer but not assertive
+    // Update only polite — should cancel its timer but leave assertive's intact
     useAnnouncerStore.setState({ polite: { msg: "Polite updated", id: 3 } });
     rerender(<AccessibilityAnnouncer />);
-    vi.advanceTimersByTime(100);
 
     const politeRegion = container.querySelector('[aria-live="polite"]');
     const assertiveRegion = container.querySelector('[aria-live="assertive"]');
 
+    // Assertive fires at its original 100ms deadline
+    vi.advanceTimersByTime(50);
+    expect(assertiveRegion?.textContent).toBe("Assertive");
+    // Polite was reset at 50ms and won't fire until 150ms
+    expect(politeRegion?.textContent).toBe("");
+
+    vi.advanceTimersByTime(50);
     expect(politeRegion?.textContent).toBe("Polite updated");
     expect(assertiveRegion?.textContent).toBe("Assertive");
+  });
+
+  it("does not leak timers under StrictMode double-mount", () => {
+    useAnnouncerStore.setState({ polite: { msg: "Hello", id: 1 } });
+    render(
+      <StrictMode>
+        <AccessibilityAnnouncer />
+      </StrictMode>
+    );
+    vi.advanceTimersByTime(100);
+
+    const state = useAnnouncerStore.getState();
+    expect(state.polite?.msg).toBe("Hello");
+    expect(vi.getTimerCount()).toBe(0);
   });
 });

--- a/src/store/__tests__/accessibilityAnnouncerStore.test.ts
+++ b/src/store/__tests__/accessibilityAnnouncerStore.test.ts
@@ -3,7 +3,7 @@ import { useAnnouncerStore } from "../accessibilityAnnouncerStore";
 
 describe("accessibilityAnnouncerStore", () => {
   beforeEach(() => {
-    useAnnouncerStore.setState({ polite: null, assertive: null });
+    useAnnouncerStore.setState({ polite: null, assertive: null, nextId: 1 });
   });
 
   it("starts with null polite and assertive", () => {
@@ -42,5 +42,14 @@ describe("accessibilityAnnouncerStore", () => {
     const state = useAnnouncerStore.getState();
     expect(state.polite?.msg).toBe("info");
     expect(state.assertive?.msg).toBe("critical");
+  });
+
+  it("resets ID counter to 1 after setState reset, giving deterministic IDs across tests", () => {
+    useAnnouncerStore.getState().announce("first");
+    expect(useAnnouncerStore.getState().polite?.id).toBe(1);
+
+    useAnnouncerStore.setState({ polite: null, assertive: null, nextId: 1 });
+    useAnnouncerStore.getState().announce("second");
+    expect(useAnnouncerStore.getState().polite?.id).toBe(1);
   });
 });

--- a/src/store/accessibilityAnnouncerStore.ts
+++ b/src/store/accessibilityAnnouncerStore.ts
@@ -8,20 +8,21 @@ interface AnnouncementEntry {
 interface AnnouncerState {
   polite: AnnouncementEntry | null;
   assertive: AnnouncementEntry | null;
+  nextId: number;
   announce: (msg: string, priority?: "polite" | "assertive") => void;
 }
-
-let counter = 0;
 
 export const useAnnouncerStore = create<AnnouncerState>((set) => ({
   polite: null,
   assertive: null,
+  nextId: 1,
   announce: (msg, priority = "polite") => {
-    const id = ++counter;
-    if (priority === "assertive") {
-      set({ assertive: { msg, id } });
-    } else {
-      set({ polite: { msg, id } });
-    }
+    set((state) => {
+      const id = state.nextId;
+      if (priority === "assertive") {
+        return { nextId: id + 1, assertive: { msg, id } };
+      }
+      return { nextId: id + 1, polite: { msg, id } };
+    });
   },
 }));


### PR DESCRIPTION
## Summary
This tightens up the AccessibilityAnnouncer component. A module-scoped counter and shared timer refs were causing test isolation issues and cross-channel timer interference. The timer delay was also too aggressive at 0ms.

## Changes
- Moved the module-scoped counter into Zustand store state as `nextId` so each test gets a fresh counter
- Split the shared `pendingSetRef` into per-channel `pendingPoliteRef` and `pendingAssertiveRef` timer refs
- Replaced `setTimeout(0)` with a 100ms delay, matching React Aria's LiveAnnouncer implementation
- Added an ID guard in the `setTimeout` callbacks so stale announcements don't overwrite newer ones in the DOM
- Split the single `useEffect` into two independent effects to prevent one channel's timer from clearing the other's

Resolves #7258

## Testing
All 21 tests pass. Typecheck, lint, and format are clean.