### PR TITLE
refactor(store): replace cross-store getter injection with storeAccessors leaf module

### DIFF
--- a/docs/architecture/store-init-order.md
+++ b/docs/architecture/store-init-order.md
@@ -1,107 +1,102 @@
-# Store Module Init Order and Lazy-Getter Invariants
+# Cross-Store Accessor Module and Renderer Init Order
 
-This document describes why some renderer store modules intentionally avoid direct cross-store imports at module-evaluation time. The lazy-getter injection patterns that break circular dependencies are **load-bearing**—removing or changing them will crash the renderer at boot. Optional lazy dependency patterns (e.g., `panelPersistence`) fail silently when unset.
+This document describes how renderer store modules read each other's state without forming ESM import cycles. Cross-store reads route through a single dependency-free leaf module (`src/store/storeAccessors.ts`), and the live closures are registered inside `initStoreOrchestrator()` rather than at module-evaluation time. This pattern is **load-bearing**—changing it back to module-bottom setter injection will re-introduce the TDZ and silent-failure classes documented below.
 
 ## Why This Matters
 
-Renderer stores in Daintree use lazy getter injection to break circular dependencies that would cause Temporal Dead Zone (TDZ) errors at module initialization time. When a direct import cycle exists between ES modules (e.g., `projectStore.ts` imports `panelStore.ts` which imports back), accessing non-hoisted exports (`let`/`const`) before they're initialized throws `ReferenceError: Cannot access 'X' before initialization`. The renderer crashes before any UI appears, making these errors notoriously hard to debug.
+Renderer stores in Daintree are independent Zustand `create()` calls. Several stores (`panelStore`, `projectStore`, `worktreeStore`, `fleetArmingStore`) need to read each other in narrow places—e.g., `projectStore.buildOutgoingState()` snapshots panel state during a project switch, and `worktreeStore.applyWorktreeTerminalPolicy()` reads the fleet-armed set to keep cross-worktree terminals visible while fleet scope is active.
 
-The lazy getter pattern allows stores to reference each other **after** both modules finish evaluation by deferring the actual store lookup to a function closure. The setter is called at module-init time, but the closure is invoked later during runtime operations.
+Direct top-level imports between any pair of these stores form an ESM cycle. Cycles produce two failure modes:
 
-## Current Lazy Injection Sites
+1. **TDZ crash on boot.** `ReferenceError: Cannot access 'X' before initialization` when a module references a non-hoisted binding (`let`/`const`/`class`) from a partner that has started evaluating but not finished.
+2. **Silent stale-state failure.** If the cycle is "patched" with a getter that defaults to `null`, an inverted evaluation order leaves the closure unset—and call sites like `buildOutgoingState()` quietly return incomplete data instead of crashing.
 
-| Source Module | Target Module | Injection Type | Setter Call | Purpose |
-| --- | --- | --- | --- | --- |
-| `projectStore.ts` | `panelStore.ts` | Circular dependency | `panelStore.ts:524-529` | Snapshot persistable panel state synchronously before project switch |
-| `projectStore.ts` | `worktreeSelectionStore` | Circular dependency | `worktreeStore.ts:537-538` | Capture active worktree ID during project switch |
-| `persistence/panelPersistence.ts` | `projectStore.ts` | Optional lazy dep | `projectStore.ts:636` | Provide project ID getter for persistence operations (fails silently) |
+The accessor-module pattern eliminates both classes by routing all cross-store references through a leaf module that imports nothing, and by deferring closure registration to a single explicit init point.
 
-## How It Works
+## Architecture
 
-Setter functions are hoisted and available during module evaluation. The actual store lookup happens **inside** the closure, after both modules finish initialization.
+### Leaf accessor module (`src/store/storeAccessors.ts`)
+
+Holds five mutable getter slots and a paired reader for each. No imports from any store. Stores import from this leaf unidirectionally:
 
 ```typescript
-// In consuming module (e.g., projectStore.ts)
-let _getPanelStoreState:
-  | (() => {
-      panelsById: Record<string, TerminalInstance>;
-      panelIds: string[];
-      tabGroups: Map<string, TabGroup>;
-    })
-  | null = null;
+let _getPanelStoreState: (() => PanelStoreSnapshot) | null = null;
 
-export function setPanelStoreGetter(
-  getter: () => {
-    panelsById: Record<string, TerminalInstance>;
-    panelIds: string[];
-    tabGroups: Map<string, TabGroup>;
-  }
-): void {
+export function setPanelStoreAccessor(getter: () => PanelStoreSnapshot): void {
   _getPanelStoreState = getter;
 }
 
-// Use in actions
-const terminalState = _getPanelStoreState?.();
-if (!terminalState) return;
+export function getPanelStoreSnapshot(): PanelStoreSnapshot | null {
+  return _getPanelStoreState?.() ?? null;
+}
 ```
+
+### Registration in `initStoreOrchestrator()`
+
+`rendererStoreOrchestrator.ts` already owns all cross-store subscriptions and lifecycle. It is the only place that registers accessor closures, and it registers them **before** the idempotency guard so test `destroyStoreOrchestrator()` + re-init reconnects fresh closures to the current store singletons:
 
 ```typescript
-// In source module (e.g., panelStore.ts) — call at module BOTTOM
-import { setPanelStoreGetter } from "./projectStore";
+export function initStoreOrchestrator(): () => void {
+  setPanelStoreAccessor(() => {
+    const s = usePanelStore.getState();
+    return { panelsById: s.panelsById, panelIds: s.panelIds, tabGroups: s.tabGroups };
+  });
+  // ...other accessors...
 
-setPanelStoreGetter(() => {
-  const s = usePanelStore.getState();
-  return { panelsById: s.panelsById, panelIds: s.panelIds, tabGroups: s.tabGroups };
-});
+  if (cleanupFn) return cleanupFn;
+  // ...subscriptions...
+}
 ```
 
-This works because:
+Closures always call `store.getState()` inside the body—they never capture a snapshot at registration time. This preserves the stale-closure-safety rule from lesson #5087.
 
-1. `setPanelStoreGetter` is a function, which is hoisted and available during circular dependency resolution
-2. The store reference (`usePanelStore.getState()`) is only resolved **inside** the closure when invoked during runtime operations, after both modules have finished evaluating
-3. No top-level dereference happens during module init, so no TDZ error occurs
+### Consumer call sites
+
+Stores call the readers directly and tolerate the null fallback (the accessors return `null` before the orchestrator has run, e.g., in unit tests that import a store standalone):
+
+```typescript
+const terminalState = getPanelStoreSnapshot();
+if (!terminalState) {
+  return { draftInputs, activeWorktreeId };
+}
+```
+
+## Accessor Slots
+
+| Slot | Reader | Setter | Consumer |
+| --- | --- | --- | --- |
+| Panel snapshot | `getPanelStoreSnapshot()` | `setPanelStoreAccessor()` | `projectStore.buildOutgoingState()` |
+| Worktree selection | `getWorktreeSelectionSnapshot()` | `setWorktreeSelectionAccessor()` | `projectStore.buildOutgoingState()` |
+| Fleet arming clear | `clearFleetArmingThroughAccessor()` | `setFleetArmingClearAccessor()` | `projectStore.switchProject()` |
+| Fleet armed ids | `getFleetArmedIds()` | `setFleetArmedIdsAccessor()` | `worktreeStore.applyWorktreeTerminalPolicy()` |
+| Fleet last armed id | `getFleetLastArmedId()` | `setFleetLastArmedIdAccessor()` | `worktreeStore.exitFleetScope()` |
+
+`panelPersistence.setProjectIdGetter()` is **not** in the accessor module—it is a one-directional optional dep (`panelPersistence` depends on `projectStore`, never the reverse), so a direct call at the bottom of `projectStore.ts` is load-order-safe and stays there. The accessor module is reserved for slots that previously caused cycles.
 
 ## Rules for New Store Authors
 
 **DO:**
 
