### PR TITLE
feat(onboarding): polish completion choreography on getting-started checklist

### DIFF
--- a/src/components/Onboarding/GettingStartedChecklist.tsx
+++ b/src/components/Onboarding/GettingStartedChecklist.tsx
@@ -1,6 +1,7 @@
-import { useEffect, useState } from "react";
+import { useEffect, useRef, useState } from "react";
 import { createPortal } from "react-dom";
 import { Check, ChevronDown, ChevronUp, X } from "lucide-react";
+import { useReducedMotion } from "framer-motion";
 import { cn } from "@/lib/utils";
 import { actionService } from "@/services/ActionService";
 import { AnimatedLabel } from "@/components/ui/AnimatedLabel";
@@ -8,6 +9,31 @@ import type { ChecklistState, ChecklistItemId } from "@shared/types/ipc/maps";
 import { CHECKLIST_ITEMS } from "./checklistItems";
 
 const CHECKLIST_BODY_ID = "getting-started-checklist-body";
+
+interface CheckBadgeProps {
+  done: boolean;
+  isPopping: boolean;
+  onPopEnd: () => void;
+}
+
+// Renders the round check badge for a checklist row. The pop animation is
+// driven from the parent (see GettingStartedChecklist) so that toggling
+// `done` — which swaps the row's parent element between <button> and <div>
+// and would otherwise remount this component — does not lose pop state.
+function CheckBadge({ done, isPopping, onPopEnd }: CheckBadgeProps) {
+  return (
+    <div
+      onAnimationEnd={onPopEnd}
+      className={cn(
+        "h-4 w-4 rounded-full border flex items-center justify-center shrink-0 transition-colors duration-150",
+        done ? "bg-daintree-accent border-daintree-accent" : "border-daintree-text/30",
+        isPopping && "animate-badge-bump"
+      )}
+    >
+      {done && <Check className="h-2.5 w-2.5 text-daintree-bg" />}
+    </div>
+  );
+}
 
 interface GettingStartedChecklistProps {
   checklist: ChecklistState;
@@ -25,17 +51,86 @@ export function GettingStartedChecklist({
   onMarkItem,
 }: GettingStartedChecklistProps) {
   const [isVisible, setIsVisible] = useState(false);
+  const prefersReducedMotion = useReducedMotion();
+  const items = checklist.items;
+  const prevItemsRef = useRef(items);
+  const popTimersRef = useRef(new Map<ChecklistItemId, ReturnType<typeof setTimeout>>());
+  const mountedRef = useRef(true);
+  const [poppingItems, setPoppingItems] = useState<Set<ChecklistItemId>>(() => new Set());
 
   useEffect(() => {
     const rafId = requestAnimationFrame(() => setIsVisible(true));
     return () => cancelAnimationFrame(rafId);
   }, []);
 
-  const completedCount = Object.values(checklist.items).filter(Boolean).length;
+  useEffect(() => {
+    mountedRef.current = true;
+    const timers = popTimersRef.current;
+    return () => {
+      mountedRef.current = false;
+      timers.forEach((timer) => clearTimeout(timer));
+      timers.clear();
+    };
+  }, []);
+
+  // When an item flips from incomplete → complete, pop its badge for 200ms.
+  // The 200ms setTimeout is a safety fallback for the moments when
+  // `animationend` does not fire (reduced motion, data-reduce-animations,
+  // performance mode) — it ensures isPopping is cleared even when the CSS
+  // animation is suppressed. Mirrors the toaster `bumpFallbackRef` pattern.
+  useEffect(() => {
+    const prev = prevItemsRef.current;
+    prevItemsRef.current = items;
+    if (prefersReducedMotion) return;
+
+    const newlyDone: ChecklistItemId[] = [];
+    for (const { id } of CHECKLIST_ITEMS) {
+      if (items[id] && !prev[id]) newlyDone.push(id);
+    }
+    if (newlyDone.length === 0) return;
+
+    setPoppingItems((current) => {
+      const next = new Set(current);
+      for (const id of newlyDone) next.add(id);
+      return next;
+    });
+
+    for (const id of newlyDone) {
+      const existing = popTimersRef.current.get(id);
+      if (existing) clearTimeout(existing);
+      const timer = setTimeout(() => {
+        if (!mountedRef.current) return;
+        setPoppingItems((current) => {
+          if (!current.has(id)) return current;
+          const next = new Set(current);
+          next.delete(id);
+          return next;
+        });
+        popTimersRef.current.delete(id);
+      }, 200);
+      popTimersRef.current.set(id, timer);
+    }
+  }, [items, prefersReducedMotion]);
+
+  const clearPop = (id: ChecklistItemId) => {
+    setPoppingItems((current) => {
+      if (!current.has(id)) return current;
+      const next = new Set(current);
+      next.delete(id);
+      return next;
+    });
+    const existing = popTimersRef.current.get(id);
+    if (existing) {
+      clearTimeout(existing);
+      popTimersRef.current.delete(id);
+    }
+  };
+
+  const completedCount = Object.values(items).filter(Boolean).length;
   const totalCount = CHECKLIST_ITEMS.length;
   const allComplete = completedCount === totalCount;
-  const counterLabel = allComplete ? "All done" : `${completedCount}/${totalCount}`;
-  const counterAnimateKey = allComplete ? "all-done" : String(completedCount);
+  const counterLabel = allComplete ? "All set" : `${completedCount}/${totalCount}`;
+  const counterAnimateKey = allComplete ? "all-set" : String(completedCount);
 
   return createPortal(
     <div
@@ -54,11 +149,15 @@ export function GettingStartedChecklist({
           "rounded-[var(--radius-sm)] border",
           "text-sm text-daintree-text",
           "shadow-[var(--theme-shadow-floating)]",
-          "transition-[transform,opacity] duration-300 ease-out",
+          "transition-[transform,opacity,background-color,border-color] duration-200 ease-out",
           "motion-reduce:transition-none motion-reduce:duration-0 motion-reduce:transform-none",
           isVisible ? "translate-y-0 opacity-100" : "translate-y-4 opacity-0",
-          "bg-[color-mix(in_oklab,var(--color-daintree-accent)_8%,var(--color-daintree-bg))]",
-          "border-[color:color-mix(in_oklab,var(--color-daintree-accent)_20%,transparent)]",
+          allComplete
+            ? "bg-surface-panel border-border-default"
+            : [
+                "bg-[color-mix(in_oklab,var(--color-daintree-accent)_8%,var(--color-daintree-bg))]",
+                "border-[color:color-mix(in_oklab,var(--color-daintree-accent)_20%,transparent)]",
+              ],
           "backdrop-blur-sm"
         )}
       >
@@ -114,19 +213,15 @@ export function GettingStartedChecklist({
           <div className="px-3 pb-3 space-y-1.5">
             {CHECKLIST_ITEMS.map(
               ({ id, label, description, icon: Icon, actionId, actionArgs, markOnClick }) => {
-                const done = checklist.items[id];
+                const done = items[id];
+                const isPopping = poppingItems.has(id);
                 const content = (
                   <>
-                    <div
-                      className={cn(
-                        "h-4 w-4 rounded-full border flex items-center justify-center shrink-0 transition-colors duration-150",
-                        done
-                          ? "bg-daintree-accent border-daintree-accent"
-                          : "border-daintree-text/30"
-                      )}
-                    >
-                      {done && <Check className="h-2.5 w-2.5 text-daintree-bg" />}
-                    </div>
+                    <CheckBadge
+                      done={done}
+                      isPopping={isPopping}
+                      onPopEnd={() => clearPop(id)}
+                    />
                     <Icon
                       className={cn(
                         "h-3.5 w-3.5 shrink-0",

--- a/src/components/Onboarding/GettingStartedChecklist.tsx
+++ b/src/components/Onboarding/GettingStartedChecklist.tsx
@@ -2,6 +2,7 @@ import { useEffect, useRef, useState } from "react";
 import { createPortal } from "react-dom";
 import { Check, ChevronDown, ChevronUp, X } from "lucide-react";
 import { useReducedMotion } from "framer-motion";
+import { DURATION_200 } from "@/lib/animationUtils";
 import { cn } from "@/lib/utils";
 import { actionService } from "@/services/ActionService";
 import { AnimatedLabel } from "@/components/ui/AnimatedLabel";
@@ -107,7 +108,7 @@ export function GettingStartedChecklist({
           return next;
         });
         popTimersRef.current.delete(id);
-      }, 200);
+      }, DURATION_200);
       popTimersRef.current.set(id, timer);
     }
   }, [items, prefersReducedMotion]);
@@ -220,11 +221,7 @@ export function GettingStartedChecklist({
                 const isPopping = poppingItems.has(id);
                 const content = (
                   <>
-                    <CheckBadge
-                      done={done}
-                      isPopping={isPopping}
-                      onPopEnd={() => clearPop(id)}
-                    />
+                    <CheckBadge done={done} isPopping={isPopping} onPopEnd={() => clearPop(id)} />
                     <Icon
                       className={cn(
                         "h-3.5 w-3.5 shrink-0",

--- a/src/components/Onboarding/GettingStartedChecklist.tsx
+++ b/src/components/Onboarding/GettingStartedChecklist.tsx
@@ -176,7 +176,10 @@ export function GettingStartedChecklist({
             <AnimatedLabel
               label={counterLabel}
               animateKey={counterAnimateKey}
-              textClassName="text-[10px] text-daintree-text/50 font-mono tabular-nums"
+              textClassName={cn(
+                "text-[10px] font-mono tabular-nums",
+                allComplete ? "text-daintree-accent" : "text-daintree-text/50"
+              )}
             />
             {collapsed ? (
               <ChevronUp className="h-3 w-3 text-daintree-text/50 shrink-0" />

--- a/src/components/Onboarding/__tests__/GettingStartedChecklist.test.tsx
+++ b/src/components/Onboarding/__tests__/GettingStartedChecklist.test.tsx
@@ -234,11 +234,12 @@ describe("GettingStartedChecklist", () => {
   });
 
   describe("completed-state surface", () => {
-    it("uses neutral elevated surface tokens when allComplete is true", () => {
+    it("uses neutral elevated surface tokens and drops the accent tint when allComplete is true", () => {
       render(<GettingStartedChecklist {...defaultProps} checklist={allComplete} />);
       const region = screen.getByRole("region", { name: "Getting started checklist" });
       expect(region.className).toContain("bg-surface-panel");
       expect(region.className).toContain("border-border-default");
+      expect(region.className).not.toContain("color-mix");
     });
 
     it("keeps the accent-tinted surface when not all items are complete", () => {
@@ -246,6 +247,20 @@ describe("GettingStartedChecklist", () => {
       const region = screen.getByRole("region", { name: "Getting started checklist" });
       expect(region.className).toContain("color-mix");
       expect(region.className).not.toContain("bg-surface-panel");
+    });
+
+    it("accents the counter label on completion and mutes it otherwise", () => {
+      const { rerender } = render(
+        <GettingStartedChecklist {...defaultProps} checklist={mixedState} />
+      );
+      const muted = screen.getByText("1/4");
+      expect(muted.className).toContain("text-daintree-text/50");
+      expect(muted.className).not.toContain("text-daintree-accent");
+
+      rerender(<GettingStartedChecklist {...defaultProps} checklist={allComplete} />);
+      const accented = screen.getByText("All set");
+      expect(accented.className).toContain("text-daintree-accent");
+      expect(accented.className).not.toContain("text-daintree-text/50");
     });
   });
 

--- a/src/components/Onboarding/__tests__/GettingStartedChecklist.test.tsx
+++ b/src/components/Onboarding/__tests__/GettingStartedChecklist.test.tsx
@@ -2,8 +2,9 @@
 import { render, screen, fireEvent } from "@testing-library/react";
 import { describe, expect, it, vi, beforeEach } from "vitest";
 
-const { dispatchMock } = vi.hoisted(() => ({
+const { dispatchMock, useReducedMotionMock } = vi.hoisted(() => ({
   dispatchMock: vi.fn(() => Promise.resolve()),
+  useReducedMotionMock: vi.fn(() => false),
 }));
 
 vi.mock("@/services/ActionService", () => ({
@@ -14,6 +15,10 @@ vi.mock("@/services/ActionService", () => ({
 
 vi.mock("@/lib/utils", () => ({
   cn: (...args: unknown[]) => args.filter(Boolean).join(" "),
+}));
+
+vi.mock("framer-motion", () => ({
+  useReducedMotion: useReducedMotionMock,
 }));
 
 import { GettingStartedChecklist } from "../GettingStartedChecklist";
@@ -154,12 +159,12 @@ describe("GettingStartedChecklist", () => {
   it("renders the n/n counter while the checklist is incomplete", () => {
     render(<GettingStartedChecklist {...defaultProps} checklist={mixedState} />);
     expect(screen.getByText("1/4")).toBeTruthy();
-    expect(screen.queryByText("All done")).toBeNull();
+    expect(screen.queryByText("All set")).toBeNull();
   });
 
-  it("renders the 'All done' milestone label when every item is complete", () => {
+  it("renders the 'All set' milestone label when every item is complete", () => {
     render(<GettingStartedChecklist {...defaultProps} checklist={allComplete} />);
-    expect(screen.getByText("All done")).toBeTruthy();
+    expect(screen.getByText("All set")).toBeTruthy();
     expect(screen.queryByText("4/4")).toBeNull();
   });
 
@@ -216,6 +221,61 @@ describe("GettingStartedChecklist", () => {
       const toggle = screen.getByRole("button", { name: /getting started/i });
       fireEvent.click(toggle);
       expect(defaultProps.onToggleCollapse).toHaveBeenCalledTimes(1);
+    });
+  });
+
+  describe("entry transition timing", () => {
+    it("uses the Tier 2 enter duration (200ms) on the panel surface", () => {
+      render(<GettingStartedChecklist {...defaultProps} checklist={allIncomplete} />);
+      const region = screen.getByRole("region", { name: "Getting started checklist" });
+      expect(region.className).toContain("duration-200");
+      expect(region.className).not.toContain("duration-300");
+    });
+  });
+
+  describe("completed-state surface", () => {
+    it("uses neutral elevated surface tokens when allComplete is true", () => {
+      render(<GettingStartedChecklist {...defaultProps} checklist={allComplete} />);
+      const region = screen.getByRole("region", { name: "Getting started checklist" });
+      expect(region.className).toContain("bg-surface-panel");
+      expect(region.className).toContain("border-border-default");
+    });
+
+    it("keeps the accent-tinted surface when not all items are complete", () => {
+      render(<GettingStartedChecklist {...defaultProps} checklist={mixedState} />);
+      const region = screen.getByRole("region", { name: "Getting started checklist" });
+      expect(region.className).toContain("color-mix");
+      expect(region.className).not.toContain("bg-surface-panel");
+    });
+  });
+
+  describe("check badge pop animation", () => {
+    beforeEach(() => {
+      useReducedMotionMock.mockReturnValue(false);
+    });
+
+    it("does NOT apply animate-badge-bump on first render for already-complete items", () => {
+      render(<GettingStartedChecklist {...defaultProps} checklist={allComplete} />);
+      expect(document.body.querySelector(".animate-badge-bump")).toBeNull();
+    });
+
+    it("applies animate-badge-bump when an item transitions from incomplete to complete", () => {
+      const { rerender } = render(
+        <GettingStartedChecklist {...defaultProps} checklist={allIncomplete} />
+      );
+      expect(document.body.querySelector(".animate-badge-bump")).toBeNull();
+
+      rerender(<GettingStartedChecklist {...defaultProps} checklist={mixedState} />);
+      expect(document.body.querySelector(".animate-badge-bump")).not.toBeNull();
+    });
+
+    it("skips the pop under prefers-reduced-motion even when an item ticks", () => {
+      useReducedMotionMock.mockReturnValue(true);
+      const { rerender } = render(
+        <GettingStartedChecklist {...defaultProps} checklist={allIncomplete} />
+      );
+      rerender(<GettingStartedChecklist {...defaultProps} checklist={mixedState} />);
+      expect(document.body.querySelector(".animate-badge-bump")).toBeNull();
     });
   });
 });


### PR DESCRIPTION
## Summary

- Drops the checklist entry transition from 300ms to 200ms to match the app-wide Tier 2 `UI_ENTER_DURATION` constant
- On `allComplete`, transitions the surface from an accent-tinted `color-mix` background/border to neutral elevated tokens (`bg-surface-panel` + `border-border-default`), with the counter label switching to `text-daintree-accent` so the milestone keeps a single load-bearing accent hit
- Adds a badge-pop animation using the existing `animate-badge-bump` keyframe when an item ticks; pop state is lifted to the parent so the row's button-to-div swap doesn't reset it, with a `200ms` `setTimeout` fallback for reduced-motion and performance-mode where `animationend` never fires; counter copy changes from "All done" to "All set"

Resolves #7600

## Changes

- `GettingStartedChecklist.tsx`: entry duration 300ms → 200ms; completed-state surface tokens; badge-pop state lifted to parent; pop skipped under `prefers-reduced-motion`
- 7 new tests: entry duration, completed-state surface tokens, `color-mix` removal on completion, counter label accent transition, badge pop on tick, badge pop skipped under reduced motion, no spurious pop on first render with already-complete items

## Testing

24 tests passing (17 existing + 7 new). Covered manually: checklist entry, item tick pop, all-complete surface transition, reduced-motion bypass, performance-mode `animationend` fallback.