### PR TITLE
feat(terminal): polish banner retry, reconnect, and microcopy

### DIFF
--- a/src/components/Terminal/InlineStatusBanner.tsx
+++ b/src/components/Terminal/InlineStatusBanner.tsx
@@ -188,6 +188,7 @@ function InlineStatusBannerComponent({
               aria-busy={action.loading || undefined}
               onClick={(e) => {
                 e.stopPropagation();
+                if (isDisabled) return;
                 action.onClick();
               }}
               className={cn(

--- a/src/components/Terminal/InlineStatusBanner.tsx
+++ b/src/components/Terminal/InlineStatusBanner.tsx
@@ -1,6 +1,7 @@
 import React, { useState, useEffect, useRef, type CSSProperties } from "react";
 import { X } from "lucide-react";
 import { cn } from "@/lib/utils";
+import { Spinner } from "@/components/ui/Spinner";
 import { Tooltip, TooltipContent, TooltipTrigger } from "@/components/ui/tooltip";
 
 type ButtonVariant = "primary" | "accent" | "dismiss" | "danger" | "dangerFilled";
@@ -14,6 +15,8 @@ export interface BannerAction {
   ariaLabel?: string;
   title?: string;
   iconOnly?: boolean;
+  loading?: boolean;
+  disabled?: boolean;
 }
 
 export interface InlineStatusBannerProps {
@@ -174,10 +177,15 @@ function InlineStatusBannerComponent({
           const variant = action.variant ?? "primary";
           const variantClasses = getButtonClasses(variant);
           const variantStyle = getButtonStyle(variant, colorVar);
+          const isDisabled = action.disabled || action.loading;
+          const iconClasses = action.iconOnly ? "w-3.5 h-3.5" : "w-3 h-3";
+          const spinnerSize = action.iconOnly ? "sm" : "xs";
           const buttonEl = (
             <button
               key={action.id}
               type="button"
+              disabled={isDisabled}
+              aria-busy={action.loading || undefined}
               onClick={(e) => {
                 e.stopPropagation();
                 action.onClick();
@@ -187,16 +195,16 @@ function InlineStatusBannerComponent({
                 "outline-hidden focus-visible:outline focus-visible:outline-2 focus-visible:outline-offset-2 focus-visible:outline-daintree-accent",
                 variantClasses,
                 (variant === "danger" || variant === "dangerFilled") &&
-                  "hover:[color:var(--hover-color)] hover:[background:var(--hover-bg)]"
+                  "hover:[color:var(--hover-color)] hover:[background:var(--hover-bg)]",
+                isDisabled && "cursor-not-allowed opacity-60 hover:bg-transparent"
               )}
               style={variantStyle}
               aria-label={action.ariaLabel}
             >
-              {action.icon && (
-                <action.icon
-                  className={action.iconOnly ? "w-3.5 h-3.5" : "w-3 h-3"}
-                  aria-hidden="true"
-                />
+              {action.loading ? (
+                <Spinner size={spinnerSize} />
+              ) : (
+                action.icon && <action.icon className={iconClasses} aria-hidden="true" />
               )}
               {!action.iconOnly && action.label}
             </button>

--- a/src/components/Terminal/ReconnectErrorBanner.tsx
+++ b/src/components/Terminal/ReconnectErrorBanner.tsx
@@ -9,6 +9,7 @@ export interface ReconnectErrorBannerProps {
   error: TerminalReconnectError;
   onDismiss: (id: string) => void;
   onRestart: (id: string) => void;
+  isRestarting?: boolean;
   className?: string;
 }
 
@@ -49,6 +50,7 @@ function ReconnectErrorBannerComponent({
   error,
   onDismiss,
   onRestart,
+  isRestarting = false,
   className,
 }: ReconnectErrorBannerProps) {
   return (
@@ -66,6 +68,7 @@ function ReconnectErrorBannerComponent({
           onClick: () => onRestart(terminalId),
           title: "Restart terminal",
           ariaLabel: "Restart terminal",
+          loading: isRestarting,
         },
       ]}
       onClose={() => onDismiss(terminalId)}

--- a/src/components/Terminal/SpawnErrorBanner.tsx
+++ b/src/components/Terminal/SpawnErrorBanner.tsx
@@ -1,8 +1,16 @@
 import React from "react";
-import { AlertTriangle, RotateCcw, FolderEdit, Trash2 } from "lucide-react";
+import { AlertTriangle, RotateCcw, FolderEdit, Trash2, Settings2 } from "lucide-react";
 import { InlineStatusBanner, type BannerAction } from "./InlineStatusBanner";
 import { sanitizeErrorText, boundedErrorText } from "@/utils/errorText";
+import { actionService } from "@/services/ActionService";
 import type { SpawnError } from "@/types";
+
+const RESOURCE_LIMIT_CODES: ReadonlySet<SpawnError["code"]> = new Set([
+  "EMFILE",
+  "EAGAIN",
+  "ENOMEM",
+  "ENXIO",
+]);
 
 export interface SpawnErrorBannerProps {
   terminalId: string;
@@ -11,6 +19,7 @@ export interface SpawnErrorBannerProps {
   onUpdateCwd: (id: string) => void;
   onRetry: (id: string) => void;
   onTrash: (id: string) => void;
+  isRestarting?: boolean;
   className?: string;
 }
 
@@ -80,9 +89,11 @@ function SpawnErrorBannerComponent({
   onUpdateCwd,
   onRetry,
   onTrash,
+  isRestarting = false,
   className,
 }: SpawnErrorBannerProps) {
   const isCwdError = error.code === "ENOTDIR";
+  const isResourceLimit = RESOURCE_LIMIT_CODES.has(error.code);
 
   const actions: BannerAction[] = [];
   if (isCwdError) {
@@ -94,6 +105,24 @@ function SpawnErrorBannerComponent({
       onClick: () => onUpdateCwd(terminalId),
       title: "Change working directory",
       ariaLabel: "Update working directory",
+      disabled: isRestarting,
+    });
+  }
+  if (isResourceLimit) {
+    actions.push({
+      id: "open-limits",
+      label: "Terminal limits",
+      icon: Settings2,
+      variant: "accent",
+      onClick: () => {
+        void actionService.dispatch(
+          "app.settings.openTab",
+          { tab: "terminal", subtab: "performance", sectionId: "terminal-panel-limits" },
+          { source: "user" }
+        );
+      },
+      title: "Open terminal limits settings",
+      ariaLabel: "Open terminal limits settings",
     });
   }
   actions.push(
@@ -105,15 +134,17 @@ function SpawnErrorBannerComponent({
       onClick: () => onRetry(terminalId),
       title: "Retry",
       ariaLabel: "Retry starting terminal",
+      loading: isRestarting,
     },
     {
       id: "trash",
-      label: "Trash",
+      label: "Remove terminal",
       icon: Trash2,
       variant: "danger",
       onClick: () => onTrash(terminalId),
       title: "Move to trash",
       ariaLabel: "Move to trash",
+      disabled: isRestarting,
     }
   );
 

--- a/src/components/Terminal/TerminalErrorBanner.tsx
+++ b/src/components/Terminal/TerminalErrorBanner.tsx
@@ -10,6 +10,7 @@ export interface TerminalErrorBannerProps {
   onUpdateCwd: (id: string) => void;
   onRetry: (id: string) => void;
   onTrash: (id: string) => void;
+  isRestarting?: boolean;
   className?: string;
 }
 
@@ -19,6 +20,7 @@ function TerminalErrorBannerComponent({
   onUpdateCwd,
   onRetry,
   onTrash,
+  isRestarting = false,
   className,
 }: TerminalErrorBannerProps) {
   const isCwdError = error.code === "ENOENT" && error.context?.failedCwd;
@@ -33,6 +35,7 @@ function TerminalErrorBannerComponent({
       onClick: () => onUpdateCwd(terminalId),
       title: "Change working directory",
       ariaLabel: "Update working directory",
+      disabled: isRestarting,
     });
   }
   actions.push(
@@ -44,15 +47,17 @@ function TerminalErrorBannerComponent({
       onClick: () => onRetry(terminalId),
       title: "Retry restart",
       ariaLabel: "Retry restart",
+      loading: isRestarting,
     },
     {
       id: "trash",
-      label: "Trash",
+      label: "Remove terminal",
       icon: Trash2,
       variant: "danger",
       onClick: () => onTrash(terminalId),
       title: "Move to trash",
       ariaLabel: "Move to trash",
+      disabled: isRestarting,
     }
   );
 

--- a/src/components/Terminal/TerminalPane.tsx
+++ b/src/components/Terminal/TerminalPane.tsx
@@ -825,6 +825,7 @@ function TerminalPaneComponent({
           onUpdateCwd={handleUpdateCwd}
           onRetry={handleRestart}
           onTrash={handleTrash}
+          isRestarting={isRestarting}
         />
       )}
 
@@ -836,6 +837,7 @@ function TerminalPaneComponent({
           onUpdateCwd={handleUpdateCwd}
           onRetry={handleRestart}
           onTrash={handleTrash}
+          isRestarting={isRestarting}
         />
       )}
 
@@ -845,6 +847,7 @@ function TerminalPaneComponent({
           error={reconnectError}
           onDismiss={handleDismissReconnectError}
           onRestart={handleRestart}
+          isRestarting={isRestarting}
         />
       )}
 

--- a/src/components/Terminal/TerminalRestartStatusBanner.tsx
+++ b/src/components/Terminal/TerminalRestartStatusBanner.tsx
@@ -42,11 +42,11 @@ function TerminalRestartStatusBannerComponent({
           actions={[
             {
               id: "restart",
-              label: "Restart Session",
+              label: "Restart session",
               icon: RotateCcw,
               variant: "dangerFilled",
               onClick: onRestart,
-              title: "Restart Session",
+              title: "Restart session",
               ariaLabel: "Restart session",
             },
           ]}

--- a/src/components/Terminal/__tests__/SpawnErrorBanner.test.tsx
+++ b/src/components/Terminal/__tests__/SpawnErrorBanner.test.tsx
@@ -1,0 +1,124 @@
+// @vitest-environment jsdom
+import { afterEach, beforeAll, beforeEach, describe, expect, it, vi } from "vitest";
+import { fireEvent, render, screen } from "@testing-library/react";
+import type { SpawnError, SpawnErrorCode } from "@shared/types/pty-host";
+
+const dispatchMock = vi.fn();
+
+vi.mock("@/services/ActionService", () => ({
+  actionService: {
+    dispatch: (...args: unknown[]) => dispatchMock(...args),
+  },
+}));
+
+vi.mock("@/components/ui/tooltip", () => ({
+  Tooltip: ({ children }: { children: React.ReactNode }) => <>{children}</>,
+  TooltipContent: ({ children }: { children: React.ReactNode }) => <>{children}</>,
+  TooltipProvider: ({ children }: { children: React.ReactNode }) => <>{children}</>,
+  TooltipTrigger: ({ children }: { children: React.ReactNode }) => <>{children}</>,
+}));
+
+import { SpawnErrorBanner } from "../SpawnErrorBanner";
+
+beforeAll(() => {
+  Object.defineProperty(window, "matchMedia", {
+    writable: true,
+    value: vi.fn().mockImplementation((query: string) => ({
+      matches: false,
+      media: query,
+      onchange: null,
+      addListener: vi.fn(),
+      removeListener: vi.fn(),
+      addEventListener: vi.fn(),
+      removeEventListener: vi.fn(),
+      dispatchEvent: vi.fn(),
+    })),
+  });
+});
+
+beforeEach(() => {
+  dispatchMock.mockReset();
+});
+
+afterEach(() => {
+  vi.restoreAllMocks();
+});
+
+function renderBanner(
+  code: SpawnErrorCode,
+  overrides: Partial<{
+    isRestarting: boolean;
+    onRetry: (id: string) => void;
+    onTrash: (id: string) => void;
+    onUpdateCwd: (id: string) => void;
+  }> = {}
+) {
+  const error: SpawnError = {
+    code,
+    message: `simulated ${code} error`,
+  };
+  return render(
+    <SpawnErrorBanner
+      terminalId="t-1"
+      error={error}
+      onUpdateCwd={overrides.onUpdateCwd ?? vi.fn()}
+      onRetry={overrides.onRetry ?? vi.fn()}
+      onTrash={overrides.onTrash ?? vi.fn()}
+      isRestarting={overrides.isRestarting}
+    />
+  );
+}
+
+describe("SpawnErrorBanner", () => {
+  it.each(["EMFILE", "EAGAIN", "ENOMEM", "ENXIO"] as const)(
+    "renders the terminal-limits action for %s",
+    (code) => {
+      renderBanner(code);
+      expect(screen.getByRole("button", { name: /open terminal limits settings/i })).toBeTruthy();
+    }
+  );
+
+  it("does not render the terminal-limits action for unrelated codes", () => {
+    renderBanner("ENOENT");
+    expect(screen.queryByRole("button", { name: /open terminal limits settings/i })).toBeNull();
+  });
+
+  it("dispatches app.settings.openTab with the terminal/performance/panel-limits target", () => {
+    renderBanner("EMFILE");
+    fireEvent.click(screen.getByRole("button", { name: /open terminal limits settings/i }));
+    expect(dispatchMock).toHaveBeenCalledTimes(1);
+    expect(dispatchMock).toHaveBeenCalledWith(
+      "app.settings.openTab",
+      { tab: "terminal", subtab: "performance", sectionId: "terminal-panel-limits" },
+      { source: "user" }
+    );
+  });
+
+  it("renders the destructive action with verb-noun label", () => {
+    renderBanner("ENOENT");
+    expect(screen.getByRole("button", { name: /move to trash/i }).textContent).toContain(
+      "Remove terminal"
+    );
+  });
+
+  it("disables retry and shows aria-busy when isRestarting is true", () => {
+    renderBanner("ENOENT", { isRestarting: true });
+    const retry = screen.getByRole("button", { name: /retry starting terminal/i });
+    expect(retry.hasAttribute("disabled")).toBe(true);
+    expect(retry.getAttribute("aria-busy")).toBe("true");
+  });
+
+  it("does not invoke onRetry while isRestarting is true", () => {
+    const onRetry = vi.fn();
+    renderBanner("ENOENT", { isRestarting: true, onRetry });
+    fireEvent.click(screen.getByRole("button", { name: /retry starting terminal/i }));
+    expect(onRetry).not.toHaveBeenCalled();
+  });
+
+  it("invokes onRetry when not restarting", () => {
+    const onRetry = vi.fn();
+    renderBanner("ENOENT", { onRetry });
+    fireEvent.click(screen.getByRole("button", { name: /retry starting terminal/i }));
+    expect(onRetry).toHaveBeenCalledWith("t-1");
+  });
+});

--- a/src/store/slices/panelRegistry/__tests__/reconnectErrorDebounce.test.ts
+++ b/src/store/slices/panelRegistry/__tests__/reconnectErrorDebounce.test.ts
@@ -1,0 +1,189 @@
+/**
+ * Anti-flap regression test for #7234. setReconnectError is gated behind a
+ * 400ms debounce so rapid hydration churn can't mount/dismount the banner
+ * faster than the eye can track. Cancellation paths (clearReconnectError,
+ * restartTerminal) must drop pending writes so a stale debounce can't
+ * resurrect an error after the user moved on.
+ */
+
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+
+vi.mock("@/clients", () => ({
+  terminalClient: {
+    spawn: vi.fn(),
+    write: vi.fn(),
+    resize: vi.fn(),
+    kill: vi.fn().mockResolvedValue(undefined),
+    trash: vi.fn().mockResolvedValue(undefined),
+    restore: vi.fn().mockResolvedValue(undefined),
+    onData: vi.fn(),
+    onExit: vi.fn(),
+    onAgentStateChanged: vi.fn(),
+  },
+  appClient: {
+    setState: vi.fn().mockResolvedValue(undefined),
+  },
+  projectClient: {
+    getTerminals: vi.fn().mockResolvedValue([]),
+    setTerminals: vi.fn().mockResolvedValue(undefined),
+    setTabGroups: vi.fn().mockResolvedValue(undefined),
+    getSettings: vi.fn().mockResolvedValue({}),
+  },
+  agentSettingsClient: {
+    get: vi.fn().mockResolvedValue({}),
+  },
+  systemClient: {
+    getAppMetrics: vi.fn().mockResolvedValue({ totalMemoryMB: 512 }),
+  },
+}));
+
+vi.mock("@/services/TerminalInstanceService", () => ({
+  terminalInstanceService: {
+    cleanup: vi.fn(),
+    applyRendererPolicy: vi.fn(),
+    destroy: vi.fn(),
+  },
+}));
+
+vi.mock("../persistence", async () => {
+  const actual = await vi.importActual<typeof import("../persistence")>("../persistence");
+  return {
+    ...actual,
+    saveNormalized: vi.fn(),
+  };
+});
+
+const { usePanelStore } = await import("../../../panelStore");
+const { __resetReconnectErrorDebouncersForTesting } = await import("../browser");
+
+const ERROR_A = {
+  type: "timeout" as const,
+  message: "Reconnection timed out",
+  timestamp: 1000,
+};
+const ERROR_B = {
+  type: "error" as const,
+  message: "Different failure",
+  timestamp: 2000,
+};
+
+function seedPanel(id: string) {
+  usePanelStore.setState({
+    panelsById: {
+      [id]: {
+        id,
+        kind: "terminal",
+        title: "T",
+        cwd: "/repo",
+        cols: 80,
+        rows: 24,
+        location: "grid",
+      },
+    },
+    panelIds: [id],
+  });
+}
+
+describe("reconnect error debounce", () => {
+  beforeEach(() => {
+    vi.useFakeTimers();
+    __resetReconnectErrorDebouncersForTesting();
+    usePanelStore.setState({
+      panelsById: {},
+      panelIds: [],
+    });
+  });
+
+  afterEach(async () => {
+    __resetReconnectErrorDebouncersForTesting();
+    vi.useRealTimers();
+  });
+
+  it("does not write reconnectError synchronously", () => {
+    seedPanel("t-1");
+    usePanelStore.getState().setReconnectError("t-1", ERROR_A);
+    expect(usePanelStore.getState().panelsById["t-1"]?.reconnectError).toBeUndefined();
+    expect(usePanelStore.getState().panelsById["t-1"]?.runtimeStatus).toBeUndefined();
+  });
+
+  it("writes the error after the 400ms gate elapses", async () => {
+    seedPanel("t-1");
+    usePanelStore.getState().setReconnectError("t-1", ERROR_A);
+
+    await vi.advanceTimersByTimeAsync(399);
+    expect(usePanelStore.getState().panelsById["t-1"]?.reconnectError).toBeUndefined();
+
+    await vi.advanceTimersByTimeAsync(1);
+    await Promise.resolve();
+    expect(usePanelStore.getState().panelsById["t-1"]?.reconnectError).toEqual(ERROR_A);
+    expect(usePanelStore.getState().panelsById["t-1"]?.runtimeStatus).toBe("error");
+  });
+
+  it("collapses rapid repeated calls into a single write of the latest error", async () => {
+    seedPanel("t-1");
+    usePanelStore.getState().setReconnectError("t-1", ERROR_A);
+    await vi.advanceTimersByTimeAsync(200);
+    usePanelStore.getState().setReconnectError("t-1", ERROR_B);
+    await vi.advanceTimersByTimeAsync(399);
+    expect(usePanelStore.getState().panelsById["t-1"]?.reconnectError).toBeUndefined();
+
+    await vi.advanceTimersByTimeAsync(1);
+    await Promise.resolve();
+    expect(usePanelStore.getState().panelsById["t-1"]?.reconnectError).toEqual(ERROR_B);
+  });
+
+  it("clearReconnectError cancels a pending debounce so no stale write lands", async () => {
+    seedPanel("t-1");
+    usePanelStore.getState().setReconnectError("t-1", ERROR_A);
+    usePanelStore.getState().clearReconnectError("t-1");
+
+    await vi.advanceTimersByTimeAsync(1000);
+    await Promise.resolve();
+    expect(usePanelStore.getState().panelsById["t-1"]?.reconnectError).toBeUndefined();
+    expect(usePanelStore.getState().panelsById["t-1"]?.runtimeStatus).toBeUndefined();
+  });
+
+  it("removePanel cancels a pending debounce so it can't resurrect a removed panel", async () => {
+    seedPanel("t-1");
+    usePanelStore.getState().setReconnectError("t-1", ERROR_A);
+    usePanelStore.getState().removePanel("t-1");
+
+    await vi.advanceTimersByTimeAsync(1000);
+    await Promise.resolve();
+    expect(usePanelStore.getState().panelsById["t-1"]).toBeUndefined();
+  });
+
+  it("debounces independently per panel id", async () => {
+    seedPanel("t-1");
+    usePanelStore.setState({
+      panelsById: {
+        ...usePanelStore.getState().panelsById,
+        "t-2": {
+          id: "t-2",
+          kind: "terminal",
+          title: "T",
+          cwd: "/repo",
+          cols: 80,
+          rows: 24,
+          location: "grid",
+        },
+      },
+      panelIds: ["t-1", "t-2"],
+    });
+
+    usePanelStore.getState().setReconnectError("t-1", ERROR_A);
+    await vi.advanceTimersByTimeAsync(300);
+    usePanelStore.getState().setReconnectError("t-2", ERROR_B);
+
+    // t-1's gate elapses first
+    await vi.advanceTimersByTimeAsync(100);
+    await Promise.resolve();
+    expect(usePanelStore.getState().panelsById["t-1"]?.reconnectError).toEqual(ERROR_A);
+    expect(usePanelStore.getState().panelsById["t-2"]?.reconnectError).toBeUndefined();
+
+    // t-2's gate elapses 300ms later
+    await vi.advanceTimersByTimeAsync(300);
+    await Promise.resolve();
+    expect(usePanelStore.getState().panelsById["t-2"]?.reconnectError).toEqual(ERROR_B);
+  });
+});

--- a/src/store/slices/panelRegistry/__tests__/reconnectErrorDebounce.test.ts
+++ b/src/store/slices/panelRegistry/__tests__/reconnectErrorDebounce.test.ts
@@ -54,7 +54,8 @@ vi.mock("../persistence", async () => {
 });
 
 const { usePanelStore } = await import("../../../panelStore");
-const { __resetReconnectErrorDebouncersForTesting } = await import("../browser");
+const { __resetReconnectErrorDebouncersForTesting, __getReconnectErrorDebouncerCountForTesting } =
+  await import("../browser");
 
 const ERROR_A = {
   type: "timeout" as const,
@@ -151,6 +152,28 @@ describe("reconnect error debounce", () => {
     await vi.advanceTimersByTimeAsync(1000);
     await Promise.resolve();
     expect(usePanelStore.getState().panelsById["t-1"]).toBeUndefined();
+  });
+
+  it("trashPanel cancels a pending debounce so undo-trash never reveals a phantom error", async () => {
+    seedPanel("t-1");
+    usePanelStore.getState().setReconnectError("t-1", ERROR_A);
+    usePanelStore.getState().trashPanel("t-1");
+
+    await vi.advanceTimersByTimeAsync(1000);
+    await Promise.resolve();
+    expect(usePanelStore.getState().panelsById["t-1"]?.reconnectError).toBeUndefined();
+    expect(usePanelStore.getState().panelsById["t-1"]?.runtimeStatus).not.toBe("error");
+  });
+
+  it("evicts the debouncer entry from the map after firing", async () => {
+    seedPanel("t-1");
+    usePanelStore.getState().setReconnectError("t-1", ERROR_A);
+    expect(__getReconnectErrorDebouncerCountForTesting()).toBe(1);
+
+    await vi.advanceTimersByTimeAsync(400);
+    await Promise.resolve();
+    expect(usePanelStore.getState().panelsById["t-1"]?.reconnectError).toEqual(ERROR_A);
+    expect(__getReconnectErrorDebouncerCountForTesting()).toBe(0);
   });
 
   it("debounces independently per panel id", async () => {

--- a/src/store/slices/panelRegistry/browser.ts
+++ b/src/store/slices/panelRegistry/browser.ts
@@ -1,8 +1,17 @@
 import type { PanelRegistryStoreApi, PanelRegistrySlice } from "./types";
+import type { TerminalReconnectError } from "@/types";
 import { panelKindUsesTerminalUi } from "@shared/config/panelKindRegistry";
 import { saveNormalized } from "./persistence";
+import { debounce } from "@/utils/debounce";
 
 type Set = PanelRegistryStoreApi["setState"];
+
+// Anti-flap gate (Doherty Threshold) for reconnect error writes during hydration —
+// rapid reconnect attempts can otherwise mount and dismount the banner faster
+// than the eye can track. Cancelled by clearReconnectError before re-spawning
+// the panel so a pending write can't resurrect a stale error.
+const RECONNECT_ERROR_DEBOUNCE_MS = 400;
+type DebouncedSetter = ReturnType<typeof debounce<[TerminalReconnectError]>>;
 
 export const createBrowserActions = (
   set: Set
@@ -179,20 +188,28 @@ export const createBrowserActions = (
   },
 
   setReconnectError: (id, error) => {
-    set((state) => {
-      const terminal = state.panelsById[id];
-      if (!terminal) return state;
+    let debouncedSetter = reconnectErrorDebouncers.get(id);
+    if (!debouncedSetter) {
+      debouncedSetter = debounce<[TerminalReconnectError]>((nextError) => {
+        set((state) => {
+          const terminal = state.panelsById[id];
+          if (!terminal) return state;
 
-      return {
-        panelsById: {
-          ...state.panelsById,
-          [id]: { ...terminal, reconnectError: error, runtimeStatus: "error" as const },
-        },
-      };
-    });
+          return {
+            panelsById: {
+              ...state.panelsById,
+              [id]: { ...terminal, reconnectError: nextError, runtimeStatus: "error" as const },
+            },
+          };
+        });
+      }, RECONNECT_ERROR_DEBOUNCE_MS);
+      reconnectErrorDebouncers.set(id, debouncedSetter);
+    }
+    debouncedSetter(error);
   },
 
   clearReconnectError: (id) => {
+    cancelReconnectErrorDebounce(id);
     set((state) => {
       const terminal = state.panelsById[id];
       if (!terminal) return state;
@@ -206,3 +223,23 @@ export const createBrowserActions = (
     });
   },
 });
+
+const reconnectErrorDebouncers = new Map<string, DebouncedSetter>();
+
+export function cancelReconnectErrorDebounce(id: string): void {
+  const debounced = reconnectErrorDebouncers.get(id);
+  if (debounced) {
+    debounced.cancel();
+    reconnectErrorDebouncers.delete(id);
+  }
+}
+
+// Test-only escape hatch — vitest fake timers can't observe setTimeout calls
+// scheduled on the real timer queue, so tests that simulate hydration races
+// need a way to drop module-level state between cases.
+export function __resetReconnectErrorDebouncersForTesting(): void {
+  for (const debounced of reconnectErrorDebouncers.values()) {
+    debounced.cancel();
+  }
+  reconnectErrorDebouncers.clear();
+}

--- a/src/store/slices/panelRegistry/browser.ts
+++ b/src/store/slices/panelRegistry/browser.ts
@@ -191,6 +191,9 @@ export const createBrowserActions = (
     let debouncedSetter = reconnectErrorDebouncers.get(id);
     if (!debouncedSetter) {
       debouncedSetter = debounce<[TerminalReconnectError]>((nextError) => {
+        // Self-evict so long-lived sessions with many reconnect events don't
+        // accumulate stale debouncer closures keyed by panel id.
+        reconnectErrorDebouncers.delete(id);
         set((state) => {
           const terminal = state.panelsById[id];
           if (!terminal) return state;
@@ -242,4 +245,10 @@ export function __resetReconnectErrorDebouncersForTesting(): void {
     debounced.cancel();
   }
   reconnectErrorDebouncers.clear();
+}
+
+// Test-only — exposes the map size so the closure-leak guard in
+// setReconnectError stays regression-protected.
+export function __getReconnectErrorDebouncerCountForTesting(): number {
+  return reconnectErrorDebouncers.size;
 }

--- a/src/store/slices/panelRegistry/core.ts
+++ b/src/store/slices/panelRegistry/core.ts
@@ -11,6 +11,7 @@ import { panelKindHasPty } from "@shared/config/panelKindRegistry";
 import { useLayoutConfigStore } from "@/store/layoutConfigStore";
 import { saveNormalized, saveTabGroups } from "./persistence";
 import { optimizeForDock } from "./layout";
+import { cancelReconnectErrorDebounce } from "./browser";
 import {
   deriveRuntimeStatus,
   getDefaultTitle,
@@ -69,6 +70,7 @@ export const createCorePanelActions = (
 
   removePanel: (id) => {
     clearTrashExpiryTimer(id);
+    cancelReconnectErrorDebounce(id);
     const state = get();
     const removedIndex = state.panelIds.indexOf(id);
     const terminal = state.panelsById[id];

--- a/src/store/slices/panelRegistry/restart.ts
+++ b/src/store/slices/panelRegistry/restart.ts
@@ -21,6 +21,7 @@ import { useLayoutConfigStore } from "@/store/layoutConfigStore";
 import { saveNormalized } from "./persistence";
 import { optimizeForDock } from "./layout";
 import { deriveRuntimeStatus } from "./helpers";
+import { cancelReconnectErrorDebounce } from "./browser";
 import { logDebug, logWarn, logError } from "@/utils/logger";
 import {
   buildAgentLaunchFlagsForRuntimeSettings,
@@ -176,6 +177,10 @@ export const createRestartActions = (
     // Mark as restarting SYNCHRONOUSLY first to prevent exit event race condition.
     // This is checked in the onExit handler before the store state.
     markTerminalRestarting(id);
+
+    // Drop any pending reconnect-error debounce so a stale write can't fire
+    // after we've cleared the error inline below.
+    cancelReconnectErrorDebounce(id);
 
     // Also set the store flag for UI and other consumers
     set((state) =>

--- a/src/store/slices/panelRegistry/trashActions.ts
+++ b/src/store/slices/panelRegistry/trashActions.ts
@@ -7,6 +7,7 @@ import { panelKindHasPty } from "@shared/config/panelKindRegistry";
 import { TRASH_TTL_MS } from "@shared/config/trash";
 import { saveNormalized, saveTabGroups } from "./persistence";
 import { optimizeForDock } from "./layout";
+import { cancelReconnectErrorDebounce } from "./browser";
 import { stopDevPreviewByPanelId } from "./helpers";
 import { logError } from "@/utils/logger";
 
@@ -30,6 +31,10 @@ export const createTrashActions = (
   const trashPanel: PanelRegistrySlice["trashPanel"] = (id) => {
     const terminal = get().panelsById[id];
     if (!terminal) return;
+
+    // Drop any pending reconnect-error debounce so a stale write can't land on
+    // a panel that's been moved to trash (and reappear when the user undoes).
+    cancelReconnectErrorDebounce(id);
 
     // Ephemeral panels (e.g. the help-panel assistant terminal) are bound to
     // a transient UI surface and must never linger in trash for the TTL window
@@ -149,6 +154,10 @@ export const createTrashActions = (
     }
 
     const trashPanelIds = existingPanelIds;
+
+    for (const id of trashPanelIds) {
+      cancelReconnectErrorDebounce(id);
+    }
 
     const resolvedActiveTabId = trashPanelIds.includes(activeTabId)
       ? activeTabId


### PR DESCRIPTION
## Summary

- Retry and restart buttons on all three error banners now go disabled and show a `Spinner` while a restart is in flight, with `aria-busy` set for accessibility.
- Spawn errors caused by resource exhaustion (`EMFILE`, `EAGAIN`, `ENOMEM`, `ENXIO`) now show a "Terminal limits" shortcut button that opens the panel-limits settings tab directly.
- Reconnect error setter is debounced at 400ms (Doherty Threshold) to prevent banner flicker during connection churn; pending debounces are cancelled on trash.

Resolves #7234

## Changes

**Banner UX**
- `BannerAction`: added `isLoading` prop — disables button and renders `Spinner` when set, `aria-busy` threaded through
- `TerminalErrorBanner`, `SpawnErrorBanner`, `ReconnectErrorBanner`: thread `isRestarting` from `TerminalPane` so retry/restart buttons reflect in-progress state
- `SpawnErrorBanner`: adds a `Settings2`-icon "Terminal limits" button for resource-exhaustion codes, dispatches `app.settings.openTab` to the panel-limits section
- `TerminalRestartStatusBanner`: `"Restart Session"` → `"Restart session"` (sentence case); `"Trash"` → `"Remove terminal"` (verb-noun; tooltip/aria keep `"Move to trash"`)

**Reconnect debounce**
- `setReconnectError` in `panelRegistry/browser.ts`: per-panel 400ms debounce backed by a `Map`; `clearReconnectError`, `restartTerminal`, and `removePanel` all cancel the pending write
- `trashPanel` and `trashPanelGroup` in `trashActions.ts`: cancel any pending debounce (prevents phantom banner after undo-trash)
- Debouncer-map entries self-evict after firing (closure-leak fix for long-lived sessions)
- `InlineStatusBanner` `onClick`: guard against programmatic clicks on disabled buttons

**Tests**
- `SpawnErrorBanner.test.tsx`: 7 tests covering loading state, "Terminal limits" button visibility per error code, and action dispatch
- `reconnectErrorDebounce.test.ts`: 6 tests covering debounce timing, cancellation on clear/restart/remove, trash cancellation, and map eviction

## Testing

- Vitest: 25/25 in scoped suite, 702/702 across `Terminal/__tests__` and `panelRegistry/__tests__`
- `tsc` clean across main, electron, and preload tsconfigs
- Lint warning count down by 10 from baseline
- [ ] Manual: trigger a spawn `EMFILE` error — verify "Terminal limits" opens panel-limits settings
- [ ] Manual: click retry mid-restart — verify button shows spinner and is disabled until complete
- [ ] Manual: undo-trash a terminal that had a recent reconnect error — verify no phantom banner