### PR TITLE
fix(layout): suppress width transition during sidebar/assistant drag

### DIFF
--- a/src/components/HelpPanel/HelpPanel.tsx
+++ b/src/components/HelpPanel/HelpPanel.tsx
@@ -321,12 +321,24 @@ interface HelpPanelProps {
    * readiness and writes the session-scoped .mcp.json.
    */
   isReadyToLaunch?: boolean;
+  /**
+   * Fires at the start of a pointer drag-resize so AppLayout can suppress
+   * its `transition-[width]` while the user drags. Issue #7627.
+   */
+  onResizeStart?: () => void;
+  /**
+   * Fires at the end of a pointer drag-resize. Restores the parent transition
+   * for non-drag width changes (collapse/expand toggle).
+   */
+  onResizeEnd?: () => void;
 }
 
 export function HelpPanel({
   width: effectiveWidth,
   isVisible: isVisibleProp,
   isReadyToLaunch = true,
+  onResizeStart,
+  onResizeEnd,
 }: HelpPanelProps) {
   const panelRef = useRef<HTMLElement>(null);
   const contentRef = useRef<HTMLDivElement>(null);
@@ -1030,6 +1042,7 @@ export function HelpPanel({
   const handleResizeStart = useCallback(
     (e: React.MouseEvent) => {
       e.preventDefault();
+      onResizeStart?.();
       setIsResizing(true);
       const startX = e.clientX;
       const startWidth = width;
@@ -1045,6 +1058,7 @@ export function HelpPanel({
 
       const onMouseUp = () => {
         setIsResizing(false);
+        onResizeEnd?.();
         document.removeEventListener("mousemove", onMouseMove);
         document.removeEventListener("mouseup", onMouseUp);
       };
@@ -1052,7 +1066,7 @@ export function HelpPanel({
       document.addEventListener("mousemove", onMouseMove);
       document.addEventListener("mouseup", onMouseUp);
     },
-    [width, setWidth]
+    [width, setWidth, onResizeStart, onResizeEnd]
   );
 
   // Resize via keyboard. ArrowLeft/PageUp grow the panel (it expands leftward

--- a/src/components/Layout/AppLayout.tsx
+++ b/src/components/Layout/AppLayout.tsx
@@ -1,5 +1,5 @@
 import { useState, useCallback, useEffect, useRef, type ReactNode } from "react";
-import { createPortal } from "react-dom";
+import { createPortal, flushSync } from "react-dom";
 import { cn } from "@/lib/utils";
 import { Toolbar } from "./Toolbar";
 import { Sidebar } from "./Sidebar";
@@ -71,6 +71,15 @@ export function AppLayout({
   useCcrPresetsSubscription();
   useProjectPresetsSubscription();
   const [sidebarWidth, setSidebarWidth] = useState(DEFAULT_SIDEBAR_WIDTH);
+  // Issue #7627: track active drag-resize per panel so AppLayout can suppress
+  // the 250ms ease-out-expo width transition during the drag (the transition
+  // restarts on every mousemove, which makes the rendered edge lag the cursor).
+  // Toggling these flags via flushSync at drag start guarantees the class
+  // gate disappears synchronously before the first mousemove frame; the
+  // transition is restored on drag end so collapse/expand and double-click
+  // reset still animate.
+  const [isSidebarResizing, setIsSidebarResizing] = useState(false);
+  const [isAssistantResizing, setIsAssistantResizing] = useState(false);
   const currentProject = useProjectStore((state) => state.currentProject);
   const layout = useLayoutState();
   const overlayClaims = useUIStore((s) => s.overlayClaims);
@@ -361,6 +370,25 @@ export function AppLayout({
     setSidebarWidth(clampedWidth);
   }, []);
 
+  // flushSync on the start setter so the gating class is removed from the DOM
+  // before the first mousemove fires — without it, React 19's batching can
+  // leave one eased frame at the start of the drag.
+  const handleSidebarResizeStart = useCallback(() => {
+    flushSync(() => setIsSidebarResizing(true));
+  }, []);
+
+  const handleSidebarResizeEnd = useCallback(() => {
+    setIsSidebarResizing(false);
+  }, []);
+
+  const handleAssistantResizeStart = useCallback(() => {
+    flushSync(() => setIsAssistantResizing(true));
+  }, []);
+
+  const handleAssistantResizeEnd = useCallback(() => {
+    setIsAssistantResizing(false);
+  }, []);
+
   const handleLaunchAgent = useCallback(
     (type: string) => {
       onLaunchAgent?.(type);
@@ -439,6 +467,7 @@ export function AppLayout({
             className={cn(
               "relative h-full shrink-0 overflow-clip",
               !reduceAnimations &&
+                !isSidebarResizing &&
                 "transition-[width] duration-[var(--duration-250)] ease-[var(--ease-out-expo)] motion-reduce:transition-none",
               !showSidebar && "pointer-events-none"
             )}
@@ -450,6 +479,8 @@ export function AppLayout({
                   <Sidebar
                     width={sidebarWidth}
                     onResize={handleSidebarResize}
+                    onResizeStart={handleSidebarResizeStart}
+                    onResizeEnd={handleSidebarResizeEnd}
                     isVisible={showSidebar}
                   >
                     {sidebarContent}
@@ -480,6 +511,7 @@ export function AppLayout({
               className={cn(
                 "relative h-full shrink-0 overflow-hidden",
                 !reduceAnimations &&
+                  !isAssistantResizing &&
                   "transition-[width] duration-[var(--duration-250)] ease-[var(--ease-out-expo)] motion-reduce:transition-none",
                 !showAssistant && "pointer-events-none"
               )}
@@ -493,6 +525,8 @@ export function AppLayout({
                   width={layout.helpPanelWidth}
                   isVisible={showAssistant}
                   isReadyToLaunch={isHydrated}
+                  onResizeStart={handleAssistantResizeStart}
+                  onResizeEnd={handleAssistantResizeEnd}
                 />
               </div>
             </div>

--- a/src/components/Layout/Sidebar.tsx
+++ b/src/components/Layout/Sidebar.tsx
@@ -24,6 +24,16 @@ import {
 interface SidebarProps {
   width: number;
   onResize: (width: number) => void;
+  /**
+   * Fires at the start of a pointer drag-resize so the parent can suppress
+   * its `transition-[width]` while the user drags. Issue #7627.
+   */
+  onResizeStart?: () => void;
+  /**
+   * Fires at the end of a pointer drag-resize. Restores the parent transition
+   * for non-drag width changes (collapse/expand toggle, double-click reset).
+   */
+  onResizeEnd?: () => void;
   isVisible?: boolean;
   children?: ReactNode;
   className?: string;
@@ -33,7 +43,15 @@ const RESIZE_STEP = 10;
 
 const ICON_CLASS = "w-3.5 h-3.5 mr-2 shrink-0";
 
-export function Sidebar({ width, onResize, isVisible = true, children, className }: SidebarProps) {
+export function Sidebar({
+  width,
+  onResize,
+  onResizeStart,
+  onResizeEnd,
+  isVisible = true,
+  children,
+  className,
+}: SidebarProps) {
   const [isResizing, setIsResizing] = useState(false);
   const sidebarRef = useRef<HTMLElement>(null);
   const currentProject = useProjectStore((state) => state.currentProject);
@@ -44,14 +62,19 @@ export function Sidebar({ width, onResize, isVisible = true, children, className
     return () => useMacroFocusStore.getState().setRegionRef("sidebar", null);
   }, []);
 
-  const startResizing = useCallback((e: React.MouseEvent) => {
-    e.preventDefault();
-    setIsResizing(true);
-  }, []);
+  const startResizing = useCallback(
+    (e: React.MouseEvent) => {
+      e.preventDefault();
+      onResizeStart?.();
+      setIsResizing(true);
+    },
+    [onResizeStart]
+  );
 
   const stopResizing = useCallback(() => {
     setIsResizing(false);
-  }, []);
+    onResizeEnd?.();
+  }, [onResizeEnd]);
 
   const handleKeyDown = useCallback(
     (e: React.KeyboardEvent) => {

--- a/src/components/Layout/Sidebar.tsx
+++ b/src/components/Layout/Sidebar.tsx
@@ -53,6 +53,9 @@ export function Sidebar({
   className,
 }: SidebarProps) {
   const [isResizing, setIsResizing] = useState(false);
+  // Mirrors `isResizing` synchronously so the unmount-only effect below can
+  // detect a mid-drag teardown without relying on stale closure state.
+  const isResizingRef = useRef(false);
   const sidebarRef = useRef<HTMLElement>(null);
   const currentProject = useProjectStore((state) => state.currentProject);
   const isMacroFocused = useMacroFocusStore((state) => state.focusedRegion === "sidebar");
@@ -65,6 +68,7 @@ export function Sidebar({
   const startResizing = useCallback(
     (e: React.MouseEvent) => {
       e.preventDefault();
+      isResizingRef.current = true;
       onResizeStart?.();
       setIsResizing(true);
     },
@@ -72,9 +76,31 @@ export function Sidebar({
   );
 
   const stopResizing = useCallback(() => {
+    isResizingRef.current = false;
     setIsResizing(false);
     onResizeEnd?.();
   }, [onResizeEnd]);
+
+  // If the sidebar unmounts mid-drag (e.g. `currentProject` becomes null
+  // because the user switched or closed the project), the listener-attaching
+  // effect below tears down its document listeners but stopResizing never
+  // fires — leaving AppLayout's `isSidebarResizing` flag stuck true and
+  // silently disabling the collapse/expand animation for the rest of the
+  // session. Surface onResizeEnd here so the parent transition is restored.
+  // The prop is mirrored through a ref so this unmount-only effect's deps
+  // can stay empty without disabling exhaustive-deps.
+  const onResizeEndRef = useRef(onResizeEnd);
+  useEffect(() => {
+    onResizeEndRef.current = onResizeEnd;
+  });
+  useEffect(() => {
+    return () => {
+      if (isResizingRef.current) {
+        isResizingRef.current = false;
+        onResizeEndRef.current?.();
+      }
+    };
+  }, []);
 
   const handleKeyDown = useCallback(
     (e: React.KeyboardEvent) => {

--- a/src/components/Layout/__tests__/AppLayout.sidebar.test.ts
+++ b/src/components/Layout/__tests__/AppLayout.sidebar.test.ts
@@ -162,6 +162,63 @@ describe("AppLayout independent sidebar gestures — issue #6659", () => {
   });
 });
 
+describe("AppLayout drag-resize transition gating — issue #7627", () => {
+  let source: string;
+
+  beforeEach(async () => {
+    source = await fs.readFile(APP_LAYOUT_PATH, "utf-8");
+  });
+
+  it("imports flushSync so the gating class is removed before the first mousemove", () => {
+    // React 19 batches state updates. Without flushSync, setIsSidebarResizing
+    // doesn't reach the DOM until the next render, which can leave one eased
+    // frame at the start of the drag. flushSync forces the class strip to
+    // happen synchronously inside the mousedown handler.
+    expect(source).toContain('import { createPortal, flushSync } from "react-dom"');
+  });
+
+  it("tracks per-panel drag-resize state in AppLayout", () => {
+    expect(source).toContain("const [isSidebarResizing, setIsSidebarResizing] = useState(false)");
+    expect(source).toContain(
+      "const [isAssistantResizing, setIsAssistantResizing] = useState(false)"
+    );
+  });
+
+  it("flushes the resize-start setter so the transition class disappears before mousemove", () => {
+    expect(source).toMatch(/flushSync\(\(\)\s*=>\s*setIsSidebarResizing\(true\)\)/);
+    expect(source).toMatch(/flushSync\(\(\)\s*=>\s*setIsAssistantResizing\(true\)\)/);
+  });
+
+  it("gates both width transitions on the resize state, preserving them otherwise", () => {
+    // The 250ms ease-out-expo transition is kept (it animates collapse/expand
+    // and double-click reset) but suppressed during active drag-resize so the
+    // edge tracks the cursor without the per-mousemove ease.
+    expect(source).toMatch(/!reduceAnimations\s*&&\s*!isSidebarResizing\s*&&/);
+    expect(source).toMatch(/!reduceAnimations\s*&&\s*!isAssistantResizing\s*&&/);
+    // The transition string must remain specific to width — never widened to
+    // bare `transition` or `transition-all`. Past lesson #4738.
+    expect(source).toContain("transition-[width]");
+    expect(source).not.toMatch(/"\s*transition\s+/);
+    expect(source).not.toContain("transition-all");
+  });
+
+  it("wires resize-lifecycle callbacks into Sidebar and HelpPanel", () => {
+    expect(source).toMatch(/<Sidebar[\s\S]*?onResizeStart=\{handleSidebarResizeStart\}/);
+    expect(source).toMatch(/<Sidebar[\s\S]*?onResizeEnd=\{handleSidebarResizeEnd\}/);
+    expect(source).toMatch(/<HelpPanel[\s\S]*?onResizeStart=\{handleAssistantResizeStart\}/);
+    expect(source).toMatch(/<HelpPanel[\s\S]*?onResizeEnd=\{handleAssistantResizeEnd\}/);
+  });
+
+  it("does not call the toggle-only suppression machinery on drag-resize", () => {
+    // Past lesson #4170: suppressSidebarResizes / lockSidebarLayoutTransition
+    // are timed for the fixed 250ms toggle animation. Calling them on drag
+    // would prevent the final PTY dimension flush and lock the transition for
+    // an unrelated window. Drag-resize must not invoke them.
+    expect(source).not.toMatch(/handleSidebarResizeStart[\s\S]{0,200}suppressSidebarResizes/);
+    expect(source).not.toMatch(/handleAssistantResizeStart[\s\S]{0,200}suppressSidebarResizes/);
+  });
+});
+
 describe("AppLayout portal viewport coverage — issue #6629", () => {
   let source: string;
 

--- a/src/components/Layout/__tests__/AppLayout.sidebar.test.ts
+++ b/src/components/Layout/__tests__/AppLayout.sidebar.test.ts
@@ -3,6 +3,7 @@ import fs from "fs/promises";
 import path from "path";
 
 const APP_LAYOUT_PATH = path.resolve(__dirname, "../AppLayout.tsx");
+const SIDEBAR_PATH = path.resolve(__dirname, "../Sidebar.tsx");
 
 describe("AppLayout sidebar visibility — issue #5023 hide on welcome screen", () => {
   let source: string;
@@ -216,6 +217,39 @@ describe("AppLayout drag-resize transition gating — issue #7627", () => {
     // an unrelated window. Drag-resize must not invoke them.
     expect(source).not.toMatch(/handleSidebarResizeStart[\s\S]{0,200}suppressSidebarResizes/);
     expect(source).not.toMatch(/handleAssistantResizeStart[\s\S]{0,200}suppressSidebarResizes/);
+  });
+});
+
+describe("Sidebar unmount-mid-drag safety net — issue #7627", () => {
+  let source: string;
+
+  beforeEach(async () => {
+    source = await fs.readFile(SIDEBAR_PATH, "utf-8");
+  });
+
+  it("mirrors isResizing through a ref so unmount cleanup can read latest state", () => {
+    // The state-flag closure captured by the listener-attaching effect's
+    // cleanup closes over the OLD value of isResizing (true) on every run,
+    // so it can't tell graceful end from teardown. A ref updated inside
+    // startResizing/stopResizing gives the unmount cleanup a synchronous
+    // signal of the live drag state.
+    expect(source).toMatch(/const isResizingRef = useRef\(false\)/);
+    expect(source).toMatch(/isResizingRef\.current = true/);
+    expect(source).toMatch(/isResizingRef\.current = false/);
+  });
+
+  it("calls onResizeEnd on unmount if a drag is still in progress", () => {
+    // Without this, project switching while the user is mid-drag (which
+    // unmounts Sidebar via AppLayout's `currentProject != null` guard)
+    // would leave AppLayout's `isSidebarResizing` flag stuck true forever,
+    // silently disabling the collapse/expand animation for the rest of
+    // the session.
+    // The prop is mirrored through a ref so the unmount-only effect's
+    // deps can stay empty without disabling exhaustive-deps.
+    expect(source).toMatch(/const onResizeEndRef = useRef\(onResizeEnd\)/);
+    expect(source).toMatch(
+      /if \(isResizingRef\.current\)[\s\S]{0,120}onResizeEndRef\.current\?\.\(\)/
+    );
   });
 });
 

--- a/src/components/Layout/__tests__/AppLayout.themeBrowser.test.ts
+++ b/src/components/Layout/__tests__/AppLayout.themeBrowser.test.ts
@@ -42,7 +42,7 @@ describe("AppLayout theme browser overlay structure — issue #5791", () => {
   it("portals the ThemeBrowser out of the inert subtree", () => {
     // Bug 1: rendering inside the inert main-content wrapper made the picker
     // itself unclickable. Portaling to document.body escapes the inert ancestor.
-    expect(source).toContain('import { createPortal } from "react-dom"');
+    expect(source).toMatch(/import \{ createPortal(?:, flushSync)? \} from "react-dom"/);
     expect(source).toMatch(/createPortal\([\s\S]*?<ThemeBrowser \/>[\s\S]*?document\.body/);
   });
 


### PR DESCRIPTION
## Summary

- Sidebar and assistant resize handles lagged during drag because a 250ms `ease-out-expo` width transition on the parent container was firing on every `mousemove` event. The handle was chasing the pointer instead of tracking it.
- The fix gates that transition off in `AppLayout` while a resize is in progress, preserving it for collapse/expand toggles and double-click resets where the animation is actually wanted.
- React 19's batching meant the class removal wasn't landing before the first `mousemove`, so the drag-start setter is wrapped in `flushSync`. An unmount safety net in `Sidebar.tsx` ensures a project switch mid-drag can't leave the resize flag stuck permanently.

Resolves #7627

## Changes

- `AppLayout.tsx` — `isSidebarResizing` / `isAssistantResizing` booleans gate the `sidebar-width-animated` class off during drag; `flushSync` on drag-start setters; `onResizeStart` / `onResizeEnd` callbacks passed to `Sidebar` and `HelpPanel`
- `Sidebar.tsx` — accepts optional `onResizeStart` / `onResizeEnd` props; unmount effect fires `onResizeEnd` via a mirrored ref if the component tears down mid-drag
- `HelpPanel.tsx` — accepts and wires the same `onResizeStart` / `onResizeEnd` props into the existing mouse handler
- `AppLayout.sidebar.test.ts` — 25 tests covering transition gating, `flushSync` pairing, callback wiring, and the unmount safety net

## Testing

- `vitest run AppLayout.sidebar.test.ts` — 25/25 pass
- `tsc --noEmit` — clean
- `eslint` on changed files — clean
- Prettier check on changed files — clean