### PR TITLE
feat(notifications): move unread dot to leading edge of notification rows

### DIFF
--- a/src/components/Notifications/NotificationCenterEntry.tsx
+++ b/src/components/Notifications/NotificationCenterEntry.tsx
@@ -137,10 +137,7 @@ function NotificationCenterEntryImpl({
     >
       <span
         aria-hidden="true"
-        className={cn(
-          "w-1.5 shrink-0 self-center",
-          isNew && "h-1.5 rounded-full bg-status-info"
-        )}
+        className={cn("w-1.5 shrink-0 self-center", isNew && "h-1.5 rounded-full bg-status-info")}
       />
       <div className={cn("mt-0.5 shrink-0", config.className)}>
         <Icon className="h-3.5 w-3.5" />

--- a/src/components/Notifications/NotificationCenterEntry.tsx
+++ b/src/components/Notifications/NotificationCenterEntry.tsx
@@ -135,6 +135,13 @@ function NotificationCenterEntryImpl({
           "focus-visible:outline-hidden focus-visible:ring-1 focus-visible:ring-inset focus-visible:ring-daintree-accent/50"
       )}
     >
+      <span
+        aria-hidden="true"
+        className={cn(
+          "w-1.5 shrink-0 self-center",
+          isNew && "h-1.5 rounded-full bg-status-info"
+        )}
+      />
       <div className={cn("mt-0.5 shrink-0", config.className)}>
         <Icon className="h-3.5 w-3.5" />
       </div>
@@ -230,9 +237,6 @@ function NotificationCenterEntryImpl({
             </span>
           );
         })()}
-        {isNew && (
-          <span aria-hidden="true" className="h-1.5 w-1.5 rounded-full bg-status-info shrink-0" />
-        )}
         {(entry.context?.projectId || entry.context?.eventKind) &&
           (() => {
             const eventKind = entry.context?.eventKind;

--- a/src/components/Notifications/__tests__/NotificationCenterEntry.test.tsx
+++ b/src/components/Notifications/__tests__/NotificationCenterEntry.test.tsx
@@ -97,6 +97,34 @@ describe("NotificationCenterEntry unread signal", () => {
       expect(row.className).not.toMatch(/bg-daintree-accent\/\[0\.04\]/);
     }
   });
+
+  it("renders the unread dot at the leading edge, as the first child of the row", () => {
+    const { container } = render(<NotificationCenterEntry entry={makeEntry()} isNew />);
+    const slot = container.firstElementChild?.firstElementChild;
+    expect(slot).not.toBeNull();
+    if (slot instanceof HTMLElement) {
+      expect(slot.tagName).toBe("SPAN");
+      expect(slot.className).toMatch(/bg-status-info/);
+      expect(slot.className).toMatch(/rounded-full/);
+    }
+  });
+
+  it("renders an invisible leading slot (no dot styling) when isNew is false", () => {
+    const { container } = render(<NotificationCenterEntry entry={makeEntry()} />);
+    const slot = container.firstElementChild?.firstElementChild;
+    expect(slot).not.toBeNull();
+    if (slot instanceof HTMLElement) {
+      expect(slot.tagName).toBe("SPAN");
+      expect(slot.className).not.toMatch(/bg-status-info/);
+      expect(slot.className).not.toMatch(/rounded-full/);
+    }
+  });
+
+  it("does not render a duplicate dot in the trailing metadata column", () => {
+    const { container } = render(<NotificationCenterEntry entry={makeEntry()} isNew />);
+    const dots = container.querySelectorAll(".bg-status-info.rounded-full");
+    expect(dots.length).toBe(1);
+  });
 });
 
 describe("NotificationCenterEntry title font weight", () => {

--- a/src/components/Notifications/__tests__/NotificationCenterEntry.test.tsx
+++ b/src/components/Notifications/__tests__/NotificationCenterEntry.test.tsx
@@ -106,6 +106,10 @@ describe("NotificationCenterEntry unread signal", () => {
       expect(slot.tagName).toBe("SPAN");
       expect(slot.className).toMatch(/bg-status-info/);
       expect(slot.className).toMatch(/rounded-full/);
+      // Stable spacer classes must be present in both states so the leading
+      // slot reserves the same horizontal width regardless of read/unread.
+      expect(slot.className).toMatch(/\bw-1\.5\b/);
+      expect(slot.className).toMatch(/\bshrink-0\b/);
     }
   });
 
@@ -117,6 +121,10 @@ describe("NotificationCenterEntry unread signal", () => {
       expect(slot.tagName).toBe("SPAN");
       expect(slot.className).not.toMatch(/bg-status-info/);
       expect(slot.className).not.toMatch(/rounded-full/);
+      // The spacer must always reserve the leading width — losing these
+      // classes would re-introduce the layout shift on read/unread toggle.
+      expect(slot.className).toMatch(/\bw-1\.5\b/);
+      expect(slot.className).toMatch(/\bshrink-0\b/);
     }
   });
 


### PR DESCRIPTION
## Summary

- Moves the unread indicator dot from the trailing metadata area to the leading edge of each notification row, making it the first flex child
- An invisible `w-1.5 shrink-0` spacer holds the slot when the row is read, so there's no layout shift on state change
- Keeps `bg-status-info` (not accent) and the `font-semibold` title as a redundant accessible cue; `aria-hidden` preserved on the dot

Resolves #7594

## Changes

- `src/components/Notifications/NotificationCenterEntry.tsx` — leading placeholder span added as first flex child; trailing dot removed from metadata column; `self-center` alignment used since the slot has no `mt-0.5` icon wrapper offset
- `src/components/Notifications/__tests__/NotificationCenterEntry.test.tsx` — 3 new DOM-order tests in the "unread signal" describe block: leading-edge position, invisible-spacer state, no-duplicate-dot guard; `w-1.5`/`shrink-0` classes pinned to protect the layout-shift contract

## Testing

46 vitest cases pass. Typecheck, lint, and format all clean.

**Theme spot-check:** all 14 themes have distinct hues for `bg-status-info` vs `--color-accent-primary`. Svalbard and Bondi are the closest pair (both blue/teal-family) and may benefit from a quick visual review before merge.