### PR TITLE
fix(onboarding): tighten Getting Started completion sequence

### DIFF
--- a/src/hooks/app/__tests__/useGettingStartedChecklist.test.tsx
+++ b/src/hooks/app/__tests__/useGettingStartedChecklist.test.tsx
@@ -286,7 +286,7 @@ describe("useGettingStartedChecklist", () => {
     expect(onboardingMock.markChecklistItem).toHaveBeenCalledWith("createdWorktree");
   });
 
-  describe("completion toast", () => {
+  describe("completion side effects", () => {
     beforeEach(() => {
       // Use real timers so Promise.all hydration microtasks resolve naturally.
       vi.useRealTimers();
@@ -311,13 +311,13 @@ describe("useGettingStartedChecklist", () => {
       });
     }
 
-    it("includes the panel.palette keybinding in the completion toast when bound", async () => {
-      getDisplayComboMock.mockReturnValue("⌘+N");
-
+    it("does not emit a toast or read keybinding when the final item completes", async () => {
+      // Regression guard for #7499: the on-screen CelebrationConfetti is the
+      // sole completion signal. A toast would be redundant (Visible-another-way)
+      // and its CTA would point to an action the user just finished (Helpful).
       const { result } = renderHook(() => useGettingStartedChecklist(true));
       await flushHydration();
 
-      expect(result.current.checklist).not.toBeNull();
       expect(result.current.checklist?.items.ranSecondParallelAgent).toBe(false);
 
       await act(async () => {
@@ -325,29 +325,10 @@ describe("useGettingStartedChecklist", () => {
       });
 
       expect(onboardingMock.markChecklistItem).toHaveBeenCalledWith("ranSecondParallelAgent");
-      expect(getDisplayComboMock).toHaveBeenCalledWith("panel.palette");
-      expect(notifyMock).toHaveBeenCalledTimes(1);
-      const args = notifyMock.mock.calls[0]![0];
-      expect(args.type).toBe("success");
-      expect(args.title).toBe("Checklist complete");
-      expect(args.message).toBe("You're all set. Open the panel palette (⌘+N) to launch an agent");
-      expect(args.transient).toBe(true);
-    });
-
-    it("omits the keybinding parens when panel.palette is unbound", async () => {
-      getDisplayComboMock.mockReturnValue("");
-
-      const { result } = renderHook(() => useGettingStartedChecklist(true));
-      await flushHydration();
-
-      await act(async () => {
-        result.current.markItem("ranSecondParallelAgent");
-      });
-
-      expect(notifyMock).toHaveBeenCalledTimes(1);
-      const args = notifyMock.mock.calls[0]![0];
-      expect(args.message).toBe("You're all set. Open the panel palette to launch an agent");
-      expect(args.message).not.toContain("(");
+      expect(notifyMock).not.toHaveBeenCalled();
+      expect(getDisplayComboMock).not.toHaveBeenCalled();
+      expect(onboardingMock.markChecklistCelebrationShown).toHaveBeenCalledTimes(1);
+      expect(result.current.showCelebration).toBe(true);
     });
   });
 

--- a/src/hooks/app/useGettingStartedChecklist.ts
+++ b/src/hooks/app/useGettingStartedChecklist.ts
@@ -4,8 +4,6 @@ import { isElectronAvailable } from "../useElectron";
 import { useProjectStore } from "@/store/projectStore";
 import { usePanelStore } from "@/store/panelStore";
 import { getCurrentViewStore } from "@/store/createWorktreeStore";
-import { notify } from "@/lib/notify";
-import { keybindingService } from "@/services/KeybindingService";
 import { logError } from "@/utils/logger";
 import { safeFireAndForget } from "@/utils/safeFireAndForget";
 import type { ChecklistState, ChecklistItemId } from "@shared/types/ipc/maps";
@@ -123,17 +121,6 @@ export function useGettingStartedChecklist(isStateLoaded: boolean): GettingStart
         context: "Dismissing onboarding checklist",
       });
       if (!prev.celebrationShown) {
-        const paletteCombo = keybindingService.getDisplayCombo("panel.palette");
-        const message = paletteCombo
-          ? `You're all set. Open the panel palette (${paletteCombo}) to launch an agent`
-          : "You're all set. Open the panel palette to launch an agent";
-        notify({
-          type: "success",
-          title: "Checklist complete",
-          message,
-          duration: 5000,
-          transient: true,
-        });
         setShowCelebration(true);
         safeFireAndForget(window.electron.onboarding.markChecklistCelebrationShown(), {
           context: "Marking onboarding celebration shown",

--- a/src/index.css
+++ b/src/index.css
@@ -1599,6 +1599,16 @@ body,
     will-change: auto;
   }
 
+  /* Checklist completion overlay — pure transient flash with no static-state
+   * meaning. Match the input-receipt-flash treatment: drop the keyframe and
+   * keep the overlay invisible so it can't ghost over content.
+   */
+  .animate-checklist-complete-flash {
+    animation: none;
+    opacity: 0;
+    will-change: auto;
+  }
+
   /* Label swap under reduced motion — animation removed entirely. The swap
    * still happens (the new value renders), it just snaps into place rather
    * than crossfading. WCAG 2.3.3: remove motion, don't just speed it up.
@@ -1721,6 +1731,12 @@ body[data-reduce-animations="true"] .file-change-row-new::before {
 }
 
 body[data-reduce-animations="true"] .animate-input-receipt-flash {
+  animation: none;
+  opacity: 0;
+  will-change: auto;
+}
+
+body[data-reduce-animations="true"] .animate-checklist-complete-flash {
   animation: none;
   opacity: 0;
   will-change: auto;


### PR DESCRIPTION
## Summary

- Removes the completion toast from `useGettingStartedChecklist.ts` — it failed two of the four `notify()` gate checks: the CTA described an action the user just completed to reach 4/4, and the celebration confetti already conveys completion visually
- Adds `animate-checklist-complete-flash` to both reduced-motion gate blocks in `src/index.css` (`@media (prefers-reduced-motion: reduce)` and `body[data-reduce-animations="true"]`) where all sibling flash classes already appear
- Updates tests to assert the toast does not fire on completion while `showCelebration` still triggers

Resolves #7499

## Changes

- `src/hooks/app/useGettingStartedChecklist.ts` — removed `notify()` call, dead `notify`/`keybindingService` imports, and dead `paletteCombo`/`message` locals from the all-done branch
- `src/index.css` — added `animate-checklist-complete-flash` with `animation: none; opacity: 0; will-change: auto` to both reduced-motion blocks, matching the `animate-input-receipt-flash` sibling pattern
- `src/__tests__/useGettingStartedChecklist.test.tsx` — replaced two assertions on the deleted toast with a single negative regression guard confirming neither `notify` nor keybinding lookup fires, while confetti still triggers

## Testing

All 15 tests in `useGettingStartedChecklist.test.tsx` pass. Typecheck, lint, and format clean.