### PR TITLE
feat(notifications): improve inbox legibility on open

### DIFF
--- a/src/components/Notifications/NotificationCenter.tsx
+++ b/src/components/Notifications/NotificationCenter.tsx
@@ -1,5 +1,5 @@
-import { useEffect, useMemo, useState } from "react";
-import { Bell, CheckCheck, Ellipsis, Layers, Moon, Trash2 } from "lucide-react";
+import { useEffect, useMemo, useRef, useState } from "react";
+import { ArrowDown, Bell, CheckCheck, Ellipsis, Layers, Moon, Trash2 } from "lucide-react";
 import { useShallow } from "zustand/react/shallow";
 import {
   useNotificationHistoryStore,
@@ -20,7 +20,14 @@ import { muteForDuration, muteUntilNextMorning, notify, setSessionQuietUntil } f
 import { useNotificationSettingsStore } from "@/store/notificationSettingsStore";
 import { useUIStore } from "@/store/uiStore";
 import { useWorktreeStore } from "@/hooks/useWorktreeStore";
+import { useAnnouncerStore } from "@/store/accessibilityAnnouncerStore";
 import { isScheduledQuietNow, nextOccurrenceTimestamp } from "@shared/utils/quietHours";
+import {
+  UI_ENTER_DURATION,
+  UI_EXIT_DURATION,
+  UI_ENTER_EASING,
+  UI_EXIT_EASING,
+} from "@/lib/animationUtils";
 import type { NotificationType } from "@/store/notificationStore";
 
 const SEVERITY_WEIGHTS: Record<NotificationType, number> = {
@@ -160,6 +167,10 @@ export function NotificationCenter({ open, onClose }: NotificationCenterProps) {
 
   const [filter, setFilter] = useState<"all" | "unread">("all");
   const [frozenUnreadIds, setFrozenUnreadIds] = useState<Set<string> | null>(null);
+  const [scrollContainer, setScrollContainer] = useState<HTMLDivElement | null>(null);
+  const [dividerEl, setDividerEl] = useState<HTMLDivElement | null>(null);
+  const [showJumpPill, setShowJumpPill] = useState(false);
+  const prevShowJumpPillRef = useRef(false);
 
   // Re-render at session-mute expiry and at scheduled quiet-hours boundaries —
   // mirrors the toolbar bell pattern so the pill auto-clears without an
@@ -207,6 +218,42 @@ export function NotificationCenter({ open, onClose }: NotificationCenterProps) {
       for (const i of intervals) clearInterval(i);
     };
   }, [open, isSessionMuted, quietUntil, quietHoursEnabled]);
+
+  useEffect(() => {
+    if (!scrollContainer || !dividerEl || typeof IntersectionObserver === "undefined") {
+      setShowJumpPill(false);
+      return;
+    }
+    const observer = new IntersectionObserver(
+      (entries) => {
+        for (const entry of entries) {
+          if (entry.isIntersecting) {
+            setShowJumpPill(false);
+            continue;
+          }
+          // Only show pill when divider has scrolled BELOW the viewport.
+          // If divider is above the top, the user has scrolled past unread
+          // content intentionally — don't summon them back.
+          const rootBounds = entry.rootBounds;
+          if (!rootBounds) {
+            setShowJumpPill(false);
+            continue;
+          }
+          setShowJumpPill(entry.boundingClientRect.top > rootBounds.bottom);
+        }
+      },
+      { root: scrollContainer, threshold: 0 }
+    );
+    observer.observe(dividerEl);
+    return () => observer.disconnect();
+  }, [scrollContainer, dividerEl]);
+
+  useEffect(() => {
+    if (showJumpPill && !prevShowJumpPillRef.current) {
+      useAnnouncerStore.getState().announce("New notifications below", "polite");
+    }
+    prevShowJumpPillRef.current = showJumpPill;
+  }, [showJumpPill]);
 
   const filteredEntries = useMemo(() => {
     if (filter === "all") return entries;
@@ -488,68 +535,103 @@ export function NotificationCenter({ open, onClose }: NotificationCenterProps) {
           )}
         </div>
       </div>
-      <div className="flex-1 overflow-y-auto">
-        {totalChronoGroups === 0 && needsAttentionGroups.length === 0 ? (
-          filter === "unread" && entries.length > 0 ? (
-            <EmptyState
-              variant="user-cleared"
-              title="You're all caught up"
-              icon={<Bell />}
-              className="py-10"
-            />
-          ) : showMutedPill ? (
-            <div data-testid="notification-muted-empty-state">
+      <div className="relative flex-1 min-h-0">
+        <div ref={setScrollContainer} className="h-full overflow-y-auto">
+          {totalChronoGroups === 0 && needsAttentionGroups.length === 0 ? (
+            filter === "unread" && entries.length > 0 ? (
               <EmptyState
-                variant="zero-data"
-                title="Notifications paused"
-                icon={<Moon />}
-                description={mutedEmptyDescription}
+                variant="user-cleared"
+                title="You're all caught up"
+                icon={<Bell />}
                 className="py-10"
               />
-            </div>
+            ) : showMutedPill ? (
+              <div data-testid="notification-muted-empty-state">
+                <EmptyState
+                  variant="zero-data"
+                  title="Notifications paused"
+                  icon={<Moon />}
+                  description={mutedEmptyDescription}
+                  className="py-10"
+                />
+              </div>
+            ) : (
+              <EmptyState
+                variant="zero-data"
+                title="No notifications yet"
+                icon={<Bell />}
+                description={
+                  <>
+                    Notifications appear here. Adjust which ones at{" "}
+                    <button
+                      type="button"
+                      onClick={openNotificationSettings}
+                      className="underline text-daintree-text/70 hover:text-daintree-text transition-colors"
+                    >
+                      Notification settings
+                    </button>
+                    .
+                  </>
+                }
+                className="py-10"
+              />
+            )
           ) : (
-            <EmptyState
-              variant="zero-data"
-              title="No notifications yet"
-              icon={<Bell />}
-              description={
-                <>
-                  Notifications appear here. Adjust which ones at{" "}
-                  <button
-                    type="button"
-                    onClick={openNotificationSettings}
-                    className="underline text-daintree-text/70 hover:text-daintree-text transition-colors"
-                  >
-                    Notification settings
-                  </button>
-                  .
-                </>
-              }
-              className="py-10"
-            />
-          )
-        ) : (
-          <>
-            {needsAttentionGroups.length > 0 && (
-              <NeedsAttentionSection
-                groups={needsAttentionGroups}
-                onDismiss={dismissEntry}
-                onDismissThread={dismissByCorrelationId}
-              />
+            <>
+              {needsAttentionGroups.length > 0 && (
+                <NeedsAttentionSection
+                  groups={needsAttentionGroups}
+                  onDismiss={dismissEntry}
+                  onDismissThread={dismissByCorrelationId}
+                />
+              )}
+              {chronoSections.map((section) => (
+                <ChronoSection
+                  key={section.key}
+                  section={section}
+                  groupByContext={groupByContext}
+                  dividerGroupId={dividerGroupId}
+                  dividerRef={setDividerEl}
+                  lastClosedAt={lastClosedAt}
+                  onDismiss={dismissEntry}
+                  onDismissThread={dismissByCorrelationId}
+                  onMarkIdsRead={markIdsReadWithUndo}
+                />
+              ))}
+            </>
+          )}
+        </div>
+        {dividerGroupId !== null && (
+          <button
+            type="button"
+            data-testid="jump-to-new-pill"
+            aria-label="Jump to new notifications"
+            aria-hidden={!showJumpPill || undefined}
+            tabIndex={showJumpPill ? 0 : -1}
+            onClick={() => {
+              dividerEl?.scrollIntoView({ block: "start", behavior: "instant" });
+              dividerEl?.focus();
+            }}
+            className={cn(
+              "absolute bottom-2 left-1/2 -translate-x-1/2 z-10",
+              "inline-flex items-center gap-1.5 px-3 py-1 rounded-full",
+              "bg-overlay-emphasis border border-tint/[0.08]",
+              "shadow-[var(--theme-shadow-floating)]",
+              "text-[11px] font-medium text-daintree-text/80",
+              "hover:text-daintree-text hover:bg-overlay-emphasis",
+              "transition-[transform,opacity] motion-reduce:transition-none",
+              showJumpPill
+                ? "opacity-100 translate-y-0 pointer-events-auto"
+                : "opacity-0 translate-y-2 pointer-events-none"
             )}
-            {chronoSections.map((section) => (
-              <ChronoSection
-                key={section.key}
-                section={section}
-                groupByContext={groupByContext}
-                dividerGroupId={dividerGroupId}
-                lastClosedAt={lastClosedAt}
-                onDismiss={dismissEntry}
-                onDismissThread={dismissByCorrelationId}
-                onMarkIdsRead={markIdsReadWithUndo}
-              />
-            ))}
-          </>
+            style={{
+              transitionDuration: `${showJumpPill ? UI_ENTER_DURATION : UI_EXIT_DURATION}ms`,
+              transitionTimingFunction: showJumpPill ? UI_ENTER_EASING : UI_EXIT_EASING,
+            }}
+          >
+            <ArrowDown className="h-3 w-3" aria-hidden="true" />
+            Jump to new
+          </button>
         )}
       </div>
     </div>
@@ -581,6 +663,7 @@ function ChronoSection({
   section,
   groupByContext,
   dividerGroupId,
+  dividerRef,
   lastClosedAt,
   onDismiss,
   onDismissThread,
@@ -589,6 +672,7 @@ function ChronoSection({
   section: ContextSection;
   groupByContext: boolean;
   dividerGroupId: string | null;
+  dividerRef?: (el: HTMLDivElement | null) => void;
   lastClosedAt: number;
   onDismiss: (id: string) => void;
   onDismissThread: (correlationId: string) => void;
@@ -620,6 +704,7 @@ function ChronoSection({
             <div key={groupKey}>
               {isDivider && (
                 <NewSinceLastLookedDivider
+                  ref={dividerRef}
                   unreadCount={newSinceUnreadIds.length}
                   onMarkRead={() => onMarkIdsRead(newSinceUnreadIds, { resetLastClosed: true })}
                 />
@@ -701,16 +786,20 @@ function ContextSectionHeader({
 }
 
 function NewSinceLastLookedDivider({
+  ref,
   unreadCount,
   onMarkRead,
 }: {
+  ref?: (el: HTMLDivElement | null) => void;
   unreadCount: number;
   onMarkRead: () => void;
 }) {
   return (
     <div
+      ref={ref}
+      tabIndex={-1}
       data-testid="new-since-last-looked"
-      className="flex items-center gap-2 px-3 py-1 text-[10px] font-medium text-daintree-text/50"
+      className="flex items-center gap-2 px-3 py-1 text-[10px] font-medium text-daintree-text/50 outline-none"
     >
       <span className="h-px flex-1 bg-divider" aria-hidden="true" />
       <span>New since you last looked</span>

--- a/src/components/Notifications/NotificationCenter.tsx
+++ b/src/components/Notifications/NotificationCenter.tsx
@@ -799,7 +799,7 @@ function NewSinceLastLookedDivider({
       ref={ref}
       tabIndex={-1}
       data-testid="new-since-last-looked"
-      className="flex items-center gap-2 px-3 py-1 text-[10px] font-medium text-daintree-text/50 outline-none"
+      className="flex items-center gap-2 px-3 py-1 text-[10px] font-medium text-daintree-text/50 outline-hidden"
     >
       <span className="h-px flex-1 bg-divider" aria-hidden="true" />
       <span>New since you last looked</span>

--- a/src/components/Notifications/NotificationCenterEntry.tsx
+++ b/src/components/Notifications/NotificationCenterEntry.tsx
@@ -121,7 +121,14 @@ export function NotificationCenterEntry({
       <div className="flex-1 min-w-0">
         {entry.title && (
           <div className="flex items-center gap-1.5">
-            <p className="text-xs font-medium text-daintree-text truncate">{entry.title}</p>
+            <p
+              className={cn(
+                "text-xs text-daintree-text truncate",
+                isNew ? "font-semibold" : "font-normal"
+              )}
+            >
+              {entry.title}
+            </p>
             {showChip && (
               <span
                 key={bumpKey}

--- a/src/components/Notifications/__tests__/NotificationCenter.test.tsx
+++ b/src/components/Notifications/__tests__/NotificationCenter.test.tsx
@@ -1679,6 +1679,138 @@ describe("NotificationCenter — Jump to new pill", () => {
       proto.scrollIntoView = original;
     }
   });
+
+  it("hidden pill is aria-hidden and not focusable; visible pill is reachable", () => {
+    const closedAt = Date.now() - 5000;
+    useUIStore.setState({ lastNotificationCenterClosedAt: closedAt });
+    setEntries([makeEntry({ message: "Newer", timestamp: closedAt + 4000 })]);
+
+    render(<NotificationCenter open onClose={vi.fn()} />);
+
+    const pill = screen.getByTestId("jump-to-new-pill");
+    expect(pill.getAttribute("aria-hidden")).toBe("true");
+    expect(pill.getAttribute("tabindex")).toBe("-1");
+
+    act(() => {
+      fireObserver({ top: 0, bottom: 400, left: 0, right: 360 }, 500, false);
+    });
+
+    expect(pill.getAttribute("aria-hidden")).toBeNull();
+    expect(pill.getAttribute("tabindex")).toBe("0");
+  });
+
+  it("uses Tier 2 timing — 200ms enter, 120ms exit", () => {
+    const closedAt = Date.now() - 5000;
+    useUIStore.setState({ lastNotificationCenterClosedAt: closedAt });
+    setEntries([makeEntry({ message: "Newer", timestamp: closedAt + 4000 })]);
+
+    render(<NotificationCenter open onClose={vi.fn()} />);
+
+    const pill = screen.getByTestId("jump-to-new-pill") as HTMLButtonElement;
+    expect(pill.style.transitionDuration).toBe("120ms");
+
+    act(() => {
+      fireObserver({ top: 0, bottom: 400, left: 0, right: 360 }, 500, false);
+    });
+    expect(pill.style.transitionDuration).toBe("200ms");
+
+    act(() => {
+      fireObserver({ top: 0, bottom: 400, left: 0, right: 360 }, 100, true);
+    });
+    expect(pill.style.transitionDuration).toBe("120ms");
+  });
+
+  it("observer's root is the scroll container (not the popover or document)", () => {
+    const closedAt = Date.now() - 5000;
+    useUIStore.setState({ lastNotificationCenterClosedAt: closedAt });
+    setEntries([makeEntry({ message: "Newer", timestamp: closedAt + 4000 })]);
+
+    const { container } = render(<NotificationCenter open onClose={vi.fn()} />);
+
+    expect(observers.length).toBeGreaterThan(0);
+    const root = observers[observers.length - 1]!.root;
+    expect(root).not.toBeNull();
+    const scrollDiv = container.querySelector(".overflow-y-auto");
+    expect(scrollDiv).not.toBeNull();
+    expect(root).toBe(scrollDiv);
+  });
+
+  it("disconnects the observer on unmount", () => {
+    const closedAt = Date.now() - 5000;
+    useUIStore.setState({ lastNotificationCenterClosedAt: closedAt });
+    setEntries([makeEntry({ message: "Newer", timestamp: closedAt + 4000 })]);
+
+    const { unmount } = render(<NotificationCenter open onClose={vi.fn()} />);
+    expect(observers.length).toBeGreaterThan(0);
+
+    unmount();
+    expect(observers.length).toBe(0);
+  });
+});
+
+describe("NotificationCenter — Thread title weight reflects unread state", () => {
+  it("renders thread title with font-semibold when any entry is unread", async () => {
+    const correlationId = "thread-mixed";
+    useNotificationHistoryStore.getState().addEntry(
+      makeEntry({
+        id: "thread-old",
+        type: "info",
+        title: "Mixed thread",
+        message: "First message",
+        correlationId,
+        timestamp: Date.now() - 2000,
+        seenAsToast: false,
+      })
+    );
+    useNotificationHistoryStore.getState().addEntry(
+      makeEntry({
+        id: "thread-latest",
+        type: "info",
+        title: "Mixed thread",
+        message: "Latest message",
+        correlationId,
+        timestamp: Date.now() - 1000,
+        seenAsToast: true,
+      })
+    );
+
+    render(<NotificationCenter open onClose={vi.fn()} />);
+
+    const titleEls = await screen.findAllByText("Mixed thread");
+    expect(titleEls[0]!.className).toMatch(/font-semibold/);
+    expect(titleEls[0]!.className).not.toMatch(/font-medium/);
+  });
+
+  it("renders thread title with font-normal when all entries are read", async () => {
+    const correlationId = "thread-all-read";
+    useNotificationHistoryStore.getState().addEntry(
+      makeEntry({
+        id: "read-1",
+        type: "info",
+        title: "Quiet thread",
+        message: "First",
+        correlationId,
+        timestamp: Date.now() - 2000,
+        seenAsToast: true,
+      })
+    );
+    useNotificationHistoryStore.getState().addEntry(
+      makeEntry({
+        id: "read-2",
+        type: "info",
+        title: "Quiet thread",
+        message: "Second",
+        correlationId,
+        timestamp: Date.now() - 1000,
+        seenAsToast: true,
+      })
+    );
+
+    render(<NotificationCenter open onClose={vi.fn()} />);
+
+    const titleEls = await screen.findAllByText("Quiet thread");
+    expect(titleEls[0]!.className).toMatch(/font-normal/);
+  });
 });
 
 describe("uiStore — closeNotificationCenter records timestamp", () => {

--- a/src/components/Notifications/__tests__/NotificationCenter.test.tsx
+++ b/src/components/Notifications/__tests__/NotificationCenter.test.tsx
@@ -5,6 +5,7 @@ import type { NotificationHistoryEntry } from "@/store/slices/notificationHistor
 import { useNotificationHistoryStore } from "@/store/slices/notificationHistorySlice";
 import { useNotificationSettingsStore } from "@/store/notificationSettingsStore";
 import { useUIStore } from "@/store/uiStore";
+import { useAnnouncerStore } from "@/store/accessibilityAnnouncerStore";
 import * as notifyLib from "@/lib/notify";
 import { NotificationCenter } from "../NotificationCenter";
 
@@ -1462,6 +1463,221 @@ describe("NotificationCenter — bulk mark-read with Undo", () => {
 
     const header = screen.getByTestId("context-section-header");
     expect(within(header).queryByText("Mark read")).toBeNull();
+  });
+});
+
+describe("NotificationCenter — Jump to new pill", () => {
+  type ObserverCallback = (entries: IntersectionObserverEntry[]) => void;
+  const observers: { cb: ObserverCallback; targets: Element[]; root: Element | null }[] = [];
+
+  function fireObserver(
+    rootBounds: { top: number; bottom: number; left: number; right: number },
+    targetTop: number,
+    isIntersecting: boolean
+  ) {
+    for (const o of observers) {
+      for (const target of o.targets) {
+        o.cb([
+          {
+            isIntersecting,
+            boundingClientRect: {
+              top: targetTop,
+              bottom: targetTop + 16,
+              left: 0,
+              right: 100,
+              width: 100,
+              height: 16,
+              x: 0,
+              y: targetTop,
+              toJSON() {
+                return this;
+              },
+            } as DOMRectReadOnly,
+            rootBounds: {
+              top: rootBounds.top,
+              bottom: rootBounds.bottom,
+              left: rootBounds.left,
+              right: rootBounds.right,
+              width: rootBounds.right - rootBounds.left,
+              height: rootBounds.bottom - rootBounds.top,
+              x: rootBounds.left,
+              y: rootBounds.top,
+              toJSON() {
+                return this;
+              },
+            } as DOMRectReadOnly,
+            intersectionRatio: isIntersecting ? 1 : 0,
+            intersectionRect: {} as DOMRectReadOnly,
+            target,
+            time: Date.now(),
+          } as IntersectionObserverEntry,
+        ]);
+      }
+    }
+  }
+
+  beforeEach(() => {
+    observers.length = 0;
+    useAnnouncerStore.setState({ polite: null, assertive: null, nextId: 1 });
+    class MockIntersectionObserver implements IntersectionObserver {
+      readonly root: Element | Document | null;
+      readonly rootMargin: string = "0px";
+      readonly thresholds: ReadonlyArray<number> = [0];
+      private targets: Element[] = [];
+      constructor(callback: ObserverCallback, options?: IntersectionObserverInit) {
+        this.root = (options?.root as Element | null) ?? null;
+        observers.push({ cb: callback, targets: this.targets, root: this.root as Element | null });
+      }
+      observe(target: Element) {
+        this.targets.push(target);
+      }
+      unobserve(target: Element) {
+        const idx = this.targets.indexOf(target);
+        if (idx >= 0) this.targets.splice(idx, 1);
+      }
+      disconnect() {
+        const idx = observers.findIndex((o) => o.targets === this.targets);
+        if (idx >= 0) observers.splice(idx, 1);
+        this.targets.length = 0;
+      }
+      takeRecords(): IntersectionObserverEntry[] {
+        return [];
+      }
+    }
+    vi.stubGlobal("IntersectionObserver", MockIntersectionObserver);
+  });
+
+  it("does not render when there is no unread divider (cold session)", () => {
+    setEntries([makeEntry({ message: "Old msg" })]);
+    render(<NotificationCenter open onClose={vi.fn()} />);
+    expect(screen.queryByTestId("jump-to-new-pill")).toBeNull();
+  });
+
+  it("renders pill (hidden) when divider exists and is initially visible", () => {
+    const closedAt = Date.now() - 5000;
+    useUIStore.setState({ lastNotificationCenterClosedAt: closedAt });
+    setEntries([makeEntry({ message: "Newer", timestamp: closedAt + 4000 })]);
+
+    render(<NotificationCenter open onClose={vi.fn()} />);
+    const pill = screen.getByTestId("jump-to-new-pill");
+    expect(pill).toBeTruthy();
+    expect(pill.className).toMatch(/opacity-0/);
+    expect(pill.className).toMatch(/pointer-events-none/);
+  });
+
+  it("becomes visible when divider scrolls below the viewport", () => {
+    const closedAt = Date.now() - 5000;
+    useUIStore.setState({ lastNotificationCenterClosedAt: closedAt });
+    setEntries([makeEntry({ message: "Newer", timestamp: closedAt + 4000 })]);
+
+    render(<NotificationCenter open onClose={vi.fn()} />);
+
+    act(() => {
+      fireObserver({ top: 0, bottom: 400, left: 0, right: 360 }, 500, false);
+    });
+
+    const pill = screen.getByTestId("jump-to-new-pill");
+    expect(pill.className).toMatch(/opacity-100/);
+    expect(pill.className).toMatch(/pointer-events-auto/);
+  });
+
+  it("stays hidden when divider scrolls above the viewport", () => {
+    const closedAt = Date.now() - 5000;
+    useUIStore.setState({ lastNotificationCenterClosedAt: closedAt });
+    setEntries([makeEntry({ message: "Newer", timestamp: closedAt + 4000 })]);
+
+    render(<NotificationCenter open onClose={vi.fn()} />);
+
+    act(() => {
+      fireObserver({ top: 0, bottom: 400, left: 0, right: 360 }, -50, false);
+    });
+
+    const pill = screen.getByTestId("jump-to-new-pill");
+    expect(pill.className).toMatch(/opacity-0/);
+  });
+
+  it("hides again when divider returns to the viewport", () => {
+    const closedAt = Date.now() - 5000;
+    useUIStore.setState({ lastNotificationCenterClosedAt: closedAt });
+    setEntries([makeEntry({ message: "Newer", timestamp: closedAt + 4000 })]);
+
+    render(<NotificationCenter open onClose={vi.fn()} />);
+
+    act(() => {
+      fireObserver({ top: 0, bottom: 400, left: 0, right: 360 }, 500, false);
+    });
+    expect(screen.getByTestId("jump-to-new-pill").className).toMatch(/opacity-100/);
+
+    act(() => {
+      fireObserver({ top: 0, bottom: 400, left: 0, right: 360 }, 100, true);
+    });
+    expect(screen.getByTestId("jump-to-new-pill").className).toMatch(/opacity-0/);
+  });
+
+  it("announces 'New notifications below' when pill becomes visible", () => {
+    const closedAt = Date.now() - 5000;
+    useUIStore.setState({ lastNotificationCenterClosedAt: closedAt });
+    setEntries([makeEntry({ message: "Newer", timestamp: closedAt + 4000 })]);
+
+    render(<NotificationCenter open onClose={vi.fn()} />);
+
+    expect(useAnnouncerStore.getState().polite).toBeNull();
+
+    act(() => {
+      fireObserver({ top: 0, bottom: 400, left: 0, right: 360 }, 500, false);
+    });
+
+    expect(useAnnouncerStore.getState().polite?.msg).toBe("New notifications below");
+  });
+
+  it("clicking the pill calls scrollIntoView and focus on the divider", () => {
+    const closedAt = Date.now() - 5000;
+    useUIStore.setState({ lastNotificationCenterClosedAt: closedAt });
+    setEntries([makeEntry({ message: "Newer", timestamp: closedAt + 4000 })]);
+
+    const proto = HTMLElement.prototype as unknown as {
+      scrollIntoView?: (...args: unknown[]) => void;
+    };
+    const originalScroll = proto.scrollIntoView;
+    const scrollSpy = vi.fn();
+    proto.scrollIntoView = scrollSpy;
+
+    try {
+      render(<NotificationCenter open onClose={vi.fn()} />);
+
+      const divider = screen.getByTestId("new-since-last-looked");
+      const focusSpy = vi.spyOn(divider, "focus").mockImplementation(() => undefined);
+
+      act(() => {
+        fireObserver({ top: 0, bottom: 400, left: 0, right: 360 }, 500, false);
+      });
+
+      fireEvent.click(screen.getByTestId("jump-to-new-pill"));
+
+      expect(scrollSpy).toHaveBeenCalledWith({ block: "start", behavior: "instant" });
+      expect(focusSpy).toHaveBeenCalled();
+    } finally {
+      proto.scrollIntoView = originalScroll;
+    }
+  });
+
+  it("does not auto-scroll when the panel opens (no scrollIntoView on mount)", () => {
+    const closedAt = Date.now() - 5000;
+    useUIStore.setState({ lastNotificationCenterClosedAt: closedAt });
+    setEntries([makeEntry({ message: "Newer", timestamp: closedAt + 4000 })]);
+
+    const proto = HTMLElement.prototype as unknown as {
+      scrollIntoView?: (...args: unknown[]) => void;
+    };
+    const original = proto.scrollIntoView;
+    const spy = vi.fn();
+    proto.scrollIntoView = spy;
+    try {
+      render(<NotificationCenter open onClose={vi.fn()} />);
+      expect(spy).not.toHaveBeenCalled();
+    } finally {
+      proto.scrollIntoView = original;
+    }
   });
 });
 

--- a/src/components/Notifications/__tests__/NotificationCenterEntry.test.tsx
+++ b/src/components/Notifications/__tests__/NotificationCenterEntry.test.tsx
@@ -99,6 +99,29 @@ describe("NotificationCenterEntry unread signal", () => {
   });
 });
 
+describe("NotificationCenterEntry title font weight", () => {
+  it("renders unread title with font-semibold and not font-medium", () => {
+    render(<NotificationCenterEntry entry={makeEntry({ title: "Build failed" })} isNew />);
+    const titleEl = screen.getByText("Build failed");
+    expect(titleEl.className).toMatch(/font-semibold/);
+    expect(titleEl.className).not.toMatch(/font-medium/);
+  });
+
+  it("renders read title with font-normal and not font-medium or font-semibold", () => {
+    render(<NotificationCenterEntry entry={makeEntry({ title: "Build complete" })} />);
+    const titleEl = screen.getByText("Build complete");
+    expect(titleEl.className).toMatch(/font-normal/);
+    expect(titleEl.className).not.toMatch(/font-medium/);
+    expect(titleEl.className).not.toMatch(/font-semibold/);
+  });
+
+  it("renders read title (isNew=false explicitly) with font-normal", () => {
+    render(<NotificationCenterEntry entry={makeEntry({ title: "Caught up" })} isNew={false} />);
+    const titleEl = screen.getByText("Caught up");
+    expect(titleEl.className).toMatch(/font-normal/);
+  });
+});
+
 describe("NotificationCenterEntry thread count chip", () => {
   it("renders a count chip with the bare number when threadCount >= 2", () => {
     render(<NotificationCenterEntry entry={makeEntry({ title: "Build" })} threadCount={3} />);


### PR DESCRIPTION
## Summary

- Unread notification titles now use `font-semibold`; read titles use `font-normal`. Previously both used a fixed `font-medium`, so the 6px dot was the only unread signal — easy to miss in a dense list.
- Adds a `Jump to new` pill anchored at the bottom of the scroll region. An `IntersectionObserver` watches the `New since you last looked` divider; when it scrolls off screen the pill fades in. Clicking scrolls the divider to the top of the scroll region using `scrollIntoView({ block: "start", behavior: "instant" })` and focuses it. A `polite` `aria-live` announcer fires on appearance for screen readers.

Resolves #7486

## Changes

- `NotificationCenterEntry.tsx` — title weight driven by `isNew` prop (`font-semibold` / `font-normal`)
- `NotificationCenter.tsx` — `JumpToNewPill` component with `IntersectionObserver` wiring, Tier 2 enter/exit animation, `bg-overlay-emphasis` surface, `aria-live` announcer
- `__tests__/NotificationCenter.test.tsx` — new test suite covering pill visibility, observer wiring, scroll behavior, focus, and announcer text
- `__tests__/NotificationCenterEntry.test.tsx` — title weight assertions for read/unread state

## Testing

96 unit tests pass. Full typecheck/lint/format/build clean on the rebased branch.