### PR TITLE
feat(notifications): route completed-with-changes agents to review inbox

### DIFF
--- a/shared/types/actions.ts
+++ b/shared/types/actions.ts
@@ -207,6 +207,7 @@ export type BuiltInActionId =
   | "worktree.select"
   | "worktree.copyTree"
   | "worktree.openEditor"
+  | "worktree.openReviewHub"
   | "worktree.overview.open"
   | "worktree.overview.close"
   | "action.palette.open"

--- a/src/components/Worktree/WorktreeCard.tsx
+++ b/src/components/Worktree/WorktreeCard.tsx
@@ -11,6 +11,7 @@ import { useIsWorktreeSortDragging } from "../DragDrop/DndProvider";
 import { GripVertical } from "lucide-react";
 import { useErrorStore, usePanelStore, type RetryAction, type TerminalInstance } from "../../store";
 import { useRecipeStore } from "../../store/recipeStore";
+import { useUIStore } from "../../store/uiStore";
 import { useWorktreeSelectionStore } from "../../store/worktreeStore";
 import {
   useProjectSettingsStore,
@@ -435,6 +436,13 @@ export function WorktreeCard({
 
   const onCloseReviewHub = () => setShowReviewHub(false);
   const onClosePlanViewer = () => setShowPlanViewer(false);
+
+  const pendingReviewHubWorktreeId = useUIStore((s) => s.pendingReviewHubWorktreeId);
+  useEffect(() => {
+    if (pendingReviewHubWorktreeId !== worktree.id) return;
+    setShowReviewHub(true);
+    useUIStore.getState().clearPendingReviewHubWorktreeId();
+  }, [pendingReviewHubWorktreeId, worktree.id]);
 
   const handleAttachIssue = async (issue: GitHubIssue) => {
     await worktreeClient.attachIssue({

--- a/src/services/actions/definitions/__tests__/worktreeOpenReviewHubAction.test.ts
+++ b/src/services/actions/definitions/__tests__/worktreeOpenReviewHubAction.test.ts
@@ -1,0 +1,100 @@
+// @vitest-environment jsdom
+import { beforeEach, describe, expect, it, vi } from "vitest";
+
+const setActiveWorktreeMock = vi.hoisted(() => vi.fn());
+const setPendingReviewHubWorktreeIdMock = vi.hoisted(() => vi.fn());
+
+vi.mock("@/store/worktreeStore", () => ({
+  useWorktreeSelectionStore: { getState: () => ({ setActiveWorktree: setActiveWorktreeMock }) },
+}));
+
+vi.mock("@/store/uiStore", () => ({
+  useUIStore: {
+    getState: () => ({ setPendingReviewHubWorktreeId: setPendingReviewHubWorktreeIdMock }),
+  },
+}));
+
+vi.mock("@/store/createWorktreeStore", () => ({
+  getCurrentViewStore: () => ({
+    getState: () => ({ worktrees: new Map() }),
+  }),
+}));
+
+vi.mock("@/clients", () => ({
+  copyTreeClient: { generateAndCopyFile: vi.fn() },
+  systemClient: { openPath: vi.fn() },
+}));
+
+vi.mock("@/services/ActionService", () => ({
+  actionService: { dispatch: vi.fn() },
+}));
+
+import type { ActionContext } from "@shared/types/actions";
+import type { ActionRegistry, ActionCallbacks } from "../../actionTypes";
+import { registerWorktreeContextActions } from "../worktreeContextActions";
+
+function getAction() {
+  const actions: ActionRegistry = new Map();
+  const callbacks = { onInject: vi.fn() } as unknown as ActionCallbacks;
+  registerWorktreeContextActions(actions, callbacks);
+  const factory = actions.get("worktree.openReviewHub");
+  if (!factory) throw new Error("worktree.openReviewHub is not registered");
+  return factory();
+}
+
+beforeEach(() => {
+  vi.clearAllMocks();
+});
+
+describe("worktree.openReviewHub", () => {
+  it("registers a renderer-scoped command action", () => {
+    const action = getAction();
+    expect(action.id).toBe("worktree.openReviewHub");
+    expect(action.kind).toBe("command");
+    expect(action.danger).toBe("safe");
+    expect(action.scope).toBe("renderer");
+  });
+
+  it("accepts an optional worktreeId argument", () => {
+    const action = getAction();
+    expect(action.argsSchema).toBeDefined();
+    expect(() => action.argsSchema!.parse({ worktreeId: "wt-1" })).not.toThrow();
+    expect(() => action.argsSchema!.parse({})).not.toThrow();
+    expect(() => action.argsSchema!.parse(undefined)).not.toThrow();
+  });
+
+  it("activates the worktree and sets the pending Review Hub signal with explicit worktreeId", async () => {
+    const action = getAction();
+    await action.run({ worktreeId: "wt-1" }, {} as ActionContext);
+
+    expect(setActiveWorktreeMock).toHaveBeenCalledWith("wt-1");
+    expect(setPendingReviewHubWorktreeIdMock).toHaveBeenCalledWith("wt-1");
+  });
+
+  it("falls back to focusedWorktreeId then activeWorktreeId", async () => {
+    const action = getAction();
+    await action.run(undefined, {
+      focusedWorktreeId: "wt-focus",
+      activeWorktreeId: "wt-active",
+    } as ActionContext);
+
+    expect(setActiveWorktreeMock).toHaveBeenCalledWith("wt-focus");
+    expect(setPendingReviewHubWorktreeIdMock).toHaveBeenCalledWith("wt-focus");
+  });
+
+  it("falls back to activeWorktreeId when no focused worktree is set", async () => {
+    const action = getAction();
+    await action.run(undefined, { activeWorktreeId: "wt-active" } as ActionContext);
+
+    expect(setActiveWorktreeMock).toHaveBeenCalledWith("wt-active");
+    expect(setPendingReviewHubWorktreeIdMock).toHaveBeenCalledWith("wt-active");
+  });
+
+  it("no-ops when no worktreeId can be resolved", async () => {
+    const action = getAction();
+    await action.run(undefined, {} as ActionContext);
+
+    expect(setActiveWorktreeMock).not.toHaveBeenCalled();
+    expect(setPendingReviewHubWorktreeIdMock).not.toHaveBeenCalled();
+  });
+});

--- a/src/services/actions/definitions/worktreeContextActions.ts
+++ b/src/services/actions/definitions/worktreeContextActions.ts
@@ -6,6 +6,7 @@ import { copyTreeClient, systemClient } from "@/clients";
 import { actionService } from "@/services/ActionService";
 import { getCurrentViewStore } from "@/store/createWorktreeStore";
 import { useWorktreeSelectionStore } from "@/store/worktreeStore";
+import { useUIStore } from "@/store/uiStore";
 import { DEFAULT_COPYTREE_FORMAT } from "@/lib/copyTreeFormat";
 
 export function registerWorktreeContextActions(
@@ -144,6 +145,26 @@ export function registerWorktreeContextActions(
         if (!worktree) return;
 
         await systemClient.openPath(worktree.path);
+      },
+    })
+  );
+
+  actions.set("worktree.openReviewHub", () =>
+    defineAction({
+      id: "worktree.openReviewHub",
+      title: "Open Review Hub",
+      description: "Open the Review Hub for a worktree to review uncommitted changes",
+      category: "worktree",
+      kind: "command",
+      danger: "safe",
+      scope: "renderer",
+      argsSchema: z.object({ worktreeId: z.string().optional() }).optional(),
+      run: async (args, ctx: ActionContext) => {
+        const worktreeId = args?.worktreeId;
+        const targetWorktreeId = worktreeId ?? ctx.focusedWorktreeId ?? ctx.activeWorktreeId;
+        if (!targetWorktreeId) return;
+        useWorktreeSelectionStore.getState().setActiveWorktree(targetWorktreeId);
+        useUIStore.getState().setPendingReviewHubWorktreeId(targetWorktreeId);
       },
     })
   );

--- a/src/store/__tests__/uiStore.test.ts
+++ b/src/store/__tests__/uiStore.test.ts
@@ -78,3 +78,32 @@ describe("useUIStore overlay stack", () => {
     expect(useUIStore.getState().overlayStack.includes("project-switcher")).toBe(true);
   });
 });
+
+describe("useUIStore pendingReviewHubWorktreeId", () => {
+  beforeEach(() => {
+    useUIStore.setState({ pendingReviewHubWorktreeId: null });
+  });
+
+  it("starts as null", () => {
+    expect(useUIStore.getState().pendingReviewHubWorktreeId).toBeNull();
+  });
+
+  it("setPendingReviewHubWorktreeId records the target", () => {
+    useUIStore.getState().setPendingReviewHubWorktreeId("wt-1");
+    expect(useUIStore.getState().pendingReviewHubWorktreeId).toBe("wt-1");
+  });
+
+  it("clearPendingReviewHubWorktreeId resets to null", () => {
+    useUIStore.getState().setPendingReviewHubWorktreeId("wt-1");
+    useUIStore.getState().clearPendingReviewHubWorktreeId();
+    expect(useUIStore.getState().pendingReviewHubWorktreeId).toBeNull();
+  });
+
+  it("clearPendingReviewHubWorktreeId is idempotent when already null", () => {
+    const before = useUIStore.getState();
+    useUIStore.getState().clearPendingReviewHubWorktreeId();
+    const after = useUIStore.getState();
+    // Returning the same state reference ensures Zustand skips re-renders.
+    expect(after.pendingReviewHubWorktreeId).toBe(before.pendingReviewHubWorktreeId);
+  });
+});

--- a/src/store/listeners/panel/__tests__/identity.test.ts
+++ b/src/store/listeners/panel/__tests__/identity.test.ts
@@ -180,24 +180,14 @@ describe("identity listener — completed-with-changes notification", () => {
     d.dispose();
   });
 
-  it("fires when there was no working state before completed but current count > 0", () => {
+  it("does not fire when no working state was captured (no baseline)", () => {
     setupPanel();
     const d = setupIdentityListeners();
 
-    // No baseline captured — agent jumps straight to completed.
-    mockChangedFileCount = 1;
-    transition("completed", "idle");
-
-    expect(notify).toHaveBeenCalledTimes(1);
-
-    d.dispose();
-  });
-
-  it("does not fire when there was no working state and current count is 0", () => {
-    setupPanel();
-    const d = setupIdentityListeners();
-
-    mockChangedFileCount = 0;
+    // No baseline captured — agent jumps straight to completed. Without a
+    // "started" anchor, pre-existing dirty files cannot be distinguished
+    // from agent-produced changes, so we suppress the notification.
+    mockChangedFileCount = 5;
     transition("completed", "idle");
 
     expect(notify).not.toHaveBeenCalled();
@@ -286,6 +276,49 @@ describe("identity listener — completed-with-changes notification", () => {
     transition("completed", "working");
 
     expect(notify).not.toHaveBeenCalled();
+
+    d.dispose();
+  });
+
+  it("coalesces parallel completions on the same worktree into one inbox entry", () => {
+    // Two panels on the same worktree both complete inside the coalesce
+    // window — the spec wants one rolled-up entry per worktree.
+    usePanelStore.setState({
+      panelsById: {
+        "term-1": {
+          id: "term-1",
+          kind: "terminal",
+          title: "Terminal 1",
+          cwd: "/tmp/wt-1",
+          cols: 80,
+          rows: 24,
+          location: "grid" as const,
+          worktreeId: "wt-1",
+        } as unknown as ReturnType<typeof usePanelStore.getState>["panelsById"][string],
+        "term-2": {
+          id: "term-2",
+          kind: "terminal",
+          title: "Terminal 2",
+          cwd: "/tmp/wt-1",
+          cols: 80,
+          rows: 24,
+          location: "grid" as const,
+          worktreeId: "wt-1",
+        } as unknown as ReturnType<typeof usePanelStore.getState>["panelsById"][string],
+      },
+      panelIds: ["term-1", "term-2"],
+    });
+    const d = setupIdentityListeners();
+
+    mockChangedFileCount = 0;
+    transition("working", "idle", "term-1");
+    transition("working", "idle", "term-2");
+
+    mockChangedFileCount = 3;
+    transition("completed", "working", "term-1");
+    transition("completed", "working", "term-2");
+
+    expect(notify).toHaveBeenCalledTimes(1);
 
     d.dispose();
   });

--- a/src/store/listeners/panel/__tests__/identity.test.ts
+++ b/src/store/listeners/panel/__tests__/identity.test.ts
@@ -1,0 +1,314 @@
+// @vitest-environment jsdom
+import { describe, expect, it, vi, beforeEach } from "vitest";
+import { usePanelStore } from "@/store/panelStore";
+import type {
+  AgentState,
+  AgentStateChangePayload,
+  AgentStateChangeTrigger,
+  WorktreeSnapshot,
+} from "@shared/types";
+
+const dispatchMock = vi.hoisted(() => vi.fn().mockResolvedValue({ ok: true }));
+vi.mock("@/services/ActionService", () => ({
+  actionService: { dispatch: dispatchMock },
+}));
+
+vi.mock("@/lib/notify", () => ({
+  notify: vi.fn(),
+}));
+
+vi.mock("@/services/TerminalInstanceService", () => ({
+  terminalInstanceService: {
+    setAgentState: vi.fn(),
+    applyAgentPromotion: vi.fn(),
+    clearAgentPromotion: vi.fn(),
+  },
+}));
+
+const onAgentStateChangedHandlers = vi.hoisted(
+  () => new Set<(data: AgentStateChangePayload) => void>()
+);
+const onAgentDetectedHandlers = vi.hoisted(() => new Set<(data: unknown) => void>());
+const onAgentExitedHandlers = vi.hoisted(() => new Set<(data: unknown) => void>());
+vi.mock("@/controllers", () => ({
+  terminalRegistryController: {
+    onAgentStateChanged: (cb: (data: AgentStateChangePayload) => void) => {
+      onAgentStateChangedHandlers.add(cb);
+      return () => onAgentStateChangedHandlers.delete(cb);
+    },
+    onAgentDetected: (cb: (data: unknown) => void) => {
+      onAgentDetectedHandlers.add(cb);
+      return () => onAgentDetectedHandlers.delete(cb);
+    },
+    onAgentExited: (cb: (data: unknown) => void) => {
+      onAgentExitedHandlers.add(cb);
+      return () => onAgentExitedHandlers.delete(cb);
+    },
+  },
+}));
+
+let mockChangedFileCount: number | null = 0;
+let mockStoreAvailable = true;
+vi.mock("@/store/createWorktreeStore", () => ({
+  getCurrentViewStoreOrNull: () => {
+    if (!mockStoreAvailable) return null;
+    return {
+      getState: () => ({
+        worktrees: new Map<string, WorktreeSnapshot>([
+          [
+            "wt-1",
+            {
+              id: "wt-1",
+              path: "/tmp/wt-1",
+              worktreeChanges:
+                mockChangedFileCount === null
+                  ? null
+                  : ({
+                      worktreeId: "wt-1",
+                      rootPath: "/tmp/wt-1",
+                      changes: [],
+                      changedFileCount: mockChangedFileCount,
+                    } as WorktreeSnapshot["worktreeChanges"]),
+            } as unknown as WorktreeSnapshot,
+          ],
+        ]),
+      }),
+    };
+  },
+}));
+
+import { setupIdentityListeners, _resetChangedFileBaseline } from "../identity";
+import { notify } from "@/lib/notify";
+
+function makePayload(overrides: Partial<AgentStateChangePayload> = {}): AgentStateChangePayload {
+  return {
+    terminalId: "term-1",
+    state: "working",
+    previousState: "idle",
+    timestamp: Date.now(),
+    trigger: "output" as AgentStateChangeTrigger,
+    confidence: 1,
+    ...overrides,
+  };
+}
+
+function setupPanel(overrides: Record<string, unknown> = {}) {
+  usePanelStore.setState({
+    panelsById: {
+      "term-1": {
+        id: "term-1",
+        kind: "terminal",
+        title: "Test Terminal",
+        cwd: "/tmp/wt-1",
+        cols: 80,
+        rows: 24,
+        location: "grid" as const,
+        worktreeId: "wt-1",
+        ...overrides,
+      } as unknown as ReturnType<typeof usePanelStore.getState>["panelsById"][string],
+    },
+    panelIds: ["term-1"],
+  });
+}
+
+function emitState(payload: AgentStateChangePayload): void {
+  for (const cb of onAgentStateChangedHandlers) cb(payload);
+}
+
+let _ts = 0;
+function nextTimestamp(): number {
+  _ts += 1;
+  return Date.now() + _ts;
+}
+
+beforeEach(() => {
+  onAgentStateChangedHandlers.clear();
+  onAgentDetectedHandlers.clear();
+  onAgentExitedHandlers.clear();
+  usePanelStore.setState({ panelsById: {}, panelIds: [] });
+  _resetChangedFileBaseline();
+  vi.mocked(notify).mockClear();
+  dispatchMock.mockClear();
+  mockChangedFileCount = 0;
+  mockStoreAvailable = true;
+  _ts = 0;
+});
+
+function transition(state: AgentState, previousState: AgentState, terminalId = "term-1"): void {
+  emitState(makePayload({ terminalId, state, previousState, timestamp: nextTimestamp() }));
+}
+
+describe("identity listener — completed-with-changes notification", () => {
+  it("fires a low-priority inbox notification when changed-file count grew", () => {
+    setupPanel();
+    const d = setupIdentityListeners();
+
+    mockChangedFileCount = 0;
+    transition("working", "idle");
+
+    mockChangedFileCount = 3;
+    transition("completed", "working");
+
+    expect(notify).toHaveBeenCalledTimes(1);
+    expect(notify).toHaveBeenCalledWith(
+      expect.objectContaining({
+        type: "info",
+        priority: "low",
+        title: "Agent finished with changes",
+        context: { worktreeId: "wt-1", eventKind: "completed" },
+        action: expect.objectContaining({
+          label: "Open review hub",
+          actionId: "worktree.openReviewHub",
+          actionArgs: { worktreeId: "wt-1" },
+        }),
+      })
+    );
+
+    d.dispose();
+  });
+
+  it("does not fire when changed-file count did not grow", () => {
+    setupPanel();
+    const d = setupIdentityListeners();
+
+    mockChangedFileCount = 2;
+    transition("working", "idle");
+    transition("completed", "working");
+
+    expect(notify).not.toHaveBeenCalled();
+
+    d.dispose();
+  });
+
+  it("fires when there was no working state before completed but current count > 0", () => {
+    setupPanel();
+    const d = setupIdentityListeners();
+
+    // No baseline captured — agent jumps straight to completed.
+    mockChangedFileCount = 1;
+    transition("completed", "idle");
+
+    expect(notify).toHaveBeenCalledTimes(1);
+
+    d.dispose();
+  });
+
+  it("does not fire when there was no working state and current count is 0", () => {
+    setupPanel();
+    const d = setupIdentityListeners();
+
+    mockChangedFileCount = 0;
+    transition("completed", "idle");
+
+    expect(notify).not.toHaveBeenCalled();
+
+    d.dispose();
+  });
+
+  it("does not double-fire on duplicate completed events", () => {
+    setupPanel();
+    const d = setupIdentityListeners();
+
+    mockChangedFileCount = 0;
+    transition("working", "idle");
+
+    mockChangedFileCount = 3;
+    transition("completed", "working");
+    expect(notify).toHaveBeenCalledTimes(1);
+
+    // Repeat completed → completed transition should not refire.
+    transition("completed", "completed");
+    expect(notify).toHaveBeenCalledTimes(1);
+
+    d.dispose();
+  });
+
+  it("retains the initial baseline across working↔waiting cycles", () => {
+    setupPanel();
+    const d = setupIdentityListeners();
+
+    mockChangedFileCount = 5;
+    transition("working", "idle");
+
+    mockChangedFileCount = 7;
+    transition("waiting", "working");
+
+    mockChangedFileCount = 7;
+    transition("working", "waiting");
+
+    // Final count grew beyond initial 5 → notify must fire.
+    mockChangedFileCount = 9;
+    transition("completed", "working");
+
+    expect(notify).toHaveBeenCalledTimes(1);
+
+    d.dispose();
+  });
+
+  it("clears baseline on exited so a fresh session starts from a clean baseline", () => {
+    setupPanel();
+    const d = setupIdentityListeners();
+
+    mockChangedFileCount = 4;
+    transition("working", "idle");
+    transition("exited", "working");
+
+    // Next agent run starts — baseline must be re-captured from the
+    // current count (4), so a same-count completion does NOT fire.
+    mockChangedFileCount = 4;
+    transition("working", "idle");
+    transition("completed", "working");
+
+    expect(notify).not.toHaveBeenCalled();
+
+    d.dispose();
+  });
+
+  it("does not fire when panel has no worktreeId", () => {
+    setupPanel({ worktreeId: undefined });
+    const d = setupIdentityListeners();
+
+    mockChangedFileCount = 5;
+    transition("working", "idle");
+    transition("completed", "working");
+
+    expect(notify).not.toHaveBeenCalled();
+
+    d.dispose();
+  });
+
+  it("does not fire when the worktree store is unavailable", () => {
+    setupPanel();
+    mockStoreAvailable = false;
+    const d = setupIdentityListeners();
+
+    transition("working", "idle");
+    transition("completed", "working");
+
+    expect(notify).not.toHaveBeenCalled();
+
+    d.dispose();
+  });
+
+  it("dispatches worktree.openReviewHub when the action onClick fires", () => {
+    setupPanel();
+    const d = setupIdentityListeners();
+
+    mockChangedFileCount = 0;
+    transition("working", "idle");
+
+    mockChangedFileCount = 2;
+    transition("completed", "working");
+
+    const callArgs = vi.mocked(notify).mock.lastCall?.[0];
+    expect(callArgs?.action?.onClick).toBeTypeOf("function");
+    callArgs?.action?.onClick?.();
+    expect(dispatchMock).toHaveBeenCalledWith(
+      "worktree.openReviewHub",
+      { worktreeId: "wt-1" },
+      { source: "user" }
+    );
+
+    d.dispose();
+  });
+});

--- a/src/store/listeners/panel/identity.ts
+++ b/src/store/listeners/panel/identity.ts
@@ -131,12 +131,7 @@ export function setupIdentityListeners(): DisposableStore {
           // without a `working` event has no "started" timestamp to compare
           // against, so pre-existing dirty files would otherwise look like
           // new agent work.
-          if (
-            worktreeId &&
-            current !== null &&
-            baseline !== undefined &&
-            current > baseline
-          ) {
+          if (worktreeId && current !== null && baseline !== undefined && current > baseline) {
             const lastAt = _lastReviewInboxAt.get(worktreeId) ?? 0;
             if (timestamp - lastAt >= REVIEW_INBOX_COALESCE_MS) {
               _lastReviewInboxAt.set(worktreeId, timestamp);

--- a/src/store/listeners/panel/identity.ts
+++ b/src/store/listeners/panel/identity.ts
@@ -6,8 +6,31 @@ import { terminalInstanceService } from "@/services/TerminalInstanceService";
 import { logWarn } from "@/utils/logger";
 import { DisposableStore, toDisposable } from "@/utils/disposable";
 import { usePanelStore } from "@/store/panelStore";
+import { getCurrentViewStoreOrNull } from "@/store/createWorktreeStore";
+import { actionService } from "@/services/ActionService";
+import { notify } from "@/lib/notify";
 import { reduceAgentDetected, reduceAgentExited } from "./identityReducer";
 import { logIdentityDebugDev, recordIdentityEventDev } from "./identityDiagnostics";
+
+// Per-terminal baseline of `changedFileCount` captured the first time an
+// agent enters "working" in a session. Compared against the count at
+// "completed" to gate the review-inbox notification — no notification fires
+// when the working tree did not change. Module-level (not on PtyPanelData):
+// the snapshot is ephemeral, must not persist across restarts, and is only
+// read by this listener.
+const _changedFileBaseline = new Map<string, number>();
+
+export function _resetChangedFileBaseline(): void {
+  _changedFileBaseline.clear();
+}
+
+function readChangedFileCount(worktreeId: string | undefined): number | null {
+  if (!worktreeId) return null;
+  const store = getCurrentViewStoreOrNull();
+  if (!store) return null;
+  const snapshot = store.getState().worktrees.get(worktreeId);
+  return snapshot?.worktreeChanges?.changedFileCount ?? 0;
+}
 
 export function setupIdentityListeners(): DisposableStore {
   const d = new DisposableStore();
@@ -18,6 +41,7 @@ export function setupIdentityListeners(): DisposableStore {
         const {
           terminalId,
           state,
+          previousState,
           timestamp,
           trigger,
           confidence,
@@ -74,6 +98,50 @@ export function setupIdentityListeners(): DisposableStore {
 
         if (state === "waiting" || state === "idle") {
           usePanelStore.getState().processQueue(terminalId);
+        }
+
+        // Snapshot baseline `changedFileCount` the first time an agent enters
+        // "working" in a session. Subsequent working↔waiting cycles keep the
+        // initial baseline so the comparison at completion reflects the full
+        // session, not just the latest stretch.
+        if (state === "working" && !_changedFileBaseline.has(terminalId) && isPtyPanel(terminal)) {
+          const baseline = readChangedFileCount(terminal.worktreeId);
+          if (baseline !== null) {
+            _changedFileBaseline.set(terminalId, baseline);
+          }
+        }
+
+        if (state === "completed" && previousState !== "completed" && isPtyPanel(terminal)) {
+          const worktreeId = terminal.worktreeId;
+          const current = readChangedFileCount(worktreeId);
+          const baseline = _changedFileBaseline.get(terminalId);
+          _changedFileBaseline.delete(terminalId);
+
+          if (worktreeId && current !== null && current > (baseline ?? 0)) {
+            notify({
+              type: "info",
+              priority: "low",
+              title: "Agent finished with changes",
+              message: "Open the review hub to see what changed.",
+              context: { worktreeId, eventKind: "completed" },
+              action: {
+                label: "Open review hub",
+                actionId: "worktree.openReviewHub",
+                actionArgs: { worktreeId },
+                onClick: () => {
+                  void actionService.dispatch(
+                    "worktree.openReviewHub",
+                    { worktreeId },
+                    { source: "user" }
+                  );
+                },
+              },
+            });
+          }
+        }
+
+        if (state === "exited") {
+          _changedFileBaseline.delete(terminalId);
         }
       })
     )

--- a/src/store/listeners/panel/identity.ts
+++ b/src/store/listeners/panel/identity.ts
@@ -20,8 +20,18 @@ import { logIdentityDebugDev, recordIdentityEventDev } from "./identityDiagnosti
 // read by this listener.
 const _changedFileBaseline = new Map<string, number>();
 
+// Per-worktree last-notified timestamp for the completed-with-changes inbox
+// entry. `notify()`'s built-in `coalesce` only applies to toasts, so for
+// `priority: "low"` (inbox-only) it has no effect — we dedupe at the call
+// site instead so six parallel agents finishing on the same worktree
+// collapse to a single inbox entry.
+const _lastReviewInboxAt = new Map<string, number>();
+
+const REVIEW_INBOX_COALESCE_MS = 5000;
+
 export function _resetChangedFileBaseline(): void {
   _changedFileBaseline.clear();
+  _lastReviewInboxAt.clear();
 }
 
 function readChangedFileCount(worktreeId: string | undefined): number | null {
@@ -117,26 +127,39 @@ export function setupIdentityListeners(): DisposableStore {
           const baseline = _changedFileBaseline.get(terminalId);
           _changedFileBaseline.delete(terminalId);
 
-          if (worktreeId && current !== null && current > (baseline ?? 0)) {
-            notify({
-              type: "info",
-              priority: "low",
-              title: "Agent finished with changes",
-              message: "Open the review hub to see what changed.",
-              context: { worktreeId, eventKind: "completed" },
-              action: {
-                label: "Open review hub",
-                actionId: "worktree.openReviewHub",
-                actionArgs: { worktreeId },
-                onClick: () => {
-                  void actionService.dispatch(
-                    "worktree.openReviewHub",
-                    { worktreeId },
-                    { source: "user" }
-                  );
+          // Require a captured baseline. An agent that jumps idle → completed
+          // without a `working` event has no "started" timestamp to compare
+          // against, so pre-existing dirty files would otherwise look like
+          // new agent work.
+          if (
+            worktreeId &&
+            current !== null &&
+            baseline !== undefined &&
+            current > baseline
+          ) {
+            const lastAt = _lastReviewInboxAt.get(worktreeId) ?? 0;
+            if (timestamp - lastAt >= REVIEW_INBOX_COALESCE_MS) {
+              _lastReviewInboxAt.set(worktreeId, timestamp);
+              notify({
+                type: "info",
+                priority: "low",
+                title: "Agent finished with changes",
+                message: "Open the review hub to see what changed.",
+                context: { worktreeId, eventKind: "completed" },
+                action: {
+                  label: "Open review hub",
+                  actionId: "worktree.openReviewHub",
+                  actionArgs: { worktreeId },
+                  onClick: () => {
+                    void actionService.dispatch(
+                      "worktree.openReviewHub",
+                      { worktreeId },
+                      { source: "user" }
+                    );
+                  },
                 },
-              },
-            });
+              });
+            }
           }
         }
 

--- a/src/store/uiStore.ts
+++ b/src/store/uiStore.ts
@@ -19,6 +19,13 @@ interface UIState {
   // at 0 (no divider until the first close).
   lastNotificationCenterClosedAt: number;
   resetNotificationCenterLastClosedAt: () => void;
+  // Cross-component signal to open the Review Hub on a specific worktree
+  // card. WorktreeCard for the matching worktree subscribes and opens its
+  // local ReviewHub once, then clears the value. Used by
+  // `worktree.openReviewHub` and the completed-with-changes inbox button.
+  pendingReviewHubWorktreeId: string | null;
+  setPendingReviewHubWorktreeId: (id: string) => void;
+  clearPendingReviewHubWorktreeId: () => void;
 }
 
 export const useUIStore = create<UIState>((set, get) => ({
@@ -64,4 +71,12 @@ export const useUIStore = create<UIState>((set, get) => ({
       return { notificationCenterOpen: next, lastNotificationCenterClosedAt: Date.now() };
     }),
   resetNotificationCenterLastClosedAt: () => set({ lastNotificationCenterClosedAt: 0 }),
+
+  pendingReviewHubWorktreeId: null,
+  setPendingReviewHubWorktreeId: (id) => set({ pendingReviewHubWorktreeId: id }),
+  clearPendingReviewHubWorktreeId: () =>
+    set((state) => {
+      if (state.pendingReviewHubWorktreeId === null) return state;
+      return { pendingReviewHubWorktreeId: null };
+    }),
 }));


### PR DESCRIPTION
## Summary

- When an agent transitions to `completed` and the worktree's changed-file count has grown since the agent started, fire a `priority: "low"` inbox-only notification with an "Open review hub" action — no toast, no OS ping.
- No notification when the count didn't grow or no baseline was captured. Users don't need to be pointed at an empty diff.
- Notifications per worktree coalesce over a 5-second window, so parallel agents don't flood the inbox.

Resolves #7787

## Changes

- `shared/types/actions.ts` — adds `worktree.openReviewHub` action ID
- `src/store/uiStore.ts` — adds `pendingReviewHubWorktreeId` state + setter
- `src/services/actions/definitions/worktreeContextActions.ts` — registers the `worktree.openReviewHub` action, routes through `uiStore.pendingReviewHubWorktreeId`
- `src/store/listeners/panel/identity.ts` — captures per-pane `changedFileCount` baseline at agent-start; on `completed` transition, compares against baseline and fires `notify()` if count grew; per-worktree coalesce map with 5s window
- `src/components/Worktree/WorktreeCard.tsx` — `useEffect` that consumes `pendingReviewHubWorktreeId` and opens the local ReviewHub state

## Testing

30 unit tests added/extended across three new test files:

- `src/store/listeners/panel/__tests__/identity.test.ts` — 10 tests covering baseline capture, completion gate, no-op when count is flat, coalescing window
- `src/services/actions/definitions/__tests__/worktreeOpenReviewHubAction.test.ts` — 6 tests for the action dispatch and `uiStore` routing
- `src/store/__tests__/uiStore.test.ts` — 4 tests for the new state slice

All pass. Lint and typecheck clean.