### PR TITLE
feat(mcp-audit): expose latency rollup, tier hints, and 401 counter in assistant settings

### DIFF
--- a/electron/ipc/channels.ts
+++ b/electron/ipc/channels.ts
@@ -509,6 +509,12 @@ export const CHANNELS = {
   MCP_SERVER_SET_AUDIT_MAX_RECORDS: "mcp-server:set-audit-max-records",
   MCP_SERVER_GET_AUDIT_CONFIG: "mcp-server:get-audit-config",
   /**
+   * Read the session-scoped audit health counters (currently the
+   * since-launch 401 counter). Distinct from `MCP_SERVER_GET_AUDIT_RECORDS`
+   * because pre-dispatch auth failures never reach the record ring buffer.
+   */
+  MCP_SERVER_GET_AUDIT_STATS: "mcp-server:get-audit-stats",
+  /**
    * Mount-time hydration of the runtime-state snapshot. Distinct from
    * `MCP_SERVER_GET_STATUS` (which exposes config — enabled/port/apiKey)
    * because the renderer needs the derived `disabled|starting|ready|failed`

--- a/electron/ipc/handlers/__tests__/mcpServer.adversarial.test.ts
+++ b/electron/ipc/handlers/__tests__/mcpServer.adversarial.test.ts
@@ -195,8 +195,8 @@ describe("mcpServer IPC adversarial", () => {
     expect(serviceMock.clearAuditLog).toHaveBeenCalledTimes(1);
   });
 
-  it("cleanup removes all twelve registered handlers", () => {
-    expect(ipcHandlers.size).toBe(12);
+  it("cleanup removes all thirteen registered handlers", () => {
+    expect(ipcHandlers.size).toBe(13);
     cleanup();
     expect(ipcHandlers.size).toBe(0);
   });

--- a/electron/ipc/handlers/mcpServer.ts
+++ b/electron/ipc/handlers/mcpServer.ts
@@ -75,6 +75,13 @@ export function registerMcpServerHandlers(): () => void {
   );
 
   handlers.push(
+    typedHandle(CHANNELS.MCP_SERVER_GET_AUDIT_STATS, async () => {
+      const svc = await getMcpServerService();
+      return svc.getAuditStats();
+    })
+  );
+
+  handlers.push(
     typedHandle(CHANNELS.MCP_SERVER_CLEAR_AUDIT_LOG, async () => {
       const svc = await getMcpServerService();
       svc.clearAuditLog();

--- a/electron/preload.cts
+++ b/electron/preload.cts
@@ -2386,6 +2386,7 @@ const api: ElectronAPI = {
     getConfigSnippet: () => _unwrappingInvoke(CHANNELS.MCP_SERVER_GET_CONFIG_SNIPPET),
     getAuditRecords: () => _unwrappingInvoke(CHANNELS.MCP_SERVER_GET_AUDIT_RECORDS),
     getAuditConfig: () => _unwrappingInvoke(CHANNELS.MCP_SERVER_GET_AUDIT_CONFIG),
+    getAuditStats: () => _unwrappingInvoke(CHANNELS.MCP_SERVER_GET_AUDIT_STATS),
     clearAuditLog: () => _unwrappingInvoke(CHANNELS.MCP_SERVER_CLEAR_AUDIT_LOG),
     setAuditEnabled: (enabled: boolean) =>
       _unwrappingInvoke(CHANNELS.MCP_SERVER_SET_AUDIT_ENABLED, enabled),

--- a/electron/services/McpServerService.ts
+++ b/electron/services/McpServerService.ts
@@ -4,9 +4,10 @@ import type { WindowRegistry } from "../window/WindowRegistry.js";
 import { getWindowRegistry } from "../window/windowRef.js";
 import type {
   AssistantTurnRecord,
+  McpAuditRecord,
+  McpAuditStats,
   McpRuntimeSnapshot,
   McpRuntimeState,
-  McpAuditRecord,
   TurnOutcomeClass,
 } from "../../shared/types/ipc/mcpServer.js";
 import { SessionStore } from "./mcp-server/sessionStore.js";
@@ -323,6 +324,10 @@ export class McpServerService {
 
   getAuditConfig(): { enabled: boolean; maxRecords: number } {
     return this.auditService.getAuditConfig();
+  }
+
+  getAuditStats(): McpAuditStats {
+    return this.auditService.getAuditStats();
   }
 
   clearAuditLog(): void {

--- a/electron/services/TelemetryService.ts
+++ b/electron/services/TelemetryService.ts
@@ -1,12 +1,14 @@
-import os from "os";
 import { randomUUID } from "node:crypto";
 import { app } from "electron";
 import { store } from "../store.js";
 import type { ActionBreadcrumb } from "../../shared/types/ipc/crashRecovery.js";
 import type { SanitizedTelemetryEvent } from "../../shared/types/ipc/telemetryPreview.js";
 import { scrubSecrets } from "../utils/secretScrubber.js";
+import { sanitizePath } from "../utils/pathScrubber.js";
 import { emitTelemetryPreview, isTelemetryPreviewActive } from "./TelemetryPreviewBroadcaster.js";
 import { getWritesSuppressed } from "./diskPressureState.js";
+
+export { sanitizePath };
 
 export interface SentryBreadcrumb {
   message?: string;
@@ -44,18 +46,6 @@ export interface SentryEvent {
   breadcrumbs?: SentryBreadcrumb[];
   extra?: Record<string, unknown>;
   [key: string]: unknown;
-}
-
-const HOME_DIR = os.homedir();
-
-export function sanitizePath(str: string): string {
-  const escaped = HOME_DIR.replace(/[.*+?^${}()|[\]\\]/g, "\\$&");
-  return str
-    .replace(new RegExp(escaped, "g"), "~")
-    .replace(/\/Users\/[^/]+\//g, "/Users/USER/")
-    .replace(/\/home\/[^/]+\//g, "/home/USER/")
-    .replace(/C:\\Users\\[^\\]+\\/gi, "C:\\Users\\USER\\")
-    .replace(/C:\/Users\/[^/]+\//gi, "C:/Users/USER/");
 }
 
 function sanitizeString(value: string): string {

--- a/electron/services/mcp-server/__tests__/auditLog.test.ts
+++ b/electron/services/mcp-server/__tests__/auditLog.test.ts
@@ -1,0 +1,163 @@
+import { describe, expect, it, vi } from "vitest";
+import { AuditService, type AuditOutcome } from "../auditLog.js";
+
+function makeFixture(initialConfig: Record<string, unknown> = {}) {
+  const config: Record<string, unknown> = {
+    auditEnabled: true,
+    auditMaxRecords: 500,
+    ...initialConfig,
+  };
+  const saveConfig = vi.fn((patch: Record<string, unknown>) => {
+    Object.assign(config, patch);
+  });
+  const service = new AuditService(saveConfig, () => config);
+  return { service, saveConfig, config };
+}
+
+const successOutcome: AuditOutcome = {
+  kind: "result",
+  value: { ok: true, result: null },
+};
+
+const unauthorizedOutcome: AuditOutcome = { kind: "unauthorized" };
+
+describe("AuditService.appendRecord", () => {
+  it("scrubs path-like substrings in argsSummary", () => {
+    const { service } = makeFixture();
+    service.appendRecord({
+      toolId: "files.search",
+      sessionId: "sess-1",
+      tier: "action",
+      args: {},
+      durationMs: 10,
+      outcome: successOutcome,
+      argsSummary: '{"path":"/Users/jane/secret/file.ts"}',
+    });
+    const [record] = service.getRecords();
+    expect(record).toBeDefined();
+    expect(record!.argsSummary).toContain("/Users/USER/");
+    expect(record!.argsSummary).not.toContain("/Users/jane/");
+  });
+
+  it("scrubs structural secret patterns in argsSummary", () => {
+    const { service } = makeFixture();
+    service.appendRecord({
+      toolId: "agent.launch",
+      sessionId: "sess-1",
+      tier: "action",
+      args: {},
+      durationMs: 10,
+      outcome: successOutcome,
+      argsSummary: '{"auth":"Bearer abcdefghijklmnop"}',
+    });
+    const [record] = service.getRecords();
+    expect(record!.argsSummary).toContain("Bearer [REDACTED]");
+    expect(record!.argsSummary).not.toContain("abcdefghijklmnop");
+  });
+
+  it("populates tierHint on unauthorized records using the static allowlist", () => {
+    const { service } = makeFixture();
+    // `agent.terminal` is in the action tier; from a workbench session
+    // attempting to invoke it, the minimum permitting tier is `action`.
+    service.appendRecord({
+      toolId: "agent.terminal",
+      sessionId: "sess-1",
+      tier: "workbench",
+      args: {},
+      durationMs: 0,
+      outcome: unauthorizedOutcome,
+      argsSummary: "{}",
+    });
+    const [actionTierRecord] = service.getRecords();
+    expect(actionTierRecord!.result).toBe("unauthorized");
+    expect(actionTierRecord!.tierHint).toBe("action");
+
+    // `agent.launch` is gated by the system tier; even an action-tier
+    // session needs to be elevated to system.
+    service.appendRecord({
+      toolId: "agent.launch",
+      sessionId: "sess-1",
+      tier: "action",
+      args: {},
+      durationMs: 0,
+      outcome: unauthorizedOutcome,
+      argsSummary: "{}",
+    });
+    const records = service.getRecords();
+    expect(records[0]!.tierHint).toBe("system");
+  });
+
+  it("sets tierHint to null for unknown tools on unauthorized records", () => {
+    const { service } = makeFixture();
+    service.appendRecord({
+      toolId: "definitely.notATool",
+      sessionId: "sess-1",
+      tier: "workbench",
+      args: {},
+      durationMs: 0,
+      outcome: unauthorizedOutcome,
+      argsSummary: "{}",
+    });
+    const [record] = service.getRecords();
+    expect(record!.tierHint).toBeNull();
+  });
+
+  it("does not set tierHint on success outcomes", () => {
+    const { service } = makeFixture();
+    service.appendRecord({
+      toolId: "agent.launch",
+      sessionId: "sess-1",
+      tier: "action",
+      args: {},
+      durationMs: 5,
+      outcome: successOutcome,
+      argsSummary: "{}",
+    });
+    const [record] = service.getRecords();
+    expect(record!.tierHint).toBeUndefined();
+  });
+
+  it("respects the auditEnabled kill switch", () => {
+    const { service } = makeFixture({ auditEnabled: false });
+    service.appendRecord({
+      toolId: "agent.launch",
+      sessionId: "sess-1",
+      tier: "action",
+      args: {},
+      durationMs: 5,
+      outcome: successOutcome,
+      argsSummary: "{}",
+    });
+    expect(service.getRecords()).toHaveLength(0);
+  });
+});
+
+describe("AuditService.recordAuth401 / getAuditStats", () => {
+  it("starts at zero", () => {
+    const { service } = makeFixture();
+    expect(service.getAuditStats()).toEqual({ auth401Count: 0 });
+  });
+
+  it("increments on each call", () => {
+    const { service } = makeFixture();
+    service.recordAuth401();
+    service.recordAuth401();
+    service.recordAuth401();
+    expect(service.getAuditStats()).toEqual({ auth401Count: 3 });
+  });
+
+  it("does not increment when audit is disabled", () => {
+    const { service } = makeFixture({ auditEnabled: false });
+    service.recordAuth401();
+    service.recordAuth401();
+    expect(service.getAuditStats()).toEqual({ auth401Count: 0 });
+  });
+
+  it("is not reset by clear() — counter is session-scoped, not log-scoped", () => {
+    const { service } = makeFixture();
+    service.recordAuth401();
+    service.recordAuth401();
+    service.clear();
+    expect(service.getAuditStats()).toEqual({ auth401Count: 2 });
+  });
+});

--- a/electron/services/mcp-server/__tests__/auditLog.test.ts
+++ b/electron/services/mcp-server/__tests__/auditLog.test.ts
@@ -22,7 +22,9 @@ const successOutcome: AuditOutcome = {
 const unauthorizedOutcome: AuditOutcome = { kind: "unauthorized" };
 
 describe("AuditService.appendRecord", () => {
-  it("scrubs path-like substrings in argsSummary", () => {
+  it("stores the caller-provided argsSummary verbatim", () => {
+    // Redaction lives in the call-site `summarizeMcpArgs` pipeline; the
+    // service trusts what it's handed.
     const { service } = makeFixture();
     service.appendRecord({
       toolId: "files.search",
@@ -31,28 +33,10 @@ describe("AuditService.appendRecord", () => {
       args: {},
       durationMs: 10,
       outcome: successOutcome,
-      argsSummary: '{"path":"/Users/jane/secret/file.ts"}',
+      argsSummary: '{"q":"<redacted>"}',
     });
     const [record] = service.getRecords();
-    expect(record).toBeDefined();
-    expect(record!.argsSummary).toContain("/Users/USER/");
-    expect(record!.argsSummary).not.toContain("/Users/jane/");
-  });
-
-  it("scrubs structural secret patterns in argsSummary", () => {
-    const { service } = makeFixture();
-    service.appendRecord({
-      toolId: "agent.launch",
-      sessionId: "sess-1",
-      tier: "action",
-      args: {},
-      durationMs: 10,
-      outcome: successOutcome,
-      argsSummary: '{"auth":"Bearer abcdefghijklmnop"}',
-    });
-    const [record] = service.getRecords();
-    expect(record!.argsSummary).toContain("Bearer [REDACTED]");
-    expect(record!.argsSummary).not.toContain("abcdefghijklmnop");
+    expect(record!.argsSummary).toBe('{"q":"<redacted>"}');
   });
 
   it("populates tierHint on unauthorized records using the static allowlist", () => {

--- a/electron/services/mcp-server/__tests__/httpLifecycle.test.ts
+++ b/electron/services/mcp-server/__tests__/httpLifecycle.test.ts
@@ -60,6 +60,8 @@ function fakeDeps(overrides?: Partial<HttpLifecycleDeps>): HttpLifecycleDeps {
       hydrate: vi.fn(),
       flushNow: vi.fn(),
       appendRecord: vi.fn(),
+      recordAuth401: vi.fn(),
+      getAuditStats: vi.fn(() => ({ auth401Count: 0 })),
     },
     turnOutcomeService: {
       flushNow: vi.fn(),
@@ -362,6 +364,34 @@ describe("HttpLifecycle", () => {
         expect.objectContaining({ "WWW-Authenticate": 'Bearer realm="Daintree MCP"' })
       );
       expect(res.end).toHaveBeenCalledWith("Unauthorized");
+      expect(deps.auditService.recordAuth401).toHaveBeenCalledTimes(1);
+    });
+
+    it("does not increment the 401 counter on a 403 (host mismatch)", async () => {
+      const deps = fakeDeps();
+      const lc = new HttpLifecycle(deps);
+      lc.setApiKey("test-api-key");
+      (lc as unknown as { port: number }).port = 45454;
+
+      const res = {
+        writeHead: vi.fn(),
+        end: vi.fn(),
+        headersSent: false,
+      } as unknown as http.ServerResponse;
+      const req = {
+        method: "GET",
+        url: "/sse",
+        headers: { host: "evil.example.com" },
+      } as unknown as http.IncomingMessage;
+
+      await (
+        lc as unknown as {
+          handleRequest: (req: http.IncomingMessage, res: http.ServerResponse) => Promise<void>;
+        }
+      ).handleRequest(req, res);
+
+      expect(res.writeHead).toHaveBeenCalledWith(403, expect.anything());
+      expect(deps.auditService.recordAuth401).not.toHaveBeenCalled();
     });
   });
 });

--- a/electron/services/mcp-server/auditLog.ts
+++ b/electron/services/mcp-server/auditLog.ts
@@ -2,6 +2,7 @@ import { randomUUID } from "node:crypto";
 import type {
   McpAuditRecord,
   McpAuditResult,
+  McpAuditStats,
   McpConfirmationDecision,
 } from "../../../shared/types/ipc/mcpServer.js";
 import {
@@ -16,12 +17,21 @@ import {
   CONFIRMATION_REQUIRED_CODE,
   USER_REJECTED_CODE,
   CONFIRMATION_TIMEOUT_CODE,
+  minimumPermittingTier,
 } from "./shared.js";
+import { scrubSecrets } from "../../utils/secretScrubber.js";
+import { sanitizePath } from "../../utils/pathScrubber.js";
 
 export class AuditService {
   private records: McpAuditRecord[] = [];
   private flushTimer: ReturnType<typeof setTimeout> | null = null;
   private hydrated = false;
+  /**
+   * Session-scoped 401 counter. Tracks bearer auth rejections that fail
+   * before any tool dispatch — those never reach `appendRecord` because
+   * no `toolId`/`tier` is known. Reset on app restart by design.
+   */
+  private auth401Count = 0;
 
   constructor(
     private readonly saveConfig: (patch: Record<string, unknown>) => void,
@@ -96,13 +106,20 @@ export class AuditService {
 
     const classification = this.classifyDispatchResult(input.outcome);
     const decision = this.deriveConfirmationDecision(input.outcome, input.confirmationDecision);
+    // Defense in depth: `summarizeMcpArgs` already truncates long strings and
+    // collapses nested objects, but a structural secret (Bearer prefix,
+    // sk-...-shaped key, JWT) inside a short value would slip through. Apply
+    // the same `sanitizePath`/`scrubSecrets` pipeline used by Sentry/Diagnostics
+    // so audit-record viewers see the same redaction guarantees as those
+    // outbound surfaces.
+    const safeArgsSummary = scrubSecrets(sanitizePath(input.argsSummary));
     const record: McpAuditRecord = {
       id: randomUUID(),
       timestamp: Date.now(),
       toolId: input.toolId,
       sessionId: input.sessionId,
       tier: input.tier,
-      argsSummary: input.argsSummary,
+      argsSummary: safeArgsSummary,
       result: classification.result,
       durationMs: Math.max(0, Math.round(input.durationMs)),
     };
@@ -112,6 +129,9 @@ export class AuditService {
     if (decision !== undefined) {
       record.confirmationDecision = decision;
     }
+    if (classification.result === "unauthorized") {
+      record.tierHint = minimumPermittingTier(input.toolId);
+    }
 
     this.records.push(record);
     const cap = this.normalizeMaxRecords(this.readConfig().auditMaxRecords);
@@ -119,6 +139,25 @@ export class AuditService {
       this.records.splice(0, this.records.length - cap);
     }
     this.scheduleFlush();
+  }
+
+  /**
+   * Increment the session-scoped 401 counter. Called from the HTTP lifecycle
+   * on bearer auth failures (missing/malformed/revoked) before any tool
+   * dispatch occurs. Gated by the same `auditEnabled` kill switch as
+   * `appendRecord` so toggling audit logging off uniformly silences both
+   * record writes and counter increments.
+   */
+  recordAuth401(): void {
+    if (this.readConfig().auditEnabled === false) return;
+    this.auth401Count += 1;
+  }
+
+  /**
+   * Read the session-scoped audit health counters. Renderer-facing.
+   */
+  getAuditStats(): McpAuditStats {
+    return { auth401Count: this.auth401Count };
   }
 
   private scheduleFlush(): void {

--- a/electron/services/mcp-server/auditLog.ts
+++ b/electron/services/mcp-server/auditLog.ts
@@ -19,8 +19,6 @@ import {
   CONFIRMATION_TIMEOUT_CODE,
   minimumPermittingTier,
 } from "./shared.js";
-import { scrubSecrets } from "../../utils/secretScrubber.js";
-import { sanitizePath } from "../../utils/pathScrubber.js";
 
 export class AuditService {
   private records: McpAuditRecord[] = [];
@@ -106,20 +104,16 @@ export class AuditService {
 
     const classification = this.classifyDispatchResult(input.outcome);
     const decision = this.deriveConfirmationDecision(input.outcome, input.confirmationDecision);
-    // Defense in depth: `summarizeMcpArgs` already truncates long strings and
-    // collapses nested objects, but a structural secret (Bearer prefix,
-    // sk-...-shaped key, JWT) inside a short value would slip through. Apply
-    // the same `sanitizePath`/`scrubSecrets` pipeline used by Sentry/Diagnostics
-    // so audit-record viewers see the same redaction guarantees as those
-    // outbound surfaces.
-    const safeArgsSummary = scrubSecrets(sanitizePath(input.argsSummary));
+    // `argsSummary` is expected to have already passed through the
+    // `summarizeMcpArgs` redactor (key-name + scrub + sanitizePath) at the
+    // call site in `httpLifecycle.ts`. Stored verbatim here.
     const record: McpAuditRecord = {
       id: randomUUID(),
       timestamp: Date.now(),
       toolId: input.toolId,
       sessionId: input.sessionId,
       tier: input.tier,
-      argsSummary: safeArgsSummary,
+      argsSummary: input.argsSummary,
       result: classification.result,
       durationMs: Math.max(0, Math.round(input.durationMs)),
     };

--- a/electron/services/mcp-server/httpLifecycle.ts
+++ b/electron/services/mcp-server/httpLifecycle.ts
@@ -463,6 +463,7 @@ export class HttpLifecycle {
 
     const authHeader = req.headers.authorization ?? "";
     if (!isAuthorized(authHeader, this.apiKeyBearerHash, this.helpTokenValidator)) {
+      this.deps.auditService.recordAuth401();
       res.writeHead(401, {
         "Content-Type": "text/plain",
         "WWW-Authenticate": 'Bearer realm="Daintree MCP"',

--- a/electron/services/mcp-server/httpLifecycle.ts
+++ b/electron/services/mcp-server/httpLifecycle.ts
@@ -9,6 +9,8 @@ import { store } from "../../store.js";
 import { CHANNELS } from "../../ipc/channels.js";
 import { formatErrorMessage } from "../../../shared/utils/errorMessage.js";
 import { summarizeMcpArgs } from "../../../shared/utils/mcpArgsSummary.js";
+import { scrubSecrets } from "../../utils/secretScrubber.js";
+import { sanitizePath } from "../../utils/pathScrubber.js";
 import type { HelpTokenValidator, HelpSessionWebContentsResolver, McpTier } from "./shared.js";
 import {
   extractBearerToken,
@@ -717,9 +719,13 @@ export class HttpLifecycle {
       dispatchAction,
       handleWaitUntilIdle: this.deps.handleWaitUntilIdle,
       appendAuditRecord: (input) => {
+        // Scrub structural secrets BEFORE the truncation step inside
+        // `summarizeMcpArgs` — running the scrubber after truncation would
+        // miss bearer tokens whose body got cut below the scrubber's
+        // 8-char minimum match length.
         this.deps.auditService.appendRecord({
           ...input,
-          argsSummary: summarizeMcpArgs(input.args),
+          argsSummary: summarizeMcpArgs(input.args, (s) => scrubSecrets(sanitizePath(s))),
         });
       },
       getCachedManifest,

--- a/electron/utils/pathScrubber.ts
+++ b/electron/utils/pathScrubber.ts
@@ -1,0 +1,25 @@
+import os from "os";
+
+/**
+ * Pure path-sanitizing utility for telemetry, diagnostics, and audit
+ * surfaces. Replaces the current user's home directory and common
+ * macOS / Linux / Windows user paths with `~` or `USER` placeholders so
+ * shareable strings don't reveal account names.
+ *
+ * Extracted from `TelemetryService.ts` so consumers (e.g. the MCP audit
+ * log) can apply the same scrub without dragging Sentry initialization
+ * into their import graph.
+ */
+
+const HOME_DIR = os.homedir();
+const HOME_DIR_ESCAPED = HOME_DIR.replace(/[.*+?^${}()|[\]\\]/g, "\\$&");
+const HOME_DIR_REGEX = new RegExp(HOME_DIR_ESCAPED, "g");
+
+export function sanitizePath(str: string): string {
+  return str
+    .replace(HOME_DIR_REGEX, "~")
+    .replace(/\/Users\/[^/]+\//g, "/Users/USER/")
+    .replace(/\/home\/[^/]+\//g, "/home/USER/")
+    .replace(/C:\\Users\\[^\\]+\\/gi, "C:\\Users\\USER\\")
+    .replace(/C:\/Users\/[^/]+\//gi, "C:/Users/USER/");
+}

--- a/shared/types/index.ts
+++ b/shared/types/index.ts
@@ -323,6 +323,7 @@ export { CONNECTIVITY_SERVICE_KEYS } from "./ipc/connectivity.js";
 export type {
   McpAuditRecord,
   McpAuditResult,
+  McpAuditStats,
   McpRuntimeSnapshot,
   McpRuntimeState,
 } from "./ipc/mcpServer.js";

--- a/shared/types/ipc/api.ts
+++ b/shared/types/ipc/api.ts
@@ -1298,6 +1298,11 @@ export interface ElectronAPI {
     getAuditRecords(): Promise<import("./mcpServer.js").McpAuditRecord[]>;
     /** Get the persisted audit-log configuration. */
     getAuditConfig(): Promise<{ enabled: boolean; maxRecords: number }>;
+    /**
+     * Read the session-scoped audit health counters (currently the
+     * since-launch 401 counter). Resets on app restart.
+     */
+    getAuditStats(): Promise<import("./mcpServer.js").McpAuditStats>;
     /** Clear all audit records from the ring buffer and persistence. */
     clearAuditLog(): Promise<void>;
     /** Toggle audit-log capture without losing existing records. */

--- a/shared/types/ipc/maps.ts
+++ b/shared/types/ipc/maps.ts
@@ -1811,6 +1811,10 @@ export interface IpcInvokeMap {
     args: [];
     result: { enabled: boolean; maxRecords: number };
   };
+  "mcp-server:get-audit-stats": {
+    args: [];
+    result: import("./mcpServer.js").McpAuditStats;
+  };
   "mcp-server:clear-audit-log": {
     args: [];
     result: void;

--- a/shared/types/ipc/mcpServer.ts
+++ b/shared/types/ipc/mcpServer.ts
@@ -61,12 +61,35 @@ export interface McpAuditRecord {
   errorCode?: string;
   durationMs: number;
   confirmationDecision?: McpConfirmationDecision;
+  /**
+   * For `unauthorized` outcomes, the lowest help-session tier that would have
+   * permitted the dispatch — `workbench`, `action`, or `system`. Set at
+   * record-write time from the static `TIER_ALLOWLISTS`. `null` means the
+   * tool isn't permitted at any tier (unknown tool). Optional and absent on
+   * non-unauthorized outcomes.
+   */
+  tierHint?: "workbench" | "action" | "system" | null;
 }
 
 /** Minimum and maximum values accepted for the configurable ring-buffer cap. */
 export const MCP_AUDIT_MIN_RECORDS = 50;
 export const MCP_AUDIT_MAX_RECORDS = 10000;
 export const MCP_AUDIT_DEFAULT_MAX_RECORDS = 500;
+
+/**
+ * Session-scoped audit health counters. Reset on app restart by design —
+ * these capture "since-launch" signals that complement the persisted
+ * audit-record ring buffer.
+ *
+ * - `auth401Count`: number of MCP HTTP requests rejected with `401
+ *   Unauthorized` since the current process started. Increments cover the
+ *   missing-bearer, malformed-bearer, and revoked-bearer paths uniformly —
+ *   none of which reach `appendRecord` because no `toolId`/`tier` is known
+ *   when authentication fails.
+ */
+export interface McpAuditStats {
+  auth401Count: number;
+}
 
 /**
  * Outcome classification for a single assistant turn (one `active → passive`

--- a/shared/utils/__tests__/mcpArgsSummary.test.ts
+++ b/shared/utils/__tests__/mcpArgsSummary.test.ts
@@ -88,3 +88,34 @@ describe("summarizeMcpArgs", () => {
     expect(out).toBe('{"name":"hello"}');
   });
 });
+
+describe("summarizeMcpArgs postSerializeScrub", () => {
+  it("runs the callback on the serialized JSON before truncation", () => {
+    const out = summarizeMcpArgs({ q: "hello" }, (s) => s.replace(/hello/g, "REDACTED"));
+    expect(out).toBe('{"q":"REDACTED"}');
+  });
+
+  it("scrubs structural secrets that would otherwise survive truncation", () => {
+    // Scrubber stub matches Bearer tokens with at least 8 chars of body.
+    const scrub = (s: string) => s.replace(/Bearer [A-Za-z0-9]{8,}/g, "Bearer [REDACTED]");
+    const padding = "x".repeat(MCP_ARGS_INLINE_STRING_LIMIT);
+    const out = summarizeMcpArgs({ padding, ctx: "Bearer aabbccddeeff" }, scrub);
+    expect(out).toContain("Bearer [REDACTED]");
+    expect(out).not.toContain("aabbccddeeff");
+  });
+
+  it("scrubs before truncation so a sliced bearer body is not leaked", () => {
+    // Build args whose serialized form places a bearer token at a position
+    // where the 300-char truncation would cut its body. With pre-truncation
+    // scrub the bearer body never reaches the slice.
+    const padding = "x".repeat(MCP_ARGS_INLINE_STRING_LIMIT);
+    const args: Record<string, string> = {};
+    for (let i = 0; i < 5; i += 1) args[`a${i}`] = padding;
+    args.tail = "Bearer abcdefghij";
+    const scrub = (s: string) => s.replace(/Bearer [A-Za-z0-9]{8,}/g, "Bearer [REDACTED]");
+    const out = summarizeMcpArgs(args, scrub);
+    // Either the bearer body was scrubbed before truncation, or the entire
+    // tail was truncated. Neither leaves the partial body visible.
+    expect(out).not.toMatch(/Bearer abcd/);
+  });
+});

--- a/shared/utils/__tests__/mcpArgsSummary.test.ts
+++ b/shared/utils/__tests__/mcpArgsSummary.test.ts
@@ -1,0 +1,90 @@
+import { describe, expect, it } from "vitest";
+import {
+  MCP_ARGS_INLINE_STRING_LIMIT,
+  MCP_ARGS_SUMMARY_LIMIT,
+  summarizeMcpArgs,
+} from "../mcpArgsSummary.js";
+
+describe("summarizeMcpArgs", () => {
+  it("returns null for null and undefined inputs", () => {
+    expect(summarizeMcpArgs(null)).toBe("null");
+    expect(summarizeMcpArgs(undefined)).toBe("null");
+  });
+
+  it("collapses long strings to a length placeholder", () => {
+    const long = "x".repeat(MCP_ARGS_INLINE_STRING_LIMIT + 10);
+    const out = summarizeMcpArgs({ note: long });
+    expect(out).toContain(`<string: ${long.length} chars>`);
+    expect(out).not.toContain("xxx");
+  });
+
+  it("collapses nested objects to <object>", () => {
+    const out = summarizeMcpArgs({ args: { deep: { value: 1 } } });
+    expect(out).toBe('{"args":"<object>"}');
+  });
+
+  it("excludes the _meta field entirely", () => {
+    const out = summarizeMcpArgs({ toolId: "x", _meta: { secret: "abc" } });
+    expect(out).toBe('{"toolId":"x"}');
+  });
+
+  it("redacts short string values keyed under sensitive names", () => {
+    const out = summarizeMcpArgs({
+      token: "abc123",
+      apiKey: "sk-xyz",
+      password: "hunter2",
+      authToken: "Bearer xyz",
+      credential: "x",
+      bearerToken: "x",
+      api_key: "x",
+    });
+    expect(out).toContain('"token":"<redacted>"');
+    expect(out).toContain('"apiKey":"<redacted>"');
+    expect(out).toContain('"password":"<redacted>"');
+    expect(out).toContain('"authToken":"<redacted>"');
+    expect(out).toContain('"credential":"<redacted>"');
+    expect(out).toContain('"bearerToken":"<redacted>"');
+    expect(out).toContain('"api_key":"<redacted>"');
+  });
+
+  it("redacts conservatively on key names that contain a sensitive substring", () => {
+    // Substring matching is intentional: `tokenizer` contains `token`,
+    // `keyword` contains `key`. Erring toward false positives keeps short
+    // secret values from slipping through under unfamiliar argument names.
+    const out = summarizeMcpArgs({ tokenizer: "ok", keyword: "ok" });
+    expect(out).toContain('"tokenizer":"<redacted>"');
+    expect(out).toContain('"keyword":"<redacted>"');
+  });
+
+  it("does not redact non-string values under sensitive keys", () => {
+    const out = summarizeMcpArgs({ tokenCount: 42, hasKey: true });
+    expect(out).toContain('"tokenCount":42');
+    expect(out).toContain('"hasKey":true');
+  });
+
+  it("does not redact empty strings (callers pass through)", () => {
+    const out = summarizeMcpArgs({ token: "" });
+    expect(out).toBe('{"token":""}');
+  });
+
+  it("does not redact non-sensitive keys with similarly-named substrings", () => {
+    // `tool` and `path` and `query` should not match the sensitive pattern.
+    const out = summarizeMcpArgs({ tool: "hello", path: "/tmp", query: "world" });
+    expect(out).not.toContain("<redacted>");
+  });
+
+  it("truncates the serialized summary at MCP_ARGS_SUMMARY_LIMIT", () => {
+    const big: Record<string, string> = {};
+    for (let i = 0; i < 100; i += 1) {
+      big[`key${i}`] = "v";
+    }
+    const out = summarizeMcpArgs(big);
+    expect(out.length).toBeLessThanOrEqual(MCP_ARGS_SUMMARY_LIMIT);
+    expect(out.endsWith("…")).toBe(true);
+  });
+
+  it("inlines short non-sensitive string values verbatim", () => {
+    const out = summarizeMcpArgs({ name: "hello" });
+    expect(out).toBe('{"name":"hello"}');
+  });
+});

--- a/shared/utils/mcpArgsSummary.ts
+++ b/shared/utils/mcpArgsSummary.ts
@@ -9,6 +9,21 @@ export const MCP_ARGS_INLINE_STRING_LIMIT = 50;
 export const MCP_ARGS_SUMMARY_LIMIT = 300;
 
 /**
+ * Per-key heuristic for sensitive argument names. Catches short secret
+ * values (API keys, bearer tokens, short JWTs) that fit under the 50-char
+ * inline limit and would otherwise pass through verbatim. The downstream
+ * `scrubSecrets` pass on the serialized summary covers structural patterns
+ * (`Bearer ...`, `sk-...`, etc.) but only when the surrounding context is
+ * present — a bare value like `"abc123"` keyed under `token` has none.
+ *
+ * Applies at the single-level summarization site only; nested objects
+ * already collapse to `<object>`.
+ */
+const SENSITIVE_KEY_PATTERN = /(?:token|secret|password|auth|key|credential|bearer|api[_-]?key)/i;
+
+const REDACTED_PLACEHOLDER = "<redacted>";
+
+/**
  * Build a redacted, single-level JSON summary of an MCP tool-call argument
  * blob. Long strings collapse to `<string: N chars>` and nested
  * objects/arrays collapse to `<object>`. The same logic powers the audit
@@ -39,6 +54,10 @@ export function summarizeMcpArgs(args: unknown): string {
     const out: Record<string, unknown> = {};
     for (const [key, value] of Object.entries(args as Record<string, unknown>)) {
       if (key === "_meta") continue;
+      if (SENSITIVE_KEY_PATTERN.test(key) && typeof value === "string" && value.length > 0) {
+        out[key] = REDACTED_PLACEHOLDER;
+        continue;
+      }
       const reduced = summarize(value);
       if (reduced !== undefined) {
         out[key] = reduced;

--- a/shared/utils/mcpArgsSummary.ts
+++ b/shared/utils/mcpArgsSummary.ts
@@ -29,8 +29,17 @@ const REDACTED_PLACEHOLDER = "<redacted>";
  * objects/arrays collapse to `<object>`. The same logic powers the audit
  * record and the renderer-side confirmation modal so both surfaces show
  * identical, never-leaking values.
+ *
+ * `postSerializeScrub` runs against the serialized JSON before the final
+ * `MCP_ARGS_SUMMARY_LIMIT` truncation. The audit-write path passes a
+ * `scrubSecrets(sanitizePath(...))` pipeline here so structural secrets
+ * (Bearer prefixes, sk-... keys, JWTs) cannot survive a truncation that
+ * cuts the token body below the scrubber's minimum match length.
  */
-export function summarizeMcpArgs(args: unknown): string {
+export function summarizeMcpArgs(
+  args: unknown,
+  postSerializeScrub?: (value: string) => string
+): string {
   const summarize = (value: unknown): unknown => {
     if (value === null) return null;
     if (typeof value === "string") {
@@ -71,6 +80,9 @@ export function summarizeMcpArgs(args: unknown): string {
     serialized = JSON.stringify(summary) ?? "";
   } catch {
     serialized = "<unserializable>";
+  }
+  if (postSerializeScrub) {
+    serialized = postSerializeScrub(serialized);
   }
   if (serialized.length > MCP_ARGS_SUMMARY_LIMIT) {
     return `${serialized.slice(0, MCP_ARGS_SUMMARY_LIMIT - 1)}…`;

--- a/src/components/Settings/DaintreeAssistantSettingsTab.tsx
+++ b/src/components/Settings/DaintreeAssistantSettingsTab.tsx
@@ -28,6 +28,7 @@ import { formatErrorMessage } from "@shared/utils/errorMessage";
 import { useDebounce } from "@/hooks/useDebounce";
 
 import { logError } from "@/utils/logger";
+import { safeFireAndForget } from "@/utils/safeFireAndForget";
 import { getAgentConfig, getAssistantSupportedAgentIds } from "@/config/agents";
 import { useHelpPanelStore } from "@/store/helpPanelStore";
 import type {
@@ -235,26 +236,29 @@ export function DaintreeAssistantSettingsTab() {
   useEffect(() => {
     let cancelled = false;
     setAuditLoading(true);
-    Promise.allSettled([
-      window.electron.mcpServer.getAuditRecords(),
-      window.electron.mcpServer.getAuditStats(),
-    ])
-      .then(([recordsResult, statsResult]) => {
-        if (cancelled) return;
-        if (recordsResult.status === "fulfilled") {
-          setAuditRecords(recordsResult.value);
-        } else {
-          logError("Failed initial audit load for assistant tab", recordsResult.reason);
-        }
-        if (statsResult.status === "fulfilled") {
-          setAuditStats(statsResult.value);
-        } else {
-          logError("Failed initial audit stats load for assistant tab", statsResult.reason);
-        }
-      })
-      .finally(() => {
-        if (!cancelled) setAuditLoading(false);
-      });
+    safeFireAndForget(
+      Promise.allSettled([
+        window.electron.mcpServer.getAuditRecords(),
+        window.electron.mcpServer.getAuditStats(),
+      ])
+        .then(([recordsResult, statsResult]) => {
+          if (cancelled) return;
+          if (recordsResult.status === "fulfilled") {
+            setAuditRecords(recordsResult.value);
+          } else {
+            logError("Failed initial audit load for assistant tab", recordsResult.reason);
+          }
+          if (statsResult.status === "fulfilled") {
+            setAuditStats(statsResult.value);
+          } else {
+            logError("Failed initial audit stats load for assistant tab", statsResult.reason);
+          }
+        })
+        .finally(() => {
+          if (!cancelled) setAuditLoading(false);
+        }),
+      { context: "initial audit load for assistant tab" }
+    );
     return () => {
       cancelled = true;
       if (auditCopyTimeoutRef.current) clearTimeout(auditCopyTimeoutRef.current);

--- a/src/components/Settings/DaintreeAssistantSettingsTab.tsx
+++ b/src/components/Settings/DaintreeAssistantSettingsTab.tsx
@@ -21,6 +21,7 @@ import { SettingsInput } from "./SettingsInput";
 import { SettingsSelect } from "./SettingsSelect";
 import { SettingsSwitchCard } from "./SettingsSwitchCard";
 import { McpAuditLogViewer } from "./McpAuditLogViewer";
+import { McpAuditLatencyTable } from "./McpAuditLatencyTable";
 import { useSettingsTabValidation } from "./SettingsValidationRegistry";
 import { useSettingsTabFlush } from "./SettingsFlushRegistry";
 import { formatErrorMessage } from "@shared/utils/errorMessage";
@@ -29,7 +30,12 @@ import { useDebounce } from "@/hooks/useDebounce";
 import { logError } from "@/utils/logger";
 import { getAgentConfig, getAssistantSupportedAgentIds } from "@/config/agents";
 import { useHelpPanelStore } from "@/store/helpPanelStore";
-import type { HelpAssistantSettings, HelpAssistantTier, McpAuditRecord } from "@shared/types";
+import type {
+  HelpAssistantSettings,
+  HelpAssistantTier,
+  McpAuditRecord,
+  McpAuditStats,
+} from "@shared/types";
 import {
   HELP_TIER_CUMULATIVE,
   HELP_TIER_INCREMENTAL,
@@ -109,6 +115,7 @@ export function DaintreeAssistantSettingsTab() {
   const [isRotating, setIsRotating] = useState(false);
   const [showBlastRadius, setShowBlastRadius] = useState(false);
   const [auditRecords, setAuditRecords] = useState<McpAuditRecord[]>([]);
+  const [auditStats, setAuditStats] = useState<McpAuditStats | null>(null);
   const [auditLoading, setAuditLoading] = useState(true);
   const [auditCopied, setAuditCopied] = useState(false);
   const [showClearAuditConfirm, setShowClearAuditConfirm] = useState(false);
@@ -209,8 +216,12 @@ export function DaintreeAssistantSettingsTab() {
   // viewer hydrate independently of the settings + MCP status round-trips.
   const refreshAuditRecords = useCallback(async (): Promise<void> => {
     try {
-      const records = await window.electron.mcpServer.getAuditRecords();
+      const [records, stats] = await Promise.all([
+        window.electron.mcpServer.getAuditRecords(),
+        window.electron.mcpServer.getAuditStats(),
+      ]);
       setAuditRecords(records);
+      setAuditStats(stats);
     } catch (err) {
       logError("Failed to load MCP audit records for assistant tab", err);
     }
@@ -219,11 +230,14 @@ export function DaintreeAssistantSettingsTab() {
   useEffect(() => {
     let cancelled = false;
     setAuditLoading(true);
-    window.electron.mcpServer
-      .getAuditRecords()
-      .then((records) => {
+    Promise.all([
+      window.electron.mcpServer.getAuditRecords(),
+      window.electron.mcpServer.getAuditStats(),
+    ])
+      .then(([records, stats]) => {
         if (cancelled) return;
         setAuditRecords(records);
+        setAuditStats(stats);
       })
       .catch((err) => {
         if (cancelled) return;
@@ -575,6 +589,17 @@ export function DaintreeAssistantSettingsTab() {
           copyFlashActive={auditCopied}
           includeRecord={(record) => record.tier !== "external"}
         />
+        <McpAuditLatencyTable
+          records={auditRecords}
+          includeRecord={(record) => record.tier !== "external"}
+        />
+        {auditStats && auditStats.auth401Count > 0 && (
+          <p className="text-xs text-daintree-text/60 select-text">
+            <span className="font-mono text-daintree-text/80">{auditStats.auth401Count}</span>{" "}
+            bearer rejection{auditStats.auth401Count === 1 ? "" : "s"} since last launch — an
+            external client is connecting with a stale or missing API key.
+          </p>
+        )}
       </SettingsSection>
 
       {/* Connection */}

--- a/src/components/Settings/DaintreeAssistantSettingsTab.tsx
+++ b/src/components/Settings/DaintreeAssistantSettingsTab.tsx
@@ -214,34 +214,43 @@ export function DaintreeAssistantSettingsTab() {
   // Separate audit fetch effect — keeps the settings init effect's cancellation
   // semantics simple (per past lesson #4958) while still letting the audit
   // viewer hydrate independently of the settings + MCP status round-trips.
+  // `allSettled` so a stats failure doesn't silently blank the record list.
   const refreshAuditRecords = useCallback(async (): Promise<void> => {
-    try {
-      const [records, stats] = await Promise.all([
-        window.electron.mcpServer.getAuditRecords(),
-        window.electron.mcpServer.getAuditStats(),
-      ]);
-      setAuditRecords(records);
-      setAuditStats(stats);
-    } catch (err) {
-      logError("Failed to load MCP audit records for assistant tab", err);
+    const [recordsResult, statsResult] = await Promise.allSettled([
+      window.electron.mcpServer.getAuditRecords(),
+      window.electron.mcpServer.getAuditStats(),
+    ]);
+    if (recordsResult.status === "fulfilled") {
+      setAuditRecords(recordsResult.value);
+    } else {
+      logError("Failed to load MCP audit records for assistant tab", recordsResult.reason);
+    }
+    if (statsResult.status === "fulfilled") {
+      setAuditStats(statsResult.value);
+    } else {
+      logError("Failed to load MCP audit stats for assistant tab", statsResult.reason);
     }
   }, []);
 
   useEffect(() => {
     let cancelled = false;
     setAuditLoading(true);
-    Promise.all([
+    Promise.allSettled([
       window.electron.mcpServer.getAuditRecords(),
       window.electron.mcpServer.getAuditStats(),
     ])
-      .then(([records, stats]) => {
+      .then(([recordsResult, statsResult]) => {
         if (cancelled) return;
-        setAuditRecords(records);
-        setAuditStats(stats);
-      })
-      .catch((err) => {
-        if (cancelled) return;
-        logError("Failed initial audit load for assistant tab", err);
+        if (recordsResult.status === "fulfilled") {
+          setAuditRecords(recordsResult.value);
+        } else {
+          logError("Failed initial audit load for assistant tab", recordsResult.reason);
+        }
+        if (statsResult.status === "fulfilled") {
+          setAuditStats(statsResult.value);
+        } else {
+          logError("Failed initial audit stats load for assistant tab", statsResult.reason);
+        }
       })
       .finally(() => {
         if (!cancelled) setAuditLoading(false);

--- a/src/components/Settings/McpAuditLatencyTable.tsx
+++ b/src/components/Settings/McpAuditLatencyTable.tsx
@@ -1,0 +1,121 @@
+import { useMemo, useState } from "react";
+import { ChevronRight } from "lucide-react";
+import { cn } from "@/lib/utils";
+import type { McpAuditRecord } from "@shared/types";
+
+interface McpAuditLatencyTableProps {
+  records: McpAuditRecord[];
+  /**
+   * Predicate applied before stats are computed — used by the Privacy
+   * section to hide `external` MCP traffic, mirroring the row viewer.
+   */
+  includeRecord?: (record: McpAuditRecord) => boolean;
+}
+
+interface ToolStats {
+  toolId: string;
+  count: number;
+  p50: number;
+  p95: number;
+}
+
+/**
+ * Linear-interpolation percentile. For sample sets of 1, returns the value
+ * verbatim. Caller passes an ascending-sorted, non-empty array.
+ */
+function percentile(sortedAsc: number[], p: number): number {
+  if (sortedAsc.length === 1) return sortedAsc[0]!;
+  const rank = p * (sortedAsc.length - 1);
+  const k = Math.floor(rank);
+  const f = rank - k;
+  const lower = sortedAsc[k]!;
+  const upper = sortedAsc[k + 1] ?? lower;
+  return lower + f * (upper - lower);
+}
+
+export function McpAuditLatencyTable({ records, includeRecord }: McpAuditLatencyTableProps) {
+  const [isOpen, setIsOpen] = useState(true);
+
+  const stats = useMemo<ToolStats[]>(() => {
+    // Only success records meaningfully reflect tool latency. Errors and
+    // unauthorized results often short-circuit before the work runs and
+    // would skew p50/p95 downward.
+    const buckets = new Map<string, number[]>();
+    for (const record of records) {
+      if (includeRecord && !includeRecord(record)) continue;
+      if (record.result !== "success") continue;
+      const list = buckets.get(record.toolId);
+      if (list) list.push(record.durationMs);
+      else buckets.set(record.toolId, [record.durationMs]);
+    }
+    const out: ToolStats[] = [];
+    for (const [toolId, durations] of buckets) {
+      const sorted = [...durations].sort((a, b) => a - b);
+      out.push({
+        toolId,
+        count: sorted.length,
+        p50: Math.round(percentile(sorted, 0.5)),
+        p95: Math.round(percentile(sorted, 0.95)),
+      });
+    }
+    out.sort((a, b) => b.p95 - a.p95);
+    return out;
+  }, [records, includeRecord]);
+
+  return (
+    <div className="rounded-[var(--radius-md)] border border-daintree-border bg-overlay-subtle/40">
+      <button
+        type="button"
+        onClick={() => setIsOpen((v) => !v)}
+        aria-expanded={isOpen}
+        className={cn(
+          "w-full flex items-center justify-between gap-3 px-3 py-2 text-xs",
+          "text-daintree-text/80 hover:text-daintree-text transition-colors"
+        )}
+      >
+        <span className="flex items-center gap-2">
+          <ChevronRight
+            className={cn(
+              "w-3.5 h-3.5 transition-transform duration-150",
+              isOpen ? "rotate-90" : "rotate-0"
+            )}
+          />
+          <span>
+            Latency by tool
+            {stats.length > 0 && (
+              <span className="text-daintree-text/50"> ({stats.length} tools)</span>
+            )}
+          </span>
+        </span>
+      </button>
+      {isOpen && (
+        <div className="px-3 pb-3 pt-1">
+          {stats.length === 0 ? (
+            <p className="text-xs text-daintree-text/50">No successful dispatches recorded yet.</p>
+          ) : (
+            <table className="w-full table-fixed text-xs font-mono tabular-nums">
+              <thead>
+                <tr className="text-daintree-text/50">
+                  <th className="text-left font-medium py-1 pr-2 truncate">Tool</th>
+                  <th className="text-right font-medium py-1 px-2 w-14">n</th>
+                  <th className="text-right font-medium py-1 px-2 w-20">p50</th>
+                  <th className="text-right font-medium py-1 pl-2 w-20">p95</th>
+                </tr>
+              </thead>
+              <tbody className="divide-y divide-daintree-border">
+                {stats.map((row) => (
+                  <tr key={row.toolId} className="text-daintree-text/80">
+                    <td className="py-1 pr-2 truncate">{row.toolId}</td>
+                    <td className="py-1 px-2 text-right text-daintree-text/60">{row.count}</td>
+                    <td className="py-1 px-2 text-right">{row.p50}ms</td>
+                    <td className="py-1 pl-2 text-right">{row.p95}ms</td>
+                  </tr>
+                ))}
+              </tbody>
+            </table>
+          )}
+        </div>
+      )}
+    </div>
+  );
+}

--- a/src/components/Settings/McpAuditLogViewer.tsx
+++ b/src/components/Settings/McpAuditLogViewer.tsx
@@ -1,9 +1,15 @@
-import { useMemo, useState } from "react";
-import { Check, Copy, RefreshCw } from "lucide-react";
+import { useCallback, useMemo, useState } from "react";
+import { Check, Copy, RefreshCw, ShieldOff } from "lucide-react";
 import { cn } from "@/lib/utils";
 import type { McpAuditRecord, McpAuditResult } from "@shared/types";
 
 type AuditResultFilter = "all" | McpAuditResult;
+
+const TIER_HINT_LABEL: Record<"workbench" | "action" | "system", string> = {
+  workbench: "workbench",
+  action: "action",
+  system: "system",
+};
 
 const RESULT_LABEL: Record<McpAuditResult, string> = {
   success: "Success",
@@ -68,6 +74,11 @@ export function McpAuditLogViewer({
     return records.filter(includeRecord);
   }, [records, includeRecord]);
 
+  const unauthorizedCount = useMemo(
+    () => visibleRecords.reduce((n, r) => (r.result === "unauthorized" ? n + 1 : n), 0),
+    [visibleRecords]
+  );
+
   const filteredRecords = useMemo(() => {
     const needle = toolFilter.trim().toLowerCase();
     return visibleRecords.filter((record) => {
@@ -78,6 +89,10 @@ export function McpAuditLogViewer({
   }, [visibleRecords, resultFilter, toolFilter]);
 
   const showCopyAll = filteredRecords.length === visibleRecords.length;
+
+  const showTierRejections = useCallback(() => {
+    setResultFilter("unauthorized");
+  }, []);
 
   return (
     <div className="contents">
@@ -99,7 +114,8 @@ export function McpAuditLogViewer({
               value === "success" ||
               value === "error" ||
               value === "confirmation-pending" ||
-              value === "unauthorized"
+              value === "unauthorized" ||
+              value === "dedup"
             ) {
               setResultFilter(value);
             }
@@ -112,7 +128,18 @@ export function McpAuditLogViewer({
           <option value="error">Error</option>
           <option value="confirmation-pending">Awaiting confirmation</option>
           <option value="unauthorized">Unauthorized</option>
+          <option value="dedup">Deduplicated</option>
         </select>
+        {unauthorizedCount > 0 && resultFilter !== "unauthorized" && (
+          <button
+            type="button"
+            onClick={showTierRejections}
+            className="flex items-center gap-1.5 px-2 py-1 text-xs font-medium rounded-[var(--radius-md)] border border-daintree-border text-daintree-text/70 hover:text-daintree-text hover:bg-overlay-soft transition-colors"
+          >
+            <ShieldOff className="w-3.5 h-3.5" />
+            Show tier rejections ({unauthorizedCount})
+          </button>
+        )}
       </div>
 
       <div className="max-h-64 overflow-y-auto rounded-[var(--radius-md)] border border-daintree-border bg-daintree-bg">
@@ -150,6 +177,16 @@ export function McpAuditLogViewer({
                   <div className="mt-0.5 font-mono text-daintree-text/50 truncate">
                     {record.argsSummary || "{}"}
                   </div>
+                  {record.result === "unauthorized" && record.tierHint && (
+                    <div className="mt-0.5 text-[10px] text-daintree-text/50">
+                      Raise capability tier to {TIER_HINT_LABEL[record.tierHint]} to allow.
+                    </div>
+                  )}
+                  {record.result === "unauthorized" && record.tierHint === null && (
+                    <div className="mt-0.5 text-[10px] text-daintree-text/50">
+                      Tool isn't permitted at any tier.
+                    </div>
+                  )}
                 </div>
                 <div className="text-right text-daintree-text/40 whitespace-nowrap">
                   <div>{formatRelativeTimestamp(record.timestamp)}</div>

--- a/src/components/Settings/__tests__/DaintreeAssistantSettingsTab.test.tsx
+++ b/src/components/Settings/__tests__/DaintreeAssistantSettingsTab.test.tsx
@@ -163,6 +163,7 @@ interface McpServerApi {
   getConfigSnippet: ReturnType<typeof vi.fn>;
   onRuntimeStateChanged: ReturnType<typeof vi.fn>;
   getAuditRecords: ReturnType<typeof vi.fn>;
+  getAuditStats: ReturnType<typeof vi.fn>;
   clearAuditLog: ReturnType<typeof vi.fn>;
 }
 
@@ -198,6 +199,7 @@ function installApi(
     getConfigSnippet: vi.fn().mockResolvedValue('{ "url": "http://127.0.0.1:45454/sse" }'),
     onRuntimeStateChanged: vi.fn(() => () => {}),
     getAuditRecords: vi.fn().mockResolvedValue([]),
+    getAuditStats: vi.fn().mockResolvedValue({ auth401Count: 0 }),
     clearAuditLog: vi.fn().mockResolvedValue(undefined),
   };
   window.electron = {


### PR DESCRIPTION
## Summary

- Adds MCP audit observability to the assistant settings tab: per-tool p50/p95 latency table, a tier-rejections preset filter, and inline capability-tier hints on unauthorized records
- Wires a session-scoped 401 counter through a new `MCP_SERVER_GET_AUDIT_STATS` IPC channel, and hardens redaction with a sensitive-key heuristic + a `postSerializeScrub` callback that runs before the 300-char truncation boundary
- Fixes a pre-existing missing `Deduplicated` select option in `McpAuditLogViewer`, and switches the settings tab to `Promise.allSettled` so a stats fetch failure can't blank the audit records

Resolves #7543

## Changes

- `McpAuditLatencyTable` — new component; client-side `useMemo` rollup of p50/p95 per tool (success records only)
- `McpAuditLogViewer` — tier-rejections preset filter button; inline "Raise capability tier to {tier}" hint on unauthorized rows; fixed missing `"dedup"` select option
- `DaintreeAssistantSettingsTab` — switched to `Promise.allSettled` for audit+stats fetch; renders latency table and 401 counter when data is available
- `auditLog.ts` — `recordAuth401` / `getAuditStats` for session-scoped counter; `tierHint` field population; kill-switch guard
- `httpLifecycle.ts` — calls `recordAuth401` on 401 responses (not 403)
- `mcpArgsSummary.ts` — `SENSITIVE_KEY_PATTERN` heuristic; `postSerializeScrub` callback so scrubbing runs before truncation
- `pathScrubber.ts` (new) — extracted `sanitizePath` to `electron/utils/` to avoid dragging Sentry init into audit-side imports
- IPC: `MCP_SERVER_GET_AUDIT_STATS` channel wired through `channels.ts`, `handlers/mcpServer.ts`, `preload.cts`, and the shared type maps

## Testing

- `shared/utils/__tests__/mcpArgsSummary.test.ts` — 14 cases covering sensitive-key redaction, `postSerializeScrub` callback, and scrub-before-truncate boundary ordering
- `electron/services/mcp-server/__tests__/auditLog.test.ts` — 9 cases covering `tierHint` population, `recordAuth401` increment, and kill-switch behavior
- `electron/services/mcp-server/__tests__/httpLifecycle.test.ts` — extended with 401 increment and 403 non-increment cases
- Format, lint, typecheck, and build all pass