### PR TITLE
feat(trash-dock): show active tab title in group label

### DIFF
--- a/src/components/Layout/TrashGroupItem.tsx
+++ b/src/components/Layout/TrashGroupItem.tsx
@@ -8,6 +8,8 @@ import { TerminalIcon } from "@/components/Terminal/TerminalIcon";
 import { deriveTerminalChrome } from "@/utils/terminalChrome";
 import { Tooltip, TooltipContent, TooltipTrigger } from "@/components/ui/tooltip";
 import { useGlobalSecondTicker } from "@/hooks/useGlobalSecondTicker";
+import { isUselessTitle } from "@shared/utils/isUselessTitle";
+import { getEffectiveAgentConfig } from "@shared/config/agentRegistry";
 
 interface TrashGroupItemProps {
   groupRestoreId: string;
@@ -57,7 +59,30 @@ export function TrashGroupItem({
   }, [removePanel, terminals]);
 
   const tabCount = terminals.length;
-  const groupName = `Tab Group (${tabCount} ${tabCount === 1 ? "tab" : "tabs"})`;
+
+  const activeEntry =
+    terminals.find(({ terminal }) => terminal.id === groupMetadata.activeTabId) ?? terminals[0];
+
+  const resolvedActiveTitle = (() => {
+    if (!activeEntry) return null;
+    const { terminal } = activeEntry;
+    const observed = terminal.lastObservedTitle;
+    if (observed && !isUselessTitle(observed)) return observed;
+    if (terminal.launchAgentId) {
+      if (terminal.title && !isUselessTitle(terminal.title)) return terminal.title;
+      const agentConfig = getEffectiveAgentConfig(terminal.launchAgentId);
+      return agentConfig?.name ?? terminal.launchAgentId;
+    }
+    if (terminal.title && !isUselessTitle(terminal.title)) return terminal.title;
+    return null;
+  })();
+
+  const fallbackName = `Tab Group (${tabCount} ${tabCount === 1 ? "tab" : "tabs"})`;
+  const groupName = resolvedActiveTitle
+    ? tabCount > 1
+      ? `${resolvedActiveTitle} +${tabCount - 1} more`
+      : resolvedActiveTitle
+    : fallbackName;
 
   return (
     <div className="rounded-[var(--radius-sm)] bg-transparent hover:bg-tint/5 transition-colors">

--- a/src/components/Layout/TrashGroupItem.tsx
+++ b/src/components/Layout/TrashGroupItem.tsx
@@ -60,8 +60,11 @@ export function TrashGroupItem({
 
   const tabCount = terminals.length;
 
-  const activeEntry =
-    terminals.find(({ terminal }) => terminal.id === groupMetadata.activeTabId) ?? terminals[0];
+  // Only resolve the headline title when the active id still points at a real
+  // terminal in the group — if individual deletes have left the id stale, the
+  // (active) marker won't render either, so falling back to the count-only
+  // label keeps the header and expanded list consistent.
+  const activeEntry = terminals.find(({ terminal }) => terminal.id === groupMetadata.activeTabId);
 
   const resolvedActiveTitle = (() => {
     if (!activeEntry) return null;

--- a/src/components/Layout/__tests__/TrashGroupItem.test.tsx
+++ b/src/components/Layout/__tests__/TrashGroupItem.test.tsx
@@ -5,6 +5,11 @@ import { TrashGroupItem } from "../TrashGroupItem";
 import type { TerminalInstance } from "@/store";
 import type { TrashedTerminal, TrashedTerminalGroupMetadata } from "@/store/slices";
 
+vi.mock("@shared/config/agentRegistry", () => ({
+  getEffectiveAgentConfig: (id: string) =>
+    id === "claude" ? { name: "Claude" } : id === "codex" ? { name: "Codex" } : null,
+}));
+
 vi.mock("@/store", () => ({
   usePanelStore: (selector: (s: unknown) => unknown) =>
     selector({
@@ -91,7 +96,7 @@ const terminals = [
 
 describe("TrashGroupItem", () => {
   describe("rendering", () => {
-    it("shows group name with tab count", () => {
+    it("shows active tab title with +N more for multi-tab groups", () => {
       const { container } = render(
         <TrashGroupItem
           groupRestoreId="grp1"
@@ -100,10 +105,10 @@ describe("TrashGroupItem", () => {
           earliestExpiry={Date.now() + 20000}
         />
       );
-      expect(container.textContent).toContain("Tab Group (2 tabs)");
+      expect(container.textContent).toContain("First tab +1 more");
     });
 
-    it("shows singular tab label for one terminal", () => {
+    it("shows just the active tab title for single-tab groups", () => {
       const single = [
         {
           terminal: makeTerminal({ id: "t1", title: "First tab" }),
@@ -122,7 +127,154 @@ describe("TrashGroupItem", () => {
           earliestExpiry={Date.now() + 20000}
         />
       );
-      expect(container.textContent).toContain("Tab Group (1 tab)");
+      expect(container.textContent).toContain("First tab");
+      expect(container.textContent).not.toContain("+0 more");
+      expect(container.textContent).not.toContain("Tab Group");
+    });
+
+    it("uses lastObservedTitle when present and non-useless", () => {
+      const withObserved = [
+        {
+          terminal: makeTerminal({
+            id: "t1",
+            title: "claude",
+            lastObservedTitle: "Fixing auth bug",
+          }),
+          trashedInfo: {
+            id: "t1",
+            expiresAt: Date.now() + 20000,
+            originalLocation: "grid",
+          } as TrashedTerminal,
+        },
+        {
+          terminal: makeTerminal({ id: "t2", title: "Second tab" }),
+          trashedInfo: {
+            id: "t2",
+            expiresAt: Date.now() + 30000,
+            originalLocation: "grid",
+          } as TrashedTerminal,
+        },
+      ];
+      const { container } = render(
+        <TrashGroupItem
+          groupRestoreId="grp1"
+          groupMetadata={groupMetadata}
+          terminals={withObserved}
+          earliestExpiry={Date.now() + 20000}
+        />
+      );
+      expect(container.textContent).toContain("Fixing auth bug +1 more");
+    });
+
+    it("ignores useless lastObservedTitle and falls through to title", () => {
+      const uselessObserved = [
+        {
+          terminal: makeTerminal({
+            id: "t1",
+            title: "Working on something",
+            lastObservedTitle: "claude",
+            launchAgentId: "claude",
+          }),
+          trashedInfo: {
+            id: "t1",
+            expiresAt: Date.now() + 20000,
+            originalLocation: "grid",
+          } as TrashedTerminal,
+        },
+        {
+          terminal: makeTerminal({ id: "t2", title: "Second tab" }),
+          trashedInfo: {
+            id: "t2",
+            expiresAt: Date.now() + 30000,
+            originalLocation: "grid",
+          } as TrashedTerminal,
+        },
+      ];
+      const { container } = render(
+        <TrashGroupItem
+          groupRestoreId="grp1"
+          groupMetadata={groupMetadata}
+          terminals={uselessObserved}
+          earliestExpiry={Date.now() + 20000}
+        />
+      );
+      expect(container.textContent).toContain("Working on something +1 more");
+    });
+
+    it("falls back to agent config name when launchAgentId set with no usable title", () => {
+      const agentOnly = [
+        {
+          terminal: makeTerminal({
+            id: "t1",
+            title: "claude",
+            launchAgentId: "claude",
+          }),
+          trashedInfo: {
+            id: "t1",
+            expiresAt: Date.now() + 20000,
+            originalLocation: "grid",
+          } as TrashedTerminal,
+        },
+        {
+          terminal: makeTerminal({ id: "t2", title: "Second tab" }),
+          trashedInfo: {
+            id: "t2",
+            expiresAt: Date.now() + 30000,
+            originalLocation: "grid",
+          } as TrashedTerminal,
+        },
+      ];
+      const { container } = render(
+        <TrashGroupItem
+          groupRestoreId="grp1"
+          groupMetadata={groupMetadata}
+          terminals={agentOnly}
+          earliestExpiry={Date.now() + 20000}
+        />
+      );
+      expect(container.textContent).toContain("Claude +1 more");
+    });
+
+    it("falls back to count-only label when no usable title can be resolved", () => {
+      const useless = [
+        {
+          terminal: makeTerminal({ id: "t1", title: "claude" }),
+          trashedInfo: {
+            id: "t1",
+            expiresAt: Date.now() + 20000,
+            originalLocation: "grid",
+          } as TrashedTerminal,
+        },
+        {
+          terminal: makeTerminal({ id: "t2", title: "bash" }),
+          trashedInfo: {
+            id: "t2",
+            expiresAt: Date.now() + 30000,
+            originalLocation: "grid",
+          } as TrashedTerminal,
+        },
+      ];
+      const { container } = render(
+        <TrashGroupItem
+          groupRestoreId="grp1"
+          groupMetadata={groupMetadata}
+          terminals={useless}
+          earliestExpiry={Date.now() + 20000}
+        />
+      );
+      expect(container.textContent).toContain("Tab Group (2 tabs)");
+    });
+
+    it("uses the active tab when activeTabId points to non-first panel", () => {
+      const { container } = render(
+        <TrashGroupItem
+          groupRestoreId="grp1"
+          groupMetadata={{ ...groupMetadata, activeTabId: "t2" }}
+          terminals={terminals}
+          earliestExpiry={Date.now() + 20000}
+        />
+      );
+      expect(container.textContent).toContain("Second tab +1 more");
     });
 
     it("shows active tab marker", () => {
@@ -176,7 +328,9 @@ describe("TrashGroupItem", () => {
           earliestExpiry={Date.now() + 20000}
         />
       );
-      expect(container.textContent).not.toContain("First tab");
+      // "Second tab" only appears in the expanded child list — the headline
+      // surfaces the active tab ("First tab"), not the others.
+      expect(container.textContent).not.toContain("Second tab");
     });
 
     it("expands to show child terminals on click", () => {

--- a/src/components/Layout/__tests__/TrashGroupItem.test.tsx
+++ b/src/components/Layout/__tests__/TrashGroupItem.test.tsx
@@ -277,11 +277,29 @@ describe("TrashGroupItem", () => {
       expect(container.textContent).toContain("Second tab +1 more");
     });
 
-    it("shows active tab marker", () => {
+    it("falls back to count-only label when activeTabId is stale", () => {
+      // If the originally active tab was individually removed, activeTabId no
+      // longer matches any terminal — the headline must not silently promote
+      // terminals[0] as if it were active, since the (active) marker won't
+      // render in the expanded list either.
       const { container } = render(
         <TrashGroupItem
           groupRestoreId="grp1"
-          groupMetadata={groupMetadata}
+          groupMetadata={{ ...groupMetadata, activeTabId: "t-removed" }}
+          terminals={terminals}
+          earliestExpiry={Date.now() + 20000}
+        />
+      );
+      expect(container.textContent).toContain("Tab Group (2 tabs)");
+      expect(container.textContent).not.toContain("First tab +1 more");
+      expect(container.textContent).not.toContain("Second tab +1 more");
+    });
+
+    it("shows active tab marker on the correct tab", () => {
+      const { container } = render(
+        <TrashGroupItem
+          groupRestoreId="grp1"
+          groupMetadata={{ ...groupMetadata, activeTabId: "t2" }}
           terminals={terminals}
           earliestExpiry={Date.now() + 20000}
         />
@@ -289,7 +307,12 @@ describe("TrashGroupItem", () => {
       // Expand to see child tabs
       const expandBtn = container.querySelector("button");
       act(() => expandBtn?.click());
-      expect(container.textContent).toContain("(active)");
+      // The marker should be in the same row as Second tab, not First tab
+      const rows = container.querySelectorAll('[role="region"] > div');
+      const matchingRow = Array.from(rows).find((row) => row.textContent?.includes("Second tab"));
+      expect(matchingRow?.textContent).toContain("(active)");
+      const otherRow = Array.from(rows).find((row) => row.textContent?.includes("First tab"));
+      expect(otherRow?.textContent).not.toContain("(active)");
     });
 
     it("shows worktree name when provided", () => {


### PR DESCRIPTION
## Summary

When we added the trash dock, group rows showed a generic count-only label — `Tab Group (N tabs)` regardless of what was in the group. This replaces it with a content-first headline: the active tab's title plus a `+N more` suffix (e.g. `Fixing auth bug +2 more`). Single-tab groups just show the title.

Falls back to the count-only format when no usable title can be resolved (all tabs have generic titles like `claude` or `bash`), or when `activeTabId` is stale and no longer present in the tab list.

Title resolution order mirrors `TrashBinItem`: `lastObservedTitle` (if non-useless) → agent title/agent name (when `launchAgentId`) → plain `title` (if non-useless) → count-only fallback.

Resolves #7502

## Changes

- `TrashGroupItem.tsx` — resolve active tab title using the same precedence logic as `TrashBinItem`; build the group label from it
- `TrashGroupItem.test.tsx` — 18 tests covering the resolver, suffix formatting, single-tab groups, agent title fallback, useless-title filtering, stale `activeTabId`, and active-marker positioning

## Testing

18 tests pass. New cases cover agent fallback, useless-title detection, stale `activeTabId`, and the `+N more` suffix at various group sizes.