### PR TITLE
feat(scrubber): extend secretScrubber for modern token shapes

### DIFF
--- a/electron/utils/__tests__/secretScrubber.test.ts
+++ b/electron/utils/__tests__/secretScrubber.test.ts
@@ -360,6 +360,13 @@ describe("secretScrubber", () => {
         expected: `TOGETHER_API_KEY=${REDACTED} end`,
       },
       {
+        name: "together-api-key-trailing-dash",
+        // Body ending in `-` or `_` (non-word) must still redact — the lack of
+        // a trailing `\b` is what makes this work.
+        input: `TOGETHER_API_KEY=tgp_v1_${"A".repeat(42)}-`,
+        expected: `TOGETHER_API_KEY=${REDACTED}`,
+      },
+      {
         name: "resend-api-key",
         input: `RESEND_API_KEY=re_${"A".repeat(48)}`,
         expected: `RESEND_API_KEY=${REDACTED}`,
@@ -368,6 +375,12 @@ describe("secretScrubber", () => {
         name: "heroku-oauth-token",
         input: `HEROKU_API_KEY=HRKU-${"a".repeat(60)} end`,
         expected: `HEROKU_API_KEY=${REDACTED} end`,
+      },
+      {
+        name: "heroku-oauth-token-trailing-underscore",
+        // Body ending in `_` must still redact (no trailing `\b`).
+        input: `HEROKU_API_KEY=HRKU-${"a".repeat(59)}_`,
+        expected: `HEROKU_API_KEY=${REDACTED}`,
       },
       {
         name: "telegram-bot-token",
@@ -562,6 +575,13 @@ describe("secretScrubber", () => {
     it("does not flag hf_ as substring in ordinary text", () => {
       const ordinary = "The chef_example text here is not a secret key at all";
       expect(scrubSecrets(ordinary)).toBe(ordinary);
+    });
+
+    it("does not flag vcc_ as a Vercel token (not a real prefix)", () => {
+      // Vercel issues vcp_/vci_/vca_/vcr_/vck_ — `vcc_` is not a real prefix
+      // and the character class must reject it.
+      const fake = `vcc_${"A".repeat(32)}`;
+      expect(scrubSecrets(fake)).toBe(fake);
     });
 
     it("does not flag a bare timestamp:token shape without telegram context", () => {

--- a/electron/utils/__tests__/secretScrubber.test.ts
+++ b/electron/utils/__tests__/secretScrubber.test.ts
@@ -319,6 +319,71 @@ describe("secretScrubber", () => {
         input: `SLACK_SIGNING_SECRET=${"a".repeat(32)} end`,
         expected: `${REDACTED} end`,
       },
+      {
+        name: "vercel-vcp",
+        input: `VERCEL_TOKEN=vcp_${"A".repeat(32)} end`,
+        expected: `VERCEL_TOKEN=${REDACTED} end`,
+      },
+      {
+        name: "vercel-vci",
+        input: `VERCEL_TOKEN=vci_${"a".repeat(24)}`,
+        expected: `VERCEL_TOKEN=${REDACTED}`,
+      },
+      {
+        name: "vercel-vca",
+        input: `VERCEL_TOKEN=vca_${"Z".repeat(40)} next`,
+        expected: `VERCEL_TOKEN=${REDACTED} next`,
+      },
+      {
+        name: "vercel-vcr",
+        input: `VERCEL_TOKEN=vcr_${"0".repeat(36)}`,
+        expected: `VERCEL_TOKEN=${REDACTED}`,
+      },
+      {
+        name: "vercel-vck",
+        input: `VERCEL_TOKEN=vck_${"X".repeat(28)}`,
+        expected: `VERCEL_TOKEN=${REDACTED}`,
+      },
+      {
+        name: "perplexity-api-key",
+        input: `PPLX_API_KEY=pplx-${"a".repeat(48)} end`,
+        expected: `PPLX_API_KEY=${REDACTED} end`,
+      },
+      {
+        name: "xai-api-key",
+        input: `XAI_API_KEY=xai-${"A".repeat(80)}`,
+        expected: `XAI_API_KEY=${REDACTED}`,
+      },
+      {
+        name: "together-api-key",
+        input: `TOGETHER_API_KEY=tgp_v1_${"A".repeat(43)} end`,
+        expected: `TOGETHER_API_KEY=${REDACTED} end`,
+      },
+      {
+        name: "resend-api-key",
+        input: `RESEND_API_KEY=re_${"A".repeat(48)}`,
+        expected: `RESEND_API_KEY=${REDACTED}`,
+      },
+      {
+        name: "heroku-oauth-token",
+        input: `HEROKU_API_KEY=HRKU-${"a".repeat(60)} end`,
+        expected: `HEROKU_API_KEY=${REDACTED} end`,
+      },
+      {
+        name: "telegram-bot-token",
+        input: `TELEGRAM_BOT_TOKEN=1234567890:${"A".repeat(35)} end`,
+        expected: `${REDACTED} end`,
+      },
+      {
+        name: "datadog-api-key",
+        input: `DD_API_KEY=${"a".repeat(32)} next`,
+        expected: `${REDACTED} next`,
+      },
+      {
+        name: "datadog-app-key",
+        input: `DD_APP_KEY="${"f".repeat(40)}" next`,
+        expected: `${REDACTED} next`,
+      },
     ];
 
     for (const { name, input, expected } of positive) {
@@ -497,6 +562,25 @@ describe("secretScrubber", () => {
     it("does not flag hf_ as substring in ordinary text", () => {
       const ordinary = "The chef_example text here is not a secret key at all";
       expect(scrubSecrets(ordinary)).toBe(ordinary);
+    });
+
+    it("does not flag a bare timestamp:token shape without telegram context", () => {
+      // 10-digit Unix timestamp + colon + 35-char alphanumeric tail can appear
+      // in ordinary log lines; the telegram pattern's anchor must keep it safe.
+      const bare = `1700000000:${"A".repeat(35)}`;
+      expect(scrubSecrets(bare)).toBe(bare);
+    });
+
+    it("does not flag a bare 32-char hex without datadog context", () => {
+      // Plain MD5 hash — must remain visible without the DD_API_KEY anchor.
+      const md5 = `digest=${"a".repeat(32)}`;
+      expect(scrubSecrets(md5)).toBe(md5);
+    });
+
+    it("does not flag a bare 40-char hex without datadog context", () => {
+      // Plain SHA1 hash — must remain visible without the DD_APP_KEY anchor.
+      const sha1 = `commit=${"f".repeat(40)}`;
+      expect(scrubSecrets(sha1)).toBe(sha1);
     });
 
     it("redacts realistically-sized Atlassian token bodies fully", () => {

--- a/electron/utils/secretScrubber.ts
+++ b/electron/utils/secretScrubber.ts
@@ -265,6 +265,56 @@ export const PATTERNS: readonly SecretPattern[] = [
     replacement: "$1<redacted>@",
   },
   {
+    name: "vercel-token",
+    // Covers `vcp_` (personal), `vci_` (CI), `vca_` (account), `vcr_` (refresh), `vck_` (key).
+    regex: /\bvc[piackr]_[A-Za-z0-9]{24,40}\b/g,
+    replacement: REDACTED,
+  },
+  {
+    name: "perplexity-api-key",
+    regex: /\bpplx-[a-f0-9]{48}\b/g,
+    replacement: REDACTED,
+  },
+  {
+    name: "xai-api-key",
+    regex: /\bxai-[A-Za-z0-9]{80}\b/g,
+    replacement: REDACTED,
+  },
+  {
+    name: "together-api-key",
+    regex: /\btgp_v1_[A-Za-z0-9_-]{43}\b/g,
+    replacement: REDACTED,
+  },
+  {
+    name: "resend-api-key",
+    regex: /\bre_[A-Za-z0-9]{48}\b/g,
+    replacement: REDACTED,
+  },
+  {
+    name: "heroku-oauth-token",
+    regex: /\bHRKU-[A-Za-z0-9_-]{60}\b/g,
+    replacement: REDACTED,
+  },
+  {
+    name: "telegram-bot-token",
+    // A bare `[0-9]{8,12}:[A-Za-z0-9_-]{35}` would collide with Unix-timestamp +
+    // 35-char-alphanumeric strings in log lines, so this requires the surrounding
+    // key name as context — same precedent as `aws-secret-access-key` above.
+    regex:
+      /\btelegram(?:_bot)?_token\s{0,4}[:=]\s{0,4}[0-9]{8,12}:[A-Za-z0-9_-]{35}\b/gi,
+    replacement: REDACTED,
+  },
+  {
+    name: "datadog-key",
+    // A bare `{32,40}` lowercase-hex run is just an MD5 or SHA1 hash, so this
+    // requires the key name as context. Covers both DD_API_KEY (32 hex) and
+    // DD_APP_KEY (40 hex) in one pattern; no trailing `\b` because the closing
+    // `["']?` may be a non-word char (mirrors `aws-secret-access-key`).
+    regex:
+      /\b(?:DD_API_KEY|DD_APP_KEY|datadog_api_key|datadog_app_key)["']?\s{0,8}[:=]\s{0,8}["']?[a-f0-9]{32,40}["']?/gi,
+    replacement: REDACTED,
+  },
+  {
     name: "generic-key-fallback",
     // Last-resort fallback for `.env`-shaped lines using common API key names.
     // The 16-char minimum body excludes short numeric values like `MAX_TOKENS=8192`,

--- a/electron/utils/secretScrubber.ts
+++ b/electron/utils/secretScrubber.ts
@@ -267,7 +267,7 @@ export const PATTERNS: readonly SecretPattern[] = [
   {
     name: "vercel-token",
     // Covers `vcp_` (personal), `vci_` (CI), `vca_` (account), `vcr_` (refresh), `vck_` (key).
-    regex: /\bvc[piackr]_[A-Za-z0-9]{24,40}\b/g,
+    regex: /\bvc[piakr]_[A-Za-z0-9]{24,40}\b/g,
     replacement: REDACTED,
   },
   {
@@ -282,7 +282,9 @@ export const PATTERNS: readonly SecretPattern[] = [
   },
   {
     name: "together-api-key",
-    regex: /\btgp_v1_[A-Za-z0-9_-]{43}\b/g,
+    // No trailing `\b` because the body charset includes `-` and `_` (non-word
+    // chars), so a token ending in either would silently slip past a boundary.
+    regex: /\btgp_v1_[A-Za-z0-9_-]{43}/g,
     replacement: REDACTED,
   },
   {
@@ -292,7 +294,9 @@ export const PATTERNS: readonly SecretPattern[] = [
   },
   {
     name: "heroku-oauth-token",
-    regex: /\bHRKU-[A-Za-z0-9_-]{60}\b/g,
+    // No trailing `\b`: body charset includes `-` and `_` (non-word) so tokens
+    // ending in either would silently miss the boundary check.
+    regex: /\bHRKU-[A-Za-z0-9_-]{60}/g,
     replacement: REDACTED,
   },
   {

--- a/electron/utils/secretScrubber.ts
+++ b/electron/utils/secretScrubber.ts
@@ -304,8 +304,7 @@ export const PATTERNS: readonly SecretPattern[] = [
     // A bare `[0-9]{8,12}:[A-Za-z0-9_-]{35}` would collide with Unix-timestamp +
     // 35-char-alphanumeric strings in log lines, so this requires the surrounding
     // key name as context — same precedent as `aws-secret-access-key` above.
-    regex:
-      /\btelegram(?:_bot)?_token\s{0,4}[:=]\s{0,4}[0-9]{8,12}:[A-Za-z0-9_-]{35}\b/gi,
+    regex: /\btelegram(?:_bot)?_token\s{0,4}[:=]\s{0,4}[0-9]{8,12}:[A-Za-z0-9_-]{35}\b/gi,
     replacement: REDACTED,
   },
   {


### PR DESCRIPTION
## Summary

- Adds 8 new patterns to `electron/utils/secretScrubber.ts` covering token families that have slipped through since 2024: Vercel (`vc[piakr]_`), Perplexity (`pplx-`), xAI (`xai-`), Together AI (`tgp_v1_`), Resend (`re_`), Heroku (`HRKU-`), Telegram (context-anchored numeric:alpha), and Datadog (context-anchored hex keys).
- All patterns are inserted before the generic-key fallback so full-unit redaction takes precedence.
- `safe-regex2` ReDoS invariant holds across every new pattern; bounded quantifiers throughout, and Together AI / Heroku intentionally omit `\b` because their body charsets include `-` and `_`.

Resolves #7577

## Changes

- `electron/utils/secretScrubber.ts` — 8 new `SecretPattern` entries
- `electron/utils/__tests__/secretScrubber.test.ts` — 13 new positive cases (all 5 Vercel prefixes + 6 bare tokens + Telegram + 2 Datadog), 4 new negative cases (`vcc_` rejected, bare timestamp:token, bare MD5, bare SHA1)

## Testing

173 tests pass. The auto-generated `safe-regex2` check covers every new pattern. Negative cases confirm the patterns don't over-match on structurally similar but non-secret strings.