### PR TITLE
feat(review-hub): show unresolved review comment count per file in base-branch diff

### DIFF
--- a/electron/ipc/channels.ts
+++ b/electron/ipc/channels.ts
@@ -147,6 +147,7 @@ export const CHANNELS = {
   GITHUB_GET_ISSUE_URL: "github:get-issue-url",
   GITHUB_GET_ISSUE_BY_NUMBER: "github:get-issue-by-number",
   GITHUB_GET_PR_BY_NUMBER: "github:get-pr-by-number",
+  GITHUB_GET_PR_REVIEW_THREADS: "github:get-pr-review-threads",
   GITHUB_LIST_REMOTES: "github:list-remotes",
   GITHUB_RATE_LIMIT_CHANGED: "github:rate-limit-changed",
   GITHUB_GET_RATE_LIMIT_DETAILS: "github:get-rate-limit-details",

--- a/electron/ipc/handlers/github.ts
+++ b/electron/ipc/handlers/github.ts
@@ -758,6 +758,30 @@ export function registerGithubHandlers(_deps: HandlerDependencies): () => void {
   };
   handlers.push(typedHandle(CHANNELS.GITHUB_GET_PR_BY_NUMBER, handleGitHubGetPRByNumber));
 
+  const handleGitHubGetPRReviewThreads = async (payload: { cwd: string; prNumber: number }) => {
+    checkRateLimit(CHANNELS.GITHUB_GET_PR_REVIEW_THREADS, 10, 10_000);
+    if (!payload || typeof payload !== "object") {
+      return {};
+    }
+    if (typeof payload.cwd !== "string" || !payload.cwd.trim()) {
+      return {};
+    }
+    if (!path.isAbsolute(payload.cwd)) {
+      return {};
+    }
+    if (
+      typeof payload.prNumber !== "number" ||
+      !Number.isInteger(payload.prNumber) ||
+      payload.prNumber <= 0
+    ) {
+      return {};
+    }
+
+    const { getPRReviewThreads } = await import("../../services/GitHubService.js");
+    return getPRReviewThreads(payload.cwd.trim(), payload.prNumber);
+  };
+  handlers.push(typedHandle(CHANNELS.GITHUB_GET_PR_REVIEW_THREADS, handleGitHubGetPRReviewThreads));
+
   const handleGitHubListRemotes = async (
     cwd: string
   ): Promise<

--- a/electron/preload.cts
+++ b/electron/preload.cts
@@ -1568,6 +1568,9 @@ const api: ElectronAPI = {
     getPRByNumber: (cwd: string, prNumber: number) =>
       _unwrappingInvoke(CHANNELS.GITHUB_GET_PR_BY_NUMBER, { cwd, prNumber }),
 
+    getPRReviewThreads: (cwd: string, prNumber: number) =>
+      _unwrappingInvoke(CHANNELS.GITHUB_GET_PR_REVIEW_THREADS, { cwd, prNumber }),
+
     listRemotes: (cwd: string) => _unwrappingInvoke(CHANNELS.GITHUB_LIST_REMOTES, cwd),
 
     onPRDetected: (callback: (data: PRDetectedPayload) => void) =>

--- a/electron/services/GitHubService.ts
+++ b/electron/services/GitHubService.ts
@@ -26,6 +26,7 @@ export {
   getPRTooltip,
   getIssueByNumber,
   getPRByNumber,
+  getPRReviewThreads,
 } from "./github/index.js";
 
 export type {

--- a/electron/services/github/GitHubCaches.ts
+++ b/electron/services/github/GitHubCaches.ts
@@ -51,6 +51,10 @@ export interface PRRequiredStatusEntry {
   ciStatus: GitHubPRCIStatus | undefined;
   ciSummary: GitHubPRCISummary | undefined;
 }
+export const reviewThreadsCache = new Cache<string, Record<string, number>>({
+  defaultTTL: 300000,
+});
+
 export const prRequiredStatusCache = new Cache<string, PRRequiredStatusEntry>({
   defaultTTL: 60000,
 });
@@ -67,6 +71,7 @@ export function clearGitHubCaches(): void {
   prTooltipWrittenAt.clear();
   prETagCache.clear();
   branchListETagCache.clear();
+  reviewThreadsCache.clear();
   prRequiredStatusCache.clear();
   GitHubFirstPageCache.getInstance().clear();
   GitHubStatsCache.getInstance().clear();
@@ -86,5 +91,6 @@ export function clearPRCaches(): void {
   prTooltipWrittenAt.clear();
   prETagCache.clear();
   branchListETagCache.clear();
+  reviewThreadsCache.clear();
   prRequiredStatusCache.clear();
 }

--- a/electron/services/github/GitHubPRs.ts
+++ b/electron/services/github/GitHubPRs.ts
@@ -4,6 +4,7 @@ import {
   LIST_PRS_QUERY,
   SEARCH_QUERY,
   GET_PR_QUERY,
+  GET_PR_REVIEW_THREADS_QUERY,
   buildBatchRequiredChecksQuery,
 } from "./GitHubQueries.js";
 import { gitHubRateLimitService } from "./GitHubRateLimitService.js";
@@ -14,6 +15,7 @@ import {
   prListCache,
   prTooltipCache,
   prTooltipWrittenAt,
+  reviewThreadsCache,
   prRequiredStatusCache,
   truncateBody,
   type PRRequiredStatusEntry,
@@ -458,5 +460,73 @@ export async function getPRByNumber(cwd: string, prNumber: number): Promise<GitH
       return null;
     }
     throw new Error(parseGitHubError(error));
+  }
+}
+
+export async function getPRReviewThreads(
+  cwd: string,
+  prNumber: number
+): Promise<Record<string, number>> {
+  const client = GitHubAuth.createClient();
+  if (!client) {
+    return {};
+  }
+
+  try {
+    return await withRepoContextRetry(cwd, async (context) => {
+      const cacheKey = `${context.owner}/${context.repo}:${prNumber}`;
+      const cached = reviewThreadsCache.get(cacheKey);
+      if (cached) {
+        return cached;
+      }
+
+      const allThreads: Array<{ path: string; isResolved: boolean; isOutdated: boolean }> = [];
+      let cursor: string | null = null;
+      let hasNextPage = true;
+
+      while (hasNextPage) {
+        const response = (await client(GET_PR_REVIEW_THREADS_QUERY, {
+          owner: context.owner,
+          repo: context.repo,
+          number: prNumber,
+          cursor,
+          request: { signal: AbortSignal.timeout(GITHUB_API_TIMEOUT_MS) },
+        })) as GraphQlQueryResponseData;
+
+        gitHubRateLimitService.updateFromGraphQL(response);
+
+        const threads = response?.repository?.pullRequest?.reviewThreads;
+        const nodes = (threads?.nodes ?? []) as Array<{
+          path?: string;
+          isResolved?: boolean;
+          isOutdated?: boolean;
+        }>;
+
+        for (const node of nodes) {
+          if (typeof node.path === "string") {
+            allThreads.push({
+              path: node.path,
+              isResolved: node.isResolved ?? false,
+              isOutdated: node.isOutdated ?? false,
+            });
+          }
+        }
+
+        hasNextPage = threads?.pageInfo?.hasNextPage ?? false;
+        cursor = threads?.pageInfo?.endCursor ?? null;
+      }
+
+      const counts: Record<string, number> = {};
+      for (const thread of allThreads) {
+        if (!thread.isResolved && !thread.isOutdated) {
+          counts[thread.path] = (counts[thread.path] ?? 0) + 1;
+        }
+      }
+
+      reviewThreadsCache.set(cacheKey, counts);
+      return counts;
+    });
+  } catch {
+    return {};
   }
 }

--- a/electron/services/github/GitHubPRs.ts
+++ b/electron/services/github/GitHubPRs.ts
@@ -526,7 +526,8 @@ export async function getPRReviewThreads(
       reviewThreadsCache.set(cacheKey, counts);
       return counts;
     });
-  } catch {
+  } catch (err) {
+    console.warn("Failed to fetch PR review threads", err);
     return {};
   }
 }

