### PR TITLE
fix(layout): polish dock drop-target ladder and tokenize trash hint dwell

### DIFF
--- a/src/components/Layout/ContentDock.tsx
+++ b/src/components/Layout/ContentDock.tsx
@@ -26,6 +26,8 @@ import {
   SortableDockItem,
   SortableDockPlaceholder,
   DOCK_PLACEHOLDER_ID,
+  useIsDragging,
+  useIsWorktreeSortDragging,
 } from "@/components/DragDrop";
 import { useWorktrees } from "@/hooks/useWorktrees";
 import { useHorizontalScrollControls } from "@/hooks";
@@ -148,6 +150,14 @@ export function ContentDock({ density = "normal" }: ContentDockProps) {
     data: { container: "dock" },
   });
 
+  // Mirror TrashContainer's ghost-scrim ladder: show a subtle in-flight cue for
+  // any panel drag, then a stronger armed cue when actually over the dock.
+  // Worktree-card sort drags also flip isDragging but cannot drop here, so a
+  // phantom drop target would be misleading — exclude them.
+  const isDragging = useIsDragging();
+  const isWorktreeSortDragging = useIsWorktreeSortDragging();
+  const isPanelDragging = isDragging && !isWorktreeSortDragging;
+
   // Sync droppable ref with scroll container ref using stable callback
   // This prevents ResizeObserver thrashing that causes infinite update loops
   const combinedRef = useCallback(
@@ -264,6 +274,7 @@ export function ContentDock({ density = "normal" }: ContentDockProps) {
               ref={combinedRef}
               className={cn(
                 "flex items-center gap-[var(--dock-gap)] overflow-x-auto overscroll-x-none flex-1 min-h-[var(--dock-item-height)] no-scrollbar scroll-smooth px-1 transition-colors",
+                isPanelDragging && "bg-overlay-subtle",
                 isOver &&
                   "bg-overlay-soft ring-2 ring-border-default ring-inset rounded-[var(--radius-md)]"
               )}

--- a/src/components/Layout/TrashContainer.tsx
+++ b/src/components/Layout/TrashContainer.tsx
@@ -13,16 +13,11 @@ import {
   useIsWorktreeSortDragging,
   TRASH_DROPPABLE_ID,
 } from "@/components/DragDrop";
-import { DURATION_200 } from "@/lib/animationUtils";
+import { DURATION_200, UI_TRANSIENT_HINT_DWELL_MS } from "@/lib/animationUtils";
 import type { TerminalInstance } from "@/store";
 import type { TrashedTerminal, TrashedTerminalGroupMetadata } from "@/store/slices";
 import { TrashBinItem } from "./TrashBinItem";
 import { TrashGroupItem } from "./TrashGroupItem";
-
-// How long the "Moved to trash" hint stays visible above the trash icon after
-// a panel is closed. One second is enough to draw the eye to the trash without
-// dwelling — discovery cue, not an undo affordance (the trash itself is that).
-const MOVED_HINT_DURATION_MS = 1_000;
 
 interface TrashContainerProps {
   trashedTerminals: Array<{
@@ -95,7 +90,7 @@ export function TrashContainer({ trashedTerminals, compact = false }: TrashConta
   // so back-to-back closes keep showing the hint instead of flickering off.
   useEffect(() => {
     if (!showMovedHint) return;
-    const timer = setTimeout(() => setShowMovedHint(false), MOVED_HINT_DURATION_MS);
+    const timer = setTimeout(() => setShowMovedHint(false), UI_TRANSIENT_HINT_DWELL_MS);
     return () => clearTimeout(timer);
   }, [showMovedHint, trashedTerminals.length]);
 

--- a/src/lib/animationUtils.ts
+++ b/src/lib/animationUtils.ts
@@ -56,6 +56,12 @@ export const UI_DOHERTY_THRESHOLD = 400;
  *  label change before the toast disappears. */
 export const UI_ACTION_SUCCESS_DWELL_MS = 2000;
 
+/** How long a transient discovery hint stays visible after the event that
+ *  triggered it (e.g. the "Moved to trash" tooltip above the trash icon after
+ *  a panel is closed). One second is enough to draw the eye without dwelling
+ *  — discovery cue, not an undo affordance. */
+export const UI_TRANSIENT_HINT_DWELL_MS = 1_000;
+
 export const UI_TOOLTIP_DELAY_DURATION = 500;
 export const UI_TOOLTIP_SKIP_DELAY_DURATION = DURATION_150;
 


### PR DESCRIPTION
## Summary

- The trash pill already shows a weak ghost scrim the moment a panel drag starts, giving the user early confirmation it's a valid drop target. The dock had no equivalent — it only reacted once the cursor was over it. This adds `bg-overlay-subtle` to the dock scroll container during any panel drag, so both targets signal availability at the same time. The stronger `bg-overlay-soft ring-2 ring-border-default ring-inset` armed state is preserved for true drag-over. Worktree sort drags are excluded since they can't drop on the dock.
- Extracts the local `MOVED_HINT_DURATION_MS = 1_000` from `TrashContainer.tsx` into `animationUtils.ts` as `UI_TRANSIENT_HINT_DWELL_MS`. Pure refactor — value unchanged, just moved to a more appropriate home alongside the other dwell constants.

Closes #7601

## Changes

- `src/lib/animationUtils.ts` — new `UI_TRANSIENT_HINT_DWELL_MS` constant with JSDoc
- `src/components/Layout/TrashContainer.tsx` — removed local constant, import extended, usage updated
- `src/components/Layout/ContentDock.tsx` — extended `DragDrop` import, derived `isPanelDragging`, added one `cn()` clause for the in-flight scrim

## Testing

- Full typecheck (`tsc --noEmit`) passes
- `npm run check` (typecheck, lint, format, build) clean
- Visual-only change — no E2E tests directly applicable; CI will run standard suites