### PR TITLE
fix(browser): polish zoom controls in BrowserToolbar

### DIFF
--- a/src/components/Browser/BrowserToolbar.tsx
+++ b/src/components/Browser/BrowserToolbar.tsx
@@ -412,7 +412,7 @@ export function BrowserToolbar({
 
       {/* Zoom controls */}
       {onZoomChange && (
-        <div className="flex items-center gap-0.5">
+        <div className="flex items-center gap-0.5 rounded-md bg-overlay-subtle p-0.5">
           <Tooltip>
             <TooltipTrigger asChild>
               <span className="inline-flex">
@@ -437,9 +437,8 @@ export function BrowserToolbar({
                   onClick={handleZoomReset}
                   disabled={!isNonDefaultZoom}
                   className={cn(
-                    "px-1.5 py-1 rounded text-xs font-medium transition-colors",
-                    "hover:bg-overlay-medium disabled:opacity-40 disabled:cursor-not-allowed disabled:pointer-events-none",
-                    isNonDefaultZoom ? "text-status-info" : "text-daintree-text/60"
+                    "px-1.5 py-1 rounded text-xs font-medium text-daintree-text transition-colors",
+                    "hover:bg-overlay-medium disabled:opacity-40 disabled:cursor-not-allowed disabled:pointer-events-none"
                   )}
                   aria-label="Reset zoom"
                 >


### PR DESCRIPTION
## Summary

- Wraps the three zoom buttons (zoom-out, percentage label, zoom-in) in a `rounded-md bg-overlay-subtle p-0.5` container so they read as a single grouped control rather than three independent icons
- Replaces the conditional `text-status-info` on the percentage label with neutral `text-daintree-text` — the existing `disabled:opacity-40` already carries the at-100% state signal, so the status color was redundant

Resolves #7500

## Changes

- `src/components/Browser/BrowserToolbar.tsx`: group wrapper + neutral label color

## Testing

Visually confirmed zoom controls render as a grouped pill, percentage label stays neutral at all zoom levels, and opacity correctly dims at 100%.