### PR TITLE
fix(sidebar): polish hover-toolbar interactions in worktrees header

### DIFF
--- a/src/components/Sidebar/SidebarContent.tsx
+++ b/src/components/Sidebar/SidebarContent.tsx
@@ -683,11 +683,11 @@ function SidebarContent({ onOpenOverview }: SidebarContentProps) {
           )}
         </div>
         <div className="flex items-center gap-1">
-          <div className="invisible opacity-0 pointer-events-none transition-[opacity,visibility] duration-150 delay-0 group-hover/header:visible group-hover/header:opacity-100 group-hover/header:pointer-events-auto group-hover/header:delay-75 group-focus-within/header:visible group-focus-within/header:opacity-100 group-focus-within/header:pointer-events-auto group-focus-within/header:delay-75 motion-reduce:transition-none flex items-center gap-1">
+          <div className="invisible opacity-0 pointer-events-none transition-[opacity,visibility] duration-150 delay-75 group-hover/header:visible group-hover/header:opacity-100 group-hover/header:pointer-events-auto group-hover/header:delay-75 group-focus-within/header:visible group-focus-within/header:opacity-100 group-focus-within/header:pointer-events-auto group-focus-within/header:delay-75 motion-reduce:transition-none flex items-center gap-1">
             <button
               type="button"
               onClick={onOpenOverview}
-              className="p-1 text-daintree-text/40 hover:text-daintree-text hover:bg-tint/[0.06] rounded transition-colors"
+              className="p-1 text-daintree-text/40 hover:text-daintree-text hover:bg-tint/[0.06] rounded transition-colors focus-visible:outline focus-visible:outline-2 focus-visible:outline-daintree-accent"
               aria-label="Open worktrees overview"
               aria-keyshortcuts={overviewAriaShortcut}
               title={formatButtonTitle("Open worktrees overview", overviewShortcut)}
@@ -697,7 +697,7 @@ function SidebarContent({ onOpenOverview }: SidebarContentProps) {
             <button
               type="button"
               onClick={openFleetPicker}
-              className="p-1 text-daintree-text/40 hover:text-daintree-text hover:bg-tint/[0.06] rounded transition-colors"
+              className="p-1 text-daintree-text/40 hover:text-daintree-text hover:bg-tint/[0.06] rounded transition-colors focus-visible:outline focus-visible:outline-2 focus-visible:outline-daintree-accent"
               aria-label="Select terminals to arm"
               title="Select terminals to arm"
             >
@@ -707,7 +707,7 @@ function SidebarContent({ onOpenOverview }: SidebarContentProps) {
               type="button"
               onClick={handleRefreshAll}
               disabled={isRefreshing}
-              className="p-1 text-daintree-text/40 hover:text-daintree-text hover:bg-tint/[0.06] rounded transition-colors disabled:opacity-40 disabled:cursor-not-allowed disabled:hover:bg-transparent disabled:hover:text-daintree-text/40"
+              className="p-1 text-daintree-text/40 hover:text-daintree-text hover:bg-tint/[0.06] rounded transition-colors focus-visible:outline focus-visible:outline-2 focus-visible:outline-daintree-accent disabled:opacity-40 disabled:cursor-not-allowed disabled:hover:bg-transparent disabled:hover:text-daintree-text/40"
               aria-label="Refresh sidebar"
               aria-keyshortcuts={refreshAriaShortcut}
               title={formatButtonTitle("Refresh sidebar", refreshShortcut)}
@@ -723,7 +723,7 @@ function SidebarContent({ onOpenOverview }: SidebarContentProps) {
               })
             }
             onPointerEnter={() => void preloadNewWorktreeDialog()}
-            className="p-1 text-daintree-text/40 hover:text-daintree-text hover:bg-tint/[0.06] rounded transition-colors"
+            className="p-1 text-daintree-text/60 hover:text-daintree-text hover:bg-tint/[0.06] rounded transition-colors focus-visible:outline focus-visible:outline-2 focus-visible:outline-daintree-accent"
             aria-label="Create new worktree"
             aria-keyshortcuts={createWorktreeAriaShortcut}
             title={formatButtonTitle("Create new worktree", createWorktreeShortcut)}

