### PR TITLE
refactor(mcp): collapse terminal.waitUntilIdle special-case into the action manifest

### DIFF
--- a/electron/services/__tests__/McpServerService.test.ts
+++ b/electron/services/__tests__/McpServerService.test.ts
@@ -19,6 +19,30 @@ import type {
 } from "../../../shared/types/actions.js";
 import { CHANNELS } from "../../ipc/channels.js";
 import { ACTIONS_LIST_TOOL } from "../mcp-server/shared.js";
+import {
+  WAIT_UNTIL_IDLE_DESCRIPTION,
+  WAIT_UNTIL_IDLE_INPUT_SCHEMA,
+  WAIT_UNTIL_IDLE_OUTPUT_SCHEMA,
+} from "../../../shared/types/terminalWaitUntilIdle.js";
+
+const waitUntilIdleManifestEntry = (): ActionManifestEntry => ({
+  id: "terminal.waitUntilIdle" as ActionId,
+  name: "terminal.waitUntilIdle",
+  title: "Wait until terminal idle",
+  description: WAIT_UNTIL_IDLE_DESCRIPTION,
+  category: "terminal",
+  kind: "query" as ActionKind,
+  danger: "safe" as ActionDanger,
+  inputSchema: WAIT_UNTIL_IDLE_INPUT_SCHEMA,
+  outputSchema: WAIT_UNTIL_IDLE_OUTPUT_SCHEMA,
+  enabled: true,
+  requiresArgs: true,
+  mcpAnnotations: {
+    readOnlyHint: true,
+    idempotentHint: false,
+    destructiveHint: false,
+  },
+});
 
 const testHomeDir = vi.hoisted(
   () => `${process.cwd()}/.vitest-mcp-home-${Math.random().toString(36).slice(2)}`
@@ -4713,7 +4737,9 @@ describe("McpServerService", () => {
 
     it("listTools advertises the native tool with the documented schema for the action tier", async () => {
       paneTokenTiers.set("token-wait-action", "action");
-      const { window } = createMockWindow({ getManifest: () => [] });
+      const { window } = createMockWindow({
+        getManifest: () => [waitUntilIdleManifestEntry()],
+      });
       await service.start(window);
       const { client, transport } = await connectClient(service.currentPort!, {
         Authorization: "Bearer token-wait-action",
@@ -4731,7 +4757,9 @@ describe("McpServerService", () => {
 
     it("listTools hides the native tool from the workbench tier", async () => {
       paneTokenTiers.set("token-wait-wb", "workbench");
-      const { window } = createMockWindow({ getManifest: () => [] });
+      const { window } = createMockWindow({
+        getManifest: () => [waitUntilIdleManifestEntry()],
+      });
       await service.start(window);
       const { client, transport } = await connectClient(service.currentPort!, {
         Authorization: "Bearer token-wait-wb",
@@ -5196,6 +5224,34 @@ describe("McpServerService", () => {
       // Listener count should not grow per call — the handler must remove its
       // subscription on every exit path.
       expect(innerBus.listenerCount("agent:state-changed")).toBe(baseline);
+    });
+
+    it("emits exactly one audit record per call via the shared finally path", async () => {
+      // Regression guard for the post-#7529 refactor: the wait-until-idle
+      // branch short-circuits before dispatchAction but must still feed the
+      // single shared audit `finally` block — never duplicate the record.
+      const { terminalId, agentId } = nextIds();
+      await seedTerminalAgent(terminalId, agentId, "idle");
+
+      const { window } = createMockWindow({ getManifest: () => [] });
+      await service.start(window);
+      const { client, transport } = await connectClient(service.currentPort!);
+      transports.push(transport);
+
+      const baselineMatching = service
+        .getAuditRecords()
+        .filter((r) => r.toolId === "terminal.waitUntilIdle").length;
+      const result = (await client.callTool({
+        name: "terminal.waitUntilIdle",
+        arguments: { terminalId },
+      })) as TextToolResult;
+      expect(result.isError).toBeFalsy();
+
+      const matching = service
+        .getAuditRecords()
+        .filter((r) => r.toolId === "terminal.waitUntilIdle");
+      expect(matching.length - baselineMatching).toBe(1);
+      expect(matching.at(-1)?.result).toBe("success");
     });
   });
 });

--- a/electron/services/__tests__/McpServerService.test.ts
+++ b/electron/services/__tests__/McpServerService.test.ts
@@ -5251,7 +5251,39 @@ describe("McpServerService", () => {
         .getAuditRecords()
         .filter((r) => r.toolId === "terminal.waitUntilIdle");
       expect(matching.length - baselineMatching).toBe(1);
-      expect(matching.at(-1)?.result).toBe("success");
+      const record = matching.at(-1)!;
+      expect(record.result).toBe("success");
+      expect(record.toolId).toBe("terminal.waitUntilIdle");
+      expect(record.tier).toBe("external");
+      expect(record.durationMs).toBeGreaterThanOrEqual(0);
+      expect(record.errorCode).toBeUndefined();
+    });
+
+    it("releases its event listener after a timeout exit", async () => {
+      const { events } = await import("../events.js");
+      const innerBus = (events as unknown as { bus: import("node:events").EventEmitter }).bus;
+      const { terminalId, agentId } = nextIds();
+      await seedTerminalAgent(terminalId, agentId, "working");
+
+      const { window } = createMockWindow({ getManifest: () => [] });
+      await service.start(window);
+      const { client, transport } = await connectClient(service.currentPort!);
+      transports.push(transport);
+
+      const baseline = innerBus.listenerCount("agent:state-changed");
+
+      const result = (await client.callTool({
+        name: "terminal.waitUntilIdle",
+        arguments: { terminalId, timeoutMs: 50 },
+      })) as TextToolResult;
+      expect(result.isError).toBeFalsy();
+      const payload = JSON.parse(result.content[0]!.text);
+      expect(payload.timedOut).toBe(true);
+
+      // The timeout exit path runs through the same `finally` cleanup as the
+      // resolved path — the listener must be removed even when the wait
+      // expires without a state transition.
+      expect(innerBus.listenerCount("agent:state-changed")).toBe(baseline);
     });
   });
 });

--- a/electron/services/mcp-server/sessionServer.ts
+++ b/electron/services/mcp-server/sessionServer.ts
@@ -26,10 +26,6 @@ import type {
   DispatchEnvelope,
 } from "./shared.js";
 import {
-  TERMINAL_WAIT_UNTIL_IDLE_TOOL,
-  WAIT_UNTIL_IDLE_DESCRIPTION,
-  WAIT_UNTIL_IDLE_INPUT_SCHEMA,
-  WAIT_UNTIL_IDLE_OUTPUT_SCHEMA,
   PROMPT_DEFINITIONS,
   PROMPT_TERMINAL_OUTPUT_MAX_CHARS,
   RESOURCE_SCROLLBACK_TAIL_LINES,
@@ -54,6 +50,8 @@ import {
   buildStructuredContent,
   parseToolArguments,
 } from "./tierAuth.js";
+
+const TERMINAL_WAIT_UNTIL_IDLE_TOOL = "terminal.waitUntilIdle";
 import type { SessionStore } from "./sessionStore.js";
 
 export interface SessionServerDeps {
@@ -120,22 +118,6 @@ export function createSessionServer(sessionId: string, deps: SessionServerDeps):
         };
       });
 
-    if (isTierPermitted(tier, TERMINAL_WAIT_UNTIL_IDLE_TOOL, fullToolSurface)) {
-      tools.push({
-        name: TERMINAL_WAIT_UNTIL_IDLE_TOOL,
-        description: WAIT_UNTIL_IDLE_DESCRIPTION,
-        inputSchema: WAIT_UNTIL_IDLE_INPUT_SCHEMA,
-        annotations: {
-          title: "Wait until terminal idle",
-          readOnlyHint: true,
-          idempotentHint: false,
-          destructiveHint: false,
-          openWorldHint: false,
-        },
-        outputSchema: WAIT_UNTIL_IDLE_OUTPUT_SCHEMA,
-      });
-    }
-
     return { tools };
   });
 
@@ -170,48 +152,6 @@ export function createSessionServer(sessionId: string, deps: SessionServerDeps):
       };
     }
 
