### PR TITLE
fix(terminal): fix broadcast and scroll pill overlap

### DIFF
--- a/src/components/Fleet/FleetDraftingPill.tsx
+++ b/src/components/Fleet/FleetDraftingPill.tsx
@@ -58,7 +58,7 @@ export function FleetDraftingPill(): ReactElement | null {
         </PopoverTrigger>
         <PopoverContent
           side="bottom"
-          align="end"
+          align="start"
           sideOffset={4}
           data-testid="fleet-resolution-popover"
           className="max-h-[320px] w-[360px] overflow-y-auto p-1"

--- a/src/components/Fleet/FleetDraftingPill.tsx
+++ b/src/components/Fleet/FleetDraftingPill.tsx
@@ -27,7 +27,7 @@ export function FleetDraftingPill(): ReactElement | null {
   };
 
   return (
-    <div data-testid="fleet-drafting-pill" className="flex items-center text-[11px]">
+    <div data-testid="fleet-drafting-pill" className="flex items-center">
       <Popover open={open} onOpenChange={handleOpenChange}>
         <PopoverTrigger asChild>
           <button
@@ -35,18 +35,22 @@ export function FleetDraftingPill(): ReactElement | null {
             aria-label={`Drafting for ${fleetSize} agents`}
             data-testid="fleet-drafting-pill-trigger"
             className={cn(
-              "inline-flex items-center gap-1 rounded-full px-2 py-0.5 transition-colors",
-              "bg-category-amber-subtle text-category-amber-text",
+              "inline-flex items-center gap-1.5 px-3 py-1.5 rounded-full",
+              "bg-category-amber-subtle border border-category-amber-border text-category-amber-text shadow-[var(--theme-shadow-floating)]",
+              "text-xs font-medium transition-colors",
               hasVariables && "cursor-pointer hover:bg-category-amber-subtle/80"
             )}
           >
-            <RadioTower className="h-3 w-3" aria-hidden="true" />
+            <RadioTower className="h-3.5 w-3.5" aria-hidden="true" />
             <span>
               Mirroring to {peerCount} {peerCount === 1 ? "peer" : "peers"}
             </span>
             {hasVariables && (
               <ChevronDown
-                className={cn("h-3 w-3 transition-transform duration-150", open && "rotate-180")}
+                className={cn(
+                  "h-3.5 w-3.5 transition-transform duration-150",
+                  open && "rotate-180"
+                )}
                 aria-hidden="true"
               />
             )}

--- a/src/components/Terminal/HybridInputBar.tsx
+++ b/src/components/Terminal/HybridInputBar.tsx
@@ -24,7 +24,6 @@ import { useCommandStore } from "@/store/commandStore";
 import { useProjectStore } from "@/store/projectStore";
 import { usePanelStore, useVoiceRecordingStore } from "@/store";
 import { useFleetArmingStore } from "@/store/fleetArmingStore";
-import { FleetDraftingPill } from "@/components/Fleet/FleetDraftingPill";
 import { tryFleetBroadcastFromEditor } from "@/components/Fleet/fleetEnterBroadcast";
 
 import { useWorktreeStore } from "@/hooks/useWorktreeStore";
@@ -712,13 +711,6 @@ export const HybridInputBar = forwardRef<HybridInputBarHandle, HybridInputBarPro
         className="relative group cursor-text px-3.5 pb-2.5 pt-2.5"
         style={{ backgroundColor: inputBarColors.background, ...shellVars }}
       >
-        {isFleetPrimary && (
-          <div className="pointer-events-none absolute bottom-full right-3.5 mb-1 flex items-center gap-2">
-            <div className="pointer-events-auto">
-              <FleetDraftingPill />
-            </div>
-          </div>
-        )}
         <div className="flex items-end gap-2">
           <div
             ref={inputShellRef}

--- a/src/components/Terminal/TerminalPane.tsx
+++ b/src/components/Terminal/TerminalPane.tsx
@@ -14,6 +14,7 @@ import { ArtifactOverlay } from "./ArtifactOverlay";
 
 import { TerminalSearchBar } from "./TerminalSearchBar";
 import { TerminalScrollIndicator } from "./TerminalScrollIndicator";
+import { FleetDraftingPill } from "@/components/Fleet/FleetDraftingPill";
 import { TerminalRestartStatusBanner } from "./TerminalRestartStatusBanner";
 import { getRestartBannerVariant } from "./restartStatus";
 import { TerminalErrorBanner } from "./TerminalErrorBanner";
@@ -246,6 +247,7 @@ function TerminalPaneComponent({
   // is suppressed on a single-armed seed selection because nothing fans out
   // until a second pane joins.
   const isFleetFollower = isArmed && !isFocused && armedIds.size >= 2;
+  const isFleetPrimary = isArmed && isFocused && armedIds.size >= 2;
 
   // Consolidate terminal state selectors to avoid multiple scans and ensure consistent snapshots
   const terminalState = usePanelStore(
@@ -915,6 +917,14 @@ function TerminalPaneComponent({
               </div>
 
               <TerminalScrollIndicator terminalId={id} />
+
+              {isFleetPrimary && (
+                <div className="absolute inset-0 z-30 pointer-events-none flex items-end justify-start pb-4 pl-[14px]">
+                  <div className="pointer-events-auto">
+                    <FleetDraftingPill />
+                  </div>
+                </div>
+              )}
 
               {(isBackendDisconnected || isBackendRecovering) && (
                 <div


### PR DESCRIPTION
## Summary

The broadcast pill and scroll-down pill were rendering in different coordinate systems, so when both were visible they'd overlap and look inconsistent. Moved `FleetDraftingPill` from `HybridInputBar`'s input overlay into `TerminalPane`'s viewport overlay — the same layer the scroll indicator already lives in. Broadcast is now anchored bottom-left, scroll stays bottom-right, and they can never collide.

Unified the visual tokens between the two pills while I was in there (`text-xs px-3 py-1.5 rounded-full` + `border` + `shadow-[var(--theme-shadow-floating)]`). They were using slightly different sizing and shadows, which made them look like they came from different parts of the UI.

Also flipped the `FleetDraftingPill` popover from `align="end"` to `align="start"` so the variables popover opens rightward into the terminal rather than off-screen left.

Resolves #7636

## Changes

- `TerminalPane.tsx` — add `FleetDraftingPill` to the viewport overlay, bottom-left anchor
- `HybridInputBar.tsx` — remove `FleetDraftingPill` from the input overlay
- `FleetDraftingPill.tsx` — unify pill tokens with scroll indicator; flip popover to `align="start"`

## Testing

- `tsc --noEmit` clean
- Targeted vitest: `fleetResolutionPreview`, `TerminalScrollIndicator`, `HybridInputBar.shortcuts` all green
- Manually verified both pills visible simultaneously with no overlap, popover opens correctly