### PR TITLE
fix(diff): surface fetch errors and use loading skeletons

### DIFF
--- a/src/components/FileViewer/FileViewerModal.tsx
+++ b/src/components/FileViewer/FileViewerModal.tsx
@@ -7,7 +7,7 @@ import type { CodeViewerHandle } from "./CodeViewer";
 import { filesClient } from "@/clients/filesClient";
 import { actionService } from "@/services/ActionService";
 import { ExternalLink, Copy, Check, Image as ImageIcon } from "lucide-react";
-import { Spinner } from "@/components/ui/Spinner";
+import { Skeleton, SkeletonBone, SkeletonText } from "@/components/ui/Skeleton";
 import { cn } from "@/lib/utils";
 import { formatBytes } from "@/lib/formatBytes";
 import { Tooltip, TooltipContent, TooltipTrigger } from "@/components/ui/tooltip";
@@ -26,6 +26,7 @@ export interface FileViewerModalProps {
   initialCol?: number;
   diff?: string;
   defaultMode?: "view" | "diff";
+  onRetryDiff?: () => void;
   onClose: () => void;
 }
 
@@ -67,6 +68,7 @@ export function FileViewerModal({
   initialCol,
   diff,
   defaultMode,
+  onRetryDiff,
   onClose,
 }: FileViewerModalProps) {
   // If the file is outside the project root, use its parent directory as the
@@ -78,7 +80,7 @@ export function FileViewerModal({
     ? rootPath
     : filePath.substring(0, Math.max(filePath.lastIndexOf("/"), filePath.lastIndexOf("\\"))) || "/";
 
-  const hasDiff = Boolean(diff && diff.trim() && diff !== "NO_CHANGES");
+  const hasDiff = Boolean(diff && diff.trim() && diff !== "NO_CHANGES" && diff !== "ERROR");
   const [mode, setMode] = useState<ViewMode>(() => {
     if (isImageFile(filePath)) return "view";
     if (defaultMode) return defaultMode;
@@ -411,11 +413,11 @@ export function FileViewerModal({
         {!isImageMode && mode === "view" && (
           <>
             {loadState === "loading" && (
-              <div className="flex items-center justify-center h-64">
-                <div className="flex items-center gap-3 text-muted-foreground">
-                  <Spinner size="lg" />
-                  <span>Loading file...</span>
-                </div>
+              <div className="p-4 space-y-3">
+                <Skeleton label="Loading file">
+                  <SkeletonBone className="h-5 w-1/3" />
+                  <SkeletonText lines={15} />
+                </Skeleton>
               </div>
             )}
 
@@ -467,15 +469,21 @@ export function FileViewerModal({
         )}
 
         {!isImageMode && mode === "diff" && diff && (
-          <DiffViewer diff={diff} filePath={filePath} viewType={viewType} rootPath={rootPath} />
+          <DiffViewer
+            diff={diff}
+            filePath={filePath}
+            viewType={viewType}
+            rootPath={rootPath}
+            onRetry={onRetryDiff}
+          />
         )}
 
         {!isImageMode && mode === "diff" && !diff && (
-          <div className="flex items-center justify-center h-64">
-            <div className="flex items-center gap-3 text-muted-foreground">
-              <Spinner size="lg" />
-              <span>Loading diff...</span>
-            </div>
+          <div className="p-4 space-y-3">
+            <Skeleton label="Loading diff">
+              <SkeletonBone className="h-7 w-3/4" />
+              <SkeletonText lines={8} />
+            </Skeleton>
           </div>
         )}
       </AppDialog.BodyScroll>

--- a/src/components/FileViewer/FileViewerModal.tsx
+++ b/src/components/FileViewer/FileViewerModal.tsx
@@ -118,7 +118,7 @@ export function FileViewerModal({
       setErrorCode(null);
       setDiffCopied(false);
       setSanitizedSvg(null);
-      requestRef.current = 0;
+      requestRef.current++;
       hasSwitchedToDiffRef.current = false;
       const nextMode = defaultMode ?? (hasDiff && !initialLine ? "diff" : "view");
       setMode(nextMode);

--- a/src/components/FileViewer/__tests__/FileViewerModal.test.tsx
+++ b/src/components/FileViewer/__tests__/FileViewerModal.test.tsx
@@ -53,7 +53,9 @@ vi.mock("@/components/ui/tooltip", () => ({
 }));
 
 vi.mock("@/components/Worktree/DiffViewer", () => ({
-  DiffViewer: () => <div data-testid="diff-viewer" />,
+  DiffViewer: ({ onRetry }: { onRetry?: () => void }) => (
+    <div data-testid="diff-viewer" data-has-retry={onRetry ? "true" : "false"} />
+  ),
 }));
 
 vi.mock("../CodeViewer", () => ({
@@ -298,9 +300,9 @@ describe("FileViewerModal", () => {
       <FileViewerModal {...defaultProps} diff={undefined} defaultMode="diff" />
     );
 
-    // Initially shows loading diff spinner (mode is "diff" but no diff content yet)
+    // Initially shows loading diff skeleton (mode is "diff" but no diff content yet)
     await waitFor(() => {
-      expect(screen.getByText("Loading diff...")).toBeTruthy();
+      expect(screen.getByRole("status", { name: "Loading diff" })).toBeTruthy();
     });
 
     rerender(
@@ -345,7 +347,7 @@ describe("FileViewerModal", () => {
     );
 
     await waitFor(() => {
-      expect(screen.getByText("Loading diff...")).toBeTruthy();
+      expect(screen.getByRole("status", { name: "Loading diff" })).toBeTruthy();
     });
 
     // Diff for file B arrives — should auto-switch to diff mode
@@ -361,5 +363,53 @@ describe("FileViewerModal", () => {
     await waitFor(() => {
       expect(screen.getByTestId("diff-viewer")).toBeTruthy();
     });
+  });
+
+  it("does not show view/diff toggle when diff is ERROR sentinel", async () => {
+    render(<FileViewerModal {...defaultProps} diff="ERROR" defaultMode="diff" />);
+
+    // DiffViewer renders with the ERROR sentinel (diff is truthy and mode is "diff")
+    await waitFor(() => {
+      expect(screen.getByTestId("diff-viewer")).toBeTruthy();
+    });
+
+    // Toggle buttons should not appear when diff is ERROR
+    expect(screen.queryByRole("button", { name: "View" })).toBeNull();
+    expect(screen.queryByRole("button", { name: "Diff" })).toBeNull();
+  });
+
+  it("forwards onRetryDiff to DiffViewer", async () => {
+    const onRetry = vi.fn();
+
+    render(
+      <FileViewerModal
+        {...defaultProps}
+        diff={"diff --git a/file b/file\n--- a/file\n+++ b/file\n@@ -1 +1 @@\n-old\n+new"}
+        defaultMode="diff"
+        onRetryDiff={onRetry}
+      />
+    );
+
+    await waitFor(() => {
+      expect(screen.getByTestId("diff-viewer")).toBeTruthy();
+    });
+
+    expect(screen.getByTestId("diff-viewer").getAttribute("data-has-retry")).toBe("true");
+  });
+
+  it("does not forward retry to DiffViewer when onRetryDiff is omitted", async () => {
+    render(
+      <FileViewerModal
+        {...defaultProps}
+        diff={"diff --git a/file b/file\n--- a/file\n+++ b/file\n@@ -1 +1 @@\n-old\n+new"}
+        defaultMode="diff"
+      />
+    );
+
+    await waitFor(() => {
+      expect(screen.getByTestId("diff-viewer")).toBeTruthy();
+    });
+
+    expect(screen.getByTestId("diff-viewer").getAttribute("data-has-retry")).toBe("false");
   });
 });

--- a/src/components/Worktree/DiffViewer.tsx
+++ b/src/components/Worktree/DiffViewer.tsx
@@ -12,7 +12,7 @@ import markdown from "refractor/markdown";
 import tsx from "refractor/tsx";
 import typescript from "refractor/typescript";
 import "react-diff-view/style/index.css";
-import { ExternalLink } from "lucide-react";
+import { AlertCircle, ExternalLink } from "lucide-react";
 import path from "path-browserify";
 import { getLanguageForFile } from "@/components/FileViewer/languageUtils";
 import { actionService } from "@/services/ActionService";
@@ -79,6 +79,7 @@ export interface DiffViewerProps {
   viewType?: ViewType;
   /** Absolute path to the worktree root, used to resolve per-file open-in-editor paths */
   rootPath?: string;
+  onRetry?: () => void;
 }
 
 function useTokens(
@@ -130,7 +131,13 @@ function useTokens(
   return { tokens, langLoadFailed };
 }
 
-export function DiffViewer({ diff, filePath, viewType = "split", rootPath }: DiffViewerProps) {
+export function DiffViewer({
+  diff,
+  filePath,
+  viewType = "split",
+  rootPath,
+  onRetry,
+}: DiffViewerProps) {
   const files = useMemo(() => {
     try {
       return parseDiff(diff);
@@ -159,6 +166,26 @@ export function DiffViewer({ diff, filePath, viewType = "split", rootPath }: Dif
     return (
       <div className="flex items-center justify-center p-8 text-text-muted">
         File too large to display diff ({">"} 1MB)
+      </div>
+    );
+  }
+
+  if (diff === "ERROR") {
+    return (
+      <div className="flex flex-col items-center justify-center gap-3 p-8">
+        <div className="flex items-center gap-2 text-status-error text-sm">
+          <AlertCircle className="w-4 h-4" />
+          Failed to load diff
+        </div>
+        {onRetry && (
+          <button
+            type="button"
+            onClick={onRetry}
+            className="px-3 py-1.5 text-xs font-medium rounded bg-daintree-border hover:bg-daintree-border/80 text-daintree-text transition-colors"
+          >
+            Retry
+          </button>
+        )}
       </div>
     );
   }

--- a/src/components/Worktree/FileDiffModal.tsx
+++ b/src/components/Worktree/FileDiffModal.tsx
@@ -29,6 +29,7 @@ export function FileDiffModal({
 
   const fetchDiff = useCallback(async () => {
     const requestId = ++requestRef.current;
+    setDiff(undefined);
     try {
       const result = await actionService.dispatch(
         "git.getFileDiff",
@@ -40,8 +41,8 @@ export function FileDiffModal({
         setDiff("ERROR");
         return;
       }
-      const diffResult = result.result as string;
-      setDiff(diffResult || "NO_CHANGES");
+      const diffResult = result.result;
+      setDiff(typeof diffResult === "string" ? diffResult || "NO_CHANGES" : "ERROR");
     } catch {
       if (requestRef.current !== requestId) return;
       setDiff("ERROR");
@@ -51,7 +52,7 @@ export function FileDiffModal({
   useEffect(() => {
     if (!isOpen) {
       setDiff(undefined);
-      requestRef.current = 0;
+      requestRef.current++;
       return;
     }
 

--- a/src/components/Worktree/FileDiffModal.tsx
+++ b/src/components/Worktree/FileDiffModal.tsx
@@ -37,14 +37,14 @@ export function FileDiffModal({
       );
       if (requestRef.current !== requestId) return;
       if (!result.ok) {
-        setDiff("NO_CHANGES");
+        setDiff("ERROR");
         return;
       }
       const diffResult = result.result as string;
       setDiff(diffResult || "NO_CHANGES");
     } catch {
       if (requestRef.current !== requestId) return;
-      setDiff("NO_CHANGES");
+      setDiff("ERROR");
     }
   }, [worktreePath, filePath, status]);
 
@@ -66,6 +66,7 @@ export function FileDiffModal({
       branch={branch}
       diff={diff}
       defaultMode="diff"
+      onRetryDiff={fetchDiff}
       onClose={onClose}
     />
   );

--- a/src/components/Worktree/ReviewHub/BaseBranchDiffModal.tsx
+++ b/src/components/Worktree/ReviewHub/BaseBranchDiffModal.tsx
@@ -29,6 +29,7 @@ export function BaseBranchDiffModal({
 
   const fetchDiff = useCallback(async () => {
     const requestId = ++requestRef.current;
+    setDiff(undefined);
     try {
       const result = await window.electron.git.compareWorktrees(
         worktreePath,

--- a/src/components/Worktree/ReviewHub/BaseBranchDiffModal.tsx
+++ b/src/components/Worktree/ReviewHub/BaseBranchDiffModal.tsx
@@ -41,11 +41,11 @@ export function BaseBranchDiffModal({
       if (typeof result === "string") {
         setDiff(result || "NO_CHANGES");
       } else {
-        setDiff("NO_CHANGES");
+        setDiff("ERROR");
       }
     } catch {
       if (requestRef.current !== requestId) return;
-      setDiff("NO_CHANGES");
+      setDiff("ERROR");
     }
   }, [worktreePath, mainBranch, currentBranch, filePath]);
 
@@ -66,6 +66,7 @@ export function BaseBranchDiffModal({
       branch={branch}
       diff={diff}
       defaultMode="diff"
+      onRetryDiff={fetchDiff}
       onClose={onClose}
     />
   );

--- a/src/components/Worktree/__tests__/DiffViewer.test.tsx
+++ b/src/components/Worktree/__tests__/DiffViewer.test.tsx
@@ -1,5 +1,5 @@
 // @vitest-environment jsdom
-import { render, screen, waitFor } from "@testing-library/react";
+import { render, screen, waitFor, fireEvent } from "@testing-library/react";
 import { describe, expect, it, vi, beforeEach } from "vitest";
 import { DiffViewer, _resetLangStateForTests } from "../DiffViewer";
 import { TooltipProvider } from "@/components/ui/tooltip";
@@ -72,5 +72,60 @@ index 000..111 100644
       expect(screen.getByText("foo.xyz")).toBeTruthy();
     });
     expect(screen.queryByTestId("diff-plain-text-badge")).toBeNull();
+  });
+
+  it("renders NO_CHANGES sentinel", () => {
+    render(wrap(<DiffViewer diff="NO_CHANGES" filePath="src/index.ts" />));
+    expect(screen.getByText("No changes detected")).toBeTruthy();
+  });
+
+  it("renders BINARY_FILE sentinel", () => {
+    render(wrap(<DiffViewer diff="BINARY_FILE" filePath="src/index.ts" />));
+    expect(screen.getByText("Binary file - cannot display diff")).toBeTruthy();
+  });
+
+  it("renders FILE_TOO_LARGE sentinel", () => {
+    render(wrap(<DiffViewer diff="FILE_TOO_LARGE" filePath="src/index.ts" />));
+    expect(screen.getByText(/File too large to display diff/)).toBeTruthy();
+  });
+
+  it("renders ERROR sentinel with error message", () => {
+    render(wrap(<DiffViewer diff="ERROR" filePath="src/index.ts" />));
+    expect(screen.getByText("Failed to load diff")).toBeTruthy();
+  });
+
+  it("does not render parse-failure fallback for ERROR sentinel", () => {
+    render(wrap(<DiffViewer diff="ERROR" filePath="src/index.ts" />));
+    // ERROR sentinel is checked before files.length, so we get the error UI
+    expect(screen.getByText("Failed to load diff")).toBeTruthy();
+    expect(screen.queryByText("Unable to parse diff")).toBeNull();
+  });
+
+  it("renders retry button when onRetry is provided", () => {
+    const onRetry = vi.fn();
+    render(wrap(<DiffViewer diff="ERROR" filePath="src/index.ts" onRetry={onRetry} />));
+    expect(screen.getByRole("button", { name: "Retry" })).toBeTruthy();
+  });
+
+  it("does not render retry button when onRetry is omitted", () => {
+    render(wrap(<DiffViewer diff="ERROR" filePath="src/index.ts" />));
+    expect(screen.queryByRole("button", { name: "Retry" })).toBeNull();
+  });
+
+  it("calls onRetry when retry button is clicked", () => {
+    const onRetry = vi.fn();
+    render(wrap(<DiffViewer diff="ERROR" filePath="src/index.ts" onRetry={onRetry} />));
+    fireEvent.click(screen.getByRole("button", { name: "Retry" }));
+    expect(onRetry).toHaveBeenCalledTimes(1);
+  });
+
+  it("renders empty diff sentinel", () => {
+    render(wrap(<DiffViewer diff="" filePath="src/index.ts" />));
+    expect(screen.getByText("No changes detected")).toBeTruthy();
+  });
+
+  it("renders parse failure when diff is unparseable", () => {
+    render(wrap(<DiffViewer diff="not a real diff" filePath="src/index.ts" />));
+    expect(screen.getByText("Unable to parse diff")).toBeTruthy();
   });
 });


### PR DESCRIPTION
## Summary
- The diff modal was collapsing fetch errors into `NO_CHANGES`, making real failures look like empty diffs.
- Loading states used `Spinner` instead of the `animate-pulse-delayed` skeleton, violating the 400ms Doherty threshold rule for predictable layouts.

## Changes
- Added an `ERROR` sentinel to `DiffViewer` that renders an inline retry banner with a "Retry" action.
- Routed caught errors in `FileDiffModal` and `BaseBranchDiffModal` to the `ERROR` sentinel instead of `NO_CHANGES`.
- Swapped `Spinner` for `animate-pulse-delayed` skeleton in `FileViewerModal` for both file-load and diff-load states.
- Added stale-request guards to prevent a late-arriving response from overwriting a newer request's state.
- Included unit tests for the `ERROR` sentinel render path and loading skeleton behavior.

Resolves #7781

## Testing
- Unit tests verify the `ERROR` sentinel renders the retry banner and that retry triggers a fresh fetch.
- Manually tested error scenarios (git permission failure, IPC failure) to confirm the inline error renders and the retry action works.