### PR TITLE
fix(a11y): fix active pill contrast and screen reader count in QuickStateFilterBar

### DIFF
--- a/src/components/Worktree/QuickStateFilterBar.tsx
+++ b/src/components/Worktree/QuickStateFilterBar.tsx
@@ -23,6 +23,7 @@ export function QuickStateFilterBar({ value, onChange, counts }: QuickStateFilte
     >
       {FILTER_OPTIONS.map((option) => {
         const isActive = option.value === value;
+        const count = counts && option.value !== "all" ? counts[option.value] : undefined;
         return (
           <button
             key={option.value}
@@ -32,13 +33,18 @@ export function QuickStateFilterBar({ value, onChange, counts }: QuickStateFilte
             className={cn(
               "inline-flex items-center px-2 py-0.5 text-[11px] rounded-full transition-colors",
               isActive
-                ? "bg-tint/[0.12] text-daintree-text font-medium"
+                ? "ring-1 ring-inset ring-text-secondary text-daintree-text font-medium"
                 : "text-daintree-text/60 hover:text-daintree-text hover:bg-tint/[0.04]"
             )}
           >
             {option.label}
             {/* "All" has no count — quickStateCounts excludes main/integration worktrees, so the sum != the sidebar header's (N) total. */}
-            {counts && option.value !== "all" && ` (${counts[option.value]})`}
+            {count !== undefined && (
+              <>
+                <span aria-hidden="true">{` (${count})`}</span>
+                <span className="sr-only">{`, ${count} ${count === 1 ? "worktree" : "worktrees"}`}</span>
+              </>
+            )}
           </button>
         );
       })}

--- a/src/components/Worktree/__tests__/QuickStateFilterBar.test.tsx
+++ b/src/components/Worktree/__tests__/QuickStateFilterBar.test.tsx
@@ -56,13 +56,29 @@ describe("QuickStateFilterBar", () => {
     const working = screen.getByRole("button", { name: /Working/ });
     const visibleCount = within(working).getByText("(3)", { exact: false });
     expect(visibleCount.getAttribute("aria-hidden")).toBe("true");
-    expect(within(working).getByText(", 3 worktrees")).toBeTruthy();
+    const workingSrOnly = within(working).getByText(", 3 worktrees");
+    expect(workingSrOnly.className).toContain("sr-only");
 
     const waiting = screen.getByRole("button", { name: /Waiting/ });
-    expect(within(waiting).getByText(", 1 worktree")).toBeTruthy();
+    const waitingSrOnly = within(waiting).getByText(", 1 worktree");
+    expect(waitingSrOnly.className).toContain("sr-only");
 
     const finished = screen.getByRole("button", { name: /Finished/ });
-    expect(within(finished).getByText(", 0 worktrees")).toBeTruthy();
+    const finishedSrOnly = within(finished).getByText(", 0 worktrees");
+    expect(finishedSrOnly.className).toContain("sr-only");
+  });
+
+  it("exposes the count in the button's accessible name", () => {
+    render(
+      <QuickStateFilterBar
+        value="all"
+        onChange={() => {}}
+        counts={{ working: 3, waiting: 1, finished: 0 }}
+      />
+    );
+    expect(screen.getByRole("button", { name: "Working, 3 worktrees" })).toBeTruthy();
+    expect(screen.getByRole("button", { name: "Waiting, 1 worktree" })).toBeTruthy();
+    expect(screen.getByRole("button", { name: "Finished, 0 worktrees" })).toBeTruthy();
   });
 
   it("uses an inset ring (not a translucent fill) for the active pill", () => {

--- a/src/components/Worktree/__tests__/QuickStateFilterBar.test.tsx
+++ b/src/components/Worktree/__tests__/QuickStateFilterBar.test.tsx
@@ -1,6 +1,6 @@
 // @vitest-environment jsdom
 import { describe, it, expect, vi } from "vitest";
-import { render, screen, fireEvent } from "@testing-library/react";
+import { render, screen, fireEvent, within } from "@testing-library/react";
 import { QuickStateFilterBar } from "../QuickStateFilterBar";
 
 describe("QuickStateFilterBar", () => {
@@ -21,9 +21,12 @@ describe("QuickStateFilterBar", () => {
       />
     );
     expect(screen.getByText("All")).toBeTruthy();
-    expect(screen.getByText(/Working \(3\)/)).toBeTruthy();
-    expect(screen.getByText(/Waiting \(1\)/)).toBeTruthy();
-    expect(screen.getByText(/Finished \(5\)/)).toBeTruthy();
+    const working = screen.getByRole("button", { name: /Working/ });
+    const waiting = screen.getByRole("button", { name: /Waiting/ });
+    const finished = screen.getByRole("button", { name: /Finished/ });
+    expect(within(working).getByText("(3)", { exact: false })).toBeTruthy();
+    expect(within(waiting).getByText("(1)", { exact: false })).toBeTruthy();
+    expect(within(finished).getByText("(5)", { exact: false })).toBeTruthy();
   });
 
   it("renders zero counts explicitly", () => {
@@ -34,9 +37,50 @@ describe("QuickStateFilterBar", () => {
         counts={{ working: 0, waiting: 0, finished: 0 }}
       />
     );
-    expect(screen.getByText(/Working \(0\)/)).toBeTruthy();
-    expect(screen.getByText(/Waiting \(0\)/)).toBeTruthy();
-    expect(screen.getByText(/Finished \(0\)/)).toBeTruthy();
+    const working = screen.getByRole("button", { name: /Working/ });
+    const waiting = screen.getByRole("button", { name: /Waiting/ });
+    const finished = screen.getByRole("button", { name: /Finished/ });
+    expect(within(working).getByText("(0)", { exact: false })).toBeTruthy();
+    expect(within(waiting).getByText("(0)", { exact: false })).toBeTruthy();
+    expect(within(finished).getByText("(0)", { exact: false })).toBeTruthy();
+  });
+
+  it("hides the visual count from screen readers and adds an sr-only count", () => {
+    render(
+      <QuickStateFilterBar
+        value="all"
+        onChange={() => {}}
+        counts={{ working: 3, waiting: 1, finished: 0 }}
+      />
+    );
+    const working = screen.getByRole("button", { name: /Working/ });
+    const visibleCount = within(working).getByText("(3)", { exact: false });
+    expect(visibleCount.getAttribute("aria-hidden")).toBe("true");
+    expect(within(working).getByText(", 3 worktrees")).toBeTruthy();
+
+    const waiting = screen.getByRole("button", { name: /Waiting/ });
+    expect(within(waiting).getByText(", 1 worktree")).toBeTruthy();
+
+    const finished = screen.getByRole("button", { name: /Finished/ });
+    expect(within(finished).getByText(", 0 worktrees")).toBeTruthy();
+  });
+
+  it("uses an inset ring (not a translucent fill) for the active pill", () => {
+    render(
+      <QuickStateFilterBar
+        value="working"
+        onChange={() => {}}
+        counts={{ working: 2, waiting: 0, finished: 0 }}
+      />
+    );
+    const active = screen.getByRole("button", { name: /Working/ });
+    expect(active.className).toContain("ring-1");
+    expect(active.className).toContain("ring-inset");
+    expect(active.className).toContain("ring-text-secondary");
+    expect(active.className).not.toContain("bg-tint/[0.12]");
+
+    const inactive = screen.getByRole("button", { name: /Waiting/ });
+    expect(inactive.className).not.toContain("ring-text-secondary");
   });
 
   it("marks the active pill with aria-pressed=true", () => {


### PR DESCRIPTION
## Summary

- The active pill in `QuickStateFilterBar` used `bg-tint/[0.12]` for its pressed state — roughly 1.1:1 against the bar surface, well short of the 3:1 minimum for WCAG 2.2 SC 1.4.11. Replaced it with `ring-1 ring-inset ring-text-secondary`, validated ≥3:1 across all 14 built-in themes (minimum observed 4.05:1) via the existing `CONTRAST_PAIRS` check.
- Labels like `Working (3)` were read by some screen readers as "Working left-paren 3 right-paren". The count is now split into an `aria-hidden` visible span (retaining the parens) and a `sr-only` sibling that announces `, 3 worktrees` (singular handled: `1 worktree`).
- No accent color used. Motion stays on `transition-colors` — no tier widening.

Resolves #7505.

## Changes

- `QuickStateFilterBar.tsx`: swap `bg-tint/[0.12]` active class for `ring-1 ring-inset ring-text-secondary`; split count rendering into `aria-hidden` + `sr-only` pair.
- `QuickStateFilterBar.test.tsx`: 10 tests (was 7) — adds ring-class assertions, `aria-hidden`, `sr-only` class, and an end-to-end accessible-name check.

## Testing

- Typecheck, lint (876 warnings, −1 from baseline), format, and build all pass.
- Unit tests: 10/10 green, including ring presence on active pills, absence on inactive, `aria-hidden` on the visible count span, `sr-only` class on the unit sibling, and full accessible-name verification.