### PR TITLE
fix(fleet): shift-click on panel title arms terminal in fleet

### DIFF
--- a/e2e/full/terminal/core-fleet-broadcast.spec.ts
+++ b/e2e/full/terminal/core-fleet-broadcast.spec.ts
@@ -335,4 +335,93 @@ test.describe.serial("Core: Fleet terminal broadcast", () => {
       expect(exit.ok, exit.error?.message).toBe(true);
     });
   });
+
+  test("shift-click on panel title arms terminal in fleet (#7704)", async () => {
+    test.setTimeout(60_000);
+    const { window } = ctx;
+
+    await test.step("Clear any prior arming so the ribbon transition is observable", async () => {
+      await dispatchAction(window, "terminal.disarmAll", undefined, { source: "user" });
+      await expect(window.locator('[data-testid="fleet-arming-ribbon"]')).toBeHidden({
+        timeout: T_MEDIUM,
+      });
+    });
+
+    const gridIds = await getGridPanelIds(window);
+    expect(gridIds.length).toBeGreaterThanOrEqual(2);
+
+    await test.step("Focus the first panel to seat the implicit fleet anchor", async () => {
+      await dismissBlockingPalette(window);
+      await getPanelById(window, gridIds[0]!).click();
+      await expect
+        .poll(() => getFocusedPanelId(window), { timeout: T_MEDIUM, intervals: [100, 250] })
+        .toBe(gridIds[0]!);
+    });
+
+    await test.step("Shift-click the second panel's title and verify the fleet arms", async () => {
+      const secondPanel = getPanelById(window, gridIds[1]!);
+      const titleButton = secondPanel.locator(SEL.terminal.titleButton).first();
+      await expect(titleButton).toBeVisible({ timeout: T_MEDIUM });
+      await titleButton.click({ modifiers: ["Shift"] });
+
+      await expect(window.locator('[data-testid="fleet-arming-ribbon"]')).toBeVisible({
+        timeout: T_MEDIUM,
+      });
+      await expect(window.locator('[data-testid="fleet-armed-count-chip"]')).toContainText("2", {
+        timeout: T_MEDIUM,
+      });
+    });
+  });
+
+  test("active xterm selection does not block shift-click on panel title (#7704)", async () => {
+    test.setTimeout(60_000);
+    const { window } = ctx;
+
+    await test.step("Clear any prior arming so the ribbon transition is observable", async () => {
+      await dispatchAction(window, "terminal.disarmAll", undefined, { source: "user" });
+      await expect(window.locator('[data-testid="fleet-arming-ribbon"]')).toBeHidden({
+        timeout: T_MEDIUM,
+      });
+    });
+
+    const gridIds = await getGridPanelIds(window);
+    expect(gridIds.length).toBeGreaterThanOrEqual(2);
+
+    await test.step("Focus first panel, then seed an xterm buffer selection", async () => {
+      await dismissBlockingPalette(window);
+      const firstPanel = getPanelById(window, gridIds[0]!);
+      await firstPanel.click();
+      await expect
+        .poll(() => getFocusedPanelId(window), { timeout: T_MEDIUM, intervals: [100, 250] })
+        .toBe(gridIds[0]!);
+
+      // selectAll() leaves hasSelection() === true. Pre-fix, this caused
+      // handleClick to early-return for any subsequent click on the pane,
+      // including chrome clicks on the title bar.
+      const selected = await window.evaluate(
+        (panelId) =>
+          (
+            window as unknown as {
+              __daintreeSelectTerminalAll?: (id: string) => boolean;
+            }
+          ).__daintreeSelectTerminalAll?.(panelId) ?? false,
+        gridIds[0]!
+      );
+      expect(selected).toBe(true);
+    });
+
+    await test.step("Shift-click the second panel's title — fleet should arm despite selection", async () => {
+      const secondPanel = getPanelById(window, gridIds[1]!);
+      const titleButton = secondPanel.locator(SEL.terminal.titleButton).first();
+      await expect(titleButton).toBeVisible({ timeout: T_MEDIUM });
+      await titleButton.click({ modifiers: ["Shift"] });
+
+      await expect(window.locator('[data-testid="fleet-arming-ribbon"]')).toBeVisible({
+        timeout: T_MEDIUM,
+      });
+      await expect(window.locator('[data-testid="fleet-armed-count-chip"]')).toContainText("2", {
+        timeout: T_MEDIUM,
+      });
+    });
+  });
 });

