### PR TITLE
fix(safeStringify): consolidate onto safe-stable-stringify v2.5.0

### DIFF
--- a/electron/utils/logger.ts
+++ b/electron/utils/logger.ts
@@ -501,7 +501,7 @@ function safeStringify(value: unknown): string {
         return val;
       },
       2
-    );
+    ) as string;
   } catch (error) {
     return `[Unable to stringify: ${String(error)}]`;
   }

--- a/electron/utils/logger.ts
+++ b/electron/utils/logger.ts
@@ -1,3 +1,4 @@
+import { configure } from "safe-stable-stringify";
 import { getErrorDetails } from "./errorTypes.js";
 import {
   appendFileSync,
@@ -479,12 +480,13 @@ function flushLogs(): void {
   }
 }
 
+const loggerStringify = configure({ bigint: false });
+
 function safeStringify(value: unknown): string {
-  const seen = new WeakSet<object>();
   const sensitivePatterns = ["secret", "token", "password", "key"];
 
   try {
-    return JSON.stringify(
+    return loggerStringify(
       value,
       (key, val) => {
         const lowerKey = key.toLowerCase();
@@ -495,11 +497,6 @@ function safeStringify(value: unknown): string {
         }
 
         if (typeof val === "bigint") return val.toString();
-
-        if (val && typeof val === "object") {
-          if (seen.has(val as object)) return "[Circular]";
-          seen.add(val as object);
-        }
 
         return val;
       },

--- a/electron/utils/safeStringify.ts
+++ b/electron/utils/safeStringify.ts
@@ -14,7 +14,7 @@ export function safeStringify(value: unknown, space?: string | number): string {
   if (value === undefined) return undefined as unknown as string;
 
   try {
-    return stringify(value, replacer, space);
+    return stringify(value, replacer, space) as string;
   } catch {
     try {
       return String(value);

--- a/electron/utils/safeStringify.ts
+++ b/electron/utils/safeStringify.ts
@@ -1,24 +1,20 @@
-/**
- * Safely stringify a value, handling BigInt, circular references, and other
- * non-serializable types. For use in the main process (diagnostics, exports).
- */
-export function safeStringify(value: unknown, space?: string | number): string {
-  const seen = new WeakSet<object>();
+import { configure } from "safe-stable-stringify";
 
-  const replacer = (_key: string, val: unknown): unknown => {
-    if (typeof val === "bigint") return val.toString();
-    if (typeof val === "symbol") return val.toString();
-    if (typeof val === "function") return `[Function: ${val.name || "anonymous"}]`;
-    if (val instanceof Error) return { name: val.name, message: val.message, stack: val.stack };
-    if (val !== null && typeof val === "object") {
-      if (seen.has(val)) return "[Circular]";
-      seen.add(val);
-    }
-    return val;
-  };
+const stringify = configure({ bigint: false });
+
+function replacer(_key: string, val: unknown): unknown {
+  if (typeof val === "bigint") return val.toString();
+  if (typeof val === "symbol") return val.toString();
+  if (typeof val === "function") return `[Function: ${val.name || "anonymous"}]`;
+  if (val instanceof Error) return { name: val.name, message: val.message, stack: val.stack };
+  return val;
+}
+
+export function safeStringify(value: unknown, space?: string | number): string {
+  if (value === undefined) return undefined as unknown as string;
 
   try {
-    return JSON.stringify(value, replacer, space);
+    return stringify(value, replacer, space);
   } catch {
     try {
       return String(value);

--- a/package-lock.json
+++ b/package-lock.json
@@ -19,6 +19,7 @@
         "node-addon-api": "^7.1.0",
         "node-pty": "1.2.0-beta.12",
         "react-colorful": "^5.6.1",
+        "safe-stable-stringify": "^2.5.0",
         "win-job-object": "file:electron/native/win-job-object"
       },
       "devDependencies": {
@@ -18192,6 +18193,15 @@
       },
       "bin": {
         "safe-regex2": "bin/safe-regex2.js"
+      }
+    },
+    "node_modules/safe-stable-stringify": {
+      "version": "2.5.0",
+      "resolved": "https://registry.npmjs.org/safe-stable-stringify/-/safe-stable-stringify-2.5.0.tgz",
+      "integrity": "sha512-b3rppTKm9T+PsVCBEOUR46GWI7fdOs00VKZ1+9c1EWDaDMvjQc6tUwuFyIprgGgTcWoVHSKrU8H31ZHA2e0RHA==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=10"
       }
     },
     "node_modules/safer-buffer": {

--- a/package.json
+++ b/package.json
@@ -99,6 +99,7 @@
     "node-addon-api": "^7.1.0",
     "node-pty": "1.2.0-beta.12",
     "react-colorful": "^5.6.1",
+    "safe-stable-stringify": "^2.5.0",
     "win-job-object": "file:electron/native/win-job-object"
   },
   "optionalDependencies": {

--- a/src/lib/__tests__/safeStringify.test.ts
+++ b/src/lib/__tests__/safeStringify.test.ts
@@ -172,6 +172,15 @@ describe("safeStringify", () => {
   });
 
   it("handles top-level BigInt", () => {
-    expect(safeStringify(BigInt(42))).toBe('"42"');
+    expect(safeStringify(BigInt("9007199254740993123456789"))).toBe('"9007199254740993123456789"');
+  });
+
+  it("handles circular reference containing BigInt", () => {
+    const obj: Record<string, unknown> = {
+      id: BigInt("999999999999999999999"),
+    };
+    obj.self = obj;
+    const result = safeStringify(obj);
+    expect(result).toBe('{"id":"999999999999999999999","self":"[Circular]"}');
   });
 });

--- a/src/lib/__tests__/safeStringify.test.ts
+++ b/src/lib/__tests__/safeStringify.test.ts
@@ -159,4 +159,19 @@ describe("safeStringify", () => {
     expect(parsed.user).toBe("alice");
     expect(result).toContain("\n");
   });
+
+  it("invokes replacer when space is omitted", () => {
+    const obj = { fn: function foo() {} };
+    const result = safeStringify(obj);
+    expect(result).toBe('{"fn":"[Function: foo]"}');
+  });
+
+  it("produces deterministic key order", () => {
+    const obj = { b: 1, a: 2, c: 3 };
+    expect(safeStringify(obj)).toBe('{"a":2,"b":1,"c":3}');
+  });
+
+  it("handles top-level BigInt", () => {
+    expect(safeStringify(BigInt(42))).toBe('"42"');
+  });
 });

--- a/src/lib/safeStringify.ts
+++ b/src/lib/safeStringify.ts
@@ -1,37 +1,20 @@
-/**
- * Safely stringify a value, handling BigInt, circular references, and other non-serializable types.
- */
-export function safeStringify(value: unknown, space?: string | number): string {
-  const seen = new WeakSet<object>();
+import { configure } from "safe-stable-stringify";
 
-  const replacer = (_key: string, val: unknown): unknown => {
-    if (typeof val === "bigint") {
-      return val.toString();
-    }
-    if (typeof val === "symbol") {
-      return val.toString();
-    }
-    if (typeof val === "function") {
-      return `[Function: ${val.name || "anonymous"}]`;
-    }
-    if (val instanceof Error) {
-      return {
-        name: val.name,
-        message: val.message,
-        stack: val.stack,
-      };
-    }
-    if (val !== null && typeof val === "object") {
-      if (seen.has(val)) {
-        return "[Circular]";
-      }
-      seen.add(val);
-    }
-    return val;
-  };
+const stringify = configure({ bigint: false });
+
+function replacer(_key: string, val: unknown): unknown {
+  if (typeof val === "bigint") return val.toString();
+  if (typeof val === "symbol") return val.toString();
+  if (typeof val === "function") return `[Function: ${val.name || "anonymous"}]`;
+  if (val instanceof Error) return { name: val.name, message: val.message, stack: val.stack };
+  return val;
+}
+
+export function safeStringify(value: unknown, space?: string | number): string {
+  if (value === undefined) return undefined as unknown as string;
 
   try {
-    return JSON.stringify(value, replacer, space);
+    return stringify(value, replacer, space);
   } catch {
     try {
       return String(value);

--- a/src/lib/safeStringify.ts
+++ b/src/lib/safeStringify.ts
@@ -11,10 +11,12 @@ function replacer(_key: string, val: unknown): unknown {
 }
 
 export function safeStringify(value: unknown, space?: string | number): string {
+  // eslint-disable-next-line @typescript-eslint/no-unsafe-type-assertion
   if (value === undefined) return undefined as unknown as string;
 
   try {
-    return stringify(value, replacer, space);
+    // eslint-disable-next-line @typescript-eslint/no-unsafe-type-assertion
+    return stringify(value, replacer, space) as string;
   } catch {
     try {
       return String(value);


### PR DESCRIPTION
## Summary
- Replaced two parallel `safeStringify` implementations with `safe-stable-stringify` v2.5.0, the same library pino uses internally.
- Deterministic key ordering makes log diffs and diagnostics dumps far more reliable.
- Consistent handling of `Map`, `Set`, `TypedArray`, `Symbol`, cycles, and `BigInt` across both call paths — roughly 50 lines of duplicate code removed.

Resolves #7633

## Changes
- Used `configure({ bigint: false })` at both call sites so BigInts serialize via `.toString()` instead of the library's lossy `Number` conversion (relevant for process-tree tick counters that routinely exceed `MAX_SAFE_INTEGER`).
- Logger call site retains its sensitive-key redaction replacer; standalone `safeStringify` keeps its `Symbol`/`Function`/`Error` handling.
- Added 4 tests: deterministic key order, top-level BigInt above `MAX_SAFE_INTEGER`, circular reference containing a BigInt, and replacer invocation without space.

## Testing
- All 26 existing + new `safeStringify` tests pass.
- Typecheck, lint, and format all clean.