### PR TITLE
perf(pty-host): align per-terminal byte queue with renderer watermarks

### DIFF
--- a/electron/pty-host.ts
+++ b/electron/pty-host.ts
@@ -239,7 +239,22 @@ const resourceGovernor = new ResourceGovernor({
     backpressureManager.stats.pauseCount += count;
   },
   sendEvent,
-  getPendingBytesSnapshot: () => backpressureManager.getPendingBytesSnapshot(),
+  getPendingBytesSnapshot: () => {
+    // Merge SAB-path, IPC-path, and per-window MessagePort-path queue depths so
+    // the reliability gauge captures every in-flight byte the pty-host is holding.
+    // A given terminal id should only appear in one path at a time, so concatenating
+    // the perTerminal arrays is safe.
+    const sab = backpressureManager.getPendingBytesSnapshot();
+    const ipc = ipcQueueManager.getQueueSnapshot();
+    let totalPendingBytes = sab.totalPendingBytes + ipc.totalPendingBytes;
+    const perTerminal = [...sab.perTerminal, ...ipc.perTerminal];
+    for (const conn of rendererConnections.values()) {
+      const port = conn.portQueueManager.getQueueSnapshot();
+      totalPendingBytes += port.totalPendingBytes;
+      perTerminal.push(...port.perTerminal);
+    }
+    return { totalPendingBytes, perTerminal };
+  },
 });
 
 // Helper to convert data to string for IPC fallback (IPC events expect string)

