### PR TITLE
feat(pty-pool): serve agent terminal launches via env-keyed pool

### DIFF
--- a/electron/pty-host.ts
+++ b/electron/pty-host.ts
@@ -866,7 +866,7 @@ async function initialize(): Promise<void> {
     sendEvent({ type: "ready" });
     console.log("[PtyHost] Initialized and ready (accepting IPC)");
 
-    ptyPool = getPtyPool({ poolSize: 2 });
+    ptyPool = getPtyPool({ poolSize: 2, maxEntries: 8 });
     const homedir = os.homedir();
 
     // Warm pool in background

--- a/electron/services/PtyPool.ts
+++ b/electron/services/PtyPool.ts
@@ -3,28 +3,51 @@ import type { IDisposable } from "node-pty";
 import os from "os";
 import { getDefaultShell, getDefaultShellArgs } from "./pty/terminalShell.js";
 import { filterEnvironment, ensureUtf8Locale } from "./pty/EnvironmentFilter.js";
+import { computePoolEnvHash, POOL_ENV_EMPTY_HASH } from "./pty/ptyPoolEnvHash.js";
 
 export interface PtyPoolConfig {
   poolSize?: number;
   defaultCwd?: string;
+  /**
+   * Hard cap on total pool entries across all (cwd, envHash) keys. LRU
+   * eviction kicks in when warming would exceed this. Each node-pty process
+   * is roughly 50-80 MB; the default cap (8) bounds overhead at ~640 MB
+   * across the 2-4 active pool keys we expect at steady state.
+   */
+  maxEntries?: number;
 }
 
 interface PooledPty {
   process: pty.IPty;
   cwd: string;
+  envHash: string;
+  poolKey: string;
+  env: Record<string, string>;
   createdAt: number;
   dataDisposable: IDisposable;
 }
 
 const DEFAULT_POOL_SIZE = 2;
+const DEFAULT_MAX_ENTRIES = 8;
+
+function makePoolKey(cwd: string, envHash: string): string {
+  return `${cwd}\0${envHash}`;
+}
 
 export class PtyPool {
   private pool: Map<string, PooledPty> = new Map();
   private readonly poolSize: number;
+  private readonly maxEntries: number;
   private readonly defaultShell: string;
   private defaultCwd: string;
   private isDisposed = false;
   private refillInProgress = false;
+  /**
+   * Set of pool keys currently being warmed via warmForKey. Prevents stampede
+   * when concurrent acquire-misses for the same (cwd, envHash) all attempt to
+   * warm a fresh slot.
+   */
+  private readonly warmsInFlight: Set<string> = new Set();
   /**
    * Generation counter incremented on each drainAndRefill() call.
    * Captured in createPoolEntry closures so async spawns from a prior
@@ -34,6 +57,7 @@ export class PtyPool {
 
   constructor(config: PtyPoolConfig = {}) {
     this.poolSize = this.resolvePoolSize(config.poolSize);
+    this.maxEntries = this.resolveMaxEntries(config.maxEntries);
     this.defaultCwd = this.resolveCwd(config.defaultCwd, os.homedir());
     this.defaultShell = getDefaultShell();
   }
@@ -54,10 +78,11 @@ export class PtyPool {
     }
 
     const promises: Promise<void>[] = [];
-    const needed = this.poolSize - this.pool.size;
+    const existing = this.countEntriesForKey(this.defaultCwd, POOL_ENV_EMPTY_HASH);
+    const needed = this.poolSize - existing;
 
     for (let i = 0; i < needed; i++) {
-      promises.push(this.createPoolEntry(this.defaultCwd));
+      promises.push(this.createPoolEntry(this.defaultCwd, undefined, POOL_ENV_EMPTY_HASH));
     }
 
     await Promise.all(promises);
@@ -69,23 +94,34 @@ export class PtyPool {
     }
   }
 
-  private async createPoolEntry(cwd: string): Promise<void> {
+  private async createPoolEntry(
+    cwd: string,
+    callerEnv: Record<string, string> | undefined,
+    envHash: string
+  ): Promise<void> {
     if (this.isDisposed) return;
 
     // Capture the current drain epoch. If it changes before we finish
     // registering this entry, a drainAndRefill() happened and this spawn
     // is stale — kill it instead of registering at the wrong cwd.
     const epoch = this.drainEpoch;
+    const poolKey = makePoolKey(cwd, envHash);
+
+    // Evict an idle entry if we're at the global cap. We evict from a
+    // *different* key when possible so the warm we're about to perform
+    // actually grows this key's slot count.
+    this.evictIfAtCapacity(poolKey);
 
     try {
       const id = `pool-${Date.now()}-${Math.random().toString(36).slice(2, 9)}`;
+      const env = this.buildSpawnEnv(callerEnv);
 
       const ptyProcess = pty.spawn(this.defaultShell, getDefaultShellArgs(this.defaultShell), {
         name: "xterm-256color",
         cols: 80,
         rows: 24,
         cwd,
-        env: this.getFilteredEnv(),
+        env,
       });
 
       const dataDisposable = ptyProcess.onData(() => {});
@@ -95,10 +131,13 @@ export class PtyPool {
           console.log(`[PtyPool] Pooled PTY ${id} exited with code ${exitCode}`);
         }
         const entry = this.pool.get(id);
-        if (entry) {
-          entry.dataDisposable.dispose();
-          this.pool.delete(id);
+        if (!entry) {
+          // Entry was already removed (drain, evict, or acquire path). Those
+          // paths handle their own followup; refilling here would race them.
+          return;
         }
+        entry.dataDisposable.dispose();
+        this.pool.delete(id);
         // Skip refill if this entry belonged to a prior drain cycle — a
         // newer drainAndRefill() already initiated its own refill.
         if (!this.isDisposed && this.drainEpoch === epoch) {
@@ -119,32 +158,59 @@ export class PtyPool {
       this.pool.set(id, {
         process: ptyProcess,
         cwd,
+        envHash,
+        poolKey,
+        env,
         createdAt: Date.now(),
         dataDisposable,
       });
 
       if (process.env.DAINTREE_VERBOSE) {
-        console.log(`[PtyPool] Created pooled PTY ${id}, pool size: ${this.pool.size}`);
+        console.log(
+          `[PtyPool] Created pooled PTY ${id} for key ${poolKey}, pool size: ${this.pool.size}`
+        );
       }
     } catch (error) {
       console.error("[PtyPool] Failed to create pool entry:", error);
     }
   }
 
+  /**
+   * Backward-compatible zero-arg acquire — used only by tests and legacy
+   * callers. Internally targets the env-empty key at the pool's default cwd.
+   */
   acquire(): pty.IPty | null {
+    return this.acquireByKey(this.defaultCwd, POOL_ENV_EMPTY_HASH);
+  }
+
+  /**
+   * Acquire a pre-warmed PTY for a specific (cwd, envHash) key. Returns null
+   * if no matching entry exists. Triggers a background refill of the same key
+   * so the next acquire is also instant.
+   */
+  acquireByKey(cwd: string, envHash: string): pty.IPty | null {
     if (this.isDisposed) {
       console.warn("[PtyPool] Cannot acquire - pool disposed");
       return null;
     }
 
-    if (this.pool.size === 0) {
+    const wantedKey = makePoolKey(cwd, envHash);
+    let matched: { id: string; entry: PooledPty } | null = null;
+    for (const [id, entry] of this.pool) {
+      if (entry.poolKey === wantedKey) {
+        matched = { id, entry };
+        break;
+      }
+    }
+
+    if (!matched) {
       if (process.env.DAINTREE_VERBOSE) {
-        console.log("[PtyPool] Pool empty, returning null");
+        console.log(`[PtyPool] Miss on key ${wantedKey}; pool size: ${this.pool.size}`);
       }
       return null;
     }
 
-    const [id, entry] = this.pool.entries().next().value as [string, PooledPty];
+    const { id, entry } = matched;
     this.pool.delete(id);
 
     try {
@@ -152,25 +218,53 @@ export class PtyPool {
       if (pid === undefined) {
         console.warn(`[PtyPool] Pooled PTY ${id} has no PID (already dead), discarding`);
         entry.dataDisposable.dispose();
-        this.refillPool();
+        this.warmForKey(cwd, entry.env, envHash);
         return null;
       }
     } catch (error) {
       console.warn(`[PtyPool] Pooled PTY ${id} health check failed:`, error);
       entry.dataDisposable.dispose();
-      this.refillPool();
+      this.warmForKey(cwd, entry.env, envHash);
       return null;
     }
 
     entry.dataDisposable.dispose();
 
     if (process.env.DAINTREE_VERBOSE) {
-      console.log(`[PtyPool] Acquired PTY ${id}, ${this.pool.size} remaining`);
+      console.log(`[PtyPool] Acquired PTY ${id} for key ${wantedKey}, ${this.pool.size} remaining`);
     }
 
-    this.refillPool();
+    // Refill the same key so the next acquire is also instant. Fire-and-
+    // forget — the spawn races shell init with the user typing, and either
+    // way is fine.
+    this.warmForKey(cwd, entry.env, envHash);
 
     return entry.process;
+  }
+
+  /**
+   * Fire-and-forget warm of a single (cwd, envHash) slot. Idempotent under
+   * concurrent calls for the same key — the `warmsInFlight` guard prevents
+   * stampede when many acquires miss simultaneously.
+   *
+   * `callerEnv` is the raw `options.env` from the spawn request (pre-filter,
+   * pre-DAINTREE-metadata). `buildSpawnEnv` filters and finalises it.
+   */
+  warmForKey(cwd: string, callerEnv: Record<string, string> | undefined, envHash: string): void {
+    if (this.isDisposed) return;
+
+    const key = makePoolKey(cwd, envHash);
+    if (this.warmsInFlight.has(key)) return;
+    if (this.countEntriesForKey(cwd, envHash) >= this.poolSize) return;
+
+    this.warmsInFlight.add(key);
+    this.createPoolEntry(cwd, callerEnv, envHash)
+      .catch((err) => {
+        console.error(`[PtyPool] Failed to warm key ${key}:`, err);
+      })
+      .finally(() => {
+        this.warmsInFlight.delete(key);
+      });
   }
 
   refillPool(): void {
@@ -178,7 +272,8 @@ export class PtyPool {
       return;
     }
 
-    const needed = this.poolSize - this.pool.size;
+    const existing = this.countEntriesForKey(this.defaultCwd, POOL_ENV_EMPTY_HASH);
+    const needed = this.poolSize - existing;
     if (needed <= 0) {
       return;
     }
@@ -187,7 +282,7 @@ export class PtyPool {
 
     const promises: Promise<void>[] = [];
     for (let i = 0; i < needed; i++) {
-      promises.push(this.createPoolEntry(this.defaultCwd));
+      promises.push(this.createPoolEntry(this.defaultCwd, undefined, POOL_ENV_EMPTY_HASH));
     }
 
     Promise.all(promises)
@@ -235,8 +330,13 @@ export class PtyPool {
       return;
     }
 
-    if (nextCwd === this.defaultCwd && this.pool.size === this.poolSize) {
-      // Already at the requested cwd and fully warmed — nothing to do.
+    if (
+      nextCwd === this.defaultCwd &&
+      this.countEntriesForKey(nextCwd, POOL_ENV_EMPTY_HASH) >= this.poolSize
+    ) {
+      // Already at the requested cwd and the env-empty key is fully warmed —
+      // nothing to do. (Other env-keyed entries from prior agent launches may
+      // exist and stay; they'll be evicted naturally by LRU as needed.)
       return;
     }
 
@@ -280,6 +380,20 @@ export class PtyPool {
     return this.poolSize;
   }
 
+  getMaxEntries(): number {
+    return this.maxEntries;
+  }
+
+  /** Number of entries currently held for a specific (cwd, envHash) key. */
+  countEntriesForKey(cwd: string, envHash: string): number {
+    const key = makePoolKey(cwd, envHash);
+    let count = 0;
+    for (const entry of this.pool.values()) {
+      if (entry.poolKey === key) count++;
+    }
+    return count;
+  }
+
   dispose(): void {
     if (this.isDisposed) return;
 
@@ -301,8 +415,69 @@ export class PtyPool {
     console.log("[PtyPool] Disposed");
   }
 
-  private getFilteredEnv(): Record<string, string> {
+  /**
+   * If the pool is at the global cap, evict the oldest entry whose key does
+   * NOT match `incomingKey` (so the warm we're about to do actually grows
+   * that key's count). If only same-key entries exist, fall back to evicting
+   * the oldest of those — the slot count for that key stays equal post-warm.
+   */
+  private evictIfAtCapacity(incomingKey: string): void {
+    if (this.pool.size < this.maxEntries) return;
+
+    let victim: { id: string; entry: PooledPty } | null = null;
+    let fallbackVictim: { id: string; entry: PooledPty } | null = null;
+    for (const [id, entry] of this.pool) {
+      if (entry.poolKey !== incomingKey) {
+        if (!victim || entry.createdAt < victim.entry.createdAt) {
+          victim = { id, entry };
+        }
+      } else if (!fallbackVictim || entry.createdAt < fallbackVictim.entry.createdAt) {
+        fallbackVictim = { id, entry };
+      }
+    }
+
+    const chosen = victim ?? fallbackVictim;
+    if (!chosen) return;
+
+    this.pool.delete(chosen.id);
+    try {
+      chosen.entry.dataDisposable.dispose();
+    } catch {
+      // ignore
+    }
+    try {
+      chosen.entry.process.kill();
+    } catch {
+      // already dead
+    }
+
+    if (process.env.DAINTREE_VERBOSE) {
+      console.log(
+        `[PtyPool] Evicted ${chosen.id} (key ${chosen.entry.poolKey}) to make room for ${incomingKey}`
+      );
+    }
+  }
+
+  /**
+   * Build the env that's actually written into the spawned shell. Mirrors
+   * the merge order in terminalSpawn.buildTerminalEnv: filtered process
+   * env, then caller overrides, then UTF-8 / colour normalisation.
+   *
+   * DAINTREE_* metadata is NOT injected here — pool entries don't have
+   * a paneId until acquire time, and the metadata is meaningful only for
+   * the assigned terminal. (Terminals acquired from the pool inherit
+   * whatever the pool warmed; if you need fresh metadata, fall back to
+   * direct spawn.)
+   */
+  private buildSpawnEnv(callerEnv: Record<string, string> | undefined): Record<string, string> {
     const filtered = filterEnvironment(process.env as Record<string, string | undefined>);
+
+    if (callerEnv) {
+      for (const [key, value] of Object.entries(callerEnv)) {
+        if (value === undefined) continue;
+        filtered[key] = value;
+      }
+    }
 
     // TUI reliability: ensure rich terminal capabilities for Claude/Gemini CLIs
     filtered.TERM = "xterm-256color";
@@ -324,6 +499,18 @@ export class PtyPool {
       return poolSize;
     }
     return DEFAULT_POOL_SIZE;
+  }
+
+  private resolveMaxEntries(maxEntries: number | undefined): number {
+    if (
+      typeof maxEntries === "number" &&
+      Number.isInteger(maxEntries) &&
+      Number.isFinite(maxEntries) &&
+      maxEntries > 0
+    ) {
+      return Math.max(maxEntries, this.poolSize);
+    }
+    return Math.max(DEFAULT_MAX_ENTRIES, this.poolSize);
   }
 
   private resolveCwd(cwd: string | undefined, fallback: string): string {

--- a/electron/services/PtyPool.ts
+++ b/electron/services/PtyPool.ts
@@ -3,7 +3,7 @@ import type { IDisposable } from "node-pty";
 import os from "os";
 import { getDefaultShell, getDefaultShellArgs } from "./pty/terminalShell.js";
 import { filterEnvironment, ensureUtf8Locale } from "./pty/EnvironmentFilter.js";
-import { computePoolEnvHash, POOL_ENV_EMPTY_HASH } from "./pty/ptyPoolEnvHash.js";
+import { POOL_ENV_EMPTY_HASH } from "./pty/ptyPoolEnvHash.js";
 
 export interface PtyPoolConfig {
   poolSize?: number;

--- a/electron/services/PtyPool.ts
+++ b/electron/services/PtyPool.ts
@@ -459,9 +459,14 @@ export class PtyPool {
   }
 
   /**
-   * Build the env that's actually written into the spawned shell. Mirrors
-   * the merge order in terminalSpawn.buildTerminalEnv: filtered process
-   * env, then caller overrides, then UTF-8 / colour normalisation.
+   * Build the env that's actually written into the spawned shell.
+   *
+   * Critically, callerEnv is run through `filterEnvironment` here even though
+   * the fresh-spawn path (`buildTerminalEnv` in terminalSpawn.ts) merges it
+   * raw. The pool entry outlives a single acquire — a shell warmed with one
+   * caller's secrets can be handed to a future caller whose hash matches
+   * (because the hash is also computed post-filter). Filtering at warm time
+   * guarantees no secret persists in an idle pool process.
    *
    * DAINTREE_* metadata is NOT injected here — pool entries don't have
    * a paneId until acquire time, and the metadata is meaningful only for
@@ -473,14 +478,14 @@ export class PtyPool {
     const filtered = filterEnvironment(process.env as Record<string, string | undefined>);
 
     if (callerEnv) {
-      for (const [key, value] of Object.entries(callerEnv)) {
-        if (value === undefined) continue;
-        filtered[key] = value;
-      }
+      Object.assign(filtered, filterEnvironment(callerEnv));
     }
 
-    // TUI reliability: ensure rich terminal capabilities for Claude/Gemini CLIs
+    // TUI reliability: ensure rich terminal capabilities for Claude/Gemini CLIs.
+    // Mirrors `buildTerminalEnv` so agent CLIs get the same color-rendering
+    // hints whether they spawn fresh or come out of the pool.
     filtered.TERM = "xterm-256color";
+    filtered.FORCE_COLOR = filtered.FORCE_COLOR ?? "3";
     filtered.COLORTERM = "truecolor";
 
     // Avoid tools treating the environment as CI/non-interactive

--- a/electron/services/__tests__/PtyPool.test.ts
+++ b/electron/services/__tests__/PtyPool.test.ts
@@ -42,6 +42,12 @@ function createFakeProcess(pid: number | "missing" = 100): FakePtyProcess {
   return process;
 }
 
+/**
+ * Wait one microtask tick. `warmForKey` is fire-and-forget, so callers need
+ * to flush the microtask queue before asserting on its side effects.
+ */
+const flushMicrotasks = () => Promise.resolve();
+
 describe("PtyPool", () => {
   const originalShell = process.env.SHELL;
   const originalHome = process.env.HOME;
@@ -72,6 +78,18 @@ describe("PtyPool", () => {
   it("falls back to default pool size when configured pool size is invalid", () => {
     const pool = new PtyPool({ poolSize: -2 });
     expect(pool.getMaxPoolSize()).toBe(2);
+    pool.dispose();
+  });
+
+  it("falls back to default maxEntries when configured value is invalid", () => {
+    const pool = new PtyPool({ poolSize: 2, maxEntries: -1 });
+    expect(pool.getMaxEntries()).toBe(8);
+    pool.dispose();
+  });
+
+  it("ensures maxEntries is at least poolSize", () => {
+    const pool = new PtyPool({ poolSize: 4, maxEntries: 2 });
+    expect(pool.getMaxEntries()).toBe(4);
     pool.dispose();
   });
 
@@ -181,6 +199,7 @@ describe("PtyPool", () => {
 
     const acquired = pool.acquire();
     expect(acquired).toBeNull();
+    await flushMicrotasks();
     expect(spawnMock).toHaveBeenCalledTimes(2);
     expect(pool.getPoolSize()).toBe(1);
     pool.dispose();
@@ -238,5 +257,152 @@ describe("PtyPool", () => {
     const spawnOptions = spawnMock.mock.calls[0]?.[2] as { env?: Record<string, string> };
     expect(spawnOptions.env?.LANG).toBe("en_US.UTF-8");
     pool.dispose();
+  });
+
+  describe("env-keyed acquire", () => {
+    it("acquireByKey hits the pool for the env-empty key after warmPool", async () => {
+      const proc = createFakeProcess(1101);
+      spawnMock.mockReturnValueOnce(proc);
+      const pool = new PtyPool({ poolSize: 1, defaultCwd: "/repo" });
+      await pool.warmPool();
+
+      const acquired = pool.acquireByKey("/repo", "env-empty");
+      expect(acquired).toBe(proc);
+      pool.dispose();
+    });
+
+    it("acquireByKey misses on a different cwd", async () => {
+      spawnMock.mockReturnValueOnce(createFakeProcess(1201));
+      const pool = new PtyPool({ poolSize: 1, defaultCwd: "/repo-a" });
+      await pool.warmPool();
+
+      const acquired = pool.acquireByKey("/repo-b", "env-empty");
+      expect(acquired).toBeNull();
+      pool.dispose();
+    });
+
+    it("acquireByKey misses on a different envHash", async () => {
+      spawnMock.mockReturnValueOnce(createFakeProcess(1301));
+      const pool = new PtyPool({ poolSize: 1, defaultCwd: "/repo" });
+      await pool.warmPool();
+
+      const acquired = pool.acquireByKey("/repo", "env-some-other-hash");
+      expect(acquired).toBeNull();
+      pool.dispose();
+    });
+
+    it("acquireByKey triggers a same-key warm so the next acquire is instant", async () => {
+      const first = createFakeProcess(1401);
+      const second = createFakeProcess(1402);
+      spawnMock.mockReturnValueOnce(first).mockReturnValueOnce(second);
+
+      const pool = new PtyPool({ poolSize: 1, defaultCwd: "/repo" });
+      await pool.warmPool();
+      expect(spawnMock).toHaveBeenCalledTimes(1);
+
+      const acquired = pool.acquireByKey("/repo", "env-empty");
+      expect(acquired).toBe(first);
+
+      // Background warm for the same key fires asynchronously.
+      await flushMicrotasks();
+      expect(spawnMock).toHaveBeenCalledTimes(2);
+      expect(pool.getPoolSize()).toBe(1);
+      pool.dispose();
+    });
+
+    it("warmForKey populates a slot for an arbitrary (cwd, envHash) and a later acquireByKey hits", async () => {
+      const proc = createFakeProcess(1501);
+      spawnMock.mockReturnValueOnce(proc);
+      const pool = new PtyPool({ poolSize: 1, defaultCwd: "/repo" });
+
+      pool.warmForKey("/repo", { ANTHROPIC_BASE_URL: "https://api.example" }, "env-foo");
+      await flushMicrotasks();
+
+      expect(spawnMock).toHaveBeenCalledTimes(1);
+      expect(spawnMock.mock.calls[0]?.[2]).toMatchObject({ cwd: "/repo" });
+
+      // First acquire on a different key (env-empty) misses; the env-foo slot
+      // remains, and a subsequent acquire on env-foo hits.
+      expect(pool.acquireByKey("/repo", "env-empty")).toBeNull();
+      expect(pool.acquireByKey("/repo", "env-foo")).toBe(proc);
+      pool.dispose();
+    });
+
+    it("warmForKey is idempotent under concurrent calls for the same key (no stampede)", async () => {
+      let inFlightResolve: (() => void) | null = null;
+      const inFlightPromise = new Promise<void>((resolve) => {
+        inFlightResolve = resolve;
+      });
+
+      // Make spawn block until we explicitly resolve. Three concurrent
+      // warmForKey calls should still produce only one spawn while the
+      // first is in flight.
+      spawnMock.mockImplementation(() => {
+        return createFakeProcess(1601);
+      });
+
+      const pool = new PtyPool({ poolSize: 2, defaultCwd: "/repo" });
+
+      pool.warmForKey("/repo", undefined, "env-x");
+      pool.warmForKey("/repo", undefined, "env-x");
+      pool.warmForKey("/repo", undefined, "env-x");
+
+      await flushMicrotasks();
+      // Only one spawn for the key, because warmsInFlight blocks duplicates
+      // until the first resolves.
+      expect(spawnMock).toHaveBeenCalledTimes(1);
+
+      inFlightResolve?.();
+      await inFlightPromise;
+      pool.dispose();
+    });
+
+    it("respects the per-key poolSize cap when warming", async () => {
+      spawnMock.mockReturnValue(createFakeProcess(1701));
+      const pool = new PtyPool({ poolSize: 1, defaultCwd: "/repo" });
+
+      pool.warmForKey("/repo", undefined, "env-cap");
+      await flushMicrotasks();
+      // Second call should be a no-op because the per-key cap (poolSize=1)
+      // is already met.
+      pool.warmForKey("/repo", undefined, "env-cap");
+      await flushMicrotasks();
+
+      expect(spawnMock).toHaveBeenCalledTimes(1);
+      pool.dispose();
+    });
+
+    it("evicts an idle entry from a different key when global cap is reached", async () => {
+      // Capture the first three procs so we can identify the victim.
+      const procs = [
+        createFakeProcess(1801),
+        createFakeProcess(1802),
+        createFakeProcess(1803),
+        createFakeProcess(1804),
+      ];
+      let i = 0;
+      spawnMock.mockImplementation(() => procs[i++] ?? createFakeProcess(1899));
+
+      const pool = new PtyPool({ poolSize: 1, defaultCwd: "/repo", maxEntries: 2 });
+
+      pool.warmForKey("/repo", undefined, "env-a");
+      await flushMicrotasks();
+      pool.warmForKey("/repo", undefined, "env-b");
+      await flushMicrotasks();
+
+      expect(pool.getPoolSize()).toBe(2);
+
+      // Third key would breach the global cap; the older env-a entry must
+      // be evicted (killed) before the env-c entry is registered.
+      pool.warmForKey("/repo", undefined, "env-c");
+      await flushMicrotasks();
+
+      expect(pool.getPoolSize()).toBe(2);
+      expect(procs[0]?.kill).toHaveBeenCalledTimes(1);
+      expect(procs[1]?.kill).not.toHaveBeenCalled();
+      // env-c entry is now in the pool
+      expect(pool.acquireByKey("/repo", "env-c")).toBe(procs[2]);
+      pool.dispose();
+    });
   });
 });

--- a/electron/services/__tests__/PtyPool.test.ts
+++ b/electron/services/__tests__/PtyPool.test.ts
@@ -369,7 +369,7 @@ describe("PtyPool", () => {
     });
 
     it("warmForKey is idempotent under concurrent calls for the same key (no stampede)", async () => {
-      let inFlightResolve: (() => void) | null = null;
+      let inFlightResolve!: () => void;
       const inFlightPromise = new Promise<void>((resolve) => {
         inFlightResolve = resolve;
       });
@@ -392,7 +392,7 @@ describe("PtyPool", () => {
       // until the first resolves.
       expect(spawnMock).toHaveBeenCalledTimes(1);
 
-      inFlightResolve?.();
+      inFlightResolve();
       await inFlightPromise;
       pool.dispose();
     });

--- a/electron/services/__tests__/PtyPool.test.ts
+++ b/electron/services/__tests__/PtyPool.test.ts
@@ -230,8 +230,48 @@ describe("PtyPool", () => {
     expect(spawnOptions.env?.CI).toBeUndefined();
     expect(spawnOptions.env?.TERM).toBe("xterm-256color");
     expect(spawnOptions.env?.COLORTERM).toBe("truecolor");
+    expect(spawnOptions.env?.FORCE_COLOR).toBe("3");
     expect(spawnOptions.env?.LANG).toBe("en_US.UTF-8");
     expect(spawnOptions.env?.LC_ALL).toBeUndefined();
+    pool.dispose();
+  });
+
+  it("filters secrets out of caller env before baking into the pool entry", async () => {
+    spawnMock.mockReturnValue(createFakeProcess(411));
+    const pool = new PtyPool({ poolSize: 1, defaultCwd: "/repo" });
+
+    pool.warmForKey(
+      "/repo",
+      {
+        ANTHROPIC_API_KEY: "sk-secret",
+        GITHUB_TOKEN: "ghp-x",
+        OPENAI_API_KEY: "sk-openai",
+        MY_SERVICE_PASSWORD: "pw",
+        FOO: "bar",
+      },
+      "env-empty"
+    );
+    await flushMicrotasks();
+
+    const spawnOptions = spawnMock.mock.calls[0]?.[2] as { env?: Record<string, string> };
+    expect(spawnOptions.env?.ANTHROPIC_API_KEY).toBeUndefined();
+    expect(spawnOptions.env?.GITHUB_TOKEN).toBeUndefined();
+    expect(spawnOptions.env?.OPENAI_API_KEY).toBeUndefined();
+    expect(spawnOptions.env?.MY_SERVICE_PASSWORD).toBeUndefined();
+    expect(spawnOptions.env?.FOO).toBe("bar");
+    pool.dispose();
+  });
+
+  it("preserves caller-supplied non-secret env when warming a key", async () => {
+    spawnMock.mockReturnValue(createFakeProcess(412));
+    const pool = new PtyPool({ poolSize: 1, defaultCwd: "/repo" });
+
+    pool.warmForKey("/repo", { ANTHROPIC_BASE_URL: "https://api.example", ANOTHER: "x" }, "env-x");
+    await flushMicrotasks();
+
+    const spawnOptions = spawnMock.mock.calls[0]?.[2] as { env?: Record<string, string> };
+    expect(spawnOptions.env?.ANTHROPIC_BASE_URL).toBe("https://api.example");
+    expect(spawnOptions.env?.ANOTHER).toBe("x");
     pool.dispose();
   });
 

--- a/electron/services/pty/__tests__/ptyPoolEnvHash.test.ts
+++ b/electron/services/pty/__tests__/ptyPoolEnvHash.test.ts
@@ -1,0 +1,93 @@
+import { describe, it, expect } from "vitest";
+import { computePoolEnvHash, POOL_ENV_EMPTY_HASH, VOLATILE_ENV_KEYS } from "../ptyPoolEnvHash.js";
+
+describe("computePoolEnvHash", () => {
+  it("returns the empty sentinel for undefined input", () => {
+    expect(computePoolEnvHash(undefined)).toBe(POOL_ENV_EMPTY_HASH);
+  });
+
+  it("returns the empty sentinel for an empty object", () => {
+    expect(computePoolEnvHash({})).toBe(POOL_ENV_EMPTY_HASH);
+  });
+
+  it("is deterministic across object key order", () => {
+    const a = computePoolEnvHash({ FOO: "1", BAR: "2", BAZ: "3" });
+    const b = computePoolEnvHash({ BAZ: "3", FOO: "1", BAR: "2" });
+    const c = computePoolEnvHash({ BAR: "2", BAZ: "3", FOO: "1" });
+    expect(a).toBe(b);
+    expect(b).toBe(c);
+  });
+
+  it("produces different hashes for different values", () => {
+    const a = computePoolEnvHash({ FOO: "1" });
+    const b = computePoolEnvHash({ FOO: "2" });
+    expect(a).not.toBe(b);
+  });
+
+  it("produces different hashes for different keys", () => {
+    const a = computePoolEnvHash({ FOO: "1" });
+    const b = computePoolEnvHash({ BAR: "1" });
+    expect(a).not.toBe(b);
+  });
+
+  it("excludes volatile shell-state keys from the hash", () => {
+    const base = computePoolEnvHash({ FOO: "1" });
+    for (const key of VOLATILE_ENV_KEYS) {
+      const withVolatile = computePoolEnvHash({ FOO: "1", [key]: "anything" });
+      expect(withVolatile).toBe(base);
+    }
+  });
+
+  it("returns the empty sentinel when input contains only volatile keys", () => {
+    const onlyVolatile: Record<string, string> = {};
+    for (const key of VOLATILE_ENV_KEYS) {
+      onlyVolatile[key] = "x";
+    }
+    expect(computePoolEnvHash(onlyVolatile)).toBe(POOL_ENV_EMPTY_HASH);
+  });
+
+  it("excludes sensitive secret keys via filterEnvironment", () => {
+    const a = computePoolEnvHash({ FOO: "1" });
+    const b = computePoolEnvHash({
+      FOO: "1",
+      ANTHROPIC_API_KEY: "sk-secret",
+      GITHUB_TOKEN: "ghp-x",
+      MY_SERVICE_TOKEN: "y",
+    });
+    expect(b).toBe(a);
+  });
+
+  it("returns the empty sentinel for env containing only secrets", () => {
+    expect(computePoolEnvHash({ ANTHROPIC_API_KEY: "x", DATABASE_URL: "postgres://" })).toBe(
+      POOL_ENV_EMPTY_HASH
+    );
+  });
+
+  it("excludes DAINTREE_* metadata vars (they're injected fresh per spawn)", () => {
+    const base = computePoolEnvHash({ FOO: "1" });
+    const withMetadata = computePoolEnvHash({
+      FOO: "1",
+      DAINTREE_PANE_ID: "abc",
+      DAINTREE_CWD: "/repo",
+    });
+    expect(withMetadata).toBe(base);
+  });
+
+  it("strips undefined values before hashing", () => {
+    const a = computePoolEnvHash({ FOO: "1" });
+    const b = computePoolEnvHash({ FOO: "1", BAR: undefined });
+    expect(b).toBe(a);
+  });
+
+  it("is sensitive to value length without collisions on adjacent ASCII chars", () => {
+    const a = computePoolEnvHash({ FOO: "ab" });
+    const b = computePoolEnvHash({ FOO: "ba" });
+    expect(a).not.toBe(b);
+  });
+
+  it("returns a hash with the env- prefix", () => {
+    const hash = computePoolEnvHash({ FOO: "1", BAR: "2" });
+    expect(hash).toMatch(/^env-/);
+    expect(hash).not.toBe(POOL_ENV_EMPTY_HASH);
+  });
+});

--- a/electron/services/pty/__tests__/terminalSpawn.pool.test.ts
+++ b/electron/services/pty/__tests__/terminalSpawn.pool.test.ts
@@ -168,6 +168,27 @@ describe("acquirePtyProcess pool handling", () => {
     expect(acquireByKey.mock.calls[0]?.[1]).toBe(acquireByKey.mock.calls[1]?.[1]);
   });
 
+  it("on miss, passes the same envHash to acquireByKey and warmForKey", () => {
+    const acquireByKey = vi.fn(() => null);
+    const warmForKey = vi.fn();
+    const pool = createFakePool({
+      defaultCwd: "/repo",
+      acquireByKey,
+      warmForKey,
+    });
+    spawnMock.mockReturnValue({ fake: "pty" });
+
+    const callerEnv = { FOO: "1", BAR: "2" };
+    acquirePtyProcess("p", { ...baseOptions, env: callerEnv }, {}, "/bin/bash", [], pool, () => {});
+
+    expect(acquireByKey).toHaveBeenCalledTimes(1);
+    expect(warmForKey).toHaveBeenCalledTimes(1);
+    // Same hash on the lookup side and the warm side — guarantees the
+    // background warm actually populates the slot the next acquire will
+    // look up.
+    expect(acquireByKey.mock.calls[0]?.[1]).toBe(warmForKey.mock.calls[0]?.[2]);
+  });
+
   it("falls back to direct spawn when pool is null", () => {
     const spawnedPty = { fake: "pty" };
     spawnMock.mockReturnValue(spawnedPty);

--- a/electron/services/pty/__tests__/terminalSpawn.pool.test.ts
+++ b/electron/services/pty/__tests__/terminalSpawn.pool.test.ts
@@ -23,10 +23,19 @@ function createFakePooledPty(): FakePooledPty {
   };
 }
 
-function createFakePool(overrides: { defaultCwd: string; acquire: () => unknown }): PtyPool {
+interface FakePoolOpts {
+  defaultCwd: string;
+  acquireByKey?: (cwd: string, envHash: string) => unknown;
+  acquire?: () => unknown;
+  warmForKey?: (cwd: string, env: Record<string, string> | undefined, envHash: string) => void;
+}
+
+function createFakePool(opts: FakePoolOpts): PtyPool {
   return {
-    acquire: overrides.acquire,
-    getDefaultCwd: () => overrides.defaultCwd,
+    acquire: opts.acquire ?? vi.fn(() => null),
+    acquireByKey: opts.acquireByKey ?? vi.fn(() => null),
+    warmForKey: opts.warmForKey ?? vi.fn(),
+    getDefaultCwd: () => opts.defaultCwd,
   } as unknown as PtyPool;
 }
 
@@ -36,20 +45,24 @@ const baseOptions: PtySpawnOptions = {
   rows: 24,
 };
 
-describe("acquirePtyProcess pool handling (issue #5097)", () => {
+describe("acquirePtyProcess pool handling", () => {
   beforeEach(() => {
     spawnMock.mockReset();
   });
 
-  it("acquires a pooled PTY when the pool's default cwd matches options.cwd", () => {
+  it("acquires a pooled PTY when an env-keyed slot is available for the request cwd", () => {
     const pooled = createFakePooledPty();
+    const acquireByKey = vi.fn(() => pooled);
     const pool = createFakePool({
       defaultCwd: "/repo",
-      acquire: vi.fn(() => pooled),
+      acquireByKey,
     });
 
     const result = acquirePtyProcess("t1", baseOptions, {}, "/bin/bash", [], pool, () => {});
 
+    expect(acquireByKey).toHaveBeenCalledTimes(1);
+    expect(acquireByKey.mock.calls[0]?.[0]).toBe("/repo");
+    expect(typeof acquireByKey.mock.calls[0]?.[1]).toBe("string");
     expect(result).toBe(pooled);
     expect(spawnMock).not.toHaveBeenCalled();
   });
@@ -58,7 +71,7 @@ describe("acquirePtyProcess pool handling (issue #5097)", () => {
     const pooled = createFakePooledPty();
     const pool = createFakePool({
       defaultCwd: "/repo",
-      acquire: vi.fn(() => pooled),
+      acquireByKey: vi.fn(() => pooled),
     });
 
     acquirePtyProcess("t1", baseOptions, {}, "/bin/bash", [], pool, () => {});
@@ -73,11 +86,13 @@ describe("acquirePtyProcess pool handling (issue #5097)", () => {
     expect(pooled.write).not.toHaveBeenCalled();
   });
 
-  it("skips the pool and falls back to direct spawn when pool cwd doesn't match request", () => {
-    const acquire = vi.fn();
+  it("falls back to direct spawn when the pool has no entry for the (cwd, envHash) key", () => {
+    const acquireByKey = vi.fn(() => null);
+    const warmForKey = vi.fn();
     const pool = createFakePool({
       defaultCwd: "/repo-a",
-      acquire,
+      acquireByKey,
+      warmForKey,
     });
     const spawnedPty = { fake: "pty" };
     spawnMock.mockReturnValue(spawnedPty);
@@ -92,11 +107,65 @@ describe("acquirePtyProcess pool handling (issue #5097)", () => {
       () => {}
     );
 
-    // Pool was NOT consulted — acquire() must not be called when cwd mismatches.
-    expect(acquire).not.toHaveBeenCalled();
+    // Pool was consulted with the requested cwd, missed, and a background
+    // warm was kicked off so the next spawn with the same shape hits the pool.
+    expect(acquireByKey).toHaveBeenCalledTimes(1);
+    expect(acquireByKey.mock.calls[0]?.[0]).toBe("/repo-b");
+    expect(warmForKey).toHaveBeenCalledTimes(1);
+    expect(warmForKey.mock.calls[0]?.[0]).toBe("/repo-b");
     expect(spawnMock).toHaveBeenCalledTimes(1);
     expect(spawnMock.mock.calls[0]?.[2]).toMatchObject({ cwd: "/repo-b" });
     expect(result).toBe(spawnedPty);
+  });
+
+  it("computes distinct envHash keys for differing options.env, isolating pool slots", () => {
+    const acquireByKey = vi.fn(() => null);
+    const pool = createFakePool({
+      defaultCwd: "/repo",
+      acquireByKey,
+    });
+    spawnMock.mockReturnValue({ fake: "pty" });
+
+    acquirePtyProcess(
+      "a",
+      { ...baseOptions, env: { FOO: "1" } },
+      {},
+      "/bin/bash",
+      [],
+      pool,
+      () => {}
+    );
+    acquirePtyProcess(
+      "b",
+      { ...baseOptions, env: { FOO: "2" } },
+      {},
+      "/bin/bash",
+      [],
+      pool,
+      () => {}
+    );
+    acquirePtyProcess("c", baseOptions, {}, "/bin/bash", [], pool, () => {});
+
+    const envHashes = acquireByKey.mock.calls.map((c) => c[1]);
+    // Three different env shapes → three distinct hashes
+    const unique = new Set(envHashes);
+    expect(unique.size).toBe(3);
+  });
+
+  it("uses the same envHash for the same options.env shape", () => {
+    const acquireByKey = vi.fn(() => null);
+    const pool = createFakePool({
+      defaultCwd: "/repo",
+      acquireByKey,
+    });
+    spawnMock.mockReturnValue({ fake: "pty" });
+
+    const env1 = { FOO: "1", BAR: "2" };
+    const env2 = { BAR: "2", FOO: "1" }; // same content, different key order
+    acquirePtyProcess("a", { ...baseOptions, env: env1 }, {}, "/bin/bash", [], pool, () => {});
+    acquirePtyProcess("b", { ...baseOptions, env: env2 }, {}, "/bin/bash", [], pool, () => {});
+
+    expect(acquireByKey.mock.calls[0]?.[1]).toBe(acquireByKey.mock.calls[1]?.[1]);
   });
 
   it("falls back to direct spawn when pool is null", () => {
@@ -107,5 +176,58 @@ describe("acquirePtyProcess pool handling (issue #5097)", () => {
 
     expect(spawnMock).toHaveBeenCalledTimes(1);
     expect(result).toBe(spawnedPty);
+  });
+
+  it("skips the pool entirely for dev-preview panes", () => {
+    const acquireByKey = vi.fn();
+    const pool = createFakePool({
+      defaultCwd: "/repo",
+      acquireByKey,
+    });
+    spawnMock.mockReturnValue({ fake: "pty" });
+
+    acquirePtyProcess(
+      "dp1",
+      { ...baseOptions, kind: "dev-preview" },
+      {},
+      "/bin/bash",
+      [],
+      pool,
+      () => {}
+    );
+
+    expect(acquireByKey).not.toHaveBeenCalled();
+    expect(spawnMock).toHaveBeenCalledTimes(1);
+  });
+
+  it("skips the pool when caller provides a custom shell or args", () => {
+    const acquireByKey = vi.fn();
+    const pool = createFakePool({
+      defaultCwd: "/repo",
+      acquireByKey,
+    });
+    spawnMock.mockReturnValue({ fake: "pty" });
+
+    acquirePtyProcess(
+      "x1",
+      { ...baseOptions, shell: "/bin/zsh" },
+      {},
+      "/bin/zsh",
+      [],
+      pool,
+      () => {}
+    );
+    acquirePtyProcess(
+      "x2",
+      { ...baseOptions, args: ["-l"] },
+      {},
+      "/bin/bash",
+      ["-l"],
+      pool,
+      () => {}
+    );
+
+    expect(acquireByKey).not.toHaveBeenCalled();
+    expect(spawnMock).toHaveBeenCalledTimes(2);
   });
 });

--- a/electron/services/pty/__tests__/terminalSpawn.pool.test.ts
+++ b/electron/services/pty/__tests__/terminalSpawn.pool.test.ts
@@ -32,9 +32,11 @@ interface FakePoolOpts {
 
 function createFakePool(opts: FakePoolOpts): PtyPool {
   return {
-    acquire: opts.acquire ?? vi.fn(() => null),
-    acquireByKey: opts.acquireByKey ?? vi.fn(() => null),
-    warmForKey: opts.warmForKey ?? vi.fn(),
+    acquire: opts.acquire ?? vi.fn<() => unknown>(() => null),
+    acquireByKey: opts.acquireByKey ?? vi.fn<(cwd: string, envHash: string) => unknown>(() => null),
+    warmForKey:
+      opts.warmForKey ??
+      vi.fn<(cwd: string, env: Record<string, string> | undefined, envHash: string) => void>(),
     getDefaultCwd: () => opts.defaultCwd,
   } as unknown as PtyPool;
 }
@@ -52,7 +54,7 @@ describe("acquirePtyProcess pool handling", () => {
 
   it("acquires a pooled PTY when an env-keyed slot is available for the request cwd", () => {
     const pooled = createFakePooledPty();
-    const acquireByKey = vi.fn(() => pooled);
+    const acquireByKey = vi.fn<(cwd: string, envHash: string) => FakePooledPty>(() => pooled);
     const pool = createFakePool({
       defaultCwd: "/repo",
       acquireByKey,
@@ -87,8 +89,9 @@ describe("acquirePtyProcess pool handling", () => {
   });
 
   it("falls back to direct spawn when the pool has no entry for the (cwd, envHash) key", () => {
-    const acquireByKey = vi.fn(() => null);
-    const warmForKey = vi.fn();
+    const acquireByKey = vi.fn<(cwd: string, envHash: string) => null>(() => null);
+    const warmForKey =
+      vi.fn<(cwd: string, env: Record<string, string> | undefined, envHash: string) => void>();
     const pool = createFakePool({
       defaultCwd: "/repo-a",
       acquireByKey,
@@ -119,7 +122,7 @@ describe("acquirePtyProcess pool handling", () => {
   });
 
   it("computes distinct envHash keys for differing options.env, isolating pool slots", () => {
-    const acquireByKey = vi.fn(() => null);
+    const acquireByKey = vi.fn<(cwd: string, envHash: string) => null>(() => null);
     const pool = createFakePool({
       defaultCwd: "/repo",
       acquireByKey,
@@ -153,7 +156,7 @@ describe("acquirePtyProcess pool handling", () => {
   });
 
   it("uses the same envHash for the same options.env shape", () => {
-    const acquireByKey = vi.fn(() => null);
+    const acquireByKey = vi.fn<(cwd: string, envHash: string) => null>(() => null);
     const pool = createFakePool({
       defaultCwd: "/repo",
       acquireByKey,
@@ -169,8 +172,9 @@ describe("acquirePtyProcess pool handling", () => {
   });
 
   it("on miss, passes the same envHash to acquireByKey and warmForKey", () => {
-    const acquireByKey = vi.fn(() => null);
-    const warmForKey = vi.fn();
+    const acquireByKey = vi.fn<(cwd: string, envHash: string) => null>(() => null);
+    const warmForKey =
+      vi.fn<(cwd: string, env: Record<string, string> | undefined, envHash: string) => void>();
     const pool = createFakePool({
       defaultCwd: "/repo",
       acquireByKey,

--- a/electron/services/pty/ptyPoolEnvHash.ts
+++ b/electron/services/pty/ptyPoolEnvHash.ts
@@ -1,0 +1,51 @@
+import { filterEnvironment } from "./EnvironmentFilter.js";
+
+/**
+ * Volatile env keys that change with shell session state but don't change the
+ * effective execution environment. Excluded from the pool key so that two
+ * spawns whose only differences are these keys still share a pool slot.
+ */
+export const VOLATILE_ENV_KEYS: ReadonlySet<string> = new Set(["SHLVL", "PWD", "OLDPWD", "_"]);
+
+const EMPTY_HASH = "env-empty";
+
+/**
+ * Stable identifier for a pool slot keyed by env. Two calls with the same
+ * post-filter env additions (modulo volatile keys) return the same string.
+ *
+ * The hash runs over the post-`filterEnvironment` view because that's what
+ * actually reaches the child process — secrets are stripped before hashing,
+ * so two callers that differ only in stripped-away secrets share a slot
+ * (correct: stripped secrets never reach the pre-warmed shell).
+ */
+export function computePoolEnvHash(env: Record<string, string | undefined> | undefined): string {
+  if (!env) {
+    return EMPTY_HASH;
+  }
+
+  const filtered = filterEnvironment(env);
+  const entries: string[] = [];
+  for (const [key, value] of Object.entries(filtered)) {
+    if (VOLATILE_ENV_KEYS.has(key)) continue;
+    entries.push(`${key}=${value}`);
+  }
+
+  if (entries.length === 0) {
+    return EMPTY_HASH;
+  }
+
+  entries.sort();
+
+  let hash = 5381;
+  for (const entry of entries) {
+    for (let i = 0; i < entry.length; i++) {
+      hash = ((hash << 5) + hash + entry.charCodeAt(i)) | 0;
+    }
+    hash = ((hash << 5) + hash + 10) | 0;
+  }
+
+  const u32 = hash >>> 0;
+  return `env-${u32.toString(36)}`;
+}
+
+export const POOL_ENV_EMPTY_HASH = EMPTY_HASH;

--- a/electron/services/pty/terminalSpawn.ts
+++ b/electron/services/pty/terminalSpawn.ts
@@ -6,6 +6,7 @@ import {
   ensureUtf8Locale,
 } from "./EnvironmentFilter.js";
 import { getDefaultShell, getDefaultShellArgs } from "./terminalShell.js";
+import { computePoolEnvHash } from "./ptyPoolEnvHash.js";
 import type { PtySpawnOptions } from "./types.js";
 import type { PtyPool } from "../PtyPool.js";
 
@@ -104,20 +105,16 @@ export function acquirePtyProcess(
   ptyPool: PtyPool | null,
   onWriteError: (error: unknown, context: { operation: string }) => void
 ): pty.IPty {
-  // The pool is a global singleton pre-warmed at whichever project most
-  // recently called drainAndRefill(). In multi-window setups a different
-  // window may have drained the pool to a different cwd, so skip the pool
-  // when its current cwd doesn't match the caller's request — the direct
-  // pty.spawn below will honour options.cwd via node-pty's kernel chdir.
-  const poolCwdMatches = ptyPool ? ptyPool.getDefaultCwd() === options.cwd : false;
-  const canUsePool =
-    ptyPool &&
-    poolCwdMatches &&
-    !options.shell &&
-    !options.env &&
-    !options.args &&
-    options.kind !== "dev-preview";
-  let pooledPty = canUsePool ? ptyPool!.acquire() : null;
+  // The pool is a global singleton; entries are keyed by (cwd, envHash).
+  // We can hit the pool whenever the pool exists and the request is a plain
+  // shell launch (no custom shell/args, not a dev-preview pane). The env-hash
+  // lookup handles cases where another window pre-warmed at a different cwd
+  // or with different env additions — those entries simply don't match the
+  // wanted key and we fall through to fresh spawn + background warm.
+  const canUsePool = !!ptyPool && !options.shell && !options.args && options.kind !== "dev-preview";
+  const envHash = canUsePool ? computePoolEnvHash(options.env) : null;
+  let pooledPty =
+    canUsePool && envHash !== null ? ptyPool!.acquireByKey(options.cwd, envHash) : null;
   // Suppress unused-parameter lint for the write-error callback; kept in the
   // signature so future pool-acquisition logic (e.g. agent-preamble writes) can
   // still report through the same channel.
@@ -154,6 +151,13 @@ export function acquirePtyProcess(
     }
 
     return pooledPty;
+  }
+
+  // Pool miss — kick off a background warm for this exact (cwd, envHash) key
+  // so the next spawn with the same shape hits the pool. The fresh spawn
+  // below proceeds in parallel; the warm is fire-and-forget.
+  if (canUsePool && envHash !== null) {
+    ptyPool!.warmForKey(options.cwd, options.env, envHash);
   }
 
   try {


### PR DESCRIPTION
## Summary

`PtyPool` was pre-warming shells but `canUsePool` rejected any spawn carrying `options.env` — and every agent launch carries one — so the pool was dead weight for the exact use case it was built for.

This fixes that by keying the pool on `(cwd, envHash)` so agent launches can actually hit it. The hash runs over the post-`filterEnvironment` view of `options.env`, so secrets never bake into idle shells and don't fragment the pool.

Resolves #7618.

## Changes

- New `(cwd, envHash)` pool key; `acquireByKey` and `warmForKey` on `PtyPool`
- On a miss, `terminalSpawn` falls through to a fresh spawn and fires a background warm so the next launch with the same env shape hits the pool
- Global `maxEntries` cap (default 8) with LRU eviction across keys; eviction prefers non-incoming keys so the warm we just triggered actually lands
- In-flight warm guard prevents stampede on concurrent same-key misses
- `onExit` skips refill when the entry has already been removed (drain, evict, or acquire path), preserving the "refill on unexpected exit" semantic for live entries only
- `buildSpawnEnv` filters `callerEnv` before baking into the pool entry and sets `FORCE_COLOR=3` to match the fresh-spawn path

## Testing

- `npx vitest run electron/services/__tests__/PtyPool.test.ts electron/services/pty/__tests__/` — 46 targeted tests pass
- Full pty test suite: 4772 tests pass
- `npx tsc --noEmit` clean
- `npm run check` (typecheck + channels + help + lint:ratchet + format:check) — all 5 pass

Manual verification (suggested for reviewer):
- Launch the same agent preset twice in the same project; confirm `[PtyPool] Acquired PTY ... from pool (instant spawn)` appears on the second launch (with `DAINTREE_VERBOSE=1`)
- Launch two agents with different `options.env` shapes; each should populate its own pool slot, no cross-env contamination
- Switch projects; old `cwd` entries are drained (existing `drainAndRefill` behaviour), new `cwd` warms the `env-empty` slot