### PR TITLE
perf(startup): promote early-renderer mode to default

### DIFF
--- a/electron/window/__tests__/windowServicesEarlyRenderer.test.ts
+++ b/electron/window/__tests__/windowServicesEarlyRenderer.test.ts
@@ -2,32 +2,38 @@ import { describe, expect, it } from "vitest";
 import { shouldEnableEarlyRenderer } from "../earlyRenderer.js";
 
 describe("shouldEnableEarlyRenderer", () => {
-  it("returns false when DAINTREE_EARLY_RENDERER is unset", () => {
-    expect(shouldEnableEarlyRenderer({ isSmokeTest: false, env: {} })).toBe(false);
+  it("returns true when DAINTREE_EARLY_RENDERER is unset (default on)", () => {
+    expect(shouldEnableEarlyRenderer({ isSmokeTest: false, env: {} })).toBe(true);
   });
 
-  it("returns true when DAINTREE_EARLY_RENDERER=1 and not in smoke test", () => {
+  it("returns false when DAINTREE_EARLY_RENDERER=0 (opt-out)", () => {
     expect(
       shouldEnableEarlyRenderer({
         isSmokeTest: false,
-        env: { DAINTREE_EARLY_RENDERER: "1" },
+        env: { DAINTREE_EARLY_RENDERER: "0" },
       })
-    ).toBe(true);
+    ).toBe(false);
   });
 
-  it("returns false when DAINTREE_EARLY_RENDERER is any value other than '1'", () => {
-    for (const value of ["0", "true", "yes", "on", ""]) {
+  it("returns true for non-zero values", () => {
+    for (const value of ["1", "true", "yes", "on", ""]) {
       expect(
         shouldEnableEarlyRenderer({
           isSmokeTest: false,
           env: { DAINTREE_EARLY_RENDERER: value },
         })
-      ).toBe(false);
+      ).toBe(true);
     }
   });
 
-  it("returns false in smoke-test mode even with DAINTREE_EARLY_RENDERER=1", () => {
+  it("returns false in smoke-test mode regardless of DAINTREE_EARLY_RENDERER", () => {
     // Smoke tests assert deterministic readiness — keep them on the serial path.
+    expect(
+      shouldEnableEarlyRenderer({
+        isSmokeTest: true,
+        env: {},
+      })
+    ).toBe(false);
     expect(
       shouldEnableEarlyRenderer({
         isSmokeTest: true,

--- a/electron/window/earlyRenderer.ts
+++ b/electron/window/earlyRenderer.ts
@@ -1,15 +1,16 @@
 /**
  * Decide whether to start the renderer in parallel with PTY host bootstrap.
  *
- * The default serial path awaits `ptyClient.waitForReady()` before calling
- * `loadRenderer()`, which blocks first paint behind the PTY handshake (~70–150ms
- * cold). When `DAINTREE_EARLY_RENDERER=1` is set, the renderer load is hoisted
- * ahead of the workspace/PTY init block. The smoke test path is excluded so its
- * deterministic readiness checks keep working unmodified.
+ * Early-renderer mode is the default: `loadRenderer()` is hoisted ahead of the
+ * workspace/PTY init block so first paint stops waiting on the PTY handshake
+ * (~70–150ms cold). Set `DAINTREE_EARLY_RENDERER=0` to restore the serial path
+ * (await `ptyClient.waitForReady()` before `loadRenderer()`). The smoke test
+ * path is always excluded so its deterministic readiness checks keep working
+ * unmodified.
  */
 export function shouldEnableEarlyRenderer(opts: {
   isSmokeTest: boolean;
   env: NodeJS.ProcessEnv;
 }): boolean {
-  return !opts.isSmokeTest && opts.env.DAINTREE_EARLY_RENDERER === "1";
+  return !opts.isSmokeTest && opts.env.DAINTREE_EARLY_RENDERER !== "0";
 }

--- a/electron/window/windowServices.ts
+++ b/electron/window/windowServices.ts
@@ -163,10 +163,10 @@ export async function setupWindowServices(
     markPerformance(PERF_MARKS.SERVICE_INIT_IPC_READY);
   }
 
-  // Renderer load is gated by DAINTREE_EARLY_RENDERER. With the flag, the
-  // did-finish-load handler is registered and loadRenderer() is fired before
-  // the workspace/PTY init block — first paint stops waiting on the PTY
-  // handshake. Without the flag (default), the original serial order is kept:
+  // Early-renderer mode is the default: the did-finish-load handler is
+  // registered and loadRenderer() is fired before the workspace/PTY init
+  // block, so first paint stops waiting on the PTY handshake. Set
+  // DAINTREE_EARLY_RENDERER=0 to restore the serial path:
   // workspace init → handler → loadRenderer.
   const earlyRendererEnabled = shouldEnableEarlyRenderer({ isSmokeTest, env: process.env });
 
@@ -189,9 +189,10 @@ export async function setupWindowServices(
       markPerformance(PERF_MARKS.RENDERER_READY);
       createAndDistributePorts(win, ctx);
       // Refresh workspace direct port on reload (preload context is reset).
-      // Under DAINTREE_EARLY_RENDERER, workspaceClient may still be null on the
-      // first did-finish-load — the initial direct-port attach is performed by
-      // the loadProject() path below once the workspace host is ready.
+      // With early-renderer mode (default), workspaceClient may still be null
+      // on the first did-finish-load — the initial direct-port attach is
+      // performed by the loadProject() path below once the workspace host is
+      // ready.
       const workspaceClient = getWorkspaceClientRef();
       if (workspaceClient) {
         workspaceClient.attachDirectPort(win.id, appWc);
@@ -219,7 +220,7 @@ export async function setupWindowServices(
   };
 
   if (earlyRendererEnabled) {
-    console.log("[MAIN] DAINTREE_EARLY_RENDERER=1 — loading renderer in parallel with PTY init");
+    console.log("[MAIN] Early renderer enabled — loading renderer in parallel with PTY init");
     startRendererLoad("early-renderer");
   }
 
@@ -296,11 +297,13 @@ export async function setupWindowServices(
   const { armRestoreQuota } = await import("../ipc/utils.js");
   armRestoreQuota(50, 120_000);
 
-  // Under DAINTREE_EARLY_RENDERER=1 the RENDERER_READY mark can fire before
-  // this point, since the renderer is loading concurrently with workspace init.
+  // With early-renderer mode (default), the RENDERER_READY mark can fire
+  // before this point, since the renderer is loading concurrently with
+  // workspace init.
   markPerformance(PERF_MARKS.SERVICE_INIT_COMPLETE);
-  // Default path: renderer load happens here, after workspace + PTY are ready.
-  // With DAINTREE_EARLY_RENDERER=1 this is a no-op (already started above).
+  // Opt-out path (DAINTREE_EARLY_RENDERER=0): renderer load happens here,
+  // after workspace + PTY are ready. With early-renderer mode active this is
+  // a no-op (already started above).
   startRendererLoad("after-services-ready");
 
   // Error handlers also use ipcMain.handle — register once


### PR DESCRIPTION
## Summary

- Early-renderer mode hoists `loadRenderer()` ahead of `await ptyClient.waitForReady()`, cutting 70-150ms from cold-start time. It was originally shipped opt-in pending validation — promoting it to the default now.
- `DAINTREE_EARLY_RENDERER` flips from opt-in (`=== "1"`) to opt-out (`!== "0"`). The smoke-test exclusion and the null-guards that cover the `workspaceClient` race remain untouched.
- Test suite rewritten to match the new default behaviour.

Resolves #7456

## Changes

- `electron/window/earlyRenderer.ts` — predicate flipped from `=== "1"` to `!== "0"`
- `electron/window/windowServices.ts` — JSDoc, inline comments, and one log string updated to reflect the new default
- `electron/window/__tests__/windowServicesEarlyRenderer.test.ts` — test suite rewritten around the opt-out semantics

## Testing

- Unit tests pass (`windowServicesEarlyRenderer.test.ts` fully rewritten)
- Typecheck, lint, and format clean
- Verify p50/p95 deltas with `npm run perf:cold-start -- --runs 5 --json` against the packaged binary before and after; watch Sentry for `terminal:backend-not-ready` uptick in the week after landing