### PR TITLE
chore(terminal): tidy xterm base options and add role="application"

### DIFF
--- a/src/components/Terminal/XtermAdapter.tsx
+++ b/src/components/Terminal/XtermAdapter.tsx
@@ -593,6 +593,7 @@ function XtermAdapterComponent({
         ref={containerRef}
         className="w-full h-full min-h-0 min-w-0"
         aria-label="Terminal output"
+        role="application"
       />
     </div>
   );

--- a/src/config/xtermConfig.ts
+++ b/src/config/xtermConfig.ts
@@ -30,7 +30,6 @@ export interface TerminalAppearanceConfig {
 /**
  * Base terminal options that apply to all terminals.
  * These are the common options shared across all xterm instances.
- * Note: fontLigatures is a valid xterm option but may not be in @types
  */
 export const BASE_TERMINAL_OPTIONS = {
   cursorBlink: true,
@@ -38,16 +37,16 @@ export const BASE_TERMINAL_OPTIONS = {
   cursorInactiveStyle: "block" as const,
   lineHeight: 1.1,
   letterSpacing: 0,
-  fontLigatures: false,
   fontWeight: "normal" as const,
   fontWeightBold: "700" as const,
   allowProposedApi: true,
+  customGlyphs: true,
   macOptionIsMeta: true,
   macOptionClickForcesSelection: true,
   scrollOnUserInput: false,
   fastScrollSensitivity: 5,
   scrollSensitivity: 1.5,
-} satisfies Partial<ITerminalOptions> & { fontLigatures: boolean };
+} satisfies Partial<ITerminalOptions>;
 
 /**
  * Get complete xterm options for a terminal instance.
@@ -66,7 +65,6 @@ export function getXtermOptions(config: TerminalAppearanceConfig): ITerminalOpti
     theme,
     scrollback: config.scrollback,
     screenReaderMode: config.screenReaderMode ?? false,
-    // Performance mode disables smooth scrolling
     smoothScrollDuration: 0,
   };
 }


### PR DESCRIPTION
## Summary
A small set of cleanup changes to the xterm wiring. Pins `customGlyphs` to true so a future xterm default flip can't silently change our terminals. Drops an inert `fontLigatures` line whose addon isn't loaded. Removes a misleading comment that promised conditional logic that doesn't exist. Adds `role="application"` to the terminal container for screen reader compatibility.

Resolves #7210

## Changes
- Pin `customGlyphs: true` in `BASE_TERMINAL_OPTIONS`
- Remove `fontLigatures: false` and its `& { fontLigatures: boolean }` type workaround (addon not loaded)
- Drop misleading "Performance mode disables smooth scrolling" comment (`smoothScrollDuration: 0` is unconditional)
- Add `role="application"` to the terminal output container (`XtermAdapter.tsx`)

## Testing
- Existing xterm config test verifies `customGlyphs: true` default
- Manual inspection confirms terminal renders and screen reader announces role correctly