### PR TITLE
feat(toolbar): unify toolbar customization with the agent tray

### DIFF
--- a/src/components/Layout/Toolbar.tsx
+++ b/src/components/Layout/Toolbar.tsx
@@ -2,9 +2,6 @@ import { useRef, useState, useEffect, useLayoutEffect, useMemo, useCallback } fr
 import type React from "react";
 import { Button } from "@/components/ui/button";
 import {
-  SlidersHorizontal,
-  SquareTerminal,
-  AlertCircle,
   GitCommit,
   GitPullRequest,
   CircleDot,
@@ -12,12 +9,9 @@ import {
   PanelLeftClose,
   Check,
   ChevronsUpDown,
-  Globe,
   MonitorPlay,
-  Bell,
   Ellipsis,
   GitBranch,
-  Plug,
 } from "lucide-react";
 import { Spinner } from "@/components/ui/Spinner";
 import { Folders, McpServerIcon } from "@/components/icons";
@@ -68,6 +62,7 @@ import { useOverflowBadgeSeverity, type OverflowBadgeSeverity } from "./useOverf
 
 import { BUILT_IN_AGENT_IDS, type BuiltInAgentId } from "@shared/config/agentIds";
 import { getAgentConfig } from "@/config/agents";
+import { TOOLBAR_BUTTON_METADATA } from "./toolbarButtonMetadata";
 
 const AGENT_TOOLBAR_IDS = new Set<ToolbarButtonId>([
   "agent-tray",
@@ -137,23 +132,20 @@ export function PluginToolbarButton({
   );
 }
 
-export const OVERFLOW_MENU_META: Partial<Record<AnyToolbarButtonId, OverflowMenuMeta>> = {
-  ...(Object.fromEntries(
-    BUILT_IN_AGENT_IDS.map((id) => [
-      id,
-      { label: getAgentConfig(id)?.name ?? id, icon: SquareTerminal },
-    ])
-  ) as unknown as Record<BuiltInAgentId, OverflowMenuMeta>),
-  "agent-tray": { label: "Agent Tray", icon: Plug },
-  terminal: { label: "Terminal", icon: SquareTerminal },
-  browser: { label: "Browser", icon: Globe },
-  "dev-server": { label: "Dev Preview", icon: MonitorPlay },
-  "github-stats": { label: "GitHub Stats", icon: GitPullRequest },
-  "notification-center": { label: "Notifications", icon: Bell },
-  "copy-tree": { label: "Copy Context", icon: Folders },
-  settings: { label: "Settings", icon: SlidersHorizontal },
-  problems: { label: "Problems", icon: AlertCircle },
-};
+export const OVERFLOW_MENU_META: Partial<Record<AnyToolbarButtonId, OverflowMenuMeta>> =
+  Object.fromEntries(
+    Object.entries(TOOLBAR_BUTTON_METADATA)
+      .filter(([id]) => id !== "voice-recording")
+      .map(([id, meta]) => {
+        if ((BUILT_IN_AGENT_IDS as readonly string[]).includes(id)) {
+          return [
+            id,
+            { label: getAgentConfig(id as BuiltInAgentId)?.name ?? id, icon: meta!.icon },
+          ];
+        }
+        return [id, { label: meta!.label, icon: meta!.icon }];
+      })
+  );
 
 interface ToolbarProps {
   onLaunchAgent: (type: string) => void;

--- a/src/components/Layout/__tests__/Toolbar.agentRegistry.test.ts
+++ b/src/components/Layout/__tests__/Toolbar.agentRegistry.test.ts
@@ -1,9 +1,11 @@
 import { describe, it, expect, beforeAll } from "vitest";
 import fs from "fs/promises";
 import path from "path";
+import { Plug } from "lucide-react";
 import { BUILT_IN_AGENT_IDS } from "@shared/config/agentIds";
 import { TOOLBAR_BUTTON_PRIORITIES } from "@shared/types/toolbar";
 import { OVERFLOW_MENU_META } from "../Toolbar";
+import { TOOLBAR_BUTTON_METADATA } from "../toolbarButtonMetadata";
 
 const TOOLBAR_PATH = path.resolve(__dirname, "../Toolbar.tsx");
 
@@ -65,6 +67,14 @@ describe("Toolbar — agent registry zero-touch guarantee (issue #5070)", () => 
     it("has an OVERFLOW_MENU_META entry", () => {
       expect(OVERFLOW_MENU_META["agent-tray"]).toBeDefined();
       expect(OVERFLOW_MENU_META["agent-tray"]?.label).toBeTruthy();
+    });
+
+    it("uses the canonical Plug icon (matches the settings tab — issue #7666)", () => {
+      // Both surfaces resolve through TOOLBAR_BUTTON_METADATA, so a drift
+      // between the overflow menu and the settings tab is structurally
+      // impossible. Locking the icon to Plug guards the canonical choice.
+      expect(TOOLBAR_BUTTON_METADATA["agent-tray"]?.icon).toBe(Plug);
+      expect(OVERFLOW_MENU_META["agent-tray"]?.icon).toBe(Plug);
     });
   });
 

--- a/src/components/Layout/toolbarButtonMetadata.ts
+++ b/src/components/Layout/toolbarButtonMetadata.ts
@@ -1,0 +1,97 @@
+import type React from "react";
+import {
+  SquareTerminal,
+  Globe,
+  MonitorPlay,
+  Mic,
+  GitPullRequest,
+  Bell,
+  Settings,
+  AlertCircle,
+  Plug,
+} from "lucide-react";
+import { Folders } from "@/components/icons";
+import { BUILT_IN_AGENT_IDS, type BuiltInAgentId } from "@shared/config/agentIds";
+import type { AnyToolbarButtonId } from "@/../../shared/types/toolbar";
+import { getAgentConfig } from "@/config/agents";
+
+export type ToolbarButtonIcon = React.ComponentType<{ className?: string }>;
+
+export interface ToolbarButtonMetadata {
+  label: string;
+  icon: ToolbarButtonIcon;
+  description: string;
+}
+
+const STATIC_METADATA: Partial<Record<AnyToolbarButtonId, ToolbarButtonMetadata>> = {
+  "agent-tray": {
+    label: "Agent Tray",
+    icon: Plug,
+    description: "Dropdown for launching any agent and jumping into setup",
+  },
+  terminal: {
+    label: "Terminal",
+    icon: SquareTerminal,
+    description: "Open new terminal",
+  },
+  browser: {
+    label: "Browser",
+    icon: Globe,
+    description: "Open browser panel",
+  },
+  "dev-server": {
+    label: "Dev Preview",
+    icon: MonitorPlay,
+    description: "Open dev preview panel",
+  },
+  "voice-recording": {
+    label: "Voice Recording",
+    icon: Mic,
+    description: "Persistent dictation indicator shown while recording is active",
+  },
+  "github-stats": {
+    label: "GitHub Stats",
+    icon: GitPullRequest,
+    description: "GitHub issues, PRs, and commits",
+  },
+  "notification-center": {
+    label: "Notifications",
+    icon: Bell,
+    description: "Notification history dropdown",
+  },
+  "copy-tree": {
+    label: "Copy Context",
+    icon: Folders,
+    description: "Copy project context to clipboard",
+  },
+  settings: {
+    label: "Settings",
+    icon: Settings,
+    description: "Open settings dialog",
+  },
+  problems: {
+    label: "Problems",
+    icon: AlertCircle,
+    description: "Show problems panel",
+  },
+};
+
+const AGENT_METADATA = Object.fromEntries(
+  BUILT_IN_AGENT_IDS.map((id) => {
+    const cfg = getAgentConfig(id);
+    const name = cfg?.name ?? id;
+    return [
+      id,
+      {
+        label: `${name} Agent`,
+        icon: (cfg?.icon as ToolbarButtonIcon | undefined) ?? SquareTerminal,
+        description: `Launch ${name} AI agent`,
+      },
+    ];
+  })
+) as Record<BuiltInAgentId, ToolbarButtonMetadata>;
+
+export const TOOLBAR_BUTTON_METADATA: Partial<Record<AnyToolbarButtonId, ToolbarButtonMetadata>> = {
+  ...AGENT_METADATA,
+  ...STATIC_METADATA,
+};

--- a/src/components/Layout/toolbarButtonMetadata.ts
+++ b/src/components/Layout/toolbarButtonMetadata.ts
@@ -76,20 +76,16 @@ const STATIC_METADATA: Partial<Record<AnyToolbarButtonId, ToolbarButtonMetadata>
   },
 };
 
-const AGENT_METADATA = Object.fromEntries(
-  BUILT_IN_AGENT_IDS.map((id) => {
-    const cfg = getAgentConfig(id);
-    const name = cfg?.name ?? id;
-    return [
-      id,
-      {
-        label: `${name} Agent`,
-        icon: (cfg?.icon as ToolbarButtonIcon | undefined) ?? SquareTerminal,
-        description: `Launch ${name} AI agent`,
-      },
-    ];
-  })
-) as Record<BuiltInAgentId, ToolbarButtonMetadata>;
+const AGENT_METADATA: Partial<Record<BuiltInAgentId, ToolbarButtonMetadata>> = {};
+for (const id of BUILT_IN_AGENT_IDS) {
+  const cfg = getAgentConfig(id);
+  const name = cfg?.name ?? id;
+  AGENT_METADATA[id] = {
+    label: `${name} Agent`,
+    icon: (cfg?.icon as ToolbarButtonIcon | undefined) ?? SquareTerminal,
+    description: `Launch ${name} AI agent`,
+  };
+}
 
 export const TOOLBAR_BUTTON_METADATA: Partial<Record<AnyToolbarButtonId, ToolbarButtonMetadata>> = {
   ...AGENT_METADATA,

--- a/src/components/Settings/ToolbarSettingsTab.tsx
+++ b/src/components/Settings/ToolbarSettingsTab.tsx
@@ -15,120 +15,27 @@ import {
   verticalListSortingStrategy,
 } from "@dnd-kit/sortable";
 import { CSS } from "@dnd-kit/utilities";
-import {
-  GripVertical,
-  SquareTerminal,
-  Globe,
-  MonitorPlay,
-  AlertTriangle,
-  Settings,
-  AlertCircle,
-  Bell,
-  Mic,
-  LayoutGrid,
-  Rocket,
-  RotateCcw,
-  Puzzle,
-} from "lucide-react";
-import { Folders } from "@/components/icons";
+import { GripVertical, LayoutGrid, Rocket, RotateCcw } from "lucide-react";
 import { useToolbarPreferencesStore } from "@/store";
-import { useAgentSettingsStore } from "@/store/agentSettingsStore";
 import type { AnyToolbarButtonId } from "@/../../shared/types/toolbar";
-import type { AgentSettings } from "@shared/types";
 import { BUILT_IN_AGENT_IDS } from "@shared/config/agentIds";
-import { isAgentPinnedById } from "../../../shared/utils/agentPinned";
 import { getAgentConfig } from "@/config/agents";
 import { usePluginToolbarButtons } from "@/hooks/usePluginToolbarButtons";
 import { McpServerIcon } from "@/components/icons";
 import { cn } from "@/lib/utils";
 import { SettingsSection } from "./SettingsSection";
 import { SettingsSwitchCard } from "./SettingsSwitchCard";
+import { useUnifiedToolbarVisibility } from "@/hooks/useUnifiedToolbarVisibility";
+import {
+  TOOLBAR_BUTTON_METADATA,
+  type ToolbarButtonIcon,
+} from "@/components/Layout/toolbarButtonMetadata";
 
-type ButtonMetadata = { label: string; icon: React.ReactNode; description: string };
-
-// Agent-ID writes and reads for visibility go through `agentSettingsStore`
-// (the authoritative IPC-persisted store). `toolbarPreferencesStore.hiddenButtons`
-// is the source of truth only for non-agent buttons. A `version: 5` migration
-// strips stale agent IDs from persisted `hiddenButtons` so they can't shadow
-// the canonical pinned state.
-const AGENT_ID_SET = new Set<string>(BUILT_IN_AGENT_IDS);
-
-function isEffectivelyVisible(
-  buttonId: AnyToolbarButtonId,
-  hiddenButtons: string[],
-  agentSettings: AgentSettings | null
-): boolean {
-  if (AGENT_ID_SET.has(buttonId)) return isAgentPinnedById(agentSettings, buttonId);
-  return !hiddenButtons.includes(buttonId);
+interface ButtonMetadata {
+  label: string;
+  icon: ToolbarButtonIcon;
+  description: string;
 }
-
-const BUTTON_METADATA: Partial<Record<AnyToolbarButtonId, ButtonMetadata>> = {
-  "agent-tray": {
-    label: "Agent Tray",
-    icon: <Puzzle className="h-4 w-4" />,
-    description: "Dropdown for launching any agent and jumping into setup",
-  },
-  ...Object.fromEntries(
-    BUILT_IN_AGENT_IDS.map((id) => {
-      const cfg = getAgentConfig(id);
-      const Icon = cfg?.icon;
-      const name = cfg?.name ?? id;
-      return [
-        id,
-        {
-          label: `${name} Agent`,
-          icon: Icon ? <Icon className="h-4 w-4" /> : <SquareTerminal className="h-4 w-4" />,
-          description: `Launch ${name} AI agent`,
-        },
-      ];
-    })
-  ),
-  terminal: {
-    label: "Terminal",
-    icon: <SquareTerminal className="h-4 w-4" />,
-    description: "Open new terminal",
-  },
-  browser: {
-    label: "Browser",
-    icon: <Globe className="h-4 w-4" />,
-    description: "Open browser panel",
-  },
-  "dev-server": {
-    label: "Dev Preview",
-    icon: <MonitorPlay className="h-4 w-4" />,
-    description: "Open dev preview panel",
-  },
-  "voice-recording": {
-    label: "Voice Recording",
-    icon: <Mic className="h-4 w-4" />,
-    description: "Persistent dictation indicator shown while recording is active",
-  },
-  "github-stats": {
-    label: "GitHub Stats",
-    icon: <AlertTriangle className="h-4 w-4" />,
-    description: "GitHub issues, PRs, and commits",
-  },
-  "notification-center": {
-    label: "Notifications",
-    icon: <Bell className="h-4 w-4" />,
-    description: "Notification history dropdown",
-  },
-  "copy-tree": {
-    label: "Copy Context",
-    icon: <Folders className="h-4 w-4" />,
-    description: "Copy project context to clipboard",
-  },
-  settings: {
-    label: "Settings",
-    icon: <Settings className="h-4 w-4" />,
-    description: "Open settings dialog",
-  },
-  problems: {
-    label: "Problems",
-    icon: <AlertCircle className="h-4 w-4" />,
-    description: "Show problems panel",
-  },
-};
 
 interface SortableButtonItemProps {
   buttonId: AnyToolbarButtonId;
@@ -157,6 +64,8 @@ function SortableButtonItem({
 
   if (!metadata) return null;
 
+  const Icon = metadata.icon;
+
   return (
     <div
       ref={setNodeRef}
@@ -172,7 +81,9 @@ function SortableButtonItem({
         />
       </div>
       <div className="flex items-center gap-2 flex-1">
-        <div className="text-daintree-text">{metadata.icon}</div>
+        <div className="text-daintree-text">
+          <Icon className="h-4 w-4" />
+        </div>
         <div className="flex-1">
           <div className="text-sm font-medium text-daintree-text">{metadata.label}</div>
           <div className="text-xs text-daintree-text/50 select-text">{metadata.description}</div>
@@ -194,13 +105,11 @@ export function ToolbarSettingsTab() {
   const launcher = useToolbarPreferencesStore((s) => s.launcher);
   const setLeftButtons = useToolbarPreferencesStore((s) => s.setLeftButtons);
   const setRightButtons = useToolbarPreferencesStore((s) => s.setRightButtons);
-  const toggleButtonVisibility = useToolbarPreferencesStore((s) => s.toggleButtonVisibility);
   const setAlwaysShowDevServer = useToolbarPreferencesStore((s) => s.setAlwaysShowDevServer);
   const setDefaultSelection = useToolbarPreferencesStore((s) => s.setDefaultSelection);
   const reset = useToolbarPreferencesStore((s) => s.reset);
 
-  const agentSettings = useAgentSettingsStore((s) => s.settings);
-  const setAgentPinned = useAgentSettingsStore((s) => s.setAgentPinned);
+  const { isEffectivelyVisible, toggleVisibility } = useUnifiedToolbarVisibility();
 
   const sensors = useSensors(
     useSensor(PointerSensor),
@@ -218,14 +127,17 @@ export function ToolbarSettingsTab() {
       if (config) {
         pluginMeta[id] = {
           label: config.label,
-          icon: <McpServerIcon className="h-4 w-4" />,
+          icon: McpServerIcon as ToolbarButtonIcon,
           description: `Plugin button (${config.pluginId})`,
         };
       }
     }
-    return { ...BUTTON_METADATA, ...pluginMeta };
+    return { ...TOOLBAR_BUTTON_METADATA, ...pluginMeta };
   }, [pluginButtonIds, pluginConfigs]);
 
+  // dnd-kit's DragEnd handler fires inside its own portal teardown; calling
+  // Zustand setters synchronously can race React 19's concurrent reconciler
+  // and crash. Defer the write one frame to let the portal finish unmounting.
   const handleLeftDragEnd = useCallback(
     (event: DragEndEvent) => {
       const { active, over } = event;
@@ -240,7 +152,7 @@ export function ToolbarSettingsTab() {
       newButtons.splice(oldIndex, 1);
       newButtons.splice(newIndex, 0, active.id as AnyToolbarButtonId);
 
-      setLeftButtons(newButtons);
+      requestAnimationFrame(() => setLeftButtons(newButtons));
     },
     [layout.leftButtons, setLeftButtons]
   );
@@ -259,31 +171,19 @@ export function ToolbarSettingsTab() {
       newButtons.splice(oldIndex, 1);
       newButtons.splice(newIndex, 0, active.id as AnyToolbarButtonId);
 
-      setRightButtons(newButtons);
+      requestAnimationFrame(() => setRightButtons(newButtons));
     },
     [layout.rightButtons, setRightButtons]
   );
 
   const handleToggleLeft = useCallback(
-    (buttonId: AnyToolbarButtonId) => {
-      if (AGENT_ID_SET.has(buttonId)) {
-        void setAgentPinned(buttonId, !isAgentPinnedById(agentSettings, buttonId));
-        return;
-      }
-      toggleButtonVisibility(buttonId, "left");
-    },
-    [agentSettings, setAgentPinned, toggleButtonVisibility]
+    (buttonId: AnyToolbarButtonId) => toggleVisibility(buttonId, "left"),
+    [toggleVisibility]
   );
 
   const handleToggleRight = useCallback(
-    (buttonId: AnyToolbarButtonId) => {
-      if (AGENT_ID_SET.has(buttonId)) {
-        void setAgentPinned(buttonId, !isAgentPinnedById(agentSettings, buttonId));
-        return;
-      }
-      toggleButtonVisibility(buttonId, "right");
-    },
-    [agentSettings, setAgentPinned, toggleButtonVisibility]
+    (buttonId: AnyToolbarButtonId) => toggleVisibility(buttonId, "right"),
+    [toggleVisibility]
   );
 
   return (
@@ -291,7 +191,7 @@ export function ToolbarSettingsTab() {
       <SettingsSection
         icon={LayoutGrid}
         title="Left Side Buttons"
-        description={`Drag to reorder, uncheck to hide. ${layout.leftButtons.filter((id) => isEffectivelyVisible(id, layout.hiddenButtons, agentSettings)).length} of ${layout.leftButtons.length} visible.`}
+        description={`Drag to reorder, uncheck to hide. ${layout.leftButtons.filter((id) => isEffectivelyVisible(id)).length} of ${layout.leftButtons.length} visible.`}
       >
         <DndContext
           sensors={sensors}
@@ -304,7 +204,7 @@ export function ToolbarSettingsTab() {
                 <SortableButtonItem
                   key={buttonId}
                   buttonId={buttonId}
-                  isVisible={isEffectivelyVisible(buttonId, layout.hiddenButtons, agentSettings)}
+                  isVisible={isEffectivelyVisible(buttonId)}
                   onToggle={handleToggleLeft}
                   allMetadata={allMetadata}
                 />
@@ -317,7 +217,7 @@ export function ToolbarSettingsTab() {
       <SettingsSection
         icon={LayoutGrid}
         title="Right Side Buttons"
-        description={`Drag to reorder, uncheck to hide. ${layout.rightButtons.filter((id) => isEffectivelyVisible(id, layout.hiddenButtons, agentSettings)).length} of ${layout.rightButtons.length} visible.`}
+        description={`Drag to reorder, uncheck to hide. ${layout.rightButtons.filter((id) => isEffectivelyVisible(id)).length} of ${layout.rightButtons.length} visible.`}
       >
         <DndContext
           sensors={sensors}
@@ -330,7 +230,7 @@ export function ToolbarSettingsTab() {
                 <SortableButtonItem
                   key={buttonId}
                   buttonId={buttonId}
-                  isVisible={isEffectivelyVisible(buttonId, layout.hiddenButtons, agentSettings)}
+                  isVisible={isEffectivelyVisible(buttonId)}
                   onToggle={handleToggleRight}
                   allMetadata={allMetadata}
                 />

--- a/src/components/Settings/__tests__/ToolbarSettingsTab.test.tsx
+++ b/src/components/Settings/__tests__/ToolbarSettingsTab.test.tsx
@@ -3,15 +3,7 @@ import { describe, it, expect, vi, beforeEach } from "vitest";
 import { render, fireEvent } from "@testing-library/react";
 import type { AgentSettings } from "@shared/types";
 
-const setLeftButtonsMock = vi.fn();
-const setRightButtonsMock = vi.fn();
-const toggleButtonVisibilityMock = vi.fn();
-const setAlwaysShowDevServerMock = vi.fn();
-const setDefaultSelectionMock = vi.fn();
-const resetMock = vi.fn();
-const setAgentPinnedMock = vi.fn().mockResolvedValue(undefined);
-
-interface ToolbarState {
+interface ToolbarStateShape {
   layout: {
     leftButtons: string[];
     rightButtons: string[];
@@ -21,39 +13,90 @@ interface ToolbarState {
     alwaysShowDevServer: boolean;
     defaultSelection?: string;
   };
-  setLeftButtons: typeof setLeftButtonsMock;
-  setRightButtons: typeof setRightButtonsMock;
-  toggleButtonVisibility: typeof toggleButtonVisibilityMock;
-  setAlwaysShowDevServer: typeof setAlwaysShowDevServerMock;
-  setDefaultSelection: typeof setDefaultSelectionMock;
-  reset: typeof resetMock;
+  setLeftButtons: ReturnType<typeof vi.fn>;
+  setRightButtons: ReturnType<typeof vi.fn>;
+  toggleButtonVisibility: ReturnType<typeof vi.fn>;
+  setAlwaysShowDevServer: ReturnType<typeof vi.fn>;
+  setDefaultSelection: ReturnType<typeof vi.fn>;
+  reset: ReturnType<typeof vi.fn>;
 }
 
-let mockToolbarState: ToolbarState = {
-  layout: { leftButtons: [], rightButtons: [], hiddenButtons: [] },
-  launcher: { alwaysShowDevServer: false, defaultSelection: undefined },
-  setLeftButtons: setLeftButtonsMock,
-  setRightButtons: setRightButtonsMock,
-  toggleButtonVisibility: toggleButtonVisibilityMock,
-  setAlwaysShowDevServer: setAlwaysShowDevServerMock,
-  setDefaultSelection: setDefaultSelectionMock,
-  reset: resetMock,
-};
+const hoisted = vi.hoisted(() => {
+  const setLeftButtonsMock = vi.fn();
+  const setRightButtonsMock = vi.fn();
+  const toggleButtonVisibilityMock = vi.fn();
+  const setAlwaysShowDevServerMock = vi.fn();
+  const setDefaultSelectionMock = vi.fn();
+  const resetMock = vi.fn();
+  const setAgentPinnedMock = vi.fn().mockResolvedValue(undefined);
 
-let mockAgentSettings: AgentSettings | null = null;
+  const toolbarState = {
+    layout: {
+      leftButtons: [] as string[],
+      rightButtons: [] as string[],
+      hiddenButtons: [] as string[],
+    },
+    launcher: { alwaysShowDevServer: false, defaultSelection: undefined as string | undefined },
+    setLeftButtons: setLeftButtonsMock,
+    setRightButtons: setRightButtonsMock,
+    toggleButtonVisibility: toggleButtonVisibilityMock,
+    setAlwaysShowDevServer: setAlwaysShowDevServerMock,
+    setDefaultSelection: setDefaultSelectionMock,
+    reset: resetMock,
+  };
+
+  const agentSlice = {
+    settings: null as AgentSettings | null,
+    setAgentPinned: setAgentPinnedMock,
+  };
+
+  type ToolbarHook = ((selector: (s: typeof toolbarState) => unknown) => unknown) & {
+    getState: () => typeof toolbarState;
+  };
+  const toolbarHook = ((selector: (s: typeof toolbarState) => unknown) =>
+    selector(toolbarState)) as ToolbarHook;
+  toolbarHook.getState = () => toolbarState;
+
+  type AgentHook = ((selector: (s: typeof agentSlice) => unknown) => unknown) & {
+    getState: () => typeof agentSlice;
+  };
+  const agentHook = ((selector: (s: typeof agentSlice) => unknown) =>
+    selector(agentSlice)) as AgentHook;
+  agentHook.getState = () => agentSlice;
+
+  return {
+    toolbarState,
+    agentSlice,
+    toolbarHook,
+    agentHook,
+    setLeftButtonsMock,
+    setRightButtonsMock,
+    toggleButtonVisibilityMock,
+    setAlwaysShowDevServerMock,
+    setDefaultSelectionMock,
+    resetMock,
+    setAgentPinnedMock,
+  };
+});
+
+const {
+  toolbarState,
+  agentSlice,
+  setLeftButtonsMock,
+  setRightButtonsMock,
+  toggleButtonVisibilityMock,
+  setAlwaysShowDevServerMock,
+  setDefaultSelectionMock,
+  resetMock,
+  setAgentPinnedMock,
+} = hoisted;
 
 vi.mock("@/store", () => ({
-  useToolbarPreferencesStore: (selector: (s: ToolbarState) => unknown) =>
-    selector(mockToolbarState),
+  useToolbarPreferencesStore: hoisted.toolbarHook,
 }));
 
 vi.mock("@/store/agentSettingsStore", () => ({
-  useAgentSettingsStore: (
-    selector: (s: {
-      settings: AgentSettings | null;
-      setAgentPinned: typeof setAgentPinnedMock;
-    }) => unknown
-  ) => selector({ settings: mockAgentSettings, setAgentPinned: setAgentPinnedMock }),
+  useAgentSettingsStore: hoisted.agentHook,
 }));
 
 vi.mock("@shared/config/agentIds", () => ({
@@ -128,6 +171,14 @@ function agentSettings(overrides: Record<string, { pinned?: boolean }>): AgentSe
   return { agents: overrides } as unknown as AgentSettings;
 }
 
+function setLayout(layout: ToolbarStateShape["layout"]) {
+  toolbarState.layout = layout;
+}
+
+function setAgentSettings(s: AgentSettings | null) {
+  agentSlice.settings = s;
+}
+
 describe("ToolbarSettingsTab — agent visibility routing", () => {
   beforeEach(() => {
     setLeftButtonsMock.mockClear();
@@ -138,29 +189,23 @@ describe("ToolbarSettingsTab — agent visibility routing", () => {
     resetMock.mockClear();
     setAgentPinnedMock.mockClear();
 
-    mockToolbarState = {
-      layout: {
-        // Mix of agent IDs and non-agent IDs so we can test both branches.
-        leftButtons: ["agent-tray", "claude", "gemini", "terminal"],
-        rightButtons: ["copy-tree", "settings"],
-        hiddenButtons: [],
-      },
-      launcher: { alwaysShowDevServer: false, defaultSelection: undefined },
-      setLeftButtons: setLeftButtonsMock,
-      setRightButtons: setRightButtonsMock,
-      toggleButtonVisibility: toggleButtonVisibilityMock,
-      setAlwaysShowDevServer: setAlwaysShowDevServerMock,
-      setDefaultSelection: setDefaultSelectionMock,
-      reset: resetMock,
-    };
-    mockAgentSettings = null;
+    setLayout({
+      // Mix of agent IDs and non-agent IDs so we can test both branches.
+      leftButtons: ["agent-tray", "claude", "gemini", "terminal"],
+      rightButtons: ["copy-tree", "settings"],
+      hiddenButtons: [],
+    });
+    toolbarState.launcher = { alwaysShowDevServer: false, defaultSelection: undefined };
+    setAgentSettings(null);
   });
 
   it("shows agent rows as checked when pinned in agentSettingsStore", () => {
-    mockAgentSettings = agentSettings({
-      claude: { pinned: true },
-      gemini: { pinned: false },
-    });
+    setAgentSettings(
+      agentSettings({
+        claude: { pinned: true },
+        gemini: { pinned: false },
+      })
+    );
 
     const { getByLabelText } = render(<ToolbarSettingsTab />);
 
@@ -174,10 +219,8 @@ describe("ToolbarSettingsTab — agent visibility routing", () => {
     // Stale entry from pre-migration persisted state — the UI must still
     // derive the agent's visibility from `agentSettingsStore`, not from
     // `hiddenButtons`.
-    mockToolbarState.layout.hiddenButtons = ["claude"];
-    mockAgentSettings = agentSettings({
-      claude: { pinned: true },
-    });
+    toolbarState.layout.hiddenButtons = ["claude"];
+    setAgentSettings(agentSettings({ claude: { pinned: true } }));
 
     const { getByLabelText } = render(<ToolbarSettingsTab />);
     const claudeCheckbox = getByLabelText("Toggle Claude Agent visibility") as HTMLInputElement;
@@ -185,9 +228,7 @@ describe("ToolbarSettingsTab — agent visibility routing", () => {
   });
 
   it("routes agent checkbox toggle to setAgentPinned (not toggleButtonVisibility)", () => {
-    mockAgentSettings = agentSettings({
-      claude: { pinned: true },
-    });
+    setAgentSettings(agentSettings({ claude: { pinned: true } }));
 
     const { getByLabelText } = render(<ToolbarSettingsTab />);
     fireEvent.click(getByLabelText("Toggle Claude Agent visibility"));
@@ -198,9 +239,7 @@ describe("ToolbarSettingsTab — agent visibility routing", () => {
   });
 
   it("routes agent checkbox toggle upward (unpinned → pinned) via setAgentPinned", () => {
-    mockAgentSettings = agentSettings({
-      gemini: { pinned: false },
-    });
+    setAgentSettings(agentSettings({ gemini: { pinned: false } }));
 
     const { getByLabelText } = render(<ToolbarSettingsTab />);
     fireEvent.click(getByLabelText("Toggle Gemini Agent visibility"));
@@ -219,10 +258,12 @@ describe("ToolbarSettingsTab — agent visibility routing", () => {
   });
 
   it("reflects pinned agents in the section visible-count summary", () => {
-    mockAgentSettings = agentSettings({
-      claude: { pinned: true },
-      gemini: { pinned: false },
-    });
+    setAgentSettings(
+      agentSettings({
+        claude: { pinned: true },
+        gemini: { pinned: false },
+      })
+    );
 
     const { getByTestId } = render(<ToolbarSettingsTab />);
     // Left side: agent-tray (visible), claude (pinned, visible),
@@ -232,7 +273,7 @@ describe("ToolbarSettingsTab — agent visibility routing", () => {
   });
 
   it("treats null agentSettings as all-unpinned without crashing", () => {
-    mockAgentSettings = null;
+    setAgentSettings(null);
 
     const { getByLabelText } = render(<ToolbarSettingsTab />);
     const claudeCheckbox = getByLabelText("Toggle Claude Agent visibility") as HTMLInputElement;
@@ -241,14 +282,12 @@ describe("ToolbarSettingsTab — agent visibility routing", () => {
 
   it("handles a right-side agent correctly (routes through setAgentPinned)", () => {
     // Relocate codex to the right side — an unlikely but possible layout.
-    mockToolbarState.layout = {
+    setLayout({
       leftButtons: ["agent-tray", "terminal"],
       rightButtons: ["codex", "settings"],
       hiddenButtons: [],
-    };
-    mockAgentSettings = agentSettings({
-      codex: { pinned: true },
     });
+    setAgentSettings(agentSettings({ codex: { pinned: true } }));
 
     const { getByLabelText } = render(<ToolbarSettingsTab />);
     fireEvent.click(getByLabelText("Toggle Codex Agent visibility"));

--- a/src/components/__tests__/agentPinSync.integration.test.tsx
+++ b/src/components/__tests__/agentPinSync.integration.test.tsx
@@ -27,14 +27,20 @@ const dispatchMock = vi.fn();
 const refreshAvailabilityMock = vi.fn().mockResolvedValue(undefined);
 const toggleButtonVisibilityMock = vi.fn();
 
-vi.mock("@/store/agentSettingsStore", () => ({
-  useAgentSettingsStore: (
-    selector: (s: {
-      settings: AgentSettings | null;
-      setAgentPinned: typeof setAgentPinnedMock;
-    }) => unknown
-  ) => selector({ settings: sharedSettings, setAgentPinned: setAgentPinnedMock }),
-}));
+vi.mock("@/store/agentSettingsStore", () => {
+  type Slice = {
+    settings: AgentSettings | null;
+    setAgentPinned: typeof setAgentPinnedMock;
+  };
+  const getSlice = (): Slice => ({
+    settings: sharedSettings,
+    setAgentPinned: setAgentPinnedMock,
+  });
+  type Hook = ((selector: (s: Slice) => unknown) => unknown) & { getState: () => Slice };
+  const hook = ((selector: (s: Slice) => unknown) => selector(getSlice())) as Hook;
+  hook.getState = getSlice;
+  return { useAgentSettingsStore: hook };
+});
 
 vi.mock("@/store/actionMruStore", () => ({
   useActionMruStore: (
@@ -156,30 +162,32 @@ let sharedToolbarLayout = {
 };
 const sharedToolbarLauncher = { alwaysShowDevServer: false, defaultSelection: undefined };
 
-vi.mock("@/store", () => ({
-  useToolbarPreferencesStore: (
-    selector: (s: {
-      layout: typeof sharedToolbarLayout;
-      launcher: typeof sharedToolbarLauncher;
-      setLeftButtons: () => void;
-      setRightButtons: () => void;
-      toggleButtonVisibility: typeof toggleButtonVisibilityMock;
-      setAlwaysShowDevServer: () => void;
-      setDefaultSelection: () => void;
-      reset: () => void;
-    }) => unknown
-  ) =>
-    selector({
-      layout: sharedToolbarLayout,
-      launcher: sharedToolbarLauncher,
-      setLeftButtons: vi.fn(),
-      setRightButtons: vi.fn(),
-      toggleButtonVisibility: toggleButtonVisibilityMock,
-      setAlwaysShowDevServer: vi.fn(),
-      setDefaultSelection: vi.fn(),
-      reset: vi.fn(),
-    }),
-}));
+vi.mock("@/store", () => {
+  type Slice = {
+    layout: typeof sharedToolbarLayout;
+    launcher: typeof sharedToolbarLauncher;
+    setLeftButtons: () => void;
+    setRightButtons: () => void;
+    toggleButtonVisibility: typeof toggleButtonVisibilityMock;
+    setAlwaysShowDevServer: () => void;
+    setDefaultSelection: () => void;
+    reset: () => void;
+  };
+  const getSlice = (): Slice => ({
+    layout: sharedToolbarLayout,
+    launcher: sharedToolbarLauncher,
+    setLeftButtons: vi.fn(),
+    setRightButtons: vi.fn(),
+    toggleButtonVisibility: toggleButtonVisibilityMock,
+    setAlwaysShowDevServer: vi.fn(),
+    setDefaultSelection: vi.fn(),
+    reset: vi.fn(),
+  });
+  type Hook = ((selector: (s: Slice) => unknown) => unknown) & { getState: () => Slice };
+  const hook = ((selector: (s: Slice) => unknown) => selector(getSlice())) as Hook;
+  hook.getState = getSlice;
+  return { useToolbarPreferencesStore: hook };
+});
 
 vi.mock("@/hooks/usePluginToolbarButtons", () => ({
   usePluginToolbarButtons: () => ({ buttonIds: [], configs: new Map() }),

--- a/src/hooks/__tests__/useUnifiedToolbarVisibility.test.tsx
+++ b/src/hooks/__tests__/useUnifiedToolbarVisibility.test.tsx
@@ -1,0 +1,180 @@
+// @vitest-environment jsdom
+import { describe, it, expect, vi, beforeEach } from "vitest";
+import { renderHook, act } from "@testing-library/react";
+import type { AgentSettings } from "@shared/types";
+
+const hoisted = vi.hoisted(() => {
+  const setAgentPinnedMock = vi.fn().mockResolvedValue(undefined);
+  const toggleButtonVisibilityMock = vi.fn();
+  const refs: {
+    toolbar: {
+      layout: { hiddenButtons: string[] };
+      toggleButtonVisibility: typeof toggleButtonVisibilityMock;
+    };
+    agent: { settings: AgentSettings | null; setAgentPinned: typeof setAgentPinnedMock };
+  } = {
+    toolbar: {
+      layout: { hiddenButtons: [] },
+      toggleButtonVisibility: toggleButtonVisibilityMock,
+    },
+    agent: { settings: null, setAgentPinned: setAgentPinnedMock },
+  };
+
+  type ToolbarHook = ((selector: (s: typeof refs.toolbar) => unknown) => unknown) & {
+    getState: () => typeof refs.toolbar;
+  };
+  const toolbarHook = ((selector: (s: typeof refs.toolbar) => unknown) =>
+    selector(refs.toolbar)) as ToolbarHook;
+  toolbarHook.getState = () => refs.toolbar;
+
+  type AgentHook = ((selector: (s: typeof refs.agent) => unknown) => unknown) & {
+    getState: () => typeof refs.agent;
+  };
+  const agentHook = ((selector: (s: typeof refs.agent) => unknown) =>
+    selector(refs.agent)) as AgentHook;
+  agentHook.getState = () => refs.agent;
+
+  return { setAgentPinnedMock, toggleButtonVisibilityMock, refs, toolbarHook, agentHook };
+});
+
+const { setAgentPinnedMock, toggleButtonVisibilityMock, refs } = hoisted;
+
+vi.mock("@/store", () => ({
+  useToolbarPreferencesStore: hoisted.toolbarHook,
+}));
+
+vi.mock("@/store/agentSettingsStore", () => ({
+  useAgentSettingsStore: hoisted.agentHook,
+}));
+
+vi.mock("@shared/config/agentIds", () => ({
+  BUILT_IN_AGENT_IDS: ["claude", "gemini", "codex"] as const,
+}));
+
+import { useUnifiedToolbarVisibility } from "../useUnifiedToolbarVisibility";
+
+function agentSettings(overrides: Record<string, { pinned?: boolean }>): AgentSettings {
+  return { agents: overrides } as unknown as AgentSettings;
+}
+
+function setAgentSettings(s: AgentSettings | null) {
+  refs.agent.settings = s;
+}
+
+function setHiddenButtons(ids: string[]) {
+  refs.toolbar.layout = { hiddenButtons: ids };
+}
+
+describe("useUnifiedToolbarVisibility", () => {
+  beforeEach(() => {
+    setAgentPinnedMock.mockClear();
+    toggleButtonVisibilityMock.mockClear();
+    setAgentSettings(null);
+    setHiddenButtons([]);
+  });
+
+  describe("isEffectivelyVisible", () => {
+    it("reads agent IDs from agentSettings.pinned", () => {
+      setAgentSettings(
+        agentSettings({
+          claude: { pinned: true },
+          gemini: { pinned: false },
+        })
+      );
+      const { result } = renderHook(() => useUnifiedToolbarVisibility());
+
+      expect(result.current.isEffectivelyVisible("claude")).toBe(true);
+      expect(result.current.isEffectivelyVisible("gemini")).toBe(false);
+    });
+
+    it("ignores hiddenButtons for agent IDs (agentSettingsStore wins)", () => {
+      setHiddenButtons(["claude"]);
+      setAgentSettings(agentSettings({ claude: { pinned: true } }));
+      const { result } = renderHook(() => useUnifiedToolbarVisibility());
+
+      expect(result.current.isEffectivelyVisible("claude")).toBe(true);
+    });
+
+    it("reads non-agent IDs from hiddenButtons", () => {
+      setHiddenButtons(["terminal"]);
+      const { result } = renderHook(() => useUnifiedToolbarVisibility());
+
+      expect(result.current.isEffectivelyVisible("terminal")).toBe(false);
+      expect(result.current.isEffectivelyVisible("browser")).toBe(true);
+    });
+
+    it("treats null agentSettings as all-unpinned", () => {
+      setAgentSettings(null);
+      const { result } = renderHook(() => useUnifiedToolbarVisibility());
+
+      expect(result.current.isEffectivelyVisible("claude")).toBe(false);
+      expect(result.current.isEffectivelyVisible("agent-tray")).toBe(true);
+    });
+
+    it("treats missing pinned field as not visible (opt-in semantics)", () => {
+      setAgentSettings(agentSettings({ codex: {} }));
+      const { result } = renderHook(() => useUnifiedToolbarVisibility());
+
+      expect(result.current.isEffectivelyVisible("codex")).toBe(false);
+    });
+  });
+
+  describe("toggleVisibility", () => {
+    it("routes agent toggles through setAgentPinned, not toggleButtonVisibility", () => {
+      setAgentSettings(agentSettings({ claude: { pinned: true } }));
+      const { result } = renderHook(() => useUnifiedToolbarVisibility());
+
+      act(() => result.current.toggleVisibility("claude", "left"));
+
+      expect(setAgentPinnedMock).toHaveBeenCalledTimes(1);
+      expect(setAgentPinnedMock).toHaveBeenCalledWith("claude", false);
+      expect(toggleButtonVisibilityMock).not.toHaveBeenCalled();
+    });
+
+    it("flips agent from unpinned to pinned", () => {
+      setAgentSettings(agentSettings({ gemini: { pinned: false } }));
+      const { result } = renderHook(() => useUnifiedToolbarVisibility());
+
+      act(() => result.current.toggleVisibility("gemini", "left"));
+
+      expect(setAgentPinnedMock).toHaveBeenCalledWith("gemini", true);
+    });
+
+    it("routes non-agent toggles through toggleButtonVisibility with side", () => {
+      const { result } = renderHook(() => useUnifiedToolbarVisibility());
+
+      act(() => result.current.toggleVisibility("terminal", "left"));
+      act(() => result.current.toggleVisibility("settings", "right"));
+
+      expect(toggleButtonVisibilityMock).toHaveBeenCalledTimes(2);
+      expect(toggleButtonVisibilityMock).toHaveBeenNthCalledWith(1, "terminal", "left");
+      expect(toggleButtonVisibilityMock).toHaveBeenNthCalledWith(2, "settings", "right");
+      expect(setAgentPinnedMock).not.toHaveBeenCalled();
+    });
+
+    it("reads pinned state via getState (not the render-time closure)", () => {
+      // Render with claude unpinned. Before toggling, mutate the store so the
+      // closure-captured value diverges from the latest state. The toggle
+      // must read the fresh value to flip correctly.
+      setAgentSettings(agentSettings({ claude: { pinned: false } }));
+      const { result } = renderHook(() => useUnifiedToolbarVisibility());
+
+      setAgentSettings(agentSettings({ claude: { pinned: true } }));
+
+      act(() => result.current.toggleVisibility("claude", "left"));
+
+      // With fresh read, pinned: true → flip to false. A stale closure read
+      // would flip from false → true (wrong).
+      expect(setAgentPinnedMock).toHaveBeenCalledWith("claude", false);
+    });
+
+    it("treats agent-tray as a non-agent button (routes through toggleButtonVisibility)", () => {
+      const { result } = renderHook(() => useUnifiedToolbarVisibility());
+
+      act(() => result.current.toggleVisibility("agent-tray", "left"));
+
+      expect(toggleButtonVisibilityMock).toHaveBeenCalledWith("agent-tray", "left");
+      expect(setAgentPinnedMock).not.toHaveBeenCalled();
+    });
+  });
+});

--- a/src/hooks/useUnifiedToolbarVisibility.ts
+++ b/src/hooks/useUnifiedToolbarVisibility.ts
@@ -1,0 +1,45 @@
+import { useCallback } from "react";
+import { useToolbarPreferencesStore } from "@/store";
+import { useAgentSettingsStore } from "@/store/agentSettingsStore";
+import { BUILT_IN_AGENT_IDS } from "@shared/config/agentIds";
+import { isAgentPinnedById } from "../../shared/utils/agentPinned";
+import type { AnyToolbarButtonId } from "@/../../shared/types/toolbar";
+
+export const AGENT_ID_SET: ReadonlySet<string> = new Set(BUILT_IN_AGENT_IDS);
+
+export interface UnifiedToolbarVisibility {
+  isEffectivelyVisible: (buttonId: AnyToolbarButtonId) => boolean;
+  toggleVisibility: (buttonId: AnyToolbarButtonId, side: "left" | "right") => void;
+}
+
+/**
+ * Unifies visibility reads/writes across the two toolbar configuration sources:
+ * agent IDs route through `agentSettingsStore.pinned` (IPC-persisted, async);
+ * everything else routes through `toolbarPreferencesStore.hiddenButtons` (synchronous,
+ * localStorage). Toggle handlers call `getState()` so they don't capture stale
+ * closures across async IPC settles.
+ */
+export function useUnifiedToolbarVisibility(): UnifiedToolbarVisibility {
+  const agentSettings = useAgentSettingsStore((s) => s.settings);
+  const hiddenButtons = useToolbarPreferencesStore((s) => s.layout.hiddenButtons);
+
+  const isEffectivelyVisible = useCallback(
+    (buttonId: AnyToolbarButtonId) => {
+      if (AGENT_ID_SET.has(buttonId)) return isAgentPinnedById(agentSettings, buttonId);
+      return !hiddenButtons.includes(buttonId);
+    },
+    [agentSettings, hiddenButtons]
+  );
+
+  const toggleVisibility = useCallback((buttonId: AnyToolbarButtonId, side: "left" | "right") => {
+    if (AGENT_ID_SET.has(buttonId)) {
+      const current = useAgentSettingsStore.getState().settings;
+      const nextPinned = !isAgentPinnedById(current, buttonId);
+      void useAgentSettingsStore.getState().setAgentPinned(buttonId, nextPinned);
+      return;
+    }
+    useToolbarPreferencesStore.getState().toggleButtonVisibility(buttonId, side);
+  }, []);
+
+  return { isEffectivelyVisible, toggleVisibility };
+}


### PR DESCRIPTION
## Summary

- Two parallel visibility systems (`useToolbarPreferencesStore.hiddenButtons` for non-agent buttons, `useAgentSettingsStore.pinned` for agents) are collapsed into a single source of truth
- `toolbarButtonMetadata.ts` canonicalizes labels, icons, and default visibility for all toolbar items — making icon drift like the `Plug`/`Puzzle` mismatch structurally impossible
- `useUnifiedToolbarVisibility` replaces the duplicated `isEffectivelyVisible` logic that lived independently in both `Toolbar.tsx` and `ToolbarSettingsTab.tsx`

Resolves #7666. Also folds in #7668 (agent-tray icon drift).

## Changes

- New `src/components/Layout/toolbarButtonMetadata.ts` — central registry (label, icon, default visibility) for all toolbar items
- New `src/hooks/useUnifiedToolbarVisibility.ts` — unified visibility hook consumed by both the toolbar and the settings tab
- `ToolbarSettingsTab.tsx` simplified significantly; no longer duplicates visibility logic
- `Toolbar.tsx` visibility logic pulled out in favour of the hook
- Existing user customizations (pinned agents, hidden buttons) migrate cleanly — no store shape changes

## Testing

- Updated unit tests for `ToolbarSettingsTab`, `useUnifiedToolbarVisibility`, and the agent registry integration
- Verified pinned-agent and hidden-button state round-trips correctly after the refactor
- Confirmed plugin-contributed toolbar buttons still work through the unified model