### PR TITLE
fix(diagnostics): disposed guard and themed clear-events dialog

### DIFF
--- a/src/components/Diagnostics/DiagnosticsActions.tsx
+++ b/src/components/Diagnostics/DiagnosticsActions.tsx
@@ -1,9 +1,10 @@
-import { useCallback } from "react";
+import { useCallback, useState } from "react";
 import { Button } from "@/components/ui/button";
 import { useLogsStore, useErrorStore } from "@/store";
 import { useTelemetryPreviewStore } from "@/store/telemetryPreviewStore";
 import { actionService } from "@/services/ActionService";
 import { Tooltip, TooltipContent, TooltipTrigger } from "@/components/ui/tooltip";
+import { ConfirmDialog } from "@/components/ui/ConfirmDialog";
 
 export function ProblemsActions() {
   const hasActiveErrors = useErrorStore((state) => state.errors.some((e) => !e.dismissed));
@@ -137,22 +138,34 @@ export function TelemetryActions() {
 }
 
 export function EventsActions() {
-  const handleClearEvents = async () => {
-    if (window.confirm("Clear all events? This cannot be undone.")) {
-      await actionService.dispatch("eventInspector.clear", undefined, { source: "user" });
-    }
-  };
+  const [showClearDialog, setShowClearDialog] = useState(false);
+
+  const handleConfirmClear = useCallback(async () => {
+    await actionService.dispatch("eventInspector.clear", undefined, { source: "user" });
+    setShowClearDialog(false);
+  }, []);
 
   return (
-    <div className="flex items-center gap-2">
-      <Tooltip>
-        <TooltipTrigger asChild>
-          <Button variant="subtle" size="xs" onClick={handleClearEvents}>
-            Clear
-          </Button>
-        </TooltipTrigger>
-        <TooltipContent side="bottom">Clear all events</TooltipContent>
-      </Tooltip>
-    </div>
+    <>
+      <div className="flex items-center gap-2">
+        <Tooltip>
+          <TooltipTrigger asChild>
+            <Button variant="subtle" size="xs" onClick={() => setShowClearDialog(true)}>
+              Clear
+            </Button>
+          </TooltipTrigger>
+          <TooltipContent side="bottom">Clear all events</TooltipContent>
+        </Tooltip>
+      </div>
+      <ConfirmDialog
+        isOpen={showClearDialog}
+        onClose={() => setShowClearDialog(false)}
+        title="Clear events?"
+        description="All captured event records will be permanently deleted."
+        confirmLabel="Clear events"
+        variant="destructive"
+        onConfirm={handleConfirmClear}
+      />
+    </>
   );
 }

--- a/src/components/Diagnostics/EventsContent.tsx
+++ b/src/components/Diagnostics/EventsContent.tsx
@@ -46,11 +46,14 @@ export function EventsContent({ className }: EventsContentProps) {
   );
 
   useEffect(() => {
+    let disposed = false;
+
     eventInspectorClient.subscribe();
 
     eventInspectorClient
       .getEvents()
       .then((existingEvents) => {
+        if (disposed) return;
         setEvents(existingEvents);
       })
       .catch((error) => {
@@ -58,10 +61,12 @@ export function EventsContent({ className }: EventsContentProps) {
       });
 
     const unsubscribe = eventInspectorClient.onEventBatch((events) => {
+      if (disposed) return;
       addEvents(events);
     });
 
     return () => {
+      disposed = true;
       unsubscribe();
       eventInspectorClient.unsubscribe();
     };

--- a/src/components/Diagnostics/__tests__/DiagnosticsActions.test.tsx
+++ b/src/components/Diagnostics/__tests__/DiagnosticsActions.test.tsx
@@ -1,0 +1,147 @@
+// @vitest-environment jsdom
+import React from "react";
+import { render, screen, fireEvent } from "@testing-library/react";
+import { describe, expect, it, vi, beforeEach } from "vitest";
+import { EventsActions } from "../DiagnosticsActions";
+
+const mockDispatch = vi.fn().mockResolvedValue(undefined);
+
+vi.mock("@/services/ActionService", () => ({
+  actionService: {
+    dispatch: (...args: unknown[]) => mockDispatch(...args),
+  },
+}));
+
+vi.mock("zustand/react/shallow", () => ({
+  useShallow: (fn: unknown) => fn,
+}));
+
+vi.mock("@/store", () => ({
+  useLogsStore: () => ({ autoScroll: false, setAutoScroll: vi.fn() }),
+  useErrorStore: () => ({ errors: [] }),
+  usePortalStore: () => ({ isOpen: false, width: 0 }),
+}));
+
+vi.mock("@/store/telemetryPreviewStore", () => ({
+  useTelemetryPreviewStore: () => ({ active: false, events: [] }),
+}));
+
+vi.mock("@/hooks", async (importOriginal) => {
+  const actual = (await importOriginal()) as Record<string, unknown>;
+  return {
+    ...actual,
+    useOverlayState: () => {},
+  };
+});
+
+vi.mock("@/hooks/useAnimatedPresence", () => ({
+  useAnimatedPresence: ({ isOpen }: { isOpen: boolean }) => ({
+    isVisible: isOpen,
+    shouldRender: isOpen,
+  }),
+}));
+
+vi.mock("@/components/ui/tooltip", () => ({
+  TooltipProvider: ({ children }: { children: React.ReactNode }) => <>{children}</>,
+  Tooltip: ({ children }: { children: React.ReactNode }) => <>{children}</>,
+  TooltipTrigger: ({ children }: { children: React.ReactNode }) => <>{children}</>,
+  TooltipContent: ({ children }: { children: React.ReactNode }) => <>{children}</>,
+}));
+
+vi.mock("@/components/icons", () => {
+  const stub = () => null;
+  return {
+    DaintreeIcon: stub,
+    NpmIcon: stub,
+    YarnIcon: stub,
+    PnpmIcon: stub,
+    BunIcon: stub,
+    PythonIcon: stub,
+    ComposerIcon: stub,
+    DockerIcon: stub,
+    RustIcon: stub,
+    GoIcon: stub,
+    RubyIcon: stub,
+    NodeIcon: stub,
+    DenoIcon: stub,
+    GradleIcon: stub,
+    PhpIcon: stub,
+    ViteIcon: stub,
+    WebpackIcon: stub,
+    KotlinIcon: stub,
+    SwiftIcon: stub,
+    TerraformIcon: stub,
+    ElixirIcon: stub,
+  };
+});
+
+vi.stubGlobal(
+  "ResizeObserver",
+  class {
+    observe() {}
+    unobserve() {}
+    disconnect() {}
+  }
+);
+
+describe("EventsActions — ConfirmDialog", () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+    vi.stubGlobal("matchMedia", vi.fn().mockReturnValue({ matches: false }));
+  });
+
+  it("opens ConfirmDialog when Clear button is clicked", async () => {
+    render(<EventsActions />);
+
+    fireEvent.click(screen.getByText("Clear"));
+
+    expect(screen.getByText("Clear events?")).toBeTruthy();
+    expect(
+      screen.getByText("All captured event records will be permanently deleted.")
+    ).toBeTruthy();
+    expect(screen.getByText("Clear events")).toBeTruthy();
+  });
+
+  it("closes dialog without dispatching when Cancel is clicked", async () => {
+    render(<EventsActions />);
+
+    fireEvent.click(screen.getByText("Clear"));
+
+    fireEvent.click(screen.getByText("Cancel"));
+
+    expect(mockDispatch).not.toHaveBeenCalled();
+    expect(screen.queryByText("Clear events?")).toBeNull();
+  });
+
+  it("dispatches clear action and closes dialog on Confirm", async () => {
+    render(<EventsActions />);
+
+    fireEvent.click(screen.getByText("Clear"));
+
+    fireEvent.click(screen.getByText("Clear events"));
+
+    expect(mockDispatch).toHaveBeenCalledWith("eventInspector.clear", undefined, {
+      source: "user",
+    });
+    // After dispatch resolves, dialog should close
+    await new Promise((resolve) => setTimeout(resolve, 0));
+    expect(screen.queryByText("Clear events?")).toBeNull();
+  });
+
+  it("does not show dialog before clicking Clear", () => {
+    render(<EventsActions />);
+
+    expect(screen.queryByText("Clear events?")).toBeNull();
+  });
+
+  it("does not use window.confirm", () => {
+    const confirmSpy = vi.spyOn(window, "confirm");
+
+    render(<EventsActions />);
+
+    fireEvent.click(screen.getByText("Clear"));
+
+    expect(confirmSpy).not.toHaveBeenCalled();
+    confirmSpy.mockRestore();
+  });
+});

--- a/src/components/Diagnostics/__tests__/EventsContent.test.tsx
+++ b/src/components/Diagnostics/__tests__/EventsContent.test.tsx
@@ -64,7 +64,7 @@ describe("EventsContent — disposed guard", () => {
   beforeEach(() => {
     vi.clearAllMocks();
     let unsubCallback: (() => void) | null = null;
-    mockOnEventBatch.mockImplementation((cb: (events: EventRecord[]) => void) => {
+    mockOnEventBatch.mockImplementation((_cb: (events: EventRecord[]) => void) => {
       // hold the callback but don't fire it
       unsubCallback = () => {};
       return unsubCallback;
@@ -111,7 +111,7 @@ describe("EventsContent — disposed guard", () => {
 
     unmount();
 
-    batchCallback?.([
+    batchCallback!([
       { id: "2", timestamp: 2, type: "test", category: "agent", payload: {}, source: "main" },
     ]);
 
@@ -128,7 +128,7 @@ describe("EventsContent — disposed guard", () => {
 
     render(<EventsContent />);
 
-    batchCallback?.([
+    batchCallback!([
       { id: "2", timestamp: 2, type: "test", category: "agent", payload: {}, source: "main" },
     ]);
 

--- a/src/components/Diagnostics/__tests__/EventsContent.test.tsx
+++ b/src/components/Diagnostics/__tests__/EventsContent.test.tsx
@@ -89,6 +89,7 @@ describe("EventsContent — disposed guard", () => {
     await new Promise((resolve) => setTimeout(resolve, 0));
 
     expect(mockSetEvents).not.toHaveBeenCalled();
+    expect(mockUnsubscribe).toHaveBeenCalledTimes(1);
   });
 
   it("calls setEvents when getEvents() resolves while mounted", async () => {
@@ -115,6 +116,7 @@ describe("EventsContent — disposed guard", () => {
     ]);
 
     expect(mockAddEvents).not.toHaveBeenCalled();
+    expect(mockUnsubscribe).toHaveBeenCalledTimes(1);
   });
 
   it("calls addEvents when onEventBatch fires while mounted", async () => {

--- a/src/components/Diagnostics/__tests__/EventsContent.test.tsx
+++ b/src/components/Diagnostics/__tests__/EventsContent.test.tsx
@@ -1,0 +1,135 @@
+// @vitest-environment jsdom
+import { render } from "@testing-library/react";
+import { describe, expect, it, vi, beforeEach, afterEach } from "vitest";
+import type { EventRecord } from "@shared/types";
+import { EventsContent } from "../EventsContent";
+
+vi.mock("zustand/react/shallow", () => ({
+  useShallow: (fn: unknown) => fn,
+}));
+
+const mockSetEvents = vi.fn();
+const mockAddEvents = vi.fn();
+
+vi.mock("@/store/eventStore", () => ({
+  useEventStore: (selector: (state: unknown) => unknown) => {
+    const state = {
+      events: [] as EventRecord[],
+      filters: {},
+      selectedEventId: null,
+      autoScroll: true,
+      setAutoScroll: vi.fn(),
+      addEvents: mockAddEvents,
+      setEvents: mockSetEvents,
+      setFilters: vi.fn(),
+      setSelectedEvent: vi.fn(),
+      getFilteredEvents: () => [] as EventRecord[],
+    };
+    return selector(state);
+  },
+}));
+
+const mockGetEvents = vi.fn();
+const mockSubscribe = vi.fn();
+const mockUnsubscribe = vi.fn();
+const mockOnEventBatch = vi.fn();
+
+vi.mock("@/clients", () => ({
+  eventInspectorClient: {
+    getEvents: () => mockGetEvents(),
+    subscribe: () => mockSubscribe(),
+    unsubscribe: () => mockUnsubscribe(),
+    onEventBatch: (cb: (events: EventRecord[]) => void) => mockOnEventBatch(cb),
+  },
+}));
+
+vi.mock("@/utils/logger", () => ({
+  logError: vi.fn(),
+}));
+
+vi.stubGlobal(
+  "ResizeObserver",
+  class {
+    observe() {}
+    unobserve() {}
+    disconnect() {}
+  }
+);
+
+function stubGlobals() {
+  vi.stubGlobal("matchMedia", vi.fn().mockReturnValue({ matches: false }));
+}
+
+describe("EventsContent — disposed guard", () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+    let unsubCallback: (() => void) | null = null;
+    mockOnEventBatch.mockImplementation((cb: (events: EventRecord[]) => void) => {
+      // hold the callback but don't fire it
+      unsubCallback = () => {};
+      return unsubCallback;
+    });
+    mockGetEvents.mockResolvedValue([
+      { id: "1", timestamp: 1, type: "test", category: "agent", payload: {}, source: "main" },
+    ]);
+    mockSubscribe.mockReturnValue(undefined);
+    mockUnsubscribe.mockReturnValue(undefined);
+    stubGlobals();
+  });
+
+  afterEach(() => {
+    vi.unstubAllEnvs();
+  });
+
+  it("does NOT call setEvents when getEvents() resolves after unmount", async () => {
+    const { unmount } = render(<EventsContent />);
+
+    unmount();
+
+    await new Promise((resolve) => setTimeout(resolve, 0));
+
+    expect(mockSetEvents).not.toHaveBeenCalled();
+  });
+
+  it("calls setEvents when getEvents() resolves while mounted", async () => {
+    render(<EventsContent />);
+
+    await new Promise((resolve) => setTimeout(resolve, 0));
+
+    expect(mockSetEvents).toHaveBeenCalledTimes(1);
+  });
+
+  it("does NOT call addEvents when onEventBatch fires after cleanup", async () => {
+    let batchCallback: ((events: EventRecord[]) => void) | null = null;
+    mockOnEventBatch.mockImplementation((cb: (events: EventRecord[]) => void) => {
+      batchCallback = cb;
+      return () => {};
+    });
+
+    const { unmount } = render(<EventsContent />);
+
+    unmount();
+
+    batchCallback?.([
+      { id: "2", timestamp: 2, type: "test", category: "agent", payload: {}, source: "main" },
+    ]);
+
+    expect(mockAddEvents).not.toHaveBeenCalled();
+  });
+
+  it("calls addEvents when onEventBatch fires while mounted", async () => {
+    let batchCallback: ((events: EventRecord[]) => void) | null = null;
+    mockOnEventBatch.mockImplementation((cb: (events: EventRecord[]) => void) => {
+      batchCallback = cb;
+      return () => {};
+    });
+
+    render(<EventsContent />);
+
+    batchCallback?.([
+      { id: "2", timestamp: 2, type: "test", category: "agent", payload: {}, source: "main" },
+    ]);
+
+    expect(mockAddEvents).toHaveBeenCalledTimes(1);
+  });
+});


### PR DESCRIPTION
## Summary

Two small correctness fixes in the diagnostics dock.

`EventsContent` now uses a disposed guard to prevent state updates after unmount, matching the pattern already in `LogsContent` and `TelemetryContent`. The clear-events action in `DiagnosticsActions` replaces a bare `window.confirm` with the themed `ConfirmDialog` component, following the microcopy rules in `CLAUDE.md`.

Resolves #7247.

## Changes

- **`EventsContent.tsx`**: Added a `disposed` closure flag in the `useEffect` cleanup. The async `getEvents()` promise and the `onEventBatch` callback both check `disposed` before calling setters, preventing React state updates on unmounted components.
- **`DiagnosticsActions.tsx`**: The `EventsActions` component now manages a `showClearDialog` boolean and renders `ConfirmDialog` with destructive variant, matching the copy pattern used elsewhere in the app. Dialog title is "Clear events?", body states the consequence, and the confirm button uses the verb-noun label "Clear events".
- Unit tests for both changes: `EventsContent.test.tsx` (disposed guard assertions, cleanup lifecycle verification) and `DiagnosticsActions.test.tsx` (dialog open/close, confirm dispatch, cancel behaviour).

## Testing

Unit tests pass. Manual verification of the clear-events dialog in the diagnostics dock.