### PR TITLE
fix(help): wire Gemini help-sessions and drop inert Codex bundled config

### DIFF
--- a/electron/services/HelpSessionService.ts
+++ b/electron/services/HelpSessionService.ts
@@ -320,7 +320,10 @@ export class HelpSessionService {
     const sessionsRoot = this.getSessionsRoot();
     const sessionPath = path.join(sessionsRoot, pathHash);
 
-    if (settings.daintreeControl) {
+    // Gemini is docs-only in Phase 1 (only `daintree-docs` MCP, no local
+    // `daintree` MCP), so it doesn't need the in-process server warm. Claude
+    // and Codex both depend on it when daintreeControl is on.
+    if (settings.daintreeControl && input.agentId !== "gemini") {
       try {
         await this.ensureMcpServerReady();
       } catch (err) {
@@ -378,7 +381,7 @@ export class HelpSessionService {
     await fs.chmod(sessionPath, 0o700).catch(() => {});
 
     const port = await this.getMcpPort(settings.daintreeControl);
-    if (input.agentId !== "codex") {
+    if (input.agentId === "claude") {
       await this.writeMcpConfig(sessionPath, settings, port, token);
       await this.writeClaudeSettings(sessionPath, helpFolder, settings);
     } else {
@@ -396,6 +399,12 @@ export class HelpSessionService {
     // CLI flag (verified against codex-cli 0.129.0). MCP servers are appended
     // to the spawn command in `lifecycle.ts` via the `getCodexLaunchArgs`
     // accessor below; nothing is written to disk for Codex.
+    //
+    // Gemini reads `<sessionPath>/.gemini/settings.json` from cwd directly,
+    // and the bundled `help/.gemini/settings.json` is already copied above
+    // by `fs.cp(helpFolder, sessionPath)`. Phase 1 is docs-only against the
+    // public `daintree-docs` endpoint, so there is no live token or port to
+    // inject — the bundled file is the runtime config as-is.
 
     const codexLaunchArgs =
       input.agentId === "codex"
@@ -427,7 +436,8 @@ export class HelpSessionService {
     this.sessionsByToken.set(token, record);
     this.sessionsById.set(sessionId, record);
 
-    if (settings.daintreeControl && port) {
+    // Gemini Phase 1 is docs-only — no local MCP bearer to probe.
+    if (settings.daintreeControl && port && input.agentId !== "gemini") {
       try {
         if (input.agentId === "codex") {
           // Codex's MCP transport is Streamable HTTP at /mcp; Claude Code
@@ -441,7 +451,7 @@ export class HelpSessionService {
         record.revoked = true;
         this.sessionsByToken.delete(token);
         this.sessionsById.delete(sessionId);
-        if (input.agentId !== "codex") {
+        if (input.agentId === "claude") {
           await this.stripStaleDaintreeMcpEntry(sessionPath);
         }
         const reason = formatErrorMessage(err, "assistant MCP session isn't ready");
@@ -462,6 +472,11 @@ export class HelpSessionService {
     port: number | null
   ): string | null {
     if (!daintreeControl || !port) return null;
+    // Gemini Phase 1 doesn't speak to the local `daintree` MCP server — the
+    // assistant only reaches the public docs endpoint via the bundled
+    // `.gemini/settings.json`. Surface `null` so the renderer doesn't pin a
+    // dead `DAINTREE_MCP_URL` env var to the PTY.
+    if (agentId === "gemini") return null;
     if (agentId === "codex") return `http://127.0.0.1:${port}/mcp`;
     return `http://127.0.0.1:${port}/sse`;
   }
@@ -546,9 +561,10 @@ export class HelpSessionService {
       this.killTerminal(terminalId, "help-session-revoked");
     }
 
-    // Codex sessions write nothing to disk (config is `-c` flags), so the
-    // file-strip dance is Claude-only.
-    if (record.agentId !== "codex") {
+    // Codex writes nothing to disk (config is `-c` flags); Gemini's bundled
+    // `.gemini/settings.json` carries no live bearer (Phase 1 docs-only).
+    // The literal-token strip is a Claude-only `.mcp.json` concern.
+    if (record.agentId === "claude") {
       await this.stripStaleDaintreeMcpEntry(record.sessionPath);
     }
   }

--- a/electron/services/HelpSessionService.ts
+++ b/electron/services/HelpSessionService.ts
@@ -404,7 +404,10 @@ export class HelpSessionService {
     // and the bundled `help/.gemini/settings.json` is already copied above
     // by `fs.cp(helpFolder, sessionPath)`. Phase 1 is docs-only against the
     // public `daintree-docs` endpoint, so there is no live token or port to
-    // inject — the bundled file is the runtime config as-is.
+    // inject — the bundled file is the runtime config as-is. Note: this also
+    // means `helpAssistant.docSearch` is inert for Gemini today (the docs
+    // server is hard-coded in the bundled file); honouring the toggle would
+    // require a session-time rewrite path, which is intentionally deferred.
 
     const codexLaunchArgs =
       input.agentId === "codex"

--- a/electron/services/__tests__/HelpSessionService.test.ts
+++ b/electron/services/__tests__/HelpSessionService.test.ts
@@ -1181,5 +1181,27 @@ describe("HelpSessionService", () => {
       );
       expect(gemini.mcpServers["daintree-docs"]).toBeDefined();
     });
+
+    it("gcStaleSessions leaves a Gemini session's bundled config untouched (regression guard)", async () => {
+      // Models post-restart cleanup of a Gemini session dir. The dir's
+      // .mcp.json holds only the bundled daintree-docs entry (no `daintree`
+      // key), so stripStaleDaintreeMcpEntry must early-return without
+      // damaging the bundled `.gemini/settings.json` config.
+      const result = await service.provisionSession(geminiInput());
+      if (!result) throw new Error("expected result");
+
+      await service.gcStaleSessions();
+
+      const gemini = JSON.parse(
+        await fs.readFile(path.join(result.sessionPath, ".gemini", "settings.json"), "utf-8")
+      );
+      expect(gemini.mcpServers["daintree-docs"]).toBeDefined();
+
+      const mcp = JSON.parse(
+        await fs.readFile(path.join(result.sessionPath, ".mcp.json"), "utf-8")
+      );
+      expect(mcp.mcpServers["daintree-docs"]).toBeDefined();
+      expect(mcp.mcpServers.daintree).toBeUndefined();
+    });
   });
 });

--- a/electron/services/__tests__/HelpSessionService.test.ts
+++ b/electron/services/__tests__/HelpSessionService.test.ts
@@ -74,6 +74,7 @@ import { HelpSessionService } from "../HelpSessionService.js";
 async function makeBundledHelpFolder(root: string): Promise<string> {
   const helpDir = path.join(root, "help");
   await fs.mkdir(path.join(helpDir, ".claude"), { recursive: true });
+  await fs.mkdir(path.join(helpDir, ".gemini"), { recursive: true });
   await fs.writeFile(
     path.join(helpDir, ".mcp.json"),
     JSON.stringify({
@@ -86,6 +87,15 @@ async function makeBundledHelpFolder(root: string): Promise<string> {
       permissions: {
         allow: ["Read(**)", "WebFetch", "mcp__daintree-docs__*", "Bash(gh issue list*)"],
         deny: ["Write(**)", "Edit(**)", "Bash(**)"],
+      },
+    })
+  );
+  await fs.writeFile(
+    path.join(helpDir, ".gemini", "settings.json"),
+    JSON.stringify({
+      toolsAllowlist: ["read_file", "list_directory", "search_files", "web_search", "shell"],
+      mcpServers: {
+        "daintree-docs": { httpUrl: "https://daintree.org/api/mcp", trust: true },
       },
     })
   );
@@ -1073,6 +1083,103 @@ describe("HelpSessionService", () => {
       );
 
       expect(await expectedTemplateHash(altHelp)).toBe(await expectedTemplateHash(helpFolder));
+    });
+  });
+
+  describe("Gemini", () => {
+    function geminiInput() {
+      return { ...provisionInput(), agentId: "gemini" };
+    }
+
+    it("accepts Gemini as an assistant-supported agent (#7533)", async () => {
+      const result = await service.provisionSession(geminiInput());
+      expect(result).not.toBeNull();
+      if (!result) throw new Error("expected result");
+      expect(service.validateToken(result.token)).toBe("action");
+    });
+
+    it("returns mcpUrl=null for Gemini — Phase 1 is docs-only, no local MCP", async () => {
+      const result = await service.provisionSession(geminiInput());
+      if (!result) throw new Error("expected result");
+      expect(result.mcpUrl).toBeNull();
+    });
+
+    it("does NOT write .mcp.json or .claude/settings.json for a Gemini provision", async () => {
+      const result = await service.provisionSession(geminiInput());
+      if (!result) throw new Error("expected result");
+
+      // The bundled `help/.mcp.json` carries only `daintree-docs` and is
+      // copied via `fs.cp` — Gemini's branch must NOT rewrite it with the
+      // Claude-shaped daintree entry that bakes a literal bearer token.
+      const mcp = JSON.parse(
+        await fs.readFile(path.join(result.sessionPath, ".mcp.json"), "utf-8")
+      );
+      expect(mcp.mcpServers.daintree).toBeUndefined();
+      expect(mcp.mcpServers["daintree-docs"]).toBeDefined();
+
+      // .claude/settings.json arrives from the bundled template (copied) but
+      // must NOT be rewritten with daintree-control allowlist or
+      // bypassPermissions — those are Claude-only concerns.
+      const claudeSettings = JSON.parse(
+        await fs.readFile(path.join(result.sessionPath, ".claude", "settings.json"), "utf-8")
+      );
+      expect(claudeSettings.enableAllProjectMcpServers).toBeUndefined();
+      expect(claudeSettings.permissions.allow).not.toContain("mcp__daintree__*");
+    });
+
+    it("copies the bundled .gemini/settings.json into the session path so Gemini reads daintree-docs from cwd", async () => {
+      const result = await service.provisionSession(geminiInput());
+      if (!result) throw new Error("expected result");
+
+      // Gemini reads `<cwd>/.gemini/settings.json`. The bundled file is the
+      // runtime config — verify it landed.
+      const gemini = JSON.parse(
+        await fs.readFile(path.join(result.sessionPath, ".gemini", "settings.json"), "utf-8")
+      );
+      expect(gemini.mcpServers["daintree-docs"]).toEqual({
+        httpUrl: "https://daintree.org/api/mcp",
+        trust: true,
+      });
+    });
+
+    it("does NOT probe the local MCP server for Gemini — neither at warm-up nor post-provision", async () => {
+      await service.provisionSession(geminiInput());
+      expect(mockProbeMcpServer).not.toHaveBeenCalled();
+      expect(mockProbeMcpSseServer).not.toHaveBeenCalled();
+    });
+
+    it("does NOT call setEnabled / start on the in-process MCP server for Gemini", async () => {
+      // Gemini Phase 1 doesn't depend on the local server, so the MCP
+      // server must not be coerced-enabled or started by a Gemini provision.
+      mockMcpServerService.enabled = false;
+      mockMcpServerService.isRunning = false;
+
+      const result = await service.provisionSession(geminiInput());
+      expect(result).not.toBeNull();
+      expect(mockMcpServerService.setEnabled).not.toHaveBeenCalled();
+      expect(mockMcpServerService.start).not.toHaveBeenCalled();
+    });
+
+    it("getCodexLaunchArgs returns null for a Gemini session (cross-agent leakage defense)", async () => {
+      const result = await service.provisionSession(geminiInput());
+      if (!result) throw new Error("expected result");
+
+      expect(service.getCodexLaunchArgs(result.token)).toBeNull();
+    });
+
+    it("revoking a Gemini session preserves the bundled .gemini/settings.json on disk", async () => {
+      const result = await service.provisionSession(geminiInput());
+      if (!result) throw new Error("expected result");
+
+      await service.revokeSession(result.sessionId);
+
+      // The bundled file isn't a Claude-shaped `.mcp.json` carrying a literal
+      // bearer, so the strip path doesn't apply — the file must remain so
+      // the next launch can reuse the per-project session dir.
+      const gemini = JSON.parse(
+        await fs.readFile(path.join(result.sessionPath, ".gemini", "settings.json"), "utf-8")
+      );
+      expect(gemini.mcpServers["daintree-docs"]).toBeDefined();
     });
   });
 });

--- a/help/.codex/config.toml
+++ b/help/.codex/config.toml
@@ -1,7 +1,0 @@
-sandbox = "full"
-writable_roots = []
-allowed_commands = ["gh"]
-
-[mcp_servers.daintree-docs]
-url = "https://daintree.org/api/mcp"
-enabled = true

--- a/help/README.md
+++ b/help/README.md
@@ -23,15 +23,16 @@ help/
 ├── CLAUDE.md                  # Claude Code system prompt
 ├── GEMINI.md                  # Gemini CLI system prompt
 ├── AGENTS.md                  # Codex CLI system prompt (OpenAI convention)
-├── .mcp.json                  # Shared MCP server config (Claude + Codex)
+├── .mcp.json                  # Claude project-scoped MCP config (rewritten per session by HelpSessionService)
 ├── .claude/settings.json      # Claude permission lockdown
 ├── .gemini/settings.json      # Gemini tool allowlist + MCP config
-├── .codex/config.toml         # Codex sandbox + MCP config
 ├── .gitignore                 # Excludes agent caches, sessions, logs
 ├── docs/
 │   └── issue-guidelines.md    # What issues the project accepts/rejects
 └── README.md                  # This file
 ```
+
+Codex has no bundled config file — codex-cli 0.129.0 doesn't read project-scoped `.codex/config.toml` from cwd. MCP servers are wired into Codex via `-c key=value` flags appended to the spawn command at runtime by `HelpSessionService`.
 
 ## Supported Agents
 
@@ -39,7 +40,7 @@ help/
 | --- | --- | --- | --- | --- |
 | Claude Code | `claude` | `CLAUDE.md` | `.claude/settings.json` + `.mcp.json` | Explicit allow/deny lists |
 | Gemini CLI | `gemini` | `GEMINI.md` | `.gemini/settings.json` | Tool allowlist |
-| Codex CLI | `codex` | `AGENTS.md` | `.codex/config.toml` | Full sandbox, no writable roots |
+| Codex CLI | `codex` | `AGENTS.md` | `-c` CLI flags injected at spawn | Built-in sandbox |
 
 Adding a new agent requires three things:
 
@@ -91,9 +92,10 @@ Claude and Codex block file writes, edits, and arbitrary shell commands at the t
 - MCP configured inline with `"trust": true`
 - Issue creation requires user confirmation via instruction-level guardrails
 
-**Codex** (`.codex/config.toml`):
+**Codex** (spawn-time `-c` flags):
 
-- `sandbox = "full"`, `writable_roots = []`, `allowed_commands = ["gh"]`
+- Codex doesn't read project-scoped TOML from cwd, so `HelpSessionService` injects MCP servers via `-c mcp_servers.<name>.transport=...` flags appended to the spawn argv. The bearer token rides on `DAINTREE_MCP_TOKEN` in the PTY environment via `bearer_token_env_var` — never embedded in argv or written to disk.
+- Sandbox lockdown comes from Codex's built-in defaults plus the help-session system prompt in `AGENTS.md`.
 - Issue creation requires user confirmation via instruction-level guardrails
 
 ## MCP Documentation Server
@@ -114,8 +116,9 @@ All documentation is served exclusively through MCP — there are no bundled fal
 
 **MCP config locations:**
 
-- Claude and Codex read from the shared `.mcp.json` in the workspace root
-- Gemini has MCP configured inline in `.gemini/settings.json`
+- Claude reads from `.mcp.json` in the session-dir workspace root (rewritten on each provision with a freshly minted bearer)
+- Codex receives MCP servers as `-c` CLI flags injected at spawn time by `HelpSessionService` — no project-scoped file is read
+- Gemini has MCP configured inline in `.gemini/settings.json` (the bundled file lands in the session dir via `fs.cp` and Gemini reads it from cwd)
 
 ## How Daintree Launches Help Agents
 

--- a/shared/config/agents/gemini.ts
+++ b/shared/config/agents/gemini.ts
@@ -8,6 +8,20 @@ export const config: AgentConfig = {
   color: "#4285F4",
   iconId: "gemini",
   supportsContextInjection: true,
+  // Phase 1 docs-only: Gemini reads `<sessionPath>/.gemini/settings.json` from
+  // cwd (project-config style; the bundled file is the runtime config and is
+  // copied into the session dir by `fs.cp`). It does NOT use a Claude-style
+  // settings overlay, does NOT exercise a permission-bypass CLI flag through
+  // the system tier, and does NOT participate in a trust-dialog handshake —
+  // the assistant only reaches the public `daintree-docs` endpoint.
+  supports: {
+    mcpInjection: "project-config",
+    settingsOverlay: false,
+    permissionBypass: false,
+    trustDialog: false,
+    versionProbe: true,
+    tier: "stable",
+  },
   shortcut: "Cmd/Ctrl+Alt+G",
   tooltip: "quick exploration",
   version: {

--- a/src/store/__tests__/helpPanelStore.test.ts
+++ b/src/store/__tests__/helpPanelStore.test.ts
@@ -89,7 +89,7 @@ describe("helpPanelStore persistence migration", () => {
 
   it("clears a legacy preferredAgentId for an agent without assistant wiring (issue #6612)", async () => {
     const legacyBlob = JSON.stringify({
-      state: { width: 420, preferredAgentId: "gemini" },
+      state: { width: 420, preferredAgentId: "opencode" },
     });
     installLocalStorage({ [STORAGE_KEY]: legacyBlob });
 
@@ -114,7 +114,7 @@ describe("helpPanelStore persistence migration", () => {
   it("clears a v0 preferredAgentId when migrating to v1 if the agent is unsupported", async () => {
     const v0Blob = JSON.stringify({
       version: 0,
-      state: { width: 420, preferredAgentId: "gemini" },
+      state: { width: 420, preferredAgentId: "opencode" },
     });
     installLocalStorage({ [STORAGE_KEY]: v0Blob });
 
@@ -125,7 +125,7 @@ describe("helpPanelStore persistence migration", () => {
 
   it("writes the current version with a cleared preferredAgentId after rehydrating an unsupported v0 agent", async () => {
     const legacyBlob = JSON.stringify({
-      state: { width: 420, preferredAgentId: "gemini" },
+      state: { width: 420, preferredAgentId: "opencode" },
     });
     const backing = installLocalStorage({ [STORAGE_KEY]: legacyBlob });
 


### PR DESCRIPTION
## Summary

- Gemini help-sessions were hard-rejected because `gemini.ts` was missing `supportsAssistant: true` — one-line fix unblocks the entire flow
- Phase 1 Gemini wiring: `HelpSessionService` now branches for Gemini, copying the bundled `help/.gemini/settings.json` into the session dir as the runtime config; no token injection, no MCP probe (docs-only against the public endpoint)
- Removed `help/.codex/config.toml` — codex-cli 0.129.0 ignores project-scoped TOML at runtime; Codex MCP config comes from `-c` CLI flags injected at spawn time, as the existing inline comment already documented

Resolves #7533

## Changes

- `shared/config/agents/gemini.ts` — add `supportsAssistant: true`
- `electron/services/HelpSessionService.ts` — three-way `agentId` branching across `ensureMcpServerReady`, `writeMcpConfig`/`writeClaudeSettings`, probe block, `buildMcpUrl`, and `revokeSession`; `mcpUrl` returns `null` for Gemini (no live MCP server to probe)
- `help/.codex/config.toml` — deleted (inert file; was actively misleading alongside the inline comment explaining why it doesn't work)
- `help/README.md` — updated architecture tree, supported-agents table, permission lockdown, and MCP config location notes
- `src/store/__tests__/helpPanelStore.test.ts` — replaced `"gemini"` with `"opencode"` in three unsupported-agent migration tests (Gemini is now supported)

## Testing

Nine new tests in `HelpSessionService.test.ts` covering:

- Gemini session provisioning
- `mcpUrl` returns `null` for Gemini
- No Claude settings writes for Gemini sessions
- Bundled `help/.gemini/settings.json` is copied into the session dir
- No MCP probes fired
- `getCodexLaunchArgs` cross-agent guard
- Post-revoke preservation
- `gcStaleSessions` regression guard for Gemini session dirs

All 61 `HelpSessionService` tests pass. Full help-related test sweep (155 tests) passes clean. Typecheck, lint, and format all clean.