### PR TITLE
perf(browser): clear BrowserPane.tsx React Compiler bailouts

### DIFF
--- a/compiler-bailout-baseline.json
+++ b/compiler-bailout-baseline.json
@@ -54,16 +54,11 @@
     "pipelineErrors": []
   },
   "src/components/Browser/BrowserPane.tsx": {
-    "success": 0,
+    "success": 1,
     "skip": 0,
-    "error": 1,
+    "error": 0,
     "pipeline": 0,
-    "errorBailouts": [
-      {
-        "category": "Todo",
-        "reason": "Support value blocks (conditional, logical, optional chaining, etc) within a try/catch statement"
-      }
-    ],
+    "errorBailouts": [],
     "skipReasons": [],
     "pipelineErrors": []
   },
@@ -401,16 +396,11 @@
     "pipelineErrors": []
   },
   "src/components/DragDrop/SortableWorktreeTerminal.tsx": {
-    "success": 0,
+    "success": 1,
     "skip": 0,
-    "error": 1,
+    "error": 0,
     "pipeline": 0,
-    "errorBailouts": [
-      {
-        "category": "Refs",
-        "reason": "Cannot access refs during render"
-      }
-    ],
+    "errorBailouts": [],
     "skipReasons": [],
     "pipelineErrors": []
   },
@@ -1599,16 +1589,11 @@
     "pipelineErrors": []
   },
   "src/components/Pulse/PulseHeatmap.tsx": {
-    "success": 0,
+    "success": 2,
     "skip": 0,
-    "error": 1,
+    "error": 0,
     "pipeline": 0,
-    "errorBailouts": [
-      {
-        "category": "Refs",
-        "reason": "Cannot access refs during render"
-      }
-    ],
+    "errorBailouts": [],
     "skipReasons": [],
     "pipelineErrors": []
   },
@@ -3321,20 +3306,11 @@
     "pipelineErrors": []
   },
   "src/components/ThemeBrowser/ThemeBrowser.tsx": {
-    "success": 1,
+    "success": 2,
     "skip": 0,
-    "error": 2,
+    "error": 0,
     "pipeline": 0,
-    "errorBailouts": [
-      {
-        "category": "Immutability",
-        "reason": "This value cannot be modified"
-      },
-      {
-        "category": "Immutability",
-        "reason": "This value cannot be modified"
-      }
-    ],
+    "errorBailouts": [],
     "skipReasons": [],
     "pipelineErrors": []
   },

