### PR TITLE
perf(panel-store): index panels by worktree for per-row selectors

### DIFF
--- a/src/components/Layout/AgentButton.tsx
+++ b/src/components/Layout/AgentButton.tsx
@@ -1,4 +1,5 @@
-import { useMemo, useRef, useState, type PointerEvent as ReactPointerEvent } from "react";
+import { useRef, useState, type PointerEvent as ReactPointerEvent } from "react";
+import { useShallow } from "zustand/react/shallow";
 import { Button } from "@/components/ui/button";
 import { Tooltip, TooltipContent, TooltipTrigger } from "@/components/ui/tooltip";
 import { ShortcutRevealChip } from "@/components/ui/ShortcutRevealChip";
@@ -155,8 +156,6 @@ export function AgentButton({
   const ccrPresets = useCcrPresetsStore((s) => s.ccrPresetsByAgent[type]);
   const projectPresets = useProjectPresetsStore((s) => s.presetsByAgent[type]);
 
-  const panelsById = usePanelStore((s) => s.panelsById);
-  const panelIds = usePanelStore((s) => s.panelIds);
   const activeWorktreeId = useWorktreeSelectionStore((s) => s.activeWorktreeId);
 
   // Radix Tooltip reopens on focus restoration. When the chevron's
@@ -193,26 +192,29 @@ export function AgentButton({
     isRestoringFocusRef.current = false;
   };
 
-  const activeSession = useMemo(() => {
-    const states: (AgentState | undefined)[] = [];
-    let firstId: string | null = null;
-    for (const pid of panelIds) {
-      const p = panelsById[pid];
-      if (
-        !p ||
-        getRuntimeOrBootAgentId(p) !== type ||
-        p.location === "trash" ||
-        p.location === "background"
-      )
-        continue;
-      if (activeWorktreeId && p.worktreeId !== activeWorktreeId) continue;
-      if (!ACTIVE_AGENT_STATES.has(p.agentState)) continue;
-      if (!firstId) firstId = pid;
-      states.push(p.agentState);
-    }
-    if (!firstId) return null;
-    return { id: firstId, dominantState: getDominantAgentState(states) };
-  }, [panelsById, panelIds, activeWorktreeId, type]);
+  // Single useShallow selector — scoped to the active worktree's pre-computed
+  // bucket so per-terminal ticks in unrelated worktrees do not re-evaluate this
+  // selector body. When `activeWorktreeId` is null, fall back to scanning all
+  // panel ids (rare, only during project switch hydration). See issue #7451.
+  const activeSession = usePanelStore(
+    useShallow((state) => {
+      const ids = activeWorktreeId ? state.panelIdsByWorktreeId[activeWorktreeId] : state.panelIds;
+      if (!ids || ids.length === 0) return null;
+      const states: (AgentState | undefined)[] = [];
+      let firstId: string | null = null;
+      for (const pid of ids) {
+        const p = state.panelsById[pid];
+        if (!p) continue;
+        if (getRuntimeOrBootAgentId(p) !== type) continue;
+        if (p.location === "trash" || p.location === "background") continue;
+        if (!ACTIVE_AGENT_STATES.has(p.agentState)) continue;
+        if (!firstId) firstId = pid;
+        states.push(p.agentState);
+      }
+      if (!firstId) return null;
+      return { id: firstId, dominantState: getDominantAgentState(states) };
+    })
+  );
 
   const config = getAgentConfig(type);
   if (!config) return null;

--- a/src/components/Layout/__tests__/AgentButton.test.tsx
+++ b/src/components/Layout/__tests__/AgentButton.test.tsx
@@ -73,9 +73,14 @@ vi.mock("@/store/projectPresetsStore", () => ({
 
 let mockPanelsById: Record<string, unknown> = {};
 let mockPanelIds: string[] = [];
+let mockPanelIdsByWorktreeId: Record<string, string[]> = {};
 vi.mock("@/store/panelStore", () => ({
   usePanelStore: (selector: (s: Record<string, unknown>) => unknown) =>
-    selector({ panelsById: mockPanelsById, panelIds: mockPanelIds }),
+    selector({
+      panelsById: mockPanelsById,
+      panelIds: mockPanelIds,
+      panelIdsByWorktreeId: mockPanelIdsByWorktreeId,
+    }),
 }));
 
 vi.mock("@/store/worktreeStore", () => ({
@@ -314,6 +319,7 @@ describe("AgentButton preset UX", () => {
     mockDotColor = "";
     mockPanelsById = {};
     mockPanelIds = [];
+    mockPanelIdsByWorktreeId = {};
     mockWorktrees = [];
     dropdownCloseAutoFocusSpy = null;
     dropdownPointerDownOutsideSpy = null;
@@ -832,6 +838,7 @@ describe("AgentButton preset UX", () => {
       mockSettings = settingsWith({ claude: {} });
       mockPanelsById = { "panel-1": activePanel("waiting") };
       mockPanelIds = ["panel-1"];
+      mockPanelIdsByWorktreeId = { "wt-1": ["panel-1"] };
       mockActiveWorktreeId = "wt-1";
       mockDominantState = "waiting";
       mockDotColor = "bg-state-waiting";
@@ -848,6 +855,7 @@ describe("AgentButton preset UX", () => {
       mockSettings = settingsWith({ claude: {} });
       mockPanelsById = { "panel-1": activePanel("working") };
       mockPanelIds = ["panel-1"];
+      mockPanelIdsByWorktreeId = { "wt-1": ["panel-1"] };
       mockActiveWorktreeId = "wt-1";
       mockDominantState = "working";
       mockDotColor = null;

--- a/src/components/Sidebar/SidebarContent.tsx
+++ b/src/components/Sidebar/SidebarContent.tsx
@@ -160,11 +160,68 @@ function SidebarContent({ onOpenOverview }: SidebarContentProps) {
   const pruneStaleWorktreeIds = useWorktreeFilterStore((state) => state.pruneStaleWorktreeIds);
   const setQuickStateFilter = useWorktreeFilterStore((state) => state.setQuickStateFilter);
 
-  // Terminal store for derived metadata
-  const panelsById = usePanelStore((state) => state.panelsById);
-  const panelIds = usePanelStore((state) => state.panelIds);
-  const isInTrash = usePanelStore((state) => state.isInTrash);
+  // Terminal store: single selector that emits per-worktree counts so we don't
+  // re-scan all panels on every per-terminal tick. See issue #7451.
   const worktreeIds = useWorktreeIds();
+  const worktreeIdList = useMemo(() => deferredWorktrees.map((w) => w.id), [deferredWorktrees]);
+  const panelStateByWorktree = usePanelStore(
+    useShallow((state) => {
+      const result: Record<
+        string,
+        {
+          terminalCount: number;
+          waitingTerminalCount: number;
+          hasWorkingAgent: boolean;
+          hasWaitingAgent: boolean;
+          hasCompletedAgent: boolean;
+          hasExitedAgent: boolean;
+        }
+      > = {};
+      for (const worktreeId of worktreeIdList) {
+        const ids = state.panelIdsByWorktreeId[worktreeId];
+        if (!ids || ids.length === 0) {
+          result[worktreeId] = {
+            terminalCount: 0,
+            waitingTerminalCount: 0,
+            hasWorkingAgent: false,
+            hasWaitingAgent: false,
+            hasCompletedAgent: false,
+            hasExitedAgent: false,
+          };
+          continue;
+        }
+        let terminalCount = 0;
+        let waitingTerminalCount = 0;
+        let hasWorkingAgent = false;
+        let hasWaitingAgent = false;
+        let hasCompletedAgent = false;
+        let hasExitedAgent = false;
+        for (const id of ids) {
+          const t = state.panelsById[id];
+          if (!t) continue;
+          if (!isTerminalVisible(t, state.isInTrash, worktreeIds)) continue;
+          terminalCount++;
+          if (!isAgentTerminal(t)) continue;
+          if (t.agentState === "working") hasWorkingAgent = true;
+          if (t.agentState === "waiting") {
+            hasWaitingAgent = true;
+            waitingTerminalCount++;
+          }
+          if (t.agentState === "completed") hasCompletedAgent = true;
+          if (t.agentState === "exited") hasExitedAgent = true;
+        }
+        result[worktreeId] = {
+          terminalCount,
+          waitingTerminalCount,
+          hasWorkingAgent,
+          hasWaitingAgent,
+          hasCompletedAgent,
+          hasExitedAgent,
+        };
+      }
+      return result;
+    })
+  );
 
   const scrollContentRef = useRef<HTMLDivElement>(null);
   const searchInputRef = useRef<HTMLInputElement>(null);
@@ -222,31 +279,20 @@ function SidebarContent({ onOpenOverview }: SidebarContentProps) {
     }
   }, [worktrees, manualOrder, setManualOrder]);
 
-  // Compute derived metadata for each worktree
+  // Compute derived metadata for each worktree. Panel scan is delegated to the
+  // single-pass `panelStateByWorktree` selector above, so this useMemo only
+  // joins per-worktree state with worktree-level fields and chip computation.
   const derivedMetaMap = useMemo(() => {
     const map = new Map<string, DerivedWorktreeMeta>();
     for (const worktree of deferredWorktrees) {
-      let terminalCount = 0;
-      let waitingTerminalCount = 0;
-      let hasWorkingAgent = false;
-      let hasWaitingAgent = false;
-      let hasCompletedAgent = false;
-      let hasExitedAgent = false;
-
-      for (const id of panelIds) {
-        const t = panelsById[id];
-        if (!t || t.worktreeId !== worktree.id || !isTerminalVisible(t, isInTrash, worktreeIds))
-          continue;
-        terminalCount++;
-        if (!isAgentTerminal(t)) continue;
-        if (t.agentState === "working") hasWorkingAgent = true;
-        if (t.agentState === "waiting") {
-          hasWaitingAgent = true;
-          waitingTerminalCount++;
-        }
-        if (t.agentState === "completed") hasCompletedAgent = true;
-        if (t.agentState === "exited") hasExitedAgent = true;
-      }
+      const panelState = panelStateByWorktree[worktree.id] ?? {
+        terminalCount: 0,
+        waitingTerminalCount: 0,
+        hasWorkingAgent: false,
+        hasWaitingAgent: false,
+        hasCompletedAgent: false,
+        hasExitedAgent: false,
+      };
 
       // chipState logic mirrors useWorktreeStatus.ts — keep in sync
       const hasChanges = (worktree.worktreeChanges?.changedFileCount ?? 0) > 0;
@@ -266,25 +312,25 @@ function SidebarContent({ onOpenOverview }: SidebarContentProps) {
       }
 
       const chipState = computeChipState({
-        waitingTerminalCount,
+        waitingTerminalCount: panelState.waitingTerminalCount,
         lifecycleStage,
         isComplete,
-        hasActiveAgent: hasWorkingAgent,
+        hasActiveAgent: panelState.hasWorkingAgent,
       });
 
       map.set(worktree.id, {
-        terminalCount,
-        hasWorkingAgent,
-        hasWaitingAgent,
-        hasCompletedAgent,
-        hasExitedAgent,
+        terminalCount: panelState.terminalCount,
+        hasWorkingAgent: panelState.hasWorkingAgent,
+        hasWaitingAgent: panelState.hasWaitingAgent,
+        hasCompletedAgent: panelState.hasCompletedAgent,
+        hasExitedAgent: panelState.hasExitedAgent,
         hasMergeConflict:
           worktree.worktreeChanges?.changes.some((c) => c.status === "conflicted") ?? false,
         chipState,
       });
     }
     return map;
-  }, [deferredWorktrees, panelsById, panelIds, isInTrash, worktreeIds]);
+  }, [deferredWorktrees, panelStateByWorktree]);
 
   // Apply filters and sorting
   const mainWorktree = useMemo(

--- a/src/hooks/useTerminalSelectors.ts
+++ b/src/hooks/useTerminalSelectors.ts
@@ -80,19 +80,19 @@ export function useTerminalNotificationCounts(blurTime?: number | null): {
 
 export function useWaitingTerminals(): TerminalInstance[] {
   const worktreeIds = useWorktreeIds();
-  const panelIds = usePanelStore((state) => state.panelIds);
-  const panelsById = usePanelStore((state) => state.panelsById);
-  const isInTrash = usePanelStore((state) => state.isInTrash);
 
-  return useMemo(
-    () =>
-      panelIds
-        .map((id) => panelsById[id])
-        .filter(
-          (t): t is TerminalInstance =>
-            !!t && t.agentState === "waiting" && isTerminalVisible(t, isInTrash, worktreeIds)
-        ),
-    [panelIds, panelsById, isInTrash, worktreeIds]
+  return usePanelStore(
+    useShallow((state) => {
+      const out: TerminalInstance[] = [];
+      for (const id of state.panelIds) {
+        const t = state.panelsById[id];
+        if (!t) continue;
+        if (t.agentState !== "waiting") continue;
+        if (!isTerminalVisible(t, state.isInTrash, worktreeIds)) continue;
+        out.push(t);
+      }
+      return out;
+    })
   );
 }
 
@@ -103,18 +103,19 @@ export function useWaitingTerminalIds(): string[] {
 
 export function useBackgroundedTerminals(): TerminalInstance[] {
   const worktreeIds = useWorktreeIds();
-  const panelIds = usePanelStore((state) => state.panelIds);
-  const panelsById = usePanelStore((state) => state.panelsById);
 
-  return useMemo(
-    () =>
-      panelIds
-        .map((id) => panelsById[id])
-        .filter(
-          (t): t is TerminalInstance =>
-            !!t && t.location === "background" && !isTerminalOrphaned(t, worktreeIds)
-        ),
-    [panelIds, panelsById, worktreeIds]
+  return usePanelStore(
+    useShallow((state) => {
+      const out: TerminalInstance[] = [];
+      for (const id of state.panelIds) {
+        const t = state.panelsById[id];
+        if (!t) continue;
+        if (t.location !== "background") continue;
+        if (isTerminalOrphaned(t, worktreeIds)) continue;
+        out.push(t);
+      }
+      return out;
+    })
   );
 }
 

--- a/src/hooks/useWorktreeTerminals.ts
+++ b/src/hooks/useWorktreeTerminals.ts
@@ -76,21 +76,22 @@ function useDebouncedValue<T>(value: T, delay: number): T {
 }
 
 export function useWorktreeTerminals(worktreeId: string): UseWorktreeTerminalsResult {
-  // Use useShallow to prevent infinite loops.
-  // Without this, .filter() returns a new reference every render,
-  // breaking React's useSyncExternalStore contract.
+  // Reads only from this worktree's pre-computed bucket (`panelIdsByWorktreeId`)
+  // so the selector body cost is bounded by the worktree's own panel count, not
+  // by total `panelIds`. The bucket reference is reference-stable when other
+  // worktrees mutate (issue #7451) — useShallow then skips re-renders unless a
+  // panel object inside this worktree actually changed.
   const terminals = usePanelStore(
-    useShallow((state) =>
-      state.panelIds
+    useShallow((state) => {
+      const ids = state.panelIdsByWorktreeId[worktreeId];
+      if (!ids || ids.length === 0) return [];
+      return ids
         .map((id) => state.panelsById[id])
         .filter(
           (t): t is TerminalInstance =>
-            t !== undefined &&
-            t.worktreeId === worktreeId &&
-            t.location !== "trash" &&
-            t.ephemeral !== true
-        )
-    )
+            t !== undefined && t.location !== "trash" && t.ephemeral !== true
+        );
+    })
   );
 
   const result = useMemo(() => {

--- a/src/store/panelStore.ts
+++ b/src/store/panelStore.ts
@@ -571,6 +571,7 @@ export const usePanelStore = create<PanelGridState>()(
         set({
           panelsById: {},
           panelIds: [],
+          panelIdsByWorktreeId: {},
           trashedTerminals: new Map(),
           backgroundedTerminals: new Map(),
           tabGroups: new Map(),
@@ -615,6 +616,7 @@ export const usePanelStore = create<PanelGridState>()(
         set({
           panelsById: {},
           panelIds: [],
+          panelIdsByWorktreeId: {},
           trashedTerminals: new Map(),
           backgroundedTerminals: new Map(),
           tabGroups: new Map(),
@@ -661,6 +663,7 @@ export const usePanelStore = create<PanelGridState>()(
         set({
           panelsById: {},
           panelIds: [],
+          panelIdsByWorktreeId: {},
           trashedTerminals: new Map(),
           backgroundedTerminals: new Map(),
           tabGroups: new Map(),

--- a/src/store/slices/panelRegistry/__tests__/worktreeIndex.test.ts
+++ b/src/store/slices/panelRegistry/__tests__/worktreeIndex.test.ts
@@ -1,0 +1,159 @@
+import { describe, it, expect } from "vitest";
+import {
+  addToWorktreeIndex,
+  removeFromWorktreeIndex,
+  transferBetweenWorktreeIndex,
+  buildWorktreeIndex,
+  type PanelIdsByWorktreeId,
+} from "../worktreeIndex";
+
+describe("worktreeIndex", () => {
+  describe("addToWorktreeIndex", () => {
+    it("creates a new bucket when worktree has no entries yet", () => {
+      const next = addToWorktreeIndex({}, "wt-A", "panel-1");
+      expect(next).toEqual({ "wt-A": ["panel-1"] });
+    });
+
+    it("appends to an existing bucket", () => {
+      const next = addToWorktreeIndex({ "wt-A": ["panel-1"] }, "wt-A", "panel-2");
+      expect(next).toEqual({ "wt-A": ["panel-1", "panel-2"] });
+    });
+
+    it("uses the __none__ bucket for undefined worktreeId", () => {
+      const next = addToWorktreeIndex({}, undefined, "panel-1");
+      expect(next).toEqual({ __none__: ["panel-1"] });
+    });
+
+    it("uses the __none__ bucket for null worktreeId", () => {
+      const next = addToWorktreeIndex({}, null, "panel-1");
+      expect(next).toEqual({ __none__: ["panel-1"] });
+    });
+
+    it("returns the same index reference when the panel is already present", () => {
+      const before: PanelIdsByWorktreeId = { "wt-A": ["panel-1"] };
+      const after = addToWorktreeIndex(before, "wt-A", "panel-1");
+      expect(after).toBe(before);
+    });
+
+    it("preserves reference stability for unaffected buckets", () => {
+      const wtBBucket = ["panel-2"];
+      const before: PanelIdsByWorktreeId = { "wt-A": ["panel-1"], "wt-B": wtBBucket };
+      const after = addToWorktreeIndex(before, "wt-A", "panel-3");
+      expect(after["wt-B"]).toBe(wtBBucket);
+      expect(after["wt-A"]).not.toBe(before["wt-A"]);
+    });
+  });
+
+  describe("removeFromWorktreeIndex", () => {
+    it("removes a panel from its bucket", () => {
+      const next = removeFromWorktreeIndex({ "wt-A": ["panel-1", "panel-2"] }, "wt-A", "panel-1");
+      expect(next).toEqual({ "wt-A": ["panel-2"] });
+    });
+
+    it("deletes the bucket when the last panel is removed", () => {
+      const next = removeFromWorktreeIndex({ "wt-A": ["panel-1"] }, "wt-A", "panel-1");
+      expect(next).toEqual({});
+    });
+
+    it("returns the same index reference when the panel is not in the bucket", () => {
+      const before: PanelIdsByWorktreeId = { "wt-A": ["panel-1"] };
+      const after = removeFromWorktreeIndex(before, "wt-A", "panel-99");
+      expect(after).toBe(before);
+    });
+
+    it("returns the same index reference when the bucket does not exist", () => {
+      const before: PanelIdsByWorktreeId = { "wt-A": ["panel-1"] };
+      const after = removeFromWorktreeIndex(before, "wt-Z", "panel-1");
+      expect(after).toBe(before);
+    });
+
+    it("preserves reference stability for unaffected buckets", () => {
+      const wtBBucket = ["panel-2"];
+      const before: PanelIdsByWorktreeId = {
+        "wt-A": ["panel-1", "panel-3"],
+        "wt-B": wtBBucket,
+      };
+      const after = removeFromWorktreeIndex(before, "wt-A", "panel-1");
+      expect(after["wt-B"]).toBe(wtBBucket);
+    });
+
+    it("handles the __none__ bucket via undefined worktreeId", () => {
+      const next = removeFromWorktreeIndex(
+        { __none__: ["panel-1", "panel-2"] },
+        undefined,
+        "panel-1"
+      );
+      expect(next).toEqual({ __none__: ["panel-2"] });
+    });
+  });
+
+  describe("transferBetweenWorktreeIndex", () => {
+    it("moves a panel from one worktree's bucket to another", () => {
+      const next = transferBetweenWorktreeIndex({ "wt-A": ["panel-1"] }, "wt-A", "wt-B", "panel-1");
+      expect(next).toEqual({ "wt-B": ["panel-1"] });
+    });
+
+    it("returns the same index reference when source and destination are the same", () => {
+      const before: PanelIdsByWorktreeId = { "wt-A": ["panel-1"] };
+      const after = transferBetweenWorktreeIndex(before, "wt-A", "wt-A", "panel-1");
+      expect(after).toBe(before);
+    });
+
+    it("treats undefined and null as the same bucket key (__none__)", () => {
+      const before: PanelIdsByWorktreeId = { __none__: ["panel-1"] };
+      const after = transferBetweenWorktreeIndex(before, undefined, null, "panel-1");
+      expect(after).toBe(before);
+    });
+
+    it("transfers from a defined worktree to __none__", () => {
+      const next = transferBetweenWorktreeIndex(
+        { "wt-A": ["panel-1"] },
+        "wt-A",
+        undefined,
+        "panel-1"
+      );
+      expect(next).toEqual({ __none__: ["panel-1"] });
+    });
+
+    it("preserves reference stability for unaffected buckets across a transfer", () => {
+      const wtCBucket = ["panel-99"];
+      const before: PanelIdsByWorktreeId = {
+        "wt-A": ["panel-1"],
+        "wt-B": ["panel-2"],
+        "wt-C": wtCBucket,
+      };
+      const after = transferBetweenWorktreeIndex(before, "wt-A", "wt-B", "panel-1");
+      expect(after["wt-C"]).toBe(wtCBucket);
+    });
+  });
+
+  describe("buildWorktreeIndex", () => {
+    it("groups panel ids by worktreeId", () => {
+      const index = buildWorktreeIndex(["p1", "p2", "p3"], {
+        p1: { worktreeId: "wt-A" },
+        p2: { worktreeId: "wt-A" },
+        p3: { worktreeId: "wt-B" },
+      });
+      expect(index).toEqual({ "wt-A": ["p1", "p2"], "wt-B": ["p3"] });
+    });
+
+    it("groups missing worktreeId under __none__", () => {
+      const index = buildWorktreeIndex(["p1"], { p1: {} });
+      expect(index).toEqual({ __none__: ["p1"] });
+    });
+
+    it("skips ids missing from panelsById", () => {
+      const index = buildWorktreeIndex(["p1", "p-missing"], { p1: { worktreeId: "wt-A" } });
+      expect(index).toEqual({ "wt-A": ["p1"] });
+    });
+
+    it("preserves the order of panelIds within each bucket", () => {
+      const index = buildWorktreeIndex(["p3", "p1", "p2"], {
+        p1: { worktreeId: "wt-A" },
+        p2: { worktreeId: "wt-A" },
+        p3: { worktreeId: "wt-A" },
+      });
+      expect(index["wt-A"]).toEqual(["p3", "p1", "p2"]);
+    });
+  });
+});

--- a/src/store/slices/panelRegistry/__tests__/worktreeIndexInvariant.test.ts
+++ b/src/store/slices/panelRegistry/__tests__/worktreeIndexInvariant.test.ts
@@ -1,0 +1,168 @@
+import { describe, it, expect, beforeEach, afterEach, vi } from "vitest";
+
+vi.mock("@/clients", () => ({
+  terminalClient: {
+    spawn: vi.fn(),
+    write: vi.fn(),
+    resize: vi.fn(),
+    kill: vi.fn().mockResolvedValue(undefined),
+    trash: vi.fn().mockResolvedValue(undefined),
+    restore: vi.fn().mockResolvedValue(undefined),
+    onData: vi.fn(),
+    onExit: vi.fn(),
+    onAgentStateChanged: vi.fn(),
+  },
+  appClient: {
+    setState: vi.fn().mockResolvedValue(undefined),
+  },
+  projectClient: {
+    getTerminals: vi.fn().mockResolvedValue([]),
+    setTerminals: vi.fn().mockResolvedValue(undefined),
+    setTabGroups: vi.fn().mockResolvedValue(undefined),
+  },
+  agentSettingsClient: {
+    get: vi.fn().mockResolvedValue({}),
+  },
+}));
+
+vi.mock("@/services/TerminalInstanceService", () => ({
+  terminalInstanceService: {
+    cleanup: vi.fn(),
+    applyRendererPolicy: vi.fn(),
+    destroy: vi.fn(),
+  },
+}));
+
+const { usePanelStore } = await import("../../../panelStore");
+import { addToWorktreeIndex } from "../worktreeIndex";
+
+function seedTerminal(id: string, worktreeId: string, location: "grid" | "dock" = "grid") {
+  const terminal = {
+    id,
+    title: id,
+    kind: "browser" as const,
+    type: "terminal" as const,
+    location,
+    worktreeId,
+    isVisible: true,
+  } as import("../types").TerminalInstance;
+  usePanelStore.setState((state) => ({
+    panelsById: { ...state.panelsById, [id]: terminal },
+    panelIds: [...state.panelIds, id],
+    panelIdsByWorktreeId: addToWorktreeIndex(state.panelIdsByWorktreeId, worktreeId, id),
+  }));
+}
+
+describe("panelIdsByWorktreeId invariant across mutations", () => {
+  beforeEach(async () => {
+    vi.useFakeTimers();
+    const { reset } = usePanelStore.getState();
+    await reset();
+  });
+
+  afterEach(() => {
+    vi.useRealTimers();
+  });
+
+  describe("ordering operations", () => {
+    it("reorderTerminals updates the bucket order", () => {
+      seedTerminal("t1", "wt-A");
+      seedTerminal("t2", "wt-A");
+      seedTerminal("t3", "wt-A");
+
+      // Move index 2 (t3) to position 0 within wt-A's grid scope
+      usePanelStore.getState().reorderTerminals(2, 0, "grid", "wt-A");
+
+      expect(usePanelStore.getState().panelIdsByWorktreeId["wt-A"]).toEqual(["t3", "t1", "t2"]);
+    });
+
+    it("restoreTerminalOrder syncs bucket order on hydration restore", () => {
+      seedTerminal("t1", "wt-A");
+      seedTerminal("t2", "wt-A");
+      seedTerminal("t3", "wt-A");
+
+      usePanelStore.getState().restoreTerminalOrder(["t3", "t1", "t2"]);
+
+      expect(usePanelStore.getState().panelIdsByWorktreeId["wt-A"]).toEqual(["t3", "t1", "t2"]);
+    });
+
+    it("moveTerminalToPosition reorders the affected bucket", () => {
+      seedTerminal("t1", "wt-A");
+      seedTerminal("t2", "wt-A");
+      seedTerminal("t3", "wt-A");
+
+      // Move t3 to grid position 0 within wt-A
+      usePanelStore.getState().moveTerminalToPosition("t3", 0, "grid", "wt-A");
+
+      expect(usePanelStore.getState().panelIdsByWorktreeId["wt-A"]).toEqual(["t3", "t1", "t2"]);
+    });
+
+    it("reorderTerminals does not pollute unrelated worktree buckets", () => {
+      seedTerminal("a1", "wt-A");
+      seedTerminal("a2", "wt-A");
+      seedTerminal("b1", "wt-B");
+
+      usePanelStore.getState().reorderTerminals(1, 0, "grid", "wt-A");
+
+      expect(usePanelStore.getState().panelIdsByWorktreeId["wt-A"]).toEqual(["a2", "a1"]);
+      expect(usePanelStore.getState().panelIdsByWorktreeId["wt-B"]).toEqual(["b1"]);
+    });
+  });
+
+  describe("structural mutations", () => {
+    it("removePanel drops the id from its worktree bucket", () => {
+      seedTerminal("t1", "wt-A");
+      seedTerminal("t2", "wt-A");
+      seedTerminal("t3", "wt-B");
+
+      usePanelStore.getState().removePanel("t1");
+
+      expect(usePanelStore.getState().panelIdsByWorktreeId["wt-A"]).toEqual(["t2"]);
+      expect(usePanelStore.getState().panelIdsByWorktreeId["wt-B"]).toEqual(["t3"]);
+    });
+
+    it("removePanel deletes the bucket when its last panel goes away", () => {
+      seedTerminal("solo", "wt-A");
+
+      usePanelStore.getState().removePanel("solo");
+
+      expect("wt-A" in usePanelStore.getState().panelIdsByWorktreeId).toBe(false);
+    });
+
+    it("moveTerminalToWorktree transfers the id between buckets", () => {
+      seedTerminal("t1", "wt-A");
+      seedTerminal("t2", "wt-B");
+
+      usePanelStore.getState().moveTerminalToWorktree("t1", "wt-B");
+
+      expect("wt-A" in usePanelStore.getState().panelIdsByWorktreeId).toBe(false);
+      expect(usePanelStore.getState().panelIdsByWorktreeId["wt-B"]).toEqual(["t2", "t1"]);
+    });
+  });
+
+  describe("reference stability invariant", () => {
+    it("removing a panel from one bucket does not change other bucket references", () => {
+      seedTerminal("a1", "wt-A");
+      seedTerminal("b1", "wt-B");
+      seedTerminal("b2", "wt-B");
+
+      const wtBBefore = usePanelStore.getState().panelIdsByWorktreeId["wt-B"];
+      usePanelStore.getState().removePanel("a1");
+      const wtBAfter = usePanelStore.getState().panelIdsByWorktreeId["wt-B"];
+
+      expect(wtBAfter).toBe(wtBBefore);
+    });
+
+    it("transferring a panel between two buckets does not touch a third", () => {
+      seedTerminal("a1", "wt-A");
+      seedTerminal("b1", "wt-B");
+      seedTerminal("c1", "wt-C");
+
+      const wtCBefore = usePanelStore.getState().panelIdsByWorktreeId["wt-C"];
+      usePanelStore.getState().moveTerminalToWorktree("a1", "wt-B");
+      const wtCAfter = usePanelStore.getState().panelIdsByWorktreeId["wt-C"];
+
+      expect(wtCAfter).toBe(wtCBefore);
+    });
+  });
+});

--- a/src/store/slices/panelRegistry/addPanel.ts
+++ b/src/store/slices/panelRegistry/addPanel.ts
@@ -26,7 +26,7 @@ import {
 } from "./helpers";
 import { logDebug, logWarn, logError } from "@/utils/logger";
 import { collectPanelIdForBatch, isHydrationBatchActive } from "./hydrationBatch";
-import { addToWorktreeIndex } from "./worktreeIndex";
+import { addToWorktreeIndex, transferBetweenWorktreeIndex } from "./worktreeIndex";
 
 // Lazy accessor to break circular dependency: addPanel -> projectStore -> panelPersistence -> addPanel.
 // Resolved on first call (after app init), then cached.
@@ -168,14 +168,21 @@ export const createAddPanelActions = (
         // Batched path: commit `panelsById` immediately (event listeners can find
         // the panel by id) and defer the `panelIds` append + persist to flush.
         set((state) => {
-          const isUpdate = !!state.panelsById[id];
-          if (isUpdate) {
+          const existing = state.panelsById[id];
+          if (existing) {
             logDebug("[TerminalStore] Panel already exists, updating instead of adding", { id });
           }
           return {
             panelsById: { ...state.panelsById, [id]: terminal },
-            panelIdsByWorktreeId: isUpdate
-              ? state.panelIdsByWorktreeId
+            panelIdsByWorktreeId: existing
+              ? // Defensive: if a hydration replays with a different worktreeId,
+                // keep the index in sync rather than silently corrupting it.
+                transferBetweenWorktreeIndex(
+                  state.panelIdsByWorktreeId,
+                  existing.worktreeId,
+                  terminal.worktreeId,
+                  id
+                )
               : addToWorktreeIndex(state.panelIdsByWorktreeId, terminal.worktreeId, id),
           };
         });
@@ -186,8 +193,14 @@ export const createAddPanelActions = (
           if (existing) {
             logDebug("[TerminalStore] Panel already exists, updating instead of adding", { id });
             const newById = { ...state.panelsById, [id]: terminal };
+            const newIndex = transferBetweenWorktreeIndex(
+              state.panelIdsByWorktreeId,
+              existing.worktreeId,
+              terminal.worktreeId,
+              id
+            );
             saveNormalized(newById, state.panelIds);
-            return { panelsById: newById };
+            return { panelsById: newById, panelIdsByWorktreeId: newIndex };
           }
           const newById = { ...state.panelsById, [id]: terminal };
           const newIds = [...state.panelIds, id];
@@ -397,7 +410,14 @@ export const createAddPanelActions = (
         return {
           panelsById: { ...state.panelsById, [id]: preservedTerminal },
           panelIdsByWorktreeId: existing
-            ? state.panelIdsByWorktreeId
+            ? // Defensive: PTY reconnect payloads should preserve worktreeId, but
+              // sync the index if a fresh hydration arrives with a different one.
+              transferBetweenWorktreeIndex(
+                state.panelIdsByWorktreeId,
+                existing.worktreeId,
+                preservedTerminal.worktreeId,
+                id
+              )
             : addToWorktreeIndex(state.panelIdsByWorktreeId, preservedTerminal.worktreeId, id),
         };
       });
@@ -428,8 +448,14 @@ export const createAddPanelActions = (
               }
             : terminal;
           const newById = { ...state.panelsById, [id]: preservedTerminal };
+          const newIndex = transferBetweenWorktreeIndex(
+            state.panelIdsByWorktreeId,
+            existing.worktreeId,
+            preservedTerminal.worktreeId,
+            id
+          );
           saveNormalized(newById, state.panelIds);
-          return { panelsById: newById };
+          return { panelsById: newById, panelIdsByWorktreeId: newIndex };
         }
         const newById = { ...state.panelsById, [id]: terminal };
         const newIds = [...state.panelIds, id];

--- a/src/store/slices/panelRegistry/addPanel.ts
+++ b/src/store/slices/panelRegistry/addPanel.ts
@@ -26,6 +26,7 @@ import {
 } from "./helpers";
 import { logDebug, logWarn, logError } from "@/utils/logger";
 import { collectPanelIdForBatch, isHydrationBatchActive } from "./hydrationBatch";
+import { addToWorktreeIndex } from "./worktreeIndex";
 
 // Lazy accessor to break circular dependency: addPanel -> projectStore -> panelPersistence -> addPanel.
 // Resolved on first call (after app init), then cached.
@@ -167,10 +168,16 @@ export const createAddPanelActions = (
         // Batched path: commit `panelsById` immediately (event listeners can find
         // the panel by id) and defer the `panelIds` append + persist to flush.
         set((state) => {
-          if (state.panelsById[id]) {
+          const isUpdate = !!state.panelsById[id];
+          if (isUpdate) {
             logDebug("[TerminalStore] Panel already exists, updating instead of adding", { id });
           }
-          return { panelsById: { ...state.panelsById, [id]: terminal } };
+          return {
+            panelsById: { ...state.panelsById, [id]: terminal },
+            panelIdsByWorktreeId: isUpdate
+              ? state.panelIdsByWorktreeId
+              : addToWorktreeIndex(state.panelIdsByWorktreeId, terminal.worktreeId, id),
+          };
         });
         collectPanelIdForBatch(id);
       } else {
@@ -184,6 +191,7 @@ export const createAddPanelActions = (
           }
           const newById = { ...state.panelsById, [id]: terminal };
           const newIds = [...state.panelIds, id];
+          const newIndex = addToWorktreeIndex(state.panelIdsByWorktreeId, terminal.worktreeId, id);
           saveNormalized(newById, newIds);
           // Fold dock activation into this commit so the watchdog effect in
           // `DockPanelOffscreenContainer` cannot observe `activeDockTerminalId`
@@ -202,16 +210,18 @@ export const createAddPanelActions = (
               return {
                 panelsById: newById,
                 panelIds: newIds,
+                panelIdsByWorktreeId: newIndex,
               };
             }
             return {
               panelsById: newById,
               panelIds: newIds,
+              panelIdsByWorktreeId: newIndex,
               activeDockTerminalId: id,
               focusedId: id,
             };
           }
-          return { panelsById: newById, panelIds: newIds };
+          return { panelsById: newById, panelIds: newIds, panelIdsByWorktreeId: newIndex };
         });
       }
 
@@ -384,7 +394,12 @@ export const createAddPanelActions = (
                 // preserve the existing entry if a partial reconnect omits it.
               }
             : terminal;
-        return { panelsById: { ...state.panelsById, [id]: preservedTerminal } };
+        return {
+          panelsById: { ...state.panelsById, [id]: preservedTerminal },
+          panelIdsByWorktreeId: existing
+            ? state.panelIdsByWorktreeId
+            : addToWorktreeIndex(state.panelIdsByWorktreeId, preservedTerminal.worktreeId, id),
+        };
       });
       collectPanelIdForBatch(id);
     } else {
@@ -418,6 +433,7 @@ export const createAddPanelActions = (
         }
         const newById = { ...state.panelsById, [id]: terminal };
         const newIds = [...state.panelIds, id];
+        const newIndex = addToWorktreeIndex(state.panelIdsByWorktreeId, terminal.worktreeId, id);
         saveNormalized(newById, newIds);
         // Fold dock activation into this commit so the watchdog effect in
         // `DockPanelOffscreenContainer` cannot observe `activeDockTerminalId`
@@ -436,16 +452,18 @@ export const createAddPanelActions = (
             return {
               panelsById: newById,
               panelIds: newIds,
+              panelIdsByWorktreeId: newIndex,
             };
           }
           return {
             panelsById: newById,
             panelIds: newIds,
+            panelIdsByWorktreeId: newIndex,
             activeDockTerminalId: id,
             focusedId: id,
           };
         }
-        return { panelsById: newById, panelIds: newIds };
+        return { panelsById: newById, panelIds: newIds, panelIdsByWorktreeId: newIndex };
       });
     }
 

--- a/src/store/slices/panelRegistry/background.ts
+++ b/src/store/slices/panelRegistry/background.ts
@@ -4,6 +4,7 @@ import { terminalInstanceService } from "@/services/TerminalInstanceService";
 import { TerminalRefreshTier } from "@/types";
 import { saveNormalized, saveTabGroups } from "./persistence";
 import { optimizeForDock } from "./layout";
+import { transferBetweenWorktreeIndex } from "./worktreeIndex";
 
 type Set = PanelRegistryStoreApi["setState"];
 type Get = PanelRegistryStoreApi["getState"];
@@ -184,18 +185,29 @@ export const createBackgroundActions = (
     set((state) => {
       const t = state.panelsById[id];
       if (!t) return state;
+      const nextWorktreeId = targetWorktreeId !== undefined ? targetWorktreeId : t.worktreeId;
       const newById = {
         ...state.panelsById,
         [id]: {
           ...t,
           location: restoreLocation,
-          worktreeId: targetWorktreeId !== undefined ? targetWorktreeId : t.worktreeId,
+          worktreeId: nextWorktreeId,
         },
       };
+      const newIndex = transferBetweenWorktreeIndex(
+        state.panelIdsByWorktreeId,
+        t.worktreeId,
+        nextWorktreeId,
+        id
+      );
       const newBackgrounded = new Map(state.backgroundedTerminals);
       newBackgrounded.delete(id);
       saveNormalized(newById, state.panelIds);
-      return { panelsById: newById, backgroundedTerminals: newBackgrounded };
+      return {
+        panelsById: newById,
+        panelIdsByWorktreeId: newIndex,
+        backgroundedTerminals: newBackgrounded,
+      };
     });
 
     if (terminal && panelKindHasPty(terminal.kind ?? "terminal")) {
@@ -239,14 +251,17 @@ export const createBackgroundActions = (
     set((state) => {
       const panelIdsInGroup = new Set(groupPanels.map(({ id }) => id));
       const newById = { ...state.panelsById };
+      let newIndex = state.panelIdsByWorktreeId;
       for (const pid of panelIdsInGroup) {
         const t = newById[pid];
         if (t) {
+          const nextWorktreeId = worktreeId ?? t.worktreeId;
           newById[pid] = {
             ...t,
             location: restoreLocation as "dock" | "grid",
-            worktreeId: worktreeId ?? t.worktreeId,
+            worktreeId: nextWorktreeId,
           };
+          newIndex = transferBetweenWorktreeIndex(newIndex, t.worktreeId, nextWorktreeId, pid);
         }
       }
 
@@ -256,7 +271,11 @@ export const createBackgroundActions = (
       }
 
       saveNormalized(newById, state.panelIds);
-      return { panelsById: newById, backgroundedTerminals: newBackgrounded };
+      return {
+        panelsById: newById,
+        panelIdsByWorktreeId: newIndex,
+        backgroundedTerminals: newBackgrounded,
+      };
     });
 
     // Recreate the tab group if we have multiple valid panels

--- a/src/store/slices/panelRegistry/core.ts
+++ b/src/store/slices/panelRegistry/core.ts
@@ -21,6 +21,7 @@ import {
 import type { TrashExpiryHelpers } from "./trash";
 import { logError, logWarn } from "@/utils/logger";
 import { beginBatch, consumeBatch } from "./hydrationBatch";
+import { removeFromWorktreeIndex } from "./worktreeIndex";
 
 type Set = PanelRegistryStoreApi["setState"];
 type Get = PanelRegistryStoreApi["getState"];
@@ -91,6 +92,11 @@ export const createCorePanelActions = (
     set((state) => {
       const { [id]: _, ...restById } = state.panelsById;
       const newIds = state.panelIds.filter((tid) => tid !== id);
+      const newIndex = removeFromWorktreeIndex(
+        state.panelIdsByWorktreeId,
+        terminal?.worktreeId,
+        id
+      );
 
       const newTrashed = new Map(state.trashedTerminals);
       newTrashed.delete(id);
@@ -125,6 +131,7 @@ export const createCorePanelActions = (
       return {
         panelsById: restById,
         panelIds: newIds,
+        panelIdsByWorktreeId: newIndex,
         trashedTerminals: newTrashed,
         backgroundedTerminals: newBackgrounded,
         tabGroups: newTabGroups,

--- a/src/store/slices/panelRegistry/index.ts
+++ b/src/store/slices/panelRegistry/index.ts
@@ -37,6 +37,7 @@ export const createPanelRegistrySlice =
     return {
       panelsById: {},
       panelIds: [],
+      panelIdsByWorktreeId: {},
       trashedTerminals: new Map(),
       backgroundedTerminals: new Map(),
       tabGroups: new Map(),

--- a/src/store/slices/panelRegistry/ordering.ts
+++ b/src/store/slices/panelRegistry/ordering.ts
@@ -5,6 +5,7 @@ import { TerminalRefreshTier } from "@/types";
 import { saveNormalized, saveTabGroups } from "./persistence";
 import { optimizeForDock } from "./layout";
 import { deriveRuntimeStatus, removePanelIdsFromTabGroups } from "./helpers";
+import { buildWorktreeIndex } from "./worktreeIndex";
 
 type Set = PanelRegistryStoreApi["setState"];
 type Get = PanelRegistryStoreApi["getState"];
@@ -63,7 +64,12 @@ export const createOrderingActions = (
       }
 
       saveNormalized(state.panelsById, newIds);
-      return { panelIds: newIds };
+      // Rebuild bucket order so per-worktree selectors observe the new order
+      // (issue #7451). Reorder is user-gesture rate, so a full rebuild is fine.
+      return {
+        panelIds: newIds,
+        panelIdsByWorktreeId: buildWorktreeIndex(newIds, state.panelsById),
+      };
     });
   },
 
@@ -124,9 +130,13 @@ export const createOrderingActions = (
       if (groupPrune.changed) {
         saveTabGroups(groupPrune.tabGroups);
       }
+      // Rebuild bucket order so per-worktree selectors observe the new order
+      // (issue #7451). The panel's worktreeId field is unchanged here, but its
+      // position within the bucket may have shifted.
       return {
         panelsById: newById,
         panelIds: newIds,
+        panelIdsByWorktreeId: buildWorktreeIndex(newIds, newById),
         ...(groupPrune.changed && { tabGroups: groupPrune.tabGroups }),
       };
     });
@@ -164,7 +174,12 @@ export const createOrderingActions = (
       if (!orderChanged) return state;
 
       saveNormalized(state.panelsById, newIds);
-      return { panelIds: newIds };
+      // Rebuild bucket order so per-worktree selectors observe the restored
+      // order on hydration (issue #7451).
+      return {
+        panelIds: newIds,
+        panelIdsByWorktreeId: buildWorktreeIndex(newIds, state.panelsById),
+      };
     });
   },
 });

--- a/src/store/slices/panelRegistry/restart.ts
+++ b/src/store/slices/panelRegistry/restart.ts
@@ -30,6 +30,7 @@ import {
   type AgentRuntimeSettingsResolution,
 } from "@/utils/agentRuntimeSettings";
 import { formatErrorMessage } from "@shared/utils/errorMessage";
+import { transferBetweenWorktreeIndex } from "./worktreeIndex";
 
 // Lazy accessor to break circular dependency: restart -> projectStore -> panelPersistence -> core.
 let _cachedProjectStore: typeof import("@/store/projectStore").useProjectStore | null = null;
@@ -636,8 +637,14 @@ export const createRestartActions = (
           runtimeStatus: deriveRuntimeStatus(newLocation === "grid", t.flowStatus, t.runtimeStatus),
         },
       };
+      const newIndex = transferBetweenWorktreeIndex(
+        state.panelIdsByWorktreeId,
+        t.worktreeId,
+        worktreeId,
+        id
+      );
       saveNormalized(newById, state.panelIds);
-      return { panelsById: newById };
+      return { panelsById: newById, panelIdsByWorktreeId: newIndex };
     });
 
     if (!movedToLocation) return;
@@ -675,15 +682,27 @@ export const createRestartActions = (
 
               // Update cwd, worktreeId, and clear agentSessionId so restartTerminal
               // spawns fresh instead of attempting a broken session resume
-              set((state) =>
-                updateTerminal(state, id, (t) => ({
-                  ...t,
-                  cwd: newCwd,
+              set((state) => {
+                const t = state.panelsById[id];
+                if (!t) return state;
+                const newById = {
+                  ...state.panelsById,
+                  [id]: {
+                    ...t,
+                    cwd: newCwd,
+                    worktreeId,
+                    agentSessionId: undefined,
+                    restartError: undefined,
+                  },
+                };
+                const newIndex = transferBetweenWorktreeIndex(
+                  state.panelIdsByWorktreeId,
+                  t.worktreeId,
                   worktreeId,
-                  agentSessionId: undefined,
-                  restartError: undefined,
-                }))
-              );
+                  id
+                );
+                return { panelsById: newById, panelIdsByWorktreeId: newIndex };
+              });
 
               await get().restartTerminal(id);
 

--- a/src/store/slices/panelRegistry/tabGroups.ts
+++ b/src/store/slices/panelRegistry/tabGroups.ts
@@ -7,6 +7,7 @@ import { useLayoutConfigStore } from "@/store/layoutConfigStore";
 import { saveNormalized, saveTabGroups } from "./persistence";
 import { optimizeForDock } from "./layout";
 import { deriveRuntimeStatus } from "./helpers";
+import { transferBetweenWorktreeIndex } from "./worktreeIndex";
 
 type Set = PanelRegistryStoreApi["setState"];
 type Get = PanelRegistryStoreApi["getState"];
@@ -475,6 +476,7 @@ export const createTabGroupActions = (
 
       const panelIdSet = new Set(group.panelIds);
       const newById = { ...state.panelsById };
+      let newIndex = state.panelIdsByWorktreeId;
       for (const pid of panelIdSet) {
         const t = newById[pid];
         if (!t) continue;
@@ -490,11 +492,12 @@ export const createTabGroupActions = (
             t.runtimeStatus
           ),
         };
+        newIndex = transferBetweenWorktreeIndex(newIndex, t.worktreeId, worktreeId, pid);
       }
 
       saveNormalized(newById, state.panelIds);
       saveTabGroups(newTabGroups);
-      return { panelsById: newById, tabGroups: newTabGroups };
+      return { panelsById: newById, panelIdsByWorktreeId: newIndex, tabGroups: newTabGroups };
     });
 
     for (const panelId of group.panelIds) {
@@ -712,6 +715,7 @@ export const createTabGroupActions = (
     set((s) => {
       let terminalsUpdated = false;
       const newById = { ...s.panelsById };
+      let newIndex = s.panelIdsByWorktreeId;
 
       for (const tid of s.panelIds) {
         const t = newById[tid];
@@ -727,6 +731,14 @@ export const createTabGroupActions = (
             if (needsLocationUpdate || needsWorktreeUpdate) {
               const effectiveLocation = needsLocationUpdate ? group.location : t.location;
               terminalsUpdated = true;
+              if (needsWorktreeUpdate) {
+                newIndex = transferBetweenWorktreeIndex(
+                  newIndex,
+                  t.worktreeId,
+                  group.worktreeId,
+                  tid
+                );
+              }
               newById[tid] = {
                 ...t,
                 location: effectiveLocation,
@@ -750,7 +762,11 @@ export const createTabGroupActions = (
       if (!options?.skipPersist) {
         saveTabGroups(sanitizedGroups);
       }
-      return { panelsById: newById, tabGroups: sanitizedGroups };
+      return {
+        panelsById: newById,
+        panelIdsByWorktreeId: newIndex,
+        tabGroups: sanitizedGroups,
+      };
     });
   },
 

--- a/src/store/slices/panelRegistry/trashActions.ts
+++ b/src/store/slices/panelRegistry/trashActions.ts
@@ -10,6 +10,7 @@ import { optimizeForDock } from "./layout";
 import { cancelReconnectErrorDebounce } from "./browser";
 import { stopDevPreviewByPanelId } from "./helpers";
 import { logError } from "@/utils/logger";
+import { transferBetweenWorktreeIndex } from "./worktreeIndex";
 
 type Set = PanelRegistryStoreApi["setState"];
 type Get = PanelRegistryStoreApi["getState"];
@@ -248,18 +249,29 @@ export const createTrashActions = (
       set((state) => {
         const t = state.panelsById[id];
         if (!t) return state;
+        const nextWorktreeId = targetWorktreeId !== undefined ? targetWorktreeId : t.worktreeId;
         const newById = {
           ...state.panelsById,
           [id]: {
             ...t,
             location: restoreLocation,
-            worktreeId: targetWorktreeId !== undefined ? targetWorktreeId : t.worktreeId,
+            worktreeId: nextWorktreeId,
           },
         };
+        const newIndex = transferBetweenWorktreeIndex(
+          state.panelIdsByWorktreeId,
+          t.worktreeId,
+          nextWorktreeId,
+          id
+        );
         const newTrashed = new Map(state.trashedTerminals);
         newTrashed.delete(id);
         saveNormalized(newById, state.panelIds);
-        return { panelsById: newById, trashedTerminals: newTrashed };
+        return {
+          panelsById: newById,
+          panelIdsByWorktreeId: newIndex,
+          trashedTerminals: newTrashed,
+        };
       });
 
       if (terminal && panelKindHasPty(terminal.kind ?? "terminal")) {
@@ -313,14 +325,17 @@ export const createTrashActions = (
       set((state) => {
         const panelIdsInGroup = new Set(groupPanels.map(({ id }) => id));
         const newById = { ...state.panelsById };
+        let newIndex = state.panelIdsByWorktreeId;
         for (const pid of panelIdsInGroup) {
           const t = newById[pid];
           if (t) {
+            const nextWorktreeId = worktreeId ?? t.worktreeId;
             newById[pid] = {
               ...t,
               location: restoreLocation as "dock" | "grid",
-              worktreeId: worktreeId ?? t.worktreeId,
+              worktreeId: nextWorktreeId,
             };
+            newIndex = transferBetweenWorktreeIndex(newIndex, t.worktreeId, nextWorktreeId, pid);
           }
         }
 
@@ -330,7 +345,11 @@ export const createTrashActions = (
         }
 
         saveNormalized(newById, state.panelIds);
-        return { panelsById: newById, trashedTerminals: newTrashed };
+        return {
+          panelsById: newById,
+          panelIdsByWorktreeId: newIndex,
+          trashedTerminals: newTrashed,
+        };
       });
 
       // Recreate the tab group if we have multiple panels

--- a/src/store/slices/panelRegistry/types.ts
+++ b/src/store/slices/panelRegistry/types.ts
@@ -52,6 +52,13 @@ export type HydrationBatchToken = symbol;
 export interface PanelRegistrySlice {
   panelsById: Record<string, TerminalInstance>;
   panelIds: string[];
+  /**
+   * Per-worktree panel id buckets, maintained at write time (add/remove/transfer)
+   * so per-row selectors can scope work to one worktree's panels in O(1) without
+   * scanning all `panelIds` on every per-terminal field tick. Bucket key for
+   * panels with no worktree is the literal "__none__". See issue #7451.
+   */
+  panelIdsByWorktreeId: Record<string, string[]>;
   trashedTerminals: Map<string, TrashedTerminal>;
   backgroundedTerminals: Map<string, BackgroundedTerminal>;
   /** Explicit tab group storage - single source of truth for tab membership and order */

--- a/src/store/slices/panelRegistry/worktreeIndex.ts
+++ b/src/store/slices/panelRegistry/worktreeIndex.ts
@@ -1,0 +1,87 @@
+/**
+ * Per-worktree panel id index. Maintained at write time on add/remove/transfer
+ * so per-row selectors (`useWorktreeTerminals(wid)`) can scope work to a single
+ * worktree's panels in O(1) lookup, rather than scanning all `panelIds` on
+ * every per-terminal field tick. See issue #7451.
+ *
+ * Reference-stability invariant: the bucket array for any worktree whose
+ * membership did NOT change in a given mutation must remain the same array
+ * reference across `set()`. Selectors rely on this for strict-equality skips
+ * — touching an unrelated worktree's bucket would re-fire every per-row
+ * selector on every per-terminal tick.
+ */
+export type PanelIdsByWorktreeId = Record<string, string[]>;
+
+/** Bucket key for panels with `worktreeId === undefined`. */
+const NO_WORKTREE = "__none__";
+
+function bucketKey(worktreeId: string | undefined | null): string {
+  return worktreeId ?? NO_WORKTREE;
+}
+
+export function addToWorktreeIndex(
+  index: PanelIdsByWorktreeId,
+  worktreeId: string | undefined | null,
+  panelId: string
+): PanelIdsByWorktreeId {
+  const key = bucketKey(worktreeId);
+  const existing = index[key];
+  if (existing && existing.includes(panelId)) return index;
+  const next = existing ? [...existing, panelId] : [panelId];
+  return { ...index, [key]: next };
+}
+
+export function removeFromWorktreeIndex(
+  index: PanelIdsByWorktreeId,
+  worktreeId: string | undefined | null,
+  panelId: string
+): PanelIdsByWorktreeId {
+  const key = bucketKey(worktreeId);
+  const existing = index[key];
+  if (!existing || !existing.includes(panelId)) return index;
+  const next = existing.filter((id) => id !== panelId);
+  if (next.length === 0) {
+    const { [key]: _removed, ...rest } = index;
+    return rest;
+  }
+  return { ...index, [key]: next };
+}
+
+export function transferBetweenWorktreeIndex(
+  index: PanelIdsByWorktreeId,
+  oldWorktreeId: string | undefined | null,
+  newWorktreeId: string | undefined | null,
+  panelId: string
+): PanelIdsByWorktreeId {
+  if (bucketKey(oldWorktreeId) === bucketKey(newWorktreeId)) return index;
+  return addToWorktreeIndex(
+    removeFromWorktreeIndex(index, oldWorktreeId, panelId),
+    newWorktreeId,
+    panelId
+  );
+}
+
+/**
+ * Rebuild the full index from current panel state. Used as a defensive
+ * recovery (e.g. after `hydrateTabGroups` repairs worktreeIds in bulk) and
+ * by the unit-test helpers; mutation-time paths should call the targeted
+ * `add/remove/transfer` helpers above to preserve bucket reference stability.
+ */
+export function buildWorktreeIndex(
+  panelIds: string[],
+  panelsById: Record<string, { worktreeId?: string | null }>
+): PanelIdsByWorktreeId {
+  const out: PanelIdsByWorktreeId = {};
+  for (const id of panelIds) {
+    const panel = panelsById[id];
+    if (!panel) continue;
+    const key = bucketKey(panel.worktreeId);
+    const bucket = out[key];
+    if (bucket) {
+      bucket.push(id);
+    } else {
+      out[key] = [id];
+    }
+  }
+  return out;
+}


### PR DESCRIPTION
## Summary

- Adds a `panelIdsByWorktreeId` index to the panel store, maintained at write time, so per-row selectors read their own bucket instead of filtering the full panel list on every tick
- `useWorktreeTerminals` is the main beneficiary — it runs in every sidebar row, and the old approach was O(rows × all-panels) per terminal tick; `useWaitingTerminals` and `useBackgroundedTerminals` collapse from two subscriptions + `useMemo` to a single `useShallow` call
- `AgentButton` and `SidebarContent` get scoped selectors replacing raw double-subscriptions; the index is kept in sync across all mutation sites: add, remove, transfer, background, restart, tab-group, and ordering ops

Resolves #7451

## Changes

- `src/store/slices/panelRegistry/worktreeIndex.ts` — new index builder and helpers
- `src/store/slices/panelRegistry/core.ts` + `types.ts` — `panelIdsByWorktreeId` field on state
- `addPanel`, `background`, `ordering`, `restart`, `tabGroups`, `trashActions` — index kept in sync at every write path
- `src/hooks/useWorktreeTerminals.ts` + `useTerminalSelectors.ts` — consume the index
- `src/components/Layout/AgentButton.tsx` + `src/components/Sidebar/SidebarContent.tsx` — scoped selectors
- 21 helper unit tests (`worktreeIndex.test.ts`) + 8 store-level invariant tests (`worktreeIndexInvariant.test.ts`)

## Testing

Unit tests cover all index helper functions and every mutation path. Store-level invariant tests verify the index stays consistent with `panelIds` after sequences of mixed operations.