--- a/src/components/Sidebar/__tests__/SidebarContent.headerReveal.test.ts
+++ b/src/components/Sidebar/__tests__/SidebarContent.headerReveal.test.ts
@@ -37,15 +37,11 @@ describe("SidebarContent header reveal — issue #6964", () => {
     expect(source).toContain("delay-75");
     expect(source).toContain("group-hover/header:delay-75");
     expect(source).toContain("group-focus-within/header:delay-75");
-    expect(source).not.toMatch(
-      /transition-\[opacity,visibility\][^"]*\bdelay-0\b/
-    );
+    expect(source).not.toMatch(/transition-\[opacity,visibility\][^"]*\bdelay-0\b/);
   });
 
   it("renders focus-visible outlines on all four header icon buttons — issue #7602", () => {
-    const focusVisibleCount = (
-      source.match(/focus-visible:outline-daintree-accent/g) ?? []
-    ).length;
+    const focusVisibleCount = (source.match(/focus-visible:outline-daintree-accent/g) ?? []).length;
     expect(focusVisibleCount).toBe(4);
     expect(source).toContain("focus-visible:outline focus-visible:outline-2");
   });

--- a/src/components/Sidebar/__tests__/SidebarContent.headerReveal.test.ts
+++ b/src/components/Sidebar/__tests__/SidebarContent.headerReveal.test.ts
@@ -33,10 +33,27 @@ describe("SidebarContent header reveal — issue #6964", () => {
     expect(source).toMatch(/transition-\[opacity,visibility\][^"]*duration-150/);
   });
 
-  it("applies a 75ms hover-intent delay on the hover/focus state with instant exit (delay-0)", () => {
-    expect(source).toContain("delay-0");
+  it("applies a symmetric 75ms enter/exit delay on the hover/focus state — issue #7602", () => {
+    expect(source).toContain("delay-75");
     expect(source).toContain("group-hover/header:delay-75");
     expect(source).toContain("group-focus-within/header:delay-75");
+    expect(source).not.toMatch(
+      /transition-\[opacity,visibility\][^"]*\bdelay-0\b/
+    );
+  });
+
+  it("renders focus-visible outlines on all four header icon buttons — issue #7602", () => {
+    const focusVisibleCount = (
+      source.match(/focus-visible:outline-daintree-accent/g) ?? []
+    ).length;
+    expect(focusVisibleCount).toBe(4);
+    expect(source).toContain("focus-visible:outline focus-visible:outline-2");
+  });
+
+  it("lifts the always-visible create button to text-daintree-text/60 while siblings stay at /40 — issue #7602", () => {
+    expect(source).toContain("text-daintree-text/60");
+    const fortyCount = (source.match(/text-daintree-text\/40/g) ?? []).length;
+    expect(fortyCount).toBe(4);
   });
 
   it("respects prefers-reduced-motion via motion-reduce:transition-none", () => {


### PR DESCRIPTION
Three small interaction-state fixes for the worktrees sidebar header.

- The hover-revealed icon buttons (overview, fleet picker, refresh) were appearing with a ~75ms delay but disappearing instantly on cursor leave. Grazing the header caused a flicker. The hide path now carries the same 75ms delay as the reveal (`delay-0` -> `delay-75` on the reveal container).
- Those same three buttons had no `:focus-visible` affordance, leaving keyboard users with just the browser default ring. They now pick up the same `focus-visible:outline focus-visible:outline-2 focus-visible:outline-daintree-accent` pattern used in `WorktreeActionsToolbar.tsx`.
- The always-visible create button sat at the same `text-daintree-text/40` as its hover-only siblings, so it read as just another revealed icon when the cluster was up. Lifted to `text-daintree-text/60` to put it in a clear primary tier.

Resolves #7602

## Changes

- `src/components/Sidebar/SidebarContent.tsx` — symmetric reveal delay, focus-visible outlines on all four header buttons, create button opacity bump
- `src/components/Sidebar/__tests__/SidebarContent.headerReveal.test.ts` — extended test coverage for the new behaviours

## Testing

9/9 vitest source-scan tests pass. Typecheck, lint, format check, and build all pass with no new warnings.