### PR TITLE
chore(dragdrop): lift magic constants to animationUtils and named locals

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -16,6 +16,8 @@
         "better-sqlite3": "^12.8.0",
         "copytree": "^0.14.2",
         "js-yaml": "^4.1.1",
+        "magic-string": "^0.30.21",
+        "motion-utils": "^12.36.0",
         "node-pty": "1.2.0-beta.12",
         "react-colorful": "^5.6.1"
       },
@@ -3221,7 +3223,6 @@
     },
     "node_modules/@jridgewell/sourcemap-codec": {
       "version": "1.5.5",
-      "dev": true,
       "license": "MIT"
     },
     "node_modules/@jridgewell/trace-mapping": {
@@ -14050,7 +14051,8 @@
     },
     "node_modules/magic-string": {
       "version": "0.30.21",
-      "dev": true,
+      "resolved": "https://registry.npmjs.org/magic-string/-/magic-string-0.30.21.tgz",
+      "integrity": "sha512-vd2F4YUyEXKGcLHoq+TEyCjxueSeHnFxyyjNp80yg0XV4vUhnDer/lvvlqM/arB5bXQN5K2/3oinyCRyx8T2CQ==",
       "license": "MIT",
       "dependencies": {
         "@jridgewell/sourcemap-codec": "^1.5.5"
@@ -14415,7 +14417,8 @@
     },
     "node_modules/motion-utils": {
       "version": "12.36.0",
-      "dev": true,
+      "resolved": "https://registry.npmjs.org/motion-utils/-/motion-utils-12.36.0.tgz",
+      "integrity": "sha512-eHWisygbiwVvf6PZ1vhaHCLamvkSbPIeAYxWUuL3a2PD/TROgE7FvfHWTIH4vMl798QLfMw15nRqIaRDXTlYRg==",
       "license": "MIT"
     },
     "node_modules/mrmime": {

--- a/package-lock.json
+++ b/package-lock.json
@@ -16,8 +16,6 @@
         "better-sqlite3": "^12.8.0",
         "copytree": "^0.14.2",
         "js-yaml": "^4.1.1",
-        "magic-string": "^0.30.21",
-        "motion-utils": "^12.36.0",
         "node-pty": "1.2.0-beta.12",
         "react-colorful": "^5.6.1"
       },
@@ -3223,6 +3221,7 @@
     },
     "node_modules/@jridgewell/sourcemap-codec": {
       "version": "1.5.5",
+      "dev": true,
       "license": "MIT"
     },
     "node_modules/@jridgewell/trace-mapping": {
@@ -14053,6 +14052,7 @@
       "version": "0.30.21",
       "resolved": "https://registry.npmjs.org/magic-string/-/magic-string-0.30.21.tgz",
       "integrity": "sha512-vd2F4YUyEXKGcLHoq+TEyCjxueSeHnFxyyjNp80yg0XV4vUhnDer/lvvlqM/arB5bXQN5K2/3oinyCRyx8T2CQ==",
+      "dev": true,
       "license": "MIT",
       "dependencies": {
         "@jridgewell/sourcemap-codec": "^1.5.5"
@@ -14419,6 +14419,7 @@
       "version": "12.36.0",
       "resolved": "https://registry.npmjs.org/motion-utils/-/motion-utils-12.36.0.tgz",
       "integrity": "sha512-eHWisygbiwVvf6PZ1vhaHCLamvkSbPIeAYxWUuL3a2PD/TROgE7FvfHWTIH4vMl798QLfMw15nRqIaRDXTlYRg==",
+      "dev": true,
       "license": "MIT"
     },
     "node_modules/mrmime": {

--- a/package.json
+++ b/package.json
@@ -86,6 +86,8 @@
     "better-sqlite3": "^12.8.0",
     "copytree": "^0.14.2",
     "js-yaml": "^4.1.1",
+    "magic-string": "^0.30.21",
+    "motion-utils": "^12.36.0",
     "node-pty": "1.2.0-beta.12",
     "react-colorful": "^5.6.1"
   },

--- a/package.json
+++ b/package.json
@@ -86,8 +86,6 @@
     "better-sqlite3": "^12.8.0",
     "copytree": "^0.14.2",
     "js-yaml": "^4.1.1",
-    "magic-string": "^0.30.21",
-    "motion-utils": "^12.36.0",
     "node-pty": "1.2.0-beta.12",
     "react-colorful": "^5.6.1"
   },

