### PR TITLE
fix(settings): polish dialog tablist, primitives, and persistence

### DIFF
--- a/src/components/Settings/DaintreeAssistantSettingsTab.tsx
+++ b/src/components/Settings/DaintreeAssistantSettingsTab.tsx
@@ -20,7 +20,9 @@ import { SettingsInput } from "./SettingsInput";
 import { SettingsSelect } from "./SettingsSelect";
 import { SettingsSwitchCard } from "./SettingsSwitchCard";
 import { useSettingsTabValidation } from "./SettingsValidationRegistry";
+import { useSettingsTabFlush } from "./SettingsFlushRegistry";
 import { formatErrorMessage } from "@shared/utils/errorMessage";
+import { useDebounce } from "@/hooks/useDebounce";
 
 import { logError } from "@/utils/logger";
 import { getAgentConfig, getAssistantSupportedAgentIds } from "@/config/agents";
@@ -28,6 +30,7 @@ import { useHelpPanelStore } from "@/store/helpPanelStore";
 import type { HelpAssistantSettings } from "@shared/types";
 
 const COPY_RESET_DELAY_MS = 2000;
+const CUSTOM_ARGS_DEBOUNCE_MS = 500;
 
 const DEFAULT_SETTINGS: HelpAssistantSettings = {
   docSearch: true,
@@ -67,6 +70,21 @@ export function DaintreeAssistantSettingsTab() {
   const [showRotateConfirm, setShowRotateConfirm] = useState(false);
   const [isRotating, setIsRotating] = useState(false);
   const copyTimeoutRef = useRef<ReturnType<typeof setTimeout> | null>(null);
+
+  // customArgs is a free-form text input; persisting on every keystroke would
+  // spam IPC. We track a pending edit alongside the persisted value: when the
+  // pending value is null the input mirrors `settings.customArgs` directly
+  // (no extra render round-trip on initial load), and when non-null it holds
+  // the user's in-flight edit until the debounced persist catches up. A flush
+  // hook captures the pending value before dialog dismissal (#7260).
+  const [pendingCustomArgs, setPendingCustomArgs] = useState<string | null>(null);
+  const debouncedPendingCustomArgs = useDebounce(pendingCustomArgs, CUSTOM_ARGS_DEBOUNCE_MS);
+  const displayedCustomArgs = pendingCustomArgs ?? settings.customArgs;
+  const isCustomArgsDirty = pendingCustomArgs !== null && pendingCustomArgs !== settings.customArgs;
+  const pendingCustomArgsRef = useRef(pendingCustomArgs);
+  useEffect(() => {
+    pendingCustomArgsRef.current = pendingCustomArgs;
+  }, [pendingCustomArgs]);
 
   useSettingsTabValidation("assistant", Boolean(error));
 
@@ -196,11 +214,38 @@ export function DaintreeAssistantSettingsTab() {
     [setPreferredAgent]
   );
 
-  const handleCustomArgsChange = useCallback(
-    (event: React.ChangeEvent<HTMLInputElement>) => {
-      void persist({ customArgs: event.target.value });
+  const handleCustomArgsChange = useCallback((event: React.ChangeEvent<HTMLInputElement>) => {
+    setPendingCustomArgs(event.target.value);
+  }, []);
+
+  // Persist the pending value once the debounce settles. Skipped when pending
+  // matches what's already persisted (e.g., user typed and undid, or the
+  // value just landed via the optimistic update inside `persist`).
+  useEffect(() => {
+    if (debouncedPendingCustomArgs === null) return;
+    if (debouncedPendingCustomArgs !== settings.customArgs) {
+      void persist({ customArgs: debouncedPendingCustomArgs });
+    }
+  }, [debouncedPendingCustomArgs, settings.customArgs, persist]);
+
+  // Once the persisted value catches up, clear the pending flag so the input
+  // resumes mirroring `settings.customArgs` directly.
+  useEffect(() => {
+    if (pendingCustomArgs !== null && pendingCustomArgs === settings.customArgs) {
+      setPendingCustomArgs(null);
+    }
+  }, [pendingCustomArgs, settings.customArgs]);
+
+  // Pre-close flush bypasses the debounce so closing the dialog mid-edit
+  // still captures the in-flight value.
+  useSettingsTabFlush(
+    "assistant",
+    () => {
+      const pending = pendingCustomArgsRef.current;
+      if (pending === null) return;
+      return persist({ customArgs: pending });
     },
-    [persist]
+    isCustomArgsDirty
   );
 
   const confirmRotateKey = useCallback(async () => {
@@ -280,7 +325,7 @@ export function DaintreeAssistantSettingsTab() {
           autoCorrect="off"
           autoCapitalize="off"
           placeholder="--model sonnet"
-          value={settings.customArgs}
+          value={displayedCustomArgs}
           onChange={handleCustomArgsChange}
           disabled={loading}
         />

--- a/src/components/Settings/SettingsCheckbox.tsx
+++ b/src/components/Settings/SettingsCheckbox.tsx
@@ -31,8 +31,8 @@ export function SettingsCheckbox({
   const descriptionId = useId();
   const errorId = useId();
 
-  const describedBy = error ? errorId : descriptionId;
   const isError = error !== undefined && error !== "";
+  const describedBy = [isError ? errorId : null, descriptionId].filter(Boolean).join(" ");
 
   const scopeBadge = scope ? (
     <span
@@ -90,11 +90,9 @@ export function SettingsCheckbox({
             {label}
           </span>
           {scopeBadge}
-          {!isError && (
-            <p id={descriptionId} className="text-xs text-text-muted mt-0.5 select-text">
-              {description}
-            </p>
-          )}
+          <p id={descriptionId} className="text-xs text-text-muted mt-0.5 select-text">
+            {description}
+          </p>
           {isError && (
             <p id={errorId} className="text-xs text-status-error mt-0.5">
               {error}

--- a/src/components/Settings/SettingsChoicebox.tsx
+++ b/src/components/Settings/SettingsChoicebox.tsx
@@ -58,9 +58,8 @@ export function SettingsChoicebox<T extends string = string>({
   const showReset = isModified && onReset && !disabled;
 
   const describedBy =
-    [description && !error ? descriptionId : null, error ? errorId : null]
-      .filter(Boolean)
-      .join(" ") || undefined;
+    [error ? errorId : null, description ? descriptionId : null].filter(Boolean).join(" ") ||
+    undefined;
 
   const [focusedIndex, setFocusedIndex] = useState<number>(-1);
   const containerRef = useRef<HTMLDivElement>(null);
@@ -218,7 +217,7 @@ export function SettingsChoicebox<T extends string = string>({
           );
         })}
       </div>
-      {description && !error && (
+      {description && (
         <p id={descriptionId} className="text-xs text-daintree-text/40 select-text">
           {description}
         </p>

--- a/src/components/Settings/SettingsDialog.tsx
+++ b/src/components/Settings/SettingsDialog.tsx
@@ -87,6 +87,11 @@ import { SettingsFlushProvider, SettingsFlushContext } from "./SettingsFlushRegi
 let rememberedTab: SettingsTab = "general";
 let rememberedProjectTab: SettingsTab = "project:general";
 
+// How long the `settings-highlight` pulse stays on the scrolled-to section
+// before the class is removed. Long enough to read, short enough not to draw
+// attention after the user has oriented.
+const SETTINGS_HIGHLIGHT_DECAY_MS = 1500;
+
 export interface SettingsNavTarget {
   tab: SettingsTab;
   subtab?: string;
@@ -478,41 +483,39 @@ function SettingsDialogInner({
 
   const tablistRef = useRef<HTMLDivElement>(null);
 
-  const handleTablistKeyDown = useCallback(
-    (e: ReactKeyboardEvent<HTMLDivElement>) => {
-      const container = tablistRef.current;
-      if (!container) return;
+  const handleTablistKeyDown = useCallback((e: ReactKeyboardEvent<HTMLDivElement>) => {
+    const container = tablistRef.current;
+    if (!container) return;
 
-      const tabs = Array.from(container.querySelectorAll<HTMLElement>('[role="tab"]'));
-      const focusedIndex = tabs.indexOf(document.activeElement as HTMLElement);
-      if (focusedIndex === -1) return;
+    const tabs = Array.from(container.querySelectorAll<HTMLElement>('[role="tab"]'));
+    const focusedIndex = tabs.indexOf(document.activeElement as HTMLElement);
+    if (focusedIndex === -1) return;
 
-      let nextIndex: number | null = null;
+    let nextIndex: number | null = null;
 
-      switch (e.key) {
-        case "ArrowDown":
-          nextIndex = (focusedIndex + 1) % tabs.length;
-          break;
-        case "ArrowUp":
-          nextIndex = (focusedIndex - 1 + tabs.length) % tabs.length;
-          break;
-        case "Home":
-          nextIndex = 0;
-          break;
-        case "End":
-          nextIndex = tabs.length - 1;
-          break;
-        default:
-          return;
-      }
+    switch (e.key) {
+      case "ArrowDown":
+        nextIndex = (focusedIndex + 1) % tabs.length;
+        break;
+      case "ArrowUp":
+        nextIndex = (focusedIndex - 1 + tabs.length) % tabs.length;
+        break;
+      case "Home":
+        nextIndex = 0;
+        break;
+      case "End":
+        nextIndex = tabs.length - 1;
+        break;
+      default:
+        return;
+    }
 
-      e.preventDefault();
-      tabs[nextIndex]!.focus();
-      const tabId = tabs[nextIndex]!.dataset.tab as SettingsTab | undefined;
-      if (tabId) handleNavSelect(tabId);
-    },
-    [handleNavSelect]
-  );
+    e.preventDefault();
+    // Manual activation: arrow keys move focus only. Native <button role="tab">
+    // already fires onClick on Enter/Space, so the existing onSelect handler
+    // covers activation without an explicit keydown branch here.
+    tabs[nextIndex]!.focus();
+  }, []);
 
   const tabTitles: Record<SettingsTab, string> = {
     ...globalTabTitles,
@@ -1210,7 +1213,7 @@ export function scrollAndHighlightSettingsSection(sectionId: string): boolean {
   el.scrollIntoView({ behavior: "instant", block: "start" });
   el.querySelector<HTMLInputElement>("input")?.focus({ preventScroll: true });
   el.classList.add("settings-highlight");
-  setTimeout(() => el.classList.remove("settings-highlight"), 1500);
+  setTimeout(() => el.classList.remove("settings-highlight"), SETTINGS_HIGHLIGHT_DECAY_MS);
   return true;
 }
 
@@ -1313,7 +1316,8 @@ function NavItem({
               "absolute -top-0.5 -right-0.5 w-1.5 h-1.5 rounded-full",
               hasError ? "bg-status-warning" : "bg-state-modified"
             )}
-            title={hasError ? "Contains validation errors" : "Modified from default"}
+            role="img"
+            aria-label={hasError ? "Contains validation errors" : "Modified from default"}
           />
         )}
       </span>

--- a/src/components/Settings/SettingsInput.tsx
+++ b/src/components/Settings/SettingsInput.tsx
@@ -36,9 +36,8 @@ export function SettingsInput({
   const showReset = isModified && onReset && !disabled;
 
   const describedBy =
-    [description && !error ? descriptionId : null, error ? errorId : null]
-      .filter(Boolean)
-      .join(" ") || undefined;
+    [error ? errorId : null, description ? descriptionId : null].filter(Boolean).join(" ") ||
+    undefined;
 
   const scopeBadge = scope ? (
     <span
@@ -89,7 +88,7 @@ export function SettingsInput({
         className={cn(INPUT_CLASSES, error && "border-status-error", className)}
         {...props}
       />
-      {description && !error && (
+      {description && (
         <p id={descriptionId} className="text-xs text-text-muted select-text">
           {description}
         </p>

--- a/src/components/Settings/SettingsSelect.tsx
+++ b/src/components/Settings/SettingsSelect.tsx
@@ -56,9 +56,8 @@ export function SettingsSelect({
   const showReset = isModified && onReset && !disabled;
 
   const describedBy =
-    [description && !error ? descriptionId : null, error ? errorId : null]
-      .filter(Boolean)
-      .join(" ") || undefined;
+    [error ? errorId : null, description ? descriptionId : null].filter(Boolean).join(" ") ||
+    undefined;
 
   const scopeBadge = scope ? (
     <span
@@ -122,7 +121,7 @@ export function SettingsSelect({
           ))}
         </SelectContent>
       </Select>
-      {description && !error && (
+      {description && (
         <p id={descriptionId} className="text-xs text-daintree-text/40 select-text">
           {description}
         </p>

--- a/src/components/Settings/SettingsSwitchCard.tsx
+++ b/src/components/Settings/SettingsSwitchCard.tsx
@@ -77,6 +77,7 @@ export function SettingsSwitchCard({
         isCard ? "p-4 rounded-[var(--radius-lg)] border hover:bg-tint/5" : "py-2",
         "border-daintree-border text-daintree-text/70",
         isEnabled && "border-daintree-border text-daintree-text",
+        !disabled && "cursor-pointer",
         disabled && "opacity-50"
       )}
       onClick={disabled ? undefined : handleCardClick}

--- a/src/components/Settings/SettingsTextarea.tsx
+++ b/src/components/Settings/SettingsTextarea.tsx
@@ -34,9 +34,8 @@ export function SettingsTextarea({
   const showReset = isModified && onReset && !disabled;
 
   const describedBy =
-    [description && !error ? descriptionId : null, error ? errorId : null]
-      .filter(Boolean)
-      .join(" ") || undefined;
+    [error ? errorId : null, description ? descriptionId : null].filter(Boolean).join(" ") ||
+    undefined;
 
   return (
     <div className="group grid grid-cols-subgrid gap-2 col-span-full">
@@ -72,7 +71,7 @@ export function SettingsTextarea({
         className={cn(TEXTAREA_CLASSES, error && "border-status-error", className)}
         {...props}
       />
-      {description && !error && (
+      {description && (
         <p id={descriptionId} className="text-xs text-text-muted select-text">
           {description}
         </p>

--- a/src/components/Settings/__tests__/SettingsFormPrimitives.test.tsx
+++ b/src/components/Settings/__tests__/SettingsFormPrimitives.test.tsx
@@ -144,6 +144,24 @@ describe("SettingsSelect", () => {
     expect(screen.queryByRole("alert")).toBeNull();
   });
 
+  it("aria-describedby references both error and description when both exist", () => {
+    render(
+      <SettingsSelect
+        label="Theme"
+        description="Choose a color theme"
+        error="Required"
+        value="d"
+        onValueChange={() => {}}
+        options={DEFAULT_OPTIONS}
+      />
+    );
+    const trigger = screen.getByLabelText("Theme");
+    const ids = trigger.getAttribute("aria-describedby")!.split(" ");
+    expect(ids).toHaveLength(2);
+    expect(document.getElementById(ids[0]!)?.textContent).toBe("Required");
+    expect(document.getElementById(ids[1]!)?.textContent).toBe("Choose a color theme");
+  });
+
   it("shows reset button when modified", () => {
     const onReset = vi.fn();
     render(
@@ -192,6 +210,17 @@ describe("SettingsTextarea", () => {
     const errorId = textarea.getAttribute("aria-describedby")!;
     expect(document.getElementById(errorId)?.textContent).toBe("Cannot be empty");
     expect(screen.queryByRole("alert")).toBeNull();
+  });
+
+  it("aria-describedby references both error and description when both exist", () => {
+    render(
+      <SettingsTextarea label="Notes" description="Additional notes" error="Cannot be empty" />
+    );
+    const textarea = screen.getByLabelText("Notes");
+    const ids = textarea.getAttribute("aria-describedby")!.split(" ");
+    expect(ids).toHaveLength(2);
+    expect(document.getElementById(ids[0]!)?.textContent).toBe("Cannot be empty");
+    expect(document.getElementById(ids[1]!)?.textContent).toBe("Additional notes");
   });
 
   it("forwards ref to the textarea element", () => {

--- a/src/components/Settings/__tests__/SettingsFormPrimitives.test.tsx
+++ b/src/components/Settings/__tests__/SettingsFormPrimitives.test.tsx
@@ -33,19 +33,20 @@ describe("SettingsInput", () => {
     expect(screen.queryByRole("alert")).toBeNull();
   });
 
-  it("hides description when error is shown", () => {
+  it("keeps description visible alongside error", () => {
     render(<SettingsInput label="Port" description="Server port" error="Invalid" />);
-    expect(screen.queryByText("Server port")).toBeNull();
+    expect(screen.getByText("Server port")).toBeTruthy();
     expect(screen.getByText("Invalid")).toBeTruthy();
   });
 
-  it("aria-describedby only references error when both description and error exist", () => {
+  it("aria-describedby references both error and description when both exist", () => {
     render(<SettingsInput label="Port" description="Server port" error="Required" />);
     const input = screen.getByLabelText("Port");
     const describedBy = input.getAttribute("aria-describedby")!;
     const ids = describedBy.split(" ");
-    expect(ids).toHaveLength(1);
+    expect(ids).toHaveLength(2);
     expect(document.getElementById(ids[0]!)?.textContent).toBe("Required");
+    expect(document.getElementById(ids[1]!)?.textContent).toBe("Server port");
   });
 
   it("shows modified indicator when isModified", () => {
@@ -289,7 +290,7 @@ describe("SettingsChoicebox", () => {
     expect(screen.queryByRole("alert")).toBeNull();
   });
 
-  it("hides description when error is shown", () => {
+  it("keeps description visible alongside error", () => {
     render(
       <SettingsChoicebox
         label="Density"
@@ -300,11 +301,11 @@ describe("SettingsChoicebox", () => {
         options={MOCK_OPTIONS}
       />
     );
-    expect(screen.queryByText("Choose dock density")).toBeNull();
+    expect(screen.getByText("Choose dock density")).toBeTruthy();
     expect(screen.getByText("Invalid selection")).toBeTruthy();
   });
 
-  it("aria-describedby only references error when both description and error exist", () => {
+  it("aria-describedby references both error and description when both exist", () => {
     render(
       <SettingsChoicebox
         label="Density"
@@ -318,8 +319,9 @@ describe("SettingsChoicebox", () => {
     const group = screen.getByRole("radiogroup");
     const describedBy = group.getAttribute("aria-describedby")!;
     const ids = describedBy.split(" ");
-    expect(ids).toHaveLength(1);
+    expect(ids).toHaveLength(2);
     expect(document.getElementById(ids[0]!)?.textContent).toBe("Invalid selection");
+    expect(document.getElementById(ids[1]!)?.textContent).toBe("Choose dock density");
   });
 
   it("shows modified indicator when isModified", () => {
@@ -631,8 +633,8 @@ describe("SettingsCheckbox", () => {
     );
     const checkbox = screen.getByRole("checkbox");
     expect(checkbox.getAttribute("aria-invalid")).toBe("true");
-    const errorId = checkbox.getAttribute("aria-describedby")!;
-    expect(document.getElementById(errorId)?.textContent).toBe("Invalid state");
+    const ids = checkbox.getAttribute("aria-describedby")!.split(" ");
+    expect(document.getElementById(ids[0]!)?.textContent).toBe("Invalid state");
     expect(screen.queryByRole("alert")).toBeNull();
   });
 
@@ -649,7 +651,7 @@ describe("SettingsCheckbox", () => {
     expect(checkbox.getAttribute("aria-invalid")).toBeNull();
   });
 
-  it("hides description when error is shown", () => {
+  it("keeps description visible alongside error", () => {
     render(
       <SettingsCheckbox
         label="Test Setting"
@@ -659,8 +661,26 @@ describe("SettingsCheckbox", () => {
         error="Invalid state"
       />
     );
-    expect(screen.queryByText("A test description")).toBeNull();
+    expect(screen.getByText("A test description")).toBeTruthy();
     expect(screen.getByText("Invalid state")).toBeTruthy();
+  });
+
+  it("aria-describedby references both error and description when both exist", () => {
+    render(
+      <SettingsCheckbox
+        label="Test Setting"
+        description="A test description"
+        checked={false}
+        onChange={vi.fn()}
+        error="Invalid state"
+      />
+    );
+    const checkbox = screen.getByRole("checkbox");
+    const describedBy = checkbox.getAttribute("aria-describedby")!;
+    const ids = describedBy.split(" ");
+    expect(ids).toHaveLength(2);
+    expect(document.getElementById(ids[0]!)?.textContent).toBe("Invalid state");
+    expect(document.getElementById(ids[1]!)?.textContent).toBe("A test description");
   });
 
   it("calls onChange with false when unchecking", async () => {


### PR DESCRIPTION
## Summary

Six targeted fixes across the settings dialog — keyboard nav, accessibility, form primitive wiring, cursor behaviour, and persist reliability.

Resolves #7260

## Changes

- **Tablist keyboard nav:** arrow keys move focus only; Enter/Space activation is handled by the native button `onClick`. Fixes the ARIA tablist pattern where arrow key presses were activating tabs immediately.
- **Modifier dot accessibility:** sidebar tab dots now use `aria-label` + `role="img"` instead of the `title` attribute, which is unreliable with screen readers and keyboard-only navigation.
- **Named constant:** the magic `1500`ms highlight decay is now `SETTINGS_HIGHLIGHT_DECAY_MS` — easier to find, easier to change consistently.
- **Form primitives (`Input`, `Textarea`, `Select`, `Choicebox`, `Checkbox`):** `aria-describedby` now wires both the description ID and the error ID. Previously only the error ID was linked on error, which dropped the description text from the accessibility tree and hid it visually.
- **`SettingsSwitchCard` cursor:** adds `cursor-pointer` when not disabled, consistent with other interactive controls.
- **`customArgs` persist reliability:** 500ms debounced save + flush registration on mount. Closing the dialog mid-edit no longer drops in-flight changes. Display is driven by a `pendingCustomArgs` derived state so the field stays responsive while the debounce is in flight.

## Testing

- Arrow keys move focus through tabs without activating them; Enter/Space activates the focused tab
- Modifier dots announce correctly via VoiceOver / screen reader
- Form fields with both a description and an error: both text blocks visible, both IDs in `aria-describedby`
- Switch card hover shows pointer cursor; disabled state does not
- Rapid typing in "Custom CLI args" results in a single IPC call after typing stops; closing the dialog mid-edit preserves the value