### PR TITLE
chore(pty-host): mark SharedArrayBuffer transport as future-state dead code

### DIFF
--- a/electron/pty-host.ts
+++ b/electron/pty-host.ts
@@ -322,11 +322,19 @@ ptyManager.on("data", (id: string, data: string | Uint8Array) => {
   }
 
   // PRIORITY 2: SHARED ARRAY BUFFER (Zero-Copy Fallback)
-  // Used when no MessagePort renderer connections are available (e.g., during startup before
-  // port handshake completes). SAB is single-consumer — safe only when one view is reading.
-  // SAB has one shared read pointer, so it is only safe before the app enters
-  // project-view routing. Once a window has an active project context, an
-  // unavailable MessagePort must fall through to IPC rather than the SAB.
+  // FUTURE_SAB: This entire branch is unreachable in production. SharedArrayBuffer
+  // is not supported in Electron UtilityProcess (PtyClient.getSharedBuffers()
+  // returns empty arrays, isSharedBufferEnabled() returns false). The init-buffers
+  // message that populates visualBuffers is only sent from adversarial tests.
+  // Production always routes through the MessagePort path (Priority 1).
+  //
+  // The skeleton is preserved for a potential Worker-thread migration that could
+  // revive the SAB zero-copy data path with per-consumer isolation.
+  //
+  // Original design intent: Used when no MessagePort renderer connections are
+  // available (e.g., during startup before port handshake completes). SAB is
+  // single-consumer — safe only when one view is reading. SAB has one shared
+  // read pointer, so it is only safe before the app enters project-view routing.
   const sabFallbackSafe = windowProjectMap.size === 0;
   if (
     !visualWritten &&

--- a/electron/pty-host/__tests__/backpressure.adversarial.test.ts
+++ b/electron/pty-host/__tests__/backpressure.adversarial.test.ts
@@ -3,8 +3,8 @@ import type { PtyPauseCoordinator } from "../PtyPauseCoordinator.js";
 
 import {
   BackpressureManager,
-  MAX_PENDING_BYTES_PER_TERMINAL,
-  MAX_TOTAL_PENDING_BYTES,
+  FUTURE_SAB_MAX_PENDING_BYTES_PER_TERMINAL,
+  FUTURE_SAB_MAX_TOTAL_PENDING_BYTES,
 } from "../backpressure.js";
 
 type CoordinatorLike = Pick<PtyPauseCoordinator, "pause" | "resume" | "isPaused">;
@@ -41,19 +41,19 @@ describe("BackpressureManager adversarial", () => {
     });
   }
 
-  it("rejects additional pending bytes once MAX_TOTAL_PENDING_BYTES is saturated across terminals", () => {
+  it("rejects additional pending bytes once FUTURE_SAB_MAX_TOTAL_PENDING_BYTES is saturated across terminals", () => {
     const backpressure = manager();
 
     for (let i = 0; i < 4; i++) {
       expect(
         backpressure.enqueuePendingSegment(`term-${i}`, {
-          data: new Uint8Array(MAX_PENDING_BYTES_PER_TERMINAL),
+          data: new Uint8Array(FUTURE_SAB_MAX_PENDING_BYTES_PER_TERMINAL),
           offset: 0,
         })
       ).toBe(true);
     }
 
-    expect(MAX_TOTAL_PENDING_BYTES).toBe(MAX_PENDING_BYTES_PER_TERMINAL * 4);
+    expect(FUTURE_SAB_MAX_TOTAL_PENDING_BYTES).toBe(FUTURE_SAB_MAX_PENDING_BYTES_PER_TERMINAL * 4);
     expect(
       backpressure.enqueuePendingSegment("overflow", {
         data: new Uint8Array(1),
@@ -152,7 +152,7 @@ describe("BackpressureManager adversarial", () => {
     expect(backpressure.terminalActivityTiersMap.has("term-1")).toBe(false);
   });
 
-  it("emits pending-byte-cap-hit metric (per-terminal) when per-terminal cap is exceeded, even when metrics are disabled", () => {
+  it("refuses additional pending bytes when per-terminal FUTURE_SAB cap is exceeded", () => {
     const backpressure = new BackpressureManager({
       getTerminal: vi.fn(),
       getPauseCoordinator: () => undefined,
@@ -160,30 +160,18 @@ describe("BackpressureManager adversarial", () => {
       metricsEnabled: () => false,
     });
 
-    const fullSegment = new Uint8Array(MAX_PENDING_BYTES_PER_TERMINAL);
+    const fullSegment = new Uint8Array(FUTURE_SAB_MAX_PENDING_BYTES_PER_TERMINAL);
     expect(backpressure.enqueuePendingSegment("term-1", { data: fullSegment, offset: 0 })).toBe(
       true
     );
 
-    // Per-terminal cap exceeded — should refuse and emit
+    // Per-terminal cap exceeded — should refuse
     expect(
       backpressure.enqueuePendingSegment("term-1", { data: new Uint8Array(1), offset: 0 })
     ).toBe(false);
-
-    expect(sendEvent).toHaveBeenCalledWith(
-      expect.objectContaining({
-        type: "terminal-reliability-metric",
-        payload: expect.objectContaining({
-          terminalId: "term-1",
-          metricType: "pending-byte-cap-hit",
-          capType: "per-terminal",
-          attemptedBytes: 1,
-        }),
-      })
-    );
   });
 
-  it("emits pending-byte-cap-hit metric (total) when total cap is exceeded, even when metrics are disabled", () => {
+  it("refuses additional pending bytes when total FUTURE_SAB cap is exceeded", () => {
     const backpressure = new BackpressureManager({
       getTerminal: vi.fn(),
       getPauseCoordinator: () => undefined,
@@ -195,7 +183,7 @@ describe("BackpressureManager adversarial", () => {
     for (let i = 0; i < 4; i++) {
       expect(
         backpressure.enqueuePendingSegment(`term-${i}`, {
-          data: new Uint8Array(MAX_PENDING_BYTES_PER_TERMINAL),
+          data: new Uint8Array(FUTURE_SAB_MAX_PENDING_BYTES_PER_TERMINAL),
           offset: 0,
         })
       ).toBe(true);
@@ -205,18 +193,6 @@ describe("BackpressureManager adversarial", () => {
     expect(
       backpressure.enqueuePendingSegment("term-new", { data: new Uint8Array(1), offset: 0 })
     ).toBe(false);
-
-    expect(sendEvent).toHaveBeenCalledWith(
-      expect.objectContaining({
-        type: "terminal-reliability-metric",
-        payload: expect.objectContaining({
-          terminalId: "term-new",
-          metricType: "pending-byte-cap-hit",
-          capType: "total",
-          attemptedBytes: 1,
-        }),
-      })
-    );
   });
 
   it("getPendingBytesSnapshot returns correct totals and does not mutate state", () => {

--- a/electron/pty-host/backpressure.ts
+++ b/electron/pty-host/backpressure.ts
@@ -7,14 +7,19 @@ import type {
 import type { PtyPauseCoordinator } from "./PtyPauseCoordinator.js";
 
 export const MAX_PACKET_PAYLOAD = 65535;
-// Caps are in bytes, not chars: they bound the memory consumed by in-flight
+// FUTURE_SAB: These caps are in bytes and bound the memory consumed by in-flight
 // Uint8Array payloads queued for the SharedArrayBuffer ring buffer path.
+// Currently unreachable in production — the SAB transport path is disabled
+// (SharedArrayBuffer is not supported in Electron UtilityProcess). The caps
+// are preserved as a skeleton for a potential Worker-thread migration that
+// could revive the SAB zero-copy data path.
+//
 // The Uint8Array byte length closely approximates the actual memory footprint
 // of these payloads. VS Code uses char-based flow control because its IPC
 // routes through string-based JSON-RPC; copying that approach here would
 // misrepresent the resource being protected.
-export const MAX_PENDING_BYTES_PER_TERMINAL = 4 * 1024 * 1024;
-export const MAX_TOTAL_PENDING_BYTES = 16 * 1024 * 1024;
+export const FUTURE_SAB_MAX_PENDING_BYTES_PER_TERMINAL = 4 * 1024 * 1024;
+export const FUTURE_SAB_MAX_TOTAL_PENDING_BYTES = 16 * 1024 * 1024;
 export const BACKPRESSURE_SAFETY_TIMEOUT_MS = 10000;
 
 export type PendingVisualSegment = {
@@ -143,20 +148,10 @@ export class BackpressureManager {
     const nextTerminal = current + remaining;
     const nextTotal = this.totalPendingVisualBytes + remaining;
 
-    if (nextTerminal > MAX_PENDING_BYTES_PER_TERMINAL || nextTotal > MAX_TOTAL_PENDING_BYTES) {
-      const capType = nextTerminal > MAX_PENDING_BYTES_PER_TERMINAL ? "per-terminal" : "total";
-      this.emitReliabilityMetric(
-        {
-          terminalId: id,
-          metricType: "pending-byte-cap-hit",
-          timestamp: Date.now(),
-          capType,
-          attemptedBytes: remaining,
-          currentPendingBytes: current,
-          totalPendingBytes: this.totalPendingVisualBytes,
-        },
-        true
-      );
+    if (
+      nextTerminal > FUTURE_SAB_MAX_PENDING_BYTES_PER_TERMINAL ||
+      nextTotal > FUTURE_SAB_MAX_TOTAL_PENDING_BYTES
+    ) {
       return false;
     }
 

--- a/electron/pty-host/handlers/connection.ts
+++ b/electron/pty-host/handlers/connection.ts
@@ -134,6 +134,10 @@ export function createConnectionHandlers(ctx: HostContext): HandlerMap {
       disconnectWindow(msg.windowId, "explicit-disconnect");
     },
 
+    // FUTURE_SAB: This handler is unreachable in production — the only caller
+    // is the adversarial test suite. SharedArrayBuffer is unsupported in
+    // Electron UtilityProcess, so PtyClient.getSharedBuffers() returns empty
+    // arrays and the init-buffers message is never sent outside tests.
     "init-buffers": (msg) => {
       const visualOk =
         Array.isArray(msg.visualBuffers) &&

--- a/electron/pty-host/index.ts
+++ b/electron/pty-host/index.ts
@@ -7,8 +7,8 @@ export {
   type BackpressureStats,
   type PendingVisualSegment,
   MAX_PACKET_PAYLOAD,
-  MAX_PENDING_BYTES_PER_TERMINAL,
-  MAX_TOTAL_PENDING_BYTES,
+  FUTURE_SAB_MAX_PENDING_BYTES_PER_TERMINAL,
+  FUTURE_SAB_MAX_TOTAL_PENDING_BYTES,
   BACKPRESSURE_SAFETY_TIMEOUT_MS,
 } from "./backpressure.js";
 export { IpcQueueManager, type IpcQueueDeps } from "./ipcQueue.js";

--- a/shared/types/pty-host.ts
+++ b/shared/types/pty-host.ts
@@ -503,22 +503,13 @@ export interface HostThrottlePayload {
 /** Payload for terminal reliability metrics (backpressure/suspend/wake) */
 export interface TerminalReliabilityMetricPayload {
   terminalId: string;
-  metricType:
-    | "pause-start"
-    | "pause-end"
-    | "suspend"
-    | "wake-latency"
-    | "pending-byte-cap-hit"
-    | "pending-bytes-gauge";
+  metricType: "pause-start" | "pause-end" | "suspend" | "wake-latency" | "pending-bytes-gauge";
   timestamp: number;
   durationMs?: number;
   bufferUtilization?: number;
   shardIndex?: number;
   serializedStateBytes?: number;
   wakeLatencyMs?: number;
-  capType?: "per-terminal" | "total";
-  attemptedBytes?: number;
-  currentPendingBytes?: number;
   totalPendingBytes?: number;
   perTerminal?: Array<{ terminalId: string; pendingBytes: number }>;
 }


### PR DESCRIPTION
## Summary
- Marks the SharedArrayBuffer transport path as future-state dead code. Electron UtilityProcess does not support SAB, so production always routes through MessagePort -- this was dead code with no execution path.
- Renames backpressure constants with a `FUTURE_SAB_` prefix and removes the `pending-byte-cap-hit` metric type (plus its payload fields) from `TerminalReliabilityMetricPayload`.
- The skeleton stays -- a Worker-thread migration could revive the zero-copy data path with proper per-consumer isolation.

Resolves #7653

## Changes
- `electron/pty-host/backpressure.ts` -- renamed `MAX_PENDING_BYTES_PER_TERMINAL` / `MAX_TOTAL_PENDING_BYTES` to `FUTURE_SAB_MAX_PENDING_BYTES_PER_TERMINAL` / `FUTURE_SAB_MAX_TOTAL_PENDING_BYTES`; removed metric emission on cap-hit returns
- `electron/pty-host.ts` -- expanded FUTURE_SAB commentary on the fallback branch
- `electron/pty-host/handlers/connection.ts` -- documented the `init-buffers` handler as test-only
- `electron/pty-host/__tests__/backpressure.adversarial.test.ts` -- updated constants and removed metric-assertion expectations
- `electron/pty-host/index.ts` -- re-exported renamed constants
- `shared/types/pty-host.ts` -- removed `pending-byte-cap-hit` from `metricType` union and dropped associated fields

## Testing
- Adversarial backpressure tests updated and passing.