-    if (actionId === TERMINAL_WAIT_UNTIL_IDLE_TOOL) {
-      let nativeOutcome:
-        | { kind: "result"; value: import("../../../shared/types/actions.js").ActionDispatchResult }
-        | { kind: "throw"; error: unknown }
-        | undefined;
-      try {
-        const result = await waitUntilIdle(args, extra.signal);
-        nativeOutcome = { kind: "result", value: { ok: true, result } };
-        return {
-          content: [{ type: "text" as const, text: safeSerializeToolResult(result) }],
-          structuredContent: result as unknown as Record<string, unknown>,
-        };
-      } catch (err) {
-        nativeOutcome = { kind: "throw", error: err };
-        if (err instanceof McpError) {
-          throw err;
-        }
-        return {
-          content: [
-            {
-              type: "text" as const,
-              text: `Error: ${formatErrorMessage(err, "waitUntilIdle failed")}`,
-            },
-          ],
-          isError: true,
-        };
-      } finally {
-        try {
-          appendAuditRecord({
-            toolId: actionId,
-            sessionId,
-            tier,
-            args,
-            durationMs: Date.now() - startedAt,
-            outcome: nativeOutcome ?? { kind: "throw", error: new Error("unknown") },
-          });
-        } catch (auditErr) {
-          console.error("[MCP] Failed to append audit record:", auditErr);
-        }
-      }
-    }
-
     let outcome:
       | { kind: "result"; value: import("../../../shared/types/actions.js").ActionDispatchResult }
       | { kind: "throw"; error: unknown };
