### PR TITLE
feat(help-panel): wire live version probe to gate Daintree Assistant launch

### DIFF
--- a/electron/ipc/channels.ts
+++ b/electron/ipc/channels.ts
@@ -100,6 +100,7 @@ export const CHANNELS = {
   SYSTEM_REFRESH_CLI_AVAILABILITY: "system:refresh-cli-availability",
   SYSTEM_GET_AGENT_CLI_DETAILS: "system:get-agent-cli-details",
   SYSTEM_GET_AGENT_VERSIONS: "system:get-agent-versions",
+  SYSTEM_GET_AGENT_VERSION: "system:get-agent-version",
   SYSTEM_REFRESH_AGENT_VERSIONS: "system:refresh-agent-versions",
   SYSTEM_GET_AGENT_UPDATE_SETTINGS: "system:get-agent-update-settings",
   SYSTEM_SET_AGENT_UPDATE_SETTINGS: "system:set-agent-update-settings",

--- a/electron/ipc/handlers/agentCli.ts
+++ b/electron/ipc/handlers/agentCli.ts
@@ -72,6 +72,28 @@ export function registerAgentCliHandlers(deps: HandlerDependencies): () => void 
   };
   handlers.push(typedHandle(CHANNELS.SYSTEM_GET_AGENT_VERSIONS, handleSystemGetAgentVersions));
 
