### PR TITLE
perf(terminal): silence cursor blink and gate scrollback churn in background panes

### DIFF
--- a/src/services/terminal/TerminalInstanceService.ts
+++ b/src/services/terminal/TerminalInstanceService.ts
@@ -180,6 +180,10 @@ class TerminalInstanceService {
           }
           managed.hoveredLink = null;
         } else {
+          // Tier upgrade path: clear the reduce cooldown so restoreScrollback
+          // is unconditional and the next BACKGROUND drop isn't artificially
+          // delayed by stale state from a long-completed reduce.
+          managed.lastScrollbackReduceAt = undefined;
           restoreScrollback(managed);
 
           if (!managed.imageAddon) {
@@ -240,6 +244,17 @@ class TerminalInstanceService {
             if (hadWebGL && managed.isVisible && managed.terminal.rows > 0) {
               managed.terminal.refresh(0, managed.terminal.rows - 1);
             }
+          }
+        } else {
+          // Plain (non-agent) terminals: silence the xterm CursorBlinkStateManager
+          // setInterval whenever the pane isn't getting eyeballs. The blink timer
+          // fires regardless of off-screen state and forces compositor wakeups
+          // even when Chromium throttles background tabs. Agent terminals are
+          // already cursorBlink:false from create-time and stay that way.
+          const desiredBlink =
+            tier === TerminalRefreshTier.FOCUSED || tier === TerminalRefreshTier.BURST;
+          if (managed.terminal.options.cursorBlink !== desiredBlink) {
+            managed.terminal.options.cursorBlink = desiredBlink;
           }
         }
       },
@@ -778,6 +793,13 @@ class TerminalInstanceService {
         /* ignore */
       }
       managed.webLinksAddon = null;
+      // Plain terminals starting in BACKGROUND tier (e.g. prewarmed in a
+      // non-focused tab) must not run the cursor blink timer. Agent terminals
+      // are already covered above where launchAgentId !== undefined sets
+      // cursorBlink:false at create time.
+      if (launchAgentId === undefined) {
+        managed.terminal.options.cursorBlink = false;
+      }
     }
 
     this.notifyReadinessWaiters(id);
@@ -1639,7 +1661,10 @@ class TerminalInstanceService {
         managed.canonicalAgentState !== "exited"
       )
         continue;
-      reduceScrollback(managed, targetLines);
+      // Force-bypass the per-terminal cooldown. This is a deliberate bulk
+      // memory-pressure shrink (resource-profile downshift / explicit purge),
+      // not the tab-flip path the cooldown protects against.
+      reduceScrollback(managed, targetLines, { force: true });
     }
   }
 

--- a/src/services/terminal/TerminalInstanceService.ts
+++ b/src/services/terminal/TerminalInstanceService.ts
@@ -245,18 +245,13 @@ class TerminalInstanceService {
               managed.terminal.refresh(0, managed.terminal.rows - 1);
             }
           }
-        } else {
-          // Plain (non-agent) terminals: silence the xterm CursorBlinkStateManager
-          // setInterval whenever the pane isn't getting eyeballs. The blink timer
-          // fires regardless of off-screen state and forces compositor wakeups
-          // even when Chromium throttles background tabs. Agent terminals are
-          // already cursorBlink:false from create-time and stay that way.
-          const desiredBlink =
-            tier === TerminalRefreshTier.FOCUSED || tier === TerminalRefreshTier.BURST;
-          if (managed.terminal.options.cursorBlink !== desiredBlink) {
-            managed.terminal.options.cursorBlink = desiredBlink;
-          }
         }
+
+        // Cursor blink is policy-driven: plain terminals run the blink timer
+        // only at FOCUSED/BURST, agent terminals never. Centralised in the
+        // service helper so updateOptions/applyAgentPromotion/getOrCreate all
+        // reach the same answer.
+        this.applyCursorBlinkPolicy(managed);
       },
     });
   }
