### PR TITLE
fix(terminal): prevent agent terminal blanks during bulk worktree creation (#7467)

### DIFF
--- a/src/services/terminal/TerminalWebGLManager.ts
+++ b/src/services/terminal/TerminalWebGLManager.ts
@@ -8,8 +8,12 @@ const WEBGL_DISABLED = import.meta.env.DAINTREE_DISABLE_WEBGL === "1";
 type WebglAddonConstructor = new () => WebglAddonType;
 
 // @xterm/addon-webgl loads via dynamic import so it stays out of the renderer's
-// eager critical path. ensureContext() remains synchronous: requests that arrive
-// before the chunk finishes loading are queued and replayed on resolution.
+// eager critical path. ensureContext() routes every new request through a
+// requestAnimationFrame drain queue (one attach per frame): without that
+// stagger, a burst of synchronous attaches during bulk worktree creation
+// over-subscribes Chromium's 16-context-per-renderer cap, causing silent
+// eviction of older contexts that then sit blank for 3s waiting on
+// webglcontextrestored before xterm's onContextLoss fires (see #7467).
 let WebglAddonClass: WebglAddonConstructor | null = null;
 let webglAddonLoadPromise: Promise<WebglAddonConstructor> | null = null;
 
@@ -33,6 +37,7 @@ function loadWebglAddon(): Promise<WebglAddonConstructor> {
 interface WebGLEntry {
   addon: WebglAddonType;
   contextLossDisposable: IDisposable;
+  captureDisposable: (() => void) | null;
 }
 
 export class TerminalWebGLManager {
@@ -64,8 +69,14 @@ export class TerminalWebGLManager {
   private hasLoggedSoftwareSkip = false;
   private lossTimestamps: number[] = [];
   private hasLoggedBreakerTrip = false;
-  // Latest pending ensure request per terminal id, awaiting addon-webgl load.
+  // Queue of pending ensure requests: drained one-per-rAF so each context
+  // allocation completes its GPU IPC roundtrip before the next is requested.
   private pendingEnsures = new Map<string, ManagedTerminal>();
+  // Tracked separately from the rAF id: the "scheduled" flag has different
+  // semantics than the cancellation handle when rAF runs synchronously (e.g.
+  // under a test shim that invokes the callback inline).
+  private pendingDrainScheduled = false;
+  private pendingEnsureRafId: number | null = null;
 
   setHardwareAvailable(available: boolean): void {
     this.hardwareAvailable = available;
@@ -82,15 +93,16 @@ export class TerminalWebGLManager {
     }
     if (!managed.isOpened) return;
 
+    // Dedupe: latest request per id wins until the queue drains.
+    this.pendingEnsures.set(id, managed);
+
     if (WebglAddonClass) {
-      this.attachWithLoadedAddon(id, managed, WebglAddonClass);
+      this.scheduleDrain();
       return;
     }
 
-    // Dedupe: latest request per id wins until the addon resolves.
-    this.pendingEnsures.set(id, managed);
     void loadWebglAddon().then(
-      () => this.flushPendingEnsures(),
+      () => this.scheduleDrain(),
       () => {
         // Retain pending; a subsequent ensureContext call will retry the load.
       }
@@ -117,31 +129,66 @@ export class TerminalWebGLManager {
       } catch {
         // ignore
       }
+      try {
+        entry.captureDisposable?.();
+      } catch {
+        // ignore
+      }
       this.pool.delete(id);
       this.removeFromLru(id);
     }
   }
 
   dispose(): void {
+    if (this.pendingEnsureRafId !== null) {
+      try {
+        cancelAnimationFrame(this.pendingEnsureRafId);
+      } catch {
+        // ignore
+      }
+    }
+    this.pendingEnsureRafId = null;
+    this.pendingDrainScheduled = false;
     this.pendingEnsures.clear();
     for (const id of [...this.pool.keys()]) {
       this.doRelease(id);
     }
   }
 
-  private flushPendingEnsures(): void {
+  private scheduleDrain(): void {
+    if (this.pendingDrainScheduled) return;
+    if (this.pendingEnsures.size === 0) return;
+    this.pendingDrainScheduled = true;
+    const id = requestAnimationFrame(this.drainOne);
+    // If drainOne ran synchronously (test shim or unusual host), it will have
+    // already cleared pendingDrainScheduled and there is no rAF id to cancel.
+    if (this.pendingDrainScheduled) {
+      this.pendingEnsureRafId = id;
+    }
+  }
+
+  private drainOne = (): void => {
+    this.pendingDrainScheduled = false;
+    this.pendingEnsureRafId = null;
     if (!WebglAddonClass) return;
     if (!this.hardwareAvailable) {
       this.pendingEnsures.clear();
       return;
     }
-    const pending = this.pendingEnsures;
-    this.pendingEnsures = new Map();
-    for (const [id, managed] of pending) {
-      if (!managed.isOpened) continue;
+    const next = this.pendingEnsures.entries().next();
+    if (next.done) return;
+    const [id, managed] = next.value;
+    this.pendingEnsures.delete(id);
+    if (managed.isOpened) {
+      // attachWithLoadedAddon dedups via pool.has(id) and routes the
+      // already-active case through moveLruToEnd so the touch semantics of
+      // a repeat ensure are preserved.
       this.attachWithLoadedAddon(id, managed, WebglAddonClass);
     }
-  }
+    if (this.pendingEnsures.size > 0) {
+      this.scheduleDrain();
+    }
+  };
 
   private attachWithLoadedAddon(
     id: string,
@@ -162,6 +209,7 @@ export class TerminalWebGLManager {
 
     let addon: WebglAddonType | null = null;
     let clDisposable: IDisposable | null = null;
+    let captureDisposable: (() => void) | null = null;
     try {
       addon = new AddonClass();
       const ownAddon = addon;
@@ -173,11 +221,39 @@ export class TerminalWebGLManager {
         }
       });
       managed.terminal.loadAddon(addon);
-      this.pool.set(id, { addon, contextLossDisposable: clDisposable });
+      // Capture-phase listener on the terminal element fires before xterm's
+      // own webglcontextlost handler (which would otherwise sit on a 3s
+      // restore timer before notifying us). Pre-empting that timer eliminates
+      // the visible blank window when Chromium evicts the context.
+      const element = managed.terminal.element;
+      if (element) {
+        const captureHandler = (): void => {
+          if (this.pool.get(id)?.addon !== ownAddon) return;
+          this.recordContextLoss();
+          this.releaseContext(id);
+          try {
+            if (managed.isOpened && managed.terminal.rows > 0) {
+              managed.terminal.refresh(0, managed.terminal.rows - 1);
+            }
+          } catch {
+            // ignore — DOM-renderer fallback paints on next frame regardless
+          }
+        };
+        element.addEventListener("webglcontextlost", captureHandler, { capture: true });
+        captureDisposable = () => {
+          element.removeEventListener("webglcontextlost", captureHandler, { capture: true });
+        };
+      }
+      this.pool.set(id, { addon, contextLossDisposable: clDisposable, captureDisposable });
       this.lruOrder.push(id);
     } catch {
       try {
         clDisposable?.dispose();
+      } catch {
+        // ignore
+      }
+      try {
+        captureDisposable?.();
       } catch {
         // ignore
       }
@@ -193,6 +269,9 @@ export class TerminalWebGLManager {
     const entry = this.pool.get(id);
     if (!entry) return;
 
+    // Delete from pool/lru first so the capture-phase listener (and stale
+    // onContextLoss fires) treat the loseContext below as a self-initiated
+    // release rather than a real eviction.
     this.pool.delete(id);
     this.removeFromLru(id);
 
@@ -200,6 +279,24 @@ export class TerminalWebGLManager {
       entry.contextLossDisposable.dispose();
     } catch {
       // ignore
+    }
+    try {
+      entry.captureDisposable?.();
+    } catch {
+      // ignore
+    }
+    // Force synchronous GPU-side context release before addon.dispose() so the
+    // 16-context Chromium budget actually frees this slot before the next
+    // getContext() call. Reaches into addon internals; guarded by try/catch.
+    try {
+      const gl = (
+        entry.addon as unknown as {
+          _renderer?: { _gl?: WebGL2RenderingContext | WebGLRenderingContext };
+        }
+      )._renderer?._gl;
+      gl?.getExtension("WEBGL_lose_context")?.loseContext();
+    } catch {
+      // ignore — internal addon shape may have changed in a future version
     }
     try {
       entry.addon.dispose();

--- a/src/services/terminal/TerminalWebGLManager.ts
+++ b/src/services/terminal/TerminalWebGLManager.ts
@@ -34,6 +34,24 @@ function loadWebglAddon(): Promise<WebglAddonConstructor> {
   return webglAddonLoadPromise;
 }
 
+// Force synchronous GPU-side context release. Reaches into @xterm/addon-webgl
+// 0.19's renderer internals to get the WebGL context and call loseContext()
+// before addon.dispose() — without this, Chromium's 16-context budget is not
+// freed until garbage collection runs the WebGL teardown. Wrapped in try/catch
+// so a future addon shape change degrades gracefully rather than throwing.
+function forceGpuSlotRelease(addon: WebglAddonType): void {
+  try {
+    const gl = (
+      addon as unknown as {
+        _renderer?: { _gl?: WebGL2RenderingContext | WebGLRenderingContext };
+      }
+    )._renderer?._gl;
+    gl?.getExtension("WEBGL_lose_context")?.loseContext();
+  } catch {
+    // ignore — internal addon shape may have changed in a future version
+  }
+}
+
 interface WebGLEntry {
   addon: WebglAddonType;
   contextLossDisposable: IDisposable;
@@ -134,6 +152,11 @@ export class TerminalWebGLManager {
       } catch {
         // ignore
       }
+      // terminal.dispose() handles addon cleanup, so we skip addon.dispose()
+      // here — but we still need to force the synchronous GPU-slot release so
+      // a hibernation-then-bulk-recreate cycle does not stall on the 16-slot
+      // Chromium budget the same way #7467 stalled the attach path.
+      forceGpuSlotRelease(entry.addon);
       this.pool.delete(id);
       this.removeFromLru(id);
     }
@@ -287,17 +310,8 @@ export class TerminalWebGLManager {
     }
     // Force synchronous GPU-side context release before addon.dispose() so the
     // 16-context Chromium budget actually frees this slot before the next
-    // getContext() call. Reaches into addon internals; guarded by try/catch.
-    try {
-      const gl = (
-        entry.addon as unknown as {
-          _renderer?: { _gl?: WebGL2RenderingContext | WebGLRenderingContext };
-        }
-      )._renderer?._gl;
-      gl?.getExtension("WEBGL_lose_context")?.loseContext();
-    } catch {
-      // ignore — internal addon shape may have changed in a future version
-    }
+    // getContext() call.
+    forceGpuSlotRelease(entry.addon);
     try {
       entry.addon.dispose();
     } catch {

--- a/src/services/terminal/__tests__/TerminalInstanceService.adversarial.test.ts
+++ b/src/services/terminal/__tests__/TerminalInstanceService.adversarial.test.ts
@@ -195,6 +195,14 @@ describe("TerminalInstanceService adversarial", () => {
   beforeEach(async () => {
     vi.resetModules();
     vi.useFakeTimers();
+    // useFakeTimers replaces requestAnimationFrame with its own queue; the
+    // WebGL manager's drain queue needs sync rAF for these tests to retain
+    // their ensureContext()→isActive() inline expectations.
+    globalThis.requestAnimationFrame = ((cb: FrameRequestCallback): number => {
+      cb(0);
+      return 0;
+    }) as typeof globalThis.requestAnimationFrame;
+    globalThis.cancelAnimationFrame = (() => {}) as typeof globalThis.cancelAnimationFrame;
     testState.webglAddons.length = 0;
     Object.values(testState.clientMocks).forEach((mock) => {
       if ("mockReset" in mock && typeof mock.mockReset === "function") {

--- a/src/services/terminal/__tests__/TerminalInstanceService.webglVisibility.test.ts
+++ b/src/services/terminal/__tests__/TerminalInstanceService.webglVisibility.test.ts
@@ -137,6 +137,14 @@ describe("TerminalInstanceService - visibility-driven WebGL lease", () => {
 
   beforeEach(async () => {
     vi.useFakeTimers();
+    // useFakeTimers replaces requestAnimationFrame with its own queue; the
+    // WebGL manager's drain queue needs sync rAF for these tests'
+    // ensureContext()→isActive() inline expectations.
+    globalThis.requestAnimationFrame = ((cb: FrameRequestCallback): number => {
+      cb(0);
+      return 0;
+    }) as typeof globalThis.requestAnimationFrame;
+    globalThis.cancelAnimationFrame = (() => {}) as typeof globalThis.cancelAnimationFrame;
     vi.clearAllMocks();
     vi.resetModules();
 

--- a/src/services/terminal/__tests__/TerminalWebGLManager.test.ts
+++ b/src/services/terminal/__tests__/TerminalWebGLManager.test.ts
@@ -21,10 +21,83 @@ function flushDynamicImport(): Promise<void> {
   return new Promise((resolve) => setTimeout(resolve, 0));
 }
 
+// rAF shim — JSDOM does not implement requestAnimationFrame, and the manager
+// drains its ensure queue one entry per frame. Default mode is "sync" so
+// existing tests retain their synchronous expectations; rAF-pacing tests flip
+// to "queued" and call flushRafFrame() to advance one frame at a time.
+type RafMode = "sync" | "queued";
+let rafMode: RafMode = "sync";
+const rafQueue = new Map<number, FrameRequestCallback>();
+let rafIdCounter = 0;
+
+function installRafShim(): void {
+  rafMode = "sync";
+  rafQueue.clear();
+  rafIdCounter = 0;
+  globalThis.requestAnimationFrame = ((cb: FrameRequestCallback): number => {
+    if (rafMode === "sync") {
+      cb(0);
+      return 0;
+    }
+    rafIdCounter += 1;
+    rafQueue.set(rafIdCounter, cb);
+    return rafIdCounter;
+  }) as typeof globalThis.requestAnimationFrame;
+  globalThis.cancelAnimationFrame = ((id: number): void => {
+    rafQueue.delete(id);
+  }) as typeof globalThis.cancelAnimationFrame;
+}
+
+function flushRafFrame(): boolean {
+  const next = rafQueue.entries().next();
+  if (next.done) return false;
+  const [id, cb] = next.value;
+  rafQueue.delete(id);
+  cb(0);
+  return true;
+}
+
+// Minimal element mock — vitest runs in `node` env without jsdom, so we can't
+// use document.createElement. EventTarget alone doesn't honor capture/bubble
+// phases, so emulate just the bits the manager needs: a listener registry that
+// dispatchEvent walks in registration order. The capture-phase listener is the
+// only consumer in the codepath under test, so a single ordered list suffices.
+function makeFakeElement(): HTMLElement {
+  type Listener = (event: Event) => void;
+  const listeners = new Map<string, Set<Listener>>();
+  const el = {
+    addEventListener(type: string, listener: Listener): void {
+      let bucket = listeners.get(type);
+      if (!bucket) {
+        bucket = new Set();
+        listeners.set(type, bucket);
+      }
+      bucket.add(listener);
+    },
+    removeEventListener(type: string, listener: Listener): void {
+      listeners.get(type)?.delete(listener);
+    },
+    dispatchEvent(event: Event): boolean {
+      const bucket = listeners.get(event.type);
+      if (bucket) {
+        for (const listener of [...bucket]) {
+          listener(event);
+        }
+      }
+      return true;
+    },
+  };
+  return el as unknown as HTMLElement;
+}
+
 function makeManagedTerminal(overrides: Partial<ManagedTerminal> = {}): ManagedTerminal {
+  const element = makeFakeElement();
   return {
     terminal: {
       loadAddon: vi.fn(),
+      element,
+      rows: 24,
+      refresh: vi.fn(),
     },
     isOpened: true,
     lastActiveTime: Date.now(),
@@ -37,6 +110,8 @@ describe("TerminalWebGLManager", () => {
   let WebglAddonMock: ReturnType<typeof vi.fn>;
 
   beforeEach(async () => {
+    installRafShim();
+
     mockAddonDispose = vi.fn();
     mockContextLossDispose = vi.fn();
     mockOnContextLoss = vi.fn((_handler: () => void) => ({ dispose: mockContextLossDispose }));
@@ -326,6 +401,10 @@ describe("TerminalWebGLManager", () => {
     beforeEach(() => {
       vi.useFakeTimers();
       vi.setSystemTime(0);
+      // vi.useFakeTimers() replaces requestAnimationFrame with its own queue.
+      // Reinstall our sync shim so ensureContext drains inline as the tests
+      // expect — this suite does not exercise rAF pacing.
+      installRafShim();
     });
 
     afterEach(() => {
@@ -724,6 +803,237 @@ describe("TerminalWebGLManager", () => {
       await flushDynamicImport();
 
       expect(localManager.isActive("t1")).toBe(true);
+    });
+  });
+
+  describe("rAF drain queue (#7467)", () => {
+    // Ensures bulk attaches are spaced one-per-frame so Chromium's
+    // 16-context-per-renderer cap is not over-subscribed in a single tick.
+
+    it("attaches one queued terminal per animation frame", () => {
+      rafMode = "queued";
+      const m1 = makeManagedTerminal();
+      const m2 = makeManagedTerminal();
+      const m3 = makeManagedTerminal();
+
+      manager.ensureContext("t1", m1);
+      manager.ensureContext("t2", m2);
+      manager.ensureContext("t3", m3);
+
+      expect(WebglAddonMock).not.toHaveBeenCalled();
+
+      flushRafFrame();
+      expect(WebglAddonMock).toHaveBeenCalledTimes(1);
+      expect(manager.isActive("t1")).toBe(true);
+      expect(manager.isActive("t2")).toBe(false);
+
+      flushRafFrame();
+      expect(WebglAddonMock).toHaveBeenCalledTimes(2);
+      expect(manager.isActive("t2")).toBe(true);
+      expect(manager.isActive("t3")).toBe(false);
+
+      flushRafFrame();
+      expect(WebglAddonMock).toHaveBeenCalledTimes(3);
+      expect(manager.isActive("t3")).toBe(true);
+
+      // Queue drained — no further frame should be scheduled.
+      expect(flushRafFrame()).toBe(false);
+    });
+
+    it("dedupes repeat ensure calls for the same id within the queue window", () => {
+      rafMode = "queued";
+      const managed = makeManagedTerminal();
+      manager.ensureContext("t1", managed);
+      manager.ensureContext("t1", managed);
+      manager.ensureContext("t1", managed);
+
+      flushRafFrame();
+      expect(WebglAddonMock).toHaveBeenCalledTimes(1);
+    });
+
+    it("skips queued attach if releaseContext fires before drain", () => {
+      rafMode = "queued";
+      const managed = makeManagedTerminal();
+      manager.ensureContext("t1", managed);
+      manager.releaseContext("t1");
+
+      flushRafFrame();
+      expect(WebglAddonMock).not.toHaveBeenCalled();
+      expect(manager.isActive("t1")).toBe(false);
+    });
+
+    it("skips queued attach if terminal closes before drain", () => {
+      rafMode = "queued";
+      const managed = makeManagedTerminal();
+      manager.ensureContext("t1", managed);
+      managed.isOpened = false;
+
+      flushRafFrame();
+      expect(WebglAddonMock).not.toHaveBeenCalled();
+    });
+
+    it("skips queued attach if pool already holds the id by drain time", () => {
+      rafMode = "queued";
+      const managed = makeManagedTerminal();
+      // First ensure and drain.
+      manager.ensureContext("t1", managed);
+      flushRafFrame();
+      expect(WebglAddonMock).toHaveBeenCalledTimes(1);
+
+      // Second ensure for the same id arrives — no new attach should happen.
+      manager.ensureContext("t1", managed);
+      flushRafFrame();
+      expect(WebglAddonMock).toHaveBeenCalledTimes(1);
+    });
+
+    it("drain clears all pending if hardware becomes unavailable mid-queue", () => {
+      rafMode = "queued";
+      const m1 = makeManagedTerminal();
+      const m2 = makeManagedTerminal();
+      manager.ensureContext("t1", m1);
+      manager.ensureContext("t2", m2);
+
+      manager.setHardwareAvailable(false);
+      flushRafFrame();
+
+      expect(WebglAddonMock).not.toHaveBeenCalled();
+      expect(flushRafFrame()).toBe(false);
+    });
+
+    it("dispose cancels a pending rAF and clears the queue", () => {
+      rafMode = "queued";
+      const m1 = makeManagedTerminal();
+      const m2 = makeManagedTerminal();
+      manager.ensureContext("t1", m1);
+      manager.ensureContext("t2", m2);
+
+      manager.dispose();
+      // After dispose the cancel should have removed the scheduled frame.
+      expect(flushRafFrame()).toBe(false);
+      expect(WebglAddonMock).not.toHaveBeenCalled();
+    });
+  });
+
+  describe("capture-phase webglcontextlost handler (#7467)", () => {
+    function captureContextLossHandlers(): Array<() => void> {
+      const handlers: Array<() => void> = [];
+      WebglAddonMock.mockImplementation(function () {
+        return {
+          dispose: vi.fn(),
+          onContextLoss: vi.fn((handler: () => void) => {
+            handlers.push(handler);
+            return { dispose: vi.fn() };
+          }),
+        };
+      });
+      return handlers;
+    }
+
+    it("releases the context immediately on capture-phase webglcontextlost", () => {
+      const managed = makeManagedTerminal();
+      manager.ensureContext("t1", managed);
+      expect(manager.isActive("t1")).toBe(true);
+
+      const element = managed.terminal.element as HTMLElement;
+      const event = new Event("webglcontextlost");
+      element.dispatchEvent(event);
+
+      expect(manager.isActive("t1")).toBe(false);
+      expect(managed.terminal.refresh).toHaveBeenCalledWith(0, 23);
+    });
+
+    it("subsequent stale onContextLoss for the same id is a no-op", () => {
+      const handlers = captureContextLossHandlers();
+      const managed = makeManagedTerminal();
+      manager.ensureContext("t1", managed);
+
+      const element = managed.terminal.element as HTMLElement;
+      element.dispatchEvent(new Event("webglcontextlost"));
+      expect(manager.isActive("t1")).toBe(false);
+
+      // The addon's deferred onContextLoss still fires ~3s later — should be inert.
+      expect(() => handlers[0]!()).not.toThrow();
+      expect(manager.isActive("t1")).toBe(false);
+    });
+
+    it("contributes to the circuit breaker after threshold real evictions", () => {
+      const m1 = makeManagedTerminal();
+      const m2 = makeManagedTerminal();
+      const m3 = makeManagedTerminal();
+      manager.ensureContext("t1", m1);
+      manager.ensureContext("t2", m2);
+      manager.ensureContext("t3", m3);
+
+      (m1.terminal.element as HTMLElement).dispatchEvent(new Event("webglcontextlost"));
+      (m2.terminal.element as HTMLElement).dispatchEvent(new Event("webglcontextlost"));
+      (m3.terminal.element as HTMLElement).dispatchEvent(new Event("webglcontextlost"));
+
+      const before = WebglAddonMock.mock.calls.length;
+      const m4 = makeManagedTerminal();
+      manager.ensureContext("t4", m4);
+      expect(WebglAddonMock.mock.calls.length).toBe(before);
+      expect(manager.isActive("t4")).toBe(false);
+    });
+
+    it("does not re-fire after release (handler is removed)", () => {
+      const managed = makeManagedTerminal();
+      manager.ensureContext("t1", managed);
+      manager.releaseContext("t1");
+
+      const element = managed.terminal.element as HTMLElement;
+      element.dispatchEvent(new Event("webglcontextlost"));
+
+      // Handler removed on release → refresh must NOT have fired.
+      expect(managed.terminal.refresh).not.toHaveBeenCalled();
+    });
+
+    it("ignores capture event when terminal lacks an element", () => {
+      const managed = makeManagedTerminal();
+      (managed.terminal as unknown as { element: HTMLElement | undefined }).element = undefined;
+      // Should still attach (just without a capture handler) and not throw.
+      expect(() => manager.ensureContext("t1", managed)).not.toThrow();
+      expect(manager.isActive("t1")).toBe(true);
+    });
+  });
+
+  describe("doRelease forces synchronous GPU release (#7467)", () => {
+    it("calls WEBGL_lose_context.loseContext on the addon's GL context", () => {
+      const loseContext = vi.fn();
+      const getExtension = vi.fn().mockReturnValue({ loseContext });
+      const fakeGl = { getExtension } as unknown as WebGL2RenderingContext;
+
+      WebglAddonMock.mockImplementation(function () {
+        const addon: Record<string, unknown> = {
+          dispose: vi.fn(),
+          onContextLoss: vi.fn(() => ({ dispose: vi.fn() })),
+        };
+        // Mirror the @xterm/addon-webgl 0.19 internal shape so the
+        // narrow private cast in doRelease can locate the GL context.
+        addon._renderer = { _gl: fakeGl };
+        return addon;
+      });
+
+      const managed = makeManagedTerminal();
+      manager.ensureContext("t1", managed);
+      manager.releaseContext("t1");
+
+      expect(getExtension).toHaveBeenCalledWith("WEBGL_lose_context");
+      expect(loseContext).toHaveBeenCalledTimes(1);
+    });
+
+    it("release proceeds cleanly when WEBGL_lose_context is unavailable", () => {
+      WebglAddonMock.mockImplementation(function () {
+        return {
+          dispose: vi.fn(),
+          onContextLoss: vi.fn(() => ({ dispose: vi.fn() })),
+          // No _renderer — narrow cast resolves to undefined; release must still succeed.
+        };
+      });
+
+      const managed = makeManagedTerminal();
+      manager.ensureContext("t1", managed);
+      expect(() => manager.releaseContext("t1")).not.toThrow();
+      expect(manager.isActive("t1")).toBe(false);
     });
   });
 });

--- a/src/services/terminal/__tests__/TerminalWebGLManager.test.ts
+++ b/src/services/terminal/__tests__/TerminalWebGLManager.test.ts
@@ -58,33 +58,61 @@ function flushRafFrame(): boolean {
 }
 
 // Minimal element mock — vitest runs in `node` env without jsdom, so we can't
-// use document.createElement. EventTarget alone doesn't honor capture/bubble
-// phases, so emulate just the bits the manager needs: a listener registry that
-// dispatchEvent walks in registration order. The capture-phase listener is the
-// only consumer in the codepath under test, so a single ordered list suffices.
+// use document.createElement. The mock tracks the `capture` flag separately so
+// tests can verify the manager registers and removes its listener in the
+// capture phase (a regression to a bubble listener would fire after xterm's
+// own canvas-target handler — too late to pre-empt the 3s restore timer).
+type Listener = (event: Event) => void;
+type ListenerOptions = boolean | { capture?: boolean } | undefined;
+interface FakeElement {
+  addEventListener(type: string, listener: Listener, options?: ListenerOptions): void;
+  removeEventListener(type: string, listener: Listener, options?: ListenerOptions): void;
+  dispatchEvent(event: Event): boolean;
+  // Test helper — only fires bubble-phase listeners; lets a test prove the
+  // manager registered in capture phase by showing the listener doesn't run.
+  __dispatchBubbleOnly(event: Event): void;
+  __listenerCount(type: string): number;
+}
+
+function isCapture(options: ListenerOptions): boolean {
+  if (typeof options === "boolean") return options;
+  return options?.capture === true;
+}
+
 function makeFakeElement(): HTMLElement {
-  type Listener = (event: Event) => void;
-  const listeners = new Map<string, Set<Listener>>();
-  const el = {
-    addEventListener(type: string, listener: Listener): void {
-      let bucket = listeners.get(type);
-      if (!bucket) {
-        bucket = new Set();
-        listeners.set(type, bucket);
+  const captureBucket = new Map<string, Set<Listener>>();
+  const bubbleBucket = new Map<string, Set<Listener>>();
+
+  const el: FakeElement = {
+    addEventListener(type, listener, options) {
+      const target = isCapture(options) ? captureBucket : bubbleBucket;
+      let set = target.get(type);
+      if (!set) {
+        set = new Set();
+        target.set(type, set);
       }
-      bucket.add(listener);
+      set.add(listener);
     },
-    removeEventListener(type: string, listener: Listener): void {
-      listeners.get(type)?.delete(listener);
+    removeEventListener(type, listener, options) {
+      const target = isCapture(options) ? captureBucket : bubbleBucket;
+      target.get(type)?.delete(listener);
     },
-    dispatchEvent(event: Event): boolean {
-      const bucket = listeners.get(event.type);
-      if (bucket) {
-        for (const listener of [...bucket]) {
-          listener(event);
-        }
+    dispatchEvent(event) {
+      for (const listener of [...(captureBucket.get(event.type) ?? [])]) {
+        listener(event);
+      }
+      for (const listener of [...(bubbleBucket.get(event.type) ?? [])]) {
+        listener(event);
       }
       return true;
+    },
+    __dispatchBubbleOnly(event) {
+      for (const listener of [...(bubbleBucket.get(event.type) ?? [])]) {
+        listener(event);
+      }
+    },
+    __listenerCount(type) {
+      return (captureBucket.get(type)?.size ?? 0) + (bubbleBucket.get(type)?.size ?? 0);
     },
   };
   return el as unknown as HTMLElement;
@@ -994,6 +1022,36 @@ describe("TerminalWebGLManager", () => {
       expect(() => manager.ensureContext("t1", managed)).not.toThrow();
       expect(manager.isActive("t1")).toBe(true);
     });
+
+    it("registers in the capture phase, not bubble", () => {
+      // Bubble-only dispatch must NOT fire the manager's handler — proves the
+      // listener was registered with { capture: true } so it can pre-empt
+      // xterm's canvas-target listener and its 3s restore timer.
+      const managed = makeManagedTerminal();
+      manager.ensureContext("t1", managed);
+
+      const el = managed.terminal.element as unknown as ReturnType<typeof makeFakeElement> & {
+        __dispatchBubbleOnly(e: Event): void;
+        __listenerCount(t: string): number;
+      };
+      el.__dispatchBubbleOnly(new Event("webglcontextlost"));
+
+      expect(manager.isActive("t1")).toBe(true);
+      expect(managed.terminal.refresh).not.toHaveBeenCalled();
+    });
+
+    it("releaseContext removes the capture listener with matching options", () => {
+      // Verifies addEventListener and removeEventListener used the same
+      // capture flag — a mismatch would leak the listener in production.
+      const managed = makeManagedTerminal();
+      manager.ensureContext("t1", managed);
+
+      const el = managed.terminal.element as unknown as { __listenerCount(t: string): number };
+      expect(el.__listenerCount("webglcontextlost")).toBe(1);
+
+      manager.releaseContext("t1");
+      expect(el.__listenerCount("webglcontextlost")).toBe(0);
+    });
   });
 
   describe("doRelease forces synchronous GPU release (#7467)", () => {
@@ -1019,6 +1077,32 @@ describe("TerminalWebGLManager", () => {
 
       expect(getExtension).toHaveBeenCalledWith("WEBGL_lose_context");
       expect(loseContext).toHaveBeenCalledTimes(1);
+    });
+
+    it("onTerminalDestroyed also forces synchronous GPU slot release", () => {
+      // Hibernation calls onTerminalDestroyed without addon.dispose() (xterm
+      // tears the addon down via terminal.dispose()). Without the explicit
+      // loseContext, a hibernate-then-bulk-recreate cycle would stall on the
+      // 16-slot Chromium budget the same way #7467 stalled the attach path.
+      const loseContext = vi.fn();
+      const getExtension = vi.fn().mockReturnValue({ loseContext });
+      const fakeGl = { getExtension } as unknown as WebGL2RenderingContext;
+
+      WebglAddonMock.mockImplementation(function () {
+        const addon: Record<string, unknown> = {
+          dispose: vi.fn(),
+          onContextLoss: vi.fn(() => ({ dispose: vi.fn() })),
+        };
+        addon._renderer = { _gl: fakeGl };
+        return addon;
+      });
+
+      const managed = makeManagedTerminal();
+      manager.ensureContext("t1", managed);
+      manager.onTerminalDestroyed("t1");
+
+      expect(loseContext).toHaveBeenCalledTimes(1);
+      expect(manager.isActive("t1")).toBe(false);
     });
 
     it("release proceeds cleanly when WEBGL_lose_context is unavailable", () => {

--- a/vitest.setup.ts
+++ b/vitest.setup.ts
@@ -26,6 +26,21 @@ if (typeof globalThis !== "undefined") {
   }
 }
 
+// node env does not implement requestAnimationFrame/cancelAnimationFrame.
+// Several renderer-side modules (TerminalWebGLManager, etc.) schedule work via
+// rAF in production. Install a sync default that runs the callback inline so
+// tests retain synchronous expectations without each file repeating the shim.
+// Tests that exercise rAF pacing explicitly override these globals locally.
+if (typeof globalThis.requestAnimationFrame !== "function") {
+  globalThis.requestAnimationFrame = ((cb: FrameRequestCallback): number => {
+    cb(0);
+    return 0;
+  }) as typeof globalThis.requestAnimationFrame;
+}
+if (typeof globalThis.cancelAnimationFrame !== "function") {
+  globalThis.cancelAnimationFrame = (() => {}) as typeof globalThis.cancelAnimationFrame;
+}
+
 // Node 25 exposes a broken native `localStorage` stub on `globalThis` (no
 // `clear`/`getItem`/etc) that shadows JSDOM's Storage and leaks the warning
 // `--localstorage-file was provided without a valid path`. JSDOM's env setup


### PR DESCRIPTION
## Summary

- Bulk worktree creation was triggering WebGL context eviction by firing multiple `ensureContext` calls synchronously in the same frame, leaving terminals blank for ~3 seconds while xterm waited for `webglcontextrestored`
- Three fixes in `TerminalWebGLManager`: coalesce concurrent attach calls via a single rAF drain queue, intercept `webglcontextlost` in capture phase to release the GPU slot before xterm's bubble-phase handler can start its 3-second timer, and call `WEBGL_lose_context.loseContext()` explicitly on LRU eviction so Chromium reclaims the slot immediately
- Adds `forceGpuSlotRelease()` so `onTerminalDestroyed` also frees the slot synchronously, not just on context loss

Resolves #7467

## Changes

- `src/services/terminal/TerminalWebGLManager.ts`: rAF drain queue for `ensureContext`, capture-phase `webglcontextlost` listener, explicit `loseContext()` on LRU eviction, `forceGpuSlotRelease()` helper called from both the capture listener and `onTerminalDestroyed`
- `vitest.setup.ts`: sync rAF shim installed globally, reinstalled after `vi.useFakeTimers()` so fake timers don't break rAF-dependent tests
- `src/services/terminal/__tests__/TerminalWebGLManager.test.ts`: capture-phase firing order, listener removal symmetry, `onTerminalDestroyed` slot release
- `src/services/terminal/__tests__/TerminalInstanceService.webglVisibility.test.ts` / `.adversarial.test.ts`: reinstall rAF shim after `vi.useFakeTimers`

## Testing

- New unit tests cover the capture-phase interception order, that removing a terminal cleans up its listener, and that `onTerminalDestroyed` releases the GPU slot synchronously
- Existing webgl visibility and adversarial tests updated to reinstall the rAF shim after fake timers, keeping the full suite green
- Manually reproducible via bulk worktree creation with 3-5 issues and a recipe that spawns agent panels -- terminals no longer land blank