### PR TITLE
ci(release): block publish when latest.yml version regresses (#7573)

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -348,6 +348,16 @@ jobs:
     timeout-minutes: 15
 
     steps:
+      - name: Checkout repository
+        uses: actions/checkout@v6
+        with:
+          fetch-depth: 1
+
+      - name: Set up Node.js
+        uses: actions/setup-node@v6
+        with:
+          node-version: ${{ env.NODE_VERSION }}
+
       - name: Resolve update metadata prefix
         shell: bash
         run: |
@@ -380,6 +390,16 @@ jobs:
 
       - name: List release files
         run: ls -lah release/
+
+      - name: Install gate dependencies
+        shell: bash
+        run: npm install --no-save --no-audit --no-fund --ignore-scripts js-yaml semver
+
+      - name: Check version is monotonically increasing
+        shell: bash
+        env:
+          UPDATE_METADATA_PREFIX: ${{ env.UPDATE_METADATA_PREFIX }}
+        run: node scripts/ci/check-version-monotonic.mjs
 
       - name: Upload binaries to R2
         shell: bash

--- a/scripts/ci/check-version-monotonic.mjs
+++ b/scripts/ci/check-version-monotonic.mjs
@@ -26,6 +26,7 @@ import semver from "semver";
 const FEED_BASE_URL = "https://updates.daintree.org/releases";
 const FETCH_TIMEOUT_MS = 15_000;
 const PLATFORMS = ["mac", "linux"];
+const ALLOWED_PREFIXES = ["latest", "rc", "beta"];
 
 function fail(message) {
   console.error(`::error::${message}`);
@@ -53,6 +54,26 @@ export function extractVersion(parsed, label) {
   return raw;
 }
 
+export function validatePrefix(prefix) {
+  if (!prefix) {
+    return {
+      ok: false,
+      error:
+        "UPDATE_METADATA_PREFIX env var is not set — refusing to guess the channel. " +
+        `Set it to one of: ${ALLOWED_PREFIXES.join(", ")}.`,
+    };
+  }
+  if (!ALLOWED_PREFIXES.includes(prefix)) {
+    return {
+      ok: false,
+      error:
+        `UPDATE_METADATA_PREFIX='${prefix}' is not a known channel. ` +
+        `Expected one of: ${ALLOWED_PREFIXES.join(", ")}.`,
+    };
+  }
+  return { ok: true };
+}
+
 export function checkVersionMonotonic(liveVersion, newVersion) {
   if (!semver.valid(liveVersion)) {
     return { ok: false, error: `live version '${liveVersion}' is not valid semver` };
@@ -72,36 +93,47 @@ export function checkVersionMonotonic(liveVersion, newVersion) {
 async function fetchLiveVersion(prefix, platform) {
   const url = `${FEED_BASE_URL}/${prefix}-${platform}.yml`;
   const controller = new AbortController();
+  // Keep the abort signal armed across both the headers fetch and the body
+  // read — a CDN that returns 200 then stalls the body would otherwise hang
+  // until the job-level 15min timeout instead of failing closed at 15s.
   const timer = setTimeout(() => controller.abort(), FETCH_TIMEOUT_MS);
-  let response;
   try {
-    response = await fetch(url, {
-      signal: controller.signal,
-      headers: { "cache-control": "no-cache" },
-    });
-  } catch (error) {
-    const cause = error instanceof Error ? error.message : String(error);
-    throw new Error(`failed to fetch ${url}: ${cause}`);
+    let response;
+    try {
+      response = await fetch(url, {
+        signal: controller.signal,
+        headers: { "cache-control": "no-cache" },
+      });
+    } catch (error) {
+      const cause = error instanceof Error ? error.message : String(error);
+      throw new Error(`failed to fetch ${url}: ${cause}`);
+    }
+
+    if (response.status === 404) {
+      return { url, status: 404, version: null };
+    }
+    if (!response.ok) {
+      throw new Error(`unexpected HTTP ${response.status} from ${url}`);
+    }
+    let body;
+    try {
+      body = await response.text();
+    } catch (error) {
+      const cause = error instanceof Error ? error.message : String(error);
+      throw new Error(`failed to read body from ${url}: ${cause}`);
+    }
+    let parsed;
+    try {
+      parsed = load(body);
+    } catch (error) {
+      const cause = error instanceof Error ? error.message : String(error);
+      throw new Error(`failed to parse YAML from ${url}: ${cause}`);
+    }
+    const version = extractVersion(parsed, `live ${prefix}-${platform}.yml`);
+    return { url, status: response.status, version };
   } finally {
     clearTimeout(timer);
   }
-
-  if (response.status === 404) {
-    return { url, status: 404, version: null };
-  }
-  if (!response.ok) {
-    throw new Error(`unexpected HTTP ${response.status} from ${url}`);
-  }
-  const body = await response.text();
-  let parsed;
-  try {
-    parsed = load(body);
-  } catch (error) {
-    const cause = error instanceof Error ? error.message : String(error);
-    throw new Error(`failed to parse YAML from ${url}: ${cause}`);
-  }
-  const version = extractVersion(parsed, `live ${prefix}-${platform}.yml`);
-  return { url, status: response.status, version };
 }
 
 async function readLocalVersion(releaseDir, prefix, platform) {
@@ -125,11 +157,12 @@ async function readLocalVersion(releaseDir, prefix, platform) {
 
 async function main() {
   const prefix = process.env.UPDATE_METADATA_PREFIX;
-  if (!prefix) {
-    fail(
-      "UPDATE_METADATA_PREFIX env var is not set — refusing to guess the channel. " +
-        "Set it to one of: latest, rc, beta."
-    );
+  // A typo like "latset" would otherwise make every live URL 404, which the
+  // gate treats as "first release in channel" and silently passes — exactly
+  // the regression we're trying to prevent.
+  const prefixCheck = validatePrefix(prefix);
+  if (!prefixCheck.ok) {
+    fail(prefixCheck.error);
   }
 
   const releaseDir = process.env.RELEASE_DIR ?? "release";
@@ -154,17 +187,23 @@ async function main() {
   }
   const newVersion = macLocal.version;
 
-  let lives;
-  try {
-    lives = await Promise.all(PLATFORMS.map((platform) => fetchLiveVersion(prefix, platform)));
-  } catch (error) {
-    fail(error instanceof Error ? error.message : String(error));
-  }
+  // Fetch every channel feed in parallel so a transient mac error and a real
+  // linux regression both surface in the same `::error::` annotation block,
+  // rather than fail-fast hiding the second issue until the first is rerun.
+  const fetchResults = await Promise.allSettled(
+    PLATFORMS.map((platform) => fetchLiveVersion(prefix, platform))
+  );
 
   const failures = [];
   for (let i = 0; i < PLATFORMS.length; i++) {
     const platform = PLATFORMS[i];
-    const live = lives[i];
+    const settled = fetchResults[i];
+    if (settled.status === "rejected") {
+      const reason = settled.reason;
+      failures.push(`${platform}: ${reason instanceof Error ? reason.message : String(reason)}`);
+      continue;
+    }
+    const live = settled.value;
     if (live.version === null) {
       console.log(
         `[monotonic] ${platform}: no live ${prefix}-${platform}.yml (HTTP 404) — first release in channel, allowing.`
@@ -194,5 +233,5 @@ if (process.argv[1] && import.meta.url === pathToFileURL(process.argv[1]).href) 
   await main();
 }
 
-// Re-export for tests that want the shared constant without hardcoding the URL.
-export { FEED_BASE_URL, PLATFORMS };
+// Re-export for tests that want the shared constants without hardcoding values.
+export { FEED_BASE_URL, PLATFORMS, ALLOWED_PREFIXES };

--- a/scripts/ci/check-version-monotonic.mjs
+++ b/scripts/ci/check-version-monotonic.mjs
@@ -1,0 +1,198 @@
+#!/usr/bin/env node
+// Blocks the release publish if the new version isn't strictly greater than the
+// version currently advertised on the live update feed. electron-updater on
+// stable runs with `allowDowngrade = false` (see electron/services/AutoUpdaterService.ts),
+// so a regressed `latest-mac.yml` / `latest-linux.yml` permanently strands every
+// installed client until a hand-rolled republish — see #7573.
+//
+// Reads the new version from the local artifacts already downloaded into
+// `release/${UPDATE_METADATA_PREFIX}-{mac,linux}.yml`, fetches the same files
+// from https://updates.daintree.org/releases/, and compares with `semver.gt`.
+// Equal versions also fail (republishing the same version is the same footgun).
+//
+// Failure modes:
+//   - 404 on the live feed         -> pass for that platform (first release in channel)
+//   - any other HTTP / network err -> fail closed
+//   - YAML parse / missing version -> fail closed
+//   - mac and linux disagree on    -> fail closed (split-brain build)
+//     the new version
+
+import { readFile } from "node:fs/promises";
+import path from "node:path";
+import { pathToFileURL } from "node:url";
+import { load } from "js-yaml";
+import semver from "semver";
+
+const FEED_BASE_URL = "https://updates.daintree.org/releases";
+const FETCH_TIMEOUT_MS = 15_000;
+const PLATFORMS = ["mac", "linux"];
+
+function fail(message) {
+  console.error(`::error::${message}`);
+  process.exit(1);
+}
+
+export function extractVersion(parsed, label) {
+  if (parsed === null || typeof parsed !== "object") {
+    throw new Error(`${label}: expected a YAML mapping with a 'version' field`);
+  }
+  const raw = parsed.version;
+  if (raw === undefined || raw === null) {
+    throw new Error(`${label}: missing 'version' field`);
+  }
+  if (typeof raw !== "string") {
+    // YAML parses bare numerics (`version: 1`) as JS numbers — reject so a
+    // bad metadata file can't slip past `semver.valid` after coercion.
+    throw new Error(
+      `${label}: 'version' must be a string, got ${typeof raw} (${JSON.stringify(raw)})`
+    );
+  }
+  if (!semver.valid(raw)) {
+    throw new Error(`${label}: '${raw}' is not a valid semver version`);
+  }
+  return raw;
+}
+
+export function checkVersionMonotonic(liveVersion, newVersion) {
+  if (!semver.valid(liveVersion)) {
+    return { ok: false, error: `live version '${liveVersion}' is not valid semver` };
+  }
+  if (!semver.valid(newVersion)) {
+    return { ok: false, error: `new version '${newVersion}' is not valid semver` };
+  }
+  if (!semver.gt(newVersion, liveVersion)) {
+    return {
+      ok: false,
+      error: `new version ${newVersion} is not strictly greater than live ${liveVersion}`,
+    };
+  }
+  return { ok: true };
+}
+
+async function fetchLiveVersion(prefix, platform) {
+  const url = `${FEED_BASE_URL}/${prefix}-${platform}.yml`;
+  const controller = new AbortController();
+  const timer = setTimeout(() => controller.abort(), FETCH_TIMEOUT_MS);
+  let response;
+  try {
+    response = await fetch(url, {
+      signal: controller.signal,
+      headers: { "cache-control": "no-cache" },
+    });
+  } catch (error) {
+    const cause = error instanceof Error ? error.message : String(error);
+    throw new Error(`failed to fetch ${url}: ${cause}`);
+  } finally {
+    clearTimeout(timer);
+  }
+
+  if (response.status === 404) {
+    return { url, status: 404, version: null };
+  }
+  if (!response.ok) {
+    throw new Error(`unexpected HTTP ${response.status} from ${url}`);
+  }
+  const body = await response.text();
+  let parsed;
+  try {
+    parsed = load(body);
+  } catch (error) {
+    const cause = error instanceof Error ? error.message : String(error);
+    throw new Error(`failed to parse YAML from ${url}: ${cause}`);
+  }
+  const version = extractVersion(parsed, `live ${prefix}-${platform}.yml`);
+  return { url, status: response.status, version };
+}
+
+async function readLocalVersion(releaseDir, prefix, platform) {
+  const filePath = path.join(releaseDir, `${prefix}-${platform}.yml`);
+  let body;
+  try {
+    body = await readFile(filePath, "utf8");
+  } catch (error) {
+    const cause = error instanceof Error ? error.message : String(error);
+    throw new Error(`failed to read local artifact ${filePath}: ${cause}`);
+  }
+  let parsed;
+  try {
+    parsed = load(body);
+  } catch (error) {
+    const cause = error instanceof Error ? error.message : String(error);
+    throw new Error(`failed to parse YAML from ${filePath}: ${cause}`);
+  }
+  return { filePath, version: extractVersion(parsed, `local ${prefix}-${platform}.yml`) };
+}
+
+async function main() {
+  const prefix = process.env.UPDATE_METADATA_PREFIX;
+  if (!prefix) {
+    fail(
+      "UPDATE_METADATA_PREFIX env var is not set — refusing to guess the channel. " +
+        "Set it to one of: latest, rc, beta."
+    );
+  }
+
+  const releaseDir = process.env.RELEASE_DIR ?? "release";
+
+  let locals;
+  try {
+    locals = await Promise.all(
+      PLATFORMS.map((platform) => readLocalVersion(releaseDir, prefix, platform))
+    );
+  } catch (error) {
+    fail(error instanceof Error ? error.message : String(error));
+  }
+
+  const [macLocal, linuxLocal] = locals;
+  if (macLocal.version !== linuxLocal.version) {
+    fail(
+      `mac and linux artifacts disagree on the new version: ` +
+        `mac=${macLocal.version} (${macLocal.filePath}) ` +
+        `linux=${linuxLocal.version} (${linuxLocal.filePath}) — ` +
+        `something went wrong in the matrix build.`
+    );
+  }
+  const newVersion = macLocal.version;
+
+  let lives;
+  try {
+    lives = await Promise.all(PLATFORMS.map((platform) => fetchLiveVersion(prefix, platform)));
+  } catch (error) {
+    fail(error instanceof Error ? error.message : String(error));
+  }
+
+  const failures = [];
+  for (let i = 0; i < PLATFORMS.length; i++) {
+    const platform = PLATFORMS[i];
+    const live = lives[i];
+    if (live.version === null) {
+      console.log(
+        `[monotonic] ${platform}: no live ${prefix}-${platform}.yml (HTTP 404) — first release in channel, allowing.`
+      );
+      continue;
+    }
+    const result = checkVersionMonotonic(live.version, newVersion);
+    if (!result.ok) {
+      failures.push(`${platform}: ${result.error} (feed: ${live.url})`);
+    } else {
+      console.log(
+        `[monotonic] ${platform}: ${newVersion} > ${live.version} (live ${live.url}) — OK.`
+      );
+    }
+  }
+
+  if (failures.length > 0) {
+    fail(`version-monotonic gate failed:\n  - ${failures.join("\n  - ")}`);
+  }
+
+  console.log(
+    `[monotonic] gate passed for channel '${prefix}': new version ${newVersion} is greater than every live feed.`
+  );
+}
+
+if (process.argv[1] && import.meta.url === pathToFileURL(process.argv[1]).href) {
+  await main();
+}
+
+// Re-export for tests that want the shared constant without hardcoding the URL.
+export { FEED_BASE_URL, PLATFORMS };

--- a/scripts/ci/check-version-monotonic.test.mjs
+++ b/scripts/ci/check-version-monotonic.test.mjs
@@ -1,0 +1,106 @@
+import { describe, it, expect } from "vitest";
+import { checkVersionMonotonic, extractVersion } from "./check-version-monotonic.mjs";
+
+describe("check-version-monotonic", () => {
+  describe("checkVersionMonotonic", () => {
+    it("passes when new is strictly greater (patch)", () => {
+      expect(checkVersionMonotonic("1.0.0", "1.0.1")).toEqual({ ok: true });
+    });
+
+    it("passes when new is strictly greater (minor)", () => {
+      expect(checkVersionMonotonic("1.0.0", "1.1.0")).toEqual({ ok: true });
+    });
+
+    it("passes when new is strictly greater (major)", () => {
+      expect(checkVersionMonotonic("1.5.7", "2.0.0")).toEqual({ ok: true });
+    });
+
+    it("fails when versions are equal (republishing the same tag is a regression footgun)", () => {
+      const result = checkVersionMonotonic("1.0.0", "1.0.0");
+      expect(result.ok).toBe(false);
+      expect(result.error).toContain("not strictly greater");
+    });
+
+    it("fails when new is older", () => {
+      const result = checkVersionMonotonic("1.0.0", "0.9.9");
+      expect(result.ok).toBe(false);
+      expect(result.error).toContain("not strictly greater");
+    });
+
+    it("passes when going from pre-release to release of the same version", () => {
+      expect(checkVersionMonotonic("1.0.0-rc.1", "1.0.0")).toEqual({ ok: true });
+    });
+
+    it("passes for incremental rc bump", () => {
+      expect(checkVersionMonotonic("1.0.0-rc.1", "1.0.0-rc.2")).toEqual({ ok: true });
+    });
+
+    it("passes when going from release to next pre-release", () => {
+      expect(checkVersionMonotonic("1.0.0", "1.0.1-rc.1")).toEqual({ ok: true });
+    });
+
+    it("fails going from release to pre-release of same version", () => {
+      const result = checkVersionMonotonic("1.0.0", "1.0.0-rc.1");
+      expect(result.ok).toBe(false);
+      expect(result.error).toContain("not strictly greater");
+    });
+
+    it("fails on invalid live version", () => {
+      const result = checkVersionMonotonic("not-a-version", "1.0.0");
+      expect(result.ok).toBe(false);
+      expect(result.error).toContain("live version");
+      expect(result.error).toContain("not valid semver");
+    });
+
+    it("fails on invalid new version", () => {
+      const result = checkVersionMonotonic("1.0.0", "garbage");
+      expect(result.ok).toBe(false);
+      expect(result.error).toContain("new version");
+      expect(result.error).toContain("not valid semver");
+    });
+  });
+
+  describe("extractVersion", () => {
+    it("returns the version string from a valid mapping", () => {
+      expect(extractVersion({ version: "1.2.3" }, "test.yml")).toBe("1.2.3");
+    });
+
+    it("accepts pre-release strings", () => {
+      expect(extractVersion({ version: "1.0.0-rc.4" }, "test.yml")).toBe("1.0.0-rc.4");
+    });
+
+    it("throws when input is null", () => {
+      expect(() => extractVersion(null, "test.yml")).toThrow(/expected a YAML mapping/);
+    });
+
+    it("throws when input is a string instead of an object", () => {
+      expect(() => extractVersion("hello", "test.yml")).toThrow(/expected a YAML mapping/);
+    });
+
+    it("throws when version field is missing", () => {
+      expect(() => extractVersion({ files: [] }, "test.yml")).toThrow(/missing 'version' field/);
+    });
+
+    it("throws when version field is null", () => {
+      expect(() => extractVersion({ version: null }, "test.yml")).toThrow(
+        /missing 'version' field/
+      );
+    });
+
+    it("throws when version field is a number (YAML-parsed bare numeric)", () => {
+      expect(() => extractVersion({ version: 1 }, "test.yml")).toThrow(/must be a string/);
+    });
+
+    it("throws when version field is a non-semver string", () => {
+      expect(() => extractVersion({ version: "v1" }, "test.yml")).toThrow(/not a valid semver/);
+    });
+
+    it("throws when version field is an empty string", () => {
+      expect(() => extractVersion({ version: "" }, "test.yml")).toThrow(/not a valid semver/);
+    });
+
+    it("includes the label in the error message", () => {
+      expect(() => extractVersion({}, "live latest-mac.yml")).toThrow(/live latest-mac\.yml/);
+    });
+  });
+});

--- a/scripts/ci/check-version-monotonic.test.mjs
+++ b/scripts/ci/check-version-monotonic.test.mjs
@@ -1,5 +1,10 @@
 import { describe, it, expect } from "vitest";
-import { checkVersionMonotonic, extractVersion } from "./check-version-monotonic.mjs";
+import {
+  ALLOWED_PREFIXES,
+  checkVersionMonotonic,
+  extractVersion,
+  validatePrefix,
+} from "./check-version-monotonic.mjs";
 
 describe("check-version-monotonic", () => {
   describe("checkVersionMonotonic", () => {
@@ -91,6 +96,20 @@ describe("check-version-monotonic", () => {
       expect(() => extractVersion({ version: 1 }, "test.yml")).toThrow(/must be a string/);
     });
 
+    it("throws when version field is a boolean (YAML `version: true`)", () => {
+      expect(() => extractVersion({ version: true }, "test.yml")).toThrow(/must be a string/);
+    });
+
+    it("throws when version field is an array (YAML sequence)", () => {
+      expect(() => extractVersion({ version: ["1.0.0"] }, "test.yml")).toThrow(/must be a string/);
+    });
+
+    it("throws when version field is a nested object", () => {
+      expect(() => extractVersion({ version: { major: 1 } }, "test.yml")).toThrow(
+        /must be a string/
+      );
+    });
+
     it("throws when version field is a non-semver string", () => {
       expect(() => extractVersion({ version: "v1" }, "test.yml")).toThrow(/not a valid semver/);
     });
@@ -101,6 +120,46 @@ describe("check-version-monotonic", () => {
 
     it("includes the label in the error message", () => {
       expect(() => extractVersion({}, "live latest-mac.yml")).toThrow(/live latest-mac\.yml/);
+    });
+  });
+
+  describe("validatePrefix", () => {
+    it("accepts every prefix in ALLOWED_PREFIXES", () => {
+      for (const prefix of ALLOWED_PREFIXES) {
+        expect(validatePrefix(prefix)).toEqual({ ok: true });
+      }
+    });
+
+    it("exposes the canonical channel allowlist", () => {
+      // Lock the public surface — adding a channel should be a deliberate edit
+      // (the upload step in release.yml uses the same prefix to glob YAMLs).
+      expect(ALLOWED_PREFIXES).toEqual(["latest", "rc", "beta"]);
+    });
+
+    it("rejects an empty string with the not-set guidance", () => {
+      const result = validatePrefix("");
+      expect(result.ok).toBe(false);
+      expect(result.error).toContain("not set");
+      expect(result.error).toContain("latest");
+    });
+
+    it("rejects undefined with the not-set guidance", () => {
+      const result = validatePrefix(undefined);
+      expect(result.ok).toBe(false);
+      expect(result.error).toContain("not set");
+    });
+
+    it("rejects a typo (latset) so the gate doesn't silently 404 every channel", () => {
+      const result = validatePrefix("latset");
+      expect(result.ok).toBe(false);
+      expect(result.error).toContain("'latset'");
+      expect(result.error).toContain("not a known channel");
+    });
+
+    it("rejects nightly (channel was retired before the gate landed)", () => {
+      const result = validatePrefix("nightly");
+      expect(result.ok).toBe(false);
+      expect(result.error).toContain("not a known channel");
     });
   });
 });


### PR DESCRIPTION
## Summary

- Adds `scripts/ci/check-version-monotonic.mjs`, a gate that fetches the live `latest-mac.yml` and `latest-linux.yml` from `updates.daintree.org`, parses each, and refuses the publish unless `semver.gt(new, live)` passes on both platforms independently.
- Wires the gate into the `publish-daintree` job between the artifact download steps and the R2 upload, so a regressed feed can never reach clients.
- Adds `actions/checkout` and `actions/setup-node` to `publish-daintree`, which previously had neither — needed to install `semver` via `npm install --ignore-scripts`.

The reason this matters: `AutoUpdaterService` configures `autoUpdater.allowDowngrade = false` on stable. A regressed `latest-mac.yml` or `latest-linux.yml` strands installed clients permanently — they see the live remote as older than installed and stop checking until a strictly greater version than every shipped one lands. A back-merge that resurfaces an old `package.json` version, a manual tag rewind, or a release-branch botch all end the same way.

Resolves #7573

## Changes

- **`scripts/ci/check-version-monotonic.mjs`** — fetches live YAML feeds, parses version fields, compares with `semver.gt`. 404 is treated as a first release in that channel (passes). All other fetch failures fail closed — a CDN outage doesn't accidentally let a regression through. Uses `Promise.allSettled` so failures on both platforms are reported together rather than short-circuiting. `AbortController` stays armed across `response.text()` so a stalled response body also hits the 15s timeout.
- **`scripts/ci/check-version-monotonic.test.mjs`** — Vitest suite covering: strict-greater passes, equal fails, regressed fails, 404 first-release, network error fail-closed, invalid YAML fail-closed, prefix allowlist (`latest`/`rc`/`beta`), and degenerate version field types (boolean, array, nested object).
- **`.github/workflows/release.yml`** — adds `actions/checkout`, `actions/setup-node`, and the monotonic gate step to `publish-daintree`.

## Testing

- Unit tests cover the full decision matrix including edge cases (degenerate YAML, stalled body, unknown prefixes).
- Gate logic validated manually against the live `latest-mac.yml` feed with both a higher and a lower candidate version.