### PR TITLE
fix(agent): expose location guidance and resolved placement in MCP tool surface

### DIFF
--- a/src/hooks/useAgentLauncher.ts
+++ b/src/hooks/useAgentLauncher.ts
@@ -81,7 +81,10 @@ export interface LaunchAgentOptions {
 }
 
 export interface UseAgentLauncherReturn {
-  launchAgent: (agentId: string, options?: LaunchAgentOptions) => Promise<string | null>;
+  launchAgent: (
+    agentId: string,
+    options?: LaunchAgentOptions
+  ) => Promise<{ terminalId: string; location: "grid" | "dock" } | null>;
   availability: CliAvailability;
   isCheckingAvailability: boolean;
   agentSettings: AgentSettings | null;
@@ -199,7 +202,10 @@ export function useAgentLauncher(): UseAgentLauncherReturn {
   }, [initializeCliAvailability, refreshCliAvailability]);
 
   const launchAgent = useCallback(
-    async (agentId: string, launchOptions?: LaunchAgentOptions): Promise<string | null> => {
+    async (
+      agentId: string,
+      launchOptions?: LaunchAgentOptions
+    ): Promise<{ terminalId: string; location: "grid" | "dock" } | null> => {
       if (!isElectronAvailable()) {
         console.warn("Electron API not available");
         return null;
@@ -239,7 +245,10 @@ export function useAgentLauncher(): UseAgentLauncherReturn {
               activateDockOnCreate: launchOptions?.activateDockOnCreate,
               spawnedBy: launchOptions?.spawnedBy,
             });
-            return terminalId;
+            if (!terminalId) return null;
+            const location = (usePanelStore.getState().panelsById[terminalId]?.location ??
+              "grid") as "grid" | "dock";
+            return { terminalId, location };
           } catch (error) {
             logError("Failed to launch browser pane", error);
             return null;
@@ -258,7 +267,10 @@ export function useAgentLauncher(): UseAgentLauncherReturn {
               activateDockOnCreate: launchOptions?.activateDockOnCreate,
               spawnedBy: launchOptions?.spawnedBy,
             });
-            return terminalId;
+            if (!terminalId) return null;
+            const location = (usePanelStore.getState().panelsById[terminalId]?.location ??
+              "grid") as "grid" | "dock";
+            return { terminalId, location };
           } catch (error) {
             logError("Failed to launch dev-preview pane", error);
             return null;
@@ -529,13 +541,17 @@ export function useAgentLauncher(): UseAgentLauncherReturn {
               }
               return next;
             });
-            return gateId;
+            return { terminalId: gateId, location: gatePanel.location as "grid" | "dock" };
           }
         }
 
         try {
           const terminalId = await addPanel(options);
-          return terminalId;
+          if (!terminalId) return null;
+          const location = (usePanelStore.getState().panelsById[terminalId]?.location ?? "grid") as
+            | "grid"
+            | "dock";
+          return { terminalId, location };
         } catch (error) {
           logError(`Failed to launch ${agentId} agent`, error);
           return null;

--- a/src/hooks/useAgentLauncher.ts
+++ b/src/hooks/useAgentLauncher.ts
@@ -246,8 +246,8 @@ export function useAgentLauncher(): UseAgentLauncherReturn {
               spawnedBy: launchOptions?.spawnedBy,
             });
             if (!terminalId) return null;
-            const location = (usePanelStore.getState().panelsById[terminalId]?.location ??
-              "grid") as "grid" | "dock";
+            const rawLocation = usePanelStore.getState().panelsById[terminalId]?.location ?? "grid";
+            const location = rawLocation === "dock" ? "dock" : "grid";
             return { terminalId, location };
           } catch (error) {
             logError("Failed to launch browser pane", error);
@@ -268,8 +268,8 @@ export function useAgentLauncher(): UseAgentLauncherReturn {
               spawnedBy: launchOptions?.spawnedBy,
             });
             if (!terminalId) return null;
-            const location = (usePanelStore.getState().panelsById[terminalId]?.location ??
-              "grid") as "grid" | "dock";
+            const rawLocation = usePanelStore.getState().panelsById[terminalId]?.location ?? "grid";
+            const location = rawLocation === "dock" ? "dock" : "grid";
             return { terminalId, location };
           } catch (error) {
             logError("Failed to launch dev-preview pane", error);
@@ -541,16 +541,18 @@ export function useAgentLauncher(): UseAgentLauncherReturn {
               }
               return next;
             });
