### PR TITLE
fix(github): disable pointer events on bulk-action bar exit animation

### DIFF
--- a/src/components/GitHub/BulkActionBar.tsx
+++ b/src/components/GitHub/BulkActionBar.tsx
@@ -52,7 +52,7 @@ export function BulkActionBar({
           aria-label="Bulk actions"
           initial={{ y: "100%", opacity: 0 }}
           animate={{ y: 0, opacity: 1 }}
-          exit={{ y: "100%", opacity: 0 }}
+          exit={{ y: "100%", opacity: 0, pointerEvents: "none" }}
           transition={{ type: "spring", damping: 25, stiffness: 200 }}
           className="mx-2 mb-2 rounded-xl shadow-[var(--theme-shadow-floating)] bg-surface-panel ring-1 ring-border-default inset-shadow-[0_1px_0_var(--color-overlay-soft)] flex items-center gap-3 px-4 py-3"
         >

--- a/src/components/GitHub/__tests__/BulkActionBar.test.tsx
+++ b/src/components/GitHub/__tests__/BulkActionBar.test.tsx
@@ -1,0 +1,169 @@
+/**
+ * @vitest-environment jsdom
+ */
+import { describe, it, expect, vi, beforeEach, afterEach } from "vitest";
+import { render, screen, fireEvent, cleanup } from "@testing-library/react";
+import React from "react";
+import type { GitHubIssue, GitHubPR } from "@shared/types/github";
+
+const openBulkCreateDialog = vi.fn();
+const openBulkCreateDialogForPRs = vi.fn();
+
+vi.mock("@/store/worktreeStore", () => ({
+  useWorktreeSelectionStore: (selector: (s: unknown) => unknown) =>
+    selector({ openBulkCreateDialog, openBulkCreateDialogForPRs }),
+}));
+
+vi.mock("framer-motion", () => {
+  const MotionDiv = React.forwardRef<
+    HTMLDivElement,
+    React.HTMLAttributes<HTMLDivElement> & {
+      exit?: Record<string, unknown>;
+      initial?: unknown;
+      animate?: unknown;
+      transition?: unknown;
+    }
+  >(({ children, exit, initial, animate, transition, ...rest }, ref) => (
+    <div ref={ref} data-exit={exit ? JSON.stringify(exit) : undefined} {...rest}>
+      {children}
+    </div>
+  ));
+  return {
+    AnimatePresence: ({ children }: { children: React.ReactNode }) => <>{children}</>,
+    m: { div: MotionDiv },
+    motion: { div: MotionDiv },
+  };
+});
+
+import { BulkActionBar } from "../BulkActionBar";
+
+const makeIssue = (n: number): GitHubIssue => ({
+  number: n,
+  title: `Issue #${n}`,
+  url: `https://github.com/test/repo/issues/${n}`,
+  state: "OPEN",
+  updatedAt: "2026-01-01",
+  author: { login: "user", avatarUrl: "" },
+  assignees: [],
+  commentCount: 0,
+});
+
+const makePR = (n: number): GitHubPR => ({
+  number: n,
+  title: `PR #${n}`,
+  url: `https://github.com/test/repo/pull/${n}`,
+  state: "OPEN",
+  isDraft: false,
+  updatedAt: "2026-01-02",
+  author: { login: "user", avatarUrl: "" },
+});
+
+beforeEach(() => {
+  openBulkCreateDialog.mockReset();
+  openBulkCreateDialogForPRs.mockReset();
+});
+
+afterEach(() => {
+  cleanup();
+});
+
+describe("BulkActionBar", () => {
+  it("renders when issue selection is non-empty", () => {
+    render(
+      <BulkActionBar
+        mode="issue"
+        selectedIssues={[makeIssue(1), makeIssue(2)]}
+        selectedPRs={[]}
+        onClear={vi.fn()}
+      />
+    );
+
+    expect(screen.getByRole("toolbar", { name: /bulk actions/i })).toBeTruthy();
+    expect(screen.getByText("2")).toBeTruthy();
+  });
+
+  it("does not render when selection is empty", () => {
+    render(<BulkActionBar mode="issue" selectedIssues={[]} selectedPRs={[]} onClear={vi.fn()} />);
+
+    expect(screen.queryByRole("toolbar", { name: /bulk actions/i })).toBeNull();
+  });
+
+  it("disables pointer events on the exiting bar to prevent dead-click during exit animation", () => {
+    render(
+      <BulkActionBar
+        mode="issue"
+        selectedIssues={[makeIssue(1)]}
+        selectedPRs={[]}
+        onClear={vi.fn()}
+      />
+    );
+
+    const toolbar = screen.getByRole("toolbar", { name: /bulk actions/i });
+    const exitProp = toolbar.getAttribute("data-exit");
+    expect(exitProp).toBeTruthy();
+    const exit = JSON.parse(exitProp!) as Record<string, unknown>;
+    expect(exit.pointerEvents).toBe("none");
+  });
+
+  it("calls onClear when the X button is clicked", () => {
+    const onClear = vi.fn();
+    render(
+      <BulkActionBar
+        mode="issue"
+        selectedIssues={[makeIssue(1)]}
+        selectedPRs={[]}
+        onClear={onClear}
+      />
+    );
+
+    fireEvent.click(screen.getByRole("button", { name: /clear selection/i }));
+    expect(onClear).toHaveBeenCalledTimes(1);
+  });
+
+  it("opens bulk-create dialog with issues in issue mode", () => {
+    const onClear = vi.fn();
+    const issues = [makeIssue(1), makeIssue(2)];
+    render(
+      <BulkActionBar mode="issue" selectedIssues={issues} selectedPRs={[]} onClear={onClear} />
+    );
+
+    fireEvent.click(screen.getByRole("button", { name: /create worktrees/i }));
+    expect(openBulkCreateDialog).toHaveBeenCalledWith(issues, onClear);
+    expect(openBulkCreateDialogForPRs).not.toHaveBeenCalled();
+  });
+
+  it("opens bulk-create dialog with PRs in PR mode and uses PR count", () => {
+    const onClear = vi.fn();
+    const prs = [makePR(10), makePR(11), makePR(12)];
+    render(
+      <BulkActionBar
+        mode="pr"
+        selectedIssues={[makeIssue(99)]}
+        selectedPRs={prs}
+        onClear={onClear}
+      />
+    );
+
+    expect(screen.getByText("3")).toBeTruthy();
+
+    fireEvent.click(screen.getByRole("button", { name: /create worktrees/i }));
+    expect(openBulkCreateDialogForPRs).toHaveBeenCalledWith(prs, onClear);
+    expect(openBulkCreateDialog).not.toHaveBeenCalled();
+  });
+
+  it("invokes onCloseDropdown after opening the dialog", () => {
+    const onCloseDropdown = vi.fn();
+    render(
+      <BulkActionBar
+        mode="issue"
+        selectedIssues={[makeIssue(1)]}
+        selectedPRs={[]}
+        onClear={vi.fn()}
+        onCloseDropdown={onCloseDropdown}
+      />
+    );
+
+    fireEvent.click(screen.getByRole("button", { name: /create worktrees/i }));
+    expect(onCloseDropdown).toHaveBeenCalledTimes(1);
+  });
+});

--- a/src/hooks/__tests__/useIssueSelection.test.ts
+++ b/src/hooks/__tests__/useIssueSelection.test.ts
@@ -92,4 +92,19 @@ describe("useIssueSelection", () => {
     expect(result.current.selectedIds.has(30)).toBe(true);
     expect(result.current.selectedIds.size).toBe(1);
   });
+
+  it("clear is idempotent when selection is already empty", () => {
+    const { result } = renderHook(() => useIssueSelection());
+
+    const initialIds = result.current.selectedIds;
+    expect(initialIds.size).toBe(0);
+
+    act(() => result.current.clear());
+    expect(result.current.selectedIds.size).toBe(0);
+    expect(result.current.selectedIds).toBe(initialIds);
+
+    act(() => result.current.clear());
+    expect(result.current.selectedIds.size).toBe(0);
+    expect(result.current.selectedIds).toBe(initialIds);
+  });
 });


### PR DESCRIPTION
## Summary

- The clear-selection X button in the bulk action bar looked unresponsive — first click dispatched `CLEAR` correctly, but the `m.div` stayed in the hit-test tree with pointer events active during its exit animation, so follow-up clicks landed silently on the exiting element
- Fix: adds `pointerEvents: "none"` to the `exit` variant on `BulkActionBar`'s `m.div`, pulling the element out of the hit-test tree the moment the animation begins

Resolves #7645

## Changes

- `src/components/GitHub/BulkActionBar.tsx` — adds `pointerEvents: "none"` to the `exit` animation variant
- `src/components/GitHub/__tests__/BulkActionBar.test.tsx` — 7 new tests; mocks framer-motion to assert the `exit` prop carries `pointerEvents: "none"`
- `src/hooks/__tests__/useIssueSelection.test.ts` — adds idempotent-clear test (calling `CLEAR` on an already-empty selection returns the same state reference)

## Testing

Regression tests mock framer-motion's `AnimatePresence` and `motion.div` to inspect the props passed, confirming the `exit` variant disables pointer events. Idempotent-clear test confirms the reducer short-circuits cleanly on an empty set.