### PR TITLE
refactor(settings): move project tabs into unified registry

### DIFF
--- a/src/components/Project/GitHubTab.tsx
+++ b/src/components/Project/GitHubTab.tsx
@@ -5,7 +5,7 @@ import type { RemoteInfo } from "@shared/types/ipc/github";
 interface GitHubTabProps {
   githubRemote: string | undefined;
   onGithubRemoteChange: (remote: string | undefined) => void;
-  projectPath: string;
+  projectPath: string | undefined;
 }
 
 export function GitHubTab({ githubRemote, onGithubRemoteChange, projectPath }: GitHubTabProps) {
@@ -39,6 +39,8 @@ export function GitHubTab({ githubRemote, onGithubRemoteChange, projectPath }: G
       cancelled = true;
     };
   }, [projectPath]);
+
+  if (!projectPath) return null;
 
   return (
     <div className="space-y-6">

--- a/src/components/Settings/SettingsDialog.tsx
+++ b/src/components/Settings/SettingsDialog.tsx
@@ -23,20 +23,7 @@ import {
   usePreferencesStore,
   useSettingsStore,
 } from "@/store";
-import {
-  X,
-  Github,
-  Settings as SettingsIcon,
-  Bell,
-  Search,
-  ChevronRight,
-  KeyRound,
-  FileCode,
-  GitBranch,
-  Command,
-  AlertTriangle,
-} from "lucide-react";
-import { Workflow } from "@/components/icons";
+import { X, Search, ChevronRight, AlertTriangle } from "lucide-react";
 import { cn } from "@/lib/utils";
 import { ScrollShadow } from "@/components/ui/ScrollShadow";
 import {
@@ -53,6 +40,8 @@ import {
   SETTINGS_REGISTRY,
   globalTabTitles,
   globalTabIcons,
+  projectTabTitles,
+  projectTabIcons,
   getSettingsNavGroups,
   preloadAllSettingsTabs,
   scopeForTab,
@@ -68,16 +57,11 @@ import {
   parseQuery,
 } from "./settingsSearchUtils";
 import { SCROLLBACK_DEFAULT } from "@shared/config/scrollback";
-import { useProjectSettingsForm } from "@/hooks/useProjectSettingsForm";
+import {
+  useProjectSettingsForm,
+  type ProjectSettingsFormContext,
+} from "@/hooks/useProjectSettingsForm";
 import { useFlushOnHide } from "@/hooks/useFlushOnHide";
-import { GeneralTab as ProjectGeneralTab } from "@/components/Project/GeneralTab";
-import { ContextTab as ProjectContextTab } from "@/components/Project/ContextTab";
-import { EnvironmentVariablesEditor } from "@/components/Project/EnvironmentVariablesEditor";
-import { AutomationTab as ProjectAutomationTab } from "@/components/Project/AutomationTab";
-import { RecipesTab as ProjectRecipesTab } from "@/components/Project/RecipesTab";
-import { CommandOverridesTab } from "./CommandOverridesTab";
-import { ProjectNotificationsTab } from "@/components/Project/ProjectNotificationsTab";
-import { GitHubTab as ProjectGitHubTab } from "@/components/Project/GitHubTab";
 import {
   SettingsValidationProvider,
   SettingsValidationContext,
@@ -519,27 +503,13 @@ function SettingsDialogInner({
 
   const tabTitles: Record<SettingsTab, string> = {
     ...globalTabTitles,
-    "project:general": "General",
-    "project:context": "Context",
-    "project:variables": "Variables",
-    "project:automation": "Worktree Setup",
-    "project:recipes": "Recipes",
-    "project:commands": "Commands",
-    "project:notifications": "Notifications",
-    "project:github": "GitHub",
-  } as Record<SettingsTab, string>;
+    ...projectTabTitles,
+  };
 
   const tabIcons: Record<SettingsTab, React.ReactNode> = {
     ...globalTabIcons,
-    "project:general": <SettingsIcon className="w-5 h-5 text-text-secondary" />,
-    "project:context": <FileCode className="w-5 h-5 text-text-secondary" />,
-    "project:variables": <KeyRound className="w-5 h-5 text-text-secondary" />,
-    "project:automation": <GitBranch className="w-5 h-5 text-text-secondary" />,
-    "project:recipes": <Workflow className="w-5 h-5 text-text-secondary" />,
-    "project:commands": <Command className="w-5 h-5 text-text-secondary" />,
-    "project:notifications": <Bell className="w-5 h-5 text-text-secondary" />,
-    "project:github": <Github className="w-5 h-5 text-text-secondary" />,
-  } as Record<SettingsTab, React.ReactNode>;
+    ...projectTabIcons,
+  };
 
   return (
     <AppDialog
@@ -626,114 +596,27 @@ function SettingsDialogInner({
             aria-label="Settings sections"
             onKeyDown={handleTablistKeyDown}
           >
-            {activeScope === "global" ? (
-              <>
-                {getSettingsNavGroups("global").map((group) => (
-                  <NavGroup key={group.label} label={group.label}>
-                    {group.entries.map((entry) => {
-                      const tabId = entry.id as SettingsTab;
-                      return (
-                        <NavItem
-                          key={entry.id}
-                          tab={tabId}
-                          icon={entry.icon}
-                          label={entry.label}
-                          activeTab={activeTab}
-                          isSearching={isSearching}
-                          matchCount={matchCounts[tabId]}
-                          modified={modifiedTabs.has(tabId)}
-                          hasError={tabsWithErrors.has(tabId)}
-                          onSelect={handleNavSelect}
-                        />
-                      );
-                    })}
-                  </NavGroup>
-                ))}
-              </>
-            ) : (
-              <NavGroup label="Project">
-                <NavItem
-                  tab="project:general"
-                  icon={<SettingsIcon className="w-4 h-4" />}
-                  label="General"
-                  activeTab={activeTab}
-                  isSearching={isSearching}
-                  matchCount={matchCounts["project:general"]}
-                  hasError={tabsWithErrors.has("project:general")}
-                  onSelect={handleNavSelect}
-                />
-                <NavItem
-                  tab="project:context"
-                  icon={<FileCode className="w-4 h-4" />}
-                  label="Context"
-                  activeTab={activeTab}
-                  isSearching={isSearching}
-                  matchCount={matchCounts["project:context"]}
-                  hasError={tabsWithErrors.has("project:context")}
-                  onSelect={handleNavSelect}
-                />
-                <NavItem
-                  tab="project:variables"
-                  icon={<KeyRound className="w-4 h-4" />}
-                  label="Variables"
-                  activeTab={activeTab}
-                  isSearching={isSearching}
-                  matchCount={matchCounts["project:variables"]}
-                  hasError={tabsWithErrors.has("project:variables")}
-                  onSelect={handleNavSelect}
-                />
-                <NavItem
-                  tab="project:automation"
-                  icon={<GitBranch className="w-4 h-4" />}
-                  label="Worktree Setup"
-                  activeTab={activeTab}
-                  isSearching={isSearching}
-                  matchCount={matchCounts["project:automation"]}
-                  hasError={tabsWithErrors.has("project:automation")}
-                  onSelect={handleNavSelect}
-                />
-                <NavItem
-                  tab="project:recipes"
-                  icon={<Workflow className="w-4 h-4" />}
-                  label="Recipes"
-                  activeTab={activeTab}
-                  isSearching={isSearching}
-                  matchCount={matchCounts["project:recipes"]}
-                  hasError={tabsWithErrors.has("project:recipes")}
-                  onSelect={handleNavSelect}
-                />
-                <NavItem
-                  tab="project:commands"
-                  icon={<Command className="w-4 h-4" />}
-                  label="Commands"
-                  activeTab={activeTab}
-                  isSearching={isSearching}
-                  matchCount={matchCounts["project:commands"]}
-                  hasError={tabsWithErrors.has("project:commands")}
-                  onSelect={handleNavSelect}
-                />
-                <NavItem
-                  tab="project:notifications"
-                  icon={<Bell className="w-4 h-4" />}
-                  label="Notifications"
-                  activeTab={activeTab}
-                  isSearching={isSearching}
-                  matchCount={matchCounts["project:notifications"]}
-                  hasError={tabsWithErrors.has("project:notifications")}
-                  onSelect={handleNavSelect}
-                />
-                <NavItem
-                  tab="project:github"
-                  icon={<Github className="w-4 h-4" />}
-                  label="GitHub"
-                  activeTab={activeTab}
-                  isSearching={isSearching}
-                  matchCount={matchCounts["project:github"]}
-                  hasError={tabsWithErrors.has("project:github")}
-                  onSelect={handleNavSelect}
-                />
+            {getSettingsNavGroups(activeScope).map((group) => (
+              <NavGroup key={group.label} label={group.label}>
+                {group.entries.map((entry) => {
+                  const tabId = entry.id as SettingsTab;
+                  return (
+                    <NavItem
+                      key={entry.id}
+                      tab={tabId}
+                      icon={entry.icon}
+                      label={entry.label}
+                      activeTab={activeTab}
+                      isSearching={isSearching}
+                      matchCount={matchCounts[tabId]}
+                      modified={modifiedTabs.has(tabId)}
+                      hasError={tabsWithErrors.has(tabId)}
+                      onSelect={handleNavSelect}
+                    />
+                  );
+                })}
               </NavGroup>
-            )}
+            ))}
           </ScrollShadow>
 
           <div className="pt-2 mt-2 border-t border-daintree-border px-2">
@@ -819,7 +702,7 @@ function SettingsDialogInner({
                     </button>
                   </div>
                 )}
-                {SETTINGS_REGISTRY.map((entry) => {
+                {SETTINGS_REGISTRY.filter((e) => e.scope === "global").map((entry) => {
                   const tabId = entry.id as SettingsTab;
                   const isActive = activeTab === tabId;
                   return (
@@ -896,256 +779,39 @@ function SettingsDialogInner({
                         {projectForm.projectAutoSaveError}
                       </div>
                     )}
-                    {!projectForm.projectIsLoading && !projectForm.projectError && (
-                      <>
-                        <div
-                          role="tabpanel"
-                          id="settings-panel-project:general"
-                          aria-labelledby="settings-tab-project:general"
-                          tabIndex={0}
-                          className={activeTab === "project:general" ? "" : "hidden"}
-                        >
-                          {visitedTabs.has("project:general") && (
-                            <>
-                              <ProjectGeneralTab
-                                currentProject={projectForm.currentProject}
-                                name={projectForm.projectName}
-                                onNameChange={projectForm.setProjectName}
-                                emoji={projectForm.projectEmoji}
-                                onEmojiChange={projectForm.setProjectEmoji}
-                                color={projectForm.projectColor}
-                                onColorChange={projectForm.setProjectColor}
-                                devServerCommand={projectForm.devServerCommand}
-                                onDevServerCommandChange={projectForm.setDevServerCommand}
-                                devServerLoadTimeout={projectForm.devServerLoadTimeout}
-                                onDevServerLoadTimeoutChange={projectForm.setDevServerLoadTimeout}
-                                turbopackEnabled={projectForm.turbopackEnabled}
-                                onTurbopackEnabledChange={projectForm.setTurbopackEnabled}
-                                daintreeMcpTier={projectForm.daintreeMcpTier}
-                                onDaintreeMcpTierChange={projectForm.setDaintreeMcpTier}
-                                projectIconSvg={projectForm.projectIconSvg}
-                                onProjectIconSvgChange={projectForm.setProjectIconSvg}
-                                enableInRepoSettings={projectForm.enableInRepoSettings}
-                                disableInRepoSettings={projectForm.disableInRepoSettings}
-                                projectId={projectId}
-                                isOpen={isOpen}
-                              />
-                              <SettingsTabScrollEffect
-                                isActive={activeTab === "project:general" && !isSearching}
-                                scrollToSectionId={scrollToSection}
-                                onScrollToSectionHandled={handleScrollToSectionHandled}
-                              />
-                            </>
-                          )}
-                        </div>
-
-                        <div
-                          role="tabpanel"
-                          id="settings-panel-project:context"
-                          aria-labelledby="settings-tab-project:context"
-                          tabIndex={0}
-                          className={activeTab === "project:context" ? "" : "hidden"}
-                        >
-                          {visitedTabs.has("project:context") && (
-                            <>
-                              <ProjectContextTab
-                                excludedPaths={projectForm.excludedPaths}
-                                onExcludedPathsChange={projectForm.setExcludedPaths}
-                                copyTreeSettings={projectForm.copyTreeSettings}
-                                onCopyTreeSettingsChange={projectForm.setCopyTreeSettings}
-                                worktrees={projectForm.worktrees}
-                                isOpen={isOpen}
-                              />
-                              <SettingsTabScrollEffect
-                                isActive={activeTab === "project:context" && !isSearching}
-                                scrollToSectionId={scrollToSection}
-                                onScrollToSectionHandled={handleScrollToSectionHandled}
-                              />
-                            </>
-                          )}
-                        </div>
-
-                        <div
-                          role="tabpanel"
-                          id="settings-panel-project:variables"
-                          aria-labelledby="settings-tab-project:variables"
-                          tabIndex={0}
-                          className={activeTab === "project:variables" ? "" : "hidden"}
-                        >
-                          {visitedTabs.has("project:variables") && (
-                            <>
-                              <EnvironmentVariablesEditor
-                                environmentVariables={projectForm.environmentVariables}
-                                onEnvironmentVariablesChange={projectForm.setEnvironmentVariables}
-                                settings={projectForm.projectSettings}
-                                isOpen={isOpen}
-                                onFlush={projectForm.flush}
-                                projectLabel={projectLabel}
-                                globalEnvironmentVariables={globalEnvVars}
-                              />
-                              <SettingsTabScrollEffect
-                                isActive={activeTab === "project:variables" && !isSearching}
-                                scrollToSectionId={scrollToSection}
-                                onScrollToSectionHandled={handleScrollToSectionHandled}
-                              />
-                            </>
-                          )}
-                        </div>
-
-                        <div
-                          role="tabpanel"
-                          id="settings-panel-project:automation"
-                          aria-labelledby="settings-tab-project:automation"
-                          tabIndex={0}
-                          className={activeTab === "project:automation" ? "" : "hidden"}
-                        >
-                          {visitedTabs.has("project:automation") && (
-                            <>
-                              <ProjectAutomationTab
-                                currentProject={projectForm.currentProject}
-                                runCommands={projectForm.runCommands}
-                                onRunCommandsChange={projectForm.setRunCommands}
-                                defaultWorktreeRecipeId={projectForm.defaultWorktreeRecipeId}
-                                onDefaultWorktreeRecipeIdChange={
-                                  projectForm.setDefaultWorktreeRecipeId
-                                }
-                                branchPrefixMode={projectForm.branchPrefixMode}
-                                onBranchPrefixModeChange={projectForm.setBranchPrefixMode}
-                                branchPrefixCustom={projectForm.branchPrefixCustom}
-                                onBranchPrefixCustomChange={projectForm.setBranchPrefixCustom}
-                                worktreePathPattern={projectForm.worktreePathPattern}
-                                onWorktreePathPatternChange={projectForm.setWorktreePathPattern}
-                                terminalShell={projectForm.terminalShell}
-                                onTerminalShellChange={projectForm.setTerminalShell}
-                                terminalShellArgs={projectForm.terminalShellArgs}
-                                onTerminalShellArgsChange={projectForm.setTerminalShellArgs}
-                                terminalDefaultCwd={projectForm.terminalDefaultCwd}
-                                onTerminalDefaultCwdChange={projectForm.setTerminalDefaultCwd}
-                                terminalScrollback={projectForm.terminalScrollback}
-                                onTerminalScrollbackChange={projectForm.setTerminalScrollback}
-                                recipes={projectForm.recipes}
-                                recipesLoading={projectForm.recipesLoading}
-                                onNavigateToRecipes={() => {
-                                  markTabVisited("project:recipes");
-                                  startTransition(() => setActiveTab("project:recipes"));
-                                }}
-                                resourceEnvironments={projectForm.resourceEnvironments}
-                                onResourceEnvironmentsChange={projectForm.setResourceEnvironments}
-                                activeResourceEnvironment={projectForm.activeResourceEnvironment}
-                                onActiveResourceEnvironmentChange={
-                                  projectForm.setActiveResourceEnvironment
-                                }
-                                defaultWorktreeMode={projectForm.defaultWorktreeMode}
-                                onDefaultWorktreeModeChange={projectForm.setDefaultWorktreeMode}
-                                isOpen={isOpen}
-                              />
-                              <SettingsTabScrollEffect
-                                isActive={activeTab === "project:automation" && !isSearching}
-                                scrollToSectionId={scrollToSection}
-                                onScrollToSectionHandled={handleScrollToSectionHandled}
-                              />
-                            </>
-                          )}
-                        </div>
-
-                        <div
-                          role="tabpanel"
-                          id="settings-panel-project:recipes"
-                          aria-labelledby="settings-tab-project:recipes"
-                          tabIndex={0}
-                          className={activeTab === "project:recipes" ? "" : "hidden"}
-                        >
-                          {visitedTabs.has("project:recipes") && (
-                            <>
-                              <ProjectRecipesTab
-                                projectId={projectId}
-                                defaultWorktreeRecipeId={projectForm.defaultWorktreeRecipeId}
-                                onDefaultWorktreeRecipeIdChange={
-                                  projectForm.setDefaultWorktreeRecipeId
-                                }
-                                worktreeMap={projectForm.worktreeMap}
-                                isOpen={isOpen}
-                              />
-                              <SettingsTabScrollEffect
-                                isActive={activeTab === "project:recipes" && !isSearching}
-                                scrollToSectionId={scrollToSection}
-                                onScrollToSectionHandled={handleScrollToSectionHandled}
-                              />
-                            </>
-                          )}
-                        </div>
-
-                        <div
-                          role="tabpanel"
-                          id="settings-panel-project:commands"
-                          aria-labelledby="settings-tab-project:commands"
-                          tabIndex={0}
-                          className={activeTab === "project:commands" ? "" : "hidden"}
-                        >
-                          {visitedTabs.has("project:commands") && (
-                            <>
-                              <CommandOverridesTab
-                                projectId={projectId}
-                                overrides={projectForm.commandOverrides}
-                                onChange={projectForm.setCommandOverrides}
-                              />
-                              <SettingsTabScrollEffect
-                                isActive={activeTab === "project:commands" && !isSearching}
-                                scrollToSectionId={scrollToSection}
-                                onScrollToSectionHandled={handleScrollToSectionHandled}
-                              />
-                            </>
-                          )}
-                        </div>
-
-                        <div
-                          role="tabpanel"
-                          id="settings-panel-project:notifications"
-                          aria-labelledby="settings-tab-project:notifications"
-                          tabIndex={0}
-                          className={activeTab === "project:notifications" ? "" : "hidden"}
-                        >
-                          {visitedTabs.has("project:notifications") && (
-                            <>
-                              <ProjectNotificationsTab
-                                overrides={projectForm.notificationOverrides}
-                                onChange={projectForm.setNotificationOverrides}
-                              />
-                              <SettingsTabScrollEffect
-                                isActive={activeTab === "project:notifications" && !isSearching}
-                                scrollToSectionId={scrollToSection}
-                                onScrollToSectionHandled={handleScrollToSectionHandled}
-                              />
-                            </>
-                          )}
-                        </div>
-
-                        <div
-                          role="tabpanel"
-                          id="settings-panel-project:github"
-                          aria-labelledby="settings-tab-project:github"
-                          tabIndex={0}
-                          className={activeTab === "project:github" ? "" : "hidden"}
-                        >
-                          {visitedTabs.has("project:github") && (
-                            <>
-                              {projectForm.currentProject && (
-                                <ProjectGitHubTab
-                                  githubRemote={projectForm.githubRemote}
-                                  onGithubRemoteChange={projectForm.setGithubRemote}
-                                  projectPath={projectForm.currentProject.path}
+                    {!projectForm.projectIsLoading &&
+                      !projectForm.projectError &&
+                      SETTINGS_REGISTRY.filter((e) => e.scope === "project").map((entry) => {
+                        const tabId = entry.id as SettingsTab;
+                        const isActive = activeTab === tabId;
+                        return (
+                          <div
+                            key={entry.id}
+                            role="tabpanel"
+                            id={`settings-panel-${entry.id}`}
+                            aria-labelledby={`settings-tab-${entry.id}`}
+                            tabIndex={0}
+                            className={isActive ? "" : "hidden"}
+                          >
+                            {visitedTabs.has(tabId) && (
+                              <Suspense fallback={null}>
+                                <ProjectFormTabContent
+                                  entry={entry as LazySettingsTabEntry}
+                                  projectForm={projectForm}
+                                  projectId={projectId}
+                                  isOpen={isOpen}
+                                  globalEnvVars={globalEnvVars}
+                                  projectLabel={projectLabel}
+                                  onNavigateToTab={handleNavSelect}
+                                  isActive={isActive && !isSearching}
+                                  scrollToSectionId={scrollToSection}
+                                  onScrollToSectionHandled={handleScrollToSectionHandled}
                                 />
-                              )}
-                              <SettingsTabScrollEffect
-                                isActive={activeTab === "project:github" && !isSearching}
-                                scrollToSectionId={scrollToSection}
-                                onScrollToSectionHandled={handleScrollToSectionHandled}
-                              />
-                            </>
-                          )}
-                        </div>
-                      </>
-                    )}
+                              </Suspense>
+                            )}
+                          </div>
+                        );
+                      })}
                   </>
                 )}
               </>
@@ -1201,6 +867,163 @@ function LazyTabContent({
 
   const LazyComp = entry.LazyComponent;
   return <LazyComp {...props} />;
+}
+
+function ProjectFormTabContent({
+  entry,
+  projectForm,
+  projectId,
+  isOpen,
+  globalEnvVars,
+  projectLabel,
+  onNavigateToTab,
+  isActive,
+  scrollToSectionId,
+  onScrollToSectionHandled,
+}: {
+  entry: LazySettingsTabEntry;
+  projectForm: ProjectSettingsFormContext;
+  projectId: string;
+  isOpen: boolean;
+  globalEnvVars: Record<string, string>;
+  projectLabel: string;
+  onNavigateToTab: (tab: SettingsTab) => void;
+  isActive: boolean;
+  scrollToSectionId: string | null;
+  onScrollToSectionHandled: (id: string) => void;
+}) {
+  useSettingsScrollToSection(isActive, scrollToSectionId, onScrollToSectionHandled);
+
+  const LazyComp = entry.LazyComponent;
+
+  switch (entry.id) {
+    case "project:general":
+      return (
+        <LazyComp
+          currentProject={projectForm.currentProject}
+          name={projectForm.projectName}
+          onNameChange={projectForm.setProjectName}
+          emoji={projectForm.projectEmoji}
+          onEmojiChange={projectForm.setProjectEmoji}
+          color={projectForm.projectColor}
+          onColorChange={projectForm.setProjectColor}
+          devServerCommand={projectForm.devServerCommand}
+          onDevServerCommandChange={projectForm.setDevServerCommand}
+          devServerLoadTimeout={projectForm.devServerLoadTimeout}
+          onDevServerLoadTimeoutChange={projectForm.setDevServerLoadTimeout}
+          turbopackEnabled={projectForm.turbopackEnabled}
+          onTurbopackEnabledChange={projectForm.setTurbopackEnabled}
+          daintreeMcpTier={projectForm.daintreeMcpTier}
+          onDaintreeMcpTierChange={projectForm.setDaintreeMcpTier}
+          projectIconSvg={projectForm.projectIconSvg}
+          onProjectIconSvgChange={projectForm.setProjectIconSvg}
+          enableInRepoSettings={projectForm.enableInRepoSettings}
+          disableInRepoSettings={projectForm.disableInRepoSettings}
+          projectId={projectId}
+          isOpen={isOpen}
+        />
+      );
+
+    case "project:context":
+      return (
+        <LazyComp
+          excludedPaths={projectForm.excludedPaths}
+          onExcludedPathsChange={projectForm.setExcludedPaths}
+          copyTreeSettings={projectForm.copyTreeSettings}
+          onCopyTreeSettingsChange={projectForm.setCopyTreeSettings}
+          worktrees={projectForm.worktrees}
+          isOpen={isOpen}
+        />
+      );
+
+    case "project:variables":
+      return (
+        <LazyComp
+          environmentVariables={projectForm.environmentVariables}
+          onEnvironmentVariablesChange={projectForm.setEnvironmentVariables}
+          settings={projectForm.projectSettings}
+          isOpen={isOpen}
+          onFlush={projectForm.flush}
+          projectLabel={projectLabel}
+          globalEnvironmentVariables={globalEnvVars}
+        />
+      );
+
+    case "project:automation":
+      return (
+        <LazyComp
+          currentProject={projectForm.currentProject}
+          runCommands={projectForm.runCommands}
+          onRunCommandsChange={projectForm.setRunCommands}
+          defaultWorktreeRecipeId={projectForm.defaultWorktreeRecipeId}
+          onDefaultWorktreeRecipeIdChange={projectForm.setDefaultWorktreeRecipeId}
+          branchPrefixMode={projectForm.branchPrefixMode}
+          onBranchPrefixModeChange={projectForm.setBranchPrefixMode}
+          branchPrefixCustom={projectForm.branchPrefixCustom}
+          onBranchPrefixCustomChange={projectForm.setBranchPrefixCustom}
+          worktreePathPattern={projectForm.worktreePathPattern}
+          onWorktreePathPatternChange={projectForm.setWorktreePathPattern}
+          terminalShell={projectForm.terminalShell}
+          onTerminalShellChange={projectForm.setTerminalShell}
+          terminalShellArgs={projectForm.terminalShellArgs}
+          onTerminalShellArgsChange={projectForm.setTerminalShellArgs}
+          terminalDefaultCwd={projectForm.terminalDefaultCwd}
+          onTerminalDefaultCwdChange={projectForm.setTerminalDefaultCwd}
+          terminalScrollback={projectForm.terminalScrollback}
+          onTerminalScrollbackChange={projectForm.setTerminalScrollback}
+          recipes={projectForm.recipes}
+          recipesLoading={projectForm.recipesLoading}
+          onNavigateToRecipes={() => onNavigateToTab("project:recipes")}
+          resourceEnvironments={projectForm.resourceEnvironments}
+          onResourceEnvironmentsChange={projectForm.setResourceEnvironments}
+          activeResourceEnvironment={projectForm.activeResourceEnvironment}
+          onActiveResourceEnvironmentChange={projectForm.setActiveResourceEnvironment}
+          defaultWorktreeMode={projectForm.defaultWorktreeMode}
+          onDefaultWorktreeModeChange={projectForm.setDefaultWorktreeMode}
+          isOpen={isOpen}
+        />
+      );
+
+    case "project:recipes":
+      return (
+        <LazyComp
+          projectId={projectId}
+          defaultWorktreeRecipeId={projectForm.defaultWorktreeRecipeId}
+          onDefaultWorktreeRecipeIdChange={projectForm.setDefaultWorktreeRecipeId}
+          worktreeMap={projectForm.worktreeMap}
+          isOpen={isOpen}
+        />
+      );
+
+    case "project:commands":
+      return (
+        <LazyComp
+          projectId={projectId}
+          overrides={projectForm.commandOverrides}
+          onChange={projectForm.setCommandOverrides}
+        />
+      );
+
+    case "project:notifications":
+      return (
+        <LazyComp
+          overrides={projectForm.notificationOverrides}
+          onChange={projectForm.setNotificationOverrides}
+        />
+      );
+
+    case "project:github":
+      return (
+        <LazyComp
+          githubRemote={projectForm.githubRemote}
+          onGithubRemoteChange={projectForm.setGithubRemote}
+          projectPath={projectForm.currentProject?.path}
+        />
+      );
+
+    default:
+      return null;
+  }
 }
 
 // Scrolls to the section with the given DOM id, focuses the first input

--- a/src/components/Settings/SettingsDialog.tsx
+++ b/src/components/Settings/SettingsDialog.tsx
@@ -1022,6 +1022,13 @@ function ProjectFormTabContent({
       );
 
     default:
+      // A project-scope registry entry exists but ProjectFormTabContent has no
+      // matching case. Surfaces silent-null bugs when entries are added without
+      // a renderer mapping.
+      logError(
+        "ProjectFormTabContent: no renderer for project tab",
+        new Error(`Unhandled project settings tab id: ${entry.id}`)
+      );
       return null;
   }
 }

--- a/src/components/Settings/__tests__/settingsTabRegistry.test.ts
+++ b/src/components/Settings/__tests__/settingsTabRegistry.test.ts
@@ -3,16 +3,32 @@ import {
   SETTINGS_REGISTRY,
   globalTabTitles,
   globalTabIcons,
+  projectTabTitles,
+  projectTabIcons,
   PROJECT_TAB_IDS,
   scopeForTab,
   isSettingsTab,
   getSettingsNavGroups,
+  type AnySettingsTabEntry,
+  type LazySettingsTabEntry,
   type SettingsTab,
 } from "../settingsTabRegistry";
 
+const allEntries: readonly AnySettingsTabEntry[] = SETTINGS_REGISTRY;
+const globalEntries = allEntries.filter((e) => e.scope === "global");
+const projectEntries = allEntries.filter((e) => e.scope === "project");
+
 describe("SETTINGS_REGISTRY", () => {
-  it("has 17 entries (all global tabs)", () => {
-    expect(SETTINGS_REGISTRY).toHaveLength(17);
+  it("has 25 entries (17 global + 8 project)", () => {
+    expect(SETTINGS_REGISTRY).toHaveLength(25);
+  });
+
+  it("has 17 global entries", () => {
+    expect(globalEntries).toHaveLength(17);
+  });
+
+  it("has 8 project entries", () => {
+    expect(projectEntries).toHaveLength(8);
   });
 
   it("has no duplicate tab IDs", () => {
@@ -20,9 +36,21 @@ describe("SETTINGS_REGISTRY", () => {
     expect(new Set(ids).size).toBe(ids.length);
   });
 
-  it("all entries have scope 'global'", () => {
-    for (const entry of SETTINGS_REGISTRY) {
+  it("all global entries have scope 'global'", () => {
+    for (const entry of globalEntries) {
       expect(entry.scope).toBe("global");
+    }
+  });
+
+  it("all project entries have scope 'project'", () => {
+    for (const entry of projectEntries) {
+      expect(entry.scope).toBe("project");
+    }
+  });
+
+  it("all project entry IDs start with 'project:'", () => {
+    for (const entry of projectEntries) {
+      expect(entry.id.startsWith("project:")).toBe(true);
     }
   });
 
@@ -49,42 +77,79 @@ describe("SETTINGS_REGISTRY", () => {
     expect(eager[0]!.id).toBe("general");
   });
 
-  it("has 16 lazy entries", () => {
+  it("has 24 lazy entries (16 global + 8 project)", () => {
     const lazy = SETTINGS_REGISTRY.filter((e) => e.importKind === "lazy");
-    expect(lazy).toHaveLength(16);
+    expect(lazy).toHaveLength(24);
   });
 
-  it("all entries belong to known groups", () => {
+  it("all global entries belong to known global groups", () => {
     const knownGroups = ["General", "Terminal", "Assistant", "Integrations", "Support"];
-    for (const entry of SETTINGS_REGISTRY) {
+    for (const entry of globalEntries) {
       expect(knownGroups).toContain(entry.group);
     }
   });
 
-  it("globalTabTitles covers all registry entries", () => {
-    for (const entry of SETTINGS_REGISTRY) {
+  it("all project entries belong to the 'Project' group", () => {
+    for (const entry of projectEntries) {
+      expect(entry.group).toBe("Project");
+    }
+  });
+
+  it("globalTabTitles covers all global registry entries", () => {
+    for (const entry of globalEntries) {
       expect(globalTabTitles).toHaveProperty(entry.id);
       expect(typeof globalTabTitles[entry.id as keyof typeof globalTabTitles]).toBe("string");
     }
   });
 
-  it("globalTabIcons covers all registry entries", () => {
-    for (const entry of SETTINGS_REGISTRY) {
+  it("globalTabIcons covers all global registry entries", () => {
+    for (const entry of globalEntries) {
       expect(globalTabIcons).toHaveProperty(entry.id);
     }
   });
 
-  it("does not contain project tab IDs", () => {
-    const registryIds = new Set(SETTINGS_REGISTRY.map((e) => e.id));
-    for (const id of PROJECT_TAB_IDS) {
-      expect(registryIds.has(id)).toBe(false);
+  it("projectTabTitles covers all project registry entries", () => {
+    for (const entry of projectEntries) {
+      expect(projectTabTitles).toHaveProperty(entry.id);
+      expect(typeof projectTabTitles[entry.id as keyof typeof projectTabTitles]).toBe("string");
+    }
+  });
+
+  it("projectTabIcons covers all project registry entries", () => {
+    for (const entry of projectEntries) {
+      expect(projectTabIcons).toHaveProperty(entry.id);
+    }
+  });
+
+  it("project entries are all flagged needsProjectForm", () => {
+    for (const entry of projectEntries) {
+      if (entry.importKind === "lazy") {
+        expect((entry as LazySettingsTabEntry).needsProjectForm).toBe(true);
+      }
+    }
+  });
+
+  it("project:automation declares needsOnNavigateToTab", () => {
+    const automation = allEntries.find((e) => e.id === "project:automation");
+    expect(automation).toBeDefined();
+    if (automation && automation.importKind === "lazy") {
+      expect((automation as LazySettingsTabEntry).needsOnNavigateToTab).toBe(true);
+    }
+  });
+
+  it("global entries do not declare needsProjectForm", () => {
+    for (const entry of globalEntries) {
+      if (entry.importKind === "lazy") {
+        expect((entry as LazySettingsTabEntry).needsProjectForm).toBeFalsy();
+      }
     }
   });
 });
 
 describe("PROJECT_TAB_IDS", () => {
-  it("has 8 entries", () => {
+  it("has 8 entries matching the project registry", () => {
     expect(PROJECT_TAB_IDS).toHaveLength(8);
+    expect([...PROJECT_TAB_IDS].sort()).toEqual(projectEntries.map((e) => e.id).sort());
   });
 
   it("all start with 'project:'", () => {
@@ -100,7 +165,7 @@ describe("PROJECT_TAB_IDS", () => {
 
 describe("scopeForTab", () => {
   it('returns "global" for global tabs', () => {
-    for (const entry of SETTINGS_REGISTRY) {
+    for (const entry of globalEntries) {
       expect(scopeForTab(entry.id as SettingsTab)).toBe("global");
     }
   });
@@ -137,7 +202,7 @@ describe("getSettingsNavGroups", () => {
     expect(groups).toHaveLength(5);
   });
 
-  it("returns groups in correct order", () => {
+  it("returns global groups in correct order", () => {
     const groups = getSettingsNavGroups("global");
     expect(groups.map((g) => g.label)).toEqual([
       "General",
@@ -148,23 +213,48 @@ describe("getSettingsNavGroups", () => {
     ]);
   });
 
-  it("all 17 entries are distributed across global groups", () => {
+  it("all 17 global entries are distributed across global groups", () => {
     const groups = getSettingsNavGroups("global");
     const totalEntries = groups.reduce((sum, g) => sum + g.entries.length, 0);
     expect(totalEntries).toBe(17);
   });
 
-  it("returns single Project group for project scope", () => {
+  it("global groups contain only global-scoped entries", () => {
+    const groups = getSettingsNavGroups("global");
+    for (const group of groups) {
+      for (const entry of group.entries) {
+        expect(entry.scope).toBe("global");
+      }
+    }
+  });
+
+  it("returns single Project group for project scope with 8 entries", () => {
     const groups = getSettingsNavGroups("project");
     expect(groups).toHaveLength(1);
     expect(groups[0]!.label).toBe("Project");
     expect(groups[0]!.scope).toBe("project");
+    expect(groups[0]!.entries).toHaveLength(8);
+  });
+
+  it("project group entries match the registry order", () => {
+    const groups = getSettingsNavGroups("project");
+    const expectedOrder = [
+      "project:general",
+      "project:context",
+      "project:variables",
+      "project:automation",
+      "project:recipes",
+      "project:commands",
+      "project:notifications",
+      "project:github",
+    ];
+    expect(groups[0]!.entries.map((e) => e.id)).toEqual(expectedOrder);
   });
 });
 
 describe("SettingsTab type coverage", () => {
-  it("union of registry IDs + project tab IDs equals 25", () => {
-    const allIds = new Set([...SETTINGS_REGISTRY.map((e) => e.id), ...PROJECT_TAB_IDS]);
+  it("union of registry IDs equals 25", () => {
+    const allIds = new Set(SETTINGS_REGISTRY.map((e) => e.id));
     expect(allIds.size).toBe(25);
   });
 });

--- a/src/components/Settings/settingsTabRegistry.tsx
+++ b/src/components/Settings/settingsTabRegistry.tsx
@@ -1,6 +1,9 @@
 import { lazy, type ReactNode } from "react";
 import {
   Blocks,
+  Command,
+  FileCode,
+  GitBranch,
   Github,
   LayoutGrid,
   Mic,
@@ -14,7 +17,7 @@ import {
   KeyRound,
   Shield,
 } from "lucide-react";
-import { DaintreeIcon, FolderGit2, Plug, McpServerIcon } from "@/components/icons";
+import { DaintreeIcon, FolderGit2, Plug, McpServerIcon, Workflow } from "@/components/icons";
 import { BUILT_IN_AGENT_IDS } from "@shared/config/agentIds";
 import { AGENT_REGISTRY } from "@shared/config/agentRegistry";
 import { GeneralTab } from "./GeneralTab";
@@ -59,6 +62,8 @@ export interface LazySettingsTabEntry extends SettingsTabEntry {
   readonly needsSubtabs?: boolean;
   readonly needsOnClose?: boolean;
   readonly needsOnSettingsChange?: boolean;
+  readonly needsProjectForm?: boolean;
+  readonly needsOnNavigateToTab?: boolean;
 }
 
 export interface EagerSettingsTabEntry extends SettingsTabEntry {
@@ -93,6 +98,14 @@ const importMcpServerSettingsTab = () => import("./McpServerSettingsTab");
 const importDaintreeAssistantSettingsTab = () => import("./DaintreeAssistantSettingsTab");
 const importEnvironmentSettingsTab = () => import("./EnvironmentSettingsTab");
 const importPrivacyDataTab = () => import("./PrivacyDataTab");
+const importProjectGeneralTab = () => import("@/components/Project/GeneralTab");
+const importProjectContextTab = () => import("@/components/Project/ContextTab");
+const importProjectVariablesTab = () => import("@/components/Project/EnvironmentVariablesEditor");
+const importProjectAutomationTab = () => import("@/components/Project/AutomationTab");
+const importProjectRecipesTab = () => import("@/components/Project/RecipesTab");
+const importProjectCommandsTab = () => import("./CommandOverridesTab");
+const importProjectNotificationsTab = () => import("@/components/Project/ProjectNotificationsTab");
+const importProjectGitHubTab = () => import("@/components/Project/GitHubTab");
 
 // ── Lazy components (module-level — React requires stable lazy() refs) ──
 
@@ -143,6 +156,30 @@ const LazyEnvironmentSettingsTab = lazy(() =>
 );
 const LazyPrivacyDataTab = lazy(() =>
   importPrivacyDataTab().then((m) => ({ default: m.PrivacyDataTab }))
+);
+const LazyProjectGeneralTab = lazy(() =>
+  importProjectGeneralTab().then((m) => ({ default: m.GeneralTab }))
+);
+const LazyProjectContextTab = lazy(() =>
+  importProjectContextTab().then((m) => ({ default: m.ContextTab }))
+);
+const LazyProjectVariablesTab = lazy(() =>
+  importProjectVariablesTab().then((m) => ({ default: m.EnvironmentVariablesEditor }))
+);
+const LazyProjectAutomationTab = lazy(() =>
+  importProjectAutomationTab().then((m) => ({ default: m.AutomationTab }))
+);
+const LazyProjectRecipesTab = lazy(() =>
+  importProjectRecipesTab().then((m) => ({ default: m.RecipesTab }))
+);
+const LazyProjectCommandsTab = lazy(() =>
+  importProjectCommandsTab().then((m) => ({ default: m.CommandOverridesTab }))
+);
+const LazyProjectNotificationsTab = lazy(() =>
+  importProjectNotificationsTab().then((m) => ({ default: m.ProjectNotificationsTab }))
+);
+const LazyProjectGitHubTab = lazy(() =>
+  importProjectGitHubTab().then((m) => ({ default: m.GitHubTab }))
 );
 
 // ── Voice requiresEnabled gates (referenced repeatedly) ─────────────────
@@ -1348,23 +1385,113 @@ export const SETTINGS_REGISTRY = [
       },
     ],
   } satisfies LazySettingsTabEntry,
+
+  // ═══ Project — Project ═══
+  {
+    id: "project:general",
+    scope: "project",
+    group: "Project",
+    label: "General",
+    icon: <SettingsIcon className="w-4 h-4" />,
+    importKind: "lazy",
+    importer: importProjectGeneralTab,
+    LazyComponent: LazyProjectGeneralTab,
+    needsProjectForm: true,
+  } satisfies LazySettingsTabEntry,
+
+  {
+    id: "project:context",
+    scope: "project",
+    group: "Project",
+    label: "Context",
+    icon: <FileCode className="w-4 h-4" />,
+    importKind: "lazy",
+    importer: importProjectContextTab,
+    LazyComponent: LazyProjectContextTab,
+    needsProjectForm: true,
+  } satisfies LazySettingsTabEntry,
+
+  {
+    id: "project:variables",
+    scope: "project",
+    group: "Project",
+    label: "Variables",
+    icon: <KeyRound className="w-4 h-4" />,
+    importKind: "lazy",
+    importer: importProjectVariablesTab,
+    LazyComponent: LazyProjectVariablesTab,
+    needsProjectForm: true,
+  } satisfies LazySettingsTabEntry,
+
+  {
+    id: "project:automation",
+    scope: "project",
+    group: "Project",
+    label: "Worktree Setup",
+    icon: <GitBranch className="w-4 h-4" />,
+    importKind: "lazy",
+    importer: importProjectAutomationTab,
+    LazyComponent: LazyProjectAutomationTab,
+    needsProjectForm: true,
+    needsOnNavigateToTab: true,
+  } satisfies LazySettingsTabEntry,
+
+  {
+    id: "project:recipes",
+    scope: "project",
+    group: "Project",
+    label: "Recipes",
+    icon: <Workflow className="w-4 h-4" />,
+    importKind: "lazy",
+    importer: importProjectRecipesTab,
+    LazyComponent: LazyProjectRecipesTab,
+    needsProjectForm: true,
+  } satisfies LazySettingsTabEntry,
+
+  {
+    id: "project:commands",
+    scope: "project",
+    group: "Project",
+    label: "Commands",
+    icon: <Command className="w-4 h-4" />,
+    importKind: "lazy",
+    importer: importProjectCommandsTab,
+    LazyComponent: LazyProjectCommandsTab,
+    needsProjectForm: true,
+  } satisfies LazySettingsTabEntry,
+
+  {
+    id: "project:notifications",
+    scope: "project",
+    group: "Project",
+    label: "Notifications",
+    icon: <Bell className="w-4 h-4" />,
+    importKind: "lazy",
+    importer: importProjectNotificationsTab,
+    LazyComponent: LazyProjectNotificationsTab,
+    needsProjectForm: true,
+  } satisfies LazySettingsTabEntry,
+
+  {
+    id: "project:github",
+    scope: "project",
+    group: "Project",
+    label: "GitHub",
+    icon: <Github className="w-4 h-4" />,
+    importKind: "lazy",
+    importer: importProjectGitHubTab,
+    LazyComponent: LazyProjectGitHubTab,
+    needsProjectForm: true,
+  } satisfies LazySettingsTabEntry,
 ] as const satisfies readonly AnySettingsTabEntry[];
 
-// ── Project tab IDs (not in registry — rendered with unique prop patterns) ─
+// ── Tab id types (derived from registry by scope) ───────────────────────
 
-export const PROJECT_TAB_IDS = [
-  "project:general",
-  "project:context",
-  "project:variables",
-  "project:automation",
-  "project:recipes",
-  "project:commands",
-  "project:notifications",
-  "project:github",
-] as const;
+type ProjectScopedEntry = Extract<(typeof SETTINGS_REGISTRY)[number], { scope: "project" }>;
+type GlobalScopedEntry = Extract<(typeof SETTINGS_REGISTRY)[number], { scope: "global" }>;
 
-export type ProjectSettingsTab = (typeof PROJECT_TAB_IDS)[number];
-export type GlobalSettingsTab = (typeof SETTINGS_REGISTRY)[number]["id"];
+export type ProjectSettingsTab = ProjectScopedEntry["id"];
+export type GlobalSettingsTab = GlobalScopedEntry["id"];
 export type SettingsTab = GlobalSettingsTab | ProjectSettingsTab;
 export type SettingsScope = "global" | "project";
 
@@ -1523,6 +1650,10 @@ export const PROJECT_SETTINGS_SECTIONS: Readonly<
   },
 };
 
+export const PROJECT_TAB_IDS: readonly ProjectSettingsTab[] = SETTINGS_REGISTRY.filter(
+  (e): e is ProjectScopedEntry => e.scope === "project"
+).map((e) => e.id);
+
 // ── Derived maps ────────────────────────────────────────────────────────
 
 const _entryMap = new Map(SETTINGS_REGISTRY.map((e) => [e.id, e]));
@@ -1532,7 +1663,9 @@ export function getSettingsTabEntry(id: string): AnySettingsTabEntry | undefined
 }
 
 export const globalTabTitles = Object.fromEntries(
-  SETTINGS_REGISTRY.map((e: AnySettingsTabEntry) => [e.id, e.headerTitle ?? e.label])
+  (SETTINGS_REGISTRY as readonly AnySettingsTabEntry[])
+    .filter((e) => e.scope === "global")
+    .map((e) => [e.id, e.headerTitle ?? e.label])
 ) as Record<GlobalSettingsTab, string>;
 
 export const globalTabIcons: Record<GlobalSettingsTab, ReactNode> = {
@@ -1555,12 +1688,29 @@ export const globalTabIcons: Record<GlobalSettingsTab, ReactNode> = {
   troubleshooting: <LifeBuoy className="w-5 h-5 text-text-secondary" />,
 };
 
+export const projectTabTitles = Object.fromEntries(
+  (SETTINGS_REGISTRY as readonly AnySettingsTabEntry[])
+    .filter((e) => e.scope === "project")
+    .map((e) => [e.id, e.headerTitle ?? e.label])
+) as Record<ProjectSettingsTab, string>;
+
+export const projectTabIcons: Record<ProjectSettingsTab, ReactNode> = {
+  "project:general": <SettingsIcon className="w-5 h-5 text-text-secondary" />,
+  "project:context": <FileCode className="w-5 h-5 text-text-secondary" />,
+  "project:variables": <KeyRound className="w-5 h-5 text-text-secondary" />,
+  "project:automation": <GitBranch className="w-5 h-5 text-text-secondary" />,
+  "project:recipes": <Workflow className="w-5 h-5 text-text-secondary" />,
+  "project:commands": <Command className="w-5 h-5 text-text-secondary" />,
+  "project:notifications": <Bell className="w-5 h-5 text-text-secondary" />,
+  "project:github": <Github className="w-5 h-5 text-text-secondary" />,
+};
+
 export function scopeForTab(tab: SettingsTab): SettingsScope {
   return tab.startsWith("project:") ? "project" : "global";
 }
 
 export function isSettingsTab(value: string): value is SettingsTab {
-  return _entryMap.has(value) || (PROJECT_TAB_IDS as readonly string[]).includes(value);
+  return _entryMap.has(value);
 }
 
 export function preloadAllSettingsTabs(): void {
@@ -1584,17 +1734,17 @@ const GLOBAL_GROUP_ORDER = ["General", "Terminal", "Assistant", "Integrations", 
 const _globalGroups: SettingsNavGroup[] = GLOBAL_GROUP_ORDER.map((label) => ({
   label,
   scope: "global" as const,
-  entries: SETTINGS_REGISTRY.filter((e) => e.group === label),
+  entries: SETTINGS_REGISTRY.filter((e) => e.scope === "global" && e.group === label),
 })).filter((g) => g.entries.length > 0);
 
-export function getSettingsNavGroups(scope: SettingsScope): SettingsNavGroup[] {
-  if (scope === "global") return _globalGroups;
+const _projectGroups: SettingsNavGroup[] = [
+  {
+    label: "Project",
+    scope: "project" as const,
+    entries: SETTINGS_REGISTRY.filter((e) => e.scope === "project"),
+  },
+].filter((g) => g.entries.length > 0);
 
-  return [
-    {
-      label: "Project",
-      scope: "project",
-      entries: [], // project tabs are not in the registry; rendered separately
-    },
-  ];
+export function getSettingsNavGroups(scope: SettingsScope): SettingsNavGroup[] {
+  return scope === "global" ? _globalGroups : _projectGroups;
 }

--- a/src/hooks/useProjectSettingsForm.ts
+++ b/src/hooks/useProjectSettingsForm.ts
@@ -517,3 +517,5 @@ export function useProjectSettingsForm({ projectId, isOpen }: UseProjectSettings
     flush,
   };
 }
+
+export type ProjectSettingsFormContext = ReturnType<typeof useProjectSettingsForm>;


### PR DESCRIPTION
## Summary

Moves the 8 project-scope settings tabs (`general`, `context`, `variables`, `automation`, `recipes`, `commands`, `notifications`, `github`) into the same `SETTINGS_REGISTRY` the 17 global tabs already use. One render path for both scopes, no more bespoke project block in `SettingsDialog.tsx`.

Resolves #7679.

## Changes

- Added `scope: "project"` entries for all 8 project tabs to `SETTINGS_REGISTRY` with module-level `lazy()` imports.
- Added `needsProjectForm` and `needsOnNavigateToTab` capability flags to `LazySettingsTabEntry`, mirroring the existing `needsSubtabs` / `needsOnClose` / `needsOnSettingsChange` pattern.
- Added a `ProjectFormTabContent` renderer that mirrors `LazyTabContent` and threads `useProjectSettingsForm` into each project tab.
- Replaced the 80-line hand-rolled project nav with the same `getSettingsNavGroups` loop the global tabs use.
- Derived `PROJECT_TAB_IDS`, `projectTabTitles`, and `projectTabIcons` from the registry instead of maintaining them by hand.
- Moved the `currentProject` guard for `project:github` from `SettingsDialog.tsx` into the `GitHubTab` component itself, so it returns `null` when `projectPath` is undefined.
- Exported `ProjectSettingsFormContext = ReturnType<typeof useProjectSettingsForm>` so the renderer can type its props.
- Added a `logError` call in `ProjectFormTabContent`'s `default` case so a registry entry added without a matching switch case surfaces at dev time instead of silently rendering nothing.

Didn't touch `useProjectSettingsForm` itself beyond the type export. Effect ordering in that hook is fragile (lesson from #4958), and this refactor is purely render-layer.

Net change: `SettingsDialog.tsx` -178 lines, `settingsTabRegistry.tsx` +151 lines.

## Test plan

- [x] `npx vitest run src/components/Settings/__tests__/settingsTabRegistry.test.ts` — 35 tests pass. Rewrote the intentional "all entries are global" guards into separate global/project assertions and added coverage for `needsProjectForm`, `needsOnNavigateToTab`, and project group order.
- [x] `npx tsc --noEmit` clean.
- [x] `npm run check` (typecheck + channels + help + lint ratchet + format) clean.
- [x] `npm run build` clean (renderer 14.29s, main 238ms).
- [ ] Manual: open project settings, cycle through all 8 project tabs, confirm form state persists and the `project:automation` → `project:recipes` cross-tab navigation still works.
- [ ] Manual: deep-link to a project tab via `defaultTab` and `defaultSectionId`, confirm scroll-to-section still fires after the lazy chunk hydrates.
