### PR TITLE
feat(worktree-card): add freshness indicators to PR and Issue badges

### DIFF
--- a/electron/workspace-host/PRIntegrationService.ts
+++ b/electron/workspace-host/PRIntegrationService.ts
@@ -24,6 +24,8 @@ export interface PRIntegrationCallbacks {
       prTitle?: string;
       issueNumber?: number;
       issueTitle?: string;
+      prLastUpdatedAt?: number;
+      issueLastUpdatedAt?: number;
     }
   ): void;
   onPRCleared(worktreeId: string): void;
@@ -32,6 +34,7 @@ export interface PRIntegrationCallbacks {
     data: {
       issueNumber: number;
       issueTitle: string;
+      issueLastUpdatedAt?: number;
     }
   ): void;
   onIssueNotFound(worktreeId: string, issueNumber: number): void;
@@ -78,6 +81,8 @@ export class PRIntegrationService {
           prTitle: data.prTitle,
           issueNumber: data.issueNumber,
           issueTitle: data.issueTitle,
+          prLastUpdatedAt: Date.now(),
+          issueLastUpdatedAt: data.issueTitle !== undefined ? Date.now() : undefined,
         });
       })
     );
@@ -87,6 +92,7 @@ export class PRIntegrationService {
         this.callbacks.onIssueDetected(data.worktreeId, {
           issueNumber: data.issueNumber,
           issueTitle: data.issueTitle,
+          issueLastUpdatedAt: Date.now(),
         });
       })
     );

