### PR TITLE
feat(fleet-picker): add visible select-all and select-agents buttons to footer

### DIFF
--- a/src/components/Fleet/FleetPickerPalette.tsx
+++ b/src/components/Fleet/FleetPickerPalette.tsx
@@ -88,7 +88,7 @@ export function FleetPickerPalette({ isOpen, onClose }: FleetPickerPaletteProps)
     } else {
       picker.setSelectedIds(new Set());
     }
-  }, [allVisibleSelected, hasQuery, picker.setSelectedIds, picker.visibleIds]);
+  }, [allVisibleSelected, hasQuery, picker]);
 
   // Additive — preserves existing picks (including non-agent terminals).
   const handleSelectAgents = useCallback(() => {
@@ -98,7 +98,7 @@ export function FleetPickerPalette({ isOpen, onClose }: FleetPickerPaletteProps)
       for (const id of agentVisibleIds) next.add(id);
       return next;
     });
-  }, [agentVisibleIds, picker.setSelectedIds]);
+  }, [agentVisibleIds, picker]);
 
   return (
     <AppPaletteDialog isOpen={isOpen} onClose={onClose} ariaLabel="Select terminals to arm">

--- a/src/components/Fleet/FleetPickerPalette.tsx
+++ b/src/components/Fleet/FleetPickerPalette.tsx
@@ -1,10 +1,11 @@
-import { useCallback, type ReactElement } from "react";
+import { useCallback, useMemo, type ReactElement } from "react";
 import { Zap } from "lucide-react";
 import { cn } from "@/lib/utils";
 import { AppPaletteDialog } from "@/components/ui/AppPaletteDialog";
 import { FleetPickerContent } from "@/components/Fleet/FleetPickerContent";
 import { useFleetPicker } from "@/hooks/useFleetPicker";
 import { useFleetArmingStore } from "@/store/fleetArmingStore";
+import { ACTIVE_AGENT_STATES } from "@shared/types/agent";
 
 export interface FleetPickerPaletteProps {
   isOpen: boolean;
@@ -40,6 +41,54 @@ export function FleetPickerPalette({ isOpen, onClose }: FleetPickerPaletteProps)
     owner: "cold-start",
   });
 
