### PR TITLE
fix(worktree): show search bar X when facet filters are active

### DIFF
--- a/src/components/Worktree/WorktreeSidebarSearchBar.tsx
+++ b/src/components/Worktree/WorktreeSidebarSearchBar.tsx
@@ -22,7 +22,7 @@ export function WorktreeSidebarSearchBar({ inputRef, chipCounts }: WorktreeSideb
   const query = useWorktreeFilterStore((state) => state.query);
   const setQuery = useWorktreeFilterStore((state) => state.setQuery);
   const clearAll = useWorktreeFilterStore((state) => state.clearAll);
-  const hasActiveFilters = useWorktreeFilterStore((state) => state.hasActiveFilters);
+  const hasActiveFilters = useWorktreeFilterStore((state) => state.hasActiveFilters());
 
   const [localQuery, setLocalQuery] = useState("");
   const debounceRef = useRef<NodeJS.Timeout | null>(null);
@@ -70,14 +70,14 @@ export function WorktreeSidebarSearchBar({ inputRef, chipCounts }: WorktreeSideb
     (e: React.KeyboardEvent) => {
       if (e.key === "Escape") {
         e.stopPropagation();
-        if (localQuery || hasActiveFilters()) {
+        if (localQuery || useWorktreeFilterStore.getState().hasActiveFilters()) {
           handleClear();
         } else {
           internalRef.current?.blur();
         }
       }
     },
-    [localQuery, hasActiveFilters, handleClear]
+    [localQuery, handleClear]
   );
 
   const setRefs = useCallback(
@@ -88,7 +88,7 @@ export function WorktreeSidebarSearchBar({ inputRef, chipCounts }: WorktreeSideb
     [inputRef]
   );
 
-  const showClear = localQuery || hasActiveFilters();
+  const showClear = localQuery || hasActiveFilters;
 
   return (
     <div className="px-3 py-2 border-b border-divider shrink-0">

--- a/src/store/__tests__/worktreeFilterStore.test.ts
+++ b/src/store/__tests__/worktreeFilterStore.test.ts
@@ -45,6 +45,18 @@ describe("worktreeFilterStore", () => {
     expect(useWorktreeFilterStore.getState().hasActiveFilters()).toBe(true);
   });
 
+  it("hasActiveFilters returns true when only a facet filter is active (no query)", () => {
+    useWorktreeFilterStore.getState().toggleStatusFilter("active");
+
+    expect(useWorktreeFilterStore.getState().hasActiveFilters()).toBe(true);
+    expect(useWorktreeFilterStore.getState().getActiveFilterCount()).toBe(1);
+
+    useWorktreeFilterStore.getState().clearAll();
+
+    expect(useWorktreeFilterStore.getState().hasActiveFilters()).toBe(false);
+    expect(useWorktreeFilterStore.getState().getActiveFilterCount()).toBe(0);
+  });
+
   it("treats whitespace-only query as inactive", () => {
     useWorktreeFilterStore.getState().setQuery("   ");
 


### PR DESCRIPTION
## Summary
- The worktree sidebar search bar X button wasn't appearing when only facet filters were active. The Zustand selector pulled the `hasActiveFilters` function reference instead of calling it, so the boolean never updated when filter state changed.
- Also fixes a stale closure in the Escape key handler — it was reading filter state once and never refreshing. Now it reads fresh state each time via `getState()`.
- Added test coverage for facet-filter-only active-filter detection.

Resolves #7752

## Changes
- `WorktreeSidebarSearchBar.tsx` — call `hasActiveFilters()` inside the selector so Zustand subscribes to filter state; use `getState()` in `handleKeyDown` to avoid stale closure
- `worktreeFilterStore.test.ts` — new test case for `hasActiveFilters()` returning true with only a facet filter active

## Testing
- Unit test verifies `hasActiveFilters()` returns true when only a facet filter (status filter) is toggled, and false after `clearAll()`.
- Manually verified the X button appears/disappears correctly with facet filter toggles.