### PR TITLE
fix(avatar): replace bg-muted skeleton with bg-muted-foreground/20

### DIFF
--- a/src/components/ui/Avatar.tsx
+++ b/src/components/ui/Avatar.tsx
@@ -36,7 +36,7 @@ export function Avatar({ src, alt, title, className }: AvatarProps) {
             "absolute inset-0 rounded-full flex items-center justify-center",
             error
               ? "bg-muted-foreground/30 ring-2 ring-inset ring-muted-foreground/50"
-              : "bg-muted animate-pulse-delayed"
+              : "bg-muted-foreground/20 animate-pulse-delayed"
           )}
         >
           {error && (

--- a/src/components/ui/__tests__/Avatar.test.tsx
+++ b/src/components/ui/__tests__/Avatar.test.tsx
@@ -22,6 +22,10 @@ describe("Avatar", () => {
     expect(img!.style.opacity).toBe("0");
     const skeleton = container.querySelector(".animate-pulse-delayed");
     expect(skeleton).toBeTruthy();
+    // Regression guard for #7572: bg-muted resolves to the panel surface
+    // color, making the placeholder invisible against the dropdown row.
+    expect(skeleton!.className).toContain("bg-muted-foreground/20");
+    expect(skeleton!.className).not.toMatch(/(?:^|\s)bg-muted(?:\s|$)/);
   });
 
   it("shows skeleton when complete is true but naturalWidth is 0", () => {


### PR DESCRIPTION
## Summary

- `bg-muted` on the `Avatar` loading skeleton resolved to `--theme-surface-panel` — the same color as the GitHub dropdown row background — making the placeholder completely invisible while the image loads
- Replaced with `bg-muted-foreground/20`: mid-grey at 20% alpha, which is naturally theme-adaptive across all 14 built-in themes
- `animate-pulse-delayed` is preserved (400ms Doherty gate intentional); loading at `/20` stays softer than the error state at `/30` to keep the semantic hierarchy intact

Resolves #7572

## Changes

- `src/components/ui/Avatar.tsx`: `bg-muted` → `bg-muted-foreground/20` on the loading skeleton
- `src/components/ui/__tests__/Avatar.test.tsx`: regression guard asserting the correct class is present

## Testing

- Verified visually across light and dark themes — placeholder is now clearly visible against the dropdown row background
- Regression guard test added to prevent a silent revert to the invisible state