### PR TITLE
feat(toolbar): unify toolbar customization with the agent tray

### DIFF
--- a/shared/types/toolbar.ts
+++ b/shared/types/toolbar.ts
@@ -29,14 +29,34 @@ export type ToolbarButtonId =
   | "assistant-toggle"
   | "portal-toggle";
 
+/**
+ * Sparse pin-state map for toolbar buttons. Mirrors the tri-state semantics
+ * used by `agentSettingsStore.agents[id].pinned`:
+ *
+ *   - `false`      → user explicitly hid this button
+ *   - `true`       → user explicitly pinned this button (currently unused for
+ *                    non-agent buttons since defaults are visible, reserved
+ *                    for future "pin-as-universal" extensions)
+ *   - `undefined`  → follow default visibility (visible)
+ *
+ * Agent-button IDs (entries in `BUILT_IN_AGENT_IDS`) live in
+ * `agentSettingsStore`, not here. Only `agent-tray`, the non-agent built-ins,
+ * and plugin buttons are governed by this map.
+ */
+export type ToolbarPinnedState = Partial<Record<AnyToolbarButtonId, boolean>>;
+
 /** Configuration for which toolbar buttons are visible and their order */
 export interface ToolbarLayout {
   /** Ordered list of button IDs to show on the left side (excluding sidebar-toggle which is always first) */
   leftButtons: AnyToolbarButtonId[];
   /** Ordered list of button IDs to show on the right side (excluding assistant-toggle and portal-toggle which are always last) */
   rightButtons: AnyToolbarButtonId[];
-  /** Button IDs that are hidden from the toolbar. Ordering is preserved in leftButtons/rightButtons. */
-  hiddenButtons: AnyToolbarButtonId[];
+  /**
+   * Per-button visibility overrides. `false` hides the button; missing
+   * entries fall through to the default. Ordering stays in
+   * `leftButtons`/`rightButtons`.
+   */
+  pinnedButtons: ToolbarPinnedState;
 }
 
 /** Launcher palette default behaviors */

