### PR TITLE
fix(boot): defer pre-agent snapshot pruning to deferred task queue

### DIFF
--- a/electron/services/PreAgentSnapshotService.ts
+++ b/electron/services/PreAgentSnapshotService.ts
@@ -28,20 +28,19 @@ export class PreAgentSnapshotService {
     this.pruneAllWorktrees();
     this.pruneTimer = setInterval(() => this.pruneAllWorktrees(), this.pruneIntervalMs);
 
-    try {
-      this.removeSuspendListener = getSystemSleepService().onSuspend(() => {
-        if (this.pruneTimer) {
-          clearInterval(this.pruneTimer);
-          this.pruneTimer = null;
-        }
-      });
-      this.removeWakeListener = getSystemSleepService().onWake(() => {
-        if (this.pruneTimer) return;
-        this.pruneTimer = setInterval(() => this.pruneAllWorktrees(), this.pruneIntervalMs);
-      });
-    } catch {
-      // SystemSleepService may not be initialized yet at early startup.
-    }
+    // Deferred init queue registers this task AFTER system-sleep-service, so
+    // the singleton is guaranteed live here — no try/catch needed.
+    const sleepService = getSystemSleepService();
+    this.removeSuspendListener = sleepService.onSuspend(() => {
+      if (this.pruneTimer) {
+        clearInterval(this.pruneTimer);
+        this.pruneTimer = null;
+      }
+    });
+    this.removeWakeListener = sleepService.onWake(() => {
+      if (this.pruneTimer) return;
+      this.pruneTimer = setInterval(() => this.pruneAllWorktrees(), this.pruneIntervalMs);
+    });
   }
 
   updatePollInterval(ms: number): void {

--- a/electron/window/__tests__/globalServicesInit.order.test.ts
+++ b/electron/window/__tests__/globalServicesInit.order.test.ts
@@ -266,6 +266,26 @@ describe("initGlobalServices task ordering", () => {
     expect(dbMaintIndex).toBeGreaterThan(sleepIndex);
   });
 
+  it("defers pre-agent-snapshot-service after system-sleep-service and doesn't initialize eagerly (#7656)", async () => {
+    const { preAgentSnapshotService } = await import("../../services/PreAgentSnapshotService.js");
+    const initSpy = preAgentSnapshotService.initialize as ReturnType<typeof vi.fn>;
+    initSpy.mockClear();
+
+    const fakeRegistry = { all: () => [], size: 0 } as unknown as WindowRegistry;
+    await initGlobalServices(fakeRegistry);
+
+    // The eager call has been removed — initialize() must not fire during
+    // initGlobalServices(); it runs only when the deferred queue drains.
+    expect(initSpy).not.toHaveBeenCalled();
+
+    const sleepIndex = registeredTaskNames.indexOf("system-sleep-service");
+    const snapshotIndex = registeredTaskNames.indexOf("pre-agent-snapshot-service");
+
+    expect(sleepIndex).toBeGreaterThanOrEqual(0);
+    expect(snapshotIndex).toBeGreaterThanOrEqual(0);
+    expect(snapshotIndex).toBeGreaterThan(sleepIndex);
+  });
+
   it("registers ccr-config and plugin-service as deferred tasks", async () => {
     const fakeRegistry = { all: () => [], size: 0 } as unknown as WindowRegistry;
     await initGlobalServices(fakeRegistry);

--- a/electron/window/__tests__/globalServicesInit.order.test.ts
+++ b/electron/window/__tests__/globalServicesInit.order.test.ts
@@ -279,11 +279,14 @@ describe("initGlobalServices task ordering", () => {
     expect(initSpy).not.toHaveBeenCalled();
 
     const sleepIndex = registeredTaskNames.indexOf("system-sleep-service");
+    const dbMaintIndex = registeredTaskNames.indexOf("database-maintenance");
     const snapshotIndex = registeredTaskNames.indexOf("pre-agent-snapshot-service");
 
     expect(sleepIndex).toBeGreaterThanOrEqual(0);
+    expect(dbMaintIndex).toBeGreaterThanOrEqual(0);
     expect(snapshotIndex).toBeGreaterThanOrEqual(0);
     expect(snapshotIndex).toBeGreaterThan(sleepIndex);
+    expect(snapshotIndex).toBeGreaterThan(dbMaintIndex);
   });
 
   it("registers ccr-config and plugin-service as deferred tasks", async () => {

--- a/electron/window/globalServicesInit.ts
+++ b/electron/window/globalServicesInit.ts
@@ -107,7 +107,7 @@ async function evictStaleSessionFiles(): Promise<void> {
 /**
  * Run the once-per-app-lifecycle global initialization on the first window
  * setup. Migrations run inline (synchronous, blocking); everything else is
- * either a synchronous boot (GitHubAuth storage, preAgentSnapshot) or
+ * either a synchronous boot (GitHubAuth storage, ActionBreadcrumbService) or
  * registered as a deferred task that drains after first-interactive.
  *
  * Returns "exit-requested" when migrations fail and `app.exit(1)` has been
@@ -219,11 +219,10 @@ export async function initGlobalServices(
   }
 
   // Notifications (global singletons)
-  // AgentNotificationService is deferred — agents can't emit state events
-  // before the renderer is interactive, and its boot grace period now starts
-  // from the deferred initialize() so the suppression window still covers
-  // the actual agent startup interval.
-  preAgentSnapshotService.initialize();
+  // AgentNotificationService and PreAgentSnapshotService are deferred — agents
+  // can't emit state events before the renderer is interactive, and the boot
+  // grace period now starts from the deferred initialize() so the suppression
+  // window still covers the actual agent startup interval.
   getActionBreadcrumbService().initialize();
 
   registerDeferredTask({
@@ -329,6 +328,17 @@ export async function initGlobalServices(
     name: "database-maintenance",
     run: () => {
       getDatabaseMaintenanceService().startMaintenance();
+    },
+  });
+
+  // Pre-agent snapshot pruning + 1-hour interval timer. Deferred so the
+  // initial pruneAllWorktrees() pass and setInterval arming don't contend
+  // with renderer hydration. Registered AFTER system-sleep-service so the
+  // suspend/wake listeners attach to a live service.
+  registerDeferredTask({
+    name: "pre-agent-snapshot-service",
+    run: () => {
+      preAgentSnapshotService.initialize();
     },
   });
 


### PR DESCRIPTION
## Summary

- `preAgentSnapshotService.initialize()` was running synchronously during cold-start, running git prune operations across every worktree on the same tick as renderer load
- Moves it into `registerDeferredTask` (named `"pre-agent-snapshot-service"`), placed after `"database-maintenance"` so `SystemSleepService` is live before the snapshot service attaches its suspend/wake listeners
- Removes the now-stale `try/catch` from `PreAgentSnapshotService.initialize()` and adds an ordering test to lock in the registration sequence

Resolves #7656

## Changes

- `electron/window/globalServicesInit.ts` — removes the eager `preAgentSnapshotService.initialize()` call; adds a `registerDeferredTask("pre-agent-snapshot-service", ...)` block after `"database-maintenance"`
- `electron/services/PreAgentSnapshotService.ts` — drops the stale `try/catch` wrapper in `initialize()`
- `electron/window/__tests__/globalServicesInit.order.test.ts` — new test asserting the task is deferred, registered after `"system-sleep-service"`, and after `"database-maintenance"`

## Testing

- Typecheck, lint, format, and build all clean
- New ordering test covers the registration sequence and would catch a future reorder