### PR TITLE
feat(notifications): add undo to bulk mark-read

### DIFF
--- a/src/components/Notifications/NotificationCenter.tsx
+++ b/src/components/Notifications/NotificationCenter.tsx
@@ -259,7 +259,19 @@ export function NotificationCenter({ open, onClose }: NotificationCenterProps) {
 
   const totalChronoGroups = chronoSections.reduce((sum, s) => sum + s.groups.length, 0);
 
-  const markIdsReadWithUndo = (ids: string[], options: { resetLastClosed: boolean }) => {
+  const markIdsReadWithUndo = (
+    requestedIds: string[],
+    options: { resetLastClosed: boolean }
+  ) => {
+    if (requestedIds.length === 0) return;
+    // Re-filter against live store state so a rapid second click on a stale
+    // closure doesn't fire a ghost toast for entries already marked read.
+    const liveEntries = useNotificationHistoryStore.getState().entries;
+    const liveById = new Map(liveEntries.map((e) => [e.id, e] as const));
+    const ids = requestedIds.filter((id) => {
+      const entry = liveById.get(id);
+      return entry !== undefined && !entry.seenAsToast;
+    });
     if (ids.length === 0) return;
     markIdsRead(ids);
     if (options.resetLastClosed) {

--- a/src/components/Notifications/NotificationCenter.tsx
+++ b/src/components/Notifications/NotificationCenter.tsx
@@ -16,7 +16,7 @@ import {
   DropdownMenuTrigger,
 } from "@/components/ui/dropdown-menu";
 import { actionService } from "@/services/ActionService";
-import { muteForDuration, muteUntilNextMorning, setSessionQuietUntil } from "@/lib/notify";
+import { muteForDuration, muteUntilNextMorning, notify, setSessionQuietUntil } from "@/lib/notify";
 import { useNotificationSettingsStore } from "@/store/notificationSettingsStore";
 import { useUIStore } from "@/store/uiStore";
 import { useWorktreeStore } from "@/hooks/useWorktreeStore";
@@ -130,7 +130,8 @@ export function NotificationCenter({ open, onClose }: NotificationCenterProps) {
   const entries = useNotificationHistoryStore((s) => s.entries);
   const unreadCount = useNotificationHistoryStore((s) => s.unreadCount);
   const clearAll = useNotificationHistoryStore((s) => s.clearAll);
-  const markAllRead = useNotificationHistoryStore((s) => s.markAllRead);
+  const markIdsRead = useNotificationHistoryStore((s) => s.markIdsRead);
+  const markUnseenAsToast = useNotificationHistoryStore((s) => s.markUnseenAsToast);
   const dismissEntry = useNotificationHistoryStore((s) => s.dismissEntry);
   const dismissByCorrelationId = useNotificationHistoryStore((s) => s.dismissByCorrelationId);
 
@@ -258,12 +259,42 @@ export function NotificationCenter({ open, onClose }: NotificationCenterProps) {
 
   const totalChronoGroups = chronoSections.reduce((sum, s) => sum + s.groups.length, 0);
 
-  const handleMarkAllRead = () => {
-    if (filter === "unread") {
-      setFrozenUnreadIds(new Set(entries.filter((e) => !e.seenAsToast).map((e) => e.id)));
+  const markIdsReadWithUndo = (ids: string[], options: { resetLastClosed: boolean }) => {
+    if (ids.length === 0) return;
+    markIdsRead(ids);
+    if (options.resetLastClosed) {
+      resetLastClosedAt();
     }
-    markAllRead();
-    resetLastClosedAt();
+    notify({
+      type: "success",
+      message: `Marked ${ids.length} read`,
+      // Action-bearing toasts default to sticky (duration: 0). Keep the undo
+      // window short and explicit so the toast clears itself.
+      duration: 5000,
+      priority: "high",
+      // Time-bound undo — surface even during quiet hours so the user has a
+      // recovery path.
+      urgent: true,
+      // Confirmation toast only — no inbox entry. (Don't pair with `context`:
+      // notify warns and silently drops in DEV.)
+      transient: true,
+      action: {
+        label: "Undo",
+        onClick: () => {
+          for (const id of ids) {
+            markUnseenAsToast(id, { silent: true });
+          }
+        },
+      },
+    });
+  };
+
+  const handleMarkAllRead = () => {
+    const ids = entries.filter((e) => !e.seenAsToast).map((e) => e.id);
+    if (filter === "unread") {
+      setFrozenUnreadIds(new Set(ids));
+    }
+    markIdsReadWithUndo(ids, { resetLastClosed: true });
   };
 
   const handleMuteFor = (durationMs: number) => {
@@ -503,8 +534,10 @@ export function NotificationCenter({ open, onClose }: NotificationCenterProps) {
                 section={section}
                 groupByContext={groupByContext}
                 dividerGroupId={dividerGroupId}
+                lastClosedAt={lastClosedAt}
                 onDismiss={dismissEntry}
                 onDismissThread={dismissByCorrelationId}
+                onMarkIdsRead={markIdsReadWithUndo}
               />
             ))}
           </>
@@ -539,15 +572,26 @@ function ChronoSection({
   section,
   groupByContext,
   dividerGroupId,
+  lastClosedAt,
   onDismiss,
   onDismissThread,
+  onMarkIdsRead,
 }: {
   section: ContextSection;
   groupByContext: boolean;
   dividerGroupId: string | null;
+  lastClosedAt: number;
   onDismiss: (id: string) => void;
   onDismissThread: (correlationId: string) => void;
+  onMarkIdsRead: (ids: string[], options: { resetLastClosed: boolean }) => void;
 }) {
+  const sectionUnreadIds = section.groups.flatMap((g) =>
+    g.entries.filter((e) => !e.seenAsToast).map((e) => e.id)
+  );
+  const newSinceUnreadIds = section.groups
+    .filter((g) => g.latestTimestamp > lastClosedAt)
+    .flatMap((g) => g.entries.filter((e) => !e.seenAsToast).map((e) => e.id));
+
   return (
     <div data-testid="chrono-section">
       {groupByContext && (
@@ -555,6 +599,8 @@ function ChronoSection({
           worktreeId={section.worktreeId}
           projectId={section.projectId}
           count={section.groups.length}
+          unreadIds={sectionUnreadIds}
+          onMarkRead={() => onMarkIdsRead(sectionUnreadIds, { resetLastClosed: false })}
         />
       )}
       <div className="divide-y divide-tint/[0.04]">
@@ -563,7 +609,14 @@ function ChronoSection({
           const isDivider = dividerGroupId !== null && groupKey === dividerGroupId;
           return (
             <div key={groupKey}>
-              {isDivider && <NewSinceLastLookedDivider />}
+              {isDivider && (
+                <NewSinceLastLookedDivider
+                  unreadCount={newSinceUnreadIds.length}
+                  onMarkRead={() =>
+                    onMarkIdsRead(newSinceUnreadIds, { resetLastClosed: true })
+                  }
+                />
+              )}
               {renderGroup(group, onDismiss, onDismissThread)}
             </div>
           );
@@ -602,29 +655,51 @@ function ContextSectionHeader({
   worktreeId,
   projectId,
   count,
+  unreadIds,
+  onMarkRead,
 }: {
   worktreeId?: string;
   projectId?: string;
   count: number;
+  unreadIds: string[];
+  onMarkRead: () => void;
 }) {
   const worktreeName = useWorktreeStore((s) =>
     worktreeId ? s.worktrees.get(worktreeId)?.name : undefined
   );
   const label = worktreeName ?? worktreeId ?? projectId ?? "Other";
+  const hasUnread = unreadIds.length > 0;
   return (
     <div
       data-testid="context-section-header"
-      className="flex items-center justify-between px-3 py-1 bg-overlay-subtle text-[10px] font-medium uppercase tracking-wide text-daintree-text/60"
+      className="group/section flex items-center justify-between px-3 py-1 bg-overlay-subtle text-[10px] font-medium uppercase tracking-wide text-daintree-text/60"
     >
       <span className="truncate">{label}</span>
-      <span aria-hidden="true" className="ml-2 shrink-0 text-daintree-text/40 tabular-nums">
-        {count}
-      </span>
+      <div className="ml-2 shrink-0 flex items-center gap-2">
+        {hasUnread && (
+          <button
+            type="button"
+            onClick={onMarkRead}
+            className="invisible opacity-0 pointer-events-none transition-[opacity,visibility] duration-150 motion-reduce:transition-none group-hover/section:visible group-hover/section:opacity-100 group-hover/section:pointer-events-auto group-focus-within/section:visible group-focus-within/section:opacity-100 group-focus-within/section:pointer-events-auto inline-flex items-center rounded-[var(--radius-sm)] px-1.5 py-0.5 normal-case tracking-normal text-daintree-text/60 hover:bg-overlay-emphasis hover:text-daintree-text"
+          >
+            Mark read
+          </button>
+        )}
+        <span aria-hidden="true" className="text-daintree-text/40 tabular-nums">
+          {count}
+        </span>
+      </div>
     </div>
   );
 }
 
-function NewSinceLastLookedDivider() {
+function NewSinceLastLookedDivider({
+  unreadCount,
+  onMarkRead,
+}: {
+  unreadCount: number;
+  onMarkRead: () => void;
+}) {
   return (
     <div
       data-testid="new-since-last-looked"
@@ -632,6 +707,15 @@ function NewSinceLastLookedDivider() {
     >
       <span className="h-px flex-1 bg-divider" aria-hidden="true" />
       <span>New since you last looked</span>
+      {unreadCount > 0 && (
+        <button
+          type="button"
+          onClick={onMarkRead}
+          className="inline-flex items-center rounded-[var(--radius-sm)] px-1.5 py-0.5 text-daintree-text/60 hover:bg-overlay-emphasis hover:text-daintree-text transition-colors"
+        >
+          Mark these {unreadCount} read
+        </button>
+      )}
       <span className="h-px flex-1 bg-divider" aria-hidden="true" />
     </div>
   );

--- a/src/components/Notifications/NotificationCenter.tsx
+++ b/src/components/Notifications/NotificationCenter.tsx
@@ -259,10 +259,7 @@ export function NotificationCenter({ open, onClose }: NotificationCenterProps) {
 
   const totalChronoGroups = chronoSections.reduce((sum, s) => sum + s.groups.length, 0);
 
-  const markIdsReadWithUndo = (
-    requestedIds: string[],
-    options: { resetLastClosed: boolean }
-  ) => {
+  const markIdsReadWithUndo = (requestedIds: string[], options: { resetLastClosed: boolean }) => {
     if (requestedIds.length === 0) return;
     // Re-filter against live store state so a rapid second click on a stale
     // closure doesn't fire a ghost toast for entries already marked read.
@@ -624,9 +621,7 @@ function ChronoSection({
               {isDivider && (
                 <NewSinceLastLookedDivider
                   unreadCount={newSinceUnreadIds.length}
-                  onMarkRead={() =>
-                    onMarkIdsRead(newSinceUnreadIds, { resetLastClosed: true })
-                  }
+                  onMarkRead={() => onMarkIdsRead(newSinceUnreadIds, { resetLastClosed: true })}
                 />
               )}
               {renderGroup(group, onDismiss, onDismissThread)}

--- a/src/components/Notifications/__tests__/NotificationCenter.test.tsx
+++ b/src/components/Notifications/__tests__/NotificationCenter.test.tsx
@@ -1260,6 +1260,211 @@ describe("NotificationCenter — New since you last looked divider", () => {
   });
 });
 
+describe("NotificationCenter — bulk mark-read with Undo", () => {
+  function getLastNotifyPayload() {
+    const calls = vi.mocked(notifyLib.notify).mock.calls;
+    expect(calls.length).toBeGreaterThan(0);
+    return calls[calls.length - 1]![0];
+  }
+
+  it("'Mark all read' marks every unread entry and emits an undo toast", async () => {
+    setEntries([
+      makeEntry({ id: "u1", message: "Unread 1", seenAsToast: false }),
+      makeEntry({ id: "u2", message: "Unread 2", seenAsToast: false }),
+      makeEntry({ id: "r1", message: "Already read", seenAsToast: true }),
+    ]);
+
+    render(<NotificationCenter open onClose={vi.fn()} />);
+
+    await act(async () => {
+      fireEvent.click(screen.getByText("Mark all read"));
+    });
+
+    expect(useNotificationHistoryStore.getState().unreadCount).toBe(0);
+
+    const payload = getLastNotifyPayload();
+    expect(payload.type).toBe("success");
+    expect(payload.message).toBe("Marked 2 read");
+    expect(payload.duration).toBe(5000);
+    expect(payload.urgent).toBe(true);
+    expect(payload.transient).toBe(true);
+    expect(payload.priority).toBe("high");
+    expect(payload.context).toBeUndefined();
+    expect(payload.action?.label).toBe("Undo");
+  });
+
+  it("'Mark all read' resets lastNotificationCenterClosedAt to clear the divider", async () => {
+    useUIStore.setState({ lastNotificationCenterClosedAt: 12345 });
+    setEntries([makeEntry({ message: "Unread", seenAsToast: false })]);
+
+    render(<NotificationCenter open onClose={vi.fn()} />);
+
+    await act(async () => {
+      fireEvent.click(screen.getByText("Mark all read"));
+    });
+
+    expect(useUIStore.getState().lastNotificationCenterClosedAt).toBe(0);
+  });
+
+  it("undo restores the captured ids back to unread", async () => {
+    setEntries([
+      makeEntry({ id: "u1", message: "Unread 1", seenAsToast: false }),
+      makeEntry({ id: "u2", message: "Unread 2", seenAsToast: false }),
+    ]);
+
+    render(<NotificationCenter open onClose={vi.fn()} />);
+
+    await act(async () => {
+      fireEvent.click(screen.getByText("Mark all read"));
+    });
+    expect(useNotificationHistoryStore.getState().unreadCount).toBe(0);
+
+    const payload = getLastNotifyPayload();
+    await act(async () => {
+      payload.action?.onClick?.();
+    });
+
+    expect(useNotificationHistoryStore.getState().unreadCount).toBe(2);
+    const entries = useNotificationHistoryStore.getState().entries;
+    expect(entries.find((e) => e.id === "u1")?.seenAsToast).toBe(false);
+    expect(entries.find((e) => e.id === "u2")?.seenAsToast).toBe(false);
+  });
+
+  it("undo does not increment evictedToInboxCount (silent restore)", async () => {
+    setEntries([makeEntry({ message: "Unread", seenAsToast: false })]);
+
+    render(<NotificationCenter open onClose={vi.fn()} />);
+
+    await act(async () => {
+      fireEvent.click(screen.getByText("Mark all read"));
+    });
+
+    const payload = getLastNotifyPayload();
+    await act(async () => {
+      payload.action?.onClick?.();
+    });
+
+    expect(useNotificationHistoryStore.getState().evictedToInboxCount).toBe(0);
+  });
+
+  it("does nothing and emits no toast when there are no unread entries", () => {
+    setEntries([makeEntry({ message: "Read", seenAsToast: true })]);
+
+    render(<NotificationCenter open onClose={vi.fn()} />);
+
+    // The "Mark all read" button only renders when unreadCount > 0.
+    expect(screen.queryByText("Mark all read")).toBeNull();
+    expect(vi.mocked(notifyLib.notify)).not.toHaveBeenCalled();
+  });
+
+  it("'Mark these N read' on the divider marks only entries above the divider", async () => {
+    const closedAt = Date.now() - 5000;
+    useUIStore.setState({ lastNotificationCenterClosedAt: closedAt });
+    setEntries([
+      makeEntry({
+        id: "new-1",
+        message: "Newer 1",
+        timestamp: closedAt + 4000,
+        seenAsToast: false,
+      }),
+      makeEntry({
+        id: "new-2",
+        message: "Newer 2",
+        timestamp: closedAt + 3000,
+        seenAsToast: false,
+      }),
+      makeEntry({
+        id: "old-1",
+        message: "Older",
+        timestamp: closedAt - 1000,
+        seenAsToast: false,
+      }),
+    ]);
+
+    render(<NotificationCenter open onClose={vi.fn()} />);
+
+    expect(screen.queryByTestId("new-since-last-looked")).toBeTruthy();
+    await act(async () => {
+      fireEvent.click(screen.getByText("Mark these 2 read"));
+    });
+
+    const entries = useNotificationHistoryStore.getState().entries;
+    expect(entries.find((e) => e.id === "new-1")?.seenAsToast).toBe(true);
+    expect(entries.find((e) => e.id === "new-2")?.seenAsToast).toBe(true);
+    expect(entries.find((e) => e.id === "old-1")?.seenAsToast).toBe(false);
+
+    const payload = getLastNotifyPayload();
+    expect(payload.message).toBe("Marked 2 read");
+    expect(useUIStore.getState().lastNotificationCenterClosedAt).toBe(0);
+  });
+
+  it("section 'Mark read' marks only the section's unread entries and does NOT reset lastClosedAt", async () => {
+    worktreeStoreMock.worktrees.set("wt-1", { worktreeId: "wt-1", name: "feature/login" });
+    worktreeStoreMock.worktrees.set("wt-2", { worktreeId: "wt-2", name: "feature/billing" });
+    useNotificationSettingsStore.setState({ groupByContext: true });
+    useUIStore.setState({ lastNotificationCenterClosedAt: 99999 });
+    setEntries([
+      makeEntry({
+        id: "wt1-1",
+        message: "Login msg 1",
+        seenAsToast: false,
+        context: { worktreeId: "wt-1" },
+      }),
+      makeEntry({
+        id: "wt1-2",
+        message: "Login msg 2",
+        seenAsToast: false,
+        context: { worktreeId: "wt-1" },
+      }),
+      makeEntry({
+        id: "wt2-1",
+        message: "Billing msg",
+        seenAsToast: false,
+        context: { worktreeId: "wt-2" },
+      }),
+    ]);
+
+    render(<NotificationCenter open onClose={vi.fn()} />);
+
+    const headers = screen.getAllByTestId("context-section-header");
+    const loginHeader = headers.find((h) => (h.textContent ?? "").includes("feature/login"));
+    expect(loginHeader).toBeTruthy();
+
+    await act(async () => {
+      fireEvent.click(within(loginHeader!).getByText("Mark read"));
+    });
+
+    const entries = useNotificationHistoryStore.getState().entries;
+    expect(entries.find((e) => e.id === "wt1-1")?.seenAsToast).toBe(true);
+    expect(entries.find((e) => e.id === "wt1-2")?.seenAsToast).toBe(true);
+    expect(entries.find((e) => e.id === "wt2-1")?.seenAsToast).toBe(false);
+
+    // Section "Mark read" must NOT reset the divider — only header + divider do.
+    expect(useUIStore.getState().lastNotificationCenterClosedAt).toBe(99999);
+
+    const payload = getLastNotifyPayload();
+    expect(payload.message).toBe("Marked 2 read");
+  });
+
+  it("section header 'Mark read' button is not rendered when the section has no unread entries", () => {
+    worktreeStoreMock.worktrees.set("wt-1", { worktreeId: "wt-1", name: "feature/login" });
+    useNotificationSettingsStore.setState({ groupByContext: true });
+    setEntries([
+      makeEntry({
+        id: "wt1-1",
+        message: "All read",
+        seenAsToast: true,
+        context: { worktreeId: "wt-1" },
+      }),
+    ]);
+
+    render(<NotificationCenter open onClose={vi.fn()} />);
+
+    const header = screen.getByTestId("context-section-header");
+    expect(within(header).queryByText("Mark read")).toBeNull();
+  });
+});
+
 describe("uiStore — closeNotificationCenter records timestamp", () => {
   it("sets lastNotificationCenterClosedAt to Date.now() when closing", () => {
     useUIStore.setState({ notificationCenterOpen: true, lastNotificationCenterClosedAt: 0 });

--- a/src/store/__tests__/notificationHistoryStore.test.ts
+++ b/src/store/__tests__/notificationHistoryStore.test.ts
@@ -313,6 +313,25 @@ describe("notificationHistorySlice", () => {
       getState().markIdsRead(ids);
       expect(getState().evictedToInboxCount).toBe(0);
     });
+
+    it("handles mixed unread + already-read + non-countable + missing ids in one call", () => {
+      const seenId = getState().addEntry({ type: "info", message: "seen", seenAsToast: true });
+      addEntry({ message: "unread countable" });
+      addEntry({ message: "unread non-countable", countable: false });
+      const unreadCountable = getState().entries.find((e) => e.message === "unread countable")!.id;
+      const unreadNonCountable = getState().entries.find(
+        (e) => e.message === "unread non-countable"
+      )!.id;
+      expect(getState().unreadCount).toBe(1);
+
+      getState().markIdsRead([seenId, unreadCountable, unreadNonCountable, "missing"]);
+
+      const after = getState();
+      expect(after.entries.find((e) => e.id === seenId)?.seenAsToast).toBe(true);
+      expect(after.entries.find((e) => e.id === unreadCountable)?.seenAsToast).toBe(true);
+      expect(after.entries.find((e) => e.id === unreadNonCountable)?.seenAsToast).toBe(true);
+      expect(after.unreadCount).toBe(0);
+    });
   });
 
   describe("markSummarized", () => {

--- a/src/store/__tests__/notificationHistoryStore.test.ts
+++ b/src/store/__tests__/notificationHistoryStore.test.ts
@@ -231,6 +231,90 @@ describe("notificationHistorySlice", () => {
     });
   });
 
+  describe("markIdsRead", () => {
+    it("flips seenAsToast to true on targeted ids only", () => {
+      addEntry({ message: "a" });
+      addEntry({ message: "b" });
+      addEntry({ message: "c" });
+      const entries = getState().entries;
+      const targets = [entries[0]!.id, entries[2]!.id];
+
+      getState().markIdsRead(targets);
+
+      const updated = getState().entries;
+      expect(updated[0]!.seenAsToast).toBe(true);
+      expect(updated[1]!.seenAsToast).toBe(false);
+      expect(updated[2]!.seenAsToast).toBe(true);
+    });
+
+    it("decrements unreadCount by the number of newly-read entries", () => {
+      addEntry();
+      addEntry();
+      addEntry();
+      expect(getState().unreadCount).toBe(3);
+      const ids = getState().entries.slice(0, 2).map((e) => e.id);
+
+      getState().markIdsRead(ids);
+
+      expect(getState().unreadCount).toBe(1);
+    });
+
+    it("skips entries that are already read", () => {
+      const seenId = getState().addEntry({ type: "info", message: "seen", seenAsToast: true });
+      addEntry({ message: "missed" });
+      const before = getState().entries.find((e) => e.id === seenId);
+
+      getState().markIdsRead([seenId]);
+
+      const after = getState().entries.find((e) => e.id === seenId);
+      expect(after).toBe(before!);
+    });
+
+    it("is a no-op when ids is empty", () => {
+      addEntry();
+      const before = getState();
+      getState().markIdsRead([]);
+      const after = getState();
+      expect(after.entries).toBe(before.entries);
+      expect(after.unreadCount).toBe(before.unreadCount);
+    });
+
+    it("is a no-op when no targeted ids exist", () => {
+      addEntry();
+      const before = getState();
+      getState().markIdsRead(["nonexistent-1", "nonexistent-2"]);
+      const after = getState();
+      expect(after.entries).toBe(before.entries);
+      expect(after.unreadCount).toBe(before.unreadCount);
+    });
+
+    it("handles duplicate ids idempotently", () => {
+      addEntry();
+      const id = getState().entries[0]!.id;
+      getState().markIdsRead([id, id, id]);
+      expect(getState().entries[0]!.seenAsToast).toBe(true);
+      expect(getState().unreadCount).toBe(0);
+    });
+
+    it("excludes non-countable entries from unreadCount as expected", () => {
+      addEntry({ message: "countable" });
+      addEntry({ message: "uncountable", countable: false });
+      const ids = getState().entries.map((e) => e.id);
+      expect(getState().unreadCount).toBe(1);
+      getState().markIdsRead(ids);
+      expect(getState().unreadCount).toBe(0);
+      expect(getState().entries.every((e) => e.seenAsToast)).toBe(true);
+    });
+
+    it("does not change evictedToInboxCount", () => {
+      addEntry();
+      addEntry();
+      const ids = getState().entries.map((e) => e.id);
+      getState().markIdsRead(ids);
+      expect(getState().evictedToInboxCount).toBe(0);
+    });
+  });
+
   describe("markSummarized", () => {
     it("defaults summarized to false on new entries", () => {
       addEntry({ message: "test" });

--- a/src/store/__tests__/notificationHistoryStore.test.ts
+++ b/src/store/__tests__/notificationHistoryStore.test.ts
@@ -252,7 +252,9 @@ describe("notificationHistorySlice", () => {
       addEntry();
       addEntry();
       expect(getState().unreadCount).toBe(3);
-      const ids = getState().entries.slice(0, 2).map((e) => e.id);
+      const ids = getState()
+        .entries.slice(0, 2)
+        .map((e) => e.id);
 
       getState().markIdsRead(ids);
 

--- a/src/store/slices/notificationHistorySlice.ts
+++ b/src/store/slices/notificationHistorySlice.ts
@@ -62,6 +62,13 @@ interface NotificationHistoryState {
   dismissByCorrelationId: (correlationId: string) => void;
   clearAll: () => void;
   markAllRead: () => void;
+  /**
+   * Flips `seenAsToast` to true on the targeted entries in a single atomic
+   * update. Skips entries that are already read or missing. Used by the
+   * bulk-mark-read flows that need to capture an exact ID set up-front for an
+   * undo affordance.
+   */
+  markIdsRead: (ids: string[]) => void;
   markSummarized: (ids: string[]) => void;
   resetEvictedCount: () => void;
 }
@@ -126,6 +133,24 @@ export const useNotificationHistoryStore = create<NotificationHistoryState>((set
       unreadCount: 0,
       entries: state.entries.map((e) => (e.seenAsToast ? e : { ...e, seenAsToast: true })),
     })),
+  markIdsRead: (ids) =>
+    set((state) => {
+      if (ids.length === 0) return state;
+      const idSet = new Set(ids);
+      let mutated = false;
+      const entries = state.entries.map((e) => {
+        if (idSet.has(e.id) && !e.seenAsToast) {
+          mutated = true;
+          return { ...e, seenAsToast: true };
+        }
+        return e;
+      });
+      if (!mutated) return state;
+      return {
+        entries,
+        unreadCount: entries.filter((e) => !e.seenAsToast && e.countable !== false).length,
+      };
+    }),
   markSummarized: (ids) =>
     set((state) => {
       const idSet = new Set(ids);


### PR DESCRIPTION
Closes #7483.

## Summary

- Adds `markIdsRead(ids)` to the notification history store: a single atomic flip that skips already-read entries and recomputes `unreadCount` once.
- Wraps all three bulk mark-read affordances in a shared 5-second Undo toast (transient, urgent, `priority: high`). Captured ids are re-filtered against live store state at click time so a rapid second click no-ops cleanly instead of firing a ghost toast and arming a stale undo.
- Promotes `NewSinceLastLookedDivider` to expose a `Mark these N read` button, which also clears the divider via `resetNotificationCenterLastClosedAt`.
- Adds a hover/focus-within-revealed `Mark read` button to `ContextSectionHeader` (per-section, scoped). Section mark-read does **not** reset `lastClosedAt` — only the header and divider do.
- Undo restores via `markUnseenAsToast(id, { silent: true })` so the discoverability cue (`evictedToInboxCount`) doesn't tick on restoration.

## Test plan

- [x] `npx vitest run src/store/__tests__/notificationHistoryStore.test.ts src/components/Notifications/__tests__/NotificationCenter.test.tsx` — 128 tests pass
- [x] `npm run check` — typecheck + lint + format all clean
- [x] `npm run build` — production build green
- [ ] Smoke: open the notification center with unread entries → click `Mark all read` → verify the success toast says `Marked N read`, has an `Undo` button, and auto-dismisses after 5s
- [ ] Smoke: click `Undo` mid-toast → verify the entries return to unread without the bell arrival cue
- [ ] Smoke: with `groupByContext` on, hover a section header → verify `Mark read` reveals; click → only that section's entries become read; the `New since you last looked` divider stays put
- [ ] Smoke: reopen the inbox after closing → verify the divider appears, click `Mark these N read` → divider clears and undo offers full restore