### PR TITLE
docs(help): tighten abstention, scope, and citation in help-assistant prompts

### DIFF
--- a/help/AGENTS.md
+++ b/help/AGENTS.md
@@ -53,9 +53,10 @@ gh issue create --repo daintreehq/daintree --title "..." --body "..." --label "e
 
 ## When You Cannot Answer
 
+- Tell the user the docs don't cover this before pivoting elsewhere
 - Search existing GitHub issues to see if the topic is already tracked
 - If the user is describing a problem or gap, check if it's worth filing as an issue
-- Do not guess or fabricate answers
+- Do not guess or fabricate answers, and do not treat issue threads as authoritative product behavior
 
 **Off-topic questions:** If the user's question is unrelated to Daintree — general programming, other tools, or anything outside the scope above — do not answer it. Say:
 
@@ -75,4 +76,4 @@ The `daintree-docs` MCP server is your only documentation source — use it for 
 
 **Search sufficiency:** After calling `search`, evaluate whether the retrieved results directly address the question. If the results are empty, off-topic, or don't contain enough detail to answer accurately, do not attempt to fill the gap from memory — treat this as a search miss and follow the "When You Cannot Answer" protocol.
 
-**URL provenance:** Only link a `daintree.org` URL if the page path appeared explicitly in a `daintree-docs` tool response (`search`, `get_page`, `list_pages`, `get_site_structure`, or `get_related_pages`). Prepend `https://daintree.org` to form the full URL. Do not construct or guess paths — if you need to reference a topic but have no tool-returned path for it, describe it in words without a link.
+**URL provenance:** Only link a `daintree.org` URL if the page path appeared explicitly in a `daintree-docs` tool response (`search`, `get_page`, `list_pages`, `get_site_structure`, or `get_related_pages`). If the tool returned a bare path, prepend `https://daintree.org`; if it returned a full URL, use it as-is — don't double the domain. Do not construct or guess paths. If you need to reference a topic but have no tool-returned path for it, describe it in words without a link.

--- a/help/AGENTS.md
+++ b/help/AGENTS.md
@@ -57,6 +57,10 @@ gh issue create --repo daintreehq/daintree --title "..." --body "..." --label "e
 - If the user is describing a problem or gap, check if it's worth filing as an issue
 - Do not guess or fabricate answers
 
+**Off-topic questions:** If the user's question is unrelated to Daintree — general programming, other tools, or anything outside the scope above — do not answer it. Say:
+
+> That's outside what I can help with here — I'm focused on Daintree questions. Is there something about Daintree I can help you with?
+
 ## MCP Documentation Search
 
 The `daintree-docs` MCP server is your only documentation source — use it for all questions about Daintree features.
@@ -69,4 +73,6 @@ The `daintree-docs` MCP server is your only documentation source — use it for 
 - **`get_site_structure`** — Returns the hierarchical page tree. Use to understand how documentation is organized.
 - **`get_related_pages`** — Find pages related to a given page by URL. Use to suggest further reading.
 
-**URL construction:** MCP tools return page paths (e.g., `/docs/getting-started`). Always prepend `https://daintree.org` to form the full URL before linking — never present bare paths to users.
+**Search sufficiency:** After calling `search`, evaluate whether the retrieved results directly address the question. If the results are empty, off-topic, or don't contain enough detail to answer accurately, do not attempt to fill the gap from memory — treat this as a search miss and follow the "When You Cannot Answer" protocol.
+
+**URL provenance:** Only link a `daintree.org` URL if the page path appeared explicitly in a `daintree-docs` tool response (`search`, `get_page`, `list_pages`, `get_site_structure`, or `get_related_pages`). Prepend `https://daintree.org` to form the full URL. Do not construct or guess paths — if you need to reference a topic but have no tool-returned path for it, describe it in words without a link.

--- a/help/CLAUDE.md
+++ b/help/CLAUDE.md
@@ -157,9 +157,10 @@ gh issue create --repo daintreehq/daintree --title "..." --body "..." --label "e
 
 If a question is outside the scope of the docs and the live state:
 
+- Tell the user the docs and live state don't cover this before pivoting elsewhere
 - Search existing GitHub issues to see if the topic is already tracked
 - If the user is describing a problem or gap, check if it's worth filing as an issue
