### PR TITLE
fix(release): include blockmap files in artifact upload and R2 sync

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -337,6 +337,7 @@ jobs:
             release/*.msix
             release/*.AppImage
             release/*.deb
+            release/*.blockmap
             release/*.yml
           retention-days: 7
           if-no-files-found: error
@@ -420,6 +421,7 @@ jobs:
             --include "*.msix" \
             --include "*.AppImage" \
             --include "*.deb" \
+            --include "*.blockmap" \
             --cache-control "public, max-age=31536000, immutable"
 
       - name: Upload metadata to R2


### PR DESCRIPTION
## Summary

- The release workflow was missing `.blockmap` files in two places: the artifact upload step and the R2 binary sync
- Added `release/*.blockmap` to the artifact upload path list and `--include "*.blockmap"` to the `aws s3 sync` allowlist so blockmaps ship alongside their parent artifacts
- Mirrors the pattern already in place in `nightly.yml`

Resolves #7570

## Changes

- `.github/workflows/release.yml`: add `release/*.blockmap` to the `Upload build artifacts` step and `--include "*.blockmap"` to the `Upload binaries to R2` step

## Testing

Without this fix, `latest-mac.yml` advertises `blockMapSize` for files that 404 on R2, causing electron-updater to silently fall back to full downloads on every macOS update. The nightly workflow already includes blockmaps using the same patterns, so this brings release into parity.