### PR TITLE
fix(workspace): auto-reconcile sidebar after external worktree deletion

### DIFF
--- a/electron/workspace-host/WorkspaceService.ts
+++ b/electron/workspace-host/WorkspaceService.ts
@@ -45,6 +45,8 @@ import {
 } from "./worktreeUtils.js";
 import { applyResourceConfigToMonitor } from "./resourceConfigHelpers.js";
 import { ResourceActionExecutor } from "./ResourceActionExecutor.js";
+import parcelWatcher from "@parcel/watcher";
+import { MutableDisposable } from "../utils/lifecycle.js";
 
 // Re-export so existing test imports (`probeGitLfsAvailable` from
 // `../WorkspaceService.js`) continue to work without modification.
@@ -103,6 +105,16 @@ export class WorkspaceService {
   private wslGitByWorktree: Record<string, { enabled: boolean; dismissed: boolean }> = {};
   /** Cached default WSL distro (populated lazily on first WSL-path detection). */
   private wslDefaultDistroPromise: Promise<string | null> | null = null;
+
+  // Topology watcher — watches `.git/worktrees/` for external worktree
+  // create/delete and triggers serialized reconciliation.
+  private topologyWatcherSubscription = new MutableDisposable();
+  private topologyReconcileQueue = new PQueue({ concurrency: 1 });
+  private topologyReconcilePending = false;
+  private topologyWatchSuppressUntil = 0;
+  private topologyWatchCooldownUntil = 0;
+  private topologyDebounceTimer: ReturnType<typeof setTimeout> | null = null;
+  private topologyWatcherEnabled = true;
 
   constructor(private readonly sendEvent: (event: WorkspaceHostEvent) => void) {
     this.fetchCoordinator = new RepoFetchCoordinator({
@@ -255,6 +267,8 @@ export class WorkspaceService {
         this.syncMonitors(worktrees, this.activeWorktreeId, this.mainBranch, undefined, true),
         probeGitLfsAvailable(),
       ]);
+
+      this.startTopologyWatcher();
 
       this.sendEvent({ type: "load-project-result", requestId, success: true, lfsAvailable });
 
@@ -727,6 +741,92 @@ export class WorkspaceService {
     this.sendEvent({ type: "emfile-limit-reached" });
   }
 
+  private worktreeMetadataDirPath(): string | null {
+    if (!this.projectRootPath) return null;
+    const commonDir = getGitCommonDir(this.projectRootPath);
+    if (!commonDir) return null;
+    return `${commonDir}/worktrees`;
+  }
+
+  private startTopologyWatcher(): void {
+    if (!this.topologyWatcherEnabled) return;
+    if (this.topologyWatcherSubscription.value) return;
+
+    const metadataDir = this.worktreeMetadataDirPath();
+    if (!metadataDir) return;
+    if (!existsSync(metadataDir)) return;
+
+    const schedule = () => this.scheduleTopologyReconcile();
+
+    parcelWatcher
+      .subscribe(metadataDir, (_err, _events) => {
+        if (this.topologyDebounceTimer) {
+          clearTimeout(this.topologyDebounceTimer);
+        }
+        this.topologyDebounceTimer = setTimeout(schedule, 300);
+      })
+      .then((subscription) => {
+        if (this.topologyWatcherSubscription.value) {
+          // Race: another call already set the subscription.
+          subscription.unsubscribe();
+          return;
+        }
+        this.topologyWatcherSubscription.value = {
+          dispose: () => subscription.unsubscribe(),
+        };
+      })
+      .catch((err) => {
+        console.warn(
+          `[WorkspaceHost] topology watcher subscribe failed for ${metadataDir}: ${(err as Error).message}`
+        );
+      });
+  }
+
+  private stopTopologyWatcher(): void {
+    this.topologyWatcherSubscription.value = undefined;
+    if (this.topologyDebounceTimer) {
+      clearTimeout(this.topologyDebounceTimer);
+      this.topologyDebounceTimer = null;
+    }
+    this.topologyReconcilePending = false;
+  }
+
+  private scheduleTopologyReconcile(): void {
+    if (!this.topologyWatcherEnabled) return;
+    if (!this.pollingEnabled) return;
+    if (Date.now() < this.topologyWatchSuppressUntil) return;
+    if (Date.now() < this.topologyWatchCooldownUntil) return;
+    if (this.topologyReconcilePending) return;
+
+    this.topologyReconcilePending = true;
+    this.topologyReconcileQueue.add(async () => {
+      try {
+        await this.runTopologyReconcile();
+      } finally {
+        this.topologyReconcilePending = false;
+        this.topologyWatchCooldownUntil = Date.now() + 2000;
+      }
+    });
+  }
+
+  private async runTopologyReconcile(): Promise<void> {
+    const previousActiveId = this.activeWorktreeId;
+    await this.discoverAndSyncWorktrees();
+
+    if (previousActiveId && !this.monitors.has(previousActiveId)) {
+      let mainId: string | null = null;
+      for (const [id, m] of this.monitors) {
+        if (m.isMainWorktree) {
+          mainId = id;
+          break;
+        }
+      }
+      if (mainId) {
+        this.setActiveWorktree("topology-reconcile-auto-switch", mainId);
+      }
+    }
+  }
+
   private handleExternalWorktreeRemoval(worktreeId: string): void {
     const monitor = this.monitors.get(worktreeId);
     if (!monitor) {
@@ -1035,6 +1135,12 @@ export class WorkspaceService {
 
       // `--end-of-options` after the subcommand flags so any leading-dash ref
       // or path that slipped past validation is treated as positional.
+
+      // Suppress the topology watcher during app-owned worktree creation so
+      // the `.git/worktrees/<name>/` directory creation doesn't trigger a
+      // redundant discoverAndSyncWorktrees pass.
+      this.topologyWatchSuppressUntil = Date.now() + 60000;
+
       if (useExistingBranch) {
         await git.raw(["worktree", "add", "--end-of-options", path, newBranch]);
       } else if (fromRemote) {
@@ -1108,6 +1214,11 @@ export class WorkspaceService {
       // authoritative and would remove every other non-main monitor.
       await this.addNewWorktreeMonitor(createdWorktree, isActive, true);
 
+      // Reset suppression: the monitor is registered, metadata writes will
+      // settle within 500ms. The short post-op window absorbs any remaining
+      // filesystem events from the git worktree add.
+      this.topologyWatchSuppressUntil = Date.now() + 500;
+
       if (options.worktreeMode && options.worktreeMode !== "local") {
         const m = this.monitors.get(canonicalWorktreeId);
         if (m) {
@@ -1146,6 +1257,7 @@ export class WorkspaceService {
         console.warn("[WorkspaceHost] createWorktree async tail failed:", err);
       });
     } catch (error) {
+      this.topologyWatchSuppressUntil = Date.now() + 500;
       this.sendEvent({
         type: "create-worktree-result",
         requestId,
@@ -1258,6 +1370,11 @@ export class WorkspaceService {
 
       await this.runLifecycleTeardown(worktreeId, monitor, force);
 
+      // Suppress the topology watcher during app-owned worktree deletion so
+      // the `.git/worktrees/<name>/` directory removal doesn't trigger a
+      // redundant discoverAndSyncWorktrees pass.
+      this.topologyWatchSuppressUntil = Date.now() + 60000;
+
       if (this.git) {
         // #6669: if the directory is already gone (deleted externally), skip
         // `git worktree remove` (which fails with `is not a working tree`)
@@ -1320,6 +1437,10 @@ export class WorkspaceService {
       monitor.stop();
       this.monitors.delete(worktreeId);
 
+      // Reset suppression: monitor is cleaned up, metadata writes will settle
+      // within 500ms.
+      this.topologyWatchSuppressUntil = Date.now() + 500;
+
       this.sendEvent({
         type: "worktree-removed",
         worktreeId,
@@ -1349,6 +1470,7 @@ export class WorkspaceService {
 
       this.sendEvent({ type: "delete-worktree-result", requestId, success: true });
     } catch (error) {
+      this.topologyWatchSuppressUntil = Date.now() + 500;
       this.sendEvent({
         type: "delete-worktree-result",
         requestId,
@@ -1594,6 +1716,7 @@ ${lines.map((l) => "+" + l).join("\n")}`;
     this.pollingEnabled = enabled;
 
     if (!enabled) {
+      this.stopTopologyWatcher();
       for (const monitor of this.monitors.values()) {
         monitor.pausePolling();
       }
@@ -1601,6 +1724,7 @@ ${lines.map((l) => "+" + l).join("\n")}`;
       for (const monitor of this.monitors.values()) {
         monitor.resumePolling();
       }
+      this.startTopologyWatcher();
     }
   }
 
@@ -1815,6 +1939,8 @@ ${lines.map((l) => "+" + l).join("\n")}`;
 
   dispose(): void {
     this._shutdownController.abort();
+    this.stopTopologyWatcher();
+    this.topologyReconcileQueue.clear();
     this.prService.cleanup();
     this.resourceActionExecutor.dispose();
     for (const monitor of this.monitors.values()) {

--- a/electron/workspace-host/WorkspaceService.ts
+++ b/electron/workspace-host/WorkspaceService.ts
@@ -113,8 +113,10 @@ export class WorkspaceService {
   private topologyReconcilePending = false;
   private topologyWatchSuppressUntil = 0;
   private topologyWatchCooldownUntil = 0;
+  private topologyWatchCooldownDirty = false;
   private topologyDebounceTimer: ReturnType<typeof setTimeout> | null = null;
   private topologyWatcherEnabled = true;
+  private topologyWatcherGeneration = 0;
 
   constructor(private readonly sendEvent: (event: WorkspaceHostEvent) => void) {
     this.fetchCoordinator = new RepoFetchCoordinator({
@@ -756,6 +758,7 @@ export class WorkspaceService {
     if (!metadataDir) return;
     if (!existsSync(metadataDir)) return;
 
+    const generation = ++this.topologyWatcherGeneration;
     const schedule = () => this.scheduleTopologyReconcile();
 
     parcelWatcher
@@ -766,8 +769,12 @@ export class WorkspaceService {
         this.topologyDebounceTimer = setTimeout(schedule, 300);
       })
       .then((subscription) => {
+        if (generation !== this.topologyWatcherGeneration) {
+          // stopTopologyWatcher incremented the generation — discard.
+          subscription.unsubscribe();
+          return;
+        }
         if (this.topologyWatcherSubscription.value) {
-          // Race: another call already set the subscription.
           subscription.unsubscribe();
           return;
         }
@@ -783,28 +790,43 @@ export class WorkspaceService {
   }
 
   private stopTopologyWatcher(): void {
+    this.topologyWatcherGeneration++;
     this.topologyWatcherSubscription.value = undefined;
     if (this.topologyDebounceTimer) {
       clearTimeout(this.topologyDebounceTimer);
       this.topologyDebounceTimer = null;
     }
     this.topologyReconcilePending = false;
+    this.topologyWatchCooldownDirty = false;
   }
 
   private scheduleTopologyReconcile(): void {
     if (!this.topologyWatcherEnabled) return;
     if (!this.pollingEnabled) return;
     if (Date.now() < this.topologyWatchSuppressUntil) return;
-    if (Date.now() < this.topologyWatchCooldownUntil) return;
-    if (this.topologyReconcilePending) return;
+    if (Date.now() < this.topologyWatchCooldownUntil) {
+      this.topologyWatchCooldownDirty = true;
+      return;
+    }
+    if (this.topologyReconcilePending) {
+      this.topologyWatchCooldownDirty = true;
+      return;
+    }
 
     this.topologyReconcilePending = true;
     this.topologyReconcileQueue.add(async () => {
       try {
         await this.runTopologyReconcile();
+      } catch (err) {
+        console.warn(`[WorkspaceHost] topology reconciliation failed: ${(err as Error).message}`);
       } finally {
         this.topologyReconcilePending = false;
         this.topologyWatchCooldownUntil = Date.now() + 2000;
+        if (this.topologyWatchCooldownDirty) {
+          this.topologyWatchCooldownDirty = false;
+          const remaining = this.topologyWatchCooldownUntil - Date.now();
+          setTimeout(() => this.scheduleTopologyReconcile(), Math.max(remaining, 0));
+        }
       }
     });
   }
@@ -813,7 +835,15 @@ export class WorkspaceService {
     const previousActiveId = this.activeWorktreeId;
     await this.discoverAndSyncWorktrees();
 
-    if (previousActiveId && !this.monitors.has(previousActiveId)) {
+    // Auto-switch to main if the previously-active worktree was removed.
+    // syncMonitors nulls activeWorktreeId when pruning the active monitor,
+    // so we check: was there a previous active, is it gone from monitors,
+    // and has the user NOT already switched to a *different* worktree.
+    if (
+      previousActiveId &&
+      !this.monitors.has(previousActiveId) &&
+      (this.activeWorktreeId === null || this.activeWorktreeId === previousActiveId)
+    ) {
       let mainId: string | null = null;
       for (const [id, m] of this.monitors) {
         if (m.isMainWorktree) {
@@ -1725,6 +1755,7 @@ ${lines.map((l) => "+" + l).join("\n")}`;
         monitor.resumePolling();
       }
       this.startTopologyWatcher();
+      this.scheduleTopologyReconcile();
     }
   }
 
@@ -1820,6 +1851,8 @@ ${lines.map((l) => "+" + l).join("\n")}`;
   }
 
   async onProjectSwitch(requestId: string): Promise<void> {
+    this.stopTopologyWatcher();
+    this.topologyReconcileQueue.clear();
     this.prService.cleanup();
 
     for (const id of this.monitors.keys()) {

--- a/electron/workspace-host/__tests__/WorkspaceService.createWorktree.test.ts
+++ b/electron/workspace-host/__tests__/WorkspaceService.createWorktree.test.ts
@@ -40,6 +40,7 @@ vi.mock("../../utils/git.js", () => ({
 
 vi.mock("../../utils/gitUtils.js", () => ({
   getGitDir: vi.fn().mockReturnValue("/test/worktree/.git"),
+  getGitCommonDir: vi.fn().mockReturnValue(null),
   clearGitDirCache: vi.fn(),
 }));
 

--- a/electron/workspace-host/__tests__/WorkspaceService.deleteWorktree.test.ts
+++ b/electron/workspace-host/__tests__/WorkspaceService.deleteWorktree.test.ts
@@ -41,6 +41,7 @@ vi.mock("../../utils/git.js", () => ({
 
 vi.mock("../../utils/gitUtils.js", () => ({
   getGitDir: vi.fn().mockReturnValue("/test/worktree/.git"),
+  getGitCommonDir: vi.fn().mockReturnValue(null),
   clearGitDirCache: vi.fn(),
 }));
 

--- a/electron/workspace-host/__tests__/WorkspaceService.externalRemoval.test.ts
+++ b/electron/workspace-host/__tests__/WorkspaceService.externalRemoval.test.ts
@@ -9,7 +9,7 @@ const { parcelWatcherCallbacks, mockGetGitCommonDir, mockParcelSubscribe } = vi.
   const callbacks: Array<(err: Error | null, events: unknown[]) => void> = [];
   return {
     parcelWatcherCallbacks: callbacks,
-    mockGetGitCommonDir: vi.fn<[string], string | null>().mockReturnValue(null),
+    mockGetGitCommonDir: vi.fn<(arg: string) => string | null>().mockReturnValue(null),
     mockParcelSubscribe: vi.fn(
       (_dir: string, cb: (err: Error | null, events: unknown[]) => void) => {
         callbacks.push(cb);

--- a/electron/workspace-host/__tests__/WorkspaceService.externalRemoval.test.ts
+++ b/electron/workspace-host/__tests__/WorkspaceService.externalRemoval.test.ts
@@ -5,6 +5,26 @@ import type { WorkspaceService } from "../WorkspaceService.js";
 import type { WorktreeMonitor } from "../WorktreeMonitor.js";
 import type { Worktree } from "../../../shared/types/worktree.js";
 
+const { parcelWatcherCallbacks, mockGetGitCommonDir, mockParcelSubscribe } = vi.hoisted(() => {
+  const callbacks: Array<(err: Error | null, events: unknown[]) => void> = [];
+  return {
+    parcelWatcherCallbacks: callbacks,
+    mockGetGitCommonDir: vi.fn<[string], string | null>().mockReturnValue(null),
+    mockParcelSubscribe: vi.fn(
+      (_dir: string, cb: (err: Error | null, events: unknown[]) => void) => {
+        callbacks.push(cb);
+        return Promise.resolve({ unsubscribe: vi.fn() });
+      }
+    ),
+  };
+});
+
+vi.mock("@parcel/watcher", () => ({
+  default: {
+    subscribe: mockParcelSubscribe,
+  },
+}));
+
 const mockSimpleGit = {
   raw: vi.fn().mockResolvedValue(undefined),
   branch: vi.fn().mockResolvedValue({ current: "main" }),
@@ -40,6 +60,7 @@ vi.mock("../../utils/git.js", () => ({
 
 vi.mock("../../utils/gitUtils.js", () => ({
   getGitDir: vi.fn().mockReturnValue("/test/worktree/.git"),
+  getGitCommonDir: mockGetGitCommonDir,
   clearGitDirCache: vi.fn(),
 }));
 
@@ -108,6 +129,17 @@ vi.mock("../../utils/gitFileWatcher.js", () => {
       }
       dispose() {}
     },
+  };
+});
+
+vi.mock("fs", async () => {
+  const actual = await vi.importActual<typeof import("fs")>("fs");
+  return {
+    ...actual,
+    existsSync: vi.fn((p: unknown) => {
+      if (typeof p === "string" && p.endsWith("/worktrees")) return true;
+      return (actual.existsSync as (p: unknown) => boolean)(p);
+    }),
   };
 });
 
@@ -282,6 +314,225 @@ describe("WorkspaceService external worktree removal", () => {
       expect(mockSendEvent).not.toHaveBeenCalledWith(
         expect.objectContaining({ type: "worktree-removed" })
       );
+    });
+  });
+
+  describe("topology watcher", () => {
+    beforeEach(async () => {
+      mockGetGitCommonDir.mockReturnValue("/test/root/.git");
+      parcelWatcherCallbacks.length = 0;
+      mockParcelSubscribe.mockClear();
+    });
+
+    it("starts watcher when metadata dir exists", async () => {
+      service["startTopologyWatcher"]();
+      // Wait for the async subscribe to resolve
+      await vi.waitFor(() => expect(mockParcelSubscribe).toHaveBeenCalled());
+      expect(mockParcelSubscribe).toHaveBeenCalledWith(
+        "/test/root/.git/worktrees",
+        expect.any(Function)
+      );
+    });
+
+    it("does not start watcher when already subscribed", async () => {
+      service["startTopologyWatcher"]();
+      await vi.waitFor(() => expect(mockParcelSubscribe).toHaveBeenCalledTimes(1));
+      service["startTopologyWatcher"]();
+      // Give time for a potential second async subscribe
+      await new Promise((r) => setTimeout(r, 10));
+      expect(mockParcelSubscribe).toHaveBeenCalledTimes(1);
+    });
+
+    it("skips watcher start when metadata dir is absent", () => {
+      mockGetGitCommonDir.mockReturnValue(null);
+      service["startTopologyWatcher"]();
+      expect(mockParcelSubscribe).not.toHaveBeenCalled();
+    });
+
+    it("stops watcher and clears pending state", async () => {
+      service["startTopologyWatcher"]();
+      await vi.waitFor(() => expect(mockParcelSubscribe).toHaveBeenCalledTimes(1));
+      service["topologyReconcilePending"] = true;
+
+      service["stopTopologyWatcher"]();
+
+      expect(service["topologyWatcherSubscription"].value).toBeUndefined();
+      expect(service["topologyReconcilePending"]).toBe(false);
+    });
+
+    it("fires reconciliation when watcher callback triggers after debounce", async () => {
+      vi.useFakeTimers();
+      const discoverSpy = vi
+        .spyOn(service as any, "discoverAndSyncWorktrees")
+        .mockResolvedValue(undefined);
+
+      service["startTopologyWatcher"]();
+      // Flush the async subscribe
+      await vi.runAllTimersAsync();
+      expect(parcelWatcherCallbacks.length).toBeGreaterThanOrEqual(1);
+
+      // Fire the watcher callback
+      parcelWatcherCallbacks[0]!(null, [
+        { type: "delete", path: "/test/root/.git/worktrees/phantom" },
+      ]);
+
+      // Should not have called discovery yet (debounce hasnt fired)
+      expect(discoverSpy).not.toHaveBeenCalled();
+
+      // Advance past the 300ms debounce
+      await vi.advanceTimersByTimeAsync(350);
+
+      expect(discoverSpy).toHaveBeenCalledTimes(1);
+      vi.useRealTimers();
+    });
+
+    it("coalesces burst events into a single reconciliation pass", async () => {
+      vi.useFakeTimers();
+      const discoverSpy = vi
+        .spyOn(service as any, "discoverAndSyncWorktrees")
+        .mockResolvedValue(undefined);
+
+      service["startTopologyWatcher"]();
+      await vi.runAllTimersAsync();
+
+      // Fire three events in quick succession
+      const cb = parcelWatcherCallbacks[0]!;
+      cb(null, [{ type: "delete", path: "/test/root/.git/worktrees/a" }]);
+      cb(null, [{ type: "delete", path: "/test/root/.git/worktrees/b" }]);
+      cb(null, [{ type: "delete", path: "/test/root/.git/worktrees/c" }]);
+
+      await vi.advanceTimersByTimeAsync(350);
+
+      // All three events coalesced into one reconciliation
+      expect(discoverSpy).toHaveBeenCalledTimes(1);
+      vi.useRealTimers();
+    });
+
+    it("respects suppression window during app-owned create", async () => {
+      vi.useFakeTimers();
+      const discoverSpy = vi
+        .spyOn(service as any, "discoverAndSyncWorktrees")
+        .mockResolvedValue(undefined);
+
+      // Simulate suppression set by createWorktree
+      service["topologyWatchSuppressUntil"] = Date.now() + 60000;
+
+      service["startTopologyWatcher"]();
+      await vi.runAllTimersAsync();
+
+      parcelWatcherCallbacks[0]!(null, [
+        { type: "create", path: "/test/root/.git/worktrees/new-wt" },
+      ]);
+      await vi.advanceTimersByTimeAsync(350);
+
+      // Suppression active — reconciliation should not fire
+      expect(discoverSpy).not.toHaveBeenCalled();
+
+      // Clear suppression
+      service["topologyWatchSuppressUntil"] = 0;
+      parcelWatcherCallbacks[0]!(null, [
+        { type: "create", path: "/test/root/.git/worktrees/another" },
+      ]);
+      await vi.advanceTimersByTimeAsync(350);
+
+      expect(discoverSpy).toHaveBeenCalledTimes(1);
+      vi.useRealTimers();
+    });
+
+    it("respects post-reconciliation cooldown", async () => {
+      vi.useFakeTimers();
+      const discoverSpy = vi
+        .spyOn(service as any, "discoverAndSyncWorktrees")
+        .mockResolvedValue(undefined);
+
+      service["startTopologyWatcher"]();
+      await vi.runAllTimersAsync();
+
+      // Fire first event — triggers reconciliation
+      parcelWatcherCallbacks[0]!(null, [
+        { type: "delete", path: "/test/root/.git/worktrees/wt-1" },
+      ]);
+      await vi.advanceTimersByTimeAsync(350);
+      expect(discoverSpy).toHaveBeenCalledTimes(1);
+
+      // Fire second event immediately — should be suppressed by cooldown
+      service["topologyReconcilePending"] = false; // simulate reconcile completion reset
+      parcelWatcherCallbacks[0]!(null, [
+        { type: "delete", path: "/test/root/.git/worktrees/wt-2" },
+      ]);
+      await vi.advanceTimersByTimeAsync(350);
+      // Still only 1 call because cooldown is active (set to Date.now() + 2000)
+      // The second event was swallowed by scheduleTopologyReconcile's cooldown check
+      expect(discoverSpy).toHaveBeenCalledTimes(1);
+
+      vi.useRealTimers();
+    });
+
+    it("does not process watcher events when polling is disabled", async () => {
+      vi.useFakeTimers();
+      const discoverSpy = vi
+        .spyOn(service as any, "discoverAndSyncWorktrees")
+        .mockResolvedValue(undefined);
+
+      service["setPollingEnabled"](false);
+
+      service["startTopologyWatcher"]();
+      await vi.runAllTimersAsync();
+
+      parcelWatcherCallbacks[0]!(null, [
+        { type: "delete", path: "/test/root/.git/worktrees/wt-1" },
+      ]);
+      await vi.advanceTimersByTimeAsync(350);
+
+      expect(discoverSpy).not.toHaveBeenCalled();
+      vi.useRealTimers();
+    });
+
+    it("auto-switches to main worktree when active worktree is externally removed", async () => {
+      // Register main + active worktrees
+      createAndRegisterMonitor({ id: "/test/main", path: "/test/main", isMainWorktree: true });
+      createAndRegisterMonitor({ id: "/test/active", path: "/test/active", isCurrent: true });
+      service["activeWorktreeId"] = "/test/active";
+
+      // Mock discoverAndSyncWorktrees to simulate removal of /test/active
+      const discoverSpy = vi
+        .spyOn(service as any, "discoverAndSyncWorktrees")
+        .mockImplementation(async () => {
+          // Remove the active monitor (simulating syncMonitors pruning it)
+          const monitor = service["monitors"].get("/test/active");
+          if (monitor) {
+            service["cleanupResourceActionState"]("/test/active");
+            monitor.stop();
+            service["monitors"].delete("/test/active");
+          }
+          service["activeWorktreeId"] = null;
+        });
+
+      await service["runTopologyReconcile"]();
+
+      // Active worktree should have been switched to main
+      expect(service["activeWorktreeId"]).toBe("/test/main");
+      discoverSpy.mockRestore();
+    });
+
+    it("does not switch when removal did not affect active worktree", async () => {
+      createAndRegisterMonitor({ id: "/test/main", path: "/test/main", isMainWorktree: true });
+      createAndRegisterMonitor({ id: "/test/other", path: "/test/other" });
+      service["activeWorktreeId"] = "/test/main";
+
+      // discoverAndSyncWorktrees removes /test/other but not /test/main
+      vi.spyOn(service as any, "discoverAndSyncWorktrees").mockImplementation(async () => {
+        const monitor = service["monitors"].get("/test/other");
+        if (monitor) {
+          monitor.stop();
+          service["monitors"].delete("/test/other");
+        }
+      });
+
+      await service["runTopologyReconcile"]();
+
+      // Active should still be main
+      expect(service["activeWorktreeId"]).toBe("/test/main");
     });
   });
 });

--- a/electron/workspace-host/__tests__/WorkspaceService.pauseResume.test.ts
+++ b/electron/workspace-host/__tests__/WorkspaceService.pauseResume.test.ts
@@ -39,6 +39,7 @@ vi.mock("../../utils/git.js", () => ({
 
 vi.mock("../../utils/gitUtils.js", () => ({
   getGitDir: vi.fn().mockReturnValue("/test/worktree/.git"),
+  getGitCommonDir: vi.fn().mockReturnValue(null),
   clearGitDirCache: vi.fn(),
 }));
 


### PR DESCRIPTION
## Summary

The sidebar wouldn't automatically update after a worktree was deleted externally — `git worktree remove` from the CLI, `rm -rf` followed by `git worktree prune`, or any other out-of-app deletion. The stale entry stuck around until the user clicked the global refresh button.

The `discoverAndSyncWorktrees` path from #6669 already prunes and lists correctly. The gap was that nothing automatically triggered that path. This adds a topology watcher using `@parcel/watcher` on `.git/worktrees/` to close that trigger gap.

## Changes

- **Topology watcher** watches `.git/worktrees/` with `@parcel/watcher` and triggers `discoverAndSyncWorktrees` on change.
- **Debounce (300ms) + cooldown (2s) + suppression pattern** so app-owned create/delete operations don't trigger redundant or self-inflicted reconciliation passes. Bursts of filesystem events coalesce into a single discovery pass via a serialized `PQueue`.
- **Auto-switch to main** when the active worktree disappears externally, matching the behavior of app-owned delete.
- **Does not fire on wake** — `pauseResume` test invariants are preserved (the watcher is gated on `pollingEnabled` and skips during suppression windows, so waking from pause doesn't trigger discovery).
- **Unit tests** cover watcher lifecycle (start/stop/idempotency), reconciliation triggering, suppression/cooldown gating, and auto-switch behavior.

Resolves #7706

## Testing

- Unit tests: `WorkspaceService.externalRemoval.test.ts` — watcher start/stop, reconciliation on external event, suppression during app-owned create/delete, auto-switch to main, pause/resume gate, generation-based lifecycle teardown.
- `WorkspaceService.createWorktree.test.ts` and `WorkspaceService.deleteWorktree.test.ts` — suppression calls injected, existing tests continue to pass.