### PR TITLE
chore(icons): remove redundant SVG attributes and fix MistralIcon viewBox

### DIFF
--- a/src/components/icons/DaintreeIcon.tsx
+++ b/src/components/icons/DaintreeIcon.tsx
@@ -13,7 +13,6 @@ export function DaintreeIcon({ className, size = 16, style }: DaintreeIconProps)
       width={size}
       height={size}
       fill="currentColor"
-      xmlns="http://www.w3.org/2000/svg"
       className={cn(className)}
       style={style}
       aria-hidden="true"

--- a/src/components/icons/McpServerIcon.tsx
+++ b/src/components/icons/McpServerIcon.tsx
@@ -9,7 +9,6 @@ type IconProps = SVGProps<SVGSVGElement> & { className?: string };
 export function McpServerIcon({ className, ...props }: IconProps) {
   return (
     <svg
-      xmlns="http://www.w3.org/2000/svg"
       width="24"
       height="24"
       viewBox="0 0 24 24"

--- a/src/components/icons/__tests__/icons-a11y.test.tsx
+++ b/src/components/icons/__tests__/icons-a11y.test.tsx
@@ -16,6 +16,8 @@ import { InterpreterIcon } from "../brands/InterpreterIcon";
 import { GooseIcon } from "../brands/GooseIcon";
 import { PythonIcon } from "../brands/PythonIcon";
 import { DockerIcon } from "../brands/DockerIcon";
+import { AiderIcon } from "../brands/AiderIcon";
+import { MistralIcon } from "../brands/MistralIcon";
 
 describe("DaintreeIcon a11y", () => {
   it("is decorative and exposes no aria-label", () => {
@@ -95,5 +97,17 @@ describe("Brand icon a11y", () => {
     const { container } = render(<ClaudeIcon brandColor="#FF0000" />);
     const path = container.querySelector("svg path");
     expect(path?.getAttribute("fill")).toBe("#FF0000");
+  });
+
+  it("AiderIcon preserves fill='none' (stroke-only icon)", () => {
+    const { container } = render(<AiderIcon />);
+    const svg = container.querySelector("svg");
+    expect(svg?.getAttribute("fill")).toBe("none");
+  });
+
+  it("MistralIcon uses square viewBox to center the mark", () => {
+    const { container } = render(<MistralIcon />);
+    const svg = container.querySelector("svg");
+    expect(svg?.getAttribute("viewBox")).toBe("0 -30.5 213 213");
   });
 });

--- a/src/components/icons/brands/AiderIcon.tsx
+++ b/src/components/icons/brands/AiderIcon.tsx
@@ -20,7 +20,6 @@ export function AiderIcon({ className, size = 16, brandColor, ...props }: AiderI
       strokeWidth={2}
       strokeLinecap="round"
       strokeLinejoin="round"
-      xmlns="http://www.w3.org/2000/svg"
       className={cn(className)}
       aria-hidden="true"
       {...props}

--- a/src/components/icons/brands/AmpIcon.tsx
+++ b/src/components/icons/brands/AmpIcon.tsx
@@ -13,8 +13,6 @@ export function AmpIcon({ className, size = 16, brandColor, ...props }: AmpIconP
       width={size}
       height={size}
       viewBox="0 0 21 21"
-      fill="none"
-      xmlns="http://www.w3.org/2000/svg"
       className={cn(className)}
       aria-hidden="true"
       {...props}

--- a/src/components/icons/brands/BunIcon.tsx
+++ b/src/components/icons/brands/BunIcon.tsx
@@ -21,8 +21,6 @@ export function BunIcon({ className, size = 16, ...props }: BunIconProps) {
       width={size}
       height={size}
       viewBox="0 0 24 24"
-      fill="none"
-      xmlns="http://www.w3.org/2000/svg"
       className={cn(className)}
       aria-hidden="true"
       {...props}

--- a/src/components/icons/brands/ClaudeIcon.tsx
+++ b/src/components/icons/brands/ClaudeIcon.tsx
@@ -16,8 +16,6 @@ export function ClaudeIcon({ className, size = 16, brandColor, ...props }: Claud
       width={size}
       height={size}
       viewBox="0 0 1200 1200"
-      fill="none"
-      xmlns="http://www.w3.org/2000/svg"
       className={cn(className)}
       aria-hidden="true"
       {...props}

--- a/src/components/icons/brands/CodexIcon.tsx
+++ b/src/components/icons/brands/CodexIcon.tsx
@@ -16,8 +16,6 @@ export function CodexIcon({ className, size = 16, brandColor, ...props }: CodexI
       width={size}
       height={size}
       viewBox="0 0 320 320"
-      fill="none"
-      xmlns="http://www.w3.org/2000/svg"
       className={cn(className)}
       aria-hidden="true"
       {...props}

--- a/src/components/icons/brands/ComposerIcon.tsx
+++ b/src/components/icons/brands/ComposerIcon.tsx
@@ -11,8 +11,6 @@ export function ComposerIcon({ className, size = 16, ...props }: ComposerIconPro
       width={size}
       height={size}
       viewBox="0 0 24 24"
-      fill="none"
-      xmlns="http://www.w3.org/2000/svg"
       className={cn(className)}
       aria-hidden="true"
       {...props}

--- a/src/components/icons/brands/CopilotIcon.tsx
+++ b/src/components/icons/brands/CopilotIcon.tsx
@@ -12,8 +12,6 @@ export function CopilotIcon({ className, size = 16, brandColor, ...props }: Copi
       width={size}
       height={size}
       viewBox="0 0 24 24"
-      fill="none"
-      xmlns="http://www.w3.org/2000/svg"
       className={cn(className)}
       aria-hidden="true"
       {...props}

--- a/src/components/icons/brands/CrushIcon.tsx
+++ b/src/components/icons/brands/CrushIcon.tsx
@@ -12,8 +12,6 @@ export function CrushIcon({ className, size = 16, brandColor, ...props }: CrushI
       width={size}
       height={size}
       viewBox="0 0 24 24"
-      fill="none"
-      xmlns="http://www.w3.org/2000/svg"
       className={cn(className)}
       aria-hidden="true"
       {...props}

--- a/src/components/icons/brands/CursorIcon.tsx
+++ b/src/components/icons/brands/CursorIcon.tsx
@@ -14,8 +14,6 @@ export function CursorIcon({ className, size = 16, brandColor, ...props }: Curso
       width={size}
       height={size}
       viewBox="399 393 169 194"
-      fill="none"
-      xmlns="http://www.w3.org/2000/svg"
       className={cn(className)}
       aria-hidden="true"
       {...props}

--- a/src/components/icons/brands/DenoIcon.tsx
+++ b/src/components/icons/brands/DenoIcon.tsx
@@ -11,8 +11,6 @@ export function DenoIcon({ className, size = 16, ...props }: DenoIconProps) {
       width={size}
       height={size}
       viewBox="0 0 24 24"
-      fill="none"
-      xmlns="http://www.w3.org/2000/svg"
       className={cn(className)}
       aria-hidden="true"
       {...props}

--- a/src/components/icons/brands/DockerIcon.tsx
+++ b/src/components/icons/brands/DockerIcon.tsx
@@ -11,8 +11,6 @@ export function DockerIcon({ className, size = 16, ...props }: DockerIconProps) 
       width={size}
       height={size}
       viewBox="0 0 24 24"
-      fill="none"
-      xmlns="http://www.w3.org/2000/svg"
       className={cn(className)}
       aria-hidden="true"
       {...props}

--- a/src/components/icons/brands/ElixirIcon.tsx
+++ b/src/components/icons/brands/ElixirIcon.tsx
@@ -11,8 +11,6 @@ export function ElixirIcon({ className, size = 16, ...props }: ElixirIconProps) 
       width={size}
       height={size}
       viewBox="0 0 24 24"
-      fill="none"
-      xmlns="http://www.w3.org/2000/svg"
       className={cn(className)}
       aria-hidden="true"
       {...props}

--- a/src/components/icons/brands/GeminiIcon.tsx
+++ b/src/components/icons/brands/GeminiIcon.tsx
@@ -12,8 +12,6 @@ export function GeminiIcon({ className, size = 16, brandColor, ...props }: Gemin
       width={size}
       height={size}
       viewBox="0 0 65 65"
-      fill="none"
-      xmlns="http://www.w3.org/2000/svg"
       className={cn(className)}
       aria-hidden="true"
       {...props}

--- a/src/components/icons/brands/GoIcon.tsx
+++ b/src/components/icons/brands/GoIcon.tsx
@@ -11,8 +11,6 @@ export function GoIcon({ className, size = 16, ...props }: GoIconProps) {
       width={size}
       height={size}
       viewBox="0 0 24 24"
-      fill="none"
-      xmlns="http://www.w3.org/2000/svg"
       className={cn(className)}
       aria-hidden="true"
       {...props}

--- a/src/components/icons/brands/GooseIcon.tsx
+++ b/src/components/icons/brands/GooseIcon.tsx
@@ -14,8 +14,6 @@ export function GooseIcon({ className, size = 16, brandColor, ...props }: GooseI
       width={size}
       height={size}
       viewBox="0 0 24 24"
-      fill="none"
-      xmlns="http://www.w3.org/2000/svg"
       className={cn(className)}
       aria-hidden="true"
       {...props}

--- a/src/components/icons/brands/GradleIcon.tsx
+++ b/src/components/icons/brands/GradleIcon.tsx
@@ -11,8 +11,6 @@ export function GradleIcon({ className, size = 16, ...props }: GradleIconProps) 
       width={size}
       height={size}
       viewBox="0 0 24 24"
-      fill="none"
-      xmlns="http://www.w3.org/2000/svg"
       className={cn(className)}
       aria-hidden="true"
       {...props}

--- a/src/components/icons/brands/InterpreterIcon.tsx
+++ b/src/components/icons/brands/InterpreterIcon.tsx
@@ -20,8 +20,6 @@ export function InterpreterIcon({
       width={size}
       height={size}
       viewBox="0 0 24 24"
-      fill="none"
-      xmlns="http://www.w3.org/2000/svg"
       className={cn(className)}
       aria-hidden="true"
       {...props}

--- a/src/components/icons/brands/KimiIcon.tsx
+++ b/src/components/icons/brands/KimiIcon.tsx
@@ -12,8 +12,6 @@ export function KimiIcon({ className, size = 16, brandColor, ...props }: KimiIco
       width={size}
       height={size}
       viewBox="0 0 24 24"
-      fill="none"
-      xmlns="http://www.w3.org/2000/svg"
       className={cn(className)}
       aria-hidden="true"
       {...props}

--- a/src/components/icons/brands/KiroIcon.tsx
+++ b/src/components/icons/brands/KiroIcon.tsx
@@ -12,8 +12,6 @@ export function KiroIcon({ className, size = 16, brandColor, ...props }: KiroIco
       width={size}
       height={size}
       viewBox="0 0 1200 1200"
-      fill="none"
-      xmlns="http://www.w3.org/2000/svg"
       className={cn(className)}
       aria-hidden="true"
       {...props}

--- a/src/components/icons/brands/KotlinIcon.tsx
+++ b/src/components/icons/brands/KotlinIcon.tsx
@@ -11,8 +11,6 @@ export function KotlinIcon({ className, size = 16, ...props }: KotlinIconProps) 
       width={size}
       height={size}
       viewBox="0 0 24 24"
-      fill="none"
-      xmlns="http://www.w3.org/2000/svg"
       className={cn(className)}
       aria-hidden="true"
       {...props}

--- a/src/components/icons/brands/MistralIcon.tsx
+++ b/src/components/icons/brands/MistralIcon.tsx
@@ -16,9 +16,7 @@ export function MistralIcon({ className, size = 16, brandColor, ...props }: Mist
     <svg
       width={size}
       height={size}
-      viewBox="0 0 213 152"
-      fill="none"
-      xmlns="http://www.w3.org/2000/svg"
+      viewBox="0 -30.5 213 213"
       className={cn(className)}
       aria-hidden="true"
       {...props}

--- a/src/components/icons/brands/NodeIcon.tsx
+++ b/src/components/icons/brands/NodeIcon.tsx
@@ -11,8 +11,6 @@ export function NodeIcon({ className, size = 16, ...props }: NodeIconProps) {
       width={size}
       height={size}
       viewBox="0 0 24 24"
-      fill="none"
-      xmlns="http://www.w3.org/2000/svg"
       className={cn(className)}
       aria-hidden="true"
       {...props}

--- a/src/components/icons/brands/NpmIcon.tsx
+++ b/src/components/icons/brands/NpmIcon.tsx
@@ -16,8 +16,6 @@ export function NpmIcon({ className, size = 16, ...props }: NpmIconProps) {
       width={size}
       height={size}
       viewBox="0 0 24 24"
-      fill="none"
-      xmlns="http://www.w3.org/2000/svg"
       className={cn(className)}
       aria-hidden="true"
       {...props}

--- a/src/components/icons/brands/OpenCodeIcon.tsx
+++ b/src/components/icons/brands/OpenCodeIcon.tsx
@@ -14,8 +14,6 @@ export function OpenCodeIcon({ className, size = 16, brandColor, ...props }: Ope
       width={size}
       height={size}
       viewBox="0 0 24 24"
-      fill="none"
-      xmlns="http://www.w3.org/2000/svg"
       className={cn(className)}
       aria-hidden="true"
       {...props}

--- a/src/components/icons/brands/PhpIcon.tsx
+++ b/src/components/icons/brands/PhpIcon.tsx
@@ -11,8 +11,6 @@ export function PhpIcon({ className, size = 16, ...props }: PhpIconProps) {
       width={size}
       height={size}
       viewBox="0 0 24 24"
-      fill="none"
-      xmlns="http://www.w3.org/2000/svg"
       className={cn(className)}
       aria-hidden="true"
       {...props}

--- a/src/components/icons/brands/PnpmIcon.tsx
+++ b/src/components/icons/brands/PnpmIcon.tsx
@@ -11,8 +11,6 @@ export function PnpmIcon({ className, size = 16, ...props }: PnpmIconProps) {
       width={size}
       height={size}
       viewBox="0 0 24 24"
-      fill="none"
-      xmlns="http://www.w3.org/2000/svg"
       className={cn(className)}
       aria-hidden="true"
       {...props}

--- a/src/components/icons/brands/PythonIcon.tsx
+++ b/src/components/icons/brands/PythonIcon.tsx
@@ -11,8 +11,6 @@ export function PythonIcon({ className, size = 16, ...props }: PythonIconProps) 
       width={size}
       height={size}
       viewBox="0 0 24 24"
-      fill="none"
-      xmlns="http://www.w3.org/2000/svg"
       className={cn(className)}
       aria-hidden="true"
       {...props}

--- a/src/components/icons/brands/QwenIcon.tsx
+++ b/src/components/icons/brands/QwenIcon.tsx
@@ -12,8 +12,6 @@ export function QwenIcon({ className, size = 16, brandColor, ...props }: QwenIco
       width={size}
       height={size}
       viewBox="0 0 24 24"
-      fill="none"
-      xmlns="http://www.w3.org/2000/svg"
       className={cn(className)}
       aria-hidden="true"
       {...props}

--- a/src/components/icons/brands/RubyIcon.tsx
+++ b/src/components/icons/brands/RubyIcon.tsx
@@ -11,8 +11,6 @@ export function RubyIcon({ className, size = 16, ...props }: RubyIconProps) {
       width={size}
       height={size}
       viewBox="0 0 24 24"
-      fill="none"
-      xmlns="http://www.w3.org/2000/svg"
       className={cn(className)}
       aria-hidden="true"
       {...props}

--- a/src/components/icons/brands/RustIcon.tsx
+++ b/src/components/icons/brands/RustIcon.tsx
@@ -11,8 +11,6 @@ export function RustIcon({ className, size = 16, ...props }: RustIconProps) {
       width={size}
       height={size}
       viewBox="0 0 24 24"
-      fill="none"
-      xmlns="http://www.w3.org/2000/svg"
       className={cn(className)}
       aria-hidden="true"
       {...props}

--- a/src/components/icons/brands/SwiftIcon.tsx
+++ b/src/components/icons/brands/SwiftIcon.tsx
@@ -11,8 +11,6 @@ export function SwiftIcon({ className, size = 16, ...props }: SwiftIconProps) {
       width={size}
       height={size}
       viewBox="0 0 24 24"
-      fill="none"
-      xmlns="http://www.w3.org/2000/svg"
       className={cn(className)}
       aria-hidden="true"
       {...props}

--- a/src/components/icons/brands/TerraformIcon.tsx
+++ b/src/components/icons/brands/TerraformIcon.tsx
@@ -11,8 +11,6 @@ export function TerraformIcon({ className, size = 16, ...props }: TerraformIconP
       width={size}
       height={size}
       viewBox="0 0 24 24"
-      fill="none"
-      xmlns="http://www.w3.org/2000/svg"
       className={cn(className)}
       aria-hidden="true"
       {...props}

--- a/src/components/icons/brands/ViteIcon.tsx
+++ b/src/components/icons/brands/ViteIcon.tsx
@@ -11,8 +11,6 @@ export function ViteIcon({ className, size = 16, ...props }: ViteIconProps) {
       width={size}
       height={size}
       viewBox="0 0 24 24"
-      fill="none"
-      xmlns="http://www.w3.org/2000/svg"
       className={cn(className)}
       aria-hidden="true"
       {...props}

--- a/src/components/icons/brands/WebpackIcon.tsx
+++ b/src/components/icons/brands/WebpackIcon.tsx
@@ -11,8 +11,6 @@ export function WebpackIcon({ className, size = 16, ...props }: WebpackIconProps
       width={size}
       height={size}
       viewBox="0 0 24 24"
-      fill="none"
-      xmlns="http://www.w3.org/2000/svg"
       className={cn(className)}
       aria-hidden="true"
       {...props}

--- a/src/components/icons/brands/YarnIcon.tsx
+++ b/src/components/icons/brands/YarnIcon.tsx
@@ -11,8 +11,6 @@ export function YarnIcon({ className, size = 16, ...props }: YarnIconProps) {
       width={size}
       height={size}
       viewBox="0 0 24 24"
-      fill="none"
-      xmlns="http://www.w3.org/2000/svg"
       className={cn(className)}
       aria-hidden="true"
       {...props}


### PR DESCRIPTION
Removes redundant `xmlns` attributes from all 37 SVG icon components. Strips shadowed `fill="none"` wrapper attributes where inner `path`s already set their own fills. Fixes the `MistralIcon` `viewBox` from 213x152 to a square 213x213 so the mark doesn't letterbox at small sizes.

Adds a11y tests for the icon set.

Resolves #7275