### PR TITLE
fix(worktree): distinguish never-recorded activity from decayed state in ActivityLight

### DIFF
--- a/src/components/Worktree/ActivityLight.tsx
+++ b/src/components/Worktree/ActivityLight.tsx
@@ -29,6 +29,8 @@ export function ActivityLight({ lastActivityTimestamp, className }: ActivityLigh
     setActive(isActivelyWorking(lastActivityTimestamp));
   }, [lastActivityTimestamp, globalTick]);
 
+  if (lastActivityTimestamp == null) return null;
+
   return (
     <div
       aria-hidden="true"

--- a/src/components/Worktree/WorktreeCard/WorktreeDetailsSection.tsx
+++ b/src/components/Worktree/WorktreeCard/WorktreeDetailsSection.tsx
@@ -349,11 +349,17 @@ export function WorktreeDetailsSection(props: WorktreeDetailsSectionProps) {
             <Tooltip>
               <TooltipTrigger asChild>
                 <div className="relative z-10 ml-3 flex shrink-0 items-center gap-1.5 text-xs text-text-muted">
-                  <ActivityLight
-                    lastActivityTimestamp={worktree.lastActivityTimestamp}
-                    className="w-1.5 h-1.5"
-                  />
-                  <LiveTimeAgo timestamp={worktree.lastActivityTimestamp} />
+                  {worktree.lastActivityTimestamp != null ? (
+                    <>
+                      <ActivityLight
+                        lastActivityTimestamp={worktree.lastActivityTimestamp}
+                        className="w-1.5 h-1.5"
+                      />
+                      <LiveTimeAgo timestamp={worktree.lastActivityTimestamp} />
+                    </>
+                  ) : (
+                    <span>No activity</span>
+                  )}
                 </div>
               </TooltipTrigger>
               <TooltipContent side="bottom">

--- a/src/components/Worktree/WorktreeCard/WorktreeDetailsSection.tsx
+++ b/src/components/Worktree/WorktreeCard/WorktreeDetailsSection.tsx
@@ -363,7 +363,7 @@ export function WorktreeDetailsSection(props: WorktreeDetailsSectionProps) {
                 </div>
               </TooltipTrigger>
               <TooltipContent side="bottom">
-                {worktree.lastActivityTimestamp
+                {worktree.lastActivityTimestamp != null
                   ? `Last activity: ${new Date(worktree.lastActivityTimestamp).toLocaleString()}`
                   : "No recent activity recorded"}
               </TooltipContent>

--- a/src/components/Worktree/WorktreeCard/__tests__/WorktreeDetailsSection.test.tsx
+++ b/src/components/Worktree/WorktreeCard/__tests__/WorktreeDetailsSection.test.tsx
@@ -290,3 +290,57 @@ describe("WorktreeDetailsSection count pill bump", () => {
     expect(screen.getByText(/5 files/)).toBeDefined();
   });
 });
+
+describe("WorktreeDetailsSection activity indicator", () => {
+  beforeEach(() => {
+    vi.useFakeTimers();
+    vi.setSystemTime(new Date("2025-06-15T12:00:00Z").getTime());
+  });
+
+  afterEach(() => {
+    vi.useRealTimers();
+  });
+
+  it("renders 'No activity' placeholder when lastActivityTimestamp is null", () => {
+    const worktree: WorktreeState = { ...baseWorktree, lastActivityTimestamp: null };
+    renderSection({ worktree, hasChanges: false });
+    expect(screen.getByText("No activity")).toBeDefined();
+  });
+
+  it("renders the activity dot and time ago when timestamp is present", () => {
+    const worktree: WorktreeState = {
+      ...baseWorktree,
+      lastActivityTimestamp: Date.now(),
+    };
+    renderSection({ worktree, hasChanges: false });
+    expect(screen.queryByText("No activity")).toBeNull();
+    // LiveTimeAgo renders "now" for a just-now timestamp
+    expect(screen.getByText("now")).toBeDefined();
+  });
+
+  it("renders hollow ring and time label for decayed timestamp", () => {
+    const worktree: WorktreeState = {
+      ...baseWorktree,
+      lastActivityTimestamp: Date.now() - 120_000, // 2 minutes ago — past DECAY_DURATION (90s)
+    };
+    renderSection({ worktree, hasChanges: false });
+    expect(screen.queryByText("No activity")).toBeNull();
+    // LiveTimeAgo renders a time label like "2m"
+    expect(screen.getByText("2m")).toBeDefined();
+  });
+
+  it("collapsed view shows 'No activity' when expanded view shows worktree details without activity section", () => {
+    // The expanded view (WorktreeDetails) already gates the activity section
+    // on showTime && lastActivityTimestamp (line 81). Verify the collapsed
+    // view handles the null case distinctly.
+    const worktree: WorktreeState = { ...baseWorktree, lastActivityTimestamp: null };
+    renderSection({ worktree, hasChanges: false });
+    expect(screen.getByText("No activity")).toBeDefined();
+  });
+
+  it("null timestamp worktree does not render an ActivityLight dot", () => {
+    const worktree: WorktreeState = { ...baseWorktree, lastActivityTimestamp: null };
+    const { container } = renderSection({ worktree, hasChanges: false });
+    expect(container.querySelector('[aria-hidden="true"]')).toBeNull();
+  });
+});

--- a/src/components/Worktree/WorktreeDetails.tsx
+++ b/src/components/Worktree/WorktreeDetails.tsx
@@ -71,14 +71,14 @@ export function WorktreeDetails({
     effectiveSummary ||
     (showLastCommit && rawLastCommitMsg) ||
     (hasChanges && worktree.worktreeChanges) ||
-    (showTime && lastActivityTimestamp);
+    (showTime && lastActivityTimestamp != null);
 
   return (
     <div className="space-y-4">
       {hasDetailsContent && (
         <>
           {/* Time Display for Expanded View */}
-          {showTime && lastActivityTimestamp && (
+          {showTime && lastActivityTimestamp != null && (
             <div className="flex items-center gap-2 border-b border-border-divider pb-2">
               <div className="flex items-center gap-1.5 text-xs text-text-secondary">
                 <span className="text-xs font-medium">Last active:</span>

--- a/src/components/Worktree/__tests__/ActivityLight.test.tsx
+++ b/src/components/Worktree/__tests__/ActivityLight.test.tsx
@@ -89,17 +89,14 @@ describe("ActivityLight", () => {
     expect(dot.style.borderColor).not.toBe("");
   });
 
-  it("renders hollow ring when timestamp is null", () => {
+  it("renders nothing when timestamp is null (never recorded)", () => {
     const { container } = render(<ActivityLight lastActivityTimestamp={null} />);
-    const dot = getDot(container);
-    expect(dot.className).toMatch(/\bborder\b/);
-    expect(dot.className).toMatch(/bg-transparent/);
+    expect(container.firstChild).toBeNull();
   });
 
-  it("renders hollow ring when timestamp is undefined", () => {
+  it("renders nothing when timestamp is undefined (never recorded)", () => {
     const { container } = render(<ActivityLight />);
-    const dot = getDot(container);
-    expect(dot.className).toMatch(/\bborder\b/);
+    expect(container.firstChild).toBeNull();
   });
 
   it("applies the className prop", () => {


### PR DESCRIPTION
## Summary
- `ActivityLight` was rendering a hollow ring dot for worktrees where no activity had ever been recorded. It looked the same as the hollow ring for legitimately decayed activity.
- The component now returns `null` when `lastActivityTimestamp` is `null` or `undefined`. The collapsed view shows a "No activity" text placeholder instead.
- Tightened up `!= null` guards across the worktree details components and added test coverage for the null-state behavior.

Resolves #7698.

## Changes
- **`ActivityLight.tsx`** -- early return `null` when `lastActivityTimestamp == null`
- **`WorktreeDetailsSection.tsx`** -- gate `ActivityLight` / `LiveTimeAgo` on `lastActivityTimestamp != null`; show "No activity" fallback
- **`WorktreeDetails.tsx`** -- consistent `!= null` guards for the expanded-view activity section
- **`ActivityLight.test.tsx`** -- updated null/unset tests to expect no render instead of a hollow ring
- **`WorktreeDetailsSection.test.tsx`** -- new test block covering null timestamp, active timestamp, decayed timestamp, and collapsed-view null rendering

## Testing
- Unit tests pass for both `ActivityLight` and `WorktreeDetailsSection` null-state paths
- Visual check: worktrees with no recorded activity show "No activity" text and no dot; worktrees with recent activity show the filled dot + time; decayed worktrees show the hollow ring