### PR TITLE
feat(assistant): show working/waiting state in toolbar pip and panel header

### DIFF
--- a/src/components/HelpPanel/HelpPanel.tsx
+++ b/src/components/HelpPanel/HelpPanel.tsx
@@ -35,6 +35,7 @@ import { actionService } from "@/services/ActionService";
 import { useEscapeStack } from "@/hooks/useEscapeStack";
 import { suppressSidebarResizes } from "@/lib/sidebarToggle";
 import { TerminalRefreshTier } from "@/types";
+import type { AgentState } from "@/types";
 import { logError } from "@/utils/logger";
 import { formatErrorMessage } from "@shared/utils/errorMessage";
 import { notify } from "@/lib/notify";
@@ -253,7 +254,11 @@ function revokeHelpSession(sessionId: string | null): void {
 // in-flight assistant state next to the header title so the user can read it
 // without watching the terminal. Only the actionable triad — working,
 // directing, waiting — earns a marker; idle/completed/exited stay quiet.
-function AssistantHeaderStateIndicator({ agentState }: { agentState: string | null | undefined }) {
+function AssistantHeaderStateIndicator({
+  agentState,
+}: {
+  agentState: AgentState | null | undefined;
+}) {
   if (agentState === "working") {
     return (
       <span

--- a/src/components/HelpPanel/HelpPanel.tsx
+++ b/src/components/HelpPanel/HelpPanel.tsx
@@ -12,6 +12,7 @@ import {
 import * as semver from "semver";
 import { cn } from "@/lib/utils";
 import { DaintreeIcon } from "@/components/icons/DaintreeIcon";
+import { SpinnerCircle, HollowCircle, InteractingCircle } from "@/components/icons";
 import { XtermAdapter } from "@/components/Terminal/XtermAdapter";
 import { MissingCliGate } from "@/components/Terminal/MissingCliGate";
 import { HelpIntroBanner } from "./HelpIntroBanner";
@@ -246,6 +247,53 @@ function revokeHelpSession(sessionId: string | null): void {
   window.electron.help.revokeSession(sessionId).catch((err) => {
     logError("Failed to revoke help session", err);
   });
+}
+
+// Tier-1 ambient indicator (per CLAUDE.md Runtime Signals): surfaces the
+// in-flight assistant state next to the header title so the user can read it
+// without watching the terminal. Only the actionable triad — working,
+// directing, waiting — earns a marker; idle/completed/exited stay quiet.
+function AssistantHeaderStateIndicator({ agentState }: { agentState: string | null | undefined }) {
+  if (agentState === "working") {
+    return (
+      <span
+        data-testid="assistant-header-state-indicator"
+        data-agent-state="working"
+        aria-label="Assistant is working"
+        role="status"
+        className="ml-1.5 inline-flex shrink-0"
+      >
+        <SpinnerCircle className="w-3.5 h-3.5 text-state-working animate-spin-slow motion-reduce:animate-none" />
+      </span>
+    );
+  }
+  if (agentState === "directing") {
+    return (
+      <span
+        data-testid="assistant-header-state-indicator"
+        data-agent-state="directing"
+        aria-label="Assistant is directing"
+        role="status"
+        className="ml-1.5 inline-flex shrink-0"
+      >
+        <InteractingCircle className="w-3.5 h-3.5 text-category-blue" />
+      </span>
+    );
+  }
+  if (agentState === "waiting") {
+    return (
+      <span
+        data-testid="assistant-header-state-indicator"
+        data-agent-state="waiting"
+        aria-label="Assistant is waiting"
+        role="status"
+        className="ml-1.5 inline-flex shrink-0"
+      >
+        <HollowCircle className="w-3.5 h-3.5 text-state-waiting" />
+      </span>
+    );
+  }
+  return null;
 }
 
 interface HelpPanelProps {
@@ -1637,6 +1685,7 @@ export function HelpPanel({
           <span className="ml-1.5 text-xs font-medium text-daintree-text/70 truncate">
             Daintree Assistant
           </span>
+          <AssistantHeaderStateIndicator agentState={terminal?.agentState} />
         </div>
         <button
           type="button"

--- a/src/components/HelpPanel/__tests__/HelpPanel.hibernate.test.tsx
+++ b/src/components/HelpPanel/__tests__/HelpPanel.hibernate.test.tsx
@@ -847,6 +847,72 @@ describe("HelpPanel — idle hibernation timer", () => {
   });
 });
 
+describe("HelpPanel — assistant header state indicator", () => {
+  function setupTerminalWithState(state: string) {
+    helpPanelState.terminalId = "live-term";
+    helpPanelState.agentId = "claude";
+    projectStoreState.currentProject = { id: "proj-1", path: "/tmp/proj-1" };
+    panelStoreState.panelsById = {
+      "live-term": {
+        id: "live-term",
+        kind: "terminal",
+        spawnStatus: "ready",
+        cwd: "/tmp/help/proj-1",
+        title: "Claude",
+        command: "claude",
+        location: "dock",
+        agentState: state,
+      },
+    };
+  }
+
+  it("renders the working indicator when the assistant terminal is working", () => {
+    setupTerminalWithState("working");
+
+    const { getByTestId } = render(<HelpPanel width={380} />);
+    const indicator = getByTestId("assistant-header-state-indicator");
+    expect(indicator.getAttribute("data-agent-state")).toBe("working");
+    expect(indicator.getAttribute("aria-label")).toBe("Assistant is working");
+  });
+
+  it("renders the waiting indicator when the assistant terminal is waiting", () => {
+    setupTerminalWithState("waiting");
+
+    const { getByTestId } = render(<HelpPanel width={380} />);
+    const indicator = getByTestId("assistant-header-state-indicator");
+    expect(indicator.getAttribute("data-agent-state")).toBe("waiting");
+    expect(indicator.getAttribute("aria-label")).toBe("Assistant is waiting");
+  });
+
+  it("renders the directing indicator when the assistant terminal is directing", () => {
+    setupTerminalWithState("directing");
+
+    const { getByTestId } = render(<HelpPanel width={380} />);
+    const indicator = getByTestId("assistant-header-state-indicator");
+    expect(indicator.getAttribute("data-agent-state")).toBe("directing");
+    expect(indicator.getAttribute("aria-label")).toBe("Assistant is directing");
+  });
+
+  it("does not render an indicator for idle, completed, or exited states", () => {
+    for (const state of ["idle", "completed", "exited"]) {
+      setupTerminalWithState(state);
+      const { queryByTestId, unmount } = render(<HelpPanel width={380} />);
+      expect(queryByTestId("assistant-header-state-indicator")).toBeNull();
+      unmount();
+    }
+  });
+
+  it("does not render an indicator before any assistant terminal exists", () => {
+    helpPanelState.terminalId = null;
+    helpPanelState.agentId = null;
+    projectStoreState.currentProject = { id: "proj-1", path: "/tmp/proj-1" };
+    panelStoreState.panelsById = {};
+
+    const { queryByTestId } = render(<HelpPanel width={380} />);
+    expect(queryByTestId("assistant-header-state-indicator")).toBeNull();
+  });
+});
+
 describe("HelpPanel — + New session clears hibernated entry", () => {
   it("clearHibernateSession is called for the current project when starting a new session", async () => {
     helpPanelState.terminalId = "live-term";

--- a/src/components/Layout/ToolbarAssistantButton.tsx
+++ b/src/components/Layout/ToolbarAssistantButton.tsx
@@ -12,6 +12,7 @@ import { usePanelStore } from "@/store";
 import { suppressSidebarResizes } from "@/lib/sidebarToggle";
 import { useMcpReadiness } from "@/hooks/useMcpReadiness";
 import type { McpRuntimeSnapshot } from "@shared/types";
+import type { AgentState } from "@/types";
 
 const toolbarIconButtonClass = "toolbar-icon-button text-daintree-text relative";
 
@@ -42,6 +43,28 @@ function describePip(snapshot: McpRuntimeSnapshot): PipDescriptor | null {
   }
 }
 
+interface AgentPipDescriptor {
+  className: string;
+  tooltip: string;
+}
+
+// Local mapping that includes "working" — broader than the shared
+// agentStateDotColor() in AgentStatusIndicator, which deliberately omits
+// passive states for the worktree tray. Here the toolbar button is the only
+// chrome surfacing assistant state when the panel is closed, so working and
+// directing both earn the green pip alongside the yellow waiting pip.
+function describeAgentPip(state: AgentState | null | undefined): AgentPipDescriptor | null {
+  switch (state) {
+    case "working":
+    case "directing":
+      return { className: "bg-state-working", tooltip: "Assistant is working" };
+    case "waiting":
+      return { className: "bg-state-waiting", tooltip: "Assistant is waiting" };
+    default:
+      return null;
+  }
+}
+
 export const ToolbarAssistantButton = memo(function ToolbarAssistantButton({
   "data-toolbar-item": dataToolbarItem,
 }: {
@@ -50,11 +73,11 @@ export const ToolbarAssistantButton = memo(function ToolbarAssistantButton({
   const isOpen = useHelpPanelStore((s) => s.isOpen);
   const toggle = useHelpPanelStore((s) => s.toggle);
   // Two-step primitive selectors so the button only re-renders when the
-  // assistant terminal id changes, then when its agentState transitions in or
-  // out of "working". Returning a primitive avoids needing useShallow.
+  // assistant terminal id changes, then when its agentState transitions.
+  // Returning a primitive avoids needing useShallow.
   const assistantTerminalId = useHelpPanelStore((s) => s.terminalId);
-  const isWorking = usePanelStore((s) =>
-    assistantTerminalId ? s.panelsById[assistantTerminalId]?.agentState === "working" : false
+  const agentState = usePanelStore((s) =>
+    assistantTerminalId ? (s.panelsById[assistantTerminalId]?.agentState ?? null) : null
   );
   const mcp = useMcpReadiness();
   const shortcut = useKeybindingDisplay("help.togglePanel");
@@ -68,17 +91,16 @@ export const ToolbarAssistantButton = memo(function ToolbarAssistantButton({
   }, [toggle]);
 
   const pip = describePip(mcp);
-  // The MCP-health pip takes precedence — when it's showing, the working pip
-  // would compete for the same corner. The neutral working dot is intentionally
-  // non-pulsing and non-accent (per CLAUDE.md accent-color restraint) so it
-  // reads as ambient state rather than a call to action.
-  const showWorkingPip = !pip && isWorking && !isOpen;
+  const agentPip = describeAgentPip(agentState);
+  // The MCP-health pip takes precedence — when it's showing, the agent pip
+  // would compete for the same corner. The agent pip is suppressed while the
+  // panel is open since the in-panel header indicator already conveys state.
+  const showAgentPip = !pip && agentPip !== null && !isOpen;
   const baseTooltip = isOpen ? "Close Daintree Assistant" : "Open Daintree Assistant";
-  const workingTooltip = "Assistant is working";
   const ariaLabel = pip
     ? `Daintree Assistant — ${pip.tooltip}`
-    : showWorkingPip
-      ? `Daintree Assistant — ${workingTooltip}`
+    : showAgentPip
+      ? `Daintree Assistant — ${agentPip!.tooltip}`
       : "Daintree Assistant";
 
   return (
@@ -107,13 +129,14 @@ export const ToolbarAssistantButton = memo(function ToolbarAssistantButton({
               )}
             />
           ) : (
-            showWorkingPip && (
+            showAgentPip && (
               <span
                 aria-hidden="true"
                 data-testid="assistant-working-pip"
+                data-agent-state={agentState ?? ""}
                 className={cn(
                   "absolute -top-0.5 -right-0.5 w-2 h-2 rounded-full ring-2 ring-daintree-bg",
-                  "bg-daintree-text/30"
+                  agentPip!.className
                 )}
               />
             )
@@ -125,8 +148,8 @@ export const ToolbarAssistantButton = memo(function ToolbarAssistantButton({
         {createTooltipContent(
           pip
             ? `${baseTooltip} — ${pip.tooltip}`
-            : showWorkingPip
-              ? `${baseTooltip} — ${workingTooltip}`
+            : showAgentPip
+              ? `${baseTooltip} — ${agentPip!.tooltip}`
               : baseTooltip,
           shortcut
         )}

--- a/src/components/Layout/__tests__/ToolbarAssistantButton.test.tsx
+++ b/src/components/Layout/__tests__/ToolbarAssistantButton.test.tsx
@@ -88,7 +88,7 @@ function setPanel(id: string, agentState: string | undefined): void {
   }));
 }
 
-describe("ToolbarAssistantButton — working pip", () => {
+describe("ToolbarAssistantButton — agent state pip", () => {
   beforeEach(() => {
     mcpReadinessMock.mockReturnValue({ enabled: true, state: "ready", port: 0, lastError: null });
     useHelpPanelStore.setState({
@@ -100,7 +100,7 @@ describe("ToolbarAssistantButton — working pip", () => {
     usePanelStore.setState({ panelsById: {}, panelIds: [] } as never);
   });
 
-  it("does not render the working pip when the assistant is idle", () => {
+  it("does not render the pip when the assistant is idle", () => {
     setHelpPanel({ isOpen: false, terminalId: "t-1" });
     setPanel("t-1", "idle");
 
@@ -108,21 +108,64 @@ describe("ToolbarAssistantButton — working pip", () => {
     expect(queryByTestId("assistant-working-pip")).toBeNull();
   });
 
-  it("renders the working pip when the assistant terminal's agentState is working", () => {
+  it("renders a green pip when the assistant terminal's agentState is working", () => {
     setHelpPanel({ isOpen: false, terminalId: "t-2" });
     setPanel("t-2", "working");
 
     const { queryByTestId } = render(<ToolbarAssistantButton />);
     const pip = queryByTestId("assistant-working-pip");
     expect(pip).not.toBeNull();
-    // The pip uses neutral color, not accent or status colors.
-    expect(pip!.className).toMatch(/bg-daintree-text\/30/);
+    expect(pip!.className).toMatch(/bg-state-working/);
     expect(pip!.className).not.toMatch(/animate-pulse/);
     expect(pip!.className).not.toMatch(/accent/);
     expect(pip!.className).not.toMatch(/bg-status-/);
+    expect(pip!.getAttribute("data-agent-state")).toBe("working");
   });
 
-  it("hides the working pip when the panel is open (the user can already see the activity)", () => {
+  it("renders a green pip when the assistant terminal's agentState is directing", () => {
+    setHelpPanel({ isOpen: false, terminalId: "t-2d" });
+    setPanel("t-2d", "directing");
+
+    const { queryByTestId } = render(<ToolbarAssistantButton />);
+    const pip = queryByTestId("assistant-working-pip");
+    expect(pip).not.toBeNull();
+    expect(pip!.className).toMatch(/bg-state-working/);
+    expect(pip!.getAttribute("data-agent-state")).toBe("directing");
+  });
+
+  it("renders a yellow pip when the assistant terminal's agentState is waiting", () => {
+    setHelpPanel({ isOpen: false, terminalId: "t-w" });
+    setPanel("t-w", "waiting");
+
+    const { queryByTestId } = render(<ToolbarAssistantButton />);
+    const pip = queryByTestId("assistant-working-pip");
+    expect(pip).not.toBeNull();
+    expect(pip!.className).toMatch(/bg-state-waiting/);
+    expect(pip!.className).not.toMatch(/animate-pulse/);
+    expect(pip!.getAttribute("data-agent-state")).toBe("waiting");
+  });
+
+  it("does not render the pip for completed or exited states", () => {
+    setHelpPanel({ isOpen: false, terminalId: "t-c" });
+    setPanel("t-c", "completed");
+    const { queryByTestId, rerender } = render(<ToolbarAssistantButton />);
+    expect(queryByTestId("assistant-working-pip")).toBeNull();
+
+    act(() => {
+      setPanel("t-c", "exited");
+    });
+    rerender(<ToolbarAssistantButton />);
+    expect(queryByTestId("assistant-working-pip")).toBeNull();
+  });
+
+  it("does not render the pip when there is no assistant terminal", () => {
+    setHelpPanel({ isOpen: false, terminalId: null });
+
+    const { queryByTestId } = render(<ToolbarAssistantButton />);
+    expect(queryByTestId("assistant-working-pip")).toBeNull();
+  });
+
+  it("hides the pip when the panel is open (the user can already see the state)", () => {
     setHelpPanel({ isOpen: true, terminalId: "t-3" });
     setPanel("t-3", "working");
 
@@ -130,7 +173,15 @@ describe("ToolbarAssistantButton — working pip", () => {
     expect(queryByTestId("assistant-working-pip")).toBeNull();
   });
 
-  it("MCP-health pip takes precedence over the working pip when both would apply", () => {
+  it("hides the pip when the panel is open even for waiting state", () => {
+    setHelpPanel({ isOpen: true, terminalId: "t-3w" });
+    setPanel("t-3w", "waiting");
+
+    const { queryByTestId } = render(<ToolbarAssistantButton />);
+    expect(queryByTestId("assistant-working-pip")).toBeNull();
+  });
+
+  it("MCP-health failed pip takes precedence over the agent pip when both would apply", () => {
     mcpReadinessMock.mockReturnValue({
       state: "failed",
       port: 0,
@@ -141,16 +192,39 @@ describe("ToolbarAssistantButton — working pip", () => {
 
     const { container, queryByTestId } = render(<ToolbarAssistantButton />);
     expect(queryByTestId("assistant-working-pip")).toBeNull();
-    // The MCP health pip uses bg-status-danger.
     expect(container.querySelector(".bg-status-danger")).not.toBeNull();
   });
 
-  it("re-renders when agentState transitions from working to idle", () => {
+  it("MCP-health starting pip takes precedence over a waiting agent pip", () => {
+    mcpReadinessMock.mockReturnValue({
+      state: "starting",
+      port: 0,
+      lastError: null,
+    });
+    setHelpPanel({ isOpen: false, terminalId: "t-4w" });
+    setPanel("t-4w", "waiting");
+
+    const { container, queryByTestId } = render(<ToolbarAssistantButton />);
+    expect(queryByTestId("assistant-working-pip")).toBeNull();
+    expect(container.querySelector(".bg-status-warning")).not.toBeNull();
+  });
+
+  it("re-renders when agentState transitions through working → waiting → idle", () => {
     setHelpPanel({ isOpen: false, terminalId: "t-5" });
     setPanel("t-5", "working");
 
     const { queryByTestId } = render(<ToolbarAssistantButton />);
-    expect(queryByTestId("assistant-working-pip")).not.toBeNull();
+    let pip = queryByTestId("assistant-working-pip");
+    expect(pip).not.toBeNull();
+    expect(pip!.className).toMatch(/bg-state-working/);
+
+    act(() => {
+      setPanel("t-5", "waiting");
+    });
+
+    pip = queryByTestId("assistant-working-pip");
+    expect(pip).not.toBeNull();
+    expect(pip!.className).toMatch(/bg-state-waiting/);
 
     act(() => {
       setPanel("t-5", "idle");

--- a/src/components/Layout/__tests__/ToolbarAssistantButton.test.tsx
+++ b/src/components/Layout/__tests__/ToolbarAssistantButton.test.tsx
@@ -126,11 +126,17 @@ describe("ToolbarAssistantButton — agent state pip", () => {
     setHelpPanel({ isOpen: false, terminalId: "t-2d" });
     setPanel("t-2d", "directing");
 
-    const { queryByTestId } = render(<ToolbarAssistantButton />);
+    const { queryByTestId, container } = render(<ToolbarAssistantButton />);
     const pip = queryByTestId("assistant-working-pip");
     expect(pip).not.toBeNull();
     expect(pip!.className).toMatch(/bg-state-working/);
     expect(pip!.getAttribute("data-agent-state")).toBe("directing");
+    // Coarse-signal design: directing intentionally surfaces as "working" in
+    // the toolbar tooltip — both signal "something is in flight" without
+    // proliferating tooltip variants.
+    expect(container.querySelector("button")?.getAttribute("aria-label")).toBe(
+      "Daintree Assistant — Assistant is working"
+    );
   });
 
   it("renders a yellow pip when the assistant terminal's agentState is waiting", () => {


### PR DESCRIPTION
## Summary

- Adds a state indicator pip to the toolbar assistant button: green (`bg-state-working`) for working/directing, yellow (`bg-state-waiting`) for waiting, hidden when the panel is open or the agent is idle/completed/exited
- Adds a small circle icon next to the panel header title in `HelpPanel` using `SpinnerCircle` (working), `InteractingCircle` (directing/blue), and `HollowCircle` (waiting)
- The two indicators are complementary and never both visible at once — the toolbar pip is suppressed by the `!isOpen` guard, so only one surface signals at a time

Resolves #7630

## Changes

- `ToolbarAssistantButton.tsx` — local `pipColorClass` helper maps agent state to `bg-state-working` / `bg-state-waiting`; uses a local helper rather than modifying `agentStateDotColor` to keep the pip's rendering independent of the shared utility's contract
- `HelpPanel.tsx` — `AssistantHeaderStateIndicator` component renders the appropriate circle icon next to the panel title; directing keeps `InteractingCircle` (blue) as its canonical representation in the header rather than collapsing it into the working green
- Tests added for both components: 12 tests for `ToolbarAssistantButton` covering all agent states, panel-open suppression, MCP failed/starting precedence, and the aria-label coarse-signal pin; 5 tests for `HelpPanel` header indicator covering working, directing, waiting, idle, and null states

## Testing

- `npm run check` clean (typecheck + lint + format)
- Vitest: 29/29 passing on both test files