-            return { terminalId: gateId, location: gatePanel.location as "grid" | "dock" };
+            return {
+              terminalId: gateId,
+              location: gatePanel.location === "dock" ? "dock" : "grid",
+            };
           }
         }
 
         try {
           const terminalId = await addPanel(options);
           if (!terminalId) return null;
-          const location = (usePanelStore.getState().panelsById[terminalId]?.location ?? "grid") as
-            | "grid"
-            | "dock";
+          const rawLocation = usePanelStore.getState().panelsById[terminalId]?.location ?? "grid";
+          const location = rawLocation === "dock" ? "dock" : "grid";
           return { terminalId, location };
         } catch (error) {
           logError(`Failed to launch ${agentId} agent`, error);

--- a/src/services/actions/actionTypes.ts
+++ b/src/services/actions/actionTypes.ts
@@ -64,7 +64,7 @@ export interface ActionCallbacks {
       agentLaunchFlags?: string[];
       spawnedBy?: TerminalSpawnSource;
     }
-  ) => Promise<string | null>;
+  ) => Promise<{ terminalId: string; location: "grid" | "dock" } | null>;
   onInject: (worktreeId: string) => void;
   getDefaultCwd: () => string;
   getActiveWorktreeId: () => string | undefined;

--- a/src/services/actions/definitions/__tests__/agentActions.adversarial.test.ts
+++ b/src/services/actions/definitions/__tests__/agentActions.adversarial.test.ts
@@ -33,7 +33,7 @@ import { registerAgentActions } from "../agentActions";
 
 function makeCallbacks() {
   return {
-    onLaunchAgent: vi.fn().mockResolvedValue("term-1"),
+    onLaunchAgent: vi.fn().mockResolvedValue({ terminalId: "term-1", location: "grid" }),
     onOpenQuickSwitcher: vi.fn(),
   } as unknown as ActionCallbacks & {
     onLaunchAgent: ReturnType<typeof vi.fn>;
@@ -113,7 +113,7 @@ describe("agentActions adversarial", () => {
       interactive: true,
       modelId: "gpt-5",
     });
-    expect(result).toEqual({ terminalId: "term-1" });
+    expect(result).toEqual({ terminalId: "term-1", location: "grid" });
   });
 
   it("one agent.<id> action is registered per AGENT_REGISTRY entry", () => {
@@ -133,9 +133,18 @@ describe("agentActions adversarial", () => {
     await callAction(actions, "agent.codex");
     await callAction(actions, "agent.terminal");
 
-    expect(callbacks.onLaunchAgent).toHaveBeenNthCalledWith(1, "claude");
-    expect(callbacks.onLaunchAgent).toHaveBeenNthCalledWith(2, "codex");
-    expect(callbacks.onLaunchAgent).toHaveBeenNthCalledWith(3, "terminal");
+    expect(callbacks.onLaunchAgent).toHaveBeenNthCalledWith(1, "claude", {
+      location: undefined,
+      spawnedBy: undefined,
+    });
+    expect(callbacks.onLaunchAgent).toHaveBeenNthCalledWith(2, "codex", {
+      location: undefined,
+      spawnedBy: undefined,
+    });
+    expect(callbacks.onLaunchAgent).toHaveBeenNthCalledWith(3, "terminal", {
+      location: undefined,
+      spawnedBy: undefined,
+    });
   });
 
   it("agent.palette only opens the quick switcher and does not launch", async () => {
@@ -442,7 +451,7 @@ describe("agent.launch dispatch integration", () => {
 
     expect(result.ok).toBe(true);
     if (result.ok) {
-      expect(result.result).toEqual({ terminalId: "term-1" });
+      expect(result.result).toEqual({ terminalId: "term-1", location: "grid" });
     }
     expect(callbacks.onLaunchAgent).toHaveBeenCalledWith("claude", {
       location: "grid",

--- a/src/services/actions/definitions/__tests__/workflowActions.adversarial.test.ts
+++ b/src/services/actions/definitions/__tests__/workflowActions.adversarial.test.ts
@@ -60,7 +60,7 @@ interface MockCallbacks {
 
 function makeCallbacks(): MockCallbacks & Pick<ActionCallbacks, "onLaunchAgent"> {
   return {
-    onLaunchAgent: vi.fn().mockResolvedValue("term-1"),
+    onLaunchAgent: vi.fn().mockResolvedValue({ terminalId: "term-1", location: "grid" }),
   };
 }
 

--- a/src/services/actions/definitions/agentActions.ts
+++ b/src/services/actions/definitions/agentActions.ts
@@ -12,7 +12,7 @@ export function registerAgentActions(actions: ActionRegistry, callbacks: ActionC
     id: "agent.launch",
     title: "Launch Agent",
     description:
-      "Launch an AI agent in a new terminal. Returns terminalId and the resolved location (grid or dock — defaults to grid unless overridden or grid is at capacity). For multiple agents, call sequentially (one per turn) — never in parallel.",
+      "Launch an AI agent in a new terminal. Returns terminalId and location. Call sequentially — never in parallel.",
     category: "agent",
     kind: "command",
     danger: "safe",

--- a/src/services/actions/definitions/agentActions.ts
+++ b/src/services/actions/definitions/agentActions.ts
@@ -12,7 +12,7 @@ export function registerAgentActions(actions: ActionRegistry, callbacks: ActionC
     id: "agent.launch",
     title: "Launch Agent",
     description:
-      "Launch an AI agent in a new terminal. For multiple agents, call sequentially (one per turn) — never in parallel.",
+      "Launch an AI agent in a new terminal. Returns terminalId and the resolved location (grid or dock — defaults to grid unless overridden or grid is at capacity). For multiple agents, call sequentially (one per turn) — never in parallel.",
     category: "agent",
     kind: "command",
     danger: "safe",
@@ -31,6 +31,10 @@ export function registerAgentActions(actions: ActionRegistry, callbacks: ActionC
       ephemeral: z.boolean().optional(),
       agentLaunchFlags: z.array(z.string()).optional(),
       spawnedBy: TerminalSpawnSourceSchema.optional(),
+    }),
+    resultSchema: z.object({
+      terminalId: z.string(),
+      location: LaunchLocationSchema,
     }),
     run: async (args: unknown) => {
       const {
@@ -62,7 +66,7 @@ export function registerAgentActions(actions: ActionRegistry, callbacks: ActionC
         agentLaunchFlags?: string[];
         spawnedBy?: TerminalSpawnSource;
       };
-      const terminalId = await callbacks.onLaunchAgent(agentId, {
+      const result = await callbacks.onLaunchAgent(agentId, {
         location,
         cwd,
         worktreeId,
@@ -76,7 +80,8 @@ export function registerAgentActions(actions: ActionRegistry, callbacks: ActionC
         agentLaunchFlags,
         spawnedBy,
       });
-      return { terminalId };
+      if (!result) return null;
+      return { terminalId: result.terminalId, location: result.location };
     },
   }));
 
@@ -93,11 +98,17 @@ export function registerAgentActions(actions: ActionRegistry, callbacks: ActionC
     },
   }));
 
-  // Per-agent shortcut actions (`agent.claude`, `agent.codex`, …) accept an
-  // optional `spawnedBy` arg so MCP-initiated launches can be marked
-  // non-focus-stealing. See #6959.
+  // Per-agent shortcut actions (`agent.claude`, `agent.codex`, …) accept
+  // optional `location` and `spawnedBy` args so MCP-initiated launches can set
+  // placement and be marked non-focus-stealing. See #6959, #7669.
   const shortcutLaunchSchema = z.object({
+    location: LaunchLocationSchema.optional(),
     spawnedBy: TerminalSpawnSourceSchema.optional(),
+  });
+
+  const shortcutResultSchema = z.object({
+    terminalId: z.string(),
+    location: LaunchLocationSchema,
   });
 
   for (const [id, config] of Object.entries(AGENT_REGISTRY)) {
@@ -111,10 +122,18 @@ export function registerAgentActions(actions: ActionRegistry, callbacks: ActionC
       danger: "safe",
       scope: "renderer",
       argsSchema: shortcutLaunchSchema,
+      resultSchema: shortcutResultSchema,
       run: async (args: unknown) => {
-        const { spawnedBy } = (args ?? {}) as { spawnedBy?: TerminalSpawnSource };
-        const terminalId = await callbacks.onLaunchAgent(id, ...(spawnedBy ? [{ spawnedBy }] : []));
-        return { terminalId };
+        const { location, spawnedBy } = (args ?? {}) as {
+          location?: "grid" | "dock";
+          spawnedBy?: TerminalSpawnSource;
+        };
+        const result = await callbacks.onLaunchAgent(id, {
+          location,
+          spawnedBy,
+        });
+        if (!result) return null;
+        return { terminalId: result.terminalId, location: result.location };
       },
     }));
   }
@@ -128,13 +147,18 @@ export function registerAgentActions(actions: ActionRegistry, callbacks: ActionC
     danger: "safe",
     scope: "renderer",
     argsSchema: shortcutLaunchSchema,
+    resultSchema: shortcutResultSchema,
     run: async (args: unknown) => {
-      const { spawnedBy } = (args ?? {}) as { spawnedBy?: TerminalSpawnSource };
-      const terminalId = await callbacks.onLaunchAgent(
-        "terminal",
-        ...(spawnedBy ? [{ spawnedBy }] : [])
-      );
-      return { terminalId };
+      const { location, spawnedBy } = (args ?? {}) as {
+        location?: "grid" | "dock";
+        spawnedBy?: TerminalSpawnSource;
+      };
+      const result = await callbacks.onLaunchAgent("terminal", {
+        location,
+        spawnedBy,
+      });
+      if (!result) return null;
+      return { terminalId: result.terminalId, location: result.location };
     },
   }));
 

--- a/src/services/actions/definitions/schemas.ts
+++ b/src/services/actions/definitions/schemas.ts
@@ -3,7 +3,11 @@ import { BUILT_IN_AGENT_IDS, BUILT_IN_TERMINAL_TYPES } from "@shared/config/agen
 
 export const AgentIdSchema = z.enum([...BUILT_IN_AGENT_IDS, "terminal", "browser", "dev-preview"]);
 
-export const LaunchLocationSchema = z.enum(["grid", "dock"]);
+export const LaunchLocationSchema = z
+  .enum(["grid", "dock"])
+  .describe(
+    'Where to place the panel. "grid" places it in the main panel grid (default). "dock" places it in the sidebar dock.'
+  );
 
 /**
  * Mirror of `TerminalSpawnSource` from `shared/types/panel.ts`. Kept in lockstep

--- a/src/services/actions/definitions/workflowActions.ts
+++ b/src/services/actions/definitions/workflowActions.ts
@@ -426,13 +426,16 @@ export function registerWorkflowActions(
         // caller knows the worktree is already created and not lost.
         let terminalId: string | null;
         try {
-          terminalId = await callbacks.onLaunchAgent(agentId, {
-            location: "grid",
-            cwd: worktreePath,
-            worktreeId,
-            activateDockOnCreate: false,
-            spawnedBy,
-          });
+          terminalId =
+            (
+              await callbacks.onLaunchAgent(agentId, {
+                location: "grid",
+                cwd: worktreePath,
+                worktreeId,
+                activateDockOnCreate: false,
+                spawnedBy,
+              })
+            )?.terminalId ?? null;
         } catch (err) {
           throw partialSuccessError(
             `Agent '${agentId}' failed to launch in new worktree: ${formatErrorMessage(err, "unknown error")}`,


### PR DESCRIPTION
## Summary
- Added `.describe()` to `LaunchLocationSchema` so MCP clients see human-readable guidance for each location value.
- `agent.launch` and per-agent shortcuts now return the resolved location alongside `terminalId`, letting callers detect when placement differs from what was requested.
- Per-agent shortcut actions (`agent.claude`, `agent.codex`, etc.) now accept the `location` arg, closing a gap where the shortcut form had no way to set placement.

Resolves #7669

## Changes
- `schemas.ts`: Added `.describe()` with guidance text for grid/dock enum values.
- `agentActions.ts`: Updated description string, added `resultSchema` with location, exposed `location` arg on per-agent shortcuts.
- `useAgentLauncher.ts`: `launchAgent` returns `{ terminalId, location }` instead of bare `terminalId`.
- `actionTypes.ts`: Updated `onLaunchAgent` callback signature to return structured result.
- `workflowActions.ts`: Unwrapped new structured return at call site.
- Tests: Updated mocks and assertions to match new return shapes.

## Testing
- Unit tests updated and passing (adversarial tests for `agentActions` and `workflowActions`).
- Confirmed the resolved location is correctly echoed back when launching agents via MCP.