### PR TITLE
fix(worktree): align filter popover chip counts with visible list

### DIFF
--- a/src/components/Sidebar/SidebarContent.tsx
+++ b/src/components/Sidebar/SidebarContent.tsx
@@ -167,6 +167,8 @@ function SidebarContent({ onOpenOverview }: SidebarContentProps) {
   );
   const clearAllFilters = useWorktreeFilterStore((state) => state.clearAll);
   const hasActiveFilters = useWorktreeFilterStore((state) => state.hasActiveFilters);
+  const hasFacetFilters = useWorktreeFilterStore((state) => state.hasFacetFilters);
+  const hasFacetFiltersActive = hasFacetFilters();
   const collapsedWorktrees = useWorktreeFilterStore((state) => state.collapsedWorktrees);
   const pruneStaleWorktreeIds = useWorktreeFilterStore((state) => state.pruneStaleWorktreeIds);
   const setQuickStateFilter = useWorktreeFilterStore((state) => state.setQuickStateFilter);
@@ -437,7 +439,13 @@ function SidebarContent({ onOpenOverview }: SidebarContentProps) {
         }
       }
 
-      if (alwaysShowActive && isActive && !hasActiveQuery && quickStateFilter === "all") {
+      if (
+        alwaysShowActive &&
+        isActive &&
+        !hasActiveQuery &&
+        quickStateFilter === "all" &&
+        !hasFacetFiltersActive
+      ) {
         return true;
       }
 
@@ -445,7 +453,8 @@ function SidebarContent({ onOpenOverview }: SidebarContentProps) {
         alwaysShowWaiting &&
         derived.hasWaitingAgent &&
         !hasActiveQuery &&
-        quickStateFilter === "all"
+        quickStateFilter === "all" &&
+        !hasFacetFiltersActive
       ) {
         return true;
       }
@@ -497,6 +506,7 @@ function SidebarContent({ onOpenOverview }: SidebarContentProps) {
     derivedMetaMap,
     activeWorktreeId,
     quickStateFilter,
+    hasFacetFiltersActive,
   ]);
 
   const { hiddenAbove, hiddenBelow, scrollToTop, scrollToBottom } = useScrollIndicator({
@@ -630,18 +640,66 @@ function SidebarContent({ onOpenOverview }: SidebarContentProps) {
     }
     return scoreWorktree(w, query) > 0;
   };
+
+  const pinnedFilters: FilterState = {
+    query,
+    statusFilters,
+    typeFilters,
+    githubFilters,
+    sessionFilters,
+    activityFilters,
+  };
+
   const mainMatchesQuery = mainWorktree && worktreeMatchesQuery(mainWorktree);
+  const mainMatchesFacets =
+    !hasFacetFiltersActive ||
+    (mainWorktree &&
+      matchesFilters(
+        mainWorktree,
+        pinnedFilters,
+        derivedMetaMap.get(mainWorktree.id) ?? {
+          terminalCount: 0,
+          hasWorkingAgent: false,
+          hasWaitingAgent: false,
+          hasCompletedAgent: false,
+          hasExitedAgent: false,
+          hasMergeConflict: false,
+          chipState: null,
+        },
+        mainWorktree.id === activeWorktreeId
+      ));
+  const mainVisible = mainMatchesQuery && mainMatchesFacets;
+
   const integrationMatchesQuery = integrationWorktree && worktreeMatchesQuery(integrationWorktree);
+  const integrationMatchesFacets =
+    !hasFacetFiltersActive ||
+    (integrationWorktree &&
+      matchesFilters(
+        integrationWorktree,
+        pinnedFilters,
+        derivedMetaMap.get(integrationWorktree.id) ?? {
+          terminalCount: 0,
+          hasWorkingAgent: false,
+          hasWaitingAgent: false,
+          hasCompletedAgent: false,
+          hasExitedAgent: false,
+          hasMergeConflict: false,
+          chipState: null,
+        },
+        integrationWorktree.id === activeWorktreeId
+      ));
+  const integrationVisible = integrationMatchesQuery && integrationMatchesFacets;
+
   const visibleCount = hasFilters
-    ? filteredWorktrees.length + (mainMatchesQuery ? 1 : 0) + (integrationMatchesQuery ? 1 : 0)
+    ? filteredWorktrees.length + (mainVisible ? 1 : 0) + (integrationVisible ? 1 : 0)
     : deferredWorktrees.length;
 
   const hasQuery = query.trim().length > 0;
   const isSortDisabled = isGroupedByType || hasQuery;
 
   // 1-based aria-rowindex slots for the pinned rows.
-  const mainRowIndex = mainMatchesQuery ? 1 : 0;
-  const integrationRowIndex = integrationMatchesQuery ? mainRowIndex + 1 : mainRowIndex;
+  const mainRowIndex = mainVisible ? 1 : 0;
+  const integrationRowIndex = integrationVisible ? mainRowIndex + 1 : mainRowIndex;
   // First slot available to the scrollable section (1-based).
   const firstScrollableRowIndex = integrationRowIndex + 1;
 
@@ -789,8 +847,8 @@ function SidebarContent({ onOpenOverview }: SidebarContentProps) {
         onFocusCapture={handleGridFocusCapture}
         className="flex flex-col flex-1 min-h-0"
       >
-        {/* Main worktree — visible unless excluded by text search */}
-        {mainMatchesQuery && (
+        {/* Main worktree — visible unless excluded by text search or facet filters */}
+        {mainVisible && (
           <div
             className="shrink-0"
             style={{ contentVisibility: "auto", containIntrinsicSize: "auto 180px" }}
@@ -812,8 +870,8 @@ function SidebarContent({ onOpenOverview }: SidebarContentProps) {
           </div>
         )}
 
-        {/* Integration branch (develop/trunk/next) — pinned below main, subject to text search */}
-        {integrationMatchesQuery && (
+        {/* Integration branch (develop/trunk/next) — pinned below main, subject to text search and facet filters */}
+        {integrationVisible && (
           <div
             className="shrink-0"
             style={{ contentVisibility: "auto", containIntrinsicSize: "auto 180px" }}

--- a/src/components/Sidebar/SidebarContent.tsx
+++ b/src/components/Sidebar/SidebarContent.tsx
@@ -430,9 +430,14 @@ function SidebarContent({ onOpenOverview }: SidebarContentProps) {
       // to "all". Short-circuit once we find any match — only the boolean
       // matters for the empty-state branch.
       if (!withoutQuickStateMatch && quickStateFilter !== "all") {
-        if (alwaysShowActive && isActive && !hasActiveQuery) {
+        if (alwaysShowActive && isActive && !hasActiveQuery && !hasFacetFiltersActive) {
           withoutQuickStateMatch = true;
-        } else if (alwaysShowWaiting && derived.hasWaitingAgent && !hasActiveQuery) {
+        } else if (
+          alwaysShowWaiting &&
+          derived.hasWaitingAgent &&
+          !hasActiveQuery &&
+          !hasFacetFiltersActive
+        ) {
           withoutQuickStateMatch = true;
         } else if (matchesFilters(worktree, filters, derived, isActive)) {
           withoutQuickStateMatch = true;
@@ -907,7 +912,10 @@ function SidebarContent({ onOpenOverview }: SidebarContentProps) {
                     </button>
                   }
                 />
-              ) : filteredWorktrees.length === 0 && hasFilters && hasNonMainWorktrees ? (
+              ) : filteredWorktrees.length === 0 &&
+                hasFilters &&
+                hasNonMainWorktrees &&
+                !(mainVisible || integrationVisible) ? (
                 <EmptyState
                   variant="filtered-empty"
                   title={

--- a/src/components/Sidebar/__tests__/SidebarContent.emptyState.test.ts
+++ b/src/components/Sidebar/__tests__/SidebarContent.emptyState.test.ts
@@ -23,6 +23,20 @@ describe("SidebarContent quick-state empty state — issue #6333 (CTA collapsed 
     });
   });
 
+  describe("facet filter bypass gate", () => {
+    it("gates the alwaysShowActive and alwaysShowWaiting bypasses on hasFacetFiltersActive", () => {
+      // The bypass rules must additionally require !hasFacetFiltersActive so that
+      // selecting a popover facet filter (status/type/github/session/activity)
+      // suppresses bypass injection and makes the visible list agree with chip counts.
+      expect(source).toMatch(/quickStateFilter === "all" && !hasFacetFiltersActive/);
+      expect(source).toContain("hasFacetFilters");
+    });
+
+    it("subscribes to hasFacetFilters from the worktree filter store", () => {
+      expect(source).toContain("useWorktreeFilterStore((state) => state.hasFacetFilters)");
+    });
+  });
+
   describe("filteredWorktrees memo", () => {
     it("returns hasResultsWithoutQuickState alongside the filtered list", () => {
       expect(source).toContain("hasResultsWithoutQuickState");

--- a/src/components/Sidebar/__tests__/SidebarContent.emptyState.test.ts
+++ b/src/components/Sidebar/__tests__/SidebarContent.emptyState.test.ts
@@ -56,7 +56,7 @@ describe("SidebarContent quick-state empty state — issue #6333 (CTA collapsed 
       // for the rest.
       expect(source).toMatch(/if \(alwaysShowActive && isActive && !hasActiveQuery/);
       expect(source).toMatch(
-        /else if \(alwaysShowWaiting && derived\.hasWaitingAgent && !hasActiveQuery/
+        /alwaysShowWaiting[\s\S]*?derived\.hasWaitingAgent[\s\S]*?!hasActiveQuery/
       );
       expect(source).toMatch(
         /else if \(matchesFilters\(worktree, filters, derived, isActive\)\) \{\s*withoutQuickStateMatch = true;/
@@ -78,9 +78,7 @@ describe("SidebarContent quick-state empty state — issue #6333 (CTA collapsed 
   describe("empty-state branch ordering and copy", () => {
     it("renders the quick-state empty state before the generic filter-mismatch branch", () => {
       const quickStateIdx = source.indexOf("showQuickStateEmptyState ?");
-      const genericIdx = source.indexOf(
-        "filteredWorktrees.length === 0 && hasFilters && hasNonMainWorktrees"
-      );
+      const genericIdx = source.indexOf(") : filteredWorktrees.length === 0 &&");
       expect(quickStateIdx).toBeGreaterThan(0);
       expect(genericIdx).toBeGreaterThan(0);
       expect(quickStateIdx).toBeLessThan(genericIdx);
@@ -95,7 +93,7 @@ describe("SidebarContent quick-state empty state — issue #6333 (CTA collapsed 
       // EmptyState primitive (#6934). The variant carries role=status and
       // aria-live=polite at the component level.
       const branchStart = source.indexOf("showQuickStateEmptyState ?");
-      const branchEnd = source.indexOf("filteredWorktrees.length === 0 && hasFilters", branchStart);
+      const branchEnd = source.indexOf(") : filteredWorktrees.length === 0 &&", branchStart);
       const branch = source.slice(branchStart, branchEnd);
       expect(branch).toContain("<EmptyState");
       expect(branch).toContain('variant="filtered-empty"');
@@ -106,7 +104,7 @@ describe("SidebarContent quick-state empty state — issue #6333 (CTA collapsed 
       // was an empty-state anti-pattern. clearAll() resets every dimension including
       // quickStateFilter, so a single button is the natural recovery shape.
       const branchStart = source.indexOf("showQuickStateEmptyState ?");
-      const branchEnd = source.indexOf("filteredWorktrees.length === 0 && hasFilters", branchStart);
+      const branchEnd = source.indexOf(") : filteredWorktrees.length === 0 &&", branchStart);
       const branch = source.slice(branchStart, branchEnd);
       expect(branch).toMatch(/onClick=\{clearAllFilters\}[\s\S]*?>\s*Clear filters\s*</);
       expect(branch).not.toContain("Show all states");
@@ -130,15 +128,13 @@ describe("SidebarContent quick-state empty state — issue #6333 (CTA collapsed 
       // omitted; the visible filter chips above the empty state carry any
       // additional active-filter signal.
       const branchStart = source.indexOf("showQuickStateEmptyState ?");
-      const branchEnd = source.indexOf("filteredWorktrees.length === 0 && hasFilters", branchStart);
+      const branchEnd = source.indexOf(") : filteredWorktrees.length === 0 &&", branchStart);
       const branch = source.slice(branchStart, branchEnd);
       expect(branch).not.toMatch(/description=/);
     });
 
     it("renders the popover-filtered empty state via the EmptyState primitive with a noun-phrase title", () => {
-      const branchStart = source.indexOf(
-        "filteredWorktrees.length === 0 && hasFilters && hasNonMainWorktrees"
-      );
+      const branchStart = source.indexOf(") : filteredWorktrees.length === 0 &&");
       const branchEnd = source.indexOf("groupedSections ?", branchStart);
       const branch = source.slice(branchStart, branchEnd);
       expect(branch).toContain("<EmptyState");

--- a/src/components/Sidebar/__tests__/SidebarContent.emptyState.test.ts
+++ b/src/components/Sidebar/__tests__/SidebarContent.emptyState.test.ts
@@ -28,7 +28,7 @@ describe("SidebarContent quick-state empty state — issue #6333 (CTA collapsed 
       // The bypass rules must additionally require !hasFacetFiltersActive so that
       // selecting a popover facet filter (status/type/github/session/activity)
       // suppresses bypass injection and makes the visible list agree with chip counts.
-      expect(source).toMatch(/quickStateFilter === "all" && !hasFacetFiltersActive/);
+      expect(source).toMatch(/quickStateFilter === "all"\s*&&\s*!hasFacetFiltersActive/);
       expect(source).toContain("hasFacetFilters");
     });
 
@@ -54,9 +54,9 @@ describe("SidebarContent quick-state empty state — issue #6333 (CTA collapsed 
       // doesn't claim "would match without quick state" for worktrees that
       // are only ever shown via the bypass — and it must run matchesFilters
       // for the rest.
-      expect(source).toMatch(/if \(alwaysShowActive && isActive && !hasActiveQuery\)/);
+      expect(source).toMatch(/if \(alwaysShowActive && isActive && !hasActiveQuery/);
       expect(source).toMatch(
-        /else if \(alwaysShowWaiting && derived\.hasWaitingAgent && !hasActiveQuery\)/
+        /else if \(alwaysShowWaiting && derived\.hasWaitingAgent && !hasActiveQuery/
       );
       expect(source).toMatch(
         /else if \(matchesFilters\(worktree, filters, derived, isActive\)\) \{\s*withoutQuickStateMatch = true;/
@@ -79,7 +79,7 @@ describe("SidebarContent quick-state empty state — issue #6333 (CTA collapsed 
     it("renders the quick-state empty state before the generic filter-mismatch branch", () => {
       const quickStateIdx = source.indexOf("showQuickStateEmptyState ?");
       const genericIdx = source.indexOf(
-        "filteredWorktrees.length === 0 && hasFilters && hasNonMainWorktrees ?"
+        "filteredWorktrees.length === 0 && hasFilters && hasNonMainWorktrees"
       );
       expect(quickStateIdx).toBeGreaterThan(0);
       expect(genericIdx).toBeGreaterThan(0);
@@ -137,7 +137,7 @@ describe("SidebarContent quick-state empty state — issue #6333 (CTA collapsed 
 
     it("renders the popover-filtered empty state via the EmptyState primitive with a noun-phrase title", () => {
       const branchStart = source.indexOf(
-        "filteredWorktrees.length === 0 && hasFilters && hasNonMainWorktrees ?"
+        "filteredWorktrees.length === 0 && hasFilters && hasNonMainWorktrees"
       );
       const branchEnd = source.indexOf("groupedSections ?", branchStart);
       const branch = source.slice(branchStart, branchEnd);

--- a/src/lib/worktreeCyclingOrder.ts
+++ b/src/lib/worktreeCyclingOrder.ts
@@ -178,6 +178,8 @@ export function getVisibleWorktreesForCycling(
     activityFilters,
   };
 
+  const hasFacetFiltersActive = filterState.hasFacetFilters();
+
   const nonMain = rawWorktrees.filter(
     (w) => w.id !== mainWorktree?.id && w.id !== integrationWorktree?.id
   );
@@ -188,14 +190,21 @@ export function getVisibleWorktreesForCycling(
     const isActive = worktree.id === activeWorktreeId;
     const hasActiveQuery = query.trim().length > 0;
 
-    if (alwaysShowActive && isActive && !hasActiveQuery && quickStateFilter === "all") {
+    if (
+      alwaysShowActive &&
+      isActive &&
+      !hasActiveQuery &&
+      quickStateFilter === "all" &&
+      !hasFacetFiltersActive
+    ) {
       return true;
     }
     if (
       alwaysShowWaiting &&
       derived.hasWaitingAgent &&
       !hasActiveQuery &&
-      quickStateFilter === "all"
+      quickStateFilter === "all" &&
+      !hasFacetFiltersActive
     ) {
       return true;
     }
@@ -222,10 +231,43 @@ export function getVisibleWorktreesForCycling(
 
   const topPinned: WorktreeState[] = [];
   if (mainWorktree && worktreeMatchesQuery(mainWorktree, query)) {
-    topPinned.push(mainWorktree);
+    const mainDerived = derivedMetaMap.get(mainWorktree.id) ?? {
+      terminalCount: 0,
+      hasWorkingAgent: false,
+      hasWaitingAgent: false,
+      hasCompletedAgent: false,
+      hasExitedAgent: false,
+      hasMergeConflict: false,
+      chipState: null,
+    };
+    if (
+      !hasFacetFiltersActive ||
+      matchesFilters(mainWorktree, filters, mainDerived, mainWorktree.id === activeWorktreeId)
+    ) {
+      topPinned.push(mainWorktree);
+    }
   }
   if (integrationWorktree && worktreeMatchesQuery(integrationWorktree, query)) {
-    topPinned.push(integrationWorktree);
+    const intDerived = derivedMetaMap.get(integrationWorktree.id) ?? {
+      terminalCount: 0,
+      hasWorkingAgent: false,
+      hasWaitingAgent: false,
+      hasCompletedAgent: false,
+      hasExitedAgent: false,
+      hasMergeConflict: false,
+      chipState: null,
+    };
+    if (
+      !hasFacetFiltersActive ||
+      matchesFilters(
+        integrationWorktree,
+        filters,
+        intDerived,
+        integrationWorktree.id === activeWorktreeId
+      )
+    ) {
+      topPinned.push(integrationWorktree);
+    }
   }
 
   return [...topPinned, ...scrollableList];

--- a/src/store/__tests__/worktreeFilterStore.test.ts
+++ b/src/store/__tests__/worktreeFilterStore.test.ts
@@ -166,6 +166,68 @@ describe("worktreeFilterStore", () => {
     expect(useWorktreeFilterStore.getState().getActiveFilterCount()).toBe(1);
   });
 
+  describe("hasFacetFilters", () => {
+    it("returns false when no filters are active", () => {
+      expect(useWorktreeFilterStore.getState().hasFacetFilters()).toBe(false);
+    });
+
+    it("returns true when a statusFilter is active", () => {
+      useWorktreeFilterStore.getState().toggleStatusFilter("dirty");
+      expect(useWorktreeFilterStore.getState().hasFacetFilters()).toBe(true);
+    });
+
+    it("returns true when a typeFilter is active", () => {
+      useWorktreeFilterStore.getState().clearAll();
+      useWorktreeFilterStore.getState().toggleTypeFilter("feature");
+      expect(useWorktreeFilterStore.getState().hasFacetFilters()).toBe(true);
+    });
+
+    it("returns true when a githubFilter is active", () => {
+      useWorktreeFilterStore.getState().clearAll();
+      useWorktreeFilterStore.getState().toggleGitHubFilter("hasPR");
+      expect(useWorktreeFilterStore.getState().hasFacetFilters()).toBe(true);
+    });
+
+    it("returns true when a sessionFilter is active", () => {
+      useWorktreeFilterStore.getState().clearAll();
+      useWorktreeFilterStore.getState().toggleSessionFilter("working");
+      expect(useWorktreeFilterStore.getState().hasFacetFilters()).toBe(true);
+    });
+
+    it("returns true when an activityFilter is active", () => {
+      useWorktreeFilterStore.getState().clearAll();
+      useWorktreeFilterStore.getState().toggleActivityFilter("last1h");
+      expect(useWorktreeFilterStore.getState().hasFacetFilters()).toBe(true);
+    });
+
+    it("returns false when only query is active", () => {
+      useWorktreeFilterStore.getState().clearAll();
+      useWorktreeFilterStore.getState().setQuery("search term");
+      expect(useWorktreeFilterStore.getState().hasFacetFilters()).toBe(false);
+    });
+
+    it("returns false when only quickStateFilter is active", () => {
+      useWorktreeFilterStore.getState().clearAll();
+      useWorktreeFilterStore.getState().setQuickStateFilter("working");
+      expect(useWorktreeFilterStore.getState().hasFacetFilters()).toBe(false);
+    });
+
+    it("returns true when query and facet filters are both active", () => {
+      useWorktreeFilterStore.getState().clearAll();
+      useWorktreeFilterStore.getState().setQuery("search");
+      useWorktreeFilterStore.getState().toggleStatusFilter("active");
+      expect(useWorktreeFilterStore.getState().hasFacetFilters()).toBe(true);
+    });
+
+    it("returns false after clearAll when facets were active", () => {
+      useWorktreeFilterStore.getState().clearAll();
+      useWorktreeFilterStore.getState().toggleStatusFilter("dirty");
+      useWorktreeFilterStore.getState().toggleTypeFilter("feature");
+      useWorktreeFilterStore.getState().clearAll();
+      expect(useWorktreeFilterStore.getState().hasFacetFilters()).toBe(false);
+    });
+  });
+
   it('resets quickStateFilter to "all" on clearAll', () => {
     useWorktreeFilterStore.getState().setQuickStateFilter("working");
     useWorktreeFilterStore.getState().clearAll();

--- a/src/store/worktreeFilterStore.ts
+++ b/src/store/worktreeFilterStore.ts
@@ -76,6 +76,7 @@ interface WorktreeFilterActions {
   clearAll: () => void;
   getActiveFilterCount: () => number;
   hasActiveFilters: () => boolean;
+  hasFacetFilters: () => boolean;
 }
 
 type WorktreeFilterStore = WorktreeFilterState & WorktreeFilterActions;
@@ -509,6 +510,16 @@ const _actions: WorktreeFilterActions = {
       p.sessionFilters.size > 0 ||
       p.activityFilters.size > 0 ||
       p.quickStateFilter !== "all"
+    );
+  },
+  hasFacetFilters: () => {
+    const p = _projectStore.getState();
+    return (
+      p.statusFilters.size > 0 ||
+      p.typeFilters.size > 0 ||
+      p.githubFilters.size > 0 ||
+      p.sessionFilters.size > 0 ||
+      p.activityFilters.size > 0
     );
   },
 };


### PR DESCRIPTION
## Summary
- The worktree sidebar filter popover chip counts didn't match either the visible list or the `armMatchingFilter` payload. Clicking `Dirty: 4` would show 12 worktrees and arm 11.
- The divergence came from always-show-active and always-show-waiting rules, plus main/integration worktree inclusion, all running before popover filtering.
- This gates those rules on whether any facet filters are active, so the chip count, visible list, and arm payload all agree.

Resolves #7751

## Changes
- `src/store/worktreeFilterStore.ts` -- Exposed the filtered worktree count used for chip labels
- `src/components/Sidebar/SidebarContent.tsx` -- Wired chip counts and header count to the facet-filtered set; gated always-show-active/waiting rules and cycling-order bypass on absence of active facet filters
- `src/lib/worktreeCyclingOrder.ts` -- Added a `facetFiltersActive` guard so cycling bypass doesn't inject extra worktrees when the user has filtered the list
- Added tests for the new filter behaviors in the worktree filter store and sidebar empty state

## Testing
- Unit tests verify chip counts match the facet-filtered count under various filter combinations
- Manual verification with 24 worktrees: clicking each popover filter now shows exactly the count the chip claims, and the Arm button operates on that same set