### PR TITLE
fix(worktree): use noun-phrase form for AI summary empty state

### DIFF
--- a/src/components/Worktree/WorktreeDetails.tsx
+++ b/src/components/Worktree/WorktreeDetails.tsx
@@ -147,7 +147,7 @@ export function WorktreeDetails({
           {/* Placeholder when no AI summary or note exists */}
           {!effectiveNote && !effectiveSummary && !rawLastCommitMsg && (
             <div className="rounded bg-overlay-subtle px-2 py-2 text-xs italic text-text-muted">
-              No AI summary yet. Run an agent task or use Copy Context to generate one.
+              No AI summary yet
             </div>
           )}
 


### PR DESCRIPTION

## Summary
- The AI summary empty-state placeholder in WorktreeDetails read as an instruction ("Run an agent task or use Copy Context to generate one") rather than describing the slot's state.
- Trimmed the copy to the noun-phrase form "No AI summary yet", matching the completed-work quiet-empty-state rule in CLAUDE.md.

Resolves #7695

## Changes
- src/components/Worktree/WorktreeDetails.tsx: Single-line copy fix removing the instructional sentence from the empty-state placeholder.

## Testing
- Manual visual check: confirmed the placeholder renders without the trailing instruction.