### PR TITLE
feat(worktree): surface refractor chunk-load failures in diff viewer

### DIFF
--- a/src/components/Worktree/DiffViewer.tsx
+++ b/src/components/Worktree/DiffViewer.tsx
@@ -47,6 +47,12 @@ const LANG_LOADERS: Record<string, () => Promise<{ default: Syntax }>> = {
 };
 
 const langLoadPromises = new Map<string, Promise<void>>();
+const FAILED_LANGS = new Set<string>();
+
+export function _resetLangStateForTests(): void {
+  FAILED_LANGS.clear();
+  langLoadPromises.clear();
+}
 
 function ensureLanguage(language: string): Promise<void> {
   if (refractor.registered(language)) return Promise.resolve();
@@ -58,9 +64,10 @@ function ensureLanguage(language: string): Promise<void> {
       .then((mod) => {
         refractor.register(mod.default);
       })
-      // Intentional: no retry. A failed chunk load caches as a resolved
-      // no-op so the language renders as plain text and renders don't loop.
-      .catch(() => {});
+      .catch((err: unknown) => {
+        console.warn(`Failed to load refractor grammar for "${language}"`, err);
+        FAILED_LANGS.add(language);
+      });
     langLoadPromises.set(language, pending);
   }
   return pending;
@@ -74,25 +81,36 @@ export interface DiffViewerProps {
   rootPath?: string;
 }
 
-function useTokens(hunks: HunkData[], language: string): HunkTokens | null {
+function useTokens(
+  hunks: HunkData[],
+  language: string
+): {
+  tokens: HunkTokens | null;
+  langLoadFailed: boolean;
+} {
   const [langReady, setLangReady] = useState(() => refractor.registered(language));
+  const [langLoadFailed, setLangLoadFailed] = useState(() => FAILED_LANGS.has(language));
 
   useEffect(() => {
     if (refractor.registered(language)) {
       setLangReady(true);
+      setLangLoadFailed(false);
       return;
     }
     setLangReady(false);
     let cancelled = false;
     void ensureLanguage(language).then(() => {
-      if (!cancelled) setLangReady(refractor.registered(language));
+      if (!cancelled) {
+        setLangReady(refractor.registered(language));
+        setLangLoadFailed(FAILED_LANGS.has(language));
+      }
     });
     return () => {
       cancelled = true;
     };
   }, [language]);
 
-  return useMemo(() => {
+  const tokens = useMemo(() => {
     if (!hunks.length || !langReady) return null;
 
     const options: TokenizeOptions = {
@@ -108,6 +126,8 @@ function useTokens(hunks: HunkData[], language: string): HunkTokens | null {
       return null;
     }
   }, [hunks, language, langReady]);
+
+  return { tokens, langLoadFailed };
 }
 
 export function DiffViewer({ diff, filePath, viewType = "split", rootPath }: DiffViewerProps) {
@@ -176,7 +196,7 @@ interface FileDiffProps {
 }
 
 function FileDiff({ file, viewType, language, rootPath }: FileDiffProps) {
-  const tokens = useTokens(file.hunks ?? [], language);
+  const { tokens, langLoadFailed } = useTokens(file.hunks ?? [], language);
   const diffType: DiffType = file.type as DiffType;
 
   const { additions, deletions } = useMemo(() => {
@@ -227,6 +247,15 @@ function FileDiff({ file, viewType, language, rootPath }: FileDiffProps) {
           <TruncatedTooltip content={relPath}>
             <span className="truncate">{relPath}</span>
           </TruncatedTooltip>
+          {langLoadFailed && (
+            <span
+              className="text-xs text-text-muted"
+              role="status"
+              data-testid="diff-plain-text-badge"
+            >
+              Plain text
+            </span>
+          )}
           <div className="flex items-center gap-2 shrink-0">
             {(additions > 0 || deletions > 0) && (
               <span className="flex items-center gap-1">

--- a/src/components/Worktree/__tests__/DiffViewer.test.tsx
+++ b/src/components/Worktree/__tests__/DiffViewer.test.tsx
@@ -1,0 +1,76 @@
+// @vitest-environment jsdom
+import { render, screen, waitFor } from "@testing-library/react";
+import { describe, expect, it, vi, beforeEach } from "vitest";
+import { DiffViewer, _resetLangStateForTests } from "../DiffViewer";
+import { TooltipProvider } from "@/components/ui/tooltip";
+
+vi.mock("refractor/rust", () => {
+  throw new Error("Failed to fetch dynamically imported module");
+});
+
+vi.mock("@/services/ActionService", () => ({
+  actionService: {
+    dispatch: vi.fn().mockResolvedValue({ ok: true }),
+  },
+}));
+
+const rustDiff = `diff --git a/main.rs b/main.rs
+index abc123..def456 100644
+--- a/main.rs
++++ b/main.rs
+@@ -1,3 +1,3 @@
+-fn old() {
++fn new() {
+   let x = 1;
+-  return x;
++  return x + 1;
+ }`;
+
+const jsDiff = `diff --git a/app.js b/app.js
+index 123abc..456def 100644
+--- a/app.js
++++ b/app.js
+@@ -1,1 +1,1 @@
+-console.log("old");
++console.log("new");`;
+
+function wrap(ui: React.ReactElement) {
+  return <TooltipProvider>{ui}</TooltipProvider>;
+}
+
+describe("DiffViewer", () => {
+  beforeEach(() => {
+    _resetLangStateForTests();
+  });
+
+  it("shows Plain text badge when refractor chunk load fails", async () => {
+    render(wrap(<DiffViewer diff={rustDiff} filePath="main.rs" />));
+    await waitFor(() => {
+      expect(screen.getByTestId("diff-plain-text-badge")).toBeTruthy();
+    });
+    expect(screen.getByTestId("diff-plain-text-badge").textContent).toBe("Plain text");
+  });
+
+  it("does not show Plain text badge for built-in languages", async () => {
+    render(wrap(<DiffViewer diff={jsDiff} filePath="app.js" />));
+    await waitFor(() => {
+      expect(screen.getByText("app.js")).toBeTruthy();
+    });
+    expect(screen.queryByTestId("diff-plain-text-badge")).toBeNull();
+  });
+
+  it("does not show Plain text badge for unknown file extensions", async () => {
+    const unknownDiff = `diff --git a/foo.xyz b/foo.xyz
+index 000..111 100644
+--- a/foo.xyz
++++ b/foo.xyz
+@@ -1,1 +1,1 @@
+-old
++new`;
+    render(wrap(<DiffViewer diff={unknownDiff} filePath="foo.xyz" />));
+    await waitFor(() => {
+      expect(screen.getByText("foo.xyz")).toBeTruthy();
+    });
+    expect(screen.queryByTestId("diff-plain-text-badge")).toBeNull();
+  });
+});


### PR DESCRIPTION
## Summary
- The refractor syntax highlighter silently swallows chunk-load failures, so when a language grammar can't load, the diff renders as plain text with no indication anything went wrong.
- Adds a `console.warn` in the catch block so failures are at least visible in logs, tracks failed languages in a `Set` so the UI can check, and shows a subtle "Plain text" badge on the file header when a language failed to load.
- Three unit tests cover badge visibility: shown on chunk-load failure, hidden for built-in languages, hidden for unknown extensions.

Resolves #7786

## Changes
- `src/components/Worktree/DiffViewer.tsx` — `FAILED_LANGS` Set, `console.warn` in catch, `langLoadFailed` from `useTokens`, "Plain text" badge in the per-file header strip
- `src/components/Worktree/__tests__/DiffViewer.test.tsx` — three unit tests for badge visibility

## Testing
- Unit tests pass locally. No retry behavior changed — the existing no-retry decision is preserved.