### PR TITLE
feat(review-hub): add multi-select for partial-set staging

### DIFF
--- a/electron/ipc/channels.ts
+++ b/electron/ipc/channels.ts
@@ -299,6 +299,8 @@ export const CHANNELS = {
   GIT_LIST_COMMITS: "git:list-commits",
   GIT_STAGE_FILE: "git:stage-file",
   GIT_UNSTAGE_FILE: "git:unstage-file",
+  GIT_STAGE_FILES: "git:stage-files",
+  GIT_UNSTAGE_FILES: "git:unstage-files",
   GIT_STAGE_ALL: "git:stage-all",
   GIT_UNSTAGE_ALL: "git:unstage-all",
   GIT_COMMIT: "git:commit",

--- a/electron/ipc/handlers/git-write.ts
+++ b/electron/ipc/handlers/git-write.ts
@@ -301,6 +301,53 @@ export function registerGitWriteHandlers(_deps: HandlerDependencies): () => void
   };
   handlers.push(typedHandle(CHANNELS.GIT_UNSTAGE_FILE, handleUnstageFile));
 
+  const validateFilePaths = (filePaths: unknown): string[] => {
+    if (!Array.isArray(filePaths) || filePaths.length === 0) {
+      throw new Error("filePaths must be a non-empty array");
+    }
+    for (const p of filePaths) {
+      if (typeof p !== "string" || !p) {
+        throw new Error("Invalid file path in filePaths");
+      }
+    }
+    return filePaths as string[];
+  };
+
+  const handleStageFiles = async (payload: { cwd: string; filePaths: string[] }): Promise<void> => {
+    checkRateLimit(CHANNELS.GIT_STAGE_FILES, 10, 10_000);
+    validateCwd(payload?.cwd);
+    const paths = validateFilePaths(payload?.filePaths);
+
+    const git = createHardenedGit(payload.cwd);
+    await git.add(["--", ...paths]);
+  };
+  handlers.push(typedHandle(CHANNELS.GIT_STAGE_FILES, handleStageFiles));
+
+  const handleUnstageFiles = async (payload: {
+    cwd: string;
+    filePaths: string[];
+  }): Promise<void> => {
+    checkRateLimit(CHANNELS.GIT_UNSTAGE_FILES, 10, 10_000);
+    validateCwd(payload?.cwd);
+    const paths = validateFilePaths(payload?.filePaths);
+
+    const git = createHardenedGit(payload.cwd);
+
+    let hasHead = true;
+    try {
+      await git.revparse(["HEAD"]);
+    } catch {
+      hasHead = false;
+    }
+
+    if (hasHead) {
+      await git.reset(["HEAD", "--", ...paths]);
+    } else {
+      await git.raw(["rm", "--cached", "--", ...paths]);
+    }
+  };
+  handlers.push(typedHandle(CHANNELS.GIT_UNSTAGE_FILES, handleUnstageFiles));
+
   const handleStageAll = async (cwd: string): Promise<void> => {
     checkRateLimit(CHANNELS.GIT_STAGE_ALL, 10, 10_000);
     validateCwd(cwd);

--- a/electron/preload.cts
+++ b/electron/preload.cts
@@ -1644,6 +1644,12 @@ const api: ElectronAPI = {
     unstageFile: (cwd: string, filePath: string) =>
       _unwrappingInvoke(CHANNELS.GIT_UNSTAGE_FILE, { cwd, filePath }),
 
+    stageFiles: (cwd: string, filePaths: string[]) =>
+      _unwrappingInvoke(CHANNELS.GIT_STAGE_FILES, { cwd, filePaths }),
+
+    unstageFiles: (cwd: string, filePaths: string[]) =>
+      _unwrappingInvoke(CHANNELS.GIT_UNSTAGE_FILES, { cwd, filePaths }),
+
     stageAll: (cwd: string) => _unwrappingInvoke(CHANNELS.GIT_STAGE_ALL, cwd),
 
     unstageAll: (cwd: string) => _unwrappingInvoke(CHANNELS.GIT_UNSTAGE_ALL, cwd),

--- a/shared/types/ipc/api.ts
+++ b/shared/types/ipc/api.ts
@@ -754,6 +754,8 @@ export interface ElectronAPI {
     }): Promise<import("../github.js").GitCommitListResponse>;
     stageFile(cwd: string, filePath: string): Promise<void>;
     unstageFile(cwd: string, filePath: string): Promise<void>;
+    stageFiles(cwd: string, filePaths: string[]): Promise<void>;
+    unstageFiles(cwd: string, filePaths: string[]): Promise<void>;
     stageAll(cwd: string): Promise<void>;
     unstageAll(cwd: string): Promise<void>;
     commit(cwd: string, message: string): Promise<{ hash: string; summary: string }>;

--- a/shared/types/ipc/maps.ts
+++ b/shared/types/ipc/maps.ts
@@ -1116,6 +1116,14 @@ export interface IpcInvokeMap extends GeneratedIpcInvokeMap {
     args: [payload: { cwd: string; filePath: string }];
     result: void;
   };
+  "git:stage-files": {
+    args: [payload: { cwd: string; filePaths: string[] }];
+    result: void;
+  };
+  "git:unstage-files": {
+    args: [payload: { cwd: string; filePaths: string[] }];
+    result: void;
+  };
   "git:stage-all": {
     args: [cwd: string];
     result: void;

--- a/src/components/Worktree/ReviewHub/FileStageRow.tsx
+++ b/src/components/Worktree/ReviewHub/FileStageRow.tsx
@@ -1,4 +1,4 @@
-import { useCallback } from "react";
+import { memo, useCallback } from "react";
 import type React from "react";
 import type { StagingFileEntry } from "@shared/types";
 import type { GitStatus } from "@shared/types";
@@ -51,11 +51,20 @@ const STATUS_CONFIG: Record<GitStatus, { label: string; bg: string; text: string
   },
 };
 
+export type FileStageRowSection = "staged" | "unstaged";
+
 interface FileStageRowProps {
   file: StagingFileEntry;
+  section: FileStageRowSection;
   isStaged: boolean;
+  isSelected: boolean;
   onToggle: (filePath: string) => void;
-  onFileClick: (filePath: string, status: GitStatus) => void;
+  onRowClick: (
+    section: FileStageRowSection,
+    filePath: string,
+    status: GitStatus,
+    e: React.MouseEvent
+  ) => void;
   density?: "comfortable" | "compact";
   viewed?: boolean;
   onViewedChange?: (viewed: boolean) => void;
@@ -68,11 +77,13 @@ function splitPath(filePath: string): { dir: string; base: string } {
   return { dir: normalized.slice(0, lastSlash), base: normalized.slice(lastSlash + 1) };
 }
 
-export function FileStageRow({
+function FileStageRowComponent({
   file,
+  section,
   isStaged,
+  isSelected,
   onToggle,
-  onFileClick,
+  onRowClick,
   density = "comfortable",
   viewed = false,
   onViewedChange,
@@ -92,9 +103,12 @@ export function FileStageRow({
     [onToggle, file.path]
   );
 
-  const handleClick = useCallback(() => {
-    onFileClick(file.path, file.status);
-  }, [onFileClick, file.path, file.status]);
+  const handleClick = useCallback(
+    (e: React.MouseEvent) => {
+      onRowClick(section, file.path, file.status, e);
+    },
+    [onRowClick, section, file.path, file.status]
+  );
 
   const handleViewedChange = useCallback(
     (e: React.ChangeEvent<HTMLInputElement>) => {
@@ -110,20 +124,30 @@ export function FileStageRow({
 
   return (
     <div
+      onClick={handleClick}
+      data-testid={`file-stage-row-${file.path}`}
+      data-selected={isSelected || undefined}
+      aria-selected={isSelected}
       className={cn(
-        "group/stagerow flex items-center text-xs rounded px-1.5 transition-colors",
+        "relative group/stagerow flex items-center text-xs rounded px-1.5 transition-colors",
         density === "compact" ? "py-0.5" : "py-1.5",
         isStaged ? "bg-status-success/[0.06] hover:bg-status-success/[0.10]" : "hover:bg-tint/5",
         viewed && "opacity-60"
       )}
     >
+      {isSelected && (
+        <div
+          aria-hidden="true"
+          className="absolute inset-0 rounded bg-overlay-subtle pointer-events-none"
+        />
+      )}
       <TruncatedTooltip content={file.path}>
         <button
           type="button"
           onClick={handleClick}
           aria-label={`View diff: ${file.path}`}
           className={cn(
-            "flex min-w-0 flex-1 items-baseline rounded text-left",
+            "relative flex min-w-0 flex-1 items-baseline rounded text-left",
             "focus-visible:outline-hidden focus-visible:ring-2 focus-visible:ring-daintree-accent"
           )}
         >
@@ -235,3 +259,5 @@ export function FileStageRow({
     </div>
   );
 }
+
+export const FileStageRow = memo(FileStageRowComponent);

--- a/src/components/Worktree/ReviewHub/ReviewHub.tsx
+++ b/src/components/Worktree/ReviewHub/ReviewHub.tsx
@@ -38,7 +38,7 @@ import {
 } from "lucide-react";
 import type { GitHubPRCIStatus } from "@shared/types/github";
 import { Spinner } from "@/components/ui/Spinner";
-import { FileStageRow } from "./FileStageRow";
+import { FileStageRow, type FileStageRowSection } from "./FileStageRow";
 import { CommitPanel } from "./CommitPanel";
 import { ConflictPanel } from "./ConflictPanel";
 import { FileDiffModal } from "../FileDiffModal";
@@ -508,6 +508,8 @@ export function ReviewHub({ isOpen, worktreePath, onClose }: ReviewHubProps) {
   const [reviewThreadCounts, setReviewThreadCounts] = useState<Record<string, number> | null>(null);
   const reviewThreadsRequestRef = useRef(0);
   const dialogRef = useRef<HTMLDivElement>(null);
+  const [selectedPaths, setSelectedPaths] = useState<Set<string>>(() => new Set());
+  const [selectionSection, setSelectionSection] = useState<FileStageRowSection | null>(null);
   const refreshIdRef = useRef(0);
   const bgRefreshIdRef = useRef(0);
   const baseBranchRequestRef = useRef(0);
@@ -516,6 +518,8 @@ export function ReviewHub({ isOpen, worktreePath, onClose }: ReviewHubProps) {
   const debouncedBgRefreshRef = useRef<ReturnType<typeof debounce> | null>(null);
   const conflictSectionRef = useRef<HTMLDivElement>(null);
   const unstagedSectionRef = useRef<HTMLDivElement>(null);
+  const selectionAnchorRef = useRef<string | null>(null);
+  const isBulkStagingRef = useRef(false);
 
   const [stagedView, setStagedView] = useState<SectionViewState>(DEFAULT_SECTION_STATE);
   const [changesView, setChangesView] = useState<SectionViewState>(DEFAULT_SECTION_STATE);
@@ -741,6 +745,9 @@ export function ReviewHub({ isOpen, worktreePath, onClose }: ReviewHubProps) {
       setPullRebasing(false);
       isPullRebasingRef.current = false;
       setViewedFiles(new Set());
+      setSelectedPaths(new Set());
+      setSelectionSection(null);
+      selectionAnchorRef.current = null;
     }
   }, [isOpen, refresh]);
 
@@ -778,6 +785,27 @@ export function ReviewHub({ isOpen, worktreePath, onClose }: ReviewHubProps) {
       }
     })();
   }, [isOpen, diffMode, worktreePR?.prNumber, worktreePath]);
+
+  useEffect(() => {
+    if (!status || !selectionSection) return;
+    const sectionFiles = selectionSection === "staged" ? status.staged : status.unstaged;
+    const validPaths = new Set(sectionFiles.map((f) => f.path));
+    setSelectedPaths((prev) => {
+      if (prev.size === 0) return prev;
+      let mutated = false;
+      const next = new Set<string>();
+      for (const p of prev) {
+        if (validPaths.has(p)) next.add(p);
+        else mutated = true;
+      }
+      if (!mutated) return prev;
+      if (next.size === 0) {
+        setSelectionSection(null);
+        selectionAnchorRef.current = null;
+      }
+      return next;
+    });
+  }, [status, selectionSection]);
 
   useEffect(() => {
     if (!isOpen) return;
@@ -847,6 +875,46 @@ export function ReviewHub({ isOpen, worktreePath, onClose }: ReviewHubProps) {
       setActionError(formatErrorMessage(err, "Failed to unstage all files"));
     }
   }, [worktreePath, refresh]);
+
+  const handleStageSelection = useCallback(async () => {
+    if (isBulkStagingRef.current) return;
+    if (selectionSection !== "unstaged" || selectedPaths.size === 0) return;
+    isBulkStagingRef.current = true;
+    const paths = Array.from(selectedPaths);
+    setActionError(null);
+    debouncedBgRefreshRef.current?.cancel();
+    try {
+      await window.electron.git.stageFiles(worktreePath, paths);
+      setSelectedPaths(new Set());
+      setSelectionSection(null);
+      selectionAnchorRef.current = null;
+      await refresh();
+    } catch (err) {
+      setActionError(formatErrorMessage(err, "Failed to stage selected files"));
+    } finally {
+      isBulkStagingRef.current = false;
+    }
+  }, [worktreePath, refresh, selectedPaths, selectionSection]);
+
+  const handleUnstageSelection = useCallback(async () => {
+    if (isBulkStagingRef.current) return;
+    if (selectionSection !== "staged" || selectedPaths.size === 0) return;
+    isBulkStagingRef.current = true;
+    const paths = Array.from(selectedPaths);
+    setActionError(null);
+    debouncedBgRefreshRef.current?.cancel();
+    try {
+      await window.electron.git.unstageFiles(worktreePath, paths);
+      setSelectedPaths(new Set());
+      setSelectionSection(null);
+      selectionAnchorRef.current = null;
+      await refresh();
+    } catch (err) {
+      setActionError(formatErrorMessage(err, "Failed to unstage selected files"));
+    } finally {
+      isBulkStagingRef.current = false;
+    }
+  }, [worktreePath, refresh, selectedPaths, selectionSection]);
 
   const handleCommit = useCallback(
     async (message: string) => {
@@ -1076,9 +1144,73 @@ export function ReviewHub({ isOpen, worktreePath, onClose }: ReviewHubProps) {
     savedScrollTop.current = e.currentTarget.scrollTop;
   }, []);
 
-  const handleFileClick = useCallback((filePath: string, fileStatus: GitStatus) => {
-    setSelectedFile({ path: filePath, status: fileStatus });
-  }, []);
+  const handleToggleStaged = useCallback(
+    (filePath: string) => {
+      void handleUnstageFile(filePath);
+    },
+    [handleUnstageFile]
+  );
+
+  const handleToggleUnstaged = useCallback(
+    (filePath: string) => {
+      void handleStageFile(filePath);
+    },
+    [handleStageFile]
+  );
+
+  const handleRowClick = useCallback(
+    (
+      section: FileStageRowSection,
+      filePath: string,
+      fileStatus: GitStatus,
+      e: React.MouseEvent
+    ) => {
+      const files = section === "staged" ? status?.staged : status?.unstaged;
+      if (e.shiftKey && files && selectionSection === section && selectionAnchorRef.current) {
+        const anchorIdx = files.findIndex((f) => f.path === selectionAnchorRef.current);
+        const clickIdx = files.findIndex((f) => f.path === filePath);
+        if (anchorIdx !== -1 && clickIdx !== -1) {
+          const start = Math.min(anchorIdx, clickIdx);
+          const end = Math.max(anchorIdx, clickIdx);
+          const range = new Set<string>();
+          for (let i = start; i <= end; i++) {
+            const entry = files[i];
+            if (entry) range.add(entry.path);
+          }
+          setSelectedPaths(range);
+          setSelectionSection(section);
+          return;
+        }
+      }
+
+      if (e.metaKey || e.ctrlKey) {
+        setSelectedPaths((prev) => {
+          const next = selectionSection === section ? new Set(prev) : new Set<string>();
+          if (next.has(filePath)) {
+            next.delete(filePath);
+          } else {
+            next.add(filePath);
+          }
+          if (next.size === 0) {
+            setSelectionSection(null);
+            selectionAnchorRef.current = null;
+          } else {
+            setSelectionSection(section);
+            selectionAnchorRef.current = filePath;
+          }
+          return next;
+        });
+        return;
+      }
+
+      // Plain click: clear any selection, open diff.
+      setSelectedPaths((prev) => (prev.size === 0 ? prev : new Set()));
+      setSelectionSection((prev) => (prev === null ? prev : null));
+      selectionAnchorRef.current = filePath;
+      setSelectedFile({ path: filePath, status: fileStatus });
+    },
+    [status, selectionSection]
+  );
 
   const handleViewedChange = useCallback((viewedKey: string, viewed: boolean) => {
     setViewedFiles((prev) => {
@@ -1107,6 +1239,10 @@ export function ReviewHub({ isOpen, worktreePath, onClose }: ReviewHubProps) {
         setSelectedFile(null);
       } else if (selectedBaseBranchFile) {
         setSelectedBaseBranchFile(null);
+      } else if (selectedPaths.size > 0) {
+        setSelectedPaths(new Set());
+        setSelectionSection(null);
+        selectionAnchorRef.current = null;
       } else {
         onClose();
       }
@@ -1142,6 +1278,8 @@ export function ReviewHub({ isOpen, worktreePath, onClose }: ReviewHubProps) {
     (status?.unstaged.length ?? 0) +
     (status?.conflicted.length ?? 0);
   const hasConflicts = (status?.conflicted.length ?? 0) > 0;
+  const hasStagedSelection = selectionSection === "staged" && selectedPaths.size > 0;
+  const hasUnstagedSelection = selectionSection === "unstaged" && selectedPaths.size > 0;
   const repoState = status?.repoState ?? "CLEAN";
   const isOperationState =
     repoState === "MERGING" ||
@@ -1695,17 +1833,21 @@ export function ReviewHub({ isOpen, worktreePath, onClose }: ReviewHubProps) {
                               variant="ghost"
                               size="sm"
                               onClick={() =>
-                                stagedView.filterQuery || !stagedView.showGenerated
-                                  ? void handleUnstageFiltered()
-                                  : void handleUnstageAll()
+                                void (hasStagedSelection
+                                  ? handleUnstageSelection()
+                                  : stagedView.filterQuery || !stagedView.showGenerated
+                                    ? handleUnstageFiltered()
+                                    : handleUnstageAll())
                               }
                               className="h-5 px-1.5 text-[10px] shrink-0"
-                              data-testid="review-hub-unstage-all"
+                              data-testid="review-hub-unstage-section-button"
                             >
                               <Square className="w-3 h-3 mr-1" />
-                              {stagedView.filterQuery
-                                ? `Unstage shown (${derivedStaged.length})`
-                                : `Unstage all (${derivedStaged.length})`}
+                              {hasStagedSelection
+                                ? `Unstage selection (${selectedPaths.size})`
+                                : stagedView.filterQuery
+                                  ? `Unstage shown (${derivedStaged.length})`
+                                  : `Unstage all (${derivedStaged.length})`}
                             </Button>
                           )}
                         </div>
@@ -1723,9 +1865,13 @@ export function ReviewHub({ isOpen, worktreePath, onClose }: ReviewHubProps) {
                               <FileStageRow
                                 key={`staged-${file.path}`}
                                 file={file}
+                                section="staged"
                                 isStaged={true}
-                                onToggle={(path) => void handleUnstageFile(path)}
-                                onFileClick={handleFileClick}
+                                isSelected={
+                                  selectionSection === "staged" && selectedPaths.has(file.path)
+                                }
+                                onToggle={handleToggleStaged}
+                                onRowClick={handleRowClick}
                                 density={stagedView.density}
                                 viewed={viewedFiles.has(viewedKey)}
                                 onViewedChange={(v) => handleViewedChange(viewedKey, v)}
@@ -1869,17 +2015,21 @@ export function ReviewHub({ isOpen, worktreePath, onClose }: ReviewHubProps) {
                               variant="ghost"
                               size="sm"
                               onClick={() =>
-                                changesView.filterQuery || !changesView.showGenerated
-                                  ? void handleStageFiltered()
-                                  : void handleStageAll()
+                                void (hasUnstagedSelection
+                                  ? handleStageSelection()
+                                  : changesView.filterQuery || !changesView.showGenerated
+                                    ? handleStageFiltered()
+                                    : handleStageAll())
                               }
                               className="h-5 px-1.5 text-[10px] shrink-0"
-                              data-testid="review-hub-stage-all"
+                              data-testid="review-hub-stage-section-button"
                             >
                               <CheckSquare className="w-3 h-3 mr-1" />
-                              {changesView.filterQuery
-                                ? `Stage shown (${derivedUnstaged.length})`
-                                : `Stage all (${derivedUnstaged.length})`}
+                              {hasUnstagedSelection
+                                ? `Stage selection (${selectedPaths.size})`
+                                : changesView.filterQuery
+                                  ? `Stage shown (${derivedUnstaged.length})`
+                                  : `Stage all (${derivedUnstaged.length})`}
                             </Button>
                           )}
                         </div>
@@ -1897,9 +2047,13 @@ export function ReviewHub({ isOpen, worktreePath, onClose }: ReviewHubProps) {
                               <FileStageRow
                                 key={`unstaged-${file.path}`}
                                 file={file}
+                                section="unstaged"
                                 isStaged={false}
-                                onToggle={(path) => void handleStageFile(path)}
-                                onFileClick={handleFileClick}
+                                isSelected={
+                                  selectionSection === "unstaged" && selectedPaths.has(file.path)
+                                }
+                                onToggle={handleToggleUnstaged}
+                                onRowClick={handleRowClick}
                                 density={changesView.density}
                                 viewed={viewedFiles.has(viewedKey)}
                                 onViewedChange={(v) => handleViewedChange(viewedKey, v)}

--- a/src/components/Worktree/ReviewHub/ReviewHub.tsx
+++ b/src/components/Worktree/ReviewHub/ReviewHub.tsx
@@ -802,6 +802,14 @@ export function ReviewHub({ isOpen, worktreePath, onClose }: ReviewHubProps) {
       if (next.size === 0) {
         setSelectionSection(null);
         selectionAnchorRef.current = null;
+      } else if (
+        selectionAnchorRef.current !== null &&
+        !validPaths.has(selectionAnchorRef.current)
+      ) {
+        // Anchor evicted but selection survives — reseat anchor on a remaining
+        // path so the next shift-click extends from it rather than falling
+        // through to plain-click (which would wipe the selection).
+        selectionAnchorRef.current = next.values().next().value ?? null;
       }
       return next;
     });

--- a/src/components/Worktree/ReviewHub/__tests__/ReviewHub.test.tsx
+++ b/src/components/Worktree/ReviewHub/__tests__/ReviewHub.test.tsx
@@ -3167,6 +3167,61 @@ describe("ReviewHub", () => {
       });
     });
 
+    it("reseats the anchor onto a surviving path when the original anchor is evicted by a refresh", async () => {
+      await renderHub();
+      // Anchor on src/a.ts, extend to b.ts — selection = {a, b}, anchor = a.
+      fireEvent.click(screen.getByTestId("file-stage-row-src/a.ts"), { metaKey: true });
+      fireEvent.click(screen.getByTestId("file-stage-row-src/b.ts"), { metaKey: true });
+
+      await waitFor(() => {
+        expect(screen.getByTestId("review-hub-unstage-section-button").textContent).toMatch(
+          /Unstage selection \(2\)/i
+        );
+      });
+
+      // Background refresh drops src/a.ts (the anchor); b.ts and c.ts remain.
+      getStagingStatusMock.mockResolvedValue(
+        makeStatus({
+          staged: [
+            { path: "src/b.ts", status: "modified", insertions: 1, deletions: 0 },
+            { path: "src/c.ts", status: "modified", insertions: 1, deletions: 0 },
+          ],
+          unstaged: [
+            { path: "src/x.ts", status: "modified", insertions: 1, deletions: 0 },
+            { path: "src/y.ts", status: "modified", insertions: 1, deletions: 0 },
+            { path: "src/z.ts", status: "modified", insertions: 1, deletions: 0 },
+          ],
+        })
+      );
+
+      await act(async () => {
+        capturedUpdateCallback!(makeWorktreeState());
+        await Promise.resolve();
+      });
+
+      await waitFor(() => {
+        expect(screen.queryByTestId("file-stage-row-src/a.ts")).toBeNull();
+        expect(screen.getByTestId("review-hub-unstage-section-button").textContent).toMatch(
+          /Unstage selection \(1\)/i
+        );
+      });
+
+      // Shift-click from b (the surviving anchor) to c — selection should extend.
+      fireEvent.click(screen.getByTestId("file-stage-row-src/c.ts"), { shiftKey: true });
+
+      await waitFor(() => {
+        expect(screen.getByTestId("review-hub-unstage-section-button").textContent).toMatch(
+          /Unstage selection \(2\)/i
+        );
+      });
+      expect(screen.getByTestId("file-stage-row-src/b.ts").getAttribute("aria-selected")).toBe(
+        "true"
+      );
+      expect(screen.getByTestId("file-stage-row-src/c.ts").getAttribute("aria-selected")).toBe(
+        "true"
+      );
+    });
+
     it("stage toggle button on a row does not start a selection", async () => {
       await renderHub();
       const row = screen.getByTestId("file-stage-row-src/x.ts");

--- a/src/components/Worktree/ReviewHub/__tests__/ReviewHub.test.tsx
+++ b/src/components/Worktree/ReviewHub/__tests__/ReviewHub.test.tsx
@@ -19,6 +19,11 @@ const {
   checkoutOursTheirsMock,
   openInEditorMock,
   stageFileMock,
+  unstageFileMock,
+  stageFilesMock,
+  unstageFilesMock,
+  stageAllMock,
+  unstageAllMock,
   commitMock,
   pushMock,
   pullRebaseMock,
@@ -39,6 +44,11 @@ const {
   checkoutOursTheirsMock: vi.fn().mockResolvedValue(undefined),
   openInEditorMock: vi.fn().mockResolvedValue(undefined),
   stageFileMock: vi.fn().mockResolvedValue(undefined),
+  unstageFileMock: vi.fn().mockResolvedValue(undefined),
+  stageFilesMock: vi.fn().mockResolvedValue(undefined),
+  unstageFilesMock: vi.fn().mockResolvedValue(undefined),
+  stageAllMock: vi.fn().mockResolvedValue(undefined),
+  unstageAllMock: vi.fn().mockResolvedValue(undefined),
   commitMock: vi.fn(),
   pushMock: vi.fn(),
   pullRebaseMock: vi.fn(),
@@ -381,6 +391,11 @@ describe("ReviewHub", () => {
     checkoutOursTheirsMock.mockReset().mockResolvedValue(undefined);
     openInEditorMock.mockReset().mockResolvedValue(undefined);
     stageFileMock.mockReset().mockResolvedValue(undefined);
+    unstageFileMock.mockReset().mockResolvedValue(undefined);
+    stageFilesMock.mockReset().mockResolvedValue(undefined);
+    unstageFilesMock.mockReset().mockResolvedValue(undefined);
+    stageAllMock.mockReset().mockResolvedValue(undefined);
+    unstageAllMock.mockReset().mockResolvedValue(undefined);
     commitMock.mockReset().mockResolvedValue({ hash: "abc123", summary: "commit" });
     pushMock.mockReset().mockResolvedValue(undefined);
     pullRebaseMock.mockReset().mockResolvedValue(undefined);
@@ -394,9 +409,11 @@ describe("ReviewHub", () => {
         git: {
           getStagingStatus: getStagingStatusMock,
           stageFile: stageFileMock,
-          unstageFile: vi.fn().mockResolvedValue(undefined),
-          stageAll: vi.fn().mockResolvedValue(undefined),
-          unstageAll: vi.fn().mockResolvedValue(undefined),
+          unstageFile: unstageFileMock,
+          stageFiles: stageFilesMock,
+          unstageFiles: unstageFilesMock,
+          stageAll: stageAllMock,
+          unstageAll: unstageAllMock,
           commit: commitMock,
           push: pushMock,
           pullRebase: pullRebaseMock,
@@ -2309,7 +2326,7 @@ describe("ReviewHub", () => {
 
       await waitFor(() => screen.getByText("index.ts"));
 
-      const stageAllBtn = screen.getByTestId("review-hub-stage-all");
+      const stageAllBtn = screen.getByTestId("review-hub-stage-section-button");
       fireEvent.click(stageAllBtn);
 
       await waitFor(() => {
@@ -2329,7 +2346,7 @@ describe("ReviewHub", () => {
 
       await waitFor(() => screen.getByText("Stage shown (1)"));
 
-      const stageBtn = screen.getByTestId("review-hub-stage-all");
+      const stageBtn = screen.getByTestId("review-hub-stage-section-button");
       fireEvent.click(stageBtn);
 
       await waitFor(() => {
@@ -2345,7 +2362,7 @@ describe("ReviewHub", () => {
 
       await waitFor(() => screen.getByText("index.ts"));
 
-      const unstageAllBtn = screen.getByTestId("review-hub-unstage-all");
+      const unstageAllBtn = screen.getByTestId("review-hub-unstage-section-button");
       fireEvent.click(unstageAllBtn);
 
       await waitFor(() => {
@@ -2377,9 +2394,9 @@ describe("ReviewHub", () => {
 
       await waitFor(() => screen.getByText("No unstaged changes"));
       // Stage all button (for Changes section) should be hidden when there are no unstaged files
-      expect(screen.queryByTestId("review-hub-stage-all")).toBeNull();
+      expect(screen.queryByTestId("review-hub-stage-section-button")).toBeNull();
       // Unstage all button (for Staged section) should be visible with 1 file
-      screen.getByTestId("review-hub-unstage-all");
+      screen.getByTestId("review-hub-unstage-section-button");
     });
 
     it("filter input uses ref for typing (no re-render on each keystroke)", async () => {
@@ -2851,6 +2868,318 @@ describe("ReviewHub", () => {
         name: "Mark src/index.ts as viewed",
       }) as HTMLInputElement;
       expect(reopened.checked).toBe(false);
+    });
+  });
+
+  describe("multi-select", () => {
+    const makeMultiFileStatus = (): StagingStatus =>
+      makeStatus({
+        staged: [
+          { path: "src/a.ts", status: "modified", insertions: 1, deletions: 0 },
+          { path: "src/b.ts", status: "modified", insertions: 1, deletions: 0 },
+          { path: "src/c.ts", status: "modified", insertions: 1, deletions: 0 },
+        ],
+        unstaged: [
+          { path: "src/x.ts", status: "modified", insertions: 1, deletions: 0 },
+          { path: "src/y.ts", status: "modified", insertions: 1, deletions: 0 },
+          { path: "src/z.ts", status: "modified", insertions: 1, deletions: 0 },
+        ],
+      });
+
+    const renderHub = async () => {
+      getStagingStatusMock.mockResolvedValue(makeMultiFileStatus());
+      render(<ReviewHub isOpen={true} worktreePath={WORKTREE_PATH} onClose={vi.fn()} />);
+      await waitFor(() => screen.getByTestId("file-stage-row-src/x.ts"));
+    };
+
+    it("renders the default Stage all / Unstage all labels with no selection", async () => {
+      await renderHub();
+      expect(screen.getByTestId("review-hub-stage-section-button").textContent).toMatch(
+        /Stage all/i
+      );
+      expect(screen.getByTestId("review-hub-unstage-section-button").textContent).toMatch(
+        /Unstage all/i
+      );
+    });
+
+    it("cmd-click selects an unstaged row and swaps button label to 'Stage selection (1)'", async () => {
+      await renderHub();
+      const row = screen.getByTestId("file-stage-row-src/x.ts");
+      fireEvent.click(row, { metaKey: true });
+
+      await waitFor(() => {
+        expect(screen.getByTestId("review-hub-stage-section-button").textContent).toMatch(
+          /Stage selection \(1\)/i
+        );
+      });
+      expect(row.getAttribute("aria-selected")).toBe("true");
+    });
+
+    it("ctrl-click also selects (Windows/Linux modifier)", async () => {
+      await renderHub();
+      const row = screen.getByTestId("file-stage-row-src/x.ts");
+      fireEvent.click(row, { ctrlKey: true });
+
+      await waitFor(() => {
+        expect(screen.getByTestId("review-hub-stage-section-button").textContent).toMatch(
+          /Stage selection \(1\)/i
+        );
+      });
+    });
+
+    it("cmd-click again on a selected row deselects it", async () => {
+      await renderHub();
+      const row = screen.getByTestId("file-stage-row-src/x.ts");
+
+      fireEvent.click(row, { metaKey: true });
+      await waitFor(() => expect(row.getAttribute("aria-selected")).toBe("true"));
+
+      fireEvent.click(row, { metaKey: true });
+      await waitFor(() => {
+        expect(row.getAttribute("aria-selected")).toBe("false");
+      });
+      expect(screen.getByTestId("review-hub-stage-section-button").textContent).toMatch(
+        /Stage all/i
+      );
+    });
+
+    it("shift-click extends the selection across a range", async () => {
+      await renderHub();
+      const x = screen.getByTestId("file-stage-row-src/x.ts");
+      const z = screen.getByTestId("file-stage-row-src/z.ts");
+
+      fireEvent.click(x, { metaKey: true });
+      fireEvent.click(z, { shiftKey: true });
+
+      await waitFor(() => {
+        expect(screen.getByTestId("review-hub-stage-section-button").textContent).toMatch(
+          /Stage selection \(3\)/i
+        );
+      });
+      expect(screen.getByTestId("file-stage-row-src/y.ts").getAttribute("aria-selected")).toBe(
+        "true"
+      );
+    });
+
+    it("plain click clears an active selection (and does not toggle selection)", async () => {
+      await renderHub();
+      const x = screen.getByTestId("file-stage-row-src/x.ts");
+      const y = screen.getByTestId("file-stage-row-src/y.ts");
+
+      fireEvent.click(x, { metaKey: true });
+      fireEvent.click(y, { metaKey: true });
+      await waitFor(() => {
+        expect(screen.getByTestId("review-hub-stage-section-button").textContent).toMatch(
+          /Stage selection \(2\)/i
+        );
+      });
+
+      fireEvent.click(screen.getByTestId("file-stage-row-src/z.ts"));
+
+      await waitFor(() => {
+        expect(screen.getByTestId("review-hub-stage-section-button").textContent).toMatch(
+          /Stage all/i
+        );
+      });
+      expect(x.getAttribute("aria-selected")).toBe("false");
+      expect(y.getAttribute("aria-selected")).toBe("false");
+    });
+
+    it("clicking in the other section clears the existing selection (per-section scope)", async () => {
+      await renderHub();
+      fireEvent.click(screen.getByTestId("file-stage-row-src/x.ts"), { metaKey: true });
+      fireEvent.click(screen.getByTestId("file-stage-row-src/y.ts"), { metaKey: true });
+
+      await waitFor(() => {
+        expect(screen.getByTestId("review-hub-stage-section-button").textContent).toMatch(
+          /Stage selection \(2\)/i
+        );
+      });
+
+      // Cmd-click in the staged section
+      fireEvent.click(screen.getByTestId("file-stage-row-src/a.ts"), { metaKey: true });
+
+      await waitFor(() => {
+        expect(screen.getByTestId("review-hub-stage-section-button").textContent).toMatch(
+          /Stage all/i
+        );
+        expect(screen.getByTestId("review-hub-unstage-section-button").textContent).toMatch(
+          /Unstage selection \(1\)/i
+        );
+      });
+    });
+
+    it("'Stage selection (N)' invokes stageFiles once with all selected paths", async () => {
+      await renderHub();
+      fireEvent.click(screen.getByTestId("file-stage-row-src/x.ts"), { metaKey: true });
+      fireEvent.click(screen.getByTestId("file-stage-row-src/z.ts"), { shiftKey: true });
+
+      await waitFor(() => {
+        expect(screen.getByTestId("review-hub-stage-section-button").textContent).toMatch(
+          /Stage selection \(3\)/i
+        );
+      });
+
+      fireEvent.click(screen.getByTestId("review-hub-stage-section-button"));
+
+      await waitFor(() => expect(stageFilesMock).toHaveBeenCalledTimes(1));
+      expect(stageFilesMock).toHaveBeenCalledWith(WORKTREE_PATH, [
+        "src/x.ts",
+        "src/y.ts",
+        "src/z.ts",
+      ]);
+      expect(stageFileMock).not.toHaveBeenCalled();
+      expect(stageAllMock).not.toHaveBeenCalled();
+    });
+
+    it("'Unstage selection (N)' invokes unstageFiles once with all selected paths", async () => {
+      await renderHub();
+      fireEvent.click(screen.getByTestId("file-stage-row-src/a.ts"), { metaKey: true });
+      fireEvent.click(screen.getByTestId("file-stage-row-src/b.ts"), { metaKey: true });
+
+      await waitFor(() => {
+        expect(screen.getByTestId("review-hub-unstage-section-button").textContent).toMatch(
+          /Unstage selection \(2\)/i
+        );
+      });
+
+      fireEvent.click(screen.getByTestId("review-hub-unstage-section-button"));
+
+      await waitFor(() => expect(unstageFilesMock).toHaveBeenCalledTimes(1));
+      expect(unstageFilesMock).toHaveBeenCalledWith(WORKTREE_PATH, ["src/a.ts", "src/b.ts"]);
+      expect(unstageFileMock).not.toHaveBeenCalled();
+      expect(unstageAllMock).not.toHaveBeenCalled();
+    });
+
+    it("clears the selection after a successful batch stage", async () => {
+      await renderHub();
+      fireEvent.click(screen.getByTestId("file-stage-row-src/x.ts"), { metaKey: true });
+      fireEvent.click(screen.getByTestId("file-stage-row-src/y.ts"), { metaKey: true });
+
+      // Status will reflect the stage on refresh:
+      getStagingStatusMock.mockResolvedValueOnce(
+        makeStatus({
+          staged: [
+            { path: "src/x.ts", status: "modified", insertions: 1, deletions: 0 },
+            { path: "src/y.ts", status: "modified", insertions: 1, deletions: 0 },
+          ],
+          unstaged: [{ path: "src/z.ts", status: "modified", insertions: 1, deletions: 0 }],
+        })
+      );
+
+      fireEvent.click(screen.getByTestId("review-hub-stage-section-button"));
+
+      await waitFor(() => expect(stageFilesMock).toHaveBeenCalled());
+      await waitFor(() => {
+        expect(screen.getByTestId("review-hub-stage-section-button").textContent).toMatch(
+          /Stage all/i
+        );
+      });
+    });
+
+    it("guards against rapid double-clicks — only one IPC call is issued", async () => {
+      // Hold the resolution of stageFiles so a second click can land before it completes.
+      let resolveStageFiles!: () => void;
+      stageFilesMock.mockImplementationOnce(
+        () =>
+          new Promise<void>((resolve) => {
+            resolveStageFiles = resolve;
+          })
+      );
+
+      await renderHub();
+      fireEvent.click(screen.getByTestId("file-stage-row-src/x.ts"), { metaKey: true });
+
+      await waitFor(() => {
+        expect(screen.getByTestId("review-hub-stage-section-button").textContent).toMatch(
+          /Stage selection \(1\)/i
+        );
+      });
+
+      const btn = screen.getByTestId("review-hub-stage-section-button");
+      fireEvent.click(btn);
+      fireEvent.click(btn);
+
+      // Resolve the pending call so the test cleans up.
+      resolveStageFiles();
+      await waitFor(() => expect(stageFilesMock).toHaveBeenCalledTimes(1));
+    });
+
+    it("Escape clears an active selection before closing the modal", async () => {
+      const onClose = vi.fn();
+      getStagingStatusMock.mockResolvedValue(makeMultiFileStatus());
+      render(<ReviewHub isOpen={true} worktreePath={WORKTREE_PATH} onClose={onClose} />);
+      await waitFor(() => screen.getByTestId("file-stage-row-src/x.ts"));
+
+      fireEvent.click(screen.getByTestId("file-stage-row-src/x.ts"), { metaKey: true });
+      await waitFor(() => {
+        expect(screen.getByTestId("review-hub-stage-section-button").textContent).toMatch(
+          /Stage selection \(1\)/i
+        );
+      });
+
+      fireEvent.keyDown(document, { key: "Escape" });
+
+      await waitFor(() => {
+        expect(screen.getByTestId("review-hub-stage-section-button").textContent).toMatch(
+          /Stage all/i
+        );
+      });
+      expect(onClose).not.toHaveBeenCalled();
+
+      // Second Escape with no selection closes the modal.
+      fireEvent.keyDown(document, { key: "Escape" });
+      await waitFor(() => expect(onClose).toHaveBeenCalled());
+    });
+
+    it("removes a staged-then-no-longer-present path from the selection after refresh", async () => {
+      await renderHub();
+      fireEvent.click(screen.getByTestId("file-stage-row-src/a.ts"), { metaKey: true });
+      fireEvent.click(screen.getByTestId("file-stage-row-src/b.ts"), { metaKey: true });
+
+      await waitFor(() => {
+        expect(screen.getByTestId("review-hub-unstage-section-button").textContent).toMatch(
+          /Unstage selection \(2\)/i
+        );
+      });
+
+      // Background refresh removes src/a.ts from the staged section.
+      const updated = makeStatus({
+        staged: [{ path: "src/b.ts", status: "modified", insertions: 1, deletions: 0 }],
+        unstaged: [
+          { path: "src/x.ts", status: "modified", insertions: 1, deletions: 0 },
+          { path: "src/y.ts", status: "modified", insertions: 1, deletions: 0 },
+          { path: "src/z.ts", status: "modified", insertions: 1, deletions: 0 },
+        ],
+      });
+      getStagingStatusMock.mockResolvedValue(updated);
+
+      await act(async () => {
+        capturedUpdateCallback!(makeWorktreeState());
+        await Promise.resolve();
+      });
+
+      await waitFor(() => {
+        expect(screen.queryByTestId("file-stage-row-src/a.ts")).toBeNull();
+        expect(screen.getByTestId("review-hub-unstage-section-button").textContent).toMatch(
+          /Unstage selection \(1\)/i
+        );
+      });
+    });
+
+    it("stage toggle button on a row does not start a selection", async () => {
+      await renderHub();
+      const row = screen.getByTestId("file-stage-row-src/x.ts");
+      const toggle = within(row).getByRole("button", { name: /Stage src\/x\.ts/i });
+
+      fireEvent.click(toggle);
+
+      // No selection started; the per-row toggle still fires single-file stage.
+      await waitFor(() => expect(stageFileMock).toHaveBeenCalledWith(WORKTREE_PATH, "src/x.ts"));
+      expect(row.getAttribute("aria-selected")).toBe("false");
+      expect(screen.getByTestId("review-hub-stage-section-button").textContent).toMatch(
+        /Stage all/i
+      );
     });
   });
 });


### PR DESCRIPTION
## Summary

- Adds multi-select to the Review Hub file list: shift-click for range select, cmd/ctrl-click to toggle individual rows in or out of the selection.
- When rows are selected, the section-header bulk button label switches to `Stage selection (N)` / `Unstage selection (N)`. After the bulk action runs the selection clears so it can't go stale once rows move sections.
- Selected rows use `bg-overlay-subtle` — no accent color, per `CLAUDE.md`'s Accent Color Restraint rule.

Resolves #7790

## Changes

- `ReviewHub.tsx` — adds `selectedFiles` set + `selectionAnchor` ref, handles shift-click range and cmd/ctrl-click toggle, wires updated button labels, clears selection post-action.
- `FileStageRow.tsx` — accepts `isSelected`, `onSelect`, and `selectionMode` props; applies the `bg-overlay-subtle` lift when selected; routes click events through the selection handler when applicable.
- `electron/ipc/` — thin IPC additions (`channels.ts`, `git-write.ts`, `preload.cts`, `api.ts`, `maps.ts`) to support bulk stage/unstage of a specific file list.
- `ReviewHub.test.tsx` — covers shift-click range, cmd/ctrl-click toggle, label switching, post-action clear, and anchor eviction when the original anchor row moves between sections.

## Testing

- Unit tests pass (`ReviewHub.test.tsx`, 390+ lines of new coverage).
- Manually verified shift-click range, cmd/ctrl-click toggle, bulk label update, and post-action clear on a repo with ~50 changed files.
- Anchor eviction tested by staging the anchor file mid-selection and confirming the anchor reseats cleanly.