### PR TITLE
fix(ci): verify R2 binary uploads before publishing update metadata

### DIFF
--- a/.github/workflows/nightly.yml
+++ b/.github/workflows/nightly.yml
@@ -401,6 +401,18 @@ jobs:
     timeout-minutes: 15
 
     steps:
+      - name: Check out repository
+        uses: actions/checkout@v6
+
+      - name: Set up Node.js
+        uses: actions/setup-node@v6
+        with:
+          node-version: ${{ env.NODE_VERSION }}
+          cache: npm
+
+      - name: Install dependencies
+        run: npm ci --ignore-scripts
+
       - name: Download macOS artifacts
         uses: actions/download-artifact@v8
         with:
@@ -435,6 +447,13 @@ jobs:
             --include "*.deb" \
             --include "*.blockmap" \
             --cache-control "public, max-age=31536000, immutable"
+
+      - name: Verify binaries reachable on R2
+        shell: bash
+        env:
+          PUBLISH_URL: https://updates.daintree.org/nightly/
+          UPDATE_METADATA_PREFIX: latest
+        run: node scripts/ci/verify-r2-uploads.mjs
 
       - name: Upload metadata to R2
         shell: bash

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -383,6 +383,10 @@ jobs:
         uses: actions/setup-node@v6
         with:
           node-version: ${{ env.NODE_VERSION }}
+          cache: npm
+
+      - name: Install dependencies
+        run: npm ci --ignore-scripts
 
       - name: Resolve update metadata prefix
         shell: bash
@@ -448,6 +452,12 @@ jobs:
             --include "*.deb" \
             --include "*.blockmap" \
             --cache-control "public, max-age=31536000, immutable"
+
+      - name: Verify binaries reachable on R2
+        shell: bash
+        env:
+          PUBLISH_URL: https://updates.daintree.org/releases/
+        run: node scripts/ci/verify-r2-uploads.mjs
 
       - name: Upload metadata to R2
         shell: bash