--- a/e2e/full/terminal/core-fleet-broadcast.spec.ts
+++ b/e2e/full/terminal/core-fleet-broadcast.spec.ts
@@ -367,7 +367,7 @@ test.describe.serial("Core: Fleet terminal broadcast", () => {
       await expect(window.locator('[data-testid="fleet-arming-ribbon"]')).toBeVisible({
         timeout: T_MEDIUM,
       });
-      await expect(window.locator('[data-testid="fleet-armed-count-chip"]')).toContainText("2", {
+      await expect(window.locator('[data-testid="fleet-armed-count-chip"]')).toHaveText(/^2$/, {
         timeout: T_MEDIUM,
       });
     });
@@ -387,7 +387,7 @@ test.describe.serial("Core: Fleet terminal broadcast", () => {
     const gridIds = await getGridPanelIds(window);
     expect(gridIds.length).toBeGreaterThanOrEqual(2);
 
-    await test.step("Focus first panel, then seed an xterm buffer selection", async () => {
+    await test.step("Focus first panel as anchor, then seed selection on the panel we will click", async () => {
       await dismissBlockingPalette(window);
       const firstPanel = getPanelById(window, gridIds[0]!);
       await firstPanel.click();
@@ -395,9 +395,10 @@ test.describe.serial("Core: Fleet terminal broadcast", () => {
         .poll(() => getFocusedPanelId(window), { timeout: T_MEDIUM, intervals: [100, 250] })
         .toBe(gridIds[0]!);
 
-      // selectAll() leaves hasSelection() === true. Pre-fix, this caused
-      // handleClick to early-return for any subsequent click on the pane,
-      // including chrome clicks on the title bar.
+      // selectAll() leaves hasSelection() === true on the second panel.
+      // handleClick queries the clicked pane's own terminal, so the selection
+      // must live on the same panel whose title we shift-click — otherwise
+      // the pre-fix early-return path is never exercised.
       const selected = await window.evaluate(
         (panelId) =>
           (
@@ -405,12 +406,12 @@ test.describe.serial("Core: Fleet terminal broadcast", () => {
               __daintreeSelectTerminalAll?: (id: string) => boolean;
             }
           ).__daintreeSelectTerminalAll?.(panelId) ?? false,
-        gridIds[0]!
+        gridIds[1]!
       );
       expect(selected).toBe(true);
     });
 
-    await test.step("Shift-click the second panel's title — fleet should arm despite selection", async () => {
+    await test.step("Shift-click the selected panel's title — fleet should arm despite its own selection", async () => {
       const secondPanel = getPanelById(window, gridIds[1]!);
       const titleButton = secondPanel.locator(SEL.terminal.titleButton).first();
       await expect(titleButton).toBeVisible({ timeout: T_MEDIUM });
@@ -419,7 +420,7 @@ test.describe.serial("Core: Fleet terminal broadcast", () => {
       await expect(window.locator('[data-testid="fleet-arming-ribbon"]')).toBeVisible({
         timeout: T_MEDIUM,
       });
-      await expect(window.locator('[data-testid="fleet-armed-count-chip"]')).toContainText("2", {
+      await expect(window.locator('[data-testid="fleet-armed-count-chip"]')).toHaveText(/^2$/, {
         timeout: T_MEDIUM,
       });
     });

--- a/src/components/Panel/PanelHeader.tsx
+++ b/src/components/Panel/PanelHeader.tsx
@@ -682,6 +682,7 @@ function PanelHeaderComponent({
                     tabIndex={onTitleChange ? 0 : undefined}
                     role={onTitleChange ? "button" : undefined}
                     aria-label={onTitleChange ? getTitleAriaLabel() : undefined}
+                    data-fleet-gesture-passthrough=""
                   >
                     {displayTitle}
                   </span>

--- a/src/components/Terminal/TerminalPane.tsx
+++ b/src/components/Terminal/TerminalPane.tsx
@@ -534,11 +534,15 @@ function TerminalPaneComponent({
   };
 
   const handleClick = (e?: React.MouseEvent) => {
+    const target = e?.target as HTMLElement | null;
+    const isBufferClick = !!target?.closest(".xterm");
     const managed = terminalInstanceService.get(id);
-    if (managed?.terminal.hasSelection()) {
+    if (isBufferClick && managed?.terminal.hasSelection()) {
       // Prevent ContentPanel from calling onFocus() which triggers parent
       // re-renders. Don't call setFocused() either — it triggers a
       // wake+restore cycle that calls terminal.reset(), clearing selection.
+      // Scoped to buffer clicks: a click on pane chrome (e.g. the title)
+      // must not be swallowed just because xterm has a leftover selection.
       e?.preventDefault();
       return;
     }
@@ -548,12 +552,14 @@ function TerminalPaneComponent({
     // interactive child of the chrome (overflow menu, close, restore,
     // title input, etc). Without the interactive guard, clicking the
     // overflow trigger of a pane while a fleet is armed would clear
-    // the fleet before the menu opens.
-    const target = e?.target as HTMLElement | null;
+    // the fleet before the menu opens. The passthrough whitelist lets
+    // specific chrome elements (title span carries role="button" for
+    // a11y) participate in fleet gestures without losing their a11y role.
     const isChromeClick = !!target?.closest("[data-pane-chrome]");
-    const isInteractiveChild = !!target?.closest(
-      "button, input, textarea, select, a, [role='button'], [role='menuitem']"
-    );
+    const isPassthrough = !!target?.closest("[data-fleet-gesture-passthrough]");
+    const isInteractiveChild =
+      !isPassthrough &&
+      !!target?.closest("button, input, textarea, select, a, [role='button'], [role='menuitem']");
 
     if (e && isChromeClick && !isInteractiveChild) {
       const terminal = getTerminal(id);


### PR DESCRIPTION
Shift-clicking a panel title to add a terminal to a fleet silently failed. No feedback, no indication of why — the click just fell through to focus.

Two separate issues caused this.

**`role="button"` on the title span**

`PanelHeader` sets `role={onTitleChange ? "button" : undefined}` on the title span, and `onTitleChange` is always wired by `GridPanel` and `DockedPanel`. So in practice the title span always carried `role="button"`. The interactive-child guard in `TerminalPane.handleClick` matches `[role='button']`, which meant clicking the title text skipped the fleet block entirely and fell through to `setFocused`. Clicking the header chrome around it worked; clicking the literal title text didn't. That's the "sometimes it works, sometimes it doesn't" pattern from the issue.

The fix keeps `role="button"` (it's correct for screen readers — the span really is activatable to enter rename mode) and adds a `data-fleet-gesture-passthrough` attribute to the title span. The interactive-child guard in `handleClick` now treats elements carrying that attribute as non-interactive for fleet purposes via a short-circuit before the negative selector runs. Additive whitelist rather than rewriting the exclusion list, so overflow/close/restore buttons inside chrome still block fleet gestures the same way they did before.

**`hasSelection` early-return swallowed chrome clicks**

`TerminalPane.handleClick` returned early when the terminal had an active xterm selection — for *any* click on the pane, including chrome clicks on the title bar. So if you'd selected text in the terminal and then tried to shift-click the header, the click silently bailed.

The fix scopes the `hasSelection` early-return to clicks that actually originate inside `.xterm` (the same boundary `handleXtermPointerDownCapture` already uses for buffer-click detection). A header click with a stale selection now reaches the chrome/fleet logic instead of being swallowed.

## Changes

- `src/components/Panel/PanelHeader.tsx` — add `data-fleet-gesture-passthrough` to the title span; `role="button"` retained
- `src/components/Terminal/TerminalPane.tsx` — scope the `hasSelection` guard to `.xterm` clicks; honor the passthrough attribute as a positive whitelist in the interactive-child check
- `e2e/full/terminal/core-fleet-broadcast.spec.ts` — two regression specs: shift-click on title arms the fleet, and shift-click on the title of a panel with a seeded xterm selection still arms the fleet

## Testing

The selection regression spec seeds the xterm selection on the same panel whose title is shift-clicked — `handleClick` queries the clicked pane's own terminal, so the selection has to live there to actually exercise the pre-fix early-return path. Chip count assertions use exact regex (`/^2$/`) to avoid substring matches.

Resolves #7704