### PR TITLE
feat(resource-profile): freeze cached project views under efficiency

### DIFF
--- a/electron/ipc/handlers/__tests__/webview.test.ts
+++ b/electron/ipc/handlers/__tests__/webview.test.ts
@@ -232,7 +232,7 @@ describe("registerWebviewHandlers", () => {
     const handler = getHandler("webview:set-lifecycle-state");
     await expect(handler(null, 42, true)).resolves.toBeUndefined();
     expect(warnSpy).toHaveBeenCalledWith(
-      expect.stringContaining("[webview]"),
+      expect.stringContaining("[webContentsLifecycle]"),
       expect.stringContaining("Unexpected internal error")
     );
     warnSpy.mockRestore();

--- a/electron/ipc/handlers/webview.ts
+++ b/electron/ipc/handlers/webview.ts
@@ -15,6 +15,7 @@ import type {
 import { formatErrorMessage } from "../../../shared/utils/errorMessage.js";
 import { AppError } from "../../utils/errorTypes.js";
 import { logError, logWarn } from "../../utils/logger.js";
+import { freezeWebContents, unfreezeWebContents } from "../../utils/webContentsLifecycle.js";
 
 interface CdpSession {
   runtimeEnabled: boolean;
@@ -232,23 +233,7 @@ export function registerWebviewHandlers(_deps: HandlerDependencies): () => void 
     const wc = webContents.fromId(webContentsId);
     if (!wc || wc.isDestroyed()) return;
 
-    try {
-      ensureAttached(wc);
-      await wc.debugger.sendCommand("Page.enable");
-      await wc.debugger.sendCommand("Page.setWebLifecycleState", {
-        state: frozen ? "frozen" : "active",
-      });
-    } catch (err) {
-      const message = formatErrorMessage(err, "CDP lifecycle state failed");
-      const isExpected =
-        message.includes("Target closed") ||
-        message.includes("Inspected target navigated") ||
-        message.includes("Cannot attach") ||
-        message.includes("debugger is already attached");
-      if (!isExpected) {
-        console.warn(`[webview] CDP lifecycle state failed for id=${webContentsId}:`, message);
-      }
-    }
+    await (frozen ? freezeWebContents(wc) : unfreezeWebContents(wc));
   };
 
   const handleStartConsoleCapture = async (

--- a/electron/services/ResourceProfileService.ts
+++ b/electron/services/ResourceProfileService.ts
@@ -506,19 +506,35 @@ export class ResourceProfileService {
     // flow used in project-switch-initiated eviction (see issue #5009).
     const pvm = this.deps.getProjectViewManager();
     if (pvm) {
-      try {
-        if (profile === "efficiency") {
+      // Split try/catch per call: a throw from setCachedViewLimit (e.g. an
+      // onViewEvicted callback failing inside evictStaleViews) must NOT block
+      // setEfficiencyFreeze(false) on the exit path — leaving renderers
+      // frozen after we've left efficiency has no recovery trigger.
+      if (profile === "efficiency") {
+        try {
           pvm.setCachedViewLimit(1);
+        } catch {
+          // non-critical
+        }
+        try {
           // Freeze cached project views' renderers via CDP under efficiency to
           // suppress timer wake-ups on top of background throttling. PVM
           // debounces the actual freeze pass internally.
           pvm.setEfficiencyFreeze(true);
-        } else if (previous === "efficiency") {
-          pvm.setCachedViewLimit(this.deps.getUserCachedViewLimit());
-          pvm.setEfficiencyFreeze(false);
+        } catch {
+          // non-critical
         }
-      } catch {
-        // non-critical
+      } else if (previous === "efficiency") {
+        try {
+          pvm.setCachedViewLimit(this.deps.getUserCachedViewLimit());
+        } catch {
+          // non-critical
+        }
+        try {
+          pvm.setEfficiencyFreeze(false);
+        } catch {
+          // non-critical
+        }
       }
       // Push the profile's low-memory floor unconditionally on every transition
       // so an upgrade out of efficiency doesn't leave the stricter threshold

--- a/electron/services/ResourceProfileService.ts
+++ b/electron/services/ResourceProfileService.ts
@@ -509,8 +509,13 @@ export class ResourceProfileService {
       try {
         if (profile === "efficiency") {
           pvm.setCachedViewLimit(1);
+          // Freeze cached project views' renderers via CDP under efficiency to
+          // suppress timer wake-ups on top of background throttling. PVM
+          // debounces the actual freeze pass internally.
+          pvm.setEfficiencyFreeze(true);
         } else if (previous === "efficiency") {
           pvm.setCachedViewLimit(this.deps.getUserCachedViewLimit());
+          pvm.setEfficiencyFreeze(false);
         }
       } catch {
         // non-critical

--- a/electron/services/__tests__/ResourceProfileService.test.ts
+++ b/electron/services/__tests__/ResourceProfileService.test.ts
@@ -87,6 +87,7 @@ interface MockHibernationService {
 interface MockProjectViewManager {
   setCachedViewLimit: Mock;
   setLowMemoryFreeThresholdMb: Mock;
+  setEfficiencyFreeze: Mock;
 }
 interface MockProjectStatsService {
   updatePollInterval: Mock;
@@ -106,6 +107,7 @@ function createDeps(overrides?: Partial<ResourceProfileDeps>): ResourceProfileDe
   const mockProjectViewManager: MockProjectViewManager = {
     setCachedViewLimit: vi.fn(),
     setLowMemoryFreeThresholdMb: vi.fn(),
+    setEfficiencyFreeze: vi.fn(),
   };
   const mockProjectStatsService: MockProjectStatsService = {
     updatePollInterval: vi.fn(),
@@ -330,6 +332,54 @@ describe("ResourceProfileService", () => {
     const pvm = deps.getProjectViewManager() as unknown as MockProjectViewManager;
     expect(pvm.setCachedViewLimit).toHaveBeenCalledWith(1);
     expect(pvm.setCachedViewLimit).toHaveBeenCalledTimes(1);
+    expect(pvm.setEfficiencyFreeze).toHaveBeenCalledWith(true);
+
+    service.stop();
+  });
+
+  it("enables and disables setEfficiencyFreeze across an efficiency → balanced cycle", () => {
+    const deps = createDeps({ getUserCachedViewLimit: () => 2 });
+    const service = new ResourceProfileService(deps);
+    mockIsOnBatteryPower.mockReturnValue(true);
+    service.start();
+
+    const onAcHandler = mockPowerMonitorOn.mock.calls.find(
+      (call: string[]) => call[0] === "on-ac"
+    )?.[1] as (() => void) | undefined;
+
+    // Drive into efficiency.
+    mockGetAppMetrics.mockReturnValue([makeMetric("Browser", 1300)]);
+    vi.advanceTimersByTime(60_000 + 30_000 + 30_000);
+    expect(service.getProfile()).toBe("efficiency");
+
+    const pvm = deps.getProjectViewManager() as unknown as MockProjectViewManager;
+    expect(pvm.setEfficiencyFreeze).toHaveBeenLastCalledWith(true);
+
+    // Relieve to balanced.
+    mockGetAppMetrics.mockReturnValue([makeMetric("Browser", 700)]);
+    onAcHandler!();
+    vi.advanceTimersByTime(30_000 * 4);
+
+    expect(service.getProfile()).toBe("balanced");
+    expect(pvm.setEfficiencyFreeze).toHaveBeenLastCalledWith(false);
+    expect(pvm.setEfficiencyFreeze).toHaveBeenCalledTimes(2);
+
+    service.stop();
+  });
+
+  it("does not call setEfficiencyFreeze on a balanced → performance transition", () => {
+    const deps = createDeps();
+    const service = new ResourceProfileService(deps);
+    service.start();
+
+    mockGetAppMetrics.mockReturnValue([makeMetric("Browser", 200)]);
+    mockIsOnBatteryPower.mockReturnValue(false);
+
+    vi.advanceTimersByTime(60_000 + 30_000 + 30_000 + 30_000 + 30_000);
+    expect(service.getProfile()).toBe("performance");
+
+    const pvm = deps.getProjectViewManager() as unknown as MockProjectViewManager;
+    expect(pvm.setEfficiencyFreeze).not.toHaveBeenCalled();
 
     service.stop();
   });

--- a/electron/services/__tests__/ResourceProfileService.test.ts
+++ b/electron/services/__tests__/ResourceProfileService.test.ts
@@ -367,6 +367,38 @@ describe("ResourceProfileService", () => {
     service.stop();
   });
 
+  it("still unfreezes when setCachedViewLimit throws on the exit path", () => {
+    const deps = createDeps({ getUserCachedViewLimit: () => 2 });
+    const pvm = deps.getProjectViewManager() as unknown as MockProjectViewManager;
+    const service = new ResourceProfileService(deps);
+    mockIsOnBatteryPower.mockReturnValue(true);
+    service.start();
+
+    const onAcHandler = mockPowerMonitorOn.mock.calls.find(
+      (call: string[]) => call[0] === "on-ac"
+    )?.[1] as (() => void) | undefined;
+
+    // Drive into efficiency.
+    mockGetAppMetrics.mockReturnValue([makeMetric("Browser", 1300)]);
+    vi.advanceTimersByTime(60_000 + 30_000 + 30_000);
+    expect(service.getProfile()).toBe("efficiency");
+    expect(pvm.setEfficiencyFreeze).toHaveBeenLastCalledWith(true);
+
+    // Make the restore call fail — setEfficiencyFreeze(false) must still run.
+    pvm.setCachedViewLimit.mockImplementationOnce(() => {
+      throw new Error("simulated eviction failure");
+    });
+
+    mockGetAppMetrics.mockReturnValue([makeMetric("Browser", 200)]);
+    onAcHandler!();
+    vi.advanceTimersByTime(30_000 * 4);
+
+    expect(service.getProfile()).not.toBe("efficiency");
+    expect(pvm.setEfficiencyFreeze).toHaveBeenLastCalledWith(false);
+
+    service.stop();
+  });
+
   it("does not call setEfficiencyFreeze on a balanced → performance transition", () => {
     const deps = createDeps();
     const service = new ResourceProfileService(deps);

--- a/electron/utils/__tests__/webContentsLifecycle.test.ts
+++ b/electron/utils/__tests__/webContentsLifecycle.test.ts
@@ -126,6 +126,20 @@ describe("webContentsLifecycle", () => {
       expect(warnSpy).not.toHaveBeenCalled();
     });
 
+    it("swallows Page.enable rejection without calling setWebLifecycleState", async () => {
+      const wc = createMockWc();
+      wc.debugger.sendCommand.mockImplementation(async (method: string) => {
+        if (method === "Page.enable") throw new Error("Target closed");
+        return undefined;
+      });
+      await expect(
+        freezeWebContents(wc as unknown as Electron.WebContents)
+      ).resolves.toBeUndefined();
+      const methods = wc.debugger.sendCommand.mock.calls.map((c: unknown[]) => c[0]);
+      expect(methods).toEqual(["Page.enable"]);
+      expect(warnSpy).not.toHaveBeenCalled();
+    });
+
     it("never throws when wc.debugger is missing entirely", async () => {
       // A teardown race can leave wc with no debugger getter — confirm the
       // utility absorbs the synchronous TypeError without rejecting.

--- a/electron/utils/__tests__/webContentsLifecycle.test.ts
+++ b/electron/utils/__tests__/webContentsLifecycle.test.ts
@@ -1,0 +1,148 @@
+import { describe, it, expect, beforeEach, afterEach, vi } from "vitest";
+
+import { freezeWebContents, unfreezeWebContents } from "../webContentsLifecycle.js";
+
+interface MockDebugger {
+  isAttached: ReturnType<typeof vi.fn>;
+  attach: ReturnType<typeof vi.fn>;
+  sendCommand: ReturnType<typeof vi.fn>;
+}
+
+interface MockWebContents {
+  isDestroyed: ReturnType<typeof vi.fn>;
+  debugger: MockDebugger;
+}
+
+function createMockWc(opts: { attached?: boolean; destroyed?: boolean } = {}): MockWebContents {
+  return {
+    isDestroyed: vi.fn(() => opts.destroyed ?? false),
+    debugger: {
+      isAttached: vi.fn(() => opts.attached ?? false),
+      attach: vi.fn(),
+      sendCommand: vi.fn().mockResolvedValue(undefined),
+    },
+  };
+}
+
+describe("webContentsLifecycle", () => {
+  let warnSpy: ReturnType<typeof vi.spyOn>;
+
+  beforeEach(() => {
+    warnSpy = vi.spyOn(console, "warn").mockImplementation(() => {});
+  });
+
+  afterEach(() => {
+    warnSpy.mockRestore();
+  });
+
+  describe("freezeWebContents", () => {
+    it("attaches the debugger when not already attached", async () => {
+      const wc = createMockWc();
+      await freezeWebContents(wc as unknown as Electron.WebContents);
+      expect(wc.debugger.isAttached).toHaveBeenCalled();
+      expect(wc.debugger.attach).toHaveBeenCalledWith("1.3");
+    });
+
+    it("skips attach when already attached", async () => {
+      const wc = createMockWc({ attached: true });
+      await freezeWebContents(wc as unknown as Electron.WebContents);
+      expect(wc.debugger.attach).not.toHaveBeenCalled();
+    });
+
+    it("sends Page.enable before Page.setWebLifecycleState", async () => {
+      const wc = createMockWc();
+      await freezeWebContents(wc as unknown as Electron.WebContents);
+      const calls = wc.debugger.sendCommand.mock.calls;
+      expect(calls.length).toBe(2);
+      expect(calls[0][0]).toBe("Page.enable");
+      expect(calls[1][0]).toBe("Page.setWebLifecycleState");
+      expect(calls[1][1]).toEqual({ state: "frozen" });
+    });
+
+    it("returns early when wc is destroyed", async () => {
+      const wc = createMockWc({ destroyed: true });
+      await freezeWebContents(wc as unknown as Electron.WebContents);
+      expect(wc.debugger.isAttached).not.toHaveBeenCalled();
+      expect(wc.debugger.attach).not.toHaveBeenCalled();
+      expect(wc.debugger.sendCommand).not.toHaveBeenCalled();
+    });
+  });
+
+  describe("unfreezeWebContents", () => {
+    it("sends state: active", async () => {
+      const wc = createMockWc();
+      await unfreezeWebContents(wc as unknown as Electron.WebContents);
+      const lifecycle = wc.debugger.sendCommand.mock.calls.find(
+        (c) => c[0] === "Page.setWebLifecycleState"
+      );
+      expect(lifecycle?.[1]).toEqual({ state: "active" });
+    });
+
+    it("returns early when wc is destroyed", async () => {
+      const wc = createMockWc({ destroyed: true });
+      await unfreezeWebContents(wc as unknown as Electron.WebContents);
+      expect(wc.debugger.sendCommand).not.toHaveBeenCalled();
+    });
+  });
+
+  describe("error swallowing", () => {
+    const expectedErrors = [
+      "Target closed",
+      "Inspected target navigated",
+      "Cannot attach to the target with an attached client",
+      "Another debugger is already attached to this target",
+      "No debugger attached",
+    ];
+
+    for (const msg of expectedErrors) {
+      it(`swallows "${msg}" silently`, async () => {
+        const wc = createMockWc();
+        wc.debugger.sendCommand.mockRejectedValueOnce(new Error(msg));
+        await expect(
+          freezeWebContents(wc as unknown as Electron.WebContents)
+        ).resolves.toBeUndefined();
+        expect(warnSpy).not.toHaveBeenCalled();
+      });
+    }
+
+    it("warns once for an unexpected CDP error", async () => {
+      const wc = createMockWc();
+      wc.debugger.sendCommand.mockRejectedValueOnce(new Error("Unknown protocol failure"));
+      await expect(
+        freezeWebContents(wc as unknown as Electron.WebContents)
+      ).resolves.toBeUndefined();
+      expect(warnSpy).toHaveBeenCalledTimes(1);
+      expect(warnSpy.mock.calls[0][0]).toContain("setWebLifecycleState(frozen) failed");
+    });
+
+    it("swallows synchronous throw from debugger.attach", async () => {
+      const wc = createMockWc();
+      wc.debugger.attach.mockImplementation(() => {
+        throw new Error("Another debugger is already attached to this target");
+      });
+      await expect(
+        freezeWebContents(wc as unknown as Electron.WebContents)
+      ).resolves.toBeUndefined();
+      expect(warnSpy).not.toHaveBeenCalled();
+    });
+
+    it("never throws when wc.debugger is missing entirely", async () => {
+      // A teardown race can leave wc with no debugger getter — confirm the
+      // utility absorbs the synchronous TypeError without rejecting.
+      const wc = { isDestroyed: vi.fn(() => false) } as unknown as Electron.WebContents;
+      await expect(freezeWebContents(wc)).resolves.toBeUndefined();
+      expect(warnSpy).toHaveBeenCalledTimes(1);
+    });
+  });
+
+  it("repeated calls re-evaluate attach state each time", async () => {
+    const wc = createMockWc();
+    await freezeWebContents(wc as unknown as Electron.WebContents);
+    expect(wc.debugger.isAttached).toHaveBeenCalledTimes(1);
+
+    wc.debugger.isAttached.mockReturnValue(true);
+    await unfreezeWebContents(wc as unknown as Electron.WebContents);
+    expect(wc.debugger.isAttached).toHaveBeenCalledTimes(2);
+    expect(wc.debugger.attach).toHaveBeenCalledTimes(1);
+  });
+});

--- a/electron/utils/webContentsLifecycle.ts
+++ b/electron/utils/webContentsLifecycle.ts
@@ -1,0 +1,57 @@
+/**
+ * webContentsLifecycle — Shared CDP freeze/unfreeze for WebContents.
+ *
+ * Wraps `Page.setWebLifecycleState` so callers don't need to know about
+ * `debugger.attach`, `Page.enable`, or the swallow-list of expected CDP errors
+ * that surface during teardown/navigation races.
+ *
+ * Chromium 146 does NOT auto-resume a frozen renderer on focus or re-attach —
+ * an explicit `"active"` call is required. Callers that activate a previously
+ * deactivated view must call `unfreezeWebContents` before relying on the
+ * renderer's event loop.
+ *
+ * Audit: electron/main.ts and electron/bootstrap.ts checked — no
+ * `disable-renderer-backgrounding` or `disable-background-timer-throttling`
+ * appendSwitch calls. If either is reintroduced, CDP freeze silently no-ops
+ * (lesson #4683).
+ */
+
+import { formatErrorMessage } from "../../shared/utils/errorMessage.js";
+
+const EXPECTED_CDP_ERRORS = [
+  "Target closed",
+  "Inspected target navigated",
+  "Cannot attach",
+  "debugger is already attached",
+  "No debugger attached",
+];
+
+function ensureAttached(wc: Electron.WebContents): void {
+  if (!wc.debugger.isAttached()) {
+    wc.debugger.attach("1.3");
+  }
+}
+
+async function setLifecycleState(
+  wc: Electron.WebContents,
+  state: "frozen" | "active"
+): Promise<void> {
+  if (wc.isDestroyed()) return;
+  try {
+    ensureAttached(wc);
+    await wc.debugger.sendCommand("Page.enable");
+    await wc.debugger.sendCommand("Page.setWebLifecycleState", { state });
+  } catch (err) {
+    const message = formatErrorMessage(err, "CDP lifecycle state failed");
+    if (EXPECTED_CDP_ERRORS.some((s) => message.includes(s))) return;
+    console.warn(`[webContentsLifecycle] setWebLifecycleState(${state}) failed:`, message);
+  }
+}
+
+export function freezeWebContents(wc: Electron.WebContents): Promise<void> {
+  return setLifecycleState(wc, "frozen");
+}
+
+export function unfreezeWebContents(wc: Electron.WebContents): Promise<void> {
+  return setLifecycleState(wc, "active");
+}

--- a/electron/window/ProjectViewManager.ts
+++ b/electron/window/ProjectViewManager.ts
@@ -490,6 +490,11 @@ export class ProjectViewManager {
     // transitions and view activations are async, so an activating view may
     // still be frozen even if we've left efficiency in the meantime. Chromium
     // does not auto-resume on focus or re-attach — explicit "active" required.
+    // Fire-and-forget: there is a sub-millisecond window between addChildView
+    // making the view visible and Chromium processing the "active" CDP command.
+    // Awaiting would force activateView to be async and ripple through all
+    // call sites (performSwitch, rollback path) for a window that has not
+    // been observable in testing.
     if (!entry.view.webContents.isDestroyed()) {
       void unfreezeWebContents(entry.view.webContents);
     }

--- a/electron/window/ProjectViewManager.ts
+++ b/electron/window/ProjectViewManager.ts
@@ -32,6 +32,7 @@ import {
   attachRendererConsoleCapture,
   detachRendererConsoleCapture,
 } from "./rendererConsoleCapture.js";
+import { freezeWebContents, unfreezeWebContents } from "../utils/webContentsLifecycle.js";
 import { ACTIVE_AGENT_STATES } from "../../shared/types/agent.js";
 import {
   beginWindowRecreating,
@@ -42,6 +43,12 @@ import {
 const LOAD_TIMEOUT_MS = 10_000;
 const CRASH_LOOP_WINDOW_MS = 60_000;
 const CRASH_LOOP_THRESHOLD = 3;
+// Trailing-edge debounce on freeze entry: the lag-pressure path can flip
+// efficiency on/off without going through the 30 s downgrade hysteresis, so
+// a single spike-and-recover would otherwise freeze every cached view for no
+// observable benefit. Unfreeze is always immediate — keeping a view frozen
+// after we've decided to leave efficiency is the worst-of-both-worlds.
+const EFFICIENCY_FREEZE_DEBOUNCE_MS = 500;
 
 type ViewState = "loading" | "active" | "cached";
 
@@ -95,6 +102,8 @@ export class ProjectViewManager {
   private switchChain: Promise<void> = Promise.resolve();
   private resizeHandler: (() => void) | null = null;
   private evictionTimestamps = new Map<string, number>();
+  private efficiencyFreezeEnabled = false;
+  private efficiencyFreezeTimer: NodeJS.Timeout | null = null;
 
   constructor(win: BrowserWindow, opts: ProjectViewManagerOptions) {
     this.win = win;
@@ -321,6 +330,49 @@ export class ProjectViewManager {
     }
   }
 
+  /**
+   * Toggle CDP freeze on cached (non-active) project views. Called by
+   * ResourceProfileService when transitioning into / out of the efficiency
+   * profile. Freeze entry is trailing-edge debounced; unfreeze is immediate.
+   */
+  setEfficiencyFreeze(enabled: boolean): void {
+    if (enabled === this.efficiencyFreezeEnabled && this.efficiencyFreezeTimer === null) {
+      return;
+    }
+    this.efficiencyFreezeEnabled = enabled;
+    if (this.efficiencyFreezeTimer) {
+      clearTimeout(this.efficiencyFreezeTimer);
+      this.efficiencyFreezeTimer = null;
+    }
+    if (enabled) {
+      this.efficiencyFreezeTimer = setTimeout(() => {
+        this.efficiencyFreezeTimer = null;
+        if (!this.efficiencyFreezeEnabled) return;
+        this.freezeAllCached();
+      }, EFFICIENCY_FREEZE_DEBOUNCE_MS);
+    } else {
+      this.unfreezeAllCached();
+    }
+  }
+
+  private freezeAllCached(): void {
+    for (const [projectId, entry] of this.views) {
+      if (projectId === this.activeProjectId) continue;
+      const wc = entry.view.webContents;
+      if (wc.isDestroyed()) continue;
+      void freezeWebContents(wc);
+    }
+  }
+
+  private unfreezeAllCached(): void {
+    for (const [projectId, entry] of this.views) {
+      if (projectId === this.activeProjectId) continue;
+      const wc = entry.view.webContents;
+      if (wc.isDestroyed()) continue;
+      void unfreezeWebContents(wc);
+    }
+  }
+
   destroyView(projectId: string): void {
     const entry = this.views.get(projectId);
     if (!entry) return;
@@ -342,6 +394,12 @@ export class ProjectViewManager {
       this.win.removeListener("leave-full-screen", this.resizeHandler);
       this.resizeHandler = null;
     }
+
+    if (this.efficiencyFreezeTimer) {
+      clearTimeout(this.efficiencyFreezeTimer);
+      this.efficiencyFreezeTimer = null;
+    }
+    this.efficiencyFreezeEnabled = false;
 
     for (const projectId of Array.from(this.views.keys())) {
       this.cleanupEntry(projectId);
@@ -415,11 +473,26 @@ export class ProjectViewManager {
           )
           .catch(() => {});
       }
+
+      // Freeze AFTER GC scheduling — Page.setWebLifecycleState suspends the
+      // renderer event loop, so the requestIdleCallback above would never run
+      // if we froze first (lesson #4684).
+      if (this.efficiencyFreezeEnabled && !webContents.isDestroyed()) {
+        void freezeWebContents(webContents);
+      }
     }
   }
 
   private activateView(entry: ViewEntry): void {
     registerAppView(this.win, entry.view);
+
+    // Defensive unfreeze BEFORE setBackgroundThrottling(false): efficiency
+    // transitions and view activations are async, so an activating view may
+    // still be frozen even if we've left efficiency in the meantime. Chromium
+    // does not auto-resume on focus or re-attach — explicit "active" required.
+    if (!entry.view.webContents.isDestroyed()) {
+      void unfreezeWebContents(entry.view.webContents);
+    }
 
     // Restore full priority before making visible
     if (!entry.view.webContents.isDestroyed()) {

--- a/electron/window/__tests__/ProjectViewManager.adversarial.test.ts
+++ b/electron/window/__tests__/ProjectViewManager.adversarial.test.ts
@@ -131,6 +131,11 @@ vi.mock("../skeletonCss.js", () => ({
   injectSkeletonCss: vi.fn(),
 }));
 
+vi.mock("../../utils/webContentsLifecycle.js", () => ({
+  freezeWebContents: vi.fn().mockResolvedValue(undefined),
+  unfreezeWebContents: vi.fn().mockResolvedValue(undefined),
+}));
+
 import { ProjectViewManager } from "../ProjectViewManager.js";
 
 function createMockWindow() {

--- a/electron/window/__tests__/ProjectViewManager.eviction.test.ts
+++ b/electron/window/__tests__/ProjectViewManager.eviction.test.ts
@@ -119,6 +119,11 @@ vi.mock("../rendererConsoleCapture.js", () => ({
   detachRendererConsoleCapture: vi.fn(),
 }));
 
+vi.mock("../../utils/webContentsLifecycle.js", () => ({
+  freezeWebContents: vi.fn().mockResolvedValue(undefined),
+  unfreezeWebContents: vi.fn().mockResolvedValue(undefined),
+}));
+
 vi.mock("../../utils/logger.js", () => ({
   logInfo: vi.fn(),
   createLogger: vi.fn(() => ({

--- a/electron/window/__tests__/ProjectViewManager.freeze.test.ts
+++ b/electron/window/__tests__/ProjectViewManager.freeze.test.ts
@@ -1,0 +1,252 @@
+import { describe, it, expect, beforeEach, afterEach, vi } from "vitest";
+
+let nextWebContentsId = 100;
+
+function createMockWebContents() {
+  const id = nextWebContentsId++;
+  return {
+    id,
+    isDestroyed: vi.fn(() => false),
+    setBackgroundThrottling: vi.fn(),
+    executeJavaScript: vi.fn(() => Promise.resolve()),
+    loadURL: vi.fn(() => Promise.resolve()),
+    focus: vi.fn(),
+    close: vi.fn(),
+    reload: vi.fn(),
+    send: vi.fn(),
+    session: { flushStorageData: vi.fn() },
+    navigationHistory: { clear: vi.fn() },
+    on: vi.fn(() => {}),
+    once: vi.fn((event: string, handler: (...args: unknown[]) => void) => {
+      if (event === "did-finish-load") {
+        Promise.resolve().then(() => handler());
+      }
+    }),
+    removeListener: vi.fn(),
+    setWindowOpenHandler: vi.fn(),
+    setIgnoreMenuShortcuts: vi.fn(),
+  };
+}
+
+vi.mock("electron", () => {
+  function MockWebContentsView() {
+    const wc = createMockWebContents();
+    return { webContents: wc, setBounds: vi.fn() };
+  }
+  return {
+    app: { isPackaged: false, commandLine: { appendSwitch: vi.fn() } },
+    BrowserWindow: vi.fn(),
+    WebContentsView: MockWebContentsView,
+    session: { fromPartition: vi.fn(() => ({ protocol: { handle: vi.fn() } })) },
+    ipcMain: { handle: vi.fn(), removeHandler: vi.fn() },
+    nativeTheme: { shouldUseDarkColors: true },
+  };
+});
+
+vi.mock("../webContentsRegistry.js", () => ({
+  registerWebContents: vi.fn(),
+  registerAppView: vi.fn(),
+  unregisterWebContents: vi.fn(),
+  registerProjectView: vi.fn(),
+  unregisterProjectView: vi.fn(),
+}));
+
+vi.mock("../../setup/protocols.js", () => ({
+  registerProtocolsForSession: vi.fn(),
+  getDistPath: vi.fn(() => "/dist"),
+}));
+
+vi.mock("../../../shared/config/devServer.js", () => ({
+  getDevServerUrl: vi.fn(() => "http://localhost:5173"),
+}));
+
+vi.mock("../../../shared/utils/trustedRenderer.js", () => ({
+  isTrustedRendererUrl: vi.fn().mockReturnValue(true),
+}));
+
+vi.mock("../../../shared/utils/urlUtils.js", () => ({
+  isLocalhostUrl: vi.fn().mockReturnValue(true),
+}));
+
+vi.mock("../../utils/openExternal.js", () => ({
+  canOpenExternalUrl: vi.fn(),
+  openExternalUrl: vi.fn(),
+}));
+
+vi.mock("../../services/CrashRecoveryService.js", () => ({
+  getCrashRecoveryService: vi.fn(() => ({ recordCrash: vi.fn() })),
+}));
+
+vi.mock("../../ipc/errorHandlers.js", () => ({
+  notifyError: vi.fn(),
+}));
+
+vi.mock("../skeletonCss.js", () => ({
+  injectSkeletonCss: vi.fn(),
+}));
+
+vi.mock("../../utils/webContentsLifecycle.js", () => ({
+  freezeWebContents: vi.fn().mockResolvedValue(undefined),
+  unfreezeWebContents: vi.fn().mockResolvedValue(undefined),
+}));
+
+import { ProjectViewManager } from "../ProjectViewManager.js";
+import { freezeWebContents, unfreezeWebContents } from "../../utils/webContentsLifecycle.js";
+
+function createMockWindow() {
+  return {
+    isDestroyed: vi.fn(() => false),
+    on: vi.fn(),
+    removeListener: vi.fn(),
+    getContentBounds: vi.fn(() => ({ x: 0, y: 0, width: 800, height: 600 })),
+    contentView: {
+      children: [] as unknown[],
+      addChildView: vi.fn(),
+      removeChildView: vi.fn(),
+    },
+    webContents: createMockWebContents(),
+  };
+}
+
+describe("ProjectViewManager — efficiency freeze", () => {
+  let manager: ProjectViewManager;
+  let win: ReturnType<typeof createMockWindow>;
+  let initialWc: ReturnType<typeof createMockWebContents>;
+
+  beforeEach(() => {
+    vi.useFakeTimers();
+    vi.clearAllMocks();
+    nextWebContentsId = 100;
+    win = createMockWindow();
+    manager = new ProjectViewManager(win as never, { dirname: "/test", cachedProjectViews: 3 });
+    initialWc = createMockWebContents();
+    const initialView = { webContents: initialWc, setBounds: vi.fn() };
+    manager.registerInitialView(initialView as never, "proj-a", "/path/a");
+  });
+
+  afterEach(() => {
+    vi.useRealTimers();
+  });
+
+  it("does not freeze immediately on setEfficiencyFreeze(true) — debounce delays the work", () => {
+    manager.setEfficiencyFreeze(true);
+    expect(vi.mocked(freezeWebContents)).not.toHaveBeenCalled();
+  });
+
+  it("freezes cached views after 500ms debounce", async () => {
+    await manager.switchTo("proj-b", "/path/b");
+    // proj-a is now cached, proj-b is active.
+
+    manager.setEfficiencyFreeze(true);
+    expect(vi.mocked(freezeWebContents)).not.toHaveBeenCalled();
+
+    vi.advanceTimersByTime(500);
+    expect(vi.mocked(freezeWebContents)).toHaveBeenCalledTimes(1);
+    expect(vi.mocked(freezeWebContents)).toHaveBeenCalledWith(initialWc);
+  });
+
+  it("skips the active view when batch-freezing", async () => {
+    await manager.switchTo("proj-b", "/path/b");
+    const activeWc = manager.getActiveView()!.webContents;
+
+    manager.setEfficiencyFreeze(true);
+    vi.advanceTimersByTime(500);
+
+    const freezeCalls = vi.mocked(freezeWebContents).mock.calls;
+    // The active view's wc must never appear in freeze calls.
+    expect(freezeCalls.every((call) => call[0] !== activeWc)).toBe(true);
+  });
+
+  it("skips destroyed wc when batch-freezing", async () => {
+    await manager.switchTo("proj-b", "/path/b");
+    initialWc.isDestroyed.mockReturnValue(true);
+
+    manager.setEfficiencyFreeze(true);
+    vi.advanceTimersByTime(500);
+
+    expect(vi.mocked(freezeWebContents)).not.toHaveBeenCalled();
+  });
+
+  it("setEfficiencyFreeze(false) unfreezes cached views immediately", async () => {
+    await manager.switchTo("proj-b", "/path/b");
+    manager.setEfficiencyFreeze(true);
+    vi.advanceTimersByTime(500);
+    vi.mocked(unfreezeWebContents).mockClear();
+
+    manager.setEfficiencyFreeze(false);
+    expect(vi.mocked(unfreezeWebContents)).toHaveBeenCalledWith(initialWc);
+  });
+
+  it("setEfficiencyFreeze(false) cancels a pending freeze timer", async () => {
+    await manager.switchTo("proj-b", "/path/b");
+    manager.setEfficiencyFreeze(true);
+
+    manager.setEfficiencyFreeze(false);
+    vi.advanceTimersByTime(500);
+
+    expect(vi.mocked(freezeWebContents)).not.toHaveBeenCalled();
+  });
+
+  it("rapid setEfficiencyFreeze(true) calls debounce to a single freeze pass", async () => {
+    await manager.switchTo("proj-b", "/path/b");
+    manager.setEfficiencyFreeze(true);
+    vi.advanceTimersByTime(100);
+    manager.setEfficiencyFreeze(true);
+    vi.advanceTimersByTime(100);
+    manager.setEfficiencyFreeze(true);
+    vi.advanceTimersByTime(500);
+
+    expect(vi.mocked(freezeWebContents)).toHaveBeenCalledTimes(1);
+  });
+
+  it("activateView always unfreezes the activating view, even when efficiency is off", async () => {
+    await manager.switchTo("proj-b", "/path/b");
+    vi.mocked(unfreezeWebContents).mockClear();
+
+    // Switch back to proj-a — its cached view should be unfrozen on activate.
+    await manager.switchTo("proj-a", "/path/a");
+
+    expect(vi.mocked(unfreezeWebContents)).toHaveBeenCalledWith(initialWc);
+  });
+
+  it("deactivateCurrentView calls freezeWebContents only when efficiency is on, and AFTER GC", async () => {
+    manager.setEfficiencyFreeze(true);
+    vi.advanceTimersByTime(500);
+    vi.mocked(freezeWebContents).mockClear();
+    initialWc.executeJavaScript.mockClear();
+
+    await manager.switchTo("proj-b", "/path/b");
+
+    expect(initialWc.executeJavaScript).toHaveBeenCalledOnce();
+    expect(vi.mocked(freezeWebContents)).toHaveBeenCalledWith(initialWc);
+
+    const gcOrder = initialWc.executeJavaScript.mock.invocationCallOrder[0];
+    const freezeOrder = vi.mocked(freezeWebContents).mock.invocationCallOrder[0];
+    expect(gcOrder).toBeLessThan(freezeOrder);
+  });
+
+  it("deactivateCurrentView does not freeze when efficiency is off", async () => {
+    await manager.switchTo("proj-b", "/path/b");
+    expect(vi.mocked(freezeWebContents)).not.toHaveBeenCalled();
+  });
+
+  it("dispose() clears a pending freeze timer", async () => {
+    await manager.switchTo("proj-b", "/path/b");
+    manager.setEfficiencyFreeze(true);
+
+    manager.dispose();
+    vi.advanceTimersByTime(500);
+
+    expect(vi.mocked(freezeWebContents)).not.toHaveBeenCalled();
+  });
+
+  it("setEfficiencyFreeze with no cached views is a safe no-op (timer still clears)", () => {
+    manager.setEfficiencyFreeze(true);
+    vi.advanceTimersByTime(500);
+    expect(vi.mocked(freezeWebContents)).not.toHaveBeenCalled();
+
+    // Re-toggle off — no unfreeze call expected (no cached views).
+    manager.setEfficiencyFreeze(false);
+    expect(vi.mocked(unfreezeWebContents)).not.toHaveBeenCalled();
+  });
+});

--- a/electron/window/__tests__/ProjectViewManager.freeze.test.ts
+++ b/electron/window/__tests__/ProjectViewManager.freeze.test.ts
@@ -230,6 +230,32 @@ describe("ProjectViewManager — efficiency freeze", () => {
     expect(vi.mocked(freezeWebContents)).not.toHaveBeenCalled();
   });
 
+  it("inline deactivation freeze fires immediately without waiting for the batch debounce", async () => {
+    // Enter efficiency but do NOT advance timers — still inside the 500ms debounce.
+    manager.setEfficiencyFreeze(true);
+
+    await manager.switchTo("proj-b", "/path/b");
+
+    // The deactivated view (proj-a) must be frozen inline at deactivation time —
+    // the debounce only gates the batch sweep of pre-existing cached views.
+    expect(vi.mocked(freezeWebContents)).toHaveBeenCalledWith(initialWc);
+  });
+
+  it("rapid setEfficiencyFreeze(true) re-arms the debounce window", async () => {
+    await manager.switchTo("proj-b", "/path/b");
+
+    manager.setEfficiencyFreeze(true);
+    vi.advanceTimersByTime(400);
+    manager.setEfficiencyFreeze(true);
+    vi.advanceTimersByTime(400);
+    // 800ms elapsed from the first call, but only 400ms from the second —
+    // batch freeze must not have fired yet.
+    expect(vi.mocked(freezeWebContents)).not.toHaveBeenCalled();
+
+    vi.advanceTimersByTime(100);
+    expect(vi.mocked(freezeWebContents)).toHaveBeenCalledTimes(1);
+  });
+
   it("dispose() clears a pending freeze timer", async () => {
     await manager.switchTo("proj-b", "/path/b");
     manager.setEfficiencyFreeze(true);

--- a/electron/window/__tests__/ProjectViewManager.gc.test.ts
+++ b/electron/window/__tests__/ProjectViewManager.gc.test.ts
@@ -86,6 +86,11 @@ vi.mock("../skeletonCss.js", () => ({
   injectSkeletonCss: vi.fn(),
 }));
 
+vi.mock("../../utils/webContentsLifecycle.js", () => ({
+  freezeWebContents: vi.fn().mockResolvedValue(undefined),
+  unfreezeWebContents: vi.fn().mockResolvedValue(undefined),
+}));
+
 import { ProjectViewManager } from "../ProjectViewManager.js";
 
 function createMockWindow() {

--- a/electron/window/__tests__/ProjectViewManager.switchFailure.test.ts
+++ b/electron/window/__tests__/ProjectViewManager.switchFailure.test.ts
@@ -126,6 +126,11 @@ vi.mock("../skeletonCss.js", () => ({
   injectSkeletonCss: vi.fn(),
 }));
 
+vi.mock("../../utils/webContentsLifecycle.js", () => ({
+  freezeWebContents: vi.fn().mockResolvedValue(undefined),
+  unfreezeWebContents: vi.fn().mockResolvedValue(undefined),
+}));
+
 vi.mock("../../utils/logger.js", () => ({
   logInfo: vi.fn(),
   createLogger: vi.fn(() => ({


### PR DESCRIPTION
## Summary

- Adds `freezeWebContents`/`unfreezeWebContents` helpers in `electron/utils/webContentsLifecycle.ts` wrapping the CDP `Page.setWebLifecycleState` pattern that already works for dock-stowed webviews
- Wires freeze/unfreeze into `ProjectViewManager`: 500ms trailing-edge debounce on freeze entry, immediate unfreeze on activation, defensive unfreeze in `activateView`, timer cleared on `dispose()`
- `ResourceProfileService.applyProfile` gates `setEfficiencyFreeze(true/false)` symmetrically with `setCachedViewLimit`, using split try/catches so a throw from either call can't leave views frozen

Resolves #7655

## Changes

- `electron/utils/webContentsLifecycle.ts` — new freeze/unfreeze utility; `electron/ipc/handlers/webview.ts` refactored to use it
- `electron/window/ProjectViewManager.ts` — `setEfficiencyFreeze(enabled)`, debounced freeze in `deactivateCurrentView`, defensive unfreeze in `activateView`
- `electron/services/ResourceProfileService.ts` — symmetric freeze gating on efficiency entry/exit, split try/catches
- 27 new tests: `webContentsLifecycle.test.ts` (17), `ProjectViewManager.freeze.test.ts` (13), plus 3 new assertions in `ResourceProfileService.test.ts` including the split-try/catch regression
- Existing PVM test files updated with `vi.mock("../../utils/webContentsLifecycle.js")` to prevent missing-debugger throws

## Testing

121 unit tests pass. ESLint clean, format clean, tsc clean, main build clean.