### PR TITLE
refactor(uiStore): convert overlayClaims to ordered stack and add typed helpers

### DIFF
--- a/src/components/Layout/AppLayout.tsx
+++ b/src/components/Layout/AppLayout.tsx
@@ -32,7 +32,7 @@ import { useProjectPresetsSubscription } from "@/hooks/useProjectPresetsSubscrip
 import type { RetryAction } from "@/store";
 import { appClient } from "@/clients";
 import type { CliAvailability, AgentSettings } from "@shared/types";
-import { useLayoutState } from "@/hooks";
+import { useLayoutState, useOverlayOpen } from "@/hooks";
 import type { UseProjectSwitcherPaletteReturn } from "@/hooks";
 import { suppressSidebarResizes } from "@/lib/sidebarToggle";
 import { logError } from "@/utils/logger";
@@ -82,8 +82,7 @@ export function AppLayout({
   const [isAssistantResizing, setIsAssistantResizing] = useState(false);
   const currentProject = useProjectStore((state) => state.currentProject);
   const layout = useLayoutState();
-  const overlayClaims = useUIStore((s) => s.overlayClaims);
-  const isThemeBrowserOpen = overlayClaims.has("theme-browser");
+  const isThemeBrowserOpen = useOverlayOpen("theme-browser");
   const themeBrowserOpen = useThemeBrowserStore((s) => s.isOpen);
   const reduceAnimations = usePreferencesStore((s) => s.reduceAnimations);
   const showSidebar = !layout.gestureSidebarHidden && currentProject != null;

--- a/src/components/Layout/__tests__/AppLayout.themeBrowser.test.ts
+++ b/src/components/Layout/__tests__/AppLayout.themeBrowser.test.ts
@@ -27,7 +27,7 @@ describe("AppLayout theme browser mount gate — issue #5738", () => {
     // The overlay claim is the correct signal for inert because it fires after
     // ThemeBrowser has mounted — intended PR #5721 behavior. inert on the
     // toolbar + main-content wrappers prevents interaction with blocked UI.
-    expect(source).toContain('const isThemeBrowserOpen = overlayClaims.has("theme-browser")');
+    expect(source).toContain('const isThemeBrowserOpen = useOverlayOpen("theme-browser")');
     expect(source).toContain("isThemeBrowserOpen ? { inert: true } : {}");
   });
 });

