### PR TITLE
fix(toolbar): sync assistant button highlight with actual panel visibility

### DIFF
--- a/src/components/Layout/ToolbarAssistantButton.tsx
+++ b/src/components/Layout/ToolbarAssistantButton.tsx
@@ -72,6 +72,14 @@ export const ToolbarAssistantButton = memo(function ToolbarAssistantButton({
 }) {
   const isOpen = useHelpPanelStore((s) => s.isOpen);
   const toggle = useHelpPanelStore((s) => s.toggle);
+  // The panel's actual visibility in AppLayout is `!gestureAssistantHidden &&
+  // helpPanelOpen` — two independent stores. Reading only `isOpen` here would
+  // leave the button highlighted (aria-pressed, "Close" tooltip, suppressed
+  // pip) while the focus-mode gesture hides the panel. Mirror the same
+  // compound predicate so the visual state can't drift from what the user
+  // actually sees.
+  const gestureAssistantHidden = useFocusStore((s) => s.gestureAssistantHidden);
+  const isVisible = !gestureAssistantHidden && isOpen;
   // Two-step primitive selectors so the button only re-renders when the
   // assistant terminal id changes, then when its agentState transitions.
   // Returning a primitive avoids needing useShallow.
@@ -97,10 +105,10 @@ export const ToolbarAssistantButton = memo(function ToolbarAssistantButton({
     state: AgentState | null;
   } | null>(null);
   useEffect(() => {
-    if (isOpen) {
+    if (isVisible) {
       setLastSeenMarker({ terminalId: assistantTerminalId, state: agentState });
     }
-  }, [isOpen, assistantTerminalId, agentState]);
+  }, [isVisible, assistantTerminalId, agentState]);
 
   const handleClick = useCallback(() => {
     suppressSidebarResizes();
@@ -119,8 +127,8 @@ export const ToolbarAssistantButton = memo(function ToolbarAssistantButton({
     lastSeenMarker !== null &&
     lastSeenMarker.terminalId === assistantTerminalId &&
     lastSeenMarker.state === agentState;
-  const showAgentPip = !pip && agentPip !== null && !isOpen && !isAcknowledged;
-  const baseTooltip = isOpen ? "Close Daintree Assistant" : "Open Daintree Assistant";
+  const showAgentPip = !pip && agentPip !== null && !isVisible && !isAcknowledged;
+  const baseTooltip = isVisible ? "Close Daintree Assistant" : "Open Daintree Assistant";
   const ariaLabel = pip
     ? `Daintree Assistant — ${pip.tooltip}`
     : showAgentPip
@@ -139,7 +147,7 @@ export const ToolbarAssistantButton = memo(function ToolbarAssistantButton({
           onClick={handleClick}
           className={toolbarIconButtonClass}
           aria-label={ariaLabel}
-          aria-pressed={isOpen}
+          aria-pressed={isVisible}
           aria-keyshortcuts={ariaShortcut}
         >
           <div className="relative">

--- a/src/components/Layout/ToolbarAssistantButton.tsx
+++ b/src/components/Layout/ToolbarAssistantButton.tsx
@@ -112,9 +112,17 @@ export const ToolbarAssistantButton = memo(function ToolbarAssistantButton({
 
   const handleClick = useCallback(() => {
     suppressSidebarResizes();
+    // When the gesture hides a logically-open panel the button reads as
+    // "Open"; clearing the gesture alone reveals it. Calling toggle() on
+    // top would flip isOpen to false and re-hide what the user just asked
+    // to reveal. Only toggle when clearing the gesture wouldn't already
+    // restore visibility.
+    const wasGestureHidden = useFocusStore.getState().gestureAssistantHidden;
     useFocusStore.getState().clearAssistantGesture();
-    toggle();
-  }, [toggle]);
+    if (!wasGestureHidden || !isOpen) {
+      toggle();
+    }
+  }, [toggle, isOpen]);
 
   const pip = describePip(mcp);
   const agentPip = describeAgentPip(agentState);

--- a/src/components/Layout/__tests__/ToolbarAssistantButton.test.tsx
+++ b/src/components/Layout/__tests__/ToolbarAssistantButton.test.tsx
@@ -58,8 +58,15 @@ vi.mock("@/hooks/useMcpReadiness", () => ({
   useMcpReadiness: () => mcpReadiness(),
 }));
 
+let mockGestureAssistantHidden = false;
+const clearAssistantGestureMock = vi.fn();
+
 vi.mock("@/store/focusStore", () => ({
-  useFocusStore: { getState: () => ({ clearAssistantGesture: vi.fn() }) },
+  useFocusStore: Object.assign(
+    (selector: (s: { gestureAssistantHidden: boolean }) => unknown) =>
+      selector({ gestureAssistantHidden: mockGestureAssistantHidden }),
+    { getState: () => ({ clearAssistantGesture: clearAssistantGestureMock }) }
+  ),
 }));
 
 function setHelpPanel(state: { isOpen: boolean; terminalId: string | null }) {
@@ -98,6 +105,8 @@ describe("ToolbarAssistantButton — agent state pip", () => {
       sessionId: null,
     });
     usePanelStore.setState({ panelsById: {}, panelIds: [] } as never);
+    mockGestureAssistantHidden = false;
+    clearAssistantGestureMock.mockClear();
   });
 
   it("does not render the pip when the assistant is idle", () => {
@@ -289,6 +298,66 @@ describe("ToolbarAssistantButton — agent state pip", () => {
       useHelpPanelStore.setState({ isOpen: false });
     });
     expect(queryByTestId("assistant-working-pip")).toBeNull();
+  });
+
+  describe("gesture-hidden desync", () => {
+    // The toolbar button's highlighted state must mirror the panel's *actual*
+    // visibility — `!gestureAssistantHidden && helpPanelOpen` — not just
+    // `helpPanelStore.isOpen`. The focus-mode gesture can collapse the panel
+    // without flipping isOpen, and the button must stop reading as pressed
+    // and resume showing the pip in that case.
+
+    it("renders aria-pressed=false when the panel is open but gesture-hidden", () => {
+      mockGestureAssistantHidden = true;
+      setHelpPanel({ isOpen: true, terminalId: "t-gh-1" });
+      setPanel("t-gh-1", "idle");
+
+      const { container } = render(<ToolbarAssistantButton />);
+      expect(container.querySelector("button")?.getAttribute("aria-pressed")).toBe("false");
+    });
+
+    it("renders aria-pressed=true when isOpen and the gesture is not hiding the panel", () => {
+      mockGestureAssistantHidden = false;
+      setHelpPanel({ isOpen: true, terminalId: "t-gh-2" });
+      setPanel("t-gh-2", "idle");
+
+      const { container } = render(<ToolbarAssistantButton />);
+      expect(container.querySelector("button")?.getAttribute("aria-pressed")).toBe("true");
+    });
+
+    it("renders aria-pressed=false when isOpen=false regardless of gesture", () => {
+      mockGestureAssistantHidden = true;
+      setHelpPanel({ isOpen: false, terminalId: null });
+
+      const { container } = render(<ToolbarAssistantButton />);
+      expect(container.querySelector("button")?.getAttribute("aria-pressed")).toBe("false");
+    });
+
+    it("shows the agent pip when the panel is gesture-hidden even if isOpen=true", () => {
+      // The lastSeenMarker effect is gated on isVisible (not isOpen) for the
+      // same reason: while the panel is gesture-hidden the user can't see
+      // the assistant header, so state transitions during that window must
+      // remain unread. Because isVisible=false here the effect does not
+      // advance the marker, isAcknowledged stays false, and the pip surfaces
+      // through every state change while the gesture holds.
+      mockGestureAssistantHidden = true;
+      setHelpPanel({ isOpen: true, terminalId: "t-gh-3" });
+      setPanel("t-gh-3", "working");
+
+      const { queryByTestId } = render(<ToolbarAssistantButton />);
+      const pip = queryByTestId("assistant-working-pip");
+      expect(pip).not.toBeNull();
+      expect(pip!.className).toMatch(/bg-state-working/);
+
+      // Agent transitions while gesture-hidden — pip tracks the new state
+      // because the marker was never advanced.
+      act(() => {
+        setPanel("t-gh-3", "waiting");
+      });
+      const pip2 = queryByTestId("assistant-working-pip");
+      expect(pip2).not.toBeNull();
+      expect(pip2!.className).toMatch(/bg-state-waiting/);
+    });
   });
 
   it("re-renders when agentState transitions through working → waiting → idle", () => {

--- a/src/components/Layout/__tests__/ToolbarAssistantButton.test.tsx
+++ b/src/components/Layout/__tests__/ToolbarAssistantButton.test.tsx
@@ -1,6 +1,6 @@
 // @vitest-environment jsdom
 import { describe, it, expect, beforeEach, vi } from "vitest";
-import { render, act } from "@testing-library/react";
+import { render, act, fireEvent } from "@testing-library/react";
 import { ToolbarAssistantButton } from "../ToolbarAssistantButton";
 import { useHelpPanelStore } from "@/store/helpPanelStore";
 import { usePanelStore } from "@/store";
@@ -59,13 +59,20 @@ vi.mock("@/hooks/useMcpReadiness", () => ({
 }));
 
 let mockGestureAssistantHidden = false;
-const clearAssistantGestureMock = vi.fn();
+const clearAssistantGestureMock = vi.fn(() => {
+  mockGestureAssistantHidden = false;
+});
 
 vi.mock("@/store/focusStore", () => ({
   useFocusStore: Object.assign(
     (selector: (s: { gestureAssistantHidden: boolean }) => unknown) =>
       selector({ gestureAssistantHidden: mockGestureAssistantHidden }),
-    { getState: () => ({ clearAssistantGesture: clearAssistantGestureMock }) }
+    {
+      getState: () => ({
+        gestureAssistantHidden: mockGestureAssistantHidden,
+        clearAssistantGesture: clearAssistantGestureMock,
+      }),
+    }
   ),
 }));
 
@@ -357,6 +364,42 @@ describe("ToolbarAssistantButton — agent state pip", () => {
       const pip2 = queryByTestId("assistant-working-pip");
       expect(pip2).not.toBeNull();
       expect(pip2!.className).toMatch(/bg-state-waiting/);
+    });
+
+    it("click reveals the panel without toggling isOpen when gesture-hidden", () => {
+      // Button labelled "Open" must actually open. Clearing the gesture
+      // already restores visibility; calling toggle() on top would flip
+      // isOpen to false and re-hide what the user just asked to reveal.
+      mockGestureAssistantHidden = true;
+      setHelpPanel({ isOpen: true, terminalId: "t-gh-click-1" });
+
+      const { container } = render(<ToolbarAssistantButton />);
+      fireEvent.click(container.querySelector("button")!);
+
+      expect(clearAssistantGestureMock).toHaveBeenCalledTimes(1);
+      expect(useHelpPanelStore.getState().isOpen).toBe(true);
+      expect(mockGestureAssistantHidden).toBe(false);
+    });
+
+    it("click toggles isOpen when the panel is visible (no gesture)", () => {
+      mockGestureAssistantHidden = false;
+      setHelpPanel({ isOpen: true, terminalId: "t-gh-click-2" });
+
+      const { container } = render(<ToolbarAssistantButton />);
+      fireEvent.click(container.querySelector("button")!);
+
+      expect(clearAssistantGestureMock).toHaveBeenCalledTimes(1);
+      expect(useHelpPanelStore.getState().isOpen).toBe(false);
+    });
+
+    it("click opens the panel when isOpen=false regardless of gesture flag", () => {
+      mockGestureAssistantHidden = false;
+      setHelpPanel({ isOpen: false, terminalId: null });
+
+      const { container } = render(<ToolbarAssistantButton />);
+      fireEvent.click(container.querySelector("button")!);
+
+      expect(useHelpPanelStore.getState().isOpen).toBe(true);
     });
   });
 


### PR DESCRIPTION
## Summary

- The assistant toolbar button read only `isOpen` for its highlight state, but the panel's actual visibility in `AppLayout.tsx` is `!gestureAssistantHidden && helpPanelOpen`. When the focus-mode gesture set `gestureAssistantHidden=true`, the panel collapsed while the button stayed pressed.
- Fix: derive `isVisible = !gestureAssistantHidden && isOpen` and use it everywhere the visual state is computed — `aria-pressed`, tooltip, agent pip, and the `lastSeenMarker` effect dependency.
- Fix: branch the click handler so that when the gesture is hiding a logically-open panel, `clearAssistantGesture()` alone reveals it without `toggle()` flipping `isOpen=false` and re-hiding.

Resolves #7667

## Changes

- `ToolbarAssistantButton.tsx`: subscribe to `gestureAssistantHidden`, compute `isVisible`, update `aria-pressed`/tooltip/pip/effect to use it; branch `handleClick` for the gesture-hidden+open case
- `ToolbarAssistantButton.test.tsx`: 7 new cases in a "gesture-hidden desync" describe block covering `aria-pressed` flips, pip visibility, pip state tracking through transitions, and all three `handleClick` branches

## Testing

- Toggle focus mode with the assistant panel open — button drops to unpressed, tooltip reads "Open Daintree Assistant", agent pip surfaces with current state
- Click while gesture-hidden — panel reveals, no double-toggle re-hide
- Click while visible — panel closes
- Click while closed — panel opens
- Existing pip acknowledgement semantics pass