### PR TITLE
fix(toaster): honor action variant field in toast renderer

### DIFF
--- a/src/components/ui/__tests__/toaster.test.tsx
+++ b/src/components/ui/__tests__/toaster.test.tsx
@@ -1706,7 +1706,7 @@ describe("Toast action variant rendering (issue #7595)", () => {
     expect(cancel.className).toContain("text-daintree-text/70");
   });
 
-  it("dimmed secondary action retains opacity-50 + pointer-events-none", async () => {
+  it("dimmed secondary action retains opacity-50, stays disabled, and ignores clicks", async () => {
     let resolvePrimary: () => void = () => {};
     const primaryClick = vi.fn(
       () =>
@@ -1714,6 +1714,7 @@ describe("Toast action variant rendering (issue #7595)", () => {
           resolvePrimary = res;
         })
     );
+    const cancelClick = vi.fn();
 
     render(<Toaster />);
     await act(async () => {
@@ -1725,7 +1726,7 @@ describe("Toast action variant rendering (issue #7595)", () => {
             successLabel: "Confirmed",
             onClick: primaryClick,
           },
-          { label: "Cancel", variant: "secondary", onClick: vi.fn() },
+          { label: "Cancel", variant: "secondary", onClick: cancelClick },
         ],
       });
       vi.advanceTimersByTime(16);
@@ -1734,13 +1735,17 @@ describe("Toast action variant rendering (issue #7595)", () => {
     const confirm = screen.getByRole("button", { name: "Confirm" });
     fireEvent.click(confirm);
 
-    // The secondary button should now be dimmed (other action active).
-    const cancel = screen.getByRole("button", { name: "Cancel" });
+    const cancel = screen.getByRole("button", { name: "Cancel" }) as HTMLButtonElement;
     expect(cancel.className).toContain("opacity-50");
     expect(cancel.className).toContain("pointer-events-none");
-    // And it must still carry the secondary text-only styling.
+    // Still carries the secondary text-only styling under the dim.
     expect(cancel.className).toContain("text-daintree-text/70");
     expect(cancel.className).not.toContain("bg-status-info/10");
+    // Behavioral inertness: HTML `disabled` is the real guard (CSS
+    // pointer-events doesn't block fireEvent in JSDOM). Confirm both.
+    expect(cancel.disabled).toBe(true);
+    fireEvent.click(cancel);
+    expect(cancelClick).not.toHaveBeenCalled();
 
     // Cleanup the in-flight promise so afterEach timers settle.
     resolvePrimary();

--- a/src/components/ui/__tests__/toaster.test.tsx
+++ b/src/components/ui/__tests__/toaster.test.tsx
@@ -1622,3 +1622,144 @@ describe("Toast a11y, focus, and ergonomics polish (issue #7238)", () => {
     expect(chipAfter.className).not.toContain("animate-badge-bump");
   });
 });
+
+describe("Toast action variant rendering (issue #7595)", () => {
+  beforeEach(() => {
+    vi.useFakeTimers();
+    useNotificationStore.getState().reset();
+    useNotificationHistoryStore.setState({ entries: [], unreadCount: 0, evictedToInboxCount: 0 });
+    useAnnouncerStore.setState({ polite: null, assertive: null });
+    resetEscapeStack();
+  });
+
+  afterEach(() => {
+    vi.runOnlyPendingTimers();
+    vi.useRealTimers();
+    resetEscapeStack();
+    for (const el of fixtureElements) {
+      el.remove();
+    }
+    fixtureElements = [];
+  });
+
+  it("renders primary action with the tonal info fill", async () => {
+    render(<Toaster />);
+    await act(async () => {
+      addToast({
+        actions: [{ label: "Primary", variant: "primary", onClick: vi.fn() }],
+      });
+      vi.advanceTimersByTime(16);
+    });
+
+    const button = screen.getByRole("button", { name: "Primary" });
+    expect(button.className).toContain("bg-status-info/10");
+    expect(button.className).toContain("text-status-info");
+  });
+
+  it("renders secondary action as text-only — no fill, no border", async () => {
+    render(<Toaster />);
+    await act(async () => {
+      addToast({
+        actions: [{ label: "Secondary", variant: "secondary", onClick: vi.fn() }],
+      });
+      vi.advanceTimersByTime(16);
+    });
+
+    const button = screen.getByRole("button", { name: "Secondary" });
+    expect(button.className).not.toContain("bg-status-info/10");
+    expect(button.className).not.toContain("text-status-info");
+    expect(button.className).not.toMatch(/\bborder\b/);
+    expect(button.className).toContain("text-daintree-text/70");
+    expect(button.className).toContain("hover:bg-tint/10");
+  });
+
+  it("defaults to primary when variant is omitted", async () => {
+    render(<Toaster />);
+    await act(async () => {
+      addToast({
+        actions: [{ label: "Default", onClick: vi.fn() }],
+      });
+      vi.advanceTimersByTime(16);
+    });
+
+    const button = screen.getByRole("button", { name: "Default" });
+    expect(button.className).toContain("bg-status-info/10");
+    expect(button.className).toContain("text-status-info");
+  });
+
+  it("renders mixed primary+secondary actions distinctly in the same toast", async () => {
+    render(<Toaster />);
+    await act(async () => {
+      addToast({
+        actions: [
+          { label: "Confirm", variant: "primary", onClick: vi.fn() },
+          { label: "Cancel", variant: "secondary", onClick: vi.fn() },
+        ],
+      });
+      vi.advanceTimersByTime(16);
+    });
+
+    const confirm = screen.getByRole("button", { name: "Confirm" });
+    const cancel = screen.getByRole("button", { name: "Cancel" });
+    expect(confirm.className).toContain("bg-status-info/10");
+    expect(cancel.className).not.toContain("bg-status-info/10");
+    expect(cancel.className).toContain("text-daintree-text/70");
+  });
+
+  it("dimmed secondary action retains opacity-50 + pointer-events-none", async () => {
+    let resolvePrimary: () => void = () => {};
+    const primaryClick = vi.fn(
+      () =>
+        new Promise<void>((res) => {
+          resolvePrimary = res;
+        })
+    );
+
+    render(<Toaster />);
+    await act(async () => {
+      addToast({
+        actions: [
+          {
+            label: "Confirm",
+            variant: "primary",
+            successLabel: "Confirmed",
+            onClick: primaryClick,
+          },
+          { label: "Cancel", variant: "secondary", onClick: vi.fn() },
+        ],
+      });
+      vi.advanceTimersByTime(16);
+    });
+
+    const confirm = screen.getByRole("button", { name: "Confirm" });
+    fireEvent.click(confirm);
+
+    // The secondary button should now be dimmed (other action active).
+    const cancel = screen.getByRole("button", { name: "Cancel" });
+    expect(cancel.className).toContain("opacity-50");
+    expect(cancel.className).toContain("pointer-events-none");
+    // And it must still carry the secondary text-only styling.
+    expect(cancel.className).toContain("text-daintree-text/70");
+    expect(cancel.className).not.toContain("bg-status-info/10");
+
+    // Cleanup the in-flight promise so afterEach timers settle.
+    resolvePrimary();
+    await act(async () => {
+      vi.advanceTimersByTime(0);
+    });
+  });
+
+  it("legacy singular `action` honors variant: secondary", async () => {
+    render(<Toaster />);
+    await act(async () => {
+      addToast({
+        action: { label: "Mute", variant: "secondary", onClick: vi.fn() },
+      });
+      vi.advanceTimersByTime(16);
+    });
+
+    const button = screen.getByRole("button", { name: "Mute" });
+    expect(button.className).toContain("text-daintree-text/70");
+    expect(button.className).not.toContain("bg-status-info/10");
+  });
+});

--- a/src/components/ui/toaster.tsx
+++ b/src/components/ui/toaster.tsx
@@ -14,6 +14,7 @@ import { cn } from "@/lib/utils";
 import { logError } from "@/utils/logger";
 import {
   DURATION_150,
+  DURATION_200,
   DURATION_300,
   UI_ENTER_DURATION,
   UI_EXIT_DURATION,
@@ -149,7 +150,7 @@ function Toast({ notification, isTopmost }: { notification: Notification; isTopm
       if (!mountedRef.current) return;
       setIsCountBumping(false);
       bumpFallbackRef.current = null;
-    }, 200);
+    }, DURATION_200);
   }, [notification.count]);
 
   useLayoutEffect(() => {
@@ -341,7 +342,7 @@ function Toast({ notification, isTopmost }: { notification: Notification; isTopm
                     "shrink-0 rounded-full bg-tint/10 px-1.5 py-0.5 text-[10px] font-medium leading-none text-daintree-text/60 tabular-nums min-w-[3.5ch] text-center",
                     isCountBumping && "animate-badge-bump"
                   )}
-                  style={{ animationDuration: "150ms" }}
+                  style={{ animationDuration: `${DURATION_150}ms` }}
                   onAnimationEnd={(e) => {
                     if (e.animationName === "badge-bump") setIsCountBumping(false);
                   }}
@@ -360,7 +361,7 @@ function Toast({ notification, isTopmost }: { notification: Notification; isTopm
                 "inline-block rounded-full bg-tint/10 px-1.5 py-0.5 text-[10px] font-medium leading-none text-daintree-text/60 tabular-nums min-w-[3.5ch] text-center",
                 isCountBumping && "animate-badge-bump"
               )}
-              style={{ animationDuration: "150ms" }}
+              style={{ animationDuration: `${DURATION_150}ms` }}
               onAnimationEnd={(e) => {
                 if (e.animationName === "badge-bump") setIsCountBumping(false);
               }}
@@ -471,6 +472,7 @@ function Toast({ notification, isTopmost }: { notification: Notification; isTopm
               {actions.map((action, index) => {
                 const isActive = activeActionIndex === index;
                 const isDimmed = activeActionIndex !== null && !isActive;
+                const variant = action.variant ?? "primary";
 
                 return (
                   <button
@@ -479,9 +481,10 @@ function Toast({ notification, isTopmost }: { notification: Notification; isTopm
                     onClick={() => handleActionClick(action, index)}
                     className={cn(
                       "px-2.5 py-1 rounded-[var(--radius-xs)]",
-                      "text-xs font-medium",
-                      "bg-status-info/10 text-status-info",
-                      "hover:bg-status-info/20 transition-colors",
+                      "text-xs font-medium transition-colors",
+                      variant === "secondary"
+                        ? "text-daintree-text/70 hover:text-daintree-text hover:bg-tint/10"
+                        : "bg-status-info/10 text-status-info hover:bg-status-info/20",
                       "focus-visible:outline focus-visible:outline-2 focus-visible:outline-daintree-accent focus-visible:outline-offset-2",
                       isDimmed && "opacity-50 pointer-events-none"
                     )}

--- a/src/hooks/useIdleTerminalNotifications.ts
+++ b/src/hooks/useIdleTerminalNotifications.ts
@@ -31,12 +31,14 @@ export function useIdleTerminalNotifications(): void {
       const closeAction = single
         ? {
             label: "Close Them",
+            variant: "primary" as const,
             onClick: () => {
               void idleTerminalClient.closeProject(single.projectId);
             },
           }
         : {
             label: "View",
+            variant: "primary" as const,
             onClick: () => {
               useUIStore.getState().openNotificationCenter();
             },
@@ -44,6 +46,7 @@ export function useIdleTerminalNotifications(): void {
 
       const dismissAction = {
         label: "Mute project",
+        variant: "secondary" as const,
         onClick: () => {
           if (single) {
             void idleTerminalClient.dismissProject(single.projectId);

--- a/src/hooks/useIdleTerminalNotifications.ts
+++ b/src/hooks/useIdleTerminalNotifications.ts
@@ -81,6 +81,7 @@ export function useIdleTerminalNotifications(): void {
             count > 1
               ? {
                   label: "View",
+                  variant: "primary" as const,
                   onClick: () => {
                     useUIStore.getState().openNotificationCenter();
                   },


### PR DESCRIPTION
## Summary

The toast renderer was ignoring the `variant` field on `NotificationAction`, giving every action button identical visual weight regardless of whether it was primary or secondary. The other three notification surfaces (`GridNotificationBar`, `NotificationCenterEntry`, `InlineStatusBanner`) already branched on this field, so the toast was the odd one out.

- `toaster.tsx` now branches on `action.variant`, defaulting to `"primary"` when undefined (matching `InlineStatusBanner`'s pattern). Secondary actions get a text-only treatment — no fill, no border — keeping the toast surface visually tighter than the other three.
- The only multi-action toast callsite (`useIdleTerminalNotifications`) now carries explicit `variant` fields on its close and view actions so the new hierarchy actually lands.
- Hardcoded animation duration literals (`200`, `"150ms"`) replaced with the already-imported `DURATION_200` / `DURATION_150` constants.

Resolves #7595

## Changes

- `src/components/ui/toaster.tsx` — variant branch in action render loop, secondary text-only treatment, named animation constants
- `src/hooks/useIdleTerminalNotifications.ts` — explicit `variant` fields on `closeAction` (primary) and `dismissAction` (secondary), plus coalesced `buildAction` View (primary)
- `src/components/ui/__tests__/toaster.test.tsx` — 6 new test cases: primary/secondary rendering, default fallback, mixed variants, dimmed-secondary composition with `inert` check, legacy singular action

## Testing

- `npx vitest run src/components/ui/__tests__/toaster.test.tsx` — 79 tests pass
- Full verify (`typecheck`, `lint`, `format`) — all 5 checks pass