### PR TITLE
ci(release): verify macOS notarization staple after build

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -193,6 +193,29 @@ jobs:
           fi
           npx electron-builder --config electron-builder.config.cjs --publish always -c.buildDependenciesFromSource=true $EXTRA_ARGS
 
+      - name: Verify macOS notarization staple
+        if: startsWith(matrix.os, 'macos') && inputs.skip_notarization != 'true'
+        shell: bash
+        run: |
+          set -euo pipefail
+          apps=(
+            "release/mac-arm64/Daintree.app"
+            "release/mac-x64/Daintree.app"
+            "release/mac-universal/Daintree.app"
+          )
+          for app in "${apps[@]}"; do
+            if [[ ! -d "$app" ]]; then
+              echo "::error::Missing expected macOS app bundle: $app"
+              exit 1
+            fi
+            echo "--- codesign: $app"
+            codesign --verify --deep --strict --verbose=4 "$app"
+            echo "--- stapler validate: $app"
+            xcrun stapler validate "$app"
+            echo "--- spctl (diagnostic only): $app"
+            spctl --assess --type execute --verbose --ignore-cache --no-cache "$app" || true
+          done
+
       - name: Build
         if: ${{ !startsWith(matrix.os, 'macos') }}
         shell: bash

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -198,9 +198,11 @@ jobs:
         shell: bash
         run: |
           set -euo pipefail
+          # x64 has no arch suffix because electron-builder treats it as the default arch
+          # (builder-util getArchSuffix returns "" for the default); arm64 and universal do.
           apps=(
             "release/mac-arm64/Daintree.app"
-            "release/mac-x64/Daintree.app"
+            "release/mac/Daintree.app"
             "release/mac-universal/Daintree.app"
           )
           for app in "${apps[@]}"; do


### PR DESCRIPTION
## Summary

- Adds a step to `.github/workflows/release.yml` that runs after the macOS build and validates that notarization actually completed — `codesign --verify` + `xcrun stapler validate` across all three `.app` bundles (arm64, x64, universal). Hard-fails on any missing bundle, codesign failure, or stapler validation failure.
- `spctl --assess` output is logged diagnostically only (`|| true`) — known CI false-positive because built artifacts don't carry the quarantine xattr.
- Guarded by the existing `skip_notarization` input so the escape hatch still works if Apple's notary service is degraded.
- Fixed a path bug caught during review: the x64 bundle path was wrong (`release/mac-arm64` instead of `release/mac`) — corrected to `release/mac/Daintree.app`.

Resolves #7574

## Changes

- `.github/workflows/release.yml`: new inline shell step "Verify macOS notarization staple" inserted between the macOS build step and the cross-platform build step (+25 / -1)

## Testing

- YAML structure verified; `if` guard and path expressions confirmed against electron-builder's output layout.
- Existing `skip_notarization` input correctly short-circuits the new step.
- No JS/TS changes; typecheck, lint, and format all pass.