### PR TITLE
fix(toolbar): collapse double-stacked Problems signal and dwell-vs-tooltip overlap

### DIFF
--- a/src/components/Layout/ToolbarProblemsButton.tsx
+++ b/src/components/Layout/ToolbarProblemsButton.tsx
@@ -36,7 +36,7 @@ export const ToolbarProblemsButton = memo(function ToolbarProblemsButton({
           size="icon"
           data-toolbar-item={dataToolbarItem}
           onClick={onToggleProblems}
-          className={cn(toolbarIconButtonClass, "relative", errorCount > 0 && "text-status-error")}
+          className={cn(toolbarIconButtonClass, "relative")}
           aria-label={`Problems: ${errorCount} error${errorCount !== 1 ? "s" : ""}`}
           aria-keyshortcuts={diagnosticsAriaShortcut}
           aria-expanded={isDockOpen}

--- a/src/components/Layout/__tests__/ToolbarProblemsButton.test.tsx
+++ b/src/components/Layout/__tests__/ToolbarProblemsButton.test.tsx
@@ -28,6 +28,12 @@ vi.mock("lucide-react", () => ({
   AlertCircle: () => <span data-testid="icon-alert" />,
 }));
 
+function getIconHostClassName(container: HTMLElement): string {
+  const button = container.querySelector("button");
+  if (!button) throw new Error("button not rendered");
+  return button.className;
+}
+
 vi.mock("@/hooks", () => ({
   useAriaKeyshortcuts: () => "",
   useKeybindingDisplay: () => "",
@@ -62,5 +68,28 @@ describe("ToolbarProblemsButton — aria-expanded / aria-controls", () => {
 
     expect(button?.getAttribute("aria-expanded")).toBe("true");
     expect(button?.getAttribute("aria-controls")).toBe("diagnostics-dock-region");
+  });
+});
+
+describe("ToolbarProblemsButton — single-signal error treatment", () => {
+  beforeEach(() => {
+    useDiagnosticsStore.setState({ isOpen: false });
+  });
+
+  it("does not recolor the icon host when errorCount > 0 (badge dot is the only signal)", () => {
+    const { container } = render(<ToolbarProblemsButton errorCount={3} />);
+    expect(getIconHostClassName(container)).not.toMatch(/text-status-error/);
+  });
+
+  it("shows the badge as visible when errorCount > 0", () => {
+    const { container } = render(<ToolbarProblemsButton errorCount={1} />);
+    const badge = container.querySelector(".toolbar-problems-badge");
+    expect(badge?.getAttribute("data-visible")).toBe("true");
+  });
+
+  it("hides the badge when errorCount is 0", () => {
+    const { container } = render(<ToolbarProblemsButton errorCount={0} />);
+    const badge = container.querySelector(".toolbar-problems-badge");
+    expect(badge?.getAttribute("data-visible")).toBe("false");
   });
 });

--- a/src/hooks/__tests__/useShortcutHintHover.test.ts
+++ b/src/hooks/__tests__/useShortcutHintHover.test.ts
@@ -215,6 +215,36 @@ describe("useShortcutHintHover", () => {
     expect(shortcutHintStore.getState().activeHint).toBeNull();
   });
 
+  it("suppresses dwell hint when trigger transitions to delayed-open mid-dwell", () => {
+    // Real-world race: Radix tooltip opens at ~500ms during the 1500ms dwell.
+    // The hook must read data-state at fire time, not at pointer-enter time.
+    shortcutHintStore.getState().hydrateCounts({ "nav.toggleSidebar": 0 });
+
+    const trigger = document.createElement("button");
+    trigger.setAttribute("data-state", "closed");
+
+    const { result } = renderHook(() => useShortcutHintHover("nav.toggleSidebar"));
+
+    act(() => {
+      vi.advanceTimersByTime(10);
+    });
+
+    act(() => {
+      result.current.onPointerEnter(createPointerEvent(100, 200, trigger));
+    });
+
+    act(() => {
+      vi.advanceTimersByTime(800);
+      trigger.setAttribute("data-state", "delayed-open");
+    });
+
+    act(() => {
+      vi.advanceTimersByTime(700);
+    });
+
+    expect(shortcutHintStore.getState().activeHint).toBeNull();
+  });
+
   it("fires dwell hint when trigger data-state is closed", () => {
     shortcutHintStore.getState().hydrateCounts({ "nav.toggleSidebar": 0 });
 

--- a/src/hooks/__tests__/useShortcutHintHover.test.ts
+++ b/src/hooks/__tests__/useShortcutHintHover.test.ts
@@ -18,9 +18,10 @@ vi.mock("@/services/KeybindingService", () => ({
 
 function createPointerEvent(
   clientX: number,
-  clientY: number
+  clientY: number,
+  currentTarget?: Element
 ): React.PointerEvent<HTMLButtonElement> {
-  return { clientX, clientY } as React.PointerEvent<HTMLButtonElement>;
+  return { clientX, clientY, currentTarget } as unknown as React.PointerEvent<HTMLButtonElement>;
 }
 
 describe("useShortcutHintHover", () => {
@@ -166,6 +167,77 @@ describe("useShortcutHintHover", () => {
       vi.advanceTimersByTime(2000);
     });
     expect(shortcutHintStore.getState().activeHint).toBeNull();
+  });
+
+  it("suppresses dwell hint when trigger data-state is delayed-open", () => {
+    shortcutHintStore.getState().hydrateCounts({ "nav.toggleSidebar": 0 });
+
+    const trigger = document.createElement("button");
+    trigger.setAttribute("data-state", "delayed-open");
+
+    const { result } = renderHook(() => useShortcutHintHover("nav.toggleSidebar"));
+
+    act(() => {
+      vi.advanceTimersByTime(10);
+    });
+
+    act(() => {
+      result.current.onPointerEnter(createPointerEvent(100, 200, trigger));
+    });
+
+    act(() => {
+      vi.advanceTimersByTime(1500);
+    });
+
+    expect(shortcutHintStore.getState().activeHint).toBeNull();
+  });
+
+  it("suppresses dwell hint when trigger data-state is instant-open", () => {
+    shortcutHintStore.getState().hydrateCounts({ "nav.toggleSidebar": 0 });
+
+    const trigger = document.createElement("button");
+    trigger.setAttribute("data-state", "instant-open");
+
+    const { result } = renderHook(() => useShortcutHintHover("nav.toggleSidebar"));
+
+    act(() => {
+      vi.advanceTimersByTime(10);
+    });
+
+    act(() => {
+      result.current.onPointerEnter(createPointerEvent(100, 200, trigger));
+    });
+
+    act(() => {
+      vi.advanceTimersByTime(1500);
+    });
+
+    expect(shortcutHintStore.getState().activeHint).toBeNull();
+  });
+
+  it("fires dwell hint when trigger data-state is closed", () => {
+    shortcutHintStore.getState().hydrateCounts({ "nav.toggleSidebar": 0 });
+
+    const trigger = document.createElement("button");
+    trigger.setAttribute("data-state", "closed");
+
+    const { result } = renderHook(() => useShortcutHintHover("nav.toggleSidebar"));
+
+    act(() => {
+      vi.advanceTimersByTime(10);
+    });
+
+    act(() => {
+      result.current.onPointerEnter(createPointerEvent(100, 200, trigger));
+    });
+
+    act(() => {
+      vi.advanceTimersByTime(1500);
+    });
+
+    const hint = shortcutHintStore.getState().activeHint;
+    expect(hint).not.toBeNull();
+    expect(hint!.actionId).toBe("nav.toggleSidebar");
   });
 
   it("respects one-shot gating at same count level", () => {

--- a/src/hooks/useShortcutHintHover.ts
+++ b/src/hooks/useShortcutHintHover.ts
@@ -17,6 +17,7 @@ const HOVER_DWELL_MS = 1500;
 export function useShortcutHintHover(actionId: string) {
   const timerRef = useRef<ReturnType<typeof setTimeout> | null>(null);
   const displayComboRef = useRef<string>("");
+  const triggerRef = useRef<Element | null>(null);
   // Ref-based callback to avoid stale closures in setTimeout without useEffectEvent.
   const fireDwellRef = useRef<(clientX: number, clientY: number) => void>(() => {});
 
@@ -34,6 +35,11 @@ export function useShortcutHintHover(actionId: string) {
     fireDwellRef.current = (clientX: number, clientY: number) => {
       const displayCombo = displayComboRef.current;
       if (!displayCombo) return;
+
+      // Suppress when a Radix tooltip is already teaching the same shortcut on
+      // this trigger (data-state is merged onto the trigger child via asChild).
+      const tooltipState = triggerRef.current?.getAttribute("data-state");
+      if (tooltipState === "delayed-open" || tooltipState === "instant-open") return;
 
       const store = shortcutHintStore;
       if (!store.getState().isHoverEligible(actionId)) return;
@@ -53,6 +59,7 @@ export function useShortcutHintHover(actionId: string) {
       clearTimeout(timerRef.current);
       timerRef.current = null;
     }
+    triggerRef.current = null;
   };
 
   useEffect(() => {
@@ -68,10 +75,12 @@ export function useShortcutHintHover(actionId: string) {
 
     const clientX = e.clientX;
     const clientY = e.clientY;
+    triggerRef.current = e.currentTarget;
 
     timerRef.current = setTimeout(() => {
       timerRef.current = null;
       fireDwellRef.current(clientX, clientY);
+      triggerRef.current = null;
     }, HOVER_DWELL_MS);
   };
 


### PR DESCRIPTION
## Summary

- `ToolbarProblemsButton`: removed the `text-status-error` icon recolor — the badge dot already carries the error signal, and the icon recolor was just doubling it. Every other toolbar button uses single-treatment encoding; Problems was the outlier.
- `useShortcutHintHover`: captures the trigger element on pointer-enter and reads its Radix `data-state` at the 1500ms dwell point. If the tooltip is already open, the dwell hint is suppressed — no more two overlays teaching the same shortcut on the same trigger.

Resolves #7503

## Changes

- `ToolbarProblemsButton.tsx`: drop `errorCount > 0 && "text-status-error"` from the button class
- `useShortcutHintHover.ts`: capture trigger ref on `pointerenter`, check `data-state !== "open"` before firing the hint
- `ToolbarProblemsButton.test.tsx`: 3 new cases covering icon class regression and badge visibility
- `useShortcutHintHover.test.ts`: 4 new cases including the dynamic state-mutation race (tooltip opens during the dwell window)

## Testing

- `useShortcutHintHover`: 10/10 pass (6 existing + 4 new)
- `ToolbarProblemsButton`: 5/5 pass (2 existing + 3 new)
- Typecheck, lint, format: clean