### PR TITLE
fix(fleet): broadcast directing state to all targets

### DIFF
--- a/src/components/Fleet/__tests__/fleetExecution.test.ts
+++ b/src/components/Fleet/__tests__/fleetExecution.test.ts
@@ -9,6 +9,7 @@ import { useFleetBroadcastProgressStore } from "@/store/fleetBroadcastProgressSt
 import type { TerminalInstance } from "@shared/types";
 
 const submitMock = vi.fn<(id: string, text: string) => Promise<void>>();
+const notifyUserInputMock = vi.hoisted(() => vi.fn<(id: string, data?: string) => void>());
 const notifyEnterPressedMock = vi.hoisted(() => vi.fn<(id: string) => void>());
 const clearDirectingStateMock = vi.hoisted(() => vi.fn<(id: string) => void>());
 
@@ -25,6 +26,7 @@ vi.mock("@/clients", async (importOriginal) => {
 
 vi.mock("@/services/TerminalInstanceService", () => ({
   terminalInstanceService: {
+    notifyUserInput: notifyUserInputMock,
     notifyEnterPressed: notifyEnterPressedMock,
     clearDirectingState: clearDirectingStateMock,
   },
@@ -66,6 +68,7 @@ function armTwo() {
 function reset() {
   submitMock.mockReset();
   submitMock.mockResolvedValue(undefined);
+  notifyUserInputMock.mockReset();
   notifyEnterPressedMock.mockReset();
   clearDirectingStateMock.mockReset();
   useFleetArmingStore.setState({
@@ -417,17 +420,42 @@ describe("executeFleetBroadcast", () => {
       reset();
     });
 
-    it("calls notifyEnterPressed for every target on the non-batched path", async () => {
+    it("enters directing on every target before submit dispatches (non-batched)", async () => {
+      // Track call order to assert notifyUserInput precedes submit so the
+      // blue directing indicator renders fleet-wide before PTY echo flips
+      // the canonical state machine to working.
+      seedPanels([makeAgent("a"), makeAgent("b"), makeAgent("c")]);
+      const order: string[] = [];
+      notifyUserInputMock.mockImplementation((id: string) => order.push(`notify:${id}`));
+      submitMock.mockReset();
+      submitMock.mockImplementation(async (id: string) => {
+        order.push(`submit:${id}`);
+      });
+
+      await executeFleetBroadcast("hello", ["a", "b", "c"]);
+
+      expect(notifyUserInputMock).toHaveBeenCalledTimes(3);
+      expect(notifyUserInputMock.mock.calls.map(([id]) => id).sort()).toEqual(["a", "b", "c"]);
+      // Real payload is passed (not "") so Phase 2 escalation engages for
+      // large pastes — see #3565.
+      expect(notifyUserInputMock.mock.calls.every(([, data]) => data === "hello")).toBe(true);
+      // Every notify lands before the first submit dispatches.
+      const lastNotify = order.lastIndexOf("notify:c");
+      const firstSubmit = order.findIndex((e) => e.startsWith("submit:"));
+      expect(lastNotify).toBeLessThan(firstSubmit);
+    });
+
+    it("transitions directing → working via notifyEnterPressed for fulfilled targets", async () => {
       seedPanels([makeAgent("a"), makeAgent("b"), makeAgent("c")]);
       await executeFleetBroadcast("hello", ["a", "b", "c"]);
+
       expect(notifyEnterPressedMock).toHaveBeenCalledTimes(3);
-      const notifiedIds = notifyEnterPressedMock.mock.calls.map(([id]) => id).sort();
-      expect(notifiedIds).toEqual(["a", "b", "c"]);
-      // No rejections → no rollback.
+      expect(notifyEnterPressedMock.mock.calls.map(([id]) => id).sort()).toEqual(["a", "b", "c"]);
+      // No rejections → no rollback path.
       expect(clearDirectingStateMock).not.toHaveBeenCalled();
     });
 
-    it("calls clearDirectingState only for rejected targets (non-batched)", async () => {
+    it("rolls back directing via clearDirectingState only for rejected targets (non-batched)", async () => {
       submitMock.mockReset();
       submitMock.mockImplementation(async (id: string) => {
         if (id === "dead") throw new Error("EPIPE");
@@ -435,28 +463,27 @@ describe("executeFleetBroadcast", () => {
       seedPanels([makeAgent("a"), makeAgent("dead"), makeAgent("b")]);
       await executeFleetBroadcast("hello", ["a", "dead", "b"]);
 
-      // All three are pre-notified before allSettled.
-      expect(notifyEnterPressedMock.mock.calls.map(([id]) => id).sort()).toEqual([
-        "a",
-        "b",
-        "dead",
-      ]);
-      // Only the rejected target gets rolled back.
+      // All three enter directing pre-allSettled.
+      expect(notifyUserInputMock.mock.calls.map(([id]) => id).sort()).toEqual(["a", "b", "dead"]);
+      // Only the fulfilled targets advance to working.
+      expect(notifyEnterPressedMock.mock.calls.map(([id]) => id).sort()).toEqual(["a", "b"]);
+      // Only the rejected target is rolled back from directing.
       expect(clearDirectingStateMock).toHaveBeenCalledTimes(1);
       expect(clearDirectingStateMock).toHaveBeenCalledWith("dead");
     });
 
-    it("calls notifyEnterPressed for each target across batches when batching", async () => {
+    it("enters directing on every target across batches (batched path)", async () => {
       const ids = Array.from({ length: 12 }, (_, i) => `t${i}`);
       seedPanels(ids.map((id) => makeAgent(id)));
       await executeFleetBroadcast("x".repeat(120_000), ids);
+
+      expect(notifyUserInputMock).toHaveBeenCalledTimes(12);
+      expect(notifyUserInputMock.mock.calls.map(([id]) => id).sort()).toEqual([...ids].sort());
       expect(notifyEnterPressedMock).toHaveBeenCalledTimes(12);
-      const notifiedIds = notifyEnterPressedMock.mock.calls.map(([id]) => id).sort();
-      expect(notifiedIds).toEqual([...ids].sort());
       expect(clearDirectingStateMock).not.toHaveBeenCalled();
     });
 
-    it("rolls back directing state per-batch for rejections (batched path)", async () => {
+    it("rolls back directing per-batch for rejected targets (batched path)", async () => {
       const ids = Array.from({ length: 12 }, (_, i) => `t${i}`);
       seedPanels(ids.map((id) => makeAgent(id)));
       submitMock.mockReset();
@@ -467,32 +494,9 @@ describe("executeFleetBroadcast", () => {
       await executeFleetBroadcast("x".repeat(120_000), ids);
 
       expect(clearDirectingStateMock).toHaveBeenCalledTimes(2);
-      const cleared = clearDirectingStateMock.mock.calls.map(([id]) => id).sort();
-      expect(cleared).toEqual(["t10", "t2"]);
-    });
-
-    it("notifies before allSettled resolves so directing precedes any PTY echo", async () => {
-      // Capture the call order: every notifyEnterPressed must land before
-      // any submit promise resolves, otherwise PTY output could flip the
-      // terminal to `working` before the directing transition fires.
-      seedPanels([makeAgent("a"), makeAgent("b")]);
-      const callOrder: string[] = [];
-      notifyEnterPressedMock.mockImplementation((id: string) => {
-        callOrder.push(`notify:${id}`);
-      });
-      submitMock.mockReset();
-      submitMock.mockImplementation(async (id: string) => {
-        callOrder.push(`submit:${id}`);
-      });
-      await executeFleetBroadcast("hi", ["a", "b"]);
-
-      const firstNotify = callOrder.findIndex((e) => e.startsWith("notify:"));
-      const firstSubmit = callOrder.findIndex((e) => e.startsWith("submit:"));
-      const lastNotify = callOrder.lastIndexOf("notify:b");
-      expect(firstNotify).toBeGreaterThanOrEqual(0);
-      expect(firstSubmit).toBeGreaterThanOrEqual(0);
-      // Every notify lands before the first submit dispatches.
-      expect(lastNotify).toBeLessThan(firstSubmit);
+      expect(clearDirectingStateMock.mock.calls.map(([id]) => id).sort()).toEqual(["t10", "t2"]);
+      // The 10 fulfilled targets all moved through to working.
+      expect(notifyEnterPressedMock).toHaveBeenCalledTimes(10);
     });
 
     it("does not notify when the executor returns early on pre-aborted signal", async () => {
@@ -500,6 +504,7 @@ describe("executeFleetBroadcast", () => {
       const controller = new AbortController();
       controller.abort();
       await executeFleetBroadcast("hi", ["a", "b"], undefined, controller.signal);
+      expect(notifyUserInputMock).not.toHaveBeenCalled();
       expect(notifyEnterPressedMock).not.toHaveBeenCalled();
       expect(clearDirectingStateMock).not.toHaveBeenCalled();
     });

--- a/src/components/Fleet/__tests__/fleetExecution.test.ts
+++ b/src/components/Fleet/__tests__/fleetExecution.test.ts
@@ -9,6 +9,8 @@ import { useFleetBroadcastProgressStore } from "@/store/fleetBroadcastProgressSt
 import type { TerminalInstance } from "@shared/types";
 
 const submitMock = vi.fn<(id: string, text: string) => Promise<void>>();
+const notifyEnterPressedMock = vi.hoisted(() => vi.fn<(id: string) => void>());
+const clearDirectingStateMock = vi.hoisted(() => vi.fn<(id: string) => void>());
 
 vi.mock("@/clients", async (importOriginal) => {
   const actual = await importOriginal<typeof import("@/clients")>();
@@ -20,6 +22,13 @@ vi.mock("@/clients", async (importOriginal) => {
     },
   };
 });
+
+vi.mock("@/services/TerminalInstanceService", () => ({
+  terminalInstanceService: {
+    notifyEnterPressed: notifyEnterPressedMock,
+    clearDirectingState: clearDirectingStateMock,
+  },
+}));
 
 function makeAgent(id: string, overrides: Partial<TerminalInstance> = {}): TerminalInstance {
   return {
@@ -57,6 +66,8 @@ function armTwo() {
 function reset() {
   submitMock.mockReset();
   submitMock.mockResolvedValue(undefined);
+  notifyEnterPressedMock.mockReset();
+  clearDirectingStateMock.mockReset();
   useFleetArmingStore.setState({
     armedIds: new Set<string>(),
     armOrder: [],
@@ -398,6 +409,99 @@ describe("executeFleetBroadcast", () => {
       const result = await executeFleetBroadcast("hi", ["a", "b"]);
       expect(result.cancelled).toBe(false);
       expect(result.skippedCount).toBe(0);
+    });
+  });
+
+  describe("directing-state notification (#7799)", () => {
+    beforeEach(() => {
+      reset();
+    });
+
+    it("calls notifyEnterPressed for every target on the non-batched path", async () => {
+      seedPanels([makeAgent("a"), makeAgent("b"), makeAgent("c")]);
+      await executeFleetBroadcast("hello", ["a", "b", "c"]);
+      expect(notifyEnterPressedMock).toHaveBeenCalledTimes(3);
+      const notifiedIds = notifyEnterPressedMock.mock.calls.map(([id]) => id).sort();
+      expect(notifiedIds).toEqual(["a", "b", "c"]);
+      // No rejections → no rollback.
+      expect(clearDirectingStateMock).not.toHaveBeenCalled();
+    });
+
+    it("calls clearDirectingState only for rejected targets (non-batched)", async () => {
+      submitMock.mockReset();
+      submitMock.mockImplementation(async (id: string) => {
+        if (id === "dead") throw new Error("EPIPE");
+      });
+      seedPanels([makeAgent("a"), makeAgent("dead"), makeAgent("b")]);
+      await executeFleetBroadcast("hello", ["a", "dead", "b"]);
+
+      // All three are pre-notified before allSettled.
+      expect(notifyEnterPressedMock.mock.calls.map(([id]) => id).sort()).toEqual([
+        "a",
+        "b",
+        "dead",
+      ]);
+      // Only the rejected target gets rolled back.
+      expect(clearDirectingStateMock).toHaveBeenCalledTimes(1);
+      expect(clearDirectingStateMock).toHaveBeenCalledWith("dead");
+    });
+
+    it("calls notifyEnterPressed for each target across batches when batching", async () => {
+      const ids = Array.from({ length: 12 }, (_, i) => `t${i}`);
+      seedPanels(ids.map((id) => makeAgent(id)));
+      await executeFleetBroadcast("x".repeat(120_000), ids);
+      expect(notifyEnterPressedMock).toHaveBeenCalledTimes(12);
+      const notifiedIds = notifyEnterPressedMock.mock.calls.map(([id]) => id).sort();
+      expect(notifiedIds).toEqual([...ids].sort());
+      expect(clearDirectingStateMock).not.toHaveBeenCalled();
+    });
+
+    it("rolls back directing state per-batch for rejections (batched path)", async () => {
+      const ids = Array.from({ length: 12 }, (_, i) => `t${i}`);
+      seedPanels(ids.map((id) => makeAgent(id)));
+      submitMock.mockReset();
+      submitMock.mockImplementation(async (id: string) => {
+        // One failure in batch 1 (t2) and one in batch 3 (t10).
+        if (id === "t2" || id === "t10") throw new Error("EPIPE");
+      });
+      await executeFleetBroadcast("x".repeat(120_000), ids);
+
+      expect(clearDirectingStateMock).toHaveBeenCalledTimes(2);
+      const cleared = clearDirectingStateMock.mock.calls.map(([id]) => id).sort();
+      expect(cleared).toEqual(["t10", "t2"]);
+    });
+
+    it("notifies before allSettled resolves so directing precedes any PTY echo", async () => {
+      // Capture the call order: every notifyEnterPressed must land before
+      // any submit promise resolves, otherwise PTY output could flip the
+      // terminal to `working` before the directing transition fires.
+      seedPanels([makeAgent("a"), makeAgent("b")]);
+      const callOrder: string[] = [];
+      notifyEnterPressedMock.mockImplementation((id: string) => {
+        callOrder.push(`notify:${id}`);
+      });
+      submitMock.mockReset();
+      submitMock.mockImplementation(async (id: string) => {
+        callOrder.push(`submit:${id}`);
+      });
+      await executeFleetBroadcast("hi", ["a", "b"]);
+
+      const firstNotify = callOrder.findIndex((e) => e.startsWith("notify:"));
+      const firstSubmit = callOrder.findIndex((e) => e.startsWith("submit:"));
+      const lastNotify = callOrder.lastIndexOf("notify:b");
+      expect(firstNotify).toBeGreaterThanOrEqual(0);
+      expect(firstSubmit).toBeGreaterThanOrEqual(0);
+      // Every notify lands before the first submit dispatches.
+      expect(lastNotify).toBeLessThan(firstSubmit);
+    });
+
+    it("does not notify when the executor returns early on pre-aborted signal", async () => {
+      seedPanels([makeAgent("a"), makeAgent("b")]);
+      const controller = new AbortController();
+      controller.abort();
+      await executeFleetBroadcast("hi", ["a", "b"], undefined, controller.signal);
+      expect(notifyEnterPressedMock).not.toHaveBeenCalled();
+      expect(clearDirectingStateMock).not.toHaveBeenCalled();
     });
   });
 });

--- a/src/components/Fleet/__tests__/fleetRawInputBroadcast.test.ts
+++ b/src/components/Fleet/__tests__/fleetRawInputBroadcast.test.ts
@@ -8,6 +8,7 @@ import type { TerminalInstance } from "@shared/types";
 
 const broadcastMock = vi.hoisted(() => vi.fn<(ids: string[], data: string) => void>());
 const notifyUserInputMock = vi.hoisted(() => vi.fn<(id: string, data?: string) => void>());
+const clearDirectingStateMock = vi.hoisted(() => vi.fn<(id: string) => void>());
 
 vi.mock("@/clients", async (importOriginal) => {
   const actual = await importOriginal<typeof import("@/clients")>();
@@ -23,6 +24,7 @@ vi.mock("@/clients", async (importOriginal) => {
 vi.mock("@/services/TerminalInstanceService", () => ({
   terminalInstanceService: {
     notifyUserInput: notifyUserInputMock,
+    clearDirectingState: clearDirectingStateMock,
   },
 }));
 
@@ -52,6 +54,7 @@ function seedPanels(terminals: TerminalInstance[]): void {
 function resetStores(): void {
   broadcastMock.mockReset();
   notifyUserInputMock.mockReset();
+  clearDirectingStateMock.mockReset();
   useFleetArmingStore.setState({
     armedIds: new Set<string>(),
     armOrder: [],
@@ -212,6 +215,11 @@ describe("applyFleetBroadcastResult", () => {
     // The fleetFailureStore subscription auto-clears records for unarmed
     // targets, so a dead-pipe target should not surface a chip.
     expect(useFleetFailureStore.getState().failedIds.size).toBe(0);
+
+    // The synthetic directing state set by notifyUserInput needs to be
+    // cleared for permanently-failed targets so the blue indicator doesn't
+    // linger for the full 1.5s debounce window on a dead pipe.
+    expect(clearDirectingStateMock).toHaveBeenCalledWith("t2");
   });
 
   it("records non-permanent failures without disarming the target", () => {

--- a/src/components/Fleet/__tests__/fleetRawInputBroadcast.test.ts
+++ b/src/components/Fleet/__tests__/fleetRawInputBroadcast.test.ts
@@ -7,6 +7,7 @@ import { usePanelStore } from "@/store/panelStore";
 import type { TerminalInstance } from "@shared/types";
 
 const broadcastMock = vi.hoisted(() => vi.fn<(ids: string[], data: string) => void>());
+const notifyUserInputMock = vi.hoisted(() => vi.fn<(id: string, data?: string) => void>());
 
 vi.mock("@/clients", async (importOriginal) => {
   const actual = await importOriginal<typeof import("@/clients")>();
@@ -18,6 +19,12 @@ vi.mock("@/clients", async (importOriginal) => {
     },
   };
 });
+
+vi.mock("@/services/TerminalInstanceService", () => ({
+  terminalInstanceService: {
+    notifyUserInput: notifyUserInputMock,
+  },
+}));
 
 function makeTerminal(id: string, overrides: Partial<TerminalInstance> = {}): TerminalInstance {
   return {
@@ -44,6 +51,7 @@ function seedPanels(terminals: TerminalInstance[]): void {
 
 function resetStores(): void {
   broadcastMock.mockReset();
+  notifyUserInputMock.mockReset();
   useFleetArmingStore.setState({
     armedIds: new Set<string>(),
     armOrder: [],
@@ -150,6 +158,31 @@ describe("broadcastFleetRawInput", () => {
 
     broadcastFleetRawInput("t1", "");
     expect(useFleetArmingStore.getState().broadcastSignal).toBe(0);
+  });
+
+  it("fires notifyUserInput on every non-origin target so directing shows fleet-wide (#7799)", () => {
+    seedPanels([makeTerminal("t1"), makeTerminal("t2"), makeTerminal("t3")]);
+    useFleetArmingStore.getState().armIds(["t1", "t2", "t3"]);
+
+    expect(broadcastFleetRawInput("t1", "abc")).toBe(true);
+
+    // Origin (t1) already gets directing from its own xterm onData listener,
+    // so it must NOT be notified here or it would double-fire.
+    const calls = notifyUserInputMock.mock.calls;
+    const notifiedIds = calls.map(([id]) => id);
+    expect(notifiedIds).not.toContain("t1");
+    expect(notifiedIds.sort()).toEqual(["t2", "t3"]);
+    // Raw payload is passed through (not "") so Phase 2 escalation still
+    // engages for large pastes — see #3565.
+    expect(calls.every(([, data]) => data === "abc")).toBe(true);
+  });
+
+  it("does not call notifyUserInput when the broadcast is rejected", () => {
+    seedPanels([makeTerminal("t1"), makeTerminal("t2")]);
+    useFleetArmingStore.getState().armIds(["t2"]);
+
+    expect(broadcastFleetRawInput("t1", "rejected")).toBe(false);
+    expect(notifyUserInputMock).not.toHaveBeenCalled();
   });
 });
 

--- a/src/components/Fleet/fleetExecution.ts
+++ b/src/components/Fleet/fleetExecution.ts
@@ -220,23 +220,31 @@ export async function executeFleetBroadcast(
         }
         const batch = resolved.slice(i, i + FLEET_LARGE_PASTE_BATCH_SIZE);
         dispatchedCount += batch.length;
-        // Drive each target into `directing → working` before its submit
-        // dispatches. Calling before allSettled is load-bearing: the PTY can
-        // echo output and flip the terminal back to `working` via the
-        // canonical state machine before submit resolves, so the directing
-        // transition must register first.
-        for (const r of batch) terminalInstanceService.notifyEnterPressed(r.terminalId);
+        // Enter `directing` on every target BEFORE submit dispatches —
+        // mirrors what xterm onData → onUserInput does for the origin.
+        // `notifyEnterPressed` alone would skip `directing` (it only fires
+        // the `directing → working` transition when the target is already
+        // `directing`), so the user-input call is the load-bearing step
+        // that makes the blue indicator render fleet-wide. Real payload
+        // (not "") preserves Phase 2 escalation for large pastes — see #3565.
+        for (const r of batch) terminalInstanceService.notifyUserInput(r.terminalId, r.payload);
         const batchResults = await Promise.allSettled(
           batch.map((r) => terminalClient.submit(r.terminalId, r.payload))
         );
         for (let j = 0; j < batchResults.length; j += 1) {
           const r = batchResults[j]!;
           results.push(r);
-          // Rollback for rejected submits — the PTY never received bytes,
-          // so the directing state would otherwise hang until the debounce
-          // timer fires.
-          if (r.status === "rejected") {
-            terminalInstanceService.clearDirectingState(batch[j]!.terminalId);
+          const terminalId = batch[j]!.terminalId;
+          if (r.status === "fulfilled") {
+            // Submit landed — close out directing and flip to working.
+            // `onEnterPressed` is a no-op if the canonical state machine has
+            // already transitioned the terminal to working from PTY echo.
+            terminalInstanceService.notifyEnterPressed(terminalId);
+          } else {
+            // Submit rejected — the PTY never received bytes, so revert
+            // the synthetic `directing` we set above rather than leaving
+            // it to age out on the 1.5s debounce timer.
+            terminalInstanceService.clearDirectingState(terminalId);
           }
         }
 
@@ -249,17 +257,19 @@ export async function executeFleetBroadcast(
       }
     } else {
       dispatchedCount = resolved.length;
-      // Same ordering rule as the batched path: notify before allSettled so
-      // the directing transition lands ahead of any PTY echo.
-      for (const r of resolved) terminalInstanceService.notifyEnterPressed(r.terminalId);
+      // Same ordering rule as the batched path — see comment above.
+      for (const r of resolved) terminalInstanceService.notifyUserInput(r.terminalId, r.payload);
       const all = await Promise.allSettled(
         resolved.map((r) => terminalClient.submit(r.terminalId, r.payload))
       );
       for (let j = 0; j < all.length; j += 1) {
         const r = all[j]!;
         results.push(r);
-        if (r.status === "rejected") {
-          terminalInstanceService.clearDirectingState(resolved[j]!.terminalId);
+        const terminalId = resolved[j]!.terminalId;
+        if (r.status === "fulfilled") {
+          terminalInstanceService.notifyEnterPressed(terminalId);
+        } else {
+          terminalInstanceService.clearDirectingState(terminalId);
         }
       }
       const nonBatchedFailures = all.filter((r) => r.status === "rejected").length;

--- a/src/components/Fleet/fleetExecution.ts
+++ b/src/components/Fleet/fleetExecution.ts
@@ -2,6 +2,7 @@ import { useFleetArmingStore } from "@/store/fleetArmingStore";
 import { usePanelStore } from "@/store/panelStore";
 import { useFleetBroadcastProgressStore } from "@/store/fleetBroadcastProgressStore";
 import { terminalClient } from "@/clients";
+import { terminalInstanceService } from "@/services/TerminalInstanceService";
 import { isTerminalFleetEligible } from "@/store/fleetEligibility";
 import { replaceRecipeVariables, type RecipeContext } from "@/utils/recipeVariables";
 import type { TerminalInstance } from "@shared/types";
@@ -219,10 +220,25 @@ export async function executeFleetBroadcast(
         }
         const batch = resolved.slice(i, i + FLEET_LARGE_PASTE_BATCH_SIZE);
         dispatchedCount += batch.length;
+        // Drive each target into `directing → working` before its submit
+        // dispatches. Calling before allSettled is load-bearing: the PTY can
+        // echo output and flip the terminal back to `working` via the
+        // canonical state machine before submit resolves, so the directing
+        // transition must register first.
+        for (const r of batch) terminalInstanceService.notifyEnterPressed(r.terminalId);
         const batchResults = await Promise.allSettled(
           batch.map((r) => terminalClient.submit(r.terminalId, r.payload))
         );
-        for (const r of batchResults) results.push(r);
+        for (let j = 0; j < batchResults.length; j += 1) {
+          const r = batchResults[j]!;
+          results.push(r);
+          // Rollback for rejected submits — the PTY never received bytes,
+          // so the directing state would otherwise hang until the debounce
+          // timer fires.
+          if (r.status === "rejected") {
+            terminalInstanceService.clearDirectingState(batch[j]!.terminalId);
+          }
+        }
 
         const batchFailures = batchResults.filter((r) => r.status === "rejected").length;
         useFleetBroadcastProgressStore.getState().advance(batch.length, batchFailures);
@@ -233,10 +249,19 @@ export async function executeFleetBroadcast(
       }
     } else {
       dispatchedCount = resolved.length;
+      // Same ordering rule as the batched path: notify before allSettled so
+      // the directing transition lands ahead of any PTY echo.
+      for (const r of resolved) terminalInstanceService.notifyEnterPressed(r.terminalId);
       const all = await Promise.allSettled(
         resolved.map((r) => terminalClient.submit(r.terminalId, r.payload))
       );
-      for (const r of all) results.push(r);
+      for (let j = 0; j < all.length; j += 1) {
+        const r = all[j]!;
+        results.push(r);
+        if (r.status === "rejected") {
+          terminalInstanceService.clearDirectingState(resolved[j]!.terminalId);
+        }
+      }
       const nonBatchedFailures = all.filter((r) => r.status === "rejected").length;
       useFleetBroadcastProgressStore.getState().advance(resolved.length, nonBatchedFailures);
     }

--- a/src/components/Fleet/fleetRawInputBroadcast.ts
+++ b/src/components/Fleet/fleetRawInputBroadcast.ts
@@ -118,6 +118,10 @@ export function applyFleetBroadcastResult(payload: BroadcastWriteResultPayload):
       // disarmId is a no-op for non-armed ids per fleetArmingStore semantics,
       // so a stale result for a manually-disarmed target is harmless.
       arming.disarmId(id);
+      // Clear the synthetic `directing` set when we mirrored the broadcast
+      // through notifyUserInput, so a dead-pipe target doesn't show the
+      // blue indicator for the full 1.5s debounce window.
+      terminalInstanceService.clearDirectingState(id);
     }
   }
 }

--- a/src/components/Fleet/fleetRawInputBroadcast.ts
+++ b/src/components/Fleet/fleetRawInputBroadcast.ts
@@ -1,5 +1,6 @@
 import { terminalClient } from "@/clients";
 import { registerFleetInputBroadcastHandler } from "@/services/terminal/fleetInputRouter";
+import { terminalInstanceService } from "@/services/TerminalInstanceService";
 import { isFleetArmEligible, useFleetArmingStore } from "@/store/fleetArmingStore";
 import { useFleetFailureStore } from "@/store/fleetFailureStore";
 import { usePanelStore } from "@/store/panelStore";
@@ -42,6 +43,14 @@ export function broadcastFleetRawInput(originId: string, data: string): boolean 
   if (targets.length < 2 || !targets.includes(originId)) return false;
 
   terminalClient.broadcast(targets, data);
+  // Mirror the origin's xterm onData → onUserInput path on every non-origin
+  // target so the `directing` indicator fires fleet-wide. Pass the raw
+  // payload (not "") so Phase 2 escalation still kicks in for large pastes —
+  // see #3565.
+  for (const id of targets) {
+    if (id === originId) continue;
+    terminalInstanceService.notifyUserInput(id, data);
+  }
   // Bump the broadcast signal so the ribbon can fire a one-shot commit
   // flash. Counter increments only; subscribers diff against their last
   // observed value to detect a new commit. Lives here (not in

--- a/src/services/terminal/TerminalInstanceService.ts
+++ b/src/services/terminal/TerminalInstanceService.ts
@@ -264,6 +264,10 @@ class TerminalInstanceService {
     this.onUserInput(id, data);
   }
 
+  notifyEnterPressed(id: string): void {
+    this.onEnterPressed(id);
+  }
+
   /**
    * Builds the deps surface consumed by `installTerminalBoundListeners`. Both
    * the create path (`getOrCreate`) and the wake path (via


### PR DESCRIPTION
## Summary

- Fleet broadcast operations were skipping the blue `directing` indicator on every target terminal — targets wrote straight to the PTY via `terminalClient.broadcast` and `terminalClient.submit`, bypassing the `onUserInput` pipeline entirely
- The fix wires directing-state notifications into both broadcast paths: raw keystrokes (`broadcastFleetRawInput`) and `HybridInputBar` Enter (`executeFleetBroadcast`), and clears the indicator on permanently-failed targets so it doesn't linger past disarm

Resolves #7799

## Changes

- `TerminalInstanceService`: add public `notifyEnterPressed(id)` method
- `broadcastFleetRawInput`: mirror the origin's `onUserInput` call on every non-origin target (passes real `data` so Phase 2 escalation is preserved)
- `executeFleetBroadcast`: call `notifyUserInput(id, payload)` on all targets before `allSettled`; call `notifyEnterPressed` on fulfilled targets and `clearDirectingState` on rejected targets after — covers both batched and non-batched paths
- `applyFleetBroadcastResult`: clear directing on permanently-failed broadcast targets

## Testing

50 fleet tests pass across 3 files, including new coverage for directing-state notification ordering, rejection rollback, and dead-pipe cleanup. No new dependencies. xterm 6.0 `onData` only fires for browser-originated input so there's no double-fire risk from echoed PTY output.