### PR TITLE
refactor(worktree): move modifier flags to trailing rail

### DIFF
--- a/src/components/Worktree/WorktreeCard/EnvironmentPopover.tsx
+++ b/src/components/Worktree/WorktreeCard/EnvironmentPopover.tsx
@@ -91,16 +91,17 @@ export function EnvironmentPopover({
     <Popover>
       <PopoverTrigger asChild>
         <button
+          type="button"
           data-no-dnd
           className="shrink-0 rounded focus-visible:outline-hidden focus-visible:ring-1 focus-visible:ring-daintree-accent"
-          aria-label={`${worktreeMode} environment status`}
+          aria-label={`${worktreeMode ?? "Remote"} environment status`}
         >
           <EnvironmentIcon className={cn(iconClass, className)} />
         </button>
       </PopoverTrigger>
       <PopoverContent side="top" align="start" className="w-72 p-3 text-xs">
         <div className="flex items-center justify-between gap-2 mb-2">
-          <span className="font-semibold text-text-primary">{worktreeMode}</span>
+          <span className="font-semibold text-text-primary">{worktreeMode ?? "Remote"}</span>
           {resourceStatusLabel && (
             <span
               className={cn(
@@ -140,6 +141,7 @@ export function EnvironmentPopover({
           )}
           {onCheckResourceStatus && (
             <button
+              type="button"
               onClick={onCheckResourceStatus}
               className="flex items-center gap-1 text-text-muted hover:text-text-primary transition-colors"
             >

--- a/src/components/Worktree/WorktreeCard/EnvironmentPopover.tsx
+++ b/src/components/Worktree/WorktreeCard/EnvironmentPopover.tsx
@@ -38,6 +38,7 @@ interface EnvironmentPopoverProps {
   resourceEndpoint: string | undefined;
   resourceLastCheckedAt: number | undefined;
   onCheckResourceStatus: (() => void) | undefined;
+  className?: string;
 }
 
 export function EnvironmentPopover({
@@ -50,6 +51,7 @@ export function EnvironmentPopover({
   resourceEndpoint,
   resourceLastCheckedAt,
   onCheckResourceStatus,
+  className,
 }: EnvironmentPopoverProps) {
   const EnvironmentIcon = (environmentIcon && ENVIRONMENT_ICONS[environmentIcon]) || Cloud;
 
@@ -76,7 +78,7 @@ export function EnvironmentPopover({
       <Tooltip>
         <TooltipTrigger asChild>
           <EnvironmentIcon
-            className={cn(iconClass, "pointer-events-none")}
+            className={cn(iconClass, className, "pointer-events-none")}
             aria-label={`${worktreeMode} environment`}
           />
         </TooltipTrigger>
@@ -93,7 +95,7 @@ export function EnvironmentPopover({
           className="shrink-0 rounded focus-visible:outline-hidden focus-visible:ring-1 focus-visible:ring-daintree-accent"
           aria-label={`${worktreeMode} environment status`}
         >
-          <EnvironmentIcon className={iconClass} />
+          <EnvironmentIcon className={cn(iconClass, className)} />
         </button>
       </PopoverTrigger>
       <PopoverContent side="top" align="start" className="w-72 p-3 text-xs">

--- a/src/components/Worktree/WorktreeCard/WorktreeHeader.tsx
+++ b/src/components/Worktree/WorktreeCard/WorktreeHeader.tsx
@@ -180,33 +180,6 @@ export function WorktreeHeader({
               aria-hidden="true"
             />
           )}
-          {isPinned && !isMainWorktree && (
-            <Pin
-              className="w-3 h-3 text-daintree-text/40 shrink-0 pointer-events-none"
-              aria-label="Pinned"
-            />
-          )}
-          {isProjectNotificationsMuted && (
-            <BellOff
-              className="w-3.5 h-3.5 text-daintree-text/40 shrink-0 pointer-events-none"
-              aria-label="Notifications muted for this project"
-            />
-          )}
-          {((worktree.worktreeMode && worktree.worktreeMode !== "local") ||
-            resourceStatusLabel ||
-            isLifecycleRunning) && (
-            <EnvironmentPopover
-              worktreeMode={worktree.worktreeMode}
-              environmentIcon={environmentIcon}
-              isLifecycleRunning={isLifecycleRunning}
-              resourceStatusLabel={resourceStatusLabel}
-              resourceStatusColor={resourceStatusColor}
-              resourceLastOutput={resourceLastOutput}
-              resourceEndpoint={resourceEndpoint}
-              resourceLastCheckedAt={resourceLastCheckedAt}
-              onCheckResourceStatus={onCheckResourceStatus}
-            />
-          )}
           {hasIssueTitle ? (
             <IssueBadge
               issueNumber={worktree.issueNumber!}
@@ -247,6 +220,43 @@ export function WorktreeHeader({
             </span>
           )}
         </div>
+
+        {((isPinned && !isMainWorktree) ||
+          isProjectNotificationsMuted ||
+          (worktree.worktreeMode && worktree.worktreeMode !== "local") ||
+          resourceStatusLabel ||
+          isLifecycleRunning) && (
+          <div className="flex items-center gap-2 shrink-0">
+            {isPinned && !isMainWorktree && (
+              <Pin
+                className="w-3.5 h-3.5 text-daintree-text/40 shrink-0 pointer-events-none"
+                aria-label="Pinned"
+              />
+            )}
+            {isProjectNotificationsMuted && (
+              <BellOff
+                className="w-3.5 h-3.5 text-daintree-text/40 shrink-0 pointer-events-none"
+                aria-label="Notifications muted for this project"
+              />
+            )}
+            {((worktree.worktreeMode && worktree.worktreeMode !== "local") ||
+              resourceStatusLabel ||
+              isLifecycleRunning) && (
+              <EnvironmentPopover
+                worktreeMode={worktree.worktreeMode}
+                environmentIcon={environmentIcon}
+                isLifecycleRunning={isLifecycleRunning}
+                resourceStatusLabel={resourceStatusLabel}
+                resourceStatusColor={resourceStatusColor}
+                resourceLastOutput={resourceLastOutput}
+                resourceEndpoint={resourceEndpoint}
+                resourceLastCheckedAt={resourceLastCheckedAt}
+                onCheckResourceStatus={onCheckResourceStatus}
+                className="w-3.5 h-3.5 text-daintree-text/40"
+              />
+            )}
+          </div>
+        )}
 
         {isCollapsed && visibleStates.length > 0 && (
           <CollapsedSessionIndicators


### PR DESCRIPTION
## Summary
- Moved modifier flag icons (pin, bell-off, environment) from the leading slot to a trailing rail after the headline, matching the convention in Linear, Notion, and VS Code.
- Normalized icon sizes and opacity across all four modifier glyphs so they read as one consistent tier.
- Added defensive `type="button"` attributes and an `undefined` fallback in `EnvironmentPopover`.

Resolves #7700

## Changes
- `WorktreeHeader.tsx`: relocates `Pin`, `BellOff`, and `EnvironmentPopover` to a trailing flex container after the headline/identity block. `Sprout` stays leading specifically when `isMainWorktree` — it is an identity marker, not a flag.
- `EnvironmentPopover.tsx`: accepts a `className` prop for external sizing/opacity control, adds `type="button"` on both button elements, and falls back to `"Remote"` when `worktreeMode` is undefined.
- Icon sizes consolidated to `w-3.5 h-3.5` (14px) with `text-daintree-text/40` opacity for all four modifier glyphs.

## Testing
- Verified modifier icons render in the trailing rail position across pinned, muted, and environment-enabled worktree rows.
- Confirmed no layout shift when zero modifier flags are active (the rail container is conditionally rendered).
- Validated `Sprout` still appears leading for main worktree rows and is absent for secondary rows.