### PR TITLE
fix(review-hub): polish file lists with unified rows and churn summary

### DIFF
--- a/src/components/Worktree/ReviewHub/ReviewHubContent.tsx
+++ b/src/components/Worktree/ReviewHub/ReviewHubContent.tsx
@@ -25,7 +25,6 @@ import {
   Clock,
   GitBranch,
   GitPullRequest,
-  FileIcon,
   XCircle,
   SlidersHorizontal,
   ChevronUp,
@@ -73,7 +72,7 @@ import {
   matchesFilter,
   readGitErrorFields,
   sortFiles,
-  statusLabel,
+  getBaseBranchStatusConfig,
 } from "./reviewHubUtils";
 
 export interface ReviewHubContentProps {
@@ -127,35 +126,58 @@ function BaseBranchFileRow({
   unresolvedCount,
   onBadgeClick,
 }: BaseBranchFileRowProps) {
-  const { label, className: statusClass } = statusLabel(file.status);
-  const filename = file.path.split(/[/\\]/).filter(Boolean).pop() || file.path;
-  const dirPath = /[/\\]/.test(file.path)
-    ? file.path.substring(0, Math.max(file.path.lastIndexOf("/"), file.path.lastIndexOf("\\")))
-    : "";
+  const config = getBaseBranchStatusConfig(file.status);
+  const normalized = file.path.replace(/\\/g, "/");
+  const lastSlash = normalized.lastIndexOf("/");
+  const dir = lastSlash === -1 ? "" : normalized.slice(0, lastSlash);
+  const base = lastSlash === -1 ? normalized : normalized.slice(lastSlash + 1);
 
   return (
     <TruncatedTooltip content={file.path}>
       <div
         className={cn(
-          "w-full flex items-center gap-2 px-2 py-1.5 rounded text-left text-xs",
-          "hover:bg-tint/[0.05] transition-colors"
+          "group/baserow w-full flex items-center text-xs rounded px-1.5 py-1.5",
+          "hover:bg-tint/5 transition-colors"
         )}
       >
         <button
           type="button"
           onClick={onClick}
           className={cn(
-            "flex items-center gap-2 min-w-0 flex-1",
-            "focus-visible:outline-hidden focus-visible:ring-1 focus-visible:ring-daintree-accent rounded"
+            "relative flex min-w-0 flex-1 items-baseline rounded text-left",
+            "focus-visible:outline-hidden focus-visible:ring-2 focus-visible:ring-daintree-accent"
           )}
         >
-          <span className={cn("font-mono font-bold shrink-0 w-3 text-center", statusClass)}>
-            {label}
+          <span
+            aria-hidden="true"
+            className={cn(
+              "inline-flex items-center justify-center rounded-sm px-1 mr-2 shrink-0",
+              "text-[10px] font-medium leading-4 h-4 min-w-[16px]",
+              config.bg,
+              config.text
+            )}
+          >
+            {config.label}
           </span>
-          <FileIcon className="w-3 h-3 shrink-0 text-daintree-text/40" />
-          <span className="text-daintree-text/80 truncate min-w-0">{filename}</span>
-          <span className="text-daintree-text/30 truncate min-w-0 text-[10px] ml-auto">
-            {dirPath}
+          {dir && (
+            <span
+              data-testid="base-branch-file-row-dir"
+              className={cn(
+                "shrink truncate font-mono text-[11px] transition-colors",
+                "text-daintree-text/50 group-hover/baserow:text-daintree-text/70"
+              )}
+            >
+              {dir}/
+            </span>
+          )}
+          <span
+            data-testid="base-branch-file-row-base"
+            className={cn(
+              "shrink truncate font-medium font-mono text-[11px] transition-colors",
+              "text-daintree-text group-hover/baserow:text-daintree-text"
+            )}
+          >
+            {base}
           </span>
         </button>
         {unresolvedCount !== undefined && unresolvedCount > 0 && (
@@ -164,7 +186,7 @@ function BaseBranchFileRow({
             onClick={onBadgeClick}
             aria-label={`${unresolvedCount} unresolved review comment${unresolvedCount !== 1 ? "s" : ""} on ${file.path}`}
             className={cn(
-              "shrink-0 inline-flex items-center justify-center min-w-[18px] h-[18px] px-1 rounded-full",
+              "shrink-0 inline-flex items-center justify-center min-w-[18px] h-[18px] px-1 ml-2 rounded-full",
               "text-[10px] font-semibold tabular-nums",
               "bg-status-warning/15 text-status-warning",
               "hover:bg-status-warning/25 transition-colors cursor-pointer",
@@ -297,6 +319,40 @@ export function ReviewHubContent({
       rows = rows.filter((f) => matchesFilter(f.path, changesView.filterQuery));
     return sortFiles(rows, changesView.sortKey, changesView.sortDir);
   }, [status, changesView]);
+
+  const stagedChurn = useMemo(
+    () =>
+      derivedStaged.reduce(
+        (acc, f) => ({
+          ins: acc.ins + (f.insertions ?? 0),
+          del: acc.del + (f.deletions ?? 0),
+        }),
+        { ins: 0, del: 0 }
+      ),
+    [derivedStaged]
+  );
+
+  const unstagedChurn = useMemo(
+    () =>
+      derivedUnstaged.reduce(
+        (acc, f) => ({
+          ins: acc.ins + (f.insertions ?? 0),
+          del: acc.del + (f.deletions ?? 0),
+        }),
+        { ins: 0, del: 0 }
+      ),
+    [derivedUnstaged]
+  );
+
+  const sortedBaseBranchFiles = useMemo(
+    () =>
+      baseBranchFiles
+        ? [...baseBranchFiles].sort((a, b) =>
+            a.path.replace(/\\/g, "/").localeCompare(b.path.replace(/\\/g, "/"))
+          )
+        : null,
+    [baseBranchFiles]
+  );
 
   const mainBranch = useWorktreeStore(
     (state) =>
@@ -1334,24 +1390,25 @@ export function ReviewHubContent({
                   Retry
                 </Button>
               </div>
-            ) : baseBranchFiles !== null && baseBranchFiles.length === 0 ? (
+            ) : sortedBaseBranchFiles !== null && sortedBaseBranchFiles.length === 0 ? (
               <div className="flex flex-col items-center justify-center py-12 text-daintree-text/50">
                 <CheckSquare className="w-8 h-8 mb-2 text-daintree-text/30" />
                 <p className="text-sm">No changes vs {mainBranch}</p>
                 <p className="text-xs mt-1">This branch has no commits ahead of {mainBranch}</p>
               </div>
-            ) : baseBranchFiles !== null ? (
+            ) : sortedBaseBranchFiles !== null ? (
               <div>
                 <div className="flex items-center justify-between px-4 py-2 bg-overlay-subtle border-b border-divider">
                   <span className="text-[11px] font-semibold uppercase tracking-wider text-daintree-text/60">
                     Changed vs {mainBranch}
                     <span className="ml-1.5 tabular-nums bg-tint/10 rounded px-1 py-0.5 text-[10px] font-medium normal-case tracking-normal">
-                      {baseBranchFiles.length}
+                      {sortedBaseBranchFiles.length} file
+                      {sortedBaseBranchFiles.length !== 1 ? "s" : ""}
                     </span>
                   </span>
                 </div>
                 <div className="px-2 py-1 flex flex-col gap-0.5">
-                  {baseBranchFiles.map((file) => (
+                  {sortedBaseBranchFiles.map((file) => (
                     <BaseBranchFileRow
                       key={`${file.status}:${file.path}`}
                       file={file}
@@ -1427,8 +1484,26 @@ export function ReviewHubContent({
                     <div className="flex items-center justify-between px-4 py-2 bg-overlay-subtle gap-2">
                       <span className="text-[11px] font-semibold uppercase tracking-wider text-daintree-text/60 shrink-0">
                         Staged
-                        <span className="ml-1.5 tabular-nums bg-tint/10 rounded px-1 py-0.5 text-[10px] font-medium normal-case tracking-normal">
-                          {derivedStaged.length}
+                        <span
+                          data-testid="staged-section-count-chip"
+                          className="ml-1.5 tabular-nums bg-tint/10 rounded px-1 py-0.5 text-[10px] font-medium normal-case tracking-normal inline-flex items-center gap-1"
+                        >
+                          <span>
+                            {derivedStaged.length} file{derivedStaged.length !== 1 ? "s" : ""}
+                          </span>
+                          {(stagedChurn.ins > 0 || stagedChurn.del > 0) && (
+                            <>
+                              <span aria-hidden="true" className="text-daintree-text/30">
+                                ·
+                              </span>
+                              {stagedChurn.ins > 0 && (
+                                <span className="text-status-success/80">{`+${stagedChurn.ins}`}</span>
+                              )}
+                              {stagedChurn.del > 0 && (
+                                <span className="text-status-error/80">{`-${stagedChurn.del}`}</span>
+                              )}
+                            </>
+                          )}
                         </span>
                       </span>
                       <div className="flex items-center gap-1.5 min-w-0">
@@ -1607,8 +1682,26 @@ export function ReviewHubContent({
                     <div className="flex items-center justify-between px-4 py-2 bg-overlay-subtle gap-2">
                       <span className="text-[11px] font-semibold uppercase tracking-wider text-daintree-text/60 shrink-0">
                         Changes
-                        <span className="ml-1.5 tabular-nums bg-tint/10 rounded px-1 py-0.5 text-[10px] font-medium normal-case tracking-normal">
-                          {derivedUnstaged.length}
+                        <span
+                          data-testid="changes-section-count-chip"
+                          className="ml-1.5 tabular-nums bg-tint/10 rounded px-1 py-0.5 text-[10px] font-medium normal-case tracking-normal inline-flex items-center gap-1"
+                        >
+                          <span>
+                            {derivedUnstaged.length} file{derivedUnstaged.length !== 1 ? "s" : ""}
+                          </span>
+                          {(unstagedChurn.ins > 0 || unstagedChurn.del > 0) && (
+                            <>
+                              <span aria-hidden="true" className="text-daintree-text/30">
+                                ·
+                              </span>
+                              {unstagedChurn.ins > 0 && (
+                                <span className="text-status-success/80">{`+${unstagedChurn.ins}`}</span>
+                              )}
+                              {unstagedChurn.del > 0 && (
+                                <span className="text-status-error/80">{`-${unstagedChurn.del}`}</span>
+                              )}
+                            </>
+                          )}
                         </span>
                       </span>
                       <div className="flex items-center gap-1.5 min-w-0">

--- a/src/components/Worktree/ReviewHub/__tests__/ReviewHub.test.tsx
+++ b/src/components/Worktree/ReviewHub/__tests__/ReviewHub.test.tsx
@@ -2224,9 +2224,156 @@ describe("ReviewHub", () => {
       // Verify the section headers show "Staged" and "Changes" labels with counts
       screen.getByText("Staged");
       screen.getByText("Changes");
+      // Pluralized count appears in the chip ("3 files" — both sections have 3 entries).
+      expect(screen.getAllByText("3 files").length).toBe(2);
       // Both sections have 3 files each, and the bulk buttons also show counts
       screen.getByText("Stage all (3)");
       screen.getByText("Unstage all (3)");
+    });
+
+    it("includes aggregate +X -Y churn in section header chips when available", async () => {
+      getStagingStatusMock.mockResolvedValue(
+        makeStatus({
+          staged: [
+            { path: "src/a.ts", status: "modified", insertions: 5, deletions: 2 },
+            { path: "src/b.ts", status: "modified", insertions: 10, deletions: 1 },
+          ],
+          unstaged: [{ path: "src/c.ts", status: "modified", insertions: 3, deletions: 4 }],
+        })
+      );
+
+      render(<ReviewHub isOpen={true} worktreePath={WORKTREE_PATH} onClose={vi.fn()} />);
+
+      await waitFor(() => screen.getByText("a.ts"));
+      // Exact full-text match: catches misordered/duplicate/missing segments.
+      const stagedChip = screen.getByTestId("staged-section-count-chip");
+      expect(stagedChip.textContent).toBe("2 files·+15-3");
+      const changesChip = screen.getByTestId("changes-section-count-chip");
+      expect(changesChip.textContent).toBe("1 file·+3-4");
+    });
+
+    it("renders only +N when deletions are zero in the chip", async () => {
+      getStagingStatusMock.mockResolvedValue(
+        makeStatus({
+          staged: [{ path: "new.ts", status: "added", insertions: 10, deletions: 0 }],
+          unstaged: [],
+        })
+      );
+
+      render(<ReviewHub isOpen={true} worktreePath={WORKTREE_PATH} onClose={vi.fn()} />);
+      await waitFor(() => screen.getByText("new.ts"));
+      const stagedChip = screen.getByTestId("staged-section-count-chip");
+      expect(stagedChip.textContent).toBe("1 file·+10");
+    });
+
+    it("omits churn suffix when all insertions/deletions are null", async () => {
+      getStagingStatusMock.mockResolvedValue(multiFileStatus());
+
+      render(<ReviewHub isOpen={true} worktreePath={WORKTREE_PATH} onClose={vi.fn()} />);
+
+      await waitFor(() => screen.getByText("index.ts"));
+      const stagedChip = screen.getByTestId("staged-section-count-chip");
+      expect(stagedChip.textContent).toBe("3 files");
+      const changesChip = screen.getByTestId("changes-section-count-chip");
+      expect(changesChip.textContent).toBe("3 files");
+    });
+
+    it("renders base-branch files in sorted path order", async () => {
+      compareWorktreesMock.mockResolvedValue({
+        branch1: "main",
+        branch2: "feature/test",
+        files: [
+          { status: "M", path: "z-last.ts" },
+          { status: "A", path: "a-first.ts" },
+          { status: "M", path: "m-middle.ts" },
+        ],
+      });
+
+      render(<ReviewHub isOpen={true} worktreePath={WORKTREE_PATH} onClose={vi.fn()} />);
+      await waitFor(() => screen.getByText("index.ts"));
+
+      act(() => fireEvent.click(screen.getByRole("button", { name: /vs main/i })));
+
+      await waitFor(() => screen.getByText("a-first.ts"));
+
+      // Query the rendered filename spans in DOM order.
+      const baseSpans = screen.getAllByTestId("base-branch-file-row-base");
+      expect(baseSpans.map((el) => el.textContent)).toEqual([
+        "a-first.ts",
+        "m-middle.ts",
+        "z-last.ts",
+      ]);
+    });
+
+    it("sorts base-branch files by directory prefix then filename", async () => {
+      compareWorktreesMock.mockResolvedValue({
+        branch1: "main",
+        branch2: "feature/test",
+        files: [
+          { status: "M", path: "z/a.ts" },
+          { status: "A", path: "a/z.ts" },
+          { status: "M", path: "a/a.ts" },
+        ],
+      });
+
+      render(<ReviewHub isOpen={true} worktreePath={WORKTREE_PATH} onClose={vi.fn()} />);
+      await waitFor(() => screen.getByText("index.ts"));
+
+      act(() => fireEvent.click(screen.getByRole("button", { name: /vs main/i })));
+
+      await waitFor(() =>
+        expect(screen.getAllByTestId("base-branch-file-row-base")).toHaveLength(3)
+      );
+
+      const rows = screen.getAllByTestId("base-branch-file-row-dir");
+      const bases = screen.getAllByTestId("base-branch-file-row-base");
+      // Expected order: a/a.ts, a/z.ts, z/a.ts
+      expect(rows.map((el) => el.textContent)).toEqual(["a/", "a/", "z/"]);
+      expect(bases.map((el) => el.textContent)).toEqual(["a.ts", "z.ts", "a.ts"]);
+    });
+
+    it("splits base-branch row into dir and base spans for nested paths", async () => {
+      compareWorktreesMock.mockResolvedValue({
+        branch1: "main",
+        branch2: "feature/test",
+        files: [{ status: "M", path: "src/components/button.tsx" }],
+      });
+
+      render(<ReviewHub isOpen={true} worktreePath={WORKTREE_PATH} onClose={vi.fn()} />);
+      await waitFor(() => screen.getByText("index.ts"));
+
+      act(() => fireEvent.click(screen.getByRole("button", { name: /vs main/i })));
+
+      await waitFor(() => screen.getByText("button.tsx"));
+
+      const dirSpans = screen.getAllByTestId("base-branch-file-row-dir");
+      expect(dirSpans).toHaveLength(1);
+      expect(dirSpans[0]!.textContent).toBe("src/components/");
+
+      const baseSpans = screen.getAllByTestId("base-branch-file-row-base");
+      expect(baseSpans.map((el) => el.textContent)).toEqual(["button.tsx"]);
+    });
+
+    it("omits the dir span for root-level base-branch files", async () => {
+      compareWorktreesMock.mockResolvedValue({
+        branch1: "main",
+        branch2: "feature/test",
+        files: [{ status: "M", path: "rootfile.md" }],
+      });
+
+      render(<ReviewHub isOpen={true} worktreePath={WORKTREE_PATH} onClose={vi.fn()} />);
+      await waitFor(() => screen.getByText("index.ts"));
+
+      act(() => fireEvent.click(screen.getByRole("button", { name: /vs main/i })));
+
+      await waitFor(() =>
+        expect(screen.getAllByTestId("base-branch-file-row-base")).toHaveLength(1)
+      );
+
+      // Root-level path has no dir prefix.
+      expect(screen.queryByTestId("base-branch-file-row-dir")).toBeNull();
+      const baseSpans = screen.getAllByTestId("base-branch-file-row-base");
+      expect(baseSpans[0]!.textContent).toBe("rootfile.md");
     });
 
     it("renders Stage all (N) button with correct count", async () => {

--- a/src/components/Worktree/ReviewHub/reviewHubUtils.ts
+++ b/src/components/Worktree/ReviewHub/reviewHubUtils.ts
@@ -192,21 +192,27 @@ export function extractGitHubErrorCode(rawMessage: string): string | undefined {
   return match ? match[0] : undefined;
 }
 
-export function statusLabel(status: string): { label: string; className: string } {
-  switch (status) {
-    case "A":
-      return { label: "A", className: "text-status-success" };
-    case "D":
-      return { label: "D", className: "text-status-error" };
-    case "M":
-      return { label: "M", className: "text-status-warning" };
-    case "R":
-      return { label: "R", className: "text-status-info" };
-    case "C":
-      return { label: "C", className: "text-github-merged" };
-    default:
-      return { label: status, className: "text-text-muted" };
-  }
+const BASE_BRANCH_STATUS_CONFIG: Record<string, { label: string; bg: string; text: string }> = {
+  A: { label: "A", bg: "bg-status-success/15", text: "text-status-success" },
+  D: { label: "D", bg: "bg-status-error/15", text: "text-status-error" },
+  M: { label: "M", bg: "bg-status-warning/15", text: "text-status-warning" },
+  R: { label: "R", bg: "bg-status-info/15", text: "text-status-info" },
+  C: { label: "C", bg: "bg-status-info/15", text: "text-status-info" },
+  U: { label: "U", bg: "bg-status-error/15", text: "text-status-error" },
+};
+
+export function getBaseBranchStatusConfig(status: string): {
+  label: string;
+  bg: string;
+  text: string;
+} {
+  return (
+    BASE_BRANCH_STATUS_CONFIG[status] ?? {
+      label: status,
+      bg: "bg-tint/[0.06]",
+      text: "text-daintree-text/40",
+    }
+  );
 }
 
 export type SortKey = "path" | "status";


### PR DESCRIPTION
## Summary

- Unified `BaseBranchFileRow` and `FileStageRow` into a consistent row layout — same status-letter treatment, padding, and dir-path placement across both lists
- Added per-file churn numbers to `FileStageRow` using the existing `insertions`/`deletions` fields already present on `StagingFileEntry`
- Added aggregate churn summary to the Staged and Changes section-header chips, and added client-side path sort to the base-branch list

Resolves #7782

## Changes

- `ReviewHub.tsx`: unified row layout for `BaseBranchFileRow`, wired churn into `FileStageRow`, added `+X -Y` aggregate to section-header chips, sorted base-branch list by dir then filename
- `ReviewHub.test.tsx`: added chip assertion coverage and dir/sort tests

## Testing

Existing test suite passes. New assertions cover the chip churn summary and confirm base-branch entries sort correctly by path.