### PR TITLE
fix(sidebar): replace loading text with skeleton, use noun phrase for filtered-empty title

### DIFF
--- a/src/components/Sidebar/SidebarContent.tsx
+++ b/src/components/Sidebar/SidebarContent.tsx
@@ -11,6 +11,7 @@ import {
 } from "react";
 import { FolderOpen, LayoutGrid, Plus, RefreshCw, Zap } from "lucide-react";
 import { EmptyState } from "@/components/ui/EmptyState";
+import { Skeleton, SkeletonBone } from "@/components/ui/Skeleton";
 import { ScrollIndicator } from "@/components/Worktree/ScrollIndicator";
 import {
   useAgentLauncher,
@@ -488,7 +489,14 @@ function SidebarContent({ onOpenOverview }: SidebarContentProps) {
         <div className="flex items-center px-4 py-4 border-b border-divider shrink-0">
           <h2 className="text-daintree-text font-semibold text-sm tracking-wide">Worktrees</h2>
         </div>
-        <div className="px-4 py-4 text-daintree-text/60 text-sm">Loading worktrees...</div>
+        <Skeleton label="Loading worktrees" className="flex flex-col gap-2 px-4 py-4">
+          <SkeletonBone className="h-14 w-full" />
+          <SkeletonBone className="h-12 w-full" />
+          <SkeletonBone className="h-14 w-full" />
+          <SkeletonBone className="h-12 w-full" />
+          <SkeletonBone className="h-14 w-full" />
+          <SkeletonBone className="h-12 w-full" />
+        </Skeleton>
       </div>
     );
   }
@@ -798,7 +806,7 @@ function SidebarContent({ onOpenOverview }: SidebarContentProps) {
               ) : filteredWorktrees.length === 0 && hasFilters && hasNonMainWorktrees ? (
                 <EmptyState
                   variant="filtered-empty"
-                  title="No worktrees match your filters"
+                  title="No matching worktrees"
                   action={
                     <button
                       onClick={clearAllFilters}

--- a/src/components/Sidebar/__tests__/SidebarContent.emptyState.test.ts
+++ b/src/components/Sidebar/__tests__/SidebarContent.emptyState.test.ts
@@ -142,7 +142,7 @@ describe("SidebarContent quick-state empty state — issue #6333 (CTA collapsed 
       expect(branch).toContain("undefined");
     });
 
-    it("preserves the 'No worktrees match your filters' branch via the EmptyState primitive", () => {
+    it("preserves the 'No matching worktrees' branch via the EmptyState primitive", () => {
       const branchStart = source.indexOf(
         "filteredWorktrees.length === 0 && hasFilters && hasNonMainWorktrees ?"
       );
@@ -150,7 +150,7 @@ describe("SidebarContent quick-state empty state — issue #6333 (CTA collapsed 
       const branch = source.slice(branchStart, branchEnd);
       expect(branch).toContain("<EmptyState");
       expect(branch).toContain('variant="filtered-empty"');
-      expect(branch).toContain('title="No worktrees match your filters"');
+      expect(branch).toContain('title="No matching worktrees"');
       expect(branch).toMatch(/onClick=\{clearAllFilters\}[\s\S]*?>\s*Clear filters\s*</);
     });
   });
@@ -267,5 +267,43 @@ describe("SidebarContent zero-worktrees taxonomy alignment — issue #6934", () 
     const branchEnd = source.indexOf("const hasNonMainWorktrees", branchStart);
     const branch = source.slice(branchStart, branchEnd);
     expect(branch).not.toContain("<button");
+  });
+});
+
+describe("SidebarContent loading skeleton — issue #7215", () => {
+  let source: string;
+
+  beforeAll(async () => {
+    source = await fs.readFile(SIDEBAR_CONTENT_PATH, "utf-8");
+  });
+
+  it("does not render immediate 'Loading worktrees...' text", () => {
+    expect(source).not.toContain(">Loading worktrees...</div>");
+  });
+
+  it("imports Skeleton and SkeletonBone from the shared skeleton component", () => {
+    expect(source).toMatch(
+      /import \{ Skeleton, SkeletonBone \} from "@\/components\/ui\/Skeleton"/
+    );
+  });
+
+  it("renders a Skeleton wrapper with role='status' and aria-label='Loading worktrees'", () => {
+    expect(source).toContain("<Skeleton");
+    expect(source).toContain('label="Loading worktrees"');
+  });
+
+  it("renders 6 SkeletonBone rows inside the loading branch", () => {
+    const branchStart = source.indexOf("if (isLoading && worktrees.length === 0)");
+    const branchEnd = source.indexOf("if (error)", branchStart);
+    const branch = source.slice(branchStart, branchEnd);
+    const boneCount = (branch.match(/<SkeletonBone/g) || []).length;
+    expect(boneCount).toBe(6);
+  });
+
+  it("does not use animate-pulse-immediate on skeleton bones", () => {
+    const branchStart = source.indexOf("if (isLoading && worktrees.length === 0)");
+    const branchEnd = source.indexOf("if (error)", branchStart);
+    const branch = source.slice(branchStart, branchEnd);
+    expect(branch).not.toContain("immediate");
   });
 });


### PR DESCRIPTION
## Summary
Minor polish fix for the sidebar loading and empty-state copy.

First, replaces the immediate "Loading worktrees..." text with a skeleton that uses `animate-pulse-delayed` to respect the 400ms Doherty Threshold. The worktree list shape is predictable, so a skeleton is the right choice per our loading-indicator rules.

Second, changes the filtered-empty title from a sentence (`No worktrees match your filters`) to a noun phrase (`No matching worktrees`). This matches the CLAUDE.md empty-state convention that filtered-empty titles are noun phrases naming the result.

Resolves #7215.

## Changes
- `SidebarContent.tsx` -- loading branch uses `Skeleton` + `SkeletonBone` instead of text; filtered-empty title updated to noun phrase
- `SidebarContent.emptyState.test.ts` -- test assertions updated for the new copy and added skeleton rendering checks

## Testing
- Prettier and ESLint pass cleanly
- Unit tests updated to verify the skeleton renders 6 bones, the title text changed, and no `animate-pulse-immediate` usage