### PR TITLE
feat(settings): inline keyboard shortcut assignment for agents (#7703)

### DIFF
--- a/src/components/KeyboardShortcuts/AgentShortcutCapture.tsx
+++ b/src/components/KeyboardShortcuts/AgentShortcutCapture.tsx
@@ -1,0 +1,50 @@
+import { useCallback } from "react";
+import { isMac } from "@/lib/platform";
+import { SettingsShortcutCapture } from "./SettingsShortcutCapture";
+import type { BuiltInAgentId } from "@shared/config/agentIds";
+
+export interface AgentShortcutCaptureProps {
+  agentId: BuiltInAgentId;
+  onCapture: (combo: string) => void;
+  onCancel: () => void;
+}
+
+const AGENT_COMBO_PATTERN_MAC = /^Cmd\+Alt\+[A-Za-z]$/;
+const AGENT_COMBO_PATTERN_WIN_LINUX = /^Cmd\+Alt\+[A-Za-z]$/;
+
+/**
+ * Thin wrapper around SettingsShortcutCapture that enforces the agent-shortcut
+ * convention (Cmd+Alt+letter on Mac, Ctrl+Alt+letter elsewhere). The internal
+ * combo format uses "Cmd+" on both platforms — SettingsShortcutCapture's
+ * keydown handler maps ctrlKey to "Cmd" on non-Mac. We compare against that
+ * canonical internal format, not the display form, so the validator stays
+ * consistent with stored bindings in defaultKeybindings.ts.
+ */
+export function AgentShortcutCapture({ agentId, onCapture, onCancel }: AgentShortcutCaptureProps) {
+  const actionId = `agent.${agentId}`;
+  const mac = isMac();
+
+  const validateCombo = useCallback(
+    (combo: string): string | null => {
+      // Single-stroke combos only (no chords) for agent shortcuts.
+      if (combo.includes(" ")) {
+        return mac ? "Agent shortcuts use ⌘⌥ + letter" : "Agent shortcuts use Ctrl+Alt+letter";
+      }
+      const pattern = mac ? AGENT_COMBO_PATTERN_MAC : AGENT_COMBO_PATTERN_WIN_LINUX;
+      if (!pattern.test(combo)) {
+        return mac ? "Agent shortcuts use ⌘⌥ + letter" : "Agent shortcuts use Ctrl+Alt+letter";
+      }
+      return null;
+    },
+    [mac]
+  );
+
+  return (
+    <SettingsShortcutCapture
+      onCapture={onCapture}
+      onCancel={onCancel}
+      excludeActionId={actionId}
+      validateCombo={validateCombo}
+    />
+  );
+}

--- a/src/components/KeyboardShortcuts/SettingsShortcutCapture.tsx
+++ b/src/components/KeyboardShortcuts/SettingsShortcutCapture.tsx
@@ -24,6 +24,14 @@ export interface SettingsShortcutCaptureProps {
    * Defaults to "global" (the conservative behavior — flags any overlap).
    */
   scope?: KeyScope;
+  /**
+   * Optional validator for the captured combo. Receives the full captured
+   * combo string (e.g. "Cmd+Alt+K") and returns an error message to display
+   * inline, or null when the combo is acceptable. When non-null, the Save
+   * button is disabled. Use to enforce domain rules like "agent shortcuts
+   * must use Cmd+Alt+letter" without baking domain copy into this widget.
+   */
+  validateCombo?: (combo: string) => string | null;
 }
 
 export function SettingsShortcutCapture({
@@ -31,6 +39,7 @@ export function SettingsShortcutCapture({
   onCancel,
   excludeActionId,
   scope = "global",
+  validateCombo,
 }: SettingsShortcutCaptureProps) {
   const [recording, setRecording] = useState(false);
   const [capturedCombos, setCapturedCombos] = useState<string[]>([]);
@@ -41,6 +50,11 @@ export function SettingsShortcutCapture({
   const [isUnbinding, setIsUnbinding] = useState(false);
 
   const capturedCombo = capturedCombos.length > 0 ? capturedCombos.join(" ") : null;
+
+  const validationError = useMemo(() => {
+    if (!capturedCombo || !validateCombo) return null;
+    return validateCombo(capturedCombo);
+  }, [capturedCombo, validateCombo]);
 
   const conflicts = useMemo(() => {
     if (!capturedCombo) return [];
@@ -117,9 +131,21 @@ export function SettingsShortcutCapture({
       }
     };
 
+    const handleBlur = () => {
+      // If the window loses focus mid-recording, held modifier state can't be
+      // observed reliably on return — bail out rather than ship a stuck combo.
+      clearChordTimeout();
+      chordTokenRef.current += 1;
+      setRecording(false);
+      setCapturedCombos([]);
+      setChordStep("first");
+    };
+
     window.addEventListener("keydown", handler, { capture: true });
+    window.addEventListener("blur", handleBlur);
     return () => {
       window.removeEventListener("keydown", handler, { capture: true });
+      window.removeEventListener("blur", handleBlur);
       clearChordTimeout();
     };
   }, [recording, clearChordTimeout, finishRecording]);
@@ -131,7 +157,7 @@ export function SettingsShortcutCapture({
   };
 
   const handleSave = () => {
-    if (capturedCombo) {
+    if (capturedCombo && !validationError) {
       clearChordTimeout();
       setRecording(false);
       onCapture(capturedCombo);
@@ -307,6 +333,17 @@ export function SettingsShortcutCapture({
         )}
       </div>
 
+      {validationError && (
+        <div
+          className="flex items-start gap-2 text-status-error text-sm"
+          role="alert"
+          data-testid="shortcut-capture-validation-error"
+        >
+          <AlertTriangle className="w-4 h-4 mt-0.5 shrink-0" />
+          <span>{validationError}</span>
+        </div>
+      )}
+
       {conflicts.length > 0 && (
         <div className="space-y-2">
           <div className="flex items-start gap-2 text-status-warning text-sm">
@@ -362,7 +399,8 @@ export function SettingsShortcutCapture({
         {capturedCombo && (
           <button
             onClick={handleSave}
-            className="px-3 py-1.5 text-sm bg-daintree-accent text-daintree-bg rounded hover:bg-daintree-accent/90 transition-colors"
+            disabled={Boolean(validationError)}
+            className="px-3 py-1.5 text-sm bg-daintree-accent text-daintree-bg rounded hover:bg-daintree-accent/90 transition-colors disabled:opacity-50 disabled:cursor-not-allowed"
           >
             Save
           </button>

--- a/src/components/KeyboardShortcuts/SettingsShortcutCapture.tsx
+++ b/src/components/KeyboardShortcuts/SettingsShortcutCapture.tsx
@@ -62,6 +62,7 @@ export function SettingsShortcutCapture({
     // conflictRefreshKey forces the memo to re-evaluate after a successful
     // Unbind so the dismissed conflict row disappears immediately. Without it,
     // the memoized result persists against the unchanged capturedCombo.
+    // eslint-disable-next-line react-hooks/exhaustive-deps
   }, [capturedCombo, excludeActionId, scope, conflictRefreshKey]);
 
   const clearChordTimeout = useCallback(() => {

--- a/src/components/KeyboardShortcuts/SettingsShortcutCapture.tsx
+++ b/src/components/KeyboardShortcuts/SettingsShortcutCapture.tsx
@@ -46,7 +46,7 @@ export function SettingsShortcutCapture({
   const [chordStep, setChordStep] = useState<"first" | "waiting" | "complete">("first");
   const chordTimeoutRef = useRef<ReturnType<typeof setTimeout> | null>(null);
   const chordTokenRef = useRef(0);
-  const [_conflictRefreshKey, setConflictRefreshKey] = useState(0);
+  const [conflictRefreshKey, setConflictRefreshKey] = useState(0);
   const [isUnbinding, setIsUnbinding] = useState(false);
 
   const capturedCombo = capturedCombos.length > 0 ? capturedCombos.join(" ") : null;
@@ -59,7 +59,10 @@ export function SettingsShortcutCapture({
   const conflicts = useMemo(() => {
     if (!capturedCombo) return [];
     return keybindingService.findConflicts(capturedCombo, excludeActionId, scope);
-  }, [capturedCombo, excludeActionId, scope]);
+    // conflictRefreshKey forces the memo to re-evaluate after a successful
+    // Unbind so the dismissed conflict row disappears immediately. Without it,
+    // the memoized result persists against the unchanged capturedCombo.
+  }, [capturedCombo, excludeActionId, scope, conflictRefreshKey]);
 
   const clearChordTimeout = useCallback(() => {
     if (chordTimeoutRef.current) {
@@ -134,11 +137,15 @@ export function SettingsShortcutCapture({
     const handleBlur = () => {
       // If the window loses focus mid-recording, held modifier state can't be
       // observed reliably on return — bail out rather than ship a stuck combo.
+      // Invoke onCancel so any parent state coordinating the capture session
+      // (e.g. AgentTrayCapturingContext.capturingId) also clears; otherwise the
+      // tray dropdown can become un-dismissable after a mid-capture alt-tab.
       clearChordTimeout();
       chordTokenRef.current += 1;
       setRecording(false);
       setCapturedCombos([]);
       setChordStep("first");
+      onCancel();
     };
 
     window.addEventListener("keydown", handler, { capture: true });
@@ -148,7 +155,7 @@ export function SettingsShortcutCapture({
       window.removeEventListener("blur", handleBlur);
       clearChordTimeout();
     };
-  }, [recording, clearChordTimeout, finishRecording]);
+  }, [recording, clearChordTimeout, finishRecording, onCancel]);
 
   const handleStartRecording = () => {
     setCapturedCombos([]);
@@ -344,7 +351,7 @@ export function SettingsShortcutCapture({
         </div>
       )}
 
-      {conflicts.length > 0 && (
+      {!validationError && conflicts.length > 0 && (
         <div className="space-y-2">
           <div className="flex items-start gap-2 text-status-warning text-sm">
             <AlertTriangle className="w-4 h-4 mt-0.5 shrink-0" />

--- a/src/components/KeyboardShortcuts/__tests__/AgentShortcutCapture.test.tsx
+++ b/src/components/KeyboardShortcuts/__tests__/AgentShortcutCapture.test.tsx
@@ -1,0 +1,120 @@
+// @vitest-environment jsdom
+
+import { describe, it, expect, vi, beforeEach, afterEach } from "vitest";
+import { render, screen, fireEvent, act } from "@testing-library/react";
+import { AgentShortcutCapture } from "../AgentShortcutCapture";
+
+vi.mock("@/services/KeybindingService", () => ({
+  CHORD_TIMEOUT_MS: 1000,
+  keybindingService: {
+    findConflicts: vi.fn(() => []),
+    formatComboForDisplay: vi.fn((combo: string) => combo),
+    getOverride: vi.fn(() => undefined),
+    getDefaultCombo: vi.fn(() => undefined),
+  },
+  normalizeKeyForBinding: vi.fn((e: KeyboardEvent) => e.key),
+}));
+
+vi.mock("@/lib/platform", () => ({
+  isMac: vi.fn(() => false),
+}));
+
+vi.mock("@/services/ActionService", () => ({
+  actionService: { dispatch: vi.fn().mockResolvedValue({ ok: true }) },
+}));
+
+vi.mock("@/lib/notify", () => ({ notify: vi.fn() }));
+
+vi.mock("@/store/notificationStore", () => ({
+  useNotificationStore: { getState: vi.fn(() => ({ addNotification: vi.fn() })) },
+}));
+
+describe("AgentShortcutCapture", () => {
+  const onCapture = vi.fn();
+  const onCancel = vi.fn();
+
+  beforeEach(() => {
+    vi.clearAllMocks();
+    vi.useFakeTimers();
+  });
+
+  afterEach(() => {
+    vi.useRealTimers();
+  });
+
+  it("accepts a Cmd+Alt+letter combo and forwards to onCapture", () => {
+    render(<AgentShortcutCapture agentId="claude" onCapture={onCapture} onCancel={onCancel} />);
+
+    fireEvent.click(screen.getByText("Click to record shortcut"));
+
+    // On non-Mac, ctrlKey + altKey + KeyK produces the internal "Cmd+Alt+k" combo
+    // via SettingsShortcutCapture's normalization (ctrlKey -> "Cmd" prefix).
+    const ev = new KeyboardEvent("keydown", {
+      key: "k",
+      code: "KeyK",
+      ctrlKey: true,
+      altKey: true,
+      bubbles: true,
+    });
+
+    act(() => {
+      window.dispatchEvent(ev);
+      vi.advanceTimersByTime(1100);
+    });
+
+    expect(screen.queryByTestId("shortcut-capture-validation-error")).toBeNull();
+    const save = screen.getByText("Save") as HTMLButtonElement;
+    expect(save.disabled).toBe(false);
+    fireEvent.click(save);
+    expect(onCapture).toHaveBeenCalledWith("Cmd+Alt+k");
+  });
+
+  it("rejects a Cmd+letter combo (missing Alt) and disables Save", () => {
+    render(<AgentShortcutCapture agentId="claude" onCapture={onCapture} onCancel={onCancel} />);
+
+    fireEvent.click(screen.getByText("Click to record shortcut"));
+
+    const ev = new KeyboardEvent("keydown", {
+      key: "k",
+      code: "KeyK",
+      ctrlKey: true,
+      bubbles: true,
+    });
+
+    act(() => {
+      window.dispatchEvent(ev);
+      vi.advanceTimersByTime(1100);
+    });
+
+    expect(screen.getByTestId("shortcut-capture-validation-error")).toBeTruthy();
+    expect(screen.getByText(/Ctrl\+Alt\+letter/)).toBeTruthy();
+    const save = screen.getByText("Save") as HTMLButtonElement;
+    expect(save.disabled).toBe(true);
+    fireEvent.click(save);
+    expect(onCapture).not.toHaveBeenCalled();
+  });
+
+  it("rejects Cmd+Shift+Alt+letter (extra modifier) and disables Save", () => {
+    render(<AgentShortcutCapture agentId="claude" onCapture={onCapture} onCancel={onCancel} />);
+
+    fireEvent.click(screen.getByText("Click to record shortcut"));
+
+    const ev = new KeyboardEvent("keydown", {
+      key: "k",
+      code: "KeyK",
+      ctrlKey: true,
+      shiftKey: true,
+      altKey: true,
+      bubbles: true,
+    });
+
+    act(() => {
+      window.dispatchEvent(ev);
+      vi.advanceTimersByTime(1100);
+    });
+
+    expect(screen.getByTestId("shortcut-capture-validation-error")).toBeTruthy();
+    const save = screen.getByText("Save") as HTMLButtonElement;
+    expect(save.disabled).toBe(true);
+  });
+});

--- a/src/components/KeyboardShortcuts/__tests__/SettingsShortcutCapture.test.tsx
+++ b/src/components/KeyboardShortcuts/__tests__/SettingsShortcutCapture.test.tsx
@@ -691,6 +691,118 @@ describe("SettingsShortcutCapture", () => {
     });
   });
 
+  describe("validateCombo prop", () => {
+    it("shows inline validation error and disables Save when validator returns a message", () => {
+      const validate = vi.fn((_combo: string) => "Agent shortcuts use Ctrl+Alt+letter");
+
+      render(
+        <SettingsShortcutCapture
+          onCapture={mockOnCapture}
+          onCancel={mockOnCancel}
+          excludeActionId="test.action"
+          validateCombo={validate}
+        />
+      );
+
+      fireEvent.click(screen.getByText("Click to record shortcut"));
+
+      const keyEvent = new KeyboardEvent("keydown", {
+        key: "s",
+        code: "KeyS",
+        ctrlKey: true,
+        bubbles: true,
+      });
+
+      act(() => {
+        window.dispatchEvent(keyEvent);
+        vi.advanceTimersByTime(1100);
+      });
+
+      expect(screen.getByTestId("shortcut-capture-validation-error")).toBeTruthy();
+      expect(screen.getByText("Agent shortcuts use Ctrl+Alt+letter")).toBeTruthy();
+
+      const saveButton = screen.getByText("Save") as HTMLButtonElement;
+      expect(saveButton.disabled).toBe(true);
+
+      fireEvent.click(saveButton);
+      expect(mockOnCapture).not.toHaveBeenCalled();
+    });
+
+    it("allows Save when validateCombo returns null", () => {
+      const validate = vi.fn((_combo: string) => null);
+
+      render(
+        <SettingsShortcutCapture
+          onCapture={mockOnCapture}
+          onCancel={mockOnCancel}
+          excludeActionId="test.action"
+          validateCombo={validate}
+        />
+      );
+
+      fireEvent.click(screen.getByText("Click to record shortcut"));
+
+      const keyEvent = new KeyboardEvent("keydown", {
+        key: "k",
+        code: "KeyK",
+        ctrlKey: true,
+        altKey: true,
+        bubbles: true,
+      });
+
+      act(() => {
+        window.dispatchEvent(keyEvent);
+        vi.advanceTimersByTime(1100);
+      });
+
+      expect(screen.queryByTestId("shortcut-capture-validation-error")).toBeNull();
+
+      const saveButton = screen.getByText("Save") as HTMLButtonElement;
+      expect(saveButton.disabled).toBe(false);
+
+      fireEvent.click(saveButton);
+      expect(mockOnCapture).toHaveBeenCalled();
+    });
+  });
+
+  describe("window blur during recording", () => {
+    it("clears the in-progress combo and exits recording state on window blur", () => {
+      render(
+        <SettingsShortcutCapture
+          onCapture={mockOnCapture}
+          onCancel={mockOnCancel}
+          excludeActionId="test.action"
+        />
+      );
+
+      fireEvent.click(screen.getByText("Click to record shortcut"));
+
+      // Start a chord — held modifier state would otherwise be stuck on blur.
+      const firstKey = new KeyboardEvent("keydown", {
+        key: "k",
+        code: "KeyK",
+        ctrlKey: true,
+        bubbles: true,
+      });
+
+      act(() => {
+        window.dispatchEvent(firstKey);
+      });
+
+      expect(screen.getByText(/press second key or wait to finish/)).toBeTruthy();
+
+      // Simulate the window losing focus (e.g., user Cmd+Tabs away mid-chord).
+      act(() => {
+        window.dispatchEvent(new Event("blur"));
+      });
+
+      // Recording should be cancelled — the prompt and Save button both gone.
+      expect(screen.queryByText("Save")).toBeNull();
+      expect(screen.queryByText(/press second key or wait to finish/)).toBeNull();
+      expect(screen.getByText("Click to record shortcut")).toBeTruthy();
+    });
+  });
+
   describe("conflict remediation", () => {
     it("renders unbind buttons for each conflict", async () => {
       const { keybindingService } = await import("@/services/KeybindingService");

--- a/src/components/KeyboardShortcuts/__tests__/SettingsShortcutCapture.test.tsx
+++ b/src/components/KeyboardShortcuts/__tests__/SettingsShortcutCapture.test.tsx
@@ -801,6 +801,69 @@ describe("SettingsShortcutCapture", () => {
       expect(screen.queryByText(/press second key or wait to finish/)).toBeNull();
       expect(screen.getByText("Click to record shortcut")).toBeTruthy();
     });
+
+    it("invokes onCancel on window blur so parent capture coordination clears", () => {
+      render(
+        <SettingsShortcutCapture
+          onCapture={mockOnCapture}
+          onCancel={mockOnCancel}
+          excludeActionId="test.action"
+        />
+      );
+
+      fireEvent.click(screen.getByText("Click to record shortcut"));
+
+      act(() => {
+        window.dispatchEvent(new Event("blur"));
+      });
+
+      expect(mockOnCancel).toHaveBeenCalled();
+    });
+  });
+
+  describe("conflict suppression while validation error is active", () => {
+    it("hides the conflicts section when validateCombo returns an error", async () => {
+      const { keybindingService } = await import("@/services/KeybindingService");
+      vi.mocked(keybindingService.findConflicts).mockReturnValue([
+        {
+          actionId: "conflict.action",
+          description: "Conflicting Action",
+          combo: "Cmd+A",
+          scope: "global",
+          priority: 0,
+          kind: "conflict",
+        },
+      ]);
+
+      render(
+        <SettingsShortcutCapture
+          onCapture={mockOnCapture}
+          onCancel={mockOnCancel}
+          excludeActionId="test.action"
+          validateCombo={() => "Use a different shape"}
+        />
+      );
+
+      fireEvent.click(screen.getByText("Click to record shortcut"));
+
+      const keyEvent = new KeyboardEvent("keydown", {
+        key: "k",
+        code: "KeyK",
+        ctrlKey: true,
+        bubbles: true,
+      });
+
+      act(() => {
+        window.dispatchEvent(keyEvent);
+        vi.advanceTimersByTime(1100);
+      });
+
+      // Validation error is shown.
+      expect(screen.getByTestId("shortcut-capture-validation-error")).toBeTruthy();
+      // Conflict section suppressed — no Unbind button to accidentally fire.
+      expect(screen.queryByText("Conflicts with:")).toBeNull();
+      expect(screen.queryByText("Unbind")).toBeNull();
+    });
   });
 
   describe("conflict remediation", () => {

--- a/src/components/KeyboardShortcuts/index.ts
+++ b/src/components/KeyboardShortcuts/index.ts
@@ -1,3 +1,5 @@
 export { ShortcutReferenceDialog } from "./ShortcutReferenceDialog";
 export { SettingsShortcutCapture } from "./SettingsShortcutCapture";
 export type { SettingsShortcutCaptureProps } from "./SettingsShortcutCapture";
+export { AgentShortcutCapture } from "./AgentShortcutCapture";
+export type { AgentShortcutCaptureProps } from "./AgentShortcutCapture";

--- a/src/components/Layout/AgentTrayButton.tsx
+++ b/src/components/Layout/AgentTrayButton.tsx
@@ -47,6 +47,7 @@ import { useWorktreeSelectionStore } from "@/store/worktreeStore";
 import { useKeybindingDisplay } from "@/hooks";
 import { useAgentDiscoveryOnboarding } from "@/hooks/app/useAgentDiscoveryOnboarding";
 import { AgentShortcutCapture } from "@/components/KeyboardShortcuts";
+import { notify } from "@/lib/notify";
 import { BUILT_IN_AGENT_IDS, type BuiltInAgentId } from "@shared/config/agentIds";
 import type { CliAvailability, AgentState } from "@shared/types";
 import { resolveEffectivePresetId } from "@shared/types";
@@ -798,8 +799,14 @@ function LaunchRow({
         { source: "user" }
       );
       if (!result.ok) {
-        // Stay open on failure so the user can retry — the capture widget
-        // will surface a follow-up error via existing notify() paths.
+        // Stay open on failure so the user can retry; surface the failure
+        // explicitly since the user otherwise has no visible signal.
+        notify({
+          type: "error",
+          message: "Couldn't save shortcut. Try again.",
+          duration: 3000,
+          priority: "high",
+        });
         return;
       }
       setCapturingId(null);

--- a/src/components/Layout/AgentTrayButton.tsx
+++ b/src/components/Layout/AgentTrayButton.tsx
@@ -1,4 +1,6 @@
 import {
+  createContext,
+  useContext,
   useEffect,
   useMemo,
   useRef,
@@ -8,7 +10,7 @@ import {
   type KeyboardEvent,
   type PointerEvent as ReactPointerEvent,
 } from "react";
-import { Plug, Pin, Settings2, ChevronRight } from "lucide-react";
+import { Plug, Pin, Settings2, ChevronRight, Keyboard } from "lucide-react";
 import { Button } from "@/components/ui/button";
 import { Tooltip, TooltipContent, TooltipTrigger } from "@/components/ui/tooltip";
 import {
@@ -44,6 +46,7 @@ import { useWorktreeSelectionStore } from "@/store/worktreeStore";
 
 import { useKeybindingDisplay } from "@/hooks";
 import { useAgentDiscoveryOnboarding } from "@/hooks/app/useAgentDiscoveryOnboarding";
+import { AgentShortcutCapture } from "@/components/KeyboardShortcuts";
 import { BUILT_IN_AGENT_IDS, type BuiltInAgentId } from "@shared/config/agentIds";
 import type { CliAvailability, AgentState } from "@shared/types";
 import { resolveEffectivePresetId } from "@shared/types";
@@ -60,6 +63,20 @@ interface AgentTrayButtonProps {
   agentAvailability?: CliAvailability;
   "data-toolbar-item"?: string;
 }
+
+// File-local context so DropdownMenuContent can guard onEscapeKeyDown when any
+// LaunchRow is in shortcut-capture mode (Radix DismissableLayer otherwise
+// closes the dropdown on Escape — see lesson #4588). Exclusivity is enforced
+// at the setter so two rows can't both be capturing at once.
+type AgentTrayCapturingContextValue = {
+  capturingId: BuiltInAgentId | null;
+  setCapturingId: (id: BuiltInAgentId | null) => void;
+};
+
+const AgentTrayCapturingContext = createContext<AgentTrayCapturingContextValue>({
+  capturingId: null,
+  setCapturingId: () => {},
+});
 
 type AgentRow = {
   id: BuiltInAgentId;
@@ -293,6 +310,18 @@ export function AgentTrayButton({
   } = useAgentDiscoveryOnboarding();
 
   const [open, setOpen] = useState(false);
+  const [capturingId, setCapturingId] = useState<BuiltInAgentId | null>(null);
+
+  const captureContextValue = useMemo<AgentTrayCapturingContextValue>(
+    () => ({ capturingId, setCapturingId }),
+    [capturingId]
+  );
+
+  // Reset capture state whenever the dropdown closes so a half-open capture
+  // doesn't persist into the next time the user opens the tray.
+  useEffect(() => {
+    if (!open) setCapturingId(null);
+  }, [open]);
 
   const panelsById = usePanelStore((s) => s.panelsById);
   const panelIds = usePanelStore((s) => s.panelIds);
@@ -585,142 +614,162 @@ export function AgentTrayButton({
   };
 
   return (
-    <DropdownMenu
-      open={open}
-      onOpenChange={(o) => {
-        setOpen(o);
-        handleOpenChange(o);
-      }}
-    >
-      <Tooltip open={tooltipOpen} onOpenChange={handleTooltipOpenChange}>
-        <TooltipTrigger asChild>
-          <DropdownMenuTrigger asChild>
-            <Button
-              variant="ghost"
-              size={emptyTrayLabel ? "sm" : "icon"}
-              data-toolbar-item={dataToolbarItem}
-              className={`toolbar-agent-button${emptyTrayLabel ? "" : " text-daintree-text"}`}
-              aria-label={
-                emptyTrayLabel
-                  ? `Agent tray — ${emptyTrayLabel}`
-                  : showDiscoveryBadge
-                    ? "Agent tray — new agents detected"
-                    : "Agent tray"
-              }
-              onPointerEnter={clearFocusRestoreSuppression}
-            >
-              <span className="relative inline-flex items-center justify-center">
-                <Plug />
-                <span
-                  data-testid="agent-tray-discovery-badge"
-                  data-visible={showDiscoveryBadge}
-                  className="toolbar-badge absolute top-0 right-0 size-1.5 rounded-full bg-status-info ring-1 ring-daintree-sidebar"
-                  aria-hidden="true"
-                />
-              </span>
-              {emptyTrayLabel}
-            </Button>
-          </DropdownMenuTrigger>
-        </TooltipTrigger>
-        <TooltipContent side="bottom">Agent Tray</TooltipContent>
-      </Tooltip>
-      <DropdownMenuContent
-        align="start"
-        sideOffset={4}
-        className="min-w-[16rem]"
-        onPointerDownOutside={() => {
-          wasPointerCloseRef.current = true;
-        }}
-        onCloseAutoFocus={(e) => {
-          suppressTooltipDuringFocusRestore();
-          if (wasPointerCloseRef.current) {
-            e.preventDefault();
-            wasPointerCloseRef.current = false;
-          }
+    <AgentTrayCapturingContext.Provider value={captureContextValue}>
+      <DropdownMenu
+        open={open}
+        onOpenChange={(o) => {
+          setOpen(o);
+          handleOpenChange(o);
         }}
       >
-        {isAvailabilityLoading && (
-          <div className="px-2.5 py-1.5 text-xs text-daintree-text/60">Checking agents…</div>
-        )}
-
-        {launchable.length > 0 && (
-          <>
-            <DropdownMenuLabel>Launch</DropdownMenuLabel>
-            {hasNoPinnedAgents && !isAvailabilityLoading && (
-              <DropdownMenuLabel
-                data-testid="agent-tray-pin-hint"
-                className="text-daintree-text/50 font-normal text-[11px] -mt-1 pb-1.5"
+        <Tooltip open={tooltipOpen} onOpenChange={handleTooltipOpenChange}>
+          <TooltipTrigger asChild>
+            <DropdownMenuTrigger asChild>
+              <Button
+                variant="ghost"
+                size={emptyTrayLabel ? "sm" : "icon"}
+                data-toolbar-item={dataToolbarItem}
+                className={`toolbar-agent-button${emptyTrayLabel ? "" : " text-daintree-text"}`}
+                aria-label={
+                  emptyTrayLabel
+                    ? `Agent tray — ${emptyTrayLabel}`
+                    : showDiscoveryBadge
+                      ? "Agent tray — new agents detected"
+                      : "Agent tray"
+                }
+                onPointerEnter={clearFocusRestoreSuppression}
               >
-                Hover an agent and click the pin to keep it on the toolbar.
-              </DropdownMenuLabel>
-            )}
-            {launchable.map((row) => renderLaunchItem(row))}
-          </>
-        )}
+                <span className="relative inline-flex items-center justify-center">
+                  <Plug />
+                  <span
+                    data-testid="agent-tray-discovery-badge"
+                    data-visible={showDiscoveryBadge}
+                    className="toolbar-badge absolute top-0 right-0 size-1.5 rounded-full bg-status-info ring-1 ring-daintree-sidebar"
+                    aria-hidden="true"
+                  />
+                </span>
+                {emptyTrayLabel}
+              </Button>
+            </DropdownMenuTrigger>
+          </TooltipTrigger>
+          <TooltipContent side="bottom">Agent Tray</TooltipContent>
+        </Tooltip>
+        <DropdownMenuContent
+          align="start"
+          sideOffset={4}
+          className="min-w-[16rem]"
+          onPointerDownOutside={(e) => {
+            // Keep the tray open during shortcut capture so a stray click on the
+            // capture row's inner controls doesn't tear down the in-progress
+            // recording session.
+            if (capturingId !== null) {
+              e.preventDefault();
+              return;
+            }
+            wasPointerCloseRef.current = true;
+          }}
+          onEscapeKeyDown={(e) => {
+            // Belt-and-suspenders: SettingsShortcutCapture's window-capture
+            // listener already swallows Escape during active recording, but
+            // between mounting the capture UI and entering recording state
+            // Escape would otherwise reach Radix's DismissableLayer and dismiss
+            // the dropdown (lesson #4588). Cancel the capture in-place instead.
+            if (capturingId !== null) {
+              e.preventDefault();
+              setCapturingId(null);
+            }
+          }}
+          onCloseAutoFocus={(e) => {
+            suppressTooltipDuringFocusRestore();
+            if (wasPointerCloseRef.current) {
+              e.preventDefault();
+              wasPointerCloseRef.current = false;
+            }
+          }}
+        >
+          {isAvailabilityLoading && (
+            <div className="px-2.5 py-1.5 text-xs text-daintree-text/60">Checking agents…</div>
+          )}
 
-        {needsSetup.length > 0 && (
-          <>
-            {launchable.length > 0 && <DropdownMenuSeparator />}
-            <DropdownMenuLabel>Needs Setup</DropdownMenuLabel>
-            {needsSetup.map((row) => (
-              <DropdownMenuItem
-                key={`setup-${row.id}`}
-                onSelect={() => handleSetup(row.id)}
-                className="group h-7"
-              >
-                <span className="mr-2 inline-flex h-4 w-4 items-center justify-center grayscale opacity-50">
-                  <BrandMark brandColor={getBrandColorHex(row.id)}>
-                    <row.Icon brandColor={getBrandColorHex(row.id)} />
-                  </BrandMark>
-                </span>
-                <span className="flex-1 text-daintree-text/70">{row.name}</span>
-                <span className="ml-2 shrink-0 rounded border border-daintree-text/15 px-1.5 py-0.5 text-[10px] uppercase tracking-wide text-daintree-text/50">
-                  Setup
-                </span>
-              </DropdownMenuItem>
-            ))}
-          </>
-        )}
+          {launchable.length > 0 && (
+            <>
+              <DropdownMenuLabel>Launch</DropdownMenuLabel>
+              {hasNoPinnedAgents && !isAvailabilityLoading && (
+                <DropdownMenuLabel
+                  data-testid="agent-tray-pin-hint"
+                  className="text-daintree-text/50 font-normal text-[11px] -mt-1 pb-1.5"
+                >
+                  Hover an agent and click the pin to keep it on the toolbar.
+                </DropdownMenuLabel>
+              )}
+              {launchable.map((row) => renderLaunchItem(row))}
+            </>
+          )}
 
-        {showFallback && (
-          <>
-            <DropdownMenuLabel>Available Agents</DropdownMenuLabel>
-            {fallbackSetup.map((row) => (
-              <DropdownMenuItem
-                key={`fallback-${row.id}`}
-                onSelect={() => handleSetup(row.id)}
-                className="group h-7"
-                data-testid={`agent-tray-fallback-${row.id}`}
-              >
-                <span className="mr-2 inline-flex h-4 w-4 items-center justify-center grayscale opacity-50">
-                  <BrandMark brandColor={getBrandColorHex(row.id)}>
-                    <row.Icon brandColor={getBrandColorHex(row.id)} />
-                  </BrandMark>
-                </span>
-                <span className="flex-1 text-daintree-text/70">{row.name}</span>
-                <span className="ml-2 shrink-0 rounded border border-daintree-text/15 px-1.5 py-0.5 text-[10px] uppercase tracking-wide text-daintree-text/50">
-                  Setup
-                </span>
-              </DropdownMenuItem>
-            ))}
-          </>
-        )}
+          {needsSetup.length > 0 && (
+            <>
+              {launchable.length > 0 && <DropdownMenuSeparator />}
+              <DropdownMenuLabel>Needs Setup</DropdownMenuLabel>
+              {needsSetup.map((row) => (
+                <DropdownMenuItem
+                  key={`setup-${row.id}`}
+                  onSelect={() => handleSetup(row.id)}
+                  className="group h-7"
+                >
+                  <span className="mr-2 inline-flex h-4 w-4 items-center justify-center grayscale opacity-50">
+                    <BrandMark brandColor={getBrandColorHex(row.id)}>
+                      <row.Icon brandColor={getBrandColorHex(row.id)} />
+                    </BrandMark>
+                  </span>
+                  <span className="flex-1 text-daintree-text/70">{row.name}</span>
+                  <span className="ml-2 shrink-0 rounded border border-daintree-text/15 px-1.5 py-0.5 text-[10px] uppercase tracking-wide text-daintree-text/50">
+                    Setup
+                  </span>
+                </DropdownMenuItem>
+              ))}
+            </>
+          )}
 
-        {(hasAnyContent || showFallback) && <DropdownMenuSeparator />}
-        <DropdownMenuItem onSelect={handleManageAgents} className="h-7">
-          <Settings2 className="mr-2 h-3.5 w-3.5 opacity-60" />
-          Manage Agents
-        </DropdownMenuItem>
-        <DropdownMenuItem onSelect={handleCustomizeToolbar} className="h-7">
-          <Settings2 className="mr-2 h-3.5 w-3.5 opacity-60" />
-          Customize Toolbar
-        </DropdownMenuItem>
-        <DropdownMenuItem onSelect={handleOpenAgentSetupWizard} className="h-7">
-          <Plug className="mr-2 h-3.5 w-3.5" />
-          Set Up Agents
-        </DropdownMenuItem>
-      </DropdownMenuContent>
-    </DropdownMenu>
+          {showFallback && (
+            <>
+              <DropdownMenuLabel>Available Agents</DropdownMenuLabel>
+              {fallbackSetup.map((row) => (
+                <DropdownMenuItem
+                  key={`fallback-${row.id}`}
+                  onSelect={() => handleSetup(row.id)}
+                  className="group h-7"
+                  data-testid={`agent-tray-fallback-${row.id}`}
+                >
+                  <span className="mr-2 inline-flex h-4 w-4 items-center justify-center grayscale opacity-50">
+                    <BrandMark brandColor={getBrandColorHex(row.id)}>
+                      <row.Icon brandColor={getBrandColorHex(row.id)} />
+                    </BrandMark>
+                  </span>
+                  <span className="flex-1 text-daintree-text/70">{row.name}</span>
+                  <span className="ml-2 shrink-0 rounded border border-daintree-text/15 px-1.5 py-0.5 text-[10px] uppercase tracking-wide text-daintree-text/50">
+                    Setup
+                  </span>
+                </DropdownMenuItem>
+              ))}
+            </>
+          )}
+
+          {(hasAnyContent || showFallback) && <DropdownMenuSeparator />}
+          <DropdownMenuItem onSelect={handleManageAgents} className="h-7">
+            <Settings2 className="mr-2 h-3.5 w-3.5 opacity-60" />
+            Manage Agents
+          </DropdownMenuItem>
+          <DropdownMenuItem onSelect={handleCustomizeToolbar} className="h-7">
+            <Settings2 className="mr-2 h-3.5 w-3.5 opacity-60" />
+            Customize Toolbar
+          </DropdownMenuItem>
+          <DropdownMenuItem onSelect={handleOpenAgentSetupWizard} className="h-7">
+            <Plug className="mr-2 h-3.5 w-3.5" />
+            Set Up Agents
+          </DropdownMenuItem>
+        </DropdownMenuContent>
+      </DropdownMenu>
+    </AgentTrayCapturingContext.Provider>
   );
 }
 
@@ -738,6 +787,51 @@ function LaunchRow({
   stopPointer: (e: ReactPointerEvent) => void;
 }) {
   const displayCombo = useKeybindingDisplay(`agent.${row.id}`);
+  const { capturingId, setCapturingId } = useContext(AgentTrayCapturingContext);
+  const isCapturing = capturingId === row.id;
+
+  const handleShortcutSave = useCallback(
+    async (combo: string) => {
+      const result = await actionService.dispatch(
+        "keybinding.setOverride",
+        { actionId: `agent.${row.id}`, combo: combo === "" ? [] : [combo] },
+        { source: "user" }
+      );
+      if (!result.ok) {
+        // Stay open on failure so the user can retry — the capture widget
+        // will surface a follow-up error via existing notify() paths.
+        return;
+      }
+      setCapturingId(null);
+    },
+    [row.id, setCapturingId]
+  );
+
+  if (isCapturing) {
+    return (
+      <div
+        data-testid={`agent-tray-capture-${row.id}`}
+        // Sidestep DropdownMenuItem semantics during capture — Radix would try
+        // to interpret keystrokes inside as menu navigation.
+        className="px-2.5 py-2 space-y-2"
+        onKeyDown={(e) => e.stopPropagation()}
+      >
+        <div className="flex items-center gap-2 text-xs text-daintree-text/70">
+          <span className="inline-flex h-4 w-4 items-center justify-center shrink-0">
+            <BrandMark brandColor={getBrandColorHex(row.id)}>
+              <row.Icon brandColor={getBrandColorHex(row.id)} />
+            </BrandMark>
+          </span>
+          <span>Set shortcut for {row.name}</span>
+        </div>
+        <AgentShortcutCapture
+          agentId={row.id}
+          onCapture={(combo) => void handleShortcutSave(combo)}
+          onCancel={() => setCapturingId(null)}
+        />
+      </div>
+    );
+  }
 
   return (
     <DropdownMenuItem
@@ -767,6 +861,22 @@ function LaunchRow({
       {displayCombo && <DropdownMenuShortcut>{displayCombo}</DropdownMenuShortcut>}
 
       <span className="sr-only">Press P to {row.pinned ? "unpin from" : "pin to"} toolbar</span>
+
+      <span
+        role="presentation"
+        aria-hidden="true"
+        data-testid={`agent-tray-shortcut-edit-${row.id}`}
+        title={displayCombo ? "Change keyboard shortcut" : "Assign keyboard shortcut"}
+        onPointerDown={stopPointer}
+        onPointerUp={stopPointer}
+        onClick={(e) => {
+          e.stopPropagation();
+          setCapturingId(row.id);
+        }}
+        className="ml-1 inline-flex h-5 w-5 items-center justify-center rounded-sm text-daintree-text/50 opacity-0 transition-opacity hover:bg-overlay-emphasis hover:text-daintree-text group-data-[highlighted]:opacity-100"
+      >
+        <Keyboard className="h-3 w-3" />
+      </span>
 
       <span
         role="presentation"

--- a/src/components/Layout/__tests__/AgentTrayButton.test.tsx
+++ b/src/components/Layout/__tests__/AgentTrayButton.test.tsx
@@ -107,9 +107,35 @@ vi.mock("@/store/worktreeStore", () => ({
     selector({ activeWorktreeId: mockActiveWorktreeId }),
 }));
 
+let mockKeybindingDisplay: Record<string, string | null> = {};
+
 vi.mock("@/hooks", () => ({
-  useKeybindingDisplay: () => null,
+  useKeybindingDisplay: (actionId: string) => mockKeybindingDisplay[actionId] ?? null,
   useAriaKeyshortcuts: () => undefined,
+}));
+
+vi.mock("@/components/KeyboardShortcuts", () => ({
+  AgentShortcutCapture: ({
+    agentId,
+    onCapture,
+    onCancel,
+  }: {
+    agentId: string;
+    onCapture: (combo: string) => void;
+    onCancel: () => void;
+  }) => (
+    <div data-testid={`mock-agent-shortcut-capture-${agentId}`}>
+      <button
+        data-testid={`mock-agent-shortcut-save-${agentId}`}
+        onClick={() => onCapture("Cmd+Alt+K")}
+      >
+        Save Mock
+      </button>
+      <button data-testid={`mock-agent-shortcut-cancel-${agentId}`} onClick={() => onCancel()}>
+        Cancel Mock
+      </button>
+    </div>
+  ),
 }));
 
 let mockCcrPresetsByAgent: Record<string, Array<{ id: string; name: string }>> = {};
@@ -308,6 +334,7 @@ vi.mock("lucide-react", () => ({
   Plus: () => <span data-testid="plus-icon" />,
   Settings2: () => <span data-testid="settings2-icon" />,
   ChevronRight: () => <span data-testid="chevron-right-icon" />,
+  Keyboard: () => <span data-testid="keyboard-icon" />,
 }));
 
 import { AgentTrayButton } from "../AgentTrayButton";
@@ -357,6 +384,7 @@ describe("AgentTrayButton", () => {
     mockOnboardingLoaded = true;
     mockCcrPresetsByAgent = {};
     mockMergedPresetsFn = () => [];
+    mockKeybindingDisplay = {};
   });
 
   afterEach(() => {
@@ -1358,6 +1386,110 @@ describe("AgentTrayButton", () => {
       const { getAllByTestId } = render(<AgentTrayButton agentAvailability={availability} />);
       const groups = getAllByTestId("preset-radio-group");
       expect(groups[0]!.getAttribute("data-value")).toBe("");
+    });
+  });
+
+  describe("inline keyboard shortcut assignment (issue #7703)", () => {
+    const availability = {
+      claude: "ready",
+      gemini: "ready",
+      codex: "ready",
+    } as unknown as CliAvailability;
+
+    it("renders the shortcut pill when a binding is set and the edit affordance is always present", () => {
+      mockKeybindingDisplay = { "agent.claude": "⌘⌥C" };
+      mockSettings = settingsWith({ claude: { pinned: false } });
+
+      const { getByTestId, getAllByTestId } = render(
+        <AgentTrayButton agentAvailability={availability} />
+      );
+
+      const shortcutNodes = getAllByTestId("menu-shortcut").map((el) => el.textContent);
+      expect(shortcutNodes).toContain("⌘⌥C");
+      expect(getByTestId("agent-tray-shortcut-edit-claude")).toBeTruthy();
+    });
+
+    it("renders the edit affordance without a pill when the agent is unbound", () => {
+      mockKeybindingDisplay = {};
+      mockSettings = settingsWith({ claude: { pinned: false } });
+
+      const { getByTestId, queryAllByTestId } = render(
+        <AgentTrayButton agentAvailability={availability} />
+      );
+
+      expect(getByTestId("agent-tray-shortcut-edit-claude")).toBeTruthy();
+      const claudeRow = getByTestId("agent-tray-row-claude");
+      // No menu-shortcut node inside the row when unbound.
+      const shortcutsInRow = Array.from(
+        claudeRow.querySelectorAll('[data-testid="menu-shortcut"]')
+      );
+      expect(shortcutsInRow).toHaveLength(0);
+      // Other agents' edit affordances are independent.
+      expect(queryAllByTestId(/agent-tray-shortcut-edit-/).length).toBeGreaterThan(1);
+    });
+
+    it("clicking the edit affordance opens the inline capture and does not launch the agent", () => {
+      mockSettings = settingsWith({ claude: { pinned: false } });
+
+      const { getByTestId, queryByTestId } = render(
+        <AgentTrayButton agentAvailability={availability} />
+      );
+
+      const editButton = getByTestId("agent-tray-shortcut-edit-claude");
+      fireEvent.click(editButton);
+
+      expect(getByTestId("agent-tray-capture-claude")).toBeTruthy();
+      expect(getByTestId("mock-agent-shortcut-capture-claude")).toBeTruthy();
+      // The launch row for claude is replaced by the capture surface, so the
+      // launch onSelect path can't fire from this row.
+      expect(queryByTestId("agent-tray-row-claude")).toBeNull();
+      // No agent.launch dispatch was triggered by entering capture.
+      const launchDispatches = dispatchMock.mock.calls.filter((call) => call[0] === "agent.launch");
+      expect(launchDispatches).toHaveLength(0);
+    });
+
+    it("dispatches keybinding.setOverride and exits capture mode on save", async () => {
+      dispatchMock.mockResolvedValue({ ok: true });
+      mockSettings = settingsWith({ claude: { pinned: false } });
+
+      const { getByTestId, queryByTestId } = render(
+        <AgentTrayButton agentAvailability={availability} />
+      );
+
+      fireEvent.click(getByTestId("agent-tray-shortcut-edit-claude"));
+      expect(getByTestId("agent-tray-capture-claude")).toBeTruthy();
+
+      await act(async () => {
+        fireEvent.click(getByTestId("mock-agent-shortcut-save-claude"));
+      });
+
+      expect(dispatchMock).toHaveBeenCalledWith(
+        "keybinding.setOverride",
+        { actionId: "agent.claude", combo: ["Cmd+Alt+K"] },
+        { source: "user" }
+      );
+      expect(queryByTestId("agent-tray-capture-claude")).toBeNull();
+      expect(getByTestId("agent-tray-row-claude")).toBeTruthy();
+    });
+
+    it("Cancel from capture restores the row without dispatching anything", () => {
+      mockSettings = settingsWith({ claude: { pinned: false } });
+
+      const { getByTestId, queryByTestId } = render(
+        <AgentTrayButton agentAvailability={availability} />
+      );
+
+      fireEvent.click(getByTestId("agent-tray-shortcut-edit-claude"));
+      expect(getByTestId("agent-tray-capture-claude")).toBeTruthy();
+
+      fireEvent.click(getByTestId("mock-agent-shortcut-cancel-claude"));
+
+      expect(queryByTestId("agent-tray-capture-claude")).toBeNull();
+      expect(getByTestId("agent-tray-row-claude")).toBeTruthy();
+      const dispatchCalls = dispatchMock.mock.calls.filter(
+        (call) => call[0] === "keybinding.setOverride"
+      );
+      expect(dispatchCalls).toHaveLength(0);
     });
   });
 });

--- a/src/components/Settings/AgentSettings.tsx
+++ b/src/components/Settings/AgentSettings.tsx
@@ -27,6 +27,7 @@ import { AgentHelpOutput } from "./AgentHelpOutput";
 import { AgentCard, AgentInstallSection } from "@/components/agents/AgentCard";
 import { AgentShortcutCapture } from "@/components/KeyboardShortcuts";
 import { keybindingService } from "@/services/KeybindingService";
+import { notify } from "@/lib/notify";
 import type { DefaultAgentId } from "@/store/agentPreferencesStore";
 
 const GENERAL_SUBTAB_ID = "general";
@@ -54,6 +55,15 @@ function AgentShortcutRow({ agentId, agentName }: { agentId: BuiltInAgentId; age
         logError("[AgentSettings] Failed to save agent shortcut", undefined, {
           error: result.error,
         });
+        // Stay in capture mode so the user can retry — closing silently after
+        // a failed IPC would discard the captured combo with no recovery path.
+        notify({
+          type: "error",
+          message: "Couldn't save shortcut. Try again.",
+          duration: 3000,
+          priority: "high",
+        });
+        return;
       }
       setIsEditing(false);
     },
@@ -69,6 +79,12 @@ function AgentShortcutRow({ agentId, agentName }: { agentId: BuiltInAgentId; age
     if (!result.ok) {
       logError("[AgentSettings] Failed to reset agent shortcut", undefined, {
         error: result.error,
+      });
+      notify({
+        type: "error",
+        message: "Couldn't reset shortcut. Try again.",
+        duration: 3000,
+        priority: "high",
       });
     }
   }, [actionId]);

--- a/src/components/Settings/AgentSettings.tsx
+++ b/src/components/Settings/AgentSettings.tsx
@@ -178,7 +178,7 @@ export function AgentSettings({
   const [loadTimedOut, setLoadTimedOut] = useState(false);
 
   useEffect(() => {
-    initialize();
+    void initialize();
     setLoadTimedOut(false);
     const timer = setTimeout(() => setLoadTimedOut(true), 10_000);
     return () => clearTimeout(timer);

--- a/src/components/Settings/AgentSettings.tsx
+++ b/src/components/Settings/AgentSettings.tsx
@@ -15,6 +15,7 @@ import {
   type AgentCliDetails,
 } from "@shared/types";
 import { isAgentToolbarVisible } from "../../../shared/utils/agentPinned";
+import { isBuiltInAgentId, type BuiltInAgentId } from "@shared/config/agentIds";
 import { RotateCcw, ExternalLink } from "lucide-react";
 import { Plug } from "@/components/icons";
 import { AgentSelectorDropdown } from "./AgentSelectorDropdown";
@@ -24,9 +25,111 @@ import { AgentScopeEditor } from "./AgentScopeEditor";
 import { actionService } from "@/services/ActionService";
 import { AgentHelpOutput } from "./AgentHelpOutput";
 import { AgentCard, AgentInstallSection } from "@/components/agents/AgentCard";
+import { AgentShortcutCapture } from "@/components/KeyboardShortcuts";
+import { keybindingService } from "@/services/KeybindingService";
 import type { DefaultAgentId } from "@/store/agentPreferencesStore";
 
 const GENERAL_SUBTAB_ID = "general";
+
+function AgentShortcutRow({ agentId, agentName }: { agentId: BuiltInAgentId; agentName: string }) {
+  const actionId = `agent.${agentId}`;
+  const displayCombo = useKeybindingDisplay(actionId);
+  const [isEditing, setIsEditing] = useState(false);
+  const [isOverridden, setIsOverridden] = useState(() => keybindingService.hasOverride(actionId));
+
+  useEffect(() => {
+    const update = () => setIsOverridden(keybindingService.hasOverride(actionId));
+    update();
+    return keybindingService.subscribe(update);
+  }, [actionId]);
+
+  const handleSave = useCallback(
+    async (combo: string) => {
+      const result = await actionService.dispatch(
+        "keybinding.setOverride",
+        { actionId, combo: combo === "" ? [] : [combo] },
+        { source: "user" }
+      );
+      if (!result.ok) {
+        logError("[AgentSettings] Failed to save agent shortcut", undefined, {
+          error: result.error,
+        });
+      }
+      setIsEditing(false);
+    },
+    [actionId]
+  );
+
+  const handleReset = useCallback(async () => {
+    const result = await actionService.dispatch(
+      "keybinding.removeOverride",
+      { actionId },
+      { source: "user" }
+    );
+    if (!result.ok) {
+      logError("[AgentSettings] Failed to reset agent shortcut", undefined, {
+        error: result.error,
+      });
+    }
+  }, [actionId]);
+
+  return (
+    <div
+      id={`agents-shortcut-${agentId}`}
+      data-testid={`agent-shortcut-row-${agentId}`}
+      className="rounded-[var(--radius-lg)] border border-daintree-border bg-surface p-3 space-y-3"
+    >
+      <div className="flex items-start justify-between gap-3">
+        <div className="min-w-0">
+          <div className="text-sm font-medium text-daintree-text">Keyboard shortcut</div>
+          <div className="text-xs text-daintree-text/50 mt-0.5 select-text">
+            Launch {agentName} from anywhere with a key combination
+          </div>
+        </div>
+        {!isEditing && (
+          <div className="flex items-center gap-2 shrink-0">
+            {displayCombo ? (
+              <span
+                data-testid={`agent-shortcut-pill-${agentId}`}
+                className="px-2 py-0.5 text-xs font-mono rounded bg-daintree-border text-daintree-text"
+              >
+                {displayCombo}
+              </span>
+            ) : (
+              <span className="text-xs text-daintree-text/60 italic">Unbound</span>
+            )}
+            <button
+              type="button"
+              onClick={() => setIsEditing(true)}
+              data-testid={`agent-shortcut-edit-${agentId}`}
+              className="px-2 py-0.5 text-xs text-daintree-text/60 hover:text-daintree-text transition-colors"
+            >
+              {displayCombo ? "Change" : "Assign"}
+            </button>
+            {isOverridden && (
+              <button
+                type="button"
+                onClick={() => void handleReset()}
+                aria-label={`Reset ${agentName} shortcut to default`}
+                data-testid={`agent-shortcut-reset-${agentId}`}
+                className="p-0.5 text-daintree-text/60 hover:text-daintree-text transition-colors"
+              >
+                <RotateCcw className="w-3 h-3" />
+              </button>
+            )}
+          </div>
+        )}
+      </div>
+      {isEditing && (
+        <AgentShortcutCapture
+          agentId={agentId}
+          onCapture={(combo) => void handleSave(combo)}
+          onCancel={() => setIsEditing(false)}
+        />
+      )}
+    </div>
+  );
+}
 
 interface AgentSettingsProps {
   activeSubtab: string | null;
@@ -395,6 +498,12 @@ export function AgentSettings({
                 ariaLabel={`Pin ${activeAgent.name} to toolbar`}
               />
             </div>
+
+            {/* Keyboard shortcut — built-in agents only; user-defined agents
+                don't participate in the keybinding registry. */}
+            {isBuiltInAgentId(activeAgent.id) && (
+              <AgentShortcutRow agentId={activeAgent.id} agentName={activeAgent.name} />
+            )}
 
             {/* Unified scope editor — one set of controls for Default or any
                 preset. Delegates to AgentScopeEditor (useAgentScope hook + six


### PR DESCRIPTION
Closes #7703.

## Summary

Adds inline keyboard-shortcut assignment to the agent tray and Manage Agents settings, so users can bind a launch shortcut without leaving the surface that prompted them.

- **Agent tray** (`AgentTrayButton`): hover-revealed Keyboard-icon affordance on each `LaunchRow` opens an inline capture surface in place of the row. A file-local `AgentTrayCapturingContext` coordinates Escape behavior and prevents premature dropdown dismissal.
- **Manage Agents**: new shortcut row beneath the *Pin to toolbar* toggle, gated on `isBuiltInAgentId` so user-defined agents stay out of scope.
- **Convention enforcement**: new thin `AgentShortcutCapture` wrapper rejects anything other than `Cmd+Alt+letter` (Mac) / `Ctrl+Alt+letter` (Win/Linux). The shared `SettingsShortcutCapture` gains a generic `validateCombo` prop so domain copy stays out of the primitive.

## Review-driven fixes

- Window blur during recording now invokes `onCancel` so parent capture state clears — fixes a tray lock-in after Cmd+Tab.
- Save failures stay in capture mode and surface an error toast instead of silently discarding the captured combo.
- Conflicts panel is suppressed while a validation error is active, so users can't unbind for combos that can never save.
- `conflictRefreshKey` is now wired into the `conflicts` memo dependency array so dismissed conflicts disappear immediately after Unbind.

## Past lessons applied

- #1678 — Cmd+Alt+letter macOS Alt-transform: handled via existing `normalizeKeyForBinding`.
- #3831 — Escape stack: tray relies on Radix `onEscapeKeyDown` guard because `SettingsShortcutCapture`'s capture-phase `stopPropagation` prevents the global Escape dispatcher from firing during active recording.
- #4588 — Radix DismissableLayer Escape: guarded explicitly.
- #4591 — Modifier reset on window blur: implemented.

## Test plan

- [x] `npx vitest run src/components/KeyboardShortcuts/__tests__/SettingsShortcutCapture.test.tsx src/components/KeyboardShortcuts/__tests__/AgentShortcutCapture.test.tsx src/components/Layout/__tests__/AgentTrayButton.test.tsx` — 98 tests pass
- [x] `npx tsc --noEmit` — clean
- [x] `npx eslint` on changed files — clean
- [x] `npm run check` + build — pass
- [ ] Manual: open agent tray, hover a row, click the keyboard icon, record `Cmd+Opt+K`, verify the pill updates without closing the dropdown
- [ ] Manual: open Manage Agents → Claude, set a custom shortcut, reset to default, verify both states behave
- [ ] Manual: start recording in the tray, Cmd+Tab away, return — confirm the capture surface dismisses and the dropdown is still dismissable