--- a/src/components/DragDrop/DndProvider.tsx
+++ b/src/components/DragDrop/DndProvider.tsx
@@ -46,7 +46,7 @@ import { getCurrentViewStore } from "@/store/createWorktreeStore";
 import { useLayoutUndoStore } from "@/store/layoutUndoStore";
 import { applyManualWorktreeReorder } from "@/lib/worktreeReorder";
 import type { WorktreeSnapshot } from "@shared/types";
-import { m } from "framer-motion";
+import { m, useReducedMotion } from "framer-motion";
 import {
   resolveContainerId,
   filterTerminalsByContainer,
@@ -59,9 +59,13 @@ import {
 } from "./dropResolution";
 import {
   UI_ANIMATION_DURATION,
+  DURATION_100,
+  DURATION_300,
   EASE_SNAPPY,
   PANEL_RESTORE_DURATION,
   EASE_OUT_EXPO,
+  DRAG_OVERLAY_ENTRY_SCALE,
+  DRAG_OVERLAY_ENTRY_OPACITY,
   getUiAnimationDuration,
 } from "@/lib/animationUtils";
 
@@ -147,6 +151,9 @@ const TITLE_BAR_CURSOR_OFFSET = 12;
 
 // Horizontal offset from cursor to left edge of worktree drag preview
 const WORKTREE_CURSOR_LEFT_OFFSET = 8;
+
+const DND_RETRY_INTERVAL_MS = 16;
+const DND_RETRY_MAX_ATTEMPTS = 10;
 
 interface DndProviderProps {
   children: React.ReactNode;
@@ -264,6 +271,7 @@ function DragOverlayWithCursorTracking({
 }) {
   const pointerStartRef = useRef<{ x: number; y: number } | null>(null);
   const pointerPositionRef = useRef<{ x: number; y: number } | null>(null);
+  const prefersReducedMotion = useReducedMotion();
 
   useDndMonitor({
     onDragStart({ activatorEvent }) {
@@ -338,7 +346,7 @@ function DragOverlayWithCursorTracking({
       {overlayContent ? (
         <m.div
           key={activeTerminal?.id ?? activeWorktree?.id ?? "drag-overlay"}
-          initial={{ scale: 0.95, opacity: 0.8 }}
+          initial={prefersReducedMotion ? false : { scale: DRAG_OVERLAY_ENTRY_SCALE, opacity: DRAG_OVERLAY_ENTRY_OPACITY }}
           animate={{ scale: 1, opacity: 1 }}
           // eslint-disable-next-line @typescript-eslint/no-explicit-any, @typescript-eslint/no-unsafe-type-assertion -- framer-motion v12 Easing type doesn't include CSS cubic-bezier strings
           transition={{ duration: UI_ANIMATION_DURATION / 1000, ease: EASE_SNAPPY } as any}
@@ -588,7 +596,7 @@ export function DndProvider({ children }: DndProviderProps) {
       // ALWAYS unlock resize regardless of drop target - fixes stuck resize locks
       // when dropping outside droppable areas (over === null)
       if (draggedId) {
-        setTimeout(() => terminalInstanceService.lockResize(draggedId, false), 100);
+        setTimeout(() => terminalInstanceService.lockResize(draggedId, false), DURATION_100);
       }
 
       // Defensive: cancelDrop should convert rejected drops to onDragCancel.
@@ -887,8 +895,6 @@ export function DndProvider({ children }: DndProviderProps) {
           } else {
             // Terminal may not be mounted yet (popover timing), retry with bounded attempts
             let attempts = 0;
-            const maxAttempts = 10;
-            const retryInterval = 16;
 
             const retryFit = () => {
               attempts++;
@@ -897,18 +903,18 @@ export function DndProvider({ children }: DndProviderProps) {
                 refreshDockTerminal();
                 return;
               }
-              if (attempts < maxAttempts) {
-                const timerId = setTimeout(retryFit, retryInterval);
+              if (attempts < DND_RETRY_MAX_ATTEMPTS) {
+                const timerId = setTimeout(retryFit, DND_RETRY_INTERVAL_MS);
                 dockRetryTimersRef.current.add(timerId);
               }
             };
 
             // Start retry loop
-            const initialTimerId = setTimeout(retryFit, retryInterval);
+            const initialTimerId = setTimeout(retryFit, DND_RETRY_INTERVAL_MS);
             dockRetryTimersRef.current.add(initialTimerId);
           }
         }
-      }, 300);
+      }, DURATION_300);
     },
     [
       activeData,

--- a/src/components/DragDrop/DndProvider.tsx
+++ b/src/components/DragDrop/DndProvider.tsx
@@ -346,7 +346,11 @@ function DragOverlayWithCursorTracking({
       {overlayContent ? (
         <m.div
           key={activeTerminal?.id ?? activeWorktree?.id ?? "drag-overlay"}
-          initial={prefersReducedMotion ? false : { scale: DRAG_OVERLAY_ENTRY_SCALE, opacity: DRAG_OVERLAY_ENTRY_OPACITY }}
+          initial={
+            prefersReducedMotion
+              ? false
+              : { scale: DRAG_OVERLAY_ENTRY_SCALE, opacity: DRAG_OVERLAY_ENTRY_OPACITY }
+          }
           animate={{ scale: 1, opacity: 1 }}
           // eslint-disable-next-line @typescript-eslint/no-explicit-any, @typescript-eslint/no-unsafe-type-assertion -- framer-motion v12 Easing type doesn't include CSS cubic-bezier strings
           transition={{ duration: UI_ANIMATION_DURATION / 1000, ease: EASE_SNAPPY } as any}

--- a/src/components/DragDrop/SortableDockItem.tsx
+++ b/src/components/DragDrop/SortableDockItem.tsx
@@ -60,7 +60,10 @@ export function SortableDockItem({
         <m.div
           className="h-full"
           animate={{ opacity: isDragging ? DRAG_GHOST_OPACITY : 1 }}
-          transition={{ duration: isDragging ? UI_ANIMATION_DURATION / 1000 : 0, ease: DRAG_GHOST_EASING }}
+          transition={{
+            duration: isDragging ? UI_ANIMATION_DURATION / 1000 : 0,
+            ease: DRAG_GHOST_EASING,
+          }}
         >
           <DragHandleProvider value={{ listeners }}>{children}</DragHandleProvider>
         </m.div>

--- a/src/components/DragDrop/SortableDockItem.tsx
+++ b/src/components/DragDrop/SortableDockItem.tsx
@@ -2,6 +2,7 @@ import { useSortable } from "@dnd-kit/sortable";
 import { CSS } from "@dnd-kit/utilities";
 import { m } from "framer-motion";
 import { cn } from "@/lib/utils";
+import { UI_ANIMATION_DURATION, DRAG_GHOST_OPACITY, DRAG_GHOST_EASING } from "@/lib/animationUtils";
 import type { TerminalInstance } from "@/store";
 import type { DragData } from "./DndProvider";
 import { DragHandleProvider } from "./DragHandleContext";
@@ -58,8 +59,8 @@ export function SortableDockItem({
       <div ref={setNodeRef} style={style} role="listitem" className={cn("flex-shrink-0")}>
         <m.div
           className="h-full"
-          animate={{ opacity: isDragging ? 0.4 : 1 }}
-          transition={{ duration: isDragging ? 0.15 : 0, ease: "easeOut" }}
+          animate={{ opacity: isDragging ? DRAG_GHOST_OPACITY : 1 }}
+          transition={{ duration: isDragging ? UI_ANIMATION_DURATION / 1000 : 0, ease: DRAG_GHOST_EASING }}
         >
           <DragHandleProvider value={{ listeners }}>{children}</DragHandleProvider>
         </m.div>

--- a/src/components/DragDrop/SortableTerminal.tsx
+++ b/src/components/DragDrop/SortableTerminal.tsx
@@ -95,7 +95,10 @@ export function SortableTerminal({
         <m.div
           className="h-full"
           animate={{ opacity: isDragging ? DRAG_GHOST_OPACITY : 1 }}
-          transition={{ duration: isDragging ? UI_ANIMATION_DURATION / 1000 : 0, ease: DRAG_GHOST_EASING }}
+          transition={{
+            duration: isDragging ? UI_ANIMATION_DURATION / 1000 : 0,
+            ease: DRAG_GHOST_EASING,
+          }}
         >
           <DragHandleProvider value={{ listeners }}>{children}</DragHandleProvider>
         </m.div>

--- a/src/components/DragDrop/SortableTerminal.tsx
+++ b/src/components/DragDrop/SortableTerminal.tsx
@@ -2,6 +2,7 @@ import { useSortable } from "@dnd-kit/sortable";
 import { CSS } from "@dnd-kit/utilities";
 import { m, type TransformProperties, type Transition } from "framer-motion";
 import { cn } from "@/lib/utils";
+import { UI_ANIMATION_DURATION, DRAG_GHOST_OPACITY, DRAG_GHOST_EASING } from "@/lib/animationUtils";
 import type { TerminalInstance } from "@/store";
 import type { DragData } from "./DndProvider";
 import { DragHandleProvider } from "./DragHandleContext";
@@ -93,8 +94,8 @@ export function SortableTerminal({
       >
         <m.div
           className="h-full"
-          animate={{ opacity: isDragging ? 0.4 : 1 }}
-          transition={{ duration: isDragging ? 0.15 : 0, ease: "easeOut" }}
+          animate={{ opacity: isDragging ? DRAG_GHOST_OPACITY : 1 }}
+          transition={{ duration: isDragging ? UI_ANIMATION_DURATION / 1000 : 0, ease: DRAG_GHOST_EASING }}
         >
           <DragHandleProvider value={{ listeners }}>{children}</DragHandleProvider>
         </m.div>

--- a/src/components/DragDrop/SortableWorktreeCard.tsx
+++ b/src/components/DragDrop/SortableWorktreeCard.tsx
@@ -119,7 +119,10 @@ export const SortableWorktreeCard = React.memo(function SortableWorktreeCard({
           <m.div
             className="h-full"
             animate={{ opacity: isDragging ? DRAG_GHOST_OPACITY : 1 }}
-            transition={{ duration: isDragging ? UI_ANIMATION_DURATION / 1000 : 0, ease: DRAG_GHOST_EASING }}
+            transition={{
+              duration: isDragging ? UI_ANIMATION_DURATION / 1000 : 0,
+              ease: DRAG_GHOST_EASING,
+            }}
           >
             {children({
               isDraggingSort: isDragging,

--- a/src/components/DragDrop/SortableWorktreeCard.tsx
+++ b/src/components/DragDrop/SortableWorktreeCard.tsx
@@ -2,6 +2,7 @@ import React from "react";
 import { useSortable } from "@dnd-kit/sortable";
 import { CSS } from "@dnd-kit/utilities";
 import { m } from "framer-motion";
+import { UI_ANIMATION_DURATION, DRAG_GHOST_OPACITY, DRAG_GHOST_EASING } from "@/lib/animationUtils";
 import type { SyntheticListenerMap } from "@dnd-kit/core/dist/hooks/utilities";
 
 export interface WorktreeSortDragData {
@@ -117,8 +118,8 @@ export const SortableWorktreeCard = React.memo(function SortableWorktreeCard({
         <div role="gridcell">
           <m.div
             className="h-full"
-            animate={{ opacity: isDragging ? 0.4 : 1 }}
-            transition={{ duration: isDragging ? 0.15 : 0, ease: "easeOut" }}
+            animate={{ opacity: isDragging ? DRAG_GHOST_OPACITY : 1 }}
+            transition={{ duration: isDragging ? UI_ANIMATION_DURATION / 1000 : 0, ease: DRAG_GHOST_EASING }}
           >
             {children({
               isDraggingSort: isDragging,

--- a/src/components/DragDrop/SortableWorktreeTerminal.tsx
+++ b/src/components/DragDrop/SortableWorktreeTerminal.tsx
@@ -2,6 +2,7 @@ import { useSortable } from "@dnd-kit/sortable";
 import { CSS } from "@dnd-kit/utilities";
 import { m } from "framer-motion";
 import { cn } from "@/lib/utils";
+import { UI_ANIMATION_DURATION, DRAG_GHOST_OPACITY, DRAG_GHOST_EASING } from "@/lib/animationUtils";
 import type { TerminalInstance } from "@/store";
 import type { WorktreeDragData } from "./DndProvider";
 import { pixelSnapTransform } from "./SortableTerminal";
@@ -72,8 +73,8 @@ export function SortableWorktreeTerminal({
       >
         <m.div
           className="h-full"
-          animate={{ opacity: isDragging ? 0.4 : 1 }}
-          transition={{ duration: isDragging ? 0.15 : 0, ease: "easeOut" }}
+          animate={{ opacity: isDragging ? DRAG_GHOST_OPACITY : 1 }}
+          transition={{ duration: isDragging ? UI_ANIMATION_DURATION / 1000 : 0, ease: DRAG_GHOST_EASING }}
         >
           {typeof children === "function" ? (
             children({ listeners })

--- a/src/components/DragDrop/SortableWorktreeTerminal.tsx
+++ b/src/components/DragDrop/SortableWorktreeTerminal.tsx
@@ -74,7 +74,10 @@ export function SortableWorktreeTerminal({
         <m.div
           className="h-full"
           animate={{ opacity: isDragging ? DRAG_GHOST_OPACITY : 1 }}
-          transition={{ duration: isDragging ? UI_ANIMATION_DURATION / 1000 : 0, ease: DRAG_GHOST_EASING }}
+          transition={{
+            duration: isDragging ? UI_ANIMATION_DURATION / 1000 : 0,
+            ease: DRAG_GHOST_EASING,
+          }}
         >
           {typeof children === "function" ? (
             children({ listeners })

--- a/src/lib/animationUtils.ts
+++ b/src/lib/animationUtils.ts
@@ -95,6 +95,11 @@ export const PANEL_RESTORE_DURATION = DURATION_200;
 export const BANNER_ENTER_DURATION = DURATION_250;
 export const BANNER_EXIT_DURATION = DURATION_200;
 
+export const DRAG_GHOST_OPACITY = 0.4;
+export const DRAG_GHOST_EASING = "easeOut";
+export const DRAG_OVERLAY_ENTRY_SCALE = 0.95;
+export const DRAG_OVERLAY_ENTRY_OPACITY = 0.8;
+
 export const PANEL_MINIMIZE_EASING = "cubic-bezier(0.3, 0, 0.8, 0.15)";
 export const PANEL_RESTORE_EASING = EASE_OUT_EXPO;
 


### PR DESCRIPTION
Lifts magic numbers out of the DragDrop components and into named constants. Most live in `animationUtils.ts` alongside the existing duration/easing constants; the DnD retry loop locals stayed in `DndProvider.tsx` since they are single-use.

The drag overlay entry animation in `DragOverlayWithCursorTracking` picked up an explicit `useReducedMotion` check, matching the same pattern already used in `WorktreeDetailsSection`, `SystemRequirementsSection`, and `AgentSetupWizard`.

No behavior change — just a refactor.

Resolves #7265