### PR TITLE
feat(help-panel): first-launch links and title-bar help icon (#7628)

### DIFF
--- a/src/components/HelpPanel/HelpPanel.tsx
+++ b/src/components/HelpPanel/HelpPanel.tsx
@@ -1,5 +1,14 @@
 import { Suspense, useCallback, useEffect, useRef, useState, useMemo } from "react";
-import { Settings2, ChevronRight, Plus, X, ShieldAlert, History } from "lucide-react";
+import {
+  Settings2,
+  ChevronRight,
+  Plus,
+  X,
+  ShieldAlert,
+  History,
+  CircleHelp,
+  ExternalLink,
+} from "lucide-react";
 import * as semver from "semver";
 import { cn } from "@/lib/utils";
 import { DaintreeIcon } from "@/components/icons/DaintreeIcon";
@@ -41,12 +50,7 @@ const RESIZE_STEP = 10;
 const RESIZE_PAGE_STEP = 50;
 
 const DAINTREE_HOME_URL = "https://daintree.org";
-
-const SEED_PROMPTS = [
-  "Explain this codebase to me",
-  "Review my recent changes",
-  "Help me debug an issue",
-] as const;
+const ASSISTANT_DOCS_URL = "https://daintree.org/assistant";
 
 const HIBERNATE_VALID_MINUTES: readonly number[] = [0, 15, 30, 60, 120];
 const DEFAULT_HIBERNATE_MINUTES = 30;
@@ -1366,26 +1370,13 @@ export function HelpPanel({
     void actionService.dispatch("app.settings.openTab", { tab: "assistant" }, { source: "user" });
   }, []);
 
-  // Picks the agent to launch when a seed-prompt chip is clicked. Falls back to
-  // the single installed assistant-supported agent when the user hasn't picked
-  // a preference yet — matches the auto-launch effect's resolution rule. Returns
-  // null only when zero supported agents are installed; in that state the chips
-  // are inert and the user is steered to the bottom settings link.
-  const seedAgentToLaunch = preferredAgentId
-    ? preferredAgentId
-    : supportedInstalledAgentIds.length === 1
-      ? (supportedInstalledAgentIds[0] ?? null)
-      : null;
-
-  const handleSeedPromptClick = useCallback(
-    (prompt: string) => {
-      if (!seedAgentToLaunch) return;
-      safeFireAndForget(handleSelectAgent(seedAgentToLaunch, prompt), {
-        context: "HelpPanel: seed-prompt chip launch",
-      });
-    },
-    [seedAgentToLaunch, handleSelectAgent]
-  );
+  const handleOpenAssistantDocs = useCallback(() => {
+    void actionService.dispatch(
+      "system.openExternal",
+      { url: ASSISTANT_DOCS_URL },
+      { source: "user" }
+    );
+  }, []);
 
   const dismissTierMismatch = useCallback(() => {
     setTierMismatch(null);
@@ -1647,6 +1638,14 @@ export function HelpPanel({
             Daintree Assistant
           </span>
         </div>
+        <button
+          type="button"
+          onClick={handleOpenAssistantDocs}
+          className="p-1 rounded-[var(--radius-sm)] text-daintree-text/50 hover:text-daintree-text hover:bg-tint/8 transition-colors focus-visible:outline focus-visible:outline-2 focus-visible:outline-daintree-accent focus-visible:outline-offset-2"
+          aria-label="Open assistant docs"
+        >
+          <CircleHelp className="w-3.5 h-3.5" />
+        </button>
         {terminalId && agentId && (
           <button
             type="button"
@@ -1851,26 +1850,25 @@ export function HelpPanel({
         ) : (
           <div className="flex-1 flex flex-col items-center justify-center gap-6 p-8 text-center">
             <p className="text-sm text-daintree-text/70 max-w-[30ch]">
-              Ask the assistant to explain code, review changes, or debug issues.
+              Use Daintree Assistant to configure and navigate Daintree.
             </p>
-            <div className="flex flex-col gap-2 w-full max-w-[28ch]">
-              {SEED_PROMPTS.map((prompt) => (
-                <button
-                  key={prompt}
-                  type="button"
-                  onClick={() => handleSeedPromptClick(prompt)}
-                  disabled={!seedAgentToLaunch}
-                  className={cn(
-                    "w-full px-3 py-1.5 rounded-[var(--radius-md)] text-xs text-left",
-                    "border border-daintree-border text-daintree-text/80",
-                    "hover:bg-overlay-soft hover:text-daintree-text transition-colors",
-                    "focus-visible:outline focus-visible:outline-2 focus-visible:outline-daintree-accent focus-visible:outline-offset-2",
-                    "disabled:opacity-50 disabled:cursor-not-allowed disabled:hover:bg-transparent disabled:hover:text-daintree-text/80"
-                  )}
-                >
-                  {prompt}
-                </button>
-              ))}
+            <div className="flex flex-col gap-2">
+              <button
+                type="button"
+                onClick={handleOpenSettings}
+                className="flex items-center gap-1 text-[11px] text-daintree-text/40 hover:text-daintree-text/60 transition-colors focus-visible:outline focus-visible:outline-2 focus-visible:outline-daintree-accent focus-visible:outline-offset-2"
+              >
+                <Settings2 className="w-3.5 h-3.5" />
+                Assistant settings
+              </button>
+              <button
+                type="button"
+                onClick={handleOpenAssistantDocs}
+                className="flex items-center gap-1 text-[11px] text-daintree-text/40 hover:text-daintree-text/60 transition-colors focus-visible:outline focus-visible:outline-2 focus-visible:outline-daintree-accent focus-visible:outline-offset-2"
+              >
+                <ExternalLink className="w-3.5 h-3.5" />
+                Daintree Assistant guide
+              </button>
             </div>
           </div>
         )}
@@ -1900,19 +1898,6 @@ export function HelpPanel({
           </button>
         </div>
       )}
-      {!showTerminal && (
-        <div className="flex items-center justify-end px-3 py-1.5 border-t border-daintree-border shrink-0 text-[11px] text-daintree-text/40">
-          <button
-            type="button"
-            onClick={handleOpenSettings}
-            className="flex items-center gap-1 hover:text-daintree-text/60 transition-colors focus-visible:outline focus-visible:outline-2 focus-visible:outline-daintree-accent focus-visible:outline-offset-2"
-          >
-            <Settings2 className="w-3.5 h-3.5" />
-            Assistant settings
-          </button>
-        </div>
-      )}
-
       <ConfirmDialog
         isOpen={showNewSessionConfirm}
         title="Start a new session?"

--- a/src/components/HelpPanel/__tests__/HelpPanel.helpLaunch.test.tsx
+++ b/src/components/HelpPanel/__tests__/HelpPanel.helpLaunch.test.tsx
@@ -1275,35 +1275,21 @@ describe("HelpPanel — single-supported-agent auto-skip (issue #6612)", () => {
   });
 });
 
-describe("HelpPanel — empty state hero (intent-first replacement)", () => {
-  it("renders the value-prop sentence and three seed-prompt chips when no preferred agent and multiple supported agents installed", async () => {
+describe("HelpPanel — empty state hero (Daintree-relevant entry points)", () => {
+  it("renders the value-prop sentence and the two navigation links when no preferred agent and multiple supported agents installed", async () => {
     helpPanelState.preferredAgentId = null;
     cliAvailabilityState.availability = { claude: "ready", codex: "ready" };
     mockGetAssistantSupportedAgentIds.mockReturnValue(["claude", "codex"]);
 
     const { findByRole, getByText } = render(<HelpPanel width={380} />);
 
-    expect(
-      getByText(/Ask the assistant to explain code, review changes, or debug issues/i)
-    ).toBeTruthy();
-    expect(await findByRole("button", { name: "Explain this codebase to me" })).toBeTruthy();
-    expect(await findByRole("button", { name: "Review my recent changes" })).toBeTruthy();
-    expect(await findByRole("button", { name: "Help me debug an issue" })).toBeTruthy();
+    expect(getByText(/Use Daintree Assistant to configure and navigate Daintree/i)).toBeTruthy();
+    expect(await findByRole("button", { name: "Assistant settings" })).toBeTruthy();
+    expect(await findByRole("button", { name: "Daintree Assistant guide" })).toBeTruthy();
     expect(mockDispatch).not.toHaveBeenCalled();
   });
 
-  it("renders the demoted 'Assistant settings' link in the bottom info bar (no center button)", async () => {
-    helpPanelState.preferredAgentId = null;
-    cliAvailabilityState.availability = { claude: "ready", codex: "ready" };
-    mockGetAssistantSupportedAgentIds.mockReturnValue(["claude", "codex"]);
-
-    const { findByRole } = render(<HelpPanel width={380} />);
-
-    const button = await findByRole("button", { name: "Assistant settings" });
-    expect(button).toBeTruthy();
-  });
-
-  it("dispatches app.settings.openTab with tab='assistant' when the bottom settings link is clicked", async () => {
+  it("dispatches app.settings.openTab with tab='assistant' when the empty-state settings link is clicked", async () => {
     helpPanelState.preferredAgentId = null;
     cliAvailabilityState.availability = { claude: "ready", codex: "ready" };
     mockGetAssistantSupportedAgentIds.mockReturnValue(["claude", "codex"]);
@@ -1320,94 +1306,62 @@ describe("HelpPanel — empty state hero (intent-first replacement)", () => {
     );
   });
 
-  it("disables the seed-prompt chips when no preferred agent and zero supported agents installed", async () => {
+  it("dispatches system.openExternal with the assistant docs URL when the empty-state guide link is clicked", async () => {
+    helpPanelState.preferredAgentId = null;
+    cliAvailabilityState.availability = { claude: "ready", codex: "ready" };
+    mockGetAssistantSupportedAgentIds.mockReturnValue(["claude", "codex"]);
+
+    const { findByRole } = render(<HelpPanel width={380} />);
+
+    const button = await findByRole("button", { name: "Daintree Assistant guide" });
+    fireEvent.click(button);
+
+    expect(mockDispatch).toHaveBeenCalledWith(
+      "system.openExternal",
+      { url: "https://daintree.org/assistant" },
+      { source: "user" }
+    );
+  });
+
+  it("does not provision a session or auto-launch an agent when the empty-state links are clicked", async () => {
     helpPanelState.preferredAgentId = null;
     cliAvailabilityState.availability = { claude: "missing", codex: "missing" };
     mockGetAssistantSupportedAgentIds.mockReturnValue(["claude", "codex"]);
 
     const { findByRole } = render(<HelpPanel width={380} />);
 
-    const chip = (await findByRole("button", {
-      name: "Explain this codebase to me",
-    })) as HTMLButtonElement;
-    expect(chip.disabled).toBe(true);
+    const settings = await findByRole("button", { name: "Assistant settings" });
+    const docs = await findByRole("button", { name: "Daintree Assistant guide" });
 
-    fireEvent.click(chip);
+    fireEvent.click(settings);
+    fireEvent.click(docs);
+
     expect(mockProvisionSession).not.toHaveBeenCalled();
-    expect(mockDispatch).not.toHaveBeenCalled();
+    expect(mockDispatch).not.toHaveBeenCalledWith(
+      "agent.launch",
+      expect.anything(),
+      expect.anything()
+    );
   });
 
-  it("dispatches agent.launch with the chip text as prompt when a chip is clicked (preferredAgentId path)", async () => {
-    helpPanelState.preferredAgentId = "claude";
+  it("renders the title-bar help button that dispatches system.openExternal with the assistant docs URL", async () => {
+    helpPanelState.preferredAgentId = null;
     cliAvailabilityState.availability = { claude: "ready", codex: "ready" };
     mockGetAssistantSupportedAgentIds.mockReturnValue(["claude", "codex"]);
-    mockGetFolderPath.mockResolvedValue("/help");
-    mockDispatch.mockResolvedValue({ ok: true, result: { terminalId: "seeded-term" } });
 
     const { findByRole } = render(<HelpPanel width={380} />);
 
-    // The auto-launch effect for preferredAgentId fires on mount. Clear the
-    // initial mock dispatch so we can isolate the chip-click dispatch below.
-    await act(async () => {
-      // Yield to flush the in-flight auto-launch.
-    });
-    mockDispatch.mockClear();
-    mockDispatch.mockResolvedValue({ ok: true, result: { terminalId: "seeded-term-2" } });
-    helpPanelState.terminalId = null; // reset so re-launch is allowed
-
-    const chip = await findByRole("button", { name: "Review my recent changes" });
-    await act(async () => {
-      fireEvent.click(chip);
-    });
+    const help = await findByRole("button", { name: "Open assistant docs" });
+    fireEvent.click(help);
 
     expect(mockDispatch).toHaveBeenCalledWith(
-      "agent.launch",
-      expect.objectContaining({
-        agentId: "claude",
-        prompt: "Review my recent changes",
-      }),
+      "system.openExternal",
+      { url: "https://daintree.org/assistant" },
       { source: "user" }
     );
   });
 
-  it("skips hibernate resume when a seed prompt is provided (regression: prompt must reach agent.launch)", async () => {
-    helpPanelState.preferredAgentId = "claude";
-    helpPanelState.hibernateSessions = {
-      "proj-default": { sessionId: "h-sess", cwd: "/help", agentId: "claude" },
-    };
-    cliAvailabilityState.availability = { claude: "ready", codex: "ready" };
-    mockGetAssistantSupportedAgentIds.mockReturnValue(["claude", "codex"]);
-    mockGetFolderPath.mockResolvedValue("/help");
-    mockDispatch.mockResolvedValue({ ok: true, result: { terminalId: "fresh-term" } });
-
-    const { findByRole } = render(<HelpPanel width={380} />);
-
-    // The auto-launch effect for preferredAgentId fires on mount and would
-    // hit the resume path (no seedPrompt). Wait, then clear so we can
-    // isolate the chip-click dispatch.
-    await act(async () => {
-      // flush
-    });
-    mockDispatch.mockClear();
-    mockDispatch.mockResolvedValue({ ok: true, result: { terminalId: "fresh-term-2" } });
-    helpPanelState.terminalId = null;
-
-    const chip = await findByRole("button", { name: "Help me debug an issue" });
-    await act(async () => {
-      fireEvent.click(chip);
-    });
-
-    expect(mockDispatch).toHaveBeenCalledWith(
-      "agent.launch",
-      expect.objectContaining({
-        agentId: "claude",
-        prompt: "Help me debug an issue",
-      }),
-      { source: "user" }
-    );
-  });
-
-  it("does not render the bottom 'Assistant settings' link when a terminal is active", () => {
+  it("renders the title-bar help button even when a terminal session is active", () => {
     helpPanelState.terminalId = "term-1";
     helpPanelState.agentId = "claude";
     panelStoreState.panelsById = {
@@ -1416,41 +1370,20 @@ describe("HelpPanel — empty state hero (intent-first replacement)", () => {
 
     const { queryByRole } = render(<HelpPanel width={380} />);
 
-    expect(queryByRole("button", { name: "Assistant settings" })).toBeNull();
+    expect(queryByRole("button", { name: "Open assistant docs" })).not.toBeNull();
   });
 
-  it("falls back to the single installed supported agent when no preferred agent is set", async () => {
+  it("does not render a bottom 'Assistant settings' footer in either terminal state", () => {
     helpPanelState.preferredAgentId = null;
-    cliAvailabilityState.availability = { claude: "missing", codex: "ready" };
+    cliAvailabilityState.availability = { claude: "ready", codex: "ready" };
     mockGetAssistantSupportedAgentIds.mockReturnValue(["claude", "codex"]);
-    mockGetFolderPath.mockResolvedValue("/help");
-    mockDispatch.mockResolvedValue({ ok: true, result: { terminalId: "fallback-term" } });
 
-    const { findByRole } = render(<HelpPanel width={380} />);
+    const { queryAllByRole } = render(<HelpPanel width={380} />);
 
-    // The single-agent auto-skip effect ALSO fires here (only "codex" is
-    // installed). Wait for that, then click the chip; the fallback resolves
-    // codex via supportedInstalledAgentIds[0].
-    await act(async () => {
-      // flush
-    });
-    mockDispatch.mockClear();
-    mockDispatch.mockResolvedValue({ ok: true, result: { terminalId: "fallback-term-2" } });
-    helpPanelState.terminalId = null;
-
-    const chip = await findByRole("button", { name: "Help me debug an issue" });
-    await act(async () => {
-      fireEvent.click(chip);
-    });
-
-    expect(mockDispatch).toHaveBeenCalledWith(
-      "agent.launch",
-      expect.objectContaining({
-        agentId: "codex",
-        prompt: "Help me debug an issue",
-      }),
-      { source: "user" }
-    );
+    // The empty state contains exactly one "Assistant settings" button; the
+    // duplicate `!showTerminal` footer link is removed.
+    const matches = queryAllByRole("button", { name: "Assistant settings" });
+    expect(matches.length).toBe(1);
   });
 });
 

--- a/src/components/HelpPanel/__tests__/HelpPanel.helpLaunch.test.tsx
+++ b/src/components/HelpPanel/__tests__/HelpPanel.helpLaunch.test.tsx
@@ -1323,7 +1323,7 @@ describe("HelpPanel — empty state hero (Daintree-relevant entry points)", () =
     );
   });
 
-  it("does not provision a session or auto-launch an agent when the empty-state links are clicked", async () => {
+  it("dispatches navigation actions (not agent.launch) when the empty-state links are clicked", async () => {
     helpPanelState.preferredAgentId = null;
     cliAvailabilityState.availability = { claude: "missing", codex: "missing" };
     mockGetAssistantSupportedAgentIds.mockReturnValue(["claude", "codex"]);
@@ -1337,6 +1337,16 @@ describe("HelpPanel — empty state hero (Daintree-relevant entry points)", () =
     fireEvent.click(docs);
 
     expect(mockProvisionSession).not.toHaveBeenCalled();
+    expect(mockDispatch).toHaveBeenCalledWith(
+      "app.settings.openTab",
+      { tab: "assistant" },
+      { source: "user" }
+    );
+    expect(mockDispatch).toHaveBeenCalledWith(
+      "system.openExternal",
+      { url: "https://daintree.org/assistant" },
+      { source: "user" }
+    );
     expect(mockDispatch).not.toHaveBeenCalledWith(
       "agent.launch",
       expect.anything(),
@@ -1373,17 +1383,28 @@ describe("HelpPanel — empty state hero (Daintree-relevant entry points)", () =
     expect(queryByRole("button", { name: "Open assistant docs" })).not.toBeNull();
   });
 
-  it("does not render a bottom 'Assistant settings' footer in either terminal state", () => {
+  it("does not render a duplicate 'Assistant settings' footer link (empty state)", () => {
     helpPanelState.preferredAgentId = null;
     cliAvailabilityState.availability = { claude: "ready", codex: "ready" };
     mockGetAssistantSupportedAgentIds.mockReturnValue(["claude", "codex"]);
 
     const { queryAllByRole } = render(<HelpPanel width={380} />);
 
-    // The empty state contains exactly one "Assistant settings" button; the
-    // duplicate `!showTerminal` footer link is removed.
     const matches = queryAllByRole("button", { name: "Assistant settings" });
     expect(matches.length).toBe(1);
+  });
+
+  it("does not render any 'Assistant settings' button when a terminal session is active", () => {
+    helpPanelState.terminalId = "term-1";
+    helpPanelState.agentId = "claude";
+    panelStoreState.panelsById = {
+      "term-1": { id: "term-1", kind: "terminal", spawnStatus: "ready", cwd: "/help" },
+    };
+
+    const { queryAllByRole } = render(<HelpPanel width={380} />);
+
+    const matches = queryAllByRole("button", { name: "Assistant settings" });
+    expect(matches.length).toBe(0);
   });
 });
 


### PR DESCRIPTION
## Summary

The Daintree Assistant's first-launch empty state previously showed seed-prompt chips borrowed from the agent CLI — examples like "explore the codebase" that point users toward the wrong mental model. The assistant controls Daintree; it isn't a code-exploration agent in its own right.

- Replaced the seed-prompt chips with two focused links: one to the assistant settings tab, one to the docs at https://daintree.org/assistant
- Added a `CircleHelp` icon button to the help panel title bar that opens the same docs URL in the external browser, matching the existing `CircleHelp` convention used in `AppPaletteDialog` and `FleetPickerContent`

Resolves #7628

## Changes

- `src/components/HelpPanel/HelpPanel.tsx` — empty-state content replaced with settings + docs links; `CircleHelp` button added to panel header
- `src/components/HelpPanel/__tests__/HelpPanel.helpLaunch.test.tsx` — assertions tightened to cover the empty-state links and the footer

## Testing

- Unit tests updated and passing — empty-state links, footer, and header button all covered
- `npm run check` clean (typecheck + lint + format)