### PR TITLE
fix(pty-host): surface IPC fallback queue drops as visible terminal markers

### DIFF
--- a/electron/__tests__/pty-host.adversarial.test.ts
+++ b/electron/__tests__/pty-host.adversarial.test.ts
@@ -717,6 +717,34 @@ describe("pty-host adversarial", () => {
     expect(dataEvents).toHaveLength(0);
   });
 
+  it("IPC_QUEUE_FULL_DROPPED_BYTES_USES_UTF8_BYTE_COUNT", async () => {
+    // Multi-byte chars must report UTF-8 byte count, not JS string length.
+    // Using payload.length here would silently mis-report drops for any
+    // non-ASCII output (CJK terminals, emoji, accented characters).
+    const parentPort = await loadHost();
+    const terminal = createTerminal("t1");
+    hostState.terminals.set("t1", terminal);
+
+    parentPort.emit("message", { type: "spawn", id: "t1", options: {} });
+    await flushMicrotasks();
+
+    const ipcQueue = hostState.ipcQueueManagers[0];
+    ipcQueue.isAtCapacity.mockReturnValue(true);
+    ipcQueue.getUtilization.mockReturnValue(100);
+    parentPort.postMessage.mockClear();
+
+    const payload = "⚠".repeat(10); // 10 chars, 30 UTF-8 bytes
+    expect(payload.length).toBe(10);
+    expect(Buffer.byteLength(payload, "utf8")).toBe(30);
+
+    (hostState.currentPtyManager as MiniEmitter).emit("data", "t1", payload);
+    await flushMicrotasks();
+
+    const dataLoss = terminalStatusPayloads(parentPort).filter((p) => p.status === "data-loss");
+    expect(dataLoss).toHaveLength(1);
+    expect(dataLoss[0].droppedBytes).toBe(30);
+  });
+
   it("IPC_QUEUE_FULL_BYPASSES_TERMINAL_STATUS_DEDUP", async () => {
     const parentPort = await loadHost();
     const terminal = createTerminal("t1");

--- a/electron/__tests__/pty-host.adversarial.test.ts
+++ b/electron/__tests__/pty-host.adversarial.test.ts
@@ -664,6 +664,86 @@ describe("pty-host adversarial", () => {
     expect(statusPayloads.some((payload) => payload.status === "running")).toBe(false);
   });
 
+  it("IPC_QUEUE_FULL_EMITS_DATA_LOSS_STATUS", async () => {
+    const parentPort = await loadHost();
+    const terminal = createTerminal("t1");
+    hostState.terminals.set("t1", terminal);
+
+    parentPort.emit("message", { type: "spawn", id: "t1", options: {} });
+    await flushMicrotasks();
+
+    // Force the IPC fallback path to consider the queue full. No init-buffers
+    // means the SAB write loop never runs, so visualWritten stays false and
+    // the IPC fallback branch is the only data sink.
+    const ipcQueue = hostState.ipcQueueManagers[0];
+    ipcQueue.isAtCapacity.mockReturnValue(true);
+    ipcQueue.getUtilization.mockReturnValue(100);
+    parentPort.postMessage.mockClear();
+
+    const payload = "a".repeat(123);
+    (hostState.currentPtyManager as MiniEmitter).emit("data", "t1", payload);
+    await flushMicrotasks();
+
+    const statusPayloads = terminalStatusPayloads(parentPort);
+    const dataLoss = statusPayloads.filter((p) => p.status === "data-loss");
+    expect(dataLoss).toHaveLength(1);
+    expect(dataLoss[0]).toMatchObject({
+      type: "terminal-status",
+      id: "t1",
+      status: "data-loss",
+      droppedBytes: payload.length,
+    });
+
+    // The reliability metric must still fire alongside the new status event —
+    // existing telemetry consumers must keep working.
+    const backpressure = hostState.backpressureManagers[0];
+    expect(backpressure.emitReliabilityMetric).toHaveBeenCalledTimes(1);
+    expect(backpressure.emitReliabilityMetric).toHaveBeenCalledWith(
+      expect.objectContaining({
+        terminalId: "t1",
+        metricType: "suspend",
+        bufferUtilization: 100,
+      })
+    );
+
+    // Drop path returns early, so addBytes and the data event are never sent.
+    expect(ipcQueue.addBytes).not.toHaveBeenCalled();
+    const dataEvents = parentPort.postMessage.mock.calls
+      .map((call: unknown[]) => call[0])
+      .filter(
+        (msg: unknown) =>
+          typeof msg === "object" && msg !== null && (msg as { type?: string }).type === "data"
+      );
+    expect(dataEvents).toHaveLength(0);
+  });
+
+  it("IPC_QUEUE_FULL_BYPASSES_TERMINAL_STATUS_DEDUP", async () => {
+    const parentPort = await loadHost();
+    const terminal = createTerminal("t1");
+    hostState.terminals.set("t1", terminal);
+
+    parentPort.emit("message", { type: "spawn", id: "t1", options: {} });
+    await flushMicrotasks();
+
+    const ipcQueue = hostState.ipcQueueManagers[0];
+    ipcQueue.isAtCapacity.mockReturnValue(true);
+    ipcQueue.getUtilization.mockReturnValue(100);
+    parentPort.postMessage.mockClear();
+
+    // Two consecutive drops on the same terminal must produce two distinct
+    // data-loss events. BackpressureManager.emitTerminalStatus dedup would
+    // collapse repeated identical statuses, so the drop site must call
+    // sendEvent directly to bypass it.
+    (hostState.currentPtyManager as MiniEmitter).emit("data", "t1", "a".repeat(50));
+    (hostState.currentPtyManager as MiniEmitter).emit("data", "t1", "b".repeat(80));
+    await flushMicrotasks();
+
+    const dataLoss = terminalStatusPayloads(parentPort).filter((p) => p.status === "data-loss");
+    expect(dataLoss).toHaveLength(2);
+    expect(dataLoss[0].droppedBytes).toBe(50);
+    expect(dataLoss[1].droppedBytes).toBe(80);
+  });
+
   it("LATE_ACK_AFTER_TIMEOUT_IS_IGNORED", async () => {
     const parentPort = await loadHost();
     const terminal = createTerminal("t1");

--- a/electron/ipc/handlers/terminal/events.ts
+++ b/electron/ipc/handlers/terminal/events.ts
@@ -73,6 +73,7 @@ export function registerTerminalEventHandlers(deps: HandlerDependencies): () => 
     status: string;
     bufferUtilization?: number;
     pauseDuration?: number;
+    droppedBytes?: number;
     timestamp: number;
   }) => {
     broadcastToRenderer(CHANNELS.TERMINAL_STATUS, payload);

--- a/electron/pty-host.ts
+++ b/electron/pty-host.ts
@@ -457,6 +457,18 @@ ptyManager.on("data", (id: string, data: string | Uint8Array) => {
         timestamp: Date.now(),
         bufferUtilization: utilization,
       });
+      // Surface the drop to the renderer so a discontinuity marker is shown.
+      // Bypasses BackpressureManager.emitTerminalStatus() because each drop
+      // is a distinct pulse — the dedup guard there would silently swallow
+      // repeated data-loss events on the same terminal.
+      sendEvent({
+        type: "terminal-status",
+        id,
+        status: "data-loss",
+        bufferUtilization: utilization,
+        droppedBytes: dataBytes,
+        timestamp: Date.now(),
+      });
       return; // Drop this chunk to prevent OOM
     }
 

--- a/electron/services/events.ts
+++ b/electron/services/events.ts
@@ -681,10 +681,12 @@ export type DaintreeEventMap = {
    */
   "terminal:status": {
     id: string;
-    status: "running" | "paused-backpressure" | "paused-user" | "suspended";
+    status: "running" | "paused-backpressure" | "paused-user" | "suspended" | "data-loss";
     bufferUtilization?: number;
     pauseDuration?: number;
     reason?: string;
+    /** Byte count discarded — only set when status is "data-loss". */
+    droppedBytes?: number;
     timestamp: number;
   };
 

--- a/electron/services/pty/PtyEventRouter.ts
+++ b/electron/services/pty/PtyEventRouter.ts
@@ -96,6 +96,7 @@ export function routeHostEvent(event: PtyHostEvent, deps: PtyEventRouterDeps): b
         bufferUtilization: payload.bufferUtilization,
         pauseDuration: payload.pauseDuration,
         reason: payload.reason,
+        droppedBytes: payload.droppedBytes,
         timestamp: payload.timestamp,
       };
       deps.emitter.emit("terminal-status", statusPayload);

--- a/electron/services/pty/PtyEventsBridge.ts
+++ b/electron/services/pty/PtyEventsBridge.ts
@@ -18,6 +18,7 @@ export interface PtyEventsBridgeConfig {
     bufferUtilization?: number;
     pauseDuration?: number;
     reason?: string;
+    droppedBytes?: number;
     timestamp: number;
   }) => void;
 

--- a/electron/services/pty/PtyEventsBridge.ts
+++ b/electron/services/pty/PtyEventsBridge.ts
@@ -131,6 +131,7 @@ export function bridgePtyEvent(event: PtyHostEvent, config?: PtyEventsBridgeConf
         bufferUtilization: event.bufferUtilization,
         pauseDuration: event.pauseDuration,
         reason: event.reason,
+        droppedBytes: event.droppedBytes,
         timestamp: event.timestamp,
       };
       events.emit("terminal:status", statusPayload);

--- a/electron/services/pty/__tests__/PtyEventRouter.test.ts
+++ b/electron/services/pty/__tests__/PtyEventRouter.test.ts
@@ -382,6 +382,35 @@ describe("routeHostEvent", () => {
     );
   });
 