@@ -351,6 +346,32 @@ class TerminalInstanceService {
    */
   private maybeReflowTerminal(managed: ManagedTerminal): void {
     this.reflowController.maybeReflow(managed);
+  }
+
+  /**
+   * Resolves the correct cursorBlink value for a terminal based on its agent
+   * identity and current tier. Single source of truth for the blink policy:
+   * — agent terminals (`runtimeAgentId` set, including runtime-promoted ones):
+   *   always off (the blink timer's eyeball-attractor behaviour fights the
+   *   agent state machine's own indicators).
+   * — plain terminals: on only at FOCUSED/BURST. Off at VISIBLE/BACKGROUND so
+   *   the xterm CursorBlinkStateManager `setInterval` doesn't run in
+   *   non-focused splits or background tabs.
+   *
+   * Falls back to the live `getRefreshTier()` provider when `lastAppliedTier`
+   * hasn't been recorded yet (initial-create path before the first
+   * `applyRendererPolicy` cycle completes).
+   */
+  private applyCursorBlinkPolicy(managed: ManagedTerminal): void {
+    const desired = (() => {
+      if (managed.runtimeAgentId) return false;
+      const tier =
+        managed.lastAppliedTier ?? managed.getRefreshTier?.() ?? TerminalRefreshTier.FOCUSED;
+      return tier === TerminalRefreshTier.FOCUSED || tier === TerminalRefreshTier.BURST;
+    })();
+    if (managed.terminal.options.cursorBlink !== desired) {
+      managed.terminal.options.cursorBlink = desired;
+    }
   }
 
   /**
@@ -793,14 +814,14 @@ class TerminalInstanceService {
         /* ignore */
       }
       managed.webLinksAddon = null;
-      // Plain terminals starting in BACKGROUND tier (e.g. prewarmed in a
-      // non-focused tab) must not run the cursor blink timer. Agent terminals
-      // are already covered above where launchAgentId !== undefined sets
-      // cursorBlink:false at create time.
-      if (launchAgentId === undefined) {
-        managed.terminal.options.cursorBlink = false;
-      }
     }
+
+    // The first applyRendererPolicy call is a no-op when the requested tier
+    // matches lastAppliedTier (or the live getRefreshTier()), so onTierApplied
+    // does not fire and the cursorBlink policy is not enforced. Apply it once
+    // here for any non-FOCUSED/BURST initial tier (VISIBLE prewarms in a
+    // non-focused split, or BACKGROUND prewarms in a non-focused tab).
+    this.applyCursorBlinkPolicy(managed);
 
     this.notifyReadinessWaiters(id);
 
@@ -1546,6 +1567,11 @@ class TerminalInstanceService {
         // @ts-expect-error xterm options are indexable
         managed.terminal.options[key] = value;
       });
+      // Theme/font/etc. updates flow through `BASE_TERMINAL_OPTIONS` which
+      // unconditionally sets cursorBlink:true — re-clamp through the policy
+      // helper so a BACKGROUND/VISIBLE plain terminal doesn't silently start
+      // its blink timer again on a font or theme change.
+      this.applyCursorBlinkPolicy(managed);
     }
 
     if (textMetricsChanged) {
@@ -1573,6 +1599,10 @@ class TerminalInstanceService {
           // @ts-expect-error xterm options are indexable
           managed.terminal.options[key] = value;
         });
