### PR TITLE
chore(terminal): route panel-kind literal compares through type guards

### DIFF
--- a/src/components/Terminal/TerminalContextMenu.tsx
+++ b/src/components/Terminal/TerminalContextMenu.tsx
@@ -8,7 +8,7 @@ import { useWorktrees } from "@/hooks/useWorktrees";
 import { useFleetArmingStore, isFleetArmEligible } from "@/store/fleetArmingStore";
 import { isValidBrowserUrl } from "@/components/Browser/browserUtils";
 import { actionService } from "@/services/ActionService";
-import { panelKindHasPty } from "@shared/config/panelKindRegistry";
+import { isBrowserPanel, isDevPreviewPanel, isPtyPanel } from "@shared/types/panel";
 import { terminalInstanceService } from "@/services/TerminalInstanceService";
 import {
   ArrowDownFromLine,
@@ -296,9 +296,9 @@ export function TerminalContextMenu({
     return <div className="contents">{children}</div>;
   }
 
-  const isBrowser = terminal.kind === "browser";
-  const isDevPreview = terminal.kind === "dev-preview";
-  const hasPty = terminal.kind ? panelKindHasPty(terminal.kind) : true;
+  const isBrowser = isBrowserPanel(terminal);
+  const isDevPreview = isDevPreviewPanel(terminal);
+  const hasPty = isPtyPanel(terminal);
 
   const layoutSection = (
     <>

--- a/src/components/Terminal/TerminalContextMenu.tsx
+++ b/src/components/Terminal/TerminalContextMenu.tsx
@@ -8,7 +8,8 @@ import { useWorktrees } from "@/hooks/useWorktrees";
 import { useFleetArmingStore, isFleetArmEligible } from "@/store/fleetArmingStore";
 import { isValidBrowserUrl } from "@/components/Browser/browserUtils";
 import { actionService } from "@/services/ActionService";
-import { isBrowserPanel, isDevPreviewPanel, isPtyPanel } from "@shared/types/panel";
+import { panelKindHasPty } from "@shared/config/panelKindRegistry";
+import { isBrowserPanel, isDevPreviewPanel } from "@shared/types/panel";
 import { terminalInstanceService } from "@/services/TerminalInstanceService";
 import {
   ArrowDownFromLine,
@@ -298,7 +299,7 @@ export function TerminalContextMenu({
 
   const isBrowser = isBrowserPanel(terminal);
   const isDevPreview = isDevPreviewPanel(terminal);
-  const hasPty = isPtyPanel(terminal);
+  const hasPty = terminal.kind ? panelKindHasPty(terminal.kind) : true;
 
   const layoutSection = (
     <>

--- a/src/components/Terminal/TwoPaneSplitLayout.tsx
+++ b/src/components/Terminal/TwoPaneSplitLayout.tsx
@@ -10,6 +10,7 @@ import { GridPanel } from "./GridPanel";
 import { TwoPaneSplitDivider, DIVIDER_WIDTH_PX } from "./TwoPaneSplitDivider";
 import { MIN_TERMINAL_WIDTH_PX } from "@/lib/terminalLayout";
 import { terminalInstanceService } from "@/services/TerminalInstanceService";
+import { isBrowserPanel, isDevPreviewPanel } from "@shared/types/panel";
 import { useResizeObserverRaf } from "@/hooks/useResizeObserverRaf";
 
 interface TwoPaneSplitLayoutProps {
@@ -85,8 +86,8 @@ export function TwoPaneSplitLayout({
     if (!preferPreview) return defaultRatio;
 
     const [left, right] = terminals;
-    const leftIsPreview = left.kind === "browser" || left.kind === "dev-preview";
-    const rightIsPreview = right.kind === "browser" || right.kind === "dev-preview";
+    const leftIsPreview = isBrowserPanel(left) || isDevPreviewPanel(left);
+    const rightIsPreview = isBrowserPanel(right) || isDevPreviewPanel(right);
 
     if (leftIsPreview && !rightIsPreview) {
       return 0.65;


### PR DESCRIPTION
## Summary

Two call sites in `src/components/Terminal/` were comparing `panel.kind` directly against the string literals `"browser"` and `"dev-preview"`, while `shared/types/panel.ts` already exports `isBrowserPanel` and `isDevPreviewPanel` type guards for this exact purpose. `TerminalContextMenu.tsx` was the obvious one -- literal compares sitting a line above an existing `panelKindHasPty()` call, half-using the registry already.

This swaps the literal compares for the guards. No behavioral difference.

Resolves #7670.

## Changes

- **`TerminalContextMenu.tsx`** -- replaced `terminal.kind === "browser"` and `terminal.kind === "dev-preview"` with `isBrowserPanel(terminal)` and `isDevPreviewPanel(terminal)`
- **`TwoPaneSplitLayout.tsx`** -- replaced `left.kind === "browser" || left.kind === "dev-preview"` (and the mirror on `right`) with `isBrowserPanel(left) || isDevPreviewPanel(left)`

## Testing

Manual smoke test: context menus and two-pane split ratios behave identically.