### PR TITLE
docs(security): document trust-boundary invariants in csp.ts and trustedRenderer.ts

### DIFF
--- a/shared/config/csp.ts
+++ b/shared/config/csp.ts
@@ -30,6 +30,11 @@ export const TRUSTED_TYPES_POLICY_NAME = "daintree-svg";
  *      at build time by the Vite plugin in vite.config.ts.
  *   2. `Content-Security-Policy` HTTP response header set by the main process
  *      via `webRequest.onHeadersReceived` on the persist:daintree session.
+ *
+ * Chromium 146 silently ignores `frame-ancestors`, `report-uri`, `report-to`,
+ * and `sandbox` when delivered via `<meta http-equiv>`. Those directives must
+ * appear on the HTTP response header only (layer 2 above) — adding them to
+ * the meta layer is a no-op and gives a false sense of coverage.
  */
 export function getDaintreeAppProdCSP(): string {
   return [

--- a/shared/config/csp.ts
+++ b/shared/config/csp.ts
@@ -31,10 +31,13 @@ export const TRUSTED_TYPES_POLICY_NAME = "daintree-svg";
  *   2. `Content-Security-Policy` HTTP response header set by the main process
  *      via `webRequest.onHeadersReceived` on the persist:daintree session.
  *
- * Chromium 146 silently ignores `frame-ancestors`, `report-uri`, `report-to`,
- * and `sandbox` when delivered via `<meta http-equiv>`. Those directives must
- * appear on the HTTP response header only (layer 2 above) — adding them to
- * the meta layer is a no-op and gives a false sense of coverage.
+ * Per the W3C CSP3 spec, `frame-ancestors`, `report-uri`, and `sandbox` are
+ * not supported when delivered via `<meta http-equiv>` — Chromium 146 drops
+ * them with a DevTools warning. Those directives must appear on the HTTP
+ * response header only (layer 2 above); adding them to the meta layer is a
+ * no-op and gives a false sense of coverage. `report-to` is technically
+ * honored in meta but its endpoint mapping requires the `Reporting-Endpoints`
+ * HTTP response header, so it is also effectively header-only.
  */
 export function getDaintreeAppProdCSP(): string {
   return [

--- a/shared/utils/trustedRenderer.ts
+++ b/shared/utils/trustedRenderer.ts
@@ -19,6 +19,21 @@ function getRendererOrigin(urlString: string): string | null {
   }
 }
 
+/**
+ * Returns true if the renderer URL belongs to a trusted origin
+ * (`app://daintree` in production; Vite dev-server origins in development).
+ *
+ * Trust is origin-scoped, not route-scoped: any path under `app://daintree`
+ * passes. The preload blocks contextBridge in sub-frames via a
+ * `window.top === window` guard, so `window.electron` is not directly exposed
+ * there. A same-origin sub-frame can still reach the parent's `window.electron`
+ * via `window.parent` (DOM same-origin access), and `event.senderFrame.url` on
+ * the resulting IPC call resolves to the trusted origin. Adding a route beyond
+ * `index.html` / `recovery.html` under `app://daintree/` therefore widens the
+ * effective IPC trust surface.
+ *
+ * For route-specific narrowing see {@link isRecoveryPageUrl}.
+ */
 export function isTrustedRendererUrl(urlString: string): boolean {
   const origin = getRendererOrigin(urlString);
   if (!origin) return false;

--- a/shared/utils/trustedRenderer.ts
+++ b/shared/utils/trustedRenderer.ts
@@ -24,11 +24,11 @@ function getRendererOrigin(urlString: string): string | null {
  * (`app://daintree` in production; Vite dev-server origins in development).
  *
  * Trust is origin-scoped, not route-scoped: any path under `app://daintree`
- * passes. The preload blocks contextBridge in sub-frames via a
- * `window.top === window` guard, so `window.electron` is not directly exposed
- * there. A same-origin sub-frame can still reach the parent's `window.electron`
- * via `window.parent` (DOM same-origin access), and `event.senderFrame.url` on
- * the resulting IPC call resolves to the trusted origin. Adding a route beyond
+ * passes. The preload guards `window.electron` exposure with
+ * `window.top === window` so it is not directly available in sub-frames, but a
+ * same-origin sub-frame can still reach the parent's `window.electron` via
+ * `window.parent` (DOM same-origin access), and `event.senderFrame.url` on the
+ * resulting IPC call resolves to the trusted origin. Adding a route beyond
  * `index.html` / `recovery.html` under `app://daintree/` therefore widens the
  * effective IPC trust surface.
  *


### PR DESCRIPTION
## Summary

- Adds JSDoc to `isTrustedRendererUrl` (`shared/utils/trustedRenderer.ts`) explaining origin-scoped trust, the sub-frame escalation path via `window.parent.electron`, and a pointer to `isRecoveryPageUrl` as the route-narrowing precedent
- Adds JSDoc to `getDaintreeAppProdCSP` (`shared/config/csp.ts`) listing the three directives silently ignored in `<meta http-equiv>` (`frame-ancestors`, `report-uri`, `sandbox`) and noting `report-to` is effectively header-only
- No runtime changes — documentation only

Resolves #7566

## Changes

- `shared/utils/trustedRenderer.ts`: 15 lines of JSDoc added
- `shared/config/csp.ts`: 8 lines of JSDoc added

## Testing

Typecheck, lint ratchet (steady at 875), format, and build all passed clean. Doc-only — no behavioural change to verify.