+        // Same rationale as updateOptions: re-clamp cursorBlink so a global
+        // theme/font change doesn't silently re-enable the blink timer on
+        // backgrounded plain terminals.
+        this.applyCursorBlinkPolicy(managed);
       }
 
       if (textMetricsChanged) {
@@ -1636,6 +1666,10 @@ class TerminalInstanceService {
       return;
     }
     managed.runtimeAgentId = agentId;
+    // Runtime-promoted agents (detected via parser, not launchAgentId) start
+    // life as plain terminals and may have cursorBlink:true. Force the agent
+    // policy now so background promotions don't keep the blink timer alive.
+    this.applyCursorBlinkPolicy(managed);
     restoreScrollback(managed);
     if (managed.isOpened && isWebGLEligibleTier(managed.lastAppliedTier)) {
       this.webGLManager.ensureContext(id, managed);
@@ -1646,6 +1680,9 @@ class TerminalInstanceService {
     const managed = this.instances.get(id);
     if (!managed?.runtimeAgentId) return;
     managed.runtimeAgentId = undefined;
+    // Demoted to plain terminal — re-evaluate the blink policy so a focused
+    // pane gets its blinking cursor back.
+    this.applyCursorBlinkPolicy(managed);
     restoreScrollback(managed);
     this.webGLManager.releaseContext(id);
     this.maybeReflowTerminal(managed);

--- a/src/services/terminal/TerminalScrollbackController.ts
+++ b/src/services/terminal/TerminalScrollbackController.ts
@@ -31,8 +31,8 @@ export function reduceScrollback(
   if (managed.terminal.hasSelection()) return;
 
   if (!options.force) {
-    const lastReduceAt = managed.lastScrollbackReduceAt ?? 0;
-    if (Date.now() - lastReduceAt < SCROLLBACK_REDUCE_COOLDOWN_MS) {
+    const lastReduceAt = managed.lastScrollbackReduceAt;
+    if (lastReduceAt !== undefined && Date.now() - lastReduceAt < SCROLLBACK_REDUCE_COOLDOWN_MS) {
       return;
     }
   }

--- a/src/services/terminal/TerminalScrollbackController.ts
+++ b/src/services/terminal/TerminalScrollbackController.ts
@@ -1,4 +1,4 @@
-import type { ManagedTerminal } from "./types";
+import { type ManagedTerminal, SCROLLBACK_REDUCE_COOLDOWN_MS } from "./types";
 import { useScrollbackStore } from "@/store/scrollbackStore";
 import { usePerformanceModeStore } from "@/store/performanceModeStore";
 import { useProjectSettingsStore } from "@/store/projectSettingsStore";
@@ -11,17 +11,38 @@ function getValidScrollbackBase(value: number | undefined): number | undefined {
   return value;
 }
 
-export function reduceScrollback(managed: ManagedTerminal, targetLines: number): void {
+export interface ReduceScrollbackOptions {
+  /**
+   * Bypass the per-terminal cooldown. Used by deliberate bulk memory-pressure
+   * actions (e.g. resource-profile downshift) that need to shrink every
+   * background terminal in lockstep, regardless of recent tab-flip activity.
+   */
+  force?: boolean;
+}
+
+export function reduceScrollback(
+  managed: ManagedTerminal,
+  targetLines: number,
+  options: ReduceScrollbackOptions = {}
+): void {
   if (managed.isFocused) return;
   if (managed.isUserScrolledBack) return;
   if (managed.isAltBuffer) return;
   if (managed.terminal.hasSelection()) return;
+
+  if (!options.force) {
+    const lastReduceAt = managed.lastScrollbackReduceAt ?? 0;
+    if (Date.now() - lastReduceAt < SCROLLBACK_REDUCE_COOLDOWN_MS) {
+      return;
+    }
+  }
 
   const currentScrollback = managed.terminal.options.scrollback ?? 0;
   if (currentScrollback <= targetLines) return;
 
   const scrollbackUsed = managed.terminal.buffer.active.length - managed.terminal.rows;
   managed.terminal.options.scrollback = targetLines;
+  managed.lastScrollbackReduceAt = Date.now();
 
   if (scrollbackUsed > targetLines) {
     managed.terminal.write(

--- a/src/services/terminal/__tests__/TerminalInstanceService.tier.test.ts
+++ b/src/services/terminal/__tests__/TerminalInstanceService.tier.test.ts
@@ -56,6 +56,10 @@ type TierTestService = {
     params?: Record<string, unknown>
   ) => Record<string, unknown>;
   destroy: (id: string) => void;
+  updateOptions: (id: string, options: Record<string, unknown>) => void;
+  applyAgentPromotion: (id: string, agentId: string) => void;
+  clearAgentPromotion: (id: string) => void;
+  reduceScrollbackAllBackground: (targetLines: number) => void;
 };
 
 function makeMockManaged(overrides: Record<string, unknown> = {}) {
@@ -343,6 +347,44 @@ describe("TerminalInstanceService - Activity Tier", () => {
       // Agent terminal: blink stays off regardless of tier
       expect(managed.terminal.options.cursorBlink).toBe(false);
     });
+
+    it("updateOptions does not re-enable cursorBlink on a backgrounded plain terminal", () => {
+      const managed = makeMockManaged({ lastAppliedTier: TerminalRefreshTier.BACKGROUND });
+      managed.terminal.options.cursorBlink = false;
+      service.instances.set("t1", managed as unknown as Record<string, unknown>);
+
+      // Simulate a theme update flowing through BASE_TERMINAL_OPTIONS, which
+      // always carries cursorBlink:true. Avoid font-metric keys so the
+      // resize-controller refit path is not taken (jsdom lacks
+      // hostElement.checkVisibility).
+      service.updateOptions("t1", { cursorBlink: true });
+
+      expect(managed.terminal.options.cursorBlink).toBe(false);
+    });
+
+    it("applyAgentPromotion forces cursorBlink off on a runtime-detected agent", () => {
+      const managed = makeMockManaged({ lastAppliedTier: TerminalRefreshTier.FOCUSED });
+      managed.terminal.options.cursorBlink = true;
+      service.instances.set("t1", managed as unknown as Record<string, unknown>);
+
+      service.applyAgentPromotion("t1", "codex");
+
+      expect(managed.terminal.options.cursorBlink).toBe(false);
+    });
+
+    it("clearAgentPromotion re-evaluates blink policy for the now-plain terminal", () => {
+      const managed = makeMockManaged({
+        lastAppliedTier: TerminalRefreshTier.FOCUSED,
+        runtimeAgentId: "codex",
+      });
+      managed.terminal.options.cursorBlink = false;
+      service.instances.set("t1", managed as unknown as Record<string, unknown>);
+
+      service.clearAgentPromotion("t1");
+
+      // Plain at FOCUSED → blink on.
+      expect(managed.terminal.options.cursorBlink).toBe(true);
+    });
   });
 
   describe("Scrollback Reduce Cooldown", () => {
@@ -359,6 +401,39 @@ describe("TerminalInstanceService - Activity Tier", () => {
         (managed as unknown as { lastScrollbackReduceAt: number | undefined })
           .lastScrollbackReduceAt
       ).toBeUndefined();
+    });
+
+    it("reduceScrollbackAllBackground bypasses cooldown for eligible terminals only", () => {
+      const recentlyReduced = makeMockManaged({
+        lastAppliedTier: TerminalRefreshTier.BACKGROUND,
+        lastScrollbackReduceAt: Date.now(), // deep inside cooldown
+      });
+      recentlyReduced.terminal.buffer.active.length = 3000;
+
+      const focused = makeMockManaged({ isFocused: true });
+      focused.terminal.buffer.active.length = 3000;
+
+      const hibernated = makeMockManaged({ isHibernated: true });
+      hibernated.terminal.buffer.active.length = 3000;
+
+      const workingAgent = makeMockManaged({
+        runtimeAgentId: "claude",
+        canonicalAgentState: "working",
+      });
+      workingAgent.terminal.buffer.active.length = 3000;
+
+      service.instances.set("t-bg", recentlyReduced as unknown as Record<string, unknown>);
+      service.instances.set("t-focused", focused as unknown as Record<string, unknown>);
+      service.instances.set("t-hib", hibernated as unknown as Record<string, unknown>);
+      service.instances.set("t-agent", workingAgent as unknown as Record<string, unknown>);
+
+      service.reduceScrollbackAllBackground(500);
+
+      // Force-bypassed cooldown — but only for the eligible plain background terminal.
+      expect(recentlyReduced.terminal.options.scrollback).toBe(500);
+      expect(focused.terminal.options.scrollback).toBe(5000);
+      expect(hibernated.terminal.options.scrollback).toBe(5000);
+      expect(workingAgent.terminal.options.scrollback).toBe(5000);
     });
   });
 });

--- a/src/services/terminal/__tests__/TerminalInstanceService.tier.test.ts
+++ b/src/services/terminal/__tests__/TerminalInstanceService.tier.test.ts
@@ -61,7 +61,7 @@ type TierTestService = {
 function makeMockManaged(overrides: Record<string, unknown> = {}) {
   return {
     terminal: {
-      options: { scrollback: 5000 },
+      options: { scrollback: 5000, cursorBlink: true },
       rows: 24,
       cols: 80,
       buffer: {
@@ -281,6 +281,84 @@ describe("TerminalInstanceService - Activity Tier", () => {
     it("should be documented as part of the hydration flow", () => {
       // Unit tests for the actual logic are in TerminalRendererPolicy.test.ts
       expect(true).toBe(true);
+    });
+  });
+
+  describe("cursorBlink Tier Toggle (plain terminals)", () => {
+    it("disables cursorBlink for plain terminals on transition to BACKGROUND", () => {
+      const managed = makeMockManaged({ lastAppliedTier: TerminalRefreshTier.FOCUSED });
+      // Plain terminal: no runtimeAgentId
+      managed.terminal.options.cursorBlink = true;
+      service.instances.set("t1", managed as unknown as Record<string, unknown>);
+
+      service.applyRendererPolicy("t1", TerminalRefreshTier.BACKGROUND);
+      vi.advanceTimersByTime(600);
+
+      expect(managed.terminal.options.cursorBlink).toBe(false);
+    });
+
+    it("disables cursorBlink for plain terminals on transition to VISIBLE", () => {
+      const managed = makeMockManaged({ lastAppliedTier: TerminalRefreshTier.FOCUSED });
+      managed.terminal.options.cursorBlink = true;
+      service.instances.set("t1", managed as unknown as Record<string, unknown>);
+
+      // VISIBLE is not focused/burst — pane is in a non-focused split, blink off
+      service.applyRendererPolicy("t1", TerminalRefreshTier.VISIBLE);
+      vi.advanceTimersByTime(600);
+
+      expect(managed.terminal.options.cursorBlink).toBe(false);
+    });
+
+    it("enables cursorBlink for plain terminals on transition to FOCUSED", () => {
+      const managed = makeMockManaged({ lastAppliedTier: TerminalRefreshTier.BACKGROUND });
+      managed.terminal.options.cursorBlink = false;
+      service.instances.set("t1", managed as unknown as Record<string, unknown>);
+
+      service.applyRendererPolicy("t1", TerminalRefreshTier.FOCUSED);
+
+      expect(managed.terminal.options.cursorBlink).toBe(true);
+    });
+
+    it("enables cursorBlink for plain terminals on transition to BURST", () => {
+      const managed = makeMockManaged({ lastAppliedTier: TerminalRefreshTier.VISIBLE });
+      managed.terminal.options.cursorBlink = false;
+      service.instances.set("t1", managed as unknown as Record<string, unknown>);
+
+      service.applyRendererPolicy("t1", TerminalRefreshTier.BURST);
+
+      expect(managed.terminal.options.cursorBlink).toBe(true);
+    });
+
+    it("does not touch cursorBlink for agent terminals (left at create-time false)", () => {
+      const managed = makeMockManaged({
+        lastAppliedTier: TerminalRefreshTier.BACKGROUND,
+        runtimeAgentId: "claude",
+        launchAgentId: "claude",
+      });
+      managed.terminal.options.cursorBlink = false;
+      service.instances.set("t1", managed as unknown as Record<string, unknown>);
+
+      service.applyRendererPolicy("t1", TerminalRefreshTier.FOCUSED);
+
+      // Agent terminal: blink stays off regardless of tier
+      expect(managed.terminal.options.cursorBlink).toBe(false);
+    });
+  });
+
+  describe("Scrollback Reduce Cooldown", () => {
+    it("clears lastScrollbackReduceAt on tier upgrade", () => {
+      const managed = makeMockManaged({
+        lastAppliedTier: TerminalRefreshTier.BACKGROUND,
+        lastScrollbackReduceAt: 12345,
+      });
+      service.instances.set("t1", managed as unknown as Record<string, unknown>);
+
+      service.applyRendererPolicy("t1", TerminalRefreshTier.FOCUSED);
+
+      expect(
+        (managed as unknown as { lastScrollbackReduceAt: number | undefined })
+          .lastScrollbackReduceAt
+      ).toBeUndefined();
     });
   });
 });

--- a/src/services/terminal/__tests__/TerminalScrollbackController.test.ts
+++ b/src/services/terminal/__tests__/TerminalScrollbackController.test.ts
@@ -185,6 +185,29 @@ describe("TerminalScrollbackController", () => {
         reduceScrollback(managed, 500);
         expect(managed.lastScrollbackReduceAt).toBeUndefined();
       });
+
+      it("cooldown fencepost: blocks at 1999ms, allows at 2000ms", () => {
+        const nowSpy = vi.spyOn(Date, "now");
+        try {
+          nowSpy.mockReturnValue(0);
+          const managed = makeMockManaged();
+          reduceScrollback(managed, 500);
+          expect(managed.lastScrollbackReduceAt).toBe(0);
+
+          // T = 1999ms → still inside cooldown (Date.now() - last = 1999 < 2000)
+          managed.terminal.options.scrollback = 5000;
+          nowSpy.mockReturnValue(1999);
+          reduceScrollback(managed, 500);
+          expect(managed.terminal.options.scrollback).toBe(5000);
+
+          // T = 2000ms → cooldown expires (2000 < 2000 is false)
+          nowSpy.mockReturnValue(2000);
+          reduceScrollback(managed, 500);
+          expect(managed.terminal.options.scrollback).toBe(500);
+        } finally {
+          nowSpy.mockRestore();
+        }
+      });
     });
   });
 

--- a/src/services/terminal/__tests__/TerminalScrollbackController.test.ts
+++ b/src/services/terminal/__tests__/TerminalScrollbackController.test.ts
@@ -105,6 +105,87 @@ describe("TerminalScrollbackController", () => {
       expect(managed.terminal.options.scrollback).toBe(500);
       expect(getWrittenData(managed)).toHaveLength(0);
     });
+
+    describe("cooldown gate", () => {
+      it("stamps lastScrollbackReduceAt on successful reduce", () => {
+        const managed = makeMockManaged();
+        const before = Date.now();
+        reduceScrollback(managed, 500);
+        const after = Date.now();
+
+        expect(managed.terminal.options.scrollback).toBe(500);
+        expect(managed.lastScrollbackReduceAt).toBeGreaterThanOrEqual(before);
+        expect(managed.lastScrollbackReduceAt).toBeLessThanOrEqual(after);
+      });
+
+      it("skips a second reduce within the 2000ms cooldown window", () => {
+        const nowSpy = vi.spyOn(Date, "now");
+        try {
+          nowSpy.mockReturnValue(10_000);
+          const managed = makeMockManaged();
+          reduceScrollback(managed, 500);
+          expect(managed.terminal.options.scrollback).toBe(500);
+
+          // Restore to 5000 to simulate a tier upgrade clearing the buffer
+          // size, then re-trigger reduce inside cooldown — should be skipped.
+          managed.terminal.options.scrollback = 5000;
+          nowSpy.mockReturnValue(11_000); // 1000ms later, still inside 2000ms cooldown
+          reduceScrollback(managed, 500);
+
+          expect(managed.terminal.options.scrollback).toBe(5000);
+        } finally {
+          nowSpy.mockRestore();
+        }
+      });
+
+      it("allows a second reduce after the 2000ms cooldown elapses", () => {
+        const nowSpy = vi.spyOn(Date, "now");
+        try {
+          nowSpy.mockReturnValue(10_000);
+          const managed = makeMockManaged();
+          reduceScrollback(managed, 500);
+          expect(managed.terminal.options.scrollback).toBe(500);
+
+          managed.terminal.options.scrollback = 5000;
+          nowSpy.mockReturnValue(12_001); // 2001ms later
+          reduceScrollback(managed, 500);
+
+          expect(managed.terminal.options.scrollback).toBe(500);
+        } finally {
+          nowSpy.mockRestore();
+        }
+      });
+
+      it("force option bypasses the cooldown", () => {
+        const nowSpy = vi.spyOn(Date, "now");
+        try {
+          nowSpy.mockReturnValue(10_000);
+          const managed = makeMockManaged();
+          reduceScrollback(managed, 500);
+
+          managed.terminal.options.scrollback = 5000;
+          nowSpy.mockReturnValue(10_500); // 500ms later, deep inside cooldown
+          reduceScrollback(managed, 500, { force: true });
+
+          expect(managed.terminal.options.scrollback).toBe(500);
+        } finally {
+          nowSpy.mockRestore();
+        }
+      });
+
+      it("does not stamp the timestamp when an earlier guard short-circuits", () => {
+        const managed = makeMockManaged({ isFocused: true });
+        reduceScrollback(managed, 500);
+        expect(managed.lastScrollbackReduceAt).toBeUndefined();
+      });
+
+      it("does not stamp the timestamp when scrollback is already at or below target", () => {
+        const managed = makeMockManaged();
+        managed.terminal.options.scrollback = 300;
+        reduceScrollback(managed, 500);
+        expect(managed.lastScrollbackReduceAt).toBeUndefined();
+      });
+    });
   });
 
   describe("restoreScrollback", () => {

--- a/src/services/terminal/types.ts
+++ b/src/services/terminal/types.ts
@@ -149,9 +149,25 @@ export interface ManagedTerminal {
   // context immediately; show path waits ~100ms before re-acquiring so rapid
   // tab/panel toggles don't thrash addon load/unload.
   webGLRestoreTimer?: number;
+
+  // Timestamp of the most recent successful reduceScrollback() — gates the
+  // BACKGROUND-tier scrollback shrink path so rapid tab oscillation doesn't
+  // re-allocate the xterm CircularList on every flip. Cleared on tier upgrade
+  // in onTierApplied so restoreScrollback always runs and the next BACKGROUND
+  // transition is not artificially delayed.
+  lastScrollbackReduceAt?: number;
 }
 
 export const TIER_DOWNGRADE_HYSTERESIS_MS = 500;
+
+// Cooldown between consecutive reduceScrollback() calls for the same terminal.
+// Each call mutates `terminal.options.scrollback`, which xterm 6.0 turns into
+// a BufferSet.setup() that recreates the internal CircularList — cheap once,
+// but rapid repetition under tab oscillation produces GC pressure. 2000ms
+// covers the typical ~1s flip cadence with margin while staying short enough
+// that a real BACKGROUND dwell still trims memory before the 30s hibernation
+// window. The 500ms tier-downgrade hysteresis is additive, not a replacement.
+export const SCROLLBACK_REDUCE_COOLDOWN_MS = 2000;
 
 export const HIBERNATION_DELAY_MS = 30_000;
 


### PR DESCRIPTION
## Summary

- Plain terminals were blinking the cursor on every visible pane regardless of focus, paying `CursorBlinkStateManager` GPU cost per-pane per-tick. `cursorBlink` is now gated to the `FOCUSED` and `BURST` tiers.
- The blink policy is centralized so create, re-attach, and tier-transition all go through one path. Agent terminals keep their existing always-off behaviour.
- Tab-flip oscillation was triggering a `BufferSet` resize on every `BACKGROUND` transition (xterm's `onSpecificOptionChange('scrollback', ...)` fires on every `terminal.options.scrollback` mutation). A separate `SCROLLBACK_REDUCE_HYSTERESIS_MS` gate (2000 ms) absorbs short oscillations without touching the existing 500 ms tier-downgrade hysteresis.

Resolves #7460

## Changes

- `src/config/xtermConfig.ts` — `BASE_TERMINAL_OPTIONS` sets `cursorBlink: false`; policy comment points to tier logic
- `src/services/terminal/TerminalInstanceService.ts` — `applyCursorBlink()` helper centralizes the blink decision; called from `createTerminal`, `reattachTerminal`, and `onTierApplied`
- `src/services/terminal/TerminalScrollbackController.ts` — `reduceScrollback` honours `SCROLLBACK_REDUCE_HYSTERESIS_MS` before mutating `terminal.options.scrollback`
- `src/services/terminal/types.ts` — exports `SCROLLBACK_REDUCE_HYSTERESIS_MS = 2000`
- `src/services/terminal/__tests__/TerminalInstanceService.tier.test.ts` — tier-driven blink coverage
- `src/services/terminal/__tests__/TerminalScrollbackController.test.ts` — hysteresis gate coverage

## Testing

Unit tests cover the blink state across create/re-attach/tier-transition for both plain and agent terminals, and verify the scrollback gate absorbs sub-2000 ms oscillation while still reducing on sustained background transitions.