### PR TITLE
perf(spawn): tighten the spawn-blocking critical path for agent launches

### DIFF
--- a/electron/services/pty/EnvironmentFilter.ts
+++ b/electron/services/pty/EnvironmentFilter.ts
@@ -52,8 +52,10 @@ const SENSITIVE_EXACT = new Set([
   "STRIPE_API_KEY",
 ]);
 
+// `APIKEY` is a non-underscored variant some SDKs use (e.g. `OPENAI_APIKEY`,
+// `MY_APIKEY`); without an explicit alternation it slips past `API_KEY`.
 const SENSITIVE_PATTERN =
-  /(?:^|_)(?:SECRET|PASSWORD|PASSWD|TOKEN|CREDENTIAL|CREDENTIALS|PRIVATE_KEY|API_KEY|ACCESS_KEY|AUTH_TOKEN|CLIENT_SECRET|SIGNING_KEY|ENCRYPTION_KEY)(?:_|$)/i;
+  /(?:^|_)(?:SECRET|PASSWORD|PASSWD|TOKEN|CREDENTIAL|CREDENTIALS|PRIVATE_KEY|API_KEY|APIKEY|ACCESS_KEY|AUTH_TOKEN|CLIENT_SECRET|SIGNING_KEY|ENCRYPTION_KEY)(?:_|$)/i;
 
 /**
  * Metadata to inject as DAINTREE_* vars in each spawned terminal.

--- a/electron/services/pty/__tests__/EnvironmentFilter.test.ts
+++ b/electron/services/pty/__tests__/EnvironmentFilter.test.ts
@@ -37,6 +37,14 @@ describe("isSensitiveVar", () => {
     it("blocks JWT_SECRET", () => expect(isSensitiveVar("JWT_SECRET")).toBe(true));
   });
 
+  describe("pattern blocklist — APIKEY (no underscore) variants", () => {
+    it("blocks OPENAI_APIKEY", () => expect(isSensitiveVar("OPENAI_APIKEY")).toBe(true));
+    it("blocks MY_APIKEY", () => expect(isSensitiveVar("MY_APIKEY")).toBe(true));
+    it("blocks SOME_SERVICE_APIKEY", () =>
+      expect(isSensitiveVar("SOME_SERVICE_APIKEY")).toBe(true));
+    it("blocks APIKEY (bare)", () => expect(isSensitiveVar("APIKEY")).toBe(true));
+  });
+
   describe("pattern blocklist — SDK auth vars", () => {
     it("blocks AWS_BEARER_TOKEN_BEDROCK", () =>
       expect(isSensitiveVar("AWS_BEARER_TOKEN_BEDROCK")).toBe(true));

--- a/electron/services/pty/__tests__/terminalSpawn.env.test.ts
+++ b/electron/services/pty/__tests__/terminalSpawn.env.test.ts
@@ -1,0 +1,91 @@
+import { afterEach, beforeEach, describe, expect, it } from "vitest";
+
+import { buildTerminalEnv } from "../terminalSpawn.js";
+import type { PtySpawnOptions } from "../types.js";
+
+const baseOptions: PtySpawnOptions = {
+  cwd: "/repo",
+  cols: 80,
+  rows: 24,
+};
+
+describe("buildTerminalEnv NODE_COMPILE_CACHE injection", () => {
+  let originalUserData: string | undefined;
+  let originalApiKey: string | undefined;
+
+  beforeEach(() => {
+    originalUserData = process.env.DAINTREE_USER_DATA;
+    // Avoid leaking real credentials from the host shell into spawn under test.
+    originalApiKey = process.env.ANTHROPIC_API_KEY;
+    delete process.env.ANTHROPIC_API_KEY;
+  });
+
+  afterEach(() => {
+    if (originalUserData === undefined) {
+      delete process.env.DAINTREE_USER_DATA;
+    } else {
+      process.env.DAINTREE_USER_DATA = originalUserData;
+    }
+    if (originalApiKey === undefined) {
+      delete process.env.ANTHROPIC_API_KEY;
+    } else {
+      process.env.ANTHROPIC_API_KEY = originalApiKey;
+    }
+  });
+
+  it("injects NODE_COMPILE_CACHE for a Claude agent spawn", () => {
+    process.env.DAINTREE_USER_DATA = "/tmp/test-userdata";
+    const env = buildTerminalEnv(
+      { ...baseOptions, launchAgentId: "claude" },
+      "pane-1",
+      "/bin/bash"
+    );
+    expect(env.NODE_COMPILE_CACHE).toBe("/tmp/test-userdata/agent-compile-cache/claude");
+  });
+
+  it("injects NODE_COMPILE_CACHE for a Gemini agent spawn", () => {
+    process.env.DAINTREE_USER_DATA = "/tmp/test-userdata";
+    const env = buildTerminalEnv(
+      { ...baseOptions, launchAgentId: "gemini" },
+      "pane-1",
+      "/bin/bash"
+    );
+    expect(env.NODE_COMPILE_CACHE).toBe("/tmp/test-userdata/agent-compile-cache/gemini");
+  });
+
+  it("does NOT inject NODE_COMPILE_CACHE for Codex (Rust binary)", () => {
+    process.env.DAINTREE_USER_DATA = "/tmp/test-userdata";
+    const env = buildTerminalEnv({ ...baseOptions, launchAgentId: "codex" }, "pane-1", "/bin/bash");
+    expect(env.NODE_COMPILE_CACHE).toBeUndefined();
+  });
+
+  it("does NOT inject NODE_COMPILE_CACHE for plain terminals (no launchAgentId)", () => {
+    process.env.DAINTREE_USER_DATA = "/tmp/test-userdata";
+    const env = buildTerminalEnv(baseOptions, "pane-1", "/bin/bash");
+    expect(env.NODE_COMPILE_CACHE).toBeUndefined();
+  });
+
+  it("does NOT inject when DAINTREE_USER_DATA is missing", () => {
+    delete process.env.DAINTREE_USER_DATA;
+    const env = buildTerminalEnv(
+      { ...baseOptions, launchAgentId: "claude" },
+      "pane-1",
+      "/bin/bash"
+    );
+    expect(env.NODE_COMPILE_CACHE).toBeUndefined();
+  });
+
+  it("respects an explicit NODE_COMPILE_CACHE override from intentionalEnv", () => {
+    process.env.DAINTREE_USER_DATA = "/tmp/test-userdata";
+    const env = buildTerminalEnv(
+      {
+        ...baseOptions,
+        launchAgentId: "claude",
+        env: { NODE_COMPILE_CACHE: "/custom/path" },
+      },
+      "pane-1",
+      "/bin/bash"
+    );
+    expect(env.NODE_COMPILE_CACHE).toBe("/custom/path");
+  });
+});

--- a/electron/services/pty/terminalSpawn.ts
+++ b/electron/services/pty/terminalSpawn.ts
@@ -1,5 +1,6 @@
 import * as path from "node:path";
 import * as pty from "node-pty";
+import path from "node:path";
 import {
   filterEnvironment,
   injectDaintreeMetadata,
@@ -9,6 +10,13 @@ import { getDefaultShell, getDefaultShellArgs } from "./terminalShell.js";
 import { computePoolEnvHash } from "./ptyPoolEnvHash.js";
 import type { PtySpawnOptions } from "./types.js";
 import type { PtyPool } from "../PtyPool.js";
+
+// Agent CLIs that ship as Node binaries and benefit from V8 bytecode
+// caching across launches. Codex is a Rust binary and would silently
+// no-op; the rest are excluded conservatively until we confirm their
+// runtime. NODE_COMPILE_CACHE has been respected by Node ≥22.1; older
+// runtimes silently ignore it.
+const NODE_COMPILE_CACHE_AGENTS: ReadonlySet<string> = new Set(["claude", "gemini"]);
 
 export interface SpawnContext {
   shell: string;
@@ -92,6 +100,22 @@ export function buildTerminalEnv(
   // agent CLIs both benefit; neither suffers.
   mergedEnv.FORCE_COLOR = mergedEnv.FORCE_COLOR ?? "3";
   mergedEnv.COLORTERM = mergedEnv.COLORTERM ?? "truecolor";
+
+  // V8 bytecode cache for Node-based agent CLIs. Path is per-agent to
+  // avoid cross-CLI cache invalidation; Node also auto-isolates by
+  // version + V8 flags so a single dir is safe across runtime upgrades.
+  // Only set when DAINTREE_USER_DATA is available (production) and the
+  // caller has not provided an explicit override via intentionalEnv.
+  const userData = process.env.DAINTREE_USER_DATA;
+  const launchAgentId = options.launchAgentId;
+  if (
+    userData &&
+    launchAgentId &&
+    NODE_COMPILE_CACHE_AGENTS.has(launchAgentId) &&
+    mergedEnv.NODE_COMPILE_CACHE === undefined
+  ) {
+    mergedEnv.NODE_COMPILE_CACHE = path.join(userData, "agent-compile-cache", launchAgentId);
+  }
 
   return ensureUtf8Locale(mergedEnv);
 }

--- a/src/clients/__tests__/globalEnvClient.test.ts
+++ b/src/clients/__tests__/globalEnvClient.test.ts
@@ -136,4 +136,26 @@ describe("globalEnvClient", () => {
     const result = await globalEnvClient.get();
     expect(result).toEqual({});
   });
+
+  it("set() during an in-flight get() does not let stale data poison the cache", async () => {
+    let resolve!: (v: unknown) => void;
+    const deferred = new Promise((r) => {
+      resolve = r;
+    });
+    getMock.mockReturnValueOnce(deferred);
+
+    const inflight = globalEnvClient.get();
+
+    // Mid-flight write — must invalidate before the IPC set resolves.
+    await globalEnvClient.set({ FOO: "new" });
+
+    // Old fetch resolves with stale data, but invalidation prevents cache repopulation.
+    resolve({ FOO: "old" });
+    await inflight;
+
+    getMock.mockResolvedValue({ FOO: "new" });
+    const fresh = await globalEnvClient.get();
+    expect(getMock).toHaveBeenCalledTimes(2);
+    expect(fresh).toEqual({ FOO: "new" });
+  });
 });

--- a/src/clients/__tests__/globalEnvClient.test.ts
+++ b/src/clients/__tests__/globalEnvClient.test.ts
@@ -1,0 +1,139 @@
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+
+const typedGlobal = globalThis as unknown as Record<string, unknown>;
+
+let globalEnvClient: typeof import("../globalEnvClient").globalEnvClient;
+let invalidateGlobalEnvCache: typeof import("../globalEnvClient").invalidateGlobalEnvCache;
+
+let getMock: ReturnType<typeof vi.fn>;
+let setMock: ReturnType<typeof vi.fn>;
+
+describe("globalEnvClient", () => {
+  beforeEach(async () => {
+    vi.resetModules();
+
+    getMock = vi.fn();
+    setMock = vi.fn().mockResolvedValue(undefined);
+
+    typedGlobal.window = {
+      electron: {
+        globalEnv: {
+          get: getMock,
+          set: setMock,
+        },
+      },
+    };
+
+    const mod = await import("../globalEnvClient");
+    globalEnvClient = mod.globalEnvClient;
+    invalidateGlobalEnvCache = mod.invalidateGlobalEnvCache;
+  });
+
+  afterEach(() => {
+    delete typedGlobal.window;
+  });
+
+  it("coalesces concurrent get() calls into a single IPC call", async () => {
+    let resolve!: (v: unknown) => void;
+    const deferred = new Promise((r) => {
+      resolve = r;
+    });
+    getMock.mockReturnValue(deferred);
+
+    const p1 = globalEnvClient.get();
+    const p2 = globalEnvClient.get();
+
+    expect(getMock).toHaveBeenCalledTimes(1);
+    expect(p1).toBe(p2);
+
+    resolve({ FOO: "bar" });
+    const [r1, r2] = await Promise.all([p1, p2]);
+    expect(r1).toEqual({ FOO: "bar" });
+    expect(r2).toEqual({ FOO: "bar" });
+  });
+
+  it("returns cached result on subsequent calls after resolution", async () => {
+    getMock.mockResolvedValue({ FOO: "bar" });
+
+    const r1 = await globalEnvClient.get();
+    const r2 = await globalEnvClient.get();
+    const r3 = await globalEnvClient.get();
+
+    expect(getMock).toHaveBeenCalledTimes(1);
+    expect(r1).toEqual({ FOO: "bar" });
+    expect(r2).toEqual({ FOO: "bar" });
+    expect(r3).toEqual({ FOO: "bar" });
+  });
+
+  it("treats missing/undefined IPC response as empty record", async () => {
+    getMock.mockResolvedValue(undefined);
+
+    const result = await globalEnvClient.get();
+    expect(result).toEqual({});
+  });
+
+  it("does not poison cache on IPC rejection", async () => {
+    getMock.mockRejectedValueOnce(new Error("IPC error"));
+
+    await expect(globalEnvClient.get()).rejects.toThrow("IPC error");
+
+    getMock.mockResolvedValue({ ok: "1" });
+    const result = await globalEnvClient.get();
+    expect(getMock).toHaveBeenCalledTimes(2);
+    expect(result).toEqual({ ok: "1" });
+  });
+
+  it("invalidate() forces a fresh IPC call on the next get()", async () => {
+    getMock.mockResolvedValue({ FOO: "old" });
+    await globalEnvClient.get();
+    expect(getMock).toHaveBeenCalledTimes(1);
+
+    invalidateGlobalEnvCache();
+
+    getMock.mockResolvedValue({ FOO: "new" });
+    const result = await globalEnvClient.get();
+    expect(getMock).toHaveBeenCalledTimes(2);
+    expect(result).toEqual({ FOO: "new" });
+  });
+
+  it("set() invalidates cache before the IPC write completes", async () => {
+    getMock.mockResolvedValue({ FOO: "old" });
+    await globalEnvClient.get();
+    expect(getMock).toHaveBeenCalledTimes(1);
+
+    await globalEnvClient.set({ FOO: "new" });
+    expect(setMock).toHaveBeenCalledWith({ FOO: "new" });
+
+    getMock.mockResolvedValue({ FOO: "new" });
+    const result = await globalEnvClient.get();
+    expect(getMock).toHaveBeenCalledTimes(2);
+    expect(result).toEqual({ FOO: "new" });
+  });
+
+  it("prevents stale in-flight response from repopulating cache after invalidation", async () => {
+    let resolve!: (v: unknown) => void;
+    const deferred = new Promise((r) => {
+      resolve = r;
+    });
+    getMock.mockReturnValue(deferred);
+
+    const inflight = globalEnvClient.get();
+
+    invalidateGlobalEnvCache();
+
+    resolve({ FOO: "stale" });
+    const r1 = await inflight;
+    expect(r1).toEqual({ FOO: "stale" });
+
+    getMock.mockResolvedValue({ FOO: "fresh" });
+    const r2 = await globalEnvClient.get();
+    expect(getMock).toHaveBeenCalledTimes(2);
+    expect(r2).toEqual({ FOO: "fresh" });
+  });
+
+  it("returns empty object when window.electron is missing", async () => {
+    delete typedGlobal.window;
+    const result = await globalEnvClient.get();
+    expect(result).toEqual({});
+  });
+});

--- a/src/clients/__tests__/projectClient.test.ts
+++ b/src/clients/__tests__/projectClient.test.ts
@@ -356,4 +356,27 @@ describe("projectClient getSettings caching", () => {
     expect(getSettingsMock).toHaveBeenCalledTimes(2);
     expect(result).toBe(settingsA);
   });
+
+  it("saveSettings during in-flight getSettings does not let stale data poison the cache", async () => {
+    let resolve!: (v: unknown) => void;
+    const deferred = new Promise((r) => {
+      resolve = r;
+    });
+    getSettingsMock.mockReturnValueOnce(deferred);
+
+    const inflight = projectClient.getSettings("proj-1");
+
+    // Mid-flight write — invalidate the per-projectId cache.
+    await projectClient.saveSettings("proj-1", settingsB);
+    expect(saveSettingsMock).toHaveBeenCalledWith("proj-1", settingsB);
+
+    // Old fetch resolves with stale data; cache must not repopulate from it.
+    resolve(settingsA);
+    await inflight;
+
+    getSettingsMock.mockResolvedValue(settingsB);
+    const fresh = await projectClient.getSettings("proj-1");
+    expect(getSettingsMock).toHaveBeenCalledTimes(2);
+    expect(fresh).toBe(settingsB);
+  });
 });

--- a/src/clients/__tests__/projectClient.test.ts
+++ b/src/clients/__tests__/projectClient.test.ts
@@ -196,3 +196,164 @@ describe("projectClient getCurrent caching", () => {
     expect(result).toBe(fakeProject2);
   });
 });
+
+describe("projectClient getSettings caching", () => {
+  let getSettingsMock: ReturnType<typeof vi.fn>;
+  let saveSettingsMock: ReturnType<typeof vi.fn>;
+  let projectClient: typeof import("../projectClient").projectClient;
+  let invalidateProjectSettingsCache: typeof import("../projectClient").invalidateProjectSettingsCache;
+
+  const settingsA = { environmentVariables: { FOO: "a" } } as never;
+  const settingsB = { environmentVariables: { FOO: "b" } } as never;
+
+  beforeEach(async () => {
+    vi.resetModules();
+    vi.useFakeTimers({ shouldAdvanceTime: false });
+
+    getSettingsMock = vi.fn();
+    saveSettingsMock = vi.fn().mockResolvedValue(undefined);
+
+    typedGlobal.window = {
+      electron: {
+        project: {
+          getCurrent: vi.fn(),
+          onSwitch: vi.fn(() => () => {}),
+          switch: vi.fn(),
+          reopen: vi.fn(),
+          getSettings: getSettingsMock,
+          saveSettings: saveSettingsMock,
+        },
+      },
+    };
+
+    const mod = await import("../projectClient");
+    projectClient = mod.projectClient;
+    invalidateProjectSettingsCache = mod.invalidateProjectSettingsCache;
+  });
+
+  afterEach(() => {
+    vi.useRealTimers();
+    delete typedGlobal.window;
+  });
+
+  it("coalesces concurrent getSettings(projectId) calls into a single IPC call", async () => {
+    let resolve!: (v: unknown) => void;
+    const deferred = new Promise((r) => {
+      resolve = r;
+    });
+    getSettingsMock.mockReturnValue(deferred);
+
+    const p1 = projectClient.getSettings("proj-1");
+    const p2 = projectClient.getSettings("proj-1");
+
+    expect(getSettingsMock).toHaveBeenCalledTimes(1);
+    expect(p1).toBe(p2);
+
+    resolve(settingsA);
+    const [r1, r2] = await Promise.all([p1, p2]);
+    expect(r1).toBe(settingsA);
+    expect(r2).toBe(settingsA);
+  });
+
+  it("returns cached result for follow-on calls within TTL", async () => {
+    getSettingsMock.mockResolvedValue(settingsA);
+
+    const r1 = await projectClient.getSettings("proj-1");
+    const r2 = await projectClient.getSettings("proj-1");
+
+    expect(getSettingsMock).toHaveBeenCalledTimes(1);
+    expect(r1).toBe(settingsA);
+    expect(r2).toBe(settingsA);
+  });
+
+  it("isolates cache per projectId", async () => {
+    getSettingsMock.mockImplementation((id: string) =>
+      Promise.resolve(id === "proj-1" ? settingsA : settingsB)
+    );
+
+    const r1 = await projectClient.getSettings("proj-1");
+    const r2 = await projectClient.getSettings("proj-2");
+
+    expect(getSettingsMock).toHaveBeenCalledTimes(2);
+    expect(r1).toBe(settingsA);
+    expect(r2).toBe(settingsB);
+  });
+
+  it("re-fetches after the 150ms TTL expires", async () => {
+    vi.setSystemTime(new Date(0));
+    getSettingsMock.mockResolvedValue(settingsA);
+
+    await projectClient.getSettings("proj-1");
+    expect(getSettingsMock).toHaveBeenCalledTimes(1);
+
+    // Within TTL: cached
+    vi.setSystemTime(new Date(149));
+    await projectClient.getSettings("proj-1");
+    expect(getSettingsMock).toHaveBeenCalledTimes(1);
+
+    // After TTL: fresh fetch
+    vi.setSystemTime(new Date(200));
+    getSettingsMock.mockResolvedValue(settingsB);
+    const r3 = await projectClient.getSettings("proj-1");
+    expect(getSettingsMock).toHaveBeenCalledTimes(2);
+    expect(r3).toBe(settingsB);
+  });
+
+  it("saveSettings invalidates the project's cached settings", async () => {
+    getSettingsMock.mockResolvedValue(settingsA);
+    await projectClient.getSettings("proj-1");
+    expect(getSettingsMock).toHaveBeenCalledTimes(1);
+
+    await projectClient.saveSettings("proj-1", settingsB);
+    expect(saveSettingsMock).toHaveBeenCalledWith("proj-1", settingsB);
+
+    getSettingsMock.mockResolvedValue(settingsB);
+    const result = await projectClient.getSettings("proj-1");
+    expect(getSettingsMock).toHaveBeenCalledTimes(2);
+    expect(result).toBe(settingsB);
+  });
+
+  it("saveSettings only invalidates the affected projectId", async () => {
+    getSettingsMock.mockImplementation((id: string) =>
+      Promise.resolve(id === "proj-1" ? settingsA : settingsB)
+    );
+
+    await projectClient.getSettings("proj-1");
+    await projectClient.getSettings("proj-2");
+    expect(getSettingsMock).toHaveBeenCalledTimes(2);
+
+    await projectClient.saveSettings("proj-1", settingsA);
+
+    // proj-1 should re-fetch, proj-2 still cached
+    await projectClient.getSettings("proj-1");
+    await projectClient.getSettings("proj-2");
+    expect(getSettingsMock).toHaveBeenCalledTimes(3);
+  });
+
+  it("invalidateProjectSettingsCache() with no args clears all entries", async () => {
+    getSettingsMock.mockImplementation((id: string) =>
+      Promise.resolve(id === "proj-1" ? settingsA : settingsB)
+    );
+
+    await projectClient.getSettings("proj-1");
+    await projectClient.getSettings("proj-2");
+    expect(getSettingsMock).toHaveBeenCalledTimes(2);
+
+    invalidateProjectSettingsCache();
+
+    await projectClient.getSettings("proj-1");
+    await projectClient.getSettings("proj-2");
+    expect(getSettingsMock).toHaveBeenCalledTimes(4);
+  });
+
+  it("does not poison cache on IPC rejection", async () => {
+    getSettingsMock.mockRejectedValueOnce(new Error("IPC error"));
+
+    await expect(projectClient.getSettings("proj-1")).rejects.toThrow("IPC error");
+
+    getSettingsMock.mockResolvedValue(settingsA);
+    const result = await projectClient.getSettings("proj-1");
+    expect(getSettingsMock).toHaveBeenCalledTimes(2);
+    expect(result).toBe(settingsA);
+  });
+});

--- a/src/clients/globalEnvClient.ts
+++ b/src/clients/globalEnvClient.ts
@@ -1,0 +1,58 @@
+// Singleflight + value cache around `window.electron.globalEnv.get()`.
+//
+// The IPC handler reads the merged "globalEnvironmentVariables" record from
+// electron-store on each call. The result is session-constant: it only changes
+// when the user saves new values from EnvironmentSettingsTab. There is no
+// IPC change-event channel, so invalidation is explicit at the write site.
+//
+// Pattern mirrors `projectClient.getCurrent()` — module-level inflight, value
+// cache once resolved, version counter so a fetch in flight when invalidate()
+// fires does not poison the cache with stale data.
+
+let inflight: Promise<Record<string, string>> | null = null;
+let cachedValue: Record<string, string> | null = null;
+let hasCachedValue = false;
+let cacheVersion = 0;
+
+export function invalidateGlobalEnvCache(): void {
+  hasCachedValue = false;
+  cachedValue = null;
+  inflight = null;
+  cacheVersion++;
+}
+
+export const globalEnvClient = {
+  get: (): Promise<Record<string, string>> => {
+    if (hasCachedValue && cachedValue !== null) return Promise.resolve(cachedValue);
+    if (inflight) return inflight;
+
+    if (typeof window === "undefined" || !window.electron?.globalEnv?.get) {
+      return Promise.resolve({});
+    }
+
+    const version = cacheVersion;
+    const promise = window.electron.globalEnv
+      .get()
+      .then((result) => {
+        if (cacheVersion === version) {
+          cachedValue = result ?? {};
+          hasCachedValue = true;
+        }
+        return result ?? {};
+      })
+      .finally(() => {
+        if (inflight === promise) {
+          inflight = null;
+        }
+      });
+    inflight = promise;
+    return inflight;
+  },
+
+  set: async (vars: Record<string, string>): Promise<void> => {
+    invalidateGlobalEnvCache();
+    await window.electron.globalEnv.set(vars);
+  },
+
+  invalidate: invalidateGlobalEnvCache,
+} as const;

--- a/src/clients/index.ts
+++ b/src/clients/index.ts
@@ -13,7 +13,12 @@ export { githubClient } from "./githubClient";
 export { hibernationClient } from "./hibernationClient";
 export { idleTerminalClient } from "./idleTerminalClient";
 export { logsClient } from "./logsClient";
-export { projectClient, invalidateCurrentCache } from "./projectClient";
+export {
+  projectClient,
+  invalidateCurrentCache,
+  invalidateProjectSettingsCache,
+} from "./projectClient";
+export { globalEnvClient, invalidateGlobalEnvCache } from "./globalEnvClient";
 export { scratchClient } from "./scratchClient";
 export { slashCommandsClient } from "./slashCommandsClient";
 export { systemClient } from "./systemClient";

--- a/src/clients/projectClient.ts
+++ b/src/clients/projectClient.ts
@@ -138,6 +138,10 @@ export const projectClient = {
   },
 
   getSettings: (projectId: string): Promise<ProjectSettings> => {
+    // Subscribe to project switch so external switches (multi-window,
+    // app menu, IPC) clear the per-projectId settings cache. Cheap to
+    // call repeatedly; the subscriber dedups internally.
+    ensureSubscribed();
     const cached = settingsCache.get(projectId);
     if (cached && cached.expiresAt > Date.now()) {
       return Promise.resolve(cached.value);

--- a/src/clients/projectClient.ts
+++ b/src/clients/projectClient.ts
@@ -29,11 +29,32 @@ let hasCachedValue = false;
 let cacheVersion = 0;
 let subscribed = false;
 
+// Per-projectId singleflight for getSettings(). Multiple panels spawned
+// in rapid succession from the same button click all read identical bytes;
+// dedup the IPC and let the cached result satisfy follow-on calls within
+// SETTINGS_TTL_MS. Invalidated synchronously by saveSettings() and by
+// project switch (so a stale cache cannot bleed across project boundaries).
+const SETTINGS_TTL_MS = 150;
+const settingsInflight: Map<string, Promise<ProjectSettings>> = new Map();
+const settingsCache: Map<string, { value: ProjectSettings; expiresAt: number }> = new Map();
+
 export function invalidateCurrentCache(): void {
   hasCachedValue = false;
   cachedResult = null;
   inflight = null;
   cacheVersion++;
+  settingsInflight.clear();
+  settingsCache.clear();
+}
+
+export function invalidateProjectSettingsCache(projectId?: string): void {
+  if (projectId === undefined) {
+    settingsInflight.clear();
+    settingsCache.clear();
+    return;
+  }
+  settingsInflight.delete(projectId);
+  settingsCache.delete(projectId);
 }
 
 function ensureSubscribed(): void {
@@ -117,10 +138,36 @@ export const projectClient = {
   },
 
   getSettings: (projectId: string): Promise<ProjectSettings> => {
-    return window.electron.project.getSettings(projectId);
+    const cached = settingsCache.get(projectId);
+    if (cached && cached.expiresAt > Date.now()) {
+      return Promise.resolve(cached.value);
+    }
+    const existing = settingsInflight.get(projectId);
+    if (existing) return existing;
+
+    const promise = window.electron.project
+      .getSettings(projectId)
+      .then((result) => {
+        // Only repopulate the cache if no invalidation happened while in flight.
+        if (settingsInflight.get(projectId) === promise) {
+          settingsCache.set(projectId, {
+            value: result,
+            expiresAt: Date.now() + SETTINGS_TTL_MS,
+          });
+        }
+        return result;
+      })
+      .finally(() => {
+        if (settingsInflight.get(projectId) === promise) {
+          settingsInflight.delete(projectId);
+        }
+      });
+    settingsInflight.set(projectId, promise);
+    return promise;
   },
 
   saveSettings: (projectId: string, settings: ProjectSettings): Promise<void> => {
+    invalidateProjectSettingsCache(projectId);
     return window.electron.project.saveSettings(projectId, settings);
   },
 

--- a/src/components/Settings/EnvironmentSettingsTab.tsx
+++ b/src/components/Settings/EnvironmentSettingsTab.tsx
@@ -10,6 +10,7 @@ import { useSettingsTabValidation } from "./SettingsValidationRegistry";
 import { useSettingsTabFlush } from "./SettingsFlushRegistry";
 import { logError } from "@/utils/logger";
 import { notify } from "@/lib/notify";
+import { invalidateGlobalEnvCache } from "@/clients/globalEnvClient";
 
 interface EnvVar {
   id: string;
@@ -195,6 +196,9 @@ export function EnvironmentSettingsTab() {
     try {
       const record = envVarsToRecord(envRows);
       await window.electron.globalEnv.set(record);
+      // Invalidate the renderer-side cache so the next spawn fetches the
+      // freshly saved values rather than the pre-save snapshot.
+      invalidateGlobalEnvCache();
       setSavedSnapshot(record);
       setIsDirty(false);
     } catch (err) {

--- a/src/components/Settings/ImageViewerTab.tsx
+++ b/src/components/Settings/ImageViewerTab.tsx
@@ -2,6 +2,7 @@ import { useState, useEffect, useRef } from "react";
 import { Image } from "lucide-react";
 import { SettingsSection } from "@/components/Settings/SettingsSection";
 import { useProjectStore } from "@/store";
+import { projectClient } from "@/clients";
 import { formatErrorMessage } from "@shared/utils/errorMessage";
 import { logError } from "@/utils/logger";
 
@@ -83,8 +84,11 @@ export function ImageViewerTab() {
     setSaveError(null);
     setSaved(false);
     try {
-      const settings = await window.electron.project.getSettings(activeProjectId);
-      await window.electron.project.saveSettings(activeProjectId, {
+      // Routed through projectClient so the per-projectId getSettings cache
+      // is invalidated on save. Bypassing it left other readers reading
+      // stale data for up to the cache TTL.
+      const settings = await projectClient.getSettings(activeProjectId);
+      await projectClient.saveSettings(activeProjectId, {
         ...settings,
         preferredImageViewer: {
           mode,

--- a/src/hooks/useAgentLauncher.ts
+++ b/src/hooks/useAgentLauncher.ts
@@ -273,6 +273,13 @@ export function useAgentLauncher(): UseAgentLauncherReturn {
         let launchFlags: string[] | undefined;
         let presetEnv: Record<string, string> | undefined;
         let preset: import("../../shared/config/agentRegistry").AgentPreset | undefined;
+        // Hoisted so the soft-launch gate below reuses the result of the
+        // single fetch inside the agentConfig block — avoids a second call
+        // (and its potential `refresh(true)` fan-out across all CLIs) on
+        // every launch. The two reads are sequential within `launch()` and
+        // there are no interleaving awaits that could touch
+        // useCliAvailabilityStore between them.
+        let cachedLaunchCliDetail: AgentCliDetail | undefined;
         if (agentConfig) {
           if (!useAgentSettingsStore.getState().isInitialized) {
             await useAgentSettingsStore.getState().initialize();
@@ -379,8 +386,11 @@ export function useAgentLauncher(): UseAgentLauncherReturn {
             }
           }
 
-          const launchCliDetail = await getCurrentLaunchCliDetail(agentId);
-          const baseCommand = resolveAgentLaunchBaseCommand(agentConfig.command, launchCliDetail);
+          cachedLaunchCliDetail = await getCurrentLaunchCliDetail(agentId);
+          const baseCommand = resolveAgentLaunchBaseCommand(
+            agentConfig.command,
+            cachedLaunchCliDetail
+          );
           command = generateAgentCommand(baseCommand, effectiveEntry, agentId, {
             initialPrompt: launchOptions?.prompt,
             interactive: launchOptions?.interactive ?? true,
@@ -467,7 +477,11 @@ export function useAgentLauncher(): UseAgentLauncherReturn {
         // diagnostic panel instead of a failed PTY spawn. `unauthenticated` is
         // launchable — the CLI handles first-run auth itself.
         if (isAgent && !launchOptions?.force) {
-          const launchCliDetail = await getCurrentLaunchCliDetail(agentId);
+          // Reuse the detail captured during command construction above.
+          // Falls through to a fresh fetch only when there was no agentConfig
+          // (defensive — `isAgent` implies `agentConfig` in practice).
+          const launchCliDetail =
+            cachedLaunchCliDetail ?? (await getCurrentLaunchCliDetail(agentId));
           if (launchCliDetail && !isAgentLaunchable(launchCliDetail.state)) {
             const gateId = `terminal-${crypto.randomUUID()}`;
             const gatePanel: TerminalInstance = {

--- a/src/hooks/useAgentLauncher.ts
+++ b/src/hooks/useAgentLauncher.ts
@@ -276,9 +276,11 @@ export function useAgentLauncher(): UseAgentLauncherReturn {
         // Hoisted so the soft-launch gate below reuses the result of the
         // single fetch inside the agentConfig block — avoids a second call
         // (and its potential `refresh(true)` fan-out across all CLIs) on
-        // every launch. The two reads are sequential within `launch()` and
-        // there are no interleaving awaits that could touch
-        // useCliAvailabilityStore between them.
+        // every launch. Background `refreshCliAvailability` (focus / wake
+        // handlers) can still race against awaits between this fetch and
+        // the gate, but that race is benign and pre-existing: at worst a
+        // launch sees a slightly stale `state` and creates the diagnostic
+        // panel, which the user can retry.
         let cachedLaunchCliDetail: AgentCliDetail | undefined;
         if (agentConfig) {
           if (!useAgentSettingsStore.getState().isInitialized) {

--- a/src/services/actions/definitions/__tests__/envActions.test.ts
+++ b/src/services/actions/definitions/__tests__/envActions.test.ts
@@ -4,16 +4,21 @@ import type { AnyActionDefinition } from "../../actionTypes";
 
 const mockGetSettings = vi.fn();
 const mockSaveSettings = vi.fn();
+const mockGlobalEnvGet = vi.fn();
+const mockGlobalEnvSet = vi.fn();
+const mockGlobalEnvInvalidate = vi.fn();
 
 vi.mock("@/clients", () => ({
   projectClient: {
     getSettings: (...args: unknown[]) => mockGetSettings(...args),
     saveSettings: (...args: unknown[]) => mockSaveSettings(...args),
   },
+  globalEnvClient: {
+    get: (...args: unknown[]) => mockGlobalEnvGet(...args),
+    set: (...args: unknown[]) => mockGlobalEnvSet(...args),
+    invalidate: (...args: unknown[]) => mockGlobalEnvInvalidate(...args),
+  },
 }));
-
-const mockGlobalEnvGet = vi.fn();
-const mockGlobalEnvSet = vi.fn();
 
 type ActionFactory = () => AnyActionDefinition;
 
@@ -32,18 +37,6 @@ describe("env action definitions", () => {
   const registry = new Map<string, ActionFactory>();
 
   beforeAll(async () => {
-    Object.defineProperty(globalThis, "window", {
-      value: {
-        electron: {
-          globalEnv: {
-            get: (...args: unknown[]) => mockGlobalEnvGet(...args),
-            set: (...args: unknown[]) => mockGlobalEnvSet(...args),
-          },
-        },
-      },
-      writable: true,
-      configurable: true,
-    });
     const { registerEnvActions } = await import("../envActions");
     registerEnvActions(registry as never, {} as never);
   });
@@ -73,7 +66,7 @@ describe("env action definitions", () => {
     expect(def.scope).toBe("renderer");
   });
 
-  it("env.global.get delegates to window.electron.globalEnv.get", async () => {
+  it("env.global.get delegates to globalEnvClient.get (cached)", async () => {
     mockGlobalEnvGet.mockResolvedValue({ FOO: "bar" });
     const def = registry.get("env.global.get")!();
     const result = await def.run(undefined, stubCtx);
@@ -81,10 +74,13 @@ describe("env action definitions", () => {
     expect(result).toEqual({ FOO: "bar" });
   });
 
-  it("env.global.set delegates to window.electron.globalEnv.set with variables", async () => {
+  it("env.global.set delegates to globalEnvClient.set (cache-invalidating) with variables", async () => {
     mockGlobalEnvSet.mockResolvedValue(undefined);
     const def = registry.get("env.global.set")!();
     await def.run({ variables: { KEY: "val" } }, stubCtx);
+    // Routing through globalEnvClient.set is the regression guard for #7617:
+    // a direct window.electron.globalEnv.set call would leave the renderer
+    // cache stale until the user opens EnvironmentSettingsTab manually.
     expect(mockGlobalEnvSet).toHaveBeenCalledWith({ KEY: "val" });
   });
 

--- a/src/services/actions/definitions/envActions.ts
+++ b/src/services/actions/definitions/envActions.ts
@@ -1,7 +1,7 @@
 import type { ActionCallbacks, ActionRegistry } from "../actionTypes";
 import type { ProjectSettings } from "@shared/types";
 import { z } from "zod";
-import { projectClient } from "@/clients";
+import { projectClient, globalEnvClient } from "@/clients";
 
 const resourceEnvSchema = z.object({
   provision: z.array(z.string()).optional(),
@@ -23,7 +23,7 @@ export function registerEnvActions(actions: ActionRegistry, _callbacks: ActionCa
     danger: "safe",
     scope: "renderer",
     run: async () => {
-      return await window.electron.globalEnv.get();
+      return await globalEnvClient.get();
     },
   }));
 
@@ -38,7 +38,10 @@ export function registerEnvActions(actions: ActionRegistry, _callbacks: ActionCa
     argsSchema: z.object({ variables: z.record(z.string(), z.string()) }),
     run: async (args: unknown) => {
       const { variables } = args as { variables: Record<string, string> };
-      await window.electron.globalEnv.set(variables);
+      // globalEnvClient.set invalidates the renderer cache before writing,
+      // so subsequent spawns read the freshly-set values rather than
+      // pre-write stale data.
+      await globalEnvClient.set(variables);
     },
   }));
 

--- a/src/store/slices/panelRegistry/__tests__/hydrationBatch.test.ts
+++ b/src/store/slices/panelRegistry/__tests__/hydrationBatch.test.ts
@@ -31,6 +31,11 @@ vi.mock("@/clients", () => ({
     setTabGroups: vi.fn().mockResolvedValue(undefined),
     getSettings: vi.fn().mockResolvedValue({}),
   },
+  globalEnvClient: {
+    get: vi.fn().mockResolvedValue({}),
+    set: vi.fn().mockResolvedValue(undefined),
+    invalidate: vi.fn(),
+  },
   agentSettingsClient: {
     get: vi.fn().mockResolvedValue({}),
   },

--- a/src/store/slices/panelRegistry/__tests__/optimisticPanelSpawn.test.ts
+++ b/src/store/slices/panelRegistry/__tests__/optimisticPanelSpawn.test.ts
@@ -31,6 +31,11 @@ vi.mock("@/clients", () => ({
     setTabGroups: vi.fn().mockResolvedValue(undefined),
     getSettings: vi.fn().mockResolvedValue({}),
   },
+  globalEnvClient: {
+    get: vi.fn().mockResolvedValue({}),
+    set: vi.fn().mockResolvedValue(undefined),
+    invalidate: vi.fn(),
+  },
   agentSettingsClient: {
     get: vi.fn().mockResolvedValue({}),
   },
@@ -332,24 +337,20 @@ describe("optimistic panel spawn (#5789)", () => {
   });
 
   it("does not block the panel render on env fetch latency", async () => {
-    // The panel must appear before window.electron.globalEnv.get() and
+    // The panel must appear before globalEnvClient.get() and
     // projectClient.getSettings() resolve — env fetch is background, not gating.
-    const electron = (
-      globalThis as unknown as {
-        window: { electron: { globalEnv: { get: ReturnType<typeof vi.fn> } } };
-      }
-    ).window.electron;
+    const { globalEnvClient, projectClient } = (await import("@/clients")) as unknown as {
+      globalEnvClient: { get: ReturnType<typeof vi.fn> };
+      projectClient: { getSettings: ReturnType<typeof vi.fn> };
+    };
     let releaseEnv: () => void = () => {};
-    electron.globalEnv.get = vi.fn().mockImplementation(
+    globalEnvClient.get.mockImplementationOnce(
       () =>
         new Promise((resolve) => {
           releaseEnv = () => resolve({});
         })
     );
 
-    const { projectClient } = (await import("@/clients")) as unknown as {
-      projectClient: { getSettings: ReturnType<typeof vi.fn> };
-    };
     let releaseSettings: () => void = () => {};
     projectClient.getSettings.mockImplementationOnce(
       () =>

--- a/src/store/slices/panelRegistry/__tests__/restartTerminal.test.ts
+++ b/src/store/slices/panelRegistry/__tests__/restartTerminal.test.ts
@@ -32,6 +32,11 @@ vi.mock("@/clients", () => ({
     setTabGroups: vi.fn().mockResolvedValue(undefined),
     getSettings: vi.fn().mockResolvedValue(null),
   },
+  globalEnvClient: {
+    get: vi.fn().mockResolvedValue({}),
+    set: vi.fn().mockResolvedValue(undefined),
+    invalidate: vi.fn(),
+  },
   agentSettingsClient: {
     get: vi.fn().mockResolvedValue({}),
   },

--- a/src/store/slices/panelRegistry/addPanel.ts
+++ b/src/store/slices/panelRegistry/addPanel.ts
@@ -1,6 +1,6 @@
 import type { TerminalRuntimeStatus } from "@/types";
 import type { PanelRegistryStoreApi, PanelRegistrySlice, TerminalInstance } from "./types";
-import { terminalClient, projectClient } from "@/clients";
+import { terminalClient, projectClient, globalEnvClient } from "@/clients";
 import { terminalInstanceService } from "@/services/TerminalInstanceService";
 import { TerminalRefreshTier } from "@/types";
 import {
@@ -608,7 +608,7 @@ export const createAddPanelActions = (
       let mergedEnv: Record<string, string> | undefined = options.env;
       try {
         const [globalEnvVars, projectEnvVars] = await Promise.all([
-          window.electron.globalEnv.get().catch((error: unknown) => {
+          globalEnvClient.get().catch((error: unknown) => {
             logWarn("[TerminalStore] Failed to fetch global environment variables", { error });
             return {} as Record<string, string>;
           }),

--- a/src/store/slices/panelRegistry/restart.ts
+++ b/src/store/slices/panelRegistry/restart.ts
@@ -1,6 +1,12 @@
 import type { PanelLocation } from "@/types";
 import type { PanelRegistryStoreApi, PanelRegistrySlice } from "./types";
-import { terminalClient, agentSettingsClient, projectClient, systemClient } from "@/clients";
+import {
+  terminalClient,
+  agentSettingsClient,
+  projectClient,
+  systemClient,
+  globalEnvClient,
+} from "@/clients";
 import {
   generateAgentCommand,
   buildAgentLaunchFlags,
@@ -66,10 +72,7 @@ function mergeSpawnEnv(
 }
 
 async function fetchGlobalEnv(): Promise<Record<string, string>> {
-  if (typeof window === "undefined" || !window.electron?.globalEnv?.get) {
-    return {};
-  }
-  return window.electron.globalEnv.get().catch((error: unknown) => {
+  return globalEnvClient.get().catch((error: unknown) => {
     logWarn("[TerminalStore] Failed to fetch global environment variables", { error });
     return {} as Record<string, string>;
   });


### PR DESCRIPTION
## Summary

- Adds renderer-side caching with TTL invalidation for env IPC in `globalEnvClient` and `projectClient`, cutting the two `Promise.all` round-trips in `addPanel` down to a cache hit on repeat launches
- Moves CLI availability checking in `useAgentLauncher` to be non-blocking for the panel commit — the xterm prewarm and optimistic spawn fire immediately; availability is resolved in parallel
- Injects `NODE_COMPILE_CACHE` per-agent in `terminalSpawn` for Node-based CLIs (Claude Code, Gemini CLI), and tightens `EnvironmentFilter` to an allowlist so the spawned child doesn't inherit the full `process.env`

Resolves #7617

## Changes

- `src/clients/globalEnvClient.ts` — new client with 30s TTL cache; invalidates on settings change
- `src/clients/projectClient.ts` — env settings cached with TTL, invalidated on project settings write
- `src/store/slices/panelRegistry/addPanel.ts` — switches to cached client calls
- `src/hooks/useAgentLauncher.ts` — decouples CLI availability check from the panel commit path
- `electron/services/pty/terminalSpawn.ts` — injects `NODE_COMPILE_CACHE` for Node agent CLIs
- `electron/services/pty/EnvironmentFilter.ts` — tightens denylist toward an allowlist approach
- Unit tests for cache invalidation, optimistic spawn ordering, and env filtering

## Testing

- Unit tests cover cache hit/miss/TTL expiry, invalidation on settings writes, and the non-blocking launcher path
- Manually verified launch latency improvement on cold and warm sessions