+  const handleSystemGetAgentVersion = async (agentId: string) => {
+    if (typeof agentId !== "string" || !agentId) {
+      throw new Error("Invalid agentId");
+    }
+
+    if (!agentVersionService) {
+      console.warn("[IPC] AgentVersionService not available");
+      return {
+        agentId: agentId as import("../../../shared/types/agent.js").AgentId,
+        installedVersion: null,
+        latestVersion: null,
+        updateAvailable: false,
+        lastChecked: null,
+      };
+    }
+
+    return await agentVersionService.getVersion(
+      agentId as import("../../../shared/types/agent.js").AgentId
+    );
+  };
+  handlers.push(typedHandle(CHANNELS.SYSTEM_GET_AGENT_VERSION, handleSystemGetAgentVersion));
+
   const handleSystemRefreshAgentVersions = async () => {
     if (!agentVersionService) {
       console.warn("[IPC] AgentVersionService not available");

--- a/electron/ipc/handlers/agentCli.ts
+++ b/electron/ipc/handlers/agentCli.ts
@@ -72,7 +72,7 @@ export function registerAgentCliHandlers(deps: HandlerDependencies): () => void 
   };
   handlers.push(typedHandle(CHANNELS.SYSTEM_GET_AGENT_VERSIONS, handleSystemGetAgentVersions));
 
-  const handleSystemGetAgentVersion = async (agentId: string) => {
+  const handleSystemGetAgentVersion = async (agentId: string, refresh?: boolean) => {
     if (typeof agentId !== "string" || !agentId) {
       throw new Error("Invalid agentId");
     }
@@ -89,7 +89,8 @@ export function registerAgentCliHandlers(deps: HandlerDependencies): () => void 
     }
 
     return await agentVersionService.getVersion(
-      agentId as import("../../../shared/types/agent.js").AgentId
+      agentId as import("../../../shared/types/agent.js").AgentId,
+      refresh === true
     );
   };
   handlers.push(typedHandle(CHANNELS.SYSTEM_GET_AGENT_VERSION, handleSystemGetAgentVersion));

--- a/electron/preload.cts
+++ b/electron/preload.cts
@@ -966,8 +966,8 @@ const api: ElectronAPI = {
 
     getAgentVersions: () => _unwrappingInvoke(CHANNELS.SYSTEM_GET_AGENT_VERSIONS),
 
-    getAgentVersion: (agentId: string) =>
-      _unwrappingInvoke(CHANNELS.SYSTEM_GET_AGENT_VERSION, agentId),
+    getAgentVersion: (agentId: string, refresh?: boolean) =>
+      _unwrappingInvoke(CHANNELS.SYSTEM_GET_AGENT_VERSION, agentId, refresh),
 
     refreshAgentVersions: () => _unwrappingInvoke(CHANNELS.SYSTEM_REFRESH_AGENT_VERSIONS),
 

--- a/electron/preload.cts
+++ b/electron/preload.cts
@@ -966,6 +966,9 @@ const api: ElectronAPI = {
 
     getAgentVersions: () => _unwrappingInvoke(CHANNELS.SYSTEM_GET_AGENT_VERSIONS),
 
+    getAgentVersion: (agentId: string) =>
+      _unwrappingInvoke(CHANNELS.SYSTEM_GET_AGENT_VERSION, agentId),
+
     refreshAgentVersions: () => _unwrappingInvoke(CHANNELS.SYSTEM_REFRESH_AGENT_VERSIONS),
 
     getAgentUpdateSettings: () => _unwrappingInvoke(CHANNELS.SYSTEM_GET_AGENT_UPDATE_SETTINGS),

--- a/shared/config/agentRegistry.ts
+++ b/shared/config/agentRegistry.ts
@@ -330,6 +330,16 @@ export interface AgentConfig {
    * is structurally enabled but hidden from the picker until promoted.
    */
   supports?: AssistantSupports | false;
+  /**
+   * Minimum installed CLI semver required for the Daintree Assistant launch
+   * path. Compared against the live `AgentVersionService.getVersion()` probe
+   * before `provisionHelpSession` runs — when the installed version is
+   * definitively below this floor, `HelpPanel` surfaces an inline upgrade
+   * prompt instead of minting a session token. A `null` probe result (CLI
+   * missing or version unparseable) passes through so existing missing-CLI
+   * surfaces handle it. Omit when no minimum applies.
+   */
+  assistantMinVersion?: string;
   shortcut?: string | null;
   tooltip?: string;
   usageUrl?: string;

--- a/shared/config/agents/claude.ts
+++ b/shared/config/agents/claude.ts
@@ -23,6 +23,7 @@ export const config: AgentConfig = {
     versionProbe: true,
     tier: "stable",
   },
+  assistantMinVersion: "1.0.0",
   shortcut: "Cmd/Ctrl+Alt+C",
   usageUrl: "https://claude.ai/settings/usage",
   version: {

--- a/shared/types/ipc/api.ts
+++ b/shared/types/ipc/api.ts
@@ -352,6 +352,7 @@ export interface ElectronAPI {
     refreshCliAvailability(): Promise<CliAvailability>;
     getAgentCliDetails(): Promise<AgentCliDetails>;
     getAgentVersions(): Promise<AgentVersionInfo[]>;
+    getAgentVersion(agentId: string): Promise<AgentVersionInfo>;
     refreshAgentVersions(): Promise<AgentVersionInfo[]>;
     getAgentUpdateSettings(): Promise<AgentUpdateSettings>;
     setAgentUpdateSettings(settings: AgentUpdateSettings): Promise<void>;

--- a/shared/types/ipc/api.ts
+++ b/shared/types/ipc/api.ts
@@ -352,7 +352,7 @@ export interface ElectronAPI {
     refreshCliAvailability(): Promise<CliAvailability>;
     getAgentCliDetails(): Promise<AgentCliDetails>;
     getAgentVersions(): Promise<AgentVersionInfo[]>;
-    getAgentVersion(agentId: string): Promise<AgentVersionInfo>;
+    getAgentVersion(agentId: string, refresh?: boolean): Promise<AgentVersionInfo>;
     refreshAgentVersions(): Promise<AgentVersionInfo[]>;
     getAgentUpdateSettings(): Promise<AgentUpdateSettings>;
     setAgentUpdateSettings(settings: AgentUpdateSettings): Promise<void>;

--- a/shared/types/ipc/maps.ts
+++ b/shared/types/ipc/maps.ts
@@ -531,7 +531,7 @@ export interface IpcInvokeMap {
     result: AgentVersionInfo[];
   };
   "system:get-agent-version": {
-    args: [agentId: string];
+    args: [agentId: string, refresh?: boolean];
     result: AgentVersionInfo;
   };
   "system:refresh-agent-versions": {

--- a/shared/types/ipc/maps.ts
+++ b/shared/types/ipc/maps.ts
@@ -530,6 +530,10 @@ export interface IpcInvokeMap {
     args: [];
     result: AgentVersionInfo[];
   };
+  "system:get-agent-version": {
+    args: [agentId: string];
+    result: AgentVersionInfo;
+  };
   "system:refresh-agent-versions": {
     args: [];
     result: AgentVersionInfo[];

--- a/src/components/HelpPanel/HelpPanel.tsx
+++ b/src/components/HelpPanel/HelpPanel.tsx
@@ -1,5 +1,6 @@
 import { Suspense, useCallback, useEffect, useRef, useState, useMemo } from "react";
 import { Settings2, ChevronRight, Plus, X } from "lucide-react";
+import * as semver from "semver";
 import { cn } from "@/lib/utils";
 import { DaintreeIcon } from "@/components/icons/DaintreeIcon";
 import { XtermAdapter } from "@/components/Terminal/XtermAdapter";
@@ -136,6 +137,49 @@ async function provisionHelpSession(
   }
 }
 
+interface VersionTooOld {
+  agentId: string;
+  agentName: string;
+  installedVersion: string;
+  requiredVersion: string;
+}
+
+// Probes the installed CLI version and compares it against the agent's
+// `assistantMinVersion` floor. Returns a block descriptor when the installed
+// version is definitively below the floor; returns null otherwise (no minimum
+// configured, probe failed, version unparseable, or installed >= required).
+// A null pass-through preserves the existing missing-CLI surface and avoids
+// blocking on transient probe failures.
+async function checkAssistantVersion(
+  agentId: string,
+  agentName: string
+): Promise<VersionTooOld | null> {
+  const config = getAgentConfig(agentId);
+  const required = config?.assistantMinVersion;
+  if (!required) return null;
+
+  let info;
+  try {
+    info = await window.electron.system.getAgentVersion(agentId);
+  } catch (err) {
+    logError("Failed to probe assistant CLI version", err);
+    return null;
+  }
+
+  const installed = info?.installedVersion;
+  if (!installed) return null;
+
+  try {
+    if (semver.lt(installed, required)) {
+      return { agentId, agentName, installedVersion: installed, requiredVersion: required };
+    }
+  } catch (err) {
+    logError("Failed to compare assistant CLI version", err);
+    return null;
+  }
+  return null;
+}
+
 // Fetches the user-configured custom CLI args from helpAssistant settings and
 // splits them into a flag array. Settings are loaded at launch time (not at
 // render) so changes in the Daintree Assistant settings tab take effect on the
@@ -212,6 +256,7 @@ export function HelpPanel({
   const isVisible = isVisibleProp ?? effectiveWidth > 0;
   const [showNewSessionConfirm, setShowNewSessionConfirm] = useState(false);
   const [showResumeBanner, setShowResumeBanner] = useState(false);
+  const [assistantVersionTooOld, setAssistantVersionTooOld] = useState<VersionTooOld | null>(null);
 
   const {
     isOpen,
@@ -600,6 +645,18 @@ export function HelpPanel({
           return;
         }
 
+        // Version gate runs BEFORE provisionHelpSession to avoid minting a
+        // session token (with .mcp.json side effects) we'd immediately
+        // discard. Pass-through on null preserves missing-CLI behavior.
+        const launchAgentName = getAgentConfig(launchAgentId)?.name ?? launchAgentId;
+        const versionBlock = await checkAssistantVersion(launchAgentId, launchAgentName);
+        if (versionBlock) {
+          hasAutoLaunched.current = false;
+          setAssistantVersionTooOld(versionBlock);
+          return;
+        }
+        setAssistantVersionTooOld(null);
+
         const outcome = await provisionHelpSession(launchProject, launchAgentId);
         if (!outcome.ok) {
           hasAutoLaunched.current = false;
@@ -859,6 +916,19 @@ export function HelpPanel({
           notifyLaunchFailed(selectedAgentId, "Help folder is not available.");
           return;
         }
+
+        // Version gate runs BEFORE provisionHelpSession so we don't mint a
+        // session token we'd immediately discard. Pass-through on null
+        // (probe failure / unparseable installed version) lets the existing
+        // missing-CLI surface handle those edge cases.
+        const selectedAgentName = getAgentConfig(selectedAgentId)?.name ?? selectedAgentId;
+        const versionBlock = await checkAssistantVersion(selectedAgentId, selectedAgentName);
+        if (versionBlock) {
+          hasAutoLaunched.current = false;
+          setAssistantVersionTooOld(versionBlock);
+          return;
+        }
+        setAssistantVersionTooOld(null);
 
         const outcome = await provisionHelpSession(launchProject, selectedAgentId);
         if (!outcome.ok) {
@@ -1414,6 +1484,33 @@ export function HelpPanel({
               </div>
             </>
           )
+        ) : assistantVersionTooOld ? (
+          <div
+            className="flex-1 flex flex-col items-center justify-center gap-3 p-8 text-center"
+            data-testid="help-version-too-old"
+          >
+            <p className="text-sm text-daintree-text/70">
+              Update {assistantVersionTooOld.agentName} to use Daintree Assistant
+            </p>
+            <p className="text-xs text-daintree-text/50 max-w-[32ch]">
+              Daintree Assistant needs {assistantVersionTooOld.agentName}{" "}
+              {assistantVersionTooOld.requiredVersion} or later. You're on{" "}
+              {assistantVersionTooOld.installedVersion}.
+            </p>
+            <button
+              type="button"
+              onClick={handleOpenSettings}
+              className={cn(
+                "mt-1 inline-flex items-center gap-1.5 px-3 py-1.5 rounded-[var(--radius-md)]",
+                "text-xs font-medium border border-daintree-border text-daintree-text/80",
+                "hover:bg-overlay-soft hover:text-daintree-text transition-colors",
+                "focus-visible:outline focus-visible:outline-2 focus-visible:outline-daintree-accent focus-visible:outline-offset-2"
+              )}
+            >
+              <Settings2 className="w-3.5 h-3.5" />
+              <span>Update {assistantVersionTooOld.agentName}</span>
+            </button>
+          </div>
         ) : (
           <div className="flex-1 flex flex-col items-center justify-center gap-6 p-8 text-center">
             <p className="text-sm text-daintree-text/70 max-w-[30ch]">

--- a/src/components/HelpPanel/HelpPanel.tsx
+++ b/src/components/HelpPanel/HelpPanel.tsx
@@ -149,10 +149,14 @@ interface VersionTooOld {
 // version is definitively below the floor; returns null otherwise (no minimum
 // configured, probe failed, version unparseable, or installed >= required).
 // A null pass-through preserves the existing missing-CLI surface and avoids
-// blocking on transient probe failures.
+// blocking on transient probe failures. `refresh=true` bypasses the 12h
+// AgentVersionService cache — pass it on retry so a user who manually
+// updates the CLI outside Daintree's update flow can recover within one
+// panel reopen instead of waiting for cache expiry.
 async function checkAssistantVersion(
   agentId: string,
-  agentName: string
+  agentName: string,
+  refresh = false
 ): Promise<VersionTooOld | null> {
   const config = getAgentConfig(agentId);
   const required = config?.assistantMinVersion;
@@ -160,7 +164,7 @@ async function checkAssistantVersion(
 
   let info;
   try {
-    info = await window.electron.system.getAgentVersion(agentId);
+    info = await window.electron.system.getAgentVersion(agentId, refresh);
   } catch (err) {
     logError("Failed to probe assistant CLI version", err);
     return null;
@@ -257,6 +261,11 @@ export function HelpPanel({
   const [showNewSessionConfirm, setShowNewSessionConfirm] = useState(false);
   const [showResumeBanner, setShowResumeBanner] = useState(false);
   const [assistantVersionTooOld, setAssistantVersionTooOld] = useState<VersionTooOld | null>(null);
+  // Tracks whether the version gate has blocked at any point in this panel
+  // instance. When true, the next `checkAssistantVersion` call passes
+  // `refresh=true` so an externally-updated CLI is detected without waiting
+  // for the 12h AgentVersionService cache TTL. Cleared once a probe passes.
+  const hasBlockedThisSessionRef = useRef(false);
 
   const {
     isOpen,
@@ -649,12 +658,28 @@ export function HelpPanel({
         // session token (with .mcp.json side effects) we'd immediately
         // discard. Pass-through on null preserves missing-CLI behavior.
         const launchAgentName = getAgentConfig(launchAgentId)?.name ?? launchAgentId;
-        const versionBlock = await checkAssistantVersion(launchAgentId, launchAgentName);
+        const versionBlock = await checkAssistantVersion(
+          launchAgentId,
+          launchAgentName,
+          hasBlockedThisSessionRef.current
+        );
         if (versionBlock) {
+          // Stale-agent guard: only relevant when we're about to paint a
+          // block. If the user changed `preferredAgentId` while the probe
+          // was in flight, skip the block so the new agent's empty state
+          // isn't covered by an "Update Claude" message that no longer
+          // applies. The non-block path falls through to provision/dispatch
+          // and the existing post-dispatch stale guard handles cleanup.
+          if (useHelpPanelStore.getState().preferredAgentId !== launchAgentId) {
+            hasAutoLaunched.current = false;
+            return;
+          }
           hasAutoLaunched.current = false;
+          hasBlockedThisSessionRef.current = true;
           setAssistantVersionTooOld(versionBlock);
           return;
         }
+        hasBlockedThisSessionRef.current = false;
         setAssistantVersionTooOld(null);
 
         const outcome = await provisionHelpSession(launchProject, launchAgentId);
@@ -778,6 +803,14 @@ export function HelpPanel({
       hasAutoLaunched.current = false;
     }
   }, [isOpen]);
+
+  // Clear the version-too-old block when the preferred agent changes — the
+  // stale block belongs to the previous agent and would otherwise paint over
+  // the new agent's empty state. The retry-refresh ref intentionally
+  // survives this reset so a recovering panel still busts the cache.
+  useEffect(() => {
+    setAssistantVersionTooOld(null);
+  }, [preferredAgentId]);
 
   // Register the panel root with the macro-focus store so the assistant
   // participates in cross-region cycling.
@@ -920,14 +953,22 @@ export function HelpPanel({
         // Version gate runs BEFORE provisionHelpSession so we don't mint a
         // session token we'd immediately discard. Pass-through on null
         // (probe failure / unparseable installed version) lets the existing
-        // missing-CLI surface handle those edge cases.
+        // missing-CLI surface handle those edge cases. `refresh=true` on
+        // retry busts the 12h AgentVersionService cache so an externally
+        // updated CLI is detected without waiting for TTL expiry.
         const selectedAgentName = getAgentConfig(selectedAgentId)?.name ?? selectedAgentId;
-        const versionBlock = await checkAssistantVersion(selectedAgentId, selectedAgentName);
+        const versionBlock = await checkAssistantVersion(
+          selectedAgentId,
+          selectedAgentName,
+          hasBlockedThisSessionRef.current
+        );
         if (versionBlock) {
           hasAutoLaunched.current = false;
+          hasBlockedThisSessionRef.current = true;
           setAssistantVersionTooOld(versionBlock);
           return;
         }
+        hasBlockedThisSessionRef.current = false;
         setAssistantVersionTooOld(null);
 
         const outcome = await provisionHelpSession(launchProject, selectedAgentId);

--- a/src/components/HelpPanel/__tests__/HelpPanel.helpLaunch.test.tsx
+++ b/src/components/HelpPanel/__tests__/HelpPanel.helpLaunch.test.tsx
@@ -12,6 +12,7 @@ const {
   mockRevokeSession,
   mockGetAssistantSupportedAgentIds,
   mockGetHelpAssistantSettings,
+  mockGetAgentVersion,
   mockSystemSleepGetMetrics,
   mockSystemSleepOnSuspend,
   mockSystemSleepOnWake,
@@ -37,6 +38,13 @@ const {
     skipPermissions: false,
     auditRetention: 7,
     customArgs: "",
+  }),
+  mockGetAgentVersion: vi.fn().mockResolvedValue({
+    agentId: "claude",
+    installedVersion: null,
+    latestVersion: null,
+    updateAvailable: false,
+    lastChecked: null,
   }),
   mockSystemSleepGetMetrics: vi.fn().mockResolvedValue({
     totalSleepMs: 0,
@@ -134,7 +142,12 @@ vi.mock("@/config/agents", () => ({
   },
   getAgentConfig: (id: string) =>
     ({
-      claude: { name: "Claude", icon: () => null, models: [] },
+      claude: {
+        name: "Claude",
+        icon: () => null,
+        models: [],
+        assistantMinVersion: "1.0.0",
+      },
       gemini: { name: "Gemini", icon: () => null, models: [] },
       codex: { name: "Codex", icon: () => null, models: [] },
     })[id],
@@ -313,6 +326,14 @@ function resetState() {
     auditRetention: 7,
     customArgs: "",
   });
+  mockGetAgentVersion.mockReset();
+  mockGetAgentVersion.mockResolvedValue({
+    agentId: "claude",
+    installedVersion: null,
+    latestVersion: null,
+    updateAvailable: false,
+    lastChecked: null,
+  });
 }
 
 beforeEach(() => {
@@ -356,6 +377,9 @@ beforeEach(() => {
         },
         helpAssistant: {
           getSettings: mockGetHelpAssistantSettings,
+        },
+        system: {
+          getAgentVersion: mockGetAgentVersion,
         },
         systemSleep: {
           getMetrics: mockSystemSleepGetMetrics,
@@ -2292,5 +2316,190 @@ describe("HelpPanel — visibilitychange re-launch after teardown (issue #7201)"
       { source: "user" }
     );
     expect(mockProvisionSession).toHaveBeenCalledTimes(1);
+  });
+});
+
+describe("HelpPanel — assistantMinVersion gate (issue #7539)", () => {
+  it("blocks the single-supported-agent launch when installed version is below assistantMinVersion", async () => {
+    helpPanelState.preferredAgentId = null;
+    cliAvailabilityState.availability = { claude: "ready" };
+    mockGetAssistantSupportedAgentIds.mockReturnValue(["claude"]);
+    mockGetFolderPath.mockResolvedValue("/help");
+    mockGetAgentVersion.mockResolvedValue({
+      agentId: "claude",
+      installedVersion: "0.2.74",
+      latestVersion: "1.0.0",
+      updateAvailable: true,
+      lastChecked: Date.now(),
+    });
+    mockDispatch.mockResolvedValue({ ok: true, result: { terminalId: "blocked-term" } });
+
+    const { findByTestId } = render(<HelpPanel width={380} />);
+
+    await findByTestId("help-version-too-old");
+
+    expect(mockGetAgentVersion).toHaveBeenCalledWith("claude");
+    expect(mockProvisionSession).not.toHaveBeenCalled();
+    expect(mockDispatch).not.toHaveBeenCalled();
+    expect(helpPanelState.setTerminal).not.toHaveBeenCalled();
+  });
+
+  it("blocks the preferredAgentId auto-launch when installed version is below assistantMinVersion", async () => {
+    helpPanelState.preferredAgentId = "claude";
+    mockGetFolderPath.mockResolvedValue("/help");
+    mockGetAgentVersion.mockResolvedValue({
+      agentId: "claude",
+      installedVersion: "0.9.0",
+      latestVersion: "1.0.0",
+      updateAvailable: true,
+      lastChecked: Date.now(),
+    });
+    mockDispatch.mockResolvedValue({ ok: true, result: { terminalId: "auto-term-1" } });
+
+    const { findByTestId } = render(<HelpPanel width={380} />);
+
+    await findByTestId("help-version-too-old");
+
+    expect(mockGetAgentVersion).toHaveBeenCalledWith("claude");
+    expect(mockProvisionSession).not.toHaveBeenCalled();
+    expect(mockDispatch).not.toHaveBeenCalled();
+    expect(helpPanelState.setTerminal).not.toHaveBeenCalled();
+  });
+
+  it("renders the upgrade copy with required and installed versions", async () => {
+    helpPanelState.preferredAgentId = "claude";
+    mockGetFolderPath.mockResolvedValue("/help");
+    mockGetAgentVersion.mockResolvedValue({
+      agentId: "claude",
+      installedVersion: "0.2.74",
+      latestVersion: "1.0.0",
+      updateAvailable: true,
+      lastChecked: Date.now(),
+    });
+
+    const { findByTestId } = render(<HelpPanel width={380} />);
+
+    const block = await findByTestId("help-version-too-old");
+    expect(block.textContent).toContain("Update Claude to use Daintree Assistant");
+    expect(block.textContent).toContain("1.0.0");
+    expect(block.textContent).toContain("0.2.74");
+  });
+
+  it("update CTA dispatches app.settings.openTab to the assistant tab", async () => {
+    helpPanelState.preferredAgentId = "claude";
+    mockGetFolderPath.mockResolvedValue("/help");
+    mockGetAgentVersion.mockResolvedValue({
+      agentId: "claude",
+      installedVersion: "0.2.74",
+      latestVersion: "1.0.0",
+      updateAvailable: true,
+      lastChecked: Date.now(),
+    });
+
+    const { findByRole } = render(<HelpPanel width={380} />);
+
+    const cta = await findByRole("button", { name: /update claude/i });
+    fireEvent.click(cta);
+
+    expect(mockDispatch).toHaveBeenCalledWith(
+      "app.settings.openTab",
+      { tab: "assistant" },
+      { source: "user" }
+    );
+  });
+
+  it("passes through when installed version equals assistantMinVersion", async () => {
+    helpPanelState.preferredAgentId = "claude";
+    mockGetFolderPath.mockResolvedValue("/help");
+    mockGetAgentVersion.mockResolvedValue({
+      agentId: "claude",
+      installedVersion: "1.0.0",
+      latestVersion: "1.2.0",
+      updateAvailable: true,
+      lastChecked: Date.now(),
+    });
+    mockDispatch.mockResolvedValue({ ok: true, result: { terminalId: "auto-term-1" } });
+
+    await act(async () => {
+      render(<HelpPanel width={380} />);
+    });
+
+    expect(mockProvisionSession).toHaveBeenCalled();
+    expect(mockDispatch).toHaveBeenCalledWith(
+      "agent.launch",
+      expect.objectContaining({ agentId: "claude" }),
+      { source: "user" }
+    );
+  });
+
+  it("passes through when installedVersion is null (probe could not determine version)", async () => {
+    helpPanelState.preferredAgentId = "claude";
+    mockGetFolderPath.mockResolvedValue("/help");
+    mockGetAgentVersion.mockResolvedValue({
+      agentId: "claude",
+      installedVersion: null,
+      latestVersion: null,
+      updateAvailable: false,
+      lastChecked: null,
+    });
+    mockDispatch.mockResolvedValue({ ok: true, result: { terminalId: "auto-term-1" } });
+
+    await act(async () => {
+      render(<HelpPanel width={380} />);
+    });
+
+    expect(mockProvisionSession).toHaveBeenCalled();
+    expect(mockDispatch).toHaveBeenCalledWith(
+      "agent.launch",
+      expect.objectContaining({ agentId: "claude" }),
+      { source: "user" }
+    );
+  });
+
+  it("passes through when the version probe IPC throws (transient failure does not block launch)", async () => {
+    helpPanelState.preferredAgentId = "claude";
+    mockGetFolderPath.mockResolvedValue("/help");
+    mockGetAgentVersion.mockRejectedValueOnce(new Error("ipc disconnected"));
+    mockDispatch.mockResolvedValue({ ok: true, result: { terminalId: "auto-term-1" } });
+
+    await act(async () => {
+      render(<HelpPanel width={380} />);
+    });
+
+    expect(mockProvisionSession).toHaveBeenCalled();
+    expect(mockDispatch).toHaveBeenCalled();
+    expect(mockLogError).toHaveBeenCalledWith(
+      "Failed to probe assistant CLI version",
+      expect.any(Error)
+    );
+  });
+
+  it("does not gate agents without an assistantMinVersion (e.g., codex)", async () => {
+    mockGetAssistantSupportedAgentIds.mockReturnValue(["codex"]);
+    helpPanelState.preferredAgentId = "codex";
+    cliAvailabilityState.availability = { codex: "ready" };
+    mockGetFolderPath.mockResolvedValue("/help");
+    mockGetAgentVersion.mockResolvedValue({
+      agentId: "codex",
+      installedVersion: "0.0.1",
+      latestVersion: "1.0.0",
+      updateAvailable: true,
+      lastChecked: Date.now(),
+    });
+    mockDispatch.mockResolvedValue({ ok: true, result: { terminalId: "codex-term-1" } });
+
+    await act(async () => {
+      render(<HelpPanel width={380} />);
+    });
+
+    // Without an assistantMinVersion, the helper short-circuits to null and the IPC
+    // probe should never be called — saves a probe per launch on un-gated agents.
+    expect(mockGetAgentVersion).not.toHaveBeenCalled();
+    expect(mockProvisionSession).toHaveBeenCalled();
+    expect(mockDispatch).toHaveBeenCalledWith(
+      "agent.launch",
+      expect.objectContaining({ agentId: "codex" }),
+      { source: "user" }
+    );
   });
 });

--- a/src/components/HelpPanel/__tests__/HelpPanel.helpLaunch.test.tsx
+++ b/src/components/HelpPanel/__tests__/HelpPanel.helpLaunch.test.tsx
@@ -2338,7 +2338,7 @@ describe("HelpPanel — assistantMinVersion gate (issue #7539)", () => {
 
     await findByTestId("help-version-too-old");
 
-    expect(mockGetAgentVersion).toHaveBeenCalledWith("claude");
+    expect(mockGetAgentVersion).toHaveBeenCalledWith("claude", false);
     expect(mockProvisionSession).not.toHaveBeenCalled();
     expect(mockDispatch).not.toHaveBeenCalled();
     expect(helpPanelState.setTerminal).not.toHaveBeenCalled();
@@ -2360,7 +2360,7 @@ describe("HelpPanel — assistantMinVersion gate (issue #7539)", () => {
 
     await findByTestId("help-version-too-old");
 
-    expect(mockGetAgentVersion).toHaveBeenCalledWith("claude");
+    expect(mockGetAgentVersion).toHaveBeenCalledWith("claude", false);
     expect(mockProvisionSession).not.toHaveBeenCalled();
     expect(mockDispatch).not.toHaveBeenCalled();
     expect(helpPanelState.setTerminal).not.toHaveBeenCalled();
@@ -2499,6 +2499,117 @@ describe("HelpPanel — assistantMinVersion gate (issue #7539)", () => {
     expect(mockDispatch).toHaveBeenCalledWith(
       "agent.launch",
       expect.objectContaining({ agentId: "codex" }),
+      { source: "user" }
+    );
+  });
+
+  it("clears the version-too-old block when preferredAgentId changes", async () => {
+    helpPanelState.preferredAgentId = "claude";
+    mockGetFolderPath.mockResolvedValue("/help");
+    mockGetAgentVersion.mockResolvedValue({
+      agentId: "claude",
+      installedVersion: "0.2.74",
+      latestVersion: "1.0.0",
+      updateAvailable: true,
+      lastChecked: Date.now(),
+    });
+
+    const { findByTestId, queryByTestId, rerender } = render(<HelpPanel width={380} />);
+    await findByTestId("help-version-too-old");
+
+    // User clears their preferred agent — the stale block should disappear so
+    // the no-preference empty state can render correctly.
+    helpPanelState.preferredAgentId = null;
+    cliAvailabilityState.availability = { claude: "ready", codex: "ready" };
+    mockGetAssistantSupportedAgentIds.mockReturnValue(["claude", "codex"]);
+
+    await act(async () => {
+      rerender(<HelpPanel width={380} />);
+    });
+
+    expect(queryByTestId("help-version-too-old")).toBeNull();
+  });
+
+  it("does not paint a stale version-too-old block when preferredAgentId changes mid-probe", async () => {
+    helpPanelState.preferredAgentId = "claude";
+    mockGetFolderPath.mockResolvedValue("/help");
+
+    let resolveProbe: (info: unknown) => void = () => {};
+    mockGetAgentVersion.mockImplementationOnce(
+      () =>
+        new Promise((r) => {
+          resolveProbe = r;
+        })
+    );
+    mockDispatch.mockResolvedValue({ ok: true, result: { terminalId: "term-1" } });
+
+    const { queryByTestId, rerender } = render(<HelpPanel width={380} />);
+
+    // User switches preference while probe is in flight.
+    helpPanelState.preferredAgentId = "codex";
+    await act(async () => {
+      rerender(<HelpPanel width={380} />);
+    });
+
+    // Probe finally returns "too old" for the now-stale claude.
+    await act(async () => {
+      resolveProbe({
+        agentId: "claude",
+        installedVersion: "0.2.74",
+        latestVersion: "1.0.0",
+        updateAvailable: true,
+        lastChecked: Date.now(),
+      });
+    });
+
+    // The stale block must NOT be rendered; the new preferred agent's launch
+    // should proceed unobstructed.
+    expect(queryByTestId("help-version-too-old")).toBeNull();
+  });
+
+  it("passes refresh=true on retry so an externally-updated CLI recovers without waiting for cache TTL", async () => {
+    helpPanelState.preferredAgentId = "claude";
+    mockGetFolderPath.mockResolvedValue("/help");
+
+    // First probe: blocked.
+    mockGetAgentVersion.mockResolvedValueOnce({
+      agentId: "claude",
+      installedVersion: "0.2.74",
+      latestVersion: "1.0.0",
+      updateAvailable: true,
+      lastChecked: Date.now(),
+    });
+    // Second probe (retry after user updated externally): passes.
+    mockGetAgentVersion.mockResolvedValueOnce({
+      agentId: "claude",
+      installedVersion: "1.5.0",
+      latestVersion: "1.5.0",
+      updateAvailable: false,
+      lastChecked: Date.now(),
+    });
+    mockDispatch.mockResolvedValue({ ok: true, result: { terminalId: "recovered-term" } });
+
+    const { findByTestId, rerender } = render(<HelpPanel width={380} />);
+    await findByTestId("help-version-too-old");
+
+    // First call uses cached path (refresh=false). Confirm call signature.
+    expect(mockGetAgentVersion).toHaveBeenNthCalledWith(1, "claude", false);
+
+    // Simulate a retry: close + reopen flips hasAutoLaunched, retriggering the effect.
+    helpPanelState.isOpen = false;
+    await act(async () => {
+      rerender(<HelpPanel width={380} />);
+    });
+    helpPanelState.isOpen = true;
+    await act(async () => {
+      rerender(<HelpPanel width={380} />);
+    });
+
+    // Second probe must pass refresh=true to bust the 12h cache.
+    expect(mockGetAgentVersion).toHaveBeenNthCalledWith(2, "claude", true);
+    expect(mockDispatch).toHaveBeenCalledWith(
+      "agent.launch",
+      expect.objectContaining({ agentId: "claude" }),
       { source: "user" }
     );
   });


### PR DESCRIPTION
## Summary

- Adds `assistantMinVersion` to `AgentConfig` (set to `"1.0.0"` on Claude) and a `system.getAgentVersion(agentId, refresh?)` IPC that reuses the existing `AgentVersionService` cache
- Gates both `HelpPanel` launch paths (auto-launch via `preferredAgentId` and the single-supported-agent path in `handleSelectAgent`) before `provisionHelpSession` so we never mint session tokens we'd discard; renders an inline empty-state with an "Update Claude" CTA when the installed version is below the floor
- Probe failures and `null` `installedVersion` are treated as pass-through to avoid blocking on transient errors; a `hasBlockedThisSessionRef` flag forces `refresh=true` on the next probe after a block so an externally-updated CLI is picked up without waiting for the 12h cache TTL

Resolves #7539

## Changes

- `shared/config/agentRegistry.ts` / `shared/config/agents/claude.ts` — `assistantMinVersion` field on `AgentConfig`, set to `"1.0.0"` on Claude
- `electron/ipc/channels.ts`, `electron/ipc/handlers/agentCli.ts`, `electron/preload.cts`, `shared/types/ipc/api.ts`, `shared/types/ipc/maps.ts` — `system.getAgentVersion` IPC wired end-to-end
- `src/components/HelpPanel/HelpPanel.tsx` — version gate logic, stale-agent guard, block-state reset on `preferredAgentId` change, inline empty-state render

## Testing

11 new tests in `HelpPanel.helpLaunch.test.tsx` covering: gate blocks single-supported-agent path, gate blocks `preferredAgentId` path, upgrade copy renders correctly, CTA dispatches settings tab, equal-version pass-through, `null` `installedVersion` pass-through, probe-throw pass-through, no-floor agents skip the IPC entirely, stale block clears on `preferredAgentId` change, in-flight stale-agent guard, and `refresh=true` retry after a block. 86/86 `HelpPanel` tests + 21/21 `AgentVersionService` tests passing.