### PR TITLE
feat(a11y): polish logs and event inspector ARIA semantics

### DIFF
--- a/src/components/Diagnostics/LogsContent.tsx
+++ b/src/components/Diagnostics/LogsContent.tsx
@@ -283,6 +283,9 @@ export function LogsContent({ className, onSourcesChange }: LogsContentProps) {
                 toggleExpanded={toggleExpanded}
               />
             )}
+            role="log"
+            aria-label="Application logs"
+            aria-live="off"
             className="absolute inset-0 overflow-y-auto overflow-x-hidden font-mono"
           />
         )}

--- a/src/components/EventInspector/EventFilters.tsx
+++ b/src/components/EventInspector/EventFilters.tsx
@@ -166,7 +166,7 @@ export function EventFilters({ events, filters, onFiltersChange, className }: Ev
         <div className="relative">
           <Search className="absolute left-3 top-1/2 -translate-y-1/2 w-4 h-4 text-muted-foreground" />
           <input
-            type="text"
+            type="search"
             value={searchInput}
             onChange={(e) => handleSearchChange(e.target.value)}
             placeholder="Search events..."
@@ -174,7 +174,8 @@ export function EventFilters({ events, filters, onFiltersChange, className }: Ev
               "w-full pl-9 pr-9 py-2 text-sm rounded-[var(--radius-md)]",
               "bg-muted/50 border border-transparent",
               "focus:bg-background focus:border-primary focus:outline-hidden",
-              "placeholder:text-muted-foreground"
+              "placeholder:text-muted-foreground",
+              "[&::-webkit-search-cancel-button]:hidden"
             )}
           />
           {searchInput && (
@@ -255,6 +256,7 @@ export function EventFilters({ events, filters, onFiltersChange, className }: Ev
                       ? config.color
                       : "bg-muted/30 text-muted-foreground border-transparent hover:bg-muted/50"
                   )}
+                  aria-pressed={isActive}
                 >
                   <span>{config.label}</span>
                   {count > 0 && (

--- a/src/components/EventInspector/EventTimeline.tsx
+++ b/src/components/EventInspector/EventTimeline.tsx
@@ -182,6 +182,9 @@ export function EventTimeline({
         itemContent={(_index, event) => (
           <EventRow event={event} isSelected={event.id === selectedId} onSelect={onSelectEvent} />
         )}
+        role="log"
+        aria-label="Event timeline"
+        aria-live="off"
         className="h-full"
       />
 

--- a/src/components/EventInspector/__tests__/EventFilters.test.tsx
+++ b/src/components/EventInspector/__tests__/EventFilters.test.tsx
@@ -1,0 +1,57 @@
+// @vitest-environment jsdom
+import { render, screen } from "@testing-library/react";
+import { describe, expect, it, vi } from "vitest";
+import { EventFilters } from "../EventFilters";
+import type { EventRecord } from "@/store/eventStore";
+
+describe("EventFilters accessibility", () => {
+  const baseProps = {
+    events: [] as EventRecord[],
+    filters: {} as {
+      types?: string[];
+      categories?: import("@/store/eventStore").EventCategory[];
+      search?: string;
+      traceId?: string;
+    },
+    onFiltersChange: vi.fn(),
+  };
+
+  it("renders search input with type='search'", () => {
+    render(<EventFilters {...baseProps} />);
+    const input = screen.getByPlaceholderText("Search events...") as HTMLInputElement;
+    expect(input.type).toBe("search");
+  });
+
+  it("renders traceId input with type='text'", () => {
+    render(<EventFilters {...baseProps} />);
+    const input = screen.getByPlaceholderText("Filter by trace ID...") as HTMLInputElement;
+    expect(input.type).toBe("text");
+  });
+
+  it("renders category chips with aria-pressed", () => {
+    render(
+      <EventFilters
+        {...baseProps}
+        events={[
+          {
+            id: "1",
+            timestamp: Date.now(),
+            type: "agent:test",
+            category: "agent",
+            payload: {},
+            source: "main",
+          },
+        ]}
+        filters={{ categories: ["agent"] }}
+      />
+    );
+    const agentChip = screen.getByText("Agent").closest("button")!;
+    expect(agentChip.getAttribute("aria-pressed")).toBe("true");
+  });
+
+  it("renders inactive category chips with aria-pressed=false", () => {
+    render(<EventFilters {...baseProps} />);
+    const systemChip = screen.getByText("System").closest("button")!;
+    expect(systemChip.getAttribute("aria-pressed")).toBe("false");
+  });
+});

--- a/src/components/EventInspector/__tests__/EventFilters.test.tsx
+++ b/src/components/EventInspector/__tests__/EventFilters.test.tsx
@@ -1,5 +1,5 @@
 // @vitest-environment jsdom
-import { render, screen } from "@testing-library/react";
+import { render, screen, fireEvent } from "@testing-library/react";
 import { describe, expect, it, vi } from "vitest";
 import { EventFilters } from "../EventFilters";
 import type { EventRecord } from "@/store/eventStore";
@@ -53,5 +53,14 @@ describe("EventFilters accessibility", () => {
     render(<EventFilters {...baseProps} />);
     const systemChip = screen.getByText("System").closest("button")!;
     expect(systemChip.getAttribute("aria-pressed")).toBe("false");
+  });
+
+  it("calls onFiltersChange with toggled category on click", () => {
+    const onFiltersChange = vi.fn();
+    render(<EventFilters {...baseProps} onFiltersChange={onFiltersChange} />);
+    fireEvent.click(screen.getByText("System").closest("button")!);
+    expect(onFiltersChange).toHaveBeenCalledWith(
+      expect.objectContaining({ categories: ["system"] })
+    );
   });
 });

--- a/src/components/EventInspector/__tests__/EventTimeline.test.tsx
+++ b/src/components/EventInspector/__tests__/EventTimeline.test.tsx
@@ -1,0 +1,46 @@
+// @vitest-environment jsdom
+import { render, screen } from "@testing-library/react";
+import { describe, expect, it, vi } from "vitest";
+import { EventTimeline } from "../EventTimeline";
+
+vi.stubGlobal(
+  "ResizeObserver",
+  class {
+    observe() {}
+    unobserve() {}
+    disconnect() {}
+  }
+);
+
+describe("EventTimeline accessibility", () => {
+  const mockEvents = [
+    {
+      id: "1",
+      timestamp: Date.now(),
+      type: "agent:test",
+      category: "agent" as const,
+      payload: {},
+      source: "main",
+    },
+    {
+      id: "2",
+      timestamp: Date.now() + 1000,
+      type: "task:test",
+      category: "task" as const,
+      payload: { taskId: "abc123" },
+      source: "main",
+    },
+  ];
+
+  it("renders Virtuoso with role='log' and aria-live='off'", () => {
+    render(<EventTimeline events={mockEvents} selectedId={null} onSelectEvent={vi.fn()} />);
+    const log = screen.getByRole("log", { name: "Event timeline" });
+    expect(log).toBeTruthy();
+    expect(log.getAttribute("aria-live")).toBe("off");
+  });
+
+  it("renders Virtuoso with aria-label='Event timeline'", () => {
+    render(<EventTimeline events={mockEvents} selectedId={null} onSelectEvent={vi.fn()} />);
+    expect(screen.getByRole("log").getAttribute("aria-label")).toBe("Event timeline");
+  });
+});

--- a/src/components/EventInspector/__tests__/EventTimeline.test.tsx
+++ b/src/components/EventInspector/__tests__/EventTimeline.test.tsx
@@ -2,6 +2,7 @@
 import { render, screen } from "@testing-library/react";
 import { describe, expect, it, vi } from "vitest";
 import { EventTimeline } from "../EventTimeline";
+import type { EventRecord } from "@/store/eventStore";
 
 vi.stubGlobal(
   "ResizeObserver",
@@ -13,7 +14,7 @@ vi.stubGlobal(
 );
 
 describe("EventTimeline accessibility", () => {
-  const mockEvents = [
+  const mockEvents: EventRecord[] = [
     {
       id: "1",
       timestamp: Date.now(),

--- a/src/components/Logs/LogFilters.tsx
+++ b/src/components/Logs/LogFilters.tsx
@@ -1,6 +1,7 @@
 import { useCallback, useEffect, useState, useRef } from "react";
 import { cn } from "@/lib/utils";
 import { Button } from "@/components/ui/button";
+import { useEscapeStack } from "@/hooks/useEscapeStack";
 import type { LogLevel, LogFilterOptions } from "@/types";
 
 interface LogFiltersProps {
@@ -32,6 +33,8 @@ export function LogFilters({
   const [searchValue, setSearchValue] = useState(filters.search || "");
   const [isSourcesOpen, setIsSourcesOpen] = useState(false);
   const sourcesRef = useRef<HTMLDivElement>(null);
+
+  useEscapeStack(isSourcesOpen, () => setIsSourcesOpen(false));
 
   useEffect(() => {
     const timer = setTimeout(() => {
@@ -91,7 +94,7 @@ export function LogFilters({
     <div className="flex flex-wrap items-center gap-2 p-2 border-b border-daintree-border bg-daintree-sidebar/50">
       <div className="relative flex-1 min-w-[150px] max-w-[250px]">
         <input
-          type="text"
+          type="search"
           value={searchValue}
           onChange={(e) => setSearchValue(e.target.value)}
           placeholder="Search logs..."
@@ -99,7 +102,8 @@ export function LogFilters({
             "w-full px-2 py-1 text-xs rounded",
             "bg-daintree-bg border border-daintree-border",
             "text-daintree-text placeholder-daintree-text/40",
-            "focus:outline-hidden focus:border-status-info"
+            "focus:outline-hidden focus:border-status-info",
+            "[&::-webkit-search-cancel-button]:hidden"
           )}
         />
         {searchValue && (
@@ -127,6 +131,7 @@ export function LogFilters({
               size="xs"
               onClick={() => handleLevelToggle(level)}
               className={cn(isActive ? "bg-daintree-border font-medium" : "bg-daintree-bg/50", color)}
+              aria-pressed={isActive}
               aria-label={`${label}${count > 0 ? ` (${count})` : ""}`}
             >
               {label}
@@ -143,6 +148,7 @@ export function LogFilters({
             size="xs"
             onClick={() => setIsSourcesOpen(!isSourcesOpen)}
             aria-expanded={isSourcesOpen}
+            aria-haspopup="true"
           >
             Sources {filters.sources?.length ? <span className="tabular-nums">({filters.sources.length})</span> : ""}
           </Button>
@@ -166,6 +172,7 @@ export function LogFilters({
                       "w-full justify-start rounded-none",
                       isActive ? "text-status-info bg-status-info/10" : "text-daintree-text"
                     )}
+                    aria-pressed={isActive}
                   >
                     {isActive && "* "}
                     {source}

--- a/src/components/Logs/LogFilters.tsx
+++ b/src/components/Logs/LogFilters.tsx
@@ -122,7 +122,7 @@ export function LogFilters({
       <div className="flex items-center gap-1">
         <span className="text-daintree-text/60 text-xs mr-1">Level:</span>
         {LOG_LEVELS.map(({ level, label, color }) => {
-          const isActive = filters.levels?.includes(level);
+          const isActive = filters.levels?.includes(level) ?? false;
           const count = levelCounts?.[level] ?? 0;
           return (
             <Button
@@ -161,7 +161,7 @@ export function LogFilters({
               )}
             >
               {availableSources.map((source) => {
-                const isActive = filters.sources?.includes(source);
+                const isActive = filters.sources?.includes(source) ?? false;
                 return (
                   <Button
                     key={source}

--- a/src/components/Logs/__tests__/LogFilters.test.tsx
+++ b/src/components/Logs/__tests__/LogFilters.test.tsx
@@ -42,6 +42,18 @@ describe("LogFilters accessibility", () => {
     expect(trigger.getAttribute("aria-expanded")).toBe("false");
   });
 
+  it("toggles aria-expanded when sources popover opens and closes", async () => {
+    render(<LogFilters {...baseProps} />);
+    const trigger = screen.getByText(/Sources/).closest("button")!;
+    expect(trigger.getAttribute("aria-expanded")).toBe("false");
+    fireEvent.click(trigger);
+    expect(trigger.getAttribute("aria-expanded")).toBe("true");
+    dispatchEscape();
+    await waitFor(() => {
+      expect(trigger.getAttribute("aria-expanded")).toBe("false");
+    });
+  });
+
   it("renders source items with aria-pressed when popover is open", () => {
     render(<LogFilters {...baseProps} filters={{ sources: ["renderer"] }} />);
     fireEvent.click(screen.getByText(/Sources/).closest("button")!);

--- a/src/components/Logs/__tests__/LogFilters.test.tsx
+++ b/src/components/Logs/__tests__/LogFilters.test.tsx
@@ -1,0 +1,63 @@
+// @vitest-environment jsdom
+import { render, screen, fireEvent, waitFor } from "@testing-library/react";
+import { describe, expect, it, vi, afterEach } from "vitest";
+import { LogFilters } from "../LogFilters";
+import { dispatchEscape, _resetForTests } from "@/lib/escapeStack";
+
+describe("LogFilters accessibility", () => {
+  afterEach(() => {
+    _resetForTests();
+  });
+
+  const baseProps = {
+    filters: {} as {
+      levels?: import("@/types").LogLevel[];
+      sources?: string[];
+      search?: string;
+    },
+    onFiltersChange: vi.fn(),
+    onClear: vi.fn(),
+    availableSources: ["renderer", "main", "preload"],
+    levelCounts: { debug: 1, info: 2, warn: 3, error: 4 } as const,
+  };
+
+  it("renders search input with type='search'", () => {
+    render(<LogFilters {...baseProps} />);
+    const input = screen.getByPlaceholderText("Search logs...") as HTMLInputElement;
+    expect(input.type).toBe("search");
+  });
+
+  it("renders active and inactive level pills with aria-pressed", () => {
+    render(<LogFilters {...baseProps} filters={{ levels: ["info", "error"] }} />);
+    const debugBtn = screen.getByLabelText("Debug (1)");
+    const infoBtn = screen.getByLabelText("Info (2)");
+    expect(debugBtn.getAttribute("aria-pressed")).toBe("false");
+    expect(infoBtn.getAttribute("aria-pressed")).toBe("true");
+  });
+
+  it("renders sources trigger with aria-haspopup", () => {
+    render(<LogFilters {...baseProps} />);
+    const trigger = screen.getByText(/Sources/).closest("button")!;
+    expect(trigger.getAttribute("aria-haspopup")).toBe("true");
+    expect(trigger.getAttribute("aria-expanded")).toBe("false");
+  });
+
+  it("renders source items with aria-pressed when popover is open", () => {
+    render(<LogFilters {...baseProps} filters={{ sources: ["renderer"] }} />);
+    fireEvent.click(screen.getByText(/Sources/).closest("button")!);
+    const rendererBtn = screen.getByText(/\* renderer/).closest("button")!;
+    const mainBtn = screen.getByText("main").closest("button")!;
+    expect(rendererBtn.getAttribute("aria-pressed")).toBe("true");
+    expect(mainBtn.getAttribute("aria-pressed")).toBe("false");
+  });
+
+  it("closes sources popover on Escape", async () => {
+    render(<LogFilters {...baseProps} />);
+    fireEvent.click(screen.getByText(/Sources/).closest("button")!);
+    expect(screen.getByText("renderer")).toBeTruthy();
+    dispatchEscape();
+    await waitFor(() => {
+      expect(screen.queryByText("renderer")).toBeNull();
+    });
+  });
+});


### PR DESCRIPTION
## Summary
Pulls the logs view and event inspector closer to WAI-ARIA authoring practices. The Virtuoso feeds get proper `role="log"` semantics, toggle buttons ship `aria-pressed`, and filter inputs use the correct `type="search"`.

Resolves #7269.

## Changes
- **Virtuoso feeds** (`LogsContent`, `EventTimeline`) — `role="log"` with `aria-live="off"` and `aria-label`, giving screen readers the right append-only-feed semantics without spamming on high-rate streams
- **Toggle buttons** (`LogFilters` level pills and source items, `EventFilters` category chips) — `aria-pressed` so assistive tech knows what's active
- **Sources popover** (`LogFilters`) — `aria-haspopup="true"` and wired into `useEscapeStack` so Escape closes it
- **Search inputs** — changed from `type="text"` to `type="search"` with webkit cancel button suppressed
- **Tests** — 13 unit tests across 3 new spec files covering ARIA attributes, toggle states, and component semantics

## Testing
`npm run check` passes (typecheck, lint, format). 13 unit tests pass, covering:
- `LogFilters` — level pills `aria-pressed`, search `type="search"`, source item `aria-pressed`, popover `aria-haspopup`
- `EventFilters` — category chip `aria-pressed`, search `type="search"`
- `EventTimeline` — Virtuoso `role="log"`, `aria-live="off"`, `aria-label`