--- a/electron/services/github/GitHubQueries.ts
+++ b/electron/services/github/GitHubQueries.ts
@@ -392,6 +392,34 @@ export const GET_ISSUE_QUERY = `
   }
 `;
 
+export const GET_PR_REVIEW_THREADS_QUERY = `
+  query GetPRReviewThreads($owner: String!, $repo: String!, $number: Int!, $cursor: String) {
+    repository(owner: $owner, name: $repo) {
+      pullRequest(number: $number) {
+        reviewThreads(first: 100, after: $cursor) {
+          nodes {
+            path
+            isResolved
+            isOutdated
+            comments(first: 1) {
+              totalCount
+            }
+          }
+          pageInfo {
+            hasNextPage
+            endCursor
+          }
+        }
+      }
+    }
+    rateLimit {
+      cost
+      remaining
+      resetAt
+    }
+  }
+`;
+
 export const GET_PR_QUERY = `
   query GetPR($owner: String!, $repo: String!, $number: Int!) {
     repository(owner: $owner, name: $repo) {

--- a/electron/services/github/GitHubQueries.ts
+++ b/electron/services/github/GitHubQueries.ts
@@ -401,9 +401,6 @@ export const GET_PR_REVIEW_THREADS_QUERY = `
             path
             isResolved
             isOutdated
