### PR TITLE
perf(compiler): capture bailout reasons and categories in report

### DIFF
--- a/compiler-bailout-baseline.json
+++ b/compiler-bailout-baseline.json
@@ -1,3338 +1,5986 @@
 {
   "src/App.tsx": {
-    "success": 1,
+    "success": 0,
     "skip": 0,
-    "error": 0,
-    "pipeline": 0
+    "error": 2,
+    "pipeline": 0,
+    "errorBailouts": [
+      {
+        "category": "Todo",
+        "reason": "(BuildHIR::lowerExpression) Handle Import expressions"
+      },
+      {
+        "category": "Todo",
+        "reason": "(BuildHIR::lowerExpression) Handle Import expressions"
+      }
+    ],
+    "skipReasons": [],
+    "pipelineErrors": []
   },
   "src/components/Accessibility/AccessibilityAnnouncer.tsx": {
     "success": 1,
     "skip": 0,
     "error": 0,
-    "pipeline": 0
+    "pipeline": 0,
+    "errorBailouts": [],
+    "skipReasons": [],
+    "pipelineErrors": []
   },
   "src/components/ActionPalette/ActionPalette.tsx": {
     "success": 1,
     "skip": 0,
     "error": 0,
-    "pipeline": 0
+    "pipeline": 0,
+    "errorBailouts": [],
+    "skipReasons": [],
+    "pipelineErrors": []
   },
   "src/components/ActionPalette/ActionPaletteItem.tsx": {
     "success": 1,
     "skip": 0,
     "error": 0,
-    "pipeline": 0
+    "pipeline": 0,
+    "errorBailouts": [],
+    "skipReasons": [],
+    "pipelineErrors": []
   },
   "src/components/AllClearOverlay/AllClearOverlay.tsx": {
     "success": 1,
     "skip": 0,
     "error": 0,
-    "pipeline": 0
+    "pipeline": 0,
+    "errorBailouts": [],
+    "skipReasons": [],
+    "pipelineErrors": []
   },
   "src/components/Browser/BrowserPane.tsx": {
     "success": 0,
     "skip": 0,
     "error": 1,
-    "pipeline": 0
+    "pipeline": 0,
+    "errorBailouts": [
+      {
+        "category": "Todo",
+        "reason": "Support value blocks (conditional, logical, optional chaining, etc) within a try/catch statement"
+      }
+    ],
+    "skipReasons": [],
+    "pipelineErrors": []
   },
   "src/components/Browser/BrowserPaneSkeleton.tsx": {
     "success": 1,
     "skip": 0,
     "error": 0,
-    "pipeline": 0
+    "pipeline": 0,
+    "errorBailouts": [],
+    "skipReasons": [],
+    "pipelineErrors": []
   },
   "src/components/Browser/BrowserToolbar.tsx": {
     "success": 0,
     "skip": 0,
     "error": 1,
-    "pipeline": 0
+    "pipeline": 0,
+    "errorBailouts": [
+      {
+        "category": "Todo",
+        "reason": "(BuildHIR::lowerStatement) Support ThrowStatement inside of try/catch"
+      }
+    ],
+    "skipReasons": [],
+    "pipelineErrors": []
   },
   "src/components/Browser/ConsolePanel.tsx": {
-    "success": 2,
+    "success": 1,
     "skip": 0,
-    "error": 0,
-    "pipeline": 0
+    "error": 1,
+    "pipeline": 0,
+    "errorBailouts": [
+      {
+        "category": "Todo",
+        "reason": "(BuildHIR::lowerExpression) Handle ??= operators in AssignmentExpression"
+      }
+    ],
+    "skipReasons": [],
+    "pipelineErrors": []
   },
   "src/components/Browser/FindBar.tsx": {
     "success": 1,
     "skip": 0,
     "error": 0,
-    "pipeline": 0
+    "pipeline": 0,
+    "errorBailouts": [],
+    "skipReasons": [],
+    "pipelineErrors": []
   },
   "src/components/Browser/ObjectInspector.tsx": {
     "success": 2,
     "skip": 0,
     "error": 1,
-    "pipeline": 0
+    "pipeline": 0,
+    "errorBailouts": [
+      {
+        "category": "Todo",
+        "reason": "(BuildHIR::lowerStatement) Handle TryStatement with a finalizer ('finally') clause"
+      }
+    ],
+    "skipReasons": [],
+    "pipelineErrors": []
   },
   "src/components/Browser/StackTrace.tsx": {
     "success": 1,
     "skip": 0,
     "error": 0,
-    "pipeline": 0
+    "pipeline": 0,
+    "errorBailouts": [],
+    "skipReasons": [],
+    "pipelineErrors": []
   },
   "src/components/Browser/WebviewDialog.tsx": {
     "success": 1,
     "skip": 0,
     "error": 0,
-    "pipeline": 0
+    "pipeline": 0,
+    "errorBailouts": [],
+    "skipReasons": [],
+    "pipelineErrors": []
   },
   "src/components/Commands/CommandBuilder.tsx": {
     "success": 6,
     "skip": 0,
     "error": 0,
-    "pipeline": 0
+    "pipeline": 0,
+    "errorBailouts": [],
+    "skipReasons": [],
+    "pipelineErrors": []
   },
   "src/components/Commands/CommandPicker.tsx": {
     "success": 1,
     "skip": 0,
     "error": 0,
-    "pipeline": 0
+    "pipeline": 0,
+    "errorBailouts": [],
+    "skipReasons": [],
+    "pipelineErrors": []
   },
   "src/components/Commands/CommandPickerButton.tsx": {
     "success": 1,
     "skip": 0,
     "error": 0,
-    "pipeline": 0
+    "pipeline": 0,
+    "errorBailouts": [],
+    "skipReasons": [],
+    "pipelineErrors": []
   },
   "src/components/Commands/CommandPickerHost.tsx": {
     "success": 1,
     "skip": 0,
     "error": 0,
-    "pipeline": 0
+    "pipeline": 0,
+    "errorBailouts": [],
+    "skipReasons": [],
+    "pipelineErrors": []
   },
   "src/components/Demo/DemoCaptureBridge.tsx": {
     "success": 0,
     "skip": 0,
     "error": 1,
-    "pipeline": 0
+    "pipeline": 0,
+    "errorBailouts": [
+      {
+        "category": "Todo",
+        "reason": "(BuildHIR::lowerStatement) Handle TryStatement with a finalizer ('finally') clause"
+      }
+    ],
+    "skipReasons": [],
+    "pipelineErrors": []
   },
   "src/components/Demo/DemoCursor.tsx": {
     "success": 0,
     "skip": 0,
     "error": 1,
-    "pipeline": 0
+    "pipeline": 0,
+    "errorBailouts": [
+      {
+        "category": "Todo",
+        "reason": "(BuildHIR::lowerStatement) Handle TryStatement without a catch clause"
+      }
+    ],
+    "skipReasons": [],
+    "pipelineErrors": []
   },
   "src/components/Demo/DemoOverlay.tsx": {
     "success": 0,
     "skip": 0,
     "error": 1,
-    "pipeline": 0
+    "pipeline": 0,
+    "errorBailouts": [
+      {
+        "category": "Todo",
+        "reason": "Support value blocks (conditional, logical, optional chaining, etc) within a try/catch statement"
+      }
+    ],
+    "skipReasons": [],
+    "pipelineErrors": []
   },
   "src/components/DevPreview/ConsoleDrawer.tsx": {
     "success": 1,
     "skip": 0,
     "error": 0,
-    "pipeline": 0
+    "pipeline": 0,
+    "errorBailouts": [],
+    "skipReasons": [],
+    "pipelineErrors": []
   },
   "src/components/DevPreview/DevPreviewPane.tsx": {
     "success": 0,
     "skip": 0,
     "error": 2,
-    "pipeline": 0
+    "pipeline": 0,
+    "errorBailouts": [
+      {
+        "category": "Todo",
+        "reason": "Support value blocks (conditional, logical, optional chaining, etc) within a try/catch statement"
+      },
+      {
+        "category": "Todo",
+        "reason": "(BuildHIR::lowerStatement) Handle TryStatement with a finalizer ('finally') clause"
+      }
+    ],
+    "skipReasons": [],
+    "pipelineErrors": []
   },
   "src/components/DevPreview/useDevPreviewLoadLifecycle.ts": {
     "success": 0,
     "skip": 0,
     "error": 1,
-    "pipeline": 0
+    "pipeline": 0,
+    "errorBailouts": [
+      {
+        "category": "Todo",
+        "reason": "Support value blocks (conditional, logical, optional chaining, etc) within a try/catch statement"
+      }
+    ],
+    "skipReasons": [],
+    "pipelineErrors": []
   },
   "src/components/Diagnostics/DiagnosticsActions.tsx": {
     "success": 4,
     "skip": 0,
     "error": 0,
-    "pipeline": 0
+    "pipeline": 0,
+    "errorBailouts": [],
+    "skipReasons": [],
+    "pipelineErrors": []
   },
   "src/components/Diagnostics/DiagnosticsDock.tsx": {
     "success": 1,
     "skip": 0,
     "error": 1,
-    "pipeline": 0
+    "pipeline": 0,
+    "errorBailouts": [
+      {
+        "category": "Todo",
+        "reason": "Support value blocks (conditional, logical, optional chaining, etc) within a try/catch statement"
+      }
+    ],
+    "skipReasons": [],
+    "pipelineErrors": []
   },
   "src/components/Diagnostics/EventsContent.tsx": {
     "success": 0,
     "skip": 1,
     "error": 0,
-    "pipeline": 0
+    "pipeline": 0,
+    "errorBailouts": [],
+    "skipReasons": ["Skipped due to '[object Object]' directive."],
+    "pipelineErrors": []
   },
   "src/components/Diagnostics/LogsContent.tsx": {
-    "success": 1,
+    "success": 2,
     "skip": 0,
     "error": 0,
-    "pipeline": 0
+    "pipeline": 0,
+    "errorBailouts": [],
+    "skipReasons": [],
+    "pipelineErrors": []
   },
   "src/components/Diagnostics/ProblemsContent.tsx": {
     "success": 2,
     "skip": 0,
     "error": 0,
-    "pipeline": 0
+    "pipeline": 0,
+    "errorBailouts": [],
+    "skipReasons": [],
+    "pipelineErrors": []
   },
   "src/components/Diagnostics/TelemetryContent.tsx": {
     "success": 4,
     "skip": 0,
     "error": 0,
-    "pipeline": 0
+    "pipeline": 0,
+    "errorBailouts": [],
+    "skipReasons": [],
+    "pipelineErrors": []
   },
   "src/components/DragDrop/DndProvider.tsx": {
     "success": 4,
     "skip": 0,
     "error": 1,
-    "pipeline": 0
+    "pipeline": 0,
+    "errorBailouts": [
+      {
+        "category": "Todo",
+        "reason": "(BuildHIR::lowerExpression) Handle UpdateExpression to variables captured within lambdas."
+      }
+    ],
+    "skipReasons": [],
+    "pipelineErrors": []
   },
   "src/components/DragDrop/DockPlaceholder.tsx": {
     "success": 2,
     "skip": 0,
     "error": 0,
-    "pipeline": 0
+    "pipeline": 0,
+    "errorBailouts": [],
+    "skipReasons": [],
+    "pipelineErrors": []
   },
   "src/components/DragDrop/DragHandleContext.tsx": {
     "success": 2,
     "skip": 0,
     "error": 0,
-    "pipeline": 0
+    "pipeline": 0,
+    "errorBailouts": [],
+    "skipReasons": [],
+    "pipelineErrors": []
   },
   "src/components/DragDrop/GridPlaceholder.tsx": {
     "success": 2,
     "skip": 0,
     "error": 0,
-    "pipeline": 0
+    "pipeline": 0,
+    "errorBailouts": [],
+    "skipReasons": [],
+    "pipelineErrors": []
   },
   "src/components/DragDrop/PlaceholderContent.tsx": {
     "success": 5,
     "skip": 0,
     "error": 0,
-    "pipeline": 0
+    "pipeline": 0,
+    "errorBailouts": [],
+    "skipReasons": [],
+    "pipelineErrors": []
   },
   "src/components/DragDrop/SortableDockItem.tsx": {
     "success": 1,
     "skip": 0,
     "error": 0,
-    "pipeline": 0
+    "pipeline": 0,
+    "errorBailouts": [],
+    "skipReasons": [],
+    "pipelineErrors": []
   },
   "src/components/DragDrop/SortableTerminal.tsx": {
     "success": 1,
     "skip": 0,
     "error": 0,
-    "pipeline": 0
+    "pipeline": 0,
+    "errorBailouts": [],
+    "skipReasons": [],
+    "pipelineErrors": []
   },
   "src/components/DragDrop/SortableWorktreeCard.tsx": {
     "success": 1,
     "skip": 0,
     "error": 0,
-    "pipeline": 0
+    "pipeline": 0,
+    "errorBailouts": [],
+    "skipReasons": [],
+    "pipelineErrors": []
   },
   "src/components/DragDrop/SortableWorktreeTerminal.tsx": {
-    "success": 1,
+    "success": 0,
     "skip": 0,
-    "error": 0,
-    "pipeline": 0
+    "error": 1,
+    "pipeline": 0,
+    "errorBailouts": [
+      {
+        "category": "Refs",
+        "reason": "Cannot access refs during render"
+      }
+    ],
+    "skipReasons": [],
+    "pipelineErrors": []
   },
   "src/components/DragDrop/TerminalDragPreview.tsx": {
     "success": 1,
     "skip": 0,
     "error": 0,
-    "pipeline": 0
+    "pipeline": 0,
+    "errorBailouts": [],
+    "skipReasons": [],
+    "pipelineErrors": []
   },
   "src/components/DragDrop/WorktreeDragPreview.tsx": {
     "success": 1,
     "skip": 0,
     "error": 0,
-    "pipeline": 0
+    "pipeline": 0,
+    "errorBailouts": [],
+    "skipReasons": [],
+    "pipelineErrors": []
   },
   "src/components/ErrorBoundary/ErrorBoundary.tsx": {
     "success": 1,
     "skip": 0,
     "error": 0,
-    "pipeline": 0
+    "pipeline": 0,
+    "errorBailouts": [],
+    "skipReasons": [],
+    "pipelineErrors": []
   },
   "src/components/ErrorBoundary/ErrorFallback.tsx": {
     "success": 1,
     "skip": 0,
     "error": 0,
-    "pipeline": 0
+    "pipeline": 0,
+    "errorBailouts": [],
+    "skipReasons": [],
+    "pipelineErrors": []
   },
   "src/components/Errors/ErrorBanner.tsx": {
     "success": 1,
     "skip": 0,
     "error": 0,
-    "pipeline": 0
+    "pipeline": 0,
+    "errorBailouts": [],
+    "skipReasons": [],
+    "pipelineErrors": []
   },
   "src/components/EventInspector/EventDetail.tsx": {
     "success": 2,
     "skip": 0,
     "error": 0,
-    "pipeline": 0
+    "pipeline": 0,
+    "errorBailouts": [],
+    "skipReasons": [],
+    "pipelineErrors": []
   },
   "src/components/EventInspector/EventFilters.tsx": {
     "success": 1,
     "skip": 0,
     "error": 0,
-    "pipeline": 0
+    "pipeline": 0,
+    "errorBailouts": [],
+    "skipReasons": [],
+    "pipelineErrors": []
   },
   "src/components/EventInspector/EventTimeline.tsx": {
-    "success": 1,
+    "success": 2,
     "skip": 0,
     "error": 0,
-    "pipeline": 0
+    "pipeline": 0,
+    "errorBailouts": [],
+    "skipReasons": [],
+    "pipelineErrors": []
   },
   "src/components/FileViewer/CodeViewer.tsx": {
     "success": 0,
     "skip": 0,
     "error": 1,
-    "pipeline": 0
+    "pipeline": 0,
+    "errorBailouts": [
+      {
+        "category": "Todo",
+        "reason": "Support value blocks (conditional, logical, optional chaining, etc) within a try/catch statement"
+      }
+    ],
+    "skipReasons": [],
+    "pipelineErrors": []
   },
   "src/components/FileViewer/FileViewerModal.tsx": {
     "success": 1,
     "skip": 0,
     "error": 0,
-    "pipeline": 0
+    "pipeline": 0,
+    "errorBailouts": [],
+    "skipReasons": [],
+    "pipelineErrors": []
   },
   "src/components/FileViewer/FileViewerModalHost.tsx": {
     "success": 1,
     "skip": 0,
     "error": 0,
-    "pipeline": 0
+    "pipeline": 0,
+    "errorBailouts": [],
+    "skipReasons": [],
+    "pipelineErrors": []
   },
   "src/components/FileViewer/PlanFileViewer.tsx": {
     "success": 1,
     "skip": 0,
     "error": 0,
-    "pipeline": 0
+    "pipeline": 0,
+    "errorBailouts": [],
+    "skipReasons": [],
+    "pipelineErrors": []
   },
   "src/components/Fleet/FleetArmingRibbon.tsx": {
     "success": 0,
     "skip": 0,
     "error": 1,
-    "pipeline": 0
+    "pipeline": 0,
+    "errorBailouts": [
+      {
+        "category": "Todo",
+        "reason": "(BuildHIR::lowerStatement) Handle TryStatement without a catch clause"
+      }
+    ],
+    "skipReasons": [],
+    "pipelineErrors": []
   },
   "src/components/Fleet/FleetCountChip.tsx": {
     "success": 1,
     "skip": 0,
     "error": 0,
-    "pipeline": 0
+    "pipeline": 0,
+    "errorBailouts": [],
+    "skipReasons": [],
+    "pipelineErrors": []
   },
   "src/components/Fleet/FleetDraftingPill.tsx": {
     "success": 2,
     "skip": 0,
     "error": 0,
-    "pipeline": 0
+    "pipeline": 0,
+    "errorBailouts": [],
+    "skipReasons": [],
+    "pipelineErrors": []
   },
   "src/components/Fleet/FleetPickerContent.tsx": {
     "success": 8,
     "skip": 0,
     "error": 0,
-    "pipeline": 0
+    "pipeline": 0,
+    "errorBailouts": [],
+    "skipReasons": [],
+    "pipelineErrors": []
   },
   "src/components/Fleet/FleetPickerPalette.tsx": {
     "success": 1,
     "skip": 0,
     "error": 0,
-    "pipeline": 0
+    "pipeline": 0,
+    "errorBailouts": [],
+    "skipReasons": [],
+    "pipelineErrors": []
   },
   "src/components/Fleet/FleetWorktreeDots.tsx": {
     "success": 1,
     "skip": 0,
     "error": 0,
-    "pipeline": 0
+    "pipeline": 0,
+    "errorBailouts": [],
+    "skipReasons": [],
+    "pipelineErrors": []
   },
   "src/components/Fleet/SaveFleetForm.tsx": {
     "success": 1,
     "skip": 0,
     "error": 0,
-    "pipeline": 0
+    "pipeline": 0,
+    "errorBailouts": [],
+    "skipReasons": [],
+    "pipelineErrors": []
   },
   "src/components/Fleet/SavedFleetRow.tsx": {
     "success": 1,
     "skip": 0,
     "error": 0,
-    "pipeline": 0
+    "pipeline": 0,
+    "errorBailouts": [],
+    "skipReasons": [],
+    "pipelineErrors": []
   },
   "src/components/Fleet/SavedFleetsSection.tsx": {
     "success": 1,
     "skip": 0,
     "error": 0,
-    "pipeline": 0
+    "pipeline": 0,
+    "errorBailouts": [],
+    "skipReasons": [],
+    "pipelineErrors": []
   },
   "src/components/Fleet/useFleetEscapeChords.ts": {
     "success": 1,
     "skip": 0,
     "error": 0,
-    "pipeline": 0
+    "pipeline": 0,
+    "errorBailouts": [],
+    "skipReasons": [],
+    "pipelineErrors": []
   },
   "src/components/Fleet/useFleetRibbonFlashes.ts": {
     "success": 1,
     "skip": 0,
     "error": 0,
-    "pipeline": 0
+    "pipeline": 0,
+    "errorBailouts": [],
+    "skipReasons": [],
+    "pipelineErrors": []
   },
   "src/components/Fleet/useFleetWorktreeScope.ts": {
     "success": 1,
     "skip": 0,
     "error": 0,
-    "pipeline": 0
+    "pipeline": 0,
+    "errorBailouts": [],
+    "skipReasons": [],
+    "pipelineErrors": []
   },
   "src/components/GitHub/BulkActionBar.tsx": {
     "success": 1,
     "skip": 0,
     "error": 0,
-    "pipeline": 0
+    "pipeline": 0,
+    "errorBailouts": [],
+    "skipReasons": [],
+    "pipelineErrors": []
   },
   "src/components/GitHub/BulkCreateWorktreeDialog.tsx": {
     "success": 0,
     "skip": 0,
     "error": 6,
-    "pipeline": 0
+    "pipeline": 0,
+    "errorBailouts": [
+      {
+        "category": "Todo",
+        "reason": "(BuildHIR::lowerStatement) Support ThrowStatement inside of try/catch"
+      },
+      {
+        "category": "Todo",
+        "reason": "(BuildHIR::lowerStatement) Support ThrowStatement inside of try/catch"
+      },
+      {
+        "category": "Todo",
+        "reason": "(BuildHIR::lowerStatement) Support ThrowStatement inside of try/catch"
+      },
+      {
+        "category": "Todo",
+        "reason": "(BuildHIR::lowerStatement) Support ThrowStatement inside of try/catch"
+      },
+      {
+        "category": "Todo",
+        "reason": "(BuildHIR::lowerStatement) Handle TryStatement without a catch clause"
+      },
+      {
+        "category": "Todo",
+        "reason": "(BuildHIR::lowerStatement) Handle TryStatement without a catch clause"
+      }
+    ],
+    "skipReasons": [],
+    "pipelineErrors": []
   },
   "src/components/GitHub/CommitList.tsx": {
     "success": 0,
     "skip": 0,
     "error": 2,
-    "pipeline": 0
+    "pipeline": 0,
+    "errorBailouts": [
+      {
+        "category": "Todo",
+        "reason": "(BuildHIR::lowerStatement) Handle TryStatement with a finalizer ('finally') clause"
+      },
+      {
+        "category": "Todo",
+        "reason": "(BuildHIR::lowerStatement) Support ThrowStatement inside of try/catch"
+      }
+    ],
+    "skipReasons": [],
+    "pipelineErrors": []
   },
   "src/components/GitHub/CommitListItem.tsx": {
     "success": 1,
     "skip": 0,
     "error": 0,
-    "pipeline": 0
+    "pipeline": 0,
+    "errorBailouts": [],
+    "skipReasons": [],
+    "pipelineErrors": []
   },
   "src/components/GitHub/GitHubDropdownSkeletons.tsx": {
     "success": 3,
     "skip": 0,
     "error": 0,
-    "pipeline": 0
+    "pipeline": 0,
+    "errorBailouts": [],
+    "skipReasons": [],
+    "pipelineErrors": []
   },
   "src/components/GitHub/GitHubListItem.tsx": {
     "success": 1,
     "skip": 0,
     "error": 0,
-    "pipeline": 0
+    "pipeline": 0,
+    "errorBailouts": [],
+    "skipReasons": [],
+    "pipelineErrors": []
   },
   "src/components/GitHub/GitHubResourceList.tsx": {
     "success": 2,
     "skip": 0,
     "error": 0,
-    "pipeline": 0
+    "pipeline": 0,
+    "errorBailouts": [],
+    "skipReasons": [],
+    "pipelineErrors": []
   },
   "src/components/GitHub/IssueSelector.tsx": {
     "success": 1,
     "skip": 0,
     "error": 0,
-    "pipeline": 0
+    "pipeline": 0,
+    "errorBailouts": [],
+    "skipReasons": [],
+    "pipelineErrors": []
   },
   "src/components/GitHub/useGitHubResourceListSWR.ts": {
     "success": 0,
     "skip": 0,
     "error": 2,
-    "pipeline": 0
+    "pipeline": 0,
+    "errorBailouts": [
+      {
+        "category": "Todo",
+        "reason": "(BuildHIR::lowerStatement) Handle TryStatement without a catch clause"
+      },
+      {
+        "category": "Todo",
+        "reason": "(BuildHIR::lowerStatement) Handle TryStatement without a catch clause"
+      }
+    ],
+    "skipReasons": [],
+    "pipelineErrors": []
   },
   "src/components/HelpPanel/HelpIntroBanner.tsx": {
     "success": 1,
     "skip": 0,
     "error": 0,
-    "pipeline": 0
+    "pipeline": 0,
+    "errorBailouts": [],
+    "skipReasons": [],
+    "pipelineErrors": []
   },
   "src/components/HelpPanel/HelpPanel.tsx": {
     "success": 0,
     "skip": 0,
-    "error": 2,
-    "pipeline": 0
+    "error": 3,
+    "pipeline": 0,
+    "errorBailouts": [
+      {
+        "category": "Todo",
+        "reason": "(BuildHIR::lowerStatement) Handle TryStatement without a catch clause"
+      },
+      {
+        "category": "Todo",
+        "reason": "(BuildHIR::lowerStatement) Handle TryStatement with a finalizer ('finally') clause"
+      },
+      {
+        "category": "Todo",
+        "reason": "(BuildHIR::lowerStatement) Handle TryStatement with a finalizer ('finally') clause"
+      }
+    ],
+    "skipReasons": [],
+    "pipelineErrors": []
   },
   "src/components/KeyboardShortcuts/SettingsShortcutCapture.tsx": {
     "success": 0,
     "skip": 0,
     "error": 5,
-    "pipeline": 0
+    "pipeline": 0,
+    "errorBailouts": [
+      {
+        "category": "Todo",
+        "reason": "(BuildHIR::lowerStatement) Handle TryStatement with a finalizer ('finally') clause"
+      },
+      {
+        "category": "Todo",
+        "reason": "(BuildHIR::lowerStatement) Support ThrowStatement inside of try/catch"
+      },
+      {
+        "category": "Todo",
+        "reason": "(BuildHIR::lowerStatement) Support ThrowStatement inside of try/catch"
+      },
+      {
+        "category": "Todo",
+        "reason": "(BuildHIR::lowerStatement) Support ThrowStatement inside of try/catch"
+      },
+      {
+        "category": "Todo",
+        "reason": "(BuildHIR::lowerStatement) Support ThrowStatement inside of try/catch"
+      }
+    ],
+    "skipReasons": [],
+    "pipelineErrors": []
   },
   "src/components/KeyboardShortcuts/ShortcutReferenceDialog.tsx": {
     "success": 1,
     "skip": 0,
     "error": 0,
-    "pipeline": 0
+    "pipeline": 0,
+    "errorBailouts": [],
+    "skipReasons": [],
+    "pipelineErrors": []
   },
   "src/components/Layout/AgentButton.tsx": {
     "success": 2,
     "skip": 0,
     "error": 0,
-    "pipeline": 0
+    "pipeline": 0,
+    "errorBailouts": [],
+    "skipReasons": [],
+    "pipelineErrors": []
   },
   "src/components/Layout/AgentTrayButton.tsx": {
     "success": 4,
     "skip": 0,
     "error": 0,
-    "pipeline": 0
+    "pipeline": 0,
+    "errorBailouts": [],
+    "skipReasons": [],
+    "pipelineErrors": []
   },
   "src/components/Layout/AppLayout.tsx": {
     "success": 1,
     "skip": 0,
     "error": 0,
-    "pipeline": 0
+    "pipeline": 0,
+    "errorBailouts": [],
+    "skipReasons": [],
+    "pipelineErrors": []
   },
   "src/components/Layout/BackgroundContainer.tsx": {
     "success": 2,
     "skip": 0,
     "error": 0,
-    "pipeline": 0
+    "pipeline": 0,
+    "errorBailouts": [],
+    "skipReasons": [],
+    "pipelineErrors": []
   },
   "src/components/Layout/ChordIndicator.tsx": {
     "success": 1,
     "skip": 0,
     "error": 0,
-    "pipeline": 0
+    "pipeline": 0,
+    "errorBailouts": [],
+    "skipReasons": [],
+    "pipelineErrors": []
   },
   "src/components/Layout/ContentDock.tsx": {
     "success": 1,
     "skip": 0,
     "error": 0,
-    "pipeline": 0
+    "pipeline": 0,
+    "errorBailouts": [],
+    "skipReasons": [],
+    "pipelineErrors": []
   },
   "src/components/Layout/DockLaunchButton.tsx": {
     "success": 1,
     "skip": 0,
     "error": 0,
-    "pipeline": 0
+    "pipeline": 0,
+    "errorBailouts": [],
+    "skipReasons": [],
+    "pipelineErrors": []
   },
   "src/components/Layout/DockLaunchMenuItems.tsx": {
     "success": 1,
     "skip": 0,
     "error": 0,
-    "pipeline": 0
+    "pipeline": 0,
+    "errorBailouts": [],
+    "skipReasons": [],
+    "pipelineErrors": []
   },
   "src/components/Layout/DockPanelOffscreenContainer.tsx": {
     "success": 1,
     "skip": 0,
     "error": 1,
-    "pipeline": 0
+    "pipeline": 0,
+    "errorBailouts": [
+      {
+        "category": "Todo",
+        "reason": "Support value blocks (conditional, logical, optional chaining, etc) within a try/catch statement"
+      }
+    ],
+    "skipReasons": [],
+    "pipelineErrors": []
   },
   "src/components/Layout/DockedTabGroup.tsx": {
     "success": 0,
     "skip": 0,
     "error": 1,
-    "pipeline": 0
+    "pipeline": 0,
+    "errorBailouts": [
+      {
+        "category": "Todo",
+        "reason": "Support value blocks (conditional, logical, optional chaining, etc) within a try/catch statement"
+      }
+    ],
+    "skipReasons": [],
+    "pipelineErrors": []
   },
   "src/components/Layout/DockedTerminalItem.tsx": {
     "success": 0,
     "skip": 0,
     "error": 1,
-    "pipeline": 0
+    "pipeline": 0,
+    "errorBailouts": [
+      {
+        "category": "Todo",
+        "reason": "Support value blocks (conditional, logical, optional chaining, etc) within a try/catch statement"
+      }
+    ],
+    "skipReasons": [],
+    "pipelineErrors": []
   },
   "src/components/Layout/FreshnessUtils.tsx": {
     "success": 1,
     "skip": 0,
     "error": 0,
-    "pipeline": 0
+    "pipeline": 0,
+    "errorBailouts": [],
+    "skipReasons": [],
+    "pipelineErrors": []
   },
   "src/components/Layout/GitHubStatPill.tsx": {
     "success": 1,
     "skip": 0,
     "error": 0,
-    "pipeline": 0
+    "pipeline": 0,
+    "errorBailouts": [],
+    "skipReasons": [],
+    "pipelineErrors": []
   },
   "src/components/Layout/GitHubStatsToolbarButton.tsx": {
     "success": 0,
     "skip": 0,
     "error": 1,
-    "pipeline": 0
+    "pipeline": 0,
+    "errorBailouts": [
+      {
+        "category": "Todo",
+        "reason": "(BuildHIR::lowerExpression) Expected Identifier, got TSAsExpression key in ObjectExpression"
+      }
+    ],
+    "skipReasons": [],
+    "pipelineErrors": []
   },
   "src/components/Layout/GitHubStatusIndicator.tsx": {
     "success": 1,
     "skip": 0,
     "error": 0,
-    "pipeline": 0
+    "pipeline": 0,
+    "errorBailouts": [],
+    "skipReasons": [],
+    "pipelineErrors": []
   },
   "src/components/Layout/NotificationCenterToolbarButton.tsx": {
     "success": 1,
     "skip": 0,
     "error": 0,
-    "pipeline": 0
+    "pipeline": 0,
+    "errorBailouts": [],
+    "skipReasons": [],
+    "pipelineErrors": []
   },
   "src/components/Layout/RateLimitDetails.tsx": {
     "success": 2,
     "skip": 0,
     "error": 0,
-    "pipeline": 0
+    "pipeline": 0,
+    "errorBailouts": [],
+    "skipReasons": [],
+    "pipelineErrors": []
   },
   "src/components/Layout/Sidebar.tsx": {
     "success": 1,
     "skip": 0,
     "error": 0,
-    "pipeline": 0
+    "pipeline": 0,
+    "errorBailouts": [],
+    "skipReasons": [],
+    "pipelineErrors": []
   },
   "src/components/Layout/StatusContainer.tsx": {
     "success": 1,
     "skip": 0,
     "error": 0,
-    "pipeline": 0
+    "pipeline": 0,
+    "errorBailouts": [],
+    "skipReasons": [],
+    "pipelineErrors": []
   },
   "src/components/Layout/TerminalDockRegion.tsx": {
     "success": 1,
     "skip": 0,
     "error": 0,
-    "pipeline": 0
+    "pipeline": 0,
+    "errorBailouts": [],
+    "skipReasons": [],
+    "pipelineErrors": []
   },
   "src/components/Layout/Toolbar.tsx": {
     "success": 1,
     "skip": 0,
     "error": 1,
-    "pipeline": 0
+    "pipeline": 0,
+    "errorBailouts": [
+      {
+        "category": "Todo",
+        "reason": "(BuildHIR::lowerStatement) Handle TryStatement without a catch clause"
+      }
+    ],
+    "skipReasons": [],
+    "pipelineErrors": []
   },
   "src/components/Layout/ToolbarAssistantButton.tsx": {
     "success": 1,
     "skip": 0,
     "error": 0,
-    "pipeline": 0
+    "pipeline": 0,
+    "errorBailouts": [],
+    "skipReasons": [],
+    "pipelineErrors": []
   },
   "src/components/Layout/ToolbarLauncherButton.tsx": {
     "success": 1,
     "skip": 0,
     "error": 0,
-    "pipeline": 0
+    "pipeline": 0,
+    "errorBailouts": [],
+    "skipReasons": [],
+    "pipelineErrors": []
   },
   "src/components/Layout/ToolbarPortalButton.tsx": {
     "success": 1,
     "skip": 0,
     "error": 0,
-    "pipeline": 0
+    "pipeline": 0,
+    "errorBailouts": [],
+    "skipReasons": [],
+    "pipelineErrors": []
   },
   "src/components/Layout/ToolbarProblemsButton.tsx": {
     "success": 1,
     "skip": 0,
     "error": 0,
-    "pipeline": 0
+    "pipeline": 0,
+    "errorBailouts": [],
+    "skipReasons": [],
+    "pipelineErrors": []
   },
   "src/components/Layout/ToolbarSettingsButton.tsx": {
     "success": 1,
     "skip": 0,
     "error": 0,
-    "pipeline": 0
+    "pipeline": 0,
+    "errorBailouts": [],
+    "skipReasons": [],
+    "pipelineErrors": []
   },
   "src/components/Layout/TrashBinItem.tsx": {
     "success": 1,
     "skip": 0,
     "error": 0,
-    "pipeline": 0
+    "pipeline": 0,
+    "errorBailouts": [],
+    "skipReasons": [],
+    "pipelineErrors": []
   },
   "src/components/Layout/TrashContainer.tsx": {
     "success": 1,
     "skip": 0,
     "error": 0,
-    "pipeline": 0
+    "pipeline": 0,
+    "errorBailouts": [],
+    "skipReasons": [],
+    "pipelineErrors": []
   },
   "src/components/Layout/TrashGroupItem.tsx": {
     "success": 1,
     "skip": 0,
     "error": 0,
-    "pipeline": 0
+    "pipeline": 0,
+    "errorBailouts": [],
+    "skipReasons": [],
+    "pipelineErrors": []
   },
   "src/components/Layout/VoiceRecordingToolbarButton.tsx": {
     "success": 1,
     "skip": 0,
     "error": 0,
-    "pipeline": 0
+    "pipeline": 0,
+    "errorBailouts": [],
+    "skipReasons": [],
+    "pipelineErrors": []
   },
   "src/components/Layout/WaitingContainer.tsx": {
     "success": 1,
     "skip": 0,
     "error": 0,
-    "pipeline": 0
+    "pipeline": 0,
+    "errorBailouts": [],
+    "skipReasons": [],
+    "pipelineErrors": []
   },
   "src/components/Layout/useDockBlockedState.ts": {
     "success": 1,
     "skip": 0,
     "error": 0,
-    "pipeline": 0
+    "pipeline": 0,
+    "errorBailouts": [],
+    "skipReasons": [],
+    "pipelineErrors": []
   },
   "src/components/Layout/useOverflowBadgeSeverity.ts": {
     "success": 1,
     "skip": 0,
     "error": 0,
-    "pipeline": 0
+    "pipeline": 0,
+    "errorBailouts": [],
+    "skipReasons": [],
+    "pipelineErrors": []
   },
   "src/components/LogLevelPalette/LogLevelPalette.tsx": {
     "success": 1,
     "skip": 0,
     "error": 0,
-    "pipeline": 0
+    "pipeline": 0,
+    "errorBailouts": [],
+    "skipReasons": [],
+    "pipelineErrors": []
   },
   "src/components/Logs/LogEntry.tsx": {
     "success": 1,
     "skip": 0,
     "error": 0,
-    "pipeline": 0
+    "pipeline": 0,
+    "errorBailouts": [],
+    "skipReasons": [],
+    "pipelineErrors": []
   },
   "src/components/Logs/LogFilters.tsx": {
     "success": 1,
     "skip": 0,
     "error": 0,
-    "pipeline": 0
+    "pipeline": 0,
+    "errorBailouts": [],
+    "skipReasons": [],
+    "pipelineErrors": []
   },
   "src/components/McpConfirmDialog.tsx": {
     "success": 1,
     "skip": 0,
     "error": 0,
-    "pipeline": 0
+    "pipeline": 0,
+    "errorBailouts": [],
+    "skipReasons": [],
+    "pipelineErrors": []
   },
   "src/components/Notifications/NotificationCenter.tsx": {
-    "success": 2,
+    "success": 6,
     "skip": 0,
     "error": 0,
-    "pipeline": 0
+    "pipeline": 0,
+    "errorBailouts": [],
+    "skipReasons": [],
+    "pipelineErrors": []
   },
   "src/components/Notifications/NotificationCenterEntry.tsx": {
     "success": 1,
     "skip": 0,
     "error": 0,
-    "pipeline": 0
+    "pipeline": 0,
+    "errorBailouts": [],
+    "skipReasons": [],
+    "pipelineErrors": []
   },
   "src/components/Onboarding/CelebrationConfetti.tsx": {
     "success": 1,
     "skip": 0,
     "error": 0,
-    "pipeline": 0
+    "pipeline": 0,
+    "errorBailouts": [],
+    "skipReasons": [],
+    "pipelineErrors": []
   },
   "src/components/Onboarding/GettingStartedChecklist.tsx": {
     "success": 1,
     "skip": 0,
     "error": 0,
-    "pipeline": 0
+    "pipeline": 0,
+    "errorBailouts": [],
+    "skipReasons": [],
+    "pipelineErrors": []
   },
   "src/components/Onboarding/OnboardingFlow.tsx": {
     "success": 1,
     "skip": 0,
     "error": 0,
-    "pipeline": 0
+    "pipeline": 0,
+    "errorBailouts": [],
+    "skipReasons": [],
+    "pipelineErrors": []
   },
   "src/components/Panel/ContentPanel.tsx": {
-    "success": 1,
+    "success": 2,
     "skip": 0,
-    "error": 1,
-    "pipeline": 0
+    "error": 0,
+    "pipeline": 0,
+    "errorBailouts": [],
+    "skipReasons": [],
+    "pipelineErrors": []
   },
   "src/components/Panel/PanelHeader.tsx": {
     "success": 1,
     "skip": 0,
     "error": 0,
-    "pipeline": 0
+    "pipeline": 0,
+    "errorBailouts": [],
+    "skipReasons": [],
+    "pipelineErrors": []
   },
   "src/components/Panel/PanelTabList.tsx": {
     "success": 1,
     "skip": 0,
     "error": 0,
-    "pipeline": 0
+    "pipeline": 0,
+    "errorBailouts": [],
+    "skipReasons": [],
+    "pipelineErrors": []
   },
   "src/components/Panel/PanelTransitionOverlay.tsx": {
     "success": 2,
     "skip": 0,
     "error": 0,
-    "pipeline": 0
+    "pipeline": 0,
+    "errorBailouts": [],
+    "skipReasons": [],
+    "pipelineErrors": []
   },
   "src/components/Panel/PluginMissingPanel.tsx": {
     "success": 1,
     "skip": 0,
     "error": 0,
-    "pipeline": 0
+    "pipeline": 0,
+    "errorBailouts": [],
+    "skipReasons": [],
+    "pipelineErrors": []
   },
   "src/components/Panel/SortableTabButton.tsx": {
     "success": 1,
     "skip": 0,
     "error": 0,
-    "pipeline": 0
+    "pipeline": 0,
+    "errorBailouts": [],
+    "skipReasons": [],
+    "pipelineErrors": []
   },
   "src/components/Panel/TabButton.tsx": {
     "success": 1,
     "skip": 0,
     "error": 0,
-    "pipeline": 0
+    "pipeline": 0,
+    "errorBailouts": [],
+    "skipReasons": [],
+    "pipelineErrors": []
   },
   "src/components/Panel/TitleEditingContext.tsx": {
     "success": 3,
     "skip": 0,
     "error": 0,
-    "pipeline": 0
+    "pipeline": 0,
+    "errorBailouts": [],
+    "skipReasons": [],
+    "pipelineErrors": []
   },
   "src/components/PanelPalette/PanelKindIcon.tsx": {
     "success": 1,
     "skip": 0,
     "error": 0,
-    "pipeline": 0
+    "pipeline": 0,
+    "errorBailouts": [],
+    "skipReasons": [],
+    "pipelineErrors": []
   },
   "src/components/PanelPalette/PanelPalette.tsx": {
     "success": 1,
     "skip": 0,
     "error": 0,
-    "pipeline": 0
+    "pipeline": 0,
+    "errorBailouts": [],
+    "skipReasons": [],
+    "pipelineErrors": []
   },
   "src/components/Portal/PortalDock.tsx": {
     "success": 0,
     "skip": 0,
     "error": 1,
-    "pipeline": 0
+    "pipeline": 0,
+    "errorBailouts": [
+      {
+        "category": "Todo",
+        "reason": "(BuildHIR::lowerStatement) Handle TryStatement with a finalizer ('finally') clause"
+      }
+    ],
+    "skipReasons": [],
+    "pipelineErrors": []
   },
   "src/components/Portal/PortalIcon.tsx": {
     "success": 1,
     "skip": 0,
     "error": 0,
-    "pipeline": 0
+    "pipeline": 0,
+    "errorBailouts": [],
+    "skipReasons": [],
+    "pipelineErrors": []
   },
   "src/components/Portal/PortalLaunchpad.tsx": {
-    "success": 1,
+    "success": 0,
     "skip": 0,
-    "error": 0,
-    "pipeline": 0
+    "error": 1,
+    "pipeline": 0,
+    "errorBailouts": [
+      {
+        "category": "Todo",
+        "reason": "Support value blocks (conditional, logical, optional chaining, etc) within a try/catch statement"
+      }
+    ],
+    "skipReasons": [],
+    "pipelineErrors": []
   },
   "src/components/Portal/PortalToolbar.tsx": {
     "success": 2,
     "skip": 0,
     "error": 0,
-    "pipeline": 0
+    "pipeline": 0,
+    "errorBailouts": [],
+    "skipReasons": [],
+    "pipelineErrors": []
   },
   "src/components/Portal/PortalVisibilityController.tsx": {
     "success": 0,
     "skip": 0,
     "error": 1,
-    "pipeline": 0
+    "pipeline": 0,
+    "errorBailouts": [
+      {
+        "category": "Todo",
+        "reason": "(BuildHIR::lowerStatement) Handle TryStatement with a finalizer ('finally') clause"
+      }
+    ],
+    "skipReasons": [],
+    "pipelineErrors": []
   },
   "src/components/Project/AutomationTab.tsx": {
     "success": 1,
     "skip": 0,
     "error": 0,
-    "pipeline": 0
+    "pipeline": 0,
+    "errorBailouts": [],
+    "skipReasons": [],
+    "pipelineErrors": []
   },
   "src/components/Project/CloneRepoDialog.tsx": {
     "success": 0,
     "skip": 0,
     "error": 1,
-    "pipeline": 0
+    "pipeline": 0,
+    "errorBailouts": [
+      {
+        "category": "Todo",
+        "reason": "(BuildHIR::lowerStatement) Handle TryStatement with a finalizer ('finally') clause"
+      }
+    ],
+    "skipReasons": [],
+    "pipelineErrors": []
   },
   "src/components/Project/ContextTab.tsx": {
     "success": 0,
     "skip": 0,
     "error": 1,
-    "pipeline": 0
+    "pipeline": 0,
+    "errorBailouts": [
+      {
+        "category": "Todo",
+        "reason": "(BuildHIR::lowerStatement) Handle TryStatement with a finalizer ('finally') clause"
+      }
+    ],
+    "skipReasons": [],
+    "pipelineErrors": []
   },
   "src/components/Project/CreateProjectFolderDialog.tsx": {
     "success": 0,
     "skip": 0,
     "error": 1,
-    "pipeline": 0
+    "pipeline": 0,
+    "errorBailouts": [
+      {
+        "category": "Todo",
+        "reason": "(BuildHIR::lowerStatement) Handle TryStatement with a finalizer ('finally') clause"
+      }
+    ],
+    "skipReasons": [],
+    "pipelineErrors": []
   },
   "src/components/Project/EnvironmentVariablesEditor.tsx": {
     "success": 0,
     "skip": 0,
     "error": 1,
-    "pipeline": 0
+    "pipeline": 0,
+    "errorBailouts": [
+      {
+        "category": "Todo",
+        "reason": "(BuildHIR::lowerStatement) Handle TryStatement with a finalizer ('finally') clause"
+      }
+    ],
+    "skipReasons": [],
+    "pipelineErrors": []
   },
   "src/components/Project/GeneralTab.tsx": {
     "success": 0,
     "skip": 0,
     "error": 2,
-    "pipeline": 0
+    "pipeline": 0,
+    "errorBailouts": [
+      {
+        "category": "Todo",
+        "reason": "(BuildHIR::lowerStatement) Handle TryStatement with a finalizer ('finally') clause"
+      },
+      {
+        "category": "Todo",
+        "reason": "(BuildHIR::lowerStatement) Handle TryStatement with a finalizer ('finally') clause"
+      }
+    ],
+    "skipReasons": [],
+    "pipelineErrors": []
   },
   "src/components/Project/GitHubTab.tsx": {
     "success": 1,
     "skip": 0,
     "error": 0,
-    "pipeline": 0
+    "pipeline": 0,
+    "errorBailouts": [],
+    "skipReasons": [],
+    "pipelineErrors": []
   },
   "src/components/Project/GitInitDialog.tsx": {
     "success": 0,
     "skip": 0,
     "error": 1,
-    "pipeline": 0
+    "pipeline": 0,
+    "errorBailouts": [
+      {
+        "category": "Todo",
+        "reason": "(BuildHIR::lowerStatement) Handle TryStatement with a finalizer ('finally') clause"
+      }
+    ],
+    "skipReasons": [],
+    "pipelineErrors": []
   },
   "src/components/Project/ProjectMruSwitcherOverlay.tsx": {
     "success": 1,
     "skip": 0,
     "error": 0,
-    "pipeline": 0
+    "pipeline": 0,
+    "errorBailouts": [],
+    "skipReasons": [],
+    "pipelineErrors": []
   },
   "src/components/Project/ProjectNotificationsTab.tsx": {
     "success": 2,
     "skip": 0,
     "error": 0,
-    "pipeline": 0
+    "pipeline": 0,
+    "errorBailouts": [],
+    "skipReasons": [],
+    "pipelineErrors": []
   },
   "src/components/Project/ProjectResourceBadge.tsx": {
     "success": 4,
     "skip": 0,
     "error": 1,
-    "pipeline": 0
+    "pipeline": 0,
+    "errorBailouts": [
+      {
+        "category": "Todo",
+        "reason": "Support value blocks (conditional, logical, optional chaining, etc) within a try/catch statement"
+      }
+    ],
+    "skipReasons": [],
+    "pipelineErrors": []
   },
   "src/components/Project/ProjectSwitcher.tsx": {
     "success": 1,
     "skip": 0,
     "error": 0,
-    "pipeline": 0
+    "pipeline": 0,
+    "errorBailouts": [],
+    "skipReasons": [],
+    "pipelineErrors": []
   },
   "src/components/Project/ProjectSwitcherPalette.tsx": {
-    "success": 8,
+    "success": 9,
     "skip": 0,
     "error": 0,
-    "pipeline": 0
+    "pipeline": 0,
+    "errorBailouts": [],
+    "skipReasons": [],
+    "pipelineErrors": []
   },
   "src/components/Project/QuickRun.tsx": {
     "success": 0,
     "skip": 0,
     "error": 1,
-    "pipeline": 0
+    "pipeline": 0,
+    "errorBailouts": [
+      {
+        "category": "Todo",
+        "reason": "(BuildHIR::lowerStatement) Handle TryStatement with a finalizer ('finally') clause"
+      }
+    ],
+    "skipReasons": [],
+    "pipelineErrors": []
   },
   "src/components/Project/RecipesTab.tsx": {
     "success": 1,
     "skip": 0,
     "error": 0,
-    "pipeline": 0
+    "pipeline": 0,
+    "errorBailouts": [],
+    "skipReasons": [],
+    "pipelineErrors": []
   },
   "src/components/Project/RunningTaskList.tsx": {
     "success": 3,
     "skip": 0,
     "error": 0,
-    "pipeline": 0
+    "pipeline": 0,
+    "errorBailouts": [],
+    "skipReasons": [],
+    "pipelineErrors": []
   },
   "src/components/Project/WelcomeScreen.tsx": {
     "success": 5,
     "skip": 0,
     "error": 1,
-    "pipeline": 0
+    "pipeline": 0,
+    "errorBailouts": [
+      {
+        "category": "Todo",
+        "reason": "(BuildHIR::lowerStatement) Handle TryStatement without a catch clause"
+      }
+    ],
+    "skipReasons": [],
+    "pipelineErrors": []
   },
   "src/components/Pulse/ProjectPulseCard.tsx": {
     "success": 8,
     "skip": 0,
     "error": 0,
-    "pipeline": 0
+    "pipeline": 0,
+    "errorBailouts": [],
+    "skipReasons": [],
+    "pipelineErrors": []
   },
   "src/components/Pulse/PulseHeatmap.tsx": {
-    "success": 1,
+    "success": 0,
     "skip": 0,
-    "error": 0,
-    "pipeline": 0
+    "error": 1,
+    "pipeline": 0,
+    "errorBailouts": [
+      {
+        "category": "Refs",
+        "reason": "Cannot access refs during render"
+      }
+    ],
+    "skipReasons": [],
+    "pipelineErrors": []
   },
   "src/components/Pulse/PulseSummary.tsx": {
     "success": 2,
     "skip": 0,
     "error": 0,
-    "pipeline": 0
+    "pipeline": 0,
+    "errorBailouts": [],
+    "skipReasons": [],
+    "pipelineErrors": []
   },
   "src/components/Pulse/StreakFlame.tsx": {
     "success": 1,
     "skip": 0,
     "error": 0,
-    "pipeline": 0
+    "pipeline": 0,
+    "errorBailouts": [],
+    "skipReasons": [],
+    "pipelineErrors": []
   },
   "src/components/QuickSwitcher/QuickSwitcher.tsx": {
     "success": 1,
     "skip": 0,
     "error": 0,
-    "pipeline": 0
+    "pipeline": 0,
+    "errorBailouts": [],
+    "skipReasons": [],
+    "pipelineErrors": []
   },
   "src/components/QuickSwitcher/QuickSwitcherItem.tsx": {
     "success": 1,
     "skip": 0,
     "error": 0,
-    "pipeline": 0
+    "pipeline": 0,
+    "errorBailouts": [],
+    "skipReasons": [],
+    "pipelineErrors": []
   },
   "src/components/Recovery/CloudSyncBanner.tsx": {
     "success": 1,
     "skip": 0,
     "error": 0,
-    "pipeline": 0
+    "pipeline": 0,
+    "errorBailouts": [],
+    "skipReasons": [],
+    "pipelineErrors": []
   },
   "src/components/Recovery/CrashRecoveryDialog.tsx": {
     "success": 2,
     "skip": 0,
     "error": 1,
-    "pipeline": 0
+    "pipeline": 0,
+    "errorBailouts": [
+      {
+        "category": "Todo",
+        "reason": "(BuildHIR::lowerStatement) Handle TryStatement without a catch clause"
+      }
+    ],
+    "skipReasons": [],
+    "pipelineErrors": []
   },
   "src/components/Recovery/GitHubTokenBanner.tsx": {
     "success": 1,
     "skip": 0,
     "error": 0,
-    "pipeline": 0
+    "pipeline": 0,
+    "errorBailouts": [],
+    "skipReasons": [],
+    "pipelineErrors": []
+  },
+  "src/components/Recovery/HostCrashBanner.tsx": {
+    "success": 1,
+    "skip": 0,
+    "error": 0,
+    "pipeline": 0,
+    "errorBailouts": [],
+    "skipReasons": [],
+    "pipelineErrors": []
   },
   "src/components/Recovery/SafeModeBanner.tsx": {
     "success": 1,
     "skip": 0,
     "error": 0,
-    "pipeline": 0
+    "pipeline": 0,
+    "errorBailouts": [],
+    "skipReasons": [],
+    "pipelineErrors": []
   },
   "src/components/Settings/AddPresetDialog.tsx": {
     "success": 2,
     "skip": 0,
     "error": 0,
-    "pipeline": 0
+    "pipeline": 0,
+    "errorBailouts": [],
+    "skipReasons": [],
+    "pipelineErrors": []
   },
   "src/components/Settings/AgentHelpOutput.tsx": {
     "success": 0,
     "skip": 0,
     "error": 1,
-    "pipeline": 0
+    "pipeline": 0,
+    "errorBailouts": [
+      {
+        "category": "Todo",
+        "reason": "(BuildHIR::lowerStatement) Handle TryStatement with a finalizer ('finally') clause"
+      }
+    ],
+    "skipReasons": [],
+    "pipelineErrors": []
   },
   "src/components/Settings/AgentScopeEditor/AgentScopeEditor.tsx": {
     "success": 1,
     "skip": 0,
     "error": 0,
-    "pipeline": 0
+    "pipeline": 0,
+    "errorBailouts": [],
+    "skipReasons": [],
+    "pipelineErrors": []
   },
   "src/components/Settings/AgentScopeEditor/BehavioralControls.tsx": {
     "success": 1,
     "skip": 0,
     "error": 0,
-    "pipeline": 0
+    "pipeline": 0,
+    "errorBailouts": [],
+    "skipReasons": [],
+    "pipelineErrors": []
   },
   "src/components/Settings/AgentScopeEditor/CustomPresetChrome.tsx": {
     "success": 1,
     "skip": 0,
     "error": 0,
-    "pipeline": 0
+    "pipeline": 0,
+    "errorBailouts": [],
+    "skipReasons": [],
+    "pipelineErrors": []
   },
   "src/components/Settings/AgentScopeEditor/EnvBlock.tsx": {
     "success": 2,
     "skip": 0,
     "error": 0,
-    "pipeline": 0
+    "pipeline": 0,
+    "errorBailouts": [],
+    "skipReasons": [],
+    "pipelineErrors": []
   },
   "src/components/Settings/AgentScopeEditor/FallbackChainEditor.tsx": {
     "success": 1,
     "skip": 0,
     "error": 0,
-    "pipeline": 0
+    "pipeline": 0,
+    "errorBailouts": [],
+    "skipReasons": [],
+    "pipelineErrors": []
   },
   "src/components/Settings/AgentScopeEditor/ReadOnlyDetail.tsx": {
     "success": 1,
     "skip": 0,
     "error": 0,
-    "pipeline": 0
+    "pipeline": 0,
+    "errorBailouts": [],
+    "skipReasons": [],
+    "pipelineErrors": []
   },
   "src/components/Settings/AgentScopeEditor/ScopeBanner.tsx": {
     "success": 1,
     "skip": 0,
     "error": 0,
-    "pipeline": 0
+    "pipeline": 0,
+    "errorBailouts": [],
+    "skipReasons": [],
+    "pipelineErrors": []
   },
   "src/components/Settings/AgentScopeEditor/useAgentScope.ts": {
     "success": 0,
     "skip": 0,
     "error": 1,
-    "pipeline": 0
+    "pipeline": 0,
+    "errorBailouts": [
+      {
+        "category": "Todo",
+        "reason": "Support value blocks (conditional, logical, optional chaining, etc) within a try/catch statement"
+      }
+    ],
+    "skipReasons": [],
+    "pipelineErrors": []
   },
   "src/components/Settings/AgentSelectorDropdown.tsx": {
     "success": 1,
     "skip": 0,
     "error": 0,
-    "pipeline": 0
+    "pipeline": 0,
+    "errorBailouts": [],
+    "skipReasons": [],
+    "pipelineErrors": []
   },
   "src/components/Settings/AgentSettings.tsx": {
     "success": 0,
     "skip": 0,
     "error": 1,
-    "pipeline": 0
+    "pipeline": 0,
+    "errorBailouts": [
+      {
+        "category": "Todo",
+        "reason": "(BuildHIR::lowerStatement) Support ThrowStatement inside of try/catch"
+      }
+    ],
+    "skipReasons": [],
+    "pipelineErrors": []
   },
   "src/components/Settings/AppThemePicker.tsx": {
     "success": 1,
     "skip": 0,
     "error": 1,
-    "pipeline": 0
+    "pipeline": 0,
+    "errorBailouts": [
+      {
+        "category": "Todo",
+        "reason": "Support value blocks (conditional, logical, optional chaining, etc) within a try/catch statement"
+      }
+    ],
+    "skipReasons": [],
+    "pipelineErrors": []
   },
   "src/components/Settings/ColorSchemePicker.tsx": {
     "success": 2,
     "skip": 0,
     "error": 0,
-    "pipeline": 0
+    "pipeline": 0,
+    "errorBailouts": [],
+    "skipReasons": [],
+    "pipelineErrors": []
   },
   "src/components/Settings/ColorVisionPicker.tsx": {
     "success": 2,
     "skip": 0,
     "error": 0,
-    "pipeline": 0
+    "pipeline": 0,
+    "errorBailouts": [],
+    "skipReasons": [],
+    "pipelineErrors": []
   },
   "src/components/Settings/CommandOverridesTab.tsx": {
     "success": 1,
     "skip": 0,
     "error": 1,
-    "pipeline": 0
+    "pipeline": 0,
+    "errorBailouts": [
+      {
+        "category": "Todo",
+        "reason": "(BuildHIR::lowerStatement) Handle TryStatement with a finalizer ('finally') clause"
+      }
+    ],
+    "skipReasons": [],
+    "pipelineErrors": []
   },
   "src/components/Settings/DaintreeAssistantSettingsTab.tsx": {
-    "success": 1,
+    "success": 0,
     "skip": 0,
-    "error": 0,
-    "pipeline": 0
+    "error": 1,
+    "pipeline": 0,
+    "errorBailouts": [
+      {
+        "category": "Todo",
+        "reason": "(BuildHIR::lowerStatement) Handle TryStatement with a finalizer ('finally') clause"
+      }
+    ],
+    "skipReasons": [],
+    "pipelineErrors": []
   },
   "src/components/Settings/DiagnosticsReviewDialog.tsx": {
     "success": 1,
     "skip": 0,
     "error": 0,
-    "pipeline": 0
+    "pipeline": 0,
+    "errorBailouts": [],
+    "skipReasons": [],
+    "pipelineErrors": []
   },
   "src/components/Settings/DockDensityPicker.tsx": {
     "success": 1,
     "skip": 0,
     "error": 0,
-    "pipeline": 0
+    "pipeline": 0,
+    "errorBailouts": [],
+    "skipReasons": [],
+    "pipelineErrors": []
   },
   "src/components/Settings/EditorIntegrationTab.tsx": {
     "success": 0,
     "skip": 0,
     "error": 3,
-    "pipeline": 0
+    "pipeline": 0,
+    "errorBailouts": [
+      {
+        "category": "Todo",
+        "reason": "(BuildHIR::lowerStatement) Handle TryStatement with a finalizer ('finally') clause"
+      },
+      {
+        "category": "Todo",
+        "reason": "(BuildHIR::lowerStatement) Handle TryStatement with a finalizer ('finally') clause"
+      },
+      {
+        "category": "Todo",
+        "reason": "(BuildHIR::lowerStatement) Handle TryStatement with a finalizer ('finally') clause"
+      }
+    ],
+    "skipReasons": [],
+    "pipelineErrors": []
   },
   "src/components/Settings/EnvVarEditor.tsx": {
     "success": 2,
     "skip": 0,
     "error": 0,
-    "pipeline": 0
+    "pipeline": 0,
+    "errorBailouts": [],
+    "skipReasons": [],
+    "pipelineErrors": []
   },
   "src/components/Settings/EnvironmentSettingsTab.tsx": {
     "success": 0,
     "skip": 0,
     "error": 1,
-    "pipeline": 0
+    "pipeline": 0,
+    "errorBailouts": [
+      {
+        "category": "Todo",
+        "reason": "(BuildHIR::lowerStatement) Handle TryStatement with a finalizer ('finally') clause"
+      }
+    ],
+    "skipReasons": [],
+    "pipelineErrors": []
   },
   "src/components/Settings/GeneralTab.tsx": {
     "success": 0,
     "skip": 0,
     "error": 9,
-    "pipeline": 0
+    "pipeline": 0,
+    "errorBailouts": [
+      {
+        "category": "Todo",
+        "reason": "(BuildHIR::lowerStatement) Handle TryStatement with a finalizer ('finally') clause"
+      },
+      {
+        "category": "Todo",
+        "reason": "(BuildHIR::lowerStatement) Handle TryStatement with a finalizer ('finally') clause"
+      },
+      {
+        "category": "Todo",
+        "reason": "(BuildHIR::lowerStatement) Support ThrowStatement inside of try/catch"
+      },
+      {
+        "category": "Todo",
+        "reason": "(BuildHIR::lowerStatement) Handle TryStatement with a finalizer ('finally') clause"
+      },
+      {
+        "category": "Todo",
+        "reason": "(BuildHIR::lowerStatement) Support ThrowStatement inside of try/catch"
+      },
+      {
+        "category": "Todo",
+        "reason": "(BuildHIR::lowerStatement) Handle TryStatement with a finalizer ('finally') clause"
+      },
+      {
+        "category": "Todo",
+        "reason": "(BuildHIR::lowerStatement) Support ThrowStatement inside of try/catch"
+      },
+      {
+        "category": "Todo",
+        "reason": "(BuildHIR::lowerStatement) Handle TryStatement with a finalizer ('finally') clause"
+      },
+      {
+        "category": "Todo",
+        "reason": "(BuildHIR::lowerStatement) Support ThrowStatement inside of try/catch"
+      }
+    ],
+    "skipReasons": [],
+    "pipelineErrors": []
   },
   "src/components/Settings/GitHubSettingsTab.tsx": {
     "success": 0,
     "skip": 0,
     "error": 7,
-    "pipeline": 0
+    "pipeline": 0,
+    "errorBailouts": [
+      {
+        "category": "Todo",
+        "reason": "(BuildHIR::lowerStatement) Handle TryStatement with a finalizer ('finally') clause"
+      },
+      {
+        "category": "Todo",
+        "reason": "(BuildHIR::lowerStatement) Support ThrowStatement inside of try/catch"
+      },
+      {
+        "category": "Todo",
+        "reason": "(BuildHIR::lowerStatement) Support ThrowStatement inside of try/catch"
+      },
+      {
+        "category": "Todo",
+        "reason": "(BuildHIR::lowerStatement) Support ThrowStatement inside of try/catch"
+      },
+      {
+        "category": "Todo",
+        "reason": "(BuildHIR::lowerStatement) Support ThrowStatement inside of try/catch"
+      },
+      {
+        "category": "Todo",
+        "reason": "(BuildHIR::lowerStatement) Handle TryStatement with a finalizer ('finally') clause"
+      },
+      {
+        "category": "Todo",
+        "reason": "(BuildHIR::lowerStatement) Support ThrowStatement inside of try/catch"
+      }
+    ],
+    "skipReasons": [],
+    "pipelineErrors": []
   },
   "src/components/Settings/ImageViewerTab.tsx": {
     "success": 0,
     "skip": 0,
     "error": 1,
-    "pipeline": 0
+    "pipeline": 0,
+    "errorBailouts": [
+      {
+        "category": "Todo",
+        "reason": "(BuildHIR::lowerStatement) Handle TryStatement with a finalizer ('finally') clause"
+      }
+    ],
+    "skipReasons": [],
+    "pipelineErrors": []
   },
   "src/components/Settings/ImportEnvDialog.tsx": {
     "success": 2,
     "skip": 0,
     "error": 0,
-    "pipeline": 0
+    "pipeline": 0,
+    "errorBailouts": [],
+    "skipReasons": [],
+    "pipelineErrors": []
   },
   "src/components/Settings/IntegrationsTab.tsx": {
     "success": 1,
     "skip": 0,
     "error": 0,
-    "pipeline": 0
+    "pipeline": 0,
+    "errorBailouts": [],
+    "skipReasons": [],
+    "pipelineErrors": []
   },
   "src/components/Settings/KeybindingProfileActions.tsx": {
     "success": 0,
     "skip": 0,
     "error": 2,
-    "pipeline": 0
+    "pipeline": 0,
+    "errorBailouts": [
+      {
+        "category": "Todo",
+        "reason": "(BuildHIR::lowerStatement) Handle TryStatement with a finalizer ('finally') clause"
+      },
+      {
+        "category": "Todo",
+        "reason": "(BuildHIR::lowerStatement) Handle TryStatement with a finalizer ('finally') clause"
+      }
+    ],
+    "skipReasons": [],
+    "pipelineErrors": []
   },
   "src/components/Settings/KeyboardShortcutsTab.tsx": {
     "success": 1,
     "skip": 0,
     "error": 1,
-    "pipeline": 0
+    "pipeline": 0,
+    "errorBailouts": [
+      {
+        "category": "Todo",
+        "reason": "(BuildHIR::lowerStatement) Handle TryStatement without a catch clause"
+      }
+    ],
+    "skipReasons": [],
+    "pipelineErrors": []
   },
   "src/components/Settings/McpServerSettingsTab.tsx": {
     "success": 0,
     "skip": 0,
-    "error": 1,
-    "pipeline": 0
+    "error": 2,
+    "pipeline": 0,
+    "errorBailouts": [
+      {
+        "category": "Todo",
+        "reason": "(BuildHIR::lowerStatement) Handle TryStatement with a finalizer ('finally') clause"
+      },
+      {
+        "category": "Todo",
+        "reason": "(BuildHIR::lowerStatement) Handle TryStatement with a finalizer ('finally') clause"
+      }
+    ],
+    "skipReasons": [],
+    "pipelineErrors": []
   },
   "src/components/Settings/NotificationSettingsTab.tsx": {
-    "success": 2,
+    "success": 3,
     "skip": 0,
     "error": 0,
-    "pipeline": 0
+    "pipeline": 0,
+    "errorBailouts": [],
+    "skipReasons": [],
+    "pipelineErrors": []
   },
   "src/components/Settings/PortalSettingsTab.tsx": {
     "success": 3,
     "skip": 0,
     "error": 0,
-    "pipeline": 0
+    "pipeline": 0,
+    "errorBailouts": [],
+    "skipReasons": [],
+    "pipelineErrors": []
   },
   "src/components/Settings/PresetColorPicker.tsx": {
     "success": 1,
     "skip": 0,
     "error": 0,
-    "pipeline": 0
+    "pipeline": 0,
+    "errorBailouts": [],
+    "skipReasons": [],
+    "pipelineErrors": []
   },
   "src/components/Settings/PresetSelector.tsx": {
     "success": 3,
     "skip": 0,
     "error": 0,
-    "pipeline": 0
+    "pipeline": 0,
+    "errorBailouts": [],
+    "skipReasons": [],
+    "pipelineErrors": []
   },
   "src/components/Settings/PrivacyDataTab.tsx": {
     "success": 0,
     "skip": 0,
     "error": 1,
-    "pipeline": 0
+    "pipeline": 0,
+    "errorBailouts": [
+      {
+        "category": "Todo",
+        "reason": "(BuildHIR::lowerStatement) Handle TryStatement with a finalizer ('finally') clause"
+      }
+    ],
+    "skipReasons": [],
+    "pipelineErrors": []
   },
   "src/components/Settings/ResourceEnvironmentsSection.tsx": {
     "success": 3,
     "skip": 0,
     "error": 0,
-    "pipeline": 0
+    "pipeline": 0,
+    "errorBailouts": [],
+    "skipReasons": [],
+    "pipelineErrors": []
   },
   "src/components/Settings/SettingsCheckbox.tsx": {
     "success": 1,
     "skip": 0,
     "error": 0,
-    "pipeline": 0
+    "pipeline": 0,
+    "errorBailouts": [],
+    "skipReasons": [],
+    "pipelineErrors": []
   },
   "src/components/Settings/SettingsChoicebox.tsx": {
     "success": 0,
     "skip": 0,
     "error": 1,
-    "pipeline": 0
+    "pipeline": 0,
+    "errorBailouts": [
+      {
+        "category": "Todo",
+        "reason": "Unexpected terminal kind `ternary` for logical test block"
+      }
+    ],
+    "skipReasons": [],
+    "pipelineErrors": []
   },
   "src/components/Settings/SettingsDialog.tsx": {
-    "success": 6,
+    "success": 9,
     "skip": 0,
-    "error": 1,
-    "pipeline": 0
+    "error": 0,
+    "pipeline": 0,
+    "errorBailouts": [],
+    "skipReasons": [],
+    "pipelineErrors": []
+  },
+  "src/components/Settings/SettingsFlushRegistry.tsx": {
+    "success": 2,
+    "skip": 0,
+    "error": 0,
+    "pipeline": 0,
+    "errorBailouts": [],
+    "skipReasons": [],
+    "pipelineErrors": []
   },
   "src/components/Settings/SettingsInput.tsx": {
     "success": 0,
     "skip": 0,
     "error": 1,
-    "pipeline": 0
+    "pipeline": 0,
+    "errorBailouts": [
+      {
+        "category": "Todo",
+        "reason": "Unexpected terminal kind `ternary` for logical test block"
+      }
+    ],
+    "skipReasons": [],
+    "pipelineErrors": []
   },
   "src/components/Settings/SettingsNumberInput.tsx": {
     "success": 1,
     "skip": 0,
     "error": 0,
-    "pipeline": 0
+    "pipeline": 0,
+    "errorBailouts": [],
+    "skipReasons": [],
+    "pipelineErrors": []
   },
   "src/components/Settings/SettingsSection.tsx": {
     "success": 1,
     "skip": 0,
     "error": 0,
-    "pipeline": 0
+    "pipeline": 0,
+    "errorBailouts": [],
+    "skipReasons": [],
+    "pipelineErrors": []
   },
   "src/components/Settings/SettingsSelect.tsx": {
     "success": 0,
     "skip": 0,
     "error": 1,
-    "pipeline": 0
+    "pipeline": 0,
+    "errorBailouts": [
+      {
+        "category": "Todo",
+        "reason": "Unexpected terminal kind `ternary` for logical test block"
+      }
+    ],
+    "skipReasons": [],
+    "pipelineErrors": []
   },
   "src/components/Settings/SettingsSubtabBar.tsx": {
     "success": 1,
     "skip": 0,
     "error": 0,
-    "pipeline": 0
+    "pipeline": 0,
+    "errorBailouts": [],
+    "skipReasons": [],
+    "pipelineErrors": []
   },
   "src/components/Settings/SettingsSwitch.tsx": {
     "success": 1,
     "skip": 0,
     "error": 0,
-    "pipeline": 0
+    "pipeline": 0,
+    "errorBailouts": [],
+    "skipReasons": [],
+    "pipelineErrors": []
   },
   "src/components/Settings/SettingsSwitchCard.tsx": {
     "success": 1,
     "skip": 0,
     "error": 0,
-    "pipeline": 0
+    "pipeline": 0,
+    "errorBailouts": [],
+    "skipReasons": [],
+    "pipelineErrors": []
   },
   "src/components/Settings/SettingsTextarea.tsx": {
     "success": 0,
     "skip": 0,
     "error": 1,
-    "pipeline": 0
+    "pipeline": 0,
+    "errorBailouts": [
+      {
+        "category": "Todo",
+        "reason": "Unexpected terminal kind `ternary` for logical test block"
+      }
+    ],
+    "skipReasons": [],
+    "pipelineErrors": []
   },
   "src/components/Settings/SettingsValidationRegistry.tsx": {
     "success": 2,
     "skip": 0,
     "error": 0,
-    "pipeline": 0
+    "pipeline": 0,
+    "errorBailouts": [],
+    "skipReasons": [],
+    "pipelineErrors": []
   },
   "src/components/Settings/TerminalAppearanceTab.tsx": {
     "success": 0,
     "skip": 0,
     "error": 2,
-    "pipeline": 0
+    "pipeline": 0,
+    "errorBailouts": [
+      {
+        "category": "Todo",
+        "reason": "(BuildHIR::lowerStatement) Support ThrowStatement inside of try/catch"
+      },
+      {
+        "category": "Todo",
+        "reason": "(BuildHIR::lowerStatement) Support ThrowStatement inside of try/catch"
+      }
+    ],
+    "skipReasons": [],
+    "pipelineErrors": []
   },
   "src/components/Settings/TerminalSettingsTab.tsx": {
     "success": 0,
     "skip": 0,
     "error": 6,
-    "pipeline": 0
+    "pipeline": 0,
+    "errorBailouts": [
+      {
+        "category": "Todo",
+        "reason": "(BuildHIR::lowerStatement) Support ThrowStatement inside of try/catch"
+      },
+      {
+        "category": "Todo",
+        "reason": "(BuildHIR::lowerStatement) Support ThrowStatement inside of try/catch"
+      },
+      {
+        "category": "Todo",
+        "reason": "(BuildHIR::lowerStatement) Support ThrowStatement inside of try/catch"
+      },
+      {
+        "category": "Todo",
+        "reason": "(BuildHIR::lowerStatement) Support ThrowStatement inside of try/catch"
+      },
+      {
+        "category": "Todo",
+        "reason": "(BuildHIR::lowerStatement) Support ThrowStatement inside of try/catch"
+      },
+      {
+        "category": "Todo",
+        "reason": "(BuildHIR::lowerStatement) Support ThrowStatement inside of try/catch"
+      }
+    ],
+    "skipReasons": [],
+    "pipelineErrors": []
   },
   "src/components/Settings/ToolbarSettingsTab.tsx": {
     "success": 2,
     "skip": 0,
     "error": 0,
-    "pipeline": 0
+    "pipeline": 0,
+    "errorBailouts": [],
+    "skipReasons": [],
+    "pipelineErrors": []
   },
   "src/components/Settings/TroubleshootingTab.tsx": {
     "success": 1,
     "skip": 0,
     "error": 6,
-    "pipeline": 0
+    "pipeline": 0,
+    "errorBailouts": [
+      {
+        "category": "Todo",
+        "reason": "(BuildHIR::lowerStatement) Handle TryStatement with a finalizer ('finally') clause"
+      },
+      {
+        "category": "Todo",
+        "reason": "(BuildHIR::lowerStatement) Handle TryStatement with a finalizer ('finally') clause"
+      },
+      {
+        "category": "Todo",
+        "reason": "(BuildHIR::lowerStatement) Handle TryStatement with a finalizer ('finally') clause"
+      },
+      {
+        "category": "Todo",
+        "reason": "(BuildHIR::lowerStatement) Support ThrowStatement inside of try/catch"
+      },
+      {
+        "category": "Todo",
+        "reason": "(BuildHIR::lowerStatement) Handle TryStatement with a finalizer ('finally') clause"
+      },
+      {
+        "category": "Todo",
+        "reason": "(BuildHIR::lowerStatement) Support ThrowStatement inside of try/catch"
+      }
+    ],
+    "skipReasons": [],
+    "pipelineErrors": []
   },
   "src/components/Settings/VoiceInputSettingsTab.tsx": {
     "success": 5,
     "skip": 0,
     "error": 2,
-    "pipeline": 0
+    "pipeline": 0,
+    "errorBailouts": [
+      {
+        "category": "Todo",
+        "reason": "(BuildHIR::lowerStatement) Handle TryStatement with a finalizer ('finally') clause"
+      },
+      {
+        "category": "Todo",
+        "reason": "Support value blocks (conditional, logical, optional chaining, etc) within a try/catch statement"
+      }
+    ],
+    "skipReasons": [],
+    "pipelineErrors": []
   },
   "src/components/Settings/WorktreeSettingsTab.tsx": {
     "success": 0,
     "skip": 0,
     "error": 2,
-    "pipeline": 0
+    "pipeline": 0,
+    "errorBailouts": [
+      {
+        "category": "Todo",
+        "reason": "(BuildHIR::lowerStatement) Handle TryStatement with a finalizer ('finally') clause"
+      },
+      {
+        "category": "Todo",
+        "reason": "(BuildHIR::lowerStatement) Support ThrowStatement inside of try/catch"
+      }
+    ],
+    "skipReasons": [],
+    "pipelineErrors": []
   },
   "src/components/Settings/settingsSearchUtils.tsx": {
     "success": 1,
     "skip": 0,
     "error": 0,
-    "pipeline": 0
+    "pipeline": 0,
+    "errorBailouts": [],
+    "skipReasons": [],
+    "pipelineErrors": []
   },
   "src/components/Setup/AgentCliStep.tsx": {
     "success": 0,
     "skip": 0,
     "error": 1,
-    "pipeline": 0
+    "pipeline": 0,
+    "errorBailouts": [
+      {
+        "category": "Todo",
+        "reason": "(BuildHIR::lowerStatement) Handle TryStatement with a finalizer ('finally') clause"
+      }
+    ],
+    "skipReasons": [],
+    "pipelineErrors": []
   },
   "src/components/Setup/AgentSetupWizard.tsx": {
     "success": 3,
     "skip": 0,
     "error": 2,
-    "pipeline": 0
+    "pipeline": 0,
+    "errorBailouts": [
+      {
+        "category": "Todo",
+        "reason": "(BuildHIR::lowerStatement) Handle TryStatement without a catch clause"
+      },
+      {
+        "category": "Todo",
+        "reason": "(BuildHIR::lowerStatement) Handle TryStatement without a catch clause"
+      }
+    ],
+    "skipReasons": [],
+    "pipelineErrors": []
   },
-  "src/components/Setup/InstallBlock.tsx": {
-    "success": 2,
+  "src/components/Setup/CopyableCommand.tsx": {
+    "success": 1,
     "skip": 0,
     "error": 0,
-    "pipeline": 0
+    "pipeline": 0,
+    "errorBailouts": [],
+    "skipReasons": [],
+    "pipelineErrors": []
+  },
+  "src/components/Setup/InstallBlock.tsx": {
+    "success": 1,
+    "skip": 0,
+    "error": 0,
+    "pipeline": 0,
+    "errorBailouts": [],
+    "skipReasons": [],
+    "pipelineErrors": []
   },
   "src/components/Setup/SystemRequirementsSection.tsx": {
     "success": 1,
     "skip": 0,
     "error": 0,
-    "pipeline": 0
+    "pipeline": 0,
+    "errorBailouts": [],
+    "skipReasons": [],
+    "pipelineErrors": []
   },
   "src/components/Setup/SystemToolsStep.tsx": {
     "success": 2,
     "skip": 0,
     "error": 0,
-    "pipeline": 0
+    "pipeline": 0,
+    "errorBailouts": [],
+    "skipReasons": [],
+    "pipelineErrors": []
   },
   "src/components/Setup/useAgentSetupPoll.ts": {
     "success": 1,
     "skip": 0,
     "error": 0,
-    "pipeline": 0
+    "pipeline": 0,
+    "errorBailouts": [],
+    "skipReasons": [],
+    "pipelineErrors": []
   },
   "src/components/Setup/useSystemHealthCheck.ts": {
     "success": 0,
     "skip": 0,
     "error": 1,
-    "pipeline": 0
+    "pipeline": 0,
+    "errorBailouts": [
+      {
+        "category": "Todo",
+        "reason": "(BuildHIR::lowerStatement) Handle TryStatement with a finalizer ('finally') clause"
+      }
+    ],
+    "skipReasons": [],
+    "pipelineErrors": []
   },
   "src/components/Sidebar/E2EFaultInjector.tsx": {
     "success": 1,
     "skip": 0,
     "error": 0,
-    "pipeline": 0
+    "pipeline": 0,
+    "errorBailouts": [],
+    "skipReasons": [],
+    "pipelineErrors": []
   },
   "src/components/Sidebar/SidebarContent.tsx": {
-    "success": 1,
+    "success": 0,
     "skip": 0,
-    "error": 0,
-    "pipeline": 0
+    "error": 2,
+    "pipeline": 0,
+    "errorBailouts": [
+      {
+        "category": "Todo",
+        "reason": "(BuildHIR::lowerExpression) Handle UpdateExpression to variables captured within lambdas."
+      },
+      {
+        "category": "Todo",
+        "reason": "(BuildHIR::lowerExpression) Handle UpdateExpression to variables captured within lambdas."
+      }
+    ],
+    "skipReasons": [],
+    "pipelineErrors": []
   },
   "src/components/Sidebar/SidebarWorktreeRow.tsx": {
     "success": 1,
     "skip": 0,
     "error": 0,
-    "pipeline": 0
+    "pipeline": 0,
+    "errorBailouts": [],
+    "skipReasons": [],
+    "pipelineErrors": []
   },
   "src/components/Sidebar/StaticWorktreeRow.tsx": {
     "success": 1,
     "skip": 0,
     "error": 0,
-    "pipeline": 0
+    "pipeline": 0,
+    "errorBailouts": [],
+    "skipReasons": [],
+    "pipelineErrors": []
   },
   "src/components/Sidebar/useRecipeDialogState.ts": {
     "success": 1,
     "skip": 0,
     "error": 0,
-    "pipeline": 0
+    "pipeline": 0,
+    "errorBailouts": [],
+    "skipReasons": [],
+    "pipelineErrors": []
   },
   "src/components/Sidebar/useScrollIndicator.ts": {
     "success": 1,
     "skip": 0,
     "error": 0,
-    "pipeline": 0
+    "pipeline": 0,
+    "errorBailouts": [],
+    "skipReasons": [],
+    "pipelineErrors": []
   },
   "src/components/Sidebar/useWorktreeGridRovingFocus.ts": {
     "success": 1,
     "skip": 0,
     "error": 0,
-    "pipeline": 0
+    "pipeline": 0,
+    "errorBailouts": [],
+    "skipReasons": [],
+    "pipelineErrors": []
   },
   "src/components/Terminal/ArtifactOverlay.tsx": {
     "success": 2,
     "skip": 0,
     "error": 0,
-    "pipeline": 0
+    "pipeline": 0,
+    "errorBailouts": [],
+    "skipReasons": [],
+    "pipelineErrors": []
   },
   "src/components/Terminal/AutocompleteMenu.tsx": {
     "success": 1,
     "skip": 0,
     "error": 0,
-    "pipeline": 0
+    "pipeline": 0,
+    "errorBailouts": [],
+    "skipReasons": [],
+    "pipelineErrors": []
   },
   "src/components/Terminal/ContentGrid.tsx": {
     "success": 1,
     "skip": 0,
     "error": 0,
-    "pipeline": 0
+    "pipeline": 0,
+    "errorBailouts": [],
+    "skipReasons": [],
+    "pipelineErrors": []
   },
   "src/components/Terminal/ContentGridDefault.tsx": {
     "success": 1,
     "skip": 0,
     "error": 0,
-    "pipeline": 0
+    "pipeline": 0,
+    "errorBailouts": [],
+    "skipReasons": [],
+    "pipelineErrors": []
   },
   "src/components/Terminal/ContentGridEmptyState.tsx": {
     "success": 1,
     "skip": 0,
     "error": 0,
-    "pipeline": 0
+    "pipeline": 0,
+    "errorBailouts": [],
+    "skipReasons": [],
+    "pipelineErrors": []
   },
   "src/components/Terminal/ContentGridFleetScope.tsx": {
     "success": 1,
     "skip": 0,
     "error": 0,
-    "pipeline": 0
+    "pipeline": 0,
+    "errorBailouts": [],
+    "skipReasons": [],
+    "pipelineErrors": []
   },
   "src/components/Terminal/ContentGridMaximizedGroup.tsx": {
     "success": 1,
     "skip": 0,
     "error": 0,
-    "pipeline": 0
+    "pipeline": 0,
+    "errorBailouts": [],
+    "skipReasons": [],
+    "pipelineErrors": []
   },
   "src/components/Terminal/ContentGridMaximizedSingle.tsx": {
     "success": 1,
     "skip": 0,
     "error": 0,
-    "pipeline": 0
+    "pipeline": 0,
+    "errorBailouts": [],
+    "skipReasons": [],
+    "pipelineErrors": []
   },
   "src/components/Terminal/ContentGridTwoPaneSplit.tsx": {
     "success": 1,
     "skip": 0,
     "error": 0,
-    "pipeline": 0
+    "pipeline": 0,
+    "errorBailouts": [],
+    "skipReasons": [],
+    "pipelineErrors": []
   },
   "src/components/Terminal/DockedPanel.tsx": {
     "success": 1,
     "skip": 0,
     "error": 0,
-    "pipeline": 0
+    "pipeline": 0,
+    "errorBailouts": [],
+    "skipReasons": [],
+    "pipelineErrors": []
   },
   "src/components/Terminal/GridFullOverlay.tsx": {
     "success": 1,
     "skip": 0,
     "error": 0,
-    "pipeline": 0
+    "pipeline": 0,
+    "errorBailouts": [],
+    "skipReasons": [],
+    "pipelineErrors": []
   },
   "src/components/Terminal/GridNotificationBar.tsx": {
     "success": 1,
     "skip": 0,
     "error": 0,
-    "pipeline": 0
+    "pipeline": 0,
+    "errorBailouts": [],
+    "skipReasons": [],
+    "pipelineErrors": []
   },
   "src/components/Terminal/GridPanel.tsx": {
     "success": 1,
     "skip": 0,
     "error": 0,
-    "pipeline": 0
+    "pipeline": 0,
+    "errorBailouts": [],
+    "skipReasons": [],
+    "pipelineErrors": []
   },
   "src/components/Terminal/GridShell.tsx": {
     "success": 1,
     "skip": 0,
     "error": 0,
-    "pipeline": 0
+    "pipeline": 0,
+    "errorBailouts": [],
+    "skipReasons": [],
+    "pipelineErrors": []
   },
   "src/components/Terminal/GridTabGroup.tsx": {
     "success": 1,
     "skip": 0,
     "error": 0,
-    "pipeline": 0
+    "pipeline": 0,
+    "errorBailouts": [],
+    "skipReasons": [],
+    "pipelineErrors": []
   },
   "src/components/Terminal/HybridInputBar.tsx": {
     "success": 1,
     "skip": 0,
     "error": 0,
-    "pipeline": 0
+    "pipeline": 0,
+    "errorBailouts": [],
+    "skipReasons": [],
+    "pipelineErrors": []
   },
   "src/components/Terminal/InlineStatusBanner.tsx": {
     "success": 1,
     "skip": 0,
     "error": 0,
-    "pipeline": 0
+    "pipeline": 0,
+    "errorBailouts": [],
+    "skipReasons": [],
+    "pipelineErrors": []
   },
   "src/components/Terminal/MissingCliGate.tsx": {
-    "success": 4,
+    "success": 3,
     "skip": 0,
     "error": 0,
-    "pipeline": 0
+    "pipeline": 0,
+    "errorBailouts": [],
+    "skipReasons": [],
+    "pipelineErrors": []
   },
   "src/components/Terminal/PanelLimitConfirmDialog.tsx": {
     "success": 1,
     "skip": 0,
     "error": 0,
-    "pipeline": 0
+    "pipeline": 0,
+    "errorBailouts": [],
+    "skipReasons": [],
+    "pipelineErrors": []
   },
   "src/components/Terminal/PromptHistoryPalette.tsx": {
     "success": 1,
     "skip": 0,
     "error": 0,
-    "pipeline": 0
+    "pipeline": 0,
+    "errorBailouts": [],
+    "skipReasons": [],
+    "pipelineErrors": []
   },
   "src/components/Terminal/RecipeRunner/RecipeRunner.tsx": {
     "success": 1,
     "skip": 0,
     "error": 0,
-    "pipeline": 0
+    "pipeline": 0,
+    "errorBailouts": [],
+    "skipReasons": [],
+    "pipelineErrors": []
   },
   "src/components/Terminal/RecipeRunner/RecipeRunnerEmpty.tsx": {
     "success": 1,
     "skip": 0,
     "error": 0,
-    "pipeline": 0
+    "pipeline": 0,
+    "errorBailouts": [],
+    "skipReasons": [],
+    "pipelineErrors": []
   },
   "src/components/Terminal/RecipeRunner/RecipeRunnerGrid.tsx": {
     "success": 1,
     "skip": 0,
     "error": 0,
-    "pipeline": 0
+    "pipeline": 0,
+    "errorBailouts": [],
+    "skipReasons": [],
+    "pipelineErrors": []
   },
   "src/components/Terminal/RecipeRunner/RecipeRunnerItem.tsx": {
     "success": 2,
     "skip": 0,
     "error": 0,
-    "pipeline": 0
+    "pipeline": 0,
+    "errorBailouts": [],
+    "skipReasons": [],
+    "pipelineErrors": []
   },
   "src/components/Terminal/RecipeRunner/RecipeRunnerList.tsx": {
     "success": 0,
     "skip": 0,
     "error": 1,
-    "pipeline": 0
+    "pipeline": 0,
+    "errorBailouts": [
+      {
+        "category": "Todo",
+        "reason": "(BuildHIR::lowerExpression) Handle UpdateExpression to variables captured within lambdas."
+      }
+    ],
+    "skipReasons": [],
+    "pipelineErrors": []
   },
   "src/components/Terminal/RecipeRunner/useRecipeRunner.ts": {
-    "success": 1,
+    "success": 0,
     "skip": 0,
-    "error": 0,
-    "pipeline": 0
+    "error": 2,
+    "pipeline": 0,
+    "errorBailouts": [
+      {
+        "category": "Todo",
+        "reason": "(BuildHIR::lowerStatement) Handle TryStatement with a finalizer ('finally') clause"
+      },
+      {
+        "category": "Todo",
+        "reason": "(BuildHIR::lowerStatement) Handle TryStatement with a finalizer ('finally') clause"
+      }
+    ],
+    "skipReasons": [],
+    "pipelineErrors": []
   },
   "src/components/Terminal/ReconnectErrorBanner.tsx": {
     "success": 1,
     "skip": 0,
     "error": 0,
-    "pipeline": 0
+    "pipeline": 0,
+    "errorBailouts": [],
+    "skipReasons": [],
+    "pipelineErrors": []
   },
   "src/components/Terminal/SendToAgentPalette.tsx": {
     "success": 2,
     "skip": 0,
     "error": 0,
-    "pipeline": 0
+    "pipeline": 0,
+    "errorBailouts": [],
+    "skipReasons": [],
+    "pipelineErrors": []
   },
   "src/components/Terminal/SpawnErrorBanner.tsx": {
     "success": 1,
     "skip": 0,
     "error": 0,
-    "pipeline": 0
-  },
-  "src/components/Terminal/TerminalCloseConfirmHost.tsx": {
-    "success": 1,
-    "skip": 0,
-    "error": 0,
-    "pipeline": 0
+    "pipeline": 0,
+    "errorBailouts": [],
+    "skipReasons": [],
+    "pipelineErrors": []
   },
   "src/components/Terminal/TerminalContextMenu.tsx": {
     "success": 1,
     "skip": 0,
     "error": 0,
-    "pipeline": 0
+    "pipeline": 0,
+    "errorBailouts": [],
+    "skipReasons": [],
+    "pipelineErrors": []
   },
   "src/components/Terminal/TerminalCountWarning.tsx": {
     "success": 1,
     "skip": 0,
     "error": 0,
-    "pipeline": 0
+    "pipeline": 0,
+    "errorBailouts": [],
+    "skipReasons": [],
+    "pipelineErrors": []
   },
   "src/components/Terminal/TerminalErrorBanner.tsx": {
     "success": 1,
     "skip": 0,
     "error": 0,
-    "pipeline": 0
+    "pipeline": 0,
+    "errorBailouts": [],
+    "skipReasons": [],
+    "pipelineErrors": []
   },
   "src/components/Terminal/TerminalHeaderContent.tsx": {
     "success": 2,
     "skip": 0,
     "error": 0,
-    "pipeline": 0
+    "pipeline": 0,
+    "errorBailouts": [],
+    "skipReasons": [],
+    "pipelineErrors": []
   },
   "src/components/Terminal/TerminalIcon.tsx": {
     "success": 1,
     "skip": 0,
     "error": 0,
-    "pipeline": 0
+    "pipeline": 0,
+    "errorBailouts": [],
+    "skipReasons": [],
+    "pipelineErrors": []
   },
   "src/components/Terminal/TerminalInfoDialog.tsx": {
     "success": 3,
     "skip": 0,
     "error": 2,
-    "pipeline": 0
+    "pipeline": 0,
+    "errorBailouts": [
+      {
+        "category": "Todo",
+        "reason": "(BuildHIR::lowerStatement) Handle TryStatement with a finalizer ('finally') clause"
+      },
+      {
+        "category": "Todo",
+        "reason": "(BuildHIR::lowerStatement) Support ThrowStatement inside of try/catch"
+      }
+    ],
+    "skipReasons": [],
+    "pipelineErrors": []
   },
   "src/components/Terminal/TerminalInfoDialogHost.tsx": {
     "success": 1,
     "skip": 0,
     "error": 0,
-    "pipeline": 0
+    "pipeline": 0,
+    "errorBailouts": [],
+    "skipReasons": [],
+    "pipelineErrors": []
   },
   "src/components/Terminal/TerminalPane.tsx": {
     "success": 1,
     "skip": 0,
     "error": 0,
-    "pipeline": 0
+    "pipeline": 0,
+    "errorBailouts": [],
+    "skipReasons": [],
+    "pipelineErrors": []
   },
   "src/components/Terminal/TerminalResourceSparkline.tsx": {
     "success": 1,
     "skip": 0,
     "error": 0,
-    "pipeline": 0
+    "pipeline": 0,
+    "errorBailouts": [],
+    "skipReasons": [],
+    "pipelineErrors": []
   },
   "src/components/Terminal/TerminalRestartStatusBanner.tsx": {
     "success": 1,
     "skip": 0,
     "error": 0,
-    "pipeline": 0
+    "pipeline": 0,
+    "errorBailouts": [],
+    "skipReasons": [],
+    "pipelineErrors": []
   },
   "src/components/Terminal/TerminalScrollIndicator.tsx": {
     "success": 1,
     "skip": 0,
     "error": 0,
-    "pipeline": 0
+    "pipeline": 0,
+    "errorBailouts": [],
+    "skipReasons": [],
+    "pipelineErrors": []
   },
   "src/components/Terminal/TerminalSearchBar.tsx": {
     "success": 0,
     "skip": 0,
     "error": 1,
-    "pipeline": 0
+    "pipeline": 0,
+    "errorBailouts": [
+      {
+        "category": "Todo",
+        "reason": "Support value blocks (conditional, logical, optional chaining, etc) within a try/catch statement"
+      }
+    ],
+    "skipReasons": [],
+    "pipelineErrors": []
   },
   "src/components/Terminal/TwoPaneSplitDivider.tsx": {
     "success": 1,
     "skip": 0,
     "error": 0,
-    "pipeline": 0
+    "pipeline": 0,
+    "errorBailouts": [],
+    "skipReasons": [],
+    "pipelineErrors": []
   },
   "src/components/Terminal/TwoPaneSplitLayout.tsx": {
     "success": 1,
     "skip": 0,
     "error": 0,
-    "pipeline": 0
+    "pipeline": 0,
+    "errorBailouts": [],
+    "skipReasons": [],
+    "pipelineErrors": []
   },
   "src/components/Terminal/UpdateCwdDialog.tsx": {
     "success": 0,
     "skip": 0,
     "error": 1,
-    "pipeline": 0
+    "pipeline": 0,
+    "errorBailouts": [
+      {
+        "category": "Todo",
+        "reason": "(BuildHIR::lowerStatement) Handle TryStatement with a finalizer ('finally') clause"
+      }
+    ],
+    "skipReasons": [],
+    "pipelineErrors": []
   },
   "src/components/Terminal/VoiceInputButton.tsx": {
     "success": 1,
     "skip": 0,
     "error": 0,
-    "pipeline": 0
+    "pipeline": 0,
+    "errorBailouts": [],
+    "skipReasons": [],
+    "pipelineErrors": []
   },
   "src/components/Terminal/VoiceRecordingAnnouncer.tsx": {
     "success": 1,
     "skip": 0,
     "error": 0,
-    "pipeline": 0
+    "pipeline": 0,
+    "errorBailouts": [],
+    "skipReasons": [],
+    "pipelineErrors": []
   },
   "src/components/Terminal/XtermAdapter.tsx": {
     "success": 1,
     "skip": 0,
     "error": 0,
-    "pipeline": 0
+    "pipeline": 0,
+    "errorBailouts": [],
+    "skipReasons": [],
+    "pipelineErrors": []
   },
   "src/components/Terminal/contentGridTips.tsx": {
     "success": 2,
     "skip": 0,
     "error": 0,
-    "pipeline": 0
+    "pipeline": 0,
+    "errorBailouts": [],
+    "skipReasons": [],
+    "pipelineErrors": []
   },
   "src/components/Terminal/hooks/useAutocompleteApply.ts": {
     "success": 1,
     "skip": 0,
     "error": 0,
-    "pipeline": 0
+    "pipeline": 0,
+    "errorBailouts": [],
+    "skipReasons": [],
+    "pipelineErrors": []
   },
   "src/components/Terminal/hooks/useAutocompleteItems.ts": {
     "success": 1,
     "skip": 0,
     "error": 0,
-    "pipeline": 0
+    "pipeline": 0,
+    "errorBailouts": [],
+    "skipReasons": [],
+    "pipelineErrors": []
   },
   "src/components/Terminal/hooks/useAutocompletePositioning.ts": {
     "success": 1,
     "skip": 0,
     "error": 0,
-    "pipeline": 0
+    "pipeline": 0,
+    "errorBailouts": [],
+    "skipReasons": [],
+    "pipelineErrors": []
   },
   "src/components/Terminal/hooks/useAutocompleteState.ts": {
     "success": 1,
     "skip": 0,
     "error": 0,
-    "pipeline": 0
+    "pipeline": 0,
+    "errorBailouts": [],
+    "skipReasons": [],
+    "pipelineErrors": []
   },
   "src/components/Terminal/hooks/useCompartmentDriver.ts": {
     "success": 1,
     "skip": 0,
     "error": 0,
-    "pipeline": 0
+    "pipeline": 0,
+    "errorBailouts": [],
+    "skipReasons": [],
+    "pipelineErrors": []
   },
   "src/components/Terminal/hooks/useContextDetection.ts": {
     "success": 1,
     "skip": 0,
     "error": 0,
-    "pipeline": 0
+    "pipeline": 0,
+    "errorBailouts": [],
+    "skipReasons": [],
+    "pipelineErrors": []
   },
   "src/components/Terminal/hooks/useDragDrop.ts": {
     "success": 0,
     "skip": 0,
     "error": 1,
-    "pipeline": 0
+    "pipeline": 0,
+    "errorBailouts": [
+      {
+        "category": "Todo",
+        "reason": "Support value blocks (conditional, logical, optional chaining, etc) within a try/catch statement"
+      }
+    ],
+    "skipReasons": [],
+    "pipelineErrors": []
   },
   "src/components/Terminal/hooks/useEditorCompartments.ts": {
     "success": 1,
     "skip": 0,
     "error": 0,
-    "pipeline": 0
+    "pipeline": 0,
+    "errorBailouts": [],
+    "skipReasons": [],
+    "pipelineErrors": []
   },
   "src/components/Terminal/hooks/useEditorDomHandlers.ts": {
     "success": 0,
     "skip": 0,
     "error": 1,
-    "pipeline": 0
+    "pipeline": 0,
+    "errorBailouts": [
+      {
+        "category": "Refs",
+        "reason": "Cannot access refs during render"
+      }
+    ],
+    "skipReasons": [],
+    "pipelineErrors": []
   },
   "src/components/Terminal/hooks/useEditorFactory.ts": {
     "success": 1,
     "skip": 0,
     "error": 0,
-    "pipeline": 0
+    "pipeline": 0,
+    "errorBailouts": [],
+    "skipReasons": [],
+    "pipelineErrors": []
   },
   "src/components/Terminal/hooks/useEditorKeymap.ts": {
     "success": 1,
     "skip": 0,
     "error": 0,
-    "pipeline": 0
+    "pipeline": 0,
+    "errorBailouts": [],
+    "skipReasons": [],
+    "pipelineErrors": []
   },
   "src/components/Terminal/hooks/useFleetMirror.ts": {
     "success": 1,
     "skip": 0,
     "error": 0,
-    "pipeline": 0
+    "pipeline": 0,
+    "errorBailouts": [],
+    "skipReasons": [],
+    "pipelineErrors": []
   },
   "src/components/Terminal/hooks/useHostReparent.ts": {
     "success": 1,
     "skip": 0,
     "error": 0,
-    "pipeline": 0
+    "pipeline": 0,
+    "errorBailouts": [],
+    "skipReasons": [],
+    "pipelineErrors": []
   },
   "src/components/Terminal/hooks/usePasteExtensions.ts": {
     "success": 1,
     "skip": 0,
     "error": 0,
-    "pipeline": 0
+    "pipeline": 0,
+    "errorBailouts": [],
+    "skipReasons": [],
+    "pipelineErrors": []
   },
   "src/components/Terminal/hooks/useTokenResolution.ts": {
     "success": 0,
     "skip": 0,
     "error": 1,
-    "pipeline": 0
+    "pipeline": 0,
+    "errorBailouts": [
+      {
+        "category": "Todo",
+        "reason": "(BuildHIR::lowerStatement) Handle TryStatement without a catch clause"
+      }
+    ],
+    "skipReasons": [],
+    "pipelineErrors": []
   },
   "src/components/Terminal/hooks/useVoiceDecorations.ts": {
     "success": 1,
     "skip": 0,
     "error": 0,
-    "pipeline": 0
+    "pipeline": 0,
+    "errorBailouts": [],
+    "skipReasons": [],
+    "pipelineErrors": []
   },
   "src/components/Terminal/hooks/useVoiceWaitSubmit.ts": {
     "success": 0,
     "skip": 0,
     "error": 1,
-    "pipeline": 0
+    "pipeline": 0,
+    "errorBailouts": [
+      {
+        "category": "Todo",
+        "reason": "(BuildHIR::lowerStatement) Handle TryStatement without a catch clause"
+      }
+    ],
+    "skipReasons": [],
+    "pipelineErrors": []
   },
   "src/components/Terminal/useContentGridContext.tsx": {
     "success": 0,
     "skip": 0,
     "error": 2,
-    "pipeline": 0
+    "pipeline": 0,
+    "errorBailouts": [
+      {
+        "category": "Todo",
+        "reason": "(BuildHIR::lowerExpression) Handle UpdateExpression to variables captured within lambdas."
+      },
+      {
+        "category": "Todo",
+        "reason": "(BuildHIR::lowerExpression) Handle UpdateExpression to variables captured within lambdas."
+      }
+    ],
+    "skipReasons": [],
+    "pipelineErrors": []
   },
   "src/components/Terminal/useTerminalFileTransfer.ts": {
     "success": 0,
     "skip": 0,
     "error": 1,
-    "pipeline": 0
+    "pipeline": 0,
+    "errorBailouts": [
+      {
+        "category": "Todo",
+        "reason": "Support value blocks (conditional, logical, optional chaining, etc) within a try/catch statement"
+      }
+    ],
+    "skipReasons": [],
+    "pipelineErrors": []
   },
   "src/components/TerminalPalette/NewTerminalPalette.tsx": {
     "success": 1,
     "skip": 0,
     "error": 0,
-    "pipeline": 0
+    "pipeline": 0,
+    "errorBailouts": [],
+    "skipReasons": [],
+    "pipelineErrors": []
   },
   "src/components/TerminalRecipe/RecipeEditor.tsx": {
     "success": 0,
     "skip": 0,
     "error": 2,
-    "pipeline": 0
+    "pipeline": 0,
+    "errorBailouts": [
+      {
+        "category": "Todo",
+        "reason": "(BuildHIR::lowerStatement) Handle TryStatement with a finalizer ('finally') clause"
+      },
+      {
+        "category": "Todo",
+        "reason": "(BuildHIR::lowerStatement) Support ThrowStatement inside of try/catch"
+      }
+    ],
+    "skipReasons": [],
+    "pipelineErrors": []
   },
   "src/components/TerminalRecipe/RecipeManager.tsx": {
     "success": 0,
     "skip": 0,
     "error": 1,
-    "pipeline": 0
+    "pipeline": 0,
+    "errorBailouts": [
+      {
+        "category": "Todo",
+        "reason": "(BuildHIR::lowerStatement) Handle TryStatement with a finalizer ('finally') clause"
+      }
+    ],
+    "skipReasons": [],
+    "pipelineErrors": []
   },
   "src/components/ThemeBrowser/ThemeBrowser.tsx": {
-    "success": 2,
+    "success": 1,
     "skip": 0,
-    "error": 0,
-    "pipeline": 0
+    "error": 2,
+    "pipeline": 0,
+    "errorBailouts": [
+      {
+        "category": "Immutability",
+        "reason": "This value cannot be modified"
+      },
+      {
+        "category": "Immutability",
+        "reason": "This value cannot be modified"
+      }
+    ],
+    "skipReasons": [],
+    "pipelineErrors": []
   },
   "src/components/ThemePalette/ThemePalette.tsx": {
     "success": 2,
     "skip": 0,
     "error": 0,
-    "pipeline": 0
+    "pipeline": 0,
+    "errorBailouts": [],
+    "skipReasons": [],
+    "pipelineErrors": []
   },
   "src/components/Worktree/ActivityLight.tsx": {
     "success": 1,
     "skip": 0,
     "error": 0,
-    "pipeline": 0
+    "pipeline": 0,
+    "errorBailouts": [],
+    "skipReasons": [],
+    "pipelineErrors": []
   },
   "src/components/Worktree/AgentStatusIndicator.tsx": {
     "success": 1,
     "skip": 0,
     "error": 0,
-    "pipeline": 0
+    "pipeline": 0,
+    "errorBailouts": [],
+    "skipReasons": [],
+    "pipelineErrors": []
   },
   "src/components/Worktree/BranchLabel.tsx": {
     "success": 1,
     "skip": 0,
     "error": 0,
-    "pipeline": 0
+    "pipeline": 0,
+    "errorBailouts": [],
+    "skipReasons": [],
+    "pipelineErrors": []
   },
   "src/components/Worktree/CrossWorktreeDiff.tsx": {
     "success": 1,
     "skip": 0,
     "error": 2,
-    "pipeline": 0
+    "pipeline": 0,
+    "errorBailouts": [
+      {
+        "category": "Todo",
+        "reason": "(BuildHIR::lowerStatement) Handle TryStatement with a finalizer ('finally') clause"
+      },
+      {
+        "category": "Todo",
+        "reason": "(BuildHIR::lowerStatement) Handle TryStatement with a finalizer ('finally') clause"
+      }
+    ],
+    "skipReasons": [],
+    "pipelineErrors": []
   },
   "src/components/Worktree/DiffViewer.tsx": {
     "success": 3,
     "skip": 0,
     "error": 0,
-    "pipeline": 0
+    "pipeline": 0,
+    "errorBailouts": [],
+    "skipReasons": [],
+    "pipelineErrors": []
   },
   "src/components/Worktree/FileChangeList.tsx": {
     "success": 1,
     "skip": 0,
     "error": 0,
-    "pipeline": 0
+    "pipeline": 0,
+    "errorBailouts": [],
+    "skipReasons": [],
+    "pipelineErrors": []
   },
   "src/components/Worktree/FileDiffModal.tsx": {
     "success": 0,
     "skip": 0,
     "error": 1,
-    "pipeline": 0
+    "pipeline": 0,
+    "errorBailouts": [
+      {
+        "category": "Todo",
+        "reason": "Support value blocks (conditional, logical, optional chaining, etc) within a try/catch statement"
+      }
+    ],
+    "skipReasons": [],
+    "pipelineErrors": []
   },
   "src/components/Worktree/IssuePickerDialog.tsx": {
     "success": 1,
     "skip": 0,
     "error": 1,
-    "pipeline": 0
+    "pipeline": 0,
+    "errorBailouts": [
+      {
+        "category": "Todo",
+        "reason": "(BuildHIR::lowerStatement) Handle TryStatement with a finalizer ('finally') clause"
+      }
+    ],
+    "skipReasons": [],
+    "pipelineErrors": []
   },
   "src/components/Worktree/LiveTimeAgo.tsx": {
     "success": 1,
     "skip": 0,
     "error": 0,
-    "pipeline": 0
+    "pipeline": 0,
+    "errorBailouts": [],
+    "skipReasons": [],
+    "pipelineErrors": []
   },
   "src/components/Worktree/NewWorktreeDialog.tsx": {
     "success": 0,
     "skip": 0,
     "error": 2,
-    "pipeline": 0
+    "pipeline": 0,
+    "errorBailouts": [
+      {
+        "category": "Todo",
+        "reason": "(BuildHIR::lowerStatement) Handle TryStatement with a finalizer ('finally') clause"
+      },
+      {
+        "category": "Todo",
+        "reason": "(BuildHIR::lowerStatement) Support ThrowStatement inside of try/catch"
+      }
+    ],
+    "skipReasons": [],
+    "pipelineErrors": []
   },
   "src/components/Worktree/QuickCreatePalette.tsx": {
     "success": 2,
     "skip": 0,
     "error": 0,
-    "pipeline": 0
+    "pipeline": 0,
+    "errorBailouts": [],
+    "skipReasons": [],
+    "pipelineErrors": []
   },
   "src/components/Worktree/QuickStateFilterBar.tsx": {
     "success": 1,
     "skip": 0,
     "error": 0,
-    "pipeline": 0
+    "pipeline": 0,
+    "errorBailouts": [],
+    "skipReasons": [],
+    "pipelineErrors": []
   },
   "src/components/Worktree/ReviewHub/BaseBranchDiffModal.tsx": {
     "success": 0,
     "skip": 0,
     "error": 1,
-    "pipeline": 0
+    "pipeline": 0,
+    "errorBailouts": [
+      {
+        "category": "Todo",
+        "reason": "Support value blocks (conditional, logical, optional chaining, etc) within a try/catch statement"
+      }
+    ],
+    "skipReasons": [],
+    "pipelineErrors": []
   },
   "src/components/Worktree/ReviewHub/CommitPanel.tsx": {
     "success": 0,
     "skip": 0,
     "error": 2,
-    "pipeline": 0
+    "pipeline": 0,
+    "errorBailouts": [
+      {
+        "category": "Todo",
+        "reason": "(BuildHIR::lowerStatement) Handle TryStatement with a finalizer ('finally') clause"
+      },
+      {
+        "category": "Todo",
+        "reason": "(BuildHIR::lowerStatement) Handle TryStatement with a finalizer ('finally') clause"
+      }
+    ],
+    "skipReasons": [],
+    "pipelineErrors": []
   },
   "src/components/Worktree/ReviewHub/ConflictPanel.tsx": {
     "success": 0,
     "skip": 0,
     "error": 3,
-    "pipeline": 0
+    "pipeline": 0,
+    "errorBailouts": [
+      {
+        "category": "Todo",
+        "reason": "(BuildHIR::lowerStatement) Handle TryStatement without a catch clause"
+      },
+      {
+        "category": "Todo",
+        "reason": "(BuildHIR::lowerStatement) Handle TryStatement without a catch clause"
+      },
+      {
+        "category": "Todo",
+        "reason": "(BuildHIR::lowerStatement) Handle TryStatement without a catch clause"
+      }
+    ],
+    "skipReasons": [],
+    "pipelineErrors": []
   },
   "src/components/Worktree/ReviewHub/FileStageRow.tsx": {
     "success": 1,
     "skip": 0,
     "error": 0,
-    "pipeline": 0
+    "pipeline": 0,
+    "errorBailouts": [],
+    "skipReasons": [],
+    "pipelineErrors": []
   },
   "src/components/Worktree/ReviewHub/ReviewHub.tsx": {
     "success": 1,
     "skip": 0,
     "error": 3,
-    "pipeline": 0
+    "pipeline": 0,
+    "errorBailouts": [
+      {
+        "category": "Todo",
+        "reason": "(BuildHIR::lowerStatement) Handle TryStatement with a finalizer ('finally') clause"
+      },
+      {
+        "category": "Todo",
+        "reason": "(BuildHIR::lowerStatement) Handle TryStatement with a finalizer ('finally') clause"
+      },
+      {
+        "category": "Todo",
+        "reason": "(BuildHIR::lowerStatement) Handle TryStatement with a finalizer ('finally') clause"
+      }
+    ],
+    "skipReasons": [],
+    "pipelineErrors": []
   },
   "src/components/Worktree/ScrollIndicator.tsx": {
     "success": 1,
     "skip": 0,
     "error": 0,
-    "pipeline": 0
+    "pipeline": 0,
+    "errorBailouts": [],
+    "skipReasons": [],
+    "pipelineErrors": []
   },
   "src/components/Worktree/WorktreeCard.tsx": {
     "success": 1,
     "skip": 0,
     "error": 0,
-    "pipeline": 0
+    "pipeline": 0,
+    "errorBailouts": [],
+    "skipReasons": [],
+    "pipelineErrors": []
   },
   "src/components/Worktree/WorktreeCard/CollapsedSessionIndicators.tsx": {
     "success": 1,
     "skip": 0,
     "error": 0,
-    "pipeline": 0
+    "pipeline": 0,
+    "errorBailouts": [],
+    "skipReasons": [],
+    "pipelineErrors": []
   },
   "src/components/Worktree/WorktreeCard/EnvironmentPopover.tsx": {
     "success": 1,
     "skip": 0,
     "error": 0,
-    "pipeline": 0
+    "pipeline": 0,
+    "errorBailouts": [],
+    "skipReasons": [],
+    "pipelineErrors": []
   },
   "src/components/Worktree/WorktreeCard/GitHubTooltipContent.tsx": {
     "success": 5,
     "skip": 0,
     "error": 0,
-    "pipeline": 0
+    "pipeline": 0,
+    "errorBailouts": [],
+    "skipReasons": [],
+    "pipelineErrors": []
   },
   "src/components/Worktree/WorktreeCard/IssueBadge.tsx": {
     "success": 1,
     "skip": 0,
     "error": 0,
-    "pipeline": 0
+    "pipeline": 0,
+    "errorBailouts": [],
+    "skipReasons": [],
+    "pipelineErrors": []
   },
   "src/components/Worktree/WorktreeCard/MainWorktreeSecondaryRow.tsx": {
     "success": 1,
     "skip": 0,
     "error": 0,
-    "pipeline": 0
+    "pipeline": 0,
+    "errorBailouts": [],
+    "skipReasons": [],
+    "pipelineErrors": []
   },
   "src/components/Worktree/WorktreeCard/MainWorktreeSummaryRows.tsx": {
     "success": 1,
     "skip": 0,
     "error": 0,
-    "pipeline": 0
+    "pipeline": 0,
+    "errorBailouts": [],
+    "skipReasons": [],
+    "pipelineErrors": []
   },
   "src/components/Worktree/WorktreeCard/NonMainSecondaryRow.tsx": {
     "success": 1,
     "skip": 0,
     "error": 0,
-    "pipeline": 0
+    "pipeline": 0,
+    "errorBailouts": [],
+    "skipReasons": [],
+    "pipelineErrors": []
   },
   "src/components/Worktree/WorktreeCard/PRBadge.tsx": {
     "success": 1,
     "skip": 0,
     "error": 0,
-    "pipeline": 0
+    "pipeline": 0,
+    "errorBailouts": [],
+    "skipReasons": [],
+    "pipelineErrors": []
   },
   "src/components/Worktree/WorktreeCard/UpstreamSyncBadge.tsx": {
     "success": 1,
     "skip": 0,
     "error": 0,
-    "pipeline": 0
+    "pipeline": 0,
+    "errorBailouts": [],
+    "skipReasons": [],
+    "pipelineErrors": []
   },
   "src/components/Worktree/WorktreeCard/WorktreeActionsToolbar.tsx": {
     "success": 1,
     "skip": 0,
     "error": 0,
-    "pipeline": 0
+    "pipeline": 0,
+    "errorBailouts": [],
+    "skipReasons": [],
+    "pipelineErrors": []
   },
   "src/components/Worktree/WorktreeCard/WorktreeDetailsSection.tsx": {
     "success": 1,
     "skip": 0,
     "error": 0,
-    "pipeline": 0
+    "pipeline": 0,
+    "errorBailouts": [],
+    "skipReasons": [],
+    "pipelineErrors": []
   },
   "src/components/Worktree/WorktreeCard/WorktreeDialogs.tsx": {
     "success": 1,
     "skip": 0,
     "error": 0,
-    "pipeline": 0
+    "pipeline": 0,
+    "errorBailouts": [],
+    "skipReasons": [],
+    "pipelineErrors": []
   },
   "src/components/Worktree/WorktreeCard/WorktreeHeader.tsx": {
     "success": 1,
     "skip": 0,
     "error": 0,
-    "pipeline": 0
+    "pipeline": 0,
+    "errorBailouts": [],
+    "skipReasons": [],
+    "pipelineErrors": []
   },
   "src/components/Worktree/WorktreeCard/WorktreeTerminalSection.tsx": {
     "success": 3,
     "skip": 0,
     "error": 0,
-    "pipeline": 0
+    "pipeline": 0,
+    "errorBailouts": [],
+    "skipReasons": [],
+    "pipelineErrors": []
   },
   "src/components/Worktree/WorktreeCard/WslGitBanner.tsx": {
     "success": 0,
     "skip": 0,
     "error": 2,
-    "pipeline": 0
+    "pipeline": 0,
+    "errorBailouts": [
+      {
+        "category": "Todo",
+        "reason": "(BuildHIR::lowerStatement) Handle TryStatement with a finalizer ('finally') clause"
+      },
+      {
+        "category": "Todo",
+        "reason": "(BuildHIR::lowerStatement) Handle TryStatement with a finalizer ('finally') clause"
+      }
+    ],
+    "skipReasons": [],
+    "pipelineErrors": []
   },
   "src/components/Worktree/WorktreeCard/hooks/useGitHubBadgeTooltip.ts": {
     "success": 1,
     "skip": 0,
     "error": 0,
-    "pipeline": 0
+    "pipeline": 0,
+    "errorBailouts": [],
+    "skipReasons": [],
+    "pipelineErrors": []
   },
   "src/components/Worktree/WorktreeCard/hooks/useInputReceiptKey.ts": {
     "success": 1,
     "skip": 0,
     "error": 0,
-    "pipeline": 0
+    "pipeline": 0,
+    "errorBailouts": [],
+    "skipReasons": [],
+    "pipelineErrors": []
   },
   "src/components/Worktree/WorktreeCard/hooks/useWorktreeActions.ts": {
     "success": 0,
     "skip": 0,
     "error": 1,
-    "pipeline": 0
+    "pipeline": 0,
+    "errorBailouts": [
+      {
+        "category": "Todo",
+        "reason": "(BuildHIR::lowerStatement) Handle TryStatement with a finalizer ('finally') clause"
+      }
+    ],
+    "skipReasons": [],
+    "pipelineErrors": []
   },
   "src/components/Worktree/WorktreeCard/hooks/useWorktreeStatus.ts": {
     "success": 1,
     "skip": 0,
     "error": 0,
-    "pipeline": 0
+    "pipeline": 0,
+    "errorBailouts": [],
+    "skipReasons": [],
+    "pipelineErrors": []
   },
   "src/components/Worktree/WorktreeCardErrorFallback.tsx": {
     "success": 1,
     "skip": 0,
     "error": 0,
-    "pipeline": 0
+    "pipeline": 0,
+    "errorBailouts": [],
+    "skipReasons": [],
+    "pipelineErrors": []
   },
   "src/components/Worktree/WorktreeDeleteDialog.tsx": {
     "success": 0,
     "skip": 0,
     "error": 2,
-    "pipeline": 0
+    "pipeline": 0,
+    "errorBailouts": [
+      {
+        "category": "Todo",
+        "reason": "(BuildHIR::lowerStatement) Handle TryStatement with a finalizer ('finally') clause"
+      },
+      {
+        "category": "Todo",
+        "reason": "(BuildHIR::lowerStatement) Support ThrowStatement inside of try/catch"
+      }
+    ],
+    "skipReasons": [],
+    "pipelineErrors": []
   },
   "src/components/Worktree/WorktreeDetails.tsx": {
-    "success": 0,
+    "success": 1,
     "skip": 0,
-    "error": 1,
-    "pipeline": 0
+    "error": 0,
+    "pipeline": 0,
+    "errorBailouts": [],
+    "skipReasons": [],
+    "pipelineErrors": []
   },
   "src/components/Worktree/WorktreeFilterPopover.tsx": {
     "success": 3,
     "skip": 0,
     "error": 0,
-    "pipeline": 0
+    "pipeline": 0,
+    "errorBailouts": [],
+    "skipReasons": [],
+    "pipelineErrors": []
   },
   "src/components/Worktree/WorktreeMenuItems.tsx": {
     "success": 1,
     "skip": 0,
     "error": 0,
-    "pipeline": 0
+    "pipeline": 0,
+    "errorBailouts": [],
+    "skipReasons": [],
+    "pipelineErrors": []
   },
   "src/components/Worktree/WorktreeOverviewModal.tsx": {
     "success": 3,
     "skip": 0,
     "error": 0,
-    "pipeline": 0
+    "pipeline": 0,
+    "errorBailouts": [],
+    "skipReasons": [],
+    "pipelineErrors": []
   },
   "src/components/Worktree/WorktreePalette.tsx": {
     "success": 2,
     "skip": 0,
     "error": 0,
-    "pipeline": 0
+    "pipeline": 0,
+    "errorBailouts": [],
+    "skipReasons": [],
+    "pipelineErrors": []
   },
   "src/components/Worktree/WorktreeSelector.tsx": {
     "success": 1,
     "skip": 0,
     "error": 0,
-    "pipeline": 0
+    "pipeline": 0,
+    "errorBailouts": [],
+    "skipReasons": [],
+    "pipelineErrors": []
   },
   "src/components/Worktree/WorktreeSidebarSearchBar.tsx": {
     "success": 1,
     "skip": 0,
     "error": 0,
-    "pipeline": 0
+    "pipeline": 0,
+    "errorBailouts": [],
+    "skipReasons": [],
+    "pipelineErrors": []
   },
   "src/components/Worktree/hooks/useBranchInput.ts": {
     "success": 1,
     "skip": 0,
     "error": 0,
-    "pipeline": 0
+    "pipeline": 0,
+    "errorBailouts": [],
+    "skipReasons": [],
+    "pipelineErrors": []
   },
   "src/components/Worktree/hooks/useBranchPicker.ts": {
     "success": 1,
     "skip": 0,
     "error": 0,
-    "pipeline": 0
+    "pipeline": 0,
+    "errorBailouts": [],
+    "skipReasons": [],
+    "pipelineErrors": []
   },
   "src/components/Worktree/hooks/useBranchValidation.ts": {
     "success": 1,
     "skip": 0,
     "error": 0,
-    "pipeline": 0
+    "pipeline": 0,
+    "errorBailouts": [],
+    "skipReasons": [],
+    "pipelineErrors": []
   },
   "src/components/Worktree/hooks/useNewWorktreeProjectSettings.ts": {
     "success": 1,
     "skip": 0,
     "error": 0,
-    "pipeline": 0
+    "pipeline": 0,
+    "errorBailouts": [],
+    "skipReasons": [],
+    "pipelineErrors": []
   },
   "src/components/Worktree/hooks/usePrefixPicker.ts": {
     "success": 1,
     "skip": 0,
     "error": 0,
-    "pipeline": 0
+    "pipeline": 0,
+    "errorBailouts": [],
+    "skipReasons": [],
+    "pipelineErrors": []
   },
   "src/components/Worktree/hooks/useRecipePicker.ts": {
     "success": 1,
     "skip": 0,
     "error": 0,
-    "pipeline": 0
+    "pipeline": 0,
+    "errorBailouts": [],
+    "skipReasons": [],
+    "pipelineErrors": []
   },
   "src/components/Worktree/hooks/useWorktreeFormErrors.ts": {
     "success": 1,
     "skip": 0,
     "error": 0,
-    "pipeline": 0
+    "pipeline": 0,
+    "errorBailouts": [],
+    "skipReasons": [],
+    "pipelineErrors": []
   },
   "src/components/Worktree/hooks/useWorktreeFormValidation.ts": {
     "success": 1,
     "skip": 0,
     "error": 0,
-    "pipeline": 0
+    "pipeline": 0,
+    "errorBailouts": [],
+    "skipReasons": [],
+    "pipelineErrors": []
   },
   "src/components/Worktree/views/BaseBranchCombobox.tsx": {
     "success": 0,
     "skip": 0,
     "error": 1,
-    "pipeline": 0
+    "pipeline": 0,
+    "errorBailouts": [
+      {
+        "category": "Todo",
+        "reason": "(BuildHIR::lowerExpression) Handle UpdateExpression to variables captured within lambdas."
+      }
+    ],
+    "skipReasons": [],
+    "pipelineErrors": []
   },
   "src/components/Worktree/views/BranchModeControl.tsx": {
     "success": 1,
     "skip": 0,
     "error": 0,
-    "pipeline": 0
+    "pipeline": 0,
+    "errorBailouts": [],
+    "skipReasons": [],
+    "pipelineErrors": []
   },
   "src/components/Worktree/views/EnvironmentRadioGroup.tsx": {
     "success": 1,
     "skip": 0,
     "error": 0,
-    "pipeline": 0
+    "pipeline": 0,
+    "errorBailouts": [],
+    "skipReasons": [],
+    "pipelineErrors": []
   },
   "src/components/Worktree/views/ExistingBranchPicker.tsx": {
     "success": 1,
     "skip": 0,
     "error": 0,
-    "pipeline": 0
+    "pipeline": 0,
+    "errorBailouts": [],
+    "skipReasons": [],
+    "pipelineErrors": []
   },
   "src/components/Worktree/views/HighlightBranchText.tsx": {
     "success": 1,
     "skip": 0,
     "error": 0,
-    "pipeline": 0
+    "pipeline": 0,
+    "errorBailouts": [],
+    "skipReasons": [],
+    "pipelineErrors": []
   },
   "src/components/Worktree/views/IssueSelectorView.tsx": {
     "success": 1,
     "skip": 0,
     "error": 0,
-    "pipeline": 0
+    "pipeline": 0,
+    "errorBailouts": [],
+    "skipReasons": [],
+    "pipelineErrors": []
   },
   "src/components/Worktree/views/NewBranchInput.tsx": {
     "success": 0,
     "skip": 0,
     "error": 1,
-    "pipeline": 0
+    "pipeline": 0,
+    "errorBailouts": [
+      {
+        "category": "Todo",
+        "reason": "Unexpected terminal kind `ternary` for logical test block"
+      }
+    ],
+    "skipReasons": [],
+    "pipelineErrors": []
   },
   "src/components/Worktree/views/PrHeader.tsx": {
     "success": 1,
     "skip": 0,
     "error": 0,
-    "pipeline": 0
+    "pipeline": 0,
+    "errorBailouts": [],
+    "skipReasons": [],
+    "pipelineErrors": []
   },
   "src/components/Worktree/views/RecipePickerPopover.tsx": {
     "success": 1,
     "skip": 0,
     "error": 0,
-    "pipeline": 0
+    "pipeline": 0,
+    "errorBailouts": [],
+    "skipReasons": [],
+    "pipelineErrors": []
   },
   "src/components/Worktree/views/WorktreePathPicker.tsx": {
     "success": 1,
     "skip": 0,
     "error": 0,
-    "pipeline": 0
+    "pipeline": 0,
+    "errorBailouts": [],
+    "skipReasons": [],
+    "pipelineErrors": []
   },
   "src/components/agents/AgentCard.tsx": {
     "success": 5,
     "skip": 0,
     "error": 0,
-    "pipeline": 0
+    "pipeline": 0,
+    "errorBailouts": [],
+    "skipReasons": [],
+    "pipelineErrors": []
   },
   "src/components/icons/AgentStateCircles.tsx": {
-    "success": 7,
+    "success": 4,
     "skip": 0,
     "error": 0,
-    "pipeline": 0
+    "pipeline": 0,
+    "errorBailouts": [],
+    "skipReasons": [],
+    "pipelineErrors": []
   },
   "src/components/icons/BrandMark.tsx": {
     "success": 1,
     "skip": 0,
     "error": 0,
-    "pipeline": 0
+    "pipeline": 0,
+    "errorBailouts": [],
+    "skipReasons": [],
+    "pipelineErrors": []
   },
   "src/components/icons/DaintreeIcon.tsx": {
     "success": 1,
     "skip": 0,
     "error": 0,
-    "pipeline": 0
+    "pipeline": 0,
+    "errorBailouts": [],
+    "skipReasons": [],
+    "pipelineErrors": []
   },
   "src/components/icons/McpServerIcon.tsx": {
     "success": 1,
     "skip": 0,
     "error": 0,
-    "pipeline": 0
+    "pipeline": 0,
+    "errorBailouts": [],
+    "skipReasons": [],
+    "pipelineErrors": []
   },
   "src/components/icons/brands/AiderIcon.tsx": {
     "success": 1,
     "skip": 0,
     "error": 0,
-    "pipeline": 0
+    "pipeline": 0,
+    "errorBailouts": [],
+    "skipReasons": [],
+    "pipelineErrors": []
   },
   "src/components/icons/brands/AmpIcon.tsx": {
     "success": 1,
     "skip": 0,
     "error": 0,
-    "pipeline": 0
+    "pipeline": 0,
+    "errorBailouts": [],
+    "skipReasons": [],
+    "pipelineErrors": []
   },
   "src/components/icons/brands/BunIcon.tsx": {
     "success": 1,
     "skip": 0,
     "error": 0,
-    "pipeline": 0
+    "pipeline": 0,
+    "errorBailouts": [],
+    "skipReasons": [],
+    "pipelineErrors": []
   },
   "src/components/icons/brands/ClaudeIcon.tsx": {
     "success": 1,
     "skip": 0,
     "error": 0,
-    "pipeline": 0
+    "pipeline": 0,
+    "errorBailouts": [],
+    "skipReasons": [],
+    "pipelineErrors": []
   },
   "src/components/icons/brands/CodexIcon.tsx": {
     "success": 1,
     "skip": 0,
     "error": 0,
-    "pipeline": 0
+    "pipeline": 0,
+    "errorBailouts": [],
+    "skipReasons": [],
+    "pipelineErrors": []
   },
   "src/components/icons/brands/ComposerIcon.tsx": {
     "success": 1,
     "skip": 0,
     "error": 0,
-    "pipeline": 0
+    "pipeline": 0,
+    "errorBailouts": [],
+    "skipReasons": [],
+    "pipelineErrors": []
   },
   "src/components/icons/brands/CopilotIcon.tsx": {
     "success": 1,
     "skip": 0,
     "error": 0,
-    "pipeline": 0
+    "pipeline": 0,
+    "errorBailouts": [],
+    "skipReasons": [],
+    "pipelineErrors": []
   },
   "src/components/icons/brands/CrushIcon.tsx": {
     "success": 1,
     "skip": 0,
     "error": 0,
-    "pipeline": 0
+    "pipeline": 0,
+    "errorBailouts": [],
+    "skipReasons": [],
+    "pipelineErrors": []
   },
   "src/components/icons/brands/CursorIcon.tsx": {
     "success": 1,
     "skip": 0,
     "error": 0,
-    "pipeline": 0
+    "pipeline": 0,
+    "errorBailouts": [],
+    "skipReasons": [],
+    "pipelineErrors": []
   },
   "src/components/icons/brands/DenoIcon.tsx": {
     "success": 1,
     "skip": 0,
     "error": 0,
-    "pipeline": 0
+    "pipeline": 0,
+    "errorBailouts": [],
+    "skipReasons": [],
+    "pipelineErrors": []
   },
   "src/components/icons/brands/DockerIcon.tsx": {
     "success": 1,
     "skip": 0,
     "error": 0,
-    "pipeline": 0
+    "pipeline": 0,
+    "errorBailouts": [],
+    "skipReasons": [],
+    "pipelineErrors": []
   },
   "src/components/icons/brands/ElixirIcon.tsx": {
     "success": 1,
     "skip": 0,
     "error": 0,
-    "pipeline": 0
+    "pipeline": 0,
+    "errorBailouts": [],
+    "skipReasons": [],
+    "pipelineErrors": []
   },
   "src/components/icons/brands/GeminiIcon.tsx": {
     "success": 1,
     "skip": 0,
     "error": 0,
-    "pipeline": 0
+    "pipeline": 0,
+    "errorBailouts": [],
+    "skipReasons": [],
+    "pipelineErrors": []
   },
   "src/components/icons/brands/GoIcon.tsx": {
     "success": 1,
     "skip": 0,
     "error": 0,
-    "pipeline": 0
+    "pipeline": 0,
+    "errorBailouts": [],
+    "skipReasons": [],
+    "pipelineErrors": []
   },
   "src/components/icons/brands/GooseIcon.tsx": {
     "success": 1,
     "skip": 0,
     "error": 0,
-    "pipeline": 0
+    "pipeline": 0,
+    "errorBailouts": [],
+    "skipReasons": [],
+    "pipelineErrors": []
   },
   "src/components/icons/brands/GradleIcon.tsx": {
     "success": 1,
     "skip": 0,
     "error": 0,
-    "pipeline": 0
+    "pipeline": 0,
+    "errorBailouts": [],
+    "skipReasons": [],
+    "pipelineErrors": []
   },
   "src/components/icons/brands/InterpreterIcon.tsx": {
     "success": 1,
     "skip": 0,
     "error": 0,
-    "pipeline": 0
+    "pipeline": 0,
+    "errorBailouts": [],
+    "skipReasons": [],
+    "pipelineErrors": []
   },
   "src/components/icons/brands/KimiIcon.tsx": {
     "success": 1,
     "skip": 0,
     "error": 0,
-    "pipeline": 0
+    "pipeline": 0,
+    "errorBailouts": [],
+    "skipReasons": [],
+    "pipelineErrors": []
   },
   "src/components/icons/brands/KiroIcon.tsx": {
     "success": 1,
     "skip": 0,
     "error": 0,
-    "pipeline": 0
+    "pipeline": 0,
+    "errorBailouts": [],
+    "skipReasons": [],
+    "pipelineErrors": []
   },
   "src/components/icons/brands/KotlinIcon.tsx": {
     "success": 1,
     "skip": 0,
     "error": 0,
-    "pipeline": 0
+    "pipeline": 0,
+    "errorBailouts": [],
+    "skipReasons": [],
+    "pipelineErrors": []
   },
   "src/components/icons/brands/MistralIcon.tsx": {
     "success": 1,
     "skip": 0,
     "error": 0,
-    "pipeline": 0
+    "pipeline": 0,
+    "errorBailouts": [],
+    "skipReasons": [],
+    "pipelineErrors": []
   },
   "src/components/icons/brands/NodeIcon.tsx": {
     "success": 1,
     "skip": 0,
     "error": 0,
-    "pipeline": 0
+    "pipeline": 0,
+    "errorBailouts": [],
+    "skipReasons": [],
+    "pipelineErrors": []
   },
   "src/components/icons/brands/NpmIcon.tsx": {
     "success": 1,
     "skip": 0,
     "error": 0,
-    "pipeline": 0
+    "pipeline": 0,
+    "errorBailouts": [],
+    "skipReasons": [],
+    "pipelineErrors": []
   },
   "src/components/icons/brands/OpenCodeIcon.tsx": {
     "success": 1,
     "skip": 0,
     "error": 0,
-    "pipeline": 0
+    "pipeline": 0,
+    "errorBailouts": [],
+    "skipReasons": [],
+    "pipelineErrors": []
   },
   "src/components/icons/brands/PhpIcon.tsx": {
     "success": 1,
     "skip": 0,
     "error": 0,
-    "pipeline": 0
+    "pipeline": 0,
+    "errorBailouts": [],
+    "skipReasons": [],
+    "pipelineErrors": []
   },
   "src/components/icons/brands/PnpmIcon.tsx": {
     "success": 1,
     "skip": 0,
     "error": 0,
-    "pipeline": 0
+    "pipeline": 0,
+    "errorBailouts": [],
+    "skipReasons": [],
+    "pipelineErrors": []
   },
   "src/components/icons/brands/PythonIcon.tsx": {
     "success": 1,
     "skip": 0,
     "error": 0,
-    "pipeline": 0
+    "pipeline": 0,
+    "errorBailouts": [],
+    "skipReasons": [],
+    "pipelineErrors": []
   },
   "src/components/icons/brands/QwenIcon.tsx": {
     "success": 1,
     "skip": 0,
     "error": 0,
-    "pipeline": 0
+    "pipeline": 0,
+    "errorBailouts": [],
+    "skipReasons": [],
+    "pipelineErrors": []
   },
   "src/components/icons/brands/RubyIcon.tsx": {
     "success": 1,
     "skip": 0,
     "error": 0,
-    "pipeline": 0
+    "pipeline": 0,
+    "errorBailouts": [],
+    "skipReasons": [],
+    "pipelineErrors": []
   },
   "src/components/icons/brands/RustIcon.tsx": {
     "success": 1,
     "skip": 0,
     "error": 0,
-    "pipeline": 0
+    "pipeline": 0,
+    "errorBailouts": [],
+    "skipReasons": [],
+    "pipelineErrors": []
   },
   "src/components/icons/brands/SwiftIcon.tsx": {
     "success": 1,
     "skip": 0,
     "error": 0,
-    "pipeline": 0
+    "pipeline": 0,
+    "errorBailouts": [],
+    "skipReasons": [],
+    "pipelineErrors": []
   },
   "src/components/icons/brands/TerraformIcon.tsx": {
     "success": 1,
     "skip": 0,
     "error": 0,
-    "pipeline": 0
+    "pipeline": 0,
+    "errorBailouts": [],
+    "skipReasons": [],
+    "pipelineErrors": []
   },
   "src/components/icons/brands/ViteIcon.tsx": {
     "success": 1,
     "skip": 0,
     "error": 0,
-    "pipeline": 0
+    "pipeline": 0,
+    "errorBailouts": [],
+    "skipReasons": [],
+    "pipelineErrors": []
   },
   "src/components/icons/brands/WebpackIcon.tsx": {
     "success": 1,
     "skip": 0,
     "error": 0,
-    "pipeline": 0
+    "pipeline": 0,
+    "errorBailouts": [],
+    "skipReasons": [],
+    "pipelineErrors": []
   },
   "src/components/icons/brands/YarnIcon.tsx": {
     "success": 1,
     "skip": 0,
     "error": 0,
-    "pipeline": 0
+    "pipeline": 0,
+    "errorBailouts": [],
+    "skipReasons": [],
+    "pipelineErrors": []
   },
   "src/components/ui/AnimatedLabel.tsx": {
     "success": 1,
     "skip": 0,
     "error": 0,
-    "pipeline": 0
+    "pipeline": 0,
+    "errorBailouts": [],
+    "skipReasons": [],
+    "pipelineErrors": []
   },
   "src/components/ui/AppDialog.tsx": {
     "success": 0,
     "skip": 0,
     "error": 1,
-    "pipeline": 0
+    "pipeline": 0,
+    "errorBailouts": [
+      {
+        "category": "Todo",
+        "reason": "(BuildHIR::lowerStatement) Handle TryStatement with a finalizer ('finally') clause"
+      }
+    ],
+    "skipReasons": [],
+    "pipelineErrors": []
   },
   "src/components/ui/AppPaletteDialog.tsx": {
     "success": 3,
     "skip": 0,
     "error": 0,
-    "pipeline": 0
+    "pipeline": 0,
+    "errorBailouts": [],
+    "skipReasons": [],
+    "pipelineErrors": []
   },
   "src/components/ui/Avatar.tsx": {
     "success": 1,
     "skip": 0,
     "error": 0,
-    "pipeline": 0
+    "pipeline": 0,
+    "errorBailouts": [],
+    "skipReasons": [],
+    "pipelineErrors": []
   },
   "src/components/ui/ConfirmDialog.tsx": {
     "success": 1,
     "skip": 0,
     "error": 0,
-    "pipeline": 0
+    "pipeline": 0,
+    "errorBailouts": [],
+    "skipReasons": [],
+    "pipelineErrors": []
   },
   "src/components/ui/ContentFadeIn.tsx": {
     "success": 1,
     "skip": 0,
     "error": 0,
-    "pipeline": 0
+    "pipeline": 0,
+    "errorBailouts": [],
+    "skipReasons": [],
+    "pipelineErrors": []
   },
   "src/components/ui/EmptyState.tsx": {
     "success": 1,
     "skip": 0,
     "error": 0,
-    "pipeline": 0
+    "pipeline": 0,
+    "errorBailouts": [],
+    "skipReasons": [],
+    "pipelineErrors": []
   },
   "src/components/ui/HighlightedText.tsx": {
     "success": 1,
     "skip": 0,
     "error": 0,
-    "pipeline": 0
+    "pipeline": 0,
+    "errorBailouts": [],
+    "skipReasons": [],
+    "pipelineErrors": []
   },
   "src/components/ui/Kbd.tsx": {
     "success": 2,
     "skip": 0,
     "error": 0,
-    "pipeline": 0
+    "pipeline": 0,
+    "errorBailouts": [],
+    "skipReasons": [],
+    "pipelineErrors": []
   },
   "src/components/ui/PaletteOverflowNotice.tsx": {
     "success": 1,
     "skip": 0,
     "error": 0,
-    "pipeline": 0
+    "pipeline": 0,
+    "errorBailouts": [],
+    "skipReasons": [],
+    "pipelineErrors": []
   },
   "src/components/ui/PaletteStrip.tsx": {
     "success": 1,
     "skip": 0,
     "error": 0,
-    "pipeline": 0
+    "pipeline": 0,
+    "errorBailouts": [],
+    "skipReasons": [],
+    "pipelineErrors": []
   },
   "src/components/ui/ReEntrySummary.tsx": {
     "success": 1,
     "skip": 0,
     "error": 0,
-    "pipeline": 0
+    "pipeline": 0,
+    "errorBailouts": [],
+    "skipReasons": [],
+    "pipelineErrors": []
   },
   "src/components/ui/ScrollShadow.tsx": {
     "success": 2,
     "skip": 0,
     "error": 0,
-    "pipeline": 0
+    "pipeline": 0,
+    "errorBailouts": [],
+    "skipReasons": [],
+    "pipelineErrors": []
   },
   "src/components/ui/SearchablePalette.tsx": {
     "success": 1,
     "skip": 0,
     "error": 0,
-    "pipeline": 0
+    "pipeline": 0,
+    "errorBailouts": [],
+    "skipReasons": [],
+    "pipelineErrors": []
   },
   "src/components/ui/ShortcutHint.tsx": {
     "success": 1,
     "skip": 0,
     "error": 0,
-    "pipeline": 0
+    "pipeline": 0,
+    "errorBailouts": [],
+    "skipReasons": [],
+    "pipelineErrors": []
   },
   "src/components/ui/ShortcutRevealChip.tsx": {
     "success": 1,
     "skip": 0,
     "error": 0,
-    "pipeline": 0
+    "pipeline": 0,
+    "errorBailouts": [],
+    "skipReasons": [],
+    "pipelineErrors": []
   },
   "src/components/ui/Skeleton.tsx": {
     "success": 4,
     "skip": 0,
     "error": 0,
-    "pipeline": 0
+    "pipeline": 0,
+    "errorBailouts": [],
+    "skipReasons": [],
+    "pipelineErrors": []
   },
   "src/components/ui/Spinner.tsx": {
     "success": 1,
     "skip": 0,
     "error": 0,
-    "pipeline": 0
+    "pipeline": 0,
+    "errorBailouts": [],
+    "skipReasons": [],
+    "pipelineErrors": []
   },
   "src/components/ui/TruncatedTooltip.tsx": {
     "success": 1,
     "skip": 0,
     "error": 0,
-    "pipeline": 0
+    "pipeline": 0,
+    "errorBailouts": [],
+    "skipReasons": [],
+    "pipelineErrors": []
   },
   "src/components/ui/button.tsx": {
     "success": 1,
     "skip": 0,
     "error": 0,
-    "pipeline": 0
+    "pipeline": 0,
+    "errorBailouts": [],
+    "skipReasons": [],
+    "pipelineErrors": []
   },
   "src/components/ui/context-menu.tsx": {
     "success": 9,
     "skip": 0,
     "error": 0,
-    "pipeline": 0
+    "pipeline": 0,
+    "errorBailouts": [],
+    "skipReasons": [],
+    "pipelineErrors": []
   },
   "src/components/ui/dropdown-menu.tsx": {
     "success": 9,
     "skip": 0,
     "error": 0,
-    "pipeline": 0
+    "pipeline": 0,
+    "errorBailouts": [],
+    "skipReasons": [],
+    "pipelineErrors": []
   },
   "src/components/ui/emoji-picker.tsx": {
     "success": 1,
     "skip": 0,
     "error": 0,
-    "pipeline": 0
+    "pipeline": 0,
+    "errorBailouts": [],
+    "skipReasons": [],
+    "pipelineErrors": []
   },
   "src/components/ui/fixed-dropdown.tsx": {
     "success": 1,
     "skip": 0,
     "error": 0,
-    "pipeline": 0
+    "pipeline": 0,
+    "errorBailouts": [],
+    "skipReasons": [],
+    "pipelineErrors": []
   },
   "src/components/ui/popover.tsx": {
     "success": 1,
     "skip": 0,
     "error": 0,
-    "pipeline": 0
+    "pipeline": 0,
+    "errorBailouts": [],
+    "skipReasons": [],
+    "pipelineErrors": []
   },
   "src/components/ui/select.tsx": {
     "success": 7,
     "skip": 0,
     "error": 0,
-    "pipeline": 0
+    "pipeline": 0,
+    "errorBailouts": [],
+    "skipReasons": [],
+    "pipelineErrors": []
   },
   "src/components/ui/toaster.tsx": {
     "success": 2,
     "skip": 0,
     "error": 1,
-    "pipeline": 0
+    "pipeline": 0,
+    "errorBailouts": [
+      {
+        "category": "Todo",
+        "reason": "Support value blocks (conditional, logical, optional chaining, etc) within a try/catch statement"
+      }
+    ],
+    "skipReasons": [],
+    "pipelineErrors": []
   },
   "src/components/ui/tooltip.tsx": {
     "success": 1,
     "skip": 0,
     "error": 0,
-    "pipeline": 0
+    "pipeline": 0,
+    "errorBailouts": [],
+    "skipReasons": [],
+    "pipelineErrors": []
   },
   "src/contexts/WorktreeStoreContext.tsx": {
     "success": 0,
     "skip": 0,
     "error": 2,
-    "pipeline": 0
+    "pipeline": 0,
+    "errorBailouts": [
+      {
+        "category": "Todo",
+        "reason": "(BuildHIR::lowerExpression) Handle UpdateExpression to variables captured within lambdas."
+      },
+      {
+        "category": "Todo",
+        "reason": "(BuildHIR::lowerExpression) Handle UpdateExpression to variables captured within lambdas."
+      }
+    ],
+    "skipReasons": [],
+    "pipelineErrors": []
   },
   "src/hooks/app/useAccessibilityAnnouncements.ts": {
     "success": 1,
     "skip": 0,
     "error": 0,
-    "pipeline": 0
+    "pipeline": 0,
+    "errorBailouts": [],
+    "skipReasons": [],
+    "pipelineErrors": []
   },
   "src/hooks/app/useActiveWorktreeSync.ts": {
     "success": 1,
     "skip": 0,
     "error": 0,
-    "pipeline": 0
+    "pipeline": 0,
+    "errorBailouts": [],
+    "skipReasons": [],
+    "pipelineErrors": []
   },
   "src/hooks/app/useAgentDiscoveryOnboarding.ts": {
     "success": 1,
     "skip": 0,
     "error": 0,
-    "pipeline": 0
+    "pipeline": 0,
+    "errorBailouts": [],
+    "skipReasons": [],
+    "pipelineErrors": []
   },
   "src/hooks/app/useAgentWaitingNudge.ts": {
     "success": 0,
     "skip": 0,
     "error": 1,
-    "pipeline": 0
+    "pipeline": 0,
+    "errorBailouts": [
+      {
+        "category": "Todo",
+        "reason": "Support value blocks (conditional, logical, optional chaining, etc) within a try/catch statement"
+      }
+    ],
+    "skipReasons": [],
+    "pipelineErrors": []
   },
   "src/hooks/app/useAppEventListeners.ts": {
     "success": 1,
     "skip": 0,
     "error": 0,
-    "pipeline": 0
+    "pipeline": 0,
+    "errorBailouts": [],
+    "skipReasons": [],
+    "pipelineErrors": []
   },
   "src/hooks/app/useAppHydration.ts": {
     "success": 0,
     "skip": 0,
     "error": 1,
-    "pipeline": 0
+    "pipeline": 0,
+    "errorBailouts": [
+      {
+        "category": "Todo",
+        "reason": "(BuildHIR::lowerStatement) Handle TryStatement with a finalizer ('finally') clause"
+      }
+    ],
+    "skipReasons": [],
+    "pipelineErrors": []
   },
   "src/hooks/app/useCloudSyncWarning.tsx": {
     "success": 1,
     "skip": 0,
     "error": 0,
-    "pipeline": 0
+    "pipeline": 0,
+    "errorBailouts": [],
+    "skipReasons": [],
+    "pipelineErrors": []
   },
   "src/hooks/app/useCrashRecoveryGate.ts": {
     "success": 1,
     "skip": 0,
     "error": 0,
-    "pipeline": 0
+    "pipeline": 0,
+    "errorBailouts": [],
+    "skipReasons": [],
+    "pipelineErrors": []
   },
   "src/hooks/app/useErrorRetry.ts": {
     "success": 0,
     "skip": 0,
     "error": 1,
-    "pipeline": 0
+    "pipeline": 0,
+    "errorBailouts": [
+      {
+        "category": "Todo",
+        "reason": "(BuildHIR::lowerStatement) Handle TryStatement with a finalizer ('finally') clause"
+      }
+    ],
+    "skipReasons": [],
+    "pipelineErrors": []
   },
   "src/hooks/app/useGettingStartedChecklist.ts": {
     "success": 1,
     "skip": 0,
     "error": 0,
-    "pipeline": 0
+    "pipeline": 0,
+    "errorBailouts": [],
+    "skipReasons": [],
+    "pipelineErrors": []
   },
   "src/hooks/app/useHomeDir.ts": {
     "success": 1,
     "skip": 0,
     "error": 0,
-    "pipeline": 0
+    "pipeline": 0,
+    "errorBailouts": [],
+    "skipReasons": [],
+    "pipelineErrors": []
   },
   "src/hooks/app/useOrchestrationMilestones.ts": {
     "success": 1,
     "skip": 0,
     "error": 0,
-    "pipeline": 0
+    "pipeline": 0,
+    "errorBailouts": [],
+    "skipReasons": [],
+    "pipelineErrors": []
   },
   "src/hooks/app/usePanelStoreBootstrap.ts": {
     "success": 1,
     "skip": 0,
     "error": 0,
-    "pipeline": 0
+    "pipeline": 0,
+    "errorBailouts": [],
+    "skipReasons": [],
+    "pipelineErrors": []
   },
   "src/hooks/app/usePerformanceMonitors.ts": {
     "success": 1,
     "skip": 0,
     "error": 0,
-    "pipeline": 0
+    "pipeline": 0,
+    "errorBailouts": [],
+    "skipReasons": [],
+    "pipelineErrors": []
   },
   "src/hooks/app/useSemanticWorkerLifecycle.ts": {
     "success": 1,
     "skip": 0,
     "error": 0,
-    "pipeline": 0
+    "pipeline": 0,
+    "errorBailouts": [],
+    "skipReasons": [],
+    "pipelineErrors": []
   },
   "src/hooks/app/useSettingsDialog.ts": {
     "success": 1,
     "skip": 0,
     "error": 0,
-    "pipeline": 0
+    "pipeline": 0,
+    "errorBailouts": [],
+    "skipReasons": [],
+    "pipelineErrors": []
   },
   "src/hooks/app/useShortcutHints.ts": {
     "success": 1,
     "skip": 0,
     "error": 0,
-    "pipeline": 0
+    "pipeline": 0,
+    "errorBailouts": [],
+    "skipReasons": [],
+    "pipelineErrors": []
   },
   "src/hooks/app/useSystemWakeHandler.ts": {
     "success": 1,
     "skip": 0,
     "error": 0,
-    "pipeline": 0
+    "pipeline": 0,
+    "errorBailouts": [],
+    "skipReasons": [],
+    "pipelineErrors": []
   },
   "src/hooks/app/useThemeBrowserSettingsBridge.ts": {
     "success": 1,
     "skip": 0,
     "error": 0,
-    "pipeline": 0
+    "pipeline": 0,
+    "errorBailouts": [],
+    "skipReasons": [],
+    "pipelineErrors": []
   },
   "src/hooks/app/useWorktreeOverview.ts": {
     "success": 1,
     "skip": 0,
     "error": 0,
-    "pipeline": 0
+    "pipeline": 0,
+    "errorBailouts": [],
+    "skipReasons": [],
+    "pipelineErrors": []
   },
   "src/hooks/useActionPalette.ts": {
     "success": 1,
     "skip": 0,
     "error": 0,
-    "pipeline": 0
+    "pipeline": 0,
+    "errorBailouts": [],
+    "skipReasons": [],
+    "pipelineErrors": []
   },
   "src/hooks/useActionRegistry.ts": {
     "success": 1,
     "skip": 0,
     "error": 0,
-    "pipeline": 0
+    "pipeline": 0,
+    "errorBailouts": [],
+    "skipReasons": [],
+    "pipelineErrors": []
   },
   "src/hooks/useActiveAppScheme.ts": {
     "success": 1,
     "skip": 0,
     "error": 0,
-    "pipeline": 0
+    "pipeline": 0,
+    "errorBailouts": [],
+    "skipReasons": [],
+    "pipelineErrors": []
   },
   "src/hooks/useAgentLauncher.ts": {
     "success": 0,
     "skip": 0,
     "error": 1,
-    "pipeline": 0
+    "pipeline": 0,
+    "errorBailouts": [
+      {
+        "category": "Todo",
+        "reason": "(BuildHIR::lowerStatement) Handle TryStatement without a catch clause"
+      }
+    ],
+    "skipReasons": [],
+    "pipelineErrors": []
   },
   "src/hooks/useAnimatedPresence.ts": {
     "success": 1,
     "skip": 0,
     "error": 0,
-    "pipeline": 0
+    "pipeline": 0,
+    "errorBailouts": [],
+    "skipReasons": [],
+    "pipelineErrors": []
   },
   "src/hooks/useAppThemeConfig.ts": {
     "success": 1,
     "skip": 0,
     "error": 0,
-    "pipeline": 0
+    "pipeline": 0,
+    "errorBailouts": [],
+    "skipReasons": [],
+    "pipelineErrors": []
   },
   "src/hooks/useArtifacts.ts": {
     "success": 0,
     "skip": 0,
     "error": 8,
-    "pipeline": 0
+    "pipeline": 0,
+    "errorBailouts": [
+      {
+        "category": "Todo",
+        "reason": "(BuildHIR::lowerStatement) Handle TryStatement with a finalizer ('finally') clause"
+      },
+      {
+        "category": "Todo",
+        "reason": "(BuildHIR::lowerStatement) Handle TryStatement with a finalizer ('finally') clause"
+      },
+      {
+        "category": "Todo",
+        "reason": "(BuildHIR::lowerStatement) Support ThrowStatement inside of try/catch"
+      },
+      {
+        "category": "Todo",
+        "reason": "(BuildHIR::lowerStatement) Handle TryStatement with a finalizer ('finally') clause"
+      },
+      {
+        "category": "Todo",
+        "reason": "(BuildHIR::lowerStatement) Support ThrowStatement inside of try/catch"
+      },
+      {
+        "category": "Todo",
+        "reason": "(BuildHIR::lowerStatement) Handle TryStatement with a finalizer ('finally') clause"
+      },
+      {
+        "category": "Todo",
+        "reason": "(BuildHIR::lowerStatement) Handle TryStatement without a catch clause"
+      },
+      {
+        "category": "Todo",
+        "reason": "(BuildHIR::lowerStatement) Handle TryStatement without a catch clause"
+      }
+    ],
+    "skipReasons": [],
+    "pipelineErrors": []
   },
   "src/hooks/useBranchForPath.ts": {
     "success": 1,
     "skip": 0,
     "error": 0,
-    "pipeline": 0
+    "pipeline": 0,
+    "errorBailouts": [],
+    "skipReasons": [],
+    "pipelineErrors": []
   },
   "src/hooks/useBrowserActionListeners.ts": {
     "success": 1,
     "skip": 0,
     "error": 0,
-    "pipeline": 0
+    "pipeline": 0,
+    "errorBailouts": [],
+    "skipReasons": [],
+    "pipelineErrors": []
   },
   "src/hooks/useCcrPresetsSubscription.ts": {
     "success": 0,
     "skip": 0,
     "error": 1,
-    "pipeline": 0
+    "pipeline": 0,
+    "errorBailouts": [
+      {
+        "category": "Todo",
+        "reason": "Support value blocks (conditional, logical, optional chaining, etc) within a try/catch statement"
+      }
+    ],
+    "skipReasons": [],
+    "pipelineErrors": []
   },
   "src/hooks/useConnectivity.ts": {
     "success": 2,
     "skip": 0,
     "error": 0,
-    "pipeline": 0
+    "pipeline": 0,
+    "errorBailouts": [],
+    "skipReasons": [],
+    "pipelineErrors": []
   },
   "src/hooks/useContextInjection.ts": {
     "success": 0,
     "skip": 0,
     "error": 3,
-    "pipeline": 0
+    "pipeline": 0,
+    "errorBailouts": [
+      {
+        "category": "Todo",
+        "reason": "(BuildHIR::lowerStatement) Handle TryStatement with a finalizer ('finally') clause"
+      },
+      {
+        "category": "Todo",
+        "reason": "(BuildHIR::lowerStatement) Support ThrowStatement inside of try/catch"
+      },
+      {
+        "category": "Todo",
+        "reason": "(BuildHIR::lowerStatement) Support ThrowStatement inside of try/catch"
+      }
+    ],
+    "skipReasons": [],
+    "pipelineErrors": []
+  },
+  "src/hooks/useCopyWithFeedback.ts": {
+    "success": 1,
+    "skip": 0,
+    "error": 0,
+    "pipeline": 0,
+    "errorBailouts": [],
+    "skipReasons": [],
+    "pipelineErrors": []
   },
   "src/hooks/useDebounce.ts": {
     "success": 1,
     "skip": 0,
     "error": 0,
-    "pipeline": 0
+    "pipeline": 0,
+    "errorBailouts": [],
+    "skipReasons": [],
+    "pipelineErrors": []
   },
   "src/hooks/useDeferredLoading.ts": {
     "success": 1,
     "skip": 0,
     "error": 0,
-    "pipeline": 0
+    "pipeline": 0,
+    "errorBailouts": [],
+    "skipReasons": [],
+    "pipelineErrors": []
   },
   "src/hooks/useDevServer.ts": {
     "success": 0,
     "skip": 0,
     "error": 1,
-    "pipeline": 0
+    "pipeline": 0,
+    "errorBailouts": [
+      {
+        "category": "Todo",
+        "reason": "(BuildHIR::lowerStatement) Handle TryStatement with a finalizer ('finally') clause"
+      }
+    ],
+    "skipReasons": [],
+    "pipelineErrors": []
   },
   "src/hooks/useDiskSpaceWarnings.ts": {
     "success": 1,
     "skip": 0,
     "error": 0,
-    "pipeline": 0
+    "pipeline": 0,
+    "errorBailouts": [],
+    "skipReasons": [],
+    "pipelineErrors": []
   },
   "src/hooks/useDockRenderState.ts": {
     "success": 1,
     "skip": 0,
     "error": 0,
-    "pipeline": 0
+    "pipeline": 0,
+    "errorBailouts": [],
+    "skipReasons": [],
+    "pipelineErrors": []
   },
   "src/hooks/useDoubleShift.ts": {
     "success": 1,
     "skip": 0,
     "error": 0,
-    "pipeline": 0
+    "pipeline": 0,
+    "errorBailouts": [],
+    "skipReasons": [],
+    "pipelineErrors": []
   },
   "src/hooks/useErrors.ts": {
     "success": 0,
     "skip": 0,
     "error": 1,
-    "pipeline": 0
+    "pipeline": 0,
+    "errorBailouts": [
+      {
+        "category": "Todo",
+        "reason": "(BuildHIR::lowerStatement) Handle TryStatement with a finalizer ('finally') clause"
+      }
+    ],
+    "skipReasons": [],
+    "pipelineErrors": []
   },
   "src/hooks/useEscapeStack.ts": {
     "success": 1,
     "skip": 0,
     "error": 0,
-    "pipeline": 0
+    "pipeline": 0,
+    "errorBailouts": [],
+    "skipReasons": [],
+    "pipelineErrors": []
   },
   "src/hooks/useFileAutocomplete.ts": {
     "success": 2,
     "skip": 0,
     "error": 0,
-    "pipeline": 0
+    "pipeline": 0,
+    "errorBailouts": [],
+    "skipReasons": [],
+    "pipelineErrors": []
   },
   "src/hooks/useFileDropGuard.ts": {
     "success": 1,
     "skip": 0,
     "error": 0,
-    "pipeline": 0
+    "pipeline": 0,
+    "errorBailouts": [],
+    "skipReasons": [],
+    "pipelineErrors": []
   },
   "src/hooks/useFindInPage.ts": {
     "success": 1,
     "skip": 0,
     "error": 0,
-    "pipeline": 0
+    "pipeline": 0,
+    "errorBailouts": [],
+    "skipReasons": [],
+    "pipelineErrors": []
   },
   "src/hooks/useFleetPicker.ts": {
     "success": 0,
     "skip": 0,
     "error": 4,
-    "pipeline": 0
+    "pipeline": 0,
+    "errorBailouts": [
+      {
+        "category": "Todo",
+        "reason": "(BuildHIR::lowerExpression) Support UpdateExpression where argument is a global"
+      },
+      {
+        "category": "Todo",
+        "reason": "(BuildHIR::lowerExpression) Support UpdateExpression where argument is a global"
+      },
+      {
+        "category": "Todo",
+        "reason": "(BuildHIR::lowerExpression) Support UpdateExpression where argument is a global"
+      },
+      {
+        "category": "Todo",
+        "reason": "(BuildHIR::lowerExpression) Support UpdateExpression where argument is a global"
+      }
+    ],
+    "skipReasons": [],
+    "pipelineErrors": []
+  },
+  "src/hooks/useFlushOnHide.ts": {
+    "success": 1,
+    "skip": 0,
+    "error": 0,
+    "pipeline": 0,
+    "errorBailouts": [],
+    "skipReasons": [],
+    "pipelineErrors": []
   },
   "src/hooks/useGitHubTokenExpiryNotification.ts": {
     "success": 1,
     "skip": 0,
     "error": 0,
-    "pipeline": 0
+    "pipeline": 0,
+    "errorBailouts": [],
+    "skipReasons": [],
+    "pipelineErrors": []
   },
   "src/hooks/useGitHubTokenHealth.ts": {
     "success": 1,
     "skip": 0,
     "error": 0,
-    "pipeline": 0
+    "pipeline": 0,
+    "errorBailouts": [],
+    "skipReasons": [],
+    "pipelineErrors": []
   },
   "src/hooks/useGitHubTooltip.ts": {
     "success": 0,
     "skip": 0,
     "error": 2,
-    "pipeline": 0
+    "pipeline": 0,
+    "errorBailouts": [
+      {
+        "category": "Todo",
+        "reason": "(BuildHIR::lowerStatement) Handle TryStatement with a finalizer ('finally') clause"
+      },
+      {
+        "category": "Todo",
+        "reason": "(BuildHIR::lowerStatement) Handle TryStatement with a finalizer ('finally') clause"
+      }
+    ],
+    "skipReasons": [],
+    "pipelineErrors": []
   },
   "src/hooks/useGlobalEscapeDispatcher.ts": {
     "success": 1,
     "skip": 0,
     "error": 0,
-    "pipeline": 0
+    "pipeline": 0,
+    "errorBailouts": [],
+    "skipReasons": [],
+    "pipelineErrors": []
   },
   "src/hooks/useGlobalKeybindings.ts": {
     "success": 2,
     "skip": 0,
     "error": 0,
-    "pipeline": 0
+    "pipeline": 0,
+    "errorBailouts": [],
+    "skipReasons": [],
+    "pipelineErrors": []
   },
   "src/hooks/useGlobalMinuteTicker.ts": {
     "success": 1,
     "skip": 0,
     "error": 0,
-    "pipeline": 0
+    "pipeline": 0,
+    "errorBailouts": [],
+    "skipReasons": [],
+    "pipelineErrors": []
   },
   "src/hooks/useGlobalSecondTicker.ts": {
     "success": 1,
     "skip": 0,
     "error": 0,
-    "pipeline": 0
+    "pipeline": 0,
+    "errorBailouts": [],
+    "skipReasons": [],
+    "pipelineErrors": []
   },
   "src/hooks/useGridNavigation.ts": {
     "success": 0,
     "skip": 0,
     "error": 1,
-    "pipeline": 0
+    "pipeline": 0,
+    "errorBailouts": [
+      {
+        "category": "Refs",
+        "reason": "Cannot access refs during render"
+      }
+    ],
+    "skipReasons": [],
+    "pipelineErrors": []
   },
   "src/hooks/useHasBeenVisible.ts": {
     "success": 1,
     "skip": 0,
     "error": 0,
-    "pipeline": 0
+    "pipeline": 0,
+    "errorBailouts": [],
+    "skipReasons": [],
+    "pipelineErrors": []
   },
   "src/hooks/useHeldShortcutReveal.ts": {
     "success": 1,
     "skip": 0,
     "error": 0,
-    "pipeline": 0
+    "pipeline": 0,
+    "errorBailouts": [],
+    "skipReasons": [],
+    "pipelineErrors": []
   },
   "src/hooks/useHibernationNotifications.ts": {
     "success": 1,
     "skip": 0,
     "error": 0,
-    "pipeline": 0
+    "pipeline": 0,
+    "errorBailouts": [],
+    "skipReasons": [],
+    "pipelineErrors": []
   },
   "src/hooks/useHorizontalScrollControls.ts": {
     "success": 1,
     "skip": 0,
     "error": 0,
-    "pipeline": 0
+    "pipeline": 0,
+    "errorBailouts": [],
+    "skipReasons": [],
+    "pipelineErrors": []
   },
   "src/hooks/useIdleTerminalNotifications.ts": {
     "success": 1,
     "skip": 0,
     "error": 0,
-    "pipeline": 0
+    "pipeline": 0,
+    "errorBailouts": [],
+    "skipReasons": [],
+    "pipelineErrors": []
+  },
+  "src/hooks/useImageError.ts": {
+    "success": 1,
+    "skip": 0,
+    "error": 0,
+    "pipeline": 0,
+    "errorBailouts": [],
+    "skipReasons": [],
+    "pipelineErrors": []
   },
   "src/hooks/useIssueSelection.ts": {
     "success": 1,
     "skip": 0,
     "error": 0,
-    "pipeline": 0
+    "pipeline": 0,
+    "errorBailouts": [],
+    "skipReasons": [],
+    "pipelineErrors": []
   },
   "src/hooks/useKeybinding.ts": {
-    "success": 3,
+    "success": 4,
     "skip": 0,
     "error": 0,
-    "pipeline": 0
+    "pipeline": 0,
+    "errorBailouts": [],
+    "skipReasons": [],
+    "pipelineErrors": []
   },
   "src/hooks/useLayoutState.ts": {
     "success": 1,
     "skip": 0,
     "error": 0,
-    "pipeline": 0
+    "pipeline": 0,
+    "errorBailouts": [],
+    "skipReasons": [],
+    "pipelineErrors": []
   },
   "src/hooks/useMainProcessToastListener.ts": {
     "success": 1,
     "skip": 0,
     "error": 0,
-    "pipeline": 0
+    "pipeline": 0,
+    "errorBailouts": [],
+    "skipReasons": [],
+    "pipelineErrors": []
   },
   "src/hooks/useMcpBridge.ts": {
     "success": 0,
     "skip": 0,
     "error": 1,
-    "pipeline": 0
+    "pipeline": 0,
+    "errorBailouts": [
+      {
+        "category": "Todo",
+        "reason": "(BuildHIR::lowerStatement) Handle TryStatement without a catch clause"
+      }
+    ],
+    "skipReasons": [],
+    "pipelineErrors": []
   },
   "src/hooks/useMcpReadiness.ts": {
     "success": 1,
     "skip": 0,
     "error": 0,
-    "pipeline": 0
+    "pipeline": 0,
+    "errorBailouts": [],
+    "skipReasons": [],
+    "pipelineErrors": []
   },
   "src/hooks/useMemoryLeakDetection.ts": {
     "success": 1,
     "skip": 0,
     "error": 0,
-    "pipeline": 0
+    "pipeline": 0,
+    "errorBailouts": [],
+    "skipReasons": [],
+    "pipelineErrors": []
   },
   "src/hooks/useMenuActions.ts": {
     "success": 1,
     "skip": 0,
     "error": 0,
-    "pipeline": 0
+    "pipeline": 0,
+    "errorBailouts": [],
+    "skipReasons": [],
+    "pipelineErrors": []
   },
   "src/hooks/useModifierKeys.ts": {
     "success": 1,
     "skip": 0,
     "error": 0,
-    "pipeline": 0
+    "pipeline": 0,
+    "errorBailouts": [],
+    "skipReasons": [],
+    "pipelineErrors": []
   },
   "src/hooks/useNewTerminalPalette.ts": {
     "success": 0,
     "skip": 0,
     "error": 1,
-    "pipeline": 0
+    "pipeline": 0,
+    "errorBailouts": [
+      {
+        "category": "Todo",
+        "reason": "Support value blocks (conditional, logical, optional chaining, etc) within a try/catch statement"
+      }
+    ],
+    "skipReasons": [],
+    "pipelineErrors": []
   },
   "src/hooks/useOverlayState.ts": {
     "success": 2,
     "skip": 0,
     "error": 0,
-    "pipeline": 0
+    "pipeline": 0,
+    "errorBailouts": [],
+    "skipReasons": [],
+    "pipelineErrors": []
   },
   "src/hooks/usePanelHandlers.ts": {
     "success": 0,
     "skip": 0,
     "error": 1,
-    "pipeline": 0
+    "pipeline": 0,
+    "errorBailouts": [
+      {
+        "category": "Todo",
+        "reason": "(BuildHIR::lowerStatement) Handle TryStatement with a finalizer ('finally') clause"
+      }
+    ],
+    "skipReasons": [],
+    "pipelineErrors": []
   },
   "src/hooks/usePanelLifecycle.ts": {
     "success": 1,
     "skip": 0,
     "error": 0,
-    "pipeline": 0
+    "pipeline": 0,
+    "errorBailouts": [],
+    "skipReasons": [],
+    "pipelineErrors": []
   },
   "src/hooks/usePanelPalette.ts": {
     "success": 1,
     "skip": 0,
     "error": 0,
-    "pipeline": 0
+    "pipeline": 0,
+    "errorBailouts": [],
+    "skipReasons": [],
+    "pipelineErrors": []
   },
   "src/hooks/usePlanFileContent.ts": {
     "success": 0,
     "skip": 0,
     "error": 1,
-    "pipeline": 0
+    "pipeline": 0,
+    "errorBailouts": [
+      {
+        "category": "Todo",
+        "reason": "Support value blocks (conditional, logical, optional chaining, etc) within a try/catch statement"
+      }
+    ],
+    "skipReasons": [],
+    "pipelineErrors": []
   },
   "src/hooks/usePluginActions.ts": {
     "success": 1,
     "skip": 0,
     "error": 0,
-    "pipeline": 0
+    "pipeline": 0,
+    "errorBailouts": [],
+    "skipReasons": [],
+    "pipelineErrors": []
   },
   "src/hooks/usePluginPanelKinds.ts": {
     "success": 1,
     "skip": 0,
     "error": 0,
-    "pipeline": 0
+    "pipeline": 0,
+    "errorBailouts": [],
+    "skipReasons": [],
+    "pipelineErrors": []
   },
   "src/hooks/usePluginToolbarButtons.ts": {
     "success": 1,
     "skip": 0,
     "error": 0,
-    "pipeline": 0
+    "pipeline": 0,
+    "errorBailouts": [],
+    "skipReasons": [],
+    "pipelineErrors": []
   },
   "src/hooks/useProjectBranding.ts": {
     "success": 1,
     "skip": 0,
     "error": 0,
-    "pipeline": 0
+    "pipeline": 0,
+    "errorBailouts": [],
+    "skipReasons": [],
+    "pipelineErrors": []
   },
   "src/hooks/useProjectHealth.ts": {
     "success": 0,
     "skip": 0,
     "error": 1,
-    "pipeline": 0
+    "pipeline": 0,
+    "errorBailouts": [
+      {
+        "category": "Todo",
+        "reason": "(BuildHIR::lowerStatement) Handle TryStatement with a finalizer ('finally') clause"
+      }
+    ],
+    "skipReasons": [],
+    "pipelineErrors": []
   },
   "src/hooks/useProjectMruSwitcher.ts": {
     "success": 1,
     "skip": 0,
     "error": 0,
-    "pipeline": 0
+    "pipeline": 0,
+    "errorBailouts": [],
+    "skipReasons": [],
+    "pipelineErrors": []
   },
   "src/hooks/useProjectPresetsSubscription.ts": {
     "success": 1,
     "skip": 0,
     "error": 0,
-    "pipeline": 0
+    "pipeline": 0,
+    "errorBailouts": [],
+    "skipReasons": [],
+    "pipelineErrors": []
   },
   "src/hooks/useProjectSettings.ts": {
     "success": 0,
     "skip": 0,
     "error": 1,
-    "pipeline": 0
+    "pipeline": 0,
+    "errorBailouts": [
+      {
+        "category": "Todo",
+        "reason": "(BuildHIR::lowerStatement) Handle TryStatement with a finalizer ('finally') clause"
+      }
+    ],
+    "skipReasons": [],
+    "pipelineErrors": []
   },
   "src/hooks/useProjectSettingsForm.ts": {
     "success": 0,
     "skip": 0,
     "error": 1,
-    "pipeline": 0
+    "pipeline": 0,
+    "errorBailouts": [
+      {
+        "category": "Todo",
+        "reason": "Support value blocks (conditional, logical, optional chaining, etc) within a try/catch statement"
+      }
+    ],
+    "skipReasons": [],
+    "pipelineErrors": []
   },
   "src/hooks/useProjectSwitcherPalette.ts": {
     "success": 0,
     "skip": 0,
-    "error": 2,
-    "pipeline": 0
+    "error": 3,
+    "pipeline": 0,
+    "errorBailouts": [
+      {
+        "category": "Todo",
+        "reason": "(BuildHIR::lowerStatement) Handle TryStatement with a finalizer ('finally') clause"
+      },
+      {
+        "category": "Todo",
+        "reason": "(BuildHIR::lowerStatement) Handle TryStatement with a finalizer ('finally') clause"
+      },
+      {
+        "category": "Todo",
+        "reason": "(BuildHIR::lowerStatement) Handle TryStatement with a finalizer ('finally') clause"
+      }
+    ],
+    "skipReasons": [],
+    "pipelineErrors": []
   },
   "src/hooks/usePromptHistoryPalette.ts": {
     "success": 1,
     "skip": 0,
     "error": 0,
-    "pipeline": 0
+    "pipeline": 0,
+    "errorBailouts": [],
+    "skipReasons": [],
+    "pipelineErrors": []
   },
   "src/hooks/useQuickCreatePalette.ts": {
     "success": 0,
     "skip": 0,
     "error": 1,
-    "pipeline": 0
+    "pipeline": 0,
+    "errorBailouts": [
+      {
+        "category": "Todo",
+        "reason": "(BuildHIR::lowerStatement) Handle TryStatement with a finalizer ('finally') clause"
+      }
+    ],
+    "skipReasons": [],
+    "pipelineErrors": []
   },
   "src/hooks/useQuickSwitcher.ts": {
     "success": 1,
     "skip": 0,
     "error": 0,
-    "pipeline": 0
+    "pipeline": 0,
+    "errorBailouts": [],
+    "skipReasons": [],
+    "pipelineErrors": []
   },
   "src/hooks/useReEntrySummary.ts": {
     "success": 1,
     "skip": 0,
     "error": 0,
-    "pipeline": 0
+    "pipeline": 0,
+    "errorBailouts": [],
+    "skipReasons": [],
+    "pipelineErrors": []
   },
   "src/hooks/useRepositoryStats.ts": {
     "success": 0,
     "skip": 0,
     "error": 1,
-    "pipeline": 0
+    "pipeline": 0,
+    "errorBailouts": [
+      {
+        "category": "Todo",
+        "reason": "(BuildHIR::lowerStatement) Handle TryStatement with a finalizer ('finally') clause"
+      }
+    ],
+    "skipReasons": [],
+    "pipelineErrors": []
+  },
+  "src/hooks/useResizeObserverRaf.ts": {
+    "success": 1,
+    "skip": 0,
+    "error": 0,
+    "pipeline": 0,
+    "errorBailouts": [],
+    "skipReasons": [],
+    "pipelineErrors": []
   },
   "src/hooks/useResourceProfile.ts": {
     "success": 1,
     "skip": 0,
     "error": 0,
-    "pipeline": 0
+    "pipeline": 0,
+    "errorBailouts": [],
+    "skipReasons": [],
+    "pipelineErrors": []
   },
   "src/hooks/useSearchablePalette.ts": {
     "success": 1,
     "skip": 0,
     "error": 0,
-    "pipeline": 0
+    "pipeline": 0,
+    "errorBailouts": [],
+    "skipReasons": [],
+    "pipelineErrors": []
   },
   "src/hooks/useSendToAgentPalette.ts": {
     "success": 1,
     "skip": 0,
     "error": 0,
-    "pipeline": 0
+    "pipeline": 0,
+    "errorBailouts": [],
+    "skipReasons": [],
+    "pipelineErrors": []
   },
   "src/hooks/useShortcutHintHover.ts": {
     "success": 1,
     "skip": 0,
     "error": 0,
-    "pipeline": 0
+    "pipeline": 0,
+    "errorBailouts": [],
+    "skipReasons": [],
+    "pipelineErrors": []
   },
   "src/hooks/useSlashCommandAutocomplete.ts": {
     "success": 1,
     "skip": 0,
     "error": 0,
-    "pipeline": 0
+    "pipeline": 0,
+    "errorBailouts": [],
+    "skipReasons": [],
+    "pipelineErrors": []
   },
   "src/hooks/useSlashCommandList.ts": {
     "success": 1,
     "skip": 0,
     "error": 0,
-    "pipeline": 0
+    "pipeline": 0,
+    "errorBailouts": [],
+    "skipReasons": [],
+    "pipelineErrors": []
   },
   "src/hooks/useSlowCall.ts": {
     "success": 1,
     "skip": 0,
     "error": 0,
-    "pipeline": 0
+    "pipeline": 0,
+    "errorBailouts": [],
+    "skipReasons": [],
+    "pipelineErrors": []
   },
   "src/hooks/useSoundPlaybackListener.ts": {
     "success": 1,
     "skip": 0,
     "error": 0,
-    "pipeline": 0
+    "pipeline": 0,
+    "errorBailouts": [],
+    "skipReasons": [],
+    "pipelineErrors": []
   },
   "src/hooks/useTabOverflow.ts": {
     "success": 1,
     "skip": 0,
     "error": 0,
-    "pipeline": 0
+    "pipeline": 0,
+    "errorBailouts": [],
+    "skipReasons": [],
+    "pipelineErrors": []
   },
   "src/hooks/useTerminalAppearance.ts": {
     "success": 1,
     "skip": 0,
     "error": 0,
-    "pipeline": 0
+    "pipeline": 0,
+    "errorBailouts": [],
+    "skipReasons": [],
+    "pipelineErrors": []
   },
   "src/hooks/useTerminalConfig.ts": {
     "success": 1,
     "skip": 0,
     "error": 0,
-    "pipeline": 0
+    "pipeline": 0,
+    "errorBailouts": [],
+    "skipReasons": [],
+    "pipelineErrors": []
   },
   "src/hooks/useTerminalLogic.ts": {
     "success": 0,
     "skip": 0,
     "error": 1,
-    "pipeline": 0
+    "pipeline": 0,
+    "errorBailouts": [
+      {
+        "category": "Todo",
+        "reason": "(BuildHIR::lowerStatement) Handle TryStatement with a finalizer ('finally') clause"
+      }
+    ],
+    "skipReasons": [],
+    "pipelineErrors": []
   },
   "src/hooks/useTerminalSelectors.ts": {
     "success": 7,
     "skip": 0,
     "error": 0,
-    "pipeline": 0
+    "pipeline": 0,
+    "errorBailouts": [],
+    "skipReasons": [],
+    "pipelineErrors": []
   },
   "src/hooks/useToolbarOverflow.ts": {
     "success": 1,
     "skip": 0,
     "error": 0,
-    "pipeline": 0
+    "pipeline": 0,
+    "errorBailouts": [],
+    "skipReasons": [],
+    "pipelineErrors": []
   },
   "src/hooks/useTruncationDetection.ts": {
     "success": 1,
     "skip": 0,
     "error": 0,
-    "pipeline": 0
+    "pipeline": 0,
+    "errorBailouts": [],
+    "skipReasons": [],
+    "pipelineErrors": []
   },
   "src/hooks/useUnsavedChanges.ts": {
     "success": 1,
     "skip": 0,
     "error": 0,
-    "pipeline": 0
+    "pipeline": 0,
+    "errorBailouts": [],
+    "skipReasons": [],
+    "pipelineErrors": []
   },
   "src/hooks/useUnseenOutput.ts": {
     "success": 1,
     "skip": 0,
     "error": 0,
-    "pipeline": 0
+    "pipeline": 0,
+    "errorBailouts": [],
+    "skipReasons": [],
+    "pipelineErrors": []
   },
   "src/hooks/useUpdateListener.tsx": {
     "success": 2,
     "skip": 0,
     "error": 0,
-    "pipeline": 0
+    "pipeline": 0,
+    "errorBailouts": [],
+    "skipReasons": [],
+    "pipelineErrors": []
   },
   "src/hooks/useVerticalScrollShadows.ts": {
     "success": 1,
     "skip": 0,
     "error": 0,
-    "pipeline": 0
+    "pipeline": 0,
+    "errorBailouts": [],
+    "skipReasons": [],
+    "pipelineErrors": []
   },
   "src/hooks/useWatchedPanelNotifications.ts": {
     "success": 1,
     "skip": 0,
     "error": 0,
-    "pipeline": 0
+    "pipeline": 0,
+    "errorBailouts": [],
+    "skipReasons": [],
+    "pipelineErrors": []
   },
   "src/hooks/useWebviewDialog.ts": {
     "success": 1,
     "skip": 0,
     "error": 0,
-    "pipeline": 0
+    "pipeline": 0,
+    "errorBailouts": [],
+    "skipReasons": [],
+    "pipelineErrors": []
   },
   "src/hooks/useWebviewEvents.ts": {
     "success": 0,
     "skip": 0,
     "error": 1,
-    "pipeline": 0
+    "pipeline": 0,
+    "errorBailouts": [
+      {
+        "category": "Todo",
+        "reason": "Support value blocks (conditional, logical, optional chaining, etc) within a try/catch statement"
+      }
+    ],
+    "skipReasons": [],
+    "pipelineErrors": []
   },
   "src/hooks/useWebviewEviction.ts": {
     "success": 1,
     "skip": 0,
     "error": 0,
-    "pipeline": 0
+    "pipeline": 0,
+    "errorBailouts": [],
+    "skipReasons": [],
+    "pipelineErrors": []
   },
   "src/hooks/useWebviewThrottle.ts": {
     "success": 1,
     "skip": 0,
     "error": 0,
-    "pipeline": 0
+    "pipeline": 0,
+    "errorBailouts": [],
+    "skipReasons": [],
+    "pipelineErrors": []
   },
   "src/hooks/useWindowNotifications.ts": {
     "success": 1,
     "skip": 0,
     "error": 0,
-    "pipeline": 0
+    "pipeline": 0,
+    "errorBailouts": [],
+    "skipReasons": [],
+    "pipelineErrors": []
   },
   "src/hooks/useWorktreeActions.ts": {
     "success": 0,
     "skip": 0,
     "error": 1,
-    "pipeline": 0
+    "pipeline": 0,
+    "errorBailouts": [
+      {
+        "category": "Todo",
+        "reason": "(BuildHIR::lowerStatement) Support ThrowStatement inside of try/catch"
+      }
+    ],
+    "skipReasons": [],
+    "pipelineErrors": []
   },
   "src/hooks/useWorktreeColorMap.ts": {
     "success": 1,
     "skip": 0,
     "error": 0,
-    "pipeline": 0
+    "pipeline": 0,
+    "errorBailouts": [],
+    "skipReasons": [],
+    "pipelineErrors": []
   },
   "src/hooks/useWorktreePalette.ts": {
     "success": 1,
     "skip": 0,
     "error": 0,
-    "pipeline": 0
+    "pipeline": 0,
+    "errorBailouts": [],
+    "skipReasons": [],
+    "pipelineErrors": []
   },
   "src/hooks/useWorktreeStore.ts": {
     "success": 1,
     "skip": 0,
     "error": 0,
-    "pipeline": 0
+    "pipeline": 0,
+    "errorBailouts": [],
+    "skipReasons": [],
+    "pipelineErrors": []
   },
   "src/hooks/useWorktreeTerminals.ts": {
     "success": 2,
     "skip": 0,
     "error": 0,
-    "pipeline": 0
+    "pipeline": 0,
+    "errorBailouts": [],
+    "skipReasons": [],
+    "pipelineErrors": []
   },
   "src/hooks/useWorktrees.ts": {
     "success": 2,
     "skip": 0,
     "error": 0,
-    "pipeline": 0
+    "pipeline": 0,
+    "errorBailouts": [],
+    "skipReasons": [],
+    "pipelineErrors": []
   },
   "src/panels/registry.tsx": {
     "success": 2,
     "skip": 0,
     "error": 0,
-    "pipeline": 0
+    "pipeline": 0,
+    "errorBailouts": [],
+    "skipReasons": [],
+    "pipelineErrors": []
   },
   "src/store/worktreeFilterStore.ts": {
     "success": 1,
     "skip": 0,
     "error": 0,
-    "pipeline": 0
+    "pipeline": 0,
+    "errorBailouts": [],
+    "skipReasons": [],
+    "pipelineErrors": []
   },
   "src/utils/renderProfiler.ts": {
     "success": 1,
     "skip": 0,
     "error": 0,
-    "pipeline": 0
+    "pipeline": 0,
+    "errorBailouts": [],
+    "skipReasons": [],
+    "pipelineErrors": []
   }
 }

--- a/scripts/check-compiler-budget.mjs
+++ b/scripts/check-compiler-budget.mjs
@@ -79,12 +79,23 @@ function validateShape(data, label, file) {
 }
 
 function writeBaseline(report, { force }) {
-  // Sort keys deterministically so diffs stay clean across runs.
+  // Sort keys deterministically so diffs stay clean across runs. Preserve the
+  // diagnostic arrays alongside the gating counts — the explicit field list
+  // (no spread) prevents unintended propagation if the report shape gains
+  // future fields that aren't yet vetted for the baseline.
   const sorted = Object.keys(report)
     .sort()
     .reduce((acc, k) => {
       const e = report[k];
-      acc[k] = { success: e.success, skip: e.skip, error: e.error, pipeline: e.pipeline };
+      acc[k] = {
+        success: e.success,
+        skip: e.skip,
+        error: e.error,
+        pipeline: e.pipeline,
+        errorBailouts: Array.isArray(e.errorBailouts) ? e.errorBailouts : [],
+        skipReasons: Array.isArray(e.skipReasons) ? e.skipReasons : [],
+        pipelineErrors: Array.isArray(e.pipelineErrors) ? e.pipelineErrors : [],
+      };
       return acc;
     }, {});
 
@@ -221,6 +232,35 @@ function main() {
     const summary = deltas.map(({ key, from, to }) => `${key}: was ${from}, now ${to}`).join("; ");
     const prefix = isNew ? "new file with compiler bailouts" : "compiler bailout regression";
     console.error(`::error file=${file}::${prefix} (${summary})`);
+    // Surface the diagnostic detail captured by the plugin so failing runs
+    // point at the actual cause without re-running the build locally.
+    // Backward-compat: the report may pre-date the diagnostic arrays.
+    const entry = report[file];
+    const errorBailouts = Array.isArray(entry?.errorBailouts) ? entry.errorBailouts : [];
+    const skipReasons = Array.isArray(entry?.skipReasons) ? entry.skipReasons : [];
+    const pipelineErrors = Array.isArray(entry?.pipelineErrors) ? entry.pipelineErrors : [];
+    if (errorBailouts.length > 0) {
+      const grouped = new Map();
+      for (const { category, reason } of errorBailouts) {
+        const key = category || "(unknown)";
+        if (!grouped.has(key)) grouped.set(key, []);
+        grouped.get(key).push(reason);
+      }
+      for (const [category, reasons] of grouped) {
+        const sample = reasons[0];
+        const more = reasons.length > 1 ? ` (+${reasons.length - 1} more)` : "";
+        console.error(`   error[${category}]: ${sample}${more}`);
+      }
+    }
+    if (skipReasons.length > 0) {
+      const unique = [...new Set(skipReasons)];
+      const sample = unique[0];
+      const more = skipReasons.length > 1 ? ` (×${skipReasons.length})` : "";
+      console.error(`   skip: ${sample}${more}`);
+    }
+    if (pipelineErrors.length > 0) {
+      console.error(`   pipeline: ${pipelineErrors[0]}`);
+    }
   }
   for (const file of disappeared) {
     console.error(

--- a/scripts/check-compiler-budget.mjs
+++ b/scripts/check-compiler-budget.mjs
@@ -241,10 +241,11 @@ function main() {
     const pipelineErrors = Array.isArray(entry?.pipelineErrors) ? entry.pipelineErrors : [];
     if (errorBailouts.length > 0) {
       const grouped = new Map();
-      for (const { category, reason } of errorBailouts) {
-        const key = category || "(unknown)";
+      for (const item of errorBailouts) {
+        if (!item || typeof item !== "object") continue;
+        const key = item.category || "(unknown)";
         if (!grouped.has(key)) grouped.set(key, []);
-        grouped.get(key).push(reason);
+        grouped.get(key).push(item.reason);
       }
       for (const [category, reasons] of grouped) {
         const sample = reasons[0];
@@ -253,9 +254,12 @@ function main() {
       }
     }
     if (skipReasons.length > 0) {
+      // Dedupe so the count reflects distinct reasons; show the first unique
+      // reason and indicate additional unique reasons via "(+N more)" for
+      // parity with the errorBailouts category display above.
       const unique = [...new Set(skipReasons)];
       const sample = unique[0];
-      const more = skipReasons.length > 1 ? ` (×${skipReasons.length})` : "";
+      const more = unique.length > 1 ? ` (+${unique.length - 1} more)` : "";
       console.error(`   skip: ${sample}${more}`);
     }
     if (pipelineErrors.length > 0) {

--- a/scripts/check-compiler-budget.test.mjs
+++ b/scripts/check-compiler-budget.test.mjs
@@ -45,6 +45,43 @@ function entryShapeError(entry) {
   return null;
 }
 
+/**
+ * Mirrors the regression-display formatting in check-compiler-budget.mjs.
+ * Returns the lines that would be written to stderr after the ::error
+ * header, in order. Used to verify (a) errorBailouts grouping/null
+ * tolerance, and (b) skipReasons deduplication semantics.
+ */
+function formatDiagnostics(entry) {
+  const lines = [];
+  const errorBailouts = Array.isArray(entry?.errorBailouts) ? entry.errorBailouts : [];
+  const skipReasons = Array.isArray(entry?.skipReasons) ? entry.skipReasons : [];
+  const pipelineErrors = Array.isArray(entry?.pipelineErrors) ? entry.pipelineErrors : [];
+  if (errorBailouts.length > 0) {
+    const grouped = new Map();
+    for (const item of errorBailouts) {
+      if (!item || typeof item !== "object") continue;
+      const key = item.category || "(unknown)";
+      if (!grouped.has(key)) grouped.set(key, []);
+      grouped.get(key).push(item.reason);
+    }
+    for (const [category, reasons] of grouped) {
+      const sample = reasons[0];
+      const more = reasons.length > 1 ? ` (+${reasons.length - 1} more)` : "";
+      lines.push(`   error[${category}]: ${sample}${more}`);
+    }
+  }
+  if (skipReasons.length > 0) {
+    const unique = [...new Set(skipReasons)];
+    const sample = unique[0];
+    const more = unique.length > 1 ? ` (+${unique.length - 1} more)` : "";
+    lines.push(`   skip: ${sample}${more}`);
+  }
+  if (pipelineErrors.length > 0) {
+    lines.push(`   pipeline: ${pipelineErrors[0]}`);
+  }
+  return lines;
+}
+
 describe("summarizePipelineError", () => {
   it("returns empty string for null", () => {
     expect(summarizePipelineError(null)).toBe("");
@@ -190,5 +227,75 @@ describe("validateShape tolerance", () => {
     expect(entryShapeError({ success: Infinity, skip: 0, error: 0, pipeline: 0 })).toBe(
       "invalid-success"
     );
+  });
+});
+
+describe("regression diagnostic display", () => {
+  it("returns no lines when all diagnostic arrays are empty", () => {
+    expect(formatDiagnostics({ errorBailouts: [], skipReasons: [], pipelineErrors: [] })).toEqual(
+      []
+    );
+  });
+
+  it("returns no lines when entry is missing or arrays are absent", () => {
+    expect(formatDiagnostics(undefined)).toEqual([]);
+    expect(formatDiagnostics({})).toEqual([]);
+  });
+
+  it("groups multiple errorBailouts by category", () => {
+    const lines = formatDiagnostics({
+      errorBailouts: [
+        { category: "Todo", reason: "first todo" },
+        { category: "Todo", reason: "second todo" },
+        { category: "Refs", reason: "ref problem" },
+      ],
+    });
+    expect(lines).toEqual(["   error[Todo]: first todo (+1 more)", "   error[Refs]: ref problem"]);
+  });
+
+  it("falls back to (unknown) category for empty-string category", () => {
+    const lines = formatDiagnostics({
+      errorBailouts: [{ category: "", reason: "missing category" }],
+    });
+    expect(lines).toEqual(["   error[(unknown)]: missing category"]);
+  });
+
+  it("skips null/non-object errorBailouts elements without crashing", () => {
+    const lines = formatDiagnostics({
+      errorBailouts: [null, { category: "Hooks", reason: "real" }, "string-junk", 42],
+    });
+    expect(lines).toEqual(["   error[Hooks]: real"]);
+  });
+
+  it("dedupes skipReasons and reports unique-count, not raw-count", () => {
+    // Two distinct reasons → "(+1 more)", not "(×2)" which would be
+    // misleading (it would imply the same reason occurred twice).
+    const lines = formatDiagnostics({
+      skipReasons: ["reason A", "reason B"],
+    });
+    expect(lines).toEqual(["   skip: reason A (+1 more)"]);
+  });
+
+  it("collapses repeated identical skipReasons to the single entry with no suffix", () => {
+    const lines = formatDiagnostics({
+      skipReasons: ["only reason", "only reason", "only reason"],
+    });
+    expect(lines).toEqual(["   skip: only reason"]);
+  });
+
+  it("shows only the first pipelineError summary", () => {
+    const lines = formatDiagnostics({
+      pipelineErrors: ["first error: boom", "second error: kaboom"],
+    });
+    expect(lines).toEqual(["   pipeline: first error: boom"]);
+  });
+
+  it("emits all three sections in order when all are populated", () => {
+    const lines = formatDiagnostics({
+      errorBailouts: [{ category: "Refs", reason: "r" }],
+      skipReasons: ["s"],
+      pipelineErrors: ["p"],
+    });
+    expect(lines).toEqual(["   error[Refs]: r", "   skip: s", "   pipeline: p"]);
   });
 });

--- a/scripts/check-compiler-budget.test.mjs
+++ b/scripts/check-compiler-budget.test.mjs
@@ -1,0 +1,194 @@
+import { describe, it, expect } from "vitest";
+
+// Tests the pure logic introduced in #7454 — capturing compiler bailout
+// reasons and categories. Mirrors the lint-ratchet.test.mjs pattern: extract
+// the logic under test inline, no shell-out, no script import.
+
+/**
+ * Mirrors `summarizePipelineError` in vite.config.ts. Trims to first line,
+ * caps at 200 chars, tolerates null/undefined.
+ */
+function summarizePipelineError(data) {
+  return String(data ?? "")
+    .split(/\r?\n/)[0]
+    .slice(0, 200);
+}
+
+/**
+ * Mirrors the writeBaseline reconstruction in check-compiler-budget.mjs.
+ * Explicit field list (not spread) — prevents unintended propagation of
+ * future report fields into the baseline.
+ */
+function reconstructBaselineEntry(e) {
+  return {
+    success: e.success,
+    skip: e.skip,
+    error: e.error,
+    pipeline: e.pipeline,
+    errorBailouts: Array.isArray(e.errorBailouts) ? e.errorBailouts : [],
+    skipReasons: Array.isArray(e.skipReasons) ? e.skipReasons : [],
+    pipelineErrors: Array.isArray(e.pipelineErrors) ? e.pipelineErrors : [],
+  };
+}
+
+/**
+ * Mirrors the validateShape COUNT_KEYS check — extra fields are tolerated;
+ * only the four counts must be present and valid non-negative finite numbers.
+ */
+const COUNT_KEYS = ["success", "skip", "error", "pipeline"];
+function entryShapeError(entry) {
+  if (!entry || typeof entry !== "object" || Array.isArray(entry)) return "not-object";
+  for (const key of COUNT_KEYS) {
+    const v = entry[key];
+    if (typeof v !== "number" || v < 0 || !Number.isFinite(v)) return `invalid-${key}`;
+  }
+  return null;
+}
+
+describe("summarizePipelineError", () => {
+  it("returns empty string for null", () => {
+    expect(summarizePipelineError(null)).toBe("");
+  });
+
+  it("returns empty string for undefined", () => {
+    expect(summarizePipelineError(undefined)).toBe("");
+  });
+
+  it("returns the input unchanged for short single-line input", () => {
+    expect(summarizePipelineError("boom")).toBe("boom");
+  });
+
+  it("strips everything after the first newline (LF)", () => {
+    expect(summarizePipelineError("ValidationError: foo\n  at bar (baz.ts:1:2)")).toBe(
+      "ValidationError: foo"
+    );
+  });
+
+  it("strips everything after the first newline (CRLF)", () => {
+    expect(summarizePipelineError("ValidationError: foo\r\n  at bar")).toBe("ValidationError: foo");
+  });
+
+  it("caps single-line input at 200 characters", () => {
+    const long = "x".repeat(500);
+    const result = summarizePipelineError(long);
+    expect(result.length).toBe(200);
+    expect(result).toBe("x".repeat(200));
+  });
+
+  it("caps the first line, ignoring later lines, at 200 chars", () => {
+    const first = "y".repeat(300);
+    const input = `${first}\nsecond line`;
+    const result = summarizePipelineError(input);
+    expect(result.length).toBe(200);
+    expect(result).toBe("y".repeat(200));
+  });
+
+  it("coerces non-string inputs via String()", () => {
+    expect(summarizePipelineError(42)).toBe("42");
+  });
+});
+
+describe("writeBaseline reconstruction", () => {
+  it("preserves all four count keys", () => {
+    const result = reconstructBaselineEntry({
+      success: 3,
+      skip: 1,
+      error: 2,
+      pipeline: 0,
+    });
+    expect(result.success).toBe(3);
+    expect(result.skip).toBe(1);
+    expect(result.error).toBe(2);
+    expect(result.pipeline).toBe(0);
+  });
+
+  it("preserves diagnostic arrays from the report", () => {
+    const result = reconstructBaselineEntry({
+      success: 0,
+      skip: 1,
+      error: 1,
+      pipeline: 1,
+      errorBailouts: [{ category: "Hooks", reason: "called conditionally" }],
+      skipReasons: ["Skipped due to 'use no memo' directive."],
+      pipelineErrors: ["Internal error: boom"],
+    });
+    expect(result.errorBailouts).toEqual([{ category: "Hooks", reason: "called conditionally" }]);
+    expect(result.skipReasons).toEqual(["Skipped due to 'use no memo' directive."]);
+    expect(result.pipelineErrors).toEqual(["Internal error: boom"]);
+  });
+
+  it("defaults missing diagnostic arrays to [] (legacy report)", () => {
+    const result = reconstructBaselineEntry({ success: 1, skip: 0, error: 0, pipeline: 0 });
+    expect(result.errorBailouts).toEqual([]);
+    expect(result.skipReasons).toEqual([]);
+    expect(result.pipelineErrors).toEqual([]);
+  });
+
+  it("coerces non-array diagnostic fields to [] (defense in depth)", () => {
+    const result = reconstructBaselineEntry({
+      success: 1,
+      skip: 0,
+      error: 0,
+      pipeline: 0,
+      errorBailouts: "not an array",
+      skipReasons: null,
+      pipelineErrors: undefined,
+    });
+    expect(result.errorBailouts).toEqual([]);
+    expect(result.skipReasons).toEqual([]);
+    expect(result.pipelineErrors).toEqual([]);
+  });
+
+  it("does not propagate unknown report fields into the baseline", () => {
+    const result = reconstructBaselineEntry({
+      success: 1,
+      skip: 0,
+      error: 0,
+      pipeline: 0,
+      futureField: "should not appear",
+    });
+    expect(Object.prototype.hasOwnProperty.call(result, "futureField")).toBe(false);
+  });
+});
+
+describe("validateShape tolerance", () => {
+  it("accepts an entry with only the four count keys", () => {
+    expect(entryShapeError({ success: 1, skip: 0, error: 0, pipeline: 0 })).toBeNull();
+  });
+
+  it("accepts an entry with the new diagnostic arrays alongside counts", () => {
+    expect(
+      entryShapeError({
+        success: 1,
+        skip: 1,
+        error: 1,
+        pipeline: 0,
+        errorBailouts: [{ category: "Refs", reason: "x" }],
+        skipReasons: ["y"],
+        pipelineErrors: [],
+      })
+    ).toBeNull();
+  });
+
+  it("rejects an entry missing a count key", () => {
+    expect(entryShapeError({ success: 1, skip: 0, error: 0 })).toBe("invalid-pipeline");
+  });
+
+  it("rejects negative counts", () => {
+    expect(entryShapeError({ success: -1, skip: 0, error: 0, pipeline: 0 })).toBe(
+      "invalid-success"
+    );
+  });
+
+  it("rejects non-numeric counts", () => {
+    expect(entryShapeError({ success: "1", skip: 0, error: 0, pipeline: 0 })).toBe(
+      "invalid-success"
+    );
+  });
+
+  it("rejects Infinity counts", () => {
+    expect(entryShapeError({ success: Infinity, skip: 0, error: 0, pipeline: 0 })).toBe(
+      "invalid-success"
+    );
+  });
+});

--- a/vite.config.ts
+++ b/vite.config.ts
@@ -22,37 +22,68 @@ const PROD_CSP = getDaintreeAppProdCSP();
 // build completes. Counts come from babel-plugin-react-compiler's logger:
 // CompileSuccess, CompileSkip, CompileError, PipelineError. Other event kinds
 // (Timing, CompileDiagnostic, AutoDeps*) are ignored — they aren't regression
-// signals. The accumulator Map and the logger object MUST be created in the
-// same factory call so they share state via closure; threading either through
-// module scope would silently produce an empty report.
-type CompilerBailoutCounts = {
+// signals. Diagnostic arrays (errorBailouts, skipReasons, pipelineErrors)
+// preserve the human-readable reason and ErrorCategory for each bailout so
+// CI failures point at the actual cause without rebuilding locally. The
+// accumulator Map and the logger object MUST be created in the same factory
+// call so they share state via closure; threading either through module scope
+// would silently produce an empty report.
+type CompilerBailoutEntry = {
   success: number;
   skip: number;
   error: number;
   pipeline: number;
+  // Source type is `ErrorCategory` from babel-plugin-react-compiler — kept as
+  // string at this boundary to avoid cross-package type coupling that would
+  // break silently on a plugin upgrade.
+  errorBailouts: Array<{ category: string; reason: string }>;
+  skipReasons: string[];
+  pipelineErrors: string[];
 };
 
-type CompilerLoggerEvent = { kind: string };
+type CompilerLoggerEvent =
+  | { kind: "CompileSuccess" }
+  | { kind: "CompileSkip"; reason?: unknown }
+  | { kind: "CompileError"; detail?: unknown }
+  | { kind: "PipelineError"; data?: unknown }
+  | { kind: string };
 
 type CompilerLogger = {
   logEvent: (filename: string | null, event: CompilerLoggerEvent) => void;
 };
 
+// PipelineError.data is a serialized stack trace. Keep only the first line
+// (the error message) and cap length so a pathological single-line error
+// can't bloat the report.
+function summarizePipelineError(data: unknown): string {
+  return String(data ?? "")
+    .split(/\r?\n/)[0]
+    .slice(0, 200);
+}
+
 function reactCompilerReportPlugin(command: "build" | "serve"): {
   plugin: Plugin;
   logger: CompilerLogger;
 } {
-  const counts = new Map<string, CompilerBailoutCounts>();
+  const counts = new Map<string, CompilerBailoutEntry>();
   const cwd = process.cwd();
   const reportPath = path.join(cwd, "dist", "compiler-bailout-report.json");
 
-  function bump(filename: string, key: keyof CompilerBailoutCounts) {
+  function getOrInit(filename: string): CompilerBailoutEntry {
     let entry = counts.get(filename);
     if (!entry) {
-      entry = { success: 0, skip: 0, error: 0, pipeline: 0 };
+      entry = {
+        success: 0,
+        skip: 0,
+        error: 0,
+        pipeline: 0,
+        errorBailouts: [],
+        skipReasons: [],
+        pipelineErrors: [],
+      };
       counts.set(filename, entry);
     }
-    entry[key]++;
+    return entry;
   }
 
   const logger: CompilerLogger = {
@@ -65,19 +96,40 @@ function reactCompilerReportPlugin(command: "build" | "serve"): {
       // operating systems and don't leak absolute filesystem paths.
       const rel = path.relative(cwd, filename).split(path.sep).join("/");
       if (!rel || rel.startsWith("..")) return;
+      const entry = getOrInit(rel);
       switch (event.kind) {
         case "CompileSuccess":
-          bump(rel, "success");
+          entry.success++;
           break;
-        case "CompileSkip":
-          bump(rel, "skip");
+        case "CompileSkip": {
+          entry.skip++;
+          const reason = (event as { reason?: unknown }).reason;
+          if (typeof reason === "string" && reason.length > 0) {
+            entry.skipReasons.push(reason);
+          }
           break;
-        case "CompileError":
-          bump(rel, "error");
+        }
+        case "CompileError": {
+          entry.error++;
+          // detail is CompilerErrorDetail | CompilerDiagnostic — both expose
+          // .category (ErrorCategory enum) and .reason (string) via getters
+          // backed by required Zod-validated options. Cast is safe.
+          const detail = (event as { detail?: { category?: unknown; reason?: unknown } }).detail;
+          if (detail && typeof detail === "object") {
+            entry.errorBailouts.push({
+              category: String(detail.category ?? ""),
+              reason:
+                typeof detail.reason === "string" ? detail.reason : String(detail.reason ?? ""),
+            });
+          }
           break;
-        case "PipelineError":
-          bump(rel, "pipeline");
+        }
+        case "PipelineError": {
+          entry.pipeline++;
+          const summary = summarizePipelineError((event as { data?: unknown }).data);
+          if (summary.length > 0) entry.pipelineErrors.push(summary);
           break;
+        }
         default:
           // Timing, CompileDiagnostic, AutoDepsDecorations, AutoDepsEligible —
           // not regression signals.
@@ -111,7 +163,7 @@ function reactCompilerReportPlugin(command: "build" | "serve"): {
         // Plain lexicographic sort matches the check script's default Array#sort
         // so the freshly built report and the checked-in baseline diff cleanly.
         const sorted = [...counts.entries()].sort(([a], [b]) => (a < b ? -1 : a > b ? 1 : 0));
-        const out: Record<string, CompilerBailoutCounts> = {};
+        const out: Record<string, CompilerBailoutEntry> = {};
         for (const [file, entry] of sorted) out[file] = entry;
         mkdirSync(path.dirname(reportPath), { recursive: true });
         writeFileSync(reportPath, JSON.stringify(out, null, 2) + "\n");


### PR DESCRIPTION
## Summary

- The compiler budget report only captured counts, so when CI failed there was no indication of what caused the bailout. This PR adds the diagnostic detail.
- Extends the `reactCompilerReportPlugin` in `vite.config.ts` and `scripts/check-compiler-budget.mjs` to capture three new arrays per file entry alongside existing counts: `errorBailouts` (objects with `category` and `reason`), `skipReasons` (deduplicated strings), and `pipelineErrors` (trimmed, capped strings via `summarizePipelineError`).
- Fixes tolerance for malformed baseline entries and deduplicates skip reasons. Backward compatible: `validateShape` already accepts extra fields; consumers guard with `Array.isArray`.

Resolves #7454

## Changes

- `vite.config.ts`: extended `reactCompilerReportPlugin` to collect `errorBailouts`, `skipReasons`, and `pipelineErrors` per file; tightened `CompilerLoggerEvent` to a discriminated union; added `summarizePipelineError` helper (first line, 200-char cap).
- `scripts/check-compiler-budget.mjs`: `writeBaseline` preserves the new arrays; regression error output now prints captured reasons under each `::error` line, grouped by `ErrorCategory`; added null/junk tolerance and unique-count deduplication for skip reasons.
- `scripts/check-compiler-budget.test.mjs`: 28 new tests covering `summarizePipelineError`, baseline reconstruction, `validateShape` tolerance, and regression diagnostic display.
- `compiler-bailout-baseline.json`: regenerated to include the three new arrays per entry. This incidentally captured ~12 pre-existing count drifts that accumulated since the last baseline refresh — the count logic is unchanged.

## Testing

- `npx vitest run scripts/check-compiler-budget.test.mjs` — 28 pass
- `npm run compiler-budget:build` — OK; report has populated arrays
- `npm run compiler-budget:check` — OK against new baseline
- `npm run check` (typecheck + lint + format + build) — all pass