### PR TITLE
fix(updater): classify Electron net::ERR_* errors as transient and retry

### DIFF
--- a/electron/services/AutoUpdaterService.ts
+++ b/electron/services/AutoUpdaterService.ts
@@ -53,6 +53,33 @@ const PERMANENT_CERT_ERROR_CODES = new Set([
   "ERR_TLS_CERT_ALTNAME_INVALID",
   "CERT_UNTRUSTED",
 ]);
+// Issue #7592: Electron's net stack rejects with errors whose only signal is
+// `err.message = "net::ERR_*"` — no Node-style `code`, no `cause`. These two
+// allowlists cover the Chromium tokens we explicitly know how to classify.
+// Anything outside both sets falls through to the permanent path (fail closed).
+const TRANSIENT_NET_ERROR_TOKENS = new Set([
+  "ERR_INTERNET_DISCONNECTED",
+  "ERR_NETWORK_CHANGED",
+  "ERR_CONNECTION_RESET",
+  "ERR_CONNECTION_ABORTED",
+  "ERR_CONNECTION_CLOSED",
+  "ERR_CONNECTION_TIMED_OUT",
+  "ERR_TIMED_OUT",
+  "ERR_NAME_NOT_RESOLVED",
+  "ERR_DNS_TIMED_OUT",
+  "ERR_ADDRESS_UNREACHABLE",
+]);
+const PERMANENT_NET_ERROR_TOKENS = new Set([
+  "ERR_CERT_DATE_INVALID",
+  "ERR_CERT_AUTHORITY_INVALID",
+  "ERR_CERT_COMMON_NAME_INVALID",
+  "ERR_CERT_REVOKED",
+  "ERR_SSL_PROTOCOL_ERROR",
+  "ERR_BLOCKED_BY_CLIENT",
+  "ERR_NETWORK_ACCESS_DENIED",
+  "ERR_HSTS_POLICY_BYPASSED",
+]);
+const ELECTRON_NET_TOKEN_RE = /net::([A-Z0-9_]+)/;
 const STABLE_FEED_URL = "https://updates.daintree.org/releases/";
 const NIGHTLY_FEED_URL = "https://updates.daintree.org/nightly/";
 const { autoUpdater } = electronUpdater;
@@ -164,12 +191,13 @@ class AutoUpdaterService {
   }
 
   // electron-updater 6.3.x doesn't surface a categorized error type, so classify
-  // by Node `err.code` (network/DNS) and `err.statusCode` (HTTP). Walk the
-  // `cause` chain so transient codes nested by builder-util-runtime's HTTP
-  // executor (or future Node error-chaining) aren't hidden from the classifier.
-  // Cert errors at any depth return false immediately (permanent wins); transient
-  // signals are deferred until the full chain is walked so a deeper cert error
-  // can override. Anything we can't positively prove is transient is treated as
+  // by Node `err.code` (network/DNS), `err.statusCode` (HTTP), and `err.message`
+  // (Electron net errors, which carry a `net::ERR_*` token in the message and
+  // no `code`). Walk the `cause` chain so signals nested by builder-util-runtime
+  // or future Node error-chaining aren't hidden from the classifier. Cert errors
+  // at any depth return false immediately (permanent wins); transient signals
+  // are deferred until the full chain is walked so a deeper cert error can
+  // override. Anything we can't positively prove is transient is treated as
   // permanent — fail closed so we don't loop on a misconfigured feed.
   private isTransientUpdateError(err: unknown): boolean {
     let current: unknown = err;
@@ -185,6 +213,14 @@ class AutoUpdaterService {
         if (statusCode === 404 || statusCode === 401 || statusCode === 403) return false;
         if (statusCode >= 500 && statusCode < 600) foundTransient = true;
         if (statusCode === 408 || statusCode === 429) foundTransient = true;
+      }
+      const message = (current as { message?: unknown }).message;
+      if (typeof message === "string") {
+        const token = ELECTRON_NET_TOKEN_RE.exec(message)?.[1];
+        if (token) {
+          if (PERMANENT_NET_ERROR_TOKENS.has(token)) return false;
+          if (TRANSIENT_NET_ERROR_TOKENS.has(token)) foundTransient = true;
+        }
       }
       current = (current as { cause?: unknown }).cause;
     }

