### PR TITLE
chore(crash-recovery): route writes through canonical atomic helper

### DIFF
--- a/electron/services/CrashRecoveryService.ts
+++ b/electron/services/CrashRecoveryService.ts
@@ -13,6 +13,7 @@ import { store, windowStatesStore } from "../store.js";
 import { isGpuDisabledByFlag } from "./GpuCrashMonitorService.js";
 import { getSystemSleepService } from "./SystemSleepService.js";
 import { getActionBreadcrumbService } from "./ActionBreadcrumbService.js";
+import { resilientAtomicWriteFileSync } from "../utils/fs.js";
 
 const MAX_CRASH_LOGS = 10;
 const MARKER_FILENAME = "running.lock";
@@ -85,7 +86,7 @@ export class CrashRecoveryService {
 
       const entry = this.buildCrashEntry(error);
       const logPath = path.join(this.crashesDir, `crash-${entry.id}.json`);
-      this.atomicWrite(logPath, JSON.stringify(entry, null, 2));
+      resilientAtomicWriteFileSync(logPath, JSON.stringify(entry, null, 2), "utf-8");
       this.writeMarker(entry);
       this.pruneOldLogs();
       console.log("[CrashRecovery] Crash recorded:", logPath);
@@ -163,7 +164,7 @@ export class CrashRecoveryService {
       fs.mkdirSync(backupDir, { recursive: true });
 
       const snapshot = this.captureSessionSnapshot();
-      this.atomicWrite(this.backupPath, JSON.stringify(snapshot, null, 2));
+      resilientAtomicWriteFileSync(this.backupPath, JSON.stringify(snapshot, null, 2), "utf-8");
     } catch (err) {
       console.error("[CrashRecovery] Failed to take backup:", err);
     }
@@ -355,7 +356,7 @@ export class CrashRecoveryService {
           ? path.join(this.crashesDir, `crash-${crashEntry.id}.json`)
           : undefined,
       };
-      this.atomicWrite(this.markerPath, JSON.stringify(marker));
+      resilientAtomicWriteFileSync(this.markerPath, JSON.stringify(marker), "utf-8");
     } catch (err) {
       console.error("[CrashRecovery] Failed to write marker:", err);
     }
@@ -557,23 +558,6 @@ export class CrashRecoveryService {
       }
     } catch (err) {
       console.error("[CrashRecovery] Failed to prune logs:", err);
-    }
-  }
-
-  private atomicWrite(targetPath: string, data: string): void {
-    const tmpPath = `${targetPath}.${Date.now()}.tmp`;
-    try {
-      fs.writeFileSync(tmpPath, data, { encoding: "utf8", flush: true } as Parameters<
-        typeof fs.writeFileSync
-      >[2]);
-      fs.renameSync(tmpPath, targetPath);
-    } catch (err) {
-      try {
-        fs.unlinkSync(tmpPath);
-      } catch {
-        // ignore
-      }
-      throw err;
     }
   }
 }

--- a/electron/services/__tests__/CrashRecoveryService.adversarial.test.ts
+++ b/electron/services/__tests__/CrashRecoveryService.adversarial.test.ts
@@ -23,6 +23,12 @@ const browserWindowMock = vi.hoisted(() => ({
   getAllWindows: vi.fn(() => [{}]),
 }));
 
