### PR TITLE
refactor(workspace-host): move resource-action coordination into ResourceActionExecutor

### DIFF
--- a/electron/workspace-host/ResourceActionExecutor.ts
+++ b/electron/workspace-host/ResourceActionExecutor.ts
@@ -1,5 +1,6 @@
 import { mkdir, writeFile } from "fs/promises";
 import { join as pathJoin } from "path";
+import PQueue from "p-queue";
 import type { WorkspaceHostEvent } from "../../shared/types/workspace-host.js";
 import type { WorktreeResourceStatus } from "../../shared/types/worktree.js";
 import { WorktreeMonitor } from "./WorktreeMonitor.js";
@@ -36,14 +37,16 @@ export interface ResourceActionContext {
 }
 
 /**
- * Encapsulates resource-action execution (`provision` / `teardown` /
- * `resume` / `pause` / `status`).
- *
- * The owning `WorkspaceService` retains the per-worktree `PQueue` and
- * `AbortController` Maps (an existing test inspects them via bracket
- * notation) and only delegates the execution body to this class.
+ * Encapsulates resource-action coordination and execution (`provision` /
+ * `teardown` / `resume` / `pause` / `status`). Owns the per-worktree
+ * `PQueue` and `AbortController` Maps so queue lifecycle is co-located
+ * with the execution body.
  */
 export class ResourceActionExecutor {
+  private resourceActionQueues = new Map<string, PQueue>();
+  private resourceActionAbortControllers = new Map<string, AbortController>();
+  private disposed = false;
+
   constructor(private readonly ctx: ResourceActionContext) {}
 
   async execute(
@@ -373,6 +376,98 @@ export class ResourceActionExecutor {
       error: result.error,
     });
     return { success: result.success, output: result.output, error: result.error };
+  }
+
+  private getResourceActionQueue(worktreeId: string): PQueue {
+    let queue = this.resourceActionQueues.get(worktreeId);
+    if (!queue) {
+      queue = new PQueue({ concurrency: 1 });
+      this.resourceActionQueues.set(worktreeId, queue);
+    }
+    return queue;
+  }
+
+  private getResourceActionAbortController(worktreeId: string): AbortController {
+    let controller = this.resourceActionAbortControllers.get(worktreeId);
+    if (!controller) {
+      controller = new AbortController();
+      this.resourceActionAbortControllers.set(worktreeId, controller);
+    }
+    return controller;
+  }
+
+  cleanupResourceActionState(worktreeId: string): void {
+    const controller = this.resourceActionAbortControllers.get(worktreeId);
+    if (controller) {
+      controller.abort();
+      this.resourceActionAbortControllers.delete(worktreeId);
+    }
+    const queue = this.resourceActionQueues.get(worktreeId);
+    if (queue) {
+      queue.clear();
+      this.resourceActionQueues.delete(worktreeId);
+    }
+  }
+
+  async runResourceAction(
+    requestId: string,
+    worktreeId: string,
+    action: "provision" | "teardown" | "resume" | "pause" | "status",
+    environmentId?: string,
+    options?: { origin?: "auto-poll" }
+  ): Promise<{ success: boolean; error?: string; output?: string }> {
+    if (this.disposed) {
+      return { success: false, error: "Aborted" };
+    }
+
+    const monitor = this.ctx.getMonitor(worktreeId);
+    if (!monitor) {
+      this.ctx.sendEvent({
+        type: "resource-action-result",
+        requestId,
+        success: false,
+        error: "Worktree not found",
+      });
+      return { success: false, error: "Worktree not found" };
+    }
+
+    if (!this.ctx.getProjectRootPath()) {
+      this.ctx.sendEvent({
+        type: "resource-action-result",
+        requestId,
+        success: false,
+        error: "No project root path",
+      });
+      return { success: false, error: "No project root path" };
+    }
+
+    const queue = this.getResourceActionQueue(worktreeId);
+
+    if (options?.origin === "auto-poll" && (queue.pending > 0 || queue.size > 0)) {
+      return { success: true };
+    }
+
+    const controller = this.getResourceActionAbortController(worktreeId);
+
+    const queued = await queue
+      .add(() => this.execute(requestId, worktreeId, action, environmentId, controller.signal), {
+        signal: controller.signal,
+      })
+      .catch(() => undefined);
+
+    return queued ?? { success: false, error: "Aborted" };
+  }
+
+  dispose(): void {
+    if (this.disposed) return;
+    this.disposed = true;
+    const keys = new Set([
+      ...this.resourceActionAbortControllers.keys(),
+      ...this.resourceActionQueues.keys(),
+    ]);
+    for (const key of keys) {
+      this.cleanupResourceActionState(key);
+    }
   }
 }
 

