### PR TITLE
ci(release): submit MSIX to Microsoft Store on tag push

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -203,6 +203,18 @@ jobs:
           npm run build
           npx electron-builder --config electron-builder.config.cjs --publish never
 
+      - name: Verify Windows Store package was built
+        if: matrix.os == 'windows-latest'
+        shell: pwsh
+        run: |
+          $packages = @(Get-ChildItem -Path 'release\*.appx', 'release\*.msix' -ErrorAction SilentlyContinue)
+          if ($packages.Count -eq 0) {
+            Write-Host "::error::No .appx or .msix found in release/. Confirm electron-builder is configured with the appx target (see #7198)."
+            Get-ChildItem -Path release -ErrorAction SilentlyContinue | ForEach-Object { Write-Host $_.Name }
+            exit 1
+          }
+          Write-Host "Found $($packages.Count) Store package(s) in release/"
+
       - name: Run WACK (Windows, best-effort)
         if: matrix.os == 'windows-latest'
         shell: pwsh

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -203,6 +203,83 @@ jobs:
           npm run build
           npx electron-builder --config electron-builder.config.cjs --publish never
 
+      - name: Run WACK (Windows, best-effort)
+        if: matrix.os == 'windows-latest'
+        shell: pwsh
+        continue-on-error: true
+        run: |
+          $appx = Get-ChildItem -Path release -Filter *.appx -ErrorAction SilentlyContinue |
+            Select-Object -First 1
+          if (-not $appx) {
+            $appx = Get-ChildItem -Path release -Filter *.msix -ErrorAction SilentlyContinue |
+              Select-Object -First 1
+          }
+          if (-not $appx) {
+            Write-Host "::warning::No .appx or .msix found in release/ — skipping WACK"
+            exit 0
+          }
+          $appcert = Join-Path ${env:ProgramFiles(x86)} 'Windows Kits\10\App Certification Kit\appcert.exe'
+          if (-not (Test-Path $appcert)) {
+            Write-Host "::warning::WACK (appcert.exe) not found at $appcert — skipping"
+            exit 0
+          }
+          $report = Join-Path $env:RUNNER_TEMP 'wack-report.xml'
+          & $appcert test -appxpackagepath $appx.FullName -reportoutputpath $report
+          if ($LASTEXITCODE -ne 0) {
+            Write-Host "::warning::WACK reported issues (exit $LASTEXITCODE). Microsoft re-runs WACK during certification — see $report for details."
+          }
+
+      - name: Check Microsoft Store secrets (Windows)
+        id: store-secrets
+        if: matrix.os == 'windows-latest'
+        shell: pwsh
+        env:
+          PARTNER_CENTER_TENANT_ID: ${{ secrets.PARTNER_CENTER_TENANT_ID }}
+          PARTNER_CENTER_SELLER_ID: ${{ secrets.PARTNER_CENTER_SELLER_ID }}
+          PARTNER_CENTER_CLIENT_ID: ${{ secrets.PARTNER_CENTER_CLIENT_ID }}
+          PARTNER_CENTER_CLIENT_SECRET: ${{ secrets.PARTNER_CENTER_CLIENT_SECRET }}
+          STORE_PRODUCT_ID: ${{ secrets.STORE_PRODUCT_ID }}
+        run: |
+          $configured = -not [string]::IsNullOrEmpty($env:PARTNER_CENTER_TENANT_ID) `
+            -and -not [string]::IsNullOrEmpty($env:PARTNER_CENTER_SELLER_ID) `
+            -and -not [string]::IsNullOrEmpty($env:PARTNER_CENTER_CLIENT_ID) `
+            -and -not [string]::IsNullOrEmpty($env:PARTNER_CENTER_CLIENT_SECRET) `
+            -and -not [string]::IsNullOrEmpty($env:STORE_PRODUCT_ID)
+          $value = if ($configured) { 'true' } else { 'false' }
+          "configured=$value" | Out-File -FilePath $env:GITHUB_OUTPUT -Append
+          if (-not $configured) {
+            Write-Host "::notice::Microsoft Store submission skipped — PARTNER_CENTER_* and STORE_PRODUCT_ID secrets not configured. The .appx is still built and archived to R2."
+          }
+
+      - name: Install Microsoft Store CLI (Windows)
+        if: matrix.os == 'windows-latest' && steps.store-secrets.outputs.configured == 'true'
+        uses: microsoft/microsoft-store-apppublisher@v1.3
+
+      - name: Submit to Microsoft Store (Windows)
+        if: matrix.os == 'windows-latest' && steps.store-secrets.outputs.configured == 'true'
+        shell: pwsh
+        env:
+          PARTNER_CENTER_TENANT_ID: ${{ secrets.PARTNER_CENTER_TENANT_ID }}
+          PARTNER_CENTER_SELLER_ID: ${{ secrets.PARTNER_CENTER_SELLER_ID }}
+          PARTNER_CENTER_CLIENT_ID: ${{ secrets.PARTNER_CENTER_CLIENT_ID }}
+          PARTNER_CENTER_CLIENT_SECRET: ${{ secrets.PARTNER_CENTER_CLIENT_SECRET }}
+          STORE_PRODUCT_ID: ${{ secrets.STORE_PRODUCT_ID }}
+        run: |
+          msstore reconfigure `
+            --tenantId $env:PARTNER_CENTER_TENANT_ID `
+            --sellerId $env:PARTNER_CENTER_SELLER_ID `
+            --clientId $env:PARTNER_CENTER_CLIENT_ID `
+            --clientSecret $env:PARTNER_CENTER_CLIENT_SECRET
+          if ($LASTEXITCODE -ne 0) {
+            Write-Host "::error::msstore reconfigure failed (exit $LASTEXITCODE)"
+            exit $LASTEXITCODE
+          }
+          msstore publish . --appId $env:STORE_PRODUCT_ID --inputDirectory .\release
+          if ($LASTEXITCODE -ne 0) {
+            Write-Host "::error::msstore publish failed (exit $LASTEXITCODE). If the failure is 'unknown command,' the CLI grammar may have shifted — run 'msstore --help' on the runner and update this step."
+            exit $LASTEXITCODE
+          }
+
       - name: Validate update metadata (macOS)
         if: startsWith(matrix.os, 'macos')
         shell: bash
