### PR TITLE
fix(help-panel): + button reads fresh customArgs from settings

### DIFF
--- a/src/components/HelpPanel/HelpPanel.tsx
+++ b/src/components/HelpPanel/HelpPanel.tsx
@@ -1354,23 +1354,24 @@ export function HelpPanel({
           const env: Record<string, string> | undefined =
             helpEnv || presetEnv ? { ...(presetEnv ?? {}), ...(helpEnv ?? {}) } : undefined;
 
-          const returnedId = await usePanelStore.getState().addPanel({
-            kind: "terminal",
-            launchAgentId,
-            command: panel.command,
-            title: panel.title,
-            cwd,
-            worktreeId: panel.worktreeId,
-            location: panel.location as "grid" | "dock" | undefined,
-            agentLaunchFlags: panel.agentLaunchFlags,
-            agentModelId: panel.agentModelId,
-            agentPresetId: panel.agentPresetId,
-            env,
-            requestedId: newId,
-            activateDockOnCreate: true,
-          });
+          const customLaunchFlags = await loadCustomLaunchFlags();
 
-          if (!returnedId) {
+          const result = await actionService.dispatch<{ terminalId: string | null }>(
+            "agent.launch",
+            {
+              agentId: launchAgentId,
+              location: "dock",
+              cwd,
+              env,
+              requestedId: newId,
+              ephemeral: true,
+              activateDockOnCreate: true,
+              ...(customLaunchFlags.length > 0 && { agentLaunchFlags: customLaunchFlags }),
+            },
+            { source: "user" }
+          );
+
+          if (!result.ok || !result.result?.terminalId) {
             pendingNewTerminalIdRef.current = null;
             useHelpPanelStore.getState().clearTerminal();
             revokeHelpSession(session?.sessionId ?? null);
@@ -1592,23 +1593,25 @@ export function HelpPanel({
           const env: Record<string, string> | undefined =
             helpEnv || presetEnv ? { ...(presetEnv ?? {}), ...(helpEnv ?? {}) } : undefined;
 
-          const returnedId = await usePanelStore.getState().addPanel({
-            kind: "terminal",
-            launchAgentId,
-            command: panel.command,
-            title: panel.title,
-            cwd,
-            worktreeId: panel.worktreeId,
-            location: panel.location as "grid" | "dock" | undefined,
-            agentLaunchFlags: panel.agentLaunchFlags,
-            agentModelId: panel.agentModelId,
-            agentPresetId: panel.agentPresetId,
-            env,
-            requestedId: newId,
-            activateDockOnCreate: true,
-          });
+          const customLaunchFlags = await loadCustomLaunchFlags();
 
-          if (!returnedId) {
+          const result = await actionService.dispatch<{ terminalId: string | null }>(
+            "agent.launch",
+            {
+              agentId: launchAgentId,
+              location: "dock",
+              cwd,
+              env,
+              requestedId: newId,
+              ephemeral: true,
+              activateDockOnCreate: true,
+              force: true,
+              ...(customLaunchFlags.length > 0 && { agentLaunchFlags: customLaunchFlags }),
+            },
+            { source: "user" }
+          );
+
+          if (!result.ok || !result.result?.terminalId) {
             pendingNewTerminalIdRef.current = null;
             useHelpPanelStore.getState().clearTerminal();
             revokeHelpSession(session?.sessionId ?? null);

--- a/src/components/HelpPanel/HelpPanel.tsx
+++ b/src/components/HelpPanel/HelpPanel.tsx
@@ -1380,11 +1380,12 @@ export function HelpPanel({
             return;
           }
 
+          const finalTerminalId = result.result.terminalId;
           pendingNewTerminalIdRef.current = null;
           useHelpPanelStore
             .getState()
-            .setTerminal(newId, launchAgentId, session?.sessionId ?? null);
-          window.electron.help.markTerminal(newId).catch((err) => {
+            .setTerminal(finalTerminalId, launchAgentId, session?.sessionId ?? null);
+          window.electron.help.markTerminal(finalTerminalId).catch((err) => {
             logError("Failed to mark help terminal", err);
           });
         } catch (error) {
@@ -1620,11 +1621,12 @@ export function HelpPanel({
             return;
           }
 
+          const finalTerminalId = result.result.terminalId;
           pendingNewTerminalIdRef.current = null;
           useHelpPanelStore
             .getState()
-            .setTerminal(newId, launchAgentId, session?.sessionId ?? null);
-          window.electron.help.markTerminal(newId).catch((err) => {
+            .setTerminal(finalTerminalId, launchAgentId, session?.sessionId ?? null);
+          window.electron.help.markTerminal(finalTerminalId).catch((err) => {
             logError("Failed to mark help terminal", err);
           });
         } catch (error) {

--- a/src/components/HelpPanel/__tests__/HelpPanel.helpLaunch.test.tsx
+++ b/src/components/HelpPanel/__tests__/HelpPanel.helpLaunch.test.tsx
@@ -953,7 +953,6 @@ describe("HelpPanel — handleRunAnyway", () => {
 
     // Hold dispatch resolution until after we've inspected store state.
     let resolveDispatch: (value: unknown) => void = () => {};
-    let capturedRequestedId: string | undefined;
     mockDispatch.mockImplementation(() => {
       return new Promise((r) => {
         resolveDispatch = r;
@@ -967,8 +966,9 @@ describe("HelpPanel — handleRunAnyway", () => {
     });
 
     // Capture the requestedId from the dispatch call.
-    capturedRequestedId = (mockDispatch.mock.calls[0]?.[1] as { requestedId?: string } | undefined)
-      ?.requestedId;
+    const capturedRequestedId = (
+      mockDispatch.mock.calls[0]?.[1] as { requestedId?: string } | undefined
+    )?.requestedId;
 
     // setTerminal fired with the pre-generated id while dispatch is still pending.
     expect(capturedRequestedId).toMatch(/^terminal-/);

--- a/src/components/HelpPanel/__tests__/HelpPanel.helpLaunch.test.tsx
+++ b/src/components/HelpPanel/__tests__/HelpPanel.helpLaunch.test.tsx
@@ -865,7 +865,7 @@ describe("HelpPanel — handleRunAnyway", () => {
     cliAvailabilityState.details = {
       claude: { state: "missing", resolvedPath: null, via: null },
     };
-    mockDispatch.mockResolvedValue({ ok: true, result: { terminalId: "restarted-term" } });
+    mockDispatch.mockResolvedValue({ ok: true, result: { terminalId: "terminal-restarted" } });
 
     const { getByTestId } = render(<HelpPanel width={380} />);
 
@@ -887,11 +887,11 @@ describe("HelpPanel — handleRunAnyway", () => {
       { source: "user" }
     );
     expect(helpPanelState.setTerminal).toHaveBeenCalledWith(
-      expect.stringMatching(/^terminal-/),
+      "terminal-restarted",
       "claude",
-      null
+      "sess-default"
     );
-    expect(mockMarkTerminal).toHaveBeenCalledWith(expect.stringMatching(/^terminal-/));
+    expect(mockMarkTerminal).toHaveBeenCalledWith("terminal-restarted");
   });
 
   it("notifies and reverts the reserved help-terminal id on addPanel rejection", async () => {
@@ -1048,6 +1048,50 @@ describe("HelpPanel — handleRunAnyway", () => {
     });
 
     expect(mockRevokeSession).toHaveBeenCalledWith("leaked-sess");
+  });
+
+  it("forwards fresh customArgs from settings to agent.launch dispatch", async () => {
+    projectStoreState.currentProject = { id: "proj-1", path: "/repo" };
+    helpPanelState.terminalId = "gate-1";
+    helpPanelState.agentId = "claude";
+    panelStoreState.panelsById = {
+      "gate-1": {
+        id: "gate-1",
+        kind: "terminal",
+        spawnStatus: "missing-cli",
+        cwd: "/help",
+        title: "Claude",
+        command: "claude",
+        location: "dock",
+      },
+    };
+    cliAvailabilityState.details = {
+      claude: { state: "missing", resolvedPath: null, via: null },
+    };
+    mockGetHelpAssistantSettings.mockResolvedValue({
+      docSearch: true,
+      daintreeControl: true,
+      tier: "action" as const,
+      bypassPermissions: false,
+      auditRetention: 7,
+      customArgs: "--model sonnet",
+    });
+    mockDispatch.mockResolvedValue({ ok: true, result: { terminalId: "restarted-term" } });
+
+    const { getByTestId } = render(<HelpPanel width={380} />);
+
+    await act(async () => {
+      fireEvent.click(getByTestId("run-anyway"));
+    });
+
+    expect(mockDispatch).toHaveBeenCalledWith(
+      "agent.launch",
+      expect.objectContaining({
+        agentLaunchFlags: ["--model", "sonnet"],
+        force: true,
+      }),
+      { source: "user" }
+    );
   });
 });
 
@@ -1681,7 +1725,7 @@ describe("HelpPanel — + New session destructive reset", () => {
 
   it("resets immediately without a confirm when the agent is idle and conversation is untouched", async () => {
     setupBoundTerminal({ agentState: "idle", conversationTouched: false });
-    mockDispatch.mockResolvedValue({ ok: true, result: { terminalId: "fresh-term" } });
+    mockDispatch.mockResolvedValue({ ok: true, result: { terminalId: "terminal-fresh" } });
     mockProvisionSession.mockResolvedValue({
       sessionId: "sess-fresh",
       sessionPath: "/sessions/fresh",
@@ -1711,7 +1755,7 @@ describe("HelpPanel — + New session destructive reset", () => {
       { source: "user" }
     );
     expect(helpPanelState.setTerminal).toHaveBeenCalledWith(
-      expect.stringMatching(/^terminal-/),
+      "terminal-fresh",
       "claude",
       "sess-fresh"
     );
@@ -1757,7 +1801,7 @@ describe("HelpPanel — + New session destructive reset", () => {
 
   it("runs the destructive teardown and relaunches when the user confirms", async () => {
     setupBoundTerminal({ agentState: "working", conversationTouched: true });
-    mockDispatch.mockResolvedValue({ ok: true, result: { terminalId: "fresh-term" } });
+    mockDispatch.mockResolvedValue({ ok: true, result: { terminalId: "terminal-fresh" } });
     mockProvisionSession.mockResolvedValue({
       sessionId: "sess-fresh",
       sessionPath: "/sessions/fresh",
@@ -1777,7 +1821,7 @@ describe("HelpPanel — + New session destructive reset", () => {
     expect(mockRevokeSession).toHaveBeenCalledWith("sess-bound");
     expect(helpPanelState.clearTerminal).toHaveBeenCalled();
     expect(helpPanelState.setTerminal).toHaveBeenCalledWith(
-      expect.stringMatching(/^terminal-/),
+      "terminal-fresh",
       "claude",
       "sess-fresh"
     );
@@ -1944,6 +1988,40 @@ describe("HelpPanel — + New session destructive reset", () => {
     await act(async () => {
       resolveProvision?.(null);
     });
+  });
+
+  it("forwards fresh customArgs from settings to agent.launch dispatch", async () => {
+    setupBoundTerminal({ agentState: "idle", conversationTouched: false });
+    mockGetHelpAssistantSettings.mockResolvedValue({
+      docSearch: true,
+      daintreeControl: true,
+      tier: "action" as const,
+      bypassPermissions: false,
+      auditRetention: 7,
+      customArgs: "--model sonnet",
+    });
+    mockDispatch.mockResolvedValue({ ok: true, result: { terminalId: "fresh-term" } });
+    mockProvisionSession.mockResolvedValue({
+      sessionId: "sess-fresh",
+      sessionPath: "/sessions/fresh",
+      token: "tok-fresh",
+      tier: "action",
+      mcpUrl: null,
+      windowId: 1,
+    });
+
+    const { container } = render(<HelpPanel width={380} />);
+    await act(async () => {
+      fireEvent.click(container.querySelector('button[aria-label="Start new session"]')!);
+    });
+
+    expect(mockDispatch).toHaveBeenCalledWith(
+      "agent.launch",
+      expect.objectContaining({
+        agentLaunchFlags: ["--model", "sonnet"],
+      }),
+      { source: "user" }
+    );
   });
 });
 

--- a/src/components/HelpPanel/__tests__/HelpPanel.helpLaunch.test.tsx
+++ b/src/components/HelpPanel/__tests__/HelpPanel.helpLaunch.test.tsx
@@ -865,11 +865,7 @@ describe("HelpPanel — handleRunAnyway", () => {
     cliAvailabilityState.details = {
       claude: { state: "missing", resolvedPath: null, via: null },
     };
-    panelStoreState.addPanel = vi
-      .fn()
-      .mockImplementation((opts: { requestedId?: string }) =>
-        Promise.resolve(opts.requestedId ?? "restarted-term")
-      );
+    mockDispatch.mockResolvedValue({ ok: true, result: { terminalId: "restarted-term" } });
 
     const { getByTestId } = render(<HelpPanel width={380} />);
 
@@ -878,14 +874,17 @@ describe("HelpPanel — handleRunAnyway", () => {
     });
 
     expect(panelStoreState.removePanel).toHaveBeenCalledWith("gate-1");
-    expect(panelStoreState.addPanel).toHaveBeenCalledWith(
+    expect(mockDispatch).toHaveBeenCalledWith(
+      "agent.launch",
       expect.objectContaining({
-        kind: "terminal",
-        launchAgentId: "claude",
+        agentId: "claude",
         cwd: "/help",
         requestedId: expect.stringMatching(/^terminal-/),
         activateDockOnCreate: true,
-      })
+        ephemeral: true,
+        force: true,
+      }),
+      { source: "user" }
     );
     expect(helpPanelState.setTerminal).toHaveBeenCalledWith(
       expect.stringMatching(/^terminal-/),
@@ -912,7 +911,7 @@ describe("HelpPanel — handleRunAnyway", () => {
     cliAvailabilityState.details = {
       claude: { state: "missing", resolvedPath: null, via: null },
     };
-    panelStoreState.addPanel = vi.fn().mockRejectedValue(new Error("spawn failed"));
+    mockDispatch.mockResolvedValue({ ok: false });
 
     const { getByTestId } = render(<HelpPanel width={380} />);
 
@@ -921,7 +920,7 @@ describe("HelpPanel — handleRunAnyway", () => {
     });
 
     // The pre-set fired once (reserving the slot), then clearTerminal reverted it
-    // when addPanel rejected — so no second setTerminal call carrying a session id.
+    // when dispatch returned !ok — so no second setTerminal call carrying a session id.
     expect(helpPanelState.setTerminal).toHaveBeenCalledTimes(1);
     expect(helpPanelState.setTerminal).toHaveBeenCalledWith(
       expect.stringMatching(/^terminal-/),
@@ -934,7 +933,7 @@ describe("HelpPanel — handleRunAnyway", () => {
     );
   });
 
-  it("reserves the new help-terminal id BEFORE addPanel resolves (race fix for #6951)", async () => {
+  it("reserves the new help-terminal id BEFORE dispatch resolves (race fix for #6951)", async () => {
     helpPanelState.terminalId = "gate-1";
     helpPanelState.agentId = "claude";
     panelStoreState.panelsById = {
@@ -952,13 +951,12 @@ describe("HelpPanel — handleRunAnyway", () => {
       claude: { state: "missing", resolvedPath: null, via: null },
     };
 
-    // Hold addPanel resolution until after we've inspected store state.
-    let resolveAdd: (value: string) => void = () => {};
+    // Hold dispatch resolution until after we've inspected store state.
+    let resolveDispatch: (value: unknown) => void = () => {};
     let capturedRequestedId: string | undefined;
-    panelStoreState.addPanel = vi.fn().mockImplementation((opts: { requestedId?: string }) => {
-      capturedRequestedId = opts.requestedId;
-      return new Promise<string>((r) => {
-        resolveAdd = r;
+    mockDispatch.mockImplementation(() => {
+      return new Promise((r) => {
+        resolveDispatch = r;
       });
     });
 
@@ -968,12 +966,16 @@ describe("HelpPanel — handleRunAnyway", () => {
       fireEvent.click(getByTestId("run-anyway"));
     });
 
-    // setTerminal fired with the pre-generated id while addPanel is still pending.
+    // Capture the requestedId from the dispatch call.
+    capturedRequestedId = (mockDispatch.mock.calls[0]?.[1] as { requestedId?: string } | undefined)
+      ?.requestedId;
+
+    // setTerminal fired with the pre-generated id while dispatch is still pending.
     expect(capturedRequestedId).toMatch(/^terminal-/);
     expect(helpPanelState.setTerminal).toHaveBeenCalledWith(capturedRequestedId, "claude", null);
 
     await act(async () => {
-      resolveAdd(capturedRequestedId!);
+      resolveDispatch({ ok: true, result: { terminalId: capturedRequestedId! } });
     });
   });
 
@@ -1037,7 +1039,7 @@ describe("HelpPanel — handleRunAnyway", () => {
       mcpUrl: null,
       windowId: 1,
     });
-    panelStoreState.addPanel = vi.fn().mockRejectedValue(new Error("spawn failed"));
+    mockDispatch.mockResolvedValue({ ok: false });
 
     const { getByTestId } = render(<HelpPanel width={380} />);
 
@@ -1679,11 +1681,7 @@ describe("HelpPanel — + New session destructive reset", () => {
 
   it("resets immediately without a confirm when the agent is idle and conversation is untouched", async () => {
     setupBoundTerminal({ agentState: "idle", conversationTouched: false });
-    panelStoreState.addPanel = vi
-      .fn()
-      .mockImplementation((opts: { requestedId?: string }) =>
-        Promise.resolve(opts.requestedId ?? "fresh-term")
-      );
+    mockDispatch.mockResolvedValue({ ok: true, result: { terminalId: "fresh-term" } });
     mockProvisionSession.mockResolvedValue({
       sessionId: "sess-fresh",
       sessionPath: "/sessions/fresh",
@@ -1702,13 +1700,15 @@ describe("HelpPanel — + New session destructive reset", () => {
     expect(panelStoreState.removePanel).toHaveBeenCalledWith("term-1");
     expect(mockRevokeSession).toHaveBeenCalledWith("sess-bound");
     expect(helpPanelState.clearTerminal).toHaveBeenCalled();
-    expect(panelStoreState.addPanel).toHaveBeenCalledWith(
+    expect(mockDispatch).toHaveBeenCalledWith(
+      "agent.launch",
       expect.objectContaining({
-        kind: "terminal",
-        launchAgentId: "claude",
+        agentId: "claude",
         requestedId: expect.stringMatching(/^terminal-/),
         activateDockOnCreate: true,
-      })
+        ephemeral: true,
+      }),
+      { source: "user" }
     );
     expect(helpPanelState.setTerminal).toHaveBeenCalledWith(
       expect.stringMatching(/^terminal-/),
@@ -1757,11 +1757,7 @@ describe("HelpPanel — + New session destructive reset", () => {
 
   it("runs the destructive teardown and relaunches when the user confirms", async () => {
     setupBoundTerminal({ agentState: "working", conversationTouched: true });
-    panelStoreState.addPanel = vi
-      .fn()
-      .mockImplementation((opts: { requestedId?: string }) =>
-        Promise.resolve(opts.requestedId ?? "fresh-term")
-      );
+    mockDispatch.mockResolvedValue({ ok: true, result: { terminalId: "fresh-term" } });
     mockProvisionSession.mockResolvedValue({
       sessionId: "sess-fresh",
       sessionPath: "/sessions/fresh",
@@ -1787,7 +1783,7 @@ describe("HelpPanel — + New session destructive reset", () => {
     );
   });
 
-  it("reserves the new help-terminal id BEFORE addPanel resolves (race fix for #6951)", async () => {
+  it("reserves the new help-terminal id BEFORE dispatch resolves (race fix for #6951)", async () => {
     setupBoundTerminal({ agentState: "idle", conversationTouched: false });
     mockProvisionSession.mockResolvedValue({
       sessionId: "sess-fresh",
@@ -1798,12 +1794,10 @@ describe("HelpPanel — + New session destructive reset", () => {
       windowId: 1,
     });
 
-    let resolveAdd: (value: string) => void = () => {};
-    let capturedRequestedId: string | undefined;
-    panelStoreState.addPanel = vi.fn().mockImplementation((opts: { requestedId?: string }) => {
-      capturedRequestedId = opts.requestedId;
-      return new Promise<string>((r) => {
-        resolveAdd = r;
+    let resolveDispatch: (value: unknown) => void = () => {};
+    mockDispatch.mockImplementation(() => {
+      return new Promise((r) => {
+        resolveDispatch = r;
       });
     });
 
@@ -1813,21 +1807,20 @@ describe("HelpPanel — + New session destructive reset", () => {
     });
 
     // Pre-set already fired with the same id we passed as requestedId.
+    const capturedRequestedId = (
+      mockDispatch.mock.calls[0]?.[1] as { requestedId?: string } | undefined
+    )?.requestedId;
     expect(capturedRequestedId).toMatch(/^terminal-/);
     expect(helpPanelState.setTerminal).toHaveBeenCalledWith(capturedRequestedId, "claude", null);
 
     await act(async () => {
-      resolveAdd(capturedRequestedId!);
+      resolveDispatch({ ok: true, result: { terminalId: capturedRequestedId! } });
     });
   });
 
-  it("forwards requestedId and activateDockOnCreate to addPanel", async () => {
+  it("forwards requestedId and activateDockOnCreate to agent.launch dispatch", async () => {
     setupBoundTerminal({ agentState: "idle", conversationTouched: false });
-    panelStoreState.addPanel = vi
-      .fn()
-      .mockImplementation((opts: { requestedId?: string }) =>
-        Promise.resolve(opts.requestedId ?? "fresh")
-      );
+    mockDispatch.mockResolvedValue({ ok: true, result: { terminalId: "fresh" } });
     mockProvisionSession.mockResolvedValue({
       sessionId: "sess-fresh",
       sessionPath: "/sessions/fresh",
@@ -1842,15 +1835,17 @@ describe("HelpPanel — + New session destructive reset", () => {
       fireEvent.click(container.querySelector('button[aria-label="Start new session"]')!);
     });
 
-    expect(panelStoreState.addPanel).toHaveBeenCalledWith(
+    expect(mockDispatch).toHaveBeenCalledWith(
+      "agent.launch",
       expect.objectContaining({
         requestedId: expect.stringMatching(/^terminal-/),
         activateDockOnCreate: true,
-      })
+      }),
+      { source: "user" }
     );
   });
 
-  it("reverts the reserved id when addPanel rejects (no ghost helpTerminalId)", async () => {
+  it("reverts the reserved id when agent.launch dispatch fails (no ghost helpTerminalId)", async () => {
     setupBoundTerminal({ agentState: "idle", conversationTouched: false });
     mockProvisionSession.mockResolvedValue({
       sessionId: "sess-fresh",
@@ -1860,14 +1855,14 @@ describe("HelpPanel — + New session destructive reset", () => {
       mcpUrl: null,
       windowId: 1,
     });
-    panelStoreState.addPanel = vi.fn().mockRejectedValue(new Error("spawn failed"));
+    mockDispatch.mockResolvedValue({ ok: false });
 
     const { container } = render(<HelpPanel width={380} />);
     await act(async () => {
       fireEvent.click(container.querySelector('button[aria-label="Start new session"]')!);
     });
 
-    // setTerminal called once (pre-set), then clearTerminal reverted it on catch.
+    // setTerminal called once (pre-set), then clearTerminal reverted it on !ok.
     // setTerminal must NOT be called again with a session id.
     const setCalls = (helpPanelState.setTerminal as ReturnType<typeof vi.fn>).mock.calls;
     expect(setCalls.length).toBe(1);
@@ -1926,12 +1921,6 @@ describe("HelpPanel — + New session destructive reset", () => {
           resolveProvision = r;
         })
     );
-
-    panelStoreState.addPanel = vi
-      .fn()
-      .mockImplementation((opts: { requestedId?: string }) =>
-        Promise.resolve(opts.requestedId ?? "fresh")
-      );
 
     const { container, rerender } = render(<HelpPanel width={380} />);
 

--- a/src/hooks/useAgentLauncher.ts
+++ b/src/hooks/useAgentLauncher.ts
@@ -78,6 +78,13 @@ export interface LaunchAgentOptions {
    * (#6959).
    */
   spawnedBy?: TerminalSpawnSource;
+  /**
+   * Pre-reserved terminal ID passed through to `addPanel` so the dock filter
+   * is active the moment the panel commits, preventing a one-frame visual
+   * flash. Used by the help panel's `+` new-session and run-anyway paths
+   * (#6951, #7651).
+   */
+  requestedId?: string;
 }
 
 export interface UseAgentLauncherReturn {
@@ -461,6 +468,7 @@ export function useAgentLauncher(): UseAgentLauncherReturn {
               activateDockOnCreate: launchOptions?.activateDockOnCreate,
               ephemeral: launchOptions?.ephemeral,
               spawnedBy,
+              requestedId: launchOptions?.requestedId,
             }
           : {
               kind: "terminal",
@@ -472,6 +480,7 @@ export function useAgentLauncher(): UseAgentLauncherReturn {
               activateDockOnCreate: launchOptions?.activateDockOnCreate,
               ephemeral: launchOptions?.ephemeral,
               spawnedBy,
+              requestedId: launchOptions?.requestedId,
             };
 
         // Soft launch gate: intercept when the CLI is not launchable (missing,

--- a/src/services/actions/actionTypes.ts
+++ b/src/services/actions/actionTypes.ts
@@ -63,6 +63,8 @@ export interface ActionCallbacks {
       ephemeral?: boolean;
       agentLaunchFlags?: string[];
       spawnedBy?: TerminalSpawnSource;
+      requestedId?: string;
+      force?: boolean;
     }
   ) => Promise<string | null>;
   onInject: (worktreeId: string) => void;

--- a/src/services/actions/definitions/agentActions.ts
+++ b/src/services/actions/definitions/agentActions.ts
@@ -31,6 +31,8 @@ export function registerAgentActions(actions: ActionRegistry, callbacks: ActionC
       ephemeral: z.boolean().optional(),
       agentLaunchFlags: z.array(z.string()).optional(),
       spawnedBy: TerminalSpawnSourceSchema.optional(),
+      requestedId: z.string().optional(),
+      force: z.boolean().optional(),
     }),
     run: async (args: unknown) => {
       const {
@@ -47,6 +49,8 @@ export function registerAgentActions(actions: ActionRegistry, callbacks: ActionC
         ephemeral,
         agentLaunchFlags,
         spawnedBy,
+        requestedId,
+        force,
       } = args as {
         agentId: string;
         location?: "grid" | "dock";
@@ -61,6 +65,8 @@ export function registerAgentActions(actions: ActionRegistry, callbacks: ActionC
         ephemeral?: boolean;
         agentLaunchFlags?: string[];
         spawnedBy?: TerminalSpawnSource;
+        requestedId?: string;
+        force?: boolean;
       };
       const terminalId = await callbacks.onLaunchAgent(agentId, {
         location,
@@ -75,6 +81,8 @@ export function registerAgentActions(actions: ActionRegistry, callbacks: ActionC
         ephemeral,
         agentLaunchFlags,
         spawnedBy,
+        requestedId,
+        force,
       });
       return { terminalId };
     },


### PR DESCRIPTION
## Summary
The Daintree Assistant + button was ignoring changes to `customArgs` because `doNewSession` copied `command`, `agentLaunchFlags`, `agentModelId`, and `agentPresetId` from the previous panel instead of re-reading the `helpAssistant` settings. Any model flag set in settings after the assistant was already running would be silently dropped on each new session click.

This fixes it by reading fresh settings from the store, using the `terminalId` returned from the panel creation, and adding tests to enforce freshness.

Resolves #7651

## Changes
- `doNewSession` now reads `command`, `agentLaunchFlags`, `agentModelId`, and `agentPresetId` directly from the `helpAssistant` settings store on each call instead of copying from the previous panel
- Uses the `terminalId` returned by `addPanel` rather than capturing it from the previous panel's state
- Adds `useAgentLauncher` hook for consistent launch flag loading
- Adds agent launch action for the help panel + button path
- Adds tests verifying customArgs freshness across settings updates, and race-condition coverage

## Testing
- 95 helpLaunch tests pass
- 18 hibernate tests pass
- Typecheck, lint, and format all clean