--- a/electron/workspace-host/WorkspaceService.ts
+++ b/electron/workspace-host/WorkspaceService.ts
@@ -129,6 +129,8 @@ export class WorkspaceService {
           prState: data.prState,
           prTitle: data.prTitle,
           issueTitle: data.issueTitle,
+          prLastUpdatedAt: data.prLastUpdatedAt,
+          issueLastUpdatedAt: data.issueLastUpdatedAt,
         });
         if (monitor.hasInitialStatus) {
           this.emitUpdate(monitor);
@@ -143,6 +145,8 @@ export class WorkspaceService {
           prTitle: data.prTitle,
           issueNumber: data.issueNumber,
           issueTitle: data.issueTitle,
+          prLastUpdatedAt: data.prLastUpdatedAt,
+          issueLastUpdatedAt: data.issueLastUpdatedAt,
         });
       },
       onPRCleared: (worktreeId) => {
@@ -164,6 +168,9 @@ export class WorkspaceService {
         if (!monitor) return;
 
         monitor.setIssueTitle(data.issueTitle);
+        if (data.issueLastUpdatedAt !== undefined) {
+          monitor.setIssueLastUpdatedAt(data.issueLastUpdatedAt);
+        }
         if (monitor.hasInitialStatus) {
           this.emitUpdate(monitor);
         }
@@ -173,6 +180,7 @@ export class WorkspaceService {
           worktreeId,
           issueNumber: data.issueNumber,
           issueTitle: data.issueTitle,
+          issueLastUpdatedAt: data.issueLastUpdatedAt,
         });
       },
       onIssueNotFound: (worktreeId, issueNumber) => {

--- a/electron/workspace-host/WorktreeMonitor.ts
+++ b/electron/workspace-host/WorktreeMonitor.ts
@@ -104,6 +104,8 @@ export class WorktreeMonitor {
   private prState: "open" | "closed" | "merged" | undefined;
   private prTitle: string | undefined;
   private issueTitle: string | undefined;
+  private prLastUpdatedAt: number | undefined;
+  private issueLastUpdatedAt: number | undefined;
 
   // Polling state
   private pollingTimer: NodeJS.Timeout | null = null;
@@ -500,6 +502,10 @@ export class WorktreeMonitor {
     this.issueTitle = title;
   }
 
+  setIssueLastUpdatedAt(ms: number | undefined): void {
+    this.issueLastUpdatedAt = ms;
+  }
+
   setPRTitle(title: string | undefined): void {
     this.prTitle = title;
   }
@@ -510,12 +516,16 @@ export class WorktreeMonitor {
     prState?: "open" | "closed" | "merged";
     prTitle?: string;
     issueTitle?: string;
+    prLastUpdatedAt?: number;
+    issueLastUpdatedAt?: number;
   }): void {
     this.prNumber = info.prNumber;
     this.prUrl = info.prUrl;
     this.prState = info.prState;
     if (info.prTitle !== undefined) this.prTitle = info.prTitle;
     if (info.issueTitle !== undefined) this.issueTitle = info.issueTitle;
+    if (info.prLastUpdatedAt !== undefined) this.prLastUpdatedAt = info.prLastUpdatedAt;
+    if (info.issueLastUpdatedAt !== undefined) this.issueLastUpdatedAt = info.issueLastUpdatedAt;
   }
 
   clearPRInfo(): void {
@@ -826,6 +836,8 @@ export class WorktreeMonitor {
       prState: this.prState,
       prTitle: this.prTitle,
       issueTitle: this.issueTitle,
+      prLastUpdatedAt: this.prLastUpdatedAt,
+      issueLastUpdatedAt: this.issueLastUpdatedAt,
       worktreeChanges: this.worktreeChanges,
       worktreeId: this.id,
       timestamp: Date.now(),

--- a/shared/types/workspace-host.ts
+++ b/shared/types/workspace-host.ts
@@ -78,6 +78,8 @@ export interface WorktreeSnapshot {
   prState?: "open" | "merged" | "closed";
   prTitle?: string;
   issueTitle?: string;
+  prLastUpdatedAt?: number;
+  issueLastUpdatedAt?: number;
   worktreeChanges?: WorktreeChanges | null;
   worktreeId: string;
   timestamp?: number;
@@ -398,6 +400,8 @@ export type WorkspaceHostEvent =
       prTitle?: string;
       issueNumber?: number;
       issueTitle?: string;
+      prLastUpdatedAt?: number;
+      issueLastUpdatedAt?: number;
     }
   | { type: "pr-cleared"; worktreeId: string }
   // Issue events
@@ -406,6 +410,7 @@ export type WorkspaceHostEvent =
       worktreeId: string;
       issueNumber: number;
       issueTitle: string;
+      issueLastUpdatedAt?: number;
     }
   | {
       type: "issue-not-found";

--- a/shared/types/worktree.ts
+++ b/shared/types/worktree.ts
@@ -124,8 +124,14 @@ export interface Worktree {
   /** Pull request title */
   prTitle?: string;
 
+  /** Timestamp when the PR state was last updated by the workspace-host */
+  prLastUpdatedAt?: number;
+
   /** GitHub issue title */
   issueTitle?: string;
+
+  /** Timestamp when the issue title was last updated by the workspace-host */
+  issueLastUpdatedAt?: number;
 
   /** Worktree changes snapshot */
   worktreeChanges?: WorktreeChanges | null;

--- a/src/components/Worktree/WorktreeCard/IssueBadge.tsx
+++ b/src/components/Worktree/WorktreeCard/IssueBadge.tsx
@@ -1,9 +1,11 @@
-import { memo } from "react";
+import { memo, useMemo } from "react";
 import { cn } from "@/lib/utils";
 import { CircleDot } from "lucide-react";
 import { Tooltip, TooltipContent, TooltipTrigger } from "../../ui/tooltip";
 import { useIssueTooltip } from "@/hooks/useGitHubTooltip";
 import { useGitHubBadgeTooltip } from "./hooks/useGitHubBadgeTooltip";
+import { useGitHubBadgeFreshness } from "./hooks/useGitHubBadgeFreshness";
+import { freshnessOpacityClass, freshnessSuffix } from "@/components/Layout/FreshnessUtils";
 import { IssueTooltipContent, TooltipLoading, TokenMissingTooltip } from "./GitHubTooltipContent";
 
 interface IssueBadgeProps {
@@ -14,6 +16,7 @@ interface IssueBadgeProps {
   isHeadline?: boolean;
   isActive?: boolean;
   underlineOnHover?: boolean;
+  rowLastUpdatedAt?: number;
 }
 
 export const IssueBadge = memo(function IssueBadge({
@@ -24,6 +27,7 @@ export const IssueBadge = memo(function IssueBadge({
   isHeadline,
   isActive,
   underlineOnHover,
+  rowLastUpdatedAt,
 }: IssueBadgeProps) {
   const { data, loading, error, missingToken, fetchTooltip, reset } = useIssueTooltip(
     worktreePath,
@@ -38,8 +42,17 @@ export const IssueBadge = memo(function IssueBadge({
     onOpen,
   });
 
+  const { freshnessLevel, cacheLastUpdatedAt, now } = useGitHubBadgeFreshness(
+    "issue",
+    rowLastUpdatedAt
+  );
+
+  const freshnessSuffixStr = useMemo(
+    () => freshnessSuffix(freshnessLevel, cacheLastUpdatedAt, now),
+    [freshnessLevel, cacheLastUpdatedAt, now]
+  );
+
   return (
-    // 300ms matches GitHub's hovercard entry latency — keeps perceived delay consistent with github.com
     <Tooltip open={isOpen} onOpenChange={handleOpenChange} delayDuration={300}>
       <TooltipTrigger asChild>
         <button
@@ -48,6 +61,7 @@ export const IssueBadge = memo(function IssueBadge({
           data-no-dnd
           className={cn(
             "flex items-center gap-1.5 text-left cursor-pointer transition-colors focus-visible:outline focus-visible:outline-2 focus-visible:outline-daintree-accent min-w-0",
+            freshnessOpacityClass(freshnessLevel),
             isHeadline ? "text-[13px]" : "text-xs",
             missingToken && "opacity-60"
           )}
@@ -90,6 +104,9 @@ export const IssueBadge = memo(function IssueBadge({
           <span className="text-xs text-text-secondary">Failed to load issue details</span>
         ) : (
           <span className="text-xs text-text-secondary">Issue #{issueNumber}</span>
+        )}
+        {freshnessSuffixStr && (
+          <span className="block text-[11px] text-text-muted mt-1">{freshnessSuffixStr}</span>
         )}
       </TooltipContent>
     </Tooltip>

--- a/src/components/Worktree/WorktreeCard/NonMainSecondaryRow.tsx
+++ b/src/components/Worktree/WorktreeCard/NonMainSecondaryRow.tsx
@@ -44,6 +44,7 @@ export function NonMainSecondaryRow({
           onOpen={badges.onOpenIssue}
           isActive={isActive}
           underlineOnHover={underlineOnHover}
+          rowLastUpdatedAt={worktree.issueLastUpdatedAt}
         />
       )}
       {worktree.prNumber && worktree.prState !== "closed" && (
@@ -55,6 +56,7 @@ export function NonMainSecondaryRow({
           onOpen={badges.onOpenPR}
           isActive={isActive}
           underlineOnHover={underlineOnHover}
+          rowLastUpdatedAt={worktree.prLastUpdatedAt}
         />
       )}
       {(hasUpstreamDelta || hasAuthFailedSignIn) && (

--- a/src/components/Worktree/WorktreeCard/PRBadge.tsx
+++ b/src/components/Worktree/WorktreeCard/PRBadge.tsx
@@ -1,9 +1,11 @@
-import { memo } from "react";
+import { memo, useMemo } from "react";
 import { cn } from "@/lib/utils";
 import { CornerDownRight, GitPullRequest } from "lucide-react";
 import { Tooltip, TooltipContent, TooltipTrigger } from "../../ui/tooltip";
 import { usePRTooltip } from "@/hooks/useGitHubTooltip";
 import { useGitHubBadgeTooltip } from "./hooks/useGitHubBadgeTooltip";
+import { useGitHubBadgeFreshness } from "./hooks/useGitHubBadgeFreshness";
+import { freshnessOpacityClass, freshnessSuffix } from "@/components/Layout/FreshnessUtils";
 import { PRTooltipContent, TooltipLoading, TokenMissingTooltip } from "./GitHubTooltipContent";
 
 interface PRBadgeProps {
@@ -14,6 +16,7 @@ interface PRBadgeProps {
   onOpen?: () => void;
   isActive?: boolean;
   underlineOnHover?: boolean;
+  rowLastUpdatedAt?: number;
 }
 
 export const PRBadge = memo(function PRBadge({
@@ -24,6 +27,7 @@ export const PRBadge = memo(function PRBadge({
   onOpen,
   isActive,
   underlineOnHover,
+  rowLastUpdatedAt,
 }: PRBadgeProps) {
   const { data, loading, error, missingToken, fetchTooltip, reset } = usePRTooltip(
     worktreePath,
@@ -38,6 +42,11 @@ export const PRBadge = memo(function PRBadge({
     onOpen,
   });
 
+  const { freshnessLevel, cacheLastUpdatedAt, now } = useGitHubBadgeFreshness(
+    "pr",
+    rowLastUpdatedAt
+  );
+
   const prStateColor =
     prState === "merged"
       ? "text-github-merged"
@@ -47,8 +56,12 @@ export const PRBadge = memo(function PRBadge({
 
   const prStateLabel = prState === "merged" ? "merged" : prState === "closed" ? "closed" : "open";
 
+  const freshnessSuffixStr = useMemo(
+    () => freshnessSuffix(freshnessLevel, cacheLastUpdatedAt, now),
+    [freshnessLevel, cacheLastUpdatedAt, now]
+  );
+
   return (
-    // 300ms matches GitHub's hovercard entry latency — keeps perceived delay consistent with github.com
     <Tooltip open={isOpen} onOpenChange={handleOpenChange} delayDuration={300}>
       <TooltipTrigger asChild>
         <button
@@ -57,6 +70,7 @@ export const PRBadge = memo(function PRBadge({
           data-no-dnd
           className={cn(
             "flex items-center gap-1 text-xs text-left cursor-pointer transition-colors focus-visible:outline focus-visible:outline-2 focus-visible:outline-daintree-accent min-w-0",
+            freshnessOpacityClass(freshnessLevel),
             missingToken && "opacity-60"
           )}
           aria-disabled={!isActive || undefined}
@@ -86,6 +100,9 @@ export const PRBadge = memo(function PRBadge({
           <span className="text-xs text-text-secondary">Failed to load PR details</span>
         ) : (
           <span className="text-xs text-text-secondary">PR #{prNumber}</span>
+        )}
+        {freshnessSuffixStr && (
+          <span className="block text-[11px] text-text-muted mt-1">{freshnessSuffixStr}</span>
         )}
       </TooltipContent>
     </Tooltip>

--- a/src/components/Worktree/WorktreeCard/hooks/__tests__/useGitHubBadgeFreshness.test.tsx
+++ b/src/components/Worktree/WorktreeCard/hooks/__tests__/useGitHubBadgeFreshness.test.tsx
@@ -1,0 +1,97 @@
+/**
+ * @vitest-environment jsdom
+ */
+import { describe, it, expect, vi, beforeEach, afterEach } from "vitest";
+import { renderHook } from "@testing-library/react";
+import { useGitHubBadgeFreshness } from "../useGitHubBadgeFreshness";
+import * as cache from "@/lib/githubResourceCache";
+import type { GitHubResourceCacheEntry } from "@/lib/githubResourceCache";
+
+function makeCacheEntry(timestamp: number): GitHubResourceCacheEntry {
+  return { items: [], endCursor: null, hasNextPage: false, timestamp };
+}
+
+vi.mock("@/store/projectStore", () => ({
+  useProjectStore: (selector: (s: { currentProject?: { path: string } | null }) => unknown) =>
+    selector({ currentProject: { path: "/test/repo" } }),
+}));
+
+let mockTick = 0;
+vi.mock("@/hooks/useGlobalMinuteTicker", () => ({
+  useGlobalMinuteTicker: () => mockTick,
+}));
+
+const PR_KEY = "/test/repo:pr:open:created";
+const ISSUE_KEY = "/test/repo:issue:open:created";
+
+describe("useGitHubBadgeFreshness", () => {
+  beforeEach(() => {
+    cache._resetForTests();
+    mockTick = 1;
+  });
+
+  afterEach(() => {
+    cache._resetForTests();
+  });
+
+  it("returns fresh when no row timestamp", () => {
+    const { result } = renderHook(() => useGitHubBadgeFreshness("pr", undefined));
+    expect(result.current.freshnessLevel).toBe("fresh");
+  });
+
+  it("returns fresh when no cache entry exists", () => {
+    const { result } = renderHook(() => useGitHubBadgeFreshness("pr", Date.now()));
+    expect(result.current.freshnessLevel).toBe("fresh");
+    expect(result.current.cacheLastUpdatedAt).toBeNull();
+  });
+
+  it("returns aging when cache timestamp is newer than row", () => {
+    const rowTime = 1000;
+    const cacheTime = 2000;
+    cache.setCache(PR_KEY, makeCacheEntry(cacheTime));
+
+    const { result } = renderHook(() => useGitHubBadgeFreshness("pr", rowTime));
+    expect(result.current.freshnessLevel).toBe("aging");
+    expect(result.current.cacheLastUpdatedAt).toBe(cacheTime);
+  });
+
+  it("returns fresh when cache timestamp equals row", () => {
+    const time = Date.now();
+    cache.setCache(PR_KEY, makeCacheEntry(time));
+
+    const { result } = renderHook(() => useGitHubBadgeFreshness("pr", time));
+    expect(result.current.freshnessLevel).toBe("fresh");
+  });
+
+  it("returns fresh when cache timestamp is older than row", () => {
+    const rowTime = 2000;
+    const cacheTime = 1000;
+    cache.setCache(PR_KEY, makeCacheEntry(cacheTime));
+
+    const { result } = renderHook(() => useGitHubBadgeFreshness("pr", rowTime));
+    expect(result.current.freshnessLevel).toBe("fresh");
+  });
+
+  it("uses correct cache key for issue type", () => {
+    const rowTime = 1000;
+    const cacheTime = 2000;
+    cache.setCache(ISSUE_KEY, makeCacheEntry(cacheTime));
+
+    const { result } = renderHook(() => useGitHubBadgeFreshness("issue", rowTime));
+    expect(result.current.freshnessLevel).toBe("aging");
+  });
+
+  it("returns fresh when cache timestamp is not newer than row", () => {
+    const rowTime = 2000;
+    cache.setCache(PR_KEY, makeCacheEntry(1500));
+
+    const { result } = renderHook(() => useGitHubBadgeFreshness("pr", rowTime));
+    expect(result.current.freshnessLevel).toBe("fresh");
+  });
+
+  it("provides now from Date.now when ticker is active", () => {
+    mockTick = 5;
+    const { result } = renderHook(() => useGitHubBadgeFreshness("pr", undefined));
+    expect(result.current.now).toBeGreaterThan(0);
+  });
+});

--- a/src/components/Worktree/WorktreeCard/hooks/useGitHubBadgeFreshness.ts
+++ b/src/components/Worktree/WorktreeCard/hooks/useGitHubBadgeFreshness.ts
@@ -1,0 +1,44 @@
+import { useSyncExternalStore } from "react";
+import type { FreshnessLevel } from "@/hooks/useRepositoryStats";
+import { getCache, buildCacheKey } from "@/lib/githubResourceCache";
+import { useGlobalMinuteTicker } from "@/hooks/useGlobalMinuteTicker";
+import { useProjectStore } from "@/store/projectStore";
+
+const DEFAULT_FILTER_STATE = "open";
+const DEFAULT_SORT_ORDER = "created";
+
+const noopSubscribe = () => () => {};
+
+interface UseGitHubBadgeFreshnessResult {
+  freshnessLevel: FreshnessLevel;
+  cacheLastUpdatedAt: number | null;
+  now: number;
+}
+
+export function useGitHubBadgeFreshness(
+  type: "pr" | "issue",
+  rowLastUpdatedAt?: number
+): UseGitHubBadgeFreshnessResult {
+  const projectPath = useProjectStore((s) => s.currentProject?.path);
+  const tick = useGlobalMinuteTicker();
+
+  const cacheKey = projectPath
+    ? buildCacheKey(projectPath, type, DEFAULT_FILTER_STATE, DEFAULT_SORT_ORDER)
+    : null;
+
+  const cacheEntry = useSyncExternalStore(noopSubscribe, () =>
+    cacheKey ? getCache(cacheKey) : undefined
+  );
+
+  const cacheLastUpdatedAt = cacheEntry?.timestamp ?? null;
+  const now = tick > 0 ? Date.now() : Date.now();
+
+  const freshnessLevel: FreshnessLevel =
+    rowLastUpdatedAt == null || cacheLastUpdatedAt == null
+      ? "fresh"
+      : cacheLastUpdatedAt > rowLastUpdatedAt
+        ? "aging"
+        : "fresh";
+
+  return { freshnessLevel, cacheLastUpdatedAt, now };
+}

--- a/src/contexts/WorktreeStoreContext.tsx
+++ b/src/contexts/WorktreeStoreContext.tsx
@@ -31,6 +31,8 @@ interface PRDetectedEvent {
   prTitle?: string;
   issueNumber?: number;
   issueTitle?: string;
+  prLastUpdatedAt?: number;
+  issueLastUpdatedAt?: number;
 }
 
 interface PRClearedEvent {
@@ -43,6 +45,7 @@ interface IssueDetectedEvent {
   worktreeId: string;
   issueNumber: number;
   issueTitle: string;
+  issueLastUpdatedAt?: number;
 }
 
 interface IssueNotFoundEvent {
@@ -203,6 +206,8 @@ export function WorktreeStoreProvider({ children }: { children: ReactNode }) {
             prTitle: event.prTitle ?? existing.prTitle,
             issueNumber: event.issueNumber ?? existing.issueNumber,
             issueTitle: event.issueTitle ?? existing.issueTitle,
+            prLastUpdatedAt: event.prLastUpdatedAt ?? existing.prLastUpdatedAt,
+            issueLastUpdatedAt: event.issueLastUpdatedAt ?? existing.issueLastUpdatedAt,
           },
           store.getState().nextVersion()
         );
@@ -239,6 +244,7 @@ export function WorktreeStoreProvider({ children }: { children: ReactNode }) {
             ...existing,
             issueNumber: event.issueNumber,
             issueTitle: event.issueTitle,
+            issueLastUpdatedAt: event.issueLastUpdatedAt ?? existing.issueLastUpdatedAt,
           },
           store.getState().nextVersion()
         );

--- a/src/contexts/WorktreeStoreContext.tsx
+++ b/src/contexts/WorktreeStoreContext.tsx
@@ -227,6 +227,8 @@ export function WorktreeStoreProvider({ children }: { children: ReactNode }) {
             prUrl: undefined,
             prState: undefined,
             prTitle: undefined,
+            prLastUpdatedAt: undefined,
+            issueLastUpdatedAt: undefined,
           },
           store.getState().nextVersion()
         );
@@ -263,6 +265,7 @@ export function WorktreeStoreProvider({ children }: { children: ReactNode }) {
             ...existing,
             issueNumber: undefined,
             issueTitle: undefined,
+            issueLastUpdatedAt: undefined,
           },
           store.getState().nextVersion()
         );

--- a/src/store/createWorktreeStore.ts
+++ b/src/store/createWorktreeStore.ts
@@ -203,6 +203,8 @@ function snapshotsEqual(a: WorktreeSnapshot, b: WorktreeSnapshot): boolean {
     a.prTitle === b.prTitle &&
     a.issueNumber === b.issueNumber &&
     a.issueTitle === b.issueTitle &&
+    a.prLastUpdatedAt === b.prLastUpdatedAt &&
+    a.issueLastUpdatedAt === b.issueLastUpdatedAt &&
     a.taskId === b.taskId &&
     a.hasPlanFile === b.hasPlanFile &&
     a.planFilePath === b.planFilePath &&


### PR DESCRIPTION
## Summary
This PR adds freshness indicators to the worktree-card PR and Issue badges. When the renderer's SWR cache has newer GitHub data than the workspace-host's polled snapshot, the badge dims and surfaces a tooltip suffix indicating how fresh the cached data is. The workspace-host stays authoritative for the badge value -- the SWR cache is only authoritative for freshness level.

Resolves #7677

## Changes
- Plumb `prLastUpdatedAt` and `issueLastUpdatedAt` timestamps from `PullRequestService` through 5 workspace-host boundaries into `WorktreeSnapshot` and renderer events
- Add `useGitHubBadgeFreshness` hook comparing row timestamps against the SWR cache via `useSyncExternalStore`
- Apply `freshnessOpacityClass` dimming and `freshnessSuffix` tooltip text when the SWR cache has newer data than the workspace-host row
- Fix snapshot guard to include freshness timestamps in `snapshotsEqual` comparison, and clear timestamps on badge removal

## Testing
- TypeScript passes across all 3 configs
- ESLint reports 0 new errors
- 181 vitest tests pass, including new unit tests for `useGitHubBadgeFreshness`