### PR TITLE
fix(palette): align backdrop animation with Tier 2-fast

### DIFF
--- a/src/components/Fleet/__tests__/FleetPickerPalette.test.tsx
+++ b/src/components/Fleet/__tests__/FleetPickerPalette.test.tsx
@@ -15,6 +15,7 @@ vi.mock("@/lib/animationUtils", () => ({
   UI_PALETTE_ENTER_DURATION: 0,
   UI_PALETTE_EXIT_DURATION: 0,
   getUiTransitionDuration: () => 0,
+  getUiPaletteTransitionDuration: () => 0,
 }));
 
 vi.mock("@/hooks/useAnimatedPresence", () => ({

--- a/src/components/ui/AppPaletteDialog.tsx
+++ b/src/components/ui/AppPaletteDialog.tsx
@@ -15,14 +15,11 @@ import {
 import { useAnimatedPresence } from "@/hooks/useAnimatedPresence";
 import { usePaletteStore } from "@/store/paletteStore";
 import {
-  UI_ENTER_DURATION,
-  UI_EXIT_DURATION,
   UI_PALETTE_ENTER_DURATION,
   UI_PALETTE_EXIT_DURATION,
   UI_ENTER_EASING,
   UI_EXIT_EASING,
   UI_DOHERTY_THRESHOLD,
-  getUiTransitionDuration,
 } from "@/lib/animationUtils";
 
 export const KBD_CLASS =
@@ -64,7 +61,7 @@ export function AppPaletteDialog({
 
   const { isVisible, shouldRender } = useAnimatedPresence({
     isOpen,
-    animationDuration: getUiTransitionDuration("exit"),
+    animationDuration: UI_PALETTE_EXIT_DURATION,
     onAnimateOut: restoreFocus,
   });
 
@@ -185,7 +182,9 @@ export function AppPaletteDialog({
         isVisible ? "opacity-100" : "opacity-0"
       )}
       style={{
-        transitionDuration: isVisible ? `${UI_ENTER_DURATION}ms` : `${UI_EXIT_DURATION}ms`,
+        transitionDuration: isVisible
+          ? `${UI_PALETTE_ENTER_DURATION}ms`
+          : `${UI_PALETTE_EXIT_DURATION}ms`,
         transitionTimingFunction: "linear",
       }}
       onClick={handleBackdropClick}

--- a/src/components/ui/AppPaletteDialog.tsx
+++ b/src/components/ui/AppPaletteDialog.tsx
@@ -20,6 +20,7 @@ import {
   UI_ENTER_EASING,
   UI_EXIT_EASING,
   UI_DOHERTY_THRESHOLD,
+  getUiPaletteTransitionDuration,
 } from "@/lib/animationUtils";
 
 export const KBD_CLASS =
@@ -61,7 +62,7 @@ export function AppPaletteDialog({
 
   const { isVisible, shouldRender } = useAnimatedPresence({
     isOpen,
-    animationDuration: UI_PALETTE_EXIT_DURATION,
+    animationDuration: getUiPaletteTransitionDuration("exit"),
     onAnimateOut: restoreFocus,
   });
 

--- a/src/lib/animationUtils.ts
+++ b/src/lib/animationUtils.ts
@@ -85,6 +85,17 @@ export function getUiTransitionDuration(direction: "enter" | "exit"): number {
   return direction === "enter" ? UI_ENTER_DURATION : UI_EXIT_DURATION;
 }
 
+export function getUiPaletteTransitionDuration(direction: "enter" | "exit"): number {
+  if (typeof window === "undefined" || typeof document === "undefined") {
+    return direction === "enter" ? UI_PALETTE_ENTER_DURATION : UI_PALETTE_EXIT_DURATION;
+  }
+
+  const performanceMode = document.body.dataset.performanceMode === "true";
+  if (performanceMode) return 0;
+
+  return direction === "enter" ? UI_PALETTE_ENTER_DURATION : UI_PALETTE_EXIT_DURATION;
+}
+
 export const PANEL_MINIMIZE_DURATION = 120;
 export const PANEL_RESTORE_DURATION = DURATION_200;
 


### PR DESCRIPTION
## Summary

- The `AppPaletteDialog` backdrop was animating on the dialog tier (200ms enter / 120ms exit) instead of the Tier 2-fast palette tier (150ms enter / 100ms exit), causing a visible 50ms desync where the inner panel finished before the backdrop on entry
- Swaps `transitionDuration` to `UI_PALETTE_ENTER_DURATION` / `UI_PALETTE_EXIT_DURATION` and passes `UI_PALETTE_EXIT_DURATION` into `useAnimatedPresence` so the unmount gate matches the 100ms exit
- Adds `getUiPaletteTransitionDuration` to `animationUtils.ts` — mirrors the existing `getUiTransitionDuration` pattern and returns 0 in performance mode, keeping the short-circuit intact

Resolves #7599

## Changes

- `src/components/ui/AppPaletteDialog.tsx` — swap backdrop `transitionDuration`, pass palette exit duration to `useAnimatedPresence`, remove unused dialog-tier imports
- `src/lib/animationUtils.ts` — add `getUiPaletteTransitionDuration` helper

## Testing

- Opened the command palette and verified backdrop and panel animate in sync at the faster tier
- Verified `motion-reduce` and `data-performance-mode` bypasses remain intact
- Typecheck, lint, format, and build all pass