### PR TITLE
fix(sidebar): echo search query in filtered-empty title

### DIFF
--- a/src/components/Sidebar/SidebarContent.tsx
+++ b/src/components/Sidebar/SidebarContent.tsx
@@ -73,6 +73,15 @@ function formatButtonTitle(label: string, shortcut?: string | null): string {
   return shortcut ? `${label} (${shortcut})` : label;
 }
 
+const NO_MATCH_QUERY_MAX = 40;
+
+function truncateSearchQuery(trimmedQuery: string) {
+  const codepoints = Array.from(trimmedQuery);
+  return codepoints.length > NO_MATCH_QUERY_MAX
+    ? `${codepoints.slice(0, NO_MATCH_QUERY_MAX).join("")}…`
+    : trimmedQuery;
+}
+
 interface SidebarContentProps {
   onOpenOverview: () => void;
 }
@@ -843,7 +852,11 @@ function SidebarContent({ onOpenOverview }: SidebarContentProps) {
               ) : filteredWorktrees.length === 0 && hasFilters && hasNonMainWorktrees ? (
                 <EmptyState
                   variant="filtered-empty"
-                  title="No matching worktrees"
+                  title={
+                    hasQuery
+                      ? `No matches for "${truncateSearchQuery(query.trim())}"`
+                      : "No matching worktrees"
+                  }
                   action={
                     <button
                       onClick={clearAllFilters}

--- a/src/components/Sidebar/__tests__/SidebarContent.emptyState.test.ts
+++ b/src/components/Sidebar/__tests__/SidebarContent.emptyState.test.ts
@@ -129,7 +129,9 @@ describe("SidebarContent quick-state empty state — issue #6333 (CTA collapsed 
       const branch = source.slice(branchStart, branchEnd);
       expect(branch).toContain("<EmptyState");
       expect(branch).toContain('variant="filtered-empty"');
-      expect(branch).toContain('title="No matching worktrees"');
+      expect(branch).toContain('"No matching worktrees"');
+      expect(branch).toMatch(/hasQuery/);
+      expect(branch).toMatch(/truncateSearchQuery/);
       expect(branch).toMatch(/onClick=\{clearAllFilters\}[\s\S]*?>\s*Clear filters\s*</);
     });
   });


### PR DESCRIPTION
## Summary
- When sidebar search yields no results, the empty state now echoes the query: "No matches for `{query}`"
- Falls back to "No matching worktrees" when filters other than search cause the empty state
- Queries longer than 40 codepoints are truncated with an ellipsis

Resolves #7696

## Changes
- Added `NO_MATCH_QUERY_MAX` constant and `truncateSearchQuery` helper to `SidebarContent.tsx`
- Conditional title in the generic filtered-empty branch based on `hasQuery`
- Updated the source-string test assertion to cover the conditional title branches

## Testing
- All 29 existing empty-state tests pass
- New assertion verifies `hasQuery` and `truncateSearchQuery` references in the rendered output