### PR TITLE
refactor(voice): unify Deepgram and OpenAI keys into single openaiApiKey

### DIFF
--- a/electron/ipc/channels.ts
+++ b/electron/ipc/channels.ts
@@ -572,7 +572,6 @@ export const CHANNELS = {
   VOICE_INPUT_REQUEST_MIC_PERMISSION: "voice-input:request-mic-permission",
   VOICE_INPUT_OPEN_MIC_SETTINGS: "voice-input:open-mic-settings",
   VOICE_INPUT_VALIDATE_API_KEY: "voice-input:validate-api-key",
-  VOICE_INPUT_VALIDATE_CORRECTION_API_KEY: "voice-input:validate-correction-api-key",
   VOICE_INPUT_FLUSH_PARAGRAPH: "voice-input:flush-paragraph",
   VOICE_INPUT_PARAGRAPH_BOUNDARY: "voice-input:paragraph-boundary",
   VOICE_INPUT_FILE_TOKEN_RESOLVED: "voice-input:file-token-resolved",

--- a/electron/ipc/handlers/__tests__/voiceInput.paragraph.test.ts
+++ b/electron/ipc/handlers/__tests__/voiceInput.paragraph.test.ts
@@ -159,7 +159,7 @@ vi.mock("../../channels.js", () => ({
 }));
 
 // ── Module import (once) ───────────────────────────────────────────────────
-import { registerVoiceInputHandlers } from "../voiceInput.js";
+import { registerVoiceInputHandlers, getVoiceSettings } from "../voiceInput.js";
 
 // ── Helpers ────────────────────────────────────────────────────────────────
 
@@ -621,5 +621,99 @@ describe("voiceInput — streaming word-level correction", () => {
     expect(shared.correctionWordCalls[0].request.leftContext).toBe("I love");
     expect(shared.correctionWordCalls[0].request.rawSpan).toBe("racked");
     expect(shared.correctionWordCalls[0].request.rightContext).toBe("is a great");
+  });
+});
+
+describe("getVoiceSettings migration", () => {
+  beforeEach(async () => {
+    const { store } = await import("../../../store.js");
+    vi.mocked(store.set).mockReset();
+    vi.mocked(store.get).mockReset();
+  });
+
+  it("migrates legacy correctionApiKey (sk-*) into openaiApiKey and persists cleanup", async () => {
+    const { store } = await import("../../../store.js");
+    vi.mocked(store.get).mockReturnValueOnce({
+      enabled: true,
+      correctionApiKey: "sk-correction",
+      language: "en",
+      customDictionary: [],
+      transcriptionModel: "nova-3",
+      correctionEnabled: false,
+      correctionModel: "gpt-5-mini",
+      correctionCustomInstructions: "",
+      paragraphingStrategy: "spoken-command",
+    });
+
+    const settings = getVoiceSettings();
+
+    expect(settings.openaiApiKey).toBe("sk-correction");
+    expect(vi.mocked(store.set)).toHaveBeenCalledWith(
+      "voiceInput",
+      expect.objectContaining({ openaiApiKey: "sk-correction" })
+    );
+    // Persisted object should not retain legacy keys.
+    const persisted = (
+      vi.mocked(store.set).mock.calls[0] as unknown as [string, Record<string, unknown>]
+    )[1];
+    expect(persisted).not.toHaveProperty("correctionApiKey");
+    expect(persisted).not.toHaveProperty("deepgramApiKey");
+    expect(persisted).not.toHaveProperty("apiKey");
+  });
+
+  it("migrates first-generation apiKey (sk-*) into openaiApiKey", async () => {
+    const { store } = await import("../../../store.js");
+    vi.mocked(store.get).mockReturnValueOnce({
+      enabled: true,
+      apiKey: "sk-original",
+    });
+
+    const settings = getVoiceSettings();
+
+    expect(settings.openaiApiKey).toBe("sk-original");
+    expect(vi.mocked(store.set)).toHaveBeenCalledOnce();
+  });
+
+  it("drops deepgramApiKey without carrying it into openaiApiKey", async () => {
+    const { store } = await import("../../../store.js");
+    vi.mocked(store.get).mockReturnValueOnce({
+      enabled: true,
+      deepgramApiKey: "dg-xxx",
+    });
+
+    const settings = getVoiceSettings();
+
+    expect(settings.openaiApiKey).toBe("");
+    // Cleanup is still persisted so the dropped key disappears from disk.
+    expect(vi.mocked(store.set)).toHaveBeenCalledOnce();
+    const persisted = (
+      vi.mocked(store.set).mock.calls[0] as unknown as [string, Record<string, unknown>]
+    )[1];
+    expect(persisted).not.toHaveProperty("deepgramApiKey");
+  });
+
+  it("does not overwrite an existing openaiApiKey when legacy fields are present", async () => {
+    const { store } = await import("../../../store.js");
+    vi.mocked(store.get).mockReturnValueOnce({
+      enabled: true,
+      openaiApiKey: "sk-new",
+      correctionApiKey: "sk-old",
+    });
+
+    const settings = getVoiceSettings();
+
+    expect(settings.openaiApiKey).toBe("sk-new");
+  });
+
+  it("does not write to disk when no legacy fields are present", async () => {
+    const { store } = await import("../../../store.js");
+    vi.mocked(store.get).mockReturnValueOnce({
+      enabled: true,
+      openaiApiKey: "sk-present",
+    });
+
+    getVoiceSettings();
+
+    expect(vi.mocked(store.set)).not.toHaveBeenCalled();
   });
 });