--- a/electron/pty-host.ts
+++ b/electron/pty-host.ts
@@ -242,8 +242,11 @@ const resourceGovernor = new ResourceGovernor({
   getPendingBytesSnapshot: () => {
     // Merge SAB-path, IPC-path, and per-window MessagePort-path queue depths so
     // the reliability gauge captures every in-flight byte the pty-host is holding.
-    // A given terminal id should only appear in one path at a time, so concatenating
-    // the perTerminal arrays is safe.
+    // totalPendingBytes is an exact sum across paths. The perTerminal array may
+    // contain duplicate entries for a terminal that streams to multiple windows
+    // simultaneously (one entry per window's port queue) — that's intentional
+    // for the reliability gauge, which wants per-path attribution rather than a
+    // collapsed per-terminal view.
     const sab = backpressureManager.getPendingBytesSnapshot();
     const ipc = ipcQueueManager.getQueueSnapshot();
     let totalPendingBytes = sab.totalPendingBytes + ipc.totalPendingBytes;

--- a/electron/pty-host/__tests__/ipcQueue.adversarial.test.ts
+++ b/electron/pty-host/__tests__/ipcQueue.adversarial.test.ts
@@ -210,7 +210,7 @@ describe("IpcQueueManager adversarial", () => {
     expect(startMetric).toBeUndefined();
   });
 
-  it("dispose clears all paused terminals and cancels their safety timeouts", () => {
+  it("dispose releases held pause tokens and cancels their safety timeouts", () => {
     mgr.addBytes("t1", HIGH_BYTES);
     mgr.applyBackpressure("t1", mgr.getUtilization("t1"));
     mgr.addBytes("t2", HIGH_BYTES);
@@ -221,8 +221,14 @@ describe("IpcQueueManager adversarial", () => {
 
     expect(mgr.isPaused("t1")).toBe(false);
     expect(mgr.isPaused("t2")).toBe(false);
+    // Held tokens MUST be released during dispose so the coordinator does not
+    // outlive this manager with a stale hold.
+    expect(coord.resume).toHaveBeenCalledTimes(2);
+    expect(coord.resume).toHaveBeenCalledWith("ipc-queue");
 
+    coord.resume.mockClear();
     vi.advanceTimersByTime(IPC_MAX_PAUSE_MS * 2);
+    // Safety timers must have been cancelled — no further resume calls.
     expect(coord.resume).not.toHaveBeenCalled();
   });
 

--- a/electron/pty-host/__tests__/ipcQueue.adversarial.test.ts
+++ b/electron/pty-host/__tests__/ipcQueue.adversarial.test.ts
@@ -239,4 +239,82 @@ describe("IpcQueueManager adversarial", () => {
     expect(mgr.isAtCapacity("t1", IPC_MAX_QUEUE_BYTES)).toBe(false);
     expect(mgr.isAtCapacity("t1", IPC_MAX_QUEUE_BYTES + 1)).toBe(true);
   });
+
+  describe("aggregate byte tracking", () => {
+    it("tracks total queued bytes across multiple terminals", () => {
+      expect(mgr.getTotalQueuedBytes()).toBe(0);
+
+      mgr.addBytes("t1", 1000);
+      mgr.addBytes("t2", 2500);
+      mgr.addBytes("t1", 500);
+
+      expect(mgr.getTotalQueuedBytes()).toBe(4000);
+    });
+
+    it("removeBytes clamps the aggregate delta to per-terminal balance (no underflow)", () => {
+      mgr.addBytes("t1", 1000);
+      mgr.addBytes("t2", 1500);
+
+      mgr.removeBytes("t1", 10_000);
+
+      expect(mgr.getQueuedBytes("t1")).toBe(0);
+      expect(mgr.getTotalQueuedBytes()).toBe(1500);
+    });
+
+    it("clearQueue removes only the cleared terminal's contribution", () => {
+      mgr.addBytes("t1", 1000);
+      mgr.addBytes("t2", 2000);
+      mgr.addBytes("t3", 3000);
+
+      mgr.clearQueue("t2");
+
+      expect(mgr.getTotalQueuedBytes()).toBe(4000);
+    });
+
+    it("safety timeout clears t1's bytes from aggregate without affecting t2", () => {
+      mgr.addBytes("t1", HIGH_BYTES);
+      mgr.addBytes("t2", 1000);
+      mgr.applyBackpressure("t1", mgr.getUtilization("t1"));
+
+      vi.advanceTimersByTime(IPC_MAX_PAUSE_MS);
+
+      expect(mgr.getQueuedBytes("t1")).toBe(0);
+      expect(mgr.getQueuedBytes("t2")).toBe(1000);
+      expect(mgr.getTotalQueuedBytes()).toBe(1000);
+    });
+
+    it("dispose resets the aggregate scalar", () => {
+      mgr.addBytes("t1", 1000);
+      mgr.addBytes("t2", 2000);
+      mgr.dispose();
+      expect(mgr.getTotalQueuedBytes()).toBe(0);
+    });
+
+    it("getQueueSnapshot returns ResourceGovernor-compatible shape", () => {
+      mgr.addBytes("t1", 1000);
+      mgr.addBytes("t2", 2500);
+
+      const snap = mgr.getQueueSnapshot();
+      expect(snap.totalPendingBytes).toBe(3500);
+      const byId = new Map(snap.perTerminal.map((e) => [e.terminalId, e.pendingBytes]));
+      expect(byId.get("t1")).toBe(1000);
+      expect(byId.get("t2")).toBe(2500);
+    });
+
+    it("aggregate boundary tracking at 0, low, high, max, max+1", () => {
+      expect(mgr.getTotalQueuedBytes()).toBe(0);
+
+      mgr.addBytes("t1", LOW_BYTES);
+      expect(mgr.getTotalQueuedBytes()).toBe(LOW_BYTES);
+
+      mgr.addBytes("t1", HIGH_BYTES - LOW_BYTES);
+      expect(mgr.getTotalQueuedBytes()).toBe(HIGH_BYTES);
+
+      mgr.addBytes("t1", IPC_MAX_QUEUE_BYTES - HIGH_BYTES);
+      expect(mgr.getTotalQueuedBytes()).toBe(IPC_MAX_QUEUE_BYTES);
+
+      mgr.addBytes("t1", 1);
+      expect(mgr.getTotalQueuedBytes()).toBe(IPC_MAX_QUEUE_BYTES + 1);
+    });
+  });
 });

--- a/electron/pty-host/__tests__/portQueue.test.ts
+++ b/electron/pty-host/__tests__/portQueue.test.ts
@@ -1,11 +1,11 @@
 import { describe, it, expect, vi, beforeEach, afterEach } from "vitest";
 import { PortQueueManager, type PortQueueDeps } from "../portQueue.js";
 import type { PtyPauseCoordinator } from "../PtyPauseCoordinator.js";
-
-// Mirror the real constants from pty/types.ts
-const IPC_MAX_QUEUE_BYTES = 8 * 1024 * 1024;
-const IPC_HIGH_WATERMARK_PERCENT = 95;
-const IPC_LOW_WATERMARK_PERCENT = 60;
+import {
+  IPC_MAX_QUEUE_BYTES,
+  IPC_HIGH_WATERMARK_PERCENT,
+  IPC_LOW_WATERMARK_PERCENT,
+} from "../../services/pty/types.js";
 
 function createMockDeps(): PortQueueDeps {
   const mockCoordinator: Pick<PtyPauseCoordinator, "pause" | "resume" | "isPaused"> = {
@@ -277,5 +277,121 @@ describe("PortQueueManager", () => {
     const result = mgr.applyBackpressure("t1", mgr.getUtilization("t1"));
     expect(result).toBe(false);
     expect(mgr.isPaused("t1")).toBe(false);
+  });
+
+  describe("aggregate byte tracking", () => {
+    it("tracks total queued bytes across multiple terminals", () => {
+      const deps = createMockDeps();
+      const mgr = new PortQueueManager(deps);
+
+      expect(mgr.getTotalQueuedBytes()).toBe(0);
+
+      mgr.addBytes("t1", 1000);
+      expect(mgr.getTotalQueuedBytes()).toBe(1000);
+
+      mgr.addBytes("t2", 2500);
+      expect(mgr.getTotalQueuedBytes()).toBe(3500);
+
+      mgr.addBytes("t1", 500);
+      expect(mgr.getTotalQueuedBytes()).toBe(4000);
+    });
+
+    it("subtracts from total on removeBytes without underflow on over-remove", () => {
+      const deps = createMockDeps();
+      const mgr = new PortQueueManager(deps);
+
+      mgr.addBytes("t1", 1000);
+      mgr.addBytes("t2", 1500);
+
+      mgr.removeBytes("t1", 400);
+      expect(mgr.getTotalQueuedBytes()).toBe(2100);
+      expect(mgr.getQueuedBytes("t1")).toBe(600);
+
+      // Over-remove from t1 — must not subtract more than t1 actually held
+      mgr.removeBytes("t1", 10_000);
+      expect(mgr.getQueuedBytes("t1")).toBe(0);
+      expect(mgr.getTotalQueuedBytes()).toBe(1500);
+
+      // t2 untouched
+      expect(mgr.getQueuedBytes("t2")).toBe(1500);
+    });
+
+    it("clearQueue subtracts only the cleared terminal's bytes", () => {
+      const deps = createMockDeps();
+      const mgr = new PortQueueManager(deps);
+
+      mgr.addBytes("t1", 1000);
+      mgr.addBytes("t2", 2000);
+      mgr.addBytes("t3", 3000);
+
+      mgr.clearQueue("t2");
+
+      expect(mgr.getTotalQueuedBytes()).toBe(4000);
+      expect(mgr.getQueuedBytes("t1")).toBe(1000);
+      expect(mgr.getQueuedBytes("t2")).toBe(0);
+      expect(mgr.getQueuedBytes("t3")).toBe(3000);
+    });
+
+    it("safety timeout subtracts dropped bytes from aggregate (#6244 + aggregate)", () => {
+      const deps = createMockDeps();
+      const mgr = new PortQueueManager(deps);
+
+      const highWatermark = (IPC_MAX_QUEUE_BYTES * IPC_HIGH_WATERMARK_PERCENT) / 100;
+      mgr.addBytes("t1", highWatermark + 1);
+      mgr.addBytes("t2", 1000);
+      mgr.applyBackpressure("t1", mgr.getUtilization("t1"));
+
+      const totalBefore = mgr.getTotalQueuedBytes();
+      expect(totalBefore).toBe(highWatermark + 1 + 1000);
+
+      vi.advanceTimersByTime(5000);
+
+      // Only t1's bytes were dropped on force-resume; t2 untouched.
+      expect(mgr.getQueuedBytes("t1")).toBe(0);
+      expect(mgr.getQueuedBytes("t2")).toBe(1000);
+      expect(mgr.getTotalQueuedBytes()).toBe(1000);
+    });
+
+    it("dispose resets the aggregate scalar", () => {
+      const deps = createMockDeps();
+      const mgr = new PortQueueManager(deps);
+
+      mgr.addBytes("t1", 1000);
+      mgr.addBytes("t2", 2000);
+      expect(mgr.getTotalQueuedBytes()).toBe(3000);
+
+      mgr.dispose();
+
+      expect(mgr.getTotalQueuedBytes()).toBe(0);
+    });
+
+    it("getQueueSnapshot mirrors BackpressureManager shape", () => {
+      const deps = createMockDeps();
+      const mgr = new PortQueueManager(deps);
+
+      mgr.addBytes("t1", 1000);
+      mgr.addBytes("t2", 2500);
+
+      const snap = mgr.getQueueSnapshot();
+      expect(snap.totalPendingBytes).toBe(3500);
+      expect(snap.perTerminal).toHaveLength(2);
+      const byId = new Map(snap.perTerminal.map((e) => [e.terminalId, e.pendingBytes]));
+      expect(byId.get("t1")).toBe(1000);
+      expect(byId.get("t2")).toBe(2500);
+    });
+  });
+
+  describe("constants alignment with renderer precedent", () => {
+    it("max queue is 512KB to match 4× renderer high watermark (128KB)", () => {
+      expect(IPC_MAX_QUEUE_BYTES).toBe(512 * 1024);
+    });
+
+    it("high watermark sits at 384KB (75% of cap)", () => {
+      expect((IPC_MAX_QUEUE_BYTES * IPC_HIGH_WATERMARK_PERCENT) / 100).toBe(384 * 1024);
+    });
+
+    it("low watermark sits at 128KB (25% of cap, equals one renderer drain cycle)", () => {
+      expect((IPC_MAX_QUEUE_BYTES * IPC_LOW_WATERMARK_PERCENT) / 100).toBe(128 * 1024);
+    });
   });
 });

--- a/electron/pty-host/__tests__/portQueue.test.ts
+++ b/electron/pty-host/__tests__/portQueue.test.ts
@@ -5,6 +5,7 @@ import {
   IPC_MAX_QUEUE_BYTES,
   IPC_HIGH_WATERMARK_PERCENT,
   IPC_LOW_WATERMARK_PERCENT,
+  IPC_MAX_PAUSE_MS,
 } from "../../services/pty/types.js";
 
 function createMockDeps(): PortQueueDeps {
@@ -151,7 +152,7 @@ describe("PortQueueManager", () => {
 
     expect(mgr.isPaused("t1")).toBe(true);
 
-    vi.advanceTimersByTime(5000);
+    vi.advanceTimersByTime(IPC_MAX_PAUSE_MS);
 
     expect(mgr.isPaused("t1")).toBe(false);
     const coordinator = deps.getPauseCoordinator("t1");
@@ -171,7 +172,7 @@ describe("PortQueueManager", () => {
     mgr.addBytes("t1", highWatermark + 1);
     mgr.applyBackpressure("t1", mgr.getUtilization("t1"));
 
-    vi.advanceTimersByTime(5000);
+    vi.advanceTimersByTime(IPC_MAX_PAUSE_MS);
 
     expect(mgr.getQueuedBytes("t1")).toBe(0);
 
@@ -240,7 +241,7 @@ describe("PortQueueManager", () => {
     expect(coordinator!.resume).toHaveBeenCalledWith("port-queue-7");
   });
 
-  it("dispose clears all terminals", () => {
+  it("dispose clears all terminals and releases held pause tokens", () => {
     const deps = createMockDeps();
     const mgr = new PortQueueManager(deps);
 
@@ -250,12 +251,18 @@ describe("PortQueueManager", () => {
     mgr.applyBackpressure("t1", mgr.getUtilization("t1"));
     mgr.applyBackpressure("t2", mgr.getUtilization("t2"));
 
+    const coordinator = deps.getPauseCoordinator("t1")!;
+    vi.mocked(coordinator.resume).mockClear();
+
     mgr.dispose();
 
     expect(mgr.getQueuedBytes("t1")).toBe(0);
     expect(mgr.getQueuedBytes("t2")).toBe(0);
     expect(mgr.isPaused("t1")).toBe(false);
     expect(mgr.isPaused("t2")).toBe(false);
+    // Held pause tokens MUST be released so the coordinator does not outlive
+    // this manager with a stale hold.
+    expect(coordinator.resume).toHaveBeenCalledWith("port-queue");
   });
 
   it("removeBytes clamps to zero for unknown terminals", () => {
@@ -344,7 +351,7 @@ describe("PortQueueManager", () => {
       const totalBefore = mgr.getTotalQueuedBytes();
       expect(totalBefore).toBe(highWatermark + 1 + 1000);
 
-      vi.advanceTimersByTime(5000);
+      vi.advanceTimersByTime(IPC_MAX_PAUSE_MS);
 
       // Only t1's bytes were dropped on force-resume; t2 untouched.
       expect(mgr.getQueuedBytes("t1")).toBe(0);

--- a/electron/pty-host/ipcQueue.ts
+++ b/electron/pty-host/ipcQueue.ts
@@ -31,6 +31,7 @@ export class IpcQueueManager {
   private readonly queuedBytes = new Map<string, number>();
   private readonly pausedTerminals = new Map<string, ReturnType<typeof setInterval>>();
   private readonly pauseStartTimes = new Map<string, number>();
+  private totalQueuedBytes = 0;
 
   constructor(private readonly deps: IpcQueueDeps) {}
 
@@ -43,21 +44,42 @@ export class IpcQueueManager {
     const current = this.queuedBytes.get(id) ?? 0;
     const next = current + bytes;
     this.queuedBytes.set(id, next);
+    this.totalQueuedBytes += bytes;
     return next;
   }
 
   removeBytes(id: string, bytes: number): void {
     const current = this.queuedBytes.get(id) ?? 0;
-    const next = Math.max(0, current - bytes);
+    // Clamp the aggregate delta to the per-terminal balance to prevent
+    // underflow when callers over-remove (the per-terminal value is
+    // already clamped via Math.max below).
+    const removed = Math.min(bytes, current);
+    const next = current - removed;
     if (next === 0) {
       this.queuedBytes.delete(id);
     } else {
       this.queuedBytes.set(id, next);
     }
+    this.totalQueuedBytes = Math.max(0, this.totalQueuedBytes - removed);
   }
 
   getQueuedBytes(id: string): number {
     return this.queuedBytes.get(id) ?? 0;
+  }
+
+  getTotalQueuedBytes(): number {
+    return this.totalQueuedBytes;
+  }
+
+  getQueueSnapshot(): {
+    totalPendingBytes: number;
+    perTerminal: Array<{ terminalId: string; pendingBytes: number }>;
+  } {
+    const perTerminal: Array<{ terminalId: string; pendingBytes: number }> = [];
+    for (const [terminalId, pendingBytes] of this.queuedBytes) {
+      perTerminal.push({ terminalId, pendingBytes });
+    }
+    return { totalPendingBytes: this.totalQueuedBytes, perTerminal };
   }
 
   isAtCapacity(id: string, additionalBytes: number): boolean {
@@ -116,7 +138,9 @@ export class IpcQueueManager {
         // the next addBytes call immediately re-triggers applyBackpressure
         // and the pause loop wedges across the entire renderer reload
         // (mirrors the port-path fix in #6244).
+        const droppedBytes = this.queuedBytes.get(id) ?? 0;
         this.queuedBytes.delete(id);
+        this.totalQueuedBytes = Math.max(0, this.totalQueuedBytes - droppedBytes);
 
         const coordinator = this.deps.getPauseCoordinator(id);
         if (coordinator) {
@@ -193,7 +217,9 @@ export class IpcQueueManager {
     if (wasPaused) {
       this.deps.getPauseCoordinator(id)?.resume("ipc-queue");
     }
+    const removed = this.queuedBytes.get(id) ?? 0;
     this.queuedBytes.delete(id);
+    this.totalQueuedBytes = Math.max(0, this.totalQueuedBytes - removed);
     this.pausedTerminals.delete(id);
     this.pauseStartTimes.delete(id);
   }
@@ -206,5 +232,6 @@ export class IpcQueueManager {
     this.pausedTerminals.clear();
     this.pauseStartTimes.clear();
     this.queuedBytes.clear();
+    this.totalQueuedBytes = 0;
   }
 }

--- a/electron/pty-host/ipcQueue.ts
+++ b/electron/pty-host/ipcQueue.ts
@@ -225,8 +225,11 @@ export class IpcQueueManager {
   }
 
   dispose(): void {
+    // Release any held pause tokens before tearing down so the coordinator
+    // doesn't outlive this manager with a stale hold.
     for (const [id, safetyTimeout] of this.pausedTerminals) {
       clearTimeout(safetyTimeout);
+      this.deps.getPauseCoordinator(id)?.resume("ipc-queue");
       console.log(`[PtyHost] Cleared IPC backpressure monitor for terminal ${id}`);
     }
     this.pausedTerminals.clear();

--- a/electron/pty-host/portQueue.ts
+++ b/electron/pty-host/portQueue.ts
@@ -238,12 +238,12 @@ export class PortQueueManager {
   }
 
   dispose(): void {
-    for (const [id, safetyTimeout] of this.pausedTerminals) {
-      clearTimeout(safetyTimeout);
+    // Release any held pause tokens before tearing down so the coordinator
+    // doesn't outlive this manager with a stale hold.
+    for (const id of this.pausedTerminals.keys()) {
       console.log(`[PtyHost] Cleared port backpressure monitor for terminal ${id}`);
     }
-    this.pausedTerminals.clear();
-    this.pauseStartTimes.clear();
+    this.resumeAll();
     this.queuedBytes.clear();
     this.totalQueuedBytes = 0;
   }

--- a/electron/pty-host/portQueue.ts
+++ b/electron/pty-host/portQueue.ts
@@ -33,6 +33,7 @@ export class PortQueueManager {
   private readonly pausedTerminals = new Map<string, ReturnType<typeof setTimeout>>();
   private readonly pauseStartTimes = new Map<string, number>();
   private readonly pauseToken: PauseToken;
+  private totalQueuedBytes = 0;
 
   constructor(private readonly deps: PortQueueDeps) {
     this.pauseToken = deps.pauseToken ?? "port-queue";
@@ -47,21 +48,42 @@ export class PortQueueManager {
     const current = this.queuedBytes.get(id) ?? 0;
     const next = current + bytes;
     this.queuedBytes.set(id, next);
+    this.totalQueuedBytes += bytes;
     return next;
   }
 
   removeBytes(id: string, bytes: number): void {
     const current = this.queuedBytes.get(id) ?? 0;
-    const next = Math.max(0, current - bytes);
+    // Clamp the aggregate delta to the per-terminal balance to prevent
+    // underflow when callers over-remove (the per-terminal value is
+    // already clamped via Math.max below).
+    const removed = Math.min(bytes, current);
+    const next = current - removed;
     if (next === 0) {
       this.queuedBytes.delete(id);
     } else {
       this.queuedBytes.set(id, next);
     }
+    this.totalQueuedBytes = Math.max(0, this.totalQueuedBytes - removed);
   }
 
   getQueuedBytes(id: string): number {
     return this.queuedBytes.get(id) ?? 0;
+  }
+
+  getTotalQueuedBytes(): number {
+    return this.totalQueuedBytes;
+  }
+
+  getQueueSnapshot(): {
+    totalPendingBytes: number;
+    perTerminal: Array<{ terminalId: string; pendingBytes: number }>;
+  } {
+    const perTerminal: Array<{ terminalId: string; pendingBytes: number }> = [];
+    for (const [terminalId, pendingBytes] of this.queuedBytes) {
+      perTerminal.push({ terminalId, pendingBytes });
+    }
+    return { totalPendingBytes: this.totalQueuedBytes, perTerminal };
   }
 
   isAtCapacity(id: string, additionalBytes: number): boolean {
@@ -117,7 +139,9 @@ export class PortQueueManager {
         // Drop stale byte accounting alongside the pause maps. Without this,
         // the next addBytes call immediately re-triggers applyBackpressure
         // and the pause loop wedges across the entire renderer reload (#6244).
+        const droppedBytes = this.queuedBytes.get(id) ?? 0;
         this.queuedBytes.delete(id);
+        this.totalQueuedBytes = Math.max(0, this.totalQueuedBytes - droppedBytes);
 
         const coordinator = this.deps.getPauseCoordinator(id);
         if (coordinator) {
@@ -194,7 +218,9 @@ export class PortQueueManager {
     if (wasPaused) {
       this.deps.getPauseCoordinator(id)?.resume(this.pauseToken);
     }
+    const removed = this.queuedBytes.get(id) ?? 0;
     this.queuedBytes.delete(id);
+    this.totalQueuedBytes = Math.max(0, this.totalQueuedBytes - removed);
     this.pausedTerminals.delete(id);
     this.pauseStartTimes.delete(id);
   }
@@ -219,5 +245,6 @@ export class PortQueueManager {
     this.pausedTerminals.clear();
     this.pauseStartTimes.clear();
     this.queuedBytes.clear();
+    this.totalQueuedBytes = 0;
   }
 }

--- a/electron/services/pty/types.ts
+++ b/electron/services/pty/types.ts
@@ -239,9 +239,12 @@ export const GRACEFUL_SHUTDOWN_BUFFER_SIZE = 8 * 1024;
 export const GRACEFUL_SHUTDOWN_CLEAR_DELAY_MS = 100;
 
 // IPC Flow Control Configuration
-export const IPC_MAX_QUEUE_BYTES = 8 * 1024 * 1024; // 8MB max per terminal
-export const IPC_HIGH_WATERMARK_PERCENT = 95; // Pause PTY at 95% full
-export const IPC_LOW_WATERMARK_PERCENT = 60; // Resume PTY when drops to 60%
+// Sized to match the renderer-side TerminalOutputIngestService watermarks (128KB high / 32KB low).
+// 512KB ceiling = 4× renderer high watermark, holds ~8 saturated 64KB pipe-buffer events.
+// 75%/25% gives a 3:1 hysteresis where resume threshold (128KB) equals one renderer drain cycle.
+export const IPC_MAX_QUEUE_BYTES = 512 * 1024; // 512KB max per terminal
+export const IPC_HIGH_WATERMARK_PERCENT = 75; // Pause PTY at 75% full (384KB)
+export const IPC_LOW_WATERMARK_PERCENT = 25; // Resume PTY when drops to 25% (128KB)
 export const IPC_MAX_PAUSE_MS = 5000; // Force resume after 5 seconds to prevent indefinite pause
 
 // MessagePort adaptive batching configuration


### PR DESCRIPTION
## Summary

- Retunes `IPC_MAX_QUEUE_BYTES` from 8MB to 512KB and widens hysteresis to 75%/25% — matching the watermark ratios the renderer already uses and keeping memory pressure proportional across concurrent agent panes.
- Adds `totalQueuedBytes` aggregate and `getQueueSnapshot()` to `PortQueueManager` and `IpcQueueManager`, then wires the merged snapshot into `ResourceGovernor`'s pending-bytes gauge so the governor can see actual backlog size.
- Fixes a pre-existing dispose leak: pause tokens weren't released on terminal close, leaving the coordinator stuck in a paused state after the PTY exited.

Resolves #7453

## Changes

- `electron/services/pty/types.ts` — `IPC_MAX_QUEUE_BYTES` 8MB → 512KB; high/low watermarks 95%/60% → 75%/25%
- `electron/pty-host/portQueue.ts` + `ipcQueue.ts` — `totalQueuedBytes` property + `getQueueSnapshot()` method on both managers; dispose now releases coordinator pause tokens
- `electron/pty-host.ts` — merges `portQueue` + `ipcQueue` snapshots into `ResourceGovernor` pending-bytes gauge
- `electron/pty-host/__tests__/portQueue.test.ts` + `ipcQueue.adversarial.test.ts` — replaces hardcoded `5000ms` with `IPC_MAX_PAUSE_MS`; adds snapshot and dispose-release coverage

## Testing

All 154 pty-host unit tests pass. `npm run check` clean.