+  const allVisibleSelected = useMemo(
+    () =>
+      picker.visibleIds.length > 0 && picker.visibleIds.every((id) => picker.selectedIds.has(id)),
+    [picker.visibleIds, picker.selectedIds]
+  );
+
+  const agentVisibleIds = useMemo(
+    () =>
+      picker.visibleTerminals
+        .filter((t) => t.agentState && ACTIVE_AGENT_STATES.has(t.agentState))
+        .map((t) => t.id),
+    [picker.visibleTerminals]
+  );
+
+  const hasQuery = picker.query.trim() !== "";
+  const selectAllLabel = allVisibleSelected
+    ? hasQuery
+      ? "Deselect visible"
+      : "Deselect all"
+    : hasQuery
+      ? "Select all visible"
+      : "Select all";
+
+  // Select → replace visible (matches Cmd+A in useFleetPicker).
+  // Deselect → scoped remove of visible ids only, so picks for terminals
+  // filtered out by the current query survive.
+  const handleToggleAllVisible = useCallback(() => {
+    if (allVisibleSelected) {
+      picker.setSelectedIds((prev) => {
+        const next = new Set(prev);
+        for (const id of picker.visibleIds) next.delete(id);
+        return next;
+      });
+    } else {
+      picker.setSelectedIds(new Set(picker.visibleIds));
+    }
+  }, [allVisibleSelected, picker.setSelectedIds, picker.visibleIds]);
+
+  // Additive — preserves existing picks (including non-agent terminals).
+  const handleSelectAgents = useCallback(() => {
+    if (agentVisibleIds.length === 0) return;
+    picker.setSelectedIds((prev) => {
+      const next = new Set(prev);
+      for (const id of agentVisibleIds) next.add(id);
+      return next;
+    });
+  }, [agentVisibleIds, picker.setSelectedIds]);
+
   return (
     <AppPaletteDialog isOpen={isOpen} onClose={onClose} ariaLabel="Select terminals to arm">
       <div className="flex flex-col">
@@ -64,16 +113,44 @@ export function FleetPickerPalette({ isOpen, onClose }: FleetPickerPaletteProps)
             </div>
 
             <div className="flex items-center justify-between gap-2 border-t border-daintree-border px-3 py-2">
-              <span
-                className="text-[11px] tabular-nums text-daintree-text/55"
-                data-testid="fleet-picker-cold-start-status"
-              >
-                {picker.confirmedIds.length === 0
-                  ? "Select terminals to arm"
-                  : `${picker.confirmedIds.length} selected${
-                      picker.driftCount > 0 ? ` · ${picker.driftCount} ineligible` : ""
-                    }`}
-              </span>
+              <div className="flex items-center gap-1.5">
+                <span
+                  role="status"
+                  className="text-[11px] tabular-nums text-daintree-text/55"
+                  data-testid="fleet-picker-cold-start-status"
+                >
+                  Select terminals to arm
+                  {picker.driftCount > 0 ? ` · ${picker.driftCount} ineligible` : ""}
+                </span>
+                <button
+                  type="button"
+                  onClick={handleToggleAllVisible}
+                  disabled={picker.visibleIds.length === 0}
+                  data-testid="fleet-picker-cold-start-select-all"
+                  className={cn(
+                    "rounded px-2.5 py-1 text-[12px] text-daintree-text/70",
+                    "hover:bg-tint/[0.08] hover:text-daintree-text",
+                    "disabled:cursor-not-allowed disabled:opacity-40 disabled:pointer-events-none",
+                    "focus-visible:outline focus-visible:outline-2 focus-visible:outline-daintree-accent"
+                  )}
+                >
+                  {selectAllLabel}
+                </button>
+                <button
+                  type="button"
+                  onClick={handleSelectAgents}
+                  disabled={agentVisibleIds.length === 0}
+                  data-testid="fleet-picker-cold-start-select-agents"
+                  className={cn(
+                    "rounded px-2.5 py-1 text-[12px] text-daintree-text/70",
+                    "hover:bg-tint/[0.08] hover:text-daintree-text",
+                    "disabled:cursor-not-allowed disabled:opacity-40 disabled:pointer-events-none",
+                    "focus-visible:outline focus-visible:outline-2 focus-visible:outline-daintree-accent"
+                  )}
+                >
+                  Select agents
+                </button>
+              </div>
               <div className="flex items-center gap-1.5">
                 <button
                   type="button"

--- a/src/components/Fleet/FleetPickerPalette.tsx
+++ b/src/components/Fleet/FleetPickerPalette.tsx
@@ -47,6 +47,11 @@ export function FleetPickerPalette({ isOpen, onClose }: FleetPickerPaletteProps)
     [picker.visibleIds, picker.selectedIds]
   );
 
