### PR TITLE
feat(voice): add dictation-command post-processor for OpenAI realtime path

### DIFF
--- a/electron/ipc/handlers/voiceInput.ts
+++ b/electron/ipc/handlers/voiceInput.ts
@@ -506,24 +506,27 @@ export function registerVoiceInputHandlers(deps: HandlerDependencies): () => voi
         // OpenAI Realtime emits spoken dictation commands ("new paragraph",
         // "period", etc.) as literal text. Deepgram dictation mode rewrites
         // them upstream; here we reproduce that behavior post-hoc, gated on
-        // the user's paragraphing strategy.
+        // the session-snapshotted paragraphing strategy (matches the
+        // transcription-settings convention documented at handleStart).
         const processedText =
-          liveSettings.paragraphingStrategy === "spoken-command"
+          settings.paragraphingStrategy === "spoken-command"
             ? applyDictationCommands(rawText)
             : rawText;
 
-        // Split on \n\n so each paragraph is emitted as its own complete event
-        // with a paragraph_boundary between them — mirrors the Deepgram path
-        // in VoiceTranscriptionService.emitCompleteWithParagraphDetection so
-        // the renderer's onParagraphBoundary handler is invoked consistently.
-        const parts = processedText.split(/\n\n+/).map((p) => p.trim());
+        // Split on \n\n and emit one complete event per non-empty part with a
+        // paragraph_boundary between them — mirrors the Deepgram path in
+        // VoiceTranscriptionService.emitCompleteWithParagraphDetection.
+        // .filter(Boolean) ensures command-only utterances (e.g. "new paragraph"
+        // alone produces "\n\n" → ["", ""]) emit nothing, consistent with Deepgram.
+        const parts = processedText
+          .split(/\n\n+/)
+          .map((p) => p.trim())
+          .filter(Boolean);
         for (let i = 0; i < parts.length; i++) {
-          if (parts[i]) {
-            getAppWebContents(win).send(CHANNELS.VOICE_INPUT_TRANSCRIPTION_COMPLETE, {
-              text: parts[i],
-              willCorrect: false,
-            });
-          }
+          getAppWebContents(win).send(CHANNELS.VOICE_INPUT_TRANSCRIPTION_COMPLETE, {
+            text: parts[i],
+            willCorrect: false,
+          });
           if (i < parts.length - 1) {
             getAppWebContents(win).send(CHANNELS.VOICE_INPUT_PARAGRAPH_BOUNDARY, {
               rawText: null,

--- a/electron/ipc/handlers/voiceInput.ts
+++ b/electron/ipc/handlers/voiceInput.ts
@@ -13,6 +13,7 @@ import type { VoiceInputSettings } from "../../../shared/types/ipc/api.js";
 import { CONFIDENCE_TAG_THRESHOLD } from "../../../shared/config/voiceCorrection.js";
 import { logDebug, logWarn } from "../../utils/logger.js";
 import { assembleKeyterms } from "../../services/voiceContextKeyterms.js";
+import { applyDictationCommands } from "../../services/voiceDictationCommands.js";
 import { getAppWebContents } from "../../window/webContentsRegistry.js";
 import { voiceFileLinkResolver } from "../../services/VoiceFileLinkResolver.js";
 import { typedHandle, typedHandleWithContext } from "../utils.js";
@@ -500,15 +501,38 @@ export function registerVoiceInputHandlers(deps: HandlerDependencies): () => voi
         getAppWebContents(win).send(CHANNELS.VOICE_INPUT_TRANSCRIPTION_DELTA, voiceEvent.text);
       } else if (voiceEvent.type === "complete") {
         const rawText = voiceEvent.text.trim();
+        const liveSettings = getVoiceSettings();
 
-        // Notify the renderer so it can finalize the utterance in the draft.
-        getAppWebContents(win).send(CHANNELS.VOICE_INPUT_TRANSCRIPTION_COMPLETE, {
-          text: rawText,
-          willCorrect: false,
-        });
+        // OpenAI Realtime emits spoken dictation commands ("new paragraph",
+        // "period", etc.) as literal text. Deepgram dictation mode rewrites
+        // them upstream; here we reproduce that behavior post-hoc, gated on
+        // the user's paragraphing strategy.
+        const processedText =
+          liveSettings.paragraphingStrategy === "spoken-command"
+            ? applyDictationCommands(rawText)
+            : rawText;
+
+        // Split on \n\n so each paragraph is emitted as its own complete event
+        // with a paragraph_boundary between them — mirrors the Deepgram path
+        // in VoiceTranscriptionService.emitCompleteWithParagraphDetection so
+        // the renderer's onParagraphBoundary handler is invoked consistently.
+        const parts = processedText.split(/\n\n+/).map((p) => p.trim());
+        for (let i = 0; i < parts.length; i++) {
+          if (parts[i]) {
+            getAppWebContents(win).send(CHANNELS.VOICE_INPUT_TRANSCRIPTION_COMPLETE, {
+              text: parts[i],
+              willCorrect: false,
+            });
+          }
+          if (i < parts.length - 1) {
+            getAppWebContents(win).send(CHANNELS.VOICE_INPUT_PARAGRAPH_BOUNDARY, {
+              rawText: null,
+              correctionId: null,
+            });
+          }
+        }
 
         // Feed word-level data into the streaming correction buffer
-        const liveSettings = getVoiceSettings();
         const correctionEnabled = !!(
           liveSettings.correctionEnabled && liveSettings.correctionApiKey
         );

--- a/electron/services/__tests__/voiceDictationCommands.test.ts
+++ b/electron/services/__tests__/voiceDictationCommands.test.ts
@@ -1,0 +1,158 @@
+import { describe, it, expect } from "vitest";
+import { applyDictationCommands } from "../voiceDictationCommands.js";
+
+describe("applyDictationCommands", () => {
+  describe("individual commands at end of utterance", () => {
+    it("replaces trailing 'period' with '.'", () => {
+      expect(applyDictationCommands("hello period")).toBe("hello.");
+    });
+
+    it("replaces trailing 'full stop' with '.'", () => {
+      expect(applyDictationCommands("hello full stop")).toBe("hello.");
+    });
+
+    it("replaces trailing 'comma' with ','", () => {
+      expect(applyDictationCommands("hello comma")).toBe("hello,");
+    });
+
+    it("replaces trailing 'question mark' with '?'", () => {
+      expect(applyDictationCommands("are you there question mark")).toBe("are you there?");
+    });
+
+    it("replaces trailing 'exclamation point' with '!'", () => {
+      expect(applyDictationCommands("watch out exclamation point")).toBe("watch out!");
+    });
+
+    it("replaces trailing 'exclamation mark' with '!'", () => {
+      expect(applyDictationCommands("watch out exclamation mark")).toBe("watch out!");
+    });
+
+    it("replaces trailing 'new paragraph' with '\\n\\n'", () => {
+      expect(applyDictationCommands("hello new paragraph")).toBe("hello\n\n");
+    });
+
+    it("replaces trailing 'new line' with '\\n'", () => {
+      expect(applyDictationCommands("hello new line")).toBe("hello\n");
+    });
+  });
+
+  describe("command-only utterances", () => {
+    it("replaces a standalone 'period'", () => {
+      expect(applyDictationCommands("period")).toBe(".");
+    });
+
+    it("replaces a standalone 'new paragraph'", () => {
+      expect(applyDictationCommands("new paragraph")).toBe("\n\n");
+    });
+
+    it("replaces a standalone 'new line'", () => {
+      expect(applyDictationCommands("new line")).toBe("\n");
+    });
+  });
+
+  describe("case insensitivity", () => {
+    it("replaces uppercase commands", () => {
+      expect(applyDictationCommands("hello PERIOD")).toBe("hello.");
+    });
+
+    it("replaces mixed-case commands", () => {
+      expect(applyDictationCommands("hello New Paragraph")).toBe("hello\n\n");
+    });
+
+    it("replaces 'NEW PARAGRAPH' (caps)", () => {
+      expect(applyDictationCommands("NEW PARAGRAPH")).toBe("\n\n");
+    });
+  });
+
+  describe("false-positive safety (mid-sentence)", () => {
+    it("leaves 'I'll add a new paragraph here' literal", () => {
+      const input = "I'll add a new paragraph here";
+      expect(applyDictationCommands(input)).toBe(input);
+    });
+
+    it("leaves 'periodic table' literal", () => {
+      const input = "periodic table";
+      expect(applyDictationCommands(input)).toBe(input);
+    });
+
+    it("leaves 'an Oxford comma matters' literal", () => {
+      const input = "an Oxford comma matters";
+      expect(applyDictationCommands(input)).toBe(input);
+    });
+
+    it("leaves 'I question mark choices' literal (mid-sentence)", () => {
+      const input = "I question mark choices";
+      expect(applyDictationCommands(input)).toBe(input);
+    });
+
+    it("leaves empty string unchanged", () => {
+      expect(applyDictationCommands("")).toBe("");
+    });
+
+    it("leaves text without any commands unchanged", () => {
+      const input = "the quick brown fox";
+      expect(applyDictationCommands(input)).toBe(input);
+    });
+  });
+
+  describe("chained trailing commands", () => {
+    it("replaces 'hello comma period' as a chain", () => {
+      expect(applyDictationCommands("hello comma period")).toBe("hello,.");
+    });
+
+    it("replaces 'hello comma new paragraph' as a chain", () => {
+      expect(applyDictationCommands("hello comma new paragraph")).toBe("hello,\n\n");
+    });
+
+    it("replaces a long chain at the tail", () => {
+      expect(applyDictationCommands("done period new paragraph")).toBe("done.\n\n");
+    });
+
+    it("replaces the trailing chain only when literal text intervenes", () => {
+      // "world" interrupts the chain, so only "period" at the tail fires.
+      expect(applyDictationCommands("hello comma world period")).toBe("hello comma world.");
+    });
+  });
+
+  describe("whitespace handling", () => {
+    it("handles multiple spaces between text and command", () => {
+      expect(applyDictationCommands("hello   period")).toBe("hello.");
+    });
+
+    it("handles trailing whitespace after command", () => {
+      expect(applyDictationCommands("hello period   ")).toBe("hello.");
+    });
+
+    it("preserves leading whitespace before the literal portion", () => {
+      // Leading whitespace before "hello" is preserved; only the trailing chain replaces.
+      expect(applyDictationCommands("  hello period")).toBe("  hello.");
+    });
+  });
+
+  describe("idempotence", () => {
+    it("running twice produces the same result", () => {
+      const once = applyDictationCommands("hello period");
+      const twice = applyDictationCommands(once);
+      expect(twice).toBe(once);
+    });
+
+    it("does not re-process already-replaced punctuation", () => {
+      // After replacement, "." is not a command — running again is a no-op.
+      expect(applyDictationCommands("hello.")).toBe("hello.");
+    });
+  });
+
+  describe("word-boundary safety", () => {
+    it("does not match 'period' inside 'periodic'", () => {
+      expect(applyDictationCommands("periodic")).toBe("periodic");
+    });
+
+    it("does not match 'period' inside 'periodically'", () => {
+      expect(applyDictationCommands("worked periodically")).toBe("worked periodically");
+    });
+
+    it("does not match 'comma' inside 'commando'", () => {
+      expect(applyDictationCommands("the commando")).toBe("the commando");
+    });
+  });
+});

--- a/electron/services/__tests__/voiceDictationCommands.test.ts
+++ b/electron/services/__tests__/voiceDictationCommands.test.ts
@@ -112,6 +112,13 @@ describe("applyDictationCommands", () => {
       // "world" interrupts the chain, so only "period" at the tail fires.
       expect(applyDictationCommands("hello comma world period")).toBe("hello comma world.");
     });
+
+    it("preserves a chain that ends in a formatting command followed by punctuation", () => {
+      // Chain produces a paragraph break followed by a literal comma — the
+      // downstream split-on-\\n\\n yields ["hello", ","] which the handler
+      // emits as two paragraphs.
+      expect(applyDictationCommands("hello new paragraph comma")).toBe("hello\n\n,");
+    });
   });
 
   describe("whitespace handling", () => {
@@ -153,6 +160,23 @@ describe("applyDictationCommands", () => {
 
     it("does not match 'comma' inside 'commando'", () => {
       expect(applyDictationCommands("the commando")).toBe("the commando");
+    });
+
+    it("matches a trailing command after a word that starts with the same prefix", () => {
+      // "periodic" is preserved; the trailing standalone "period" still fires.
+      expect(applyDictationCommands("periodic period")).toBe("periodic.");
+    });
+  });
+
+  describe("documented limitations", () => {
+    // The trailing-anchor design is end-of-utterance only. Legitimate trailing
+    // nouns that happen to be command words will convert. This is the same
+    // tradeoff Deepgram dictation mode makes — kept for parity. If a user
+    // dislikes it, the manual paragraphing strategy disables the post-processor.
+    it("converts a trailing noun that happens to spell a command (known tradeoff)", () => {
+      expect(applyDictationCommands("I studied the Jurassic period")).toBe(
+        "I studied the Jurassic."
+      );
     });
   });
 });

--- a/electron/services/voiceDictationCommands.ts
+++ b/electron/services/voiceDictationCommands.ts
@@ -1,0 +1,79 @@
+/**
+ * Dictation-command post-processor for the OpenAI realtime transcription path.
+ *
+ * Deepgram Dictation mode intercepts spoken commands ("new paragraph" → \n\n,
+ * "period" → ".", etc.) at the transcription layer. OpenAI Realtime has no
+ * equivalent — those phrases arrive as literal text. This module reproduces
+ * the behavior in post-processing so users get the same UX.
+ *
+ * Safety: commands only fire when they form a trailing chain at the end of the
+ * utterance. Mid-sentence uses like "I'll add a new paragraph here" stay literal.
+ */
+
+type CommandPhrase = string;
+type CommandReplacement = string;
+
+// Multi-word commands precede single-word commands so the regex alternation
+// prefers the longer phrase ("exclamation point" before any hypothetical "point",
+// "new paragraph" before any hypothetical "new").
+const COMMAND_MAP: ReadonlyArray<readonly [CommandPhrase, CommandReplacement]> = [
+  ["new paragraph", "\n\n"],
+  ["new line", "\n"],
+  ["exclamation point", "!"],
+  ["exclamation mark", "!"],
+  ["question mark", "?"],
+  ["full stop", "."],
+  ["period", "."],
+  ["comma", ","],
+];
+
+const COMMAND_REPLACEMENTS = new Map<string, string>(
+  COMMAND_MAP.map(([phrase, replacement]) => [phrase, replacement])
+);
+
+const COMMAND_ALTERNATION = COMMAND_MAP.map(([phrase]) => phrase.replace(/\s+/g, "\\s+")).join("|");
+
+// Matches a trailing chain of one or more commands separated by whitespace.
+// \b anchors at a word boundary so "period" doesn't match inside "periodic".
+// $ anchors at end of string so commands embedded mid-sentence stay literal.
+// Group 1 captures the chain (commands + their separating whitespace).
+const TRAILING_CHAIN_RE = new RegExp(
+  `\\s*\\b((?:${COMMAND_ALTERNATION})(?:\\s+(?:${COMMAND_ALTERNATION}))*)\\s*$`,
+  "i"
+);
+
+// Used to tokenize a captured chain back into individual command phrases.
+const SINGLE_COMMAND_RE = new RegExp(`(?:${COMMAND_ALTERNATION})`, "gi");
+
+/**
+ * Replace trailing spoken dictation commands with their text equivalents.
+ *
+ * Only the chain of commands at the END of the utterance is replaced — text
+ * preceding the chain is preserved verbatim. A "chain" is one or more
+ * recognized commands separated by whitespace.
+ *
+ * Examples:
+ *   applyDictationCommands("hello period")              → "hello."
+ *   applyDictationCommands("hello comma new paragraph") → "hello,\n\n"
+ *   applyDictationCommands("new paragraph")             → "\n\n"
+ *   applyDictationCommands("I'll add a new paragraph here") → unchanged
+ *
+ * Idempotent on text without trailing commands.
+ */
+export function applyDictationCommands(text: string): string {
+  const match = TRAILING_CHAIN_RE.exec(text);
+  if (!match) return text;
+
+  const chain = match[1];
+  const phrases = chain.match(SINGLE_COMMAND_RE);
+  if (!phrases || phrases.length === 0) return text;
+
+  const replaced = phrases
+    .map((phrase) => {
+      const key = phrase.replace(/\s+/g, " ").toLowerCase();
+      return COMMAND_REPLACEMENTS.get(key) ?? phrase;
+    })
+    .join("");
+
+  return text.slice(0, match.index) + replaced;
+}


### PR DESCRIPTION
## Summary

- Adds `applyDictationCommands` in `electron/services/voiceDictationCommands.ts` — a pure function that rewrites spoken commands (`new paragraph`, `new line`, `period`, `comma`, `question mark`, `exclamation point`) into the appropriate punctuation or paragraph breaks on the OpenAI realtime transcription path, matching the behaviour Deepgram's `dictation: true` mode provides natively.
- Gated on `paragraphingStrategy === "spoken-command"`, so manual mode is completely unaffected.
- Wired in `electron/ipc/handlers/voiceInput.ts` between the raw `complete` event and the IPC send to the renderer. Splits on `\n\n` to emit `paragraph_boundary` events and uses `filter(Boolean)` to drop utterances that collapse to empty after command substitution — mirrors `emitCompleteWithParagraphDetection` on the Deepgram side.

Resolves #7833

## Changes

- `electron/services/voiceDictationCommands.ts` — new pure-function module with command table and boundary-aware matching
- `electron/services/__tests__/voiceDictationCommands.test.ts` — 35 unit tests: each command, false-positive protection (`"I'll add a new paragraph here"` stays literal), leading/trailing punctuation, case-insensitivity
- `electron/ipc/handlers/voiceInput.ts` — thin invoker in the `complete` handler, gated on session-snapshotted strategy

## Testing

35 new unit tests pass alongside the 28 existing `voiceInput` tests (63 total). All 6 CI checks pass: typecheck, channels, ipc, help, lint:ratchet, format, build.