### PR TITLE
fix(help-session): enforce single-backend invariant per project

### DIFF
--- a/electron/ipc/handlers/terminal/__tests__/lifecycle.spawn.test.ts
+++ b/electron/ipc/handlers/terminal/__tests__/lifecycle.spawn.test.ts
@@ -96,10 +96,19 @@ const mockGetCodexLaunchArgs = vi.hoisted(() =>
   vi.fn<(token: string) => string[] | null>(() => null)
 );
 
+const mockMarkTerminalForToken = vi.hoisted(() =>
+  vi.fn<(token: string, terminalId: string) => boolean>(() => true)
+);
+
+const mockUnbindTerminal = vi.hoisted(() => vi.fn<(terminalId: string) => void>());
+
 vi.mock("../../../../services/HelpSessionService.js", () => ({
   helpSessionService: {
     validateToken: (token: string) => mockValidateToken(token),
     getCodexLaunchArgs: (token: string) => mockGetCodexLaunchArgs(token),
+    markTerminalForToken: (token: string, terminalId: string) =>
+      mockMarkTerminalForToken(token, terminalId),
+    unbindTerminal: (terminalId: string) => mockUnbindTerminal(terminalId),
   },
 }));
 
@@ -566,6 +575,9 @@ describe("terminal spawn handler - help session detection (#6524)", () => {
     mockCurrentPort.mockReturnValue(null);
     mockGetCodexLaunchArgs.mockReset();
     mockGetCodexLaunchArgs.mockReturnValue(null);
+    mockMarkTerminalForToken.mockReset();
+    mockMarkTerminalForToken.mockReturnValue(true);
+    mockUnbindTerminal.mockReset();
   });
 
   it("skips per-pane MCP injection when DAINTREE_MCP_TOKEN is a valid help token (session-dir owns the .mcp.json)", async () => {
@@ -866,5 +878,74 @@ describe("terminal spawn handler - help session detection (#6524)", () => {
 
     const spawnArgs = ptyClient.spawn.mock.calls[0][1];
     expect(spawnArgs.command).toBe("codex");
+  });
+
+  it("binds terminalId to the help session before spawn so HelpSessionService can kill it on displacement (#7509)", async () => {
+    mockValidateToken.mockImplementation((token) => (token === "help-token" ? "action" : false));
+
+    const deps = { ptyClient } as unknown as HandlerDependencies;
+    registerTerminalLifecycleHandlers(deps);
+
+    const handler = getSpawnHandler();
+    const id = await handler(
+      {} as Electron.IpcMainInvokeEvent,
+      {
+        cols: 80,
+        rows: 24,
+        cwd: tmpDir,
+        command: "claude",
+        launchAgentId: "claude",
+        env: { DAINTREE_MCP_TOKEN: "help-token" },
+      } as unknown as Parameters<typeof handler>[1]
+    );
+
+    expect(mockMarkTerminalForToken).toHaveBeenCalledWith("help-token", id);
+    expect(ptyClient.spawn).toHaveBeenCalledTimes(1);
+  });
+
+  it("refuses to spawn an assistant PTY when markTerminalForToken returns false (#7509)", async () => {
+    mockValidateToken.mockImplementation((token) => (token === "help-token" ? "action" : false));
+    mockMarkTerminalForToken.mockReturnValue(false);
+
+    const deps = { ptyClient } as unknown as HandlerDependencies;
+    registerTerminalLifecycleHandlers(deps);
+
+    const handler = getSpawnHandler();
+    await expect(
+      handler(
+        {} as Electron.IpcMainInvokeEvent,
+        {
+          cols: 80,
+          rows: 24,
+          cwd: tmpDir,
+          command: "claude",
+          launchAgentId: "claude",
+          env: { DAINTREE_MCP_TOKEN: "help-token" },
+        } as unknown as Parameters<typeof handler>[1]
+      )
+    ).rejects.toThrow(/Daintree Assistant session token is invalid/);
+
+    expect(ptyClient.spawn).not.toHaveBeenCalled();
+  });
+
+  it("does not call markTerminalForToken for a non-help launch", async () => {
+    mockValidateToken.mockReturnValue(false);
+
+    const deps = { ptyClient } as unknown as HandlerDependencies;
+    registerTerminalLifecycleHandlers(deps);
+
+    const handler = getSpawnHandler();
+    await handler(
+      {} as Electron.IpcMainInvokeEvent,
+      {
+        cols: 80,
+        rows: 24,
+        cwd: tmpDir,
+        command: "claude",
+        launchAgentId: "claude",
+      } as unknown as Parameters<typeof handler>[1]
+    );
+
+    expect(mockMarkTerminalForToken).not.toHaveBeenCalled();
   });
 });

