### PR TITLE
fix(toaster): polish notification toast a11y, focus, and ergonomics

### DIFF
--- a/src/components/Accessibility/AccessibilityAnnouncer.tsx
+++ b/src/components/Accessibility/AccessibilityAnnouncer.tsx
@@ -69,8 +69,8 @@ export function AccessibilityAnnouncer() {
 
   return (
     <>
-      <div ref={politeRef} className="sr-only" aria-live="polite" aria-atomic="false" />
-      <div ref={assertiveRef} className="sr-only" aria-live="assertive" aria-atomic="false" />
+      <div ref={politeRef} className="sr-only" aria-live="polite" aria-atomic="true" />
+      <div ref={assertiveRef} className="sr-only" aria-live="assertive" aria-atomic="true" />
     </>
   );
 }

--- a/src/components/Accessibility/__tests__/AccessibilityAnnouncer.test.tsx
+++ b/src/components/Accessibility/__tests__/AccessibilityAnnouncer.test.tsx
@@ -25,12 +25,12 @@ describe("AccessibilityAnnouncer", () => {
     expect(assertiveRegion).toBeTruthy();
   });
 
-  it("both regions have aria-atomic=false", () => {
+  it("both regions have aria-atomic=true", () => {
     const { container } = render(<AccessibilityAnnouncer />);
     const regions = container.querySelectorAll("[aria-atomic]");
     expect(regions.length).toBe(2);
     for (const region of regions) {
-      expect(region.getAttribute("aria-atomic")).toBe("false");
+      expect(region.getAttribute("aria-atomic")).toBe("true");
     }
   });
 

--- a/src/components/ui/__tests__/toaster.test.tsx
+++ b/src/components/ui/__tests__/toaster.test.tsx
@@ -1076,20 +1076,20 @@ describe("Toast severity-based dismissal (issue #5859)", () => {
     expect(screen.queryByText("Failed once")).toBeNull();
   });
 
-  it("success toast dismisses around the 4s severity default", async () => {
+  it("success toast dismisses around the 5s severity default", async () => {
     render(<Toaster />);
     await act(async () => {
       notify({ type: "success", message: "Saved!" });
       vi.advanceTimersByTime(16);
     });
 
-    // Just before 4s — still visible.
+    // Just before 5s — still visible.
     await act(async () => {
-      vi.advanceTimersByTime(3500);
+      vi.advanceTimersByTime(4500);
     });
     expect(screen.getByText("Saved!")).toBeTruthy();
 
-    // Past 4s + the exit fade — gone.
+    // Past 5s + the exit fade — gone.
     await act(async () => {
       vi.advanceTimersByTime(1000);
     });
@@ -1204,7 +1204,7 @@ describe("Toast overflow pill (issue #6424)", () => {
     });
     const pill = screen.getByTestId("toast-overflow-pill");
     expect(pill.textContent).toBe("+1 more");
-    expect(pill.getAttribute("aria-live")).toBe("polite");
+    expect(pill.getAttribute("aria-live")).toBeNull();
     expect(pill.getAttribute("aria-label")).toBe("1 more in notification center");
   });
 

--- a/src/components/ui/__tests__/toaster.test.tsx
+++ b/src/components/ui/__tests__/toaster.test.tsx
@@ -8,6 +8,7 @@ import { useNotificationSettingsStore } from "@/store/notificationSettingsStore"
 import { useAnnouncerStore } from "@/store/accessibilityAnnouncerStore";
 import { useUIStore } from "@/store/uiStore";
 import { notify } from "@/lib/notify";
+import { dispatchEscape, _resetForTests as resetEscapeStack } from "@/lib/escapeStack";
 import { Toaster } from "../toaster";
 
 const dispatchMock = vi.hoisted(() => vi.fn().mockResolvedValue({ ok: true }));
@@ -1443,5 +1444,181 @@ describe("Toast success dwell — 2000ms (issue #6844)", () => {
       vi.advanceTimersByTime(200);
     });
     expect(screen.queryByText("Quick action")).toBeNull();
+  });
+});
+
+describe("Toast a11y, focus, and ergonomics polish (issue #7238)", () => {
+  beforeEach(() => {
+    vi.useFakeTimers();
+    useNotificationStore.getState().reset();
+    useNotificationHistoryStore.setState({ entries: [], unreadCount: 0, evictedToInboxCount: 0 });
+    useAnnouncerStore.setState({ polite: null, assertive: null });
+    resetEscapeStack();
+  });
+
+  afterEach(() => {
+    vi.runOnlyPendingTimers();
+    vi.useRealTimers();
+    resetEscapeStack();
+    for (const el of fixtureElements) {
+      el.remove();
+    }
+    fixtureElements = [];
+  });
+
+  it("renders the portal container as a labeled landmark region", async () => {
+    render(<Toaster />);
+    await act(async () => {
+      addToast({ message: "Hello" });
+      vi.advanceTimersByTime(16);
+    });
+    const region = screen.getByRole("region", { name: /notifications/i });
+    expect(region).toBeTruthy();
+  });
+
+  it("Escape dismisses the topmost toast first (LIFO)", async () => {
+    render(<Toaster />);
+    await act(async () => {
+      addToast({ message: "first" });
+      vi.advanceTimersByTime(16);
+    });
+    await act(async () => {
+      addToast({ message: "second" });
+      vi.advanceTimersByTime(16);
+    });
+    await act(async () => {
+      addToast({ message: "third" });
+      vi.advanceTimersByTime(16);
+    });
+
+    expect(screen.getByText("third")).toBeTruthy();
+    expect(screen.getByText("second")).toBeTruthy();
+    expect(screen.getByText("first")).toBeTruthy();
+
+    // First Escape dismisses the newest (third).
+    await act(async () => {
+      dispatchEscape();
+      vi.advanceTimersByTime(300);
+    });
+    expect(screen.queryByText("third")).toBeNull();
+    expect(screen.getByText("second")).toBeTruthy();
+    expect(screen.getByText("first")).toBeTruthy();
+
+    // Second Escape dismisses second.
+    await act(async () => {
+      dispatchEscape();
+      vi.advanceTimersByTime(300);
+    });
+    expect(screen.queryByText("second")).toBeNull();
+    expect(screen.getByText("first")).toBeTruthy();
+
+    // Third Escape dismisses first.
+    await act(async () => {
+      dispatchEscape();
+      vi.advanceTimersByTime(300);
+    });
+    expect(screen.queryByText("first")).toBeNull();
+  });
+
+  it("mouseLeave grace does not unpause while focus stays inside the toast", async () => {
+    render(<Toaster />);
+    await act(async () => {
+      addToast({ duration: 1000, message: "stay" });
+      vi.advanceTimersByTime(16);
+    });
+
+    const toast = screen.getByRole("status");
+    // Hover, then keyboard-focus the dismiss button while still hovered.
+    fireEvent.mouseEnter(toast);
+    const closeBtn = screen.getByLabelText("Dismiss notification");
+    fireEvent.focus(closeBtn);
+    // Pointer leaves; grace timer starts.
+    fireEvent.mouseLeave(toast);
+    // Past the 500ms grace window, hover-pause clears but focus-pause holds.
+    await act(async () => {
+      vi.advanceTimersByTime(600);
+    });
+    // Past the toast's 1000ms duration; without focus-pause it would dismiss.
+    await act(async () => {
+      vi.advanceTimersByTime(1500);
+    });
+    expect(screen.getByText("stay")).toBeTruthy();
+  });
+
+  it("mouseLeave grace cancels when the cursor re-enters", async () => {
+    render(<Toaster />);
+    await act(async () => {
+      addToast({ duration: 600, message: "linger" });
+      vi.advanceTimersByTime(16);
+    });
+
+    const toast = screen.getByRole("status");
+    fireEvent.mouseEnter(toast);
+    fireEvent.mouseLeave(toast);
+    // Re-enter before the 500ms grace fires.
+    await act(async () => {
+      vi.advanceTimersByTime(300);
+    });
+    fireEvent.mouseEnter(toast);
+    // Now wait well past the original grace + dismiss; toast must persist.
+    await act(async () => {
+      vi.advanceTimersByTime(2000);
+    });
+    expect(screen.getByText("linger")).toBeTruthy();
+  });
+
+  it("restoreFocus skips focus when the previous element has been disconnected", async () => {
+    const external = createFixtureButton("external");
+    external.focus();
+    expect(document.activeElement).toBe(external);
+
+    render(<Toaster />);
+    await act(async () => {
+      addToast({ message: "with-focus" });
+      vi.advanceTimersByTime(16);
+    });
+
+    // Focus the toast's dismiss button so restoreFocus has somewhere to send focus from.
+    const closeBtn = screen.getByLabelText("Dismiss notification");
+    closeBtn.focus();
+    expect(document.activeElement).toBe(closeBtn);
+
+    // Detach the external button before dismissing.
+    external.remove();
+
+    // Trigger dismiss; restoreFocus must short-circuit on the disconnected node.
+    expect(() => {
+      fireEvent.click(closeBtn);
+    }).not.toThrow();
+
+    await act(async () => {
+      vi.advanceTimersByTime(500);
+    });
+    // Focus should not have landed back on the detached element.
+    expect(document.activeElement).not.toBe(external);
+  });
+
+  it("count-bump class clears via the 200ms timeout fallback when animationend never fires", async () => {
+    render(<Toaster />);
+    await act(async () => {
+      addToast({ title: "Updates", message: "ready", count: 1 });
+      vi.advanceTimersByTime(16);
+    });
+
+    // Advance the count — sets isCountBumping=true.
+    await act(async () => {
+      const id = useNotificationStore.getState().notifications[0]!.id;
+      useNotificationStore.getState().updateNotification(id, { count: 2 });
+      vi.advanceTimersByTime(16);
+    });
+    const chip = screen.getByLabelText(/2 events/i) as HTMLElement;
+    expect(chip.className).toContain("animate-badge-bump");
+
+    // Without firing onAnimationEnd, the 200ms safety fallback must clear it.
+    await act(async () => {
+      vi.advanceTimersByTime(250);
+    });
+    const chipAfter = screen.getByLabelText(/2 events/i) as HTMLElement;
+    expect(chipAfter.className).not.toContain("animate-badge-bump");
   });
 });

