### PR TITLE
fix(worktree): tighten copy in delete confirm dialog

### DIFF
--- a/src/components/Worktree/WorktreeDeleteDialog.tsx
+++ b/src/components/Worktree/WorktreeDeleteDialog.tsx
@@ -98,7 +98,7 @@ export function WorktreeDeleteDialog({ isOpen, onClose, worktree }: WorktreeDele
     }
   };
 
-  const deleteButtonLabel = isHighTier ? `Delete '${confirmTarget}'` : "Delete worktree";
+  const deleteButtonLabel = "Delete worktree";
 
   return (
     <AppDialog
@@ -143,9 +143,11 @@ export function WorktreeDeleteDialog({ isOpen, onClose, worktree }: WorktreeDele
                   </span>
                 </>
               )}
-              .{closeTerminals && hasTerminals && " All associated terminals will be closed."}
-              {hasChanges &&
-                " Uncommitted changes will be lost unless the worktree is first restored from git."}
+              .
+              {closeTerminals &&
+                hasTerminals &&
+                ` ${terminalCounts.total} terminal${terminalCounts.total === 1 ? "" : "s"} will be closed.`}
+              {hasChanges && " Uncommitted changes will be lost."}
               {" This cannot be undone."}
             </p>
 

--- a/src/components/Worktree/__tests__/WorktreeDeleteDialog.test.tsx
+++ b/src/components/Worktree/__tests__/WorktreeDeleteDialog.test.tsx
@@ -230,6 +230,57 @@ describe("WorktreeDeleteDialog — body copy", () => {
     const body = screen.getByText(/This will permanently delete the worktree directory/);
     expect(body.textContent).toMatch(/This cannot be undone\.$/);
   });
+
+  it("uses singular 'terminal' when one terminal is associated", () => {
+    terminalCountsMock.total = 1;
+    const worktree = makeWorktree(makeChanges([]));
+    render(<WorktreeDeleteDialog isOpen={true} onClose={vi.fn()} worktree={worktree} />);
+
+    const body = screen.getByText(/This will permanently delete the worktree directory/);
+    expect(body.textContent).toContain("1 terminal will be closed.");
+    expect(body.textContent).not.toContain("1 terminals");
+  });
+
+  it("uses plural 'terminals' when multiple terminals are associated", () => {
+    terminalCountsMock.total = 3;
+    const worktree = makeWorktree(makeChanges([]));
+    render(<WorktreeDeleteDialog isOpen={true} onClose={vi.fn()} worktree={worktree} />);
+
+    const body = screen.getByText(/This will permanently delete the worktree directory/);
+    expect(body.textContent).toContain("3 terminals will be closed.");
+  });
+
+  it("omits the terminal sentence when no terminals are associated", () => {
+    terminalCountsMock.total = 0;
+    const worktree = makeWorktree(makeChanges([]));
+    render(<WorktreeDeleteDialog isOpen={true} onClose={vi.fn()} worktree={worktree} />);
+
+    const body = screen.getByText(/This will permanently delete the worktree directory/);
+    expect(body.textContent).not.toMatch(/terminals? will be closed/);
+  });
+
+  it("omits the terminal sentence when closeTerminals is unchecked", () => {
+    terminalCountsMock.total = 2;
+    const worktree = makeWorktree(makeChanges([]));
+    render(<WorktreeDeleteDialog isOpen={true} onClose={vi.fn()} worktree={worktree} />);
+
+    const closeTerminalsCheckbox = screen.getByRole("checkbox", {
+      name: /close all terminals/i,
+    });
+    fireEvent.click(closeTerminalsCheckbox);
+
+    const body = screen.getByText(/This will permanently delete the worktree directory/);
+    expect(body.textContent).not.toMatch(/terminals? will be closed/);
+  });
+
+  it("states 'Uncommitted changes will be lost.' without the git-restore hint", () => {
+    const worktree = makeWorktree(makeChanges([{ path: "src/app.ts", status: "modified" }]));
+    render(<WorktreeDeleteDialog isOpen={true} onClose={vi.fn()} worktree={worktree} />);
+
+    const body = screen.getByText(/This will permanently delete the worktree directory/);
+    expect(body.textContent).toContain("Uncommitted changes will be lost.");
+    expect(body.textContent).not.toContain("restored from git");
+  });
 });
 
 describe("WorktreeDeleteDialog — medium tier (no name confirmation)", () => {
@@ -314,7 +365,7 @@ describe("WorktreeDeleteDialog — high tier (name confirmation)", () => {
 
     expect(screen.getByTestId("delete-worktree-confirm-input")).toBeDefined();
     const button = screen.getByTestId("delete-worktree-confirm") as HTMLButtonElement;
-    expect(button.textContent).toBe("Delete 'main'");
+    expect(button.textContent).toBe("Delete worktree");
     expect(button.disabled).toBe(true);
   });
 
@@ -383,7 +434,7 @@ describe("WorktreeDeleteDialog — high tier (name confirmation)", () => {
     fireEvent.click(screen.getByRole("checkbox", { name: /force delete/i }));
 
     const button = screen.getByTestId("delete-worktree-confirm") as HTMLButtonElement;
-    expect(button.textContent).toBe("Delete 'abc1234'");
+    expect(button.textContent).toBe("Delete worktree");
 
     const input = screen.getByTestId("delete-worktree-confirm-input") as HTMLInputElement;
     fireEvent.change(input, { target: { value: "abc1234" } });


### PR DESCRIPTION
## Summary

Three microcopy fixes in the worktree delete confirmation dialog, per the guidance in CLAUDE.md.

- Button label is now a constant `Delete worktree` rather than switching to an interpolated branch name on high-tier deletes — the name already appears in the title and the typed-confirm input, so the third repetition adds nothing and makes the button width variable on long branch names
- Terminal count sentence is now count-aware, using singular or plural depending on `terminalCounts.total`
- Removed the inactionable clause about restoring from git after the uncommitted changes warning — it weakens the consequence the sentence is meant to deliver

Resolves #7497

## Changes

- `src/components/Worktree/WorktreeDeleteDialog.tsx` — three copy fixes as above
- `src/components/Worktree/__tests__/WorktreeDeleteDialog.test.tsx` — two assertion updates + five new body copy tests

## Testing

29/29 tests pass on the dialog test file. Full check gates pass: typecheck, channel drift, lint ratchet (−1 warning), format, and build.