### PR TITLE
fix(worktree): tighten session-state chrome on terminals section

### DIFF
--- a/src/components/Worktree/WorktreeCard/WorktreeTerminalSection.tsx
+++ b/src/components/Worktree/WorktreeCard/WorktreeTerminalSection.tsx
@@ -156,7 +156,7 @@ function TerminalRow({ term, onClick }: TerminalRowProps) {
             ref={dragHandle?.setActivatorNodeRef}
             type="button"
             data-drag-handle
-            className="cursor-grab rounded text-text-muted opacity-0 group-hover/termrow:opacity-100 focus-visible:opacity-100 transition-colors transition-opacity hover:text-text-secondary focus-visible:outline focus-visible:outline-2 focus-visible:outline-daintree-accent focus-visible:outline-offset-1 active:cursor-grabbing"
+            className="cursor-grab rounded text-text-muted opacity-0 group-hover/termrow:opacity-100 focus-visible:opacity-100 transition-opacity hover:text-text-secondary focus-visible:outline focus-visible:outline-2 focus-visible:outline-daintree-accent focus-visible:outline-offset-1 active:cursor-grabbing"
             aria-label="Drag to move terminal"
             {...(dragHandle?.listeners as React.HTMLAttributes<HTMLElement> | undefined)}
           >

--- a/src/components/Worktree/WorktreeCard/WorktreeTerminalSection.tsx
+++ b/src/components/Worktree/WorktreeCard/WorktreeTerminalSection.tsx
@@ -1,7 +1,6 @@
 import { useCallback, useMemo, useRef, useState } from "react";
 import type React from "react";
 import { SortableContext, verticalListSortingStrategy } from "@dnd-kit/sortable";
-import type { AgentState } from "@/types";
 import type { TerminalInstance } from "@/store/panelStore";
 import { TerminalIcon } from "@/components/Terminal/TerminalIcon";
 import { cn } from "@/lib/utils";
@@ -15,6 +14,7 @@ import {
   getEffectiveStateIcon,
   getEffectiveStateColor,
 } from "../terminalStateConfig";
+import { CollapsedSessionIndicators } from "./CollapsedSessionIndicators";
 import { Tooltip, TooltipContent, TooltipTrigger } from "../../ui/tooltip";
 import { TruncatedTooltip } from "@/components/ui/TruncatedTooltip";
 import { useTruncationDetection } from "@/hooks/useTruncationDetection";
@@ -32,41 +32,6 @@ import {
 import { useDragHandle } from "@/components/DragDrop/DragHandleContext";
 import { useFleetArmingStore, isFleetArmEligible } from "@/store/fleetArmingStore";
 import { useKeybindingScope } from "@/hooks/useKeybinding";
-
-interface StateIconProps {
-  state: AgentState;
-  count: number;
-}
-
-function StateIcon({ state, count }: StateIconProps) {
-  const Icon = getEffectiveStateIcon(state);
-  const colorClass = getEffectiveStateColor(state);
-  const label = STATE_LABELS[state];
-
-  return (
-    <Tooltip>
-      <TooltipTrigger asChild>
-        <span
-          className={cn("flex items-center gap-1 text-[11px]", colorClass)}
-          role="img"
-          aria-label={`${count} ${label}`}
-        >
-          <Icon
-            className={cn(
-              "w-3 h-3",
-              state === "working" && "animate-spin-slow motion-reduce:animate-none"
-            )}
-            aria-hidden
-          />
-          <span className="font-mono tabular-nums">{count}</span>
-        </span>
-      </TooltipTrigger>
-      <TooltipContent side="top" className="text-xs">
-        {count} {label}
-      </TooltipContent>
-    </Tooltip>
-  );
-}
 
 interface MarqueeBox {
   x: number;
@@ -191,7 +156,7 @@ function TerminalRow({ term, onClick }: TerminalRowProps) {
             ref={dragHandle?.setActivatorNodeRef}
             type="button"
             data-drag-handle
-            className="cursor-grab rounded text-text-muted transition-colors hover:text-text-secondary focus-visible:outline focus-visible:outline-2 focus-visible:outline-daintree-accent focus-visible:outline-offset-1 active:cursor-grabbing"
+            className="cursor-grab rounded text-text-muted opacity-0 group-hover/termrow:opacity-100 focus-visible:opacity-100 transition-colors transition-opacity hover:text-text-secondary focus-visible:outline focus-visible:outline-2 focus-visible:outline-daintree-accent focus-visible:outline-offset-1 active:cursor-grabbing"
             aria-label="Drag to move terminal"
             {...(dragHandle?.listeners as React.HTMLAttributes<HTMLElement> | undefined)}
           >
@@ -234,15 +199,17 @@ export function WorktreeTerminalSection({
   );
   const armedIdsSize = useFleetArmingStore((s) => s.armedIds.size);
 
-  const topTerminalState = ((): { state: AgentState; count: number } | null => {
-    for (const state of STATE_PRIORITY) {
-      const count = counts.byState[state];
-      if (count > 0) {
-        return { state, count };
-      }
-    }
-    return null;
-  })();
+  const { visibleTerminalStates, terminalSessionAriaLabel } = useMemo(() => {
+    const visible = STATE_PRIORITY.filter((s) => s !== "idle" && counts.byState[s] > 0).map(
+      (s) => ({
+        state: s,
+        count: counts.byState[s],
+      })
+    );
+    const parts = visible.map((v) => `${v.count} ${STATE_LABELS[v.state]}`);
+    const label = `${counts.total} session${counts.total !== 1 ? "s" : ""}: ${parts.join(", ")}`;
+    return { visibleTerminalStates: visible, terminalSessionAriaLabel: label };
+  }, [counts.byState, counts.total]);
 
   const SummaryIcon = useMemo(() => {
     if (terminals.length === 0) return null;
@@ -509,8 +476,11 @@ export function WorktreeTerminalSection({
             </span>
           </div>
 
-          {topTerminalState && (
-            <StateIcon state={topTerminalState.state} count={topTerminalState.count} />
+          {visibleTerminalStates.length > 0 && (
+            <CollapsedSessionIndicators
+              visibleStates={visibleTerminalStates}
+              sessionAriaLabel={terminalSessionAriaLabel}
+            />
           )}
         </button>
       )}

--- a/src/components/Worktree/WorktreeCard/__tests__/WorktreeTerminalSection.test.tsx
+++ b/src/components/Worktree/WorktreeCard/__tests__/WorktreeTerminalSection.test.tsx
@@ -592,6 +592,30 @@ describe("WorktreeTerminalSection collapsed pill state indicators", () => {
     expect(countSpans.length).toBe(1);
   });
 
+  it("sets aria-label with full state breakdown on the role=img container", () => {
+    renderSection({
+      isExpanded: false,
+      counts: {
+        total: 5,
+        byState: { idle: 3, working: 2, waiting: 2, directing: 0, completed: 1, exited: 0 },
+      },
+    });
+    const indicators = screen.getByTestId("collapsed-session-indicators");
+    expect(indicators.getAttribute("role")).toBe("img");
+    expect(indicators.getAttribute("aria-label")).toBe("5 sessions: 2 working, 2 waiting, 1 done");
+  });
+
+  it("does not render indicators when section is expanded", () => {
+    renderSection({
+      isExpanded: true,
+      counts: {
+        total: 3,
+        byState: { idle: 0, working: 2, waiting: 1, directing: 0, completed: 0, exited: 0 },
+      },
+    });
+    expect(screen.queryByTestId("collapsed-session-indicators")).toBeNull();
+  });
+
   it("renders nothing when all terminals are idle", () => {
     renderSection({
       isExpanded: false,

--- a/src/components/Worktree/WorktreeCard/__tests__/WorktreeTerminalSection.test.tsx
+++ b/src/components/Worktree/WorktreeCard/__tests__/WorktreeTerminalSection.test.tsx
@@ -562,3 +562,76 @@ describe("WorktreeTerminalSection row state icon", () => {
     expect(stateRelated.length).toBe(0);
   });
 });
+
+describe("WorktreeTerminalSection collapsed pill state indicators", () => {
+  it("renders multi-state indicators when collapsed with mixed agent states", () => {
+    renderSection({
+      isExpanded: false,
+      counts: {
+        total: 5,
+        byState: { idle: 0, working: 2, waiting: 2, directing: 0, completed: 1, exited: 0 },
+      },
+    });
+    const indicators = screen.getByTestId("collapsed-session-indicators");
+    expect(indicators).toBeDefined();
+    const countSpans = indicators.querySelectorAll(".font-mono.tabular-nums");
+    expect(countSpans.length).toBe(3);
+  });
+
+  it("renders single state indicator when only one non-idle state has count", () => {
+    renderSection({
+      isExpanded: false,
+      counts: {
+        total: 3,
+        byState: { idle: 0, working: 3, waiting: 0, directing: 0, completed: 0, exited: 0 },
+      },
+    });
+    const indicators = screen.getByTestId("collapsed-session-indicators");
+    expect(indicators).toBeDefined();
+    const countSpans = indicators.querySelectorAll(".font-mono.tabular-nums");
+    expect(countSpans.length).toBe(1);
+  });
+
+  it("renders nothing when all terminals are idle", () => {
+    renderSection({
+      isExpanded: false,
+      counts: {
+        total: 2,
+        byState: { idle: 2, working: 0, waiting: 0, directing: 0, completed: 0, exited: 0 },
+      },
+    });
+    expect(screen.queryByTestId("collapsed-session-indicators")).toBeNull();
+  });
+
+  it("renders nothing when all non-idle states have zero count", () => {
+    renderSection({
+      isExpanded: false,
+      counts: {
+        total: 0,
+        byState: { idle: 0, working: 0, waiting: 0, directing: 0, completed: 0, exited: 0 },
+      },
+    });
+    expect(screen.queryByTestId("collapsed-session-indicators")).toBeNull();
+  });
+});
+
+describe("WorktreeTerminalSection drag handle visibility", () => {
+  it("has opacity-0 at rest and group-hover/termrow:opacity-100 on hover", () => {
+    renderSection({ isExpanded: true });
+    const handles = screen.getAllByRole("button", { name: "Drag to move terminal" });
+    expect(handles.length).toBeGreaterThanOrEqual(1);
+    for (const handle of handles) {
+      expect(handle.className).toContain("opacity-0");
+      expect(handle.className).toContain("group-hover/termrow:opacity-100");
+    }
+  });
+
+  it("has focus-visible:opacity-100 for keyboard users", () => {
+    renderSection({ isExpanded: true });
+    const handles = screen.getAllByRole("button", { name: "Drag to move terminal" });
+    expect(handles.length).toBeGreaterThanOrEqual(1);
+    for (const handle of handles) {
+      expect(handle.className).toContain("focus-visible:opacity-100");
+    }
+  });
+});


### PR DESCRIPTION
## Summary
- The collapsed terminals-section pill now surfaces the full non-idle state distribution instead of just the highest-priority state, using the existing `CollapsedSessionIndicators` component
- Terminal row drag handles hide at rest and only appear on hover or keyboard focus, reducing chrome clutter when the row is armed or active
- Added tests for collapsed-pill multi-state rendering and drag-handle visibility

Resolves #7701

## Changes
- Replaced the single-state `StateIcon` with `CollapsedSessionIndicators` in `WorktreeTerminalSection.tsx`, including an aria-label with the full state breakdown
- Removed the now-unused `StateIcon` component
- Applied `opacity-0 group-hover/termrow:opacity-100 focus-visible:opacity-100` to the drag handle button
- Added `WorktreeTerminalSection.test.tsx` coverage: collapsed pill renders all non-idle states, drag handle is hidden at rest and visible on hover/focus

## Testing
- All existing tests pass
- New tests cover: multi-state collapsed pill, single-state pill, aria-label with full breakdown, idle-only skips rendering, hover/focus-visible opacity classes on drag handle