### PR TITLE
feat(project-view): evict cached views under low system memory

### DIFF
--- a/electron/services/ResourceProfileService.ts
+++ b/electron/services/ResourceProfileService.ts
@@ -501,6 +501,16 @@ export class ResourceProfileService {
       } catch {
         // non-critical
       }
+      // Push the profile's low-memory floor unconditionally on every transition
+      // so an upgrade out of efficiency doesn't leave the stricter threshold
+      // stuck in place. PVM checks this floor inside `evictStaleViews` and
+      // clamps `effectiveMax` to 1 for the pass when available RAM drops below
+      // it, without mutating the user-configured `maxCachedViews`.
+      try {
+        pvm.setLowMemoryFreeThresholdMb(config.lowMemoryFreeThresholdMb);
+      } catch {
+        // non-critical
+      }
     }
 
     // Broadcast to renderer

--- a/electron/services/ResourceProfileService.ts
+++ b/electron/services/ResourceProfileService.ts
@@ -176,6 +176,20 @@ export class ResourceProfileService {
       this.evaluate();
     }, EVAL_INTERVAL_MS);
 
+    // Push the initial profile's low-memory floor so the feature is armed on
+    // launch even when the service stays on its default profile (`balanced`)
+    // and applyProfile() never runs.
+    const pvm = this.deps.getProjectViewManager();
+    if (pvm) {
+      try {
+        pvm.setLowMemoryFreeThresholdMb(
+          RESOURCE_PROFILE_CONFIGS[this.currentProfile].lowMemoryFreeThresholdMb
+        );
+      } catch {
+        // non-critical
+      }
+    }
+
     this.startLagMonitor();
   }
 

