### PR TITLE
fix(trash): quiet the trash dock countdown row

### DIFF
--- a/src/components/Layout/TrashBinItem.tsx
+++ b/src/components/Layout/TrashBinItem.tsx
@@ -88,7 +88,7 @@ export function TrashBinItem({ terminal, trashedInfo, worktreeName }: TrashBinIt
             "text-[11px] tabular-nums transition-opacity",
             seconds <= COUNTDOWN_CRITICAL_SECONDS
               ? "opacity-100 text-status-warning/70"
-              : "text-daintree-text/40 opacity-0 group-hover:opacity-100 group-focus-within:opacity-100 motion-reduce:opacity-100"
+              : "text-daintree-text/40 opacity-0 group-hover:opacity-100 group-focus-within:opacity-100"
           )}
           aria-hidden="true"
         >

--- a/src/components/Layout/TrashBinItem.tsx
+++ b/src/components/Layout/TrashBinItem.tsx
@@ -10,6 +10,12 @@ import { Tooltip, TooltipContent, TooltipTrigger } from "@/components/ui/tooltip
 import { isUselessTitle } from "@shared/utils/isUselessTitle";
 import { getEffectiveAgentConfig } from "@shared/config/agentRegistry";
 import { useGlobalSecondTicker } from "@/hooks/useGlobalSecondTicker";
+import { cn } from "@/lib/utils";
+
+// Reveal precise seconds only when the deadline is imminent (≤5s, the M3/WCAG
+// "final approach" window). Outside that, the row stays quiet and the value is
+// available on hover or keyboard focus. Sub-threshold meta-info should not tick.
+const COUNTDOWN_CRITICAL_SECONDS = 5;
 
 interface TrashBinItemProps {
   terminal: TerminalInstance;
@@ -77,7 +83,15 @@ export function TrashBinItem({ terminal, trashedInfo, worktreeName }: TrashBinIt
             </span>
           ) : null}
         </div>
-        <div className="text-[11px] text-daintree-text/40" aria-live="polite">
+        <div
+          className={cn(
+            "text-[11px] tabular-nums transition-opacity",
+            seconds <= COUNTDOWN_CRITICAL_SECONDS
+              ? "opacity-100 text-status-warning/70"
+              : "text-daintree-text/40 opacity-0 group-hover:opacity-100 group-focus-within:opacity-100 motion-reduce:opacity-100"
+          )}
+          aria-hidden="true"
+        >
           {seconds}s remaining
         </div>
       </div>

--- a/src/components/Layout/TrashGroupItem.tsx
+++ b/src/components/Layout/TrashGroupItem.tsx
@@ -10,6 +10,9 @@ import { Tooltip, TooltipContent, TooltipTrigger } from "@/components/ui/tooltip
 import { useGlobalSecondTicker } from "@/hooks/useGlobalSecondTicker";
 import { isUselessTitle } from "@shared/utils/isUselessTitle";
 import { getEffectiveAgentConfig } from "@shared/config/agentRegistry";
+import { cn } from "@/lib/utils";
+
+const COUNTDOWN_CRITICAL_SECONDS = 5;
 
 interface TrashGroupItemProps {
   groupRestoreId: string;
@@ -121,7 +124,15 @@ export function TrashGroupItem({
               </span>
             ) : null}
           </div>
-          <div className="text-[11px] text-daintree-text/40" aria-live="off">
+          <div
+            className={cn(
+              "text-[11px] tabular-nums transition-opacity",
+              seconds <= COUNTDOWN_CRITICAL_SECONDS
+                ? "opacity-100 text-status-warning/70"
+                : "text-daintree-text/40 opacity-0 group-hover:opacity-100 group-focus-within:opacity-100 motion-reduce:opacity-100"
+            )}
+            aria-hidden="true"
+          >
             {seconds}s remaining
           </div>
         </div>

--- a/src/components/Layout/TrashGroupItem.tsx
+++ b/src/components/Layout/TrashGroupItem.tsx
@@ -129,7 +129,7 @@ export function TrashGroupItem({
               "text-[11px] tabular-nums transition-opacity",
               seconds <= COUNTDOWN_CRITICAL_SECONDS
                 ? "opacity-100 text-status-warning/70"
-                : "text-daintree-text/40 opacity-0 group-hover:opacity-100 group-focus-within:opacity-100 motion-reduce:opacity-100"
+                : "text-daintree-text/40 opacity-0 group-hover:opacity-100 group-focus-within:opacity-100"
             )}
             aria-hidden="true"
           >

--- a/src/components/Layout/__tests__/TrashBinItem.test.tsx
+++ b/src/components/Layout/__tests__/TrashBinItem.test.tsx
@@ -299,7 +299,7 @@ describe("TrashBinItem", () => {
       expect(el.className).toContain("opacity-0");
       expect(el.className).toContain("group-hover:opacity-100");
       expect(el.className).toContain("group-focus-within:opacity-100");
-      expect(el.className).toContain("motion-reduce:opacity-100");
+      expect(el.className).not.toContain("motion-reduce:opacity-100");
       expect(el.className).not.toContain("text-status-warning");
     });
 

--- a/src/components/Layout/__tests__/TrashBinItem.test.tsx
+++ b/src/components/Layout/__tests__/TrashBinItem.test.tsx
@@ -252,4 +252,95 @@ describe("TrashBinItem", () => {
       expect(container.textContent).toContain("0s remaining");
     });
   });
