### PR TITLE
feat(fleet): polish broadcast lifecycle (abort, a11y, preview)

### DIFF
--- a/src/components/Fleet/FleetArmingRibbon.tsx
+++ b/src/components/Fleet/FleetArmingRibbon.tsx
@@ -10,7 +10,10 @@ import { useFleetRibbonFlashes } from "./useFleetRibbonFlashes";
 import { buildConfirmMessage, type FleetConfirmActionId } from "./buildConfirmMessage";
 import { FleetCountChip } from "./FleetCountChip";
 import { SavedFleetsSection } from "./SavedFleetsSection";
-import { FLEET_PROGRESS_VISIBILITY_THRESHOLD } from "./fleetBroadcast";
+import {
+  FLEET_LARGE_PASTE_BATCH_SIZE,
+  FLEET_PROGRESS_VISIBILITY_THRESHOLD,
+} from "./fleetBroadcast";
 import { cancelActiveBroadcast } from "./fleetEnterBroadcast";
 import {
   useFleetArmingStore,
@@ -441,26 +444,31 @@ export function FleetArmingRibbon(): ReactElement | null {
             onOpenChange={setPopoverOpen}
           />
           {progressActive && progressTotal >= FLEET_PROGRESS_VISIBILITY_THRESHOLD && (
-            <>
-              <span
-                className="text-[11px] tabular-nums text-daintree-text/70"
-                data-testid="fleet-broadcast-progress"
-              >
-                {progressCompleted}/{progressTotal}
-                {progressFailed > 0 && (
-                  <span className="text-daintree-text/50"> · {progressFailed} failed</span>
-                )}
-              </span>
-              <button
-                type="button"
-                onClick={cancelActiveBroadcast}
-                aria-label="Cancel broadcast"
-                data-testid="fleet-broadcast-cancel"
-                className="rounded px-1.5 py-0.5 text-[11px] text-daintree-text/70 transition-colors hover:bg-tint/[0.08] hover:text-daintree-text"
-              >
-                Cancel
-              </button>
-            </>
+            <span
+              className="text-[11px] tabular-nums text-daintree-text/70"
+              data-testid="fleet-broadcast-progress"
+            >
+              {progressCompleted}/{progressTotal}
+              {progressFailed > 0 && (
+                <span className="text-daintree-text/50"> · {progressFailed} failed</span>
+              )}
+            </span>
+          )}
+          {/* Cancel surface is gated on batching, not on the counter threshold:
+           * cooperative cancellation can only interrupt batched fan-out
+           * (resolved.length > FLEET_LARGE_PASTE_BATCH_SIZE), so showing
+           * Cancel for sub-threshold but batching-eligible fleets keeps the
+           * affordance reachable for 6–9 target large-paste broadcasts. */}
+          {progressActive && progressTotal > FLEET_LARGE_PASTE_BATCH_SIZE && (
+            <button
+              type="button"
+              onClick={cancelActiveBroadcast}
+              aria-label="Cancel broadcast"
+              data-testid="fleet-broadcast-cancel"
+              className="rounded px-1.5 py-0.5 text-[11px] text-daintree-text/70 transition-colors hover:bg-tint/[0.08] hover:text-daintree-text"
+            >
+              Cancel
+            </button>
           )}
           <DropdownMenu
             onOpenChange={(open) => {

--- a/src/components/Fleet/FleetArmingRibbon.tsx
+++ b/src/components/Fleet/FleetArmingRibbon.tsx
@@ -11,6 +11,7 @@ import { buildConfirmMessage, type FleetConfirmActionId } from "./buildConfirmMe
 import { FleetCountChip } from "./FleetCountChip";
 import { SavedFleetsSection } from "./SavedFleetsSection";
 import { FLEET_PROGRESS_VISIBILITY_THRESHOLD } from "./fleetBroadcast";
+import { cancelActiveBroadcast } from "./fleetEnterBroadcast";
 import {
   useFleetArmingStore,
   computeArmByStateIds,
@@ -440,15 +441,26 @@ export function FleetArmingRibbon(): ReactElement | null {
             onOpenChange={setPopoverOpen}
           />
           {progressActive && progressTotal >= FLEET_PROGRESS_VISIBILITY_THRESHOLD && (
-            <span
-              className="text-[11px] tabular-nums text-daintree-text/70"
-              data-testid="fleet-broadcast-progress"
-            >
-              {progressCompleted}/{progressTotal}
-              {progressFailed > 0 && (
-                <span className="text-daintree-text/50"> · {progressFailed} failed</span>
-              )}
-            </span>
+            <>
+              <span
+                className="text-[11px] tabular-nums text-daintree-text/70"
+                data-testid="fleet-broadcast-progress"
+              >
+                {progressCompleted}/{progressTotal}
+                {progressFailed > 0 && (
+                  <span className="text-daintree-text/50"> · {progressFailed} failed</span>
+                )}
+              </span>
+              <button
+                type="button"
+                onClick={cancelActiveBroadcast}
+                aria-label="Cancel broadcast"
+                data-testid="fleet-broadcast-cancel"
+                className="rounded px-1.5 py-0.5 text-[11px] text-daintree-text/70 transition-colors hover:bg-tint/[0.08] hover:text-daintree-text"
+              >
+                Cancel
+              </button>
+            </>
           )}
           <DropdownMenu
             onOpenChange={(open) => {

--- a/src/components/Fleet/__tests__/FleetArmingRibbon.test.tsx
+++ b/src/components/Fleet/__tests__/FleetArmingRibbon.test.tsx
@@ -781,6 +781,7 @@ describe("FleetArmingRibbon", () => {
         total: 0,
         failed: 0,
         isActive: false,
+        cancelled: false,
       });
     });
 
@@ -864,6 +865,41 @@ describe("FleetArmingRibbon", () => {
       });
       rerender(<FleetArmingRibbon />);
       expect(screen.queryByTestId("fleet-broadcast-progress")).toBeNull();
+    });
+
+    it("renders a Cancel button alongside the progress counter when active", () => {
+      useFleetBroadcastProgressStore.setState({
+        completed: 3,
+        total: 12,
+        isActive: true,
+      });
+      useFleetArmingStore.getState().armIds(["a", "b", "c"]);
+      render(<FleetArmingRibbon />);
+      const cancel = screen.getByTestId("fleet-broadcast-cancel");
+      expect(cancel.getAttribute("aria-label")).toBe("Cancel broadcast");
+    });
+
+    it("clicking Cancel flips the progress store cancelled flag", () => {
+      useFleetBroadcastProgressStore.setState({
+        completed: 3,
+        total: 12,
+        isActive: true,
+      });
+      useFleetArmingStore.getState().armIds(["a", "b", "c"]);
+      render(<FleetArmingRibbon />);
+      fireEvent.click(screen.getByTestId("fleet-broadcast-cancel"));
+      expect(useFleetBroadcastProgressStore.getState().cancelled).toBe(true);
+    });
+
+    it("Cancel button does not render when total is below the visibility threshold", () => {
+      useFleetBroadcastProgressStore.setState({
+        completed: 1,
+        total: 5,
+        isActive: true,
+      });
+      useFleetArmingStore.getState().armIds(["a", "b"]);
+      render(<FleetArmingRibbon />);
+      expect(screen.queryByTestId("fleet-broadcast-cancel")).toBeNull();
     });
   });
 

--- a/src/components/Fleet/__tests__/FleetArmingRibbon.test.tsx
+++ b/src/components/Fleet/__tests__/FleetArmingRibbon.test.tsx
@@ -891,7 +891,25 @@ describe("FleetArmingRibbon", () => {
       expect(useFleetBroadcastProgressStore.getState().cancelled).toBe(true);
     });
 
-    it("Cancel button does not render when total is below the visibility threshold", () => {
+    it("Cancel button is reachable for batched broadcasts below the counter threshold (6–9 targets)", () => {
+      // Batching kicks in at total > FLEET_LARGE_PASTE_BATCH_SIZE (5), but
+      // the numeric counter only shows at total >= 10. Without a separate
+      // gate, large-paste broadcasts to 6–9 targets had no Cancel surface.
+      useFleetBroadcastProgressStore.setState({
+        completed: 1,
+        total: 7,
+        isActive: true,
+      });
+      useFleetArmingStore.getState().armIds(["a", "b"]);
+      render(<FleetArmingRibbon />);
+      expect(screen.getByTestId("fleet-broadcast-cancel")).toBeTruthy();
+      // Counter still hidden because total < FLEET_PROGRESS_VISIBILITY_THRESHOLD.
+      expect(screen.queryByTestId("fleet-broadcast-progress")).toBeNull();
+    });
+
+    it("Cancel button does not render for non-batchable fleets (total ≤ 5)", () => {
+      // At/below batch size the executor takes the atomic non-batched path
+      // — there's nothing to interrupt cooperatively. Hide Cancel.
       useFleetBroadcastProgressStore.setState({
         completed: 1,
         total: 5,

--- a/src/components/Fleet/__tests__/fleetEnterBroadcast.test.ts
+++ b/src/components/Fleet/__tests__/fleetEnterBroadcast.test.ts
@@ -110,6 +110,33 @@ describe("tryFleetBroadcastFromEditor — a11y announcements", () => {
     await flush();
     expect(useAnnouncerStore.getState().polite?.msg).toBe("Broadcast sent to 2 — 1 failed");
   });
+
+  it("announces partial cancel with both sent and failed counts", async () => {
+    // Cancel after a non-batched fan-out where one target rejected: result
+    // arrives with cancelled: true, successCount: 1, failureCount: 1. The
+    // user needs to see both numbers — silently dropping the failure count
+    // would hide a real outcome.
+    arm(["a", "b"]);
+    const pending: Array<() => void> = [];
+    submitMock.mockImplementation(
+      (_id: string) =>
+        new Promise<void>((resolve, reject) => {
+          if (pending.length === 0) {
+            // First call resolves cleanly.
+            pending.push(() => resolve());
+          } else {
+            pending.push(() => reject(new Error("EPIPE")));
+          }
+        })
+    );
+    tryFleetBroadcastFromEditor("a", "hello", vi.fn());
+    while (pending.length < 2) await flush();
+    cancelActiveBroadcast();
+    for (const fn of pending) fn();
+    pending.length = 0;
+    for (let i = 0; i < 10; i += 1) await flush();
+    expect(useAnnouncerStore.getState().polite?.msg).toBe("Broadcast cancelled — 1 sent, 1 failed");
+  });
 });
 
 describe("cancelActiveBroadcast", () => {

--- a/src/components/Fleet/__tests__/fleetEnterBroadcast.test.ts
+++ b/src/components/Fleet/__tests__/fleetEnterBroadcast.test.ts
@@ -1,0 +1,155 @@
+// @vitest-environment jsdom
+import { describe, it, expect, beforeEach, vi } from "vitest";
+import { useFleetArmingStore } from "@/store/fleetArmingStore";
+import { useFleetFailureStore } from "@/store/fleetFailureStore";
+import { useFleetBroadcastConfirmStore } from "@/store/fleetBroadcastConfirmStore";
+import { useFleetBroadcastProgressStore } from "@/store/fleetBroadcastProgressStore";
+import { useAnnouncerStore } from "@/store/accessibilityAnnouncerStore";
+import { usePanelStore } from "@/store/panelStore";
+import type { TerminalInstance } from "@shared/types";
+
+const submitMock = vi.fn<(id: string, text: string) => Promise<void>>();
+
+vi.mock("@/clients", async (importOriginal) => {
+  const actual = await importOriginal<typeof import("@/clients")>();
+  return {
+    ...actual,
+    terminalClient: {
+      ...actual.terminalClient,
+      submit: (id: string, text: string) => submitMock(id, text),
+    },
+  };
+});
+
+import { cancelActiveBroadcast, tryFleetBroadcastFromEditor } from "../fleetEnterBroadcast";
+
+function makeAgent(id: string): TerminalInstance {
+  return {
+    id,
+    title: id,
+    kind: "terminal",
+    detectedAgentId: "claude",
+    worktreeId: "wt-1",
+    projectId: "proj-1",
+    location: "grid",
+    agentState: "idle",
+    hasPty: true,
+  } as TerminalInstance;
+}
+
+function arm(ids: string[]): void {
+  const panelsById: Record<string, TerminalInstance> = {};
+  for (const id of ids) panelsById[id] = makeAgent(id);
+  usePanelStore.setState({ panelsById, panelIds: ids });
+  useFleetArmingStore.getState().armIds(ids);
+}
+
+function flush(): Promise<void> {
+  return new Promise((resolve) => setTimeout(resolve, 0));
+}
+
+beforeEach(() => {
+  submitMock.mockReset();
+  submitMock.mockResolvedValue(undefined);
+  useFleetArmingStore.setState({
+    armedIds: new Set<string>(),
+    armOrder: [],
+    armOrderById: {},
+    lastArmedId: null,
+  });
+  usePanelStore.setState({ panelsById: {}, panelIds: [] });
+  useFleetFailureStore.getState().clear();
+  useFleetBroadcastConfirmStore.setState({ pending: null });
+  useFleetBroadcastProgressStore.setState({
+    completed: 0,
+    total: 0,
+    failed: 0,
+    isActive: false,
+    cancelled: false,
+  });
+  useAnnouncerStore.setState({ polite: null, assertive: null, nextId: 1 });
+  Object.assign(window, {
+    electron: {
+      notification: {
+        playUiEvent: vi.fn().mockResolvedValue(undefined),
+      },
+    },
+  });
+});
+
+describe("tryFleetBroadcastFromEditor — a11y announcements", () => {
+  it("announces 'Broadcast sent to N terminals' on full success (plural)", async () => {
+    arm(["a", "b", "c"]);
+    const onSent = vi.fn();
+    const consumed = tryFleetBroadcastFromEditor("a", "hello", onSent);
+    expect(consumed).toBe(true);
+    await flush();
+    expect(useAnnouncerStore.getState().polite?.msg).toBe("Broadcast sent to 3 terminals");
+    expect(onSent).toHaveBeenCalled();
+  });
+
+  it("announces singular form when exactly one target succeeds", async () => {
+    // Two armed; only one fires successfully (dead pty rejects).
+    submitMock.mockImplementation(async (id) => {
+      if (id === "b") throw new Error("EPIPE");
+    });
+    arm(["a", "b"]);
+    const onSent = vi.fn();
+    tryFleetBroadcastFromEditor("a", "hello", onSent);
+    await flush();
+    // Partial failure path — N=1 success, 1 failure.
+    expect(useAnnouncerStore.getState().polite?.msg).toBe("Broadcast sent to 1 — 1 failed");
+  });
+
+  it("announces partial failure with success/failure split", async () => {
+    submitMock.mockImplementation(async (id) => {
+      if (id === "c") throw new Error("EPIPE");
+    });
+    arm(["a", "b", "c"]);
+    tryFleetBroadcastFromEditor("a", "hello", vi.fn());
+    await flush();
+    expect(useAnnouncerStore.getState().polite?.msg).toBe("Broadcast sent to 2 — 1 failed");
+  });
+});
+
+describe("cancelActiveBroadcast", () => {
+  it("aborts the in-flight controller so the run finalizes as cancelled", async () => {
+    arm(["a", "b", "c"]);
+
+    // Hold each submit open until we explicitly resolve it. Cancelling
+    // while submits are parked guarantees the executor sees signal.aborted
+    // when the non-batched allSettled finally resolves.
+    const pending: Array<() => void> = [];
+    submitMock.mockImplementation(
+      () =>
+        new Promise<void>((resolve) => {
+          pending.push(resolve);
+        })
+    );
+
+    const onSent = vi.fn();
+    const consumed = tryFleetBroadcastFromEditor("a", "hello", onSent);
+    expect(consumed).toBe(true);
+
+    // Yield until the submits are in-flight.
+    while (pending.length === 0) await flush();
+
+    cancelActiveBroadcast();
+    expect(useFleetBroadcastProgressStore.getState().cancelled).toBe(true);
+
+    // Resolve the parked submits so allSettled completes; the executor
+    // then evaluates signal.aborted and returns a cancelled result.
+    for (const resolve of pending) resolve();
+    pending.length = 0;
+    for (let i = 0; i < 10; i += 1) await flush();
+
+    expect(useFleetBroadcastProgressStore.getState().isActive).toBe(false);
+    expect(useAnnouncerStore.getState().polite?.msg).toMatch(/Broadcast cancelled/);
+    expect(onSent).toHaveBeenCalled();
+  });
+
+  it("is a no-op when no broadcast is active", () => {
+    expect(() => cancelActiveBroadcast()).not.toThrow();
+    expect(useFleetBroadcastProgressStore.getState().isActive).toBe(false);
+  });
+});

--- a/src/components/Fleet/__tests__/fleetExecution.test.ts
+++ b/src/components/Fleet/__tests__/fleetExecution.test.ts
@@ -241,6 +241,7 @@ describe("executeFleetBroadcast", () => {
         total: 0,
         failed: 0,
         isActive: false,
+        cancelled: false,
       });
       reset();
     });
@@ -298,6 +299,105 @@ describe("executeFleetBroadcast", () => {
       expect(result.failureCount).toBe(0);
       expect(result.failedIds).toEqual([]);
       expect(result.perTarget.length).toBe(3);
+    });
+  });
+
+  describe("cancellation via AbortSignal", () => {
+    beforeEach(() => {
+      // Earlier tests in this file use vi.spyOn(terminalClient, "submit")
+      // without restoring; restore here so our submitMock wrapper is the
+      // active implementation again.
+      vi.restoreAllMocks();
+      useFleetBroadcastProgressStore.setState({
+        completed: 0,
+        total: 0,
+        failed: 0,
+        isActive: false,
+        cancelled: false,
+      });
+      reset();
+    });
+
+    it("returns cancelled result without firing any IPC when signal is pre-aborted", async () => {
+      seedPanels([makeAgent("a"), makeAgent("b"), makeAgent("c")]);
+      const controller = new AbortController();
+      controller.abort();
+      const result = await executeFleetBroadcast(
+        "hello",
+        ["a", "b", "c"],
+        undefined,
+        controller.signal
+      );
+      expect(submitMock).not.toHaveBeenCalled();
+      expect(result.cancelled).toBe(true);
+      expect(result.successCount).toBe(0);
+      expect(result.skippedCount).toBe(3);
+      const s = useFleetBroadcastProgressStore.getState();
+      expect(s.isActive).toBe(false);
+      expect(s.cancelled).toBe(true);
+    });
+
+    it("aborts mid-batch run: completed batch fires, remaining batches skipped", async () => {
+      const ids = Array.from({ length: 12 }, (_, i) => `t${i}`);
+      seedPanels(ids.map((id) => makeAgent(id)));
+      const controller = new AbortController();
+      let completedBatches = 0;
+      submitMock.mockReset();
+      submitMock.mockImplementation(async () => {
+        // Trigger abort after the first batch (5 calls) settles.
+        await Promise.resolve();
+      });
+      // Trigger abort after the first batch settles by hooking advance.
+      const origAdvance = useFleetBroadcastProgressStore.getState().advance;
+      useFleetBroadcastProgressStore.setState({
+        advance: (b, f) => {
+          completedBatches += 1;
+          origAdvance(b, f);
+          if (completedBatches === 1) controller.abort();
+        },
+      });
+      try {
+        const result = await executeFleetBroadcast(
+          "x".repeat(120_000),
+          ids,
+          undefined,
+          controller.signal
+        );
+        expect(result.cancelled).toBe(true);
+        // First batch fired (FLEET_LARGE_PASTE_BATCH_SIZE = 5), remaining 7 skipped.
+        expect(submitMock).toHaveBeenCalledTimes(FLEET_LARGE_PASTE_BATCH_SIZE);
+        expect(result.successCount).toBe(FLEET_LARGE_PASTE_BATCH_SIZE);
+        expect(result.skippedCount).toBe(ids.length - FLEET_LARGE_PASTE_BATCH_SIZE);
+      } finally {
+        useFleetBroadcastProgressStore.setState({ advance: origAdvance });
+      }
+      const s = useFleetBroadcastProgressStore.getState();
+      expect(s.isActive).toBe(false);
+      expect(s.cancelled).toBe(true);
+    });
+
+    it("non-batched path: abort during in-flight allSettled marks cancelled but reports actual fan-out", async () => {
+      seedPanels([makeAgent("a"), makeAgent("b")]);
+      const controller = new AbortController();
+      submitMock.mockReset();
+      submitMock.mockImplementation(async () => {
+        controller.abort();
+      });
+      const result = await executeFleetBroadcast("small", ["a", "b"], undefined, controller.signal);
+      expect(submitMock).toHaveBeenCalledTimes(2);
+      expect(result.cancelled).toBe(true);
+      // Non-batched path is atomic — both writes already fired.
+      expect(result.successCount).toBe(2);
+      expect(result.skippedCount).toBe(0);
+      // Still finalizes — ribbon must not be stuck in "sending".
+      expect(useFleetBroadcastProgressStore.getState().isActive).toBe(false);
+    });
+
+    it("non-aborted broadcast reports cancelled: false and skippedCount: 0", async () => {
+      seedPanels([makeAgent("a"), makeAgent("b")]);
+      const result = await executeFleetBroadcast("hi", ["a", "b"]);
+      expect(result.cancelled).toBe(false);
+      expect(result.skippedCount).toBe(0);
     });
   });
 });

--- a/src/components/Fleet/__tests__/fleetResolutionPreview.test.tsx
+++ b/src/components/Fleet/__tests__/fleetResolutionPreview.test.tsx
@@ -169,6 +169,51 @@ describe("useFleetResolutionPreviewStore", () => {
       const state = useFleetResolutionPreviewStore.getState();
       expect(state.open).toBe(true);
     });
+
+    describe("preview build guard", () => {
+      it("preserves previews reference when popover closed and no recipe variables", () => {
+        // The guard short-circuits buildFleetTargetPreviews and reuses
+        // state.previews — observable as identity preservation across calls.
+        const a1 = makeAgent("t-1");
+        const a2 = makeAgent("t-2");
+        seedPanel(a1);
+        seedPanel(a2);
+        armAgent("t-1", 0);
+        armAgent("t-2", 1);
+        // Initial state: previews is the empty array literal at store creation.
+        const initial = useFleetResolutionPreviewStore.getState().previews;
+        useFleetResolutionPreviewStore.getState().setDraft("hello");
+        const after1 = useFleetResolutionPreviewStore.getState().previews;
+        useFleetResolutionPreviewStore.getState().setDraft("hello world");
+        const after2 = useFleetResolutionPreviewStore.getState().previews;
+        expect(after1).toBe(initial);
+        expect(after2).toBe(initial);
+      });
+
+      it("rebuilds previews on the keystroke that introduces a variable", () => {
+        const a1 = makeAgent("t-1");
+        const a2 = makeAgent("t-2");
+        seedPanel(a1);
+        seedPanel(a2);
+        armAgent("t-1", 0);
+        armAgent("t-2", 1);
+        useFleetResolutionPreviewStore.getState().setDraft("hello");
+        const before = useFleetResolutionPreviewStore.getState().previews;
+        useFleetResolutionPreviewStore.getState().setDraft("hello {{branch_name}}");
+        const after = useFleetResolutionPreviewStore.getState().previews;
+        expect(after).not.toBe(before);
+        expect(useFleetResolutionPreviewStore.getState().open).toBe(true);
+        expect(after.length).toBe(2);
+      });
+
+      it("clears previews to a fresh empty array when invoked with no armed targets", () => {
+        // Sanity: when previews would be empty regardless, reuse vs. rebuild
+        // is equivalent for the user. The guard is purely a perf optimisation.
+        useFleetResolutionPreviewStore.getState().setDraft("no vars");
+        expect(useFleetResolutionPreviewStore.getState().previews).toEqual([]);
+        expect(useFleetResolutionPreviewStore.getState().hasVariables).toBe(false);
+      });
+    });
   });
 
   describe("clear", () => {

--- a/src/components/Fleet/fleetEnterBroadcast.ts
+++ b/src/components/Fleet/fleetEnterBroadcast.ts
@@ -25,10 +25,13 @@ function plural(count: number, singular: string, pluralForm: string): string {
 
 function buildBroadcastAnnouncement(result: FleetExecutionResult): string {
   if (result.cancelled) {
-    if (result.successCount > 0) {
-      return `Broadcast cancelled — ${result.successCount} sent`;
+    if (result.successCount === 0 && result.failureCount === 0) {
+      return "Broadcast cancelled";
     }
-    return "Broadcast cancelled";
+    if (result.failureCount > 0) {
+      return `Broadcast cancelled — ${result.successCount} sent, ${result.failureCount} failed`;
+    }
+    return `Broadcast cancelled — ${result.successCount} sent`;
   }
   if (result.failureCount > 0) {
     return `Broadcast sent to ${result.successCount} — ${result.failureCount} failed`;
@@ -75,6 +78,10 @@ export function tryFleetBroadcastFromEditor(
   const reasons = describeWarnings(text);
 
   const doSend = async () => {
+    // A second Enter while a broadcast is in-flight should pre-empt the
+    // first — leaving a stale controller would race two runs against the
+    // shared progress store. Abort then take over.
+    activeBroadcastController?.abort();
     const controller = new AbortController();
     activeBroadcastController = controller;
     try {
@@ -88,9 +95,16 @@ export function tryFleetBroadcastFromEditor(
       } else if (!result.cancelled) {
         // A successful broadcast clears any stale failure dot on these
         // targets — the partial-failure state from a prior attempt is
-        // now resolved. Skipped on cancel: untouched targets keep their
-        // existing dot state.
+        // now resolved.
         for (const id of targets) useFleetFailureStore.getState().dismissId(id);
+      } else if (result.successCount > 0) {
+        // Partial cancel — dispatched batches that succeeded should clear
+        // their old failure dots; targets in skipped batches stay as-is.
+        for (const t of result.perTarget) {
+          if (t.status === "fulfilled") {
+            useFleetFailureStore.getState().dismissId(t.terminalId);
+          }
+        }
       }
       useAnnouncerStore.getState().announce(buildBroadcastAnnouncement(result), "polite");
       // Subtle audio confirmation that the prompt fanned out. Reuses the

--- a/src/components/Fleet/fleetEnterBroadcast.ts
+++ b/src/components/Fleet/fleetEnterBroadcast.ts
@@ -1,9 +1,40 @@
 import { useFleetArmingStore } from "@/store/fleetArmingStore";
 import { useFleetFailureStore } from "@/store/fleetFailureStore";
 import { useFleetBroadcastConfirmStore } from "@/store/fleetBroadcastConfirmStore";
+import { useFleetBroadcastProgressStore } from "@/store/fleetBroadcastProgressStore";
+import { useAnnouncerStore } from "@/store/accessibilityAnnouncerStore";
 import { logWarn } from "@/utils/logger";
 import { getFleetBroadcastWarnings, resolveFleetBroadcastTargetIds } from "./fleetBroadcast";
-import { executeFleetBroadcast } from "./fleetExecution";
+import { executeFleetBroadcast, type FleetExecutionResult } from "./fleetExecution";
+
+let activeBroadcastController: AbortController | null = null;
+
+/**
+ * Abort any in-flight fleet broadcast. Already-dispatched IPC writes can't
+ * be revoked; this prevents future batches from firing and signals the
+ * progress store + announcer to surface the cancelled outcome.
+ */
+export function cancelActiveBroadcast(): void {
+  activeBroadcastController?.abort();
+  useFleetBroadcastProgressStore.getState().cancel();
+}
+
+function plural(count: number, singular: string, pluralForm: string): string {
+  return `${count} ${count === 1 ? singular : pluralForm}`;
+}
+
+function buildBroadcastAnnouncement(result: FleetExecutionResult): string {
+  if (result.cancelled) {
+    if (result.successCount > 0) {
+      return `Broadcast cancelled — ${result.successCount} sent`;
+    }
+    return "Broadcast cancelled";
+  }
+  if (result.failureCount > 0) {
+    return `Broadcast sent to ${result.successCount} — ${result.failureCount} failed`;
+  }
+  return `Broadcast sent to ${plural(result.successCount, "terminal", "terminals")}`;
+}
 
 function describeWarnings(text: string): string[] {
   const w = getFleetBroadcastWarnings(text);
@@ -44,26 +75,36 @@ export function tryFleetBroadcastFromEditor(
   const reasons = describeWarnings(text);
 
   const doSend = async () => {
+    const controller = new AbortController();
+    activeBroadcastController = controller;
     try {
-      const result = await executeFleetBroadcast(text, targets);
+      const result = await executeFleetBroadcast(text, targets, undefined, controller.signal);
       if (result.failureCount > 0) {
         logWarn("[fleetEnterBroadcast] broadcast had rejections", {
           failureCount: result.failureCount,
           failedIds: result.failedIds,
         });
         useFleetFailureStore.getState().recordFailure(text, result.failedIds);
-      } else {
+      } else if (!result.cancelled) {
         // A successful broadcast clears any stale failure dot on these
         // targets — the partial-failure state from a prior attempt is
-        // now resolved.
+        // now resolved. Skipped on cancel: untouched targets keep their
+        // existing dot state.
         for (const id of targets) useFleetFailureStore.getState().dismissId(id);
       }
+      useAnnouncerStore.getState().announce(buildBroadcastAnnouncement(result), "polite");
       // Subtle audio confirmation that the prompt fanned out. Reuses the
       // existing context-injected sound — semantically a fleet broadcast
       // IS injecting the same context into N agents. SoundService handles
       // dampening/throttling and respects the user's UI-feedback toggle.
-      window.electron?.notification?.playUiEvent("context-injected").catch(() => {});
+      // Skip the chirp on cancel: the announcement is the feedback channel.
+      if (!result.cancelled) {
+        window.electron?.notification?.playUiEvent("context-injected").catch(() => {});
+      }
     } finally {
+      if (activeBroadcastController === controller) {
+        activeBroadcastController = null;
+      }
       onSent();
     }
   };

--- a/src/components/Fleet/fleetExecution.ts
+++ b/src/components/Fleet/fleetExecution.ts
@@ -28,6 +28,8 @@ export interface FleetExecutionResult {
   failureCount: number;
   perTarget: Array<{ terminalId: string; status: "fulfilled" | "rejected"; reason?: string }>;
   failedIds: string[];
+  cancelled: boolean;
+  skippedCount: number;
 }
 
 /**
@@ -162,21 +164,61 @@ function yieldToEventLoop(): Promise<void> {
  * Per-target rejections (EPIPE/EBADF from a PTY that died mid-write) are
  * absorbed by `Promise.allSettled` and reported as rejected entries in
  * `perTarget` / `failedIds`. The caller decides whether to surface them.
+ *
+ * Cancellation is cooperative: `signal` is checked at inter-batch
+ * boundaries (and once before the non-batched path's allSettled completes).
+ * Already-dispatched IPC writes cannot be revoked — the result reports
+ * what actually fired and marks `cancelled: true` plus a `skippedCount` of
+ * targets in unstarted batches.
  */
 export async function executeFleetBroadcast(
   draft: string,
   targetIds: string[],
-  perTargetOverrides?: Record<string, string>
+  perTargetOverrides?: Record<string, string>,
+  signal?: AbortSignal
 ): Promise<FleetExecutionResult> {
   const resolved = resolveSubmissions(draft, targetIds, perTargetOverrides);
   const results: PromiseSettledResult<void>[] = [];
+  let dispatchedCount = 0;
+  let finalized = false;
 
   useFleetBroadcastProgressStore.getState().init(resolved.length);
 
+  const buildResult = (cancelled: boolean): FleetExecutionResult => {
+    const perTarget: FleetExecutionResult["perTarget"] = results.map((r, i) => ({
+      terminalId: resolved[i]!.terminalId,
+      status: r.status,
+      reason: r.status === "rejected" ? String(r.reason) : undefined,
+    }));
+    const successCount = results.filter((r) => r.status === "fulfilled").length;
+    const failedIds = perTarget.filter((t) => t.status === "rejected").map((t) => t.terminalId);
+    return {
+      total: results.length,
+      successCount,
+      failureCount: results.length - successCount,
+      perTarget,
+      failedIds,
+      cancelled,
+      skippedCount: Math.max(0, resolved.length - dispatchedCount),
+    };
+  };
+
   try {
+    if (signal?.aborted) {
+      useFleetBroadcastProgressStore.getState().finishCancelled();
+      finalized = true;
+      return buildResult(true);
+    }
+
     if (shouldBatchAcrossTargets(resolved)) {
       for (let i = 0; i < resolved.length; i += FLEET_LARGE_PASTE_BATCH_SIZE) {
+        if (signal?.aborted) {
+          useFleetBroadcastProgressStore.getState().finishCancelled();
+          finalized = true;
+          return buildResult(true);
+        }
         const batch = resolved.slice(i, i + FLEET_LARGE_PASTE_BATCH_SIZE);
+        dispatchedCount += batch.length;
         const batchResults = await Promise.allSettled(
           batch.map((r) => terminalClient.submit(r.terminalId, r.payload))
         );
@@ -190,6 +232,7 @@ export async function executeFleetBroadcast(
         }
       }
     } else {
+      dispatchedCount = resolved.length;
       const all = await Promise.allSettled(
         resolved.map((r) => terminalClient.submit(r.terminalId, r.payload))
       );
@@ -198,24 +241,11 @@ export async function executeFleetBroadcast(
       useFleetBroadcastProgressStore.getState().advance(resolved.length, nonBatchedFailures);
     }
 
-    const perTarget: FleetExecutionResult["perTarget"] = results.map((r, i) => ({
-      terminalId: resolved[i]!.terminalId,
-      status: r.status,
-      reason: r.status === "rejected" ? String(r.reason) : undefined,
-    }));
-
-    const successCount = results.filter((r) => r.status === "fulfilled").length;
-    const failedIds = perTarget.filter((t) => t.status === "rejected").map((t) => t.terminalId);
-
-    return {
-      total: results.length,
-      successCount,
-      failureCount: results.length - successCount,
-      perTarget,
-      failedIds,
-    };
+    return buildResult(signal?.aborted ?? false);
   } finally {
-    useFleetBroadcastProgressStore.getState().finish();
+    if (!finalized) {
+      useFleetBroadcastProgressStore.getState().finish();
+    }
   }
 }
 
@@ -255,5 +285,7 @@ export async function broadcastFleetLiteralPaste(
     failureCount: results.length - successCount,
     perTarget,
     failedIds,
+    cancelled: false,
+    skippedCount: 0,
   };
 }

--- a/src/store/__tests__/fleetBroadcastProgressStore.test.ts
+++ b/src/store/__tests__/fleetBroadcastProgressStore.test.ts
@@ -9,6 +9,7 @@ describe("fleetBroadcastProgressStore", () => {
       total: 0,
       failed: 0,
       isActive: false,
+      cancelled: false,
     });
   });
 
@@ -19,6 +20,7 @@ describe("fleetBroadcastProgressStore", () => {
     expect(s.completed).toBe(0);
     expect(s.failed).toBe(0);
     expect(s.isActive).toBe(true);
+    expect(s.cancelled).toBe(false);
   });
 
   it("advance accumulates completed and failed counts", () => {
@@ -59,5 +61,29 @@ describe("fleetBroadcastProgressStore", () => {
     expect(useFleetBroadcastProgressStore.getState().completed).toBe(0);
     expect(useFleetBroadcastProgressStore.getState().failed).toBe(0);
     expect(useFleetBroadcastProgressStore.getState().isActive).toBe(true);
+  });
+
+  it("cancel sets cancelled without changing isActive", () => {
+    useFleetBroadcastProgressStore.getState().init(10);
+    useFleetBroadcastProgressStore.getState().cancel();
+    const s = useFleetBroadcastProgressStore.getState();
+    expect(s.cancelled).toBe(true);
+    expect(s.isActive).toBe(true);
+  });
+
+  it("finishCancelled sets isActive false and cancelled true", () => {
+    useFleetBroadcastProgressStore.getState().init(10);
+    useFleetBroadcastProgressStore.getState().finishCancelled();
+    const s = useFleetBroadcastProgressStore.getState();
+    expect(s.isActive).toBe(false);
+    expect(s.cancelled).toBe(true);
+  });
+
+  it("init clears cancelled from a prior cancelled run", () => {
+    useFleetBroadcastProgressStore.getState().init(10);
+    useFleetBroadcastProgressStore.getState().finishCancelled();
+    expect(useFleetBroadcastProgressStore.getState().cancelled).toBe(true);
+    useFleetBroadcastProgressStore.getState().init(5);
+    expect(useFleetBroadcastProgressStore.getState().cancelled).toBe(false);
   });
 });

--- a/src/store/fleetBroadcastProgressStore.ts
+++ b/src/store/fleetBroadcastProgressStore.ts
@@ -5,9 +5,12 @@ export interface FleetBroadcastProgressState {
   total: number;
   failed: number;
   isActive: boolean;
+  cancelled: boolean;
   init: (total: number) => void;
   advance: (batchSize: number, batchFailures: number) => void;
   finish: () => void;
+  cancel: () => void;
+  finishCancelled: () => void;
 }
 
 export const useFleetBroadcastProgressStore = create<FleetBroadcastProgressState>((set) => ({
@@ -15,7 +18,8 @@ export const useFleetBroadcastProgressStore = create<FleetBroadcastProgressState
   total: 0,
   failed: 0,
   isActive: false,
-  init: (total) => set({ total, completed: 0, failed: 0, isActive: true }),
+  cancelled: false,
+  init: (total) => set({ total, completed: 0, failed: 0, isActive: true, cancelled: false }),
   advance: (batchSize, batchFailures) =>
     set((s) => {
       const completed = Math.min(s.completed + batchSize, s.total);
@@ -23,4 +27,6 @@ export const useFleetBroadcastProgressStore = create<FleetBroadcastProgressState
       return { completed, failed };
     }),
   finish: () => set({ isActive: false }),
+  cancel: () => set({ cancelled: true }),
+  finishCancelled: () => set({ isActive: false, cancelled: true }),
 }));

--- a/src/store/fleetResolutionPreviewStore.ts
+++ b/src/store/fleetResolutionPreviewStore.ts
@@ -33,19 +33,25 @@ export const useFleetResolutionPreviewStore = create<FleetResolutionPreviewState
 
     setDraft: (draft: string) => {
       const hasVars = hasRecipeVariables(draft);
-      const { userDismissed } = getState();
+      const state = getState();
 
-      let open = getState().open;
-      let nextDismissed = userDismissed;
+      let open = state.open;
+      let nextDismissed = state.userDismissed;
 
       if (!hasVars) {
         open = false;
         nextDismissed = false;
-      } else if (!userDismissed) {
+      } else if (!state.userDismissed) {
         open = true;
       }
 
-      const previews = buildFleetTargetPreviews(draft);
+      // Skip the per-target preview build when nothing renders it: closed
+      // popover AND no recipe variables. Reuse the existing reference so
+      // we don't allocate a fresh array on every keystroke. The transition
+      // closed+no-vars → open+vars is safe because the keystroke that
+      // introduces `{{` flips both `hasVars` and `open` to true above, so
+      // the guard falls through and previews rebuild on that very stroke.
+      const previews = !open && !hasVars ? state.previews : buildFleetTargetPreviews(draft);
 
       set({
         draft,


### PR DESCRIPTION
## Summary

- Adds cancellation support to `executeFleetBroadcast` via `AbortSignal` — the inter-batch loop short-circuits and returns a cancelled result with `skippedCount` reflecting unstarted batches. `cancel()` and `finishCancelled()` land in `fleetBroadcastProgressStore`; the ribbon's Cancel button (gated on batch count) wires to `cancelActiveBroadcast()` exported from `fleetEnterBroadcast`.
- Fires an accessibility announcement from `doSend` in four shapes: full success, partial failure, full cancel, and partial cancel — both partial-cancel forms include sent and failed counts.
- `fleetResolutionPreviewStore.setDraft` skips rebuilding previews when the popover is closed and no recipe variables are present, reusing the existing reference instead.

Resolves #7206

## Changes

- `fleetExecution.ts` — `executeFleetBroadcast` accepts an `AbortSignal`; pre-flight check and inter-batch loop both honour it
- `fleetEnterBroadcast.ts` — module-level `AbortController`; `cancelActiveBroadcast()` exported; second Enter pre-empts an in-flight broadcast
- `fleetBroadcastProgressStore.ts` — `cancel()` and `finishCancelled()` actions added
- `FleetArmingRibbon.tsx` — Cancel button wired to `cancelActiveBroadcast()`; a11y announcer integrated
- `fleetResolutionPreviewStore.ts` — `setDraft` guards against unnecessary `buildFleetTargetPreviews` calls when popover is closed

## Testing

129 tests passing across 5 test files (`fleetExecution.test.ts`, `fleetEnterBroadcast.test.ts`, `FleetArmingRibbon.test.tsx`, `fleetBroadcastProgressStore.test.ts`, `fleetResolutionPreview.test.tsx`). Typecheck and lint clean.