### PR TITLE
fix(e2e): guard against null return from getCurrentProject in switchToProject

### DIFF
--- a/e2e/full/core-project-switch-race.spec.ts
+++ b/e2e/full/core-project-switch-race.spec.ts
@@ -127,6 +127,7 @@ test.describe.serial("Core: Project Switch Race Conditions", () => {
 
     // Capture Project A's ID
     const projectA = await getCurrentProject(ctx.window);
+    expect(projectA).not.toBeNull();
 
     // Open a terminal in Project A to confirm normal flow works
     await openTerminal(ctx.window);
@@ -164,7 +165,7 @@ test.describe.serial("Core: Project Switch Race Conditions", () => {
     const withProject = activeTerminals.filter((t: TerminalInfo) => t.projectId !== undefined);
     expect(withProject.length).toBeGreaterThanOrEqual(1);
     for (const t of withProject) {
-      expect(t.projectId).toBe(projectA.id);
+      expect(t.projectId).toBe(projectA!.id);
     }
   });
 
@@ -221,6 +222,7 @@ test.describe.serial("Core: Project Switch Race Conditions", () => {
     // Switch to Project A to spawn from there
     await switchToProject(ctx.window, PROJECT_A_NAME);
     const projectA = await getCurrentProject(ctx.window);
+    expect(projectA).not.toBeNull();
 
     // Inject delay and trigger a spawn
     await injectDelay(ctx.app, "terminal:spawn", 2000);
@@ -248,7 +250,7 @@ test.describe.serial("Core: Project Switch Race Conditions", () => {
     const withProject = activeTerminals.filter((t: TerminalInfo) => t.projectId !== undefined);
     expect(withProject.length).toBeGreaterThanOrEqual(1);
     for (const t of withProject) {
-      expect(t.projectId).toBe(projectA.id);
+      expect(t.projectId).toBe(projectA!.id);
     }
   });
 });

--- a/e2e/full/core-project-switch-race.spec.ts
+++ b/e2e/full/core-project-switch-race.spec.ts
@@ -38,7 +38,7 @@ async function getAllTerminals(page: typeof ctx.window): Promise<TerminalInfo[]>
   });
 }
 
-async function getCurrentProject(page: typeof ctx.window): Promise<ProjectInfo> {
+async function getCurrentProject(page: typeof ctx.window): Promise<ProjectInfo | null> {
   return page.evaluate(async () => {
     return await (window as any).electron.project.getCurrent();
   });
@@ -50,7 +50,7 @@ async function switchToProject(
 ): Promise<typeof ctx.window> {
   // Skip if already on the target project
   const current = await getCurrentProject(page);
-  if (current.name === projectName) return page;
+  if (current?.name === projectName) return page;
 
   await page.locator(SEL.toolbar.projectSwitcherTrigger).click();
   const palette = page.locator(SEL.projectSwitcher.palette);


### PR DESCRIPTION
## Summary

- `getCurrentProject()` was typed as `Promise<ProjectInfo>` but the underlying IPC call returns `null` when no project is loaded
- `switchToProject` read `current.name` without a null check, crashing `beforeAll` and blocking all tests in the race-conditions suite
- Fix: widen return type to `ProjectInfo | null`, add optional chaining (`current?.name`)

Closes #7619

## Test plan

- [ ] Run `npx playwright test e2e/full/core-project-switch-race.spec.ts` and confirm no TypeError in beforeAll
- [ ] Confirm `switchToProject` proceeds to the palette flow when `current` is null (no project loaded)