### PR TITLE
fix(terminal): refresh and refit terminals on theme and font changes

### DIFF
--- a/src/services/terminal/TerminalInstanceService.ts
+++ b/src/services/terminal/TerminalInstanceService.ts
@@ -1530,13 +1530,22 @@ class TerminalInstanceService {
       managed.lastWidth = 0;
       managed.lastHeight = 0;
     }
+
+    if (!managed.isHibernated) {
+      if (textMetricsChanged) {
+        this.resizeController.fit(id);
+      }
+      if ("theme" in options) {
+        managed.terminal.refresh(0, managed.terminal.rows - 1);
+      }
+    }
   }
 
   applyGlobalOptions(options: Partial<Terminal["options"]>): void {
     const textMetricKeys = ["fontSize", "fontFamily", "lineHeight", "letterSpacing", "fontWeight"];
     const textMetricsChanged = textMetricKeys.some((key) => key in options);
 
-    this.instances.forEach((managed) => {
+    this.instances.forEach((managed, id) => {
       if (!managed.isHibernated) {
         Object.entries(options).forEach(([key, value]) => {
           // @ts-expect-error xterm options are indexable
@@ -1547,6 +1556,15 @@ class TerminalInstanceService {
       if (textMetricsChanged) {
         managed.lastWidth = 0;
         managed.lastHeight = 0;
+      }
+
+      if (!managed.isHibernated) {
+        if (textMetricsChanged) {
+          this.resizeController.fit(id);
+        }
+        if ("theme" in options) {
+          managed.terminal.refresh(0, managed.terminal.rows - 1);
+        }
       }
     });
   }

--- a/src/services/terminal/__tests__/TerminalInstanceService.options.test.ts
+++ b/src/services/terminal/__tests__/TerminalInstanceService.options.test.ts
@@ -15,6 +15,7 @@ vi.mock("@/clients", () => ({
     onExit: vi.fn(() => vi.fn()),
     setActivityTier: vi.fn(),
     wake: vi.fn(),
+    resize: vi.fn(),
     getSerializedState: vi.fn(),
     getSharedBuffer: vi.fn(() => null),
   },

--- a/src/services/terminal/__tests__/TerminalInstanceService.options.test.ts
+++ b/src/services/terminal/__tests__/TerminalInstanceService.options.test.ts
@@ -54,6 +54,7 @@ const mockDocument = {
     addEventListener: vi.fn(),
     removeEventListener: vi.fn(),
     remove: vi.fn(),
+    checkVisibility: vi.fn(() => true),
     getBoundingClientRect: vi.fn(() => ({ width: 800, height: 600 })),
   })),
   body: {
@@ -194,5 +195,256 @@ describe("TerminalInstanceService - options", () => {
     expect(managed.terminal.options.fontSize).toBe(14);
 
     terminalInstanceService.destroy("test-options");
+  });
+
+  it("updateOptions with theme calls refresh but not fit", async () => {
+    const { terminalInstanceService } = await import("../TerminalInstanceService");
+
+    window.matchMedia = vi.fn().mockReturnValue({
+      matches: false,
+      addEventListener: vi.fn(),
+      removeEventListener: vi.fn(),
+      addListener: vi.fn(),
+      removeListener: vi.fn(),
+    });
+
+    const managed = terminalInstanceService.getOrCreate(
+      "test-options-theme",
+      undefined,
+      {},
+      () => TerminalRefreshTier.FOCUSED,
+      undefined
+    );
+
+    const refreshSpy = vi.spyOn(managed.terminal, "refresh");
+    const fitSpy = vi.spyOn(managed.fitAddon, "fit");
+
+    terminalInstanceService.updateOptions("test-options-theme", {
+      theme: { foreground: "#ffffff", background: "#000000" },
+    });
+
+    expect(refreshSpy).toHaveBeenCalledWith(0, managed.terminal.rows - 1);
+    expect(fitSpy).not.toHaveBeenCalled();
+
+    terminalInstanceService.destroy("test-options-theme");
+  });
+
+  it("updateOptions with fontSize calls fit but not refresh", async () => {
+    const { terminalInstanceService } = await import("../TerminalInstanceService");
+
+    window.matchMedia = vi.fn().mockReturnValue({
+      matches: false,
+      addEventListener: vi.fn(),
+      removeEventListener: vi.fn(),
+      addListener: vi.fn(),
+      removeListener: vi.fn(),
+    });
+
+    const managed = terminalInstanceService.getOrCreate(
+      "test-options-font",
+      undefined,
+      {},
+      () => TerminalRefreshTier.FOCUSED,
+      undefined
+    );
+
+    const refreshSpy = vi.spyOn(managed.terminal, "refresh");
+    const fitSpy = vi.spyOn(managed.fitAddon, "fit");
+
+    terminalInstanceService.updateOptions("test-options-font", { fontSize: 16 });
+
+    expect(fitSpy).toHaveBeenCalled();
+    expect(refreshSpy).not.toHaveBeenCalled();
+
+    terminalInstanceService.destroy("test-options-font");
+  });
+
+  it("updateOptions with both theme and fontSize calls both", async () => {
+    const { terminalInstanceService } = await import("../TerminalInstanceService");
+
+    window.matchMedia = vi.fn().mockReturnValue({
+      matches: false,
+      addEventListener: vi.fn(),
+      removeEventListener: vi.fn(),
+      addListener: vi.fn(),
+      removeListener: vi.fn(),
+    });
+
+    const managed = terminalInstanceService.getOrCreate(
+      "test-options-both",
+      undefined,
+      {},
+      () => TerminalRefreshTier.FOCUSED,
+      undefined
+    );
+
+    const refreshSpy = vi.spyOn(managed.terminal, "refresh");
+    const fitSpy = vi.spyOn(managed.fitAddon, "fit");
+
+    terminalInstanceService.updateOptions("test-options-both", {
+      theme: { foreground: "#ffffff", background: "#000000" },
+      fontSize: 16,
+    });
+
+    expect(refreshSpy).toHaveBeenCalled();
+    expect(fitSpy).toHaveBeenCalled();
+
+    terminalInstanceService.destroy("test-options-both");
+  });
+
+  it("updateOptions on hibernated terminal calls neither refresh nor fit", async () => {
+    const { terminalInstanceService } = await import("../TerminalInstanceService");
+
+    window.matchMedia = vi.fn().mockReturnValue({
+      matches: false,
+      addEventListener: vi.fn(),
+      removeEventListener: vi.fn(),
+      addListener: vi.fn(),
+      removeListener: vi.fn(),
+    });
+
+    const managed = terminalInstanceService.getOrCreate(
+      "test-options-hibernated",
+      undefined,
+      {},
+      () => TerminalRefreshTier.FOCUSED,
+      undefined
+    );
+
+    // Simulate hibernation
+    managed.isHibernated = true;
+
+    const refreshSpy = vi.spyOn(managed.terminal, "refresh");
+    const fitSpy = vi.spyOn(managed.fitAddon, "fit");
+
+    terminalInstanceService.updateOptions("test-options-hibernated", {
+      theme: { foreground: "#ffffff", background: "#000000" },
+      fontSize: 16,
+    });
+
+    expect(refreshSpy).not.toHaveBeenCalled();
+    expect(fitSpy).not.toHaveBeenCalled();
+
+    terminalInstanceService.destroy("test-options-hibernated");
+  });
+
+  it("applyGlobalOptions with theme calls refresh on each instance", async () => {
+    const { terminalInstanceService } = await import("../TerminalInstanceService");
+
+    window.matchMedia = vi.fn().mockReturnValue({
+      matches: false,
+      addEventListener: vi.fn(),
+      removeEventListener: vi.fn(),
+      addListener: vi.fn(),
+      removeListener: vi.fn(),
+    });
+
+    const m1 = terminalInstanceService.getOrCreate(
+      "test-global-1",
+      undefined,
+      {},
+      () => TerminalRefreshTier.FOCUSED,
+      undefined
+    );
+    const m2 = terminalInstanceService.getOrCreate(
+      "test-global-2",
+      undefined,
+      {},
+      () => TerminalRefreshTier.FOCUSED,
+      undefined
+    );
+
+    const r1 = vi.spyOn(m1.terminal, "refresh");
+    const r2 = vi.spyOn(m2.terminal, "refresh");
+
+    terminalInstanceService.applyGlobalOptions({
+      theme: { foreground: "#ffffff", background: "#000000" },
+    });
+
+    expect(r1).toHaveBeenCalled();
+    expect(r2).toHaveBeenCalled();
+
+    terminalInstanceService.destroy("test-global-1");
+    terminalInstanceService.destroy("test-global-2");
+  });
+
+  it("applyGlobalOptions with fontSize calls fit on each instance", async () => {
+    const { terminalInstanceService } = await import("../TerminalInstanceService");
+
+    window.matchMedia = vi.fn().mockReturnValue({
+      matches: false,
+      addEventListener: vi.fn(),
+      removeEventListener: vi.fn(),
+      addListener: vi.fn(),
+      removeListener: vi.fn(),
+    });
+
+    const m1 = terminalInstanceService.getOrCreate(
+      "test-global-font-1",
+      undefined,
+      {},
+      () => TerminalRefreshTier.FOCUSED,
+      undefined
+    );
+    const m2 = terminalInstanceService.getOrCreate(
+      "test-global-font-2",
+      undefined,
+      {},
+      () => TerminalRefreshTier.FOCUSED,
+      undefined
+    );
+
+    const f1 = vi.spyOn(m1.fitAddon, "fit");
+    const f2 = vi.spyOn(m2.fitAddon, "fit");
+
+    terminalInstanceService.applyGlobalOptions({ fontSize: 18 });
+
+    expect(f1).toHaveBeenCalled();
+    expect(f2).toHaveBeenCalled();
+
+    terminalInstanceService.destroy("test-global-font-1");
+    terminalInstanceService.destroy("test-global-font-2");
+  });
+
+  it("applyGlobalOptions skips hibernated instances", async () => {
+    const { terminalInstanceService } = await import("../TerminalInstanceService");
+
+    window.matchMedia = vi.fn().mockReturnValue({
+      matches: false,
+      addEventListener: vi.fn(),
+      removeEventListener: vi.fn(),
+      addListener: vi.fn(),
+      removeListener: vi.fn(),
+    });
+
+    const active = terminalInstanceService.getOrCreate(
+      "test-global-active",
+      undefined,
+      {},
+      () => TerminalRefreshTier.FOCUSED,
+      undefined
+    );
+    const hibernated = terminalInstanceService.getOrCreate(
+      "test-global-hibernated",
+      undefined,
+      {},
+      () => TerminalRefreshTier.FOCUSED,
+      undefined
+    );
+    hibernated.isHibernated = true;
+
+    const rActive = vi.spyOn(active.terminal, "refresh");
+    const rHibernated = vi.spyOn(hibernated.terminal, "refresh");
+
+    terminalInstanceService.applyGlobalOptions({
+      theme: { foreground: "#ffffff", background: "#000000" },
+      fontSize: 16,
+    });
+
+    expect(rActive).toHaveBeenCalled();
+    expect(rHibernated).not.toHaveBeenCalled();
+
+    terminalInstanceService.destroy("test-global-active");
+    terminalInstanceService.destroy("test-global-hibernated");
   });
 });


### PR DESCRIPTION
## Summary

Fixes #7209.

When a user changes the color theme or font metrics in settings, the terminal was missing two bookkeeping steps that need to happen immediately. After a theme change, the canvas wasn't being refreshed, so WebGL terminals could show a flash of the old color scheme before the texture atlas caught up. After a font-size or font-family change, the terminal wasn't being refitted, so the grid kept its old columns and rows until the next window resize triggered a fit.

This adds those calls, guarded on `!isHibernated` so they don't fire on terminals that aren't visible.

## Changes

- `updateOptions`: call `resizeController.fit(id)` after text-metric changes, `terminal.refresh(0, rows - 1)` after theme changes
- `applyGlobalOptions`: same pattern applied across all managed instances, with per-instance hibernation check
- Unit tests covering theme-only, font-only, combined-changes, hibernation skip, and per-instance behavior across `updateOptions` and `applyGlobalOptions`

## Testing

All new tests pass. The existing options test suite continues to pass. Manual verification: changing the font size slider in Settings triggers an immediate grid refit; switching color schemes triggers an immediate repaint with no stale frame.