### PR TITLE
fix(e2e): gate refreshActiveWindow on sidebar DOM attachment

### DIFF
--- a/e2e/helpers/launch.ts
+++ b/e2e/helpers/launch.ts
@@ -407,12 +407,9 @@ export async function refreshActiveWindow(app: ElectronApplication, oldPage?: Pa
     .locator('[aria-label="Toggle Sidebar"]')
     .waitFor({ state: "visible", timeout: refreshTimeout });
 
-  // Wait for the sidebar element to appear in the DOM. AppLayout only mounts
-  // <Sidebar> when currentProject != null, so this guards against returning
-  // before the IPC loadCurrentProject call resolves. Without this gate the
-  // worktree wait below times out (no sidebar = no worktree cards), and the
-  // previous "Loading worktrees..." fallback was a no-op because that text is
-  // sr-only in the Skeleton component and was never found by the locator.
+  // <Sidebar> mounts only after currentProject hydrates — best-effort gate
+  // before the worktree poll. Use attached not visible: a gesture-hidden
+  // sidebar is aria-hidden/inert but still in the DOM.
   await newWindow
     .locator('aside[aria-label="Sidebar"]')
     .waitFor({ state: "attached", timeout: refreshTimeout })

--- a/e2e/helpers/launch.ts
+++ b/e2e/helpers/launch.ts
@@ -407,25 +407,28 @@ export async function refreshActiveWindow(app: ElectronApplication, oldPage?: Pa
     .locator('[aria-label="Toggle Sidebar"]')
     .waitFor({ state: "visible", timeout: refreshTimeout });
 
+  // Wait for the sidebar element to appear in the DOM. AppLayout only mounts
+  // <Sidebar> when currentProject != null, so this guards against returning
+  // before the IPC loadCurrentProject call resolves. Without this gate the
+  // worktree wait below times out (no sidebar = no worktree cards), and the
+  // previous "Loading worktrees..." fallback was a no-op because that text is
+  // sr-only in the Skeleton component and was never found by the locator.
+  await newWindow
+    .locator('aside[aria-label="Sidebar"]')
+    .waitFor({ state: "attached", timeout: refreshTimeout })
+    .catch(() => {});
+
   // Wait for the project's active worktree to finish loading. Without this,
   // shortcuts like Cmd+Alt+T fire with `activeWorktreeId=undefined`, which
   // creates an orphan panel that never renders (worktree-filtered out) — the
   // root cause of the original "Cmd+Alt+T opens a new terminal" flake.
-  // The worktree sidebar heading stops showing "Loading worktrees..." once
-  // the first worktree entry is in the DOM.
   await newWindow
     .locator(
       '[data-worktree-branch], [data-worktree-is-main="true"], [aria-label="Worktrees"] a, [aria-label="Worktrees"] [role="button"], .worktree-item'
     )
     .first()
     .waitFor({ state: "attached", timeout: refreshTimeout })
-    .catch(async () => {
-      // Fallback: just wait for the loading text to disappear.
-      await newWindow
-        .locator("text=Loading worktrees...")
-        .waitFor({ state: "hidden", timeout: refreshTimeout })
-        .catch(() => {});
-    });
+    .catch(() => {});
 
   // After WebContentsView creation, the new view's renderer may not receive
   // keyboard events from Playwright's CDP `Input.dispatchKeyEvent` until the


### PR DESCRIPTION
Fixes #7624

## Summary

- `AppLayout` only mounts `<Sidebar>` when `currentProject != null`; without a
  gate, `refreshActiveWindow` returned before the IPC `loadCurrentProject` call
  resolved
- The previous `text=Loading worktrees...` fallback was a no-op: `Skeleton`
  renders that text as sr-only without "..." so the locator never matched and
  `waitFor({ state: "hidden" })` resolved immediately
- Add `aside[aria-label="Sidebar"]` attached-wait between the Toggle Sidebar
  check and the worktree poll — sidebar mounts only when `currentProject != null`,
  so this reliably blocks until the project is loaded
- Remove the broken fallback (replace with no-op catch)

## Affected tests (sample)

- `e2e/core/core-persistence.spec.ts` — project switcher showed "Open project"
- `e2e/core/core-worktree-lifecycle.spec.ts` — `[data-worktree-branch]` not found
- `e2e/full/core-terminal-panels.spec.ts` — worktree dashboard not appearing
- Dozens more `e2e/full/` specs with the same root failure

## Test plan

- [ ] `npx playwright test e2e/core/core-persistence.spec.ts` — "previously onboarded project appears after restart" passes
- [ ] `npx playwright test e2e/core/core-worktree-lifecycle.spec.ts` — "main worktree card is visible and selected" passes
- [ ] `npx playwright test e2e/full/core-terminal-panels.spec.ts` — "worktree dashboard appears with at least one card" passes