### PR TITLE
chore(userAgentRegistry): consolidate setUserRegistry via subscribeWithSelector

### DIFF
--- a/src/store/__tests__/userAgentRegistryStore.test.ts
+++ b/src/store/__tests__/userAgentRegistryStore.test.ts
@@ -1,4 +1,5 @@
 import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+import { getUserRegistry } from "../../../shared/config/agentRegistry";
 
 const { getMock, addMock, updateMock, removeMock } = vi.hoisted(() => ({
   getMock: vi.fn(),
@@ -48,6 +49,45 @@ describe("userAgentRegistryStore", () => {
     expect(afterRetry.isInitialized).toBe(true);
     expect(afterRetry.error).toBeNull();
     expect(afterRetry.registry).toEqual({ myAgent: { id: "myAgent", name: "My Agent" } });
+  });
+
+  it("syncs the userRegistry singleton on initialize", async () => {
+    getMock.mockResolvedValue({ myAgent: { id: "myAgent", name: "My Agent" } });
+
+    await useUserAgentRegistryStore.getState().initialize();
+
+    const singleton = getUserRegistry();
+    expect(singleton).toEqual({ myAgent: { id: "myAgent", name: "My Agent" } });
+  });
+
+  it("syncs the userRegistry singleton on addAgent", async () => {
+    getMock
+      .mockResolvedValueOnce({ myAgent: { id: "myAgent", name: "My Agent" } })
+      .mockResolvedValueOnce({
+        myAgent: { id: "myAgent", name: "My Agent" },
+        newAgent: { id: "newAgent", name: "New" },
+      });
+    addMock.mockResolvedValue({ success: true });
+
+    await useUserAgentRegistryStore.getState().initialize();
+    await useUserAgentRegistryStore.getState().addAgent({ id: "newAgent", name: "New" } as never);
+
+    const singleton = getUserRegistry();
+    expect(singleton).toHaveProperty("myAgent");
+    expect(singleton).toHaveProperty("newAgent");
+  });
+
+  it("clears the userRegistry singleton on cleanup", () => {
+    useUserAgentRegistryStore.setState({
+      registry: { test: { id: "test", name: "Test Agent" } as never },
+      isLoading: false,
+      error: null,
+      isInitialized: true,
+    });
+
+    cleanupUserAgentRegistryStore();
+
+    expect(getUserRegistry()).toEqual({});
   });
 
   it("cleanup resets the store to pre-initialized state", () => {

--- a/src/store/userAgentRegistryStore.ts
+++ b/src/store/userAgentRegistryStore.ts
@@ -1,4 +1,5 @@
 import { create } from "zustand";
+import { subscribeWithSelector } from "zustand/middleware";
 import type { UserAgentRegistry, UserAgentConfig } from "@shared/types";
 import { userAgentRegistryClient } from "@/clients/userAgentRegistryClient";
 import { setUserRegistry } from "../../shared/config/agentRegistry";
@@ -26,106 +27,112 @@ type UserAgentRegistryStore = UserAgentRegistryState & UserAgentRegistryActions;
 
 let initPromise: Promise<void> | null = null;
 
-export const useUserAgentRegistryStore = create<UserAgentRegistryStore>()((set, get) => ({
-  registry: null,
-  isLoading: true,
-  error: null,
-  isInitialized: false,
+export const useUserAgentRegistryStore = create<UserAgentRegistryStore>()(
+  subscribeWithSelector((set, get) => ({
+    registry: null,
+    isLoading: true,
+    error: null,
+    isInitialized: false,
 
-  initialize: () => {
-    if (get().isInitialized) return Promise.resolve();
-    if (initPromise) return initPromise;
+    initialize: () => {
+      if (get().isInitialized) return Promise.resolve();
+      if (initPromise) return initPromise;
 
-    initPromise = (async () => {
+      initPromise = (async () => {
+        try {
+          set({ isLoading: true, error: null });
+
+          const registry = (await userAgentRegistryClient.get()) ?? {};
+          set({ registry, isLoading: false, isInitialized: true });
+        } catch (e) {
+          set({
+            error: formatErrorMessage(e, "Failed to load user agent registry"),
+            isLoading: false,
+            isInitialized: false,
+          });
+        } finally {
+          initPromise = null;
+        }
+      })();
+
+      return initPromise;
+    },
+
+    addAgent: async (config: UserAgentConfig) => {
+      set({ error: null });
       try {
-        set({ isLoading: true, error: null });
-
-        const registry = (await userAgentRegistryClient.get()) ?? {};
-        setUserRegistry(registry);
-        set({ registry, isLoading: false, isInitialized: true });
+        const result = await userAgentRegistryClient.add(config);
+        if (result.success) {
+          const registry = (await userAgentRegistryClient.get()) ?? {};
+          set({ registry });
+        } else {
+          set({ error: result.error });
+        }
+        return result;
       } catch (e) {
-        set({
-          error: formatErrorMessage(e, "Failed to load user agent registry"),
-          isLoading: false,
-          isInitialized: false,
-        });
-      } finally {
-        initPromise = null;
+        const error = formatErrorMessage(e, "Failed to add agent");
+        set({ error });
+        return { success: false, error };
       }
-    })();
+    },
 
-    return initPromise;
-  },
+    updateAgent: async (id: string, config: UserAgentConfig) => {
+      set({ error: null });
+      try {
+        const result = await userAgentRegistryClient.update(id, config);
+        if (result.success) {
+          const registry = (await userAgentRegistryClient.get()) ?? {};
+          set({ registry });
+        } else {
+          set({ error: result.error });
+        }
+        return result;
+      } catch (e) {
+        const error = formatErrorMessage(e, "Failed to update agent");
+        set({ error });
+        return { success: false, error };
+      }
+    },
 
-  addAgent: async (config: UserAgentConfig) => {
-    set({ error: null });
-    try {
-      const result = await userAgentRegistryClient.add(config);
-      if (result.success) {
+    removeAgent: async (id: string) => {
+      set({ error: null });
+      try {
+        const result = await userAgentRegistryClient.remove(id);
+        if (result.success) {
+          const registry = (await userAgentRegistryClient.get()) ?? {};
+          set({ registry });
+        } else {
+          set({ error: result.error });
+        }
+        return result;
+      } catch (e) {
+        const error = formatErrorMessage(e, "Failed to remove agent");
+        set({ error });
+        return { success: false, error };
+      }
+    },
+
+    refresh: async () => {
+      set({ error: null });
+      try {
         const registry = (await userAgentRegistryClient.get()) ?? {};
-        setUserRegistry(registry);
         set({ registry });
-      } else {
-        set({ error: result.error });
+      } catch (e) {
+        set({ error: formatErrorMessage(e, "Failed to refresh user agent registry") });
+        throw e;
       }
-      return result;
-    } catch (e) {
-      const error = formatErrorMessage(e, "Failed to add agent");
-      set({ error });
-      return { success: false, error };
-    }
-  },
+    },
+  }))
+);
 
-  updateAgent: async (id: string, config: UserAgentConfig) => {
-    set({ error: null });
-    try {
-      const result = await userAgentRegistryClient.update(id, config);
-      if (result.success) {
-        const registry = (await userAgentRegistryClient.get()) ?? {};
-        setUserRegistry(registry);
-        set({ registry });
-      } else {
-        set({ error: result.error });
-      }
-      return result;
-    } catch (e) {
-      const error = formatErrorMessage(e, "Failed to update agent");
-      set({ error });
-      return { success: false, error };
-    }
-  },
-
-  removeAgent: async (id: string) => {
-    set({ error: null });
-    try {
-      const result = await userAgentRegistryClient.remove(id);
-      if (result.success) {
-        const registry = (await userAgentRegistryClient.get()) ?? {};
-        setUserRegistry(registry);
-        set({ registry });
-      } else {
-        set({ error: result.error });
-      }
-      return result;
-    } catch (e) {
-      const error = formatErrorMessage(e, "Failed to remove agent");
-      set({ error });
-      return { success: false, error };
-    }
-  },
-
-  refresh: async () => {
-    set({ error: null });
-    try {
-      const registry = (await userAgentRegistryClient.get()) ?? {};
+useUserAgentRegistryStore.subscribe(
+  (state) => state.registry,
+  (registry) => {
+    if (registry !== null) {
       setUserRegistry(registry);
-      set({ registry });
-    } catch (e) {
-      set({ error: formatErrorMessage(e, "Failed to refresh user agent registry") });
-      throw e;
     }
-  },
-}));
+  }
+);
 
 export function cleanupUserAgentRegistryStore() {
   initPromise = null;
@@ -135,4 +142,5 @@ export function cleanupUserAgentRegistryStore() {
     error: null,
     isInitialized: false,
   });
+  setUserRegistry({});
 }


### PR DESCRIPTION
## Summary
- Wraps the store with `subscribeWithSelector` middleware so `setUserRegistry` runs once from a module-level subscriber instead of being duplicated across five action methods
- Removes 5 duplicate `setUserRegistry` calls and the future-bug surface where a new action could forget the side-effect call
- Adds cleanup to reset the singleton and writes tests covering the subscriber, add-then-sync, and cleanup paths

Resolves #7223

## Changes
- `src/store/userAgentRegistryStore.ts` — wrapped with `subscribeWithSelector`, added subscriber, removed per-action `setUserRegistry` calls, updated cleanup
- `src/store/__tests__/userAgentRegistryStore.test.ts` — new tests for subscriber behavior, add-sync, cleanup reset

## Testing
Unit tests pass. The subscriber pattern is already established in `panelStore`, `cliAvailabilityStore`, and `projectStore`.