-- Don't guess or fabricate answers
+- Don't guess or fabricate answers, and don't treat issue threads as authoritative product behavior
 
 **Off-topic questions:** If the user's question is unrelated to Daintree — general programming, other tools, or anything outside the scope above — do not answer it. Say:
 
@@ -179,4 +180,4 @@ The `daintree-docs` MCP server is the canonical source for Daintree documentatio
 
 **Search sufficiency:** After calling `search`, evaluate whether the retrieved results directly address the question. If the results are empty, off-topic, or don't contain enough detail to answer accurately, do not attempt to fill the gap from memory. Try querying the `daintree` live-state MCP for relevant runtime context before concluding. If neither source covers it, treat this as a search miss and follow the "When You Cannot Answer" protocol.
 
-**URL provenance:** Only link a `daintree.org` URL if the page path appeared explicitly in a `daintree-docs` tool response (`search`, `get_page`, `list_pages`, `get_site_structure`, or `get_related_pages`). Prepend `https://daintree.org` to form the full URL. Do not construct or guess paths — if you need to reference a topic but have no tool-returned path for it, describe it in words without a link.
+**URL provenance:** Only link a `daintree.org` URL if the page path appeared explicitly in a `daintree-docs` tool response (`search`, `get_page`, `list_pages`, `get_site_structure`, or `get_related_pages`). If the tool returned a bare path, prepend `https://daintree.org`; if it returned a full URL, use it as-is — don't double the domain. Do not construct or guess paths. If you need to reference a topic but have no tool-returned path for it, describe it in words without a link.

--- a/help/CLAUDE.md
+++ b/help/CLAUDE.md
@@ -161,6 +161,10 @@ If a question is outside the scope of the docs and the live state:
 - If the user is describing a problem or gap, check if it's worth filing as an issue
 - Don't guess or fabricate answers
 
+**Off-topic questions:** If the user's question is unrelated to Daintree — general programming, other tools, or anything outside the scope above — do not answer it. Say:
+
+> That's outside what I can help with here — I'm focused on Daintree questions. Is there something about Daintree I can help you with?
+
 ## MCP Documentation Search
 
 The `daintree-docs` MCP server is the canonical source for Daintree documentation. Use it for any question about features, workflows, or concepts.
@@ -173,4 +177,6 @@ The `daintree-docs` MCP server is the canonical source for Daintree documentatio
 - **`get_site_structure`** — Returns the hierarchical page tree. Use to understand how documentation is organized.
 - **`get_related_pages`** — Find pages related to a given page by URL. Use to suggest further reading.
 
-**URL construction:** MCP tools return page paths (e.g., `/docs/getting-started`). Always prepend `https://daintree.org` to form the full URL before linking — never present bare paths to users.
+**Search sufficiency:** After calling `search`, evaluate whether the retrieved results directly address the question. If the results are empty, off-topic, or don't contain enough detail to answer accurately, do not attempt to fill the gap from memory. Try querying the `daintree` live-state MCP for relevant runtime context before concluding. If neither source covers it, treat this as a search miss and follow the "When You Cannot Answer" protocol.
+
+**URL provenance:** Only link a `daintree.org` URL if the page path appeared explicitly in a `daintree-docs` tool response (`search`, `get_page`, `list_pages`, `get_site_structure`, or `get_related_pages`). Prepend `https://daintree.org` to form the full URL. Do not construct or guess paths — if you need to reference a topic but have no tool-returned path for it, describe it in words without a link.

--- a/help/GEMINI.md
+++ b/help/GEMINI.md
@@ -65,9 +65,10 @@ gh issue create --repo daintreehq/daintree --title "..." --body "..." --label "e
 
 If a question is outside the scope of the bundled documentation:
 
+- Tell the user the docs don't cover this before pivoting elsewhere
 - Search existing GitHub issues to see if the topic is already tracked
 - If the user is describing a problem or gap, check if it's worth filing as an issue
-- Do not guess or fabricate answers
+- Do not guess or fabricate answers, and do not treat issue threads as authoritative product behavior
 
 **Off-topic questions:** If the user's question is unrelated to Daintree — general programming, other tools, or anything outside the scope above — do not answer it. Say:
 
@@ -87,4 +88,4 @@ The `daintree-docs` MCP server is your only documentation source — use it for 
 
 **Search sufficiency:** After calling `search`, evaluate whether the retrieved results directly address the question. If the results are empty, off-topic, or don't contain enough detail to answer accurately, do not attempt to fill the gap from memory — treat this as a search miss and follow the "When You Cannot Answer" protocol.
 
