### PR TITLE
fix(window): audit one-renderer assumptions in project-view swap path

### DIFF
--- a/electron/services/WorktreePortBroker.ts
+++ b/electron/services/WorktreePortBroker.ts
@@ -62,7 +62,10 @@ export class WorktreePortBroker {
       return false;
     }
 
-    // Set up lifecycle listeners (stored for cleanup to prevent accumulation)
+    // Lifecycle listeners (stored for cleanup to prevent accumulation).
+    // port1.on("close") covers host-side shutdown/transfer paths where the
+    // renderer-side webContents events don't fire; closePortsForView is
+    // already idempotent via the map-deletion guard.
     const onDestroyed = () => {
       this.closePortsForView(wcId);
     };
@@ -73,10 +76,15 @@ export class WorktreePortBroker {
         this.closePortsForView(wcId);
       }
     };
+    const onPortClose = () => {
+      this.closePortsForView(wcId);
+    };
     webContents.once("destroyed", onDestroyed);
     webContents.on("did-start-navigation", onNavigation);
+    port1.on("close", onPortClose);
 
     const cleanupListeners = () => {
+      port1.removeListener("close", onPortClose);
       webContents.removeListener("destroyed", onDestroyed);
       webContents.removeListener("did-start-navigation", onNavigation);
     };

--- a/electron/services/__tests__/WorktreePortBroker.adversarial.test.ts
+++ b/electron/services/__tests__/WorktreePortBroker.adversarial.test.ts
@@ -3,17 +3,24 @@ import { beforeEach, describe, expect, it, vi } from "vitest";
 import type { WebContents } from "electron";
 import type { WorkspaceHostProcess } from "../WorkspaceHostProcess.js";
 
+type MockPort = EventEmitter & { close: ReturnType<typeof vi.fn> };
+
 const { createdChannels } = vi.hoisted(() => ({
-  createdChannels: [] as Array<{
-    port1: { close: ReturnType<typeof vi.fn> };
-    port2: { close: ReturnType<typeof vi.fn> };
-  }>,
+  createdChannels: [] as Array<{ port1: MockPort; port2: MockPort }>,
 }));
 
