### PR TITLE
fix(agent-router): trim JSDoc to match shipped selection behavior

### DIFF
--- a/electron/services/AgentRouter.ts
+++ b/electron/services/AgentRouter.ts
@@ -4,7 +4,7 @@
  * Implements filter-score-select pattern:
  * 1. Filter: Only agents with required capabilities and availability
  * 2. Score: Rank by domain weight + load + availability
- * 3. Select: Top-scored or weighted lottery selection
+ * 3. Select: Top-scored selection
  */
 
 import {
@@ -197,7 +197,7 @@ export class AgentRouter {
 
   /**
    * Select the best agent from scored candidates.
-   * Uses top-scored selection (deterministic for testing).
+   * Uses top-scored selection.
    */
   private selectAgent(scores: AgentScore[]): string | null {
     if (scores.length === 0) {


### PR DESCRIPTION
## Summary
- The `AgentRouter` class JSDoc referenced a weighted lottery selection step that was never built. Trimmed it.
- `selectAgent`'s JSDoc described the selection as deterministic, but `scoreAgent` uses `Math.random()` for tie-breaking. Dropped the parenthetical.
- Two comment-only changes in `electron/services/AgentRouter.ts`. No behavior change.

Resolves #7065

## Changes
- `electron/services/AgentRouter.ts`: removed "or weighted lottery selection" from the class JSDoc filter-score-select pipeline, and removed "(deterministic for testing)" from `selectAgent`'s JSDoc.

## Testing
- `npm run check` passes (typecheck + lint + format). Doc-only change -- no runtime impact.