+const utilsMock = vi.hoisted(() => ({
+  resilientAtomicWriteFileSync: vi.fn(),
+}));
+
+vi.mock("../../utils/fs.js", () => utilsMock);
+
 vi.mock("../../store.js", () => ({
   store: storeMock,
   windowStatesStore: windowStatesStoreMock,
@@ -81,6 +87,11 @@ describe("CrashRecoveryService adversarial", () => {
       return undefined;
     });
     storeMock.set.mockImplementation(() => {});
+    utilsMock.resilientAtomicWriteFileSync.mockImplementation(
+      (fp: string, data: string, enc?: BufferEncoding) => {
+        fs.writeFileSync(fp, data, enc ?? "utf-8");
+      }
+    );
     vi.spyOn(console, "log").mockImplementation(() => {});
     vi.spyOn(console, "warn").mockImplementation(() => {});
     vi.spyOn(console, "error").mockImplementation(() => {});

--- a/electron/services/__tests__/CrashRecoveryService.test.ts
+++ b/electron/services/__tests__/CrashRecoveryService.test.ts
@@ -19,6 +19,12 @@ const appMock = vi.hoisted(() => ({
   isPackaged: false as boolean,
 }));
 
+const utilsMock = vi.hoisted(() => ({
+  resilientAtomicWriteFileSync: vi.fn(),
+}));
+
+vi.mock("../../utils/fs.js", () => utilsMock);
+
 vi.mock("../../store.js", () => ({
   store: storeMock,
   windowStatesStore: windowStatesStoreMock,
@@ -63,6 +69,11 @@ describe("CrashRecoveryService", () => {
     appMock.isPackaged = false;
     storeMock.get.mockReturnValue({ autoRestoreOnCrash: false });
     storeMock.set.mockImplementation(() => {});
+    utilsMock.resilientAtomicWriteFileSync.mockImplementation(
+      (fp: string, data: string, enc?: BufferEncoding) => {
+        fs.writeFileSync(fp, data, enc ?? "utf-8");
+      }
+    );
     vi.spyOn(console, "log").mockImplementation(() => {});
     vi.spyOn(console, "warn").mockImplementation(() => {});
     vi.spyOn(console, "error").mockImplementation(() => {});
@@ -995,6 +1006,55 @@ describe("CrashRecoveryService", () => {
       svc.cleanupOnExit();
 
       expect(svc.restoreBackup()).toBe(false);
+    });
+  });
+
+  describe("atomic write routing", () => {
+    it("routes initialize() marker write through resilientAtomicWriteFileSync", () => {
+      const svc = makeService();
+      svc.initialize();
+
+      const markerPath = path.join(userData, "running.lock");
+      expect(utilsMock.resilientAtomicWriteFileSync).toHaveBeenCalledWith(
+        markerPath,
+        expect.any(String),
+        "utf-8"
+      );
+    });
+
+    it("routes recordCrash() log and marker rewrite through resilientAtomicWriteFileSync", () => {
+      const svc = makeService();
+      svc.initialize();
+      utilsMock.resilientAtomicWriteFileSync.mockClear();
+
+      svc.recordCrash(new Error("boom"));
+
+      const markerPath = path.join(userData, "running.lock");
+      const calls = utilsMock.resilientAtomicWriteFileSync.mock.calls;
+      const crashLogCalls = calls.filter(([fp]) =>
+        String(fp).startsWith(path.join(userData, "crashes", "crash-"))
+      );
+      const markerCalls = calls.filter(([fp]) => fp === markerPath);
+
+      expect(crashLogCalls).toHaveLength(1);
+      expect(markerCalls).toHaveLength(1);
+      expect(crashLogCalls[0][2]).toBe("utf-8");
+      expect(markerCalls[0][2]).toBe("utf-8");
+    });
+
+    it("routes takeBackup() through resilientAtomicWriteFileSync", () => {
+      const svc = makeService();
+      svc.initialize();
+      utilsMock.resilientAtomicWriteFileSync.mockClear();
+
+      svc.takeBackup();
+
+      const backupPath = path.join(userData, "backups", "session-state.json");
+      expect(utilsMock.resilientAtomicWriteFileSync).toHaveBeenCalledWith(
+        backupPath,
+        expect.any(String),
+        "utf-8"
+      );
     });
   });
 });


### PR DESCRIPTION
## Summary

- Removes the private `atomicWrite` method in `CrashRecoveryService` and routes all four write sites through the canonical `resilientAtomicWriteFileSync` helper from `electron/utils/fs.ts`
- Picks up three durability improvements automatically: parent-directory fsync after rename, collision-safe temp suffix (`Date.now()` + random hex tail), and `stubborn-fs` retry on transient `EPERM`/`EBUSY`/`EACCES`
- Wires the `utilsMock` passthrough into both test suites following the `CrashLoopGuardService.test.ts` pattern, and adds spy-assertion tests covering all write paths (init marker, `recordCrash` log + marker rewrite, backup tick)

Resolves #7564

## Changes

- `electron/services/CrashRecoveryService.ts` — drop 16-line inline `atomicWrite`, replace 3 call sites with `resilientAtomicWriteFileSync`
- `electron/services/__tests__/CrashRecoveryService.test.ts` — `utilsMock` passthrough + new `atomic write routing` describe block (3 spy tests)
- `electron/services/__tests__/CrashRecoveryService.adversarial.test.ts` — `utilsMock` passthrough

## Testing

All 89 tests across `CrashRecoveryService.test.ts`, `CrashRecoveryService.adversarial.test.ts`, and `CrashLoopGuardService.test.ts` pass. Full `npm run check` clean (typecheck, lint, format, build).