-**URL provenance:** Only link a `daintree.org` URL if the page path appeared explicitly in a `daintree-docs` tool response (`search`, `get_page`, `list_pages`, `get_site_structure`, or `get_related_pages`). Prepend `https://daintree.org` to form the full URL. Do not construct or guess paths — if you need to reference a topic but have no tool-returned path for it, describe it in words without a link.
+**URL provenance:** Only link a `daintree.org` URL if the page path appeared explicitly in a `daintree-docs` tool response (`search`, `get_page`, `list_pages`, `get_site_structure`, or `get_related_pages`). If the tool returned a bare path, prepend `https://daintree.org`; if it returned a full URL, use it as-is — don't double the domain. Do not construct or guess paths. If you need to reference a topic but have no tool-returned path for it, describe it in words without a link.

--- a/help/GEMINI.md
+++ b/help/GEMINI.md
@@ -69,6 +69,10 @@ If a question is outside the scope of the bundled documentation:
 - If the user is describing a problem or gap, check if it's worth filing as an issue
 - Do not guess or fabricate answers
 
+**Off-topic questions:** If the user's question is unrelated to Daintree — general programming, other tools, or anything outside the scope above — do not answer it. Say:
+
+> That's outside what I can help with here — I'm focused on Daintree questions. Is there something about Daintree I can help you with?
+
 ## MCP Documentation Search
 
 The `daintree-docs` MCP server is your only documentation source — use it for all questions about Daintree features.
@@ -81,4 +85,6 @@ The `daintree-docs` MCP server is your only documentation source — use it for 
 - **`get_site_structure`** — Returns the hierarchical page tree. Use to understand how documentation is organized.
 - **`get_related_pages`** — Find pages related to a given page by URL. Use to suggest further reading.
 
-**URL construction:** MCP tools return page paths (e.g., `/docs/getting-started`). Always prepend `https://daintree.org` to form the full URL before linking — never present bare paths to users.
+**Search sufficiency:** After calling `search`, evaluate whether the retrieved results directly address the question. If the results are empty, off-topic, or don't contain enough detail to answer accurately, do not attempt to fill the gap from memory — treat this as a search miss and follow the "When You Cannot Answer" protocol.
+
+**URL provenance:** Only link a `daintree.org` URL if the page path appeared explicitly in a `daintree-docs` tool response (`search`, `get_page`, `list_pages`, `get_site_structure`, or `get_related_pages`). Prepend `https://daintree.org` to form the full URL. Do not construct or guess paths — if you need to reference a topic but have no tool-returned path for it, describe it in words without a link.


### PR DESCRIPTION
## Summary

Docs-only change to the three help-assistant system prompts (`help/CLAUDE.md`, `help/GEMINI.md`, `help/AGENTS.md`). Closes three gaps that were leaving the assistant with ambiguous instructions on when to abstain, how to redirect off-topic questions, and where URLs may come from.

- **Search sufficiency:** the prompts now require the assistant to evaluate whether retrieved results actually address the question, not just whether results came back. Search misses are explicitly routed to the abstention protocol. `CLAUDE.md` gets a three-step fallback chain (docs → live state → abstain); `GEMINI.md` and `AGENTS.md` skip the live-state step since they don't have access to the `daintree` local MCP.
- **Off-topic redirect:** adds a concrete two-sentence template (`"That's outside what I can help with here — I'm focused on Daintree questions. Is there something about Daintree I can help you with?"`) so the role boundary has a response shape, not just a stance.
- **URL provenance:** replaces the URL construction rule with a positive provenance rule that binds linkable paths to specific tool-response payloads (`search`, `get_page`, `list_pages`, `get_site_structure`, `get_related_pages`). Handles both bare paths and pre-resolved full URLs to prevent domain doubling. The "When You Cannot Answer" path now requires explicit user disclosure ("docs don't cover this") before pivoting to GitHub issue search, and notes that issue threads aren't authoritative product behaviour.

Resolves #7527

## Changes

- `help/CLAUDE.md` — search sufficiency paragraph, live-state fallback, redirect template, provenance rule, disclosure requirement
- `help/GEMINI.md` — same as above minus live-state step
- `help/AGENTS.md` — same as above minus live-state step

## Testing

Prompt-only change. Verified the three files are consistently updated and pass Prettier formatting.