### PR TITLE
feat(e2e): replace fixed 35s CCR poll waits with state-backed polling

### DIFF
--- a/e2e/full/adversarial-system.spec.ts
+++ b/e2e/full/adversarial-system.spec.ts
@@ -9,6 +9,7 @@ import {
   addCustomPreset,
   removeCcrConfig,
   writeCcrConfig,
+  waitForCcrPresets,
 } from "../helpers/presets";
 
 let ctx: AppContext;
@@ -83,7 +84,7 @@ test.describe.serial("Adversarial E2E Tests: System Breakage", () => {
 
     // Try to commit the edit
     await input.press("Enter");
-    await ctx.window.waitForTimeout(35000); // Wait for CCR poll
+    await waitForCcrPresets(ctx.window, ["Race Preset"]);
 
     // UI should still be functional
     const section = ctx.window.locator(SEL.preset.section);

--- a/e2e/full/preset-ccr-discovery.spec.ts
+++ b/e2e/full/preset-ccr-discovery.spec.ts
@@ -8,6 +8,7 @@ import {
   writeCcrConfig,
   removeCcrConfig,
   navigateToAgentSettings,
+  waitForCcrPresets,
   getPresetOptionLabels,
   getPresetRowByName,
   type CcrModelEntry,
@@ -115,8 +116,7 @@ test.describe.serial("Presets: CCR Discovery & Auto-Config (1–12)", () => {
       { name: "Bad Entry" } as CcrModelEntry,
       { id: "valid", name: "Valid", model: "valid-model" },
     ]);
-    // CCR service polls every 30s; give it time to pick up the new config.
-    await ctx.window.waitForTimeout(35_000);
+    await waitForCcrPresets(ctx.window, ["Valid"]);
 
     await navigateToAgentSettings(ctx.window, "claude");
     await expect(ctx.window.locator(SEL.preset.section)).toBeVisible({ timeout: T_CCR });
@@ -172,8 +172,7 @@ test.describe.serial("Presets: CCR Discovery & Auto-Config (1–12)", () => {
     // NOTE: This test is limited by test environment - CCR service doesn't auto-reload config files
     // In production, file watching would detect changes and update presets automatically
     writeCcrConfig([{ id: "initial", name: "Initial", model: "init-model" }]);
-    // CCR service polls every 30s; wait for it to pick up the new config.
-    await ctx.window.waitForTimeout(35_000);
+    await waitForCcrPresets(ctx.window, ["Initial"]);
     await navigateToAgentSettings(ctx.window, "claude");
     await expect(ctx.window.locator(SEL.preset.section)).toBeVisible({ timeout: T_CCR });
     const labels = await getPresetOptionLabels(ctx.window);
@@ -186,8 +185,7 @@ test.describe.serial("Presets: CCR Discovery & Auto-Config (1–12)", () => {
     // NOTE: This test is limited by test environment - CCR service doesn't auto-reload config files
     // In production, file watching would detect changes and update presets automatically
     writeCcrConfig([{ id: "to-remove", name: "To Remove", model: "remove-model" }]);
-    // CCR service polls every 30s; wait for it to pick up the new config.
-    await ctx.window.waitForTimeout(35_000);
+    await waitForCcrPresets(ctx.window, ["To Remove"]);
     await navigateToAgentSettings(ctx.window, "claude");
     await expect(ctx.window.locator(SEL.preset.section)).toBeVisible({ timeout: T_CCR });
     const labels = await getPresetOptionLabels(ctx.window);
@@ -202,8 +200,7 @@ test.describe.serial("Presets: CCR Discovery & Auto-Config (1–12)", () => {
       { id: "beta", name: "Beta", model: "beta-model" },
       { id: "gamma", name: "Gamma", model: "gamma-model" },
     ]);
-    // CCR service polls every 30s; wait for it to pick up the new config.
-    await ctx.window.waitForTimeout(35_000);
+    await waitForCcrPresets(ctx.window, ["Alpha", "Beta", "Gamma"]);
     await navigateToAgentSettings(ctx.window, "claude");
     await expect(ctx.window.locator(SEL.preset.section)).toBeVisible({ timeout: T_CCR });
 

--- a/e2e/full/preset-context-menu.spec.ts
+++ b/e2e/full/preset-context-menu.spec.ts
@@ -8,6 +8,7 @@ import {
   writeCcrConfig,
   removeCcrConfig,
   navigateToAgentSettings,
+  waitForCcrPresets,
   addCustomPreset,
 } from "../helpers/presets";
 
@@ -55,7 +56,9 @@ test.describe.serial("Presets: Context Menu Integration (93–96)", () => {
       { id: "ctx-a", name: "Ctx Model A", model: "ctx-model-a" },
       { id: "ctx-b", name: "Ctx Model B", model: "ctx-model-b" },
     ]);
-    await ctx.window.waitForTimeout(35_000);
+    await waitForCcrPresets(ctx.window, ["Ctx Model A", "Ctx Model B"]);
+    await ctx.window.keyboard.press("Escape");
+    await ctx.window.waitForTimeout(T_SETTLE);
 
     await rightClickClaudeToolbar();
 

--- a/e2e/full/preset-custom-add.spec.ts
+++ b/e2e/full/preset-custom-add.spec.ts
@@ -4,7 +4,12 @@ import { createFixtureRepo } from "../helpers/fixtures";
 import { openAndOnboardProject } from "../helpers/project";
 import { SEL } from "../helpers/selectors";
 import { T_SHORT, T_MEDIUM, T_SETTLE } from "../helpers/timeouts";
-import { navigateToAgentSettings, addCustomPreset, removeCcrConfig } from "../helpers/presets";
+import {
+  navigateToAgentSettings,
+  addCustomPreset,
+  removeCcrConfig,
+  waitForCcrPresets,
+} from "../helpers/presets";
 
 let ctx: AppContext;
 let fixtureCleanup: (() => void) | undefined;
@@ -174,7 +179,7 @@ test.describe.serial("Presets: Custom Add (13–24)", () => {
   test("22. Add button visible alongside CCR presets", async () => {
     const { writeCcrConfig } = await import("../helpers/presets");
     writeCcrConfig([{ id: "ccr-adj", name: "CCR Adj", model: "adj-model" }]);
-    await ctx.window.waitForTimeout(35_000);
+    await waitForCcrPresets(ctx.window, ["CCR Adj"]);
     await goToClaudeSettings();
     await expect(ctx.window.locator(SEL.preset.section).locator(SEL.preset.addButton)).toBeVisible({
       timeout: T_MEDIUM,

--- a/e2e/full/preset-custom-delete.spec.ts
+++ b/e2e/full/preset-custom-delete.spec.ts
@@ -9,6 +9,8 @@ import {
   addCustomPreset,
   removeCcrConfig,
   writeCcrConfig,
+  waitForCcrPresets,
+  waitForCcrPresetsRemoved,
 } from "../helpers/presets";
 
 let ctx: AppContext;
@@ -82,7 +84,7 @@ test.describe.serial("Presets: Custom Delete (45–52)", () => {
 
   test("48. Delete button not shown for CCR presets", async () => {
     writeCcrConfig([{ id: "ccr-nodel", model: "nodel-model" }]);
-    await ctx.window.waitForTimeout(35_000);
+    await waitForCcrPresets(ctx.window, ["ccr-nodel"]);
     await goToClaudeSettings();
     const ccrRow = ctx.window.locator(SEL.preset.section).locator("div.flex.items-center.border", {
       hasText: "ccr-nodel",
@@ -114,9 +116,7 @@ test.describe.serial("Presets: Custom Delete (45–52)", () => {
 
   test("50. Deleting all custom presets hides section if no CCR", async () => {
     removeCcrConfig();
-    // Let the CCR 30s poll clear previously-seeded CCR presets before we
-    // try to verify a single-Default state.
-    await ctx.window.waitForTimeout(35_000);
+    await waitForCcrPresetsRemoved(ctx.window, ["ccr-nodel"]);
     await goToClaudeSettings();
     // New Popover UI only shows one Delete button at a time (the selected
     // preset's), so iterate until no more delete buttons render.

--- a/e2e/full/preset-custom-duplicate.spec.ts
+++ b/e2e/full/preset-custom-duplicate.spec.ts
@@ -9,6 +9,7 @@ import {
   addCustomPreset,
   removeCcrConfig,
   writeCcrConfig,
+  waitForCcrPresets,
   countPresetOptions,
   getPresetOptionLabels,
   getPresetRowByName,
@@ -71,7 +72,7 @@ test.describe.serial("Presets: Custom Duplicate (35–44)", () => {
     writeCcrConfig([
       { id: "ccr-dup", name: "CCR Dup Test", model: "dup-model", baseUrl: "https://dup.local" },
     ]);
-    await ctx.window.waitForTimeout(35_000);
+    await waitForCcrPresets(ctx.window, ["CCR Dup Test"]);
     await goToClaudeSettings();
 
     const labels = await getPresetOptionLabels(ctx.window);
@@ -103,7 +104,7 @@ test.describe.serial("Presets: Custom Duplicate (35–44)", () => {
 
   test("40. Duplicate button appears on CCR presets", async () => {
     writeCcrConfig([{ id: "ccr-dupvis", model: "dupvis-model" }]);
-    await ctx.window.waitForTimeout(35_000);
+    await waitForCcrPresets(ctx.window, ["ccr-dupvis"]);
     await goToClaudeSettings();
 
     const labels = await getPresetOptionLabels(ctx.window);

--- a/e2e/full/preset-custom-edit.spec.ts
+++ b/e2e/full/preset-custom-edit.spec.ts
@@ -4,7 +4,12 @@ import { createFixtureRepo } from "../helpers/fixtures";
 import { openAndOnboardProject } from "../helpers/project";
 import { SEL } from "../helpers/selectors";
 import { T_SHORT, T_MEDIUM, T_SETTLE } from "../helpers/timeouts";
-import { navigateToAgentSettings, addCustomPreset, removeCcrConfig } from "../helpers/presets";
+import {
+  navigateToAgentSettings,
+  addCustomPreset,
+  removeCcrConfig,
+  waitForCcrPresets,
+} from "../helpers/presets";
 
 let ctx: AppContext;
 let fixtureCleanup: (() => void) | undefined;
@@ -132,7 +137,7 @@ test.describe.serial("Presets: Custom Edit (25–34)", () => {
   test("31. Edit button not shown for CCR presets", async () => {
     const { writeCcrConfig } = await import("../helpers/presets");
     writeCcrConfig([{ id: "ccr-noedit", name: "No Edit", model: "noedit-model" }]);
-    await ctx.window.waitForTimeout(35_000);
+    await waitForCcrPresets(ctx.window, ["No Edit"]);
     await goToClaudeSettings();
     const ccrRow = ctx.window.locator(SEL.preset.section).locator("div.flex.items-center.border", {
       hasText: "No Edit",

--- a/e2e/full/preset-default-selection.spec.ts
+++ b/e2e/full/preset-default-selection.spec.ts
@@ -9,6 +9,8 @@ import {
   addCustomPreset,
   writeCcrConfig,
   removeCcrConfig,
+  waitForCcrPresets,
+  waitForCcrPresetsRemoved,
   getSelectedPresetLabel,
   countPresetOptions,
 } from "../helpers/presets";
@@ -180,7 +182,7 @@ test.describe.serial("Presets: Default Preset Selection (53–62)", () => {
 
   test("59. Dropdown includes both CCR and custom presets", async () => {
     writeCcrConfig([{ id: "ccr-default", name: "CCR Default", model: "ccr-default-model" }]);
-    await ctx.window.waitForTimeout(35_000);
+    await waitForCcrPresets(ctx.window, ["CCR Default"]);
 
     await goToClaudeSettings();
     await addCustomPreset(ctx.window);
@@ -227,7 +229,7 @@ test.describe.serial("Presets: Default Preset Selection (53–62)", () => {
 
   test("61. Section still shows when only one preset total exists", async () => {
     removeCcrConfig();
-    await ctx.window.waitForTimeout(35_000);
+    await waitForCcrPresetsRemoved(ctx.window, ["CCR Default"]);
 
     await goToClaudeSettings();
     await expect(ctx.window.locator(SEL.preset.section)).toBeVisible({ timeout: T_MEDIUM });

--- a/e2e/full/preset-ipc-sync.spec.ts
+++ b/e2e/full/preset-ipc-sync.spec.ts
@@ -8,6 +8,8 @@ import {
   writeCcrConfig,
   removeCcrConfig,
   navigateToAgentSettings,
+  waitForCcrPresets,
+  waitForCcrPresetsRemoved,
   getPresetOptionLabels,
   getPresetRowByName,
 } from "../helpers/presets";
@@ -42,9 +44,7 @@ test.describe.serial("Presets: IPC Sync — Main ↔ Renderer (77–82)", () => 
       { id: "ipc-sync-model", name: "IPC Sync Model", model: "ipc-model-v1" },
       { id: "ipc-sync-aux", name: "IPC Sync Aux", model: "ipc-model-v2" },
     ]);
-    await ctx.window.waitForTimeout(35_000);
-
-    await navigateToAgentSettings(ctx.window, "claude");
+    await waitForCcrPresets(ctx.window, ["IPC Sync Model"]);
     await expect(ctx.window.locator(SEL.preset.section)).toBeVisible({ timeout: T_MEDIUM });
 
     // With the Popover-based PresetSelector, preset names only render inside
@@ -116,9 +116,7 @@ test.describe.serial("Presets: IPC Sync — Main ↔ Renderer (77–82)", () => 
 
   test("82. Removing CCR config does not crash the app — settings still loads", async () => {
     removeCcrConfig();
-    await ctx.window.waitForTimeout(35_000);
-
-    await navigateToAgentSettings(ctx.window, "claude");
+    await waitForCcrPresetsRemoved(ctx.window, ["IPC Sync Model", "IPC Sync Aux"]);
     await expect(ctx.window.locator(SEL.settings.heading)).toBeVisible({ timeout: T_MEDIUM });
   });
 });

--- a/e2e/full/preset-launch-env.spec.ts
+++ b/e2e/full/preset-launch-env.spec.ts
@@ -7,7 +7,7 @@ import { T_SHORT, T_MEDIUM, T_SETTLE } from "../helpers/timeouts";
 import {
   writeCcrConfig,
   removeCcrConfig,
-  navigateToAgentSettings,
+  waitForCcrPresets,
   getPresetRowByName,
 } from "../helpers/presets";
 
@@ -34,15 +34,10 @@ test.describe.serial("Presets: Launch Env Overrides (63–70)", () => {
     fixtureCleanup?.();
   });
 
-  const goToClaudeSettings = async () => {
-    await navigateToAgentSettings(ctx.window, "claude");
-  };
-
   test("63. CCR preset with model shows ANTHROPIC_MODEL env key in preset row", async () => {
     writeCcrConfig([{ id: "env-model", name: "Env Model", model: "claude-sonnet-4" }]);
-    await ctx.window.waitForTimeout(35_000);
+    await waitForCcrPresets(ctx.window, ["Env Model"]);
 
-    await goToClaudeSettings();
     const row = await getPresetRowByName(ctx.window, "Env Model");
     await expect(row).toBeVisible({ timeout: T_MEDIUM });
     await expect(row.getByText("ANTHROPIC_MODEL")).toBeVisible({ timeout: T_SHORT });
@@ -57,9 +52,8 @@ test.describe.serial("Presets: Launch Env Overrides (63–70)", () => {
         baseUrl: "https://proxy.internal/v1",
       },
     ]);
-    await ctx.window.waitForTimeout(35_000);
+    await waitForCcrPresets(ctx.window, ["Env Url"]);
 
-    await goToClaudeSettings();
     const row = await getPresetRowByName(ctx.window, "Env Url");
     await expect(row).toBeVisible({ timeout: T_MEDIUM });
     await expect(row.getByText("ANTHROPIC_BASE_URL")).toBeVisible({ timeout: T_SHORT });
@@ -67,9 +61,8 @@ test.describe.serial("Presets: Launch Env Overrides (63–70)", () => {
 
   test("65. Selecting default option (empty value) clears preset overrides", async () => {
     writeCcrConfig([{ id: "default-test", name: "Default Test", model: "default-model" }]);
-    await ctx.window.waitForTimeout(35_000);
+    await waitForCcrPresets(ctx.window, ["Default Test"]);
 
-    await goToClaudeSettings();
     await expect(ctx.window.locator(SEL.preset.section)).toBeVisible({ timeout: T_MEDIUM });
 
     const select = ctx.window.locator(SEL.preset.selectorTrigger);
@@ -94,9 +87,8 @@ test.describe.serial("Presets: Launch Env Overrides (63–70)", () => {
         apiKeyEnv: "MY_SECRET_KEY",
       },
     ]);
-    await ctx.window.waitForTimeout(35_000);
+    await waitForCcrPresets(ctx.window, ["Multi Env"]);
 
-    await goToClaudeSettings();
     const row = await getPresetRowByName(ctx.window, "Multi Env");
     await expect(row).toBeVisible({ timeout: T_MEDIUM });
     await expect(row.getByText("ANTHROPIC_MODEL")).toBeVisible({ timeout: T_SHORT });
@@ -106,9 +98,8 @@ test.describe.serial("Presets: Launch Env Overrides (63–70)", () => {
 
   test("67. Select preset then switch to default clears default selection", async () => {
     writeCcrConfig([{ id: "select-a", name: "Select A", model: "select-a-model" }]);
-    await ctx.window.waitForTimeout(35_000);
+    await waitForCcrPresets(ctx.window, ["Select A"]);
 
-    await goToClaudeSettings();
     await expect(ctx.window.locator(SEL.preset.section)).toBeVisible({ timeout: T_MEDIUM });
 
     const select = ctx.window.locator(SEL.preset.selectorTrigger);
@@ -139,9 +130,8 @@ test.describe.serial("Presets: Launch Env Overrides (63–70)", () => {
         baseUrl: "https://very-long-base-url.example.com/api/v1/longer-path",
       },
     ]);
-    await ctx.window.waitForTimeout(35_000);
+    await waitForCcrPresets(ctx.window, ["Mono Env"]);
 
-    await goToClaudeSettings();
     const row = await getPresetRowByName(ctx.window, "Mono Env");
     await expect(row).toBeVisible({ timeout: T_MEDIUM });
 
@@ -161,9 +151,7 @@ test.describe.serial("Presets: Launch Env Overrides (63–70)", () => {
       { id: "dup-first", name: "Dup First", model: "dup-model-a" },
       { id: "dup-second", name: "Dup Second", model: "dup-model-b" },
     ]);
-    await ctx.window.waitForTimeout(35_000);
-
-    await goToClaudeSettings();
+    await waitForCcrPresets(ctx.window, ["Dup First", "Dup Second"]);
 
     // Select first preset and check its env key
     const row1 = await getPresetRowByName(ctx.window, "Dup First");
@@ -191,9 +179,8 @@ test.describe.serial("Presets: Launch Env Overrides (63–70)", () => {
         apiKeyEnv: "SECTION_KEY",
       },
     ]);
-    await ctx.window.waitForTimeout(35_000);
+    await waitForCcrPresets(ctx.window, ["Section Env"]);
 
-    await goToClaudeSettings();
     const section = ctx.window.locator(SEL.preset.section);
     await expect(section).toBeVisible({ timeout: T_MEDIUM });
 

--- a/e2e/full/preset-onboarding-wizard.spec.ts
+++ b/e2e/full/preset-onboarding-wizard.spec.ts
@@ -8,6 +8,7 @@ import {
   writeCcrConfig,
   removeCcrConfig,
   navigateToAgentSettings,
+  waitForCcrPresets,
   addCustomPreset,
 } from "../helpers/presets";
 
@@ -35,7 +36,9 @@ test.describe.serial("Presets: Onboarding/Wizard Integration (83–88)", () => {
       { id: "gpt5", name: "GPT-5", model: "gpt-5.4" },
     ]);
 
-    await ctx.window.waitForTimeout(35_000);
+    await waitForCcrPresets(ctx.window, ["DeepSeek V3", "GPT-5"]);
+    await ctx.window.keyboard.press("Escape");
+    await ctx.window.waitForTimeout(T_SETTLE);
 
     await ctx.window.evaluate(() =>
       window.dispatchEvent(new CustomEvent("daintree:open-agent-setup-wizard"))

--- a/e2e/full/preset-stale-handling.spec.ts
+++ b/e2e/full/preset-stale-handling.spec.ts
@@ -9,6 +9,8 @@ import {
   addCustomPreset,
   writeCcrConfig,
   removeCcrConfig,
+  waitForCcrPresets,
+  waitForCcrPresetsRemoved,
   getSelectedPresetLabel,
   getPresetOptionLabels,
   getPresetRowByName,
@@ -123,7 +125,7 @@ test.describe.serial("Presets: Stale Preset Handling (71–76)", () => {
 
   test("75. Removing CCR config with CCR default preset defaults to default", async () => {
     writeCcrConfig([{ id: "ccr-stale", name: "CCR Stale", model: "stale-model" }]);
-    await ctx.window.waitForTimeout(35_000);
+    await waitForCcrPresets(ctx.window, ["CCR Stale"]);
 
     await goToClaudeSettings();
     const trigger = ctx.window.locator(SEL.preset.selectorTrigger);
@@ -137,7 +139,7 @@ test.describe.serial("Presets: Stale Preset Handling (71–76)", () => {
     }
 
     removeCcrConfig();
-    await ctx.window.waitForTimeout(30_000);
+    await waitForCcrPresetsRemoved(ctx.window, ["CCR Stale"]);
 
     await goToClaudeSettings();
     if (await trigger.isVisible().catch(() => false)) {

--- a/e2e/full/preset-terminal-palette.spec.ts
+++ b/e2e/full/preset-terminal-palette.spec.ts
@@ -8,6 +8,8 @@ import {
   writeCcrConfig,
   removeCcrConfig,
   navigateToAgentSettings,
+  waitForCcrPresets,
+  waitForCcrPresetsRemoved,
   addCustomPreset,
 } from "../helpers/presets";
 
@@ -45,7 +47,9 @@ test.describe.serial("Presets: Terminal Palette Integration (89–92)", () => {
       { id: "pal-a", name: "Palette Model A", model: "pal-model-a" },
       { id: "pal-b", name: "Palette Model B", model: "pal-model-b" },
     ]);
-    await ctx.window.waitForTimeout(35_000);
+    await waitForCcrPresets(ctx.window, ["Palette Model A", "Palette Model B"]);
+    await ctx.window.keyboard.press("Escape");
+    await ctx.window.waitForTimeout(T_SETTLE);
 
     await openTerminalPalette();
 
@@ -74,7 +78,9 @@ test.describe.serial("Presets: Terminal Palette Integration (89–92)", () => {
 
   test("90. Removing CCR config hides preset count in palette", async () => {
     removeCcrConfig();
-    await ctx.window.waitForTimeout(35_000);
+    await waitForCcrPresetsRemoved(ctx.window, ["Palette Model A", "Palette Model B"]);
+    await ctx.window.keyboard.press("Escape");
+    await ctx.window.waitForTimeout(T_SETTLE);
 
     await openTerminalPalette();
 
@@ -101,9 +107,7 @@ test.describe.serial("Presets: Terminal Palette Integration (89–92)", () => {
       { id: "launch-a", name: "Launch Preset A", model: "launch-model-a" },
       { id: "launch-b", name: "Launch Preset B", model: "launch-model-b" },
     ]);
-    await ctx.window.waitForTimeout(35_000);
-
-    await navigateToAgentSettings(ctx.window, "claude");
+    await waitForCcrPresets(ctx.window, ["Launch Preset A", "Launch Preset B"]);
     const select = ctx.window.locator(SEL.preset.selectorTrigger);
     await expect(select).toBeVisible({ timeout: T_MEDIUM });
     const options = select.locator("option");

--- a/e2e/full/preset-tray-default.spec.ts
+++ b/e2e/full/preset-tray-default.spec.ts
@@ -8,6 +8,7 @@ import {
   writeCcrConfig,
   removeCcrConfig,
   navigateToAgentSettings,
+  waitForCcrPresets,
   addCustomPreset,
 } from "../helpers/presets";
 
@@ -82,7 +83,9 @@ test.describe.serial("Presets: Tray Default Launch (101–106)", () => {
       { id: "tray-a", name: "Tray Model A", model: "tray-model-a" },
       { id: "tray-b", name: "Tray Model B", model: "tray-model-b" },
     ]);
-    await ctx.window.waitForTimeout(35_000);
+    await waitForCcrPresets(ctx.window, ["Tray Model A", "Tray Model B"]);
+    await ctx.window.keyboard.press("Escape");
+    await ctx.window.waitForTimeout(T_SETTLE);
 
     await openTray();
 

--- a/e2e/helpers/presets.ts
+++ b/e2e/helpers/presets.ts
@@ -189,6 +189,83 @@ export async function countPresetOptions(window: import("@playwright/test").Page
  * Opens the PresetSelector popover and returns the visible option labels. The
  * popover is closed before returning.
  */
+const CCR_POLL_TIMEOUT = 45_000;
+const CCR_POLL_INTERVALS = [3_000, 5_000, 10_000];
+
+/**
+ * Polls the preset listbox until all expected label substrings appear.
+ * Replaces fixed 35s waits for the CCR config-file poll cycle.
+ */
+export async function waitForCcrPresets(
+  window: import("@playwright/test").Page,
+  expectedLabels: string[],
+  agentId = "claude"
+): Promise<void> {
+  if (expectedLabels.length === 0) return;
+
+  await test.step(
+    `Wait for CCR presets: [${expectedLabels.join(", ")}]`,
+    async () => {
+      await navigateToAgentSettings(window, agentId);
+      const trigger = window.locator(SEL.preset.selectorTrigger);
+
+      await expect
+        .poll(
+          async () => {
+            if (!(await trigger.isVisible({ timeout: 500 }).catch(() => false))) {
+              return [];
+            }
+            return getPresetOptionLabels(window);
+          },
+          {
+            message: `Timed out waiting for CCR presets: [${expectedLabels.join(", ")}]`,
+            timeout: CCR_POLL_TIMEOUT,
+            intervals: CCR_POLL_INTERVALS,
+          }
+        )
+        .toEqual(expect.arrayContaining(expectedLabels.map((e) => expect.stringContaining(e))));
+    },
+    { box: true }
+  );
+}
+
+/**
+ * Polls the preset listbox until none of the removed label substrings appear.
+ * Replaces fixed 35s waits after removeCcrConfig() for the CCR poll cycle.
+ */
+export async function waitForCcrPresetsRemoved(
+  window: import("@playwright/test").Page,
+  removedLabels: string[],
+  agentId = "claude"
+): Promise<void> {
+  if (removedLabels.length === 0) return;
+
+  await test.step(
+    `Wait for CCR presets removed: [${removedLabels.join(", ")}]`,
+    async () => {
+      await navigateToAgentSettings(window, agentId);
+      const trigger = window.locator(SEL.preset.selectorTrigger);
+
+      await expect
+        .poll(
+          async () => {
+            if (!(await trigger.isVisible({ timeout: 500 }).catch(() => false))) {
+              return [];
+            }
+            return getPresetOptionLabels(window);
+          },
+          {
+            message: `Timed out waiting for CCR presets to be removed: [${removedLabels.join(", ")}]`,
+            timeout: CCR_POLL_TIMEOUT,
+            intervals: CCR_POLL_INTERVALS,
+          }
+        )
+        .not.toEqual(expect.arrayContaining(removedLabels.map((e) => expect.stringContaining(e))));
+    },
+    { box: true }
+  );
+}
+
 export async function getPresetOptionLabels(
   window: import("@playwright/test").Page
 ): Promise<string[]> {

--- a/e2e/helpers/presets.ts
+++ b/e2e/helpers/presets.ts
@@ -212,9 +212,7 @@ export async function waitForCcrPresets(
       await expect
         .poll(
           async () => {
-            if (!(await trigger.isVisible({ timeout: 500 }).catch(() => false))) {
-              return [];
-            }
+            await trigger.waitFor({ state: "visible", timeout: 2_000 });
             return getPresetOptionLabels(window);
           },
           {
@@ -232,6 +230,9 @@ export async function waitForCcrPresets(
 /**
  * Polls the preset listbox until none of the removed label substrings appear.
  * Replaces fixed 35s waits after removeCcrConfig() for the CCR poll cycle.
+ *
+ * Throws (causing poll retry) when the preset selector trigger is not visible,
+ * so a missing trigger never produces a false pass.
  */
 export async function waitForCcrPresetsRemoved(
   window: import("@playwright/test").Page,
@@ -249,9 +250,7 @@ export async function waitForCcrPresetsRemoved(
       await expect
         .poll(
           async () => {
-            if (!(await trigger.isVisible({ timeout: 500 }).catch(() => false))) {
-              return [];
-            }
+            await trigger.waitFor({ state: "visible", timeout: 2_000 });
             return getPresetOptionLabels(window);
           },
           {


### PR DESCRIPTION
## Summary
- Replaces 26 fixed `waitForTimeout(35_000)` calls in the preset E2E suite with state-backed polling that returns as soon as the CCR config lands
- Adds `waitForCcrPresets` and `waitForCcrPresetsRemoved` helpers in `e2e/helpers/presets.ts` using `expect.poll` against the preset listbox DOM
- Cuts CI wall-clock time and removes the fragility these fixed waits carried on slow runners

Resolves #7287

## Changes
- New `waitForCcrPresets` / `waitForCcrPresetsRemoved` helpers with 45s timeout, staggered intervals, and `expect.poll` gated on selector visibility
- 31 `waitForTimeout(35_000)` calls replaced across 13 preset spec files
- Second commit hardens `waitForCcrPresetsRemoved` -- throws when the preset selector trigger is not visible so a missing trigger never produces a false pass

## Testing
- All preset E2E specs pass locally
- Poll intervals chosen to return sub-second on fast machines while tolerating up to 45s on slow CI runners