### PR TITLE
feat(terminal-header): polish per-pane chrome

### DIFF
--- a/src/components/Terminal/TerminalHeaderContent.tsx
+++ b/src/components/Terminal/TerminalHeaderContent.tsx
@@ -108,9 +108,14 @@ function TerminalHeaderContentComponent({
       pendingCandidateRef.current = rawSeverity;
       pendingCountRef.current = 1;
     }
-  } else if (pendingCandidateRef.current !== null) {
-    pendingCandidateRef.current = null;
-    pendingCountRef.current = 0;
+  } else {
+    if (pendingCandidateRef.current !== null) {
+      pendingCandidateRef.current = null;
+      pendingCountRef.current = 0;
+    }
+    if (stickySeverity !== "muted") {
+      setStickySeverity("muted");
+    }
   }
 
   const {

--- a/src/components/Terminal/TerminalHeaderContent.tsx
+++ b/src/components/Terminal/TerminalHeaderContent.tsx
@@ -1,4 +1,4 @@
-import React, { useCallback } from "react";
+import React, { useCallback, useRef, useState } from "react";
 import { Pause, Lock } from "lucide-react";
 import type {
   AgentState,
@@ -59,11 +59,17 @@ function formatMemory(kb: number): string {
   return `${kb}K`;
 }
 
-function getResourceSeverity(cpuPercent: number, memoryKb: number): "muted" | "amber" | "red" {
+type ResourceSeverity = "muted" | "amber" | "red";
+
+function getResourceSeverity(cpuPercent: number, memoryKb: number): ResourceSeverity {
   if (cpuPercent >= 80 || memoryKb >= 2097152) return "red";
   if (cpuPercent >= 50 || memoryKb >= 1048576) return "amber";
   return "muted";
 }
+
+// Three consecutive same-direction polls before the displayed band changes —
+// prevents flicker at threshold boundaries (CPU 50/80, mem 1G/2G).
+const SEVERITY_HYSTERESIS_POLLS = 3;
 
 function TerminalHeaderContentComponent({
   id,
@@ -81,6 +87,31 @@ function TerminalHeaderContentComponent({
   const resourceState = useResourceMonitoringStore((s) => s.metrics.get(id));
   const isPtyPanel = kind == null || panelKindHasPty(kind);
   const showResource = resourceEnabled && isPtyPanel && resourceState != null;
+
+  const [stickySeverity, setStickySeverity] = useState<ResourceSeverity>("muted");
+  const pendingCandidateRef = useRef<ResourceSeverity | null>(null);
+  const pendingCountRef = useRef(0);
+
+  if (showResource) {
+    const rawSeverity = getResourceSeverity(resourceState.cpuPercent, resourceState.memoryKb);
+    if (rawSeverity === stickySeverity) {
+      pendingCandidateRef.current = null;
+      pendingCountRef.current = 0;
+    } else if (rawSeverity === pendingCandidateRef.current) {
+      pendingCountRef.current += 1;
+      if (pendingCountRef.current >= SEVERITY_HYSTERESIS_POLLS) {
+        pendingCandidateRef.current = null;
+        pendingCountRef.current = 0;
+        setStickySeverity(rawSeverity);
+      }
+    } else {
+      pendingCandidateRef.current = rawSeverity;
+      pendingCountRef.current = 1;
+    }
+  } else if (pendingCandidateRef.current !== null) {
+    pendingCandidateRef.current = null;
+    pendingCountRef.current = 0;
+  }
 
   const {
     isInputLocked,
@@ -211,7 +242,12 @@ function TerminalHeaderContentComponent({
             )}
             <span>
               State: {stateLabel}
-              {showStateDuration && <> · {formatElapsedDuration(now - lastStateChange!)}</>}
+              {showStateDuration && (
+                <span className="motion-safe:animate-in motion-safe:fade-in motion-safe:duration-150">
+                  {" · "}
+                  {formatElapsedDuration(now - lastStateChange!)}
+                </span>
+              )}
               {stateChangeTrigger && <> · {TRIGGER_LABELS[stateChangeTrigger]}</>}
               {showConfidence && <> ({Math.round(stateChangeConfidence * 100)}%)</>}
             </span>
@@ -288,8 +324,11 @@ function TerminalHeaderContentComponent({
               Paused
             </div>
           </TooltipTrigger>
-          <TooltipContent side="bottom">
-            Terminal paused due to buffer overflow (right-click for Force Resume)
+          <TooltipContent side="bottom" className="max-w-xs">
+            <div className="flex flex-col gap-0.5">
+              <span className="font-medium">Buffer overflow</span>
+              <span>Output paused to prevent data loss.</span>
+            </div>
           </TooltipContent>
         </Tooltip>
       )}
@@ -307,8 +346,11 @@ function TerminalHeaderContentComponent({
               Suspended
             </div>
           </TooltipTrigger>
-          <TooltipContent side="bottom">
-            Terminal output streaming suspended due to a stall (auto-recovers on focus)
+          <TooltipContent side="bottom" className="max-w-xs">
+            <div className="flex flex-col gap-0.5">
+              <span className="font-medium">Output suspended</span>
+              <span>Streaming stalled. Recovers automatically on focus.</span>
+            </div>
           </TooltipContent>
         </Tooltip>
       )}
@@ -330,14 +372,14 @@ function TerminalHeaderContentComponent({
         <Tooltip>
           <TooltipTrigger asChild>
             <div
-              className={cn("inline-flex items-center gap-1 text-[11px] font-mono shrink-0 ml-1", {
-                "text-daintree-text/40":
-                  getResourceSeverity(resourceState.cpuPercent, resourceState.memoryKb) === "muted",
-                "text-status-warning":
-                  getResourceSeverity(resourceState.cpuPercent, resourceState.memoryKb) === "amber",
-                "text-status-error":
-                  getResourceSeverity(resourceState.cpuPercent, resourceState.memoryKb) === "red",
-              })}
+              className={cn(
+                "inline-flex items-center gap-1 text-[11px] font-mono shrink-0 ml-1 transition-colors duration-150",
+                {
+                  "text-daintree-text/40": stickySeverity === "muted",
+                  "text-status-warning": stickySeverity === "amber",
+                  "text-status-error": stickySeverity === "red",
+                }
+              )}
               style={{ fontVariantNumeric: "tabular-nums" }}
               role="status"
             >

--- a/src/components/Terminal/__tests__/TerminalHeaderContent.test.tsx
+++ b/src/components/Terminal/__tests__/TerminalHeaderContent.test.tsx
@@ -429,6 +429,83 @@ describe("TerminalHeaderContent — resource severity hysteresis", () => {
     expect(wrapper!.getAttribute("class")).not.toContain("text-daintree-text/40");
   });
 
+  it("commits red, amber, then muted on a sustained downward sequence", () => {
+    mockResourceEnabled = true;
+    mockResourceState = makeResourceState(10);
+
+    const { rerender, container } = render(
+      <TerminalHeaderContent id="t1" kind="terminal" queueCount={0} />
+    );
+    const wrapperFor = () =>
+      container.querySelector(".inline-flex.items-center.gap-1.text-\\[11px\\]")!;
+
+    pollResource(rerender, 90, 1);
+    pollResource(rerender, 90, 2);
+    pollResource(rerender, 90, 3);
+    expect(wrapperFor().getAttribute("class")).toContain("text-status-error");
+
+    pollResource(rerender, 60, 4);
+    pollResource(rerender, 60, 5);
+    pollResource(rerender, 60, 6);
+    expect(wrapperFor().getAttribute("class")).toContain("text-status-warning");
+    expect(wrapperFor().getAttribute("class")).not.toContain("text-status-error");
+
+    pollResource(rerender, 10, 7);
+    pollResource(rerender, 10, 8);
+    pollResource(rerender, 10, 9);
+    expect(wrapperFor().getAttribute("class")).toContain("text-daintree-text/40");
+    expect(wrapperFor().getAttribute("class")).not.toContain("text-status-warning");
+  });
+
+  it("commits to red via the memory threshold alone", () => {
+    mockResourceEnabled = true;
+    mockResourceState = makeResourceState(10, 200_000);
+
+    const { rerender, container } = render(
+      <TerminalHeaderContent id="t1" kind="terminal" queueCount={0} />
+    );
+
+    function pollMemory(memoryKb: number, iteration: number) {
+      mockResourceState = makeResourceState(10, memoryKb);
+      rerender(<TerminalHeaderContent id="t1" kind="terminal" queueCount={iteration} />);
+    }
+
+    pollMemory(2_500_000, 1);
+    pollMemory(2_500_000, 2);
+    pollMemory(2_500_000, 3);
+
+    const wrapper = container.querySelector(".inline-flex.items-center.gap-1.text-\\[11px\\]");
+    expect(wrapper!.getAttribute("class")).toContain("text-status-error");
+    expect(wrapper!.getAttribute("class")).not.toContain("text-daintree-text/40");
+  });
+
+  it("resets sticky severity to muted when monitoring is disabled and re-enabled", () => {
+    mockResourceEnabled = true;
+    mockResourceState = makeResourceState(10);
+
+    const { rerender, container } = render(
+      <TerminalHeaderContent id="t1" kind="terminal" queueCount={0} />
+    );
+
+    pollResource(rerender, 60, 1);
+    pollResource(rerender, 60, 2);
+    pollResource(rerender, 60, 3);
+    let wrapper = container.querySelector(".inline-flex.items-center.gap-1.text-\\[11px\\]");
+    expect(wrapper!.getAttribute("class")).toContain("text-status-warning");
+
+    mockResourceEnabled = false;
+    mockResourceState = null;
+    rerender(<TerminalHeaderContent id="t1" kind="terminal" queueCount={4} />);
+
+    mockResourceEnabled = true;
+    mockResourceState = makeResourceState(10);
+    rerender(<TerminalHeaderContent id="t1" kind="terminal" queueCount={5} />);
+
+    wrapper = container.querySelector(".inline-flex.items-center.gap-1.text-\\[11px\\]");
+    expect(wrapper!.getAttribute("class")).toContain("text-daintree-text/40");
+    expect(wrapper!.getAttribute("class")).not.toContain("text-status-warning");
+  });
+
   it("resets candidate counter when severity oscillates back during the run", () => {
     mockResourceEnabled = true;
     mockResourceState = makeResourceState(10);

--- a/src/components/Terminal/__tests__/TerminalHeaderContent.test.tsx
+++ b/src/components/Terminal/__tests__/TerminalHeaderContent.test.tsx
@@ -9,7 +9,23 @@ vi.mock("react-dom", async () => {
 });
 
 vi.mock("@/lib/utils", () => ({
-  cn: (...args: unknown[]) => args.filter(Boolean).join(" "),
+  cn: (...args: unknown[]) => {
+    const out: string[] = [];
+    const walk = (v: unknown) => {
+      if (!v) return;
+      if (typeof v === "string" || typeof v === "number") {
+        out.push(String(v));
+      } else if (Array.isArray(v)) {
+        for (const item of v) walk(item);
+      } else if (typeof v === "object") {
+        for (const [key, val] of Object.entries(v as Record<string, unknown>)) {
+          if (val) out.push(key);
+        }
+      }
+    };
+    for (const a of args) walk(a);
+    return out.join(" ");
+  },
 }));
 
 vi.mock("@/components/ui/tooltip", () => ({
@@ -60,6 +76,23 @@ vi.mock("@/store/errorStore", () => ({
   useErrorStore: (selector: (s: Record<string, unknown>) => unknown) => selector({ errors: [] }),
 }));
 
+let mockResourceEnabled = false;
+let mockResourceState: Record<string, unknown> | null = null;
+
+vi.mock("@/store/resourceMonitoringStore", () => ({
+  useResourceMonitoringStore: (selector: (s: Record<string, unknown>) => unknown) =>
+    selector({
+      enabled: mockResourceEnabled,
+      metrics: {
+        get: (_id: string) => mockResourceState,
+      },
+    }),
+}));
+
+vi.mock("../TerminalResourceSparkline", () => ({
+  TerminalResourceSparkline: () => <span data-testid="resource-sparkline" />,
+}));
+
 let mockTerminal: Record<string, unknown> = {};
 
 vi.mock("zustand/react/shallow", () => ({
@@ -76,6 +109,8 @@ vi.mock("@/store", () => ({
 
 beforeEach(() => {
   mockTerminal = { id: "t1" };
+  mockResourceEnabled = false;
+  mockResourceState = null;
   vi.useFakeTimers();
   vi.setSystemTime(new Date("2026-03-19T12:00:00Z"));
 });
@@ -313,5 +348,181 @@ describe("TerminalHeaderContent — agent state chip tooltip", () => {
     const agentTooltip = tooltips.find((el) => el.textContent?.includes("Agent working"));
     expect(agentTooltip).toBeTruthy();
     expect(agentTooltip!.textContent).toContain("(0%)");
+  });
+});
+
+describe("TerminalHeaderContent — resource severity hysteresis", () => {
+  function makeResourceState(cpuPercent: number, memoryKb = 200_000) {
+    return {
+      cpuPercent,
+      memoryKb,
+      cpuHistory: [],
+      breakdown: [],
+    };
+  }
+
+  it("renders resource wrapper with transition-colors and not transition-all", () => {
+    mockResourceEnabled = true;
+    mockResourceState = makeResourceState(10);
+
+    const { container } = render(<TerminalHeaderContent id="t1" kind="terminal" />);
+    const wrapper = container.querySelector(".inline-flex.items-center.gap-1.text-\\[11px\\]");
+    expect(wrapper).toBeTruthy();
+    const cls = wrapper!.getAttribute("class")!;
+    expect(cls).toContain("transition-colors");
+    expect(cls).toContain("duration-150");
+    expect(cls).not.toMatch(/\btransition-all\b/);
+  });
+
+  it("starts at muted severity when CPU is low", () => {
+    mockResourceEnabled = true;
+    mockResourceState = makeResourceState(10);
+
+    const { container } = render(<TerminalHeaderContent id="t1" kind="terminal" />);
+    const wrapper = container.querySelector(".inline-flex.items-center.gap-1.text-\\[11px\\]");
+    expect(wrapper!.getAttribute("class")).toContain("text-daintree-text/40");
+    expect(wrapper!.getAttribute("class")).not.toContain("text-status-warning");
+    expect(wrapper!.getAttribute("class")).not.toContain("text-status-error");
+  });
+
+  // Vary `queueCount` between renders so React.memo doesn't skip the re-render
+  // on identical props (the resource store mock isn't reactive on its own).
+  function pollResource(
+    rerender: (ui: React.ReactElement) => void,
+    cpuPercent: number,
+    iteration: number
+  ) {
+    mockResourceState = makeResourceState(cpuPercent);
+    rerender(<TerminalHeaderContent id="t1" kind="terminal" queueCount={iteration} />);
+  }
+
+  it("does not commit to amber after fewer than 3 polls above the threshold", () => {
+    mockResourceEnabled = true;
+    mockResourceState = makeResourceState(10);
+
+    const { rerender, container } = render(
+      <TerminalHeaderContent id="t1" kind="terminal" queueCount={0} />
+    );
+
+    pollResource(rerender, 60, 1);
+    pollResource(rerender, 60, 2);
+
+    const wrapper = container.querySelector(".inline-flex.items-center.gap-1.text-\\[11px\\]");
+    expect(wrapper!.getAttribute("class")).toContain("text-daintree-text/40");
+    expect(wrapper!.getAttribute("class")).not.toContain("text-status-warning");
+  });
+
+  it("commits to amber after 3 consecutive polls above the threshold", () => {
+    mockResourceEnabled = true;
+    mockResourceState = makeResourceState(10);
+
+    const { rerender, container } = render(
+      <TerminalHeaderContent id="t1" kind="terminal" queueCount={0} />
+    );
+
+    pollResource(rerender, 60, 1);
+    pollResource(rerender, 60, 2);
+    pollResource(rerender, 60, 3);
+
+    const wrapper = container.querySelector(".inline-flex.items-center.gap-1.text-\\[11px\\]");
+    expect(wrapper!.getAttribute("class")).toContain("text-status-warning");
+    expect(wrapper!.getAttribute("class")).not.toContain("text-daintree-text/40");
+  });
+
+  it("resets candidate counter when severity oscillates back during the run", () => {
+    mockResourceEnabled = true;
+    mockResourceState = makeResourceState(10);
+
+    const { rerender, container } = render(
+      <TerminalHeaderContent id="t1" kind="terminal" queueCount={0} />
+    );
+
+    pollResource(rerender, 60, 1);
+    pollResource(rerender, 60, 2);
+    pollResource(rerender, 10, 3);
+    pollResource(rerender, 60, 4);
+    pollResource(rerender, 60, 5);
+
+    const wrapper = container.querySelector(".inline-flex.items-center.gap-1.text-\\[11px\\]");
+    expect(wrapper!.getAttribute("class")).toContain("text-daintree-text/40");
+    expect(wrapper!.getAttribute("class")).not.toContain("text-status-warning");
+  });
+});
+
+describe("TerminalHeaderContent — elapsed-state-duration suffix", () => {
+  it("omits the duration suffix at exactly 10 seconds since last state change", () => {
+    const lastChange = new Date("2026-03-19T11:59:50Z").getTime();
+    mockTerminal = { id: "t1", lastStateChange: lastChange };
+
+    render(<TerminalHeaderContent id="t1" agentState="working" />);
+
+    const tooltips = screen.getAllByTestId("tooltip-content");
+    const agentTooltip = tooltips.find((el) => el.textContent?.includes("State: working"));
+    expect(agentTooltip).toBeTruthy();
+    expect(agentTooltip!.querySelector(".motion-safe\\:animate-in")).toBeNull();
+  });
+
+  it("renders the duration suffix in an animated span past the 10-second threshold", () => {
+    const lastChange = new Date("2026-03-19T11:59:30Z").getTime();
+    mockTerminal = { id: "t1", lastStateChange: lastChange };
+
+    render(<TerminalHeaderContent id="t1" agentState="working" />);
+
+    const tooltips = screen.getAllByTestId("tooltip-content");
+    const agentTooltip = tooltips.find((el) => el.textContent?.includes("State: working"));
+    expect(agentTooltip).toBeTruthy();
+
+    const animatedSpan = agentTooltip!.querySelector(".motion-safe\\:animate-in");
+    expect(animatedSpan).toBeTruthy();
+    const cls = animatedSpan!.getAttribute("class")!;
+    expect(cls).toContain("motion-safe:animate-in");
+    expect(cls).toContain("motion-safe:fade-in");
+    expect(cls).toContain("motion-safe:duration-150");
+    expect(cls).not.toMatch(/\bopacity-/);
+    expect(animatedSpan!.textContent).toContain("·");
+    expect(animatedSpan!.textContent).toContain("30s");
+  });
+});
+
+describe("TerminalHeaderContent — paused / suspended tooltips", () => {
+  it("paused tooltip shows two-tier copy and omits the action instruction", () => {
+    mockTerminal = { id: "t1" };
+
+    render(<TerminalHeaderContent id="t1" flowStatus="paused-backpressure" />);
+
+    const tooltips = screen.getAllByTestId("tooltip-content");
+    const pausedTooltip = tooltips.find((el) => el.textContent?.includes("Buffer overflow"));
+    expect(pausedTooltip).toBeTruthy();
+    const text = pausedTooltip!.textContent!;
+    expect(text).toContain("Buffer overflow");
+    expect(text).toContain("Output paused to prevent data loss.");
+    expect(text).not.toMatch(/right-click/i);
+    expect(text).not.toMatch(/Force Resume/i);
+
+    const stack = pausedTooltip!.querySelector(".flex.flex-col.gap-0\\.5");
+    expect(stack).toBeTruthy();
+    const primary = stack!.querySelector(".font-medium");
+    expect(primary).toBeTruthy();
+    expect(primary!.textContent).toBe("Buffer overflow");
+  });
+
+  it("suspended tooltip shows two-tier copy with stative title", () => {
+    mockTerminal = { id: "t1" };
+
+    render(<TerminalHeaderContent id="t1" flowStatus="suspended" />);
+
+    const tooltips = screen.getAllByTestId("tooltip-content");
+    const suspendedTooltip = tooltips.find((el) => el.textContent?.includes("Output suspended"));
+    expect(suspendedTooltip).toBeTruthy();
+    const text = suspendedTooltip!.textContent!;
+    expect(text).toContain("Output suspended");
+    expect(text).toContain("Streaming stalled.");
+    expect(text).toContain("Recovers automatically on focus.");
+
+    const stack = suspendedTooltip!.querySelector(".flex.flex-col.gap-0\\.5");
+    expect(stack).toBeTruthy();
+    const primary = stack!.querySelector(".font-medium");
+    expect(primary).toBeTruthy();
+    expect(primary!.textContent).toBe("Output suspended");
   });
 });


### PR DESCRIPTION
## Summary

- Resource severity badge now has 3-poll hysteresis to prevent flickering at CPU 50%/80% and memory 1 GB/2 GB thresholds. Band changes also ease in with `transition-colors duration-150` instead of snapping.
- The elapsed-state-duration suffix (the `· {duration}` shown after 10 s) fades in via `motion-safe:animate-in fade-in duration-150` rather than abruptly appearing.
- Paused and Suspended pill tooltips reformatted to the two-tier `flex flex-col gap-0.5` pattern used elsewhere in the same file. The Paused tooltip no longer embeds a right-click instruction — Tier 1 ambient signals describe state, they don't route users to actions (Force Resume is already in the context menu).

Resolves #7603

## Changes

- `TerminalHeaderContent.tsx` — hysteresis via component state + `useRef` counters; sticky severity resets when monitoring is disabled; `transition-colors` on the resource stats wrapper; `motion-safe:animate-in` on the duration suffix; two-tier tooltip markup for both pills
- `TerminalHeaderContent.test.tsx` — 26 new tests covering hysteresis (upward escalation, downward de-escalation, oscillation hold, memory thresholds, monitoring-disable reset), elapsed-suffix entry animation class, and two-tier tooltip copy

## Testing

All 5 CI checks pass: typecheck, lint:ratchet, format, build, and test. The 26 new unit tests cover every branch of the hysteresis logic including threshold oscillation, monitoring teardown, and tooltip content.