-vi.mock("electron", () => {
+vi.mock("electron", async () => {
+  const { EventEmitter: EE } = await import("events");
+
+  function makePort(): MockPort {
+    const ee = new EE() as MockPort;
+    ee.close = vi.fn();
+    return ee;
+  }
+
   class MockMessageChannelMain {
-    port1 = { close: vi.fn() };
-    port2 = { close: vi.fn() };
+    port1: MockPort = makePort();
+    port2: MockPort = makePort();
 
     constructor() {
       createdChannels.push(this);
@@ -279,5 +286,59 @@ describe("WorktreePortBroker adversarial", () => {
 
     expect(channel.port1.close).toHaveBeenCalledTimes(1);
     expect(broker.hasPort(webContents.id)).toBe(false);
+  });
+
+  it("closes the port when port1 emits 'close' (host-side shutdown / transfer failure)", () => {
+    // The webContents lifecycle events don't fire when the host-side shuts the
+    // port (utility process crash, port transfer failure on the workspace
+    // host). port1.on('close') is the authoritative signal for those paths.
+    const broker = new WorktreePortBroker();
+    const host = createHost();
+    const webContents = createWebContents();
+
+    expect(broker.brokerPort(asWorkspaceHostProcess(host), asWebContents(webContents))).toBe(true);
+    const channel = createdChannels[0];
+
+    expect(channel.port1.listenerCount("close")).toBe(1);
+
+    channel.port1.emit("close");
+
+    expect(channel.port1.close).toHaveBeenCalledTimes(1);
+    expect(broker.hasPort(webContents.id)).toBe(false);
+    // The webContents listeners are also cleaned up via cleanupListeners.
+    expect(webContents.listenerCount("destroyed")).toBe(0);
+    expect(webContents.listenerCount("did-start-navigation")).toBe(0);
+    // Re-entrant 'close' on the dead port does nothing (listener removed).
+    expect(channel.port1.listenerCount("close")).toBe(0);
+  });
+
+  it("removes the old port1 close listener when re-brokering the same view", () => {
+    // Re-brokering must not leave a stale onPortClose attached to the old
+    // port1 — accumulating listeners across host restarts would leak handlers.
+    const broker = new WorktreePortBroker();
+    const firstHost = createHost("/tmp/project-a");
+    const secondHost = createHost("/tmp/project-b");
+    const webContents = createWebContents();
+
+    expect(broker.brokerPort(asWorkspaceHostProcess(firstHost), asWebContents(webContents))).toBe(
+      true
+    );
+    const firstChannel = createdChannels[0];
+    expect(firstChannel.port1.listenerCount("close")).toBe(1);
+
+    expect(broker.brokerPort(asWorkspaceHostProcess(secondHost), asWebContents(webContents))).toBe(
+      true
+    );
+    const secondChannel = createdChannels[1];
+
+    // First channel's close listener must be gone after re-broker.
+    expect(firstChannel.port1.listenerCount("close")).toBe(0);
+    // Second channel has exactly one fresh listener.
+    expect(secondChannel.port1.listenerCount("close")).toBe(1);
+
+    // Emitting close on the dead first channel must not affect the broker.
+    firstChannel.port1.emit("close");
+    expect(broker.hasPort(webContents.id)).toBe(true);
+    expect(secondChannel.port1.close).not.toHaveBeenCalled();
   });
 });

--- a/electron/window/ProjectViewManager.ts
+++ b/electron/window/ProjectViewManager.ts
@@ -710,9 +710,17 @@ export class ProjectViewManager {
         });
       } else {
         console.log("[ProjectViewManager] Renderer crash, auto-reloading view");
-        notifyError(new Error("A project view crashed and was automatically reloaded."), {
-          source: "renderer-crash",
-        });
+        // Only the active view's crash is observable to the user — a cached
+        // view auto-reloading silently has no UI signal worth a toast.
+        if (projectId && projectId === this.activeProjectId) {
+          notifyError(new Error("A project view crashed and was automatically reloaded."), {
+            source: "renderer-crash",
+          });
+        } else {
+          console.warn(
+            `[ProjectViewManager] Cached view crashed and was auto-reloaded (project: ${projectId})`
+          );
+        }
         setImmediate(() => {
           if (!wc.isDestroyed()) wc.reload();
         });

--- a/electron/window/__tests__/ProjectViewManager.recovery.test.ts
+++ b/electron/window/__tests__/ProjectViewManager.recovery.test.ts
@@ -45,6 +45,9 @@ interface SetupOptions {
   onViewCrashed?: (wc: ReturnType<typeof createMockWebContents>) => void;
   /** Mirrors `projectId === activeProjectId` in the real PVM. Defaults to true. */
   isActiveProject?: boolean;
+  /** Mirrors the real `notifyError` import — kept as an injected fn so the test
+   *  doesn't need to vi.mock the module. Auto-reload branch only. */
+  notifyError?: (err: Error, ctx: { source: string }) => void;
 }
 
 /**
@@ -57,7 +60,13 @@ function setupCrashRecovery(
   wc: ReturnType<typeof createMockWebContents>,
   options: SetupOptions = {}
 ) {
-  const { entry = null, backupTimestamp = null, onViewCrashed, isActiveProject = true } = options;
+  const {
+    entry = null,
+    backupTimestamp = null,
+    onViewCrashed,
+    isActiveProject = true,
+    notifyError,
+  } = options;
   const crashTimestamps: number[] = entry?.crashTimestamps ?? [];
 
   wc.on("render-process-gone", (_event, ...args) => {
@@ -92,6 +101,13 @@ function setupCrashRecovery(
         wc.loadURL(`app://daintree/recovery.html?${params}`);
       });
     } else {
+      // Mirrors the gated notifyError in the real handler: only the active
+      // view's auto-reload is observable to the user; cached views stay quiet.
+      if (isActiveProject) {
+        notifyError?.(new Error("A project view crashed and was automatically reloaded."), {
+          source: "renderer-crash",
+        });
+      }
       setImmediate(() => {
         if (!wc.isDestroyed()) wc.reload();
       });
@@ -314,5 +330,77 @@ describe("ProjectViewManager — onViewCrashed callback (#6244)", () => {
     wc._emit("render-process-gone", { reason: "crashed", exitCode: 1 });
 
     expect(onViewCrashed).not.toHaveBeenCalled();
+  });
+});
+
+describe("ProjectViewManager — auto-reload notifyError gate (#7565)", () => {
+  beforeEach(() => {
+    vi.useFakeTimers();
+  });
+
+  afterEach(() => {
+    vi.useRealTimers();
+  });
+
+  it("fires notifyError on auto-reload when the active view crashes", () => {
+    const win = createMockWindow();
+    const wc = createMockWebContents();
+    const entry: ViewEntryLike = {
+      projectPath: "/home/user/proj-a",
+      crashTimestamps: [],
+      state: "active",
+    };
+    const notifyError = vi.fn();
+    setupCrashRecovery(win, wc, { entry, notifyError, isActiveProject: true });
+
+    wc._emit("render-process-gone", { reason: "crashed", exitCode: 1 });
+    vi.advanceTimersByTime(0);
+
+    expect(notifyError).toHaveBeenCalledTimes(1);
+    expect(notifyError.mock.calls[0][1]).toEqual({ source: "renderer-crash" });
+    expect(wc.reload).toHaveBeenCalledTimes(1);
+  });
+
+  it("does NOT fire notifyError when a cached (non-active) view auto-reloads", () => {
+    // Per CLAUDE.md notify() policy: only emit for events the user could not
+    // otherwise observe. A cached view crash-reload is invisible — the user
+    // is looking at a different project — so demote to console.warn.
+    const win = createMockWindow();
+    const wc = createMockWebContents();
+    const entry: ViewEntryLike = {
+      projectPath: "/home/user/proj-cached",
+      crashTimestamps: [],
+      state: "cached",
+    };
+    const notifyError = vi.fn();
+    setupCrashRecovery(win, wc, { entry, notifyError, isActiveProject: false });
+
+    wc._emit("render-process-gone", { reason: "crashed", exitCode: 1 });
+    vi.advanceTimersByTime(0);
+
+    expect(notifyError).not.toHaveBeenCalled();
+    // Reload still happens — the gate is on the toast, not the recovery action.
+    expect(wc.reload).toHaveBeenCalledTimes(1);
+  });
+
+  it("does not fire notifyError on the crash-loop branch (recovery page)", () => {
+    // The crash-loop threshold loads recovery.html; that's a separate UX
+    // surface from the auto-reload toast and shouldn't trigger notifyError.
+    const win = createMockWindow();
+    const wc = createMockWebContents();
+    const entry: ViewEntryLike = {
+      projectPath: "/home/user/proj-a",
+      crashTimestamps: [],
+      state: "active",
+    };
+    const notifyError = vi.fn();
+    setupCrashRecovery(win, wc, { entry, notifyError, isActiveProject: true });
+
+    crashThrice(wc);
+
+    // Two auto-reload notifies (first two crashes) then the third loads
+    // recovery.html without notifying.
+    expect(notifyError).toHaveBeenCalledTimes(2);
+    expect(wc.loadURL).toHaveBeenCalledTimes(1);
   });
 });

--- a/electron/window/createWindow.ts
+++ b/electron/window/createWindow.ts
@@ -12,6 +12,7 @@ import {
   registerWebContents,
   registerAppView,
 } from "./webContentsRegistry.js";
+import { getProjectViewManager } from "./windowRef.js";
 import path from "path";
 import { createWindowWithState } from "../windowState.js";
 import { store } from "../store.js";
@@ -300,7 +301,9 @@ export function setupBrowserWindow(
           unresponsiveDialogOpen = false;
           if (response === 1 && !win.isDestroyed()) {
             console.warn("[MAIN] User triggered force-restart of unresponsive renderer");
-            appWebContents.forcefullyCrashRenderer();
+            const activeWc = getProjectViewManager()?.getActiveView()?.webContents;
+            const target = activeWc && !activeWc.isDestroyed() ? activeWc : appWebContents;
+            if (!target.isDestroyed()) target.forcefullyCrashRenderer();
           }
         })
         .catch(() => {


### PR DESCRIPTION
## Summary

Three narrow fixes to assumptions about single-renderer project-view swaps.

- `createWindow.ts` unresponsive-dialog "Restart view" button now resolves the active view's `webContents` at click time (via `getProjectViewManager()`), with a fallback to `appWebContents` when PVM is null during shutdown — previously it captured a stale reference at dialog-creation time
- `WorktreePortBroker` subscribes to `port1.on('close')` as a fallback cleanup signal for host-side shutdown and port-transfer-failure paths; `cleanupListeners` removes the listener to prevent accumulation across re-brokering
- `ProjectViewManager.handleRenderProcessGone` gates the auto-reload `notifyError` on `projectId === activeProjectId` — crashes in cached non-active views log to `console.warn` instead of toasting

Resolves #7565

## Changes

- `electron/window/createWindow.ts` — late-resolve `webContents` in the unresponsive-dialog restart handler
- `electron/services/WorktreePortBroker.ts` — `port1` close listener as fallback cleanup signal; removed on re-broker
- `electron/window/ProjectViewManager.ts` — gate auto-reload toast on active project match
- `electron/window/__tests__/ProjectViewManager.recovery.test.ts` — 3 new tests for the notifyError gate
- `electron/services/__tests__/WorktreePortBroker.adversarial.test.ts` — 2 new tests for port1 close triggering cleanup and re-broker removing old listener; mock extended so `port1`/`port2` are `EventEmitter` instances

## Testing

Vitest 26/26 pass. Full `npm run check` clean (typecheck, channel-drift, lint-ratchet, format, build).