### PR TITLE
fix(worktree): prevent sidebar row overlap during bulk-create insertion

### DIFF
--- a/eslint.config.js
+++ b/eslint.config.js
@@ -411,6 +411,13 @@ export default tseslint.config(
     rules: { "no-restricted-imports": "off" },
   },
 
+  // Allowlist — framer-motion worktree row entry animations (AnimatePresence
+  // wraps the row mapping to prevent overlap during bulk-create insertion).
+  {
+    files: ["src/components/Sidebar/SidebarContent.tsx"],
+    rules: { "no-restricted-imports": "off" },
+  },
+
   // Allowlist — framer-motion content grid animations (terminal layout).
   {
     files: [

--- a/src/components/DragDrop/SortableWorktreeCard.tsx
+++ b/src/components/DragDrop/SortableWorktreeCard.tsx
@@ -112,7 +112,13 @@ export const SortableWorktreeCard = React.memo(function SortableWorktreeCard({
   } = attributes;
 
   return (
-    <m.div layout="position" {...filteredAttributes}>
+    <m.div
+      layout="position"
+      initial={{ opacity: 0 }}
+      animate={{ opacity: 1 }}
+      exit={{ opacity: 0 }}
+      {...filteredAttributes}
+    >
       <div
         ref={setNodeRef}
         style={style}

--- a/src/components/Sidebar/SidebarContent.tsx
+++ b/src/components/Sidebar/SidebarContent.tsx
@@ -28,6 +28,7 @@ import { BulkCreateWorktreeDialog } from "@/components/GitHub/BulkCreateWorktree
 import { FleetPickerPalette } from "@/components/Fleet/FleetPickerPalette";
 import { ErrorBoundary } from "@/components/ErrorBoundary";
 import { SortableContext, verticalListSortingStrategy } from "@dnd-kit/sortable";
+import { AnimatePresence } from "framer-motion";
 import { getWorktreeSortDragId } from "@/components/DragDrop/SortableWorktreeCard";
 import { usePanelStore, useWorktreeSelectionStore, useProjectStore } from "@/store";
 import { useFleetArmingStore } from "@/store/fleetArmingStore";
@@ -100,6 +101,7 @@ function SidebarContent({ onOpenOverview }: SidebarContentProps) {
   const deferredWorktrees = useDeferredValue(worktrees);
   const [isRefreshing, startRefreshTransition] = useTransition();
   const showRefreshSpinner = useDeferredLoading(isRefreshing, UI_DOHERTY_THRESHOLD);
+  const disableMotion = document.body.dataset.performanceMode === "true";
   const currentProject = useProjectStore((state) => state.currentProject);
   useProjectSettings();
   const { availability, agentSettings } = useAgentLauncher();
@@ -965,28 +967,37 @@ function SidebarContent({ onOpenOverview }: SidebarContentProps) {
               ) : (
                 <SortableContext items={sortableIds} strategy={verticalListSortingStrategy}>
                   <div className="flex flex-col">
-                    {filteredWorktrees.map((worktree, idx) => {
-                      const isPinned = pinnedWorktrees.includes(worktree.id);
-                      return (
-                        <SidebarWorktreeRow
-                          key={worktree.id}
-                          worktreeId={worktree.id}
-                          activeWorktreeId={activeWorktreeId}
-                          focusedWorktreeId={focusedWorktreeId}
-                          totalWorktreeCount={deferredWorktrees.length}
-                          selectWorktree={selectWorktree}
-                          worktreeActions={worktreeActions}
-                          availability={availability}
-                          agentSettings={agentSettings}
-                          homeDir={homeDir}
-                          dragStartOrder={dragStartOrder}
-                          isSortDisabled={isSortDisabled}
-                          isPinned={isPinned}
-                          rowIndex={idx}
-                          ariaRowIndex={firstScrollableRowIndex + idx}
-                        />
+                    {(() => {
+                      const rows = filteredWorktrees.map((worktree, idx) => {
+                        const isPinned = pinnedWorktrees.includes(worktree.id);
+                        return (
+                          <SidebarWorktreeRow
+                            key={worktree.id}
+                            worktreeId={worktree.id}
+                            activeWorktreeId={activeWorktreeId}
+                            focusedWorktreeId={focusedWorktreeId}
+                            totalWorktreeCount={deferredWorktrees.length}
+                            selectWorktree={selectWorktree}
+                            worktreeActions={worktreeActions}
+                            availability={availability}
+                            agentSettings={agentSettings}
+                            homeDir={homeDir}
+                            dragStartOrder={dragStartOrder}
+                            isSortDisabled={isSortDisabled}
+                            isPinned={isPinned}
+                            rowIndex={idx}
+                            ariaRowIndex={firstScrollableRowIndex + idx}
+                          />
+                        );
+                      });
+                      return disableMotion ? (
+                        rows
+                      ) : (
+                        <AnimatePresence initial={false} mode="popLayout">
+                          {rows}
+                        </AnimatePresence>
                       );
-                    })}
+                    })()}
                   </div>
                 </SortableContext>
               )}


### PR DESCRIPTION
## Summary

- Fixed a visual glitch where new sidebar rows overlapped existing rows during bulk worktree creation. The existing rows translate to their new layout positions via FLIP animation, and the new row appeared instantly at its final slot, causing the translating rows to pass through it.
- Wrapped the worktree row list in `AnimatePresence mode="popLayout"` so new rows get a proper entry animation instead of popping in. Gave `SortableWorktreeCard` `initial`/`animate`/`exit` opacity props so rows fade in and out.
- The animation is gated on `data-performance-mode` -- when reduced motion is active, rows appear without an entry animation, matching the precedent in `PanelTabList`.

Resolves #7705.

## Changes

- `src/components/Sidebar/SidebarContent.tsx` -- wrapped the row mapping in `AnimatePresence mode="popLayout"`, gated on `document.body.dataset.performanceMode` to respect reduced-motion preferences.
- `src/components/DragDrop/SortableWorktreeCard.tsx` -- added `initial={{ opacity: 0 }}`, `animate={{ opacity: 1 }}`, and `exit={{ opacity: 0 }}` to the `m.div` that already had `layout="position"`.
- `eslint.config.js` -- allowlisted `SidebarContent.tsx` for the framer-motion import, matching the existing pattern for other animation imports.

## Testing

- Verified that creating worktrees through the bulk-create flow no longer shows overlapping rows in the sidebar gap beside the dialog.
- Confirmed the `data-performance-mode` gate skips `AnimatePresence` entirely when enabled.