### PR TITLE
fix(worktree): remove fleet aggregate row from main worktree card

### DIFF
--- a/src/components/Worktree/WorktreeCard.tsx
+++ b/src/components/Worktree/WorktreeCard.tsx
@@ -77,7 +77,7 @@ export function WorktreeCard({
   isActive,
   isFocused,
   isSingleWorktree: _isSingleWorktree,
-  aggregateCounts,
+  aggregateCounts: _aggregateCounts,
   onSelect,
   onCopyTree,
   onOpenEditor,

--- a/src/components/Worktree/WorktreeCard.tsx
+++ b/src/components/Worktree/WorktreeCard.tsx
@@ -787,12 +787,7 @@ export function WorktreeCard({
                       wslGitEligible={worktree.wslGitEligible}
                     />
                   )}
-                  {isMainWorktree && (
-                    <MainWorktreeSummaryRows
-                      aggregateCounts={aggregateCounts}
-                      health={projectHealth ?? null}
-                    />
-                  )}
+                  {isMainWorktree && <MainWorktreeSummaryRows health={projectHealth ?? null} />}
 
                   <WorktreeDetailsSection
                     worktree={worktree}

--- a/src/components/Worktree/WorktreeCard/MainWorktreeSummaryRows.tsx
+++ b/src/components/Worktree/WorktreeCard/MainWorktreeSummaryRows.tsx
@@ -1,17 +1,7 @@
 import { memo } from "react";
 import type { ProjectHealthData } from "@shared/types";
-import { cn } from "@/lib/utils";
 import { Tooltip, TooltipContent, TooltipTrigger } from "../../ui/tooltip";
-import { STATE_ICONS, STATE_COLORS } from "../terminalStateConfig";
-import {
-  GitBranch,
-  CheckCircle2,
-  XCircle,
-  Clock,
-  CircleMinus,
-  GitPullRequest,
-  CircleDot,
-} from "lucide-react";
+import { CheckCircle2, XCircle, Clock, CircleMinus, GitPullRequest, CircleDot } from "lucide-react";
 
 export interface AggregateCounts {
   worktrees: number;
@@ -21,13 +11,8 @@ export interface AggregateCounts {
 }
 
 interface MainWorktreeSummaryRowsProps {
-  aggregateCounts?: AggregateCounts;
   health: ProjectHealthData | null;
 }
-
-const WorkingIcon = STATE_ICONS.working;
-const WaitingIcon = STATE_ICONS.waiting;
-const CompletedIcon = STATE_ICONS.completed;
 
 function ciStatusIcon(status: ProjectHealthData["ciStatus"]) {
   switch (status) {
@@ -61,94 +46,38 @@ function ciStatusLabel(status: ProjectHealthData["ciStatus"]): string {
 }
 
 export const MainWorktreeSummaryRows = memo(function MainWorktreeSummaryRows({
-  aggregateCounts,
   health,
 }: MainWorktreeSummaryRowsProps) {
-  const hasWorktrees = aggregateCounts && aggregateCounts.worktrees > 0;
-  const hasHealth = health !== null;
-
-  if (!hasWorktrees && !hasHealth) return null;
+  if (!health) return null;
 
   return (
     <div className="flex flex-col gap-1 mt-2" data-testid="main-worktree-summary">
-      {hasWorktrees && (
-        <Tooltip>
-          <TooltipTrigger asChild>
-            <div
-              className="flex items-center gap-2 text-[10px] text-daintree-text/60"
-              data-testid="aggregate-worktree-row"
-            >
-              <span className="flex items-center gap-0.5">
-                <GitBranch className="w-2.5 h-2.5" />
-                <span className="font-mono tabular-nums">{aggregateCounts.worktrees}</span>
-              </span>
-              {aggregateCounts.working > 0 && (
-                <span className={cn("flex items-center gap-0.5", STATE_COLORS.working)}>
-                  <WorkingIcon className="w-2.5 h-2.5 animate-spin-slow motion-reduce:animate-none" />
-                  <span className="font-mono tabular-nums">{aggregateCounts.working}</span>
-                </span>
-              )}
-              {aggregateCounts.waiting > 0 && (
-                <span className={cn("flex items-center gap-0.5", STATE_COLORS.waiting)}>
-                  <WaitingIcon className="w-2.5 h-2.5" />
-                  <span className="font-mono tabular-nums">{aggregateCounts.waiting}</span>
-                </span>
-              )}
-              {aggregateCounts.finished > 0 &&
-                aggregateCounts.working === 0 &&
-                aggregateCounts.waiting === 0 && (
-                  <span className={cn("flex items-center gap-0.5", STATE_COLORS.completed)}>
-                    <CompletedIcon className="w-2.5 h-2.5" />
-                    <span className="font-mono tabular-nums">{aggregateCounts.finished}</span>
-                  </span>
-                )}
-            </div>
-          </TooltipTrigger>
-          <TooltipContent side="right" className="text-xs">
-            {aggregateCounts.worktrees} worktree
-            {aggregateCounts.worktrees !== 1 ? "s" : ""}
-            {(aggregateCounts.working > 0 ||
-              aggregateCounts.waiting > 0 ||
-              aggregateCounts.finished > 0) &&
-              " — "}
-            {[
-              aggregateCounts.working > 0 && `${aggregateCounts.working} working`,
-              aggregateCounts.waiting > 0 && `${aggregateCounts.waiting} waiting`,
-              aggregateCounts.finished > 0 && `${aggregateCounts.finished} done`,
-            ]
-              .filter(Boolean)
-              .join(", ")}
-          </TooltipContent>
-        </Tooltip>
-      )}
-      {hasHealth && (
-        <Tooltip>
-          <TooltipTrigger asChild>
-            <div
-              className="flex items-center gap-2 text-[10px] text-daintree-text/60"
-              data-testid="github-pulse-row"
-            >
-              <span className="flex items-center gap-0.5">
-                {ciStatusIcon(health.ciStatus)}
-                <span className="font-mono tabular-nums">{ciStatusLabel(health.ciStatus)}</span>
-              </span>
-              <span className="flex items-center gap-0.5">
-                <GitPullRequest className="w-2.5 h-2.5" />
-                <span className="font-mono tabular-nums">{health.prCount}</span>
-              </span>
-              <span className="flex items-center gap-0.5">
-                <CircleDot className="w-2.5 h-2.5 text-github-open" />
-                <span className="font-mono tabular-nums">{health.issueCount}</span>
-              </span>
-            </div>
-          </TooltipTrigger>
-          <TooltipContent side="right" className="text-xs">
-            CI: {ciStatusLabel(health.ciStatus)} · {health.prCount} open PR
-            {health.prCount !== 1 ? "s" : ""} · {health.issueCount} open issue
-            {health.issueCount !== 1 ? "s" : ""}
-          </TooltipContent>
-        </Tooltip>
-      )}
+      <Tooltip>
+        <TooltipTrigger asChild>
+          <div
+            className="flex items-center gap-2 text-[10px] text-daintree-text/60"
+            data-testid="github-pulse-row"
+          >
+            <span className="flex items-center gap-0.5">
+              {ciStatusIcon(health.ciStatus)}
+              <span className="font-mono tabular-nums">{ciStatusLabel(health.ciStatus)}</span>
+            </span>
+            <span className="flex items-center gap-0.5">
+              <GitPullRequest className="w-2.5 h-2.5" />
+              <span className="font-mono tabular-nums">{health.prCount}</span>
+            </span>
+            <span className="flex items-center gap-0.5">
+              <CircleDot className="w-2.5 h-2.5 text-github-open" />
+              <span className="font-mono tabular-nums">{health.issueCount}</span>
+            </span>
+          </div>
+        </TooltipTrigger>
+        <TooltipContent side="right" className="text-xs">
+          CI: {ciStatusLabel(health.ciStatus)} · {health.prCount} open PR
+          {health.prCount !== 1 ? "s" : ""} · {health.issueCount} open issue
+          {health.issueCount !== 1 ? "s" : ""}
+        </TooltipContent>
+      </Tooltip>
     </div>
   );
 });

--- a/src/components/Worktree/WorktreeCard/__tests__/MainWorktreeSummaryRows.test.tsx
+++ b/src/components/Worktree/WorktreeCard/__tests__/MainWorktreeSummaryRows.test.tsx
@@ -4,7 +4,7 @@
 import { describe, it, expect, vi } from "vitest";
 import { render, screen } from "@testing-library/react";
 import type { ReactNode } from "react";
-import { MainWorktreeSummaryRows, type AggregateCounts } from "../MainWorktreeSummaryRows";
+import { MainWorktreeSummaryRows } from "../MainWorktreeSummaryRows";
 import type { ProjectHealthData } from "@shared/types";
 import { TooltipProvider } from "@/components/ui/tooltip";
 
@@ -16,13 +16,6 @@ vi.mock("react-dom", async () => {
 function renderWithTooltip(ui: ReactNode) {
   return render(<TooltipProvider>{ui}</TooltipProvider>);
 }
-
-const baseCounts: AggregateCounts = {
-  worktrees: 5,
-  working: 2,
-  waiting: 1,
-  finished: 1,
-};
 
 const baseHealth: ProjectHealthData = {
   ciStatus: "success",
@@ -37,47 +30,13 @@ const baseHealth: ProjectHealthData = {
 };
 
 describe("MainWorktreeSummaryRows", () => {
-  it("renders nothing when no aggregateCounts and no health", () => {
-    renderWithTooltip(<MainWorktreeSummaryRows aggregateCounts={undefined} health={null} />);
+  it("renders nothing when health is null", () => {
+    renderWithTooltip(<MainWorktreeSummaryRows health={null} />);
     expect(screen.queryByTestId("main-worktree-summary")).toBeNull();
-  });
-
-  it("renders nothing when worktrees is 0 and no health", () => {
-    renderWithTooltip(
-      <MainWorktreeSummaryRows
-        aggregateCounts={{ worktrees: 0, working: 0, waiting: 0, finished: 0 }}
-        health={null}
-      />
-    );
-    expect(screen.queryByTestId("main-worktree-summary")).toBeNull();
-  });
-
-  it("renders worktree count and working/waiting agent counts", () => {
-    renderWithTooltip(<MainWorktreeSummaryRows aggregateCounts={baseCounts} health={null} />);
-    const row = screen.getByTestId("aggregate-worktree-row");
-    expect(row).toBeTruthy();
-    expect(row.textContent).toContain("5");
-    expect(row.textContent).toContain("2");
-    expect(row.textContent).toContain("1");
-  });
-
-  it("shows finished count only when working and waiting are both 0", () => {
-    const counts: AggregateCounts = { worktrees: 3, working: 0, waiting: 0, finished: 3 };
-    renderWithTooltip(<MainWorktreeSummaryRows aggregateCounts={counts} health={null} />);
-    const row = screen.getByTestId("aggregate-worktree-row");
-    expect(row.textContent).toContain("3");
-  });
-
-  it("hides finished count when working or waiting are active", () => {
-    renderWithTooltip(<MainWorktreeSummaryRows aggregateCounts={baseCounts} health={null} />);
-    const row = screen.getByTestId("aggregate-worktree-row");
-    const spans = row.querySelectorAll("span.font-mono");
-    const texts = Array.from(spans).map((s) => s.textContent);
-    expect(texts).toEqual(["5", "2", "1"]);
   });
 
   it("renders GitHub pulse row with CI success", () => {
-    renderWithTooltip(<MainWorktreeSummaryRows aggregateCounts={undefined} health={baseHealth} />);
+    renderWithTooltip(<MainWorktreeSummaryRows health={baseHealth} />);
     const row = screen.getByTestId("github-pulse-row");
     expect(row.textContent).toContain("passing");
     expect(row.textContent).toContain("3");
@@ -86,33 +45,33 @@ describe("MainWorktreeSummaryRows", () => {
 
   it("renders CI failure status", () => {
     const health: ProjectHealthData = { ...baseHealth, ciStatus: "failure" };
-    renderWithTooltip(<MainWorktreeSummaryRows aggregateCounts={undefined} health={health} />);
+    renderWithTooltip(<MainWorktreeSummaryRows health={health} />);
     const row = screen.getByTestId("github-pulse-row");
     expect(row.textContent).toContain("failing");
   });
 
   it("renders CI pending status", () => {
     const health: ProjectHealthData = { ...baseHealth, ciStatus: "pending" };
-    renderWithTooltip(<MainWorktreeSummaryRows aggregateCounts={undefined} health={health} />);
+    renderWithTooltip(<MainWorktreeSummaryRows health={health} />);
     const row = screen.getByTestId("github-pulse-row");
     expect(row.textContent).toContain("pending");
   });
 
   it("renders CI none status", () => {
     const health: ProjectHealthData = { ...baseHealth, ciStatus: "none" };
-    renderWithTooltip(<MainWorktreeSummaryRows aggregateCounts={undefined} health={health} />);
+    renderWithTooltip(<MainWorktreeSummaryRows health={health} />);
     const row = screen.getByTestId("github-pulse-row");
     expect(row.textContent).toContain("no CI");
   });
 
-  it("renders both rows when both data sources are present", () => {
-    renderWithTooltip(<MainWorktreeSummaryRows aggregateCounts={baseCounts} health={baseHealth} />);
-    expect(screen.getByTestId("aggregate-worktree-row")).toBeTruthy();
+  it("renders GitHub health row when health data is present", () => {
+    renderWithTooltip(<MainWorktreeSummaryRows health={baseHealth} />);
+    expect(screen.queryByTestId("aggregate-worktree-row")).toBeNull();
     expect(screen.getByTestId("github-pulse-row")).toBeTruthy();
   });
 
   it("uses tabular-nums for numeric displays", () => {
-    renderWithTooltip(<MainWorktreeSummaryRows aggregateCounts={baseCounts} health={baseHealth} />);
+    renderWithTooltip(<MainWorktreeSummaryRows health={baseHealth} />);
     const container = screen.getByTestId("main-worktree-summary");
     const monoSpans = container.querySelectorAll(".tabular-nums");
     expect(monoSpans.length).toBeGreaterThan(0);


### PR DESCRIPTION
## Summary

This is a small cleanup. The main worktree card was showing a fleet-wide agent aggregate row that counted working, waiting, and finished agents across all non-main worktrees. Each worktree is its own space, so cramming fleet-level agent counts into the root workspace's card mixed two unrelated concerns.

The `QuickStateFilterBar` below the pinned worktrees already surfaces the same counts, so this row was redundant. Now `MainWorktreeSummaryRows` only renders the GitHub health row: CI status, open PRs, and open issues for the main repo.

Resolves #7693

## Changes

- Removed the `aggregateCounts` prop from `MainWorktreeSummaryRows` and stripped the fleet-aggregate row
- Updated `WorktreeCard` to pass only `health` to `MainWorktreeSummaryRows`
- Cleaned up now-unused imports (`GitBranch`, `STATE_ICONS`, `STATE_COLORS`, `cn`)
- Prefixed the unused `aggregateCounts` param in `WorktreeCard` with `_` to satisfy `noUnusedParameters`
- Updated tests to reflect the single-row output

## Testing

- Ran the full worktree test suite -- all `MainWorktreeSummaryRows` tests pass
- The GitHub health row (CI status, PR count, issue count) renders correctly when health data is present
- The component returns null when no health data is available