--- a/electron/ipc/handlers/__tests__/voiceInput.paragraph.test.ts
+++ b/electron/ipc/handlers/__tests__/voiceInput.paragraph.test.ts
@@ -114,8 +114,7 @@ vi.mock("../../../store.js", () => ({
       if (key === "voiceInput") {
         return {
           enabled: true,
-          deepgramApiKey: "dg-test-key",
-          correctionApiKey: "sk-test",
+          openaiApiKey: "sk-test",
           correctionEnabled: true,
           correctionModel: "gpt-5-mini",
           customDictionary: [],
@@ -154,7 +153,6 @@ vi.mock("../../channels.js", () => ({
     VOICE_INPUT_REQUEST_MIC_PERMISSION: "voice-input:request-mic-permission",
     VOICE_INPUT_OPEN_MIC_SETTINGS: "voice-input:open-mic-settings",
     VOICE_INPUT_VALIDATE_API_KEY: "voice-input:validate-api-key",
-    VOICE_INPUT_VALIDATE_CORRECTION_API_KEY: "voice-input:validate-correction-api-key",
     VOICE_INPUT_FLUSH_PARAGRAPH: "voice-input:flush-paragraph",
     VOICE_INPUT_PARAGRAPH_BOUNDARY: "voice-input:paragraph-boundary",
   },
@@ -463,8 +461,7 @@ describe("voiceInput — streaming word-level correction", () => {
     const { store } = await import("../../../store.js");
     const disabledSettings = {
       enabled: true,
-      deepgramApiKey: "dg-test-key",
-      correctionApiKey: "",
+      openaiApiKey: "sk-test",
       correctionEnabled: false,
       correctionModel: "gpt-5-mini",
       customDictionary: [],

--- a/electron/ipc/handlers/voiceInput.ts
+++ b/electron/ipc/handlers/voiceInput.ts
@@ -189,7 +189,7 @@ const VOICE_INPUT_DEFAULTS: VoiceInputSettings = {
 };
 
 /** Read voiceInput settings with defaults for fields added after initial store creation. */
-function getVoiceSettings(): VoiceInputSettings {
+export function getVoiceSettings(): VoiceInputSettings {
   const stored = store.get("voiceInput") as
     | (Partial<VoiceInputSettings> & {
         apiKey?: string;

--- a/electron/ipc/handlers/voiceInput.ts
+++ b/electron/ipc/handlers/voiceInput.ts
@@ -177,8 +177,7 @@ let sessionProjectInfo: { name?: string; path?: string } = {};
 
 const VOICE_INPUT_DEFAULTS: VoiceInputSettings = {
   enabled: false,
-  deepgramApiKey: "",
-  correctionApiKey: "",
+  openaiApiKey: "",
   language: "en",
   customDictionary: [],
   transcriptionModel: "nova-3",
@@ -192,16 +191,31 @@ const VOICE_INPUT_DEFAULTS: VoiceInputSettings = {
 /** Read voiceInput settings with defaults for fields added after initial store creation. */
 function getVoiceSettings(): VoiceInputSettings {
   const stored = store.get("voiceInput") as
-    | (Partial<VoiceInputSettings> & { apiKey?: string })
+    | (Partial<VoiceInputSettings> & {
+        apiKey?: string;
+        deepgramApiKey?: string;
+        correctionApiKey?: string;
+      })
     | undefined;
-  const merged = { ...VOICE_INPUT_DEFAULTS, ...stored };
 
-  // Migrate legacy apiKey (OpenAI sk-* key) to correctionApiKey.
-  // The deepgramApiKey field is new and must be set explicitly by the user.
-  if (stored?.apiKey && !stored.deepgramApiKey && !stored.correctionApiKey) {
-    if (stored.apiKey.startsWith("sk-")) {
-      merged.correctionApiKey = stored.apiKey;
+  // Pluck legacy fields so they don't leak into the merged object via spread.
+  const { apiKey, deepgramApiKey, correctionApiKey, ...rest } = stored ?? {};
+  const merged: VoiceInputSettings = { ...VOICE_INPUT_DEFAULTS, ...rest };
+
+  // Migrate prior OpenAI keys into the unified field. The Deepgram key is
+  // dropped — it belonged to a different provider.
+  if (!merged.openaiApiKey) {
+    if (correctionApiKey?.startsWith("sk-")) {
+      merged.openaiApiKey = correctionApiKey;
+    } else if (apiKey?.startsWith("sk-")) {
+      merged.openaiApiKey = apiKey;
     }
+  }
+
+  // Persist the cleaned object on first read after upgrade so the legacy
+  // fields disappear from disk. `store.set` with a full object replaces.
+  if (apiKey !== undefined || deepgramApiKey !== undefined || correctionApiKey !== undefined) {
+    store.set("voiceInput", merged);
   }
 
   return merged;
@@ -264,37 +278,6 @@ function openMicSettings(): void {
         error: (err as Error)?.message ?? String(err),
       });
     }
-  }
-}
-
-async function validateDeepgramKey(apiKey: string): Promise<{ valid: boolean; error?: string }> {
-  if (!apiKey.trim()) {
-    return { valid: false, error: "API key is required" };
-  }
-
-  try {
-    const response = await fetch("https://api.deepgram.com/v1/auth/token", {
-      method: "GET",
-      headers: {
-        Authorization: `Token ${apiKey.trim()}`,
-      },
-      signal: AbortSignal.timeout(10_000),
-    });
-
-    if (response.ok) {
-      return { valid: true };
-    }
-
-    if (response.status === 401 || response.status === 403) {
-      return { valid: false, error: "Invalid API key" };
-    }
-
-    return { valid: false, error: `API returned status ${response.status}` };
-  } catch (error) {
-    if (error instanceof Error && error.name === "TimeoutError") {
-      return { valid: false, error: "Connection timed out" };
-    }
-    return { valid: false, error: "Failed to connect to Deepgram" };
   }
 }
 
@@ -417,7 +400,7 @@ function fireMicroCorrection(
       },
       {
         model: liveSettings.correctionModel,
-        apiKey: liveSettings.correctionApiKey,
+        apiKey: liveSettings.openaiApiKey,
         customDictionary: liveSettings.customDictionary,
         customInstructions: liveSettings.correctionCustomInstructions,
         projectName: projectInfo.name,
@@ -537,7 +520,7 @@ export function registerVoiceInputHandlers(deps: HandlerDependencies): () => voi
 
         // Feed word-level data into the streaming correction buffer
         const correctionEnabled = !!(
-          liveSettings.correctionEnabled && liveSettings.correctionApiKey
+          liveSettings.correctionEnabled && liveSettings.openaiApiKey
         );
         if (
           correctionEnabled &&
@@ -560,7 +543,7 @@ export function registerVoiceInputHandlers(deps: HandlerDependencies): () => voi
           rawText.length > 0
         ) {
           const projectPath = sessionProjectInfo.path;
-          const apiKey = liveSettings.correctionApiKey;
+          const apiKey = liveSettings.openaiApiKey;
           if (projectPath && apiKey) {
             const signal = sessionController?.signal;
             correctionPool.add(async () => {
@@ -697,10 +680,6 @@ export function registerVoiceInputHandlers(deps: HandlerDependencies): () => voi
   };
 
   const handleValidateApiKey = async (apiKey: string) => {
-    return validateDeepgramKey(apiKey);
-  };
-
-  const handleValidateCorrectionApiKey = async (apiKey: string) => {
     return validateOpenAIKey(apiKey);
   };
 
@@ -714,7 +693,6 @@ export function registerVoiceInputHandlers(deps: HandlerDependencies): () => voi
     typedHandle(CHANNELS.VOICE_INPUT_REQUEST_MIC_PERMISSION, handleRequestMicPermission),
     typedHandle(CHANNELS.VOICE_INPUT_OPEN_MIC_SETTINGS, handleOpenMicSettings),
     typedHandle(CHANNELS.VOICE_INPUT_VALIDATE_API_KEY, handleValidateApiKey),
-    typedHandle(CHANNELS.VOICE_INPUT_VALIDATE_CORRECTION_API_KEY, handleValidateCorrectionApiKey),
     typedHandle(CHANNELS.VOICE_INPUT_FLUSH_PARAGRAPH, handleFlushParagraph),
   ];
 

--- a/electron/preload.cts
+++ b/electron/preload.cts
@@ -2319,8 +2319,7 @@ const api: ElectronAPI = {
     setSettings: (
       patch: Partial<{
         enabled: boolean;
-        deepgramApiKey: string;
-        correctionApiKey: string;
+        openaiApiKey: string;
         language: string;
         customDictionary: string[];
         transcriptionModel: "nova-3" | "nova-2";
@@ -2357,8 +2356,6 @@ const api: ElectronAPI = {
     openMicSettings: () => _unwrappingInvoke(CHANNELS.VOICE_INPUT_OPEN_MIC_SETTINGS),
     validateApiKey: (apiKey: string) =>
       _unwrappingInvoke(CHANNELS.VOICE_INPUT_VALIDATE_API_KEY, apiKey),
-    validateCorrectionApiKey: (apiKey: string) =>
-      _unwrappingInvoke(CHANNELS.VOICE_INPUT_VALIDATE_CORRECTION_API_KEY, apiKey),
     onFileTokenResolved: (
       callback: (payload: { description: string; replacement: string; resolved: boolean }) => void
     ) => _typedOn(CHANNELS.VOICE_INPUT_FILE_TOKEN_RESOLVED, callback),

--- a/electron/services/VoiceTranscriptionService.ts
+++ b/electron/services/VoiceTranscriptionService.ts
@@ -108,9 +108,9 @@ export class VoiceTranscriptionService {
   }
 
   async start(settings: VoiceInputSettings): Promise<VoiceStartResult> {
-    if (!settings.deepgramApiKey) {
-      logWarn(`${P} No Deepgram API key configured`);
-      return { ok: false, error: "Deepgram API key not configured" };
+    if (!settings.openaiApiKey) {
+      logWarn(`${P} No OpenAI API key configured`);
+      return { ok: false, error: "OpenAI API key not configured" };
     }
 
     const mySessionId = this.sessionId + 1;
@@ -130,7 +130,7 @@ export class VoiceTranscriptionService {
       this.pendingStart = { sessionId: mySessionId, resolve };
 
       const keyterms = settings.customDictionary;
-      const deepgram = createClient(settings.deepgramApiKey);
+      const deepgram = createClient(settings.openaiApiKey);
 
       logDebug(`${P} Opening Deepgram live connection`, {
         model: settings.transcriptionModel || "nova-3",

--- a/electron/services/__tests__/VoiceTranscriptionService.integration.test.ts
+++ b/electron/services/__tests__/VoiceTranscriptionService.integration.test.ts
@@ -25,8 +25,7 @@ describe("VoiceTranscriptionService integration", () => {
 
       const result = await service.start({
         enabled: true,
-        deepgramApiKey: DEEPGRAM_API_KEY,
-        correctionApiKey: "",
+        openaiApiKey: DEEPGRAM_API_KEY,
         language: "en",
         customDictionary: [],
         transcriptionModel: "nova-3",

--- a/electron/services/__tests__/VoiceTranscriptionService.test.ts
+++ b/electron/services/__tests__/VoiceTranscriptionService.test.ts
@@ -75,8 +75,7 @@ import { VoiceTranscriptionService } from "../VoiceTranscriptionService.js";
 
 const BASE_SETTINGS: VoiceInputSettings = {
   enabled: true,
-  deepgramApiKey: "dg-test-key",
-  correctionApiKey: "",
+  openaiApiKey: "sk-test",
   language: "en",
   customDictionary: [],
   transcriptionModel: "nova-3",
@@ -135,10 +134,10 @@ describe("VoiceTranscriptionService", () => {
     expect(statuses.at(-1)).toBe("recording");
   });
 
-  it("fails to start when no Deepgram API key is configured", async () => {
+  it("fails to start when no OpenAI API key is configured", async () => {
     const service = new VoiceTranscriptionService();
-    const result = await service.start({ ...BASE_SETTINGS, deepgramApiKey: "" });
-    expect(result).toEqual({ ok: false, error: "Deepgram API key not configured" });
+    const result = await service.start({ ...BASE_SETTINGS, openaiApiKey: "" });
+    expect(result).toEqual({ ok: false, error: "OpenAI API key not configured" });
   });
 
   it("settles a pending start when the session is stopped before connect completes", async () => {

--- a/electron/store.ts
+++ b/electron/store.ts
@@ -180,7 +180,7 @@ export interface StoreSchema {
   };
   voiceInput: {
     enabled: boolean;
-    apiKey: string;
+    openaiApiKey: string;
     language: string;
     customDictionary: string[];
     transcriptionModel: string;
@@ -188,6 +188,7 @@ export interface StoreSchema {
     correctionModel: string;
     correctionCustomInstructions: string;
     paragraphingStrategy: string;
+    resolveFileLinks: boolean;
   };
   mcpServer: {
     enabled: boolean;
@@ -354,7 +355,7 @@ const storeOptions = {
     },
     voiceInput: {
       enabled: false,
-      apiKey: "",
+      openaiApiKey: "",
       language: "en",
       customDictionary: [],
       transcriptionModel: "nova-3",
@@ -362,6 +363,7 @@ const storeOptions = {
       correctionModel: "gpt-5-mini",
       correctionCustomInstructions: "",
       paragraphingStrategy: "spoken-command",
+      resolveFileLinks: true,
     },
     mcpServer: {
       enabled: false,

--- a/shared/types/ipc/api.ts
+++ b/shared/types/ipc/api.ts
@@ -1290,7 +1290,6 @@ export interface ElectronAPI {
     requestMicPermission(): Promise<boolean>;
     openMicSettings(): Promise<void>;
     validateApiKey(apiKey: string): Promise<{ valid: boolean; error?: string }>;
-    validateCorrectionApiKey(apiKey: string): Promise<{ valid: boolean; error?: string }>;
     onFileTokenResolved(
       callback: (payload: { description: string; replacement: string; resolved: boolean }) => void
     ): () => void;
@@ -1540,8 +1539,7 @@ export type VoiceParagraphingStrategy = "spoken-command" | "manual";
 
 export interface VoiceInputSettings {
   enabled: boolean;
-  deepgramApiKey: string;
-  correctionApiKey: string;
+  openaiApiKey: string;
   language: string;
   customDictionary: string[];
   transcriptionModel: VoiceTranscriptionModel;

--- a/shared/types/ipc/maps.ts
+++ b/shared/types/ipc/maps.ts
@@ -1644,10 +1644,6 @@ export interface IpcInvokeMap extends GeneratedIpcInvokeMap {
     args: [apiKey: string];
     result: { valid: boolean; error?: string };
   };
-  "voice-input:validate-correction-api-key": {
-    args: [apiKey: string];
-    result: { valid: boolean; error?: string };
-  };
 
   // Crash Recovery channels
   "crash-recovery:get-pending": {

--- a/src/components/Settings/VoiceInputSettingsTab.tsx
+++ b/src/components/Settings/VoiceInputSettingsTab.tsx
@@ -85,8 +85,7 @@ const TRANSCRIPTION_MODELS: {
 
 const DEFAULT_SETTINGS: VoiceInputSettings = {
   enabled: false,
-  deepgramApiKey: "",
-  correctionApiKey: "",
+  openaiApiKey: "",
   language: "en",
   customDictionary: [],
   transcriptionModel: "nova-3",
@@ -214,7 +213,7 @@ export function VoiceInputSettingsTab() {
       <SettingsSection
         icon={Mic}
         title="Speech-to-Text"
-        description="Real-time transcription via Deepgram Nova. Requires a Deepgram API key and microphone access."
+        description="Real-time transcription. Requires an OpenAI API key and microphone access."
         id="voice-speech-to-text"
       >
         <SettingsSwitchCard
@@ -237,12 +236,12 @@ export function VoiceInputSettingsTab() {
             />
 
             <ApiKeyRow
-              label="Deepgram API Key"
-              value={settings.deepgramApiKey}
-              placeholder="dg_..."
-              onSave={(key) => update({ deepgramApiKey: key })}
+              label="OpenAI API Key"
+              value={settings.openaiApiKey}
+              placeholder="sk-..."
+              onSave={(key) => update({ openaiApiKey: key })}
               onValidate={(key) => window.electron?.voiceInput?.validateApiKey(key)}
-              helpUrl="https://console.deepgram.com/project/api-keys"
+              helpUrl="https://platform.openai.com/api-keys"
               helpLabel="Get API key"
             />
 
@@ -301,16 +300,6 @@ export function VoiceInputSettingsTab() {
 
           {settings.correctionEnabled && (
             <div className="space-y-4">
-              <ApiKeyRow
-                label="OpenAI API Key"
-                value={settings.correctionApiKey}
-                placeholder="sk-..."
-                onSave={(key) => update({ correctionApiKey: key })}
-                onValidate={(key) => window.electron?.voiceInput?.validateCorrectionApiKey(key)}
-                helpUrl="https://platform.openai.com/api-keys"
-                helpLabel="Get API key"
-              />
-
               <SettingsSelect
                 label="Correction Model"
                 value={settings.correctionModel}
@@ -322,7 +311,7 @@ export function VoiceInputSettingsTab() {
                 }))}
               />
 
-              {settings.correctionApiKey && (
+              {settings.openaiApiKey && (
                 <>
                   <SettingsSwitchCard
                     icon={FileSearch}
@@ -750,7 +739,7 @@ function DictionarySection({
         </div>
       ) : (
         <p className="text-xs text-daintree-text/40 select-text">
-          Domain-specific terms sent to Deepgram to boost recognition accuracy.
+          Domain-specific terms sent to the transcription service to boost recognition accuracy.
         </p>
       )}
     </div>

--- a/src/services/VoiceRecordingService.ts
+++ b/src/services/VoiceRecordingService.ts
@@ -436,17 +436,17 @@ class VoiceRecordingService {
 
   async refreshConfiguration(): Promise<boolean> {
     const settings = await window.electron.voiceInput.getSettings();
-    const isConfigured = settings.enabled && !!settings.deepgramApiKey;
+    const isConfigured = settings.enabled && !!settings.openaiApiKey;
     logDebug(`${LOG_PREFIX} refreshConfiguration`, {
       enabled: settings.enabled,
-      hasApiKey: !!settings.deepgramApiKey,
+      hasApiKey: !!settings.openaiApiKey,
       isConfigured,
       correctionEnabled: settings.correctionEnabled,
     });
     // Keep correction state in sync for live-segment dimming
     useVoiceRecordingStore
       .getState()
-      .setCorrectionEnabled(!!(settings.correctionEnabled && settings.correctionApiKey));
+      .setCorrectionEnabled(!!(settings.correctionEnabled && settings.openaiApiKey));
     useVoiceRecordingStore.getState().setConfigured(isConfigured);
     return isConfigured;
   }

--- a/src/services/__tests__/VoiceRecordingService.adversarial.test.ts
+++ b/src/services/__tests__/VoiceRecordingService.adversarial.test.ts
@@ -154,8 +154,7 @@ const runtime = vi.hoisted(() => ({
     getSettings: vi.fn<
       () => Promise<{
         enabled: boolean;
-        deepgramApiKey: string;
-        correctionApiKey: string;
+        openaiApiKey: string;
         correctionEnabled: boolean;
       }>
     >(),
@@ -278,8 +277,7 @@ function resetRuntime(): void {
 
   runtime.voiceInput.getSettings.mockResolvedValue({
     enabled: true,
-    deepgramApiKey: "dg-key",
-    correctionApiKey: "corr-key",
+    openaiApiKey: "sk-key",
     correctionEnabled: true,
   });
   runtime.voiceInput.checkMicPermission.mockImplementation(async () => {

--- a/src/services/__tests__/VoiceRecordingService.corrections.test.ts
+++ b/src/services/__tests__/VoiceRecordingService.corrections.test.ts
@@ -141,8 +141,7 @@ function buildElectronStub() {
     onStatus: vi.fn(() => () => {}),
     getSettings: vi.fn().mockResolvedValue({
       enabled: true,
-      deepgramApiKey: "dg-key",
-      correctionApiKey: "sk-key",
+      openaiApiKey: "sk-key",
       correctionEnabled: true,
     }),
     checkMicPermission: vi.fn().mockResolvedValue("granted"),

--- a/src/services/__tests__/VoiceRecordingService.test.ts
+++ b/src/services/__tests__/VoiceRecordingService.test.ts
@@ -103,8 +103,7 @@ function buildElectronStub() {
       onStatus: vi.fn(() => () => {}),
       getSettings: vi.fn().mockResolvedValue({
         enabled: true,
-        deepgramApiKey: "dg-key",
-        correctionApiKey: "",
+        openaiApiKey: "sk-key",
         correctionEnabled: false,
       }),
       checkMicPermission: vi.fn().mockResolvedValue("granted"),


### PR DESCRIPTION
## Summary

- Collapses `deepgramApiKey` and `correctionApiKey` into a single `openaiApiKey` field in voice input settings; the IPC validation channel is similarly collapsed from two into one, now validating against `api.openai.com/v1/models`
- `getVoiceSettings()` migrates legacy `sk-*` keys on first read (`correctionApiKey` first, then the first-gen `apiKey`), silently drops `deepgramApiKey`, and persists the cleaned object so legacy fields disappear from disk
- Settings UI now shows a single "OpenAI API Key" row; the AI Text Correction section no longer duplicates the key input

`VoiceTranscriptionService` still calls `createClient(openaiApiKey)` against Deepgram — the transport switch is deferred to #7831.

Resolves #7830

## Changes

- `electron/ipc/handlers/voiceInput.ts` — collapsed `VOICE_INPUT_VALIDATE_API_KEY` + `VOICE_INPUT_VALIDATE_CORRECTION_API_KEY` into one channel; added `getVoiceSettings()` migration logic
- `electron/ipc/channels.ts`, `shared/types/ipc/api.ts`, `shared/types/ipc/maps.ts` — removed the redundant correction-key channel
- `electron/store.ts` — `StoreSchema` updated for `openaiApiKey` and the previously-missing `resolveFileLinks`
- `src/components/Settings/VoiceInputSettingsTab.tsx` — single key row, no duplication in the correction section
- `src/services/VoiceRecordingService.ts`, `electron/services/VoiceTranscriptionService.ts` — updated to read `openaiApiKey`

## Testing

- Added 5 migration tests covering `sk-*` carry-over, `deepgramApiKey` drop, idempotency, and no-op when no legacy fields are present
- All 109 voice-input tests pass; typecheck, lint, format, and build are clean