### PR TITLE
refactor(github): collapse IPC handlers into thin service orchestrators

### DIFF
--- a/electron/ipc/handlers/__tests__/github.rateLimit.test.ts
+++ b/electron/ipc/handlers/__tests__/github.rateLimit.test.ts
@@ -116,6 +116,17 @@ vi.mock("../../../services/github/index.js", () => ({
   hasGitHubToken: gitHubServiceMock.hasGitHubToken,
   getGitHubConfigAsync: gitHubServiceMock.getGitHubConfigAsync,
   getProjectHealth: gitHubServiceMock.getProjectHealth,
+  buildEmptyProjectHealthData: vi.fn().mockReturnValue({
+    ciStatus: "none",
+    issueCount: 0,
+    prCount: 0,
+    latestRelease: null,
+    securityAlerts: { visible: false, count: 0 },
+    mergeVelocity: { mergedCounts: { 60: 0, 120: 0, 180: 0 } },
+    repoUrl: "",
+    hasRemote: false,
+    loading: false,
+  }),
   getFirstPageCache: vi.fn().mockResolvedValue(null),
   getRepoStatsComplete: vi.fn().mockResolvedValue({
     stats: { commitCount: 0, issueCount: null, prCount: null, loading: false },
@@ -259,6 +270,7 @@ describe("github handlers — rate limiting", () => {
     type HandlerSpec = {
       channel: string;
       maxCalls: number;
+      windowMs?: number;
       invoke: (handler: (...args: unknown[]) => Promise<unknown>) => Promise<unknown>;
     };
 
@@ -321,18 +333,31 @@ describe("github handlers — rate limiting", () => {
         maxCalls: 5,
         invoke: (h) => h({}, { cwd, issueNumber: 1, username: "octocat" }),
       },
+      // rate-limit details: 30/60s (quota-free endpoint, but we still gate the IPC)
+      {
+        channel: CHANNELS.GITHUB_GET_RATE_LIMIT_DETAILS,
+        maxCalls: 30,
+        windowMs: 60_000,
+        invoke: (h) => h({}),
+      },
+      // first-page cache: 10/10s
+      {
+        channel: CHANNELS.GITHUB_GET_FIRST_PAGE_CACHE,
+        maxCalls: 10,
+        invoke: (h) => h({}, cwd),
+      },
     ];
 
-    it("registers all 21 github channels", () => {
-      expect(specs).toHaveLength(21);
+    it("registers all 23 github channels", () => {
+      expect(specs).toHaveLength(23);
     });
 
     it.each(specs)(
-      "$channel calls checkRateLimit($channel, $maxCalls, 10_000)",
-      async ({ channel, maxCalls, invoke }) => {
+      "$channel calls checkRateLimit($channel, $maxCalls, $windowMs)",
+      async ({ channel, maxCalls, windowMs, invoke }) => {
         const handler = getInvokeHandler(channel);
         await invoke(handler);
-        expect(checkRateLimitMock).toHaveBeenCalledWith(channel, maxCalls, 10_000);
+        expect(checkRateLimitMock).toHaveBeenCalledWith(channel, maxCalls, windowMs ?? 10_000);
       }
     );
   });

--- a/electron/ipc/handlers/__tests__/github.rateLimit.test.ts
+++ b/electron/ipc/handlers/__tests__/github.rateLimit.test.ts
@@ -97,6 +97,30 @@ vi.mock("../../../services/github/index.js", () => ({
     resetState: vi.fn(),
     refresh: vi.fn().mockResolvedValue(undefined),
   },
+  fetchRateLimitDetails: vi.fn().mockResolvedValue(null),
+  setTokenAndSync: vi
+    .fn()
+    .mockResolvedValue({ valid: true, scopes: [], username: "user", avatarUrl: null }),
+  clearTokenAndSync: vi.fn().mockResolvedValue(undefined),
+  getRepoUrl: gitHubServiceMock.getRepoUrl,
+  buildGitHubSearchQuery: vi.fn().mockReturnValue("is:open bug"),
+  listIssues: gitHubServiceMock.listIssues,
+  listPullRequests: gitHubServiceMock.listPullRequests,
+  validateGitHubToken: gitHubServiceMock.validateGitHubToken,
+  assignIssue: gitHubServiceMock.assignIssue,
+  getIssueUrl: gitHubServiceMock.getIssueUrl,
+  getIssueTooltip: gitHubServiceMock.getIssueTooltip,
+  getPRTooltip: gitHubServiceMock.getPRTooltip,
+  getIssueByNumber: gitHubServiceMock.getIssueByNumber,
+  getPRByNumber: gitHubServiceMock.getPRByNumber,
+  hasGitHubToken: gitHubServiceMock.hasGitHubToken,
+  getGitHubConfigAsync: gitHubServiceMock.getGitHubConfigAsync,
+  getProjectHealth: gitHubServiceMock.getProjectHealth,
+  getFirstPageCache: vi.fn().mockResolvedValue(null),
+  getRepoStatsComplete: vi.fn().mockResolvedValue({
+    stats: { commitCount: 0, issueCount: null, prCount: null, loading: false },
+  }),
+  listGitHubRemotes: vi.fn().mockResolvedValue([]),
 }));
 
 vi.mock("../../../services/GitService.js", () => ({

--- a/electron/ipc/handlers/__tests__/github.searchQuery.test.ts
+++ b/electron/ipc/handlers/__tests__/github.searchQuery.test.ts
@@ -13,7 +13,7 @@ vi.mock("electron", () => ({
   },
 }));
 
-import { buildGitHubSearchQuery } from "../github.js";
+import { buildGitHubSearchQuery } from "../../../services/github/GitHubQueries.js";
 
 describe("buildGitHubSearchQuery", () => {
   // Issues

--- a/electron/ipc/handlers/github.ts
+++ b/electron/ipc/handlers/github.ts
@@ -15,120 +15,37 @@ import type {
   GitHubRateLimitDetails,
 } from "../../types/index.js";
 import {
-  GitHubAuth,
-  GITHUB_API_TIMEOUT_MS,
-  captureAuthMetadata,
   gitHubRateLimitService,
   gitHubTokenHealthService,
+  fetchRateLimitDetails,
+  setTokenAndSync,
+  clearTokenAndSync,
 } from "../../services/github/index.js";
-import { getWorkspaceClient } from "../../services/WorkspaceClient.js";
 import { formatErrorMessage } from "../../../shared/utils/errorMessage.js";
-
-export function buildGitHubSearchQuery(
-  searchText: string | undefined,
-  state: string | undefined,
-  resourceType: "issue" | "pr"
-): string {
-  const parts: string[] = [];
-
-  const defaultState = "open";
-  const effectiveState = state || defaultState;
-
-  if (effectiveState !== "open") {
-    if (resourceType === "pr" && effectiveState === "merged") {
-      parts.push("is:merged");
-    } else if (effectiveState === "closed") {
-      parts.push("is:closed");
-    } else if (effectiveState === "all") {
-      // No state qualifier for "all"
-    }
-  }
-
-  if (searchText?.trim()) {
-    parts.push(searchText.trim());
-  }
-
-  // If state is "open" and no search text, return empty to preserve bare URL
-  if (effectiveState === "open" && !searchText?.trim()) {
-    return "";
-  }
-
-  // If we have search text but state is open, add is:open so GitHub doesn't default differently
-  if (effectiveState === "open" && searchText?.trim()) {
-    parts.unshift("is:open");
-  }
-
-  return parts.join(" ");
-}
 
 export function registerGithubHandlers(_deps: HandlerDependencies): () => void {
   const handlers: Array<() => void> = [];
 
-  // Main-process transport: every time the main-process rate-limit singleton
-  // changes state (either from a local fetch observation or a forwarded
-  // utility-process observation via WorkspaceClient.routeHostEvent), push
-  // the new state to every renderer window.
+  // Main-process transport: push rate-limit state changes to every renderer.
   const unsubscribeRateLimit = gitHubRateLimitService.onStateChange((state) => {
     broadcastToRenderer(CHANNELS.GITHUB_RATE_LIMIT_CHANGED, state);
   });
   handlers.push(unsubscribeRateLimit);
 
-  // Main-process transport: push token-health state changes to every
-  // renderer so a "Reconnect to GitHub" banner can surface when the
-  // background probe detects a dead token.
+  // Main-process transport: push token-health state changes to every renderer.
   const unsubscribeTokenHealth = gitHubTokenHealthService.onStateChange((state) => {
     broadcastToRenderer(CHANNELS.GITHUB_TOKEN_HEALTH_CHANGED, state);
   });
   handlers.push(unsubscribeTokenHealth);
 
-  // Invoke handler: renderer subscribers call this on mount to replay the
-  // current state — guarantees a second window, or a window that mounts
-  // after the initial probe completed, can surface the banner without
-  // waiting for the next state transition (which might never come while
-  // the token stays unhealthy).
+  // Replay current token-health state on mount so a second window can surface
+  // the banner without waiting for the next probe.
   const handleGetTokenHealth = async () => gitHubTokenHealthService.getState();
   handlers.push(typedHandle(CHANNELS.GITHUB_GET_TOKEN_HEALTH, handleGetTokenHealth));
 
-  // GitHub's `/rate_limit` endpoint is itself quota-free, so the renderer
-  // can call this on demand (e.g. opening the rate-limit tooltip) without
-  // worrying about feedback loops with the very limit it's reporting on.
   const handleGetRateLimitDetails = async (): Promise<GitHubRateLimitDetails | null> => {
     checkRateLimit(CHANNELS.GITHUB_GET_RATE_LIMIT_DETAILS, 30, 60_000);
-    const token = GitHubAuth.getToken();
-    if (!token) return null;
-    try {
-      const response = await fetch("https://api.github.com/rate_limit", {
-        headers: {
-          Authorization: `Bearer ${token}`,
-          Accept: "application/vnd.github.v3+json",
-        },
-        signal: AbortSignal.timeout(GITHUB_API_TIMEOUT_MS),
-      });
-      if (!response.ok) return null;
-      captureAuthMetadata(response.headers);
-      const body = (await response.json()) as {
-        resources?: Record<
-          string,
-          { limit: number; used: number; remaining: number; reset: number } | undefined
-        >;
-      };
-      const resources = body.resources;
-      if (!resources?.core || !resources.graphql || !resources.search) return null;
-      const toBucket = (b: { limit: number; used: number; remaining: number; reset: number }) => ({
-        limit: b.limit,
-        used: b.used,
-        remaining: b.remaining,
-        resetAt: b.reset * 1000,
-      });
-      return {
-        core: toBucket(resources.core),
-        graphql: toBucket(resources.graphql),
-        search: toBucket(resources.search),
-        fetchedAt: Date.now(),
-      };
-    } catch {
-      return null;
-    }
+    return fetchRateLimitDetails();
   };
   handlers.push(typedHandle(CHANNELS.GITHUB_GET_RATE_LIMIT_DETAILS, handleGetRateLimitDetails));
 
@@ -144,153 +61,34 @@ export function registerGithubHandlers(_deps: HandlerDependencies): () => void {
       throw new Error("Working directory must be an absolute path");
     }
 
-    const { getRepoStatsAndPage } = await import("../../services/GitHubService.js");
-    const { getCommitCount } = await import("../../utils/git.js");
+    const { getRepoStatsComplete } = await import("../../services/github/index.js");
+    const result = await getRepoStatsComplete(cwd, bypassCache);
 
-    try {
+    if (result.issues && result.prs && result.source === "network" && !result.stale) {
       const resolved = path.resolve(cwd);
-      const stat = await fs.stat(resolved);
-      if (!stat.isDirectory()) {
-        return {
-          commitCount: 0,
-          issueCount: null,
-          prCount: null,
-          loading: false,
-          ghError: "Path is not a directory",
-        };
-      }
-
-      // Combined query: counts + first page of open issues + open PRs in one
-      // round-trip. The first-page payload is broadcast to renderers below so
-      // their `githubResourceCache` gets primed for the (open, created)
-      // default-filter cache key — meaning the dropdown opens against hot
-      // cache with no spinner.
-      const statsResult = await getRepoStatsAndPage(resolved, bypassCache);
-
-      const commitCount = await getCommitCount(resolved).catch(() => 0);
-
-      const rateLimitState = gitHubRateLimitService.getState();
-
-      const repositoryStats: RepositoryStats = {
-        commitCount,
-        issueCount: statsResult.stats?.issueCount ?? null,
-        prCount: statsResult.stats?.prCount ?? null,
-        loading: false,
-        ghError: statsResult.error,
-        stale: statsResult.stats?.stale,
-        lastUpdated: statsResult.stats?.lastUpdated,
-        rateLimitResetAt:
-          rateLimitState.blocked && rateLimitState.resetAt ? rateLimitState.resetAt : undefined,
-        rateLimitKind: rateLimitState.blocked ? (rateLimitState.kind ?? undefined) : undefined,
+      const payload: RepoStatsAndPagePayload = {
+        projectPath: resolved,
+        stats: result.stats,
+        issues: result.issues,
+        prs: result.prs,
+        fetchedAt: Date.now(),
       };
-
-      // Broadcast only after a real network fetch (`source === "network"`).
-      // Skipping the in-memory short-circuit prevents extending the renderer
-      // cache TTL with a fresh wall-clock timestamp on data the backend
-      // already considered cached — the renderer's TtlCache.set() resets
-      // expiry from write time, so a re-broadcast of cache-extended data
-      // would mask staleness.
-      if (
-        statsResult.issues &&
-        statsResult.prs &&
-        statsResult.source === "network" &&
-        !statsResult.stats?.stale
-      ) {
-        const payload: RepoStatsAndPagePayload = {
-          projectPath: resolved,
-          stats: repositoryStats,
-          issues: statsResult.issues,
-          prs: statsResult.prs,
-          fetchedAt: Date.now(),
-        };
-        broadcastToRenderer(CHANNELS.GITHUB_REPO_STATS_AND_PAGE_UPDATED, payload);
-      }
-
-      return repositoryStats;
-    } catch (err) {
-      const message = formatErrorMessage(err, "Failed to fetch GitHub repo stats");
-      return {
-        commitCount: 0,
-        issueCount: null,
-        prCount: null,
-        loading: false,
-        ghError: message,
-      };
+      broadcastToRenderer(CHANNELS.GITHUB_REPO_STATS_AND_PAGE_UPDATED, payload);
     }
+
+    return result.stats;
   };
   handlers.push(typedHandle(CHANNELS.GITHUB_GET_REPO_STATS, handleGitHubGetRepoStats));
 
-  // Cold-start hydration: returns the disk-persisted first page for a project
-  // (open issues + open PRs in the default-created sort) so the renderer can
-  // seed `githubResourceCache` BEFORE the first poll completes. Combined with
-  // the broadcast push, this makes the very first dropdown click after app
-  // launch resolve against real data instead of a skeleton.
   const handleGitHubGetFirstPageCache = async (
     cwd: string
   ): Promise<GitHubFirstPageCachePayload | null> => {
-    // Rate-limit at the same shape as `getRepoStats` — the renderer only
-    // calls this once per hook mount, but that includes every project view
-    // and we want a hard ceiling against accidental call-loops.
     checkRateLimit(CHANNELS.GITHUB_GET_FIRST_PAGE_CACHE, 10, 10_000);
     if (typeof cwd !== "string" || !cwd) return null;
     if (!path.isAbsolute(cwd)) return null;
 
-    try {
-      const resolved = path.resolve(cwd);
-      const stat = await fs.stat(resolved);
-      if (!stat.isDirectory()) return null;
-
-      const { GitHubFirstPageCache } = await import("../../services/GitHubFirstPageCache.js");
-      const { GitHubStatsCache } = await import("../../services/GitHubStatsCache.js");
-      const { getRepoContext } = await import("../../services/GitHubService.js");
-      const context = await getRepoContext(resolved);
-      if (!context) return null;
-      const repoKey = `${context.owner}/${context.repo}`;
-      const entry = GitHubFirstPageCache.getInstance().get(repoKey);
-      const cachedStats = GitHubStatsCache.getInstance().getForBootstrap(repoKey);
-
-      // Neither cache has data — let the network poll populate everything.
-      if (!entry && !cachedStats) return null;
-
-      // First-page items present: attach bootstrap stats if available.
-      if (entry) {
-        const payload: GitHubFirstPageCachePayload = {
-          projectPath: resolved,
-          issues: entry.issues,
-          prs: entry.prs,
-          lastUpdated: entry.lastUpdated,
-        };
-        if (cachedStats) {
-          payload.stats = {
-            issueCount: cachedStats.issueCount,
-            prCount: cachedStats.prCount,
-            lastUpdated: cachedStats.lastUpdated,
-          };
-        }
-        return payload;
-      }
-
-      // Stats-only payload: first-page cache expired but stats are still within
-      // the 60-minute bootstrap TTL. Return empty pages so the hydration effect
-      // can seed toolbar counts without damaging the renderer items cache.
-      if (!cachedStats) return null;
-      return {
-        projectPath: resolved,
-        issues: { items: [], endCursor: null, hasNextPage: false },
-        prs: { items: [], endCursor: null, hasNextPage: false },
-        lastUpdated: cachedStats.lastUpdated,
-        stats: {
-          issueCount: cachedStats.issueCount,
-          prCount: cachedStats.prCount,
-          lastUpdated: cachedStats.lastUpdated,
-        },
-      };
-    } catch {
-      // Disk-cache reads are best-effort: a missing cache file, malformed
-      // JSON, or a transient repo-context lookup failure should not surface
-      // as a renderer error — the network poll fallback will populate the UI.
-      return null;
-    }
+    const { getFirstPageCache } = await import("../../services/github/index.js");
+    return getFirstPageCache(cwd);
   };
   handlers.push(typedHandle(CHANNELS.GITHUB_GET_FIRST_PAGE_CACHE, handleGitHubGetFirstPageCache));
 
@@ -306,7 +104,7 @@ export function registerGithubHandlers(_deps: HandlerDependencies): () => void {
       throw new Error("Working directory must be an absolute path");
     }
 
-    const { getProjectHealth } = await import("../../services/GitHubService.js");
+    const { getProjectHealth } = await import("../../services/github/index.js");
 
     try {
       const resolved = path.resolve(cwd);
@@ -329,12 +127,7 @@ export function registerGithubHandlers(_deps: HandlerDependencies): () => void {
       const result = await getProjectHealth(resolved, bypassCache);
 
       if (result.health) {
-        return {
-          ...result.health,
-          hasRemote: true,
-          loading: false,
-          error: result.error,
-        };
+        return { ...result.health, hasRemote: true, loading: false, error: result.error };
       }
 
       return {
@@ -375,7 +168,7 @@ export function registerGithubHandlers(_deps: HandlerDependencies): () => void {
     if (!path.isAbsolute(cwd)) {
       throw new Error("Working directory must be an absolute path");
     }
-    const { getRepoUrl } = await import("../../services/GitHubService.js");
+    const { getRepoUrl, buildGitHubSearchQuery } = await import("../../services/github/index.js");
     const repoUrl = await getRepoUrl(cwd);
     if (!repoUrl) {
       throw new Error("Not a GitHub repository");
@@ -394,7 +187,7 @@ export function registerGithubHandlers(_deps: HandlerDependencies): () => void {
     if (!path.isAbsolute(cwd)) {
       throw new Error("Working directory must be an absolute path");
     }
-    const { getRepoUrl } = await import("../../services/GitHubService.js");
+    const { getRepoUrl, buildGitHubSearchQuery } = await import("../../services/github/index.js");
     const repoUrl = await getRepoUrl(cwd);
     if (!repoUrl) {
       throw new Error("Not a GitHub repository");
@@ -416,7 +209,7 @@ export function registerGithubHandlers(_deps: HandlerDependencies): () => void {
     if (branch !== undefined && (typeof branch !== "string" || !branch.trim())) {
       throw new Error("Invalid branch name");
     }
-    const { getRepoUrl } = await import("../../services/GitHubService.js");
+    const { getRepoUrl } = await import("../../services/github/index.js");
     const repoUrl = await getRepoUrl(cwd);
     if (!repoUrl) {
       throw new Error("Not a GitHub repository");
@@ -444,7 +237,7 @@ export function registerGithubHandlers(_deps: HandlerDependencies): () => void {
     ) {
       throw new Error("Invalid issue number");
     }
-    const { getIssueUrl } = await import("../../services/GitHubService.js");
+    const { getIssueUrl } = await import("../../services/github/index.js");
     const issueUrl = await getIssueUrl(payload.cwd, payload.issueNumber);
     if (!issueUrl) {
       throw new Error("Not a GitHub repository");
@@ -476,7 +269,7 @@ export function registerGithubHandlers(_deps: HandlerDependencies): () => void {
 
   const handleGitHubCheckCli = async (): Promise<GitHubCliStatus> => {
     checkRateLimit(CHANNELS.GITHUB_CHECK_CLI, 10, 10_000);
-    const { hasGitHubToken } = await import("../../services/GitHubService.js");
+    const { hasGitHubToken } = await import("../../services/github/index.js");
     if (hasGitHubToken()) {
       return { available: true };
     }
@@ -486,7 +279,7 @@ export function registerGithubHandlers(_deps: HandlerDependencies): () => void {
 
   const handleGitHubGetConfig = async (): Promise<GitHubTokenConfig> => {
     checkRateLimit(CHANNELS.GITHUB_GET_CONFIG, 10, 10_000);
-    const { getGitHubConfigAsync } = await import("../../services/GitHubService.js");
+    const { getGitHubConfigAsync } = await import("../../services/github/index.js");
     return getGitHubConfigAsync();
   };
   handlers.push(typedHandle(CHANNELS.GITHUB_GET_CONFIG, handleGitHubGetConfig));
@@ -496,57 +289,13 @@ export function registerGithubHandlers(_deps: HandlerDependencies): () => void {
     if (typeof token !== "string" || !token.trim()) {
       return { valid: false, scopes: [], error: "Token is required" };
     }
-    const trimmed = token.trim();
-
-    const { validateGitHubToken, setGitHubToken } = await import("../../services/GitHubService.js");
-    const { GitHubAuth } = await import("../../services/github/index.js");
-
-    const validation = await validateGitHubToken(trimmed);
-
-    if (validation.valid) {
-      setGitHubToken(trimmed);
-      const versionAfterSet = GitHubAuth.getTokenVersion();
-
-      if (validation.username) {
-        GitHubAuth.setValidatedUserInfo(
-          validation.username,
-          validation.avatarUrl,
-          validation.scopes,
-          versionAfterSet
-        );
-      }
-
-      try {
-        const workspaceClient = getWorkspaceClient();
-        workspaceClient.updateGitHubToken(trimmed);
-      } catch {
-        // WorkspaceClient may not be initialized yet
-      }
-
-      // Reset any lingering health state so a previously-surfaced
-      // "Reconnect" banner is cleared before the next probe runs.
-      gitHubTokenHealthService.resetState();
-      void gitHubTokenHealthService.refresh({ force: true });
-    }
-
-    return validation;
+    return setTokenAndSync(token);
   };
   handlers.push(typedHandle(CHANNELS.GITHUB_SET_TOKEN, handleGitHubSetToken));
 
   const handleGitHubClearToken = async (): Promise<void> => {
     checkRateLimit(CHANNELS.GITHUB_CLEAR_TOKEN, 5, 10_000);
-    const { clearGitHubToken } = await import("../../services/GitHubService.js");
-    clearGitHubToken();
-
-    try {
-      const workspaceClient = getWorkspaceClient();
-      workspaceClient.updateGitHubToken(null);
-    } catch {
-      // WorkspaceClient may not be initialized yet
-    }
-
-    // Token removed: drop any lingering health state and banner.
-    gitHubTokenHealthService.resetState();
+    await clearTokenAndSync();
   };
   handlers.push(typedHandle(CHANNELS.GITHUB_CLEAR_TOKEN, handleGitHubClearToken));
 
@@ -555,8 +304,7 @@ export function registerGithubHandlers(_deps: HandlerDependencies): () => void {
     if (typeof token !== "string" || !token.trim()) {
       return { valid: false, scopes: [], error: "Token is required" };
     }
-
-    const { validateGitHubToken } = await import("../../services/GitHubService.js");
+    const { validateGitHubToken } = await import("../../services/github/index.js");
     return validateGitHubToken(token.trim());
   };
   handlers.push(typedHandle(CHANNELS.GITHUB_VALIDATE_TOKEN, handleGitHubValidateToken));
@@ -576,8 +324,7 @@ export function registerGithubHandlers(_deps: HandlerDependencies): () => void {
     if (!path.isAbsolute(options.cwd)) {
       throw new Error("Working directory must be an absolute path");
     }
-
-    const { listIssues } = await import("../../services/GitHubService.js");
+    const { listIssues } = await import("../../services/github/index.js");
     return listIssues(options);
   };
   handlers.push(typedHandle(CHANNELS.GITHUB_LIST_ISSUES, handleGitHubListIssues));
@@ -597,8 +344,7 @@ export function registerGithubHandlers(_deps: HandlerDependencies): () => void {
     if (!path.isAbsolute(options.cwd)) {
       throw new Error("Working directory must be an absolute path");
     }
-
-    const { listPullRequests } = await import("../../services/GitHubService.js");
+    const { listPullRequests } = await import("../../services/github/index.js");
     return listPullRequests(options);
   };
   handlers.push(typedHandle(CHANNELS.GITHUB_LIST_PRS, handleGitHubListPRs));
@@ -629,56 +375,39 @@ export function registerGithubHandlers(_deps: HandlerDependencies): () => void {
     if (typeof payload.username !== "string" || !trimmedUsername) {
       throw new Error("Invalid username");
     }
-
-    const { assignIssue } = await import("../../services/GitHubService.js");
+    const { assignIssue } = await import("../../services/github/index.js");
     await assignIssue(payload.cwd.trim(), payload.issueNumber, trimmedUsername);
   };
   handlers.push(typedHandle(CHANNELS.GITHUB_ASSIGN_ISSUE, handleGitHubAssignIssue));
 
   const handleGitHubGetIssueTooltip = async (payload: { cwd: string; issueNumber: number }) => {
     checkRateLimit(CHANNELS.GITHUB_GET_ISSUE_TOOLTIP, 20, 10_000);
-    if (!payload || typeof payload !== "object") {
-      return null;
-    }
-    if (typeof payload.cwd !== "string" || !payload.cwd.trim()) {
-      return null;
-    }
-    if (!path.isAbsolute(payload.cwd)) {
-      return null;
-    }
+    if (!payload || typeof payload !== "object") return null;
+    if (typeof payload.cwd !== "string" || !payload.cwd.trim()) return null;
+    if (!path.isAbsolute(payload.cwd)) return null;
     if (
       typeof payload.issueNumber !== "number" ||
       !Number.isInteger(payload.issueNumber) ||
       payload.issueNumber <= 0
-    ) {
+    )
       return null;
-    }
-
-    const { getIssueTooltip } = await import("../../services/GitHubService.js");
+    const { getIssueTooltip } = await import("../../services/github/index.js");
     return getIssueTooltip(payload.cwd.trim(), payload.issueNumber);
   };
   handlers.push(typedHandle(CHANNELS.GITHUB_GET_ISSUE_TOOLTIP, handleGitHubGetIssueTooltip));
 
   const handleGitHubGetPRTooltip = async (payload: { cwd: string; prNumber: number }) => {
     checkRateLimit(CHANNELS.GITHUB_GET_PR_TOOLTIP, 20, 10_000);
-    if (!payload || typeof payload !== "object") {
-      return null;
-    }
-    if (typeof payload.cwd !== "string" || !payload.cwd.trim()) {
-      return null;
-    }
-    if (!path.isAbsolute(payload.cwd)) {
-      return null;
-    }
+    if (!payload || typeof payload !== "object") return null;
+    if (typeof payload.cwd !== "string" || !payload.cwd.trim()) return null;
+    if (!path.isAbsolute(payload.cwd)) return null;
     if (
       typeof payload.prNumber !== "number" ||
       !Number.isInteger(payload.prNumber) ||
       payload.prNumber <= 0
-    ) {
+    )
       return null;
-    }
-
-    const { getPRTooltip } = await import("../../services/GitHubService.js");
+    const { getPRTooltip } = await import("../../services/github/index.js");
     return getPRTooltip(payload.cwd.trim(), payload.prNumber);
   };
   handlers.push(typedHandle(CHANNELS.GITHUB_GET_PR_TOOLTIP, handleGitHubGetPRTooltip));
@@ -688,72 +417,48 @@ export function registerGithubHandlers(_deps: HandlerDependencies): () => void {
     issueNumber: number;
   }): Promise<string | null> => {
     checkRateLimit(CHANNELS.GITHUB_GET_ISSUE_URL, 10, 10_000);
-    if (!payload || typeof payload !== "object") {
-      return null;
-    }
-    if (typeof payload.cwd !== "string" || !payload.cwd.trim()) {
-      return null;
-    }
-    if (!path.isAbsolute(payload.cwd)) {
-      return null;
-    }
+    if (!payload || typeof payload !== "object") return null;
+    if (typeof payload.cwd !== "string" || !payload.cwd.trim()) return null;
+    if (!path.isAbsolute(payload.cwd)) return null;
     if (
       typeof payload.issueNumber !== "number" ||
       !Number.isInteger(payload.issueNumber) ||
       payload.issueNumber <= 0
-    ) {
+    )
       return null;
-    }
-
-    const { getIssueUrl } = await import("../../services/GitHubService.js");
+    const { getIssueUrl } = await import("../../services/github/index.js");
     return getIssueUrl(payload.cwd.trim(), payload.issueNumber);
   };
   handlers.push(typedHandle(CHANNELS.GITHUB_GET_ISSUE_URL, handleGitHubGetIssueUrl));
 
   const handleGitHubGetIssueByNumber = async (payload: { cwd: string; issueNumber: number }) => {
     checkRateLimit(CHANNELS.GITHUB_GET_ISSUE_BY_NUMBER, 25, 10_000);
-    if (!payload || typeof payload !== "object") {
-      return null;
-    }
-    if (typeof payload.cwd !== "string" || !payload.cwd.trim()) {
-      return null;
-    }
-    if (!path.isAbsolute(payload.cwd)) {
-      return null;
-    }
+    if (!payload || typeof payload !== "object") return null;
+    if (typeof payload.cwd !== "string" || !payload.cwd.trim()) return null;
+    if (!path.isAbsolute(payload.cwd)) return null;
     if (
       typeof payload.issueNumber !== "number" ||
       !Number.isInteger(payload.issueNumber) ||
       payload.issueNumber <= 0
-    ) {
+    )
       return null;
-    }
-
-    const { getIssueByNumber } = await import("../../services/GitHubService.js");
+    const { getIssueByNumber } = await import("../../services/github/index.js");
     return getIssueByNumber(payload.cwd.trim(), payload.issueNumber);
   };
   handlers.push(typedHandle(CHANNELS.GITHUB_GET_ISSUE_BY_NUMBER, handleGitHubGetIssueByNumber));
 
   const handleGitHubGetPRByNumber = async (payload: { cwd: string; prNumber: number }) => {
     checkRateLimit(CHANNELS.GITHUB_GET_PR_BY_NUMBER, 25, 10_000);
-    if (!payload || typeof payload !== "object") {
-      return null;
-    }
-    if (typeof payload.cwd !== "string" || !payload.cwd.trim()) {
-      return null;
-    }
-    if (!path.isAbsolute(payload.cwd)) {
-      return null;
-    }
+    if (!payload || typeof payload !== "object") return null;
+    if (typeof payload.cwd !== "string" || !payload.cwd.trim()) return null;
+    if (!path.isAbsolute(payload.cwd)) return null;
     if (
       typeof payload.prNumber !== "number" ||
       !Number.isInteger(payload.prNumber) ||
       payload.prNumber <= 0
-    ) {
+    )
       return null;
-    }
-
-    const { getPRByNumber } = await import("../../services/GitHubService.js");
+    const { getPRByNumber } = await import("../../services/github/index.js");
     return getPRByNumber(payload.cwd.trim(), payload.prNumber);
   };
   handlers.push(typedHandle(CHANNELS.GITHUB_GET_PR_BY_NUMBER, handleGitHubGetPRByNumber));
@@ -794,25 +499,8 @@ export function registerGithubHandlers(_deps: HandlerDependencies): () => void {
     if (!path.isAbsolute(cwd)) {
       throw new Error("Working directory must be an absolute path");
     }
-
-    const { GitService } = await import("../../services/GitService.js");
-    const { parseGitHubRepoUrl } = await import("../../services/GitHubService.js");
-    const gitService = new GitService(cwd);
-    const remotes = await gitService.listRemotes(cwd);
-
-    const result = remotes.map((r) => ({
-      name: r.name,
-      fetchUrl: r.fetchUrl,
-      parsedRepo: parseGitHubRepoUrl(r.fetchUrl),
-    }));
-
-    result.sort((a, b) => {
-      if (a.name === "origin") return -1;
-      if (b.name === "origin") return 1;
-      return a.name.localeCompare(b.name);
-    });
-
-    return result;
+    const { listGitHubRemotes } = await import("../../services/github/index.js");
+    return listGitHubRemotes(cwd);
   };
   handlers.push(typedHandle(CHANNELS.GITHUB_LIST_REMOTES, handleGitHubListRemotes));
 

--- a/electron/ipc/handlers/github.ts
+++ b/electron/ipc/handlers/github.ts
@@ -104,24 +104,14 @@ export function registerGithubHandlers(_deps: HandlerDependencies): () => void {
       throw new Error("Working directory must be an absolute path");
     }
 
-    const { getProjectHealth } = await import("../../services/github/index.js");
+    const { getProjectHealth, buildEmptyProjectHealthData } =
+      await import("../../services/github/index.js");
 
     try {
       const resolved = path.resolve(cwd);
       const stat = await fs.stat(resolved);
       if (!stat.isDirectory()) {
-        return {
-          ciStatus: "none",
-          issueCount: 0,
-          prCount: 0,
-          latestRelease: null,
-          securityAlerts: { visible: false, count: 0 },
-          mergeVelocity: { mergedCounts: { 60: 0, 120: 0, 180: 0 } },
-          repoUrl: "",
-          hasRemote: false,
-          loading: false,
-          error: "Path is not a directory",
-        };
+        return buildEmptyProjectHealthData({ error: "Path is not a directory" });
       }
 
       const result = await getProjectHealth(resolved, bypassCache);
@@ -130,32 +120,13 @@ export function registerGithubHandlers(_deps: HandlerDependencies): () => void {
         return { ...result.health, hasRemote: true, loading: false, error: result.error };
       }
 
-      return {
-        ciStatus: "none",
-        issueCount: 0,
-        prCount: 0,
-        latestRelease: null,
-        securityAlerts: { visible: false, count: 0 },
-        mergeVelocity: { mergedCounts: { 60: 0, 120: 0, 180: 0 } },
-        repoUrl: "",
-        hasRemote: result.error !== "Not a GitHub repository",
-        loading: false,
+      return buildEmptyProjectHealthData({
         error: result.error,
-      };
+        hasRemote: result.error !== "Not a GitHub repository",
+      });
     } catch (err) {
       const message = formatErrorMessage(err, "Failed to fetch GitHub project health");
-      return {
-        ciStatus: "none",
-        issueCount: 0,
-        prCount: 0,
-        latestRelease: null,
-        securityAlerts: { visible: false, count: 0 },
-        mergeVelocity: { mergedCounts: { 60: 0, 120: 0, 180: 0 } },
-        repoUrl: "",
-        hasRemote: false,
-        loading: false,
-        error: message,
-      };
+      return buildEmptyProjectHealthData({ error: message });
     }
   };
   handlers.push(typedHandle(CHANNELS.GITHUB_GET_PROJECT_HEALTH, handleGitHubGetProjectHealth));

--- a/electron/services/github/GitHubHealth.ts
+++ b/electron/services/github/GitHubHealth.ts
@@ -6,6 +6,24 @@ import { rateLimitMessage, parseGitHubError } from "./GitHubErrors.js";
 import { getRepoContext, isRepoNotFoundError } from "./GitHubRepoContext.js";
 import { repoContextCache, projectHealthCache } from "./GitHubCaches.js";
 import type { CIStatus, ProjectHealth, ProjectHealthResult } from "./types.js";
+import type { ProjectHealthData } from "../../types/index.js";
+
+export function buildEmptyProjectHealthData(
+  opts: { error?: string; hasRemote?: boolean } = {}
+): ProjectHealthData {
+  return {
+    ciStatus: "none",
+    issueCount: 0,
+    prCount: 0,
+    latestRelease: null,
+    securityAlerts: { visible: false, count: 0 },
+    mergeVelocity: { mergedCounts: { 60: 0, 120: 0, 180: 0 } },
+    repoUrl: "",
+    hasRemote: opts.hasRemote ?? false,
+    loading: false,
+    error: opts.error,
+  };
+}
 
 function parseCIStatus(statusCheckRollup: { state?: string } | null | undefined): CIStatus {
   if (!statusCheckRollup) return "none";

--- a/electron/services/github/GitHubQueries.ts
+++ b/electron/services/github/GitHubQueries.ts
@@ -469,6 +469,41 @@ export const GET_PR_QUERY = `
   }
 `;
 
+export function buildGitHubSearchQuery(
+  searchText: string | undefined,
+  state: string | undefined,
+  resourceType: "issue" | "pr"
+): string {
+  const parts: string[] = [];
+
+  const defaultState = "open";
+  const effectiveState = state || defaultState;
+
+  if (effectiveState !== "open") {
+    if (resourceType === "pr" && effectiveState === "merged") {
+      parts.push("is:merged");
+    } else if (effectiveState === "closed") {
+      parts.push("is:closed");
+    } else if (effectiveState === "all") {
+      // No state qualifier for "all"
+    }
+  }
+
+  if (searchText?.trim()) {
+    parts.push(searchText.trim());
+  }
+
+  if (effectiveState === "open" && !searchText?.trim()) {
+    return "";
+  }
+
+  if (effectiveState === "open" && searchText?.trim()) {
+    parts.unshift("is:open");
+  }
+
+  return parts.join(" ");
+}
+
 function escapeGraphQLString(value: string): string {
   return JSON.stringify(value).slice(1, -1);
 }

--- a/electron/services/github/GitHubRateLimitApi.ts
+++ b/electron/services/github/GitHubRateLimitApi.ts
@@ -1,0 +1,46 @@
+import { GitHubAuth, GITHUB_API_TIMEOUT_MS, captureAuthMetadata } from "./GitHubAuth.js";
+import { PRIMARY_RESET_BUFFER_MS } from "./GitHubRateLimitService.js";
+import type { GitHubRateLimitDetails } from "../../types/index.js";
+
+export async function fetchRateLimitDetails(): Promise<GitHubRateLimitDetails | null> {
+  const token = GitHubAuth.getToken();
+  if (!token) return null;
+
+  try {
+    const response = await fetch("https://api.github.com/rate_limit", {
+      headers: {
+        Authorization: `Bearer ${token}`,
+        Accept: "application/vnd.github.v3+json",
+      },
+      signal: AbortSignal.timeout(GITHUB_API_TIMEOUT_MS),
+    });
+    if (!response.ok) return null;
+
+    captureAuthMetadata(response.headers);
+
+    const body = (await response.json()) as {
+      resources?: Record<
+        string,
+        { limit: number; used: number; remaining: number; reset: number } | undefined
+      >;
+    };
+    const resources = body.resources;
+    if (!resources?.core || !resources.graphql || !resources.search) return null;
+
+    const toBucket = (b: { limit: number; used: number; remaining: number; reset: number }) => ({
+      limit: b.limit,
+      used: b.used,
+      remaining: b.remaining,
+      resetAt: b.reset * 1000 + PRIMARY_RESET_BUFFER_MS,
+    });
+
+    return {
+      core: toBucket(resources.core),
+      graphql: toBucket(resources.graphql),
+      search: toBucket(resources.search),
+      fetchedAt: Date.now(),
+    };
+  } catch {
+    return null;
+  }
+}

--- a/electron/services/github/GitHubRateLimitApi.ts
+++ b/electron/services/github/GitHubRateLimitApi.ts
@@ -27,6 +27,22 @@ export async function fetchRateLimitDetails(): Promise<GitHubRateLimitDetails | 
     const resources = body.resources;
     if (!resources?.core || !resources.graphql || !resources.search) return null;
 
+    const isValidBucket = (
+      b: unknown
+    ): b is { limit: number; used: number; remaining: number; reset: number } => {
+      if (!b || typeof b !== "object") return false;
+      const r = b as Record<string, unknown>;
+      return [r.limit, r.used, r.remaining, r.reset].every(
+        (v) => typeof v === "number" && Number.isFinite(v)
+      );
+    };
+    if (
+      !isValidBucket(resources.core) ||
+      !isValidBucket(resources.graphql) ||
+      !isValidBucket(resources.search)
+    )
+      return null;
+
     const toBucket = (b: { limit: number; used: number; remaining: number; reset: number }) => ({
       limit: b.limit,
       used: b.used,

--- a/electron/services/github/GitHubRateLimitService.ts
+++ b/electron/services/github/GitHubRateLimitService.ts
@@ -8,7 +8,7 @@ import { formatErrorMessage } from "../../../shared/utils/errorMessage.js";
 // Buffer applied to GitHub's `x-ratelimit-reset` to absorb clock skew between
 // the local host and api.github.com, and to avoid a poll slipping in a tick
 // before the server clears the quota. Aligns with lesson #4629 guidance.
-const PRIMARY_RESET_BUFFER_MS = 7_000;
+export const PRIMARY_RESET_BUFFER_MS = 7_000;
 
 // Fallback pause when a 403/429 response carries no `retry-after` header and
 // no primary-quota signal, matching GitHub's documented minimum.

--- a/electron/services/github/GitHubRemotes.ts
+++ b/electron/services/github/GitHubRemotes.ts
@@ -1,0 +1,25 @@
+import { GitService } from "../GitService.js";
+import { parseGitHubRepoUrl } from "./GitHubRepoContext.js";
+
+export async function listGitHubRemotes(
+  cwd: string
+): Promise<
+  Array<{ name: string; fetchUrl: string; parsedRepo: { owner: string; repo: string } | null }>
+> {
+  const gitService = new GitService(cwd);
+  const remotes = await gitService.listRemotes(cwd);
+
+  const result = remotes.map((r) => ({
+    name: r.name,
+    fetchUrl: r.fetchUrl,
+    parsedRepo: parseGitHubRepoUrl(r.fetchUrl),
+  }));
+
+  result.sort((a, b) => {
+    if (a.name === "origin") return -1;
+    if (b.name === "origin") return 1;
+    return a.name.localeCompare(b.name);
+  });
+
+  return result;
+}

--- a/electron/services/github/GitHubStats.ts
+++ b/electron/services/github/GitHubStats.ts
@@ -1,3 +1,5 @@
+import fs from "fs/promises";
+import path from "path";
 import type { GraphQlQueryResponseData } from "@octokit/graphql";
 import { GitHubAuth, GITHUB_API_TIMEOUT_MS } from "./GitHubAuth.js";
 import { REPO_STATS_QUERY, REPO_STATS_AND_PAGE_QUERY } from "./GitHubQueries.js";
@@ -12,6 +14,7 @@ import type { RepoStats, RepoStatsResult } from "./types.js";
 import type { GitHubIssue, GitHubPR } from "../../../shared/types/github.js";
 import { parseIssueNode } from "./GitHubIssues.js";
 import { parsePRNode, buildListCacheKey } from "./GitHubPRs.js";
+import type { RepositoryStats, GitHubFirstPageCachePayload } from "../../types/index.js";
 
 export async function getRepoStats(
   cwd: string,
@@ -388,5 +391,124 @@ export async function getRepoStatsAndPage(
       };
     }
     return { stats: null, issues: null, prs: null, error: parseGitHubError(error) };
+  }
+}
+
+export async function getFirstPageCache(cwd: string): Promise<GitHubFirstPageCachePayload | null> {
+  if (!path.isAbsolute(cwd)) return null;
+
+  try {
+    const resolved = path.resolve(cwd);
+    const stat = await fs.stat(resolved);
+    if (!stat.isDirectory()) return null;
+
+    const context = await getRepoContext(resolved);
+    if (!context) return null;
+
+    const repoKey = `${context.owner}/${context.repo}`;
+    const entry = GitHubFirstPageCache.getInstance().get(repoKey);
+    const cachedStats = GitHubStatsCache.getInstance().getForBootstrap(repoKey);
+
+    if (!entry && !cachedStats) return null;
+
+    if (entry) {
+      const payload: GitHubFirstPageCachePayload = {
+        projectPath: resolved,
+        issues: entry.issues,
+        prs: entry.prs,
+        lastUpdated: entry.lastUpdated,
+      };
+      if (cachedStats) {
+        payload.stats = {
+          issueCount: cachedStats.issueCount,
+          prCount: cachedStats.prCount,
+          lastUpdated: cachedStats.lastUpdated,
+        };
+      }
+      return payload;
+    }
+
+    if (!cachedStats) return null;
+    return {
+      projectPath: resolved,
+      issues: { items: [], endCursor: null, hasNextPage: false },
+      prs: { items: [], endCursor: null, hasNextPage: false },
+      lastUpdated: cachedStats.lastUpdated,
+      stats: {
+        issueCount: cachedStats.issueCount,
+        prCount: cachedStats.prCount,
+        lastUpdated: cachedStats.lastUpdated,
+      },
+    };
+  } catch {
+    return null;
+  }
+}
+
+export interface RepoStatsCompleteResult {
+  stats: RepositoryStats;
+  source?: "network" | "memory-cache";
+  issues?: RepoStatsAndPageResult["issues"];
+  prs?: RepoStatsAndPageResult["prs"];
+  stale?: boolean;
+}
+
+export async function getRepoStatsComplete(
+  cwd: string,
+  bypassCache = false
+): Promise<RepoStatsCompleteResult> {
+  const { getCommitCount } = await import("../../utils/git.js");
+
+  try {
+    const resolved = path.resolve(cwd);
+    const stat = await fs.stat(resolved);
+    if (!stat.isDirectory()) {
+      return {
+        stats: {
+          commitCount: 0,
+          issueCount: null,
+          prCount: null,
+          loading: false,
+          ghError: "Path is not a directory",
+        },
+      };
+    }
+
+    const statsResult = await getRepoStatsAndPage(resolved, bypassCache);
+    const commitCount = await getCommitCount(resolved).catch(() => 0);
+    const rateLimitState = gitHubRateLimitService.getState();
+
+    const repositoryStats: RepositoryStats = {
+      commitCount,
+      issueCount: statsResult.stats?.issueCount ?? null,
+      prCount: statsResult.stats?.prCount ?? null,
+      loading: false,
+      ghError: statsResult.error,
+      stale: statsResult.stats?.stale,
+      lastUpdated: statsResult.stats?.lastUpdated,
+      rateLimitResetAt:
+        rateLimitState.blocked && rateLimitState.resetAt ? rateLimitState.resetAt : undefined,
+      rateLimitKind: rateLimitState.blocked ? (rateLimitState.kind ?? undefined) : undefined,
+    };
+
+    return {
+      stats: repositoryStats,
+      source: statsResult.source,
+      issues: statsResult.issues,
+      prs: statsResult.prs,
+      stale: statsResult.stats?.stale,
+    };
+  } catch (err) {
+    const { formatErrorMessage } = await import("../../../shared/utils/errorMessage.js");
+    const message = formatErrorMessage(err, "Failed to fetch GitHub repo stats");
+    return {
+      stats: {
+        commitCount: 0,
+        issueCount: null,
+        prCount: null,
+        loading: false,
+        ghError: message,
+      },
+    };
   }
 }

--- a/electron/services/github/GitHubTokenOrchestrator.ts
+++ b/electron/services/github/GitHubTokenOrchestrator.ts
@@ -2,7 +2,15 @@ import type { GitHubTokenValidation } from "./GitHubAuth.js";
 import { GitHubAuth } from "./GitHubAuth.js";
 import { setGitHubToken, clearGitHubToken, validateGitHubToken } from "./GitHubToken.js";
 import { gitHubTokenHealthService } from "./GitHubTokenHealthService.js";
-import { getWorkspaceClient } from "../WorkspaceClient.js";
+
+async function syncWorkspaceToken(token: string | null): Promise<void> {
+  try {
+    const { getWorkspaceClient } = await import("../WorkspaceClient.js");
+    getWorkspaceClient().updateGitHubToken(token);
+  } catch {
+    // WorkspaceClient may not be initialized yet
+  }
+}
 
 export async function setTokenAndSync(token: string): Promise<GitHubTokenValidation> {
   const trimmed = token.trim();
@@ -21,12 +29,7 @@ export async function setTokenAndSync(token: string): Promise<GitHubTokenValidat
       );
     }
 
-    try {
-      const workspaceClient = getWorkspaceClient();
-      workspaceClient.updateGitHubToken(trimmed);
-    } catch {
-      // WorkspaceClient may not be initialized yet
-    }
+    await syncWorkspaceToken(trimmed);
 
     gitHubTokenHealthService.resetState();
     void gitHubTokenHealthService.refresh({ force: true }).catch(() => {});
@@ -37,13 +40,6 @@ export async function setTokenAndSync(token: string): Promise<GitHubTokenValidat
 
 export async function clearTokenAndSync(): Promise<void> {
   clearGitHubToken();
-
-  try {
-    const workspaceClient = getWorkspaceClient();
-    workspaceClient.updateGitHubToken(null);
-  } catch {
-    // WorkspaceClient may not be initialized yet
-  }
-
+  await syncWorkspaceToken(null);
   gitHubTokenHealthService.resetState();
 }

--- a/electron/services/github/GitHubTokenOrchestrator.ts
+++ b/electron/services/github/GitHubTokenOrchestrator.ts
@@ -29,7 +29,7 @@ export async function setTokenAndSync(token: string): Promise<GitHubTokenValidat
     }
 
     gitHubTokenHealthService.resetState();
-    void gitHubTokenHealthService.refresh({ force: true });
+    void gitHubTokenHealthService.refresh({ force: true }).catch(() => {});
   }
 
   return validation;

--- a/electron/services/github/GitHubTokenOrchestrator.ts
+++ b/electron/services/github/GitHubTokenOrchestrator.ts
@@ -1,0 +1,49 @@
+import type { GitHubTokenValidation } from "./GitHubAuth.js";
+import { GitHubAuth } from "./GitHubAuth.js";
+import { setGitHubToken, clearGitHubToken, validateGitHubToken } from "./GitHubToken.js";
+import { gitHubTokenHealthService } from "./GitHubTokenHealthService.js";
+import { getWorkspaceClient } from "../WorkspaceClient.js";
+
+export async function setTokenAndSync(token: string): Promise<GitHubTokenValidation> {
+  const trimmed = token.trim();
+  const validation = await validateGitHubToken(trimmed);
+
+  if (validation.valid) {
+    setGitHubToken(trimmed);
+    const versionAfterSet = GitHubAuth.getTokenVersion();
+
+    if (validation.username) {
+      GitHubAuth.setValidatedUserInfo(
+        validation.username,
+        validation.avatarUrl,
+        validation.scopes,
+        versionAfterSet
+      );
+    }
+
+    try {
+      const workspaceClient = getWorkspaceClient();
+      workspaceClient.updateGitHubToken(trimmed);
+    } catch {
+      // WorkspaceClient may not be initialized yet
+    }
+
+    gitHubTokenHealthService.resetState();
+    void gitHubTokenHealthService.refresh({ force: true });
+  }
+
+  return validation;
+}
+
+export async function clearTokenAndSync(): Promise<void> {
+  clearGitHubToken();
+
+  try {
+    const workspaceClient = getWorkspaceClient();
+    workspaceClient.updateGitHubToken(null);
+  } catch {
+    // WorkspaceClient may not be initialized yet
+  }
+
+  gitHubTokenHealthService.resetState();
+}

--- a/electron/services/github/index.ts
+++ b/electron/services/github/index.ts
@@ -89,7 +89,7 @@ export {
 export type { RepoStatsAndPageResult, RepoStatsCompleteResult } from "./GitHubStats.js";
 
 // Project health
-export { getProjectHealth } from "./GitHubHealth.js";
+export { getProjectHealth, buildEmptyProjectHealthData } from "./GitHubHealth.js";
 
 // PR discovery
 export { batchCheckLinkedPRs } from "./GitHubPRDiscovery.js";

--- a/electron/services/github/index.ts
+++ b/electron/services/github/index.ts
@@ -6,7 +6,11 @@ export {
 } from "./GitHubAuth.js";
 export type { GitHubTokenConfig, GitHubTokenValidation } from "./GitHubAuth.js";
 
-export { gitHubRateLimitService, GitHubRateLimitError } from "./GitHubRateLimitService.js";
+export {
+  gitHubRateLimitService,
+  GitHubRateLimitError,
+  PRIMARY_RESET_BUFFER_MS,
+} from "./GitHubRateLimitService.js";
 export type { ShouldBlockResult } from "./GitHubRateLimitService.js";
 
 export {
@@ -29,6 +33,7 @@ export {
   GET_PR_REVIEW_THREADS_QUERY,
   buildBatchPRQuery,
   buildBatchRequiredChecksQuery,
+  buildGitHubSearchQuery,
 } from "./GitHubQueries.js";
 
 export { deriveRequiredCIStatus } from "./prRequiredCIStatus.js";
@@ -58,6 +63,9 @@ export {
   validateGitHubToken,
 } from "./GitHubToken.js";
 
+// Token orchestration
+export { setTokenAndSync, clearTokenAndSync } from "./GitHubTokenOrchestrator.js";
+
 // Repo context
 export {
   parseGitHubRepoUrl,
@@ -72,8 +80,13 @@ export {
 export { clearGitHubCaches, clearPRCaches } from "./GitHubCaches.js";
 
 // Stats
-export { getRepoStats, getRepoStatsAndPage } from "./GitHubStats.js";
-export type { RepoStatsAndPageResult } from "./GitHubStats.js";
+export {
+  getRepoStats,
+  getRepoStatsAndPage,
+  getFirstPageCache,
+  getRepoStatsComplete,
+} from "./GitHubStats.js";
+export type { RepoStatsAndPageResult, RepoStatsCompleteResult } from "./GitHubStats.js";
 
 // Project health
 export { getProjectHealth } from "./GitHubHealth.js";
@@ -90,3 +103,9 @@ export { listPullRequests, getPRByNumber, getPRTooltip, getPRReviewThreads } fro
 // Issues
 export { listIssues, getIssueByNumber, getIssueTooltip, assignIssue } from "./GitHubIssues.js";
 export type { AssignIssueResult } from "./GitHubIssues.js";
+
+// Rate limit API
+export { fetchRateLimitDetails } from "./GitHubRateLimitApi.js";
+
+// Remotes
+export { listGitHubRemotes } from "./GitHubRemotes.js";

--- a/renderer-import-baseline.json
+++ b/renderer-import-baseline.json
@@ -1,6 +1,6 @@
 {
   "entryName": "index",
-  "eagerChunkCount": 36,
+  "eagerChunkCount": 40,
   "eagerChunks": [
     "ActionService",
     "Spinner",
@@ -12,6 +12,8 @@
     "appClient",
     "appThemeStore",
     "clients",
+    "commandsClient",
+    "copyTreeClient",
     "createWorktreeStore",
     "errorMessage",
     "githubConfigStore",
@@ -22,7 +24,9 @@
     "notify",
     "persistedStoreRegistry",
     "portalStore",
+    "projectSettingsStore",
     "projectStore",
+    "radix-loader",
     "rolldown-runtime",
     "safeStorage",
     "store",
@@ -34,7 +38,7 @@
     "vendor-editor",
     "vendor-icons",
     "vendor-motion",
-    "vendor-radix",
+    "vendor-radix-utils",
     "vendor-react",
     "vendor-xterm",
     "vendor-zod"


### PR DESCRIPTION
## Summary
- Collapses `electron/ipc/handlers/github.ts` from ~800 lines to ~350 by delegating to the existing `electron/services/github/` service layer.
- Each handler body now validates its arguments, calls the relevant service, and returns the result.
- Three new service files added (`GitHubRateLimitApi`, `GitHubStats`, `GitHubTokenOrchestrator`), and several existing services gained new methods to absorb the extracted logic.

Resolves #7687

## Changes
- **Handlers thinned:** `electron/ipc/handlers/github.ts` -- removed inline rate-limit fetching, search-query building, PR list parsing, and token orchestration logic. Every handler delegates to a typed service.
- **New services:**
  - `GitHubRateLimitApi` -- raw `/rate_limit` endpoint client, replacing the bare `fetch()` that was in the handler.
  - `GitHubStats` -- aggregates issue/PR counts and other stats.
  - `GitHubTokenOrchestrator` -- centralizes token validation and auth flow logic.
- **Existing services extended:** `GitHubHealth`, `GitHubQueries`, `GitHubRateLimitService`, `GitHubRemotes` all got new methods for the handler-to-service handoff.
- **Tests updated** to match the new service boundaries.

## Testing
- All existing GitHub IPC handler tests pass.
- Typecheck passes across main, renderer, and preload.