### PR TITLE
fix(errors): cap pendingErrors uniformly across renderer and main paths

### DIFF
--- a/electron/ipc/__tests__/errorHandlers.test.ts
+++ b/electron/ipc/__tests__/errorHandlers.test.ts
@@ -751,9 +751,14 @@ describe("errorHandlers", () => {
       const persistCalls = storeMock.store.set.mock.calls.filter(
         ([key]) => key === "pendingErrors"
       );
-      const lastPersisted = persistCalls[persistCalls.length - 1]?.[1] as Array<{ id: string }>;
+      const lastPersisted = persistCalls[persistCalls.length - 1]?.[1] as Array<{
+        id: string;
+        type: string;
+      }>;
       expect(lastPersisted).toHaveLength(50);
       expect(lastPersisted[0].id).toBe("seeded-1");
+      expect(lastPersisted[lastPersisted.length - 1].type).toBe("config");
+      expect(lastPersisted[lastPersisted.length - 1].id).not.toMatch(/^seeded-/);
     });
 
     it("preserves correlationId through buffer and flush", async () => {

--- a/electron/ipc/__tests__/errorHandlers.test.ts
+++ b/electron/ipc/__tests__/errorHandlers.test.ts
@@ -720,6 +720,42 @@ describe("errorHandlers", () => {
       );
     });
 
+    it("caps persisted pendingErrors at 50 when store already holds 50 entries", async () => {
+      const CHANNELS = await getChannels();
+      const { ConfigError } = await import("../../utils/errorTypes.js");
+
+      const seeded = Array.from({ length: 50 }, (_, i) => ({
+        id: `seeded-${i}`,
+        type: "config",
+        message: `seeded ${i}`,
+        timestamp: i,
+        source: "main-process",
+        isTransient: false,
+        dismissed: false,
+      }));
+      storeMock.store.get.mockReturnValue(seeded);
+      createMockWindow({ destroyed: true });
+
+      const spawn = vi.fn(() => {
+        throw new ConfigError("Bad config", { key: "config-key" });
+      });
+      registerErrorHandlers(null, createPtyClientMock(spawn));
+
+      const retryHandler = getInvokeHandler(CHANNELS.ERROR_RETRY);
+      await retryHandler({} as never, {
+        errorId: "e",
+        action: "terminal",
+        args: { id: "t", cwd: "/" },
+      }).catch(() => {});
+
+      const persistCalls = storeMock.store.set.mock.calls.filter(
+        ([key]) => key === "pendingErrors"
+      );
+      const lastPersisted = persistCalls[persistCalls.length - 1]?.[1] as Array<{ id: string }>;
+      expect(lastPersisted).toHaveLength(50);
+      expect(lastPersisted[0].id).toBe("seeded-1");
+    });
+
     it("preserves correlationId through buffer and flush", async () => {
       const CHANNELS = await getChannels();
       createMockWindow({ destroyed: true });

--- a/electron/ipc/errorHandlers.ts
+++ b/electron/ipc/errorHandlers.ts
@@ -17,6 +17,7 @@ import {
 } from "../utils/errorTypes.js";
 import { getGitRecoveryAction, getGitRecoveryHint } from "../../shared/utils/gitOperationErrors.js";
 import { store } from "../store.js";
+import { appendPendingError, MAX_PENDING_ERRORS } from "./pendingErrorsStore.js";
 import { FAULT_MODE_ENABLED } from "./faultRegistry.js";
 import type { PtyClient } from "../services/PtyClient.js";
 import type { WorkspaceClient } from "../services/WorkspaceClient.js";
@@ -28,8 +29,6 @@ interface RetryPayload {
   action: RetryAction;
   args?: Record<string, unknown>;
 }
-
-const MAX_PENDING_ERRORS = 50;
 
 const MAX_RETRY_ATTEMPTS: Record<RetryAction, number> = {
   terminal: 3,
@@ -294,9 +293,7 @@ class ErrorService {
 
   private persistError(error: ErrorRecord): void {
     try {
-      const existing = (store.get("pendingErrors") as ErrorRecord[] | undefined) ?? [];
-      const updated = [...existing, error].slice(-MAX_PENDING_ERRORS);
-      store.set("pendingErrors", updated);
+      appendPendingError(error);
     } catch {
       // Don't let persistence failure block error handling
     }

--- a/electron/ipc/pendingErrorsStore.ts
+++ b/electron/ipc/pendingErrorsStore.ts
@@ -1,0 +1,11 @@
+import { store } from "../store.js";
+import type { ErrorRecord } from "../../shared/types/ipc/errors.js";
+
+export const MAX_PENDING_ERRORS = 50;
+
+export function appendPendingError(record: ErrorRecord): void {
+  const raw = store.get("pendingErrors");
+  const existing = Array.isArray(raw) ? (raw as ErrorRecord[]) : [];
+  const updated = [...existing, record].slice(-MAX_PENDING_ERRORS);
+  store.set("pendingErrors", updated);
+}

--- a/electron/ipc/pendingErrorsStore.ts
+++ b/electron/ipc/pendingErrorsStore.ts
@@ -6,6 +6,9 @@ export const MAX_PENDING_ERRORS = 50;
 export function appendPendingError(record: ErrorRecord): void {
   const raw = store.get("pendingErrors");
   const existing = Array.isArray(raw) ? (raw as ErrorRecord[]) : [];
-  const updated = [...existing, record].slice(-MAX_PENDING_ERRORS);
-  store.set("pendingErrors", updated);
+  // Trim before append so a pre-fix bloated store (>50 entries) doesn't
+  // allocate a giant intermediate array on the first post-fix write.
+  const trimmed = existing.slice(-(MAX_PENDING_ERRORS - 1));
+  trimmed.push(record);
+  store.set("pendingErrors", trimmed);
 }

--- a/electron/setup/__tests__/globalErrorHandlers.test.ts
+++ b/electron/setup/__tests__/globalErrorHandlers.test.ts
@@ -176,6 +176,28 @@ describe("globalErrorHandlers", () => {
       );
     });
 
+    it("caps persisted pendingErrors at 50 when store already holds 50 entries", () => {
+      const seeded = Array.from({ length: 50 }, (_, i) => ({
+        id: `seeded-${i}`,
+        timestamp: i,
+        type: "unknown",
+        message: `seeded ${i}`,
+        source: "main-process",
+        isTransient: false,
+        dismissed: false,
+      }));
+      storeMock.get.mockReturnValue(seeded);
+
+      uncaughtHandler(new Error("new crash"));
+
+      const persisted = storeMock.set.mock.calls.find(
+        ([key]) => key === "pendingErrors"
+      )?.[1] as Array<{ id: string }>;
+      expect(persisted).toHaveLength(50);
+      expect(persisted[0].id).toBe("seeded-1");
+      expect(persisted[persisted.length - 1].id).toMatch(/^fatal-/);
+    });
+
     it("sends error notification to renderer via broadcast", () => {
       const error = new Error("test crash");
       uncaughtHandler(error);
@@ -376,6 +398,28 @@ describe("globalErrorHandlers", () => {
         "pendingErrors",
         expect.arrayContaining([expect.objectContaining({ fromPreviousSession: true })])
       );
+    });
+
+    it("caps persisted pendingErrors at 50 when store already holds 50 entries", () => {
+      const seeded = Array.from({ length: 50 }, (_, i) => ({
+        id: `seeded-${i}`,
+        timestamp: i,
+        type: "unknown",
+        message: `seeded ${i}`,
+        source: "main-process",
+        isTransient: false,
+        dismissed: false,
+      }));
+      storeMock.get.mockReturnValue(seeded);
+
+      rejectionHandler(new Error("rejected"));
+
+      const persisted = storeMock.set.mock.calls.find(
+        ([key]) => key === "pendingErrors"
+      )?.[1] as Array<{ id: string }>;
+      expect(persisted).toHaveLength(50);
+      expect(persisted[0].id).toBe("seeded-1");
+      expect(persisted[persisted.length - 1].id).toMatch(/^fatal-/);
     });
 
     it("handles non-Error rejection reasons", () => {

--- a/electron/setup/globalErrorHandlers.ts
+++ b/electron/setup/globalErrorHandlers.ts
@@ -5,7 +5,7 @@ import { getCrashLoopGuard } from "../services/CrashLoopGuardService.js";
 import { closeTelemetry } from "../services/TelemetryService.js";
 import { broadcastToRenderer } from "../ipc/utils.js";
 import { CHANNELS } from "../ipc/channels.js";
-import { store } from "../store.js";
+import { appendPendingError } from "../ipc/pendingErrorsStore.js";
 import type { ErrorRecord } from "../../shared/types/ipc/errors.js";
 import { formatErrorMessage } from "../../shared/utils/errorMessage.js";
 
@@ -46,9 +46,7 @@ function notifyRenderer(appError: ErrorRecord): void {
 
 function persistPendingError(appError: ErrorRecord): void {
   try {
-    const existing = store.get("pendingErrors");
-    const pending = Array.isArray(existing) ? existing : [];
-    store.set("pendingErrors", [...pending, { ...appError, fromPreviousSession: true }]);
+    appendPendingError({ ...appError, fromPreviousSession: true });
   } catch {
     // best-effort only
   }


### PR DESCRIPTION
## Summary

- The `pendingErrors` array had a 50-entry cap, but it was only enforced on the renderer path (`ErrorService.persistError`). The main-process fatal error path (`globalErrorHandlers.persistPendingError`) bypassed it entirely, allowing unbounded growth.
- Because electron-store re-serializes the entire JSON config on every `set`, an oversized array turns each config write into an O(N) main-thread block during synchronous fsync — and widens the partial-write window on non-atomic Conf fallback paths (Windows EXDEV, Linux Snap).
- New `electron/ipc/pendingErrorsStore.ts` exports `MAX_PENDING_ERRORS` and `appendPendingError(record)` — a single capped writer that both paths delegate to. The helper trims existing entries before appending to avoid large intermediate allocations if a store was already bloated by the pre-fix path.

Resolves #7571

## Changes

- `electron/ipc/pendingErrorsStore.ts` — shared helper with `MAX_PENDING_ERRORS = 50` constant and `appendPendingError`
- `electron/ipc/errorHandlers.ts` — renderer path delegates to helper instead of inline slice
- `electron/setup/globalErrorHandlers.ts` — main-process path delegates to same helper
- Cap-boundary tests on all three call paths (`criticalError` IPC retry, `uncaughtException`, `unhandledRejection`) — assert length stays at 50, oldest record is evicted, new record lands as last element

## Testing

Targeted vitest run of `electron/setup/__tests__/globalErrorHandlers.test.ts` and `electron/ipc/__tests__/errorHandlers.test.ts` — 89 tests pass. Full `npm run check` (typecheck + lint + format) clean.