### PR TITLE
refactor(ipc): migrate UI/panels handlers to defineIpcNamespace

### DIFF
--- a/electron/ipc/__tests__/leafPreloadNamespaces.test.ts
+++ b/electron/ipc/__tests__/leafPreloadNamespaces.test.ts
@@ -232,7 +232,7 @@ describe("leaf preload namespace bindings", () => {
       const invoke = vi.fn().mockResolvedValue([]);
       const bindings = buildEventInspectorPreloadBindings(invoke);
 
-      const filters = { type: "user-action" } as const;
+      const filters = { types: ["user-action"] };
       await bindings.getFiltered(filters);
 
       expect(invoke).toHaveBeenCalledTimes(1);
@@ -307,7 +307,7 @@ describe("leaf preload namespace bindings", () => {
         projectId: "p1",
         panelId: "panel1",
         cwd: "/tmp/p",
-        commandLine: "npm run dev",
+        devCommand: "npm run dev",
       };
       await bindings.ensure(request);
 
@@ -331,7 +331,14 @@ describe("leaf preload namespace bindings", () => {
       const invoke = vi.fn().mockResolvedValue(undefined);
       const bindings = buildPluginPreloadBindings(invoke);
 
-      const contribution = { id: "act-1", name: "Do thing" } as const;
+      const contribution = {
+        id: "act-1",
+        title: "Do thing",
+        description: "Does the thing",
+        category: "general",
+        kind: "command" as const,
+        danger: "safe" as const,
+      };
       await bindings.registerAction("plug-1", contribution);
 
       expect(invoke).toHaveBeenCalledTimes(1);

--- a/electron/ipc/__tests__/leafPreloadNamespaces.test.ts
+++ b/electron/ipc/__tests__/leafPreloadNamespaces.test.ts
@@ -115,10 +115,25 @@ describe("leaf preload namespace bindings", () => {
 
     it("demo matches", () => {
       expect(DEMO_METHOD_CHANNELS.moveTo).toBe(CHANNELS.DEMO_MOVE_TO);
+      expect(DEMO_METHOD_CHANNELS.moveToSelector).toBe(CHANNELS.DEMO_MOVE_TO_SELECTOR);
       expect(DEMO_METHOD_CHANNELS.click).toBe(CHANNELS.DEMO_CLICK);
+      expect(DEMO_METHOD_CHANNELS.type).toBe(CHANNELS.DEMO_TYPE);
       expect(DEMO_METHOD_CHANNELS.screenshot).toBe(CHANNELS.DEMO_SCREENSHOT);
+      expect(DEMO_METHOD_CHANNELS.waitForSelector).toBe(CHANNELS.DEMO_WAIT_FOR_SELECTOR);
+      expect(DEMO_METHOD_CHANNELS.pause).toBe(CHANNELS.DEMO_PAUSE);
+      expect(DEMO_METHOD_CHANNELS.resume).toBe(CHANNELS.DEMO_RESUME);
+      expect(DEMO_METHOD_CHANNELS.sleep).toBe(CHANNELS.DEMO_SLEEP);
+      expect(DEMO_METHOD_CHANNELS.scroll).toBe(CHANNELS.DEMO_SCROLL);
+      expect(DEMO_METHOD_CHANNELS.drag).toBe(CHANNELS.DEMO_DRAG);
+      expect(DEMO_METHOD_CHANNELS.pressKey).toBe(CHANNELS.DEMO_PRESS_KEY);
+      expect(DEMO_METHOD_CHANNELS.spotlight).toBe(CHANNELS.DEMO_SPOTLIGHT);
+      expect(DEMO_METHOD_CHANNELS.dismissSpotlight).toBe(CHANNELS.DEMO_DISMISS_SPOTLIGHT);
+      expect(DEMO_METHOD_CHANNELS.annotate).toBe(CHANNELS.DEMO_ANNOTATE);
+      expect(DEMO_METHOD_CHANNELS.dismissAnnotation).toBe(CHANNELS.DEMO_DISMISS_ANNOTATION);
+      expect(DEMO_METHOD_CHANNELS.waitForIdle).toBe(CHANNELS.DEMO_WAIT_FOR_IDLE);
       expect(DEMO_METHOD_CHANNELS.startCapture).toBe(CHANNELS.DEMO_START_CAPTURE);
       expect(DEMO_METHOD_CHANNELS.stopCapture).toBe(CHANNELS.DEMO_STOP_CAPTURE);
+      expect(DEMO_METHOD_CHANNELS.getCaptureStatus).toBe(CHANNELS.DEMO_GET_CAPTURE_STATUS);
     });
   });
 

--- a/electron/ipc/__tests__/leafPreloadNamespaces.test.ts
+++ b/electron/ipc/__tests__/leafPreloadNamespaces.test.ts
@@ -14,6 +14,25 @@ import {
   ACCESSIBILITY_METHOD_CHANNELS,
   buildAccessibilityPreloadBindings,
 } from "../handlers/accessibility.preload.js";
+import {
+  EVENT_INSPECTOR_METHOD_CHANNELS,
+  buildEventInspectorPreloadBindings,
+} from "../handlers/eventInspector.preload.js";
+import {
+  COMMANDS_METHOD_CHANNELS,
+  buildCommandsPreloadBindings,
+} from "../handlers/commands.preload.js";
+import { PORTAL_METHOD_CHANNELS, buildPortalPreloadBindings } from "../handlers/portal.preload.js";
+import {
+  DEV_PREVIEW_METHOD_CHANNELS,
+  buildDevPreviewPreloadBindings,
+} from "../handlers/devPreview.preload.js";
+import { PLUGIN_METHOD_CHANNELS, buildPluginPreloadBindings } from "../handlers/plugin.preload.js";
+import {
+  SCRATCH_METHOD_CHANNELS,
+  buildScratchPreloadBindings,
+} from "../handlers/scratch/preload.js";
+import { DEMO_METHOD_CHANNELS, buildDemoPreloadBindings } from "../handlers/demo.preload.js";
 
 describe("leaf preload namespace bindings", () => {
   describe("METHOD_CHANNELS stay in sync with CHANNELS", () => {
@@ -34,6 +53,72 @@ describe("leaf preload namespace bindings", () => {
 
     it("accessibility matches", () => {
       expect(ACCESSIBILITY_METHOD_CHANNELS.getEnabled).toBe(CHANNELS.ACCESSIBILITY_GET_ENABLED);
+    });
+
+    it("eventInspector matches", () => {
+      expect(EVENT_INSPECTOR_METHOD_CHANNELS.getEvents).toBe(CHANNELS.EVENT_INSPECTOR_GET_EVENTS);
+      expect(EVENT_INSPECTOR_METHOD_CHANNELS.getFiltered).toBe(
+        CHANNELS.EVENT_INSPECTOR_GET_FILTERED
+      );
+      expect(EVENT_INSPECTOR_METHOD_CHANNELS.clear).toBe(CHANNELS.EVENT_INSPECTOR_CLEAR);
+    });
+
+    it("commands matches", () => {
+      expect(COMMANDS_METHOD_CHANNELS.list).toBe(CHANNELS.COMMANDS_LIST);
+      expect(COMMANDS_METHOD_CHANNELS.get).toBe(CHANNELS.COMMANDS_GET);
+      expect(COMMANDS_METHOD_CHANNELS.execute).toBe(CHANNELS.COMMANDS_EXECUTE);
+      expect(COMMANDS_METHOD_CHANNELS.getBuilder).toBe(CHANNELS.COMMANDS_GET_BUILDER);
+    });
+
+    it("portal matches", () => {
+      expect(PORTAL_METHOD_CHANNELS.create).toBe(CHANNELS.PORTAL_CREATE);
+      expect(PORTAL_METHOD_CHANNELS.show).toBe(CHANNELS.PORTAL_SHOW);
+      expect(PORTAL_METHOD_CHANNELS.hide).toBe(CHANNELS.PORTAL_HIDE);
+      expect(PORTAL_METHOD_CHANNELS.resize).toBe(CHANNELS.PORTAL_RESIZE);
+      expect(PORTAL_METHOD_CHANNELS.closeTab).toBe(CHANNELS.PORTAL_CLOSE_TAB);
+      expect(PORTAL_METHOD_CHANNELS.navigate).toBe(CHANNELS.PORTAL_NAVIGATE);
+      expect(PORTAL_METHOD_CHANNELS.goBack).toBe(CHANNELS.PORTAL_GO_BACK);
+      expect(PORTAL_METHOD_CHANNELS.goForward).toBe(CHANNELS.PORTAL_GO_FORWARD);
+      expect(PORTAL_METHOD_CHANNELS.reload).toBe(CHANNELS.PORTAL_RELOAD);
+      expect(PORTAL_METHOD_CHANNELS.showNewTabMenu).toBe(CHANNELS.PORTAL_SHOW_NEW_TAB_MENU);
+    });
+
+    it("devPreview matches", () => {
+      expect(DEV_PREVIEW_METHOD_CHANNELS.ensure).toBe(CHANNELS.DEV_PREVIEW_ENSURE);
+      expect(DEV_PREVIEW_METHOD_CHANNELS.restart).toBe(CHANNELS.DEV_PREVIEW_RESTART);
+      expect(DEV_PREVIEW_METHOD_CHANNELS.stop).toBe(CHANNELS.DEV_PREVIEW_STOP);
+      expect(DEV_PREVIEW_METHOD_CHANNELS.stopByPanel).toBe(CHANNELS.DEV_PREVIEW_STOP_BY_PANEL);
+      expect(DEV_PREVIEW_METHOD_CHANNELS.getState).toBe(CHANNELS.DEV_PREVIEW_GET_STATE);
+      expect(DEV_PREVIEW_METHOD_CHANNELS.getByWorktree).toBe(CHANNELS.DEV_PREVIEW_GET_BY_WORKTREE);
+    });
+
+    it("plugin matches (plugin:invoke intentionally excluded)", () => {
+      expect(PLUGIN_METHOD_CHANNELS.list).toBe(CHANNELS.PLUGIN_LIST);
+      expect(PLUGIN_METHOD_CHANNELS.toolbarButtons).toBe(CHANNELS.PLUGIN_TOOLBAR_BUTTONS);
+      expect(PLUGIN_METHOD_CHANNELS.menuItems).toBe(CHANNELS.PLUGIN_MENU_ITEMS);
+      expect(PLUGIN_METHOD_CHANNELS.validateActionIds).toBe(CHANNELS.PLUGIN_VALIDATE_ACTION_IDS);
+      expect(PLUGIN_METHOD_CHANNELS.getActions).toBe(CHANNELS.PLUGIN_ACTIONS_GET);
+      expect(PLUGIN_METHOD_CHANNELS.registerAction).toBe(CHANNELS.PLUGIN_ACTIONS_REGISTER);
+      expect(PLUGIN_METHOD_CHANNELS.unregisterAction).toBe(CHANNELS.PLUGIN_ACTIONS_UNREGISTER);
+      expect(PLUGIN_METHOD_CHANNELS.getPanelKinds).toBe(CHANNELS.PLUGIN_PANEL_KINDS_GET);
+    });
+
+    it("scratch matches", () => {
+      expect(SCRATCH_METHOD_CHANNELS.getAll).toBe(CHANNELS.SCRATCH_GET_ALL);
+      expect(SCRATCH_METHOD_CHANNELS.getCurrent).toBe(CHANNELS.SCRATCH_GET_CURRENT);
+      expect(SCRATCH_METHOD_CHANNELS.create).toBe(CHANNELS.SCRATCH_CREATE);
+      expect(SCRATCH_METHOD_CHANNELS.update).toBe(CHANNELS.SCRATCH_UPDATE);
+      expect(SCRATCH_METHOD_CHANNELS.remove).toBe(CHANNELS.SCRATCH_REMOVE);
+      expect(SCRATCH_METHOD_CHANNELS.switch).toBe(CHANNELS.SCRATCH_SWITCH);
+      expect(SCRATCH_METHOD_CHANNELS.saveAsProject).toBe(CHANNELS.SCRATCH_SAVE_AS_PROJECT);
+    });
+
+    it("demo matches", () => {
+      expect(DEMO_METHOD_CHANNELS.moveTo).toBe(CHANNELS.DEMO_MOVE_TO);
+      expect(DEMO_METHOD_CHANNELS.click).toBe(CHANNELS.DEMO_CLICK);
+      expect(DEMO_METHOD_CHANNELS.screenshot).toBe(CHANNELS.DEMO_SCREENSHOT);
+      expect(DEMO_METHOD_CHANNELS.startCapture).toBe(CHANNELS.DEMO_START_CAPTURE);
+      expect(DEMO_METHOD_CHANNELS.stopCapture).toBe(CHANNELS.DEMO_STOP_CAPTURE);
     });
   });
 
@@ -114,6 +199,174 @@ describe("leaf preload namespace bindings", () => {
 
       expect(invoke).toHaveBeenCalledTimes(1);
       expect(invoke).toHaveBeenCalledWith("accessibility:get-enabled");
+    });
+  });
+
+  describe("eventInspector", () => {
+    it("routes getEvents() to event-inspector:get-events with no args", async () => {
+      const invoke = vi.fn().mockResolvedValue([]);
+      const bindings = buildEventInspectorPreloadBindings(invoke);
+
+      await bindings.getEvents();
+
+      expect(invoke).toHaveBeenCalledTimes(1);
+      expect(invoke).toHaveBeenCalledWith("event-inspector:get-events");
+    });
+
+    it("routes getFiltered(filters) to event-inspector:get-filtered with the filters forwarded", async () => {
+      const invoke = vi.fn().mockResolvedValue([]);
+      const bindings = buildEventInspectorPreloadBindings(invoke);
+
+      const filters = { type: "user-action" } as const;
+      await bindings.getFiltered(filters);
+
+      expect(invoke).toHaveBeenCalledTimes(1);
+      expect(invoke).toHaveBeenCalledWith("event-inspector:get-filtered", filters);
+    });
+
+    it("routes clear() to event-inspector:clear with no args", async () => {
+      const invoke = vi.fn().mockResolvedValue(undefined);
+      const bindings = buildEventInspectorPreloadBindings(invoke);
+
+      await bindings.clear();
+
+      expect(invoke).toHaveBeenCalledTimes(1);
+      expect(invoke).toHaveBeenCalledWith("event-inspector:clear");
+    });
+  });
+
+  describe("commands", () => {
+    it("routes list(context) to commands:list with the context forwarded", async () => {
+      const invoke = vi.fn().mockResolvedValue([]);
+      const bindings = buildCommandsPreloadBindings(invoke);
+
+      const ctx = { projectId: "p1" } as const;
+      await bindings.list(ctx);
+
+      expect(invoke).toHaveBeenCalledTimes(1);
+      expect(invoke).toHaveBeenCalledWith("commands:list", ctx);
+    });
+
+    it("routes execute(payload) to commands:execute with the payload forwarded", async () => {
+      const invoke = vi.fn().mockResolvedValue({ success: true });
+      const bindings = buildCommandsPreloadBindings(invoke);
+
+      const payload = { commandId: "do-thing", context: {} };
+      await bindings.execute(payload);
+
+      expect(invoke).toHaveBeenCalledTimes(1);
+      expect(invoke).toHaveBeenCalledWith("commands:execute", payload);
+    });
+  });
+
+  describe("portal", () => {
+    it("routes create(payload) to portal:create with the payload forwarded", async () => {
+      const invoke = vi.fn().mockResolvedValue(undefined);
+      const bindings = buildPortalPreloadBindings(invoke);
+
+      const payload = { tabId: "t1", url: "https://example.com" };
+      await bindings.create(payload);
+
+      expect(invoke).toHaveBeenCalledTimes(1);
+      expect(invoke).toHaveBeenCalledWith("portal:create", payload);
+    });
+
+    it("routes goBack(tabId) to portal:go-back with the tabId forwarded", async () => {
+      const invoke = vi.fn().mockResolvedValue(true);
+      const bindings = buildPortalPreloadBindings(invoke);
+
+      await bindings.goBack("t1");
+
+      expect(invoke).toHaveBeenCalledTimes(1);
+      expect(invoke).toHaveBeenCalledWith("portal:go-back", "t1");
+    });
+  });
+
+  describe("devPreview", () => {
+    it("routes ensure(request) to dev-preview:ensure with the request forwarded", async () => {
+      const invoke = vi.fn().mockResolvedValue({ status: "running" });
+      const bindings = buildDevPreviewPreloadBindings(invoke);
+
+      const request = {
+        worktreeId: "wt1",
+        projectId: "p1",
+        panelId: "panel1",
+        cwd: "/tmp/p",
+        commandLine: "npm run dev",
+      };
+      await bindings.ensure(request);
+
+      expect(invoke).toHaveBeenCalledTimes(1);
+      expect(invoke).toHaveBeenCalledWith("dev-preview:ensure", request);
+    });
+  });
+
+  describe("plugin", () => {
+    it("routes list() to plugin:list with no args", async () => {
+      const invoke = vi.fn().mockResolvedValue([]);
+      const bindings = buildPluginPreloadBindings(invoke);
+
+      await bindings.list();
+
+      expect(invoke).toHaveBeenCalledTimes(1);
+      expect(invoke).toHaveBeenCalledWith("plugin:list");
+    });
+
+    it("routes registerAction(pluginId, contribution) with both args forwarded", async () => {
+      const invoke = vi.fn().mockResolvedValue(undefined);
+      const bindings = buildPluginPreloadBindings(invoke);
+
+      const contribution = { id: "act-1", name: "Do thing" } as const;
+      await bindings.registerAction("plug-1", contribution);
+
+      expect(invoke).toHaveBeenCalledTimes(1);
+      expect(invoke).toHaveBeenCalledWith("plugin:actions-register", "plug-1", contribution);
+    });
+  });
+
+  describe("scratch", () => {
+    it("routes getAll() to scratch:get-all with no args", async () => {
+      const invoke = vi.fn().mockResolvedValue([]);
+      const bindings = buildScratchPreloadBindings(invoke);
+
+      await bindings.getAll();
+
+      expect(invoke).toHaveBeenCalledTimes(1);
+      expect(invoke).toHaveBeenCalledWith("scratch:get-all");
+    });
+
+    it("routes update(scratchId, updates) with both args forwarded", async () => {
+      const invoke = vi.fn().mockResolvedValue({});
+      const bindings = buildScratchPreloadBindings(invoke);
+
+      const updates = { name: "renamed" };
+      await bindings.update("s1", updates);
+
+      expect(invoke).toHaveBeenCalledTimes(1);
+      expect(invoke).toHaveBeenCalledWith("scratch:update", "s1", updates);
+    });
+  });
+
+  describe("demo", () => {
+    it("routes click() to demo:click with no args", async () => {
+      const invoke = vi.fn().mockResolvedValue(undefined);
+      const bindings = buildDemoPreloadBindings(invoke);
+
+      await bindings.click();
+
+      expect(invoke).toHaveBeenCalledTimes(1);
+      expect(invoke).toHaveBeenCalledWith("demo:click");
+    });
+
+    it("routes moveTo(payload) to demo:move-to with the payload forwarded", async () => {
+      const invoke = vi.fn().mockResolvedValue(undefined);
+      const bindings = buildDemoPreloadBindings(invoke);
+
+      const payload = { x: 10, y: 20, durationMs: 100 };
+      await bindings.moveTo(payload);
+
+      expect(invoke).toHaveBeenCalledTimes(1);
+      expect(invoke).toHaveBeenCalledWith("demo:move-to", payload);
     });
   });
 });

--- a/electron/ipc/handlers/commands.preload.ts
+++ b/electron/ipc/handlers/commands.preload.ts
@@ -1,0 +1,27 @@
+import type { IpcInvokeMap } from "../../types/index.js";
+
+export const COMMANDS_METHOD_CHANNELS = {
+  list: "commands:list",
+  get: "commands:get",
+  execute: "commands:execute",
+  getBuilder: "commands:get-builder",
+} as const satisfies Record<string, keyof IpcInvokeMap>;
+
+type Methods = typeof COMMANDS_METHOD_CHANNELS;
+
+export type CommandsPreloadBindings = {
+  [M in keyof Methods]: (
+    ...args: IpcInvokeMap[Methods[M]]["args"]
+  ) => Promise<IpcInvokeMap[Methods[M]]["result"]>;
+};
+
+type Invoker = (channel: string, ...args: unknown[]) => Promise<unknown>;
+
+export function buildCommandsPreloadBindings(invoke: Invoker): CommandsPreloadBindings {
+  const out: Record<string, (...args: unknown[]) => Promise<unknown>> = {};
+  for (const method of Object.keys(COMMANDS_METHOD_CHANNELS) as Array<keyof Methods>) {
+    const channel = COMMANDS_METHOD_CHANNELS[method];
+    out[method as string] = (...args) => invoke(channel, ...args);
+  }
+  return out as unknown as CommandsPreloadBindings;
+}

--- a/electron/ipc/handlers/commands.ts
+++ b/electron/ipc/handlers/commands.ts
@@ -7,12 +7,12 @@ import { defineIpcNamespace, op } from "../define.js";
 import { COMMANDS_METHOD_CHANNELS } from "./commands.preload.js";
 import { commandService } from "../../services/CommandService.js";
 import type {
+  BuilderStep,
   CommandContext,
   CommandExecutePayload,
   CommandGetPayload,
   CommandManifestEntry,
   CommandResult,
-  DaintreeCommand,
 } from "../../../shared/types/commands.js";
 import { AppError } from "../../utils/errorTypes.js";
 
@@ -61,7 +61,7 @@ async function handleCommandsExecute(payload: CommandExecutePayload): Promise<Co
 
 async function handleCommandsGetBuilder(
   commandId: string
-): Promise<DaintreeCommand["builder"] | null> {
+): Promise<{ steps: BuilderStep[] } | null> {
   if (typeof commandId !== "string") {
     return null;
   }

--- a/electron/ipc/handlers/commands.ts
+++ b/electron/ipc/handlers/commands.ts
@@ -3,7 +3,8 @@
  * Exposes command registry and execution to the renderer process.
  */
 
-import { CHANNELS } from "../channels.js";
+import { defineIpcNamespace, op } from "../define.js";
+import { COMMANDS_METHOD_CHANNELS } from "./commands.preload.js";
 import { commandService } from "../../services/CommandService.js";
 import type {
   CommandContext,
@@ -13,75 +14,71 @@ import type {
   CommandResult,
   DaintreeCommand,
 } from "../../../shared/types/commands.js";
-import { typedHandle } from "../utils.js";
 import { AppError } from "../../utils/errorTypes.js";
 
-export function registerCommandHandlers(): () => void {
-  const handlers: Array<() => void> = [];
+async function handleCommandsList(context?: CommandContext): Promise<CommandManifestEntry[]> {
+  return await commandService.list(context);
+}
 
-  // List all commands
-  const handleCommandsList = async (context?: CommandContext): Promise<CommandManifestEntry[]> => {
-    return await commandService.list(context);
-  };
-  handlers.push(typedHandle(CHANNELS.COMMANDS_LIST, handleCommandsList));
+async function handleCommandsGet(payload: CommandGetPayload): Promise<CommandManifestEntry | null> {
+  if (!payload || typeof payload.commandId !== "string") {
+    console.warn("[CommandHandlers] Invalid commands:get payload", payload);
+    return null;
+  }
+  return (await commandService.getManifest(payload.commandId, payload.context)) ?? null;
+}
 
-  // Get single command
-  const handleCommandsGet = async (
-    payload: CommandGetPayload
-  ): Promise<CommandManifestEntry | null> => {
-    if (!payload || typeof payload.commandId !== "string") {
-      console.warn("[CommandHandlers] Invalid commands:get payload", payload);
-      return null;
-    }
-    return (await commandService.getManifest(payload.commandId, payload.context)) ?? null;
-  };
-  handlers.push(typedHandle(CHANNELS.COMMANDS_GET, handleCommandsGet));
+// Execute command. Validation failures throw `AppError({code: "VALIDATION"})`;
+// command-domain success/failure is still carried by the returned
+// `CommandResult` (the commands system has its own structured result contract
+// that includes optional `prompt` injection — intentional, not an envelope).
+async function handleCommandsExecute(payload: CommandExecutePayload): Promise<CommandResult> {
+  if (!payload || typeof payload.commandId !== "string") {
+    throw new AppError({
+      code: "VALIDATION",
+      message: "Invalid command execution payload",
+    });
+  }
 
-  // Execute command. Validation failures throw `AppError({code: "VALIDATION"})`;
-  // command-domain success/failure is still carried by the returned
-  // `CommandResult` (the commands system has its own structured result contract
-  // that includes optional `prompt` injection — intentional, not an envelope).
-  const handleCommandsExecute = async (payload: CommandExecutePayload): Promise<CommandResult> => {
-    if (!payload || typeof payload.commandId !== "string") {
-      throw new AppError({
-        code: "VALIDATION",
-        message: "Invalid command execution payload",
-      });
-    }
+  const context = payload.context ?? {};
+  if (typeof context !== "object" || Array.isArray(context)) {
+    throw new AppError({
+      code: "VALIDATION",
+      message: "Context must be a plain object",
+    });
+  }
 
-    const context = payload.context ?? {};
-    if (typeof context !== "object" || Array.isArray(context)) {
-      throw new AppError({
-        code: "VALIDATION",
-        message: "Context must be a plain object",
-      });
-    }
+  const args = payload.args ?? {};
+  if (args !== null && (typeof args !== "object" || Array.isArray(args))) {
+    throw new AppError({
+      code: "VALIDATION",
+      message: "Arguments must be a plain object",
+    });
+  }
 
-    const args = payload.args ?? {};
-    if (args !== null && (typeof args !== "object" || Array.isArray(args))) {
-      throw new AppError({
-        code: "VALIDATION",
-        message: "Arguments must be a plain object",
-      });
-    }
+  return commandService.execute(payload.commandId, context, args);
+}
 
-    return commandService.execute(payload.commandId, context, args);
-  };
-  handlers.push(
+async function handleCommandsGetBuilder(
+  commandId: string
+): Promise<DaintreeCommand["builder"] | null> {
+  if (typeof commandId !== "string") {
+    return null;
+  }
+  return commandService.getBuilder(commandId) ?? null;
+}
+
+export const commandsNamespace = defineIpcNamespace({
+  name: "commands",
+  ops: {
+    list: op(COMMANDS_METHOD_CHANNELS.list, handleCommandsList),
+    get: op(COMMANDS_METHOD_CHANNELS.get, handleCommandsGet),
     // @ts-expect-error: result type CommandResult contains {success} — pending migration to throw AppError. See #6020.
-    typedHandle(CHANNELS.COMMANDS_EXECUTE, handleCommandsExecute)
-  );
+    execute: op(COMMANDS_METHOD_CHANNELS.execute, handleCommandsExecute),
+    getBuilder: op(COMMANDS_METHOD_CHANNELS.getBuilder, handleCommandsGetBuilder),
+  },
+});
 
-  // Get command builder
-  const handleCommandsGetBuilder = async (
-    commandId: string
-  ): Promise<DaintreeCommand["builder"] | null> => {
-    if (typeof commandId !== "string") {
-      return null;
-    }
-    return commandService.getBuilder(commandId) ?? null;
-  };
-  handlers.push(typedHandle(CHANNELS.COMMANDS_GET_BUILDER, handleCommandsGetBuilder));
-
-  return () => handlers.forEach((cleanup) => cleanup());
+export function registerCommandHandlers(): () => void {
+  return commandsNamespace.register();
 }

--- a/electron/ipc/handlers/demo.preload.ts
+++ b/electron/ipc/handlers/demo.preload.ts
@@ -1,0 +1,47 @@
+import type { IpcInvokeMap } from "../../types/index.js";
+
+// `demo:exec-*`, `demo:command-done`, `demo:capture-chunk`, and
+// `demo:capture-stop` are renderer→main / main→renderer send channels
+// (used by the demo runner harness) and are intentionally NOT part of
+// this invoke map.
+export const DEMO_METHOD_CHANNELS = {
+  moveTo: "demo:move-to",
+  moveToSelector: "demo:move-to-selector",
+  click: "demo:click",
+  type: "demo:type",
+  screenshot: "demo:screenshot",
+  waitForSelector: "demo:wait-for-selector",
+  pause: "demo:pause",
+  resume: "demo:resume",
+  sleep: "demo:sleep",
+  scroll: "demo:scroll",
+  drag: "demo:drag",
+  pressKey: "demo:press-key",
+  spotlight: "demo:spotlight",
+  dismissSpotlight: "demo:dismiss-spotlight",
+  annotate: "demo:annotate",
+  dismissAnnotation: "demo:dismiss-annotation",
+  waitForIdle: "demo:wait-for-idle",
+  startCapture: "demo:start-capture",
+  stopCapture: "demo:stop-capture",
+  getCaptureStatus: "demo:get-capture-status",
+} as const satisfies Record<string, keyof IpcInvokeMap>;
+
+type Methods = typeof DEMO_METHOD_CHANNELS;
+
+export type DemoPreloadBindings = {
+  [M in keyof Methods]: (
+    ...args: IpcInvokeMap[Methods[M]]["args"]
+  ) => Promise<IpcInvokeMap[Methods[M]]["result"]>;
+};
+
+type Invoker = (channel: string, ...args: unknown[]) => Promise<unknown>;
+
+export function buildDemoPreloadBindings(invoke: Invoker): DemoPreloadBindings {
+  const out: Record<string, (...args: unknown[]) => Promise<unknown>> = {};
+  for (const method of Object.keys(DEMO_METHOD_CHANNELS) as Array<keyof Methods>) {
+    const channel = DEMO_METHOD_CHANNELS[method];
+    out[method as string] = (...args) => invoke(channel, ...args);
+  }
+  return out as unknown as DemoPreloadBindings;
+}

--- a/electron/ipc/handlers/demo.preload.ts
+++ b/electron/ipc/handlers/demo.preload.ts
@@ -37,6 +37,15 @@ export type DemoPreloadBindings = {
 
 type Invoker = (channel: string, ...args: unknown[]) => Promise<unknown>;
 
+/**
+ * NOT used in production preload.cts — exported for symmetry with the other
+ * namespace builders and exercised by `leafPreloadNamespaces.test.ts`.
+ *
+ * The renderer-facing `window.electron.demo` API takes positional args
+ * (e.g. `moveTo(x, y, durationMs)`) while channels carry a single payload
+ * object. The translation layer stays inline in `preload.cts` so the user-
+ * facing shape matches the declared `ElectronAPI.demo` signature.
+ */
 export function buildDemoPreloadBindings(invoke: Invoker): DemoPreloadBindings {
   const out: Record<string, (...args: unknown[]) => Promise<unknown>> = {};
   for (const method of Object.keys(DEMO_METHOD_CHANNELS) as Array<keyof Methods>) {

--- a/electron/ipc/handlers/demo.ts
+++ b/electron/ipc/handlers/demo.ts
@@ -3,9 +3,10 @@ import { randomBytes } from "crypto";
 import * as fs from "fs";
 import * as path from "path";
 import { CHANNELS } from "../channels.js";
+import { defineIpcNamespace, op } from "../define.js";
+import { DEMO_METHOD_CHANNELS } from "./demo.preload.js";
 import type { HandlerDependencies } from "../types.js";
 import { getAppWebContents } from "../../window/webContentsRegistry.js";
-import { typedHandle } from "../utils.js";
 import type {
   DemoMoveToPayload,
   DemoMoveToSelectorPayload,
@@ -75,87 +76,6 @@ export function registerDemoHandlers(deps: HandlerDependencies): () => void {
     });
   }
 
-  const handleMoveTo = async (payload: DemoMoveToPayload): Promise<void> => {
-    await sendCommandAndAwait(CHANNELS.DEMO_EXEC_MOVE_TO, payload);
-  };
-
-  const handleMoveToSelector = async (payload: DemoMoveToSelectorPayload): Promise<void> => {
-    await sendCommandAndAwait(CHANNELS.DEMO_EXEC_MOVE_TO_SELECTOR, payload);
-  };
-
-  const handleClick = async (): Promise<void> => {
-    await sendCommandAndAwait(CHANNELS.DEMO_EXEC_CLICK);
-  };
-
-  const handleType = async (payload: DemoTypePayload): Promise<void> => {
-    await sendCommandAndAwait(CHANNELS.DEMO_EXEC_TYPE, payload);
-  };
-
-  const handleScreenshot = async (): Promise<DemoScreenshotResult> => {
-    const win = getMainWindow();
-    if (!win || win.isDestroyed()) {
-      throw new Error("No window available for screenshot");
-    }
-    const image = await getAppWebContents(win).capturePage();
-    const pngBuffer = image.toPNG();
-    const size = image.getSize();
-    return {
-      data: new Uint8Array(pngBuffer),
-      width: size.width,
-      height: size.height,
-    };
-  };
-
-  const handleWaitForSelector = async (payload: DemoWaitForSelectorPayload): Promise<void> => {
-    await sendCommandAndAwait(CHANNELS.DEMO_EXEC_WAIT_FOR_SELECTOR, payload);
-  };
-
-  const handlePause = async (): Promise<void> => {
-    await sendCommandAndAwait(CHANNELS.DEMO_EXEC_PAUSE);
-  };
-
-  const handleResume = async (): Promise<void> => {
-    await sendCommandAndAwait(CHANNELS.DEMO_EXEC_RESUME);
-  };
-
-  const handleSleep = async (payload: DemoSleepPayload): Promise<void> => {
-    await sendCommandAndAwait(CHANNELS.DEMO_EXEC_SLEEP, payload);
-  };
-
-  const handleScroll = async (payload: DemoScrollPayload): Promise<void> => {
-    await sendCommandAndAwait(CHANNELS.DEMO_EXEC_SCROLL, payload);
-  };
-
-  const handleDrag = async (payload: DemoDragPayload): Promise<void> => {
-    await sendCommandAndAwait(CHANNELS.DEMO_EXEC_DRAG, payload);
-  };
-
-  const handlePressKey = async (payload: DemoPressKeyPayload): Promise<void> => {
-    await sendCommandAndAwait(CHANNELS.DEMO_EXEC_PRESS_KEY, payload);
-  };
-
-  const handleSpotlight = async (payload: DemoSpotlightPayload): Promise<void> => {
-    await sendCommandAndAwait(CHANNELS.DEMO_EXEC_SPOTLIGHT, payload);
-  };
-
-  const handleDismissSpotlight = async (): Promise<void> => {
-    await sendCommandAndAwait(CHANNELS.DEMO_EXEC_DISMISS_SPOTLIGHT);
-  };
-
-  const handleAnnotate = async (payload: DemoAnnotatePayload): Promise<DemoAnnotateResult> => {
-    const id = payload.id ?? randomBytes(8).toString("hex");
-    await sendCommandAndAwait(CHANNELS.DEMO_EXEC_ANNOTATE, { ...payload, id });
-    return { id };
-  };
-
-  const handleDismissAnnotation = async (payload: DemoDismissAnnotationPayload): Promise<void> => {
-    await sendCommandAndAwait(CHANNELS.DEMO_EXEC_DISMISS_ANNOTATION, payload);
-  };
-
-  const handleWaitForIdle = async (payload: DemoWaitForIdlePayload): Promise<void> => {
-    await sendCommandAndAwait(CHANNELS.DEMO_EXEC_WAIT_FOR_IDLE, payload);
-  };
-
   // --- MediaRecorder-based capture state ---
   interface CaptureSession {
     captureId: string;
@@ -212,120 +132,196 @@ export function registerDemoHandlers(deps: HandlerDependencies): () => void {
   ipcMain.on(CHANNELS.DEMO_CAPTURE_CHUNK, onCaptureChunk);
   ipcMain.on(CHANNELS.DEMO_CAPTURE_STOP, onCaptureStop);
 
-  const handleStartCapture = async (
-    payload: DemoStartCapturePayload
-  ): Promise<DemoStartCaptureResult> => {
-    if (captureSession) {
-      throw new Error("Capture already in progress");
-    }
+  const namespace = defineIpcNamespace({
+    name: "demo",
+    ops: {
+      moveTo: op(DEMO_METHOD_CHANNELS.moveTo, async (payload: DemoMoveToPayload): Promise<void> => {
+        await sendCommandAndAwait(CHANNELS.DEMO_EXEC_MOVE_TO, payload);
+      }),
+      moveToSelector: op(
+        DEMO_METHOD_CHANNELS.moveToSelector,
+        async (payload: DemoMoveToSelectorPayload): Promise<void> => {
+          await sendCommandAndAwait(CHANNELS.DEMO_EXEC_MOVE_TO_SELECTOR, payload);
+        }
+      ),
+      click: op(DEMO_METHOD_CHANNELS.click, async (): Promise<void> => {
+        await sendCommandAndAwait(CHANNELS.DEMO_EXEC_CLICK);
+      }),
+      type: op(DEMO_METHOD_CHANNELS.type, async (payload: DemoTypePayload): Promise<void> => {
+        await sendCommandAndAwait(CHANNELS.DEMO_EXEC_TYPE, payload);
+      }),
+      screenshot: op(DEMO_METHOD_CHANNELS.screenshot, async (): Promise<DemoScreenshotResult> => {
+        const win = getMainWindow();
+        if (!win || win.isDestroyed()) {
+          throw new Error("No window available for screenshot");
+        }
+        const image = await getAppWebContents(win).capturePage();
+        const pngBuffer = image.toPNG();
+        const size = image.getSize();
+        return {
+          data: new Uint8Array(pngBuffer),
+          width: size.width,
+          height: size.height,
+        };
+      }),
+      waitForSelector: op(
+        DEMO_METHOD_CHANNELS.waitForSelector,
+        async (payload: DemoWaitForSelectorPayload): Promise<void> => {
+          await sendCommandAndAwait(CHANNELS.DEMO_EXEC_WAIT_FOR_SELECTOR, payload);
+        }
+      ),
+      pause: op(DEMO_METHOD_CHANNELS.pause, async (): Promise<void> => {
+        await sendCommandAndAwait(CHANNELS.DEMO_EXEC_PAUSE);
+      }),
+      resume: op(DEMO_METHOD_CHANNELS.resume, async (): Promise<void> => {
+        await sendCommandAndAwait(CHANNELS.DEMO_EXEC_RESUME);
+      }),
+      sleep: op(DEMO_METHOD_CHANNELS.sleep, async (payload: DemoSleepPayload): Promise<void> => {
+        await sendCommandAndAwait(CHANNELS.DEMO_EXEC_SLEEP, payload);
+      }),
+      scroll: op(DEMO_METHOD_CHANNELS.scroll, async (payload: DemoScrollPayload): Promise<void> => {
+        await sendCommandAndAwait(CHANNELS.DEMO_EXEC_SCROLL, payload);
+      }),
+      drag: op(DEMO_METHOD_CHANNELS.drag, async (payload: DemoDragPayload): Promise<void> => {
+        await sendCommandAndAwait(CHANNELS.DEMO_EXEC_DRAG, payload);
+      }),
+      pressKey: op(
+        DEMO_METHOD_CHANNELS.pressKey,
+        async (payload: DemoPressKeyPayload): Promise<void> => {
+          await sendCommandAndAwait(CHANNELS.DEMO_EXEC_PRESS_KEY, payload);
+        }
+      ),
+      spotlight: op(
+        DEMO_METHOD_CHANNELS.spotlight,
+        async (payload: DemoSpotlightPayload): Promise<void> => {
+          await sendCommandAndAwait(CHANNELS.DEMO_EXEC_SPOTLIGHT, payload);
+        }
+      ),
+      dismissSpotlight: op(DEMO_METHOD_CHANNELS.dismissSpotlight, async (): Promise<void> => {
+        await sendCommandAndAwait(CHANNELS.DEMO_EXEC_DISMISS_SPOTLIGHT);
+      }),
+      annotate: op(
+        DEMO_METHOD_CHANNELS.annotate,
+        async (payload: DemoAnnotatePayload): Promise<DemoAnnotateResult> => {
+          const id = payload.id ?? randomBytes(8).toString("hex");
+          await sendCommandAndAwait(CHANNELS.DEMO_EXEC_ANNOTATE, { ...payload, id });
+          return { id };
+        }
+      ),
+      dismissAnnotation: op(
+        DEMO_METHOD_CHANNELS.dismissAnnotation,
+        async (payload: DemoDismissAnnotationPayload): Promise<void> => {
+          await sendCommandAndAwait(CHANNELS.DEMO_EXEC_DISMISS_ANNOTATION, payload);
+        }
+      ),
+      waitForIdle: op(
+        DEMO_METHOD_CHANNELS.waitForIdle,
+        async (payload: DemoWaitForIdlePayload): Promise<void> => {
+          await sendCommandAndAwait(CHANNELS.DEMO_EXEC_WAIT_FOR_IDLE, payload);
+        }
+      ),
+      startCapture: op(
+        DEMO_METHOD_CHANNELS.startCapture,
+        async (payload: DemoStartCapturePayload): Promise<DemoStartCaptureResult> => {
+          if (captureSession) {
+            throw new Error("Capture already in progress");
+          }
 
-    const fps = payload.fps ?? 30;
-    const { outputPath } = payload;
+          const fps = payload.fps ?? 30;
+          const { outputPath } = payload;
 
-    fs.mkdirSync(path.dirname(outputPath), { recursive: true });
+          fs.mkdirSync(path.dirname(outputPath), { recursive: true });
 
-    const captureId = randomBytes(8).toString("hex");
-    const writeStream = fs.createWriteStream(outputPath);
+          const captureId = randomBytes(8).toString("hex");
+          const writeStream = fs.createWriteStream(outputPath);
 
-    let resolveFinalizeWith!: (result: DemoStopCaptureResult) => void;
-    let rejectFinalizeWith!: (err: Error) => void;
-    const finalizePromise = new Promise<DemoStopCaptureResult>((resolve, reject) => {
-      resolveFinalizeWith = resolve;
-      rejectFinalizeWith = reject;
-    });
-    // Suppress unhandled rejection if nothing ever awaits finalize (e.g., handlers
-    // torn down before stopCapture is called). Real awaiters still observe the rejection.
-    finalizePromise.catch(() => {});
+          let resolveFinalizeWith!: (result: DemoStopCaptureResult) => void;
+          let rejectFinalizeWith!: (err: Error) => void;
+          const finalizePromise = new Promise<DemoStopCaptureResult>((resolve, reject) => {
+            resolveFinalizeWith = resolve;
+            rejectFinalizeWith = reject;
+          });
+          // Suppress unhandled rejection if nothing ever awaits finalize (e.g., handlers
+          // torn down before stopCapture is called). Real awaiters still observe the rejection.
+          finalizePromise.catch(() => {});
 
-    const newSession: CaptureSession = {
-      captureId,
-      outputPath,
-      writeStream,
-      frameCount: 0,
-      stopping: false,
-      finalized: false,
-      finalizePromise,
-      resolveFinalizeWith,
-      rejectFinalizeWith,
-    };
+          const newSession: CaptureSession = {
+            captureId,
+            outputPath,
+            writeStream,
+            frameCount: 0,
+            stopping: false,
+            finalized: false,
+            finalizePromise,
+            resolveFinalizeWith,
+            rejectFinalizeWith,
+          };
 
-    writeStream.on("error", (err: Error) => {
-      if (captureSession === newSession && !newSession.finalized) {
-        newSession.finalized = true;
-        captureSession = null;
-        rejectFinalizeWith(new Error(`Capture write failed: ${err.message}`));
-      }
-    });
+          writeStream.on("error", (err: Error) => {
+            if (captureSession === newSession && !newSession.finalized) {
+              newSession.finalized = true;
+              captureSession = null;
+              rejectFinalizeWith(new Error(`Capture write failed: ${err.message}`));
+            }
+          });
 
-    captureSession = newSession;
+          captureSession = newSession;
 
-    try {
-      await sendCommandAndAwait(CHANNELS.DEMO_EXEC_START_CAPTURE, {
-        captureId,
-        fps,
-        mimeType: CAPTURE_MIME_TYPE,
-      });
-    } catch (err) {
-      captureSession = null;
-      writeStream.destroy();
-      throw err;
-    }
+          try {
+            await sendCommandAndAwait(CHANNELS.DEMO_EXEC_START_CAPTURE, {
+              captureId,
+              fps,
+              mimeType: CAPTURE_MIME_TYPE,
+            });
+          } catch (err) {
+            captureSession = null;
+            writeStream.destroy();
+            throw err;
+          }
 
-    return { outputPath };
-  };
+          return { outputPath };
+        }
+      ),
+      stopCapture: op(
+        DEMO_METHOD_CHANNELS.stopCapture,
+        async (): Promise<DemoStopCaptureResult> => {
+          const active = captureSession;
+          if (!active) {
+            throw new Error("No capture in progress");
+          }
+          if (active.stopping) {
+            return active.finalizePromise;
+          }
+          active.stopping = true;
+          try {
+            await sendCommandAndAwait(CHANNELS.DEMO_EXEC_STOP_CAPTURE, {
+              captureId: active.captureId,
+            });
+          } catch (err) {
+            if (captureSession === active && !active.finalized) {
+              active.finalized = true;
+              captureSession = null;
+              active.writeStream.destroy();
+              active.rejectFinalizeWith(err instanceof Error ? err : new Error(String(err)));
+            }
+          }
+          return active.finalizePromise;
+        }
+      ),
+      getCaptureStatus: op(
+        DEMO_METHOD_CHANNELS.getCaptureStatus,
+        async (): Promise<DemoCaptureStatus> => {
+          return {
+            active: captureSession !== null && !captureSession.finalized,
+            frameCount: captureSession?.frameCount ?? 0,
+            outputPath: captureSession?.outputPath ?? null,
+          };
+        }
+      ),
+    },
+  });
 
-  const handleStopCapture = async (): Promise<DemoStopCaptureResult> => {
-    const active = captureSession;
-    if (!active) {
-      throw new Error("No capture in progress");
-    }
-    if (active.stopping) {
-      return active.finalizePromise;
-    }
-    active.stopping = true;
-    try {
-      await sendCommandAndAwait(CHANNELS.DEMO_EXEC_STOP_CAPTURE, { captureId: active.captureId });
-    } catch (err) {
-      if (captureSession === active && !active.finalized) {
-        active.finalized = true;
-        captureSession = null;
-        active.writeStream.destroy();
-        active.rejectFinalizeWith(err instanceof Error ? err : new Error(String(err)));
-      }
-    }
-    return active.finalizePromise;
-  };
-
-  const handleGetCaptureStatus = async (): Promise<DemoCaptureStatus> => {
-    return {
-      active: captureSession !== null && !captureSession.finalized,
-      frameCount: captureSession?.frameCount ?? 0,
-      outputPath: captureSession?.outputPath ?? null,
-    };
-  };
-
-  const cleanups: Array<() => void> = [
-    typedHandle(CHANNELS.DEMO_MOVE_TO, handleMoveTo),
-    typedHandle(CHANNELS.DEMO_MOVE_TO_SELECTOR, handleMoveToSelector),
-    typedHandle(CHANNELS.DEMO_CLICK, handleClick),
-    typedHandle(CHANNELS.DEMO_SCREENSHOT, handleScreenshot),
-    typedHandle(CHANNELS.DEMO_TYPE, handleType),
-    typedHandle(CHANNELS.DEMO_WAIT_FOR_SELECTOR, handleWaitForSelector),
-    typedHandle(CHANNELS.DEMO_PAUSE, handlePause),
-    typedHandle(CHANNELS.DEMO_RESUME, handleResume),
-    typedHandle(CHANNELS.DEMO_SLEEP, handleSleep),
-    typedHandle(CHANNELS.DEMO_SCROLL, handleScroll),
-    typedHandle(CHANNELS.DEMO_DRAG, handleDrag),
-    typedHandle(CHANNELS.DEMO_PRESS_KEY, handlePressKey),
-    typedHandle(CHANNELS.DEMO_SPOTLIGHT, handleSpotlight),
-    typedHandle(CHANNELS.DEMO_DISMISS_SPOTLIGHT, handleDismissSpotlight),
-    typedHandle(CHANNELS.DEMO_ANNOTATE, handleAnnotate),
-    typedHandle(CHANNELS.DEMO_DISMISS_ANNOTATION, handleDismissAnnotation),
-    typedHandle(CHANNELS.DEMO_WAIT_FOR_IDLE, handleWaitForIdle),
-    typedHandle(CHANNELS.DEMO_START_CAPTURE, handleStartCapture),
-    typedHandle(CHANNELS.DEMO_STOP_CAPTURE, handleStopCapture),
-    typedHandle(CHANNELS.DEMO_GET_CAPTURE_STATUS, handleGetCaptureStatus),
-  ];
+  const cleanups: Array<() => void> = [namespace.register()];
 
   return () => {
     if (captureSession && !captureSession.finalized) {
@@ -338,8 +334,6 @@ export function registerDemoHandlers(deps: HandlerDependencies): () => void {
     ipcMain.removeListener(CHANNELS.DEMO_CAPTURE_CHUNK, onCaptureChunk);
     ipcMain.removeListener(CHANNELS.DEMO_CAPTURE_STOP, onCaptureStop);
     displayMediaHandlerSession.setDisplayMediaRequestHandler(null);
-    for (const cleanup of cleanups) {
-      cleanup();
-    }
+    cleanups.forEach((cleanup) => cleanup());
   };
 }

--- a/electron/ipc/handlers/devPreview.preload.ts
+++ b/electron/ipc/handlers/devPreview.preload.ts
@@ -1,0 +1,29 @@
+import type { IpcInvokeMap } from "../../types/index.js";
+
+export const DEV_PREVIEW_METHOD_CHANNELS = {
+  ensure: "dev-preview:ensure",
+  restart: "dev-preview:restart",
+  stop: "dev-preview:stop",
+  stopByPanel: "dev-preview:stop-by-panel",
+  getState: "dev-preview:get-state",
+  getByWorktree: "dev-preview:get-by-worktree",
+} as const satisfies Record<string, keyof IpcInvokeMap>;
+
+type Methods = typeof DEV_PREVIEW_METHOD_CHANNELS;
+
+export type DevPreviewPreloadBindings = {
+  [M in keyof Methods]: (
+    ...args: IpcInvokeMap[Methods[M]]["args"]
+  ) => Promise<IpcInvokeMap[Methods[M]]["result"]>;
+};
+
+type Invoker = (channel: string, ...args: unknown[]) => Promise<unknown>;
+
+export function buildDevPreviewPreloadBindings(invoke: Invoker): DevPreviewPreloadBindings {
+  const out: Record<string, (...args: unknown[]) => Promise<unknown>> = {};
+  for (const method of Object.keys(DEV_PREVIEW_METHOD_CHANNELS) as Array<keyof Methods>) {
+    const channel = DEV_PREVIEW_METHOD_CHANNELS[method];
+    out[method as string] = (...args) => invoke(channel, ...args);
+  }
+  return out as unknown as DevPreviewPreloadBindings;
+}

--- a/electron/ipc/handlers/devPreview.ts
+++ b/electron/ipc/handlers/devPreview.ts
@@ -1,5 +1,7 @@
 import { CHANNELS } from "../channels.js";
-import { broadcastToRenderer, typedHandle } from "../utils.js";
+import { broadcastToRenderer } from "../utils.js";
+import { defineIpcNamespace, op } from "../define.js";
+import { DEV_PREVIEW_METHOD_CHANNELS } from "./devPreview.preload.js";
 import type { HandlerDependencies } from "../types.js";
 import type {
   DevPreviewEnsureRequest,
@@ -12,8 +14,6 @@ import type { DevPreviewSessionService as DevPreviewSessionServiceType } from ".
 import { getHibernationService } from "../../services/HibernationService.js";
 
 export function registerDevPreviewHandlers(deps: HandlerDependencies): () => void {
-  const handlers: Array<() => void> = [];
-
   let sessionService: DevPreviewSessionServiceType | null = null;
   let sessionServicePromise: Promise<DevPreviewSessionServiceType> | null = null;
 
@@ -38,44 +38,52 @@ export function registerDevPreviewHandlers(deps: HandlerDependencies): () => voi
     return sessionServicePromise;
   }
 
-  const handleEnsure = async (request: DevPreviewEnsureRequest) => {
-    const svc = await getSessionService();
-    return svc.ensure(request);
-  };
-  handlers.push(typedHandle(CHANNELS.DEV_PREVIEW_ENSURE, handleEnsure));
+  const namespace = defineIpcNamespace({
+    name: "devPreview",
+    ops: {
+      ensure: op(DEV_PREVIEW_METHOD_CHANNELS.ensure, async (request: DevPreviewEnsureRequest) => {
+        const svc = await getSessionService();
+        return svc.ensure(request);
+      }),
+      restart: op(
+        DEV_PREVIEW_METHOD_CHANNELS.restart,
+        async (request: DevPreviewSessionRequest) => {
+          const svc = await getSessionService();
+          return svc.restart(request);
+        }
+      ),
+      stop: op(DEV_PREVIEW_METHOD_CHANNELS.stop, async (request: DevPreviewSessionRequest) => {
+        const svc = await getSessionService();
+        return svc.stop(request);
+      }),
+      stopByPanel: op(
+        DEV_PREVIEW_METHOD_CHANNELS.stopByPanel,
+        async (request: DevPreviewStopByPanelRequest) => {
+          const svc = await getSessionService();
+          await svc.stopByPanel(request);
+        }
+      ),
+      getState: op(
+        DEV_PREVIEW_METHOD_CHANNELS.getState,
+        async (request: DevPreviewSessionRequest) => {
+          const svc = await getSessionService();
+          return svc.getState(request);
+        }
+      ),
+      getByWorktree: op(
+        DEV_PREVIEW_METHOD_CHANNELS.getByWorktree,
+        async (request: DevPreviewGetByWorktreeRequest) => {
+          if (!request || typeof request.worktreeId !== "string" || !request.worktreeId.trim()) {
+            throw new Error("worktreeId is required");
+          }
+          const svc = await getSessionService();
+          return svc.getByWorktree(request.worktreeId);
+        }
+      ),
+    },
+  });
 
-  const handleRestart = async (request: DevPreviewSessionRequest) => {
-    const svc = await getSessionService();
-    return svc.restart(request);
-  };
-  handlers.push(typedHandle(CHANNELS.DEV_PREVIEW_RESTART, handleRestart));
-
-  const handleStop = async (request: DevPreviewSessionRequest) => {
-    const svc = await getSessionService();
-    return svc.stop(request);
-  };
-  handlers.push(typedHandle(CHANNELS.DEV_PREVIEW_STOP, handleStop));
-
-  const handleStopByPanel = async (request: DevPreviewStopByPanelRequest) => {
-    const svc = await getSessionService();
-    await svc.stopByPanel(request);
-  };
-  handlers.push(typedHandle(CHANNELS.DEV_PREVIEW_STOP_BY_PANEL, handleStopByPanel));
-
-  const handleGetState = async (request: DevPreviewSessionRequest) => {
-    const svc = await getSessionService();
-    return svc.getState(request);
-  };
-  handlers.push(typedHandle(CHANNELS.DEV_PREVIEW_GET_STATE, handleGetState));
-
-  const handleGetByWorktree = async (request: DevPreviewGetByWorktreeRequest) => {
-    if (!request || typeof request.worktreeId !== "string" || !request.worktreeId.trim()) {
-      throw new Error("worktreeId is required");
-    }
-    const svc = await getSessionService();
-    return svc.getByWorktree(request.worktreeId);
-  };
-  handlers.push(typedHandle(CHANNELS.DEV_PREVIEW_GET_BY_WORKTREE, handleGetByWorktree));
+  const cleanups: Array<() => void> = [namespace.register()];
 
   const unsubHibernation = getHibernationService().onProjectHibernated((projectId) => {
     // Skip if the session service was never created — no sessions exist to stop.
@@ -90,6 +98,6 @@ export function registerDevPreviewHandlers(deps: HandlerDependencies): () => voi
     if (sessionService) {
       sessionService.dispose();
     }
-    handlers.forEach((dispose) => dispose());
+    cleanups.forEach((dispose) => dispose());
   };
 }

--- a/electron/ipc/handlers/eventInspector.preload.ts
+++ b/electron/ipc/handlers/eventInspector.preload.ts
@@ -1,0 +1,26 @@
+import type { IpcInvokeMap } from "../../types/index.js";
+
+export const EVENT_INSPECTOR_METHOD_CHANNELS = {
+  getEvents: "event-inspector:get-events",
+  getFiltered: "event-inspector:get-filtered",
+  clear: "event-inspector:clear",
+} as const satisfies Record<string, keyof IpcInvokeMap>;
+
+type Methods = typeof EVENT_INSPECTOR_METHOD_CHANNELS;
+
+export type EventInspectorPreloadBindings = {
+  [M in keyof Methods]: (
+    ...args: IpcInvokeMap[Methods[M]]["args"]
+  ) => Promise<IpcInvokeMap[Methods[M]]["result"]>;
+};
+
+type Invoker = (channel: string, ...args: unknown[]) => Promise<unknown>;
+
+export function buildEventInspectorPreloadBindings(invoke: Invoker): EventInspectorPreloadBindings {
+  const out: Record<string, (...args: unknown[]) => Promise<unknown>> = {};
+  for (const method of Object.keys(EVENT_INSPECTOR_METHOD_CHANNELS) as Array<keyof Methods>) {
+    const channel = EVENT_INSPECTOR_METHOD_CHANNELS[method];
+    out[method as string] = (...args) => invoke(channel, ...args);
+  }
+  return out as unknown as EventInspectorPreloadBindings;
+}

--- a/electron/ipc/handlers/eventInspector.ts
+++ b/electron/ipc/handlers/eventInspector.ts
@@ -1,9 +1,10 @@
 import { ipcMain, type WebContents } from "electron";
 import { CHANNELS } from "../channels.js";
+import { defineIpcNamespace, op } from "../define.js";
+import { EVENT_INSPECTOR_METHOD_CHANNELS } from "./eventInspector.preload.js";
 import type { HandlerDependencies } from "../types.js";
 import type { FilterOptions } from "../../services/EventBuffer.js";
 import type { EventFilterOptions, EventRecord } from "../../../shared/types/index.js";
-import { typedHandle } from "../utils.js";
 
 const subscribedWebContents = new Map<WebContents, () => void>();
 let eventBufferUnsubscribe: (() => void) | null = null;
@@ -13,34 +14,35 @@ const BATCH_WINDOW_MS = 50;
 const MAX_BATCH_SIZE = 200;
 
 export function registerEventInspectorHandlers(deps: HandlerDependencies): () => void {
-  const handlers: Array<() => void> = [];
+  const namespace = defineIpcNamespace({
+    name: "eventInspector",
+    ops: {
+      getEvents: op(EVENT_INSPECTOR_METHOD_CHANNELS.getEvents, async () => {
+        if (!deps.eventBuffer) {
+          return [];
+        }
+        return deps.eventBuffer.getAll();
+      }),
+      getFiltered: op(
+        EVENT_INSPECTOR_METHOD_CHANNELS.getFiltered,
+        async (filters: EventFilterOptions) => {
+          if (!deps.eventBuffer) {
+            return [];
+          }
+          // Handler accepts the broader shared type; EventBuffer enforces stricter typing internally.
+          return deps.eventBuffer.getFiltered(filters as FilterOptions);
+        }
+      ),
+      clear: op(EVENT_INSPECTOR_METHOD_CHANNELS.clear, async () => {
+        if (!deps.eventBuffer) {
+          return;
+        }
+        deps.eventBuffer.clear();
+      }),
+    },
+  });
 
-  const handleEventInspectorGetEvents = async () => {
-    if (!deps.eventBuffer) {
-      return [];
-    }
-    return deps.eventBuffer.getAll();
-  };
-  handlers.push(typedHandle(CHANNELS.EVENT_INSPECTOR_GET_EVENTS, handleEventInspectorGetEvents));
-
-  const handleEventInspectorGetFiltered = async (filters: EventFilterOptions) => {
-    if (!deps.eventBuffer) {
-      return [];
-    }
-    // Handler accepts the broader shared type; EventBuffer enforces stricter typing internally.
-    return deps.eventBuffer.getFiltered(filters as FilterOptions);
-  };
-  handlers.push(
-    typedHandle(CHANNELS.EVENT_INSPECTOR_GET_FILTERED, handleEventInspectorGetFiltered)
-  );
-
-  const handleEventInspectorClear = async () => {
-    if (!deps.eventBuffer) {
-      return;
-    }
-    deps.eventBuffer.clear();
-  };
-  handlers.push(typedHandle(CHANNELS.EVENT_INSPECTOR_CLEAR, handleEventInspectorClear));
+  const cleanups: Array<() => void> = [namespace.register()];
 
   const flushBatch = () => {
     if (batchTimeout) {
@@ -109,7 +111,7 @@ export function registerEventInspectorHandlers(deps: HandlerDependencies): () =>
     }
   };
   ipcMain.on(CHANNELS.EVENT_INSPECTOR_SUBSCRIBE, handleSubscribe);
-  handlers.push(() => ipcMain.removeListener(CHANNELS.EVENT_INSPECTOR_SUBSCRIBE, handleSubscribe));
+  cleanups.push(() => ipcMain.removeListener(CHANNELS.EVENT_INSPECTOR_SUBSCRIBE, handleSubscribe));
 
   const handleUnsubscribe = (event: Electron.IpcMainEvent) => {
     const sender = event.sender;
@@ -126,12 +128,12 @@ export function registerEventInspectorHandlers(deps: HandlerDependencies): () =>
     }
   };
   ipcMain.on(CHANNELS.EVENT_INSPECTOR_UNSUBSCRIBE, handleUnsubscribe);
-  handlers.push(() =>
+  cleanups.push(() =>
     ipcMain.removeListener(CHANNELS.EVENT_INSPECTOR_UNSUBSCRIBE, handleUnsubscribe)
   );
 
   return () => {
-    handlers.forEach((cleanup) => cleanup());
+    cleanups.forEach((cleanup) => cleanup());
 
     flushBatch();
 

--- a/electron/ipc/handlers/plugin.preload.ts
+++ b/electron/ipc/handlers/plugin.preload.ts
@@ -1,0 +1,36 @@
+import type { IpcInvokeMap } from "../../types/index.js";
+
+// `plugin:invoke` is intentionally NOT in this map. Its variadic
+// `(pluginId, channel, ...args)` signature and senderFrame trust check
+// can't be expressed through `IpcInvokeMap` without widening types to
+// `unknown[]`, so the raw `ipcMain.handle` route in `plugin.ts` is kept
+// (allowlisted in `ipcHandleCoverage.test.ts`).
+export const PLUGIN_METHOD_CHANNELS = {
+  list: "plugin:list",
+  toolbarButtons: "plugin:toolbar-buttons",
+  menuItems: "plugin:menu-items",
+  validateActionIds: "plugin:validate-action-ids",
+  getActions: "plugin:actions-get",
+  registerAction: "plugin:actions-register",
+  unregisterAction: "plugin:actions-unregister",
+  getPanelKinds: "plugin:panel-kinds-get",
+} as const satisfies Record<string, keyof IpcInvokeMap>;
+
+type Methods = typeof PLUGIN_METHOD_CHANNELS;
+
+export type PluginPreloadBindings = {
+  [M in keyof Methods]: (
+    ...args: IpcInvokeMap[Methods[M]]["args"]
+  ) => Promise<IpcInvokeMap[Methods[M]]["result"]>;
+};
+
+type Invoker = (channel: string, ...args: unknown[]) => Promise<unknown>;
+
+export function buildPluginPreloadBindings(invoke: Invoker): PluginPreloadBindings {
+  const out: Record<string, (...args: unknown[]) => Promise<unknown>> = {};
+  for (const method of Object.keys(PLUGIN_METHOD_CHANNELS) as Array<keyof Methods>) {
+    const channel = PLUGIN_METHOD_CHANNELS[method];
+    out[method as string] = (...args) => invoke(channel, ...args);
+  }
+  return out as unknown as PluginPreloadBindings;
+}

--- a/electron/ipc/handlers/plugin.ts
+++ b/electron/ipc/handlers/plugin.ts
@@ -1,5 +1,7 @@
 import { ipcMain } from "electron";
 import { CHANNELS } from "../channels.js";
+import { defineIpcNamespace, op } from "../define.js";
+import { PLUGIN_METHOD_CHANNELS } from "./plugin.preload.js";
 import { pluginService } from "../../services/PluginService.js";
 import {
   getPluginToolbarButtonIds,
@@ -19,86 +21,97 @@ import type {
   PluginActionDescriptor,
 } from "../../../shared/types/plugin.js";
 import type { ToolbarButtonConfig } from "../../../shared/config/toolbarButtonRegistry.js";
-import { typedHandle } from "../utils.js";
 import { assertIpcSecurityReady } from "../ipcGuard.js";
 
+async function handleList(): Promise<LoadedPluginInfo[]> {
+  return pluginService.listPlugins();
+}
+
+async function handleToolbarButtons(): Promise<ToolbarButtonConfig[]> {
+  return getPluginToolbarButtonIds()
+    .map((id) => getToolbarButtonConfig(id))
+    .filter((c): c is ToolbarButtonConfig => c !== undefined);
+}
+
+async function handleMenuItems() {
+  return getPluginMenuItems();
+}
+
+async function handleValidateActionIds(actionIds: string[]): Promise<void> {
+  if (!Array.isArray(actionIds)) return;
+
+  const knownIds = new Set(actionIds.filter((id): id is string => typeof id === "string"));
+
+  // Plugin-contributed actions are registered dynamically in the renderer
+  // after this snapshot runs, so their IDs won't appear in `knownIds`. Pull
+  // the live plugin-action registry from the main-side PluginService and
+  // treat those as known.
+  for (const { id } of pluginService.listPluginActions()) {
+    knownIds.add(id);
+  }
+
+  for (const id of getPluginToolbarButtonIds()) {
+    const config = getToolbarButtonConfig(id);
+    if (!config) continue;
+    if (!knownIds.has(config.actionId)) {
+      console.warn(
+        `[Plugin] Unknown actionId "${config.actionId}" on toolbar button "${config.id}" (plugin: ${config.pluginId})`
+      );
+    }
+  }
+
+  for (const { pluginId, item } of getPluginMenuItems()) {
+    if (!knownIds.has(item.actionId)) {
+      console.warn(
+        `[Plugin] Unknown actionId "${item.actionId}" on menu item "${item.label}" (plugin: ${pluginId})`
+      );
+    }
+  }
+}
+
+// Trust model for plugin:actions-* channels: defineIpcNamespace deliberately
+// omits an isTrustedRendererUrl check because contextBridge only exposes
+// window.electron to trusted renderer frames (the app origin). Untrusted
+// iframes, <webview>, and portal WebContents have no access to this API,
+// so no per-request URL check is needed. PLUGIN_INVOKE has a check only
+// because it uses raw ipcMain.handle for its variadic signature, which
+// gives it direct access to event.senderFrame — the typed path here does
+// not and doesn't need it.
+async function handleActionsGet(): Promise<PluginActionDescriptor[]> {
+  return pluginService.listPluginActions();
+}
+
+async function handleActionsRegister(
+  pluginId: string,
+  contribution: PluginActionContribution
+): Promise<void> {
+  pluginService.registerPluginAction(pluginId, contribution);
+}
+
+async function handleActionsUnregister(pluginId: string, actionId: string): Promise<void> {
+  pluginService.unregisterPluginAction(pluginId, actionId);
+}
+
+async function handlePanelKindsGet(): Promise<PanelKindConfig[]> {
+  return getPluginPanelKinds();
+}
+
+export const pluginNamespace = defineIpcNamespace({
+  name: "plugin",
+  ops: {
+    list: op(PLUGIN_METHOD_CHANNELS.list, handleList),
+    toolbarButtons: op(PLUGIN_METHOD_CHANNELS.toolbarButtons, handleToolbarButtons),
+    menuItems: op(PLUGIN_METHOD_CHANNELS.menuItems, handleMenuItems),
+    validateActionIds: op(PLUGIN_METHOD_CHANNELS.validateActionIds, handleValidateActionIds),
+    getActions: op(PLUGIN_METHOD_CHANNELS.getActions, handleActionsGet),
+    registerAction: op(PLUGIN_METHOD_CHANNELS.registerAction, handleActionsRegister),
+    unregisterAction: op(PLUGIN_METHOD_CHANNELS.unregisterAction, handleActionsUnregister),
+    getPanelKinds: op(PLUGIN_METHOD_CHANNELS.getPanelKinds, handlePanelKindsGet),
+  },
+});
+
 export function registerPluginHandlers(): () => void {
-  const handlers: Array<() => void> = [];
-
-  const handleList = async (): Promise<LoadedPluginInfo[]> => {
-    return pluginService.listPlugins();
-  };
-
-  const handleToolbarButtons = async (): Promise<ToolbarButtonConfig[]> => {
-    return getPluginToolbarButtonIds()
-      .map((id) => getToolbarButtonConfig(id))
-      .filter((c): c is ToolbarButtonConfig => c !== undefined);
-  };
-
-  const handleMenuItems = async () => {
-    return getPluginMenuItems();
-  };
-
-  const handleValidateActionIds = async (actionIds: string[]): Promise<void> => {
-    if (!Array.isArray(actionIds)) return;
-
-    const knownIds = new Set(actionIds.filter((id): id is string => typeof id === "string"));
-
-    // Plugin-contributed actions are registered dynamically in the renderer
-    // after this snapshot runs, so their IDs won't appear in `knownIds`. Pull
-    // the live plugin-action registry from the main-side PluginService and
-    // treat those as known.
-    for (const { id } of pluginService.listPluginActions()) {
-      knownIds.add(id);
-    }
-
-    for (const id of getPluginToolbarButtonIds()) {
-      const config = getToolbarButtonConfig(id);
-      if (!config) continue;
-      if (!knownIds.has(config.actionId)) {
-        console.warn(
-          `[Plugin] Unknown actionId "${config.actionId}" on toolbar button "${config.id}" (plugin: ${config.pluginId})`
-        );
-      }
-    }
-
-    for (const { pluginId, item } of getPluginMenuItems()) {
-      if (!knownIds.has(item.actionId)) {
-        console.warn(
-          `[Plugin] Unknown actionId "${item.actionId}" on menu item "${item.label}" (plugin: ${pluginId})`
-        );
-      }
-    }
-  };
-
-  // Trust model for plugin:actions-* channels: typedHandle deliberately omits
-  // an isTrustedRendererUrl check because contextBridge only exposes
-  // window.electron to trusted renderer frames (the app origin). Untrusted
-  // iframes, <webview>, and portal WebContents have no access to this API,
-  // so no per-request URL check is needed. PLUGIN_INVOKE has a check only
-  // because it uses raw ipcMain.handle for its variadic signature, which
-  // gives it direct access to event.senderFrame — the typed path here does
-  // not and doesn't need it.
-  const handleActionsGet = async (): Promise<PluginActionDescriptor[]> => {
-    return pluginService.listPluginActions();
-  };
-
-  const handleActionsRegister = async (
-    pluginId: string,
-    contribution: PluginActionContribution
-  ): Promise<void> => {
-    pluginService.registerPluginAction(pluginId, contribution);
-  };
-
-  const handleActionsUnregister = async (pluginId: string, actionId: string): Promise<void> => {
-    pluginService.unregisterPluginAction(pluginId, actionId);
-  };
-
-  const handlePanelKindsGet = async (): Promise<PanelKindConfig[]> => {
-    return getPluginPanelKinds();
-  };
-
-  handlers.push(typedHandle(CHANNELS.PLUGIN_LIST, handleList));
+  const cleanups: Array<() => void> = [pluginNamespace.register()];
 
   // plugin:invoke intentionally stays on raw ipcMain.handle: its variadic
   // `...args: unknown[]` signature and senderFrame.url trust check can't be
@@ -121,17 +134,9 @@ export function registerPluginHandlers(): () => void {
       return await pluginService.dispatchHandler(pluginId, channel, ctx, args);
     }
   );
-  handlers.push(() => ipcMain.removeHandler(CHANNELS.PLUGIN_INVOKE));
+  cleanups.push(() => ipcMain.removeHandler(CHANNELS.PLUGIN_INVOKE));
 
-  handlers.push(typedHandle(CHANNELS.PLUGIN_TOOLBAR_BUTTONS, handleToolbarButtons));
-  handlers.push(typedHandle(CHANNELS.PLUGIN_MENU_ITEMS, handleMenuItems));
-  handlers.push(typedHandle(CHANNELS.PLUGIN_VALIDATE_ACTION_IDS, handleValidateActionIds));
-  handlers.push(typedHandle(CHANNELS.PLUGIN_ACTIONS_GET, handleActionsGet));
-  handlers.push(typedHandle(CHANNELS.PLUGIN_ACTIONS_REGISTER, handleActionsRegister));
-  handlers.push(typedHandle(CHANNELS.PLUGIN_ACTIONS_UNREGISTER, handleActionsUnregister));
-  handlers.push(typedHandle(CHANNELS.PLUGIN_PANEL_KINDS_GET, handlePanelKindsGet));
-
-  return () => handlers.forEach((cleanup) => cleanup());
+  return () => cleanups.forEach((cleanup) => cleanup());
 }
 
 export function registerPluginHandler(

--- a/electron/ipc/handlers/portal.preload.ts
+++ b/electron/ipc/handlers/portal.preload.ts
@@ -1,0 +1,33 @@
+import type { IpcInvokeMap } from "../../types/index.js";
+
+export const PORTAL_METHOD_CHANNELS = {
+  create: "portal:create",
+  show: "portal:show",
+  hide: "portal:hide",
+  resize: "portal:resize",
+  closeTab: "portal:close-tab",
+  navigate: "portal:navigate",
+  goBack: "portal:go-back",
+  goForward: "portal:go-forward",
+  reload: "portal:reload",
+  showNewTabMenu: "portal:show-new-tab-menu",
+} as const satisfies Record<string, keyof IpcInvokeMap>;
+
+type Methods = typeof PORTAL_METHOD_CHANNELS;
+
+export type PortalPreloadBindings = {
+  [M in keyof Methods]: (
+    ...args: IpcInvokeMap[Methods[M]]["args"]
+  ) => Promise<IpcInvokeMap[Methods[M]]["result"]>;
+};
+
+type Invoker = (channel: string, ...args: unknown[]) => Promise<unknown>;
+
+export function buildPortalPreloadBindings(invoke: Invoker): PortalPreloadBindings {
+  const out: Record<string, (...args: unknown[]) => Promise<unknown>> = {};
+  for (const method of Object.keys(PORTAL_METHOD_CHANNELS) as Array<keyof Methods>) {
+    const channel = PORTAL_METHOD_CHANNELS[method];
+    out[method as string] = (...args) => invoke(channel, ...args);
+  }
+  return out as unknown as PortalPreloadBindings;
+}

--- a/electron/ipc/handlers/portal.ts
+++ b/electron/ipc/handlers/portal.ts
@@ -1,6 +1,8 @@
 import { Menu } from "electron";
 import { getAppWebContents } from "../../window/webContentsRegistry.js";
 import { CHANNELS } from "../channels.js";
+import { defineIpcNamespace, op } from "../define.js";
+import { PORTAL_METHOD_CHANNELS } from "./portal.preload.js";
 import type { HandlerDependencies } from "../types.js";
 import type {
   PortalCreatePayload,
@@ -11,25 +13,23 @@ import type {
   PortalShowNewTabMenuPayload,
   PortalNewTabMenuAction,
 } from "../../../shared/types/portal.js";
-import { typedHandle, typedHandleWithContext } from "../utils.js";
+
+function isValidBounds(bounds: unknown): bounds is PortalBounds {
+  if (!bounds || typeof bounds !== "object") return false;
+  const candidate = bounds as Partial<PortalBounds>;
+  return (
+    typeof candidate.x === "number" &&
+    Number.isFinite(candidate.x) &&
+    typeof candidate.y === "number" &&
+    Number.isFinite(candidate.y) &&
+    typeof candidate.width === "number" &&
+    Number.isFinite(candidate.width) &&
+    typeof candidate.height === "number" &&
+    Number.isFinite(candidate.height)
+  );
+}
 
 export function registerPortalHandlers(deps: HandlerDependencies): () => void {
-  const handlers: Array<() => void> = [];
-  const isValidBounds = (bounds: unknown): bounds is PortalBounds => {
-    if (!bounds || typeof bounds !== "object") return false;
-    const candidate = bounds as Partial<PortalBounds>;
-    return (
-      typeof candidate.x === "number" &&
-      Number.isFinite(candidate.x) &&
-      typeof candidate.y === "number" &&
-      Number.isFinite(candidate.y) &&
-      typeof candidate.width === "number" &&
-      Number.isFinite(candidate.width) &&
-      typeof candidate.height === "number" &&
-      Number.isFinite(candidate.height)
-    );
-  };
-
   const sendMenuAction = (win: Electron.BrowserWindow, action: string) => {
     try {
       const appWebContents = getAppWebContents(win);
@@ -40,183 +40,169 @@ export function registerPortalHandlers(deps: HandlerDependencies): () => void {
     }
   };
 
-  const handlePortalCreate = async (payload: PortalCreatePayload) => {
-    try {
-      if (!deps.portalManager) return;
-      if (!payload?.tabId || typeof payload.tabId !== "string") {
-        throw new Error("Invalid tabId");
-      }
-      if (!payload?.url || typeof payload.url !== "string") {
-        throw new Error("Invalid url");
-      }
-      deps.portalManager.createTab(payload.tabId, payload.url);
-    } catch (error) {
-      console.error("[PortalHandler] Error in create:", error);
-      throw error;
-    }
-  };
-  handlers.push(typedHandle(CHANNELS.PORTAL_CREATE, handlePortalCreate));
+  const namespace = defineIpcNamespace({
+    name: "portal",
+    ops: {
+      create: op(PORTAL_METHOD_CHANNELS.create, async (payload: PortalCreatePayload) => {
+        try {
+          if (!deps.portalManager) return;
+          if (!payload?.tabId || typeof payload.tabId !== "string") {
+            throw new Error("Invalid tabId");
+          }
+          if (!payload?.url || typeof payload.url !== "string") {
+            throw new Error("Invalid url");
+          }
+          deps.portalManager.createTab(payload.tabId, payload.url);
+        } catch (error) {
+          console.error("[PortalHandler] Error in create:", error);
+          throw error;
+        }
+      }),
+      show: op(PORTAL_METHOD_CHANNELS.show, async (payload: PortalShowPayload) => {
+        try {
+          if (!deps.portalManager) return;
+          if (!payload?.tabId || typeof payload.tabId !== "string") {
+            throw new Error("Invalid tabId");
+          }
+          if (!isValidBounds(payload?.bounds)) {
+            throw new Error("Invalid bounds");
+          }
+          deps.portalManager.showTab(payload.tabId, payload.bounds);
+        } catch (error) {
+          console.error("[PortalHandler] Error in show:", error);
+          throw error;
+        }
+      }),
+      hide: op(PORTAL_METHOD_CHANNELS.hide, async () => {
+        if (!deps.portalManager) return;
+        deps.portalManager.hideAll();
+      }),
+      resize: op(PORTAL_METHOD_CHANNELS.resize, async (bounds: PortalBounds) => {
+        try {
+          if (!deps.portalManager) return;
+          if (!isValidBounds(bounds)) {
+            throw new Error("Invalid bounds");
+          }
+          deps.portalManager.updateBounds(bounds);
+        } catch (error) {
+          console.error("[PortalHandler] Error in resize:", error);
+          throw error;
+        }
+      }),
+      closeTab: op(PORTAL_METHOD_CHANNELS.closeTab, async (payload: PortalCloseTabPayload) => {
+        if (!deps.portalManager) return;
+        if (!payload || typeof payload !== "object" || typeof payload.tabId !== "string") {
+          return;
+        }
+        await deps.portalManager.closeTab(payload.tabId);
+      }),
+      navigate: op(PORTAL_METHOD_CHANNELS.navigate, async (payload: PortalNavigatePayload) => {
+        if (!deps.portalManager) return;
+        if (
+          !payload ||
+          typeof payload !== "object" ||
+          typeof payload.tabId !== "string" ||
+          typeof payload.url !== "string"
+        ) {
+          return;
+        }
+        deps.portalManager.navigate(payload.tabId, payload.url);
+      }),
+      goBack: op(PORTAL_METHOD_CHANNELS.goBack, async (tabId: string): Promise<boolean> => {
+        if (!deps.portalManager) return false;
+        if (typeof tabId !== "string") return false;
+        return deps.portalManager.goBack(tabId);
+      }),
+      goForward: op(PORTAL_METHOD_CHANNELS.goForward, async (tabId: string): Promise<boolean> => {
+        if (!deps.portalManager) return false;
+        if (typeof tabId !== "string") return false;
+        return deps.portalManager.goForward(tabId);
+      }),
+      reload: op(PORTAL_METHOD_CHANNELS.reload, async (tabId: string) => {
+        if (!deps.portalManager) return;
+        if (typeof tabId !== "string") return;
+        deps.portalManager.reload(tabId);
+      }),
+      showNewTabMenu: op(
+        PORTAL_METHOD_CHANNELS.showNewTabMenu,
+        async (ctx, payload: PortalShowNewTabMenuPayload): Promise<void> => {
+          if (!payload || typeof payload !== "object") return;
+          if (!Array.isArray(payload.links)) return;
 
-  const handlePortalShow = async (payload: PortalShowPayload) => {
-    try {
-      if (!deps.portalManager) return;
-      if (!payload?.tabId || typeof payload.tabId !== "string") {
-        throw new Error("Invalid tabId");
-      }
-      if (!isValidBounds(payload?.bounds)) {
-        throw new Error("Invalid bounds");
-      }
-      deps.portalManager.showTab(payload.tabId, payload.bounds);
-    } catch (error) {
-      console.error("[PortalHandler] Error in show:", error);
-      throw error;
-    }
-  };
-  handlers.push(typedHandle(CHANNELS.PORTAL_SHOW, handlePortalShow));
+          const x = Number.isFinite(payload.x) ? Math.round(payload.x) : 0;
+          const y = Number.isFinite(payload.y) ? Math.round(payload.y) : 0;
+          const defaultNewTabUrl =
+            payload.defaultNewTabUrl === null ||
+            (typeof payload.defaultNewTabUrl === "string" && payload.defaultNewTabUrl.trim())
+              ? payload.defaultNewTabUrl
+              : null;
 
-  const handlePortalHide = async () => {
-    if (!deps.portalManager) return;
-    deps.portalManager.hideAll();
-  };
-  handlers.push(typedHandle(CHANNELS.PORTAL_HIDE, handlePortalHide));
+          const links = payload.links
+            .filter(
+              (l): l is { title: string; url: string } =>
+                !!l &&
+                typeof l === "object" &&
+                typeof (l as { title?: unknown }).title === "string" &&
+                typeof (l as { url?: unknown }).url === "string" &&
+                (l as { title: string }).title.trim() !== "" &&
+                (l as { url: string }).url.trim() !== ""
+            )
+            .map((l) => ({ title: l.title.trim(), url: l.url.trim() }));
 
-  const handlePortalResize = async (bounds: PortalBounds) => {
-    try {
-      if (!deps.portalManager) return;
-      if (!isValidBounds(bounds)) {
-        throw new Error("Invalid bounds");
-      }
-      deps.portalManager.updateBounds(bounds);
-    } catch (error) {
-      console.error("[PortalHandler] Error in resize:", error);
-      throw error;
-    }
-  };
-  handlers.push(typedHandle(CHANNELS.PORTAL_RESIZE, handlePortalResize));
+          const win = ctx.senderWindow;
+          if (!win || win.isDestroyed()) return;
 
-  const handlePortalCloseTab = async (payload: PortalCloseTabPayload) => {
-    if (!deps.portalManager) return;
-    if (!payload || typeof payload !== "object" || typeof payload.tabId !== "string") {
-      return;
-    }
-    await deps.portalManager.closeTab(payload.tabId);
-  };
-  handlers.push(typedHandle(CHANNELS.PORTAL_CLOSE_TAB, handlePortalCloseTab));
+          const sendAction = (action: PortalNewTabMenuAction) => {
+            if (ctx.event.sender.isDestroyed()) return;
+            ctx.event.sender.send(CHANNELS.PORTAL_NEW_TAB_MENU_ACTION, action);
+          };
 
-  const handlePortalNavigate = async (payload: PortalNavigatePayload) => {
-    if (!deps.portalManager) return;
-    if (
-      !payload ||
-      typeof payload !== "object" ||
-      typeof payload.tabId !== "string" ||
-      typeof payload.url !== "string"
-    ) {
-      return;
-    }
-    deps.portalManager.navigate(payload.tabId, payload.url);
-  };
-  handlers.push(typedHandle(CHANNELS.PORTAL_NAVIGATE, handlePortalNavigate));
+          const menu = Menu.buildFromTemplate([
+            ...links.map((link) => ({
+              label: link.title,
+              click: () => sendAction({ type: "open-url", url: link.url, title: link.title }),
+            })),
+            ...(links.length > 0 ? [{ type: "separator" as const }] : []),
+            {
+              label: "Launchpad (Pick provider...)",
+              click: () => sendAction({ type: "open-launchpad" }),
+            },
+            { type: "separator" as const },
+            {
+              label: "Default New Tab",
+              submenu: [
+                {
+                  label: "Launchpad",
+                  type: "radio" as const,
+                  checked: defaultNewTabUrl === null,
+                  click: () => sendAction({ type: "set-default-new-tab-url", url: null }),
+                },
+                ...(links.length > 0 ? [{ type: "separator" as const }] : []),
+                ...links.map((link) => ({
+                  label: link.title,
+                  type: "radio" as const,
+                  checked: defaultNewTabUrl === link.url,
+                  click: () => sendAction({ type: "set-default-new-tab-url", url: link.url }),
+                })),
+                ...(links.length > 0 ? [{ type: "separator" as const }] : []),
+                {
+                  label: "Manage Portal Settings...",
+                  click: () => sendMenuAction(win, "open-settings:portal"),
+                },
+              ],
+            },
+            {
+              label: "Manage Portal Settings...",
+              click: () => sendMenuAction(win, "open-settings:portal"),
+            },
+          ]);
 
-  const handlePortalGoBack = async (tabId: string): Promise<boolean> => {
-    if (!deps.portalManager) return false;
-    if (typeof tabId !== "string") return false;
-    return deps.portalManager.goBack(tabId);
-  };
-  handlers.push(typedHandle(CHANNELS.PORTAL_GO_BACK, handlePortalGoBack));
+          menu.popup({ window: win, x, y });
+        },
+        { withContext: true }
+      ),
+    },
+  });
 
-  const handlePortalGoForward = async (tabId: string): Promise<boolean> => {
-    if (!deps.portalManager) return false;
-    if (typeof tabId !== "string") return false;
-    return deps.portalManager.goForward(tabId);
-  };
-  handlers.push(typedHandle(CHANNELS.PORTAL_GO_FORWARD, handlePortalGoForward));
-
-  const handlePortalReload = async (tabId: string) => {
-    if (!deps.portalManager) return;
-    if (typeof tabId !== "string") return;
-    deps.portalManager.reload(tabId);
-  };
-  handlers.push(typedHandle(CHANNELS.PORTAL_RELOAD, handlePortalReload));
-
-  handlers.push(
-    typedHandleWithContext(
-      CHANNELS.PORTAL_SHOW_NEW_TAB_MENU,
-      async (ctx, payload: PortalShowNewTabMenuPayload): Promise<void> => {
-        if (!payload || typeof payload !== "object") return;
-        if (!Array.isArray(payload.links)) return;
-
-        const x = Number.isFinite(payload.x) ? Math.round(payload.x) : 0;
-        const y = Number.isFinite(payload.y) ? Math.round(payload.y) : 0;
-        const defaultNewTabUrl =
-          payload.defaultNewTabUrl === null ||
-          (typeof payload.defaultNewTabUrl === "string" && payload.defaultNewTabUrl.trim())
-            ? payload.defaultNewTabUrl
-            : null;
-
-        const links = payload.links
-          .filter(
-            (l): l is { title: string; url: string } =>
-              !!l &&
-              typeof l === "object" &&
-              typeof (l as { title?: unknown }).title === "string" &&
-              typeof (l as { url?: unknown }).url === "string" &&
-              (l as { title: string }).title.trim() !== "" &&
-              (l as { url: string }).url.trim() !== ""
-          )
-          .map((l) => ({ title: l.title.trim(), url: l.url.trim() }));
-
-        const win = ctx.senderWindow;
-        if (!win || win.isDestroyed()) return;
-
-        const sendAction = (action: PortalNewTabMenuAction) => {
-          if (ctx.event.sender.isDestroyed()) return;
-          ctx.event.sender.send(CHANNELS.PORTAL_NEW_TAB_MENU_ACTION, action);
-        };
-
-        const menu = Menu.buildFromTemplate([
-          ...links.map((link) => ({
-            label: link.title,
-            click: () => sendAction({ type: "open-url", url: link.url, title: link.title }),
-          })),
-          ...(links.length > 0 ? [{ type: "separator" as const }] : []),
-          {
-            label: "Launchpad (Pick provider...)",
-            click: () => sendAction({ type: "open-launchpad" }),
-          },
-          { type: "separator" as const },
-          {
-            label: "Default New Tab",
-            submenu: [
-              {
-                label: "Launchpad",
-                type: "radio" as const,
-                checked: defaultNewTabUrl === null,
-                click: () => sendAction({ type: "set-default-new-tab-url", url: null }),
-              },
-              ...(links.length > 0 ? [{ type: "separator" as const }] : []),
-              ...links.map((link) => ({
-                label: link.title,
-                type: "radio" as const,
-                checked: defaultNewTabUrl === link.url,
-                click: () => sendAction({ type: "set-default-new-tab-url", url: link.url }),
-              })),
-              ...(links.length > 0 ? [{ type: "separator" as const }] : []),
-              {
-                label: "Manage Portal Settings...",
-                click: () => sendMenuAction(win, "open-settings:portal"),
-              },
-            ],
-          },
-          {
-            label: "Manage Portal Settings...",
-            click: () => sendMenuAction(win, "open-settings:portal"),
-          },
-        ]);
-
-        menu.popup({ window: win, x, y });
-      }
-    )
-  );
-
-  return () => handlers.forEach((cleanup) => cleanup());
+  return namespace.register();
 }

--- a/electron/ipc/handlers/scratch/index.ts
+++ b/electron/ipc/handlers/scratch/index.ts
@@ -12,7 +12,9 @@ import { dialog, type WebContentsView } from "electron";
 import fs from "fs/promises";
 import path from "path";
 import { CHANNELS } from "../../channels.js";
-import { broadcastToRenderer, typedHandle, typedHandleWithContext } from "../../utils.js";
+import { broadcastToRenderer } from "../../utils.js";
+import { defineIpcNamespace, op } from "../../define.js";
+import { SCRATCH_METHOD_CHANNELS } from "./preload.js";
 import { getWindowForWebContents } from "../../../window/webContentsRegistry.js";
 import { distributePortsToView } from "../../../window/portDistribution.js";
 import { scratchStore } from "../../../services/ScratchStore.js";
@@ -25,215 +27,224 @@ import type { Scratch } from "../../../../shared/types/scratch.js";
 import type { ScratchSaveAsProjectResult } from "../../../../shared/types/ipc/scratch.js";
 
 export function registerScratchHandlers(deps: HandlerDependencies): () => void {
-  const handlers: Array<() => void> = [];
-
-  const handleGetAll = async (): Promise<Scratch[]> => scratchStore.getAllScratches();
-  handlers.push(typedHandle(CHANNELS.SCRATCH_GET_ALL, handleGetAll));
-
-  const handleGetCurrent = async (): Promise<Scratch | null> => scratchStore.getCurrentScratch();
-  handlers.push(typedHandle(CHANNELS.SCRATCH_GET_CURRENT, handleGetCurrent));
-
-  const handleCreate = async (name?: string): Promise<Scratch> => {
-    const scratch = await scratchStore.createScratch(name);
-    broadcastToRenderer(CHANNELS.SCRATCH_UPDATED, scratch);
-    return scratch;
-  };
-  handlers.push(typedHandle(CHANNELS.SCRATCH_CREATE, handleCreate));
-
-  const handleUpdate = async (
-    scratchId: string,
-    updates: { name?: string; lastOpened?: number }
-  ): Promise<Scratch> => {
-    if (typeof scratchId !== "string" || !scratchId) {
-      throw new Error("Invalid scratch ID");
-    }
-    if (typeof updates !== "object" || updates === null) {
-      throw new Error("Invalid updates object");
-    }
-    const updated = scratchStore.updateScratch(scratchId, updates);
-    broadcastToRenderer(CHANNELS.SCRATCH_UPDATED, updated);
-    return updated;
-  };
-  handlers.push(typedHandle(CHANNELS.SCRATCH_UPDATE, handleUpdate));
-
-  const handleRemove = async (scratchId: string): Promise<void> => {
-    if (typeof scratchId !== "string" || !scratchId) {
-      throw new Error("Invalid scratch ID");
-    }
-
-    if (deps.ptyClient) {
-      await deps.ptyClient.killByProject(scratchId).catch((err: unknown) => {
-        console.error(`[IPC] scratch:remove: Failed to kill terminals for ${scratchId}:`, err);
-      });
-    }
-
-    await scratchStore.removeScratch(scratchId);
-    broadcastToRenderer(CHANNELS.SCRATCH_REMOVED, scratchId);
-  };
-  handlers.push(typedHandle(CHANNELS.SCRATCH_REMOVE, handleRemove));
-
-  const handleSwitch = async (
-    ctx: import("../../types.js").IpcContext,
-    scratchId: string
-  ): Promise<Scratch> => {
-    if (typeof scratchId !== "string" || !scratchId) {
-      throw new Error("Invalid scratch ID");
-    }
-
-    const scratch = scratchStore.getScratchById(scratchId);
-    if (!scratch) {
-      throw new Error(`Scratch not found: ${scratchId}`);
-    }
-
-    // Resolve the per-window ProjectViewManager (the same view manager handles
-    // scratches; PVM is keyed on opaque string IDs and has no entity-type
-    // assumptions, so a UUID scratch ID coexists with SHA256 project IDs).
-    const senderWindow = getWindowForWebContents(ctx.event.sender);
-    const pvmCtx = senderWindow ? deps.windowRegistry?.getByWindowId(senderWindow.id) : undefined;
-    const pvm = pvmCtx?.services?.projectViewManager ?? deps.projectViewManager;
-
-    // Run the PVM switch first; if it throws, the canonical pointers stay
-    // pointed at the previous state so an app restart hydrates a coherent
-    // workspace. Mirrors the project:switch flow where `setCurrentProject` is
-    // only called after `pvm.switchTo()` resolves.
-    let activeView: WebContentsView | null = null;
-    if (pvm) {
-      const result = await pvm.switchTo(scratchId, scratch.path);
-      activeView = result.view;
-    }
-
-    // Now commit canonical pointers — scratch active, project cleared.
-    // Mutually exclusive with project: clear the project pointer so the
-    // renderer's `getCurrentProject` does not race-restore the previous project.
-    const updated = scratchStore.setCurrentScratch(scratchId);
-    projectStore.clearCurrentProject();
-
-    // Tell the PTY host the active workspace changed. PtyClient treats the ID
-    // as an opaque string and the path as a working directory, so passing a
-    // scratch UUID + scratch dir is supported by the existing protocol.
-    const windowId = senderWindow?.id ?? deps.mainWindow?.id;
-    if (windowId !== undefined && deps.ptyClient) {
-      deps.ptyClient.onProjectSwitch(windowId, scratchId, scratch.path);
-    }
-
-    // Distribute a fresh PTY MessagePort to the active view. Without this,
-    // terminals spawned in the scratch can't reach the PTY host.
-    if (windowId !== undefined && senderWindow && deps.windowRegistry) {
-      const wctx = deps.windowRegistry.getByWindowId(senderWindow.id);
-      if (wctx) {
-        const targetWc = activeView?.webContents ?? ctx.event.sender;
-        if (!targetWc.isDestroyed()) {
-          distributePortsToView(senderWindow, wctx, targetWc, deps.ptyClient ?? null);
+  const namespace = defineIpcNamespace({
+    name: "scratch",
+    ops: {
+      getAll: op(
+        SCRATCH_METHOD_CHANNELS.getAll,
+        async (): Promise<Scratch[]> => scratchStore.getAllScratches()
+      ),
+      getCurrent: op(
+        SCRATCH_METHOD_CHANNELS.getCurrent,
+        async (): Promise<Scratch | null> => scratchStore.getCurrentScratch()
+      ),
+      create: op(SCRATCH_METHOD_CHANNELS.create, async (name?: string): Promise<Scratch> => {
+        const scratch = await scratchStore.createScratch(name);
+        broadcastToRenderer(CHANNELS.SCRATCH_UPDATED, scratch);
+        return scratch;
+      }),
+      update: op(
+        SCRATCH_METHOD_CHANNELS.update,
+        async (
+          scratchId: string,
+          updates: { name?: string; lastOpened?: number }
+        ): Promise<Scratch> => {
+          if (typeof scratchId !== "string" || !scratchId) {
+            throw new Error("Invalid scratch ID");
+          }
+          if (typeof updates !== "object" || updates === null) {
+            throw new Error("Invalid updates object");
+          }
+          const updated = scratchStore.updateScratch(scratchId, updates);
+          broadcastToRenderer(CHANNELS.SCRATCH_UPDATED, updated);
+          return updated;
         }
-      }
-    }
+      ),
+      remove: op(SCRATCH_METHOD_CHANNELS.remove, async (scratchId: string): Promise<void> => {
+        if (typeof scratchId !== "string" || !scratchId) {
+          throw new Error("Invalid scratch ID");
+        }
 
-    const switchId = randomUUID();
-    broadcastToRenderer(CHANNELS.SCRATCH_ON_SWITCH, { scratch: updated, switchId });
+        if (deps.ptyClient) {
+          await deps.ptyClient.killByProject(scratchId).catch((err: unknown) => {
+            console.error(`[IPC] scratch:remove: Failed to kill terminals for ${scratchId}:`, err);
+          });
+        }
 
-    return updated;
-  };
-  handlers.push(typedHandleWithContext(CHANNELS.SCRATCH_SWITCH, handleSwitch));
+        await scratchStore.removeScratch(scratchId);
+        broadcastToRenderer(CHANNELS.SCRATCH_REMOVED, scratchId);
+      }),
+      switch: op(
+        SCRATCH_METHOD_CHANNELS.switch,
+        async (ctx, scratchId: string): Promise<Scratch> => {
+          if (typeof scratchId !== "string" || !scratchId) {
+            throw new Error("Invalid scratch ID");
+          }
 
-  /**
-   * Save-as-Project — opens a directory picker, copies the scratch folder to
-   * the chosen destination, and registers the destination as a regular
-   * project. Copy (not move) so a failed registration leaves the scratch
-   * intact; the original scratch is NOT deleted by this handler. The renderer
-   * prompts the user separately and calls `scratch:remove` if they confirm.
-   */
-  const handleSaveAsProject = async (
-    ctx: import("../../types.js").IpcContext,
-    scratchId: string
-  ): Promise<ScratchSaveAsProjectResult> => {
-    if (typeof scratchId !== "string" || !scratchId) {
-      throw new Error("Invalid scratch ID");
-    }
+          const scratch = scratchStore.getScratchById(scratchId);
+          if (!scratch) {
+            throw new Error(`Scratch not found: ${scratchId}`);
+          }
 
-    const scratch = scratchStore.getScratchById(scratchId);
-    if (!scratch) {
-      throw new Error(`Scratch not found: ${scratchId}`);
-    }
+          // Resolve the per-window ProjectViewManager (the same view manager handles
+          // scratches; PVM is keyed on opaque string IDs and has no entity-type
+          // assumptions, so a UUID scratch ID coexists with SHA256 project IDs).
+          const senderWindow = getWindowForWebContents(ctx.event.sender);
+          const pvmCtx = senderWindow
+            ? deps.windowRegistry?.getByWindowId(senderWindow.id)
+            : undefined;
+          const pvm = pvmCtx?.services?.projectViewManager ?? deps.projectViewManager;
 
-    const senderWindow = getWindowForWebContents(ctx.event.sender);
-    const dialogOpts: Electron.OpenDialogOptions = {
-      title: "Save scratch as project",
-      buttonLabel: "Save here",
-      properties: ["openDirectory", "createDirectory"],
-    };
-    const result = senderWindow
-      ? await dialog.showOpenDialog(senderWindow, dialogOpts)
-      : await dialog.showOpenDialog(dialogOpts);
+          // Run the PVM switch first; if it throws, the canonical pointers stay
+          // pointed at the previous state so an app restart hydrates a coherent
+          // workspace. Mirrors the project:switch flow where `setCurrentProject` is
+          // only called after `pvm.switchTo()` resolves.
+          let activeView: WebContentsView | null = null;
+          if (pvm) {
+            const result = await pvm.switchTo(scratchId, scratch.path);
+            activeView = result.view;
+          }
 
-    if (result.canceled || result.filePaths.length === 0) {
-      return { status: "cancelled" };
-    }
+          // Now commit canonical pointers — scratch active, project cleared.
+          // Mutually exclusive with project: clear the project pointer so the
+          // renderer's `getCurrentProject` does not race-restore the previous project.
+          const updated = scratchStore.setCurrentScratch(scratchId);
+          projectStore.clearCurrentProject();
 
-    const destinationPath = result.filePaths[0]!;
-    if (!path.isAbsolute(destinationPath)) {
-      throw new Error("Destination path must be absolute");
-    }
+          // Tell the PTY host the active workspace changed. PtyClient treats the ID
+          // as an opaque string and the path as a working directory, so passing a
+          // scratch UUID + scratch dir is supported by the existing protocol.
+          const windowId = senderWindow?.id ?? deps.mainWindow?.id;
+          if (windowId !== undefined && deps.ptyClient) {
+            deps.ptyClient.onProjectSwitch(windowId, scratchId, scratch.path);
+          }
 
-    // Refuse if the user picked the scratch directory itself or a path inside
-    // the scratch — `fs.cp` would recurse into the destination it's writing.
-    // Use realpath so a symlink at the destination that resolves into the
-    // scratch dir cannot bypass the guard. `realpath` throws ENOENT for paths
-    // that don't yet exist (the dialog's `createDirectory` option produces
-    // these); fall back to lexical resolve in that case.
-    const normalizedScratch = await fs.realpath(scratch.path).catch(() => scratch.path);
-    const normalizedDest = await fs.realpath(destinationPath).catch(() => destinationPath);
-    const resolvedScratch = path.resolve(normalizedScratch);
-    const resolvedDest = path.resolve(normalizedDest);
-    if (resolvedDest === resolvedScratch || resolvedDest.startsWith(resolvedScratch + path.sep)) {
-      throw new Error("Destination cannot be inside the scratch folder");
-    }
+          // Distribute a fresh PTY MessagePort to the active view. Without this,
+          // terminals spawned in the scratch can't reach the PTY host.
+          if (windowId !== undefined && senderWindow && deps.windowRegistry) {
+            const wctx = deps.windowRegistry.getByWindowId(senderWindow.id);
+            if (wctx) {
+              const targetWc = activeView?.webContents ?? ctx.event.sender;
+              if (!targetWc.isDestroyed()) {
+                distributePortsToView(senderWindow, wctx, targetWc, deps.ptyClient ?? null);
+              }
+            }
+          }
 
-    // Reject pre-existing non-empty destinations so we never silently merge
-    // the scratch contents into another project. The dialog's `createDirectory`
-    // option lets users make a fresh folder right from the picker.
-    try {
-      const entries = await fs.readdir(destinationPath);
-      if (entries.length > 0) {
-        throw new Error("Destination folder is not empty. Choose an empty folder.");
-      }
-    } catch (error) {
-      const code = (error as NodeJS.ErrnoException).code;
-      if (code !== "ENOENT") throw error;
-      // ENOENT means the dir doesn't exist; fs.cp will create it.
-    }
+          const switchId = randomUUID();
+          broadcastToRenderer(CHANNELS.SCRATCH_ON_SWITCH, { scratch: updated, switchId });
 
-    try {
-      // No fsync — destination may be incomplete on crash. Scratch source is preserved as recovery path.
-      await fs.cp(scratch.path, destinationPath, {
-        recursive: true,
-        preserveTimestamps: true,
-        errorOnExist: false,
-      });
-    } catch (error) {
-      logError(
-        `[IPC] scratch:save-as-project: copy failed for ${scratchId} -> ${destinationPath}`,
-        error
-      );
-      throw error;
-    }
+          return updated;
+        },
+        { withContext: true }
+      ),
+      /**
+       * Save-as-Project — opens a directory picker, copies the scratch folder to
+       * the chosen destination, and registers the destination as a regular
+       * project. Copy (not move) so a failed registration leaves the scratch
+       * intact; the original scratch is NOT deleted by this handler. The renderer
+       * prompts the user separately and calls `scratch:remove` if they confirm.
+       */
+      saveAsProject: op(
+        SCRATCH_METHOD_CHANNELS.saveAsProject,
+        async (ctx, scratchId: string): Promise<ScratchSaveAsProjectResult> => {
+          if (typeof scratchId !== "string" || !scratchId) {
+            throw new Error("Invalid scratch ID");
+          }
 
-    // Scratch folders are not git repositories, but `projectStore.addProject`
-    // requires a git root. Initialize a fresh repo at the destination so the
-    // saved folder behaves like any other project (worktrees, status, etc.).
-    // If the user already chose a git-tracked destination, `git init` is a
-    // no-op — it reports the existing repo and exits 0.
-    try {
-      const git = createHardenedGit(destinationPath);
-      await git.init();
-    } catch (error) {
-      logError(`[IPC] scratch:save-as-project: git init failed for ${destinationPath}`, error);
-      throw error;
-    }
+          const scratch = scratchStore.getScratchById(scratchId);
+          if (!scratch) {
+            throw new Error(`Scratch not found: ${scratchId}`);
+          }
 
-    const project = await addProjectByPath(destinationPath);
-    return { status: "saved", project, destinationPath };
-  };
-  handlers.push(typedHandleWithContext(CHANNELS.SCRATCH_SAVE_AS_PROJECT, handleSaveAsProject));
+          const senderWindow = getWindowForWebContents(ctx.event.sender);
+          const dialogOpts: Electron.OpenDialogOptions = {
+            title: "Save scratch as project",
+            buttonLabel: "Save here",
+            properties: ["openDirectory", "createDirectory"],
+          };
+          const result = senderWindow
+            ? await dialog.showOpenDialog(senderWindow, dialogOpts)
+            : await dialog.showOpenDialog(dialogOpts);
 
-  return () => handlers.forEach((cleanup) => cleanup());
+          if (result.canceled || result.filePaths.length === 0) {
+            return { status: "cancelled" };
+          }
+
+          const destinationPath = result.filePaths[0]!;
+          if (!path.isAbsolute(destinationPath)) {
+            throw new Error("Destination path must be absolute");
+          }
+
+          // Refuse if the user picked the scratch directory itself or a path inside
+          // the scratch — `fs.cp` would recurse into the destination it's writing.
+          // Use realpath so a symlink at the destination that resolves into the
+          // scratch dir cannot bypass the guard. `realpath` throws ENOENT for paths
+          // that don't yet exist (the dialog's `createDirectory` option produces
+          // these); fall back to lexical resolve in that case.
+          const normalizedScratch = await fs.realpath(scratch.path).catch(() => scratch.path);
+          const normalizedDest = await fs.realpath(destinationPath).catch(() => destinationPath);
+          const resolvedScratch = path.resolve(normalizedScratch);
+          const resolvedDest = path.resolve(normalizedDest);
+          if (
+            resolvedDest === resolvedScratch ||
+            resolvedDest.startsWith(resolvedScratch + path.sep)
+          ) {
+            throw new Error("Destination cannot be inside the scratch folder");
+          }
+
+          // Reject pre-existing non-empty destinations so we never silently merge
+          // the scratch contents into another project. The dialog's `createDirectory`
+          // option lets users make a fresh folder right from the picker.
+          try {
+            const entries = await fs.readdir(destinationPath);
+            if (entries.length > 0) {
+              throw new Error("Destination folder is not empty. Choose an empty folder.");
+            }
+          } catch (error) {
+            const code = (error as NodeJS.ErrnoException).code;
+            if (code !== "ENOENT") throw error;
+            // ENOENT means the dir doesn't exist; fs.cp will create it.
+          }
+
+          try {
+            // No fsync — destination may be incomplete on crash. Scratch source is preserved as recovery path.
+            await fs.cp(scratch.path, destinationPath, {
+              recursive: true,
+              preserveTimestamps: true,
+              errorOnExist: false,
+            });
+          } catch (error) {
+            logError(
+              `[IPC] scratch:save-as-project: copy failed for ${scratchId} -> ${destinationPath}`,
+              error
+            );
+            throw error;
+          }
+
+          // Scratch folders are not git repositories, but `projectStore.addProject`
+          // requires a git root. Initialize a fresh repo at the destination so the
+          // saved folder behaves like any other project (worktrees, status, etc.).
+          // If the user already chose a git-tracked destination, `git init` is a
+          // no-op — it reports the existing repo and exits 0.
+          try {
+            const git = createHardenedGit(destinationPath);
+            await git.init();
+          } catch (error) {
+            logError(
+              `[IPC] scratch:save-as-project: git init failed for ${destinationPath}`,
+              error
+            );
+            throw error;
+          }
+
+          const project = await addProjectByPath(destinationPath);
+          return { status: "saved", project, destinationPath };
+        },
+        { withContext: true }
+      ),
+    },
+  });
+
+  return namespace.register();
 }

--- a/electron/ipc/handlers/scratch/preload.ts
+++ b/electron/ipc/handlers/scratch/preload.ts
@@ -1,0 +1,30 @@
+import type { IpcInvokeMap } from "../../../types/index.js";
+
+export const SCRATCH_METHOD_CHANNELS = {
+  getAll: "scratch:get-all",
+  getCurrent: "scratch:get-current",
+  create: "scratch:create",
+  update: "scratch:update",
+  remove: "scratch:remove",
+  switch: "scratch:switch",
+  saveAsProject: "scratch:save-as-project",
+} as const satisfies Record<string, keyof IpcInvokeMap>;
+
+type Methods = typeof SCRATCH_METHOD_CHANNELS;
+
+export type ScratchPreloadBindings = {
+  [M in keyof Methods]: (
+    ...args: IpcInvokeMap[Methods[M]]["args"]
+  ) => Promise<IpcInvokeMap[Methods[M]]["result"]>;
+};
+
+type Invoker = (channel: string, ...args: unknown[]) => Promise<unknown>;
+
+export function buildScratchPreloadBindings(invoke: Invoker): ScratchPreloadBindings {
+  const out: Record<string, (...args: unknown[]) => Promise<unknown>> = {};
+  for (const method of Object.keys(SCRATCH_METHOD_CHANNELS) as Array<keyof Methods>) {
+    const channel = SCRATCH_METHOD_CHANNELS[method];
+    out[method as string] = (...args) => invoke(channel, ...args);
+  }
+  return out as unknown as ScratchPreloadBindings;
+}

--- a/electron/preload.cts
+++ b/electron/preload.cts
@@ -22,6 +22,12 @@ import { buildSlashCommandsPreloadBindings } from "./ipc/handlers/slashCommands.
 import { buildGlobalEnvPreloadBindings } from "./ipc/handlers/globalEnv.preload.js";
 import { buildAccessibilityPreloadBindings } from "./ipc/handlers/accessibility.preload.js";
 import { buildHelpPreloadBindings } from "./ipc/handlers/help.preload.js";
+import { buildEventInspectorPreloadBindings } from "./ipc/handlers/eventInspector.preload.js";
+import { buildCommandsPreloadBindings } from "./ipc/handlers/commands.preload.js";
+import { buildPortalPreloadBindings } from "./ipc/handlers/portal.preload.js";
+import { buildDevPreviewPreloadBindings } from "./ipc/handlers/devPreview.preload.js";
+import { buildPluginPreloadBindings } from "./ipc/handlers/plugin.preload.js";
+import { buildScratchPreloadBindings } from "./ipc/handlers/scratch/preload.js";
 
 import type {
   WorktreeState,
@@ -34,7 +40,6 @@ import type {
   LogEntry,
   LogFilterOptions,
   EventRecord,
-  EventFilterOptions,
   RetryAction,
   RetryProgressPayload,
   ErrorRecord,
@@ -77,12 +82,7 @@ import type {
   ArtifactDetectedPayload,
   SaveArtifactOptions,
   ApplyPatchOptions,
-  DevPreviewEnsureRequest,
-  DevPreviewSessionRequest,
-  DevPreviewStopByPanelRequest,
-  DevPreviewSessionState,
   DevPreviewStateChangedPayload,
-  DevPreviewGetByWorktreeRequest,
 } from "../shared/types/ipc.js";
 import type { TerminalActivityPayload } from "../shared/types/terminal.js";
 import type {
@@ -94,10 +94,7 @@ import type {
 } from "../shared/types/pty-host.js";
 
 type SpawnResultPayload = SpawnResult;
-import type {
-  PortalNewTabMenuAction,
-  PortalShowNewTabMenuPayload,
-} from "../shared/types/portal.js";
+import type { PortalNewTabMenuAction } from "../shared/types/portal.js";
 import type { ShowContextMenuPayload } from "../shared/types/menu.js";
 import type { ResourceProfilePayload } from "../shared/types/resourceProfile.js";
 import type { PluginActionDescriptor } from "../shared/types/plugin.js";
@@ -1188,12 +1185,7 @@ const api: ElectronAPI = {
 
   // Event Inspector API
   eventInspector: {
-    getEvents: () => _unwrappingInvoke(CHANNELS.EVENT_INSPECTOR_GET_EVENTS),
-
-    getFiltered: (filters: EventFilterOptions) =>
-      _unwrappingInvoke(CHANNELS.EVENT_INSPECTOR_GET_FILTERED, filters),
-
-    clear: () => _unwrappingInvoke(CHANNELS.EVENT_INSPECTOR_CLEAR),
+    ...buildEventInspectorPreloadBindings(_unwrappingInvoke),
 
     subscribe: () => ipcRenderer.send(CHANNELS.EVENT_INSPECTOR_SUBSCRIBE),
 
@@ -1438,31 +1430,7 @@ const api: ElectronAPI = {
 
   // Scratch (one-off agent workspace) API
   scratch: {
-    getAll: (): Promise<import("../shared/types/scratch.js").Scratch[]> =>
-      _unwrappingInvoke(CHANNELS.SCRATCH_GET_ALL),
-
-    getCurrent: (): Promise<import("../shared/types/scratch.js").Scratch | null> =>
-      _unwrappingInvoke(CHANNELS.SCRATCH_GET_CURRENT),
-
-    create: (name?: string): Promise<import("../shared/types/scratch.js").Scratch> =>
-      _unwrappingInvoke(CHANNELS.SCRATCH_CREATE, name),
-
-    update: (
-      scratchId: string,
-      updates: { name?: string; lastOpened?: number }
-    ): Promise<import("../shared/types/scratch.js").Scratch> =>
-      _unwrappingInvoke(CHANNELS.SCRATCH_UPDATE, scratchId, updates),
-
-    remove: (scratchId: string): Promise<void> =>
-      _unwrappingInvoke(CHANNELS.SCRATCH_REMOVE, scratchId),
-
-    switch: (scratchId: string): Promise<import("../shared/types/scratch.js").Scratch> =>
-      _unwrappingInvoke(CHANNELS.SCRATCH_SWITCH, scratchId),
-
-    saveAsProject: (
-      scratchId: string
-    ): Promise<import("../shared/types/ipc/scratch.js").ScratchSaveAsProjectResult> =>
-      _unwrappingInvoke(CHANNELS.SCRATCH_SAVE_AS_PROJECT, scratchId),
+    ...buildScratchPreloadBindings(_unwrappingInvoke),
 
     onUpdated: (callback: (scratch: import("../shared/types/scratch.js").Scratch) => void) =>
       _typedOn(CHANNELS.SCRATCH_UPDATED, callback),
@@ -1631,28 +1599,7 @@ const api: ElectronAPI = {
 
   // Dev Preview API
   devPreview: {
-    ensure: (request: DevPreviewEnsureRequest): Promise<DevPreviewSessionState> =>
-      _unwrappingInvoke(CHANNELS.DEV_PREVIEW_ENSURE, request) as Promise<DevPreviewSessionState>,
-
-    restart: (request: DevPreviewSessionRequest): Promise<DevPreviewSessionState> =>
-      _unwrappingInvoke(CHANNELS.DEV_PREVIEW_RESTART, request) as Promise<DevPreviewSessionState>,
-
-    stop: (request: DevPreviewSessionRequest): Promise<DevPreviewSessionState> =>
-      _unwrappingInvoke(CHANNELS.DEV_PREVIEW_STOP, request) as Promise<DevPreviewSessionState>,
-
-    stopByPanel: (request: DevPreviewStopByPanelRequest): Promise<void> =>
-      _unwrappingInvoke(CHANNELS.DEV_PREVIEW_STOP_BY_PANEL, request) as Promise<void>,
-
-    getState: (request: DevPreviewSessionRequest): Promise<DevPreviewSessionState> =>
-      _unwrappingInvoke(CHANNELS.DEV_PREVIEW_GET_STATE, request) as Promise<DevPreviewSessionState>,
-
-    getByWorktree: (
-      request: DevPreviewGetByWorktreeRequest
-    ): Promise<DevPreviewSessionState | null> =>
-      _unwrappingInvoke(
-        CHANNELS.DEV_PREVIEW_GET_BY_WORKTREE,
-        request
-      ) as Promise<DevPreviewSessionState | null>,
+    ...buildDevPreviewPreloadBindings(_unwrappingInvoke),
 
     onStateChanged: (callback: (payload: DevPreviewStateChangedPayload) => void) =>
       _typedOn(CHANNELS.DEV_PREVIEW_STATE_CHANGED, callback),
@@ -1795,32 +1742,7 @@ const api: ElectronAPI = {
 
   // Portal API
   portal: {
-    create: (payload: { tabId: string; url: string }) =>
-      _unwrappingInvoke(CHANNELS.PORTAL_CREATE, payload),
-
-    show: (payload: {
-      tabId: string;
-      bounds: { x: number; y: number; width: number; height: number };
-    }) => _unwrappingInvoke(CHANNELS.PORTAL_SHOW, payload),
-
-    hide: () => _unwrappingInvoke(CHANNELS.PORTAL_HIDE),
-
-    resize: (bounds: { x: number; y: number; width: number; height: number }) =>
-      _unwrappingInvoke(CHANNELS.PORTAL_RESIZE, bounds),
-
-    closeTab: (payload: { tabId: string }) => _unwrappingInvoke(CHANNELS.PORTAL_CLOSE_TAB, payload),
-
-    navigate: (payload: { tabId: string; url: string }) =>
-      _unwrappingInvoke(CHANNELS.PORTAL_NAVIGATE, payload),
-
-    goBack: (tabId: string) => _unwrappingInvoke(CHANNELS.PORTAL_GO_BACK, tabId),
-
-    goForward: (tabId: string) => _unwrappingInvoke(CHANNELS.PORTAL_GO_FORWARD, tabId),
-
-    reload: (tabId: string) => _unwrappingInvoke(CHANNELS.PORTAL_RELOAD, tabId),
-
-    showNewTabMenu: (payload: PortalShowNewTabMenuPayload) =>
-      _unwrappingInvoke(CHANNELS.PORTAL_SHOW_NEW_TAB_MENU, payload),
+    ...buildPortalPreloadBindings(_unwrappingInvoke),
 
     onNavEvent: (callback: (data: { tabId: string; title: string; url: string }) => void) =>
       _typedOn(CHANNELS.PORTAL_NAV_EVENT, callback),
@@ -2139,40 +2061,7 @@ const api: ElectronAPI = {
   },
 
   // Commands API
-  commands: {
-    list: (context?: {
-      terminalId?: string;
-      worktreeId?: string;
-      projectId?: string;
-      cwd?: string;
-      agentId?: string;
-    }) => _unwrappingInvoke(CHANNELS.COMMANDS_LIST, context),
-
-    get: (payload: {
-      commandId: string;
-      context?: {
-        terminalId?: string;
-        worktreeId?: string;
-        projectId?: string;
-        cwd?: string;
-        agentId?: string;
-      };
-    }) => _unwrappingInvoke(CHANNELS.COMMANDS_GET, payload),
-
-    execute: (payload: {
-      commandId: string;
-      context: {
-        terminalId?: string;
-        worktreeId?: string;
-        projectId?: string;
-        cwd?: string;
-        agentId?: string;
-      };
-      args?: Record<string, unknown>;
-    }) => _unwrappingInvoke(CHANNELS.COMMANDS_EXECUTE, payload),
-
-    getBuilder: (commandId: string) => _unwrappingInvoke(CHANNELS.COMMANDS_GET_BUILDER, commandId),
-  },
+  commands: buildCommandsPreloadBindings(_unwrappingInvoke),
 
   // App Agent API - Configuration and API key management
   appAgent: {
@@ -2520,8 +2409,10 @@ const api: ElectronAPI = {
   },
 
   plugin: {
-    list: () => _unwrappingInvoke(CHANNELS.PLUGIN_LIST),
+    ...buildPluginPreloadBindings(_unwrappingInvoke),
 
+    // plugin:invoke uses raw ipcMain.handle with variadic args — its signature
+    // can't be expressed through IpcInvokeMap, so it stays inline.
     invoke: (pluginId: string, channel: string, ...args: unknown[]) =>
       _unwrappingInvoke(CHANNELS.PLUGIN_INVOKE, pluginId, channel, ...args),
 
@@ -2534,19 +2425,8 @@ const api: ElectronAPI = {
       };
     },
 
-    toolbarButtons: () => _unwrappingInvoke(CHANNELS.PLUGIN_TOOLBAR_BUTTONS),
-    menuItems: () => _unwrappingInvoke(CHANNELS.PLUGIN_MENU_ITEMS),
-    validateActionIds: (actionIds: string[]) =>
-      _unwrappingInvoke(CHANNELS.PLUGIN_VALIDATE_ACTION_IDS, actionIds),
-
-    getActions: () => _unwrappingInvoke(CHANNELS.PLUGIN_ACTIONS_GET),
-    registerAction: (pluginId: string, contribution: unknown) =>
-      _unwrappingInvoke(CHANNELS.PLUGIN_ACTIONS_REGISTER, pluginId, contribution),
-    unregisterAction: (pluginId: string, actionId: string) =>
-      _unwrappingInvoke(CHANNELS.PLUGIN_ACTIONS_UNREGISTER, pluginId, actionId),
     onActionsChanged: (callback: (payload: { actions: PluginActionDescriptor[] }) => void) =>
       _eventBusOn("plugin:actions-changed", callback),
-    getPanelKinds: () => _unwrappingInvoke(CHANNELS.PLUGIN_PANEL_KINDS_GET),
     onPanelKindsChanged: (callback: (payload: { kinds: PanelKindConfig[] }) => void) =>
       _eventBusOn("plugin:panel-kinds-changed", callback),
   },
@@ -2576,6 +2456,11 @@ const api: ElectronAPI = {
     }) => ipcRenderer.send(CHANNELS.PERF_FLUSH_RENDERER_MARKS, payload),
   },
 
+  // Demo API — channel constants live in `./ipc/handlers/demo.preload.ts` and
+  // back the main-side `defineIpcNamespace`, but the renderer-facing shape
+  // takes positional args (moveTo(x, y, durationMs)) while channels carry a
+  // single payload object. The translation stays inline so window.electron.demo
+  // matches its declared `ElectronAPI.demo` signature.
   ...(isDemoMode
     ? {
         demo: {

--- a/shared/types/ipc/maps.ts
+++ b/shared/types/ipc/maps.ts
@@ -196,12 +196,12 @@ import type { CloneRepoOptions, CloneRepoResult } from "./gitClone.js";
 import type { AppAgentConfig } from "../appAgent.js";
 import type { AgentSessionRecord } from "./agentSessionHistory.js";
 import type {
+  BuilderStep,
   CommandContext,
   CommandExecutePayload,
   CommandGetPayload,
   CommandManifestEntry,
   CommandResult,
-  DaintreeCommand,
 } from "../commands.js";
 
 export type ChecklistItemId =
@@ -1997,7 +1997,7 @@ export interface IpcInvokeMap {
   };
   "commands:get-builder": {
     args: [commandId: string];
-    result: DaintreeCommand["builder"] | null;
+    result: { steps: BuilderStep[] } | null;
   };
 
   // Additional GitHub channels


### PR DESCRIPTION
## Summary

Migrates 7 IPC handler groups to \`defineIpcNamespace\` as part of #7680's domain-group plan, covering \`eventInspector\`, \`commands\`, \`portal\`, \`devPreview\`, \`plugin\`, \`scratch\`, and \`demo\`.

Each namespace gets a dedicated \`*.preload.ts\` file holding channel-string maps and a \`buildXxxPreloadBindings\` factory modelled on the existing \`clipboard\`/\`help\` templates. \`preload.cts\` spreads the new builders for 6 namespaces; \`demo\`'s renderer-facing positional-arg API differs from the channel payload shape so its preload block stays inline, though the handler itself is migrated.

One exception: \`plugin:invoke\` stays on raw \`ipcMain.handle\`. The variadic arg list combined with the \`senderFrame\` trust check can't be expressed cleanly in \`IpcInvokeMap\`.

Resolves #7680

## Changes

- 7 new \`*.preload.ts\` files (\`commands\`, \`portal\`, \`devPreview\`, \`plugin\`, \`scratch\`, \`demo\`, \`eventInspector\`)
- \`preload.cts\` slimmed down — 6 namespaces spread via new builders; \`demo\` preload block stays inline
- \`IpcInvokeMap["commands:get-builder"]["result"]\` tightened to drop the implicit \`undefined\` that slipped through \`DaintreeCommand["builder"] | null\`
- \`commands:execute\` keeps its \`@ts-expect-error\` (pending \`CommandResult\` envelope fix in #6020)
- \`leafPreloadNamespaces.test.ts\` extended with 7 new namespace blocks covering channel-sync and routing assertions (32 tests total)
- \`channelDrift.test.ts\` passes unchanged — \`channels.ts\` intentionally untouched

## Out of scope

- Remaining 5 domain groups (Worktree, Terminal, Project/App/GitHub, Agent, System)
- \`handlers.ts\` loop refactor and runtime channel-Set assertion
- CLAUDE.md "Adding IPC channel" recipe update
- Codegen of \`IpcInvokeMap\` from namespace files

## Testing

- \`leafPreloadNamespaces.test.ts\` — 32 tests, all green
- \`channelDrift.test.ts\` — green, no drift
- Per-handler test files for \`commands\`, \`portal\`, \`devPreview\`, \`plugin\`, \`scratch\`, \`demo\`, and \`eventInspector\` — all green