--- a/src/components/Browser/BrowserPane.tsx
+++ b/src/components/Browser/BrowserPane.tsx
@@ -491,7 +491,12 @@ export function BrowserPane({
   const handleCaptureScreenshot = useCallback(async () => {
     const webview = webviewRef.current;
     if (!webview || !isWebviewReady) return;
-    const url = webview.getURL();
+    let url: string;
+    try {
+      url = webview.getURL();
+    } catch {
+      return;
+    }
     if (!url || url === "about:blank") return;
     try {
       const image = await webview.capturePage();

--- a/src/components/Browser/BrowserPane.tsx
+++ b/src/components/Browser/BrowserPane.tsx
@@ -16,6 +16,7 @@ import { ConsolePanel } from "./ConsolePanel";
 import {
   normalizeBrowserUrl,
   extractHostPort,
+  extractHostname,
   isValidBrowserUrl,
   clampZoom,
   type LoadError,
@@ -44,6 +45,8 @@ import { logError } from "@/utils/logger";
 
 export interface BrowserPaneProps extends BasePanelProps {
   initialUrl: string;
+  initialHistory?: BrowserHistory;
+  initialZoom?: number;
   // Tab support
   tabs?: import("@/components/Panel/TabButton").TabInfo[];
   onTabClick?: (tabId: string) => void;
@@ -84,6 +87,8 @@ export function BrowserPane({
   id,
   title,
   initialUrl,
+  initialHistory,
+  initialZoom,
   isFocused,
   isMaximized = false,
   location = "grid",
@@ -134,39 +139,25 @@ export function BrowserPane({
   );
   const setBrowserConsoleOpen = usePanelStore((state) => state.setBrowserConsoleOpen);
 
-  // Initialize history from persisted state or initialUrl. Compute both
-  // `history` and `isRestoredLoad` in a single useState initializer so the ref
-  // below can be seeded without writing to a ref during the lazy-init closure
-  // (React Compiler bailout).
-  const [initialHistoryComputation] = useState<{
-    history: BrowserHistory;
-    isRestoredLoad: boolean;
-  }>(() => {
-    const terminal = usePanelStore.getState().getTerminal(id);
-    const saved = terminal?.browserHistory;
-    // Use extended mode (empty allowedHosts) so private/LAN URLs in session state
-    // are recognized as valid-syntax and return a normalized string; restored URLs
-    // bypass the approval prompt since being in history implies prior approval.
+  // Seed history from the `initialHistory` prop (threaded by buildPanelProps from
+  // the persisted terminal state). Reading the store via getState() inside a lazy
+  // useState initializer was a React Compiler bailout (Globals); prop threading
+  // moves the read to the parent and keeps the leaf component compiler-friendly.
+  // Use extended mode (empty allowedHosts) so private/LAN URLs in session state
+  // are recognized as valid-syntax and return a normalized string; restored URLs
+  // bypass the approval prompt since being in history implies prior approval.
+  const [history, setHistory] = useState<BrowserHistory>(() => {
     const normalized = normalizeBrowserUrl(initialUrl, { allowedHosts: [] });
-    const fallbackPresent = terminal?.browserUrl || normalized.url || initialUrl;
-    return {
-      history: initializeBrowserHistory(saved, fallbackPresent),
-      // Only treat this as a restored session load if we actually have persisted history
-      isRestoredLoad: Boolean(saved?.present),
-    };
+    const fallbackPresent = normalized.url || initialUrl;
+    return initializeBrowserHistory(initialHistory ?? null, fallbackPresent);
   });
 
   // Track whether the current load is the initial session-restored load (not a fresh panel)
-  const isInitialRestoredLoadRef = useRef(initialHistoryComputation.isRestoredLoad);
+  const isInitialRestoredLoadRef = useRef(Boolean(initialHistory?.present));
 
-  const [history, setHistory] = useState<BrowserHistory>(initialHistoryComputation.history);
-
-  // Initialize zoom factor from persisted state (default 1.0 = 100%)
-  // Clamp to valid range [0.25, 2.0] to handle corrupt storage
-  const [zoomFactor, setZoomFactor] = useState<number>(() => {
-    const terminal = usePanelStore.getState().getTerminal(id);
-    return clampZoom(terminal?.browserZoom ?? 1.0);
-  });
+  // Initialize zoom factor from the `initialZoom` prop (already clamped at the
+  // prop-build site). Default 1.0 (100%) when the prop is absent.
+  const [zoomFactor, setZoomFactor] = useState<number>(() => clampZoom(initialZoom ?? 1.0));
 
   const [isLoading, setIsLoading] = useState(true);
   // Doherty 400ms gate: skip loading affordances on fast loads to prevent flicker.
@@ -455,10 +446,13 @@ export function BrowserPane({
     }
     setIsSlowLoad(false);
     setIsLoading(false);
-    try {
-      webviewRef.current?.stop();
-    } catch {
-      // Webview detached
+    const webview = webviewRef.current;
+    if (webview) {
+      try {
+        webview.stop();
+      } catch {
+        // Webview detached
+      }
     }
     setLoadError({ kind: "cancelled", message: "Load cancelled." });
   }, []);
@@ -497,9 +491,9 @@ export function BrowserPane({
   const handleCaptureScreenshot = useCallback(async () => {
     const webview = webviewRef.current;
     if (!webview || !isWebviewReady) return;
+    const url = webview.getURL();
+    if (!url || url === "about:blank") return;
     try {
-      const url = webview.getURL();
-      if (!url || url === "about:blank") return;
       const image = await webview.capturePage();
       const pngData = new Uint8Array(image.toPNG());
       await window.electron.clipboard.writeImage(pngData);
@@ -795,14 +789,7 @@ export function BrowserPane({
               >
                 <ExternalLink className="h-3.5 w-3.5 shrink-0 text-status-warning" />
                 <span className="truncate flex-1">
-                  Navigation to external site blocked:{" "}
-                  {(() => {
-                    try {
-                      return new URL(blockedNav.url).hostname;
-                    } catch {
-                      return blockedNav.url;
-                    }
-                  })()}
+                  Navigation to external site blocked: {extractHostname(blockedNav.url)}
                 </span>
                 {blockedNav.canOpenExternal && (
                   <button

--- a/src/components/Browser/__tests__/BrowserPane.webview.test.tsx
+++ b/src/components/Browser/__tests__/BrowserPane.webview.test.tsx
@@ -178,6 +178,12 @@ describe("BrowserPane webview lifecycle regression", () => {
     id: "browser-panel-1",
     title: "Browser",
     initialUrl: "http://localhost:5173/",
+    initialHistory: {
+      past: [],
+      present: "http://localhost:5173/",
+      future: [],
+    },
+    initialZoom: 1.35,
     isFocused: true,
     onFocus: vi.fn(),
     onClose: vi.fn(),

--- a/src/components/Browser/browserUtils.ts
+++ b/src/components/Browser/browserUtils.ts
@@ -28,6 +28,14 @@ export function extractHostPort(url: string): string {
   }
 }
 
+export function extractHostname(url: string): string {
+  try {
+    return new URL(url).hostname;
+  } catch {
+    return url;
+  }
+}
+
 export function isValidBrowserUrl(url: string | undefined | null): boolean {
   if (!url || !url.trim()) return false;
   // Pass an empty allow-list so non-loopback hosts return `{ url, requiresConfirmation }`

--- a/src/utils/panelProps.ts
+++ b/src/utils/panelProps.ts
@@ -2,6 +2,7 @@ import type { TerminalInstance } from "@/store";
 import type { PanelComponentProps } from "@/registry";
 import type { ActivityState } from "@/components/Terminal/TerminalPane";
 import { deriveTerminalChrome } from "@/utils/terminalChrome";
+import { clampZoom } from "@/components/Browser/browserUtils";
 
 const activityCache = new Map<string, ActivityState>();
 
@@ -105,6 +106,8 @@ export function buildPanelProps({
 
     // Browser-specific
     initialUrl: terminal.browserUrl || "http://localhost:3000",
+    initialHistory: terminal.browserHistory,
+    initialZoom: clampZoom(terminal.browserZoom ?? 1.0),
 
     ...overrides,
   };


### PR DESCRIPTION
## Summary

- Extracts the inline IIFE `try/catch` from JSX into `extractHostname()` in `browserUtils` — the compiler can't handle value blocks inside `try/catch` arms, so this was the primary bailout trigger.
- Threads `initialHistory` and `initialZoom` through `buildPanelProps` in `src/utils/panelProps.ts`, matching the pattern already used for `initialUrl`. The lazy `useState` initializers no longer call `usePanelStore.getState()` at mount, clearing the `Globals` bailout.
- Lifts optional chaining and logical-OR conditionals out of the `try` bodies in `handleCancelLoad` and `handleCaptureScreenshot`. `handleCaptureScreenshot` keeps a separate `try` around `getURL()` so detached-webview throws stay caught.

`BrowserPane.tsx` goes from `{success:0, error:1}` to `{success:1, error:0}` in `compiler-bailout-baseline.json`. Lint warnings ratchet decreased by 2.

Resolves #7457

## Changes

- `src/components/Browser/browserUtils.ts` — new `extractHostname()` utility
- `src/utils/panelProps.ts` — thread `initialHistory` and `initialZoom` through `buildPanelProps`
- `src/components/Browser/BrowserPane.tsx` — remove IIFE, use prop-threaded initializers, refactor try-body shapes
- `compiler-bailout-baseline.json` — updated baseline

## Testing

40 `BrowserPane` webview tests + 158 broader Browser/panelProps tests pass. Typecheck, lint ratchet, format, and build all clean.