### PR TITLE
feat(pty): instrument agent CLI startup phases

### DIFF
--- a/docs/development.md
+++ b/docs/development.md
@@ -117,6 +117,33 @@ logInfo("ServiceName", "message", { data });
 - Type errors in electron/: `npm run build:main`
 - Stale cache: `rm -rf node_modules/.vite && npm run dev`
 
+## Agent startup profiling
+
+Two pieces of dev-only instrumentation help diagnose slow agent CLI launches.
+
+### Structured startup metrics
+
+Every agent terminal logs a single `[AgentStartup]` line to the pty-host console as soon as boot completion is detected. The line is JSON keyed on `(agentId, cwdHash)` so traces from different launches in the same project can be compared:
+
+```text
+[AgentStartup] {"agentId":"claude","cwdHash":"a1b2c3d4","terminalId":"...","spawnedAt":1700000000000,"firstByteAt":1700000000180,"bootCompleteAt":1700000000420,"bootDurationMs":420,"timeToFirstByteMs":180}
+```
+
+`firstByteAt` and `timeToFirstByteMs` are omitted when boot completion fires before any PTY output (timeout-only path). The fields `firstByteAt` and `bootCompleteAt` are also surfaced on the terminal's `getPublicState()` payload for tooling that needs to read them programmatically.
+
+### CPU profiling
+
+For deeper investigations, the agent CLI can be CPU-profiled by Node's built-in profiler.
+
+1. Set `DAINTREE_PROFILE_AGENT_STARTUP=1` in the shell that launches the dev build (`npm run dev`).
+2. Spawn an agent terminal as usual.
+3. Find the resulting `*.cpuprofile` file under `<userData>/agent-profiles/` (`~/Library/Application Support/Daintree/agent-profiles/` on macOS).
+4. Open Chrome DevTools → Performance → Load profile, or use the same workflow in VS Code.
+
+The flag is gated on `app.isPackaged === false` (forwarded to the pty host as `DAINTREE_IS_PACKAGED=0`). Packaged builds never honour the flag.
+
+`NODE_OPTIONS=--cpu-prof --cpu-prof-dir=...` is inherited by every Node.js subprocess the agent spawns (npm, tsc, MCP servers). The output directory will accumulate profiles for those subprocesses too — filter by filename or PID when analysing.
+
 ## CI
 
 GitHub Actions on push/PR to main:

--- a/electron/services/ActivityMonitor.ts
+++ b/electron/services/ActivityMonitor.ts
@@ -421,6 +421,14 @@ export class ActivityMonitor {
         return;
       }
       this.lastDataTimestamp = now;
+      // Boot detection runs in the simple-output path too so onBootComplete
+      // (#7616) fires for real agent terminals — `simpleOutputState` is true
+      // for every agent monitor built via `buildActivityMonitorOptions`.
+      if (!this.bootDetector.hasExitedBootState) {
+        if (this.bootDetector.check(stripAnsi(data), false, 0, Infinity)) {
+          this.fireBootComplete(now);
+        }
+      }
       if (!this.getVisibleLines) {
         this.noteSimpleOutputSnapshot(createVisibleContentSnapshot(stripAnsi(data)), now);
       }
