### PR TITLE
fix(telemetry): bump Sentry maxBreadcrumbs to 250 in main and renderer

### DIFF
--- a/electron/services/TelemetryService.ts
+++ b/electron/services/TelemetryService.ts
@@ -234,6 +234,10 @@ export async function initializeTelemetry(): Promise<void> {
         // against a future change silently narrowing the breadth limit.
         normalizeDepth: MAX_DEEP_SANITIZE_DEPTH,
         normalizeMaxBreadth: 1000,
+        // Raise the default 100-entry ring so high-frequency action dispatches
+        // (drag bursts, agent-state polls, file-watcher fanouts) don't rotate
+        // the crash-triggering breadcrumb out before flush. See #7575.
+        maxBreadcrumbs: 250,
         // Do not set `sampleRate` — it defaults to 1.0 (100% error capture). If
         // performance tracing is ever added, use `tracesSampleRate` instead.
         // The local `SentryEvent` interface is a narrower projection of the

--- a/electron/services/__tests__/TelemetryService.test.ts
+++ b/electron/services/__tests__/TelemetryService.test.ts
@@ -723,6 +723,9 @@ describe("initializeTelemetry", () => {
     // normalizeMaxBreadth is frozen at the current SDK default to insulate
     // against a future SDK change silently narrowing the breadth limit.
     expect(options.normalizeMaxBreadth).toBe(1000);
+    // maxBreadcrumbs raises the default 100-slot ring so a crash-triggering
+    // breadcrumb isn't rotated out by high-frequency action dispatches. See #7575.
+    expect(options.maxBreadcrumbs).toBe(250);
     process.env.SENTRY_DSN = original;
   });
 

--- a/src/utils/__tests__/rendererSentry.test.ts
+++ b/src/utils/__tests__/rendererSentry.test.ts
@@ -5,6 +5,7 @@ type SentryInit = {
   integrations?: unknown;
   beforeSend?: (event: unknown) => unknown;
   beforeBreadcrumb?: (breadcrumb: unknown) => unknown;
+  maxBreadcrumbs?: number;
 };
 
 const sentryInit = vi.fn<(opts: SentryInit) => void>();
@@ -64,6 +65,16 @@ describe("rendererSentry", () => {
     expect(result).not.toContain("GlobalHandlers");
     expect(result).toContain("BrowserApiErrors");
     expect(result).toContain("Dedupe");
+  });
+
+  // #7575 — the renderer keeps its own breadcrumb ring buffer, so the bump must
+  // be applied here too or renderer breadcrumbs stay capped at the SDK default 100.
+  it("passes maxBreadcrumbs: 250 to Sentry.init", async () => {
+    const mod = await import("../rendererSentry");
+    await mod.initRendererSentry();
+
+    const opts = sentryInit.mock.calls[0]![0];
+    expect(opts.maxBreadcrumbs).toBe(250);
   });
 
   it.each([

--- a/src/utils/rendererSentry.ts
+++ b/src/utils/rendererSentry.ts
@@ -53,6 +53,9 @@ export async function initRendererSentry(): Promise<void> {
       if (!consentState.hasSeenPrompt || consentState.level === "off") return null;
       return breadcrumb;
     },
+    // Match the main-process ring size — renderer breadcrumbs merge into
+    // crash payloads via IPC, but each process keeps its own buffer. See #7575.
+    maxBreadcrumbs: 250,
   });
 
   consentUnsubscribe?.();


### PR DESCRIPTION
## Summary

- The default `maxBreadcrumbs` of 100 is too low for our action dispatch volume. High-frequency surfaces like drag, agent-state polls, and file-watcher fanouts can rotate the breadcrumb that triggered a crash out of the ring before the event flushes, leaving reports without useful context.
- Bumps `maxBreadcrumbs` to 250 in both the main (`TelemetryService`) and renderer (`rendererSentry`) `Sentry.init` calls, alongside the existing `normalizeDepth` and `normalizeMaxBreadth` overrides.
- Per-event payload stays well within Sentry's limits.

Resolves #7575

## Changes

- `electron/services/TelemetryService.ts` — add `maxBreadcrumbs: 250` to main process `Sentry.init`
- `src/utils/rendererSentry.ts` — add `maxBreadcrumbs: 250` to renderer `Sentry.init`
- Tests added for both init paths

## Testing

95 specs pass. Both init paths covered by unit tests asserting `maxBreadcrumbs: 250` is forwarded to the SDK.