### PR TITLE
fix(actions): ignore stale focused panel when duplicating

### DIFF
--- a/src/services/actions/__tests__/actionDefinitions.adversarial.test.ts
+++ b/src/services/actions/__tests__/actionDefinitions.adversarial.test.ts
@@ -775,6 +775,54 @@ describe("terminal action hardening", () => {
     expect(addPanel).toHaveBeenCalledWith(expect.objectContaining({ title: "Live One (copy)" }));
   });
 
+  it("ignores dangling focusedId pointing at a missing panel and falls back to the lone live terminal", async () => {
+    const actions = buildRegistry(registerTerminalActions);
+    const duplicate = actions.get("terminal.duplicate")!();
+    const addPanel = vi.fn().mockResolvedValue("copy-id");
+
+    usePanelStore.setState({
+      panelsById: { "term-live": createTerminal({ id: "term-live", title: "Live One" }) },
+      panelIds: ["term-live"],
+      focusedId: "gone",
+      addPanel,
+    } as never);
+
+    await duplicate.run(undefined, {} as never);
+
+    expect(addPanel).toHaveBeenCalledWith(expect.objectContaining({ title: "Live One (copy)" }));
+  });
+
+  it("falls through to lastClosedConfig snapshot when focusedId is stale-trashed and no live panels exist", async () => {
+    const actions = buildRegistry(registerTerminalActions);
+    const duplicate = actions.get("terminal.duplicate")!();
+    const addPanel = vi.fn().mockResolvedValue("new-id");
+
+    usePanelStore.setState({
+      panelsById: {
+        "term-trash": createTerminal({ id: "term-trash", location: "trash" }),
+      },
+      panelIds: ["term-trash"],
+      focusedId: "term-trash",
+      lastClosedConfig: {
+        kind: "terminal",
+        type: "terminal",
+        cwd: "/projects/app",
+        worktreeId: "wt-1",
+      },
+      addPanel,
+    } as never);
+
+    await duplicate.run(undefined, {} as never);
+
+    expect(addPanel).toHaveBeenCalledWith(
+      expect.objectContaining({
+        cwd: "/projects/app",
+        worktreeId: "wt-1",
+        location: "grid",
+      })
+    );
+  });
+
   it("does not duplicate trashed panel when focusedId is stale-trashed and multiple live panels exist", async () => {
     const actions = buildRegistry(registerTerminalActions);
     const duplicate = actions.get("terminal.duplicate")!();

--- a/src/services/actions/__tests__/actionDefinitions.adversarial.test.ts
+++ b/src/services/actions/__tests__/actionDefinitions.adversarial.test.ts
@@ -711,6 +711,95 @@ describe("terminal action hardening", () => {
 
     expect(addPanel).not.toHaveBeenCalled();
   });
+
+  // #7477: focusedId can lag behind a trash op (e.g. cross-process IPC race).
+  // The duplicate handler must treat a focusedId pointing at a trashed panel
+  // as if there were no implicit focus, falling through to the same paths as
+  // focusedId === null.
+  it("ignores stale focusedId that points at a trashed panel and creates a fresh terminal", async () => {
+    const actions = buildRegistry(registerTerminalActions);
+    const duplicate = actions.get("terminal.duplicate")!();
+    const addPanel = vi.fn().mockResolvedValue("new-id");
+
+    usePanelStore.setState({
+      panelsById: {
+        "term-trash": createTerminal({
+          id: "term-trash",
+          location: "trash",
+          title: "Stale Focus",
+          command: "npm test",
+        }),
+      },
+      panelIds: ["term-trash"],
+      focusedId: "term-trash",
+      lastClosedConfig: null,
+      addPanel,
+    } as never);
+
+    await duplicate.run(undefined, {} as never);
+
+    expect(addPanel).toHaveBeenCalledWith(
+      expect.objectContaining({
+        kind: "terminal",
+        cwd: "/repo",
+        location: "grid",
+      })
+    );
+    expect(addPanel).not.toHaveBeenCalledWith(
+      expect.objectContaining({ title: expect.stringContaining("Stale Focus") })
+    );
+    expect(addPanel).not.toHaveBeenCalledWith(expect.objectContaining({ command: "npm test" }));
+  });
+
+  it("duplicates the lone live terminal when focusedId is stale-trashed", async () => {
+    const actions = buildRegistry(registerTerminalActions);
+    const duplicate = actions.get("terminal.duplicate")!();
+    const addPanel = vi.fn().mockResolvedValue("copy-id");
+
+    usePanelStore.setState({
+      panelsById: {
+        "term-trash": createTerminal({
+          id: "term-trash",
+          location: "trash",
+          title: "Stale Focus",
+        }),
+        "term-live": createTerminal({ id: "term-live", title: "Live One" }),
+      },
+      panelIds: ["term-trash", "term-live"],
+      focusedId: "term-trash",
+      addPanel,
+    } as never);
+
+    await duplicate.run(undefined, {} as never);
+
+    expect(addPanel).toHaveBeenCalledWith(expect.objectContaining({ title: "Live One (copy)" }));
+  });
+
+  it("does not duplicate trashed panel when focusedId is stale-trashed and multiple live panels exist", async () => {
+    const actions = buildRegistry(registerTerminalActions);
+    const duplicate = actions.get("terminal.duplicate")!();
+    const addPanel = vi.fn().mockResolvedValue("copy-id");
+
+    usePanelStore.setState({
+      panelsById: {
+        "term-trash": createTerminal({
+          id: "term-trash",
+          location: "trash",
+          title: "Stale Focus",
+          command: "npm test",
+        }),
+        "term-a": createTerminal({ id: "term-a" }),
+        "term-b": createTerminal({ id: "term-b" }),
+      },
+      panelIds: ["term-trash", "term-a", "term-b"],
+      focusedId: "term-trash",
+      addPanel,
+    } as never);
+
+    await duplicate.run(undefined, {} as never);
+
+    expect(addPanel).not.toHaveBeenCalled();
+  });
 });
 
 describe("panel action hardening", () => {

--- a/src/services/actions/definitions/terminalSpawnActions.ts
+++ b/src/services/actions/definitions/terminalSpawnActions.ts
@@ -55,8 +55,11 @@ export function registerTerminalSpawnActions(
       const nonTrashed = state.panelIds
         .map((id) => state.panelsById[id])
         .filter((t) => t && t.location !== "trash");
+      const focusedPanel = state.focusedId ? state.panelsById[state.focusedId] : undefined;
+      const liveFocusedId =
+        focusedPanel && focusedPanel.location !== "trash" ? state.focusedId : undefined;
       const targetId =
-        terminalId ?? state.focusedId ?? (nonTrashed.length === 1 ? nonTrashed[0]!.id : undefined);
+        terminalId ?? liveFocusedId ?? (nonTrashed.length === 1 ? nonTrashed[0]!.id : undefined);
 
       if (targetId) {
         const terminal = state.panelsById[targetId];


### PR DESCRIPTION
## Summary

- `terminal.duplicate` was reading `state.focusedId` without checking whether that panel was still live. When a trash op left `focusedId` pointing at a trashed panel (IPC race or just normal close-then-Cmd+T), the action duplicated the trashed panel rather than falling through to the fresh-terminal path.
- Fix: derive `liveFocusedId` by checking `panelsById[focusedId]?.location !== "trash"` before using it as the target. The explicit `terminalId` path (context-menu / panel-header dispatches) is unchanged.
- 5 new adversarial tests: stale focus + 0 live panels, stale focus + 1 live panel, dangling `focusedId` (id missing from `panelsById`), stale focus + `lastClosedConfig` fallthrough, stale focus + multiple live panels (no-op).

Resolves #7477

## Changes

- `src/services/actions/definitions/terminalSpawnActions.ts` — guard `focusedId` against trashed location before resolving `targetId`
- `src/services/actions/__tests__/actionDefinitions.adversarial.test.ts` — 5 new cases covering the above edge conditions

## Testing

- 45/45 unit tests pass on the adversarial spec
- Typecheck, lint, format, and build all pass