+
+  describe("countdown accessibility and visibility", () => {
+    function findCountdownEl(container: HTMLElement): HTMLElement {
+      const matches = Array.from(container.querySelectorAll<HTMLElement>("[aria-hidden]")).filter(
+        (el) => el.textContent?.includes("s remaining")
+      );
+      expect(matches.length).toBe(1);
+      return matches[0];
+    }
+
+    it("removes aria-live and marks the countdown aria-hidden", () => {
+      const terminal = makeAgentTerminal();
+      const trashedInfo: TrashedTerminal = {
+        id: "t1",
+        expiresAt: Date.now() + 20000,
+        originalLocation: "grid",
+      };
+      const { container } = render(<TrashBinItem terminal={terminal} trashedInfo={trashedInfo} />);
+      const el = findCountdownEl(container);
+      expect(el.getAttribute("aria-hidden")).toBe("true");
+      expect(el.hasAttribute("aria-live")).toBe(false);
+    });
+
+    it("uses tabular-nums to keep digits aligned", () => {
+      const terminal = makeAgentTerminal();
+      const trashedInfo: TrashedTerminal = {
+        id: "t1",
+        expiresAt: Date.now() + 20000,
+        originalLocation: "grid",
+      };
+      const { container } = render(<TrashBinItem terminal={terminal} trashedInfo={trashedInfo} />);
+      const el = findCountdownEl(container);
+      expect(el.className).toContain("tabular-nums");
+    });
+
+    it("hides the countdown by default outside the final approach window", () => {
+      const terminal = makeAgentTerminal();
+      const trashedInfo: TrashedTerminal = {
+        id: "t1",
+        expiresAt: Date.now() + 20000,
+        originalLocation: "grid",
+      };
+      const { container } = render(<TrashBinItem terminal={terminal} trashedInfo={trashedInfo} />);
+      const el = findCountdownEl(container);
+      expect(el.className).toContain("opacity-0");
+      expect(el.className).toContain("group-hover:opacity-100");
+      expect(el.className).toContain("group-focus-within:opacity-100");
+      expect(el.className).toContain("motion-reduce:opacity-100");
+      expect(el.className).not.toContain("text-status-warning");
+    });
+
+    it("surfaces the countdown unconditionally at the 5s threshold", () => {
+      const terminal = makeAgentTerminal();
+      const trashedInfo: TrashedTerminal = {
+        id: "t1",
+        expiresAt: Date.now() + 5000,
+        originalLocation: "grid",
+      };
+      const { container } = render(<TrashBinItem terminal={terminal} trashedInfo={trashedInfo} />);
+      const el = findCountdownEl(container);
+      expect(el.className).toContain("opacity-100");
+      expect(el.className).toContain("text-status-warning");
+      expect(el.className).not.toContain("opacity-0");
+    });
+
+    it("keeps the warning treatment below the threshold", () => {
+      const terminal = makeAgentTerminal();
+      const trashedInfo: TrashedTerminal = {
+        id: "t1",
+        expiresAt: Date.now() + 4000,
+        originalLocation: "grid",
+      };
+      const { container } = render(<TrashBinItem terminal={terminal} trashedInfo={trashedInfo} />);
+      const el = findCountdownEl(container);
+      expect(el.className).toContain("opacity-100");
+      expect(el.className).toContain("text-status-warning");
+    });
+
+    it("stays quiet just above the threshold", () => {
+      const terminal = makeAgentTerminal();
+      const trashedInfo: TrashedTerminal = {
+        id: "t1",
+        expiresAt: Date.now() + 6000,
+        originalLocation: "grid",
+      };
+      const { container } = render(<TrashBinItem terminal={terminal} trashedInfo={trashedInfo} />);
+      const el = findCountdownEl(container);
+      expect(el.className).toContain("opacity-0");
+      expect(el.className).not.toContain("text-status-warning");
+    });
+  });
 });

--- a/src/components/Layout/__tests__/TrashBinItem.test.tsx
+++ b/src/components/Layout/__tests__/TrashBinItem.test.tsx
@@ -259,7 +259,7 @@ describe("TrashBinItem", () => {
         (el) => el.textContent?.includes("s remaining")
       );
       expect(matches.length).toBe(1);
-      return matches[0];
+      return matches[0]!;
     }
 
     it("removes aria-live and marks the countdown aria-hidden", () => {

--- a/src/components/Layout/__tests__/TrashGroupItem.test.tsx
+++ b/src/components/Layout/__tests__/TrashGroupItem.test.tsx
@@ -499,4 +499,101 @@ describe("TrashGroupItem", () => {
       expect(container.textContent).toContain("0s remaining");
     });
   });
