### PR TITLE
refactor(agent-state): tighten visual encoding to prevent drift

### DIFF
--- a/src/components/Layout/ToolbarAssistantButton.tsx
+++ b/src/components/Layout/ToolbarAssistantButton.tsx
@@ -53,16 +53,18 @@ interface AgentPipDescriptor {
 // passive states for the worktree tray. Here the toolbar button is the only
 // chrome surfacing assistant state when the panel is closed, so working and
 // directing both earn the green pip alongside the yellow waiting pip.
+const AGENT_PIP_BY_STATE = {
+  working: { className: "bg-state-working", tooltip: "Assistant is working" },
+  directing: { className: "bg-state-working", tooltip: "Assistant is working" },
+  waiting: { className: "bg-state-waiting", tooltip: "Assistant is waiting" },
+} as const satisfies Record<
+  Extract<AgentState, "working" | "directing" | "waiting">,
+  AgentPipDescriptor
+>;
+
 function describeAgentPip(state: AgentState | null | undefined): AgentPipDescriptor | null {
-  switch (state) {
-    case "working":
-    case "directing":
-      return { className: "bg-state-working", tooltip: "Assistant is working" };
-    case "waiting":
-      return { className: "bg-state-waiting", tooltip: "Assistant is waiting" };
-    default:
-      return null;
-  }
+  if (state == null) return null;
+  return (AGENT_PIP_BY_STATE as Partial<Record<AgentState, AgentPipDescriptor>>)[state] ?? null;
 }
 
 export const ToolbarAssistantButton = memo(function ToolbarAssistantButton({

--- a/src/components/Worktree/AgentStatusIndicator.tsx
+++ b/src/components/Worktree/AgentStatusIndicator.tsx
@@ -2,56 +2,47 @@ import { useEffect, useRef, useState } from "react";
 import { cn } from "../../lib/utils";
 import type { AgentState } from "@/types";
 import { Tooltip, TooltipContent, TooltipTrigger } from "@/components/ui/tooltip";
-import { STATE_PRIORITY } from "./terminalStateConfig";
+import { STATE_LABELS, STATE_PRIORITY } from "./terminalStateConfig";
 
 interface AgentStatusIndicatorProps {
   state: AgentState | null | undefined;
   className?: string;
 }
 
+// Keys deliberately narrowed to states the render guard below actually renders:
+// "idle" and "waiting" both early-return null, so including them here would be
+// dead config. The explicit Record annotation enforces both the narrowing and
+// exhaustiveness at compile time.
 const STATE_CONFIG: Record<
-  Exclude<AgentState, "idle">,
+  Exclude<AgentState, "idle" | "waiting">,
   {
     icon: string;
     color: string;
     bgColor?: string;
     borderColor?: string;
     glow?: string;
-    label: string;
     tooltip: string;
   }
 > = {
   working: {
     icon: "⟳",
     color: "status-working",
-    label: "working",
     tooltip: "Agent is working on your request",
-  },
-  waiting: {
-    icon: "?",
-    color: "text-daintree-bg",
-    bgColor: "bg-state-waiting",
-    glow: "shadow-[0_0_8px_color-mix(in_srgb,var(--color-activity-waiting)_40%,transparent)]",
-    label: "waiting",
-    tooltip: "Agent is waiting for your direction",
   },
   completed: {
     icon: "✓",
     color: "text-status-success",
-    label: "completed",
     tooltip: "Agent finished this task",
   },
   exited: {
     icon: "–",
     color: "text-daintree-text/40",
-    label: "exited",
     tooltip: "Process exited",
   },
   directing: {
     icon: "✎",
     color: "text-status-info",
     borderColor: "border-status-info",
-    label: "directing",
     tooltip: "You are typing a prompt for this agent",
   },
 };
@@ -105,7 +96,7 @@ export function AgentStatusIndicator({ state, className }: AgentStatusIndicatorP
             className
           )}
           role="img"
-          aria-label={`Agent status: ${config.label}`}
+          aria-label={`Agent status: ${STATE_LABELS[state]}`}
           onAnimationEnd={() => setIsFlashing(false)}
         >
           {config.icon}
@@ -136,13 +127,11 @@ export function getDominantAgentState(states: (AgentState | undefined)[]): Agent
 // the actionable states a human should attend to — earn a visible dot. Keeping
 // passive sessions unmarked lets the actionable few stand out on a toolbar
 // that may show many running agents at once.
+const AGENT_DOT_COLORS = {
+  directing: "bg-state-working",
+  waiting: "bg-state-waiting",
+} as const satisfies Record<Extract<AgentState, "directing" | "waiting">, string>;
+
 export function agentStateDotColor(state: AgentState): string | null {
-  switch (state) {
-    case "directing":
-      return "bg-state-working";
-    case "waiting":
-      return "bg-state-waiting";
-    default:
-      return null;
-  }
+  return (AGENT_DOT_COLORS as Partial<Record<AgentState, string>>)[state] ?? null;
 }

--- a/src/components/Worktree/AgentStatusIndicator.tsx
+++ b/src/components/Worktree/AgentStatusIndicator.tsx
@@ -77,9 +77,6 @@ export function AgentStatusIndicator({ state, className }: AgentStatusIndicatorP
   }
 
   const config = STATE_CONFIG[state];
-  if (!config) {
-    return null;
-  }
 
   return (
     <Tooltip>

--- a/src/components/Worktree/__tests__/AgentStatusIndicator.test.tsx
+++ b/src/components/Worktree/__tests__/AgentStatusIndicator.test.tsx
@@ -8,7 +8,7 @@ import {
   agentStateDotColor,
   getDominantAgentState,
 } from "../AgentStatusIndicator";
-import { STATE_PRIORITY } from "../terminalStateConfig";
+import { STATE_LABELS, STATE_PRIORITY } from "../terminalStateConfig";
 import type { AgentState } from "@/types";
 
 vi.mock("@/components/ui/tooltip", () => ({
@@ -32,7 +32,7 @@ describe("AgentStatusIndicator", () => {
     const { container } = render(<AgentStatusIndicator state={state} />);
     const el = container.querySelector('[role="img"]');
     expect(el).not.toBeNull();
-    expect(el?.getAttribute("aria-label")).toBe(`Agent status: ${state}`);
+    expect(el?.getAttribute("aria-label")).toBe(`Agent status: ${STATE_LABELS[state]}`);
     expect(el?.textContent).toBe(glyph);
   });
 

--- a/src/components/Worktree/__tests__/AgentStatusIndicator.test.tsx
+++ b/src/components/Worktree/__tests__/AgentStatusIndicator.test.tsx
@@ -154,7 +154,19 @@ describe("getDominantAgentState", () => {
 // the only thing standing between the source of truth and the UI.
 describe("STATE_PRIORITY contract", () => {
   it("includes every AgentState exactly once", () => {
-    const all: AgentState[] = ["working", "directing", "waiting", "completed", "exited", "idle"];
+    // The `satisfies Record<AgentState, 1>` clause turns this into a
+    // compile-time exhaustiveness check — if a new AgentState value is added
+    // to the union, this object literal fails typecheck unless the new key
+    // is also added here, which keeps the runtime comparison honest.
+    const allStates = {
+      working: 1,
+      directing: 1,
+      waiting: 1,
+      completed: 1,
+      exited: 1,
+      idle: 1,
+    } satisfies Record<AgentState, 1>;
+    const all = Object.keys(allStates) as AgentState[];
     expect([...STATE_PRIORITY].sort()).toEqual([...all].sort());
     expect(STATE_PRIORITY.length).toBe(new Set(STATE_PRIORITY).size);
   });

--- a/src/components/Worktree/terminalStateConfig.tsx
+++ b/src/components/Worktree/terminalStateConfig.tsx
@@ -2,41 +2,41 @@ import { Circle, CheckCircle2 } from "lucide-react";
 import type { AgentState } from "@/types";
 import { SpinnerCircle, HollowCircle, InteractingCircle, ExitedCircle } from "@/components/icons";
 
-export const STATE_ICONS: Record<AgentState, React.ComponentType<{ className?: string }>> = {
+export const STATE_ICONS = {
   working: SpinnerCircle,
   waiting: HollowCircle,
   directing: InteractingCircle,
   idle: Circle,
   completed: CheckCircle2,
   exited: ExitedCircle,
-};
+} satisfies Record<AgentState, React.ComponentType<{ className?: string }>>;
 
-export const STATE_COLORS: Record<AgentState, string> = {
+export const STATE_COLORS = {
   working: "text-state-working",
   waiting: "text-state-waiting",
   directing: "text-category-blue",
   idle: "text-daintree-text/40",
   completed: "text-status-success",
   exited: "text-daintree-text/40",
-};
+} as const satisfies Record<AgentState, string>;
 
-export const STATE_LABELS: Record<AgentState, string> = {
+export const STATE_LABELS = {
   working: "working",
   idle: "idle",
   waiting: "waiting",
   directing: "directing",
   completed: "done",
   exited: "exited",
-};
+} as const satisfies Record<AgentState, string>;
 
-export const STATE_PRIORITY: AgentState[] = [
+export const STATE_PRIORITY = [
   "working",
   "directing",
   "waiting",
   "completed",
   "exited",
   "idle",
-];
+] as const satisfies readonly AgentState[];
 
 export function getEffectiveStateIcon(
   agentState: AgentState


### PR DESCRIPTION
## Summary

- Added `as const satisfies Record<AgentState, T>` to `STATE_COLORS`, `STATE_LABELS`, `STATE_ICONS`, and `STATE_PRIORITY` so exhaustiveness is compile-time checked — adding a new `AgentState` variant will now cause a type error at every declaration site, not just at runtime.
- Narrowed `STATE_CONFIG` keys to `Exclude<AgentState, "idle" | "waiting">` to align the type with the runtime render guard; removed the now-dead `if (!config)` guard and the duplicated `label` field (aria-label reads from `STATE_LABELS` at the call site).
- Replaced `switch` statements in `agentStateDotColor` and `describeAgentPip` with typed `Partial<Record<AgentState, T>>` lookups for the same compile-time guarantees.

Resolves #7675

## Changes

- `terminalStateConfig.tsx` — `satisfies` annotations on all state maps; narrowed `STATE_CONFIG` key type; dropped duplicate `label` field.
- `AgentStatusIndicator.tsx` — removed dead `if (!config)` guard; aria-label sourced from `STATE_LABELS`.
- `ToolbarAssistantButton.tsx` — replaced `agentStateDotColor`/`describeAgentPip` switches with Record lookups.
- `AgentStatusIndicator.test.tsx` — updated tests to reflect aria-label sourced from `STATE_LABELS` (e.g. "Agent status: done" for `completed`).

## Testing

Typechecked, linted, formatted, and all 53 targeted tests pass.