### PR TITLE
fix(palette): prevent confirm-danger actions from landing in recently-used rail

### DIFF
--- a/src/components/ActionPalette/ActionPalette.test.tsx
+++ b/src/components/ActionPalette/ActionPalette.test.tsx
@@ -49,6 +49,7 @@ function makeItem(id: string, title: string): ActionPaletteItemType {
     description: "",
     category: "General",
     enabled: true,
+    danger: "safe",
     kind: "command",
     titleLower: title.toLowerCase(),
     categoryLower: "general",

--- a/src/components/ActionPalette/ActionPaletteItem.test.tsx
+++ b/src/components/ActionPalette/ActionPaletteItem.test.tsx
@@ -22,6 +22,7 @@ function makeItem(overrides: Partial<ActionPaletteItemType> = {}): ActionPalette
     description: "Test description",
     category: "terminal",
     enabled: true,
+    danger: "safe",
     kind: "command",
     titleLower: "test action",
     categoryLower: "terminal",

--- a/src/hooks/__tests__/useActionPalette.test.tsx
+++ b/src/hooks/__tests__/useActionPalette.test.tsx
@@ -305,6 +305,66 @@ describe("useActionPalette", () => {
     expect(dispatchMock).toHaveBeenCalledWith("a.action", {}, { source: "user" });
   });
 
+  it("excludes confirm-danger ids persisted in MRU from the Recently used rail", async () => {
+    // Pre-fix sessions could have written confirm-danger ids into MRU. After
+    // the fix they must not surface on the empty-query rail even though the
+    // ids are still in the persisted store (issue #7481).
+    listMock.mockReturnValue([
+      makeEntry("a.action", "Alpha"),
+      makeEntry("worktree.delete", "Delete worktree", true, "worktree", "confirm"),
+      makeEntry("b.action", "Bravo"),
+    ]);
+
+    useActionMruStore.getState().hydrateActionMru(["worktree.delete", "a.action", "b.action"]);
+
+    const { result } = renderHook(() => useActionPalette());
+
+    act(() => {
+      result.current.open();
+    });
+
+    await waitFor(() => {
+      expect(result.current.results.length).toBe(2);
+    });
+
+    const ids = result.current.results.map((r) => r.id);
+    expect(ids).not.toContain("worktree.delete");
+    expect(ids).toEqual(["a.action", "b.action"]);
+  });
+
+  it("does not give a search-rank MRU bonus to confirm-danger items", async () => {
+    // Even with a stale confirm-danger id in MRU, a typed-query result must
+    // not get an MRU rank boost — pairs with the rail filter above.
+    // Both entries share the same title so their base scores tie; without
+    // the filter the MRU bonus would lift the danger entry above the safe
+    // one, with the filter the stable-sort tiebreak keeps insertion order.
+    listMock.mockReturnValue([
+      makeEntry("safe.close", "Close", true, "terminal"),
+      makeEntry("danger.close", "Close", true, "terminal", "confirm"),
+    ]);
+
+    useActionMruStore.getState().hydrateActionMru(["danger.close"]);
+
+    const { result } = renderHook(() => useActionPalette());
+
+    act(() => {
+      result.current.open();
+    });
+
+    act(() => {
+      result.current.setQuery("close");
+    });
+
+    await waitFor(
+      () => {
+        expect(result.current.results.length).toBe(2);
+      },
+      { timeout: 2000 }
+    );
+
+    expect(result.current.results[0]!.id).toBe("safe.close");
+  });
+
   it("does NOT record frecency when executeAction is called on confirm-danger item", async () => {
     dispatchMock.mockResolvedValue({ ok: true });
     listMock.mockReturnValue([

--- a/src/hooks/__tests__/useActionPalette.test.tsx
+++ b/src/hooks/__tests__/useActionPalette.test.tsx
@@ -37,7 +37,8 @@ function makeEntry(
   id: string,
   title: string,
   enabled = true,
-  category = "General"
+  category = "General",
+  danger: "safe" | "confirm" | "restricted" = "safe"
 ): {
   id: string;
   title: string;
@@ -45,9 +46,10 @@ function makeEntry(
   category: string;
   kind: string;
   enabled: boolean;
+  danger: "safe" | "confirm" | "restricted";
   requiresArgs?: boolean;
 } {
-  return { id, title, description: "", category, kind: "command", enabled };
+  return { id, title, description: "", category, kind: "command", enabled, danger };
 }
 
 describe("useActionPalette", () => {
@@ -301,6 +303,40 @@ describe("useActionPalette", () => {
     expect(sorted.length).toBe(1);
     expect(sorted[0]!.id).toBe("a.action");
     expect(dispatchMock).toHaveBeenCalledWith("a.action", {}, { source: "user" });
+  });
+
+  it("does NOT record frecency when executeAction is called on confirm-danger item", async () => {
+    dispatchMock.mockResolvedValue({ ok: true });
+    listMock.mockReturnValue([
+      makeEntry("worktree.delete", "Delete worktree", true, "worktree", "confirm"),
+    ]);
+
+    const { result } = renderHook(() => useActionPalette());
+
+    act(() => {
+      result.current.open();
+    });
+
+    act(() => {
+      result.current.setQuery("delete");
+    });
+
+    await waitFor(
+      () => {
+        expect(result.current.results.length).toBe(1);
+      },
+      { timeout: 2000 }
+    );
+
+    act(() => {
+      result.current.executeAction(result.current.results[0]!);
+    });
+
+    // Dispatch still runs so ActionService can show the confirmation dialog,
+    // but MRU stays clean — destructive actions must not land in the
+    // "Recently used" rail (issue #7481).
+    expect(useActionMruStore.getState().getSortedActionMruList().length).toBe(0);
+    expect(dispatchMock).toHaveBeenCalledWith("worktree.delete", {}, { source: "user" });
   });
 
   it("does NOT record frecency when executeAction is called on disabled item", async () => {

--- a/src/hooks/useActionPalette.ts
+++ b/src/hooks/useActionPalette.ts
@@ -92,7 +92,15 @@ export function useActionPalette(): UseActionPaletteReturn {
 
   const filterFn = useCallback(
     (items: ActionPaletteItem[], query: string): ActionPaletteItem[] => {
-      const actionMruList = getSortedActionMruList().map(({ id }) => id);
+      // Strip confirm-danger ids from the MRU list so destructive actions
+      // persisted from a pre-fix session don't keep surfacing in the
+      // "Recently used" rail or get a search-rank bonus (issue #7481).
+      const confirmDangerIds = new Set(
+        items.filter((item) => item.danger === "confirm").map((item) => item.id)
+      );
+      const actionMruList = getSortedActionMruList()
+        .map(({ id }) => id)
+        .filter((id) => !confirmDangerIds.has(id));
 
       if (!query.trim()) {
         if (actionMruList.length === 0) return [];

--- a/src/hooks/useActionPalette.ts
+++ b/src/hooks/useActionPalette.ts
@@ -3,7 +3,7 @@ import { useCallback, useMemo } from "react";
 import { actionService } from "@/services/ActionService";
 import { keybindingService } from "@/services/KeybindingService";
 import { notify } from "@/lib/notify";
-import type { ActionManifestEntry } from "@shared/types/actions";
+import type { ActionDanger, ActionManifestEntry } from "@shared/types/actions";
 import { usePaletteStore } from "@/store/paletteStore";
 import { useActionMruStore } from "@/store/actionMruStore";
 import { extractAcronym, rankActionMatches } from "@/lib/actionPaletteSearch";
@@ -16,6 +16,7 @@ export interface ActionPaletteItem {
   description: string;
   category: string;
   enabled: boolean;
+  danger: ActionDanger;
   disabledReason?: string;
   keybinding?: string;
   kind: string;
@@ -67,6 +68,7 @@ function toActionPaletteItem(entry: ActionManifestEntry): ActionPaletteItem {
     description,
     category,
     enabled: entry.enabled,
+    danger: entry.danger,
     disabledReason,
     keybinding: keybindingService.getDisplayCombo(entry.id),
     kind: entry.kind,
@@ -143,7 +145,9 @@ export function useActionPalette(): UseActionPaletteReturn {
       // Only record frecency for enabled items so disabled actions don't get
       // promoted to the top from repeated attempts. Dispatch still runs for
       // disabled items so ActionService can surface the disabled-reason toast.
-      if (item.enabled) {
+      // Also skip confirm-danger actions (e.g. "Delete worktree") so destructive
+      // actions don't land in the "Recently used" rail (issue #7481).
+      if (item.enabled && item.danger !== "confirm") {
         useActionMruStore.getState().recordActionMru(item.id);
       }
       close();


### PR DESCRIPTION
## Summary

- `danger: "confirm"` actions (e.g. `Delete worktree`, `Reset agent`) could enter the frecency log and surface in the palette's Recently used rail after a single use
- `ActionService` already drops `restricted` actions at listing time, but the recency-write path in `useActionPalette` only gated on `item.enabled`, not `item.danger`
- Two-part fix: skip frecency recording for `confirm` danger actions at write time, and strip any already-persisted `confirm` danger ids from the MRU rail and rank bonus on read

Resolves #7481

## Changes

- `useActionPalette`: pass `danger` through the `ActionPaletteItem` projection so it's available at the recording callsite
- `useActionPalette`: guard `recordAction()` call — skip when `item.danger === "confirm"`
- `useActionPalette`: filter persisted `confirm` danger ids out of the frecency results before building the MRU rail and applying the rank bonus
- Tests covering both the write-skip and read-filter paths

## Testing

- Unit tests added in `src/hooks/__tests__/useActionPalette.test.tsx` covering the skip-on-write and filter-on-read cases
- Confirmed existing palette tests still pass