### PR TITLE
fix(e2e,resource): terminal selection lost in context menu test + provision no-op skips connect command sync

### DIFF
--- a/e2e/full/terminal/core-terminal-context-menu.spec.ts
+++ b/e2e/full/terminal/core-terminal-context-menu.spec.ts
@@ -134,7 +134,7 @@ test.describe.serial("Core: Terminal Context Menu", () => {
       const { window } = ctx;
 
       await selectAllTerminalText(panel);
-      await openTerminalContextMenu(panel);
+      await openTerminalContextMenu(panel, { preserveSelection: true });
 
       const copyItem = window.getByRole("menuitem", { name: "Copy" });
       await expect(copyItem).toBeVisible({ timeout: T_SHORT });

--- a/e2e/helpers/terminal.ts
+++ b/e2e/helpers/terminal.ts
@@ -320,7 +320,10 @@ async function dispatchXtermContextMenu(xterm: Locator): Promise<boolean> {
   });
 }
 
-export async function openTerminalContextMenu(panelLocator: Locator): Promise<void> {
+export async function openTerminalContextMenu(
+  panelLocator: Locator,
+  { preserveSelection = false }: { preserveSelection?: boolean } = {}
+): Promise<void> {
   const page = panelLocator.page();
   const menu = page.locator(SEL.contextMenu.content);
   const xterm = panelLocator.locator(SEL.terminal.xtermRows);
@@ -328,7 +331,12 @@ export async function openTerminalContextMenu(panelLocator: Locator): Promise<vo
 
   for (let attempt = 0; attempt < 3; attempt++) {
     await dismissBlockingPalette(page);
-    await page.keyboard.press("Escape").catch(() => undefined);
+    // Skip Escape when preserveSelection is true: xterm.js calls clearSelection()
+    // synchronously in _keyDown for non-browser-handled keys (including Escape),
+    // so sending Escape while xterm has focus destroys any prior selectAll() call.
+    if (!preserveSelection) {
+      await page.keyboard.press("Escape").catch(() => undefined);
+    }
 
     if (attempt === 0) {
       await xterm.click({ button: "right", timeout: 5_000 }).catch(() => undefined);

--- a/electron/workspace-host/ResourceActionExecutor.ts
+++ b/electron/workspace-host/ResourceActionExecutor.ts
@@ -137,6 +137,11 @@ export class ResourceActionExecutor {
         console.log(
           `[WorktreeLifecycle] Provision no-op for worktree ${worktreeId}: already ${currentStatus}`
         );
+        // applyResourceConfigToMonitor already ran above and may have updated
+        // resourceConnectCommand (e.g. when the config file changed on disk since
+        // the last provision). Emit an update so the renderer's store reflects the
+        // new command before returning early.
+        this.ctx.emitUpdate(monitor);
         this.ctx.sendEvent({
           type: "resource-action-result",
           requestId,

--- a/electron/workspace-host/ResourceActionExecutor.ts
+++ b/electron/workspace-host/ResourceActionExecutor.ts
@@ -137,11 +137,17 @@ export class ResourceActionExecutor {
         console.log(
           `[WorktreeLifecycle] Provision no-op for worktree ${worktreeId}: already ${currentStatus}`
         );
-        // applyResourceConfigToMonitor already ran above and may have updated
-        // resourceConnectCommand (e.g. when the config file changed on disk since
-        // the last provision). Emit an update so the renderer's store reflects the
-        // new command before returning early.
-        this.ctx.emitUpdate(monitor);
+        // Re-fetch monitor — it may have been removed during loadConfig await.
+        // Without this, emitUpdate broadcasts a snapshot that the renderer would
+        // resurrect via its monotonic version counter (worktree-update arriving
+        // after worktree-removed re-inserts the entry).
+        const liveMonitor = this.ctx.getMonitor(worktreeId);
+        if (liveMonitor) {
+          // applyResourceConfigToMonitor already ran above and may have updated
+          // resourceConnectCommand (e.g. when the config file changed on disk
+          // since the last provision). Emit so the renderer store sees it.
+          this.ctx.emitUpdate(liveMonitor);
+        }
         this.ctx.sendEvent({
           type: "resource-action-result",
           requestId,

--- a/electron/workspace-host/__tests__/WorkspaceService.resource.test.ts
+++ b/electron/workspace-host/__tests__/WorkspaceService.resource.test.ts
@@ -1040,6 +1040,30 @@ describe("WorkspaceService.runResourceAction", () => {
       );
     });
 
+    it("no-op provision skips worktree-update when monitor removed during config load", async () => {
+      const monitor = createAndRegisterMonitor();
+      monitor.setResourceStatus({ lastStatus: "ready", lastCheckedAt: Date.now() });
+
+      // Mock loadConfig to remove the monitor mid-await, simulating a concurrent
+      // worktree removal (e.g. user deletes the worktree while provision is in flight).
+      const lifecycleService = service["lifecycleService"];
+      vi.spyOn(lifecycleService, "loadConfig").mockImplementation(async () => {
+        service["monitors"].delete(monitor.id);
+        return { resource: { provision: ["terraform apply"] } } as never;
+      });
+
+      await service.runResourceAction("req-prov-removed", "/test/worktree", "provision");
+
+      // resource-action-result still sent (it carries no monitor data — no resurrection risk),
+      // but worktree-update must NOT fire for a removed monitor.
+      expect(mockSendEvent).toHaveBeenCalledWith(
+        expect.objectContaining({ type: "resource-action-result", success: true })
+      );
+      expect(mockSendEvent).not.toHaveBeenCalledWith(
+        expect.objectContaining({ type: "worktree-update" })
+      );
+    });
+
     it("provision routes to resume when status is `paused`", async () => {
       const monitor = createAndRegisterMonitor();
       await setupConfig({

--- a/electron/workspace-host/__tests__/WorkspaceService.resource.test.ts
+++ b/electron/workspace-host/__tests__/WorkspaceService.resource.test.ts
@@ -1017,6 +1017,29 @@ describe("WorkspaceService.runResourceAction", () => {
       expect(runCommandsSpy).toHaveBeenCalledTimes(0);
     });
 
+    it("no-op provision broadcasts updated resourceConnectCommand to renderer", async () => {
+      const monitor = createAndRegisterMonitor({ branch: "feature/remote" });
+      await setupConfig({
+        resource: {
+          provision: ["terraform apply"],
+          connect: "ssh root@{{branch}}.dev.example.com",
+        },
+      });
+      monitor.setResourceStatus({ lastStatus: "ready", lastCheckedAt: Date.now() });
+
+      await service.runResourceAction("req-prov-noop-emit", "/test/worktree", "provision");
+
+      expect(monitor.resourceConnectCommand).toBe("ssh root@'feature/remote'.dev.example.com");
+      expect(mockSendEvent).toHaveBeenCalledWith(
+        expect.objectContaining({
+          type: "worktree-update",
+          worktree: expect.objectContaining({
+            resourceConnectCommand: "ssh root@'feature/remote'.dev.example.com",
+          }),
+        })
+      );
+    });
+
     it("provision routes to resume when status is `paused`", async () => {
       const monitor = createAndRegisterMonitor();
       await setupConfig({


### PR DESCRIPTION
## Summary

Two nightly E2E failures fixed (Ubuntu x86-64, full suite run):

**1. `core-terminal-context-menu` — Copy always disabled after selectAll**

- `openTerminalContextMenu` sends `page.keyboard.press("Escape")` at the start of each attempt before right-clicking
- xterm.js 6.0 calls `clearSelection()` synchronously in `_keyDown` for any key that isn't browser-handled (Escape is forwarded to the PTY — it's not browser-handled)
- This destroyed any prior `selectAll()` call before the `contextmenu` event could read the selection via `terminal.getSelection()`
- Fix: add `preserveSelection` option to `openTerminalContextMenu` that skips the Escape; the "Copy is enabled after selecting text" test passes `{ preserveSelection: true }`

**2. `core-worktree-resource-lifecycle` — `{{branch}}`/`{{worktree_path}}` substitution ignored**

- When re-provisioning a resource that is already in a ready state, `ResourceActionExecutor.execute` correctly calls `applyResourceConfigToMonitor` (which updates `monitor.resourceConnectCommand` with the new substituted command from the on-disk config), but then returns early without calling `this.ctx.emitUpdate(monitor)`
- The renderer's Zustand store never received the updated connect command; "Connect to Resource" used the stale original command stored from the previous provision
- Fix: call `this.ctx.emitUpdate(monitor)` before the early return so the renderer always has the current connect command after any provision call

## Test plan

- [x] `npx playwright test e2e/full/terminal/core-terminal-context-menu.spec.ts --project=full-terminal` → 10 passed (Ubuntu)
- [x] `npx playwright test e2e/full/worktree/core-worktree-resource-lifecycle.spec.ts --project=full-worktree` → 14 passed (Ubuntu)
- [x] `npm run typecheck` → passes