### PR TITLE
chore(errors): tighten internals — dedup store, fix all-clear timing, drop dead exports

### DIFF
--- a/src/App.tsx
+++ b/src/App.tsx
@@ -308,7 +308,7 @@ function App() {
       });
     };
     window.__DAINTREE_E2E_CLEAR_ERRORS__ = () => {
-      useErrorStore.getState().clearAll();
+      useErrorStore.getState().reset();
     };
     // Refreshes the GitHub config store from the main process. Used by
     // fault-mode tests to pick up a token seeded via __daintreeSeedGitHubToken

--- a/src/components/AllClearOverlay/AllClearOverlay.tsx
+++ b/src/components/AllClearOverlay/AllClearOverlay.tsx
@@ -15,19 +15,18 @@ export function AllClearOverlay() {
     return cleanup;
   }, []);
 
-  const handleAnimationEnd = useCallback(
-    (event: React.AnimationEvent) => {
-      if (event.animationName === "all-clear-flash") {
-        setVisible(false);
-      }
-    },
-    [],
-  );
+  const handleAnimationEnd = useCallback((event: React.AnimationEvent) => {
+    if (event.animationName === "all-clear-flash") {
+      setVisible(false);
+    }
+  }, []);
 
   useEffect(() => {
     if (!visible) return;
     safetyTimerRef.current = setTimeout(() => setVisible(false), 500);
-    return () => clearTimeout(safetyTimerRef.current);
+    return () => {
+      if (safetyTimerRef.current !== null) clearTimeout(safetyTimerRef.current);
+    };
   }, [visible]);
 
   if (!visible) return null;
@@ -38,6 +37,6 @@ export function AllClearOverlay() {
       aria-hidden="true"
       onAnimationEnd={handleAnimationEnd}
     />,
-    document.body,
+    document.body
   );
 }

