### PR TITLE
fix(pty): raise IPC queue cap from 512KB to 3MB for agent burst headroom

### DIFF
--- a/electron/pty-host/__tests__/portQueue.test.ts
+++ b/electron/pty-host/__tests__/portQueue.test.ts
@@ -388,17 +388,21 @@ describe("PortQueueManager", () => {
     });
   });
 
-  describe("constants alignment with renderer precedent", () => {
-    it("max queue is 512KB to match 4× renderer high watermark (128KB)", () => {
-      expect(IPC_MAX_QUEUE_BYTES).toBe(512 * 1024);
+  describe("constants alignment — Claude burst headroom", () => {
+    it("max queue is 3MB to absorb low-single-digit-MB bursts", () => {
+      expect(IPC_MAX_QUEUE_BYTES).toBe(3 * 1024 * 1024);
     });
 
-    it("high watermark sits at 384KB (75% of cap)", () => {
-      expect((IPC_MAX_QUEUE_BYTES * IPC_HIGH_WATERMARK_PERCENT) / 100).toBe(384 * 1024);
+    it("high watermark sits near 2MB (67% of cap)", () => {
+      const high = (IPC_MAX_QUEUE_BYTES * IPC_HIGH_WATERMARK_PERCENT) / 100;
+      expect(high).toBeGreaterThanOrEqual(2 * 1024 * 1024);
+      expect(high).toBeLessThan(2.1 * 1024 * 1024);
     });
 
-    it("low watermark sits at 128KB (25% of cap, equals one renderer drain cycle)", () => {
-      expect((IPC_MAX_QUEUE_BYTES * IPC_LOW_WATERMARK_PERCENT) / 100).toBe(128 * 1024);
+    it("low watermark sits near 1MB (33% of cap, ~1MB drain window)", () => {
+      const low = (IPC_MAX_QUEUE_BYTES * IPC_LOW_WATERMARK_PERCENT) / 100;
+      expect(low).toBeGreaterThan(1000 * 1024);
+      expect(low).toBeLessThanOrEqual(1024 * 1024);
     });
   });
 });

--- a/electron/services/pty/types.ts
+++ b/electron/services/pty/types.ts
@@ -243,13 +243,17 @@ export const GRACEFUL_SHUTDOWN_BUFFER_SIZE = 8 * 1024;
 export const GRACEFUL_SHUTDOWN_CLEAR_DELAY_MS = 100;
 
 // IPC Flow Control Configuration
-// Sized to match the renderer-side TerminalOutputIngestService watermarks (128KB high / 32KB low).
-// 512KB ceiling = 4× renderer high watermark, holds ~8 saturated 64KB pipe-buffer events.
-// 75%/25% gives a 3:1 hysteresis where resume threshold (128KB) equals one renderer drain cycle.
-export const IPC_MAX_QUEUE_BYTES = 512 * 1024; // 512KB max per terminal
-export const IPC_HIGH_WATERMARK_PERCENT = 75; // Pause PTY at 75% full (384KB)
-export const IPC_LOW_WATERMARK_PERCENT = 25; // Resume PTY when drops to 25% (128KB)
-export const IPC_MAX_PAUSE_MS = 5000; // Force resume after 5 seconds to prevent indefinite pause
+// 3MB ceiling gives Claude Code completions, diffs, and tool outputs comfortable
+// headroom — real bursts land in the low-single-digit MB range, and a tighter cap
+// triggers backpressure during normal renderer micro-stalls and produces visible
+// output freezes. 67/33 hysteresis makes the drain window ~1MB (vs ~1.5MB at 75/25),
+// so the PTY resumes faster after a burst. Renderer watermarks (128KB high / 32KB
+// low in TerminalOutputIngestService) are a separate layer and unchanged — the IPC
+// queue is the burst absorber, the renderer watermarks throttle xterm consumption.
+export const IPC_MAX_QUEUE_BYTES = 3 * 1024 * 1024; // 3MB max per terminal
+export const IPC_HIGH_WATERMARK_PERCENT = 67; // Pause PTY at 67% full (~2MB)
+export const IPC_LOW_WATERMARK_PERCENT = 33; // Resume PTY when drops to 33% (~1MB)
+export const IPC_MAX_PAUSE_MS = 10000; // Force resume after 10s — accommodates degraded background-tab parse rates
 
 // MessagePort adaptive batching configuration
 export const PORT_BATCH_THRESHOLD_BYTES = 64 * 1024; // 64KB — sync-flush when buffered data exceeds this


### PR DESCRIPTION
## Summary

- `IPC_MAX_QUEUE_BYTES` raised from 512KB to 3MB — gives Claude Code bursts comfortable headroom without hitting backpressure on single-agent streams
- Watermarks shifted from 75/25 to 67/33 (~2MB pause / ~1MB resume), leaving a ~1MB drain window before force-resume kicks in (was ~1.5MB at the old ratios)
- `IPC_MAX_PAUSE_MS` raised from 5s to 10s to accommodate degraded xterm parse rates in background tabs

Resolves #7640

## Changes

- `electron/services/pty/types.ts` — 4 constants + updated comment
- `electron/pty-host/__tests__/portQueue.test.ts` — constants alignment block updated to match

## Testing

45 unit tests pass. All `npm run check` steps (typecheck, lint, format) clean.