### PR TITLE
fix(diagnostics): polish dock keyboard, ARIA, and resize behavior

### DIFF
--- a/src/components/Diagnostics/DiagnosticsDock.tsx
+++ b/src/components/Diagnostics/DiagnosticsDock.tsx
@@ -23,6 +23,8 @@ import type { RetryAction } from "@/store";
 import { appClient } from "@/clients";
 import { logError } from "@/utils/logger";
 
+export const DIAGNOSTICS_DOCK_REGION_ID = "diagnostics-dock-region";
+
 interface TabButtonProps {
   tab: DiagnosticsTab;
   label: string;
@@ -41,7 +43,9 @@ const TabButton = memo(function TabButton({
   return (
     <button
       id={`diagnostics-${tab}-tab`}
+      data-tab={tab}
       onClick={onClick}
+      tabIndex={isActive ? 0 : -1}
       className={cn(
         "px-3 py-1.5 text-sm font-medium transition-colors relative rounded",
         "hover:text-daintree-text hover:bg-overlay-soft",
@@ -69,9 +73,21 @@ interface DiagnosticsDockProps {
   className?: string;
 }
 
+const RESIZE_STEP = 10;
+const RESIZE_STEP_LARGE = 50;
+
 export function DiagnosticsDock({ onRetry, onCancelRetry, className }: DiagnosticsDockProps) {
-  const { isOpen, activeTab, height, openDock, closeDock, setActiveTab, setHeight } =
-    useDiagnosticsStore();
+  const {
+    isOpen,
+    activeTab,
+    height,
+    maxHeight,
+    openDock,
+    closeDock,
+    setActiveTab,
+    setHeight,
+    setMaxHeight,
+  } = useDiagnosticsStore();
   const errorCount = useErrorStore((state) => state.errors.filter((e) => !e.dismissed).length);
   const prevErrorCountRef = useRef(0);
 
@@ -85,8 +101,8 @@ export function DiagnosticsDock({ onRetry, onCancelRetry, className }: Diagnosti
   const [isResizing, setIsResizing] = useState(false);
   const resizeStartY = useRef(0);
   const resizeStartHeight = useRef(0);
-
-  const RESIZE_STEP = 10;
+  const outerRef = useRef<HTMLDivElement>(null);
+  const tablistRef = useRef<HTMLDivElement>(null);
 
   const handleResizeStart = useCallback(
     (e: React.MouseEvent) => {
@@ -100,18 +116,74 @@ export function DiagnosticsDock({ onRetry, onCancelRetry, className }: Diagnosti
 
   const handleKeyDown = useCallback(
     (e: React.KeyboardEvent) => {
-      if (e.key === "ArrowUp") {
-        e.preventDefault();
-        const maxHeight = window.innerHeight * DIAGNOSTICS_MAX_HEIGHT_RATIO;
-        const newHeight = Math.min(height + RESIZE_STEP, maxHeight);
-        setHeight(newHeight);
-      } else if (e.key === "ArrowDown") {
-        e.preventDefault();
-        const newHeight = Math.max(height - RESIZE_STEP, DIAGNOSTICS_MIN_HEIGHT);
-        setHeight(newHeight);
+      const step = e.shiftKey ? RESIZE_STEP_LARGE : RESIZE_STEP;
+      switch (e.key) {
+        case "ArrowUp":
+          e.preventDefault();
+          setHeight(height + step);
+          break;
+        case "ArrowDown":
+          e.preventDefault();
+          setHeight(height - step);
+          break;
+        case "PageUp":
+          e.preventDefault();
+          setHeight(height + RESIZE_STEP_LARGE);
+          break;
+        case "PageDown":
+          e.preventDefault();
+          setHeight(height - RESIZE_STEP_LARGE);
+          break;
+        case "Home":
+          e.preventDefault();
+          setHeight(DIAGNOSTICS_MIN_HEIGHT);
+          break;
+        case "End":
+          e.preventDefault();
+          setHeight(maxHeight);
+          break;
+        default:
+          return;
       }
     },
-    [height, setHeight]
+    [height, maxHeight, setHeight]
+  );
+
+  const handleTablistKeyDown = useCallback(
+    (e: React.KeyboardEvent<HTMLDivElement>) => {
+      const container = tablistRef.current;
+      if (!container) return;
+
+      const tabButtons = Array.from(container.querySelectorAll<HTMLButtonElement>('[role="tab"]'));
+      const focusedIndex = tabButtons.indexOf(document.activeElement as HTMLButtonElement);
+      if (focusedIndex === -1) return;
+
+      let nextIndex: number | null = null;
+      switch (e.key) {
+        case "ArrowRight":
+          nextIndex = (focusedIndex + 1) % tabButtons.length;
+          break;
+        case "ArrowLeft":
+          nextIndex = (focusedIndex - 1 + tabButtons.length) % tabButtons.length;
+          break;
+        case "Home":
+          nextIndex = 0;
+          break;
+        case "End":
+          nextIndex = tabButtons.length - 1;
+          break;
+        default:
+          return;
+      }
+
+      e.preventDefault();
+      const nextTab = tabButtons[nextIndex];
+      if (!nextTab) return;
+      nextTab.focus();
+      const tabId = nextTab.dataset.tab as DiagnosticsTab | undefined;
+      if (tabId) setActiveTab(tabId);
+    },
+    [setActiveTab]
   );
 
   useEffect(() => {
@@ -120,9 +192,7 @@ export function DiagnosticsDock({ onRetry, onCancelRetry, className }: Diagnosti
     const handleMouseMove = (e: MouseEvent) => {
       const deltaY = resizeStartY.current - e.clientY;
       const newHeight = resizeStartHeight.current + deltaY;
-      const maxHeight = window.innerHeight * DIAGNOSTICS_MAX_HEIGHT_RATIO;
-      const clampedHeight = Math.min(Math.max(newHeight, DIAGNOSTICS_MIN_HEIGHT), maxHeight);
-      setHeight(clampedHeight);
+      setHeight(newHeight);
     };
 
     const handleMouseUp = () => {
@@ -137,6 +207,36 @@ export function DiagnosticsDock({ onRetry, onCancelRetry, className }: Diagnosti
       document.removeEventListener("mouseup", handleMouseUp);
     };
   }, [isResizing, setHeight]);
+
+  // Track the available container height so aria-valuemax and the in-store
+  // clamp stay accurate when the viewport or sidebars resize. Observe the
+  // dock's parent (a flex column whose height is bounded by the viewport,
+  // not by our own height) to avoid Chromium's ResizeObserver loop guard.
+  useEffect(() => {
+    if (!isOpen) return;
+    const node = outerRef.current;
+    const parent = node?.parentElement;
+    if (!parent) return;
+
+    const apply = (containerHeight: number) => {
+      const next = Math.max(
+        Math.floor(containerHeight * DIAGNOSTICS_MAX_HEIGHT_RATIO),
+        DIAGNOSTICS_MIN_HEIGHT
+      );
+      setMaxHeight(next);
+    };
+
+    apply(parent.getBoundingClientRect().height);
+
+    const observer = new ResizeObserver((entries) => {
+      const entry = entries[0];
+      if (!entry) return;
+      const blockSize = entry.contentBoxSize?.[0]?.blockSize ?? entry.contentRect.height;
+      apply(blockSize);
+    });
+    observer.observe(parent);
+    return () => observer.disconnect();
+  }, [isOpen, setMaxHeight]);
 
   useEffect(() => {
     if (!isResizing && isOpen) {
@@ -177,13 +277,15 @@ export function DiagnosticsDock({ onRetry, onCancelRetry, className }: Diagnosti
 
   return (
     <div
+      ref={outerRef}
+      id={DIAGNOSTICS_DOCK_REGION_ID}
       className={cn(
-        "flex flex-col border-t border-[var(--dock-border)] bg-[var(--dock-bg)]/95 backdrop-blur-sm shadow-[var(--dock-shadow)]",
-        "transition-[height] duration-200 ease-out",
+        "diagnostics-dock flex flex-col border-t border-[var(--dock-border)] bg-[var(--dock-bg)]/95 backdrop-blur-sm shadow-[var(--dock-shadow)]",
         isResizing && "select-none",
         className
       )}
       style={{ height }}
+      data-resizing={isResizing ? "true" : undefined}
       role="region"
       aria-label="Diagnostics dock"
     >
@@ -200,7 +302,7 @@ export function DiagnosticsDock({ onRetry, onCancelRetry, className }: Diagnosti
         aria-label="Resize diagnostics dock"
         aria-valuenow={Math.round(height)}
         aria-valuemin={DIAGNOSTICS_MIN_HEIGHT}
-        aria-valuemax={Math.round(window.innerHeight * DIAGNOSTICS_MAX_HEIGHT_RATIO)}
+        aria-valuemax={Math.round(maxHeight)}
         tabIndex={0}
       >
         <div
@@ -214,7 +316,13 @@ export function DiagnosticsDock({ onRetry, onCancelRetry, className }: Diagnosti
       </div>
 
       <div className="flex items-center justify-between px-4 h-10 border-b border-[var(--dock-border)] bg-daintree-sidebar/50 shrink-0">
-        <div className="flex items-center gap-2" role="tablist" aria-label="Diagnostics tabs">
+        <div
+          ref={tablistRef}
+          className="flex items-center gap-2"
+          role="tablist"
+          aria-label="Diagnostics tabs"
+          onKeyDown={handleTablistKeyDown}
+        >
           {tabs.map((tab) => (
             <TabButton
               key={tab.id}

--- a/src/components/Diagnostics/__tests__/DiagnosticsDock.test.tsx
+++ b/src/components/Diagnostics/__tests__/DiagnosticsDock.test.tsx
@@ -1,0 +1,232 @@
+// @vitest-environment jsdom
+import { describe, it, expect, beforeEach, vi } from "vitest";
+import { render, act, fireEvent } from "@testing-library/react";
+import { DiagnosticsDock, DIAGNOSTICS_DOCK_REGION_ID } from "../DiagnosticsDock";
+import { useDiagnosticsStore, DIAGNOSTICS_MIN_HEIGHT } from "@/store/diagnosticsStore";
+import { useErrorStore } from "@/store";
+
+vi.mock("@/components/ui/tooltip", () => ({
+  Tooltip: ({ children }: { children: React.ReactNode }) => <>{children}</>,
+  TooltipContent: () => null,
+  TooltipProvider: ({ children }: { children: React.ReactNode }) => <>{children}</>,
+  TooltipTrigger: ({ children }: { children: React.ReactNode }) => <>{children}</>,
+}));
+
+vi.mock("../ProblemsContent", () => ({
+  ProblemsContent: () => <div data-testid="problems-content" />,
+}));
+vi.mock("../LogsContent", () => ({
+  LogsContent: () => <div data-testid="logs-content" />,
+}));
+vi.mock("../EventsContent", () => ({
+  EventsContent: () => <div data-testid="events-content" />,
+}));
+vi.mock("../TelemetryContent", () => ({
+  TelemetryContent: () => <div data-testid="telemetry-content" />,
+}));
+vi.mock("../DiagnosticsActions", () => ({
+  ProblemsActions: () => null,
+  LogsActions: () => null,
+  EventsActions: () => null,
+  TelemetryActions: () => null,
+}));
+
+vi.mock("@/clients", async (importOriginal) => {
+  const actual = (await importOriginal()) as Record<string, unknown>;
+  return {
+    ...actual,
+    appClient: {
+      setState: vi.fn().mockResolvedValue(undefined),
+      getState: vi.fn().mockResolvedValue({}),
+    },
+  };
+});
+
+vi.mock("@/utils/logger", () => ({
+  logError: vi.fn(),
+}));
+
+vi.stubGlobal(
+  "ResizeObserver",
+  class {
+    observe() {}
+    unobserve() {}
+    disconnect() {}
+  }
+);
+
+function resetStores() {
+  useDiagnosticsStore.setState({
+    isOpen: true,
+    activeTab: "problems",
+    height: 256,
+    maxHeight: 600,
+  });
+  useErrorStore.setState({ errors: [] });
+}
+
+describe("DiagnosticsDock — region id and aria wiring", () => {
+  beforeEach(() => {
+    resetStores();
+  });
+
+  it("renders the outer region with the shared id constant", () => {
+    const { container } = render(<DiagnosticsDock />);
+    const region = container.querySelector(`#${DIAGNOSTICS_DOCK_REGION_ID}`);
+    expect(region).not.toBeNull();
+    expect(region?.getAttribute("role")).toBe("region");
+  });
+
+  it("uses the named diagnostics-dock class for transition control", () => {
+    const { container } = render(<DiagnosticsDock />);
+    const region = container.querySelector(`#${DIAGNOSTICS_DOCK_REGION_ID}`);
+    expect(region?.className).toContain("diagnostics-dock");
+    expect(region?.getAttribute("data-resizing")).toBeNull();
+  });
+
+  it("derives aria-valuemax from the store maxHeight, not window.innerHeight", () => {
+    const { container } = render(<DiagnosticsDock />);
+    act(() => {
+      useDiagnosticsStore.setState({ maxHeight: 480 });
+    });
+    const separator = container.querySelector('[role="separator"]');
+    expect(separator?.getAttribute("aria-valuemax")).toBe("480");
+  });
+});
+
+describe("DiagnosticsDock — roving tabindex on the tab strip", () => {
+  beforeEach(() => {
+    resetStores();
+  });
+
+  it("gives only the active tab tabIndex=0", () => {
+    const { container } = render(<DiagnosticsDock />);
+    const tabs = container.querySelectorAll('[role="tab"]');
+    expect(tabs.length).toBe(4);
+    const active = container.querySelector('[role="tab"][aria-selected="true"]');
+    expect(active?.getAttribute("tabindex")).toBe("0");
+    container.querySelectorAll('[role="tab"][aria-selected="false"]').forEach((el) => {
+      expect(el.getAttribute("tabindex")).toBe("-1");
+    });
+  });
+
+  it("ArrowRight moves focus and activates the next tab", () => {
+    const { container } = render(<DiagnosticsDock />);
+    const tablist = container.querySelector('[role="tablist"]') as HTMLDivElement;
+    const tabs = Array.from(tablist.querySelectorAll<HTMLButtonElement>('[role="tab"]'));
+    tabs[0]!.focus();
+    fireEvent.keyDown(tablist, { key: "ArrowRight" });
+    expect(useDiagnosticsStore.getState().activeTab).toBe("logs");
+    expect(document.activeElement).toBe(tabs[1]);
+  });
+
+  it("ArrowLeft from the first tab wraps to the last", () => {
+    const { container } = render(<DiagnosticsDock />);
+    const tablist = container.querySelector('[role="tablist"]') as HTMLDivElement;
+    const tabs = Array.from(tablist.querySelectorAll<HTMLButtonElement>('[role="tab"]'));
+    tabs[0]!.focus();
+    fireEvent.keyDown(tablist, { key: "ArrowLeft" });
+    expect(useDiagnosticsStore.getState().activeTab).toBe("telemetry");
+    expect(document.activeElement).toBe(tabs[tabs.length - 1]);
+  });
+
+  it("Home jumps to the first tab and End jumps to the last", () => {
+    useDiagnosticsStore.setState({ activeTab: "events" });
+    const { container } = render(<DiagnosticsDock />);
+    const tablist = container.querySelector('[role="tablist"]') as HTMLDivElement;
+    const tabs = Array.from(tablist.querySelectorAll<HTMLButtonElement>('[role="tab"]'));
+    const eventsTab = tabs.find((t) => t.dataset.tab === "events")!;
+    eventsTab.focus();
+
+    fireEvent.keyDown(tablist, { key: "Home" });
+    expect(useDiagnosticsStore.getState().activeTab).toBe("problems");
+
+    tabs.find((t) => t.dataset.tab === "problems")!.focus();
+    fireEvent.keyDown(tablist, { key: "End" });
+    expect(useDiagnosticsStore.getState().activeTab).toBe("telemetry");
+  });
+});
+
+describe("DiagnosticsDock — separator keyboard resize", () => {
+  beforeEach(() => {
+    resetStores();
+  });
+
+  // The ResizeObserver effect runs once on mount and seeds maxHeight from the
+  // parent's bounding rect — which is 0 in jsdom. Set the harness state after
+  // render to bypass that initial seed.
+  function renderWith(height: number, maxHeight: number) {
+    const result = render(<DiagnosticsDock />);
+    act(() => {
+      useDiagnosticsStore.setState({ height, maxHeight });
+    });
+    return result;
+  }
+
+  it("ArrowUp grows by 10px, ArrowDown shrinks by 10px", () => {
+    const { container } = renderWith(300, 600);
+    const separator = container.querySelector('[role="separator"]') as HTMLDivElement;
+    fireEvent.keyDown(separator, { key: "ArrowUp" });
+    expect(useDiagnosticsStore.getState().height).toBe(310);
+    fireEvent.keyDown(separator, { key: "ArrowDown" });
+    expect(useDiagnosticsStore.getState().height).toBe(300);
+  });
+
+  it("Shift+ArrowUp / Shift+ArrowDown step by 50px", () => {
+    const { container } = renderWith(300, 600);
+    const separator = container.querySelector('[role="separator"]') as HTMLDivElement;
+    fireEvent.keyDown(separator, { key: "ArrowUp", shiftKey: true });
+    expect(useDiagnosticsStore.getState().height).toBe(350);
+    fireEvent.keyDown(separator, { key: "ArrowDown", shiftKey: true });
+    expect(useDiagnosticsStore.getState().height).toBe(300);
+  });
+
+  it("PageUp / PageDown step by 50px", () => {
+    const { container } = renderWith(300, 600);
+    const separator = container.querySelector('[role="separator"]') as HTMLDivElement;
+    fireEvent.keyDown(separator, { key: "PageUp" });
+    expect(useDiagnosticsStore.getState().height).toBe(350);
+    fireEvent.keyDown(separator, { key: "PageDown" });
+    expect(useDiagnosticsStore.getState().height).toBe(300);
+  });
+
+  it("Home jumps to DIAGNOSTICS_MIN_HEIGHT, End jumps to maxHeight", () => {
+    const { container } = renderWith(300, 480);
+    const separator = container.querySelector('[role="separator"]') as HTMLDivElement;
+    fireEvent.keyDown(separator, { key: "Home" });
+    expect(useDiagnosticsStore.getState().height).toBe(DIAGNOSTICS_MIN_HEIGHT);
+    fireEvent.keyDown(separator, { key: "End" });
+    expect(useDiagnosticsStore.getState().height).toBe(480);
+  });
+
+  it("respects clamp ceiling when growing past the cap", () => {
+    const { container } = renderWith(470, 480);
+    const separator = container.querySelector('[role="separator"]') as HTMLDivElement;
+    fireEvent.keyDown(separator, { key: "PageUp" });
+    expect(useDiagnosticsStore.getState().height).toBe(480);
+  });
+});
+
+describe("DiagnosticsDock — resize lag suppression", () => {
+  beforeEach(() => {
+    resetStores();
+  });
+
+  it("flips data-resizing on mousedown and clears it on mouseup", () => {
+    const { container } = render(<DiagnosticsDock />);
+    const region = container.querySelector(`#${DIAGNOSTICS_DOCK_REGION_ID}`) as HTMLDivElement;
+    const separator = container.querySelector('[role="separator"]') as HTMLDivElement;
+
+    expect(region.getAttribute("data-resizing")).toBeNull();
+
+    act(() => {
+      fireEvent.mouseDown(separator, { clientY: 100 });
+    });
+    expect(region.getAttribute("data-resizing")).toBe("true");
+
+    act(() => {
+      fireEvent(document, new MouseEvent("mouseup", { bubbles: true }));
+    });
+    expect(region.getAttribute("data-resizing")).toBeNull();
+  });
+});

--- a/src/components/Layout/ToolbarProblemsButton.tsx
+++ b/src/components/Layout/ToolbarProblemsButton.tsx
@@ -6,6 +6,8 @@ import { Tooltip, TooltipContent, TooltipTrigger } from "@/components/ui/tooltip
 import { ShortcutRevealChip } from "@/components/ui/ShortcutRevealChip";
 import { createTooltipContent } from "@/lib/tooltipShortcut";
 import { useAriaKeyshortcuts, useKeybindingDisplay, useShortcutHintHover } from "@/hooks";
+import { useDiagnosticsStore } from "@/store/diagnosticsStore";
+import { DIAGNOSTICS_DOCK_REGION_ID } from "@/components/Diagnostics/DiagnosticsDock";
 
 const toolbarIconButtonClass = "toolbar-icon-button text-daintree-text";
 
@@ -23,6 +25,7 @@ export const ToolbarProblemsButton = memo(function ToolbarProblemsButton({
   const diagnosticsShortcut = useKeybindingDisplay("panel.toggleDiagnostics");
   const diagnosticsAriaShortcut = useAriaKeyshortcuts("panel.toggleDiagnostics");
   const diagnosticsHover = useShortcutHintHover("panel.toggleDiagnostics");
+  const isDockOpen = useDiagnosticsStore((state) => state.isOpen);
 
   return (
     <Tooltip>
@@ -36,6 +39,8 @@ export const ToolbarProblemsButton = memo(function ToolbarProblemsButton({
           className={cn(toolbarIconButtonClass, "relative", errorCount > 0 && "text-status-error")}
           aria-label={`Problems: ${errorCount} error${errorCount !== 1 ? "s" : ""}`}
           aria-keyshortcuts={diagnosticsAriaShortcut}
+          aria-expanded={isDockOpen}
+          aria-controls={DIAGNOSTICS_DOCK_REGION_ID}
         >
           <AlertCircle />
           <span

--- a/src/components/Layout/__tests__/ToolbarProblemsButton.test.tsx
+++ b/src/components/Layout/__tests__/ToolbarProblemsButton.test.tsx
@@ -1,0 +1,66 @@
+// @vitest-environment jsdom
+import { describe, it, expect, beforeEach, vi } from "vitest";
+import { render, act } from "@testing-library/react";
+import { ToolbarProblemsButton } from "../ToolbarProblemsButton";
+import { useDiagnosticsStore } from "@/store/diagnosticsStore";
+
+vi.mock("@/components/ui/tooltip", () => ({
+  Tooltip: ({ children }: { children: React.ReactNode }) => <>{children}</>,
+  TooltipContent: () => null,
+  TooltipProvider: ({ children }: { children: React.ReactNode }) => <>{children}</>,
+  TooltipTrigger: ({ children }: { children: React.ReactNode }) => <>{children}</>,
+}));
+
+vi.mock("@/components/ui/button", () => ({
+  Button: ({
+    children,
+    ...rest
+  }: { children: React.ReactNode } & React.ButtonHTMLAttributes<HTMLButtonElement>) => (
+    <button {...rest}>{children}</button>
+  ),
+}));
+
+vi.mock("@/components/ui/ShortcutRevealChip", () => ({
+  ShortcutRevealChip: () => null,
+}));
+
+vi.mock("lucide-react", () => ({
+  AlertCircle: () => <span data-testid="icon-alert" />,
+}));
+
+vi.mock("@/hooks", () => ({
+  useAriaKeyshortcuts: () => "",
+  useKeybindingDisplay: () => "",
+  useShortcutHintHover: () => ({}),
+}));
+
+vi.mock("@/lib/tooltipShortcut", () => ({
+  createTooltipContent: () => null,
+}));
+
+describe("ToolbarProblemsButton — aria-expanded / aria-controls", () => {
+  beforeEach(() => {
+    useDiagnosticsStore.setState({ isOpen: false });
+  });
+
+  it("exposes aria-expanded=false and aria-controls when the dock is closed", () => {
+    const { container } = render(<ToolbarProblemsButton errorCount={0} />);
+    const button = container.querySelector("button");
+    expect(button).not.toBeNull();
+    expect(button?.getAttribute("aria-expanded")).toBe("false");
+    expect(button?.getAttribute("aria-controls")).toBe("diagnostics-dock-region");
+  });
+
+  it("flips aria-expanded to true when the dock opens", () => {
+    const { container } = render(<ToolbarProblemsButton errorCount={2} />);
+    const button = container.querySelector("button");
+    expect(button?.getAttribute("aria-expanded")).toBe("false");
+
+    act(() => {
+      useDiagnosticsStore.setState({ isOpen: true });
+    });
+
+    expect(button?.getAttribute("aria-expanded")).toBe("true");
+    expect(button?.getAttribute("aria-controls")).toBe("diagnostics-dock-region");
+  });
+});

--- a/src/index.css
+++ b/src/index.css
@@ -1824,6 +1824,27 @@ body[data-reduce-animations="true"] :is(.terminal-restoring, .terminal-trashing)
   animation: none;
 }
 
+/* Diagnostics dock — 200ms height transition (semantic exception per CLAUDE.md):
+ * height encodes open/close state. Suppressed during active drag and under
+ * reduced-motion to mirror the .terminal-restoring peer pattern. */
+.diagnostics-dock {
+  transition: height 200ms ease-out;
+}
+
+.diagnostics-dock[data-resizing="true"] {
+  transition: none;
+}
+
+@media (prefers-reduced-motion: reduce) {
+  .diagnostics-dock {
+    transition: none;
+  }
+}
+
+body[data-reduce-animations="true"] .diagnostics-dock {
+  transition: none;
+}
+
 /* Terminal Selection State */
 .terminal-selected {
   border-color: color-mix(in oklab, var(--theme-border-strong) 92%, var(--theme-text-primary));

--- a/src/store/__tests__/diagnosticsStore.test.ts
+++ b/src/store/__tests__/diagnosticsStore.test.ts
@@ -1,0 +1,62 @@
+import { beforeEach, describe, expect, it } from "vitest";
+import {
+  useDiagnosticsStore,
+  DIAGNOSTICS_MIN_HEIGHT,
+  DIAGNOSTICS_DEFAULT_HEIGHT,
+} from "../diagnosticsStore";
+
+describe("diagnosticsStore height & maxHeight", () => {
+  beforeEach(() => {
+    useDiagnosticsStore.setState({
+      isOpen: false,
+      activeTab: "problems",
+      height: DIAGNOSTICS_DEFAULT_HEIGHT,
+      maxHeight: 600,
+    });
+  });
+
+  it("setHeight clamps below the minimum", () => {
+    useDiagnosticsStore.getState().setHeight(10);
+    expect(useDiagnosticsStore.getState().height).toBe(DIAGNOSTICS_MIN_HEIGHT);
+  });
+
+  it("setHeight clamps above the configured maxHeight", () => {
+    useDiagnosticsStore.setState({ maxHeight: 400 });
+    useDiagnosticsStore.getState().setHeight(9999);
+    expect(useDiagnosticsStore.getState().height).toBe(400);
+  });
+
+  it("setHeight accepts values inside the allowed range", () => {
+    useDiagnosticsStore.setState({ maxHeight: 500 });
+    useDiagnosticsStore.getState().setHeight(300);
+    expect(useDiagnosticsStore.getState().height).toBe(300);
+  });
+
+  it("setMaxHeight floors at DIAGNOSTICS_MIN_HEIGHT", () => {
+    useDiagnosticsStore.getState().setMaxHeight(50);
+    expect(useDiagnosticsStore.getState().maxHeight).toBe(DIAGNOSTICS_MIN_HEIGHT);
+  });
+
+  it("setMaxHeight re-clamps the current height when shrinking the cap", () => {
+    useDiagnosticsStore.setState({ maxHeight: 600, height: 500 });
+    useDiagnosticsStore.getState().setMaxHeight(300);
+    expect(useDiagnosticsStore.getState().maxHeight).toBe(300);
+    expect(useDiagnosticsStore.getState().height).toBe(300);
+  });
+
+  it("setMaxHeight leaves a smaller current height untouched", () => {
+    useDiagnosticsStore.setState({ maxHeight: 400, height: 200 });
+    useDiagnosticsStore.getState().setMaxHeight(800);
+    expect(useDiagnosticsStore.getState().maxHeight).toBe(800);
+    expect(useDiagnosticsStore.getState().height).toBe(200);
+  });
+
+  it("setMaxHeight is idempotent when nothing changes", () => {
+    useDiagnosticsStore.setState({ maxHeight: 400, height: 200 });
+    const before = useDiagnosticsStore.getState();
+    useDiagnosticsStore.getState().setMaxHeight(400);
+    const after = useDiagnosticsStore.getState();
+    expect(after.maxHeight).toBe(before.maxHeight);
+    expect(after.height).toBe(before.height);
+  });
+});

--- a/src/store/__tests__/diagnosticsStore.test.ts
+++ b/src/store/__tests__/diagnosticsStore.test.ts
@@ -59,4 +59,17 @@ describe("diagnosticsStore height & maxHeight", () => {
     expect(after.maxHeight).toBe(before.maxHeight);
     expect(after.height).toBe(before.height);
   });
+
+  it("setMaxHeight skips subscriber notifications on a no-op", () => {
+    useDiagnosticsStore.setState({ maxHeight: 400, height: 200 });
+    let notifyCount = 0;
+    const unsub = useDiagnosticsStore.subscribe(() => {
+      notifyCount += 1;
+    });
+    useDiagnosticsStore.getState().setMaxHeight(400);
+    expect(notifyCount).toBe(0);
+    useDiagnosticsStore.getState().setMaxHeight(500);
+    expect(notifyCount).toBe(1);
+    unsub();
+  });
 });

--- a/src/store/diagnosticsStore.ts
+++ b/src/store/diagnosticsStore.ts
@@ -69,9 +69,13 @@ const createDiagnosticsStore: StateCreator<DiagnosticsState> = (set) => ({
     set((state) => {
       const nextMax = Math.max(max, MIN_HEIGHT);
       const clampedHeight = Math.min(state.height, nextMax);
-      return clampedHeight === state.height && nextMax === state.maxHeight
-        ? {}
-        : { maxHeight: nextMax, height: clampedHeight };
+      // Returning the existing state reference makes Zustand 5 skip the
+      // subscriber notification — important because ResizeObserver can
+      // fire the same parent height repeatedly during layout churn.
+      if (clampedHeight === state.height && nextMax === state.maxHeight) {
+        return state;
+      }
+      return { maxHeight: nextMax, height: clampedHeight };
     }),
 
   reset: () =>

--- a/src/store/diagnosticsStore.ts
+++ b/src/store/diagnosticsStore.ts
@@ -6,6 +6,7 @@ interface DiagnosticsState {
   isOpen: boolean;
   activeTab: DiagnosticsTab;
   height: number;
+  maxHeight: number;
 
   toggleDock: () => void;
   openDock: (tab?: DiagnosticsTab) => void;
@@ -13,6 +14,7 @@ interface DiagnosticsState {
   setActiveTab: (tab: DiagnosticsTab) => void;
   setOpen: (open: boolean) => void;
   setHeight: (height: number) => void;
+  setMaxHeight: (max: number) => void;
   reset: () => void;
 }
 
@@ -20,10 +22,16 @@ const DEFAULT_HEIGHT = 256;
 const MIN_HEIGHT = 128;
 const MAX_HEIGHT_RATIO = 0.5; // 50% of viewport
 
+const initialMaxHeight =
+  typeof window !== "undefined"
+    ? Math.max(window.innerHeight * MAX_HEIGHT_RATIO, MIN_HEIGHT)
+    : DEFAULT_HEIGHT;
+
 const createDiagnosticsStore: StateCreator<DiagnosticsState> = (set) => ({
   isOpen: false,
   activeTab: "problems",
   height: DEFAULT_HEIGHT,
+  maxHeight: initialMaxHeight,
 
   toggleDock: () =>
     set((state) => ({
@@ -51,18 +59,27 @@ const createDiagnosticsStore: StateCreator<DiagnosticsState> = (set) => ({
       isOpen,
     }),
 
-  setHeight: (height) => {
-    const maxHeight =
-      typeof window !== "undefined" ? window.innerHeight * MAX_HEIGHT_RATIO : height;
-    const clampedHeight = Math.min(Math.max(height, MIN_HEIGHT), maxHeight);
-    set({ height: clampedHeight });
-  },
+  setHeight: (height) =>
+    set((state) => {
+      const clampedHeight = Math.min(Math.max(height, MIN_HEIGHT), state.maxHeight);
+      return { height: clampedHeight };
+    }),
+
+  setMaxHeight: (max) =>
+    set((state) => {
+      const nextMax = Math.max(max, MIN_HEIGHT);
+      const clampedHeight = Math.min(state.height, nextMax);
+      return clampedHeight === state.height && nextMax === state.maxHeight
+        ? {}
+        : { maxHeight: nextMax, height: clampedHeight };
+    }),
 
   reset: () =>
     set({
       isOpen: false,
       activeTab: "problems",
       height: DEFAULT_HEIGHT,
+      maxHeight: initialMaxHeight,
     }),
 });
 


### PR DESCRIPTION
## Summary

- Strips the height transition during active drag so the dock tracks the cursor without lag, and adds `prefers-reduced-motion` / `data-reduce-animations` support so the transition is suppressed for users who need it
- Implements the APG roving-tabindex pattern and left/right arrow navigation on the Problems/Logs/Events/Telemetry tab strip, and adds Home/End/PageUp/PageDown support to the resize handle `role="separator"`
- Wires a resize observer so `aria-valuemax` and the in-store height clamp stay accurate when the viewport shrinks, and adds `aria-expanded` + `aria-controls` to the toolbar trigger button

Resolves #7243

## Changes

- `DiagnosticsDock.tsx` — conditional transition classes (omitted during `isResizing`), roving tabindex + arrow-key handler on tab strip, extended keyboard map on separator, ResizeObserver for max-height clamp
- `diagnosticsStore.ts` — `setMaxHeight` action; resize observer registration; clamp re-fires on viewport change
- `ToolbarProblemsButton.tsx` — `aria-expanded` and `aria-controls` wired to dock open state
- `src/index.css` — reduced-motion rule for the dock height transition (mirrors existing `.terminal-restoring` peer)
- Unit tests for all new behaviors in `DiagnosticsDock.test.tsx`, `ToolbarProblemsButton.test.tsx`, and `diagnosticsStore.test.ts`

## Testing

- Drag resize: dock height follows cursor immediately, no 200ms lag
- Keyboard resize: ArrowUp/Down step 10px; PageUp/Down step 50px; Home/End jump to min/max
- Tab strip: only the active tab is in the tab order; Left/Right arrows move focus and activate tabs
- `prefers-reduced-motion: reduce` in DevTools: transition absent during open/close
- `body[data-reduce-animations="true"]`: same
- Resize OS window to less than current dock height: dock clamps and `aria-valuemax` updates
- `aria-expanded` on toolbar button reflects open/closed state correctly