### PR TITLE
perf(pty-host): scope PortBatcher flush cadence per-terminal

### DIFF
--- a/electron/pty-host/__tests__/portBatcher.test.ts
+++ b/electron/pty-host/__tests__/portBatcher.test.ts
@@ -410,8 +410,10 @@ describe("PortBatcher", () => {
       expect(vi.getTimerCount()).toBe(2);
       expect(deps.postMessage).not.toHaveBeenCalled();
 
-      // Advance 0ms: t2's setImmediate fires → flush() drains both terminals.
-      // This proves t2 was not waiting for t1's 16ms throughput timer.
+      // Advance 0ms drains pending setImmediate handles without advancing the 16ms
+      // setTimeout — Vitest treats setImmediate as a 0-delay timer. (Use this rather
+      // than runAllTimers so the test fails if t2 was scheduled with setTimeout(16)
+      // instead of setImmediate.) t2's setImmediate fires → global flush drains both.
       vi.advanceTimersByTime(0);
 
       expect(deps.postMessage).toHaveBeenCalledTimes(2);

--- a/electron/pty-host/__tests__/portBatcher.test.ts
+++ b/electron/pty-host/__tests__/portBatcher.test.ts
@@ -176,22 +176,21 @@ describe("PortBatcher", () => {
     expect(deps.postMessage).toHaveBeenCalledWith("t2", bytes("bbb"), 3);
   });
 
-  it("flushTerminal resets mode when buffer empties — next write gets latency mode", () => {
+  it("flushTerminal: subsequent write to a fresh terminal starts in latency mode", () => {
     const deps = createDeps();
     const batcher = new PortBatcher(deps);
 
     batcher.write("t1", bytes("aaa"), 3);
-    batcher.write("t1", bytes("bbb"), 3); // upgrade to throughput
+    batcher.write("t1", bytes("bbb"), 3); // t1 upgrades to throughput
 
-    // Flush t1 — buffer is now empty, mode should reset to idle
     batcher.flushTerminal("t1");
     expect(deps.postMessage).toHaveBeenCalledWith("t1", bytes("aaabbb"), 6);
 
-    // Next write should use latency mode (setImmediate), not stale throughput (setTimeout 16)
+    // Next write to a fresh terminal starts with its own idle entry → latency (setImmediate),
+    // not stale throughput inherited from t1.
     (deps.postMessage as ReturnType<typeof vi.fn>).mockClear();
     batcher.write("t2", bytes("ccc"), 3);
 
-    // setImmediate fires immediately via runAllTimers, not delayed by 16ms
     vi.advanceTimersByTime(2);
     expect(deps.postMessage).toHaveBeenCalledWith("t2", bytes("ccc"), 3);
   });
@@ -389,5 +388,93 @@ describe("PortBatcher", () => {
     expect(emitted.byteLength).toBe(9);
     expect(emitted.buffer.byteLength).toBe(9);
     expect(Buffer.from(emitted).toString("utf8")).toBe("foobarbaz");
+  });
+
+  describe("per-terminal isolation", () => {
+    it("quiet terminal is not stalled by a busy sibling's throughput cadence", () => {
+      // Regression for #7652: previously a single class-level mode meant t1 entering
+      // throughput would force t2's first write to inherit the 16ms cadence. With per-
+      // terminal state, t2 schedules its own setImmediate and flushes before 16ms.
+      const deps = createDeps();
+      const batcher = new PortBatcher(deps);
+
+      // t1 enters throughput mode (setTimeout 16ms)
+      batcher.write("t1", bytes("a1"), 2);
+      batcher.write("t1", bytes("a2"), 2);
+
+      // t2's first write should schedule its own setImmediate (latency), not inherit
+      // t1's throughput cadence.
+      batcher.write("t2", bytes("b1"), 2);
+
+      // Two pending timers: t1's setTimeout(16) + t2's setImmediate
+      expect(vi.getTimerCount()).toBe(2);
+      expect(deps.postMessage).not.toHaveBeenCalled();
+
+      // Advance 0ms: t2's setImmediate fires → flush() drains both terminals.
+      // This proves t2 was not waiting for t1's 16ms throughput timer.
+      vi.advanceTimersByTime(0);
+
+      expect(deps.postMessage).toHaveBeenCalledTimes(2);
+      expect(deps.postMessage).toHaveBeenCalledWith("t2", bytes("b1"), 2);
+      expect(deps.postMessage).toHaveBeenCalledWith("t1", bytes("a1a2"), 4);
+      expect(vi.getTimerCount()).toBe(0);
+    });
+
+    it("each terminal upgrades to throughput independently", () => {
+      const deps = createDeps();
+      const batcher = new PortBatcher(deps);
+
+      batcher.write("t1", bytes("a1"), 2); // t1: setImmediate
+      batcher.write("t1", bytes("a2"), 2); // t1: setTimeout(16)
+      batcher.write("t2", bytes("b1"), 2); // t2: setImmediate
+      batcher.write("t2", bytes("b2"), 2); // t2: setTimeout(16)
+
+      // Each terminal owns its own setTimeout(16)
+      expect(vi.getTimerCount()).toBe(2);
+      expect(deps.postMessage).not.toHaveBeenCalled();
+
+      // First timer to fire (16ms) calls global flush(), draining both
+      vi.advanceTimersByTime(16);
+      expect(deps.postMessage).toHaveBeenCalledTimes(2);
+      expect(deps.postMessage).toHaveBeenCalledWith("t1", bytes("a1a2"), 4);
+      expect(deps.postMessage).toHaveBeenCalledWith("t2", bytes("b1b2"), 4);
+      expect(vi.getTimerCount()).toBe(0);
+    });
+
+    it("dispose cancels per-terminal timers across all entries", () => {
+      const deps = createDeps();
+      const batcher = new PortBatcher(deps);
+
+      batcher.write("t1", bytes("a"), 1); // t1: setImmediate
+      batcher.write("t2", bytes("b1"), 2); // t2: setImmediate
+      batcher.write("t2", bytes("b2"), 2); // t2: setTimeout(16)
+
+      // t1 setImmediate + t2 setTimeout
+      expect(vi.getTimerCount()).toBe(2);
+
+      batcher.dispose();
+      expect(vi.getTimerCount()).toBe(0);
+    });
+
+    it("flushTerminal cancels only the target's timer, leaving siblings pending", () => {
+      const deps = createDeps();
+      const batcher = new PortBatcher(deps);
+
+      batcher.write("t1", bytes("a1"), 2); // t1: setImmediate
+      batcher.write("t1", bytes("a2"), 2); // t1: setTimeout(16)
+      batcher.write("t2", bytes("b"), 1); // t2: setImmediate
+
+      // t1's setTimeout(16) + t2's setImmediate
+      expect(vi.getTimerCount()).toBe(2);
+
+      batcher.flushTerminal("t1");
+      expect(deps.postMessage).toHaveBeenCalledWith("t1", bytes("a1a2"), 4);
+      // t2's setImmediate is still pending
+      expect(vi.getTimerCount()).toBe(1);
+
+      vi.advanceTimersByTime(0);
+      expect(deps.postMessage).toHaveBeenCalledWith("t2", bytes("b"), 1);
+      expect(vi.getTimerCount()).toBe(0);
+    });
   });
 });

--- a/electron/pty-host/portBatcher.ts
+++ b/electron/pty-host/portBatcher.ts
@@ -13,6 +13,9 @@ export interface PortBatcherDeps {
 interface PendingTerminal {
   chunks: Uint8Array[];
   bytes: number;
+  mode: FlushMode;
+  immediateHandle: ReturnType<typeof setImmediate> | null;
+  timeoutHandle: ReturnType<typeof setTimeout> | null;
 }
 
 export interface PortBatcherFailedBatch {
@@ -26,9 +29,6 @@ type FlushMode = "idle" | "latency" | "throughput";
 export class PortBatcher {
   private pendingChunks = new Map<string, PendingTerminal>();
   private totalPendingBytes = 0;
-  private immediateHandle: ReturnType<typeof setImmediate> | null = null;
-  private timeoutHandle: ReturnType<typeof setTimeout> | null = null;
-  private mode: FlushMode = "idle";
   private disposed = false;
 
   constructor(private readonly deps: PortBatcherDeps) {}
@@ -48,7 +48,13 @@ export class PortBatcher {
 
     let entry = this.pendingChunks.get(id);
     if (!entry) {
-      entry = { chunks: [], bytes: 0 };
+      entry = {
+        chunks: [],
+        bytes: 0,
+        mode: "idle",
+        immediateHandle: null,
+        timeoutHandle: null,
+      };
       this.pendingChunks.set(id, entry);
     }
     entry.chunks.push(data);
@@ -60,16 +66,18 @@ export class PortBatcher {
       return true;
     }
 
-    if (this.mode === "idle") {
-      this.immediateHandle = setImmediate(() => this.flush());
-      this.mode = "latency";
-    } else if (this.mode === "latency") {
-      if (this.immediateHandle !== null) {
-        clearImmediate(this.immediateHandle);
-        this.immediateHandle = null;
+    // Per-terminal flush cadence: each terminal owns its own (mode, immediate, timeout)
+    // so a quiet terminal's first write isn't stalled by a busy sibling's throughput timer.
+    if (entry.mode === "idle") {
+      entry.immediateHandle = setImmediate(() => this.flush());
+      entry.mode = "latency";
+    } else if (entry.mode === "latency") {
+      if (entry.immediateHandle !== null) {
+        clearImmediate(entry.immediateHandle);
+        entry.immediateHandle = null;
       }
-      this.timeoutHandle = setTimeout(() => this.flush(), PORT_BATCH_THROUGHPUT_DELAY_MS);
-      this.mode = "throughput";
+      entry.timeoutHandle = setTimeout(() => this.flush(), PORT_BATCH_THROUGHPUT_DELAY_MS);
+      entry.mode = "throughput";
     }
     // throughput mode: timer already scheduled, nothing to do
 
@@ -80,8 +88,12 @@ export class PortBatcher {
     const snapshot = this.pendingChunks;
     this.pendingChunks = new Map();
     this.totalPendingBytes = 0;
-    this.cancelTimers();
-    this.mode = "idle";
+
+    // Cancel each entry's per-terminal handles before processing so callbacks
+    // already-queued can't fire after the snapshot is drained.
+    for (const entry of snapshot.values()) {
+      this.cancelEntryTimers(entry);
+    }
 
     const entries = Array.from(snapshot.entries());
     for (let i = 0; i < entries.length; i++) {
@@ -114,14 +126,9 @@ export class PortBatcher {
     const entry = this.pendingChunks.get(id);
     if (!entry) return;
 
+    this.cancelEntryTimers(entry);
     this.pendingChunks.delete(id);
     this.totalPendingBytes -= entry.bytes;
-
-    // If buffer is now empty, reset mode and cancel stale timers
-    if (this.pendingChunks.size === 0) {
-      this.cancelTimers();
-      this.mode = "idle";
-    }
 
     let data: Uint8Array = new Uint8Array(0);
     try {
@@ -138,21 +145,22 @@ export class PortBatcher {
   }
 
   dispose(): void {
-    this.cancelTimers();
+    for (const entry of this.pendingChunks.values()) {
+      this.cancelEntryTimers(entry);
+    }
     this.pendingChunks.clear();
     this.totalPendingBytes = 0;
-    this.mode = "idle";
     this.disposed = true;
   }
 
-  private cancelTimers(): void {
-    if (this.immediateHandle !== null) {
-      clearImmediate(this.immediateHandle);
-      this.immediateHandle = null;
+  private cancelEntryTimers(entry: PendingTerminal): void {
+    if (entry.immediateHandle !== null) {
+      clearImmediate(entry.immediateHandle);
+      entry.immediateHandle = null;
     }
-    if (this.timeoutHandle !== null) {
-      clearTimeout(this.timeoutHandle);
-      this.timeoutHandle = null;
+    if (entry.timeoutHandle !== null) {
+      clearTimeout(entry.timeoutHandle);
+      entry.timeoutHandle = null;
     }
   }
 }


### PR DESCRIPTION
## Summary

- `PortBatcher` had a single global `(mode, immediateHandle, timeoutHandle)` triple shared across every terminal. A busy terminal in throughput mode dragged quiet siblings into its 16ms cadence instead of letting them flush at latency cadence.
- Moved `mode`, `immediateHandle`, and `timeoutHandle` into each terminal's `PendingTerminal` entry so each terminal owns its flush cadence independently. Added a `cancelEntryTimers` helper used by both `flush()` and `dispose()`.
- The 64KB `totalPendingBytes` global threshold stays as-is — that's intentional IPC-overload protection from #4899.

Resolves #7652

## Changes

- `electron/pty-host/portBatcher.ts` — per-terminal `mode`/`immediateHandle`/`timeoutHandle` fields; `cancelEntryTimers()` helper; `flush()` cancels per-entry handles before processing; `dispose()` iterates entries to cancel all
- `electron/pty-host/__tests__/portBatcher.test.ts` — 4 new isolation tests: cross-terminal isolation regression, independent throughput upgrade, `dispose` cancels all timers, `flushTerminal` cancels only the target

## Testing

27 unit tests pass (23 existing + 4 new). Typecheck, lint, format, and build all clean.