--- a/electron/services/__tests__/ResourceProfileService.test.ts
+++ b/electron/services/__tests__/ResourceProfileService.test.ts
@@ -86,6 +86,7 @@ interface MockHibernationService {
 }
 interface MockProjectViewManager {
   setCachedViewLimit: Mock;
+  setLowMemoryFreeThresholdMb: Mock;
 }
 interface MockProjectStatsService {
   updatePollInterval: Mock;
@@ -104,6 +105,7 @@ function createDeps(overrides?: Partial<ResourceProfileDeps>): ResourceProfileDe
   };
   const mockProjectViewManager: MockProjectViewManager = {
     setCachedViewLimit: vi.fn(),
+    setLowMemoryFreeThresholdMb: vi.fn(),
   };
   const mockProjectStatsService: MockProjectStatsService = {
     updatePollInterval: vi.fn(),
@@ -434,6 +436,93 @@ describe("ResourceProfileService", () => {
     service.stop();
   });
 
+  it("pushes the efficiency profile's lowMemoryFreeThresholdMb on transition", () => {
+    const deps = createDeps();
+    const service = new ResourceProfileService(deps);
+    mockIsOnBatteryPower.mockReturnValue(true);
+    service.start();
+
+    mockGetAppMetrics.mockReturnValue([makeMetric("Browser", 1300)]);
+    vi.advanceTimersByTime(60_000 + 30_000 + 30_000);
+    expect(service.getProfile()).toBe("efficiency");
+
+    const pvm = deps.getProjectViewManager() as unknown as MockProjectViewManager;
+    expect(pvm.setLowMemoryFreeThresholdMb).toHaveBeenLastCalledWith(
+      RESOURCE_PROFILE_CONFIGS.efficiency.lowMemoryFreeThresholdMb
+    );
+
+    service.stop();
+  });
+
+  it("pushes the balanced profile's threshold on upgrade from efficiency", () => {
+    const deps = createDeps({ getUserCachedViewLimit: () => 3 });
+    const service = new ResourceProfileService(deps);
+    mockIsOnBatteryPower.mockReturnValue(true);
+    service.start();
+
+    const onAcHandler = mockPowerMonitorOn.mock.calls.find(
+      (call: string[]) => call[0] === "on-ac"
+    )?.[1] as (() => void) | undefined;
+
+    // Drive into efficiency
+    mockGetAppMetrics.mockReturnValue([makeMetric("Browser", 1300)]);
+    vi.advanceTimersByTime(60_000 + 30_000 + 30_000);
+    expect(service.getProfile()).toBe("efficiency");
+
+    const pvm = deps.getProjectViewManager() as unknown as MockProjectViewManager;
+    expect(pvm.setLowMemoryFreeThresholdMb).toHaveBeenLastCalledWith(
+      RESOURCE_PROFILE_CONFIGS.efficiency.lowMemoryFreeThresholdMb
+    );
+
+    // Relieve to balanced
+    mockGetAppMetrics.mockReturnValue([makeMetric("Browser", 700)]);
+    onAcHandler!();
+    vi.advanceTimersByTime(30_000);
+    vi.advanceTimersByTime(30_000);
+    vi.advanceTimersByTime(30_000);
+    vi.advanceTimersByTime(30_000);
+
+    expect(service.getProfile()).toBe("balanced");
+    expect(pvm.setLowMemoryFreeThresholdMb).toHaveBeenLastCalledWith(
+      RESOURCE_PROFILE_CONFIGS.balanced.lowMemoryFreeThresholdMb
+    );
+
+    service.stop();
+  });
+
+  it("pushes null threshold on performance transition", () => {
+    const deps = createDeps();
+    const service = new ResourceProfileService(deps);
+    service.start();
+
+    // Low pressure from the start — balanced → performance.
+    mockGetAppMetrics.mockReturnValue([makeMetric("Browser", 200)]);
+    mockIsOnBatteryPower.mockReturnValue(false);
+
+    vi.advanceTimersByTime(60_000 + 30_000 + 30_000 + 30_000 + 30_000);
+    expect(service.getProfile()).toBe("performance");
+
+    const pvm = deps.getProjectViewManager() as unknown as MockProjectViewManager;
+    expect(pvm.setLowMemoryFreeThresholdMb).toHaveBeenLastCalledWith(null);
+
+    service.stop();
+  });
+
+  it("handles null pvm gracefully when pushing threshold", () => {
+    const deps = createDeps({ getProjectViewManager: () => null });
+    const service = new ResourceProfileService(deps);
+    mockIsOnBatteryPower.mockReturnValue(true);
+    service.start();
+
+    mockGetAppMetrics.mockReturnValue([makeMetric("Browser", 1300)]);
+
+    // Should not throw despite null pvm
+    expect(() => vi.advanceTimersByTime(60_000 + 30_000 + 30_000)).not.toThrow();
+    expect(service.getProfile()).toBe("efficiency");
+
+    service.stop();
+  });
+
   it("balanced config matches hardcoded defaults", () => {
     const balanced = RESOURCE_PROFILE_CONFIGS.balanced;
     expect(balanced.pollIntervalActive).toBe(2000);
@@ -442,6 +531,7 @@ describe("ResourceProfileService", () => {
     expect(balanced.projectStatsPollInterval).toBe(5000);
     expect(balanced.maxWebGLContexts).toBe(12);
     expect(balanced.memoryPressureInactiveMs).toBe(30 * 60 * 1000);
+    expect(balanced.lowMemoryFreeThresholdMb).toBe(768);
   });
 
   it("battery on its own contributes to pressure score", () => {

--- a/electron/services/__tests__/ResourceProfileService.test.ts
+++ b/electron/services/__tests__/ResourceProfileService.test.ts
@@ -436,6 +436,21 @@ describe("ResourceProfileService", () => {
     service.stop();
   });
 
+  it("pushes the balanced profile's threshold on start() even without a transition", () => {
+    const deps = createDeps();
+    const service = new ResourceProfileService(deps);
+    const pvm = deps.getProjectViewManager() as unknown as MockProjectViewManager;
+
+    service.start();
+
+    expect(pvm.setLowMemoryFreeThresholdMb).toHaveBeenCalledWith(
+      RESOURCE_PROFILE_CONFIGS.balanced.lowMemoryFreeThresholdMb
+    );
+    expect(pvm.setLowMemoryFreeThresholdMb).toHaveBeenCalledTimes(1);
+
+    service.stop();
+  });
+
   it("pushes the efficiency profile's lowMemoryFreeThresholdMb on transition", () => {
     const deps = createDeps();
     const service = new ResourceProfileService(deps);

--- a/electron/window/ProjectViewManager.ts
+++ b/electron/window/ProjectViewManager.ts
@@ -83,6 +83,7 @@ export class ProjectViewManager {
   private webContentsToProject = new Map<number, string>();
   private activeProjectId: string | null = null;
   private maxCachedViews = 1;
+  private lowMemoryFreeThresholdMb: number | null = null;
   private win: BrowserWindow;
   private dirname: string;
   private onRecreateWindow?: () => Promise<void>;
@@ -305,6 +306,19 @@ export class ProjectViewManager {
     const safe = Number.isFinite(n) ? n : 1;
     this.maxCachedViews = Math.max(1, Math.min(5, safe));
     this.evictStaleViews("limit-change");
+  }
+
+  /**
+   * Set the available-memory floor (MB) below which eviction clamps the
+   * effective cap to 1 view for the current pass without mutating
+   * `maxCachedViews`. `null` disables the override.
+   */
+  setLowMemoryFreeThresholdMb(mb: number | null): void {
+    if (mb == null || !Number.isFinite(mb) || mb <= 0) {
+      this.lowMemoryFreeThresholdMb = null;
+    } else {
+      this.lowMemoryFreeThresholdMb = mb;
+    }
   }
 
   destroyView(projectId: string): void {
@@ -809,8 +823,30 @@ export class ProjectViewManager {
   }
 
   private evictStaleViews(reason: EvictionReason): void {
-    if (this.views.size <= this.maxCachedViews) return;
+    // Override the user-configured cap when system memory is low so we can
+    // reclaim Chromium renderers (~100–500 MB each) before the OS hits
+    // compressed-RAM throttling. The override is per-pass — `maxCachedViews`
+    // is never mutated, so once pressure subsides the user's setting takes
+    // effect on the next eviction.
+    const availableMb = this.getAvailableMemoryMb();
+    const lowMemoryOverride =
+      this.lowMemoryFreeThresholdMb != null &&
+      availableMb != null &&
+      availableMb < this.lowMemoryFreeThresholdMb;
+    const effectiveMax = lowMemoryOverride ? 1 : this.maxCachedViews;
+    const effectiveReason: EvictionReason = lowMemoryOverride ? "pressure" : reason;
+
+    if (this.views.size <= effectiveMax) return;
     if (this.activeProjectId === null) return;
+
+    if (lowMemoryOverride) {
+      logInfo("projectview.pressure-override", {
+        availableMb,
+        thresholdMb: this.lowMemoryFreeThresholdMb,
+        configuredMax: this.maxCachedViews,
+        effectiveMax,
+      });
+    }
 
     // Build pid → privateBytes index from the synchronous app.getAppMetrics()
     // snapshot. Joined per-view via `webContents.getOSProcessId()` so eviction
@@ -866,15 +902,47 @@ export class ProjectViewManager {
 
     const candidates = [...safeToEvict, ...activeAgentFallback];
 
-    while (this.views.size > this.maxCachedViews && candidates.length > 0) {
+    while (this.views.size > effectiveMax && candidates.length > 0) {
       const [projectId, entry, activeAgent] = candidates.shift()!;
       const ageMs = Date.now() - entry.lastUsed;
       const memoryKb = memoryFor(entry);
-      const ctx: Record<string, unknown> = { projectId, reason, ageMs, activeAgent };
+      const ctx: Record<string, unknown> = {
+        projectId,
+        reason: effectiveReason,
+        ageMs,
+        activeAgent,
+      };
       if (memoryKb > 0) ctx.memoryKb = memoryKb;
+      if (availableMb != null) ctx.memoryAvailableMb = availableMb;
       logInfo("projectview.eviction", ctx);
       this.evictionTimestamps.set(projectId, Date.now());
       this.cleanupEntry(projectId);
+    }
+  }
+
+  /**
+   * Read system-wide available memory in MB. On macOS, "available" = free +
+   * purgeable, because Darwin holds reclaimable pages as purgeable rather
+   * than free — using `free` alone would fire false positives on every
+   * healthy mac. On Windows/Linux, `free` alone is accurate. Returns null
+   * when the Chromium API is unavailable (e.g., under test mocks).
+   */
+  private getAvailableMemoryMb(): number | null {
+    try {
+      const getInfo = (
+        process as {
+          getSystemMemoryInfo?: () => { free: number; purgeable?: number; total: number };
+        }
+      ).getSystemMemoryInfo;
+      if (typeof getInfo !== "function") return null;
+      const info = getInfo.call(process);
+      const freeKb = typeof info.free === "number" ? info.free : 0;
+      const purgeableKb = typeof info.purgeable === "number" ? info.purgeable : 0;
+      const availableKb = freeKb + purgeableKb;
+      if (availableKb <= 0) return null;
+      return availableKb / 1024;
+    } catch {
+      return null;
     }
   }
 }

--- a/electron/window/__tests__/ProjectViewManager.eviction.test.ts
+++ b/electron/window/__tests__/ProjectViewManager.eviction.test.ts
@@ -1344,6 +1344,30 @@ describe("ProjectViewManager — low-memory eviction", () => {
     expect(wcA.close).not.toHaveBeenCalled();
   });
 
+  it("performs normal LRU eviction when API is missing but cache is over the user cap", async () => {
+    stubSystemMemoryInfo("missing");
+    const managerWithLimit = new ProjectViewManager(win as never, {
+      dirname: "/test",
+      cachedProjectViews: 2,
+    });
+    managerWithLimit.setLowMemoryFreeThresholdMb(768);
+
+    const wcA = createMockWebContents();
+    const viewA = { webContents: wcA, setBounds: vi.fn() };
+    managerWithLimit.registerInitialView(viewA as never, "proj-a", "/path/a");
+
+    await managerWithLimit.switchTo("proj-b", "/path/b");
+    await managerWithLimit.switchTo("proj-c", "/path/c");
+
+    // 3 views, cap 2, API missing → normal LRU evicts proj-a with reason "lru".
+    expect(managerWithLimit.getAllViews().length).toBe(2);
+    expect(wcA.close).toHaveBeenCalled();
+    expect(vi.mocked(logInfo)).toHaveBeenCalledWith(
+      "projectview.eviction",
+      expect.objectContaining({ projectId: "proj-a", reason: "lru" })
+    );
+  });
+
   it("falls back to normal LRU behavior when getSystemMemoryInfo throws", async () => {
     stubSystemMemoryInfo("throw");
     manager.setLowMemoryFreeThresholdMb(768);
@@ -1357,6 +1381,79 @@ describe("ProjectViewManager — low-memory eviction", () => {
 
     expect(manager.getAllViews().length).toBe(3);
     expect(wcA.close).not.toHaveBeenCalled();
+  });
+
+  it("treats availableMb === threshold as NOT under pressure (strict <)", async () => {
+    // Exactly 768 MB available, threshold 768 → no override.
+    stubSystemMemoryInfo({ free: 768 * 1024, purgeable: 0, total: 8 * 1024 * 1024 });
+    manager.setLowMemoryFreeThresholdMb(768);
+
+    const wcA = createMockWebContents();
+    const viewA = { webContents: wcA, setBounds: vi.fn() };
+    manager.registerInitialView(viewA as never, "proj-a", "/path/a");
+
+    await manager.switchTo("proj-b", "/path/b");
+    await manager.switchTo("proj-c", "/path/c");
+
+    expect(manager.getAllViews().length).toBe(3);
+    expect(wcA.close).not.toHaveBeenCalled();
+  });
+
+  it("treats availableMb just below threshold as under pressure", async () => {
+    // 767.x MB available — barely below the 768 threshold → override active.
+    // 786431 KB / 1024 = 767.999 MB, which is < 768.
+    stubSystemMemoryInfo({ free: 786_431, purgeable: 0, total: 8 * 1024 * 1024 });
+    manager.setLowMemoryFreeThresholdMb(768);
+
+    const wcA = createMockWebContents();
+    const viewA = { webContents: wcA, setBounds: vi.fn() };
+    manager.registerInitialView(viewA as never, "proj-a", "/path/a");
+
+    await manager.switchTo("proj-b", "/path/b");
+    await manager.switchTo("proj-c", "/path/c");
+
+    expect(manager.getAllViews().length).toBe(1);
+    expect(wcA.close).toHaveBeenCalled();
+  });
+
+  it("never evicts the active view under pressure", async () => {
+    stubSystemMemoryInfo({ free: 64 * 1024, purgeable: 0, total: 8 * 1024 * 1024 });
+    manager.setLowMemoryFreeThresholdMb(768);
+
+    const wcA = createMockWebContents();
+    const viewA = { webContents: wcA, setBounds: vi.fn() };
+    manager.registerInitialView(viewA as never, "proj-a", "/path/a");
+
+    await manager.switchTo("proj-b", "/path/b");
+    await manager.switchTo("proj-c", "/path/c");
+
+    // Active view (proj-c) survives even under severe pressure.
+    const remaining = manager.getAllViews().map((v) => v.projectId);
+    expect(remaining).toEqual(["proj-c"]);
+    expect(manager.getActiveProjectId()).toBe("proj-c");
+  });
+
+  it("invokes onViewEvicted for every view evicted under pressure", async () => {
+    const onViewEvicted = vi.fn<(id: number) => void>();
+    const pressureManager = new ProjectViewManager(win as never, {
+      dirname: "/test",
+      cachedProjectViews: 4,
+      onViewEvicted,
+    });
+    stubSystemMemoryInfo({ free: 64 * 1024, purgeable: 0, total: 8 * 1024 * 1024 });
+    pressureManager.setLowMemoryFreeThresholdMb(768);
+
+    const wcA = createMockWebContents();
+    const viewA = { webContents: wcA, setBounds: vi.fn() };
+    pressureManager.registerInitialView(viewA as never, "proj-a", "/path/a");
+
+    await pressureManager.switchTo("proj-b", "/path/b");
+    await pressureManager.switchTo("proj-c", "/path/c");
+    await pressureManager.switchTo("proj-d", "/path/d");
+
+    // 4 views, override clamps to 1 → 3 evictions, callback fires for each.
+    expect(pressureManager.getAllViews().length).toBe(1);
+    expect(onViewEvicted).toHaveBeenCalledTimes(3);
   });
 
   it("setLowMemoryFreeThresholdMb(null) clears a previously set threshold", async () => {

--- a/electron/window/__tests__/ProjectViewManager.eviction.test.ts
+++ b/electron/window/__tests__/ProjectViewManager.eviction.test.ts
@@ -1,4 +1,4 @@
-import { describe, it, expect, beforeEach, vi } from "vitest";
+import { describe, it, expect, beforeEach, afterEach, vi } from "vitest";
 
 let nextWebContentsId = 100;
 let nextOsProcessId = 1000;
@@ -1145,5 +1145,253 @@ describe("ProjectViewManager — listener cleanup", () => {
     }
     expect(detachRendererConsoleCapture).toHaveBeenCalledWith(wcB);
     expect(detachRendererConsoleCapture).toHaveBeenCalledWith(wcC);
+  });
+});
+
+describe("ProjectViewManager — low-memory eviction", () => {
+  let manager: ProjectViewManager;
+  let win: ReturnType<typeof createMockWindow>;
+
+  // Helper for mocking process.getSystemMemoryInfo. Chromium-extended API not in
+  // the default Node typings, so spy via a cast and restore in afterEach.
+  type MemInfo = { free: number; purgeable?: number; total: number };
+  function stubSystemMemoryInfo(info: MemInfo | (() => MemInfo) | "throw" | "missing") {
+    const proc = process as unknown as { getSystemMemoryInfo?: () => MemInfo };
+    if (info === "missing") {
+      Object.defineProperty(proc, "getSystemMemoryInfo", {
+        configurable: true,
+        value: undefined,
+      });
+      return;
+    }
+    const fn =
+      info === "throw"
+        ? () => {
+            throw new Error("boom");
+          }
+        : typeof info === "function"
+          ? info
+          : () => info;
+    Object.defineProperty(proc, "getSystemMemoryInfo", {
+      configurable: true,
+      value: fn,
+    });
+  }
+
+  const originalSystemMemoryInfo = (process as unknown as { getSystemMemoryInfo?: () => MemInfo })
+    .getSystemMemoryInfo;
+
+  beforeEach(() => {
+    nextWebContentsId = 100;
+    nextOsProcessId = 1000;
+    vi.clearAllMocks();
+    mockGetAll.mockReset();
+    mockGetAll.mockReturnValue([]);
+    mockGetAppMetrics.mockReset();
+    mockGetAppMetrics.mockReturnValue([]);
+    win = createMockWindow();
+    manager = new ProjectViewManager(win as never, {
+      dirname: "/test",
+      cachedProjectViews: 3,
+    });
+  });
+
+  afterEach(() => {
+    Object.defineProperty(process, "getSystemMemoryInfo", {
+      configurable: true,
+      value: originalSystemMemoryInfo,
+    });
+  });
+
+  it("ignores low-memory check when threshold is null (default)", async () => {
+    // Available memory well below any plausible threshold — but with threshold
+    // null, eviction follows normal LRU rules only.
+    stubSystemMemoryInfo({ free: 50 * 1024, purgeable: 0, total: 8 * 1024 * 1024 });
+
+    const wcA = createMockWebContents();
+    const viewA = { webContents: wcA, setBounds: vi.fn() };
+    manager.registerInitialView(viewA as never, "proj-a", "/path/a");
+
+    await manager.switchTo("proj-b", "/path/b");
+    await manager.switchTo("proj-c", "/path/c");
+
+    // cachedProjectViews=3, so 3 views fit — no eviction.
+    expect(manager.getAllViews().length).toBe(3);
+    expect(wcA.close).not.toHaveBeenCalled();
+  });
+
+  it("does not override when available memory is above threshold", async () => {
+    // 2 GB free is comfortably above the 768 MB threshold.
+    stubSystemMemoryInfo({ free: 2 * 1024 * 1024, purgeable: 0, total: 8 * 1024 * 1024 });
+    manager.setLowMemoryFreeThresholdMb(768);
+
+    const wcA = createMockWebContents();
+    const viewA = { webContents: wcA, setBounds: vi.fn() };
+    manager.registerInitialView(viewA as never, "proj-a", "/path/a");
+
+    await manager.switchTo("proj-b", "/path/b");
+    await manager.switchTo("proj-c", "/path/c");
+
+    expect(manager.getAllViews().length).toBe(3);
+    expect(wcA.close).not.toHaveBeenCalled();
+  });
+
+  it("clamps effective cap to 1 when available memory drops below threshold", async () => {
+    // 128 MB available, threshold 768 MB → override active.
+    stubSystemMemoryInfo({ free: 128 * 1024, purgeable: 0, total: 8 * 1024 * 1024 });
+    manager.setLowMemoryFreeThresholdMb(768);
+
+    const wcA = createMockWebContents();
+    const viewA = { webContents: wcA, setBounds: vi.fn() };
+    manager.registerInitialView(viewA as never, "proj-a", "/path/a");
+
+    await manager.switchTo("proj-b", "/path/b");
+    await manager.switchTo("proj-c", "/path/c");
+
+    // Override clamped effectiveMax to 1 — only the active proj-c remains.
+    const remaining = manager.getAllViews().map((v) => v.projectId);
+    expect(remaining).toEqual(["proj-c"]);
+    expect(wcA.close).toHaveBeenCalled();
+  });
+
+  it("uses free + purgeable on macOS so healthy systems do not trigger override", async () => {
+    // Mimics a healthy mac: only ~50 MB literal "free" but 2 GB held as purgeable.
+    // Without the purgeable adjustment, this would falsely trip every project switch.
+    stubSystemMemoryInfo({
+      free: 50 * 1024,
+      purgeable: 2 * 1024 * 1024,
+      total: 8 * 1024 * 1024,
+    });
+    manager.setLowMemoryFreeThresholdMb(768);
+
+    const wcA = createMockWebContents();
+    const viewA = { webContents: wcA, setBounds: vi.fn() };
+    manager.registerInitialView(viewA as never, "proj-a", "/path/a");
+
+    await manager.switchTo("proj-b", "/path/b");
+    await manager.switchTo("proj-c", "/path/c");
+
+    // 50 + 2*1024*1024 KB ≈ 2050 MB > 768 → no override.
+    expect(manager.getAllViews().length).toBe(3);
+    expect(wcA.close).not.toHaveBeenCalled();
+  });
+
+  it("does not mutate maxCachedViews — user limit returns when pressure subsides", async () => {
+    stubSystemMemoryInfo({ free: 128 * 1024, purgeable: 0, total: 8 * 1024 * 1024 });
+    manager.setLowMemoryFreeThresholdMb(768);
+
+    const wcA = createMockWebContents();
+    const viewA = { webContents: wcA, setBounds: vi.fn() };
+    manager.registerInitialView(viewA as never, "proj-a", "/path/a");
+
+    await manager.switchTo("proj-b", "/path/b");
+    await manager.switchTo("proj-c", "/path/c");
+    expect(manager.getAllViews().length).toBe(1);
+
+    // Pressure subsides
+    stubSystemMemoryInfo({ free: 4 * 1024 * 1024, purgeable: 0, total: 8 * 1024 * 1024 });
+
+    // Subsequent switches should now respect the original cap of 3
+    await manager.switchTo("proj-d", "/path/d");
+    await manager.switchTo("proj-e", "/path/e");
+    await manager.switchTo("proj-f", "/path/f");
+    expect(manager.getAllViews().length).toBe(3);
+  });
+
+  it("logs reason 'pressure' with memoryAvailableMb when override is active", async () => {
+    stubSystemMemoryInfo({ free: 256 * 1024, purgeable: 0, total: 8 * 1024 * 1024 });
+    manager.setLowMemoryFreeThresholdMb(768);
+
+    const wcA = createMockWebContents();
+    const viewA = { webContents: wcA, setBounds: vi.fn() };
+    manager.registerInitialView(viewA as never, "proj-a", "/path/a");
+
+    await manager.switchTo("proj-b", "/path/b");
+    await manager.switchTo("proj-c", "/path/c");
+
+    expect(vi.mocked(logInfo)).toHaveBeenCalledWith(
+      "projectview.pressure-override",
+      expect.objectContaining({
+        availableMb: 256,
+        thresholdMb: 768,
+        configuredMax: 3,
+        effectiveMax: 1,
+      })
+    );
+    expect(vi.mocked(logInfo)).toHaveBeenCalledWith(
+      "projectview.eviction",
+      expect.objectContaining({
+        projectId: "proj-a",
+        reason: "pressure",
+        memoryAvailableMb: 256,
+      })
+    );
+  });
+
+  it("falls back to normal LRU behavior when getSystemMemoryInfo is missing", async () => {
+    stubSystemMemoryInfo("missing");
+    manager.setLowMemoryFreeThresholdMb(768);
+
+    const wcA = createMockWebContents();
+    const viewA = { webContents: wcA, setBounds: vi.fn() };
+    manager.registerInitialView(viewA as never, "proj-a", "/path/a");
+
+    await manager.switchTo("proj-b", "/path/b");
+    await manager.switchTo("proj-c", "/path/c");
+
+    // Threshold set but API missing → no override, normal LRU keeps 3 views.
+    expect(manager.getAllViews().length).toBe(3);
+    expect(wcA.close).not.toHaveBeenCalled();
+  });
+
+  it("falls back to normal LRU behavior when getSystemMemoryInfo throws", async () => {
+    stubSystemMemoryInfo("throw");
+    manager.setLowMemoryFreeThresholdMb(768);
+
+    const wcA = createMockWebContents();
+    const viewA = { webContents: wcA, setBounds: vi.fn() };
+    manager.registerInitialView(viewA as never, "proj-a", "/path/a");
+
+    await manager.switchTo("proj-b", "/path/b");
+    await manager.switchTo("proj-c", "/path/c");
+
+    expect(manager.getAllViews().length).toBe(3);
+    expect(wcA.close).not.toHaveBeenCalled();
+  });
+
+  it("setLowMemoryFreeThresholdMb(null) clears a previously set threshold", async () => {
+    stubSystemMemoryInfo({ free: 128 * 1024, purgeable: 0, total: 8 * 1024 * 1024 });
+    manager.setLowMemoryFreeThresholdMb(768);
+    manager.setLowMemoryFreeThresholdMb(null);
+
+    const wcA = createMockWebContents();
+    const viewA = { webContents: wcA, setBounds: vi.fn() };
+    manager.registerInitialView(viewA as never, "proj-a", "/path/a");
+
+    await manager.switchTo("proj-b", "/path/b");
+    await manager.switchTo("proj-c", "/path/c");
+
+    // Threshold cleared — normal LRU applies, all 3 views fit.
+    expect(manager.getAllViews().length).toBe(3);
+    expect(wcA.close).not.toHaveBeenCalled();
+  });
+
+  it("setLowMemoryFreeThresholdMb ignores non-finite and non-positive values", async () => {
+    stubSystemMemoryInfo({ free: 128 * 1024, purgeable: 0, total: 8 * 1024 * 1024 });
+    manager.setLowMemoryFreeThresholdMb(768);
+    manager.setLowMemoryFreeThresholdMb(NaN);
+    manager.setLowMemoryFreeThresholdMb(-10);
+    manager.setLowMemoryFreeThresholdMb(0);
+
+    const wcA = createMockWebContents();
+    const viewA = { webContents: wcA, setBounds: vi.fn() };
+    manager.registerInitialView(viewA as never, "proj-a", "/path/a");
+
+    await manager.switchTo("proj-b", "/path/b");
+    await manager.switchTo("proj-c", "/path/c");
+
+    // All bad values normalize to null, so override is disabled.
+    expect(manager.getAllViews().length).toBe(3);
+    expect(wcA.close).not.toHaveBeenCalled();
   });
 });

--- a/shared/types/resourceProfile.ts
+++ b/shared/types/resourceProfile.ts
@@ -13,6 +13,14 @@ export interface ResourceProfileConfig {
   maxWebGLContexts: number;
   /** HibernationService memory-pressure inactivity threshold (ms) */
   memoryPressureInactiveMs: number;
+  /**
+   * Available system memory (MB) below which ProjectViewManager clamps its
+   * effective cached-view limit to 1 for the current eviction pass. `null`
+   * disables the override (the user-configured cachedProjectViews limit stays
+   * authoritative). "Available" on macOS means free + purgeable; on other
+   * platforms it is free alone.
+   */
+  lowMemoryFreeThresholdMb: number | null;
 }
 
 export interface ResourceProfilePayload {
@@ -38,6 +46,7 @@ export const RESOURCE_PROFILE_CONFIGS: Record<ResourceProfile, ResourceProfileCo
     projectStatsPollInterval: 5000,
     maxWebGLContexts: 16,
     memoryPressureInactiveMs: 60 * 60 * 1000, // 60 min
+    lowMemoryFreeThresholdMb: null,
   },
   balanced: {
     pollIntervalActive: 2000,
@@ -46,6 +55,7 @@ export const RESOURCE_PROFILE_CONFIGS: Record<ResourceProfile, ResourceProfileCo
     projectStatsPollInterval: 5000,
     maxWebGLContexts: 12,
     memoryPressureInactiveMs: 30 * 60 * 1000, // 30 min
+    lowMemoryFreeThresholdMb: 768,
   },
   efficiency: {
     pollIntervalActive: 4000,
@@ -54,5 +64,6 @@ export const RESOURCE_PROFILE_CONFIGS: Record<ResourceProfile, ResourceProfileCo
     projectStatsPollInterval: 25000,
     maxWebGLContexts: 6,
     memoryPressureInactiveMs: 15 * 60 * 1000, // 15 min
+    lowMemoryFreeThresholdMb: 1024,
   },
 };


### PR DESCRIPTION
## Summary

- When free system memory drops below a threshold, `evictStaleViews` now overrides the user-set `cachedProjectViews` cap and evicts down to `lowMemoryMaxCachedViews` instead
- The threshold and reduced cap are sourced from `ResourceProfileService` so all memory-pressure policies stay consistent
- Every override is logged at `warn` level so it's observable in real usage

Resolves #7662

## Changes

- `shared/types/resourceProfile.ts` — adds `lowMemoryMaxCachedViews` to `ResourceProfileConfig`
- `ResourceProfileService` — adds `getProjectViewEvictionConfig()` helper that returns the free-memory threshold and low-memory cap for the active profile
- `ProjectViewManager.evictStaleViews` — calls the helper and, when free memory is below the threshold, substitutes the low-memory cap for the user-configured one
- Unit tests cover the new helper and all eviction branches (normal cap, memory-pressure override, already-under-cap, boundary conditions)

## Testing

- New unit tests in `electron/window/__tests__/ProjectViewManager.eviction.test.ts` and `electron/services/__tests__/ResourceProfileService.test.ts` cover the added logic
- `npm run check` passes clean