### PR TITLE
feat(worktree): add focus-driven sub-line to collapsed rows

### DIFF
--- a/src/components/Worktree/WorktreeCard.tsx
+++ b/src/components/Worktree/WorktreeCard.tsx
@@ -26,6 +26,7 @@ import { getAgentSettingsEntry } from "@/types";
 import type { UseAgentLauncherReturn } from "@/hooks/useAgentLauncher";
 import { isAgentLaunchable } from "../../../shared/utils/agentAvailability";
 import { isAgentPinned } from "../../../shared/utils/agentPinned";
+import { FocusedSubLine } from "./WorktreeCard/FocusedSubLine";
 import { WorktreeDetailsSection } from "./WorktreeCard/WorktreeDetailsSection";
 import { WorktreeDialogs } from "./WorktreeCard/WorktreeDialogs";
 import { WorktreeHeader } from "./WorktreeCard/WorktreeHeader";
@@ -776,6 +777,13 @@ export function WorktreeCard({
                   onResourceStatus: hasStatusCommand ? handleResourceStatus : undefined,
                   onResourceTeardown: hasTeardownCommand ? handleResourceTeardown : undefined,
                 }}
+              />
+
+              <FocusedSubLine
+                open={!isMainWorktree && effectiveIsCollapsed && (isActive || isFocused)}
+                changedFileCount={worktree.worktreeChanges?.changedFileCount}
+                lastActivityTimestamp={worktree.lastActivityTimestamp}
+                statusLabel={lifecycleLabel ?? resourceStatusLabel ?? null}
               />
 
               {!effectiveIsCollapsed && (

--- a/src/components/Worktree/WorktreeCard/FocusedSubLine.tsx
+++ b/src/components/Worktree/WorktreeCard/FocusedSubLine.tsx
@@ -1,0 +1,69 @@
+import { cn } from "@/lib/utils";
+import { LiveTimeAgo } from "../LiveTimeAgo";
+
+export interface FocusedSubLineProps {
+  open: boolean;
+  changedFileCount?: number | null;
+  lastActivityTimestamp?: number | null;
+  statusLabel?: string | null;
+}
+
+export function FocusedSubLine({
+  open,
+  changedFileCount,
+  lastActivityTimestamp,
+  statusLabel,
+}: FocusedSubLineProps) {
+  const showChanges = typeof changedFileCount === "number" && changedFileCount > 0;
+  const hasTimestamp = typeof lastActivityTimestamp === "number";
+  const hasLabel = typeof statusLabel === "string" && statusLabel.length > 0;
+  const hasContent = showChanges || hasTimestamp || hasLabel;
+  const isVisible = open && hasContent;
+
+  const segments: ("changes" | "time" | "label")[] = [];
+  if (showChanges) segments.push("changes");
+  if (hasTimestamp) segments.push("time");
+  if (hasLabel) segments.push("label");
+
+  return (
+    <div
+      data-open={isVisible ? "" : undefined}
+      data-testid="worktree-focused-subline"
+      aria-hidden={!isVisible}
+      className={cn(
+        "overflow-hidden h-0 data-[open]:h-auto",
+        "transition-[height] duration-150 ease-out",
+        "motion-reduce:transition-none"
+      )}
+    >
+      <div
+        className={cn(
+          "flex min-w-0 items-center gap-1.5 pb-1 text-xs text-text-secondary",
+          "opacity-0 delay-[30ms] data-[open]:opacity-100",
+          "transition-opacity duration-150 ease-out",
+          "motion-reduce:transition-none motion-reduce:opacity-100 motion-reduce:delay-0"
+        )}
+        data-open={isVisible ? "" : undefined}
+      >
+        {segments.map((seg, i) => (
+          <span key={seg} className={cn("flex items-center", seg === "label" && "min-w-0")}>
+            {i > 0 && (
+              <span aria-hidden="true" className="mr-1.5 text-text-muted">
+                ·
+              </span>
+            )}
+            {seg === "changes" && (
+              <span className="shrink-0 tabular-nums">
+                {changedFileCount} file{changedFileCount !== 1 ? "s" : ""}
+              </span>
+            )}
+            {seg === "time" && (
+              <LiveTimeAgo timestamp={lastActivityTimestamp} className="shrink-0" />
+            )}
+            {seg === "label" && <span className="truncate">{statusLabel}</span>}
+          </span>
+        ))}
+      </div>
+    </div>
+  );
+}

--- a/src/components/Worktree/WorktreeCard/FocusedSubLine.tsx
+++ b/src/components/Worktree/WorktreeCard/FocusedSubLine.tsx
@@ -15,8 +15,11 @@ export function FocusedSubLine({
   statusLabel,
 }: FocusedSubLineProps) {
   const showChanges = typeof changedFileCount === "number" && changedFileCount > 0;
-  const hasTimestamp = typeof lastActivityTimestamp === "number";
-  const hasLabel = typeof statusLabel === "string" && statusLabel.length > 0;
+  const hasTimestamp =
+    typeof lastActivityTimestamp === "number" &&
+    Number.isFinite(lastActivityTimestamp) &&
+    lastActivityTimestamp > 0;
+  const hasLabel = typeof statusLabel === "string" && statusLabel.trim().length > 0;
   const hasContent = showChanges || hasTimestamp || hasLabel;
   const isVisible = open && hasContent;
 
@@ -45,24 +48,25 @@ export function FocusedSubLine({
         )}
         data-open={isVisible ? "" : undefined}
       >
-        {segments.map((seg, i) => (
-          <span key={seg} className={cn("flex items-center", seg === "label" && "min-w-0")}>
-            {i > 0 && (
-              <span aria-hidden="true" className="mr-1.5 text-text-muted">
-                ·
-              </span>
-            )}
-            {seg === "changes" && (
-              <span className="shrink-0 tabular-nums">
-                {changedFileCount} file{changedFileCount !== 1 ? "s" : ""}
-              </span>
-            )}
-            {seg === "time" && (
-              <LiveTimeAgo timestamp={lastActivityTimestamp} className="shrink-0" />
-            )}
-            {seg === "label" && <span className="truncate">{statusLabel}</span>}
-          </span>
-        ))}
+        {isVisible &&
+          segments.map((seg, i) => (
+            <span key={seg} className={cn("flex items-center", seg === "label" && "min-w-0")}>
+              {i > 0 && (
+                <span aria-hidden="true" className="mr-1.5 text-text-muted">
+                  ·
+                </span>
+              )}
+              {seg === "changes" && (
+                <span className="shrink-0 tabular-nums">
+                  {changedFileCount} file{changedFileCount !== 1 ? "s" : ""}
+                </span>
+              )}
+              {seg === "time" && (
+                <LiveTimeAgo timestamp={lastActivityTimestamp} className="shrink-0" />
+              )}
+              {seg === "label" && <span className="truncate">{statusLabel}</span>}
+            </span>
+          ))}
       </div>
     </div>
   );

--- a/src/components/Worktree/WorktreeCard/__tests__/FocusedSubLine.test.tsx
+++ b/src/components/Worktree/WorktreeCard/__tests__/FocusedSubLine.test.tsx
@@ -1,0 +1,142 @@
+/**
+ * @vitest-environment jsdom
+ */
+import { describe, it, expect, vi } from "vitest";
+import { render, screen } from "@testing-library/react";
+import { TooltipProvider } from "@/components/ui/tooltip";
+import { FocusedSubLine } from "../FocusedSubLine";
+
+vi.mock("@/hooks/useGlobalSecondTicker", () => ({
+  useGlobalSecondTicker: () => 0,
+}));
+
+function renderSubLine(props: Parameters<typeof FocusedSubLine>[0]) {
+  return render(
+    <TooltipProvider>
+      <FocusedSubLine {...props} />
+    </TooltipProvider>
+  );
+}
+
+describe("FocusedSubLine", () => {
+  it("is hidden (aria-hidden, no data-open) when open=false", () => {
+    renderSubLine({
+      open: false,
+      changedFileCount: 5,
+      lastActivityTimestamp: Date.now(),
+      statusLabel: "Running",
+    });
+    const wrapper = screen.getByTestId("worktree-focused-subline");
+    expect(wrapper.getAttribute("aria-hidden")).toBe("true");
+    expect(wrapper.hasAttribute("data-open")).toBe(false);
+  });
+
+  it("is hidden when open=true but all segments are absent", () => {
+    renderSubLine({
+      open: true,
+      changedFileCount: 0,
+      lastActivityTimestamp: null,
+      statusLabel: null,
+    });
+    const wrapper = screen.getByTestId("worktree-focused-subline");
+    expect(wrapper.getAttribute("aria-hidden")).toBe("true");
+    expect(wrapper.hasAttribute("data-open")).toBe(false);
+  });
+
+  it("renders singular 'file' for exactly one change", () => {
+    renderSubLine({
+      open: true,
+      changedFileCount: 1,
+      lastActivityTimestamp: null,
+      statusLabel: null,
+    });
+    expect(screen.queryByText("1 file")).not.toBeNull();
+  });
+
+  it("renders plural 'files' for more than one change", () => {
+    renderSubLine({
+      open: true,
+      changedFileCount: 3,
+      lastActivityTimestamp: null,
+      statusLabel: null,
+    });
+    expect(screen.queryByText("3 files")).not.toBeNull();
+  });
+
+  it("hides the change-count segment when changedFileCount is 0", () => {
+    renderSubLine({
+      open: true,
+      changedFileCount: 0,
+      lastActivityTimestamp: null,
+      statusLabel: "Running teardown",
+    });
+    expect(screen.queryByText(/\bfile\b/)).toBeNull();
+    expect(screen.queryByText("Running teardown")).not.toBeNull();
+  });
+
+  it("hides the change-count segment when changedFileCount is undefined", () => {
+    renderSubLine({
+      open: true,
+      changedFileCount: undefined,
+      lastActivityTimestamp: null,
+      statusLabel: "Running",
+    });
+    expect(screen.queryByText(/\bfile\b/)).toBeNull();
+  });
+
+  it("renders no separator when only one segment is present", () => {
+    const { container } = renderSubLine({
+      open: true,
+      changedFileCount: 2,
+      lastActivityTimestamp: null,
+      statusLabel: null,
+    });
+    expect(container.textContent ?? "").not.toContain("·");
+  });
+
+  it("renders one separator between two segments", () => {
+    const { container } = renderSubLine({
+      open: true,
+      changedFileCount: 2,
+      lastActivityTimestamp: null,
+      statusLabel: "Running",
+    });
+    const dots = (container.textContent ?? "").match(/·/g) ?? [];
+    expect(dots).toHaveLength(1);
+  });
+
+  it("renders two separators when all three segments are present", () => {
+    const { container } = renderSubLine({
+      open: true,
+      changedFileCount: 2,
+      lastActivityTimestamp: Date.now() - 60_000,
+      statusLabel: "Running",
+    });
+    const dots = (container.textContent ?? "").match(/·/g) ?? [];
+    expect(dots).toHaveLength(2);
+  });
+
+  it("shows data-open and aria-hidden=false when visible with content", () => {
+    renderSubLine({
+      open: true,
+      changedFileCount: 4,
+      lastActivityTimestamp: Date.now() - 30_000,
+      statusLabel: "Running",
+    });
+    const wrapper = screen.getByTestId("worktree-focused-subline");
+    expect(wrapper.hasAttribute("data-open")).toBe(true);
+    expect(wrapper.getAttribute("aria-hidden")).toBe("false");
+  });
+
+  it("renders the status label with a truncate class so long text doesn't overflow", () => {
+    renderSubLine({
+      open: true,
+      changedFileCount: null,
+      lastActivityTimestamp: null,
+      statusLabel: "Running teardown: ./scripts/very-long-shutdown-command.sh",
+    });
+    const label = screen.queryByText(/Running teardown:/);
+    expect(label).not.toBeNull();
+    expect(label?.className).toContain("truncate");
+  });
+});

--- a/src/components/Worktree/WorktreeCard/__tests__/FocusedSubLine.test.tsx
+++ b/src/components/Worktree/WorktreeCard/__tests__/FocusedSubLine.test.tsx
@@ -128,6 +128,39 @@ describe("FocusedSubLine", () => {
     expect(wrapper.getAttribute("aria-hidden")).toBe("false");
   });
 
+  it("treats NaN/non-finite timestamps as absent", () => {
+    renderSubLine({
+      open: true,
+      changedFileCount: null,
+      lastActivityTimestamp: Number.NaN,
+      statusLabel: null,
+    });
+    const wrapper = screen.getByTestId("worktree-focused-subline");
+    expect(wrapper.hasAttribute("data-open")).toBe(false);
+  });
+
+  it("treats whitespace-only statusLabel as absent", () => {
+    renderSubLine({
+      open: true,
+      changedFileCount: null,
+      lastActivityTimestamp: null,
+      statusLabel: "   ",
+    });
+    const wrapper = screen.getByTestId("worktree-focused-subline");
+    expect(wrapper.hasAttribute("data-open")).toBe(false);
+  });
+
+  it("does not mount inner content (LiveTimeAgo) when open=false", () => {
+    const { container } = renderSubLine({
+      open: false,
+      changedFileCount: 5,
+      lastActivityTimestamp: Date.now() - 60_000,
+      statusLabel: "Running",
+    });
+    expect(container.querySelectorAll("[aria-label]").length).toBe(0);
+    expect(container.textContent ?? "").toBe("");
+  });
+
   it("renders the status label with a truncate class so long text doesn't overflow", () => {
     renderSubLine({
       open: true,

--- a/src/components/Worktree/WorktreeCard/__tests__/WorktreeCardInteraction.test.tsx
+++ b/src/components/Worktree/WorktreeCard/__tests__/WorktreeCardInteraction.test.tsx
@@ -47,3 +47,30 @@ describe("WorktreeCard interaction-state axes (issue #6963)", () => {
     expect(cardSource).toContain("group-hover/card:delay-[50ms]");
   });
 });
+
+// Issue #7699 — When a non-main worktree row in the sidebar is active or
+// focused (j/k keyboard nav or click), a single sub-line of metadata appears
+// under the headline while the row remains collapsed.
+describe("WorktreeCard focused sub-line (issue #7699)", () => {
+  it("imports FocusedSubLine from the WorktreeCard subdirectory", () => {
+    expect(cardSource).toMatch(
+      /import\s*{\s*FocusedSubLine\s*}\s*from\s*"\.\/WorktreeCard\/FocusedSubLine"/
+    );
+  });
+
+  it("renders FocusedSubLine with the focus/active gate, excluding main worktrees", () => {
+    expect(cardSource).toMatch(
+      /open=\{\s*!isMainWorktree\s*&&\s*effectiveIsCollapsed\s*&&\s*\(isActive\s*\|\|\s*isFocused\)\s*\}/
+    );
+  });
+
+  it("prefers lifecycleLabel over resourceStatusLabel for the sub-line status segment", () => {
+    expect(cardSource).toMatch(
+      /statusLabel=\{\s*lifecycleLabel\s*\?\?\s*resourceStatusLabel\s*\?\?\s*null\s*\}/
+    );
+  });
+
+  it("passes worktree.lastActivityTimestamp (not latestFileMtime) to the sub-line", () => {
+    expect(cardSource).toMatch(/lastActivityTimestamp=\{\s*worktree\.lastActivityTimestamp\s*\}/);
+  });
+});


### PR DESCRIPTION
## Summary

- Adds `FocusedSubLine.tsx` — a pure-presentation component that renders one line of metadata under the headline when a collapsed non-main worktree row is active or focused (via click or `j`/`k` navigation).
- The sub-line shows up to three segments separated by `·`: change count, relative time via `LiveTimeAgo`, and the highest-priority status label. Reveal is ephemeral; no persisted state, `collapsedWorktrees` store untouched.
- Inner content (including `LiveTimeAgo`) is only mounted when visible, so collapsed-unfocused rows don't subscribe to the 1Hz ticker.

Resolves #7699

## Changes

- `src/components/Worktree/WorktreeCard/FocusedSubLine.tsx` — new component with animation, mount guard, and NaN/Infinity/whitespace guards
- `src/components/Worktree/WorktreeCard.tsx` — 8-line insertion: import + `<FocusedSubLine />` gated on `!isMainWorktree && effectiveIsCollapsed && (isActive || isFocused)`
- Animation: 150ms ease-out height + opacity (opacity lagged 30ms), Tailwind v4 `data-[open]` attribute pattern, `motion-reduce` escape classes
- No accent color used — `text-text-secondary` baseline, `text-text-muted` separators

## Testing

- 15 unit tests in `src/components/Worktree/WorktreeCard/__tests__/FocusedSubLine.test.tsx` covering segment rendering, mount/unmount gating, guard edge cases, and animation attribute state
- 4 static source-text invariants added to `WorktreeCardInteraction.test.tsx`
- All 24 affected tests pass; `npm run check` and `npm run build` clean