--- a/electron/services/AutoUpdaterService.ts
+++ b/electron/services/AutoUpdaterService.ts
@@ -63,6 +63,7 @@ const TRANSIENT_NET_ERROR_TOKENS = new Set([
   "ERR_CONNECTION_RESET",
   "ERR_CONNECTION_ABORTED",
   "ERR_CONNECTION_CLOSED",
+  "ERR_CONNECTION_REFUSED",
   "ERR_CONNECTION_TIMED_OUT",
   "ERR_TIMED_OUT",
   "ERR_NAME_NOT_RESOLVED",
@@ -79,7 +80,7 @@ const PERMANENT_NET_ERROR_TOKENS = new Set([
   "ERR_NETWORK_ACCESS_DENIED",
   "ERR_HSTS_POLICY_BYPASSED",
 ]);
-const ELECTRON_NET_TOKEN_RE = /net::([A-Z0-9_]+)/;
+const ELECTRON_NET_TOKEN_RE = /net::([A-Z0-9_]+)/g;
 const STABLE_FEED_URL = "https://updates.daintree.org/releases/";
 const NIGHTLY_FEED_URL = "https://updates.daintree.org/nightly/";
 const { autoUpdater } = electronUpdater;
@@ -216,8 +217,11 @@ class AutoUpdaterService {
       }
       const message = (current as { message?: unknown }).message;
       if (typeof message === "string") {
-        const token = ELECTRON_NET_TOKEN_RE.exec(message)?.[1];
-        if (token) {
+        // Walk every `net::ERR_*` token in the message — a permanent token
+        // anywhere in the string must short-circuit even if a transient token
+        // appears first (preserves permanent-wins inside a single message).
+        for (const match of message.matchAll(ELECTRON_NET_TOKEN_RE)) {
+          const token = match[1];
           if (PERMANENT_NET_ERROR_TOKENS.has(token)) return false;
           if (TRANSIENT_NET_ERROR_TOKENS.has(token)) foundTransient = true;
         }

--- a/electron/services/__tests__/AutoUpdaterService.test.ts
+++ b/electron/services/__tests__/AutoUpdaterService.test.ts
@@ -290,6 +290,20 @@ describe("AutoUpdaterService", () => {
       );
     });
 
+    it("does not schedule background retry for manual-check transient errors", () => {
+      // Manual checks own their own retry button — the background retry path
+      // would shadow it. The wasManual guard must short-circuit even when the
+      // error would otherwise classify as transient (issue #7592).
+      vi.advanceTimersByTime(STARTUP_JITTER_MAX_MS);
+      autoUpdaterMock.checkForUpdatesAndNotify.mockClear();
+
+      autoUpdaterService.checkForUpdatesManually();
+      errorHandler(new Error("net::ERR_INTERNET_DISCONNECTED"));
+      vi.advanceTimersByTime(60_000);
+
+      expect(autoUpdaterMock.checkForUpdatesAndNotify).not.toHaveBeenCalled();
+    });
+
     it("resets isManualCheck flag when update-available fires", () => {
       autoUpdaterService.checkForUpdatesManually();
       availableHandler({ version: "2.0.0" });
@@ -1430,6 +1444,56 @@ describe("AutoUpdaterService", () => {
 
     it("does not retry on HTTP 403 (forbidden)", () => {
       errorHandler(Object.assign(new Error("forbidden"), { statusCode: 403 }));
+      vi.advanceTimersByTime(60_000);
+
+      expect(autoUpdaterMock.checkForUpdatesAndNotify).not.toHaveBeenCalled();
+    });
+
+    it("retries on Electron net::ERR_INTERNET_DISCONNECTED (issue #7592)", () => {
+      // Telemetry shows Electron net errors arrive with the token only in
+      // err.message, no err.code — must be classified as transient.
+      errorHandler(new Error("net::ERR_INTERNET_DISCONNECTED"));
+      vi.advanceTimersByTime(36_000);
+
+      expect(autoUpdaterMock.checkForUpdatesAndNotify).toHaveBeenCalledTimes(1);
+    });
+
+    it("retries on Electron net::ERR_NETWORK_CHANGED", () => {
+      errorHandler(new Error("net::ERR_NETWORK_CHANGED"));
+      vi.advanceTimersByTime(36_000);
+
+      expect(autoUpdaterMock.checkForUpdatesAndNotify).toHaveBeenCalledTimes(1);
+    });
+
+    it("retries on Electron net token nested under err.cause", () => {
+      const cause = new Error("net::ERR_INTERNET_DISCONNECTED");
+      const wrapper = Object.assign(new Error("request failed"), { cause });
+
+      errorHandler(wrapper);
+      vi.advanceTimersByTime(36_000);
+
+      expect(autoUpdaterMock.checkForUpdatesAndNotify).toHaveBeenCalledTimes(1);
+    });
+
+    it("does not retry on Electron net::ERR_CERT_AUTHORITY_INVALID", () => {
+      errorHandler(new Error("net::ERR_CERT_AUTHORITY_INVALID"));
+      vi.advanceTimersByTime(60_000);
+
+      expect(autoUpdaterMock.checkForUpdatesAndNotify).not.toHaveBeenCalled();
+    });
+
+    it("permanent net token in cause wins over transient outer message", () => {
+      const cause = new Error("net::ERR_CERT_AUTHORITY_INVALID");
+      const wrapper = Object.assign(new Error("net::ERR_INTERNET_DISCONNECTED"), { cause });
+
+      errorHandler(wrapper);
+      vi.advanceTimersByTime(60_000);
+
+      expect(autoUpdaterMock.checkForUpdatesAndNotify).not.toHaveBeenCalled();
+    });
+
+    it("does not retry on unknown Electron net token (fail closed)", () => {
+      errorHandler(new Error("net::ERR_SOME_UNKNOWN_VALUE"));
       vi.advanceTimersByTime(60_000);
 
       expect(autoUpdaterMock.checkForUpdatesAndNotify).not.toHaveBeenCalled();

--- a/electron/services/__tests__/AutoUpdaterService.test.ts
+++ b/electron/services/__tests__/AutoUpdaterService.test.ts
@@ -1498,6 +1498,27 @@ describe("AutoUpdaterService", () => {
 
       expect(autoUpdaterMock.checkForUpdatesAndNotify).not.toHaveBeenCalled();
     });
+
+    it("retries on Electron net::ERR_CONNECTION_REFUSED", () => {
+      // Symmetry with the Node `ECONNREFUSED` code in TRANSIENT_ERROR_CODES —
+      // a brief firewall block or server restart is recoverable.
+      errorHandler(new Error("net::ERR_CONNECTION_REFUSED"));
+      vi.advanceTimersByTime(36_000);
+
+      expect(autoUpdaterMock.checkForUpdatesAndNotify).toHaveBeenCalledTimes(1);
+    });
+
+    it("permanent net token wins when both tokens appear in same message", () => {
+      // Even if a transient token appears first in the message, a permanent
+      // cert token elsewhere in the same string must short-circuit. Real
+      // Electron messages are single-token, but the invariant must hold.
+      errorHandler(
+        new Error("net::ERR_INTERNET_DISCONNECTED chained with net::ERR_CERT_AUTHORITY_INVALID")
+      );
+      vi.advanceTimersByTime(60_000);
+
+      expect(autoUpdaterMock.checkForUpdatesAndNotify).not.toHaveBeenCalled();
+    });
   });
 
   describe("menu state lifecycle", () => {


### PR DESCRIPTION
## Summary

- The transient error classifier in `AutoUpdaterService.ts` only inspected `err.code`, `err.statusCode`, and nested `cause` chains — Electron `net::ERR_*` errors surface only in `err.message`, so they were classified as permanent and skipped the retry schedule entirely.
- Added an `ELECTRON_TRANSIENT_NET_ERRORS` allowlist and extended the cause-chain walk to inspect `message` fields for `net::ERR_*` tokens. `ERR_CONNECTION_REFUSED` is now treated as transient. Permanent-wins semantics are preserved — cert/TLS errors still take precedence when present anywhere in the chain.

Resolves #7592

## Changes

- `electron/services/AutoUpdaterService.ts` — added `ELECTRON_TRANSIENT_NET_ERRORS` allowlist; extended `isTransientUpdateError()` to scan `message` fields during the cause-chain walk; reclassified `ERR_CONNECTION_REFUSED` as transient
- `electron/services/__tests__/AutoUpdaterService.test.ts` — 7 new test cases: `ERR_INTERNET_DISCONNECTED` retries, `ERR_NETWORK_CHANGED` retries, nested cause-chain detection, cert failures stay permanent, permanent-wins with multi-token messages, `ERR_CONNECTION_REFUSED` retries, unknown net errors stay permanent

## Testing

147 tests pass. The 7 new cases cover the full classification matrix for Electron net errors: known-transient retries, nested detection, and the two permanent-wins paths (cert code and cert token in a multi-token message).