### PR TITLE
chore(theme): polish commit lifecycle and toast wording

### DIFF
--- a/src/components/ThemePalette/ThemePalette.tsx
+++ b/src/components/ThemePalette/ThemePalette.tsx
@@ -158,7 +158,7 @@ export function ThemePalette({ isOpen, onClose }: ThemePaletteProps) {
         notify({
           type: "error",
           priority: "high",
-          message: `Failed to save theme: ${scheme.name}`,
+          message: `Couldn't save theme preference — '${scheme.name}' is applied but the choice will be lost on restart.`,
           duration: 3000,
         });
       });

--- a/src/lib/__tests__/appThemeViewTransition.test.ts
+++ b/src/lib/__tests__/appThemeViewTransition.test.ts
@@ -64,6 +64,7 @@ describe("appThemeViewTransition", () => {
 
   afterEach(() => {
     delete (document as unknown as { startViewTransition?: unknown }).startViewTransition;
+    delete (document as unknown as { activeViewTransition?: unknown }).activeViewTransition;
     delete document.body.dataset.performanceMode;
     vi.restoreAllMocks();
   });
@@ -178,6 +179,59 @@ describe("appThemeViewTransition", () => {
 
       expect(() => runThemeReveal({ x: 0, y: 0 }, () => {})).not.toThrow();
       await rejected.catch(() => {});
+    });
+
+    it("skips in-flight ViewTransition before starting a new one", () => {
+      const skipTransition = vi.fn();
+      (
+        document as unknown as { activeViewTransition?: { skipTransition: () => void } }
+      ).activeViewTransition = { skipTransition };
+      const { startSpy } = installViewTransitionMock();
+
+      runThemeReveal({ x: 100, y: 100 }, () => {});
+
+      expect(skipTransition).toHaveBeenCalledTimes(1);
+      expect(startSpy).toHaveBeenCalledTimes(1);
+      const skipOrder = skipTransition.mock.invocationCallOrder[0]!;
+      const startOrder = startSpy.mock.invocationCallOrder[0]!;
+      expect(skipOrder).toBeLessThan(startOrder);
+    });
+
+    it("starts transition normally when no in-flight transition exists", () => {
+      delete (document as unknown as { activeViewTransition?: unknown }).activeViewTransition;
+      const { startSpy } = installViewTransitionMock();
+
+      runThemeReveal({ x: 100, y: 100 }, () => {});
+
+      expect(startSpy).toHaveBeenCalledTimes(1);
+    });
+
+    it("does not call skipTransition when reduced-motion fallback skips the transition", () => {
+      const skipTransition = vi.fn();
+      (
+        document as unknown as { activeViewTransition?: { skipTransition: () => void } }
+      ).activeViewTransition = { skipTransition };
+      const { startSpy } = installViewTransitionMock();
+      setReducedMotion(true);
+
+      runThemeReveal({ x: 100, y: 100 }, () => {});
+
+      expect(startSpy).not.toHaveBeenCalled();
+      expect(skipTransition).not.toHaveBeenCalled();
+    });
+
+    it("does not call skipTransition when hidden-document fallback skips the transition", () => {
+      const skipTransition = vi.fn();
+      (
+        document as unknown as { activeViewTransition?: { skipTransition: () => void } }
+      ).activeViewTransition = { skipTransition };
+      const { startSpy } = installViewTransitionMock();
+      setVisibility("hidden");
+
+      runThemeReveal({ x: 100, y: 100 }, () => {});
+
+      expect(startSpy).not.toHaveBeenCalled();
+      expect(skipTransition).not.toHaveBeenCalled();
     });
   });
 });

--- a/src/lib/appThemeViewTransition.ts
+++ b/src/lib/appThemeViewTransition.ts
@@ -1,6 +1,8 @@
+// The 400ms wipe IS the theme-reveal signal — it encodes the origin/direction of the switch via clip-path animation (semantic exception).
 export const THEME_WIPE_DURATION = 400;
 
 type ViewTransitionDocument = Document & {
+  activeViewTransition?: { skipTransition: () => void };
   startViewTransition?: (callback: () => void) => {
     ready: Promise<void>;
     finished: Promise<void>;
@@ -30,6 +32,7 @@ export function runThemeReveal(origin: { x: number; y: number } | null, mutate: 
 
   const wipeFromLeft = (origin?.x ?? 0) < window.innerWidth / 2;
 
+  doc.activeViewTransition?.skipTransition();
   const transition = doc.startViewTransition(mutate);
 
   transition.ready

--- a/src/services/actions/definitions/__tests__/themeActions.test.ts
+++ b/src/services/actions/definitions/__tests__/themeActions.test.ts
@@ -201,7 +201,11 @@ describe("app.theme.toggle", () => {
     expect(mockSetSelectedSchemeId).toHaveBeenCalledWith("light-a");
     expect(mockNotify).toHaveBeenCalledTimes(1);
     expect(mockNotify).toHaveBeenCalledWith(
-      expect.objectContaining({ type: "error", message: "Failed to save theme: Light A" })
+      expect.objectContaining({
+        type: "error",
+        message:
+          "Couldn't save theme preference — 'Light A' is applied but the choice will be lost on restart.",
+      })
     );
     expect(mockNotify).not.toHaveBeenCalledWith(expect.objectContaining({ priority: "low" }));
     expect(mockAddNotification).not.toHaveBeenCalled();

--- a/src/services/actions/definitions/appActions.ts
+++ b/src/services/actions/definitions/appActions.ts
@@ -197,7 +197,7 @@ export function registerAppActions(actions: ActionRegistry, callbacks: ActionCal
         notify({
           type: "error",
           priority: "high",
-          message: `Failed to save theme: ${target.name}`,
+          message: `Couldn't save theme preference — '${target.name}' is applied but the choice will be lost on restart.`,
           duration: 3000,
         });
         return;


### PR DESCRIPTION
## Summary
- Aborts in-flight ViewTransitions when rapidly switching themes via `document.activeViewTransition.skipTransition()`, matching the same pattern already used in `removeStartupSkeleton.ts`
- Documents `THEME_WIPE_DURATION` as a semantic exception to the animation timing tiers -- the wipe IS the commit-confirmation signal, not motion for motion's sake
- Fixes the commit-failure toast wording to distinguish local application from persistence failure instead of claiming the theme save itself failed

Resolves #7255

## Changes
- `src/lib/appThemeViewTransition.ts` -- adds `activeViewTransition` to the ViewTransition document type and calls `skipTransition()` before starting a new transition; adds a comment marking `THEME_WIPE_DURATION` as a semantic exception
- `src/components/ThemePalette/ThemePalette.tsx` -- rewords the commit-failure toast to say the theme is applied but the choice will be lost on restart
- `src/services/actions/definitions/appActions.ts` -- same toast wording fix in the action handler path
- `src/lib/__tests__/appThemeViewTransition.test.ts` -- adds 4 tests: skipTransition called before starting a new transition, starts normally when no in-flight transition exists, and skipTransition not called in reduced-motion or hidden-document fallback paths
- `src/services/actions/definitions/__tests__/themeActions.test.ts` -- updates test expectation to match the new toast wording

## Testing
- Unit tests pass for ViewTransition abort tracking and toast wording
- Manual verification: rapid theme switching from the palette no longer holds stale `::view-transition-old(root)` snapshots