### PR TITLE
build(windows): replace nsis+portable targets with appx for Microsoft Store

### DIFF
--- a/README.md
+++ b/README.md
@@ -212,7 +212,7 @@ npm run rebuild      # Rebuild native modules
 npm run build        # Production build
 npm run package      # Package for current platform
 npm run package:mac  # macOS (DMG, ZIP — arm64, x64, universal)
-npm run package:win  # Windows (NSIS, portable)
+npm run package:win  # Windows (AppX — Microsoft Store)
 npm run package:linux # Linux (AppImage, deb)
 ```
 

--- a/electron-builder.config.cjs
+++ b/electron-builder.config.cjs
@@ -108,17 +108,20 @@ module.exports = async function () {
     },
     win: {
       icon: "build/icon.ico",
-      target: [
-        { target: "nsis", arch: ["x64"] },
-        { target: "portable", arch: ["x64"] },
-      ],
+      target: [{ target: "appx", arch: ["x64"] }],
     },
-    nsis: {
-      oneClick: false,
-      allowToChangeInstallationDirectory: true,
-      installerIcon: "build/icon.ico",
-      uninstallerIcon: "build/icon.ico",
-      installerHeaderIcon: "build/icon.ico",
+    // Microsoft Store identity. Placeholder values until Partner Center setup
+    // completes — see docs/distribution/microsoft-store.md for the swap-in
+    // procedure. `identityName` and `publisher` MUST match Partner Center →
+    // Daintree → Product Identity verbatim before first Store submission, or
+    // `msstore submission update` will fail with `Invalid Identity`.
+    appx: {
+      identityName: "Daintree",
+      publisher: "CN=00000000-0000-0000-0000-000000000000",
+      publisherDisplayName: "Greg Priday",
+      applicationId: "Daintree",
+      displayName: "Daintree",
+      languages: ["en-US"],
     },
     linux: {
       icon: "build/icon.png",

--- a/package.json
+++ b/package.json
@@ -26,7 +26,7 @@
     "build": "tsc && vite build && npm run build:main",
     "package": "npm run build && electron-builder",
     "package:mac": "npm run build && electron-builder --mac",
-    "package:win": "npm run build && electron-builder --win",
+    "package:win": "npm run build && electron-builder --win appx",
     "package:linux": "npm run build && electron-builder --linux",
     "package:local": "npm run build && electron-builder --mac --dir -c.mac.identity=null -c.mac.forceCodeSigning=false -c.mac.notarize=false",
     "package:local:dmg": "npm run build && electron-builder --mac dmg -c.mac.identity=null -c.mac.forceCodeSigning=false -c.mac.notarize=false",


### PR DESCRIPTION
Replaces the Windows NSIS and portable build targets with a single `appx` target for distribution through the Microsoft Store.

Resolves #7198
Closes #2817
Closes #5831

## Changes

- `electron-builder.config.cjs`: `win.target` is now a single `{ target: "appx", arch: ["x64"] }` entry; added an `appx` config block with Partner Center identity placeholders (`identityName`, `publisher`, `publisherDisplayName`, `applicationId`, `displayName`, `languages`) to fill in once the app is registered
- `package.json`: `package:win` script simplified to `electron-builder --win appx`
- `README.md`: updated the `package:win` comment to match

## Notes

Microsoft re-signs the package after certification, which removes both the SmartScreen "Unknown Publisher" warning (#2817) and the Smart App Control hard-block (#5831) without needing an Authenticode certificate purchase or SignPath.

Existing users on the `.exe` won't auto-migrate to the Store version — worth a clear callout in the release notes when this ships, alongside removing the `.exe` download link from the website.

## Testing

Build config changes only — no runtime code paths affected. `scripts/afterPack.cjs` and `.github/workflows/release.yml` already handle `appx` output (verify step at line 207, WACK at line 218, R2 sync includes `*.appx`).