### PR TITLE
fix(tooltip): tighten slide-in distance from 8px to 4px

### DIFF
--- a/src/components/ui/__tests__/radix-animation-classes.test.tsx
+++ b/src/components/ui/__tests__/radix-animation-classes.test.tsx
@@ -46,10 +46,10 @@ const TOOLTIP_CLASSES = [
   "data-[state=closed]:duration-[100ms]",
   "data-[state=closed]:fade-out-0",
   "data-[state=closed]:zoom-out-95",
-  "data-[side=bottom]:slide-in-from-top-2",
-  "data-[side=left]:slide-in-from-right-2",
-  "data-[side=right]:slide-in-from-left-2",
-  "data-[side=top]:slide-in-from-bottom-2",
+  "data-[side=bottom]:slide-in-from-top-1",
+  "data-[side=left]:slide-in-from-right-1",
+  "data-[side=right]:slide-in-from-left-1",
+  "data-[side=top]:slide-in-from-bottom-1",
 ];
 
 function expectAllInString(haystack: string, needles: string[], label: string) {

--- a/src/components/ui/tooltip.tsx
+++ b/src/components/ui/tooltip.tsx
@@ -19,7 +19,7 @@ const TooltipContent = React.forwardRef<
       style={{ transformOrigin: "var(--radix-tooltip-content-transform-origin)", ...style }}
       className={cn(
         "z-[var(--z-popover)] overflow-hidden rounded-[var(--radius-md)] surface-overlay shadow-overlay px-3 py-1.5 text-xs text-daintree-text",
-        "animate-in fade-in-0 zoom-in-95 duration-150 data-[state=closed]:animate-out data-[state=closed]:duration-[100ms] data-[state=closed]:fade-out-0 data-[state=closed]:zoom-out-95 data-[side=bottom]:slide-in-from-top-2 data-[side=left]:slide-in-from-right-2 data-[side=right]:slide-in-from-left-2 data-[side=top]:slide-in-from-bottom-2",
+        "animate-in fade-in-0 zoom-in-95 duration-150 data-[state=closed]:animate-out data-[state=closed]:duration-[100ms] data-[state=closed]:fade-out-0 data-[state=closed]:zoom-out-95 data-[side=bottom]:slide-in-from-top-1 data-[side=left]:slide-in-from-right-1 data-[side=right]:slide-in-from-left-1 data-[side=top]:slide-in-from-bottom-1",
         className
       )}
       {...props}


### PR DESCRIPTION
## Summary

- Reduces the tooltip slide-in distance from 8px to 4px by swapping `slide-in-from-*-2` to `slide-in-from-*-1` in `src/components/ui/tooltip.tsx`. 8px reads as the tooltip flying in from somewhere rather than appearing at the trigger — 4px is much closer to what the motion should feel like.
- Alternative worth eyeballing: drop the four `slide-in-from-*` classes entirely and let `fade-in-0 zoom-in-95` carry the entry. The zoom already emanates from the trigger via `--radix-tooltip-content-transform-origin`, so the slide is decorative weight a one-line label doesn't need. Leaving that call to the reviewer — the 4px default ships cleanly either way.
- Popover slide distance is intentionally untouched. The larger surface benefits from the spatial cue.

Resolves #7598

## Changes

- `src/components/ui/tooltip.tsx` — four `slide-in-from-*-2` → `slide-in-from-*-1` token swaps on the enter animation classes
- `src/components/ui/__tests__/radix-animation-classes.test.tsx` — `TOOLTIP_CLASSES` updated to match

## Testing

Co-located animation class test updated and passing. No other test surface touches tooltip slide classes.