### PR TITLE
feat(ui): lift typed-name confirm to shared ConfirmDialog primitive

### DIFF
--- a/src/components/Settings/DaintreeAssistantSettingsTab.tsx
+++ b/src/components/Settings/DaintreeAssistantSettingsTab.tsx
@@ -269,7 +269,8 @@ export function DaintreeAssistantSettingsTab() {
     setShowRotateConfirm(false);
   }, [isRotating]);
 
-  const apiKeySuffix = mcpStatus?.apiKey ? mcpStatus.apiKey.slice(-4) : "";
+  const apiKeySuffix =
+    mcpStatus?.apiKey && mcpStatus.apiKey.length >= 8 ? mcpStatus.apiKey.slice(-4) : "";
 
   const handleCopyConfig = useCallback(async () => {
     try {
@@ -473,7 +474,9 @@ export function DaintreeAssistantSettingsTab() {
               <button
                 type="button"
                 onClick={() => setShowRotateConfirm(true)}
-                className="flex items-center gap-2 px-3 py-1.5 rounded-[var(--radius-md)] text-xs font-medium border border-daintree-border text-daintree-text/70 hover:text-daintree-text hover:bg-overlay-soft transition-colors"
+                disabled={!apiKeySuffix}
+                title={apiKeySuffix ? undefined : "Waiting for the MCP key to load…"}
+                className="flex items-center gap-2 px-3 py-1.5 rounded-[var(--radius-md)] text-xs font-medium border border-daintree-border text-daintree-text/70 hover:text-daintree-text hover:bg-overlay-soft transition-colors disabled:opacity-50 disabled:cursor-not-allowed disabled:hover:bg-transparent disabled:hover:text-daintree-text/70"
               >
                 <RefreshCw className="w-3.5 h-3.5" />
                 Rotate MCP key

--- a/src/components/Settings/DaintreeAssistantSettingsTab.tsx
+++ b/src/components/Settings/DaintreeAssistantSettingsTab.tsx
@@ -269,6 +269,8 @@ export function DaintreeAssistantSettingsTab() {
     setShowRotateConfirm(false);
   }, [isRotating]);
 
+  const apiKeySuffix = mcpStatus?.apiKey ? mcpStatus.apiKey.slice(-4) : "";
+
   const handleCopyConfig = useCallback(async () => {
     try {
       const snippet = await window.electron.mcpServer.getConfigSnippet();
@@ -497,13 +499,29 @@ export function DaintreeAssistantSettingsTab() {
         isOpen={showRotateConfirm}
         onClose={isRotating ? undefined : handleCancelRotate}
         title="Rotate API key?"
-        description="The current key will be invalidated immediately. External clients using this key will need to update their configuration."
+        description={
+          <>
+            The current key will be invalidated immediately. External clients using this key will
+            need to update their configuration.
+            {apiKeySuffix && (
+              <>
+                {" "}
+                Type the last 4 characters of the current key (
+                <code className="font-mono text-xs bg-daintree-bg/50 px-1.5 py-0.5 rounded border border-daintree-border">
+                  {apiKeySuffix}
+                </code>
+                ) to confirm.
+              </>
+            )}
+          </>
+        }
         confirmLabel="Rotate key"
         cancelLabel="Cancel"
         onConfirm={confirmRotateKey}
         isConfirmLoading={isRotating}
         variant="destructive"
         zIndex="nested"
+        typedNameTarget={apiKeySuffix || undefined}
       />
     </div>
   );

--- a/src/components/Settings/__tests__/DaintreeAssistantSettingsTab.test.tsx
+++ b/src/components/Settings/__tests__/DaintreeAssistantSettingsTab.test.tsx
@@ -285,11 +285,42 @@ describe("DaintreeAssistantSettingsTab", () => {
     });
     expect(window.electron.mcpServer.rotateApiKey).not.toHaveBeenCalled();
 
-    fireEvent.click(screen.getByRole("button", { name: /^rotate key$/i }));
+    const confirmButton = screen.getByRole("button", {
+      name: /^rotate key$/i,
+    }) as HTMLButtonElement;
+    expect(confirmButton.disabled).toBe(true);
+
+    const typedInput = screen.getByLabelText(/^Type .* to confirm$/i) as HTMLInputElement;
+    fireEvent.change(typedInput, { target: { value: "y-abc" } });
+    expect(confirmButton.disabled).toBe(true);
+
+    fireEvent.change(typedInput, { target: { value: "-abc" } });
+    expect(confirmButton.disabled).toBe(false);
+
+    fireEvent.click(confirmButton);
 
     await waitFor(() => {
       expect(window.electron.mcpServer.rotateApiKey).toHaveBeenCalledTimes(1);
     });
+  });
+
+  it("does not expose the full API key in the rotate dialog body", async () => {
+    const { container } = render(
+      <SettingsValidationProvider>
+        <DaintreeAssistantSettingsTab />
+      </SettingsValidationProvider>
+    );
+    await waitForContent(container, "Rotate MCP key");
+
+    fireEvent.click(screen.getByRole("button", { name: /rotate mcp key/i }));
+
+    await waitFor(() => {
+      expect(screen.getByRole("heading", { name: /rotate api key\?/i })).toBeTruthy();
+    });
+
+    const dialogText = document.body.textContent ?? "";
+    expect(dialogText).not.toContain("dnt-key-abc");
+    expect(dialogText).toContain("-abc");
   });
 
   it("rotate key dialog can be canceled without rotating", async () => {

--- a/src/components/Settings/__tests__/DaintreeAssistantSettingsTab.test.tsx
+++ b/src/components/Settings/__tests__/DaintreeAssistantSettingsTab.test.tsx
@@ -304,6 +304,33 @@ describe("DaintreeAssistantSettingsTab", () => {
     });
   });
 
+  it("disables the Rotate MCP key button when the API key has not loaded yet", async () => {
+    installApi(
+      {},
+      {
+        getStatus: vi.fn().mockResolvedValue({
+          enabled: true,
+          port: 45454,
+          configuredPort: 45454,
+          apiKey: "",
+        }),
+      }
+    );
+
+    const { container } = render(
+      <SettingsValidationProvider>
+        <DaintreeAssistantSettingsTab />
+      </SettingsValidationProvider>
+    );
+    await waitForContent(container, "Rotate MCP key");
+
+    const button = screen.getByRole("button", { name: /rotate mcp key/i }) as HTMLButtonElement;
+    expect(button.disabled).toBe(true);
+
+    fireEvent.click(button);
+    expect(screen.queryByRole("heading", { name: /rotate api key\?/i })).toBeNull();
+  });
+
   it("does not expose the full API key in the rotate dialog body", async () => {
     const { container } = render(
       <SettingsValidationProvider>

--- a/src/components/Worktree/WorktreeDeleteDialog.tsx
+++ b/src/components/Worktree/WorktreeDeleteDialog.tsx
@@ -40,7 +40,7 @@ export function WorktreeDeleteDialog({ isOpen, onClose, worktree }: WorktreeDele
   const canDeleteBranch =
     !isProtectedBranch && !isDetachedHead && worktree.isMainWorktree === false;
 
-  const confirmTarget = worktree.branch ?? worktree.name;
+  const confirmTarget = worktree.branch || worktree.name;
   const isHighTier = force && (isProtectedBranch || worktree.isMainWorktree === true);
   const isConfirmMatched = confirmInput === confirmTarget;
   const canSubmit = !isDeleting && (!isHighTier || isConfirmMatched);

--- a/src/components/Worktree/WorktreeDeleteDialog.tsx
+++ b/src/components/Worktree/WorktreeDeleteDialog.tsx
@@ -1,6 +1,7 @@
 import { useState, useEffect, useRef } from "react";
 import { Button } from "@/components/ui/button";
 import { AppDialog } from "@/components/ui/AppDialog";
+import { TypedNameConfirmInput } from "@/components/ui/TypedNameConfirmInput";
 import { AlertTriangle, Trash2 } from "lucide-react";
 import { FolderGit2 } from "@/components/icons";
 import { useWorktreeTerminals } from "@/hooks/useWorktreeTerminals";
@@ -234,35 +235,22 @@ export function WorktreeDeleteDialog({ isOpen, onClose, worktree }: WorktreeDele
             )}
 
             {isHighTier && (
-              <div className="space-y-2 p-3 bg-status-error/5 border border-status-error/20 rounded">
-                <p id="worktree-delete-confirm-instructions" className="text-sm text-daintree-text">
-                  Force-deleting this protected worktree is irreversible. Type{" "}
-                  <code className="font-mono text-xs bg-daintree-bg/50 px-1.5 py-0.5 rounded border border-daintree-border">
-                    {confirmTarget}
-                  </code>{" "}
-                  to confirm.
-                </p>
-                <input
-                  type="text"
-                  value={confirmInput}
-                  onChange={(e) => setConfirmInput(e.target.value)}
-                  onKeyDown={(e) => {
-                    if (e.key === "Enter" && isConfirmMatched) {
-                      e.preventDefault();
-                      void handleDelete();
-                    }
-                  }}
-                  aria-describedby="worktree-delete-confirm-instructions"
-                  aria-label={`Type ${confirmTarget} to confirm deletion`}
-                  autoComplete="off"
-                  spellCheck={false}
-                  className="w-full px-3 py-2 text-sm font-mono bg-daintree-bg border border-daintree-border rounded focus:outline-hidden focus:ring-2 focus:ring-status-error"
-                  data-testid="delete-worktree-confirm-input"
-                />
-                <span className="sr-only" aria-live="polite">
-                  {isConfirmMatched ? "Name confirmed. You may now delete." : ""}
-                </span>
-              </div>
+              <TypedNameConfirmInput
+                target={confirmTarget}
+                value={confirmInput}
+                onChange={setConfirmInput}
+                onMatchSubmit={() => void handleDelete()}
+                instructions={
+                  <>
+                    Force-deleting this protected worktree is irreversible. Type{" "}
+                    <code className="font-mono text-xs bg-daintree-bg/50 px-1.5 py-0.5 rounded border border-daintree-border">
+                      {confirmTarget}
+                    </code>{" "}
+                    to confirm.
+                  </>
+                }
+                data-testid="delete-worktree-confirm-input"
+              />
             )}
           </div>
         )}

--- a/src/components/Worktree/__tests__/WorktreeDeleteDialog.test.tsx
+++ b/src/components/Worktree/__tests__/WorktreeDeleteDialog.test.tsx
@@ -353,6 +353,25 @@ describe("WorktreeDeleteDialog — high tier (name confirmation)", () => {
     expect(button.disabled).toBe(false);
   });
 
+  it("falls back to worktree.name when branch is the empty string", () => {
+    const worktree = makeWorktree(makeChanges([]), {
+      branch: "",
+      name: "abc1234",
+      isMainWorktree: true,
+    });
+    render(<WorktreeDeleteDialog isOpen={true} onClose={vi.fn()} worktree={worktree} />);
+
+    fireEvent.click(screen.getByRole("checkbox", { name: /force delete/i }));
+
+    const button = screen.getByTestId("delete-worktree-confirm") as HTMLButtonElement;
+    expect(button.textContent).toBe("Delete 'abc1234'");
+    expect(button.disabled).toBe(true);
+
+    const input = screen.getByTestId("delete-worktree-confirm-input") as HTMLInputElement;
+    fireEvent.change(input, { target: { value: "abc1234" } });
+    expect(button.disabled).toBe(false);
+  });
+
   it("uses worktree.name as the confirmation target for detached HEAD", () => {
     const worktree = makeWorktree(makeChanges([]), {
       branch: undefined,

--- a/src/components/ui/ConfirmDialog.tsx
+++ b/src/components/ui/ConfirmDialog.tsx
@@ -1,5 +1,7 @@
 import type React from "react";
+import { useEffect, useState } from "react";
 import { AppDialog, type DialogZIndex } from "@/components/ui/AppDialog";
+import { TypedNameConfirmInput } from "@/components/ui/TypedNameConfirmInput";
 
 const DESTRUCTIVE_CONFIRM_LABEL_RE =
   /^\s*(delete|remove|destroy|erase|wipe|purge|abort|reset|revoke|terminate|uninstall)\b/i;
@@ -16,6 +18,7 @@ export interface ConfirmDialogProps {
   isConfirmLoading?: boolean;
   variant: "default" | "destructive" | "info";
   zIndex?: DialogZIndex;
+  typedNameTarget?: string;
 }
 
 export function ConfirmDialog({
@@ -30,8 +33,14 @@ export function ConfirmDialog({
   isConfirmLoading = false,
   variant,
   zIndex,
+  typedNameTarget,
 }: ConfirmDialogProps) {
   const handleClose = onClose ?? (() => {});
+  const [typedValue, setTypedValue] = useState("");
+
+  useEffect(() => {
+    if (!isOpen) setTypedValue("");
+  }, [isOpen]);
 
   if (
     import.meta.env.DEV &&
@@ -44,6 +53,21 @@ export function ConfirmDialog({
     );
   }
 
+  if (import.meta.env.DEV && typedNameTarget && variant !== "destructive") {
+    // eslint-disable-next-line no-console
+    console.error(
+      `[ConfirmDialog] typedNameTarget="${typedNameTarget}" was set with variant="${variant}". The typed-name gate is intended for destructive actions; use variant="destructive".`
+    );
+  }
+
+  const hasTypedNameGate = !!typedNameTarget;
+  const isTypedMatched = !hasTypedNameGate || typedValue === typedNameTarget;
+
+  const handleConfirm = () => {
+    if (hasTypedNameGate && !isTypedMatched) return;
+    return onConfirm();
+  };
+
   return (
     <AppDialog isOpen={isOpen} onClose={handleClose} size="sm" variant={variant} zIndex={zIndex}>
       <AppDialog.Header>
@@ -54,6 +78,16 @@ export function ConfirmDialog({
       <AppDialog.Body className="space-y-3">
         {description && <AppDialog.Description>{description}</AppDialog.Description>}
         {children}
+        {hasTypedNameGate && (
+          <TypedNameConfirmInput
+            target={typedNameTarget}
+            value={typedValue}
+            onChange={setTypedValue}
+            onMatchSubmit={() => {
+              void handleConfirm();
+            }}
+          />
+        )}
       </AppDialog.Body>
 
       <AppDialog.Footer
@@ -64,8 +98,9 @@ export function ConfirmDialog({
         }}
         primaryAction={{
           label: confirmLabel,
-          onClick: onConfirm,
+          onClick: handleConfirm,
           loading: isConfirmLoading,
+          disabled: hasTypedNameGate && !isTypedMatched,
           intent: variant === "destructive" ? "destructive" : "default",
         }}
       />

--- a/src/components/ui/TypedNameConfirmInput.tsx
+++ b/src/components/ui/TypedNameConfirmInput.tsx
@@ -1,0 +1,61 @@
+import type React from "react";
+import { useId } from "react";
+
+export interface TypedNameConfirmInputProps {
+  target: string;
+  value: string;
+  onChange: (value: string) => void;
+  onMatchSubmit?: () => void;
+  instructions?: React.ReactNode;
+  "data-testid"?: string;
+}
+
+export function TypedNameConfirmInput({
+  target,
+  value,
+  onChange,
+  onMatchSubmit,
+  instructions,
+  "data-testid": testId,
+}: TypedNameConfirmInputProps) {
+  const instructionsId = useId();
+  const isMatched = value === target;
+
+  const defaultInstructions = (
+    <>
+      Type{" "}
+      <code className="font-mono text-xs bg-daintree-bg/50 px-1.5 py-0.5 rounded border border-daintree-border">
+        {target}
+      </code>{" "}
+      to confirm.
+    </>
+  );
+
+  return (
+    <div className="space-y-2 p-3 bg-status-error/5 border border-status-error/20 rounded">
+      <p id={instructionsId} className="text-sm text-daintree-text">
+        {instructions ?? defaultInstructions}
+      </p>
+      <input
+        type="text"
+        value={value}
+        onChange={(e) => onChange(e.target.value)}
+        onKeyDown={(e) => {
+          if (e.key === "Enter" && isMatched && onMatchSubmit) {
+            e.preventDefault();
+            onMatchSubmit();
+          }
+        }}
+        aria-describedby={instructionsId}
+        aria-label={`Type ${target} to confirm`}
+        autoComplete="off"
+        spellCheck={false}
+        className="w-full px-3 py-2 text-sm font-mono bg-daintree-bg border border-daintree-border rounded focus:outline-hidden focus:ring-2 focus:ring-status-error"
+        data-testid={testId}
+      />
+      <span className="sr-only" aria-live="polite">
+        {isMatched ? "Name confirmed. You may now confirm." : ""}
+      </span>
+    </div>
+  );
+}

--- a/src/components/ui/__tests__/ConfirmDialog.test.tsx
+++ b/src/components/ui/__tests__/ConfirmDialog.test.tsx
@@ -203,6 +203,25 @@ describe("ConfirmDialog — typed-name gate", () => {
     expect(onConfirm).not.toHaveBeenCalled();
   });
 
+  it("does not call onConfirm when the primary button is clicked while unmatched", () => {
+    const onConfirm = vi.fn();
+    render(
+      <ConfirmDialog
+        isOpen={true}
+        onClose={() => {}}
+        title="Delete repo?"
+        confirmLabel="Delete it"
+        onConfirm={onConfirm}
+        variant="destructive"
+        typedNameTarget="my-repo"
+      />
+    );
+
+    const button = findConfirmButton();
+    fireEvent.click(button);
+    expect(onConfirm).not.toHaveBeenCalled();
+  });
+
   it("submits on Enter when the typed value matches", () => {
     const onConfirm = vi.fn();
     render(

--- a/src/components/ui/__tests__/ConfirmDialog.test.tsx
+++ b/src/components/ui/__tests__/ConfirmDialog.test.tsx
@@ -318,9 +318,9 @@ describe("ConfirmDialog — typed-name gate", () => {
     );
 
     expect(errorSpy).toHaveBeenCalled();
-    const message = errorSpy.mock.calls.map((call) => call[0]).join("\n");
-    expect(message).toContain("typedNameTarget");
-    expect(message).toContain('variant="default"');
+    const firstMessage = String(errorSpy.mock.calls[0]?.[0] ?? "");
+    expect(firstMessage).toContain("typedNameTarget");
+    expect(firstMessage).toContain('variant="default"');
   });
 
   it("is silent for typedNameTarget on a destructive variant", () => {

--- a/src/components/ui/__tests__/ConfirmDialog.test.tsx
+++ b/src/components/ui/__tests__/ConfirmDialog.test.tsx
@@ -1,5 +1,5 @@
 // @vitest-environment jsdom
-import { render } from "@testing-library/react";
+import { cleanup, fireEvent, render, screen } from "@testing-library/react";
 import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
 import { ConfirmDialog } from "../ConfirmDialog";
 
@@ -122,6 +122,216 @@ describe("ConfirmDialog destructive-label dev guard", () => {
         confirmLabel="Delete worktree"
         onConfirm={() => {}}
         variant="default"
+      />
+    );
+
+    expect(errorSpy).not.toHaveBeenCalled();
+  });
+});
+
+describe("ConfirmDialog — typed-name gate", () => {
+  let errorSpy: ReturnType<typeof vi.spyOn>;
+
+  beforeEach(() => {
+    errorSpy = vi.spyOn(console, "error").mockImplementation(() => {});
+    vi.stubGlobal("matchMedia", vi.fn().mockReturnValue({ matches: false }));
+  });
+
+  afterEach(() => {
+    cleanup();
+    errorSpy.mockRestore();
+    vi.unstubAllEnvs();
+  });
+
+  function findConfirmButton() {
+    const buttons = Array.from(document.querySelectorAll("button")) as HTMLButtonElement[];
+    const button = buttons.find((b) => b.textContent?.trim() === "Delete it");
+    if (!button) throw new Error("Confirm button not found");
+    return button;
+  }
+
+  function findTypedInput() {
+    const input = screen.getByLabelText(/^Type .* to confirm$/i) as HTMLInputElement;
+    return input;
+  }
+
+  it("renders the typed-name input and disables confirm until exact match", () => {
+    render(
+      <ConfirmDialog
+        isOpen={true}
+        onClose={() => {}}
+        title="Delete repo?"
+        confirmLabel="Delete it"
+        onConfirm={() => {}}
+        variant="destructive"
+        typedNameTarget="my-repo"
+      />
+    );
+
+    const input = findTypedInput();
+    const button = findConfirmButton();
+
+    expect(input).toBeDefined();
+    expect(button.disabled).toBe(true);
+
+    fireEvent.change(input, { target: { value: "my-rep" } });
+    expect(button.disabled).toBe(true);
+
+    fireEvent.change(input, { target: { value: "My-Repo" } });
+    expect(button.disabled).toBe(true);
+
+    fireEvent.change(input, { target: { value: "my-repo" } });
+    expect(button.disabled).toBe(false);
+  });
+
+  it("does not call onConfirm when primary action is invoked while unmatched", () => {
+    const onConfirm = vi.fn();
+    render(
+      <ConfirmDialog
+        isOpen={true}
+        onClose={() => {}}
+        title="Delete repo?"
+        confirmLabel="Delete it"
+        onConfirm={onConfirm}
+        variant="destructive"
+        typedNameTarget="my-repo"
+      />
+    );
+
+    const input = findTypedInput();
+    fireEvent.keyDown(input, { key: "Enter" });
+    expect(onConfirm).not.toHaveBeenCalled();
+  });
+
+  it("submits on Enter when the typed value matches", () => {
+    const onConfirm = vi.fn();
+    render(
+      <ConfirmDialog
+        isOpen={true}
+        onClose={() => {}}
+        title="Delete repo?"
+        confirmLabel="Delete it"
+        onConfirm={onConfirm}
+        variant="destructive"
+        typedNameTarget="my-repo"
+      />
+    );
+
+    const input = findTypedInput();
+    fireEvent.change(input, { target: { value: "my-repo" } });
+    fireEvent.keyDown(input, { key: "Enter" });
+    expect(onConfirm).toHaveBeenCalledTimes(1);
+  });
+
+  it("resets the typed value when the dialog closes and reopens", () => {
+    const { rerender } = render(
+      <ConfirmDialog
+        isOpen={true}
+        onClose={() => {}}
+        title="Delete repo?"
+        confirmLabel="Delete it"
+        onConfirm={() => {}}
+        variant="destructive"
+        typedNameTarget="my-repo"
+      />
+    );
+
+    const input = findTypedInput();
+    fireEvent.change(input, { target: { value: "my-repo" } });
+    expect(findConfirmButton().disabled).toBe(false);
+
+    rerender(
+      <ConfirmDialog
+        isOpen={false}
+        onClose={() => {}}
+        title="Delete repo?"
+        confirmLabel="Delete it"
+        onConfirm={() => {}}
+        variant="destructive"
+        typedNameTarget="my-repo"
+      />
+    );
+    rerender(
+      <ConfirmDialog
+        isOpen={true}
+        onClose={() => {}}
+        title="Delete repo?"
+        confirmLabel="Delete it"
+        onConfirm={() => {}}
+        variant="destructive"
+        typedNameTarget="my-repo"
+      />
+    );
+
+    const reopenedInput = findTypedInput();
+    expect(reopenedInput.value).toBe("");
+    expect(findConfirmButton().disabled).toBe(true);
+  });
+
+  it("does not render the input or gate the button when typedNameTarget is empty", () => {
+    render(
+      <ConfirmDialog
+        isOpen={true}
+        onClose={() => {}}
+        title="Delete repo?"
+        confirmLabel="Delete it"
+        onConfirm={() => {}}
+        variant="destructive"
+        typedNameTarget=""
+      />
+    );
+
+    expect(screen.queryByLabelText(/^Type .* to confirm$/i)).toBeNull();
+    expect(findConfirmButton().disabled).toBe(false);
+  });
+
+  it("warns in dev when typedNameTarget is set with a non-destructive variant", () => {
+    render(
+      <ConfirmDialog
+        isOpen={true}
+        onClose={() => {}}
+        title="Confirm?"
+        confirmLabel="Continue"
+        onConfirm={() => {}}
+        variant="default"
+        typedNameTarget="thing"
+      />
+    );
+
+    expect(errorSpy).toHaveBeenCalled();
+    const message = errorSpy.mock.calls.map((call) => call[0]).join("\n");
+    expect(message).toContain("typedNameTarget");
+    expect(message).toContain('variant="default"');
+  });
+
+  it("is silent for typedNameTarget on a destructive variant", () => {
+    render(
+      <ConfirmDialog
+        isOpen={true}
+        onClose={() => {}}
+        title="Delete it?"
+        confirmLabel="Delete it"
+        onConfirm={() => {}}
+        variant="destructive"
+        typedNameTarget="thing"
+      />
+    );
+
+    expect(errorSpy).not.toHaveBeenCalled();
+  });
+
+  it("does not warn in production builds", () => {
+    vi.stubEnv("DEV", false);
+
+    render(
+      <ConfirmDialog
+        isOpen={true}
+        onClose={() => {}}
+        title="Confirm?"
+        confirmLabel="Continue"
+        onConfirm={() => {}}
+        variant="default"
+        typedNameTarget="thing"
       />
     );
 


### PR DESCRIPTION
## Summary

- Adds a `TypedNameConfirmInput` primitive and a `typedNameTarget` prop to `ConfirmDialog`, so any destructive flow can gate its primary action on a typed name match without reimplementing the affordance
- Migrates `WorktreeDeleteDialog` to use the primitive (eliminates the bespoke block, preserves all a11y — sr-only live region, `focus:ring-status-error`, Enter-to-submit)
- Gates the Rotate API key dialog on the last-4-char key suffix; adds a DEV sniffer that warns when `typedNameTarget` is used on a non-`destructive` variant

Also fixes a `?? ''` vs `|| fallback` bug in `WorktreeDeleteDialog` where an empty string branch name could pass the strict-match check and bypass the high-tier gate.

Resolves #7485

## Changes

- `src/components/ui/TypedNameConfirmInput.tsx` — new shared primitive (match input, sr-only announcement, error ring, Enter-to-submit)
- `src/components/ui/ConfirmDialog.tsx` — `typedNameTarget` prop, internal typed-name state, reset `useEffect` on close, DEV sniffer, primary-action gate
- `src/components/Worktree/WorktreeDeleteDialog.tsx` — migrated to primitive; `||` fallback fix
- `src/components/Settings/DaintreeAssistantSettingsTab.tsx` — Rotate dialog gated on key suffix; Rotate button disabled until key loads; defensive guard requiring `apiKey.length >= 8` before deriving suffix

## Testing

9 new `ConfirmDialog` gate cases, 1 updated rotate test, 2 new tests for empty-key disabled button and full-key-not-exposed, 1 new `WorktreeDeleteDialog` empty-branch fallback test. 61 tests passing across 3 files. `npm run check` clean.