### PR TITLE
fix(settings): four correctness fixes in agent settings components

### DIFF
--- a/src/components/Settings/AgentHelpOutput.tsx
+++ b/src/components/Settings/AgentHelpOutput.tsx
@@ -32,12 +32,13 @@ export function AgentHelpOutput({
   const [isCopied, setIsCopied] = useState(false);
   const copyTimeoutRef = useRef<ReturnType<typeof setTimeout> | null>(null);
   const isMountedRef = useRef(true);
+  const loadGenRef = useRef(0);
 
   useEffect(() => {
     setHelpResult(null);
     setError(null);
     setIsCopied(false);
-  }, [agentId]);
+  }, [agentId, availability]);
 
   useEffect(() => {
     isMountedRef.current = true;
@@ -51,6 +52,7 @@ export function AgentHelpOutput({
 
   const loadHelp = useCallback(
     async (refresh = false) => {
+      const gen = ++loadGenRef.current;
       setIsLoading(true);
       setError(null);
 
@@ -61,11 +63,13 @@ export function AgentHelpOutput({
 
       try {
         const result = await agentHelpClient.get({ agentId, refresh });
+        if (loadGenRef.current !== gen) return;
         setHelpResult(result);
       } catch (err) {
+        if (loadGenRef.current !== gen) return;
         setError(formatErrorMessage(err, "Failed to load help output"));
       } finally {
-        setIsLoading(false);
+        if (loadGenRef.current === gen) setIsLoading(false);
       }
     },
     [agentId, availability]

--- a/src/components/Settings/AgentHelpOutput.tsx
+++ b/src/components/Settings/AgentHelpOutput.tsx
@@ -3,7 +3,7 @@ import { Button } from "@/components/ui/button";
 import { Copy, RefreshCw } from "lucide-react";
 import { Spinner } from "@/components/ui/Spinner";
 import { agentHelpClient } from "@/clients";
-import { cliAvailabilityClient } from "@/clients";
+
 import type { AgentHelpResult } from "@shared/types/ipc/agent";
 import type { AgentAvailabilityState } from "@shared/types";
 import { isAgentInstalled, isAgentMissing } from "../../../shared/utils/agentAvailability";
@@ -15,33 +15,23 @@ interface AgentHelpOutputProps {
   agentId: string;
   agentName: string;
   usageUrl?: string;
+  availability: AgentAvailabilityState;
+  isCliLoading?: boolean;
 }
 
-export function AgentHelpOutput({ agentId, agentName, usageUrl }: AgentHelpOutputProps) {
+export function AgentHelpOutput({
+  agentId,
+  agentName,
+  usageUrl,
+  availability,
+  isCliLoading,
+}: AgentHelpOutputProps) {
   const [helpResult, setHelpResult] = useState<AgentHelpResult | null>(null);
   const [isLoading, setIsLoading] = useState(false);
   const [error, setError] = useState<string | null>(null);
-  const [isCliAvailable, setIsCliAvailable] = useState<AgentAvailabilityState | null>(null);
   const [isCopied, setIsCopied] = useState(false);
-  const copyTimeoutRef = useRef<NodeJS.Timeout | null>(null);
+  const copyTimeoutRef = useRef<ReturnType<typeof setTimeout> | null>(null);
   const isMountedRef = useRef(true);
-
-  const checkCliAvailability = useCallback(async () => {
-    try {
-      const availability = await cliAvailabilityClient.get();
-      return availability[agentId] ?? "missing";
-    } catch {
-      return "missing";
-    }
-  }, [agentId]);
-
-  useEffect(() => {
-    void checkCliAvailability().then((available) => {
-      if (isMountedRef.current) {
-        setIsCliAvailable(available);
-      }
-    });
-  }, [checkCliAvailability]);
 
   useEffect(() => {
     setHelpResult(null);
@@ -64,10 +54,7 @@ export function AgentHelpOutput({ agentId, agentName, usageUrl }: AgentHelpOutpu
       setIsLoading(true);
       setError(null);
 
-      const available = await checkCliAvailability();
-      setIsCliAvailable(available);
-
-      if (!isAgentInstalled(available)) {
+      if (!isAgentInstalled(availability)) {
         setIsLoading(false);
         return;
       }
@@ -81,7 +68,7 @@ export function AgentHelpOutput({ agentId, agentName, usageUrl }: AgentHelpOutpu
         setIsLoading(false);
       }
     },
-    [agentId, checkCliAvailability]
+    [agentId, availability]
   );
 
   const handleCopy = useCallback(async () => {
@@ -163,7 +150,7 @@ export function AgentHelpOutput({ agentId, agentName, usageUrl }: AgentHelpOutpu
             </p>
           </div>
 
-          {isAgentInstalled(isCliAvailable ?? undefined) && (
+          {isAgentInstalled(availability) && (
             <div className="flex items-center gap-2">
               <Button
                 size="sm"
@@ -199,7 +186,7 @@ export function AgentHelpOutput({ agentId, agentName, usageUrl }: AgentHelpOutpu
         </div>
       )}
 
-      {!isLoading && isAgentMissing(isCliAvailable ?? undefined) && isCliAvailable !== null && (
+      {!isLoading && isAgentMissing(availability) && !isCliLoading && (
         <div className="px-4 py-6 rounded-[var(--radius-md)] border border-daintree-border bg-surface text-center space-y-2">
           <p className="text-sm text-daintree-text/60">CLI not found</p>
           <p className="text-xs text-daintree-text/40 select-text">

--- a/src/components/Settings/AgentSettings.tsx
+++ b/src/components/Settings/AgentSettings.tsx
@@ -60,6 +60,7 @@ export function AgentSettings({
 
   useEffect(() => {
     initialize();
+    setLoadTimedOut(false);
     const timer = setTimeout(() => setLoadTimedOut(true), 10_000);
     return () => clearTimeout(timer);
   }, [initialize]);

--- a/src/components/Settings/AgentSettings.tsx
+++ b/src/components/Settings/AgentSettings.tsx
@@ -1,4 +1,5 @@
 import { useEffect, useEffectEvent, useMemo, useRef, useState, useCallback } from "react";
+import { useKeybindingDisplay } from "@/hooks/useKeybinding";
 import { getAgentIds, getAgentConfig, getMergedPresets, type AgentPreset } from "@/config/agents";
 import { useAgentSettingsStore, useCliAvailabilityStore, useAgentPreferencesStore } from "@/store";
 import { cliAvailabilityClient } from "@/clients";
@@ -108,6 +109,8 @@ export function AgentSettings({
   // Rate limiting refs
   const lastAddTimeRef = useRef(0);
   const lastEditTimeRef = useRef(0);
+
+  const helpShortcut = useKeybindingDisplay("help.launchAgent");
 
   // Preset editing state
   const [editingPresetId, setEditingPresetId] = useState<string | null>(null);
@@ -223,7 +226,7 @@ export function AgentSettings({
   }
 
   if (isLoading && !settings) {
-    if (loadTimedOut) {
+    if (isLoading && loadTimedOut) {
       return (
         <div className="flex flex-col items-center justify-center h-32 gap-3">
           <div className="text-status-error text-sm">Settings load timed out</div>
@@ -314,7 +317,8 @@ export function AgentSettings({
                 ))}
               </select>
               <p className="text-xs text-daintree-text/40 select-text">
-                Agent used for the help dock button (⌘⇧H) and automated workflows ("What's Next?",
+                Agent used for the help dock button
+                {helpShortcut && ` (${helpShortcut})`} and automated workflows ("What's Next?",
                 onboarding, project explanations). Distinct from the Portal "Default New Tab Agent"
                 which controls the browser panel opened by the + button.
               </p>
@@ -431,6 +435,8 @@ export function AgentSettings({
               agentId={activeAgent.id}
               agentName={activeAgent.name}
               usageUrl={activeAgent.usageUrl}
+              availability={cliAvailability[activeAgent.id] ?? "missing"}
+              isCliLoading={isCliLoading}
             />
 
             {/* Installation */}


### PR DESCRIPTION
## Summary
- Four small, independent correctness fixes across `AgentSettings.tsx` and `AgentHelpOutput.tsx`.
- The hardcoded keyboard shortcut is replaced with `useKeybindingDisplay`, the `loadTimedOut` timer is properly gated behind `isLoading`, the `NodeJS.Timeout` ref type is corrected to `ReturnType<typeof setTimeout>`, and `AgentHelpOutput` receives CLI availability from its parent instead of making a redundant IPC call.

Resolves #7219

## Changes
- `AgentSettings.tsx`: `(⌘⇧H)` shortcut hint replaced with live binding via `useKeybindingDisplay("help.launchAgent")`; `loadTimedOut` branch gated on `isLoading`; `setLoadTimedOut(false)` reset on re-initialize.
- `AgentHelpOutput.tsx`: `availability` and `isCliLoading` props replace the internal IPC call; stale load guard (`loadGenRef`) added to the help fetch; `copyTimeoutRef` typed as `ReturnType<typeof setTimeout>`.

## Testing
- Verified the settings tab renders, the CLI availability state propagates correctly, and the bound shortcut displays in the help-assistant agent dropdown label.