### PR TITLE
fix(persistence): pre-flight disk-space checks in openDb and MigrationRunner

### DIFF
--- a/electron/services/StoreMigrations.ts
+++ b/electron/services/StoreMigrations.ts
@@ -4,6 +4,7 @@ import { tightenFilePermissions } from "../store.js";
 import fs from "fs";
 import { z } from "zod";
 import { formatErrorMessage } from "../../shared/utils/errorMessage.js";
+import { getCurrentDiskSpaceStatus } from "./DiskSpaceMonitor.js";
 
 export const LATEST_SCHEMA_VERSION = 20;
 
@@ -81,6 +82,14 @@ export class MigrationRunner {
   ) {}
 
   private backupStore(fromVersion: number): string | null {
+    // Skip the copy when the volume is already critical — fs.copyFileSync would
+    // either fail with ENOSPC or leave a truncated backup. The runMigrations
+    // guard short-circuits well before this in practice; keep the check anyway
+    // so direct callers (and any future relaxation upstream) stay safe.
+    if (getCurrentDiskSpaceStatus().status === "critical") {
+      console.warn("[Migrations] Skipping pre-migration backup: disk space is critical");
+      return null;
+    }
     try {
       const storePath = this.store.path;
       if (!fs.existsSync(storePath)) {
@@ -169,6 +178,14 @@ export class MigrationRunner {
   }
 
   async runMigrations(migrations: Migration[]): Promise<void> {
+    // Pre-flight disk-space gate. Migrations write the pre-migration backup
+    // and may call electron-store's atomic write under the hood; both fail
+    // hard on a critical-pressure volume. Throw before the chain starts so the
+    // caller can surface the condition instead of partially mutating state.
+    if (getCurrentDiskSpaceStatus().status === "critical") {
+      throw new Error("Cannot run migrations: disk space is critical");
+    }
+
     const current = this.getCurrentVersion();
     const maxKnownVersion = Math.max(...migrations.map((m) => m.version), 0);
 

--- a/electron/services/StoreMigrations.ts
+++ b/electron/services/StoreMigrations.ts
@@ -232,6 +232,12 @@ export class MigrationRunner {
     const backupPath = this.backupStore(current);
     if (backupPath) {
       console.log(`[Migrations] Store backed up, can restore from: ${backupPath}`);
+    } else if (getCurrentDiskSpaceStatus().status === "critical") {
+      // Disk transitioned to critical between the top-of-method guard and the
+      // backup write — backupStore skipped the copy. Don't proceed without a
+      // backup on a critical volume; surface the condition before mutating
+      // the live store.
+      throw new Error("Cannot run migrations: disk space is critical");
     }
 
     let stage: "loop" | "validate" = "loop";

--- a/electron/services/__tests__/StoreMigrations.test.ts
+++ b/electron/services/__tests__/StoreMigrations.test.ts
@@ -32,13 +32,20 @@ vi.mock("../ProjectStore.js", () => ({
 
 // Mock DiskSpaceMonitor so MigrationRunner's pre-flight guard is controllable.
 // Defaults to a normal-status return; individual tests override per-case.
-const { mockGetCurrentDiskSpaceStatus } = vi.hoisted(() => ({
-  mockGetCurrentDiskSpaceStatus: vi.fn(() => ({
-    status: "normal" as const,
-    availableMb: 4096,
-    writesSuppressed: false,
-  })),
-}));
+const { mockGetCurrentDiskSpaceStatus } = vi.hoisted(() => {
+  type DiskSpaceStatusResult = {
+    status: "normal" | "warning" | "critical";
+    availableMb: number;
+    writesSuppressed: boolean;
+  };
+  return {
+    mockGetCurrentDiskSpaceStatus: vi.fn<() => DiskSpaceStatusResult>(() => ({
+      status: "normal" as const,
+      availableMb: 4096,
+      writesSuppressed: false,
+    })),
+  };
+});
 vi.mock("../DiskSpaceMonitor.js", () => ({
   getCurrentDiskSpaceStatus: () => mockGetCurrentDiskSpaceStatus(),
 }));
@@ -449,7 +456,7 @@ describe("MigrationRunner", () => {
       const store = createMockStore(storePath, { _schemaVersion: 0 });
       const runner = new MigrationRunner(store as never);
       mockGetCurrentDiskSpaceStatus.mockReturnValue({
-        status: "critical",
+        status: "critical" as const,
         availableMb: 50,
         writesSuppressed: true,
       });
@@ -471,7 +478,7 @@ describe("MigrationRunner", () => {
       const store = createMockStore(storePath, { _schemaVersion: 1, sentinel: "keep" });
       const runner = new MigrationRunner(store as never, { floorVersion: 5 });
       mockGetCurrentDiskSpaceStatus.mockReturnValue({
-        status: "critical",
+        status: "critical" as const,
         availableMb: 50,
         writesSuppressed: true,
       });
@@ -492,7 +499,7 @@ describe("MigrationRunner", () => {
       const store = createMockStore(storePath, { _schemaVersion: 0 });
       const runner = new MigrationRunner(store as never);
       mockGetCurrentDiskSpaceStatus.mockReturnValue({
-        status: "warning",
+        status: "warning" as const,
         availableMb: 1024,
         writesSuppressed: false,
       });
@@ -510,7 +517,7 @@ describe("MigrationRunner", () => {
       const store = createMockStore(storePath, { _schemaVersion: "3" });
       const runner = new MigrationRunner(store as never);
       mockGetCurrentDiskSpaceStatus.mockReturnValue({
-        status: "critical",
+        status: "critical" as const,
         availableMb: 50,
         writesSuppressed: true,
       });
@@ -529,7 +536,7 @@ describe("MigrationRunner", () => {
       const store = createMockStore(storePath, { _schemaVersion: 2 });
       const runner = new MigrationRunner(store as never);
       mockGetCurrentDiskSpaceStatus.mockReturnValue({
-        status: "critical",
+        status: "critical" as const,
         availableMb: 50,
         writesSuppressed: true,
       });
@@ -549,7 +556,7 @@ describe("MigrationRunner", () => {
       const store = createMockStore(storePath, { _schemaVersion: 99 });
       const runner = new MigrationRunner(store as never);
       mockGetCurrentDiskSpaceStatus.mockReturnValue({
-        status: "critical",
+        status: "critical" as const,
         availableMb: 50,
         writesSuppressed: true,
       });
@@ -569,12 +576,12 @@ describe("MigrationRunner", () => {
       const runner = new MigrationRunner(store as never);
       mockGetCurrentDiskSpaceStatus
         .mockReturnValueOnce({
-          status: "normal",
+          status: "normal" as const,
           availableMb: 4096,
           writesSuppressed: false,
         })
         .mockReturnValue({
-          status: "critical",
+          status: "critical" as const,
           availableMb: 50,
           writesSuppressed: true,
         });
@@ -598,7 +605,7 @@ describe("MigrationRunner", () => {
       const store = createMockStore(storePath, { _schemaVersion: 3 });
       const runner = new MigrationRunner(store as never);
       mockGetCurrentDiskSpaceStatus.mockReturnValue({
-        status: "critical",
+        status: "critical" as const,
         availableMb: 50,
         writesSuppressed: true,
       });

--- a/electron/services/__tests__/StoreMigrations.test.ts
+++ b/electron/services/__tests__/StoreMigrations.test.ts
@@ -30,6 +30,19 @@ vi.mock("../ProjectStore.js", () => ({
   projectStore: mockProjectStore,
 }));
 
+// Mock DiskSpaceMonitor so MigrationRunner's pre-flight guard is controllable.
+// Defaults to a normal-status return; individual tests override per-case.
+const { mockGetCurrentDiskSpaceStatus } = vi.hoisted(() => ({
+  mockGetCurrentDiskSpaceStatus: vi.fn(() => ({
+    status: "normal" as const,
+    availableMb: 4096,
+    writesSuppressed: false,
+  })),
+}));
+vi.mock("../DiskSpaceMonitor.js", () => ({
+  getCurrentDiskSpaceStatus: () => mockGetCurrentDiskSpaceStatus(),
+}));
+
 import type { Migration } from "../StoreMigrations.js";
 import {
   LATEST_SCHEMA_VERSION,
@@ -95,6 +108,11 @@ describe("MigrationRunner", () => {
     tempDir = fs.mkdtempSync(path.join(os.tmpdir(), "daintree-migrations-"));
     storePath = path.join(tempDir, "config.json");
     fs.writeFileSync(storePath, JSON.stringify({ ok: true }), "utf8");
+    mockGetCurrentDiskSpaceStatus.mockReturnValue({
+      status: "normal",
+      availableMb: 4096,
+      writesSuppressed: false,
+    });
   });
 
   afterEach(() => {
@@ -422,6 +440,93 @@ describe("MigrationRunner", () => {
       ).rejects.toThrow(/Post-migration sanity check failed/);
 
       expect(fs.readFileSync(storePath, "utf8")).toBe(originalBytes);
+    });
+  });
+
+  describe("disk-space pre-flight guard", () => {
+    it("runMigrations throws before any backup or migration when disk is critical", async () => {
+      const upSpy = vi.fn();
+      const store = createMockStore(storePath, { _schemaVersion: 0 });
+      const runner = new MigrationRunner(store as never);
+      mockGetCurrentDiskSpaceStatus.mockReturnValue({
+        status: "critical",
+        availableMb: 50,
+        writesSuppressed: true,
+      });
+
+      await expect(
+        runner.runMigrations([{ version: 1, description: "v1", up: upSpy }])
+      ).rejects.toThrow(/disk space is critical/);
+
+      expect(upSpy).not.toHaveBeenCalled();
+      // No backup file should have been created — the guard fires before
+      // backupStore is reached.
+      const backups = fs.readdirSync(tempDir).filter((f) => f.startsWith("config.json.backup-"));
+      expect(backups).toHaveLength(0);
+      // Schema version untouched
+      expect(store.data._schemaVersion).toBe(0);
+    });
+
+    it("runMigrations throws on critical disk even on the floorVersion reset path", async () => {
+      const store = createMockStore(storePath, { _schemaVersion: 1, sentinel: "keep" });
+      const runner = new MigrationRunner(store as never, { floorVersion: 5 });
+      mockGetCurrentDiskSpaceStatus.mockReturnValue({
+        status: "critical",
+        availableMb: 50,
+        writesSuppressed: true,
+      });
+
+      await expect(
+        runner.runMigrations([{ version: 5, description: "v5", up: () => {} }])
+      ).rejects.toThrow(/disk space is critical/);
+
+      // Floor-reset should not have run — store keys preserved.
+      expect(store.data._schemaVersion).toBe(1);
+      expect(store.data.sentinel).toBe("keep");
+      const backups = fs.readdirSync(tempDir).filter((f) => f.startsWith("config.json.backup-"));
+      expect(backups).toHaveLength(0);
+    });
+
+    it("runMigrations does not block at warning tier (only critical bails)", async () => {
+      const upSpy = vi.fn();
+      const store = createMockStore(storePath, { _schemaVersion: 0 });
+      const runner = new MigrationRunner(store as never);
+      mockGetCurrentDiskSpaceStatus.mockReturnValue({
+        status: "warning",
+        availableMb: 1024,
+        writesSuppressed: false,
+      });
+
+      await runner.runMigrations([{ version: 1, description: "v1", up: upSpy }]);
+
+      expect(upSpy).toHaveBeenCalledTimes(1);
+      expect(store.data._schemaVersion).toBe(1);
+    });
+
+    it("backupStore returns null without writing a file when disk is critical", () => {
+      // Defense-in-depth check: if a future caller invokes backupStore directly
+      // (bypassing runMigrations' guard), it must still skip the copy.
+      const store = createMockStore(storePath, { _schemaVersion: 3 });
+      const runner = new MigrationRunner(store as never);
+      mockGetCurrentDiskSpaceStatus.mockReturnValue({
+        status: "critical",
+        availableMb: 50,
+        writesSuppressed: true,
+      });
+      const warnSpy = vi.spyOn(console, "warn").mockImplementation(() => {});
+
+      const result = (
+        runner as unknown as { backupStore: (v: number) => string | null }
+      ).backupStore(3);
+
+      expect(result).toBeNull();
+      const backups = fs.readdirSync(tempDir).filter((f) => f.startsWith("config.json.backup-"));
+      expect(backups).toHaveLength(0);
+      expect(warnSpy).toHaveBeenCalledWith(
+        expect.stringContaining("Skipping pre-migration backup")
+      );
+
+      warnSpy.mockRestore();
     });
   });
 

--- a/electron/services/__tests__/StoreMigrations.test.ts
+++ b/electron/services/__tests__/StoreMigrations.test.ts
@@ -503,6 +503,95 @@ describe("MigrationRunner", () => {
       expect(store.data._schemaVersion).toBe(1);
     });
 
+    it("runMigrations throws on critical disk before _schemaVersion normalization", async () => {
+      // Guard must fire before getCurrentVersion() runs, so an invalid stored
+      // _schemaVersion (e.g. a string) must not be normalized to 0 on a
+      // critical-pressure volume.
+      const store = createMockStore(storePath, { _schemaVersion: "3" });
+      const runner = new MigrationRunner(store as never);
+      mockGetCurrentDiskSpaceStatus.mockReturnValue({
+        status: "critical",
+        availableMb: 50,
+        writesSuppressed: true,
+      });
+
+      await expect(
+        runner.runMigrations([{ version: 1, description: "v1", up: () => {} }])
+      ).rejects.toThrow(/disk space is critical/);
+
+      expect(store.data._schemaVersion).toBe("3");
+    });
+
+    it("runMigrations throws on critical disk even when no migrations are pending", async () => {
+      // Guard fires unconditionally — having nothing to do is not a reason to
+      // skip the disk check, since callers may still rely on the throw to
+      // surface the condition.
+      const store = createMockStore(storePath, { _schemaVersion: 2 });
+      const runner = new MigrationRunner(store as never);
+      mockGetCurrentDiskSpaceStatus.mockReturnValue({
+        status: "critical",
+        availableMb: 50,
+        writesSuppressed: true,
+      });
+
+      await expect(
+        runner.runMigrations([
+          { version: 1, description: "v1", up: () => {} },
+          { version: 2, description: "v2", up: () => {} },
+        ])
+      ).rejects.toThrow(/disk space is critical/);
+    });
+
+    it("runMigrations throws on critical disk even when current version is ahead (downgrade compat mode)", async () => {
+      // Guard fires before the compatibility-mode early-return, so a critical
+      // disk surfaces an error rather than silently logging the downgrade
+      // warning and returning success.
+      const store = createMockStore(storePath, { _schemaVersion: 99 });
+      const runner = new MigrationRunner(store as never);
+      mockGetCurrentDiskSpaceStatus.mockReturnValue({
+        status: "critical",
+        availableMb: 50,
+        writesSuppressed: true,
+      });
+
+      await expect(
+        runner.runMigrations([{ version: 5, description: "v5", up: () => {} }])
+      ).rejects.toThrow(/disk space is critical/);
+    });
+
+    it("runMigrations throws when disk transitions to critical between guard and backupStore", async () => {
+      // Mid-flight TOCTOU: the top-of-method guard sees normal, the volume
+      // fills before backupStore is reached, backupStore correctly skips the
+      // copy, and the post-backup re-check then surfaces the condition. Without
+      // the re-check, migrations would mutate the live store with no backup.
+      const upSpy = vi.fn();
+      const store = createMockStore(storePath, { _schemaVersion: 0 });
+      const runner = new MigrationRunner(store as never);
+      mockGetCurrentDiskSpaceStatus
+        .mockReturnValueOnce({
+          status: "normal",
+          availableMb: 4096,
+          writesSuppressed: false,
+        })
+        .mockReturnValue({
+          status: "critical",
+          availableMb: 50,
+          writesSuppressed: true,
+        });
+      const warnSpy = vi.spyOn(console, "warn").mockImplementation(() => {});
+
+      await expect(
+        runner.runMigrations([{ version: 1, description: "v1", up: upSpy }])
+      ).rejects.toThrow(/disk space is critical/);
+
+      expect(upSpy).not.toHaveBeenCalled();
+      expect(store.data._schemaVersion).toBe(0);
+      const backups = fs.readdirSync(tempDir).filter((f) => f.startsWith("config.json.backup-"));
+      expect(backups).toHaveLength(0);
+
+      warnSpy.mockRestore();
+    });
+
     it("backupStore returns null without writing a file when disk is critical", () => {
       // Defense-in-depth check: if a future caller invokes backupStore directly
       // (bypassing runMigrations' guard), it must still skip the copy.

--- a/electron/services/persistence/__tests__/db.test.ts
+++ b/electron/services/persistence/__tests__/db.test.ts
@@ -39,7 +39,7 @@ vi.mock("drizzle-orm/better-sqlite3", () => ({
   drizzle: vi.fn(() => ({})),
 }));
 
-import { probeDb, attemptRecovery, closeSharedDb, withDiskRecovery } from "../db.js";
+import { openDb, probeDb, attemptRecovery, closeSharedDb, withDiskRecovery } from "../db.js";
 
 describe("probeDb", () => {
   let tmpDir: string;
@@ -218,6 +218,47 @@ describe("attemptRecovery", () => {
 describe("closeSharedDb", () => {
   it("does nothing when no shared instance exists", () => {
     expect(() => closeSharedDb({ checkpoint: true })).not.toThrow();
+  });
+});
+
+describe("openDb", () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+    vi.spyOn(console, "warn").mockImplementation(() => {});
+  });
+
+  afterEach(() => {
+    vi.restoreAllMocks();
+  });
+
+  it("throws before constructing a Database when disk space is critical", () => {
+    mockGetCurrentDiskSpaceStatus.mockReturnValue({
+      status: "critical",
+      availableMb: 100,
+      writesSuppressed: true,
+    });
+
+    expect(() => openDb("/fake/userData/daintree.db", "/fake/migrations")).toThrow(
+      /disk space is critical/
+    );
+    expect(mockDatabaseConstructor).not.toHaveBeenCalled();
+  });
+
+  it("does not block on the disk guard when status is warning (only critical bails)", () => {
+    // status === "warning" should still allow opens — the guard fires only on
+    // "critical" so writes can keep draining at the warning tier. We force the
+    // constructor to throw a sentinel error so we don't depend on the rest of
+    // openDb's wiring; reaching the constructor at all proves the guard passed.
+    mockGetCurrentDiskSpaceStatus.mockReturnValue({
+      status: "warning",
+      availableMb: 1024,
+      writesSuppressed: false,
+    });
+    const sentinel = new Error("sentinel — should not be reached on critical");
+    mockDatabaseConstructor.mockImplementation(() => ({ error: sentinel }));
+
+    expect(() => openDb("/fake/userData/daintree.db", "/fake/migrations")).toThrow(sentinel);
+    expect(mockDatabaseConstructor).toHaveBeenCalled();
   });
 });
 

--- a/electron/services/persistence/db.ts
+++ b/electron/services/persistence/db.ts
@@ -73,6 +73,13 @@ export function openDb(
   dbPath: string,
   migrationsFolder?: string
 ): { sqlite: Database.Database; db: AppDb } {
+  // Pre-flight disk-space gate. better-sqlite3's constructor creates the file
+  // on open; on a critical-pressure volume that leaves a zero-byte database
+  // for probeDb to quarantine next boot. Bail before allocating a handle.
+  if (getCurrentDiskSpaceStatus().status === "critical") {
+    throw new Error("Cannot open database: disk space is critical");
+  }
+
   const sqlite = new Database(dbPath);
   try {
     sqlite.pragma("journal_mode = WAL");


### PR DESCRIPTION
## Summary

- `openDb()` and `MigrationRunner.runMigrations()` both lacked a pre-flight disk-space gate, meaning a critical-disk machine could start a write to a full WAL or kick off a migration with no valid rollback target
- Both paths now throw early when `getCurrentDiskSpaceStatus().status === "critical"`, before touching the filesystem — mirrors the existing `setWritesSuppressed` pattern from #4295
- Closed a TOCTOU window in `backupStore()`: disk status is re-checked immediately before `fs.copyFileSync` so the guard and the write are atomic with respect to status changes

Resolves #7568

## Changes

- `electron/services/persistence/db.ts` — disk guard at the top of `openDb()`
- `electron/services/StoreMigrations.ts` — disk guard in `runMigrations()` and a second re-check in `backupStore()` before the copy
- `electron/services/persistence/__tests__/db.test.ts` — 2 new tests covering the critical-disk rejection path
- `electron/services/__tests__/StoreMigrations.test.ts` — `DiskSpaceMonitor` mock + 8 new tests covering guards in both functions and the TOCTOU re-check

## Testing

All 111 tests pass. Typecheck, lint, and format clean.