### PR TITLE
feat(assistant): split skipPermissions into tier picker + CLI bypass

### DIFF
--- a/electron/ipc/handlers/__tests__/helpAssistant.handlers.test.ts
+++ b/electron/ipc/handlers/__tests__/helpAssistant.handlers.test.ts
@@ -85,7 +85,9 @@ describe("registerHelpAssistantHandlers", () => {
   });
 
   it("migrates legacy skipPermissions=true to tier='system' + bypassPermissions=true", async () => {
-    storeMock.get.mockReturnValue({ skipPermissions: true });
+    storeMock.get.mockReturnValue({
+      skipPermissions: true,
+    } as unknown as Partial<HelpAssistantSettings>);
     registerHelpAssistantHandlers();
     const handler = ipcMainMock._handlers.get(GET_CHANNEL)!;
 
@@ -94,7 +96,9 @@ describe("registerHelpAssistantHandlers", () => {
   });
 
   it("migrates legacy skipPermissions=false to tier='action' + bypassPermissions=false", async () => {
-    storeMock.get.mockReturnValue({ skipPermissions: false });
+    storeMock.get.mockReturnValue({
+      skipPermissions: false,
+    } as unknown as Partial<HelpAssistantSettings>);
     registerHelpAssistantHandlers();
     const handler = ipcMainMock._handlers.get(GET_CHANNEL)!;
 
@@ -107,7 +111,7 @@ describe("registerHelpAssistantHandlers", () => {
       skipPermissions: true,
       tier: "action",
       bypassPermissions: false,
-    });
+    } as unknown as Partial<HelpAssistantSettings>);
     registerHelpAssistantHandlers();
     const handler = ipcMainMock._handlers.get(GET_CHANNEL)!;
 
@@ -119,7 +123,7 @@ describe("registerHelpAssistantHandlers", () => {
     storeMock.get.mockReturnValue({
       tier: "external",
       bypassPermissions: false,
-    });
+    } as unknown as Partial<HelpAssistantSettings>);
     registerHelpAssistantHandlers();
     const handler = ipcMainMock._handlers.get(GET_CHANNEL)!;
 

--- a/electron/ipc/handlers/__tests__/helpAssistant.handlers.test.ts
+++ b/electron/ipc/handlers/__tests__/helpAssistant.handlers.test.ts
@@ -55,7 +55,8 @@ describe("registerHelpAssistantHandlers", () => {
     expect(result).toEqual({
       docSearch: true,
       daintreeControl: true,
-      skipPermissions: false,
+      tier: "action",
+      bypassPermissions: false,
       auditRetention: 7,
       customArgs: "",
       idleHibernateMinutes: 30,
@@ -63,7 +64,11 @@ describe("registerHelpAssistantHandlers", () => {
   });
 
   it("merges stored values over defaults so legacy partial state still loads", async () => {
-    storeMock.get.mockReturnValue({ skipPermissions: true, auditRetention: 30 });
+    storeMock.get.mockReturnValue({
+      tier: "system",
+      bypassPermissions: true,
+      auditRetention: 30,
+    });
     registerHelpAssistantHandlers();
     const handler = ipcMainMock._handlers.get(GET_CHANNEL)!;
 
@@ -71,22 +76,90 @@ describe("registerHelpAssistantHandlers", () => {
     expect(result).toEqual({
       docSearch: true,
       daintreeControl: true,
-      skipPermissions: true,
+      tier: "system",
+      bypassPermissions: true,
       auditRetention: 30,
       customArgs: "",
       idleHibernateMinutes: 30,
     });
   });
 
+  it("migrates legacy skipPermissions=true to tier='system' + bypassPermissions=true", async () => {
+    storeMock.get.mockReturnValue({ skipPermissions: true });
+    registerHelpAssistantHandlers();
+    const handler = ipcMainMock._handlers.get(GET_CHANNEL)!;
+
+    const result = await handler(null);
+    expect(result).toMatchObject({ tier: "system", bypassPermissions: true });
+  });
+
+  it("migrates legacy skipPermissions=false to tier='action' + bypassPermissions=false", async () => {
+    storeMock.get.mockReturnValue({ skipPermissions: false });
+    registerHelpAssistantHandlers();
+    const handler = ipcMainMock._handlers.get(GET_CHANNEL)!;
+
+    const result = await handler(null);
+    expect(result).toMatchObject({ tier: "action", bypassPermissions: false });
+  });
+
+  it("prefers new fields over legacy skipPermissions when both are present", async () => {
+    storeMock.get.mockReturnValue({
+      skipPermissions: true,
+      tier: "action",
+      bypassPermissions: false,
+    });
+    registerHelpAssistantHandlers();
+    const handler = ipcMainMock._handlers.get(GET_CHANNEL)!;
+
+    const result = await handler(null);
+    expect(result).toMatchObject({ tier: "action", bypassPermissions: false });
+  });
+
+  it("rejects an invalid stored tier and falls back to default", async () => {
+    storeMock.get.mockReturnValue({
+      tier: "external",
+      bypassPermissions: false,
+    });
+    registerHelpAssistantHandlers();
+    const handler = ipcMainMock._handlers.get(GET_CHANNEL)!;
+
+    const result = await handler(null);
+    expect(result).toMatchObject({ tier: "action", bypassPermissions: false });
+  });
+
   it("persists each touched key under helpAssistant.<field>", async () => {
     registerHelpAssistantHandlers();
     const handler = ipcMainMock._handlers.get(SET_CHANNEL)!;
 
-    await handler(null, { docSearch: false, skipPermissions: true });
+    await handler(null, { docSearch: false, bypassPermissions: true });
 
     expect(storeMock.set).toHaveBeenCalledWith("helpAssistant.docSearch", false);
-    expect(storeMock.set).toHaveBeenCalledWith("helpAssistant.skipPermissions", true);
+    expect(storeMock.set).toHaveBeenCalledWith("helpAssistant.bypassPermissions", true);
     expect(storeMock.set).toHaveBeenCalledTimes(2);
+  });
+
+  it("persists tier when set to a valid value", async () => {
+    registerHelpAssistantHandlers();
+    const handler = ipcMainMock._handlers.get(SET_CHANNEL)!;
+
+    await handler(null, { tier: "system" });
+    await handler(null, { tier: "workbench" });
+    await handler(null, { tier: "action" });
+
+    expect(storeMock.set).toHaveBeenCalledWith("helpAssistant.tier", "system");
+    expect(storeMock.set).toHaveBeenCalledWith("helpAssistant.tier", "workbench");
+    expect(storeMock.set).toHaveBeenCalledWith("helpAssistant.tier", "action");
+  });
+
+  it("rejects tier values outside the valid HelpAssistantTier union", async () => {
+    registerHelpAssistantHandlers();
+    const handler = ipcMainMock._handlers.get(SET_CHANNEL)!;
+
+    await handler(null, { tier: "external" });
+    await handler(null, { tier: "off" });
+    await handler(null, { tier: 0 });
+
+    expect(storeMock.set).not.toHaveBeenCalled();
   });
 
   it("ignores undefined values so partial patches do not erase keys", async () => {
@@ -137,7 +210,7 @@ describe("registerHelpAssistantHandlers", () => {
     registerHelpAssistantHandlers();
     const handler = ipcMainMock._handlers.get(SET_CHANNEL)!;
 
-    await handler(null, { docSearch: "yes", daintreeControl: 1, skipPermissions: 0 });
+    await handler(null, { docSearch: "yes", daintreeControl: 1, bypassPermissions: 0 });
 
     expect(storeMock.set).not.toHaveBeenCalled();
   });
@@ -160,7 +233,8 @@ describe("registerHelpAssistantHandlers", () => {
     storeMock.get.mockReturnValue({
       docSearch: "not-a-boolean" as unknown as boolean,
       daintreeControl: 42 as unknown as boolean,
-      skipPermissions: null as unknown as boolean,
+      tier: null as unknown as "action",
+      bypassPermissions: "yes" as unknown as boolean,
       auditRetention: 365 as unknown as 7,
     });
     registerHelpAssistantHandlers();
@@ -170,7 +244,8 @@ describe("registerHelpAssistantHandlers", () => {
     expect(result).toEqual({
       docSearch: true,
       daintreeControl: true,
-      skipPermissions: false,
+      tier: "action",
+      bypassPermissions: false,
       auditRetention: 7,
       customArgs: "",
       idleHibernateMinutes: 30,

--- a/electron/ipc/handlers/helpAssistant.ts
+++ b/electron/ipc/handlers/helpAssistant.ts
@@ -6,6 +6,7 @@ import type {
   HelpAssistantIdleHibernateMinutes,
   HelpAssistantSettings,
 } from "../../../shared/types/ipc/api.js";
+import type { HelpAssistantTier } from "../../../shared/types/ipc/maps.js";
 import { hasShellMetachar } from "../../../shared/utils/shellEscape.js";
 import type * as McpServerServiceModule from "../../services/McpServerService.js";
 
@@ -25,7 +26,8 @@ const CUSTOM_ARGS_MAX_LEN = 10000;
 const HELP_ASSISTANT_DEFAULTS: HelpAssistantSettings = {
   docSearch: true,
   daintreeControl: true,
-  skipPermissions: false,
+  tier: "action",
+  bypassPermissions: false,
   auditRetention: 7,
   customArgs: "",
   idleHibernateMinutes: 30,
@@ -34,7 +36,8 @@ const HELP_ASSISTANT_DEFAULTS: HelpAssistantSettings = {
 const HELP_ASSISTANT_KEYS = [
   "docSearch",
   "daintreeControl",
-  "skipPermissions",
+  "tier",
+  "bypassPermissions",
   "auditRetention",
   "customArgs",
   "idleHibernateMinutes",
@@ -48,6 +51,10 @@ function isValidAuditRetention(value: unknown): value is HelpAssistantAuditReten
 
 function isValidIdleHibernateMinutes(value: unknown): value is HelpAssistantIdleHibernateMinutes {
   return value === 0 || value === 15 || value === 30 || value === 60 || value === 120;
+}
+
+function isValidHelpAssistantTier(value: unknown): value is HelpAssistantTier {
+  return value === "workbench" || value === "action" || value === "system";
 }
 
 // Mirrors `customFlags` validation in src/config/agents.ts: the value is
@@ -68,7 +75,20 @@ function sanitizeStored(stored: unknown): Partial<HelpAssistantSettings> {
   const record = stored as Record<string, unknown>;
   if (typeof record.docSearch === "boolean") out.docSearch = record.docSearch;
   if (typeof record.daintreeControl === "boolean") out.daintreeControl = record.daintreeControl;
-  if (typeof record.skipPermissions === "boolean") out.skipPermissions = record.skipPermissions;
+  // Read-time migration from the legacy `skipPermissions` boolean: if the
+  // new fields aren't stored, derive them from the old boolean. New writes
+  // never touch `skipPermissions`, so once a user has saved the new fields
+  // the legacy fallback is dormant.
+  if (isValidHelpAssistantTier(record.tier)) {
+    out.tier = record.tier;
+  } else if (typeof record.skipPermissions === "boolean") {
+    out.tier = record.skipPermissions ? "system" : "action";
+  }
+  if (typeof record.bypassPermissions === "boolean") {
+    out.bypassPermissions = record.bypassPermissions;
+  } else if (typeof record.skipPermissions === "boolean") {
+    out.bypassPermissions = record.skipPermissions;
+  }
   if (isValidAuditRetention(record.auditRetention)) out.auditRetention = record.auditRetention;
   if (isValidIdleHibernateMinutes(record.idleHibernateMinutes)) {
     out.idleHibernateMinutes = record.idleHibernateMinutes;
@@ -96,8 +116,9 @@ export function registerHelpAssistantHandlers(): () => void {
       if (!KNOWN_KEYS.has(field)) continue;
       if (field === "auditRetention" && !isValidAuditRetention(value)) continue;
       if (field === "idleHibernateMinutes" && !isValidIdleHibernateMinutes(value)) continue;
+      if (field === "tier" && !isValidHelpAssistantTier(value)) continue;
       if (
-        (field === "docSearch" || field === "daintreeControl" || field === "skipPermissions") &&
+        (field === "docSearch" || field === "daintreeControl" || field === "bypassPermissions") &&
         typeof value !== "boolean"
       ) {
         continue;

--- a/electron/ipc/handlers/terminal/__tests__/lifecycle.spawn.test.ts
+++ b/electron/ipc/handlers/terminal/__tests__/lifecycle.spawn.test.ts
@@ -726,6 +726,65 @@ describe("terminal spawn handler - help session detection (#6524)", () => {
     expect(spawnArgs.command).not.toContain("--dangerously-skip-permissions");
   });
 
+  it("strips a lookalike --dangerously-skip-permissions=false from help launches with bypass off", async () => {
+    // Defense-in-depth: a customArgs lookalike like
+    // `--dangerously-skip-permissions=false` could survive a substring-only
+    // check. The strip must use a token-boundary regex that also matches
+    // `--flag=value` forms.
+    mockValidateToken.mockImplementation((token) => (token === "help-token" ? "action" : false));
+    mockGetBypassPermissions.mockImplementation(() => false);
+
+    const deps = { ptyClient } as unknown as HandlerDependencies;
+    registerTerminalLifecycleHandlers(deps);
+
+    const handler = getSpawnHandler();
+    await handler(
+      {} as Electron.IpcMainInvokeEvent,
+      {
+        cols: 80,
+        rows: 24,
+        cwd: tmpDir,
+        command: "claude --dangerously-skip-permissions=false --resume abc",
+        launchAgentId: "claude",
+        env: { DAINTREE_MCP_TOKEN: "help-token" },
+      } as unknown as Parameters<typeof handler>[1]
+    );
+
+    const spawnArgs = ptyClient.spawn.mock.calls[0][1];
+    expect(spawnArgs.command).not.toContain("--dangerously-skip-permissions");
+    expect(spawnArgs.command).toContain("--resume abc");
+  });
+
+  it("strips lookalike =false and appends canonical --dangerously-skip-permissions when bypass is on", async () => {
+    // Strip-first then conditionally append guarantees the session's
+    // bypass preference wins over a smuggled `=false` form in customArgs.
+    mockValidateToken.mockImplementation((token) => (token === "bypass-token" ? "action" : false));
+    mockGetBypassPermissions.mockImplementation((token) => token === "bypass-token");
+
+    const deps = { ptyClient } as unknown as HandlerDependencies;
+    registerTerminalLifecycleHandlers(deps);
+
+    const handler = getSpawnHandler();
+    await handler(
+      {} as Electron.IpcMainInvokeEvent,
+      {
+        cols: 80,
+        rows: 24,
+        cwd: tmpDir,
+        command: "claude --dangerously-skip-permissions=false --resume abc",
+        launchAgentId: "claude",
+        env: { DAINTREE_MCP_TOKEN: "bypass-token" },
+      } as unknown as Parameters<typeof handler>[1]
+    );
+
+    const spawnArgs = ptyClient.spawn.mock.calls[0][1];
+    // No `=false` lookalike survives.
+    expect(spawnArgs.command).not.toContain("--dangerously-skip-permissions=false");
+    // Canonical flag is present as a standalone token.
+    expect(spawnArgs.command).toMatch(/(^|\s)--dangerously-skip-permissions(\s|$)/);
+    expect(spawnArgs.command).toContain("--resume abc");
+  });
+
   it("refuses to spawn when DAINTREE_MCP_TOKEN is present but invalid for an assistant-supported launch (#7509)", async () => {
     // Models the orphan-backend scenario: the renderer provisioned a session,
     // a sibling provision displaced it, then the renderer's spawn IPC arrived

--- a/electron/ipc/handlers/terminal/__tests__/lifecycle.spawn.test.ts
+++ b/electron/ipc/handlers/terminal/__tests__/lifecycle.spawn.test.ts
@@ -102,10 +102,13 @@ const mockMarkTerminalForToken = vi.hoisted(() =>
 
 const mockUnbindTerminal = vi.hoisted(() => vi.fn<(terminalId: string) => void>());
 
+const mockGetBypassPermissions = vi.hoisted(() => vi.fn<(token: string) => boolean>(() => false));
+
 vi.mock("../../../../services/HelpSessionService.js", () => ({
   helpSessionService: {
     validateToken: (token: string) => mockValidateToken(token),
     getCodexLaunchArgs: (token: string) => mockGetCodexLaunchArgs(token),
+    getBypassPermissions: (token: string) => mockGetBypassPermissions(token),
     markTerminalForToken: (token: string, terminalId: string) =>
       mockMarkTerminalForToken(token, terminalId),
     unbindTerminal: (terminalId: string) => mockUnbindTerminal(terminalId),
@@ -575,6 +578,8 @@ describe("terminal spawn handler - help session detection (#6524)", () => {
     mockCurrentPort.mockReturnValue(null);
     mockGetCodexLaunchArgs.mockReset();
     mockGetCodexLaunchArgs.mockReturnValue(null);
+    mockGetBypassPermissions.mockReset();
+    mockGetBypassPermissions.mockReturnValue(false);
     mockMarkTerminalForToken.mockReset();
     mockMarkTerminalForToken.mockReturnValue(true);
     mockUnbindTerminal.mockReset();
@@ -608,8 +613,9 @@ describe("terminal spawn handler - help session detection (#6524)", () => {
     expect(mockPreparePaneConfig).not.toHaveBeenCalled();
   });
 
-  it("appends --dangerously-skip-permissions when help session tier is 'system'", async () => {
-    mockValidateToken.mockImplementation((token) => (token === "system-token" ? "system" : false));
+  it("appends --dangerously-skip-permissions when help session bypassPermissions is true", async () => {
+    mockValidateToken.mockImplementation((token) => (token === "bypass-token" ? "system" : false));
+    mockGetBypassPermissions.mockImplementation((token) => token === "bypass-token");
 
     const deps = { ptyClient } as unknown as HandlerDependencies;
     registerTerminalLifecycleHandlers(deps);
@@ -623,7 +629,7 @@ describe("terminal spawn handler - help session detection (#6524)", () => {
         cwd: tmpDir,
         command: "claude",
         launchAgentId: "claude",
-        env: { DAINTREE_MCP_TOKEN: "system-token" },
+        env: { DAINTREE_MCP_TOKEN: "bypass-token" },
       } as unknown as Parameters<typeof handler>[1]
     );
 
@@ -633,13 +639,71 @@ describe("terminal spawn handler - help session detection (#6524)", () => {
     expect(mockPreparePaneConfig).not.toHaveBeenCalled();
   });
 
-  it("strips --dangerously-skip-permissions from action-tier help launches even if it leaked in via agent settings", async () => {
-    // The help-tier classification — driven by `helpAssistant.skipPermissions`
-    // — is the source of truth. If a user has Claude's global
-    // `dangerousEnabled` on, the renderer's command generator may include
-    // `--dangerously-skip-permissions`, and the action-tier help session must
-    // strip it so the assistant doesn't silently bypass permission prompts.
+  it("appends --dangerously-skip-permissions even at action tier when bypassPermissions is on", async () => {
+    // Tier and bypassPermissions are decoupled (#7532): an action-tier
+    // session with bypass on should still skip the CLI confirmation gate.
+    mockValidateToken.mockImplementation((token) =>
+      token === "bypass-action-token" ? "action" : false
+    );
+    mockGetBypassPermissions.mockImplementation((token) => token === "bypass-action-token");
+
+    const deps = { ptyClient } as unknown as HandlerDependencies;
+    registerTerminalLifecycleHandlers(deps);
+
+    const handler = getSpawnHandler();
+    await handler(
+      {} as Electron.IpcMainInvokeEvent,
+      {
+        cols: 80,
+        rows: 24,
+        cwd: tmpDir,
+        command: "claude",
+        launchAgentId: "claude",
+        env: { DAINTREE_MCP_TOKEN: "bypass-action-token" },
+      } as unknown as Parameters<typeof handler>[1]
+    );
+
+    const spawnArgs = ptyClient.spawn.mock.calls[0][1];
+    expect(spawnArgs.command).toContain("--dangerously-skip-permissions");
+  });
+
+  it("does NOT append --dangerously-skip-permissions when tier=system but bypassPermissions=false", async () => {
+    // Tier and bypassPermissions are decoupled (#7532): a system-tier
+    // session can still respect Claude's permission gate.
+    mockValidateToken.mockImplementation((token) =>
+      token === "system-no-bypass" ? "system" : false
+    );
+    mockGetBypassPermissions.mockImplementation(() => false);
+
+    const deps = { ptyClient } as unknown as HandlerDependencies;
+    registerTerminalLifecycleHandlers(deps);
+
+    const handler = getSpawnHandler();
+    await handler(
+      {} as Electron.IpcMainInvokeEvent,
+      {
+        cols: 80,
+        rows: 24,
+        cwd: tmpDir,
+        command: "claude",
+        launchAgentId: "claude",
+        env: { DAINTREE_MCP_TOKEN: "system-no-bypass" },
+      } as unknown as Parameters<typeof handler>[1]
+    );
+
+    const spawnArgs = ptyClient.spawn.mock.calls[0][1];
+    expect(spawnArgs.command).toBe("claude");
+    expect(spawnArgs.command).not.toContain("--dangerously-skip-permissions");
+  });
+
+  it("strips --dangerously-skip-permissions from help launches with bypass off, even if it leaked in via agent settings", async () => {
+    // The session-snapshotted bypassPermissions flag is the source of
+    // truth. If a user has Claude's global `dangerousEnabled` on, the
+    // renderer's command generator may include `--dangerously-skip-permissions`,
+    // and a help session with bypass off must strip it so the assistant
+    // doesn't silently bypass permission prompts.
     mockValidateToken.mockImplementation((token) => (token === "help-token" ? "action" : false));
+    mockGetBypassPermissions.mockImplementation(() => false);
 
     const deps = { ptyClient } as unknown as HandlerDependencies;
     registerTerminalLifecycleHandlers(deps);
@@ -813,8 +877,9 @@ describe("terminal spawn handler - help session detection (#6524)", () => {
     expect(mockPreparePaneConfig).not.toHaveBeenCalled();
   });
 
-  it("appends --dangerously-bypass-approvals-and-sandbox to a system-tier Codex help launch", async () => {
+  it("appends --dangerously-bypass-approvals-and-sandbox when bypassPermissions is on for a Codex help launch", async () => {
     mockValidateToken.mockImplementation((token) => (token === "system-token" ? "system" : false));
+    mockGetBypassPermissions.mockImplementation((token) => token === "system-token");
     mockGetCodexLaunchArgs.mockReturnValue([]);
 
     const deps = { ptyClient } as unknown as HandlerDependencies;

--- a/electron/ipc/handlers/terminal/lifecycle.ts
+++ b/electron/ipc/handlers/terminal/lifecycle.ts
@@ -217,8 +217,10 @@ export function registerTerminalLifecycleHandlers(deps: HandlerDependencies): ()
     // a .claude/settings.json that sets `enableAllProjectMcpServers: true` so
     // Claude Code auto-trusts the project-scoped servers without prompting.
     // Skip per-pane MCP config injection (the session dir owns it) and let
-    // Claude's normal cwd discovery do its thing. For `system`-tier sessions
-    // (skipPermissions), append the dangerous flag.
+    // Claude's normal cwd discovery do its thing. The CLI bypass flag is
+    // gated on the session's snapshotted `bypassPermissions` (independent
+    // of `tier`), so an `action`-tier session can still skip permission
+    // prompts and a `system`-tier session can still respect them.
     const helpToken = spawnEnv?.DAINTREE_MCP_TOKEN ?? "";
     const helpTier = helpToken ? helpSessionService.validateToken(helpToken) : false;
     const isAssistantAgent =
@@ -240,17 +242,19 @@ export function registerTerminalLifecycleHandlers(deps: HandlerDependencies): ()
 
     if (isHelpLaunch && launchAgentId) {
       const dangerous = DEFAULT_DANGEROUS_ARGS[launchAgentId];
-      if (helpTier === "system") {
+      const bypassPermissions = helpSessionService.getBypassPermissions(helpToken);
+      if (bypassPermissions) {
         if (dangerous && !safeCommand.includes(dangerous)) {
           safeCommand = `${safeCommand} ${dangerous}`;
         }
       } else if (dangerous) {
-        // The help-tier classification is the source of truth for whether the
-        // assistant runs in dangerous mode — `helpAssistant.skipPermissions`
-        // governs it, not the global Claude agent settings. Strip the flag if
-        // it leaked in via `entry.dangerousEnabled` from the agent registry,
-        // otherwise an `action`-tier session would silently skip permission
-        // prompts despite the assistant config saying otherwise.
+        // The session-snapshotted `bypassPermissions` flag is the source of
+        // truth for whether the assistant runs in dangerous mode — set per
+        // help session at provision time, decoupled from the MCP `tier`.
+        // Strip the flag if it leaked in via `entry.dangerousEnabled` from
+        // the agent registry, otherwise a session with bypass off would
+        // silently skip permission prompts despite the assistant config
+        // saying otherwise.
         const stripPattern = new RegExp(
           `(^|\\s)${dangerous.replace(/[.*+?^${}()|[\\]\\\\]/g, "\\$&")}(?=\\s|$)`,
           "g"

--- a/electron/ipc/handlers/terminal/lifecycle.ts
+++ b/electron/ipc/handlers/terminal/lifecycle.ts
@@ -243,26 +243,24 @@ export function registerTerminalLifecycleHandlers(deps: HandlerDependencies): ()
     if (isHelpLaunch && launchAgentId) {
       const dangerous = DEFAULT_DANGEROUS_ARGS[launchAgentId];
       const bypassPermissions = helpSessionService.getBypassPermissions(helpToken);
-      if (bypassPermissions) {
-        if (dangerous && !safeCommand.includes(dangerous)) {
-          safeCommand = `${safeCommand} ${dangerous}`;
-        }
-      } else if (dangerous) {
+      if (dangerous) {
         // The session-snapshotted `bypassPermissions` flag is the source of
         // truth for whether the assistant runs in dangerous mode — set per
         // help session at provision time, decoupled from the MCP `tier`.
-        // Strip the flag if it leaked in via `entry.dangerousEnabled` from
-        // the agent registry, otherwise a session with bypass off would
-        // silently skip permission prompts despite the assistant config
-        // saying otherwise.
-        const stripPattern = new RegExp(
-          `(^|\\s)${dangerous.replace(/[.*+?^${}()|[\\]\\\\]/g, "\\$&")}(?=\\s|$)`,
-          "g"
-        );
+        // Always strip first (covering bare flag and `--flag=value`
+        // lookalikes that could survive a substring-only check). Then append
+        // the canonical flag iff bypass is on. The strip-first pass means
+        // `--dangerously-skip-permissions=false` smuggled via customArgs on
+        // a resume launch never wins over the session's stored preference.
+        const dangerousEscaped = dangerous.replace(/[.*+?^${}()|[\]\\]/g, "\\$&");
+        const stripPattern = new RegExp(`(^|\\s)${dangerousEscaped}(?:=\\S*)?(?=\\s|$)`, "g");
         safeCommand = safeCommand
           .replace(stripPattern, "$1")
           .replace(/\s{2,}/g, " ")
           .trim();
+        if (bypassPermissions) {
+          safeCommand = safeCommand.length > 0 ? `${safeCommand} ${dangerous}` : dangerous;
+        }
       }
       // Codex doesn't read project-scoped `.codex/config.toml` from cwd —
       // its only override mechanism is the `-c key=value` CLI flag. The

--- a/electron/preload.cts
+++ b/electron/preload.cts
@@ -15,6 +15,7 @@ import { isIpcEnvelope } from "../shared/types/ipc/errors.js";
 import { deserializeError } from "../shared/utils/ipcErrorSerialization.js";
 import type { AppErrorCode } from "../shared/types/appError.js";
 import type { McpRuntimeSnapshot } from "../shared/types/ipc/mcpServer.js";
+import type { HelpAssistantTier } from "../shared/types/ipc/maps.js";
 import { CHANNELS } from "./ipc/channels.js";
 import { buildClipboardPreloadBindings } from "./ipc/handlers/clipboard.preload.js";
 import { buildSlashCommandsPreloadBindings } from "./ipc/handlers/slashCommands.preload.js";
@@ -2411,7 +2412,8 @@ const api: ElectronAPI = {
       patch: Partial<{
         docSearch: boolean;
         daintreeControl: boolean;
-        skipPermissions: boolean;
+        tier: HelpAssistantTier;
+        bypassPermissions: boolean;
         auditRetention: 7 | 30 | 0;
       }>
     ) => _unwrappingInvoke(CHANNELS.HELP_ASSISTANT_SET_SETTINGS, patch),

--- a/electron/services/HelpSessionService.ts
+++ b/electron/services/HelpSessionService.ts
@@ -35,7 +35,11 @@ const TEMPLATE_HASH_FILE = ".template-hash";
 const DEFAULT_TIER: HelpAssistantTier = "action";
 const DEFAULT_DAINTREE_CONTROL = true;
 const DEFAULT_DOC_SEARCH = true;
-const DEFAULT_SKIP_PERMISSIONS = false;
+const DEFAULT_BYPASS_PERMISSIONS = false;
+
+function isHelpAssistantTier(value: unknown): value is HelpAssistantTier {
+  return value === "workbench" || value === "action" || value === "system";
+}
 
 interface ProvisionInput {
   projectId: string;
@@ -64,6 +68,13 @@ interface HelpSessionRecord {
   sessionPath: string;
   agentId: string;
   tier: HelpAssistantTier;
+  /**
+   * Snapshot at provision time of the user's CLI bypass preference. Consumed
+   * by `lifecycle.ts` to decide whether to append `--dangerously-skip-permissions`
+   * to the spawn command. Decoupled from `tier` so a `tier="action"` session
+   * can still bypass Claude's confirmation gate (and vice versa).
+   */
+  bypassPermissions: boolean;
   createdAt: number;
   revoked: boolean;
   /** Computed at provision for codex sessions; consumed by lifecycle.ts. */
@@ -345,7 +356,7 @@ export class HelpSessionService {
     pathHash: string
   ): Promise<ProvisionResult | null> {
     const settings = this.readSettings();
-    const tier = this.resolveTier(settings.skipPermissions);
+    const tier = settings.tier;
     const sessionId = randomUUID();
     const token = randomBytes(SESSION_TOKEN_BYTES).toString("hex");
     const sessionsRoot = this.getSessionsRoot();
@@ -445,6 +456,7 @@ export class HelpSessionService {
       sessionPath,
       agentId: input.agentId,
       tier,
+      bypassPermissions: settings.bypassPermissions,
       createdAt: now,
       revoked: false,
       codexLaunchArgs,
@@ -724,24 +736,51 @@ export class HelpSessionService {
   private readSettings(): {
     daintreeControl: boolean;
     docSearch: boolean;
-    skipPermissions: boolean;
+    tier: HelpAssistantTier;
+    bypassPermissions: boolean;
   } {
     const stored = (store.get("helpAssistant") as Record<string, unknown> | undefined) ?? {};
+    // Read-time migration from the legacy `skipPermissions` boolean. This
+    // mirrors the IPC handler's `sanitizeStored` exactly — both must stay in
+    // lockstep so a session provisioned during the same boot as a renderer
+    // settings load reads identical values from the store.
+    const legacySkip = typeof stored.skipPermissions === "boolean" ? stored.skipPermissions : null;
+    const tier: HelpAssistantTier = isHelpAssistantTier(stored.tier)
+      ? stored.tier
+      : legacySkip !== null
+        ? legacySkip
+          ? "system"
+          : "action"
+        : DEFAULT_TIER;
+    const bypassPermissions =
+      typeof stored.bypassPermissions === "boolean"
+        ? stored.bypassPermissions
+        : legacySkip !== null
+          ? legacySkip
+          : DEFAULT_BYPASS_PERMISSIONS;
     return {
       daintreeControl:
         typeof stored.daintreeControl === "boolean"
           ? stored.daintreeControl
           : DEFAULT_DAINTREE_CONTROL,
       docSearch: typeof stored.docSearch === "boolean" ? stored.docSearch : DEFAULT_DOC_SEARCH,
-      skipPermissions:
-        typeof stored.skipPermissions === "boolean"
-          ? stored.skipPermissions
-          : DEFAULT_SKIP_PERMISSIONS,
+      tier,
+      bypassPermissions,
     };
   }
 
-  private resolveTier(skipPermissions: boolean): HelpAssistantTier {
-    return skipPermissions ? "system" : DEFAULT_TIER;
+  /**
+   * Returns the snapshot of the user's CLI bypass preference taken at
+   * provision time. `lifecycle.ts` reads this to decide whether to append
+   * `--dangerously-skip-permissions` to the assistant spawn command —
+   * decoupled from `tier` (which controls MCP capability) so the two
+   * controls are truly orthogonal.
+   */
+  getBypassPermissions(token: string): boolean {
+    if (!token) return false;
+    const record = this.sessionsByToken.get(token);
+    if (!record || record.revoked) return false;
+    return record.bypassPermissions;
   }
 
   private getSessionsRoot(): string {
@@ -880,7 +919,7 @@ export class HelpSessionService {
   private async writeClaudeSettings(
     sessionPath: string,
     bundledHelpFolder: string,
-    settings: { daintreeControl: boolean; skipPermissions: boolean }
+    settings: { daintreeControl: boolean; bypassPermissions: boolean }
   ): Promise<void> {
     const bundledSettingsPath = path.join(bundledHelpFolder, ".claude", "settings.json");
     const baseline = await this.readBundledSettings(bundledSettingsPath);
@@ -898,7 +937,7 @@ export class HelpSessionService {
     // server interactively on first launch, which would block the assistant.
     merged.enableAllProjectMcpServers = true;
 
-    if (settings.skipPermissions) {
+    if (settings.bypassPermissions) {
       merged.defaultMode = "bypassPermissions";
     }
 

--- a/electron/services/HelpSessionService.ts
+++ b/electron/services/HelpSessionService.ts
@@ -937,8 +937,13 @@ export class HelpSessionService {
     // server interactively on first launch, which would block the assistant.
     merged.enableAllProjectMcpServers = true;
 
+    // Always assign defaultMode explicitly so a baseline change (or a future
+    // bundled template that ships with `defaultMode` set) can never silently
+    // bypass permissions when the user has bypass off.
     if (settings.bypassPermissions) {
       merged.defaultMode = "bypassPermissions";
+    } else {
+      delete merged.defaultMode;
     }
 
     const target = path.join(sessionPath, ".claude", "settings.json");

--- a/electron/services/__tests__/HelpSessionService.test.ts
+++ b/electron/services/__tests__/HelpSessionService.test.ts
@@ -216,7 +216,7 @@ describe("HelpSessionService", () => {
     expect(settings.permissions.deny).toContain("Write(**)");
   });
 
-  it("sets defaultMode=bypassPermissions and tier=system when skipPermissions is true", async () => {
+  it("sets defaultMode=bypassPermissions and tier=system when legacy skipPermissions is true", async () => {
     mockStoreGet.mockReturnValue({ skipPermissions: true });
 
     const result = await service.provisionSession(provisionInput());
@@ -227,6 +227,54 @@ describe("HelpSessionService", () => {
       await fs.readFile(path.join(result.sessionPath, ".claude", "settings.json"), "utf-8")
     );
     expect(settings.defaultMode).toBe("bypassPermissions");
+  });
+
+  it("writes defaultMode=bypassPermissions when bypassPermissions is on but tier stays at action", async () => {
+    mockStoreGet.mockReturnValue({ tier: "action", bypassPermissions: true });
+
+    const result = await service.provisionSession(provisionInput());
+    if (!result) throw new Error("expected result");
+    // tier and bypassPermissions are decoupled — action tier with bypass
+    // on writes defaultMode but does NOT elevate the MCP tier to system.
+    expect(result.tier).toBe("action");
+
+    const settings = JSON.parse(
+      await fs.readFile(path.join(result.sessionPath, ".claude", "settings.json"), "utf-8")
+    );
+    expect(settings.defaultMode).toBe("bypassPermissions");
+  });
+
+  it("does NOT write defaultMode when tier=system but bypassPermissions is off", async () => {
+    mockStoreGet.mockReturnValue({ tier: "system", bypassPermissions: false });
+
+    const result = await service.provisionSession(provisionInput());
+    if (!result) throw new Error("expected result");
+    expect(result.tier).toBe("system");
+
+    const settings = JSON.parse(
+      await fs.readFile(path.join(result.sessionPath, ".claude", "settings.json"), "utf-8")
+    );
+    expect(settings.defaultMode).toBeUndefined();
+  });
+
+  it("getBypassPermissions returns the snapshot taken at provision time", async () => {
+    mockStoreGet.mockReturnValue({ tier: "action", bypassPermissions: true });
+
+    const result = await service.provisionSession(provisionInput());
+    if (!result) throw new Error("expected result");
+
+    expect(service.getBypassPermissions(result.token)).toBe(true);
+    expect(service.getBypassPermissions("not-a-token")).toBe(false);
+    expect(service.getBypassPermissions("")).toBe(false);
+
+    await service.revokeSession(result.sessionId);
+    expect(service.getBypassPermissions(result.token)).toBe(false);
+  });
+
+  it("getBypassPermissions defaults to false when settings have not been touched", async () => {
+    const result = await service.provisionSession(provisionInput());
+    if (!result) throw new Error("expected result");
+    expect(service.getBypassPermissions(result.token)).toBe(false);
   });
 
   it("omits the daintree MCP server when daintreeControl is false", async () => {

--- a/electron/services/mcp-server/shared.ts
+++ b/electron/services/mcp-server/shared.ts
@@ -16,6 +16,11 @@ import {
   WAIT_UNTIL_IDLE_OUTPUT_SCHEMA,
   WAIT_UNTIL_IDLE_DESCRIPTION,
 } from "../../../shared/types/terminalWaitUntilIdle.js";
+import {
+  ACTION_TIER_ADDONS as ACTION_TIER_ADDONS_LIST,
+  SYSTEM_TIER_ADDONS as SYSTEM_TIER_ADDONS_LIST,
+  WORKBENCH_TIER_TOOLS as WORKBENCH_TIER_TOOLS_LIST,
+} from "../../../shared/config/helpAssistantTierAllowlists.js";
 
 export {
   type WaitUntilIdleResult,
@@ -94,117 +99,14 @@ export const OPEN_WORLD_CATEGORIES: ReadonlySet<string> = new Set([
 
 export type McpTier = "workbench" | "action" | "system" | "external";
 
-const WORKBENCH_TOOLS: ReadonlySet<string> = new Set([
-  ACTIONS_LIST_TOOL,
-  "actions.getContext",
-
-  "project.getAll",
-  "project.getCurrent",
-  "project.getSettings",
-  "project.getStats",
-  "project.detectRunners",
-
-  "worktree.list",
-  "worktree.getCurrent",
-  "worktree.listBranches",
-  "worktree.getDefaultPath",
-  "worktree.getAvailableBranch",
-  "worktree.resource.status",
-
-  "files.search",
-  "file.view",
-
-  "copyTree.generate",
-
-  "terminal.list",
-  "terminal.getOutput",
-  "terminal.getStatus",
-
-  "agent.getState",
-
-  "agentSettings.get",
-  "keybinding.getOverrides",
-
-  "slashCommands.list",
-
-  "git.getProjectPulse",
-  "git.getFileDiff",
-  "git.listCommits",
-  "git.getStagingStatus",
-  "git.snapshotGet",
-  "git.snapshotList",
-
-  "github.checkCli",
-  "github.getRepoStats",
-  "github.listIssues",
-  "github.listPullRequests",
-  "github.getIssueByNumber",
-
-  "workflow.prepBranchForReview",
-
-  "system.checkCommand",
-  "system.checkDirectory",
-]);
-
-const ACTION_TIER_ADDONS: ReadonlySet<string> = new Set([
-  "worktree.createWithRecipe",
-  "worktree.setActive",
-  "worktree.refresh",
-
-  "terminal.inject",
-  "terminal.new",
-  "terminal.waitUntilIdle",
-
-  "recipe.list",
-  "recipe.run",
-
-  "copyTree.injectToTerminal",
-
-  "file.openInEditor",
-
-  "agent.terminal",
-  "agent.focusNextWaiting",
-  "agent.focusNextWorking",
-  "agent.focusNextAgent",
-  "agent.focusPreviousAgent",
-
-  "workflow.startWorkOnIssue",
-  "workflow.focusNextAttention",
-
-  "app.theme.pick",
-  "app.theme.browser.open",
-  "app.theme.toggle",
-
-  "project.update",
-  "project.saveSettings",
-  "project.muteNotifications",
-]);
-
-const SYSTEM_TIER_ADDONS: ReadonlySet<string> = new Set([
-  "worktree.delete",
-
-  "terminal.sendCommand",
-  "terminal.close",
-  "terminal.closeAll",
-  "terminal.kill",
-  "terminal.killAll",
-
-  "copyTree.generateAndCopyFile",
-
-  "agent.launch",
-
-  "git.stageFile",
-  "git.unstageFile",
-  "git.stageAll",
-  "git.unstageAll",
-  "git.commit",
-  "git.push",
-  "git.snapshotRevert",
-  "git.snapshotDelete",
-
-  "github.openIssue",
-  "github.openPR",
-]);
+// Tier tool lists live in `shared/config/helpAssistantTierAllowlists.ts`
+// so the renderer's blast-radius preview can read them without an IPC
+// round-trip. The arrays remain the single source of truth; this module
+// just lifts them into Sets for O(1) membership checks at dispatch time.
+// `terminal.waitUntilIdle` is included in `ACTION_TIER_ADDONS_LIST`.
+const WORKBENCH_TOOLS: ReadonlySet<string> = new Set(WORKBENCH_TIER_TOOLS_LIST);
+const ACTION_TIER_ADDONS: ReadonlySet<string> = new Set(ACTION_TIER_ADDONS_LIST);
+const SYSTEM_TIER_ADDONS: ReadonlySet<string> = new Set(SYSTEM_TIER_ADDONS_LIST);
 
 export function unionSet(...sets: ReadonlySet<string>[]): ReadonlySet<string> {
   const out = new Set<string>();

--- a/electron/store.ts
+++ b/electron/store.ts
@@ -18,6 +18,7 @@ import type { AgentId } from "../shared/types/agent.js";
 import { DEFAULT_AGENT_SETTINGS, DEFAULT_APP_AGENT_CONFIG } from "../shared/types/index.js";
 import type { AppThemeConfig } from "../shared/types/appTheme.js";
 import type { SettingsRecovery, ActionFrecencyEntry } from "../shared/types/ipc/app.js";
+import type { HelpAssistantTier } from "../shared/types/ipc/maps.js";
 
 interface WindowStateEntry {
   x?: number;
@@ -208,7 +209,24 @@ export interface StoreSchema {
   helpAssistant: {
     docSearch: boolean;
     daintreeControl: boolean;
-    skipPermissions: boolean;
+    /**
+     * MCP capability tier for the help assistant. Migrated at read time from
+     * the legacy `skipPermissions` boolean — see `helpAssistant.ts`
+     * `sanitizeStored` and `HelpSessionService.readSettings`.
+     */
+    tier: HelpAssistantTier;
+    /**
+     * Bypass Claude Code's per-tool confirmation prompt for help sessions.
+     * Migrated at read time from the legacy `skipPermissions` boolean.
+     */
+    bypassPermissions: boolean;
+    /**
+     * Legacy field — kept in the schema for backward compatibility so old
+     * stored values round-trip through the read-time migration without being
+     * stripped by the typed accessor. New writes use `tier` and
+     * `bypassPermissions`; this field is no longer written to.
+     */
+    skipPermissions?: boolean;
     auditRetention: 7 | 30 | 0;
   };
   pendingErrors: ErrorRecord[];
@@ -356,7 +374,8 @@ const storeOptions = {
     helpAssistant: {
       docSearch: true,
       daintreeControl: true,
-      skipPermissions: false,
+      tier: "action" as const,
+      bypassPermissions: false,
       auditRetention: 7 as const,
     },
     pendingErrors: [],

--- a/shared/config/helpAssistantTierAllowlists.ts
+++ b/shared/config/helpAssistantTierAllowlists.ts
@@ -1,0 +1,146 @@
+import type { HelpAssistantTier } from "../types/ipc/maps.js";
+
+const ACTIONS_LIST_TOOL = "actions.list";
+const TERMINAL_WAIT_UNTIL_IDLE_TOOL = "terminal.waitUntilIdle";
+
+export const WORKBENCH_TIER_TOOLS: readonly string[] = [
+  ACTIONS_LIST_TOOL,
+  "actions.getContext",
+
+  "project.getAll",
+  "project.getCurrent",
+  "project.getSettings",
+  "project.getStats",
+  "project.detectRunners",
+
+  "worktree.list",
+  "worktree.getCurrent",
+  "worktree.listBranches",
+  "worktree.getDefaultPath",
+  "worktree.getAvailableBranch",
+  "worktree.resource.status",
+
+  "files.search",
+  "file.view",
+
+  "copyTree.generate",
+
+  "terminal.list",
+  "terminal.getOutput",
+  "terminal.getStatus",
+
+  "agent.getState",
+
+  "agentSettings.get",
+  "keybinding.getOverrides",
+
+  "slashCommands.list",
+
+  "git.getProjectPulse",
+  "git.getFileDiff",
+  "git.listCommits",
+  "git.getStagingStatus",
+  "git.snapshotGet",
+  "git.snapshotList",
+
+  "github.checkCli",
+  "github.getRepoStats",
+  "github.listIssues",
+  "github.listPullRequests",
+  "github.getIssueByNumber",
+
+  "workflow.prepBranchForReview",
+
+  "system.checkCommand",
+  "system.checkDirectory",
+];
+
+export const ACTION_TIER_ADDONS: readonly string[] = [
+  "worktree.createWithRecipe",
+  "worktree.setActive",
+  "worktree.refresh",
+
+  "terminal.inject",
+  "terminal.new",
+  TERMINAL_WAIT_UNTIL_IDLE_TOOL,
+
+  "recipe.list",
+  "recipe.run",
+
+  "copyTree.injectToTerminal",
+
+  "file.openInEditor",
+
+  "agent.terminal",
+  "agent.focusNextWaiting",
+  "agent.focusNextWorking",
+  "agent.focusNextAgent",
+  "agent.focusPreviousAgent",
+
+  "workflow.startWorkOnIssue",
+  "workflow.focusNextAttention",
+
+  "app.theme.pick",
+  "app.theme.browser.open",
+  "app.theme.toggle",
+
+  "project.update",
+  "project.saveSettings",
+  "project.muteNotifications",
+];
+
+export const SYSTEM_TIER_ADDONS: readonly string[] = [
+  "worktree.delete",
+
+  "terminal.sendCommand",
+  "terminal.close",
+  "terminal.closeAll",
+  "terminal.kill",
+  "terminal.killAll",
+
+  "copyTree.generateAndCopyFile",
+
+  "agent.launch",
+
+  "git.stageFile",
+  "git.unstageFile",
+  "git.stageAll",
+  "git.unstageAll",
+  "git.commit",
+  "git.push",
+  "git.snapshotRevert",
+  "git.snapshotDelete",
+
+  "github.openIssue",
+  "github.openPR",
+];
+
+/**
+ * Tools added at each tier on top of the previous one. Useful for the
+ * blast-radius preview UI which shows the incremental capability change.
+ */
+export const HELP_TIER_INCREMENTAL: Record<HelpAssistantTier, readonly string[]> = {
+  workbench: WORKBENCH_TIER_TOOLS,
+  action: ACTION_TIER_ADDONS,
+  system: SYSTEM_TIER_ADDONS,
+};
+
+/**
+ * Cumulative allow-list per tier — every tool the assistant can call
+ * without prompting at that tier.
+ */
+export const HELP_TIER_CUMULATIVE: Record<HelpAssistantTier, readonly string[]> = {
+  workbench: WORKBENCH_TIER_TOOLS,
+  action: [...WORKBENCH_TIER_TOOLS, ...ACTION_TIER_ADDONS],
+  system: [...WORKBENCH_TIER_TOOLS, ...ACTION_TIER_ADDONS, ...SYSTEM_TIER_ADDONS],
+};
+
+/**
+ * Tools whose blast radius is high enough that the UI pins them at the top
+ * of the system-tier preview so users don't miss them in a long list.
+ */
+export const SYSTEM_TIER_HIGH_BLAST_RADIUS: readonly string[] = [
+  "git.push",
+  "terminal.killAll",
+  "worktree.delete",
+];

--- a/shared/types/index.ts
+++ b/shared/types/index.ts
@@ -497,6 +497,7 @@ export type {
   ChecklistState,
   ChecklistItems,
   ChecklistItemId,
+  HelpAssistantTier,
 } from "./ipc/maps.js";
 
 // Task Queue types - DAG-based task management

--- a/shared/types/ipc/api.ts
+++ b/shared/types/ipc/api.ts
@@ -10,7 +10,13 @@ import type {
   TerminalRecipe,
   TerminalSnapshot,
 } from "../project.js";
-import type { OnboardingState, ChecklistState, ChecklistItemId, IpcEventBusMap } from "./maps.js";
+import type {
+  OnboardingState,
+  ChecklistState,
+  ChecklistItemId,
+  HelpAssistantTier,
+  IpcEventBusMap,
+} from "./maps.js";
 import type { AgentSettings, AgentSettingsEntry } from "../agentSettings.js";
 import type { AgentPreset } from "../../config/agentRegistry.js";
 import type { VoiceInputStatus } from "../voice.js";
@@ -1520,8 +1526,17 @@ export interface HelpAssistantSettings {
   docSearch: boolean;
   /** Allow the help assistant to call Daintree control tools via the local MCP. Defaults to true. */
   daintreeControl: boolean;
-  /** Pass --dangerously-skip-permissions when launching the help assistant. Defaults to false. */
-  skipPermissions: boolean;
+  /**
+   * MCP capability tier the help assistant runs at — controls which Daintree
+   * actions the assistant can call without prompting. Defaults to `"action"`.
+   */
+  tier: HelpAssistantTier;
+  /**
+   * Pass `--dangerously-skip-permissions` (Claude) and write
+   * `defaultMode: "bypassPermissions"` into the session's `.claude/settings.json`.
+   * Bypasses Claude Code's per-tool confirmation gate. Defaults to false.
+   */
+  bypassPermissions: boolean;
   /** How long to retain help-session audit logs. 7 = 7 days, 30 = 30 days, 0 = off. Defaults to 7. */
   auditRetention: HelpAssistantAuditRetention;
   /** Whitespace-separated CLI flags appended at assistant launch (e.g. "--model sonnet"). Defaults to "". */

--- a/src/components/HelpPanel/__tests__/HelpPanel.helpLaunch.test.tsx
+++ b/src/components/HelpPanel/__tests__/HelpPanel.helpLaunch.test.tsx
@@ -35,7 +35,8 @@ const {
   mockGetHelpAssistantSettings: vi.fn().mockResolvedValue({
     docSearch: true,
     daintreeControl: true,
-    skipPermissions: false,
+    tier: "action" as const,
+    bypassPermissions: false,
     auditRetention: 7,
     customArgs: "",
   }),
@@ -328,7 +329,8 @@ function resetState() {
   mockGetHelpAssistantSettings.mockResolvedValue({
     docSearch: true,
     daintreeControl: true,
-    skipPermissions: false,
+    tier: "action" as const,
+    bypassPermissions: false,
     auditRetention: 7,
     customArgs: "",
   });
@@ -1457,7 +1459,8 @@ describe("HelpPanel — customArgs threading", () => {
     mockGetHelpAssistantSettings.mockResolvedValue({
       docSearch: true,
       daintreeControl: true,
-      skipPermissions: false,
+      tier: "action" as const,
+      bypassPermissions: false,
       auditRetention: 7,
       customArgs: "--model sonnet --verbose",
     });
@@ -1481,7 +1484,8 @@ describe("HelpPanel — customArgs threading", () => {
     mockGetHelpAssistantSettings.mockResolvedValue({
       docSearch: true,
       daintreeControl: true,
-      skipPermissions: false,
+      tier: "action" as const,
+      bypassPermissions: false,
       auditRetention: 7,
       customArgs: "",
     });
@@ -1503,7 +1507,8 @@ describe("HelpPanel — customArgs threading", () => {
     mockGetHelpAssistantSettings.mockResolvedValue({
       docSearch: true,
       daintreeControl: true,
-      skipPermissions: false,
+      tier: "action" as const,
+      bypassPermissions: false,
       auditRetention: 7,
       customArgs: "   \t  ",
     });
@@ -1526,7 +1531,8 @@ describe("HelpPanel — customArgs threading", () => {
     mockGetHelpAssistantSettings.mockResolvedValue({
       docSearch: true,
       daintreeControl: true,
-      skipPermissions: false,
+      tier: "action" as const,
+      bypassPermissions: false,
       auditRetention: 7,
       customArgs: "--model sonnet",
     });

--- a/src/components/HelpPanel/__tests__/HelpPanel.hibernate.test.tsx
+++ b/src/components/HelpPanel/__tests__/HelpPanel.hibernate.test.tsx
@@ -38,7 +38,8 @@ const {
   mockGetHelpAssistantSettings: vi.fn().mockResolvedValue({
     docSearch: true,
     daintreeControl: true,
-    skipPermissions: false,
+    tier: "action" as const,
+    bypassPermissions: false,
     auditRetention: 7,
     customArgs: "",
     idleHibernateMinutes: 30,
@@ -298,7 +299,8 @@ function resetState() {
   mockGetHelpAssistantSettings.mockResolvedValue({
     docSearch: true,
     daintreeControl: true,
-    skipPermissions: false,
+    tier: "action" as const,
+    bypassPermissions: false,
     auditRetention: 7,
     customArgs: "",
     idleHibernateMinutes: 30,
@@ -593,7 +595,8 @@ describe("HelpPanel — resume preserves user-configured launch flags", () => {
     mockGetHelpAssistantSettings.mockResolvedValue({
       docSearch: true,
       daintreeControl: true,
-      skipPermissions: false,
+      tier: "action" as const,
+      bypassPermissions: false,
       auditRetention: 7,
       customArgs: "--model claude-opus-4-5",
       idleHibernateMinutes: 30,
@@ -776,7 +779,8 @@ describe("HelpPanel — idle hibernation timer", () => {
       mockGetHelpAssistantSettings.mockResolvedValue({
         docSearch: true,
         daintreeControl: true,
-        skipPermissions: false,
+        tier: "action" as const,
+        bypassPermissions: false,
         auditRetention: 7,
         customArgs: "",
         idleHibernateMinutes: 0,

--- a/src/components/Settings/DaintreeAssistantSettingsTab.tsx
+++ b/src/components/Settings/DaintreeAssistantSettingsTab.tsx
@@ -4,6 +4,7 @@ import {
   AlertTriangle,
   BookOpen,
   Check,
+  ChevronRight,
   Copy,
   KeyRound,
   Moon,
@@ -19,6 +20,7 @@ import { SettingsSection } from "./SettingsSection";
 import { SettingsInput } from "./SettingsInput";
 import { SettingsSelect } from "./SettingsSelect";
 import { SettingsSwitchCard } from "./SettingsSwitchCard";
+import { McpAuditLogViewer } from "./McpAuditLogViewer";
 import { useSettingsTabValidation } from "./SettingsValidationRegistry";
 import { useSettingsTabFlush } from "./SettingsFlushRegistry";
 import { formatErrorMessage } from "@shared/utils/errorMessage";
@@ -27,7 +29,12 @@ import { useDebounce } from "@/hooks/useDebounce";
 import { logError } from "@/utils/logger";
 import { getAgentConfig, getAssistantSupportedAgentIds } from "@/config/agents";
 import { useHelpPanelStore } from "@/store/helpPanelStore";
-import type { HelpAssistantSettings } from "@shared/types";
+import type { HelpAssistantSettings, HelpAssistantTier, McpAuditRecord } from "@shared/types";
+import {
+  HELP_TIER_CUMULATIVE,
+  HELP_TIER_INCREMENTAL,
+  SYSTEM_TIER_HIGH_BLAST_RADIUS,
+} from "@shared/config/helpAssistantTierAllowlists";
 
 const COPY_RESET_DELAY_MS = 2000;
 const CUSTOM_ARGS_DEBOUNCE_MS = 500;
@@ -35,11 +42,42 @@ const CUSTOM_ARGS_DEBOUNCE_MS = 500;
 const DEFAULT_SETTINGS: HelpAssistantSettings = {
   docSearch: true,
   daintreeControl: true,
-  skipPermissions: false,
+  tier: "action",
+  bypassPermissions: false,
   auditRetention: 7,
   customArgs: "",
   idleHibernateMinutes: 30,
 };
+
+const TIER_OPTIONS = [
+  { value: "workbench", label: "Workbench — read-only" },
+  { value: "action", label: "Action — read + write (default)" },
+  { value: "system", label: "System — destructive actions" },
+];
+
+const TIER_DESCRIPTIONS: Record<HelpAssistantTier, string> = {
+  workbench:
+    "The assistant can read project state but can't change it. Best when you're handing off observation tasks.",
+  action:
+    "The assistant can edit files, run terminals, and trigger workflows. Most assistance tasks need this.",
+  system:
+    "Includes destructive actions: delete worktrees, kill terminals, push commits. Reserve for trusted automation.",
+};
+
+function groupToolsByNamespace(tools: readonly string[]): Array<[string, string[]]> {
+  const groups = new Map<string, string[]>();
+  for (const tool of tools) {
+    const dot = tool.indexOf(".");
+    const ns = dot >= 0 ? tool.slice(0, dot) : tool;
+    const list = groups.get(ns);
+    if (list) {
+      list.push(tool);
+    } else {
+      groups.set(ns, [tool]);
+    }
+  }
+  return [...groups.entries()].sort(([a], [b]) => a.localeCompare(b));
+}
 
 interface McpStatusSnapshot {
   enabled: boolean;
@@ -69,7 +107,14 @@ export function DaintreeAssistantSettingsTab() {
   const [copied, setCopied] = useState(false);
   const [showRotateConfirm, setShowRotateConfirm] = useState(false);
   const [isRotating, setIsRotating] = useState(false);
+  const [showBlastRadius, setShowBlastRadius] = useState(false);
+  const [auditRecords, setAuditRecords] = useState<McpAuditRecord[]>([]);
+  const [auditLoading, setAuditLoading] = useState(true);
+  const [auditCopied, setAuditCopied] = useState(false);
+  const [showClearAuditConfirm, setShowClearAuditConfirm] = useState(false);
+  const [isClearingAudit, setIsClearingAudit] = useState(false);
   const copyTimeoutRef = useRef<ReturnType<typeof setTimeout> | null>(null);
+  const auditCopyTimeoutRef = useRef<ReturnType<typeof setTimeout> | null>(null);
 
   // customArgs is a free-form text input; persisting on every keystroke would
   // spam IPC. We track a pending edit alongside the persisted value: when the
@@ -159,6 +204,78 @@ export function DaintreeAssistantSettingsTab() {
     };
   }, []);
 
+  // Separate audit fetch effect — keeps the settings init effect's cancellation
+  // semantics simple (per past lesson #4958) while still letting the audit
+  // viewer hydrate independently of the settings + MCP status round-trips.
+  const refreshAuditRecords = useCallback(async (): Promise<void> => {
+    try {
+      const records = await window.electron.mcpServer.getAuditRecords();
+      setAuditRecords(records);
+    } catch (err) {
+      logError("Failed to load MCP audit records for assistant tab", err);
+    }
+  }, []);
+
+  useEffect(() => {
+    let cancelled = false;
+    setAuditLoading(true);
+    window.electron.mcpServer
+      .getAuditRecords()
+      .then((records) => {
+        if (cancelled) return;
+        setAuditRecords(records);
+      })
+      .catch((err) => {
+        if (cancelled) return;
+        logError("Failed initial audit load for assistant tab", err);
+      })
+      .finally(() => {
+        if (!cancelled) setAuditLoading(false);
+      });
+    return () => {
+      cancelled = true;
+      if (auditCopyTimeoutRef.current) clearTimeout(auditCopyTimeoutRef.current);
+    };
+  }, []);
+
+  const handleCopyAuditAsJson = useCallback(async (records: McpAuditRecord[]) => {
+    try {
+      await navigator.clipboard.writeText(JSON.stringify(records, null, 2));
+      setAuditCopied(true);
+      if (auditCopyTimeoutRef.current) clearTimeout(auditCopyTimeoutRef.current);
+      auditCopyTimeoutRef.current = setTimeout(() => setAuditCopied(false), COPY_RESET_DELAY_MS);
+    } catch (err) {
+      setAuditCopied(false);
+      if (auditCopyTimeoutRef.current) {
+        clearTimeout(auditCopyTimeoutRef.current);
+        auditCopyTimeoutRef.current = null;
+      }
+      setError(formatErrorMessage(err, "Couldn't copy audit log"));
+      logError("Failed to copy MCP audit log from assistant tab", err);
+    }
+  }, []);
+
+  const confirmClearAuditLog = useCallback(async () => {
+    if (isClearingAudit) return;
+    setIsClearingAudit(true);
+    try {
+      setError(null);
+      await window.electron.mcpServer.clearAuditLog();
+      setAuditRecords([]);
+      setShowClearAuditConfirm(false);
+    } catch (err) {
+      setError(formatErrorMessage(err, "Couldn't clear audit log"));
+      logError("Failed to clear MCP audit log from assistant tab", err);
+    } finally {
+      setIsClearingAudit(false);
+    }
+  }, [isClearingAudit]);
+
+  const handleCancelClearAudit = useCallback(() => {
+    if (isClearingAudit) return;
+    setShowClearAuditConfirm(false);
+  }, [isClearingAudit]);
+
   const persist = useCallback(
     async (patch: Partial<HelpAssistantSettings>) => {
       const next = { ...settings, ...patch } as HelpAssistantSettings;
@@ -183,9 +300,17 @@ export function DaintreeAssistantSettingsTab() {
     void persist({ daintreeControl: !settings.daintreeControl });
   }, [persist, settings.daintreeControl]);
 
-  const toggleSkipPermissions = useCallback(() => {
-    void persist({ skipPermissions: !settings.skipPermissions });
-  }, [persist, settings.skipPermissions]);
+  const setTier = useCallback(
+    (value: string) => {
+      if (value !== "workbench" && value !== "action" && value !== "system") return;
+      void persist({ tier: value });
+    },
+    [persist]
+  );
+
+  const toggleBypassPermissions = useCallback(() => {
+    void persist({ bypassPermissions: !settings.bypassPermissions });
+  }, [persist, settings.bypassPermissions]);
 
   const setRetention = useCallback(
     (value: string) => {
@@ -382,20 +507,35 @@ export function DaintreeAssistantSettingsTab() {
       <SettingsSection
         icon={ShieldAlert}
         title="Security"
-        description="Confirmation prompts protect destructive actions. Disable only if you understand the risk."
+        description="Pick how much the assistant can do without prompting, and whether to bypass Claude Code's per-tool confirmation gate."
       >
+        <SettingsSelect
+          label="Capability tier"
+          description={TIER_DESCRIPTIONS[settings.tier]}
+          value={settings.tier}
+          onValueChange={setTier}
+          options={TIER_OPTIONS}
+          disabled={loading}
+        />
+
+        <BlastRadiusPreview
+          tier={settings.tier}
+          isOpen={showBlastRadius}
+          onToggle={() => setShowBlastRadius((v) => !v)}
+        />
+
         <SettingsSwitchCard
           variant="compact"
           icon={ShieldAlert}
-          title="Skip permission prompts"
-          subtitle="Bypass Claude Code's confirmation gate for help sessions"
-          isEnabled={settings.skipPermissions}
-          onChange={toggleSkipPermissions}
-          ariaLabel="Skip permission prompts during help sessions"
+          title="Bypass Claude permission prompts"
+          subtitle="Skip Claude Code's per-tool confirmation gate (passes --dangerously-skip-permissions)"
+          isEnabled={settings.bypassPermissions}
+          onChange={toggleBypassPermissions}
+          ariaLabel="Bypass Claude Code permission prompts during help sessions"
           colorScheme="amber"
           disabled={loading}
         />
-        {settings.skipPermissions && (
+        {settings.bypassPermissions && (
           <div
             className={cn(
               "flex items-start gap-2 p-3 rounded-[var(--radius-md)]",
@@ -405,7 +545,8 @@ export function DaintreeAssistantSettingsTab() {
             <AlertTriangle className="w-4 h-4 text-status-warning shrink-0 mt-0.5" />
             <div className="text-xs text-daintree-text/70 leading-relaxed select-text">
               With this on, Claude Code's permission gate is bypassed for all tools — built-in
-              (Bash, Write) and MCP. The Daintree MCP becomes the only safeguard.
+              (Bash, Write) and MCP. The capability tier above is the only remaining safeguard for
+              Daintree actions.
             </div>
           </div>
         )}
@@ -424,6 +565,15 @@ export function DaintreeAssistantSettingsTab() {
           onValueChange={setRetention}
           options={RETENTION_OPTIONS}
           disabled={loading}
+        />
+        <McpAuditLogViewer
+          records={auditRecords}
+          loading={auditLoading}
+          onRefresh={refreshAuditRecords}
+          onCopy={handleCopyAuditAsJson}
+          onClear={() => setShowClearAuditConfirm(true)}
+          copyFlashActive={auditCopied}
+          includeRecord={(record) => record.tier !== "external"}
         />
       </SettingsSection>
 
@@ -499,6 +649,19 @@ export function DaintreeAssistantSettingsTab() {
       )}
 
       <ConfirmDialog
+        isOpen={showClearAuditConfirm}
+        onClose={isClearingAudit ? undefined : handleCancelClearAudit}
+        title="Clear audit log?"
+        description="All recorded tool dispatches will be permanently deleted — including those from external MCP clients."
+        confirmLabel="Clear log"
+        cancelLabel="Cancel"
+        onConfirm={confirmClearAuditLog}
+        isConfirmLoading={isClearingAudit}
+        variant="destructive"
+        zIndex="nested"
+      />
+
+      <ConfirmDialog
         isOpen={showRotateConfirm}
         onClose={isRotating ? undefined : handleCancelRotate}
         title="Rotate API key?"
@@ -526,6 +689,84 @@ export function DaintreeAssistantSettingsTab() {
         zIndex="nested"
         typedNameTarget={apiKeySuffix || undefined}
       />
+    </div>
+  );
+}
+
+interface BlastRadiusPreviewProps {
+  tier: HelpAssistantTier;
+  isOpen: boolean;
+  onToggle: () => void;
+}
+
+function BlastRadiusPreview({ tier, isOpen, onToggle }: BlastRadiusPreviewProps) {
+  const totalCount = HELP_TIER_CUMULATIVE[tier].length;
+  const newAtTier = HELP_TIER_INCREMENTAL[tier].length;
+  const groups = useMemo(() => {
+    const cumulative = HELP_TIER_CUMULATIVE[tier];
+    if (tier !== "system") return groupToolsByNamespace(cumulative);
+    // Pin the load-bearing dangerous actions at the top of the system tier
+    // so users don't miss them when scanning a long alphabetical list.
+    const pinned = new Set(SYSTEM_TIER_HIGH_BLAST_RADIUS);
+    const rest = cumulative.filter((tool) => !pinned.has(tool));
+    const pinnedList = SYSTEM_TIER_HIGH_BLAST_RADIUS.filter((tool) => cumulative.includes(tool));
+    return [
+      ["⚠ high blast radius", pinnedList] as [string, string[]],
+      ...groupToolsByNamespace(rest),
+    ];
+  }, [tier]);
+
+  return (
+    <div className="rounded-[var(--radius-md)] border border-daintree-border bg-overlay-subtle/40">
+      <button
+        type="button"
+        onClick={onToggle}
+        aria-expanded={isOpen}
+        className={cn(
+          "w-full flex items-center justify-between gap-3 px-3 py-2 text-xs",
+          "text-daintree-text/80 hover:text-daintree-text transition-colors"
+        )}
+      >
+        <span className="flex items-center gap-2">
+          <ChevronRight
+            className={cn(
+              "w-3.5 h-3.5 transition-transform duration-150",
+              isOpen ? "rotate-90" : "rotate-0"
+            )}
+          />
+          <span>
+            {totalCount} actions allowed without prompting
+            {tier !== "workbench" && (
+              <span className="text-daintree-text/50"> ({newAtTier} new at this tier)</span>
+            )}
+          </span>
+        </span>
+      </button>
+      {isOpen && (
+        <div className="px-3 pb-3 pt-1 space-y-2">
+          {groups.map(([ns, tools]) => (
+            <div key={ns} className="space-y-1">
+              <div className="text-[10px] uppercase tracking-wide text-daintree-text/50 font-mono">
+                {ns}
+                <span className="ml-1 text-daintree-text/30">({tools.length})</span>
+              </div>
+              <div className="flex flex-wrap gap-1">
+                {tools.map((tool) => (
+                  <span
+                    key={tool}
+                    className={cn(
+                      "px-1.5 py-0.5 rounded text-[10px] font-mono",
+                      "bg-daintree-bg border border-daintree-border text-daintree-text/70"
+                    )}
+                  >
+                    {tool}
+                  </span>
+                ))}
+              </div>
+            </div>
+          ))}
+        </div>
+      )}
     </div>
   );
 }

--- a/src/components/Settings/McpAuditLogViewer.tsx
+++ b/src/components/Settings/McpAuditLogViewer.tsx
@@ -1,0 +1,213 @@
+import { useMemo, useState } from "react";
+import { Check, Copy, RefreshCw } from "lucide-react";
+import { cn } from "@/lib/utils";
+import type { McpAuditRecord, McpAuditResult } from "@shared/types";
+
+type AuditResultFilter = "all" | McpAuditResult;
+
+const RESULT_LABEL: Record<McpAuditResult, string> = {
+  success: "Success",
+  error: "Error",
+  "confirmation-pending": "Awaiting confirmation",
+  unauthorized: "Unauthorized",
+};
+
+const RESULT_DOT_CLASS: Record<McpAuditResult, string> = {
+  success: "bg-status-success",
+  error: "bg-status-danger",
+  "confirmation-pending": "bg-status-warning",
+  unauthorized: "bg-status-danger",
+};
+
+function formatRelativeTimestamp(ts: number): string {
+  const diffMs = Date.now() - ts;
+  if (diffMs < 0) return "just now";
+  const sec = Math.floor(diffMs / 1000);
+  if (sec < 60) return `${sec}s ago`;
+  const min = Math.floor(sec / 60);
+  if (min < 60) return `${min}m ago`;
+  const hr = Math.floor(min / 60);
+  if (hr < 24) return `${hr}h ago`;
+  const day = Math.floor(hr / 24);
+  return `${day}d ago`;
+}
+
+interface McpAuditLogViewerProps {
+  records: McpAuditRecord[];
+  loading: boolean;
+  onRefresh: () => Promise<void> | void;
+  onCopy: (records: McpAuditRecord[]) => Promise<void> | void;
+  onClear?: () => void;
+  /**
+   * Predicate applied before filters render — used by the Daintree Assistant
+   * Privacy section to hide `external` MCP traffic.
+   */
+  includeRecord?: (record: McpAuditRecord) => boolean;
+  maxRecords?: number;
+  /** Set when a copy succeeded so the UI can flash a confirmation. */
+  copyFlashActive?: boolean;
+}
+
+export function McpAuditLogViewer({
+  records,
+  loading,
+  onRefresh,
+  onCopy,
+  onClear,
+  includeRecord,
+  maxRecords,
+  copyFlashActive,
+}: McpAuditLogViewerProps) {
+  const [toolFilter, setToolFilter] = useState("");
+  const [resultFilter, setResultFilter] = useState<AuditResultFilter>("all");
+
+  const visibleRecords = useMemo(() => {
+    if (!includeRecord) return records;
+    return records.filter(includeRecord);
+  }, [records, includeRecord]);
+
+  const filteredRecords = useMemo(() => {
+    const needle = toolFilter.trim().toLowerCase();
+    return visibleRecords.filter((record) => {
+      if (resultFilter !== "all" && record.result !== resultFilter) return false;
+      if (needle.length > 0 && !record.toolId.toLowerCase().includes(needle)) return false;
+      return true;
+    });
+  }, [visibleRecords, resultFilter, toolFilter]);
+
+  const showCopyAll = filteredRecords.length === visibleRecords.length;
+
+  return (
+    <div className="contents">
+      <div className="flex flex-wrap items-center gap-2">
+        <input
+          type="text"
+          value={toolFilter}
+          onChange={(e) => setToolFilter(e.target.value)}
+          placeholder="Filter by tool ID"
+          aria-label="Filter audit by tool name"
+          className="flex-1 min-w-[160px] bg-daintree-bg border border-border-strong rounded-[var(--radius-md)] px-2 py-1 text-xs text-daintree-text placeholder:text-daintree-text/40 font-mono focus-visible:outline focus-visible:outline-2 focus-visible:outline-daintree-accent focus-visible:outline-offset-2"
+        />
+        <select
+          value={resultFilter}
+          onChange={(e) => {
+            const value = e.target.value;
+            if (
+              value === "all" ||
+              value === "success" ||
+              value === "error" ||
+              value === "confirmation-pending" ||
+              value === "unauthorized"
+            ) {
+              setResultFilter(value);
+            }
+          }}
+          aria-label="Filter audit by result"
+          className="bg-daintree-bg border border-border-strong rounded-[var(--radius-md)] px-2 py-1 text-xs text-daintree-text focus-visible:outline focus-visible:outline-2 focus-visible:outline-daintree-accent focus-visible:outline-offset-2"
+        >
+          <option value="all">All results</option>
+          <option value="success">Success</option>
+          <option value="error">Error</option>
+          <option value="confirmation-pending">Awaiting confirmation</option>
+          <option value="unauthorized">Unauthorized</option>
+        </select>
+      </div>
+
+      <div className="max-h-64 overflow-y-auto rounded-[var(--radius-md)] border border-daintree-border bg-daintree-bg">
+        {loading ? (
+          <p className="p-3 text-xs text-daintree-text/50">Loading…</p>
+        ) : filteredRecords.length === 0 ? (
+          <p className="p-3 text-xs text-daintree-text/50">
+            {visibleRecords.length === 0
+              ? "No tool dispatches recorded yet."
+              : "No records match the current filters."}
+          </p>
+        ) : (
+          <ul className="divide-y divide-daintree-border">
+            {filteredRecords.map((record) => (
+              <li key={record.id} className="grid grid-cols-[auto_1fr_auto] gap-2 p-2 text-xs">
+                <span
+                  className={cn(
+                    "mt-1 h-2 w-2 rounded-full shrink-0",
+                    RESULT_DOT_CLASS[record.result]
+                  )}
+                  aria-label={RESULT_LABEL[record.result]}
+                  title={RESULT_LABEL[record.result]}
+                />
+                <div className="min-w-0">
+                  <div className="flex items-center gap-2">
+                    <span className="font-mono text-daintree-text/90 truncate">
+                      {record.toolId}
+                    </span>
+                    {record.errorCode && (
+                      <span className="text-[10px] uppercase tracking-wide text-status-danger/80">
+                        {record.errorCode}
+                      </span>
+                    )}
+                  </div>
+                  <div className="mt-0.5 font-mono text-daintree-text/50 truncate">
+                    {record.argsSummary || "{}"}
+                  </div>
+                </div>
+                <div className="text-right text-daintree-text/40 whitespace-nowrap">
+                  <div>{formatRelativeTimestamp(record.timestamp)}</div>
+                  <div>{record.durationMs}ms</div>
+                </div>
+              </li>
+            ))}
+          </ul>
+        )}
+      </div>
+
+      <div className="flex flex-wrap items-center gap-2">
+        <button
+          type="button"
+          onClick={() => void onRefresh()}
+          className="flex items-center gap-1.5 px-3 py-1.5 text-xs font-medium rounded-[var(--radius-md)] border border-daintree-border text-daintree-text/70 hover:text-daintree-text hover:bg-overlay-soft transition-colors"
+          aria-label="Refresh audit log"
+        >
+          <RefreshCw className="w-3.5 h-3.5" />
+          Refresh
+        </button>
+        <button
+          type="button"
+          onClick={() => void onCopy(filteredRecords)}
+          disabled={filteredRecords.length === 0}
+          className={cn(
+            "flex items-center gap-1.5 px-3 py-1.5 text-xs font-medium rounded-[var(--radius-md)] border transition-colors",
+            filteredRecords.length === 0
+              ? "border-daintree-border text-daintree-text/30 cursor-not-allowed"
+              : copyFlashActive
+                ? "text-status-success border-status-success/30"
+                : "border-daintree-border text-daintree-text/70 hover:text-daintree-text hover:bg-overlay-soft"
+          )}
+        >
+          {copyFlashActive ? <Check className="w-3.5 h-3.5" /> : <Copy className="w-3.5 h-3.5" />}
+          {copyFlashActive ? "Copied!" : `Copy ${showCopyAll ? "all" : "filtered"} as JSON`}
+        </button>
+        {onClear && (
+          <button
+            type="button"
+            onClick={onClear}
+            disabled={visibleRecords.length === 0}
+            className={cn(
+              "px-3 py-1.5 text-xs font-medium rounded-[var(--radius-md)] border transition-colors",
+              visibleRecords.length === 0
+                ? "border-daintree-border text-daintree-text/30 cursor-not-allowed"
+                : "border-daintree-border text-status-danger hover:text-status-danger hover:bg-status-danger/10 hover:border-status-danger/20"
+            )}
+          >
+            Clear log
+          </button>
+        )}
+        <span className="ml-auto text-xs text-daintree-text/40">
+          {resultFilter !== "all" || toolFilter.trim().length > 0
+            ? `${filteredRecords.length} of ${visibleRecords.length}`
+            : maxRecords !== undefined
+              ? `${visibleRecords.length} of ${maxRecords}`
+              : `${visibleRecords.length}`}
+        </span>
+      </div>
+    </div>
+  );
+}

--- a/src/components/Settings/McpAuditLogViewer.tsx
+++ b/src/components/Settings/McpAuditLogViewer.tsx
@@ -10,6 +10,7 @@ const RESULT_LABEL: Record<McpAuditResult, string> = {
   error: "Error",
   "confirmation-pending": "Awaiting confirmation",
   unauthorized: "Unauthorized",
+  dedup: "Deduplicated",
 };
 
 const RESULT_DOT_CLASS: Record<McpAuditResult, string> = {
@@ -17,6 +18,7 @@ const RESULT_DOT_CLASS: Record<McpAuditResult, string> = {
   error: "bg-status-danger",
   "confirmation-pending": "bg-status-warning",
   unauthorized: "bg-status-danger",
+  dedup: "bg-status-info",
 };
 
 function formatRelativeTimestamp(ts: number): string {

--- a/src/components/Settings/McpServerSettingsTab.tsx
+++ b/src/components/Settings/McpServerSettingsTab.tsx
@@ -1,4 +1,4 @@
-import { useState, useEffect, useCallback, useMemo, useRef } from "react";
+import { useState, useEffect, useCallback, useRef } from "react";
 import {
   Copy,
   Check,
@@ -19,11 +19,11 @@ import { EmptyState } from "@/components/ui/EmptyState";
 import { SettingsSection } from "@/components/Settings/SettingsSection";
 import { SettingsSwitchCard } from "@/components/Settings/SettingsSwitchCard";
 import { useSettingsTabValidation } from "@/components/Settings/SettingsValidationRegistry";
+import { McpAuditLogViewer } from "@/components/Settings/McpAuditLogViewer";
 import { formatErrorMessage } from "@shared/utils/errorMessage";
 import { logError } from "@/utils/logger";
 import {
   type McpAuditRecord,
-  type McpAuditResult,
   MCP_AUDIT_DEFAULT_MAX_RECORDS,
   MCP_AUDIT_MAX_RECORDS,
   MCP_AUDIT_MIN_RECORDS,
@@ -36,40 +36,9 @@ interface McpServerStatus {
   apiKey: string;
 }
 
-type AuditResultFilter = "all" | McpAuditResult;
-
 const COPY_FEEDBACK_MS = 2000;
 
 const MASKED_KEY = "•".repeat(24);
-
-const RESULT_LABEL: Record<McpAuditResult, string> = {
-  success: "Success",
-  error: "Error",
-  "confirmation-pending": "Awaiting confirmation",
-  unauthorized: "Unauthorized",
-  dedup: "Deduplicated",
-};
-
-const RESULT_DOT_CLASS: Record<McpAuditResult, string> = {
-  success: "bg-status-success",
-  error: "bg-status-danger",
-  "confirmation-pending": "bg-status-warning",
-  unauthorized: "bg-status-danger",
-  dedup: "bg-status-info",
-};
-
-function formatRelativeTimestamp(ts: number): string {
-  const diffMs = Date.now() - ts;
-  if (diffMs < 0) return "just now";
-  const sec = Math.floor(diffMs / 1000);
-  if (sec < 60) return `${sec}s ago`;
-  const min = Math.floor(sec / 60);
-  if (min < 60) return `${min}m ago`;
-  const hr = Math.floor(min / 60);
-  if (hr < 24) return `${hr}h ago`;
-  const day = Math.floor(hr / 24);
-  return `${day}d ago`;
-}
 
 export function McpServerSettingsTab() {
   const [status, setStatus] = useState<McpServerStatus>({
@@ -95,8 +64,6 @@ export function McpServerSettingsTab() {
   const [auditMaxRecords, setAuditMaxRecords] = useState(MCP_AUDIT_DEFAULT_MAX_RECORDS);
   const [maxRecordsInput, setMaxRecordsInput] = useState(MCP_AUDIT_DEFAULT_MAX_RECORDS.toString());
   const [auditLoading, setAuditLoading] = useState(true);
-  const [toolFilter, setToolFilter] = useState("");
-  const [resultFilter, setResultFilter] = useState<AuditResultFilter>("all");
 
   const [showRotateConfirm, setShowRotateConfirm] = useState(false);
   const [isRotating, setIsRotating] = useState(false);
@@ -341,15 +308,6 @@ export function McpServerSettingsTab() {
       logError("Failed to copy MCP audit log", err);
     }
   }, []);
-
-  const filteredAuditRecords = useMemo(() => {
-    const needle = toolFilter.trim().toLowerCase();
-    return auditRecords.filter((record) => {
-      if (resultFilter !== "all" && record.result !== resultFilter) return false;
-      if (needle.length > 0 && !record.toolId.toLowerCase().includes(needle)) return false;
-      return true;
-    });
-  }, [auditRecords, resultFilter, toolFilter]);
 
   const sseUrl = status.port ? `http://127.0.0.1:${status.port}/sse` : null;
 
@@ -602,140 +560,15 @@ export function McpServerSettingsTab() {
                 </span>
               </div>
 
-              <div className="flex flex-wrap items-center gap-2">
-                <input
-                  type="text"
-                  value={toolFilter}
-                  onChange={(e) => setToolFilter(e.target.value)}
-                  placeholder="Filter by tool ID"
-                  aria-label="Filter audit by tool name"
-                  className="flex-1 min-w-[160px] bg-daintree-bg border border-border-strong rounded-[var(--radius-md)] px-2 py-1 text-xs text-daintree-text placeholder:text-daintree-text/40 font-mono focus-visible:outline focus-visible:outline-2 focus-visible:outline-daintree-accent focus-visible:outline-offset-2"
-                />
-                <select
-                  value={resultFilter}
-                  onChange={(e) => {
-                    const value = e.target.value;
-                    if (
-                      value === "all" ||
-                      value === "success" ||
-                      value === "error" ||
-                      value === "confirmation-pending" ||
-                      value === "unauthorized"
-                    ) {
-                      setResultFilter(value);
-                    }
-                  }}
-                  aria-label="Filter audit by result"
-                  className="bg-daintree-bg border border-border-strong rounded-[var(--radius-md)] px-2 py-1 text-xs text-daintree-text focus-visible:outline focus-visible:outline-2 focus-visible:outline-daintree-accent focus-visible:outline-offset-2"
-                >
-                  <option value="all">All results</option>
-                  <option value="success">Success</option>
-                  <option value="error">Error</option>
-                  <option value="confirmation-pending">Awaiting confirmation</option>
-                  <option value="unauthorized">Unauthorized</option>
-                </select>
-              </div>
-
-              <div className="max-h-64 overflow-y-auto rounded-[var(--radius-md)] border border-daintree-border bg-daintree-bg">
-                {auditLoading ? (
-                  <p className="p-3 text-xs text-daintree-text/50">Loading…</p>
-                ) : filteredAuditRecords.length === 0 ? (
-                  <p className="p-3 text-xs text-daintree-text/50">
-                    {auditRecords.length === 0
-                      ? "No tool dispatches recorded yet."
-                      : "No records match the current filters."}
-                  </p>
-                ) : (
-                  <ul className="divide-y divide-daintree-border">
-                    {filteredAuditRecords.map((record) => (
-                      <li
-                        key={record.id}
-                        className="grid grid-cols-[auto_1fr_auto] gap-2 p-2 text-xs"
-                      >
-                        <span
-                          className={cn(
-                            "mt-1 h-2 w-2 rounded-full shrink-0",
-                            RESULT_DOT_CLASS[record.result]
-                          )}
-                          aria-label={RESULT_LABEL[record.result]}
-                          title={RESULT_LABEL[record.result]}
-                        />
-                        <div className="min-w-0">
-                          <div className="flex items-center gap-2">
-                            <span className="font-mono text-daintree-text/90 truncate">
-                              {record.toolId}
-                            </span>
-                            {record.errorCode && (
-                              <span className="text-[10px] uppercase tracking-wide text-status-danger/80">
-                                {record.errorCode}
-                              </span>
-                            )}
-                          </div>
-                          <div className="mt-0.5 font-mono text-daintree-text/50 truncate">
-                            {record.argsSummary || "{}"}
-                          </div>
-                        </div>
-                        <div className="text-right text-daintree-text/40 whitespace-nowrap">
-                          <div>{formatRelativeTimestamp(record.timestamp)}</div>
-                          <div>{record.durationMs}ms</div>
-                        </div>
-                      </li>
-                    ))}
-                  </ul>
-                )}
-              </div>
-
-              <div className="flex flex-wrap items-center gap-2">
-                <button
-                  type="button"
-                  onClick={() => void refreshAuditRecords()}
-                  className="flex items-center gap-1.5 px-3 py-1.5 text-xs font-medium rounded-[var(--radius-md)] border border-daintree-border text-daintree-text/70 hover:text-daintree-text hover:bg-overlay-soft transition-colors"
-                  aria-label="Refresh audit log"
-                >
-                  <RefreshCw className="w-3.5 h-3.5" />
-                  Refresh
-                </button>
-                <button
-                  type="button"
-                  onClick={() => void handleCopyAuditAsJson(filteredAuditRecords)}
-                  disabled={filteredAuditRecords.length === 0}
-                  className={cn(
-                    "flex items-center gap-1.5 px-3 py-1.5 text-xs font-medium rounded-[var(--radius-md)] border transition-colors",
-                    filteredAuditRecords.length === 0
-                      ? "border-daintree-border text-daintree-text/30 cursor-not-allowed"
-                      : copiedAudit
-                        ? "text-status-success border-status-success/30"
-                        : "border-daintree-border text-daintree-text/70 hover:text-daintree-text hover:bg-overlay-soft"
-                  )}
-                >
-                  {copiedAudit ? (
-                    <Check className="w-3.5 h-3.5" />
-                  ) : (
-                    <Copy className="w-3.5 h-3.5" />
-                  )}
-                  {copiedAudit
-                    ? "Copied!"
-                    : `Copy ${filteredAuditRecords.length === auditRecords.length ? "all" : "filtered"} as JSON`}
-                </button>
-                <button
-                  type="button"
-                  onClick={() => setShowClearConfirm(true)}
-                  disabled={auditRecords.length === 0}
-                  className={cn(
-                    "px-3 py-1.5 text-xs font-medium rounded-[var(--radius-md)] border transition-colors",
-                    auditRecords.length === 0
-                      ? "border-daintree-border text-daintree-text/30 cursor-not-allowed"
-                      : "border-daintree-border text-status-danger hover:text-status-danger hover:bg-status-danger/10 hover:border-status-danger/20"
-                  )}
-                >
-                  Clear log
-                </button>
-                <span className="ml-auto text-xs text-daintree-text/40">
-                  {resultFilter !== "all" || toolFilter.trim().length > 0
-                    ? `${filteredAuditRecords.length} of ${auditRecords.length}`
-                    : `${auditRecords.length} of ${auditMaxRecords}`}
-                </span>
-              </div>
+              <McpAuditLogViewer
+                records={auditRecords}
+                loading={auditLoading}
+                onRefresh={refreshAuditRecords}
+                onCopy={handleCopyAuditAsJson}
+                onClear={() => setShowClearConfirm(true)}
+                copyFlashActive={copiedAudit}
+                maxRecords={auditMaxRecords}
+              />
             </div>
           </SettingsSection>
         </>

--- a/src/components/Settings/__tests__/DaintreeAssistantSettingsTab.test.tsx
+++ b/src/components/Settings/__tests__/DaintreeAssistantSettingsTab.test.tsx
@@ -162,6 +162,8 @@ interface McpServerApi {
   rotateApiKey: ReturnType<typeof vi.fn>;
   getConfigSnippet: ReturnType<typeof vi.fn>;
   onRuntimeStateChanged: ReturnType<typeof vi.fn>;
+  getAuditRecords: ReturnType<typeof vi.fn>;
+  clearAuditLog: ReturnType<typeof vi.fn>;
 }
 
 function installApi(
@@ -172,7 +174,8 @@ function installApi(
     getSettings: vi.fn().mockResolvedValue({
       docSearch: true,
       daintreeControl: true,
-      skipPermissions: false,
+      tier: "action" as const,
+      bypassPermissions: false,
       auditRetention: 7,
       customArgs: "",
     }),
@@ -194,6 +197,8 @@ function installApi(
     rotateApiKey: vi.fn().mockResolvedValue("dnt-key-new"),
     getConfigSnippet: vi.fn().mockResolvedValue('{ "url": "http://127.0.0.1:45454/sse" }'),
     onRuntimeStateChanged: vi.fn(() => () => {}),
+    getAuditRecords: vi.fn().mockResolvedValue([]),
+    clearAuditLog: vi.fn().mockResolvedValue(undefined),
   };
   window.electron = {
     helpAssistant: { ...helpDefaults, ...helpAssistant },
@@ -251,22 +256,42 @@ describe("DaintreeAssistantSettingsTab", () => {
     });
   });
 
-  it("turning on skip permissions reveals the inline warning copy", async () => {
+  it("turning on bypass permissions reveals the inline warning copy", async () => {
     const { container } = render(
       <SettingsValidationProvider>
         <DaintreeAssistantSettingsTab />
       </SettingsValidationProvider>
     );
-    await waitForContent(container, "Skip permission prompts");
+    await waitForContent(container, "Bypass Claude permission prompts");
 
-    expect(container.textContent).not.toContain("becomes the only safeguard");
+    expect(container.textContent).not.toContain("only remaining safeguard");
 
-    const toggle = screen.getByLabelText("Skip permission prompts during help sessions");
+    const toggle = screen.getByLabelText(
+      "Bypass Claude Code permission prompts during help sessions"
+    );
     fireEvent.click(toggle);
 
-    await waitForContent(container, "becomes the only safeguard");
+    await waitForContent(container, "only remaining safeguard");
     expect(window.electron.helpAssistant.setSettings).toHaveBeenCalledWith({
-      skipPermissions: true,
+      bypassPermissions: true,
+    });
+  });
+
+  it("changing the capability tier persists tier=system", async () => {
+    const { container } = render(
+      <SettingsValidationProvider>
+        <DaintreeAssistantSettingsTab />
+      </SettingsValidationProvider>
+    );
+    await waitForContent(container, "Capability tier");
+
+    const select = screen.getByLabelText("Capability tier") as HTMLSelectElement;
+    fireEvent.change(select, { target: { value: "system" } });
+
+    await waitFor(() => {
+      expect(window.electron.helpAssistant.setSettings).toHaveBeenCalledWith({
+        tier: "system",
+      });
     });
   });
 
@@ -464,7 +489,8 @@ describe("DaintreeAssistantSettingsTab", () => {
         getSettings: vi.fn().mockResolvedValue({
           docSearch: false,
           daintreeControl: true,
-          skipPermissions: false,
+          tier: "action" as const,
+          bypassPermissions: false,
           auditRetention: 7,
         }),
       },
@@ -594,7 +620,8 @@ describe("DaintreeAssistantSettingsTab", () => {
       getSettings: vi.fn().mockResolvedValue({
         docSearch: true,
         daintreeControl: true,
-        skipPermissions: false,
+        tier: "action" as const,
+        bypassPermissions: false,
         auditRetention: 7,
         customArgs: "--model sonnet",
       }),
@@ -634,7 +661,8 @@ describe("DaintreeAssistantSettingsTab", () => {
       getSettings: vi.fn().mockResolvedValue({
         docSearch: true,
         daintreeControl: true,
-        skipPermissions: false,
+        tier: "action" as const,
+        bypassPermissions: false,
         auditRetention: 7,
         customArgs: "--model sonnet",
       }),


### PR DESCRIPTION
## Summary

- Replaces `HelpAssistantSettings.skipPermissions: boolean` with two orthogonal controls: a 3-way `tier` picker (`workbench` / `action` / `system`) and a separate `bypassPermissions` toggle. The tier governs which MCP tools are available; the bypass governs whether the `--dangerously-skip-permissions` CLI flag is passed. These were previously conflated in a single boolean.
- Read-time migration in both `sanitizeStored` (`helpAssistant.ts`) and `readSettings` (`HelpSessionService.ts`) converts legacy data transparently: `skipPermissions: true` maps to `tier: "system" + bypassPermissions: true`; `false` maps to `tier: "action" + bypassPermissions: false`.
- Extracts `McpAuditLogViewer` as a shared component (reused by `DaintreeAssistantSettingsTab` filtered to non-external entries, and by `McpServerSettingsTab` unfiltered). Adds a `BlastRadiusPreview` collapsible that groups tools by namespace with the most dangerous ones (`git.push`, `terminal.killAll`, `worktree.delete`) pinned at the top for the system tier. Tier allowlists moved to `shared/config/helpAssistantTierAllowlists.ts` so the renderer reads them without an IPC round-trip.

Resolves #7532

## Changes

- `shared/types/ipc/api.ts` + `shared/config/helpAssistantTierAllowlists.ts` — `HelpAssistantTier` type, per-tier tool allowlists
- `electron/ipc/handlers/helpAssistant.ts` — `sanitizeStored` migration + updated handlers
- `electron/services/HelpSessionService.ts` — `readSettings` migration, `getBypassPermissions` per-session snapshot
- `electron/ipc/handlers/terminal/lifecycle.ts` — reads `bypassPermissions` snapshot instead of inferring from tier; strip-then-append guards against `--dangerously-skip-permissions=value` lookalikes in `customArgs`; `defaultMode` explicitly cleared when bypass is off
- `src/components/Settings/DaintreeAssistantSettingsTab.tsx` — tier picker UI + `BlastRadiusPreview`
- `src/components/Settings/McpAuditLogViewer.tsx` — extracted shared audit log viewer
- `src/components/Settings/McpServerSettingsTab.tsx` — now delegates audit log to `McpAuditLogViewer`
- `electron/store.ts` — updated default shape

## Testing

229 tests pass across `helpAssistant.handlers`, `HelpSessionService`, `lifecycle.spawn`, `HelpPanel`, and `DaintreeAssistantSettingsTab`. TypeScript and lint both clean.