### PR TITLE
feat(dev-preview): refresh viewport presets for 2025-2026 devices

### DIFF
--- a/shared/types/panel.ts
+++ b/shared/types/panel.ts
@@ -334,7 +334,7 @@ export interface BrowserPanelData extends BasePanelData {
 }
 
 /** Viewport preset IDs for dev-preview responsive emulation */
-export type ViewportPresetId = "iphone" | "pixel" | "ipad";
+export type ViewportPresetId = "iphone" | "pixel" | "ipad" | "galaxy";
 
 export interface DevPreviewPanelData extends BasePanelData {
   kind: "dev-preview";

--- a/src/components/Browser/__tests__/BrowserToolbar.test.tsx
+++ b/src/components/Browser/__tests__/BrowserToolbar.test.tsx
@@ -427,7 +427,10 @@ describe("BrowserToolbar viewport presets", () => {
     it("each chip is a radio with aria-checked reflecting selection", () => {
       renderWithViewport();
       const radios = document.querySelectorAll('[role="radio"]');
-      expect(radios.length).toBe(3);
+      expect(radios.length).toBe(4);
+
+      const galaxyRadio = document.querySelector('[data-viewport-preset-id="galaxy"]');
+      expect(galaxyRadio!.getAttribute("aria-checked")).toBe("false");
 
       const iphoneRadio = document.querySelector('[data-viewport-preset-id="iphone"]');
       expect(iphoneRadio!.getAttribute("aria-checked")).toBe("true");
@@ -451,7 +454,10 @@ describe("BrowserToolbar viewport presets", () => {
     it("has aria-label matching preset label", () => {
       renderWithViewport();
       const iphoneRadio = document.querySelector('[data-viewport-preset-id="iphone"]');
-      expect(iphoneRadio!.getAttribute("aria-label")).toBe("iPhone 15");
+      expect(iphoneRadio!.getAttribute("aria-label")).toBe("iPhone 16");
+
+      const galaxyRadio = document.querySelector('[data-viewport-preset-id="galaxy"]');
+      expect(galaxyRadio!.getAttribute("aria-label")).toBe("Galaxy S25");
     });
   });
 
@@ -558,52 +564,52 @@ describe("BrowserToolbar viewport presets", () => {
 
     it("ArrowLeft wraps from first to last", () => {
       renderWithViewport();
-      const iphoneRadio = document.querySelector(
-        '[data-viewport-preset-id="iphone"]'
+      const galaxyRadio = document.querySelector(
+        '[data-viewport-preset-id="galaxy"]'
       )! as HTMLElement;
       const ipadRadio = document.querySelector('[data-viewport-preset-id="ipad"]')! as HTMLElement;
 
-      iphoneRadio.focus();
-      fireEvent.keyDown(iphoneRadio, { key: "ArrowLeft" });
+      galaxyRadio.focus();
+      fireEvent.keyDown(galaxyRadio, { key: "ArrowLeft" });
 
       expect(document.activeElement).toBe(ipadRadio);
     });
 
     it("ArrowRight wraps from last to first", () => {
       renderWithViewport();
-      const iphoneRadio = document.querySelector(
-        '[data-viewport-preset-id="iphone"]'
+      const galaxyRadio = document.querySelector(
+        '[data-viewport-preset-id="galaxy"]'
       )! as HTMLElement;
       const ipadRadio = document.querySelector('[data-viewport-preset-id="ipad"]')! as HTMLElement;
 
       ipadRadio.focus();
       fireEvent.keyDown(ipadRadio, { key: "ArrowRight" });
 
-      expect(document.activeElement).toBe(iphoneRadio);
+      expect(document.activeElement).toBe(galaxyRadio);
     });
 
     it("Home moves focus to first radio", () => {
       renderWithViewport();
-      const iphoneRadio = document.querySelector(
-        '[data-viewport-preset-id="iphone"]'
+      const galaxyRadio = document.querySelector(
+        '[data-viewport-preset-id="galaxy"]'
       )! as HTMLElement;
       const ipadRadio = document.querySelector('[data-viewport-preset-id="ipad"]')! as HTMLElement;
 
       ipadRadio.focus();
       fireEvent.keyDown(ipadRadio, { key: "Home" });
 
-      expect(document.activeElement).toBe(iphoneRadio);
+      expect(document.activeElement).toBe(galaxyRadio);
     });
 
     it("End moves focus to last radio", () => {
       renderWithViewport();
-      const iphoneRadio = document.querySelector(
-        '[data-viewport-preset-id="iphone"]'
+      const galaxyRadio = document.querySelector(
+        '[data-viewport-preset-id="galaxy"]'
       )! as HTMLElement;
       const ipadRadio = document.querySelector('[data-viewport-preset-id="ipad"]')! as HTMLElement;
 
-      iphoneRadio.focus();
-      fireEvent.keyDown(iphoneRadio, { key: "End" });
+      galaxyRadio.focus();
+      fireEvent.keyDown(galaxyRadio, { key: "End" });
 
       expect(document.activeElement).toBe(ipadRadio);
     });
@@ -659,15 +665,17 @@ describe("BrowserToolbar viewport presets", () => {
 
     it("ArrowUp moves focus backward like ArrowLeft", () => {
       renderWithViewport();
+      const galaxyRadio = document.querySelector(
+        '[data-viewport-preset-id="galaxy"]'
+      )! as HTMLElement;
       const iphoneRadio = document.querySelector(
         '[data-viewport-preset-id="iphone"]'
       )! as HTMLElement;
-      const ipadRadio = document.querySelector('[data-viewport-preset-id="ipad"]')! as HTMLElement;
 
       iphoneRadio.focus();
       fireEvent.keyDown(iphoneRadio, { key: "ArrowUp" });
 
-      expect(document.activeElement).toBe(ipadRadio);
+      expect(document.activeElement).toBe(galaxyRadio);
     });
 
     it("maintains roving tabIndex after ArrowRight focus move", () => {

--- a/src/panels/dev-preview/__tests__/viewportPresets.test.ts
+++ b/src/panels/dev-preview/__tests__/viewportPresets.test.ts
@@ -5,13 +5,8 @@ import type { ViewportPresetId } from "@shared/types/panel";
 import { VIEWPORT_PRESET_LIST, VIEWPORT_PRESETS, getViewportPreset } from "../viewportPresets";
 
 describe("VIEWPORT_PRESETS", () => {
-  it("exposes all four preset ids", () => {
-    expect(VIEWPORT_PRESET_LIST.map((p) => p.id).sort()).toEqual([
-      "galaxy",
-      "ipad",
-      "iphone",
-      "pixel",
-    ]);
+  it("renders smallest-to-largest in the chip row order", () => {
+    expect(VIEWPORT_PRESET_LIST.map((p) => p.id)).toEqual(["galaxy", "iphone", "pixel", "ipad"]);
   });
 
   it("Galaxy S25 covers the sub-393 px breakpoint", () => {

--- a/src/panels/dev-preview/__tests__/viewportPresets.test.ts
+++ b/src/panels/dev-preview/__tests__/viewportPresets.test.ts
@@ -1,0 +1,72 @@
+import { describe, expect, it } from "vitest";
+
+import type { ViewportPresetId } from "@shared/types/panel";
+
+import { VIEWPORT_PRESET_LIST, VIEWPORT_PRESETS, getViewportPreset } from "../viewportPresets";
+
+describe("VIEWPORT_PRESETS", () => {
+  it("exposes all four preset ids", () => {
+    expect(VIEWPORT_PRESET_LIST.map((p) => p.id).sort()).toEqual([
+      "galaxy",
+      "ipad",
+      "iphone",
+      "pixel",
+    ]);
+  });
+
+  it("Galaxy S25 covers the sub-393 px breakpoint", () => {
+    expect(VIEWPORT_PRESETS.galaxy).toMatchObject({
+      id: "galaxy",
+      label: "Galaxy S25",
+      width: 360,
+      height: 780,
+    });
+    expect(VIEWPORT_PRESETS.galaxy.userAgent).toContain("Android 15");
+    expect(VIEWPORT_PRESETS.galaxy.userAgent).toContain("SM-S931U");
+  });
+
+  it("iPhone 16 keeps the iPhone 15 dimensions", () => {
+    expect(VIEWPORT_PRESETS.iphone).toMatchObject({
+      id: "iphone",
+      label: "iPhone 16",
+      width: 393,
+      height: 852,
+    });
+    expect(VIEWPORT_PRESETS.iphone.userAgent).toContain("iPhone OS 18_0");
+  });
+
+  it("Pixel 9 ticks height up to 923", () => {
+    expect(VIEWPORT_PRESETS.pixel).toMatchObject({
+      id: "pixel",
+      label: "Pixel 9",
+      width: 412,
+      height: 923,
+    });
+    expect(VIEWPORT_PRESETS.pixel.userAgent).toContain("Android 15");
+    expect(VIEWPORT_PRESETS.pixel.userAgent).toContain("Pixel 9");
+  });
+
+  it("iPad Air M3 keeps the iPad Air dimensions", () => {
+    expect(VIEWPORT_PRESETS.ipad).toMatchObject({
+      id: "ipad",
+      label: "iPad Air M3",
+      width: 820,
+      height: 1180,
+    });
+    expect(VIEWPORT_PRESETS.ipad.userAgent).toContain("CPU OS 18_0");
+  });
+});
+
+describe("getViewportPreset", () => {
+  it("returns the matching preset for a known id", () => {
+    expect(getViewportPreset("galaxy")).toBe(VIEWPORT_PRESETS.galaxy);
+    expect(getViewportPreset("iphone")).toBe(VIEWPORT_PRESETS.iphone);
+    expect(getViewportPreset("pixel")).toBe(VIEWPORT_PRESETS.pixel);
+    expect(getViewportPreset("ipad")).toBe(VIEWPORT_PRESETS.ipad);
+  });
+
+  it("falls back to iphone when given a stale persisted id", () => {
+    const stale = "nokia" as unknown as ViewportPresetId;
+    expect(getViewportPreset(stale)).toBe(VIEWPORT_PRESETS.iphone);
+  });
+});

--- a/src/panels/dev-preview/viewportPresets.ts
+++ b/src/panels/dev-preview/viewportPresets.ts
@@ -9,34 +9,42 @@ export interface ViewportPreset {
 }
 
 export const VIEWPORT_PRESETS: Record<ViewportPresetId, ViewportPreset> = {
+  galaxy: {
+    id: "galaxy",
+    label: "Galaxy S25",
+    width: 360,
+    height: 780,
+    userAgent:
+      "Mozilla/5.0 (Linux; Android 15; SM-S931U) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/130.0.0.0 Mobile Safari/537.36",
+  },
   iphone: {
     id: "iphone",
-    label: "iPhone 15",
+    label: "iPhone 16",
     width: 393,
     height: 852,
     userAgent:
-      "Mozilla/5.0 (iPhone; CPU iPhone OS 17_5 like Mac OS X) AppleWebKit/605.1.15 (KHTML, like Gecko) Version/17.5 Mobile/15E148 Safari/604.1",
+      "Mozilla/5.0 (iPhone; CPU iPhone OS 18_0 like Mac OS X) AppleWebKit/605.1.15 (KHTML, like Gecko) Version/18.0 Mobile/15E148 Safari/604.1",
   },
   pixel: {
     id: "pixel",
-    label: "Pixel 8",
+    label: "Pixel 9",
     width: 412,
-    height: 915,
+    height: 923,
     userAgent:
-      "Mozilla/5.0 (Linux; Android 14; Pixel 8) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/125.0.6422.113 Mobile Safari/537.36",
+      "Mozilla/5.0 (Linux; Android 15; Pixel 9) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/130.0.0.0 Mobile Safari/537.36",
   },
   ipad: {
     id: "ipad",
-    label: "iPad Air",
+    label: "iPad Air M3",
     width: 820,
     height: 1180,
     userAgent:
-      "Mozilla/5.0 (iPad; CPU OS 17_5 like Mac OS X) AppleWebKit/605.1.15 (KHTML, like Gecko) Version/17.5 Mobile/15E148 Safari/604.1",
+      "Mozilla/5.0 (iPad; CPU OS 18_0 like Mac OS X) AppleWebKit/605.1.15 (KHTML, like Gecko) Version/18.0 Mobile/15E148 Safari/604.1",
   },
 };
 
 export const VIEWPORT_PRESET_LIST: ViewportPreset[] = Object.values(VIEWPORT_PRESETS);
 
 export function getViewportPreset(id: ViewportPresetId): ViewportPreset {
-  return VIEWPORT_PRESETS[id];
+  return VIEWPORT_PRESETS[id] ?? VIEWPORT_PRESETS.iphone;
 }


### PR DESCRIPTION
## Summary

- Refreshes the three existing viewport presets to current-generation devices: iPhone 15 → iPhone 16 (label + UA, dimensions stay `393×852`), Pixel 8 → Pixel 9 (label + UA, dimensions update to `412×923`), iPad Air → iPad Air M3 (label + UA, dimensions stay `820×1180`).
- Adds a Galaxy S25 preset at `360×780` — the sub-393px small-phone breakpoint was the most common place for mobile layout issues but we had nothing in that range.
- Hardens `getViewportPreset()` with a fallback to the `iphone` preset for unknown IDs, so a downgrade back to a build that doesn't have a saved preset key doesn't crash.

Resolves #7203

## Changes

- `shared/types/panel.ts` — add `"galaxy"` to the `ViewportPresetId` union
- `src/panels/dev-preview/viewportPresets.ts` — rewrite preset map with updated labels/UA strings, new Galaxy S25 entry, and `?? VIEWPORT_PRESETS.iphone` fallback in `getViewportPreset()`
- `src/panels/dev-preview/__tests__/viewportPresets.test.ts` — new file, 7 tests covering all four presets, dimensions, labels, UA invariants, and the fallback
- `src/components/Browser/__tests__/BrowserToolbar.test.tsx` — updated for chip count 3→4, refreshed labels, new ordering (galaxy first as smallest)

## Testing

Unit tests cover all four presets and the downgrade fallback. `BrowserToolbar` tests updated to match the new chip ordering.