--- a/src/components/ui/toaster.tsx
+++ b/src/components/ui/toaster.tsx
@@ -68,7 +68,7 @@ const TYPE_ICON_CONFIG: Record<string, IconConfig> = {
 const MAX_VISIBLE_DURATION_MS = 15000;
 const VISIBLE_DURATION_MULTIPLIER = 3;
 
-function Toast({ notification }: { notification: Notification }) {
+function Toast({ notification, isTopmost }: { notification: Notification; isTopmost: boolean }) {
   const { dismissNotification, removeNotification } = useNotificationStore(
     useShallow((state) => ({
       dismissNotification: state.dismissNotification,
@@ -76,7 +76,14 @@ function Toast({ notification }: { notification: Notification }) {
     }))
   );
   const [isVisible, setIsVisible] = useState(false);
-  const [isPaused, setIsPaused] = useState(false);
+  // Track each pause source independently so the dismiss timer only resumes
+  // when *every* reason has cleared. Collapsing them into a single boolean
+  // races on mouseLeave: hover-grace would unpause while focus is still
+  // inside the toast or while the options dropdown is open.
+  const [isHovered, setIsHovered] = useState(false);
+  const [isFocusInside, setIsFocusInside] = useState(false);
+  const [isDropdownOpen, setIsDropdownOpen] = useState(false);
+  const isPaused = isHovered || isFocusInside || isDropdownOpen;
   const toastRef = useRef<HTMLDivElement>(null);
   const prevFocusRef = useRef<Element | null>(null);
 
@@ -177,11 +184,20 @@ function Toast({ notification }: { notification: Notification }) {
     }
   }, []);
 
+  // Ref-mirror of dismissed state so re-entrant calls within the same tick
+  // (e.g. two synchronous Escape dispatches before React flushes the store
+  // update) short-circuit before firing notification.onDismiss twice.
+  const dismissedRef = useRef(false);
+  useEffect(() => {
+    if (notification.dismissed) dismissedRef.current = true;
+  }, [notification.dismissed]);
+
   const handleDismiss = useCallback(() => {
     // If the notification is already dismissed, this click came in during the
     // exit fade after an eviction (or a double-click race). Skip the
     // user-dismiss callback so eviction/reentrancy don't fire onDismiss.
-    if (notification.dismissed) return;
+    if (dismissedRef.current || notification.dismissed) return;
+    dismissedRef.current = true;
     if (dwellTimerRef.current) {
       clearTimeout(dwellTimerRef.current);
       dwellTimerRef.current = null;
@@ -215,11 +231,12 @@ function Toast({ notification }: { notification: Notification }) {
     }
   }, [notification.dismissed, notification.id, isVisible, removeNotification, restoreFocus]);
 
-  // Escape dismisses the topmost active toast. Each Toast registers
-  // independently so multi-toast stacks pop LIFO — the most recent toast
-  // first. The stack defers to higher-priority overlays (open dialogs,
-  // command palette) automatically.
-  useEscapeStack(!notification.dismissed, handleDismiss);
+  // Escape dismisses the topmost active toast. Only the topmost toast (as
+  // determined by the parent Toaster) registers a handler so a single
+  // keypress dismisses one toast at a time, newest first. Open dialogs and
+  // the command palette take precedence via their own dialog-backstop path
+  // before the global escape stack is consulted.
+  useEscapeStack(isTopmost && !notification.dismissed, handleDismiss);
 
   // Latest-ref for handleDismiss so the auto-dismiss effect doesn't restart
   // every time the callback identity changes — the effect should restart only
@@ -286,22 +303,23 @@ function Toast({ notification }: { notification: Notification }) {
           clearTimeout(mouseLeaveTimerRef.current);
           mouseLeaveTimerRef.current = null;
         }
-        setIsPaused(true);
+        setIsHovered(true);
       }}
       onMouseLeave={() => {
         if (mouseLeaveTimerRef.current) clearTimeout(mouseLeaveTimerRef.current);
-        // 500ms grace before resuming the dismiss timer absorbs small jitter
-        // and brief crossings of inner chrome (Sonner default).
+        // 500ms grace before clearing the hover-pause absorbs small jitter
+        // and brief crossings of inner chrome (Sonner default). Focus and
+        // dropdown-open pauses are tracked separately and remain held.
         mouseLeaveTimerRef.current = setTimeout(() => {
           if (!mountedRef.current) return;
-          setIsPaused(false);
+          setIsHovered(false);
           mouseLeaveTimerRef.current = null;
         }, 500);
       }}
-      onFocus={() => setIsPaused(true)}
+      onFocus={() => setIsFocusInside(true)}
       onBlur={(e) => {
         if (!e.currentTarget.contains(e.relatedTarget as Node | null)) {
-          setIsPaused(false);
+          setIsFocusInside(false);
         }
       }}
       role={notification.type === "error" ? "alert" : "status"}
@@ -494,7 +512,7 @@ function Toast({ notification }: { notification: Notification }) {
         (() => {
           const eventKind = notification.context?.eventKind;
           return (
-            <DropdownMenu onOpenChange={(open) => setIsPaused(open)}>
+            <DropdownMenu onOpenChange={(open) => setIsDropdownOpen(open)}>
               <DropdownMenuTrigger asChild>
                 <button
                   type="button"
@@ -606,6 +624,13 @@ export function Toaster() {
 
   if (!mounted || (toastNotifications.length === 0 && evictedToInboxCount === 0)) return null;
 
+  // Newest renders first (top of the visual stack). Only the topmost active
+  // notification owns the Escape handler — the parent decides which one
+  // because mount order doesn't track active/dismissed state. As soon as the
+  // topmost dismisses, the next active notification picks up registration.
+  const renderOrder = [...toastNotifications].reverse();
+  const topmostActiveId = renderOrder.find((n) => !n.dismissed)?.id;
+
   return createPortal(
     <div
       role="region"
@@ -613,8 +638,12 @@ export function Toaster() {
       className="fixed top-14 z-[var(--z-toast)] flex flex-col gap-3 w-full max-w-[380px] pointer-events-none p-4"
       style={{ right: "calc(var(--right-obstruction-offset, 0px))" }}
     >
-      {[...toastNotifications].reverse().map((notification) => (
-        <Toast key={notification.id} notification={notification} />
+      {renderOrder.map((notification) => (
+        <Toast
+          key={notification.id}
+          notification={notification}
+          isTopmost={notification.id === topmostActiveId}
+        />
       ))}
       {evictedToInboxCount > 0 && <OverflowPill count={evictedToInboxCount} />}
     </div>,

--- a/src/components/ui/toaster.tsx
+++ b/src/components/ui/toaster.tsx
@@ -40,6 +40,7 @@ import {
 } from "@/components/ui/dropdown-menu";
 import { actionService } from "@/services/ActionService";
 import { EVENT_KIND_LABEL, isNotificationEventKind } from "@/lib/notify";
+import { useEscapeStack } from "@/hooks/useEscapeStack";
 
 const ACCENT_CLASS: Record<string, string> = {
   success: "border-l-status-success",
@@ -86,6 +87,13 @@ function Toast({ notification }: { notification: Notification }) {
   const dwellTimerRef = useRef<ReturnType<typeof setTimeout> | null>(null);
   const busyTimerRef = useRef<ReturnType<typeof setTimeout> | null>(null);
   const dismissTimerRef = useRef<ReturnType<typeof setTimeout> | null>(null);
+  // Safety fallback for the count-badge bump animation: when reduced-motion or
+  // performance mode forces `animation: none`, `animationend` never fires, so
+  // `isCountBumping` would latch true. Mirrors NotificationCenterToolbarButton.
+  const bumpFallbackRef = useRef<ReturnType<typeof setTimeout> | null>(null);
+  // Short grace before resuming the dismiss timer after the cursor leaves —
+  // prevents accidental dismissal on small jitter or briefly crossing chrome.
+  const mouseLeaveTimerRef = useRef<ReturnType<typeof setTimeout> | null>(null);
   const mountedRef = useRef(true);
 
   // While bursts of count-only updates arrive, set aria-busy on the live
@@ -108,6 +116,8 @@ function Toast({ notification }: { notification: Notification }) {
       if (dwellTimerRef.current) clearTimeout(dwellTimerRef.current);
       if (busyTimerRef.current) clearTimeout(busyTimerRef.current);
       if (dismissTimerRef.current) clearTimeout(dismissTimerRef.current);
+      if (bumpFallbackRef.current) clearTimeout(bumpFallbackRef.current);
+      if (mouseLeaveTimerRef.current) clearTimeout(mouseLeaveTimerRef.current);
     };
   }, []);
 
@@ -123,6 +133,16 @@ function Toast({ notification }: { notification: Notification }) {
       setIsCountBusy(false);
       busyTimerRef.current = null;
     }, DURATION_300);
+    // 150ms badge-bump animation + 50ms buffer. Under prefers-reduced-motion
+    // or data-reduce-animations, the CSS animation is suppressed and
+    // `animationend` never fires — without this fallback, isCountBumping
+    // would latch true and stale-class on the next chip remount.
+    if (bumpFallbackRef.current) clearTimeout(bumpFallbackRef.current);
+    bumpFallbackRef.current = setTimeout(() => {
+      if (!mountedRef.current) return;
+      setIsCountBumping(false);
+      bumpFallbackRef.current = null;
+    }, 200);
   }, [notification.count]);
 
   useLayoutEffect(() => {
@@ -149,7 +169,11 @@ function Toast({ notification }: { notification: Notification }) {
   const restoreFocus = useCallback(() => {
     if (toastRef.current?.contains(document.activeElement)) {
       const prev = prevFocusRef.current;
-      if (prev instanceof HTMLElement) prev.focus();
+      // Guard against the previously-focused element having been unmounted
+      // (e.g. its panel was torn down while the toast was active). Calling
+      // .focus() on a detached node is a silent no-op, so focus would land
+      // on body — explicit guard keeps intent obvious.
+      if (prev instanceof HTMLElement && prev.isConnected) prev.focus();
     }
   }, []);
 
@@ -190,6 +214,12 @@ function Toast({ notification }: { notification: Notification }) {
       setTimeout(() => removeNotification(notification.id), getUiTransitionDuration("exit"));
     }
   }, [notification.dismissed, notification.id, isVisible, removeNotification, restoreFocus]);
+
+  // Escape dismisses the topmost active toast. Each Toast registers
+  // independently so multi-toast stacks pop LIFO — the most recent toast
+  // first. The stack defers to higher-priority overlays (open dialogs,
+  // command palette) automatically.
+  useEscapeStack(!notification.dismissed, handleDismiss);
 
   // Latest-ref for handleDismiss so the auto-dismiss effect doesn't restart
   // every time the callback identity changes — the effect should restart only
@@ -251,8 +281,23 @@ function Toast({ notification }: { notification: Notification }) {
         transitionDuration: `${isVisible ? UI_ENTER_DURATION : UI_EXIT_DURATION}ms`,
         transitionTimingFunction: isVisible ? UI_ENTER_EASING : UI_EXIT_EASING,
       }}
-      onMouseEnter={() => setIsPaused(true)}
-      onMouseLeave={() => setIsPaused(false)}
+      onMouseEnter={() => {
+        if (mouseLeaveTimerRef.current) {
+          clearTimeout(mouseLeaveTimerRef.current);
+          mouseLeaveTimerRef.current = null;
+        }
+        setIsPaused(true);
+      }}
+      onMouseLeave={() => {
+        if (mouseLeaveTimerRef.current) clearTimeout(mouseLeaveTimerRef.current);
+        // 500ms grace before resuming the dismiss timer absorbs small jitter
+        // and brief crossings of inner chrome (Sonner default).
+        mouseLeaveTimerRef.current = setTimeout(() => {
+          if (!mountedRef.current) return;
+          setIsPaused(false);
+          mouseLeaveTimerRef.current = null;
+        }, 500);
+      }}
       onFocus={() => setIsPaused(true)}
       onBlur={(e) => {
         if (!e.currentTarget.contains(e.relatedTarget as Node | null)) {
@@ -527,7 +572,6 @@ function OverflowPill({ count }: { count: number }) {
     <button
       type="button"
       onClick={openNotificationCenter}
-      aria-live="polite"
       aria-label={label}
       data-testid="toast-overflow-pill"
       className={cn(
@@ -564,6 +608,8 @@ export function Toaster() {
 
   return createPortal(
     <div
+      role="region"
+      aria-label="Notifications"
       className="fixed top-14 z-[var(--z-toast)] flex flex-col gap-3 w-full max-w-[380px] pointer-events-none p-4"
       style={{ right: "calc(var(--right-obstruction-offset, 0px))" }}
     >

--- a/src/lib/__tests__/notify.test.ts
+++ b/src/lib/__tests__/notify.test.ts
@@ -681,11 +681,11 @@ describe("notify()", () => {
       expect(notification!.duration).toBe(TOAST_DURATION.warning);
     });
 
-    it("applies a 4s default for success notifications", () => {
+    it("applies a 5s default for success notifications", () => {
       vi.spyOn(document, "hasFocus").mockReturnValue(true);
       notify({ type: "success", message: "Saved" });
       const notification = useNotificationStore.getState().notifications[0];
-      expect(notification!.duration).toBe(4000);
+      expect(notification!.duration).toBe(5000);
       expect(notification!.duration).toBe(TOAST_DURATION.success);
     });
 

--- a/src/lib/notify.ts
+++ b/src/lib/notify.ts
@@ -42,12 +42,13 @@ export function isNotificationEventKind(v: string | undefined): v is Notificatio
  * Default auto-dismiss durations (ms) by notification type.
  *
  * Errors and warnings get a generous 12s so the user has time to read them;
- * success dismisses in 4s (two-word confirmations need no more). Info gets
- * 8s to match the Atlassian accessibility minimum for sentence-length
- * content. When a toast fires, the persistent inbox is the WCAG 2.2.1 conforming
- * alternative — users who miss a toast can always recover it from the
- * notification center. When no toast is shown (priority "low"), the inbox is the
- * primary channel and carries no compliance load.
+ * success dismisses in 5s — Adobe Spectrum's accessibility minimum, leaving
+ * room for short-sentence copy without rushing slow readers. Info gets 8s to
+ * match the Atlassian accessibility minimum for sentence-length content. When
+ * a toast fires, the persistent inbox is the WCAG 2.2.1 conforming alternative
+ * — users who miss a toast can always recover it from the notification center.
+ * When no toast is shown (priority "low"), the inbox is the primary channel and
+ * carries no compliance load.
  *
  * Action-bearing toasts override this to `0` (sticky) so the action remains
  * available; explicit `duration` on the payload always wins.
@@ -55,7 +56,7 @@ export function isNotificationEventKind(v: string | undefined): v is Notificatio
 export const TOAST_DURATION: Record<NotificationType, number> = {
   error: 12000,
   warning: 12000,
-  success: 4000,
+  success: 5000,
   info: 8000,
 };
 


### PR DESCRIPTION
## Summary

- Adds a `role="region"` landmark around the toast portal so screen reader users can navigate directly to notifications; fixes `aria-atomic` on `AccessibilityAnnouncer` (both polite and assertive regions now use `aria-atomic="true"`)
- Splits pause sources into discrete `isHovered`, `isFocusInside`, and `isDropdownOpen` booleans so no single source can accidentally unpause while another is still active; adds a 500ms `mouseLeave` grace period before the dismiss timer resumes, cancelled on re-enter
- Adds Escape-to-dismiss via `useEscapeStack` with LIFO ordering (only the topmost active toast registers), guards `restoreFocus` against disconnected DOM nodes, bumps `TOAST_DURATION.success` from 4 000ms to 5 000ms to meet the Adobe Spectrum minimum, and adds a 200ms `setTimeout` fallback for the count-bump animation so it doesn't latch under `prefers-reduced-motion`

Resolves #7238

## Changes

- `src/components/Accessibility/AccessibilityAnnouncer.tsx`: `aria-atomic="false"` → `"true"` on both live regions
- `src/lib/notify.ts`: `TOAST_DURATION.success` 4 000ms → 5 000ms
- `src/components/ui/toaster.tsx`:
  - `Toaster` portal: `role="region" aria-label="Notifications"` landmark
  - `OverflowPill`: removed redundant `aria-live="polite"` (button is already tab-reachable)
  - `ToastItem`: Escape-to-dismiss via `useEscapeStack`, topmost-only registration, LIFO pop order
  - `restoreFocus`: `prev.isConnected` guard before focusing
  - Count-badge animation: 200ms `setTimeout` safety fallback so `isCountBumping` doesn't latch
  - `mouseLeave`: 500ms grace before resuming dismiss timer, cancelled on pointer re-enter
  - Pause sources split into `isHovered` / `isFocusInside` / `isDropdownOpen`
  - `dismissedRef` synchronously short-circuits re-entrant `handleDismiss` calls

## Testing

Six new tests added to `src/components/ui/__tests__/toaster.test.tsx` covering: landmark region presence, Escape LIFO ordering, `mouseLeave` grace respecting an active focus-pause, `mouseLeave` grace cancelling on re-enter, `restoreFocus` disconnected-node guard, and the count-bump 200ms animation fallback. All 244 tests passing.