@@ -863,6 +871,18 @@ export class ActivityMonitor {
     const now = Date.now();
 
     if (this.simpleOutputState) {
+      // Boot detection in the simple-output polling path so the timeout
+      // fallback (`timeSinceBoot >= POLLING_MAX_BOOT_MS`) still fires
+      // onBootComplete (#7616) when agents emit no recognizable boot pattern.
+      if (!this.bootDetector.hasExitedBootState && this.getVisibleLines) {
+        const lines = this.getVisibleLines(50);
+        const strippedText = stripAnsi(lines.join(" "));
+        const timeSinceBoot = now - this.bootDetector.pollingStartTime;
+        if (this.bootDetector.check(strippedText, false, timeSinceBoot, this.POLLING_MAX_BOOT_MS)) {
+          this.fireBootComplete(now);
+        }
+      }
+
       const snapshot = this.captureSimpleOutputSnapshot();
       if (snapshot !== undefined) {
         this.noteSimpleOutputSnapshot(snapshot, now);

--- a/electron/services/ActivityMonitor.ts
+++ b/electron/services/ActivityMonitor.ts
@@ -116,6 +116,14 @@ export interface ActivityMonitorOptions {
   // reachable.
   waitingWatchdogFailThreshold?: number;
   onWaitingTimeout?: (id: string, spawnedAt: number) => void;
+  /**
+   * Fires once per boot cycle the first time `BootDetector.check()` returns
+   * true (or `markExited()` is invoked indirectly). The timestamp is the
+   * wall-clock `Date.now()` at the moment boot completion is observed. Used
+   * by `TerminalProcess` to record `bootCompleteAt` and emit the
+   * `[AgentStartup]` structured log entry.
+   */
+  onBootComplete?: (bootCompleteAt: number) => void;
 }
 
 export interface ActivityStateMetadata {
@@ -170,6 +178,8 @@ export class ActivityMonitor {
   private resizeSuppressUntil = 0;
 
   private readonly onWaitingTimeout?: (id: string, spawnedAt: number) => void;
+  private readonly onBootComplete?: (bootCompleteAt: number) => void;
+  private bootCompleteCallbackFired = false;
   private readonly processStateValidator?: ProcessStateValidator;
   private lastActivityTimestamp = Date.now();
   private lastDataTimestamp = Date.now();
@@ -236,6 +246,7 @@ export class ActivityMonitor {
 
     this.processStateValidator = options?.processStateValidator;
     this.onWaitingTimeout = options?.onWaitingTimeout;
+    this.onBootComplete = options?.onBootComplete;
 
     // Initialize subsystems
     this.inputTracker = new InputTracker({
@@ -352,6 +363,23 @@ export class ActivityMonitor {
     this.structuralRecoveryDebouncer.setDelay(delay);
   }
 
+  /**
+   * Fires the configured `onBootComplete` callback at most once per boot
+   * cycle. Reset by `startPolling()` when boot detection re-enters from
+   * `hasExitedBootState=false`. Both `BootDetector.check()` call sites (data
+   * path and polling cycle) must funnel through this guard.
+   */
+  private fireBootComplete(timestamp: number): void {
+    if (this.bootCompleteCallbackFired) return;
+    this.bootCompleteCallbackFired = true;
+    if (!this.onBootComplete) return;
+    try {
+      this.onBootComplete(timestamp);
+    } catch {
+      // Callback failure must not destabilize the activity monitor.
+    }
+  }
+
   private isEscInterruptFallback(input: string): boolean {
     return (
       input.toLowerCase().includes("esc to interrupt") ||
@@ -421,6 +449,7 @@ export class ActivityMonitor {
       if (!this.bootDetector.hasExitedBootState) {
         if (this.bootDetector.check(bufferText, false, 0, Infinity)) {
           // Boot detected via pattern in rolling buffer
+          this.fireBootComplete(now);
         }
       }
 
@@ -804,6 +833,9 @@ export class ActivityMonitor {
       }
     } else {
       this.bootDetector.hasExitedBootState = false;
+      // Re-arm the one-shot boot-complete callback for restart paths so the
+      // next observed boot completion fires telemetry again.
+      this.bootCompleteCallbackFired = false;
 
       this.state = "busy";
       this.onStateChange(this.terminalId, this.spawnedAt, "busy", { trigger: "pattern" });
@@ -901,6 +933,7 @@ export class ActivityMonitor {
         this.bootDetector.check(strippedText, isPrompt, timeSinceBoot, this.POLLING_MAX_BOOT_MS)
       ) {
         // Boot complete, continue to normal detection
+        this.fireBootComplete(now);
       } else {
         return; // Still booting, stay busy
       }

--- a/electron/services/__tests__/ActivityMonitor.test.ts
+++ b/electron/services/__tests__/ActivityMonitor.test.ts
@@ -5246,5 +5246,60 @@ describe("ActivityMonitor", () => {
 
       monitor.dispose();
     });
+
+    it("fires for agent monitors using simpleOutputState (real-world wiring)", () => {
+      // Regression for #7616 review: every monitor built via
+      // `buildActivityMonitorOptions(<agentId>, ...)` runs with
+      // `simpleOutputState: true`, which short-circuits the regular
+      // boot-detection path. The simple-output branches must also call
+      // `fireBootComplete`, otherwise the entire instrumentation is a no-op
+      // for real agent terminals.
+      vi.setSystemTime(10000);
+      const onStateChange = vi.fn();
+      const onBootComplete = vi.fn();
+      const monitor = new ActivityMonitor("boot-simple-data", 1000, onStateChange, {
+        agentId: "claude",
+        simpleOutputState: true,
+        getVisibleLines: () => ["claude code v0.5.6", "Type your message"],
+        getCursorLine: () => "Type your message",
+        bootCompletePatterns: [/claude\s+code\s+v?\d/i],
+        idleDebounceMs: 4000,
+        onBootComplete,
+      });
+
+      // Data path: onData runs in simpleOutputState mode and must still detect
+      // the boot pattern from the immediate chunk.
+      monitor.onData("claude code v0.5.6\n");
+      expect(onBootComplete).toHaveBeenCalledTimes(1);
+
+      monitor.dispose();
+    });
+
+    it("fires from the simple-output polling path on the boot-timeout fallback", () => {
+      // When the agent's banner does not match a known boot pattern, the
+      // POLLING_MAX_BOOT_MS timeout still flips boot state. The
+      // simpleOutputState polling branch must run that check.
+      vi.setSystemTime(10000);
+      const onStateChange = vi.fn();
+      const onBootComplete = vi.fn();
+      const monitor = new ActivityMonitor("boot-simple-timeout", 1000, onStateChange, {
+        agentId: "claude",
+        simpleOutputState: true,
+        getVisibleLines: () => ["miscellaneous output", "no boot marker here"],
+        getCursorLine: () => "no boot marker here",
+        bootCompletePatterns: [/never matches/],
+        pollingIntervalMs: 50,
+        pollingMaxBootMs: 200,
+        idleDebounceMs: 4000,
+        onBootComplete,
+      });
+
+      monitor.startPolling();
+      // Advance well past pollingMaxBootMs so the timeout branch fires.
+      vi.advanceTimersByTime(400);
+      expect(onBootComplete).toHaveBeenCalledTimes(1);
+
+      monitor.dispose();
+    });
   });
 });

--- a/electron/services/__tests__/ActivityMonitor.test.ts
+++ b/electron/services/__tests__/ActivityMonitor.test.ts
@@ -5138,4 +5138,113 @@ describe("ActivityMonitor", () => {
       monitor.dispose();
     });
   });
+
+  describe("onBootComplete callback (Issue #7616)", () => {
+    it("fires once when boot completion is detected via the data-path", () => {
+      vi.setSystemTime(10000);
+      const onStateChange = vi.fn();
+      const onBootComplete = vi.fn();
+      const monitor = new ActivityMonitor("boot-data", 1000, onStateChange, {
+        getVisibleLines: () => ["> "],
+        getCursorLine: () => "> ",
+        bootCompletePatterns: [/ready/i],
+        idleDebounceMs: 4000,
+        onBootComplete,
+      });
+
+      monitor.startPolling();
+      // The data path runs through onData() and triggers bootDetector.check
+      // against the rolling pattern buffer.
+      monitor.onData("starting up\nstill working\n");
+      expect(onBootComplete).not.toHaveBeenCalled();
+
+      monitor.onData("system ready\n");
+      expect(onBootComplete).toHaveBeenCalledTimes(1);
+      expect(onBootComplete).toHaveBeenCalledWith(expect.any(Number));
+
+      // Subsequent matching data must not re-fire.
+      monitor.onData("ready again ready\n");
+      expect(onBootComplete).toHaveBeenCalledTimes(1);
+
+      monitor.dispose();
+    });
+
+    it("fires once when boot completion is detected via the polling cycle", () => {
+      vi.setSystemTime(10000);
+      const onStateChange = vi.fn();
+      const onBootComplete = vi.fn();
+      // Visible lines stable; the polling cycle's bootDetector.check observes
+      // the boot pattern in the joined visible text.
+      const monitor = new ActivityMonitor("boot-poll", 1000, onStateChange, {
+        getVisibleLines: () => ["welcome banner", "agent ready"],
+        getCursorLine: () => "agent ready",
+        bootCompletePatterns: [/ready/i],
+        pollingIntervalMs: 50,
+        idleDebounceMs: 4000,
+        onBootComplete,
+      });
+
+      monitor.startPolling();
+      // One polling tick is enough for the boot detector to see "ready".
+      vi.advanceTimersByTime(60);
+      expect(onBootComplete).toHaveBeenCalledTimes(1);
+
+      // Further polling cycles must not re-fire.
+      vi.advanceTimersByTime(500);
+      expect(onBootComplete).toHaveBeenCalledTimes(1);
+
+      monitor.dispose();
+    });
+
+    it("re-arms the one-shot guard when polling restarts on a fresh PTY", () => {
+      vi.setSystemTime(10000);
+      const onStateChange = vi.fn();
+      const onBootComplete = vi.fn();
+      let visibleText = ["agent ready"];
+      const monitor = new ActivityMonitor("boot-restart", 1000, onStateChange, {
+        getVisibleLines: () => visibleText,
+        getCursorLine: () => visibleText[visibleText.length - 1] ?? null,
+        bootCompletePatterns: [/ready/i],
+        pollingIntervalMs: 50,
+        idleDebounceMs: 4000,
+        onBootComplete,
+      });
+
+      monitor.startPolling();
+      vi.advanceTimersByTime(60);
+      expect(onBootComplete).toHaveBeenCalledTimes(1);
+
+      // Simulate a restart: stop polling, then start again. The boot path is
+      // re-entered (skipInitialStateEmit is false by default), so the one-shot
+      // flag must reset and the next observed boot must fire telemetry again.
+      monitor.stopPolling();
+      visibleText = ["restarting", "agent ready"];
+      monitor.startPolling();
+      vi.advanceTimersByTime(60);
+      expect(onBootComplete).toHaveBeenCalledTimes(2);
+
+      monitor.dispose();
+    });
+
+    it("does not throw if the callback throws", () => {
+      vi.setSystemTime(10000);
+      const onStateChange = vi.fn();
+      const onBootComplete = vi.fn(() => {
+        throw new Error("boom");
+      });
+      const monitor = new ActivityMonitor("boot-throw", 1000, onStateChange, {
+        getVisibleLines: () => ["> "],
+        getCursorLine: () => "> ",
+        bootCompletePatterns: [/ready/i],
+        idleDebounceMs: 4000,
+        onBootComplete,
+      });
+
+      monitor.startPolling();
+      expect(() => monitor.onData("system ready\n")).not.toThrow();
+      expect(onBootComplete).toHaveBeenCalledTimes(1);
+
+      monitor.dispose();
+    });
+  });
 });

--- a/electron/services/pty/PtyHostLifecycle.ts
+++ b/electron/services/pty/PtyHostLifecycle.ts
@@ -286,6 +286,10 @@ export class PtyHostLifecycle {
         env: {
           ...(process.env as Record<string, string>),
           DAINTREE_USER_DATA: app.getPath("userData"),
+          // Forward packaged-build state to the pty host so dev-only diagnostics
+          // (e.g. agent CLI CPU profiling via `DAINTREE_PROFILE_AGENT_STARTUP`)
+          // can gate themselves on `!== "0"` without touching `app.isPackaged`.
+          DAINTREE_IS_PACKAGED: app.isPackaged ? "1" : "0",
           DAINTREE_UTILITY_PROCESS_KIND: "pty-host",
           // node-pty 1.x hangs intermittently on Linux kernels with io_uring
           // enabled (microsoft/node-pty#630, closed as not planned). The fix

--- a/electron/services/pty/TerminalProcess.ts
+++ b/electron/services/pty/TerminalProcess.ts
@@ -1,3 +1,4 @@
+import { createHash } from "node:crypto";
 import type * as pty from "node-pty";
 import type { Terminal as HeadlessTerminalType } from "@xterm/headless";
 import headless from "@xterm/headless";
@@ -443,6 +444,7 @@ export class TerminalProcess {
               0.6
             );
           },
+          onBootComplete: (timestamp) => this.recordBootComplete(timestamp),
         }
       );
       this.activityMonitor.startPolling();
@@ -592,6 +594,8 @@ export class TerminalProcess {
       titleMode: t.titleMode,
       command: t.command,
       spawnedAt: t.spawnedAt,
+      firstByteAt: t.firstByteAt,
+      bootCompleteAt: t.bootCompleteAt,
       wasKilled,
       isExited,
       agentState: t.agentState,
@@ -1279,6 +1283,7 @@ export class TerminalProcess {
               0.6
             );
           },
+          onBootComplete: (timestamp) => this.recordBootComplete(timestamp),
         }
       );
       this.activityMonitor.startPolling();