@@ -221,6 +161,36 @@ export function createSessionServer(sessionId: string, deps: SessionServerDeps):
     let dispatchConfirmed = false;
 
     try {
+      // Short-circuit: terminal.waitUntilIdle runs in the main process. The
+      // action manifest entry handles schema, tier, and audit registration; the
+      // execution must bypass renderer dispatch because (a) the MCP AbortSignal
+      // can't cross IPC, and (b) renderer dispatch has a 30s wall — too short
+      // for the 30-minute default wait. Audit unifies via the shared finally.
+      if (actionId === TERMINAL_WAIT_UNTIL_IDLE_TOOL) {
+        try {
+          const result = await waitUntilIdle(args, extra.signal);
+          outcome = { kind: "result", value: { ok: true, result } };
+          return {
+            content: [{ type: "text" as const, text: safeSerializeToolResult(result) }],
+            structuredContent: result as unknown as Record<string, unknown>,
+          };
+        } catch (err) {
+          outcome = { kind: "throw", error: err };
+          if (err instanceof McpError) {
+            throw err;
+          }
+          return {
+            content: [
+              {
+                type: "text" as const,
+                text: `Error: ${formatErrorMessage(err, "waitUntilIdle failed")}`,
+              },
+            ],
+            isError: true,
+          };
+        }
+      }
+
       const entry = await lookupManifestEntry(actionId, getCachedManifest, requestManifest);
       if (!dispatchConfirmed && entry?.danger === "confirm") {
         const supportsForm = server.getClientCapabilities()?.elicitation?.form !== undefined;

--- a/electron/services/mcp-server/shared.ts
+++ b/electron/services/mcp-server/shared.ts
@@ -7,7 +7,24 @@ import type {
   McpRuntimeState,
 } from "../../../shared/types/ipc/mcpServer.js";
 import type { HelpAssistantTier } from "../../../shared/types/ipc/maps.js";
-import type { AgentState, WaitingReason } from "../../../shared/types/agent.js";
+import type { AgentState } from "../../../shared/types/agent.js";
+import {
+  type WaitUntilIdleResult,
+  DEFAULT_WAIT_UNTIL_IDLE_TIMEOUT_MS,
+  MAX_WAIT_UNTIL_IDLE_TIMEOUT_MS,
+  WAIT_UNTIL_IDLE_INPUT_SCHEMA,
+  WAIT_UNTIL_IDLE_OUTPUT_SCHEMA,
+  WAIT_UNTIL_IDLE_DESCRIPTION,
+} from "../../../shared/types/terminalWaitUntilIdle.js";
+
+export {
+  type WaitUntilIdleResult,
+  DEFAULT_WAIT_UNTIL_IDLE_TIMEOUT_MS,
+  MAX_WAIT_UNTIL_IDLE_TIMEOUT_MS,
+  WAIT_UNTIL_IDLE_INPUT_SCHEMA,
+  WAIT_UNTIL_IDLE_OUTPUT_SCHEMA,
+  WAIT_UNTIL_IDLE_DESCRIPTION,
+};
 
 export type McpAuthClass = "external" | HelpAssistantTier;
 export type HelpTokenValidator = (token: string) => HelpAssistantTier | false;
@@ -38,71 +55,6 @@ export const RESTART_BASE_DELAY_MS = 500;
 export const RESTART_MAX_DELAY_MS = 15_000;
 export const RESTART_JITTER_MS = 250;
 export const RESTART_STABLE_RESET_MS = 30_000;
-
-export const TERMINAL_WAIT_UNTIL_IDLE_TOOL = "terminal.waitUntilIdle";
-
-export const DEFAULT_WAIT_UNTIL_IDLE_TIMEOUT_MS = 30 * 60 * 1000;
-export const MAX_WAIT_UNTIL_IDLE_TIMEOUT_MS = 2 * 60 * 60 * 1000;
-
-export type WaitUntilIdleResult = {
-  terminalId: string;
-  agentId?: string;
-  busyState: "working" | "idle";
-  idleReason?: "idle" | "waiting_for_user" | "completed" | "exited" | "unknown";
-  /**
-   * Only present when `idleReason === "waiting_for_user"`. Distinguishes a safe
-   * auto-drive moment (`"prompt"` — empty input prompt) from an agent actively
-   * asking the user a question (`"question"`).
-   */
-  waitingReason?: WaitingReason;
-  previousBusyState?: "working" | "idle";
-  lastTransitionAt?: number;
-  timedOut: boolean;
-};
-
-export const WAIT_UNTIL_IDLE_INPUT_SCHEMA: Record<string, unknown> = {
-  type: "object",
-  properties: {
-    terminalId: {
-      type: "string",
-      description: "Panel UUID returned by `terminal.list` (the `id` field).",
-    },
-    timeoutMs: {
-      type: "integer",
-      minimum: 0,
-      maximum: MAX_WAIT_UNTIL_IDLE_TIMEOUT_MS,
-      description: `Pass 0 for an immediate non-blocking snapshot — the recommended mode when polling multiple terminals in parallel. Otherwise, the maximum time to block in milliseconds; defaults to ${DEFAULT_WAIT_UNTIL_IDLE_TIMEOUT_MS} ms (${DEFAULT_WAIT_UNTIL_IDLE_TIMEOUT_MS / 60_000} minutes) and clamped to ${MAX_WAIT_UNTIL_IDLE_TIMEOUT_MS} ms (${MAX_WAIT_UNTIL_IDLE_TIMEOUT_MS / 60_000 / 60} hours).`,
-    },
-  },
-  required: ["terminalId"],
-  additionalProperties: false,
-};
-
-export const WAIT_UNTIL_IDLE_OUTPUT_SCHEMA: Record<string, unknown> = {
-  type: "object",
-  properties: {
-    terminalId: { type: "string" },
-    agentId: { type: "string" },
-    busyState: { type: "string", enum: ["working", "idle"] },
-    idleReason: {
-      type: "string",
-      enum: ["idle", "waiting_for_user", "completed", "exited", "unknown"],
-    },
-    waitingReason: {
-      type: "string",
-      enum: ["prompt", "question"],
-      description:
-        "Present only when idleReason is 'waiting_for_user'. 'prompt' = empty input prompt (safe to auto-drive); 'question' = agent is asking the user a question.",
-    },
-    previousBusyState: { type: "string", enum: ["working", "idle"] },
-    lastTransitionAt: { type: "number" },
-    timedOut: { type: "boolean" },
-  },
-  required: ["terminalId", "busyState", "timedOut"],
-};
-
-export const WAIT_UNTIL_IDLE_DESCRIPTION =
-  "[terminal] Wait until idle: blocks until the agent in the given terminal transitions out of the `working` state, or until the timeout elapses. Resolves immediately if the agent is already non-working or no agent is attached. When the agent settles in `waiting_for_user`, the result also includes `waitingReason` (`prompt` = empty input prompt, safe to auto-drive; `question` = agent is asking the user a question). Honours client cancellation. When orchestrating multiple terminals, call with `timeoutMs: 0` in parallel for snapshots — do not issue concurrent default-timeout waits, which race unpredictably and can each block for 30 minutes.";
 
 export function mapAgentStateToBusyState(state: AgentState | undefined): "working" | "idle" {
   return state === "working" ? "working" : "idle";
@@ -201,7 +153,7 @@ const ACTION_TIER_ADDONS: ReadonlySet<string> = new Set([
 
   "terminal.inject",
   "terminal.new",
-  TERMINAL_WAIT_UNTIL_IDLE_TOOL,
+  "terminal.waitUntilIdle",
 
   "recipe.list",
   "recipe.run",
@@ -297,7 +249,7 @@ const MCP_TOOL_ALLOWLIST: ReadonlySet<string> = new Set([
   "terminal.sendCommand",
   "terminal.inject",
   "terminal.new",
-  TERMINAL_WAIT_UNTIL_IDLE_TOOL,
+  "terminal.waitUntilIdle",
 
   "worktree.list",
   "worktree.getCurrent",

--- a/electron/services/mcp-server/waitUntilIdle.ts
+++ b/electron/services/mcp-server/waitUntilIdle.ts
@@ -6,9 +6,8 @@ import {
   type WaitUntilIdleResult,
   DEFAULT_WAIT_UNTIL_IDLE_TIMEOUT_MS,
   MAX_WAIT_UNTIL_IDLE_TIMEOUT_MS,
-  mapAgentStateToBusyState,
-  mapAgentStateToIdleReason,
-} from "./shared.js";
+} from "../../../shared/types/terminalWaitUntilIdle.js";
+import { mapAgentStateToBusyState, mapAgentStateToIdleReason } from "./shared.js";
 
 export async function handleWaitUntilIdle(
   rawArgs: unknown,

--- a/scripts/lint-ratchet.mjs
+++ b/scripts/lint-ratchet.mjs
@@ -33,7 +33,7 @@ function main() {
     lintOutput = execSync("npx eslint . --format json", {
       cwd: ROOT,
       encoding: "utf-8",
-      maxBuffer: 10 * 1024 * 1024, // 10MB buffer for large output
+      maxBuffer: 50 * 1024 * 1024, // 50MB buffer for large output
       stdio: ["pipe", "pipe", "pipe"],
     });
   } catch (error) {

--- a/shared/types/actions.ts
+++ b/shared/types/actions.ts
@@ -32,6 +32,7 @@ export type BuiltInActionId =
   | "terminal.getOutput"
   | "terminal.getStatus"
   | "terminal.sendCommand"
+  | "terminal.waitUntilIdle"
   | "panel.list"
   | "worktree.list"
   | "worktree.getCurrent"

--- a/shared/types/terminalWaitUntilIdle.ts
+++ b/shared/types/terminalWaitUntilIdle.ts
@@ -1,0 +1,64 @@
+import type { WaitingReason } from "./agent.js";
+
+export const DEFAULT_WAIT_UNTIL_IDLE_TIMEOUT_MS = 30 * 60 * 1000;
+export const MAX_WAIT_UNTIL_IDLE_TIMEOUT_MS = 2 * 60 * 60 * 1000;
+
+export type WaitUntilIdleResult = {
+  terminalId: string;
+  agentId?: string;
+  busyState: "working" | "idle";
+  idleReason?: "idle" | "waiting_for_user" | "completed" | "exited" | "unknown";
+  /**
+   * Only present when `idleReason === "waiting_for_user"`. Distinguishes a safe
+   * auto-drive moment (`"prompt"` — empty input prompt) from an agent actively
+   * asking the user a question (`"question"`).
+   */
+  waitingReason?: WaitingReason;
+  previousBusyState?: "working" | "idle";
+  lastTransitionAt?: number;
+  timedOut: boolean;
+};
+
+export const WAIT_UNTIL_IDLE_INPUT_SCHEMA: Record<string, unknown> = {
+  type: "object",
+  properties: {
+    terminalId: {
+      type: "string",
+      description: "Panel UUID returned by `terminal.list` (the `id` field).",
+    },
+    timeoutMs: {
+      type: "integer",
+      minimum: 0,
+      maximum: MAX_WAIT_UNTIL_IDLE_TIMEOUT_MS,
+      description: `Pass 0 for an immediate non-blocking snapshot — the recommended mode when polling multiple terminals in parallel. Otherwise, the maximum time to block in milliseconds; defaults to ${DEFAULT_WAIT_UNTIL_IDLE_TIMEOUT_MS} ms (${DEFAULT_WAIT_UNTIL_IDLE_TIMEOUT_MS / 60_000} minutes) and clamped to ${MAX_WAIT_UNTIL_IDLE_TIMEOUT_MS} ms (${MAX_WAIT_UNTIL_IDLE_TIMEOUT_MS / 60_000 / 60} hours).`,
+    },
+  },
+  required: ["terminalId"],
+  additionalProperties: false,
+};
+
+export const WAIT_UNTIL_IDLE_OUTPUT_SCHEMA: Record<string, unknown> = {
+  type: "object",
+  properties: {
+    terminalId: { type: "string" },
+    agentId: { type: "string" },
+    busyState: { type: "string", enum: ["working", "idle"] },
+    idleReason: {
+      type: "string",
+      enum: ["idle", "waiting_for_user", "completed", "exited", "unknown"],
+    },
+    waitingReason: {
+      type: "string",
+      enum: ["prompt", "question"],
+      description:
+        "Present only when idleReason is 'waiting_for_user'. 'prompt' = empty input prompt (safe to auto-drive); 'question' = agent is asking the user a question.",
+    },
+    previousBusyState: { type: "string", enum: ["working", "idle"] },
+    lastTransitionAt: { type: "number" },
+    timedOut: { type: "boolean" },
+  },
+  required: ["terminalId", "busyState", "timedOut"],
+};
+
+export const WAIT_UNTIL_IDLE_DESCRIPTION =
+  "[terminal] Wait until idle: blocks until the agent in the given terminal transitions out of the `working` state, or until the timeout elapses. Resolves immediately if the agent is already non-working or no agent is attached. When the agent settles in `waiting_for_user`, the result also includes `waitingReason` (`prompt` = empty input prompt, safe to auto-drive; `question` = agent is asking the user a question). Honours client cancellation. When orchestrating multiple terminals, call with `timeoutMs: 0` in parallel for snapshots — do not issue concurrent default-timeout waits, which race unpredictably and can each block for 30 minutes.";

--- a/shared/types/terminalWaitUntilIdle.ts
+++ b/shared/types/terminalWaitUntilIdle.ts
@@ -61,4 +61,4 @@ export const WAIT_UNTIL_IDLE_OUTPUT_SCHEMA: Record<string, unknown> = {
 };
 
 export const WAIT_UNTIL_IDLE_DESCRIPTION =
-  "[terminal] Wait until idle: blocks until the agent in the given terminal transitions out of the `working` state, or until the timeout elapses. Resolves immediately if the agent is already non-working or no agent is attached. When the agent settles in `waiting_for_user`, the result also includes `waitingReason` (`prompt` = empty input prompt, safe to auto-drive; `question` = agent is asking the user a question). Honours client cancellation. When orchestrating multiple terminals, call with `timeoutMs: 0` in parallel for snapshots — do not issue concurrent default-timeout waits, which race unpredictably and can each block for 30 minutes.";
+  "Wait until the agent transitions from working state or the timeout elapses";

--- a/src/services/ActionService.ts
+++ b/src/services/ActionService.ts
@@ -143,7 +143,7 @@ function computeManifestPartials(definition: AnyActionDefinition): CachedManifes
       : definition.rawInputSchema,
     outputSchema: definition.resultSchema
       ? zodSchemaToJsonSchema(definition.resultSchema)
-      : undefined,
+      : definition.rawOutputSchema,
     requiresArgs: definition.argsSchema
       ? !definition.argsSchema.safeParse(undefined).success &&
         !definition.argsSchema.safeParse({}).success

--- a/src/services/__tests__/ActionService.test.ts
+++ b/src/services/__tests__/ActionService.test.ts
@@ -145,6 +145,52 @@ describe("ActionService", () => {
       expect(service.get("acme.plugin.maybe" as ActionId)!.requiresArgs).toBe(false);
     });
 
+    it("propagates rawOutputSchema onto ActionManifestEntry when no Zod resultSchema is set", () => {
+      const rawOutput = {
+        type: "object",
+        properties: { ok: { type: "boolean" } },
+        required: ["ok"],
+      };
+      const action = {
+        id: "acme.plugin.report" as ActionId,
+        title: "Report",
+        description: "Returns a payload with a raw output schema",
+        category: "plugin",
+        kind: "query",
+        danger: "safe",
+        scope: "renderer",
+        rawOutputSchema: rawOutput,
+        run: vi.fn().mockResolvedValue({ ok: true }),
+      };
+      service.register(action as unknown as ActionDefinition);
+      expect(service.get("acme.plugin.report" as ActionId)!.outputSchema).toEqual(rawOutput);
+    });
+
+    it("prefers Zod resultSchema over rawOutputSchema when both are provided", async () => {
+      const { z } = await import("zod");
+      const rawOutput = { type: "object", properties: { fallback: { type: "string" } } };
+      const action = {
+        id: "acme.plugin.both" as ActionId,
+        title: "Both Schemas",
+        description: "Has both result and raw output",
+        category: "plugin",
+        kind: "query",
+        danger: "safe",
+        scope: "renderer",
+        resultSchema: z.object({ canonical: z.string() }),
+        rawOutputSchema: rawOutput,
+        run: vi.fn().mockResolvedValue({ canonical: "x" }),
+      };
+      service.register(action as unknown as ActionDefinition);
+      const entry = service.get("acme.plugin.both" as ActionId)!;
+      expect(entry.outputSchema).toBeDefined();
+      // resultSchema (Zod) wins — produced schema must mention the canonical
+      // property, not the raw schema's `fallback`.
+      const props = (entry.outputSchema as { properties: Record<string, unknown> }).properties;
+      expect(props.canonical).toBeDefined();
+      expect(props.fallback).toBeUndefined();
+    });
+
     it("should throw when registering duplicate action and preserve the original registration", async () => {
       const originalRun = vi.fn().mockResolvedValue("original");
       const original: ActionDefinition = {

--- a/src/services/actions/actionTypes.ts
+++ b/src/services/actions/actionTypes.ts
@@ -16,6 +16,14 @@ export type AnyActionDefinition = ActionDefinition<any, any> & {
    * which is surfaced directly in the MCP manifest.
    */
   rawInputSchema?: Record<string, unknown>;
+  /**
+   * Raw JSON-Schema object for the action result. Mirrors `rawInputSchema` for
+   * cases where a Zod `resultSchema` isn't practical — for example, when the
+   * canonical schema lives outside the renderer (shared with the main process)
+   * and is the source of truth for both the MCP tool definition and runtime
+   * structuredContent shape.
+   */
+  rawOutputSchema?: Record<string, unknown>;
 };
 
 export type ActionRegistry = Map<ActionId, () => AnyActionDefinition>;

--- a/src/services/actions/definitions/__tests__/terminalWaitUntilIdleAction.test.ts
+++ b/src/services/actions/definitions/__tests__/terminalWaitUntilIdleAction.test.ts
@@ -36,13 +36,9 @@ describe("terminal.waitUntilIdle action definition", () => {
     expect(def.argsSchema?.safeParse({ terminalId: "term-1" }).success).toBe(true);
     expect(def.argsSchema?.safeParse({ terminalId: "" }).success).toBe(false);
     expect(def.argsSchema?.safeParse({}).success).toBe(false);
-    expect(
-      def.argsSchema?.safeParse({ terminalId: "term-1", timeoutMs: 0 }).success
-    ).toBe(true);
+    expect(def.argsSchema?.safeParse({ terminalId: "term-1", timeoutMs: 0 }).success).toBe(true);
     // Negative timeout — rejected by min(0).
-    expect(
-      def.argsSchema?.safeParse({ terminalId: "term-1", timeoutMs: -1 }).success
-    ).toBe(false);
+    expect(def.argsSchema?.safeParse({ terminalId: "term-1", timeoutMs: -1 }).success).toBe(false);
   });
 
   it("throws when run() is invoked through renderer dispatch", async () => {

--- a/src/services/actions/definitions/__tests__/terminalWaitUntilIdleAction.test.ts
+++ b/src/services/actions/definitions/__tests__/terminalWaitUntilIdleAction.test.ts
@@ -1,0 +1,60 @@
+import { describe, expect, it, vi } from "vitest";
+import type { ActionCallbacks, ActionRegistry, AnyActionDefinition } from "../../actionTypes";
+
+vi.mock("@/store/panelStore", () => ({
+  usePanelStore: { getState: vi.fn() },
+}));
+vi.mock("@/clients", () => ({ terminalClient: { submit: vi.fn() } }));
+vi.mock("@shared/config/panelKindRegistry", () => ({
+  panelKindHasPty: () => true,
+}));
+
+import { registerTerminalQueryActions } from "../terminalQueryActions";
+
+function setupActions(): ActionRegistry {
+  const actions: ActionRegistry = new Map();
+  registerTerminalQueryActions(actions, {} as ActionCallbacks);
+  return actions;
+}
+
+describe("terminal.waitUntilIdle action definition", () => {
+  it("registers a manifest entry with query/safe/renderer metadata", () => {
+    const def = setupActions().get("terminal.waitUntilIdle")?.() as AnyActionDefinition;
+    expect(def).toBeDefined();
+    expect(def.id).toBe("terminal.waitUntilIdle");
+    expect(def.kind).toBe("query");
+    expect(def.danger).toBe("safe");
+    expect(def.scope).toBe("renderer");
+    expect(def.mcpAnnotations?.readOnlyHint).toBe(true);
+    expect(def.mcpAnnotations?.idempotentHint).toBe(false);
+    expect(def.mcpAnnotations?.destructiveHint).toBe(false);
+    expect(def.rawOutputSchema).toBeDefined();
+  });
+
+  it("validates required terminalId via the Zod argsSchema", () => {
+    const def = setupActions().get("terminal.waitUntilIdle")?.() as AnyActionDefinition;
+    expect(def.argsSchema?.safeParse({ terminalId: "term-1" }).success).toBe(true);
+    expect(def.argsSchema?.safeParse({ terminalId: "" }).success).toBe(false);
+    expect(def.argsSchema?.safeParse({}).success).toBe(false);
+    expect(
+      def.argsSchema?.safeParse({ terminalId: "term-1", timeoutMs: 0 }).success
+    ).toBe(true);
+    // Negative timeout — rejected by min(0).
+    expect(
+      def.argsSchema?.safeParse({ terminalId: "term-1", timeoutMs: -1 }).success
+    ).toBe(false);
+  });
+
+  it("throws when run() is invoked through renderer dispatch", async () => {
+    // Guard for the manifest-only registration: the action exists in the
+    // registry purely so `ActionService.list()` advertises it through the
+    // standard MCP manifest. Execution must stay in the main process — if
+    // the renderer ever dispatches it directly (bypassing the CallTool
+    // short-circuit), the throw catches the bug at the callsite rather
+    // than silently returning a malformed result.
+    const def = setupActions().get("terminal.waitUntilIdle")?.() as AnyActionDefinition;
+    await expect(def.run({ terminalId: "term-1" }, {} as never)).rejects.toThrow(
+      /must be invoked through the MCP main-process path/
+    );
+  });
+});

--- a/src/services/actions/definitions/terminalQueryActions.ts
+++ b/src/services/actions/definitions/terminalQueryActions.ts
@@ -4,6 +4,11 @@ import { stripAnsiCodes } from "@shared/utils/artifactParser";
 import { panelKindHasPty } from "@shared/config/panelKindRegistry";
 import { terminalClient } from "@/clients";
 import { usePanelStore, type TerminalInstance } from "@/store/panelStore";
+import {
+  MAX_WAIT_UNTIL_IDLE_TIMEOUT_MS,
+  WAIT_UNTIL_IDLE_DESCRIPTION,
+  WAIT_UNTIL_IDLE_OUTPUT_SCHEMA,
+} from "@shared/types/terminalWaitUntilIdle";
 export function registerTerminalQueryActions(
   actions: ActionRegistry,
   _callbacks: ActionCallbacks
@@ -312,6 +317,49 @@ export function registerTerminalQueryActions(
       });
 
       return { terminals: entries };
+    },
+  }));
+
+  // terminal.waitUntilIdle is registered here purely for manifest registration —
+  // schema, description, tier, and audit metadata. Execution is handled inline
+  // in the MCP CallTool handler (electron/services/mcp-server/sessionServer.ts)
+  // because the request must stay in the main process: the renderer-dispatch
+  // path has a 30s timeout (waitUntilIdle defaults to 30 minutes) and cannot
+  // serialize the AbortSignal that powers MCP request cancellation. `run()`
+  // throws if the renderer ever invokes it directly.
+  actions.set("terminal.waitUntilIdle", () => ({
+    id: "terminal.waitUntilIdle",
+    title: "Wait until terminal idle",
+    description: WAIT_UNTIL_IDLE_DESCRIPTION,
+    category: "terminal",
+    kind: "query",
+    danger: "safe",
+    scope: "renderer",
+    argsSchema: z.object({
+      terminalId: z
+        .string()
+        .min(1)
+        .describe("Panel UUID returned by `terminal.list` (the `id` field)."),
+      timeoutMs: z
+        .number()
+        .int()
+        .min(0)
+        .max(MAX_WAIT_UNTIL_IDLE_TIMEOUT_MS)
+        .optional()
+        .describe(
+          "Pass 0 for an immediate non-blocking snapshot. Otherwise, the maximum time to block in milliseconds; defaults to 30 minutes and clamped to 2 hours."
+        ),
+    }),
+    rawOutputSchema: WAIT_UNTIL_IDLE_OUTPUT_SCHEMA,
+    mcpAnnotations: {
+      readOnlyHint: true,
+      idempotentHint: false,
+      destructiveHint: false,
+    },
+    run: async () => {
+      throw new Error(
+        "terminal.waitUntilIdle must be invoked through the MCP main-process path, not renderer dispatch."
+      );
     },
   }));
 


### PR DESCRIPTION
## Summary

- Registers `terminal.waitUntilIdle` in the renderer action manifest so its schema, description, tier, and audit metadata flow through the same path as every other action — manual `ListTools` push removed
- Adds `rawOutputSchema` to `AnyActionDefinition` as an escape hatch mirroring `rawInputSchema`; `resultSchema` wins when both are set
- Extracts `WaitUntilIdleResult`, schema constants, and description into `shared/types/terminalWaitUntilIdle.ts` so renderer and main share a single source of truth; `mcp-server/shared.ts` re-exports for back-compat

Resolves #7529

## Changes

- Duplicate `try/catch/finally` audit block in `sessionServer.ts` collapsed: the short-circuit branch now sits inside the existing outer try, so both paths unify through a single shared `finally`
- Execution still runs in the main process — renderer dispatch can't carry an `AbortSignal` and would hit the 30s renderer-dispatch wall before the 30-minute default wait completes; renderer `run()` throws to catch accidental dispatch

## Testing

Tests cover the audit-unification regression, listener cleanup on the timeout exit path, the throwing renderer-dispatch guard, and `rawOutputSchema` propagation and precedence.