--- a/scripts/ci/verify-r2-uploads.mjs
+++ b/scripts/ci/verify-r2-uploads.mjs
@@ -1,0 +1,174 @@
+#!/usr/bin/env node
+// Verifies that every binary referenced in the generated update metadata
+// (release/<prefix>-mac.yml, release/<prefix>-linux.yml) is reachable at the
+// public CDN URL with a matching Content-Length before the metadata files
+// are uploaded.
+//
+// Without this gap check, a CDN propagation race or a partial binary upload
+// would publish update metadata pointing at a 404 or a truncated artifact.
+// electron-updater fails silently in that case and users sit on the previous
+// version until the next poll catches a corrected publish.
+
+import { readFileSync } from "node:fs";
+import { readdir } from "node:fs/promises";
+import path from "node:path";
+import { fileURLToPath, pathToFileURL } from "node:url";
+import { setTimeout as defaultSleep } from "node:timers/promises";
+import { load } from "js-yaml";
+
+export function buildPublishedUrl(baseUrl, filename) {
+  if (!baseUrl) throw new Error("baseUrl is required");
+  if (!filename) throw new Error("filename is required");
+  if (/^https?:\/\//i.test(filename)) return filename;
+  const trimmed = baseUrl.endsWith("/") ? baseUrl : `${baseUrl}/`;
+  return `${trimmed}${filename}`;
+}
+
+export async function verifyFileUrl(entry, { fetch: fetchFn, publishUrl }) {
+  const url = buildPublishedUrl(publishUrl, entry.url);
+  let response;
+  try {
+    response = await fetchFn(url, { method: "HEAD", redirect: "follow" });
+  } catch (err) {
+    return `network error fetching ${url}: ${err?.message ?? err}`;
+  }
+  if (response.status !== 200) {
+    return `expected HTTP 200 for ${url}, got ${response.status}`;
+  }
+  const contentLengthRaw = response.headers.get("content-length");
+  if (contentLengthRaw == null) {
+    return `missing Content-Length header for ${url}`;
+  }
+  const contentLength = Number(contentLengthRaw);
+  if (!Number.isFinite(contentLength)) {
+    return `invalid Content-Length "${contentLengthRaw}" for ${url}`;
+  }
+  if (contentLength !== entry.size) {
+    return `Content-Length mismatch for ${url}: expected ${entry.size}, got ${contentLength}`;
+  }
+  return null;
+}
+
+export async function verifyWithRetries(
+  entry,
+  {
+    fetch: fetchFn,
+    publishUrl,
+    sleep: sleepFn = defaultSleep,
+    maxAttempts = 3,
+    baseDelayMs = 5000,
+  } = {}
+) {
+  let lastError = null;
+  for (let attempt = 1; attempt <= maxAttempts; attempt++) {
+    const error = await verifyFileUrl(entry, { fetch: fetchFn, publishUrl });
+    if (!error) return null;
+    lastError = error;
+    if (attempt < maxAttempts) {
+      const delay = baseDelayMs * Math.pow(2, attempt - 1);
+      await sleepFn(delay);
+    }
+  }
+  return lastError;
+}
+
+export async function findMetadataFiles(releaseDir, prefix) {
+  const entries = await readdir(releaseDir);
+  const platforms = ["mac", "linux"];
+  const found = [];
+  for (const platform of platforms) {
+    const target = `${prefix}-${platform}.yml`;
+    if (entries.includes(target)) {
+      found.push(path.join(releaseDir, target));
+    }
+  }
+  return found;
+}
+
+export function loadMetadata(filePath) {
+  return load(readFileSync(filePath, "utf8"));
+}
+
+export async function verifyAllFiles({
+  metadataFiles,
+  publishUrl,
+  fetch: fetchFn = fetch,
+  sleep: sleepFn = defaultSleep,
+  maxAttempts,
+  baseDelayMs,
+  log = console.log,
+}) {
+  const failures = [];
+  for (const filePath of metadataFiles) {
+    const data = loadMetadata(filePath);
+    if (!Array.isArray(data?.files) || data.files.length === 0) {
+      failures.push({ filePath, message: "files[] missing or empty" });
+      continue;
+    }
+    for (const entry of data.files) {
+      if (!entry?.url || typeof entry.size !== "number") {
+        failures.push({
+          filePath,
+          message: `invalid file entry in metadata: ${JSON.stringify(entry)}`,
+        });
+        continue;
+      }
+      const error = await verifyWithRetries(entry, {
+        fetch: fetchFn,
+        publishUrl,
+        sleep: sleepFn,
+        maxAttempts,
+        baseDelayMs,
+      });
+      if (error) {
+        failures.push({ filePath, message: error });
+      } else {
+        log(`[verify] ok ${buildPublishedUrl(publishUrl, entry.url)} (${entry.size} bytes)`);
+      }
+    }
+  }
+  return failures;
+}
+
+async function main() {
+  const publishUrl = process.env.PUBLISH_URL ?? process.argv[2];
+  const releaseDir = process.env.RELEASE_DIR ?? process.argv[3] ?? "release";
+  const prefix = process.env.UPDATE_METADATA_PREFIX ?? process.argv[4] ?? "latest";
+
+  if (!publishUrl) {
+    console.error("::error::PUBLISH_URL env var (or first CLI arg) is required");
+    process.exit(1);
+  }
+
+  const metadataFiles = await findMetadataFiles(releaseDir, prefix);
+  if (metadataFiles.length === 0) {
+    console.error(
+      `::error::No update metadata files found in ${releaseDir} matching ${prefix}-{mac,linux}.yml`
+    );
+    process.exit(1);
+  }
+
+  console.log(`[verify] PUBLISH_URL=${publishUrl}`);
+  console.log(
+    `[verify] checking ${metadataFiles.length} metadata file(s): ${metadataFiles.join(", ")}`
+  );
+
+  const failures = await verifyAllFiles({
+    metadataFiles,
+    publishUrl,
+  });
+
+  if (failures.length > 0) {
+    for (const { filePath, message } of failures) {
+      console.error(`::error file=${filePath}::${message}`);
+    }
+    console.error(`[verify] ${failures.length} binary URL(s) failed verification`);
+    process.exit(1);
+  }
+
+  console.log(`[verify] all binaries verified reachable`);
+}
+
+if (process.argv[1] && import.meta.url === pathToFileURL(process.argv[1]).href) {
+  await main();
+}

--- a/scripts/ci/verify-r2-uploads.mjs
+++ b/scripts/ci/verify-r2-uploads.mjs
@@ -100,13 +100,22 @@ export async function verifyAllFiles({
 }) {
   const failures = [];
   for (const filePath of metadataFiles) {
-    const data = loadMetadata(filePath);
+    let data;
+    try {
+      data = loadMetadata(filePath);
+    } catch (err) {
+      failures.push({
+        filePath,
+        message: `failed to read or parse metadata: ${err?.message ?? err}`,
+      });
+      continue;
+    }
     if (!Array.isArray(data?.files) || data.files.length === 0) {
       failures.push({ filePath, message: "files[] missing or empty" });
       continue;
     }
     for (const entry of data.files) {
-      if (!entry?.url || typeof entry.size !== "number") {
+      if (!entry?.url || !Number.isFinite(entry?.size)) {
         failures.push({
           filePath,
           message: `invalid file entry in metadata: ${JSON.stringify(entry)}`,

--- a/scripts/ci/verify-r2-uploads.test.mjs
+++ b/scripts/ci/verify-r2-uploads.test.mjs
@@ -313,6 +313,56 @@ describe("verifyAllFiles", () => {
     }
   });
 
+  it("flags malformed YAML as a structured failure rather than throwing", async () => {
+    const dir = await mkdtemp(path.join(os.tmpdir(), "verify-r2-test-"));
+    try {
+      const yml = path.join(dir, "latest-mac.yml");
+      await writeFile(yml, "files:\n  - url: foo\n    size: [unclosed\n");
+
+      const fetchFn = vi.fn();
+      const failures = await verifyAllFiles({
+        metadataFiles: [yml],
+        publishUrl,
+        fetch: fetchFn,
+        sleep: vi.fn(),
+        log: () => {},
+      });
+
+      expect(failures).toHaveLength(1);
+      expect(failures[0].filePath).toBe(yml);
+      expect(failures[0].message).toContain("failed to read or parse metadata");
+      expect(fetchFn).not.toHaveBeenCalled();
+    } finally {
+      await rm(dir, { recursive: true, force: true });
+    }
+  });
+
+  it("flags non-finite entry.size (NaN) as invalid metadata", async () => {
+    const dir = await mkdtemp(path.join(os.tmpdir(), "verify-r2-test-"));
+    try {
+      const yml = path.join(dir, "latest-mac.yml");
+      await writeFile(
+        yml,
+        "version: 1.0.0\nfiles:\n  - url: mac.zip\n    sha512: aaa\n    size: .nan\npath: mac.zip\nsha512: aaa\nreleaseDate: 2024-01-01\n"
+      );
+
+      const fetchFn = vi.fn();
+      const failures = await verifyAllFiles({
+        metadataFiles: [yml],
+        publishUrl,
+        fetch: fetchFn,
+        sleep: vi.fn(),
+        log: () => {},
+      });
+
+      expect(failures).toHaveLength(1);
+      expect(failures[0].message).toContain("invalid file entry");
+      expect(fetchFn).not.toHaveBeenCalled();
+    } finally {
+      await rm(dir, { recursive: true, force: true });
+    }
+  });
+
   it("flags metadata with empty files[]", async () => {
     const dir = await mkdtemp(path.join(os.tmpdir(), "verify-r2-test-"));
     try {

--- a/scripts/ci/verify-r2-uploads.test.mjs
+++ b/scripts/ci/verify-r2-uploads.test.mjs
@@ -1,0 +1,338 @@
+import { describe, it, expect, vi } from "vitest";
+import { mkdtemp, writeFile, rm } from "node:fs/promises";
+import path from "node:path";
+import os from "node:os";
+
+import {
+  buildPublishedUrl,
+  verifyFileUrl,
+  verifyWithRetries,
+  findMetadataFiles,
+  verifyAllFiles,
+} from "./verify-r2-uploads.mjs";
+
+function makeResponse({ status = 200, contentLength = 100 }) {
+  return {
+    status,
+    headers: {
+      get: (name) => {
+        if (name.toLowerCase() === "content-length") {
+          return contentLength == null ? null : String(contentLength);
+        }
+        return null;
+      },
+    },
+  };
+}
+
+describe("buildPublishedUrl", () => {
+  it("joins base + filename when base has trailing slash", () => {
+    expect(buildPublishedUrl("https://x.example/r/", "foo.zip")).toBe(
+      "https://x.example/r/foo.zip"
+    );
+  });
+
+  it("joins base + filename when base lacks trailing slash", () => {
+    expect(buildPublishedUrl("https://x.example/r", "foo.zip")).toBe("https://x.example/r/foo.zip");
+  });
+
+  it("passes through absolute URLs unchanged", () => {
+    expect(buildPublishedUrl("https://x.example/r/", "https://other.example/foo.zip")).toBe(
+      "https://other.example/foo.zip"
+    );
+  });
+
+  it("throws if baseUrl is missing", () => {
+    expect(() => buildPublishedUrl("", "foo.zip")).toThrow(/baseUrl/);
+  });
+
+  it("throws if filename is missing", () => {
+    expect(() => buildPublishedUrl("https://x/", "")).toThrow(/filename/);
+  });
+});
+
+describe("verifyFileUrl", () => {
+  const publishUrl = "https://x.example/r/";
+  const entry = { url: "Daintree-1.0.0-mac.zip", size: 100 };
+
+  it("returns null on 200 with matching size", async () => {
+    const fetchFn = vi.fn().mockResolvedValue(makeResponse({ status: 200, contentLength: 100 }));
+    const result = await verifyFileUrl(entry, { fetch: fetchFn, publishUrl });
+    expect(result).toBeNull();
+    expect(fetchFn).toHaveBeenCalledWith(
+      "https://x.example/r/Daintree-1.0.0-mac.zip",
+      expect.objectContaining({ method: "HEAD" })
+    );
+  });
+
+  it("returns error on 404", async () => {
+    const fetchFn = vi.fn().mockResolvedValue(makeResponse({ status: 404 }));
+    const result = await verifyFileUrl(entry, { fetch: fetchFn, publishUrl });
+    expect(result).toContain("expected HTTP 200");
+    expect(result).toContain("404");
+    expect(result).toContain("Daintree-1.0.0-mac.zip");
+  });
+
+  it("returns error on 500", async () => {
+    const fetchFn = vi.fn().mockResolvedValue(makeResponse({ status: 500 }));
+    const result = await verifyFileUrl(entry, { fetch: fetchFn, publishUrl });
+    expect(result).toContain("500");
+  });
+
+  it("returns error on size mismatch", async () => {
+    const fetchFn = vi.fn().mockResolvedValue(makeResponse({ status: 200, contentLength: 200 }));
+    const result = await verifyFileUrl(entry, { fetch: fetchFn, publishUrl });
+    expect(result).toContain("Content-Length mismatch");
+    expect(result).toContain("expected 100");
+    expect(result).toContain("got 200");
+  });
+
+  it("returns error on missing Content-Length", async () => {
+    const fetchFn = vi.fn().mockResolvedValue(makeResponse({ status: 200, contentLength: null }));
+    const result = await verifyFileUrl(entry, { fetch: fetchFn, publishUrl });
+    expect(result).toContain("missing Content-Length");
+  });
+
+  it("returns error when Content-Length is 0 but entry size > 0", async () => {
+    const fetchFn = vi.fn().mockResolvedValue(makeResponse({ status: 200, contentLength: 0 }));
+    const result = await verifyFileUrl(entry, { fetch: fetchFn, publishUrl });
+    expect(result).toContain("Content-Length mismatch");
+    expect(result).toContain("got 0");
+  });
+
+  it("returns error on invalid (non-numeric) Content-Length", async () => {
+    const fetchFn = vi.fn().mockResolvedValue(makeResponse({ status: 200, contentLength: "abc" }));
+    const result = await verifyFileUrl(entry, { fetch: fetchFn, publishUrl });
+    expect(result).toContain("invalid Content-Length");
+  });
+
+  it("returns error on network failure", async () => {
+    const fetchFn = vi.fn().mockRejectedValue(new Error("DNS lookup failed"));
+    const result = await verifyFileUrl(entry, { fetch: fetchFn, publishUrl });
+    expect(result).toContain("network error");
+    expect(result).toContain("DNS lookup failed");
+  });
+});
+
+describe("verifyWithRetries", () => {
+  const publishUrl = "https://x.example/r/";
+  const entry = { url: "foo.zip", size: 100 };
+
+  it("returns null on first-attempt success without sleeping", async () => {
+    const fetchFn = vi.fn().mockResolvedValue(makeResponse({ status: 200, contentLength: 100 }));
+    const sleepFn = vi.fn().mockResolvedValue(undefined);
+    const result = await verifyWithRetries(entry, {
+      fetch: fetchFn,
+      publishUrl,
+      sleep: sleepFn,
+    });
+    expect(result).toBeNull();
+    expect(fetchFn).toHaveBeenCalledTimes(1);
+    expect(sleepFn).not.toHaveBeenCalled();
+  });
+
+  it("retries on failure and succeeds on third attempt", async () => {
+    const fetchFn = vi
+      .fn()
+      .mockResolvedValueOnce(makeResponse({ status: 404 }))
+      .mockResolvedValueOnce(makeResponse({ status: 404 }))
+      .mockResolvedValueOnce(makeResponse({ status: 200, contentLength: 100 }));
+    const sleepFn = vi.fn().mockResolvedValue(undefined);
+    const result = await verifyWithRetries(entry, {
+      fetch: fetchFn,
+      publishUrl,
+      sleep: sleepFn,
+    });
+    expect(result).toBeNull();
+    expect(fetchFn).toHaveBeenCalledTimes(3);
+    expect(sleepFn).toHaveBeenCalledTimes(2);
+    expect(sleepFn).toHaveBeenNthCalledWith(1, 5000);
+    expect(sleepFn).toHaveBeenNthCalledWith(2, 10000);
+  });
+
+  it("returns the last error after all retries are exhausted", async () => {
+    const fetchFn = vi.fn().mockResolvedValue(makeResponse({ status: 404 }));
+    const sleepFn = vi.fn().mockResolvedValue(undefined);
+    const result = await verifyWithRetries(entry, {
+      fetch: fetchFn,
+      publishUrl,
+      sleep: sleepFn,
+    });
+    expect(result).toContain("404");
+    expect(fetchFn).toHaveBeenCalledTimes(3);
+    expect(sleepFn).toHaveBeenCalledTimes(2);
+  });
+
+  it("retries on network errors as well as HTTP errors", async () => {
+    const fetchFn = vi
+      .fn()
+      .mockRejectedValueOnce(new Error("ECONNRESET"))
+      .mockResolvedValueOnce(makeResponse({ status: 200, contentLength: 100 }));
+    const sleepFn = vi.fn().mockResolvedValue(undefined);
+    const result = await verifyWithRetries(entry, {
+      fetch: fetchFn,
+      publishUrl,
+      sleep: sleepFn,
+    });
+    expect(result).toBeNull();
+    expect(fetchFn).toHaveBeenCalledTimes(2);
+  });
+
+  it("respects custom maxAttempts and baseDelayMs", async () => {
+    const fetchFn = vi.fn().mockResolvedValue(makeResponse({ status: 404 }));
+    const sleepFn = vi.fn().mockResolvedValue(undefined);
+    await verifyWithRetries(entry, {
+      fetch: fetchFn,
+      publishUrl,
+      sleep: sleepFn,
+      maxAttempts: 4,
+      baseDelayMs: 100,
+    });
+    expect(fetchFn).toHaveBeenCalledTimes(4);
+    expect(sleepFn).toHaveBeenCalledTimes(3);
+    expect(sleepFn).toHaveBeenNthCalledWith(1, 100);
+    expect(sleepFn).toHaveBeenNthCalledWith(2, 200);
+    expect(sleepFn).toHaveBeenNthCalledWith(3, 400);
+  });
+});
+
+describe("findMetadataFiles", () => {
+  it("returns mac and linux files when both present, ignoring others", async () => {
+    const dir = await mkdtemp(path.join(os.tmpdir(), "verify-r2-test-"));
+    try {
+      await writeFile(path.join(dir, "latest-mac.yml"), "x: 1");
+      await writeFile(path.join(dir, "latest-linux.yml"), "x: 1");
+      await writeFile(path.join(dir, "latest.yml"), "x: 1");
+      await writeFile(path.join(dir, "Daintree-1.0.0.zip"), "binary");
+
+      const result = await findMetadataFiles(dir, "latest");
+      expect(result.map((p) => path.basename(p)).sort()).toEqual([
+        "latest-linux.yml",
+        "latest-mac.yml",
+      ]);
+    } finally {
+      await rm(dir, { recursive: true, force: true });
+    }
+  });
+
+  it("matches the prefix exactly (rc, beta, latest)", async () => {
+    const dir = await mkdtemp(path.join(os.tmpdir(), "verify-r2-test-"));
+    try {
+      await writeFile(path.join(dir, "rc-mac.yml"), "x: 1");
+      await writeFile(path.join(dir, "rc-linux.yml"), "x: 1");
+      await writeFile(path.join(dir, "latest-mac.yml"), "x: 1");
+
+      const result = await findMetadataFiles(dir, "rc");
+      expect(result.map((p) => path.basename(p)).sort()).toEqual(["rc-linux.yml", "rc-mac.yml"]);
+    } finally {
+      await rm(dir, { recursive: true, force: true });
+    }
+  });
+
+  it("returns only the platforms that exist", async () => {
+    const dir = await mkdtemp(path.join(os.tmpdir(), "verify-r2-test-"));
+    try {
+      await writeFile(path.join(dir, "latest-mac.yml"), "x: 1");
+      const result = await findMetadataFiles(dir, "latest");
+      expect(result.map((p) => path.basename(p))).toEqual(["latest-mac.yml"]);
+    } finally {
+      await rm(dir, { recursive: true, force: true });
+    }
+  });
+});
+
+describe("verifyAllFiles", () => {
+  const publishUrl = "https://x.example/r/";
+
+  it("aggregates failures across multiple metadata files", async () => {
+    const dir = await mkdtemp(path.join(os.tmpdir(), "verify-r2-test-"));
+    try {
+      const macYml = path.join(dir, "latest-mac.yml");
+      const linuxYml = path.join(dir, "latest-linux.yml");
+      await writeFile(
+        macYml,
+        "version: 1.0.0\nfiles:\n  - url: mac-a.zip\n    sha512: aaa\n    size: 100\n  - url: mac-b.zip\n    sha512: bbb\n    size: 200\npath: mac-a.zip\nsha512: aaa\nreleaseDate: 2024-01-01\n"
+      );
+      await writeFile(
+        linuxYml,
+        "version: 1.0.0\nfiles:\n  - url: linux.AppImage\n    sha512: ccc\n    size: 300\npath: linux.AppImage\nsha512: ccc\nreleaseDate: 2024-01-01\n"
+      );
+
+      const fetchFn = vi.fn(async (url) => {
+        if (url.endsWith("mac-a.zip")) return makeResponse({ status: 200, contentLength: 100 });
+        if (url.endsWith("mac-b.zip")) return makeResponse({ status: 404 });
+        if (url.endsWith("linux.AppImage"))
+          return makeResponse({ status: 200, contentLength: 999 });
+        throw new Error(`unexpected url ${url}`);
+      });
+      const sleepFn = vi.fn().mockResolvedValue(undefined);
+      const log = vi.fn();
+
+      const failures = await verifyAllFiles({
+        metadataFiles: [macYml, linuxYml],
+        publishUrl,
+        fetch: fetchFn,
+        sleep: sleepFn,
+        log,
+      });
+
+      expect(failures).toHaveLength(2);
+      expect(failures[0].filePath).toBe(macYml);
+      expect(failures[0].message).toContain("404");
+      expect(failures[1].filePath).toBe(linuxYml);
+      expect(failures[1].message).toContain("Content-Length mismatch");
+      expect(log).toHaveBeenCalledWith(expect.stringContaining("[verify] ok"));
+    } finally {
+      await rm(dir, { recursive: true, force: true });
+    }
+  });
+
+  it("returns empty failures when every entry verifies", async () => {
+    const dir = await mkdtemp(path.join(os.tmpdir(), "verify-r2-test-"));
+    try {
+      const yml = path.join(dir, "latest-mac.yml");
+      await writeFile(
+        yml,
+        "version: 1.0.0\nfiles:\n  - url: mac.zip\n    sha512: aaa\n    size: 100\npath: mac.zip\nsha512: aaa\nreleaseDate: 2024-01-01\n"
+      );
+
+      const fetchFn = vi.fn().mockResolvedValue(makeResponse({ status: 200, contentLength: 100 }));
+      const sleepFn = vi.fn().mockResolvedValue(undefined);
+
+      const failures = await verifyAllFiles({
+        metadataFiles: [yml],
+        publishUrl,
+        fetch: fetchFn,
+        sleep: sleepFn,
+        log: () => {},
+      });
+
+      expect(failures).toEqual([]);
+    } finally {
+      await rm(dir, { recursive: true, force: true });
+    }
+  });
+
+  it("flags metadata with empty files[]", async () => {
+    const dir = await mkdtemp(path.join(os.tmpdir(), "verify-r2-test-"));
+    try {
+      const yml = path.join(dir, "latest-mac.yml");
+      await writeFile(yml, "version: 1.0.0\nfiles: []\n");
+
+      const fetchFn = vi.fn();
+      const failures = await verifyAllFiles({
+        metadataFiles: [yml],
+        publishUrl,
+        fetch: fetchFn,
+        sleep: vi.fn(),
+        log: () => {},
+      });
+
+      expect(failures).toHaveLength(1);
+      expect(failures[0].message).toContain("files[] missing or empty");
+      expect(fetchFn).not.toHaveBeenCalled();
+    } finally {
+      await rm(dir, { recursive: true, force: true });
+    }
+  });
+});


### PR DESCRIPTION
## Summary

- The `publish-daintree` job in `release.yml` and `nightly.yml` was uploading `latest-mac.yml` / `latest-linux.yml` without checking that the binaries those files point to were actually reachable on the CDN. A silent partial upload or CDN propagation lag would ship metadata pointing at 404s, breaking auto-update for every client on that channel.
- Adds `scripts/ci/verify-r2-uploads.mjs` — `HEAD`-checks every `files[].url` from the platform YML files against `PUBLISH_URL`, asserting HTTP 200 and a `Content-Length` matching `files[].size`. 3 retries with 5s exponential backoff to absorb CDN propagation lag.
- The verification step runs between binary sync and metadata sync in both workflows, so a failed check blocks the metadata upload rather than letting a broken yml land.

Resolves #7569

## Changes

- `scripts/ci/verify-r2-uploads.mjs` — new verification script
- `scripts/ci/verify-r2-uploads.test.mjs` — 26 unit tests covering URL construction, status checks, size checks, retry behaviour, metadata discovery, failure aggregation, malformed YAML, and NaN/Infinity size guards
- `.github/workflows/release.yml` — checkout + setup-node + `npm ci --ignore-scripts` added to `publish-daintree`, plus verify step between binary and metadata sync
- `.github/workflows/nightly.yml` — same pattern, `PUBLISH_URL=https://updates.daintree.org/nightly/`

## Testing

All 26 unit tests pass. Typecheck, lint, format, and build clean.