### PR TITLE
chore(github): polish issues/PRs dropdown a11y and microcopy

### DIFF
--- a/src/components/GitHub/GitHubResourceList.tsx
+++ b/src/components/GitHub/GitHubResourceList.tsx
@@ -506,7 +506,7 @@ export function GitHubResourceList({
     if (isFilterActive) {
       const title =
         exactNumberNotFound !== null
-          ? `${type === "issue" ? "Issue" : "PR"} #${exactNumberNotFound} not found`
+          ? `No ${type === "issue" ? "issue" : "PR"} #${exactNumberNotFound} in this view`
           : trimmedSearch.length > 0
             ? `No ${resourceLabel} match "${trimmedSearch}"`
             : `No ${resourceLabel} in this view`;
@@ -608,7 +608,11 @@ export function GitHubResourceList({
             type="button"
             onClick={handleManualRefreshClick}
             disabled={loading || refreshing}
-            aria-label={`Refresh ${type === "issue" ? "issues" : "pull requests"}`}
+            aria-label={
+              showSpinner
+                ? "Refreshing…"
+                : `Refresh ${type === "issue" ? "issues" : "pull requests"}`
+            }
             title={
               showSpinner
                 ? "Refreshing…"
@@ -629,11 +633,11 @@ export function GitHubResourceList({
                 type="button"
                 aria-label={`Sort ${type === "issue" ? "issues" : "pull requests"}`}
                 aria-haspopup="dialog"
+                aria-expanded={sortPopoverOpen}
                 className={cn(
                   "relative flex items-center justify-center w-7 h-7 rounded shrink-0",
                   "text-daintree-text/60 hover:text-daintree-text hover:bg-tint/[0.06]",
-                  "transition-colors",
-                  sortOrder !== "created" && "text-status-info"
+                  "transition-colors"
                 )}
               >
                 <Filter className="w-3.5 h-3.5" />
@@ -659,42 +663,61 @@ export function GitHubResourceList({
                 Sort by
               </div>
               <div className="flex flex-col gap-1" role="radiogroup" aria-label="Sort order">
-                {(
-                  [
+                {(() => {
+                  const sortOptions = [
                     { value: "created", label: "Newest" },
                     { value: "updated", label: "Recently updated" },
-                  ] as const
-                ).map((option) => (
-                  <button
-                    key={option.value}
-                    type="button"
-                    onClick={() => setSortOrder(option.value)}
-                    role="radio"
-                    aria-checked={sortOrder === option.value}
-                    className={cn(
-                      "flex items-center gap-2 px-2 py-1 text-xs rounded",
-                      sortOrder === option.value
-                        ? "bg-overlay-soft text-daintree-text"
-                        : "text-daintree-text/70 hover:bg-overlay-medium"
-                    )}
-                  >
-                    <div
+                  ] as const;
+                  return sortOptions.map((option, idx) => (
+                    <button
+                      key={option.value}
+                      type="button"
+                      onClick={() => setSortOrder(option.value)}
+                      role="radio"
+                      aria-checked={sortOrder === option.value}
+                      tabIndex={sortOrder === option.value ? 0 : -1}
+                      onKeyDown={(e) => {
+                        const isNext = e.key === "ArrowDown" || e.key === "ArrowRight";
+                        const isPrev = e.key === "ArrowUp" || e.key === "ArrowLeft";
+                        if (!isNext && !isPrev) return;
+                        e.preventDefault();
+                        e.stopPropagation();
+                        const delta = isNext ? 1 : -1;
+                        const nextIdx = (idx + delta + sortOptions.length) % sortOptions.length;
+                        const nextValue = sortOptions[nextIdx]!.value;
+                        setSortOrder(nextValue);
+                        const group = e.currentTarget.parentElement;
+                        requestAnimationFrame(() => {
+                          const radios =
+                            group?.querySelectorAll<HTMLButtonElement>('[role="radio"]');
+                          radios?.[nextIdx]?.focus();
+                        });
+                      }}
                       className={cn(
-                        "w-3 h-3 rounded-full border",
+                        "flex items-center gap-2 px-2 py-1 text-xs rounded",
                         sortOrder === option.value
-                          ? "border-daintree-text bg-daintree-text"
-                          : "border-daintree-border"
+                          ? "bg-overlay-soft text-daintree-text"
+                          : "text-daintree-text/70 hover:bg-overlay-medium"
                       )}
                     >
-                      {sortOrder === option.value && (
-                        <div className="w-full h-full flex items-center justify-center">
-                          <div className="w-1.5 h-1.5 bg-text-inverse rounded-full" />
-                        </div>
-                      )}
-                    </div>
-                    {option.label}
-                  </button>
-                ))}
+                      <div
+                        className={cn(
+                          "w-3 h-3 rounded-full border",
+                          sortOrder === option.value
+                            ? "border-daintree-text bg-daintree-text"
+                            : "border-daintree-border"
+                        )}
+                      >
+                        {sortOrder === option.value && (
+                          <div className="w-full h-full flex items-center justify-center">
+                            <div className="w-1.5 h-1.5 bg-text-inverse rounded-full" />
+                          </div>
+                        )}
+                      </div>
+                      {option.label}
+                    </button>
+                  ));
+                })()}
               </div>
             </PopoverContent>
           </Popover>
@@ -745,17 +768,34 @@ export function GitHubResourceList({
 
         <div
           className="flex p-0.5 bg-overlay-soft border border-[var(--border-divider)] rounded-[var(--radius-md)]"
-          role="group"
+          role="radiogroup"
           aria-label="Filter by state"
         >
-          {stateTabs.map((tab) => {
+          {stateTabs.map((tab, idx) => {
             const isActive = filterState === tab.id;
             return (
               <button
                 key={tab.id}
                 type="button"
                 onClick={() => setFilterState(tab.id as StateFilter)}
-                aria-pressed={isActive}
+                role="radio"
+                aria-checked={isActive}
+                tabIndex={isActive ? 0 : -1}
+                onKeyDown={(e) => {
+                  const isNext = e.key === "ArrowRight" || e.key === "ArrowDown";
+                  const isPrev = e.key === "ArrowLeft" || e.key === "ArrowUp";
+                  if (!isNext && !isPrev) return;
+                  e.preventDefault();
+                  const delta = isNext ? 1 : -1;
+                  const nextIdx = (idx + delta + stateTabs.length) % stateTabs.length;
+                  const nextTab = stateTabs[nextIdx]!;
+                  setFilterState(nextTab.id as StateFilter);
+                  const group = e.currentTarget.parentElement;
+                  requestAnimationFrame(() => {
+                    const radios = group?.querySelectorAll<HTMLButtonElement>('[role="radio"]');
+                    radios?.[nextIdx]?.focus();
+                  });
+                }}
                 className={cn(
                   "flex-1 px-3 py-1 text-xs font-medium rounded transition-colors",
                   isActive
@@ -865,7 +905,7 @@ export function GitHubResourceList({
               <div
                 id={listId}
                 role="listbox"
-                aria-multiselectable={true}
+                aria-multiselectable={selection.isSelectionActive}
                 aria-busy={loading || refreshing}
                 className="flex-1 min-h-0"
               >

--- a/src/components/GitHub/GitHubResourceList.tsx
+++ b/src/components/GitHub/GitHubResourceList.tsx
@@ -631,7 +631,11 @@ export function GitHubResourceList({
             <PopoverTrigger asChild>
               <button
                 type="button"
-                aria-label={`Sort ${type === "issue" ? "issues" : "pull requests"}`}
+                aria-label={
+                  sortOrder === "created"
+                    ? `Sort ${type === "issue" ? "issues" : "pull requests"}`
+                    : `Sort ${type === "issue" ? "issues" : "pull requests"}, sorted by recently updated`
+                }
                 aria-haspopup="dialog"
                 aria-expanded={sortPopoverOpen}
                 className={cn(
@@ -786,6 +790,7 @@ export function GitHubResourceList({
                   const isPrev = e.key === "ArrowLeft" || e.key === "ArrowUp";
                   if (!isNext && !isPrev) return;
                   e.preventDefault();
+                  e.stopPropagation();
                   const delta = isNext ? 1 : -1;
                   const nextIdx = (idx + delta + stateTabs.length) % stateTabs.length;
                   const nextTab = stateTabs[nextIdx]!;

--- a/src/components/GitHub/__tests__/GitHubResourceList.swr.test.tsx
+++ b/src/components/GitHub/__tests__/GitHubResourceList.swr.test.tsx
@@ -58,10 +58,14 @@ vi.mock("@/services/ActionService", () => ({
   actionService: { dispatch: (...args: unknown[]) => dispatchMock(...args) },
 }));
 
+let mockIsSelectionActive = false;
+
 vi.mock("@/hooks/useIssueSelection", () => ({
   useIssueSelection: () => ({
     selectedIds: new Set<number>(),
-    isSelectionActive: false,
+    get isSelectionActive() {
+      return mockIsSelectionActive;
+    },
     toggle: vi.fn(),
     toggleRange: vi.fn(),
     selectAll: vi.fn(),
@@ -191,6 +195,7 @@ beforeEach(() => {
   LiveTimeAgoMock.mockClear();
   dispatchMock.mockReset();
   initializeMock.mockClear();
+  mockIsSelectionActive = false;
   mockGitHubConfig = { hasToken: true };
   mockGitHubConfigInitialized = true;
   const filterStore = useGitHubFilterStore.getState();
@@ -811,7 +816,7 @@ describe("GitHubResourceList empty state branching", () => {
     render(<GitHubResourceList type="issue" projectPath="/test/proj" />);
 
     await waitFor(() => {
-      expect(screen.getByText(/Issue #999 not found/)).toBeTruthy();
+      expect(screen.getByText(/No issue #999 in this view/)).toBeTruthy();
     });
     expect(screen.getByRole("button", { name: /clear filters/i })).toBeTruthy();
   });
@@ -1399,7 +1404,7 @@ describe("GitHubResourceList aria-busy placement (#6867)", () => {
       expect(listbox.getAttribute("aria-busy")).toBe("true");
     });
 
-    const refreshButton = screen.getByRole("button", { name: /refresh issues/i });
+    const refreshButton = screen.getByRole("button", { name: /^refresh/i });
     expect(refreshButton.hasAttribute("aria-busy")).toBe(false);
   });
 });
@@ -1586,7 +1591,7 @@ describe("GitHubResourceList number-query chip (#6867)", () => {
     render(<GitHubResourceList type="issue" projectPath="/test/proj" />);
 
     await waitFor(() => {
-      expect(screen.getByText(/Issue #999 not found/)).toBeTruthy();
+      expect(screen.getByText(/No issue #999 in this view/)).toBeTruthy();
     });
     // The chip would contradict the empty state — it must not render alongside.
     expect(screen.queryByText("Showing issue #999")).toBeNull();
@@ -1636,9 +1641,7 @@ describe("GitHubResourceList spinner gate (#6867)", () => {
 
       await vi.advanceTimersByTimeAsync(399);
 
-      const refreshIcon = screen
-        .getByRole("button", { name: /refresh issues/i })
-        .querySelector("svg");
+      const refreshIcon = screen.getByRole("button", { name: /^refresh/i }).querySelector("svg");
       expect(refreshIcon?.classList.contains("animate-spin")).toBe(false);
     }
   );
@@ -1657,9 +1660,7 @@ describe("GitHubResourceList spinner gate (#6867)", () => {
 
     await vi.advanceTimersByTimeAsync(450);
 
-    const refreshIcon = screen
-      .getByRole("button", { name: /refresh issues/i })
-      .querySelector("svg");
+    const refreshIcon = screen.getByRole("button", { name: /^refresh/i }).querySelector("svg");
     expect(refreshIcon?.classList.contains("animate-spin")).toBe(true);
   });
 
@@ -1678,9 +1679,7 @@ describe("GitHubResourceList spinner gate (#6867)", () => {
     // Let the fetch settle well within the 400ms gate.
     await vi.advanceTimersByTimeAsync(50);
 
-    const refreshIcon = screen
-      .getByRole("button", { name: /refresh issues/i })
-      .querySelector("svg");
+    const refreshIcon = screen.getByRole("button", { name: /^refresh/i }).querySelector("svg");
     expect(refreshIcon?.classList.contains("animate-spin")).toBe(false);
   });
 
@@ -1707,7 +1706,7 @@ describe("GitHubResourceList spinner gate (#6867)", () => {
     // is cleared before the click.
     await vi.advanceTimersByTimeAsync(500);
 
-    const refreshButton = screen.getByRole("button", { name: /refresh issues/i });
+    const refreshButton = screen.getByRole("button", { name: /^refresh/i });
     act(() => {
       refreshButton.click();
     });
@@ -1746,22 +1745,125 @@ describe("GitHubResourceList spinner gate (#6867)", () => {
 
     // Cross the 400ms gate so the spinner becomes visible.
     await vi.advanceTimersByTimeAsync(450);
-    const refreshIcon = screen
-      .getByRole("button", { name: /refresh issues/i })
-      .querySelector("svg");
+    const refreshIcon = screen.getByRole("button", { name: /^refresh/i }).querySelector("svg");
     expect(refreshIcon?.classList.contains("animate-spin")).toBe(true);
 
     // Resolve immediately — dwell timer kicks in for the remaining 500ms.
     resolveFetch(makeResponse([makeIssue(1)]));
     await vi.advanceTimersByTimeAsync(0);
-    const stillSpinning = screen
-      .getByRole("button", { name: /refresh issues/i })
-      .querySelector("svg");
+    const stillSpinning = screen.getByRole("button", { name: /^refresh/i }).querySelector("svg");
     expect(stillSpinning?.classList.contains("animate-spin")).toBe(true);
 
     // After the full 500ms minimum dwell elapses, the spinner clears.
     await vi.advanceTimersByTimeAsync(550);
-    const finalIcon = screen.getByRole("button", { name: /refresh issues/i }).querySelector("svg");
+    const finalIcon = screen.getByRole("button", { name: /^refresh/i }).querySelector("svg");
     expect(finalIcon?.classList.contains("animate-spin")).toBe(false);
+  });
+});
+
+describe("GitHubResourceList polish (#7202)", () => {
+  it("state filter renders as a radiogroup with aria-checked + roving tabindex", async () => {
+    mockListIssues.mockResolvedValue(makeResponse([makeIssue(1)]));
+
+    render(<GitHubResourceList type="issue" projectPath="/test/proj" />);
+
+    const group = await screen.findByRole("radiogroup", { name: /filter by state/i });
+    const radios = group.querySelectorAll<HTMLButtonElement>('[role="radio"]');
+    expect(radios.length).toBe(2); // Open, Closed for issues
+
+    const openRadio = radios[0]!;
+    const closedRadio = radios[1]!;
+    expect(openRadio.getAttribute("aria-checked")).toBe("true");
+    expect(openRadio.tabIndex).toBe(0);
+    expect(closedRadio.getAttribute("aria-checked")).toBe("false");
+    expect(closedRadio.tabIndex).toBe(-1);
+
+    // ArrowRight on the active radio moves checked state and focus to the next.
+    act(() => {
+      openRadio.focus();
+      openRadio.dispatchEvent(new KeyboardEvent("keydown", { key: "ArrowRight", bubbles: true }));
+    });
+
+    await waitFor(() => {
+      const updated = group.querySelectorAll<HTMLButtonElement>('[role="radio"]');
+      expect(updated[1]!.getAttribute("aria-checked")).toBe("true");
+      expect(updated[0]!.getAttribute("aria-checked")).toBe("false");
+    });
+  });
+
+  it("sort popover trigger reflects open state via aria-expanded", async () => {
+    mockListIssues.mockResolvedValue(makeResponse([makeIssue(1)]));
+
+    render(<GitHubResourceList type="issue" projectPath="/test/proj" />);
+
+    const sortButton = await screen.findByRole("button", { name: /^sort/i });
+    expect(sortButton.getAttribute("aria-expanded")).toBe("false");
+
+    act(() => {
+      sortButton.click();
+    });
+
+    await waitFor(() => {
+      expect(sortButton.getAttribute("aria-expanded")).toBe("true");
+    });
+  });
+
+  it("sort trigger drops the accent tint when sort is non-default; only the dot remains", async () => {
+    mockListIssues.mockResolvedValue(makeResponse([makeIssue(1)]));
+    useGitHubFilterStore.getState().setIssueSortOrder("updated");
+
+    render(<GitHubResourceList type="issue" projectPath="/test/proj" />);
+
+    const sortButton = await screen.findByRole("button", { name: /^sort/i });
+    expect(sortButton.classList.contains("text-status-info")).toBe(false);
+
+    // The dot is the sole signal — find the absolutely-positioned status-info span inside the button.
+    const dot = sortButton.querySelector("span.bg-status-info");
+    expect(dot).not.toBeNull();
+  });
+
+  it("listbox aria-multiselectable tracks selection.isSelectionActive", async () => {
+    mockListIssues.mockResolvedValue(makeResponse([makeIssue(1)]));
+    mockIsSelectionActive = false;
+
+    const { unmount } = render(<GitHubResourceList type="issue" projectPath="/test/proj" />);
+
+    const listbox = await screen.findByRole("listbox");
+    expect(listbox.getAttribute("aria-multiselectable")).toBe("false");
+
+    unmount();
+
+    mockIsSelectionActive = true;
+    render(<GitHubResourceList type="issue" projectPath="/test/proj" />);
+    const activeListbox = await screen.findByRole("listbox");
+    expect(activeListbox.getAttribute("aria-multiselectable")).toBe("true");
+  });
+
+  it("refresh button aria-label flips to 'Refreshing…' once the spinner fires", async () => {
+    vi.useFakeTimers({ shouldAdvanceTime: true });
+    try {
+      const cacheKey = buildCacheKey("/test/proj", "issue", "open", "created");
+      setCache(cacheKey, {
+        items: [makeIssue(1)],
+        endCursor: null,
+        hasNextPage: false,
+        timestamp: Date.now(),
+      });
+      mockListIssues.mockImplementation(() => new Promise(() => {}));
+
+      render(<GitHubResourceList type="issue" projectPath="/test/proj" />);
+
+      // Before the gate elapses, label is "Refresh issues".
+      await vi.advanceTimersByTimeAsync(50);
+      expect(screen.getByRole("button", { name: /refresh issues/i })).toBeTruthy();
+
+      // After the 400ms gate, the label should reflect the active spinner.
+      await vi.advanceTimersByTimeAsync(450);
+      await waitFor(() => {
+        expect(screen.getByRole("button", { name: /refreshing/i })).toBeTruthy();
+      });
+    } finally {
+      vi.useRealTimers();
+    }
   });
 });

--- a/src/components/GitHub/__tests__/GitHubResourceList.swr.test.tsx
+++ b/src/components/GitHub/__tests__/GitHubResourceList.swr.test.tsx
@@ -1778,7 +1778,7 @@ describe("GitHubResourceList polish (#7202)", () => {
     expect(closedRadio.getAttribute("aria-checked")).toBe("false");
     expect(closedRadio.tabIndex).toBe(-1);
 
-    // ArrowRight on the active radio moves checked state and focus to the next.
+    // ArrowRight on the active radio moves checked state, tabindex, and focus to the next.
     act(() => {
       openRadio.focus();
       openRadio.dispatchEvent(new KeyboardEvent("keydown", { key: "ArrowRight", bubbles: true }));
@@ -1788,7 +1788,44 @@ describe("GitHubResourceList polish (#7202)", () => {
       const updated = group.querySelectorAll<HTMLButtonElement>('[role="radio"]');
       expect(updated[1]!.getAttribute("aria-checked")).toBe("true");
       expect(updated[0]!.getAttribute("aria-checked")).toBe("false");
+      expect(updated[1]!.tabIndex).toBe(0);
+      expect(updated[0]!.tabIndex).toBe(-1);
+      expect(document.activeElement).toBe(updated[1]);
     });
+  });
+
+  it("sort popover ArrowDown moves checked + focus to the next radio", async () => {
+    mockListIssues.mockResolvedValue(makeResponse([makeIssue(1)]));
+
+    render(<GitHubResourceList type="issue" projectPath="/test/proj" />);
+
+    const sortButton = await screen.findByRole("button", { name: /^sort/i });
+    act(() => {
+      sortButton.click();
+    });
+
+    const newest = await screen.findByRole("radio", { name: /newest/i });
+    expect(newest.getAttribute("aria-checked")).toBe("true");
+
+    act(() => {
+      newest.focus();
+      newest.dispatchEvent(new KeyboardEvent("keydown", { key: "ArrowDown", bubbles: true }));
+    });
+
+    await waitFor(() => {
+      const recent = screen.getByRole("radio", { name: /recently updated/i });
+      expect(recent.getAttribute("aria-checked")).toBe("true");
+      expect(document.activeElement).toBe(recent);
+    });
+  });
+
+  it("sort trigger has no accent dot on the default sort", async () => {
+    mockListIssues.mockResolvedValue(makeResponse([makeIssue(1)]));
+
+    render(<GitHubResourceList type="issue" projectPath="/test/proj" />);
+
+    const sortButton = await screen.findByRole("button", { name: /^sort/i });
+    expect(sortButton.querySelector("span.bg-status-info")).toBeNull();
   });
 
   it("sort popover trigger reflects open state via aria-expanded", async () => {


### PR DESCRIPTION
Six small a11y, visual-restraint, and microcopy fixes in `GitHubResourceList.tsx`. No redesign — release polish only.

## Changes

- **State filter radiogroup** — replaces `role="group"` + `aria-pressed` with `role="radiogroup"` + `role="radio"` + `aria-checked`, with arrow-key roving tabindex. This is what WAI-ARIA APG prescribes for one-of-N exclusive selection.
- **Listbox `aria-multiselectable`** — was unconditionally `true`; now tracks `selection.isSelectionActive` so it only advertises multi-select when the user has actually entered selection mode.
- **Sort popover trigger `aria-expanded`** — was missing entirely; now bound to `sortPopoverOpen`.
- **Refresh button `aria-label`** — was static; now mirrors the `title` attribute and flips between `Refresh issues` / `Refreshing…` based on `showSpinner`.
- **Sort-active double signal** — the filter icon was getting `text-status-info` tint alongside the dot. The dot is enough; tint removed.
- **Exact-number empty state** — searching `#42` while a state filter is active now reads `No issue #42 in this view` / `No PR #42 in this view` rather than the filter-ignorant `Issue #42 not found`.

**Bonus:** the sort popover radiogroup had the same missing roving tabindex as the state filter — fixed in the same pass. Sort trigger `aria-label` also now describes the active sort when non-default.

Resolves #7202

## Testing

- Updated unit tests in `GitHubResourceList.swr.test.tsx` cover all six items plus the bonus roving-tabindex behaviour.
- Ran `npm run check` — clean.