### PR TITLE
fix(ui): bring SearchablePalette and AppPaletteDialog up to APG combobox + IME standard

### DIFF
--- a/src/components/ui/AppPaletteDialog.tsx
+++ b/src/components/ui/AppPaletteDialog.tsx
@@ -192,12 +192,12 @@ export function AppPaletteDialog({
         transitionTimingFunction: "linear",
       }}
       onClick={handleBackdropClick}
-      role="dialog"
-      aria-modal="true"
-      aria-label={ariaLabel}
     >
       <div
         ref={dialogRef}
+        role="dialog"
+        aria-modal="true"
+        aria-label={ariaLabel}
         className={cn(
           "w-full max-w-xl mx-4 bg-daintree-bg border border-[var(--border-overlay)] rounded-[var(--radius-xl)] shadow-modal overflow-hidden origin-top",
           "transition-[opacity,transform]",

--- a/src/components/ui/PaletteOverflowNotice.tsx
+++ b/src/components/ui/PaletteOverflowNotice.tsx
@@ -8,7 +8,7 @@ export function PaletteOverflowNotice({ shown, total }: PaletteOverflowNoticePro
 
   return (
     <div
-      aria-hidden="true"
+      role="status"
       className="px-3 py-2 text-xs tabular-nums text-daintree-text/40 text-center border-t border-daintree-border/30"
     >
       Showing {shown} of {total} — refine your search to see more

--- a/src/components/ui/SearchablePalette.tsx
+++ b/src/components/ui/SearchablePalette.tsx
@@ -205,7 +205,7 @@ export function SearchablePalette<T>({
 
   const handleKeyDown = useCallback(
     (e: React.KeyboardEvent) => {
-      if (e.isComposing || e.nativeEvent.keyCode === 229) return;
+      if (e.nativeEvent.isComposing || e.nativeEvent.keyCode === 229) return;
 
       if (onKeyDown) {
         onKeyDown(e);

--- a/src/components/ui/SearchablePalette.tsx
+++ b/src/components/ui/SearchablePalette.tsx
@@ -205,6 +205,8 @@ export function SearchablePalette<T>({
 
   const handleKeyDown = useCallback(
     (e: React.KeyboardEvent) => {
+      if (e.isComposing || e.nativeEvent.keyCode === 229) return;
+
       if (onKeyDown) {
         onKeyDown(e);
         if (e.defaultPrevented) return;
@@ -298,6 +300,7 @@ export function SearchablePalette<T>({
           role="combobox"
           aria-expanded={isOpen}
           aria-haspopup="listbox"
+          aria-autocomplete="list"
           aria-label={searchAriaLabel ?? searchPlaceholder.replace("...", "")}
           aria-controls={listId}
           aria-activedescendant={activeDescendant}
@@ -333,6 +336,7 @@ export function SearchablePalette<T>({
                 aria-label={label}
                 className={isFiltering ? "palette-results-stale" : undefined}
                 data-stale={isFiltering ? "true" : undefined}
+                aria-busy={isFiltering || undefined}
               >
                 {results.map((item, index) =>
                   renderItem(

--- a/src/components/ui/__tests__/AppPaletteDialog.test.tsx
+++ b/src/components/ui/__tests__/AppPaletteDialog.test.tsx
@@ -1,5 +1,5 @@
 // @vitest-environment jsdom
-import { render, act } from "@testing-library/react";
+import { render, act, screen } from "@testing-library/react";
 import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
 import { AppPaletteDialog } from "../AppPaletteDialog";
 import { usePaletteStore } from "@/store/paletteStore";
@@ -53,6 +53,23 @@ function renderPalette(props: { isOpen: boolean }) {
     </>
   );
 }
+
+describe("AppPaletteDialog ARIA placement", () => {
+  it("places role='dialog' and aria-modal on the inner panel, not the scrim", () => {
+    const { container } = renderPalette({ isOpen: true });
+    const dialog = screen.getByRole("dialog", { name: "Test palette" });
+    expect(dialog).toBeTruthy();
+    expect(dialog.getAttribute("aria-modal")).toBe("true");
+    // The inner panel is scoped to the palette body — it should NOT be the
+    // fixed-inset scrim that also matches `.bg-scrim-medium`.
+    expect(dialog.classList.contains("bg-scrim-medium")).toBe(false);
+    // Confirm the scrim no longer carries a dialog role.
+    const scrims = container.querySelectorAll('[class*="bg-scrim-medium"]');
+    for (const el of scrims) {
+      expect(el.getAttribute("role")).not.toBe("dialog");
+    }
+  });
+});
 
 describe("AppPaletteDialog focus restore", () => {
   beforeEach(() => {

--- a/src/components/ui/__tests__/PaletteOverflowNotice.test.tsx
+++ b/src/components/ui/__tests__/PaletteOverflowNotice.test.tsx
@@ -19,15 +19,10 @@ describe("PaletteOverflowNotice", () => {
     expect(container.firstChild).toBeNull();
   });
 
-  it("has aria-hidden attribute", () => {
+  it("has role='status' so AT announces the count", () => {
     render(<PaletteOverflowNotice shown={20} total={47} />);
-    const notice = screen.getByText(/Showing 20 of 47/);
-    expect(notice.getAttribute("aria-hidden")).toBe("true");
-  });
-
-  it("does not have role=option", () => {
-    render(<PaletteOverflowNotice shown={20} total={47} />);
-    const notice = screen.getByText(/Showing 20 of 47/);
-    expect(notice.getAttribute("role")).toBeNull();
+    const notice = screen.getByRole("status");
+    expect(notice).toBeTruthy();
+    expect(notice.textContent).toContain("Showing 20 of 47");
   });
 });

--- a/src/components/ui/__tests__/SearchablePalette.keyboard.test.tsx
+++ b/src/components/ui/__tests__/SearchablePalette.keyboard.test.tsx
@@ -1,0 +1,149 @@
+// @vitest-environment jsdom
+import { render, screen, fireEvent } from "@testing-library/react";
+import { beforeAll, describe, expect, it, vi } from "vitest";
+
+class ResizeObserverStub {
+  observe() {}
+  unobserve() {}
+  disconnect() {}
+}
+
+beforeAll(() => {
+  if (typeof globalThis.ResizeObserver === "undefined") {
+    globalThis.ResizeObserver = ResizeObserverStub as typeof ResizeObserver;
+  }
+});
+
+vi.mock("@/lib/utils", () => ({
+  cn: (...args: unknown[]) => args.filter(Boolean).join(" "),
+}));
+
+vi.mock("@/hooks", () => ({
+  useEscapeStack: () => {},
+  useOverlayState: () => {},
+}));
+
+vi.mock("@/store/paletteStore", () => ({
+  usePaletteStore: { getState: () => ({ activePaletteId: null }) },
+}));
+
+import { SearchablePalette } from "../SearchablePalette";
+
+interface Item {
+  id: string;
+}
+
+const items: Item[] = [{ id: "a" }, { id: "b" }];
+
+function renderPalette(overrides: Record<string, unknown> = {}) {
+  const props = {
+    isOpen: true,
+    query: "",
+    results: items,
+    selectedIndex: 0,
+    onQueryChange: vi.fn(),
+    onSelectPrevious: vi.fn(),
+    onSelectNext: vi.fn(),
+    onConfirm: vi.fn(),
+    onClose: vi.fn(),
+    getItemId: (item: Item) => item.id,
+    renderItem: (item: Item) => <div key={item.id}>{item.id}</div>,
+    label: "Test",
+    ariaLabel: "Test palette",
+    ...overrides,
+  };
+  return render(<SearchablePalette<Item> {...props} />);
+}
+
+/**
+ * IME composition guard predicate — mirrors the canonical pattern from
+ * `src/components/Terminal/__tests__/xtermCompositionGuard.test.ts`.
+ */
+function isComposing(event: { isComposing: boolean; nativeEvent: { keyCode: number } }): boolean {
+  return event.isComposing || event.nativeEvent.keyCode === 229;
+}
+
+describe("SearchablePalette IME composition guard (predicate)", () => {
+  describe("blocks keys during active composition", () => {
+    it("returns true when isComposing is true", () => {
+      expect(isComposing({ isComposing: true, nativeEvent: { keyCode: 13 } })).toBe(true);
+    });
+
+    it("returns true for keyCode 229 (Chromium Process key)", () => {
+      expect(isComposing({ isComposing: false, nativeEvent: { keyCode: 229 } })).toBe(true);
+    });
+
+    it("returns true when both isComposing and keyCode 229", () => {
+      expect(isComposing({ isComposing: true, nativeEvent: { keyCode: 229 } })).toBe(true);
+    });
+  });
+
+  describe("allows keys when not composing", () => {
+    it("returns false for plain Enter", () => {
+      expect(isComposing({ isComposing: false, nativeEvent: { keyCode: 13 } })).toBe(false);
+    });
+
+    it("returns false for ArrowDown", () => {
+      expect(isComposing({ isComposing: false, nativeEvent: { keyCode: 40 } })).toBe(false);
+    });
+
+    it("returns false for ArrowUp", () => {
+      expect(isComposing({ isComposing: false, nativeEvent: { keyCode: 38 } })).toBe(false);
+    });
+
+    it("returns false for Tab", () => {
+      expect(isComposing({ isComposing: false, nativeEvent: { keyCode: 9 } })).toBe(false);
+    });
+  });
+});
+
+describe("SearchablePalette keyboard navigation (non-composing)", () => {
+  it("navigates down on ArrowDown", () => {
+    const onSelectNext = vi.fn();
+    renderPalette({ onSelectNext });
+    const input = screen.getByRole("combobox");
+    fireEvent.keyDown(input, { key: "ArrowDown", keyCode: 40 });
+    expect(onSelectNext).toHaveBeenCalled();
+  });
+
+  it("navigates up on ArrowUp", () => {
+    const onSelectPrevious = vi.fn();
+    renderPalette({ onSelectPrevious });
+    const input = screen.getByRole("combobox");
+    fireEvent.keyDown(input, { key: "ArrowUp", keyCode: 38 });
+    expect(onSelectPrevious).toHaveBeenCalled();
+  });
+
+  it("confirms on Enter", () => {
+    const onConfirm = vi.fn();
+    renderPalette({ onConfirm });
+    const input = screen.getByRole("combobox");
+    fireEvent.keyDown(input, { key: "Enter", keyCode: 13 });
+    expect(onConfirm).toHaveBeenCalled();
+  });
+
+  it("does NOT call onConfirm when Enter fires during composition", () => {
+    const onConfirm = vi.fn();
+    renderPalette({ onConfirm, selectedIndex: 0 });
+    const input = screen.getByRole("combobox");
+    const event = new window.KeyboardEvent("keydown", {
+      key: "Enter",
+      keyCode: 13,
+    });
+    Object.defineProperty(event, "isComposing", { value: true });
+    input.dispatchEvent(event);
+    expect(onConfirm).not.toHaveBeenCalled();
+  });
+
+  it("does NOT call onConfirm when keyCode 229 (Process key) fires", () => {
+    const onConfirm = vi.fn();
+    renderPalette({ onConfirm });
+    const input = screen.getByRole("combobox");
+    const event = new window.KeyboardEvent("keydown", {
+      key: "Process",
+      keyCode: 229,
+    });
+    input.dispatchEvent(event);
+    expect(onConfirm).not.toHaveBeenCalled();
+  });
+});

--- a/src/components/ui/__tests__/SearchablePalette.stale.test.tsx
+++ b/src/components/ui/__tests__/SearchablePalette.stale.test.tsx
@@ -78,3 +78,31 @@ describe("SearchablePalette stale visual", () => {
     expect(listbox.classList.contains("palette-results-stale")).toBe(false);
   });
 });
+
+describe("SearchablePalette aria-busy on listbox", () => {
+  it("sets aria-busy='true' when isFiltering is true", () => {
+    renderPalette(true);
+    const listbox = screen.getByRole("listbox");
+    expect(listbox.getAttribute("aria-busy")).toBe("true");
+  });
+
+  it("omits aria-busy when isFiltering is false", () => {
+    renderPalette(false);
+    const listbox = screen.getByRole("listbox");
+    expect(listbox.hasAttribute("aria-busy")).toBe(false);
+  });
+
+  it("omits aria-busy when isFiltering is undefined", () => {
+    renderPalette(undefined);
+    const listbox = screen.getByRole("listbox");
+    expect(listbox.hasAttribute("aria-busy")).toBe(false);
+  });
+});
+
+describe("SearchablePalette combobox input ARIA", () => {
+  it("has aria-autocomplete='list'", () => {
+    renderPalette();
+    const input = screen.getByRole("combobox");
+    expect(input.getAttribute("aria-autocomplete")).toBe("list");
+  });
+});

--- a/src/components/ui/__tests__/SearchablePalette.stale.test.tsx
+++ b/src/components/ui/__tests__/SearchablePalette.stale.test.tsx
@@ -101,7 +101,7 @@ describe("SearchablePalette aria-busy on listbox", () => {
 
 describe("SearchablePalette combobox input ARIA", () => {
   it("has aria-autocomplete='list'", () => {
-    renderPalette();
+    renderPalette(undefined);
     const input = screen.getByRole("combobox");
     expect(input.getAttribute("aria-autocomplete")).toBe("list");
   });


### PR DESCRIPTION
## Summary

Tightens ARIA and IME-composition behavior in `SearchablePalette` and `AppPaletteDialog` -- the shell that ships under every palette in the app (action, theme, panel, project, worktree, log-level, terminal).

This is a focused PR with two commits: the a11y work, plus a follow-up that fixes a React typecheck issue.

Resolves #7264.

## Changes

- **IME composition guard** on the `SearchablePalette` keydown handler. CJK users pressing Enter to commit an IME composition no longer dispatch the highlighted action.
- **`aria-autocomplete="list"`** on the combobox input, matching the existing `BaseBranchCombobox` pattern.
- **`aria-busy`** on the stale listbox container while `useDeferredValue` lags behind keystrokes, so AT users get the equivalent of the `palette-results-stale` visual cue.
- **Removed `aria-hidden`** from `PaletteOverflowNotice`. The "Showing X of Y" text is meaningful; screen readers now announce it via `role="status"`.
- **Moved dialog ARIA** (`role="dialog"`, `aria-modal`, `aria-label`) from the backdrop scrim to the inner panel, matching the W3C APG dialog pattern.
- **Fixed `nativeEvent.isComposing`** TypeScript compatibility in the second commit.

## Testing

Tests added for IME composition guarding, ARIA attributes on the overflow notice, dialog role placement, and stale-state signaling. Existing tests pass.