### PR TITLE
refactor(empty-state): downgrade popover CTA weight, drop redundant sidebar description

### DIFF
--- a/src/components/GitHub/GitHubResourceList.tsx
+++ b/src/components/GitHub/GitHubResourceList.tsx
@@ -517,7 +517,7 @@ export function GitHubResourceList({
           title={title}
           action={
             <Button
-              variant="outline"
+              variant="ghost"
               size="sm"
               onClick={() => {
                 setSearchQuery("");

--- a/src/components/GitHub/__tests__/GitHubResourceList.swr.test.tsx
+++ b/src/components/GitHub/__tests__/GitHubResourceList.swr.test.tsx
@@ -777,7 +777,14 @@ describe("GitHubResourceList empty state branching", () => {
     await waitFor(() => {
       expect(screen.getByText(/No issues match "nonexistent"/)).toBeTruthy();
     });
-    expect(screen.getByRole("button", { name: /clear filters/i })).toBeTruthy();
+    const clearButton = screen.getByRole("button", { name: /clear filters/i });
+    expect(clearButton).toBeTruthy();
+    // CLAUDE.md popover/palette empty-state rule: never render primary-weight
+    // buttons. The Clear filters CTA must use the ghost variant — locking the
+    // class signature catches a regression to outline (ring-border-strong) or
+    // any other heavier variant.
+    expect(clearButton.className).toContain("text-text-secondary");
+    expect(clearButton.className).not.toContain("ring-border-strong");
   });
 
   it("renders filtered-empty when a non-default state filter is active", async () => {

--- a/src/components/Sidebar/SidebarContent.tsx
+++ b/src/components/Sidebar/SidebarContent.tsx
@@ -608,13 +608,6 @@ function SidebarContent({ onOpenOverview }: SidebarContentProps) {
 
   const hasNonMainWorktrees = deferredWorktrees.length > 1;
   const hasFilters = hasActiveFilters();
-  const hasPopoverFilters =
-    query.trim().length > 0 ||
-    statusFilters.size > 0 ||
-    typeFilters.size > 0 ||
-    githubFilters.size > 0 ||
-    sessionFilters.size > 0 ||
-    activityFilters.size > 0;
   const showQuickStateEmptyState =
     filteredWorktrees.length === 0 &&
     quickStateFilter !== "all" &&
@@ -838,9 +831,6 @@ function SidebarContent({ onOpenOverview }: SidebarContentProps) {
                 <EmptyState
                   variant="filtered-empty"
                   title={`No ${quickStateFilter} worktrees`}
-                  description={
-                    hasPopoverFilters ? "Clear filters to show every worktree" : undefined
-                  }
                   action={
                     <button
                       onClick={clearAllFilters}

--- a/src/components/Sidebar/__tests__/SidebarContent.emptyState.test.ts
+++ b/src/components/Sidebar/__tests__/SidebarContent.emptyState.test.ts
@@ -50,27 +50,6 @@ describe("SidebarContent quick-state empty state — issue #6333 (CTA collapsed 
     });
   });
 
-  describe("hasPopoverFilters derivation", () => {
-    it("excludes quickStateFilter from the popover-only check", () => {
-      // hasPopoverFilters powers the secondary "Clear all filters" CTA — it
-      // must NOT include quickStateFilter, otherwise the second button shows
-      // even when the only active filter is the quick state itself.
-      const block = source.match(/const hasPopoverFilters =\s*[\s\S]*?activityFilters\.size > 0;/);
-      expect(block).not.toBeNull();
-      expect(block![0]).not.toContain("quickStateFilter");
-    });
-
-    it("includes query, statusFilters, typeFilters, githubFilters, sessionFilters, activityFilters", () => {
-      const block = source.match(/const hasPopoverFilters =\s*[\s\S]*?activityFilters\.size > 0;/);
-      expect(block![0]).toContain("query.trim().length > 0");
-      expect(block![0]).toContain("statusFilters.size > 0");
-      expect(block![0]).toContain("typeFilters.size > 0");
-      expect(block![0]).toContain("githubFilters.size > 0");
-      expect(block![0]).toContain("sessionFilters.size > 0");
-      expect(block![0]).toContain("activityFilters.size > 0");
-    });
-  });
-
   describe("showQuickStateEmptyState gate", () => {
     it("requires zero results, non-'all' filter, would-match-without, and non-main worktrees", () => {
       const block = source.match(/const showQuickStateEmptyState =\s*[\s\S]*?hasNonMainWorktrees;/);
@@ -130,16 +109,16 @@ describe("SidebarContent quick-state empty state — issue #6333 (CTA collapsed 
       expect(source).not.toContain("Clear all filters");
     });
 
-    it("gates the description on hasPopoverFilters so the no-popover-filters case stays quiet", () => {
-      // When only the quick-state filter is active, the title and single
-      // CTA already convey everything; an additional descriptive line would
-      // be redundant noise. The description prop passes `undefined` in that
-      // path, which the EmptyState primitive treats as "no description".
+    it("does not render a description in the quick-state branch (single CTA conveys recovery)", () => {
+      // CLAUDE.md popover/sidebar empty-state rule: when the filter input above
+      // explains the cause and the title + CTA convey recovery, an additional
+      // description is redundant. The `description` prop is intentionally
+      // omitted; the visible filter chips above the empty state carry any
+      // additional active-filter signal.
       const branchStart = source.indexOf("showQuickStateEmptyState ?");
       const branchEnd = source.indexOf("filteredWorktrees.length === 0 && hasFilters", branchStart);
       const branch = source.slice(branchStart, branchEnd);
-      expect(branch).toMatch(/description=\{[\s\S]*?hasPopoverFilters[\s\S]*?\}/);
-      expect(branch).toContain("undefined");
+      expect(branch).not.toMatch(/description=/);
     });
 
     it("renders the popover-filtered empty state via the EmptyState primitive with a noun-phrase title", () => {


### PR DESCRIPTION
Two micro-refinements at sub-canvas scale, both following the same principle: when an empty state sits below filter chrome that already explains the cause, the CTA should be lighter weight and the description should either add new information or be dropped.

Resolves #7504

## Changes

- **`GitHubResourceList.tsx`** — `Clear filters` button in the GitHub issues/PRs popover empty state downgraded from `variant="outline"` to `variant="ghost"`. The popover renders directly above a search input; outline weight is redundant when the input already signals what caused the empty state.

- **`SidebarContent.tsx`** — Removed the conditional `"Clear filters to show every worktree"` description from the quick-state filtered-empty `EmptyState`. It echoed the action button below it, and the filter chips in `WorktreeSidebarSearchBar` (always visible when this state renders) already make filter state apparent. Removed the now-unused `hasPopoverFilters` derivation alongside it.

- **`GitHubResourceList.swr.test.tsx`** — Added a class-signature assertion (`text-text-secondary` present, `ring-border-strong` absent) so a regression from ghost back to outline fails the suite.

- **`SidebarContent.emptyState.test.ts`** — Dropped the stale `hasPopoverFilters` derivation tests; replaced the gating test with a positive guard asserting `description` is absent in the quick-state branch.

## Testing

Existing and updated unit tests cover both changes. `npm run check` passes clean.