### PR TITLE
fix(settings): polish MCP server settings tab a11y, consistency, and correctness

### DIFF
--- a/src/components/Settings/McpServerSettingsTab.tsx
+++ b/src/components/Settings/McpServerSettingsTab.tsx
@@ -443,7 +443,7 @@ export function McpServerSettingsTab() {
                   portDirtyRef.current = true;
                 }}
                 onKeyDown={(e) => {
-                  if (e.key === "Enter") handlePortSave();
+                  if (e.key === "Enter") void handlePortSave();
                 }}
                 placeholder="45454"
                 aria-label="MCP server port"

--- a/src/components/Settings/McpServerSettingsTab.tsx
+++ b/src/components/Settings/McpServerSettingsTab.tsx
@@ -83,7 +83,8 @@ export function McpServerSettingsTab() {
   const [showApiKey, setShowApiKey] = useState(false);
   const [copiedKey, setCopiedKey] = useState(false);
   const [copiedAudit, setCopiedAudit] = useState(false);
-  const copyTimeoutRef = useRef<ReturnType<typeof setTimeout> | null>(null);
+  const configCopyTimeoutRef = useRef<ReturnType<typeof setTimeout> | null>(null);
+  const apiKeyCopyTimeoutRef = useRef<ReturnType<typeof setTimeout> | null>(null);
   const auditCopyTimeoutRef = useRef<ReturnType<typeof setTimeout> | null>(null);
 
   const [auditRecords, setAuditRecords] = useState<McpAuditRecord[]>([]);
@@ -114,7 +115,7 @@ export function McpServerSettingsTab() {
     let settled = false;
     const timer = setTimeout(() => {
       settled = true;
-      setError("Settings load timed out");
+      setError("Couldn't load MCP server settings. Restart Daintree and try again.");
       setLoading(false);
       logError("MCP status load timed out");
     }, 10_000);
@@ -146,9 +147,25 @@ export function McpServerSettingsTab() {
         setAuditLoading(false);
       });
 
+    const unsub = window.electron.mcpServer.onRuntimeStateChanged(() => {
+      if (!settled) return;
+      window.electron.mcpServer
+        .getStatus()
+        .then((s) => {
+          setStatus(s);
+          setPortInput(s.configuredPort?.toString() ?? "");
+          setError(null);
+        })
+        .catch((err) => {
+          logError("Failed to refresh MCP status on runtime change", err);
+        });
+    });
+
     return () => {
       clearTimeout(timer);
-      if (copyTimeoutRef.current) clearTimeout(copyTimeoutRef.current);
+      unsub();
+      if (configCopyTimeoutRef.current) clearTimeout(configCopyTimeoutRef.current);
+      if (apiKeyCopyTimeoutRef.current) clearTimeout(apiKeyCopyTimeoutRef.current);
       if (auditCopyTimeoutRef.current) clearTimeout(auditCopyTimeoutRef.current);
     };
   }, []);
@@ -169,9 +186,14 @@ export function McpServerSettingsTab() {
       const snippet = await window.electron.mcpServer.getConfigSnippet();
       await navigator.clipboard.writeText(snippet);
       setCopied(true);
-      if (copyTimeoutRef.current) clearTimeout(copyTimeoutRef.current);
-      copyTimeoutRef.current = setTimeout(() => setCopied(false), 2000);
+      if (configCopyTimeoutRef.current) clearTimeout(configCopyTimeoutRef.current);
+      configCopyTimeoutRef.current = setTimeout(() => setCopied(false), COPY_FEEDBACK_MS);
     } catch (err) {
+      setCopied(false);
+      if (configCopyTimeoutRef.current) {
+        clearTimeout(configCopyTimeoutRef.current);
+        configCopyTimeoutRef.current = null;
+      }
       setError(formatErrorMessage(err, "Failed to copy config"));
       logError("Failed to copy MCP config", err);
     }
