### PR TITLE
fix(panel-grid): stabilize empty-state slots to prevent hydration layout shifts

### DIFF
--- a/src/components/Pulse/ProjectPulseCard.tsx
+++ b/src/components/Pulse/ProjectPulseCard.tsx
@@ -232,7 +232,7 @@ function PulseSkeleton({ className }: { className?: string }) {
   return (
     <div
       className={cn(
-        "pulse-card w-fit rounded-[var(--radius-lg)] border border-daintree-border",
+        "pulse-card w-fit rounded-[var(--radius-lg)] border border-daintree-border min-h-[240px]",
         className
       )}
     >
@@ -263,7 +263,7 @@ function PulseSkeleton({ className }: { className?: string }) {
 
         <div className="h-3 pulse-skeleton-shimmer rounded w-72" />
 
-        <div className="border-t border-daintree-border pt-3">
+        <div className="border-t border-daintree-border pt-3 min-h-9">
           <div className="flex items-center gap-2">
             <div className="h-5 w-16 rounded-full pulse-skeleton-shimmer" />
             <div className="h-5 w-12 rounded-full pulse-skeleton-shimmer" />
@@ -286,35 +286,29 @@ function PulseSkeleton({ className }: { className?: string }) {
 
 function HealthSectionSkeleton() {
   return (
-    <div className="border-t border-daintree-border pt-3 animate-pulse-delayed">
-      <div className="flex items-center gap-2">
-        <div className="h-5 pulse-skeleton-shimmer rounded-full w-16" />
-        <div className="h-5 pulse-skeleton-shimmer rounded-full w-12" />
-        <div className="h-5 pulse-skeleton-shimmer rounded-full w-12" />
-        <div className="h-5 pulse-skeleton-shimmer rounded-full w-24" />
-      </div>
+    <div className="animate-pulse-delayed flex items-center gap-2">
+      <div className="h-5 pulse-skeleton-shimmer rounded-full w-16" />
+      <div className="h-5 pulse-skeleton-shimmer rounded-full w-12" />
+      <div className="h-5 pulse-skeleton-shimmer rounded-full w-12" />
+      <div className="h-5 pulse-skeleton-shimmer rounded-full w-24" />
     </div>
   );
 }
 
 function NoRemoteHint() {
   return (
-    <div className="border-t border-daintree-border pt-3">
-      <div className="flex items-center gap-2 text-xs text-daintree-text/75">
-        <Github className="w-3.5 h-3.5" />
-        <span>Connect a GitHub remote for CI status, issues, and PRs</span>
-      </div>
+    <div className="flex items-center gap-2 text-xs text-daintree-text/75">
+      <Github className="w-3.5 h-3.5" />
+      <span>Connect a GitHub remote for CI status, issues, and PRs</span>
     </div>
   );
 }
 
 function OfflineHint() {
   return (
-    <div className="border-t border-daintree-border pt-3">
-      <div className="flex items-center gap-2 text-xs text-daintree-text/75">
-        <WifiOff className="w-3.5 h-3.5" />
-        <span>Offline — GitHub status unavailable</span>
-      </div>
+    <div className="flex items-center gap-2 text-xs text-daintree-text/75">
+      <WifiOff className="w-3.5 h-3.5" />
+      <span>Offline — GitHub status unavailable</span>
     </div>
   );
 }
@@ -416,6 +410,11 @@ export function ProjectPulseCard({ worktreeId, className }: ProjectPulseCardProp
       <div
         className={cn(
           "pulse-card p-4 rounded-[var(--radius-lg)] border border-daintree-border",
+          // Hold the slot at PulseSkeleton's natural height so the empty-state
+          // column doesn't reflow when the skeleton swaps to this one-liner
+          // (#7671). The card centers its short message inside the reserved
+          // box instead of shrinking and shifting siblings up.
+          "min-h-[240px] flex items-center",
           className
         )}
       >
@@ -436,10 +435,13 @@ export function ProjectPulseCard({ worktreeId, className }: ProjectPulseCardProp
       <div
         className={cn(
           "pulse-card p-4 rounded-[var(--radius-lg)] border border-daintree-border",
+          // Match PulseSkeleton height so the error swap doesn't collapse the
+          // card and shift siblings up (#7671).
+          "min-h-[240px] flex items-center",
           className
         )}
       >
-        <div className="flex flex-col gap-2">
+        <div className="flex flex-col gap-2 w-full">
           <div className="flex items-center gap-2 text-daintree-text/75" role="alert">
             <AlertCircle className="w-4 h-4 text-status-error" aria-hidden="true" />
             <span className="text-xs">{error}</span>
@@ -475,7 +477,7 @@ export function ProjectPulseCard({ worktreeId, className }: ProjectPulseCardProp
   return (
     <div
       className={cn(
-        "pulse-card w-fit rounded-[var(--radius-lg)] border border-daintree-border",
+        "pulse-card w-fit rounded-[var(--radius-lg)] border border-daintree-border min-h-[240px]",
         className
       )}
       aria-busy={isLoading}
@@ -542,17 +544,22 @@ export function ProjectPulseCard({ worktreeId, className }: ProjectPulseCardProp
 
         <p className="text-xs text-daintree-text/80">{getCoachLine(pulse)}</p>
 
-        {health && !health.error && health.repoUrl ? (
-          <div className="border-t border-daintree-border pt-3">
+        {/* Health section: always renders the wrapper so the 4 sub-variants
+            (signals, skeleton, no-remote hint, offline hint) can swap without
+            growing or collapsing the card. `min-h-9` matches the chip row
+            height (h-5 chip + pt-3 padding) so the loaded HealthSignals row
+            doesn't push siblings down when it resolves after pulse (#7671). */}
+        <div className="border-t border-daintree-border pt-3 min-h-9">
+          {health && !health.error && health.repoUrl ? (
             <HealthSignals health={health} rangeDays={rangeDays} />
-          </div>
-        ) : healthLoading ? (
-          <HealthSectionSkeleton />
-        ) : health && !health.hasRemote ? (
-          <NoRemoteHint />
-        ) : health && health.hasRemote ? (
-          <OfflineHint />
-        ) : null}
+          ) : healthLoading ? (
+            <HealthSectionSkeleton />
+          ) : health && !health.hasRemote ? (
+            <NoRemoteHint />
+          ) : health && health.hasRemote ? (
+            <OfflineHint />
+          ) : null}
+        </div>
 
         <div className="border-t border-daintree-border pt-3">
           <PulseSummary pulse={pulse} />

--- a/src/components/Pulse/__tests__/pulseContrast.test.ts
+++ b/src/components/Pulse/__tests__/pulseContrast.test.ts
@@ -119,6 +119,30 @@ describe("PulseHeatmap — accent restraint (issue #7229)", () => {
   });
 });
 
+describe("ProjectPulseCard — slot stability (issue #7671)", () => {
+  it("skeleton, loaded, error, and new-repo variants share min-h-[240px] so swaps don't shift siblings", async () => {
+    const content = await readFile(CARD_PATH, "utf-8");
+    const occurrences = content.match(/min-h-\[240px\]/g);
+    expect(occurrences).not.toBeNull();
+    // PulseSkeleton + loaded card + new-repo variant + error variant = 4
+    expect(occurrences!.length).toBeGreaterThanOrEqual(4);
+  });
+
+  it("health section wraps all four sub-variants in a single stable border-t pt-3 min-h-9 container", async () => {
+    const content = await readFile(CARD_PATH, "utf-8");
+    // The wrapping div holds the slot at a constant height while the loaded
+    // health row, skeleton, no-remote hint, and offline hint swap inside it.
+    expect(content).toContain('"border-t border-daintree-border pt-3 min-h-9"');
+  });
+
+  it("non-loaded variants centre content vertically inside the reserved slot", async () => {
+    const content = await readFile(CARD_PATH, "utf-8");
+    // `flex items-center` keeps the short message centred when min-h reserves
+    // extra space (otherwise the message would pin to the top of the card).
+    expect(content).toMatch(/min-h-\[240px\] flex items-center/);
+  });
+});
+
 describe("ProjectPulseCard — accessibility (issue #7229)", () => {
   it("range selector uses radiogroup semantics with descriptive label", async () => {
     const content = await readFile(CARD_PATH, "utf-8");

--- a/src/components/Terminal/__tests__/contentGridTips.test.tsx
+++ b/src/components/Terminal/__tests__/contentGridTips.test.tsx
@@ -80,6 +80,27 @@ describe("RotatingTip — count-biased selection (#6756)", () => {
     expect(container.querySelector("p")?.textContent).toMatch(/^Tip:/);
   });
 
+  it("placeholder shares the hydrated tip's column structure so swap doesn't shift layout (#7671)", () => {
+    // The anti-jump invariant: the unhydrated placeholder must match the
+    // rendered tip's outer flex layout and child count, so when shortcutHints
+    // hydrates the swap doesn't change the column's height.
+    const { container, rerender } = render(<RotatingTip />);
+    const before = container.firstChild as HTMLElement | null;
+    expect(before).not.toBeNull();
+    const beforeClasses = before!.className;
+    const beforeChildCount = before!.childElementCount;
+
+    setHydrated();
+    rerender(<RotatingTip />);
+    const after = container.firstChild as HTMLElement | null;
+    expect(after).not.toBeNull();
+
+    // Same flex column shape (items-center gap-2) and same row count.
+    expect(after!.className).toContain("flex flex-col items-center gap-2");
+    expect(beforeClasses).toContain("flex flex-col items-center gap-2");
+    expect(after!.childElementCount).toBe(beforeChildCount);
+  });
+
   it("biases toward an unused (zero-count) actionId over high-count ones", () => {
     // Math.random=0 always picks the first item in the prioritized subset.
     vi.spyOn(Math, "random").mockReturnValue(0);

--- a/src/components/Terminal/__tests__/contentGridTips.test.tsx
+++ b/src/components/Terminal/__tests__/contentGridTips.test.tsx
@@ -61,14 +61,21 @@ describe("RotatingTip — count-biased selection (#6756)", () => {
     isAgentLaunchableMock.mockReturnValue(true);
   });
 
-  it("renders nothing while shortcutHintStore is not hydrated", () => {
+  it("reserves an invisible slot while shortcutHintStore is not hydrated (#7671)", () => {
+    // Returning null would pop the tip in once shortcutHints hydrates a few
+    // ticks after first paint, shifting the empty-state column. The
+    // placeholder is aria-hidden so screen readers skip it.
     const { container } = render(<RotatingTip />);
-    expect(container.firstChild).toBeNull();
+    const placeholder = container.firstChild as HTMLElement | null;
+    expect(placeholder).not.toBeNull();
+    expect(placeholder!.getAttribute("aria-hidden")).toBe("true");
+    expect(placeholder!.className).toContain("invisible");
+    expect(container.textContent ?? "").not.toMatch(/Tip:/);
   });
 
   it("renders a tip once hydrated", () => {
     const { container } = render(<RotatingTip />);
-    expect(container.firstChild).toBeNull();
+    expect(container.textContent ?? "").not.toMatch(/Tip:/);
     setHydrated();
     expect(container.querySelector("p")?.textContent).toMatch(/^Tip:/);
   });

--- a/src/components/Terminal/contentGridTips.tsx
+++ b/src/components/Terminal/contentGridTips.tsx
@@ -242,22 +242,38 @@ export function RotatingTip() {
     if (picked) setTip(picked);
   }, [tip, hydrated, filteredTips]);
 
-  if (!tip) return null;
+  if (tip) {
+    return (
+      <div className="flex flex-col items-center gap-2 animate-in fade-in duration-200">
+        <p className="text-xs text-daintree-text/70 text-center">
+          Tip: <LiveTipMessage tip={tip} />
+        </p>
+        {tip.actionId && tip.actionLabel && (
+          <button
+            type="button"
+            onClick={() =>
+              void actionService.dispatch(tip.actionId!, undefined, { source: "user" })
+            }
+            className="text-xs text-text-secondary hover:text-daintree-text underline-offset-2 hover:underline transition-colors focus-visible:outline focus-visible:outline-2 focus-visible:outline-daintree-accent focus-visible:outline-offset-2 rounded px-1"
+          >
+            {tip.actionLabel}
+          </button>
+        )}
+      </div>
+    );
+  }
 
+  // No tip will ever appear (no agent tips survive filtering, no fallback). Stay quiet.
+  if (hydrated && filteredTips.length === 0) return null;
+
+  // Reserve the tip slot before hydration completes so the empty-state column
+  // doesn't reflow when `shortcutHintStore.hydrated` flips a few ticks after
+  // first paint (#7671). `invisible` keeps the box in layout flow without
+  // showing skeleton noise — the tip is sub-Doherty so a flash isn't needed.
   return (
-    <div className="flex flex-col items-center gap-2 animate-in fade-in duration-200">
-      <p className="text-xs text-daintree-text/70 text-center">
-        Tip: <LiveTipMessage tip={tip} />
-      </p>
-      {tip.actionId && tip.actionLabel && (
-        <button
-          type="button"
-          onClick={() => void actionService.dispatch(tip.actionId!, undefined, { source: "user" })}
-          className="text-xs text-text-secondary hover:text-daintree-text underline-offset-2 hover:underline transition-colors focus-visible:outline focus-visible:outline-2 focus-visible:outline-daintree-accent focus-visible:outline-offset-2 rounded px-1"
-        >
-          {tip.actionLabel}
-        </button>
-      )}
+    <div className="flex flex-col items-center gap-2 invisible" aria-hidden="true">
+      <p className="text-xs">&nbsp;</p>
+      <span className="text-xs px-1">&nbsp;</span>
     </div>
   );
 }


### PR DESCRIPTION
## Summary

Fixes visible layout shifts in the empty state panel grid as multiple data stores hydrate at different ticks. Three slots needed stabilization:

- **`RotatingTip`** — was rendering `null` while `shortcutHintStore` hydrated, causing a height pop-in that shifted siblings. Now renders an invisible `aria-hidden` placeholder with the same flex shape and child count as a hydrated tip. Returns `null` only when `filteredTips` is permanently empty.
- **`ProjectPulseCard`** — pins `min-h-[240px]` on all four variants (skeleton, loaded, error, new-repo). The new-repo and error variants centre their short message inside the reserved slot with `flex items-center`, so the card height is stable across the skeleton → loaded transition.
- **Health section** — wrapped in a single `border-t pt-3 min-h-9` container. The four sub-variants (`HealthSignals`, `HealthSectionSkeleton`, `NoRemoteHint`, `OfflineHint`) provide content only, so the wrapper height doesn't shift when health data arrives after pulse.

A `isStateLoaded` thread-through was considered but rejected — `App.tsx` already gates the whole render on `isStateLoaded`, so by the time `ContentGridEmptyState` mounts that flag is already true. The remaining shifts come from sources that fire after it (`shortcutHints` IPC, `pulseStore.fetchPulse`, `useProjectHealth` IPC), so per-slot stabilization is the right fix.

Resolves #7671

## Changes

- `src/components/Terminal/contentGridTips.tsx` — `RotatingTip` placeholder
- `src/components/Pulse/ProjectPulseCard.tsx` — `min-h` on all variants + stable health section wrapper
- `src/components/Terminal/__tests__/contentGridTips.test.tsx` — placeholder shape parity assertions
- `src/components/Pulse/__tests__/pulseContrast.test.ts` — card stability assertions across variants

## Testing

- Cold-open on a returning-user project: `RotatingTip` slot is empty (invisible placeholder) on the first frame, tip fades in without shifting the project icon or pulse card
- Worktree with a new-repo or error pulse: skeleton → final variant transition doesn't collapse the card
- Worktree with a GitHub remote: health chips appearing after pulse data doesn't grow the card height
- `vitest run`: 47+ relevant tests passing; `npm run check` clean