### PR TITLE
fix(settings): WCAG 2.2 accessibility polish across agents settings tab

### DIFF
--- a/src/components/Settings/AgentScopeEditor/BehavioralControls.tsx
+++ b/src/components/Settings/AgentScopeEditor/BehavioralControls.tsx
@@ -107,7 +107,7 @@ export function BehavioralControls({
               <button
                 type="button"
                 aria-label={`Reset custom arguments override for ${scopeLabel}`}
-                className="p-0.5 rounded-sm text-daintree-text/40 hover:text-daintree-text invisible group-hover/args:visible group-focus-within/args:visible focus-visible:visible focus-visible:outline focus-visible:outline-2 focus-visible:outline-daintree-accent transition-colors"
+                className="p-0.5 rounded-sm text-daintree-text/40 hover:text-daintree-text focus-visible:outline focus-visible:outline-2 focus-visible:outline-daintree-accent transition-colors"
                 onClick={onCustomFlagsOverrideReset}
                 data-testid="preset-custom-flags-reset"
               >

--- a/src/components/Settings/AgentSelectorDropdown.tsx
+++ b/src/components/Settings/AgentSelectorDropdown.tsx
@@ -118,16 +118,22 @@ export function AgentSelectorDropdown({
               {(!selectedAgent.selected || selectedAgent.dangerousEnabled) && (
                 <span className="flex items-center gap-1">
                   {!selectedAgent.selected && (
-                    <span
-                      className="w-1.5 h-1.5 rounded-full bg-daintree-text/30"
-                      title="Not in workflow"
-                    />
+                    <>
+                      <span
+                        className="w-1.5 h-1.5 rounded-full bg-daintree-text/30"
+                        aria-hidden="true"
+                      />
+                      <span className="sr-only">Not in workflow</span>
+                    </>
                   )}
                   {selectedAgent.dangerousEnabled && (
-                    <span
-                      className="w-1.5 h-1.5 rounded-full bg-status-error"
-                      title="Skip permissions enabled"
-                    />
+                    <>
+                      <span
+                        className="w-1.5 h-1.5 rounded-full bg-status-error"
+                        aria-hidden="true"
+                      />
+                      <span className="sr-only">Skip permissions enabled</span>
+                    </>
                   )}
                 </span>
               )}
@@ -175,7 +181,12 @@ export function AgentSelectorDropdown({
             className="flex-1 min-w-0 text-xs bg-transparent text-daintree-text placeholder:text-daintree-text/40 focus:outline-hidden"
           />
         </div>
-        <div role="listbox" id="agent-selector-list" className="overflow-y-auto max-h-60 p-1">
+        <div
+          role="listbox"
+          id="agent-selector-list"
+          aria-label="Agents"
+          className="overflow-y-auto max-h-60 p-1"
+        >
           {items.map((item, index) => {
             const isActive = index === activeIndex;
             const isSelected =
@@ -215,16 +226,22 @@ export function AgentSelectorDropdown({
                     {(!item.agent.selected || item.agent.dangerousEnabled) && (
                       <span className="flex items-center gap-1 shrink-0">
                         {!item.agent.selected && (
-                          <span
-                            className="w-1.5 h-1.5 rounded-full bg-daintree-text/30"
-                            title="Not in workflow"
-                          />
+                          <>
+                            <span
+                              className="w-1.5 h-1.5 rounded-full bg-daintree-text/30"
+                              aria-hidden="true"
+                            />
+                            <span className="sr-only">Not in workflow</span>
+                          </>
                         )}
                         {item.agent.dangerousEnabled && (
-                          <span
-                            className="w-1.5 h-1.5 rounded-full bg-status-error"
-                            title="Skip permissions enabled"
-                          />
+                          <>
+                            <span
+                              className="w-1.5 h-1.5 rounded-full bg-status-error"
+                              aria-hidden="true"
+                            />
+                            <span className="sr-only">Skip permissions enabled</span>
+                          </>
                         )}
                       </span>
                     )}

--- a/src/components/Settings/PresetSelector.tsx
+++ b/src/components/Settings/PresetSelector.tsx
@@ -107,7 +107,7 @@ export function PresetSelector({
           data-testid="preset-selector-trigger"
         >
           <span
-            className="w-2.5 h-2.5 rounded-full shrink-0 border border-daintree-border/60"
+            className="w-2.5 h-2.5 rounded-full shrink-0 border border-daintree-border"
             style={{ backgroundColor: selectedItem.color }}
             aria-hidden="true"
           />
@@ -257,7 +257,7 @@ function PresetOption({
       )}
     >
       <span
-        className="w-2.5 h-2.5 rounded-full shrink-0 border border-daintree-border/60"
+        className="w-2.5 h-2.5 rounded-full shrink-0 border border-daintree-border"
         style={{ backgroundColor: color }}
         aria-hidden="true"
       />

--- a/src/components/Settings/SettingsSwitchCard.tsx
+++ b/src/components/Settings/SettingsSwitchCard.tsx
@@ -135,7 +135,6 @@ export function SettingsSwitchCard({
           className={cn(
             "absolute top-1/2 -translate-y-1/2 z-10 p-1 rounded-sm",
             "text-daintree-text/40 hover:text-daintree-text",
-            "invisible group-hover:visible group-focus-within:visible focus-visible:visible",
             "focus-visible:outline focus-visible:outline-2 focus-visible:outline-daintree-accent",
             "transition-colors",
             isCard ? "right-[4.5rem]" : "right-[3.25rem]"

--- a/src/components/Settings/SettingsSwitchCard.tsx
+++ b/src/components/Settings/SettingsSwitchCard.tsx
@@ -128,7 +128,6 @@ export function SettingsSwitchCard({
   return (
     <div id={id} className="grid grid-cols-subgrid col-span-full gap-2">
       <div className="group relative">
-        {card}
         <button
           type="button"
           aria-label={resetAriaLabel ?? `Reset ${title} to default`}
@@ -143,6 +142,7 @@ export function SettingsSwitchCard({
         >
           <RotateCcw className="w-3 h-3" />
         </button>
+        {card}
       </div>
     </div>
   );


### PR DESCRIPTION
## Summary

- Reset buttons in `SettingsSwitchCard` and `BehavioralControls` were hidden behind hover/focus visibility toggling. They're already conditionally mounted, so once they appear they should stay visible — aligns with SC 3.2.7 intent for cognitive/motor accessibility.
- In the compact variant of `SettingsSwitchCard`, the reset button was placed after the switch in DOM order, breaking tab order. Moved it before `{card}` in JSX so keyboard navigation matches the visual left-to-right reading order. Visual layout is unchanged (button stays `absolute`-positioned).
- Status dots in `AgentSelectorDropdown` only had `title` attributes, giving screen readers noisy or empty computed names. Replaced with `aria-hidden="true"` on the dot and a sibling `<span className="sr-only">` carrying the status text, so `role=option` names flatten cleanly.
- Added `aria-label="Agents"` to the listbox `div` — WAI-ARIA 1.2 requires an accessible name on any `role=listbox` element.
- Promoted `PresetSelector` swatch border opacity from `/60` to full for safer non-text contrast across all 14 built-in themes.

Resolves #7214

## Changes

- `src/components/Settings/SettingsSwitchCard.tsx` — remove `invisible group-hover:visible` etc. from reset button; reorder reset before card in compact variant
- `src/components/Settings/AgentScopeEditor/BehavioralControls.tsx` — remove hover/focus visibility toggle from reset button
- `src/components/Settings/AgentSelectorDropdown.tsx` — `aria-hidden` dots + `sr-only` status spans; `aria-label="Agents"` on listbox
- `src/components/Settings/PresetSelector.tsx` — swatch border opacity to full

## Testing

- Typecheck: pass
- Lint: improved by 10 warnings vs baseline
- Format: pass
- Build: pass (renderer + main)