--- a/electron/workspace-host/ResourceActionExecutor.ts
+++ b/electron/workspace-host/ResourceActionExecutor.ts
@@ -56,6 +56,8 @@ export class ResourceActionExecutor {
     environmentId: string | undefined,
     signal: AbortSignal
   ): Promise<{ success: boolean; error?: string; output?: string }> {
+    if (this.disposed) return { success: false, error: "Aborted" };
+
     const monitor = this.ctx.getMonitor(worktreeId);
     const projectRootPath = this.ctx.getProjectRootPath();
     if (!monitor || !projectRootPath) {
@@ -218,7 +220,7 @@ export class ResourceActionExecutor {
       try {
         const parsed = JSON.parse(result.output);
         statusMonitor.setResourceStatus({
-          lastStatus: parsed.status ?? "unhealthy",
+          lastStatus: typeof parsed.status === "string" ? parsed.status : "unhealthy",
           lastOutput: result.output,
           lastCheckedAt: Date.now(),
           endpoint: typeof parsed.endpoint === "string" ? parsed.endpoint : undefined,

--- a/electron/workspace-host/WorkspaceService.ts
+++ b/electron/workspace-host/WorkspaceService.ts
@@ -91,9 +91,7 @@ export class WorkspaceService {
   private prService: PRIntegrationService;
   private fetchCoordinator: RepoFetchCoordinator;
   private _shutdownController = new AbortController();
-  private resourceActionQueues = new Map<string, PQueue>();
-  private resourceActionAbortControllers = new Map<string, AbortController>();
-  private readonly resourceActionExecutor: ResourceActionExecutor;
+  readonly resourceActionExecutor: ResourceActionExecutor;
   /** Session-scoped guard so we notify the user about Linux inotify limits
    *  only once, even if many worktrees hit ENOSPC concurrently. */
   private inotifyLimitNotified = false;
@@ -325,7 +323,7 @@ export class WorkspaceService {
           this.activeWorktreeId = null;
         }
 
-        this.cleanupResourceActionState(id);
+        this.resourceActionExecutor.cleanupResourceActionState(id);
         monitor.stop();
         this.monitors.delete(id);
         clearGitDirCache(monitor.path);
@@ -751,7 +749,7 @@ export class WorkspaceService {
       this.activeWorktreeId = null;
     }
 
-    this.cleanupResourceActionState(worktreeId);
+    this.resourceActionExecutor.cleanupResourceActionState(worktreeId);
     monitor.stop();
     this.monitors.delete(worktreeId);
 
@@ -1318,7 +1316,7 @@ export class WorkspaceService {
       // Clean up the monitor immediately after worktree removal succeeds,
       // before attempting branch deletion — so the monitor doesn't linger
       // if branch deletion fails.
-      this.cleanupResourceActionState(worktreeId);
+      this.resourceActionExecutor.cleanupResourceActionState(worktreeId);
       monitor.stop();
       this.monitors.delete(worktreeId);
 
@@ -1763,37 +1761,6 @@ ${lines.map((l) => "+" + l).join("\n")}`;
     });
   }
 
-  private getResourceActionQueue(worktreeId: string): PQueue {
-    let queue = this.resourceActionQueues.get(worktreeId);
-    if (!queue) {
-      queue = new PQueue({ concurrency: 1 });
-      this.resourceActionQueues.set(worktreeId, queue);
-    }
-    return queue;
-  }
-
-  private getResourceActionAbortController(worktreeId: string): AbortController {
-    let controller = this.resourceActionAbortControllers.get(worktreeId);
-    if (!controller) {
-      controller = new AbortController();
-      this.resourceActionAbortControllers.set(worktreeId, controller);
-    }
-    return controller;
-  }
-
-  private cleanupResourceActionState(worktreeId: string): void {
-    const controller = this.resourceActionAbortControllers.get(worktreeId);
-    if (controller) {
-      controller.abort();
-      this.resourceActionAbortControllers.delete(worktreeId);
-    }
-    const queue = this.resourceActionQueues.get(worktreeId);
-    if (queue) {
-      queue.clear();
-      this.resourceActionQueues.delete(worktreeId);
-    }
-  }
-
   async runResourceAction(
     requestId: string,
     worktreeId: string,
@@ -1801,66 +1768,12 @@ ${lines.map((l) => "+" + l).join("\n")}`;
     environmentId?: string,
     options?: { origin?: "auto-poll" }
   ): Promise<{ success: boolean; error?: string; output?: string }> {
-    const monitor = this.monitors.get(worktreeId);
-    if (!monitor) {
-      this.sendEvent({
-        type: "resource-action-result",
-        requestId,
-        success: false,
-        error: "Worktree not found",
-      });
-      return { success: false, error: "Worktree not found" };
-    }
-
-    if (!this.projectRootPath) {
-      this.sendEvent({
-        type: "resource-action-result",
-        requestId,
-        success: false,
-        error: "No project root path",
-      });
-      return { success: false, error: "No project root path" };
-    }
-
-    const queue = this.getResourceActionQueue(worktreeId);
-
-    // Auto-poll: skip if any resource action is already in-flight or queued
-    if (options?.origin === "auto-poll" && (queue.pending > 0 || queue.size > 0)) {
-      return { success: true };
-    }
-
-    const controller = this.getResourceActionAbortController(worktreeId);
-
-    const queued = await queue
-      .add(
-        () =>
-          this._executeResourceAction(
-            requestId,
-            worktreeId,
-            action,
-            environmentId,
-            controller.signal
-          ),
-        { signal: controller.signal }
-      )
-      .catch(() => undefined);
-
-    return queued ?? { success: false, error: "Aborted" };
-  }
-
-  private _executeResourceAction(
-    requestId: string,
-    worktreeId: string,
-    action: "provision" | "teardown" | "resume" | "pause" | "status",
-    environmentId: string | undefined,
-    signal: AbortSignal
-  ): Promise<{ success: boolean; error?: string; output?: string }> {
-    return this.resourceActionExecutor.execute(
+    return this.resourceActionExecutor.runResourceAction(
       requestId,
       worktreeId,
       action,
       environmentId,
-      signal
+      options
     );
   }
 
@@ -1900,9 +1813,7 @@ ${lines.map((l) => "+" + l).join("\n")}`;
   dispose(): void {
     this._shutdownController.abort();
     this.prService.cleanup();
-    for (const id of this.monitors.keys()) {
-      this.cleanupResourceActionState(id);
-    }
+    this.resourceActionExecutor.dispose();
     for (const monitor of this.monitors.values()) {
       monitor.stop();
     }

--- a/electron/workspace-host/WorkspaceService.ts
+++ b/electron/workspace-host/WorkspaceService.ts
@@ -1698,6 +1698,9 @@ ${lines.map((l) => "+" + l).join("\n")}`;
   async onProjectSwitch(requestId: string): Promise<void> {
     this.prService.cleanup();
 
+    for (const id of this.monitors.keys()) {
+      this.resourceActionExecutor.cleanupResourceActionState(id);
+    }
     for (const monitor of this.monitors.values()) {
       monitor.stop();
     }

--- a/electron/workspace-host/__tests__/WorkspaceService.resource.test.ts
+++ b/electron/workspace-host/__tests__/WorkspaceService.resource.test.ts
@@ -1612,14 +1612,18 @@ describe("WorkspaceService.runResourceAction — concurrency", () => {
     await new Promise((r) => setTimeout(r, 20));
 
     // Simulate worktree removal — triggers cleanupResourceActionState
-    service["cleanupResourceActionState"]("/test/worktree");
+    service.resourceActionExecutor["cleanupResourceActionState"]("/test/worktree");
 
     deferred.resolveChild();
     await actionPromise;
 
     // Queue and controller should be cleaned up
-    expect(service["resourceActionQueues"].has("/test/worktree")).toBe(false);
-    expect(service["resourceActionAbortControllers"].has("/test/worktree")).toBe(false);
+    expect(service.resourceActionExecutor["resourceActionQueues"].has("/test/worktree")).toBe(
+      false
+    );
+    expect(
+      service.resourceActionExecutor["resourceActionAbortControllers"].has("/test/worktree")
+    ).toBe(false);
   });
 });
 


### PR DESCRIPTION
## Summary

This PR moves the resource-action coordination out of `WorkspaceService` and into `ResourceActionExecutor`, so the executor is fully self-contained. The executor already ran the action body -- but the queue maps, abort controllers, and `runResourceAction` / `cleanupResourceActionState` calls lived one layer up. Now the executor owns its own coordination state and logic.

Resolves #7690

## Changes

- `ResourceActionExecutor` now owns the per-worktree `PQueue` and `AbortController` maps, `runResourceAction`, `cleanupResourceActionState`, and a new `dispose` method
- `WorkspaceService` delegates to `this.resourceActionExecutor` for cleanup and execution -- it no longer carries its own coordination maps or methods
- `onProjectSwitch` now cleans up resource action state per worktree before stopping monitors
- Tests updated to access the coordination state through `service.resourceActionExecutor`

## Testing

Existing resource action tests pass. Concurrency and cleanup tests updated to reference the new location of the queue and controller maps.