-- Keep cross-store reads inside functions/callbacks, never at module top level
-- Call injection setters at module bottom, after `create()` returns
-- Tolerate getter absence with null-safe checks (e.g., `_getPanelStoreState?.()`)
-- Use `getState()` **inside** async callbacks, not captured in closures
+- Read cross-store state through `storeAccessors.ts` when there is any risk of a cycle.
+- Tolerate `null` returns from accessor readers—the orchestrator may not have run yet in test contexts.
+- Add new accessor slots to `storeAccessors.ts` rather than re-introducing module-bottom setter injection.
+- Register the accessor closure inside `initStoreOrchestrator()` before the idempotency guard, calling `store.getState()` inside the closure body.
 
 **DON'T:**
 
-- Add top-level reads of imported store state in cyclic dependency graphs
-- Call lazy getters during module evaluation (they will be unset)
-- Assume singletons span renderer contexts (each view has independent stores)
+- Call lazy accessor readers at module top level. They will be `null` during module evaluation.
+- Add module-bottom side effects (`setXxxGetter(...)`, `store.subscribe(...)`) for cross-store wiring. The orchestrator owns lifecycle.
+- Add module-scope `store.subscribe()` calls for cross-store reactions. Use the orchestrator's `DisposableStore` instead (lesson #4754).
+- Assume singletons span renderer contexts (each `WebContentsView` evaluates modules independently).
 
 **Red Flags:**
 
-- `ReferenceError: Cannot access 'X' before initialization` — you have a direct import cycle
-- Cyclic dependency warnings from TypeScript or bundlers
-- `getState is not a function` — you tried to call a getter that was never set
-
-## Decision Tree for Cross-Store Access
-
-```
-I want store A to use store B. What do I do?
-
-├─ Is there a direct import cycle? (A imports B, B imports A)
-│  └─ YES → Add a module-level setter/getter pair and register at module bottom
-├─ Does store A need to read store B during module initialization?
-│  └─ YES → Lazy getter injection
-├─ Does store A only need store B from action/event handlers?
-│  └─ YES → Direct import is acceptable (if no cycle)
-└─ Does store A need store B only in async code paths?
-   └─ YES → Consider dynamic `import()` inside the async function
-```
+- `ReferenceError: Cannot access 'X' before initialization` — you re-introduced a direct cycle.
+- Test mocks needing to stub `setXxxGetter` exports on `projectStore`/`worktreeStore` — those exports are gone; mock the accessor reader instead, or call the setter from the accessor module directly.
 
 ## Multi-Renderer Context
 
-Each `WebContentsView` has an independent V8 context due to Site Isolation. Module-level singletons **do not span contexts** — each renderer evaluates modules independently.
-
-If you register a getter in project view A, it does **not** exist in project view B. Each renderer runs `setPanelStoreGetter()` independently when it loads. State mutations in view A do not automatically update view B; cross-view sync must use Main process IPC.
+Each `WebContentsView` has an independent V8 context due to Site Isolation. Module-level singletons—including the accessor slots—**do not span contexts**. Each renderer runs `initStoreOrchestrator()` independently as part of `src/main.tsx` boot, populating its own accessor slots. State mutations in view A do not automatically update view B; cross-view sync must use Main process IPC.
 
 ## When This Breaks
 
@@ -111,16 +106,18 @@ If you register a getter in project view A, it does **not** exist in project vie
 ReferenceError: Cannot access 'usePanelStore' before initialization
 ```
 
-Caused by directly importing `usePanelStore` at module level in a cyclic dependency graph.
+Caused by directly importing `usePanelStore` at module level in a cyclic dependency graph. Fix by reading through `storeAccessors.ts`.
 
 **Silent failure in `buildOutgoingState()`:**
 
 ```typescript
-const terminalState = _getPanelStoreState?.();
-if (!terminalState) return { draftInputs, activeWorktreeId }; // Incomplete state
+const terminalState = getPanelStoreSnapshot();
+if (!terminalState) {
+  return { draftInputs, activeWorktreeId }; // Incomplete state
+}
 ```
 
-The getter was never set (setter not called at module bottom, or called in wrong order), so `buildOutgoingState()` returns incomplete outgoing state and panel data is lost during project switch.
+The accessor was never set because `initStoreOrchestrator()` did not run. In production this only happens if the renderer entry stops calling the orchestrator; in tests it is the normal path when a store is imported in isolation.
 
 **Stale closures in async callbacks:**
 
@@ -131,11 +128,10 @@ document.startViewTransition(() => {
   console.log(stale.panelsById); // Stale!
 });
 
-// CORRECT — captures getState(), calls it when needed
-const getState = usePanelStore.getState;
+// CORRECT — call getState() inside the callback
 document.startViewTransition(() => {
-  console.log(getState().panelsById); // Fresh
+  console.log(usePanelStore.getState().panelsById); // Fresh
 });
 ```
 
-`document.startViewTransition()` is asynchronous — it waits for the current frame to finish before invoking the callback. Any Zustand state accessed via closure formed before the call is stale.
+`document.startViewTransition()` is asynchronous—it waits for the current frame before invoking the callback. Any Zustand state captured into a closure before that point is stale. The same rule applies to the accessor closures inside `initStoreOrchestrator()`: always read state inside the closure body, never at registration time.

