### PR TITLE
refactor(help-panel): extract session lifecycle into HelpSessionController

### DIFF
--- a/src/components/HelpPanel/HelpPanel.tsx
+++ b/src/components/HelpPanel/HelpPanel.tsx
@@ -1,21 +1,21 @@
-import { Suspense, useCallback, useEffect, useRef, useState, useMemo } from "react";
 import {
-  Settings2,
-  ChevronRight,
-  Plus,
-  X,
-  ShieldAlert,
-  History,
-  CircleHelp,
-  ExternalLink,
-} from "lucide-react";
-import * as semver from "semver";
+  Suspense,
+  useCallback,
+  useEffect,
+  useMemo,
+  useRef,
+  useState,
+  useSyncExternalStore,
+} from "react";
+import { ExternalLink, Settings2 } from "lucide-react";
 import { cn } from "@/lib/utils";
 import { DaintreeIcon } from "@/components/icons/DaintreeIcon";
-import { SpinnerCircle, HollowCircle, InteractingCircle } from "@/components/icons";
 import { XtermAdapter } from "@/components/Terminal/XtermAdapter";
 import { MissingCliGate } from "@/components/Terminal/MissingCliGate";
 import { HelpIntroBanner } from "./HelpIntroBanner";
+import { HelpPanelHeader } from "./HelpPanelHeader";
+import { HelpPanelBanners } from "./HelpPanelBanners";
+import { HelpPanelVersionGate } from "./HelpPanelVersionGate";
 import {
   useHelpPanelStore,
   HELP_PANEL_MIN_WIDTH,
@@ -35,271 +35,17 @@ import { actionService } from "@/services/ActionService";
 import { useEscapeStack } from "@/hooks/useEscapeStack";
 import { suppressSidebarResizes } from "@/lib/sidebarToggle";
 import { TerminalRefreshTier } from "@/types";
-import type { AgentState } from "@/types";
 import { logError } from "@/utils/logger";
-import { formatErrorMessage } from "@shared/utils/errorMessage";
-import { notify } from "@/lib/notify";
-import { safeFireAndForget } from "@/utils/safeFireAndForget";
-import { ACTIVE_AGENT_STATES, CLOSE_CONFIRM_AGENT_STATES } from "@shared/types/agent";
-import { buildResumeCommand } from "@shared/types/agentSettings";
+import { CLOSE_CONFIRM_AGENT_STATES } from "@shared/types/agent";
 import { ConfirmDialog } from "@/components/ui/ConfirmDialog";
 import { TABBABLE_SELECTOR } from "@/lib/accessibility";
-import { projectClient } from "@/clients/projectClient";
-import { resolveDaintreeMcpTier } from "@shared/types/project";
-import type { SnapshotInfo } from "@shared/types/ipc/git";
+import { HelpSessionController } from "@/controllers/HelpSessionController";
 
 const RESIZE_STEP = 10;
 const RESIZE_PAGE_STEP = 50;
 
 const DAINTREE_HOME_URL = "https://daintree.org";
 const ASSISTANT_DOCS_URL = "https://daintree.org/assistant";
-
-const HIBERNATE_VALID_MINUTES: readonly number[] = [0, 15, 30, 60, 120];
-const DEFAULT_HIBERNATE_MINUTES = 30;
-
-function notifyLaunchFailed(agentId: string, reason: string): void {
-  const cfg = getAgentConfig(agentId);
-  const name = cfg?.name ?? agentId;
-  notify({
-    type: "error",
-    title: "Assistant launch failed",
-    message: `Couldn't start ${name}. ${reason}`,
-  });
-}
-
-// Re-checks every 2 minutes while the agent is busy ("working" / "waiting" /
-// "directing"), so hibernation defers cleanly until the conversation is idle
-// without restarting the full hibernate countdown each time.
-const HIBERNATE_BUSY_RECHECK_MS = 2 * 60 * 1000;
-
-// Tier-1 ambient banner auto-dismiss for "Session resumed". The user will
-// usually see it for the moment they return to the panel; long-lived banners
-// distract from the conversation.
-const RESUME_BANNER_AUTO_DISMISS_MS = 10_000;
-
-// Tier-1 ambient banner auto-dismiss for the auto-snapshot pre-flight notice.
-// The signal is reassurance, not a call to action — fade once the user has had
-// time to see it.
-const SNAPSHOT_BANNER_AUTO_DISMISS_MS = 12_000;
-
-interface TierMismatchState {
-  sessionId: string;
-  toolId: string;
-  tier: string;
-  targetTier: "workbench" | "action" | "system" | null;
-  /**
-   * Captured at event time so "Always allow" persists to the project the
-   * banner originated from, not whichever project is current at click time —
-   * matters during rapid project switches.
-   */
-  projectId: string | null;
-}
-
-function notifyMcpNotReady(reason: string): void {
-  notify({
-    type: "error",
-    title: "Start MCP failed",
-    message: `Daintree Assistant needs MCP, but the server didn't start. ${reason}`,
-    action: {
-      label: "Open settings",
-      actionId: "app.settings.openTab",
-      actionArgs: { tab: "assistant" },
-      onClick: () => {
-        void actionService.dispatch("app.settings.openTab", { tab: "assistant" });
-      },
-    },
-  });
-}
-
-interface HelpSessionRef {
-  sessionId: string;
-  sessionPath: string;
-  token: string;
-  mcpUrl: string | null;
-  windowId: number;
-}
-
-type ProvisionOutcome =
-  | { ok: true; session: HelpSessionRef }
-  | { ok: false; code: "MCP_NOT_READY"; message: string }
-  | { ok: false; code: "UNKNOWN"; message: string };
-
-interface HelpProjectRef {
-  id: string;
-  path: string;
-}
-
-async function provisionHelpSession(
-  project: HelpProjectRef,
-  agentId: string
-): Promise<ProvisionOutcome> {
-  try {
-    const result = await window.electron.help.provisionSession({
-      projectId: project.id,
-      projectPath: project.path,
-      agentId,
-    });
-    if (!result) {
-      return {
-        ok: false,
-        code: "UNKNOWN",
-        message: "Couldn't provision help session.",
-      };
-    }
-    return { ok: true, session: result };
-  } catch (err) {
-    logError("Failed to provision help session", err);
-    // The main process throws `HelpSessionError` with `.code = "MCP_NOT_READY"`
-    // when daintreeControl is on but the in-process MCP server can't be
-    // wired. Bubble that up so the launcher renders a specific toast
-    // instead of the generic "agent didn't start" message.
-    const code =
-      err && typeof err === "object" && "code" in err
-        ? (err as Record<string, unknown>).code
-        : undefined;
-    const message = formatErrorMessage(err, "Couldn't provision help session");
-    if (code === "MCP_NOT_READY") {
-      return { ok: false, code: "MCP_NOT_READY", message };
-    }
-    return { ok: false, code: "UNKNOWN", message };
-  }
-}
-
-interface VersionTooOld {
-  agentId: string;
-  agentName: string;
-  installedVersion: string;
-  requiredVersion: string;
-}
-
-// Probes the installed CLI version and compares it against the agent's
-// `assistantMinVersion` floor. Returns a block descriptor when the installed
-// version is definitively below the floor; returns null otherwise (no minimum
-// configured, probe failed, version unparseable, or installed >= required).
-// A null pass-through preserves the existing missing-CLI surface and avoids
-// blocking on transient probe failures. `refresh=true` bypasses the 12h
-// AgentVersionService cache — pass it on retry so a user who manually
-// updates the CLI outside Daintree's update flow can recover within one
-// panel reopen instead of waiting for cache expiry.
-async function checkAssistantVersion(
-  agentId: string,
-  agentName: string,
-  refresh = false
-): Promise<VersionTooOld | null> {
-  const config = getAgentConfig(agentId);
-  const required = config?.assistantMinVersion;
-  if (!required) return null;
-
-  let info;
-  try {
-    info = await window.electron.system.getAgentVersion(agentId, refresh);
-  } catch (err) {
-    logError("Failed to probe assistant CLI version", err);
-    return null;
-  }
-
-  const installed = info?.installedVersion;
-  if (!installed) return null;
-
-  try {
-    if (semver.lt(installed, required)) {
-      return { agentId, agentName, installedVersion: installed, requiredVersion: required };
-    }
-  } catch (err) {
-    logError("Failed to compare assistant CLI version", err);
-    return null;
-  }
-  return null;
-}
-
-// Fetches the user-configured custom CLI args from helpAssistant settings and
-// splits them into a flag array. Settings are loaded at launch time (not at
-// render) so changes in the Daintree Assistant settings tab take effect on the
-// next launch without remounting the panel. Errors are logged and treated as
-// "no custom flags" so a settings IPC failure can't block the assistant.
-async function loadCustomLaunchFlags(): Promise<string[]> {
-  try {
-    const settings = await window.electron.helpAssistant.getSettings();
-    const raw = settings.customArgs?.trim();
-    if (!raw) return [];
-    return raw.split(/\s+/).filter(Boolean);
-  } catch (err) {
-    logError("Failed to load helpAssistant customArgs", err);
-    return [];
-  }
-}
-
-function buildHelpEnv(
-  session: HelpSessionRef | null,
-  projectId: string | null
-): Record<string, string> | undefined {
-  if (!session) return undefined;
-  const env: Record<string, string> = {
-    DAINTREE_MCP_TOKEN: session.token,
-    DAINTREE_WINDOW_ID: String(session.windowId),
-  };
-  if (session.mcpUrl) env.DAINTREE_MCP_URL = session.mcpUrl;
-  if (projectId) env.DAINTREE_PROJECT_ID = projectId;
-  return env;
-}
-
-function revokeHelpSession(sessionId: string | null): void {
-  if (!sessionId) return;
-  window.electron.help.revokeSession(sessionId).catch((err) => {
-    logError("Failed to revoke help session", err);
-  });
-}
-
-// Tier-1 ambient indicator (per CLAUDE.md Runtime Signals): surfaces the
-// in-flight assistant state next to the header title so the user can read it
-// without watching the terminal. Only the actionable triad — working,
-// directing, waiting — earns a marker; idle/completed/exited stay quiet.
-function AssistantHeaderStateIndicator({
-  agentState,
-}: {
-  agentState: AgentState | null | undefined;
-}) {
-  if (agentState === "working") {
-    return (
-      <span
-        data-testid="assistant-header-state-indicator"
-        data-agent-state="working"
-        aria-label="Assistant is working"
-        role="status"
-        className="ml-1.5 inline-flex shrink-0"
-      >
-        <SpinnerCircle className="w-3.5 h-3.5 text-state-working animate-spin-slow motion-reduce:animate-none" />
-      </span>
-    );
-  }
-  if (agentState === "directing") {
-    return (
-      <span
-        data-testid="assistant-header-state-indicator"
-        data-agent-state="directing"
-        aria-label="Assistant is directing"
-        role="status"
-        className="ml-1.5 inline-flex shrink-0"
-      >
-        <InteractingCircle className="w-3.5 h-3.5 text-category-blue" />
-      </span>
-    );
-  }
-  if (agentState === "waiting") {
-    return (
-      <span
-        data-testid="assistant-header-state-indicator"
-        data-agent-state="waiting"
-        aria-label="Assistant is waiting"
-        role="status"
-        className="ml-1.5 inline-flex shrink-0"
-      >
-        <HollowCircle className="w-3.5 h-3.5 text-state-waiting" />
-      </span>
-    );
-  }
-  return null;
-}
 
 interface HelpPanelProps {
   /**
@@ -350,17 +96,20 @@ export function HelpPanel({
   const isMacroFocused = useMacroFocusStore((s) => s.focusedRegion === "assistant");
   const isVisible = isVisibleProp ?? effectiveWidth > 0;
   const [showNewSessionConfirm, setShowNewSessionConfirm] = useState(false);
-  const [showResumeBanner, setShowResumeBanner] = useState(false);
-  const [assistantVersionTooOld, setAssistantVersionTooOld] = useState<VersionTooOld | null>(null);
-  // Tracks whether the version gate has blocked at any point in this panel
-  // instance. When true, the next `checkAssistantVersion` call passes
-  // `refresh=true` so an externally-updated CLI is detected without waiting
-  // for the 12h AgentVersionService cache TTL. Cleared once a probe passes.
-  const hasBlockedThisSessionRef = useRef(false);
-  const [tierMismatch, setTierMismatch] = useState<TierMismatchState | null>(null);
-  const [preflightSnapshot, setPreflightSnapshot] = useState<SnapshotInfo | null>(null);
-  const [isApprovingTier, setIsApprovingTier] = useState(false);
+  const [visibilityEpoch, setVisibilityEpoch] = useState(0);
   const activeWorktreeId = useWorktreeSelectionStore((s) => s.activeWorktreeId);
+
+  // useRef null-guard for the controller instance — `useMemo` does not
+  // guarantee a single instantiation in React 19, so we use the canonical
+  // mutable-ref pattern. The constructor is pure; side effects live in
+  // `start()` which fires from the lifecycle effect below.
+  const controllerRef = useRef<HelpSessionController | null>(null);
+  if (controllerRef.current === null) {
+    controllerRef.current = new HelpSessionController();
+  }
+  const controller = controllerRef.current;
+
+  const session = useSyncExternalStore(controller.subscribe, controller.getSnapshot);
 
   const {
     isOpen,
@@ -373,12 +122,10 @@ export function HelpPanel({
     markConversationStarted,
     setWidth,
     setOpen,
-    clearTerminal,
     dismissIntro,
   } = useHelpPanelStore();
 
   const terminal = usePanelStore((s) => (terminalId ? s.panelsById[terminalId] : undefined));
-  const removePanel = usePanelStore((s) => s.removePanel);
   // Mirrors useGettingStartedChecklist.ts:45-55 — must stay in sync. Gates the
   // intro banner so it never reappears once the user has launched any assistant
   // (`everDetectedAgent` is persisted via panelStore so this survives restarts).
@@ -398,134 +145,100 @@ export function HelpPanel({
   const agentConfig = agentId ? getAgentConfig(agentId) : undefined;
 
   // Intersection of "wired for the assistant overlay" and "CLI is installed".
-  // Drives the single-supported-agent auto-skip effect below. Recomputes only
-  // when availability or load state changes — `getAssistantSupportedAgentIds()`
-  // reads from a static registry.
+  // Drives the single-supported-agent auto-skip in the controller.
   const supportedInstalledAgentIds = useMemo(() => {
     if (!cliHasRealData) return [];
     return getAssistantSupportedAgentIds().filter((id) => isAgentInstalled(cliAvailability[id]));
   }, [cliHasRealData, cliAvailability]);
   const supportedInstalledAgentIdsKey = supportedInstalledAgentIds.join(",");
 
-  // Tracks a session minted before `setTerminal` commits its sessionId to the
-  // store. If the user closes/navigates while `agent.launch` is in flight,
-  // cleanup paths revoke this ref so the token isn't leaked until 7-day GC.
-  const pendingSessionIdRef = useRef<string | null>(null);
-
-  // Once-per-session guard for the auto-snapshot pre-flight. Set TRUE
-  // synchronously before the async snapshotGet IPC so React 19 StrictMode's
-  // double-invoke of the effect can't fire two parallel pre-flights. Reset
-  // when the underlying terminal id (the assistant session boundary) changes.
-  const hasTakenPreflightSnapshotRef = useRef<string | null>(null);
-
-  // Set true while the OS is suspended so the visibilitychange teardown below
-  // distinguishes "system slept" from "project switched / window unloaded".
-  // macOS flips document.hidden=true on display-off, which is indistinguishable
-  // from a project switch without this flag (issue #6758).
-  const isSystemSuspendedRef = useRef(false);
-
-  // Tracks an id reserved by doNewSession / handleRunAnyway that has been
-  // pre-recorded in helpPanelStore *before* addPanel commits the new panel
-  // to panelsById. Without this, the cleanup effect below would observe
-  // `terminalId && !terminal` during the provision/spawn await and wipe the
-  // reservation — re-opening the dock-filter gap that #6951 is closing.
-  const pendingNewTerminalIdRef = useRef<string | null>(null);
-
-  // Last-loaded idle-hibernate setting in minutes (0 = disabled). Re-fetched
-  // each time the timer arms (panel hides) so a settings-tab change takes
-  // effect without remounting the panel.
-  const hibernateMinutesRef = useRef<number>(DEFAULT_HIBERNATE_MINUTES);
-  const hibernateTimerRef = useRef<ReturnType<typeof setTimeout> | null>(null);
-  const [visibilityEpoch, setVisibilityEpoch] = useState(0);
-
-  const revokePendingSession = useCallback(() => {
-    const pending = pendingSessionIdRef.current;
-    if (pending) {
-      pendingSessionIdRef.current = null;
-      revokeHelpSession(pending);
-    }
-  }, []);
-
-  // Revoke the bound help session if the underlying PTY panel disappears from
-  // the panel store. addPanel puts the placeholder in panelsById before
-  // setTerminal records the id here, so a missing entry usually means the
-  // process exited and removePanel was called from elsewhere — except during
-  // the brief window where the +New session / Run-anyway flows have reserved
-  // the id but addPanel has not yet committed it (guarded by the ref).
+  // Lifecycle — arms IPC subscriptions on mount, clears all timers on
+  // unmount. `start()` is idempotent across StrictMode's double-mount.
   useEffect(() => {
-    if (terminalId && !terminal && terminalId !== pendingNewTerminalIdRef.current) {
-      const { sessionId } = useHelpPanelStore.getState();
-      revokeHelpSession(sessionId);
-      hasAutoLaunched.current = false;
-      clearTerminal();
-    }
-  }, [terminalId, terminal, clearTerminal]);
+    controller.start();
+    return () => controller.stop();
+  }, [controller]);
 
-  // Clean up help terminal when the view becomes hidden (project switch, window close).
-  // In Electron 41, beforeunload does not fire on WebContentsView detach, but
-  // visibilitychange does — this covers both project switches and window unload.
-  // Skip teardown when the OS is suspended (display-off / sleep) — otherwise
-  // the assistant restarts and loses its conversation on every wake (#6758).
+  // Sync the controller's inputs whenever the upstream state changes. The
+  // controller decides what to do (clear version block, arm hibernate,
+  // attempt auto-launch). Centralizing the inputs means the controller can
+  // reason about transitions (e.g. preferredAgentId changing mid-launch)
+  // without scattering effects across the component.
+  useEffect(() => {
+    controller.syncInputs({
+      isOpen,
+      isReadyToLaunch,
+      currentProject: currentProject ? { id: currentProject.id, path: currentProject.path } : null,
+      terminalId,
+      preferredAgentId,
+      supportedInstalledAgentIds,
+      visibilityEpoch,
+    });
+  }, [
+    controller,
+    isOpen,
+    isReadyToLaunch,
+    currentProject,
+    terminalId,
+    preferredAgentId,
+    supportedInstalledAgentIdsKey,
+    supportedInstalledAgentIds,
+    visibilityEpoch,
+  ]);
+
+  // visibilitychange touches DOM events and lives in the component. The
+  // controller decides whether teardown should proceed.
   useEffect(() => {
     let cancelled = false;
 
-    const tearDown = () => {
-      const state = useHelpPanelStore.getState();
-      if (state.terminalId) {
-        usePanelStore.getState().removePanel(state.terminalId);
-        revokeHelpSession(state.sessionId);
-        hasAutoLaunched.current = false;
-        useHelpPanelStore.getState().clearTerminal();
-      }
-      revokePendingSession();
-    };
-
     const handler = () => {
       if (document.hidden) {
-        if (isSystemSuspendedRef.current) return;
-        // Race: visibilitychange may fire before the suspend IPC reaches the
-        // renderer. Confirm with the main process before tearing down.
+        if (controller.isSystemSuspended()) return;
+        // Race: visibilitychange may fire before the suspend IPC reaches
+        // the renderer. Confirm with the main process before tearing down.
         void window.electron.systemSleep
           .getMetrics()
           .then((metrics) => {
             if (cancelled) return;
             if (metrics.isCurrentlySleeping) return;
-            // Re-check after the IPC round-trip: the user may have reopened the
-            // lid (hidden → visible) or onSuspend may have arrived while we
-            // were waiting. Either way, skip teardown.
             if (!document.hidden) return;
-            if (isSystemSuspendedRef.current) return;
-            tearDown();
+            if (controller.isSystemSuspended()) return;
+            controller.tearDownForViewHidden();
           })
           .catch((err: unknown) => {
             if (cancelled) return;
             logError("HelpPanel: failed to read systemSleep metrics", err);
             if (!document.hidden) return;
-            if (isSystemSuspendedRef.current) return;
-            tearDown();
+            if (controller.isSystemSuspended()) return;
+            controller.tearDownForViewHidden();
           });
       } else {
         setVisibilityEpoch((e) => e + 1);
       }
     };
 
-    const offSuspend = window.electron.systemSleep.onSuspend(() => {
-      isSystemSuspendedRef.current = true;
-    });
-    const offWake = window.electron.systemSleep.onWake(() => {
-      isSystemSuspendedRef.current = false;
-    });
     document.addEventListener("visibilitychange", handler);
     return () => {
       cancelled = true;
-      offSuspend();
-      offWake();
       document.removeEventListener("visibilitychange", handler);
     };
-  }, [revokePendingSession]);
+  }, [controller]);
 
-  // Latch conversationTouched when the terminal's agent state first leaves idle,
-  // so the close-confirm guard protects accumulated chat history indefinitely.
+  // Revoke the bound help session if the underlying PTY panel disappears
+  // from the panel store. The controller's `_pendingNewTerminalId` guard
+  // keeps the reservation alive across the brief addPanel/setTerminal gap.
+  useEffect(() => {
+    if (terminalId) {
+      controller.handleTerminalPanelMissing({
+        terminalId,
+        terminalExists: Boolean(terminal),
+      });
+    }
+  }, [controller, terminalId, terminal]);
+
+  // Latch conversationTouched when the terminal's agent state first leaves
+  // idle so the close-confirm guard protects accumulated chat history
+  // indefinitely.
   useEffect(() => {
     if (terminalId && terminal?.agentState !== undefined && terminal.agentState !== "idle") {
       const store = useHelpPanelStore.getState();
@@ -535,453 +248,18 @@ export function HelpPanel({
     }
   }, [terminalId, terminal?.agentState, markConversationStarted]);
 
-  // Idle-hibernate timer. When the panel is hidden with a live terminal,
-  // schedule a graceful kill that captures the agent's resume session ID.
-  // Reads store state via getState() in the callback to avoid stale closures
-  // (#5087 lesson). Defers if the agent is mid-turn so the user's work isn't
-  // interrupted. The hibernate-minutes setting is fetched at arm-time so a
-  // change in the settings tab takes effect on the next hide without a remount.
-  useEffect(() => {
-    const clearTimer = () => {
-      if (hibernateTimerRef.current) {
-        clearTimeout(hibernateTimerRef.current);
-        hibernateTimerRef.current = null;
-      }
-    };
-
-    if (isOpen || !terminalId) {
-      clearTimer();
-      return clearTimer;
-    }
-
-    const initialAgentId = agentId;
-    const initialTerminalId = terminalId;
-    let cancelled = false;
-
-    const fire = () => {
-      hibernateTimerRef.current = null;
-      if (cancelled) return;
-
-      // Re-validate: the terminal we armed for must still match the live one,
-      // and the OS must not be suspended (display-off must not fire teardown).
-      const helpState = useHelpPanelStore.getState();
-      if (helpState.terminalId !== initialTerminalId) return;
-      if (helpState.isOpen) return;
-      if (isSystemSuspendedRef.current) return;
-
-      const panelState = usePanelStore.getState();
-      const livePanel = panelState.panelsById[initialTerminalId];
-      if (!livePanel) return;
-      const agentState = livePanel.agentState;
-      if (agentState && ACTIVE_AGENT_STATES.has(agentState)) {
-        // Agent is mid-turn. Re-check shortly without restarting the full
-        // hibernate countdown — the user is presumably about to come back.
-        hibernateTimerRef.current = setTimeout(fire, HIBERNATE_BUSY_RECHECK_MS);
-        return;
-      }
-
-      const projectId = useProjectStore.getState().currentProject?.id ?? null;
-      const cwd = livePanel.cwd ?? "";
-      const sessionToRevoke = helpState.sessionId;
-      const liveAgentId = helpState.agentId ?? initialAgentId;
-
-      safeFireAndForget(
-        window.electron.terminal
-          .gracefulKill(initialTerminalId)
-          .then((capturedSessionId) => {
-            // State may have changed during the IPC round-trip. Don't act on
-            // stale captures.
-            const after = useHelpPanelStore.getState();
-            if (after.terminalId !== initialTerminalId) return;
-            // Critical race: user reopened the panel while gracefulKill was
-            // in flight. The terminal is still live and visible — don't tear
-            // it down out from under them. The captured session ID is also
-            // discarded; the next hibernation cycle will capture a fresh one.
-            if (after.isOpen) return;
-            if (capturedSessionId && projectId && liveAgentId && cwd) {
-              after.setHibernateSession(projectId, {
-                sessionId: capturedSessionId,
-                cwd,
-                agentId: liveAgentId,
-              });
-            } else if (projectId) {
-              // No session captured — make sure we don't try to resume from a
-              // stale entry on next open.
-              after.clearHibernateSession(projectId);
-            }
-            usePanelStore.getState().removePanel(initialTerminalId);
-            revokeHelpSession(sessionToRevoke);
-            useHelpPanelStore.getState().clearTerminal();
-          })
-          .catch((err) => {
-            // Mirror the .then race-guard: bail if the user has reopened the
-            // panel or the terminal id has been replaced during the IPC.
-            const after = useHelpPanelStore.getState();
-            if (after.terminalId !== initialTerminalId || after.isOpen) return;
-            logError("HelpPanel: gracefulKill during hibernate failed", err);
-            if (projectId) {
-              // Drop any prior hibernate entry so we don't auto-resume from a
-              // potentially stale one after a kill failure.
-              useHelpPanelStore.getState().clearHibernateSession(projectId);
-            }
-            // Fall back to direct removal so we don't leak a hidden PTY.
-            usePanelStore.getState().removePanel(initialTerminalId);
-            revokeHelpSession(sessionToRevoke);
-            useHelpPanelStore.getState().clearTerminal();
-          }),
-        { context: "HelpPanel:hibernate gracefulKill" }
-      );
-    };
-
-    safeFireAndForget(
-      window.electron.helpAssistant
-        .getSettings()
-        .then((settings) => {
-          if (cancelled) return;
-          const minutes = settings.idleHibernateMinutes;
-          if (!HIBERNATE_VALID_MINUTES.includes(minutes)) {
-            // Stored value out of range — fall back to the default rather than
-            // hibernating immediately.
-            hibernateMinutesRef.current = DEFAULT_HIBERNATE_MINUTES;
-          } else {
-            hibernateMinutesRef.current = minutes;
-          }
-          if (hibernateMinutesRef.current <= 0) return;
-          clearTimer();
-          hibernateTimerRef.current = setTimeout(fire, hibernateMinutesRef.current * 60 * 1000);
-        })
-        .catch((err) => {
-          if (cancelled) return;
-          logError("HelpPanel: failed to load idleHibernateMinutes", err);
-          // Fall back to the default so a settings IPC blip doesn't leave the
-          // assistant resident forever.
-          hibernateMinutesRef.current = DEFAULT_HIBERNATE_MINUTES;
-          clearTimer();
-          hibernateTimerRef.current = setTimeout(fire, DEFAULT_HIBERNATE_MINUTES * 60 * 1000);
-        }),
-      { context: "HelpPanel:hibernate getSettings" }
-    );
-
-    return () => {
-      cancelled = true;
-      clearTimer();
-    };
-  }, [isOpen, terminalId, agentId]);
-
-  // Auto-dismiss the resume banner after a short window. Conversation-touched
-  // can't be the dismiss trigger here: a resumed Claude session immediately
-  // re-reads history and enters a non-idle state, which flips
-  // conversationTouched=true and would otherwise dismiss the banner before
-  // the user has a chance to see it. The user can also dismiss manually via
-  // the X button.
-  // Subscribe to tier-mismatch pushes from the MCP server. The push is
-  // targeted at this WebContents (only fires for help-session bearers minted
-  // here), so we don't need to filter by sessionId — any event we receive is
-  // for our help-session.
-  useEffect(() => {
-    const dispose = window.electron.mcpServer.onTierNotPermitted((payload) => {
-      // Capture the project at event time. If the user switches projects
-      // before clicking "Always allow", the persisted tier should still
-      // belong to the project the banner originated from.
-      const projectId = useProjectStore.getState().currentProject?.id ?? null;
-      setTierMismatch({
-        sessionId: payload.sessionId,
-        toolId: payload.toolId,
-        tier: payload.tier,
-        targetTier: payload.targetTier,
-        projectId,
-      });
-    });
-    return dispose;
-  }, []);
-
-  // Auto-snapshot pre-flight: when the project's MCP tier is `system`, take a
-  // pre-flight snapshot once per session and surface a Tier-1 ambient banner.
-  // Triggered when the assistant terminal first becomes active (terminalId
-  // commits and `terminal` exists). Sets the ref synchronously to survive
-  // React 19 StrictMode double-mount; the `cancelled` flag handles in-flight
-  // cleanup on unmount.
+  // Auto-snapshot pre-flight: when the project's MCP tier is `system`, take
+  // a pre-flight snapshot once per session and surface a Tier-1 banner.
   useEffect(() => {
     if (!terminalId || !terminal) return;
-    if (hasTakenPreflightSnapshotRef.current === terminalId) return;
-    const projectId = currentProject?.id;
-    if (!projectId) return;
     const worktreeId = terminal.worktreeId ?? activeWorktreeId;
-    if (!worktreeId) return;
-
-    let cancelled = false;
-    hasTakenPreflightSnapshotRef.current = terminalId;
-    safeFireAndForget(
-      (async () => {
-        const settings = await projectClient.getSettings(projectId);
-        const tier = resolveDaintreeMcpTier(settings);
-        if (tier !== "system") return;
-        const snapshot = await window.electron.git.snapshotGet(worktreeId);
-        // PreAgentSnapshotService records a sentinel (`stashRef: ""`) before
-        // the actual stash completes, to coordinate concurrent creation. A
-        // sentinel means the snapshot is still in-flight (or failed early) —
-        // surfacing the banner would lie about the user's safety. Wait for a
-        // real ref.
-        if (cancelled || !snapshot || !snapshot.stashRef) return;
-        setPreflightSnapshot(snapshot);
-      })().catch((err) => {
-        logError("HelpPanel: snapshot pre-flight failed", err);
-      }),
-      { context: "HelpPanel:snapshot pre-flight" }
-    );
-
-    return () => {
-      cancelled = true;
-    };
-  }, [terminalId, terminal, currentProject?.id, activeWorktreeId]);
-
-  // Auto-dismiss the pre-flight snapshot banner after the read-window. Mirrors
-  // the resume-banner pattern at RESUME_BANNER_AUTO_DISMISS_MS — ambient signal,
-  // not a call to action.
-  useEffect(() => {
-    if (!preflightSnapshot) return;
-    const id = setTimeout(() => setPreflightSnapshot(null), SNAPSHOT_BANNER_AUTO_DISMISS_MS);
-    return () => clearTimeout(id);
-  }, [preflightSnapshot]);
-
-  useEffect(() => {
-    if (!showResumeBanner) return;
-    const id = setTimeout(() => setShowResumeBanner(false), RESUME_BANNER_AUTO_DISMISS_MS);
-    return () => clearTimeout(id);
-  }, [showResumeBanner]);
-
-  // Spawn a resumed PTY directly via addPanel with a pre-built
-  // `--resume <id>` command, bypassing `agent.launch` (which has no
-  // command-override arg). Caller is responsible for provisioning the help
-  // session (so a single MCP failure doesn't notify twice) and for clearing
-  // the persisted hibernate entry on success/give-up. The user's custom CLI
-  // flags are loaded here and threaded into both `buildResumeCommand` (so
-  // they're prepended before `--resume`) and `agentLaunchFlags` (so the
-  // panel records them for future restarts). Returns the spawned terminalId,
-  // or null if either there's no resume config for the agent or the spawn
-  // returned no id (caller falls back to a fresh launch).
-  const spawnResumed = useCallback(
-    async (
-      launchAgentId: string,
-      hibernated: { sessionId: string; cwd: string },
-      session: HelpSessionRef | null,
-      folderPath: string
-    ): Promise<string | null> => {
-      const customLaunchFlags = await loadCustomLaunchFlags();
-      const command = buildResumeCommand(
-        launchAgentId,
-        hibernated.sessionId,
-        customLaunchFlags.length > 0 ? customLaunchFlags : undefined
-      );
-      if (!command) return null;
-
-      // Resumed sessions launch from the same sessionPath the previous run
-      // used, so Claude finds its `~/.claude/projects/<encoded-cwd>/` JSONL.
-      const cwd = session?.sessionPath ?? hibernated.cwd ?? folderPath;
-      const projectId = useProjectStore.getState().currentProject?.id ?? null;
-      const env = buildHelpEnv(session, projectId);
-
-      const newId = await usePanelStore.getState().addPanel({
-        kind: "terminal",
-        launchAgentId,
-        command,
-        cwd,
-        location: "dock",
-        ephemeral: true,
-        ...(env && { env }),
-        ...(customLaunchFlags.length > 0 && { agentLaunchFlags: customLaunchFlags }),
-      });
-      return newId ?? null;
-    },
-    []
-  );
-
-  // Auto-launch preferred agent when panel opens without an active terminal.
-  // If a hibernated session exists for the current project + agent, resumes
-  // that conversation; otherwise starts fresh.
-  const hasAutoLaunched = useRef(false);
-  useEffect(() => {
-    if (
-      document.hidden ||
-      !isOpen ||
-      !isReadyToLaunch ||
-      !currentProject ||
-      terminalId ||
-      !preferredAgentId ||
-      hasAutoLaunched.current
-    ) {
-      return;
-    }
-    const launchAgentId = preferredAgentId;
-    const launchProject = currentProject;
-    hasAutoLaunched.current = true;
-
-    safeFireAndForget(
-      (async () => {
-        const folderPath = await window.electron.help.getFolderPath();
-        if (!folderPath) {
-          hasAutoLaunched.current = false;
-          notifyLaunchFailed(launchAgentId, "Help folder is not available.");
-          return;
-        }
-
-        // Version gate runs BEFORE provisionHelpSession to avoid minting a
-        // session token (with .mcp.json side effects) we'd immediately
-        // discard. Pass-through on null preserves missing-CLI behavior.
-        const launchAgentName = getAgentConfig(launchAgentId)?.name ?? launchAgentId;
-        const versionBlock = await checkAssistantVersion(
-          launchAgentId,
-          launchAgentName,
-          hasBlockedThisSessionRef.current
-        );
-        if (versionBlock) {
-          // Stale-agent guard: only relevant when we're about to paint a
-          // block. If the user changed `preferredAgentId` while the probe
-          // was in flight, skip the block so the new agent's empty state
-          // isn't covered by an "Update Claude" message that no longer
-          // applies. The non-block path falls through to provision/dispatch
-          // and the existing post-dispatch stale guard handles cleanup.
-          if (useHelpPanelStore.getState().preferredAgentId !== launchAgentId) {
-            hasAutoLaunched.current = false;
-            return;
-          }
-          hasAutoLaunched.current = false;
-          hasBlockedThisSessionRef.current = true;
-          setAssistantVersionTooOld(versionBlock);
-          return;
-        }
-        hasBlockedThisSessionRef.current = false;
-        setAssistantVersionTooOld(null);
-
-        const outcome = await provisionHelpSession(launchProject, launchAgentId);
-        if (!outcome.ok) {
-          hasAutoLaunched.current = false;
-          if (outcome.code === "MCP_NOT_READY") {
-            notifyMcpNotReady(outcome.message);
-          } else {
-            notifyLaunchFailed(launchAgentId, outcome.message);
-          }
-          return;
-        }
-        const session = outcome.session;
-        pendingSessionIdRef.current = session.sessionId;
-        const cwd = session.sessionPath;
-        const env = buildHelpEnv(session, launchProject.id);
-
-        // Resume path: only if the persisted hibernate session was for this
-        // exact agent and project. A different agent (e.g. user changed
-        // preference) starts fresh.
-        const hibernated = useHelpPanelStore.getState().hibernateSessions[launchProject.id];
-        if (hibernated && hibernated.agentId === launchAgentId) {
-          const resumedId = await spawnResumed(launchAgentId, hibernated, session, folderPath);
-          if (resumedId) {
-            // Stale-launch guard: handleClose may have revoked the pending
-            // session while addPanel was in flight.
-            const expectedSessionId = session.sessionId;
-            if (pendingSessionIdRef.current !== expectedSessionId) {
-              usePanelStore.getState().removePanel(resumedId);
-              hasAutoLaunched.current = false;
-              return;
-            }
-            useHelpPanelStore.getState().clearHibernateSession(launchProject.id);
-            useHelpPanelStore.getState().setTerminal(resumedId, launchAgentId, session.sessionId);
-            pendingSessionIdRef.current = null;
-            window.electron.help.markTerminal(resumedId).catch((err) => {
-              logError("Failed to mark help terminal", err);
-            });
-            setShowResumeBanner(true);
-            return;
-          }
-          // Resume failed (no resume config or addPanel returned null). Drop
-          // the stale entry so we don't loop, then fall through to fresh
-          // launch using the already-provisioned session.
-          useHelpPanelStore.getState().clearHibernateSession(launchProject.id);
-        }
-
-        const customLaunchFlags = await loadCustomLaunchFlags();
-
-        const result = await actionService.dispatch<{ terminalId: string | null }>(
-          "agent.launch",
-          {
-            agentId: launchAgentId,
-            location: "dock",
-            cwd,
-            ephemeral: true,
-            ...(env && { env }),
-            ...(customLaunchFlags.length > 0 && { agentLaunchFlags: customLaunchFlags }),
-          },
-          { source: "user" }
-        );
-
-        // Stale-launch guard: if the user changed the preferred agent
-        // (via the settings tab) while the IPC was in flight, discard this
-        // result and clean up the spawned panel rather than reviving a
-        // stale terminal. Reset hasAutoLaunched so the new preferred
-        // agent can auto-launch on the next effect tick.
-        const currentPreferred = useHelpPanelStore.getState().preferredAgentId;
-        if (currentPreferred !== launchAgentId) {
-          if (result.ok && result.result?.terminalId) {
-            usePanelStore.getState().removePanel(result.result.terminalId);
-          }
-          revokeHelpSession(session?.sessionId ?? null);
-          pendingSessionIdRef.current = null;
-          hasAutoLaunched.current = false;
-          return;
-        }
-
-        if (!result.ok || !result.result?.terminalId) {
-          hasAutoLaunched.current = false;
-          revokeHelpSession(session?.sessionId ?? null);
-          pendingSessionIdRef.current = null;
-          logError("Help auto-launch failed", { agentId: launchAgentId, result });
-          notifyLaunchFailed(launchAgentId, "The agent didn't start. Try again.");
-          return;
-        }
-
-        // Stale-launch guard: handleClose revoked the pending session via
-        // revokePendingSession (clearing the ref). Drop the orphan terminal
-        // rather than binding a panel to a revoked token.
-        const expectedSessionId = session?.sessionId ?? null;
-        if (expectedSessionId && pendingSessionIdRef.current !== expectedSessionId) {
-          usePanelStore.getState().removePanel(result.result.terminalId);
-          hasAutoLaunched.current = false;
-          return;
-        }
-
-        useHelpPanelStore
-          .getState()
-          .setTerminal(result.result.terminalId, launchAgentId, session?.sessionId ?? null);
-        pendingSessionIdRef.current = null;
-        window.electron.help.markTerminal(result.result.terminalId).catch((err) => {
-          logError("Failed to mark help terminal", err);
-        });
-      })(),
-      { context: "Auto-launching preferred help agent" }
-    );
-  }, [
-    isOpen,
-    isReadyToLaunch,
-    currentProject,
-    terminalId,
-    preferredAgentId,
-    spawnResumed,
-    visibilityEpoch,
-  ]);
-
-  // Reset auto-launch guard when panel closes
-  useEffect(() => {
-    if (!isOpen) {
-      hasAutoLaunched.current = false;
-    }
-  }, [isOpen]);
-
-  // Clear the version-too-old block when the preferred agent changes — the
-  // stale block belongs to the previous agent and would otherwise paint over
-  // the new agent's empty state. The retry-refresh ref intentionally
-  // survives this reset so a recovering panel still busts the cache.
-  useEffect(() => {
-    setAssistantVersionTooOld(null);
-  }, [preferredAgentId]);
+    return controller.maybeRunPreflightSnapshot({
+      terminalId,
+      terminalExists: true,
+      projectId: currentProject?.id ?? null,
+      worktreeId,
+    });
+  }, [controller, terminalId, terminal, currentProject?.id, activeWorktreeId]);
 
   // Register the panel root with the macro-focus store so the assistant
   // participates in cross-region cycling.
@@ -991,11 +269,6 @@ export function HelpPanel({
   }, []);
 
   // Move keyboard focus into the panel on open and restore it on close.
-  // Gated on (isOpen && isVisible) — the panel is always mounted, and
-  // `inert` is driven by isVisible, so focusing children before isVisible
-  // flips would land focus inside an inert subtree. Restore on close skips
-  // anything that lives inside the panel itself, since the panel becomes
-  // inert and would just re-trap focus.
   useEffect(() => {
     if (isOpen && isVisible) {
       const active = document.activeElement;
@@ -1003,16 +276,10 @@ export function HelpPanel({
         previousFocusRef.current = active;
       }
       const raf = requestAnimationFrame(() => {
-        // Don't yank focus away from our own xterm — the assistant terminal
-        // owns its caret. We only check the panel-local xterm; an external
-        // grid-terminal still loses focus to the panel by design.
         const current = document.activeElement;
         if (current?.closest?.(".xterm-helper-textarea") && panelRef.current?.contains(current)) {
           return;
         }
-        // Skip the resize separator — it's the first tabbable in DOM order
-        // but lands keyboard users on a chrome control rather than usable
-        // content.
         const candidates = panelRef.current?.querySelectorAll<HTMLElement>(TABBABLE_SELECTOR);
         let first: HTMLElement | undefined;
         for (const el of candidates ?? []) {
@@ -1028,8 +295,6 @@ export function HelpPanel({
       });
       return () => cancelAnimationFrame(raf);
     }
-    // Panel went non-interactive (closed OR gesture-hidden). Restore focus
-    // to the opener so the user isn't stranded in an inert subtree.
     const el = previousFocusRef.current;
     previousFocusRef.current = null;
     if (el && document.contains(el) && !panelRef.current?.contains(el)) {
@@ -1069,9 +334,7 @@ export function HelpPanel({
     [width, setWidth, onResizeStart, onResizeEnd]
   );
 
-  // Resize via keyboard. ArrowLeft/PageUp grow the panel (it expands leftward
-  // from the right edge); ArrowRight/PageDown shrink it. Home/End jump to the
-  // min/max clamp values.
+  // Resize via keyboard.
   const handleResizeKeyDown = useCallback(
     (e: React.KeyboardEvent) => {
       if (e.key === "ArrowLeft") {
@@ -1097,322 +360,14 @@ export function HelpPanel({
     [width, setWidth]
   );
 
-  const isLaunchingRef = useRef(false);
-  const handleSelectAgent = useCallback(
-    async (selectedAgentId: string, seedPrompt?: string) => {
-      if (isLaunchingRef.current) return;
-      if (!isReadyToLaunch || !currentProject) {
-        notifyLaunchFailed(selectedAgentId, "Project state is still loading. Try again.");
-        return;
-      }
-      const launchProject = currentProject;
-      isLaunchingRef.current = true;
-
-      try {
-        // Remove existing terminal if switching agents
-        const existing = useHelpPanelStore.getState();
-        if (existing.terminalId) {
-          removePanel(existing.terminalId);
-          revokeHelpSession(existing.sessionId);
-          clearTerminal();
-        }
-
-        const folderPath = await window.electron.help.getFolderPath();
-        if (!folderPath) {
-          notifyLaunchFailed(selectedAgentId, "Help folder is not available.");
-          return;
-        }
-
-        // Version gate runs BEFORE provisionHelpSession so we don't mint a
-        // session token we'd immediately discard. Pass-through on null
-        // (probe failure / unparseable installed version) lets the existing
-        // missing-CLI surface handle those edge cases. `refresh=true` on
-        // retry busts the 12h AgentVersionService cache so an externally
-        // updated CLI is detected without waiting for TTL expiry.
-        const selectedAgentName = getAgentConfig(selectedAgentId)?.name ?? selectedAgentId;
-        const versionBlock = await checkAssistantVersion(
-          selectedAgentId,
-          selectedAgentName,
-          hasBlockedThisSessionRef.current
-        );
-        if (versionBlock) {
-          hasAutoLaunched.current = false;
-          hasBlockedThisSessionRef.current = true;
-          setAssistantVersionTooOld(versionBlock);
-          return;
-        }
-        hasBlockedThisSessionRef.current = false;
-        setAssistantVersionTooOld(null);
-
-        const outcome = await provisionHelpSession(launchProject, selectedAgentId);
-        if (!outcome.ok) {
-          // Reset the auto-launch gate so a recovered MCP can re-launch on
-          // the next render — the single-supported-agent useEffect uses
-          // this same ref to one-shot itself, so without the reset the
-          // panel is stuck on the empty state until close/reopen.
-          hasAutoLaunched.current = false;
-          if (outcome.code === "MCP_NOT_READY") {
-            notifyMcpNotReady(outcome.message);
-          } else {
-            notifyLaunchFailed(selectedAgentId, outcome.message);
-          }
-          return;
-        }
-        const session = outcome.session;
-        pendingSessionIdRef.current = session.sessionId;
-        const cwd = session.sessionPath;
-        const env = buildHelpEnv(session, launchProject.id);
-
-        // Resume path: matches the auto-launch effect — if the persisted
-        // hibernate entry is for this exact project + agent, resume that
-        // conversation instead of starting fresh. Skipped when a seedPrompt is
-        // provided (chip click): the user explicitly asked to start a fresh
-        // conversation with that prompt, so silently resuming the prior chat
-        // would drop the prompt and confuse them.
-        const hibernated = seedPrompt
-          ? null
-          : useHelpPanelStore.getState().hibernateSessions[launchProject.id];
-        if (hibernated && hibernated.agentId === selectedAgentId) {
-          const resumedId = await spawnResumed(selectedAgentId, hibernated, session, folderPath);
-          if (resumedId) {
-            const expectedSessionId = session.sessionId;
-            if (pendingSessionIdRef.current !== expectedSessionId) {
-              usePanelStore.getState().removePanel(resumedId);
-              return;
-            }
-            useHelpPanelStore.getState().clearHibernateSession(launchProject.id);
-            useHelpPanelStore.getState().setTerminal(resumedId, selectedAgentId, session.sessionId);
-            pendingSessionIdRef.current = null;
-            window.electron.help.markTerminal(resumedId).catch((err) => {
-              logError("Failed to mark help terminal", err);
-            });
-            setShowResumeBanner(true);
-            return;
-          }
-          useHelpPanelStore.getState().clearHibernateSession(launchProject.id);
-        }
-
-        const customLaunchFlags = await loadCustomLaunchFlags();
-
-        const result = await actionService.dispatch<{ terminalId: string | null }>(
-          "agent.launch",
-          {
-            agentId: selectedAgentId,
-            location: "dock",
-            cwd,
-            ephemeral: true,
-            ...(env && { env }),
-            ...(customLaunchFlags.length > 0 && { agentLaunchFlags: customLaunchFlags }),
-            ...(seedPrompt && { prompt: seedPrompt }),
-          },
-          { source: "user" }
-        );
-
-        if (!result.ok || !result.result?.terminalId) {
-          hasAutoLaunched.current = false;
-          revokeHelpSession(session?.sessionId ?? null);
-          pendingSessionIdRef.current = null;
-          logError("Help launch failed", { agentId: selectedAgentId, result });
-          notifyLaunchFailed(selectedAgentId, "The agent didn't start. Try again.");
-          return;
-        }
-
-        // Stale-launch guard: if handleClose revoked the pending session while
-        // dispatch was in-flight, the session is dead. Drop the orphan terminal
-        // rather than binding a panel to a revoked token.
-        const expectedSessionId = session?.sessionId ?? null;
-        if (expectedSessionId && pendingSessionIdRef.current !== expectedSessionId) {
-          usePanelStore.getState().removePanel(result.result.terminalId);
-          return;
-        }
-
-        useHelpPanelStore
-          .getState()
-          .setTerminal(result.result.terminalId, selectedAgentId, session?.sessionId ?? null);
-        pendingSessionIdRef.current = null;
-        window.electron.help.markTerminal(result.result.terminalId).catch((err) => {
-          logError("Failed to mark help terminal", err);
-        });
-      } finally {
-        isLaunchingRef.current = false;
-      }
-    },
-    [isReadyToLaunch, currentProject, removePanel, clearTerminal, spawnResumed]
-  );
-
-  // Single-supported-agent auto-launch: when only one assistant-supported
-  // agent is installed and there's no persisted preference, launch it
-  // directly instead of showing the empty "open settings" state. Mutually
-  // exclusive with the preferred-agent auto-launch (which only runs when
-  // `preferredAgentId` is set), so they share the same `hasAutoLaunched`
-  // ref to prevent any double-fire.
-  useEffect(() => {
-    if (
-      document.hidden ||
-      !isOpen ||
-      !isReadyToLaunch ||
-      !currentProject ||
-      terminalId ||
-      preferredAgentId ||
-      hasAutoLaunched.current
-    ) {
-      return;
-    }
-    if (supportedInstalledAgentIds.length !== 1) return;
-    const onlyAgentId = supportedInstalledAgentIds[0];
-    if (!onlyAgentId) return;
-    hasAutoLaunched.current = true;
-    safeFireAndForget(handleSelectAgent(onlyAgentId), {
-      context: "Auto-launching single supported help agent",
-    });
-    // The agent-id key is included in deps so a change in installed agents
-    // (e.g. user installs a second supported CLI) re-evaluates the gate.
-  }, [
-    isOpen,
-    isReadyToLaunch,
-    currentProject,
-    terminalId,
-    preferredAgentId,
-    supportedInstalledAgentIdsKey,
-    supportedInstalledAgentIds,
-    handleSelectAgent,
-    visibilityEpoch,
-  ]);
-
-  // Hide the panel without tearing down the agent or conversation. The PTY,
-  // chat history, and help session all stay resident so reopening lands the
-  // user exactly where they left off — closing is collapse, not destroy.
-  // The destructive equivalent (end this session, start a new one) lives on
-  // a separate "+ New session" affordance.
+  // Hide the panel without tearing down the agent or conversation.
   const handleClose = useCallback(() => {
     suppressSidebarResizes();
     setOpen(false);
   }, [setOpen]);
 
-  // Destructive reset: stop the current agent, drop the conversation, revoke
-  // the bound + pending help sessions, then provision a fresh session and
-  // relaunch the same agent. Mirrors the run-anyway path; the only difference
-  // is the diagnostic context label and that we always have a live terminal
-  // (run-anyway is for the missing-CLI placeholder case).
-  const doNewSession = useCallback(() => {
-    if (!terminalId || !agentId) return;
-    if (!isReadyToLaunch || !currentProject) {
-      notifyLaunchFailed(agentId, "Project state is still loading. Try again.");
-      return;
-    }
-    if (isLaunchingRef.current) return;
-    const panel = usePanelStore.getState().panelsById[terminalId];
-    if (!panel) return;
-    const presetEnv = panel.extensionState?.presetEnv as Record<string, string> | undefined;
-    const launchAgentId = agentId;
-    const launchProject = currentProject;
-    const previousSessionId = useHelpPanelStore.getState().sessionId;
-    // The user explicitly chose to discard the conversation — drop any
-    // hibernated entry for this project so the next reopen starts fresh
-    // instead of resuming the just-discarded chat.
-    const projectIdForReset = useProjectStore.getState().currentProject?.id ?? null;
-    if (projectIdForReset) {
-      useHelpPanelStore.getState().clearHibernateSession(projectIdForReset);
-    }
-    setShowResumeBanner(false);
-
-    // Reserve the new terminal id synchronously so the dock filter
-    // (`helpTerminalId` exclusion in ContentDock) is active the moment
-    // `addPanel` commits the new panel — not one microtask later. Without
-    // this, the gap between `addPanel` resolving and `setTerminal` running
-    // leaves a stray help terminal visible in the dock for one render.
-    // The ref tells the line-221 cleanup effect to leave the reservation
-    // alone while addPanel is still in flight (panelsById[newId] absent).
-    const newId = `terminal-${crypto.randomUUID()}`;
-    pendingNewTerminalIdRef.current = newId;
-
-    isLaunchingRef.current = true;
-    removePanel(terminalId);
-    revokeHelpSession(previousSessionId);
-    revokePendingSession();
-    clearTerminal();
-    useHelpPanelStore.getState().setTerminal(newId, launchAgentId, null);
-
-    safeFireAndForget(
-      (async () => {
-        let session: HelpSessionRef | null = null;
-        try {
-          const outcome = await provisionHelpSession(launchProject, launchAgentId);
-          if (!outcome.ok) {
-            pendingNewTerminalIdRef.current = null;
-            useHelpPanelStore.getState().clearTerminal();
-            if (outcome.code === "MCP_NOT_READY") {
-              notifyMcpNotReady(outcome.message);
-            } else {
-              notifyLaunchFailed(launchAgentId, outcome.message);
-            }
-            return;
-          }
-          session = outcome.session;
-          const cwd = session.sessionPath;
-          const helpEnv = buildHelpEnv(session, launchProject.id);
-          const env: Record<string, string> | undefined =
-            helpEnv || presetEnv ? { ...(presetEnv ?? {}), ...(helpEnv ?? {}) } : undefined;
-
-          const customLaunchFlags = await loadCustomLaunchFlags();
-
-          const result = await actionService.dispatch<{ terminalId: string | null }>(
-            "agent.launch",
-            {
-              agentId: launchAgentId,
-              location: "dock",
-              cwd,
-              env,
-              requestedId: newId,
-              ephemeral: true,
-              activateDockOnCreate: true,
-              ...(customLaunchFlags.length > 0 && { agentLaunchFlags: customLaunchFlags }),
-            },
-            { source: "user" }
-          );
-
-          if (!result.ok || !result.result?.terminalId) {
-            pendingNewTerminalIdRef.current = null;
-            useHelpPanelStore.getState().clearTerminal();
-            revokeHelpSession(session?.sessionId ?? null);
-            logError("Help new-session returned no terminal id", { agentId: launchAgentId });
-            notifyLaunchFailed(launchAgentId, "The agent didn't start. Try again.");
-            return;
-          }
-
-          const finalTerminalId = result.result.terminalId;
-          pendingNewTerminalIdRef.current = null;
-          useHelpPanelStore
-            .getState()
-            .setTerminal(finalTerminalId, launchAgentId, session?.sessionId ?? null);
-          window.electron.help.markTerminal(finalTerminalId).catch((err) => {
-            logError("Failed to mark help terminal", err);
-          });
-        } catch (error) {
-          pendingNewTerminalIdRef.current = null;
-          useHelpPanelStore.getState().clearTerminal();
-          revokeHelpSession(session?.sessionId ?? null);
-          logError("Help new-session failed", error);
-          notifyLaunchFailed(launchAgentId, "The agent didn't start. Try again.");
-        } finally {
-          isLaunchingRef.current = false;
-        }
-      })(),
-      { context: "Help: + New session relaunch" }
-    );
-  }, [
-    terminalId,
-    agentId,
-    isReadyToLaunch,
-    currentProject,
-    removePanel,
-    clearTerminal,
-    revokePendingSession,
-  ]);
-
   // Confirm only when there's something to lose — a working agent or a
-  // conversation the user has actually engaged with. An untouched idle agent
-  // resets silently; the user wouldn't notice the difference anyway.
+  // conversation the user has actually engaged with.
   const shouldConfirmNewSession =
     (terminal?.agentState !== undefined && CLOSE_CONFIRM_AGENT_STATES.has(terminal.agentState)) ||
     conversationTouched;
@@ -1423,13 +378,13 @@ export function HelpPanel({
       setShowNewSessionConfirm(true);
       return;
     }
-    doNewSession();
-  }, [terminalId, agentId, shouldConfirmNewSession, doNewSession]);
+    controller.newSession();
+  }, [controller, terminalId, agentId, shouldConfirmNewSession]);
 
   const handleConfirmNewSession = useCallback(() => {
     setShowNewSessionConfirm(false);
-    doNewSession();
-  }, [doNewSession]);
+    controller.newSession();
+  }, [controller]);
 
   const handleCancelNewSession = useCallback(() => {
     setShowNewSessionConfirm(false);
@@ -1447,209 +402,24 @@ export function HelpPanel({
     );
   }, []);
 
-  const dismissTierMismatch = useCallback(() => {
-    setTierMismatch(null);
-  }, []);
+  const handleRunAnyway = useCallback(() => {
+    controller.runAnyway();
+  }, [controller]);
 
-  // Clears the banner only if a fresh denial hasn't arrived during the IPC
-  // round-trip. Without this, a second denial that fires while the user's
-  // approval is in flight gets silently wiped out by the resolver.
-  const clearIfStillCurrent = useCallback((sessionId: string, toolId: string) => {
-    setTierMismatch((prev) =>
-      prev && prev.sessionId === sessionId && prev.toolId === toolId ? null : prev
-    );
-  }, []);
-
-  const handleApproveOnce = useCallback(() => {
-    const current = tierMismatch;
-    if (!current?.targetTier || isApprovingTier) return;
-    const targetTier = current.targetTier;
-    const sessionId = current.sessionId;
-    const toolId = current.toolId;
-    setIsApprovingTier(true);
-    safeFireAndForget(
-      window.electron.mcpServer
-        .setSessionTier(sessionId, targetTier)
-        .then(() => {
-          clearIfStillCurrent(sessionId, toolId);
-        })
-        .catch((err) => {
-          logError("HelpPanel: setSessionTier failed", err);
-          notify({
-            type: "error",
-            title: "Couldn't approve tool",
-            message: formatErrorMessage(err, "Couldn't elevate the assistant's tier."),
-          });
-        })
-        .finally(() => {
-          setIsApprovingTier(false);
-        }),
-      { context: "HelpPanel:setSessionTier" }
-    );
-  }, [tierMismatch, isApprovingTier, clearIfStillCurrent]);
-
-  const handleAlwaysAllow = useCallback(() => {
-    const current = tierMismatch;
-    if (!current?.targetTier || isApprovingTier) return;
-    // Use the project captured at event time — `current.projectId` is
-    // immutable for this banner instance, so a project switch after the
-    // banner appears doesn't redirect the save to the wrong project. Fall
-    // back to the live currentProject only if the event didn't carry one.
-    const projectId = current.projectId ?? useProjectStore.getState().currentProject?.id ?? null;
-    if (!projectId) {
-      dismissTierMismatch();
-      return;
-    }
-    const targetTier = current.targetTier;
-    const sessionId = current.sessionId;
-    const toolId = current.toolId;
-    setIsApprovingTier(true);
-    safeFireAndForget(
-      (async () => {
-        // projectClient.saveSettings goes directly to the IPC handler — using
-        // the `project.saveSettings` action would silently strip the
-        // `daintreeMcpTier` field (sanitized to keep agents from
-        // self-elevating).
-        const settings = await projectClient.getSettings(projectId);
-        await projectClient.saveSettings(projectId, {
-          ...settings,
-          daintreeMcpTier: targetTier,
-        });
-        // Also lift the live session immediately so the assistant doesn't have
-        // to wait for a new session to pick up the persisted change.
-        await window.electron.mcpServer.setSessionTier(sessionId, targetTier);
-        clearIfStillCurrent(sessionId, toolId);
-      })()
-        .catch((err) => {
-          logError("HelpPanel: always-allow tier write failed", err);
-          notify({
-            type: "error",
-            title: "Couldn't save permission",
-            message: formatErrorMessage(err, "Couldn't update project tier setting."),
-          });
-        })
-        .finally(() => {
-          setIsApprovingTier(false);
-        }),
-      { context: "HelpPanel:alwaysAllowTier" }
-    );
-  }, [tierMismatch, isApprovingTier, dismissTierMismatch, clearIfStillCurrent]);
+  const dismissResume = useCallback(() => controller.dismissResumeBanner(), [controller]);
+  const dismissSnapshot = useCallback(() => controller.dismissPreflightSnapshot(), [controller]);
+  const dismissTierMismatch = useCallback(() => controller.dismissTierMismatch(), [controller]);
+  const approveTierOnce = useCallback(() => controller.approveTierOnce(), [controller]);
+  const alwaysAllowTier = useCallback(() => controller.alwaysAllowTier(), [controller]);
 
   // Esc-to-close. The xterm-helper-textarea check lets Escape reach the
-  // running PTY (Codex/Claude/etc.) when the assistant terminal has focus
-  // instead of closing the panel out from under the user.
+  // running PTY when the assistant terminal has focus.
   const handleEscape = useCallback(() => {
     const active = document.activeElement as HTMLElement | null;
     if (active?.closest(".xterm-helper-textarea")) return;
     handleClose();
   }, [handleClose]);
   useEscapeStack(isOpen, handleEscape);
-
-  const handleRunAnyway = useCallback(() => {
-    if (!terminalId || !agentId) return;
-    if (!isReadyToLaunch || !currentProject) {
-      notifyLaunchFailed(agentId, "Project state is still loading. Try again.");
-      return;
-    }
-    if (isLaunchingRef.current) return;
-    const panel = usePanelStore.getState().panelsById[terminalId];
-    if (!panel) return;
-    const presetEnv = panel.extensionState?.presetEnv as Record<string, string> | undefined;
-    const launchAgentId = agentId;
-    const launchProject = currentProject;
-    const previousSessionId = useHelpPanelStore.getState().sessionId;
-
-    // Reserve the new terminal id synchronously so the dock filter is
-    // active the instant `addPanel` commits — see doNewSession for the full
-    // rationale; this path has the identical race. The ref guards the
-    // line-221 cleanup effect during the in-flight window.
-    const newId = `terminal-${crypto.randomUUID()}`;
-    pendingNewTerminalIdRef.current = newId;
-
-    isLaunchingRef.current = true;
-    removePanel(terminalId);
-    revokeHelpSession(previousSessionId);
-    revokePendingSession();
-    clearTerminal();
-    useHelpPanelStore.getState().setTerminal(newId, launchAgentId, null);
-
-    safeFireAndForget(
-      (async () => {
-        let session: HelpSessionRef | null = null;
-        try {
-          const outcome = await provisionHelpSession(launchProject, launchAgentId);
-          if (!outcome.ok) {
-            pendingNewTerminalIdRef.current = null;
-            useHelpPanelStore.getState().clearTerminal();
-            if (outcome.code === "MCP_NOT_READY") {
-              notifyMcpNotReady(outcome.message);
-            } else {
-              notifyLaunchFailed(launchAgentId, outcome.message);
-            }
-            return;
-          }
-          session = outcome.session;
-          const cwd = session.sessionPath;
-          const helpEnv = buildHelpEnv(session, launchProject.id);
-          const env: Record<string, string> | undefined =
-            helpEnv || presetEnv ? { ...(presetEnv ?? {}), ...(helpEnv ?? {}) } : undefined;
-
-          const customLaunchFlags = await loadCustomLaunchFlags();
-
-          const result = await actionService.dispatch<{ terminalId: string | null }>(
-            "agent.launch",
-            {
-              agentId: launchAgentId,
-              location: "dock",
-              cwd,
-              env,
-              requestedId: newId,
-              ephemeral: true,
-              activateDockOnCreate: true,
-              force: true,
-              ...(customLaunchFlags.length > 0 && { agentLaunchFlags: customLaunchFlags }),
-            },
-            { source: "user" }
-          );
-
-          if (!result.ok || !result.result?.terminalId) {
-            pendingNewTerminalIdRef.current = null;
-            useHelpPanelStore.getState().clearTerminal();
-            revokeHelpSession(session?.sessionId ?? null);
-            logError("Help run-anyway returned no terminal id", { agentId: launchAgentId });
-            notifyLaunchFailed(launchAgentId, "The agent didn't start. Try again.");
-            return;
-          }
-
-          const finalTerminalId = result.result.terminalId;
-          pendingNewTerminalIdRef.current = null;
-          useHelpPanelStore
-            .getState()
-            .setTerminal(finalTerminalId, launchAgentId, session?.sessionId ?? null);
-          window.electron.help.markTerminal(finalTerminalId).catch((err) => {
-            logError("Failed to mark help terminal", err);
-          });
-        } catch (error) {
-          pendingNewTerminalIdRef.current = null;
-          useHelpPanelStore.getState().clearTerminal();
-          revokeHelpSession(session?.sessionId ?? null);
-          logError("Help run-anyway failed", error);
-          notifyLaunchFailed(launchAgentId, "The agent didn't start. Try again.");
-        } finally {
-          isLaunchingRef.current = false;
-        }
-      })(),
-      { context: "Help: run-anyway re-launch" }
-    );
-  }, [
-    terminalId,
-    agentId,
-    isReadyToLaunch,
-    currentProject,
-    removePanel,
-    clearTerminal,
-    revokePendingSession,
-  ]);
 
   const getRefreshTier = useMemo(() => {
     return () => {
@@ -1667,11 +437,10 @@ export function HelpPanel({
       id="daintree-assistant-panel"
       tabIndex={-1}
       aria-label="Daintree Assistant"
-      // `inert` removes descendants from focus / a11y tree while the aside is
-      // collapsed. Chromium 146 supports it natively, so we don't need a
+      // `inert` removes descendants from focus / a11y tree while the aside
+      // is collapsed. Chromium 146 supports it natively, so we don't need a
       // matching `aria-hidden` (which would also be redundant on an `inert`
-      // element per ARIA 1.2 and trips axe's `aria-hidden-focus` rule on the
-      // legacy combination).
+      // element per ARIA 1.2 and trips axe's `aria-hidden-focus` rule).
       inert={!isVisible || undefined}
       data-macro-focus={isMacroFocused ? "true" : undefined}
       className={cn(
@@ -1702,42 +471,13 @@ export function HelpPanel({
         onKeyDown={handleResizeKeyDown}
       />
 
-      {/* Header */}
-      <div className="flex items-center gap-1 px-3 py-2 border-b border-daintree-border shrink-0">
-        <div className="flex items-center min-w-0 flex-1">
-          <DaintreeIcon className="w-4 h-4 text-daintree-text/50 shrink-0" />
-          <span className="ml-1.5 text-xs font-medium text-daintree-text/70 truncate">
-            Daintree Assistant
-          </span>
-          <AssistantHeaderStateIndicator agentState={terminal?.agentState} />
-        </div>
-        <button
-          type="button"
-          onClick={handleOpenAssistantDocs}
-          className="p-1 rounded-[var(--radius-sm)] text-daintree-text/50 hover:text-daintree-text hover:bg-tint/8 transition-colors focus-visible:outline focus-visible:outline-2 focus-visible:outline-daintree-accent focus-visible:outline-offset-2"
-          aria-label="Open assistant docs"
-        >
-          <CircleHelp className="w-3.5 h-3.5" />
-        </button>
-        {terminalId && agentId && (
-          <button
-            type="button"
-            onClick={handleNewSession}
-            className="p-1 rounded-[var(--radius-sm)] text-daintree-text/50 hover:text-daintree-text hover:bg-tint/8 transition-colors focus-visible:outline focus-visible:outline-2 focus-visible:outline-daintree-accent focus-visible:outline-offset-2"
-            aria-label="Start new session"
-          >
-            <Plus className="w-3.5 h-3.5" />
-          </button>
-        )}
-        <button
-          type="button"
-          onClick={handleClose}
-          className="p-1 rounded-[var(--radius-sm)] text-daintree-text/50 hover:text-daintree-text hover:bg-tint/8 transition-colors focus-visible:outline focus-visible:outline-2 focus-visible:outline-daintree-accent focus-visible:outline-offset-2"
-          aria-label="Hide Daintree Assistant"
-        >
-          <ChevronRight className="w-3.5 h-3.5" />
-        </button>
-      </div>
+      <HelpPanelHeader
+        agentState={terminal?.agentState}
+        canStartNewSession={Boolean(terminalId && agentId)}
+        onNewSession={handleNewSession}
+        onOpenDocs={handleOpenAssistantDocs}
+        onClose={handleClose}
+      />
 
       {/* Content */}
       <div ref={contentRef} className="flex-1 flex flex-col min-h-0 relative">
@@ -1753,134 +493,17 @@ export function HelpPanel({
               {!introDismissed && !hasEverLaunchedAgent && (
                 <HelpIntroBanner onDismiss={dismissIntro} />
               )}
-              {showResumeBanner && (
-                <div
-                  role="status"
-                  aria-live="polite"
-                  className={cn(
-                    "flex items-start gap-2 px-3 py-2 mx-3 mt-3 mb-1",
-                    "rounded-[var(--radius-md)] bg-overlay-subtle border border-daintree-border",
-                    "text-xs text-daintree-text/80"
-                  )}
-                  data-testid="help-resume-banner"
-                >
-                  <span className="flex-1 select-text">Resumed your previous session.</span>
-                  <button
-                    type="button"
-                    onClick={() => setShowResumeBanner(false)}
-                    aria-label="Dismiss resume notice"
-                    className="text-daintree-text/50 hover:text-daintree-text transition-colors focus-visible:outline focus-visible:outline-2 focus-visible:outline-daintree-accent focus-visible:outline-offset-2"
-                  >
-                    <X className="w-3 h-3" />
-                  </button>
-                </div>
-              )}
-              {preflightSnapshot && (
-                <div
-                  role="status"
-                  aria-live="polite"
-                  className={cn(
-                    "flex items-start gap-2 px-3 py-2 mx-3 mt-3 mb-1",
-                    "rounded-[var(--radius-md)] bg-overlay-subtle border border-daintree-border",
-                    "text-xs text-daintree-text/80"
-                  )}
-                  data-testid="help-snapshot-banner"
-                >
-                  <History
-                    className="w-3.5 h-3.5 shrink-0 mt-0.5 text-daintree-text/60"
-                    aria-hidden="true"
-                  />
-                  <span className="flex-1 select-text">
-                    Saved a snapshot of this worktree before any changes.
-                  </span>
-                  <button
-                    type="button"
-                    onClick={() => setPreflightSnapshot(null)}
-                    aria-label="Dismiss snapshot notice"
-                    className="text-daintree-text/50 hover:text-daintree-text transition-colors focus-visible:outline focus-visible:outline-2 focus-visible:outline-daintree-accent focus-visible:outline-offset-2"
-                  >
-                    <X className="w-3 h-3" />
-                  </button>
-                </div>
-              )}
-              {tierMismatch && (
-                <div
-                  role="alert"
-                  className={cn(
-                    "flex flex-col gap-2 px-3 py-2.5 mx-3 mt-3 mb-1",
-                    "rounded-[var(--radius-md)]",
-                    "bg-status-warning/10 border border-status-warning/40",
-                    "text-xs text-daintree-text/85"
-                  )}
-                  data-testid="help-tier-mismatch-banner"
-                >
-                  <div className="flex items-start gap-2">
-                    <ShieldAlert
-                      className="w-3.5 h-3.5 shrink-0 mt-0.5 text-status-warning"
-                      aria-hidden="true"
-                    />
-                    <div className="flex-1 select-text">
-                      <p className="font-medium text-daintree-text">Tool not permitted</p>
-                      <p className="mt-0.5 text-daintree-text/70">
-                        {tierMismatch.targetTier
-                          ? `${tierMismatch.toolId} needs ${tierMismatch.targetTier} tier access.`
-                          : `${tierMismatch.toolId} isn't available at any project tier.`}
-                      </p>
-                    </div>
-                    <button
-                      type="button"
-                      onClick={dismissTierMismatch}
-                      aria-label="Dismiss tier mismatch notice"
-                      className="text-daintree-text/50 hover:text-daintree-text transition-colors focus-visible:outline focus-visible:outline-2 focus-visible:outline-daintree-accent focus-visible:outline-offset-2"
-                    >
-                      <X className="w-3 h-3" />
-                    </button>
-                  </div>
-                  {tierMismatch.targetTier && (
-                    <div className="flex items-center gap-2 flex-wrap pl-5">
-                      <button
-                        type="button"
-                        onClick={handleApproveOnce}
-                        disabled={isApprovingTier}
-                        className={cn(
-                          "px-2 py-1 rounded-[var(--radius-sm)] text-xs font-medium",
-                          "bg-daintree-text/10 hover:bg-daintree-text/15 text-daintree-text",
-                          "disabled:opacity-50 disabled:cursor-not-allowed transition-colors",
-                          "focus-visible:outline focus-visible:outline-2 focus-visible:outline-daintree-accent focus-visible:outline-offset-2"
-                        )}
-                      >
-                        Approve once
-                      </button>
-                      <button
-                        type="button"
-                        onClick={handleAlwaysAllow}
-                        disabled={isApprovingTier}
-                        className={cn(
-                          "px-2 py-1 rounded-[var(--radius-sm)] text-xs font-medium",
-                          "bg-daintree-text/5 hover:bg-daintree-text/10 text-daintree-text/85",
-                          "disabled:opacity-50 disabled:cursor-not-allowed transition-colors",
-                          "focus-visible:outline focus-visible:outline-2 focus-visible:outline-daintree-accent focus-visible:outline-offset-2"
-                        )}
-                      >
-                        Always allow for this project
-                      </button>
-                      <button
-                        type="button"
-                        onClick={dismissTierMismatch}
-                        disabled={isApprovingTier}
-                        className={cn(
-                          "px-2 py-1 rounded-[var(--radius-sm)] text-xs",
-                          "text-daintree-text/65 hover:text-daintree-text",
-                          "disabled:opacity-50 disabled:cursor-not-allowed transition-colors",
-                          "focus-visible:outline focus-visible:outline-2 focus-visible:outline-daintree-accent focus-visible:outline-offset-2"
-                        )}
-                      >
-                        Cancel
-                      </button>
-                    </div>
-                  )}
-                </div>
-              )}
+              <HelpPanelBanners
+                showResumeBanner={session.showResumeBanner}
+                preflightSnapshot={session.preflightSnapshot}
+                tierMismatch={session.tierMismatch}
+                isApprovingTier={session.isApprovingTier}
+                onDismissResume={dismissResume}
+                onDismissSnapshot={dismissSnapshot}
+                onDismissTierMismatch={dismissTierMismatch}
+                onApproveOnce={approveTierOnce}
+                onAlwaysAllow={alwaysAllowTier}
+              />
               <div className="flex-1 relative min-h-0">
                 <Suspense fallback={null}>
                   <XtermAdapter
@@ -1893,33 +516,11 @@ export function HelpPanel({
               </div>
             </>
           )
-        ) : assistantVersionTooOld ? (
-          <div
-            className="flex-1 flex flex-col items-center justify-center gap-3 p-8 text-center"
-            data-testid="help-version-too-old"
-          >
-            <p className="text-sm text-daintree-text/70">
-              Update {assistantVersionTooOld.agentName} to use Daintree Assistant
-            </p>
-            <p className="text-xs text-daintree-text/50 max-w-[32ch]">
-              Daintree Assistant needs {assistantVersionTooOld.agentName}{" "}
-              {assistantVersionTooOld.requiredVersion} or later. You're on{" "}
-              {assistantVersionTooOld.installedVersion}.
-            </p>
-            <button
-              type="button"
-              onClick={handleOpenSettings}
-              className={cn(
-                "mt-1 inline-flex items-center gap-1.5 px-3 py-1.5 rounded-[var(--radius-md)]",
-                "text-xs font-medium border border-daintree-border text-daintree-text/80",
-                "hover:bg-overlay-soft hover:text-daintree-text transition-colors",
-                "focus-visible:outline focus-visible:outline-2 focus-visible:outline-daintree-accent focus-visible:outline-offset-2"
-              )}
-            >
-              <Settings2 className="w-3.5 h-3.5" />
-              <span>Update {assistantVersionTooOld.agentName}</span>
-            </button>
-          </div>
+        ) : session.assistantVersionTooOld ? (
+          <HelpPanelVersionGate
+            versionTooOld={session.assistantVersionTooOld}
+            onOpenSettings={handleOpenSettings}
+          />
         ) : (
           <div className="flex-1 flex flex-col items-center justify-center gap-6 p-8 text-center">
             <p className="text-sm text-daintree-text/70 max-w-[30ch]">

--- a/src/components/HelpPanel/HelpPanelBanners.tsx
+++ b/src/components/HelpPanel/HelpPanelBanners.tsx
@@ -1,0 +1,161 @@
+import { History, ShieldAlert, X } from "lucide-react";
+import { cn } from "@/lib/utils";
+import type { SnapshotInfo } from "@shared/types/ipc/git";
+import type { TierMismatchState } from "@/controllers/HelpSessionController";
+
+interface HelpPanelBannersProps {
+  showResumeBanner: boolean;
+  preflightSnapshot: SnapshotInfo | null;
+  tierMismatch: TierMismatchState | null;
+  isApprovingTier: boolean;
+  onDismissResume: () => void;
+  onDismissSnapshot: () => void;
+  onDismissTierMismatch: () => void;
+  onApproveOnce: () => void;
+  onAlwaysAllow: () => void;
+}
+
+export function HelpPanelBanners({
+  showResumeBanner,
+  preflightSnapshot,
+  tierMismatch,
+  isApprovingTier,
+  onDismissResume,
+  onDismissSnapshot,
+  onDismissTierMismatch,
+  onApproveOnce,
+  onAlwaysAllow,
+}: HelpPanelBannersProps) {
+  return (
+    <>
+      {showResumeBanner && (
+        <div
+          role="status"
+          aria-live="polite"
+          className={cn(
+            "flex items-start gap-2 px-3 py-2 mx-3 mt-3 mb-1",
+            "rounded-[var(--radius-md)] bg-overlay-subtle border border-daintree-border",
+            "text-xs text-daintree-text/80"
+          )}
+          data-testid="help-resume-banner"
+        >
+          <span className="flex-1 select-text">Resumed your previous session.</span>
+          <button
+            type="button"
+            onClick={onDismissResume}
+            aria-label="Dismiss resume notice"
+            className="text-daintree-text/50 hover:text-daintree-text transition-colors focus-visible:outline focus-visible:outline-2 focus-visible:outline-daintree-accent focus-visible:outline-offset-2"
+          >
+            <X className="w-3 h-3" />
+          </button>
+        </div>
+      )}
+      {preflightSnapshot && (
+        <div
+          role="status"
+          aria-live="polite"
+          className={cn(
+            "flex items-start gap-2 px-3 py-2 mx-3 mt-3 mb-1",
+            "rounded-[var(--radius-md)] bg-overlay-subtle border border-daintree-border",
+            "text-xs text-daintree-text/80"
+          )}
+          data-testid="help-snapshot-banner"
+        >
+          <History
+            className="w-3.5 h-3.5 shrink-0 mt-0.5 text-daintree-text/60"
+            aria-hidden="true"
+          />
+          <span className="flex-1 select-text">
+            Saved a snapshot of this worktree before any changes.
+          </span>
+          <button
+            type="button"
+            onClick={onDismissSnapshot}
+            aria-label="Dismiss snapshot notice"
+            className="text-daintree-text/50 hover:text-daintree-text transition-colors focus-visible:outline focus-visible:outline-2 focus-visible:outline-daintree-accent focus-visible:outline-offset-2"
+          >
+            <X className="w-3 h-3" />
+          </button>
+        </div>
+      )}
+      {tierMismatch && (
+        <div
+          role="alert"
+          className={cn(
+            "flex flex-col gap-2 px-3 py-2.5 mx-3 mt-3 mb-1",
+            "rounded-[var(--radius-md)]",
+            "bg-status-warning/10 border border-status-warning/40",
+            "text-xs text-daintree-text/85"
+          )}
+          data-testid="help-tier-mismatch-banner"
+        >
+          <div className="flex items-start gap-2">
+            <ShieldAlert
+              className="w-3.5 h-3.5 shrink-0 mt-0.5 text-status-warning"
+              aria-hidden="true"
+            />
+            <div className="flex-1 select-text">
+              <p className="font-medium text-daintree-text">Tool not permitted</p>
+              <p className="mt-0.5 text-daintree-text/70">
+                {tierMismatch.targetTier
+                  ? `${tierMismatch.toolId} needs ${tierMismatch.targetTier} tier access.`
+                  : `${tierMismatch.toolId} isn't available at any project tier.`}
+              </p>
+            </div>
+            <button
+              type="button"
+              onClick={onDismissTierMismatch}
+              aria-label="Dismiss tier mismatch notice"
+              className="text-daintree-text/50 hover:text-daintree-text transition-colors focus-visible:outline focus-visible:outline-2 focus-visible:outline-daintree-accent focus-visible:outline-offset-2"
+            >
+              <X className="w-3 h-3" />
+            </button>
+          </div>
+          {tierMismatch.targetTier && (
+            <div className="flex items-center gap-2 flex-wrap pl-5">
+              <button
+                type="button"
+                onClick={onApproveOnce}
+                disabled={isApprovingTier}
+                className={cn(
+                  "px-2 py-1 rounded-[var(--radius-sm)] text-xs font-medium",
+                  "bg-daintree-text/10 hover:bg-daintree-text/15 text-daintree-text",
+                  "disabled:opacity-50 disabled:cursor-not-allowed transition-colors",
+                  "focus-visible:outline focus-visible:outline-2 focus-visible:outline-daintree-accent focus-visible:outline-offset-2"
+                )}
+              >
+                Approve once
+              </button>
+              <button
+                type="button"
+                onClick={onAlwaysAllow}
+                disabled={isApprovingTier}
+                className={cn(
+                  "px-2 py-1 rounded-[var(--radius-sm)] text-xs font-medium",
+                  "bg-daintree-text/5 hover:bg-daintree-text/10 text-daintree-text/85",
+                  "disabled:opacity-50 disabled:cursor-not-allowed transition-colors",
+                  "focus-visible:outline focus-visible:outline-2 focus-visible:outline-daintree-accent focus-visible:outline-offset-2"
+                )}
+              >
+                Always allow for this project
+              </button>
+              <button
+                type="button"
+                onClick={onDismissTierMismatch}
+                disabled={isApprovingTier}
+                className={cn(
+                  "px-2 py-1 rounded-[var(--radius-sm)] text-xs",
+                  "text-daintree-text/65 hover:text-daintree-text",
+                  "disabled:opacity-50 disabled:cursor-not-allowed transition-colors",
+                  "focus-visible:outline focus-visible:outline-2 focus-visible:outline-daintree-accent focus-visible:outline-offset-2"
+                )}
+              >
+                Cancel
+              </button>
+            </div>
+          )}
+        </div>
+      )}
+    </>
+  );
+}

--- a/src/components/HelpPanel/HelpPanelHeader.tsx
+++ b/src/components/HelpPanel/HelpPanelHeader.tsx
@@ -1,0 +1,109 @@
+import { ChevronRight, CircleHelp, Plus } from "lucide-react";
+import { SpinnerCircle, HollowCircle, InteractingCircle } from "@/components/icons";
+import { DaintreeIcon } from "@/components/icons/DaintreeIcon";
+import type { AgentState } from "@/types";
+
+// Tier-1 ambient indicator (per CLAUDE.md Runtime Signals): surfaces the
+// in-flight assistant state next to the header title so the user can read it
+// without watching the terminal. Only the actionable triad — working,
+// directing, waiting — earns a marker; idle/completed/exited stay quiet.
+function AssistantHeaderStateIndicator({
+  agentState,
+}: {
+  agentState: AgentState | null | undefined;
+}) {
+  if (agentState === "working") {
+    return (
+      <span
+        data-testid="assistant-header-state-indicator"
+        data-agent-state="working"
+        aria-label="Assistant is working"
+        role="status"
+        className="ml-1.5 inline-flex shrink-0"
+      >
+        <SpinnerCircle className="w-3.5 h-3.5 text-state-working animate-spin-slow motion-reduce:animate-none" />
+      </span>
+    );
+  }
+  if (agentState === "directing") {
+    return (
+      <span
+        data-testid="assistant-header-state-indicator"
+        data-agent-state="directing"
+        aria-label="Assistant is directing"
+        role="status"
+        className="ml-1.5 inline-flex shrink-0"
+      >
+        <InteractingCircle className="w-3.5 h-3.5 text-category-blue" />
+      </span>
+    );
+  }
+  if (agentState === "waiting") {
+    return (
+      <span
+        data-testid="assistant-header-state-indicator"
+        data-agent-state="waiting"
+        aria-label="Assistant is waiting"
+        role="status"
+        className="ml-1.5 inline-flex shrink-0"
+      >
+        <HollowCircle className="w-3.5 h-3.5 text-state-waiting" />
+      </span>
+    );
+  }
+  return null;
+}
+
+interface HelpPanelHeaderProps {
+  agentState: AgentState | null | undefined;
+  canStartNewSession: boolean;
+  onNewSession: () => void;
+  onOpenDocs: () => void;
+  onClose: () => void;
+}
+
+export function HelpPanelHeader({
+  agentState,
+  canStartNewSession,
+  onNewSession,
+  onOpenDocs,
+  onClose,
+}: HelpPanelHeaderProps) {
+  return (
+    <div className="flex items-center gap-1 px-3 py-2 border-b border-daintree-border shrink-0">
+      <div className="flex items-center min-w-0 flex-1">
+        <DaintreeIcon className="w-4 h-4 text-daintree-text/50 shrink-0" />
+        <span className="ml-1.5 text-xs font-medium text-daintree-text/70 truncate">
+          Daintree Assistant
+        </span>
+        <AssistantHeaderStateIndicator agentState={agentState} />
+      </div>
+      <button
+        type="button"
+        onClick={onOpenDocs}
+        className="p-1 rounded-[var(--radius-sm)] text-daintree-text/50 hover:text-daintree-text hover:bg-tint/8 transition-colors focus-visible:outline focus-visible:outline-2 focus-visible:outline-daintree-accent focus-visible:outline-offset-2"
+        aria-label="Open assistant docs"
+      >
+        <CircleHelp className="w-3.5 h-3.5" />
+      </button>
+      {canStartNewSession && (
+        <button
+          type="button"
+          onClick={onNewSession}
+          className="p-1 rounded-[var(--radius-sm)] text-daintree-text/50 hover:text-daintree-text hover:bg-tint/8 transition-colors focus-visible:outline focus-visible:outline-2 focus-visible:outline-daintree-accent focus-visible:outline-offset-2"
+          aria-label="Start new session"
+        >
+          <Plus className="w-3.5 h-3.5" />
+        </button>
+      )}
+      <button
+        type="button"
+        onClick={onClose}
+        className="p-1 rounded-[var(--radius-sm)] text-daintree-text/50 hover:text-daintree-text hover:bg-tint/8 transition-colors focus-visible:outline focus-visible:outline-2 focus-visible:outline-daintree-accent focus-visible:outline-offset-2"
+        aria-label="Hide Daintree Assistant"
+      >
+        <ChevronRight className="w-3.5 h-3.5" />
+      </button>
+    </div>
+  );
+}

--- a/src/components/HelpPanel/HelpPanelVersionGate.tsx
+++ b/src/components/HelpPanel/HelpPanelVersionGate.tsx
@@ -1,0 +1,38 @@
+import { Settings2 } from "lucide-react";
+import { cn } from "@/lib/utils";
+import type { VersionTooOld } from "@/controllers/HelpSessionController";
+
+interface HelpPanelVersionGateProps {
+  versionTooOld: VersionTooOld;
+  onOpenSettings: () => void;
+}
+
+export function HelpPanelVersionGate({ versionTooOld, onOpenSettings }: HelpPanelVersionGateProps) {
+  return (
+    <div
+      className="flex-1 flex flex-col items-center justify-center gap-3 p-8 text-center"
+      data-testid="help-version-too-old"
+    >
+      <p className="text-sm text-daintree-text/70">
+        Update {versionTooOld.agentName} to use Daintree Assistant
+      </p>
+      <p className="text-xs text-daintree-text/50 max-w-[32ch]">
+        Daintree Assistant needs {versionTooOld.agentName} {versionTooOld.requiredVersion} or later.
+        You're on {versionTooOld.installedVersion}.
+      </p>
+      <button
+        type="button"
+        onClick={onOpenSettings}
+        className={cn(
+          "mt-1 inline-flex items-center gap-1.5 px-3 py-1.5 rounded-[var(--radius-md)]",
+          "text-xs font-medium border border-daintree-border text-daintree-text/80",
+          "hover:bg-overlay-soft hover:text-daintree-text transition-colors",
+          "focus-visible:outline focus-visible:outline-2 focus-visible:outline-daintree-accent focus-visible:outline-offset-2"
+        )}
+      >
+        <Settings2 className="w-3.5 h-3.5" />
+        <span>Update {versionTooOld.agentName}</span>
+      </button>
+    </div>
+  );
+}

--- a/src/controllers/HelpSessionController.ts
+++ b/src/controllers/HelpSessionController.ts
@@ -1,0 +1,1302 @@
+// Encapsulates the renderer-side session lifecycle that previously lived
+// inline in HelpPanel.tsx: auto-launch, version probe, MCP provisioning,
+// resume-or-fresh, idle hibernate with busy-recheck, gracefulKill, revoke,
+// and tier-mismatch handling. The panel subscribes via `useSyncExternalStore`
+// and delegates store writes back through the existing `helpPanelStore`
+// actions — this controller never shadows persisted state.
+
+import * as semver from "semver";
+
+import { getAgentConfig } from "@/config/agents";
+import { actionService } from "@/services/ActionService";
+import { useHelpPanelStore } from "@/store/helpPanelStore";
+import { usePanelStore, useProjectStore } from "@/store";
+import { projectClient } from "@/clients/projectClient";
+import { notify } from "@/lib/notify";
+import { logError } from "@/utils/logger";
+import { safeFireAndForget } from "@/utils/safeFireAndForget";
+import { formatErrorMessage } from "@shared/utils/errorMessage";
+import { ACTIVE_AGENT_STATES } from "@shared/types/agent";
+import { buildResumeCommand } from "@shared/types/agentSettings";
+import { resolveDaintreeMcpTier } from "@shared/types/project";
+import type { SnapshotInfo } from "@shared/types/ipc/git";
+
+const HIBERNATE_VALID_MINUTES: readonly number[] = [0, 15, 30, 60, 120];
+const DEFAULT_HIBERNATE_MINUTES = 30;
+
+// Re-checks every 2 minutes while the agent is busy so hibernation defers
+// cleanly until the conversation is idle without restarting the full
+// countdown each time.
+const HIBERNATE_BUSY_RECHECK_MS = 2 * 60 * 1000;
+
+const RESUME_BANNER_AUTO_DISMISS_MS = 10_000;
+const SNAPSHOT_BANNER_AUTO_DISMISS_MS = 12_000;
+
+export type HelpSessionPhase =
+  | "idle"
+  | "version-checking"
+  | "provisioning"
+  | "launching"
+  | "live"
+  | "hibernating";
+
+export interface VersionTooOld {
+  agentId: string;
+  agentName: string;
+  installedVersion: string;
+  requiredVersion: string;
+}
+
+export interface TierMismatchState {
+  sessionId: string;
+  toolId: string;
+  tier: string;
+  targetTier: "workbench" | "action" | "system" | null;
+  /**
+   * Captured at event time so "Always allow" persists to the project the
+   * banner originated from, not whichever project is current at click time —
+   * matters during rapid project switches.
+   */
+  projectId: string | null;
+}
+
+export interface HelpSessionSnapshot {
+  phase: HelpSessionPhase;
+  showResumeBanner: boolean;
+  assistantVersionTooOld: VersionTooOld | null;
+  tierMismatch: TierMismatchState | null;
+  preflightSnapshot: SnapshotInfo | null;
+  isApprovingTier: boolean;
+}
+
+export interface HelpProjectRef {
+  id: string;
+  path: string;
+}
+
+export interface HelpSessionInputs {
+  isOpen: boolean;
+  isReadyToLaunch: boolean;
+  currentProject: HelpProjectRef | null;
+  terminalId: string | null;
+  preferredAgentId: string | null;
+  supportedInstalledAgentIds: readonly string[];
+  /** Bumped each time the panel becomes visible — re-evaluates auto-launch. */
+  visibilityEpoch: number;
+}
+
+export interface HelpLaunchOptions {
+  agentId: string;
+  /** Optional prompt to seed the agent — when set, the resume path is skipped. */
+  seedPrompt?: string;
+  /**
+   * Pre-reserved terminal id. When provided, the controller writes
+   * `setTerminal(requestedId, agentId, null)` synchronously before the first
+   * await so the dock filter (`#6951`) sees the reservation immediately.
+   * Pass for "+ New session" and "Run anyway" paths.
+   */
+  requestedId?: string;
+  /** For run-anyway: bypass missing-CLI guard. */
+  force?: boolean;
+  /** For new-session / run-anyway: ask the dispatcher to activate the dock. */
+  activateDock?: boolean;
+  /** Remove the existing terminal+session before launching the new one. */
+  replaceExisting?: boolean;
+  /** True when called from the controller's auto-launch decision path. */
+  isAutoLaunch?: boolean;
+}
+
+interface HelpSessionRef {
+  sessionId: string;
+  sessionPath: string;
+  token: string;
+  mcpUrl: string | null;
+  windowId: number;
+}
+
+type ProvisionOutcome =
+  | { ok: true; session: HelpSessionRef }
+  | { ok: false; code: "MCP_NOT_READY"; message: string }
+  | { ok: false; code: "UNKNOWN"; message: string };
+
+async function provisionHelpSession(
+  project: HelpProjectRef,
+  agentId: string
+): Promise<ProvisionOutcome> {
+  try {
+    const result = await window.electron.help.provisionSession({
+      projectId: project.id,
+      projectPath: project.path,
+      agentId,
+    });
+    if (!result) {
+      return {
+        ok: false,
+        code: "UNKNOWN",
+        message: "Couldn't provision help session.",
+      };
+    }
+    return { ok: true, session: result };
+  } catch (err) {
+    logError("Failed to provision help session", err);
+    const code =
+      err && typeof err === "object" && "code" in err
+        ? (err as Record<string, unknown>).code
+        : undefined;
+    const message = formatErrorMessage(err, "Couldn't provision help session");
+    if (code === "MCP_NOT_READY") {
+      return { ok: false, code: "MCP_NOT_READY", message };
+    }
+    return { ok: false, code: "UNKNOWN", message };
+  }
+}
+
+// `refresh=true` bypasses the 12h AgentVersionService cache — pass on retry
+// so a user who manually updates the CLI outside Daintree's update flow can
+// recover within one panel reopen instead of waiting for cache expiry.
+async function checkAssistantVersion(
+  agentId: string,
+  agentName: string,
+  refresh = false
+): Promise<VersionTooOld | null> {
+  const config = getAgentConfig(agentId);
+  const required = config?.assistantMinVersion;
+  if (!required) return null;
+
+  let info;
+  try {
+    info = await window.electron.system.getAgentVersion(agentId, refresh);
+  } catch (err) {
+    logError("Failed to probe assistant CLI version", err);
+    return null;
+  }
+
+  const installed = info?.installedVersion;
+  if (!installed) return null;
+
+  try {
+    if (semver.lt(installed, required)) {
+      return { agentId, agentName, installedVersion: installed, requiredVersion: required };
+    }
+  } catch (err) {
+    logError("Failed to compare assistant CLI version", err);
+    return null;
+  }
+  return null;
+}
+
+async function loadCustomLaunchFlags(): Promise<string[]> {
+  try {
+    const settings = await window.electron.helpAssistant.getSettings();
+    const raw = settings.customArgs?.trim();
+    if (!raw) return [];
+    return raw.split(/\s+/).filter(Boolean);
+  } catch (err) {
+    logError("Failed to load helpAssistant customArgs", err);
+    return [];
+  }
+}
+
+function buildHelpEnv(
+  session: HelpSessionRef | null,
+  projectId: string | null
+): Record<string, string> | undefined {
+  if (!session) return undefined;
+  const env: Record<string, string> = {
+    DAINTREE_MCP_TOKEN: session.token,
+    DAINTREE_WINDOW_ID: String(session.windowId),
+  };
+  if (session.mcpUrl) env.DAINTREE_MCP_URL = session.mcpUrl;
+  if (projectId) env.DAINTREE_PROJECT_ID = projectId;
+  return env;
+}
+
+function revokeHelpSession(sessionId: string | null): void {
+  if (!sessionId) return;
+  window.electron.help.revokeSession(sessionId).catch((err) => {
+    logError("Failed to revoke help session", err);
+  });
+}
+
+function notifyLaunchFailed(agentId: string, reason: string): void {
+  const cfg = getAgentConfig(agentId);
+  const name = cfg?.name ?? agentId;
+  notify({
+    type: "error",
+    title: "Assistant launch failed",
+    message: `Couldn't start ${name}. ${reason}`,
+  });
+}
+
+function notifyMcpNotReady(reason: string): void {
+  notify({
+    type: "error",
+    title: "Start MCP failed",
+    message: `Daintree Assistant needs MCP, but the server didn't start. ${reason}`,
+    action: {
+      label: "Open settings",
+      actionId: "app.settings.openTab",
+      actionArgs: { tab: "assistant" },
+      onClick: () => {
+        void actionService.dispatch("app.settings.openTab", { tab: "assistant" });
+      },
+    },
+  });
+}
+
+const INITIAL_SNAPSHOT: HelpSessionSnapshot = Object.freeze({
+  phase: "idle",
+  showResumeBanner: false,
+  assistantVersionTooOld: null,
+  tierMismatch: null,
+  preflightSnapshot: null,
+  isApprovingTier: false,
+});
+
+/**
+ * Owns the imperative help-session lifecycle. One instance per HelpPanel
+ * mount, created via `useRef` null-guard. The panel reads `getSnapshot()`
+ * via `useSyncExternalStore` and calls action methods from event handlers
+ * and synchronizing effects.
+ *
+ * Idempotency contract:
+ * - Constructor is pure (no IPC, no timers, no async).
+ * - `start()` arms IPC subscriptions; `stop()` clears all timers and
+ *   unsubscribes. `start()` is idempotent so StrictMode's double-mount cycle
+ *   doesn't double-arm.
+ * - `_launchGen` is a monotonic counter — every async checkpoint compares
+ *   the captured `gen` against `_launchGen` and bails if superseded.
+ * - `_pendingNewTerminalId` is written synchronously before any `await` so
+ *   the dock filter race (#6951) closes immediately when the reservation
+ *   is committed to the store.
+ */
+export class HelpSessionController {
+  private _snapshot: HelpSessionSnapshot = INITIAL_SNAPSHOT;
+  private _listeners = new Set<() => void>();
+  private _started = false;
+  private _launchGen = 0;
+  private _isLaunching = false;
+  private _hasAutoLaunched = false;
+  private _pendingSessionId: string | null = null;
+  private _pendingNewTerminalId: string | null = null;
+  /**
+   * Tracks whether the version gate has blocked at any point in this panel
+   * instance. When true, the next `checkAssistantVersion` call passes
+   * `refresh=true` so an externally-updated CLI is detected without waiting
+   * for the 12h AgentVersionService cache TTL. Cleared once a probe passes.
+   */
+  private _hasBlockedThisSession = false;
+  /**
+   * Once-per-terminal-id guard for the auto-snapshot pre-flight. Stores the
+   * terminal id we last took a snapshot for so React 19 StrictMode's
+   * double-invoke can't fire two parallel pre-flights.
+   */
+  private _preflightSnapshotTerminalId: string | null = null;
+  private _isSystemSuspended = false;
+  private _hibernateMinutes = DEFAULT_HIBERNATE_MINUTES;
+  private _hibernateTimer: ReturnType<typeof setTimeout> | null = null;
+  private _resumeBannerTimer: ReturnType<typeof setTimeout> | null = null;
+  private _snapshotBannerTimer: ReturnType<typeof setTimeout> | null = null;
+  private _disposers: Array<() => void> = [];
+  private _lastInputs: HelpSessionInputs | null = null;
+  private _hibernateArmedFor: { terminalId: string; agentId: string | null } | null = null;
+
+  // Bound for stable references across StrictMode re-subscribe.
+  subscribe = (listener: () => void): (() => void) => {
+    this._listeners.add(listener);
+    return () => {
+      this._listeners.delete(listener);
+    };
+  };
+
+  getSnapshot = (): HelpSessionSnapshot => this._snapshot;
+
+  /**
+   * Arm IPC subscriptions. Idempotent across StrictMode double-mount: a
+   * second start while `_started` is true is a no-op so we don't stack
+   * tier-mismatch listeners.
+   */
+  start(): void {
+    if (this._started) return;
+    this._started = true;
+
+    const disposeTier = window.electron.mcpServer.onTierNotPermitted((payload) => {
+      const projectId = useProjectStore.getState().currentProject?.id ?? null;
+      this._patch({
+        tierMismatch: {
+          sessionId: payload.sessionId,
+          toolId: payload.toolId,
+          tier: payload.tier,
+          targetTier: payload.targetTier,
+          projectId,
+        },
+      });
+    });
+    this._disposers.push(disposeTier);
+
+    const offSuspend = window.electron.systemSleep.onSuspend(() => {
+      this._isSystemSuspended = true;
+    });
+    const offWake = window.electron.systemSleep.onWake(() => {
+      this._isSystemSuspended = false;
+    });
+    this._disposers.push(offSuspend, offWake);
+  }
+
+  stop(): void {
+    if (!this._started) return;
+    this._started = false;
+    for (const dispose of this._disposers) {
+      try {
+        dispose();
+      } catch (err) {
+        logError("HelpSessionController: disposer threw", err);
+      }
+    }
+    this._disposers = [];
+    this._clearHibernateTimer();
+    this._clearResumeBannerTimer();
+    this._clearSnapshotBannerTimer();
+    // Bumping the gen invalidates any in-flight launch so its post-await
+    // checkpoints bail. Live store state is left to the explicit teardown
+    // paths (tearDownForViewHidden) so a StrictMode synthetic unmount
+    // doesn't tear down the user's session.
+    this._launchGen++;
+    this._hibernateArmedFor = null;
+    this._lastInputs = null;
+  }
+
+  /**
+   * Called from a single React effect whose deps cover every input the
+   * controller needs. Each call may trigger:
+   *  - clearing the version block when `preferredAgentId` changes;
+   *  - arming or clearing the idle-hibernate timer;
+   *  - the auto-launch decision (preferred or single-supported).
+   */
+  syncInputs(inputs: HelpSessionInputs): void {
+    const prev = this._lastInputs;
+    this._lastInputs = inputs;
+
+    // Clear the version block when the preferred agent changes — the stale
+    // block belongs to the previous agent and would otherwise paint over
+    // the new agent's empty state. The in-flight launch's stale-agent
+    // post-dispatch check handles its own cleanup, so we don't bump
+    // `_launchGen` here.
+    if (prev && prev.preferredAgentId !== inputs.preferredAgentId) {
+      this._patch({ assistantVersionTooOld: null });
+    }
+
+    // Reset auto-launch guard when the panel closes so the next open can
+    // try again from scratch.
+    if (!inputs.isOpen) {
+      this._hasAutoLaunched = false;
+    }
+
+    this._maybeArmHibernate(inputs);
+    this._maybeAutoLaunch(inputs);
+  }
+
+  handleVisibilityChanged(isHidden: boolean): { tearDown: boolean } {
+    if (!isHidden) {
+      return { tearDown: false };
+    }
+    if (this._isSystemSuspended) {
+      return { tearDown: false };
+    }
+    return { tearDown: true };
+  }
+
+  isSystemSuspended(): boolean {
+    return this._isSystemSuspended;
+  }
+
+  /**
+   * Revoke the bound help session if the underlying PTY panel disappears
+   * from the panel store. addPanel puts the placeholder in panelsById
+   * before setTerminal records the id here, so a missing entry usually
+   * means the process exited — except during the brief window where the
+   * +New session / Run-anyway flows have reserved the id but addPanel has
+   * not yet committed it (guarded by `_pendingNewTerminalId`).
+   */
+  handleTerminalPanelMissing(args: { terminalId: string; terminalExists: boolean }): void {
+    const { terminalId, terminalExists } = args;
+    if (!terminalId || terminalExists) return;
+    if (terminalId === this._pendingNewTerminalId) return;
+    const store = useHelpPanelStore.getState();
+    if (store.terminalId !== terminalId) return;
+    revokeHelpSession(store.sessionId);
+    this._hasAutoLaunched = false;
+    store.clearTerminal();
+  }
+
+  /**
+   * Hide the panel without tearing down. Called from the panel's
+   * visibilitychange handler once it has confirmed the OS isn't suspended.
+   */
+  tearDownForViewHidden(): void {
+    const state = useHelpPanelStore.getState();
+    if (state.terminalId) {
+      usePanelStore.getState().removePanel(state.terminalId);
+      revokeHelpSession(state.sessionId);
+      this._hasAutoLaunched = false;
+      useHelpPanelStore.getState().clearTerminal();
+    }
+    this._revokePendingSession();
+  }
+
+  /**
+   * Auto-snapshot pre-flight: when the project's MCP tier is `system`, take
+   * a pre-flight snapshot once per session and surface a Tier-1 ambient
+   * banner. The guard is set synchronously to survive React 19 StrictMode
+   * double-invocation; callers should pass `cancelled` to skip the surface
+   * on unmount.
+   */
+  maybeRunPreflightSnapshot(args: {
+    terminalId: string | null;
+    terminalExists: boolean;
+    projectId: string | null;
+    worktreeId: string | null;
+  }): (() => void) | void {
+    const { terminalId, terminalExists, projectId, worktreeId } = args;
+    if (!terminalId || !terminalExists) return;
+    if (this._preflightSnapshotTerminalId === terminalId) return;
+    if (!projectId) return;
+    if (!worktreeId) return;
+
+    let cancelled = false;
+    this._preflightSnapshotTerminalId = terminalId;
+    safeFireAndForget(
+      (async () => {
+        const settings = await projectClient.getSettings(projectId);
+        const tier = resolveDaintreeMcpTier(settings);
+        if (tier !== "system") return;
+        const snapshot = await window.electron.git.snapshotGet(worktreeId);
+        // PreAgentSnapshotService records a sentinel (`stashRef: ""`)
+        // before the actual stash completes to coordinate concurrent
+        // creation. A sentinel means the snapshot is still in-flight (or
+        // failed early) — surfacing the banner would lie about safety.
+        if (cancelled || !snapshot || !snapshot.stashRef) return;
+        this._patch({ preflightSnapshot: snapshot });
+        this._armSnapshotBannerAutoDismiss();
+      })().catch((err) => {
+        logError("HelpPanel: snapshot pre-flight failed", err);
+      }),
+      { context: "HelpPanel:snapshot pre-flight" }
+    );
+    return () => {
+      cancelled = true;
+    };
+  }
+
+  /**
+   * User-initiated launch from the empty-state agent picker or other
+   * caller. Mirrors the original `handleSelectAgent` semantics: removes the
+   * existing terminal if present, runs the version gate, provisions, then
+   * either resumes or starts fresh.
+   */
+  selectAgent(agentId: string, seedPrompt?: string): void {
+    this.launch({ agentId, seedPrompt, replaceExisting: true });
+  }
+
+  /**
+   * "+ New session" — destructive reset: stop the current agent, drop the
+   * conversation, revoke the bound + pending sessions, then relaunch the
+   * same agent. The reserved id is pre-recorded in the store synchronously
+   * so the dock filter sees the new reservation the instant `addPanel`
+   * commits (#6951).
+   */
+  newSession(): void {
+    const help = useHelpPanelStore.getState();
+    const { terminalId, agentId } = help;
+    if (!terminalId || !agentId) return;
+    const reservedId = `terminal-${crypto.randomUUID()}`;
+    this.launch({
+      agentId,
+      requestedId: reservedId,
+      replaceExisting: true,
+      activateDock: true,
+    });
+  }
+
+  /**
+   * "Run anyway" from the missing-CLI gate — same as `newSession` plus
+   * `force: true` so the dispatcher bypasses the missing-CLI guard.
+   */
+  runAnyway(): void {
+    const help = useHelpPanelStore.getState();
+    const { terminalId, agentId } = help;
+    if (!terminalId || !agentId) return;
+    const reservedId = `terminal-${crypto.randomUUID()}`;
+    this.launch({
+      agentId,
+      requestedId: reservedId,
+      replaceExisting: true,
+      activateDock: true,
+      force: true,
+    });
+  }
+
+  /**
+   * Unified launch handler. The three legacy entry points (handleSelectAgent,
+   * doNewSession, handleRunAnyway) collapse into this one method — options
+   * model their differences.
+   *
+   * Synchronous write order before the first `await` (preserving #6951):
+   *   1. Capture live state + bump _launchGen.
+   *   2. If `replaceExisting`, remove existing panel and revoke prior sessions.
+   *   3. If `requestedId`, set `_pendingNewTerminalId` synchronously, then
+   *      write the reservation via `setTerminal(reservedId, agentId, null)`.
+   *   4. Only then enter the async provision/dispatch sequence.
+   */
+  launch(options: HelpLaunchOptions): void {
+    const inputs = this._lastInputs;
+    const launchAgentId = options.agentId;
+    if (!inputs?.isReadyToLaunch || !inputs?.currentProject) {
+      notifyLaunchFailed(launchAgentId, "Project state is still loading. Try again.");
+      return;
+    }
+    if (this._isLaunching) return;
+
+    const launchProject = inputs.currentProject;
+    this._isLaunching = true;
+
+    const gen = ++this._launchGen;
+    const replaceExisting = options.replaceExisting === true;
+    const reservedId = options.requestedId ?? null;
+    let presetEnv: Record<string, string> | undefined;
+
+    if (replaceExisting) {
+      const existing = useHelpPanelStore.getState();
+      const existingTerminalId = existing.terminalId;
+      const previousSessionId = existing.sessionId;
+      if (existingTerminalId) {
+        const panel = usePanelStore.getState().panelsById[existingTerminalId];
+        const candidate = panel?.extensionState?.presetEnv;
+        if (candidate && typeof candidate === "object") {
+          presetEnv = candidate as Record<string, string>;
+        }
+        usePanelStore.getState().removePanel(existingTerminalId);
+        revokeHelpSession(previousSessionId);
+        if (reservedId) this._revokePendingSession();
+        useHelpPanelStore.getState().clearTerminal();
+      }
+      // Discarding the current conversation invalidates any persisted
+      // hibernate entry for this project — leaving it would resume the
+      // just-discarded chat on next open.
+      if (reservedId) {
+        const projectIdForReset = useProjectStore.getState().currentProject?.id ?? null;
+        if (projectIdForReset) {
+          useHelpPanelStore.getState().clearHibernateSession(projectIdForReset);
+        }
+        this._patch({ showResumeBanner: false });
+      }
+    }
+
+    if (reservedId) {
+      // Synchronous reservation — must complete before any `await` so the
+      // dock filter (#6951) sees `helpPanelStore.terminalId === reservedId`
+      // the instant `addPanel` commits.
+      this._pendingNewTerminalId = reservedId;
+      useHelpPanelStore.getState().setTerminal(reservedId, launchAgentId, null);
+    }
+
+    safeFireAndForget(this._executeLaunch(gen, options, launchProject, presetEnv), {
+      context: reservedId
+        ? options.force
+          ? "Help: run-anyway re-launch"
+          : "Help: + New session relaunch"
+        : "Help: select agent launch",
+    });
+  }
+
+  dismissResumeBanner(): void {
+    this._clearResumeBannerTimer();
+    this._patch({ showResumeBanner: false });
+  }
+
+  dismissPreflightSnapshot(): void {
+    this._clearSnapshotBannerTimer();
+    this._patch({ preflightSnapshot: null });
+  }
+
+  dismissTierMismatch(): void {
+    this._patch({ tierMismatch: null });
+  }
+
+  approveTierOnce(): void {
+    const current = this._snapshot.tierMismatch;
+    if (!current?.targetTier || this._snapshot.isApprovingTier) return;
+    const { targetTier, sessionId, toolId } = current;
+    this._patch({ isApprovingTier: true });
+    safeFireAndForget(
+      window.electron.mcpServer
+        .setSessionTier(sessionId, targetTier)
+        .then(() => {
+          this._clearTierMismatchIfStillCurrent(sessionId, toolId);
+        })
+        .catch((err) => {
+          logError("HelpPanel: setSessionTier failed", err);
+          notify({
+            type: "error",
+            title: "Couldn't approve tool",
+            message: formatErrorMessage(err, "Couldn't elevate the assistant's tier."),
+          });
+        })
+        .finally(() => {
+          this._patch({ isApprovingTier: false });
+        }),
+      { context: "HelpPanel:setSessionTier" }
+    );
+  }
+
+  alwaysAllowTier(): void {
+    const current = this._snapshot.tierMismatch;
+    if (!current?.targetTier || this._snapshot.isApprovingTier) return;
+    // Use the project captured at event time — `current.projectId` is
+    // immutable for this banner, so a project switch after the banner
+    // appears doesn't redirect the save to the wrong project.
+    const projectId = current.projectId ?? useProjectStore.getState().currentProject?.id ?? null;
+    if (!projectId) {
+      this.dismissTierMismatch();
+      return;
+    }
+    const { targetTier, sessionId, toolId } = current;
+    this._patch({ isApprovingTier: true });
+    safeFireAndForget(
+      (async () => {
+        // projectClient.saveSettings goes directly to the IPC handler —
+        // the `project.saveSettings` action sanitizes `daintreeMcpTier`
+        // out to keep agents from self-elevating.
+        const settings = await projectClient.getSettings(projectId);
+        await projectClient.saveSettings(projectId, {
+          ...settings,
+          daintreeMcpTier: targetTier,
+        });
+        await window.electron.mcpServer.setSessionTier(sessionId, targetTier);
+        this._clearTierMismatchIfStillCurrent(sessionId, toolId);
+      })()
+        .catch((err) => {
+          logError("HelpPanel: always-allow tier write failed", err);
+          notify({
+            type: "error",
+            title: "Couldn't save permission",
+            message: formatErrorMessage(err, "Couldn't update project tier setting."),
+          });
+        })
+        .finally(() => {
+          this._patch({ isApprovingTier: false });
+        }),
+      { context: "HelpPanel:alwaysAllowTier" }
+    );
+  }
+
+  // --- internal ---
+
+  private _patch(partial: Partial<HelpSessionSnapshot>): void {
+    let changed = false;
+    const next = { ...this._snapshot };
+    for (const key of Object.keys(partial) as Array<keyof HelpSessionSnapshot>) {
+      const value = partial[key];
+      if (value === undefined) continue;
+      if (next[key] !== value) {
+        // eslint-disable-next-line @typescript-eslint/no-explicit-any
+        (next as any)[key] = value;
+        changed = true;
+      }
+    }
+    if (!changed) return;
+    this._snapshot = Object.freeze(next);
+    for (const listener of this._listeners) {
+      try {
+        listener();
+      } catch (err) {
+        logError("HelpSessionController: listener threw", err);
+      }
+    }
+  }
+
+  private _clearHibernateTimer(): void {
+    if (this._hibernateTimer) {
+      clearTimeout(this._hibernateTimer);
+      this._hibernateTimer = null;
+    }
+  }
+
+  private _clearResumeBannerTimer(): void {
+    if (this._resumeBannerTimer) {
+      clearTimeout(this._resumeBannerTimer);
+      this._resumeBannerTimer = null;
+    }
+  }
+
+  private _clearSnapshotBannerTimer(): void {
+    if (this._snapshotBannerTimer) {
+      clearTimeout(this._snapshotBannerTimer);
+      this._snapshotBannerTimer = null;
+    }
+  }
+
+  private _armResumeBannerAutoDismiss(): void {
+    this._clearResumeBannerTimer();
+    this._resumeBannerTimer = setTimeout(() => {
+      this._resumeBannerTimer = null;
+      this._patch({ showResumeBanner: false });
+    }, RESUME_BANNER_AUTO_DISMISS_MS);
+  }
+
+  private _armSnapshotBannerAutoDismiss(): void {
+    this._clearSnapshotBannerTimer();
+    this._snapshotBannerTimer = setTimeout(() => {
+      this._snapshotBannerTimer = null;
+      this._patch({ preflightSnapshot: null });
+    }, SNAPSHOT_BANNER_AUTO_DISMISS_MS);
+  }
+
+  private _revokePendingSession(): void {
+    const pending = this._pendingSessionId;
+    if (pending) {
+      this._pendingSessionId = null;
+      revokeHelpSession(pending);
+    }
+  }
+
+  private _clearTierMismatchIfStillCurrent(sessionId: string, toolId: string): void {
+    const current = this._snapshot.tierMismatch;
+    if (current && current.sessionId === sessionId && current.toolId === toolId) {
+      this._patch({ tierMismatch: null });
+    }
+  }
+
+  private _maybeArmHibernate(inputs: HelpSessionInputs): void {
+    const { isOpen, terminalId, preferredAgentId } = inputs;
+    if (isOpen || !terminalId) {
+      this._clearHibernateTimer();
+      this._hibernateArmedFor = null;
+      return;
+    }
+    // Already armed for this exact terminal+agent — leave the timer.
+    if (
+      this._hibernateArmedFor &&
+      this._hibernateArmedFor.terminalId === terminalId &&
+      this._hibernateArmedFor.agentId === preferredAgentId
+    ) {
+      return;
+    }
+    this._clearHibernateTimer();
+    this._hibernateArmedFor = {
+      terminalId,
+      agentId: useHelpPanelStore.getState().agentId,
+    };
+    const initialTerminalId = terminalId;
+    const initialAgentId = this._hibernateArmedFor.agentId;
+
+    safeFireAndForget(
+      window.electron.helpAssistant
+        .getSettings()
+        .then((settings) => {
+          if (!this._isStillArmedFor(initialTerminalId)) return;
+          const minutes = settings.idleHibernateMinutes;
+          if (!HIBERNATE_VALID_MINUTES.includes(minutes)) {
+            this._hibernateMinutes = DEFAULT_HIBERNATE_MINUTES;
+          } else {
+            this._hibernateMinutes = minutes;
+          }
+          if (this._hibernateMinutes <= 0) return;
+          this._clearHibernateTimer();
+          this._hibernateTimer = setTimeout(
+            () => this._fireHibernate(initialTerminalId, initialAgentId),
+            this._hibernateMinutes * 60 * 1000
+          );
+        })
+        .catch((err) => {
+          if (!this._isStillArmedFor(initialTerminalId)) return;
+          logError("HelpPanel: failed to load idleHibernateMinutes", err);
+          this._hibernateMinutes = DEFAULT_HIBERNATE_MINUTES;
+          this._clearHibernateTimer();
+          this._hibernateTimer = setTimeout(
+            () => this._fireHibernate(initialTerminalId, initialAgentId),
+            DEFAULT_HIBERNATE_MINUTES * 60 * 1000
+          );
+        }),
+      { context: "HelpPanel:hibernate getSettings" }
+    );
+  }
+
+  private _isStillArmedFor(terminalId: string): boolean {
+    return this._hibernateArmedFor?.terminalId === terminalId;
+  }
+
+  private _fireHibernate(initialTerminalId: string, initialAgentId: string | null): void {
+    this._hibernateTimer = null;
+    if (!this._isStillArmedFor(initialTerminalId)) return;
+
+    const helpState = useHelpPanelStore.getState();
+    if (helpState.terminalId !== initialTerminalId) return;
+    if (helpState.isOpen) return;
+    if (this._isSystemSuspended) return;
+
+    const panelState = usePanelStore.getState();
+    const livePanel = panelState.panelsById[initialTerminalId];
+    if (!livePanel) return;
+    const agentState = livePanel.agentState;
+    if (agentState && ACTIVE_AGENT_STATES.has(agentState)) {
+      // Re-check shortly without restarting the full hibernate countdown —
+      // the user is presumably about to come back.
+      this._hibernateTimer = setTimeout(
+        () => this._fireHibernate(initialTerminalId, initialAgentId),
+        HIBERNATE_BUSY_RECHECK_MS
+      );
+      return;
+    }
+
+    const projectId = useProjectStore.getState().currentProject?.id ?? null;
+    const cwd = livePanel.cwd ?? "";
+    const sessionToRevoke = helpState.sessionId;
+    const liveAgentId = helpState.agentId ?? initialAgentId;
+
+    safeFireAndForget(
+      window.electron.terminal
+        .gracefulKill(initialTerminalId)
+        .then((capturedSessionId) => {
+          const after = useHelpPanelStore.getState();
+          if (after.terminalId !== initialTerminalId) return;
+          // Critical race: user reopened the panel while gracefulKill was
+          // in flight. Terminal is still live — don't tear it down out
+          // from under them. The captured session ID is also discarded;
+          // the next hibernation cycle will capture a fresh one.
+          if (after.isOpen) return;
+          if (capturedSessionId && projectId && liveAgentId && cwd) {
+            after.setHibernateSession(projectId, {
+              sessionId: capturedSessionId,
+              cwd,
+              agentId: liveAgentId,
+            });
+          } else if (projectId) {
+            after.clearHibernateSession(projectId);
+          }
+          usePanelStore.getState().removePanel(initialTerminalId);
+          revokeHelpSession(sessionToRevoke);
+          useHelpPanelStore.getState().clearTerminal();
+        })
+        .catch((err) => {
+          const after = useHelpPanelStore.getState();
+          if (after.terminalId !== initialTerminalId || after.isOpen) return;
+          logError("HelpPanel: gracefulKill during hibernate failed", err);
+          if (projectId) {
+            useHelpPanelStore.getState().clearHibernateSession(projectId);
+          }
+          usePanelStore.getState().removePanel(initialTerminalId);
+          revokeHelpSession(sessionToRevoke);
+          useHelpPanelStore.getState().clearTerminal();
+        }),
+      { context: "HelpPanel:hibernate gracefulKill" }
+    );
+  }
+
+  private _maybeAutoLaunch(inputs: HelpSessionInputs): void {
+    if (typeof document !== "undefined" && document.hidden) return;
+    if (!inputs.isOpen) return;
+    if (!inputs.isReadyToLaunch) return;
+    if (!inputs.currentProject) return;
+    if (inputs.terminalId) return;
+    if (this._hasAutoLaunched) return;
+
+    if (inputs.preferredAgentId) {
+      const launchAgentId = inputs.preferredAgentId;
+      const launchProject = inputs.currentProject;
+      this._hasAutoLaunched = true;
+      const gen = ++this._launchGen;
+      safeFireAndForget(this._executeAutoLaunch(gen, launchAgentId, launchProject), {
+        context: "Auto-launching preferred help agent",
+      });
+      return;
+    }
+
+    if (inputs.supportedInstalledAgentIds.length === 1) {
+      const onlyAgentId = inputs.supportedInstalledAgentIds[0];
+      if (!onlyAgentId) return;
+      this._hasAutoLaunched = true;
+      this.launch({
+        agentId: onlyAgentId,
+        isAutoLaunch: true,
+        replaceExisting: true,
+      });
+    }
+  }
+
+  private async _spawnResumed(
+    launchAgentId: string,
+    hibernated: { sessionId: string; cwd: string },
+    session: HelpSessionRef | null,
+    folderPath: string
+  ): Promise<string | null> {
+    const customLaunchFlags = await loadCustomLaunchFlags();
+    const command = buildResumeCommand(
+      launchAgentId,
+      hibernated.sessionId,
+      customLaunchFlags.length > 0 ? customLaunchFlags : undefined
+    );
+    if (!command) return null;
+
+    const cwd = session?.sessionPath ?? hibernated.cwd ?? folderPath;
+    const projectId = useProjectStore.getState().currentProject?.id ?? null;
+    const env = buildHelpEnv(session, projectId);
+
+    const newId = await usePanelStore.getState().addPanel({
+      kind: "terminal",
+      launchAgentId,
+      command,
+      cwd,
+      location: "dock",
+      ephemeral: true,
+      ...(env && { env }),
+      ...(customLaunchFlags.length > 0 && { agentLaunchFlags: customLaunchFlags }),
+    });
+    return newId ?? null;
+  }
+
+  private async _executeAutoLaunch(
+    gen: number,
+    launchAgentId: string,
+    launchProject: HelpProjectRef
+  ): Promise<void> {
+    try {
+      const folderPath = await window.electron.help.getFolderPath();
+      if (gen !== this._launchGen) return;
+      if (!folderPath) {
+        this._hasAutoLaunched = false;
+        notifyLaunchFailed(launchAgentId, "Help folder is not available.");
+        return;
+      }
+
+      const launchAgentName = getAgentConfig(launchAgentId)?.name ?? launchAgentId;
+      const versionBlock = await checkAssistantVersion(
+        launchAgentId,
+        launchAgentName,
+        this._hasBlockedThisSession
+      );
+      if (gen !== this._launchGen) return;
+      if (versionBlock) {
+        // Stale-agent guard: skip the block if the user changed
+        // preferredAgentId while the probe was in flight — the new
+        // agent's empty state shouldn't be covered by an "Update Claude"
+        // message that no longer applies.
+        if (useHelpPanelStore.getState().preferredAgentId !== launchAgentId) {
+          this._hasAutoLaunched = false;
+          return;
+        }
+        this._hasAutoLaunched = false;
+        this._hasBlockedThisSession = true;
+        this._patch({ assistantVersionTooOld: versionBlock });
+        return;
+      }
+      this._hasBlockedThisSession = false;
+      this._patch({ assistantVersionTooOld: null });
+
+      const outcome = await provisionHelpSession(launchProject, launchAgentId);
+      if (gen !== this._launchGen) return;
+      if (!outcome.ok) {
+        this._hasAutoLaunched = false;
+        if (outcome.code === "MCP_NOT_READY") {
+          notifyMcpNotReady(outcome.message);
+        } else {
+          notifyLaunchFailed(launchAgentId, outcome.message);
+        }
+        return;
+      }
+      const session = outcome.session;
+      this._pendingSessionId = session.sessionId;
+      const cwd = session.sessionPath;
+      const env = buildHelpEnv(session, launchProject.id);
+
+      const hibernated = useHelpPanelStore.getState().hibernateSessions[launchProject.id];
+      if (hibernated && hibernated.agentId === launchAgentId) {
+        const resumedId = await this._spawnResumed(launchAgentId, hibernated, session, folderPath);
+        if (gen !== this._launchGen) {
+          if (resumedId) usePanelStore.getState().removePanel(resumedId);
+          return;
+        }
+        if (resumedId) {
+          // Stale-launch guard: handleClose may have revoked the pending
+          // session while addPanel was in flight.
+          const expectedSessionId = session.sessionId;
+          if (this._pendingSessionId !== expectedSessionId) {
+            usePanelStore.getState().removePanel(resumedId);
+            this._hasAutoLaunched = false;
+            return;
+          }
+          useHelpPanelStore.getState().clearHibernateSession(launchProject.id);
+          useHelpPanelStore.getState().setTerminal(resumedId, launchAgentId, session.sessionId);
+          this._pendingSessionId = null;
+          window.electron.help.markTerminal(resumedId).catch((err) => {
+            logError("Failed to mark help terminal", err);
+          });
+          this._patch({ showResumeBanner: true });
+          this._armResumeBannerAutoDismiss();
+          return;
+        }
+        // Resume failed — drop the stale entry so we don't loop, then fall
+        // through to fresh launch using the already-provisioned session.
+        useHelpPanelStore.getState().clearHibernateSession(launchProject.id);
+      }
+
+      const customLaunchFlags = await loadCustomLaunchFlags();
+      if (gen !== this._launchGen) return;
+
+      const result = await actionService.dispatch<{ terminalId: string | null }>(
+        "agent.launch",
+        {
+          agentId: launchAgentId,
+          location: "dock",
+          cwd,
+          ephemeral: true,
+          ...(env && { env }),
+          ...(customLaunchFlags.length > 0 && { agentLaunchFlags: customLaunchFlags }),
+        },
+        { source: "user" }
+      );
+      if (gen !== this._launchGen) {
+        if (result.ok && result.result?.terminalId) {
+          usePanelStore.getState().removePanel(result.result.terminalId);
+        }
+        return;
+      }
+
+      // Stale-launch guard: if the user changed preferredAgentId while the
+      // IPC was in flight, drop the result and clean up the spawned panel
+      // rather than reviving a stale terminal.
+      const currentPreferred = useHelpPanelStore.getState().preferredAgentId;
+      if (currentPreferred !== launchAgentId) {
+        if (result.ok && result.result?.terminalId) {
+          usePanelStore.getState().removePanel(result.result.terminalId);
+        }
+        revokeHelpSession(session?.sessionId ?? null);
+        this._pendingSessionId = null;
+        this._hasAutoLaunched = false;
+        return;
+      }
+
+      if (!result.ok || !result.result?.terminalId) {
+        this._hasAutoLaunched = false;
+        revokeHelpSession(session?.sessionId ?? null);
+        this._pendingSessionId = null;
+        logError("Help auto-launch failed", { agentId: launchAgentId, result });
+        notifyLaunchFailed(launchAgentId, "The agent didn't start. Try again.");
+        return;
+      }
+
+      const expectedSessionId = session?.sessionId ?? null;
+      if (expectedSessionId && this._pendingSessionId !== expectedSessionId) {
+        usePanelStore.getState().removePanel(result.result.terminalId);
+        this._hasAutoLaunched = false;
+        return;
+      }
+
+      useHelpPanelStore
+        .getState()
+        .setTerminal(result.result.terminalId, launchAgentId, session?.sessionId ?? null);
+      this._pendingSessionId = null;
+      window.electron.help.markTerminal(result.result.terminalId).catch((err) => {
+        logError("Failed to mark help terminal", err);
+      });
+    } catch (err) {
+      logError("HelpPanel: auto-launch threw", err);
+      this._hasAutoLaunched = false;
+    }
+  }
+
+  private async _executeLaunch(
+    gen: number,
+    options: HelpLaunchOptions,
+    launchProject: HelpProjectRef,
+    presetEnv: Record<string, string> | undefined
+  ): Promise<void> {
+    const launchAgentId = options.agentId;
+    const reservedId = options.requestedId ?? null;
+    let session: HelpSessionRef | null = null;
+    try {
+      const folderPath = await window.electron.help.getFolderPath();
+      if (gen !== this._launchGen) return;
+
+      // Empty-state launch (no reservedId) treats a null folder as a
+      // hard fail. New-session and run-anyway already have a live
+      // terminal context so the folder path isn't strictly required.
+      if (!reservedId && !folderPath) {
+        if (options.isAutoLaunch) this._hasAutoLaunched = false;
+        notifyLaunchFailed(launchAgentId, "Help folder is not available.");
+        return;
+      }
+
+      // Version gate runs BEFORE provisionHelpSession so we don't mint a
+      // session token we'd immediately discard. Skipped for the
+      // "requestedId" paths (newSession/runAnyway) because those are
+      // triggered from a live terminal where the version was already
+      // accepted on the initial launch.
+      if (!reservedId) {
+        const launchAgentName = getAgentConfig(launchAgentId)?.name ?? launchAgentId;
+        const versionBlock = await checkAssistantVersion(
+          launchAgentId,
+          launchAgentName,
+          this._hasBlockedThisSession
+        );
+        if (gen !== this._launchGen) return;
+        if (versionBlock) {
+          this._hasAutoLaunched = false;
+          this._hasBlockedThisSession = true;
+          this._patch({ assistantVersionTooOld: versionBlock });
+          return;
+        }
+        this._hasBlockedThisSession = false;
+        this._patch({ assistantVersionTooOld: null });
+      }
+
+      const outcome = await provisionHelpSession(launchProject, launchAgentId);
+      if (gen !== this._launchGen) return;
+      if (!outcome.ok) {
+        if (reservedId) {
+          this._pendingNewTerminalId = null;
+          useHelpPanelStore.getState().clearTerminal();
+        } else {
+          this._hasAutoLaunched = false;
+        }
+        if (outcome.code === "MCP_NOT_READY") {
+          notifyMcpNotReady(outcome.message);
+        } else {
+          notifyLaunchFailed(launchAgentId, outcome.message);
+        }
+        return;
+      }
+      session = outcome.session;
+      if (!reservedId) {
+        this._pendingSessionId = session.sessionId;
+      }
+      const cwd = session.sessionPath;
+      const helpEnv = buildHelpEnv(session, launchProject.id);
+      const env: Record<string, string> | undefined =
+        helpEnv || presetEnv ? { ...(presetEnv ?? {}), ...(helpEnv ?? {}) } : undefined;
+
+      // Resume path applies only to the empty-state select-agent flow.
+      // newSession/runAnyway explicitly discard prior sessions.
+      if (!reservedId && !options.seedPrompt) {
+        const hibernated = useHelpPanelStore.getState().hibernateSessions[launchProject.id];
+        if (hibernated && hibernated.agentId === launchAgentId && folderPath) {
+          const resumedId = await this._spawnResumed(
+            launchAgentId,
+            hibernated,
+            session,
+            folderPath
+          );
+          if (gen !== this._launchGen) {
+            if (resumedId) usePanelStore.getState().removePanel(resumedId);
+            return;
+          }
+          if (resumedId) {
+            const expectedSessionId = session.sessionId;
+            if (this._pendingSessionId !== expectedSessionId) {
+              usePanelStore.getState().removePanel(resumedId);
+              return;
+            }
+            useHelpPanelStore.getState().clearHibernateSession(launchProject.id);
+            useHelpPanelStore.getState().setTerminal(resumedId, launchAgentId, session.sessionId);
+            this._pendingSessionId = null;
+            window.electron.help.markTerminal(resumedId).catch((err) => {
+              logError("Failed to mark help terminal", err);
+            });
+            this._patch({ showResumeBanner: true });
+            this._armResumeBannerAutoDismiss();
+            return;
+          }
+          useHelpPanelStore.getState().clearHibernateSession(launchProject.id);
+        }
+      }
+
+      const customLaunchFlags = await loadCustomLaunchFlags();
+      if (gen !== this._launchGen) return;
+
+      const dispatchArgs: Record<string, unknown> = {
+        agentId: launchAgentId,
+        location: "dock",
+        cwd,
+        ephemeral: true,
+      };
+      if (env) dispatchArgs.env = env;
+      if (customLaunchFlags.length > 0) dispatchArgs.agentLaunchFlags = customLaunchFlags;
+      if (options.seedPrompt) dispatchArgs.prompt = options.seedPrompt;
+      if (reservedId) dispatchArgs.requestedId = reservedId;
+      if (options.activateDock) dispatchArgs.activateDockOnCreate = true;
+      if (options.force) dispatchArgs.force = true;
+
+      const result = await actionService.dispatch<{ terminalId: string | null }>(
+        "agent.launch",
+        dispatchArgs,
+        { source: "user" }
+      );
+      if (gen !== this._launchGen) {
+        if (result.ok && result.result?.terminalId) {
+          usePanelStore.getState().removePanel(result.result.terminalId);
+        }
+        return;
+      }
+
+      if (!result.ok || !result.result?.terminalId) {
+        if (reservedId) {
+          this._pendingNewTerminalId = null;
+          useHelpPanelStore.getState().clearTerminal();
+          revokeHelpSession(session?.sessionId ?? null);
+          logError(
+            options.force
+              ? "Help run-anyway returned no terminal id"
+              : "Help new-session returned no terminal id",
+            { agentId: launchAgentId }
+          );
+        } else {
+          this._hasAutoLaunched = false;
+          revokeHelpSession(session?.sessionId ?? null);
+          this._pendingSessionId = null;
+          logError("Help launch failed", { agentId: launchAgentId, result });
+        }
+        notifyLaunchFailed(launchAgentId, "The agent didn't start. Try again.");
+        return;
+      }
+
+      const finalTerminalId = result.result.terminalId;
+      if (reservedId) {
+        this._pendingNewTerminalId = null;
+        useHelpPanelStore
+          .getState()
+          .setTerminal(finalTerminalId, launchAgentId, session?.sessionId ?? null);
+      } else {
+        // Stale-launch guard: handleClose may have revoked the pending
+        // session while dispatch was in-flight. Drop the orphan terminal
+        // rather than binding a panel to a revoked token.
+        const expectedSessionId = session?.sessionId ?? null;
+        if (expectedSessionId && this._pendingSessionId !== expectedSessionId) {
+          usePanelStore.getState().removePanel(finalTerminalId);
+          return;
+        }
+        useHelpPanelStore
+          .getState()
+          .setTerminal(finalTerminalId, launchAgentId, session?.sessionId ?? null);
+        this._pendingSessionId = null;
+      }
+      window.electron.help.markTerminal(finalTerminalId).catch((err) => {
+        logError("Failed to mark help terminal", err);
+      });
+    } catch (error) {
+      if (reservedId) {
+        this._pendingNewTerminalId = null;
+        useHelpPanelStore.getState().clearTerminal();
+        revokeHelpSession(session?.sessionId ?? null);
+        logError(options.force ? "Help run-anyway failed" : "Help new-session failed", error);
+      } else {
+        this._hasAutoLaunched = false;
+        revokeHelpSession(session?.sessionId ?? null);
+        this._pendingSessionId = null;
+        logError("Help select-agent launch failed", error);
+      }
+      notifyLaunchFailed(launchAgentId, "The agent didn't start. Try again.");
+    } finally {
+      this._isLaunching = false;
+    }
+  }
+}

--- a/src/controllers/HelpSessionController.ts
+++ b/src/controllers/HelpSessionController.ts
@@ -218,6 +218,16 @@ function revokeHelpSession(sessionId: string | null): void {
   });
 }
 
+function asStringRecord(value: unknown): Record<string, string> | undefined {
+  if (!value || typeof value !== "object") return undefined;
+  const out: Record<string, string> = {};
+  for (const [k, v] of Object.entries(value)) {
+    if (typeof v !== "string") return undefined;
+    out[k] = v;
+  }
+  return out;
+}
+
 function notifyLaunchFailed(agentId: string, reason: string): void {
   const cfg = getAgentConfig(agentId);
   const name = cfg?.name ?? agentId;
@@ -579,10 +589,7 @@ export class HelpSessionController {
       const previousSessionId = existing.sessionId;
       if (existingTerminalId) {
         const panel = usePanelStore.getState().panelsById[existingTerminalId];
-        const candidate = panel?.extensionState?.presetEnv;
-        if (candidate && typeof candidate === "object") {
-          presetEnv = candidate as Record<string, string>;
-        }
+        presetEnv = asStringRecord(panel?.extensionState?.presetEnv);
         usePanelStore.getState().removePanel(existingTerminalId);
         revokeHelpSession(previousSessionId);
         if (reservedId) this._revokePendingSession();
@@ -701,18 +708,20 @@ export class HelpSessionController {
   // --- internal ---
 
   private _patch(partial: Partial<HelpSessionSnapshot>): void {
-    let changed = false;
-    const next = { ...this._snapshot };
-    for (const key of Object.keys(partial) as Array<keyof HelpSessionSnapshot>) {
-      const value = partial[key];
-      if (value === undefined) continue;
-      if (next[key] !== value) {
-        // eslint-disable-next-line @typescript-eslint/no-explicit-any
-        (next as any)[key] = value;
-        changed = true;
-      }
+    // Spread-merge first, then structurally compare per-field. Reusing the
+    // same snapshot reference when nothing changed keeps Object.is stable
+    // for useSyncExternalStore.
+    const next: HelpSessionSnapshot = { ...this._snapshot, ...partial };
+    if (
+      next.phase === this._snapshot.phase &&
+      next.showResumeBanner === this._snapshot.showResumeBanner &&
+      next.assistantVersionTooOld === this._snapshot.assistantVersionTooOld &&
+      next.tierMismatch === this._snapshot.tierMismatch &&
+      next.preflightSnapshot === this._snapshot.preflightSnapshot &&
+      next.isApprovingTier === this._snapshot.isApprovingTier
+    ) {
+      return;
     }
-    if (!changed) return;
     this._snapshot = Object.freeze(next);
     for (const listener of this._listeners) {
       try {

--- a/src/controllers/HelpSessionController.ts
+++ b/src/controllers/HelpSessionController.ts
@@ -299,7 +299,11 @@ export class HelpSessionController {
   private _snapshotBannerTimer: ReturnType<typeof setTimeout> | null = null;
   private _disposers: Array<() => void> = [];
   private _lastInputs: HelpSessionInputs | null = null;
-  private _hibernateArmedFor: { terminalId: string; agentId: string | null } | null = null;
+  private _hibernateArmedFor: {
+    terminalId: string;
+    agentId: string | null;
+    projectId: string | null;
+  } | null = null;
 
   // Bound for stable references across StrictMode re-subscribe.
   subscribe = (listener: () => void): (() => void) => {
@@ -432,8 +436,12 @@ export class HelpSessionController {
   /**
    * Hide the panel without tearing down. Called from the panel's
    * visibilitychange handler once it has confirmed the OS isn't suspended.
+   * Bumps `_launchGen` so any in-flight `agent.launch` dispatch resolves
+   * into a stale-gen branch and cleans itself up rather than rebinding a
+   * fresh terminal into the now-torn-down view.
    */
   tearDownForViewHidden(): void {
+    this._launchGen++;
     const state = useHelpPanelStore.getState();
     if (state.terminalId) {
       usePanelStore.getState().removePanel(state.terminalId);
@@ -760,6 +768,42 @@ export class HelpSessionController {
     }
   }
 
+  /**
+   * Called from every stale-gen early return inside the async launch flow.
+   * Cleans up the local synchronous reservation (reservedId paths) and
+   * revokes the provisioned session token (provision-succeeded paths)
+   * before the method exits, so neither a phantom `terminalId` nor a
+   * minted-but-orphaned session token survives the abort. Removing a
+   * spawned panel after a stale dispatch is the caller's responsibility
+   * — it has the result in scope.
+   */
+  private _abandonInFlightLaunch(
+    reservedId: string | null,
+    session: HelpSessionRef | null,
+    options: { resetAutoLaunch: boolean }
+  ): void {
+    if (reservedId) {
+      // Clear the reservation only if the store still points at our slot.
+      // Another launch may have already taken over and overwritten it.
+      if (this._pendingNewTerminalId === reservedId) {
+        this._pendingNewTerminalId = null;
+        const help = useHelpPanelStore.getState();
+        if (help.terminalId === reservedId) {
+          help.clearTerminal();
+        }
+      }
+    }
+    if (session) {
+      revokeHelpSession(session.sessionId);
+      if (this._pendingSessionId === session.sessionId) {
+        this._pendingSessionId = null;
+      }
+    }
+    if (options.resetAutoLaunch) {
+      this._hasAutoLaunched = false;
+    }
+  }
+
   private _clearTierMismatchIfStillCurrent(sessionId: string, toolId: string): void {
     const current = this._snapshot.tierMismatch;
     if (current && current.sessionId === sessionId && current.toolId === toolId) {
@@ -783,12 +827,18 @@ export class HelpSessionController {
       return;
     }
     this._clearHibernateTimer();
+    // Capture the project at arm time so a project switch between panel
+    // close and hibernate fire doesn't write project A's session into
+    // project B's slot. The fire path reads this captured value, never
+    // the live currentProject.
     this._hibernateArmedFor = {
       terminalId,
       agentId: useHelpPanelStore.getState().agentId,
+      projectId: useProjectStore.getState().currentProject?.id ?? null,
     };
     const initialTerminalId = terminalId;
     const initialAgentId = this._hibernateArmedFor.agentId;
+    const initialProjectId = this._hibernateArmedFor.projectId;
 
     safeFireAndForget(
       window.electron.helpAssistant
@@ -804,7 +854,7 @@ export class HelpSessionController {
           if (this._hibernateMinutes <= 0) return;
           this._clearHibernateTimer();
           this._hibernateTimer = setTimeout(
-            () => this._fireHibernate(initialTerminalId, initialAgentId),
+            () => this._fireHibernate(initialTerminalId, initialAgentId, initialProjectId),
             this._hibernateMinutes * 60 * 1000
           );
         })
@@ -814,7 +864,7 @@ export class HelpSessionController {
           this._hibernateMinutes = DEFAULT_HIBERNATE_MINUTES;
           this._clearHibernateTimer();
           this._hibernateTimer = setTimeout(
-            () => this._fireHibernate(initialTerminalId, initialAgentId),
+            () => this._fireHibernate(initialTerminalId, initialAgentId, initialProjectId),
             DEFAULT_HIBERNATE_MINUTES * 60 * 1000
           );
         }),
@@ -826,7 +876,11 @@ export class HelpSessionController {
     return this._hibernateArmedFor?.terminalId === terminalId;
   }
 
-  private _fireHibernate(initialTerminalId: string, initialAgentId: string | null): void {
+  private _fireHibernate(
+    initialTerminalId: string,
+    initialAgentId: string | null,
+    initialProjectId: string | null
+  ): void {
     this._hibernateTimer = null;
     if (!this._isStillArmedFor(initialTerminalId)) return;
 
@@ -843,13 +897,17 @@ export class HelpSessionController {
       // Re-check shortly without restarting the full hibernate countdown —
       // the user is presumably about to come back.
       this._hibernateTimer = setTimeout(
-        () => this._fireHibernate(initialTerminalId, initialAgentId),
+        () => this._fireHibernate(initialTerminalId, initialAgentId, initialProjectId),
         HIBERNATE_BUSY_RECHECK_MS
       );
       return;
     }
 
-    const projectId = useProjectStore.getState().currentProject?.id ?? null;
+    // Use the projectId captured at arm time, not the live currentProject.
+    // The user may have switched projects between panel close and timer
+    // fire — writing project A's session into project B's hibernate slot
+    // would resume the wrong conversation on next open.
+    const projectId = initialProjectId;
     const cwd = livePanel.cwd ?? "";
     const sessionToRevoke = helpState.sessionId;
     const liveAgentId = helpState.agentId ?? initialAgentId;
@@ -960,9 +1018,13 @@ export class HelpSessionController {
     launchAgentId: string,
     launchProject: HelpProjectRef
   ): Promise<void> {
+    let session: HelpSessionRef | null = null;
     try {
       const folderPath = await window.electron.help.getFolderPath();
-      if (gen !== this._launchGen) return;
+      if (gen !== this._launchGen) {
+        this._abandonInFlightLaunch(null, session, { resetAutoLaunch: true });
+        return;
+      }
       if (!folderPath) {
         this._hasAutoLaunched = false;
         notifyLaunchFailed(launchAgentId, "Help folder is not available.");
@@ -975,7 +1037,10 @@ export class HelpSessionController {
         launchAgentName,
         this._hasBlockedThisSession
       );
-      if (gen !== this._launchGen) return;
+      if (gen !== this._launchGen) {
+        this._abandonInFlightLaunch(null, session, { resetAutoLaunch: true });
+        return;
+      }
       if (versionBlock) {
         // Stale-agent guard: skip the block if the user changed
         // preferredAgentId while the probe was in flight — the new
@@ -994,7 +1059,11 @@ export class HelpSessionController {
       this._patch({ assistantVersionTooOld: null });
 
       const outcome = await provisionHelpSession(launchProject, launchAgentId);
-      if (gen !== this._launchGen) return;
+      if (gen !== this._launchGen) {
+        if (outcome.ok) session = outcome.session;
+        this._abandonInFlightLaunch(null, session, { resetAutoLaunch: true });
+        return;
+      }
       if (!outcome.ok) {
         this._hasAutoLaunched = false;
         if (outcome.code === "MCP_NOT_READY") {
@@ -1004,7 +1073,7 @@ export class HelpSessionController {
         }
         return;
       }
-      const session = outcome.session;
+      session = outcome.session;
       this._pendingSessionId = session.sessionId;
       const cwd = session.sessionPath;
       const env = buildHelpEnv(session, launchProject.id);
@@ -1014,6 +1083,7 @@ export class HelpSessionController {
         const resumedId = await this._spawnResumed(launchAgentId, hibernated, session, folderPath);
         if (gen !== this._launchGen) {
           if (resumedId) usePanelStore.getState().removePanel(resumedId);
+          this._abandonInFlightLaunch(null, session, { resetAutoLaunch: true });
           return;
         }
         if (resumedId) {
@@ -1041,7 +1111,10 @@ export class HelpSessionController {
       }
 
       const customLaunchFlags = await loadCustomLaunchFlags();
-      if (gen !== this._launchGen) return;
+      if (gen !== this._launchGen) {
+        this._abandonInFlightLaunch(null, session, { resetAutoLaunch: true });
+        return;
+      }
 
       const result = await actionService.dispatch<{ terminalId: string | null }>(
         "agent.launch",
@@ -1059,6 +1132,7 @@ export class HelpSessionController {
         if (result.ok && result.result?.terminalId) {
           usePanelStore.getState().removePanel(result.result.terminalId);
         }
+        this._abandonInFlightLaunch(null, session, { resetAutoLaunch: true });
         return;
       }
 
@@ -1113,10 +1187,14 @@ export class HelpSessionController {
   ): Promise<void> {
     const launchAgentId = options.agentId;
     const reservedId = options.requestedId ?? null;
+    const resetAutoLaunch = options.isAutoLaunch === true;
     let session: HelpSessionRef | null = null;
     try {
       const folderPath = await window.electron.help.getFolderPath();
-      if (gen !== this._launchGen) return;
+      if (gen !== this._launchGen) {
+        this._abandonInFlightLaunch(reservedId, session, { resetAutoLaunch });
+        return;
+      }
 
       // Empty-state launch (no reservedId) treats a null folder as a
       // hard fail. New-session and run-anyway already have a live
@@ -1139,7 +1217,10 @@ export class HelpSessionController {
           launchAgentName,
           this._hasBlockedThisSession
         );
-        if (gen !== this._launchGen) return;
+        if (gen !== this._launchGen) {
+          this._abandonInFlightLaunch(reservedId, session, { resetAutoLaunch });
+          return;
+        }
         if (versionBlock) {
           this._hasAutoLaunched = false;
           this._hasBlockedThisSession = true;
@@ -1151,7 +1232,11 @@ export class HelpSessionController {
       }
 
       const outcome = await provisionHelpSession(launchProject, launchAgentId);
-      if (gen !== this._launchGen) return;
+      if (gen !== this._launchGen) {
+        if (outcome.ok) session = outcome.session;
+        this._abandonInFlightLaunch(reservedId, session, { resetAutoLaunch });
+        return;
+      }
       if (!outcome.ok) {
         if (reservedId) {
           this._pendingNewTerminalId = null;
@@ -1188,6 +1273,7 @@ export class HelpSessionController {
           );
           if (gen !== this._launchGen) {
             if (resumedId) usePanelStore.getState().removePanel(resumedId);
+            this._abandonInFlightLaunch(reservedId, session, { resetAutoLaunch });
             return;
           }
           if (resumedId) {
@@ -1211,7 +1297,10 @@ export class HelpSessionController {
       }
 
       const customLaunchFlags = await loadCustomLaunchFlags();
-      if (gen !== this._launchGen) return;
+      if (gen !== this._launchGen) {
+        this._abandonInFlightLaunch(reservedId, session, { resetAutoLaunch });
+        return;
+      }
 
       const dispatchArgs: Record<string, unknown> = {
         agentId: launchAgentId,
@@ -1235,6 +1324,7 @@ export class HelpSessionController {
         if (result.ok && result.result?.terminalId) {
           usePanelStore.getState().removePanel(result.result.terminalId);
         }
+        this._abandonInFlightLaunch(reservedId, session, { resetAutoLaunch });
         return;
       }
 

--- a/src/controllers/__tests__/HelpSessionController.test.ts
+++ b/src/controllers/__tests__/HelpSessionController.test.ts
@@ -1,0 +1,371 @@
+// @vitest-environment jsdom
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+
+const {
+  mockMcpOnTierNotPermitted,
+  mockMcpSetSessionTier,
+  mockSystemSleepOnSuspend,
+  mockSystemSleepOnWake,
+  systemSleepListeners,
+  tierListeners,
+  helpPanelState,
+  panelStoreState,
+  projectStoreState,
+} = vi.hoisted(() => ({
+  mockMcpOnTierNotPermitted: vi.fn(),
+  mockMcpSetSessionTier: vi.fn().mockResolvedValue(undefined),
+  mockSystemSleepOnSuspend: vi.fn(),
+  mockSystemSleepOnWake: vi.fn(),
+  systemSleepListeners: {
+    suspend: [] as Array<() => void>,
+    wake: [] as Array<() => void>,
+  },
+  tierListeners: [] as Array<(payload: unknown) => void>,
+  helpPanelState: {
+    isOpen: false,
+    terminalId: null as string | null,
+    agentId: null as string | null,
+    preferredAgentId: null as string | null,
+    sessionId: null as string | null,
+    hibernateSessions: {} as Record<string, unknown>,
+    setTerminal: vi.fn(),
+    clearTerminal: vi.fn(),
+    setHibernateSession: vi.fn(),
+    clearHibernateSession: vi.fn(),
+  },
+  panelStoreState: {
+    panelIds: [] as string[],
+    panelsById: {} as Record<string, unknown>,
+    removePanel: vi.fn(),
+    addPanel: vi.fn().mockResolvedValue(""),
+  },
+  projectStoreState: {
+    currentProject: null as { id: string; path: string } | null,
+  },
+}));
+
+vi.mock("@/config/agents", () => ({
+  getAgentConfig: (id: string) =>
+    ({ claude: { name: "Claude", assistantMinVersion: "1.0.0" } })[id],
+}));
+
+vi.mock("@/services/ActionService", () => ({
+  actionService: { dispatch: vi.fn() },
+}));
+
+vi.mock("@/store/helpPanelStore", () => {
+  const store = (selector?: (s: typeof helpPanelState) => unknown) =>
+    selector ? selector(helpPanelState) : helpPanelState;
+  store.getState = () => helpPanelState;
+  return { useHelpPanelStore: store };
+});
+
+vi.mock("@/store", () => {
+  const panelStore = (selector?: (s: typeof panelStoreState) => unknown) =>
+    selector ? selector(panelStoreState) : panelStoreState;
+  panelStore.getState = () => panelStoreState;
+
+  const projectStore = (selector?: (s: typeof projectStoreState) => unknown) =>
+    selector ? selector(projectStoreState) : projectStoreState;
+  projectStore.getState = () => projectStoreState;
+
+  return { usePanelStore: panelStore, useProjectStore: projectStore };
+});
+
+vi.mock("@/clients/projectClient", () => ({
+  projectClient: {
+    getSettings: vi.fn().mockResolvedValue({}),
+    saveSettings: vi.fn().mockResolvedValue(undefined),
+  },
+}));
+
+vi.mock("@/lib/notify", () => ({ notify: vi.fn() }));
+vi.mock("@/utils/logger", () => ({ logError: vi.fn() }));
+vi.mock("@/utils/safeFireAndForget", () => ({
+  safeFireAndForget: (p: Promise<unknown>) => p,
+}));
+
+import { HelpSessionController } from "../HelpSessionController";
+
+function resetState() {
+  helpPanelState.isOpen = false;
+  helpPanelState.terminalId = null;
+  helpPanelState.agentId = null;
+  helpPanelState.preferredAgentId = null;
+  helpPanelState.sessionId = null;
+  helpPanelState.hibernateSessions = {};
+  helpPanelState.setTerminal = vi.fn();
+  helpPanelState.clearTerminal = vi.fn();
+  helpPanelState.setHibernateSession = vi.fn();
+  helpPanelState.clearHibernateSession = vi.fn();
+  panelStoreState.panelIds = [];
+  panelStoreState.panelsById = {};
+  panelStoreState.removePanel = vi.fn();
+  panelStoreState.addPanel = vi.fn().mockResolvedValue("");
+  projectStoreState.currentProject = null;
+}
+
+beforeEach(() => {
+  vi.clearAllMocks();
+  resetState();
+  systemSleepListeners.suspend.length = 0;
+  systemSleepListeners.wake.length = 0;
+  tierListeners.length = 0;
+
+  mockMcpOnTierNotPermitted.mockReset();
+  mockMcpOnTierNotPermitted.mockImplementation((cb: (payload: unknown) => void) => {
+    tierListeners.push(cb);
+    return () => {
+      const idx = tierListeners.indexOf(cb);
+      if (idx >= 0) tierListeners.splice(idx, 1);
+    };
+  });
+  mockMcpSetSessionTier.mockReset();
+  mockMcpSetSessionTier.mockResolvedValue(undefined);
+  mockSystemSleepOnSuspend.mockReset();
+  mockSystemSleepOnSuspend.mockImplementation((cb: () => void) => {
+    systemSleepListeners.suspend.push(cb);
+    return () => {
+      const idx = systemSleepListeners.suspend.indexOf(cb);
+      if (idx >= 0) systemSleepListeners.suspend.splice(idx, 1);
+    };
+  });
+  mockSystemSleepOnWake.mockReset();
+  mockSystemSleepOnWake.mockImplementation((cb: () => void) => {
+    systemSleepListeners.wake.push(cb);
+    return () => {
+      const idx = systemSleepListeners.wake.indexOf(cb);
+      if (idx >= 0) systemSleepListeners.wake.splice(idx, 1);
+    };
+  });
+
+  Object.defineProperty(globalThis, "window", {
+    value: {
+      electron: {
+        help: {
+          getFolderPath: vi.fn().mockResolvedValue("/help"),
+          markTerminal: vi.fn().mockResolvedValue(undefined),
+          provisionSession: vi.fn().mockResolvedValue(null),
+          revokeSession: vi.fn().mockResolvedValue(undefined),
+        },
+        helpAssistant: {
+          getSettings: vi.fn().mockResolvedValue({ idleHibernateMinutes: 30 }),
+        },
+        system: {
+          getAgentVersion: vi
+            .fn()
+            .mockResolvedValue({ installedVersion: null, latestVersion: null }),
+        },
+        systemSleep: {
+          getMetrics: vi.fn().mockResolvedValue({ isCurrentlySleeping: false }),
+          onSuspend: mockSystemSleepOnSuspend,
+          onWake: mockSystemSleepOnWake,
+        },
+        mcpServer: {
+          onTierNotPermitted: mockMcpOnTierNotPermitted,
+          setSessionTier: mockMcpSetSessionTier,
+        },
+        git: { snapshotGet: vi.fn().mockResolvedValue(null) },
+        terminal: { gracefulKill: vi.fn().mockResolvedValue(null) },
+      },
+    },
+    writable: true,
+    configurable: true,
+  });
+});
+
+afterEach(() => {
+  // Defensive: any test that didn't stop its controller would leak listeners.
+});
+
+describe("HelpSessionController — lifecycle", () => {
+  it("start() arms tier-mismatch and system-sleep subscriptions", () => {
+    const ctrl = new HelpSessionController();
+    ctrl.start();
+    expect(mockMcpOnTierNotPermitted).toHaveBeenCalledTimes(1);
+    expect(mockSystemSleepOnSuspend).toHaveBeenCalledTimes(1);
+    expect(mockSystemSleepOnWake).toHaveBeenCalledTimes(1);
+    ctrl.stop();
+  });
+
+  it("start() is idempotent across StrictMode double-mount (no duplicate listeners)", () => {
+    const ctrl = new HelpSessionController();
+    ctrl.start();
+    ctrl.start();
+    ctrl.start();
+    expect(mockMcpOnTierNotPermitted).toHaveBeenCalledTimes(1);
+    expect(mockSystemSleepOnSuspend).toHaveBeenCalledTimes(1);
+    ctrl.stop();
+  });
+
+  it("stop() unsubscribes every disposer registered by start()", () => {
+    const ctrl = new HelpSessionController();
+    ctrl.start();
+    expect(tierListeners).toHaveLength(1);
+    expect(systemSleepListeners.suspend).toHaveLength(1);
+    expect(systemSleepListeners.wake).toHaveLength(1);
+    ctrl.stop();
+    expect(tierListeners).toHaveLength(0);
+    expect(systemSleepListeners.suspend).toHaveLength(0);
+    expect(systemSleepListeners.wake).toHaveLength(0);
+  });
+
+  it("stop() is safe to call when start() has not run", () => {
+    const ctrl = new HelpSessionController();
+    expect(() => ctrl.stop()).not.toThrow();
+  });
+});
+
+describe("HelpSessionController — subscribe / getSnapshot", () => {
+  it("snapshot is initially in the idle state with no banners", () => {
+    const ctrl = new HelpSessionController();
+    const snap = ctrl.getSnapshot();
+    expect(snap.phase).toBe("idle");
+    expect(snap.showResumeBanner).toBe(false);
+    expect(snap.assistantVersionTooOld).toBeNull();
+    expect(snap.tierMismatch).toBeNull();
+    expect(snap.preflightSnapshot).toBeNull();
+    expect(snap.isApprovingTier).toBe(false);
+  });
+
+  it("returns the same snapshot reference when no state changes (Object.is stable)", () => {
+    const ctrl = new HelpSessionController();
+    const a = ctrl.getSnapshot();
+    const b = ctrl.getSnapshot();
+    expect(a).toBe(b);
+  });
+
+  it("notifies listeners when state changes via patch", () => {
+    const ctrl = new HelpSessionController();
+    ctrl.start();
+    const listener = vi.fn();
+    const unsubscribe = ctrl.subscribe(listener);
+
+    // Simulate a tier-mismatch event firing
+    const fire = tierListeners[0];
+    fire({ sessionId: "s1", toolId: "t1", tier: "workbench", targetTier: "action" });
+    expect(listener).toHaveBeenCalled();
+    expect(ctrl.getSnapshot().tierMismatch).toEqual({
+      sessionId: "s1",
+      toolId: "t1",
+      tier: "workbench",
+      targetTier: "action",
+      projectId: null,
+    });
+
+    listener.mockClear();
+    ctrl.dismissTierMismatch();
+    expect(listener).toHaveBeenCalled();
+    expect(ctrl.getSnapshot().tierMismatch).toBeNull();
+
+    unsubscribe();
+    ctrl.stop();
+  });
+
+  it("subscribe returns a stable unsubscribe function that removes only that listener", () => {
+    const ctrl = new HelpSessionController();
+    const a = vi.fn();
+    const b = vi.fn();
+    const unsubA = ctrl.subscribe(a);
+    ctrl.subscribe(b);
+    unsubA();
+    ctrl.dismissTierMismatch(); // currently null → no notify
+    ctrl["_patch"]({ showResumeBanner: true });
+    expect(a).not.toHaveBeenCalled();
+    expect(b).toHaveBeenCalled();
+  });
+});
+
+describe("HelpSessionController — syncInputs", () => {
+  it("clears the version block when preferredAgentId changes", () => {
+    const ctrl = new HelpSessionController();
+    ctrl.start();
+    ctrl["_patch"]({
+      assistantVersionTooOld: {
+        agentId: "claude",
+        agentName: "Claude",
+        installedVersion: "0.9.0",
+        requiredVersion: "1.0.0",
+      },
+    });
+    expect(ctrl.getSnapshot().assistantVersionTooOld).not.toBeNull();
+
+    ctrl.syncInputs({
+      isOpen: false,
+      isReadyToLaunch: false,
+      currentProject: null,
+      terminalId: null,
+      preferredAgentId: "claude",
+      supportedInstalledAgentIds: [],
+      visibilityEpoch: 0,
+    });
+    expect(ctrl.getSnapshot().assistantVersionTooOld).not.toBeNull();
+
+    ctrl.syncInputs({
+      isOpen: false,
+      isReadyToLaunch: false,
+      currentProject: null,
+      terminalId: null,
+      preferredAgentId: "codex",
+      supportedInstalledAgentIds: [],
+      visibilityEpoch: 0,
+    });
+    expect(ctrl.getSnapshot().assistantVersionTooOld).toBeNull();
+    ctrl.stop();
+  });
+});
+
+describe("HelpSessionController — tier-mismatch handlers", () => {
+  it("approveTierOnce() calls setSessionTier and clears banner on success", async () => {
+    const ctrl = new HelpSessionController();
+    ctrl.start();
+    tierListeners[0]?.({
+      sessionId: "s1",
+      toolId: "t1",
+      tier: "workbench",
+      targetTier: "action",
+    });
+    expect(ctrl.getSnapshot().tierMismatch).not.toBeNull();
+
+    ctrl.approveTierOnce();
+    expect(ctrl.getSnapshot().isApprovingTier).toBe(true);
+    expect(mockMcpSetSessionTier).toHaveBeenCalledWith("s1", "action");
+
+    await vi.waitFor(() => {
+      expect(ctrl.getSnapshot().isApprovingTier).toBe(false);
+      expect(ctrl.getSnapshot().tierMismatch).toBeNull();
+    });
+    ctrl.stop();
+  });
+
+  it("approveTierOnce() is a no-op while another approval is in flight", () => {
+    const ctrl = new HelpSessionController();
+    ctrl.start();
+    tierListeners[0]?.({
+      sessionId: "s1",
+      toolId: "t1",
+      tier: "workbench",
+      targetTier: "action",
+    });
+    ctrl.approveTierOnce();
+    const callsBefore = mockMcpSetSessionTier.mock.calls.length;
+    ctrl.approveTierOnce();
+    expect(mockMcpSetSessionTier.mock.calls.length).toBe(callsBefore);
+    ctrl.stop();
+  });
+
+  it("dismissTierMismatch() clears the banner immediately", () => {
+    const ctrl = new HelpSessionController();
+    ctrl.start();
+    tierListeners[0]?.({
+      sessionId: "s1",
+      toolId: "t1",
+      tier: "workbench",
+      targetTier: null,
+    });
+    expect(ctrl.getSnapshot().tierMismatch).not.toBeNull();
+    ctrl.dismissTierMismatch();
+    expect(ctrl.getSnapshot().tierMismatch).toBeNull();
+    ctrl.stop();
+  });
+});

--- a/src/controllers/__tests__/HelpSessionController.test.ts
+++ b/src/controllers/__tests__/HelpSessionController.test.ts
@@ -242,7 +242,7 @@ describe("HelpSessionController — subscribe / getSnapshot", () => {
     const unsubscribe = ctrl.subscribe(listener);
 
     // Simulate a tier-mismatch event firing
-    const fire = tierListeners[0];
+    const fire = tierListeners[0]!;
     fire({ sessionId: "s1", toolId: "t1", tier: "workbench", targetTier: "action" });
     expect(listener).toHaveBeenCalled();
     expect(ctrl.getSnapshot().tierMismatch).toEqual({

--- a/src/controllers/index.ts
+++ b/src/controllers/index.ts
@@ -1,13 +1,2 @@
 export { terminalRegistryController } from "./TerminalRegistryController";
 export type { SpawnTerminalOptions, SpawnTerminalResult } from "./TerminalRegistryController";
-
-export { HelpSessionController } from "./HelpSessionController";
-export type {
-  HelpSessionSnapshot,
-  HelpSessionPhase,
-  HelpSessionInputs,
-  HelpLaunchOptions,
-  HelpProjectRef,
-  TierMismatchState,
-  VersionTooOld,
-} from "./HelpSessionController";

--- a/src/controllers/index.ts
+++ b/src/controllers/index.ts
@@ -1,2 +1,13 @@
 export { terminalRegistryController } from "./TerminalRegistryController";
 export type { SpawnTerminalOptions, SpawnTerminalResult } from "./TerminalRegistryController";
+
+export { HelpSessionController } from "./HelpSessionController";
+export type {
+  HelpSessionSnapshot,
+  HelpSessionPhase,
+  HelpSessionInputs,
+  HelpLaunchOptions,
+  HelpProjectRef,
+  TierMismatchState,
+  VersionTooOld,
+} from "./HelpSessionController";


### PR DESCRIPTION
## Summary

- `HelpPanel.tsx` was at 1980 LOC with nine `useRef` race-guard sentinels scattered across a single React component. The session lifecycle — auto-launch, version probe, MCP provision, resume-or-fresh, hibernate, `gracefulKill`, revoke — now lives in `HelpSessionController`, a proper renderer-side class in the same shape as `TerminalRegistryController` and the `Terminal*Controller` siblings.
- The panel subscribes to the controller via `useSyncExternalStore`. Three near-duplicate launch handlers (`handleSelectAgent`, `doNewSession`, `handleRunAnyway`) collapsed into one shared helper. JSX split into `HelpPanelBanners`, `HelpPanelHeader`, and `HelpPanelVersionGate`.
- Tests retargeted to the controller class, which cuts most of the `vi.mock` soup. Lint warning count drops by 2 from the baseline.

Resolves #7681

## Changes

- `src/controllers/HelpSessionController.ts` — new controller class; owns race-guard fields, launch sequence, hibernate timer, version probe, tier-mismatch subscription, snapshot pre-flight, and `phase` enum (`idle | version-checking | provisioning | launching | live | hibernating`)
- `src/components/HelpPanel/HelpPanel.tsx` — slimmed from ~1980 LOC to a thin render layer subscribing to the controller
- `src/components/HelpPanel/HelpPanelBanners.tsx` — extracted banner JSX
- `src/components/HelpPanel/HelpPanelHeader.tsx` — extracted header JSX
- `src/components/HelpPanel/HelpPanelVersionGate.tsx` — extracted version-gate JSX
- `src/controllers/__tests__/HelpSessionController.test.ts` — controller-targeted test suite
- `src/controllers/index.ts` — barrel export

## Testing

- Existing regression coverage for #7201 (stale auto-launch reset) and #6951 (new-session dock-leak race) migrated and passing
- Controller is idempotent across StrictMode double-mount (mirrors the existing `hasTakenPreflightSnapshotRef === terminalId` guard)
- Resource leak fix verified: stale-generation bail paths now consistently revoke provisioned sessions before returning