### PR TITLE
feat(notifications): add keyboard navigation to the inbox

### DIFF
--- a/src/components/Notifications/NotificationCenter.tsx
+++ b/src/components/Notifications/NotificationCenter.tsx
@@ -385,12 +385,7 @@ export function NotificationCenter({ open, onClose }: NotificationCenterProps) {
   const [focusedIndex, setFocusedIndex] = useState(0);
   const rowRefs = useRef<Map<number, HTMLDivElement>>(new Map());
   const dropdownOpenCountRef = useRef(0);
-
-  useEffect(() => {
-    if (focusedIndex >= rowCount) {
-      setFocusedIndex(Math.max(0, rowCount - 1));
-    }
-  }, [rowCount, focusedIndex]);
+  const prevRowCountRef = useRef(rowCount);
 
   const setRowRef = useCallback((index: number, el: HTMLDivElement | null) => {
     if (el) {
@@ -403,6 +398,35 @@ export function NotificationCenter({ open, onClose }: NotificationCenterProps) {
   const handleDropdownOpenChange = useCallback((open: boolean) => {
     dropdownOpenCountRef.current = Math.max(0, dropdownOpenCountRef.current + (open ? 1 : -1));
   }, []);
+
+  // After any row count change, clamp focusedIndex; reset the dropdown
+  // counter (a row removed mid-menu may never fire onOpenChange(false)); and
+  // when row count *decreases* with focus dropped to <body> (the focused row
+  // just unmounted), snap focus back to the surviving slot at the prior
+  // index. Only on decrease — never on mount or addition — to avoid
+  // hijacking focus from the toolbar bell button when the panel opens.
+  useEffect(() => {
+    const prevRowCount = prevRowCountRef.current;
+    prevRowCountRef.current = rowCount;
+
+    dropdownOpenCountRef.current = 0;
+
+    if (rowCount === 0) {
+      if (focusedIndex !== 0) setFocusedIndex(0);
+      return;
+    }
+
+    const clamped = Math.min(focusedIndex, rowCount - 1);
+    if (clamped !== focusedIndex) {
+      setFocusedIndex(clamped);
+    }
+
+    if (rowCount >= prevRowCount) return;
+    if (typeof document === "undefined") return;
+    const active = document.activeElement;
+    if (active && active !== document.body) return;
+    rowRefs.current.get(clamped)?.focus();
+  }, [rowCount, focusedIndex]);
 
   const dispatchPrimaryAction = useCallback((row: FlatRow) => {
     const action = row.primaryAction;

--- a/src/components/Notifications/NotificationCenter.tsx
+++ b/src/components/Notifications/NotificationCenter.tsx
@@ -1,4 +1,4 @@
-import { useEffect, useMemo, useRef, useState } from "react";
+import { useCallback, useEffect, useMemo, useRef, useState } from "react";
 import { ArrowDown, Bell, CheckCheck, Ellipsis, Layers, Moon, Trash2 } from "lucide-react";
 import { useShallow } from "zustand/react/shallow";
 import {
@@ -16,6 +16,7 @@ import {
   DropdownMenuTrigger,
 } from "@/components/ui/dropdown-menu";
 import { actionService } from "@/services/ActionService";
+import type { ActionId } from "@shared/types/actions";
 import { muteForDuration, muteUntilNextMorning, notify, setSessionQuietUntil } from "@/lib/notify";
 import { useNotificationSettingsStore } from "@/store/notificationSettingsStore";
 import { useUIStore } from "@/store/uiStore";
@@ -82,6 +83,28 @@ interface ContextSection {
   worktreeId?: string;
   projectId?: string;
   groups: ThreadGroup[];
+}
+
+type NotificationAction = NonNullable<NotificationHistoryEntry["actions"]>[number];
+
+interface FlatRow {
+  key: string;
+  isThread: boolean;
+  correlationId: string | undefined;
+  entryId: string;
+  primaryAction: NotificationAction | undefined;
+}
+
+function buildFlatRow(group: ThreadGroup): FlatRow {
+  const isThread = !!group.correlationId && group.entries.length > 1;
+  const latest = group.entries[0]!;
+  return {
+    key: group.correlationId ?? latest.id,
+    isThread,
+    correlationId: group.correlationId,
+    entryId: latest.id,
+    primaryAction: latest.actions?.[0],
+  };
 }
 
 function groupByCorrelationId(entries: NotificationHistoryEntry[]): ThreadGroup[] {
@@ -345,6 +368,127 @@ export function NotificationCenter({ open, onClose }: NotificationCenterProps) {
     });
   };
 
+  const flatRows = useMemo<FlatRow[]>(() => {
+    const rows: FlatRow[] = [];
+    for (const g of needsAttentionGroups) {
+      rows.push(buildFlatRow(g));
+    }
+    for (const section of chronoSections) {
+      for (const g of section.groups) {
+        rows.push(buildFlatRow(g));
+      }
+    }
+    return rows;
+  }, [needsAttentionGroups, chronoSections]);
+
+  const rowCount = flatRows.length;
+  const [focusedIndex, setFocusedIndex] = useState(0);
+  const rowRefs = useRef<Map<number, HTMLDivElement>>(new Map());
+  const dropdownOpenCountRef = useRef(0);
+
+  useEffect(() => {
+    if (focusedIndex >= rowCount) {
+      setFocusedIndex(Math.max(0, rowCount - 1));
+    }
+  }, [rowCount, focusedIndex]);
+
+  const setRowRef = useCallback((index: number, el: HTMLDivElement | null) => {
+    if (el) {
+      rowRefs.current.set(index, el);
+    } else {
+      rowRefs.current.delete(index);
+    }
+  }, []);
+
+  const handleDropdownOpenChange = useCallback((open: boolean) => {
+    dropdownOpenCountRef.current = Math.max(0, dropdownOpenCountRef.current + (open ? 1 : -1));
+  }, []);
+
+  const dispatchPrimaryAction = useCallback((row: FlatRow) => {
+    const action = row.primaryAction;
+    if (!action) return;
+    const manifest = actionService.get(action.actionId as ActionId);
+    if (!manifest || !manifest.enabled) return;
+    void actionService.dispatch(action.actionId as ActionId, action.actionArgs);
+  }, []);
+
+  const dismissRow = useCallback(
+    (row: FlatRow) => {
+      if (row.isThread && row.correlationId) {
+        dismissByCorrelationId(row.correlationId);
+      } else {
+        dismissEntry(row.entryId);
+      }
+    },
+    [dismissByCorrelationId, dismissEntry]
+  );
+
+  const moveFocusTo = useCallback((index: number) => {
+    const target = rowRefs.current.get(index);
+    if (target) {
+      target.focus();
+    }
+    setFocusedIndex(index);
+  }, []);
+
+  const handleListKeyDown = useCallback(
+    (e: React.KeyboardEvent<HTMLDivElement>) => {
+      if (dropdownOpenCountRef.current > 0) return;
+      if (rowCount === 0) return;
+
+      const active = document.activeElement;
+      let activeIndex = -1;
+      for (const [idx, el] of rowRefs.current.entries()) {
+        if (el === active) {
+          activeIndex = idx;
+          break;
+        }
+      }
+      if (activeIndex === -1) return;
+
+      switch (e.key) {
+        case "j":
+        case "ArrowDown": {
+          e.preventDefault();
+          moveFocusTo(Math.min(activeIndex + 1, rowCount - 1));
+          return;
+        }
+        case "k":
+        case "ArrowUp": {
+          e.preventDefault();
+          moveFocusTo(Math.max(activeIndex - 1, 0));
+          return;
+        }
+        case "Home": {
+          e.preventDefault();
+          moveFocusTo(0);
+          return;
+        }
+        case "End": {
+          e.preventDefault();
+          moveFocusTo(rowCount - 1);
+          return;
+        }
+        case "e": {
+          e.preventDefault();
+          const row = flatRows[activeIndex];
+          if (row) dismissRow(row);
+          return;
+        }
+        case "Enter": {
+          const row = flatRows[activeIndex];
+          if (!row || !row.primaryAction) return;
+          e.preventDefault();
+          dispatchPrimaryAction(row);
+          return;
+        }
+        default:
+          return;
+      }
+    },
+    [rowCount, flatRows, moveFocusTo, dismissRow, dispatchPrimaryAction]
+  );
+
   const handleMarkAllRead = () => {
     const ids = entries.filter((e) => !e.seenAsToast).map((e) => e.id);
     if (filter === "unread") {
@@ -536,7 +680,13 @@ export function NotificationCenter({ open, onClose }: NotificationCenterProps) {
         </div>
       </div>
       <div className="relative flex-1 min-h-0">
-        <div ref={setScrollContainer} className="h-full overflow-y-auto">
+        <div
+          ref={setScrollContainer}
+          onKeyDown={handleListKeyDown}
+          role={rowCount > 0 ? "list" : undefined}
+          aria-label={rowCount > 0 ? "Notifications" : undefined}
+          className="h-full overflow-y-auto"
+        >
           {totalChronoGroups === 0 && needsAttentionGroups.length === 0 ? (
             filter === "unread" && entries.length > 0 ? (
               <EmptyState
@@ -581,14 +731,29 @@ export function NotificationCenter({ open, onClose }: NotificationCenterProps) {
               {needsAttentionGroups.length > 0 && (
                 <NeedsAttentionSection
                   groups={needsAttentionGroups}
+                  indexOffset={0}
+                  focusedIndex={focusedIndex}
+                  setRowRef={setRowRef}
+                  onRowFocus={setFocusedIndex}
+                  onDropdownOpenChange={handleDropdownOpenChange}
                   onDismiss={dismissEntry}
                   onDismissThread={dismissByCorrelationId}
                 />
               )}
-              {chronoSections.map((section) => (
+              {chronoSections.map((section, sectionIdx) => (
                 <ChronoSection
                   key={section.key}
                   section={section}
+                  indexOffset={
+                    needsAttentionGroups.length +
+                    chronoSections
+                      .slice(0, sectionIdx)
+                      .reduce((sum, s) => sum + s.groups.length, 0)
+                  }
+                  focusedIndex={focusedIndex}
+                  setRowRef={setRowRef}
+                  onRowFocus={setFocusedIndex}
+                  onDropdownOpenChange={handleDropdownOpenChange}
                   groupByContext={groupByContext}
                   dividerGroupId={dividerGroupId}
                   dividerRef={setDividerEl}
@@ -638,22 +803,43 @@ export function NotificationCenter({ open, onClose }: NotificationCenterProps) {
   );
 }
 
+interface RovingSectionProps {
+  indexOffset: number;
+  focusedIndex: number;
+  setRowRef: (index: number, el: HTMLDivElement | null) => void;
+  onRowFocus: (index: number) => void;
+  onDropdownOpenChange: (open: boolean) => void;
+}
+
 function NeedsAttentionSection({
   groups,
+  indexOffset,
+  focusedIndex,
+  setRowRef,
+  onRowFocus,
+  onDropdownOpenChange,
   onDismiss,
   onDismissThread,
 }: {
   groups: ThreadGroup[];
   onDismiss: (id: string) => void;
   onDismissThread: (correlationId: string) => void;
-}) {
+} & RovingSectionProps) {
   return (
     <div data-testid="needs-attention-section" className="border-b border-divider">
       <div className="px-3 pt-2 pb-1 text-[10px] font-semibold uppercase tracking-wide text-daintree-text/50">
         Needs attention
       </div>
-      <div className="divide-y divide-tint/[0.04]">
-        {groups.map((group) => renderGroup(group, onDismiss, onDismissThread))}
+      <div role="group" aria-label="Needs attention" className="divide-y divide-tint/[0.04]">
+        {groups.map((group, idx) =>
+          renderGroup(group, onDismiss, onDismissThread, {
+            flatIndex: indexOffset + idx,
+            focusedIndex,
+            setRowRef,
+            onRowFocus,
+            onDropdownOpenChange,
+          })
+        )}
       </div>
     </div>
   );
@@ -665,6 +851,11 @@ function ChronoSection({
   dividerGroupId,
   dividerRef,
   lastClosedAt,
+  indexOffset,
+  focusedIndex,
+  setRowRef,
+  onRowFocus,
+  onDropdownOpenChange,
   onDismiss,
   onDismissThread,
   onMarkIdsRead,
@@ -677,14 +868,14 @@ function ChronoSection({
   onDismiss: (id: string) => void;
   onDismissThread: (correlationId: string) => void;
   onMarkIdsRead: (ids: string[], options: { resetLastClosed: boolean }) => void;
-}) {
+} & RovingSectionProps) {
   const sectionUnreadIds = section.groups.flatMap((g) =>
     g.entries.filter((e) => !e.seenAsToast).map((e) => e.id)
   );
   const newSinceUnreadIds = section.groups
     .filter((g) => g.latestTimestamp > lastClosedAt)
     .flatMap((g) => g.entries.filter((e) => !e.seenAsToast).map((e) => e.id));
-
+  const sectionLabel = groupByContext ? "Notifications for this context" : "All notifications";
   return (
     <div data-testid="chrono-section">
       {groupByContext && (
@@ -696,8 +887,8 @@ function ChronoSection({
           onMarkRead={() => onMarkIdsRead(sectionUnreadIds, { resetLastClosed: false })}
         />
       )}
-      <div className="divide-y divide-tint/[0.04]">
-        {section.groups.map((group) => {
+      <div role="group" aria-label={sectionLabel} className="divide-y divide-tint/[0.04]">
+        {section.groups.map((group, idx) => {
           const groupKey = group.correlationId ?? group.entries[0]!.id;
           const isDivider = dividerGroupId !== null && groupKey === dividerGroupId;
           return (
@@ -709,7 +900,13 @@ function ChronoSection({
                   onMarkRead={() => onMarkIdsRead(newSinceUnreadIds, { resetLastClosed: true })}
                 />
               )}
-              {renderGroup(group, onDismiss, onDismissThread)}
+              {renderGroup(group, onDismiss, onDismissThread, {
+                flatIndex: indexOffset + idx,
+                focusedIndex,
+                setRowRef,
+                onRowFocus,
+                onDropdownOpenChange,
+              })}
             </div>
           );
         })}
@@ -718,17 +915,35 @@ function ChronoSection({
   );
 }
 
+interface RowRovingProps {
+  flatIndex: number;
+  focusedIndex: number;
+  setRowRef: (index: number, el: HTMLDivElement | null) => void;
+  onRowFocus: (index: number) => void;
+  onDropdownOpenChange: (open: boolean) => void;
+}
+
 function renderGroup(
   group: ThreadGroup,
   onDismiss: (id: string) => void,
-  onDismissThread: (correlationId: string) => void
+  onDismissThread: (correlationId: string) => void,
+  roving: RowRovingProps
 ) {
+  const isFocused = roving.flatIndex === roving.focusedIndex;
+  const tabIndex = isFocused ? 0 : -1;
+  const rowRef = (el: HTMLDivElement | null) => roving.setRowRef(roving.flatIndex, el);
+  const handleFocus = () => roving.onRowFocus(roving.flatIndex);
+
   if (group.correlationId && group.entries.length > 1) {
     return (
       <NotificationThread
         key={group.correlationId}
         group={group}
         onDismiss={() => onDismissThread(group.correlationId!)}
+        rowRef={rowRef}
+        tabIndex={tabIndex}
+        onRowFocus={handleFocus}
+        onDropdownOpenChange={roving.onDropdownOpenChange}
       />
     );
   }
@@ -739,6 +954,11 @@ function renderGroup(
       entry={entry}
       isNew={!entry.seenAsToast}
       onDismiss={() => onDismiss(entry.id)}
+      rowRef={rowRef}
+      tabIndex={tabIndex}
+      role="listitem"
+      onFocus={handleFocus}
+      onDropdownOpenChange={roving.onDropdownOpenChange}
     />
   );
 }
@@ -817,7 +1037,21 @@ function NewSinceLastLookedDivider({
   );
 }
 
-function NotificationThread({ group, onDismiss }: { group: ThreadGroup; onDismiss: () => void }) {
+function NotificationThread({
+  group,
+  onDismiss,
+  rowRef,
+  tabIndex,
+  onRowFocus,
+  onDropdownOpenChange,
+}: {
+  group: ThreadGroup;
+  onDismiss: () => void;
+  rowRef?: (el: HTMLDivElement | null) => void;
+  tabIndex?: number;
+  onRowFocus?: () => void;
+  onDropdownOpenChange?: (open: boolean) => void;
+}) {
   const latest = group.entries[0];
   const isNew = group.entries.some((e) => !e.seenAsToast);
 
@@ -826,13 +1060,25 @@ function NotificationThread({ group, onDismiss }: { group: ThreadGroup; onDismis
   const displayType = getWorstSeverity(group.entries);
 
   return (
-    <div data-testid="notification-thread" className="relative border-l-2 border-tint/15">
+    <div
+      ref={rowRef}
+      tabIndex={tabIndex}
+      role="listitem"
+      onFocus={onRowFocus}
+      data-testid="notification-thread"
+      className={cn(
+        "group relative border-l-2 border-tint/15",
+        tabIndex !== undefined &&
+          "focus-visible:outline-hidden focus-visible:ring-1 focus-visible:ring-inset focus-visible:ring-daintree-accent/50"
+      )}
+    >
       <NotificationCenterEntry
         entry={latest}
         displayType={displayType}
         threadCount={group.entries.length}
         isNew={isNew}
         onDismiss={onDismiss}
+        onDropdownOpenChange={onDropdownOpenChange}
       />
     </div>
   );

--- a/src/components/Notifications/NotificationCenterEntry.tsx
+++ b/src/components/Notifications/NotificationCenterEntry.tsx
@@ -1,4 +1,4 @@
-import { useEffect, useRef, useState } from "react";
+import { memo, useEffect, useRef, useState, type Ref } from "react";
 import { CheckCircle2, XCircle, Info, AlertTriangle, MoreHorizontal, X } from "lucide-react";
 import { cn } from "@/lib/utils";
 import type { NotificationHistoryEntry } from "@/store/slices/notificationHistorySlice";
@@ -79,14 +79,24 @@ interface NotificationCenterEntryProps {
   threadCount?: number;
   isNew?: boolean;
   onDismiss?: () => void;
+  rowRef?: Ref<HTMLDivElement>;
+  tabIndex?: number;
+  role?: string;
+  onFocus?: () => void;
+  onDropdownOpenChange?: (open: boolean) => void;
 }
 
-export function NotificationCenterEntry({
+function NotificationCenterEntryImpl({
   entry,
   displayType,
   threadCount,
   isNew = false,
   onDismiss,
+  rowRef,
+  tabIndex,
+  role,
+  onFocus,
+  onDropdownOpenChange,
 }: NotificationCenterEntryProps) {
   const config = TYPE_CONFIG[displayType ?? entry.type];
   const Icon = config.icon;
@@ -114,7 +124,17 @@ export function NotificationCenterEntry({
   }, [safeCount]);
 
   return (
-    <div className="group flex items-start gap-2.5 px-3 py-2 hover:bg-overlay-medium transition-colors">
+    <div
+      ref={rowRef}
+      tabIndex={tabIndex}
+      role={role}
+      onFocus={onFocus}
+      className={cn(
+        "group flex items-start gap-2.5 px-3 py-2 hover:bg-overlay-medium transition-colors",
+        tabIndex !== undefined &&
+          "focus-visible:outline-hidden focus-visible:ring-1 focus-visible:ring-inset focus-visible:ring-daintree-accent/50"
+      )}
+    >
       <div className={cn("mt-0.5 shrink-0", config.className)}>
         <Icon className="h-3.5 w-3.5" />
       </div>
@@ -217,13 +237,13 @@ export function NotificationCenterEntry({
           (() => {
             const eventKind = entry.context?.eventKind;
             return (
-              <DropdownMenu>
+              <DropdownMenu onOpenChange={onDropdownOpenChange}>
                 <DropdownMenuTrigger asChild>
                   <button
                     type="button"
                     aria-label="Notification options"
                     onClick={(e) => e.stopPropagation()}
-                    className="opacity-0 group-hover:opacity-100 focus:opacity-100 data-[state=open]:opacity-100 h-4 w-4 flex items-center justify-center rounded text-daintree-text/40 hover:text-daintree-text/70 transition-opacity"
+                    className="opacity-0 group-hover:opacity-100 group-focus-within:opacity-100 focus:opacity-100 data-[state=open]:opacity-100 h-4 w-4 flex items-center justify-center rounded text-daintree-text/40 hover:text-daintree-text/70 transition-opacity"
                   >
                     <MoreHorizontal className="h-3 w-3" />
                   </button>
@@ -269,7 +289,7 @@ export function NotificationCenterEntry({
               e.stopPropagation();
               onDismiss();
             }}
-            className="opacity-0 group-hover:opacity-100 focus:opacity-100 h-4 w-4 flex items-center justify-center rounded text-daintree-text/40 hover:text-daintree-text/70 transition-opacity"
+            className="opacity-0 group-hover:opacity-100 group-focus-within:opacity-100 focus:opacity-100 h-4 w-4 flex items-center justify-center rounded text-daintree-text/40 hover:text-daintree-text/70 transition-opacity"
           >
             <X className="h-3 w-3" />
           </button>
@@ -278,3 +298,5 @@ export function NotificationCenterEntry({
     </div>
   );
 }
+
+export const NotificationCenterEntry = memo(NotificationCenterEntryImpl);

--- a/src/components/Notifications/__tests__/NotificationCenter.test.tsx
+++ b/src/components/Notifications/__tests__/NotificationCenter.test.tsx
@@ -2091,4 +2091,124 @@ describe("NotificationCenter — keyboard navigation", () => {
     expect(rows.length).toBeGreaterThanOrEqual(2);
     expect(rows[0]?.getAttribute("tabindex")).toBe("0");
   });
+
+  it("restores focus to the surviving row after dismissing the focused row via 'e'", async () => {
+    setEntries([
+      makeEntry({ id: "a", message: "Stay-1" }),
+      makeEntry({ id: "b", message: "Stay-2" }),
+      makeEntry({ id: "c", message: "Will go" }),
+    ]);
+    const { container } = render(<NotificationCenter open onClose={vi.fn()} />);
+    const list = container.querySelector('[role="list"]') as HTMLElement;
+
+    act(() => {
+      getRows(container)[2]?.focus();
+    });
+
+    await act(async () => {
+      fireEvent.keyDown(list, { key: "e" });
+    });
+
+    await waitFor(() => {
+      expect(getRows(container)).toHaveLength(2);
+    });
+    // Focus must have followed to the new last surviving row, not dropped to <body>.
+    expect(document.activeElement).toBe(getRows(container)[1]);
+  });
+
+  it("resumes navigation after the row dropdown is closed", async () => {
+    setEntries([
+      makeEntry({ id: "a", context: { projectId: "p1" } }),
+      makeEntry({ id: "b", context: { projectId: "p1" } }),
+    ]);
+    const { container } = render(<NotificationCenter open onClose={vi.fn()} />);
+    const list = container.querySelector('[role="list"]') as HTMLElement;
+    const rows = getRows(container);
+
+    act(() => {
+      rows[0]?.focus();
+    });
+
+    const trigger = within(rows[0]!).getByLabelText("Notification options");
+    await act(async () => {
+      fireEvent.pointerDown(trigger, { button: 0 });
+      fireEvent.pointerUp(trigger, { button: 0 });
+      fireEvent.click(trigger);
+    });
+
+    // Close via Escape — Radix should fire onOpenChange(false).
+    await act(async () => {
+      fireEvent.keyDown(document.activeElement ?? document.body, { key: "Escape" });
+    });
+
+    // After the menu closes, j must navigate again.
+    act(() => {
+      getRows(container)[0]?.focus();
+    });
+    fireEvent.keyDown(list, { key: "j" });
+    expect(document.activeElement).toBe(getRows(container)[1]);
+  });
+
+  it("recovers navigation after a focused-menu row is externally dismissed", async () => {
+    setEntries([
+      makeEntry({ id: "a", context: { projectId: "p1" } }),
+      makeEntry({ id: "b" }),
+      makeEntry({ id: "c" }),
+    ]);
+    const { container } = render(<NotificationCenter open onClose={vi.fn()} />);
+    const list = container.querySelector('[role="list"]') as HTMLElement;
+    const rows = getRows(container);
+
+    act(() => {
+      rows[0]?.focus();
+    });
+
+    const trigger = within(rows[0]!).getByLabelText("Notification options");
+    await act(async () => {
+      fireEvent.pointerDown(trigger, { button: 0 });
+      fireEvent.pointerUp(trigger, { button: 0 });
+      fireEvent.click(trigger);
+    });
+
+    // External dismissal — bypass the kebab menu entirely. The dropdown
+    // counter must reset so navigation isn't permanently stuck.
+    await act(async () => {
+      useNotificationHistoryStore.getState().dismissEntry("a");
+    });
+
+    await waitFor(() => {
+      expect(getRows(container)).toHaveLength(2);
+    });
+
+    act(() => {
+      getRows(container)[0]?.focus();
+    });
+    fireEvent.keyDown(list, { key: "j" });
+    expect(document.activeElement).toBe(getRows(container)[1]);
+  });
+
+  it("does not navigate or dismiss when focus is on a descendant button inside the row", async () => {
+    getMock.mockReturnValue({ enabled: true });
+    setEntries([
+      makeEntry({
+        id: "a",
+        message: "Has action",
+        actions: [{ actionId: "test.action", label: "Open", actionArgs: { x: 1 } }],
+      }),
+      makeEntry({ id: "b", message: "Plain row" }),
+    ]);
+    const { container } = render(<NotificationCenter open onClose={vi.fn()} />);
+    const list = container.querySelector('[role="list"]') as HTMLElement;
+
+    const actionButton = screen.getByText("Open");
+    act(() => {
+      actionButton.focus();
+    });
+
+    fireEvent.keyDown(list, { key: "j" });
+    expect(document.activeElement).toBe(actionButton);
+
+    fireEvent.keyDown(list, { key: "e" });
+    expect(useNotificationHistoryStore.getState().entries.length).toBe(2);
+  });
 });

--- a/src/components/Notifications/__tests__/NotificationCenter.test.tsx
+++ b/src/components/Notifications/__tests__/NotificationCenter.test.tsx
@@ -1844,3 +1844,251 @@ describe("uiStore — closeNotificationCenter records timestamp", () => {
     expect(useUIStore.getState().lastNotificationCenterClosedAt).toBeGreaterThan(0);
   });
 });
+
+describe("NotificationCenter — keyboard navigation", () => {
+  function getRows(container: HTMLElement): HTMLElement[] {
+    return Array.from(container.querySelectorAll<HTMLElement>('[role="listitem"]'));
+  }
+
+  it("marks the scroll container as role=list with an aria-label", () => {
+    setEntries([
+      makeEntry({ id: "row-a", message: "First" }),
+      makeEntry({ id: "row-b", message: "Second" }),
+    ]);
+    const { container } = render(<NotificationCenter open onClose={vi.fn()} />);
+    const list = container.querySelector('[role="list"][aria-label="Notifications"]');
+    expect(list).not.toBeNull();
+  });
+
+  it("does not mark the container as a list when there are no rows", () => {
+    const { container } = render(<NotificationCenter open onClose={vi.fn()} />);
+    expect(container.querySelector('[role="list"]')).toBeNull();
+  });
+
+  it("renders the first row with tabIndex=0 and the rest with tabIndex=-1", () => {
+    setEntries([
+      makeEntry({ id: "a", message: "First" }),
+      makeEntry({ id: "b", message: "Second" }),
+      makeEntry({ id: "c", message: "Third" }),
+    ]);
+    const { container } = render(<NotificationCenter open onClose={vi.fn()} />);
+    const rows = getRows(container);
+    expect(rows).toHaveLength(3);
+    expect(rows[0]?.getAttribute("tabindex")).toBe("0");
+    expect(rows[1]?.getAttribute("tabindex")).toBe("-1");
+    expect(rows[2]?.getAttribute("tabindex")).toBe("-1");
+  });
+
+  it("moves the roving focus to the next row on j and ArrowDown", () => {
+    setEntries([
+      makeEntry({ id: "a", message: "First" }),
+      makeEntry({ id: "b", message: "Second" }),
+      makeEntry({ id: "c", message: "Third" }),
+    ]);
+    const { container } = render(<NotificationCenter open onClose={vi.fn()} />);
+    const rows = getRows(container);
+    const list = container.querySelector('[role="list"]') as HTMLElement;
+
+    act(() => {
+      rows[0]?.focus();
+    });
+    fireEvent.keyDown(list, { key: "j" });
+    expect(getRows(container)[1]?.getAttribute("tabindex")).toBe("0");
+    expect(document.activeElement).toBe(getRows(container)[1]);
+
+    fireEvent.keyDown(list, { key: "ArrowDown" });
+    expect(getRows(container)[2]?.getAttribute("tabindex")).toBe("0");
+    expect(document.activeElement).toBe(getRows(container)[2]);
+  });
+
+  it("moves the roving focus to the previous row on k and ArrowUp", () => {
+    setEntries([
+      makeEntry({ id: "a", message: "First" }),
+      makeEntry({ id: "b", message: "Second" }),
+      makeEntry({ id: "c", message: "Third" }),
+    ]);
+    const { container } = render(<NotificationCenter open onClose={vi.fn()} />);
+    const list = container.querySelector('[role="list"]') as HTMLElement;
+    const lastRow = getRows(container)[2]!;
+
+    act(() => {
+      lastRow.focus();
+    });
+    fireEvent.keyDown(list, { key: "k" });
+    expect(document.activeElement).toBe(getRows(container)[1]);
+
+    fireEvent.keyDown(list, { key: "ArrowUp" });
+    expect(document.activeElement).toBe(getRows(container)[0]);
+  });
+
+  it("clamps at the last row instead of wrapping", () => {
+    setEntries([makeEntry({ id: "a" }), makeEntry({ id: "b" })]);
+    const { container } = render(<NotificationCenter open onClose={vi.fn()} />);
+    const list = container.querySelector('[role="list"]') as HTMLElement;
+
+    act(() => {
+      getRows(container)[1]?.focus();
+    });
+    fireEvent.keyDown(list, { key: "j" });
+    expect(document.activeElement).toBe(getRows(container)[1]);
+  });
+
+  it("clamps at the first row instead of wrapping", () => {
+    setEntries([makeEntry({ id: "a" }), makeEntry({ id: "b" })]);
+    const { container } = render(<NotificationCenter open onClose={vi.fn()} />);
+    const list = container.querySelector('[role="list"]') as HTMLElement;
+
+    act(() => {
+      getRows(container)[0]?.focus();
+    });
+    fireEvent.keyDown(list, { key: "k" });
+    expect(document.activeElement).toBe(getRows(container)[0]);
+  });
+
+  it("Home jumps to the first row and End to the last", () => {
+    setEntries([
+      makeEntry({ id: "a" }),
+      makeEntry({ id: "b" }),
+      makeEntry({ id: "c" }),
+      makeEntry({ id: "d" }),
+    ]);
+    const { container } = render(<NotificationCenter open onClose={vi.fn()} />);
+    const list = container.querySelector('[role="list"]') as HTMLElement;
+
+    act(() => {
+      getRows(container)[0]?.focus();
+    });
+    fireEvent.keyDown(list, { key: "End" });
+    expect(document.activeElement).toBe(getRows(container)[3]);
+
+    fireEvent.keyDown(list, { key: "Home" });
+    expect(document.activeElement).toBe(getRows(container)[0]);
+  });
+
+  it("does nothing when focus is outside the row set", () => {
+    setEntries([makeEntry({ id: "a" }), makeEntry({ id: "b" })]);
+    const { container } = render(<NotificationCenter open onClose={vi.fn()} />);
+    const list = container.querySelector('[role="list"]') as HTMLElement;
+
+    // No row is focused — j must be a no-op.
+    expect(document.activeElement).not.toBe(getRows(container)[0]);
+    fireEvent.keyDown(list, { key: "j" });
+    expect(getRows(container)[0]?.getAttribute("tabindex")).toBe("0");
+    expect(getRows(container)[1]?.getAttribute("tabindex")).toBe("-1");
+  });
+
+  it("dismisses the focused row on 'e' and clamps focus to the new last row", async () => {
+    setEntries([
+      makeEntry({ id: "a", message: "First" }),
+      makeEntry({ id: "b", message: "Second" }),
+      makeEntry({ id: "c", message: "Last to remove" }),
+    ]);
+    const { container } = render(<NotificationCenter open onClose={vi.fn()} />);
+    const list = container.querySelector('[role="list"]') as HTMLElement;
+
+    act(() => {
+      getRows(container)[2]?.focus();
+    });
+
+    await act(async () => {
+      fireEvent.keyDown(list, { key: "e" });
+    });
+
+    await waitFor(() => {
+      expect(getRows(container)).toHaveLength(2);
+    });
+    expect(screen.queryByText("Last to remove")).toBeNull();
+    // After the last row is removed, the clamping effect drops focusedIndex to 1.
+    expect(getRows(container)[1]?.getAttribute("tabindex")).toBe("0");
+  });
+
+  it("dispatches the focused row's primary action on Enter", async () => {
+    getMock.mockReturnValue({ enabled: true });
+    setEntries([
+      makeEntry({
+        id: "a",
+        message: "Has action",
+        actions: [{ actionId: "test.action", label: "Open", actionArgs: { x: 1 } }],
+      }),
+    ]);
+    const { container } = render(<NotificationCenter open onClose={vi.fn()} />);
+    const list = container.querySelector('[role="list"]') as HTMLElement;
+
+    act(() => {
+      getRows(container)[0]?.focus();
+    });
+
+    await act(async () => {
+      fireEvent.keyDown(list, { key: "Enter" });
+    });
+
+    expect(dispatchMock).toHaveBeenCalledWith("test.action", { x: 1 });
+  });
+
+  it("does not dispatch on Enter when the action is unavailable", async () => {
+    getMock.mockReturnValue({ enabled: false });
+    setEntries([
+      makeEntry({
+        id: "a",
+        message: "Disabled action",
+        actions: [{ actionId: "test.action", label: "Open" }],
+      }),
+    ]);
+    const { container } = render(<NotificationCenter open onClose={vi.fn()} />);
+    const list = container.querySelector('[role="list"]') as HTMLElement;
+
+    act(() => {
+      getRows(container)[0]?.focus();
+    });
+
+    await act(async () => {
+      fireEvent.keyDown(list, { key: "Enter" });
+    });
+
+    expect(dispatchMock).not.toHaveBeenCalled();
+  });
+
+  it("does not steal navigation keys while a row dropdown is open", () => {
+    setEntries([
+      makeEntry({ id: "a", context: { projectId: "p1" } }),
+      makeEntry({ id: "b", context: { projectId: "p1" } }),
+    ]);
+    const { container } = render(<NotificationCenter open onClose={vi.fn()} />);
+    const list = container.querySelector('[role="list"]') as HTMLElement;
+    const rows = getRows(container);
+
+    act(() => {
+      rows[0]?.focus();
+    });
+
+    // Open the kebab menu on the first row — emulates Radix DropdownMenu open.
+    const trigger = within(rows[0]!).getByLabelText("Notification options");
+    act(() => {
+      fireEvent.pointerDown(trigger, { button: 0 });
+      fireEvent.pointerUp(trigger, { button: 0 });
+      fireEvent.click(trigger);
+    });
+
+    // While the dropdown is open, j must NOT navigate.
+    fireEvent.keyDown(list, { key: "j" });
+    expect(getRows(container)[0]?.getAttribute("tabindex")).toBe("0");
+    expect(getRows(container)[1]?.getAttribute("tabindex")).toBe("-1");
+  });
+
+  it("orders the flat row index across needs-attention and chrono sections", () => {
+    setEntries([
+      makeEntry({ id: "info-1", type: "info", message: "Info note", seenAsToast: true }),
+      makeEntry({
+        id: "err-1",
+        type: "error",
+        message: "Pinned error",
+        seenAsToast: false,
+      }),
+    ]);
+    const { container } = render(<NotificationCenter open onClose={vi.fn()} />);
+    const rows = getRows(container);
+    // Pinned needs-attention section comes first; it dedupes the entry from chrono not.
+    expect(rows.length).toBeGreaterThanOrEqual(2);
+    expect(rows[0]?.getAttribute("tabindex")).toBe("0");
+  });
+});

--- a/src/components/Notifications/__tests__/NotificationCenterEntry.test.tsx
+++ b/src/components/Notifications/__tests__/NotificationCenterEntry.test.tsx
@@ -442,3 +442,81 @@ describe("NotificationCenterEntry timestamp formatting", () => {
     }
   });
 });
+
+describe("NotificationCenterEntry roving focus props", () => {
+  it("applies tabIndex and role to the root row when provided", () => {
+    const { container } = render(
+      <NotificationCenterEntry entry={makeEntry()} tabIndex={0} role="listitem" />
+    );
+    const root = container.firstElementChild as HTMLElement;
+    expect(root.getAttribute("tabindex")).toBe("0");
+    expect(root.getAttribute("role")).toBe("listitem");
+  });
+
+  it("invokes rowRef with the row DOM element", () => {
+    const rowRef = vi.fn();
+    render(<NotificationCenterEntry entry={makeEntry()} tabIndex={-1} rowRef={rowRef} />);
+    expect(rowRef).toHaveBeenCalledTimes(1);
+    expect(rowRef.mock.calls[0]?.[0]).toBeInstanceOf(HTMLDivElement);
+  });
+
+  it("calls onFocus when the row receives focus", () => {
+    const onFocus = vi.fn();
+    const { container } = render(
+      <NotificationCenterEntry entry={makeEntry()} tabIndex={0} onFocus={onFocus} />
+    );
+    const root = container.firstElementChild as HTMLElement;
+    act(() => {
+      root.focus();
+    });
+    expect(onFocus).toHaveBeenCalledTimes(1);
+  });
+
+  it("adds focus-visible ring classes only when tabIndex is set", () => {
+    const { container, rerender } = render(<NotificationCenterEntry entry={makeEntry()} />);
+    expect((container.firstElementChild as HTMLElement).className).not.toMatch(
+      /focus-visible:ring/
+    );
+
+    rerender(<NotificationCenterEntry entry={makeEntry()} tabIndex={0} />);
+    expect((container.firstElementChild as HTMLElement).className).toMatch(/focus-visible:ring/);
+  });
+
+  it("reveals the dismiss button on group-focus-within (focus inside the row)", () => {
+    render(<NotificationCenterEntry entry={makeEntry()} onDismiss={vi.fn()} />);
+    const dismiss = screen.getByLabelText("Dismiss notification");
+    expect(dismiss.className).toMatch(/group-focus-within:opacity-100/);
+  });
+
+  it("reveals the kebab trigger on group-focus-within", () => {
+    render(<NotificationCenterEntry entry={makeEntry({ context: { projectId: "p1" } })} />);
+    const kebab = screen.getByLabelText("Notification options");
+    expect(kebab.className).toMatch(/group-focus-within:opacity-100/);
+  });
+
+  it("invokes onDropdownOpenChange when the kebab menu opens and closes", async () => {
+    const onDropdownOpenChange = vi.fn();
+    render(
+      <NotificationCenterEntry
+        entry={makeEntry({ context: { projectId: "p1" } })}
+        onDropdownOpenChange={onDropdownOpenChange}
+      />
+    );
+    const trigger = screen.getByLabelText("Notification options");
+
+    await act(async () => {
+      fireEvent.pointerDown(trigger, { button: 0 });
+      fireEvent.pointerUp(trigger, { button: 0 });
+      fireEvent.click(trigger);
+    });
+
+    expect(onDropdownOpenChange).toHaveBeenCalledWith(true);
+
+    // Press Escape on the menu — Radix closes and fires onOpenChange(false).
+    await act(async () => {
+      fireEvent.keyDown(document.activeElement ?? document.body, { key: "Escape" });
+    });
+
+    expect(onDropdownOpenChange).toHaveBeenCalledWith(false);
+  });
+});


### PR DESCRIPTION
## Summary

- Notification inbox rows weren't reachable by keyboard — `Tab` skipped past each row entirely, making the dismiss `X` and kebab menu effectively dead for keyboard users. This adds full keyboard navigation via roving `tabIndex`.
- Container-scoped keymap: `j`/`k`/ArrowUp/ArrowDown/Home/End to move between rows, `e` to dismiss, `Enter` for the row's primary action. Only fires when focus is inside the panel, so these keys stay available everywhere else.
- `group-focus-within:opacity-100` replaces the dead `focus:opacity-100` on dismiss and kebab buttons. Radix `DropdownMenu` open state is tracked with a counter so navigation no-ops while a menu is open.

Resolves #7484

## Changes

- `NotificationCenter.tsx` — flat row model, `focusedIndex` state, `rowRefs` Map, container `onKeyDown` handler, ARIA roles (`role=list` on scroll container, `role=group` on sections, `role=listitem` on rows), dropdown open counter threaded through to row menus
- `NotificationCenterEntry.tsx` — optional `rowRef`/`tabIndex`/`role`/`onFocus`/`onDropdownOpenChange` props, `focus-visible` ring when `tabIndex` is set, `group-focus-within` reveal on dismiss/kebab buttons, memoized
- Focus restores correctly after dismiss via a clamp effect — if the dismissed row was last, focus moves to the new last row
- 25 new tests across `NotificationCenter.test.tsx` and `NotificationCenterEntry.test.tsx` covering roving `tabIndex`, all nav keys with clamping, dismiss and focus restore, Enter dispatch with manifest gating, dropdown guard, and `group-focus-within` reveal

## Testing

- 111 notification tests passing (25 new)
- Typecheck, lint, format, and build all clean