### PR TITLE
feat(worktree): promote QuickStateFilterBar to a combined status and filter bar

### DIFF
--- a/src/components/Worktree/QuickStateFilterBar.tsx
+++ b/src/components/Worktree/QuickStateFilterBar.tsx
@@ -1,5 +1,6 @@
 import { cn } from "@/lib/utils";
 import type { QuickStateFilter } from "@/lib/worktreeFilters";
+import { STATE_ICONS, STATE_COLORS } from "./terminalStateConfig";
 
 const FILTER_OPTIONS: { value: QuickStateFilter; label: string }[] = [
   { value: "all", label: "All" },
@@ -8,6 +9,15 @@ const FILTER_OPTIONS: { value: QuickStateFilter; label: string }[] = [
   { value: "finished", label: "Finished" },
 ];
 
+const FILTER_VISUALS: Record<
+  Exclude<QuickStateFilter, "all">,
+  { Icon: React.ComponentType<{ className?: string }>; color: string }
+> = {
+  working: { Icon: STATE_ICONS.working, color: STATE_COLORS.working },
+  waiting: { Icon: STATE_ICONS.waiting, color: STATE_COLORS.waiting },
+  finished: { Icon: STATE_ICONS.completed, color: STATE_COLORS.completed },
+};
+
 interface QuickStateFilterBarProps {
   value: QuickStateFilter;
   onChange: (value: QuickStateFilter) => void;
@@ -15,6 +25,7 @@ interface QuickStateFilterBarProps {
 }
 
 export function QuickStateFilterBar({ value, onChange, counts }: QuickStateFilterBarProps) {
+  const workingActive = counts !== undefined && counts.working > 0;
   return (
     <div
       className="flex items-center gap-1 px-4 py-1.5 border-b border-border-default"
@@ -24,6 +35,8 @@ export function QuickStateFilterBar({ value, onChange, counts }: QuickStateFilte
       {FILTER_OPTIONS.map((option) => {
         const isActive = option.value === value;
         const count = counts && option.value !== "all" ? counts[option.value] : undefined;
+        const visual = option.value === "all" ? null : FILTER_VISUALS[option.value];
+        const Icon = visual?.Icon;
         return (
           <button
             key={option.value}
@@ -31,12 +44,23 @@ export function QuickStateFilterBar({ value, onChange, counts }: QuickStateFilte
             aria-pressed={isActive}
             onClick={() => onChange(isActive ? "all" : option.value)}
             className={cn(
-              "inline-flex items-center px-2 py-0.5 text-[11px] rounded-full transition-colors",
+              "inline-flex items-center gap-1.5 px-3 py-1 text-xs rounded-full transition-colors",
               isActive
                 ? "bg-overlay-strong ring-1 ring-inset ring-border-strong text-daintree-text font-medium"
                 : "text-daintree-text/60 hover:text-daintree-text hover:bg-tint/[0.04]"
             )}
           >
+            {Icon && visual && (
+              <Icon
+                className={cn(
+                  "w-3.5 h-3.5",
+                  visual.color,
+                  option.value === "working" &&
+                    workingActive &&
+                    "animate-spin-slow motion-reduce:animate-none"
+                )}
+              />
+            )}
             {option.label}
             {/* "All" has no count — quickStateCounts excludes main/integration worktrees, so the sum != the sidebar header's (N) total. */}
             {count !== undefined && (

--- a/src/components/Worktree/__tests__/QuickStateFilterBar.test.tsx
+++ b/src/components/Worktree/__tests__/QuickStateFilterBar.test.tsx
@@ -151,4 +151,78 @@ describe("QuickStateFilterBar", () => {
     render(<QuickStateFilterBar value="all" onChange={() => {}} />);
     expect(screen.getByText("All").getAttribute("aria-pressed")).toBe("true");
   });
+
+  it("renders a state icon on each non-All pill and no icon on All", () => {
+    render(
+      <QuickStateFilterBar
+        value="all"
+        onChange={() => {}}
+        counts={{ working: 1, waiting: 1, finished: 1 }}
+      />
+    );
+    const all = screen.getByRole("button", { name: /^All$/ });
+    const working = screen.getByRole("button", { name: /Working/ });
+    const waiting = screen.getByRole("button", { name: /Waiting/ });
+    const finished = screen.getByRole("button", { name: /Finished/ });
+    expect(all.querySelector("svg")).toBeNull();
+    expect(working.querySelector("svg")).not.toBeNull();
+    expect(waiting.querySelector("svg")).not.toBeNull();
+    expect(finished.querySelector("svg")).not.toBeNull();
+  });
+
+  it("applies state-color tokens to each pill's icon", () => {
+    render(
+      <QuickStateFilterBar
+        value="all"
+        onChange={() => {}}
+        counts={{ working: 1, waiting: 1, finished: 1 }}
+      />
+    );
+    const working = screen.getByRole("button", { name: /Working/ });
+    const waiting = screen.getByRole("button", { name: /Waiting/ });
+    const finished = screen.getByRole("button", { name: /Finished/ });
+    expect(working.querySelector("svg")?.getAttribute("class") ?? "").toContain(
+      "text-state-working"
+    );
+    expect(waiting.querySelector("svg")?.getAttribute("class") ?? "").toContain(
+      "text-state-waiting"
+    );
+    expect(finished.querySelector("svg")?.getAttribute("class") ?? "").toContain(
+      "text-status-success"
+    );
+  });
+
+  it("spins the working icon when counts.working > 0 even if Working is not the active filter", () => {
+    render(
+      <QuickStateFilterBar
+        value="all"
+        onChange={() => {}}
+        counts={{ working: 2, waiting: 0, finished: 0 }}
+      />
+    );
+    const working = screen.getByRole("button", { name: /Working/ });
+    const svgClass = working.querySelector("svg")?.getAttribute("class") ?? "";
+    expect(svgClass).toContain("animate-spin-slow");
+    expect(svgClass).toContain("motion-reduce:animate-none");
+  });
+
+  it("does not spin the working icon when counts.working is zero", () => {
+    render(
+      <QuickStateFilterBar
+        value="all"
+        onChange={() => {}}
+        counts={{ working: 0, waiting: 1, finished: 1 }}
+      />
+    );
+    const working = screen.getByRole("button", { name: /Working/ });
+    const svgClass = working.querySelector("svg")?.getAttribute("class") ?? "";
+    expect(svgClass).not.toContain("animate-spin-slow");
+  });
+
+  it("does not spin the working icon when counts prop is omitted", () => {
+    render(<QuickStateFilterBar value="all" onChange={() => {}} />);
+    const working = screen.getByRole("button", { name: /Working/ });
+    const svgClass = working.querySelector("svg")?.getAttribute("class") ?? "";
+    expect(svgClass).not.toContain("animate-spin-slow");
+  });
 });

--- a/src/components/Worktree/__tests__/QuickStateFilterBar.test.tsx
+++ b/src/components/Worktree/__tests__/QuickStateFilterBar.test.tsx
@@ -201,9 +201,27 @@ describe("QuickStateFilterBar", () => {
       />
     );
     const working = screen.getByRole("button", { name: /Working/ });
-    const svgClass = working.querySelector("svg")?.getAttribute("class") ?? "";
+    const svg = working.querySelector("svg");
+    expect(svg).not.toBeNull();
+    const svgClass = svg?.getAttribute("class") ?? "";
     expect(svgClass).toContain("animate-spin-slow");
     expect(svgClass).toContain("motion-reduce:animate-none");
+  });
+
+  it("keeps the working icon spinning while Working is the active filter", () => {
+    render(
+      <QuickStateFilterBar
+        value="working"
+        onChange={() => {}}
+        counts={{ working: 2, waiting: 0, finished: 0 }}
+      />
+    );
+    const working = screen.getByRole("button", { name: /Working/ });
+    expect(working.getAttribute("aria-pressed")).toBe("true");
+    expect(working.className).toContain("bg-overlay-strong");
+    const svg = working.querySelector("svg");
+    expect(svg).not.toBeNull();
+    expect(svg?.getAttribute("class") ?? "").toContain("animate-spin-slow");
   });
 
   it("does not spin the working icon when counts.working is zero", () => {
@@ -215,14 +233,32 @@ describe("QuickStateFilterBar", () => {
       />
     );
     const working = screen.getByRole("button", { name: /Working/ });
-    const svgClass = working.querySelector("svg")?.getAttribute("class") ?? "";
-    expect(svgClass).not.toContain("animate-spin-slow");
+    const svg = working.querySelector("svg");
+    expect(svg).not.toBeNull();
+    expect(svg?.getAttribute("class") ?? "").not.toContain("animate-spin-slow");
   });
 
   it("does not spin the working icon when counts prop is omitted", () => {
     render(<QuickStateFilterBar value="all" onChange={() => {}} />);
     const working = screen.getByRole("button", { name: /Working/ });
-    const svgClass = working.querySelector("svg")?.getAttribute("class") ?? "";
-    expect(svgClass).not.toContain("animate-spin-slow");
+    const svg = working.querySelector("svg");
+    expect(svg).not.toBeNull();
+    expect(svg?.getAttribute("class") ?? "").not.toContain("animate-spin-slow");
+  });
+
+  it("marks each pill icon as aria-hidden so the accessible name stays clean", () => {
+    render(
+      <QuickStateFilterBar
+        value="all"
+        onChange={() => {}}
+        counts={{ working: 1, waiting: 1, finished: 1 }}
+      />
+    );
+    for (const name of [/Working/, /Waiting/, /Finished/]) {
+      const button = screen.getByRole("button", { name });
+      const svg = button.querySelector("svg");
+      expect(svg).not.toBeNull();
+      expect(svg?.getAttribute("aria-hidden")).toBe("true");
+    }
   });
 });


### PR DESCRIPTION
## Summary

- Promotes `QuickStateFilterBar` from plain text chips into a combined status display and filter control — the non-`All` pills now carry state-colored icons (`SpinnerCircle` for working, `HollowCircle` for waiting, `CheckCircle2` for finished)
- The Working pill's spinner animates whenever `counts.working > 0`, regardless of which filter is active, giving ambient fleet awareness without requiring the Working filter to be selected
- Pill sizing bumped from `text-[11px] px-2 py-0.5` to `text-xs px-3 py-1` for better breathing room; state colors used throughout, not the accent color

Closes #7694

## Changes

- `src/components/Worktree/QuickStateFilterBar.tsx` — icon-bearing pills with conditional spin logic
- `src/components/Worktree/__tests__/QuickStateFilterBar.test.tsx` — 7 new unit tests (17 total)

## Testing

Unit tests cover icon presence and identity, state-color classes, spinner independence from the active filter, spinner coexisting with active state, no-spin when count is zero or undefined, and the `aria-hidden` invariant on every icon.