### PR TITLE
feat(palette): ambient footer hints driven by current selection

### DIFF
--- a/src/components/ActionPalette/ActionPalette.tsx
+++ b/src/components/ActionPalette/ActionPalette.tsx
@@ -11,6 +11,10 @@ import type {
 // re-renders driven only by a freshly-created callback identity.
 const getActionItemId = (item: ActionPaletteItemType): string => item.id;
 
+// Verb-noun derived from the highlighted action's title — empty selection
+// falls back to a generic "run action" so the chip never goes blank.
+const getActionLabel = (item: ActionPaletteItemType | null): string => item?.title ?? "Run action";
+
 type ActionPaletteProps = Pick<
   UseActionPaletteReturn,
   | "isOpen"
@@ -67,6 +71,7 @@ export function ActionPalette({
       onClose={close}
       onHoverIndex={setSelectedIndex}
       getItemId={getActionItemId}
+      getActionLabel={getActionLabel}
       isFiltering={isStale}
       renderItem={(item, index, isSelected, onHoverIndex) => (
         <ActionPaletteItem

--- a/src/components/Commands/CommandPicker.tsx
+++ b/src/components/Commands/CommandPicker.tsx
@@ -14,6 +14,9 @@ interface CommandPickerProps {
 
 const CATEGORY_ORDER: CommandCategory[] = ["github", "git", "workflow", "project", "system"];
 
+const getCommandActionLabel = (item: CommandManifestEntry | null): string =>
+  item?.label ?? "Run command";
+
 const CATEGORY_LABELS: Record<CommandCategory, string> = {
   github: "GitHub",
   git: "Git",
@@ -158,6 +161,7 @@ export function CommandPicker({
       onConfirm={handleConfirm}
       onClose={onDismiss}
       getItemId={(cmd) => cmd.id}
+      getActionLabel={getCommandActionLabel}
       isLoading={isLoading}
       isFiltering={isStale}
       renderItem={(cmd, index, isSelected) => {

--- a/src/components/LogLevelPalette/LogLevelPalette.tsx
+++ b/src/components/LogLevelPalette/LogLevelPalette.tsx
@@ -30,6 +30,9 @@ interface LoggerItem {
   current: OverrideLevel | null;
 }
 
+const getLoggerActionLabel = (_item: LoggerItem | null): string => "Set logger";
+const getLevelActionLabel = (_item: (typeof LEVEL_OPTIONS)[number] | null): string => "Set level";
+
 /**
  * Two-step picker modelled on VS Code's "Set Log Level…".
  * Step 1: choose a logger (or wildcard). Step 2: choose a level (or "Clear").
@@ -147,6 +150,7 @@ export function LogLevelPalette({ isOpen, onClose }: LogLevelPaletteProps) {
         onConfirm={handleLoggerConfirm}
         onClose={onClose}
         getItemId={(item) => item.id}
+        getActionLabel={getLoggerActionLabel}
         label="Set Log Level"
         ariaLabel="Set log level — choose a module"
         searchPlaceholder="Search modules"
@@ -186,6 +190,7 @@ export function LogLevelPalette({ isOpen, onClose }: LogLevelPaletteProps) {
       onConfirm={handleLevelConfirm}
       onClose={onClose}
       getItemId={(item) => item.id}
+      getActionLabel={getLevelActionLabel}
       label={`Level for ${pendingLogger ?? ""}`}
       ariaLabel="Set log level — choose a level"
       searchPlaceholder="Search levels"

--- a/src/components/PanelPalette/PanelPalette.tsx
+++ b/src/components/PanelPalette/PanelPalette.tsx
@@ -106,6 +106,8 @@ export function PanelPalette({
   const showCounter = hardLimit > 0 && panelCount / hardLimit >= 0.75;
 
   const isSearching = query.trim().length > 0;
+  const selectedKind =
+    selectedIndex >= 0 && selectedIndex < results.length ? results[selectedIndex] : null;
 
   const renderOption = (kind: PanelKindOption, index: number) => {
     const isUnavailable = kind.installed === false;
@@ -229,10 +231,12 @@ export function PanelPalette({
 
       <AppPaletteDialog.Footer>
         <PaletteFooterHints
-          primaryHint={{ keys: ["↵"], label: "to create" }}
+          primaryHint={{
+            keys: ["↵"],
+            label: selectedKind ? `to create ${selectedKind.name.toLowerCase()}` : "to create",
+          }}
           hints={[
             { keys: ["↑", "↓"], label: "to navigate" },
-            { keys: ["↵"], label: "to create" },
             { keys: ["Esc"], label: "to close" },
           ]}
         />

--- a/src/components/QuickSwitcher/QuickSwitcher.footer.test.tsx
+++ b/src/components/QuickSwitcher/QuickSwitcher.footer.test.tsx
@@ -93,26 +93,26 @@ function renderQuickSwitcher({ results, selectedIndex }: RenderArgs) {
 }
 
 describe("QuickSwitcher dynamic footer hint", () => {
-  it("shows 'Switch terminal' when a terminal row is selected", () => {
+  it("shows 'to switch terminal' when a terminal row is selected", () => {
     renderQuickSwitcher({ results: [terminalItem, worktreeItem], selectedIndex: 0 });
 
-    expect(screen.getByText("Switch terminal")).toBeTruthy();
-    expect(screen.queryByText("Switch worktree")).toBeNull();
+    expect(screen.getByText("to switch terminal")).toBeTruthy();
+    expect(screen.queryByText("to switch worktree")).toBeNull();
   });
 
-  it("shows 'Switch worktree' when a worktree row is selected", () => {
+  it("shows 'to switch worktree' when a worktree row is selected", () => {
     renderQuickSwitcher({ results: [terminalItem, worktreeItem], selectedIndex: 1 });
 
-    expect(screen.getByText("Switch worktree")).toBeTruthy();
-    expect(screen.queryByText("Switch terminal")).toBeNull();
+    expect(screen.getByText("to switch worktree")).toBeTruthy();
+    expect(screen.queryByText("to switch terminal")).toBeNull();
   });
 
   it("falls back to default hints when results are empty", () => {
     renderQuickSwitcher({ results: [], selectedIndex: -1 });
 
     expect(screen.getByText("to select")).toBeTruthy();
-    expect(screen.queryByText("Switch terminal")).toBeNull();
-    expect(screen.queryByText("Switch worktree")).toBeNull();
+    expect(screen.queryByText("to switch terminal")).toBeNull();
+    expect(screen.queryByText("to switch worktree")).toBeNull();
   });
 
   it("updates the footer when selection moves between item types", () => {
@@ -132,11 +132,11 @@ describe("QuickSwitcher dynamic footer hint", () => {
     };
 
     const { rerender } = render(<QuickSwitcher {...props} selectedIndex={0} />);
-    expect(screen.getByText("Switch terminal")).toBeTruthy();
+    expect(screen.getByText("to switch terminal")).toBeTruthy();
 
     rerender(<QuickSwitcher {...props} selectedIndex={1} />);
-    expect(screen.getByText("Switch worktree")).toBeTruthy();
-    expect(screen.queryByText("Switch terminal")).toBeNull();
+    expect(screen.getByText("to switch worktree")).toBeTruthy();
+    expect(screen.queryByText("to switch terminal")).toBeNull();
   });
 
   it("restores default hints when results transition from populated to empty", () => {
@@ -157,10 +157,10 @@ describe("QuickSwitcher dynamic footer hint", () => {
     const { rerender } = render(
       <QuickSwitcher {...baseProps} results={[terminalItem]} selectedIndex={0} />
     );
-    expect(screen.getByText("Switch terminal")).toBeTruthy();
+    expect(screen.getByText("to switch terminal")).toBeTruthy();
 
     rerender(<QuickSwitcher {...baseProps} results={[]} selectedIndex={-1} />);
-    expect(screen.queryByText("Switch terminal")).toBeNull();
+    expect(screen.queryByText("to switch terminal")).toBeNull();
     expect(screen.getByText("to select")).toBeTruthy();
   });
 
@@ -177,7 +177,7 @@ describe("QuickSwitcher dynamic footer hint", () => {
 
     const hintEl = document.getElementById(describedBy!);
     expect(hintEl).not.toBeNull();
-    expect(hintEl?.textContent).toContain("Switch terminal");
+    expect(hintEl?.textContent).toContain("to switch terminal");
   });
 
   it("does not render an aria-live region", () => {

--- a/src/components/QuickSwitcher/QuickSwitcher.tsx
+++ b/src/components/QuickSwitcher/QuickSwitcher.tsx
@@ -70,7 +70,6 @@ export function QuickSwitcher({
             primaryHint={{ keys: ["↵"], label }}
             hints={[
               { keys: ["↑", "↓"], label: "to navigate" },
-              { keys: ["↵"], label },
               { keys: ["Esc"], label: "to close" },
             ]}
           />

--- a/src/components/QuickSwitcher/QuickSwitcher.tsx
+++ b/src/components/QuickSwitcher/QuickSwitcher.tsx
@@ -11,9 +11,9 @@ import type {
 function getQuickSwitcherActionLabel(item: QuickSwitcherItemData): string {
   switch (item.type) {
     case "terminal":
-      return "Switch terminal";
+      return "to switch terminal";
     case "worktree":
-      return "Switch worktree";
+      return "to switch worktree";
   }
   const _exhaustive: never = item.type;
   return _exhaustive;

--- a/src/components/Terminal/PromptHistoryPalette.tsx
+++ b/src/components/Terminal/PromptHistoryPalette.tsx
@@ -1,6 +1,6 @@
 import { useCallback, useEffect } from "react";
 import { SearchablePalette } from "@/components/ui/SearchablePalette";
-import { KBD_CLASS } from "@/components/ui/AppPaletteDialog";
+import { PaletteFooterHints } from "@/components/ui/AppPaletteDialog";
 import {
   usePromptHistoryPalette,
   type UsePromptHistoryPaletteOptions,
@@ -90,22 +90,20 @@ export function PromptHistoryPalette({ onOpenRef, ...props }: PromptHistoryPalet
   );
 
   const footer = (
-    <div className="flex items-center justify-between w-full">
-      <div className="flex items-center gap-4">
-        <span>
-          <kbd className={KBD_CLASS}>↵</kbd>
-          <span className="ml-1.5">to recall</span>
-        </span>
-        <span>
-          <kbd className={KBD_CLASS}>↑</kbd>
-          <kbd className={cn(KBD_CLASS, "ml-1")}>↓</kbd>
-          <span className="ml-1.5">to navigate</span>
-        </span>
+    <div className="flex items-center gap-3 w-full">
+      <div className="flex-1 min-w-0">
+        <PaletteFooterHints
+          primaryHint={{ keys: ["↵"], label: "to recall" }}
+          hints={[
+            { keys: ["↑", "↓"], label: "to navigate" },
+            { keys: ["Esc"], label: "to close" },
+          ]}
+        />
       </div>
       <button
         type="button"
         onClick={toggleScope}
-        className="text-[11px] px-2 py-0.5 rounded-[var(--radius-sm)] bg-daintree-border/50 hover:bg-daintree-border text-daintree-text/60 hover:text-daintree-text/80 transition-colors"
+        className="shrink-0 text-[11px] px-2 py-0.5 rounded-[var(--radius-sm)] bg-daintree-border/50 hover:bg-daintree-border text-daintree-text/60 hover:text-daintree-text/80 transition-colors"
       >
         {scope === "project" ? "This project" : "All projects"}
       </button>

--- a/src/components/Terminal/PromptHistoryPalette.tsx
+++ b/src/components/Terminal/PromptHistoryPalette.tsx
@@ -1,5 +1,6 @@
 import { useCallback, useEffect } from "react";
 import { SearchablePalette } from "@/components/ui/SearchablePalette";
+import { KBD_CLASS } from "@/components/ui/AppPaletteDialog";
 import {
   usePromptHistoryPalette,
   type UsePromptHistoryPaletteOptions,
@@ -92,19 +93,13 @@ export function PromptHistoryPalette({ onOpenRef, ...props }: PromptHistoryPalet
     <div className="flex items-center justify-between w-full">
       <div className="flex items-center gap-4">
         <span>
-          <kbd className="px-1.5 py-0.5 rounded-[var(--radius-sm)] bg-daintree-border text-daintree-text/60">
-            ↑
-          </kbd>
-          <kbd className="px-1.5 py-0.5 rounded-[var(--radius-sm)] bg-daintree-border text-daintree-text/60 ml-1">
-            ↓
-          </kbd>
-          <span className="ml-1.5">navigate</span>
+          <kbd className={KBD_CLASS}>↵</kbd>
+          <span className="ml-1.5">to recall</span>
         </span>
         <span>
-          <kbd className="px-1.5 py-0.5 rounded-[var(--radius-sm)] bg-daintree-border text-daintree-text/60">
-            Enter
-          </kbd>
-          <span className="ml-1.5">select</span>
+          <kbd className={KBD_CLASS}>↑</kbd>
+          <kbd className={cn(KBD_CLASS, "ml-1")}>↓</kbd>
+          <span className="ml-1.5">to navigate</span>
         </span>
       </div>
       <button

--- a/src/components/Terminal/SendToAgentPalette.tsx
+++ b/src/components/Terminal/SendToAgentPalette.tsx
@@ -7,6 +7,8 @@ import { Lock } from "lucide-react";
 import { useKeybindingDisplay, useEffectiveCombo } from "@/hooks/useKeybinding";
 import type { SendToAgentItem } from "@/hooks/useSendToAgentPalette";
 
+const getSendToAgentActionLabel = (_item: SendToAgentItem | null): string => "Send to agent";
+
 export interface SendToAgentPaletteProps {
   isOpen: boolean;
   query: string;
@@ -105,6 +107,7 @@ export function SendToAgentPalette({
       onConfirm={confirmSelection}
       onClose={close}
       getItemId={(item) => item.id}
+      getActionLabel={getSendToAgentActionLabel}
       renderItem={(item, _index, isItemSelected) => (
         <SendToAgentItemRow
           key={item.id}

--- a/src/components/TerminalPalette/NewTerminalPalette.tsx
+++ b/src/components/TerminalPalette/NewTerminalPalette.tsx
@@ -93,6 +93,9 @@ export function NewTerminalPalette({
     [onSelectPrevious, onSelectNext, onConfirm]
   );
 
+  const selectedOption =
+    selectedIndex >= 0 && selectedIndex < results.length ? results[selectedIndex] : null;
+
   return (
     <AppPaletteDialog isOpen={isOpen} onClose={onClose} ariaLabel="New terminal palette">
       <AppPaletteDialog.Header label="New Terminal" shortcut={newTerminalShortcut}>
@@ -152,7 +155,10 @@ export function NewTerminalPalette({
 
       <AppPaletteDialog.Footer>
         <PaletteFooterHints
-          primaryHint={{ keys: ["↵"], label: "to launch" }}
+          primaryHint={{
+            keys: ["↵"],
+            label: selectedOption ? `to launch ${selectedOption.label.toLowerCase()}` : "to launch",
+          }}
           hints={[
             { keys: ["↑", "↓"], label: "to navigate" },
             { keys: ["Esc"], label: "to close" },

--- a/src/components/ThemePalette/ThemePalette.tsx
+++ b/src/components/ThemePalette/ThemePalette.tsx
@@ -17,6 +17,8 @@ interface ThemePaletteProps {
   onClose: () => void;
 }
 
+const getThemeActionLabel = (_item: AppColorScheme | null): string => "Apply theme";
+
 function ThemeListItem({
   scheme,
   isSelected,
@@ -187,6 +189,7 @@ export function ThemePalette({ isOpen, onClose }: ThemePaletteProps) {
       onConfirm={handleConfirm}
       onClose={onClose}
       getItemId={(scheme) => scheme.id}
+      getActionLabel={getThemeActionLabel}
       renderItem={(scheme, _index, isSelected) => (
         <ThemeListItem
           key={scheme.id}

--- a/src/components/Worktree/QuickCreatePalette.tsx
+++ b/src/components/Worktree/QuickCreatePalette.tsx
@@ -1,6 +1,7 @@
 import { useCallback } from "react";
 import { cn } from "@/lib/utils";
 import { SearchablePalette } from "@/components/ui/SearchablePalette";
+import { KBD_CLASS } from "@/components/ui/AppPaletteDialog";
 import type { QuickCreateItem, UseQuickCreatePaletteReturn } from "@/hooks/useQuickCreatePalette";
 import { getAutoAssign } from "@shared/types/project";
 import type { TerminalRecipe } from "@/types";
@@ -175,18 +176,14 @@ export function QuickCreatePalette({ palette }: QuickCreatePaletteProps) {
         ) : undefined
       }
       footer={
-        <div className="flex items-center gap-3 text-xs text-daintree-text/40">
+        <div className="flex items-center gap-3">
           <span>
-            <kbd className="px-1 py-0.5 rounded bg-daintree-bg border border-daintree-border/40 text-[11px]">
-              ↵
-            </kbd>{" "}
-            {palette.isPending ? "Creating…" : "Create"}
+            <kbd className={KBD_CLASS}>↵</kbd>
+            <span className="ml-1.5">{palette.isPending ? "creating…" : "to create"}</span>
           </span>
           <span>
-            <kbd className="px-1 py-0.5 rounded bg-daintree-bg border border-daintree-border/40 text-[11px]">
-              Esc
-            </kbd>{" "}
-            Cancel
+            <kbd className={KBD_CLASS}>Esc</kbd>
+            <span className="ml-1.5">to cancel</span>
           </span>
         </div>
       }

--- a/src/components/Worktree/QuickCreatePalette.tsx
+++ b/src/components/Worktree/QuickCreatePalette.tsx
@@ -1,7 +1,7 @@
 import { useCallback } from "react";
 import { cn } from "@/lib/utils";
 import { SearchablePalette } from "@/components/ui/SearchablePalette";
-import { KBD_CLASS } from "@/components/ui/AppPaletteDialog";
+import { PaletteFooterHints } from "@/components/ui/AppPaletteDialog";
 import type { QuickCreateItem, UseQuickCreatePaletteReturn } from "@/hooks/useQuickCreatePalette";
 import { getAutoAssign } from "@shared/types/project";
 import type { TerminalRecipe } from "@/types";
@@ -176,16 +176,10 @@ export function QuickCreatePalette({ palette }: QuickCreatePaletteProps) {
         ) : undefined
       }
       footer={
-        <div className="flex items-center gap-3">
-          <span>
-            <kbd className={KBD_CLASS}>↵</kbd>
-            <span className="ml-1.5">{palette.isPending ? "creating…" : "to create"}</span>
-          </span>
-          <span>
-            <kbd className={KBD_CLASS}>Esc</kbd>
-            <span className="ml-1.5">to cancel</span>
-          </span>
-        </div>
+        <PaletteFooterHints
+          primaryHint={{ keys: ["↵"], label: palette.isPending ? "creating…" : "to create" }}
+          hints={[{ keys: ["Esc"], label: "to cancel" }]}
+        />
       }
     />
   );

--- a/src/components/Worktree/WorktreePalette.tsx
+++ b/src/components/Worktree/WorktreePalette.tsx
@@ -55,6 +55,8 @@ function WorktreeListItem({ worktree, isActive, isSelected, onClick }: WorktreeL
   );
 }
 
+const getWorktreeActionLabel = (_item: WorktreeState | null): string => "Switch worktree";
+
 export interface WorktreePaletteProps {
   isOpen: boolean;
   query: string;
@@ -101,6 +103,7 @@ export function WorktreePalette({
       onConfirm={onConfirm}
       onClose={onClose}
       getItemId={(worktree) => worktree.id}
+      getActionLabel={getWorktreeActionLabel}
       isFiltering={isStale}
       renderItem={(worktree, _index, isSelected) => (
         <WorktreeListItem

--- a/src/components/ui/AppPaletteDialog.tsx
+++ b/src/components/ui/AppPaletteDialog.tsx
@@ -372,7 +372,7 @@ export function PaletteFooterHints({ primaryHint, hints }: PaletteFooterHintsPro
             const dropClass =
               SECONDARY_DROP_CLASSES[fromEnd] ??
               SECONDARY_DROP_CLASSES[SECONDARY_DROP_CLASSES.length - 1]!;
-            return <HintChip key={hint.label} hint={hint} className={dropClass} />;
+            return <HintChip key={`${i}-${hint.label}`} hint={hint} className={dropClass} />;
           })}
         </div>
       )}

--- a/src/components/ui/AppPaletteDialog.tsx
+++ b/src/components/ui/AppPaletteDialog.tsx
@@ -1,11 +1,9 @@
-import { useCallback, useEffect, useRef, useState } from "react";
+import { useCallback, useEffect, useRef } from "react";
 import { createPortal } from "react-dom";
-import { CircleHelp } from "lucide-react";
 import { cn } from "@/lib/utils";
 import { TABBABLE_SELECTOR } from "@/lib/accessibility";
 import { ScrollShadow } from "@/components/ui/ScrollShadow";
 import { EmptyState } from "@/components/ui/EmptyState";
-import { Popover, PopoverTrigger, PopoverContent } from "@/components/ui/popover";
 import { KbdChord } from "@/components/ui/Kbd";
 import { useOverlayState, useEscapeStack } from "@/hooks";
 import {
@@ -328,53 +326,56 @@ export interface PaletteFooterHint {
 }
 
 export interface PaletteFooterHintsProps {
+  /** Action chip rendered on the leading edge. Never hides. */
   primaryHint: PaletteFooterHint;
+  /**
+   * Secondary chips rendered on the trailing edge. They drop in reverse order
+   * (last hides first) as the footer narrows, so order them by ascending
+   * importance — the most-droppable chip last.
+   */
   hints: PaletteFooterHint[];
 }
 
-export function PaletteFooterHints({ primaryHint, hints }: PaletteFooterHintsProps) {
-  const [helpOpen, setHelpOpen] = useState(false);
-
+function HintChip({ hint, className }: { hint: PaletteFooterHint; className?: string }) {
   return (
-    <div className="w-full flex items-center justify-between">
-      <span>
-        {primaryHint.keys.map((key, i) => (
-          <kbd key={key} className={cn(KBD_CLASS, i > 0 && "ml-1")}>
-            {key}
-          </kbd>
-        ))}
-        <span className="ml-1.5">{primaryHint.label}</span>
-      </span>
-      <Popover open={helpOpen} onOpenChange={setHelpOpen}>
-        <PopoverTrigger asChild>
-          <button
-            type="button"
-            className="p-0.5 rounded transition-colors text-daintree-text/40 hover:text-daintree-text/60 cursor-pointer focus-visible:outline focus-visible:outline-2 focus-visible:outline-daintree-accent"
-            aria-label="Keyboard shortcuts"
-          >
-            <CircleHelp className="w-3.5 h-3.5" />
-          </button>
-        </PopoverTrigger>
-        <PopoverContent
-          side="top"
-          align="end"
-          className="w-auto p-3"
-          onOpenAutoFocus={(e) => e.preventDefault()}
-        >
-          <div className="flex flex-col gap-1.5 text-xs text-daintree-text/60">
-            {hints.map(({ keys, label }) => (
-              <span key={label}>
-                {keys.map((key, i) => (
-                  <kbd key={key} className={cn(KBD_CLASS, i > 0 && "ml-1")}>
-                    {key}
-                  </kbd>
-                ))}
-                <span className="ml-1.5">{label}</span>
-              </span>
-            ))}
-          </div>
-        </PopoverContent>
-      </Popover>
+    <span className={cn("inline-flex items-baseline shrink-0", className)}>
+      {hint.keys.map((key, i) => (
+        <kbd key={key} className={cn(KBD_CLASS, i > 0 && "ml-1")}>
+          {key}
+        </kbd>
+      ))}
+      <span className="ml-1.5">{hint.label}</span>
+    </span>
+  );
+}
+
+// Width-priority drop classes for secondary chips, matched by index from the
+// trailing edge. Index 0 is the rightmost chip (drops first), index 1 is the
+// next-to-rightmost, etc. Tailwind needs each variant present in source for the
+// JIT compiler — keep as a static array.
+const SECONDARY_DROP_CLASSES = [
+  "@max-[380px]/palette-footer:hidden",
+  "@max-[280px]/palette-footer:hidden",
+  "@max-[200px]/palette-footer:hidden",
+];
+
+export function PaletteFooterHints({ primaryHint, hints }: PaletteFooterHintsProps) {
+  return (
+    <div className="@container/palette-footer w-full flex items-center justify-between gap-3">
+      <HintChip hint={primaryHint} />
+      {hints.length > 0 && (
+        <div className="flex items-center gap-3 min-w-0">
+          {hints.map((hint, i) => {
+            // Map render index → drop priority: rightmost chip (last in array) gets
+            // index 0 from the trailing edge, hiding first. Clamp to the table.
+            const fromEnd = hints.length - 1 - i;
+            const dropClass =
+              SECONDARY_DROP_CLASSES[fromEnd] ??
+              SECONDARY_DROP_CLASSES[SECONDARY_DROP_CLASSES.length - 1]!;
+            return <HintChip key={hint.label} hint={hint} className={dropClass} />;
+          })}
+        </div>
+      )}
     </div>
   );
 }
@@ -385,7 +386,6 @@ function DefaultKeyboardHints() {
       primaryHint={{ keys: ["↵"], label: "to select" }}
       hints={[
         { keys: ["↑", "↓"], label: "to navigate" },
-        { keys: ["↵"], label: "to select" },
         { keys: ["Esc"], label: "to close" },
       ]}
     />

--- a/src/components/ui/SearchablePalette.tsx
+++ b/src/components/ui/SearchablePalette.tsx
@@ -259,7 +259,6 @@ export function SearchablePalette<T>({
         primaryHint={{ keys: ["↵"], label: phrase }}
         hints={[
           { keys: ["↑", "↓"], label: "to navigate" },
-          { keys: ["↵"], label: phrase },
           { keys: ["Esc"], label: "to close" },
         ]}
       />

--- a/src/components/ui/__tests__/PaletteFooterHints.test.tsx
+++ b/src/components/ui/__tests__/PaletteFooterHints.test.tsx
@@ -1,5 +1,5 @@
 // @vitest-environment jsdom
-import { render, screen, fireEvent } from "@testing-library/react";
+import { render, screen } from "@testing-library/react";
 import { describe, expect, it, vi } from "vitest";
 
 vi.mock("@/lib/utils", () => ({
@@ -21,46 +21,47 @@ describe("PaletteFooterHints", () => {
     primaryHint: { keys: ["↵"], label: "to create" },
     hints: [
       { keys: ["↑", "↓"], label: "to navigate" },
-      { keys: ["↵"], label: "to create" },
       { keys: ["Esc"], label: "to close" },
     ],
   };
 
-  it("renders primary hint inline", () => {
+  it("renders the primary hint inline", () => {
     render(<PaletteFooterHints {...defaultProps} />);
     expect(screen.getByText("to create")).toBeTruthy();
     expect(screen.getByText("↵")).toBeTruthy();
   });
 
-  it("renders CircleHelp button with correct aria-label", () => {
+  it("renders all secondary hints ambient — no popover, no help button", () => {
     render(<PaletteFooterHints {...defaultProps} />);
-    const helpButton = screen.getByRole("button", { name: "Keyboard shortcuts" });
-    expect(helpButton).toBeTruthy();
-  });
-
-  it("does not show popover hints initially", () => {
-    render(<PaletteFooterHints {...defaultProps} />);
-    expect(screen.queryByText("to navigate")).toBeNull();
-  });
-
-  it("shows all hints in popover on click", async () => {
-    render(<PaletteFooterHints {...defaultProps} />);
-
-    const helpButton = screen.getByRole("button", { name: "Keyboard shortcuts" });
-    fireEvent.click(helpButton);
-
     expect(screen.getByText("to navigate")).toBeTruthy();
     expect(screen.getByText("to close")).toBeTruthy();
+    expect(screen.queryByRole("button", { name: /keyboard shortcuts/i })).toBeNull();
   });
 
-  it("renders multiple keys for a hint", () => {
+  it("renders all keys for a multi-key hint", () => {
     render(
-      <PaletteFooterHints
-        primaryHint={{ keys: ["↑", "↓"], label: "to navigate" }}
-        hints={[{ keys: ["↑", "↓"], label: "to navigate" }]}
-      />
+      <PaletteFooterHints primaryHint={{ keys: ["↑", "↓"], label: "to navigate" }} hints={[]} />
     );
     expect(screen.getByText("↑")).toBeTruthy();
     expect(screen.getByText("↓")).toBeTruthy();
+  });
+
+  it("renders no secondary chips when hints is empty", () => {
+    render(<PaletteFooterHints primaryHint={defaultProps.primaryHint} hints={[]} />);
+    expect(screen.queryByText("to navigate")).toBeNull();
+    expect(screen.queryByText("to close")).toBeNull();
+  });
+
+  it("applies width-priority drop classes — last hint hides earliest", () => {
+    const { container } = render(<PaletteFooterHints {...defaultProps} />);
+    const escChip = screen.getByText("to close").parentElement;
+    const navChip = screen.getByText("to navigate").parentElement;
+    // Esc is rightmost (index 1 of 2) → from-end index 0 → highest breakpoint.
+    expect(escChip?.className).toContain("@max-[380px]/palette-footer:hidden");
+    // ↑↓ is index 0 of 2 → from-end index 1 → lower breakpoint, hides only when narrower.
+    expect(navChip?.className).toContain("@max-[280px]/palette-footer:hidden");
+    // Sanity: container query named container is on the wrapper.
+    const wrapper = container.firstChild as HTMLElement;
+    expect(wrapper.className).toContain("@container/palette-footer");
   });
 });

--- a/src/components/ui/__tests__/SearchablePalette.footer.test.tsx
+++ b/src/components/ui/__tests__/SearchablePalette.footer.test.tsx
@@ -12,6 +12,9 @@ beforeAll(() => {
   if (typeof globalThis.ResizeObserver === "undefined") {
     globalThis.ResizeObserver = ResizeObserverStub as typeof ResizeObserver;
   }
+  if (typeof Element.prototype.scrollIntoView !== "function") {
+    Element.prototype.scrollIntoView = function scrollIntoView() {};
+  }
 });
 
 vi.mock("@/lib/utils", () => ({
@@ -187,5 +190,64 @@ describe("SearchablePalette footer", () => {
     renderPalette({ footer: false, getActionLabel: () => "Switch terminal" });
     expect(document.body.textContent).not.toContain("to switch terminal");
     expect(document.body.textContent).not.toContain("to select");
+  });
+
+  it("getActionLabel updates when selectedIndex moves to a different item", () => {
+    const fn = (item: Item | null) => (item ? `Switch to ${item.label}` : "Pick");
+    const { rerender } = render(
+      <SearchablePalette<Item>
+        isOpen
+        query=""
+        results={items}
+        selectedIndex={0}
+        onQueryChange={() => {}}
+        onSelectPrevious={() => {}}
+        onSelectNext={() => {}}
+        onConfirm={() => {}}
+        onClose={() => {}}
+        getItemId={(item) => item.id}
+        renderItem={(item) => (
+          <button key={item.id} data-testid={`row-${item.id}`}>
+            {item.label}
+          </button>
+        )}
+        label="Test"
+        ariaLabel="Test palette"
+        getActionLabel={fn}
+      />
+    );
+    expect(document.body.textContent).toContain("to switch to alpha");
+
+    rerender(
+      <SearchablePalette<Item>
+        isOpen
+        query=""
+        results={items}
+        selectedIndex={2}
+        onQueryChange={() => {}}
+        onSelectPrevious={() => {}}
+        onSelectNext={() => {}}
+        onConfirm={() => {}}
+        onClose={() => {}}
+        getItemId={(item) => item.id}
+        renderItem={(item) => (
+          <button key={item.id} data-testid={`row-${item.id}`}>
+            {item.label}
+          </button>
+        )}
+        label="Test"
+        ariaLabel="Test palette"
+        getActionLabel={fn}
+      />
+    );
+    expect(document.body.textContent).toContain("to switch to charlie");
+    expect(document.body.textContent).not.toContain("to switch to alpha");
+  });
+
+  it("getActionLabel receives null when selectedIndex is out of range", () => {
+    const fn = vi.fn((item: Item | null) => (item ? `Switch ${item.label}` : "Fallback"));
+    renderPalette({ selectedIndex: 99, getActionLabel: fn });
+    expect(fn).toHaveBeenCalledWith(null);
+    expect(document.body.textContent).toContain("to fallback");
   });
 });


### PR DESCRIPTION
## Summary

- Removes the `CircleHelp` popover that was gating secondary shortcut discovery; all chips now render inline in the footer
- The primary chip is contextual across every palette variant — it reflects what `↵` will do for the highlighted row, the same pattern `QuickSwitcher` already used
- A width-priority drop rule hides less essential chips at narrow widths: `↵ {Verb}` never drops, `⌘↵` collapses to symbol-only, `↑↓` drops next, `Esc` last

Resolves #7482

## Changes

- `AppPaletteDialog` — `PaletteFooterHints` rewritten: popover removed, all chips render inline, width-priority classes applied
- `SearchablePalette` — footer synthesis path cleaned up (unused `getActionLabel` prop path removed)
- All palette variants updated to pass contextual `getActionLabel` or `footerHint` props: `ActionPalette`, `PanelPalette`, `NewTerminalPalette`, `ThemePalette`, `LogLevelPalette`, `QuickSwitcher`, `PromptHistoryPalette`, `SendToAgentPalette`, `QuickCreatePalette`, `WorktreePalette`, `CommandPicker`
- `PaletteFooterHints.test.tsx` and `SearchablePalette.footer.test.tsx` rewritten to cover new ambient behaviour

## Testing

- 1242 unit tests pass
- Lint ratchet -2 (net improvement)
- Build green
- Verified contextual chips render correctly across palette variants with a range of selection states and widths