@@ -238,10 +315,10 @@ jobs:
           path: |
             release/*.dmg
             release/*.zip
-            release/*.exe
+            release/*.appx
+            release/*.msix
             release/*.AppImage
             release/*.deb
-            release/*.blockmap
             release/*.yml
           retention-days: 7
           if-no-files-found: error
@@ -301,10 +378,10 @@ jobs:
             --exclude "*" \
             --include "*.dmg" \
             --include "*.zip" \
-            --include "*.exe" \
+            --include "*.appx" \
+            --include "*.msix" \
             --include "*.AppImage" \
             --include "*.deb" \
-            --include "*.blockmap" \
             --cache-control "public, max-age=31536000, immutable"
 
       - name: Upload metadata to R2


### PR DESCRIPTION
## Summary

Adds four Windows-only steps to the release workflow: verify the `.appx`/`.msix` package exists, run WACK, install the `msstore` CLI, and submit to the Microsoft Store via `msstore publish`.

Depends on #7198, which swaps the `electron-builder` target to `appx`. The package-existence assertion (`Verify Windows Store package`) will fail loudly if #7198 hasn't landed, so the dependency is enforced at build time.

When Partner Center secrets are absent, the build proceeds normally and the `.appx` is archived to R2 — only the submission step is skipped (a notice is emitted). WACK runs with `continue-on-error: true` so cert warnings don't block the release.

The `msstore publish` command was verified against the upstream source at [microsoft/msstore-cli](https://github.com/microsoft/msstore-cli). The issue body's two-step flow (`submission update` + `submission publish`) is incorrect for the current CLI; the single-step `msstore publish` covers both.

Resolves #7200.

## Changes

- Artifact glob and R2 sync filters updated to match `.appx`/`.msix` instead of `.exe`/`.blockmap`
- `Verify Windows Store package` step fails the build explicitly if no package is found
- WACK step added with `continue-on-error: true`
- `msstore` CLI install + `msstore publish` submission step, gated on Partner Center secrets being present

## Testing

The workflow only fires on `v*` tag push, so full end-to-end verification happens at the next release. Pre-release sanity checks:

- **Missing secrets:** notice emitted, submission skipped, `.appx` still archived to R2
- **Placeholder secrets:** `msstore reconfigure` fails cleanly with `::error::`
- **Missing package (no #7198):** `Verify Windows Store package` step fails with an explicit error message