+
+  describe("countdown accessibility and visibility", () => {
+    function findCountdownEl(container: HTMLElement): HTMLElement {
+      const matches = Array.from(container.querySelectorAll<HTMLElement>("[aria-hidden]")).filter(
+        (el) => el.textContent?.includes("s remaining")
+      );
+      expect(matches.length).toBe(1);
+      return matches[0];
+    }
+
+    it("removes aria-live and marks the countdown aria-hidden", () => {
+      const { container } = render(
+        <TrashGroupItem
+          groupRestoreId="grp1"
+          groupMetadata={groupMetadata}
+          terminals={terminals}
+          earliestExpiry={Date.now() + 20000}
+        />
+      );
+      const el = findCountdownEl(container);
+      expect(el.getAttribute("aria-hidden")).toBe("true");
+      expect(el.hasAttribute("aria-live")).toBe(false);
+    });
+
+    it("uses tabular-nums to keep digits aligned", () => {
+      const { container } = render(
+        <TrashGroupItem
+          groupRestoreId="grp1"
+          groupMetadata={groupMetadata}
+          terminals={terminals}
+          earliestExpiry={Date.now() + 20000}
+        />
+      );
+      const el = findCountdownEl(container);
+      expect(el.className).toContain("tabular-nums");
+    });
+
+    it("hides the countdown by default outside the final approach window", () => {
+      const { container } = render(
+        <TrashGroupItem
+          groupRestoreId="grp1"
+          groupMetadata={groupMetadata}
+          terminals={terminals}
+          earliestExpiry={Date.now() + 20000}
+        />
+      );
+      const el = findCountdownEl(container);
+      expect(el.className).toContain("opacity-0");
+      expect(el.className).toContain("group-hover:opacity-100");
+      expect(el.className).toContain("group-focus-within:opacity-100");
+      expect(el.className).not.toContain("motion-reduce:opacity-100");
+      expect(el.className).not.toContain("text-status-warning");
+    });
+
+    it("surfaces the countdown unconditionally at the 5s threshold", () => {
+      const { container } = render(
+        <TrashGroupItem
+          groupRestoreId="grp1"
+          groupMetadata={groupMetadata}
+          terminals={terminals}
+          earliestExpiry={Date.now() + 5000}
+        />
+      );
+      const el = findCountdownEl(container);
+      expect(el.className).toContain("opacity-100");
+      expect(el.className).toContain("text-status-warning");
+      expect(el.className).not.toContain("opacity-0");
+    });
+
+    it("keeps the warning treatment below the threshold", () => {
+      const { container } = render(
+        <TrashGroupItem
+          groupRestoreId="grp1"
+          groupMetadata={groupMetadata}
+          terminals={terminals}
+          earliestExpiry={Date.now() + 4000}
+        />
+      );
+      const el = findCountdownEl(container);
+      expect(el.className).toContain("opacity-100");
+      expect(el.className).toContain("text-status-warning");
+    });
+
+    it("stays quiet just above the threshold", () => {
+      const { container } = render(
+        <TrashGroupItem
+          groupRestoreId="grp1"
+          groupMetadata={groupMetadata}
+          terminals={terminals}
+          earliestExpiry={Date.now() + 6000}
+        />
+      );
+      const el = findCountdownEl(container);
+      expect(el.className).toContain("opacity-0");
+      expect(el.className).not.toContain("text-status-warning");
+    });
+  });
 });

--- a/src/components/Layout/__tests__/TrashGroupItem.test.tsx
+++ b/src/components/Layout/__tests__/TrashGroupItem.test.tsx
@@ -506,7 +506,7 @@ describe("TrashGroupItem", () => {
         (el) => el.textContent?.includes("s remaining")
       );
       expect(matches.length).toBe(1);
-      return matches[0];
+      return matches[0]!;
     }
 
     it("removes aria-live and marks the countdown aria-hidden", () => {


### PR DESCRIPTION
## Summary

- The countdown text in `TrashBinItem` had `aria-live="polite"`, causing screen readers to re-announce the seconds value every second for 20 seconds after every panel close. The existing `sr-only` announce on close already tells screen readers that `Cmd+Shift+T` recovers the panel, so the per-second readback adds nothing.
- No `tabular-nums` on the counter meant digits shifted left and right as the number narrowed.
- The countdown was visible from the moment a panel was trashed rather than only surfacing when it matters.

Resolves #7501

## Changes

- `TrashBinItem.tsx`: removes `aria-live`, adds `aria-hidden` + `tabular-nums` to the countdown span; hides it with `opacity-0` by default and reveals on `group-hover` / `group-focus-within`; warning treatment surfaces unconditionally at `<= 5s`.
- `TrashGroupItem.tsx`: same `tabular-nums` + visibility treatment applied for consistency (it already had `aria-live="off"`).
- `TrashBinItem.test.tsx`: 5 boundary and visibility unit tests covering the hide/reveal and warning threshold behaviour.
- `TrashGroupItem.test.tsx`: mirrored test block for the group variant.

## Testing

33/33 unit tests pass. `npm run check` clean (lint warnings 877 → 876 — one previous warning resolved as a side effect).