### PR TITLE
fix(github): clear bulk selection on dropdown and dialog dismissal

### DIFF
--- a/src/components/GitHub/BulkActionBar.tsx
+++ b/src/components/GitHub/BulkActionBar.tsx
@@ -10,6 +10,7 @@ interface BulkActionBarProps {
   mode: "issue" | "pr";
   selectedIssues: GitHubIssue[];
   selectedPRs: GitHubPR[];
+  selectedCount: number;
   onClear: () => void;
   onCloseDropdown?: () => void;
 }
@@ -18,13 +19,14 @@ export function BulkActionBar({
   mode,
   selectedIssues,
   selectedPRs,
+  selectedCount,
   onClear,
   onCloseDropdown,
 }: BulkActionBarProps) {
   const openBulkCreateDialog = useWorktreeSelectionStore((s) => s.openBulkCreateDialog);
   const openBulkCreateDialogForPRs = useWorktreeSelectionStore((s) => s.openBulkCreateDialogForPRs);
 
-  const count = mode === "pr" ? selectedPRs.length : selectedIssues.length;
+  const count = selectedCount;
 
   const handleOpenDialog = useCallback(() => {
     if (mode === "pr") {

--- a/src/components/GitHub/BulkCreateWorktreeDialog.tsx
+++ b/src/components/GitHub/BulkCreateWorktreeDialog.tsx
@@ -790,6 +790,9 @@ export function BulkCreateWorktreeDialog({
   }, [progress.items, planned, runBatch]);
 
   const handleClose = useCallback(() => {
+    // Capture before onClose() — onClose is wired to closeBulkCreateDialog upstream,
+    // which zeroes out the stored callback as part of its reset.
+    const storedOnComplete = useWorktreeSelectionStore.getState().bulkCreateDialog.onComplete;
     if (isExecuting) {
       runIdRef.current++;
       queueRef.current?.clear();
@@ -797,6 +800,7 @@ export function BulkCreateWorktreeDialog({
     }
     isExecutingRef.current = false;
     onClose();
+    storedOnComplete?.();
   }, [isExecuting, onClose]);
 
   const handleDone = useCallback(() => {

--- a/src/components/GitHub/GitHubResourceList.tsx
+++ b/src/components/GitHub/GitHubResourceList.tsx
@@ -128,6 +128,13 @@ interface GitHubResourceListProps {
    * for the next 30s stats poll.
    */
   onFreshFetch?: () => void;
+  /**
+   * Tracks the parent popover's open state. The list is `keepMounted`, so
+   * outside-click / Escape / toolbar-toggle dismissals never trigger a
+   * close handler inside this tree — watching this prop transition true→false
+   * lets the list run its dismissal cleanup (clear bulk selection).
+   */
+  isOpen?: boolean;
 }
 
 export function GitHubResourceList({
@@ -136,6 +143,7 @@ export function GitHubResourceList({
   onClose,
   initialCount,
   onFreshFetch,
+  isOpen,
 }: GitHubResourceListProps) {
   const searchQuery = useGitHubFilterStore((s) =>
     type === "issue" ? s.issueSearchQuery : s.prSearchQuery
@@ -312,6 +320,17 @@ export function GitHubResourceList({
     onClose?.();
   }, [onClose, selection]);
 
+  const prevIsOpenRef = useRef<boolean | undefined>(undefined);
+  useEffect(() => {
+    // Popover is keepMounted, so outside-click / Escape / toolbar-toggle never
+    // call onClose. Watch the parent's open state and run dismissal cleanup
+    // (selection clear, cache reset) on a true→false transition.
+    if (prevIsOpenRef.current === true && isOpen === false) {
+      handleClose();
+    }
+    prevIsOpenRef.current = isOpen;
+  }, [isOpen, handleClose]);
+
   const handleOpenInGitHub = () => {
     const query = searchQuery.trim() || undefined;
     const state = filterState as string;
@@ -470,8 +489,8 @@ export function GitHubResourceList({
       { tab: "github", sectionId: "github-token" },
       { source: "user" }
     );
-    onClose?.();
-  }, [onClose]);
+    handleClose();
+  }, [handleClose]);
 
   const footerContext = useMemo<LoadMoreFooterContext>(
     () => ({
@@ -1024,6 +1043,7 @@ export function GitHubResourceList({
                 .filter((pr): pr is GitHubPR => pr !== undefined)
             : []
         }
+        selectedCount={selection.selectedIds.size}
         onClear={selection.clear}
         onCloseDropdown={onClose}
       />

--- a/src/components/GitHub/GitHubResourceList.tsx
+++ b/src/components/GitHub/GitHubResourceList.tsx
@@ -313,23 +313,39 @@ export function GitHubResourceList({
     ];
   }, [type]);
 
-  const handleClose = useCallback(() => {
+  // Idempotency guard: dismissal cleanup runs at most once per open-cycle.
+  // A click-initiated close (e.g. settings link) calls handleClose AND causes
+  // the parent to flip isOpen=false, which would otherwise re-fire cleanup
+  // through the isOpen effect below.
+  const cleanedUpRef = useRef(false);
+
+  const runDismissalCleanup = useCallback(() => {
+    if (cleanedUpRef.current) return;
+    cleanedUpRef.current = true;
     selection.clear();
     setIssueCache(new Map());
     setPrCache(new Map());
+  }, [selection]);
+
+  const handleClose = useCallback(() => {
+    runDismissalCleanup();
     onClose?.();
-  }, [onClose, selection]);
+  }, [onClose, runDismissalCleanup]);
 
   const prevIsOpenRef = useRef<boolean | undefined>(undefined);
   useEffect(() => {
     // Popover is keepMounted, so outside-click / Escape / toolbar-toggle never
-    // call onClose. Watch the parent's open state and run dismissal cleanup
-    // (selection clear, cache reset) on a true→false transition.
+    // call onClose. Watch the parent's open state and run dismissal cleanup on
+    // a true→false transition. Reset the cleanup flag on each (re)open so the
+    // next dismissal can run.
+    if (isOpen === true) {
+      cleanedUpRef.current = false;
+    }
     if (prevIsOpenRef.current === true && isOpen === false) {
-      handleClose();
+      runDismissalCleanup();
     }
     prevIsOpenRef.current = isOpen;
-  }, [isOpen, handleClose]);
+  }, [isOpen, runDismissalCleanup]);
 
   const handleOpenInGitHub = () => {
     const query = searchQuery.trim() || undefined;
@@ -1045,6 +1061,9 @@ export function GitHubResourceList({
         }
         selectedCount={selection.selectedIds.size}
         onClear={selection.clear}
+        // Pass the raw onClose (not handleClose) — opening the bulk dialog
+        // hands selected items off by value, and selection cleanup is then
+        // driven by the dialog's stored onComplete (or the isOpen effect).
         onCloseDropdown={onClose}
       />
     </div>

--- a/src/components/GitHub/__tests__/BulkCreateWorktreeDialog.test.tsx
+++ b/src/components/GitHub/__tests__/BulkCreateWorktreeDialog.test.tsx
@@ -1325,18 +1325,25 @@ describe("BulkCreateWorktreeDialog", () => {
     expect(storedOnComplete).toHaveBeenCalledTimes(1);
   });
 
-  it("does not invoke stored bulkCreateDialog.onComplete when dialog is cancelled", async () => {
+  it("invokes stored bulkCreateDialog.onComplete when dialog is cancelled (issue #7644)", async () => {
     const storedOnComplete = vi.fn();
     mockBulkCreateDialog.onComplete = storedOnComplete;
+    // Mirrors closeBulkCreateDialog: onClose zeroes the stored callback as part
+    // of its reset. handleClose must capture the stored callback BEFORE calling
+    // onClose, otherwise the dismissal path leaks selection state across opens.
+    const propOnClose = vi.fn(() => {
+      mockBulkCreateDialog.onComplete = undefined;
+    });
 
-    render(<BulkCreateWorktreeDialog {...defaultProps} />);
+    render(<BulkCreateWorktreeDialog {...defaultProps} onClose={propOnClose} />);
 
-    // Cancel from idle state via Cancel button (handleClose path)
+    // Cancel from idle state via Cancel button (handleClose path).
     await act(async () => {
       screen.getByText("Cancel").click();
     });
 
-    expect(storedOnComplete).not.toHaveBeenCalled();
+    expect(storedOnComplete).toHaveBeenCalledTimes(1);
+    expect(propOnClose).toHaveBeenCalledTimes(1);
   });
 
   it("clone layout generates command for agent panels and preserves plain terminal commands", async () => {

--- a/src/components/GitHub/__tests__/GitHubResourceList.swr.test.tsx
+++ b/src/components/GitHub/__tests__/GitHubResourceList.swr.test.tsx
@@ -59,6 +59,7 @@ vi.mock("@/services/ActionService", () => ({
 }));
 
 let mockIsSelectionActive = false;
+const mockSelectionClear = vi.fn();
 
 vi.mock("@/hooks/useIssueSelection", () => ({
   useIssueSelection: () => ({
@@ -69,7 +70,7 @@ vi.mock("@/hooks/useIssueSelection", () => ({
     toggle: vi.fn(),
     toggleRange: vi.fn(),
     selectAll: vi.fn(),
-    clear: vi.fn(),
+    clear: mockSelectionClear,
   }),
 }));
 
@@ -195,6 +196,7 @@ beforeEach(() => {
   LiveTimeAgoMock.mockClear();
   dispatchMock.mockReset();
   initializeMock.mockClear();
+  mockSelectionClear.mockReset();
   mockIsSelectionActive = false;
   mockGitHubConfig = { hasToken: true };
   mockGitHubConfigInitialized = true;
@@ -1909,5 +1911,50 @@ describe("GitHubResourceList polish (#7202)", () => {
     } finally {
       vi.useRealTimers();
     }
+  });
+});
+
+describe("GitHubResourceList dismissal cleanup (#7644)", () => {
+  it("clears selection when isOpen transitions true → false", () => {
+    mockListIssues.mockResolvedValue(makeResponse([makeIssue(1)]));
+
+    const { rerender } = render(
+      <GitHubResourceList type="issue" projectPath="/test/proj" isOpen={true} />
+    );
+    expect(mockSelectionClear).not.toHaveBeenCalled();
+
+    rerender(<GitHubResourceList type="issue" projectPath="/test/proj" isOpen={false} />);
+
+    expect(mockSelectionClear).toHaveBeenCalledTimes(1);
+  });
+
+  it("does not clear selection on initial mount with isOpen=false", () => {
+    mockListIssues.mockResolvedValue(makeResponse([makeIssue(1)]));
+
+    render(<GitHubResourceList type="issue" projectPath="/test/proj" isOpen={false} />);
+
+    expect(mockSelectionClear).not.toHaveBeenCalled();
+  });
+
+  it("does not clear selection when isOpen prop is omitted (no parent control)", () => {
+    mockListIssues.mockResolvedValue(makeResponse([makeIssue(1)]));
+
+    const { rerender } = render(<GitHubResourceList type="issue" projectPath="/test/proj" />);
+    rerender(<GitHubResourceList type="issue" projectPath="/test/proj" />);
+
+    expect(mockSelectionClear).not.toHaveBeenCalled();
+  });
+
+  it("clears selection when the no-token settings link is clicked", () => {
+    mockGitHubConfig = { hasToken: false };
+    mockGitHubConfigInitialized = true;
+    const onClose = vi.fn();
+
+    render(<GitHubResourceList type="issue" projectPath="/test/proj" onClose={onClose} />);
+
+    screen.getByRole("button", { name: /add github token/i }).click();
+
+    expect(mockSelectionClear).toHaveBeenCalledTimes(1);
+    expect(onClose).toHaveBeenCalledTimes(1);
   });
 });

--- a/src/components/GitHub/__tests__/GitHubResourceList.swr.test.tsx
+++ b/src/components/GitHub/__tests__/GitHubResourceList.swr.test.tsx
@@ -1957,4 +1957,42 @@ describe("GitHubResourceList dismissal cleanup (#7644)", () => {
     expect(mockSelectionClear).toHaveBeenCalledTimes(1);
     expect(onClose).toHaveBeenCalledTimes(1);
   });
+
+  it("does not double-clear when click-path also flips isOpen=false", () => {
+    // Click-initiated close (handleClose) calls onClose; the parent reacts by
+    // setting isOpen=false, which would otherwise re-fire cleanup via the
+    // useEffect. The cleanedUpRef guard must absorb the second call.
+    mockGitHubConfig = { hasToken: false };
+    mockGitHubConfigInitialized = true;
+    const onClose = vi.fn();
+
+    const { rerender } = render(
+      <GitHubResourceList type="issue" projectPath="/test/proj" isOpen={true} onClose={onClose} />
+    );
+
+    screen.getByRole("button", { name: /add github token/i }).click();
+
+    rerender(
+      <GitHubResourceList type="issue" projectPath="/test/proj" isOpen={false} onClose={onClose} />
+    );
+
+    expect(mockSelectionClear).toHaveBeenCalledTimes(1);
+    expect(onClose).toHaveBeenCalledTimes(1);
+  });
+
+  it("re-arms cleanup on each open cycle", () => {
+    mockListIssues.mockResolvedValue(makeResponse([makeIssue(1)]));
+
+    const { rerender } = render(
+      <GitHubResourceList type="issue" projectPath="/test/proj" isOpen={true} />
+    );
+    rerender(<GitHubResourceList type="issue" projectPath="/test/proj" isOpen={false} />);
+    expect(mockSelectionClear).toHaveBeenCalledTimes(1);
+
+    // Reopen and close again — cleanup must run a second time.
+    rerender(<GitHubResourceList type="issue" projectPath="/test/proj" isOpen={true} />);
+    rerender(<GitHubResourceList type="issue" projectPath="/test/proj" isOpen={false} />);
+
+    expect(mockSelectionClear).toHaveBeenCalledTimes(2);
+  });
 });

--- a/src/components/Layout/GitHubStatsToolbarButton.tsx
+++ b/src/components/Layout/GitHubStatsToolbarButton.tsx
@@ -644,6 +644,7 @@ export const GitHubStatsToolbarButton = memo(
                 }}
                 initialCount={stats?.issueCount}
                 onFreshFetch={handleListFreshFetch}
+                isOpen={issuesOpen}
               />
             ) : (
               <Suspense
@@ -661,6 +662,7 @@ export const GitHubStatsToolbarButton = memo(
                   }}
                   initialCount={stats?.issueCount}
                   onFreshFetch={handleListFreshFetch}
+                  isOpen={issuesOpen}
                 />
               </Suspense>
             )
@@ -750,6 +752,7 @@ export const GitHubStatsToolbarButton = memo(
                 }}
                 initialCount={stats?.prCount}
                 onFreshFetch={handleListFreshFetch}
+                isOpen={prsOpen}
               />
             ) : (
               <Suspense
@@ -765,6 +768,7 @@ export const GitHubStatsToolbarButton = memo(
                   }}
                   initialCount={stats?.prCount}
                   onFreshFetch={handleListFreshFetch}
+                  isOpen={prsOpen}
                 />
               </Suspense>
             )


### PR DESCRIPTION
## Summary

After creating worktrees from a bulk issue/PR selection, the selected items would persist in the dropdown when it was reopened. The selection state wasn't being cleared on dismissal — only on explicit completion.

Resolves #7644

## Changes

- `GitHubResourceList`: adds an `isOpen` prop tracked with a prev-value ref and a `cleanedUpRef` guard so dismissal cleanup fires at most once per open cycle. `handleOpenGitHubSettings` now routes through `handleClose` to ensure selection is cleared before navigating away. `BulkActionBar` receives `selectedCount` from `selectedIds.size` directly rather than the cache-resolved array, so the badge reflects pending selections accurately.
- `BulkCreateWorktreeDialog`: `handleClose` captures the stored `onComplete` callback before calling `onClose()` and invokes it after, so Cancel/Escape/backdrop trigger the same cleanup as Done.
- `GitHubStatsToolbarButton`: wires `isOpen` to all four `GitHubResourceList` mount points (eager + lazy, issues + PRs).
- `BulkActionBar`: new `selectedCount` prop drives the badge count.
- Tests: corrected the existing "cancel does not invoke onComplete" assertion (it now should), plus 6 new tests covering `isOpen` transitions, the initial-mount guard, omitted-prop behaviour, settings-link cleanup, double-fire guard, and re-arm-on-reopen.

## Testing

- 135 targeted unit tests pass.
- Typecheck, lint, format, and build all clean.
- Scope is dismissal paths only — the X-button is being handled separately, and clearing-on-reopen is tracked under #7645.