### PR TITLE
feat(help-panel): surface tier-mismatch, auto-snapshot, and working pip

### DIFF
--- a/electron/ipc/channels.ts
+++ b/electron/ipc/channels.ts
@@ -525,6 +525,18 @@ export const CHANNELS = {
   MCP_SERVER_DISPATCH_ACTION_REQUEST: "mcp:dispatch-action-request",
   /** Bridge: renderer returns the action dispatch result to the main process. */
   MCP_SERVER_DISPATCH_ACTION_RESPONSE: "mcp:dispatch-action-response",
+  /**
+   * Push channel: a tool call from a help-session was denied because the
+   * session tier doesn't permit it. Targeted at the pinned WebContents — the
+   * renderer surfaces this in the assistant panel as an inline approval banner.
+   */
+  MCP_TIER_NOT_PERMITTED: "mcp-server:tier-not-permitted",
+  /**
+   * Elevate the tier of an active help-session (Approve once). Mutates
+   * `sessionTierMap` in-place — never downgrades, so a malicious renderer
+   * cannot drop its own privileges.
+   */
+  MCP_SERVER_SET_SESSION_TIER: "mcp-server:set-session-tier",
 
   // Voice Input channels
   VOICE_INPUT_GET_SETTINGS: "voice-input:get-settings",

--- a/electron/ipc/handlers/__tests__/mcpServer.adversarial.test.ts
+++ b/electron/ipc/handlers/__tests__/mcpServer.adversarial.test.ts
@@ -195,8 +195,8 @@ describe("mcpServer IPC adversarial", () => {
     expect(serviceMock.clearAuditLog).toHaveBeenCalledTimes(1);
   });
 
-  it("cleanup removes all eleven registered handlers", () => {
-    expect(ipcHandlers.size).toBe(11);
+  it("cleanup removes all twelve registered handlers", () => {
+    expect(ipcHandlers.size).toBe(12);
     cleanup();
     expect(ipcHandlers.size).toBe(0);
   });

--- a/electron/ipc/handlers/mcpServer.ts
+++ b/electron/ipc/handlers/mcpServer.ts
@@ -112,6 +112,30 @@ export function registerMcpServerHandlers(): () => void {
     })
   );
 
+  handlers.push(
+    typedHandle(
+      CHANNELS.MCP_SERVER_SET_SESSION_TIER,
+      async (payload: { sessionId: string; tier: "workbench" | "action" | "system" }) => {
+        if (!payload || typeof payload !== "object") {
+          throw new Error("Invalid payload");
+        }
+        const { sessionId, tier } = payload;
+        if (typeof sessionId !== "string" || !sessionId) {
+          throw new Error("Invalid sessionId");
+        }
+        if (tier !== "workbench" && tier !== "action" && tier !== "system") {
+          throw new Error("Invalid tier");
+        }
+        const svc = await getMcpServerService();
+        const result = svc.setSessionTier(sessionId, tier);
+        return {
+          sessionId: result.sessionId,
+          tier: result.tier as "workbench" | "action" | "system",
+        };
+      }
+    )
+  );
+
   // Push runtime-state transitions to every renderer. Subscribed lazily so
   // we don't pay the McpServerService import cost just to register a no-op
   // listener — but cleanup MUST observe whichever side won the race:

--- a/electron/ipc/handlers/mcpServer.ts
+++ b/electron/ipc/handlers/mcpServer.ts
@@ -1,6 +1,6 @@
 import { CHANNELS } from "../channels.js";
 import type * as McpServerServiceModule from "../../services/McpServerService.js";
-import { broadcastToRenderer, typedHandle } from "../utils.js";
+import { broadcastToRenderer, typedHandle, typedHandleWithContext } from "../utils.js";
 
 type McpServerSingleton = typeof McpServerServiceModule.mcpServerService;
 
@@ -113,9 +113,9 @@ export function registerMcpServerHandlers(): () => void {
   );
 
   handlers.push(
-    typedHandle(
+    typedHandleWithContext(
       CHANNELS.MCP_SERVER_SET_SESSION_TIER,
-      async (payload: { sessionId: string; tier: "workbench" | "action" | "system" }) => {
+      async (ctx, payload: { sessionId: string; tier: "workbench" | "action" | "system" }) => {
         if (!payload || typeof payload !== "object") {
           throw new Error("Invalid payload");
         }
@@ -127,7 +127,10 @@ export function registerMcpServerHandlers(): () => void {
           throw new Error("Invalid tier");
         }
         const svc = await getMcpServerService();
-        const result = svc.setSessionTier(sessionId, tier);
+        // Caller-pin check: only the renderer that minted the help-session
+        // can elevate it. Without this, a different window/view could pass
+        // a sessionId pinned to another WebContents and succeed.
+        const result = svc.setSessionTier(sessionId, tier, ctx.webContentsId);
         return {
           sessionId: result.sessionId,
           tier: result.tier as "workbench" | "action" | "system",

--- a/electron/preload.cts
+++ b/electron/preload.cts
@@ -2393,6 +2393,16 @@ const api: ElectronAPI = {
     getRuntimeState: () => _unwrappingInvoke(CHANNELS.MCP_SERVER_GET_RUNTIME_STATE),
     onRuntimeStateChanged: (callback: (snapshot: McpRuntimeSnapshot) => void) =>
       _typedOn(CHANNELS.MCP_SERVER_RUNTIME_STATE_CHANGED, callback),
+    setSessionTier: (sessionId: string, tier: "workbench" | "action" | "system") =>
+      _unwrappingInvoke(CHANNELS.MCP_SERVER_SET_SESSION_TIER, { sessionId, tier }),
+    onTierNotPermitted: (
+      callback: (payload: {
+        sessionId: string;
+        toolId: string;
+        tier: string;
+        targetTier: "workbench" | "action" | "system" | null;
+      }) => void
+    ) => _typedOn(CHANNELS.MCP_TIER_NOT_PERMITTED, callback),
   },
 
   helpAssistant: {

--- a/electron/services/McpServerService.ts
+++ b/electron/services/McpServerService.ts
@@ -364,6 +364,13 @@ export class McpServerService {
     this.getSessionIdForTerminal = resolver;
   }
 
+  setSessionTier(
+    sessionId: string,
+    tier: "workbench" | "action" | "system"
+  ): { sessionId: string; tier: McpTier } {
+    return this.httpLifecycle.setSessionTier(sessionId, tier);
+  }
+
   // Delegates for test access — tests call .bind(service) on these.
   requestManifest(...args: Parameters<typeof this.bridge.requestManifest>) {
     return this.bridge.requestManifest(...args);

--- a/electron/services/McpServerService.ts
+++ b/electron/services/McpServerService.ts
@@ -366,9 +366,10 @@ export class McpServerService {
 
   setSessionTier(
     sessionId: string,
-    tier: "workbench" | "action" | "system"
+    tier: "workbench" | "action" | "system",
+    callerWcId?: number
   ): { sessionId: string; tier: McpTier } {
-    return this.httpLifecycle.setSessionTier(sessionId, tier);
+    return this.httpLifecycle.setSessionTier(sessionId, tier, callerWcId);
   }
 
   // Delegates for test access — tests call .bind(service) on these.

--- a/electron/services/mcp-server/__tests__/httpLifecycle.test.ts
+++ b/electron/services/mcp-server/__tests__/httpLifecycle.test.ts
@@ -232,10 +232,19 @@ describe("HttpLifecycle", () => {
   });
 
   describe("setSessionTier", () => {
+    function pinnedSession(deps: HttpLifecycleDeps, sessionId: string, wcId: number) {
+      deps.sessionStore.sessionWebContentsMap.set(sessionId, wcId);
+      // Mark transport active so the live-session guard passes.
+      (deps.sessionStore.httpSessions as Map<string, unknown>).set(sessionId, {
+        transport: { close: vi.fn().mockResolvedValue(undefined) },
+        idleTimer: setTimeout(() => {}, 1_000_000),
+      } as never);
+    }
+
     it("elevates a help-session tier and updates sessionTierMap", () => {
       const deps = fakeDeps();
       deps.sessionStore.sessionTierMap.set("sess-1", "workbench");
-      deps.sessionStore.sessionWebContentsMap.set("sess-1", 42);
+      pinnedSession(deps, "sess-1", 42);
 
       const lc = new HttpLifecycle(deps);
       const result = lc.setSessionTier("sess-1", "system");
@@ -247,7 +256,7 @@ describe("HttpLifecycle", () => {
     it("refuses downgrades silently and keeps current tier", () => {
       const deps = fakeDeps();
       deps.sessionStore.sessionTierMap.set("sess-2", "system");
-      deps.sessionStore.sessionWebContentsMap.set("sess-2", 42);
+      pinnedSession(deps, "sess-2", 42);
 
       const lc = new HttpLifecycle(deps);
       const result = lc.setSessionTier("sess-2", "workbench");
@@ -262,9 +271,44 @@ describe("HttpLifecycle", () => {
       expect(() => lc.setSessionTier("nonexistent", "system")).toThrow(/Unknown session/);
     });
 
+    it("throws when caller WebContents id doesn't match the pinned id", () => {
+      const deps = fakeDeps();
+      deps.sessionStore.sessionTierMap.set("sess-pin", "workbench");
+      pinnedSession(deps, "sess-pin", 42);
+
+      const lc = new HttpLifecycle(deps);
+      expect(() => lc.setSessionTier("sess-pin", "system", 99)).toThrow(/not the pinned renderer/);
+      // Tier must remain unchanged on rejection.
+      expect(deps.sessionStore.sessionTierMap.get("sess-pin")).toBe("workbench");
+    });
+
+    it("accepts caller WebContents id when it matches the pinned id", () => {
+      const deps = fakeDeps();
+      deps.sessionStore.sessionTierMap.set("sess-ok", "workbench");
+      pinnedSession(deps, "sess-ok", 42);
+
+      const lc = new HttpLifecycle(deps);
+      const result = lc.setSessionTier("sess-ok", "action", 42);
+      expect(result.tier).toBe("action");
+    });
+
+    it("throws when the session's transport has already closed (idle/torn down)", () => {
+      const deps = fakeDeps();
+      deps.sessionStore.sessionTierMap.set("sess-dead", "workbench");
+      deps.sessionStore.sessionWebContentsMap.set("sess-dead", 42);
+      // Don't add to sessions/httpSessions — transport is dead.
+
+      const lc = new HttpLifecycle(deps);
+      expect(() => lc.setSessionTier("sess-dead", "system")).toThrow(/no longer active/);
+    });
+
     it("throws for sessions without a pinned WebContents (api-key/external)", () => {
       const deps = fakeDeps();
       deps.sessionStore.sessionTierMap.set("ext-1", "external");
+      (deps.sessionStore.httpSessions as Map<string, unknown>).set("ext-1", {
+        transport: { close: vi.fn().mockResolvedValue(undefined) },
+        idleTimer: setTimeout(() => {}, 1_000_000),
+      } as never);
       // No sessionWebContentsMap entry — this is an api-key session.
 
       const lc = new HttpLifecycle(deps);
@@ -276,7 +320,7 @@ describe("HttpLifecycle", () => {
     it("throws for invalid tier values", () => {
       const deps = fakeDeps();
       deps.sessionStore.sessionTierMap.set("sess-3", "workbench");
-      deps.sessionStore.sessionWebContentsMap.set("sess-3", 42);
+      pinnedSession(deps, "sess-3", 42);
 
       const lc = new HttpLifecycle(deps);
       expect(() => lc.setSessionTier("sess-3", "external" as never)).toThrow(/Invalid tier/);

--- a/electron/services/mcp-server/__tests__/httpLifecycle.test.ts
+++ b/electron/services/mcp-server/__tests__/httpLifecycle.test.ts
@@ -231,6 +231,64 @@ describe("HttpLifecycle", () => {
     });
   });
 
+  describe("setSessionTier", () => {
+    it("elevates a help-session tier and updates sessionTierMap", () => {
+      const deps = fakeDeps();
+      deps.sessionStore.sessionTierMap.set("sess-1", "workbench");
+      deps.sessionStore.sessionWebContentsMap.set("sess-1", 42);
+
+      const lc = new HttpLifecycle(deps);
+      const result = lc.setSessionTier("sess-1", "system");
+
+      expect(result).toEqual({ sessionId: "sess-1", tier: "system" });
+      expect(deps.sessionStore.sessionTierMap.get("sess-1")).toBe("system");
+    });
+
+    it("refuses downgrades silently and keeps current tier", () => {
+      const deps = fakeDeps();
+      deps.sessionStore.sessionTierMap.set("sess-2", "system");
+      deps.sessionStore.sessionWebContentsMap.set("sess-2", 42);
+
+      const lc = new HttpLifecycle(deps);
+      const result = lc.setSessionTier("sess-2", "workbench");
+
+      expect(result.tier).toBe("system");
+      expect(deps.sessionStore.sessionTierMap.get("sess-2")).toBe("system");
+    });
+
+    it("throws for unknown sessions", () => {
+      const deps = fakeDeps();
+      const lc = new HttpLifecycle(deps);
+      expect(() => lc.setSessionTier("nonexistent", "system")).toThrow(/Unknown session/);
+    });
+
+    it("throws for sessions without a pinned WebContents (api-key/external)", () => {
+      const deps = fakeDeps();
+      deps.sessionStore.sessionTierMap.set("ext-1", "external");
+      // No sessionWebContentsMap entry — this is an api-key session.
+
+      const lc = new HttpLifecycle(deps);
+      expect(() => lc.setSessionTier("ext-1", "system")).toThrow(
+        /not eligible for renderer tier elevation/
+      );
+    });
+
+    it("throws for invalid tier values", () => {
+      const deps = fakeDeps();
+      deps.sessionStore.sessionTierMap.set("sess-3", "workbench");
+      deps.sessionStore.sessionWebContentsMap.set("sess-3", 42);
+
+      const lc = new HttpLifecycle(deps);
+      expect(() => lc.setSessionTier("sess-3", "external" as never)).toThrow(/Invalid tier/);
+    });
+
+    it("throws for blank session ids", () => {
+      const deps = fakeDeps();
+      const lc = new HttpLifecycle(deps);
+      expect(() => lc.setSessionTier("", "system")).toThrow(/Invalid sessionId/);
+    });
+  });
+
   describe("auth gate", () => {
     it("returns 401 with WWW-Authenticate: Bearer realm header", async () => {
       const deps = fakeDeps();

--- a/electron/services/mcp-server/__tests__/sessionServer.test.ts
+++ b/electron/services/mcp-server/__tests__/sessionServer.test.ts
@@ -696,3 +696,109 @@ describe("CallTool idempotency dedup", () => {
     expect(dispatchAction).toHaveBeenCalledTimes(1);
   });
 });
+
+describe("sessionServer tier-mismatch notifier", () => {
+  async function callTool(
+    server: ReturnType<typeof createSessionServer>,
+    params: { name: string; arguments?: Record<string, unknown> }
+  ) {
+    const handlers = (
+      server as unknown as {
+        _requestHandlers: Map<string, (req: unknown, extra: unknown) => Promise<unknown>>;
+      }
+    )._requestHandlers;
+    const handler = handlers.get("tools/call");
+    if (!handler) throw new Error("tools/call handler not found");
+    return handler(
+      {
+        method: "tools/call",
+        params,
+        jsonrpc: "2.0",
+        id: 1,
+      },
+      {
+        signal: new AbortController().signal,
+        _meta: {},
+        sendNotification: vi.fn(),
+        requestId: 1,
+      }
+    );
+  }
+
+  it("invokes notifyTierMismatch with targetTier when a workbench session calls a system-tier tool", async () => {
+    const notify = vi.fn();
+    const dispatchAction = vi.fn();
+    const deps = fakeDeps({ notifyTierMismatch: notify, dispatchAction });
+    const server = createSessionServer("session-A", deps);
+    await server.connect(makeMockTransport());
+
+    // worktree.delete is in SYSTEM_TIER_ADDONS — denied at workbench tier.
+    const result = (await callTool(server, {
+      name: "worktree.delete",
+      arguments: {},
+    })) as { isError?: boolean; content: Array<{ text: string }> };
+
+    expect(result.isError).toBe(true);
+    expect(result.content[0].text).toContain("TIER_NOT_PERMITTED");
+    expect(dispatchAction).not.toHaveBeenCalled();
+    expect(notify).toHaveBeenCalledTimes(1);
+    expect(notify).toHaveBeenCalledWith({
+      sessionId: "session-A",
+      toolId: "worktree.delete",
+      tier: "workbench",
+      targetTier: "system",
+    });
+  });
+
+  it("does not invoke notifyTierMismatch when the call is permitted", async () => {
+    const notify = vi.fn();
+    const dispatchAction = vi.fn().mockResolvedValue({ result: { ok: true, result: { ok: 1 } } });
+    const deps = fakeDeps({ notifyTierMismatch: notify, dispatchAction });
+    const server = createSessionServer("session-B", deps);
+    await server.connect(makeMockTransport());
+
+    // worktree.list is in WORKBENCH_TOOLS — permitted at workbench tier.
+    await callTool(server, { name: "worktree.list", arguments: {} });
+
+    expect(notify).not.toHaveBeenCalled();
+    expect(dispatchAction).toHaveBeenCalled();
+  });
+
+  it("computes targetTier=action for action-tier tools and forwards it", async () => {
+    const notify = vi.fn();
+    const deps = fakeDeps({ notifyTierMismatch: notify });
+    const server = createSessionServer("session-C", deps);
+    await server.connect(makeMockTransport());
+
+    // worktree.createWithRecipe is in ACTION_TIER_ADDONS — denied at workbench.
+    await callTool(server, {
+      name: "worktree.createWithRecipe",
+      arguments: { branchName: "x" },
+    });
+
+    expect(notify).toHaveBeenCalledWith(
+      expect.objectContaining({
+        toolId: "worktree.createWithRecipe",
+        targetTier: "action",
+      })
+    );
+  });
+
+  it("survives a notifyTierMismatch throw without crashing the call", async () => {
+    const notify = vi.fn(() => {
+      throw new Error("boom");
+    });
+    const deps = fakeDeps({ notifyTierMismatch: notify });
+    const server = createSessionServer("session-D", deps);
+    await server.connect(makeMockTransport());
+
+    // The denial response should still be returned even if the notifier throws.
+    const result = (await callTool(server, {
+      name: "worktree.delete",
+      arguments: {},
+    })) as { isError?: boolean; content: Array<{ text: string }> };
+
+    expect(result.isError).toBe(true);
+    expect(result.content[0].text).toContain("TIER_NOT_PERMITTED");
+  });
+});

--- a/electron/services/mcp-server/httpLifecycle.ts
+++ b/electron/services/mcp-server/httpLifecycle.ts
@@ -3,11 +3,13 @@ import { randomUUID } from "node:crypto";
 import type { AddressInfo } from "node:net";
 import { SSEServerTransport } from "@modelcontextprotocol/sdk/server/sse.js";
 import { StreamableHTTPServerTransport } from "@modelcontextprotocol/sdk/server/streamableHttp.js";
+import { webContents as webContentsModule } from "electron";
 import type { WindowRegistry } from "../../window/WindowRegistry.js";
 import { store } from "../../store.js";
+import { CHANNELS } from "../../ipc/channels.js";
 import { formatErrorMessage } from "../../../shared/utils/errorMessage.js";
 import { summarizeMcpArgs } from "../../../shared/utils/mcpArgsSummary.js";
-import type { HelpTokenValidator, HelpSessionWebContentsResolver } from "./shared.js";
+import type { HelpTokenValidator, HelpSessionWebContentsResolver, McpTier } from "./shared.js";
 import {
   extractBearerToken,
   isAuthorized,
@@ -686,6 +688,28 @@ export class HttpLifecycle {
         return this.deps.getCachedManifest();
       };
 
+    const notifyTierMismatch: import("./sessionServer.js").SessionServerDeps["notifyTierMismatch"] =
+      (payload) => {
+        // Help-session bearers only — external/api-key sessions have no
+        // associated UI to surface a banner. Targeted at the pinned WebContents
+        // so the assistant panel that triggered the call gets the event,
+        // even if a different project view is currently focused.
+        const id = this.deps.sessionStore.sessionWebContentsMap.get(payload.sessionId);
+        if (id === undefined) return;
+        const wc = webContentsModule.fromId(id);
+        if (!wc || wc.isDestroyed()) return;
+        try {
+          wc.send(CHANNELS.MCP_TIER_NOT_PERMITTED, {
+            sessionId: payload.sessionId,
+            toolId: payload.toolId,
+            tier: payload.tier,
+            targetTier: payload.targetTier,
+          });
+        } catch (err) {
+          console.error("[MCP] tier-not-permitted send failed:", err);
+        }
+      };
+
     return {
       sessionStore: this.deps.sessionStore,
       requestManifest,
@@ -699,7 +723,41 @@ export class HttpLifecycle {
       },
       getCachedManifest,
       getFullToolSurface: () => this.getConfig().fullToolSurface === true,
+      notifyTierMismatch,
     };
+  }
+
+  /**
+   * Promote a help-session's tier in-memory (Approve once). Refuses downgrades
+   * — a malicious renderer cannot drop its own privileges. Returns the new
+   * tier or throws if the session is unknown / the request is invalid.
+   */
+  setSessionTier(sessionId: string, tier: McpTier): { sessionId: string; tier: McpTier } {
+    if (!sessionId || typeof sessionId !== "string") {
+      throw new Error("Invalid sessionId");
+    }
+    if (tier !== "workbench" && tier !== "action" && tier !== "system") {
+      throw new Error("Invalid tier");
+    }
+    const current = this.deps.sessionStore.sessionTierMap.get(sessionId);
+    if (current === undefined) {
+      throw new Error("Unknown session");
+    }
+    // Only help-session bearers should be elevated through this surface —
+    // an unpinned session is api-key/external and has no UI invariant to
+    // satisfy.
+    if (!this.deps.sessionStore.sessionWebContentsMap.has(sessionId)) {
+      throw new Error("Session is not eligible for renderer tier elevation");
+    }
+    const order: McpTier[] = ["workbench", "action", "system", "external"];
+    const currentRank = order.indexOf(current);
+    const newRank = order.indexOf(tier);
+    if (newRank < currentRank) {
+      // Refuse downgrades — keep current tier.
+      return { sessionId, tier: current };
+    }
+    this.deps.sessionStore.sessionTierMap.set(sessionId, tier);
+    return { sessionId, tier };
   }
 
   getStatus(): {

--- a/electron/services/mcp-server/httpLifecycle.ts
+++ b/electron/services/mcp-server/httpLifecycle.ts
@@ -729,10 +729,16 @@ export class HttpLifecycle {
 
   /**
    * Promote a help-session's tier in-memory (Approve once). Refuses downgrades
-   * — a malicious renderer cannot drop its own privileges. Returns the new
-   * tier or throws if the session is unknown / the request is invalid.
+   * — a malicious renderer cannot drop its own privileges. When `callerWcId`
+   * is supplied, also requires the caller to be the WebContents the session
+   * was pinned to at handshake (cross-window forgery defence). Returns the
+   * new tier or throws if the session is unknown / the request is invalid.
    */
-  setSessionTier(sessionId: string, tier: McpTier): { sessionId: string; tier: McpTier } {
+  setSessionTier(
+    sessionId: string,
+    tier: McpTier,
+    callerWcId?: number
+  ): { sessionId: string; tier: McpTier } {
     if (!sessionId || typeof sessionId !== "string") {
       throw new Error("Invalid sessionId");
     }
@@ -743,11 +749,27 @@ export class HttpLifecycle {
     if (current === undefined) {
       throw new Error("Unknown session");
     }
+    // Reject elevations for sessions whose transport already closed (idle
+    // timeout, server shutdown). The tier-map entry can outlive the transport
+    // briefly during cleanup; mutating a dead entry would silently fail when
+    // the next call lands.
+    if (
+      !this.deps.sessionStore.sessions.has(sessionId) &&
+      !this.deps.sessionStore.httpSessions.has(sessionId)
+    ) {
+      throw new Error("Session is no longer active");
+    }
     // Only help-session bearers should be elevated through this surface —
     // an unpinned session is api-key/external and has no UI invariant to
     // satisfy.
-    if (!this.deps.sessionStore.sessionWebContentsMap.has(sessionId)) {
+    const pinnedWcId = this.deps.sessionStore.sessionWebContentsMap.get(sessionId);
+    if (pinnedWcId === undefined) {
       throw new Error("Session is not eligible for renderer tier elevation");
+    }
+    if (callerWcId !== undefined && callerWcId !== pinnedWcId) {
+      // Cross-WebContents forgery: another renderer is trying to elevate a
+      // session that wasn't minted by it. Reject loudly.
+      throw new Error("Caller is not the pinned renderer for this session");
     }
     const order: McpTier[] = ["workbench", "action", "system", "external"];
     const currentRank = order.indexOf(current);

--- a/electron/services/mcp-server/sessionServer.ts
+++ b/electron/services/mcp-server/sessionServer.ts
@@ -43,6 +43,7 @@ import {
   MCP_DEDUP_ALLOWLIST,
   MCP_DEDUP_TTL_MS,
   MCP_DEDUP_MAX_ENTRIES_PER_SESSION,
+  minimumPermittingTier,
 } from "./shared.js";
 import { buildDedupKey, readDedupCache, type CallToolResultLike } from "./sessionDedup.js";
 import {
@@ -81,6 +82,24 @@ export interface SessionServerDeps {
   }) => void;
   getCachedManifest: () => import("../../../shared/types/actions.js").ActionManifestEntry[] | null;
   getFullToolSurface: () => boolean;
+  /**
+   * Optional renderer notifier fired when a help-session tool call is denied
+   * because the session tier doesn't permit it. Implemented by httpLifecycle
+   * for help-session bearers (pinned WebContents); absent for external/api-key
+   * sessions, which have no associated UI.
+   */
+  notifyTierMismatch?: (payload: {
+    sessionId: string;
+    toolId: string;
+    tier: McpTier;
+    /**
+     * Minimum tier that permits the denied tool, or `null` if no tier permits
+     * it (unknown tool). The renderer uses this to label the elevation buttons
+     * — "Allow Action tier" / "Allow System tier" — and to drive the
+     * `setSessionTier` call.
+     */
+    targetTier: "workbench" | "action" | "system" | null;
+  }) => void;
 }
 
 export function createSessionServer(sessionId: string, deps: SessionServerDeps): Server {
@@ -92,6 +111,7 @@ export function createSessionServer(sessionId: string, deps: SessionServerDeps):
     appendAuditRecord,
     getCachedManifest,
     getFullToolSurface,
+    notifyTierMismatch,
   } = deps;
 
   const server = new Server(
@@ -144,6 +164,18 @@ export function createSessionServer(sessionId: string, deps: SessionServerDeps):
         });
       } catch (err) {
         console.error("[MCP] Failed to append audit record:", err);
+      }
+      if (notifyTierMismatch) {
+        try {
+          notifyTierMismatch({
+            sessionId,
+            toolId: actionId,
+            tier,
+            targetTier: minimumPermittingTier(actionId),
+          });
+        } catch (err) {
+          console.error("[MCP] Failed to notify tier-mismatch:", err);
+        }
       }
       return {
         content: [

--- a/electron/services/mcp-server/shared.ts
+++ b/electron/services/mcp-server/shared.ts
@@ -333,6 +333,24 @@ export const MCP_DEDUP_TTL_MS = 120_000;
  */
 export const MCP_DEDUP_MAX_ENTRIES_PER_SESSION = 256;
 
+/**
+ * Compute the minimum non-external tier that permits the given tool. Used to
+ * tell the renderer how to elevate the session in response to a
+ * TIER_NOT_PERMITTED denial: "Approve once" / "Always allow" both target this
+ * tier rather than blanket-elevating to `system`. Returns `null` if the tool
+ * isn't permitted at any tier (unknown tool).
+ *
+ * The `external` tier is intentionally excluded because it's a peer of the
+ * help-session tiers (api-key sessions only) and is never the right target
+ * for renderer-driven elevation.
+ */
+export function minimumPermittingTier(toolId: string): "workbench" | "action" | "system" | null {
+  if (TIER_ALLOWLISTS.workbench.has(toolId)) return "workbench";
+  if (TIER_ALLOWLISTS.action.has(toolId)) return "action";
+  if (TIER_ALLOWLISTS.system.has(toolId)) return "system";
+  return null;
+}
+
 export type ResourceKind = "pulse" | "scrollback" | "agentState" | "issues";
 
 export interface ParsedResourceUri {

--- a/scripts/lint-ratchet.mjs
+++ b/scripts/lint-ratchet.mjs
@@ -40,7 +40,7 @@ function main() {
     // ESLint exits with code 1 when there are warnings/errors
     // The output is still valid JSON in stdout
     if (error.code === "ERR_CHILD_PROCESS_STDIO_MAXBUFFER") {
-      console.error("❌ ESLint output exceeded buffer size (10MB)");
+      console.error("❌ ESLint output exceeded buffer size (25MB)");
       console.error("   Try reducing the number of files or increasing maxBuffer");
       process.exit(1);
     }

--- a/shared/types/ipc/api.ts
+++ b/shared/types/ipc/api.ts
@@ -1308,6 +1308,27 @@ export interface ElectronAPI {
     onRuntimeStateChanged(
       callback: (snapshot: import("./mcpServer.js").McpRuntimeSnapshot) => void
     ): () => void;
+    /**
+     * Elevate an active help-session's tier (Approve once). Server-side
+     * validates that the new tier is not a downgrade.
+     */
+    setSessionTier(
+      sessionId: string,
+      tier: "workbench" | "action" | "system"
+    ): Promise<{ sessionId: string; tier: "workbench" | "action" | "system" }>;
+    /**
+     * Subscribe to tier-not-permitted pushes for the pinned help-session in
+     * this WebContents. The callback fires when a tool call is denied because
+     * the session tier doesn't permit it.
+     */
+    onTierNotPermitted(
+      callback: (payload: {
+        sessionId: string;
+        toolId: string;
+        tier: string;
+        targetTier: "workbench" | "action" | "system" | null;
+      }) => void
+    ): () => void;
   };
   helpAssistant: {
     getSettings(): Promise<HelpAssistantSettings>;

--- a/shared/types/ipc/maps.ts
+++ b/shared/types/ipc/maps.ts
@@ -1827,6 +1827,10 @@ export interface IpcInvokeMap {
     args: [];
     result: import("./mcpServer.js").McpRuntimeSnapshot;
   };
+  "mcp-server:set-session-tier": {
+    args: [payload: { sessionId: string; tier: "workbench" | "action" | "system" }];
+    result: { sessionId: string; tier: "workbench" | "action" | "system" };
+  };
 
   // Webview console capture
   "webview:start-console-capture": {
@@ -2361,6 +2365,21 @@ export interface IpcEventMap {
    * binary reachability.
    */
   "mcp-server:runtime-state-changed": import("./mcpServer.js").McpRuntimeSnapshot;
+
+  /**
+   * Targeted push: a help-session tool call was denied because its tier
+   * doesn't permit the tool. Sent to the pinned WebContents so the renderer
+   * can surface an inline approval banner. Tier is `string` (not `McpTier`)
+   * because the type is main-process only — see `McpAuditRecord.tier`
+   * precedent. `targetTier` is the minimum tier that permits the tool, or
+   * `null` if the tool isn't recognized at any tier.
+   */
+  "mcp-server:tier-not-permitted": {
+    sessionId: string;
+    toolId: string;
+    tier: string;
+    targetTier: "workbench" | "action" | "system" | null;
+  };
 
   // Error events
   "error:notify": ErrorRecord;

--- a/src/components/HelpPanel/HelpPanel.tsx
+++ b/src/components/HelpPanel/HelpPanel.tsx
@@ -81,6 +81,12 @@ interface TierMismatchState {
   toolId: string;
   tier: string;
   targetTier: "workbench" | "action" | "system" | null;
+  /**
+   * Captured at event time so "Always allow" persists to the project the
+   * banner originated from, not whichever project is current at click time —
+   * matters during rapid project switches.
+   */
+  projectId: string | null;
 }
 
 function notifyMcpNotReady(reason: string): void {
@@ -605,11 +611,16 @@ export function HelpPanel({
   // for our help-session.
   useEffect(() => {
     const dispose = window.electron.mcpServer.onTierNotPermitted((payload) => {
+      // Capture the project at event time. If the user switches projects
+      // before clicking "Always allow", the persisted tier should still
+      // belong to the project the banner originated from.
+      const projectId = useProjectStore.getState().currentProject?.id ?? null;
       setTierMismatch({
         sessionId: payload.sessionId,
         toolId: payload.toolId,
         tier: payload.tier,
         targetTier: payload.targetTier,
+        projectId,
       });
     });
     return dispose;
@@ -637,7 +648,12 @@ export function HelpPanel({
         const tier = resolveDaintreeMcpTier(settings);
         if (tier !== "system") return;
         const snapshot = await window.electron.git.snapshotGet(worktreeId);
-        if (cancelled || !snapshot) return;
+        // PreAgentSnapshotService records a sentinel (`stashRef: ""`) before
+        // the actual stash completes, to coordinate concurrent creation. A
+        // sentinel means the snapshot is still in-flight (or failed early) —
+        // surfacing the banner would lie about the user's safety. Wait for a
+        // real ref.
+        if (cancelled || !snapshot || !snapshot.stashRef) return;
         setPreflightSnapshot(snapshot);
       })().catch((err) => {
         logError("HelpPanel: snapshot pre-flight failed", err);
@@ -1375,15 +1391,27 @@ export function HelpPanel({
     setTierMismatch(null);
   }, []);
 
+  // Clears the banner only if a fresh denial hasn't arrived during the IPC
+  // round-trip. Without this, a second denial that fires while the user's
+  // approval is in flight gets silently wiped out by the resolver.
+  const clearIfStillCurrent = useCallback((sessionId: string, toolId: string) => {
+    setTierMismatch((prev) =>
+      prev && prev.sessionId === sessionId && prev.toolId === toolId ? null : prev
+    );
+  }, []);
+
   const handleApproveOnce = useCallback(() => {
     const current = tierMismatch;
     if (!current?.targetTier || isApprovingTier) return;
+    const targetTier = current.targetTier;
+    const sessionId = current.sessionId;
+    const toolId = current.toolId;
     setIsApprovingTier(true);
     safeFireAndForget(
       window.electron.mcpServer
-        .setSessionTier(current.sessionId, current.targetTier)
+        .setSessionTier(sessionId, targetTier)
         .then(() => {
-          setTierMismatch(null);
+          clearIfStillCurrent(sessionId, toolId);
         })
         .catch((err) => {
           logError("HelpPanel: setSessionTier failed", err);
@@ -1398,19 +1426,23 @@ export function HelpPanel({
         }),
       { context: "HelpPanel:setSessionTier" }
     );
-  }, [tierMismatch, isApprovingTier]);
+  }, [tierMismatch, isApprovingTier, clearIfStillCurrent]);
 
   const handleAlwaysAllow = useCallback(() => {
     const current = tierMismatch;
     if (!current?.targetTier || isApprovingTier) return;
-    // Read fresh state at click time — currentProject from render-time closure
-    // can drift if the user switches projects after the banner appears.
-    const projectId = useProjectStore.getState().currentProject?.id;
+    // Use the project captured at event time — `current.projectId` is
+    // immutable for this banner instance, so a project switch after the
+    // banner appears doesn't redirect the save to the wrong project. Fall
+    // back to the live currentProject only if the event didn't carry one.
+    const projectId = current.projectId ?? useProjectStore.getState().currentProject?.id ?? null;
     if (!projectId) {
       dismissTierMismatch();
       return;
     }
     const targetTier = current.targetTier;
+    const sessionId = current.sessionId;
+    const toolId = current.toolId;
     setIsApprovingTier(true);
     safeFireAndForget(
       (async () => {
@@ -1425,8 +1457,8 @@ export function HelpPanel({
         });
         // Also lift the live session immediately so the assistant doesn't have
         // to wait for a new session to pick up the persisted change.
-        await window.electron.mcpServer.setSessionTier(current.sessionId, targetTier);
-        setTierMismatch(null);
+        await window.electron.mcpServer.setSessionTier(sessionId, targetTier);
+        clearIfStillCurrent(sessionId, toolId);
       })()
         .catch((err) => {
           logError("HelpPanel: always-allow tier write failed", err);
@@ -1441,7 +1473,7 @@ export function HelpPanel({
         }),
       { context: "HelpPanel:alwaysAllowTier" }
     );
-  }, [tierMismatch, isApprovingTier, dismissTierMismatch]);
+  }, [tierMismatch, isApprovingTier, dismissTierMismatch, clearIfStillCurrent]);
 
   // Esc-to-close. The xterm-helper-textarea check lets Escape reach the
   // running PTY (Codex/Claude/etc.) when the assistant terminal has focus

--- a/src/components/HelpPanel/HelpPanel.tsx
+++ b/src/components/HelpPanel/HelpPanel.tsx
@@ -1,5 +1,5 @@
 import { Suspense, useCallback, useEffect, useRef, useState, useMemo } from "react";
-import { Settings2, ChevronRight, Plus, X } from "lucide-react";
+import { Settings2, ChevronRight, Plus, X, ShieldAlert, History } from "lucide-react";
 import * as semver from "semver";
 import { cn } from "@/lib/utils";
 import { DaintreeIcon } from "@/components/icons/DaintreeIcon";
@@ -16,6 +16,7 @@ import {
   getTerminalRefreshTier,
   useCliAvailabilityStore,
   useProjectStore,
+  useWorktreeSelectionStore,
 } from "@/store";
 import { useMacroFocusStore } from "@/store/macroFocusStore";
 import { getAgentConfig, getAssistantSupportedAgentIds } from "@/config/agents";
@@ -32,6 +33,9 @@ import { ACTIVE_AGENT_STATES, CLOSE_CONFIRM_AGENT_STATES } from "@shared/types/a
 import { buildResumeCommand } from "@shared/types/agentSettings";
 import { ConfirmDialog } from "@/components/ui/ConfirmDialog";
 import { TABBABLE_SELECTOR } from "@/lib/accessibility";
+import { projectClient } from "@/clients/projectClient";
+import { resolveDaintreeMcpTier } from "@shared/types/project";
+import type { SnapshotInfo } from "@shared/types/ipc/git";
 
 const RESIZE_STEP = 10;
 const RESIZE_PAGE_STEP = 50;
@@ -66,6 +70,18 @@ const HIBERNATE_BUSY_RECHECK_MS = 2 * 60 * 1000;
 // usually see it for the moment they return to the panel; long-lived banners
 // distract from the conversation.
 const RESUME_BANNER_AUTO_DISMISS_MS = 10_000;
+
+// Tier-1 ambient banner auto-dismiss for the auto-snapshot pre-flight notice.
+// The signal is reassurance, not a call to action — fade once the user has had
+// time to see it.
+const SNAPSHOT_BANNER_AUTO_DISMISS_MS = 12_000;
+
+interface TierMismatchState {
+  sessionId: string;
+  toolId: string;
+  tier: string;
+  targetTier: "workbench" | "action" | "system" | null;
+}
 
 function notifyMcpNotReady(reason: string): void {
   notify({
@@ -266,6 +282,10 @@ export function HelpPanel({
   // `refresh=true` so an externally-updated CLI is detected without waiting
   // for the 12h AgentVersionService cache TTL. Cleared once a probe passes.
   const hasBlockedThisSessionRef = useRef(false);
+  const [tierMismatch, setTierMismatch] = useState<TierMismatchState | null>(null);
+  const [preflightSnapshot, setPreflightSnapshot] = useState<SnapshotInfo | null>(null);
+  const [isApprovingTier, setIsApprovingTier] = useState(false);
+  const activeWorktreeId = useWorktreeSelectionStore((s) => s.activeWorktreeId);
 
   const {
     isOpen,
@@ -316,6 +336,12 @@ export function HelpPanel({
   // store. If the user closes/navigates while `agent.launch` is in flight,
   // cleanup paths revoke this ref so the token isn't leaked until 7-day GC.
   const pendingSessionIdRef = useRef<string | null>(null);
+
+  // Once-per-session guard for the auto-snapshot pre-flight. Set TRUE
+  // synchronously before the async snapshotGet IPC so React 19 StrictMode's
+  // double-invoke of the effect can't fire two parallel pre-flights. Reset
+  // when the underlying terminal id (the assistant session boundary) changes.
+  const hasTakenPreflightSnapshotRef = useRef<string | null>(null);
 
   // Set true while the OS is suspended so the visibilitychange teardown below
   // distinguishes "system slept" from "project switched / window unloaded".
@@ -573,6 +599,66 @@ export function HelpPanel({
   // conversationTouched=true and would otherwise dismiss the banner before
   // the user has a chance to see it. The user can also dismiss manually via
   // the X button.
+  // Subscribe to tier-mismatch pushes from the MCP server. The push is
+  // targeted at this WebContents (only fires for help-session bearers minted
+  // here), so we don't need to filter by sessionId — any event we receive is
+  // for our help-session.
+  useEffect(() => {
+    const dispose = window.electron.mcpServer.onTierNotPermitted((payload) => {
+      setTierMismatch({
+        sessionId: payload.sessionId,
+        toolId: payload.toolId,
+        tier: payload.tier,
+        targetTier: payload.targetTier,
+      });
+    });
+    return dispose;
+  }, []);
+
+  // Auto-snapshot pre-flight: when the project's MCP tier is `system`, take a
+  // pre-flight snapshot once per session and surface a Tier-1 ambient banner.
+  // Triggered when the assistant terminal first becomes active (terminalId
+  // commits and `terminal` exists). Sets the ref synchronously to survive
+  // React 19 StrictMode double-mount; the `cancelled` flag handles in-flight
+  // cleanup on unmount.
+  useEffect(() => {
+    if (!terminalId || !terminal) return;
+    if (hasTakenPreflightSnapshotRef.current === terminalId) return;
+    const projectId = currentProject?.id;
+    if (!projectId) return;
+    const worktreeId = terminal.worktreeId ?? activeWorktreeId;
+    if (!worktreeId) return;
+
+    let cancelled = false;
+    hasTakenPreflightSnapshotRef.current = terminalId;
+    safeFireAndForget(
+      (async () => {
+        const settings = await projectClient.getSettings(projectId);
+        const tier = resolveDaintreeMcpTier(settings);
+        if (tier !== "system") return;
+        const snapshot = await window.electron.git.snapshotGet(worktreeId);
+        if (cancelled || !snapshot) return;
+        setPreflightSnapshot(snapshot);
+      })().catch((err) => {
+        logError("HelpPanel: snapshot pre-flight failed", err);
+      }),
+      { context: "HelpPanel:snapshot pre-flight" }
+    );
+
+    return () => {
+      cancelled = true;
+    };
+  }, [terminalId, terminal, currentProject?.id, activeWorktreeId]);
+
+  // Auto-dismiss the pre-flight snapshot banner after the read-window. Mirrors
+  // the resume-banner pattern at RESUME_BANNER_AUTO_DISMISS_MS — ambient signal,
+  // not a call to action.
+  useEffect(() => {
+    if (!preflightSnapshot) return;
+    const id = setTimeout(() => setPreflightSnapshot(null), SNAPSHOT_BANNER_AUTO_DISMISS_MS);
+    return () => clearTimeout(id);
+  }, [preflightSnapshot]);
+
   useEffect(() => {
     if (!showResumeBanner) return;
     const id = setTimeout(() => setShowResumeBanner(false), RESUME_BANNER_AUTO_DISMISS_MS);
@@ -1285,6 +1371,78 @@ export function HelpPanel({
     [seedAgentToLaunch, handleSelectAgent]
   );
 
+  const dismissTierMismatch = useCallback(() => {
+    setTierMismatch(null);
+  }, []);
+
+  const handleApproveOnce = useCallback(() => {
+    const current = tierMismatch;
+    if (!current?.targetTier || isApprovingTier) return;
+    setIsApprovingTier(true);
+    safeFireAndForget(
+      window.electron.mcpServer
+        .setSessionTier(current.sessionId, current.targetTier)
+        .then(() => {
+          setTierMismatch(null);
+        })
+        .catch((err) => {
+          logError("HelpPanel: setSessionTier failed", err);
+          notify({
+            type: "error",
+            title: "Couldn't approve tool",
+            message: formatErrorMessage(err, "Couldn't elevate the assistant's tier."),
+          });
+        })
+        .finally(() => {
+          setIsApprovingTier(false);
+        }),
+      { context: "HelpPanel:setSessionTier" }
+    );
+  }, [tierMismatch, isApprovingTier]);
+
+  const handleAlwaysAllow = useCallback(() => {
+    const current = tierMismatch;
+    if (!current?.targetTier || isApprovingTier) return;
+    // Read fresh state at click time — currentProject from render-time closure
+    // can drift if the user switches projects after the banner appears.
+    const projectId = useProjectStore.getState().currentProject?.id;
+    if (!projectId) {
+      dismissTierMismatch();
+      return;
+    }
+    const targetTier = current.targetTier;
+    setIsApprovingTier(true);
+    safeFireAndForget(
+      (async () => {
+        // projectClient.saveSettings goes directly to the IPC handler — using
+        // the `project.saveSettings` action would silently strip the
+        // `daintreeMcpTier` field (sanitized to keep agents from
+        // self-elevating).
+        const settings = await projectClient.getSettings(projectId);
+        await projectClient.saveSettings(projectId, {
+          ...settings,
+          daintreeMcpTier: targetTier,
+        });
+        // Also lift the live session immediately so the assistant doesn't have
+        // to wait for a new session to pick up the persisted change.
+        await window.electron.mcpServer.setSessionTier(current.sessionId, targetTier);
+        setTierMismatch(null);
+      })()
+        .catch((err) => {
+          logError("HelpPanel: always-allow tier write failed", err);
+          notify({
+            type: "error",
+            title: "Couldn't save permission",
+            message: formatErrorMessage(err, "Couldn't update project tier setting."),
+          });
+        })
+        .finally(() => {
+          setIsApprovingTier(false);
+        }),
+      { context: "HelpPanel:alwaysAllowTier" }
+    );
+  }, [tierMismatch, isApprovingTier, dismissTierMismatch]);
+
   // Esc-to-close. The xterm-helper-textarea check lets Escape reach the
   // running PTY (Codex/Claude/etc.) when the assistant terminal has focus
   // instead of closing the panel out from under the user.
@@ -1511,6 +1669,112 @@ export function HelpPanel({
                   >
                     <X className="w-3 h-3" />
                   </button>
+                </div>
+              )}
+              {preflightSnapshot && (
+                <div
+                  role="status"
+                  aria-live="polite"
+                  className={cn(
+                    "flex items-start gap-2 px-3 py-2 mx-3 mt-3 mb-1",
+                    "rounded-[var(--radius-md)] bg-overlay-subtle border border-daintree-border",
+                    "text-xs text-daintree-text/80"
+                  )}
+                  data-testid="help-snapshot-banner"
+                >
+                  <History
+                    className="w-3.5 h-3.5 shrink-0 mt-0.5 text-daintree-text/60"
+                    aria-hidden="true"
+                  />
+                  <span className="flex-1 select-text">
+                    Saved a snapshot of this worktree before any changes.
+                  </span>
+                  <button
+                    type="button"
+                    onClick={() => setPreflightSnapshot(null)}
+                    aria-label="Dismiss snapshot notice"
+                    className="text-daintree-text/50 hover:text-daintree-text transition-colors focus-visible:outline focus-visible:outline-2 focus-visible:outline-daintree-accent focus-visible:outline-offset-2"
+                  >
+                    <X className="w-3 h-3" />
+                  </button>
+                </div>
+              )}
+              {tierMismatch && (
+                <div
+                  role="alert"
+                  className={cn(
+                    "flex flex-col gap-2 px-3 py-2.5 mx-3 mt-3 mb-1",
+                    "rounded-[var(--radius-md)]",
+                    "bg-status-warning/10 border border-status-warning/40",
+                    "text-xs text-daintree-text/85"
+                  )}
+                  data-testid="help-tier-mismatch-banner"
+                >
+                  <div className="flex items-start gap-2">
+                    <ShieldAlert
+                      className="w-3.5 h-3.5 shrink-0 mt-0.5 text-status-warning"
+                      aria-hidden="true"
+                    />
+                    <div className="flex-1 select-text">
+                      <p className="font-medium text-daintree-text">Tool not permitted</p>
+                      <p className="mt-0.5 text-daintree-text/70">
+                        {tierMismatch.targetTier
+                          ? `${tierMismatch.toolId} needs ${tierMismatch.targetTier} tier access.`
+                          : `${tierMismatch.toolId} isn't available at any project tier.`}
+                      </p>
+                    </div>
+                    <button
+                      type="button"
+                      onClick={dismissTierMismatch}
+                      aria-label="Dismiss tier mismatch notice"
+                      className="text-daintree-text/50 hover:text-daintree-text transition-colors focus-visible:outline focus-visible:outline-2 focus-visible:outline-daintree-accent focus-visible:outline-offset-2"
+                    >
+                      <X className="w-3 h-3" />
+                    </button>
+                  </div>
+                  {tierMismatch.targetTier && (
+                    <div className="flex items-center gap-2 flex-wrap pl-5">
+                      <button
+                        type="button"
+                        onClick={handleApproveOnce}
+                        disabled={isApprovingTier}
+                        className={cn(
+                          "px-2 py-1 rounded-[var(--radius-sm)] text-xs font-medium",
+                          "bg-daintree-text/10 hover:bg-daintree-text/15 text-daintree-text",
+                          "disabled:opacity-50 disabled:cursor-not-allowed transition-colors",
+                          "focus-visible:outline focus-visible:outline-2 focus-visible:outline-daintree-accent focus-visible:outline-offset-2"
+                        )}
+                      >
+                        Approve once
+                      </button>
+                      <button
+                        type="button"
+                        onClick={handleAlwaysAllow}
+                        disabled={isApprovingTier}
+                        className={cn(
+                          "px-2 py-1 rounded-[var(--radius-sm)] text-xs font-medium",
+                          "bg-daintree-text/5 hover:bg-daintree-text/10 text-daintree-text/85",
+                          "disabled:opacity-50 disabled:cursor-not-allowed transition-colors",
+                          "focus-visible:outline focus-visible:outline-2 focus-visible:outline-daintree-accent focus-visible:outline-offset-2"
+                        )}
+                      >
+                        Always allow for this project
+                      </button>
+                      <button
+                        type="button"
+                        onClick={dismissTierMismatch}
+                        disabled={isApprovingTier}
+                        className={cn(
+                          "px-2 py-1 rounded-[var(--radius-sm)] text-xs",
+                          "text-daintree-text/65 hover:text-daintree-text",
+                          "disabled:opacity-50 disabled:cursor-not-allowed transition-colors",
+                          "focus-visible:outline focus-visible:outline-2 focus-visible:outline-daintree-accent focus-visible:outline-offset-2"
+                        )}
+                      >
+                        Cancel
+                      </button>
+                    </div>
+                  )}
                 </div>
               )}
               <div className="flex-1 relative min-h-0">

--- a/src/components/HelpPanel/__tests__/HelpPanel.helpLaunch.test.tsx
+++ b/src/components/HelpPanel/__tests__/HelpPanel.helpLaunch.test.tsx
@@ -202,12 +202,18 @@ vi.mock("@/store", () => {
     selector ? selector(preferencesState) : preferencesState;
   preferencesStore.getState = () => preferencesState;
 
+  const worktreeSelectionState = { activeWorktreeId: null as string | null };
+  const worktreeSelectionStore = (selector?: (state: typeof worktreeSelectionState) => unknown) =>
+    selector ? selector(worktreeSelectionState) : worktreeSelectionState;
+  worktreeSelectionStore.getState = () => worktreeSelectionState;
+
   return {
     usePanelStore: panelStore,
     useCliAvailabilityStore: cliStore,
     useAgentSettingsStore: agentSettingsStore,
     useProjectStore: projectStore,
     usePreferencesStore: preferencesStore,
+    useWorktreeSelectionStore: worktreeSelectionStore,
     getTerminalRefreshTier: () => 0,
   };
 });
@@ -385,6 +391,17 @@ beforeEach(() => {
           getMetrics: mockSystemSleepGetMetrics,
           onSuspend: mockSystemSleepOnSuspend,
           onWake: mockSystemSleepOnWake,
+        },
+        mcpServer: {
+          onTierNotPermitted: vi.fn(() => () => {}),
+          setSessionTier: vi.fn().mockResolvedValue({ sessionId: "", tier: "workbench" }),
+        },
+        git: {
+          snapshotGet: vi.fn().mockResolvedValue(null),
+        },
+        project: {
+          getSettings: vi.fn().mockResolvedValue({}),
+          saveSettings: vi.fn().mockResolvedValue(undefined),
         },
       },
     },

--- a/src/components/HelpPanel/__tests__/HelpPanel.hibernate.test.tsx
+++ b/src/components/HelpPanel/__tests__/HelpPanel.hibernate.test.tsx
@@ -188,12 +188,18 @@ vi.mock("@/store", () => {
     selector ? selector(preferencesState) : preferencesState;
   preferencesStore.getState = () => preferencesState;
 
+  const worktreeSelectionState = { activeWorktreeId: null as string | null };
+  const worktreeSelectionStore = (selector?: (state: typeof worktreeSelectionState) => unknown) =>
+    selector ? selector(worktreeSelectionState) : worktreeSelectionState;
+  worktreeSelectionStore.getState = () => worktreeSelectionState;
+
   return {
     usePanelStore: panelStore,
     useCliAvailabilityStore: cliStore,
     useAgentSettingsStore: agentSettingsStore,
     useProjectStore: projectStore,
     usePreferencesStore: preferencesStore,
+    useWorktreeSelectionStore: worktreeSelectionStore,
     getTerminalRefreshTier: () => 0,
   };
 });
@@ -348,6 +354,17 @@ beforeEach(() => {
         },
         terminal: {
           gracefulKill: mockGracefulKill,
+        },
+        mcpServer: {
+          onTierNotPermitted: vi.fn(() => () => {}),
+          setSessionTier: vi.fn().mockResolvedValue({ sessionId: "", tier: "workbench" }),
+        },
+        git: {
+          snapshotGet: vi.fn().mockResolvedValue(null),
+        },
+        project: {
+          getSettings: vi.fn().mockResolvedValue({}),
+          saveSettings: vi.fn().mockResolvedValue(undefined),
         },
       },
       addEventListener: vi.fn(),

--- a/src/components/Layout/ToolbarAssistantButton.tsx
+++ b/src/components/Layout/ToolbarAssistantButton.tsx
@@ -8,6 +8,7 @@ import { cn } from "@/lib/utils";
 import { DaintreeIcon } from "@/components/icons/DaintreeIcon";
 import { useFocusStore } from "@/store/focusStore";
 import { useHelpPanelStore } from "@/store/helpPanelStore";
+import { usePanelStore } from "@/store";
 import { suppressSidebarResizes } from "@/lib/sidebarToggle";
 import { useMcpReadiness } from "@/hooks/useMcpReadiness";
 import type { McpRuntimeSnapshot } from "@shared/types";
@@ -48,6 +49,13 @@ export const ToolbarAssistantButton = memo(function ToolbarAssistantButton({
 }) {
   const isOpen = useHelpPanelStore((s) => s.isOpen);
   const toggle = useHelpPanelStore((s) => s.toggle);
+  // Two-step primitive selectors so the button only re-renders when the
+  // assistant terminal id changes, then when its agentState transitions in or
+  // out of "working". Returning a primitive avoids needing useShallow.
+  const assistantTerminalId = useHelpPanelStore((s) => s.terminalId);
+  const isWorking = usePanelStore((s) =>
+    assistantTerminalId ? s.panelsById[assistantTerminalId]?.agentState === "working" : false
+  );
   const mcp = useMcpReadiness();
   const shortcut = useKeybindingDisplay("help.togglePanel");
   const ariaShortcut = useAriaKeyshortcuts("help.togglePanel");
@@ -60,8 +68,18 @@ export const ToolbarAssistantButton = memo(function ToolbarAssistantButton({
   }, [toggle]);
 
   const pip = describePip(mcp);
+  // The MCP-health pip takes precedence — when it's showing, the working pip
+  // would compete for the same corner. The neutral working dot is intentionally
+  // non-pulsing and non-accent (per CLAUDE.md accent-color restraint) so it
+  // reads as ambient state rather than a call to action.
+  const showWorkingPip = !pip && isWorking && !isOpen;
   const baseTooltip = isOpen ? "Close Daintree Assistant" : "Open Daintree Assistant";
-  const ariaLabel = pip ? `Daintree Assistant — ${pip.tooltip}` : "Daintree Assistant";
+  const workingTooltip = "Assistant is working";
+  const ariaLabel = pip
+    ? `Daintree Assistant — ${pip.tooltip}`
+    : showWorkingPip
+      ? `Daintree Assistant — ${workingTooltip}`
+      : "Daintree Assistant";
 
   return (
     <Tooltip>
@@ -79,7 +97,7 @@ export const ToolbarAssistantButton = memo(function ToolbarAssistantButton({
           aria-keyshortcuts={ariaShortcut}
         >
           <DaintreeIcon />
-          {pip && (
+          {pip ? (
             <span
               aria-hidden="true"
               className={cn(
@@ -88,12 +106,30 @@ export const ToolbarAssistantButton = memo(function ToolbarAssistantButton({
                 pip.delayed && "animate-pulse-delayed"
               )}
             />
+          ) : (
+            showWorkingPip && (
+              <span
+                aria-hidden="true"
+                data-testid="assistant-working-pip"
+                className={cn(
+                  "absolute -top-0.5 -right-0.5 w-2 h-2 rounded-full ring-2 ring-daintree-bg",
+                  "bg-daintree-text/30"
+                )}
+              />
+            )
           )}
           <ShortcutRevealChip actionId="help.togglePanel" />
         </Button>
       </TooltipTrigger>
       <TooltipContent side="bottom">
-        {createTooltipContent(pip ? `${baseTooltip} — ${pip.tooltip}` : baseTooltip, shortcut)}
+        {createTooltipContent(
+          pip
+            ? `${baseTooltip} — ${pip.tooltip}`
+            : showWorkingPip
+              ? `${baseTooltip} — ${workingTooltip}`
+              : baseTooltip,
+          shortcut
+        )}
       </TooltipContent>
     </Tooltip>
   );

--- a/src/components/Layout/__tests__/ToolbarAssistantButton.test.tsx
+++ b/src/components/Layout/__tests__/ToolbarAssistantButton.test.tsx
@@ -1,0 +1,157 @@
+// @vitest-environment jsdom
+import { describe, it, expect, beforeEach, vi } from "vitest";
+import { render, act } from "@testing-library/react";
+import { ToolbarAssistantButton } from "../ToolbarAssistantButton";
+import { useHelpPanelStore } from "@/store/helpPanelStore";
+import { usePanelStore } from "@/store";
+import type { McpRuntimeSnapshot } from "@shared/types";
+
+const mcpReadiness = vi.fn<[], McpRuntimeSnapshot>(() => ({
+  state: "ready",
+  port: 0,
+  lastError: null,
+}));
+
+vi.mock("@/components/ui/tooltip", () => ({
+  Tooltip: ({ children }: { children: React.ReactNode }) => <>{children}</>,
+  TooltipContent: () => null,
+  TooltipProvider: ({ children }: { children: React.ReactNode }) => <>{children}</>,
+  TooltipTrigger: ({ children }: { children: React.ReactNode }) => <>{children}</>,
+}));
+
+vi.mock("@/components/ui/button", () => ({
+  Button: ({
+    children,
+    ...rest
+  }: { children: React.ReactNode } & React.ButtonHTMLAttributes<HTMLButtonElement>) => (
+    <button {...rest}>{children}</button>
+  ),
+}));
+
+vi.mock("@/components/ui/ShortcutRevealChip", () => ({
+  ShortcutRevealChip: () => null,
+}));
+
+vi.mock("@/components/icons/DaintreeIcon", () => ({
+  DaintreeIcon: () => <span data-testid="icon-daintree" />,
+}));
+
+vi.mock("@/hooks", () => ({
+  useAriaKeyshortcuts: () => "",
+  useKeybindingDisplay: () => "",
+  useShortcutHintHover: () => ({}),
+}));
+
+vi.mock("@/lib/tooltipShortcut", () => ({
+  createTooltipContent: () => null,
+}));
+
+vi.mock("@/lib/sidebarToggle", () => ({
+  suppressSidebarResizes: vi.fn(),
+}));
+
+vi.mock("@/hooks/useMcpReadiness", () => ({
+  useMcpReadiness: () => mcpReadiness(),
+}));
+
+vi.mock("@/store/focusStore", () => ({
+  useFocusStore: { getState: () => ({ clearAssistantGesture: vi.fn() }) },
+}));
+
+function setHelpPanel(state: { isOpen: boolean; terminalId: string | null }) {
+  useHelpPanelStore.setState({
+    isOpen: state.isOpen,
+    terminalId: state.terminalId,
+  });
+}
+
+function setPanel(id: string, agentState: string | undefined): void {
+  usePanelStore.setState((s) => ({
+    ...s,
+    panelsById: {
+      ...s.panelsById,
+      [id]: {
+        id,
+        kind: "terminal",
+        title: "test",
+        cwd: "/tmp",
+        location: "dock",
+        worktreeId: undefined,
+        agentState: agentState as never,
+      } as never,
+    },
+    panelIds: s.panelIds.includes(id) ? s.panelIds : [...s.panelIds, id],
+  }));
+}
+
+describe("ToolbarAssistantButton — working pip", () => {
+  beforeEach(() => {
+    mcpReadiness.mockReturnValue({ state: "ready", port: 0, lastError: null });
+    useHelpPanelStore.setState({
+      isOpen: false,
+      terminalId: null,
+      agentId: null,
+      sessionId: null,
+    });
+    usePanelStore.setState({ panelsById: {}, panelIds: [] } as never);
+  });
+
+  it("does not render the working pip when the assistant is idle", () => {
+    setHelpPanel({ isOpen: false, terminalId: "t-1" });
+    setPanel("t-1", "idle");
+
+    const { queryByTestId } = render(<ToolbarAssistantButton />);
+    expect(queryByTestId("assistant-working-pip")).toBeNull();
+  });
+
+  it("renders the working pip when the assistant terminal's agentState is working", () => {
+    setHelpPanel({ isOpen: false, terminalId: "t-2" });
+    setPanel("t-2", "working");
+
+    const { queryByTestId } = render(<ToolbarAssistantButton />);
+    const pip = queryByTestId("assistant-working-pip");
+    expect(pip).not.toBeNull();
+    // The pip uses neutral color, not accent or status colors.
+    expect(pip!.className).toMatch(/bg-daintree-text\/30/);
+    expect(pip!.className).not.toMatch(/animate-pulse/);
+    expect(pip!.className).not.toMatch(/accent/);
+    expect(pip!.className).not.toMatch(/bg-status-/);
+  });
+
+  it("hides the working pip when the panel is open (the user can already see the activity)", () => {
+    setHelpPanel({ isOpen: true, terminalId: "t-3" });
+    setPanel("t-3", "working");
+
+    const { queryByTestId } = render(<ToolbarAssistantButton />);
+    expect(queryByTestId("assistant-working-pip")).toBeNull();
+  });
+
+  it("MCP-health pip takes precedence over the working pip when both would apply", () => {
+    mcpReadiness.mockReturnValue({
+      state: "failed",
+      port: 0,
+      lastError: "oops",
+    });
+    setHelpPanel({ isOpen: false, terminalId: "t-4" });
+    setPanel("t-4", "working");
+
+    const { container, queryByTestId } = render(<ToolbarAssistantButton />);
+    expect(queryByTestId("assistant-working-pip")).toBeNull();
+    // The MCP health pip uses bg-status-danger.
+    expect(container.querySelector(".bg-status-danger")).not.toBeNull();
+  });
+
+  it("re-renders when agentState transitions from working to idle", () => {
+    setHelpPanel({ isOpen: false, terminalId: "t-5" });
+    setPanel("t-5", "working");
+
+    const { queryByTestId } = render(<ToolbarAssistantButton />);
+    expect(queryByTestId("assistant-working-pip")).not.toBeNull();
+
+    act(() => {
+      setPanel("t-5", "idle");
+    });
+
+    expect(queryByTestId("assistant-working-pip")).toBeNull();
+  });
+});

--- a/src/components/Layout/__tests__/ToolbarAssistantButton.test.tsx
+++ b/src/components/Layout/__tests__/ToolbarAssistantButton.test.tsx
@@ -6,11 +6,15 @@ import { useHelpPanelStore } from "@/store/helpPanelStore";
 import { usePanelStore } from "@/store";
 import type { McpRuntimeSnapshot } from "@shared/types";
 
-const mcpReadiness = vi.fn<[], McpRuntimeSnapshot>(() => ({
-  state: "ready",
-  port: 0,
-  lastError: null,
-}));
+const mcpReadiness: () => McpRuntimeSnapshot = vi.fn(
+  (): McpRuntimeSnapshot => ({
+    enabled: true,
+    state: "ready",
+    port: 0,
+    lastError: null,
+  })
+);
+const mcpReadinessMock = mcpReadiness as ReturnType<typeof vi.fn>;
 
 vi.mock("@/components/ui/tooltip", () => ({
   Tooltip: ({ children }: { children: React.ReactNode }) => <>{children}</>,
@@ -86,7 +90,7 @@ function setPanel(id: string, agentState: string | undefined): void {
 
 describe("ToolbarAssistantButton — working pip", () => {
   beforeEach(() => {
-    mcpReadiness.mockReturnValue({ state: "ready", port: 0, lastError: null });
+    mcpReadinessMock.mockReturnValue({ enabled: true, state: "ready", port: 0, lastError: null });
     useHelpPanelStore.setState({
       isOpen: false,
       terminalId: null,
@@ -127,7 +131,7 @@ describe("ToolbarAssistantButton — working pip", () => {
   });
 
   it("MCP-health pip takes precedence over the working pip when both would apply", () => {
-    mcpReadiness.mockReturnValue({
+    mcpReadinessMock.mockReturnValue({
       state: "failed",
       port: 0,
       lastError: "oops",


### PR DESCRIPTION
## Summary

- Adds an inline amber banner when a tool call is denied (`TIER_NOT_PERMITTED`): the MCP server pushes a targeted event to the pinned `WebContents`, and `HelpPanel` renders Approve once / Always allow for this project / Cancel options. Captures `projectId` at event time; clears only if no fresh denial has landed during the IPC round-trip.
- Adds a pre-flight snapshot banner that runs once per session when the project MCP tier is `system` and a worktree is active. Calls `git.snapshotGet`, surfaces a Tier-1 ambient confirmation, and filters out `PreAgentSnapshotService`'s in-flight sentinel (`stashRef === ""`).
- Adds a neutral non-pulsing working-state pip on `ToolbarAssistantButton` when the assistant terminal's `agentState === "working"` and the panel is closed. MCP-health pip takes precedence.

Resolves #7536

## Changes

- IPC: new channels in `channels.ts`, `IpcEventMap`/`IpcInvokeMap` entries in `api.ts` and `maps.ts`, preload exposure, and `electron.d.ts` types
- MCP server: `sessionServer` (`notifyTierMismatch` + `minimumPermittingTier`), `httpLifecycle` (`setSessionTier`, targeted `webContents.send`), `shared.ts` helper
- `McpServerService`: `setSessionTier` delegate
- IPC handler: `mcpServer.ts` uses `typedHandleWithContext` to verify caller `WebContents` matches the pinned id (cross-window forgery defence); rejects elevations when transport has already closed
- `HelpPanel.tsx`: state, effects, banner JSX, and handlers for all three surfaces
- `ToolbarAssistantButton.tsx`: working pip with MCP-health precedence
- Tests: `sessionServer` notifier (4 cases), `httpLifecycle.setSessionTier` (8 cases), `ToolbarAssistantButton` (5 cases), `mcpServer.adversarial` (11→12 cases), `HelpPanel` mock extensions

## Testing

- Unit tests cover the new IPC handler, MCP server notifier, `httpLifecycle.setSessionTier`, and `ToolbarAssistantButton` pip logic
- `HelpPanel` test mocks extended for `useWorktreeSelectionStore`, `mcpServer`, `git`, and `project`
- Typecheck clean; lint at 875-warning baseline (no new warnings); format clean; build clean