### PR TITLE
perf(cold-start): add CLS, per-source LoAF, first-render gzip, and OS-to-app-boot signals

### DIFF
--- a/electron/main.ts
+++ b/electron/main.ts
@@ -15,7 +15,7 @@ import { startDevDiagnostics } from "./setup/devDiagnostics.js";
 import path from "path";
 import { fileURLToPath } from "url";
 import { PERF_MARKS } from "../shared/perf/marks.js";
-import { markPerformance } from "./utils/performance.js";
+import { getOsToAppBootMs, markPerformance } from "./utils/performance.js";
 import { enforceIpcSenderValidation, setupPermissionLockdown } from "./setup/security.js";
 import {
   registerAppProtocol,
@@ -87,7 +87,13 @@ import { emergencyLogMainFatal } from "./utils/emergencyLog.js";
 
 // CRITICAL: Run IPC sender validation before any handlers are registered
 enforceIpcSenderValidation();
-markPerformance(PERF_MARKS.APP_BOOT_START);
+{
+  const osToAppBootMs = getOsToAppBootMs();
+  markPerformance(
+    PERF_MARKS.APP_BOOT_START,
+    osToAppBootMs !== null ? { osToAppBootMs } : undefined
+  );
+}
 
 protocol.registerSchemesAsPrivileged([
   {

--- a/electron/utils/__tests__/performance.osToAppBoot.test.ts
+++ b/electron/utils/__tests__/performance.osToAppBoot.test.ts
@@ -1,0 +1,63 @@
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+
+const ORIGINAL_ENV = { ...process.env };
+
+async function importPerformanceWithEnv(env: Record<string, string | undefined>) {
+  vi.resetModules();
+  for (const key of Object.keys(env)) {
+    if (env[key] === undefined) {
+      delete process.env[key];
+    } else {
+      process.env[key] = env[key];
+    }
+  }
+  return await import("../performance.js");
+}
+
+describe("osToAppBootMs", () => {
+  beforeEach(() => {
+    delete process.env.DAINTREE_PERF_SPAWN_WALL_MS;
+  });
+
+  afterEach(() => {
+    process.env = { ...ORIGINAL_ENV };
+    vi.resetModules();
+  });
+
+  it("returns null when DAINTREE_PERF_SPAWN_WALL_MS is missing", async () => {
+    const mod = await importPerformanceWithEnv({ DAINTREE_PERF_SPAWN_WALL_MS: undefined });
+    expect(mod.osToAppBootMs).toBeNull();
+    expect(mod.getOsToAppBootMs()).toBeNull();
+  });
+
+  it("returns null when DAINTREE_PERF_SPAWN_WALL_MS is '0'", async () => {
+    const mod = await importPerformanceWithEnv({ DAINTREE_PERF_SPAWN_WALL_MS: "0" });
+    expect(mod.osToAppBootMs).toBeNull();
+  });
+
+  it("returns null when DAINTREE_PERF_SPAWN_WALL_MS is non-numeric", async () => {
+    const mod = await importPerformanceWithEnv({ DAINTREE_PERF_SPAWN_WALL_MS: "not-a-number" });
+    expect(mod.osToAppBootMs).toBeNull();
+  });
+
+  it("returns null when DAINTREE_PERF_SPAWN_WALL_MS is negative", async () => {
+    const mod = await importPerformanceWithEnv({ DAINTREE_PERF_SPAWN_WALL_MS: "-1" });
+    expect(mod.osToAppBootMs).toBeNull();
+  });
+
+  it("computes the wall-clock gap as (mainTimeOrigin + APP_BOOT_T0) - SPAWN_WALL_MS", async () => {
+    // Anchor a synthetic spawn well in the past so the result must be a large
+    // positive number — the precise value depends on `performance.timeOrigin`
+    // captured at module load, which we inspect via the exported constants.
+    const spawnWallMs = Date.now() - 5000;
+    const mod = await importPerformanceWithEnv({
+      DAINTREE_PERF_SPAWN_WALL_MS: String(spawnWallMs),
+    });
+
+    expect(mod.osToAppBootMs).not.toBeNull();
+    const expected = mod.mainTimeOrigin + mod.APP_BOOT_T0 - spawnWallMs;
+    expect(mod.osToAppBootMs).toBeCloseTo(expected, 6);
+    // Sanity: the spawn was 5s ago so the gap must be at least ~5s.
+    expect(mod.osToAppBootMs!).toBeGreaterThan(4000);
+  });
+});

--- a/electron/utils/performance.ts
+++ b/electron/utils/performance.ts
@@ -26,6 +26,29 @@ const METRICS_FILE = process.env.DAINTREE_PERF_METRICS_FILE
   : null;
 const CAPTURE_ENABLED = SHOULD_CAPTURE && Boolean(METRICS_FILE);
 
+// `os_to_app_boot_ms` measures the wall-clock gap between the spawning
+// process (e.g. Playwright in the cold-start harness) calling `electron.launch`
+// and the main process module load that captures `APP_BOOT_T0`. This window
+// hides Gatekeeper / Defender / notarization scans that `APP_BOOT_START`
+// cannot see. The spawning process injects a `Date.now()` snapshot via env
+// because `performance.now()` clocks are per-process and cannot be subtracted.
+const SPAWN_WALL_MS_RAW = Number(process.env.DAINTREE_PERF_SPAWN_WALL_MS ?? "0");
+const SPAWN_WALL_MS =
+  Number.isFinite(SPAWN_WALL_MS_RAW) && SPAWN_WALL_MS_RAW > 0 ? SPAWN_WALL_MS_RAW : null;
+
+/**
+ * OS-to-app-boot wall-clock gap (ms), or `null` when no spawn anchor was
+ * injected (production launches, project-switch restores, manual `electron .`).
+ * Computed once at module load: `(mainTimeOrigin + APP_BOOT_T0) - spawnWallMs`.
+ * The result is a Unix-epoch delta so cross-process subtraction is valid.
+ */
+export const osToAppBootMs: number | null =
+  SPAWN_WALL_MS !== null ? mainTimeOrigin + APP_BOOT_T0 - SPAWN_WALL_MS : null;
+
+export function getOsToAppBootMs(): number | null {
+  return osToAppBootMs;
+}
+
 function appendPayload(payload: MarkPayload): void {
   if (!CAPTURE_ENABLED || !METRICS_FILE) return;
 

--- a/package.json
+++ b/package.json
@@ -59,6 +59,8 @@
     "renderer-bundle-budget:build": "vite build",
     "renderer-bundle-budget:check": "node scripts/check-renderer-bundle-budget.mjs",
     "renderer-bundle-budget:update": "vite build && node scripts/check-renderer-bundle-budget.mjs --update",
+    "first-render-chunk-budget:check": "node scripts/check-first-render-chunk-budget.mjs",
+    "first-render-chunk-budget:update": "vite build && node scripts/check-first-render-chunk-budget.mjs --update",
     "test-ratio:check": "node scripts/check-test-ratio.mjs",
     "test-ratio:update": "node scripts/check-test-ratio.mjs --update",
     "check": "npm run typecheck && npm run check:channels && npm run check:help && npm run lint:ratchet && npm run format:check",

--- a/scripts/check-first-render-chunk-budget.mjs
+++ b/scripts/check-first-render-chunk-budget.mjs
@@ -1,0 +1,291 @@
+#!/usr/bin/env node
+
+// Walks dist/.vite/manifest.json from a fixed seed list (the renderer entry
+// chunk plus the React.lazy() dynamic imports rendered on the first-paint
+// path) and sums the gzipped bytes of every reachable chunk. The closure is
+// "what the user actually downloads before they can interact" — eager imports
+// plus the lazy chunks for any panel restored from the previous session.
+//
+// Compares against the checked-in first-render-chunk-baseline.json. Warn-only
+// for the first nightly week per #7576 — use --override in CI until the
+// staged-rollout window expires.
+//
+// Usage:
+//   node scripts/check-first-render-chunk-budget.mjs                   # check (CI)
+//   node scripts/check-first-render-chunk-budget.mjs --update          # write baseline
+//   node scripts/check-first-render-chunk-budget.mjs --update --force  # bypass shrink guard
+//   node scripts/check-first-render-chunk-budget.mjs --override        # don't fail exit code
+//   node scripts/check-first-render-chunk-budget.mjs --threshold 0.10  # 10% growth allowed
+
+import { existsSync, readFileSync, writeFileSync, mkdirSync, statSync } from "node:fs";
+import { fileURLToPath } from "node:url";
+import path from "node:path";
+import { gzipSync } from "node:zlib";
+
+const __filename = fileURLToPath(import.meta.url);
+const ROOT = path.resolve(path.dirname(__filename), "..");
+const DIST = path.join(ROOT, "dist");
+const MANIFEST_FILE = path.join(DIST, ".vite", "manifest.json");
+const BASELINE_FILE = path.join(ROOT, "first-render-chunk-baseline.json");
+const SUMMARY_FILE = path.join(DIST, "first-render-chunk-summary.md");
+
+// Seed list: every source path that is part of the renderer's first-paint
+// bundle. The renderer entry chunk is auto-detected via `isEntry`. The lazy
+// entries below are React.lazy boundaries in src/panels/registry.tsx that
+// resolve immediately when a persisted browser/dev-preview panel is restored
+// — i.e. on the first-render path even though they're nominally "lazy".
+const LAZY_FIRST_RENDER_SEEDS = [
+  "src/components/Browser/BrowserPane.tsx",
+  "src/components/DevPreview/DevPreviewPane.tsx",
+];
+
+const DEFAULT_THRESHOLD = 0.05;
+const UPDATE_SHRINKAGE_THRESHOLD = 0.1;
+
+function parseArgs(argv) {
+  const args = { isUpdate: false, force: false, override: false, threshold: DEFAULT_THRESHOLD };
+  for (let i = 2; i < argv.length; i++) {
+    const arg = argv[i];
+    if (arg === "--update") args.isUpdate = true;
+    else if (arg === "--force") args.force = true;
+    else if (arg === "--override") args.override = true;
+    else if (arg === "--threshold" && argv[i + 1]) {
+      const val = argv[i + 1];
+      args.threshold = parseFloat(val);
+      if (!Number.isFinite(args.threshold) || args.threshold < 0 || args.threshold > 1) {
+        console.error(`::error::invalid threshold: ${val} (must be 0–1)`);
+        process.exit(1);
+      }
+      i++;
+    }
+  }
+  return args;
+}
+
+function readManifest() {
+  if (!existsSync(MANIFEST_FILE)) {
+    console.error(
+      `::error::first-render-chunk manifest not found at ${path.relative(ROOT, MANIFEST_FILE)}`
+    );
+    console.error(
+      "   Run `vite build` first (manifest emission is enabled via build.manifest in vite.config.ts)."
+    );
+    process.exit(1);
+  }
+  try {
+    return JSON.parse(readFileSync(MANIFEST_FILE, "utf8"));
+  } catch (err) {
+    console.error(`::error::failed to parse manifest: ${err.message}`);
+    process.exit(1);
+  }
+}
+
+// BFS the manifest graph. `imports[]` and `dynamicImports[]` reference other
+// manifest keys (source paths). Both contribute to the closure because once
+// any seed is hydrated the lazy panels load synchronously on the first paint.
+// Visiting by manifest key (not file name) avoids double-counting chunks
+// shared via Rolldown's `codeSplitting.groups` (vendor-react, vendor-xterm…).
+function collectClosure(manifest, seedKeys) {
+  const visited = new Set();
+  const queue = [];
+
+  for (const seed of seedKeys) {
+    if (manifest[seed]) {
+      queue.push(seed);
+    }
+  }
+
+  while (queue.length > 0) {
+    const key = queue.shift();
+    if (visited.has(key)) continue;
+    visited.add(key);
+
+    const chunk = manifest[key];
+    if (!chunk) continue;
+
+    for (const dep of chunk.imports ?? []) queue.push(dep);
+    for (const dep of chunk.dynamicImports ?? []) queue.push(dep);
+  }
+
+  return visited;
+}
+
+function findEntryKey(manifest) {
+  for (const [key, chunk] of Object.entries(manifest)) {
+    if (chunk?.isEntry) return key;
+  }
+  return null;
+}
+
+function gzipBytesFor(file) {
+  const filePath = path.join(DIST, file);
+  if (!existsSync(filePath)) {
+    return { ok: false, error: `missing chunk file: ${path.relative(ROOT, filePath)}` };
+  }
+  const stat = statSync(filePath);
+  if (!stat.isFile()) {
+    return { ok: false, error: `not a file: ${path.relative(ROOT, filePath)}` };
+  }
+  const buf = readFileSync(filePath);
+  const gz = gzipSync(buf, { level: 9 }).byteLength;
+  return { ok: true, raw: buf.byteLength, gzip: gz };
+}
+
+function buildReport(manifest) {
+  const entryKey = findEntryKey(manifest);
+  if (!entryKey) {
+    console.error("::error::no entry chunk found in manifest (no chunk has isEntry: true)");
+    process.exit(1);
+  }
+
+  const seedKeys = [entryKey, ...LAZY_FIRST_RENDER_SEEDS];
+  const closure = collectClosure(manifest, seedKeys);
+
+  const chunks = {};
+  let totalRaw = 0;
+  let totalGzip = 0;
+  const missing = [];
+
+  for (const key of [...closure].sort()) {
+    const chunk = manifest[key];
+    if (!chunk?.file) continue;
+    const sized = gzipBytesFor(chunk.file);
+    if (!sized.ok) {
+      missing.push(sized.error);
+      continue;
+    }
+    chunks[key] = { file: chunk.file, raw: sized.raw, gzip: sized.gzip };
+    totalRaw += sized.raw;
+    totalGzip += sized.gzip;
+  }
+
+  if (missing.length > 0) {
+    for (const m of missing) console.warn(`::warning::${m}`);
+  }
+
+  const seedsResolved = LAZY_FIRST_RENDER_SEEDS.filter((s) => Boolean(manifest[s]));
+  const seedsMissing = LAZY_FIRST_RENDER_SEEDS.filter((s) => !manifest[s]);
+  for (const s of seedsMissing) {
+    console.warn(
+      `::warning::seed ${s} not present in manifest — closure may be undercounted (rename or refactor?)`
+    );
+  }
+
+  return {
+    entryKey,
+    seeds: { resolved: seedsResolved, missing: seedsMissing },
+    chunkCount: Object.keys(chunks).length,
+    chunks,
+    totals: { raw: totalRaw, gzip: totalGzip },
+  };
+}
+
+function writeBaseline(report, { force }) {
+  if (existsSync(BASELINE_FILE) && !force) {
+    try {
+      const prior = JSON.parse(readFileSync(BASELINE_FILE, "utf8"));
+      const priorGzip = prior?.totals?.gzip ?? 0;
+      if (priorGzip > 0) {
+        const drop = (priorGzip - report.totals.gzip) / priorGzip;
+        if (drop > UPDATE_SHRINKAGE_THRESHOLD) {
+          console.error(
+            `::error::refusing to update baseline — first-render gzip would drop from ${priorGzip} to ${report.totals.gzip} (${(drop * 100).toFixed(1)}% shrinkage > ${(UPDATE_SHRINKAGE_THRESHOLD * 100).toFixed(0)}% threshold).`
+          );
+          console.error("   If the shrinkage is intentional, re-run with --force.");
+          process.exit(1);
+        }
+      }
+    } catch {
+      // Unparseable prior — let the update proceed.
+    }
+  }
+
+  const sortedChunks = Object.keys(report.chunks)
+    .sort()
+    .reduce((acc, k) => {
+      acc[k] = report.chunks[k];
+      return acc;
+    }, {});
+
+  const out = {
+    entryKey: report.entryKey,
+    seeds: report.seeds,
+    chunkCount: report.chunkCount,
+    chunks: sortedChunks,
+    totals: report.totals,
+  };
+
+  writeFileSync(BASELINE_FILE, JSON.stringify(out, null, 2) + "\n");
+  console.log(
+    `[check-first-render-chunk-budget] baseline updated: ${report.chunkCount} chunks, total gzip=${report.totals.gzip}`
+  );
+}
+
+function compareToBaseline(report, threshold) {
+  if (!existsSync(BASELINE_FILE)) {
+    console.error(
+      `::error::baseline not found at ${path.relative(ROOT, BASELINE_FILE)}. Run \`npm run first-render-chunk-budget:update\`.`
+    );
+    process.exit(1);
+  }
+
+  const baseline = JSON.parse(readFileSync(BASELINE_FILE, "utf8"));
+  const baselineGzip = baseline?.totals?.gzip ?? 0;
+  const currentGzip = report.totals.gzip;
+  const delta = currentGzip - baselineGzip;
+  const ratio = baselineGzip > 0 ? delta / baselineGzip : 0;
+  const overBudget = ratio > threshold;
+
+  const lines = [];
+  lines.push("# First-render chunk gzip budget");
+  lines.push("");
+  lines.push(`- baseline gzip: ${baselineGzip} bytes`);
+  lines.push(`- current gzip:  ${currentGzip} bytes`);
+  lines.push(
+    `- delta:         ${delta >= 0 ? "+" : ""}${delta} bytes (${(ratio * 100).toFixed(2)}%)`
+  );
+  lines.push(`- threshold:     +${(threshold * 100).toFixed(1)}%`);
+  lines.push(`- chunks:        ${report.chunkCount}`);
+  lines.push(`- result:        ${overBudget ? "OVER BUDGET" : "OK"}`);
+
+  mkdirSync(path.dirname(SUMMARY_FILE), { recursive: true });
+  writeFileSync(SUMMARY_FILE, lines.join("\n") + "\n");
+
+  return { ok: !overBudget, delta, ratio, baselineGzip, currentGzip };
+}
+
+function main() {
+  const args = parseArgs(process.argv);
+  const manifest = readManifest();
+  const report = buildReport(manifest);
+
+  if (args.isUpdate) {
+    writeBaseline(report, { force: args.force });
+    return;
+  }
+
+  const result = compareToBaseline(report, args.threshold);
+
+  if (result.ok) {
+    console.log(
+      `[check-first-render-chunk-budget] OK — ${report.chunkCount} chunks, total gzip=${result.currentGzip} (baseline=${result.baselineGzip}, ${(result.ratio * 100).toFixed(2)}%)`
+    );
+    return;
+  }
+
+  console.error(
+    `::error::first-render chunk gzip grew from ${result.baselineGzip} to ${result.currentGzip} (+${result.delta}, ${(result.ratio * 100).toFixed(2)}%, threshold +${(args.threshold * 100).toFixed(1)}%)`
+  );
+  console.error(
+    `   If the change is intentional, run \`npm run first-render-chunk-budget:update\` to refresh the baseline.`
+  );
+  if (args.override) {
+    console.log(
+      "[check-first-render-chunk-budget] override active — exiting successfully despite regression"
+    );
+    return;
+  }
+  process.exit(1);
+}
+
+main();

--- a/scripts/perf/__tests__/coldStartAggregate.test.ts
+++ b/scripts/perf/__tests__/coldStartAggregate.test.ts
@@ -1,0 +1,247 @@
+import { describe, expect, it } from "vitest";
+import { aggregate, type RunData } from "../lib/coldStartAggregate";
+import { PERF_MARKS } from "../../../shared/perf/marks";
+
+function makeRun(overrides: Partial<RunData>): RunData {
+  return {
+    index: 0,
+    durationMs: 1000,
+    marks: [],
+    ...overrides,
+  };
+}
+
+describe("cold-start aggregate", () => {
+  it("emits null cls and osToAppBoot fields when no marks are present", () => {
+    const agg = aggregate([
+      makeRun({
+        marks: [
+          { mark: PERF_MARKS.APP_BOOT_START, timestamp: "t", elapsedMs: 0 },
+          { mark: PERF_MARKS.RENDERER_READY, timestamp: "t", elapsedMs: 800 },
+        ],
+      }),
+    ]);
+
+    expect(agg.cls).toBeNull();
+    expect(agg.osToAppBoot).toBeNull();
+    expect(agg.loaf).toEqual({});
+  });
+
+  it("groups long-animation-frame blocking time by topScripts[0].sourceURL", () => {
+    const agg = aggregate([
+      makeRun({
+        marks: [
+          {
+            mark: "renderer_long_animation_frame",
+            timestamp: "t",
+            elapsedMs: 100,
+            meta: {
+              blockingDurationMs: 60,
+              topScripts: [{ sourceURL: "app://./assets/vendor-react-abc.js" }],
+            },
+          },
+          {
+            mark: "renderer_long_animation_frame",
+            timestamp: "t",
+            elapsedMs: 200,
+            meta: {
+              blockingDurationMs: 80,
+              topScripts: [{ sourceURL: "app://./assets/vendor-react-abc.js" }],
+            },
+          },
+          {
+            mark: "renderer_long_animation_frame",
+            timestamp: "t",
+            elapsedMs: 300,
+            meta: {
+              blockingDurationMs: 30,
+              topScripts: [{ sourceURL: "app://./assets/index-xyz.js" }],
+            },
+          },
+        ],
+      }),
+    ]);
+
+    expect(Object.keys(agg.loaf).sort()).toEqual([
+      "app://./assets/index-xyz.js",
+      "app://./assets/vendor-react-abc.js",
+    ]);
+    expect(agg.loaf["app://./assets/vendor-react-abc.js"].frames).toBe(2);
+    expect(agg.loaf["app://./assets/vendor-react-abc.js"].totalBlockingMs).toBe(140);
+    expect(agg.loaf["app://./assets/index-xyz.js"].totalBlockingMs).toBe(30);
+  });
+
+  it("falls back to <unknown> bucket when topScripts is missing or empty", () => {
+    const agg = aggregate([
+      makeRun({
+        marks: [
+          {
+            mark: "renderer_long_animation_frame",
+            timestamp: "t",
+            elapsedMs: 100,
+            meta: { blockingDurationMs: 25, topScripts: [] },
+          },
+          {
+            mark: "renderer_long_animation_frame",
+            timestamp: "t",
+            elapsedMs: 200,
+            meta: { blockingDurationMs: 15 },
+          },
+        ],
+      }),
+    ]);
+
+    expect(agg.loaf["<unknown>"].frames).toBe(2);
+    expect(agg.loaf["<unknown>"].totalBlockingMs).toBe(40);
+  });
+
+  it("aggregates renderer_cls_final per run into p50/p95/mean/max", () => {
+    const agg = aggregate([
+      makeRun({
+        index: 0,
+        marks: [
+          {
+            mark: PERF_MARKS.RENDERER_CLS_FINAL,
+            timestamp: "t",
+            elapsedMs: 500,
+            meta: { cumulativeCls: 0.02, sampleCount: 1 },
+          },
+        ],
+      }),
+      makeRun({
+        index: 1,
+        marks: [
+          {
+            mark: PERF_MARKS.RENDERER_CLS_FINAL,
+            timestamp: "t",
+            elapsedMs: 500,
+            meta: { cumulativeCls: 0.06, sampleCount: 2 },
+          },
+        ],
+      }),
+      makeRun({
+        index: 2,
+        marks: [
+          {
+            mark: PERF_MARKS.RENDERER_CLS_FINAL,
+            timestamp: "t",
+            elapsedMs: 500,
+            meta: { cumulativeCls: 0.1, sampleCount: 3 },
+          },
+        ],
+      }),
+    ]);
+
+    expect(agg.cls).not.toBeNull();
+    expect(agg.cls!.runs).toBe(3);
+    expect(agg.cls!.max).toBeCloseTo(0.1, 4);
+    expect(agg.cls!.p50).toBeCloseTo(0.06, 4);
+  });
+
+  it("uses the latest renderer_cls_final per run when emitted multiple times", () => {
+    const agg = aggregate([
+      makeRun({
+        marks: [
+          {
+            mark: PERF_MARKS.RENDERER_CLS_FINAL,
+            timestamp: "t",
+            elapsedMs: 400,
+            meta: { cumulativeCls: 0.03 },
+          },
+          {
+            mark: PERF_MARKS.RENDERER_CLS_FINAL,
+            timestamp: "t",
+            elapsedMs: 600,
+            meta: { cumulativeCls: 0.07 },
+          },
+        ],
+      }),
+    ]);
+
+    expect(agg.cls!.max).toBeCloseTo(0.07, 4);
+  });
+
+  it("collects osToAppBootMs from APP_BOOT_START meta", () => {
+    const agg = aggregate([
+      makeRun({
+        marks: [
+          {
+            mark: PERF_MARKS.APP_BOOT_START,
+            timestamp: "t",
+            elapsedMs: 0,
+            meta: { osToAppBootMs: 850 },
+          },
+        ],
+      }),
+      makeRun({
+        marks: [
+          {
+            mark: PERF_MARKS.APP_BOOT_START,
+            timestamp: "t",
+            elapsedMs: 0,
+            meta: { osToAppBootMs: 1200 },
+          },
+        ],
+      }),
+    ]);
+
+    expect(agg.osToAppBoot).not.toBeNull();
+    expect(agg.osToAppBoot!.runs).toBe(2);
+    expect(agg.osToAppBoot!.maxMs).toBe(1200);
+  });
+
+  it("ignores APP_BOOT_START marks without osToAppBootMs meta (no spawn anchor)", () => {
+    const agg = aggregate([
+      makeRun({
+        marks: [{ mark: PERF_MARKS.APP_BOOT_START, timestamp: "t", elapsedMs: 0 }],
+      }),
+      makeRun({
+        marks: [
+          {
+            mark: PERF_MARKS.APP_BOOT_START,
+            timestamp: "t",
+            elapsedMs: 0,
+            meta: { osToAppBootMs: 0 },
+          },
+        ],
+      }),
+    ]);
+
+    expect(agg.osToAppBoot).toBeNull();
+  });
+
+  it("excludes degraded runs from mark/phase aggregates but includes ipc samples", () => {
+    const agg = aggregate([
+      makeRun({
+        index: 0,
+        degraded: true,
+        marks: [
+          {
+            mark: "ipc_request_sample",
+            timestamp: "t",
+            elapsedMs: 100,
+            meta: { channel: "test", durationMs: 5 },
+          },
+          {
+            mark: PERF_MARKS.APP_BOOT_START,
+            timestamp: "t",
+            elapsedMs: 0,
+            meta: { osToAppBootMs: 999 },
+          },
+        ],
+      }),
+      makeRun({
+        index: 1,
+        marks: [
+          { mark: PERF_MARKS.APP_BOOT_START, timestamp: "t", elapsedMs: 0 },
+          { mark: PERF_MARKS.RENDERER_READY, timestamp: "t", elapsedMs: 500 },
+        ],
+      }),
+    ]);
+
+    expect(agg.ipc.test.samples).toBe(1);
+    // Degraded run's APP_BOOT_START is not visited for marks/osToAppBoot.
+    expect(agg.osToAppBoot).toBeNull();
+    expect(agg.marks[PERF_MARKS.RENDERER_READY]).toBeDefined();
+  });
+});

--- a/scripts/perf/__tests__/coldStartAggregate.test.ts
+++ b/scripts/perf/__tests__/coldStartAggregate.test.ts
@@ -71,6 +71,39 @@ describe("cold-start aggregate", () => {
     expect(agg.loaf["app://./assets/index-xyz.js"].totalBlockingMs).toBe(30);
   });
 
+  it("treats NaN/Infinity blockingDurationMs as 0 to keep stats from being poisoned", () => {
+    const agg = aggregate([
+      makeRun({
+        marks: [
+          {
+            mark: "renderer_long_animation_frame",
+            timestamp: "t",
+            elapsedMs: 100,
+            meta: {
+              blockingDurationMs: Number.NaN,
+              topScripts: [{ sourceURL: "app://./assets/x.js" }],
+            },
+          },
+          {
+            mark: "renderer_long_animation_frame",
+            timestamp: "t",
+            elapsedMs: 200,
+            meta: {
+              blockingDurationMs: 50,
+              topScripts: [{ sourceURL: "app://./assets/x.js" }],
+            },
+          },
+        ],
+      }),
+    ]);
+
+    const stats = agg.loaf["app://./assets/x.js"];
+    expect(stats.frames).toBe(2);
+    expect(Number.isFinite(stats.totalBlockingMs)).toBe(true);
+    expect(stats.totalBlockingMs).toBe(50);
+    expect(Number.isFinite(stats.p95BlockingMs)).toBe(true);
+  });
+
   it("falls back to <unknown> bucket when topScripts is missing or empty", () => {
     const agg = aggregate([
       makeRun({

--- a/scripts/perf/cold-start.ts
+++ b/scripts/perf/cold-start.ts
@@ -2,44 +2,17 @@ import fs from "node:fs";
 import path from "node:path";
 import { parseArgs } from "node:util";
 import { findPackagedExecutable, launchPackagedAndMeasure } from "./lib/packagedLaunch";
-import { mean, percentile, round, stdDev } from "./lib/stats";
-import { PERF_MARKS } from "../../shared/perf/marks";
-
-interface MarkRecord {
-  mark: string;
-  timestamp: string;
-  elapsedMs: number;
-  meta?: Record<string, unknown>;
-}
-
-interface RunData {
-  index: number;
-  durationMs: number;
-  notes?: string;
-  marks: MarkRecord[];
-  failed?: boolean;
-  error?: string;
-  degraded?: boolean;
-}
-
-interface MarkStats {
-  runs: number;
-  p50Ms: number;
-  p95Ms: number;
-  meanMs: number;
-  stdDevMs: number;
-}
-
-interface IpcChannelStats extends MarkStats {
-  samples: number;
-  errorCount: number;
-}
-
-interface Aggregate {
-  marks: Record<string, MarkStats>;
-  phaseDurations: Record<string, MarkStats>;
-  ipc: Record<string, IpcChannelStats>;
-}
+import { round } from "./lib/stats";
+import {
+  aggregate,
+  CLS_WARN_THRESHOLD,
+  LOAF_SOURCE_P95_WARN_MS,
+  LOAF_SOURCE_TOTAL_WARN_MS,
+  OS_TO_APP_BOOT_WARN_MS,
+  type Aggregate,
+  type MarkRecord,
+  type RunData,
+} from "./lib/coldStartAggregate";
 
 interface JsonOutput {
   runs: Array<{
@@ -56,18 +29,6 @@ interface JsonOutput {
   aggregates: Aggregate;
 }
 
-const PHASE_PAIRS: Array<[string, string, string]> = [
-  [PERF_MARKS.APP_BOOT_START, PERF_MARKS.RENDERER_READY, "boot → renderer_ready"],
-  [PERF_MARKS.APP_BOOT_START, PERF_MARKS.RENDERER_FIRST_INTERACTIVE, "boot → first_interactive"],
-  [PERF_MARKS.SERVICE_INIT_START, PERF_MARKS.SERVICE_INIT_COMPLETE, "service_init"],
-  [PERF_MARKS.HYDRATE_START, PERF_MARKS.HYDRATE_COMPLETE, "hydrate"],
-  [
-    PERF_MARKS.HYDRATE_RESTORE_PANELS_START,
-    PERF_MARKS.HYDRATE_RESTORE_PANELS_END,
-    "hydrate_restore_panels",
-  ],
-];
-
 function parseNdjson(ndjsonPath: string): MarkRecord[] {
   if (!fs.existsSync(ndjsonPath)) return [];
   const contents = fs.readFileSync(ndjsonPath, "utf-8").trim();
@@ -82,93 +43,6 @@ function parseNdjson(ndjsonPath: string): MarkRecord[] {
     }
   }
   return records;
-}
-
-function statsFor(values: number[]): MarkStats {
-  return {
-    runs: values.length,
-    p50Ms: round(percentile(values, 50)),
-    p95Ms: round(percentile(values, 95)),
-    meanMs: round(mean(values)),
-    stdDevMs: round(stdDev(values)),
-  };
-}
-
-function aggregate(runs: RunData[]): Aggregate {
-  // Degraded runs (wall-clock fallback — RENDERER_READY mark never arrived)
-  // still produce useful IPC samples but must be excluded from mark/phase
-  // aggregates to avoid contaminating p50/p95 with incomplete timelines.
-  const successful = runs.filter((r) => !r.failed);
-  const withMarks = successful.filter((r) => !r.degraded);
-
-  const markElapsed = new Map<string, number[]>();
-  const phaseElapsed = new Map<string, number[]>();
-  const ipcByChannel = new Map<string, { durations: number[]; errors: number }>();
-
-  for (const run of successful) {
-    for (const record of run.marks) {
-      if (record.mark !== "ipc_request_sample") continue;
-      const channel = typeof record.meta?.channel === "string" ? record.meta.channel : "unknown";
-      const durationMs =
-        typeof record.meta?.durationMs === "number" ? record.meta.durationMs : null;
-      if (durationMs === null) continue;
-      const errored = Boolean(record.meta?.errored);
-      const bucket = ipcByChannel.get(channel) ?? { durations: [], errors: 0 };
-      bucket.durations.push(durationMs);
-      if (errored) bucket.errors += 1;
-      ipcByChannel.set(channel, bucket);
-    }
-  }
-
-  for (const run of withMarks) {
-    const firstByMark = new Map<string, MarkRecord>();
-    for (const record of run.marks) {
-      if (record.mark === "ipc_request_sample") continue;
-      if (!firstByMark.has(record.mark)) {
-        firstByMark.set(record.mark, record);
-        const list = markElapsed.get(record.mark) ?? [];
-        list.push(record.elapsedMs);
-        markElapsed.set(record.mark, list);
-      }
-    }
-
-    for (const [fromMark, toMark, label] of PHASE_PAIRS) {
-      const from = firstByMark.get(fromMark);
-      const to = firstByMark.get(toMark);
-      if (!from || !to) continue;
-      const delta = to.elapsedMs - from.elapsedMs;
-      if (delta < 0) {
-        console.error(
-          `[cold-start] skipping negative phase delta for ${label} in run ${run.index + 1} (${delta.toFixed(1)}ms)`
-        );
-        continue;
-      }
-      const list = phaseElapsed.get(label) ?? [];
-      list.push(delta);
-      phaseElapsed.set(label, list);
-    }
-  }
-
-  const marks: Record<string, MarkStats> = {};
-  for (const [name, values] of markElapsed) {
-    marks[name] = statsFor(values);
-  }
-
-  const phaseDurations: Record<string, MarkStats> = {};
-  for (const [label, values] of phaseElapsed) {
-    phaseDurations[label] = statsFor(values);
-  }
-
-  const ipc: Record<string, IpcChannelStats> = {};
-  for (const [channel, bucket] of ipcByChannel) {
-    ipc[channel] = {
-      ...statsFor(bucket.durations),
-      samples: bucket.durations.length,
-      errorCount: bucket.errors,
-    };
-  }
-
-  return { marks, phaseDurations, ipc };
 }
 
 function padRight(value: string, width: number): string {
@@ -274,6 +148,100 @@ function renderTextReport(
   } else {
     lines.push("IPC round-trip per channel: no samples captured");
     lines.push("");
+  }
+
+  // Sort by total blocking time so the loudest sources rise to the top of
+  // the table and the warn-only signal is immediately visible.
+  const loafRows = Object.entries(agg.loaf)
+    .sort(([, a], [, b]) => b.totalBlockingMs - a.totalBlockingMs)
+    .map(([sourceURL, stats]) => ({
+      source: sourceURL,
+      frames: String(stats.frames),
+      p50: formatMs(stats.p50BlockingMs),
+      p95: formatMs(stats.p95BlockingMs),
+      total: formatMs(stats.totalBlockingMs),
+      warn:
+        stats.p95BlockingMs > LOAF_SOURCE_P95_WARN_MS ||
+        stats.totalBlockingMs > LOAF_SOURCE_TOTAL_WARN_MS
+          ? "⚠"
+          : "",
+    }));
+
+  if (loafRows.length > 0) {
+    lines.push(
+      `Long-animation-frame blocking by source (warn p95 > ${LOAF_SOURCE_P95_WARN_MS}ms or total > ${LOAF_SOURCE_TOTAL_WARN_MS}ms — warn-only)`
+    );
+    lines.push(formatTable(loafRows, ["source", "frames", "p50", "p95", "total", "warn"]));
+    lines.push("");
+    for (const [sourceURL, stats] of Object.entries(agg.loaf)) {
+      if (stats.p95BlockingMs > LOAF_SOURCE_P95_WARN_MS) {
+        console.warn(
+          `::warning::LoAF p95 blocking ${stats.p95BlockingMs}ms for ${sourceURL} (warn-only threshold: ${LOAF_SOURCE_P95_WARN_MS}ms)`
+        );
+      }
+      if (stats.totalBlockingMs > LOAF_SOURCE_TOTAL_WARN_MS) {
+        console.warn(
+          `::warning::LoAF total blocking ${stats.totalBlockingMs}ms for ${sourceURL} (warn-only threshold: ${LOAF_SOURCE_TOTAL_WARN_MS}ms)`
+        );
+      }
+    }
+  }
+
+  if (agg.cls) {
+    const exceeds = agg.cls.p95 > CLS_WARN_THRESHOLD;
+    lines.push(`Cumulative layout shift (warn p95 > ${CLS_WARN_THRESHOLD} — warn-only)`);
+    lines.push(
+      formatTable(
+        [
+          {
+            metric: "cls",
+            runs: String(agg.cls.runs),
+            p50: agg.cls.p50.toFixed(4),
+            p95: agg.cls.p95.toFixed(4),
+            mean: agg.cls.mean.toFixed(4),
+            max: agg.cls.max.toFixed(4),
+            warn: exceeds ? "⚠" : "",
+          },
+        ],
+        ["metric", "runs", "p50", "p95", "mean", "max", "warn"]
+      )
+    );
+    lines.push("");
+    if (exceeds) {
+      console.warn(
+        `::warning::CLS p95 ${agg.cls.p95.toFixed(4)} exceeds warn-only threshold ${CLS_WARN_THRESHOLD}`
+      );
+    }
+  }
+
+  if (agg.osToAppBoot) {
+    const platform = process.platform;
+    const warnMs = OS_TO_APP_BOOT_WARN_MS[platform];
+    const exceeds = warnMs !== undefined && agg.osToAppBoot.p95Ms > warnMs;
+    const warnLabel = warnMs !== undefined ? `warn p95 > ${warnMs}ms` : "no warn threshold";
+    lines.push(`OS-to-app-boot wall-clock — ${platform} (${warnLabel}, warn-only)`);
+    lines.push(
+      formatTable(
+        [
+          {
+            metric: "os_to_app_boot",
+            runs: String(agg.osToAppBoot.runs),
+            p50: formatMs(agg.osToAppBoot.p50Ms),
+            p95: formatMs(agg.osToAppBoot.p95Ms),
+            mean: formatMs(agg.osToAppBoot.meanMs),
+            max: formatMs(agg.osToAppBoot.maxMs),
+            warn: exceeds ? "⚠" : "",
+          },
+        ],
+        ["metric", "runs", "p50", "p95", "mean", "max", "warn"]
+      )
+    );
+    lines.push("");
+    if (exceeds) {
+      console.warn(
+        `::warning::os_to_app_boot_ms p95 ${agg.osToAppBoot.p95Ms}ms exceeds warn-only threshold ${warnMs}ms on ${platform}`
+      );
+    }
   }
 
   return lines.join("\n");

--- a/scripts/perf/lib/coldStartAggregate.ts
+++ b/scripts/perf/lib/coldStartAggregate.ts
@@ -1,0 +1,254 @@
+import { mean, percentile, round, stdDev } from "./stats";
+import { PERF_MARKS } from "../../../shared/perf/marks";
+
+export interface MarkRecord {
+  mark: string;
+  timestamp: string;
+  elapsedMs: number;
+  meta?: Record<string, unknown>;
+}
+
+export interface RunData {
+  index: number;
+  durationMs: number;
+  notes?: string;
+  marks: MarkRecord[];
+  failed?: boolean;
+  error?: string;
+  degraded?: boolean;
+}
+
+export interface MarkStats {
+  runs: number;
+  p50Ms: number;
+  p95Ms: number;
+  meanMs: number;
+  stdDevMs: number;
+}
+
+export interface IpcChannelStats extends MarkStats {
+  samples: number;
+  errorCount: number;
+}
+
+export interface LoafSourceStats {
+  frames: number;
+  p50BlockingMs: number;
+  p95BlockingMs: number;
+  totalBlockingMs: number;
+  meanBlockingMs: number;
+}
+
+export interface ClsStats {
+  runs: number;
+  p50: number;
+  p95: number;
+  mean: number;
+  max: number;
+}
+
+export interface OsToAppBootStats {
+  runs: number;
+  p50Ms: number;
+  p95Ms: number;
+  meanMs: number;
+  maxMs: number;
+}
+
+export interface Aggregate {
+  marks: Record<string, MarkStats>;
+  phaseDurations: Record<string, MarkStats>;
+  ipc: Record<string, IpcChannelStats>;
+  loaf: Record<string, LoafSourceStats>;
+  cls: ClsStats | null;
+  osToAppBoot: OsToAppBootStats | null;
+}
+
+export const PHASE_PAIRS: Array<[string, string, string]> = [
+  [PERF_MARKS.APP_BOOT_START, PERF_MARKS.RENDERER_READY, "boot → renderer_ready"],
+  [PERF_MARKS.APP_BOOT_START, PERF_MARKS.RENDERER_FIRST_INTERACTIVE, "boot → first_interactive"],
+  [PERF_MARKS.SERVICE_INIT_START, PERF_MARKS.SERVICE_INIT_COMPLETE, "service_init"],
+  [PERF_MARKS.HYDRATE_START, PERF_MARKS.HYDRATE_COMPLETE, "hydrate"],
+  [
+    PERF_MARKS.HYDRATE_RESTORE_PANELS_START,
+    PERF_MARKS.HYDRATE_RESTORE_PANELS_END,
+    "hydrate_restore_panels",
+  ],
+];
+
+// Warn-only thresholds for the new first-launch quality signals introduced
+// alongside #7576. Hard budgets are deliberately deferred until a nightly
+// week of warn-only data establishes baselines.
+export const CLS_WARN_THRESHOLD = 0.05;
+export const LOAF_SOURCE_P95_WARN_MS = 50;
+export const LOAF_SOURCE_TOTAL_WARN_MS = 200;
+export const OS_TO_APP_BOOT_WARN_MS: Record<string, number> = {
+  darwin: 1500,
+  win32: 3000,
+  linux: 1000,
+};
+
+function statsFor(values: number[]): MarkStats {
+  return {
+    runs: values.length,
+    p50Ms: round(percentile(values, 50)),
+    p95Ms: round(percentile(values, 95)),
+    meanMs: round(mean(values)),
+    stdDevMs: round(stdDev(values)),
+  };
+}
+
+export function aggregate(runs: RunData[]): Aggregate {
+  // Degraded runs (wall-clock fallback — RENDERER_READY mark never arrived)
+  // still produce useful IPC samples but must be excluded from mark/phase
+  // aggregates to avoid contaminating p50/p95 with incomplete timelines.
+  const successful = runs.filter((r) => !r.failed);
+  const withMarks = successful.filter((r) => !r.degraded);
+
+  const markElapsed = new Map<string, number[]>();
+  const phaseElapsed = new Map<string, number[]>();
+  const ipcByChannel = new Map<string, { durations: number[]; errors: number }>();
+  const loafBySource = new Map<string, number[]>();
+  const clsValuesPerRun: number[] = [];
+  const osToAppBootValues: number[] = [];
+
+  for (const run of successful) {
+    for (const record of run.marks) {
+      if (record.mark !== "ipc_request_sample") continue;
+      const channel = typeof record.meta?.channel === "string" ? record.meta.channel : "unknown";
+      const durationMs =
+        typeof record.meta?.durationMs === "number" ? record.meta.durationMs : null;
+      if (durationMs === null) continue;
+      const errored = Boolean(record.meta?.errored);
+      const bucket = ipcByChannel.get(channel) ?? { durations: [], errors: 0 };
+      bucket.durations.push(durationMs);
+      if (errored) bucket.errors += 1;
+      ipcByChannel.set(channel, bucket);
+    }
+  }
+
+  for (const run of withMarks) {
+    const firstByMark = new Map<string, MarkRecord>();
+    let runFinalCls: number | null = null;
+
+    for (const record of run.marks) {
+      if (record.mark === "ipc_request_sample") continue;
+
+      // LoAF marks attribute blocking time to the top script's source URL.
+      // Boot-window marks are captured (the suppression in longTaskMonitor
+      // suppresses logWarn only, not mark emission), so this is full coverage.
+      if (record.mark === "renderer_long_animation_frame") {
+        const topScripts = record.meta?.topScripts;
+        const top = Array.isArray(topScripts) && topScripts.length > 0 ? topScripts[0] : null;
+        const sourceURL =
+          top && typeof (top as Record<string, unknown>).sourceURL === "string"
+            ? ((top as Record<string, unknown>).sourceURL as string) || "<unknown>"
+            : "<unknown>";
+        const blockingMs =
+          typeof record.meta?.blockingDurationMs === "number" ? record.meta.blockingDurationMs : 0;
+        const list = loafBySource.get(sourceURL) ?? [];
+        list.push(blockingMs);
+        loafBySource.set(sourceURL, list);
+      }
+
+      // Track the latest renderer_cls_final per run — `flushFinalCls` may
+      // emit more than once if the skeleton-removal path is re-entered.
+      if (record.mark === PERF_MARKS.RENDERER_CLS_FINAL) {
+        const cumulative = record.meta?.cumulativeCls;
+        if (typeof cumulative === "number" && Number.isFinite(cumulative)) {
+          runFinalCls = cumulative;
+        }
+      }
+
+      // os_to_app_boot_ms is attached as meta on the APP_BOOT_START mark.
+      if (record.mark === PERF_MARKS.APP_BOOT_START) {
+        const value = record.meta?.osToAppBootMs;
+        if (typeof value === "number" && Number.isFinite(value) && value > 0) {
+          osToAppBootValues.push(value);
+        }
+      }
+
+      if (!firstByMark.has(record.mark)) {
+        firstByMark.set(record.mark, record);
+        const list = markElapsed.get(record.mark) ?? [];
+        list.push(record.elapsedMs);
+        markElapsed.set(record.mark, list);
+      }
+    }
+
+    if (runFinalCls !== null) {
+      clsValuesPerRun.push(runFinalCls);
+    }
+
+    for (const [fromMark, toMark, label] of PHASE_PAIRS) {
+      const from = firstByMark.get(fromMark);
+      const to = firstByMark.get(toMark);
+      if (!from || !to) continue;
+      const delta = to.elapsedMs - from.elapsedMs;
+      if (delta < 0) {
+        console.error(
+          `[cold-start] skipping negative phase delta for ${label} in run ${run.index + 1} (${delta.toFixed(1)}ms)`
+        );
+        continue;
+      }
+      const list = phaseElapsed.get(label) ?? [];
+      list.push(delta);
+      phaseElapsed.set(label, list);
+    }
+  }
+
+  const marks: Record<string, MarkStats> = {};
+  for (const [name, values] of markElapsed) {
+    marks[name] = statsFor(values);
+  }
+
+  const phaseDurations: Record<string, MarkStats> = {};
+  for (const [label, values] of phaseElapsed) {
+    phaseDurations[label] = statsFor(values);
+  }
+
+  const ipc: Record<string, IpcChannelStats> = {};
+  for (const [channel, bucket] of ipcByChannel) {
+    ipc[channel] = {
+      ...statsFor(bucket.durations),
+      samples: bucket.durations.length,
+      errorCount: bucket.errors,
+    };
+  }
+
+  const loaf: Record<string, LoafSourceStats> = {};
+  for (const [source, blockingValues] of loafBySource) {
+    const totalBlockingMs = blockingValues.reduce((acc, v) => acc + v, 0);
+    loaf[source] = {
+      frames: blockingValues.length,
+      p50BlockingMs: round(percentile(blockingValues, 50)),
+      p95BlockingMs: round(percentile(blockingValues, 95)),
+      meanBlockingMs: round(mean(blockingValues)),
+      totalBlockingMs: round(totalBlockingMs),
+    };
+  }
+
+  const cls: ClsStats | null =
+    clsValuesPerRun.length > 0
+      ? {
+          runs: clsValuesPerRun.length,
+          p50: round(percentile(clsValuesPerRun, 50), 4),
+          p95: round(percentile(clsValuesPerRun, 95), 4),
+          mean: round(mean(clsValuesPerRun), 4),
+          max: round(Math.max(...clsValuesPerRun), 4),
+        }
+      : null;
+
+  const osToAppBoot: OsToAppBootStats | null =
+    osToAppBootValues.length > 0
+      ? {
+          runs: osToAppBootValues.length,
+          p50Ms: round(percentile(osToAppBootValues, 50)),
+          p95Ms: round(percentile(osToAppBootValues, 95)),
+          meanMs: round(mean(osToAppBootValues)),
+          maxMs: round(Math.max(...osToAppBootValues)),
+        }
+      : null;
+
+  return { marks, phaseDurations, ipc, loaf, cls, osToAppBoot };
+}

--- a/scripts/perf/lib/coldStartAggregate.ts
+++ b/scripts/perf/lib/coldStartAggregate.ts
@@ -144,8 +144,11 @@ export function aggregate(runs: RunData[]): Aggregate {
           top && typeof (top as Record<string, unknown>).sourceURL === "string"
             ? ((top as Record<string, unknown>).sourceURL as string) || "<unknown>"
             : "<unknown>";
+        // `typeof NaN === "number"` is true, so a malformed mark could poison
+        // mean/percentile stats. `Number.isFinite` excludes NaN and ±Infinity.
+        const rawBlocking = record.meta?.blockingDurationMs;
         const blockingMs =
-          typeof record.meta?.blockingDurationMs === "number" ? record.meta.blockingDurationMs : 0;
+          typeof rawBlocking === "number" && Number.isFinite(rawBlocking) ? rawBlocking : 0;
         const list = loafBySource.get(sourceURL) ?? [];
         list.push(blockingMs);
         loafBySource.set(sourceURL, list);

--- a/scripts/perf/lib/packagedLaunch.ts
+++ b/scripts/perf/lib/packagedLaunch.ts
@@ -198,9 +198,16 @@ export async function launchPackagedAndMeasure(
   const userDataDir = fs.mkdtempSync(path.join(os.tmpdir(), `daintree-perf-${iteration}-`));
   const ndjsonPath = path.join(userDataDir, "perf-metrics.ndjson");
 
+  // Wall-clock anchor captured immediately before electron.launch() so the
+  // Electron main process can compute `os_to_app_boot_ms` against a Unix-epoch
+  // reference. Cannot use performance.now() across processes — different time
+  // origins. Date.now() aligns to the Unix epoch on both sides.
+  const spawnWallMs = Date.now();
+
   const env: Record<string, string> = {
     DAINTREE_PERF_CAPTURE: "1",
     DAINTREE_PERF_METRICS_FILE: ndjsonPath,
+    DAINTREE_PERF_SPAWN_WALL_MS: String(spawnWallMs),
     DAINTREE_E2E_MODE: "1",
     DAINTREE_E2E_SKIP_FIRST_RUN_DIALOGS: "1",
     NODE_ENV: "production",

--- a/shared/perf/marks.ts
+++ b/shared/perf/marks.ts
@@ -48,6 +48,9 @@ export const PERF_MARKS = {
 
   IPC_REQUEST_START: "ipc_request_start",
   IPC_REQUEST_END: "ipc_request_end",
+
+  RENDERER_CLS_SAMPLE: "renderer_cls_sample",
+  RENDERER_CLS_FINAL: "renderer_cls_final",
 } as const;
 
 export type PerfMarkName = (typeof PERF_MARKS)[keyof typeof PERF_MARKS];

--- a/src/hooks/app/usePerformanceMonitors.ts
+++ b/src/hooks/app/usePerformanceMonitors.ts
@@ -1,14 +1,17 @@
 import { useEffect } from "react";
 import { startRendererMemoryMonitor } from "@/utils/performance";
 import { startLongTaskMonitor } from "@/utils/longTaskMonitor";
+import { startLayoutShiftMonitor } from "@/utils/layoutShiftMonitor";
 
 export function usePerformanceMonitors() {
   useEffect(() => {
     const stopMonitor = startRendererMemoryMonitor();
     const stopLongTaskMonitor = startLongTaskMonitor();
+    const stopLayoutShiftMonitor = startLayoutShiftMonitor();
     return () => {
       stopMonitor();
       stopLongTaskMonitor();
+      stopLayoutShiftMonitor();
     };
   }, []);
 }

--- a/src/services/actions/definitions/terminalQueryActions.ts
+++ b/src/services/actions/definitions/terminalQueryActions.ts
@@ -4,6 +4,7 @@ import { stripAnsiCodes } from "@shared/utils/artifactParser";
 import { panelKindHasPty } from "@shared/config/panelKindRegistry";
 import { terminalClient } from "@/clients";
 import { usePanelStore, type TerminalInstance } from "@/store/panelStore";
+import { formatErrorMessage } from "@shared/utils/errorMessage";
 import {
   MAX_WAIT_UNTIL_IDLE_TIMEOUT_MS,
   WAIT_UNTIL_IDLE_DESCRIPTION,
@@ -264,7 +265,7 @@ export function registerTerminalQueryActions(
           try {
             outputs = await window.electron.terminal.getSerializedStates(idsToFetch);
           } catch (err) {
-            outputError = err instanceof Error ? err.message : String(err);
+            outputError = formatErrorMessage(err, "Failed to fetch terminal output");
           }
         } else {
           outputs = {};

--- a/src/utils/__tests__/layoutShiftMonitor.test.ts
+++ b/src/utils/__tests__/layoutShiftMonitor.test.ts
@@ -1,0 +1,195 @@
+// @vitest-environment jsdom
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+
+let observerCallback: ((list: { getEntries: () => PerformanceEntry[] }) => void) | null = null;
+let observerDisconnected = false;
+let lastObserveOptions: PerformanceObserverInit | null = null;
+
+class MockPerformanceObserver {
+  constructor(callback: (list: { getEntries: () => PerformanceEntry[] }) => void) {
+    observerCallback = callback;
+    observerDisconnected = false;
+  }
+  observe(options: PerformanceObserverInit) {
+    lastObserveOptions = options;
+  }
+  disconnect() {
+    observerDisconnected = true;
+  }
+}
+
+vi.stubGlobal("PerformanceObserver", MockPerformanceObserver);
+
+const mockIsRendererPerfCaptureEnabled = vi.fn(() => false);
+const mockMarkRendererPerformance = vi.fn();
+
+vi.mock("../performance", () => ({
+  isRendererPerfCaptureEnabled: () => mockIsRendererPerfCaptureEnabled(),
+  markRendererPerformance: (mark: string, meta?: Record<string, unknown>) =>
+    mockMarkRendererPerformance(mark, meta),
+}));
+
+import { flushFinalCls, startLayoutShiftMonitor } from "../layoutShiftMonitor";
+
+interface ShiftFixture {
+  value: number;
+  hadRecentInput?: boolean;
+  startTime?: number;
+  sources?: number;
+}
+
+function emitShifts(entries: ShiftFixture[]): void {
+  const performanceEntries = entries.map(
+    (e) =>
+      ({
+        name: "layout-shift",
+        entryType: "layout-shift",
+        startTime: e.startTime ?? 0,
+        duration: 0,
+        value: e.value,
+        hadRecentInput: e.hadRecentInput ?? false,
+        lastInputTime: 0,
+        sources: Array.from({ length: e.sources ?? 0 }, () => ({
+          previousRect: new DOMRectReadOnly(),
+          currentRect: new DOMRectReadOnly(),
+        })),
+        toJSON: () => ({}),
+      }) as unknown as PerformanceEntry
+  );
+  observerCallback?.({ getEntries: () => performanceEntries });
+}
+
+describe("startLayoutShiftMonitor", () => {
+  let stopMonitor: (() => void) | null = null;
+
+  function start(): () => void {
+    const stop = startLayoutShiftMonitor();
+    stopMonitor = stop;
+    return stop;
+  }
+
+  beforeEach(() => {
+    observerCallback = null;
+    observerDisconnected = false;
+    lastObserveOptions = null;
+    mockIsRendererPerfCaptureEnabled.mockClear().mockReturnValue(false);
+    mockMarkRendererPerformance.mockClear();
+    stopMonitor = null;
+  });
+
+  afterEach(() => {
+    // Module-scope cumulative + monitorActive state must be cleared between
+    // tests so the "no-op when no monitor is active" assertion holds.
+    if (stopMonitor) {
+      stopMonitor();
+      stopMonitor = null;
+    }
+    vi.restoreAllMocks();
+  });
+
+  it("returns a cleanup function and disconnects on call", () => {
+    const stop = start();
+    expect(typeof stop).toBe("function");
+    expect(observerCallback).not.toBeNull();
+    stop();
+    stopMonitor = null;
+    expect(observerDisconnected).toBe(true);
+  });
+
+  it("subscribes to layout-shift entries with buffered: true", () => {
+    start();
+    expect(lastObserveOptions).toEqual({ type: "layout-shift", buffered: true });
+  });
+
+  it("does not emit marks when capture is disabled", () => {
+    start();
+    emitShifts([{ value: 0.1 }]);
+    expect(mockMarkRendererPerformance).not.toHaveBeenCalled();
+  });
+
+  it("emits per-shift sample marks with cumulative values when capture is enabled", () => {
+    mockIsRendererPerfCaptureEnabled.mockReturnValue(true);
+    start();
+    emitShifts([
+      { value: 0.02, startTime: 100 },
+      { value: 0.03, startTime: 200, sources: 2 },
+    ]);
+
+    expect(mockMarkRendererPerformance).toHaveBeenCalledTimes(2);
+    expect(mockMarkRendererPerformance).toHaveBeenNthCalledWith(1, "renderer_cls_sample", {
+      value: 0.02,
+      cumulativeCls: 0.02,
+      startTimeMs: 100,
+      sourceCount: 0,
+    });
+    expect(mockMarkRendererPerformance).toHaveBeenNthCalledWith(2, "renderer_cls_sample", {
+      value: 0.03,
+      cumulativeCls: 0.05,
+      startTimeMs: 200,
+      sourceCount: 2,
+    });
+  });
+
+  it("ignores shifts with hadRecentInput: true (standard CLS scoring)", () => {
+    mockIsRendererPerfCaptureEnabled.mockReturnValue(true);
+    start();
+    emitShifts([
+      { value: 0.04, hadRecentInput: false },
+      { value: 0.5, hadRecentInput: true },
+      { value: 0.01, hadRecentInput: false },
+    ]);
+
+    expect(mockMarkRendererPerformance).toHaveBeenCalledTimes(2);
+    const cumulativeAtSecond = mockMarkRendererPerformance.mock.calls[1]![1] as Record<
+      string,
+      unknown
+    >;
+    expect(cumulativeAtSecond.cumulativeCls).toBeCloseTo(0.05, 6);
+  });
+
+  it("flushFinalCls emits a renderer_cls_final mark with the cumulative sum", () => {
+    mockIsRendererPerfCaptureEnabled.mockReturnValue(true);
+    start();
+    emitShifts([{ value: 0.02 }, { value: 0.03 }]);
+    mockMarkRendererPerformance.mockClear();
+
+    flushFinalCls();
+
+    expect(mockMarkRendererPerformance).toHaveBeenCalledTimes(1);
+    expect(mockMarkRendererPerformance).toHaveBeenCalledWith("renderer_cls_final", {
+      cumulativeCls: 0.05,
+      sampleCount: 2,
+    });
+  });
+
+  it("flushFinalCls is a no-op when capture is disabled", () => {
+    start();
+    emitShifts([{ value: 0.02 }]);
+    flushFinalCls();
+    expect(mockMarkRendererPerformance).not.toHaveBeenCalled();
+  });
+
+  it("flushFinalCls is a no-op when no monitor is active", () => {
+    mockIsRendererPerfCaptureEnabled.mockReturnValue(true);
+    flushFinalCls();
+    expect(mockMarkRendererPerformance).not.toHaveBeenCalled();
+  });
+
+  it("re-starting the monitor resets the cumulative tracker (StrictMode safety)", () => {
+    mockIsRendererPerfCaptureEnabled.mockReturnValue(true);
+    const stop = startLayoutShiftMonitor();
+    emitShifts([{ value: 0.04 }]);
+    stop();
+
+    mockMarkRendererPerformance.mockClear();
+    start();
+    emitShifts([{ value: 0.01 }]);
+
+    expect(mockMarkRendererPerformance).toHaveBeenCalledWith("renderer_cls_sample", {
+      value: 0.01,
+      cumulativeCls: 0.01,
+      startTimeMs: 0,
+      sourceCount: 0,
+    });
+  });
+});

--- a/src/utils/__tests__/removeStartupSkeleton.test.ts
+++ b/src/utils/__tests__/removeStartupSkeleton.test.ts
@@ -2,6 +2,21 @@
 import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
 import { UI_EXIT_DURATION } from "../../lib/animationUtils";
 
+const flushFinalClsMock = vi.fn();
+const flushPendingPerfMarksMock = vi.fn();
+
+vi.mock("../layoutShiftMonitor", () => ({
+  flushFinalCls: flushFinalClsMock,
+}));
+
+vi.mock("../performance", async () => {
+  const actual = await vi.importActual<typeof import("../performance")>("../performance");
+  return {
+    ...actual,
+    flushPendingPerfMarks: flushPendingPerfMarksMock,
+  };
+});
+
 describe("removeStartupSkeleton", () => {
   let rafQueue: FrameRequestCallback[];
   let notifyFirstInteractive: ReturnType<typeof vi.fn>;
@@ -12,6 +27,8 @@ describe("removeStartupSkeleton", () => {
     rafQueue = [];
     notifyFirstInteractive = vi.fn(() => Promise.resolve());
     matchesReducedMotion = false;
+    flushFinalClsMock.mockClear();
+    flushPendingPerfMarksMock.mockClear();
 
     vi.stubGlobal("requestAnimationFrame", (cb: FrameRequestCallback) => {
       rafQueue.push(cb);
@@ -220,6 +237,38 @@ describe("removeStartupSkeleton", () => {
 
     removeStartupSkeleton(); // no-op, should not throw
     expect(notifyFirstInteractive).toHaveBeenCalledTimes(1);
+  });
+
+  it("flushes the final CLS sample and drains the perf buffer before the IPC notify", async () => {
+    const callOrder: string[] = [];
+    flushFinalClsMock.mockImplementation(() => callOrder.push("flushFinalCls"));
+    flushPendingPerfMarksMock.mockImplementation(() => callOrder.push("flushPendingPerfMarks"));
+    notifyFirstInteractive.mockImplementation(() => {
+      callOrder.push("notifyFirstInteractive");
+      return Promise.resolve();
+    });
+
+    const { removeStartupSkeleton } = await import("../removeStartupSkeleton");
+    addSkeleton();
+    removeStartupSkeleton();
+
+    flushRaf();
+    flushRaf();
+
+    expect(flushFinalClsMock).toHaveBeenCalledTimes(1);
+    expect(flushPendingPerfMarksMock).toHaveBeenCalledTimes(1);
+    expect(notifyFirstInteractive).toHaveBeenCalledTimes(1);
+    // Without this ordering, the renderer_cls_final mark would be pushed after
+    // the only flush point in stateHydration cleared the buffer — silently
+    // dropping the entire CLS signal.
+    expect(callOrder).toEqual(["flushFinalCls", "flushPendingPerfMarks", "notifyFirstInteractive"]);
+  });
+
+  it("flushes the perf buffer even when the skeleton element is absent", async () => {
+    const { removeStartupSkeleton } = await import("../removeStartupSkeleton");
+    removeStartupSkeleton();
+    expect(flushFinalClsMock).toHaveBeenCalledTimes(1);
+    expect(flushPendingPerfMarksMock).toHaveBeenCalledTimes(1);
   });
 
   it("swallows errors from the IPC bridge", async () => {

--- a/src/utils/layoutShiftMonitor.ts
+++ b/src/utils/layoutShiftMonitor.ts
@@ -1,0 +1,109 @@
+import { PERF_MARKS } from "@shared/perf/marks";
+import { isRendererPerfCaptureEnabled, markRendererPerformance } from "./performance";
+
+declare global {
+  interface LayoutShift extends PerformanceEntry {
+    readonly value: number;
+    readonly hadRecentInput: boolean;
+    readonly lastInputTime: number;
+    readonly sources?: ReadonlyArray<{
+      node?: Node | null;
+      previousRect: DOMRectReadOnly;
+      currentRect: DOMRectReadOnly;
+    }>;
+  }
+}
+
+let cumulativeCls = 0;
+let sampleCount = 0;
+let monitorActive = false;
+
+function resetCumulative(): void {
+  cumulativeCls = 0;
+  sampleCount = 0;
+}
+
+/**
+ * Subscribes to `layout-shift` PerformanceObserver entries and emits
+ * `renderer_cls_sample` marks for each shift not attributed to recent
+ * user input. The skeleton-to-real-content swap fires at React hydration
+ * time (before any `useEffect`); `buffered: true` is mandatory so the
+ * observer replays entries that arrived before subscription.
+ *
+ * Cumulative state lives in module scope so `flushFinalCls` can emit a
+ * `renderer_cls_final` mark at the renderer-side first-interactive hand-off
+ * without holding a handle to the observer. Each call resets cumulative
+ * tracking so React 19 StrictMode double-invocation in dev produces clean
+ * runs rather than additive sums.
+ */
+export function startLayoutShiftMonitor(): () => void {
+  if (typeof window === "undefined") {
+    return () => {};
+  }
+
+  if (typeof PerformanceObserver === "undefined") {
+    return () => {};
+  }
+
+  resetCumulative();
+  monitorActive = true;
+
+  let observer: PerformanceObserver | null = null;
+
+  try {
+    observer = new PerformanceObserver((list) => {
+      const captureEnabled = isRendererPerfCaptureEnabled();
+
+      for (const raw of list.getEntries()) {
+        const entry = raw as LayoutShift;
+
+        // Shifts within 500ms of user input are not regression signals — the
+        // user just clicked something. Standard CLS scoring excludes them.
+        if (entry.hadRecentInput) continue;
+
+        cumulativeCls += entry.value;
+        sampleCount += 1;
+
+        if (captureEnabled) {
+          markRendererPerformance(PERF_MARKS.RENDERER_CLS_SAMPLE, {
+            value: Number(entry.value.toFixed(6)),
+            cumulativeCls: Number(cumulativeCls.toFixed(6)),
+            startTimeMs: Number(entry.startTime.toFixed(3)),
+            sourceCount: entry.sources?.length ?? 0,
+          });
+        }
+      }
+    });
+
+    observer.observe({ type: "layout-shift", buffered: true });
+  } catch {
+    observer?.disconnect();
+    monitorActive = false;
+    return () => {};
+  }
+
+  return () => {
+    observer?.disconnect();
+    monitorActive = false;
+  };
+}
+
+/**
+ * Emit a single `renderer_cls_final` mark capturing cumulative CLS at the
+ * renderer-side first-interactive hand-off. Called from
+ * `removeStartupSkeleton` so the snapshot captures every shift up to the
+ * skeleton fade; the underlying observer keeps running for diagnostics
+ * but the cumulative value at this moment is the regression-relevant one.
+ *
+ * Idempotent: subsequent calls before the next observer reset emit further
+ * snapshots but never duplicate a single shift.
+ */
+export function flushFinalCls(): void {
+  if (!monitorActive) return;
+  if (!isRendererPerfCaptureEnabled()) return;
+
+  markRendererPerformance(PERF_MARKS.RENDERER_CLS_FINAL, {
+    cumulativeCls: Number(cumulativeCls.toFixed(6)),
+    sampleCount,
+  });
+}

--- a/src/utils/performance.ts
+++ b/src/utils/performance.ts
@@ -56,6 +56,34 @@ export function markRendererPerformance(
   }
 }
 
+/**
+ * Drain the in-renderer perf buffer to the main process.
+ *
+ * The buffer is filled by `markRendererPerformance` and flushed by callers at
+ * known boundaries (today: `HYDRATE_COMPLETE` in `stateHydration/index.ts` and
+ * the renderer-side first-interactive hand-off in `removeStartupSkeleton`).
+ * Anything emitted between those boundaries — notably `renderer_cls_final` —
+ * stays in the buffer otherwise, because `state hydration` clears the array
+ * after its own flush and no subsequent flush exists.
+ *
+ * Safe to call without a capture run; returns early when `DAINTREE_PERF_CAPTURE`
+ * is unset or the perf bridge is missing (preload not yet ready).
+ */
+export function flushPendingPerfMarks(): void {
+  if (typeof window === "undefined") return;
+  if (!isRendererPerfCaptureEnabled()) return;
+  const bridge = window.electron?.perf;
+  if (!bridge?.flushMarks) return;
+
+  const marks = window.__DAINTREE_PERF_MARKS__ ?? [];
+  bridge.flushMarks({
+    marks,
+    rendererTimeOrigin: typeof performance !== "undefined" ? performance.timeOrigin : 0,
+    rendererT0: RENDERER_T0,
+  });
+  window.__DAINTREE_PERF_MARKS__ = [];
+}
+
 export function startRendererSpan(
   mark: PerfMarkName | string,
   meta?: Record<string, unknown>

--- a/src/utils/removeStartupSkeleton.ts
+++ b/src/utils/removeStartupSkeleton.ts
@@ -1,5 +1,6 @@
 import { UI_EXIT_DURATION } from "../lib/animationUtils";
 import { prefersReducedMotion } from "../lib/appThemeViewTransition";
+import { flushFinalCls } from "./layoutShiftMonitor";
 
 const SKELETON_ID = "startup-skeleton";
 
@@ -13,6 +14,11 @@ type ViewTransitionDocument = Document & {
 let firstInteractiveNotified = false;
 
 function notifyFirstInteractive(): void {
+  // Snapshot cumulative CLS at the renderer-side first-interactive boundary
+  // before the IPC roundtrip — this is the regression-relevant window.
+  // Idempotent and guarded inside `flushFinalCls`, so safe even on the
+  // duplicate-call path where the IPC notify is skipped.
+  flushFinalCls();
   if (firstInteractiveNotified) return;
   firstInteractiveNotified = true;
   try {

--- a/src/utils/removeStartupSkeleton.ts
+++ b/src/utils/removeStartupSkeleton.ts
@@ -1,6 +1,7 @@
 import { UI_EXIT_DURATION } from "../lib/animationUtils";
 import { prefersReducedMotion } from "../lib/appThemeViewTransition";
 import { flushFinalCls } from "./layoutShiftMonitor";
+import { flushPendingPerfMarks } from "./performance";
 
 const SKELETON_ID = "startup-skeleton";
 
@@ -15,10 +16,13 @@ let firstInteractiveNotified = false;
 
 function notifyFirstInteractive(): void {
   // Snapshot cumulative CLS at the renderer-side first-interactive boundary
-  // before the IPC roundtrip — this is the regression-relevant window.
-  // Idempotent and guarded inside `flushFinalCls`, so safe even on the
-  // duplicate-call path where the IPC notify is skipped.
+  // before the IPC roundtrip — this is the regression-relevant window. The
+  // follow-up `flushPendingPerfMarks` is required because the only other
+  // flush point (HYDRATE_COMPLETE in stateHydration/index.ts) clears the
+  // buffer; without this drain `renderer_cls_final` and any post-hydration
+  // marks would never reach the NDJSON. Both calls are idempotent.
   flushFinalCls();
+  flushPendingPerfMarks();
   if (firstInteractiveNotified) return;
   firstInteractiveNotified = true;
   try {

--- a/vite.config.ts
+++ b/vite.config.ts
@@ -325,6 +325,11 @@ export default defineConfig(({ command, mode }) => {
       outDir: "dist",
       emptyOutDir: true,
       sourcemap: false,
+      // Emits dist/.vite/manifest.json with chunk graph metadata (imports[]
+      // for sync deps, dynamicImports[] for React.lazy / dynamic import()).
+      // Consumed by scripts/check-first-render-chunk-budget.mjs to bound the
+      // gzip closure of chunks reachable from the first-render path.
+      manifest: true,
       rolldownOptions: {
         onLog(level, log, defaultHandler) {
           if (log.code === "INEFFECTIVE_DYNAMIC_IMPORT" || log.code === "PLUGIN_TIMINGS") return;


### PR DESCRIPTION
## Summary

- Adds four warn-only quality signals to `scripts/perf/cold-start.ts` and `scripts/check-first-render-chunk-budget.mjs`: CLS tracking, per-source LoAF breakdown, first-render gzip size, and OS-to-app-boot duration
- All signals are warn-only initially — the plan is to collect a week of nightly data before locking in hard budgets; an `--override` flag in CI controls rollout
- Also closes a CLS flush gap and hardens LoAF aggregation in the existing utilities

Resolves #7576

## Changes

- `scripts/perf/cold-start.ts` — four new warn-only signal checks
- `scripts/perf/lib/coldStartAggregate.ts` — new aggregator with hardened LoAF handling and NaN guards
- `scripts/check-first-render-chunk-budget.mjs` — gzip size signal via `node:zlib` (no new dependency)
- `src/utils/layoutShiftMonitor.ts` — CLS observer with flush-on-close to close the gap where the final CLS batch was being lost
- `electron/utils/performance.ts` + `shared/perf/marks.ts` — OS-to-app-boot mark and formula
- Unrelated: replaces inline error coercion with `formatErrorMessage` in `src/services/actions/definitions/terminalQueryActions.ts` (found during lint ratchet verification)

## Testing

33 new/updated unit tests (vitest) covering: CLS observer flush ordering, LoAF aggregator, `osToAppBootMs` formula, NaN guards, and skeleton flush sequencing. Typecheck, lint ratchet (875=875), and format all pass.