### PR TITLE
build(windows): switch to single APPX target for Microsoft Store distribution

### DIFF
--- a/.github/workflows/README.md
+++ b/.github/workflows/README.md
@@ -101,7 +101,7 @@ If you see "Tag version does not match package.json version":
 If builds fail with "Missing release/latest\*.yml":
 
 - Check electron-builder configuration in `package.json`
-- Ensure targets include both installers and update-friendly formats (zip for macOS, nsis for Windows)
+- Ensure targets include update-friendly formats (zip for macOS; APPX for Windows is distributed via Microsoft Store and does not use electron-updater)
 
 ### AWS CLI errors
 
@@ -136,7 +136,7 @@ This ensures users never see incomplete releases or transient 404s.
 
 ### Cache Headers
 
-- **Binaries** (`*.dmg`, `*.exe`, etc.): `public, max-age=31536000, immutable`
+- **Binaries** (`*.dmg`, `*.appx`, etc.): `public, max-age=31536000, immutable`
   - Cached for 1 year (versioned filenames)
 - **Metadata** (`latest*.yml`): `no-cache, no-store, must-revalidate`
   - Never cached (checked on every update check)

--- a/.github/workflows/nightly.yml
+++ b/.github/workflows/nightly.yml
@@ -330,7 +330,7 @@ jobs:
           path: |
             release/*.dmg
             release/*.zip
-            release/*.exe
+            release/*.appx
             release/*.AppImage
             release/*.deb
             release/*.blockmap

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -238,7 +238,7 @@ jobs:
           path: |
             release/*.dmg
             release/*.zip
-            release/*.exe
+            release/*.appx
             release/*.AppImage
             release/*.deb
             release/*.blockmap
@@ -301,7 +301,7 @@ jobs:
             --exclude "*" \
             --include "*.dmg" \
             --include "*.zip" \
-            --include "*.exe" \
+            --include "*.appx" \
             --include "*.AppImage" \
             --include "*.deb" \
             --include "*.blockmap" \
@@ -322,6 +322,41 @@ jobs:
             --exclude "*" \
             --include "${UPDATE_METADATA_PREFIX}*.yml" \
             --cache-control "no-cache, no-store, must-revalidate"
+
+      - name: Submit Windows package to Microsoft Store
+        shell: bash
+        env:
+          PARTNER_CENTER_TENANT_ID: ${{ secrets.PARTNER_CENTER_TENANT_ID }}
+          PARTNER_CENTER_SELLER_ID: ${{ secrets.PARTNER_CENTER_SELLER_ID }}
+          PARTNER_CENTER_CLIENT_ID: ${{ secrets.PARTNER_CENTER_CLIENT_ID }}
+          PARTNER_CENTER_CLIENT_SECRET: ${{ secrets.PARTNER_CENTER_CLIENT_SECRET }}
+          STORE_PRODUCT_ID: ${{ secrets.STORE_PRODUCT_ID }}
+        run: |
+          if [ -z "$PARTNER_CENTER_TENANT_ID" ] || \
+             [ -z "$PARTNER_CENTER_SELLER_ID" ] || \
+             [ -z "$PARTNER_CENTER_CLIENT_ID" ] || \
+             [ -z "$PARTNER_CENTER_CLIENT_SECRET" ] || \
+             [ -z "$STORE_PRODUCT_ID" ]; then
+            echo "::notice::Microsoft Store secrets not configured; skipping Store submission. The .appx is still archived to R2."
+            exit 0
+          fi
+          APPX_FILE=$(find release -maxdepth 1 -name '*.appx' | head -n 1)
+          if [ -z "$APPX_FILE" ]; then
+            echo "::error::No .appx file found in release/ — Windows build did not produce an APPX package."
+            exit 1
+          fi
+          # msstore CLI grammar may shift between preview releases. See
+          # docs/distribution/microsoft-store.md "msstore CLI subcommand
+          # grammar drift" for troubleshooting.
+          dotnet tool install --global Microsoft.WindowsStore.MSStoreCLI
+          export PATH="$PATH:$HOME/.dotnet/tools"
+          msstore reconfigure \
+            --tenantId "$PARTNER_CENTER_TENANT_ID" \
+            --sellerId "$PARTNER_CENTER_SELLER_ID" \
+            --clientId "$PARTNER_CENTER_CLIENT_ID" \
+            --clientSecret "$PARTNER_CENTER_CLIENT_SECRET"
+          msstore submission update "$STORE_PRODUCT_ID" "$APPX_FILE"
+          msstore submission publish "$STORE_PRODUCT_ID"
 
       - name: Notify website of new release
         shell: bash

--- a/electron-builder.config.cjs
+++ b/electron-builder.config.cjs
@@ -108,17 +108,20 @@ module.exports = async function () {
     },
     win: {
       icon: "build/icon.ico",
-      target: [
-        { target: "nsis", arch: ["x64"] },
-        { target: "portable", arch: ["x64"] },
-      ],
+      target: [{ target: "appx", arch: ["x64"] }],
     },
-    nsis: {
-      oneClick: false,
-      allowToChangeInstallationDirectory: true,
-      installerIcon: "build/icon.ico",
-      uninstallerIcon: "build/icon.ico",
-      installerHeaderIcon: "build/icon.ico",
+    // Identity values must match Partner Center → Daintree → Product Identity
+    // exactly. Until the Partner Center account is verified, these are
+    // placeholders — the release pipeline gracefully skips Store submission
+    // when the PARTNER_CENTER_* / STORE_PRODUCT_ID secrets are absent.
+    // See docs/distribution/microsoft-store.md for setup instructions.
+    appx: {
+      identityName: "<from-partner-center>",
+      publisher: "CN=<from-partner-center>",
+      publisherDisplayName: "Greg Priday",
+      applicationId: "Daintree",
+      displayName: "Daintree",
+      languages: ["en-US"],
     },
     linux: {
       icon: "build/icon.png",

--- a/electron-builder.config.cjs
+++ b/electron-builder.config.cjs
@@ -116,8 +116,13 @@ module.exports = async function () {
     // when the PARTNER_CENTER_* / STORE_PRODUCT_ID secrets are absent.
     // See docs/distribution/microsoft-store.md for setup instructions.
     appx: {
-      identityName: "<from-partner-center>",
-      publisher: "CN=<from-partner-center>",
+      // Placeholders pass electron-builder's AppxTarget regex
+      // (/^[a-zA-Z0-9.-]+$/ for identityName, "CN=…" for publisher) so the
+      // Windows build succeeds before Partner Center is wired up. Replace
+      // with the real Product Identity values from Partner Center before
+      // the first real Store submission. See docs/distribution/microsoft-store.md.
+      identityName: "Daintree.Placeholder",
+      publisher: "CN=Placeholder",
       publisherDisplayName: "Greg Priday",
       applicationId: "Daintree",
       displayName: "Daintree",

--- a/package.json
+++ b/package.json
@@ -26,7 +26,7 @@
     "build": "tsc && vite build && npm run build:main",
     "package": "npm run build && electron-builder",
     "package:mac": "npm run build && electron-builder --mac",
-    "package:win": "npm run build && electron-builder --win",
+    "package:win": "npm run build && electron-builder --win appx",
     "package:linux": "npm run build && electron-builder --linux",
     "package:local": "npm run build && electron-builder --mac --dir -c.mac.identity=null -c.mac.forceCodeSigning=false -c.mac.notarize=false",
     "package:local:dmg": "npm run build && electron-builder --mac dmg -c.mac.identity=null -c.mac.forceCodeSigning=false -c.mac.notarize=false",


### PR DESCRIPTION
## Summary

- Replaces the NSIS installer and portable `.exe` targets with a single `appx` target, routing Windows distribution through the Microsoft Store
- `electron-builder.config.cjs` gets `win.target = [{ target: "appx", arch: ["x64"] }]` with schema-valid identity placeholders; the `package:win` script in `package.json` simplifies to `--win appx`
- Release pipeline gracefully skips the Partner Center submission step when the five required secrets are absent — the `.appx` still archives to R2 alongside macOS and Linux artifacts

Resolves #7198

## Changes

- `electron-builder.config.cjs` — NSIS block removed; `appx` config block added with `identityName`, `publisher`, `publisherDisplayName`, `applicationId`, `displayName`, and `languages` placeholders that pass electron-builder's schema regex
- `package.json` — `package:win` simplified to `electron-builder --win appx`
- `.github/workflows/release.yml` — artifact and R2 globs updated from `*.exe` to `*.appx`; new gracefully-skipping Microsoft Store submission step added to `publish-daintree`
- `.github/workflows/nightly.yml` — stale `release/*.exe` glob updated to `release/*.appx`
- `.github/workflows/README.md` — NSIS/exe doc references refreshed

## Testing

- `afterPack.cjs` post-package validation is unchanged — APPX uses the same `resources/app.asar.unpacked` layout; all 26 `afterPack` tests pass
- The runbook at `docs/distribution/microsoft-store.md` covers Partner Center setup, the five required secrets, and the Store re-signing behaviour (Microsoft's re-sign removes both the SmartScreen warning and the Smart App Control hard-block)
- Note: existing users on the website-distributed `.exe` won't auto-migrate to the Store version — worth a release-notes callout when this ships, alongside removing the `.exe` link from the website