+  // Scope is `agentState`-only — terminals are picked by their reported
+  // agent state (working/waiting/directing). No capability-id gate, so a
+  // terminal whose `agentState` is set but whose registered agent has gone
+  // away is still eligible to be armed (arming broadcasts keystrokes, not
+  // agent commands — the surface is acceptable).
   const agentVisibleIds = useMemo(
     () =>
       picker.visibleTerminals
@@ -65,19 +70,25 @@ export function FleetPickerPalette({ isOpen, onClose }: FleetPickerPaletteProps)
       : "Select all";
 
   // Select → replace visible (matches Cmd+A in useFleetPicker).
-  // Deselect → scoped remove of visible ids only, so picks for terminals
-  // filtered out by the current query survive.
+  // Deselect when filtered → scoped removal so picks for filtered-out
+  // terminals survive. Deselect when unfiltered → full clear, otherwise
+  // drifted (transiently-ineligible) ids would sneak back into the
+  // selection after re-eligibility, contradicting the "Deselect all" label.
   const handleToggleAllVisible = useCallback(() => {
-    if (allVisibleSelected) {
+    if (!allVisibleSelected) {
+      picker.setSelectedIds(new Set(picker.visibleIds));
+      return;
+    }
+    if (hasQuery) {
       picker.setSelectedIds((prev) => {
         const next = new Set(prev);
         for (const id of picker.visibleIds) next.delete(id);
         return next;
       });
     } else {
-      picker.setSelectedIds(new Set(picker.visibleIds));
+      picker.setSelectedIds(new Set());
     }
-  }, [allVisibleSelected, picker.setSelectedIds, picker.visibleIds]);
+  }, [allVisibleSelected, hasQuery, picker.setSelectedIds, picker.visibleIds]);
 
   // Additive — preserves existing picks (including non-agent terminals).
   const handleSelectAgents = useCallback(() => {

--- a/src/components/Fleet/__tests__/FleetPickerPalette.test.tsx
+++ b/src/components/Fleet/__tests__/FleetPickerPalette.test.tsx
@@ -426,30 +426,121 @@ describe("FleetPickerPalette", () => {
       expect(selectAgents.disabled).toBe(true);
     });
 
-    it("'Select agents' preserves non-agent terminals already in the selection", async () => {
-      // t-idle is preselected via cold-start (active worktree). Clicking
-      // "Select agents" must ADD t-working without dropping t-idle.
+    it("'Select agents' is truly additive — adds the agent without dropping a manually-picked non-agent", async () => {
+      // No preselection (null active worktree). Filter to the idle terminal,
+      // select it via "Select all visible", clear the query, then click
+      // "Select agents" — the agent must be added on top of the idle pick.
+      useWorktreeSelectionStore.setState({ activeWorktreeId: null });
       seedTerminals([
-        makeTerminal("t-idle", { agentState: "idle", worktreeId: "wt-1" }),
-        makeTerminal("t-working", { agentState: "working", worktreeId: "wt-1" }),
+        makeTerminal("alpha-idle", { agentState: "idle" }),
+        makeTerminal("beta-working", { agentState: "working" }),
       ]);
-      renderPalette([makeWorktreeSnap("wt-1", "main")]);
+      const onClose = vi.fn();
+      renderPalette([makeWorktreeSnap("wt-1", "main")], true, onClose);
       await act(async () => {});
 
-      const confirmBefore = screen.getByTestId(
-        "fleet-picker-cold-start-confirm"
-      ) as HTMLButtonElement;
-      expect(confirmBefore.textContent).toContain("Arm 2 selected");
+      const search = screen.getByTestId("fleet-picker-cold-start-search") as HTMLInputElement;
+      await act(async () => {
+        fireEvent.change(search, { target: { value: "alpha" } });
+      });
+      await act(async () => {});
+
+      await act(async () => {
+        fireEvent.click(screen.getByTestId("fleet-picker-cold-start-select-all"));
+      });
+
+      await act(async () => {
+        fireEvent.change(search, { target: { value: "" } });
+      });
+      await act(async () => {});
 
       await act(async () => {
         fireEvent.click(screen.getByTestId("fleet-picker-cold-start-select-agents"));
       });
 
-      const confirmAfter = screen.getByTestId(
-        "fleet-picker-cold-start-confirm"
-      ) as HTMLButtonElement;
-      // Still 2 — t-working was already selected; t-idle stayed selected.
-      expect(confirmAfter.textContent).toContain("Arm 2 selected");
+      await act(async () => {
+        fireEvent.click(screen.getByTestId("fleet-picker-cold-start-confirm"));
+      });
+
+      const s = useFleetArmingStore.getState();
+      expect(s.armOrder.sort()).toEqual(["alpha-idle", "beta-working"]);
+    });
+
+    it("'Select all visible' replaces a prior cross-filter selection", async () => {
+      // Cold-start preselects wt-1 terminals. Filter to a wt-2 terminal,
+      // hit "Select all visible" — replace semantics drop the wt-1 pick and
+      // leave only the wt-2 visible id in the armed set.
+      seedTerminals([
+        makeTerminal("a-wt1", { worktreeId: "wt-1" }),
+        makeTerminal("b-wt2", { worktreeId: "wt-2" }),
+      ]);
+      const onClose = vi.fn();
+      renderPalette(
+        [makeWorktreeSnap("wt-1", "main"), makeWorktreeSnap("wt-2", "feature")],
+        true,
+        onClose
+      );
+      await act(async () => {});
+
+      const search = screen.getByTestId("fleet-picker-cold-start-search") as HTMLInputElement;
+      await act(async () => {
+        fireEvent.change(search, { target: { value: "b-wt2" } });
+      });
+      await act(async () => {});
+
+      await act(async () => {
+        fireEvent.click(screen.getByTestId("fleet-picker-cold-start-select-all"));
+      });
+
+      await act(async () => {
+        fireEvent.change(search, { target: { value: "" } });
+      });
+      await act(async () => {});
+
+      await act(async () => {
+        fireEvent.click(screen.getByTestId("fleet-picker-cold-start-confirm"));
+      });
+
+      expect(useFleetArmingStore.getState().armOrder).toEqual(["b-wt2"]);
+    });
+
+    it("'Deselect all' (no query) fully clears selection — drifted ids do not survive", async () => {
+      // Cold-start preselects two wt-1 terminals. Simulate drift by removing
+      // one from the panel store while the picker is open. Click the toggle
+      // (label is now "Deselect all", since visible == selected). With the
+      // unfiltered path doing a full clear, when the drifted terminal
+      // re-enters the panel store its id is no longer in selectedIds, so the
+      // confirm-eligible count stays at 0.
+      seedTerminals([
+        makeTerminal("t1", { worktreeId: "wt-1" }),
+        makeTerminal("t2", { worktreeId: "wt-1" }),
+      ]);
+      renderPalette([makeWorktreeSnap("wt-1", "main")]);
+      await act(async () => {});
+
+      let confirm = screen.getByTestId("fleet-picker-cold-start-confirm") as HTMLButtonElement;
+      expect(confirm.textContent).toContain("Arm 2 selected");
+
+      // Drift t2 out of the panel store. visibleIds shrinks to [t1] and
+      // allVisibleSelected stays true (t1 is selected).
+      seedTerminals([makeTerminal("t1", { worktreeId: "wt-1" })]);
+      await act(async () => {});
+
+      await act(async () => {
+        fireEvent.click(screen.getByTestId("fleet-picker-cold-start-select-all"));
+      });
+
+      // Re-introduce t2 — confirm should still be empty if "Deselect all"
+      // really cleared everything.
+      seedTerminals([
+        makeTerminal("t1", { worktreeId: "wt-1" }),
+        makeTerminal("t2", { worktreeId: "wt-1" }),
+      ]);
+      await act(async () => {});
+
+      confirm = screen.getByTestId("fleet-picker-cold-start-confirm") as HTMLButtonElement;
+      expect(confirm.disabled).toBe(true);
+      expect(confirm.textContent).toContain("Arm selected");
     });
 
     it("footer status reads as a persistent prompt with role='status'", async () => {

--- a/src/components/Fleet/__tests__/FleetPickerPalette.test.tsx
+++ b/src/components/Fleet/__tests__/FleetPickerPalette.test.tsx
@@ -119,7 +119,9 @@ describe("FleetPickerPalette", () => {
     seedTerminals([makeTerminal("t1")]);
     renderPalette([makeWorktreeSnap("wt-1", "main")]);
     await act(async () => {});
-    expect(screen.getByText("Select terminals to arm")).toBeTruthy();
+    // "Select terminals to arm" appears in both the h2 header and the footer
+    // status span (which is now a persistent prompt), so scope to the heading.
+    expect(screen.getByRole("heading", { name: "Select terminals to arm" })).toBeTruthy();
     expect(screen.getByTestId("fleet-picker-cold-start-root")).toBeTruthy();
   });
 
@@ -272,5 +274,192 @@ describe("FleetPickerPalette", () => {
     );
     const confirm = screen.getByTestId("fleet-picker-cold-start-confirm") as HTMLButtonElement;
     expect(confirm.disabled).toBe(true);
+  });
+
+  describe("Select all / Select agents footer buttons", () => {
+    it("renders 'Select all' and selects all visible terminals on click", async () => {
+      // No active worktree → no preselection, so the Arm button starts at 0
+      // and clicking "Select all" must populate the selection.
+      useWorktreeSelectionStore.setState({ activeWorktreeId: null });
+      seedTerminals([makeTerminal("t1"), makeTerminal("t2"), makeTerminal("t3")]);
+      renderPalette([makeWorktreeSnap("wt-1", "main")]);
+      await act(async () => {});
+
+      const selectAll = screen.getByTestId(
+        "fleet-picker-cold-start-select-all"
+      ) as HTMLButtonElement;
+      expect(selectAll.textContent).toContain("Select all");
+      expect(selectAll.disabled).toBe(false);
+
+      await act(async () => {
+        fireEvent.click(selectAll);
+      });
+
+      const confirm = screen.getByTestId("fleet-picker-cold-start-confirm") as HTMLButtonElement;
+      expect(confirm.textContent).toContain("Arm 3 selected");
+    });
+
+    it("label becomes 'Select all visible' when a search query narrows the list", async () => {
+      useWorktreeSelectionStore.setState({ activeWorktreeId: null });
+      seedTerminals([makeTerminal("alpha"), makeTerminal("beta"), makeTerminal("gamma")]);
+      renderPalette([makeWorktreeSnap("wt-1", "main")]);
+      await act(async () => {});
+
+      const search = screen.getByTestId("fleet-picker-cold-start-search") as HTMLInputElement;
+      await act(async () => {
+        fireEvent.change(search, { target: { value: "alp" } });
+      });
+      await act(async () => {});
+
+      const selectAll = screen.getByTestId(
+        "fleet-picker-cold-start-select-all"
+      ) as HTMLButtonElement;
+      expect(selectAll.textContent).toContain("Select all visible");
+
+      await act(async () => {
+        fireEvent.click(selectAll);
+      });
+
+      const confirm = screen.getByTestId("fleet-picker-cold-start-confirm") as HTMLButtonElement;
+      // Only "alpha" matches the query, so exactly one terminal is armed.
+      expect(confirm.textContent).toContain("Arm 1 selected");
+    });
+
+    it("toggles to 'Deselect all' once every visible terminal is selected", async () => {
+      useWorktreeSelectionStore.setState({ activeWorktreeId: null });
+      seedTerminals([makeTerminal("t1"), makeTerminal("t2")]);
+      renderPalette([makeWorktreeSnap("wt-1", "main")]);
+      await act(async () => {});
+
+      const selectAll = screen.getByTestId(
+        "fleet-picker-cold-start-select-all"
+      ) as HTMLButtonElement;
+      await act(async () => {
+        fireEvent.click(selectAll);
+      });
+      expect(selectAll.textContent).toContain("Deselect all");
+
+      await act(async () => {
+        fireEvent.click(selectAll);
+      });
+      const confirm = screen.getByTestId("fleet-picker-cold-start-confirm") as HTMLButtonElement;
+      expect(confirm.disabled).toBe(true);
+      expect(selectAll.textContent).toContain("Select all");
+    });
+
+    it("'Deselect visible' only removes the filtered subset and keeps other picks", async () => {
+      // Cold-start preselects active-worktree eligibles, so all three start
+      // selected. Filtering to "alpha" and clicking the button should drop
+      // alpha but keep beta and gamma selected.
+      seedTerminals([
+        makeTerminal("alpha", { worktreeId: "wt-1" }),
+        makeTerminal("beta", { worktreeId: "wt-1" }),
+        makeTerminal("gamma", { worktreeId: "wt-1" }),
+      ]);
+      renderPalette([makeWorktreeSnap("wt-1", "main")]);
+      await act(async () => {});
+
+      const search = screen.getByTestId("fleet-picker-cold-start-search") as HTMLInputElement;
+      await act(async () => {
+        fireEvent.change(search, { target: { value: "alp" } });
+      });
+      await act(async () => {});
+
+      const selectAll = screen.getByTestId(
+        "fleet-picker-cold-start-select-all"
+      ) as HTMLButtonElement;
+      expect(selectAll.textContent).toContain("Deselect visible");
+
+      await act(async () => {
+        fireEvent.click(selectAll);
+      });
+
+      // Clear the query — confirm should now show beta + gamma still selected.
+      await act(async () => {
+        fireEvent.change(search, { target: { value: "" } });
+      });
+      await act(async () => {});
+
+      const confirm = screen.getByTestId("fleet-picker-cold-start-confirm") as HTMLButtonElement;
+      expect(confirm.textContent).toContain("Arm 2 selected");
+    });
+
+    it("'Select agents' adds only working/waiting/directing terminals additively", async () => {
+      useWorktreeSelectionStore.setState({ activeWorktreeId: null });
+      seedTerminals([
+        makeTerminal("t-working", { agentState: "working" }),
+        makeTerminal("t-waiting", { agentState: "waiting" }),
+        makeTerminal("t-directing", { agentState: "directing" }),
+        makeTerminal("t-idle", { agentState: "idle" }),
+        makeTerminal("t-completed", { agentState: "completed" }),
+        makeTerminal("t-exited", { agentState: "exited" }),
+      ]);
+      renderPalette([makeWorktreeSnap("wt-1", "main")]);
+      await act(async () => {});
+
+      const selectAgents = screen.getByTestId(
+        "fleet-picker-cold-start-select-agents"
+      ) as HTMLButtonElement;
+      expect(selectAgents.disabled).toBe(false);
+
+      await act(async () => {
+        fireEvent.click(selectAgents);
+      });
+
+      const confirm = screen.getByTestId("fleet-picker-cold-start-confirm") as HTMLButtonElement;
+      // Exactly 3: working + waiting + directing. idle/completed/exited skipped.
+      expect(confirm.textContent).toContain("Arm 3 selected");
+    });
+
+    it("'Select agents' is disabled when no visible terminals are in an active agent state", async () => {
+      useWorktreeSelectionStore.setState({ activeWorktreeId: null });
+      seedTerminals([
+        makeTerminal("t1", { agentState: "idle" }),
+        makeTerminal("t2", { agentState: "completed" }),
+      ]);
+      renderPalette([makeWorktreeSnap("wt-1", "main")]);
+      await act(async () => {});
+
+      const selectAgents = screen.getByTestId(
+        "fleet-picker-cold-start-select-agents"
+      ) as HTMLButtonElement;
+      expect(selectAgents.disabled).toBe(true);
+    });
+
+    it("'Select agents' preserves non-agent terminals already in the selection", async () => {
+      // t-idle is preselected via cold-start (active worktree). Clicking
+      // "Select agents" must ADD t-working without dropping t-idle.
+      seedTerminals([
+        makeTerminal("t-idle", { agentState: "idle", worktreeId: "wt-1" }),
+        makeTerminal("t-working", { agentState: "working", worktreeId: "wt-1" }),
+      ]);
+      renderPalette([makeWorktreeSnap("wt-1", "main")]);
+      await act(async () => {});
+
+      const confirmBefore = screen.getByTestId(
+        "fleet-picker-cold-start-confirm"
+      ) as HTMLButtonElement;
+      expect(confirmBefore.textContent).toContain("Arm 2 selected");
+
+      await act(async () => {
+        fireEvent.click(screen.getByTestId("fleet-picker-cold-start-select-agents"));
+      });
+
+      const confirmAfter = screen.getByTestId(
+        "fleet-picker-cold-start-confirm"
+      ) as HTMLButtonElement;
+      // Still 2 — t-working was already selected; t-idle stayed selected.
+      expect(confirmAfter.textContent).toContain("Arm 2 selected");
+    });
+
+    it("footer status reads as a persistent prompt with role='status'", async () => {
+      seedTerminals([makeTerminal("t1")]);
+      renderPalette([makeWorktreeSnap("wt-1", "main")]);
+      await act(async () => {});
+
+      const status = screen.getByTestId("fleet-picker-cold-start-status");
+      expect(status.getAttribute("role")).toBe("status");
+      expect(status.textContent).toBe("Select terminals to arm");
+    });
   });
 });


### PR DESCRIPTION
## Summary

- Adds a visible "Select all" / "Select all visible" toggle button and a "Select agents" button to the fleet picker palette footer, addressing the discoverability gap where `Cmd+A` was the only way to bulk-select
- Replaces the dynamic count label in the footer with a persistent "Select terminals to arm" prompt — the count lives on the Arm button now, where it's already more contextually useful
- "Select agents" is additive and targets working, waiting, and directing terminals specifically, which covers the common recipe-across-fleet flow

Resolves #7800

## Changes

- `FleetPickerPalette.tsx` — footer rebuilt with select-all toggle (`Select all` / `Select all visible` / `Deselect all` / `Deselect visible` depending on filter state) and "Select agents" button; "Deselect all" fully clears including any ids that drifted out of the current view, "Deselect visible" scopes to filtered ids only; select semantics match `Cmd+A` (replace, not additive)
- `FleetPickerPalette.test.tsx` — extended with coverage for all new button states and selection/deselection behaviour

## Testing

- Unit tests updated and passing for all new button variants and selection semantics
- Verified select-all, deselect-all, select-visible, deselect-visible, and select-agents flows against filtered and unfiltered lists