### PR TITLE
fix(help): reset auto-launch guard after visibility teardown

### DIFF
--- a/src/components/HelpPanel/HelpPanel.tsx
+++ b/src/components/HelpPanel/HelpPanel.tsx
@@ -251,6 +251,7 @@ export function HelpPanel({
   // effect without remounting the panel.
   const hibernateMinutesRef = useRef<number>(30);
   const hibernateTimerRef = useRef<ReturnType<typeof setTimeout> | null>(null);
+  const [visibilityEpoch, setVisibilityEpoch] = useState(0);
 
   const revokePendingSession = useCallback(() => {
     const pending = pendingSessionIdRef.current;
@@ -270,6 +271,7 @@ export function HelpPanel({
     if (terminalId && !terminal && terminalId !== pendingNewTerminalIdRef.current) {
       const { sessionId } = useHelpPanelStore.getState();
       revokeHelpSession(sessionId);
+      hasAutoLaunched.current = false;
       clearTerminal();
     }
   }, [terminalId, terminal, clearTerminal]);
@@ -287,35 +289,39 @@ export function HelpPanel({
       if (state.terminalId) {
         usePanelStore.getState().removePanel(state.terminalId);
         revokeHelpSession(state.sessionId);
+        hasAutoLaunched.current = false;
         useHelpPanelStore.getState().clearTerminal();
       }
       revokePendingSession();
     };
 
     const handler = () => {
-      if (!document.hidden) return;
-      if (isSystemSuspendedRef.current) return;
-      // Race: visibilitychange may fire before the suspend IPC reaches the
-      // renderer. Confirm with the main process before tearing down.
-      void window.electron.systemSleep
-        .getMetrics()
-        .then((metrics) => {
-          if (cancelled) return;
-          if (metrics.isCurrentlySleeping) return;
-          // Re-check after the IPC round-trip: the user may have reopened the
-          // lid (hidden → visible) or onSuspend may have arrived while we
-          // were waiting. Either way, skip teardown.
-          if (!document.hidden) return;
-          if (isSystemSuspendedRef.current) return;
-          tearDown();
-        })
-        .catch((err: unknown) => {
-          if (cancelled) return;
-          logError("HelpPanel: failed to read systemSleep metrics", err);
-          if (!document.hidden) return;
-          if (isSystemSuspendedRef.current) return;
-          tearDown();
-        });
+      if (document.hidden) {
+        if (isSystemSuspendedRef.current) return;
+        // Race: visibilitychange may fire before the suspend IPC reaches the
+        // renderer. Confirm with the main process before tearing down.
+        void window.electron.systemSleep
+          .getMetrics()
+          .then((metrics) => {
+            if (cancelled) return;
+            if (metrics.isCurrentlySleeping) return;
+            // Re-check after the IPC round-trip: the user may have reopened the
+            // lid (hidden → visible) or onSuspend may have arrived while we
+            // were waiting. Either way, skip teardown.
+            if (!document.hidden) return;
+            if (isSystemSuspendedRef.current) return;
+            tearDown();
+          })
+          .catch((err: unknown) => {
+            if (cancelled) return;
+            logError("HelpPanel: failed to read systemSleep metrics", err);
+            if (!document.hidden) return;
+            if (isSystemSuspendedRef.current) return;
+            tearDown();
+          });
+      } else {
+        setVisibilityEpoch((e) => e + 1);
+      }
     };
 
     const offSuspend = window.electron.systemSleep.onSuspend(() => {
@@ -547,6 +553,7 @@ export function HelpPanel({
   const hasAutoLaunched = useRef(false);
   useEffect(() => {
     if (
+      document.hidden ||
       !isOpen ||
       !isReadyToLaunch ||
       !currentProject ||
@@ -674,7 +681,15 @@ export function HelpPanel({
       })(),
       { context: "Auto-launching preferred help agent" }
     );
-  }, [isOpen, isReadyToLaunch, currentProject, terminalId, preferredAgentId, spawnResumed]);
+  }, [
+    isOpen,
+    isReadyToLaunch,
+    currentProject,
+    terminalId,
+    preferredAgentId,
+    spawnResumed,
+    visibilityEpoch,
+  ]);
 
   // Reset auto-launch guard when panel closes
   useEffect(() => {
@@ -857,6 +872,7 @@ export function HelpPanel({
   // ref to prevent any double-fire.
   useEffect(() => {
     if (
+      document.hidden ||
       !isOpen ||
       !isReadyToLaunch ||
       !currentProject ||
@@ -884,6 +900,7 @@ export function HelpPanel({
     supportedInstalledAgentIdsKey,
     supportedInstalledAgentIds,
     handleSelectAgent,
+    visibilityEpoch,
   ]);
 
   // Hide the panel without tearing down the agent or conversation. The PTY,

--- a/src/components/HelpPanel/__tests__/HelpPanel.helpLaunch.test.tsx
+++ b/src/components/HelpPanel/__tests__/HelpPanel.helpLaunch.test.tsx
@@ -1961,10 +1961,10 @@ describe("HelpPanel — visibilitychange teardown vs. system sleep (issue #6758)
 });
 
 describe("HelpPanel — visibilitychange re-launch after teardown (issue #7201)", () => {
-  function mountWithBoundTerminal() {
+  function mountWithBoundTerminal(preferredAgentId: string | null = "claude") {
     helpPanelState.terminalId = "term-7201";
     helpPanelState.agentId = "claude";
-    helpPanelState.preferredAgentId = "claude";
+    helpPanelState.preferredAgentId = preferredAgentId;
     helpPanelState.sessionId = "session-7201";
     panelStoreState.panelsById = { "term-7201": { id: "term-7201" } };
     return render(<HelpPanel width={380} />);
@@ -2013,13 +2013,14 @@ describe("HelpPanel — visibilitychange re-launch after teardown (issue #7201)"
     });
     await flushAsync();
 
-    // Auto-launch must fire for the preferred agent.
+    // Auto-launch must fire for the preferred agent and re-provision the session.
     expect(mockDispatch).toHaveBeenCalledTimes(1);
     expect(mockDispatch).toHaveBeenCalledWith(
       "agent.launch",
       expect.objectContaining({ agentId: "claude" }),
       { source: "user" }
     );
+    expect(mockProvisionSession).toHaveBeenCalledTimes(1);
   });
 
   it("does not launch while document.hidden after teardown resets hasAutoLaunched", async () => {
@@ -2053,13 +2054,12 @@ describe("HelpPanel — visibilitychange re-launch after teardown (issue #7201)"
   });
 
   it("re-launches the single supported agent after visibility restore when no preference is set", async () => {
-    helpPanelState.preferredAgentId = null;
     cliAvailabilityState.availability = { claude: "ready" };
     mockGetFolderPath.mockResolvedValue("/help");
     mockDispatch.mockResolvedValue({ ok: true, result: { terminalId: "term-auto" } });
 
     await act(async () => {
-      mountWithBoundTerminal();
+      mountWithBoundTerminal(null);
     });
 
     // Trigger visibility hide.
@@ -2091,5 +2091,6 @@ describe("HelpPanel — visibilitychange re-launch after teardown (issue #7201)"
       expect.objectContaining({ agentId: "claude" }),
       { source: "user" }
     );
+    expect(mockProvisionSession).toHaveBeenCalledTimes(1);
   });
 });

--- a/src/components/HelpPanel/__tests__/HelpPanel.helpLaunch.test.tsx
+++ b/src/components/HelpPanel/__tests__/HelpPanel.helpLaunch.test.tsx
@@ -371,7 +371,7 @@ beforeEach(() => {
 });
 
 describe("HelpPanel — single-supported-agent launch (handleSelectAgent)", () => {
-  it("commits the terminal to helpPanelStore even when document.hidden is true", async () => {
+  it("does not auto-launch when document.hidden is true (issue #7201 guard)", async () => {
     Object.defineProperty(document, "hidden", { configurable: true, get: () => true });
     mockGetFolderPath.mockResolvedValue("/help");
     mockDispatch.mockResolvedValue({ ok: true, result: { terminalId: "term-1" } });
@@ -380,8 +380,8 @@ describe("HelpPanel — single-supported-agent launch (handleSelectAgent)", () =
       render(<HelpPanel width={380} />);
     });
 
-    expect(helpPanelState.setTerminal).toHaveBeenCalledWith("term-1", "claude", "sess-default");
-    expect(mockNotify).not.toHaveBeenCalled();
+    expect(helpPanelState.setTerminal).not.toHaveBeenCalled();
+    expect(mockDispatch).not.toHaveBeenCalled();
   });
 
   it("dispatches agent.launch without a prompt field (regression: auto-greeting removed)", async () => {
@@ -555,7 +555,7 @@ describe("HelpPanel — auto-launch (preferredAgentId)", () => {
     );
   });
 
-  it("commits the terminal even when document.hidden is true", async () => {
+  it("does not auto-launch when document.hidden is true (issue #7201 guard)", async () => {
     Object.defineProperty(document, "hidden", { configurable: true, get: () => true });
     helpPanelState.preferredAgentId = "claude";
     mockGetFolderPath.mockResolvedValue("/help");
@@ -565,11 +565,8 @@ describe("HelpPanel — auto-launch (preferredAgentId)", () => {
       render(<HelpPanel width={380} />);
     });
 
-    expect(helpPanelState.setTerminal).toHaveBeenCalledWith(
-      "auto-term-1",
-      "claude",
-      "sess-default"
-    );
+    expect(helpPanelState.setTerminal).not.toHaveBeenCalled();
+    expect(mockDispatch).not.toHaveBeenCalled();
   });
 
   it("dispatches auto-launch agent.launch without a prompt field", async () => {
@@ -1960,5 +1957,139 @@ describe("HelpPanel — visibilitychange teardown vs. system sleep (issue #6758)
     expect(mockSystemSleepGetMetrics).toHaveBeenCalledTimes(1);
     expect(panelStoreState.removePanel).toHaveBeenCalledWith("term-sleep");
     expect(mockRevokeSession).toHaveBeenCalledWith("session-sleep");
+  });
+});
+
+describe("HelpPanel — visibilitychange re-launch after teardown (issue #7201)", () => {
+  function mountWithBoundTerminal() {
+    helpPanelState.terminalId = "term-7201";
+    helpPanelState.agentId = "claude";
+    helpPanelState.preferredAgentId = "claude";
+    helpPanelState.sessionId = "session-7201";
+    panelStoreState.panelsById = { "term-7201": { id: "term-7201" } };
+    return render(<HelpPanel width={380} />);
+  }
+
+  async function flushAsync() {
+    await act(async () => {
+      await Promise.resolve();
+      await Promise.resolve();
+    });
+  }
+
+  it("resets hasAutoLaunched in teardown and re-launches on visibility restore", async () => {
+    mockGetFolderPath.mockResolvedValue("/help");
+    mockDispatch.mockResolvedValue({ ok: true, result: { terminalId: "term-relaunched" } });
+
+    await act(async () => {
+      mountWithBoundTerminal();
+    });
+
+    // Trigger visibility hide (project switch / window hide).
+    Object.defineProperty(document, "hidden", { configurable: true, get: () => true });
+    await act(async () => {
+      document.dispatchEvent(new Event("visibilitychange"));
+    });
+    await flushAsync();
+
+    // Teardown should have fired.
+    expect(panelStoreState.removePanel).toHaveBeenCalledWith("term-7201");
+    expect(helpPanelState.clearTerminal).toHaveBeenCalled();
+
+    // Simulate the real store mutation that clearTerminal() would perform.
+    helpPanelState.terminalId = null;
+    helpPanelState.agentId = null;
+    helpPanelState.sessionId = null;
+
+    // Reset spies to measure post-restore calls.
+    panelStoreState.removePanel.mockClear();
+    helpPanelState.clearTerminal.mockClear();
+    mockDispatch.mockClear();
+
+    // Restore visibility.
+    Object.defineProperty(document, "hidden", { configurable: true, get: () => false });
+    await act(async () => {
+      document.dispatchEvent(new Event("visibilitychange"));
+    });
+    await flushAsync();
+
+    // Auto-launch must fire for the preferred agent.
+    expect(mockDispatch).toHaveBeenCalledTimes(1);
+    expect(mockDispatch).toHaveBeenCalledWith(
+      "agent.launch",
+      expect.objectContaining({ agentId: "claude" }),
+      { source: "user" }
+    );
+  });
+
+  it("does not launch while document.hidden after teardown resets hasAutoLaunched", async () => {
+    mockGetFolderPath.mockResolvedValue("/help");
+
+    await act(async () => {
+      mountWithBoundTerminal();
+    });
+
+    // Trigger visibility hide.
+    Object.defineProperty(document, "hidden", { configurable: true, get: () => true });
+    await act(async () => {
+      document.dispatchEvent(new Event("visibilitychange"));
+    });
+    await flushAsync();
+
+    // Simulate the real store mutation.
+    helpPanelState.terminalId = null;
+
+    // Clear any launch from the initial mount.
+    mockDispatch.mockClear();
+
+    // Re-render — auto-launch effect must NOT fire because document.hidden is true.
+    await act(async () => {
+      // Re-render triggered by state change.
+      await Promise.resolve();
+      await Promise.resolve();
+    });
+
+    expect(mockDispatch).not.toHaveBeenCalled();
+  });
+
+  it("re-launches the single supported agent after visibility restore when no preference is set", async () => {
+    helpPanelState.preferredAgentId = null;
+    cliAvailabilityState.availability = { claude: "ready" };
+    mockGetFolderPath.mockResolvedValue("/help");
+    mockDispatch.mockResolvedValue({ ok: true, result: { terminalId: "term-auto" } });
+
+    await act(async () => {
+      mountWithBoundTerminal();
+    });
+
+    // Trigger visibility hide.
+    Object.defineProperty(document, "hidden", { configurable: true, get: () => true });
+    await act(async () => {
+      document.dispatchEvent(new Event("visibilitychange"));
+    });
+    await flushAsync();
+
+    // Simulate teardown effect.
+    helpPanelState.terminalId = null;
+    helpPanelState.agentId = null;
+    helpPanelState.sessionId = null;
+
+    panelStoreState.removePanel.mockClear();
+    mockDispatch.mockClear();
+
+    // Restore visibility.
+    Object.defineProperty(document, "hidden", { configurable: true, get: () => false });
+    await act(async () => {
+      document.dispatchEvent(new Event("visibilitychange"));
+    });
+    await flushAsync();
+
+    // Single-supported-agent path should fire (via handleSelectAgent).
+    expect(mockDispatch).toHaveBeenCalledTimes(1);
+    expect(mockDispatch).toHaveBeenCalledWith(
+      "agent.launch",
+      expect.objectContaining({ agentId: "claude" }),
+      { source: "user" }
+    );
   });
 });


### PR DESCRIPTION
## Summary
- Resets the `hasAutoLaunched` ref guard in both the `visibilitychange` teardown and the `panelDisappeared` cleanup path, so the agent restarts when the document becomes visible again after being hidden.
- Adds `document.hidden` bail-outs to both auto-launch effects to prevent hidden-phase launches in detached `WebContentsView`s.
- Uses a `visibilityEpoch` counter incremented on each visibility restore, wired into the auto-launch effect dependency arrays so the effects re-trigger when the document reappears.

Resolves #7201

## Changes
- `src/components/HelpPanel/HelpPanel.tsx` — reset `hasAutoLaunched` during teardown, add `document.hidden` gates to auto-launch effects, introduce `visibilityEpoch` to re-trigger on restore.
- `src/components/HelpPanel/__tests__/HelpPanel.helpLaunch.test.tsx` — add assertions for guard reset, hidden-document bail-out, and provision behavior.

## Testing
- 74 existing + new tests pass.
- Typecheck, lint, and format all clean.