### PR TITLE
fix(recipes): surface partial-failure feedback in recipe runner

### DIFF
--- a/src/components/Terminal/RecipeRunner/RecipeRunner.tsx
+++ b/src/components/Terminal/RecipeRunner/RecipeRunner.tsx
@@ -2,10 +2,21 @@ import { useRecipeRunner } from "./useRecipeRunner";
 import { RecipeRunnerGrid } from "./RecipeRunnerGrid";
 import { RecipeRunnerList } from "./RecipeRunnerList";
 import { RecipeRunnerEmpty } from "./RecipeRunnerEmpty";
+import { InlineStatusBanner } from "@/components/Terminal/InlineStatusBanner";
+import { AlertTriangle, RotateCcw } from "lucide-react";
 
 interface RecipeRunnerProps {
   activeWorktreeId: string | null | undefined;
   defaultCwd: string | undefined;
+}
+
+function buildBannerTitle(spawned: number, total: number, failedNames: string[]): string {
+  const failedCount = failedNames.length;
+  if (spawned === 0) {
+    return `Couldn't start any terminals. ${failedCount} failed.`;
+  }
+  const terminalWord = spawned === 1 ? "terminal" : "terminals";
+  return `Started ${spawned} of ${total} ${terminalWord}. ${failedCount} failed: ${failedNames.join(", ")}.`;
 }
 
 export function RecipeRunner({ activeWorktreeId, defaultCwd }: RecipeRunnerProps) {
@@ -16,9 +27,40 @@ export function RecipeRunner({ activeWorktreeId, defaultCwd }: RecipeRunnerProps
   }
 
   const flatRecipes = runner.getFlatRecipes();
+  const banner = runner.spawnBanner;
 
   return (
     <div className="w-full max-w-lg">
+      {banner && (
+        <InlineStatusBanner
+          icon={AlertTriangle}
+          severity="warning"
+          title={buildBannerTitle(
+            banner.spawned,
+            banner.total,
+            banner.failed.map((f) => f.name)
+          )}
+          description={
+            banner.unresolvedVars.length > 0
+              ? `Missing context for ${banner.unresolvedVars.map((v) => `{{${v}}}`).join(", ")}.`
+              : undefined
+          }
+          actions={
+            banner.failed.length > 0
+              ? [
+                  {
+                    id: "retry-failed",
+                    label: "Retry failed",
+                    icon: RotateCcw,
+                    variant: "primary",
+                    onClick: runner.retryFailed,
+                  },
+                ]
+              : []
+          }
+          onClose={runner.dismissSpawnBanner}
+        />
+      )}
       {runner.showSearch ? (
         <RecipeRunnerList
           sections={runner.sections}

--- a/src/components/Terminal/RecipeRunner/RecipeRunner.tsx
+++ b/src/components/Terminal/RecipeRunner/RecipeRunner.tsx
@@ -12,8 +12,12 @@ interface RecipeRunnerProps {
 
 function buildBannerTitle(spawned: number, total: number, failedNames: string[]): string {
   const failedCount = failedNames.length;
-  if (spawned === 0) {
+  if (spawned === 0 && failedCount > 0) {
     return `Couldn't start any terminals. ${failedCount} failed.`;
+  }
+  if (failedCount === 0) {
+    const terminalWord = total === 1 ? "terminal" : "terminals";
+    return `Started ${total} ${terminalWord}.`;
   }
   const terminalWord = spawned === 1 ? "terminal" : "terminals";
   return `Started ${spawned} of ${total} ${terminalWord}. ${failedCount} failed: ${failedNames.join(", ")}.`;

--- a/src/components/Terminal/RecipeRunner/__tests__/RecipeRunner.test.tsx
+++ b/src/components/Terminal/RecipeRunner/__tests__/RecipeRunner.test.tsx
@@ -1,0 +1,205 @@
+// @vitest-environment jsdom
+import { describe, it, expect, vi } from "vitest";
+import { render } from "@testing-library/react";
+import type { UseRecipeRunnerResult, SpawnBannerState } from "../useRecipeRunner";
+import type { TerminalRecipe, RunCommand } from "@/types";
+import type { RecipeSections, RankedRecipe } from "../recipeRunnerUtils";
+
+let mockRunnerResult: UseRecipeRunnerResult;
+
+vi.mock("../useRecipeRunner", () => ({
+  useRecipeRunner: () => mockRunnerResult,
+}));
+
+vi.mock("../RecipeRunnerGrid", () => ({
+  RecipeRunnerGrid: ({ recipes }: { recipes: TerminalRecipe[] }) => (
+    <div data-testid="recipe-grid">{recipes.length} recipes</div>
+  ),
+}));
+
+vi.mock("../RecipeRunnerList", () => ({
+  RecipeRunnerList: () => <div data-testid="recipe-list">List</div>,
+}));
+
+vi.mock("../RecipeRunnerEmpty", () => ({
+  RecipeRunnerEmpty: ({ onCreate }: { onCreate: () => void }) => (
+    <button data-testid="recipe-empty-create" onClick={onCreate}>
+      Create recipe
+    </button>
+  ),
+}));
+
+vi.mock("@/components/Terminal/InlineStatusBanner", () => ({
+  InlineStatusBanner: ({
+    title,
+    description,
+    actions,
+    onClose,
+  }: {
+    title: string;
+    description?: string;
+    actions?: Array<{ id: string; label: string; onClick: () => void }>;
+    onClose?: () => void;
+  }) => (
+    <div data-testid="inline-banner">
+      <span data-testid="banner-title">{title}</span>
+      {description && <span data-testid="banner-description">{description}</span>}
+      {actions?.map((a) => (
+        <button key={a.id} data-testid={`banner-action-${a.id}`} onClick={a.onClick}>
+          {a.label}
+        </button>
+      ))}
+      {onClose && (
+        <button data-testid="banner-close" onClick={onClose}>
+          Dismiss
+        </button>
+      )}
+    </div>
+  ),
+}));
+
+import { RecipeRunner } from "../RecipeRunner";
+
+function baseRunner(): UseRecipeRunnerResult {
+  return {
+    recipes: [],
+    sections: { pinned: [], recent: [], all: [] } as RecipeSections,
+    searchQuery: "",
+    setSearchQuery: vi.fn(),
+    searchResults: [] as RankedRecipe[],
+    focusedIndex: 0,
+    setFocusedIndex: vi.fn(),
+    showSearch: false,
+    totalItems: 1,
+    focusedItemId: undefined,
+    suggestions: [] as RunCommand[],
+    handleRun: vi.fn(),
+    handleEdit: vi.fn(),
+    handleDuplicate: vi.fn(),
+    handlePin: vi.fn(),
+    handleUnpin: vi.fn(),
+    handleDelete: vi.fn(),
+    handleCreate: vi.fn(),
+    handleKeyDown: vi.fn(),
+    getFlatRecipes: vi.fn(() => []),
+    spawnBanner: null,
+    dismissSpawnBanner: vi.fn(),
+    retryFailed: vi.fn(),
+  };
+}
+
+function makeBanner(overrides?: Partial<SpawnBannerState>): SpawnBannerState {
+  return {
+    recipeId: "r1",
+    recipeName: "Test Recipe",
+    total: 4,
+    spawned: 3,
+    failed: [{ index: 1, name: "Codex Agent" }],
+    unresolvedVars: [],
+    ...overrides,
+  };
+}
+
+function makeRecipe(id: string, name = id): TerminalRecipe {
+  return {
+    id,
+    name,
+    terminals: [{ type: "terminal", env: {} }],
+    createdAt: Date.now(),
+  } as TerminalRecipe;
+}
+
+describe("RecipeRunner", () => {
+  it("shows empty state when no recipes", () => {
+    mockRunnerResult = { ...baseRunner(), recipes: [] };
+    const { getByTestId } = render(<RecipeRunner activeWorktreeId="wt-1" defaultCwd="/tmp" />);
+    expect(getByTestId("recipe-empty-create")).toBeTruthy();
+  });
+
+  it("renders grid when recipes exist and search is hidden", () => {
+    mockRunnerResult = {
+      ...baseRunner(),
+      recipes: [makeRecipe("r1")],
+      getFlatRecipes: vi.fn(() => [makeRecipe("r1")]),
+      showSearch: false,
+    };
+    const { getByTestId } = render(<RecipeRunner activeWorktreeId="wt-1" defaultCwd="/tmp" />);
+    expect(getByTestId("recipe-grid")).toBeTruthy();
+  });
+
+  it("renders banner above grid when spawnBanner is set", () => {
+    const retryMock = vi.fn();
+    const dismissMock = vi.fn();
+    mockRunnerResult = {
+      ...baseRunner(),
+      recipes: [makeRecipe("r1")],
+      getFlatRecipes: vi.fn(() => [makeRecipe("r1")]),
+      showSearch: false,
+      spawnBanner: makeBanner(),
+      retryFailed: retryMock,
+      dismissSpawnBanner: dismissMock,
+    };
+    const { getByTestId } = render(<RecipeRunner activeWorktreeId="wt-1" defaultCwd="/tmp" />);
+    expect(getByTestId("inline-banner")).toBeTruthy();
+    expect(getByTestId("banner-title").textContent).toContain("Started 3 of 4");
+  });
+
+  it("shows unresolved var description in banner", () => {
+    mockRunnerResult = {
+      ...baseRunner(),
+      recipes: [makeRecipe("r1")],
+      getFlatRecipes: vi.fn(() => [makeRecipe("r1")]),
+      showSearch: false,
+      spawnBanner: makeBanner({
+        spawned: 4,
+        failed: [],
+        unresolvedVars: ["issue_number", "branch_name"],
+      }),
+    };
+    const { getByTestId } = render(<RecipeRunner activeWorktreeId="wt-1" defaultCwd="/tmp" />);
+    expect(getByTestId("banner-description").textContent).toContain("{{issue_number}}");
+    expect(getByTestId("banner-description").textContent).toContain("{{branch_name}}");
+  });
+
+  it("does not show retry button when there are no spawn failures", () => {
+    mockRunnerResult = {
+      ...baseRunner(),
+      recipes: [makeRecipe("r1")],
+      getFlatRecipes: vi.fn(() => [makeRecipe("r1")]),
+      showSearch: false,
+      spawnBanner: makeBanner({ spawned: 4, failed: [], unresolvedVars: ["issue_number"] }),
+    };
+    const { queryByTestId } = render(<RecipeRunner activeWorktreeId="wt-1" defaultCwd="/tmp" />);
+    expect(queryByTestId("banner-action-retry-failed")).toBeNull();
+  });
+
+  it("shows retry button when there are spawn failures", () => {
+    mockRunnerResult = {
+      ...baseRunner(),
+      recipes: [makeRecipe("r1")],
+      getFlatRecipes: vi.fn(() => [makeRecipe("r1")]),
+      showSearch: false,
+      spawnBanner: makeBanner(),
+    };
+    const { getByTestId } = render(<RecipeRunner activeWorktreeId="wt-1" defaultCwd="/tmp" />);
+    expect(getByTestId("banner-action-retry-failed")).toBeTruthy();
+  });
+
+  it("banner title handles all-failed case", () => {
+    mockRunnerResult = {
+      ...baseRunner(),
+      recipes: [makeRecipe("r1")],
+      getFlatRecipes: vi.fn(() => [makeRecipe("r1")]),
+      showSearch: false,
+      spawnBanner: makeBanner({
+        spawned: 0,
+        failed: [
+          { index: 0, name: "Shell 1" },
+          { index: 1, name: "Shell 2" },
+        ],
+      }),
+    };
+    const { getByTestId } = render(<RecipeRunner activeWorktreeId="wt-1" defaultCwd="/tmp" />);
+    expect(getByTestId("banner-title").textContent).toContain("Couldn't start any terminals");
+  });
+});

--- a/src/components/Terminal/RecipeRunner/__tests__/useRecipeRunner.test.tsx
+++ b/src/components/Terminal/RecipeRunner/__tests__/useRecipeRunner.test.tsx
@@ -1,0 +1,294 @@
+// @vitest-environment jsdom
+import { describe, it, expect, vi, beforeEach } from "vitest";
+import { renderHook, act } from "@testing-library/react";
+
+const runRecipeWithResultsMock = vi.fn();
+const getRecipeByIdMock = vi.fn();
+
+let mockRecipes: Array<{
+  id: string;
+  name: string;
+  terminals: Array<{
+    type: string;
+    title?: string;
+    command?: string;
+    initialPrompt?: string;
+    env?: Record<string, string>;
+  }>;
+  worktreeId?: string;
+  createdAt: number;
+}> = [];
+
+let mockWorktreeData: Record<string, { issueNumber?: number; prNumber?: number; branch?: string }> =
+  {};
+
+vi.mock("@/store/recipeStore", () => ({
+  useRecipeStore: Object.assign(
+    (selector: (s: unknown) => unknown) =>
+      selector({
+        recipes: mockRecipes,
+        runRecipeWithResults: runRecipeWithResultsMock,
+        updateRecipe: vi.fn(),
+        deleteRecipe: vi.fn(),
+        createRecipe: vi.fn(),
+        getRecipeById: getRecipeByIdMock,
+      }),
+    { getState: () => ({ recipes: mockRecipes, runRecipeWithResults: runRecipeWithResultsMock }) }
+  ),
+}));
+
+vi.mock("@/store/createWorktreeStore", () => ({
+  getCurrentViewStore: () => ({
+    getState: () => ({
+      worktrees: new Map(Object.entries(mockWorktreeData)),
+    }),
+  }),
+}));
+
+vi.mock("@/store/projectSettingsStore", () => ({
+  useProjectSettingsStore: (selector: (s: unknown) => unknown) =>
+    selector({ allDetectedRunners: [] }),
+}));
+
+vi.mock("@/services/ActionService", () => ({
+  actionService: { dispatch: vi.fn() },
+}));
+
+vi.mock("@/config/agents", () => ({
+  getAgentDisplayTitle: (id: string) =>
+    id === "claude" ? "Claude Code" : id === "codex" ? "Codex" : id,
+}));
+
+import { useRecipeRunner } from "../useRecipeRunner";
+import type { TerminalRecipe } from "@/types";
+
+function makeRecipe(
+  overrides: Partial<TerminalRecipe> & { id: string; name: string }
+): TerminalRecipe {
+  return {
+    terminals: [{ type: "terminal", env: {} }],
+    createdAt: Date.now(),
+    ...overrides,
+  } as TerminalRecipe;
+}
+
+describe("useRecipeRunner", () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+    mockRecipes = [];
+    mockWorktreeData = {};
+    runRecipeWithResultsMock.mockResolvedValue({ spawned: [], failed: [] });
+    getRecipeByIdMock.mockImplementation((id: string) => mockRecipes.find((r) => r.id === id));
+  });
+
+  it("calls runRecipeWithResults with recipe context on handleRun", async () => {
+    const recipe = makeRecipe({
+      id: "r1",
+      name: "Test",
+      terminals: [{ type: "terminal", command: "echo hi", env: {} }],
+    });
+    mockRecipes = [recipe];
+    mockWorktreeData = { "wt-1": { issueNumber: 42, branch: "feature/x" } };
+    runRecipeWithResultsMock.mockResolvedValue({
+      spawned: [{ index: 0, terminalId: "t1" }],
+      failed: [],
+    });
+
+    const { result } = renderHook(() =>
+      useRecipeRunner({ activeWorktreeId: "wt-1", defaultCwd: "/tmp" })
+    );
+
+    await act(async () => {
+      result.current.handleRun("r1");
+    });
+
+    expect(runRecipeWithResultsMock).toHaveBeenCalledWith(
+      "r1",
+      "/tmp",
+      "wt-1",
+      { issueNumber: 42, prNumber: undefined, worktreePath: "/tmp", branchName: "feature/x" },
+      { spawnedBy: "recipe" }
+    );
+  });
+
+  it("sets spawnBanner on partial failure", async () => {
+    const recipe = makeRecipe({
+      id: "r1",
+      name: "Multi Terminal",
+      terminals: [
+        { type: "terminal", title: "Shell", command: "npm test", env: {} },
+        { type: "terminal", title: "Watch", command: "npm watch", env: {} },
+      ],
+    });
+    mockRecipes = [recipe];
+    runRecipeWithResultsMock.mockResolvedValue({
+      spawned: [{ index: 0, terminalId: "t1" }],
+      failed: [{ index: 1, error: "Panel limit reached" }],
+    });
+
+    const { result } = renderHook(() =>
+      useRecipeRunner({ activeWorktreeId: "wt-1", defaultCwd: "/tmp" })
+    );
+
+    await act(async () => {
+      result.current.handleRun("r1");
+    });
+
+    expect(result.current.spawnBanner).not.toBeNull();
+    expect(result.current.spawnBanner!.spawned).toBe(1);
+    expect(result.current.spawnBanner!.total).toBe(2);
+    expect(result.current.spawnBanner!.failed).toHaveLength(1);
+    expect(result.current.spawnBanner!.failed[0]!.name).toBe("Watch");
+  });
+
+  it("does not set spawnBanner when all terminals succeed", async () => {
+    const recipe = makeRecipe({
+      id: "r1",
+      name: "All Good",
+      terminals: [
+        { type: "terminal", title: "A", command: "echo a", env: {} },
+        { type: "terminal", title: "B", command: "echo b", env: {} },
+      ],
+    });
+    mockRecipes = [recipe];
+    runRecipeWithResultsMock.mockResolvedValue({
+      spawned: [
+        { index: 0, terminalId: "t1" },
+        { index: 1, terminalId: "t2" },
+      ],
+      failed: [],
+    });
+
+    const { result } = renderHook(() =>
+      useRecipeRunner({ activeWorktreeId: "wt-1", defaultCwd: "/tmp" })
+    );
+
+    await act(async () => {
+      result.current.handleRun("r1");
+    });
+
+    expect(result.current.spawnBanner).toBeNull();
+  });
+
+  it("sets spawnBanner when unresolved variables exist", async () => {
+    const recipe = makeRecipe({
+      id: "r1",
+      name: "Missing Vars",
+      terminals: [
+        { type: "terminal", title: "A", command: "gh issue view {{issue_number}}", env: {} },
+      ],
+    });
+    mockRecipes = [recipe];
+    runRecipeWithResultsMock.mockResolvedValue({
+      spawned: [{ index: 0, terminalId: "t1" }],
+      failed: [],
+    });
+
+    const { result } = renderHook(() =>
+      useRecipeRunner({ activeWorktreeId: "wt-1", defaultCwd: "/tmp" })
+    );
+
+    await act(async () => {
+      result.current.handleRun("r1");
+    });
+
+    expect(result.current.spawnBanner).not.toBeNull();
+    expect(result.current.spawnBanner!.unresolvedVars).toContain("issue_number");
+  });
+
+  it("dismissSpawnBanner clears the banner", async () => {
+    const recipe = makeRecipe({
+      id: "r1",
+      name: "Test",
+      terminals: [
+        { type: "terminal", title: "A", command: "gh issue view {{issue_number}}", env: {} },
+      ],
+    });
+    mockRecipes = [recipe];
+    runRecipeWithResultsMock.mockResolvedValue({
+      spawned: [{ index: 0, terminalId: "t1" }],
+      failed: [],
+    });
+
+    const { result } = renderHook(() =>
+      useRecipeRunner({ activeWorktreeId: "wt-1", defaultCwd: "/tmp" })
+    );
+
+    await act(async () => {
+      result.current.handleRun("r1");
+    });
+    expect(result.current.spawnBanner).not.toBeNull();
+
+    act(() => {
+      result.current.dismissSpawnBanner();
+    });
+    expect(result.current.spawnBanner).toBeNull();
+  });
+
+  it("retryFailed calls runRecipeWithResults with failed terminal indices", async () => {
+    const recipe = makeRecipe({
+      id: "r1",
+      name: "Multi",
+      terminals: [
+        { type: "terminal", title: "A", command: "echo a", env: {} },
+        { type: "terminal", title: "B", command: "echo b", env: {} },
+        { type: "terminal", title: "C", command: "echo c", env: {} },
+      ],
+    });
+    mockRecipes = [recipe];
+    mockWorktreeData = { "wt-1": { branch: "main" } };
+
+    runRecipeWithResultsMock
+      .mockResolvedValueOnce({
+        spawned: [
+          { index: 0, terminalId: "t1" },
+          { index: 2, terminalId: "t3" },
+        ],
+        failed: [{ index: 1, error: "Panel limit reached" }],
+      })
+      .mockResolvedValueOnce({
+        spawned: [{ index: 1, terminalId: "t2" }],
+        failed: [],
+      });
+
+    const { result } = renderHook(() =>
+      useRecipeRunner({ activeWorktreeId: "wt-1", defaultCwd: "/tmp" })
+    );
+
+    await act(async () => {
+      result.current.handleRun("r1");
+    });
+
+    await act(async () => {
+      result.current.retryFailed();
+    });
+
+    expect(runRecipeWithResultsMock).toHaveBeenCalledTimes(2);
+    const retryCall = runRecipeWithResultsMock.mock.calls[1]!;
+    expect(retryCall[0]).toBe("r1");
+    expect(retryCall[4]).toEqual(expect.objectContaining({ terminalIndices: [1] }));
+  });
+
+  it("uses getAgentDisplayTitle for agent terminal names", async () => {
+    const recipe = makeRecipe({
+      id: "r1",
+      name: "Agent Recipe",
+      terminals: [{ type: "claude", title: "", command: undefined, env: {} }],
+    });
+    mockRecipes = [recipe];
+    runRecipeWithResultsMock.mockResolvedValue({
+      spawned: [],
+      failed: [{ index: 0, error: "Failed" }],
+    });
+
+    const { result } = renderHook(() =>
+      useRecipeRunner({ activeWorktreeId: "wt-1", defaultCwd: "/tmp" })
+    );
+
+    await act(async () => {
+      result.current.handleRun("r1");
+    });
+
+    expect(result.current.spawnBanner!.failed[0]!.name).toBe("Claude Code");
+  });
+});

--- a/src/components/Terminal/RecipeRunner/useRecipeRunner.ts
+++ b/src/components/Terminal/RecipeRunner/useRecipeRunner.ts
@@ -209,42 +209,50 @@ export function useRecipeRunner({
     setSpawnBanner(null);
   }, []);
 
+  const spawnBannerRef = useRef<SpawnBannerState | null>(null);
+  // Keep ref in sync so retryFailed reads the latest banner without a stale closure.
+  useEffect(() => {
+    spawnBannerRef.current = spawnBanner;
+  }, [spawnBanner]);
+
   const retryFailed = useCallback(() => {
-    setSpawnBanner((current) => {
-      if (!current || current.failed.length === 0) return null;
-      const recipe = getRecipeById(current.recipeId);
-      if (!recipe) return null;
+    const banner = spawnBannerRef.current;
+    if (!banner || banner.failed.length === 0) return;
+    if (!defaultCwd) return;
 
-      const context = resolveContext();
-      const indices = current.failed.map((f) => f.index);
+    const recipe = getRecipeById(banner.recipeId);
+    if (!recipe) return;
 
-      runRecipeWithResults(current.recipeId, defaultCwd!, activeWorktreeId ?? undefined, context, {
-        spawnedBy: "recipe",
-        terminalIndices: indices,
+    const context = resolveContext();
+    const indices = banner.failed.map((f) => f.index);
+    const alreadySpawned = banner.total - banner.failed.length;
+    const runId = ++runCounterRef.current;
+
+    runRecipeWithResults(banner.recipeId, defaultCwd, activeWorktreeId ?? undefined, context, {
+      spawnedBy: "recipe",
+      terminalIndices: indices,
+    })
+      .then((results) => {
+        if (runId !== runCounterRef.current) return;
+
+        const stillFailed = results.failed.map((f) => {
+          const terminal = recipe.terminals[f.index];
+          const name = terminal ? buildDisplayName(terminal) : `Terminal ${f.index + 1}`;
+          return { index: f.index, name };
+        });
+
+        setSpawnBanner((prev) => {
+          if (!prev || prev.recipeId !== banner.recipeId) return prev;
+          const cumSpawned = alreadySpawned + results.spawned.length;
+          if (stillFailed.length === 0 && prev.unresolvedVars.length === 0) return null;
+          return {
+            ...prev,
+            spawned: cumSpawned,
+            failed: stillFailed,
+          };
+        });
       })
-        .then((results) => {
-          const stillFailed = results.failed.map((f) => {
-            const terminal = recipe.terminals[f.index];
-            const name = terminal ? buildDisplayName(terminal) : `Terminal ${f.index + 1}`;
-            return { index: f.index, name };
-          });
-
-          setSpawnBanner((prev) => {
-            if (!prev) return null;
-            const prevUnresolved = prev.unresolvedVars;
-            if (stillFailed.length === 0 && prevUnresolved.length === 0) return null;
-            return {
-              ...prev,
-              spawned: results.spawned.length,
-              failed: stillFailed,
-              unresolvedVars: prevUnresolved,
-            };
-          });
-        })
-        .catch(() => {});
-
-      return current;
-    });
+      .catch(() => {});
   }, [
     getRecipeById,
     resolveContext,

--- a/src/components/Terminal/RecipeRunner/useRecipeRunner.ts
+++ b/src/components/Terminal/RecipeRunner/useRecipeRunner.ts
@@ -1,8 +1,10 @@
-import { useMemo, useState, useCallback, useEffect } from "react";
+import { useMemo, useState, useCallback, useEffect, useRef } from "react";
 import { useRecipeStore } from "@/store/recipeStore";
 import { getCurrentViewStore } from "@/store/createWorktreeStore";
 import { useProjectSettingsStore } from "@/store/projectSettingsStore";
 import { actionService } from "@/services/ActionService";
+import { detectUnresolvedVariables, type RecipeContext } from "@/utils/recipeVariables";
+import { getAgentDisplayTitle } from "@/config/agents";
 import {
   buildRecipeSections,
   rankSearchResults,
@@ -10,11 +12,20 @@ import {
   type RecipeSections,
   type RankedRecipe,
 } from "./recipeRunnerUtils";
-import type { TerminalRecipe, RunCommand } from "@/types";
+import type { TerminalRecipe, RunCommand, RecipeTerminal } from "@/types";
 
 export interface UseRecipeRunnerOptions {
   activeWorktreeId: string | null | undefined;
   defaultCwd: string | undefined;
+}
+
+export interface SpawnBannerState {
+  recipeId: string;
+  recipeName: string;
+  total: number;
+  spawned: number;
+  failed: Array<{ index: number; name: string }>;
+  unresolvedVars: string[];
 }
 
 export interface UseRecipeRunnerResult {
@@ -38,6 +49,9 @@ export interface UseRecipeRunnerResult {
   handleCreate: () => void;
   handleKeyDown: (e: React.KeyboardEvent) => void;
   getFlatRecipes: () => TerminalRecipe[];
+  spawnBanner: SpawnBannerState | null;
+  dismissSpawnBanner: () => void;
+  retryFailed: () => void;
 }
 
 export function useRecipeRunner({
@@ -45,7 +59,7 @@ export function useRecipeRunner({
   defaultCwd,
 }: UseRecipeRunnerOptions): UseRecipeRunnerResult {
   const allRecipes = useRecipeStore((s) => s.recipes);
-  const runRecipe = useRecipeStore((s) => s.runRecipe);
+  const runRecipeWithResults = useRecipeStore((s) => s.runRecipeWithResults);
   const updateRecipe = useRecipeStore((s) => s.updateRecipe);
   const deleteRecipe = useRecipeStore((s) => s.deleteRecipe);
   const createRecipe = useRecipeStore((s) => s.createRecipe);
@@ -55,6 +69,8 @@ export function useRecipeRunner({
 
   const [searchQuery, setSearchQuery] = useState("");
   const [focusedIndex, setFocusedIndex] = useState(0);
+  const [spawnBanner, setSpawnBanner] = useState<SpawnBannerState | null>(null);
+  const runCounterRef = useRef(0);
 
   // Stable filtered recipe array for Fuse cache
   const recipes = useMemo(() => {
@@ -109,27 +125,134 @@ export function useRecipeRunner({
     );
   }, [allDetectedRunners]);
 
+  const buildDisplayName = useCallback((terminal: RecipeTerminal): string => {
+    if (terminal.title) return terminal.title;
+    if (terminal.type !== "terminal" && terminal.type !== "dev-preview") {
+      return getAgentDisplayTitle(terminal.type);
+    }
+    return terminal.type === "dev-preview" ? "Dev Server" : "Terminal";
+  }, []);
+
+  const resolveContext = useCallback((): RecipeContext => {
+    const worktreeData = activeWorktreeId
+      ? getCurrentViewStore().getState().worktrees.get(activeWorktreeId)
+      : null;
+    return {
+      issueNumber: worktreeData?.issueNumber,
+      prNumber: worktreeData?.prNumber,
+      worktreePath: defaultCwd,
+      branchName: worktreeData?.branch,
+    };
+  }, [defaultCwd, activeWorktreeId]);
+
   const handleRun = useCallback(
     (recipeId: string) => {
       if (!defaultCwd) return;
-      const worktreeData = activeWorktreeId
-        ? getCurrentViewStore().getState().worktrees.get(activeWorktreeId)
-        : null;
-      void runRecipe(
-        recipeId,
-        defaultCwd,
-        activeWorktreeId ?? undefined,
-        {
-          issueNumber: worktreeData?.issueNumber,
-          prNumber: worktreeData?.prNumber,
-          worktreePath: defaultCwd,
-          branchName: worktreeData?.branch,
-        },
-        { spawnedBy: "recipe" }
-      );
+      const recipe = getRecipeById(recipeId);
+      if (!recipe) return;
+
+      const context = resolveContext();
+
+      const unresolvedVars = new Set<string>();
+      for (const terminal of recipe.terminals) {
+        const texts = [terminal.command, terminal.initialPrompt, terminal.devCommand].filter(
+          (t): t is string => typeof t === "string" && t.length > 0
+        );
+        for (const text of texts) {
+          for (const v of detectUnresolvedVariables(text, context)) {
+            unresolvedVars.add(v);
+          }
+        }
+      }
+
+      setSpawnBanner(null);
+      const runId = ++runCounterRef.current;
+
+      runRecipeWithResults(recipeId, defaultCwd, activeWorktreeId ?? undefined, context, {
+        spawnedBy: "recipe",
+      })
+        .then((results) => {
+          if (runId !== runCounterRef.current) return;
+          if (results.failed.length === 0 && unresolvedVars.size === 0) return;
+
+          const failed = results.failed.map((f) => {
+            const terminal = recipe.terminals[f.index];
+            const name = terminal ? buildDisplayName(terminal) : `Terminal ${f.index + 1}`;
+            return { index: f.index, name };
+          });
+
+          setSpawnBanner({
+            recipeId,
+            recipeName: recipe.name,
+            total: recipe.terminals.length,
+            spawned: results.spawned.length,
+            failed,
+            unresolvedVars: [...unresolvedVars].sort(),
+          });
+        })
+        .catch(() => {
+          // runRecipeWithResults already logs errors internally;
+          // a thrown error here means the recipe itself wasn't found
+        });
     },
-    [defaultCwd, activeWorktreeId, runRecipe]
+    [
+      defaultCwd,
+      activeWorktreeId,
+      getRecipeById,
+      resolveContext,
+      runRecipeWithResults,
+      buildDisplayName,
+    ]
   );
+
+  const dismissSpawnBanner = useCallback(() => {
+    setSpawnBanner(null);
+  }, []);
+
+  const retryFailed = useCallback(() => {
+    setSpawnBanner((current) => {
+      if (!current || current.failed.length === 0) return null;
+      const recipe = getRecipeById(current.recipeId);
+      if (!recipe) return null;
+
+      const context = resolveContext();
+      const indices = current.failed.map((f) => f.index);
+
+      runRecipeWithResults(current.recipeId, defaultCwd!, activeWorktreeId ?? undefined, context, {
+        spawnedBy: "recipe",
+        terminalIndices: indices,
+      })
+        .then((results) => {
+          const stillFailed = results.failed.map((f) => {
+            const terminal = recipe.terminals[f.index];
+            const name = terminal ? buildDisplayName(terminal) : `Terminal ${f.index + 1}`;
+            return { index: f.index, name };
+          });
+
+          setSpawnBanner((prev) => {
+            if (!prev) return null;
+            const prevUnresolved = prev.unresolvedVars;
+            if (stillFailed.length === 0 && prevUnresolved.length === 0) return null;
+            return {
+              ...prev,
+              spawned: results.spawned.length,
+              failed: stillFailed,
+              unresolvedVars: prevUnresolved,
+            };
+          });
+        })
+        .catch(() => {});
+
+      return current;
+    });
+  }, [
+    getRecipeById,
+    resolveContext,
+    runRecipeWithResults,
+    defaultCwd,
+    activeWorktreeId,
+    buildDisplayName,
+  ]);
 
   const handleEdit = useCallback(
     (recipeId: string) => {
@@ -250,5 +373,8 @@ export function useRecipeRunner({
     handleCreate,
     handleKeyDown,
     getFlatRecipes,
+    spawnBanner,
+    dismissSpawnBanner,
+    retryFailed,
   };
 }

--- a/src/store/__tests__/recipeStore.test.ts
+++ b/src/store/__tests__/recipeStore.test.ts
@@ -628,6 +628,74 @@ describe("recipeStore", () => {
       expect(results.spawned).toHaveLength(1);
       expect(results.spawned[0]?.index).toBe(1);
     });
+
+    it("substitutes variables in plain terminal commands", async () => {
+      addTerminalMock.mockResolvedValue("terminal-1");
+
+      useRecipeStore.setState({
+        recipes: [
+          {
+            id: "recipe-1",
+            name: "Test Recipe",
+            projectId: "project-1",
+            terminals: [
+              {
+                type: "terminal",
+                title: "Shell",
+                command: "gh issue view {{issue_number}}",
+                env: {},
+              },
+            ],
+            createdAt: Date.now(),
+          },
+        ],
+        isLoading: false,
+        currentProjectId: "project-1",
+      });
+
+      await useRecipeStore
+        .getState()
+        .runRecipeWithResults("recipe-1", "/tmp/worktree", "worktree-1", {
+          issueNumber: 42,
+        });
+
+      expect(addTerminalMock).toHaveBeenCalledTimes(1);
+      const callArg = addTerminalMock.mock.calls[0]?.[0];
+      expect(callArg.command).toBe("gh issue view #42");
+    });
+
+    it("substitutes variables in dev-preview devCommand", async () => {
+      addTerminalMock.mockResolvedValue("dp-1");
+
+      useRecipeStore.setState({
+        recipes: [
+          {
+            id: "recipe-1",
+            name: "Test Recipe",
+            projectId: "project-1",
+            terminals: [
+              {
+                type: "dev-preview",
+                title: "Dev",
+                devCommand: "echo {{branch_name}}",
+              },
+            ],
+            createdAt: Date.now(),
+          },
+        ],
+        isLoading: false,
+        currentProjectId: "project-1",
+      });
+
+      await useRecipeStore
+        .getState()
+        .runRecipeWithResults("recipe-1", "/tmp/worktree", "worktree-1", {
+          branchName: "feature/foo",
+        });
+
+      const callArg = addTerminalMock.mock.calls[0]?.[0];
+      expect(callArg.devCommand).toBe("echo feature/foo");
+    });
   });
 
   it("keeps importing valid terminals even when others are invalid", async () => {

--- a/src/store/recipeStore.ts
+++ b/src/store/recipeStore.ts
@@ -538,7 +538,9 @@ const createRecipeStore: StateCreator<RecipeState> = (set, get) => ({
     // Pre-fetch agent settings once for all agent terminals
     let agentSettings: Awaited<ReturnType<typeof agentSettingsClient.get>> | null = null;
     let clipboardDirectory: string | undefined;
-    const terminalsToSpawn = indicesToSpawn.map((i) => recipe.terminals[i]!);
+    // Filter out-of-bounds terminal indices before mapping
+    const validIndices = indicesToSpawn.filter((i) => i >= 0 && i < recipe.terminals.length);
+    const terminalsToSpawn = validIndices.map((i) => recipe.terminals[i]!);
     const hasAgent = terminalsToSpawn.some(
       (t) => t.type !== "terminal" && t.type !== "dev-preview"
     );

--- a/src/store/recipeStore.ts
+++ b/src/store/recipeStore.ts
@@ -557,6 +557,11 @@ const createRecipeStore: StateCreator<RecipeState> = (set, get) => ({
 
     const results: RecipeSpawnResults = { spawned: [], failed: [] };
 
+    const resolvedContext: RecipeContext = {
+      ...context,
+      worktreePath,
+    };
+
     for (const index of indicesToSpawn) {
       const terminal = recipe.terminals[index];
       if (!terminal) {
@@ -566,12 +571,15 @@ const createRecipeStore: StateCreator<RecipeState> = (set, get) => ({
       try {
         // Handle dev-preview terminals
         if (terminal.type === "dev-preview") {
+          const devCommand = terminal.devCommand?.trim()
+            ? replaceRecipeVariables(terminal.devCommand.trim(), resolvedContext)
+            : undefined;
           const terminalId = await terminalStore.addPanel({
             kind: "dev-preview",
             title: terminal.title || "Dev Server",
             cwd: worktreePath,
             worktreeId: worktreeId,
-            devCommand: terminal.devCommand?.trim() || undefined,
+            devCommand,
             env: terminal.env,
             exitBehavior: terminal.exitBehavior,
             spawnedBy,
@@ -592,10 +600,6 @@ const createRecipeStore: StateCreator<RecipeState> = (set, get) => ({
           const agentConfig = getAgentConfig(agentId);
           const baseCommand = agentConfig?.command ?? "";
           const rawPrompt = terminal.initialPrompt?.trim();
-          const resolvedContext: RecipeContext = {
-            ...context,
-            worktreePath,
-          };
           const initialPrompt = rawPrompt
             ? replaceRecipeVariables(rawPrompt, resolvedContext)
             : undefined;
@@ -617,11 +621,12 @@ const createRecipeStore: StateCreator<RecipeState> = (set, get) => ({
             spawnedBy,
           });
         } else {
+          const command = replaceRecipeVariables(terminal.command?.trim() || "", resolvedContext);
           terminalId = await terminalStore.addPanel({
             kind: "terminal",
             title: terminal.title,
             cwd: worktreePath,
-            command: terminal.command?.trim() || "",
+            command,
             worktreeId: worktreeId,
             env: terminal.env,
             exitBehavior: terminal.exitBehavior,


### PR DESCRIPTION
Fixes #7220.

The recipe runner was discarding the result from `runRecipeWithResults`, which already returned the counts of spawned and failed terminals. If a recipe of four terminals had one fail to spawn, three would appear with no signal about the fourth.

## Summary

- An inline banner now appears above the recipe grid when some terminals fail to spawn, showing how many started vs failed with a one-click "Retry failed" button. The retry passes only the failed terminal indices via `RecipeRunOptions.terminalIndices`, which the store already supported.
- `detectUnresolvedVariables` was exported but never called -- variables like `{{issue_number}}` with no context value were silently replaced with empty strings. It's now wired at run time, routing warnings into the same inline banner so unresolved variables are surfaced rather than producing broken commands.
- Added tests for the banner rendering, the `useRecipeRunner` hook, and the store changes.

## Changes

| File | What |
|---|---|
| `src/components/Terminal/RecipeRunner/RecipeRunner.tsx` | Partial-failure banner with counts and retry action |
| `src/components/Terminal/RecipeRunner/useRecipeRunner.ts` | Returns structured result with `spawned`/`failed` counts, wires `detectUnresolvedVariables` at run time |
| `src/store/recipeStore.ts` | `runRecipeWithResults` now returns counts; accepts `terminalIndices` for targeted retry |
| `src/store/__tests__/recipeStore.test.ts` | Store-level tests for partial-failure return values |
| `src/components/Terminal/RecipeRunner/__tests__/RecipeRunner.test.tsx` | Banner rendering and retry action tests |
| `src/components/Terminal/RecipeRunner/__tests__/useRecipeRunner.test.tsx` | Hook-level tests for counts and variable detection |

## Testing

- Unit tests cover: banner visibility when terminals fail, retry action dispatches correct indices, hook returns correct spawned/failed counts, unresolved variable detection surfaces warnings.
- Ran `npm run check` (typecheck + lint + format) -- clean.
- Manually verified the banner renders and the retry action works end-to-end.