@@ -1402,6 +1407,42 @@ export class TerminalProcess {
     }
   }
 
+  /**
+   * Wired into `ActivityMonitor` via `onBootComplete`. Captures
+   * `bootCompleteAt` on the terminal once per boot cycle and emits a
+   * structured `[AgentStartup]` JSON log entry keyed on `(agentId,
+   * cwdHash)` so traces from independent launches can be compared. Does
+   * nothing for plain (non-agent) terminals.
+   */
+  private recordBootComplete(timestamp: number): void {
+    const terminal = this.terminalInfo;
+    if (terminal.bootCompleteAt === undefined) {
+      terminal.bootCompleteAt = timestamp;
+    }
+
+    const agentId = terminal.launchAgentId;
+    if (!agentId) return;
+
+    const spawnedAt = terminal.spawnedAt;
+    const firstByteAt = terminal.firstByteAt;
+    const cwdHash = createHash("md5").update(terminal.cwd).digest("hex").slice(0, 8);
+
+    const entry: Record<string, unknown> = {
+      agentId,
+      cwdHash,
+      terminalId: terminal.id,
+      spawnedAt,
+      bootCompleteAt: timestamp,
+      bootDurationMs: timestamp - spawnedAt,
+    };
+    if (firstByteAt !== undefined) {
+      entry.firstByteAt = firstByteAt;
+      entry.timeToFirstByteMs = firstByteAt - spawnedAt;
+    }
+
+    console.log(`[AgentStartup] ${JSON.stringify(entry)}`);
+  }
+
   private setupPtyHandlers(ptyProcess: pty.IPty): void {
     const terminal = this.terminalInfo;
 
@@ -1410,7 +1451,13 @@ export class TerminalProcess {
         return;
       }
 
-      terminal.lastOutputTime = Date.now();
+      const now = Date.now();
+      // One-shot startup metric: wall-clock time of the first PTY data byte.
+      // Surfaces in `getPublicState()` and the `[AgentStartup]` structured log.
+      if (terminal.firstByteAt === undefined) {
+        terminal.firstByteAt = now;
+      }
+      terminal.lastOutputTime = now;
       const beforeContentSnapshot = this.isAgentLive
         ? this.getAgentOutputContentSnapshot()
         : undefined;

--- a/electron/services/pty/TerminalProcess.ts
+++ b/electron/services/pty/TerminalProcess.ts
@@ -1416,9 +1416,12 @@ export class TerminalProcess {
    */
   private recordBootComplete(timestamp: number): void {
     const terminal = this.terminalInfo;
-    if (terminal.bootCompleteAt === undefined) {
-      terminal.bootCompleteAt = timestamp;
-    }
+    // Idempotent: only the first call captures bootCompleteAt and emits the
+    // log. The `ActivityMonitor.fireBootComplete` one-shot guard normally
+    // already prevents re-entry, but this defends against accidental direct
+    // calls and restart paths that re-arm the upstream guard.
+    if (terminal.bootCompleteAt !== undefined) return;
+    terminal.bootCompleteAt = timestamp;
 
     const agentId = terminal.launchAgentId;
     if (!agentId) return;

--- a/electron/services/pty/__tests__/TerminalProcess.lifecycle.test.ts
+++ b/electron/services/pty/__tests__/TerminalProcess.lifecycle.test.ts
@@ -979,6 +979,38 @@ describe("TerminalProcess — agent startup instrumentation (Issue #7616)", () =
     }
   });
 
+  it("emits the [AgentStartup] log only on the first recordBootComplete call (idempotency)", () => {
+    vi.useFakeTimers();
+    vi.setSystemTime(7000);
+    const pty = createControllablePty();
+    const consoleLog = vi.spyOn(console, "log").mockImplementation(() => {});
+    const terminal = createTerminal(pty, {
+      kind: "terminal",
+      launchAgentId: "claude",
+    });
+
+    try {
+      const recordBootComplete = (
+        terminal as unknown as { recordBootComplete: (ts: number) => void }
+      ).recordBootComplete.bind(terminal);
+
+      recordBootComplete(7100);
+      recordBootComplete(7200);
+      recordBootComplete(7300);
+
+      const startupLogs = consoleLog.mock.calls
+        .map((c) => String(c[0] ?? ""))
+        .filter((line) => line.startsWith("[AgentStartup] "));
+      expect(startupLogs).toHaveLength(1);
+      // The first timestamp wins; later calls do not mutate or re-emit.
+      expect(terminal.getPublicState().bootCompleteAt).toBe(7100);
+    } finally {
+      consoleLog.mockRestore();
+      terminal.dispose();
+      vi.useRealTimers();
+    }
+  });
+
   it("omits firstByteAt/timeToFirstByteMs from the log when no data was observed before boot completes", () => {
     const pty = createControllablePty();
     const consoleLog = vi.spyOn(console, "log").mockImplementation(() => {});

--- a/electron/services/pty/__tests__/TerminalProcess.lifecycle.test.ts
+++ b/electron/services/pty/__tests__/TerminalProcess.lifecycle.test.ts
@@ -874,3 +874,136 @@ describe("TerminalProcess — getPublicState lifecycle derivation", () => {
     expect(state.exitCode).toBe(0);
   });
 });
+
+describe("TerminalProcess — agent startup instrumentation (Issue #7616)", () => {
+  it("leaves firstByteAt and bootCompleteAt undefined before any data arrives", () => {
+    const pty = createControllablePty();
+    const terminal = createTerminal(pty);
+
+    const state = terminal.getPublicState();
+    expect(state.firstByteAt).toBeUndefined();
+    expect(state.bootCompleteAt).toBeUndefined();
+    terminal.dispose();
+  });
+
+  it("captures firstByteAt on the first data event and does not overwrite it on subsequent data", async () => {
+    vi.useFakeTimers();
+    vi.setSystemTime(2000);
+    const pty = createControllablePty();
+    const terminal = createTerminal(pty);
+
+    try {
+      await emitDataAndFlush(pty, "first");
+      const initial = terminal.getPublicState().firstByteAt;
+      expect(initial).toBe(2000);
+
+      vi.setSystemTime(2500);
+      await emitDataAndFlush(pty, "second");
+      expect(terminal.getPublicState().firstByteAt).toBe(initial);
+    } finally {
+      terminal.dispose();
+      vi.useRealTimers();
+    }
+  });
+
+  it("emits a single [AgentStartup] log line keyed on (agentId, cwdHash) for agent terminals", () => {
+    vi.useFakeTimers();
+    vi.setSystemTime(5000);
+    const pty = createControllablePty();
+    const consoleLog = vi.spyOn(console, "log").mockImplementation(() => {});
+    const terminal = createTerminal(pty, {
+      kind: "terminal",
+      launchAgentId: "claude",
+      cwd: "/repo/agent",
+    });
+
+    try {
+      // Drive ActivityMonitor's onData path to surface the boot-complete callback.
+      terminal.getInfo().firstByteAt = 5050;
+      terminal.getInfo().bootCompleteAt = undefined;
+      // Invoke recordBootComplete via the public path: simulate boot at 5100ms.
+      // We expose this by reading through getPublicState after manually firing.
+      // (We bypass ActivityMonitor here because the production wiring is
+      // covered by ActivityMonitor.test.ts; this test asserts the log shape.)
+      const recordBootComplete = (
+        terminal as unknown as { recordBootComplete: (ts: number) => void }
+      ).recordBootComplete.bind(terminal);
+      recordBootComplete(5100);
+
+      const startupLogs = consoleLog.mock.calls
+        .map((c) => String(c[0] ?? ""))
+        .filter((line) => line.startsWith("[AgentStartup] "));
+      expect(startupLogs).toHaveLength(1);
+
+      const json = JSON.parse(startupLogs[0]!.replace(/^\[AgentStartup\] /, ""));
+      expect(json).toMatchObject({
+        agentId: "claude",
+        terminalId: expect.any(String),
+        spawnedAt: expect.any(Number),
+        firstByteAt: 5050,
+        bootCompleteAt: 5100,
+        bootDurationMs: expect.any(Number),
+        timeToFirstByteMs: expect.any(Number),
+      });
+      // 8-char md5 hex slice
+      expect(typeof json.cwdHash).toBe("string");
+      expect(json.cwdHash).toMatch(/^[0-9a-f]{8}$/);
+
+      const state = terminal.getPublicState();
+      expect(state.bootCompleteAt).toBe(5100);
+    } finally {
+      consoleLog.mockRestore();
+      terminal.dispose();
+      vi.useRealTimers();
+    }
+  });
+
+  it("does not emit [AgentStartup] for plain terminals without a launch hint", () => {
+    const pty = createControllablePty();
+    const consoleLog = vi.spyOn(console, "log").mockImplementation(() => {});
+    const terminal = createTerminal(pty);
+
+    try {
+      const recordBootComplete = (
+        terminal as unknown as { recordBootComplete: (ts: number) => void }
+      ).recordBootComplete.bind(terminal);
+      recordBootComplete(Date.now());
+
+      const startupLogs = consoleLog.mock.calls
+        .map((c) => String(c[0] ?? ""))
+        .filter((line) => line.startsWith("[AgentStartup] "));
+      expect(startupLogs).toHaveLength(0);
+    } finally {
+      consoleLog.mockRestore();
+      terminal.dispose();
+    }
+  });
+
+  it("omits firstByteAt/timeToFirstByteMs from the log when no data was observed before boot completes", () => {
+    const pty = createControllablePty();
+    const consoleLog = vi.spyOn(console, "log").mockImplementation(() => {});
+    const terminal = createTerminal(pty, {
+      kind: "terminal",
+      launchAgentId: "codex",
+    });
+
+    try {
+      const recordBootComplete = (
+        terminal as unknown as { recordBootComplete: (ts: number) => void }
+      ).recordBootComplete.bind(terminal);
+      recordBootComplete(Date.now());
+
+      const line = consoleLog.mock.calls
+        .map((c) => String(c[0] ?? ""))
+        .find((l) => l.startsWith("[AgentStartup] "));
+      expect(line).toBeDefined();
+      const json = JSON.parse(line!.replace(/^\[AgentStartup\] /, ""));
+      expect(json.firstByteAt).toBeUndefined();
+      expect(json.timeToFirstByteMs).toBeUndefined();
+      expect(json.bootDurationMs).toEqual(expect.any(Number));
+    } finally {
+      consoleLog.mockRestore();
+      terminal.dispose();
+    }
+  });
+});

--- a/electron/services/pty/__tests__/terminalSpawn.profile.test.ts
+++ b/electron/services/pty/__tests__/terminalSpawn.profile.test.ts
@@ -1,0 +1,143 @@
+import { describe, it, expect, beforeEach, afterEach, vi } from "vitest";
+import * as path from "node:path";
+
+vi.mock("node-pty", () => ({
+  spawn: vi.fn(),
+}));
+
+import { computeSpawnContext } from "../terminalSpawn.js";
+import type { PtySpawnOptions } from "../types.js";
+
+const PROFILE_FLAG = "DAINTREE_PROFILE_AGENT_STARTUP";
+const PACKAGED_FLAG = "DAINTREE_IS_PACKAGED";
+const USER_DATA = "DAINTREE_USER_DATA";
+
+const baseOptions: PtySpawnOptions = {
+  cwd: "/repo",
+  cols: 80,
+  rows: 24,
+};
+
+describe("terminalSpawn agent startup CPU profiling injection (Issue #7616)", () => {
+  let originalProfile: string | undefined;
+  let originalPackaged: string | undefined;
+  let originalUserData: string | undefined;
+  let originalNodeOptions: string | undefined;
+
+  beforeEach(() => {
+    originalProfile = process.env[PROFILE_FLAG];
+    originalPackaged = process.env[PACKAGED_FLAG];
+    originalUserData = process.env[USER_DATA];
+    originalNodeOptions = process.env.NODE_OPTIONS;
+    delete process.env[PROFILE_FLAG];
+    delete process.env[PACKAGED_FLAG];
+    delete process.env[USER_DATA];
+    delete process.env.NODE_OPTIONS;
+  });
+
+  afterEach(() => {
+    restore(PROFILE_FLAG, originalProfile);
+    restore(PACKAGED_FLAG, originalPackaged);
+    restore(USER_DATA, originalUserData);
+    restore("NODE_OPTIONS", originalNodeOptions);
+  });
+
+  function restore(key: string, value: string | undefined) {
+    if (value === undefined) {
+      delete process.env[key];
+    } else {
+      process.env[key] = value;
+    }
+  }
+
+  it("injects --cpu-prof + --cpu-prof-dir when flag, dev gate, userData, and launchAgentId all hold", () => {
+    process.env[PROFILE_FLAG] = "1";
+    process.env[PACKAGED_FLAG] = "0";
+    process.env[USER_DATA] = "/tmp/daintree-userdata";
+
+    const context = computeSpawnContext("term-1", {
+      ...baseOptions,
+      launchAgentId: "claude",
+    });
+
+    const expectedDir = path.join("/tmp/daintree-userdata", "agent-profiles");
+    expect(context.env.NODE_OPTIONS).toBe(`--cpu-prof --cpu-prof-dir=${expectedDir}`);
+  });
+
+  it("preserves and appends to an existing NODE_OPTIONS value", () => {
+    process.env[PROFILE_FLAG] = "1";
+    process.env[PACKAGED_FLAG] = "0";
+    process.env[USER_DATA] = "/tmp/daintree-userdata";
+    process.env.NODE_OPTIONS = "--max-old-space-size=4096";
+
+    const context = computeSpawnContext("term-2", {
+      ...baseOptions,
+      launchAgentId: "codex",
+    });
+
+    expect(context.env.NODE_OPTIONS).toContain("--max-old-space-size=4096");
+    expect(context.env.NODE_OPTIONS).toContain("--cpu-prof");
+    expect(context.env.NODE_OPTIONS).toContain("--cpu-prof-dir=");
+  });
+
+  it("does NOT inject when DAINTREE_IS_PACKAGED is '1' (packaged build)", () => {
+    process.env[PROFILE_FLAG] = "1";
+    process.env[PACKAGED_FLAG] = "1";
+    process.env[USER_DATA] = "/tmp/daintree-userdata";
+
+    const context = computeSpawnContext("term-3", {
+      ...baseOptions,
+      launchAgentId: "claude",
+    });
+
+    expect(context.env.NODE_OPTIONS).toBeUndefined();
+  });
+
+  it("does NOT inject when DAINTREE_IS_PACKAGED is missing (defensive default)", () => {
+    process.env[PROFILE_FLAG] = "1";
+    process.env[USER_DATA] = "/tmp/daintree-userdata";
+    // packaged flag intentionally absent
+
+    const context = computeSpawnContext("term-4", {
+      ...baseOptions,
+      launchAgentId: "claude",
+    });
+
+    expect(context.env.NODE_OPTIONS).toBeUndefined();
+  });
+
+  it("does NOT inject when DAINTREE_PROFILE_AGENT_STARTUP is unset", () => {
+    process.env[PACKAGED_FLAG] = "0";
+    process.env[USER_DATA] = "/tmp/daintree-userdata";
+
+    const context = computeSpawnContext("term-5", {
+      ...baseOptions,
+      launchAgentId: "claude",
+    });
+
+    expect(context.env.NODE_OPTIONS).toBeUndefined();
+  });
+
+  it("does NOT inject when launchAgentId is absent (plain shell)", () => {
+    process.env[PROFILE_FLAG] = "1";
+    process.env[PACKAGED_FLAG] = "0";
+    process.env[USER_DATA] = "/tmp/daintree-userdata";
+
+    const context = computeSpawnContext("term-6", baseOptions);
+
+    expect(context.env.NODE_OPTIONS).toBeUndefined();
+  });
+
+  it("does NOT inject when DAINTREE_USER_DATA is missing", () => {
+    process.env[PROFILE_FLAG] = "1";
+    process.env[PACKAGED_FLAG] = "0";
+    // userData intentionally absent
+
+    const context = computeSpawnContext("term-7", {
+      ...baseOptions,
+      launchAgentId: "claude",
+    });
+
+    expect(context.env.NODE_OPTIONS).toBeUndefined();
+  });
+});

--- a/electron/services/pty/terminalSpawn.ts
+++ b/electron/services/pty/terminalSpawn.ts
@@ -1,3 +1,4 @@
+import * as path from "node:path";
 import * as pty from "node-pty";
 import {
   filterEnvironment,
@@ -18,7 +19,36 @@ export function computeSpawnContext(id: string, options: PtySpawnOptions): Spawn
   const shell = options.shell || getDefaultShell();
   const args = options.args || getDefaultShellArgs(shell);
   const env = buildTerminalEnv(options, id, shell);
+  injectAgentStartupProfiling(env, options);
   return { shell, args, env };
+}
+
+/**
+ * Dev-only opt-in CPU profiling for agent CLI startup. Activates when ALL of:
+ *   - `options.launchAgentId` is set (agent panel, not a plain shell)
+ *   - `DAINTREE_PROFILE_AGENT_STARTUP === "1"` (caller opt-in)
+ *   - `DAINTREE_IS_PACKAGED === "0"` (forwarded by `PtyHostLifecycle`; the
+ *      strict-equality check disables profiling whenever the flag is missing
+ *      or anything other than `"0"`)
+ *   - `DAINTREE_USER_DATA` is available (target directory for `.cpuprofile`s)
+ *
+ * Appends `--cpu-prof --cpu-prof-dir=<userData>/agent-profiles` to any existing
+ * `NODE_OPTIONS`. Note this is inherited by every Node.js child process the
+ * agent spawns (npm, tsc, MCP servers); the resulting `.cpuprofile` files are
+ * still loadable in Chrome DevTools but the directory will fill with
+ * subprocess profiles too. See `docs/development.md` for the full caveat.
+ */
+function injectAgentStartupProfiling(env: Record<string, string>, options: PtySpawnOptions): void {
+  if (!options.launchAgentId) return;
+  if (process.env.DAINTREE_PROFILE_AGENT_STARTUP !== "1") return;
+  if (process.env.DAINTREE_IS_PACKAGED !== "0") return;
+  const userData = process.env.DAINTREE_USER_DATA;
+  if (!userData) return;
+
+  const profileDir = path.join(userData, "agent-profiles");
+  const injection = `--cpu-prof --cpu-prof-dir=${profileDir}`;
+  const existing = env.NODE_OPTIONS;
+  env.NODE_OPTIONS = existing && existing.length > 0 ? `${existing} ${injection}` : injection;
 }
 
 /**

--- a/electron/services/pty/types.ts
+++ b/electron/services/pty/types.ts
@@ -40,6 +40,10 @@ export interface TerminalPublicState {
   /** Command submitted immediately after shell spawn, if any. */
   command?: string;
   spawnedAt: number;
+  /** Wall-clock timestamp of the first PTY data byte after spawn. */
+  firstByteAt?: number;
+  /** Wall-clock timestamp when BootDetector first declared boot complete. */
+  bootCompleteAt?: number;
   wasKilled?: boolean;
   isExited?: boolean;
   agentState?: AgentState;


### PR DESCRIPTION
## Summary

- Adds `firstByteAt` and `bootCompleteAt` timestamps to `TerminalPublicState` and wires an `onBootComplete` callback through `ActivityMonitor` with a one-shot guard that re-arms on restart
- Hoists boot detection above the `simpleOutputState` early-returns so the callback fires correctly for real agent terminals (the critical correctness fix)
- Makes `TerminalProcess.recordBootComplete` idempotent and emits a structured `[AgentStartup]` JSON log entry per agent launch, keyed on `agentId` + 8-char `cwdHash`

Resolves #7616

## Changes

- `TerminalPublicState` (`electron/services/pty/types.ts`): adds `firstByteAt` and `bootCompleteAt` optional timestamps
- `ActivityMonitor` (`electron/services/ActivityMonitor.ts`): `onBootComplete` option with one-shot guard, re-armed on restart; boot detection hoisted before early-return paths
- `TerminalProcess` (`electron/services/pty/TerminalProcess.ts`): idempotent `recordBootComplete` emitting one `[AgentStartup]` log per launch
- `PtyHostLifecycle` (`electron/services/pty/PtyHostLifecycle.ts`): forwards `DAINTREE_IS_PACKAGED` to the pty host environment
- `terminalSpawn` (`electron/services/pty/terminalSpawn.ts`): dev-only `NODE_OPTIONS=--cpu-prof --cpu-prof-dir=...` injection, gated on `DAINTREE_ENABLE_AGENT_PROFILE` + dev + agent + `DAINTREE_IS_PACKAGED === "0"`
- `docs/development.md`: documents the profile-capture flow end to end

## Testing

- Unit tests covering `ActivityMonitor.onBootComplete` one-shot semantics, re-arm on restart, and position relative to early-return paths (`electron/services/__tests__/ActivityMonitor.test.ts`)
- Unit tests for `TerminalProcess.recordBootComplete` idempotency and structured log output (`electron/services/pty/__tests__/TerminalProcess.lifecycle.test.ts`)
- Unit tests for `terminalSpawn` cpu-prof injection gating across all flag/env combinations (`electron/services/pty/__tests__/terminalSpawn.profile.test.ts`)