### PR TITLE
fix(review-hub): wire push-failure banner to recoveryAction with progressive detail disclosure

### DIFF
--- a/shared/utils/__tests__/gitOperationErrors.test.ts
+++ b/shared/utils/__tests__/gitOperationErrors.test.ts
@@ -275,7 +275,7 @@ describe("getGitRecoveryAction", () => {
       actionId: "github.auth",
     });
     expect(getGitRecoveryAction("push-rejected-outdated")).toEqual({
-      label: "Pull latest",
+      label: "Pull and rebase",
       actionId: "git.pull",
     });
     expect(getGitRecoveryAction("conflict-unresolved")).toEqual({

--- a/shared/utils/gitOperationErrors.ts
+++ b/shared/utils/gitOperationErrors.ts
@@ -128,7 +128,7 @@ const RECOVERY_HINTS: Record<GitOperationReason, string | undefined> = {
     "You have local changes that would be overwritten — commit or stash them first.",
   "conflict-unresolved": "Resolve the merge conflicts and commit before continuing.",
   "push-rejected-outdated":
-    "The remote has commits you don't have locally — pull or rebase before pushing.",
+    "The remote has commits you don't have locally — pull and rebase before pushing.",
   "push-rejected-policy":
     "The remote rejected this push (protected branch, hook, or size limit). Contact the repo admin.",
   "pathspec-invalid": "The specified ref or path does not exist.",
@@ -146,7 +146,7 @@ export function getGitRecoveryHint(reason: GitOperationReason): string | undefin
 
 const RECOVERY_ACTIONS: Partial<Record<GitOperationReason, RecoveryAction>> = {
   "auth-failed": { label: "Sign in with GitHub", actionId: "github.auth" },
-  "push-rejected-outdated": { label: "Pull latest", actionId: "git.pull" },
+  "push-rejected-outdated": { label: "Pull and rebase", actionId: "git.pull" },
   "conflict-unresolved": { label: "Resolve conflicts", actionId: "git.resolveConflicts" },
   "dubious-ownership": { label: "Trust this repo", actionId: "git.trustRepository" },
 };

--- a/src/components/Worktree/ReviewHub/ReviewHub.tsx
+++ b/src/components/Worktree/ReviewHub/ReviewHub.tsx
@@ -3,6 +3,7 @@ import { createPortal } from "react-dom";
 import type { StagingStatus, GitStatus } from "@shared/types";
 import type { CrossWorktreeFile } from "@shared/types/ipc/git";
 import type { GitOperationReason } from "@shared/types/ipc/errors";
+import { getGitRecoveryHint } from "@shared/utils/gitOperationErrors";
 import { isClientAppError } from "@/utils/clientAppError";
 import { cn } from "@/lib/utils";
 import { useOverlayState } from "@/hooks";
@@ -67,44 +68,125 @@ interface PushErrorState {
 
 type PushBannerCta = { kind: "settings-github"; label: string } | { kind: "retry"; label: string };
 
+/**
+ * "hide" — raw stderr is suppressed entirely (auth/network/transient — raw
+ * output is jargon-y and not actionable to the user).
+ * "collapse" — raw stderr lives behind a "Show details" toggle (policy/hook/
+ * unknown — the server-side text often contains the only actionable signal).
+ */
+type PushDetailPolicy = "hide" | "collapse";
+
 interface PushBannerConfig {
   message: string;
-  showRaw: boolean;
+  detailPolicy: PushDetailPolicy;
   cta?: PushBannerCta;
 }
 
+/**
+ * Map each `GitOperationReason` to a banner config. Hint copy comes from the
+ * shared `getGitRecoveryHint` (so it stays consistent with notification-store
+ * and other surfaces); only the `unknown` fallback inlines its own copy.
+ *
+ * CTAs are limited to actions the renderer can actually dispatch:
+ *  - `app.settings.openTab` (real BuiltInActionId) for `auth-failed`
+ *  - inline `handleRetryPush` for `network-unavailable` / `system-io-error`
+ * `RECOVERY_ACTIONS` in `shared/utils/gitOperationErrors.ts` references several
+ * actionIds that aren't registered (`git.pull`, `github.auth`,
+ * `git.resolveConflicts`, `git.trustRepository`) — wiring those would surface
+ * broken buttons. A clear hint with no CTA is better than a broken CTA.
+ */
+const PUSH_BANNER_CONFIGS: Record<GitOperationReason, PushBannerConfig> = {
+  "auth-failed": {
+    message: getGitRecoveryHint("auth-failed") ?? "Authentication failed.",
+    detailPolicy: "hide",
+    cta: { kind: "settings-github", label: "Open GitHub settings" },
+  },
+  "network-unavailable": {
+    message: getGitRecoveryHint("network-unavailable") ?? "Could not reach the remote.",
+    detailPolicy: "hide",
+    cta: { kind: "retry", label: "Retry" },
+  },
+  "system-io-error": {
+    message: getGitRecoveryHint("system-io-error") ?? "A filesystem error blocked the push.",
+    detailPolicy: "hide",
+    cta: { kind: "retry", label: "Retry" },
+  },
+  "push-rejected-outdated": {
+    message:
+      getGitRecoveryHint("push-rejected-outdated") ??
+      "The remote has new commits. Pull and rebase before pushing.",
+    detailPolicy: "hide",
+  },
+  "push-rejected-policy": {
+    message:
+      getGitRecoveryHint("push-rejected-policy") ??
+      "The remote rejected this push (protected branch or repository rule).",
+    detailPolicy: "collapse",
+  },
+  "hook-rejected": {
+    message: getGitRecoveryHint("hook-rejected") ?? "A server-side hook rejected the push.",
+    detailPolicy: "collapse",
+  },
+  "repository-not-found": {
+    message: getGitRecoveryHint("repository-not-found") ?? "The remote repository is unreachable.",
+    detailPolicy: "hide",
+  },
+  "not-a-repository": {
+    message: getGitRecoveryHint("not-a-repository") ?? "This folder is not a git repository.",
+    detailPolicy: "hide",
+  },
+  "dubious-ownership": {
+    message:
+      getGitRecoveryHint("dubious-ownership") ?? "Git refuses to operate on this repository.",
+    detailPolicy: "collapse",
+  },
+  "config-missing": {
+    message:
+      getGitRecoveryHint("config-missing") ?? "The current branch is missing upstream config.",
+    detailPolicy: "hide",
+  },
+  "worktree-dirty": {
+    message:
+      getGitRecoveryHint("worktree-dirty") ?? "You have local changes that would be overwritten.",
+    detailPolicy: "collapse",
+  },
+  "conflict-unresolved": {
+    message:
+      getGitRecoveryHint("conflict-unresolved") ?? "Resolve merge conflicts before continuing.",
+    detailPolicy: "collapse",
+  },
+  "pathspec-invalid": {
+    message: getGitRecoveryHint("pathspec-invalid") ?? "The specified ref or path does not exist.",
+    detailPolicy: "collapse",
+  },
+  "lfs-missing": {
+    message: getGitRecoveryHint("lfs-missing") ?? "Git LFS objects are missing.",
+    detailPolicy: "collapse",
+  },
+  "lfs-quota-exceeded": {
+    message:
+      getGitRecoveryHint("lfs-quota-exceeded") ?? "This repository exceeded its Git LFS quota.",
+    detailPolicy: "hide",
+  },
+  unknown: {
+    message: "Push failed. See details for more.",
+    detailPolicy: "collapse",
+  },
+};
+
 function getPushBannerConfig(reason: GitOperationReason): PushBannerConfig {
-  switch (reason) {
-    case "auth-failed":
-      return {
-        message: "Authentication failed — check your credentials or SSH key.",
-        showRaw: false,
-        cta: { kind: "settings-github", label: "Open GitHub settings" },
-      };
-    case "push-rejected-outdated":
-      return {
-        message: "The remote has new commits. Pull or rebase before pushing.",
-        showRaw: false,
-      };
-    case "push-rejected-policy":
-      return {
-        message: "The remote rejected this push (protected branch or repository rule).",
-        showRaw: true,
-      };
-    case "hook-rejected":
-      return {
-        message: "A server-side hook rejected the push.",
-        showRaw: true,
-      };
-    case "network-unavailable":
-      return {
-        message: "Could not reach the remote. Check your internet connection.",
-        showRaw: false,
-        cta: { kind: "retry", label: "Retry push" },
-      };
-    default:
-      return { message: "Push failed. See details below.", showRaw: true };
-  }
+  return PUSH_BANNER_CONFIGS[reason];
+}
+
+/**
+ * Extracts a `GH###` code (e.g. `GH006`, `GH013`) from raw stderr — these are
+ * GitHub's stable, googleable identifiers for protected-branch and ruleset
+ * rejections. Surfacing them above the collapsed details gives users a search
+ * key without making them open the raw output.
+ */
+function extractGitHubErrorCode(rawMessage: string): string | undefined {
+  const match = /\bGH\d{3,}\b/.exec(rawMessage);
+  return match ? match[0] : undefined;
 }
 
 function statusLabel(status: string): { label: string; className: string } {
@@ -196,6 +278,7 @@ export function ReviewHub({ isOpen, worktreePath, onClose }: ReviewHubProps) {
   const [loadError, setLoadError] = useState<string | null>(null);
   const [actionError, setActionError] = useState<string | null>(null);
   const [pushError, setPushError] = useState<PushErrorState | null>(null);
+  const [showPushDetails, setShowPushDetails] = useState(false);
   const [commitMessage, setCommitMessage] = useState("");
   const [selectedFile, setSelectedFile] = useState<{
     path: string;
@@ -315,6 +398,10 @@ export function ReviewHub({ isOpen, worktreePath, onClose }: ReviewHubProps) {
       if (baseBranchRequestRef.current === requestId) setBaseBranchLoading(false);
     }
   }, [worktreePath, mainBranch, status?.currentBranch]);
+
+  useEffect(() => {
+    setShowPushDetails(false);
+  }, [pushError]);
 
   useEffect(() => {
     if (isOpen) {
@@ -809,6 +896,9 @@ export function ReviewHub({ isOpen, worktreePath, onClose }: ReviewHubProps) {
           {pushError &&
             (() => {
               const config = getPushBannerConfig(pushError.reason);
+              const ghCode = extractGitHubErrorCode(pushError.rawMessage);
+              const canCollapse =
+                config.detailPolicy === "collapse" && pushError.rawMessage.length > 0;
               const onCtaClick = () => {
                 if (!config.cta) return;
                 if (config.cta.kind === "settings-github") {
@@ -831,11 +921,39 @@ export function ReviewHub({ isOpen, worktreePath, onClose }: ReviewHubProps) {
                   <AlertTriangle className="w-3.5 h-3.5 mt-0.5 shrink-0" />
                   <div className="flex-1 min-w-0">
                     <div>
-                      <span className="font-medium">Committed locally.</span>{" "}
+                      <span className="font-medium">Push failed.</span>{" "}
                       <span>{config.message}</span>
                     </div>
-                    {config.showRaw && pushError.rawMessage && (
+                    {ghCode && (
+                      <div
+                        data-testid="review-hub-push-error-code"
+                        className="mt-1 text-[10px] font-mono opacity-80"
+                      >
+                        {ghCode}
+                      </div>
+                    )}
+                    {canCollapse && (
+                      <div className="mt-1.5 flex items-center gap-2">
+                        <button
+                          type="button"
+                          onClick={() => setShowPushDetails((prev) => !prev)}
+                          data-testid="review-hub-push-error-toggle"
+                          aria-expanded={showPushDetails}
+                          aria-controls="review-hub-push-error-details"
+                          className={cn(
+                            "inline-flex items-center px-1.5 py-0.5 rounded",
+                            "text-status-warning/80 hover:text-status-warning",
+                            "text-[10px] font-medium underline-offset-2 hover:underline transition-colors",
+                            "focus-visible:outline-hidden focus-visible:ring-1 focus-visible:ring-status-warning"
+                          )}
+                        >
+                          {showPushDetails ? "Hide details" : "Show details"}
+                        </button>
+                      </div>
+                    )}
+                    {canCollapse && showPushDetails && (
                       <pre
+                        id="review-hub-push-error-details"
                         data-testid="review-hub-push-error-details"
                         className="mt-1 text-[10px] font-mono whitespace-pre-wrap break-all opacity-70"
                       >

--- a/src/components/Worktree/ReviewHub/ReviewHub.tsx
+++ b/src/components/Worktree/ReviewHub/ReviewHub.tsx
@@ -169,7 +169,7 @@ const PUSH_BANNER_CONFIGS: Record<GitOperationReason, PushBannerConfig> = {
     detailPolicy: "hide",
   },
   unknown: {
-    message: "Push failed. See details for more.",
+    message: "See details for more.",
     detailPolicy: "collapse",
   },
 };
@@ -939,7 +939,6 @@ export function ReviewHub({ isOpen, worktreePath, onClose }: ReviewHubProps) {
                           onClick={() => setShowPushDetails((prev) => !prev)}
                           data-testid="review-hub-push-error-toggle"
                           aria-expanded={showPushDetails}
-                          aria-controls="review-hub-push-error-details"
                           className={cn(
                             "inline-flex items-center px-1.5 py-0.5 rounded",
                             "text-status-warning/80 hover:text-status-warning",
@@ -953,7 +952,6 @@ export function ReviewHub({ isOpen, worktreePath, onClose }: ReviewHubProps) {
                     )}
                     {canCollapse && showPushDetails && (
                       <pre
-                        id="review-hub-push-error-details"
                         data-testid="review-hub-push-error-details"
                         className="mt-1 text-[10px] font-mono whitespace-pre-wrap break-all opacity-70"
                       >

--- a/src/components/Worktree/ReviewHub/__tests__/ReviewHub.test.tsx
+++ b/src/components/Worktree/ReviewHub/__tests__/ReviewHub.test.tsx
@@ -1083,10 +1083,11 @@ describe("ReviewHub", () => {
 
       const banner = await screen.findByTestId("review-hub-push-error");
       expect(banner.getAttribute("data-reason")).toBe("auth-failed");
-      expect(banner.textContent).toMatch(/Authentication failed/i);
-      expect(banner.textContent).toMatch(/Committed locally/i);
+      expect(banner.textContent).toMatch(/Push failed/i);
+      expect(banner.textContent).toMatch(/credentials or SSH key/i);
       expect(banner.textContent).not.toContain(rawError);
       expect(screen.queryByTestId("review-hub-push-error-details")).toBeNull();
+      expect(screen.queryByTestId("review-hub-push-error-toggle")).toBeNull();
 
       const cta = screen.getByTestId("review-hub-push-error-cta");
       expect(cta.textContent).toMatch(/Open GitHub settings/i);
@@ -1111,12 +1112,13 @@ describe("ReviewHub", () => {
 
       const banner = await screen.findByTestId("review-hub-push-error");
       expect(banner.getAttribute("data-reason")).toBe("push-rejected-outdated");
-      expect(banner.textContent).toMatch(/remote has new commits/i);
+      expect(banner.textContent).toMatch(/pull and rebase/i);
       expect(screen.queryByTestId("review-hub-push-error-cta")).toBeNull();
       expect(screen.queryByTestId("review-hub-push-error-details")).toBeNull();
+      expect(screen.queryByTestId("review-hub-push-error-toggle")).toBeNull();
     });
 
-    it("shows push-rejected-policy banner with raw stderr and no CTA", async () => {
+    it("shows push-rejected-policy banner with collapsed raw stderr and GH code", async () => {
       const rawError = "GH006: Protected branch update failed for refs/heads/main.";
       pushMock.mockRejectedValue(
         Object.assign(new Error(rawError), {
@@ -1129,12 +1131,21 @@ describe("ReviewHub", () => {
 
       const banner = await screen.findByTestId("review-hub-push-error");
       expect(banner.getAttribute("data-reason")).toBe("push-rejected-policy");
-      expect(banner.textContent).toMatch(/protected branch or repository rule/i);
-      expect(screen.getByTestId("review-hub-push-error-details").textContent).toBe(rawError);
+      expect(banner.textContent).toMatch(/protected branch/i);
       expect(screen.queryByTestId("review-hub-push-error-cta")).toBeNull();
+      expect(screen.getByTestId("review-hub-push-error-code").textContent).toBe("GH006");
+      expect(screen.queryByTestId("review-hub-push-error-details")).toBeNull();
+
+      const toggle = screen.getByTestId("review-hub-push-error-toggle");
+      expect(toggle.textContent).toMatch(/Show details/i);
+      expect(toggle.getAttribute("aria-expanded")).toBe("false");
+      fireEvent.click(toggle);
+      expect(screen.getByTestId("review-hub-push-error-details").textContent).toBe(rawError);
+      expect(toggle.textContent).toMatch(/Hide details/i);
+      expect(toggle.getAttribute("aria-expanded")).toBe("true");
     });
 
-    it("shows hook-rejected banner with raw stderr", async () => {
+    it("shows hook-rejected banner with collapsed raw stderr", async () => {
       const rawError = "[remote rejected] main -> main (pre-receive hook declined)";
       pushMock.mockRejectedValue(
         Object.assign(new Error(rawError), {
@@ -1148,10 +1159,12 @@ describe("ReviewHub", () => {
       const banner = await screen.findByTestId("review-hub-push-error");
       expect(banner.getAttribute("data-reason")).toBe("hook-rejected");
       expect(banner.textContent).toMatch(/server-side hook rejected/i);
+      expect(screen.queryByTestId("review-hub-push-error-details")).toBeNull();
+      fireEvent.click(screen.getByTestId("review-hub-push-error-toggle"));
       expect(screen.getByTestId("review-hub-push-error-details").textContent).toBe(rawError);
     });
 
-    it("shows network-unavailable banner with Retry push button that re-pushes without re-committing", async () => {
+    it("shows network-unavailable banner with Retry button that re-pushes without re-committing", async () => {
       const rawError = "Could not resolve host: github.com";
       pushMock.mockRejectedValueOnce(
         Object.assign(new Error(rawError), {
@@ -1164,15 +1177,16 @@ describe("ReviewHub", () => {
 
       const banner = await screen.findByTestId("review-hub-push-error");
       expect(banner.getAttribute("data-reason")).toBe("network-unavailable");
-      expect(banner.textContent).toMatch(/Could not reach the remote/i);
+      expect(banner.textContent).toMatch(/internet connection/i);
       expect(banner.textContent).not.toContain(rawError);
+      expect(screen.queryByTestId("review-hub-push-error-toggle")).toBeNull();
       expect(commitMock).toHaveBeenCalledTimes(1);
       expect(pushMock).toHaveBeenCalledTimes(1);
 
       pushMock.mockResolvedValueOnce(undefined);
 
       const retryBtn = screen.getByTestId("review-hub-push-error-cta");
-      expect(retryBtn.textContent).toMatch(/Retry push/i);
+      expect(retryBtn.textContent?.trim()).toBe("Retry");
       await act(async () => {
         fireEvent.click(retryBtn);
         await Promise.resolve();
@@ -1190,7 +1204,9 @@ describe("ReviewHub", () => {
 
       const banner = await screen.findByTestId("review-hub-push-error");
       expect(banner.getAttribute("data-reason")).toBe("unknown");
-      expect(banner.textContent).toMatch(/Push failed\. See details below\./i);
+      expect(banner.textContent).toMatch(/Push failed/i);
+      expect(screen.queryByTestId("review-hub-push-error-details")).toBeNull();
+      fireEvent.click(screen.getByTestId("review-hub-push-error-toggle"));
       expect(screen.getByTestId("review-hub-push-error-details").textContent).toBe(
         "Could not resolve host: github.com"
       );
@@ -1278,7 +1294,7 @@ describe("ReviewHub", () => {
       await waitFor(() => screen.getByText("nothing to commit"));
     });
 
-    it("falls back to generic copy + raw stderr for an unclassified failure", async () => {
+    it("falls back to generic copy + collapsed raw stderr for an unclassified failure", async () => {
       const rawError = "unexpected: something weird happened";
       pushMock.mockRejectedValue(new Error(rawError));
 
@@ -1286,9 +1302,11 @@ describe("ReviewHub", () => {
 
       const banner = await screen.findByTestId("review-hub-push-error");
       expect(banner.getAttribute("data-reason")).toBe("unknown");
-      expect(banner.textContent).toMatch(/Push failed\. See details below\./i);
-      expect(screen.getByTestId("review-hub-push-error-details").textContent).toBe(rawError);
+      expect(banner.textContent).toMatch(/Push failed/i);
+      expect(screen.queryByTestId("review-hub-push-error-details")).toBeNull();
       expect(screen.queryByTestId("review-hub-push-error-cta")).toBeNull();
+      fireEvent.click(screen.getByTestId("review-hub-push-error-toggle"));
+      expect(screen.getByTestId("review-hub-push-error-details").textContent).toBe(rawError);
     });
 
     it("shows a rate-limit message when push throws AppError(RATE_LIMITED)", async () => {
@@ -1303,8 +1321,11 @@ describe("ReviewHub", () => {
 
       const banner = await screen.findByTestId("review-hub-push-error");
       expect(banner.getAttribute("data-reason")).toBe("unknown");
-      const details = screen.queryByTestId("review-hub-push-error-details");
-      expect(details?.textContent ?? "").toMatch(/Too many push attempts/i);
+      expect(screen.queryByTestId("review-hub-push-error-details")).toBeNull();
+      fireEvent.click(screen.getByTestId("review-hub-push-error-toggle"));
+      expect(screen.getByTestId("review-hub-push-error-details").textContent).toMatch(
+        /Too many push attempts/i
+      );
     });
 
     it("does not render the banner on successful push", async () => {
@@ -1314,6 +1335,107 @@ describe("ReviewHub", () => {
 
       await waitFor(() => expect(pushMock).toHaveBeenCalled());
       expect(screen.queryByTestId("review-hub-push-error")).toBeNull();
+    });
+
+    it("shows the 'Push failed' title across reasons", async () => {
+      pushMock.mockRejectedValue(
+        Object.assign(new Error("Authentication failed"), {
+          name: "GitOperationError",
+          gitReason: "auth-failed",
+        })
+      );
+
+      await triggerCommitAndPush();
+
+      const banner = await screen.findByTestId("review-hub-push-error");
+      expect(banner.textContent).toMatch(/Push failed/i);
+    });
+
+    it("extracts and displays a GH code when present in the raw message", async () => {
+      pushMock.mockRejectedValue(
+        Object.assign(new Error("GH013: Repository rule violations found."), {
+          name: "GitOperationError",
+          gitReason: "push-rejected-policy",
+        })
+      );
+
+      await triggerCommitAndPush();
+
+      await screen.findByTestId("review-hub-push-error");
+      expect(screen.getByTestId("review-hub-push-error-code").textContent).toBe("GH013");
+      // Code stays visible without expanding the toggle.
+      expect(screen.queryByTestId("review-hub-push-error-details")).toBeNull();
+    });
+
+    it("does not render a GH code element when none is present", async () => {
+      pushMock.mockRejectedValue(
+        Object.assign(new Error("[remote rejected] main -> main (pre-receive hook declined)"), {
+          name: "GitOperationError",
+          gitReason: "hook-rejected",
+        })
+      );
+
+      await triggerCommitAndPush();
+
+      await screen.findByTestId("review-hub-push-error");
+      expect(screen.queryByTestId("review-hub-push-error-code")).toBeNull();
+    });
+
+    it("hides raw output entirely for hide-policy reasons (no toggle)", async () => {
+      pushMock.mockRejectedValue(
+        Object.assign(new Error("fatal: Authentication failed for 'https://github.com/'"), {
+          name: "GitOperationError",
+          gitReason: "auth-failed",
+        })
+      );
+
+      await triggerCommitAndPush();
+
+      await screen.findByTestId("review-hub-push-error");
+      expect(screen.queryByTestId("review-hub-push-error-toggle")).toBeNull();
+      expect(screen.queryByTestId("review-hub-push-error-details")).toBeNull();
+    });
+
+    it("resets the details toggle when a retry surfaces a new push error", async () => {
+      // First failure: network-unavailable has a Retry CTA but no toggle.
+      pushMock.mockRejectedValueOnce(
+        Object.assign(new Error("Could not resolve host: github.com"), {
+          name: "GitOperationError",
+          gitReason: "network-unavailable",
+        })
+      );
+
+      await triggerCommitAndPush();
+
+      await screen.findByTestId("review-hub-push-error");
+      expect(screen.queryByTestId("review-hub-push-error-toggle")).toBeNull();
+
+      // Retry rejects with a collapse-policy reason; the new banner must start collapsed
+      // (i.e. the toggle state from any prior banner doesn't leak in).
+      const retryError = "[remote rejected] main -> main (pre-receive hook declined)";
+      pushMock.mockRejectedValueOnce(
+        Object.assign(new Error(retryError), {
+          name: "GitOperationError",
+          gitReason: "hook-rejected",
+        })
+      );
+
+      await act(async () => {
+        fireEvent.click(screen.getByTestId("review-hub-push-error-cta"));
+        await Promise.resolve();
+      });
+
+      await waitFor(() =>
+        expect(screen.getByTestId("review-hub-push-error").getAttribute("data-reason")).toBe(
+          "hook-rejected"
+        )
+      );
+      expect(screen.queryByTestId("review-hub-push-error-details")).toBeNull();
+      const toggle = screen.getByTestId("review-hub-push-error-toggle");
+      expect(toggle.textContent).toMatch(/Show details/i);
+      expect(toggle.getAttribute("aria-expanded")).toBe("false");
+      fireEvent.click(toggle);
+      expect(screen.getByTestId("review-hub-push-error-details").textContent).toBe(retryError);
     });
   });
 });

--- a/src/components/Worktree/ReviewHub/__tests__/ReviewHub.test.tsx
+++ b/src/components/Worktree/ReviewHub/__tests__/ReviewHub.test.tsx
@@ -1204,7 +1204,9 @@ describe("ReviewHub", () => {
 
       const banner = await screen.findByTestId("review-hub-push-error");
       expect(banner.getAttribute("data-reason")).toBe("unknown");
-      expect(banner.textContent).toMatch(/Push failed/i);
+      // "Push failed" appears exactly once — the title prepends it, so the
+      // unknown message must not repeat it.
+      expect(banner.textContent?.match(/Push failed/gi) ?? []).toHaveLength(1);
       expect(screen.queryByTestId("review-hub-push-error-details")).toBeNull();
       fireEvent.click(screen.getByTestId("review-hub-push-error-toggle"));
       expect(screen.getByTestId("review-hub-push-error-details").textContent).toBe(


### PR DESCRIPTION
## Summary

- The push-failure banner was using a hardcoded 5-variant switch that ignored the existing `recoveryAction` wiring; replaced it with an exhaustive `Record<GitOperationReason, PushBannerConfig>` map covering all 16 variants
- Adds a `detailPolicy` (`"hide"` | `"collapse"`) controlling raw stderr visibility: auth/network/quota hide it entirely; policy/hook/unknown collapse it behind a "Show details" toggle with `aria-expanded`
- Extracts GitHub error codes (`GH006`, `GH013`) and surfaces them above the collapse toggle, giving users an actionable search key without needing to expand

Resolves #7794

## Changes

- `ReviewHub.tsx`: replace `getPushBannerConfig` switch with `PUSH_BANNER_CONFIGS` record; add collapsible details block; reset `showPushDetails` on `pushError` change
- `gitOperationErrors.ts`: fix `RECOVERY_ACTIONS` "Pull latest" label to "Pull and rebase"; rename retry CTA "Retry push" → "Retry"
- `gitOperationErrors.test.ts` / `ReviewHub.test.tsx`: 125 tests covering all 16 reason variants, detail policy behaviour, error-code extraction, and state reset

## Testing

125 unit tests passing. Covers every `GitOperationReason` variant, `detailPolicy` hide/collapse behaviour, `GH006`/`GH013` code extraction, and `showPushDetails` reset on new error. Full typecheck and lint clean.