@@ -223,13 +245,13 @@ export function McpServerSettingsTab() {
     try {
       await navigator.clipboard.writeText(status.apiKey);
       setCopiedKey(true);
-      if (copyTimeoutRef.current) clearTimeout(copyTimeoutRef.current);
-      copyTimeoutRef.current = setTimeout(() => setCopiedKey(false), 2000);
+      if (apiKeyCopyTimeoutRef.current) clearTimeout(apiKeyCopyTimeoutRef.current);
+      apiKeyCopyTimeoutRef.current = setTimeout(() => setCopiedKey(false), COPY_FEEDBACK_MS);
     } catch (err) {
       setCopiedKey(false);
-      if (copyTimeoutRef.current) {
-        clearTimeout(copyTimeoutRef.current);
-        copyTimeoutRef.current = null;
+      if (apiKeyCopyTimeoutRef.current) {
+        clearTimeout(apiKeyCopyTimeoutRef.current);
+        apiKeyCopyTimeoutRef.current = null;
       }
       setError(formatErrorMessage(err, "Failed to copy API key"));
       logError("Failed to copy MCP API key", err);
@@ -415,15 +437,17 @@ export function McpServerSettingsTab() {
                   if (e.key === "Enter") handlePortSave();
                 }}
                 placeholder="45454"
-                className="w-40 bg-daintree-bg border border-border-strong rounded-[var(--radius-md)] px-3 py-2 text-sm text-daintree-text placeholder:text-daintree-text/40 font-mono focus:outline-hidden focus:ring-1 focus:ring-daintree-accent"
+                aria-label="MCP server port"
+                className="w-40 bg-daintree-bg border border-border-strong rounded-[var(--radius-md)] px-3 py-2 text-sm text-daintree-text placeholder:text-daintree-text/40 font-mono focus-visible:outline focus-visible:outline-2 focus-visible:outline-daintree-accent focus-visible:outline-offset-2"
               />
               <button
                 onClick={handlePortSave}
-                disabled={portInput === (status.configuredPort?.toString() ?? "")}
+                disabled={portInput.trim() === (status.configuredPort?.toString() ?? "")}
+                aria-label="Apply port"
                 className={cn(
                   "px-3 py-2 text-xs font-medium rounded-[var(--radius-md)] transition-colors",
                   "border border-daintree-border",
-                  portInput === (status.configuredPort?.toString() ?? "")
+                  portInput.trim() === (status.configuredPort?.toString() ?? "")
                     ? "text-daintree-text/30 cursor-not-allowed"
                     : "text-daintree-text/70 hover:text-daintree-text hover:bg-overlay-soft"
                 )}
@@ -517,26 +541,18 @@ export function McpServerSettingsTab() {
             description="Every tool dispatched over MCP is recorded with a redacted argument summary. Use this to investigate what an agent did during a session — argument values are never stored verbatim."
           >
             <div className="contents">
-              <div className="flex flex-wrap items-center gap-2">
-                <button
-                  type="button"
-                  onClick={handleAuditEnabledToggle}
-                  className={cn(
-                    "px-3 py-1.5 text-xs font-medium rounded-[var(--radius-md)] border transition-colors",
-                    auditEnabled
-                      ? "border-status-success/30 text-status-success hover:bg-status-success/10"
-                      : "border-daintree-border text-daintree-text/60 hover:text-daintree-text"
-                  )}
-                  aria-pressed={auditEnabled}
-                >
-                  {auditEnabled ? "Capture on" : "Capture off"}
-                </button>
-                <span className="text-xs text-daintree-text/50">
-                  {auditEnabled
+              <SettingsSwitchCard
+                variant="compact"
+                title="Capture audit log"
+                subtitle={
+                  auditEnabled
                     ? "Recording every dispatch."
-                    : "New dispatches will not be recorded."}
-                </span>
-              </div>
+                    : "New dispatches will not be recorded."
+                }
+                isEnabled={auditEnabled}
+                onChange={handleAuditEnabledToggle}
+                ariaLabel="Capture audit log"
+              />
 
               <div className="flex flex-wrap items-center gap-2">
                 <label htmlFor="mcp-audit-max-records" className="text-xs text-daintree-text/60">
@@ -553,12 +569,13 @@ export function McpServerSettingsTab() {
                     if (e.key === "Enter") void handleMaxRecordsSave();
                   }}
                   placeholder={MCP_AUDIT_DEFAULT_MAX_RECORDS.toString()}
-                  className="w-24 bg-daintree-bg border border-border-strong rounded-[var(--radius-md)] px-2 py-1 text-xs text-daintree-text placeholder:text-daintree-text/40 font-mono focus:outline-hidden focus:ring-1 focus:ring-daintree-accent"
+                  className="w-24 bg-daintree-bg border border-border-strong rounded-[var(--radius-md)] px-2 py-1 text-xs text-daintree-text placeholder:text-daintree-text/40 font-mono focus-visible:outline focus-visible:outline-2 focus-visible:outline-daintree-accent focus-visible:outline-offset-2"
                 />
                 <button
                   type="button"
                   onClick={() => void handleMaxRecordsSave()}
                   disabled={maxRecordsInput === auditMaxRecords.toString()}
+                  aria-label="Apply max records"
                   className={cn(
                     "px-3 py-1 text-xs font-medium rounded-[var(--radius-md)] transition-colors",
                     "border border-daintree-border",
@@ -580,7 +597,8 @@ export function McpServerSettingsTab() {
                   value={toolFilter}
                   onChange={(e) => setToolFilter(e.target.value)}
                   placeholder="Filter by tool ID"
-                  className="flex-1 min-w-[160px] bg-daintree-bg border border-border-strong rounded-[var(--radius-md)] px-2 py-1 text-xs text-daintree-text placeholder:text-daintree-text/40 font-mono focus:outline-hidden focus:ring-1 focus:ring-daintree-accent"
+                  aria-label="Filter audit by tool name"
+                  className="flex-1 min-w-[160px] bg-daintree-bg border border-border-strong rounded-[var(--radius-md)] px-2 py-1 text-xs text-daintree-text placeholder:text-daintree-text/40 font-mono focus-visible:outline focus-visible:outline-2 focus-visible:outline-daintree-accent focus-visible:outline-offset-2"
                 />
                 <select
                   value={resultFilter}
@@ -590,17 +608,20 @@ export function McpServerSettingsTab() {
                       value === "all" ||
                       value === "success" ||
                       value === "error" ||
-                      value === "confirmation-pending"
+                      value === "confirmation-pending" ||
+                      value === "unauthorized"
                     ) {
                       setResultFilter(value);
                     }
                   }}
-                  className="bg-daintree-bg border border-border-strong rounded-[var(--radius-md)] px-2 py-1 text-xs text-daintree-text focus:outline-hidden focus:ring-1 focus:ring-daintree-accent"
+                  aria-label="Filter audit by result"
+                  className="bg-daintree-bg border border-border-strong rounded-[var(--radius-md)] px-2 py-1 text-xs text-daintree-text focus-visible:outline focus-visible:outline-2 focus-visible:outline-daintree-accent focus-visible:outline-offset-2"
                 >
                   <option value="all">All results</option>
                   <option value="success">Success</option>
                   <option value="error">Error</option>
                   <option value="confirmation-pending">Awaiting confirmation</option>
+                  <option value="unauthorized">Unauthorized</option>
                 </select>
               </div>
 
@@ -699,7 +720,9 @@ export function McpServerSettingsTab() {
                   Clear log
                 </button>
                 <span className="ml-auto text-xs text-daintree-text/40">
-                  {auditRecords.length} of {auditMaxRecords}
+                  {resultFilter !== "all" || toolFilter.trim().length > 0
+                    ? `${filteredAuditRecords.length} of ${auditRecords.length}`
+                    : `${auditRecords.length} of ${auditMaxRecords}`}
                 </span>
               </div>
             </div>

--- a/src/components/Settings/McpServerSettingsTab.tsx
+++ b/src/components/Settings/McpServerSettingsTab.tsx
@@ -80,7 +80,7 @@ export function McpServerSettingsTab() {
   const [copied, setCopied] = useState(false);
   const [error, setError] = useState<string | null>(null);
   const [portInput, setPortInput] = useState("");
-  const [portDirty, setPortDirty] = useState(false);
+  const portDirtyRef = useRef(false);
   const [showApiKey, setShowApiKey] = useState(false);
   const [copiedKey, setCopiedKey] = useState(false);
   const [copiedAudit, setCopiedAudit] = useState(false);
@@ -130,7 +130,7 @@ export function McpServerSettingsTab() {
         if (settled) return;
         setStatus(s);
         setPortInput(s.configuredPort?.toString() ?? "");
-        setPortDirty(false);
+        portDirtyRef.current = false;
         setAuditEnabled(auditCfg.enabled);
         setAuditMaxRecords(auditCfg.maxRecords);
         setMaxRecordsInput(auditCfg.maxRecords.toString());
@@ -155,7 +155,7 @@ export function McpServerSettingsTab() {
         .getStatus()
         .then((s) => {
           setStatus(s);
-          if (!portDirty) {
+          if (!portDirtyRef.current) {
             setPortInput(s.configuredPort?.toString() ?? "");
           }
           setError(null);
@@ -215,7 +215,7 @@ export function McpServerSettingsTab() {
       const newStatus = await window.electron.mcpServer.setPort(port);
       setStatus(newStatus);
       setPortInput(newStatus.configuredPort?.toString() ?? "");
-      setPortDirty(false);
+      portDirtyRef.current = false;
     } catch (err) {
       setError(formatErrorMessage(err, "Failed to update port"));
       logError("Failed to update MCP port", err);
@@ -440,7 +440,7 @@ export function McpServerSettingsTab() {
                 value={portInput}
                 onChange={(e) => {
                   setPortInput(e.target.value.replace(/\D/g, ""));
-                  setPortDirty(true);
+                  portDirtyRef.current = true;
                 }}
                 onKeyDown={(e) => {
                   if (e.key === "Enter") handlePortSave();

--- a/src/components/Settings/McpServerSettingsTab.tsx
+++ b/src/components/Settings/McpServerSettingsTab.tsx
@@ -80,6 +80,7 @@ export function McpServerSettingsTab() {
   const [copied, setCopied] = useState(false);
   const [error, setError] = useState<string | null>(null);
   const [portInput, setPortInput] = useState("");
+  const [portDirty, setPortDirty] = useState(false);
   const [showApiKey, setShowApiKey] = useState(false);
   const [copiedKey, setCopiedKey] = useState(false);
   const [copiedAudit, setCopiedAudit] = useState(false);
@@ -129,6 +130,7 @@ export function McpServerSettingsTab() {
         if (settled) return;
         setStatus(s);
         setPortInput(s.configuredPort?.toString() ?? "");
+        setPortDirty(false);
         setAuditEnabled(auditCfg.enabled);
         setAuditMaxRecords(auditCfg.maxRecords);
         setMaxRecordsInput(auditCfg.maxRecords.toString());
@@ -153,7 +155,9 @@ export function McpServerSettingsTab() {
         .getStatus()
         .then((s) => {
           setStatus(s);
-          setPortInput(s.configuredPort?.toString() ?? "");
+          if (!portDirty) {
+            setPortInput(s.configuredPort?.toString() ?? "");
+          }
           setError(null);
         })
         .catch((err) => {
@@ -211,6 +215,7 @@ export function McpServerSettingsTab() {
       const newStatus = await window.electron.mcpServer.setPort(port);
       setStatus(newStatus);
       setPortInput(newStatus.configuredPort?.toString() ?? "");
+      setPortDirty(false);
     } catch (err) {
       setError(formatErrorMessage(err, "Failed to update port"));
       logError("Failed to update MCP port", err);
@@ -265,6 +270,7 @@ export function McpServerSettingsTab() {
       const cfg = await window.electron.mcpServer.setAuditEnabled(next);
       setAuditEnabled(cfg.enabled);
       setAuditMaxRecords(cfg.maxRecords);
+      setMaxRecordsInput(cfg.maxRecords.toString());
     } catch (err) {
       setError(formatErrorMessage(err, "Failed to update audit logging"));
       logError("Failed to toggle MCP audit log", err);
@@ -432,7 +438,10 @@ export function McpServerSettingsTab() {
                 inputMode="numeric"
                 pattern="[0-9]*"
                 value={portInput}
-                onChange={(e) => setPortInput(e.target.value.replace(/\D/g, ""))}
+                onChange={(e) => {
+                  setPortInput(e.target.value.replace(/\D/g, ""));
+                  setPortDirty(true);
+                }}
                 onKeyDown={(e) => {
                   if (e.key === "Enter") handlePortSave();
                 }}

--- a/src/components/Settings/__tests__/McpServerSettingsTab.test.tsx
+++ b/src/components/Settings/__tests__/McpServerSettingsTab.test.tsx
@@ -82,6 +82,7 @@ function createMcpApi(overrides: Partial<typeof window.electron.mcpServer> = {})
     clearAuditLog: vi.fn().mockResolvedValue(undefined),
     setAuditEnabled: vi.fn().mockResolvedValue({ enabled: true, maxRecords: 500 }),
     setAuditMaxRecords: vi.fn().mockResolvedValue({ enabled: true, maxRecords: 500 }),
+    onRuntimeStateChanged: vi.fn().mockReturnValue(vi.fn()),
     ...overrides,
   };
 }
@@ -561,7 +562,7 @@ describe("McpServerSettingsTab", () => {
     );
     await waitForContent(container, "API key active");
 
-    fireEvent.click(screen.getByRole("button", { name: /capture on/i }));
+    fireEvent.click(screen.getByRole("switch", { name: /capture audit log/i }));
 
     await waitForContent(container, "audit toggle failed");
     expect(mockedNotify).not.toHaveBeenCalled();
@@ -749,5 +750,156 @@ describe("McpServerSettingsTab", () => {
     await waitForContent(container, "clipboard denied");
     expect(mockedNotify).not.toHaveBeenCalled();
     expect(mockedLogError).toHaveBeenCalledWith("Failed to copy MCP audit log", expect.any(Error));
+  });
+
+  it("shows filtered count when a result filter is active", async () => {
+    installMcpApi({
+      getAuditRecords: vi.fn().mockResolvedValue([
+        {
+          id: "1",
+          toolId: "files.read",
+          argsSummary: "{}",
+          result: "success" as const,
+          timestamp: Date.now(),
+          durationMs: 42,
+        },
+        {
+          id: "2",
+          toolId: "terminal.run",
+          argsSummary: "{}",
+          result: "error" as const,
+          timestamp: Date.now(),
+          durationMs: 100,
+        },
+      ]),
+    });
+
+    const { container } = render(
+      <SettingsValidationProvider>
+        <McpServerSettingsTab />
+      </SettingsValidationProvider>
+    );
+    await waitForContent(container, "files.read");
+    // Initially unfiltered: "2 of 500"
+    expect(container.textContent).toContain("2 of 500");
+
+    fireEvent.change(screen.getByLabelText("Filter audit by result"), {
+      target: { value: "success" },
+    });
+    await waitFor(() => {
+      expect(container.textContent).toContain("1 of 2");
+    });
+  });
+
+  it("shows filtered count when tool filter is active", async () => {
+    installMcpApi({
+      getAuditRecords: vi.fn().mockResolvedValue([
+        {
+          id: "1",
+          toolId: "files.read",
+          argsSummary: "{}",
+          result: "success" as const,
+          timestamp: Date.now(),
+          durationMs: 42,
+        },
+        {
+          id: "2",
+          toolId: "terminal.run",
+          argsSummary: "{}",
+          result: "success" as const,
+          timestamp: Date.now(),
+          durationMs: 100,
+        },
+      ]),
+    });
+
+    const { container } = render(
+      <SettingsValidationProvider>
+        <McpServerSettingsTab />
+      </SettingsValidationProvider>
+    );
+    await waitForContent(container, "files.read");
+
+    fireEvent.change(screen.getByLabelText("Filter audit by tool name"), {
+      target: { value: "terminal" },
+    });
+    await waitFor(() => {
+      expect(container.textContent).toContain("1 of 2");
+    });
+  });
+
+  it("port input Apply button stays disabled when value has trailing whitespace matching configuredPort", async () => {
+    installMcpApi({
+      getStatus: vi.fn().mockResolvedValue({
+        enabled: true,
+        port: 9020,
+        configuredPort: 9020,
+        apiKey: "dnt-key-abc123",
+      }),
+    });
+
+    const { container } = render(
+      <SettingsValidationProvider>
+        <McpServerSettingsTab />
+      </SettingsValidationProvider>
+    );
+    await waitForContent(container, "API key active");
+
+    const portInput = screen.getByLabelText("MCP server port") as HTMLInputElement;
+    fireEvent.change(portInput, { target: { value: "9020 " } });
+
+    const applyButton = screen.getByRole("button", { name: "Apply port" }) as HTMLButtonElement;
+    expect(applyButton.disabled).toBe(true);
+  });
+
+  it("subscribes to runtime state changes on mount", async () => {
+    const unsub = vi.fn();
+    const onRuntimeStateChanged = vi.fn().mockReturnValue(unsub);
+
+    installMcpApi({ onRuntimeStateChanged });
+
+    render(
+      <SettingsValidationProvider>
+        <McpServerSettingsTab />
+      </SettingsValidationProvider>
+    );
+
+    await waitFor(() => {
+      expect(onRuntimeStateChanged).toHaveBeenCalledTimes(1);
+    });
+  });
+
+  it("result filter includes Unauthorized option", async () => {
+    const { container } = render(
+      <SettingsValidationProvider>
+        <McpServerSettingsTab />
+      </SettingsValidationProvider>
+    );
+    await waitForContent(container, "API key active");
+
+    const select = screen.getByLabelText("Filter audit by result") as HTMLSelectElement;
+    expect(select).toBeTruthy();
+    expect(Array.from(select.options).map((o) => o.value)).toContain("unauthorized");
+  });
+
+  it("copy config and copy API key have independent Copied! timeouts", async () => {
+    const { container } = render(
+      <SettingsValidationProvider>
+        <McpServerSettingsTab />
+      </SettingsValidationProvider>
+    );
+    await waitForContent(container, "API key active");
+
+    fireEvent.click(screen.getByRole("button", { name: /copy mcp config/i }));
+    await waitFor(() => {
+      expect(screen.getByText("Copied!")).toBeTruthy();
+    });
+
+    // Copy API key — both buttons show Copied! independently
+    fireEvent.click(screen.getByLabelText("Copy API key"));
+    await waitFor(() => {
+      const copiedEls = screen.getAllByText("Copied!");
+      expect(copiedEls.length).toBeGreaterThanOrEqual(2);
+    });
   });
 });


### PR DESCRIPTION
## Summary
A cluster of polish fixes for the MCP Server settings tab. Nothing architectural — just bringing the tab up to the standard the rest of Settings already hits.

## Changes
- **a11y** — Added `aria-label` on the port input, audit tool-filter input, result-filter `<select>`, and both Apply buttons. Screen readers now get named controls.
- **Consistency** — Swapped the bespoke Capture on/off toggle for `SettingsSwitchCard variant="compact"`, matching every other toggle in Settings. Replaced `focus:outline-hidden focus:ring-1` with the shared `focus-visible:outline focus-visible:outline-2` pattern on all text inputs.
- **Cleanup** — Replaced hardcoded `2000` with `COPY_FEEDBACK_MS` in copy handlers. Split the shared `copyTimeoutRef` into separate refs so Copy Config and Copy API key don't race each other's timeouts. Improved the load-timeout error copy from a log line to user-facing text. Added the missing `"unauthorized"` option to the result filter `<select>`.
- **Correctness** — When a result or tool filter is active the audit count now shows `{filtered} of {total}` instead of always showing the unfiltered total. The port Apply button compares against trimmed input so trailing whitespace doesn't enable a no-op save. The tab subscribes to `onRuntimeStateChanged` so it stays in sync when MCP Server is toggled from another path (e.g. the assistant tab). The `portDirtyRef` guard prevents the runtime subscription from overwriting a port value the user is currently editing.

Resolves #7244

## Testing
- 6 new test cases covering: filtered audit counts (result and tool filters), trailing-whitespace port comparison, runtime state subscription, the unauthorized filter option, and independent copy timeouts.
- Existing tests updated for the `SettingsSwitchCard` role change (`button` to `switch`).