### PR TITLE
fix(settings): bind labels and replace bespoke toggle for accessibility

### DIFF
--- a/src/components/Settings/EditorIntegrationTab.tsx
+++ b/src/components/Settings/EditorIntegrationTab.tsx
@@ -1,4 +1,4 @@
-import { useState, useEffect, useRef } from "react";
+import { useState, useEffect, useRef, useId } from "react";
 import { Code2, CheckCircle, AlertCircle, RefreshCw, ExternalLink } from "lucide-react";
 import { cn } from "@/lib/utils";
 import { SettingsSection } from "@/components/Settings/SettingsSection";
@@ -44,6 +44,9 @@ export function EditorIntegrationTab() {
   const [saveError, setSaveError] = useState<string | null>(null);
   const [testResult, setTestResult] = useState<"ok" | "error" | null>(null);
   const isMountedRef = useRef(true);
+  const editorId = useId();
+  const commandId = useId();
+  const argsId = useId();
 
   const activeProjectId = useProjectStore((s) => s.currentProject?.id);
 
@@ -155,9 +158,12 @@ export function EditorIntegrationTab() {
       >
         <div className="contents">
           <div className="space-y-1">
-            <label className="text-xs text-daintree-text/60">Editor</label>
+            <label htmlFor={editorId} className="text-xs text-daintree-text/60">
+              Editor
+            </label>
             <div className="flex items-center gap-2">
               <select
+                id={editorId}
                 value={selectedId}
                 onChange={(e) => setSelectedId(e.target.value as KnownEditorId)}
                 className="flex-1 bg-daintree-bg border border-border-strong rounded-[var(--radius-md)] px-3 py-1.5 text-sm text-daintree-text focus:outline-hidden focus:border-daintree-accent transition-colors"
@@ -214,8 +220,11 @@ export function EditorIntegrationTab() {
           {selectedId === "custom" && (
             <div className="space-y-3">
               <div className="space-y-1">
-                <label className="text-xs text-daintree-text/60">Command</label>
+                <label htmlFor={commandId} className="text-xs text-daintree-text/60">
+                  Command
+                </label>
                 <input
+                  id={commandId}
                   type="text"
                   value={customCommand}
                   onChange={(e) => setCustomCommand(e.target.value)}
@@ -224,8 +233,11 @@ export function EditorIntegrationTab() {
                 />
               </div>
               <div className="space-y-1">
-                <label className="text-xs text-daintree-text/60">Arguments template</label>
+                <label htmlFor={argsId} className="text-xs text-daintree-text/60">
+                  Arguments template
+                </label>
                 <input
+                  id={argsId}
                   type="text"
                   value={customTemplate}
                   onChange={(e) => setCustomTemplate(e.target.value)}

--- a/src/components/Settings/NotificationSettingsTab.tsx
+++ b/src/components/Settings/NotificationSettingsTab.tsx
@@ -1,4 +1,4 @@
-import { useState, useEffect } from "react";
+import { useState, useEffect, useId } from "react";
 import { Play, Bell, BellOff, Volume2, AudioLines, Moon } from "lucide-react";
 import { cn } from "@/lib/utils";
 import { SettingsSection } from "./SettingsSection";
@@ -71,11 +71,56 @@ function joinMinutes(hour: number, minute: number): number {
   return Math.max(0, Math.min(1439, hour * 60 + minute));
 }
 
+function SoundFileSelect({
+  label,
+  value,
+  onChange,
+  onPreview,
+}: {
+  label: string;
+  value: string;
+  onChange: (value: string) => void;
+  onPreview: () => void;
+}) {
+  const id = useId();
+  return (
+    <div className="space-y-1">
+      <label htmlFor={id} className="text-sm font-medium text-daintree-text block">
+        {label}
+      </label>
+      <div className="flex items-center gap-2">
+        <select
+          id={id}
+          value={value}
+          onChange={(e) => onChange(e.target.value)}
+          className="flex-1 px-3 pr-8 py-1.5 text-sm rounded-[var(--radius-md)] border border-border-strong bg-daintree-bg text-daintree-text focus:border-daintree-accent focus:outline-hidden transition-colors"
+        >
+          {AVAILABLE_SOUNDS.map(({ file, label: soundLabel }) => (
+            <option key={file} value={file}>
+              {soundLabel}
+            </option>
+          ))}
+        </select>
+        <button
+          onClick={onPreview}
+          title={`Preview ${label.toLowerCase()}`}
+          className="flex items-center gap-1.5 px-3 py-1.5 text-sm rounded-[var(--radius-md)] border border-daintree-border bg-daintree-bg text-daintree-text hover:bg-tint/[0.06] transition-colors"
+        >
+          <Play className="h-3.5 w-3.5" />
+          Preview
+        </button>
+      </div>
+    </div>
+  );
+}
+
 type LoadState = "loading" | "ready" | "error";
 
 export function NotificationSettingsTab() {
   const [settings, setSettings] = useState<NotificationSettings>(DEFAULT_SETTINGS);
   const [loadState, setLoadState] = useState<LoadState>("loading");
+  const escalationDelayId = useId();
+  const activeDaysId = useId();
 
   useEffect(() => {
     let settled = false;
@@ -208,10 +253,14 @@ export function NotificationSettingsTab() {
                 />
                 {settings.waitingEscalationEnabled && (
                   <div className="space-y-1">
-                    <label className="text-sm font-medium text-daintree-text block">
+                    <label
+                      htmlFor={escalationDelayId}
+                      className="text-sm font-medium text-daintree-text block"
+                    >
                       Escalation delay
                     </label>
                     <select
+                      id={escalationDelayId}
                       value={settings.waitingEscalationDelayMs}
                       onChange={(e) => update({ waitingEscalationDelayMs: Number(e.target.value) })}
                       className="px-3 pr-8 py-1.5 text-sm rounded-[var(--radius-md)] border border-border-strong bg-daintree-bg text-daintree-text focus:border-daintree-accent focus:outline-hidden transition-colors"
@@ -253,51 +302,30 @@ export function NotificationSettingsTab() {
 
             {settings.soundEnabled && (
               <div className="contents">
-                {(
-                  [
-                    {
-                      label: "Completed sound",
-                      field: "completedSoundFile" as const,
-                    },
-                    {
-                      label: "Waiting sound",
-                      field: "waitingSoundFile" as const,
-                    },
-                    {
-                      label: "Escalation sound",
-                      field: "escalationSoundFile" as const,
-                    },
-                    {
-                      label: "Working pulse sound",
-                      field: "workingPulseSoundFile" as const,
-                    },
-                  ] as const
-                ).map(({ label, field }) => (
-                  <div key={field} className="space-y-1">
-                    <label className="text-sm font-medium text-daintree-text block">{label}</label>
-                    <div className="flex items-center gap-2">
-                      <select
-                        value={settings[field]}
-                        onChange={(e) => update({ [field]: e.target.value })}
-                        className="flex-1 px-3 pr-8 py-1.5 text-sm rounded-[var(--radius-md)] border border-border-strong bg-daintree-bg text-daintree-text focus:border-daintree-accent focus:outline-hidden transition-colors"
-                      >
-                        {AVAILABLE_SOUNDS.map(({ file, label: soundLabel }) => (
-                          <option key={file} value={file}>
-                            {soundLabel}
-                          </option>
-                        ))}
-                      </select>
-                      <button
-                        onClick={() => handlePreview(settings[field])}
-                        title={`Preview ${label.toLowerCase()}`}
-                        className="flex items-center gap-1.5 px-3 py-1.5 text-sm rounded-[var(--radius-md)] border border-daintree-border bg-daintree-bg text-daintree-text hover:bg-tint/[0.06] transition-colors"
-                      >
-                        <Play className="h-3.5 w-3.5" />
-                        Preview
-                      </button>
-                    </div>
-                  </div>
-                ))}
+                <SoundFileSelect
+                  label="Completed sound"
+                  value={settings.completedSoundFile}
+                  onChange={(v) => update({ completedSoundFile: v })}
+                  onPreview={() => handlePreview(settings.completedSoundFile)}
+                />
+                <SoundFileSelect
+                  label="Waiting sound"
+                  value={settings.waitingSoundFile}
+                  onChange={(v) => update({ waitingSoundFile: v })}
+                  onPreview={() => handlePreview(settings.waitingSoundFile)}
+                />
+                <SoundFileSelect
+                  label="Escalation sound"
+                  value={settings.escalationSoundFile}
+                  onChange={(v) => update({ escalationSoundFile: v })}
+                  onPreview={() => handlePreview(settings.escalationSoundFile)}
+                />
+                <SoundFileSelect
+                  label="Working pulse sound"
+                  value={settings.workingPulseSoundFile}
+                  onChange={(v) => update({ workingPulseSoundFile: v })}
+                  onPreview={() => handlePreview(settings.workingPulseSoundFile)}
+                />
               </div>
             )}
           </div>
@@ -337,13 +365,13 @@ export function NotificationSettingsTab() {
                   </div>
                 )}
                 <div className="space-y-1">
-                  <label className="text-sm font-medium text-daintree-text block">
+                  <span id={activeDaysId} className="text-sm font-medium text-daintree-text block">
                     Active days
-                  </label>
+                  </span>
                   <div className="text-xs text-daintree-text/60 mb-2">
                     Leave all boxes checked to apply every day.
                   </div>
-                  <div className="flex flex-wrap gap-2">
+                  <div role="group" aria-labelledby={activeDaysId} className="flex flex-wrap gap-2">
                     {WEEKDAYS.map(({ value, label }) => {
                       const active =
                         settings.quietHoursWeekdays.length === 0 ||
@@ -415,7 +443,7 @@ function QuietHoursTimeRow({
     "px-3 pr-8 py-1.5 text-sm rounded-[var(--radius-md)] border border-border-strong bg-daintree-bg text-daintree-text focus:border-daintree-accent focus:outline-hidden transition-colors";
   return (
     <div className="space-y-1">
-      <label className="text-sm font-medium text-daintree-text block">{label}</label>
+      <span className="text-sm font-medium text-daintree-text block">{label}</span>
       <div className="flex items-center gap-2">
         <select
           aria-label={`${label} hour`}

--- a/src/components/Settings/PortalSettingsTab.tsx
+++ b/src/components/Settings/PortalSettingsTab.tsx
@@ -228,12 +228,14 @@ export function PortalSettingsTab() {
           />
           <button
             onClick={handleSaveEdit}
+            aria-label="Save edit"
             className="p-1.5 rounded hover:bg-daintree-border/50 text-status-success"
           >
             <Check className="w-4 h-4" />
           </button>
           <button
             onClick={handleCancelEdit}
+            aria-label="Cancel edit"
             className="p-1.5 rounded hover:bg-daintree-border/50 text-daintree-text/50"
           >
             <X className="w-4 h-4" />
@@ -345,6 +347,7 @@ export function PortalSettingsTab() {
                   if (e.key === "Enter") handleCustomUrlSave();
                   if (e.key === "Escape") handleCustomUrlCancel();
                 }}
+                aria-label="Custom URL"
                 aria-invalid={!!customUrlError || undefined}
                 aria-describedby={customUrlError ? customUrlErrorId : undefined}
                 autoFocus

--- a/src/components/Settings/PortalSettingsTab.tsx
+++ b/src/components/Settings/PortalSettingsTab.tsx
@@ -1,6 +1,5 @@
 import { useId, useState } from "react";
 import { Plus, Trash2, Globe, Check, X, Search, PanelRight, Link } from "lucide-react";
-import { cn } from "@/lib/utils";
 import { Tooltip, TooltipContent, TooltipTrigger } from "@/components/ui/tooltip";
 import { usePortalStore } from "@/store/portalStore";
 import { getAgentConfig, isRegisteredAgent } from "@/config/agents";
@@ -8,6 +7,7 @@ import { BrandMark } from "@/components/icons";
 import { actionService } from "@/services/ActionService";
 import { SettingsSection } from "./SettingsSection";
 import { SettingsSelect } from "./SettingsSelect";
+import { SettingsSwitch } from "./SettingsSwitch";
 import { useSettingsTabValidation } from "./SettingsValidationRegistry";
 
 function ServiceIcon({ name, size = 16 }: { name: string; size?: number }) {
@@ -216,6 +216,7 @@ export function PortalSettingsTab() {
             onChange={(e) => setEditName(e.target.value)}
             className="bg-daintree-bg border border-border-strong rounded-[var(--radius-md)] px-2 py-1 text-sm text-daintree-text w-32 focus:border-daintree-accent focus:outline-hidden"
             placeholder="e.g. My portal"
+            aria-label="Edit link name"
           />
           <input
             type="text"
@@ -223,6 +224,7 @@ export function PortalSettingsTab() {
             onChange={(e) => setEditUrl(e.target.value)}
             className="bg-daintree-bg border border-border-strong rounded-[var(--radius-md)] px-2 py-1 text-sm text-daintree-text flex-1 focus:border-daintree-accent focus:outline-hidden"
             placeholder="e.g. https://github.com/owner/repo"
+            aria-label="Edit link URL"
           />
           <button
             onClick={handleSaveEdit}
@@ -269,8 +271,9 @@ export function PortalSettingsTab() {
           >
             Edit
           </button>
-          <button
-            onClick={() =>
+          <SettingsSwitch
+            checked={link.enabled}
+            onCheckedChange={() =>
               void actionService.dispatch(
                 "portal.links.toggle",
                 { id: link.id },
@@ -278,19 +281,8 @@ export function PortalSettingsTab() {
               )
             }
             disabled={link.alwaysEnabled}
-            className={cn(
-              "w-10 h-5 rounded-full relative transition-colors shrink-0",
-              link.alwaysEnabled && "opacity-50 cursor-not-allowed",
-              link.enabled ? "bg-daintree-accent" : "bg-daintree-border"
-            )}
-          >
-            <div
-              className={cn(
-                "absolute top-0.5 w-4 h-4 rounded-full transition-transform",
-                link.enabled ? "translate-x-5 bg-text-inverse" : "translate-x-0.5 bg-daintree-text"
-              )}
-            />
-          </button>
+            aria-label={`Toggle ${link.title || "portal link"}`}
+          />
           {allowDelete && (
             <button
               onClick={() =>
@@ -417,6 +409,7 @@ export function PortalSettingsTab() {
                 setUrlError("");
               }}
               className="bg-daintree-bg border border-border-strong rounded-[var(--radius-md)] px-3 py-1.5 text-sm text-daintree-text w-32 focus:border-daintree-accent focus:outline-hidden transition-colors"
+              aria-label="New link name"
             />
             <input
               type="text"
@@ -430,6 +423,7 @@ export function PortalSettingsTab() {
               onKeyDown={(e) => {
                 if (e.key === "Enter") handleAddLink();
               }}
+              aria-label="New link URL"
               aria-invalid={!!urlError || undefined}
               aria-describedby={urlError ? addLinkErrorId : undefined}
             />


### PR DESCRIPTION
## Summary
Bound orphaned `<label>` elements with `useId()`/`htmlFor`/`id` across three settings tabs so screen readers can associate labels with controls. Replaced the bespoke Portal toggle button with the existing Radix-backed `SettingsSwitch` component, which brings `role="switch"` and `aria-checked` for free. Added `aria-label` to placeholder-only inputs and fixed two cases where `<label>` was being used for non-label elements (a button group and a dual-select row).

Resolves #7263.

## Changes
- **`NotificationSettingsTab`** — bound `htmlFor`/`id` on escalation delay and all four sound file selects; extracted a `SoundFileSelect` helper component to deduplicate the repeated markup; switched the active-days button group from `<label>` to `<span>` with `role="group"` + `aria-labelledby`; switched the quiet-hours dual-select row from `<label>` to `<span>`.
- **`EditorIntegrationTab`** — bound `htmlFor`/`id` on the editor select, command input, and arguments template input.
- **`PortalSettingsTab`** — replaced the 10x5 bespoke toggle `<button>` with `SettingsSwitch` (Radix-backed, proper switch semantics); added `aria-label` to edit/add link inputs that previously only had `placeholder` text.

## Testing
Verified each tab renders correctly with bound labels, toggle still toggles, and inputs retain their existing behavior.