### PR TITLE
fix(terminal): shrink and lower scroll/broadcast pills toward input bar

### DIFF
--- a/src/components/Fleet/FleetDraftingPill.tsx
+++ b/src/components/Fleet/FleetDraftingPill.tsx
@@ -35,22 +35,19 @@ export function FleetDraftingPill(): ReactElement | null {
             aria-label={`Drafting for ${fleetSize} agents`}
             data-testid="fleet-drafting-pill-trigger"
             className={cn(
-              "inline-flex items-center gap-1.5 px-3 py-1.5 rounded-full",
+              "inline-flex items-center gap-1 px-2 py-0.5 rounded-full",
               "bg-category-amber-subtle border border-category-amber-border text-category-amber-text shadow-[var(--theme-shadow-floating)]",
               "text-xs font-medium transition-colors",
               hasVariables && "cursor-pointer hover:bg-category-amber-subtle/80"
             )}
           >
-            <RadioTower className="h-3.5 w-3.5" aria-hidden="true" />
+            <RadioTower className="h-3 w-3" aria-hidden="true" />
             <span>
               Mirroring to {peerCount} {peerCount === 1 ? "peer" : "peers"}
             </span>
             {hasVariables && (
               <ChevronDown
-                className={cn(
-                  "h-3.5 w-3.5 transition-transform duration-150",
-                  open && "rotate-180"
-                )}
+                className={cn("h-3 w-3 transition-transform duration-150", open && "rotate-180")}
                 aria-hidden="true"
               />
             )}

--- a/src/components/Terminal/TerminalPane.tsx
+++ b/src/components/Terminal/TerminalPane.tsx
@@ -949,7 +949,7 @@ function TerminalPaneComponent({
               <TerminalScrollIndicator terminalId={id} />
 
               {isFleetPrimary && (
-                <div className="absolute inset-0 z-30 pointer-events-none flex items-end justify-start pb-4 pl-[14px]">
+                <div className="absolute inset-0 z-30 pointer-events-none flex items-end justify-start pb-1.5 pl-[14px]">
                   <div className="pointer-events-auto">
                     <FleetDraftingPill />
                   </div>

--- a/src/components/Terminal/TerminalScrollIndicator.tsx
+++ b/src/components/Terminal/TerminalScrollIndicator.tsx
@@ -26,11 +26,11 @@ export function TerminalScrollIndicator({ terminalId }: TerminalScrollIndicatorP
   };
 
   return (
-    <div className="absolute inset-0 z-30 pointer-events-none flex items-end justify-end pb-4 pr-[14px]">
+    <div className="absolute inset-0 z-30 pointer-events-none flex items-end justify-end pb-1.5 pr-[14px]">
       <button
         type="button"
         className={cn(
-          "pointer-events-auto flex items-center gap-1.5 px-3 py-1.5 rounded-full",
+          "pointer-events-auto flex items-center gap-1 px-2 py-0.5 rounded-full",
           "bg-daintree-bg/90 border border-daintree-border/40 text-daintree-text shadow-[var(--theme-shadow-floating)]",
           "text-xs font-medium cursor-pointer",
           "hover:bg-daintree-bg hover:border-daintree-border/60",
@@ -42,7 +42,7 @@ export function TerminalScrollIndicator({ terminalId }: TerminalScrollIndicatorP
         onPointerDown={(e) => e.stopPropagation()}
         aria-label="Scroll to latest output"
       >
-        <ChevronDown className="h-3.5 w-3.5" />
+        <ChevronDown className="h-3 w-3" />
         New output below
       </button>
     </div>


### PR DESCRIPTION
## Summary

The two terminal overlay pills — the scroll indicator ("New output below") and the fleet broadcast pill ("Mirroring to N peers") — sat too high and too large above the hybrid input bar, covering more of the terminal than they needed to. This shrinks both and drops them closer to the bar, so they read as small informational chips rather than floating buttons.

Resolves #7650

## Changes

- `FleetDraftingPill.tsx` — reduced padding from `px-3 py-1.5` to `px-2 py-0.5`, gap from `1.5` to `1`, icons from `3.5` to `3`
- `TerminalScrollIndicator.tsx` — same padding/gap/icon reductions, plus bottom padding from `pb-4` to `pb-1.5`
- `TerminalPane.tsx` — fleet broadcast container bottom padding from `pb-4` to `pb-1.5`

## Testing

Visual inspection — both pills now sit just above the input bar and take up less vertical space in the terminal viewport.