### PR TITLE
fix(sidebar): tighten worktree grid ARIA and keyboard model

### DIFF
--- a/src/components/DragDrop/SortableWorktreeCard.tsx
+++ b/src/components/DragDrop/SortableWorktreeCard.tsx
@@ -34,6 +34,8 @@ interface SortableWorktreeCardProps {
   worktreeId: string;
   dragStartOrder: string[];
   disabled?: boolean;
+  ariaRowIndex: number;
+  isActive: boolean;
   children: (props: {
     isDraggingSort: boolean;
     dragHandleListeners: SyntheticListenerMap | undefined;
@@ -48,6 +50,8 @@ function sortableWorktreeCardPropsAreEqual(
   if (
     prev.worktreeId !== next.worktreeId ||
     prev.disabled !== next.disabled ||
+    prev.ariaRowIndex !== next.ariaRowIndex ||
+    prev.isActive !== next.isActive ||
     prev.children !== next.children
   ) {
     return false;
@@ -64,6 +68,8 @@ export const SortableWorktreeCard = React.memo(function SortableWorktreeCard({
   worktreeId,
   dragStartOrder,
   disabled,
+  ariaRowIndex,
+  isActive,
   children,
 }: SortableWorktreeCardProps) {
   const dragData: WorktreeSortDragData = {
@@ -111,6 +117,8 @@ export const SortableWorktreeCard = React.memo(function SortableWorktreeCard({
         style={style}
         role="row"
         aria-roledescription="sortable worktree"
+        aria-rowindex={ariaRowIndex}
+        aria-current={isActive ? "true" : undefined}
         data-worktree-row={worktreeId}
         tabIndex={-1}
       >

--- a/src/components/DragDrop/__tests__/SortableWorktreeCard.test.tsx
+++ b/src/components/DragDrop/__tests__/SortableWorktreeCard.test.tsx
@@ -29,7 +29,12 @@ describe("SortableWorktreeCard", () => {
   it("isolates the card at idle so the flash overlay's blend mode anchors to the active background", () => {
     mockIsDragging = false;
     const { container } = render(
-      <SortableWorktreeCard worktreeId="wt1" dragStartOrder={["wt1"]}>
+      <SortableWorktreeCard
+        worktreeId="wt1"
+        dragStartOrder={["wt1"]}
+        ariaRowIndex={1}
+        isActive={false}
+      >
         {() => <div data-testid="child" />}
       </SortableWorktreeCard>
     );
@@ -43,7 +48,12 @@ describe("SortableWorktreeCard", () => {
   it("clears isolation during drag so dnd-kit transforms compose with the card root", () => {
     mockIsDragging = true;
     const { container } = render(
-      <SortableWorktreeCard worktreeId="wt1" dragStartOrder={["wt1"]}>
+      <SortableWorktreeCard
+        worktreeId="wt1"
+        dragStartOrder={["wt1"]}
+        ariaRowIndex={1}
+        isActive={false}
+      >
         {() => <div data-testid="child" />}
       </SortableWorktreeCard>
     );
@@ -56,7 +66,12 @@ describe("SortableWorktreeCard", () => {
   it("keeps data-worktree-row and tabIndex on the inner div for roving focus compatibility", () => {
     mockIsDragging = false;
     const { container } = render(
-      <SortableWorktreeCard worktreeId="wt1" dragStartOrder={["wt1"]}>
+      <SortableWorktreeCard
+        worktreeId="wt1"
+        dragStartOrder={["wt1"]}
+        ariaRowIndex={1}
+        isActive={false}
+      >
         {() => <div data-testid="child" />}
       </SortableWorktreeCard>
     );
@@ -70,7 +85,12 @@ describe("SortableWorktreeCard", () => {
   it("does not apply opacity-40 class (opacity now driven by framer-motion animate)", () => {
     mockIsDragging = true;
     const { container } = render(
-      <SortableWorktreeCard worktreeId="wt1" dragStartOrder={["wt1"]}>
+      <SortableWorktreeCard
+        worktreeId="wt1"
+        dragStartOrder={["wt1"]}
+        ariaRowIndex={1}
+        isActive={false}
+      >
         {() => <div data-testid="child" />}
       </SortableWorktreeCard>
     );

--- a/src/components/Sidebar/SidebarContent.tsx
+++ b/src/components/Sidebar/SidebarContent.tsx
@@ -81,7 +81,9 @@ function SidebarContent({ onOpenOverview }: SidebarContentProps) {
   const overviewAriaShortcut = useAriaKeyshortcuts("worktree.overview");
   const refreshAriaShortcut = useAriaKeyshortcuts("worktree.refresh");
   const createWorktreeAriaShortcut = useAriaKeyshortcuts("worktree.createDialog.open");
-  const { gridRef, handleGridKeyDown, handleGridFocusCapture } = useWorktreeGridRovingFocus();
+  const scrollContainerRef = useRef<HTMLDivElement>(null);
+  const { gridRef, handleGridKeyDown, handleGridFocusCapture } =
+    useWorktreeGridRovingFocus(scrollContainerRef);
   const { worktrees, isLoading, isReconnecting, error, refresh } = useWorktrees();
   const deferredWorktrees = useDeferredValue(worktrees);
   const [isRefreshing, startRefreshTransition] = useTransition();
@@ -164,7 +166,6 @@ function SidebarContent({ onOpenOverview }: SidebarContentProps) {
   const isInTrash = usePanelStore((state) => state.isInTrash);
   const worktreeIds = useWorktreeIds();
 
-  const scrollContainerRef = useRef<HTMLDivElement>(null);
   const scrollContentRef = useRef<HTMLDivElement>(null);
   const searchInputRef = useRef<HTMLInputElement>(null);
 
@@ -573,7 +574,21 @@ function SidebarContent({ onOpenOverview }: SidebarContentProps) {
   const hasQuery = query.trim().length > 0;
   const isSortDisabled = isGroupedByType || hasQuery;
 
-  const renderWorktreeCard = (worktree: WorktreeState) => (
+  // 1-based aria-rowindex slots for the pinned rows.
+  const mainRowIndex = mainMatchesQuery ? 1 : 0;
+  const integrationRowIndex = integrationMatchesQuery ? mainRowIndex + 1 : mainRowIndex;
+  // First slot available to the scrollable section (1-based).
+  const firstScrollableRowIndex = integrationRowIndex + 1;
+
+  // Total rows in the grid — pinned rows + group header rows + data rows.
+  // Group header rows count toward aria-rowcount because they carry role="row".
+  const ariaRowCount =
+    integrationRowIndex +
+    (groupedSections
+      ? groupedSections.reduce((n, s) => n + 1 + s.worktrees.length, 0)
+      : filteredWorktrees.length);
+
+  const renderWorktreeCard = (worktree: WorktreeState, ariaRowIndex: number) => (
     <StaticWorktreeRow
       key={worktree.id}
       worktreeId={worktree.id}
@@ -585,6 +600,7 @@ function SidebarContent({ onOpenOverview }: SidebarContentProps) {
       availability={availability}
       agentSettings={agentSettings}
       homeDir={homeDir}
+      ariaRowIndex={ariaRowIndex}
     />
   );
 
@@ -729,6 +745,7 @@ function SidebarContent({ onOpenOverview }: SidebarContentProps) {
         ref={gridRef}
         role="grid"
         aria-label="Worktrees"
+        aria-rowcount={ariaRowCount}
         onKeyDown={handleGridKeyDown}
         onFocusCapture={handleGridFocusCapture}
         className="flex flex-col flex-1 min-h-0"
@@ -751,6 +768,7 @@ function SidebarContent({ onOpenOverview }: SidebarContentProps) {
               agentSettings={agentSettings}
               homeDir={homeDir}
               aggregateCounts={mainWorktreeAggregateCounts}
+              ariaRowIndex={mainRowIndex}
             />
           </div>
         )}
@@ -761,7 +779,7 @@ function SidebarContent({ onOpenOverview }: SidebarContentProps) {
             className="shrink-0"
             style={{ contentVisibility: "auto", containIntrinsicSize: "auto 180px" }}
           >
-            {renderWorktreeCard(integrationWorktree)}
+            {renderWorktreeCard(integrationWorktree, integrationRowIndex)}
           </div>
         )}
 
@@ -810,14 +828,33 @@ function SidebarContent({ onOpenOverview }: SidebarContentProps) {
                 />
               ) : groupedSections ? (
                 <div className="flex flex-col">
-                  {groupedSections.map((section) => (
-                    <div key={section.type}>
-                      <div className="sticky top-0 z-10 px-4 py-2 text-[10px] font-medium text-daintree-text/50 uppercase tracking-wide bg-daintree-sidebar border-b border-divider">
-                        {section.displayName} ({section.worktrees.length})
-                      </div>
-                      {section.worktrees.map(renderWorktreeCard)}
-                    </div>
-                  ))}
+                  {(() => {
+                    let nextRowIndex = firstScrollableRowIndex;
+                    return groupedSections.map((section) => {
+                      const headerRowIndex = nextRowIndex++;
+                      const sectionWorktreeRows = section.worktrees.map((worktree) =>
+                        renderWorktreeCard(worktree, nextRowIndex++)
+                      );
+                      return (
+                        <div key={section.type} role="rowgroup">
+                          <div
+                            role="row"
+                            aria-rowindex={headerRowIndex}
+                            className="sticky top-0 z-10 bg-daintree-sidebar border-b border-divider"
+                          >
+                            <div
+                              role="rowheader"
+                              aria-colspan={1}
+                              className="px-4 py-2 text-[10px] font-medium text-daintree-text/50 uppercase tracking-wide"
+                            >
+                              {section.displayName} ({section.worktrees.length})
+                            </div>
+                          </div>
+                          {sectionWorktreeRows}
+                        </div>
+                      );
+                    });
+                  })()}
                 </div>
               ) : (
                 <SortableContext items={sortableIds} strategy={verticalListSortingStrategy}>
@@ -840,6 +877,7 @@ function SidebarContent({ onOpenOverview }: SidebarContentProps) {
                           isSortDisabled={isSortDisabled}
                           isPinned={isPinned}
                           rowIndex={idx}
+                          ariaRowIndex={firstScrollableRowIndex + idx}
                         />
                       );
                     })}

--- a/src/components/Sidebar/SidebarWorktreeRow.tsx
+++ b/src/components/Sidebar/SidebarWorktreeRow.tsx
@@ -24,6 +24,7 @@ interface SidebarWorktreeRowProps {
   isSortDisabled: boolean;
   isPinned: boolean;
   rowIndex: number;
+  ariaRowIndex: number;
 }
 
 const SidebarWorktreeRow = React.memo(function SidebarWorktreeRow({
@@ -40,6 +41,7 @@ const SidebarWorktreeRow = React.memo(function SidebarWorktreeRow({
   isSortDisabled,
   isPinned,
   rowIndex,
+  ariaRowIndex,
 }: SidebarWorktreeRowProps) {
   const worktreeSnap = useWorktreeStore((state) => state.worktrees.get(worktreeId));
   const worktree = useMemo(
@@ -109,6 +111,8 @@ const SidebarWorktreeRow = React.memo(function SidebarWorktreeRow({
         worktreeId={worktreeId}
         dragStartOrder={dragStartOrder}
         disabled={isSortDisabled || isPinned}
+        ariaRowIndex={ariaRowIndex}
+        isActive={isActive}
       >
         {({ isDraggingSort, dragHandleListeners, dragHandleActivatorRef }) => (
           <ErrorBoundary
@@ -146,7 +150,13 @@ const SidebarWorktreeRow = React.memo(function SidebarWorktreeRow({
   }
 
   return (
-    <SortableWorktreeCard worktreeId={worktreeId} dragStartOrder={dragStartOrder} disabled={true}>
+    <SortableWorktreeCard
+      worktreeId={worktreeId}
+      dragStartOrder={dragStartOrder}
+      disabled={true}
+      ariaRowIndex={ariaRowIndex}
+      isActive={isActive}
+    >
       {({ isDraggingSort }) => (
         <ErrorBoundary
           variant="component"

--- a/src/components/Sidebar/StaticWorktreeRow.tsx
+++ b/src/components/Sidebar/StaticWorktreeRow.tsx
@@ -18,6 +18,7 @@ interface StaticWorktreeRowProps {
   agentSettings: UseAgentLauncherReturn["agentSettings"];
   homeDir: string | undefined;
   aggregateCounts?: WorktreeCardProps["aggregateCounts"];
+  ariaRowIndex: number;
 }
 
 const StaticWorktreeRow = React.memo(function StaticWorktreeRow({
@@ -31,6 +32,7 @@ const StaticWorktreeRow = React.memo(function StaticWorktreeRow({
   agentSettings,
   homeDir,
   aggregateCounts,
+  ariaRowIndex,
 }: StaticWorktreeRowProps) {
   const worktreeSnap = useWorktreeStore((state) => state.worktrees.get(worktreeId));
   const worktree = useMemo(
@@ -65,8 +67,16 @@ const StaticWorktreeRow = React.memo(function StaticWorktreeRow({
 
   if (!worktree) return null;
 
+  const isActive = worktreeId === activeWorktreeId;
+
   return (
-    <div role="row" data-worktree-row={worktreeId} tabIndex={-1}>
+    <div
+      role="row"
+      data-worktree-row={worktreeId}
+      tabIndex={-1}
+      aria-rowindex={ariaRowIndex}
+      aria-current={isActive ? "true" : undefined}
+    >
       <div role="gridcell">
         <ErrorBoundary
           variant="component"
@@ -77,7 +87,7 @@ const StaticWorktreeRow = React.memo(function StaticWorktreeRow({
         >
           <WorktreeCard
             worktree={worktree}
-            isActive={worktreeId === activeWorktreeId}
+            isActive={isActive}
             isFocused={worktreeId === focusedWorktreeId}
             isSingleWorktree={totalWorktreeCount === 1}
             aggregateCounts={aggregateCounts}

--- a/src/components/Sidebar/__tests__/SidebarContent.grid.test.ts
+++ b/src/components/Sidebar/__tests__/SidebarContent.grid.test.ts
@@ -242,6 +242,16 @@ describe("Worktree list keyboard grid — issue #6422", () => {
         // aria-current on the row wrapper replaces the string-spliced cue.
         expect(source).not.toContain('" (selected)"');
       });
+
+      it("WorktreeCard sets aria-current on the grid variant (overview modal has no row wrapper)", async () => {
+        const source = await fs.readFile(WORKTREE_CARD_PATH, "utf-8");
+        // Sidebar rows carry aria-current on the role="row" wrapper; the
+        // overview grid has no wrapper, so the card itself must announce
+        // the active state.
+        expect(source).toContain(
+          'aria-current={variant === "grid" && isActive ? "true" : undefined}'
+        );
+      });
     });
 
     describe("grouped-by-type section structure", () => {

--- a/src/components/Sidebar/__tests__/SidebarContent.grid.test.ts
+++ b/src/components/Sidebar/__tests__/SidebarContent.grid.test.ts
@@ -107,8 +107,10 @@ describe("Worktree list keyboard grid — issue #6422", () => {
     });
 
     it('wires gridRef + handlers from the hook into a role="grid" container', () => {
-      expect(source).toContain(
-        "const { gridRef, handleGridKeyDown, handleGridFocusCapture } = useWorktreeGridRovingFocus();"
+      // Hook now takes a scrollContainerRef so PageUp/PageDown can size the page
+      // from the viewport. The destructured return shape is unchanged.
+      expect(source).toMatch(
+        /const \{ gridRef, handleGridKeyDown, handleGridFocusCapture \} =\s*useWorktreeGridRovingFocus\(scrollContainerRef\);/
       );
       expect(source).toContain('role="grid"');
       expect(source).toContain('aria-label="Worktrees"');
@@ -121,9 +123,9 @@ describe("Worktree list keyboard grid — issue #6422", () => {
       const staticSource = await fs.readFile(STATIC_ROW_PATH, "utf-8");
       // The static (pinned/grouped) rows don't go through SortableWorktreeCard,
       // so the row + gridcell roles must be added explicitly here.
-      expect(staticSource).toContain(
-        '<div role="row" data-worktree-row={worktreeId} tabIndex={-1}>'
-      );
+      expect(staticSource).toMatch(/role="row"/);
+      expect(staticSource).toContain("data-worktree-row={worktreeId}");
+      expect(staticSource).toContain("tabIndex={-1}");
       // Ensure the static path also has a gridcell wrapper
       const staticRowMatch = staticSource.match(
         /const StaticWorktreeRow[\s\S]*?<\/div>\s*\)\s*;\s*\}\s*\)\s*;/
@@ -185,6 +187,125 @@ describe("Worktree list keyboard grid — issue #6422", () => {
       );
       expect(blurEffect).toBeTruthy();
       expect(blurEffect?.[0]).toContain("syncRowTabStops");
+    });
+  });
+
+  describe("issue #7212 — APG grid attributes and keyboard model", () => {
+    describe("aria-rowcount / aria-rowindex threading", () => {
+      it("exposes aria-rowcount on the grid container", async () => {
+        const source = await fs.readFile(SIDEBAR_CONTENT_PATH, "utf-8");
+        expect(source).toContain("aria-rowcount={ariaRowCount}");
+      });
+
+      it("computes ariaRowCount including pinned, group header, and data rows", async () => {
+        const source = await fs.readFile(SIDEBAR_CONTENT_PATH, "utf-8");
+        expect(source).toMatch(/const ariaRowCount =/);
+        // Group header rows must contribute to the count (they carry role="row")
+        expect(source).toMatch(
+          /groupedSections[\s\S]*?\.reduce\([\s\S]*?1 \+ s\.worktrees\.length/
+        );
+      });
+
+      it("StaticWorktreeRow applies aria-rowindex to its role='row' div", async () => {
+        const source = await fs.readFile(STATIC_ROW_PATH, "utf-8");
+        expect(source).toContain("aria-rowindex={ariaRowIndex}");
+      });
+
+      it("SortableWorktreeCard applies aria-rowindex to its role='row' div", async () => {
+        const source = await fs.readFile(SORTABLE_CARD_PATH, "utf-8");
+        expect(source).toContain("aria-rowindex={ariaRowIndex}");
+      });
+
+      it("threads ariaRowIndex through SidebarWorktreeRow → SortableWorktreeCard", async () => {
+        const sidebarRowSource = await fs.readFile(
+          path.resolve(__dirname, "../SidebarWorktreeRow.tsx"),
+          "utf-8"
+        );
+        expect(sidebarRowSource).toMatch(/ariaRowIndex:\s*number/);
+        expect(sidebarRowSource).toContain("ariaRowIndex={ariaRowIndex}");
+      });
+    });
+
+    describe("aria-current on the active row", () => {
+      it("StaticWorktreeRow applies aria-current='true' when the row is active", async () => {
+        const source = await fs.readFile(STATIC_ROW_PATH, "utf-8");
+        expect(source).toContain('aria-current={isActive ? "true" : undefined}');
+      });
+
+      it("SortableWorktreeCard applies aria-current='true' when the row is active", async () => {
+        const source = await fs.readFile(SORTABLE_CARD_PATH, "utf-8");
+        expect(source).toContain('aria-current={isActive ? "true" : undefined}');
+      });
+
+      it("removes the (selected) suffix from WorktreeCard's aria-label", async () => {
+        const source = await fs.readFile(WORKTREE_CARD_PATH, "utf-8");
+        // aria-current on the row wrapper replaces the string-spliced cue.
+        expect(source).not.toContain('" (selected)"');
+      });
+    });
+
+    describe("grouped-by-type section structure", () => {
+      let source: string;
+      beforeEach(async () => {
+        source = await fs.readFile(SIDEBAR_CONTENT_PATH, "utf-8");
+      });
+
+      it("wraps grouped sections in role='rowgroup'", () => {
+        expect(source).toContain('role="rowgroup"');
+      });
+
+      it("renders each section header as a role='row' with role='rowheader' inside", () => {
+        // Inside the grouped-sections branch
+        const groupedBranch = source.match(/groupedSections \?\s*\([\s\S]*?\) :\s*\(/);
+        expect(groupedBranch).toBeTruthy();
+        expect(groupedBranch?.[0]).toContain('role="row"');
+        expect(groupedBranch?.[0]).toContain('role="rowheader"');
+        expect(groupedBranch?.[0]).toContain("aria-colspan={1}");
+      });
+
+      it("threads aria-rowindex onto group header rows", () => {
+        const groupedBranch = source.match(/groupedSections \?\s*\([\s\S]*?\) :\s*\(/);
+        expect(groupedBranch?.[0]).toContain("aria-rowindex={headerRowIndex}");
+      });
+    });
+
+    describe("keyboard model — PageUp/PageDown and Ctrl+Home/Ctrl+End", () => {
+      let source: string;
+      beforeEach(async () => {
+        source = await fs.readFile(HOOK_PATH, "utf-8");
+      });
+
+      it("accepts a scrollContainerRef parameter so PageUp/PageDown can size the page from viewport height", () => {
+        expect(source).toMatch(/scrollContainerRef\??:\s*React\.RefObject<HTMLDivElement \| null>/);
+      });
+
+      it("handles PageDown and PageUp in the list-mode switch", () => {
+        expect(source).toMatch(/case "PageDown"/);
+        expect(source).toMatch(/case "PageUp"/);
+      });
+
+      it("computes the page step from viewport height divided by row height", () => {
+        expect(source).toMatch(/computeGridPageSize/);
+      });
+
+      it("allows Ctrl+Home and Ctrl+End through the modifier guard", () => {
+        // The old guard bailed on every Ctrl combo; the new guard whitelists
+        // Home/End so APG's mandatory Ctrl+Home/End shortcuts can fire.
+        expect(source).toMatch(/e\.ctrlKey && e\.key !== "Home" && e\.key !== "End"/);
+      });
+
+      it("clamps ArrowUp/ArrowDown at the grid boundary (no wrap)", () => {
+        // Wrapping let users silently jump from the last row to the first;
+        // APG grid row navigation requires boundary-stop.
+        expect(source).not.toMatch(/%\s*rows\.length/);
+      });
+    });
+
+    describe("SidebarContent passes scrollContainerRef into the roving-focus hook", () => {
+      it("calls useWorktreeGridRovingFocus with the scroll container ref", async () => {
+        const source = await fs.readFile(SIDEBAR_CONTENT_PATH, "utf-8");
+        expect(source).toMatch(/useWorktreeGridRovingFocus\(scrollContainerRef\)/);
+      });
     });
   });
 });

--- a/src/components/Sidebar/useWorktreeGridRovingFocus.ts
+++ b/src/components/Sidebar/useWorktreeGridRovingFocus.ts
@@ -18,8 +18,11 @@ function isElementVisible(el: HTMLElement): boolean {
 }
 
 // Row count to advance per Page key. Read viewport height from the scroll
-// container and divide by the first visible row's height; fall back to 10
-// when sizes aren't measurable yet (initial layout, container detached).
+// container and divide by the height of a row inside that container — pinned
+// rows live outside the scroll viewport and have a different height (e.g. the
+// taller main worktree card), so sampling them would over- or under-count.
+// Fall back to 10 when sizes aren't measurable yet (initial layout, container
+// detached).
 const PAGE_SIZE_FALLBACK = 10;
 function computeGridPageSize(
   container: HTMLElement | null | undefined,
@@ -28,7 +31,8 @@ function computeGridPageSize(
   if (!container || rows.length === 0) return PAGE_SIZE_FALLBACK;
   const viewportHeight = container.clientHeight;
   if (viewportHeight <= 0) return PAGE_SIZE_FALLBACK;
-  const sampleHeight = rows[0]?.getBoundingClientRect().height ?? 0;
+  const scrollableRow = rows.find((row) => container.contains(row)) ?? rows[0];
+  const sampleHeight = scrollableRow?.getBoundingClientRect().height ?? 0;
   if (sampleHeight <= 0) return PAGE_SIZE_FALLBACK;
   return Math.max(1, Math.floor(viewportHeight / sampleHeight));
 }
@@ -326,6 +330,18 @@ export function useWorktreeGridRovingFocus(
         row.focus();
         e.preventDefault();
         e.stopPropagation();
+        return;
+      }
+      // Ctrl+Home / Ctrl+End are grid-level shortcuts even when focus has
+      // descended into a row's action toolbar. Bounce back to list mode and
+      // jump to the first/last row, mirroring the APG grid pattern.
+      if (e.ctrlKey && (e.key === "Home" || e.key === "End")) {
+        const targetRowIdx = e.key === "Home" ? 0 : rows.length - 1;
+        enterListMode(rows, targetRowIdx);
+        e.preventDefault();
+        activeRowIndexRef.current = targetRowIdx;
+        syncRowTabStops(rows, targetRowIdx);
+        rows[targetRowIdx]!.focus();
         return;
       }
       if (e.key === "ArrowUp" || e.key === "ArrowDown") {

--- a/src/components/Sidebar/useWorktreeGridRovingFocus.ts
+++ b/src/components/Sidebar/useWorktreeGridRovingFocus.ts
@@ -17,13 +17,31 @@ function isElementVisible(el: HTMLElement): boolean {
   return el.offsetParent !== null || el.getClientRects().length > 0;
 }
 
+// Row count to advance per Page key. Read viewport height from the scroll
+// container and divide by the first visible row's height; fall back to 10
+// when sizes aren't measurable yet (initial layout, container detached).
+const PAGE_SIZE_FALLBACK = 10;
+function computeGridPageSize(
+  container: HTMLElement | null | undefined,
+  rows: HTMLElement[]
+): number {
+  if (!container || rows.length === 0) return PAGE_SIZE_FALLBACK;
+  const viewportHeight = container.clientHeight;
+  if (viewportHeight <= 0) return PAGE_SIZE_FALLBACK;
+  const sampleHeight = rows[0]?.getBoundingClientRect().height ?? 0;
+  if (sampleHeight <= 0) return PAGE_SIZE_FALLBACK;
+  return Math.max(1, Math.floor(viewportHeight / sampleHeight));
+}
+
 export interface UseWorktreeGridRovingFocusReturn {
   gridRef: React.RefObject<HTMLDivElement | null>;
   handleGridKeyDown: (e: React.KeyboardEvent<HTMLDivElement>) => void;
   handleGridFocusCapture: (e: React.FocusEvent<HTMLDivElement>) => void;
 }
 
-export function useWorktreeGridRovingFocus(): UseWorktreeGridRovingFocusReturn {
+export function useWorktreeGridRovingFocus(
+  scrollContainerRef?: React.RefObject<HTMLDivElement | null>
+): UseWorktreeGridRovingFocusReturn {
   const gridRef = useRef<HTMLDivElement | null>(null);
   const modeRef = useRef<GridMode>("list");
   const activeRowIndexRef = useRef<number>(0);
@@ -219,7 +237,11 @@ export function useWorktreeGridRovingFocus(): UseWorktreeGridRovingFocusReturn {
 
   const handleGridKeyDown = useCallback(
     (e: React.KeyboardEvent<HTMLDivElement>) => {
-      if (e.metaKey || e.altKey || e.ctrlKey) return;
+      if (e.metaKey || e.altKey) return;
+      // Allow Ctrl+Home / Ctrl+End through (mandatory APG grid shortcuts);
+      // bail on every other Ctrl combo so global shortcuts (Ctrl+C, Ctrl+T,
+      // Ctrl+W, …) still reach their handlers.
+      if (e.ctrlKey && e.key !== "Home" && e.key !== "End") return;
 
       const rows = getRows();
       if (rows.length === 0) return;
@@ -257,11 +279,21 @@ export function useWorktreeGridRovingFocus(): UseWorktreeGridRovingFocusReturn {
 
         switch (e.key) {
           case "ArrowDown":
-            newIdx = (currentIdx + 1) % rows.length;
+            newIdx = Math.min(currentIdx + 1, rows.length - 1);
             break;
           case "ArrowUp":
-            newIdx = (currentIdx - 1 + rows.length) % rows.length;
+            newIdx = Math.max(currentIdx - 1, 0);
             break;
+          case "PageDown": {
+            const pageSize = computeGridPageSize(scrollContainerRef?.current, rows);
+            newIdx = Math.min(currentIdx + pageSize, rows.length - 1);
+            break;
+          }
+          case "PageUp": {
+            const pageSize = computeGridPageSize(scrollContainerRef?.current, rows);
+            newIdx = Math.max(currentIdx - pageSize, 0);
+            break;
+          }
           case "Home":
             newIdx = 0;
             break;
@@ -298,11 +330,11 @@ export function useWorktreeGridRovingFocus(): UseWorktreeGridRovingFocusReturn {
       }
       if (e.key === "ArrowUp" || e.key === "ArrowDown") {
         // Up/Down in toolbar mode bounces back to list mode and moves rows.
+        // Boundary-stop (no wrap) so users don't silently jump from the last
+        // row to the first — matches APG grid row navigation.
         enterListMode(rows, rowIdx);
         const nextIdx =
-          e.key === "ArrowDown"
-            ? (rowIdx + 1) % rows.length
-            : (rowIdx - 1 + rows.length) % rows.length;
+          e.key === "ArrowDown" ? Math.min(rowIdx + 1, rows.length - 1) : Math.max(rowIdx - 1, 0);
         e.preventDefault();
         activeRowIndexRef.current = nextIdx;
         syncRowTabStops(rows, nextIdx);
@@ -337,6 +369,7 @@ export function useWorktreeGridRovingFocus(): UseWorktreeGridRovingFocusReturn {
       enterToolbarMode,
       getRowToolbarItems,
       getRows,
+      scrollContainerRef,
       selectRow,
       syncRowTabStops,
       syncToolbarTabStops,

--- a/src/components/Worktree/WorktreeCard.tsx
+++ b/src/components/Worktree/WorktreeCard.tsx
@@ -585,7 +585,7 @@ export function WorktreeCard({
           data-worktree-is-main={isMainWorktree ? "true" : undefined}
           data-resource-status={resourceStatusLabel ?? undefined}
           role={variant === "grid" ? "group" : undefined}
-          aria-label={`Worktree: ${worktree.issueTitle ?? branchLabel}${worktree.issueTitle ? ` (${branchLabel})` : ""}${isActive ? " (selected)" : ""}${worktree.isCurrent ? " (current)" : ""}, Status: ${spineState}${hasChanges ? ", has uncommitted changes" : ""}`}
+          aria-label={`Worktree: ${worktree.issueTitle ?? branchLabel}${worktree.issueTitle ? ` (${branchLabel})` : ""}${worktree.isCurrent ? " (current)" : ""}, Status: ${spineState}${hasChanges ? ", has uncommitted changes" : ""}`}
           onClick={onSelect}
           onDoubleClick={handleDoubleClick}
         >

--- a/src/components/Worktree/WorktreeCard.tsx
+++ b/src/components/Worktree/WorktreeCard.tsx
@@ -585,6 +585,7 @@ export function WorktreeCard({
           data-worktree-is-main={isMainWorktree ? "true" : undefined}
           data-resource-status={resourceStatusLabel ?? undefined}
           role={variant === "grid" ? "group" : undefined}
+          aria-current={variant === "grid" && isActive ? "true" : undefined}
           aria-label={`Worktree: ${worktree.issueTitle ?? branchLabel}${worktree.issueTitle ? ` (${branchLabel})` : ""}${worktree.isCurrent ? " (current)" : ""}, Status: ${spineState}${hasChanges ? ", has uncommitted changes" : ""}`}
           onClick={onSelect}
           onDoubleClick={handleDoubleClick}


### PR DESCRIPTION
## Summary

- ARIA: `aria-rowcount`/`aria-rowindex` on every row, `aria-current` for active state, `role=rowgroup`/`rowheader` on grouped section headers
- Keyboard: boundary-stop arrows, `PageUp`/`PageDown` from viewport height, `Ctrl+Home`/`Ctrl+End` pass-through in both list and toolbar modes
- Replaces the `" (selected)"` suffix spliced into `aria-label` with `aria-current=true` — cleaner and correct

Resolves #7212

## Changes

**ARIA**
- Added `aria-rowcount` to the grid container and `aria-rowindex` to every `role=row` element, including group header rows
- Added `aria-current=true` on the active worktree wrapper in `StaticWorktreeRow` and `SortableWorktreeCard`; also on `WorktreeCard` for the `variant=grid` overview modal so both surfaces carry the same cue
- Removed the appended string that spliced selected state into `aria-label` — `aria-current` is the right mechanism
- Wrapped grouped sections in `role=rowgroup` with `role=row` + `role=rowheader` + `aria-colspan=1` sticky headers

**Keyboard model**
- Relaxed modifier guard to let `Ctrl+Home` and `Ctrl+End` through
- Added `PageUp`/`PageDown` sized from the scroll viewport row height
- Switched `ArrowUp`/`ArrowDown` from modulo wrap to boundary-stop in list and toolbar modes
- Routed `Ctrl+Home`/`Ctrl+End` in toolbar mode to grid row navigation

## Testing

- 17 new source-text assertions in `SidebarContent.grid.test.ts` covering ARIA attributes and keyboard behaviour
- `SortableWorktreeCard.test.tsx` updated to pass new `ariaRowIndex` and `isActive` props
- Existing tests updated for hook signature change
- 45/45 tests pass