### PR TITLE
fix(fleet): polish ribbon a11y and microcopy

### DIFF
--- a/src/components/Fleet/FleetArmingRibbon.tsx
+++ b/src/components/Fleet/FleetArmingRibbon.tsx
@@ -336,6 +336,7 @@ export function FleetArmingRibbon(): ReactElement | null {
       <div
         role="status"
         aria-live="polite"
+        aria-atomic="true"
         className={cn(
           "relative flex items-center gap-3 border-b border-daintree-border px-3 py-2 text-[12px] text-daintree-text",
           // Keep the Fleet surface continuous through confirm-pending so the
@@ -493,7 +494,7 @@ export function FleetArmingRibbon(): ReactElement | null {
                 data-testid="fleet-paste-confirm-send"
                 className="rounded bg-category-amber-subtle border border-category-amber-border px-2 py-0.5 text-category-amber-text transition hover:brightness-110 disabled:cursor-not-allowed disabled:opacity-40 disabled:pointer-events-none"
               >
-                Send anyway
+                Send broadcast
               </button>
             </div>
           ) : (

--- a/src/components/Fleet/FleetCountChip.tsx
+++ b/src/components/Fleet/FleetCountChip.tsx
@@ -205,7 +205,7 @@ export function FleetCountChip({
                       <button
                         type="button"
                         onClick={() => disarmId(id)}
-                        aria-label={`Unarm ${title}`}
+                        aria-label={`Disarm ${title}`}
                         className="inline-flex shrink-0 items-center rounded p-0.5 mr-1 text-daintree-text/50 transition-colors hover:bg-tint/[0.08] hover:text-daintree-text"
                       >
                         <X className="h-3.5 w-3.5" />

--- a/src/components/Fleet/__tests__/FleetArmingRibbon.test.tsx
+++ b/src/components/Fleet/__tests__/FleetArmingRibbon.test.tsx
@@ -172,6 +172,7 @@ describe("FleetArmingRibbon", () => {
     });
     render(<FleetArmingRibbon />);
     expect(screen.queryByTestId("fleet-leading-exit")).toBeNull();
+    expect(screen.getByRole("button", { name: "Send broadcast" })).toBeTruthy();
   });
 
   it("surfaces the cross-worktree count in the chip's visible label", () => {
@@ -279,7 +280,7 @@ describe("FleetArmingRibbon", () => {
     expect(list.textContent).toContain("backend·main");
   });
 
-  it("per-row unarm button in the popover calls disarmId", () => {
+  it("per-row disarm button in the popover calls disarmId", () => {
     seed([
       { ...makeAgent("t1"), title: "frontend·main" } as TerminalInstance,
       { ...makeAgent("t2"), title: "backend·main" } as TerminalInstance,
@@ -287,7 +288,7 @@ describe("FleetArmingRibbon", () => {
     useFleetArmingStore.getState().armIds(["t1", "t2"]);
     render(<FleetArmingRibbon />);
     fireEvent.click(screen.getByTestId("fleet-armed-count-chip"));
-    fireEvent.click(screen.getByLabelText("Unarm frontend·main"));
+    fireEvent.click(screen.getByLabelText("Disarm frontend·main"));
     const armed = useFleetArmingStore.getState().armedIds;
     expect(armed.has("t1")).toBe(false);
     expect(armed.has("t2")).toBe(true);
@@ -345,6 +346,7 @@ describe("FleetArmingRibbon", () => {
     expect(ribbon.getAttribute("data-pending-action")).toBe("restart");
     expect(screen.getByText(/Restart 3 agents\?/)).toBeTruthy();
     expect(screen.getByText(/2 agents will lose their session/)).toBeTruthy();
+    expect(ribbon.getAttribute("aria-atomic")).toBe("true");
   });
 
   it("collapses pending confirmation when the armed set drains", () => {


### PR DESCRIPTION
## Summary
Three small accessibility and microcopy fixes to the fleet ribbon.

- Added `aria-atomic="true"` to the fleet confirm row so screen readers re-read the full status message when target counts change.
- Renamed `Unarm` to `Disarm` in the popover per-pane button `aria-label` to match the action-system canonical label (`disarmId`, "Disarm Terminal", "Disarm All").
- Changed the destructive broadcast confirm button from "Send anyway" to "Send broadcast" -- verb-noun copy per the destructive-button microcopy rule.

Resolves #7207.

## Changes
- `src/components/Fleet/FleetArmingRibbon.tsx` -- added `aria-atomic="true"` on confirm row, changed "Send anyway" to "Send broadcast"
- `src/components/Fleet/FleetCountChip.tsx` -- changed `aria-label` from "Unarm" to "Disarm"
- `src/components/Fleet/__tests__/FleetArmingRibbon.test.tsx` -- updated test assertions for all three fixes

## Testing
All existing fleet ribbon tests pass. Added explicit assertions for `aria-atomic="true"` on the confirm row and the "Send broadcast" button label in the broadcast confirm test.