--- a/src/components/Layout/Toolbar.tsx
+++ b/src/components/Layout/Toolbar.tsx
@@ -2,9 +2,6 @@ import { useRef, useState, useEffect, useLayoutEffect, useMemo, useCallback } fr
 import type React from "react";
 import { Button } from "@/components/ui/button";
 import {
-  SlidersHorizontal,
-  SquareTerminal,
-  AlertCircle,
   GitCommit,
   GitPullRequest,
   CircleDot,
@@ -12,15 +9,13 @@ import {
   PanelLeftClose,
   Check,
   ChevronsUpDown,
-  Globe,
   MonitorPlay,
-  Bell,
   Ellipsis,
   GitBranch,
-  Plug,
 } from "lucide-react";
 import { Spinner } from "@/components/ui/Spinner";
 import { Folders, McpServerIcon } from "@/components/icons";
+import { TOOLBAR_BUTTON_METADATA, isToolbarButtonVisible } from "./toolbarButtonMetadata";
 import { cn } from "@/lib/utils";
 import { shortcutHintStore } from "@/store/shortcutHintStore";
 import { isMac, isLinux } from "@/lib/platform";
@@ -65,8 +60,7 @@ import { ToolbarPortalButton } from "./ToolbarPortalButton";
 import { ToolbarAssistantButton } from "./ToolbarAssistantButton";
 import { useOverflowBadgeSeverity, type OverflowBadgeSeverity } from "./useOverflowBadgeSeverity";
 
-import { BUILT_IN_AGENT_IDS, type BuiltInAgentId } from "@shared/config/agentIds";
-import { getAgentConfig } from "@/config/agents";
+import { BUILT_IN_AGENT_IDS } from "@shared/config/agentIds";
 
 const AGENT_TOOLBAR_IDS = new Set<ToolbarButtonId>([
   "agent-tray",
@@ -74,6 +68,11 @@ const AGENT_TOOLBAR_IDS = new Set<ToolbarButtonId>([
 ]);
 
 type OverflowMenuMeta = { label: string; icon: React.ComponentType<{ className?: string }> };
+
+// voice-recording has no actionable overflow item — it's a persistent
+// indicator that only appears while recording is already active. Surface the
+// label via tooltip text only; suppress from the dropdown list itself.
+const OVERFLOW_DROPDOWN_SKIP = new Set<AnyToolbarButtonId>(["voice-recording"]);
 
 const toolbarIconButtonClass = "toolbar-icon-button text-daintree-text relative";
 // These controls are project-only visually, but their no-drag rectangles must
@@ -136,23 +135,15 @@ export function PluginToolbarButton({
   );
 }
 
-export const OVERFLOW_MENU_META: Partial<Record<AnyToolbarButtonId, OverflowMenuMeta>> = {
-  ...(Object.fromEntries(
-    BUILT_IN_AGENT_IDS.map((id) => [
-      id,
-      { label: getAgentConfig(id)?.name ?? id, icon: SquareTerminal },
-    ])
-  ) as unknown as Record<BuiltInAgentId, OverflowMenuMeta>),
-  "agent-tray": { label: "Agent Tray", icon: Plug },
-  terminal: { label: "Terminal", icon: SquareTerminal },
-  browser: { label: "Browser", icon: Globe },
-  "dev-server": { label: "Dev Preview", icon: MonitorPlay },
-  "github-stats": { label: "GitHub Stats", icon: GitPullRequest },
-  "notification-center": { label: "Notifications", icon: Bell },
-  "copy-tree": { label: "Copy Context", icon: Folders },
-  settings: { label: "Settings", icon: SlidersHorizontal },
-  problems: { label: "Problems", icon: AlertCircle },
-};
+// Adapter view over the unified `TOOLBAR_BUTTON_METADATA` registry. Skips
+// entries that should never render as overflow menu items (see
+// `OVERFLOW_DROPDOWN_SKIP`) — those are still surfaced in tooltip text.
+export const OVERFLOW_MENU_META: Partial<Record<AnyToolbarButtonId, OverflowMenuMeta>> =
+  Object.fromEntries(
+    Object.entries(TOOLBAR_BUTTON_METADATA)
+      .filter(([id]) => !OVERFLOW_DROPDOWN_SKIP.has(id as AnyToolbarButtonId))
+      .map(([id, meta]) => [id, { label: meta!.label, icon: meta!.icon }])
+  ) as Partial<Record<AnyToolbarButtonId, OverflowMenuMeta>>;
 
 interface ToolbarProps {
   onLaunchAgent: (type: string) => void;
@@ -652,21 +643,29 @@ export function Toolbar({
     ]
   );
 
-  const hiddenSet = useMemo(
-    () => new Set(toolbarLayout.hiddenButtons),
-    [toolbarLayout.hiddenButtons]
-  );
+  const pinnedButtons = toolbarLayout.pinnedButtons;
 
   const effectiveLeftButtons = useMemo(
-    () => toolbarLayout.leftButtons.filter((id) => !hiddenSet.has(id)),
-    [toolbarLayout.leftButtons, hiddenSet]
+    () =>
+      toolbarLayout.leftButtons.filter((id) =>
+        isToolbarButtonVisible(id, pinnedButtons, effectiveAgentSettings, agentAvailability)
+      ),
+    [toolbarLayout.leftButtons, pinnedButtons, effectiveAgentSettings, agentAvailability]
   );
 
   const effectiveRightButtons = useMemo(() => {
     const existing = new Set(toolbarLayout.rightButtons);
     const extra = pluginButtonIds.filter((id) => !existing.has(id));
-    return [...toolbarLayout.rightButtons, ...extra].filter((id) => !hiddenSet.has(id));
-  }, [toolbarLayout.rightButtons, pluginButtonIds, hiddenSet]);
+    return [...toolbarLayout.rightButtons, ...extra].filter((id) =>
+      isToolbarButtonVisible(id, pinnedButtons, effectiveAgentSettings, agentAvailability)
+    );
+  }, [
+    toolbarLayout.rightButtons,
+    pluginButtonIds,
+    pinnedButtons,
+    effectiveAgentSettings,
+    agentAvailability,
+  ]);
 
   const availableLeftIds = useMemo(
     () =>

--- a/src/components/Layout/Toolbar.tsx
+++ b/src/components/Layout/Toolbar.tsx
@@ -72,12 +72,17 @@ type OverflowMenuMeta = { label: string; icon: React.ComponentType<{ className?:
 // voice-recording has no actionable overflow item — it's a persistent
 // indicator that only appears while recording is already active. Surface the
 // label via tooltip text only; suppress from the dropdown list itself.
-const OVERFLOW_DROPDOWN_SKIP = new Set<AnyToolbarButtonId>(["voice-recording"]);
+const OVERFLOW_DROPDOWN_SKIP: ReadonlySet<string> = new Set(["voice-recording"]);
 
 const toolbarIconButtonClass = "toolbar-icon-button text-daintree-text relative";
 // These controls are project-only visually, but their no-drag rectangles must
 // exist on first paint so secondary windows don't cache them as titlebar drag.
 const PROJECT_SCOPED_TOOLBAR_IDS = new Set<AnyToolbarButtonId>(["dev-server", "github-stats"]);
+
+// How long the copy-tree button shows the green "context copied" feedback
+// before reverting to its idle state. Long enough to register the success,
+// short enough that re-clicks don't feel stuck.
+const COPY_TREE_FEEDBACK_RESET_MS = 2000;
 
 function GitHubStatsPlaceholder() {
   return (
@@ -138,12 +143,13 @@ export function PluginToolbarButton({
 // Adapter view over the unified `TOOLBAR_BUTTON_METADATA` registry. Skips
 // entries that should never render as overflow menu items (see
 // `OVERFLOW_DROPDOWN_SKIP`) — those are still surfaced in tooltip text.
+const overflowMenuMetaInit: Record<string, OverflowMenuMeta> = {};
+for (const [id, meta] of Object.entries(TOOLBAR_BUTTON_METADATA)) {
+  if (!meta || OVERFLOW_DROPDOWN_SKIP.has(id)) continue;
+  overflowMenuMetaInit[id] = { label: meta.label, icon: meta.icon };
+}
 export const OVERFLOW_MENU_META: Partial<Record<AnyToolbarButtonId, OverflowMenuMeta>> =
-  Object.fromEntries(
-    Object.entries(TOOLBAR_BUTTON_METADATA)
-      .filter(([id]) => !OVERFLOW_DROPDOWN_SKIP.has(id as AnyToolbarButtonId))
-      .map(([id, meta]) => [id, { label: meta!.label, icon: meta!.icon }])
-  ) as Partial<Record<AnyToolbarButtonId, OverflowMenuMeta>>;
+  overflowMenuMetaInit;
 
 interface ToolbarProps {
   onLaunchAgent: (type: string) => void;
@@ -308,7 +314,7 @@ export function Toolbar({
           setTreeCopied(false);
           setCopyFeedback("");
           treeCopyTimeoutRef.current = null;
-        }, 2000);
+        }, COPY_TREE_FEEDBACK_RESET_MS);
       }
     } finally {
       setIsCopyingTree(false);

--- a/src/components/Layout/__tests__/toolbarButtonMetadata.test.ts
+++ b/src/components/Layout/__tests__/toolbarButtonMetadata.test.ts
@@ -1,0 +1,104 @@
+// @vitest-environment jsdom
+import { describe, it, expect } from "vitest";
+import { BUILT_IN_AGENT_IDS } from "@shared/config/agentIds";
+import { TOOLBAR_BUTTON_METADATA, isToolbarButtonVisible } from "../toolbarButtonMetadata";
+import type { AnyToolbarButtonId } from "@shared/types/toolbar";
+
+// IDs that intentionally have no entry in TOOLBAR_BUTTON_METADATA. The fixed
+// titlebar buttons (sidebar-toggle, assistant-toggle, portal-toggle) are
+// rendered directly, never appear in the Settings list, and never enter the
+// overflow dropdown — so omitting metadata for them is deliberate.
+const FIXED_TITLEBAR_IDS = new Set<AnyToolbarButtonId>([
+  "sidebar-toggle",
+  "assistant-toggle",
+  "portal-toggle",
+]);
+
+const CUSTOMIZABLE_BUTTON_IDS: AnyToolbarButtonId[] = [
+  "agent-tray",
+  ...(BUILT_IN_AGENT_IDS as readonly string[] as AnyToolbarButtonId[]),
+  "terminal",
+  "browser",
+  "dev-server",
+  "voice-recording",
+  "github-stats",
+  "notification-center",
+  "copy-tree",
+  "settings",
+  "problems",
+];
+
+describe("TOOLBAR_BUTTON_METADATA — registry coverage", () => {
+  it("has an entry for every customizable built-in button", () => {
+    for (const id of CUSTOMIZABLE_BUTTON_IDS) {
+      expect(TOOLBAR_BUTTON_METADATA[id], `missing metadata for "${id}"`).toBeDefined();
+    }
+  });
+
+  it("does not register entries for fixed titlebar buttons", () => {
+    // Including them would leak titlebar controls into the Settings drag list.
+    for (const id of FIXED_TITLEBAR_IDS) {
+      expect(TOOLBAR_BUTTON_METADATA[id], `unexpected metadata for fixed "${id}"`).toBeUndefined();
+    }
+  });
+
+  it("populates label, icon, and description for every entry", () => {
+    for (const [id, meta] of Object.entries(TOOLBAR_BUTTON_METADATA)) {
+      expect(meta?.label, `empty label for "${id}"`).toBeTruthy();
+      expect(meta?.icon, `missing icon for "${id}"`).toBeDefined();
+      expect(meta?.description, `empty description for "${id}"`).toBeTruthy();
+    }
+  });
+
+  it("uses the canonical agent display name for built-in agent labels", () => {
+    // Drift guard for the original issue (#7668): the agent-tray icon and
+    // labels must come from the same source the AgentButton renders so the
+    // Settings list and the overflow dropdown stay in sync.
+    for (const id of BUILT_IN_AGENT_IDS) {
+      const meta = TOOLBAR_BUTTON_METADATA[id as AnyToolbarButtonId];
+      expect(meta?.label, `agent "${id}" missing label`).toMatch(/Agent$/);
+    }
+  });
+});
+
+describe("isToolbarButtonVisible", () => {
+  it("hides a non-agent button when pinnedButtons[id] is false", () => {
+    expect(isToolbarButtonVisible("terminal", { terminal: false }, null, undefined)).toBe(false);
+  });
+
+  it("shows a non-agent button when pinnedButtons[id] is undefined", () => {
+    expect(isToolbarButtonVisible("terminal", {}, null, undefined)).toBe(true);
+  });
+
+  it("shows a non-agent button when pinnedButtons[id] is explicitly true", () => {
+    expect(isToolbarButtonVisible("terminal", { terminal: true }, null, undefined)).toBe(true);
+  });
+
+  it("routes agent IDs to isAgentToolbarVisible (pinned:true wins regardless of pinnedButtons)", () => {
+    // Even though pinnedButtons.claude is false (which would hide a non-agent
+    // button), agent visibility comes from agentSettingsStore. claude:pinned
+    // wins.
+    const visible = isToolbarButtonVisible(
+      "claude" as AnyToolbarButtonId,
+      { claude: false } as Record<AnyToolbarButtonId, boolean>,
+      { agents: { claude: { pinned: true } } } as never,
+      undefined
+    );
+    expect(visible).toBe(true);
+  });
+
+  it("routes agent IDs to isAgentToolbarVisible (pinned:false hides regardless of pinnedButtons)", () => {
+    const visible = isToolbarButtonVisible(
+      "claude" as AnyToolbarButtonId,
+      { claude: true } as Record<AnyToolbarButtonId, boolean>,
+      { agents: { claude: { pinned: false } } } as never,
+      undefined
+    );
+    expect(visible).toBe(false);
+  });
+
+  it("treats plugin buttons as visible by default", () => {
+    const pluginId = "plugin.test.example" as AnyToolbarButtonId;
+    expect(isToolbarButtonVisible(pluginId, {}, null, undefined)).toBe(true);
+  });
+});

--- a/src/components/Layout/toolbarButtonMetadata.ts
+++ b/src/components/Layout/toolbarButtonMetadata.ts
@@ -1,0 +1,126 @@
+import type { ComponentType } from "react";
+import {
+  AlertCircle,
+  Bell,
+  GitPullRequest,
+  Globe,
+  Mic,
+  MonitorPlay,
+  Plug,
+  SlidersHorizontal,
+  SquareTerminal,
+} from "lucide-react";
+import { Folders } from "@/components/icons";
+import { BUILT_IN_AGENT_IDS } from "@shared/config/agentIds";
+import type { AnyToolbarButtonId, ToolbarPinnedState } from "@/../../shared/types/toolbar";
+import type { AgentSettings, CliAvailability } from "@shared/types";
+import { isAgentToolbarVisible } from "../../../shared/utils/agentPinned";
+import { getAgentConfig } from "@/config/agents";
+
+export interface ToolbarButtonIconProps {
+  className?: string;
+}
+
+export interface ToolbarButtonMetadata {
+  label: string;
+  icon: ComponentType<ToolbarButtonIconProps>;
+  description: string;
+}
+
+const AGENT_ID_SET = new Set<string>(BUILT_IN_AGENT_IDS);
+
+// Built-in agent entries are derived from the canonical agent registry so the
+// icon shown in Settings, the agent tray, and the overflow dropdown all
+// resolve from the same source (#7666 / #7668).
+const AGENT_METADATA: Partial<Record<AnyToolbarButtonId, ToolbarButtonMetadata>> =
+  Object.fromEntries(
+    BUILT_IN_AGENT_IDS.map((id) => {
+      const cfg = getAgentConfig(id);
+      const name = cfg?.name ?? id;
+      const Icon: ComponentType<ToolbarButtonIconProps> = cfg?.icon ?? SquareTerminal;
+      return [
+        id,
+        {
+          label: `${name} Agent`,
+          icon: Icon,
+          description: `Launch ${name} AI agent`,
+        },
+      ];
+    })
+  ) as Partial<Record<AnyToolbarButtonId, ToolbarButtonMetadata>>;
+
+export const TOOLBAR_BUTTON_METADATA: Partial<Record<AnyToolbarButtonId, ToolbarButtonMetadata>> = {
+  "agent-tray": {
+    label: "Agent Tray",
+    icon: Plug,
+    description: "Dropdown for launching any agent and jumping into setup",
+  },
+  ...AGENT_METADATA,
+  terminal: {
+    label: "Terminal",
+    icon: SquareTerminal,
+    description: "Open new terminal",
+  },
+  browser: {
+    label: "Browser",
+    icon: Globe,
+    description: "Open browser panel",
+  },
+  "dev-server": {
+    label: "Dev Preview",
+    icon: MonitorPlay,
+    description: "Open dev preview panel",
+  },
+  "voice-recording": {
+    label: "Voice recording",
+    icon: Mic,
+    description: "Persistent dictation indicator shown while recording is active",
+  },
+  "github-stats": {
+    label: "GitHub Stats",
+    icon: GitPullRequest,
+    description: "GitHub issues, PRs, and commits",
+  },
+  "notification-center": {
+    label: "Notifications",
+    icon: Bell,
+    description: "Notification history dropdown",
+  },
+  "copy-tree": {
+    label: "Copy Context",
+    icon: Folders,
+    description: "Copy project context to clipboard",
+  },
+  settings: {
+    label: "Settings",
+    icon: SlidersHorizontal,
+    description: "Open settings dialog",
+  },
+  problems: {
+    label: "Problems",
+    icon: AlertCircle,
+    description: "Show problems panel",
+  },
+};
+
+/**
+ * Canonical visibility resolver for toolbar buttons. Both `Toolbar.tsx` and
+ * `ToolbarSettingsTab.tsx` consume this so they can never disagree about
+ * whether a button should appear (#7666).
+ *
+ * Agent IDs (entries in `BUILT_IN_AGENT_IDS`) route to `isAgentToolbarVisible`
+ * — their pin lives in `agentSettingsStore`. Every other ID, including
+ * `agent-tray` and plugin buttons, reads from the toolbar store's
+ * `pinnedButtons` map: an explicit `false` hides; missing or `true` shows.
+ */
+export function isToolbarButtonVisible(
+  buttonId: AnyToolbarButtonId,
+  pinnedButtons: ToolbarPinnedState,
+  agentSettings: AgentSettings | null | undefined,
+  agentAvailability: CliAvailability | null | undefined
+): boolean {
+  if (AGENT_ID_SET.has(buttonId)) {
+    return isAgentToolbarVisible(agentSettings?.agents?.[buttonId], agentAvailability?.[buttonId]);
+  }
+  return pinnedButtons[buttonId] !== false;
+}

--- a/src/components/Settings/ToolbarSettingsTab.tsx
+++ b/src/components/Settings/ToolbarSettingsTab.tsx
@@ -15,29 +15,18 @@ import {
   verticalListSortingStrategy,
 } from "@dnd-kit/sortable";
 import { CSS } from "@dnd-kit/utilities";
-import {
-  GripVertical,
-  SquareTerminal,
-  Globe,
-  MonitorPlay,
-  AlertTriangle,
-  Settings,
-  AlertCircle,
-  Bell,
-  Mic,
-  LayoutGrid,
-  Rocket,
-  RotateCcw,
-  Puzzle,
-} from "lucide-react";
-import { Folders } from "@/components/icons";
+import { GripVertical, LayoutGrid, Rocket, RotateCcw } from "lucide-react";
 import { useToolbarPreferencesStore } from "@/store";
 import { useAgentSettingsStore } from "@/store/agentSettingsStore";
 import { useCliAvailabilityStore } from "@/store/cliAvailabilityStore";
 import type { AnyToolbarButtonId } from "@/../../shared/types/toolbar";
-import type { AgentSettings, CliAvailability } from "@shared/types";
 import { BUILT_IN_AGENT_IDS } from "@shared/config/agentIds";
 import { isAgentToolbarVisible } from "../../../shared/utils/agentPinned";
+import {
+  TOOLBAR_BUTTON_METADATA,
+  isToolbarButtonVisible,
+  type ToolbarButtonMetadata,
+} from "@/components/Layout/toolbarButtonMetadata";
 import { getAgentConfig } from "@/config/agents";
 import { usePluginToolbarButtons } from "@/hooks/usePluginToolbarButtons";
 import { McpServerIcon } from "@/components/icons";
@@ -45,100 +34,18 @@ import { cn } from "@/lib/utils";
 import { SettingsSection } from "./SettingsSection";
 import { SettingsSwitchCard } from "./SettingsSwitchCard";
 
-type ButtonMetadata = { label: string; icon: React.ReactNode; description: string };
-
-// Agent-ID writes and reads for visibility go through `agentSettingsStore`
-// (the authoritative IPC-persisted store). `toolbarPreferencesStore.hiddenButtons`
-// is the source of truth only for non-agent buttons. A `version: 5` migration
-// strips stale agent IDs from persisted `hiddenButtons` so they can't shadow
-// the canonical pinned state.
+// Agent-ID writes for visibility route to `agentSettingsStore` (the
+// authoritative IPC-persisted store). Non-agent buttons (including
+// `agent-tray` and plugin buttons) live in `toolbarPreferencesStore`'s
+// `pinnedButtons` map. A version: 5 migration strips stale agent IDs from
+// pre-unification state so they can't shadow the canonical pinned state.
 const AGENT_ID_SET = new Set<string>(BUILT_IN_AGENT_IDS);
-
-function isEffectivelyVisible(
-  buttonId: AnyToolbarButtonId,
-  hiddenButtons: string[],
-  agentSettings: AgentSettings | null,
-  agentAvailability: CliAvailability | null | undefined
-): boolean {
-  if (AGENT_ID_SET.has(buttonId)) {
-    return isAgentToolbarVisible(agentSettings?.agents?.[buttonId], agentAvailability?.[buttonId]);
-  }
-  return !hiddenButtons.includes(buttonId);
-}
-
-const BUTTON_METADATA: Partial<Record<AnyToolbarButtonId, ButtonMetadata>> = {
-  "agent-tray": {
-    label: "Agent Tray",
-    icon: <Puzzle className="h-4 w-4" />,
-    description: "Dropdown for launching any agent and jumping into setup",
-  },
-  ...Object.fromEntries(
-    BUILT_IN_AGENT_IDS.map((id) => {
-      const cfg = getAgentConfig(id);
-      const Icon = cfg?.icon;
-      const name = cfg?.name ?? id;
-      return [
-        id,
-        {
-          label: `${name} Agent`,
-          icon: Icon ? <Icon className="h-4 w-4" /> : <SquareTerminal className="h-4 w-4" />,
-          description: `Launch ${name} AI agent`,
-        },
-      ];
-    })
-  ),
-  terminal: {
-    label: "Terminal",
-    icon: <SquareTerminal className="h-4 w-4" />,
-    description: "Open new terminal",
-  },
-  browser: {
-    label: "Browser",
-    icon: <Globe className="h-4 w-4" />,
-    description: "Open browser panel",
-  },
-  "dev-server": {
-    label: "Dev Preview",
-    icon: <MonitorPlay className="h-4 w-4" />,
-    description: "Open dev preview panel",
-  },
-  "voice-recording": {
-    label: "Voice Recording",
-    icon: <Mic className="h-4 w-4" />,
-    description: "Persistent dictation indicator shown while recording is active",
-  },
-  "github-stats": {
-    label: "GitHub Stats",
-    icon: <AlertTriangle className="h-4 w-4" />,
-    description: "GitHub issues, PRs, and commits",
-  },
-  "notification-center": {
-    label: "Notifications",
-    icon: <Bell className="h-4 w-4" />,
-    description: "Notification history dropdown",
-  },
-  "copy-tree": {
-    label: "Copy Context",
-    icon: <Folders className="h-4 w-4" />,
-    description: "Copy project context to clipboard",
-  },
-  settings: {
-    label: "Settings",
-    icon: <Settings className="h-4 w-4" />,
-    description: "Open settings dialog",
-  },
-  problems: {
-    label: "Problems",
-    icon: <AlertCircle className="h-4 w-4" />,
-    description: "Show problems panel",
-  },
-};
 
 interface SortableButtonItemProps {
   buttonId: AnyToolbarButtonId;
   isVisible: boolean;
   onToggle: (buttonId: AnyToolbarButtonId) => void;
-  allMetadata: Partial<Record<AnyToolbarButtonId, ButtonMetadata>>;
+  allMetadata: Partial<Record<AnyToolbarButtonId, ToolbarButtonMetadata>>;
 }
 
 function SortableButtonItem({
@@ -160,6 +67,7 @@ function SortableButtonItem({
   };
 
   if (!metadata) return null;
+  const Icon = metadata.icon;
 
   return (
     <div
@@ -176,7 +84,9 @@ function SortableButtonItem({
         />
       </div>
       <div className="flex items-center gap-2 flex-1">
-        <div className="text-daintree-text">{metadata.icon}</div>
+        <div className="text-daintree-text">
+          <Icon className="h-4 w-4" />
+        </div>
         <div className="flex-1">
           <div className="text-sm font-medium text-daintree-text">{metadata.label}</div>
           <div className="text-xs text-daintree-text/50 select-text">{metadata.description}</div>
@@ -217,18 +127,18 @@ export function ToolbarSettingsTab() {
   const { buttonIds: pluginButtonIds, configs: pluginConfigs } = usePluginToolbarButtons();
 
   const allMetadata = useMemo(() => {
-    const pluginMeta: Record<string, ButtonMetadata> = {};
+    const pluginMeta: Record<string, ToolbarButtonMetadata> = {};
     for (const id of pluginButtonIds) {
       const config = pluginConfigs.get(id);
       if (config) {
         pluginMeta[id] = {
           label: config.label,
-          icon: <McpServerIcon className="h-4 w-4" />,
+          icon: McpServerIcon,
           description: `Plugin button (${config.pluginId})`,
         };
       }
     }
-    return { ...BUTTON_METADATA, ...pluginMeta };
+    return { ...TOOLBAR_BUTTON_METADATA, ...pluginMeta };
   }, [pluginButtonIds, pluginConfigs]);
 
   const handleLeftDragEnd = (event: DragEndEvent) => {
@@ -295,7 +205,7 @@ export function ToolbarSettingsTab() {
       <SettingsSection
         icon={LayoutGrid}
         title="Left Side Buttons"
-        description={`Drag to reorder, uncheck to hide. ${layout.leftButtons.filter((id) => isEffectivelyVisible(id, layout.hiddenButtons, agentSettings, agentAvailability)).length} of ${layout.leftButtons.length} visible.`}
+        description={`Drag to reorder, uncheck to hide. ${layout.leftButtons.filter((id) => isToolbarButtonVisible(id, layout.pinnedButtons, agentSettings, agentAvailability)).length} of ${layout.leftButtons.length} visible.`}
       >
         <DndContext
           sensors={sensors}
@@ -308,9 +218,9 @@ export function ToolbarSettingsTab() {
                 <SortableButtonItem
                   key={buttonId}
                   buttonId={buttonId}
-                  isVisible={isEffectivelyVisible(
+                  isVisible={isToolbarButtonVisible(
                     buttonId,
-                    layout.hiddenButtons,
+                    layout.pinnedButtons,
                     agentSettings,
                     agentAvailability
                   )}
@@ -326,7 +236,7 @@ export function ToolbarSettingsTab() {
       <SettingsSection
         icon={LayoutGrid}
         title="Right Side Buttons"
-        description={`Drag to reorder, uncheck to hide. ${layout.rightButtons.filter((id) => isEffectivelyVisible(id, layout.hiddenButtons, agentSettings, agentAvailability)).length} of ${layout.rightButtons.length} visible.`}
+        description={`Drag to reorder, uncheck to hide. ${layout.rightButtons.filter((id) => isToolbarButtonVisible(id, layout.pinnedButtons, agentSettings, agentAvailability)).length} of ${layout.rightButtons.length} visible.`}
       >
         <DndContext
           sensors={sensors}
@@ -339,9 +249,9 @@ export function ToolbarSettingsTab() {
                 <SortableButtonItem
                   key={buttonId}
                   buttonId={buttonId}
-                  isVisible={isEffectivelyVisible(
+                  isVisible={isToolbarButtonVisible(
                     buttonId,
-                    layout.hiddenButtons,
+                    layout.pinnedButtons,
                     agentSettings,
                     agentAvailability
                   )}

--- a/src/components/Settings/__tests__/ToolbarSettingsTab.test.tsx
+++ b/src/components/Settings/__tests__/ToolbarSettingsTab.test.tsx
@@ -223,6 +223,17 @@ describe("ToolbarSettingsTab — agent visibility routing", () => {
     expect(setAgentPinnedMock).not.toHaveBeenCalled();
   });
 
+  it("dispatches `'right'` as the side argument for right-side non-agent toggles", () => {
+    // Locks the side argument so future side-aware store changes can't
+    // silently swallow the right-side branch — both handlers (left, right)
+    // are nominally identical today but each is independently wired.
+    const { getByLabelText } = render(<ToolbarSettingsTab />);
+    fireEvent.click(getByLabelText("Toggle Copy Context visibility"));
+
+    expect(toggleButtonVisibilityMock).toHaveBeenCalledTimes(1);
+    expect(toggleButtonVisibilityMock).toHaveBeenCalledWith("copy-tree", "right");
+  });
+
   it("reflects pinned agents in the section visible-count summary", () => {
     mockAgentSettings = agentSettings({
       claude: { pinned: true },

--- a/src/components/Settings/__tests__/ToolbarSettingsTab.test.tsx
+++ b/src/components/Settings/__tests__/ToolbarSettingsTab.test.tsx
@@ -15,7 +15,7 @@ interface ToolbarState {
   layout: {
     leftButtons: string[];
     rightButtons: string[];
-    hiddenButtons: string[];
+    pinnedButtons: Record<string, boolean>;
   };
   launcher: {
     alwaysShowDevServer: boolean;
@@ -30,7 +30,7 @@ interface ToolbarState {
 }
 
 let mockToolbarState: ToolbarState = {
-  layout: { leftButtons: [], rightButtons: [], hiddenButtons: [] },
+  layout: { leftButtons: [], rightButtons: [], pinnedButtons: {} },
   launcher: { alwaysShowDevServer: false, defaultSelection: undefined },
   setLeftButtons: setLeftButtonsMock,
   setRightButtons: setRightButtonsMock,
@@ -148,7 +148,7 @@ describe("ToolbarSettingsTab — agent visibility routing", () => {
         // Mix of agent IDs and non-agent IDs so we can test both branches.
         leftButtons: ["agent-tray", "claude", "gemini", "terminal"],
         rightButtons: ["copy-tree", "settings"],
-        hiddenButtons: [],
+        pinnedButtons: {},
       },
       launcher: { alwaysShowDevServer: false, defaultSelection: undefined },
       setLeftButtons: setLeftButtonsMock,
@@ -175,11 +175,11 @@ describe("ToolbarSettingsTab — agent visibility routing", () => {
     expect(geminiCheckbox.checked).toBe(false);
   });
 
-  it("ignores hiddenButtons for agent IDs (agentSettingsStore wins)", () => {
+  it("ignores pinnedButtons for agent IDs (agentSettingsStore wins)", () => {
     // Stale entry from pre-migration persisted state — the UI must still
     // derive the agent's visibility from `agentSettingsStore`, not from
-    // `hiddenButtons`.
-    mockToolbarState.layout.hiddenButtons = ["claude"];
+    // `pinnedButtons`.
+    mockToolbarState.layout.pinnedButtons = { claude: false };
     mockAgentSettings = agentSettings({
       claude: { pinned: true },
     });
@@ -249,7 +249,7 @@ describe("ToolbarSettingsTab — agent visibility routing", () => {
     mockToolbarState.layout = {
       leftButtons: ["agent-tray", "terminal"],
       rightButtons: ["codex", "settings"],
-      hiddenButtons: [],
+      pinnedButtons: {},
     };
     mockAgentSettings = agentSettings({
       codex: { pinned: true },

--- a/src/components/__tests__/agentPinSync.integration.test.tsx
+++ b/src/components/__tests__/agentPinSync.integration.test.tsx
@@ -152,7 +152,7 @@ vi.mock("@/components/ui/button", () => ({
 let sharedToolbarLayout = {
   leftButtons: ["agent-tray", "claude", "gemini", "codex", "terminal"] as string[],
   rightButtons: ["settings"] as string[],
-  hiddenButtons: [] as string[],
+  pinnedButtons: {} as Record<string, boolean>,
 };
 const sharedToolbarLauncher = { alwaysShowDevServer: false, defaultSelection: undefined };
 
@@ -243,7 +243,7 @@ describe("agent pin sync — Settings > Toolbar and Agent Tray share state (#511
     sharedToolbarLayout = {
       leftButtons: ["agent-tray", "claude", "gemini", "codex", "terminal"],
       rightButtons: ["settings"],
-      hiddenButtons: [],
+      pinnedButtons: {},
     };
   });
 
@@ -309,7 +309,7 @@ describe("agent pin sync — Settings > Toolbar and Agent Tray share state (#511
     expect(geminiCheckboxB.checked).toBe(true);
   });
 
-  it("Settings checkbox toggles for agent IDs never touch toolbarPreferencesStore.hiddenButtons", () => {
+  it("Settings checkbox toggles for agent IDs never touch toolbarPreferencesStore.pinnedButtons", () => {
     const settings = render(<ToolbarSettingsTab />);
     fireEvent.click(settings.getByLabelText("Toggle Claude Agent visibility"));
     fireEvent.click(settings.getByLabelText("Toggle Terminal visibility"));
@@ -318,7 +318,7 @@ describe("agent pin sync — Settings > Toolbar and Agent Tray share state (#511
     expect(setAgentPinnedMock).toHaveBeenCalledWith("claude", false);
     expect(toggleButtonVisibilityMock).toHaveBeenCalledTimes(1);
     expect(toggleButtonVisibilityMock).toHaveBeenCalledWith("terminal", "left");
-    // Agent toggles never write hiddenButtons.
+    // Agent toggles never write pinnedButtons.
     expect(toggleButtonVisibilityMock).not.toHaveBeenCalledWith("claude", expect.anything());
   });
 });

--- a/src/store/__tests__/toolbarPreferencesStore.test.ts
+++ b/src/store/__tests__/toolbarPreferencesStore.test.ts
@@ -76,27 +76,27 @@ describe("toolbarPreferencesStore", () => {
   });
 
   describe("toggleButtonVisibility", () => {
-    it("adds button to hiddenButtons without removing from ordering array", async () => {
+    it("hides button via pinnedButtons map without removing from ordering array", async () => {
       const store = await loadStore();
       const { layout } = store.getState();
       expect(layout.rightButtons).toContain("copy-tree");
-      expect(layout.hiddenButtons).not.toContain("copy-tree");
+      expect(layout.pinnedButtons["copy-tree"]).toBeUndefined();
 
       store.getState().toggleButtonVisibility("copy-tree", "right");
 
       const updated = store.getState();
-      expect(updated.layout.hiddenButtons).toContain("copy-tree");
+      expect(updated.layout.pinnedButtons["copy-tree"]).toBe(false);
       expect(updated.layout.rightButtons).toContain("copy-tree");
     });
 
-    it("removes button from hiddenButtons when toggled again", async () => {
+    it("removes button from pinnedButtons when toggled again", async () => {
       const store = await loadStore();
 
       store.getState().toggleButtonVisibility("copy-tree", "right");
-      expect(store.getState().layout.hiddenButtons).toContain("copy-tree");
+      expect(store.getState().layout.pinnedButtons["copy-tree"]).toBe(false);
 
       store.getState().toggleButtonVisibility("copy-tree", "right");
-      expect(store.getState().layout.hiddenButtons).not.toContain("copy-tree");
+      expect(store.getState().layout.pinnedButtons["copy-tree"]).toBeUndefined();
     });
 
     it("does not modify leftButtons or rightButtons arrays", async () => {
@@ -114,31 +114,31 @@ describe("toolbarPreferencesStore", () => {
     });
   });
 
-  describe("moveButton preserves hiddenButtons", () => {
-    it("does not lose hiddenButtons when reordering", async () => {
+  describe("moveButton preserves pinnedButtons", () => {
+    it("does not lose pinnedButtons when reordering", async () => {
       const store = await loadStore();
       store.getState().toggleButtonVisibility("copy-tree", "right");
-      expect(store.getState().layout.hiddenButtons).toContain("copy-tree");
+      expect(store.getState().layout.pinnedButtons["copy-tree"]).toBe(false);
 
       store.getState().moveButton("settings", "right", "right", 0);
-      expect(store.getState().layout.hiddenButtons).toContain("copy-tree");
+      expect(store.getState().layout.pinnedButtons["copy-tree"]).toBe(false);
     });
   });
 
-  describe("setLeftButtons/setRightButtons preserves hiddenButtons", () => {
-    it("preserves hiddenButtons when setting new button order", async () => {
+  describe("setLeftButtons/setRightButtons preserves pinnedButtons", () => {
+    it("preserves pinnedButtons when setting new button order", async () => {
       const store = await loadStore();
       store.getState().toggleButtonVisibility("terminal", "left");
 
       const reordered = [...store.getState().layout.leftButtons].reverse();
       store.getState().setLeftButtons(reordered);
 
-      expect(store.getState().layout.hiddenButtons).toContain("terminal");
+      expect(store.getState().layout.pinnedButtons["terminal"]).toBe(false);
     });
   });
 
   describe("reset", () => {
-    it("clears hiddenButtons and restores default ordering", async () => {
+    it("clears pinnedButtons and restores default ordering", async () => {
       const store = await loadStore();
       const defaults = { ...store.getState().layout };
 
@@ -147,14 +147,14 @@ describe("toolbarPreferencesStore", () => {
       store.getState().setLeftButtons([...store.getState().layout.leftButtons].reverse());
 
       store.getState().reset();
-      expect(store.getState().layout.hiddenButtons).toEqual([]);
+      expect(store.getState().layout.pinnedButtons).toEqual({});
       expect(store.getState().layout.leftButtons).toEqual(defaults.leftButtons);
       expect(store.getState().layout.rightButtons).toEqual(defaults.rightButtons);
     });
   });
 
   describe("persistence", () => {
-    it("persists hiddenButtons to localStorage", async () => {
+    it("persists pinnedButtons to localStorage", async () => {
       const store = await loadStore();
       store.getState().toggleButtonVisibility("copy-tree", "right");
 
@@ -163,11 +163,11 @@ describe("toolbarPreferencesStore", () => {
         const raw = storageMock.getItem(STORAGE_KEY);
         expect(raw).toBeTruthy();
         const parsed = JSON.parse(raw!);
-        expect(parsed.state.layout.hiddenButtons).toContain("copy-tree");
+        expect(parsed.state.layout.pinnedButtons["copy-tree"]).toBe(false);
       });
     });
 
-    it("restores hiddenButtons from persisted state on rehydration", async () => {
+    it("restores hiddenButtons from persisted v6 state on rehydration", async () => {
       setStoredState(
         {
           layout: {
@@ -181,7 +181,8 @@ describe("toolbarPreferencesStore", () => {
       );
 
       const store = await loadStore();
-      expect(store.getState().layout.hiddenButtons).toContain("copy-tree");
+      // v7→v8 converts hiddenButtons to pinnedButtons.
+      expect(store.getState().layout.pinnedButtons["copy-tree"]).toBe(false);
       expect(store.getState().layout.rightButtons).toContain("copy-tree");
     });
 
@@ -199,11 +200,11 @@ describe("toolbarPreferencesStore", () => {
       );
 
       const store = await loadStore();
-      expect(store.getState().layout.hiddenButtons).toEqual([
-        "terminal",
-        "github-stats",
-        "copy-tree",
-      ]);
+      expect(store.getState().layout.pinnedButtons).toEqual({
+        terminal: false,
+        "github-stats": false,
+        "copy-tree": false,
+      });
     });
 
     it("merges new default buttons without re-inserting hidden ones", async () => {
@@ -221,15 +222,16 @@ describe("toolbarPreferencesStore", () => {
 
       const store = await loadStore();
       // "browser" was hidden — it should be re-added to leftButtons by mergeButtonList
-      // (since it was missing from the persisted leftButtons) but remain in hiddenButtons
-      expect(store.getState().layout.hiddenButtons).toContain("browser");
+      // (since it was missing from the persisted leftButtons) but its hide-state
+      // is preserved as `pinnedButtons.browser === false`.
+      expect(store.getState().layout.pinnedButtons["browser"]).toBe(false);
       // mergeButtonList will add browser back to leftButtons since it's a default
       expect(store.getState().layout.leftButtons).toContain("browser");
     });
   });
 
   describe("migration", () => {
-    it("migrates v1 state to add hiddenButtons field", async () => {
+    it("migrates v1 state through the v7→v8 conversion to pinnedButtons", async () => {
       storageMock.setItem(
         STORAGE_KEY,
         JSON.stringify({
@@ -245,7 +247,7 @@ describe("toolbarPreferencesStore", () => {
       );
 
       const store = await loadStore();
-      expect(store.getState().layout.hiddenButtons).toEqual([]);
+      expect(store.getState().layout.pinnedButtons).toEqual({});
     });
 
     it("includes dev-server in default left buttons", async () => {
@@ -287,8 +289,10 @@ describe("toolbarPreferencesStore", () => {
       const { layout } = store.getState();
       expect(layout.leftButtons).toContain("agent-tray");
       expect(layout.leftButtons).not.toContain("agent-setup");
-      expect(layout.hiddenButtons).toContain("agent-tray");
-      expect(layout.hiddenButtons).not.toContain("agent-setup");
+      // The v3 rename moved agent-setup → agent-tray inside hiddenButtons; the
+      // v8 migration then translates that to a pinnedButtons entry.
+      expect(layout.pinnedButtons["agent-tray"]).toBe(false);
+      expect((layout.pinnedButtons as Record<string, boolean>)["agent-setup"]).toBeUndefined();
       // Position preserved (first) — agent-tray should be at index 0.
       expect(layout.leftButtons[0]).toBe("agent-tray");
     });
@@ -352,7 +356,9 @@ describe("toolbarPreferencesStore", () => {
       const { layout } = store.getState();
       expect(layout.leftButtons).not.toContain("panel-palette");
       expect(layout.rightButtons).not.toContain("panel-palette");
-      expect(layout.hiddenButtons).not.toContain("panel-palette");
+      // panel-palette gets stripped before v8 reads hiddenButtons, so no
+      // pinnedButtons entry should be created for it.
+      expect((layout.pinnedButtons as Record<string, boolean>)["panel-palette"]).toBeUndefined();
       // Order of remaining items preserved
       expect(layout.leftButtons).toContain("agent-tray");
       expect(layout.leftButtons).toContain("terminal");
@@ -374,7 +380,7 @@ describe("toolbarPreferencesStore", () => {
       expect(store.getState().layout.leftButtons).toBeDefined();
     });
 
-    it("v4→v5 strips built-in agent IDs from hiddenButtons", async () => {
+    it("v4→v5 strips built-in agent IDs from hiddenButtons before v8 conversion", async () => {
       storageMock.setItem(
         STORAGE_KEY,
         JSON.stringify({
@@ -392,8 +398,8 @@ describe("toolbarPreferencesStore", () => {
 
       const store = await loadStore();
       const { layout } = store.getState();
-      // Agent IDs stripped; non-agent entries preserved.
-      expect(layout.hiddenButtons).toEqual(["copy-tree"]);
+      // Agent IDs stripped at v5, then v8 converts the remainder to a map.
+      expect(layout.pinnedButtons).toEqual({ "copy-tree": false });
       // Ordering arrays untouched.
       expect(layout.leftButtons).toContain("claude");
       expect(layout.leftButtons).toContain("gemini");
@@ -427,11 +433,11 @@ describe("toolbarPreferencesStore", () => {
       );
 
       const store = await loadStore();
-      // All built-in agent IDs stripped; non-agent entries preserved.
-      expect(store.getState().layout.hiddenButtons).toEqual(["copy-tree"]);
+      // All built-in agent IDs stripped; non-agent entry survives into pinnedButtons.
+      expect(store.getState().layout.pinnedButtons).toEqual({ "copy-tree": false });
     });
 
-    it("v4→v5 leaves hiddenButtons untouched when no agent IDs are present", async () => {
+    it("v4→v5 leaves non-agent hidden entries untouched into pinnedButtons", async () => {
       storageMock.setItem(
         STORAGE_KEY,
         JSON.stringify({
@@ -448,14 +454,17 @@ describe("toolbarPreferencesStore", () => {
       );
 
       const store = await loadStore();
-      expect(store.getState().layout.hiddenButtons).toEqual(["github-stats", "copy-tree"]);
+      expect(store.getState().layout.pinnedButtons).toEqual({
+        "github-stats": false,
+        "copy-tree": false,
+      });
     });
 
     it("v4→v5 is a no-op on already-v5 state (idempotency guard)", async () => {
       // Rehydrating a store that's already at v5 must not re-apply the v4→v5
       // agent-stripping migration — agent IDs legitimately absent from
-      // hiddenButtons should stay absent. The v5→v6 migration still runs and
-      // strips any lingering "notes" entry.
+      // hiddenButtons should stay absent. The v5→v6 strips notes; v7→v8
+      // converts the remainder to pinnedButtons.
       storageMock.setItem(
         STORAGE_KEY,
         JSON.stringify({
@@ -472,7 +481,7 @@ describe("toolbarPreferencesStore", () => {
       );
 
       const store = await loadStore();
-      expect(store.getState().layout.hiddenButtons).toEqual(["copy-tree"]);
+      expect(store.getState().layout.pinnedButtons).toEqual({ "copy-tree": false });
       // Ordering arrays untouched.
       expect(store.getState().layout.leftButtons).toContain("claude");
     });
@@ -497,7 +506,8 @@ describe("toolbarPreferencesStore", () => {
       const { layout } = store.getState();
       expect(layout.leftButtons).not.toContain("notes");
       expect(layout.rightButtons).not.toContain("notes");
-      expect(layout.hiddenButtons).not.toContain("notes");
+      // v6 removes notes before v8 reads it — no pinnedButtons entry created.
+      expect((layout.pinnedButtons as Record<string, boolean>)["notes"]).toBeUndefined();
     });
 
     it("v6→v7 strips 'assistant-toggle' from all button arrays", async () => {
@@ -520,7 +530,8 @@ describe("toolbarPreferencesStore", () => {
       const { layout } = store.getState();
       expect(layout.leftButtons).not.toContain("assistant-toggle");
       expect(layout.rightButtons).not.toContain("assistant-toggle");
-      expect(layout.hiddenButtons).not.toContain("assistant-toggle");
+      // v7 removes assistant-toggle before v8 reads it — no pinnedButtons entry.
+      expect(layout.pinnedButtons["assistant-toggle"]).toBeUndefined();
     });
 
     it("v6→v7 is idempotent on state already lacking assistant-toggle", async () => {
@@ -544,7 +555,7 @@ describe("toolbarPreferencesStore", () => {
       expect(layout.leftButtons).toContain("terminal");
       expect(layout.leftButtons).toContain("browser");
       expect(layout.rightButtons).toContain("settings");
-      expect(layout.hiddenButtons).toEqual([]);
+      expect(layout.pinnedButtons).toEqual({});
     });
 
     it("sanitizeButtonList strips assistant-toggle when set via setRightButtons", async () => {
@@ -596,8 +607,122 @@ describe("toolbarPreferencesStore", () => {
       expect(store.getState().layout.leftButtons).toContain("dev-server");
       // v0→v1: resets defaultSelection that was "dev-server"
       expect(store.getState().launcher.defaultSelection).toBeUndefined();
-      // v1→v2: adds hiddenButtons
-      expect(store.getState().layout.hiddenButtons).toEqual([]);
+      // v7→v8: replaces the hiddenButtons array with the pinnedButtons map.
+      expect(store.getState().layout.pinnedButtons).toEqual({});
+    });
+
+    describe("v7→v8 hiddenButtons → pinnedButtons", () => {
+      it("converts a v7 hiddenButtons array to a pinnedButtons map of false entries", async () => {
+        storageMock.setItem(
+          STORAGE_KEY,
+          JSON.stringify({
+            state: {
+              layout: {
+                leftButtons: ["agent-tray", "terminal", "browser"],
+                rightButtons: ["copy-tree", "settings"],
+                hiddenButtons: ["terminal", "copy-tree"],
+              },
+              launcher: { alwaysShowDevServer: false },
+            },
+            version: 7,
+          })
+        );
+
+        const store = await loadStore();
+        const { layout } = store.getState();
+        expect(layout.pinnedButtons).toEqual({
+          terminal: false,
+          "copy-tree": false,
+        });
+        // The hidden array is dropped from the canonical shape.
+        expect((layout as unknown as { hiddenButtons?: unknown }).hiddenButtons).toBeUndefined();
+        // Ordering arrays untouched.
+        expect(layout.leftButtons).toContain("terminal");
+        expect(layout.rightButtons).toContain("copy-tree");
+      });
+
+      it("yields an empty pinnedButtons map when v7 had no hiddenButtons entries", async () => {
+        storageMock.setItem(
+          STORAGE_KEY,
+          JSON.stringify({
+            state: {
+              layout: {
+                leftButtons: ["terminal"],
+                rightButtons: ["settings"],
+                hiddenButtons: [],
+              },
+              launcher: { alwaysShowDevServer: false },
+            },
+            version: 7,
+          })
+        );
+
+        const store = await loadStore();
+        expect(store.getState().layout.pinnedButtons).toEqual({});
+      });
+
+      it("synthesizes a v8 layout shape when v7 state lacks the layout block", async () => {
+        storageMock.setItem(
+          STORAGE_KEY,
+          JSON.stringify({
+            state: { launcher: { alwaysShowDevServer: false } },
+            version: 7,
+          })
+        );
+
+        const store = await loadStore();
+        // merge() should fall back to defaults rather than crash; pinnedButtons
+        // must still be the canonical empty map.
+        expect(store.getState().layout.pinnedButtons).toEqual({});
+        expect(store.getState().layout.leftButtons).toBeDefined();
+      });
+
+      it("preserves an existing pinnedButtons map and merges v7 hiddenButtons on top", async () => {
+        // Forward-compat: a payload that's nominally v7 but already carries a
+        // pinnedButtons map (e.g. a downgrade-then-upgrade path) shouldn't lose
+        // explicit entries.
+        storageMock.setItem(
+          STORAGE_KEY,
+          JSON.stringify({
+            state: {
+              layout: {
+                leftButtons: ["terminal"],
+                rightButtons: ["settings", "copy-tree"],
+                hiddenButtons: ["copy-tree"],
+                pinnedButtons: { terminal: true },
+              },
+              launcher: { alwaysShowDevServer: false },
+            },
+            version: 7,
+          })
+        );
+
+        const store = await loadStore();
+        expect(store.getState().layout.pinnedButtons).toEqual({
+          terminal: true,
+          "copy-tree": false,
+        });
+      });
+
+      it("is idempotent on v8 state without re-applying conversion", async () => {
+        storageMock.setItem(
+          STORAGE_KEY,
+          JSON.stringify({
+            state: {
+              layout: {
+                leftButtons: ["terminal", "browser"],
+                rightButtons: ["copy-tree", "settings"],
+                pinnedButtons: { "copy-tree": false },
+              },
+              launcher: { alwaysShowDevServer: false },
+            },
+            version: 8,
+          })
+        );
+
+        const store = await loadStore();
+        expect(store.getState().layout.pinnedButtons).toEqual({ "copy-tree": false });
+      });
     });
   });
 });

--- a/src/store/__tests__/toolbarPreferencesStore.test.ts
+++ b/src/store/__tests__/toolbarPreferencesStore.test.ts
@@ -112,6 +112,32 @@ describe("toolbarPreferencesStore", () => {
       expect(after.leftButtons).toEqual(before.left);
       expect(after.rightButtons).toEqual(before.right);
     });
+
+    it("round-trips a pre-seeded `pinnedButtons[id] = true` through false → undefined", async () => {
+      // Seeds the forward-compat case where a downgrade-then-upgrade or a
+      // future explicit-pin write leaves `true` in the map — the toggle must
+      // still flip cleanly to `false` and then to omission.
+      setStoredState(
+        {
+          layout: {
+            leftButtons: ["terminal"],
+            rightButtons: ["settings"],
+            pinnedButtons: { terminal: true },
+          },
+          launcher: { alwaysShowDevServer: false },
+        },
+        8
+      );
+
+      const store = await loadStore();
+      expect(store.getState().layout.pinnedButtons["terminal"]).toBe(true);
+
+      store.getState().toggleButtonVisibility("terminal", "left");
+      expect(store.getState().layout.pinnedButtons["terminal"]).toBe(false);
+
+      store.getState().toggleButtonVisibility("terminal", "left");
+      expect(store.getState().layout.pinnedButtons["terminal"]).toBeUndefined();
+    });
   });
 
   describe("moveButton preserves pinnedButtons", () => {

--- a/src/store/toolbarPreferencesStore.ts
+++ b/src/store/toolbarPreferencesStore.ts
@@ -252,12 +252,13 @@ export const useToolbarPreferencesStore = create<ToolbarPreferencesState>()(
           // visibility uses the same tri-state semantics as agent pinning
           // (#7666). Existing hides translate to explicit `false` entries.
           const layout = state.layout as
-            | { hiddenButtons?: string[]; pinnedButtons?: Record<string, boolean> }
+            | { hiddenButtons?: unknown; pinnedButtons?: Record<string, boolean> }
             | undefined;
           if (layout) {
             const pinned: Record<string, boolean> = { ...(layout.pinnedButtons ?? {}) };
-            for (const id of layout.hiddenButtons ?? []) {
-              pinned[id] = false;
+            const hidden = Array.isArray(layout.hiddenButtons) ? layout.hiddenButtons : [];
+            for (const id of hidden) {
+              if (typeof id === "string") pinned[id] = false;
             }
             layout.pinnedButtons = pinned;
             delete layout.hiddenButtons;

--- a/src/store/toolbarPreferencesStore.ts
+++ b/src/store/toolbarPreferencesStore.ts
@@ -4,6 +4,7 @@ import type {
   ToolbarPreferences,
   ToolbarButtonId,
   AnyToolbarButtonId,
+  ToolbarPinnedState,
 } from "@/../../shared/types/toolbar";
 import { createSafeJSONStorage } from "./persistence/safeStorage";
 import { registerPersistedStore } from "./persistence/persistedStoreRegistry";
@@ -30,7 +31,7 @@ const DEFAULT_PREFERENCES: ToolbarPreferences = {
   layout: {
     leftButtons: DEFAULT_LEFT_BUTTONS,
     rightButtons: DEFAULT_RIGHT_BUTTONS,
-    hiddenButtons: [],
+    pinnedButtons: {},
   },
   launcher: {
     alwaysShowDevServer: false,
@@ -125,15 +126,18 @@ export const useToolbarPreferencesStore = create<ToolbarPreferencesState>()(
         }),
       toggleButtonVisibility: (buttonId, _side) =>
         set((state) => {
-          const hidden = [...state.layout.hiddenButtons];
-          const index = hidden.indexOf(buttonId);
-          if (index === -1) {
-            hidden.push(buttonId);
+          // Only record `false` (hidden) or omit (visible). Mirrors the
+          // pre-v8 `hiddenButtons` semantic — the map only tracks departures
+          // from the default, never redundantly persisting `true` for every
+          // visible button.
+          const pinned: ToolbarPinnedState = { ...state.layout.pinnedButtons };
+          if (pinned[buttonId] === false) {
+            delete pinned[buttonId];
           } else {
-            hidden.splice(index, 1);
+            pinned[buttonId] = false;
           }
           return {
-            layout: { ...state.layout, hiddenButtons: hidden },
+            layout: { ...state.layout, pinnedButtons: pinned },
           };
         }),
       setAlwaysShowDevServer: (value) =>
@@ -152,7 +156,7 @@ export const useToolbarPreferencesStore = create<ToolbarPreferencesState>()(
     }),
     {
       name: "daintree-toolbar-preferences",
-      version: 7,
+      version: 8,
       storage: createSafeJSONStorage(),
       migrate: (persisted, version) => {
         const state = persisted as Record<string, unknown>;
@@ -243,6 +247,27 @@ export const useToolbarPreferencesStore = create<ToolbarPreferencesState>()(
             layout.hiddenButtons = drop(layout.hiddenButtons);
           }
         }
+        if (version < 8) {
+          // Replace the `hiddenButtons` array with a `pinnedButtons` map so
+          // visibility uses the same tri-state semantics as agent pinning
+          // (#7666). Existing hides translate to explicit `false` entries.
+          const layout = state.layout as
+            | { hiddenButtons?: string[]; pinnedButtons?: Record<string, boolean> }
+            | undefined;
+          if (layout) {
+            const pinned: Record<string, boolean> = { ...(layout.pinnedButtons ?? {}) };
+            for (const id of layout.hiddenButtons ?? []) {
+              pinned[id] = false;
+            }
+            layout.pinnedButtons = pinned;
+            delete layout.hiddenButtons;
+          } else {
+            // Older payloads that never had a layout block at all still need a
+            // valid v8 shape so `merge()` doesn't fall back to overwriting the
+            // freshly-built `pinnedButtons` with the default empty map.
+            state.layout = { pinnedButtons: {} } as unknown as Record<string, unknown>;
+          }
+        }
         return state as unknown as ToolbarPreferencesState;
       },
       partialize: (state) => ({
@@ -266,7 +291,7 @@ export const useToolbarPreferencesStore = create<ToolbarPreferencesState>()(
               persisted.layout?.rightButtons,
               currentState.layout.rightButtons
             ),
-            hiddenButtons: persisted.layout?.hiddenButtons ?? [],
+            pinnedButtons: persisted.layout?.pinnedButtons ?? {},
           },
         };
       },


### PR DESCRIPTION
## Summary

- Replaces `ToolbarLayout.hiddenButtons[]` with `pinnedButtons: Partial<Record<AnyToolbarButtonId, boolean>>` — a tri-state map that mirrors the agent tray's existing pinning model (`true` pinned, `false` hidden, absent = default)
- Adds `TOOLBAR_BUTTON_METADATA` (`src/components/Layout/toolbarButtonMetadata.ts`) as a single source of truth for labels and icons across the toolbar overflow dropdown, Settings drag list, and agent tray — fixing the Plug/Puzzle icon drift described in #7668
- Store migrates v7 → v8: `hiddenButtons` entries convert to `pinnedButtons[id] = false` with defensive Array/typeof guards; `isToolbarButtonVisible` unifies the resolution path for both agent and non-agent buttons

Resolves #7666
Resolves #7668

## Changes

- `shared/types/toolbar.ts` — new `ToolbarPinnedState` alias; `ToolbarLayout.pinnedButtons` replaces `hiddenButtons`
- `src/store/toolbarPreferencesStore.ts` — v7→v8 migration, updated `toggleButtonVisibility` logic
- `src/components/Layout/toolbarButtonMetadata.ts` — new unified registry; built-in agent icons derive from `getAgentConfig()` so Toolbar and Settings stay in sync
- `src/components/Layout/Toolbar.tsx` — overflow menu derives from unified metadata; `COPY_TREE_FEEDBACK_RESET_MS` hoisted to named const
- `src/components/Settings/ToolbarSettingsTab.tsx` — drops local `BUTTON_METADATA` map and `isEffectivelyVisible()` helper; imports from unified registry
- Tests: 5 new v7→v8 migration tests, `toolbarButtonMetadata.test.ts` coverage sentinel, `pinnedButtons=true` round-trip assertion

## Testing

- 87 unit tests across 6 spec files: pass
- `tsc --noEmit`: clean
- `prettier --check`: clean
- Lint ratchet: 861 warnings (no new)
- Build and E2E deferred to CI