--- a/src/components/Portal/PortalVisibilityController.tsx
+++ b/src/components/Portal/PortalVisibilityController.tsx
@@ -17,8 +17,8 @@ export function PortalVisibilityController(): null {
   const tabs = usePortalStore((state) => state.tabs);
   const createdTabs = usePortalStore((state) => state.createdTabs);
   const markTabCreated = usePortalStore((state) => state.markTabCreated);
-  const overlayClaimsSize = useUIStore((state) => state.overlayClaims.size);
-  const hasOverlays = overlayClaimsSize > 0;
+  const overlayStackLength = useUIStore((state) => state.overlayStack.length);
+  const hasOverlays = overlayStackLength > 0;
   const isRestoringRef = useRef(false);
   const pendingRestoreRef = useRef<{ tabId: string; tabUrl: string } | null>(null);
   const isMountedRef = useRef(true);
@@ -80,7 +80,7 @@ export function PortalVisibilityController(): null {
           isRestoringRef.current = false;
           return;
         }
-        if (uiState.overlayClaims.size > 0) {
+        if (uiState.overlayStack.length > 0) {
           isRestoringRef.current = false;
           return;
         }

--- a/src/components/Portal/__tests__/PortalVisibilityController.test.tsx
+++ b/src/components/Portal/__tests__/PortalVisibilityController.test.tsx
@@ -84,7 +84,7 @@ describe("PortalVisibilityController", () => {
     });
 
     usePortalStore.getState().reset();
-    useUIStore.setState({ overlayClaims: new Set<string>(), notificationCenterOpen: false });
+    useUIStore.setState({ overlayStack: [], notificationCenterOpen: false });
   });
 
   afterEach(() => {
@@ -242,13 +242,13 @@ describe("PortalVisibilityController", () => {
     render(<PortalVisibilityController />);
 
     act(() => {
-      useUIStore.setState({ overlayClaims: new Set<string>(["test-overlay"]) });
+      useUIStore.setState({ overlayStack: ["test-overlay"] });
     });
 
     expect(portal.hide).toHaveBeenCalledTimes(1);
 
     act(() => {
-      useUIStore.setState({ overlayClaims: new Set<string>() });
+      useUIStore.setState({ overlayStack: [] });
     });
 
     await act(async () => {

--- a/src/components/Project/ProjectSwitcherPalette.tsx
+++ b/src/components/Project/ProjectSwitcherPalette.tsx
@@ -1065,8 +1065,8 @@ function DropdownContent({
 }: ProjectSwitcherPaletteProps) {
   const inputRef = useRef<HTMLInputElement>(null);
   const listRef = useRef<HTMLDivElement>(null);
-  const overlayClaimsSize = useUIStore((state) => state.overlayClaims.size);
-  const prevOverlayClaimsSizeRef = useRef<number>(overlayClaimsSize);
+  const overlayStackLength = useUIStore((state) => state.overlayStack.length);
+  const prevOverlayStackLengthRef = useRef<number>(overlayStackLength);
   const focusRafRef = useRef<number | null>(null);
 
   useEffect(() => {
@@ -1084,11 +1084,15 @@ function DropdownContent({
   }, [isOpen]);
 
   useEffect(() => {
-    if (isOpen && overlayClaimsSize > prevOverlayClaimsSizeRef.current && overlayClaimsSize > 0) {
+    if (
+      isOpen &&
+      overlayStackLength > prevOverlayStackLengthRef.current &&
+      overlayStackLength > 0
+    ) {
       onClose();
     }
-    prevOverlayClaimsSizeRef.current = overlayClaimsSize;
-  }, [isOpen, overlayClaimsSize, onClose]);
+    prevOverlayStackLengthRef.current = overlayStackLength;
+  }, [isOpen, overlayStackLength, onClose]);
 
   return (
     <Popover open={isOpen} onOpenChange={(open) => !open && onClose()}>

--- a/src/components/ThemeBrowser/__tests__/ThemeBrowser.test.tsx
+++ b/src/components/ThemeBrowser/__tests__/ThemeBrowser.test.tsx
@@ -53,7 +53,7 @@ describe("ThemeBrowser", () => {
       previewSchemeId: null,
     });
     useThemeBrowserStore.setState({ isOpen: true });
-    useUIStore.setState({ overlayClaims: new Set<string>() });
+    useUIStore.setState({ overlayStack: [] });
     usePortalStore.setState({ isOpen: false });
   });
 
@@ -62,7 +62,7 @@ describe("ThemeBrowser", () => {
     _resetForTests();
     useAppThemeStore.setState({ previewSchemeId: null });
     useThemeBrowserStore.setState({ isOpen: false });
-    useUIStore.setState({ overlayClaims: new Set<string>() });
+    useUIStore.setState({ overlayStack: [] });
   });
 
   it("clicking a theme row sets previewSchemeId instantly (no debounce)", () => {
@@ -202,16 +202,16 @@ describe("ThemeBrowser", () => {
 
   it("registers a 'theme-browser' overlay claim while mounted", () => {
     render(<Harness />);
-    expect(useUIStore.getState().overlayClaims.has("theme-browser")).toBe(true);
+    expect(useUIStore.getState().overlayStack.includes("theme-browser")).toBe(true);
   });
 
   it("releases the 'theme-browser' overlay claim on unmount", () => {
     const { unmount } = render(<Harness />);
-    expect(useUIStore.getState().overlayClaims.has("theme-browser")).toBe(true);
+    expect(useUIStore.getState().overlayStack.includes("theme-browser")).toBe(true);
 
     unmount();
 
-    expect(useUIStore.getState().overlayClaims.has("theme-browser")).toBe(false);
+    expect(useUIStore.getState().overlayStack.includes("theme-browser")).toBe(false);
   });
 
   it("renders with aria-modal='true' for native focus management", () => {

--- a/src/components/ui/__tests__/FixedDropdown.test.tsx
+++ b/src/components/ui/__tests__/FixedDropdown.test.tsx
@@ -8,19 +8,19 @@ import { useGlobalEscapeDispatcher } from "@/hooks/useGlobalEscapeDispatcher";
 
 const GRACE_MS = 300;
 
-let mockOverlayClaims = new Set<string>();
+let mockOverlayStack: string[] = [];
 
-function setOverlayClaimsSize(size: number) {
-  const next = new Set<string>();
+function setOverlayStackLength(size: number) {
+  const next: string[] = [];
   for (let i = 0; i < size; i++) {
-    next.add(`claim-${i}`);
+    next.push(`claim-${i}`);
   }
-  mockOverlayClaims = next;
+  mockOverlayStack = next;
 }
 
 vi.mock("@/store/uiStore", () => ({
-  useUIStore: (selector: (state: { overlayClaims: Set<string> }) => unknown) =>
-    selector({ overlayClaims: mockOverlayClaims }),
+  useUIStore: (selector: (state: { overlayStack: string[] }) => unknown) =>
+    selector({ overlayStack: mockOverlayStack }),
 }));
 
 vi.mock("@/hooks/useAnimatedPresence", () => ({
@@ -61,7 +61,7 @@ describe("FixedDropdown overlay-claims dismiss behavior", () => {
 
   beforeEach(() => {
     _resetForTests();
-    setOverlayClaimsSize(0);
+    setOverlayStackLength(0);
     onOpenChange = vi.fn();
     anchorRef = createAnchor();
     vi.stubGlobal("matchMedia", vi.fn().mockReturnValue({ matches: false }));
@@ -84,7 +84,7 @@ describe("FixedDropdown overlay-claims dismiss behavior", () => {
     // overlay rises are treated as user-initiated dismiss triggers.
     advancePastGrace();
 
-    setOverlayClaimsSize(1);
+    setOverlayStackLength(1);
     rerender(
       <FixedDropdown open={true} onOpenChange={onOpenChange} anchorRef={anchorRef}>
         <div>Content</div>
@@ -106,7 +106,7 @@ describe("FixedDropdown overlay-claims dismiss behavior", () => {
     // An in-flight modal (e.g. cold-start AgentSetupWizard) mounts shortly
     // after and pushes the overlay count. Still inside the grace window, so
     // the dropdown should not be auto-closed.
-    setOverlayClaimsSize(1);
+    setOverlayStackLength(1);
     rerender(
       <FixedDropdown open={true} onOpenChange={onOpenChange} anchorRef={anchorRef}>
         <div>Content</div>
@@ -141,7 +141,7 @@ describe("FixedDropdown overlay-claims dismiss behavior", () => {
     );
 
     // In-flight modal mounts during grace, absorbed into baseline=1.
-    setOverlayClaimsSize(1);
+    setOverlayStackLength(1);
     rerender(
       <FixedDropdown open={true} onOpenChange={onOpenChange} anchorRef={anchorRef}>
         <div>Content</div>
@@ -151,7 +151,7 @@ describe("FixedDropdown overlay-claims dismiss behavior", () => {
     advancePastGrace();
 
     // In-flight modal closes — baseline must decay back to 0.
-    setOverlayClaimsSize(0);
+    setOverlayStackLength(0);
     rerender(
       <FixedDropdown open={true} onOpenChange={onOpenChange} anchorRef={anchorRef}>
         <div>Content</div>
@@ -160,7 +160,7 @@ describe("FixedDropdown overlay-claims dismiss behavior", () => {
     expect(onOpenChange).not.toHaveBeenCalled();
 
     // User now opens a genuine modal at the same numeric level — must dismiss.
-    setOverlayClaimsSize(1);
+    setOverlayStackLength(1);
     rerender(
       <FixedDropdown open={true} onOpenChange={onOpenChange} anchorRef={anchorRef}>
         <div>Content</div>
@@ -175,7 +175,7 @@ describe("FixedDropdown overlay-claims dismiss behavior", () => {
     // Cold-start variant: a wizard is already open when the user clicks the
     // toolbar. The grace-setup effect must seed baseline=1 so that the
     // dropdown does not immediately self-close.
-    setOverlayClaimsSize(1);
+    setOverlayStackLength(1);
     const { rerender } = render(
       <FixedDropdown open={true} onOpenChange={onOpenChange} anchorRef={anchorRef}>
         <div>Content</div>
@@ -194,7 +194,7 @@ describe("FixedDropdown overlay-claims dismiss behavior", () => {
     expect(onOpenChange).not.toHaveBeenCalled();
 
     // A second modal on top of the first should dismiss the dropdown.
-    setOverlayClaimsSize(2);
+    setOverlayStackLength(2);
     rerender(
       <FixedDropdown open={true} onOpenChange={onOpenChange} anchorRef={anchorRef}>
         <div>Content</div>
@@ -212,7 +212,7 @@ describe("FixedDropdown overlay-claims dismiss behavior", () => {
     );
 
     // In-flight modal arrives during grace; absorbed into baseline.
-    setOverlayClaimsSize(1);
+    setOverlayStackLength(1);
     rerender(
       <FixedDropdown open={true} onOpenChange={onOpenChange} anchorRef={anchorRef}>
         <div>Content</div>
@@ -222,7 +222,7 @@ describe("FixedDropdown overlay-claims dismiss behavior", () => {
     advancePastGrace();
 
     // User now opens a genuinely new modal — this must dismiss the dropdown.
-    setOverlayClaimsSize(2);
+    setOverlayStackLength(2);
     rerender(
       <FixedDropdown open={true} onOpenChange={onOpenChange} anchorRef={anchorRef}>
         <div>Content</div>
@@ -248,7 +248,7 @@ describe("FixedDropdown overlay-claims dismiss behavior", () => {
       </FixedDropdown>
     );
 
-    setOverlayClaimsSize(2);
+    setOverlayStackLength(2);
     rerender(
       <FixedDropdown open={true} onOpenChange={onOpenChange} anchorRef={anchorRef}>
         <div>Content</div>
@@ -256,7 +256,7 @@ describe("FixedDropdown overlay-claims dismiss behavior", () => {
     );
 
     // Within the new grace window, any further in-flight rise is absorbed.
-    setOverlayClaimsSize(3);
+    setOverlayStackLength(3);
     rerender(
       <FixedDropdown open={true} onOpenChange={onOpenChange} anchorRef={anchorRef}>
         <div>Content</div>
@@ -266,7 +266,7 @@ describe("FixedDropdown overlay-claims dismiss behavior", () => {
 
     // After the new grace window expires, a further rise closes.
     advancePastGrace();
-    setOverlayClaimsSize(4);
+    setOverlayStackLength(4);
     rerender(
       <FixedDropdown open={true} onOpenChange={onOpenChange} anchorRef={anchorRef}>
         <div>Content</div>
@@ -291,7 +291,7 @@ describe("FixedDropdown overlay-claims dismiss behavior", () => {
 
     advancePastGrace();
 
-    setOverlayClaimsSize(1);
+    setOverlayStackLength(1);
     rerender(
       <FixedDropdown
         open={true}
@@ -307,7 +307,7 @@ describe("FixedDropdown overlay-claims dismiss behavior", () => {
   });
 
   it("suppresses Escape dismiss while child overlay is active", () => {
-    setOverlayClaimsSize(1);
+    setOverlayStackLength(1);
     render(
       <>
         <Dispatcher />
@@ -328,7 +328,7 @@ describe("FixedDropdown overlay-claims dismiss behavior", () => {
   });
 
   it("suppresses outside pointer dismiss while child overlay is active", () => {
-    setOverlayClaimsSize(1);
+    setOverlayStackLength(1);
     render(
       <FixedDropdown
         open={true}
@@ -348,7 +348,7 @@ describe("FixedDropdown overlay-claims dismiss behavior", () => {
   });
 
   it("resumes Escape dismiss after child overlay closes", () => {
-    setOverlayClaimsSize(1);
+    setOverlayStackLength(1);
     const { rerender } = render(
       <>
         <Dispatcher />
@@ -363,7 +363,7 @@ describe("FixedDropdown overlay-claims dismiss behavior", () => {
       </>
     );
 
-    setOverlayClaimsSize(0);
+    setOverlayStackLength(0);
     rerender(
       <>
         <Dispatcher />
@@ -384,7 +384,7 @@ describe("FixedDropdown overlay-claims dismiss behavior", () => {
   });
 
   it("stays suppressed through multiple overlay transitions (1→2→1)", () => {
-    setOverlayClaimsSize(1);
+    setOverlayStackLength(1);
     const { rerender } = render(
       <>
         <Dispatcher />
@@ -399,7 +399,7 @@ describe("FixedDropdown overlay-claims dismiss behavior", () => {
       </>
     );
 
-    setOverlayClaimsSize(2);
+    setOverlayStackLength(2);
     rerender(
       <>
         <Dispatcher />
@@ -416,7 +416,7 @@ describe("FixedDropdown overlay-claims dismiss behavior", () => {
 
     expect(onOpenChange).not.toHaveBeenCalled();
 
-    setOverlayClaimsSize(1);
+    setOverlayStackLength(1);
     rerender(
       <>
         <Dispatcher />
@@ -437,7 +437,7 @@ describe("FixedDropdown overlay-claims dismiss behavior", () => {
   });
 
   it("can be explicitly closed by parent while child overlay is active", () => {
-    setOverlayClaimsSize(1);
+    setOverlayStackLength(1);
     const { rerender } = render(
       <FixedDropdown
         open={true}
@@ -470,7 +470,7 @@ describe("FixedDropdown keepMounted behavior", () => {
 
   beforeEach(() => {
     _resetForTests();
-    setOverlayClaimsSize(0);
+    setOverlayStackLength(0);
     onOpenChange = vi.fn();
     anchorRef = createAnchor();
     vi.stubGlobal("matchMedia", vi.fn().mockReturnValue({ matches: false }));
@@ -559,7 +559,7 @@ describe("FixedDropdown right-edge anchor (issue #6800)", () => {
 
   beforeEach(() => {
     _resetForTests();
-    setOverlayClaimsSize(0);
+    setOverlayStackLength(0);
     onOpenChange = vi.fn();
     anchorRef = createAnchor();
     vi.stubGlobal("matchMedia", vi.fn().mockReturnValue({ matches: false }));

--- a/src/components/ui/fixed-dropdown.tsx
+++ b/src/components/ui/fixed-dropdown.tsx
@@ -52,17 +52,17 @@ export function FixedDropdown({
     isOpen: open,
     animationDuration: getUiTransitionDuration("exit"),
   });
-  const overlayClaimsSize = useUIStore((state) => state.overlayClaims.size);
+  const overlayStackLength = useUIStore((state) => state.overlayStack.length);
   const [overlayGraceActive, setOverlayGraceActive] = useState(false);
   const baselineOverlaySizeRef = useRef<number>(0);
   // Carry the latest overlay-claims size into the grace-setup effect without
   // adding it as a reactive dependency — re-running on every size change
   // would wrongly reset the grace window on each in-flight rise. Sync in
   // an effect so the React Compiler doesn't reject render-time ref mutation.
-  const latestOverlaySizeRef = useRef<number>(overlayClaimsSize);
+  const latestOverlaySizeRef = useRef<number>(overlayStackLength);
   useEffect(() => {
-    latestOverlaySizeRef.current = overlayClaimsSize;
-  }, [overlayClaimsSize]);
+    latestOverlaySizeRef.current = overlayStackLength;
+  }, [overlayStackLength]);
 
   useEffect(() => {
     if (!open) {
@@ -112,14 +112,14 @@ export function FixedDropdown({
     };
   }, [open, updatePosition]);
 
-  const childOverlayActive = persistThroughChildOverlays && overlayClaimsSize > 0;
+  const childOverlayActive = persistThroughChildOverlays && overlayStackLength > 0;
   useEscapeStack(open && !childOverlayActive, () => onOpenChange(false));
 
   useEffect(() => {
     if (!open) return;
 
     const handlePointerDown = (event: MouseEvent | TouchEvent) => {
-      if (persistThroughChildOverlays && overlayClaimsSize > 0) return;
+      if (persistThroughChildOverlays && overlayStackLength > 0) return;
       const target = event.target as Node | null;
       if (contentRef.current?.contains(target) || anchorRef.current?.contains(target)) return;
       onOpenChange(false);
@@ -131,7 +131,7 @@ export function FixedDropdown({
       document.removeEventListener("mousedown", handlePointerDown);
       document.removeEventListener("touchstart", handlePointerDown);
     };
-  }, [open, onOpenChange, anchorRef, persistThroughChildOverlays, overlayClaimsSize]);
+  }, [open, onOpenChange, anchorRef, persistThroughChildOverlays, overlayStackLength]);
 
   useEffect(() => {
     if (persistThroughChildOverlays || !open) return;
@@ -140,21 +140,21 @@ export function FixedDropdown({
       // flight when the dropdown opened." This keeps the baseline tracking
       // the current size so rises after grace are measured against the
       // settled baseline.
-      baselineOverlaySizeRef.current = overlayClaimsSize;
+      baselineOverlaySizeRef.current = overlayStackLength;
       return;
     }
     // Decay the baseline when the overlay-claims size drops — e.g. the
     // in-flight modal that was absorbed during grace has since closed.
     // Without this, a subsequent user-initiated modal at the same numeric
     // level would fail to dismiss the dropdown.
-    if (overlayClaimsSize < baselineOverlaySizeRef.current) {
-      baselineOverlaySizeRef.current = overlayClaimsSize;
+    if (overlayStackLength < baselineOverlaySizeRef.current) {
+      baselineOverlaySizeRef.current = overlayStackLength;
       return;
     }
-    if (overlayClaimsSize > baselineOverlaySizeRef.current) {
+    if (overlayStackLength > baselineOverlaySizeRef.current) {
       onOpenChange(false);
     }
-  }, [open, overlayClaimsSize, onOpenChange, persistThroughChildOverlays, overlayGraceActive]);
+  }, [open, overlayStackLength, onOpenChange, persistThroughChildOverlays, overlayGraceActive]);
 
   if (!mounted) return null;
   if (!position) return null;

--- a/src/hooks/__tests__/useOverlayState.test.tsx
+++ b/src/hooks/__tests__/useOverlayState.test.tsx
@@ -1,7 +1,12 @@
 // @vitest-environment jsdom
-import { render } from "@testing-library/react";
+import { render, renderHook } from "@testing-library/react";
 import { describe, expect, it, beforeEach } from "vitest";
-import { useOverlayClaim, useOverlayState } from "../useOverlayState";
+import {
+  useOverlayClaim,
+  useOverlayOpen,
+  useOverlayState,
+  useTopmostOverlay,
+} from "../useOverlayState";
 import { useUIStore } from "@/store/uiStore";
 
 function NamedClaim({ id, active }: { id: string; active: boolean }) {
@@ -14,101 +19,101 @@ function AnonymousClaim({ active }: { active: boolean }) {
   return null;
 }
 
-function getClaims() {
-  return useUIStore.getState().overlayClaims;
+function getStack() {
+  return useUIStore.getState().overlayStack;
 }
 
 beforeEach(() => {
-  useUIStore.setState({ overlayClaims: new Set<string>() });
+  useUIStore.setState({ overlayStack: [] });
 });
 
 describe("useOverlayClaim", () => {
   it("adds the claim when active becomes true", () => {
     render(<NamedClaim id="settings" active={true} />);
-    expect(getClaims().has("settings")).toBe(true);
-    expect(getClaims().size).toBe(1);
+    expect(getStack().includes("settings")).toBe(true);
+    expect(getStack().length).toBe(1);
   });
 
   it("removes the claim when active flips to false", () => {
     const { rerender } = render(<NamedClaim id="settings" active={true} />);
-    expect(getClaims().has("settings")).toBe(true);
+    expect(getStack().includes("settings")).toBe(true);
 
     rerender(<NamedClaim id="settings" active={false} />);
-    expect(getClaims().has("settings")).toBe(false);
-    expect(getClaims().size).toBe(0);
+    expect(getStack().includes("settings")).toBe(false);
+    expect(getStack().length).toBe(0);
   });
 
   it("removes the claim on unmount", () => {
     const { unmount } = render(<NamedClaim id="settings" active={true} />);
-    expect(getClaims().has("settings")).toBe(true);
+    expect(getStack().includes("settings")).toBe(true);
 
     unmount();
-    expect(getClaims().size).toBe(0);
+    expect(getStack().length).toBe(0);
   });
 
   it("does not add a claim when active is false from the start", () => {
     render(<NamedClaim id="settings" active={false} />);
-    expect(getClaims().size).toBe(0);
+    expect(getStack().length).toBe(0);
   });
 
   it("collapses duplicate registrations for the same ID", () => {
     render(<NamedClaim id="shared" active={true} />);
     render(<NamedClaim id="shared" active={true} />);
-    expect(getClaims().size).toBe(1);
-    expect(getClaims().has("shared")).toBe(true);
+    expect(getStack().length).toBe(1);
+    expect(getStack().includes("shared")).toBe(true);
   });
 
-  it("preserves the Set reference when addOverlayClaim is a no-op", () => {
+  it("preserves the array reference when addOverlayClaim is a no-op", () => {
     const { addOverlayClaim } = useUIStore.getState();
     addOverlayClaim("first");
-    const before = useUIStore.getState().overlayClaims;
+    const before = useUIStore.getState().overlayStack;
     addOverlayClaim("first");
-    const after = useUIStore.getState().overlayClaims;
+    const after = useUIStore.getState().overlayStack;
     expect(after).toBe(before);
   });
 
-  it("preserves the Set reference when removeOverlayClaim is a no-op", () => {
-    const before = useUIStore.getState().overlayClaims;
+  it("preserves the array reference when removeOverlayClaim is a no-op", () => {
+    const before = useUIStore.getState().overlayStack;
     useUIStore.getState().removeOverlayClaim("missing");
-    const after = useUIStore.getState().overlayClaims;
+    const after = useUIStore.getState().overlayStack;
     expect(after).toBe(before);
   });
 
   it("tracks rapid toggle cycles", () => {
     const { rerender } = render(<NamedClaim id="toggle" active={false} />);
-    expect(getClaims().size).toBe(0);
+    expect(getStack().length).toBe(0);
 
     rerender(<NamedClaim id="toggle" active={true} />);
-    expect(getClaims().size).toBe(1);
+    expect(getStack().length).toBe(1);
 
     rerender(<NamedClaim id="toggle" active={false} />);
-    expect(getClaims().size).toBe(0);
+    expect(getStack().length).toBe(0);
 
     rerender(<NamedClaim id="toggle" active={true} />);
-    expect(getClaims().size).toBe(1);
+    expect(getStack().length).toBe(1);
   });
 
   it("holds multiple named claims simultaneously", () => {
     const { unmount: unmountA } = render(<NamedClaim id="a" active={true} />);
     render(<NamedClaim id="b" active={true} />);
-    expect(getClaims().size).toBe(2);
-    expect(getClaims().has("a")).toBe(true);
-    expect(getClaims().has("b")).toBe(true);
+    expect(getStack().length).toBe(2);
+    expect(getStack().includes("a")).toBe(true);
+    expect(getStack().includes("b")).toBe(true);
 
     unmountA();
-    expect(getClaims().size).toBe(1);
-    expect(getClaims().has("b")).toBe(true);
+    expect(getStack().length).toBe(1);
+    expect(getStack().includes("b")).toBe(true);
   });
 
   it("swaps the registered claim when the ID changes while active", () => {
     const { rerender } = render(<NamedClaim id="a" active={true} />);
-    expect(getClaims().has("a")).toBe(true);
-    expect(getClaims().size).toBe(1);
+    expect(getStack().includes("a")).toBe(true);
+    expect(getStack().length).toBe(1);
 
     rerender(<NamedClaim id="b" active={true} />);
-    expect(getClaims().has("a")).toBe(false);
-    expect(getClaims().has("b")).toBe(true);
-    expect(getClaims().size).toBe(1);
+    expect(getStack().includes("a")).toBe(false);
+    expect(getStack().includes("b")).toBe(true);
+    expect(getStack().length).toBe(1);
   });
 });
 
@@ -118,16 +123,81 @@ describe("useOverlayState (backwards-compat shim)", () => {
     render(<AnonymousClaim active={true} />);
     // Two concurrent anonymous callers must not collide on a single ID — the
     // shim's per-instance useId() gives each its own slot.
-    expect(getClaims().size).toBe(2);
+    expect(getStack().length).toBe(2);
 
     unmountA();
-    expect(getClaims().size).toBe(1);
+    expect(getStack().length).toBe(1);
   });
 
   it("releases the claim on unmount", () => {
     const { unmount } = render(<AnonymousClaim active={true} />);
-    expect(getClaims().size).toBe(1);
+    expect(getStack().length).toBe(1);
     unmount();
-    expect(getClaims().size).toBe(0);
+    expect(getStack().length).toBe(0);
+  });
+});
+
+describe("useOverlayOpen", () => {
+  it("returns false when the id has no claim", () => {
+    const { result } = renderHook(() => useOverlayOpen("settings"));
+    expect(result.current).toBe(false);
+  });
+
+  it("returns true while the id has an active claim", () => {
+    useUIStore.getState().addOverlayClaim("settings");
+    const { result } = renderHook(() => useOverlayOpen("settings"));
+    expect(result.current).toBe(true);
+  });
+
+  it("flips to false when the claim is released", () => {
+    useUIStore.getState().addOverlayClaim("settings");
+    const { result, rerender } = renderHook(() => useOverlayOpen("settings"));
+    expect(result.current).toBe(true);
+
+    useUIStore.getState().removeOverlayClaim("settings");
+    rerender();
+    expect(result.current).toBe(false);
+  });
+
+  it("isolates each id from unrelated stack mutations", () => {
+    useUIStore.getState().addOverlayClaim("other");
+    const { result } = renderHook(() => useOverlayOpen("settings"));
+    expect(result.current).toBe(false);
+  });
+});
+
+describe("useTopmostOverlay", () => {
+  it("returns undefined when no overlay is open", () => {
+    const { result } = renderHook(() => useTopmostOverlay());
+    expect(result.current).toBeUndefined();
+  });
+
+  it("returns the most recently added claim", () => {
+    useUIStore.getState().addOverlayClaim("a");
+    useUIStore.getState().addOverlayClaim("b");
+    useUIStore.getState().addOverlayClaim("c");
+    const { result } = renderHook(() => useTopmostOverlay());
+    expect(result.current).toBe("c");
+  });
+
+  it("updates when the topmost claim is released", () => {
+    useUIStore.getState().addOverlayClaim("a");
+    useUIStore.getState().addOverlayClaim("b");
+    const { result, rerender } = renderHook(() => useTopmostOverlay());
+    expect(result.current).toBe("b");
+
+    useUIStore.getState().removeOverlayClaim("b");
+    rerender();
+    expect(result.current).toBe("a");
+  });
+
+  it("returns undefined once the stack drains", () => {
+    useUIStore.getState().addOverlayClaim("a");
+    const { result, rerender } = renderHook(() => useTopmostOverlay());
+    expect(result.current).toBe("a");
+
+    useUIStore.getState().removeOverlayClaim("a");
+    rerender();
+    expect(result.current).toBeUndefined();
   });
 });

--- a/src/hooks/index.ts
+++ b/src/hooks/index.ts
@@ -51,7 +51,12 @@ export { useWaitingTerminalIds, useBackgroundPanelStats } from "./useTerminalSel
 
 export { useWorktreeColorMap } from "./useWorktreeColorMap";
 
-export { useOverlayClaim, useOverlayState } from "./useOverlayState";
+export {
+  useOverlayClaim,
+  useOverlayState,
+  useOverlayOpen,
+  useTopmostOverlay,
+} from "./useOverlayState";
 
 export { useEscapeStack } from "./useEscapeStack";
 export { useGlobalEscapeDispatcher } from "./useGlobalEscapeDispatcher";

--- a/src/hooks/useOverlayState.ts
+++ b/src/hooks/useOverlayState.ts
@@ -3,8 +3,9 @@ import { useUIStore } from "@/store/uiStore";
 
 /**
  * Register a named claim on the viewport while `active` is true. The store
- * tracks claims as a Set keyed by stable IDs so `overlayClaims` can be read
- * to see exactly which features currently own the viewport.
+ * tracks claims as an ordered LIFO stack keyed by stable IDs so
+ * `overlayStack` can be read to see exactly which features currently own
+ * the viewport and which is topmost.
  *
  * Usage:
  * ```tsx
@@ -38,10 +39,28 @@ export function useOverlayClaim(id: string, active: boolean): void {
  * simultaneous callers never collide.
  *
  * Prefer `useOverlayClaim(id, active)` with a descriptive ID whenever a
- * stable identifier is available — named claims make `overlayClaims`
+ * stable identifier is available — named claims make `overlayStack`
  * readable from the DevTools console.
  */
 export function useOverlayState(isOpen: boolean): void {
   const id = useId();
   useOverlayClaim(id, isOpen);
+}
+
+/**
+ * Returns `true` while the named overlay claim is registered. Returns a
+ * primitive so Zustand only re-renders subscribers when this id's open
+ * state actually flips.
+ */
+export function useOverlayOpen(id: string): boolean {
+  return useUIStore((state) => state.overlayStack.includes(id));
+}
+
+/**
+ * Returns the id of the topmost overlay claim, or `undefined` when no
+ * overlay is open. Returns a primitive so subscribers only re-render when
+ * the topmost id actually changes, not on unrelated stack mutations.
+ */
+export function useTopmostOverlay(): string | undefined {
+  return useUIStore((state) => state.overlayStack.at(-1));
 }

--- a/src/services/actions/__tests__/actionDefinitions.adversarial.test.ts
+++ b/src/services/actions/__tests__/actionDefinitions.adversarial.test.ts
@@ -339,7 +339,7 @@ beforeEach(() => {
     defaultNewTabUrl: null,
   });
 
-  useUIStore.setState({ overlayClaims: new Set<string>() });
+  useUIStore.setState({ overlayStack: [] });
 
   useWorktreeSelectionStore.setState({
     activeWorktreeId: null,
@@ -892,7 +892,7 @@ describe("panel action hardening", () => {
     const actions = buildRegistry(registerPanelActions);
     const openUrl = actions.get("portal.openUrl")!();
 
-    useUIStore.setState({ overlayClaims: new Set(["theme-browser"]) });
+    useUIStore.setState({ overlayStack: ["theme-browser"] });
     usePortalStore.setState({
       isOpen: false,
       activeTabId: null,

--- a/src/services/actions/definitions/panelActions.ts
+++ b/src/services/actions/definitions/panelActions.ts
@@ -560,7 +560,7 @@ export function registerPanelActions(actions: ActionRegistry, callbacks: ActionC
       // viewport (e.g. theme browser). Mirrors portalStore.toggle()'s guard —
       // without it, setOpen(true) would flip isOpen unconditionally and the
       // portal would pop into view the moment the overlay closed.
-      if (useUIStore.getState().overlayClaims.size > 0) return;
+      if (useUIStore.getState().overlayStack.length > 0) return;
 
       // Ensure portal is visible before activating a tab
       if (!state.isOpen) {

--- a/src/store/__tests__/portalStore.test.ts
+++ b/src/store/__tests__/portalStore.test.ts
@@ -218,12 +218,12 @@ describe("portalStore", () => {
 
   describe("toggle with overlay claims", () => {
     beforeEach(() => {
-      useUIStore.setState({ overlayClaims: new Set<string>() });
+      useUIStore.setState({ overlayStack: [] });
       usePortalStore.setState({ isOpen: false });
     });
 
     afterEach(() => {
-      useUIStore.setState({ overlayClaims: new Set<string>() });
+      useUIStore.setState({ overlayStack: [] });
     });
 
     it("opens the portal when there are no active claims", () => {

--- a/src/store/__tests__/uiStore.test.ts
+++ b/src/store/__tests__/uiStore.test.ts
@@ -1,65 +1,80 @@
 import { beforeEach, describe, expect, it } from "vitest";
 import { useUIStore } from "../uiStore";
 
-describe("useUIStore overlay claims", () => {
+describe("useUIStore overlay stack", () => {
   beforeEach(() => {
-    useUIStore.setState({ overlayClaims: new Set<string>() });
+    useUIStore.setState({ overlayStack: [] });
   });
 
-  it("starts with an empty claim set", () => {
-    expect(useUIStore.getState().overlayClaims.size).toBe(0);
+  it("starts with an empty stack", () => {
+    expect(useUIStore.getState().overlayStack.length).toBe(0);
     expect(useUIStore.getState().hasOpenOverlays()).toBe(false);
   });
 
   it("addOverlayClaim records a named claim", () => {
     useUIStore.getState().addOverlayClaim("settings");
-    expect(useUIStore.getState().overlayClaims.has("settings")).toBe(true);
-    expect(useUIStore.getState().overlayClaims.size).toBe(1);
+    expect(useUIStore.getState().overlayStack.includes("settings")).toBe(true);
+    expect(useUIStore.getState().overlayStack.length).toBe(1);
     expect(useUIStore.getState().hasOpenOverlays()).toBe(true);
   });
 
   it("addOverlayClaim collapses duplicate registrations for the same ID", () => {
     useUIStore.getState().addOverlayClaim("settings");
     useUIStore.getState().addOverlayClaim("settings");
-    expect(useUIStore.getState().overlayClaims.size).toBe(1);
+    expect(useUIStore.getState().overlayStack.length).toBe(1);
   });
 
-  it("addOverlayClaim returns the same Set reference when the ID already exists", () => {
+  it("addOverlayClaim returns the same array reference when the ID already exists", () => {
     useUIStore.getState().addOverlayClaim("settings");
-    const before = useUIStore.getState().overlayClaims;
+    const before = useUIStore.getState().overlayStack;
     useUIStore.getState().addOverlayClaim("settings");
-    const after = useUIStore.getState().overlayClaims;
+    const after = useUIStore.getState().overlayStack;
     expect(after).toBe(before);
   });
 
-  it("addOverlayClaim allocates a new Set reference when a new ID is added", () => {
-    const before = useUIStore.getState().overlayClaims;
+  it("addOverlayClaim allocates a new array reference when a new ID is added", () => {
+    const before = useUIStore.getState().overlayStack;
     useUIStore.getState().addOverlayClaim("settings");
-    const after = useUIStore.getState().overlayClaims;
+    const after = useUIStore.getState().overlayStack;
     expect(after).not.toBe(before);
+  });
+
+  it("addOverlayClaim appends to the tail so the latest claim is topmost", () => {
+    useUIStore.getState().addOverlayClaim("a");
+    useUIStore.getState().addOverlayClaim("b");
+    useUIStore.getState().addOverlayClaim("c");
+    expect(useUIStore.getState().overlayStack).toEqual(["a", "b", "c"]);
   });
 
   it("removeOverlayClaim releases a named claim", () => {
     useUIStore.getState().addOverlayClaim("settings");
     useUIStore.getState().removeOverlayClaim("settings");
-    expect(useUIStore.getState().overlayClaims.size).toBe(0);
+    expect(useUIStore.getState().overlayStack.length).toBe(0);
     expect(useUIStore.getState().hasOpenOverlays()).toBe(false);
   });
 
-  it("removeOverlayClaim is a no-op for an unknown ID and preserves the Set reference", () => {
-    const before = useUIStore.getState().overlayClaims;
+  it("removeOverlayClaim is a no-op for an unknown ID and preserves the array reference", () => {
+    const before = useUIStore.getState().overlayStack;
     useUIStore.getState().removeOverlayClaim("never-added");
-    const after = useUIStore.getState().overlayClaims;
+    const after = useUIStore.getState().overlayStack;
     expect(after).toBe(before);
+  });
+
+  it("removeOverlayClaim preserves the order of remaining claims", () => {
+    useUIStore.getState().addOverlayClaim("a");
+    useUIStore.getState().addOverlayClaim("b");
+    useUIStore.getState().addOverlayClaim("c");
+    useUIStore.getState().removeOverlayClaim("b");
+    expect(useUIStore.getState().overlayStack).toEqual(["a", "c"]);
   });
 
   it("tracks multiple simultaneous claims independently", () => {
     useUIStore.getState().addOverlayClaim("settings");
     useUIStore.getState().addOverlayClaim("project-switcher");
-    expect(useUIStore.getState().overlayClaims.size).toBe(2);
+    expect(useUIStore.getState().overlayStack.length).toBe(2);
 
     useUIStore.getState().removeOverlayClaim("settings");
-    expect(useUIStore.getState().overlayClaims.size).toBe(1);
-    expect(useUIStore.getState().overlayClaims.has("project-switcher")).toBe(true);
+    expect(useUIStore.getState().overlayStack.length).toBe(1);
+    expect(useUIStore.getState().overlayStack.includes("project-switcher")).toBe(true);
   });
 });

--- a/src/store/portalStore.ts
+++ b/src/store/portalStore.ts
@@ -105,7 +105,7 @@ const createPortalStore: StateCreator<PortalState & PortalActions> = (set, get) 
         // viewport (e.g. a settings dialog). Without this the store flips to
         // isOpen=true but PortalVisibilityController keeps the webview hidden,
         // leaving the Portal visually closed yet "open" per the store.
-        if (!s.isOpen && useUIStore.getState().overlayClaims.size > 0) return s;
+        if (!s.isOpen && useUIStore.getState().overlayStack.length > 0) return s;
         return { isOpen: !s.isOpen };
       }),
 

--- a/src/store/uiStore.ts
+++ b/src/store/uiStore.ts
@@ -2,7 +2,10 @@ import { create } from "zustand";
 import { useNotificationHistoryStore } from "@/store/slices/notificationHistorySlice";
 
 interface UIState {
-  overlayClaims: Set<string>;
+  // Ordered LIFO stack of overlay claims — the last entry is the topmost
+  // overlay. Idempotent registration: re-adding an id is a no-op and the
+  // array reference is preserved so Zustand skips re-renders.
+  overlayStack: string[];
   addOverlayClaim: (id: string) => void;
   removeOverlayClaim: (id: string) => void;
   hasOpenOverlays: () => boolean;
@@ -19,28 +22,24 @@ interface UIState {
 }
 
 export const useUIStore = create<UIState>((set, get) => ({
-  overlayClaims: new Set<string>(),
+  overlayStack: [],
 
   // Idempotent — return the same state reference when the claim is already
-  // present so Zustand skips re-renders. Never mutate the existing Set; a new
-  // instance is required so reference-equality subscribers update.
+  // present so Zustand skips re-renders. Never mutate the existing array; a
+  // new instance is required so reference-equality subscribers update.
   addOverlayClaim: (id) =>
     set((state) => {
-      if (state.overlayClaims.has(id)) return state;
-      const next = new Set(state.overlayClaims);
-      next.add(id);
-      return { overlayClaims: next };
+      if (state.overlayStack.includes(id)) return state;
+      return { overlayStack: [...state.overlayStack, id] };
     }),
 
   removeOverlayClaim: (id) =>
     set((state) => {
-      if (!state.overlayClaims.has(id)) return state;
-      const next = new Set(state.overlayClaims);
-      next.delete(id);
-      return { overlayClaims: next };
+      if (!state.overlayStack.includes(id)) return state;
+      return { overlayStack: state.overlayStack.filter((x) => x !== id) };
     }),
 
-  hasOpenOverlays: () => get().overlayClaims.size > 0,
+  hasOpenOverlays: () => get().overlayStack.length > 0,
 
   notificationCenterOpen: false,
   lastNotificationCenterClosedAt: 0,


### PR DESCRIPTION
## Summary

Closes #7674.

Renames `useUIStore.overlayClaims: Set<string>` to `overlayStack: string[]` — last item is the topmost claimant. The registry can now answer which overlay is on top, which is the question every consumer was already trying to triangulate from `.size` deltas and a 300ms grace window in `FixedDropdown`.

Action signatures (`addOverlayClaim` / `removeOverlayClaim` / `hasOpenOverlays`) are unchanged. The new shape uses an `includes()` guard on add to preserve idempotency and `filter((x) => x !== id)` on remove. Both no-op paths return the bare `state` reference so Zustand 5's `Object.is` check skips notifying subscribers.

Adds two typed read helpers in `src/hooks/useOverlayState.ts`:

```ts
useOverlayOpen(id: string): boolean       // s.overlayStack.includes(id)
useTopmostOverlay(): string | undefined   // s.overlayStack.at(-1)
```

Both return primitives so subscribers only re-render when the boolean / topmost id actually changes, not on unrelated stack mutations.

## Changes

- `src/store/uiStore.ts` — `Set<string>` → `string[]` with idempotent add and first-occurrence remove. Bare `state` returns on no-ops for reference stability.
- `src/hooks/useOverlayState.ts` — add `useOverlayOpen` and `useTopmostOverlay`. Existing `useOverlayClaim` / `useOverlayState` JSDoc updated to describe the new shape.
- `src/hooks/index.ts` — barrel exports both new helpers.
- `src/components/Layout/AppLayout.tsx` — adopts `useOverlayOpen("theme-browser")` as the natural call site (the source-scan test now pins the helper call).
- `src/components/ui/fixed-dropdown.tsx` — mechanical rename: `overlayClaimsSize` → `overlayStackLength`, `.size` → `.length`. Grace-window logic intentionally unchanged (size-based by design; an identity-aware rewrite is a separate concern).
- `src/components/Portal/PortalVisibilityController.tsx`, `src/components/Project/ProjectSwitcherPalette.tsx`, `src/services/actions/definitions/panelActions.ts`, `src/store/portalStore.ts` — mechanical `.size`/`.has` → `.length`/`.includes`.
- Tests updated atomically with their source files. `FixedDropdown.test.tsx`'s hand-typed selector mock was changed by hand from `{ overlayClaims: Set<string> }` to `{ overlayStack: string[] }`. `AppLayout.themeBrowser.test.ts` keeps the structural mount-gate assertion and updates the source-scan substring to `useOverlayOpen("theme-browser")`.

## Test plan

- [x] Unit tests: 160 tests across 8 files (`uiStore`, `useOverlayState`, `FixedDropdown`, `AppLayout.themeBrowser`, `PortalVisibilityController`, `portalStore`, `actionDefinitions.adversarial`, `ThemeBrowser`)
- [x] `npm run check` (typecheck + lint + format + build) — clean
- [ ] Open the ThemeBrowser to confirm the inert gate still kicks in via `useOverlayOpen`
- [ ] Open a FixedDropdown, then trigger a modal — confirm the dropdown still dismisses (grace-window timing preserved)