### PR TITLE
feat(assistant): add Codex support to Daintree Assistant

### DIFF
--- a/electron/ipc/handlers/help.ts
+++ b/electron/ipc/handlers/help.ts
@@ -36,7 +36,7 @@ function handleUnmarkTerminal(terminalId: string): void {
 
 async function handleProvisionSession(
   ctx: import("../types.js").IpcContext,
-  input: { projectId: string; projectPath: string }
+  input: { projectId: string; projectPath: string; agentId: string }
 ): Promise<{
   sessionId: string;
   sessionPath: string;
@@ -53,6 +53,7 @@ async function handleProvisionSession(
   return helpSessionService.provisionSession({
     projectId: input.projectId,
     projectPath: input.projectPath,
+    agentId: input.agentId,
     windowId: ctx.senderWindow.id,
     projectViewWebContentsId: ctx.webContentsId,
   });

--- a/electron/ipc/handlers/terminal/__tests__/lifecycle.spawn.test.ts
+++ b/electron/ipc/handlers/terminal/__tests__/lifecycle.spawn.test.ts
@@ -75,6 +75,7 @@ vi.mock("../../../utils.js", () => ({
 
 vi.mock("../../../../shared/config/agentRegistry.js", () => ({
   isRegisteredAgent: vi.fn(() => false),
+  getAssistantSupportedAgentIds: vi.fn(() => ["claude", "codex"]),
 }));
 
 const {
@@ -743,5 +744,100 @@ describe("terminal spawn handler - help session detection (#6524)", () => {
     expect(mockPreparePaneConfig).not.toHaveBeenCalled();
     expect(spawnArgs.command).toBe("claude");
     expect(spawnArgs.env?.DAINTREE_MCP_TOKEN).toBeUndefined();
+  });
+
+  it("treats a Codex help-session token as a help launch and injects --trust-project", async () => {
+    mockValidateToken.mockImplementation((token) => (token === "help-token" ? "action" : false));
+
+    const deps = { ptyClient } as unknown as HandlerDependencies;
+    registerTerminalLifecycleHandlers(deps);
+
+    const handler = getSpawnHandler();
+    await handler(
+      {} as Electron.IpcMainInvokeEvent,
+      {
+        cols: 80,
+        rows: 24,
+        cwd: tmpDir,
+        command: "codex",
+        launchAgentId: "codex",
+        env: { DAINTREE_MCP_TOKEN: "help-token" },
+      } as unknown as Parameters<typeof handler>[1]
+    );
+
+    const spawnArgs = ptyClient.spawn.mock.calls[0][1];
+    expect(spawnArgs.command).toContain("--trust-project");
+    // No per-pane MCP injection: the session-dir .codex/config.toml owns it.
+    expect(mockPreparePaneConfig).not.toHaveBeenCalled();
+  });
+
+  it("does not duplicate --trust-project when the renderer already added it", async () => {
+    mockValidateToken.mockImplementation((token) => (token === "help-token" ? "action" : false));
+
+    const deps = { ptyClient } as unknown as HandlerDependencies;
+    registerTerminalLifecycleHandlers(deps);
+
+    const handler = getSpawnHandler();
+    await handler(
+      {} as Electron.IpcMainInvokeEvent,
+      {
+        cols: 80,
+        rows: 24,
+        cwd: tmpDir,
+        command: "codex --trust-project",
+        launchAgentId: "codex",
+        env: { DAINTREE_MCP_TOKEN: "help-token" },
+      } as unknown as Parameters<typeof handler>[1]
+    );
+
+    const spawnArgs = ptyClient.spawn.mock.calls[0][1];
+    const occurrences = (spawnArgs.command.match(/--trust-project/g) ?? []).length;
+    expect(occurrences).toBe(1);
+  });
+
+  it("appends --dangerously-bypass-approvals-and-sandbox to a system-tier Codex help launch", async () => {
+    mockValidateToken.mockImplementation((token) => (token === "system-token" ? "system" : false));
+
+    const deps = { ptyClient } as unknown as HandlerDependencies;
+    registerTerminalLifecycleHandlers(deps);
+
+    const handler = getSpawnHandler();
+    await handler(
+      {} as Electron.IpcMainInvokeEvent,
+      {
+        cols: 80,
+        rows: 24,
+        cwd: tmpDir,
+        command: "codex",
+        launchAgentId: "codex",
+        env: { DAINTREE_MCP_TOKEN: "system-token" },
+      } as unknown as Parameters<typeof handler>[1]
+    );
+
+    const spawnArgs = ptyClient.spawn.mock.calls[0][1];
+    expect(spawnArgs.command).toContain("--dangerously-bypass-approvals-and-sandbox");
+    expect(spawnArgs.command).toContain("--trust-project");
+  });
+
+  it("does not inject --trust-project for a non-help Codex launch", async () => {
+    mockValidateToken.mockReturnValue(false);
+
+    const deps = { ptyClient } as unknown as HandlerDependencies;
+    registerTerminalLifecycleHandlers(deps);
+
+    const handler = getSpawnHandler();
+    await handler(
+      {} as Electron.IpcMainInvokeEvent,
+      {
+        cols: 80,
+        rows: 24,
+        cwd: tmpDir,
+        command: "codex",
+        launchAgentId: "codex",
+      } as unknown as Parameters<typeof handler>[1]
+    );
+
+    const spawnArgs = ptyClient.spawn.mock.calls[0][1];
+    expect(spawnArgs.command).not.toContain("--trust-project");
   });
 });

--- a/electron/ipc/handlers/terminal/__tests__/lifecycle.spawn.test.ts
+++ b/electron/ipc/handlers/terminal/__tests__/lifecycle.spawn.test.ts
@@ -92,9 +92,14 @@ const {
   mockEnsureReady: vi.fn<() => Promise<boolean>>(),
 }));
 
+const mockGetCodexLaunchArgs = vi.hoisted(() =>
+  vi.fn<(token: string) => string[] | null>(() => null)
+);
+
 vi.mock("../../../../services/HelpSessionService.js", () => ({
   helpSessionService: {
     validateToken: (token: string) => mockValidateToken(token),
+    getCodexLaunchArgs: (token: string) => mockGetCodexLaunchArgs(token),
   },
 }));
 
@@ -559,6 +564,8 @@ describe("terminal spawn handler - help session detection (#6524)", () => {
     mockValidateToken.mockReturnValue(false);
     mockIsRunning.mockReturnValue(false);
     mockCurrentPort.mockReturnValue(null);
+    mockGetCodexLaunchArgs.mockReset();
+    mockGetCodexLaunchArgs.mockReturnValue(null);
   });
 
   it("skips per-pane MCP injection when DAINTREE_MCP_TOKEN is a valid help token (session-dir owns the .mcp.json)", async () => {
@@ -746,8 +753,20 @@ describe("terminal spawn handler - help session detection (#6524)", () => {
     expect(spawnArgs.env?.DAINTREE_MCP_TOKEN).toBeUndefined();
   });
 
-  it("treats a Codex help-session token as a help launch and injects --trust-project", async () => {
+  it("appends Codex MCP -c flags to a Codex help-session spawn", async () => {
     mockValidateToken.mockImplementation((token) => (token === "help-token" ? "action" : false));
+    mockGetCodexLaunchArgs.mockImplementation((token) =>
+      token === "help-token"
+        ? [
+            "-c",
+            'mcp_servers.daintree.transport="http"',
+            "-c",
+            'mcp_servers.daintree.url="http://127.0.0.1:45454/mcp"',
+            "-c",
+            'mcp_servers.daintree.bearer_token_env_var="DAINTREE_MCP_TOKEN"',
+          ]
+        : null
+    );
 
     const deps = { ptyClient } as unknown as HandlerDependencies;
     registerTerminalLifecycleHandlers(deps);
@@ -766,37 +785,23 @@ describe("terminal spawn handler - help session detection (#6524)", () => {
     );
 
     const spawnArgs = ptyClient.spawn.mock.calls[0][1];
-    expect(spawnArgs.command).toContain("--trust-project");
-    // No per-pane MCP injection: the session-dir .codex/config.toml owns it.
-    expect(mockPreparePaneConfig).not.toHaveBeenCalled();
-  });
-
-  it("does not duplicate --trust-project when the renderer already added it", async () => {
-    mockValidateToken.mockImplementation((token) => (token === "help-token" ? "action" : false));
-
-    const deps = { ptyClient } as unknown as HandlerDependencies;
-    registerTerminalLifecycleHandlers(deps);
-
-    const handler = getSpawnHandler();
-    await handler(
-      {} as Electron.IpcMainInvokeEvent,
-      {
-        cols: 80,
-        rows: 24,
-        cwd: tmpDir,
-        command: "codex --trust-project",
-        launchAgentId: "codex",
-        env: { DAINTREE_MCP_TOKEN: "help-token" },
-      } as unknown as Parameters<typeof handler>[1]
+    // Args are shell-quoted with single quotes; the inner double quotes
+    // (from TOML literals) are preserved as-is inside the single-quote
+    // wrapping.
+    expect(spawnArgs.command).toContain(`'mcp_servers.daintree.transport="http"'`);
+    expect(spawnArgs.command).toContain(`'mcp_servers.daintree.url="http://127.0.0.1:45454/mcp"'`);
+    expect(spawnArgs.command).toContain(
+      `'mcp_servers.daintree.bearer_token_env_var="DAINTREE_MCP_TOKEN"'`
     );
-
-    const spawnArgs = ptyClient.spawn.mock.calls[0][1];
-    const occurrences = (spawnArgs.command.match(/--trust-project/g) ?? []).length;
-    expect(occurrences).toBe(1);
+    // Token must NEVER appear in argv — it's read from PTY env via bearer_token_env_var.
+    expect(spawnArgs.command).not.toContain("help-token");
+    // No per-pane MCP injection: the help session owns the MCP wiring.
+    expect(mockPreparePaneConfig).not.toHaveBeenCalled();
   });
 
   it("appends --dangerously-bypass-approvals-and-sandbox to a system-tier Codex help launch", async () => {
     mockValidateToken.mockImplementation((token) => (token === "system-token" ? "system" : false));
+    mockGetCodexLaunchArgs.mockReturnValue([]);
 
     const deps = { ptyClient } as unknown as HandlerDependencies;
     registerTerminalLifecycleHandlers(deps);
@@ -816,10 +821,9 @@ describe("terminal spawn handler - help session detection (#6524)", () => {
 
     const spawnArgs = ptyClient.spawn.mock.calls[0][1];
     expect(spawnArgs.command).toContain("--dangerously-bypass-approvals-and-sandbox");
-    expect(spawnArgs.command).toContain("--trust-project");
   });
 
-  it("does not inject --trust-project for a non-help Codex launch", async () => {
+  it("does not query Codex launch args for a non-help Codex launch", async () => {
     mockValidateToken.mockReturnValue(false);
 
     const deps = { ptyClient } as unknown as HandlerDependencies;
@@ -837,7 +841,30 @@ describe("terminal spawn handler - help session detection (#6524)", () => {
       } as unknown as Parameters<typeof handler>[1]
     );
 
+    expect(mockGetCodexLaunchArgs).not.toHaveBeenCalled();
+  });
+
+  it("does not append Codex flags when getCodexLaunchArgs returns null (defense-in-depth)", async () => {
+    mockValidateToken.mockImplementation((token) => (token === "help-token" ? "action" : false));
+    mockGetCodexLaunchArgs.mockReturnValue(null);
+
+    const deps = { ptyClient } as unknown as HandlerDependencies;
+    registerTerminalLifecycleHandlers(deps);
+
+    const handler = getSpawnHandler();
+    await handler(
+      {} as Electron.IpcMainInvokeEvent,
+      {
+        cols: 80,
+        rows: 24,
+        cwd: tmpDir,
+        command: "codex",
+        launchAgentId: "codex",
+        env: { DAINTREE_MCP_TOKEN: "help-token" },
+      } as unknown as Parameters<typeof handler>[1]
+    );
+
     const spawnArgs = ptyClient.spawn.mock.calls[0][1];
-    expect(spawnArgs.command).not.toContain("--trust-project");
+    expect(spawnArgs.command).toBe("codex");
   });
 });

--- a/electron/ipc/handlers/terminal/lifecycle.ts
+++ b/electron/ipc/handlers/terminal/lifecycle.ts
@@ -249,11 +249,17 @@ export function registerTerminalLifecycleHandlers(deps: HandlerDependencies): ()
           .replace(/\s{2,}/g, " ")
           .trim();
       }
-      // Codex needs --trust-project to read the session-dir's `.codex/config.toml`
-      // without writing to ~/.codex/. Without this flag, the project-scoped
-      // config is silently ignored and MCP wiring drops on the floor.
-      if (launchAgentId === "codex" && !/(^|\s)--trust-project(\s|$)/.test(safeCommand)) {
-        safeCommand = `${safeCommand} --trust-project`;
+      // Codex doesn't read project-scoped `.codex/config.toml` from cwd —
+      // its only override mechanism is the `-c key=value` CLI flag. The
+      // help-session service computed the exact `-c` args for the toggled
+      // MCP servers at provision time; append them here, shell-quoted. No
+      // literal token is ever in the args (Codex reads
+      // `DAINTREE_MCP_TOKEN` from PTY env via `bearer_token_env_var`).
+      if (launchAgentId === "codex") {
+        const codexArgs = helpSessionService.getCodexLaunchArgs(helpToken);
+        if (codexArgs && codexArgs.length > 0) {
+          safeCommand = `${safeCommand} ${codexArgs.map(shellQuote).join(" ")}`;
+        }
       }
     } else if (launchAgentId === "claude" && safeCommand.length > 0 && projectId) {
       // Daintree MCP injection for normal Claude Code agent launches.

--- a/electron/ipc/handlers/terminal/lifecycle.ts
+++ b/electron/ipc/handlers/terminal/lifecycle.ts
@@ -20,6 +20,7 @@ import type { HandlerDependencies } from "../../types.js";
 import { TerminalSpawnOptionsSchema } from "../../../schemas/ipc.js";
 import { resolveDaintreeMcpTier } from "../../../../shared/types/project.js";
 import { DEFAULT_DANGEROUS_ARGS } from "../../../../shared/types/agentSettings.js";
+import { getAssistantSupportedAgentIds } from "../../../../shared/config/agentRegistry.js";
 
 type ValidatedTerminalSpawnOptions = z.output<typeof TerminalSpawnOptionsSchema>;
 import {
@@ -220,9 +221,13 @@ export function registerTerminalLifecycleHandlers(deps: HandlerDependencies): ()
     // (skipPermissions), append the dangerous flag.
     const helpToken = spawnEnv?.DAINTREE_MCP_TOKEN ?? "";
     const helpTier = helpToken ? helpSessionService.validateToken(helpToken) : false;
-    const isHelpLaunch = helpTier !== false && launchAgentId === "claude" && safeCommand.length > 0;
+    const isHelpLaunch =
+      helpTier !== false &&
+      typeof launchAgentId === "string" &&
+      getAssistantSupportedAgentIds().includes(launchAgentId) &&
+      safeCommand.length > 0;
 
-    if (isHelpLaunch) {
+    if (isHelpLaunch && launchAgentId) {
       const dangerous = DEFAULT_DANGEROUS_ARGS[launchAgentId];
       if (helpTier === "system") {
         if (dangerous && !safeCommand.includes(dangerous)) {
@@ -243,6 +248,12 @@ export function registerTerminalLifecycleHandlers(deps: HandlerDependencies): ()
           .replace(stripPattern, "$1")
           .replace(/\s{2,}/g, " ")
           .trim();
+      }
+      // Codex needs --trust-project to read the session-dir's `.codex/config.toml`
+      // without writing to ~/.codex/. Without this flag, the project-scoped
+      // config is silently ignored and MCP wiring drops on the floor.
+      if (launchAgentId === "codex" && !/(^|\s)--trust-project(\s|$)/.test(safeCommand)) {
+        safeCommand = `${safeCommand} --trust-project`;
       }
     } else if (launchAgentId === "claude" && safeCommand.length > 0 && projectId) {
       // Daintree MCP injection for normal Claude Code agent launches.

--- a/electron/services/HelpSessionService.ts
+++ b/electron/services/HelpSessionService.ts
@@ -53,6 +53,8 @@ interface HelpSessionRecord {
   tier: HelpAssistantTier;
   createdAt: number;
   revoked: boolean;
+  /** Computed at provision for codex sessions; consumed by lifecycle.ts. */
+  codexLaunchArgs?: string[];
 }
 
 interface SessionMeta {
@@ -217,15 +219,20 @@ export class HelpSessionService {
     await fs.chmod(sessionPath, 0o700).catch(() => {});
 
     const port = await this.getMcpPort(settings.daintreeControl);
-    if (input.agentId === "codex") {
-      // Codex reads `bearer_token_env_var` at MCP-connect time from the PTY
-      // env, so the literal token never lands on disk. The token comes from
-      // DAINTREE_MCP_TOKEN injected by `buildHelpEnv()` in the renderer.
-      await this.writeCodexConfig(sessionPath, settings, port);
-    } else {
+    if (input.agentId !== "codex") {
       await this.writeMcpConfig(sessionPath, settings, port, token);
       await this.writeClaudeSettings(sessionPath, helpFolder, settings);
     }
+    // Codex doesn't read project-scoped `.codex/config.toml` from cwd —
+    // its only mechanism for overriding the global config is the `-c key=value`
+    // CLI flag (verified against codex-cli 0.129.0). MCP servers are appended
+    // to the spawn command in `lifecycle.ts` via the `getCodexLaunchArgs`
+    // accessor below; nothing is written to disk for Codex.
+
+    const codexLaunchArgs =
+      input.agentId === "codex"
+        ? this.buildCodexLaunchArgs(settings.daintreeControl, settings.docSearch, port)
+        : undefined;
 
     const now = Date.now();
     const record: HelpSessionRecord = {
@@ -240,6 +247,7 @@ export class HelpSessionService {
       tier,
       createdAt: now,
       revoked: false,
+      codexLaunchArgs,
     };
 
     await this.writeSessionMeta(sessionPath, {
@@ -254,8 +262,9 @@ export class HelpSessionService {
     if (settings.daintreeControl && port) {
       try {
         if (input.agentId === "codex") {
-          // Codex MCP wiring uses Streamable HTTP at /mcp (probeMcpServer),
-          // not the SSE transport Claude Code reads from .mcp.json.
+          // Codex's MCP transport is Streamable HTTP at /mcp; Claude Code
+          // reads SSE at /sse. Both probes warm the same in-memory MCP token
+          // map, so neither leaks across agents.
           await probeMcpServer(port, token);
         } else {
           await probeMcpSseServer(port, token);
@@ -264,9 +273,7 @@ export class HelpSessionService {
         record.revoked = true;
         this.sessionsByToken.delete(token);
         this.sessionsById.delete(sessionId);
-        if (input.agentId === "codex") {
-          await this.clearCodexConfig(sessionPath);
-        } else {
+        if (input.agentId !== "codex") {
           await this.stripStaleDaintreeMcpEntry(sessionPath);
         }
         const reason = formatErrorMessage(err, "assistant MCP session isn't ready");
@@ -292,6 +299,56 @@ export class HelpSessionService {
   }
 
   /**
+   * Builds the `-c key=value` CLI args that wire MCP servers into a Codex
+   * help-session spawn. The values are TOML-encoded literals (quoted strings),
+   * matching Codex's `-c` parser. Returns an empty array when both server
+   * toggles are off.
+   *
+   * Token comes from `DAINTREE_MCP_TOKEN` in PTY env via `bearer_token_env_var`,
+   * so no literal token is ever embedded in argv or written to disk.
+   */
+  private buildCodexLaunchArgs(
+    daintreeControl: boolean,
+    docSearch: boolean,
+    port: number | null
+  ): string[] {
+    const args: string[] = [];
+    if (daintreeControl && port) {
+      args.push(
+        "-c",
+        `mcp_servers.daintree.transport="http"`,
+        "-c",
+        `mcp_servers.daintree.url="http://127.0.0.1:${port}/mcp"`,
+        "-c",
+        `mcp_servers.daintree.bearer_token_env_var="DAINTREE_MCP_TOKEN"`
+      );
+    }
+    if (docSearch) {
+      args.push(
+        "-c",
+        `mcp_servers.daintree-docs.transport="http"`,
+        "-c",
+        `mcp_servers.daintree-docs.url="https://daintree.org/api/mcp"`
+      );
+    }
+    return args;
+  }
+
+  /**
+   * Returns the cached `-c` flags that wire MCP servers for a Codex help
+   * session. lifecycle.ts appends them to the spawn command after the help
+   * token validates. Returns null for unknown / revoked tokens or non-Codex
+   * sessions, so the spawn handler never injects flags for the wrong agent.
+   */
+  getCodexLaunchArgs(token: string): string[] | null {
+    if (!token) return null;
+    const record = this.sessionsByToken.get(token);
+    if (!record || record.revoked) return null;
+    if (record.agentId !== "codex") return null;
+    return record.codexLaunchArgs ?? [];
+  }
+
+  /**
    * Invalidates the in-memory bearer for this session. The on-disk dir is
    * intentionally preserved across launches so the user's one-time Claude
    * Code workspace-trust acceptance for this project carries over to the
@@ -307,9 +364,9 @@ export class HelpSessionService {
     record.revoked = true;
     this.sessionsById.delete(sessionId);
     this.sessionsByToken.delete(record.token);
-    if (record.agentId === "codex") {
-      await this.clearCodexConfig(record.sessionPath);
-    } else {
+    // Codex sessions write nothing to disk (config is `-c` flags), so the
+    // file-strip dance is Claude-only.
+    if (record.agentId !== "codex") {
       await this.stripStaleDaintreeMcpEntry(record.sessionPath);
     }
   }
@@ -361,11 +418,7 @@ export class HelpSessionService {
       entries.map(async (entry) => {
         const entryPath = path.join(sessionsRoot, entry);
         if (this.isProjectHashDirName(entry)) {
-          // Both cleanups run unconditionally — the dir's previous-launch
-          // agent isn't tracked across boots, and a no-op delete on a file
-          // that doesn't exist is harmless.
           await this.stripStaleDaintreeMcpEntry(entryPath);
-          await this.clearCodexConfig(entryPath);
           return;
         }
         await this.removeSessionDir(entryPath);
@@ -605,61 +658,6 @@ export class HelpSessionService {
       await fs.rm(sessionPath, { recursive: true, force: true });
     } catch (err) {
       console.warn("[HelpSessionService] Failed to remove session dir:", sessionPath, err);
-    }
-  }
-
-  /**
-   * Writes `<sessionPath>/.codex/config.toml` for a Codex assistant launch.
-   * Uses `bearer_token_env_var` so the literal token never lands on disk —
-   * Codex reads `DAINTREE_MCP_TOKEN` from the PTY env at MCP-connect time.
-   *
-   * The transport key is `transport = "http"` (not `type = "streamable-http"`):
-   * Codex's TOML schema names the field `transport`, and using the wrong key
-   * silently leaves the entry parsed-but-disconnected. The `--trust-project`
-   * flag injected by the spawn handler is what actually authorizes Codex to
-   * read this project-scoped config.
-   */
-  private async writeCodexConfig(
-    sessionPath: string,
-    settings: { daintreeControl: boolean; docSearch: boolean },
-    port: number | null
-  ): Promise<void> {
-    const blocks: string[] = [];
-    if (settings.daintreeControl && port) {
-      blocks.push(
-        `[mcp_servers.daintree]\n` +
-          `transport = "http"\n` +
-          `url = "http://127.0.0.1:${port}/mcp"\n` +
-          `bearer_token_env_var = "DAINTREE_MCP_TOKEN"\n`
-      );
-    }
-    if (settings.docSearch) {
-      blocks.push(
-        `[mcp_servers.daintree-docs]\n` +
-          `transport = "http"\n` +
-          `url = "https://daintree.org/api/mcp"\n`
-      );
-    }
-    const target = path.join(sessionPath, ".codex", "config.toml");
-    await fs.mkdir(path.dirname(target), { recursive: true });
-    const body = blocks.length > 0 ? blocks.join("\n") : "";
-    await resilientAtomicWriteFile(target, body, "utf-8", { mode: 0o600 });
-  }
-
-  /**
-   * Deletes `<sessionPath>/.codex/config.toml` on revoke or stale GC. Unlike
-   * the Claude `.mcp.json` strip dance, the Codex TOML carries no literal
-   * token — `bearer_token_env_var` reads from PTY env — so a flat delete is
-   * both correct and race-safe (a concurrent fresh provision rewrites the
-   * file from scratch).
-   */
-  private async clearCodexConfig(sessionPath: string): Promise<void> {
-    const target = path.join(sessionPath, ".codex", "config.toml");
-    try {
-      await fs.rm(target, { force: true });
-    } catch (err) {
-      if ((err as NodeJS.ErrnoException).code === "ENOENT") return;
-      console.warn("[HelpSessionService] Failed to clear codex config:", target, err);
     }
   }
 

--- a/electron/services/HelpSessionService.ts
+++ b/electron/services/HelpSessionService.ts
@@ -8,6 +8,7 @@ import { getHelpFolderPath } from "./HelpService.js";
 import { resilientAtomicWriteFile } from "../utils/fs.js";
 import { formatErrorMessage } from "../../shared/utils/errorMessage.js";
 import { probeMcpServer, probeMcpSseServer } from "./mcp-server/readinessProbe.js";
+import { getAssistantSupportedAgentIds } from "../../shared/config/agentRegistry.js";
 import type { HelpAssistantTier } from "../../shared/types/ipc/maps.js";
 
 const SESSIONS_DIR_NAME = "help-sessions";
@@ -26,6 +27,7 @@ const DEFAULT_SKIP_PERMISSIONS = false;
 interface ProvisionInput {
   projectId: string;
   projectPath: string;
+  agentId: string;
   windowId: number;
   projectViewWebContentsId: number;
 }
@@ -47,6 +49,7 @@ interface HelpSessionRecord {
   projectId: string;
   projectPath: string;
   sessionPath: string;
+  agentId: string;
   tier: HelpAssistantTier;
   createdAt: number;
   revoked: boolean;
@@ -214,8 +217,15 @@ export class HelpSessionService {
     await fs.chmod(sessionPath, 0o700).catch(() => {});
 
     const port = await this.getMcpPort(settings.daintreeControl);
-    await this.writeMcpConfig(sessionPath, settings, port, token);
-    await this.writeClaudeSettings(sessionPath, helpFolder, settings);
+    if (input.agentId === "codex") {
+      // Codex reads `bearer_token_env_var` at MCP-connect time from the PTY
+      // env, so the literal token never lands on disk. The token comes from
+      // DAINTREE_MCP_TOKEN injected by `buildHelpEnv()` in the renderer.
+      await this.writeCodexConfig(sessionPath, settings, port);
+    } else {
+      await this.writeMcpConfig(sessionPath, settings, port, token);
+      await this.writeClaudeSettings(sessionPath, helpFolder, settings);
+    }
 
     const now = Date.now();
     const record: HelpSessionRecord = {
@@ -226,6 +236,7 @@ export class HelpSessionService {
       projectId: input.projectId,
       projectPath: input.projectPath,
       sessionPath,
+      agentId: input.agentId,
       tier,
       createdAt: now,
       revoked: false,
@@ -242,12 +253,22 @@ export class HelpSessionService {
 
     if (settings.daintreeControl && port) {
       try {
-        await probeMcpSseServer(port, token);
+        if (input.agentId === "codex") {
+          // Codex MCP wiring uses Streamable HTTP at /mcp (probeMcpServer),
+          // not the SSE transport Claude Code reads from .mcp.json.
+          await probeMcpServer(port, token);
+        } else {
+          await probeMcpSseServer(port, token);
+        }
       } catch (err) {
         record.revoked = true;
         this.sessionsByToken.delete(token);
         this.sessionsById.delete(sessionId);
-        await this.stripStaleDaintreeMcpEntry(sessionPath);
+        if (input.agentId === "codex") {
+          await this.clearCodexConfig(sessionPath);
+        } else {
+          await this.stripStaleDaintreeMcpEntry(sessionPath);
+        }
         const reason = formatErrorMessage(err, "assistant MCP session isn't ready");
         throw new HelpSessionError(
           "MCP_NOT_READY",
@@ -256,8 +277,18 @@ export class HelpSessionService {
       }
     }
 
-    const mcpUrl = settings.daintreeControl && port ? `http://127.0.0.1:${port}/sse` : null;
+    const mcpUrl = this.buildMcpUrl(input.agentId, settings.daintreeControl, port);
     return { sessionId, sessionPath, token, tier, mcpUrl, windowId: input.windowId };
+  }
+
+  private buildMcpUrl(
+    agentId: string,
+    daintreeControl: boolean,
+    port: number | null
+  ): string | null {
+    if (!daintreeControl || !port) return null;
+    if (agentId === "codex") return `http://127.0.0.1:${port}/mcp`;
+    return `http://127.0.0.1:${port}/sse`;
   }
 
   /**
@@ -276,7 +307,11 @@ export class HelpSessionService {
     record.revoked = true;
     this.sessionsById.delete(sessionId);
     this.sessionsByToken.delete(record.token);
-    await this.stripStaleDaintreeMcpEntry(record.sessionPath);
+    if (record.agentId === "codex") {
+      await this.clearCodexConfig(record.sessionPath);
+    } else {
+      await this.stripStaleDaintreeMcpEntry(record.sessionPath);
+    }
   }
 
   async revokeByWebContentsId(webContentsId: number): Promise<void> {
@@ -326,7 +361,11 @@ export class HelpSessionService {
       entries.map(async (entry) => {
         const entryPath = path.join(sessionsRoot, entry);
         if (this.isProjectHashDirName(entry)) {
+          // Both cleanups run unconditionally — the dir's previous-launch
+          // agent isn't tracked across boots, and a no-op delete on a file
+          // that doesn't exist is harmless.
           await this.stripStaleDaintreeMcpEntry(entryPath);
+          await this.clearCodexConfig(entryPath);
           return;
         }
         await this.removeSessionDir(entryPath);
@@ -361,6 +400,12 @@ export class HelpSessionService {
     }
     if (!Number.isInteger(input.projectViewWebContentsId) || input.projectViewWebContentsId < 0) {
       throw new Error("projectViewWebContentsId must be a non-negative integer");
+    }
+    if (typeof input.agentId !== "string" || !input.agentId.trim()) {
+      throw new Error("agentId is required");
+    }
+    if (!getAssistantSupportedAgentIds().includes(input.agentId)) {
+      throw new Error(`agentId "${input.agentId}" is not assistant-supported`);
     }
   }
 
@@ -560,6 +605,61 @@ export class HelpSessionService {
       await fs.rm(sessionPath, { recursive: true, force: true });
     } catch (err) {
       console.warn("[HelpSessionService] Failed to remove session dir:", sessionPath, err);
+    }
+  }
+
+  /**
+   * Writes `<sessionPath>/.codex/config.toml` for a Codex assistant launch.
+   * Uses `bearer_token_env_var` so the literal token never lands on disk —
+   * Codex reads `DAINTREE_MCP_TOKEN` from the PTY env at MCP-connect time.
+   *
+   * The transport key is `transport = "http"` (not `type = "streamable-http"`):
+   * Codex's TOML schema names the field `transport`, and using the wrong key
+   * silently leaves the entry parsed-but-disconnected. The `--trust-project`
+   * flag injected by the spawn handler is what actually authorizes Codex to
+   * read this project-scoped config.
+   */
+  private async writeCodexConfig(
+    sessionPath: string,
+    settings: { daintreeControl: boolean; docSearch: boolean },
+    port: number | null
+  ): Promise<void> {
+    const blocks: string[] = [];
+    if (settings.daintreeControl && port) {
+      blocks.push(
+        `[mcp_servers.daintree]\n` +
+          `transport = "http"\n` +
+          `url = "http://127.0.0.1:${port}/mcp"\n` +
+          `bearer_token_env_var = "DAINTREE_MCP_TOKEN"\n`
+      );
+    }
+    if (settings.docSearch) {
+      blocks.push(
+        `[mcp_servers.daintree-docs]\n` +
+          `transport = "http"\n` +
+          `url = "https://daintree.org/api/mcp"\n`
+      );
+    }
+    const target = path.join(sessionPath, ".codex", "config.toml");
+    await fs.mkdir(path.dirname(target), { recursive: true });
+    const body = blocks.length > 0 ? blocks.join("\n") : "";
+    await resilientAtomicWriteFile(target, body, "utf-8", { mode: 0o600 });
+  }
+
+  /**
+   * Deletes `<sessionPath>/.codex/config.toml` on revoke or stale GC. Unlike
+   * the Claude `.mcp.json` strip dance, the Codex TOML carries no literal
+   * token — `bearer_token_env_var` reads from PTY env — so a flat delete is
+   * both correct and race-safe (a concurrent fresh provision rewrites the
+   * file from scratch).
+   */
+  private async clearCodexConfig(sessionPath: string): Promise<void> {
+    const target = path.join(sessionPath, ".codex", "config.toml");
+    try {
+      await fs.rm(target, { force: true });
+    } catch (err) {
+      if ((err as NodeJS.ErrnoException).code === "ENOENT") return;
+      console.warn("[HelpSessionService] Failed to clear codex config:", target, err);
     }
   }
 

--- a/electron/services/__tests__/HelpSessionService.test.ts
+++ b/electron/services/__tests__/HelpSessionService.test.ts
@@ -140,6 +140,7 @@ describe("HelpSessionService", () => {
     return {
       projectId: "proj-1",
       projectPath: "/tmp/project",
+      agentId: "claude",
       windowId: 7,
       projectViewWebContentsId: 42,
     };
@@ -561,5 +562,125 @@ describe("HelpSessionService", () => {
     );
     expect(mcp.mcpServers.daintree).toBeUndefined();
     expect(mcp.mcpServers["daintree-docs"]).toBeDefined();
+  });
+
+  describe("Codex", () => {
+    function codexInput() {
+      return { ...provisionInput(), agentId: "codex" };
+    }
+
+    it("rejects an unknown agentId before any disk writes", async () => {
+      await expect(
+        service.provisionSession({ ...provisionInput(), agentId: "not-an-agent" })
+      ).rejects.toThrow(/not assistant-supported/);
+    });
+
+    it("returns a /mcp URL (Streamable HTTP) for Codex assistant launches", async () => {
+      const result = await service.provisionSession(codexInput());
+      if (!result) throw new Error("expected result");
+      expect(result.mcpUrl).toBe("http://127.0.0.1:45454/mcp");
+    });
+
+    it("writes .codex/config.toml with bearer_token_env_var (no literal token on disk)", async () => {
+      const result = await service.provisionSession(codexInput());
+      if (!result) throw new Error("expected result");
+
+      const tomlPath = path.join(result.sessionPath, ".codex", "config.toml");
+      const toml = await fs.readFile(tomlPath, "utf-8");
+
+      expect(toml).toContain("[mcp_servers.daintree]");
+      expect(toml).toContain('transport = "http"');
+      expect(toml).toContain('url = "http://127.0.0.1:45454/mcp"');
+      expect(toml).toContain('bearer_token_env_var = "DAINTREE_MCP_TOKEN"');
+      expect(toml).toContain("[mcp_servers.daintree-docs]");
+      expect(toml).toContain('url = "https://daintree.org/api/mcp"');
+      // Token must never land on disk — the bearer is read from PTY env at
+      // MCP-connect time.
+      expect(toml).not.toContain(result.token);
+      expect(toml).not.toContain("Bearer");
+      expect(toml).not.toContain("type =");
+    });
+
+    it("does NOT write Claude's .mcp.json or .claude/settings.json for a Codex provision", async () => {
+      const result = await service.provisionSession(codexInput());
+      if (!result) throw new Error("expected result");
+
+      // The bundled help template carries .mcp.json + .claude/settings.json
+      // (copied via fs.cp), so they exist on disk — but the Codex branch
+      // must not REWRITE them with Claude-shaped overlay content.
+      const mcp = JSON.parse(
+        await fs.readFile(path.join(result.sessionPath, ".mcp.json"), "utf-8")
+      );
+      // Claude branch sets `daintree` server with literal Bearer token; Codex
+      // branch leaves the bundled template untouched (no daintree entry, no
+      // enableAllProjectMcpServers overlay).
+      expect(mcp.mcpServers.daintree).toBeUndefined();
+    });
+
+    it("probes /mcp (probeMcpServer) for Codex, not /sse (probeMcpSseServer)", async () => {
+      const result = await service.provisionSession(codexInput());
+      if (!result) throw new Error("expected result");
+
+      // ensureMcpServerReady runs probeMcpServer once with the API key
+      // before provision; Codex post-provision also probes /mcp with the
+      // session token. Total: probeMcpServer twice, probeMcpSseServer never.
+      expect(mockProbeMcpServer).toHaveBeenCalledTimes(2);
+      expect(mockProbeMcpServer).toHaveBeenLastCalledWith(45454, result.token);
+      expect(mockProbeMcpSseServer).not.toHaveBeenCalled();
+    });
+
+    it("clears .codex/config.toml on revoke", async () => {
+      const result = await service.provisionSession(codexInput());
+      if (!result) throw new Error("expected result");
+
+      const tomlPath = path.join(result.sessionPath, ".codex", "config.toml");
+      await fs.access(tomlPath);
+
+      await service.revokeSession(result.sessionId);
+
+      let exists = true;
+      try {
+        await fs.access(tomlPath);
+      } catch {
+        exists = false;
+      }
+      expect(exists).toBe(false);
+    });
+
+    it("omits the daintree block from the TOML when daintreeControl is false but keeps daintree-docs", async () => {
+      mockStoreGet.mockReturnValue({ daintreeControl: false });
+
+      const result = await service.provisionSession(codexInput());
+      if (!result) throw new Error("expected result");
+
+      const toml = await fs.readFile(
+        path.join(result.sessionPath, ".codex", "config.toml"),
+        "utf-8"
+      );
+      expect(toml).not.toContain("[mcp_servers.daintree]");
+      expect(toml).toContain("[mcp_servers.daintree-docs]");
+    });
+
+    it("clears the codex TOML on probe failure and throws MCP_NOT_READY", async () => {
+      mockProbeMcpServer.mockResolvedValueOnce(undefined);
+      mockProbeMcpServer.mockRejectedValueOnce(new Error("/mcp returned status 500"));
+
+      await expect(service.provisionSession(codexInput())).rejects.toMatchObject({
+        name: "HelpSessionError",
+        code: "MCP_NOT_READY",
+      });
+
+      const sessionsRoot = path.join(userData, "help-sessions");
+      const entries = await fs.readdir(sessionsRoot);
+      expect(entries.length).toBe(1);
+      const tomlPath = path.join(sessionsRoot, entries[0]!, ".codex", "config.toml");
+      let exists = true;
+      try {
+        await fs.access(tomlPath);
+      } catch {
+        exists = false;
+      }
+      expect(exists).toBe(false);
+    });
   });
 });

--- a/electron/services/__tests__/HelpSessionService.test.ts
+++ b/electron/services/__tests__/HelpSessionService.test.ts
@@ -581,40 +581,28 @@ describe("HelpSessionService", () => {
       expect(result.mcpUrl).toBe("http://127.0.0.1:45454/mcp");
     });
 
-    it("writes .codex/config.toml with bearer_token_env_var (no literal token on disk)", async () => {
+    it("does NOT write .mcp.json or .codex/config.toml for a Codex provision (Codex uses -c flags, not files)", async () => {
       const result = await service.provisionSession(codexInput());
       if (!result) throw new Error("expected result");
 
-      const tomlPath = path.join(result.sessionPath, ".codex", "config.toml");
-      const toml = await fs.readFile(tomlPath, "utf-8");
-
-      expect(toml).toContain("[mcp_servers.daintree]");
-      expect(toml).toContain('transport = "http"');
-      expect(toml).toContain('url = "http://127.0.0.1:45454/mcp"');
-      expect(toml).toContain('bearer_token_env_var = "DAINTREE_MCP_TOKEN"');
-      expect(toml).toContain("[mcp_servers.daintree-docs]");
-      expect(toml).toContain('url = "https://daintree.org/api/mcp"');
-      // Token must never land on disk — the bearer is read from PTY env at
-      // MCP-connect time.
-      expect(toml).not.toContain(result.token);
-      expect(toml).not.toContain("Bearer");
-      expect(toml).not.toContain("type =");
-    });
-
-    it("does NOT write Claude's .mcp.json or .claude/settings.json for a Codex provision", async () => {
-      const result = await service.provisionSession(codexInput());
-      if (!result) throw new Error("expected result");
-
-      // The bundled help template carries .mcp.json + .claude/settings.json
-      // (copied via fs.cp), so they exist on disk — but the Codex branch
-      // must not REWRITE them with Claude-shaped overlay content.
+      // The bundled help template carries .mcp.json from the help/ folder
+      // (copied via fs.cp), so the bundled file exists on disk — but the
+      // Codex branch must NOT rewrite it with the Claude-shaped daintree
+      // entry that bakes a literal bearer token.
       const mcp = JSON.parse(
         await fs.readFile(path.join(result.sessionPath, ".mcp.json"), "utf-8")
       );
-      // Claude branch sets `daintree` server with literal Bearer token; Codex
-      // branch leaves the bundled template untouched (no daintree entry, no
-      // enableAllProjectMcpServers overlay).
       expect(mcp.mcpServers.daintree).toBeUndefined();
+
+      // Codex doesn't read project-scoped TOML, so a config file is dead
+      // weight if written. The Codex branch must not create one.
+      let tomlExists = true;
+      try {
+        await fs.access(path.join(result.sessionPath, ".codex", "config.toml"));
+      } catch {
+        tomlExists = false;
+      }
+      expect(tomlExists).toBe(false);
     });
 
     it("probes /mcp (probeMcpServer) for Codex, not /sse (probeMcpSseServer)", async () => {
@@ -629,58 +617,93 @@ describe("HelpSessionService", () => {
       expect(mockProbeMcpSseServer).not.toHaveBeenCalled();
     });
 
-    it("clears .codex/config.toml on revoke", async () => {
+    it("getCodexLaunchArgs returns -c flags for both daintree and daintree-docs servers", async () => {
       const result = await service.provisionSession(codexInput());
       if (!result) throw new Error("expected result");
 
-      const tomlPath = path.join(result.sessionPath, ".codex", "config.toml");
-      await fs.access(tomlPath);
-
-      await service.revokeSession(result.sessionId);
-
-      let exists = true;
-      try {
-        await fs.access(tomlPath);
-      } catch {
-        exists = false;
-      }
-      expect(exists).toBe(false);
+      const args = service.getCodexLaunchArgs(result.token);
+      expect(args).toEqual([
+        "-c",
+        'mcp_servers.daintree.transport="http"',
+        "-c",
+        'mcp_servers.daintree.url="http://127.0.0.1:45454/mcp"',
+        "-c",
+        'mcp_servers.daintree.bearer_token_env_var="DAINTREE_MCP_TOKEN"',
+        "-c",
+        'mcp_servers.daintree-docs.transport="http"',
+        "-c",
+        'mcp_servers.daintree-docs.url="https://daintree.org/api/mcp"',
+      ]);
+      // Token must NEVER appear in argv — Codex reads it from PTY env via
+      // `bearer_token_env_var`.
+      expect(args!.join(" ")).not.toContain(result.token);
     });
 
-    it("omits the daintree block from the TOML when daintreeControl is false but keeps daintree-docs", async () => {
+    it("getCodexLaunchArgs omits the daintree block when daintreeControl is false but keeps daintree-docs", async () => {
       mockStoreGet.mockReturnValue({ daintreeControl: false });
 
       const result = await service.provisionSession(codexInput());
       if (!result) throw new Error("expected result");
 
-      const toml = await fs.readFile(
-        path.join(result.sessionPath, ".codex", "config.toml"),
-        "utf-8"
-      );
-      expect(toml).not.toContain("[mcp_servers.daintree]");
-      expect(toml).toContain("[mcp_servers.daintree-docs]");
+      const args = service.getCodexLaunchArgs(result.token);
+      const flat = args!.join(" ");
+      expect(flat).not.toContain("mcp_servers.daintree.");
+      expect(flat).toContain("mcp_servers.daintree-docs.");
     });
 
-    it("clears the codex TOML on probe failure and throws MCP_NOT_READY", async () => {
-      mockProbeMcpServer.mockResolvedValueOnce(undefined);
+    it("getCodexLaunchArgs returns [] when both server toggles are off", async () => {
+      mockStoreGet.mockReturnValue({ daintreeControl: false, docSearch: false });
+
+      const result = await service.provisionSession(codexInput());
+      if (!result) throw new Error("expected result");
+
+      expect(service.getCodexLaunchArgs(result.token)).toEqual([]);
+    });
+
+    it("getCodexLaunchArgs returns null for a Claude session (defense against cross-agent leakage)", async () => {
+      const result = await service.provisionSession(provisionInput());
+      if (!result) throw new Error("expected result");
+
+      expect(service.getCodexLaunchArgs(result.token)).toBeNull();
+    });
+
+    it("getCodexLaunchArgs returns null for unknown / revoked tokens", async () => {
+      const result = await service.provisionSession(codexInput());
+      if (!result) throw new Error("expected result");
+
+      expect(service.getCodexLaunchArgs("not-a-real-token")).toBeNull();
+      expect(service.getCodexLaunchArgs("")).toBeNull();
+
+      await service.revokeSession(result.sessionId);
+      expect(service.getCodexLaunchArgs(result.token)).toBeNull();
+    });
+
+    it("revoking a Codex session leaves a sibling Codex session's launch args intact (no shared-file race)", async () => {
+      // Two windows opening the same project share one sessionPath. The
+      // Claude path needs token-checking on .mcp.json strip to avoid
+      // clobbering a live sibling's bearer; the Codex path stores nothing on
+      // disk, so a revoke just invalidates the in-memory record.
+      const a = await service.provisionSession(codexInput());
+      const b = await service.provisionSession(codexInput());
+      if (!a || !b) throw new Error("expected provisions");
+      expect(a.sessionPath).toBe(b.sessionPath);
+
+      await service.revokeSession(a.sessionId);
+
+      expect(service.getCodexLaunchArgs(a.token)).toBeNull();
+      const bArgs = service.getCodexLaunchArgs(b.token);
+      expect(bArgs).not.toBeNull();
+      expect(bArgs!.length).toBeGreaterThan(0);
+    });
+
+    it("throws MCP_NOT_READY when the post-provision /mcp probe fails", async () => {
+      mockProbeMcpServer.mockResolvedValueOnce(undefined); // ensureMcpServerReady
       mockProbeMcpServer.mockRejectedValueOnce(new Error("/mcp returned status 500"));
 
       await expect(service.provisionSession(codexInput())).rejects.toMatchObject({
         name: "HelpSessionError",
         code: "MCP_NOT_READY",
       });
-
-      const sessionsRoot = path.join(userData, "help-sessions");
-      const entries = await fs.readdir(sessionsRoot);
-      expect(entries.length).toBe(1);
-      const tomlPath = path.join(sessionsRoot, entries[0]!, ".codex", "config.toml");
-      let exists = true;
-      try {
-        await fs.access(tomlPath);
-      } catch {
-        exists = false;
-      }
-      expect(exists).toBe(false);
     });
   });
 });

--- a/shared/config/agents/codex.ts
+++ b/shared/config/agents/codex.ts
@@ -12,6 +12,7 @@ export const config: AgentConfig = {
   color: "#10a37f",
   iconId: "codex",
   supportsContextInjection: true,
+  supportsAssistant: true,
   shortcut: "Cmd/Ctrl+Alt+X",
   tooltip: "careful, methodical runs",
   usageUrl: "https://chatgpt.com/codex/settings/usage",

--- a/shared/types/ipc/api.ts
+++ b/shared/types/ipc/api.ts
@@ -1384,7 +1384,7 @@ export interface ElectronAPI {
     getFolderPath(): Promise<string | null>;
     markTerminal(terminalId: string): Promise<void>;
     unmarkTerminal(terminalId: string): Promise<void>;
-    provisionSession(input: { projectId: string; projectPath: string }): Promise<{
+    provisionSession(input: { projectId: string; projectPath: string; agentId: string }): Promise<{
       sessionId: string;
       sessionPath: string;
       token: string;

--- a/shared/types/ipc/maps.ts
+++ b/shared/types/ipc/maps.ts
@@ -2097,7 +2097,7 @@ export interface IpcInvokeMap {
     result: void;
   };
   "help:provision-session": {
-    args: [input: { projectId: string; projectPath: string }];
+    args: [input: { projectId: string; projectPath: string; agentId: string }];
     result: {
       sessionId: string;
       sessionPath: string;

--- a/src/components/HelpPanel/HelpPanel.tsx
+++ b/src/components/HelpPanel/HelpPanel.tsx
@@ -89,11 +89,15 @@ interface HelpProjectRef {
   path: string;
 }
 
-async function provisionHelpSession(project: HelpProjectRef): Promise<ProvisionOutcome> {
+async function provisionHelpSession(
+  project: HelpProjectRef,
+  agentId: string
+): Promise<ProvisionOutcome> {
   try {
     const result = await window.electron.help.provisionSession({
       projectId: project.id,
       projectPath: project.path,
+      agentId,
     });
     if (!result) {
       return {
@@ -569,7 +573,7 @@ export function HelpPanel({
           return;
         }
 
-        const outcome = await provisionHelpSession(launchProject);
+        const outcome = await provisionHelpSession(launchProject, launchAgentId);
         if (!outcome.ok) {
           hasAutoLaunched.current = false;
           if (outcome.code === "MCP_NOT_READY") {
@@ -759,7 +763,7 @@ export function HelpPanel({
           return;
         }
 
-        const outcome = await provisionHelpSession(launchProject);
+        const outcome = await provisionHelpSession(launchProject, selectedAgentId);
         if (!outcome.ok) {
           // Reset the auto-launch gate so a recovered MCP can re-launch on
           // the next render — the single-supported-agent useEffect uses
@@ -944,7 +948,7 @@ export function HelpPanel({
       (async () => {
         let session: HelpSessionRef | null = null;
         try {
-          const outcome = await provisionHelpSession(launchProject);
+          const outcome = await provisionHelpSession(launchProject, launchAgentId);
           if (!outcome.ok) {
             pendingNewTerminalIdRef.current = null;
             useHelpPanelStore.getState().clearTerminal();
@@ -1095,7 +1099,7 @@ export function HelpPanel({
       (async () => {
         let session: HelpSessionRef | null = null;
         try {
-          const outcome = await provisionHelpSession(launchProject);
+          const outcome = await provisionHelpSession(launchProject, launchAgentId);
           if (!outcome.ok) {
             pendingNewTerminalIdRef.current = null;
             useHelpPanelStore.getState().clearTerminal();

--- a/src/components/HelpPanel/__tests__/HelpPanel.helpLaunch.test.tsx
+++ b/src/components/HelpPanel/__tests__/HelpPanel.helpLaunch.test.tsx
@@ -504,6 +504,7 @@ describe("HelpPanel — auto-launch (preferredAgentId)", () => {
     expect(mockProvisionSession).toHaveBeenCalledWith({
       projectId: "proj-default",
       projectPath: "/repo",
+      agentId: "claude",
     });
     expect(mockDispatch).toHaveBeenCalledWith(
       "agent.launch",
@@ -531,6 +532,7 @@ describe("HelpPanel — auto-launch (preferredAgentId)", () => {
     expect(mockProvisionSession).toHaveBeenCalledWith({
       projectId: "proj-late",
       projectPath: "/late-repo",
+      agentId: "claude",
     });
     expect(mockDispatch).toHaveBeenCalledWith(
       "agent.launch",
@@ -627,6 +629,44 @@ describe("HelpPanel — auto-launch (preferredAgentId)", () => {
     expect(mockNotify).toHaveBeenCalledWith(
       expect.objectContaining({ type: "error", title: "Assistant launch failed" })
     );
+  });
+
+  it("provisions and dispatches a Codex assistant launch when codex is the preferred agent", async () => {
+    mockGetAssistantSupportedAgentIds.mockReturnValue(["claude", "codex"]);
+    helpPanelState.preferredAgentId = "codex";
+    mockProvisionSession.mockResolvedValue({
+      sessionId: "sess-codex",
+      sessionPath: "/help-codex",
+      token: "tok-codex",
+      tier: "action",
+      mcpUrl: "http://127.0.0.1:45454/mcp",
+      windowId: 1,
+    });
+    mockGetFolderPath.mockResolvedValue("/help");
+    mockDispatch.mockResolvedValue({ ok: true, result: { terminalId: "codex-term-1" } });
+
+    await act(async () => {
+      render(<HelpPanel width={380} />);
+    });
+
+    expect(mockProvisionSession).toHaveBeenCalledWith({
+      projectId: "proj-default",
+      projectPath: "/repo",
+      agentId: "codex",
+    });
+    expect(mockDispatch).toHaveBeenCalledWith(
+      "agent.launch",
+      expect.objectContaining({
+        agentId: "codex",
+        cwd: "/help-codex",
+        env: expect.objectContaining({
+          DAINTREE_MCP_TOKEN: "tok-codex",
+          DAINTREE_MCP_URL: "http://127.0.0.1:45454/mcp",
+        }),
+      }),
+      { source: "user" }
+    );
+    expect(helpPanelState.setTerminal).toHaveBeenCalledWith("codex-term-1", "codex", "sess-codex");
   });
 });
 
@@ -979,6 +1019,7 @@ describe("HelpPanel — session provisioning", () => {
     expect(mockProvisionSession).toHaveBeenCalledWith({
       projectId: "proj-1",
       projectPath: "/repo",
+      agentId: "claude",
     });
     expect(mockDispatch).toHaveBeenCalledWith(
       "agent.launch",

--- a/src/components/Settings/__tests__/DaintreeAssistantSettingsTab.test.tsx
+++ b/src/components/Settings/__tests__/DaintreeAssistantSettingsTab.test.tsx
@@ -128,10 +128,18 @@ vi.mock("@/store/helpPanelStore", () => {
   };
 });
 
+const { mockGetAssistantSupportedAgentIds } = vi.hoisted(() => ({
+  mockGetAssistantSupportedAgentIds: vi.fn<() => string[]>(() => ["claude"]),
+}));
+
 vi.mock("@/config/agents", () => ({
-  getAgentIds: () => ["claude"],
-  getAssistantSupportedAgentIds: () => ["claude"],
-  getAgentConfig: (id: string) => (id === "claude" ? { name: "Claude Code" } : undefined),
+  getAgentIds: () => ["claude", "codex"],
+  getAssistantSupportedAgentIds: () => mockGetAssistantSupportedAgentIds(),
+  getAgentConfig: (id: string) => {
+    if (id === "claude") return { name: "Claude Code" };
+    if (id === "codex") return { name: "Codex" };
+    return undefined;
+  },
 }));
 
 import { DaintreeAssistantSettingsTab } from "../DaintreeAssistantSettingsTab";
@@ -194,6 +202,7 @@ describe("DaintreeAssistantSettingsTab", () => {
     vi.clearAllMocks();
     helpPanelState.preferredAgentId = null;
     helpPanelState.setPreferredAgent = vi.fn();
+    mockGetAssistantSupportedAgentIds.mockReturnValue(["claude"]);
     Object.defineProperty(navigator, "clipboard", {
       value: { writeText },
       writable: true,
@@ -339,6 +348,40 @@ describe("DaintreeAssistantSettingsTab", () => {
 
     expect(screen.queryByRole("button", { name: /rotate mcp key/i })).toBeNull();
     expect(screen.queryByRole("button", { name: /copy mcp config/i })).toBeNull();
+  });
+
+  it("lists Codex in the agent dropdown when it passes the assistant gate", async () => {
+    mockGetAssistantSupportedAgentIds.mockReturnValue(["claude", "codex"]);
+
+    const { container } = render(
+      <SettingsValidationProvider>
+        <DaintreeAssistantSettingsTab />
+      </SettingsValidationProvider>
+    );
+    await waitForContent(container, "Search documentation");
+
+    const select = container.querySelector("select[aria-label='Agent']");
+    expect(select).toBeInstanceOf(HTMLSelectElement);
+    if (!(select instanceof HTMLSelectElement)) throw new Error("select not found");
+    const labels = Array.from(select.options).map((o) => o.textContent ?? "");
+    expect(labels).toContain("Claude Code");
+    expect(labels).toContain("Codex");
+  });
+
+  it("hides Codex from the dropdown when only Claude passes the assistant gate", async () => {
+    const { container } = render(
+      <SettingsValidationProvider>
+        <DaintreeAssistantSettingsTab />
+      </SettingsValidationProvider>
+    );
+    await waitForContent(container, "Search documentation");
+
+    const select = container.querySelector("select[aria-label='Agent']");
+    expect(select).toBeInstanceOf(HTMLSelectElement);
+    if (!(select instanceof HTMLSelectElement)) throw new Error("select not found");
+    const labels = Array.from(select.options).map((o) => o.textContent ?? "");
+    expect(labels).toContain("Claude Code");
+    expect(labels).not.toContain("Codex");
   });
 
   it("does not render a Preferred model section", async () => {

--- a/src/services/actions/definitions/__tests__/helpLaunchAgent.test.ts
+++ b/src/services/actions/definitions/__tests__/helpLaunchAgent.test.ts
@@ -300,6 +300,7 @@ describe("help.launchAgent", () => {
     expect(window.electron.help.provisionSession).toHaveBeenCalledWith({
       projectId: "proj-1",
       projectPath: "/repo",
+      agentId: "claude",
     });
     expect(mockDispatch).toHaveBeenCalledWith(
       "agent.launch",

--- a/src/services/actions/definitions/preferencesActions.ts
+++ b/src/services/actions/definitions/preferencesActions.ts
@@ -728,6 +728,7 @@ export function registerPreferencesActions(
         session = await window.electron.help.provisionSession({
           projectId: project.id,
           projectPath: project.path,
+          agentId,
         });
       } catch (err) {
         logError("Failed to provision help session", err);

--- a/src/store/__tests__/helpPanelStore.test.ts
+++ b/src/store/__tests__/helpPanelStore.test.ts
@@ -114,7 +114,7 @@ describe("helpPanelStore persistence migration", () => {
   it("clears a v0 preferredAgentId when migrating to v1 if the agent is unsupported", async () => {
     const v0Blob = JSON.stringify({
       version: 0,
-      state: { width: 420, preferredAgentId: "codex" },
+      state: { width: 420, preferredAgentId: "gemini" },
     });
     installLocalStorage({ [STORAGE_KEY]: v0Blob });
 


### PR DESCRIPTION
## Summary

Adds Codex as a second supported agent in the Daintree Assistant panel (in addition to Claude Code). Closes #7330.

- Codex now appears in the assistant settings dropdown when its CLI is installed (\`supportsAssistant: true\` on its \`AgentConfig\`).
- Wires the Daintree MCP server into Codex help sessions via the \`-c key=value\` CLI override mechanism — Codex's only project-scoping path. The bearer token never lands on disk or in argv: Codex reads \`DAINTREE_MCP_TOKEN\` from the PTY env via \`bearer_token_env_var\`.
- Per-tier flag handling preserved: action-tier strips dangerous flags, system-tier appends \`--dangerously-bypass-approvals-and-sandbox\`.
- Probes \`/mcp\` (Streamable HTTP) for Codex sessions; Claude continues to probe \`/sse\`.

## Implementation notes

- The agent dropdown gate — \`supportsAssistant\` on \`AgentConfig\` — was already in place for Claude. This PR just lights up the existing path for Codex.
- IPC layer: \`agentId\` is threaded through \`help:provision-session\` so the service knows which agent it's provisioning for. Validated against \`getAssistantSupportedAgentIds()\`; unknown agents throw before any disk work.
- Codex doesn't read project-scoped \`.codex/config.toml\` from cwd (verified against \`codex-cli 0.129.0\`). The only override mechanism is the \`-c\` CLI flag. The previously hallucinated \`--trust-project\` flag is **not** a real Codex flag — caught in code review.
- The shared-sessionPath race condition (two windows opening the same project) doesn't exist for Codex since nothing is written to disk for Codex sessions. Claude's existing token-checking strip in \`.mcp.json\` is unchanged.

## Test plan

- [x] Unit: \`HelpSessionService\` — Codex provision branch, \`getCodexLaunchArgs\` shape + cross-agent leakage guard + sibling-revoke isolation, \`/mcp\` probe routing
- [x] Unit: \`lifecycle.ts\` — \`-c\` flag injection on Codex help launches, system-tier dangerous flag, no injection for non-help launches, defense-in-depth when \`getCodexLaunchArgs\` returns null
- [x] Unit: \`HelpPanel.tsx\` — Codex auto-launch path passes \`agentId: \"codex\"\` and \`/mcp\` URL through to \`agent.launch\`
- [x] Unit: \`DaintreeAssistantSettingsTab.tsx\` — Codex appears/hides in dropdown based on assistant gate
- [x] Verify: typecheck + channel drift + lint ratchet (decreased by 11) + format + build all pass
- [ ] E2E: nightly suite picks up via existing assistant launch coverage; manual smoke once merged