### PR TITLE
perf(boot): defer non-critical service init off cold-start path

### DIFF
--- a/electron/services/DatabaseMaintenanceService.ts
+++ b/electron/services/DatabaseMaintenanceService.ts
@@ -17,9 +17,11 @@ class DatabaseMaintenanceService {
   private removeSuspendListener: (() => void) | null = null;
   private backupPromise: Promise<void> | null = null;
   private disposed = false;
+  private initialized = false;
 
   initialize(): void {
-    if (this.timer) return; // already initialized
+    if (this.initialized) return;
+    this.initialized = true;
 
     const dbPath = getDbPath();
 
@@ -33,6 +35,16 @@ class DatabaseMaintenanceService {
       }
     }
 
+    console.log("[DatabaseMaintenance] Initialized (probe complete)");
+  }
+
+  startMaintenance(): void {
+    // Defensive: dispose() may run before startMaintenance() drains from the
+    // deferred queue (window closed before first-interactive). The timer/listener
+    // installation must not happen post-dispose.
+    if (this.disposed) return;
+    if (this.timer) return;
+
     this.timer = setInterval(() => this.tick(), TICK_INTERVAL_MS);
 
     try {
@@ -44,7 +56,7 @@ class DatabaseMaintenanceService {
       // The suspend hook is best-effort — periodic timer covers the gap.
     }
 
-    console.log("[DatabaseMaintenance] Initialized");
+    console.log("[DatabaseMaintenance] Maintenance started");
   }
 
   async dispose(): Promise<void> {

--- a/electron/services/__tests__/DatabaseMaintenanceService.adversarial.test.ts
+++ b/electron/services/__tests__/DatabaseMaintenanceService.adversarial.test.ts
@@ -107,6 +107,7 @@ describe("DatabaseMaintenanceService adversarial", () => {
 
     const service = new DatabaseMaintenanceService();
     service.initialize();
+    service.startMaintenance();
 
     vi.advanceTimersByTime(5 * 60 * 1000);
     expect(mockSqlite.backup).toHaveBeenCalledTimes(1);
@@ -141,6 +142,7 @@ describe("DatabaseMaintenanceService adversarial", () => {
 
     const service = new DatabaseMaintenanceService();
     service.initialize();
+    service.startMaintenance();
 
     vi.advanceTimersByTime(5 * 60 * 1000);
     const disposePromise = service.dispose();
@@ -165,6 +167,7 @@ describe("DatabaseMaintenanceService adversarial", () => {
 
     const service = new DatabaseMaintenanceService();
     service.initialize();
+    service.startMaintenance();
 
     vi.advanceTimersByTime(5 * 60 * 1000);
     await flushMicrotasks();
@@ -183,6 +186,7 @@ describe("DatabaseMaintenanceService adversarial", () => {
 
     const service = new DatabaseMaintenanceService();
     service.initialize();
+    service.startMaintenance();
 
     vi.advanceTimersByTime(5 * 60 * 1000);
 
@@ -203,6 +207,7 @@ describe("DatabaseMaintenanceService adversarial", () => {
   it("DISPOSED_SERVICE_IGNORES_LATE_TIMER_FIRE", async () => {
     const service = new DatabaseMaintenanceService();
     service.initialize();
+    service.startMaintenance();
 
     await service.dispose();
     mockSqlite.backup.mockClear();
@@ -212,5 +217,23 @@ describe("DatabaseMaintenanceService adversarial", () => {
 
     expect(mockSqlite.backup).not.toHaveBeenCalled();
     expect(mockSqlite.pragma).not.toHaveBeenCalled();
+  });
+
+  it("DISPOSE_BEFORE_START_MAINTENANCE_IS_SAFE", async () => {
+    const service = new DatabaseMaintenanceService();
+    service.initialize();
+
+    await service.dispose();
+
+    // Late drain of deferred queue tries to start maintenance after dispose;
+    // must be a no-op (no timer installed, no listener registered).
+    service.startMaintenance();
+
+    expect(mockSystemSleepService.onSuspend).not.toHaveBeenCalled();
+    vi.advanceTimersByTime(10 * 60 * 1000);
+    // backup may have been called once during dispose itself; ensure no further calls
+    mockSqlite.backup.mockClear();
+    vi.advanceTimersByTime(10 * 60 * 1000);
+    expect(mockSqlite.backup).not.toHaveBeenCalled();
   });
 });

--- a/electron/services/__tests__/DatabaseMaintenanceService.test.ts
+++ b/electron/services/__tests__/DatabaseMaintenanceService.test.ts
@@ -102,9 +102,21 @@ describe("DatabaseMaintenanceService", () => {
     void service.dispose();
   });
 
+  it("initialize alone does NOT install timer or suspend listener", () => {
+    const service = new DatabaseMaintenanceService();
+    service.initialize();
+
+    expect(mockSystemSleepService.onSuspend).not.toHaveBeenCalled();
+    vi.advanceTimersByTime(5 * 60 * 1000 + 100);
+    expect(mockSqlite.pragma).not.toHaveBeenCalled();
+    expect(mockSqlite.backup).not.toHaveBeenCalled();
+    void service.dispose();
+  });
+
   it("registers suspend listener via SystemSleepService", () => {
     const service = new DatabaseMaintenanceService();
     service.initialize();
+    service.startMaintenance();
 
     expect(mockSystemSleepService.onSuspend).toHaveBeenCalledWith(expect.any(Function));
     void service.dispose();
@@ -113,6 +125,7 @@ describe("DatabaseMaintenanceService", () => {
   it("runs PASSIVE checkpoint on suspend", () => {
     const service = new DatabaseMaintenanceService();
     service.initialize();
+    service.startMaintenance();
 
     const suspendCallback = mockSystemSleepService.onSuspend.mock.calls[0][0] as () => void;
     suspendCallback();
@@ -126,6 +139,7 @@ describe("DatabaseMaintenanceService", () => {
 
     const service = new DatabaseMaintenanceService();
     service.initialize();
+    service.startMaintenance();
 
     // Advance past tick interval (5 minutes)
     vi.advanceTimersByTime(5 * 60 * 1000 + 100);
@@ -140,6 +154,7 @@ describe("DatabaseMaintenanceService", () => {
 
     const service = new DatabaseMaintenanceService();
     service.initialize();
+    service.startMaintenance();
 
     vi.advanceTimersByTime(5 * 60 * 1000 + 100);
 
@@ -153,6 +168,7 @@ describe("DatabaseMaintenanceService", () => {
 
     const service = new DatabaseMaintenanceService();
     service.initialize();
+    service.startMaintenance();
 
     vi.advanceTimersByTime(5 * 60 * 1000 + 100);
 
@@ -163,6 +179,7 @@ describe("DatabaseMaintenanceService", () => {
   it("dispose runs final backup and TRUNCATE checkpoint", async () => {
     const service = new DatabaseMaintenanceService();
     service.initialize();
+    service.startMaintenance();
 
     await service.dispose();
 
@@ -179,6 +196,7 @@ describe("DatabaseMaintenanceService", () => {
   it("dispose is idempotent", async () => {
     const service = new DatabaseMaintenanceService();
     service.initialize();
+    service.startMaintenance();
 
     await service.dispose();
     mockSqlite.pragma.mockClear();
@@ -188,6 +206,28 @@ describe("DatabaseMaintenanceService", () => {
     expect(mockSqlite.pragma).not.toHaveBeenCalledWith("wal_checkpoint(TRUNCATE)");
   });
 
+  it("dispose before startMaintenance completes without error", async () => {
+    const service = new DatabaseMaintenanceService();
+    service.initialize();
+
+    await expect(service.dispose()).resolves.toBeUndefined();
+    expect(mockSystemSleepService.onSuspend).not.toHaveBeenCalled();
+  });
+
+  it("startMaintenance after dispose is a no-op", async () => {
+    const service = new DatabaseMaintenanceService();
+    service.initialize();
+    await service.dispose();
+    // dispose runs its final backup; clear before asserting no further timer activity
+    mockSqlite.backup.mockClear();
+
+    service.startMaintenance();
+    expect(mockSystemSleepService.onSuspend).not.toHaveBeenCalled();
+
+    vi.advanceTimersByTime(5 * 60 * 1000 + 100);
+    expect(mockSqlite.backup).not.toHaveBeenCalled();
+  });
+
   it("initialize is idempotent", () => {
     const service = new DatabaseMaintenanceService();
     service.initialize();
@@ -195,6 +235,17 @@ describe("DatabaseMaintenanceService", () => {
 
     // probeDb should only be called once
     expect(mockDbModule.probeDb).toHaveBeenCalledTimes(1);
+    void service.dispose();
+  });
+
+  it("startMaintenance is idempotent", () => {
+    const service = new DatabaseMaintenanceService();
+    service.initialize();
+    service.startMaintenance();
+    service.startMaintenance();
+
+    // onSuspend should only register once even if called twice
+    expect(mockSystemSleepService.onSuspend).toHaveBeenCalledTimes(1);
     void service.dispose();
   });
 });

--- a/electron/window/__tests__/globalServicesInit.order.test.ts
+++ b/electron/window/__tests__/globalServicesInit.order.test.ts
@@ -96,6 +96,14 @@ vi.mock("../../services/SystemSleepService.js", () => ({
   getSystemSleepService: () => ({ dispose: vi.fn() }),
 }));
 
+vi.mock("../../services/DatabaseMaintenanceService.js", () => ({
+  getDatabaseMaintenanceService: () => ({
+    initialize: vi.fn(),
+    startMaintenance: vi.fn(),
+    dispose: vi.fn(),
+  }),
+}));
+
 vi.mock("../../services/CrashRecoveryService.js", () => ({
   getCrashRecoveryService: () => ({ startBackupTimer: vi.fn(), stopBackupTimer: vi.fn() }),
 }));
@@ -235,6 +243,26 @@ describe("initGlobalServices task ordering", () => {
     expect(registeredTaskNames).not.toContain("mcp-server");
     expect(registeredTaskNames).not.toContain("help-session-gc");
     expect(setMcpRegistry).not.toHaveBeenCalled();
+  });
+
+  it("registers database-maintenance after system-sleep-service so onSuspend can attach to a live service", async () => {
+    const fakeRegistry = { all: () => [], size: 0 } as unknown as WindowRegistry;
+    await initGlobalServices(fakeRegistry);
+
+    const sleepIndex = registeredTaskNames.indexOf("system-sleep-service");
+    const dbMaintIndex = registeredTaskNames.indexOf("database-maintenance");
+
+    expect(sleepIndex).toBeGreaterThanOrEqual(0);
+    expect(dbMaintIndex).toBeGreaterThanOrEqual(0);
+    expect(dbMaintIndex).toBeGreaterThan(sleepIndex);
+  });
+
+  it("registers ccr-config and plugin-service as deferred tasks", async () => {
+    const fakeRegistry = { all: () => [], size: 0 } as unknown as WindowRegistry;
+    await initGlobalServices(fakeRegistry);
+
+    expect(registeredTaskNames).toContain("ccr-config");
+    expect(registeredTaskNames).toContain("plugin-service");
   });
 
   it("returns 'ok' on the happy path", async () => {

--- a/electron/window/globalServicesInit.ts
+++ b/electron/window/globalServicesInit.ts
@@ -25,6 +25,7 @@ import {
   SESSION_EVICTION_MAX_BYTES,
 } from "../services/pty/terminalSessionPersistence.js";
 import { initializeSystemSleepService } from "../services/SystemSleepService.js";
+import { getDatabaseMaintenanceService } from "../services/DatabaseMaintenanceService.js";
 import { getCrashRecoveryService } from "../services/CrashRecoveryService.js";
 import {
   markPerformance,
@@ -106,8 +107,8 @@ async function evictStaleSessionFiles(): Promise<void> {
 /**
  * Run the once-per-app-lifecycle global initialization on the first window
  * setup. Migrations run inline (synchronous, blocking); everything else is
- * either a synchronous boot (GitHubAuth storage, preAgentSnapshot, ccrConfig)
- * or registered as a deferred task that drains after first-interactive.
+ * either a synchronous boot (GitHubAuth storage, preAgentSnapshot) or
+ * registered as a deferred task that drains after first-interactive.
  *
  * Returns "exit-requested" when migrations fail and `app.exit(1)` has been
  * called — the caller MUST early-return without continuing setup.
@@ -244,17 +245,43 @@ export async function initGlobalServices(
     },
   });
 
-  // CCR config — discover Claude Code Router models as agent presets
-  try {
-    const { CcrConfigService } = await import("../services/CcrConfigService.js");
-    const ccr = CcrConfigService.getInstance();
-    setCcrConfigService(ccr);
-    await ccr.loadAndApply();
-    ccr.startWatching();
-    console.log("[MAIN] CcrConfigService initialized");
-  } catch (err) {
-    console.warn("[MAIN] CcrConfigService init failed (non-fatal):", err);
-  }
+  // CCR config — discover Claude Code Router models as agent presets.
+  // Deferred: the renderer fetches presets via getCcrPresets() which falls
+  // through to [] when the cache is empty, and AGENT_PRESETS_UPDATED broadcasts
+  // populate the renderer store as soon as loadAndApply() completes.
+  registerDeferredTask({
+    name: "ccr-config",
+    run: async () => {
+      const { CcrConfigService } = await import("../services/CcrConfigService.js");
+      const ccr = CcrConfigService.getInstance();
+      setCcrConfigService(ccr);
+      try {
+        await ccr.loadAndApply();
+      } catch (err) {
+        console.warn("[MAIN] CcrConfigService loadAndApply failed (non-fatal):", err);
+      }
+      // Watcher is independent of initial load success — if the config file
+      // is malformed on first boot, polling lets us pick up the fix later.
+      // startWatching() is idempotent.
+      ccr.startWatching();
+      console.log("[MAIN] CcrConfigService initialized");
+    },
+  });
+
+  // Plugin service — IPC handlers are registered eagerly in windowServices.ts
+  // and return empty lists from internal Maps until initialize() populates them.
+  // Plugin contributions broadcast on registration, so late init is renderer-safe.
+  registerDeferredTask({
+    name: "plugin-service",
+    run: async () => {
+      const { pluginService } = await import("../services/PluginService.js");
+      try {
+        await pluginService.initialize();
+      } catch (err) {
+        console.error("[MAIN] PluginService initialization failed:", err);
+      }
+    },
+  });
 
   // ── Deferred global service starts ──
   // These were previously run on the same tick as loadRenderer(), contending
@@ -290,6 +317,18 @@ export async function initGlobalServices(
     name: "system-sleep-service",
     run: () => {
       initializeSystemSleepService();
+    },
+  });
+
+  // Deferred timer + suspend-listener install for DB maintenance. The probe
+  // and recovery still run synchronously in main.ts before the shared DB is
+  // opened — only the 5-minute maintenance tick and the SystemSleepService
+  // suspend hook are deferred. Registered AFTER system-sleep-service so the
+  // suspend listener attaches to a live service.
+  registerDeferredTask({
+    name: "database-maintenance",
+    run: () => {
+      getDatabaseMaintenanceService().startMaintenance();
     },
   });
 

--- a/electron/window/windowServices.ts
+++ b/electron/window/windowServices.ts
@@ -153,18 +153,14 @@ export async function setupWindowServices(
 
   console.log("[MAIN] Registering IPC handlers...");
 
-  // IPC handlers are globally scoped — register only once
+  // IPC handlers are globally scoped — register only once. PluginService
+  // initialization moved to a deferred task in globalServicesInit.ts; the
+  // plugin IPC handlers registered above return empty lists until init
+  // completes, and contribution broadcasts populate the renderer when ready.
   if (!getIpcHandlersRegistered()) {
     setIpcHandlersRegistered(true);
     setCleanupIpcHandlers(registerIpcHandlers(handlerDeps));
     markPerformance(PERF_MARKS.SERVICE_INIT_IPC_READY);
-
-    try {
-      const { pluginService } = await import("../services/PluginService.js");
-      await pluginService.initialize();
-    } catch (error) {
-      console.error("[MAIN] PluginService initialization failed:", error);
-    }
   }
 
   // Renderer load is gated by DAINTREE_EARLY_RENDERER. With the flag, the
@@ -247,8 +243,9 @@ export async function setupWindowServices(
     });
     setWorkspaceClientRef(workspaceClient);
 
-    // Give PluginService the WorkspaceClient reference now that it's ready —
-    // PluginService.initialize() ran earlier before workspaceClient existed.
+    // Give PluginService the WorkspaceClient reference now that it's ready.
+    // initialize() is deferred and may run before or after this point — the
+    // service's pendingWorktreeSubs replay handles either ordering.
     try {
       const { pluginService } = await import("../services/PluginService.js");
       pluginService.setWorkspaceClient(workspaceClient);


### PR DESCRIPTION
## Summary

- Moves three non-critical service initializations off the cold-start critical path by plugging them into the existing `registerDeferredTask` queue
- `DatabaseMaintenanceService.initialize()` is split into a synchronous `probeDb` phase (stays on the critical path, required before `readLastActiveProjectIdSync`) and a `startMaintenance()` call deferred via `registerDeferredTask` — registered after `system-sleep-service` so the `onSuspend` listener attaches to a live service
- `CcrConfigService.loadAndApply()` + `startWatching()` and `pluginService.initialize()` are both deferred; IPC handlers for plugins register eagerly, and `AGENT_PRESETS_UPDATED` broadcasts when CCR config loads

Resolves #7459

## Changes

- `DatabaseMaintenanceService`: new `startMaintenance()` method; `initialize()` now probe-only
- `globalServicesInit.ts`: `CcrConfigService` deferred; database-maintenance task registered after system-sleep-service
- `windowServices.ts`: `pluginService.initialize()` deferred with eager IPC handler registration
- New tests: probe-without-maintenance, dispose-before-`startMaintenance()`, `startMaintenance()` idempotency, deferred-task ordering (database-maintenance after system-sleep-service), CCR-config and plugin-service registration smoke

## Testing

Verified with `npm run check` (tsc + eslint + format) and full unit test suite (200+ passing). Deferred-task ordering test confirms `database-maintenance` registers after `system-sleep-service`.