-            comments(first: 1) {
-              totalCount
-            }
           }
           pageInfo {
             hasNextPage

--- a/electron/services/github/index.ts
+++ b/electron/services/github/index.ts
@@ -26,6 +26,7 @@ export {
   SEARCH_QUERY,
   GET_ISSUE_QUERY,
   GET_PR_QUERY,
+  GET_PR_REVIEW_THREADS_QUERY,
   buildBatchPRQuery,
   buildBatchRequiredChecksQuery,
 } from "./GitHubQueries.js";
@@ -84,7 +85,7 @@ export { batchCheckLinkedPRs } from "./GitHubPRDiscovery.js";
 export { parseGitHubError } from "./GitHubErrors.js";
 
 // PRs
-export { listPullRequests, getPRByNumber, getPRTooltip } from "./GitHubPRs.js";
+export { listPullRequests, getPRByNumber, getPRTooltip, getPRReviewThreads } from "./GitHubPRs.js";
 
 // Issues
 export { listIssues, getIssueByNumber, getIssueTooltip, assignIssue } from "./GitHubIssues.js";

--- a/shared/types/ipc/api.ts
+++ b/shared/types/ipc/api.ts
@@ -708,6 +708,7 @@ export interface ElectronAPI {
       issueNumber: number
     ): Promise<import("../github.js").GitHubIssue | null>;
     getPRByNumber(cwd: string, prNumber: number): Promise<import("../github.js").GitHubPR | null>;
+    getPRReviewThreads(cwd: string, prNumber: number): Promise<Record<string, number>>;
     listRemotes(cwd: string): Promise<import("./github.js").RemoteInfo[]>;
     onPRDetected(callback: (data: PRDetectedPayload) => void): () => void;
     onPRCleared(callback: (data: PRClearedPayload) => void): () => void;

--- a/shared/types/ipc/maps.ts
+++ b/shared/types/ipc/maps.ts
@@ -2021,6 +2021,10 @@ export interface IpcInvokeMap {
     args: [payload: { cwd: string; prNumber: number }];
     result: import("../github.js").GitHubPR | null;
   };
+  "github:get-pr-review-threads": {
+    args: [payload: { cwd: string; prNumber: number }];
+    result: Record<string, number>;
+  };
   "github:list-remotes": {
     args: [cwd: string];
     result: Array<{

--- a/src/clients/githubClient.ts
+++ b/src/clients/githubClient.ts
@@ -143,4 +143,8 @@ export const githubClient = {
   ): Promise<import("@shared/types/github").GitHubPR | null> => {
     return window.electron.github.getPRByNumber(cwd, prNumber);
   },
+
+  getPRReviewThreads: (cwd: string, prNumber: number): Promise<Record<string, number>> => {
+    return window.electron.github.getPRReviewThreads(cwd, prNumber);
+  },
 } as const;

--- a/src/components/Worktree/ReviewHub/ReviewHub.tsx
+++ b/src/components/Worktree/ReviewHub/ReviewHub.tsx
@@ -106,14 +106,34 @@ function statusLabel(status: string): { label: string; className: string } {
 interface BaseBranchFileRowProps {
   file: CrossWorktreeFile;
   onClick: () => void;
+  unresolvedCount?: number;
+  onBadgeClick?: () => void;
 }
 
-function BaseBranchFileRow({ file, onClick }: BaseBranchFileRowProps) {
+function BaseBranchFileRow({
+  file,
+  onClick,
+  unresolvedCount,
+  onBadgeClick,
+}: BaseBranchFileRowProps) {
   const { label, className: statusClass } = statusLabel(file.status);
   const filename = file.path.split(/[/\\]/).filter(Boolean).pop() || file.path;
   const dirPath = /[/\\]/.test(file.path)
     ? file.path.substring(0, Math.max(file.path.lastIndexOf("/"), file.path.lastIndexOf("\\")))
     : "";
+
+  const handleBadgeClick = (e: React.MouseEvent) => {
+    e.stopPropagation();
+    onBadgeClick?.();
+  };
+
+  const handleBadgeKeyDown = (e: React.KeyboardEvent) => {
+    if (e.key === "Enter" || e.key === " ") {
+      e.preventDefault();
+      e.stopPropagation();
+      onBadgeClick?.();
+    }
+  };
 
   return (
     <TruncatedTooltip content={file.path}>
@@ -131,6 +151,24 @@ function BaseBranchFileRow({ file, onClick }: BaseBranchFileRowProps) {
         </span>
         <FileIcon className="w-3 h-3 shrink-0 text-daintree-text/40" />
         <span className="text-daintree-text/80 truncate min-w-0">{filename}</span>
+        {unresolvedCount !== undefined && unresolvedCount > 0 && (
+          <span
+            onClick={handleBadgeClick}
+            role="button"
+            tabIndex={0}
+            onKeyDown={handleBadgeKeyDown}
+            aria-label={`${unresolvedCount} unresolved review comment${unresolvedCount !== 1 ? "s" : ""} on ${file.path}`}
+            className={cn(
+              "shrink-0 inline-flex items-center justify-center min-w-[18px] h-[18px] px-1 rounded-full",
+              "text-[10px] font-semibold tabular-nums",
+              "bg-status-warning/15 text-status-warning",
+              "hover:bg-status-warning/25 transition-colors cursor-pointer",
+              "focus-visible:outline-hidden focus-visible:ring-1 focus-visible:ring-status-warning"
+            )}
+          >
+            {unresolvedCount}
+          </span>
+        )}
         <span className="text-daintree-text/30 truncate min-w-0 text-[10px] ml-auto pl-2">
           {dirPath}
         </span>
@@ -158,6 +196,8 @@ export function ReviewHub({ isOpen, worktreePath, onClose }: ReviewHubProps) {
   const [selectedBaseBranchFile, setSelectedBaseBranchFile] = useState<CrossWorktreeFile | null>(
     null
   );
+  const [reviewThreadCounts, setReviewThreadCounts] = useState<Record<string, number> | null>(null);
+  const reviewThreadsRequestRef = useRef(0);
   const closeButtonRef = useRef<HTMLButtonElement>(null);
   const refreshIdRef = useRef(0);
   const bgRefreshIdRef = useRef(0);
@@ -279,6 +319,7 @@ export function ReviewHub({ isOpen, worktreePath, onClose }: ReviewHubProps) {
       setBaseBranchFiles(null);
       setBaseBranchError(null);
       setSelectedBaseBranchFile(null);
+      setReviewThreadCounts(null);
     }
   }, [isOpen, refresh]);
 
@@ -289,8 +330,33 @@ export function ReviewHub({ isOpen, worktreePath, onClose }: ReviewHubProps) {
       setBaseBranchFiles(null);
       setBaseBranchError(null);
       setSelectedBaseBranchFile(null);
+      setReviewThreadCounts(null);
     }
   }, [status?.currentBranch, mainBranch, diffMode]);
+
+  useEffect(() => {
+    if (!isOpen || diffMode !== "base-branch" || !worktreePR?.prNumber || !worktreePath) {
+      if (diffMode !== "base-branch") {
+        setReviewThreadCounts(null);
+      }
+      return;
+    }
+
+    const requestId = ++reviewThreadsRequestRef.current;
+
+    void (async () => {
+      try {
+        const counts = await githubClient.getPRReviewThreads(worktreePath, worktreePR.prNumber!);
+        if (reviewThreadsRequestRef.current === requestId) {
+          setReviewThreadCounts(counts);
+        }
+      } catch {
+        if (reviewThreadsRequestRef.current === requestId) {
+          setReviewThreadCounts(null);
+        }
+      }
+    })();
+  }, [isOpen, diffMode, worktreePR?.prNumber, worktreePath]);
 
   useEffect(() => {
     if (!isOpen) return;
@@ -805,6 +871,15 @@ export function ReviewHub({ isOpen, worktreePath, onClose }: ReviewHubProps) {
                         key={`${file.status}:${file.path}`}
                         file={file}
                         onClick={() => setSelectedBaseBranchFile(file)}
+                        unresolvedCount={reviewThreadCounts?.[file.path]}
+                        onBadgeClick={
+                          worktreePR?.prUrl
+                            ? () =>
+                                void githubClient.openPR(
+                                  `${worktreePR.prUrl}/files?file=${encodeURIComponent(file.path)}`
+                                )
+                            : undefined
+                        }
                       />
                     ))}
                   </div>

--- a/src/components/Worktree/ReviewHub/ReviewHub.tsx
+++ b/src/components/Worktree/ReviewHub/ReviewHub.tsx
@@ -122,41 +122,35 @@ function BaseBranchFileRow({
     ? file.path.substring(0, Math.max(file.path.lastIndexOf("/"), file.path.lastIndexOf("\\")))
     : "";
 
-  const handleBadgeClick = (e: React.MouseEvent) => {
-    e.stopPropagation();
-    onBadgeClick?.();
-  };
-
-  const handleBadgeKeyDown = (e: React.KeyboardEvent) => {
-    if (e.key === "Enter" || e.key === " ") {
-      e.preventDefault();
-      e.stopPropagation();
-      onBadgeClick?.();
-    }
-  };
-
   return (
     <TruncatedTooltip content={file.path}>
-      <button
-        type="button"
-        onClick={onClick}
+      <div
         className={cn(
           "w-full flex items-center gap-2 px-2 py-1.5 rounded text-left text-xs",
-          "hover:bg-tint/[0.05] transition-colors",
-          "focus-visible:outline-hidden focus-visible:ring-1 focus-visible:ring-daintree-accent"
+          "hover:bg-tint/[0.05] transition-colors"
         )}
       >
-        <span className={cn("font-mono font-bold shrink-0 w-3 text-center", statusClass)}>
-          {label}
-        </span>
-        <FileIcon className="w-3 h-3 shrink-0 text-daintree-text/40" />
-        <span className="text-daintree-text/80 truncate min-w-0">{filename}</span>
+        <button
+          type="button"
+          onClick={onClick}
+          className={cn(
+            "flex items-center gap-2 min-w-0 flex-1",
+            "focus-visible:outline-hidden focus-visible:ring-1 focus-visible:ring-daintree-accent rounded"
+          )}
+        >
+          <span className={cn("font-mono font-bold shrink-0 w-3 text-center", statusClass)}>
+            {label}
+          </span>
+          <FileIcon className="w-3 h-3 shrink-0 text-daintree-text/40" />
+          <span className="text-daintree-text/80 truncate min-w-0">{filename}</span>
+          <span className="text-daintree-text/30 truncate min-w-0 text-[10px] ml-auto">
+            {dirPath}
+          </span>
+        </button>
         {unresolvedCount !== undefined && unresolvedCount > 0 && (
-          <span
-            onClick={handleBadgeClick}
-            role="button"
-            tabIndex={0}
-            onKeyDown={handleBadgeKeyDown}
+          <button
+            type="button"
+            onClick={onBadgeClick}
             aria-label={`${unresolvedCount} unresolved review comment${unresolvedCount !== 1 ? "s" : ""} on ${file.path}`}
             className={cn(
               "shrink-0 inline-flex items-center justify-center min-w-[18px] h-[18px] px-1 rounded-full",
@@ -167,12 +161,9 @@ function BaseBranchFileRow({
             )}
           >
             {unresolvedCount}
-          </span>
+          </button>
         )}
-        <span className="text-daintree-text/30 truncate min-w-0 text-[10px] ml-auto pl-2">
-          {dirPath}
-        </span>
-      </button>
+      </div>
     </TruncatedTooltip>
   );
 }


### PR DESCRIPTION
## Summary
- Each file row in the Review Hub's base-branch diff now shows a numeric badge with the count of unresolved review comments.
- The badge routes to the file's anchored URL on GitHub so you can jump straight to the review threads without leaving Daintree.
- Built on top of #7775 — read-only surface, count only. No inline thread content.

Resolves #7777

## Changes
- Added `GET_PR_REVIEW_THREADS_QUERY` GraphQL query (paginated, fetching path + resolve/outdated state per thread).
- `getPRReviewThreads()` in `GitHubPRs` fetches all review threads, filters out resolved/outdated ones, and returns per-file counts with a timed cache.
- New `GITHUB_GET_PR_REVIEW_THREADS` IPC channel wired through preload, shared types, and renderer client.
- `BaseBranchFileRow` gains an `unresolvedCount` / `onBadgeClick` interface — a small warning-tinted pill badge that opens the GitHub file anchor.
- `ReviewHub` fetches review thread counts via a dedicated effect when viewing the base-branch diff with an active PR.

## Testing
- Verified the badge renders at the correct count after mocking GraphQL responses with mixed resolved/outdated/unresolved threads.
- Confirmed the badge is absent when a file has no unresolved threads or when the data hasn't loaded yet.
- Checked the effect cleans up stale in-flight requests and resets state on tab/branch switch.