### PR TITLE
feat(worktree-card): surface review state and add commit-and-push button

### DIFF
--- a/src/components/Worktree/WorktreeCard.tsx
+++ b/src/components/Worktree/WorktreeCard.tsx
@@ -40,6 +40,7 @@ import {
 import { useInputReceiptKey } from "./WorktreeCard/hooks/useInputReceiptKey";
 import { useWorktreeActions } from "./WorktreeCard/hooks/useWorktreeActions";
 import { copyContextWithFeedback } from "@/hooks/useWorktreeActions";
+import { formatErrorMessage } from "@shared/utils/errorMessage";
 import { useCopyWithFeedback } from "@/hooks/useCopyWithFeedback";
 import { ContextMenu, ContextMenuContent, ContextMenuTrigger } from "@/components/ui/context-menu";
 import { CONTEXT_COMPONENTS, WorktreeMenuItems } from "./WorktreeMenuItems";
@@ -293,6 +294,7 @@ export function WorktreeCard({
     effectiveNote,
     effectiveSummary,
     computedSubtitle,
+    reviewState,
     spineState,
     isLifecycleRunning,
     lifecycleLabel,
@@ -433,6 +435,9 @@ export function WorktreeCard({
   const [showIssuePicker, setShowIssuePicker] = useState(false);
   const [showReviewHub, setShowReviewHub] = useState(false);
   const [showPlanViewer, setShowPlanViewer] = useState(false);
+  const [isCommittingAndPushing, setIsCommittingAndPushing] = useState(false);
+  const [commitAndPushError, setCommitAndPushError] = useState<string | null>(null);
+  const commitAndPushInFlightRef = useRef(false);
 
   const onCloseReviewHub = () => setShowReviewHub(false);
   const onClosePlanViewer = () => setShowPlanViewer(false);
@@ -465,6 +470,46 @@ export function WorktreeCard({
     window.addEventListener("daintree:open-review-hub", handler);
     return () => window.removeEventListener("daintree:open-review-hub", handler);
   }, [worktree.id]);
+
+  const aiNoteFirstLine = worktree.aiNote?.trim().split("\n")[0]?.trim() ?? "";
+  const lastCommitFirstLine =
+    worktree.worktreeChanges?.lastCommitMessage?.trim().split("\n")[0]?.trim() ?? "";
+  const commitMessageDefault = aiNoteFirstLine || lastCommitFirstLine;
+  const hasCommitMessageSource = commitMessageDefault.length > 0;
+
+  const clearCommitAndPushError = () => setCommitAndPushError(null);
+
+  const handleCommitAndPush = async () => {
+    if (commitAndPushInFlightRef.current) return;
+    if (!commitMessageDefault) return;
+    commitAndPushInFlightRef.current = true;
+    setIsCommittingAndPushing(true);
+    setCommitAndPushError(null);
+    try {
+      try {
+        await window.electron.git.stageAll(worktree.path);
+      } catch (err) {
+        setCommitAndPushError(formatErrorMessage(err, "Couldn't stage changes"));
+        return;
+      }
+      try {
+        await window.electron.git.commit(worktree.path, commitMessageDefault);
+      } catch (err) {
+        setCommitAndPushError(formatErrorMessage(err, "Couldn't commit changes"));
+        return;
+      }
+      try {
+        await window.electron.git.push(worktree.path);
+      } catch (err) {
+        setCommitAndPushError(formatErrorMessage(err, "Couldn't push to remote"));
+        return;
+      }
+    } finally {
+      setIsCommittingAndPushing(false);
+      commitAndPushInFlightRef.current = false;
+    }
+  };
+
 
   const handleAttachIssue = async (issue: GitHubIssue) => {
     await worktreeClient.attachIssue({
@@ -837,6 +882,7 @@ export function WorktreeCard({
                     isExpanded={isExpanded}
                     hasChanges={hasChanges}
                     computedSubtitle={computedSubtitle}
+                    reviewState={reviewState}
                     effectiveNote={effectiveNote}
                     effectiveSummary={effectiveSummary}
                     worktreeErrors={worktreeErrors}
@@ -846,6 +892,11 @@ export function WorktreeCard({
                     onDismissError={dismissError}
                     onRetryError={handleErrorRetry}
                     onOpenReviewHub={openReviewHubForThisWorktree}
+                    onCommitAndPush={() => void handleCommitAndPush()}
+                    isCommitting={isCommittingAndPushing}
+                    commitError={commitAndPushError}
+                    clearCommitError={clearCommitAndPushError}
+                    hasCommitMessageSource={hasCommitMessageSource}
                     isLifecycleRunning={isLifecycleRunning}
                     lifecycleLabel={lifecycleLabel}
                     hasResourceConfig={hasResourceConfig}

--- a/src/components/Worktree/WorktreeCard.tsx
+++ b/src/components/Worktree/WorktreeCard.tsx
@@ -471,13 +471,19 @@ export function WorktreeCard({
     return () => window.removeEventListener("daintree:open-review-hub", handler);
   }, [worktree.id]);
 
-  const aiNoteFirstLine = worktree.aiNote?.trim().split("\n")[0]?.trim() ?? "";
+  const aiNoteFirstLine = effectiveNote?.split("\n")[0]?.trim() ?? "";
   const lastCommitFirstLine =
     worktree.worktreeChanges?.lastCommitMessage?.trim().split("\n")[0]?.trim() ?? "";
   const commitMessageDefault = aiNoteFirstLine || lastCommitFirstLine;
   const hasCommitMessageSource = commitMessageDefault.length > 0;
 
   const clearCommitAndPushError = () => setCommitAndPushError(null);
+
+  useEffect(() => {
+    if (reviewState !== "has-changes") {
+      setCommitAndPushError(null);
+    }
+  }, [reviewState]);
 
   const handleCommitAndPush = async () => {
     if (commitAndPushInFlightRef.current) return;

--- a/src/components/Worktree/WorktreeCard/WorktreeDetailsSection.tsx
+++ b/src/components/Worktree/WorktreeCard/WorktreeDetailsSection.tsx
@@ -10,16 +10,18 @@ import { ActivityLight } from "../ActivityLight";
 import { LiveTimeAgo } from "../LiveTimeAgo";
 import { WorktreeDetails } from "../WorktreeDetails";
 import {
+  Activity,
+  AlertTriangle,
   ChevronRight,
   GitCommitHorizontal,
-  Play,
-  Square,
   Plug,
-  Activity,
+  Play,
+  Send,
+  Square,
   Trash2,
 } from "lucide-react";
 import { Spinner } from "@/components/ui/Spinner";
-import type { ComputedSubtitle } from "./hooks/useWorktreeStatus";
+import type { ComputedSubtitle, WorktreeReviewState } from "./hooks/useWorktreeStatus";
 import { Tooltip, TooltipContent, TooltipTrigger } from "@/components/ui/tooltip";
 import {
   ContextMenu,
@@ -35,6 +37,7 @@ export interface WorktreeDetailsSectionProps {
   isExpanded: boolean;
   hasChanges: boolean;
   computedSubtitle: ComputedSubtitle;
+  reviewState?: WorktreeReviewState;
   effectiveNote?: string;
   effectiveSummary?: string | null;
   worktreeErrors: ErrorRecord[];
@@ -44,6 +47,11 @@ export interface WorktreeDetailsSectionProps {
   onDismissError: (id: string) => void;
   onRetryError: (id: string, action: RetryAction, args?: Record<string, unknown>) => Promise<void>;
   onOpenReviewHub?: () => void;
+  onCommitAndPush?: () => void;
+  isCommitting?: boolean;
+  commitError?: string | null;
+  clearCommitError?: () => void;
+  hasCommitMessageSource?: boolean;
   isLifecycleRunning?: boolean;
   lifecycleLabel?: string;
 
@@ -73,6 +81,12 @@ export function WorktreeDetailsSection(props: WorktreeDetailsSectionProps) {
     onDismissError,
     onRetryError,
     onOpenReviewHub,
+    onCommitAndPush,
+    isCommitting,
+    commitError,
+    clearCommitError,
+    hasCommitMessageSource,
+    reviewState,
     isLifecycleRunning,
     lifecycleLabel,
 
@@ -117,6 +131,12 @@ export function WorktreeDetailsSection(props: WorktreeDetailsSectionProps) {
       { duration: DURATION_200 / 1000, ease: [0.4, 0, 0.2, 1] }
     );
   }, [changedFileCount, prefersReducedMotion, animate, countScope]);
+
+  const isConflicted = reviewState === "conflicted";
+  const showCommitAndPushButton =
+    !!onCommitAndPush && !!hasCommitMessageSource && reviewState === "has-changes" && !isCommitting;
+  const showReviewHubButton = !!onOpenReviewHub && hasChanges;
+  const rightButtonGroupShown = showReviewHubButton || showCommitAndPushButton || !!isCommitting;
 
   const rsLower = resourceStatus?.toLowerCase();
   const showResourceResume =
@@ -176,9 +196,7 @@ export function WorktreeDetailsSection(props: WorktreeDetailsSectionProps) {
             onClick={onToggleExpand}
             className={cn(
               "worktree-section-button relative flex min-w-0 flex-1 items-center justify-between px-3 py-2.5 text-left transition-colors",
-              onOpenReviewHub && hasChanges
-                ? "rounded-l-[var(--radius-lg)]"
-                : "rounded-[var(--radius-lg)]"
+              rightButtonGroupShown ? "rounded-l-[var(--radius-lg)]" : "rounded-[var(--radius-lg)]"
             )}
           >
             <button
@@ -189,7 +207,7 @@ export function WorktreeDetailsSection(props: WorktreeDetailsSectionProps) {
               aria-label="Show details"
               className={cn(
                 "absolute inset-0",
-                onOpenReviewHub && hasChanges
+                rightButtonGroupShown
                   ? "rounded-l-[var(--radius-lg)]"
                   : "rounded-[var(--radius-lg)]",
                 "focus-visible:outline focus-visible:outline-2 focus-visible:outline-daintree-accent focus-visible:outline-offset-[-2px]"
@@ -205,6 +223,11 @@ export function WorktreeDetailsSection(props: WorktreeDetailsSectionProps) {
                 !isLifecycleRunning &&
                 worktree.lifecycleStatus?.state !== "success" ? (
                 <span className="text-status-error">{lifecycleLabel}</span>
+              ) : isConflicted ? (
+                <span className="flex items-center gap-1.5 text-status-error">
+                  <AlertTriangle className="w-3 h-3 shrink-0" aria-hidden="true" />
+                  <span className="truncate">Conflicts need review</span>
+                </span>
               ) : hasChanges && worktree.worktreeChanges ? (
                 <span className="flex items-center gap-1.5 text-text-secondary">
                   <span ref={countScope} className="inline-block">
@@ -370,7 +393,7 @@ export function WorktreeDetailsSection(props: WorktreeDetailsSectionProps) {
             </Tooltip>
           </div>
 
-          {onOpenReviewHub && hasChanges && (
+          {showReviewHubButton && (
             <Tooltip>
               <TooltipTrigger asChild>
                 <button
@@ -378,7 +401,7 @@ export function WorktreeDetailsSection(props: WorktreeDetailsSectionProps) {
                   className={cn(
                     "shrink-0 border-l border-border-default px-2 py-1 transition-colors",
                     "text-[var(--color-state-active)]/70 hover:bg-[var(--color-state-active)]/10 hover:text-[var(--color-state-active)]",
-                    "rounded-r-[var(--radius-lg)]",
+                    !showCommitAndPushButton && !isCommitting && "rounded-r-[var(--radius-lg)]",
                     "focus-visible:outline-hidden focus-visible:ring-2 focus-visible:ring-daintree-accent"
                   )}
                   aria-label="Open Review & Commit"
@@ -389,6 +412,72 @@ export function WorktreeDetailsSection(props: WorktreeDetailsSectionProps) {
               <TooltipContent side="bottom">Review & Commit</TooltipContent>
             </Tooltip>
           )}
+
+          {showCommitAndPushButton && (
+            <Tooltip>
+              <TooltipTrigger asChild>
+                <button
+                  onClick={onCommitAndPush}
+                  className={cn(
+                    "shrink-0 border-l border-border-default px-2 py-1 transition-colors",
+                    "text-status-success/70 hover:bg-status-success/10 hover:text-status-success",
+                    "rounded-r-[var(--radius-lg)]",
+                    "focus-visible:outline-hidden focus-visible:ring-2 focus-visible:ring-daintree-accent"
+                  )}
+                  aria-label="Commit and push"
+                >
+                  <Send className="w-3.5 h-3.5" />
+                </button>
+              </TooltipTrigger>
+              <TooltipContent side="bottom">Commit & push</TooltipContent>
+            </Tooltip>
+          )}
+
+          {isCommitting && (
+            <div
+              role="status"
+              aria-label="Committing and pushing"
+              className={cn(
+                "shrink-0 border-l border-border-default px-2 py-1",
+                "text-status-success",
+                "rounded-r-[var(--radius-lg)]",
+                "flex items-center"
+              )}
+            >
+              <Spinner size="xs" />
+            </div>
+          )}
+        </div>
+      )}
+
+      {!isExpanded && commitError && (
+        <div className="-mx-3 -mb-3 mt-3 flex items-start gap-2 rounded-b-[var(--radius-lg)] border-t border-border-default bg-surface-inset px-3 py-2 text-xs text-status-error">
+          <AlertTriangle className="w-3.5 h-3.5 shrink-0 mt-0.5" aria-hidden="true" />
+          <span className="flex-1 break-words">{commitError}</span>
+          <div className="flex shrink-0 items-center gap-2">
+            {onOpenReviewHub && (
+              <button
+                type="button"
+                onClick={() => {
+                  clearCommitError?.();
+                  onOpenReviewHub?.();
+                }}
+                className="text-status-error underline-offset-2 hover:underline focus-visible:outline-hidden focus-visible:ring-2 focus-visible:ring-daintree-accent rounded"
+              >
+                Open review hub
+              </button>
+            )}
+            {clearCommitError && (
+              <button
+                type="button"
+                onClick={clearCommitError}
+                aria-label="Dismiss error"
+                className="text-text-muted hover:text-text-primary focus-visible:outline-hidden focus-visible:ring-2 focus-visible:ring-daintree-accent rounded"
+              >
+                Dismiss
+              </button>
+            )}
+          </div>
         </div>
       )}
     </div>

--- a/src/components/Worktree/WorktreeCard/__tests__/WorktreeDetailsSection.test.tsx
+++ b/src/components/Worktree/WorktreeCard/__tests__/WorktreeDetailsSection.test.tsx
@@ -3,7 +3,7 @@
  */
 import React from "react";
 import { describe, it, expect, vi, beforeEach, afterEach } from "vitest";
-import { render, screen } from "@testing-library/react";
+import { fireEvent, render, screen } from "@testing-library/react";
 import type { ReactNode } from "react";
 import type { WorktreeState } from "@/types";
 import type { WorktreeChanges } from "@shared/types/git";
@@ -288,6 +288,107 @@ describe("WorktreeDetailsSection count pill bump", () => {
 
     expect(mockAnimate).not.toHaveBeenCalled();
     expect(screen.getByText(/5 files/)).toBeDefined();
+  });
+});
+
+describe("WorktreeDetailsSection — reviewState surfaces", () => {
+  it('replaces churn subtitle with conflict callout when reviewState is "conflicted"', () => {
+    renderSection({
+      reviewState: "conflicted",
+      worktree: withChanges({
+        changedFileCount: 4,
+        changes: [{ path: "a.ts", status: "conflicted", insertions: null, deletions: null }],
+      }),
+    });
+    expect(screen.getByText("Conflicts need review")).toBeDefined();
+    expect(screen.queryByText(/files/)).toBeNull();
+  });
+
+  it("renders the Commit & push button when gated", () => {
+    const onCommitAndPush = vi.fn();
+    renderSection({
+      reviewState: "has-changes",
+      hasCommitMessageSource: true,
+      onCommitAndPush,
+    });
+    const button = screen.getByLabelText("Commit and push");
+    expect(button).toBeDefined();
+    fireEvent.click(button);
+    expect(onCommitAndPush).toHaveBeenCalledTimes(1);
+  });
+
+  it("hides the Commit & push button when there is no commit message source", () => {
+    renderSection({
+      reviewState: "has-changes",
+      hasCommitMessageSource: false,
+      onCommitAndPush: vi.fn(),
+    });
+    expect(screen.queryByLabelText("Commit and push")).toBeNull();
+  });
+
+  it('hides the Commit & push button when reviewState is "conflicted"', () => {
+    renderSection({
+      reviewState: "conflicted",
+      hasCommitMessageSource: true,
+      onCommitAndPush: vi.fn(),
+      worktree: withChanges({
+        changedFileCount: 2,
+        changes: [{ path: "a.ts", status: "conflicted", insertions: null, deletions: null }],
+      }),
+    });
+    expect(screen.queryByLabelText("Commit and push")).toBeNull();
+  });
+
+  it("swaps the button for a spinner while committing", () => {
+    renderSection({
+      reviewState: "has-changes",
+      hasCommitMessageSource: true,
+      onCommitAndPush: vi.fn(),
+      isCommitting: true,
+    });
+    expect(screen.queryByLabelText("Commit and push")).toBeNull();
+    expect(screen.getByLabelText("Committing and pushing")).toBeDefined();
+  });
+
+  it("renders an inline error banner with commitError", () => {
+    renderSection({
+      reviewState: "has-changes",
+      hasCommitMessageSource: true,
+      onCommitAndPush: vi.fn(),
+      commitError: "Couldn't push to remote",
+      clearCommitError: vi.fn(),
+      onOpenReviewHub: vi.fn(),
+    });
+    expect(screen.getByText("Couldn't push to remote")).toBeDefined();
+    expect(screen.getByText("Open review hub")).toBeDefined();
+  });
+
+  it("invokes clearCommitError and onOpenReviewHub from the banner CTA", () => {
+    const clearCommitError = vi.fn();
+    const onOpenReviewHub = vi.fn();
+    renderSection({
+      reviewState: "has-changes",
+      hasCommitMessageSource: true,
+      onCommitAndPush: vi.fn(),
+      commitError: "Couldn't push to remote",
+      clearCommitError,
+      onOpenReviewHub,
+    });
+    fireEvent.click(screen.getByText("Open review hub"));
+    expect(clearCommitError).toHaveBeenCalledTimes(1);
+    expect(onOpenReviewHub).toHaveBeenCalledTimes(1);
+  });
+
+  it("dismisses the banner via the Dismiss button", () => {
+    const clearCommitError = vi.fn();
+    renderSection({
+      reviewState: "has-changes",
+      hasCommitMessageSource: true,
+      commitError: "Couldn't push to remote",
+      clearCommitError,
+    });
+    fireEvent.click(screen.getByLabelText("Dismiss error"));
+    expect(clearCommitError).toHaveBeenCalledTimes(1);
   });
 });
 

--- a/src/components/Worktree/WorktreeCard/__tests__/WorktreeDetailsSection.test.tsx
+++ b/src/components/Worktree/WorktreeCard/__tests__/WorktreeDetailsSection.test.tsx
@@ -390,6 +390,38 @@ describe("WorktreeDetailsSection — reviewState surfaces", () => {
     fireEvent.click(screen.getByLabelText("Dismiss error"));
     expect(clearCommitError).toHaveBeenCalledTimes(1);
   });
+
+  it('does not render Commit & push or conflict callout when reviewState is "unpushed-clean"', () => {
+    renderSection({
+      reviewState: "unpushed-clean",
+      hasChanges: false,
+      hasCommitMessageSource: true,
+      onCommitAndPush: vi.fn(),
+      computedSubtitle: { text: "fix: stuff", tone: "muted" },
+      worktree: {
+        ...baseWorktree,
+        worktreeChanges: {
+          ...baseWorktree.worktreeChanges,
+          changedFileCount: 0,
+          ahead: 2,
+        } as WorktreeChanges,
+      },
+    });
+    expect(screen.queryByLabelText("Commit and push")).toBeNull();
+    expect(screen.queryByText("Conflicts need review")).toBeNull();
+    expect(screen.getByText("fix: stuff")).toBeDefined();
+  });
+
+  it("hides the error banner when expanded", () => {
+    renderSection({
+      isExpanded: true,
+      reviewState: "has-changes",
+      hasCommitMessageSource: true,
+      commitError: "Couldn't push to remote",
+      clearCommitError: vi.fn(),
+    });
+    expect(screen.queryByText("Couldn't push to remote")).toBeNull();
+  });
 });
 
 describe("WorktreeDetailsSection activity indicator", () => {

--- a/src/components/Worktree/WorktreeCard/hooks/__tests__/useWorktreeStatus.test.tsx
+++ b/src/components/Worktree/WorktreeCard/hooks/__tests__/useWorktreeStatus.test.tsx
@@ -2,7 +2,11 @@
 import { describe, it, expect } from "vitest";
 import { renderHook } from "@testing-library/react";
 import type { WorktreeState, WorktreeChanges } from "@/types";
-import { useWorktreeStatus, type WorktreeLifecycleStage } from "../useWorktreeStatus";
+import {
+  useWorktreeStatus,
+  type WorktreeLifecycleStage,
+  type WorktreeReviewState,
+} from "../useWorktreeStatus";
 
 function makeChanges(overrides: Partial<WorktreeChanges> = {}): WorktreeChanges {
   return {
@@ -545,6 +549,111 @@ describe("useWorktreeStatus — computedSubtitle", () => {
     expect(getSubtitle({ worktreeChanges: makeChanges({ lastCommitMessage: undefined }) })).toEqual(
       { text: "No recent activity", tone: "muted" }
     );
+  });
+});
+
+describe("useWorktreeStatus — reviewState", () => {
+  function getReviewState(overrides: Partial<WorktreeState> = {}): WorktreeReviewState {
+    const { result } = renderHook(() => useWorktreeStatus({ worktree: makeWorktree(overrides) }));
+    return result.current.reviewState;
+  }
+
+  it("returns null when worktreeChanges is null", () => {
+    expect(getReviewState({ worktreeChanges: null })).toBeNull();
+  });
+
+  it("returns null when no changes, no ahead, no conflicts", () => {
+    expect(
+      getReviewState({
+        worktreeChanges: makeChanges({ changedFileCount: 0, ahead: 0 }),
+      })
+    ).toBeNull();
+  });
+
+  it('returns "conflicted" when any change has status "conflicted"', () => {
+    expect(
+      getReviewState({
+        worktreeChanges: makeChanges({
+          changedFileCount: 2,
+          changes: [
+            { path: "a.ts", status: "conflicted", insertions: null, deletions: null },
+            { path: "b.ts", status: "modified", insertions: 1, deletions: 0 },
+          ],
+        }),
+      })
+    ).toBe("conflicted");
+  });
+
+  it('"conflicted" wins over ahead and changes', () => {
+    expect(
+      getReviewState({
+        worktreeChanges: makeChanges({
+          changedFileCount: 5,
+          ahead: 3,
+          changes: [{ path: "a.ts", status: "conflicted", insertions: null, deletions: null }],
+        }),
+      })
+    ).toBe("conflicted");
+  });
+
+  it('returns "has-changes" when changedFileCount > 0 and no conflicts', () => {
+    expect(
+      getReviewState({
+        worktreeChanges: makeChanges({
+          changedFileCount: 3,
+          changes: [{ path: "a.ts", status: "modified", insertions: 2, deletions: 1 }],
+        }),
+      })
+    ).toBe("has-changes");
+  });
+
+  it('"has-changes" wins over "unpushed-clean" when both apply', () => {
+    expect(
+      getReviewState({
+        worktreeChanges: makeChanges({
+          changedFileCount: 1,
+          ahead: 2,
+        }),
+      })
+    ).toBe("has-changes");
+  });
+
+  it('returns "unpushed-clean" when ahead > 0 and no changes', () => {
+    expect(
+      getReviewState({
+        worktreeChanges: makeChanges({
+          changedFileCount: 0,
+          ahead: 2,
+        }),
+      })
+    ).toBe("unpushed-clean");
+  });
+
+  it("treats undefined ahead and empty changes as null", () => {
+    expect(
+      getReviewState({
+        worktreeChanges: makeChanges({
+          changedFileCount: 0,
+          ahead: undefined,
+          changes: [],
+        }),
+      })
+    ).toBeNull();
+  });
+
+  it("treats missing changes array as no conflicts", () => {
+    const { result } = renderHook(() =>
+      useWorktreeStatus({
+        worktree: makeWorktree({
+          worktreeChanges: {
+            worktreeId: "/test/worktree",
+            rootPath: "/test/worktree",
+            changedFileCount: 2,
+          } as unknown as WorktreeChanges,
+        }),
+      })
+    );
+    expect(result.current.reviewState).toBe("has-changes");
   });
 });
 

--- a/src/components/Worktree/WorktreeCard/hooks/useWorktreeStatus.ts
+++ b/src/components/Worktree/WorktreeCard/hooks/useWorktreeStatus.ts
@@ -15,6 +15,8 @@ export interface ComputedSubtitle {
   tone: ComputedSubtitleTone;
 }
 
+export type WorktreeReviewState = "conflicted" | "unpushed-clean" | "has-changes" | null;
+
 export type ResourceStatusColor = "green" | "yellow" | "red" | "neutral";
 
 export interface UseWorktreeStatusResult {
@@ -26,6 +28,7 @@ export interface UseWorktreeStatusResult {
   effectiveNote?: string;
   effectiveSummary?: string | null;
   computedSubtitle: ComputedSubtitle;
+  reviewState: WorktreeReviewState;
   spineState: SpineState;
   isLifecycleRunning: boolean;
   lifecycleLabel?: string;
@@ -142,6 +145,15 @@ export function useWorktreeStatus({
     return "idle";
   }, [hasChanges, worktree.isCurrent, worktree.mood]);
 
+  const reviewState: WorktreeReviewState = useMemo(() => {
+    const changes = worktree.worktreeChanges;
+    if (!changes) return null;
+    if (changes.changes?.some((c) => c.status === "conflicted")) return "conflicted";
+    if ((changes.changedFileCount ?? 0) > 0) return "has-changes";
+    if ((changes.ahead ?? 0) > 0) return "unpushed-clean";
+    return null;
+  }, [worktree.worktreeChanges]);
+
   const isComplete =
     !!worktree.issueNumber &&
     !!worktree.prNumber &&
@@ -238,6 +250,7 @@ export function useWorktreeStatus({
     effectiveNote,
     effectiveSummary,
     computedSubtitle,
+    reviewState,
     spineState,
     isLifecycleRunning,
     lifecycleLabel,


### PR DESCRIPTION
## Summary

- Adds a `reviewState` axis to `useWorktreeStatus` (`conflicted | has-changes | unpushed-clean | null`), derived purely from existing `worktreeChanges` data — no new subscriptions
- When `reviewState === "conflicted"`, the collapsed card subtitle swaps to a Tier 3 inline error callout ("Conflicts need review") instead of the churn line
- New commit-and-push button sits next to the existing Review Hub button: visible only when `reviewState === "has-changes"` and a commit message source is available (`aiNote` first-line via effectiveNote TTL, falling back to `lastCommitMessage`)

Resolves #7798

## Changes

- `useWorktreeStatus.ts` — new `reviewState` field on the return type; derived from `worktreeChanges.changes` and `aheadCount`
- `WorktreeDetailsSection.tsx` — renders the conflict callout and the commit-and-push button; `useRef` reentrancy guard prevents double-execution (pattern from #4703); spinner replaces button during the `stageAll → commit → push` IPC chain
- `WorktreeCard.tsx` — threads `commitMessage` and `reviewState` through to `WorktreeDetailsSection`
- Inline error banner on failure: "Open review hub" recovery CTA + Dismiss; no toast; auto-clears when `reviewState` moves off `has-changes`; hidden when the section is expanded
- 94 unit tests across `WorktreeDetailsSection.test.tsx` and `useWorktreeStatus.test.tsx` covering all state transitions and surfaces

## Testing

- Unit tests pass (`npm run check`)
- Manually verified conflict callout, button gating, spinner, error banner, and auto-clear against a live worktree