### PR TITLE
feat(panel): add RadioTower broadcast indicator to agent panel titles

### DIFF
--- a/e2e/full/terminal/core-fleet-broadcast.spec.ts
+++ b/e2e/full/terminal/core-fleet-broadcast.spec.ts
@@ -261,6 +261,14 @@ test.describe.serial("Core: Fleet terminal broadcast", () => {
       await armFleet(window, terminalIds);
     });
 
+    await test.step("Verify armed broadcast indicator appears on each panel header", async () => {
+      for (const { panel } of agents) {
+        await expect(panel.getByTestId("panel-armed-broadcast-indicator")).toBeVisible({
+          timeout: T_MEDIUM,
+        });
+      }
+    });
+
     const command = `fleet-direct-${Date.now()}`;
     await test.step("Type directly into the first armed terminal and verify all three respond", async () => {
       await typeDirectlyIntoTerminal(window, agents[0]!.panel, agents[0]!.id, command);
@@ -277,6 +285,21 @@ test.describe.serial("Core: Fleet terminal broadcast", () => {
         timeout: T_MEDIUM,
       });
       await expect(agents[0]!.panel.locator(SEL.terminal.cmEditor)).toHaveCount(0);
+    });
+
+    await test.step("Disarm and verify broadcast indicator disappears", async () => {
+      for (const agent of agents) {
+        const disarm = await dispatchAction(
+          window,
+          "terminal.disarm",
+          { terminalId: agent.id },
+          { source: "user" }
+        );
+        expect(disarm.ok, disarm.error?.message).toBe(true);
+        await expect(agent.panel.getByTestId("panel-armed-broadcast-indicator")).not.toBeVisible({
+          timeout: T_MEDIUM,
+        });
+      }
     });
   });
 

--- a/e2e/full/terminal/core-fleet-broadcast.spec.ts
+++ b/e2e/full/terminal/core-fleet-broadcast.spec.ts
@@ -288,15 +288,40 @@ test.describe.serial("Core: Fleet terminal broadcast", () => {
     });
 
     await test.step("Disarm and verify broadcast indicator disappears", async () => {
-      for (const agent of agents) {
+      // Disarm the first panel and verify its indicator vanishes but the
+      // other two still show theirs — guards against store bugs that clear
+      // the entire armedIds set on a single disarm.
+      const disarm0 = await dispatchAction(
+        window,
+        "terminal.disarm",
+        { terminalId: agents[0]!.id },
+        { source: "user" }
+      );
+      expect(disarm0.ok, disarm0.error?.message).toBe(true);
+      await expect(agents[0]!.panel.getByTestId("panel-armed-broadcast-indicator")).not.toBeVisible(
+        {
+          timeout: T_MEDIUM,
+        }
+      );
+      await expect(agents[1]!.panel.getByTestId("panel-armed-broadcast-indicator")).toBeVisible({
+        timeout: T_MEDIUM,
+      });
+      await expect(agents[2]!.panel.getByTestId("panel-armed-broadcast-indicator")).toBeVisible({
+        timeout: T_MEDIUM,
+      });
+
+      // Disarm the remaining two.
+      for (let i = 1; i < agents.length; i++) {
         const disarm = await dispatchAction(
           window,
           "terminal.disarm",
-          { terminalId: agent.id },
+          { terminalId: agents[i]!.id },
           { source: "user" }
         );
         expect(disarm.ok, disarm.error?.message).toBe(true);
-        await expect(agent.panel.getByTestId("panel-armed-broadcast-indicator")).not.toBeVisible({
+        await expect(
+          agents[i]!.panel.getByTestId("panel-armed-broadcast-indicator")
+        ).not.toBeVisible({
           timeout: T_MEDIUM,
         });
       }

--- a/src/components/Panel/PanelHeader.tsx
+++ b/src/components/Panel/PanelHeader.tsx
@@ -14,6 +14,7 @@ import {
   Grid2X2,
   Activity,
   Plus,
+  RadioTower,
   Bell,
   BellOff,
   ChevronDown,
@@ -68,6 +69,7 @@ import { panelKindCanRestart, panelKindHasPty } from "@shared/config/panelKindRe
 import { actionService } from "@/services/ActionService";
 import { fireWatchNotification } from "@/lib/watchNotification";
 import { useFleetFailureStore } from "@/store/fleetFailureStore";
+import { useFleetArmingStore } from "@/store/fleetArmingStore";
 import type { TerminalChromeDescriptor } from "@/utils/terminalChrome";
 
 export interface PanelHeaderProps {
@@ -255,6 +257,7 @@ function PanelHeaderComponent({
   // pane the same way a "Retry failed" button surfaces it in the ribbon.
   const isFleetFailed = useFleetFailureStore((s) => s.failedIds.has(id));
   const dismissFleetFailure = useFleetFailureStore((s) => s.dismissId);
+  const isArmed = useFleetArmingStore((s) => s.armedIds.has(id));
 
   const duplicateShortcut = useKeybindingDisplay("terminal.duplicate");
   const moveToDockShortcut = useKeybindingDisplay("terminal.moveToDock");
@@ -726,6 +729,22 @@ function PanelHeaderComponent({
                 Last fleet broadcast failed here — click to dismiss. Run "Fleet: Retry failed
                 broadcast" from the command palette to resend.
               </TooltipContent>
+            </Tooltip>
+          )}
+
+          {chrome.isAgent && isArmed && (
+            <Tooltip>
+              <TooltipTrigger asChild>
+                <span
+                  role="status"
+                  aria-label="Armed for fleet broadcast"
+                  data-testid="panel-armed-broadcast-indicator"
+                  className="shrink-0 text-category-amber-text"
+                >
+                  <RadioTower className="h-3.5 w-3.5" aria-hidden="true" />
+                </span>
+              </TooltipTrigger>
+              <TooltipContent side="bottom">Armed for fleet broadcast</TooltipContent>
             </Tooltip>
           )}
 


### PR DESCRIPTION
## Summary
- Adds a `RadioTower` icon next to the agent panel title when the terminal is armed for fleet broadcast, so you can tell at a glance whether the next broadcast will land there -- no need to open the fleet ribbon.
- Reads armed state from `useFleetArmingStore` and slots into the existing panel-header adornment row alongside the dangerous-flags dot and fleet-failure indicator.

Resolves #7692

## Changes
- `src/components/Panel/PanelHeader.tsx` -- RadioTower icon in `text-category-amber-text` shown when `chrome.isAgent && isArmed`, with an "Armed for fleet broadcast" tooltip.
- `e2e/full/terminal/core-fleet-broadcast.spec.ts` -- E2E tests for the indicator appearing on arm, vanishing on disarm, and a partial-disarm assertion that verifies disarming one panel does not clear the armedIds for the others.

## Testing
- E2E in `full-terminal` bucket: verifies the indicator appears on all three armed panels, survives partial disarm (only the disarmed panel loses it), and stays gone after full disarm.