### PR TITLE
feat(review-hub): body-line ruler and commit message history recall

### DIFF
--- a/src/components/Worktree/ReviewHub/CommitPanel.tsx
+++ b/src/components/Worktree/ReviewHub/CommitPanel.tsx
@@ -8,6 +8,7 @@ import { Tooltip, TooltipTrigger, TooltipContent } from "@/components/ui/tooltip
 import { SplitButton } from "@/components/ui/split-button";
 
 const MAX_SUBJECT_LENGTH = 72;
+const HISTORY_FETCH_POLL_INTERVAL_MS = 10;
 
 interface CommitPanelProps {
   stagedCount: number;
@@ -102,7 +103,7 @@ export function CommitPanel({
     if (historyMessagesRef.current !== null) return historyMessagesRef.current;
     if (isFetchingHistoryRef.current) {
       while (isFetchingHistoryRef.current) {
-        await new Promise((r) => setTimeout(r, 10));
+        await new Promise((r) => setTimeout(r, HISTORY_FETCH_POLL_INTERVAL_MS));
       }
       return historyMessagesRef.current ?? [];
     }

--- a/src/components/Worktree/ReviewHub/CommitPanel.tsx
+++ b/src/components/Worktree/ReviewHub/CommitPanel.tsx
@@ -1,4 +1,4 @@
-import { useState, useCallback, useRef } from "react";
+import { useState, useCallback, useRef, useEffect } from "react";
 import type { PushProgressEvent } from "@shared/types/ipc/gitPush";
 import { cn } from "@/lib/utils";
 import { GitCommit, ArrowUpFromLine, Check, CircleX } from "lucide-react";
@@ -14,6 +14,7 @@ interface CommitPanelProps {
   isDetachedHead: boolean;
   hasConflicts: boolean;
   hasRemote: boolean;
+  worktreePath: string;
   commitMessage: string;
   onCommitMessageChange: (message: string) => void;
   onCommit: (message: string) => Promise<void>;
@@ -29,6 +30,7 @@ export function CommitPanel({
   isDetachedHead,
   hasConflicts,
   hasRemote,
+  worktreePath,
   commitMessage,
   onCommitMessageChange,
   onCommit,
@@ -45,7 +47,7 @@ export function CommitPanel({
   const detachedHeadRef = useRef<HTMLDivElement>(null);
 
   const subjectLine = commitMessage.split("\n")[0] || "";
-  const isOverLimit = subjectLine.length > MAX_SUBJECT_LENGTH;
+  const hasLineOverflow = /.{73,}/.test(commitMessage);
   const isBusy = isCommitting || isPushing;
   const canCommit =
     stagedCount > 0 && commitMessage.trim().length > 0 && !isDetachedHead && !hasConflicts;
@@ -81,6 +83,43 @@ export function CommitPanel({
         break;
     }
   }, [primaryBlocker, onFocusBlocker]);
+
+  const historyMessagesRef = useRef<string[] | null>(null);
+  const historyIndexRef = useRef(-1);
+  const isFetchingHistoryRef = useRef(false);
+  const draftBeforeHistoryRef = useRef("");
+  const pendingFirstApplyRef = useRef(false);
+
+  useEffect(() => {
+    historyMessagesRef.current = null;
+    historyIndexRef.current = -1;
+    isFetchingHistoryRef.current = false;
+    draftBeforeHistoryRef.current = "";
+    pendingFirstApplyRef.current = false;
+  }, [worktreePath]);
+
+  const fetchHistoryMessages = useCallback(async (): Promise<string[]> => {
+    if (historyMessagesRef.current !== null) return historyMessagesRef.current;
+    if (isFetchingHistoryRef.current) {
+      while (isFetchingHistoryRef.current) {
+        await new Promise((r) => setTimeout(r, 10));
+      }
+      return historyMessagesRef.current ?? [];
+    }
+    isFetchingHistoryRef.current = true;
+    try {
+      const result = await window.electron.git.listCommits({ cwd: worktreePath, limit: 8 });
+      historyMessagesRef.current = result.items
+        .map((c) => (c.body?.trim() ? `${c.message}\n\n${c.body.trim()}` : c.message))
+        .filter((m) => m.length > 0);
+      return historyMessagesRef.current;
+    } catch {
+      historyMessagesRef.current = [];
+      return [];
+    } finally {
+      isFetchingHistoryRef.current = false;
+    }
+  }, [worktreePath]);
 
   const handleCommit = useCallback(async () => {
     if (!canCommit || isBusy) return;
@@ -129,6 +168,71 @@ export function CommitPanel({
 
   const handleKeyDown = useCallback(
     (e: React.KeyboardEvent<HTMLTextAreaElement>) => {
+      if (
+        (e.key === "ArrowUp" || e.key === "ArrowDown") &&
+        !e.altKey &&
+        !e.metaKey &&
+        !e.ctrlKey &&
+        e.currentTarget.selectionStart === 0 &&
+        e.currentTarget.selectionEnd === 0
+      ) {
+        e.preventDefault();
+
+        if (e.key === "ArrowUp") {
+          if (historyIndexRef.current < 0) {
+            draftBeforeHistoryRef.current = commitMessage;
+            pendingFirstApplyRef.current = true;
+          }
+
+          const messages = historyMessagesRef.current;
+          if (messages !== null) {
+            if (messages.length === 0) return;
+
+            if (pendingFirstApplyRef.current) {
+              pendingFirstApplyRef.current = false;
+              historyIndexRef.current = 0;
+              onCommitMessageChange(messages[0]);
+            } else if (historyIndexRef.current < messages.length - 1) {
+              historyIndexRef.current++;
+              onCommitMessageChange(messages[historyIndexRef.current]!);
+            }
+
+            requestAnimationFrame(() => {
+              textareaRef.current?.setSelectionRange(0, 0);
+            });
+          } else {
+            void fetchHistoryMessages().then((msgs) => {
+              if (msgs.length === 0) return;
+
+              if (pendingFirstApplyRef.current) {
+                pendingFirstApplyRef.current = false;
+                historyIndexRef.current = 0;
+                onCommitMessageChange(msgs[0]);
+              }
+
+              requestAnimationFrame(() => {
+                textareaRef.current?.setSelectionRange(0, 0);
+              });
+            });
+          }
+        } else {
+          if (historyIndexRef.current < 0) return;
+          historyIndexRef.current--;
+          if (historyIndexRef.current < 0) {
+            pendingFirstApplyRef.current = false;
+            onCommitMessageChange(draftBeforeHistoryRef.current);
+          } else {
+            const messages = historyMessagesRef.current!;
+            onCommitMessageChange(messages[historyIndexRef.current]!);
+          }
+
+          requestAnimationFrame(() => {
+            textareaRef.current?.setSelectionRange(0, 0);
+          });
+        }
+        return;
+      }
+
       if (e.key === "Enter" && (e.metaKey || e.ctrlKey)) {
         e.preventDefault();
         if (isBlocked) {
@@ -142,7 +246,16 @@ export function CommitPanel({
         }
       }
     },
-    [handlePrimaryClick, handleCommit, hasRemote, isBlocked, focusBlocker]
+    [
+      handlePrimaryClick,
+      handleCommit,
+      hasRemote,
+      isBlocked,
+      focusBlocker,
+      commitMessage,
+      fetchHistoryMessages,
+      onCommitMessageChange,
+    ]
   );
 
   const blockerTooltip = (
@@ -185,28 +298,41 @@ export function CommitPanel({
         <textarea
           ref={textareaRef}
           value={commitMessage}
-          onChange={(e) => onCommitMessageChange(e.target.value)}
+          onChange={(e) => {
+            historyIndexRef.current = -1;
+            pendingFirstApplyRef.current = false;
+            onCommitMessageChange(e.target.value);
+          }}
           onKeyDown={handleKeyDown}
           placeholder="Commit message…"
           rows={4}
           disabled={isBusy || isDetachedHead}
+          style={
+            {
+              backgroundImage: `linear-gradient(to right, transparent 72ch, rgba(128,128,128,0.14) 72ch)`,
+              backgroundOrigin: "content-box",
+              backgroundClip: "content-box",
+              backgroundAttachment: "local",
+            } as React.CSSProperties
+          }
           className={cn(
             "w-full resize-none rounded-md border bg-daintree-bg px-3 py-2 text-xs font-mono",
             "placeholder:text-daintree-text/30 text-daintree-text",
             "focus:outline-hidden focus:ring-2 focus:ring-daintree-accent focus:border-transparent",
             "disabled:opacity-50 disabled:cursor-not-allowed",
-            isOverLimit ? "border-status-warning" : "border-divider"
+            hasLineOverflow ? "border-status-warning" : "border-divider"
           )}
         />
         <div
           className={cn(
-            "absolute bottom-1.5 right-2 text-[10px]",
-            isOverLimit ? "text-status-warning" : "text-daintree-text/30"
+            "absolute bottom-1.5 right-2 text-[10px] flex items-center gap-1.5",
+            hasLineOverflow ? "text-status-warning" : "text-daintree-text/30"
           )}
         >
           <span className="tabular-nums">
             {subjectLine.length}/{MAX_SUBJECT_LENGTH}
           </span>
+          {hasLineOverflow && <span>Line over 72 chars</span>}
         </div>
       </div>
 

--- a/src/components/Worktree/ReviewHub/CommitPanel.tsx
+++ b/src/components/Worktree/ReviewHub/CommitPanel.tsx
@@ -191,7 +191,7 @@ export function CommitPanel({
             if (pendingFirstApplyRef.current) {
               pendingFirstApplyRef.current = false;
               historyIndexRef.current = 0;
-              onCommitMessageChange(messages[0]);
+              onCommitMessageChange(messages[0]!);
             } else if (historyIndexRef.current < messages.length - 1) {
               historyIndexRef.current++;
               onCommitMessageChange(messages[historyIndexRef.current]!);
@@ -207,7 +207,7 @@ export function CommitPanel({
               if (pendingFirstApplyRef.current) {
                 pendingFirstApplyRef.current = false;
                 historyIndexRef.current = 0;
-                onCommitMessageChange(msgs[0]);
+                onCommitMessageChange(msgs[0]!);
               }
 
               requestAnimationFrame(() => {

--- a/src/components/Worktree/ReviewHub/ReviewHub.tsx
+++ b/src/components/Worktree/ReviewHub/ReviewHub.tsx
@@ -1919,6 +1919,7 @@ export function ReviewHub({ isOpen, worktreePath, onClose }: ReviewHubProps) {
                 isDetachedHead={status.isDetachedHead}
                 hasConflicts={hasConflicts}
                 hasRemote={status.hasRemote}
+                worktreePath={worktreePath}
                 commitMessage={commitMessage}
                 onCommitMessageChange={setCommitMessage}
                 onCommit={handleCommit}

--- a/src/components/Worktree/ReviewHub/__tests__/ReviewHub.test.tsx
+++ b/src/components/Worktree/ReviewHub/__tests__/ReviewHub.test.tsx
@@ -2482,7 +2482,7 @@ describe("ReviewHub", () => {
       expect(textarea.className).toContain("border-status-warning");
     });
 
-    it("does not show warning when subject exceeds 72 but body line is clean", async () => {
+    it("shows warning when subject line alone exceeds 72 characters", async () => {
       render(<ReviewHub isOpen={true} worktreePath={WORKTREE_PATH} onClose={vi.fn()} />);
       await waitFor(() => screen.getByPlaceholderText("Commit message…"));
 

--- a/src/components/Worktree/ReviewHub/__tests__/ReviewHub.test.tsx
+++ b/src/components/Worktree/ReviewHub/__tests__/ReviewHub.test.tsx
@@ -24,6 +24,7 @@ const {
   pullRebaseMock,
   forcePushWithLeaseMock,
   listRemoteCommitsMock,
+  listCommitsMock,
   actionDispatchMock,
   worktreeStoreData,
 } = vi.hoisted(() => ({
@@ -43,6 +44,7 @@ const {
   pullRebaseMock: vi.fn(),
   forcePushWithLeaseMock: vi.fn(),
   listRemoteCommitsMock: vi.fn(),
+  listCommitsMock: vi.fn().mockResolvedValue({ items: [], hasMore: false, total: 0 }),
   actionDispatchMock: vi.fn().mockResolvedValue({ ok: true }),
   worktreeStoreData: {
     current: new Map<string, Partial<WorktreeState>>([
@@ -376,6 +378,7 @@ describe("ReviewHub", () => {
     pullRebaseMock.mockReset().mockResolvedValue(undefined);
     forcePushWithLeaseMock.mockReset().mockResolvedValue(undefined);
     listRemoteCommitsMock.mockReset().mockResolvedValue([]);
+    listCommitsMock.mockReset().mockResolvedValue({ items: [], hasMore: false, total: 0 });
     actionDispatchMock.mockReset().mockResolvedValue({ ok: true });
 
     Object.defineProperty(window, "electron", {
@@ -391,6 +394,7 @@ describe("ReviewHub", () => {
           pullRebase: pullRebaseMock,
           forcePushWithLease: forcePushWithLeaseMock,
           listRemoteCommits: listRemoteCommitsMock,
+          listCommits: listCommitsMock,
           compareWorktrees: compareWorktreesMock,
           abortRepositoryOperation: abortRepositoryOperationMock,
           continueRepositoryOperation: continueRepositoryOperationMock,
@@ -2457,6 +2461,285 @@ describe("ReviewHub", () => {
         expect(screen.queryByText("yarn.lock")).toBeNull();
         screen.getByText("app.ts");
       });
+    });
+  });
+
+  describe("commit message overflow", () => {
+    it("shows warning when any line exceeds 72 characters", async () => {
+      render(<ReviewHub isOpen={true} worktreePath={WORKTREE_PATH} onClose={vi.fn()} />);
+      await waitFor(() => screen.getByPlaceholderText("Commit message…"));
+
+      const textarea = screen.getByPlaceholderText("Commit message…");
+      // Subject line within limit, but body line exceeds 72
+      fireEvent.change(textarea, {
+        target: {
+          value:
+            "feat: short subject\n\nThe quick brown fox jumps over the lazy dog and then some more text goes here yes indeed wow",
+        },
+      });
+
+      expect(screen.getByText("Line over 72 chars")).toBeTruthy();
+      expect(textarea.className).toContain("border-status-warning");
+    });
+
+    it("does not show warning when subject exceeds 72 but body line is clean", async () => {
+      render(<ReviewHub isOpen={true} worktreePath={WORKTREE_PATH} onClose={vi.fn()} />);
+      await waitFor(() => screen.getByPlaceholderText("Commit message…"));
+
+      const textarea = screen.getByPlaceholderText("Commit message…");
+      // Subject line exceeds 72 chars — should trigger overflow
+      fireEvent.change(textarea, {
+        target: {
+          value:
+            "feat: this is a very long subject line that goes way beyond seventy two characters and should trigger the warning",
+        },
+      });
+
+      expect(screen.getByText("Line over 72 chars")).toBeTruthy();
+      expect(textarea.className).toContain("border-status-warning");
+    });
+
+    it("does not show warning when all lines are 72 characters or fewer", async () => {
+      render(<ReviewHub isOpen={true} worktreePath={WORKTREE_PATH} onClose={vi.fn()} />);
+      await waitFor(() => screen.getByPlaceholderText("Commit message…"));
+
+      const textarea = screen.getByPlaceholderText("Commit message…");
+      fireEvent.change(textarea, {
+        target: { value: "feat: short subject\n\nA normal body line." },
+      });
+
+      expect(screen.queryByText("Line over 72 chars")).toBeNull();
+      expect(textarea.className).toContain("border-divider");
+      expect(textarea.className).not.toContain("border-status-warning");
+    });
+
+    it("shows subject line length counter", async () => {
+      render(<ReviewHub isOpen={true} worktreePath={WORKTREE_PATH} onClose={vi.fn()} />);
+      await waitFor(() => screen.getByPlaceholderText("Commit message…"));
+
+      const textarea = screen.getByPlaceholderText("Commit message…");
+      fireEvent.change(textarea, {
+        target: { value: "fix: resolve bug" },
+      });
+
+      expect(screen.getByText("16/72")).toBeTruthy();
+    });
+  });
+
+  describe("commit history arrow-key cycling", () => {
+    function renderOpen() {
+      return render(<ReviewHub isOpen={true} worktreePath={WORKTREE_PATH} onClose={vi.fn()} />);
+    }
+
+    it("fetches and cycles through recent commits on ArrowUp from caret 0", async () => {
+      listCommitsMock.mockResolvedValue({
+        items: [
+          {
+            hash: "abc1234",
+            shortHash: "abc1234",
+            message: "feat: most recent commit",
+            author: { name: "Test", email: "test@example.com" },
+            date: "2026-05-10",
+          },
+          {
+            hash: "def5678",
+            shortHash: "def5678",
+            message: "fix: older commit",
+            body: "Detailed body text.",
+            author: { name: "Test", email: "test@example.com" },
+            date: "2026-05-09",
+          },
+        ],
+        hasMore: false,
+        total: 2,
+      });
+
+      renderOpen();
+      await waitFor(() => screen.getByPlaceholderText("Commit message…"));
+
+      const textarea = screen.getByPlaceholderText("Commit message…") as HTMLTextAreaElement;
+
+      // Position cursor at 0 (empty textarea)
+      textarea.setSelectionRange(0, 0);
+
+      fireEvent.keyDown(textarea, { key: "ArrowUp" });
+      expect(listCommitsMock).toHaveBeenCalledWith({
+        cwd: WORKTREE_PATH,
+        limit: 8,
+      });
+
+      // Wait for the async fetch to resolve and re-render
+      await act(async () => {
+        await Promise.resolve();
+      });
+
+      // After fetch, the textarea should show the most recent commit message
+      expect(textarea.value).toBe("feat: most recent commit");
+
+      // ArrowUp again → next older commit (with body)
+      textarea.setSelectionRange(0, 0);
+      fireEvent.keyDown(textarea, { key: "ArrowUp" });
+      expect(textarea.value).toBe("fix: older commit\n\nDetailed body text.");
+
+      // ArrowUp again → no more commits, stays at last
+      textarea.setSelectionRange(0, 0);
+      fireEvent.keyDown(textarea, { key: "ArrowUp" });
+      expect(textarea.value).toBe("fix: older commit\n\nDetailed body text.");
+    });
+
+    it("ArrowDown unwinds through history and restores original draft", async () => {
+      listCommitsMock.mockResolvedValue({
+        items: [
+          {
+            hash: "abc1234",
+            shortHash: "abc1234",
+            message: "feat: most recent commit",
+            author: { name: "Test", email: "test@example.com" },
+            date: "2026-05-10",
+          },
+        ],
+        hasMore: false,
+        total: 1,
+      });
+
+      renderOpen();
+      await waitFor(() => screen.getByPlaceholderText("Commit message…"));
+
+      const textarea = screen.getByPlaceholderText("Commit message…") as HTMLTextAreaElement;
+
+      // Type a draft first
+      fireEvent.change(textarea, { target: { value: "my draft message" } });
+      textarea.setSelectionRange(0, 0);
+
+      fireEvent.keyDown(textarea, { key: "ArrowUp" });
+      await act(async () => {
+        await Promise.resolve();
+      });
+
+      expect(textarea.value).toBe("feat: most recent commit");
+
+      // ArrowDown → back to draft
+      textarea.setSelectionRange(0, 0);
+      fireEvent.keyDown(textarea, { key: "ArrowDown" });
+      expect(textarea.value).toBe("my draft message");
+    });
+
+    it("does not intercept ArrowUp when caret is not at position 0", async () => {
+      renderOpen();
+      await waitFor(() => screen.getByPlaceholderText("Commit message…"));
+
+      const textarea = screen.getByPlaceholderText("Commit message…") as HTMLTextAreaElement;
+
+      fireEvent.change(textarea, { target: { value: "some text" } });
+      // Caret in middle of text
+      textarea.setSelectionRange(4, 4);
+
+      fireEvent.keyDown(textarea, { key: "ArrowUp" });
+      expect(listCommitsMock).not.toHaveBeenCalled();
+    });
+
+    it("resets history index when user types manually after cycling", async () => {
+      listCommitsMock.mockResolvedValue({
+        items: [
+          {
+            hash: "abc1234",
+            shortHash: "abc1234",
+            message: "feat: first commit",
+            author: { name: "Test", email: "test@example.com" },
+            date: "2026-05-10",
+          },
+          {
+            hash: "def5678",
+            shortHash: "def5678",
+            message: "feat: second commit",
+            author: { name: "Test", email: "test@example.com" },
+            date: "2026-05-09",
+          },
+        ],
+        hasMore: false,
+        total: 2,
+      });
+
+      renderOpen();
+      await waitFor(() => screen.getByPlaceholderText("Commit message…"));
+
+      const textarea = screen.getByPlaceholderText("Commit message…") as HTMLTextAreaElement;
+
+      textarea.setSelectionRange(0, 0);
+      fireEvent.keyDown(textarea, { key: "ArrowUp" });
+      await act(async () => {
+        await Promise.resolve();
+      });
+      expect(textarea.value).toBe("feat: first commit");
+
+      // Type manually — should reset history index and start fresh on next ArrowUp
+      fireEvent.change(textarea, { target: { value: "typed after cycling" } });
+
+      textarea.setSelectionRange(0, 0);
+      fireEvent.keyDown(textarea, { key: "ArrowUp" });
+      // Should show most recent again (cycling from start), not the second-oldest
+      expect(textarea.value).toBe("feat: first commit");
+
+      textarea.setSelectionRange(0, 0);
+      fireEvent.keyDown(textarea, { key: "ArrowUp" });
+      expect(textarea.value).toBe("feat: second commit");
+    });
+
+    it("ArrowUp does nothing when there is no commit history", async () => {
+      listCommitsMock.mockResolvedValue({ items: [], hasMore: false, total: 0 });
+
+      renderOpen();
+      await waitFor(() => screen.getByPlaceholderText("Commit message…"));
+
+      const textarea = screen.getByPlaceholderText("Commit message…") as HTMLTextAreaElement;
+
+      textarea.setSelectionRange(0, 0);
+      fireEvent.keyDown(textarea, { key: "ArrowUp" });
+      await act(async () => {
+        await Promise.resolve();
+      });
+
+      expect(textarea.value).toBe("");
+    });
+
+    it("ArrowDown does nothing when not in history mode", async () => {
+      renderOpen();
+      await waitFor(() => screen.getByPlaceholderText("Commit message…"));
+
+      const textarea = screen.getByPlaceholderText("Commit message…") as HTMLTextAreaElement;
+
+      fireEvent.change(textarea, { target: { value: "no history here" } });
+      textarea.setSelectionRange(0, 0);
+
+      fireEvent.keyDown(textarea, { key: "ArrowDown" });
+      // Should remain unchanged
+      expect(textarea.value).toBe("no history here");
+    });
+
+    it("does not intercept ArrowUp with modifier keys", async () => {
+      renderOpen();
+      await waitFor(() => screen.getByPlaceholderText("Commit message…"));
+
+      const textarea = screen.getByPlaceholderText("Commit message…") as HTMLTextAreaElement;
+
+      textarea.setSelectionRange(0, 0);
+
+      fireEvent.keyDown(textarea, { key: "ArrowUp", altKey: true });
+      expect(listCommitsMock).not.toHaveBeenCalled();
+    });
+
+    it("sets ruler background styling on textarea", async () => {
+      renderOpen();
+      await waitFor(() => screen.getByPlaceholderText("Commit message…"));
+
+      const textarea = screen.getByPlaceholderText("Commit message…") as HTMLTextAreaElement;
+
+      const styleAttr = textarea.getAttribute("style") ?? "";
+      expect(styleAttr).toContain("linear-gradient");
+      expect(styleAttr).toContain("72ch");
+      expect(styleAttr).toContain("rgba");
+      expect(styleAttr).toContain("background-origin: content-box");
+      expect(styleAttr).toContain("background-attachment: local");
     });
   });
 });


### PR DESCRIPTION
## Summary
- Added a 72-character visual ruler behind the commit composer textarea, applied to all lines.
- Extended the overflow warning border to fire when any line exceeds 72 characters, not just the subject.
- ArrowUp/ArrowDown cycling through recent commit messages when the caret is at position 0 -- shell-style recall.

Resolves #7778.

## Changes
- `CommitPanel.tsx` -- ruler background, `hasLineOverflow` regex, history fetch + keybindings
- `ReviewHub.tsx` -- passes `worktreePath` to `CommitPanel`
- `ReviewHub.test.tsx` -- 10 new tests covering overflow detection, arrow-key cycling, caret gating, modifier exclusion, and history reset on manual typing

## Testing
- Unit tests pass for all new cases -- overflow (subject-only, body-included), arrow-key cycling (fetch, cycle, unwind, restore draft), caret gating, modifier exclusion, manual typing reset, empty history, and ruler styling.