### PR TITLE
feat(review-hub): split PR chip into status pill and external-link button

### DIFF
--- a/src/components/Worktree/ReviewHub/ReviewHub.tsx
+++ b/src/components/Worktree/ReviewHub/ReviewHub.tsx
@@ -13,6 +13,7 @@ import {
   X,
   RefreshCw,
   CheckSquare,
+  ExternalLink,
   Square,
   AlertTriangle,
   CheckCircle2,
@@ -926,64 +927,75 @@ export function ReviewHub({ isOpen, worktreePath, onClose }: ReviewHubProps) {
                 worktreePR.prUrl &&
                 (() => {
                   const ciVisual = prCIStatusVisual(worktreePR.prCiStatus);
+                  const prStateLabel =
+                    worktreePR.prState === "merged"
+                      ? "merged"
+                      : worktreePR.prState === "closed"
+                        ? "closed"
+                        : "open";
                   return (
-                    <button
-                      type="button"
-                      onClick={() => void githubClient.openPR(worktreePR.prUrl as string)}
-                      className={cn(
-                        "inline-flex items-center gap-1 px-1.5 py-0.5 rounded text-[11px] font-mono",
-                        "bg-tint/[0.07] border border-tint/[0.08]",
-                        "hover:bg-tint/[0.12] transition-colors cursor-pointer",
-                        "focus-visible:outline-hidden focus-visible:ring-1 focus-visible:ring-daintree-accent"
-                      )}
-                      aria-label={
-                        ciVisual
-                          ? `Open pull request #${worktreePR.prNumber} on GitHub — CI ${ciVisual.label}`
-                          : `Open pull request #${worktreePR.prNumber} on GitHub`
-                      }
-                    >
-                      <GitPullRequest
-                        className={cn(
-                          "w-3 h-3 shrink-0",
-                          worktreePR.prState === "merged"
-                            ? "text-github-merged"
-                            : worktreePR.prState === "closed"
-                              ? "text-github-closed"
-                              : "text-github-open"
-                        )}
-                      />
+                    <>
                       <span
-                        className={
-                          worktreePR.prState === "merged"
-                            ? "text-github-merged"
-                            : worktreePR.prState === "closed"
-                              ? "text-github-closed"
-                              : "text-github-open"
+                        className={cn(
+                          "inline-flex items-center gap-1 px-1.5 py-0.5 rounded text-[11px] font-mono",
+                          "bg-tint/[0.07] border border-tint/[0.08]"
+                        )}
+                        aria-label={
+                          ciVisual
+                            ? `Pull request #${worktreePR.prNumber} ${prStateLabel} — CI ${ciVisual.label}`
+                            : `Pull request #${worktreePR.prNumber} ${prStateLabel}`
                         }
                       >
-                        #{worktreePR.prNumber}
+                        <GitPullRequest
+                          className={cn(
+                            "w-3 h-3 shrink-0",
+                            worktreePR.prState === "merged"
+                              ? "text-github-merged"
+                              : worktreePR.prState === "closed"
+                                ? "text-github-closed"
+                                : "text-github-open"
+                          )}
+                        />
+                        <span
+                          className={
+                            worktreePR.prState === "merged"
+                              ? "text-github-merged"
+                              : worktreePR.prState === "closed"
+                                ? "text-github-closed"
+                                : "text-github-open"
+                          }
+                        >
+                          #{worktreePR.prNumber}
+                        </span>
+                        <span className="text-daintree-text/40">·</span>
+                        <span className="text-daintree-text/60">{prStateLabel}</span>
+                        {ciVisual && (
+                          <>
+                            <span className="text-daintree-text/40">·</span>
+                            <span className="inline-flex items-center gap-0.5">
+                              <ciVisual.Icon
+                                className={cn("w-2.5 h-2.5 shrink-0", ciVisual.className)}
+                                aria-hidden="true"
+                              />
+                              <span className={ciVisual.className}>{ciVisual.label}</span>
+                            </span>
+                          </>
+                        )}
                       </span>
-                      <span className="text-daintree-text/40">·</span>
-                      <span className="text-daintree-text/60">
-                        {worktreePR.prState === "merged"
-                          ? "merged"
-                          : worktreePR.prState === "closed"
-                            ? "closed"
-                            : "open"}
-                      </span>
-                      {ciVisual && (
-                        <>
-                          <span className="text-daintree-text/40">·</span>
-                          <span className="inline-flex items-center gap-0.5">
-                            <ciVisual.Icon
-                              className={cn("w-2.5 h-2.5 shrink-0", ciVisual.className)}
-                              aria-hidden="true"
-                            />
-                            <span className={ciVisual.className}>{ciVisual.label}</span>
-                          </span>
-                        </>
-                      )}
-                    </button>
+                      <button
+                        type="button"
+                        onClick={() => void githubClient.openPR(worktreePR.prUrl as string)}
+                        className={cn(
+                          "inline-flex items-center justify-center p-0.5 rounded",
+                          "text-daintree-text/60 hover:bg-tint/5 hover:text-daintree-text",
+                          "transition-colors cursor-pointer",
+                          "focus-visible:outline-hidden focus-visible:ring-1 focus-visible:ring-daintree-accent"
+                        )}
+                        aria-label={`View pull request #${worktreePR.prNumber} on GitHub`}
+                      >
+                        <ExternalLink className="w-3 h-3" />
+                      </button>
+                    </>
                   );
                 })()}
               {status?.hasRemote && !worktreePR && (

--- a/src/components/Worktree/ReviewHub/__tests__/ReviewHub.test.tsx
+++ b/src/components/Worktree/ReviewHub/__tests__/ReviewHub.test.tsx
@@ -917,7 +917,7 @@ describe("ReviewHub", () => {
       render(<ReviewHub isOpen={true} worktreePath={WORKTREE_PATH} onClose={vi.fn()} />);
 
       await waitFor(() => {
-        screen.getByRole("button", { name: /open pull request #42/i });
+        screen.getByRole("button", { name: /view pull request #42/i });
         screen.getByText("#42");
         screen.getByText("open");
       });
@@ -933,8 +933,8 @@ describe("ReviewHub", () => {
 
       render(<ReviewHub isOpen={true} worktreePath={WORKTREE_PATH} onClose={vi.fn()} />);
 
-      await waitFor(() => screen.getByRole("button", { name: /open pull request #42/i }));
-      fireEvent.click(screen.getByRole("button", { name: /open pull request #42/i }));
+      await waitFor(() => screen.getByRole("button", { name: /view pull request #42/i }));
+      fireEvent.click(screen.getByRole("button", { name: /view pull request #42/i }));
 
       expect(openPRMock).toHaveBeenCalledWith("https://github.com/test/repo/pull/42");
     });
@@ -1009,7 +1009,7 @@ describe("ReviewHub", () => {
 
       await waitFor(() => {
         screen.getByText("failing");
-        screen.getByRole("button", { name: /ci failing/i });
+        screen.getByText(/ci failing/i);
       });
     });
 

--- a/src/components/Worktree/ReviewHub/__tests__/ReviewHub.test.tsx
+++ b/src/components/Worktree/ReviewHub/__tests__/ReviewHub.test.tsx
@@ -1014,7 +1014,7 @@ describe("ReviewHub", () => {
 
       await waitFor(() => {
         screen.getByText("failing");
-        screen.getByText(/ci failing/i);
+        screen.getByLabelText(/ci failing/i);
       });
     });
 

--- a/src/components/Worktree/ReviewHub/__tests__/ReviewHub.test.tsx
+++ b/src/components/Worktree/ReviewHub/__tests__/ReviewHub.test.tsx
@@ -923,7 +923,7 @@ describe("ReviewHub", () => {
       });
     });
 
-    it("opens PR in browser when PR badge is clicked", async () => {
+    it("opens PR in browser when external-link button is clicked", async () => {
       setWorktreePR({
         prNumber: 42,
         prUrl: "https://github.com/test/repo/pull/42",
@@ -934,8 +934,13 @@ describe("ReviewHub", () => {
       render(<ReviewHub isOpen={true} worktreePath={WORKTREE_PATH} onClose={vi.fn()} />);
 
       await waitFor(() => screen.getByRole("button", { name: /view pull request #42/i }));
-      fireEvent.click(screen.getByRole("button", { name: /view pull request #42/i }));
 
+      // Clicking the pill text does not open the PR
+      fireEvent.click(screen.getByText("#42"));
+      expect(openPRMock).not.toHaveBeenCalled();
+
+      // Clicking the external-link button opens the PR
+      fireEvent.click(screen.getByRole("button", { name: /view pull request #42/i }));
       expect(openPRMock).toHaveBeenCalledWith("https://github.com/test/repo/pull/42");
     });
 


### PR DESCRIPTION
## Summary
- The PR chip in ReviewHub was a single `<button>` that displayed `#N · state` and opened the PR externally on click — a badge that acted like a link, causing interaction ambiguity.
- This splits the chip into two elements: a read-only `<span>` pill for `#N · state` using the existing semantic color tokens, and an adjacent `ExternalLink` icon-only `<button>` that opens the PR on GitHub.
- ExternalLink is already the project's convention for external-link affordances, used throughout the app.

Resolves #7779

## Changes
- `ReviewHub.tsx`: replaced the dual-purpose button with a status pill and a separate `ExternalLink` icon button with `aria-label="View pull request #{N} on GitHub"`. The "No PR" span is unchanged.
- `ReviewHub.test.tsx`: updated tests to target the new icon button instead of the old chip button.

## Testing
- Existing ReviewHub tests pass with updated selectors targeting the new split elements.
- Negative-click assertion added to confirm the status pill is not clickable.