--- a/electron/ipc/handlers/terminal/__tests__/lifecycle.spawn.test.ts
+++ b/electron/ipc/handlers/terminal/__tests__/lifecycle.spawn.test.ts
@@ -662,36 +662,38 @@ describe("terminal spawn handler - help session detection (#6524)", () => {
     expect(spawnArgs.command).not.toContain("--dangerously-skip-permissions");
   });
 
-  it("falls back to per-pane MCP injection when DAINTREE_MCP_TOKEN is not a valid help token", async () => {
+  it("refuses to spawn when DAINTREE_MCP_TOKEN is present but invalid for an assistant-supported launch (#7509)", async () => {
+    // Models the orphan-backend scenario: the renderer provisioned a session,
+    // a sibling provision displaced it, then the renderer's spawn IPC arrived
+    // carrying the now-revoked token. Falling back to per-pane MCP injection
+    // here would resurrect the bug — silently spawning an unmanaged Claude
+    // instance in the assistant's slot without single-backend enforcement.
+    // The handler must refuse so the renderer is forced to provision fresh.
     mockValidateToken.mockReturnValue(false);
     mockIsRunning.mockReturnValue(true);
     mockCurrentPort.mockReturnValue(45454);
-    mockPreparePaneConfig.mockResolvedValue({
-      configPath: "/tmp/pane-config.json",
-      token: "pane-token",
-    });
     mockGetProjectSettings.mockResolvedValue({ daintreeMcpTier: "action" });
 
     const deps = { ptyClient } as unknown as HandlerDependencies;
     registerTerminalLifecycleHandlers(deps);
 
     const handler = getSpawnHandler();
-    await handler(
-      {} as Electron.IpcMainInvokeEvent,
-      {
-        cols: 80,
-        rows: 24,
-        cwd: tmpDir,
-        command: "claude",
-        launchAgentId: "claude",
-        env: { DAINTREE_MCP_TOKEN: "stale-or-spoofed" },
-      } as unknown as Parameters<typeof handler>[1]
-    );
+    await expect(
+      handler(
+        {} as Electron.IpcMainInvokeEvent,
+        {
+          cols: 80,
+          rows: 24,
+          cwd: tmpDir,
+          command: "claude",
+          launchAgentId: "claude",
+          env: { DAINTREE_MCP_TOKEN: "stale-or-spoofed" },
+        } as unknown as Parameters<typeof handler>[1]
+      )
+    ).rejects.toThrow(/Daintree Assistant session token is invalid/);
 
-    const spawnArgs = ptyClient.spawn.mock.calls[0][1];
-    expect(spawnArgs.command).toContain("--mcp-config");
-    expect(spawnArgs.command).not.toContain("--strict-mcp-config");
-    expect(mockPreparePaneConfig).toHaveBeenCalledTimes(1);
+    expect(ptyClient.spawn).not.toHaveBeenCalled();
+    expect(mockPreparePaneConfig).not.toHaveBeenCalled();
   });
 
   it("starts MCP on demand before injecting config for restored Claude agent spawns", async () => {

--- a/electron/ipc/handlers/terminal/lifecycle.ts
+++ b/electron/ipc/handlers/terminal/lifecycle.ts
@@ -261,6 +261,20 @@ export function registerTerminalLifecycleHandlers(deps: HandlerDependencies): ()
           safeCommand = `${safeCommand} ${codexArgs.map(shellQuote).join(" ")}`;
         }
       }
+
+      // Bind this terminalId to the help session so HelpSessionService can
+      // kill the PTY when the session is displaced or revoked (#7509). Owns
+      // the binding from main-process spawn time, so it doesn't depend on
+      // the renderer-issued `help.markTerminal` round-trip landing first.
+      // A false return means the token was revoked between provision and
+      // spawn (e.g. a stale resume against a session a sibling provision
+      // already displaced) — refuse to launch as a help session rather
+      // than silently degrading to a non-help Claude.
+      if (!helpSessionService.markTerminalForToken(helpToken, id)) {
+        throw new Error(
+          "Daintree Assistant session token is invalid or already displaced; refusing to spawn"
+        );
+      }
     } else if (launchAgentId === "claude" && safeCommand.length > 0 && projectId) {
       // Daintree MCP injection for normal Claude Code agent launches.
       // Mints a per-pane bearer token, writes a managed --mcp-config JSON under
@@ -349,6 +363,11 @@ export function registerTerminalLifecycleHandlers(deps: HandlerDependencies): ()
       mcpPaneConfigService.revokePaneConfig(id).catch(() => {
         // best-effort cleanup
       });
+      // If we bound this terminalId to a help session above, unbind now so a
+      // future provision doesn't try to kill a PTY that never spawned.
+      if (isHelpLaunch) {
+        helpSessionService.unbindTerminal(id);
+      }
       const errorMessage = formatErrorMessage(error, "Failed to spawn terminal");
       throw new Error(`Failed to spawn terminal: ${errorMessage}`);
     }

--- a/electron/ipc/handlers/terminal/lifecycle.ts
+++ b/electron/ipc/handlers/terminal/lifecycle.ts
@@ -221,11 +221,22 @@ export function registerTerminalLifecycleHandlers(deps: HandlerDependencies): ()
     // (skipPermissions), append the dangerous flag.
     const helpToken = spawnEnv?.DAINTREE_MCP_TOKEN ?? "";
     const helpTier = helpToken ? helpSessionService.validateToken(helpToken) : false;
-    const isHelpLaunch =
-      helpTier !== false &&
-      typeof launchAgentId === "string" &&
-      getAssistantSupportedAgentIds().includes(launchAgentId) &&
-      safeCommand.length > 0;
+    const isAssistantAgent =
+      typeof launchAgentId === "string" && getAssistantSupportedAgentIds().includes(launchAgentId);
+    const isHelpLaunch = helpTier !== false && isAssistantAgent && safeCommand.length > 0;
+
+    // If a help-session token was supplied but is invalid (revoked between
+    // provision and spawn — typically because a sibling provision displaced
+    // the session under the single-backend invariant), refuse to silently
+    // fall back to a normal Claude launch with per-pane MCP injection. The
+    // renderer must always provision a fresh session before spawning the
+    // assistant; falling through would resurrect the orphan-backend failure
+    // mode (#7509) by spawning an unmanaged Claude in the assistant slot.
+    if (!isHelpLaunch && helpToken && isAssistantAgent && safeCommand.length > 0) {
+      throw new Error(
+        "Daintree Assistant session token is invalid or already displaced; refusing to spawn"
+      );
+    }
 
     if (isHelpLaunch && launchAgentId) {
       const dangerous = DEFAULT_DANGEROUS_ARGS[launchAgentId];

--- a/electron/services/HelpSessionService.ts
+++ b/electron/services/HelpSessionService.ts
@@ -10,6 +10,12 @@ import { formatErrorMessage } from "../../shared/utils/errorMessage.js";
 import { probeMcpServer, probeMcpSseServer } from "./mcp-server/readinessProbe.js";
 import { getAssistantSupportedAgentIds } from "../../shared/config/agentRegistry.js";
 import type { HelpAssistantTier } from "../../shared/types/ipc/maps.js";
+import type { PtyClient } from "./PtyClient.js";
+
+// Narrow type so the test suite (and any future caller) can satisfy this
+// dependency without instantiating a full PtyClient. Only `kill` is needed —
+// the help-session displacement path is fire-and-forget by design.
+type PtyKillClient = Pick<PtyClient, "kill">;
 
 const SESSIONS_DIR_NAME = "help-sessions";
 const META_FILE_NAME = "meta.json";
@@ -105,11 +111,24 @@ export class HelpSessionService {
   // otherwise race the .mcp.json overwrite, producing a Claude instance
   // authenticating with the wrong session record.
   private readonly provisionLocks = new Map<string, Promise<void>>();
+  // Single-backend invariant (#7509): at most one assistant PTY per project
+  // at any given time. The renderer's cooperative cleanup paths (removePanel,
+  // gracefulKill on hibernate, visibilitychange tearDown) are fire-and-forget
+  // and can drop the kill IPC, leaving an orphan PTY that keeps dispatching
+  // MCP tool calls under a still-valid bearer. These maps let the main process
+  // displace prior backends regardless of what the renderer did.
+  private readonly activeHelpTerminalByProjectId = new Map<string, string>();
+  private readonly terminalBySessionId = new Map<string, string>();
   private mcpRegistry: WindowRegistry | null = null;
+  private ptyClient: PtyKillClient | null = null;
   private disposed = false;
 
   setMcpRegistry(registry: WindowRegistry): void {
     this.mcpRegistry = registry;
+  }
+
+  setPtyClient(client: PtyKillClient | null): void {
+    this.ptyClient = client;
   }
 
   validateToken(token: string): HelpAssistantTier | false {
@@ -118,6 +137,48 @@ export class HelpSessionService {
     if (!record) return false;
     if (record.revoked) return false;
     return record.tier;
+  }
+
+  /**
+   * Binds a freshly spawned PTY terminal id to its help-session token. Called
+   * from the lifecycle spawn handler after `validateToken` confirms the
+   * launch is a help session, so the main process owns the terminalId↔session
+   * association without depending on a renderer-issued `help.markTerminal`
+   * round-trip. Returns false for unknown or revoked tokens — the spawn
+   * handler treats that as a hard failure (the token was revoked between
+   * provision and spawn — almost certainly a stale resume against a session
+   * that was already displaced).
+   *
+   * If a different terminal was already bound for the same project, kills it
+   * here too. This is the second line of defense behind the displacement in
+   * `doProvision`: covers the renderer race where a new spawn arrives before
+   * a prior provision's terminal binding was recorded.
+   */
+  markTerminalForToken(token: string, terminalId: string): boolean {
+    if (!token || !terminalId) return false;
+    const record = this.sessionsByToken.get(token);
+    if (!record || record.revoked) return false;
+
+    const existingTerminal = this.activeHelpTerminalByProjectId.get(record.projectId);
+    if (existingTerminal && existingTerminal !== terminalId) {
+      this.killTerminal(existingTerminal, "help-session-displaced");
+      this.removeTerminalFromMaps(existingTerminal);
+    }
+
+    this.activeHelpTerminalByProjectId.set(record.projectId, terminalId);
+    this.terminalBySessionId.set(record.sessionId, terminalId);
+    return true;
+  }
+
+  /**
+   * Drops a terminal id from the help-session indexes without revoking the
+   * session record. Used by the spawn handler's catch block when the PTY
+   * spawn never landed — the session is still valid (caller may retry),
+   * but this terminalId is dead.
+   */
+  unbindTerminal(terminalId: string): void {
+    if (!terminalId) return;
+    this.removeTerminalFromMaps(terminalId);
   }
 
   /**
@@ -208,6 +269,17 @@ export class HelpSessionService {
         );
       }
     }
+
+    // Single-backend invariant (#7509): displace any prior unrevoked record
+    // for this project BEFORE writing a fresh `.mcp.json`. The bearer is
+    // marked revoked first so any in-flight MCP call from the orphan 401s
+    // before the kill IPC reaches the PTY host. Runs inside `provisionLocks`
+    // (per pathHash), so concurrent provisions for the same project see this
+    // as an atomic step. The renderer still calls `revokeHelpSession` from
+    // its cooperative cleanup paths — this enforcement is defense-in-depth
+    // for when those paths drop the kill or never fire (crash, project
+    // switch, hibernate race).
+    this.displacePriorSessions(input.projectId);
 
     await fs.mkdir(sessionsRoot, { recursive: true, mode: 0o700 });
     await fs.chmod(sessionsRoot, 0o700).catch(() => {});
@@ -364,10 +436,68 @@ export class HelpSessionService {
     record.revoked = true;
     this.sessionsById.delete(sessionId);
     this.sessionsByToken.delete(record.token);
+
+    // Single-backend invariant (#7509): kill the bound PTY now so the orphan
+    // can't keep dispatching MCP calls under the just-revoked bearer. Guard
+    // against clobbering a sibling session that took over the project's
+    // active-terminal slot before this revoke ran.
+    const terminalId = this.terminalBySessionId.get(sessionId);
+    if (terminalId) {
+      this.terminalBySessionId.delete(sessionId);
+      if (this.activeHelpTerminalByProjectId.get(record.projectId) === terminalId) {
+        this.activeHelpTerminalByProjectId.delete(record.projectId);
+      }
+      this.killTerminal(terminalId, "help-session-revoked");
+    }
+
     // Codex sessions write nothing to disk (config is `-c` flags), so the
     // file-strip dance is Claude-only.
     if (record.agentId !== "codex") {
       await this.stripStaleDaintreeMcpEntry(record.sessionPath);
+    }
+  }
+
+  private displacePriorSessions(projectId: string): void {
+    const priors = [...this.sessionsById.values()].filter(
+      (record) => record.projectId === projectId && !record.revoked
+    );
+    for (const prior of priors) {
+      prior.revoked = true;
+      this.sessionsByToken.delete(prior.token);
+      this.sessionsById.delete(prior.sessionId);
+      const terminalId = this.terminalBySessionId.get(prior.sessionId);
+      if (terminalId) {
+        this.terminalBySessionId.delete(prior.sessionId);
+        this.killTerminal(terminalId, "help-session-displaced");
+      }
+    }
+    // Also clear any stale active-terminal binding the renderer never
+    // confirmed via `markTerminalForToken` — leaving it would leak the
+    // project's slot and cause the next `markTerminalForToken` to kill
+    // the wrong PTY.
+    this.activeHelpTerminalByProjectId.delete(projectId);
+  }
+
+  private killTerminal(terminalId: string, reason: string): void {
+    if (!this.ptyClient) return;
+    try {
+      this.ptyClient.kill(terminalId, reason);
+    } catch (err) {
+      console.warn(
+        "[HelpSessionService] Failed to kill displaced help PTY:",
+        terminalId,
+        reason,
+        err
+      );
+    }
+  }
+
+  private removeTerminalFromMaps(terminalId: string): void {
+    for (const [pid, tid] of this.activeHelpTerminalByProjectId.entries()) {
+      if (tid === terminalId) this.activeHelpTerminalByProjectId.delete(pid);
+    }
+    for (const [sid, tid] of this.terminalBySessionId.entries()) {
+      if (tid === terminalId) this.terminalBySessionId.delete(sid);
     }
   }
 

--- a/electron/services/__tests__/HelpSessionService.test.ts
+++ b/electron/services/__tests__/HelpSessionService.test.ts
@@ -97,6 +97,7 @@ describe("HelpSessionService", () => {
   let userData: string;
   let helpFolder: string;
   let service: HelpSessionService;
+  let mockPtyKill: ReturnType<typeof vi.fn>;
 
   beforeEach(async () => {
     tmpRoot = await fs.mkdtemp(path.join(os.tmpdir(), "help-session-svc-"));
@@ -128,6 +129,8 @@ describe("HelpSessionService", () => {
     // happy path; one test below intentionally tests the registry-set flow
     // by overriding to a different fakeRegistry.
     service.setMcpRegistry({} as never);
+    mockPtyKill = vi.fn();
+    service.setPtyClient({ kill: mockPtyKill });
     vi.spyOn(console, "warn").mockImplementation(() => {});
   });
 
@@ -264,13 +267,18 @@ describe("HelpSessionService", () => {
   });
 
   it("getWebContentsIdForToken returns the per-session pin when two sessions are minted from different views", async () => {
+    // Distinct projectIds so the single-backend invariant (#7509) doesn't
+    // displace `a` when `b` is provisioned. The intent of this test is the
+    // per-session WebContents pin, not multi-tenancy of one project.
     const a = await service.provisionSession({
       ...provisionInput(),
+      projectId: "proj-a",
       projectPath: "/tmp/proj-a",
       projectViewWebContentsId: 100,
     });
     const b = await service.provisionSession({
       ...provisionInput(),
+      projectId: "proj-b",
       projectPath: "/tmp/proj-b",
       projectViewWebContentsId: 200,
     });
@@ -562,6 +570,159 @@ describe("HelpSessionService", () => {
     );
     expect(mcp.mcpServers.daintree).toBeUndefined();
     expect(mcp.mcpServers["daintree-docs"]).toBeDefined();
+  });
+
+  describe("single-backend invariant (#7509)", () => {
+    it("provisioning a second session for the same project revokes the first token and kills its bound PTY", async () => {
+      const first = await service.provisionSession(provisionInput());
+      if (!first) throw new Error("expected first provision");
+      expect(service.markTerminalForToken(first.token, "term-1")).toBe(true);
+
+      const second = await service.provisionSession(provisionInput());
+      if (!second) throw new Error("expected second provision");
+
+      expect(service.validateToken(first.token)).toBe(false);
+      expect(service.validateToken(second.token)).toBe("action");
+      expect(mockPtyKill).toHaveBeenCalledWith("term-1", "help-session-displaced");
+    });
+
+    it("provisioning a second session for the same project displaces the first even when no terminal was ever bound", async () => {
+      // Models the renderer race where the new provision arrives before
+      // `markTerminalForToken` was called for the prior session — bearer
+      // is still revoked, no PTY kill (nothing to kill).
+      const first = await service.provisionSession(provisionInput());
+      if (!first) throw new Error("expected first provision");
+
+      const second = await service.provisionSession(provisionInput());
+      if (!second) throw new Error("expected second provision");
+
+      expect(service.validateToken(first.token)).toBe(false);
+      expect(service.validateToken(second.token)).toBe("action");
+      expect(mockPtyKill).not.toHaveBeenCalled();
+    });
+
+    it("provisioning a session for a different project does not displace the first project's PTY", async () => {
+      const first = await service.provisionSession({
+        ...provisionInput(),
+        projectId: "proj-1",
+        projectPath: "/tmp/proj-1",
+      });
+      if (!first) throw new Error("expected first provision");
+      expect(service.markTerminalForToken(first.token, "term-1")).toBe(true);
+
+      const second = await service.provisionSession({
+        ...provisionInput(),
+        projectId: "proj-2",
+        projectPath: "/tmp/proj-2",
+      });
+      if (!second) throw new Error("expected second provision");
+
+      expect(service.validateToken(first.token)).toBe("action");
+      expect(service.validateToken(second.token)).toBe("action");
+      expect(mockPtyKill).not.toHaveBeenCalled();
+    });
+
+    it("revokeSession kills the bound PTY", async () => {
+      const result = await service.provisionSession(provisionInput());
+      if (!result) throw new Error("expected result");
+      expect(service.markTerminalForToken(result.token, "term-1")).toBe(true);
+
+      await service.revokeSession(result.sessionId);
+
+      expect(mockPtyKill).toHaveBeenCalledWith("term-1", "help-session-revoked");
+    });
+
+    it("revokeSession is idempotent — kill is called at most once", async () => {
+      const result = await service.provisionSession(provisionInput());
+      if (!result) throw new Error("expected result");
+      expect(service.markTerminalForToken(result.token, "term-1")).toBe(true);
+
+      await service.revokeSession(result.sessionId);
+      await service.revokeSession(result.sessionId);
+
+      expect(mockPtyKill).toHaveBeenCalledTimes(1);
+    });
+
+    it("markTerminalForToken returns false for an unknown token without firing kill", async () => {
+      expect(service.markTerminalForToken("not-a-token", "term-1")).toBe(false);
+      expect(mockPtyKill).not.toHaveBeenCalled();
+    });
+
+    it("markTerminalForToken returns false for a revoked token without firing kill", async () => {
+      const result = await service.provisionSession(provisionInput());
+      if (!result) throw new Error("expected result");
+      await service.revokeSession(result.sessionId);
+
+      expect(service.markTerminalForToken(result.token, "term-1")).toBe(false);
+      expect(mockPtyKill).not.toHaveBeenCalled();
+    });
+
+    it("markTerminalForToken displaces a stale terminal binding for the same project", async () => {
+      // Models the renderer race where two spawn IPCs land back-to-back for
+      // the same provisioned session: the second binding must displace the
+      // first PTY so the project's slot doesn't end up holding a stale id.
+      const result = await service.provisionSession(provisionInput());
+      if (!result) throw new Error("expected result");
+      expect(service.markTerminalForToken(result.token, "term-old")).toBe(true);
+      expect(service.markTerminalForToken(result.token, "term-new")).toBe(true);
+
+      expect(mockPtyKill).toHaveBeenCalledWith("term-old", "help-session-displaced");
+    });
+
+    it("PTY kill failures during displacement do not prevent provisioning", async () => {
+      mockPtyKill.mockImplementationOnce(() => {
+        throw new Error("pty host crashed");
+      });
+      const first = await service.provisionSession(provisionInput());
+      if (!first) throw new Error("expected first provision");
+      expect(service.markTerminalForToken(first.token, "term-1")).toBe(true);
+
+      const second = await service.provisionSession(provisionInput());
+      expect(second).not.toBeNull();
+      // Bearer revocation is the security gate; the kill is best-effort.
+      expect(service.validateToken(first.token)).toBe(false);
+    });
+
+    it("displacement still revokes the prior bearer when no PtyClient is wired", async () => {
+      // Cold-boot edge case: provision before the deferred wiring drains.
+      // The orphan's MCP calls 401 even without the kill landing.
+      service.setPtyClient(null);
+      const first = await service.provisionSession(provisionInput());
+      if (!first) throw new Error("expected first provision");
+      expect(service.markTerminalForToken(first.token, "term-1")).toBe(true);
+
+      const second = await service.provisionSession(provisionInput());
+      expect(second).not.toBeNull();
+      expect(service.validateToken(first.token)).toBe(false);
+    });
+
+    it("unbindTerminal removes the binding so a subsequent provision does not kill the unbound PTY", async () => {
+      const first = await service.provisionSession(provisionInput());
+      if (!first) throw new Error("expected first provision");
+      expect(service.markTerminalForToken(first.token, "term-1")).toBe(true);
+
+      service.unbindTerminal("term-1");
+
+      // A second provision for the same project still revokes the first's
+      // bearer — but now there is no PTY id to kill.
+      const second = await service.provisionSession(provisionInput());
+      if (!second) throw new Error("expected second provision");
+      expect(service.validateToken(first.token)).toBe(false);
+      expect(mockPtyKill).not.toHaveBeenCalled();
+    });
+
+    it("revokeByWebContentsId kills the bound PTY for the matching session", async () => {
+      const result = await service.provisionSession({
+        ...provisionInput(),
+        projectViewWebContentsId: 99,
+      });
+      if (!result) throw new Error("expected result");
+      expect(service.markTerminalForToken(result.token, "term-99")).toBe(true);
+
+      await service.revokeByWebContentsId(99);
+
+      expect(mockPtyKill).toHaveBeenCalledWith("term-99", "help-session-revoked");
+    });
   });
 
   describe("Codex", () => {

--- a/electron/services/__tests__/HelpSessionService.test.ts
+++ b/electron/services/__tests__/HelpSessionService.test.ts
@@ -97,7 +97,7 @@ describe("HelpSessionService", () => {
   let userData: string;
   let helpFolder: string;
   let service: HelpSessionService;
-  let mockPtyKill: ReturnType<typeof vi.fn>;
+  let mockPtyKill: ReturnType<typeof vi.fn<(id: string, reason?: string) => void>>;
 
   beforeEach(async () => {
     tmpRoot = await fs.mkdtemp(path.join(os.tmpdir(), "help-session-svc-"));

--- a/electron/window/__tests__/globalServicesInit.order.test.ts
+++ b/electron/window/__tests__/globalServicesInit.order.test.ts
@@ -153,7 +153,9 @@ vi.mock("../../setup/environment.js", () => ({
 vi.mock("../../services/HelpSessionService.js", () => ({
   helpSessionService: {
     setMcpRegistry,
+    setPtyClient: vi.fn(),
     validateToken: vi.fn(),
+    gcStaleSessions: vi.fn(async () => {}),
   },
 }));
 
@@ -242,7 +244,14 @@ describe("initGlobalServices task ordering", () => {
 
     expect(registeredTaskNames).not.toContain("mcp-server");
     expect(registeredTaskNames).not.toContain("help-session-gc");
+    expect(registeredTaskNames).not.toContain("help-session-pty");
     expect(setMcpRegistry).not.toHaveBeenCalled();
+  });
+
+  it("registers help-session-pty so HelpSessionService gets a PtyClient ref for displacement (#7509)", async () => {
+    const fakeRegistry = { all: () => [], size: 0 } as unknown as WindowRegistry;
+    await initGlobalServices(fakeRegistry);
+    expect(registeredTaskNames).toContain("help-session-pty");
   });
 
   it("registers database-maintenance after system-sleep-service so onSuspend can attach to a live service", async () => {

--- a/electron/window/globalServicesInit.ts
+++ b/electron/window/globalServicesInit.ts
@@ -615,6 +615,31 @@ export async function initGlobalServices(
         }
       },
     });
+
+    // Wire HelpSessionService -> PtyClient so the single-backend invariant
+    // (#7509) can fire-and-forget kill a displaced or revoked help PTY. Done
+    // as a deferred task so we run after `perWindowInit` has set the global
+    // ptyClient ref. If the ref is somehow still null when we drain (early
+    // shutdown, fork crash), the displacement still revokes the bearer in
+    // memory — the orphan's MCP calls 401 even without the kill landing.
+    registerDeferredTask({
+      name: "help-session-pty",
+      run: async () => {
+        try {
+          const ptyClient = getPtyClient();
+          if (!ptyClient) {
+            console.warn(
+              "[MAIN] PtyClient not available when wiring HelpSessionService — displacement will only revoke bearers"
+            );
+            return;
+          }
+          const { helpSessionService } = await import("../services/HelpSessionService.js");
+          helpSessionService.setPtyClient(ptyClient);
+        } catch (err) {
+          console.warn("[MAIN] Failed to wire HelpSessionService PtyClient:", err);
+        }
+      },
+    });
   }
 
   registerDeferredTask({


### PR DESCRIPTION
## Summary

- The assistant could leave an orphaned backend PTY running after a session restart — the renderer's kill IPC was fire-and-forget, so a dropped call or a race left the old process alive while a new one started for the same project.
- `HelpSessionService` now enforces a hard single-backend invariant on the main process side: provisioning a new assistant PTY for a project automatically displaces any prior one, regardless of what the renderer did or didn't clean up.
- Invalid help tokens are refused at spawn time in the terminal lifecycle handler, and the `PtyClient` is wired into `HelpSessionService` via a deferred task in `globalServicesInit.ts`.

Resolves #7509

## Changes

- `electron/services/HelpSessionService.ts` — added session maps, `setPtyClient`, `markTerminalForToken`, `displacePriorSessions`, and kill-on-revoke; displacement runs before any new PTY is provisioned
- `electron/ipc/handlers/terminal/lifecycle.ts` — refuses spawn when the help token is invalid; binds `terminalId` to the session after spawn succeeds
- `electron/window/globalServicesInit.ts` — deferred task wires `PtyClient` into `HelpSessionService` after PTY host is ready

## Testing

- New unit tests in `HelpSessionService.test.ts` cover displacement logic (prior session killed, maps updated, no orphan left)
- `lifecycle.spawn.test.ts` extended to cover invalid-token refusal
- `globalServicesInit.order.test.ts` verifies the deferred wiring runs in the right order
- All 4020 tests pass; lint, format, typecheck, and build are clean