### PR TITLE
fix(action-palette): tighten ranking weights and clamp interaction

### DIFF
--- a/src/lib/__tests__/actionPaletteSearch.test.ts
+++ b/src/lib/__tests__/actionPaletteSearch.test.ts
@@ -188,9 +188,9 @@ describe("rankActionMatches", () => {
     const results = rankActionMatches("cp", items, []);
     expect(results).toHaveLength(2);
     // Both are valid matches — order must be deterministic (alphabetical on title)
-    expect(results[0]!.title < results[1]!.title || results[0]!.title === results[1]!.title).toBe(
-      true
-    );
+    expect(
+      results[0]!.title.localeCompare(results[1]!.title, "en", { sensitivity: "base" }) <= 0
+    ).toBe(true);
   });
 
   it("full ranked list: prefix > acronym > substring > fuzzy > non-match", () => {

--- a/src/lib/__tests__/actionPaletteSearch.test.ts
+++ b/src/lib/__tests__/actionPaletteSearch.test.ts
@@ -208,6 +208,12 @@ describe("rankActionMatches", () => {
     expect(ids.indexOf("substring")).toBeLessThan(ids.indexOf("fuzzy"));
   });
 
+  it("excludes heavily-scattered subsequence when aggregate is non-positive", () => {
+    const items = [makeAction({ id: "1", title: "a" + "x".repeat(30) + "b" })];
+    const results = rankActionMatches("ab", items, []);
+    expect(results).toEqual([]);
+  });
+
   it("falls back to title alphabetical for equal score with no MRU", () => {
     const items = [
       makeAction({ id: "b", title: "Beta Terminal" }),

--- a/src/lib/actionPaletteSearch.ts
+++ b/src/lib/actionPaletteSearch.ts
@@ -140,9 +140,9 @@ export function scoreAction(query: string, item: SearchableAction): number {
 
   return (
     titleScore * TITLE_WEIGHT +
-    categoryRaw * CATEGORY_WEIGHT +
-    descriptionRaw * DESCRIPTION_WEIGHT +
-    keywordRaw * KEYWORD_WEIGHT
+    Math.max(0, categoryRaw) * CATEGORY_WEIGHT +
+    Math.max(0, descriptionRaw) * DESCRIPTION_WEIGHT +
+    Math.max(0, keywordRaw) * KEYWORD_WEIGHT
   );
 }
 

--- a/src/lib/actionPaletteSearch.ts
+++ b/src/lib/actionPaletteSearch.ts
@@ -78,10 +78,6 @@ function scoreSubsequence(lowerQuery: string, field: string, lowerField: string)
         score += 10;
       }
 
-      if (fi === 0) {
-        score += 20;
-      }
-
       lastMatchIndex = fi;
       qi++;
     }
@@ -91,7 +87,7 @@ function scoreSubsequence(lowerQuery: string, field: string, lowerField: string)
     return 0;
   }
 
-  return Math.max(0, score);
+  return score;
 }
 
 function scoreTitle(
@@ -140,7 +136,7 @@ export function scoreAction(query: string, item: SearchableAction): number {
   const keywordRaw =
     item.keywordsLower.length > 0 ? scoreKeywords(lowerQuery, item.keywordsLower) : 0;
 
-  if (titleScore === 0 && categoryRaw === 0 && descriptionRaw === 0 && keywordRaw === 0) return 0;
+  if (titleScore <= 0 && categoryRaw <= 0 && descriptionRaw <= 0 && keywordRaw <= 0) return 0;
 
   return (
     titleScore * TITLE_WEIGHT +


### PR DESCRIPTION
## Summary
- Strips a redundant `+20` first-character bonus from the subsequence scorer that was already covered by the `+90` boundary bonus.
- Wraps secondary field scores (`categoryRaw`, `descriptionRaw`, `keywordRaw`) in `Math.max(0, ...)` before weighting to prevent negative scores from dragging down or vetoing strong title matches.
- Adds regression tests for scattered-subsequence exclusion and deterministic tie-breaking sort stability.

Resolves #7273

## Changes
- `src/lib/actionPaletteSearch.ts`: removed the `fi === 0` bonus, dropped the per-field `Math.max(0, score)` clamp (redundant with the aggregate-level clamping), switched the zero-guard from `=== 0` strict equality to `<= 0` (since raw scores can now go negative), and clamped each non-title field in the weighted aggregate.
- `src/lib/__tests__/actionPaletteSearch.test.ts`: added a test that a heavily-scattered subsequence with a non-positive aggregate is excluded from results; fixed the deterministic alphabetical tiebreak test to use `localeCompare` instead of a bare `<` operator.

## Testing
- Existing test suite passes (22 tests in `actionPaletteSearch.test.ts`).
- New regression test confirms scattered-subsequence exclusion.
- Manually verified that a query with a strong title match no longer gets dropped by a negative category score.