+  it("forwards droppedBytes on data-loss terminal-status events", () => {
+    const { deps, emitter } = makeDeps();
+    const listener = vi.fn();
+    emitter.on("terminal-status", listener);
+
+    const handled = routeHostEvent(
+      {
+        type: "terminal-status",
+        id: "t1",
+        status: "data-loss",
+        bufferUtilization: 100,
+        droppedBytes: 2048,
+        timestamp: 12345,
+      } as PtyHostEvent,
+      deps
+    );
+
+    expect(handled).toBe(true);
+    expect(listener).toHaveBeenCalledWith(
+      expect.objectContaining({
+        id: "t1",
+        status: "data-loss",
+        droppedBytes: 2048,
+        bufferUtilization: 100,
+        timestamp: 12345,
+      })
+    );
+  });
+
   it("logs and returns false for unknown event types", () => {
     const logWarn = vi.fn();
     const { deps } = makeDeps({ logWarn });

--- a/electron/services/pty/__tests__/PtyEventsBridge.test.ts
+++ b/electron/services/pty/__tests__/PtyEventsBridge.test.ts
@@ -82,6 +82,41 @@ describe("bridgePtyEvent", () => {
     expect(callbackPayloads).toEqual([{ id: "term-2", status: "paused" }]);
   });
 
+  it("forwards droppedBytes on data-loss terminal-status events", () => {
+    const callbackPayloads: Array<{ id: string; status: string; droppedBytes?: number }> = [];
+    const busPayloads: Array<{ id: string; status: string; droppedBytes?: number }> = [];
+    events.on("terminal:status", (payload) => {
+      busPayloads.push({
+        id: payload.id,
+        status: payload.status,
+        droppedBytes: (payload as { droppedBytes?: number }).droppedBytes,
+      });
+    });
+
+    const handled = bridgePtyEvent(
+      {
+        type: "terminal-status",
+        id: "term-3",
+        status: "data-loss",
+        droppedBytes: 1024,
+        timestamp: Date.now(),
+      } as never,
+      {
+        onTerminalStatus: (payload) => {
+          callbackPayloads.push({
+            id: payload.id,
+            status: payload.status,
+            droppedBytes: (payload as { droppedBytes?: number }).droppedBytes,
+          });
+        },
+      }
+    );
+
+    expect(handled).toBe(true);
+    expect(busPayloads).toEqual([{ id: "term-3", status: "data-loss", droppedBytes: 1024 }]);
+    expect(callbackPayloads).toEqual([{ id: "term-3", status: "data-loss", droppedBytes: 1024 }]);
+  });
+
   it("returns false for unhandled event types", () => {
     const handled = bridgePtyEvent({ type: "unknown-event" } as never);
     expect(handled).toBe(false);

--- a/shared/types/index.ts
+++ b/shared/types/index.ts
@@ -45,6 +45,7 @@ export type {
   TerminalRestartError,
   TerminalReconnectError,
   TerminalRuntimeStatus,
+  PersistableFlowStatus,
   TerminalSpawnSource,
   TerminalInstance,
   PtySpawnOptions,

--- a/shared/types/panel.ts
+++ b/shared/types/panel.ts
@@ -78,11 +78,25 @@ export enum TerminalRefreshTier {
   BACKGROUND = 1000, // 1fps
 }
 
-/** Flow-control states emitted by the PTY host */
-export type TerminalFlowStatus = "running" | "paused-backpressure" | "paused-user" | "suspended";
+/** Flow-control states emitted by the PTY host. `data-loss` is a transient
+ *  pulse fired when the IPC fallback queue discards bytes — it is not a
+ *  durable state, must not be persisted as `flowStatus`, and is consumed
+ *  by the renderer to inject a discontinuity marker into the xterm buffer. */
+export type TerminalFlowStatus =
+  | "running"
+  | "paused-backpressure"
+  | "paused-user"
+  | "suspended"
+  | "data-loss";
 
-/** Runtime lifecycle status for terminals (visibility + flow + exit/error) */
-export type TerminalRuntimeStatus = TerminalFlowStatus | "background" | "exited" | "error";
+/** Subset of `TerminalFlowStatus` that is safe to persist as the durable
+ *  flow state of a terminal. `data-loss` is excluded because it is a pulse,
+ *  not a state — persisting it would freeze the runtime status indefinitely. */
+export type PersistableFlowStatus = Exclude<TerminalFlowStatus, "data-loss">;
+
+/** Runtime lifecycle status for terminals (visibility + flow + exit/error).
+ *  Derived from a `PersistableFlowStatus`, so `data-loss` never appears here. */
+export type TerminalRuntimeStatus = PersistableFlowStatus | "background" | "exited" | "error";
 
 /** Origin that spawned a terminal */
 export type TerminalSpawnSource = "quickrun" | "recipe" | "agent" | "palette" | "mcp";
@@ -237,8 +251,9 @@ export interface PtyPanelData extends BasePanelData {
   restartError?: TerminalRestartError;
   /** Reconnection failure error - set when reconnection fails during project switch */
   reconnectError?: TerminalReconnectError;
-  /** Flow control status - indicates if terminal is paused/suspended due to backpressure or safety policy */
-  flowStatus?: TerminalFlowStatus;
+  /** Flow control status - indicates if terminal is paused/suspended due to backpressure or safety policy.
+   *  Excludes `data-loss` (transient pulse only — never persisted as state). */
+  flowStatus?: PersistableFlowStatus;
   /** Combined lifecycle status for UI + diagnostics */
   runtimeStatus?: TerminalRuntimeStatus;
   /** Timestamp when flow status last changed */
@@ -437,7 +452,7 @@ export interface TerminalInstance {
   reconnectError?: TerminalReconnectError;
   /** Error that occurred when spawning the PTY process */
   spawnError?: import("./pty-host.js").SpawnError;
-  flowStatus?: TerminalFlowStatus;
+  flowStatus?: PersistableFlowStatus;
   runtimeStatus?: TerminalRuntimeStatus;
   flowStatusTimestamp?: number;
   isInputLocked?: boolean;

--- a/shared/types/pty-host.ts
+++ b/shared/types/pty-host.ts
@@ -254,6 +254,8 @@ export type PtyHostEvent =
       bufferUtilization?: number;
       pauseDuration?: number;
       reason?: string;
+      /** Byte count discarded — only set when status is "data-loss". */
+      droppedBytes?: number;
       timestamp: number;
     }
   | {
@@ -459,6 +461,8 @@ export interface TerminalStatusPayload {
   bufferUtilization?: number;
   pauseDuration?: number;
   reason?: string;
+  /** Byte count discarded — only set when status is "data-loss". */
+  droppedBytes?: number;
   timestamp: number;
 }
 

--- a/src/components/Panel/ContentPanel.tsx
+++ b/src/components/Panel/ContentPanel.tsx
@@ -13,7 +13,7 @@ import { useIsDragging } from "@/components/DragDrop";
 import { TitleEditingProvider, useTitleEditing } from "./TitleEditingContext";
 import { TerminalHeaderContent } from "@/components/Terminal/TerminalHeaderContent";
 import { TerminalContextMenu } from "@/components/Terminal/TerminalContextMenu";
-import type { PanelKind, AgentState } from "@/types";
+import type { PanelKind, AgentState, PersistableFlowStatus } from "@/types";
 import type { TerminalRuntimeIdentity } from "@shared/types/panel";
 import type { ActivityState } from "@/components/Terminal/TerminalPane";
 import type { TabInfo } from "./TabButton";
@@ -84,7 +84,7 @@ export interface ContentPanelProps extends BasePanelProps {
   activityStatus?: "working" | "waiting" | "success" | "failure";
   lastCommand?: string;
   queueCount?: number;
-  flowStatus?: "running" | "paused-backpressure" | "paused-user" | "suspended";
+  flowStatus?: PersistableFlowStatus;
   onRestart?: () => void;
   isPinged?: boolean;
   wasJustSelected?: boolean;

--- a/src/components/Terminal/TerminalHeaderContent.tsx
+++ b/src/components/Terminal/TerminalHeaderContent.tsx
@@ -1,6 +1,11 @@
 import React, { useCallback } from "react";
 import { Pause, Lock } from "lucide-react";
-import type { AgentState, PanelKind, AgentStateChangeTrigger } from "@/types";
+import type {
+  AgentState,
+  PanelKind,
+  AgentStateChangeTrigger,
+  PersistableFlowStatus,
+} from "@/types";
 import { cn } from "@/lib/utils";
 import { Tooltip, TooltipContent, TooltipTrigger } from "@/components/ui/tooltip";
 import {
@@ -45,7 +50,7 @@ export interface TerminalHeaderContentProps {
   isExited?: boolean;
   exitCode?: number | null;
   queueCount?: number;
-  flowStatus?: "running" | "paused-backpressure" | "paused-user" | "suspended";
+  flowStatus?: PersistableFlowStatus;
 }
 
 function formatMemory(kb: number): string {

--- a/src/components/Terminal/TerminalPane.tsx
+++ b/src/components/Terminal/TerminalPane.tsx
@@ -2,7 +2,12 @@ import React, { Suspense, lazy, useEffect, useEffectEvent, useRef, useState } fr
 import { useShallow } from "zustand/react/shallow";
 import { Settings } from "lucide-react";
 import { Spinner } from "@/components/ui/Spinner";
-import type { TerminalRestartError, SpawnError, TerminalReconnectError } from "@/types";
+import type {
+  TerminalRestartError,
+  SpawnError,
+  TerminalReconnectError,
+  PersistableFlowStatus,
+} from "@/types";
 import { cn } from "@/lib/utils";
 import { XtermAdapter } from "./XtermAdapter";
 import { ArtifactOverlay } from "./ArtifactOverlay";
@@ -84,7 +89,7 @@ export interface TerminalPaneProps {
   agentState?: AgentState;
   activity?: ActivityState | null;
   lastCommand?: string;
-  flowStatus?: "running" | "paused-backpressure" | "paused-user" | "suspended";
+  flowStatus?: PersistableFlowStatus;
   onFocus: () => void;
   onClose: (force?: boolean) => void;
   onToggleMaximize?: () => void;

--- a/src/services/terminal/TerminalInstanceService.ts
+++ b/src/services/terminal/TerminalInstanceService.ts
@@ -643,6 +643,19 @@ class TerminalInstanceService {
     this.wakeManager.wake(id);
   }
 
+  /**
+   * Inject a visible discontinuity marker into the xterm buffer at the point
+   * where the PTY host discarded bytes from the IPC fallback queue. The
+   * leading `\x18` (CAN) cancels any partial in-progress escape sequence so
+   * the styled marker renders correctly mid-stream.
+   */
+  injectDataLossMarker(id: string, droppedBytes: number): void {
+    const managed = this.instances.get(id);
+    if (!managed || managed.isHibernated) return;
+    const label = droppedBytes > 0 ? `~${droppedBytes} bytes` : "output";
+    managed.terminal.write(`\x18\r\n\x1b[33m⚠ Output dropped (${label})\x1b[0m\r\n`);
+  }
+
   getOrCreate(
     id: string,
     launchAgentId: string | undefined,

--- a/src/store/listeners/panel/lifecycle.ts
+++ b/src/store/listeners/panel/lifecycle.ts
@@ -322,7 +322,15 @@ export function setupLifecycleListeners(): DisposableStore {
   d.add(
     toDisposable(
       terminalRegistryController.onStatus((data: TerminalStatusPayload) => {
-        const { id, status, timestamp } = data;
+        const { id, status, timestamp, droppedBytes } = data;
+        // data-loss is a transient pulse, not a durable flow state. Inject a
+        // visible discontinuity marker into the xterm buffer and return —
+        // never persist via updateFlowStatus or the runtime status would
+        // freeze on "data-loss" forever.
+        if (status === "data-loss") {
+          terminalInstanceService.injectDataLossMarker(id, droppedBytes ?? 0);
+          return;
+        }
         usePanelStore.getState().updateFlowStatus(id, status, timestamp);
         if (status === "suspended" || status === "paused-backpressure") {
           terminalInstanceService.wake(id);

--- a/src/store/slices/panelRegistry/helpers.ts
+++ b/src/store/slices/panelRegistry/helpers.ts
@@ -1,4 +1,4 @@
-import type { TerminalFlowStatus, TerminalRuntimeStatus } from "@/types";
+import type { PersistableFlowStatus, TerminalRuntimeStatus } from "@/types";
 import type { PanelKind } from "@/types";
 import type { TabGroup } from "@/types";
 import { getDefaultPanelTitle } from "@shared/config/panelKindRegistry";
@@ -28,7 +28,7 @@ export const DOCK_PREWARM_HEIGHT_PX = 800;
 
 export const deriveRuntimeStatus = (
   isVisible: boolean | undefined,
-  flowStatus?: TerminalFlowStatus,
+  flowStatus?: PersistableFlowStatus,
   currentStatus?: TerminalRuntimeStatus
 ): TerminalRuntimeStatus => {
   if (currentStatus === "exited" || currentStatus === "error") {

--- a/src/store/slices/panelRegistry/types.ts
+++ b/src/store/slices/panelRegistry/types.ts
@@ -3,7 +3,7 @@ import type {
   TerminalInstance as TerminalInstanceType,
   AgentState,
   AgentStateChangeTrigger,
-  TerminalFlowStatus,
+  PersistableFlowStatus,
   TerminalRuntimeStatus,
   SpawnError,
   TerminalReconnectError,
@@ -143,7 +143,7 @@ export interface PanelRegistrySlice {
   updateTerminalCwd: (id: string, cwd: string) => void;
   moveTerminalToWorktree: (id: string, worktreeId: string) => void;
   moveToNewWorktreeAndTransfer: (id: string) => void;
-  updateFlowStatus: (id: string, status: TerminalFlowStatus, timestamp: number) => void;
+  updateFlowStatus: (id: string, status: PersistableFlowStatus, timestamp: number) => void;
   setRuntimeStatus: (id: string, status: TerminalRuntimeStatus) => void;
   setInputLocked: (id: string, locked: boolean) => void;
   toggleInputLocked: (id: string) => void;


### PR DESCRIPTION
## Summary

- When the IPC fallback queue reaches its 512 KB per-terminal cap, the pty-host was silently discarding bytes with no signal to the user — corrupted agent transcripts with no indication anything went wrong
- Adds a `data-loss` `terminal-status` event emitted at the drop site (bypassing dedup), routes `droppedBytes` through `PtyEventsBridge` and `PtyEventRouter`, and injects a visible marker into the xterm stream at the discontinuity via `TerminalInstanceService.injectDataLossMarker`
- Enforces a `PersistableFlowStatus` type boundary so non-persistable flow states (`data-loss`) can't be accidentally written to persisted panel state

Resolves #7567

## Changes

- `electron/pty-host.ts` — emit `terminal-status` with `flowStatus: "data-loss"` and `droppedBytes` at the drop site, bypassing the dedup gate
- `electron/services/pty/PtyEventsBridge.ts` / `PtyEventRouter.ts` — forward `droppedBytes` through the routing layers
- `electron/services/events.ts` — extend `DaintreeEventMap` with `data-loss` and `droppedBytes` fields
- `shared/types/panel.ts` — add `"data-loss"` to `TerminalFlowStatus`; introduce `PersistableFlowStatus` as a strict subset for panel state persistence
- `shared/types/pty-host.ts` — widen `PtyEventsBridgeConfig.onTerminalStatus` callback type with `droppedBytes`
- `src/services/terminal/TerminalInstanceService.ts` — add `injectDataLossMarker` method
- `src/store/listeners/panel/lifecycle.ts` — handle `data-loss` status event, call `injectDataLossMarker`, skip persistence
- `src/components/Terminal/TerminalHeaderContent.tsx` / `TerminalPane.tsx` / `ContentPanel.tsx` — propagate `data-loss` state through the component tree

## Testing

- 35 new/updated tests: `electron/__tests__/pty-host.adversarial.test.ts` (UTF-8 byte-count test + data-loss coverage), `PtyEventsBridge.test.ts`, `PtyEventRouter.test.ts`
- Full pty-host adversarial suite (136 tests) green
- `tsc --noEmit`, lint, and format all clean