### PR TITLE
fix(notifications): dismiss entire notification thread on X click

### DIFF
--- a/src/components/Notifications/NotificationCenter.tsx
+++ b/src/components/Notifications/NotificationCenter.tsx
@@ -132,6 +132,7 @@ export function NotificationCenter({ open, onClose }: NotificationCenterProps) {
   const clearAll = useNotificationHistoryStore((s) => s.clearAll);
   const markAllRead = useNotificationHistoryStore((s) => s.markAllRead);
   const dismissEntry = useNotificationHistoryStore((s) => s.dismissEntry);
+  const dismissByCorrelationId = useNotificationHistoryStore((s) => s.dismissByCorrelationId);
 
   const {
     quietUntil,
@@ -469,7 +470,11 @@ export function NotificationCenter({ open, onClose }: NotificationCenterProps) {
         ) : (
           <>
             {needsAttentionGroups.length > 0 && (
-              <NeedsAttentionSection groups={needsAttentionGroups} onDismiss={dismissEntry} />
+              <NeedsAttentionSection
+                groups={needsAttentionGroups}
+                onDismiss={dismissEntry}
+                onDismissThread={dismissByCorrelationId}
+              />
             )}
             {chronoSections.map((section) => (
               <ChronoSection
@@ -478,6 +483,7 @@ export function NotificationCenter({ open, onClose }: NotificationCenterProps) {
                 groupByContext={groupByContext}
                 dividerGroupId={dividerGroupId}
                 onDismiss={dismissEntry}
+                onDismissThread={dismissByCorrelationId}
               />
             ))}
           </>
@@ -490,9 +496,11 @@ export function NotificationCenter({ open, onClose }: NotificationCenterProps) {
 function NeedsAttentionSection({
   groups,
   onDismiss,
+  onDismissThread,
 }: {
   groups: ThreadGroup[];
   onDismiss: (id: string) => void;
+  onDismissThread: (correlationId: string) => void;
 }) {
   return (
     <div data-testid="needs-attention-section" className="border-b border-divider">
@@ -500,7 +508,7 @@ function NeedsAttentionSection({
         Needs attention
       </div>
       <div className="divide-y divide-tint/[0.04]">
-        {groups.map((group) => renderGroup(group, onDismiss))}
+        {groups.map((group) => renderGroup(group, onDismiss, onDismissThread))}
       </div>
     </div>
   );
@@ -511,11 +519,13 @@ function ChronoSection({
   groupByContext,
   dividerGroupId,
   onDismiss,
+  onDismissThread,
 }: {
   section: ContextSection;
   groupByContext: boolean;
   dividerGroupId: string | null;
   onDismiss: (id: string) => void;
+  onDismissThread: (correlationId: string) => void;
 }) {
   return (
     <div data-testid="chrono-section">
@@ -533,7 +543,7 @@ function ChronoSection({
           return (
             <div key={groupKey}>
               {isDivider && <NewSinceLastLookedDivider />}
-              {renderGroup(group, onDismiss)}
+              {renderGroup(group, onDismiss, onDismissThread)}
             </div>
           );
         })}
@@ -542,9 +552,19 @@ function ChronoSection({
   );
 }
 
-function renderGroup(group: ThreadGroup, onDismiss: (id: string) => void) {
+function renderGroup(
+  group: ThreadGroup,
+  onDismiss: (id: string) => void,
+  onDismissThread: (correlationId: string) => void
+) {
   if (group.correlationId && group.entries.length > 1) {
-    return <NotificationThread key={group.correlationId} group={group} onDismiss={onDismiss} />;
+    return (
+      <NotificationThread
+        key={group.correlationId}
+        group={group}
+        onDismiss={() => onDismissThread(group.correlationId!)}
+      />
+    );
   }
   const entry = group.entries[0]!;
   return (
@@ -596,13 +616,7 @@ function NewSinceLastLookedDivider() {
   );
 }
 
-function NotificationThread({
-  group,
-  onDismiss,
-}: {
-  group: ThreadGroup;
-  onDismiss: (id: string) => void;
-}) {
+function NotificationThread({ group, onDismiss }: { group: ThreadGroup; onDismiss: () => void }) {
   const latest = group.entries[0];
   const isNew = group.entries.some((e) => !e.seenAsToast);
 
@@ -617,7 +631,7 @@ function NotificationThread({
         displayType={displayType}
         threadCount={group.entries.length}
         isNew={isNew}
-        onDismiss={() => onDismiss(latest.id)}
+        onDismiss={onDismiss}
       />
     </div>
   );

--- a/src/components/Notifications/__tests__/NotificationCenter.test.tsx
+++ b/src/components/Notifications/__tests__/NotificationCenter.test.tsx
@@ -581,6 +581,133 @@ describe("NotificationThread visual treatment", () => {
   });
 });
 
+describe("NotificationThread — dismiss removes entire thread", () => {
+  it("removes all entries in a multi-entry thread with one X click", async () => {
+    const correlationId = "thread-dismiss";
+    useNotificationHistoryStore.getState().addEntry({
+      ...makeEntry({
+        id: "first",
+        type: "info",
+        message: "Build failed",
+        correlationId,
+        timestamp: Date.now() - 2000,
+      }),
+      seenAsToast: true,
+    });
+    useNotificationHistoryStore.getState().addEntry({
+      ...makeEntry({
+        id: "second",
+        type: "info",
+        message: "Build retried",
+        correlationId,
+        timestamp: Date.now() - 1000,
+      }),
+      seenAsToast: true,
+    });
+
+    render(<NotificationCenter open onClose={vi.fn()} />);
+
+    await waitFor(() => {
+      expect(screen.getByTestId("notification-thread")).toBeTruthy();
+    });
+
+    const thread = screen.getByTestId("notification-thread");
+    const dismissButton = within(thread).getByLabelText("Dismiss notification");
+    await act(async () => {
+      fireEvent.click(dismissButton);
+    });
+
+    expect(screen.queryByTestId("notification-thread")).toBeNull();
+    expect(useNotificationHistoryStore.getState().entries).toHaveLength(0);
+  });
+
+  it("does not remove entries with a different correlationId", async () => {
+    const correlationId = "thread-dismiss-2";
+    useNotificationHistoryStore.getState().addEntry({
+      ...makeEntry({
+        id: "first",
+        type: "info",
+        message: "Build failed",
+        correlationId,
+        timestamp: Date.now() - 2000,
+      }),
+      seenAsToast: true,
+    });
+    useNotificationHistoryStore.getState().addEntry({
+      ...makeEntry({
+        id: "second",
+        type: "info",
+        message: "Build retried",
+        correlationId,
+        timestamp: Date.now() - 1000,
+      }),
+      seenAsToast: true,
+    });
+    useNotificationHistoryStore.getState().addEntry(
+      makeEntry({
+        id: "solo",
+        type: "info",
+        message: "Unrelated notification",
+      })
+    );
+
+    render(<NotificationCenter open onClose={vi.fn()} />);
+
+    await waitFor(() => {
+      expect(screen.getByTestId("notification-thread")).toBeTruthy();
+    });
+
+    const thread = screen.getByTestId("notification-thread");
+    const dismissButton = within(thread).getByLabelText("Dismiss notification");
+    await act(async () => {
+      fireEvent.click(dismissButton);
+    });
+
+    expect(screen.queryByTestId("notification-thread")).toBeNull();
+    expect(useNotificationHistoryStore.getState().entries).toHaveLength(1);
+    expect(useNotificationHistoryStore.getState().entries[0]!.message).toBe(
+      "Unrelated notification"
+    );
+  });
+
+  it("updates unreadCount correctly when thread entries are dismissed", async () => {
+    const correlationId = "thread-dismiss-3";
+    useNotificationHistoryStore.getState().addEntry({
+      ...makeEntry({
+        type: "info",
+        message: "Error 1",
+        correlationId,
+      }),
+      seenAsToast: false,
+    });
+    useNotificationHistoryStore.getState().addEntry({
+      ...makeEntry({
+        id: "test-2",
+        type: "info",
+        message: "Error 2",
+        correlationId,
+      }),
+      seenAsToast: true,
+    });
+
+    expect(useNotificationHistoryStore.getState().unreadCount).toBe(1);
+
+    render(<NotificationCenter open onClose={vi.fn()} />);
+
+    await waitFor(() => {
+      expect(screen.getByTestId("notification-thread")).toBeTruthy();
+    });
+
+    const thread = screen.getByTestId("notification-thread");
+    const dismissButton = within(thread).getByLabelText("Dismiss notification");
+    await act(async () => {
+      fireEvent.click(dismissButton);
+    });
+
+    expect(useNotificationHistoryStore.getState().unreadCount).toBe(0);
+  });
+});
+
 describe("NotificationCenter empty state — zero data", () => {
   it("renders a description that explains where notifications appear", () => {
     render(<NotificationCenter open onClose={vi.fn()} />);

--- a/src/store/__tests__/notificationHistoryStore.test.ts
+++ b/src/store/__tests__/notificationHistoryStore.test.ts
@@ -475,4 +475,88 @@ describe("notificationHistorySlice", () => {
       expect(getState().entries[0]!.message).toBe("missed 1");
     });
   });
+
+  describe("dismissByCorrelationId", () => {
+    it("removes all entries with matching correlationId", () => {
+      addEntry({ message: "first", correlationId: "panel-1" });
+      addEntry({ message: "second", correlationId: "panel-1" });
+      addEntry({ message: "third", correlationId: "panel-1" });
+      expect(getState().entries).toHaveLength(3);
+      getState().dismissByCorrelationId("panel-1");
+      expect(getState().entries).toHaveLength(0);
+    });
+
+    it("preserves entries with different correlationId", () => {
+      addEntry({ message: "a", correlationId: "panel-1" });
+      addEntry({ message: "b", correlationId: "panel-2" });
+      addEntry({ message: "c", correlationId: "panel-1" });
+      getState().dismissByCorrelationId("panel-1");
+      expect(getState().entries).toHaveLength(1);
+      expect(getState().entries[0]!.message).toBe("b");
+    });
+
+    it("preserves entries with no correlationId", () => {
+      addEntry({ message: "correlated", correlationId: "panel-1" });
+      addEntry({ message: "uncorrelated" });
+      getState().dismissByCorrelationId("panel-1");
+      expect(getState().entries).toHaveLength(1);
+      expect(getState().entries[0]!.message).toBe("uncorrelated");
+    });
+
+    it("recomputes unreadCount after removal", () => {
+      addEntry({ message: "missed 1", correlationId: "panel-1" });
+      addEntry({ message: "missed 2", correlationId: "panel-1" });
+      getState().addEntry({
+        type: "info",
+        message: "seen",
+        correlationId: "panel-1",
+        seenAsToast: true,
+      });
+      expect(getState().unreadCount).toBe(2);
+      getState().dismissByCorrelationId("panel-1");
+      expect(getState().unreadCount).toBe(0);
+    });
+
+    it("recomputes unreadCount correctly with mixed seenAsToast and correlationIds", () => {
+      addEntry({ message: "missed a", correlationId: "panel-1" });
+      addEntry({ message: "missed b", correlationId: "panel-2" });
+      getState().addEntry({
+        type: "info",
+        message: "seen",
+        correlationId: "panel-1",
+        seenAsToast: true,
+      });
+      expect(getState().unreadCount).toBe(2);
+      getState().dismissByCorrelationId("panel-1");
+      expect(getState().entries).toHaveLength(1);
+      expect(getState().unreadCount).toBe(1);
+      expect(getState().entries[0]!.message).toBe("missed b");
+    });
+
+    it("is a no-op when correlationId does not exist", () => {
+      addEntry({ message: "test", correlationId: "panel-1" });
+      getState().dismissByCorrelationId("nonexistent");
+      expect(getState().entries).toHaveLength(1);
+      expect(getState().unreadCount).toBe(1);
+    });
+
+    it("correctly dismisses non-countable entries without affecting unreadCount of remaining", () => {
+      addEntry({ message: "countable", correlationId: "panel-1" });
+      addEntry({ message: "uncountable", correlationId: "panel-1", countable: false });
+      addEntry({ message: "other countable", correlationId: "panel-2" });
+      expect(getState().unreadCount).toBe(2);
+      getState().dismissByCorrelationId("panel-1");
+      expect(getState().entries).toHaveLength(1);
+      expect(getState().unreadCount).toBe(1);
+    });
+
+    it("idempotent — second call with same correlationId is a no-op", () => {
+      addEntry({ message: "first", correlationId: "panel-1" });
+      getState().dismissByCorrelationId("panel-1");
+      expect(getState().entries).toHaveLength(0);
+      getState().dismissByCorrelationId("panel-1");
+      expect(getState().entries).toHaveLength(0);
+      expect(getState().unreadCount).toBe(0);
+    });
+  });
 });

--- a/src/store/slices/notificationHistorySlice.ts
+++ b/src/store/slices/notificationHistorySlice.ts
@@ -59,6 +59,7 @@ interface NotificationHistoryState {
    */
   markUnseenAsToast: (id: string, options?: { silent?: boolean }) => void;
   dismissEntry: (id: string) => void;
+  dismissByCorrelationId: (correlationId: string) => void;
   clearAll: () => void;
   markAllRead: () => void;
   markSummarized: (ids: string[]) => void;
@@ -106,6 +107,14 @@ export const useNotificationHistoryStore = create<NotificationHistoryState>((set
   dismissEntry: (id) =>
     set((state) => {
       const entries = state.entries.filter((e) => e.id !== id);
+      return {
+        entries,
+        unreadCount: entries.filter((e) => !e.seenAsToast && e.countable !== false).length,
+      };
+    }),
+  dismissByCorrelationId: (correlationId) =>
+    set((state) => {
+      const entries = state.entries.filter((e) => e.correlationId !== correlationId);
       return {
         entries,
         unreadCount: entries.filter((e) => !e.seenAsToast && e.countable !== false).length,


### PR DESCRIPTION
## Summary
- Notification threads in the notification center group related entries by correlation ID. Clicking X on a thread only dismissed the latest entry, forcing users to click repeatedly to clear a thread.
- Adds `dismissByCorrelationId` to the notification store and wires it to the thread X button so all entries in a thread are dismissed in one click.

Resolves #7239

## Changes
- **`src/store/slices/notificationHistorySlice.ts`** — new `dismissByCorrelationId` method that filters entries by `correlationId` and recalculates `unreadCount`
- **`src/components/Notifications/NotificationCenter.tsx`** — `NotificationThread` now calls the thread-level dismiss (via `dismissByCorrelationId`) instead of passing `latest.id` to the single-entry `dismissEntry`
- **Tests** — store tests cover multi-entry removal, preserving unrelated entries, mixed `seenAsToast`, non-countable entries, missing correlationId, and idempotency. Component tests cover thread removal with one click, preserving unrelated entries, and unread count recalculation.

## Testing
- Store slice tests: 7 new cases
- Component tests: 3 new cases covering multi-entry threads, unrelated-entry isolation, and unread count
- Manual: multi-entry threads clear in one click in both the Needs Attention and chronological sections