### PR TITLE
feat(project-switcher): prefetch hydrate payload on row hover

### DIFF
--- a/electron/ipc/channels.ts
+++ b/electron/ipc/channels.ts
@@ -205,6 +205,7 @@ export const CHANNELS = {
   PROJECT_UPDATED: "project:updated",
   PROJECT_REMOVED: "project:removed",
   PROJECT_SWITCH: "project:switch",
+  PROJECT_PREFETCH_HYDRATE: "project:prefetch-hydrate",
   PROJECT_OPEN_DIALOG: "project:open-dialog",
   PROJECT_ON_SWITCH: "project:on-switch",
   PROJECT_GET_SETTINGS: "project:get-settings",

--- a/electron/ipc/handlers/app/state.ts
+++ b/electron/ipc/handlers/app/state.ts
@@ -18,6 +18,7 @@ import { typedHandle, typedHandleWithContext } from "../../utils.js";
 import { signalFirstInteractive } from "../../../window/deferredInitQueue.js";
 import { markPerformance } from "../../../utils/performance.js";
 import { PERF_MARKS } from "../../../../shared/perf/marks.js";
+import { consumePrefetchedHydrateResult } from "../../../services/prefetchHydrateCache.js";
 
 export function registerAppStateHandlers(): () => void {
   const handlers: Array<() => void> = [];
@@ -31,6 +32,26 @@ export function registerAppStateHandlers(): () => void {
       panelFilter !== null &&
       Array.isArray(globalAppState.terminals) &&
       globalAppState.terminals.length > 0;
+
+    // Hover-prefetch fast path: when a project switcher hover (or any other
+    // pre-populated path) has primed the cache for this project, short-circuit
+    // the disk read. Only safe when there's no in-flight crash recovery filter
+    // and we aren't booting in safe mode — those scenarios layer constraints
+    // (`panelFilter`, dropped terminals) that the prefetch built without.
+    const cacheGuard = getCrashLoopGuard();
+    const cacheInSafeMode = cacheGuard.isSafeMode();
+    if (projectId && panelFilter === null && !cacheInSafeMode) {
+      const cached = consumePrefetchedHydrateResult(projectId);
+      if (cached) {
+        return {
+          ...cached,
+          skippedPanelCount: 0,
+          crashCount: cacheGuard.getCrashCount(),
+          lastCrashAt: cacheGuard.getLastCrashTimestamp(),
+          settingsRecovery: consumePendingSettingsRecovery(),
+        };
+      }
+    }
 
     // First, try to get terminals from per-project state (new model)
     // Fall back to global appState.terminals for migration

--- a/electron/ipc/handlers/projectCrud/index.ts
+++ b/electron/ipc/handlers/projectCrud/index.ts
@@ -17,6 +17,7 @@ import { registerProjectSettingsHandlers } from "./settings.js";
 import { registerProjectStatsHandlers } from "./stats.js";
 import { registerGitInitHandlers } from "./gitInit.js";
 import { registerGitCloneHandlers } from "./gitClone.js";
+import { registerProjectPrefetchHandlers } from "./prefetch.js";
 
 export { getProjectStatsService } from "./stats.js";
 
@@ -28,6 +29,7 @@ export function registerProjectCrudHandlers(deps: HandlerDependencies): () => vo
     registerProjectSettingsHandlers(),
     registerGitInitHandlers(),
     registerGitCloneHandlers(),
+    registerProjectPrefetchHandlers(),
   ];
 
   return () => cleanups.forEach((cleanup) => cleanup());

--- a/electron/ipc/handlers/projectCrud/prefetch.ts
+++ b/electron/ipc/handlers/projectCrud/prefetch.ts
@@ -1,0 +1,29 @@
+import { CHANNELS } from "../../channels.js";
+import { typedHandle } from "../../utils.js";
+import { buildSwitchHydrateResult } from "../../../services/AppHydrationService.js";
+import { prefetchHydrateResult } from "../../../services/prefetchHydrateCache.js";
+import { projectStore } from "../../../services/ProjectStore.js";
+
+/**
+ * Hover-prefetch entry point for the project switcher palette. The renderer
+ * fires this as a debounced, fire-and-forget call when the mouse settles on a
+ * project row for 150ms; the main process builds the `HydrateResult` payload
+ * and caches it so the subsequent `app:hydrate` call from the new project view
+ * resolves as a cache hit (no second disk read).
+ *
+ * Errors are swallowed inside the cache layer — a failed prefetch must never
+ * surface to the user, since the click-time hydrate will simply fall through
+ * to the normal read path.
+ */
+export function registerProjectPrefetchHandlers(): () => void {
+  const handlers: Array<() => void> = [];
+
+  const handleProjectPrefetchHydrate = async (projectId: string): Promise<void> => {
+    if (typeof projectId !== "string" || !projectId) return;
+    if (!projectStore.getProjectById(projectId)) return;
+    await prefetchHydrateResult(projectId, buildSwitchHydrateResult);
+  };
+  handlers.push(typedHandle(CHANNELS.PROJECT_PREFETCH_HYDRATE, handleProjectPrefetchHydrate));
+
+  return () => handlers.forEach((cleanup) => cleanup());
+}

--- a/electron/preload.cts
+++ b/electron/preload.cts
@@ -1231,6 +1231,9 @@ const api: ElectronAPI = {
       outgoingState?: import("../shared/types/ipc/project.js").ProjectSwitchOutgoingState
     ) => _unwrappingInvoke(CHANNELS.PROJECT_SWITCH, projectId, outgoingState),
 
+    prefetchHydrate: (projectId: string) =>
+      _unwrappingInvoke(CHANNELS.PROJECT_PREFETCH_HYDRATE, projectId),
+
     openDialog: () => _unwrappingInvoke(CHANNELS.PROJECT_OPEN_DIALOG),
 
     onSwitch: (

--- a/electron/services/ProjectStore.ts
+++ b/electron/services/ProjectStore.ts
@@ -26,6 +26,7 @@ import { eq, desc } from "drizzle-orm";
 import { generateProjectId, getProjectStateDir } from "./projectStorePaths.js";
 import { ProjectSettingsManager } from "./ProjectSettingsManager.js";
 import { ProjectStateManager, type ProjectStateReadResult } from "./ProjectStateManager.js";
+import { invalidatePrefetchCache } from "./prefetchHydrateCache.js";
 import { ProjectFileStore } from "./ProjectFileStore.js";
 import { GlobalFileStore } from "./GlobalFileStore.js";
 import { ProjectIdentityFiles } from "./ProjectIdentityFiles.js";
@@ -601,6 +602,10 @@ export class ProjectStore {
   // --- State ---
 
   async saveProjectState(projectId: string, state: ProjectState): Promise<void> {
+    // Invalidate before the write so any in-flight prefetch sees a version bump
+    // and discards its result — otherwise a prefetch resolving after the write
+    // could clobber the cache with pre-mutation state.
+    invalidatePrefetchCache(projectId);
     return this.stateManager.saveProjectState(projectId, state);
   }
 

--- a/electron/services/__tests__/prefetchHydrateCache.test.ts
+++ b/electron/services/__tests__/prefetchHydrateCache.test.ts
@@ -1,0 +1,153 @@
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+import type { HydrateResult } from "../../../shared/types/ipc/app.js";
+import {
+  prefetchHydrateResult,
+  consumePrefetchedHydrateResult,
+  invalidatePrefetchCache,
+  _resetPrefetchHydrateCacheForTests,
+  _peekPrefetchCacheForTests,
+} from "../prefetchHydrateCache.js";
+
+function makeHydrate(projectId: string): HydrateResult {
+  return {
+    appState: {
+      terminals: [],
+      sidebarWidth: 350,
+    } as unknown as HydrateResult["appState"],
+    terminalConfig: {} as HydrateResult["terminalConfig"],
+    project: {
+      id: projectId,
+      name: `Project ${projectId}`,
+      path: `/p/${projectId}`,
+      emoji: "🌲",
+      lastOpened: 0,
+    } as HydrateResult["project"],
+    agentSettings: {} as HydrateResult["agentSettings"],
+    gpuWebGLHardware: true,
+    gpuHardwareAccelerationDisabled: false,
+    safeMode: false,
+    settingsRecovery: null,
+    projectStateRecovery: null,
+  };
+}
+
+beforeEach(() => {
+  _resetPrefetchHydrateCacheForTests();
+});
+
+afterEach(() => {
+  vi.useRealTimers();
+  _resetPrefetchHydrateCacheForTests();
+});
+
+describe("prefetchHydrateCache", () => {
+  it("populates the cache with the build result", async () => {
+    const build = vi.fn().mockResolvedValue(makeHydrate("p1"));
+
+    const result = await prefetchHydrateResult("p1", build);
+
+    expect(result).toBeDefined();
+    expect(result!.project!.id).toBe("p1");
+    expect(_peekPrefetchCacheForTests("p1")?.project?.id).toBe("p1");
+    expect(build).toHaveBeenCalledTimes(1);
+  });
+
+  it("singleflights concurrent calls for the same project", async () => {
+    let resolve: ((v: HydrateResult) => void) | null = null;
+    const build = vi.fn().mockImplementationOnce(
+      () =>
+        new Promise<HydrateResult>((r) => {
+          resolve = r;
+        })
+    );
+
+    const a = prefetchHydrateResult("p1", build);
+    const b = prefetchHydrateResult("p1", build);
+
+    expect(build).toHaveBeenCalledTimes(1);
+
+    resolve!(makeHydrate("p1"));
+    const [ra, rb] = await Promise.all([a, b]);
+
+    expect(ra).toBe(rb);
+  });
+
+  it("consumePrefetchedHydrateResult returns the value once and deletes it", async () => {
+    await prefetchHydrateResult("p1", () => Promise.resolve(makeHydrate("p1")));
+
+    const first = consumePrefetchedHydrateResult("p1");
+    expect(first?.project?.id).toBe("p1");
+
+    const second = consumePrefetchedHydrateResult("p1");
+    expect(second).toBeUndefined();
+  });
+
+  it("returns undefined when the cache has expired", async () => {
+    vi.useFakeTimers();
+    vi.setSystemTime(new Date("2026-01-01T00:00:00Z"));
+
+    await prefetchHydrateResult("p1", () => Promise.resolve(makeHydrate("p1")));
+
+    // Advance just past the 30s TTL.
+    vi.setSystemTime(new Date("2026-01-01T00:00:31Z"));
+
+    const result = consumePrefetchedHydrateResult("p1");
+    expect(result).toBeUndefined();
+  });
+
+  it("invalidatePrefetchCache(projectId) removes the entry", async () => {
+    await prefetchHydrateResult("p1", () => Promise.resolve(makeHydrate("p1")));
+
+    invalidatePrefetchCache("p1");
+
+    expect(consumePrefetchedHydrateResult("p1")).toBeUndefined();
+  });
+
+  it("invalidatePrefetchCache() with no arg clears everything", async () => {
+    await prefetchHydrateResult("p1", () => Promise.resolve(makeHydrate("p1")));
+    await prefetchHydrateResult("p2", () => Promise.resolve(makeHydrate("p2")));
+
+    invalidatePrefetchCache();
+
+    expect(consumePrefetchedHydrateResult("p1")).toBeUndefined();
+    expect(consumePrefetchedHydrateResult("p2")).toBeUndefined();
+  });
+
+  it("drops the result of an in-flight prefetch if invalidated mid-flight", async () => {
+    let resolve: ((v: HydrateResult) => void) | null = null;
+    const build = vi.fn().mockImplementationOnce(
+      () =>
+        new Promise<HydrateResult>((r) => {
+          resolve = r;
+        })
+    );
+
+    const pending = prefetchHydrateResult("p1", build);
+    invalidatePrefetchCache("p1");
+    resolve!(makeHydrate("p1"));
+    const result = await pending;
+
+    expect(result).toBeNull();
+    expect(consumePrefetchedHydrateResult("p1")).toBeUndefined();
+  });
+
+  it("returns null and clears in-flight ref when build throws", async () => {
+    const build = vi.fn().mockRejectedValueOnce(new Error("boom"));
+
+    const result = await prefetchHydrateResult("p1", build);
+    expect(result).toBeNull();
+    expect(consumePrefetchedHydrateResult("p1")).toBeUndefined();
+
+    // A second hover should not see a stuck in-flight ref.
+    const second = await prefetchHydrateResult("p1", () => Promise.resolve(makeHydrate("p1")));
+    expect(second?.project?.id).toBe("p1");
+  });
+
+  it("caches different projects independently", async () => {
+    await prefetchHydrateResult("p1", () => Promise.resolve(makeHydrate("p1")));
+    await prefetchHydrateResult("p2", () => Promise.resolve(makeHydrate("p2")));
+
+    expect(consumePrefetchedHydrateResult("p1")?.project?.id).toBe("p1");
+    expect(consumePrefetchedHydrateResult("p2")?.project?.id).toBe("p2");
+  });
+});

--- a/electron/services/__tests__/prefetchHydrateCache.test.ts
+++ b/electron/services/__tests__/prefetchHydrateCache.test.ts
@@ -143,6 +143,29 @@ describe("prefetchHydrateCache", () => {
     expect(second?.project?.id).toBe("p1");
   });
 
+  it("drops the result of an in-flight first-ever prefetch when globally invalidated", async () => {
+    // Regression: invalidatePrefetchCache() (no arg) must bump version counters
+    // for projects whose first-ever build is still in flight — otherwise that
+    // build resolves with versionAtStart === currentVersion === 0 and commits
+    // a stale payload even though every other consumer thinks the cache is
+    // cleared.
+    let resolve: ((v: HydrateResult) => void) | null = null;
+    const build = vi.fn().mockImplementationOnce(
+      () =>
+        new Promise<HydrateResult>((r) => {
+          resolve = r;
+        })
+    );
+
+    const pending = prefetchHydrateResult("p1", build);
+    invalidatePrefetchCache();
+    resolve!(makeHydrate("p1"));
+    const result = await pending;
+
+    expect(result).toBeNull();
+    expect(consumePrefetchedHydrateResult("p1")).toBeUndefined();
+  });
+
   it("caches different projects independently", async () => {
     await prefetchHydrateResult("p1", () => Promise.resolve(makeHydrate("p1")));
     await prefetchHydrateResult("p2", () => Promise.resolve(makeHydrate("p2")));

--- a/electron/services/prefetchHydrateCache.ts
+++ b/electron/services/prefetchHydrateCache.ts
@@ -98,7 +98,12 @@ export function consumePrefetchedHydrateResult(projectId: string): HydrateResult
 export function invalidatePrefetchCache(projectId?: string): void {
   if (projectId === undefined) {
     cache.clear();
-    for (const key of invalidationVersions.keys()) {
+    // Bump every known projectId — including any with an in-flight build that
+    // has not yet recorded a version (the project's first-ever prefetch).
+    // Without iterating `inflight` here, that first build would resolve with
+    // versionAtStart === currentVersion === 0 and commit a stale result.
+    const seen = new Set<string>([...invalidationVersions.keys(), ...inflight.keys()]);
+    for (const key of seen) {
       nextVersion(key);
     }
     return;

--- a/electron/services/prefetchHydrateCache.ts
+++ b/electron/services/prefetchHydrateCache.ts
@@ -1,4 +1,5 @@
 import type { HydrateResult } from "../../shared/types/ipc/app.js";
+import { formatErrorMessage } from "../../shared/utils/errorMessage.js";
 
 /**
  * Main-process cache of pre-built `HydrateResult` payloads, populated by hover
@@ -53,7 +54,8 @@ export function prefetchHydrateResult(
   if (existing) return existing;
 
   const versionAtStart = currentVersion(projectId);
-  const promise = (async () => {
+  let promise: Promise<HydrateResult | null> | null = null;
+  promise = (async () => {
     try {
       const result = await build(projectId);
       if (currentVersion(projectId) !== versionAtStart) {
@@ -64,11 +66,11 @@ export function prefetchHydrateResult(
     } catch (error) {
       console.warn(
         `[prefetchHydrateCache] Prefetch failed for project ${projectId}:`,
-        error instanceof Error ? error.message : error
+        formatErrorMessage(error, "prefetch failed")
       );
       return null;
     } finally {
-      if (inflight.get(projectId) === promise) {
+      if (promise && inflight.get(projectId) === promise) {
         inflight.delete(projectId);
       }
     }

--- a/electron/services/prefetchHydrateCache.ts
+++ b/electron/services/prefetchHydrateCache.ts
@@ -1,0 +1,121 @@
+import type { HydrateResult } from "../../shared/types/ipc/app.js";
+
+/**
+ * Main-process cache of pre-built `HydrateResult` payloads, populated by hover
+ * prefetches from the project switcher palette and consumed by `handleAppHydrate`
+ * when the new project view boots. Lives in its own module to avoid the
+ * `ProjectStore` ↔ `AppHydrationService` import cycle that would form if either
+ * side owned the cache directly.
+ */
+
+const PREFETCH_TTL_MS = 30_000;
+
+interface CacheEntry {
+  result: HydrateResult;
+  expiresAt: number;
+}
+
+const cache = new Map<string, CacheEntry>();
+const inflight = new Map<string, Promise<HydrateResult | null>>();
+
+/**
+ * Bumped on every invalidation for a given project. The async prefetch path
+ * snapshots the value before kicking off `buildSwitchHydrateResult` and only
+ * commits the resulting payload if the version is unchanged afterwards — this
+ * defeats the save-during-prefetch race without a full version counter on
+ * every read.
+ */
+const invalidationVersions = new Map<string, number>();
+
+function nextVersion(projectId: string): number {
+  const v = (invalidationVersions.get(projectId) ?? 0) + 1;
+  invalidationVersions.set(projectId, v);
+  return v;
+}
+
+function currentVersion(projectId: string): number {
+  return invalidationVersions.get(projectId) ?? 0;
+}
+
+/**
+ * Run a prefetch for `projectId` if none is in flight, singleflighting concurrent
+ * callers behind the same promise. The result is committed to the cache only if
+ * no invalidation occurred during the build — stale prefetches are dropped silently.
+ *
+ * Errors are caught and swallowed so callers never need to handle them; the
+ * eventual `handleAppHydrate` call simply falls through to the full read path.
+ */
+export function prefetchHydrateResult(
+  projectId: string,
+  build: (projectId: string) => Promise<HydrateResult>
+): Promise<HydrateResult | null> {
+  const existing = inflight.get(projectId);
+  if (existing) return existing;
+
+  const versionAtStart = currentVersion(projectId);
+  const promise = (async () => {
+    try {
+      const result = await build(projectId);
+      if (currentVersion(projectId) !== versionAtStart) {
+        return null;
+      }
+      cache.set(projectId, { result, expiresAt: Date.now() + PREFETCH_TTL_MS });
+      return result;
+    } catch (error) {
+      console.warn(
+        `[prefetchHydrateCache] Prefetch failed for project ${projectId}:`,
+        error instanceof Error ? error.message : error
+      );
+      return null;
+    } finally {
+      if (inflight.get(projectId) === promise) {
+        inflight.delete(projectId);
+      }
+    }
+  })();
+  inflight.set(projectId, promise);
+  return promise;
+}
+
+/**
+ * Return-and-delete: consumes the cached payload so the same prefetch never
+ * services two hydrates. Returns `undefined` on miss or when the entry has
+ * expired (the consumer falls back to the normal hydrate read path in that case).
+ */
+export function consumePrefetchedHydrateResult(projectId: string): HydrateResult | undefined {
+  const entry = cache.get(projectId);
+  if (!entry) return undefined;
+  cache.delete(projectId);
+  if (entry.expiresAt <= Date.now()) return undefined;
+  return entry.result;
+}
+
+/**
+ * Drop any cached payload for `projectId` and bump the invalidation version so
+ * any concurrently in-flight prefetch's result is discarded on resolution. Called
+ * from `ProjectStore.saveProjectState` whenever project state mutates.
+ */
+export function invalidatePrefetchCache(projectId?: string): void {
+  if (projectId === undefined) {
+    cache.clear();
+    for (const key of invalidationVersions.keys()) {
+      nextVersion(key);
+    }
+    return;
+  }
+  cache.delete(projectId);
+  nextVersion(projectId);
+}
+
+/** Test-only reset. Clears cache, in-flight promises, and invalidation versions. */
+export function _resetPrefetchHydrateCacheForTests(): void {
+  cache.clear();
+  inflight.clear();
+  invalidationVersions.clear();
+}
+
+/** Test-only inspection. */
+export function _peekPrefetchCacheForTests(projectId: string): HydrateResult | undefined {
+  const entry = cache.get(projectId);
+  return entry?.result;
+}

--- a/shared/types/ipc/api.ts
+++ b/shared/types/ipc/api.ts
@@ -452,6 +452,13 @@ export interface ElectronAPI {
     remove(projectId: string): Promise<void>;
     update(projectId: string, updates: Partial<Project>): Promise<Project>;
     switch(projectId: string, outgoingState?: ProjectSwitchOutgoingState): Promise<Project>;
+    /**
+     * Hover-prefetch trigger for the project switcher palette. Fire-and-forget:
+     * the main process builds the `HydrateResult` for the given project and
+     * caches it so the next `app:hydrate` call from the new project view
+     * resolves as a cache hit. Errors are swallowed in the cache layer.
+     */
+    prefetchHydrate(projectId: string): Promise<void>;
     openDialog(): Promise<string | null>;
     onSwitch(
       callback: (payload: {

--- a/shared/types/ipc/maps.ts
+++ b/shared/types/ipc/maps.ts
@@ -809,6 +809,10 @@ export interface IpcInvokeMap {
     args: [projectId: string, outgoingState?: ProjectSwitchOutgoingState];
     result: Project;
   };
+  "project:prefetch-hydrate": {
+    args: [projectId: string];
+    result: void;
+  };
   "project:open-dialog": {
     args: [];
     result: string | null;

--- a/src/App.tsx
+++ b/src/App.tsx
@@ -895,6 +895,8 @@ function App() {
                   onSelectPrevious={projectSwitcherPalette.selectPrevious}
                   onSelectNext={projectSwitcherPalette.selectNext}
                   onSelect={projectSwitcherPalette.selectProject}
+                  onHoverProject={projectSwitcherPalette.onHoverProject}
+                  onHoverProjectEnd={projectSwitcherPalette.onHoverProjectEnd}
                   onClose={projectSwitcherPalette.close}
                   onStopProject={(projectId) => void projectSwitcherPalette.stopProject(projectId)}
                   onCloseProject={(projectId) =>

--- a/src/clients/projectClient.ts
+++ b/src/clients/projectClient.ts
@@ -122,6 +122,15 @@ export const projectClient = {
     return window.electron.project.switch(projectId, outgoingState);
   },
 
+  /**
+   * Hover-prefetch the main-process `HydrateResult` cache for `projectId`.
+   * Fire-and-forget: errors are swallowed so a failed prefetch never surfaces
+   * to the user — the click-time hydrate falls through to the normal read path.
+   */
+  prefetchHydrate: (projectId: string): Promise<void> => {
+    return window.electron.project.prefetchHydrate(projectId).catch(() => undefined);
+  },
+
   openDialog: (): Promise<string | null> => {
     return window.electron.project.openDialog();
   },

--- a/src/components/Layout/Toolbar.tsx
+++ b/src/components/Layout/Toolbar.tsx
@@ -1005,6 +1005,8 @@ export function Toolbar({
             onSelectPrevious={projectSwitcher.selectPrevious}
             onSelectNext={projectSwitcher.selectNext}
             onSelect={projectSwitcher.selectProject}
+            onHoverProject={projectSwitcher.onHoverProject}
+            onHoverProjectEnd={projectSwitcher.onHoverProjectEnd}
             onClose={handleDropdownClose}
             onAddProject={projectSwitcher.addProject}
             onCloneRepo={projectSwitcher.cloneRepo}

--- a/src/components/Project/ProjectSwitcher.tsx
+++ b/src/components/Project/ProjectSwitcher.tsx
@@ -175,6 +175,8 @@ export function ProjectSwitcher() {
             onCopyPath={handleCopyPath}
             onSelectBackground={handleSelectBackground}
             onSelectNewWindow={handleSelectNewWindow}
+            onHoverProject={projectSwitcher.onHoverProject}
+            onHoverProjectEnd={projectSwitcher.onHoverProjectEnd}
             removeConfirmProject={projectSwitcher.removeConfirmProject}
             onRemoveConfirmClose={() => projectSwitcher.setRemoveConfirmProject(null)}
             onConfirmRemove={projectSwitcher.confirmRemoveProject}
@@ -242,6 +244,8 @@ export function ProjectSwitcher() {
         onOpenProjectSettings={handleOpenSettings}
         onCopyPath={handleCopyPath}
         onSelectBackground={handleSelectBackground}
+        onHoverProject={projectSwitcher.onHoverProject}
+        onHoverProjectEnd={projectSwitcher.onHoverProjectEnd}
         removeConfirmProject={projectSwitcher.removeConfirmProject}
         onRemoveConfirmClose={() => projectSwitcher.setRemoveConfirmProject(null)}
         onConfirmRemove={projectSwitcher.confirmRemoveProject}

--- a/src/components/Project/ProjectSwitcherPalette.tsx
+++ b/src/components/Project/ProjectSwitcherPalette.tsx
@@ -72,6 +72,10 @@ export interface ProjectSwitcherPaletteProps {
   onCopyPath?: (path: string) => void;
   onSelectBackground?: (project: SearchableProject) => void;
   onSelectNewWindow?: (project: SearchableProject) => void;
+  /** Pointer-enter callback used to schedule a hover prefetch of the project's hydrate payload. */
+  onHoverProject?: (projectId: string, pointerType: string) => void;
+  /** Pointer-leave callback used to cancel a pending hover prefetch. */
+  onHoverProjectEnd?: (pointerType: string) => void;
   onOpenProjectSettings?: () => void;
   dropdownAlign?: "start" | "center" | "end";
   children?: React.ReactNode;
@@ -112,6 +116,8 @@ interface ProjectListItemProps {
   onTogglePinProject?: (projectId: string) => void;
   onCopyPath?: (path: string) => void;
   onSelectNewWindow?: (project: SearchableProject) => void;
+  onHoverProject?: (projectId: string, pointerType: string) => void;
+  onHoverProjectEnd?: (pointerType: string) => void;
 }
 
 const StatusDot = memo(function StatusDot({ project }: { project: SearchableProject }) {
@@ -161,6 +167,8 @@ const ProjectListItem = memo(function ProjectListItem({
   onTogglePinProject,
   onCopyPath,
   onSelectNewWindow,
+  onHoverProject,
+  onHoverProjectEnd,
 }: ProjectListItemProps) {
   const showStop = project.processCount > 0 && !project.isMissing;
 
@@ -204,6 +212,8 @@ const ProjectListItem = memo(function ProjectListItem({
               : "text-daintree-text/70 hover:bg-overlay-soft hover:text-daintree-text cursor-pointer"
       )}
       onClick={() => !project.isActive && !project.isMissing && onSelect(project)}
+      onPointerEnter={onHoverProject ? (e) => onHoverProject(project.id, e.pointerType) : undefined}
+      onPointerLeave={onHoverProjectEnd ? (e) => onHoverProjectEnd(e.pointerType) : undefined}
     >
       <StatusDot project={project} />
 
@@ -343,6 +353,8 @@ interface ProjectListContentProps {
   onTogglePinProject?: (projectId: string) => void;
   onCopyPath?: (path: string) => void;
   onSelectNewWindow?: (project: SearchableProject) => void;
+  onHoverProject?: (projectId: string, pointerType: string) => void;
+  onHoverProjectEnd?: (pointerType: string) => void;
 }
 
 function ProjectListContent({
@@ -358,6 +370,8 @@ function ProjectListContent({
   onTogglePinProject,
   onCopyPath,
   onSelectNewWindow,
+  onHoverProject,
+  onHoverProjectEnd,
 }: ProjectListContentProps) {
   const isSearching = query.trim().length > 0;
 
@@ -425,6 +439,8 @@ function ProjectListContent({
           onTogglePinProject={onTogglePinProject}
           onCopyPath={onCopyPath}
           onSelectNewWindow={onSelectNewWindow}
+          onHoverProject={onHoverProject}
+          onHoverProjectEnd={onHoverProjectEnd}
         />
       </div>
     );
@@ -703,6 +719,8 @@ interface ProjectPaletteInnerProps {
   onLocateProject?: (projectId: string) => void;
   onTogglePinProject?: (projectId: string) => void;
   onCopyPath?: (path: string) => void;
+  onHoverProject?: (projectId: string, pointerType: string) => void;
+  onHoverProjectEnd?: (pointerType: string) => void;
   scratchResults?: SearchableScratch[];
   onCreateScratch?: () => void;
   onSelectScratch?: (scratch: SearchableScratch) => void;
@@ -733,6 +751,8 @@ function ProjectPaletteInner({
   onLocateProject,
   onTogglePinProject,
   onCopyPath,
+  onHoverProject,
+  onHoverProjectEnd,
   scratchResults,
   onCreateScratch,
   onSelectScratch,
@@ -855,6 +875,8 @@ function ProjectPaletteInner({
           onTogglePinProject={onTogglePinProject}
           onCopyPath={onCopyPath}
           onSelectNewWindow={onSelectNewWindow}
+          onHoverProject={onHoverProject}
+          onHoverProjectEnd={onHoverProjectEnd}
         />
         {(onCreateScratch || (scratchResults && scratchResults.length > 0)) && (
           <>
@@ -1043,6 +1065,8 @@ function ModalContent({
           onCopyPath={innerProps.onCopyPath}
           onSelectBackground={innerProps.onSelectBackground}
           onSelectNewWindow={innerProps.onSelectNewWindow}
+          onHoverProject={innerProps.onHoverProject}
+          onHoverProjectEnd={innerProps.onHoverProjectEnd}
           scratchResults={innerProps.scratchResults}
           onCreateScratch={innerProps.onCreateScratch}
           onSelectScratch={innerProps.onSelectScratch}
@@ -1126,6 +1150,8 @@ function DropdownContent({
           onCopyPath={innerProps.onCopyPath}
           onSelectBackground={innerProps.onSelectBackground}
           onSelectNewWindow={innerProps.onSelectNewWindow}
+          onHoverProject={innerProps.onHoverProject}
+          onHoverProjectEnd={innerProps.onHoverProjectEnd}
           scratchResults={innerProps.scratchResults}
           onCreateScratch={innerProps.onCreateScratch}
           onSelectScratch={innerProps.onSelectScratch}
@@ -1158,6 +1184,8 @@ export function ProjectSwitcherPalette({
   onCopyPath,
   onSelectBackground,
   onSelectNewWindow,
+  onHoverProject,
+  onHoverProjectEnd,
   onOpenProjectSettings,
   dropdownAlign,
   children,
@@ -1204,6 +1232,8 @@ export function ProjectSwitcherPalette({
         onCopyPath={onCopyPath}
         onSelectBackground={onSelectBackground}
         onSelectNewWindow={onSelectNewWindow}
+        onHoverProject={onHoverProject}
+        onHoverProjectEnd={onHoverProjectEnd}
         onOpenProjectSettings={onOpenProjectSettings}
         dropdownAlign={dropdownAlign}
         scratchResults={scratchResults}
@@ -1236,6 +1266,8 @@ export function ProjectSwitcherPalette({
         onCopyPath={onCopyPath}
         onSelectBackground={onSelectBackground}
         onSelectNewWindow={onSelectNewWindow}
+        onHoverProject={onHoverProject}
+        onHoverProjectEnd={onHoverProjectEnd}
         onOpenProjectSettings={onOpenProjectSettings}
         scratchResults={scratchResults}
         onCreateScratch={onCreateScratch}

--- a/src/hooks/__tests__/useProjectSwitcherPalette.hoverPrefetch.test.tsx
+++ b/src/hooks/__tests__/useProjectSwitcherPalette.hoverPrefetch.test.tsx
@@ -1,0 +1,352 @@
+// @vitest-environment jsdom
+/**
+ * useProjectSwitcherPalette — hover-to-prefetch (issue #7661).
+ *
+ * The project switcher palette silently primes the main-process hydrate cache
+ * on pointerenter (mouse only) so a subsequent click resolves the new view's
+ * `app:hydrate` IPC as a cache hit. The 150ms trailing-edge debounce filters
+ * cursor traversal across the list; pointerleave cancels a pending prefetch;
+ * palette close clears the timer; the freshness gate dedups re-hovers within
+ * 15s. Hover never triggers visible loading state.
+ */
+import { act, renderHook } from "@testing-library/react";
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+
+const { prefetchHydrateMock, useProjectStoreMock, notifyMock, projectState, projectStatsState } =
+  vi.hoisted(() => {
+    const prefetchHydrateMock = vi.fn().mockResolvedValue(undefined);
+
+    const projectStatsState = {
+      stats: {} as Record<
+        string,
+        { activeAgentCount: number; waitingAgentCount: number; processCount: number }
+      >,
+    };
+
+    const projectState = {
+      projects: [
+        {
+          id: "project-1",
+          name: "Project One",
+          path: "/repo/one",
+          emoji: "🌲",
+          color: "#00aa00",
+          lastOpened: 123,
+          frecencyScore: 3.0,
+          status: "active" as const,
+        },
+        {
+          id: "project-2",
+          name: "Project Two",
+          path: "/repo/two",
+          emoji: "🌳",
+          color: "#0044aa",
+          lastOpened: 456,
+          frecencyScore: 3.0,
+          status: "active" as const,
+        },
+      ],
+      currentProject: null as { id: string } | null,
+      switchProject: vi.fn().mockResolvedValue(undefined),
+      reopenProject: vi.fn().mockResolvedValue(undefined),
+      loadProjects: vi.fn().mockResolvedValue(undefined),
+      addProject: vi.fn().mockResolvedValue(undefined),
+      closeProject: vi.fn().mockResolvedValue({ processesKilled: 0 }),
+      closeActiveProject: vi.fn().mockResolvedValue({ processesKilled: 0 }),
+      removeProject: vi.fn().mockResolvedValue(undefined),
+      locateProject: vi.fn().mockResolvedValue(undefined),
+    };
+
+    const useProjectStoreMock = vi.fn((selector: (state: typeof projectState) => unknown) =>
+      selector(projectState)
+    );
+    const notifyMock = vi.fn().mockReturnValue("");
+
+    return {
+      prefetchHydrateMock,
+      useProjectStoreMock,
+      notifyMock,
+      projectState,
+      projectStatsState,
+    };
+  });
+
+vi.mock("@/clients", () => ({
+  projectClient: {
+    prefetchHydrate: prefetchHydrateMock,
+    getBulkStats: vi.fn().mockResolvedValue({}),
+  },
+  scratchClient: {
+    saveAsProject: vi.fn().mockResolvedValue({ status: "cancelled" }),
+  },
+}));
+
+vi.mock("@/store/projectStore", () => ({
+  useProjectStore: useProjectStoreMock,
+}));
+
+vi.mock("@/store/projectStatsStore", () => ({
+  useProjectStatsStore: vi.fn((selector: (state: typeof projectStatsState) => unknown) =>
+    selector(projectStatsState)
+  ),
+}));
+
+vi.mock("@/store/projectSettingsStore", () => ({
+  useProjectSettingsStore: Object.assign(
+    vi.fn((selector?: (state: unknown) => unknown) =>
+      selector ? selector({ loadNotificationOverridesForProjects: vi.fn() }) : undefined
+    ),
+    {
+      getState: () => ({
+        loadNotificationOverridesForProjects: vi.fn(),
+      }),
+    }
+  ),
+}));
+
+vi.mock("@/store/scratchStore", () => ({
+  useScratchStore: vi.fn((selector?: (state: unknown) => unknown) => {
+    const state = {
+      scratches: [],
+      currentScratch: null,
+      loadScratches: vi.fn().mockResolvedValue(undefined),
+      createScratch: vi.fn().mockResolvedValue({ id: "s1" }),
+      switchScratch: vi.fn().mockResolvedValue(undefined),
+      removeScratch: vi.fn().mockResolvedValue(undefined),
+    };
+    return selector ? selector(state) : state;
+  }),
+}));
+
+vi.mock("@/lib/notify", () => ({
+  notify: notifyMock,
+}));
+
+import { usePaletteStore } from "@/store/paletteStore";
+import { useProjectSwitcherPalette } from "../useProjectSwitcherPalette";
+
+describe("useProjectSwitcherPalette hover prefetch", () => {
+  beforeEach(() => {
+    vi.useFakeTimers({ shouldAdvanceTime: true });
+    prefetchHydrateMock.mockReset();
+    prefetchHydrateMock.mockResolvedValue(undefined);
+    projectState.currentProject = null;
+    projectStatsState.stats = {};
+    usePaletteStore.setState({ activePaletteId: null });
+  });
+
+  afterEach(() => {
+    vi.useRealTimers();
+  });
+
+  it("fires prefetchHydrate 150ms after pointerenter (mouse)", async () => {
+    const { result } = renderHook(() => useProjectSwitcherPalette());
+
+    act(() => {
+      result.current.onHoverProject("project-1", "mouse");
+    });
+
+    expect(prefetchHydrateMock).not.toHaveBeenCalled();
+
+    await act(async () => {
+      await vi.advanceTimersByTimeAsync(150);
+    });
+
+    expect(prefetchHydrateMock).toHaveBeenCalledTimes(1);
+    expect(prefetchHydrateMock).toHaveBeenCalledWith("project-1");
+  });
+
+  it("does not fire before the debounce elapses", async () => {
+    const { result } = renderHook(() => useProjectSwitcherPalette());
+
+    act(() => {
+      result.current.onHoverProject("project-1", "mouse");
+    });
+    await act(async () => {
+      await vi.advanceTimersByTimeAsync(149);
+    });
+
+    expect(prefetchHydrateMock).not.toHaveBeenCalled();
+  });
+
+  it("pointerleave cancels a pending prefetch", async () => {
+    const { result } = renderHook(() => useProjectSwitcherPalette());
+
+    act(() => {
+      result.current.onHoverProject("project-1", "mouse");
+    });
+    await act(async () => {
+      await vi.advanceTimersByTimeAsync(100);
+    });
+    act(() => {
+      result.current.onHoverProjectEnd("mouse");
+    });
+    await act(async () => {
+      await vi.advanceTimersByTimeAsync(200);
+    });
+
+    expect(prefetchHydrateMock).not.toHaveBeenCalled();
+  });
+
+  it("ignores non-mouse pointer types (touch, pen)", async () => {
+    const { result } = renderHook(() => useProjectSwitcherPalette());
+
+    act(() => {
+      result.current.onHoverProject("project-1", "touch");
+      result.current.onHoverProject("project-1", "pen");
+    });
+    await act(async () => {
+      await vi.advanceTimersByTimeAsync(300);
+    });
+
+    expect(prefetchHydrateMock).not.toHaveBeenCalled();
+  });
+
+  it("does not prefetch the currently active project", async () => {
+    projectState.currentProject = { id: "project-1" };
+    const { result } = renderHook(() => useProjectSwitcherPalette());
+
+    act(() => {
+      result.current.onHoverProject("project-1", "mouse");
+    });
+    await act(async () => {
+      await vi.advanceTimersByTimeAsync(150);
+    });
+
+    expect(prefetchHydrateMock).not.toHaveBeenCalled();
+  });
+
+  it("coalesces concurrent hovers — a re-hover while in-flight does not refetch", async () => {
+    let resolveFirst: (() => void) | null = null;
+    prefetchHydrateMock.mockImplementationOnce(
+      () =>
+        new Promise<void>((r) => {
+          resolveFirst = () => r();
+        })
+    );
+    const { result } = renderHook(() => useProjectSwitcherPalette());
+
+    act(() => {
+      result.current.onHoverProject("project-1", "mouse");
+    });
+    await act(async () => {
+      await vi.advanceTimersByTimeAsync(150);
+    });
+    expect(prefetchHydrateMock).toHaveBeenCalledTimes(1);
+
+    // Re-hover while the first request is still in flight (and the freshness
+    // gate hasn't yet been written).
+    act(() => {
+      result.current.onHoverProjectEnd("mouse");
+      result.current.onHoverProject("project-1", "mouse");
+    });
+    await act(async () => {
+      await vi.advanceTimersByTimeAsync(150);
+    });
+    expect(prefetchHydrateMock).toHaveBeenCalledTimes(1);
+
+    resolveFirst!();
+  });
+
+  it("skips re-prefetch when the freshness gate is fresh (<15s)", async () => {
+    const { result } = renderHook(() => useProjectSwitcherPalette());
+
+    act(() => {
+      result.current.onHoverProject("project-1", "mouse");
+    });
+    await act(async () => {
+      await vi.advanceTimersByTimeAsync(150);
+    });
+    // Let the prefetch promise settle and write the freshness timestamp.
+    await act(async () => {
+      await vi.advanceTimersByTimeAsync(0);
+    });
+    expect(prefetchHydrateMock).toHaveBeenCalledTimes(1);
+
+    // Less than 15s later, re-hover.
+    await act(async () => {
+      await vi.advanceTimersByTimeAsync(5_000);
+    });
+    act(() => {
+      result.current.onHoverProjectEnd("mouse");
+      result.current.onHoverProject("project-1", "mouse");
+    });
+    await act(async () => {
+      await vi.advanceTimersByTimeAsync(150);
+    });
+
+    expect(prefetchHydrateMock).toHaveBeenCalledTimes(1);
+  });
+
+  it("re-prefetches after the freshness window expires (>15s)", async () => {
+    const { result } = renderHook(() => useProjectSwitcherPalette());
+
+    act(() => {
+      result.current.onHoverProject("project-1", "mouse");
+    });
+    await act(async () => {
+      await vi.advanceTimersByTimeAsync(150);
+    });
+    await act(async () => {
+      await vi.advanceTimersByTimeAsync(0);
+    });
+    expect(prefetchHydrateMock).toHaveBeenCalledTimes(1);
+
+    await act(async () => {
+      await vi.advanceTimersByTimeAsync(16_000);
+    });
+    act(() => {
+      result.current.onHoverProjectEnd("mouse");
+      result.current.onHoverProject("project-1", "mouse");
+    });
+    await act(async () => {
+      await vi.advanceTimersByTimeAsync(150);
+    });
+
+    expect(prefetchHydrateMock).toHaveBeenCalledTimes(2);
+  });
+
+  it("clears the pending hover timer on palette close (isOpen → false)", async () => {
+    const { result } = renderHook(() => useProjectSwitcherPalette());
+
+    act(() => {
+      result.current.open();
+    });
+    act(() => {
+      result.current.onHoverProject("project-1", "mouse");
+    });
+    await act(async () => {
+      await vi.advanceTimersByTimeAsync(100);
+    });
+    act(() => {
+      result.current.close();
+    });
+    await act(async () => {
+      await vi.advanceTimersByTimeAsync(200);
+    });
+
+    expect(prefetchHydrateMock).not.toHaveBeenCalled();
+  });
+
+  it("hovering a second project before the first fires re-arms the timer", async () => {
+    const { result } = renderHook(() => useProjectSwitcherPalette());
+
+    act(() => {
+      result.current.onHoverProject("project-1", "mouse");
+    });
+    await act(async () => {
+      await vi.advanceTimersByTimeAsync(100);
+    });
+    // Sweep to project-2 — the GitHubStatsToolbarButton pattern clears and
+    // re-schedules the timer for the new target on each pointerenter.
+    act(() => {
+      result.current.onHoverProject("project-2", "mouse");
+    });
+    await act(async () => {
+      await vi.advanceTimersByTimeAsync(150);
+    });
+
+    expect(prefetchHydrateMock).toHaveBeenCalledTimes(1);
+    expect(prefetchHydrateMock).toHaveBeenCalledWith("project-2");
+  });
+});

--- a/src/hooks/useProjectSwitcherPalette.ts
+++ b/src/hooks/useProjectSwitcherPalette.ts
@@ -54,6 +54,15 @@ export interface UseProjectSwitcherPaletteReturn {
   selectPrevious: () => void;
   selectNext: () => void;
   selectProject: (project: SearchableProject) => void;
+  /**
+   * Schedule a 150ms trailing-edge hover prefetch that primes the
+   * main-process hydrate cache for `projectId`. Mouse-only — touch and pen
+   * pointers are ignored. Does nothing for the currently active project or
+   * for projects flagged as missing.
+   */
+  onHoverProject: (projectId: string, pointerType: string) => void;
+  /** Cancel any pending hover prefetch for `projectId`. */
+  onHoverProjectEnd: (pointerType: string) => void;
   confirmSelection: () => void;
   addProject: () => Promise<void>;
   cloneRepo: () => void;
@@ -97,6 +106,23 @@ export interface UseProjectSwitcherPaletteReturn {
 
 const MAX_RESULTS = 15;
 
+/**
+ * Trailing-edge debounce window for the project hover prefetch. Matches the
+ * GitHub-stats toolbar pattern (#6282) — long enough to filter cursor
+ * traversal across the list, short enough to feel "instant" on intentional
+ * dwell.
+ */
+const PROJECT_HOVER_PREFETCH_DELAY_MS = 150;
+
+/**
+ * Renderer-side freshness gate. If the cache was primed for this project less
+ * than this many milliseconds ago, the hover handler skips re-prefetching.
+ * Shorter than the main-process TTL (30s) so re-hover after a back-and-forth
+ * sweep doesn't keep firing the same IPC, but generous enough to span the
+ * realistic time between hover and click.
+ */
+const PROJECT_PREFETCH_FRESHNESS_MS = 15_000;
+
 export function useProjectSwitcherPalette(): UseProjectSwitcherPaletteReturn {
   const modalIsOpen = usePaletteStore((state) => state.activePaletteId === "project-switcher");
   const [dropdownIsOpen, setDropdownIsOpen] = useState(false);
@@ -114,6 +140,10 @@ export function useProjectSwitcherPalette(): UseProjectSwitcherPaletteReturn {
   } | null>(null);
   const [isDeletingOriginalScratch, setIsDeletingOriginalScratch] = useState(false);
   const selectedProjectIdRef = useRef<string | null>(null);
+
+  const prefetchTimerRef = useRef<ReturnType<typeof setTimeout> | null>(null);
+  const prefetchInFlightRef = useRef<Set<string>>(new Set());
+  const prefetchLastAtRef = useRef<Map<string, number>>(new Map());
 
   const projects = useProjectStore((state) => state.projects);
   const currentProject = useProjectStore((state) => state.currentProject);
@@ -307,6 +337,61 @@ export function useProjectSwitcherPalette(): UseProjectSwitcherPaletteReturn {
     },
     [close, switchProject, reopenProject]
   );
+
+  const clearPendingPrefetchTimer = useCallback(() => {
+    if (prefetchTimerRef.current !== null) {
+      clearTimeout(prefetchTimerRef.current);
+      prefetchTimerRef.current = null;
+    }
+  }, []);
+
+  const runPrefetch = useCallback((projectId: string) => {
+    if (prefetchInFlightRef.current.has(projectId)) return;
+    const lastAt = prefetchLastAtRef.current.get(projectId) ?? 0;
+    if (lastAt > 0 && Date.now() - lastAt < PROJECT_PREFETCH_FRESHNESS_MS) return;
+
+    prefetchInFlightRef.current.add(projectId);
+    void projectClient
+      .prefetchHydrate(projectId)
+      .then(() => {
+        prefetchLastAtRef.current.set(projectId, Date.now());
+      })
+      .finally(() => {
+        prefetchInFlightRef.current.delete(projectId);
+      });
+  }, []);
+
+  const onHoverProject = useCallback(
+    (projectId: string, pointerType: string) => {
+      if (pointerType !== "mouse") return;
+      const project = searchableProjects.find((p) => p.id === projectId);
+      if (!project || project.isActive || project.isMissing) return;
+      clearPendingPrefetchTimer();
+      prefetchTimerRef.current = setTimeout(() => {
+        prefetchTimerRef.current = null;
+        runPrefetch(projectId);
+      }, PROJECT_HOVER_PREFETCH_DELAY_MS);
+    },
+    [searchableProjects, clearPendingPrefetchTimer, runPrefetch]
+  );
+
+  const onHoverProjectEnd = useCallback(
+    (pointerType: string) => {
+      if (pointerType !== "mouse") return;
+      clearPendingPrefetchTimer();
+    },
+    [clearPendingPrefetchTimer]
+  );
+
+  // Cancel any pending prefetch when the palette closes — the user has either
+  // committed to a project (whose hydrate will run via the click path) or
+  // bailed out (no need to keep filling the cache).
+  useEffect(() => {
+    if (isOpen) return;
+    clearPendingPrefetchTimer();
+  }, [isOpen, clearPendingPrefetchTimer]);
+
+  useEffect(() => () => clearPendingPrefetchTimer(), [clearPendingPrefetchTimer]);
 
   const confirmSelection = useCallback(() => {
     if (results.length > 0 && selectedIndex >= 0 && selectedIndex < results.length) {
@@ -599,6 +684,8 @@ export function useProjectSwitcherPalette(): UseProjectSwitcherPaletteReturn {
     selectPrevious,
     selectNext,
     selectProject,
+    onHoverProject,
+    onHoverProjectEnd,
     confirmSelection,
     addProject,
     cloneRepo,

--- a/src/hooks/useProjectSwitcherPalette.ts
+++ b/src/hooks/useProjectSwitcherPalette.ts
@@ -351,6 +351,12 @@ export function useProjectSwitcherPalette(): UseProjectSwitcherPaletteReturn {
     if (lastAt > 0 && Date.now() - lastAt < PROJECT_PREFETCH_FRESHNESS_MS) return;
 
     prefetchInFlightRef.current.add(projectId);
+    // projectClient.prefetchHydrate swallows errors (fire-and-forget), so this
+    // .then() runs whether the main-process build succeeded or failed. We mark
+    // the freshness ref either way: a hover-induced retry-storm against a
+    // genuinely failing build is worse than a 15s window where the user gets
+    // the normal (uncached) hydrate. The click-time hydrate falls through to
+    // the full read path on a cache miss with no user-visible difference.
     void projectClient
       .prefetchHydrate(projectId)
       .then(() => {

--- a/src/store/persistence/__tests__/panelPersistence.test.ts
+++ b/src/store/persistence/__tests__/panelPersistence.test.ts
@@ -22,6 +22,7 @@ const createMockProjectClient = () => ({
   remove: vi.fn().mockResolvedValue(undefined),
   update: vi.fn().mockResolvedValue({}),
   switch: vi.fn().mockResolvedValue({}),
+  prefetchHydrate: vi.fn().mockResolvedValue(undefined),
   openDialog: vi.fn().mockResolvedValue(null),
   onSwitch: vi.fn().mockReturnValue(() => {}),
   getSettings: vi.fn().mockResolvedValue({}),

--- a/src/store/persistence/__tests__/tabGroupPersistence.test.ts
+++ b/src/store/persistence/__tests__/tabGroupPersistence.test.ts
@@ -14,6 +14,7 @@ const createMockProjectClient = () => ({
   remove: vi.fn().mockResolvedValue(undefined),
   update: vi.fn().mockResolvedValue({}),
   switch: vi.fn().mockResolvedValue({}),
+  prefetchHydrate: vi.fn().mockResolvedValue(undefined),
   openDialog: vi.fn().mockResolvedValue(null),
   onSwitch: vi.fn().mockReturnValue(() => {}),
   getSettings: vi.fn().mockResolvedValue({}),


### PR DESCRIPTION
Closes #7661.

## Summary

Hover over a row in the project switcher palette now silently primes the main-process hydrate cache so a click on that row no longer pays the disk-read cost — the new project view's `app:hydrate` IPC resolves as a cache hit.

- New `electron/services/prefetchHydrateCache.ts` keeps a per-project `Map<id, HydrateResult>` with a 30s TTL, singleflighted per project ID and guarded by an invalidation-version counter so a `saveProjectState` call mid-build drops the stale result.
- New `project:prefetch-hydrate` IPC channel — fire-and-forget; the handler calls `buildSwitchHydrateResult` and writes to the cache. Errors are swallowed at every layer so a failed prefetch is invisible.
- `handleAppHydrate` short-circuits via the cache when there's no crash-recovery panel filter and the app isn't in safe mode. Those one-shot side effects (`consumePanelFilter`, `consumePendingSettingsRecovery`) are preserved.
- `ProjectStore.saveProjectState` invalidates the cache **before** delegating to the state manager, so the prefetch-during-save race is closed pessimistically.
- `useProjectSwitcherPalette` exposes `onHoverProject` / `onHoverProjectEnd` with a 150ms trailing-edge debounce (mouse-only, `pointerleave` cancels, palette close clears the timer) plus a 15s renderer-side freshness gate that dedups re-hovers.
- `ProjectSwitcherPalette` threads the callbacks through to each row's `onPointerEnter` / `onPointerLeave`. Wired into `App.tsx` (modal), `ProjectSwitcher.tsx` (sidebar + active-project trigger), and `Toolbar.tsx`.
- Matches the GitHub-stats toolbar hover-prefetch pattern (#6282).

## Test plan

- [x] Unit: `prefetchHydrateCache` — singleflight, consume-once, TTL, invalidation race, global invalidation against first-ever in-flight build, error recovery, independent projects
- [x] Unit: `useProjectSwitcherPalette` hover — debounce timing, mouse-only, pointerleave cancel, in-flight coalescing, freshness gate inside/outside 15s, palette-close cleanup, sweep re-arm
- [x] Existing mocks: `panelPersistence` + `tabGroupPersistence` updated so the strict `ProjectService` shape stays satisfied
- [x] Typecheck, lint ratchet, channel-drift, IPC handle coverage all green
- [ ] Manual smoke: hover Project A → check console for `project:prefetch-hydrate` IPC after ~150ms → click → `app:hydrate` should return without re-reading the project state file
- [ ] Manual smoke: rapid sweep across multiple rows fires at most one IPC per dwell
- [ ] Manual smoke: pen / touch pointers do not trigger prefetch