### PR TITLE
test(keybinding): backfill AltGr and non-US layout test coverage

### DIFF
--- a/src/services/__tests__/KeybindingService.test.ts
+++ b/src/services/__tests__/KeybindingService.test.ts
@@ -63,6 +63,195 @@ describe("KeybindingService", () => {
     expect(normalizeKeyForBinding(event)).toBe("/");
   });
 
+  describe("AltGr and non-US layout key handling", () => {
+    function altGraphModifierState(): (key: string) => boolean {
+      return (key: string) => key === "AltGraph";
+    }
+
+    // ── normalizeKeyForBinding (utility layer) ──────────────────
+
+    it("returns the produced character on Windows AltGr+E, not the physical key", () => {
+      setPlatform("Win32");
+
+      const event = createKeyboardEvent({
+        key: "€",
+        code: "KeyE",
+        ctrlKey: true,
+        altKey: true,
+        getModifierState: altGraphModifierState(),
+      });
+
+      expect(normalizeKeyForBinding(event)).toBe("€");
+    });
+
+    it("returns the produced character on Windows AltGr+digit, not the physical key", () => {
+      setPlatform("Win32");
+
+      const event = createKeyboardEvent({
+        key: "{",
+        code: "Digit8",
+        ctrlKey: true,
+        altKey: true,
+        getModifierState: altGraphModifierState(),
+      });
+
+      expect(normalizeKeyForBinding(event)).toBe("{");
+    });
+
+    it("returns the physical key on macOS Option-letter (contrast with Windows AltGr)", () => {
+      setPlatform("MacIntel");
+
+      const event = createKeyboardEvent({
+        key: "π",
+        code: "KeyP",
+        altKey: true,
+      });
+
+      expect(normalizeKeyForBinding(event)).toBe("P");
+    });
+
+    // ── matchesEvent (matcher layer) ────────────────────────────
+
+    it("rejects Ctrl+Alt+E when AltGr produces € on Windows", () => {
+      setPlatform("Win32");
+
+      const service = new KeybindingService();
+      const event = createKeyboardEvent({
+        key: "€",
+        code: "KeyE",
+        ctrlKey: true,
+        altKey: true,
+        getModifierState: altGraphModifierState(),
+      });
+
+      expect(service.matchesEvent(event, "Ctrl+Alt+E")).toBe(false);
+    });
+
+    it("rejects Ctrl+Alt+Q when AltGr produces @ on Windows", () => {
+      setPlatform("Win32");
+
+      const service = new KeybindingService();
+      const event = createKeyboardEvent({
+        key: "@",
+        code: "KeyQ",
+        ctrlKey: true,
+        altKey: true,
+        getModifierState: altGraphModifierState(),
+      });
+
+      expect(service.matchesEvent(event, "Ctrl+Alt+Q")).toBe(false);
+    });
+
+    it("rejects Ctrl+Alt+E on Linux AltGr (neither modifier flag is set)", () => {
+      setPlatform("Linux x86_64");
+
+      const service = new KeybindingService();
+      const event = createKeyboardEvent({
+        key: "€",
+        code: "KeyE",
+        getModifierState: altGraphModifierState(),
+      });
+
+      expect(service.matchesEvent(event, "Ctrl+Alt+E")).toBe(false);
+    });
+
+    it("matches legitimate Ctrl+Alt+E on US-layout Windows (positive control)", () => {
+      setPlatform("Win32");
+
+      const service = new KeybindingService();
+      const event = createKeyboardEvent({
+        key: "E",
+        code: "KeyE",
+        ctrlKey: true,
+        altKey: true,
+      });
+
+      expect(service.matchesEvent(event, "Ctrl+Alt+E")).toBe(true);
+    });
+
+    it("rejects bare-key { when AltGr modifiers are present on Windows", () => {
+      setPlatform("Win32");
+
+      const service = new KeybindingService();
+      const event = createKeyboardEvent({
+        key: "{",
+        code: "Digit8",
+        ctrlKey: true,
+        altKey: true,
+        getModifierState: altGraphModifierState(),
+      });
+
+      expect(service.matchesEvent(event, "{")).toBe(false);
+    });
+
+    // ── findMatchingAction (pipeline layer) ─────────────────────
+
+    it("does not resolve a Ctrl+Alt+E action from AltGr+E on Windows", () => {
+      setPlatform("Win32");
+
+      const service = new KeybindingService();
+      service.registerBinding({
+        actionId: "test.ctrlAltE",
+        combo: "Ctrl+Alt+E",
+        scope: "global",
+        priority: 99,
+      });
+
+      const event = createKeyboardEvent({
+        key: "€",
+        code: "KeyE",
+        ctrlKey: true,
+        altKey: true,
+        getModifierState: altGraphModifierState(),
+      });
+
+      expect(service.findMatchingAction(event)).toBeUndefined();
+    });
+
+    it("resolves a Ctrl+Alt+E action from legitimate Ctrl+Alt+E on US-layout Windows", () => {
+      setPlatform("Win32");
+
+      const service = new KeybindingService();
+      service.registerBinding({
+        actionId: "test.ctrlAltE",
+        combo: "Ctrl+Alt+E",
+        scope: "global",
+        priority: 99,
+      });
+
+      const event = createKeyboardEvent({
+        key: "E",
+        code: "KeyE",
+        ctrlKey: true,
+        altKey: true,
+      });
+
+      expect(service.findMatchingAction(event)?.actionId).toBe("test.ctrlAltE");
+    });
+
+    it("does not resolve a Cmd+Alt+Q agent-launch binding from AltGr+Q on Windows — #1678 guard", () => {
+      setPlatform("Win32");
+
+      const service = new KeybindingService();
+      service.registerBinding({
+        actionId: "test.agentLaunch",
+        combo: "Cmd+Alt+Q",
+        scope: "global",
+        priority: 99,
+      });
+
+      const event = createKeyboardEvent({
+        key: "@",
+        code: "KeyQ",
+        ctrlKey: true,
+        altKey: true,
+        getModifierState: altGraphModifierState(),
+      });
+
+      expect(service.findMatchingAction(event)).toBeUndefined();
+    });
+  });
+
   it("matches Cmd bindings on non-mac when Ctrl is pressed", () => {
     setPlatform("Win32");
 


### PR DESCRIPTION
## Summary
- Adds 11 unit tests covering AltGr (Windows/Linux) and Option (macOS) behavior across all three layers of the keybinding system: `normalizeKeyForBinding` (utility), `matchesEvent` (matcher), and `findMatchingAction` (pipeline).
- No production code changes. The production behavior was already correct -- this backfills the test coverage to lock it in.
- Resolves #7634

## Changes
- `src/services/__tests__/KeybindingService.test.ts` -- 11 new tests in a dedicated `describe("AltGr and non-US layout key handling")` block

## Testing
All 74 tests pass (`npx vitest run`). The new tests verify:
- Windows AltGr+letter produces the output character (`€`) not the physical key, and is rejected by `Ctrl+Alt+E` bindings
- Windows AltGr+digit produces the output character (`{`) not the physical key
- macOS Option+letter returns the physical key (contrasting with Windows behavior)
- Linux AltGr (no modifier flags set) is rejected by `Ctrl+Alt+E` bindings
- Positive controls: legitimate `Ctrl+Alt+E` on US layout resolves correctly
- Pipeline-layer: `findMatchingAction` rejects AltGr events and resolves US-layout events
- #1678 guard: `Cmd+Alt+Q` binding is not triggered by AltGr+Q on Windows