--- a/renderer-import-baseline.json
+++ b/renderer-import-baseline.json
@@ -1,6 +1,6 @@
 {
   "entryName": "index",
-  "eagerChunkCount": 40,
+  "eagerChunkCount": 41,
   "eagerChunks": [
     "ActionService",
     "Spinner",
@@ -30,6 +30,7 @@
     "rolldown-runtime",
     "safeStorage",
     "store",
+    "storeAccessors",
     "terminalInputStore",
     "theme",
     "types",

--- a/src/store/__tests__/fleetArmingStore.test.ts
+++ b/src/store/__tests__/fleetArmingStore.test.ts
@@ -1,4 +1,4 @@
-import { describe, it, expect, beforeEach } from "vitest";
+import { describe, it, expect, beforeEach, afterEach } from "vitest";
 import {
   useFleetArmingStore,
   computeArmByStateIds,
@@ -8,6 +8,7 @@ import {
   isFleetRestartAgentEligible,
   isFleetWaitingAgentEligible,
   resolveFleetAgentCapabilityId,
+  subscribeFleetArmingPanelPruning,
 } from "../fleetArmingStore";
 import { usePanelStore } from "../panelStore";
 import { useWorktreeSelectionStore } from "../worktreeStore";
@@ -797,6 +798,17 @@ describe("fleetArmingStore", () => {
   });
 
   describe("panel prune subscription", () => {
+    let unsubscribe: (() => void) | null = null;
+
+    beforeEach(() => {
+      unsubscribe = subscribeFleetArmingPanelPruning();
+    });
+
+    afterEach(() => {
+      unsubscribe?.();
+      unsubscribe = null;
+    });
+
     it("drops armed ids when a panel is removed from panelStore", () => {
       seedPanels([makeAgentTerminal("a"), makeAgentTerminal("b"), makeAgentTerminal("c")]);
       useFleetArmingStore.getState().armIds(["a", "b", "c"]);

--- a/src/store/__tests__/projectStore.switching.test.ts
+++ b/src/store/__tests__/projectStore.switching.test.ts
@@ -190,7 +190,7 @@ describe("buildOutgoingState draft propagation (#4985)", () => {
 
 describe("buildOutgoingState terminal/tabGroup snapshot (#5001)", () => {
   it("includes browser panel snapshots in outgoing terminals", async () => {
-    const { setPanelStoreGetter } = await import("../projectStore");
+    const { setPanelStoreAccessor } = await import("../storeAccessors");
     const browserPanel = {
       id: "browser-1",
       kind: "browser",
@@ -198,7 +198,7 @@ describe("buildOutgoingState terminal/tabGroup snapshot (#5001)", () => {
       location: "grid",
       browserUrl: "https://example.com",
     };
-    setPanelStoreGetter(() => ({
+    setPanelStoreAccessor(() => ({
       panelsById: { "browser-1": browserPanel } as never,
       panelIds: ["browser-1"],
       tabGroups: new Map(),
@@ -215,14 +215,14 @@ describe("buildOutgoingState terminal/tabGroup snapshot (#5001)", () => {
   });
 
   it("includes dev-preview panel snapshots in outgoing terminals", async () => {
-    const { setPanelStoreGetter } = await import("../projectStore");
+    const { setPanelStoreAccessor } = await import("../storeAccessors");
     const devPreview = {
       id: "dev-1",
       kind: "dev-preview",
       title: "Dev Preview",
       location: "grid",
     };
-    setPanelStoreGetter(() => ({
+    setPanelStoreAccessor(() => ({
       panelsById: { "dev-1": devPreview } as never,
       panelIds: ["dev-1"],
       tabGroups: new Map(),
@@ -239,7 +239,7 @@ describe("buildOutgoingState terminal/tabGroup snapshot (#5001)", () => {
   });
 
   it("excludes trash, background, assistant, and smoke-test panels", async () => {
-    const { setPanelStoreGetter } = await import("../projectStore");
+    const { setPanelStoreAccessor } = await import("../storeAccessors");
     const panels = {
       "t-trash": { id: "t-trash", kind: "terminal", location: "trash" },
       "t-bg": { id: "t-bg", kind: "terminal", location: "background" },
@@ -247,7 +247,7 @@ describe("buildOutgoingState terminal/tabGroup snapshot (#5001)", () => {
       "smoke-test-1": { id: "smoke-test-1", kind: "terminal", location: "grid" },
       "t-keep": { id: "t-keep", kind: "browser", location: "grid" },
     } as never;
-    setPanelStoreGetter(() => ({
+    setPanelStoreAccessor(() => ({
       panelsById: panels,
       panelIds: Object.keys(panels),
       tabGroups: new Map(),
@@ -265,12 +265,12 @@ describe("buildOutgoingState terminal/tabGroup snapshot (#5001)", () => {
   });
 
   it("includes multi-panel tab groups, excludes single-panel groups", async () => {
-    const { setPanelStoreGetter } = await import("../projectStore");
+    const { setPanelStoreAccessor } = await import("../storeAccessors");
     const tabGroups = new Map([
       ["g1", { id: "g1", location: "grid" as const, activeTabId: "a", panelIds: ["a", "b"] }],
       ["g2", { id: "g2", location: "grid" as const, activeTabId: "c", panelIds: ["c"] }],
     ]);
-    setPanelStoreGetter(() => ({
+    setPanelStoreAccessor(() => ({
       panelsById: {} as never,
       panelIds: [],
       tabGroups,
@@ -289,7 +289,7 @@ describe("buildOutgoingState terminal/tabGroup snapshot (#5001)", () => {
   });
 
   it("threads previousSnapshot into panelToSnapshot for unknown-kind preservation (#5201)", async () => {
-    const { setPanelStoreGetter } = await import("../projectStore");
+    const { setPanelStoreAccessor } = await import("../storeAccessors");
     const { panelPersistence, panelToSnapshot } = await import("../persistence/panelPersistence");
 
     const extPanel = {
@@ -298,7 +298,7 @@ describe("buildOutgoingState terminal/tabGroup snapshot (#5001)", () => {
       title: "Custom",
       location: "grid",
     };
-    setPanelStoreGetter(() => ({
+    setPanelStoreAccessor(() => ({
       panelsById: { "ext-1": extPanel } as never,
       panelIds: ["ext-1"],
       tabGroups: new Map(),
@@ -342,8 +342,8 @@ describe("buildOutgoingState terminal/tabGroup snapshot (#5001)", () => {
   });
 
   it("sends empty tabGroups array to clear stale groups when none exist", async () => {
-    const { setPanelStoreGetter } = await import("../projectStore");
-    setPanelStoreGetter(() => ({
+    const { setPanelStoreAccessor } = await import("../storeAccessors");
+    setPanelStoreAccessor(() => ({
       panelsById: {} as never,
       panelIds: [],
       tabGroups: new Map(),
@@ -360,9 +360,9 @@ describe("buildOutgoingState terminal/tabGroup snapshot (#5001)", () => {
   });
 
   it("includes terminals in reopen outgoing state", async () => {
-    const { setPanelStoreGetter } = await import("../projectStore");
+    const { setPanelStoreAccessor } = await import("../storeAccessors");
     const panel = { id: "b-1", kind: "browser", location: "grid" };
-    setPanelStoreGetter(() => ({
+    setPanelStoreAccessor(() => ({
       panelsById: { "b-1": panel } as never,
       panelIds: ["b-1"],
       tabGroups: new Map(),
@@ -383,8 +383,9 @@ describe("buildOutgoingState worktree selection (#5000)", () => {
   it("includes non-root activeWorktreeId in switchProject outgoing state", async () => {
     mockActiveWorktreeId = "wt-feature";
 
-    const { useProjectStore, setWorktreeSelectionStoreGetter } = await import("../projectStore");
-    setWorktreeSelectionStoreGetter(() => ({ activeWorktreeId: mockActiveWorktreeId }));
+    const { useProjectStore } = await import("../projectStore");
+    const { setWorktreeSelectionAccessor } = await import("../storeAccessors");
+    setWorktreeSelectionAccessor(() => ({ activeWorktreeId: mockActiveWorktreeId }));
     useProjectStore.setState({ projects: [projectA, projectB], currentProject: projectA });
 
     await useProjectStore.getState().switchProject(projectB.id);
@@ -397,8 +398,9 @@ describe("buildOutgoingState worktree selection (#5000)", () => {
   it("includes non-root activeWorktreeId in reopenProject outgoing state", async () => {
     mockActiveWorktreeId = "wt-feature";
 
-    const { useProjectStore, setWorktreeSelectionStoreGetter } = await import("../projectStore");
-    setWorktreeSelectionStoreGetter(() => ({ activeWorktreeId: mockActiveWorktreeId }));
+    const { useProjectStore } = await import("../projectStore");
+    const { setWorktreeSelectionAccessor } = await import("../storeAccessors");
+    setWorktreeSelectionAccessor(() => ({ activeWorktreeId: mockActiveWorktreeId }));
     useProjectStore.setState({ projects: [projectA, projectB], currentProject: projectA });
 
     await useProjectStore.getState().reopenProject(projectB.id);
@@ -411,8 +413,9 @@ describe("buildOutgoingState worktree selection (#5000)", () => {
   it("converts null activeWorktreeId to undefined in outgoing state", async () => {
     mockActiveWorktreeId = null;
 
-    const { useProjectStore, setWorktreeSelectionStoreGetter } = await import("../projectStore");
-    setWorktreeSelectionStoreGetter(() => ({ activeWorktreeId: mockActiveWorktreeId }));
+    const { useProjectStore } = await import("../projectStore");
+    const { setWorktreeSelectionAccessor } = await import("../storeAccessors");
+    setWorktreeSelectionAccessor(() => ({ activeWorktreeId: mockActiveWorktreeId }));
     useProjectStore.setState({ projects: [projectA, projectB], currentProject: projectA });
 
     await useProjectStore.getState().switchProject(projectB.id);
@@ -426,9 +429,10 @@ describe("buildOutgoingState worktree selection (#5000)", () => {
   it("includes activeWorktreeId even when terminal store getter is null (early return)", async () => {
     mockActiveWorktreeId = "wt-early";
 
-    // Don't call setPanelStoreGetter — forces the early return path
-    const { useProjectStore, setWorktreeSelectionStoreGetter } = await import("../projectStore");
-    setWorktreeSelectionStoreGetter(() => ({ activeWorktreeId: mockActiveWorktreeId }));
+    // Don't call setPanelStoreAccessor — forces the early return path
+    const { useProjectStore } = await import("../projectStore");
+    const { setWorktreeSelectionAccessor } = await import("../storeAccessors");
+    setWorktreeSelectionAccessor(() => ({ activeWorktreeId: mockActiveWorktreeId }));
     useProjectStore.setState({ projects: [projectA, projectB], currentProject: projectA });
 
     await useProjectStore.getState().switchProject(projectB.id);
@@ -441,7 +445,8 @@ describe("buildOutgoingState worktree selection (#5000)", () => {
 
 describe("fleet arming clear on project switch (#5298)", () => {
   it("invokes the registered fleet-arming clear callback before the IPC call", async () => {
-    const { useProjectStore, setFleetArmingClear } = await import("../projectStore");
+    const { useProjectStore } = await import("../projectStore");
+    const { setFleetArmingClearAccessor: setFleetArmingClear } = await import("../storeAccessors");
     const clearSpy = vi.fn();
     setFleetArmingClear(clearSpy);
 
@@ -460,7 +465,8 @@ describe("fleet arming clear on project switch (#5298)", () => {
   });
 
   it("does not throw when the callback is a no-op", async () => {
-    const { useProjectStore, setFleetArmingClear } = await import("../projectStore");
+    const { useProjectStore } = await import("../projectStore");
+    const { setFleetArmingClearAccessor: setFleetArmingClear } = await import("../storeAccessors");
     setFleetArmingClear(() => {});
 
     useProjectStore.setState({ projects: [projectA, projectB], currentProject: projectA });
@@ -469,7 +475,8 @@ describe("fleet arming clear on project switch (#5298)", () => {
   });
 
   it("does not invoke clear when switching to the current project (early return)", async () => {
-    const { useProjectStore, setFleetArmingClear } = await import("../projectStore");
+    const { useProjectStore } = await import("../projectStore");
+    const { setFleetArmingClearAccessor: setFleetArmingClear } = await import("../storeAccessors");
     const clearSpy = vi.fn();
     setFleetArmingClear(clearSpy);
 

--- a/src/store/__tests__/rendererStoreOrchestrator.test.ts
+++ b/src/store/__tests__/rendererStoreOrchestrator.test.ts
@@ -878,9 +878,8 @@ describe("rendererStoreOrchestrator", () => {
 
   describe("storeAccessors wiring", () => {
     it("populates accessor slots so projectStore.switchProject can read panel + worktree state", async () => {
-      const { getPanelStoreSnapshot, getWorktreeSelectionSnapshot } = await import(
-        "../storeAccessors"
-      );
+      const { getPanelStoreSnapshot, getWorktreeSelectionSnapshot } =
+        await import("../storeAccessors");
 
       usePanelStore.setState({
         panelsById: {

--- a/src/store/__tests__/rendererStoreOrchestrator.test.ts
+++ b/src/store/__tests__/rendererStoreOrchestrator.test.ts
@@ -875,4 +875,156 @@ describe("rendererStoreOrchestrator", () => {
       expect(agentSettingsClient.get).not.toHaveBeenCalled();
     });
   });
+
+  describe("storeAccessors wiring", () => {
+    it("populates accessor slots so projectStore.switchProject can read panel + worktree state", async () => {
+      const { getPanelStoreSnapshot, getWorktreeSelectionSnapshot } = await import(
+        "../storeAccessors"
+      );
+
+      usePanelStore.setState({
+        panelsById: {
+          "browser-1": {
+            id: "browser-1",
+            kind: "browser",
+            title: "Browser",
+            location: "grid",
+          },
+        },
+        panelIds: ["browser-1"],
+      });
+      useWorktreeSelectionStore.setState({ activeWorktreeId: "wt-real" });
+
+      const panelSnapshot = getPanelStoreSnapshot();
+      expect(panelSnapshot?.panelIds).toEqual(["browser-1"]);
+      expect(panelSnapshot?.panelsById["browser-1"]?.kind).toBe("browser");
+
+      const worktreeSnapshot = getWorktreeSelectionSnapshot();
+      expect(worktreeSnapshot?.activeWorktreeId).toBe("wt-real");
+    });
+
+    it("clears accessor slots on destroy so consumers see the null fallback before re-init", async () => {
+      const { getPanelStoreSnapshot, getWorktreeSelectionSnapshot, getFleetArmedIds } =
+        await import("../storeAccessors");
+
+      // Sanity: init populated slots
+      expect(getPanelStoreSnapshot()).not.toBeNull();
+
+      destroyStoreOrchestrator();
+
+      expect(getPanelStoreSnapshot()).toBeNull();
+      expect(getWorktreeSelectionSnapshot()).toBeNull();
+      expect(getFleetArmedIds()).toBeNull();
+
+      initStoreOrchestrator();
+
+      expect(getPanelStoreSnapshot()).not.toBeNull();
+    });
+  });
+
+  describe("fleet-arming panel pruning", () => {
+    it("does not double-prune after destroy/re-init cycle", async () => {
+      const { useFleetArmingStore } = await import("../fleetArmingStore");
+      useFleetArmingStore.setState({
+        armedIds: new Set<string>(),
+        armOrder: [],
+        armOrderById: {},
+        lastArmedId: null,
+        broadcastSignal: 0,
+        previewArmedIds: new Set<string>(),
+      });
+
+      usePanelStore.setState({
+        panelsById: {
+          "agent-a": {
+            id: "agent-a",
+            kind: "terminal",
+            title: "A",
+            location: "grid",
+            worktreeId: "wt-1",
+            detectedAgentId: "claude",
+            everDetectedAgent: true,
+            agentState: "idle",
+            hasPty: true,
+          },
+          "agent-b": {
+            id: "agent-b",
+            kind: "terminal",
+            title: "B",
+            location: "grid",
+            worktreeId: "wt-1",
+            detectedAgentId: "claude",
+            everDetectedAgent: true,
+            agentState: "idle",
+            hasPty: true,
+          },
+        },
+        panelIds: ["agent-a", "agent-b"],
+      });
+      useFleetArmingStore.getState().armIds(["agent-a", "agent-b"]);
+
+      destroyStoreOrchestrator();
+      initStoreOrchestrator();
+
+      const pruneSpy = vi.spyOn(useFleetArmingStore.getState(), "prune");
+
+      // Trigger one panel removal — should fire prune exactly once even though
+      // the subscription was disposed and re-registered.
+      usePanelStore.setState({
+        panelsById: {
+          "agent-a": usePanelStore.getState().panelsById["agent-a"]!,
+        },
+        panelIds: ["agent-a"],
+      });
+
+      expect(pruneSpy).toHaveBeenCalledTimes(1);
+    });
+
+    it("prunes stale armed ids on re-init when a panel became ineligible while torn down", async () => {
+      const { useFleetArmingStore } = await import("../fleetArmingStore");
+      useFleetArmingStore.setState({
+        armedIds: new Set<string>(),
+        armOrder: [],
+        armOrderById: {},
+        lastArmedId: null,
+        broadcastSignal: 0,
+        previewArmedIds: new Set<string>(),
+      });
+
+      usePanelStore.setState({
+        panelsById: {
+          "agent-a": {
+            id: "agent-a",
+            kind: "terminal",
+            title: "A",
+            location: "grid",
+            worktreeId: "wt-1",
+            detectedAgentId: "claude",
+            everDetectedAgent: true,
+            agentState: "idle",
+            hasPty: true,
+          },
+        },
+        panelIds: ["agent-a"],
+      });
+      useFleetArmingStore.getState().armIds(["agent-a"]);
+
+      // Subscription torn down while panel state mutates underneath.
+      destroyStoreOrchestrator();
+      usePanelStore.setState({
+        panelsById: {
+          "agent-a": {
+            ...usePanelStore.getState().panelsById["agent-a"]!,
+            location: "trash",
+          },
+        },
+        panelIds: ["agent-a"],
+      });
+
+      // Re-init triggers the initial reconciliation pass.
+      initStoreOrchestrator();
+
+      expect([...useFleetArmingStore.getState().armedIds]).toEqual([]);
+    });
+  });
 });

--- a/src/store/__tests__/worktreeStore.test.ts
+++ b/src/store/__tests__/worktreeStore.test.ts
@@ -86,16 +86,13 @@ vi.mock("@/store/panelStore", () => ({
   },
 }));
 
-import {
-  useWorktreeSelectionStore,
-  setFleetArmedIdsGetter,
-  setFleetLastArmedIdGetter,
-} from "../worktreeStore";
+import { useWorktreeSelectionStore } from "../worktreeStore";
+import { setFleetArmedIdsAccessor, setFleetLastArmedIdAccessor } from "../storeAccessors";
 
 let armedIdsForFleet = new Set<string>();
-setFleetArmedIdsGetter(() => armedIdsForFleet);
+setFleetArmedIdsAccessor(() => armedIdsForFleet);
 let lastArmedIdForFleet: string | null = null;
-setFleetLastArmedIdGetter(() => lastArmedIdForFleet);
+setFleetLastArmedIdAccessor(() => lastArmedIdForFleet);
 
 describe("worktreeStore", () => {
   beforeEach(() => {

--- a/src/store/fleetArmingStore.ts
+++ b/src/store/fleetArmingStore.ts
@@ -1,11 +1,6 @@
 import { create } from "zustand";
 import { usePanelStore } from "@/store/panelStore";
-import {
-  useWorktreeSelectionStore,
-  setFleetArmedIdsGetter,
-  setFleetLastArmedIdGetter,
-} from "@/store/worktreeStore";
-import { setFleetArmingClear } from "@/store/projectStore";
+import { useWorktreeSelectionStore } from "@/store/worktreeStore";
 import type { TerminalInstance } from "@shared/types";
 import type { AgentState } from "@/types";
 import { isAgentFleetActionEligible, isTerminalFleetEligible } from "./fleetEligibility";
@@ -354,79 +349,40 @@ function getActiveWorktreeId(): string | null {
   return useWorktreeSelectionStore.getState().activeWorktreeId ?? null;
 }
 
-// Register the clear callback so projectStore.switchProject() can drop armed
-// selections synchronously on project switch.
-setFleetArmingClear(() => {
-  useFleetArmingStore.getState().clear();
-});
-
-// Expose the armed-id set to worktreeStore so its terminal-streaming policy
-// can keep armed cross-worktree terminals at VISIBLE during fleet scope.
-// Using a getter-injection pattern (identical to `setFleetArmingClear`)
-// avoids an otherwise cyclic module import.
-setFleetArmedIdsGetter(() => useFleetArmingStore.getState().armedIds);
-setFleetLastArmedIdGetter(() => useFleetArmingStore.getState().lastArmedId);
-
 /**
- * Module-scope subscription: when panels are removed, relocated to trash/background,
- * or become ineligible, prune them from the armed set.
- *
- * HMR and test re-imports would otherwise stack subscribers on every module
- * reload. We store registration state on `globalThis` so a subsequent module
- * instance reuses the existing subscription but drives the *current* store —
- * mirroring the pattern in `projectStore.ts`.
+ * Panel-removal pruning subscription. Wires `usePanelStore` changes into the
+ * fleet-arming store so removed/trashed/backgrounded/ineligible panels drop
+ * out of the armed set automatically. Registered by `initStoreOrchestrator()`
+ * so the subscription is scoped to the renderer lifecycle (HMR-safe via the
+ * orchestrator's `DisposableStore`) rather than module evaluation.
  */
-interface FleetArmingSubscriptionState {
-  registered: boolean;
-  lastSnapshot: { ids: string[]; panelsById: Record<string, TerminalInstance> } | null;
-}
+export function subscribeFleetArmingPanelPruning(): () => void {
+  let lastIds = usePanelStore.getState().panelIds;
+  let lastPanelsById = usePanelStore.getState().panelsById;
 
-const FLEET_ARMING_SUBSCRIPTION_KEY = "__daintreeFleetArmingSubscription";
+  return usePanelStore.subscribe((state) => {
+    const currentIds = state.panelIds;
+    const currentById = state.panelsById;
 
-function getFleetArmingSubscriptionState(): FleetArmingSubscriptionState {
-  const target = globalThis as typeof globalThis & {
-    [FLEET_ARMING_SUBSCRIPTION_KEY]?: FleetArmingSubscriptionState;
-  };
-  const existing = target[FLEET_ARMING_SUBSCRIPTION_KEY];
-  if (existing) return existing;
-  const created: FleetArmingSubscriptionState = { registered: false, lastSnapshot: null };
-  target[FLEET_ARMING_SUBSCRIPTION_KEY] = created;
-  return created;
-}
+    if (currentIds === lastIds && currentById === lastPanelsById) return;
 
-if (typeof usePanelStore.subscribe === "function") {
-  const subState = getFleetArmingSubscriptionState();
-  if (!subState.registered) {
-    subState.registered = true;
-    subState.lastSnapshot = {
-      ids: usePanelStore.getState().panelIds,
-      panelsById: usePanelStore.getState().panelsById,
-    };
+    lastIds = currentIds;
+    lastPanelsById = currentById;
 
-    usePanelStore.subscribe((state) => {
-      const prev = subState.lastSnapshot;
-      const currentIds = state.panelIds;
-      const currentById = state.panelsById;
+    const armed = useFleetArmingStore.getState().armedIds;
+    if (armed.size === 0) return;
 
-      if (prev && currentIds === prev.ids && currentById === prev.panelsById) return;
+    const validIds = new Set<string>();
+    for (const id of currentIds) {
+      const t = currentById[id];
+      if (isFleetArmEligible(t)) validIds.add(id);
+    }
 
-      subState.lastSnapshot = { ids: currentIds, panelsById: currentById };
-
-      const armed = useFleetArmingStore.getState().armedIds;
-      if (armed.size === 0) return;
-
-      const validIds = new Set<string>();
-      for (const id of currentIds) {
-        const t = currentById[id];
-        if (isFleetArmEligible(t)) validIds.add(id);
+    for (const id of armed) {
+      if (!validIds.has(id)) {
+        useFleetArmingStore.getState().prune(validIds);
+        return;
       }
-
-      for (const id of armed) {
-        if (!validIds.has(id)) {
-          useFleetArmingStore.getState().prune(validIds);
-          return;
-        }
-      }
-    });
-  }
+    }
+  });
 }

--- a/src/store/fleetArmingStore.ts
+++ b/src/store/fleetArmingStore.ts
@@ -355,20 +355,16 @@ function getActiveWorktreeId(): string | null {
  * out of the armed set automatically. Registered by `initStoreOrchestrator()`
  * so the subscription is scoped to the renderer lifecycle (HMR-safe via the
  * orchestrator's `DisposableStore`) rather than module evaluation.
+ *
+ * Runs an initial reconciliation pass before subscribing so any armed ids
+ * that became ineligible while the subscription was torn down (test
+ * destroy → mutate panels → re-init) get pruned on re-registration.
  */
 export function subscribeFleetArmingPanelPruning(): () => void {
-  let lastIds = usePanelStore.getState().panelIds;
-  let lastPanelsById = usePanelStore.getState().panelsById;
-
-  return usePanelStore.subscribe((state) => {
-    const currentIds = state.panelIds;
-    const currentById = state.panelsById;
-
-    if (currentIds === lastIds && currentById === lastPanelsById) return;
-
-    lastIds = currentIds;
-    lastPanelsById = currentById;
-
+  function reconcileAgainst(
+    currentIds: readonly string[],
+    currentById: Record<string, TerminalInstance>
+  ): void {
     const armed = useFleetArmingStore.getState().armedIds;
     if (armed.size === 0) return;
 
@@ -384,5 +380,21 @@ export function subscribeFleetArmingPanelPruning(): () => void {
         return;
       }
     }
+  }
+
+  let lastIds = usePanelStore.getState().panelIds;
+  let lastPanelsById = usePanelStore.getState().panelsById;
+  reconcileAgainst(lastIds, lastPanelsById);
+
+  return usePanelStore.subscribe((state) => {
+    const currentIds = state.panelIds;
+    const currentById = state.panelsById;
+
+    if (currentIds === lastIds && currentById === lastPanelsById) return;
+
+    lastIds = currentIds;
+    lastPanelsById = currentById;
+
+    reconcileAgainst(currentIds, currentById);
   });
 }

--- a/src/store/panelStore.ts
+++ b/src/store/panelStore.ts
@@ -37,7 +37,6 @@ import { isRuntimeAgentTerminal } from "@/utils/terminalType";
 import { logInfo, logWarn, logError } from "@/utils/logger";
 import { clearTerminalRestartGuard } from "./restartExitSuppression";
 import { buildPanelSnapshotOptions } from "@/services/terminal/panelDuplicationService";
-import { setPanelStoreGetter } from "./projectStore";
 
 export type { TerminalInstance, AddPanelOptions, QueuedCommand, CrashType };
 export { isAgentReady };
@@ -701,12 +700,5 @@ export const usePanelStore = create<PanelGridState>()(
     };
   })
 );
-
-// Break circular dependency: inject terminal store getter into projectStore
-// so buildOutgoingState() can synchronously snapshot terminal state.
-setPanelStoreGetter(() => {
-  const s = usePanelStore.getState();
-  return { panelsById: s.panelsById, panelIds: s.panelIds, tabGroups: s.tabGroups };
-});
 
 export { setupTerminalStoreListeners, cleanupTerminalStoreListeners } from "./panelStoreListeners";

--- a/src/store/projectStore.ts
+++ b/src/store/projectStore.ts
@@ -14,8 +14,13 @@ import { useTerminalInputStore } from "./terminalInputStore";
 import { isSmokeTestTerminalId } from "@shared/utils/smokeTestTerminals";
 import { formatErrorMessage } from "@shared/utils/errorMessage";
 import { isClientAppError } from "@/utils/clientAppError";
+import {
+  clearFleetArmingThroughAccessor,
+  getPanelStoreSnapshot,
+  getWorktreeSelectionSnapshot,
+} from "./storeAccessors";
 import type { ProjectSwitchOutgoingState } from "@shared/types/ipc/project";
-import type { TerminalInstance, TabGroup } from "@shared/types";
+import type { TerminalInstance } from "@shared/types";
 
 function shouldPersistTerminal(t: TerminalInstance): boolean {
   return (
@@ -27,56 +32,15 @@ function shouldPersistTerminal(t: TerminalInstance): boolean {
   );
 }
 
-// Lazy reference to usePanelStore to break circular dependency.
-// Injected at module-init time from panelStore.ts (same pattern as
-// panelPersistence.setProjectIdGetter).
-let _getPanelStoreState:
-  | (() => {
-      panelsById: Record<string, TerminalInstance>;
-      panelIds: string[];
-      tabGroups: Map<string, TabGroup>;
-    })
-  | null = null;
-
-export function setPanelStoreGetter(
-  getter: () => {
-    panelsById: Record<string, TerminalInstance>;
-    panelIds: string[];
-    tabGroups: Map<string, TabGroup>;
-  }
-): void {
-  _getPanelStoreState = getter;
-}
-
-// Lazy reference to useWorktreeSelectionStore to break circular dependency.
-// worktreeStore → terminalInstanceService → terminalStore → setPanelStoreGetter
-// would create a TDZ error if imported statically.
-let _getWorktreeSelectionState: (() => { activeWorktreeId: string | null }) | null = null;
-
-export function setWorktreeSelectionStoreGetter(
-  getter: () => { activeWorktreeId: string | null }
-): void {
-  _getWorktreeSelectionState = getter;
-}
-
-// Lazy reference to the fleet-arming store's clear() so a project switch can
-// drop armed selections synchronously before the WebContentsView gets detached.
-// Registered from fleetArmingStore at module init.
-let _clearFleetArming: (() => void) | null = null;
-
-export function setFleetArmingClear(callback: () => void): void {
-  _clearFleetArming = callback;
-}
-
 function buildOutgoingState(projectId: string): ProjectSwitchOutgoingState {
   const draftInputs = useTerminalInputStore.getState().getProjectDraftInputs(projectId);
-  const activeWorktreeId = _getWorktreeSelectionState?.()?.activeWorktreeId ?? undefined;
+  const activeWorktreeId = getWorktreeSelectionSnapshot()?.activeWorktreeId ?? undefined;
 
   // Synchronously snapshot terminal state from the Zustand store before the
   // renderer gets detached.  This captures browser/dev-preview panel state
   // that would otherwise be lost because the debounced persistence hasn't
   // flushed yet.  Uses the same filter as PanelPersistence.save().
-  const terminalState = _getPanelStoreState?.();
+  const terminalState = getPanelStoreSnapshot();
   if (!terminalState) {
     return { draftInputs, activeWorktreeId };
   }
@@ -437,7 +401,7 @@ const createProjectStore: StateCreator<ProjectState> = (set, get) => ({
     // Drop fleet arming selections synchronously — the outgoing view's armed
     // set is project-scoped and must not leak if the view is later restored
     // from the LRU cache.
-    _clearFleetArming?.();
+    clearFleetArmingThroughAccessor();
 
     // Capture outgoing state before the renderer gets detached
     const currentProjectId = get().currentProject?.id;

--- a/src/store/rendererStoreOrchestrator.ts
+++ b/src/store/rendererStoreOrchestrator.ts
@@ -5,6 +5,7 @@ import {
   isMruRecordingSuppressed,
   persistMruList,
 } from "./worktreeStore";
+import { useFleetArmingStore, subscribeFleetArmingPanelPruning } from "./fleetArmingStore";
 import { useTerminalInputStore, unregisterInputController } from "./terminalInputStore";
 import { semanticAnalysisService } from "@/services/SemanticAnalysisService";
 import { useConsoleCaptureStore } from "./consoleCaptureStore";
@@ -12,6 +13,13 @@ import { useVoiceRecordingStore } from "./voiceRecordingStore";
 import { useLayoutUndoStore } from "./layoutUndoStore";
 import { useCliAvailabilityStore } from "./cliAvailabilityStore";
 import { useAgentSettingsStore } from "./agentSettingsStore";
+import {
+  setPanelStoreAccessor,
+  setWorktreeSelectionAccessor,
+  setFleetArmingClearAccessor,
+  setFleetArmedIdsAccessor,
+  setFleetLastArmedIdAccessor,
+} from "./storeAccessors";
 import { setActiveContextAccessors } from "@/lib/notify";
 import { debounce } from "@/utils/debounce";
 import { DisposableStore, toDisposable } from "@/utils/disposable";
@@ -21,6 +29,23 @@ const debouncedPersistMruList = debounce(persistMruList, 150);
 let cleanupFn: (() => void) | null = null;
 
 export function initStoreOrchestrator(): () => void {
+  // Cross-store accessors are registered up-front, BEFORE the idempotency
+  // guard, so tests that `destroyStoreOrchestrator()` + re-init reconnect
+  // their accessor closures to the current store singletons. The closures
+  // resolve `getState()` lazily on each call (no stale-snapshot capture).
+  setPanelStoreAccessor(() => {
+    const s = usePanelStore.getState();
+    return { panelsById: s.panelsById, panelIds: s.panelIds, tabGroups: s.tabGroups };
+  });
+  setWorktreeSelectionAccessor(() => ({
+    activeWorktreeId: useWorktreeSelectionStore.getState().activeWorktreeId,
+  }));
+  setFleetArmingClearAccessor(() => {
+    useFleetArmingStore.getState().clear();
+  });
+  setFleetArmedIdsAccessor(() => useFleetArmingStore.getState().armedIds);
+  setFleetLastArmedIdAccessor(() => useFleetArmingStore.getState().lastArmedId);
+
   if (cleanupFn) return cleanupFn;
 
   // Register accessors so notify() can suppress toasts whose origin surface
@@ -180,6 +205,13 @@ export function initStoreOrchestrator(): () => void {
       )
     )
   );
+
+  // 5a. Fleet-arming panel pruning: drop armed ids when their panels are
+  //     removed, trashed, backgrounded, or otherwise become fleet-ineligible.
+  //     Lives in the orchestrator so HMR/test teardown cleans the subscription
+  //     deterministically (previously this was a module-scope subscription in
+  //     `fleetArmingStore.ts`).
+  disposables.add(toDisposable(subscribeFleetArmingPanelPruning()));
 
   // 5. Availability → agent-settings re-normalization: installed/missing state
   //    is the input to `normalizeAgentSelection`, so re-run normalization any

--- a/src/store/rendererStoreOrchestrator.ts
+++ b/src/store/rendererStoreOrchestrator.ts
@@ -19,6 +19,7 @@ import {
   setFleetArmingClearAccessor,
   setFleetArmedIdsAccessor,
   setFleetLastArmedIdAccessor,
+  resetStoreAccessorsForTesting,
 } from "./storeAccessors";
 import { setActiveContextAccessors } from "@/lib/notify";
 import { debounce } from "@/utils/debounce";
@@ -254,4 +255,9 @@ export function destroyStoreOrchestrator(): void {
   // matching pre-refactor behavior.
   debouncedPersistMruList.cancel();
   cleanupFn?.();
+  // Clear cross-store accessor slots so any code path that consumes them
+  // between destroy and a subsequent init sees null (the documented
+  // unset-fallback behavior) rather than stale closures bound to a torn-down
+  // subscription set.
+  resetStoreAccessorsForTesting();
 }

--- a/src/store/slices/panelRegistry/__tests__/moveToNewWorktreeAndTransfer.test.ts
+++ b/src/store/slices/panelRegistry/__tests__/moveToNewWorktreeAndTransfer.test.ts
@@ -73,7 +73,6 @@ vi.mock("@/store/restartExitSuppression", () => ({
 }));
 
 vi.mock("@/store/projectStore", () => ({
-  setPanelStoreGetter: vi.fn(),
   useProjectStore: {
     getState: () => ({ currentProject: { id: "proj-1" } }),
   },

--- a/src/store/slices/panelRegistry/__tests__/restartTerminal.test.ts
+++ b/src/store/slices/panelRegistry/__tests__/restartTerminal.test.ts
@@ -65,9 +65,6 @@ vi.mock("@/store/restartExitSuppression", () => ({
 }));
 
 vi.mock("@/store/projectStore", () => ({
-  setPanelStoreGetter: vi.fn(),
-  setWorktreeSelectionStoreGetter: vi.fn(),
-  setFleetArmingClear: vi.fn(),
   useProjectStore: {
     getState: () => ({ currentProject: { id: "proj-1" } }),
   },

--- a/src/store/storeAccessors.ts
+++ b/src/store/storeAccessors.ts
@@ -1,0 +1,65 @@
+import type { TerminalInstance, TabGroup } from "@shared/types";
+
+export interface PanelStoreSnapshot {
+  panelsById: Record<string, TerminalInstance>;
+  panelIds: string[];
+  tabGroups: Map<string, TabGroup>;
+}
+
+export interface WorktreeSelectionSnapshot {
+  activeWorktreeId: string | null;
+}
+
+let _getPanelStoreState: (() => PanelStoreSnapshot) | null = null;
+let _getWorktreeSelectionState: (() => WorktreeSelectionSnapshot) | null = null;
+let _clearFleetArming: (() => void) | null = null;
+let _getFleetArmedIds: (() => Set<string>) | null = null;
+let _getFleetLastArmedId: (() => string | null) | null = null;
+
+export function setPanelStoreAccessor(getter: () => PanelStoreSnapshot): void {
+  _getPanelStoreState = getter;
+}
+
+export function getPanelStoreSnapshot(): PanelStoreSnapshot | null {
+  return _getPanelStoreState?.() ?? null;
+}
+
+export function setWorktreeSelectionAccessor(getter: () => WorktreeSelectionSnapshot): void {
+  _getWorktreeSelectionState = getter;
+}
+
+export function getWorktreeSelectionSnapshot(): WorktreeSelectionSnapshot | null {
+  return _getWorktreeSelectionState?.() ?? null;
+}
+
+export function setFleetArmingClearAccessor(callback: () => void): void {
+  _clearFleetArming = callback;
+}
+
+export function clearFleetArmingThroughAccessor(): void {
+  _clearFleetArming?.();
+}
+
+export function setFleetArmedIdsAccessor(getter: () => Set<string>): void {
+  _getFleetArmedIds = getter;
+}
+
+export function getFleetArmedIds(): Set<string> | null {
+  return _getFleetArmedIds?.() ?? null;
+}
+
+export function setFleetLastArmedIdAccessor(getter: () => string | null): void {
+  _getFleetLastArmedId = getter;
+}
+
+export function getFleetLastArmedId(): string | null {
+  return _getFleetLastArmedId?.() ?? null;
+}
+
+export function resetStoreAccessorsForTesting(): void {
+  _getPanelStoreState = null;
+  _getWorktreeSelectionState = null;
+  _clearFleetArming = null;
+  _getFleetArmedIds = null;
+  _getFleetLastArmedId = null;
+}

--- a/src/store/worktreeStore.ts
+++ b/src/store/worktreeStore.ts
@@ -6,26 +6,8 @@ import { useFocusStore } from "@/store/focusStore";
 import { logErrorWithContext } from "@/utils/errorContext";
 import { PERF_MARKS } from "@shared/perf/marks";
 import { markRendererPerformance } from "@/utils/performance";
-import { setWorktreeSelectionStoreGetter } from "./projectStore";
+import { getFleetArmedIds, getFleetLastArmedId } from "./storeAccessors";
 import { formatErrorMessage } from "@shared/utils/errorMessage";
-
-// Getter injected by fleetArmingStore at module init to break the import
-// cycle (fleetArmingStore imports worktreeStore). Returns the current armed
-// terminal id set so `applyWorktreeTerminalPolicy` can keep armed
-// cross-worktree terminals at VISIBLE while fleet scope is active.
-let _getArmedIds: (() => Set<string>) | null = null;
-export function setFleetArmedIdsGetter(getter: () => Set<string>): void {
-  _getArmedIds = getter;
-}
-
-// Getter for the most-recently-armed terminal id ("primary") — injected by
-// fleetArmingStore for the same cyclic-import reason as `_getArmedIds`.
-// Consumed by `exitFleetScope` to restore keyboard focus to the primary
-// terminal after the fleet grid collapses.
-let _getLastArmedId: (() => string | null) | null = null;
-export function setFleetLastArmedIdGetter(getter: () => string | null): void {
-  _getLastArmedId = getter;
-}
 
 interface CreateDialogState {
   isOpen: boolean;
@@ -645,7 +627,7 @@ const createWorktreeSelectionStore: StateCreator<WorktreeSelectionState> = (set,
     const generation = get()._policyGeneration + 1;
     // Snapshot the primary (most-recently-armed) terminal BEFORE `set()` so
     // it's stable across the async focus-restore microtask below.
-    const primaryTerminalId = _getLastArmedId ? _getLastArmedId() : null;
+    const primaryTerminalId = getFleetLastArmedId();
     set({
       isFleetScopeActive: false,
       _previousActiveWorktreeId: null,
@@ -736,9 +718,6 @@ export const useWorktreeSelectionStore = create<WorktreeSelectionState>()(
   createWorktreeSelectionStore
 );
 
-// Inject lazy reference into projectStore to break circular dependency.
-setWorktreeSelectionStoreGetter(() => useWorktreeSelectionStore.getState());
-
 function applyWorktreeTerminalPolicy(
   get: () => WorktreeSelectionState,
   _set: (partial: Partial<WorktreeSelectionState>) => void,
@@ -764,9 +743,9 @@ function applyWorktreeTerminalPolicy(
       // live output across worktrees. Without this, cross-worktree armed
       // terminals would get demoted to BACKGROUND and show stale/frozen
       // content even though they are mounted in the fleet grid. We fetch the
-      // armed set through an injected getter to avoid a cyclic import.
+      // armed set through the shared accessor module to avoid a cyclic import.
       const fleetActive = get().isFleetScopeActive;
-      const armedIds = fleetActive && _getArmedIds ? _getArmedIds() : null;
+      const armedIds = fleetActive ? getFleetArmedIds() : null;
 
       for (const id of panelIds) {
         const terminal = panelsById[id];


### PR DESCRIPTION
## Summary

- Replaces four module-bottom setter-injection patterns across `projectStore`, `panelStore`, `worktreeStore`, and `fleetArmingStore` with a single dependency-free leaf module, `src/store/storeAccessors.ts`. The old approach patched TDZ issues at module scope; the new approach is cleaner and easier to trace.
- Accessor closures now register inside `initStoreOrchestrator()` before the idempotency guard, so test teardown and re-init reconnects accessors to fresh store singletons without stale references.
- Moves the fleet-arming panel-prune subscription out of module scope and into the orchestrator's `DisposableStore` so it's properly torn down on destroy.

Resolves #7682

## Changes

- `src/store/storeAccessors.ts` — new leaf module; exports `registerStoreAccessors()` and the four accessor functions previously scattered across store files
- `src/store/rendererStoreOrchestrator.ts` — calls `registerStoreAccessors()` and owns the fleet-arming subscription via `DisposableStore`
- `src/store/projectStore.ts`, `panelStore.ts`, `worktreeStore.ts`, `fleetArmingStore.ts` — setter-injection boilerplate removed
- `src/store/__tests__/rendererStoreOrchestrator.test.ts` — new test suite covering init, re-init, and destroy behaviour
- `docs/architecture/store-init-order.md` — updated to reflect the new pattern

## Testing

183 store tests pass. `tsc`, `eslint`, `prettier`, `lint:ratchet`, and production build all green.