--- a/src/components/AllClearOverlay/AllClearOverlay.tsx
+++ b/src/components/AllClearOverlay/AllClearOverlay.tsx
@@ -3,7 +3,7 @@ import { createPortal } from "react-dom";
 
 export function AllClearOverlay() {
   const [visible, setVisible] = useState(false);
-  const safetyTimerRef = useRef<ReturnType<typeof setTimeout>>();
+  const safetyTimerRef = useRef<ReturnType<typeof setTimeout> | null>(null);
 
   useEffect(() => {
     const cleanup = window.electron.terminal.onAllAgentsClear(() => {

--- a/src/components/AllClearOverlay/AllClearOverlay.tsx
+++ b/src/components/AllClearOverlay/AllClearOverlay.tsx
@@ -1,10 +1,9 @@
-import { useEffect, useState } from "react";
+import { useCallback, useEffect, useRef, useState } from "react";
 import { createPortal } from "react-dom";
-
-const FLASH_DURATION_MS = 450;
 
 export function AllClearOverlay() {
   const [visible, setVisible] = useState(false);
+  const safetyTimerRef = useRef<ReturnType<typeof setTimeout>>();
 
   useEffect(() => {
     const cleanup = window.electron.terminal.onAllAgentsClear(() => {
@@ -16,10 +15,19 @@ export function AllClearOverlay() {
     return cleanup;
   }, []);
 
+  const handleAnimationEnd = useCallback(
+    (event: React.AnimationEvent) => {
+      if (event.animationName === "all-clear-flash") {
+        setVisible(false);
+      }
+    },
+    [],
+  );
+
   useEffect(() => {
     if (!visible) return;
-    const timer = setTimeout(() => setVisible(false), FLASH_DURATION_MS);
-    return () => clearTimeout(timer);
+    safetyTimerRef.current = setTimeout(() => setVisible(false), 500);
+    return () => clearTimeout(safetyTimerRef.current);
   }, [visible]);
 
   if (!visible) return null;
@@ -28,7 +36,8 @@ export function AllClearOverlay() {
     <div
       className="fixed inset-0 pointer-events-none z-[200] animate-all-clear-flash bg-status-success"
       aria-hidden="true"
+      onAnimationEnd={handleAnimationEnd}
     />,
-    document.body
+    document.body,
   );
 }

--- a/src/components/AllClearOverlay/__tests__/AllClearOverlay.test.tsx
+++ b/src/components/AllClearOverlay/__tests__/AllClearOverlay.test.tsx
@@ -1,0 +1,119 @@
+// @vitest-environment jsdom
+import { render, act } from "@testing-library/react";
+import { describe, expect, it, vi, beforeEach, afterEach } from "vitest";
+import React from "react";
+import { AllClearOverlay } from "../AllClearOverlay";
+
+const OVERLAY_SELECTOR = "[aria-hidden='true']";
+
+let onAllAgentsClearCb: ((data: { timestamp: number }) => void) | null = null;
+
+beforeEach(() => {
+  vi.useFakeTimers();
+  onAllAgentsClearCb = null;
+
+  Object.defineProperty(window, "electron", {
+    configurable: true,
+    writable: true,
+    value: {
+      terminal: {
+        onAllAgentsClear: vi.fn(
+          (callback: (data: { timestamp: number }) => void) => {
+            onAllAgentsClearCb = callback;
+            return () => {
+              onAllAgentsClearCb = null;
+            };
+          },
+        ),
+      },
+    },
+  });
+
+  Object.defineProperty(window, "matchMedia", {
+    configurable: true,
+    writable: true,
+    value: vi.fn().mockReturnValue({ matches: false }),
+  });
+});
+
+afterEach(() => {
+  vi.useRealTimers();
+});
+
+describe("AllClearOverlay", () => {
+  it("renders the overlay when onAllAgentsClear fires", () => {
+    render(<AllClearOverlay />);
+
+    act(() => {
+      onAllAgentsClearCb?.({ timestamp: Date.now() });
+    });
+
+    expect(document.body.querySelector(OVERLAY_SELECTOR)).toBeTruthy();
+  });
+
+  it("does not render before the callback fires", () => {
+    render(<AllClearOverlay />);
+    expect(document.body.querySelector(OVERLAY_SELECTOR)).toBeNull();
+  });
+
+  it("suppresses the overlay when prefers-reduced-motion is set", () => {
+    (window.matchMedia as ReturnType<typeof vi.fn>).mockReturnValue({ matches: true });
+    render(<AllClearOverlay />);
+
+    act(() => {
+      onAllAgentsClearCb?.({ timestamp: Date.now() });
+    });
+
+    expect(document.body.querySelector(OVERLAY_SELECTOR)).toBeNull();
+  });
+
+  it("suppresses the overlay when data-performance-mode is true", () => {
+    document.body.setAttribute("data-performance-mode", "true");
+    render(<AllClearOverlay />);
+
+    act(() => {
+      onAllAgentsClearCb?.({ timestamp: Date.now() });
+    });
+
+    expect(document.body.querySelector(OVERLAY_SELECTOR)).toBeNull();
+    document.body.removeAttribute("data-performance-mode");
+  });
+
+  it("hides via safety timeout when animationend never fires", () => {
+    render(<AllClearOverlay />);
+
+    act(() => {
+      onAllAgentsClearCb?.({ timestamp: Date.now() });
+    });
+
+    expect(document.body.querySelector(OVERLAY_SELECTOR)).toBeTruthy();
+
+    act(() => {
+      vi.advanceTimersByTime(500);
+    });
+
+    expect(document.body.querySelector(OVERLAY_SELECTOR)).toBeNull();
+  });
+
+  it("clears the safety timer on unmount", () => {
+    const { unmount } = render(<AllClearOverlay />);
+
+    act(() => {
+      onAllAgentsClearCb?.({ timestamp: Date.now() });
+    });
+
+    unmount();
+
+    expect(() => {
+      act(() => {
+        vi.advanceTimersByTime(500);
+      });
+    }).not.toThrow();
+  });
+
+  it("cleans up onAllAgentsClear listener on unmount", () => {
+    const { unmount } = render(<AllClearOverlay />);
+    unmount();
+    expect(onAllAgentsClearCb).toBeNull();
+  });
+});

--- a/src/components/AllClearOverlay/__tests__/AllClearOverlay.test.tsx
+++ b/src/components/AllClearOverlay/__tests__/AllClearOverlay.test.tsx
@@ -1,7 +1,6 @@
 // @vitest-environment jsdom
 import { render, act } from "@testing-library/react";
 import { describe, expect, it, vi, beforeEach, afterEach } from "vitest";
-import React from "react";
 import { AllClearOverlay } from "../AllClearOverlay";
 
 const OVERLAY_SELECTOR = "[aria-hidden='true']";

--- a/src/components/AllClearOverlay/__tests__/AllClearOverlay.test.tsx
+++ b/src/components/AllClearOverlay/__tests__/AllClearOverlay.test.tsx
@@ -16,14 +16,12 @@ beforeEach(() => {
     writable: true,
     value: {
       terminal: {
-        onAllAgentsClear: vi.fn(
-          (callback: (data: { timestamp: number }) => void) => {
-            onAllAgentsClearCb = callback;
-            return () => {
-              onAllAgentsClearCb = null;
-            };
-          },
-        ),
+        onAllAgentsClear: vi.fn((callback: (data: { timestamp: number }) => void) => {
+          onAllAgentsClearCb = callback;
+          return () => {
+            onAllAgentsClearCb = null;
+          };
+        }),
       },
     },
   });

--- a/src/components/ErrorBoundary/buildReportIssueUrl.ts
+++ b/src/components/ErrorBoundary/buildReportIssueUrl.ts
@@ -13,8 +13,8 @@ const TITLE_ENCODED_BUDGET = 200;
 // When the stack must be middle-truncated we keep the top frames (where the
 // throw originates) and the tail (where it bubbled up through React). 15+5
 // fits a typical render-error stack while leaving the truncation visible.
-export const STACK_HEAD_LINES = 15;
-export const STACK_TAIL_LINES = 5;
+const STACK_HEAD_LINES = 15;
+const STACK_TAIL_LINES = 5;
 
 const COMPONENT_STACK_PLACEHOLDER =
   "<!-- component stack omitted — exceeded URL budget; full report copied to clipboard -->";

--- a/src/hooks/useErrors.ts
+++ b/src/hooks/useErrors.ts
@@ -127,7 +127,7 @@ export function useErrors() {
   const isPanelOpen = useErrorStore((state) => state.isPanelOpen);
   const addError = useErrorStore((state) => state.addError);
   const dismissError = useErrorStore((state) => state.dismissError);
-  const clearAll = useErrorStore((state) => state.clearAll);
+  const clearAll = useErrorStore((state) => state.reset);
   const removeError = useErrorStore((state) => state.removeError);
   const togglePanel = useErrorStore((state) => state.togglePanel);
   const setPanelOpen = useErrorStore((state) => state.setPanelOpen);

--- a/src/services/actions/definitions/logActions.ts
+++ b/src/services/actions/definitions/logActions.ts
@@ -183,7 +183,7 @@ export function registerLogActions(actions: ActionRegistry, _callbacks: ActionCa
     danger: "safe",
     scope: "renderer",
     run: async () => {
-      useErrorStore.getState().clearAll();
+      useErrorStore.getState().reset();
     },
   }));
 

--- a/src/store/__tests__/errorStore.test.ts
+++ b/src/store/__tests__/errorStore.test.ts
@@ -177,7 +177,7 @@ describe("errorStore", () => {
       expect(error?.retryProgress).toBeUndefined();
     });
 
-    it("clearAll removes all retryProgress", () => {
+    it("reset removes all retryProgress", () => {
       const id = useErrorStore.getState().addError({
         type: "process",
         message: "spawn failed",
@@ -186,13 +186,13 @@ describe("errorStore", () => {
       });
 
       useErrorStore.getState().updateRetryProgress(id, 1, 3);
-      useErrorStore.getState().clearAll();
+      useErrorStore.getState().reset();
 
       expect(useErrorStore.getState().errors).toEqual([]);
     });
   });
 
-  it("clearAll fully clears error panel state", () => {
+  it("reset fully clears error panel state", () => {
     useErrorStore.getState().setPanelOpen(true);
     useErrorStore.getState().addError({
       type: "git",
@@ -205,7 +205,7 @@ describe("errorStore", () => {
     expect(before.errors.length).toBe(1);
     expect(before.lastErrorTime).toBeGreaterThan(0);
 
-    useErrorStore.getState().clearAll();
+    useErrorStore.getState().reset();
 
     const after = useErrorStore.getState();
     expect(after.errors).toEqual([]);

--- a/src/store/errorStore.ts
+++ b/src/store/errorStore.ts
@@ -44,7 +44,6 @@ interface ErrorStore {
 
   addError: (error: Omit<ErrorRecord, "id" | "timestamp" | "dismissed">) => string;
   dismissError: (id: string) => void;
-  clearAll: () => void;
   removeError: (id: string) => void;
   togglePanel: () => void;
   setPanelOpen: (open: boolean) => void;
@@ -125,14 +124,6 @@ const createErrorStore: StateCreator<ErrorStore> = (set, get) => ({
     set((state) => ({
       errors: state.errors.map((e) => (e.id === id ? { ...e, dismissed: true } : e)),
     }));
-  },
-
-  clearAll: () => {
-    set({
-      errors: [],
-      isPanelOpen: false,
-      lastErrorTime: 0,
-    });
   },
 
   removeError: (id) => {


### PR DESCRIPTION
## Summary
Three small cleanups in the error-recovery internals. None was worth its own PR, but together they close out a few pre-release rough edges.

## Changes
- **`errorStore`:** `clearAll()` and `reset()` set the same state. Dropped `clearAll()` — the single call site in `useErrors.ts` and two external `getState()` calls now use `reset()` directly. Eliminates a path that would silently diverge if anyone added a field to one method and forgot the other.
- **`AllClearOverlay`:** was using `setTimeout` for the unmount, coupling JS timing to the CSS `all-clear-flash` keyframe. Switched to `onAnimationEnd`, with a 500ms safety timeout as a fallback for when the animation never fires (reduced-motion, perf mode). Added unit test coverage for the overlay's visibility lifecycle.
- **`buildReportIssueUrl.ts`:** dropped `export` on `STACK_HEAD_LINES` and `STACK_TAIL_LINES` — neither is imported outside the module.

Resolves #7253

## Testing
- Unit tests pass (including new `AllClearOverlay` suite: render, reduced-motion/perf-mode suppression, safety-timeout fallback, unmount cleanup).
- Typecheck, lint, and format clean.