### PR TITLE
fix(diagnostics): add handle reset and filtered-empty recovery to dock

### DIFF
--- a/src/components/Diagnostics/DiagnosticsDock.tsx
+++ b/src/components/Diagnostics/DiagnosticsDock.tsx
@@ -7,6 +7,7 @@ import {
   type DiagnosticsTab,
   DIAGNOSTICS_MIN_HEIGHT,
   DIAGNOSTICS_MAX_HEIGHT_RATIO,
+  DIAGNOSTICS_DEFAULT_HEIGHT,
 } from "@/store/diagnosticsStore";
 import { useErrorStore } from "@/store";
 import { ProblemsContent } from "./ProblemsContent";
@@ -114,6 +115,10 @@ export function DiagnosticsDock({ onRetry, onCancelRetry, className }: Diagnosti
     [height]
   );
 
+  const handleResetHeight = useCallback(() => {
+    setHeight(DIAGNOSTICS_DEFAULT_HEIGHT);
+  }, [setHeight]);
+
   const handleKeyDown = useCallback(
     (e: React.KeyboardEvent) => {
       const step = e.shiftKey ? RESIZE_STEP_LARGE : RESIZE_STEP;
@@ -141,6 +146,11 @@ export function DiagnosticsDock({ onRetry, onCancelRetry, className }: Diagnosti
         case "End":
           e.preventDefault();
           setHeight(maxHeight);
+          break;
+        case "Enter":
+        case " ":
+          e.preventDefault();
+          setHeight(DIAGNOSTICS_DEFAULT_HEIGHT);
           break;
         default:
           return;
@@ -296,10 +306,11 @@ export function DiagnosticsDock({ onRetry, onCancelRetry, className }: Diagnosti
           isResizing && "bg-overlay-medium"
         )}
         onMouseDown={handleResizeStart}
+        onDoubleClick={handleResetHeight}
         onKeyDown={handleKeyDown}
         role="separator"
         aria-orientation="horizontal"
-        aria-label="Resize diagnostics dock"
+        aria-label="Resize diagnostics dock (double-click to reset)"
         aria-valuenow={Math.round(height)}
         aria-valuemin={DIAGNOSTICS_MIN_HEIGHT}
         aria-valuemax={Math.round(maxHeight)}

--- a/src/components/Diagnostics/LogsContent.tsx
+++ b/src/components/Diagnostics/LogsContent.tsx
@@ -3,6 +3,7 @@ import { useShallow } from "zustand/react/shallow";
 import { Virtuoso, type VirtuosoHandle } from "react-virtuoso";
 import { cn } from "@/lib/utils";
 import { Button } from "@/components/ui/button";
+import { EmptyState } from "@/components/ui/EmptyState";
 import {
   useLogsStore,
   filterLogs,
@@ -199,6 +200,8 @@ export function LogsContent({ className, onSourcesChange }: LogsContentProps) {
   const displayEntries = useMemo(() => collapseConsecutiveDuplicates(mainLogs), [mainLogs]);
   const deferredDisplayEntries = useDeferredValue(displayEntries);
 
+  const hasActiveFilters = Object.keys(filters).length > 0;
+
   const handleAtBottomChange = useCallback(
     (bottom: boolean) => {
       setAtBottom(bottom);
@@ -261,13 +264,28 @@ export function LogsContent({ className, onSourcesChange }: LogsContentProps) {
 
       <div className="flex-1 relative min-h-0">
         {displayEntries.length === 0 ? (
-          <div className="flex items-center justify-center h-full text-daintree-text/60 text-sm">
-            {logs.length === 0 && !previousSessionEntry
-              ? "No logs yet"
-              : logs.length === 0
-                ? "No new logs this session"
-                : "No logs match filters"}
-          </div>
+          logs.length > 0 && hasActiveFilters ? (
+            <div className="flex items-center justify-center h-full">
+              <EmptyState
+                variant="filtered-empty"
+                title="No logs match filters"
+                action={
+                  <button
+                    onClick={clearFilters}
+                    className="text-xs px-3 py-1.5 text-daintree-text/60 hover:text-daintree-text hover:bg-overlay-soft rounded transition-colors"
+                  >
+                    Clear filters
+                  </button>
+                }
+              />
+            </div>
+          ) : (
+            <div className="flex items-center justify-center h-full text-daintree-text/60 text-sm">
+              {logs.length === 0 && !previousSessionEntry
+                ? "No logs yet"
+                : "No new logs this session"}
+            </div>
+          )
         ) : (
           <Virtuoso
             ref={virtuosoRef}

--- a/src/components/Diagnostics/LogsContent.tsx
+++ b/src/components/Diagnostics/LogsContent.tsx
@@ -200,7 +200,12 @@ export function LogsContent({ className, onSourcesChange }: LogsContentProps) {
   const displayEntries = useMemo(() => collapseConsecutiveDuplicates(mainLogs), [mainLogs]);
   const deferredDisplayEntries = useDeferredValue(displayEntries);
 
-  const hasActiveFilters = Object.keys(filters).length > 0;
+  const hasActiveFilters =
+    (filters.levels?.length ?? 0) > 0 ||
+    (filters.sources?.length ?? 0) > 0 ||
+    !!filters.search ||
+    filters.startTime !== undefined ||
+    filters.endTime !== undefined;
 
   const handleAtBottomChange = useCallback(
     (bottom: boolean) => {

--- a/src/components/Diagnostics/__tests__/DiagnosticsDock.test.tsx
+++ b/src/components/Diagnostics/__tests__/DiagnosticsDock.test.tsx
@@ -2,7 +2,11 @@
 import { describe, it, expect, beforeEach, vi } from "vitest";
 import { render, act, fireEvent } from "@testing-library/react";
 import { DiagnosticsDock, DIAGNOSTICS_DOCK_REGION_ID } from "../DiagnosticsDock";
-import { useDiagnosticsStore, DIAGNOSTICS_MIN_HEIGHT } from "@/store/diagnosticsStore";
+import {
+  useDiagnosticsStore,
+  DIAGNOSTICS_MIN_HEIGHT,
+  DIAGNOSTICS_DEFAULT_HEIGHT,
+} from "@/store/diagnosticsStore";
 import { useErrorStore } from "@/store";
 
 vi.mock("@/components/ui/tooltip", () => ({
@@ -204,6 +208,27 @@ describe("DiagnosticsDock — separator keyboard resize", () => {
     const separator = container.querySelector('[role="separator"]') as HTMLDivElement;
     fireEvent.keyDown(separator, { key: "PageUp" });
     expect(useDiagnosticsStore.getState().height).toBe(480);
+  });
+
+  it("double-click resets height to DIAGNOSTICS_DEFAULT_HEIGHT", () => {
+    const { container } = renderWith(420, 600);
+    const separator = container.querySelector('[role="separator"]') as HTMLDivElement;
+    fireEvent.doubleClick(separator);
+    expect(useDiagnosticsStore.getState().height).toBe(DIAGNOSTICS_DEFAULT_HEIGHT);
+  });
+
+  it("Enter key resets height to DIAGNOSTICS_DEFAULT_HEIGHT", () => {
+    const { container } = renderWith(420, 600);
+    const separator = container.querySelector('[role="separator"]') as HTMLDivElement;
+    fireEvent.keyDown(separator, { key: "Enter" });
+    expect(useDiagnosticsStore.getState().height).toBe(DIAGNOSTICS_DEFAULT_HEIGHT);
+  });
+
+  it("Space key resets height to DIAGNOSTICS_DEFAULT_HEIGHT", () => {
+    const { container } = renderWith(420, 600);
+    const separator = container.querySelector('[role="separator"]') as HTMLDivElement;
+    fireEvent.keyDown(separator, { key: " " });
+    expect(useDiagnosticsStore.getState().height).toBe(DIAGNOSTICS_DEFAULT_HEIGHT);
   });
 });
 

--- a/src/components/Diagnostics/__tests__/LogsContent.test.tsx
+++ b/src/components/Diagnostics/__tests__/LogsContent.test.tsx
@@ -1,0 +1,98 @@
+// @vitest-environment jsdom
+import { describe, it, expect, beforeEach, vi } from "vitest";
+import { act, fireEvent, render, waitFor } from "@testing-library/react";
+import type { LogEntry } from "@shared/types";
+import { LogsContent } from "../LogsContent";
+import { useLogsStore } from "@/store";
+
+vi.mock("../../Logs/LogFilters", () => ({
+  LogFilters: () => <div data-testid="log-filters" />,
+}));
+
+vi.mock("react-virtuoso", () => ({
+  Virtuoso: ({ data }: { data: unknown[] }) => (
+    <div data-testid="virtuoso" data-count={data.length} />
+  ),
+}));
+
+const mockGetAll = vi.fn<() => Promise<LogEntry[]>>().mockResolvedValue([]);
+const mockGetSources = vi.fn<() => Promise<string[]>>().mockResolvedValue([]);
+
+vi.mock("@/clients", async (importOriginal) => {
+  const actual = (await importOriginal()) as Record<string, unknown>;
+  return {
+    ...actual,
+    logsClient: {
+      getAll: () => mockGetAll(),
+      getSources: () => mockGetSources(),
+      onBatch: () => () => {},
+    },
+    appClient: {
+      getVersion: vi.fn().mockResolvedValue("1.0.0"),
+    },
+  };
+});
+
+vi.mock("@/utils/logger", () => ({
+  logError: vi.fn(),
+}));
+
+function makeLog(id: string, overrides: Partial<LogEntry> = {}): LogEntry {
+  return {
+    id,
+    timestamp: Date.now(),
+    level: "info",
+    message: `log ${id}`,
+    ...overrides,
+  };
+}
+
+describe("LogsContent — filtered-empty recovery", () => {
+  beforeEach(() => {
+    mockGetAll.mockReset().mockResolvedValue([]);
+    mockGetSources.mockReset().mockResolvedValue([]);
+    useLogsStore.setState({
+      logs: [],
+      filters: {},
+      autoScroll: true,
+      expandedIds: new Set(),
+    });
+  });
+
+  it("shows EmptyState with Clear filters action when filters hide all logs", async () => {
+    mockGetAll.mockResolvedValue([makeLog("a", { level: "error" })]);
+    useLogsStore.setState({ filters: { levels: ["debug"] } });
+
+    const { findByText, queryByTestId } = render(<LogsContent />);
+
+    expect(await findByText("No logs match filters")).toBeTruthy();
+    expect(queryByTestId("virtuoso")).toBeNull();
+
+    const button = await findByText("Clear filters");
+    await act(async () => {
+      fireEvent.click(button);
+    });
+
+    expect(useLogsStore.getState().filters).toEqual({});
+  });
+
+  it("does not show the filtered-empty action when there are no logs at all", async () => {
+    mockGetAll.mockResolvedValue([]);
+    const { findByText, queryByText } = render(<LogsContent />);
+
+    expect(await findByText("No logs yet")).toBeTruthy();
+    expect(queryByText("Clear filters")).toBeNull();
+  });
+
+  it("does not show the filtered-empty action when filters are inactive", async () => {
+    mockGetAll.mockResolvedValue([makeLog("a", { level: "info" })]);
+    useLogsStore.setState({ filters: {} });
+    const { queryByText, findByTestId } = render(<LogsContent />);
+
+    await findByTestId("virtuoso");
+    await waitFor(() => {
+      expect(queryByText("No logs match filters")).toBeNull();
+      expect(queryByText("Clear filters")).toBeNull();
+    });
+  });
+});

--- a/src/components/Diagnostics/__tests__/LogsContent.test.tsx
+++ b/src/components/Diagnostics/__tests__/LogsContent.test.tsx
@@ -95,4 +95,15 @@ describe("LogsContent — filtered-empty recovery", () => {
       expect(queryByText("Clear filters")).toBeNull();
     });
   });
+
+  it("does not flag inert filter keys (undefined values) as active", async () => {
+    mockGetAll.mockResolvedValue([makeLog("a", { level: "info" })]);
+    useLogsStore.setState({ filters: { search: undefined, levels: [] } });
+    const { queryByText, findByTestId } = render(<LogsContent />);
+
+    await findByTestId("virtuoso");
+    await waitFor(() => {
+      expect(queryByText("No logs match filters")).toBeNull();
+    });
+  });
 });

--- a/src/components/Logs/LogFilters.tsx
+++ b/src/components/Logs/LogFilters.tsx
@@ -46,6 +46,15 @@ export function LogFilters({
     return () => clearTimeout(timer);
   }, [searchValue, filters.search, onFiltersChange]);
 
+  // External resets (e.g. clearFilters) zero filters.search but cannot reach
+  // this component's local searchValue. Without this sync the debounce above
+  // would resurrect the cleared search 200ms later.
+  useEffect(() => {
+    if (!filters.search && searchValue) {
+      setSearchValue("");
+    }
+  }, [filters.search, searchValue]);
+
   const handleLevelToggle = useCallback(
     (level: LogLevel) => {
       const currentLevels = filters.levels || [];

--- a/src/components/Logs/__tests__/LogFilters.test.tsx
+++ b/src/components/Logs/__tests__/LogFilters.test.tsx
@@ -72,4 +72,25 @@ describe("LogFilters accessibility", () => {
       expect(screen.queryByText("renderer")).toBeNull();
     });
   });
+
+  it("syncs the local search input when filters.search is cleared externally", async () => {
+    const onFiltersChange = vi.fn();
+    const { rerender } = render(
+      <LogFilters {...baseProps} filters={{ search: "foo" }} onFiltersChange={onFiltersChange} />
+    );
+    const input = screen.getByPlaceholderText("Search logs...") as HTMLInputElement;
+    expect(input.value).toBe("foo");
+
+    rerender(<LogFilters {...baseProps} filters={{}} onFiltersChange={onFiltersChange} />);
+
+    await waitFor(() => {
+      expect(input.value).toBe("");
+    });
+
+    onFiltersChange.mockClear();
+    await new Promise((r) => setTimeout(r, 250));
+    expect(onFiltersChange).not.toHaveBeenCalledWith(
+      expect.objectContaining({ search: "foo" })
+    );
+  });
 });


### PR DESCRIPTION
## Summary

- Double-click or `Enter`/`Space` on the `DiagnosticsDock` resize handle now resets dock height to `DIAGNOSTICS_DEFAULT_HEIGHT`, matching the pattern already in `TwoPaneSplitDivider`
- The filtered-empty branch in `LogsContent` now uses the shared `EmptyState` component (`filtered-empty` variant) with a Clear filters action wired to `clearFilters`, replacing a bare centred string
- Added a `useEffect` in `LogFilters` to sync the local search input when `clearFilters` is called externally — without this the 200ms debounce would resurrect a cleared search on the next tick

Resolves #7498

## Changes

- `DiagnosticsDock.tsx` — `onDoubleClick` and `onKeyDown` (`Enter`/`Space`) on the resize handle call `resetHeight`
- `LogsContent.tsx` — filtered-empty branch replaced with `<EmptyState variant="filtered-empty">` + Clear filters action
- `LogFilters.tsx` — `useEffect` syncs local `searchValue` state when the store's `search` resets to empty
- `DiagnosticsDock.test.tsx` — 3 new tests covering double-click reset, `Enter` reset, and `Space` reset
- `LogsContent.test.tsx` — 4 new tests covering filtered-empty render, Clear filters wiring, and zero-data/session branches not regressing
- `LogFilters.test.tsx` — 1 regression test confirming external `clearFilters` clears the search input immediately

## Testing

All 27 tests pass. `npm run check` clean: typecheck, channel drift, lint ratchet (−1 warning), and Prettier all pass.