### PR TITLE
feat(voice): replace Deepgram client with OpenAI realtime WS

### DIFF
--- a/electron/ipc/handlers/__tests__/voiceInput.paragraph.test.ts
+++ b/electron/ipc/handlers/__tests__/voiceInput.paragraph.test.ts
@@ -90,7 +90,7 @@ vi.mock("../../../store.js", () => ({
           customDictionary: [],
           correctionCustomInstructions: "",
           language: "en",
-          transcriptionModel: "nova-3",
+          transcriptionModel: "gpt-realtime-whisper",
           paragraphingStrategy: "spoken-command",
           resolveFileLinks: true,
         };
@@ -99,12 +99,6 @@ vi.mock("../../../store.js", () => ({
     }),
     set: vi.fn(),
   },
-}));
-
-vi.mock("../../../services/voiceContextKeyterms.js", () => ({
-  assembleKeyterms: vi.fn(({ customDictionary }: { customDictionary: string[] }) =>
-    Promise.resolve(customDictionary)
-  ),
 }));
 
 vi.mock("../../channels.js", () => ({
@@ -249,7 +243,7 @@ describe("getVoiceSettings migration", () => {
       correctionApiKey: "sk-correction",
       language: "en",
       customDictionary: [],
-      transcriptionModel: "nova-3",
+      transcriptionModel: "gpt-realtime-whisper",
       correctionEnabled: false,
       correctionModel: "gpt-5-mini",
       correctionCustomInstructions: "",

--- a/electron/ipc/handlers/voiceInput.ts
+++ b/electron/ipc/handlers/voiceInput.ts
@@ -57,9 +57,13 @@ export function getVoiceSettings(): VoiceInputSettings {
     }
   }
 
+  // Migrate legacy Deepgram model values ('nova-3' / 'nova-2') to the unified OpenAI model.
+  const staleModel = merged.transcriptionModel !== "gpt-realtime-whisper";
+  if (staleModel) merged.transcriptionModel = "gpt-realtime-whisper";
+
   // Persist the cleaned object on first read after upgrade so the legacy
   // fields disappear from disk. `store.set` with a full object replaces.
-  if (apiKey !== undefined || deepgramApiKey !== undefined || correctionApiKey !== undefined) {
+  if (apiKey !== undefined || deepgramApiKey !== undefined || correctionApiKey !== undefined || staleModel) {
     store.set("voiceInput", merged);
   }
 

--- a/electron/ipc/handlers/voiceInput.ts
+++ b/electron/ipc/handlers/voiceInput.ts
@@ -7,8 +7,7 @@ import { VoiceTranscriptionService } from "../../services/VoiceTranscriptionServ
 import { VoiceCorrectionService } from "../../services/VoiceCorrectionService.js";
 import type { HandlerDependencies, IpcContext } from "../types.js";
 import type { VoiceInputSettings } from "../../../shared/types/ipc/api.js";
-import { logDebug, logWarn } from "../../utils/logger.js";
-import { assembleKeyterms } from "../../services/voiceContextKeyterms.js";
+import { logDebug } from "../../utils/logger.js";
 import { applyDictationCommands } from "../../services/voiceDictationCommands.js";
 import { getAppWebContents } from "../../window/webContentsRegistry.js";
 import { voiceFileLinkResolver } from "../../services/VoiceFileLinkResolver.js";
@@ -26,7 +25,7 @@ const VOICE_INPUT_DEFAULTS: VoiceInputSettings = {
   openaiApiKey: "",
   language: "en",
   customDictionary: [],
-  transcriptionModel: "nova-3",
+  transcriptionModel: "gpt-realtime-whisper",
   correctionEnabled: false,
   correctionModel: "gpt-5-mini",
   correctionCustomInstructions: "",
@@ -201,22 +200,6 @@ export function registerVoiceInputHandlers(deps: HandlerDependencies): () => voi
     // Capture project info at session start.
     sessionProjectInfo = getProjectInfo();
 
-    // Assemble dynamic keyterms from project context (branch, terminal output, etc.)
-    let sessionSettings = settings;
-    try {
-      const assembledKeyterms = await assembleKeyterms({
-        customDictionary: settings.customDictionary,
-        projectName: sessionProjectInfo.name,
-        projectPath: sessionProjectInfo.path,
-        ptyClient: deps.ptyClient,
-      });
-      sessionSettings = { ...settings, customDictionary: assembledKeyterms };
-    } catch (err) {
-      logWarn("[VoiceInput] Failed to assemble dynamic keyterms, using static dictionary", {
-        error: (err as Error).message,
-      });
-    }
-
     const unsubscribe = svc.onEvent((voiceEvent) => {
       const win = deps.mainWindow;
       if (!win || win.isDestroyed()) return;
@@ -228,20 +211,18 @@ export function registerVoiceInputHandlers(deps: HandlerDependencies): () => voi
         const liveSettings = getVoiceSettings();
 
         // OpenAI Realtime emits spoken dictation commands ("new paragraph",
-        // "period", etc.) as literal text. Deepgram dictation mode rewrites
-        // them upstream; here we reproduce that behavior post-hoc, gated on
-        // the session-snapshotted paragraphing strategy (matches the
-        // transcription-settings convention documented at handleStart).
+        // "period", etc.) as literal text. applyDictationCommands rewrites
+        // them post-hoc to \n\n / "." / \n etc., gated on the session-
+        // snapshotted paragraphing strategy.
         const processedText =
           settings.paragraphingStrategy === "spoken-command"
             ? applyDictationCommands(rawText)
             : rawText;
 
         // Split on \n\n and emit one complete event per non-empty part with a
-        // paragraph_boundary between them — mirrors the Deepgram path in
-        // VoiceTranscriptionService.emitCompleteWithParagraphDetection.
-        // .filter(Boolean) ensures command-only utterances (e.g. "new paragraph"
-        // alone produces "\n\n" → ["", ""]) emit nothing, consistent with Deepgram.
+        // paragraph_boundary between them. .filter(Boolean) ensures command-
+        // only utterances (e.g. "new paragraph" alone → "\n\n" → ["", ""])
+        // emit nothing.
         const parts = processedText
           .split(/\n\n+/)
           .map((p) => p.trim())
@@ -324,7 +305,7 @@ export function registerVoiceInputHandlers(deps: HandlerDependencies): () => voi
     ctx.event.sender.once("destroyed", onDestroyed);
     activeDestroyListener = { sender: ctx.event.sender, fn: onDestroyed };
 
-    const result = await svc.start(sessionSettings);
+    const result = await svc.start(settings);
     if (!result.ok) {
       // Failed to start — clean up subscription immediately
       if (activeEventUnsubscribe === unsubscribe) {
@@ -347,7 +328,8 @@ export function registerVoiceInputHandlers(deps: HandlerDependencies): () => voi
     const controller = sessionController;
 
     if (service) {
-      // Drain Deepgram first (waits for pending transcriptions, fires remaining complete events).
+      // Drain the transcription service first (waits for pending transcriptions,
+      // fires remaining complete events).
       await service.stopGracefully();
     }
 

--- a/electron/ipc/handlers/voiceInput.ts
+++ b/electron/ipc/handlers/voiceInput.ts
@@ -63,7 +63,12 @@ export function getVoiceSettings(): VoiceInputSettings {
 
   // Persist the cleaned object on first read after upgrade so the legacy
   // fields disappear from disk. `store.set` with a full object replaces.
-  if (apiKey !== undefined || deepgramApiKey !== undefined || correctionApiKey !== undefined || staleModel) {
+  if (
+    apiKey !== undefined ||
+    deepgramApiKey !== undefined ||
+    correctionApiKey !== undefined ||
+    staleModel
+  ) {
     store.set("voiceInput", merged);
   }
 

--- a/electron/preload.cts
+++ b/electron/preload.cts
@@ -2322,7 +2322,7 @@ const api: ElectronAPI = {
         openaiApiKey: string;
         language: string;
         customDictionary: string[];
-        transcriptionModel: "nova-3" | "nova-2";
+        transcriptionModel: "gpt-realtime-whisper";
         correctionEnabled: boolean;
         correctionModel: "gpt-5-nano" | "gpt-5-mini";
         correctionCustomInstructions: string;

--- a/electron/services/VoiceTranscriptionService.ts
+++ b/electron/services/VoiceTranscriptionService.ts
@@ -1,3 +1,4 @@
+import WebSocket from "ws";
 import type { VoiceInputSettings, VoiceInputStatus } from "../../shared/types/ipc/api.js";
 import { formatErrorMessage } from "../../shared/utils/errorMessage.js";
 import { logDebug, logInfo, logWarn, logError } from "../utils/logger.js";
@@ -8,6 +9,7 @@ const OPENAI_REALTIME_URL = "wss://api.openai.com/v1/realtime?model=gpt-realtime
 const OPENAI_TRANSCRIPTION_MODEL = "gpt-realtime-whisper";
 const CONNECT_TIMEOUT_MS = 10_000;
 const DRAIN_TIMEOUT_MS = 3_000;
+const DRAIN_GRACE_MS = 100;
 const PRE_CONNECT_BUFFER_MAX = 100;
 
 export interface CorrectionWord {
@@ -33,23 +35,11 @@ export type VoiceTranscriptionEvent =
 
 type VoiceStartResult = { ok: true } | { ok: false; error: string };
 
-// The OpenAI realtime endpoint speaks the WHATWG WebSocket interface; we use
-// Node 22's global `WebSocket` (available in Electron 41's main process) with
-// custom headers via the third constructor argument — a Node-only extension.
-interface OpenAIRealtimeSocket {
-  readonly readyState: number;
-  send(data: string): void;
-  close(code?: number): void;
-  onopen: (() => void) | null;
-  onmessage: ((event: { data: string | ArrayBufferLike | Buffer }) => void) | null;
-  onerror: ((event: { message?: string; error?: unknown }) => void) | null;
-  onclose: ((event: { code?: number; reason?: string }) => void) | null;
-}
-type WebSocketConstructor = new (
-  url: string,
-  protocols: string[] | undefined,
-  options: { headers: Record<string, string> }
-) => OpenAIRealtimeSocket;
+// We use the `ws` package rather than Node 22's global `WebSocket`. The
+// WHATWG spec exposes only `(url, protocols?)` — its constructor silently
+// discards any third options argument, so custom upgrade headers cannot be
+// sent. The `ws` package accepts a 2-arg `(url, options)` form with full
+// header support, which is also what the openai SDK uses internally.
 
 const STUB_CONFIDENCE: SegmentConfidence = {
   minConfidence: 1.0,
@@ -59,7 +49,7 @@ const STUB_CONFIDENCE: SegmentConfidence = {
 };
 
 export class VoiceTranscriptionService {
-  private connection: OpenAIRealtimeSocket | null = null;
+  private connection: WebSocket | null = null;
   private sessionId = 0;
   private connectTimeout: ReturnType<typeof setTimeout> | null = null;
   private listeners: Set<(event: VoiceTranscriptionEvent) => void> = new Set();
@@ -71,6 +61,7 @@ export class VoiceTranscriptionService {
 
   private drainResolve: (() => void) | null = null;
   private drainTimeout: ReturnType<typeof setTimeout> | null = null;
+  private drainGraceTimer: ReturnType<typeof setTimeout> | null = null;
   private drainPromise: Promise<void> | null = null;
   private isDraining = false;
 
@@ -140,19 +131,9 @@ export class VoiceTranscriptionService {
     return new Promise((resolve) => {
       this.pendingStart = { sessionId: mySessionId, resolve };
 
-      const WS = (globalThis as unknown as { WebSocket?: WebSocketConstructor }).WebSocket;
-      if (!WS) {
-        const message = "WebSocket is not available in this runtime";
-        logError(`${P} ${message}`);
-        this.emit({ type: "error", message });
-        this.emit({ type: "status", status: "error" });
-        this.settlePendingStart(mySessionId, { ok: false, error: message });
-        return;
-      }
-
-      let connection: OpenAIRealtimeSocket;
+      let connection: WebSocket;
       try {
-        connection = new WS(OPENAI_REALTIME_URL, undefined, {
+        connection = new WebSocket(OPENAI_REALTIME_URL, {
           headers: {
             Authorization: `Bearer ${settings.openaiApiKey}`,
             "OpenAI-Beta": "realtime=v1",
@@ -177,6 +158,11 @@ export class VoiceTranscriptionService {
         this.connectTimeout = null;
         logError(`${P} Connection timed out (${CONNECT_TIMEOUT_MS}ms)`);
         if (this.sessionId === mySessionId) {
+          try {
+            connection.close();
+          } catch {
+            // Ignore close errors
+          }
           this.cleanupConnection();
           this.emit({ type: "error", message: "Connection timed out" });
           this.emit({ type: "status", status: "error" });
@@ -184,7 +170,7 @@ export class VoiceTranscriptionService {
         }
       }, CONNECT_TIMEOUT_MS);
 
-      connection.onopen = () => {
+      connection.on("open", () => {
         if (this.sessionId !== mySessionId) {
           logWarn(`${P} Session expired during connect, closing`);
           try {
@@ -224,16 +210,18 @@ export class VoiceTranscriptionService {
           logError(`${P} ${message}`);
           this.handleFatalError(mySessionId, message);
         }
-      };
+      });
 
-      connection.onmessage = (event) => {
+      connection.on("message", (data) => {
         if (this.sessionId !== mySessionId) return;
         const raw =
-          typeof event.data === "string"
-            ? event.data
-            : event.data instanceof Buffer
-              ? event.data.toString("utf8")
-              : Buffer.from(event.data as ArrayBufferLike).toString("utf8");
+          typeof data === "string"
+            ? data
+            : Buffer.isBuffer(data)
+              ? data.toString("utf8")
+              : Array.isArray(data)
+                ? Buffer.concat(data).toString("utf8")
+                : Buffer.from(data as ArrayBuffer).toString("utf8");
 
         let parsed: Record<string, unknown>;
         try {
@@ -245,22 +233,23 @@ export class VoiceTranscriptionService {
 
         const type = typeof parsed.type === "string" ? parsed.type : "";
         this.handleServerEvent(mySessionId, type, parsed);
-      };
+      });
 
-      connection.onerror = (event) => {
+      connection.on("error", (err) => {
         this.clearConnectTimeout();
         if (this.sessionId !== mySessionId) return;
-        const inner = (event as { error?: unknown; message?: string })?.error;
-        const fallback = event?.message ?? "WebSocket error";
-        const message = formatErrorMessage(inner ?? event, fallback);
+        const message = formatErrorMessage(err, "WebSocket error");
         logError(`${P} WebSocket error`, { message });
         this.handleFatalError(mySessionId, message);
-      };
+      });
 
-      connection.onclose = (event) => {
+      connection.on("close", (code, reason) => {
         this.clearConnectTimeout();
         if (this.sessionId !== mySessionId) return;
-        logInfo(`${P} WebSocket closed`, { code: event?.code, reason: event?.reason });
+        logInfo(`${P} WebSocket closed`, {
+          code,
+          reason: Buffer.isBuffer(reason) ? reason.toString("utf8") : String(reason ?? ""),
+        });
         this.cleanupConnection();
         this.settlePendingStart(mySessionId, { ok: false, error: "Connection closed" });
         if (this.isDraining) {
@@ -268,7 +257,7 @@ export class VoiceTranscriptionService {
         } else {
           this.emit({ type: "status", status: "idle" });
         }
-      };
+      });
     });
   }
 
@@ -321,7 +310,12 @@ export class VoiceTranscriptionService {
           this.emit({ type: "complete", text: transcript, confidence: { ...STUB_CONFIDENCE } });
         }
         if (this.isDraining) {
-          this.settleDrain();
+          // server_vad can auto-commit items mid-session; the first `completed`
+          // we observe during drain may belong to one of those, with our own
+          // commit's transcript still in flight. Defer settling by a short
+          // grace period and reset it on every subsequent `completed` so the
+          // late arrival joins the same drain.
+          this.scheduleDrainGrace();
         }
         return;
       }
@@ -415,6 +409,20 @@ export class VoiceTranscriptionService {
       clearTimeout(this.drainTimeout);
       this.drainTimeout = null;
     }
+    if (this.drainGraceTimer !== null) {
+      clearTimeout(this.drainGraceTimer);
+      this.drainGraceTimer = null;
+    }
+  }
+
+  private scheduleDrainGrace(): void {
+    if (this.drainGraceTimer !== null) {
+      clearTimeout(this.drainGraceTimer);
+    }
+    this.drainGraceTimer = setTimeout(() => {
+      this.drainGraceTimer = null;
+      this.settleDrain();
+    }, DRAIN_GRACE_MS);
   }
 
   private settleDrain(): void {

--- a/electron/services/VoiceTranscriptionService.ts
+++ b/electron/services/VoiceTranscriptionService.ts
@@ -1,11 +1,14 @@
-import { createClient, LiveTranscriptionEvents } from "@deepgram/sdk";
-import type { ListenLiveClient, LiveMetadataEvent, LiveTranscriptionEvent } from "@deepgram/sdk";
 import type { VoiceInputSettings, VoiceInputStatus } from "../../shared/types/ipc/api.js";
-import { CONFIDENCE_TAG_THRESHOLD } from "../../shared/config/voiceCorrection.js";
 import { formatErrorMessage } from "../../shared/utils/errorMessage.js";
 import { logDebug, logInfo, logWarn, logError } from "../utils/logger.js";
 
 const P = "[VoiceTranscription]";
+
+const OPENAI_REALTIME_URL = "wss://api.openai.com/v1/realtime?model=gpt-realtime-whisper";
+const OPENAI_TRANSCRIPTION_MODEL = "gpt-realtime-whisper";
+const CONNECT_TIMEOUT_MS = 10_000;
+const DRAIN_TIMEOUT_MS = 3_000;
+const PRE_CONNECT_BUFFER_MAX = 100;
 
 export interface CorrectionWord {
   word: string;
@@ -30,11 +33,35 @@ export type VoiceTranscriptionEvent =
 
 type VoiceStartResult = { ok: true } | { ok: false; error: string };
 
+// The OpenAI realtime endpoint speaks the WHATWG WebSocket interface; we use
+// Node 22's global `WebSocket` (available in Electron 41's main process) with
+// custom headers via the third constructor argument — a Node-only extension.
+interface OpenAIRealtimeSocket {
+  readonly readyState: number;
+  send(data: string): void;
+  close(code?: number): void;
+  onopen: (() => void) | null;
+  onmessage: ((event: { data: string | ArrayBufferLike | Buffer }) => void) | null;
+  onerror: ((event: { message?: string; error?: unknown }) => void) | null;
+  onclose: ((event: { code?: number; reason?: string }) => void) | null;
+}
+type WebSocketConstructor = new (
+  url: string,
+  protocols: string[] | undefined,
+  options: { headers: Record<string, string> }
+) => OpenAIRealtimeSocket;
+
+const STUB_CONFIDENCE: SegmentConfidence = {
+  minConfidence: 1.0,
+  wordCount: 0,
+  uncertainWords: [],
+  words: [],
+};
+
 export class VoiceTranscriptionService {
-  private connection: ListenLiveClient | null = null;
+  private connection: OpenAIRealtimeSocket | null = null;
   private sessionId = 0;
   private connectTimeout: ReturnType<typeof setTimeout> | null = null;
-  private keepAliveInterval: ReturnType<typeof setInterval> | null = null;
   private listeners: Set<(event: VoiceTranscriptionEvent) => void> = new Set();
   private pendingStart: { sessionId: number; resolve: (result: VoiceStartResult) => void } | null =
     null;
@@ -47,18 +74,12 @@ export class VoiceTranscriptionService {
   private drainPromise: Promise<void> | null = null;
   private isDraining = false;
 
-  /** Tracks accumulated is_final segments for the current utterance. */
-  private utteranceSegments: string[] = [];
-  /** Tracks per-segment confidence for the current utterance. */
-  private utteranceConfidenceSegments: SegmentConfidence[] = [];
-  /** Total text emitted as delta events for the current utterance (for incremental diffs). */
+  /** Cumulative delta text since the last complete event — used for incremental diffs. */
   private liveText = "";
-  /**
-   * When true, all transcript events for the current Deepgram utterance are suppressed
-   * until the next speech_final or UtteranceEnd clears this flag. Set by
-   * commitParagraphBoundary() after the in-flight utterance text has been consumed.
-   */
-  private _suppressingUtterance = false;
+
+  private audioChunkCount = 0;
+  private staleChunkWarned = false;
+  private preConnectBufferOverflowWarned = false;
 
   onEvent(listener: (event: VoiceTranscriptionEvent) => void): () => void {
     this.listeners.add(listener);
@@ -66,18 +87,15 @@ export class VoiceTranscriptionService {
   }
 
   /**
-   * Captures any in-flight utterance text accumulated so far (from deltas / is_final segments),
-   * resets utterance state, and suppresses subsequent Deepgram finalization events for that
-   * utterance. Call this before flushing the paragraph buffer on a manual Enter keypress so
-   * that text spoken before the paragraph break is captured into the correct paragraph and
-   * late speech_final / UtteranceEnd events cannot overwrite the committed newline.
+   * Clears any in-flight live-delta state so the next paragraph starts fresh.
+   * Called when the user presses Enter mid-utterance; the renderer has already
+   * captured the displayed text, so the service just needs to forget it. Audio
+   * keeps streaming and the next `completed` event will reflect speech after
+   * the boundary. We do NOT send `input_audio_buffer.commit` here — that would
+   * disrupt the active server_vad turn.
    */
   commitParagraphBoundary(): void {
-    const text = (this.liveText || this.utteranceSegments.join(" ")).trim();
-    this.resetUtteranceState();
-    if (text) {
-      this._suppressingUtterance = true;
-    }
+    this.liveText = "";
   }
 
   private emit(event: VoiceTranscriptionEvent): void {
@@ -90,13 +108,6 @@ export class VoiceTranscriptionService {
     if (this.connectTimeout !== null) {
       clearTimeout(this.connectTimeout);
       this.connectTimeout = null;
-    }
-  }
-
-  private clearKeepAliveInterval(): void {
-    if (this.keepAliveInterval !== null) {
-      clearInterval(this.keepAliveInterval);
-      this.keepAliveInterval = null;
     }
   }
 
@@ -122,148 +133,134 @@ export class VoiceTranscriptionService {
     this.sessionId = mySessionId;
     this.isReady = false;
     this.preConnectBuffer = [];
-    this.resetUtteranceState();
+    this.liveText = "";
 
     this.emit({ type: "status", status: "connecting" });
 
     return new Promise((resolve) => {
       this.pendingStart = { sessionId: mySessionId, resolve };
 
-      const keyterms = settings.customDictionary;
-      const deepgram = createClient(settings.openaiApiKey);
+      const WS = (globalThis as unknown as { WebSocket?: WebSocketConstructor }).WebSocket;
+      if (!WS) {
+        const message = "WebSocket is not available in this runtime";
+        logError(`${P} ${message}`);
+        this.emit({ type: "error", message });
+        this.emit({ type: "status", status: "error" });
+        this.settlePendingStart(mySessionId, { ok: false, error: message });
+        return;
+      }
 
-      logDebug(`${P} Opening Deepgram live connection`, {
-        model: settings.transcriptionModel || "nova-3",
-        language: settings.language || "en",
-        keyterms: keyterms.length,
-      });
-
-      // Paragraphing strategy controls which Deepgram features are enabled:
-      //   "spoken-command" (default): Deepgram Dictation mode — the user says "new paragraph"
-      //     and Deepgram intercepts it, inserting \n\n into the transcript text. This is the
-      //     reliable live-streaming mechanism. `paragraphs: true` was evaluated and rejected
-      //     because it populates a JSON object rather than injecting \n\n into transcript text.
-      //   "manual": No dictation mode; paragraph breaks come from the Enter key only.
-      // Both modes use endpointing: 800ms (the sweet spot for dictation — 500ms fragments
-      // speech mid-thought; 1500ms feels sluggish) with utterance_end_ms: 1000ms as fallback.
-      // Note: Deepgram Dictation is documented as English-only. We only enable it when the
-      // session language is English; non-English sessions fall back to manual-Enter paragraphing.
-      const isEnglish = (settings.language || "en") === "en";
-      const isSpokenCommand =
-        (settings.paragraphingStrategy ?? "spoken-command") === "spoken-command" && isEnglish;
-
-      const connection = deepgram.listen.live({
-        model: settings.transcriptionModel || "nova-3",
-        language: settings.language || "en",
-        smart_format: true,
-        interim_results: true,
-        endpointing: 800,
-        utterance_end_ms: 1000,
-        encoding: "linear16",
-        sample_rate: 24000,
-        ...(isSpokenCommand ? { dictation: true } : {}),
-        ...(keyterms.length > 0 ? { keyterm: keyterms } : {}),
-      });
+      let connection: OpenAIRealtimeSocket;
+      try {
+        connection = new WS(OPENAI_REALTIME_URL, undefined, {
+          headers: {
+            Authorization: `Bearer ${settings.openaiApiKey}`,
+            "OpenAI-Beta": "realtime=v1",
+          },
+        });
+      } catch (err) {
+        const message = formatErrorMessage(err, "Failed to open WebSocket");
+        logError(`${P} ${message}`);
+        this.emit({ type: "error", message });
+        this.emit({ type: "status", status: "error" });
+        this.settlePendingStart(mySessionId, { ok: false, error: message });
+        return;
+      }
 
       this.connection = connection;
+      logDebug(`${P} Opening OpenAI realtime WebSocket`, {
+        model: OPENAI_TRANSCRIPTION_MODEL,
+        language: settings.language || "en",
+      });
 
       this.connectTimeout = setTimeout(() => {
         this.connectTimeout = null;
-        logError(`${P} Connection timed out (10s)`);
+        logError(`${P} Connection timed out (${CONNECT_TIMEOUT_MS}ms)`);
         if (this.sessionId === mySessionId) {
           this.cleanupConnection();
           this.emit({ type: "error", message: "Connection timed out" });
           this.emit({ type: "status", status: "error" });
           this.settlePendingStart(mySessionId, { ok: false, error: "Connection timed out" });
         }
-      }, 10000);
+      }, CONNECT_TIMEOUT_MS);
 
-      connection.on(LiveTranscriptionEvents.Open, () => {
-        this.clearConnectTimeout();
-        logInfo(`${P} Connection opened`);
-
+      connection.onopen = () => {
         if (this.sessionId !== mySessionId) {
           logWarn(`${P} Session expired during connect, closing`);
-          connection.requestClose();
+          try {
+            connection.close();
+          } catch {
+            // Ignore close errors
+          }
+          return;
+        }
+        logInfo(`${P} WebSocket opened, sending session.update`);
+        // TODO: pass `transcription.prompt` from settings once #7832 lands.
+        const sessionUpdate = {
+          type: "session.update",
+          session: {
+            type: "transcription",
+            audio: {
+              input: {
+                format: { type: "audio/pcm", rate: 24000 },
+                transcription: {
+                  model: OPENAI_TRANSCRIPTION_MODEL,
+                  language: settings.language || "en",
+                },
+                turn_detection: {
+                  type: "server_vad",
+                  threshold: 0.5,
+                  prefix_padding_ms: 300,
+                  silence_duration_ms: 500,
+                },
+              },
+            },
+          },
+        };
+        try {
+          connection.send(JSON.stringify(sessionUpdate));
+        } catch (err) {
+          const message = formatErrorMessage(err, "Failed to send session.update");
+          logError(`${P} ${message}`);
+          this.handleFatalError(mySessionId, message);
+        }
+      };
+
+      connection.onmessage = (event) => {
+        if (this.sessionId !== mySessionId) return;
+        const raw =
+          typeof event.data === "string"
+            ? event.data
+            : event.data instanceof Buffer
+              ? event.data.toString("utf8")
+              : Buffer.from(event.data as ArrayBufferLike).toString("utf8");
+
+        let parsed: Record<string, unknown>;
+        try {
+          parsed = JSON.parse(raw) as Record<string, unknown>;
+        } catch {
+          logWarn(`${P} Ignoring non-JSON message`);
           return;
         }
 
-        if (this.preConnectBuffer.length > 0) {
-          logInfo(`${P} Flushing ${this.preConnectBuffer.length} buffered audio chunks`);
-          for (const chunk of this.preConnectBuffer) {
-            connection.send(chunk as ArrayBuffer);
-          }
-          this.preConnectBuffer = [];
-        }
+        const type = typeof parsed.type === "string" ? parsed.type : "";
+        this.handleServerEvent(mySessionId, type, parsed);
+      };
 
-        this.keepAliveInterval = setInterval(() => {
-          if (this.connection === connection) {
-            connection.keepAlive();
-          }
-        }, 8000);
-
-        this.isReady = true;
-        this.emit({ type: "status", status: "recording" });
-        this.settlePendingStart(mySessionId, { ok: true });
-      });
-
-      connection.on(LiveTranscriptionEvents.Metadata, (data: LiveMetadataEvent) => {
-        if (this.sessionId !== mySessionId) return;
-        try {
-          logInfo(`${P} Metadata received`, { request_id: data.request_id });
-        } catch {
-          logDebug(`${P} Failed to process Metadata event`);
-        }
-      });
-
-      connection.on(LiveTranscriptionEvents.Transcript, (data: LiveTranscriptionEvent) => {
-        if (this.sessionId !== mySessionId) return;
-        try {
-          const alt = data.channel?.alternatives?.[0];
-          const transcript: string = alt?.transcript ?? "";
-          const isFinal: boolean = data.is_final ?? false;
-          const speechFinal: boolean = data.speech_final ?? false;
-          const words: Array<{ word: string; confidence: number; start?: number; end?: number }> =
-            isFinal
-              ? (((alt as Record<string, unknown>)?.words as Array<{
-                  word: string;
-                  confidence: number;
-                  start?: number;
-                  end?: number;
-                }>) ?? [])
-              : [];
-
-          logDebug(`${P} Transcript event`, { isFinal, speechFinal, len: transcript.length });
-
-          this.handleTranscript(transcript, isFinal, speechFinal, words);
-        } catch {
-          logWarn(`${P} Failed to process transcript event`);
-        }
-      });
-
-      connection.on(LiveTranscriptionEvents.UtteranceEnd, () => {
-        if (this.sessionId !== mySessionId) return;
-        logDebug(`${P} UtteranceEnd — flushing accumulated segments`);
-        this.flushUtterance();
-      });
-
-      connection.on(LiveTranscriptionEvents.Error, (err: Error) => {
+      connection.onerror = (event) => {
         this.clearConnectTimeout();
         if (this.sessionId !== mySessionId) return;
-        const errObj = err as { error?: string };
-        const message = formatErrorMessage(err, errObj?.error ?? "Deepgram error");
-        logError(`${P} Connection error`, { message });
-        this.cleanupConnection();
-        this.emit({ type: "error", message });
-        this.emit({ type: "status", status: "error" });
-        this.settlePendingStart(mySessionId, { ok: false, error: message });
-        this.settleDrain();
-      });
+        const inner = (event as { error?: unknown; message?: string })?.error;
+        const fallback = event?.message ?? "WebSocket error";
+        const message = formatErrorMessage(inner ?? event, fallback);
+        logError(`${P} WebSocket error`, { message });
+        this.handleFatalError(mySessionId, message);
+      };
 
-      connection.on(LiveTranscriptionEvents.Close, () => {
+      connection.onclose = (event) => {
         this.clearConnectTimeout();
-        logInfo(`${P} Connection closed`);
         if (this.sessionId !== mySessionId) return;
+        logInfo(`${P} WebSocket closed`, { code: event?.code, reason: event?.reason });
         this.cleanupConnection();
         this.settlePendingStart(mySessionId, { ok: false, error: "Connection closed" });
         if (this.isDraining) {
@@ -271,217 +268,95 @@ export class VoiceTranscriptionService {
         } else {
           this.emit({ type: "status", status: "idle" });
         }
-      });
+      };
     });
   }
 
-  private emitCompleteWithParagraphDetection(text: string, confidence?: SegmentConfidence): void {
-    // In spoken-command mode, Deepgram Dictation intercepts "new paragraph" and
-    // injects \n\n into the transcript text. Split on these markers so each paragraph
-    // is emitted separately with a paragraph_boundary event between them.
-    // Only emit boundaries between non-empty parts to avoid spurious events
-    // from leading/trailing \n\n (e.g. "para\n\n" or "\n\npara").
-    const parts = text
-      .split(/\n\n+/)
-      .map((p) => p.trim())
-      .filter(Boolean);
-    for (let i = 0; i < parts.length; i++) {
-      // Confidence applies to the first part; subsequent parts after paragraph
-      // splits don't have word-level alignment so omit confidence.
-      this.emit({
-        type: "complete",
-        text: parts[i],
-        ...(i === 0 && confidence ? { confidence } : {}),
-      });
-      if (i < parts.length - 1) {
-        this.emit({ type: "paragraph_boundary" });
-      }
-    }
+  private handleFatalError(mySessionId: number, message: string): void {
+    this.cleanupConnection();
+    this.emit({ type: "error", message });
+    this.emit({ type: "status", status: "error" });
+    this.settlePendingStart(mySessionId, { ok: false, error: message });
+    this.settleDrain();
   }
 
-  private handleTranscript(
-    transcript: string,
-    isFinal: boolean,
-    speechFinal: boolean,
-    words: Array<{ word: string; confidence: number }> = []
+  private handleServerEvent(
+    mySessionId: number,
+    type: string,
+    payload: Record<string, unknown>
   ): void {
-    if (this._suppressingUtterance) {
-      if (speechFinal) {
-        this._suppressingUtterance = false;
-        this.resetUtteranceState();
+    switch (type) {
+      case "session.created":
+        logDebug(`${P} session.created`);
+        return;
+
+      case "session.updated":
+        this.clearConnectTimeout();
+        logInfo(`${P} session.updated — session ready`);
+        if (this.preConnectBuffer.length > 0 && this.connection) {
+          logInfo(`${P} Flushing ${this.preConnectBuffer.length} buffered audio chunks`);
+          for (const chunk of this.preConnectBuffer) {
+            this.sendAudioJson(chunk);
+          }
+          this.preConnectBuffer = [];
+        }
+        this.isReady = true;
+        this.emit({ type: "status", status: "recording" });
+        this.settlePendingStart(mySessionId, { ok: true });
+        return;
+
+      case "conversation.item.input_audio_transcription.delta": {
+        const delta = typeof payload.delta === "string" ? payload.delta : "";
+        if (!delta) return;
+        this.emit({ type: "delta", text: delta });
+        this.liveText += delta;
+        return;
+      }
+
+      case "conversation.item.input_audio_transcription.completed": {
+        const transcript =
+          typeof payload.transcript === "string" ? payload.transcript.trim() : "";
+        this.liveText = "";
+        if (transcript) {
+          this.emit({ type: "complete", text: transcript, confidence: { ...STUB_CONFIDENCE } });
+        }
         if (this.isDraining) {
           this.settleDrain();
         }
+        return;
       }
-      return;
-    }
 
-    if (speechFinal) {
-      if (words.length > 0) {
-        this.utteranceConfidenceSegments.push(this.computeSegmentConfidence(words));
+      case "error": {
+        const errorPayload = payload.error as { message?: string; type?: string } | undefined;
+        const message = errorPayload?.message ?? "OpenAI realtime error";
+        logError(`${P} Server error event`, { message, type: errorPayload?.type });
+        this.handleFatalError(mySessionId, message);
+        return;
       }
-      const segments = [...this.utteranceSegments, transcript].filter((s) => s.trim());
-      const fullText = segments.join(" ").trim();
-      const confidence = this.mergeConfidence(this.utteranceConfidenceSegments);
-      this.resetUtteranceState();
 
-      if (fullText) {
-        this.emitCompleteWithParagraphDetection(fullText, confidence);
-      }
-      if (this.isDraining) {
-        this.settleDrain();
-      }
-    } else if (isFinal) {
-      const segConfidence = words.length > 0 ? this.computeSegmentConfidence(words) : undefined;
-
-      if (transcript.includes("\n\n")) {
-        if (segConfidence) {
-          this.utteranceConfidenceSegments.push(segConfidence);
-        }
-        this.handleIsFinalWithParagraphBoundary(transcript);
-      } else {
-        const segmentText = transcript.trim();
-        if (segmentText) {
-          const accumulated = [...this.utteranceSegments, segmentText].filter(Boolean).join(" ");
-          this.emitIncrementalDelta(accumulated);
-          this.utteranceSegments.push(segmentText);
-          if (segConfidence) {
-            this.utteranceConfidenceSegments.push(segConfidence);
-          }
-        }
-      }
-    } else {
-      if (!transcript) return;
-      const accumulated = [...this.utteranceSegments, transcript].filter(Boolean).join(" ");
-      this.emitIncrementalDelta(accumulated);
+      default:
+        logDebug(`${P} Unhandled server event`, { type });
     }
   }
 
-  private handleIsFinalWithParagraphBoundary(transcript: string): void {
-    const boundaryIdx = transcript.indexOf("\n\n");
-    const before = transcript.slice(0, boundaryIdx).trim();
-    const after = transcript
-      .slice(boundaryIdx)
-      .replace(/^\n\n+/, "")
-      .trim();
-
-    // Flush the paragraph that just ended: existing segments + any text before \n\n.
-    const completedSegments = [...this.utteranceSegments, ...(before ? [before] : [])].filter(
-      Boolean
-    );
-    const completedText = completedSegments.join(" ").trim();
-    const confidence = this.mergeConfidence(this.utteranceConfidenceSegments);
-    this.resetUtteranceState();
-
-    // Only emit a boundary when there is actually a completed paragraph to close.
-    // Suppress spurious boundaries (e.g. first-ever segment starts with \n\n) to
-    // avoid inserting a blank line into the renderer before any speech has arrived.
-    if (completedText) {
-      this.emit({ type: "complete", text: completedText, confidence });
-      this.emit({ type: "paragraph_boundary" });
-    }
-
-    // Begin accumulating the next paragraph with any text that follows the boundary.
-    // Do NOT emit it as complete yet — let speech_final/UtteranceEnd finalize it.
-    if (after) {
-      this.emitIncrementalDelta(after);
-      this.utteranceSegments.push(after);
-    }
+  private sendAudioJson(chunk: ArrayBuffer): void {
+    if (!this.connection) return;
+    const audio = Buffer.from(chunk).toString("base64");
+    this.connection.send(JSON.stringify({ type: "input_audio_buffer.append", audio }));
   }
-
-  private emitIncrementalDelta(accumulated: string): void {
-    if (accumulated.startsWith(this.liveText)) {
-      const newChars = accumulated.slice(this.liveText.length);
-      if (newChars) {
-        this.emit({ type: "delta", text: newChars });
-        this.liveText = accumulated;
-      }
-    } else if (!this.liveText) {
-      this.emit({ type: "delta", text: accumulated });
-      this.liveText = accumulated;
-    } else {
-      // Deepgram revised earlier text (non-prefix change). Update the baseline
-      // so future appends can still emit incremental deltas correctly.
-      this.liveText = accumulated;
-    }
-  }
-
-  private computeSegmentConfidence(
-    words: Array<{ word: string; confidence: number; start?: number; end?: number }>
-  ): SegmentConfidence {
-    if (words.length === 0) {
-      return { minConfidence: 1.0, wordCount: 0, uncertainWords: [], words: [] };
-    }
-    return {
-      minConfidence: Math.min(...words.map((w) => w.confidence)),
-      wordCount: words.length,
-      uncertainWords: words
-        .filter((w) => w.confidence < CONFIDENCE_TAG_THRESHOLD)
-        .map((w) => w.word),
-      words: words.map((w) => ({
-        word: w.word,
-        confidence: w.confidence,
-        ...(w.start !== undefined ? { start: w.start } : {}),
-        ...(w.end !== undefined ? { end: w.end } : {}),
-      })),
-    };
-  }
-
-  private mergeConfidence(segments: SegmentConfidence[]): SegmentConfidence {
-    if (segments.length === 0) {
-      return { minConfidence: 1.0, wordCount: 0, uncertainWords: [], words: [] };
-    }
-    return {
-      minConfidence: Math.min(...segments.map((s) => s.minConfidence)),
-      wordCount: segments.reduce((sum, s) => sum + s.wordCount, 0),
-      uncertainWords: segments.flatMap((s) => s.uncertainWords),
-      words: segments.flatMap((s) => s.words),
-    };
-  }
-
-  private flushUtterance(): void {
-    if (this._suppressingUtterance) {
-      this._suppressingUtterance = false;
-      this.resetUtteranceState();
-      if (this.isDraining) {
-        this.settleDrain();
-      }
-      return;
-    }
-
-    // Use liveText if set — it includes any pending interim transcript that has
-    // not yet received is_final=true (e.g. when UtteranceEnd fires without speech_final).
-    const fullText = (this.liveText || this.utteranceSegments.join(" ")).trim();
-    const confidence = this.mergeConfidence(this.utteranceConfidenceSegments);
-    this.resetUtteranceState();
-    if (fullText) {
-      this.emitCompleteWithParagraphDetection(fullText, confidence);
-    }
-    if (this.isDraining) {
-      this.settleDrain();
-    }
-  }
-
-  private resetUtteranceState(): void {
-    this.utteranceSegments = [];
-    this.utteranceConfidenceSegments = [];
-    this.liveText = "";
-  }
-
-  private audioChunkCount = 0;
-  private staleChunkWarned = false;
-  private preConnectBufferOverflowWarned = false;
 
   sendAudioChunk(chunk: ArrayBuffer): void {
     if (this.isDraining) return;
 
     if (!this.isReady || !this.connection) {
       if (this.connection || this.pendingStart) {
-        if (this.preConnectBuffer.length < 100) {
+        if (this.preConnectBuffer.length < PRE_CONNECT_BUFFER_MAX) {
           this.preConnectBuffer.push(chunk);
         } else if (!this.preConnectBufferOverflowWarned) {
           this.preConnectBufferOverflowWarned = true;
-          logWarn(`${P} Pre-connect buffer full (100 chunks), dropping audio`);
+          logWarn(
+            `${P} Pre-connect buffer full (${PRE_CONNECT_BUFFER_MAX} chunks), dropping audio`
+          );
         }
       } else if (!this.staleChunkWarned) {
         this.staleChunkWarned = true;
@@ -493,11 +368,10 @@ export class VoiceTranscriptionService {
     if (this.audioChunkCount <= 3 || this.audioChunkCount % 200 === 0) {
       logDebug(`${P} Sending audio chunk #${this.audioChunkCount}`, { bytes: chunk.byteLength });
     }
-    this.connection.send(chunk as ArrayBuffer);
+    this.sendAudioJson(chunk);
   }
 
   private cleanupConnection(): void {
-    this.clearKeepAliveInterval();
     this.connection = null;
     this.isReady = false;
   }
@@ -515,21 +389,20 @@ export class VoiceTranscriptionService {
     this.isReady = false;
     this.preConnectBuffer = [];
     this.clearConnectTimeout();
-    this.clearKeepAliveInterval();
     this.clearDrainTimeout();
     this.isDraining = false;
-    this._suppressingUtterance = false;
-    this.resetUtteranceState();
+    this.liveText = "";
     if (this.drainResolve) {
       this.drainResolve();
       this.drainResolve = null;
     }
+    this.drainPromise = null;
     if (pendingSessionId !== undefined) {
       this.settlePendingStart(pendingSessionId, { ok: false, error: "Voice session stopped" });
     }
     if (this.connection) {
       try {
-        this.connection.requestClose();
+        this.connection.close();
       } catch {
         // Ignore close errors
       }
@@ -577,10 +450,10 @@ export class VoiceTranscriptionService {
     this.emit({ type: "status", status: "finishing" });
 
     try {
-      this.connection.finish();
-      logDebug(`${P} Sent finalize to Deepgram`);
+      this.connection.send(JSON.stringify({ type: "input_audio_buffer.commit" }));
+      logDebug(`${P} Sent input_audio_buffer.commit`);
     } catch {
-      logWarn(`${P} Failed to send finalize, closing immediately`);
+      logWarn(`${P} Failed to send commit, closing immediately`);
       this.cleanupPreviousSession();
       this.emit({ type: "status", status: "idle" });
       return;
@@ -589,10 +462,9 @@ export class VoiceTranscriptionService {
     this.drainPromise = new Promise<void>((resolve) => {
       this.drainResolve = resolve;
       this.drainTimeout = setTimeout(() => {
-        logWarn(`${P} Drain timed out after 3s, force closing`);
-        this.flushUtterance();
+        logWarn(`${P} Drain timed out after ${DRAIN_TIMEOUT_MS}ms, force closing`);
         this.settleDrain();
-      }, 3000);
+      }, DRAIN_TIMEOUT_MS);
     });
 
     const sessionIdBeforeDrain = this.sessionId;

--- a/electron/services/VoiceTranscriptionService.ts
+++ b/electron/services/VoiceTranscriptionService.ts
@@ -303,8 +303,7 @@ export class VoiceTranscriptionService {
       }
 
       case "conversation.item.input_audio_transcription.completed": {
-        const transcript =
-          typeof payload.transcript === "string" ? payload.transcript.trim() : "";
+        const transcript = typeof payload.transcript === "string" ? payload.transcript.trim() : "";
         this.liveText = "";
         if (transcript) {
           this.emit({ type: "complete", text: transcript, confidence: { ...STUB_CONFIDENCE } });

--- a/electron/services/__tests__/StoreMigrations.test.ts
+++ b/electron/services/__tests__/StoreMigrations.test.ts
@@ -1520,7 +1520,7 @@ describe("MigrationRunner", () => {
           apiKey: "",
           language: "en",
           customDictionary: [],
-          transcriptionModel: "nova-3",
+          transcriptionModel: "gpt-realtime-whisper",
           correctionEnabled: false,
           correctionModel: "gpt-5-nano",
           correctionCustomInstructions: "",

--- a/electron/services/__tests__/VoiceTranscriptionService.integration.test.ts
+++ b/electron/services/__tests__/VoiceTranscriptionService.integration.test.ts
@@ -2,7 +2,7 @@ import { afterEach, describe, expect, it } from "vitest";
 import { VoiceTranscriptionService } from "../VoiceTranscriptionService.js";
 import type { VoiceTranscriptionEvent } from "../VoiceTranscriptionService.js";
 
-const DEEPGRAM_API_KEY = process.env.DEEPGRAM_API_KEY ?? "";
+const OPENAI_API_KEY = process.env.OPENAI_API_KEY ?? "";
 
 function delay(ms: number): Promise<void> {
   return new Promise((resolve) => setTimeout(resolve, ms));
@@ -15,8 +15,8 @@ describe("VoiceTranscriptionService integration", () => {
     service?.destroy();
   });
 
-  it.skipIf(!DEEPGRAM_API_KEY)(
-    "connects to Deepgram and session config is accepted",
+  it.skipIf(!OPENAI_API_KEY)(
+    "connects to OpenAI realtime and session config is accepted",
     async () => {
       service = new VoiceTranscriptionService();
 
@@ -25,10 +25,10 @@ describe("VoiceTranscriptionService integration", () => {
 
       const result = await service.start({
         enabled: true,
-        openaiApiKey: DEEPGRAM_API_KEY,
+        openaiApiKey: OPENAI_API_KEY,
         language: "en",
         customDictionary: [],
-        transcriptionModel: "nova-3",
+        transcriptionModel: "gpt-realtime-whisper",
         correctionEnabled: false,
         correctionModel: "gpt-5-mini",
         correctionCustomInstructions: "",

--- a/electron/services/__tests__/VoiceTranscriptionService.test.ts
+++ b/electron/services/__tests__/VoiceTranscriptionService.test.ts
@@ -112,6 +112,7 @@ vi.mock("ws", () => {
 
 // Import the service AFTER vi.mock so the mocked `ws` is used.
 const { VoiceTranscriptionService } = await import("../VoiceTranscriptionService.js");
+type VoiceTranscriptionServiceInstance = InstanceType<typeof VoiceTranscriptionService>;
 type VoiceTranscriptionEvent = import("../VoiceTranscriptionService.js").VoiceTranscriptionEvent;
 
 const BASE_SETTINGS: VoiceInputSettings = {
@@ -135,7 +136,7 @@ function latestInstance(): MockWebSocket {
 
 /** Advance the service through connect → ready. Returns the active mock socket. */
 async function bringSessionReady(
-  service: VoiceTranscriptionService,
+  service: VoiceTranscriptionServiceInstance,
   settings: VoiceInputSettings = BASE_SETTINGS
 ): Promise<{ socket: MockWebSocket; result: { ok: true } | { ok: false; error: string } }> {
   const startPromise = service.start(settings);
@@ -176,9 +177,7 @@ describe("VoiceTranscriptionService", () => {
     void service.start({ ...BASE_SETTINGS, openaiApiKey: "sk-abc" });
     await Promise.resolve();
     const socket = latestInstance();
-    expect(socket.url).toBe(
-      "wss://api.openai.com/v1/realtime?model=gpt-realtime-whisper"
-    );
+    expect(socket.url).toBe("wss://api.openai.com/v1/realtime?model=gpt-realtime-whisper");
     expect(socket.options.headers.Authorization).toBe("Bearer sk-abc");
     expect(socket.options.headers["OpenAI-Beta"]).toBe("realtime=v1");
     service.stop();
@@ -410,8 +409,9 @@ describe("VoiceTranscriptionService", () => {
     socket.simulateOpen();
     socket.simulateMessage("session.updated");
 
-    const audioCount = socket.sentJson().filter((p) => p.type === "input_audio_buffer.append")
-      .length;
+    const audioCount = socket
+      .sentJson()
+      .filter((p) => p.type === "input_audio_buffer.append").length;
     expect(audioCount).toBe(100);
     service.stop();
   });

--- a/electron/services/__tests__/VoiceTranscriptionService.test.ts
+++ b/electron/services/__tests__/VoiceTranscriptionService.test.ts
@@ -1,84 +1,107 @@
 import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
 import type { VoiceInputSettings } from "../../../shared/types/ipc/api.js";
+import { VoiceTranscriptionService } from "../VoiceTranscriptionService.js";
+import type { VoiceTranscriptionEvent } from "../VoiceTranscriptionService.js";
 
-const deepgramMock = vi.hoisted(() => {
-  const LiveTranscriptionEvents = {
-    Open: "open",
-    Close: "close",
-    Error: "error",
-    Metadata: "Metadata",
-    Transcript: "Results",
-    UtteranceEnd: "UtteranceEnd",
-  };
+// ── Mock WebSocket ────────────────────────────────────────────────────────────
+//
+// The service uses Node 22's global `WebSocket` (Electron 41 main process). We
+// stub the global so each test can drive the lifecycle (open / message / error
+// / close) deterministically. Constructor options (`{ headers }`) are captured
+// for header assertions; `sent` records the JSON payloads the service emits.
 
-  class MockConnection {
-    private handlers = new Map<string, Set<(...args: unknown[]) => void>>();
-    sent: Buffer[] = [];
-    finalized = false;
-    closed = false;
-    keepAliveCalled = 0;
+interface MockOptions {
+  headers: Record<string, string>;
+}
 
-    on(event: string, handler: (...args: unknown[]) => void) {
-      const listeners = this.handlers.get(event) ?? new Set();
-      listeners.add(handler);
-      this.handlers.set(event, listeners);
-      return this;
-    }
+class MockWebSocket {
+  static readonly CONNECTING = 0;
+  static readonly OPEN = 1;
+  static readonly CLOSING = 2;
+  static readonly CLOSED = 3;
 
-    emit(event: string, ...args: unknown[]) {
-      const listeners = this.handlers.get(event);
-      if (!listeners) return;
-      for (const handler of listeners) {
-        handler(...args);
-      }
-    }
+  url: string;
+  options: MockOptions;
+  readyState: number = MockWebSocket.CONNECTING;
+  sent: string[] = [];
+  closeCalls = 0;
+  closeCode?: number;
 
-    send(buf: Buffer) {
-      this.sent.push(buf);
-    }
+  onopen: (() => void) | null = null;
+  onmessage: ((event: { data: string }) => void) | null = null;
+  onerror: ((event: { message?: string; error?: unknown }) => void) | null = null;
+  onclose: ((event: { code?: number; reason?: string }) => void) | null = null;
 
-    finish() {
-      this.finalized = true;
-    }
-
-    requestClose() {
-      this.closed = true;
-      this.emit(LiveTranscriptionEvents.Close);
-    }
-
-    keepAlive() {
-      this.keepAliveCalled++;
-    }
+  constructor(url: string, _protocols: string[] | undefined, options: MockOptions) {
+    this.url = url;
+    this.options = options;
+    instances.push(this);
   }
 
-  const instances: MockConnection[] = [];
+  send(payload: string): void {
+    this.sent.push(payload);
+  }
 
-  const mockClient = {
-    listen: {
-      live: (_opts: unknown) => {
-        const conn = new MockConnection();
-        instances.push(conn);
-        return conn;
-      },
-    },
-  };
+  close(code?: number): void {
+    this.closeCalls++;
+    this.closeCode = code;
+    this.readyState = MockWebSocket.CLOSED;
+  }
 
-  return { LiveTranscriptionEvents, MockConnection, instances, mockClient };
-});
+  // Test helpers
+  simulateOpen(): void {
+    this.readyState = MockWebSocket.OPEN;
+    this.onopen?.();
+  }
 
-vi.mock("@deepgram/sdk", () => ({
-  createClient: () => deepgramMock.mockClient,
-  LiveTranscriptionEvents: deepgramMock.LiveTranscriptionEvents,
-}));
+  simulateMessage(type: string, payload: Record<string, unknown> = {}): void {
+    this.onmessage?.({ data: JSON.stringify({ type, ...payload }) });
+  }
 
-import { VoiceTranscriptionService } from "../VoiceTranscriptionService.js";
+  simulateRawMessage(data: string): void {
+    this.onmessage?.({ data });
+  }
+
+  simulateError(error?: unknown, message?: string): void {
+    this.onerror?.({ error, message });
+  }
+
+  simulateClose(code?: number, reason?: string): void {
+    this.readyState = MockWebSocket.CLOSED;
+    this.onclose?.({ code, reason });
+  }
+
+  sentJson(): Array<Record<string, unknown>> {
+    return this.sent.map((s) => JSON.parse(s) as Record<string, unknown>);
+  }
+}
+
+const instances: MockWebSocket[] = [];
+let throwOnConstruct = false;
+let constructError: Error | null = null;
+class ThrowingWebSocket {
+  constructor(_url: string, _protocols: string[] | undefined, _options: MockOptions) {
+    throw constructError ?? new Error("WebSocket construction failed");
+  }
+}
+
+const WS_FACTORY = function (
+  url: string,
+  protocols: string[] | undefined,
+  options: MockOptions
+): MockWebSocket | ThrowingWebSocket {
+  if (throwOnConstruct) {
+    return new ThrowingWebSocket(url, protocols, options);
+  }
+  return new MockWebSocket(url, protocols, options);
+} as unknown as typeof WebSocket;
 
 const BASE_SETTINGS: VoiceInputSettings = {
   enabled: true,
   openaiApiKey: "sk-test",
   language: "en",
   customDictionary: [],
-  transcriptionModel: "nova-3",
+  transcriptionModel: "gpt-realtime-whisper",
   correctionEnabled: false,
   correctionModel: "gpt-5-mini",
   correctionCustomInstructions: "",
@@ -86,66 +109,119 @@ const BASE_SETTINGS: VoiceInputSettings = {
   resolveFileLinks: true,
 };
 
-function makeTranscriptEvent(
-  transcript: string,
-  isFinal: boolean,
-  speechFinal: boolean,
-  words: Array<{ word: string; confidence: number }> = []
-): unknown {
-  return {
-    channel: { alternatives: [{ transcript, words }] },
-    is_final: isFinal,
-    speech_final: speechFinal,
-  };
+function latestInstance(): MockWebSocket {
+  const instance = instances.at(-1);
+  if (!instance) throw new Error("No MockWebSocket instance created");
+  return instance;
+}
+
+/** Advance the service through connect → ready. Returns the active mock socket. */
+async function bringSessionReady(
+  service: VoiceTranscriptionService,
+  settings: VoiceInputSettings = BASE_SETTINGS
+): Promise<{ socket: MockWebSocket; result: { ok: true } | { ok: false; error: string } }> {
+  const startPromise = service.start(settings);
+  // start() runs synchronously through to assigning pendingStart; allow the
+  // microtask queue to settle so the constructor + onopen wiring is in place.
+  await Promise.resolve();
+  const socket = latestInstance();
+  socket.simulateOpen();
+  socket.simulateMessage("session.updated");
+  const result = await startPromise;
+  return { socket, result };
 }
 
 describe("VoiceTranscriptionService", () => {
-  let originalLiveFn: (opts: unknown) => InstanceType<typeof deepgramMock.MockConnection>;
-
   beforeEach(() => {
-    deepgramMock.instances.length = 0;
-    // Save original listen.live so option-mapping tests can restore it
-    originalLiveFn = deepgramMock.mockClient.listen.live;
+    instances.length = 0;
+    throwOnConstruct = false;
+    constructError = null;
+    vi.stubGlobal("WebSocket", WS_FACTORY);
     vi.useFakeTimers();
   });
 
   afterEach(() => {
-    // Restore listen.live in case an option-mapping test replaced it
-    deepgramMock.mockClient.listen.live = originalLiveFn;
     vi.useRealTimers();
+    vi.unstubAllGlobals();
     vi.restoreAllMocks();
   });
 
-  it("transitions from connecting to recording when the connection opens", async () => {
-    const service = new VoiceTranscriptionService();
-    const statuses: string[] = [];
-
-    service.onEvent((event) => {
-      if (event.type === "status") statuses.push(event.status);
-    });
-
-    const startPromise = service.start(BASE_SETTINGS);
-    expect(statuses).toContain("connecting");
-
-    const conn = deepgramMock.instances.at(-1)!;
-    conn.emit(deepgramMock.LiveTranscriptionEvents.Open);
-
-    await expect(startPromise).resolves.toEqual({ ok: true });
-    expect(statuses.at(-1)).toBe("recording");
-  });
+  // ── Startup / readiness ──────────────────────────────────────────────────
 
   it("fails to start when no OpenAI API key is configured", async () => {
     const service = new VoiceTranscriptionService();
     const result = await service.start({ ...BASE_SETTINGS, openaiApiKey: "" });
     expect(result).toEqual({ ok: false, error: "OpenAI API key not configured" });
+    expect(instances).toHaveLength(0);
   });
 
-  it("settles a pending start when the session is stopped before connect completes", async () => {
+  it("constructs the WebSocket with the realtime URL and auth headers", async () => {
     const service = new VoiceTranscriptionService();
+    void service.start({ ...BASE_SETTINGS, openaiApiKey: "sk-abc" });
+    await Promise.resolve();
+    const socket = latestInstance();
+    expect(socket.url).toBe(
+      "wss://api.openai.com/v1/realtime?model=gpt-realtime-whisper"
+    );
+    expect(socket.options.headers.Authorization).toBe("Bearer sk-abc");
+    expect(socket.options.headers["OpenAI-Beta"]).toBe("realtime=v1");
+    service.stop();
+  });
+
+  it("sends session.update on WebSocket open and stays not-ready until session.updated", async () => {
+    const service = new VoiceTranscriptionService();
+    const statuses: string[] = [];
+    service.onEvent((e) => {
+      if (e.type === "status") statuses.push(e.status);
+    });
 
     const startPromise = service.start(BASE_SETTINGS);
-    service.stop();
+    expect(statuses).toEqual(["connecting"]);
+    await Promise.resolve();
+    const socket = latestInstance();
+    socket.simulateOpen();
 
+    expect(socket.sent).toHaveLength(1);
+    const sessionUpdate = JSON.parse(socket.sent[0]) as {
+      type: string;
+      session: { type: string; audio: { input: Record<string, unknown> } };
+    };
+    expect(sessionUpdate.type).toBe("session.update");
+    expect(sessionUpdate.session.type).toBe("transcription");
+    expect(sessionUpdate.session.audio.input).toMatchObject({
+      format: { type: "audio/pcm", rate: 24000 },
+      transcription: { model: "gpt-realtime-whisper", language: "en" },
+      turn_detection: { type: "server_vad" },
+    });
+
+    // Still not ready — start() must wait for session.updated
+    expect(statuses).toEqual(["connecting"]);
+
+    socket.simulateMessage("session.updated");
+    await expect(startPromise).resolves.toEqual({ ok: true });
+    expect(statuses).toEqual(["connecting", "recording"]);
+  });
+
+  it("uses the configured language in session.update", async () => {
+    const service = new VoiceTranscriptionService();
+    void service.start({ ...BASE_SETTINGS, language: "es" });
+    await Promise.resolve();
+    const socket = latestInstance();
+    socket.simulateOpen();
+    const payload = JSON.parse(socket.sent[0]) as {
+      session: { audio: { input: { transcription: { language: string } } } };
+    };
+    expect(payload.session.audio.input.transcription.language).toBe("es");
+    service.stop();
+  });
+
+  it("settles a pending start when the session is stopped before session.updated", async () => {
+    const service = new VoiceTranscriptionService();
+    const startPromise = service.start(BASE_SETTINGS);
+    await Promise.resolve();
+    latestInstance().simulateOpen();
+    // No session.updated yet — stop before ready.
+    service.stop();
     await expect(startPromise).resolves.toEqual({
       ok: false,
       error: "Voice session stopped",
@@ -154,1449 +230,364 @@ describe("VoiceTranscriptionService", () => {
 
   it("does not emit idle when start() replaces a previous session", async () => {
     const service = new VoiceTranscriptionService();
-    const events: Array<{ type: string; status?: string }> = [];
+    await bringSessionReady(service);
 
-    service.onEvent((event) => events.push(event));
-
-    const firstPromise = service.start(BASE_SETTINGS);
-    deepgramMock.instances.at(-1)!.emit(deepgramMock.LiveTranscriptionEvents.Open);
-    await firstPromise;
-
-    events.length = 0;
+    const events: VoiceTranscriptionEvent[] = [];
+    service.onEvent((e) => events.push(e));
 
     const secondPromise = service.start(BASE_SETTINGS);
     const idleBeforeConnect = events.filter((e) => e.type === "status" && e.status === "idle");
     expect(idleBeforeConnect).toHaveLength(0);
 
-    deepgramMock.instances.at(-1)!.emit(deepgramMock.LiveTranscriptionEvents.Open);
+    await Promise.resolve();
+    const socket = latestInstance();
+    socket.simulateOpen();
+    socket.simulateMessage("session.updated");
     await secondPromise;
   });
 
-  it("emits delta for interim transcripts", async () => {
+  it("times out with an error if session.updated does not arrive within 10s", async () => {
+    const service = new VoiceTranscriptionService();
+    const errors: string[] = [];
+    service.onEvent((e) => {
+      if (e.type === "error") errors.push(e.message);
+    });
+
+    const startPromise = service.start(BASE_SETTINGS);
+    await Promise.resolve();
+    latestInstance().simulateOpen();
+    // Never simulate session.updated.
+
+    vi.advanceTimersByTime(10_000);
+
+    await expect(startPromise).resolves.toEqual({ ok: false, error: "Connection timed out" });
+    expect(errors).toContain("Connection timed out");
+  });
+
+  // ── Delta / complete events ──────────────────────────────────────────────
+
+  it("emits delta for incremental transcription deltas", async () => {
     const service = new VoiceTranscriptionService();
     const deltas: string[] = [];
     service.onEvent((e) => {
       if (e.type === "delta") deltas.push(e.text);
     });
 
-    const p = service.start(BASE_SETTINGS);
-    deepgramMock.instances.at(-1)!.emit(deepgramMock.LiveTranscriptionEvents.Open);
-    await p;
-
-    const conn = deepgramMock.instances.at(-1)!;
-    conn.emit(
-      deepgramMock.LiveTranscriptionEvents.Transcript,
-      makeTranscriptEvent("Hello", false, false)
-    );
-    conn.emit(
-      deepgramMock.LiveTranscriptionEvents.Transcript,
-      makeTranscriptEvent("Hello world", false, false)
-    );
+    const { socket } = await bringSessionReady(service);
+    socket.simulateMessage("conversation.item.input_audio_transcription.delta", {
+      delta: "Hello",
+    });
+    socket.simulateMessage("conversation.item.input_audio_transcription.delta", {
+      delta: " world",
+    });
 
     expect(deltas).toEqual(["Hello", " world"]);
   });
 
-  it("emits complete on speech_final", async () => {
+  it("ignores empty deltas", async () => {
     const service = new VoiceTranscriptionService();
-    const completes: string[] = [];
+    const deltas: string[] = [];
     service.onEvent((e) => {
-      if (e.type === "complete") completes.push(e.text);
+      if (e.type === "delta") deltas.push(e.text);
     });
 
-    const p = service.start(BASE_SETTINGS);
-    deepgramMock.instances.at(-1)!.emit(deepgramMock.LiveTranscriptionEvents.Open);
-    await p;
+    const { socket } = await bringSessionReady(service);
+    socket.simulateMessage("conversation.item.input_audio_transcription.delta", { delta: "" });
+    socket.simulateMessage("conversation.item.input_audio_transcription.delta", {});
 
-    const conn = deepgramMock.instances.at(-1)!;
-    conn.emit(
-      deepgramMock.LiveTranscriptionEvents.Transcript,
-      makeTranscriptEvent("Hello world", true, true)
-    );
-
-    expect(completes).toEqual(["Hello world"]);
+    expect(deltas).toEqual([]);
   });
 
-  it("accumulates is_final segments and emits them as complete on speech_final", async () => {
+  it("emits complete with stub confidence on transcription.completed", async () => {
     const service = new VoiceTranscriptionService();
-    const completes: string[] = [];
-    service.onEvent((e) => {
-      if (e.type === "complete") completes.push(e.text);
-    });
-
-    const p = service.start(BASE_SETTINGS);
-    deepgramMock.instances.at(-1)!.emit(deepgramMock.LiveTranscriptionEvents.Open);
-    await p;
-
-    const conn = deepgramMock.instances.at(-1)!;
-    conn.emit(
-      deepgramMock.LiveTranscriptionEvents.Transcript,
-      makeTranscriptEvent("Hello world", true, false)
-    );
-    conn.emit(
-      deepgramMock.LiveTranscriptionEvents.Transcript,
-      makeTranscriptEvent("how are you", true, true)
-    );
-
-    expect(completes).toEqual(["Hello world how are you"]);
-  });
-
-  it("resets utterance state after each speech_final", async () => {
-    const service = new VoiceTranscriptionService();
-    const completes: string[] = [];
-    service.onEvent((e) => {
-      if (e.type === "complete") completes.push(e.text);
-    });
-
-    const p = service.start(BASE_SETTINGS);
-    deepgramMock.instances.at(-1)!.emit(deepgramMock.LiveTranscriptionEvents.Open);
-    await p;
-
-    const conn = deepgramMock.instances.at(-1)!;
-    conn.emit(
-      deepgramMock.LiveTranscriptionEvents.Transcript,
-      makeTranscriptEvent("First utterance.", true, true)
-    );
-    conn.emit(
-      deepgramMock.LiveTranscriptionEvents.Transcript,
-      makeTranscriptEvent("Second utterance.", true, true)
-    );
-
-    expect(completes).toEqual(["First utterance.", "Second utterance."]);
-  });
-
-  it("sends audio chunks as ArrayBuffer after connection opens", async () => {
-    const service = new VoiceTranscriptionService();
-    const p = service.start(BASE_SETTINGS);
-    const conn = deepgramMock.instances.at(-1)!;
-    conn.emit(deepgramMock.LiveTranscriptionEvents.Open);
-    await p;
-
-    const chunk = new ArrayBuffer(8);
-    service.sendAudioChunk(chunk);
-
-    expect(conn.sent).toHaveLength(1);
-    expect(conn.sent[0]).toBeInstanceOf(ArrayBuffer);
-    expect((conn.sent[0] as unknown as ArrayBuffer).byteLength).toBe(8);
-  });
-
-  it("buffers pre-connect audio chunks and flushes on open", async () => {
-    const service = new VoiceTranscriptionService();
-    const startPromise = service.start(BASE_SETTINGS);
-    const conn = deepgramMock.instances.at(-1)!;
-
-    const chunk1 = new ArrayBuffer(4);
-    const chunk2 = new ArrayBuffer(8);
-    service.sendAudioChunk(chunk1);
-    service.sendAudioChunk(chunk2);
-
-    expect(conn.sent).toHaveLength(0);
-
-    conn.emit(deepgramMock.LiveTranscriptionEvents.Open);
-    await startPromise;
-
-    expect(conn.sent).toHaveLength(2);
-  });
-
-  it("rejects audio chunks during drain", async () => {
-    const service = new VoiceTranscriptionService();
-    const p = service.start(BASE_SETTINGS);
-    const conn = deepgramMock.instances.at(-1)!;
-    conn.emit(deepgramMock.LiveTranscriptionEvents.Open);
-    await p;
-
-    const stopPromise = service.stopGracefully();
-    service.sendAudioChunk(new ArrayBuffer(4));
-
-    const chunksAfterDrain = conn.sent.length;
-    conn.emit(
-      deepgramMock.LiveTranscriptionEvents.Transcript,
-      makeTranscriptEvent("done", true, true)
-    );
-    await stopPromise;
-
-    expect(conn.sent.length).toBe(chunksAfterDrain);
-  });
-
-  it("calls connection.finish() on graceful stop", async () => {
-    const service = new VoiceTranscriptionService();
-    const p = service.start(BASE_SETTINGS);
-    const conn = deepgramMock.instances.at(-1)!;
-    conn.emit(deepgramMock.LiveTranscriptionEvents.Open);
-    await p;
-
-    const stopPromise = service.stopGracefully();
-    expect(conn.finalized).toBe(true);
-
-    conn.emit(
-      deepgramMock.LiveTranscriptionEvents.Transcript,
-      makeTranscriptEvent("bye", true, true)
-    );
-    await stopPromise;
-  });
-
-  it("drain resolves after speech_final during graceful stop", async () => {
-    const service = new VoiceTranscriptionService();
-    const p = service.start(BASE_SETTINGS);
-    const conn = deepgramMock.instances.at(-1)!;
-    conn.emit(deepgramMock.LiveTranscriptionEvents.Open);
-    await p;
-
-    let drained = false;
-    const stopPromise = service.stopGracefully().then(() => {
-      drained = true;
-    });
-
-    expect(drained).toBe(false);
-    conn.emit(
-      deepgramMock.LiveTranscriptionEvents.Transcript,
-      makeTranscriptEvent("final text", true, true)
-    );
-    await stopPromise;
-    expect(drained).toBe(true);
-  });
-
-  it("drain resolves after timeout if no speech_final arrives", async () => {
-    const service = new VoiceTranscriptionService();
-    const p = service.start(BASE_SETTINGS);
-    const conn = deepgramMock.instances.at(-1)!;
-    conn.emit(deepgramMock.LiveTranscriptionEvents.Open);
-    await p;
-
-    let drained = false;
-    const stopPromise = service.stopGracefully().then(() => {
-      drained = true;
-    });
-
-    expect(drained).toBe(false);
-    vi.advanceTimersByTime(3001);
-    await stopPromise;
-    expect(drained).toBe(true);
-  });
-
-  it("emits error and error status on connection error", async () => {
-    const service = new VoiceTranscriptionService();
-    const events: Array<{ type: string; message?: string; status?: string }> = [];
+    const events: VoiceTranscriptionEvent[] = [];
     service.onEvent((e) => events.push(e));
 
-    const p = service.start(BASE_SETTINGS);
-    const conn = deepgramMock.instances.at(-1)!;
-    conn.emit(deepgramMock.LiveTranscriptionEvents.Open);
-    await p;
+    const { socket } = await bringSessionReady(service);
+    socket.simulateMessage("conversation.item.input_audio_transcription.completed", {
+      transcript: "Hello world",
+    });
 
-    conn.emit(deepgramMock.LiveTranscriptionEvents.Error, new Error("websocket died"));
-
-    const errorEvent = events.find((e) => e.type === "error");
-    const statusEvent = events.find((e) => e.type === "status" && e.status === "error");
-    expect(errorEvent).toBeDefined();
-    expect(statusEvent).toBeDefined();
+    const complete = events.find((e) => e.type === "complete");
+    expect(complete).toEqual({
+      type: "complete",
+      text: "Hello world",
+      confidence: { minConfidence: 1.0, wordCount: 0, uncertainWords: [], words: [] },
+    });
   });
 
-  it("times out with an error if connection does not open within 10s", async () => {
+  it("does not emit complete when transcript is empty or whitespace-only", async () => {
+    const service = new VoiceTranscriptionService();
+    const completes: string[] = [];
+    service.onEvent((e) => {
+      if (e.type === "complete") completes.push(e.text);
+    });
+
+    const { socket } = await bringSessionReady(service);
+    socket.simulateMessage("conversation.item.input_audio_transcription.completed", {
+      transcript: "",
+    });
+    socket.simulateMessage("conversation.item.input_audio_transcription.completed", {
+      transcript: "   ",
+    });
+    socket.simulateMessage("conversation.item.input_audio_transcription.completed", {});
+
+    expect(completes).toEqual([]);
+  });
+
+  // ── Audio chunk handling ─────────────────────────────────────────────────
+
+  it("sends audio chunks as base64 input_audio_buffer.append after session.updated", async () => {
+    const service = new VoiceTranscriptionService();
+    const { socket } = await bringSessionReady(service);
+
+    const chunk = new Uint8Array([1, 2, 3, 4]).buffer;
+    const sentBeforeAudio = socket.sent.length;
+    service.sendAudioChunk(chunk);
+    expect(socket.sent.length).toBe(sentBeforeAudio + 1);
+    const payload = JSON.parse(socket.sent.at(-1)!) as { type: string; audio: string };
+    expect(payload.type).toBe("input_audio_buffer.append");
+    expect(payload.audio).toBe(Buffer.from(chunk).toString("base64"));
+  });
+
+  it("buffers pre-connect audio chunks and flushes them after session.updated", async () => {
+    const service = new VoiceTranscriptionService();
+    const startPromise = service.start(BASE_SETTINGS);
+    await Promise.resolve();
+    const socket = latestInstance();
+
+    // Queue chunks before the WS open / session.updated round-trip.
+    service.sendAudioChunk(new Uint8Array([1]).buffer);
+    service.sendAudioChunk(new Uint8Array([2]).buffer);
+
+    expect(socket.sent).toHaveLength(0);
+
+    socket.simulateOpen();
+    // session.update sent on open, no audio yet
+    expect(socket.sent).toHaveLength(1);
+
+    socket.simulateMessage("session.updated");
+    await startPromise;
+
+    const audioPayloads = socket
+      .sentJson()
+      .filter((p) => p.type === "input_audio_buffer.append")
+      .map((p) => p.audio as string);
+    expect(audioPayloads).toEqual([
+      Buffer.from(new Uint8Array([1])).toString("base64"),
+      Buffer.from(new Uint8Array([2])).toString("base64"),
+    ]);
+  });
+
+  it("caps the pre-connect buffer at 100 chunks and warns once on overflow", async () => {
+    const service = new VoiceTranscriptionService();
+    void service.start(BASE_SETTINGS);
+    await Promise.resolve();
+
+    // Push 105 chunks before session.updated — last 5 should be dropped.
+    for (let i = 0; i < 105; i++) {
+      service.sendAudioChunk(new Uint8Array([i % 256]).buffer);
+    }
+    const socket = latestInstance();
+    socket.simulateOpen();
+    socket.simulateMessage("session.updated");
+
+    const audioCount = socket.sentJson().filter((p) => p.type === "input_audio_buffer.append")
+      .length;
+    expect(audioCount).toBe(100);
+    service.stop();
+  });
+
+  it("drops audio chunks while draining", async () => {
+    const service = new VoiceTranscriptionService();
+    const { socket } = await bringSessionReady(service);
+
+    const drainPromise = service.stopGracefully();
+    const sentAtStartOfDrain = socket.sent.length;
+    service.sendAudioChunk(new Uint8Array([99]).buffer);
+    expect(socket.sent.length).toBe(sentAtStartOfDrain);
+
+    socket.simulateMessage("conversation.item.input_audio_transcription.completed", {
+      transcript: "done",
+    });
+    await drainPromise;
+  });
+
+  // ── Graceful stop / drain ────────────────────────────────────────────────
+
+  it("sends input_audio_buffer.commit on stopGracefully and waits for completed", async () => {
     const service = new VoiceTranscriptionService();
     const statuses: string[] = [];
     service.onEvent((e) => {
       if (e.type === "status") statuses.push(e.status);
     });
 
+    const { socket } = await bringSessionReady(service);
+    const drainPromise = service.stopGracefully();
+    expect(statuses).toContain("finishing");
+
+    const commitPayloads = socket.sentJson().filter((p) => p.type === "input_audio_buffer.commit");
+    expect(commitPayloads).toHaveLength(1);
+
+    socket.simulateMessage("conversation.item.input_audio_transcription.completed", {
+      transcript: "final",
+    });
+    await drainPromise;
+    expect(statuses.at(-1)).toBe("idle");
+  });
+
+  it("drain resolves after the timeout if no completed event arrives", async () => {
+    const service = new VoiceTranscriptionService();
+    await bringSessionReady(service);
+
+    const drainPromise = service.stopGracefully();
+    vi.advanceTimersByTime(3_000);
+    await expect(drainPromise).resolves.toBeUndefined();
+  });
+
+  it("repeated stopGracefully calls share a single in-flight drain", async () => {
+    const service = new VoiceTranscriptionService();
+    const { socket } = await bringSessionReady(service);
+
+    const first = service.stopGracefully();
+    const second = service.stopGracefully();
+
+    // Only one commit is sent, even though stop was called twice.
+    const commits = socket.sentJson().filter((p) => p.type === "input_audio_buffer.commit");
+    expect(commits).toHaveLength(1);
+
+    socket.simulateMessage("conversation.item.input_audio_transcription.completed", {
+      transcript: "ok",
+    });
+    await Promise.all([first, second]);
+  });
+
+  it("stopGracefully without an open connection goes straight to idle", async () => {
+    const service = new VoiceTranscriptionService();
+    const statuses: string[] = [];
+    service.onEvent((e) => {
+      if (e.type === "status") statuses.push(e.status);
+    });
+
+    await service.stopGracefully();
+    expect(statuses).toEqual(["idle"]);
+  });
+
+  // ── Error handling ───────────────────────────────────────────────────────
+
+  it("emits error and error status when the WebSocket reports an error", async () => {
+    const service = new VoiceTranscriptionService();
+    const events: VoiceTranscriptionEvent[] = [];
+    service.onEvent((e) => events.push(e));
+
     const startPromise = service.start(BASE_SETTINGS);
-    vi.advanceTimersByTime(10001);
-    const result = await startPromise;
+    await Promise.resolve();
+    const socket = latestInstance();
+    socket.simulateOpen();
+    socket.simulateError(new Error("network down"), "network down");
 
-    expect(result).toEqual({ ok: false, error: "Connection timed out" });
-    expect(statuses).toContain("error");
+    await expect(startPromise).resolves.toEqual({ ok: false, error: "network down" });
+    expect(events.some((e) => e.type === "error" && /network down/.test(e.message))).toBe(true);
+    expect(events.some((e) => e.type === "status" && e.status === "error")).toBe(true);
   });
 
-  describe("paragraphing strategy — Deepgram connection options", () => {
-    it("spoken-command strategy sends dictation:true to Deepgram", async () => {
-      const capturedOpts: Record<string, unknown>[] = [];
-      deepgramMock.mockClient.listen.live = (opts: unknown) => {
-        capturedOpts.push(opts as Record<string, unknown>);
-        const conn = new deepgramMock.MockConnection();
-        deepgramMock.instances.push(conn);
-        return conn;
-      };
-
-      const service = new VoiceTranscriptionService();
-      void service.start({ ...BASE_SETTINGS, paragraphingStrategy: "spoken-command" });
-
-      expect(capturedOpts[0]).toMatchObject({ dictation: true });
-      expect(capturedOpts[0]).not.toHaveProperty("punctuate");
-      expect(capturedOpts[0]).not.toHaveProperty("paragraphs");
-      expect(capturedOpts[0].endpointing).toBe(800);
+  it("propagates server-side error events", async () => {
+    const service = new VoiceTranscriptionService();
+    const errors: string[] = [];
+    service.onEvent((e) => {
+      if (e.type === "error") errors.push(e.message);
     });
 
-    it("manual strategy does not send dictation or punctuate to Deepgram", async () => {
-      const capturedOpts: Record<string, unknown>[] = [];
-      deepgramMock.mockClient.listen.live = (opts: unknown) => {
-        capturedOpts.push(opts as Record<string, unknown>);
-        const conn = new deepgramMock.MockConnection();
-        deepgramMock.instances.push(conn);
-        return conn;
-      };
-
-      const service = new VoiceTranscriptionService();
-      void service.start({ ...BASE_SETTINGS, paragraphingStrategy: "manual" });
-
-      expect(capturedOpts[0]).not.toHaveProperty("dictation");
-      expect(capturedOpts[0]).not.toHaveProperty("punctuate");
-      expect(capturedOpts[0]).not.toHaveProperty("paragraphs");
-      expect(capturedOpts[0].endpointing).toBe(800);
+    const { socket } = await bringSessionReady(service);
+    socket.simulateMessage("error", {
+      error: { message: "invalid_session_config", type: "invalid_request_error" },
     });
 
-    it("defaults to spoken-command when paragraphingStrategy is undefined", async () => {
-      const capturedOpts: Record<string, unknown>[] = [];
-      deepgramMock.mockClient.listen.live = (opts: unknown) => {
-        capturedOpts.push(opts as Record<string, unknown>);
-        const conn = new deepgramMock.MockConnection();
-        deepgramMock.instances.push(conn);
-        return conn;
-      };
-
-      const service = new VoiceTranscriptionService();
-      // Simulate a stored settings object without the new field (pre-migration)
-      void service.start({
-        ...BASE_SETTINGS,
-        paragraphingStrategy: undefined as unknown as "spoken-command",
-      });
-
-      expect(capturedOpts[0]).toMatchObject({ dictation: true });
-      expect(capturedOpts[0]).not.toHaveProperty("punctuate");
-    });
-
-    it("spoken-command strategy does not enable dictation for non-English languages", async () => {
-      const capturedOpts: Record<string, unknown>[] = [];
-      deepgramMock.mockClient.listen.live = (opts: unknown) => {
-        capturedOpts.push(opts as Record<string, unknown>);
-        const conn = new deepgramMock.MockConnection();
-        deepgramMock.instances.push(conn);
-        return conn;
-      };
-
-      const service = new VoiceTranscriptionService();
-      void service.start({
-        ...BASE_SETTINGS,
-        paragraphingStrategy: "spoken-command",
-        language: "es",
-      });
-
-      expect(capturedOpts[0]).not.toHaveProperty("dictation");
-    });
+    expect(errors).toContain("invalid_session_config");
   });
 
-  describe("paragraph boundary detection via \\n\\n in transcript", () => {
-    it("emits complete + paragraph_boundary + complete when speech_final contains \\n\\n", async () => {
-      const service = new VoiceTranscriptionService();
-      const events: Array<{ type: string; text?: string }> = [];
-      service.onEvent((e) => {
-        if (e.type === "complete" || e.type === "paragraph_boundary") events.push(e);
-      });
+  it("ignores malformed JSON messages without throwing", async () => {
+    const service = new VoiceTranscriptionService();
+    const events: VoiceTranscriptionEvent[] = [];
+    service.onEvent((e) => events.push(e));
 
-      const p = service.start(BASE_SETTINGS);
-      deepgramMock.instances.at(-1)!.emit(deepgramMock.LiveTranscriptionEvents.Open);
-      await p;
+    const { socket } = await bringSessionReady(service);
+    expect(() => socket.simulateRawMessage("not json {")).not.toThrow();
 
-      const conn = deepgramMock.instances.at(-1)!;
-      conn.emit(
-        deepgramMock.LiveTranscriptionEvents.Transcript,
-        makeTranscriptEvent("First paragraph.\n\nSecond paragraph.", true, true)
-      );
-
-      expect(events).toMatchObject([
-        { type: "complete", text: "First paragraph." },
-        { type: "paragraph_boundary" },
-        { type: "complete", text: "Second paragraph." },
-      ]);
+    // Service still functional afterward
+    socket.simulateMessage("conversation.item.input_audio_transcription.completed", {
+      transcript: "ok",
     });
-
-    it("does not emit paragraph_boundary for transcripts without \\n\\n", async () => {
-      const service = new VoiceTranscriptionService();
-      const boundaries: unknown[] = [];
-      service.onEvent((e) => {
-        if (e.type === "paragraph_boundary") boundaries.push(e);
-      });
-
-      const p = service.start(BASE_SETTINGS);
-      deepgramMock.instances.at(-1)!.emit(deepgramMock.LiveTranscriptionEvents.Open);
-      await p;
-
-      const conn = deepgramMock.instances.at(-1)!;
-      conn.emit(
-        deepgramMock.LiveTranscriptionEvents.Transcript,
-        makeTranscriptEvent("No paragraph break here.", true, true)
-      );
-
-      expect(boundaries).toHaveLength(0);
-    });
-
-    it("ignores leading and trailing \\n\\n — no spurious boundary events", async () => {
-      const service = new VoiceTranscriptionService();
-      const events: Array<{ type: string; text?: string }> = [];
-      service.onEvent((e) => {
-        if (e.type === "complete" || e.type === "paragraph_boundary") events.push(e);
-      });
-
-      const p = service.start(BASE_SETTINGS);
-      deepgramMock.instances.at(-1)!.emit(deepgramMock.LiveTranscriptionEvents.Open);
-      await p;
-
-      const conn = deepgramMock.instances.at(-1)!;
-      conn.emit(
-        deepgramMock.LiveTranscriptionEvents.Transcript,
-        makeTranscriptEvent("\n\nOnly one paragraph.\n\n", true, true)
-      );
-
-      expect(events).toMatchObject([{ type: "complete", text: "Only one paragraph." }]);
-    });
-
-    it("collapses repeated \\n\\n delimiters to a single boundary", async () => {
-      const service = new VoiceTranscriptionService();
-      const events: Array<{ type: string; text?: string }> = [];
-      service.onEvent((e) => {
-        if (e.type === "complete" || e.type === "paragraph_boundary") events.push(e);
-      });
-
-      const p = service.start(BASE_SETTINGS);
-      deepgramMock.instances.at(-1)!.emit(deepgramMock.LiveTranscriptionEvents.Open);
-      await p;
-
-      const conn = deepgramMock.instances.at(-1)!;
-      conn.emit(
-        deepgramMock.LiveTranscriptionEvents.Transcript,
-        makeTranscriptEvent("First.\n\n\n\nSecond.", true, true)
-      );
-
-      expect(events).toMatchObject([
-        { type: "complete", text: "First." },
-        { type: "paragraph_boundary" },
-        { type: "complete", text: "Second." },
-      ]);
-    });
-
-    it("does not split on single \\n — only \\n\\n triggers a boundary", async () => {
-      const service = new VoiceTranscriptionService();
-      const events: Array<{ type: string; text?: string }> = [];
-      service.onEvent((e) => {
-        if (e.type === "complete" || e.type === "paragraph_boundary") events.push(e);
-      });
-
-      const p = service.start(BASE_SETTINGS);
-      deepgramMock.instances.at(-1)!.emit(deepgramMock.LiveTranscriptionEvents.Open);
-      await p;
-
-      const conn = deepgramMock.instances.at(-1)!;
-      conn.emit(
-        deepgramMock.LiveTranscriptionEvents.Transcript,
-        makeTranscriptEvent("Line one.\nLine two.", true, true)
-      );
-
-      // A single \n is not a paragraph boundary — the text contains it but is not split
-      expect(events.filter((e) => e.type === "paragraph_boundary")).toHaveLength(0);
-      expect(events.filter((e) => e.type === "complete")).toHaveLength(1);
-    });
-
-    it("emits paragraph boundary via UtteranceEnd flush when accumulated text contains \\n\\n", async () => {
-      const service = new VoiceTranscriptionService();
-      const events: Array<{ type: string; text?: string }> = [];
-      service.onEvent((e) => {
-        if (e.type === "complete" || e.type === "paragraph_boundary") events.push(e);
-      });
-
-      const p = service.start(BASE_SETTINGS);
-      deepgramMock.instances.at(-1)!.emit(deepgramMock.LiveTranscriptionEvents.Open);
-      await p;
-
-      const conn = deepgramMock.instances.at(-1)!;
-      // Accumulate an is_final segment with \n\n
-      conn.emit(
-        deepgramMock.LiveTranscriptionEvents.Transcript,
-        makeTranscriptEvent("Part one.\n\nPart two.", true, false)
-      );
-      // UtteranceEnd flushes the accumulated segments
-      conn.emit(deepgramMock.LiveTranscriptionEvents.UtteranceEnd);
-
-      expect(events).toMatchObject([
-        { type: "complete", text: "Part one." },
-        { type: "paragraph_boundary" },
-        { type: "complete", text: "Part two." },
-      ]);
-    });
+    expect(events.some((e) => e.type === "complete")).toBe(true);
   });
 
-  it("does not emit complete for empty speech_final transcripts", async () => {
+  it("fails start when WebSocket construction throws", async () => {
+    throwOnConstruct = true;
+    constructError = new Error("ECONNREFUSED");
+    const service = new VoiceTranscriptionService();
+    const result = await service.start(BASE_SETTINGS);
+    expect(result).toEqual({ ok: false, error: "ECONNREFUSED" });
+  });
+
+  // ── Reentrancy / stale-session guard ─────────────────────────────────────
+
+  it("ignores transcript events from a stale session", async () => {
     const service = new VoiceTranscriptionService();
     const completes: string[] = [];
     service.onEvent((e) => {
       if (e.type === "complete") completes.push(e.text);
     });
 
-    const p = service.start(BASE_SETTINGS);
-    deepgramMock.instances.at(-1)!.emit(deepgramMock.LiveTranscriptionEvents.Open);
-    await p;
+    const { socket: firstSocket } = await bringSessionReady(service);
+    // Start a second session; the first socket is now stale.
+    const secondPromise = service.start(BASE_SETTINGS);
+    await Promise.resolve();
+    const secondSocket = latestInstance();
+    secondSocket.simulateOpen();
+    secondSocket.simulateMessage("session.updated");
+    await secondPromise;
 
-    const conn = deepgramMock.instances.at(-1)!;
-    conn.emit(deepgramMock.LiveTranscriptionEvents.Transcript, makeTranscriptEvent("", true, true));
+    firstSocket.simulateMessage("conversation.item.input_audio_transcription.completed", {
+      transcript: "ghost",
+    });
 
-    expect(completes).toHaveLength(0);
+    expect(completes).toEqual([]);
   });
 
-  describe("paragraph boundary detection from is_final segments", () => {
-    async function startService(): Promise<{
-      service: VoiceTranscriptionService;
-      conn: (typeof deepgramMock.instances)[number];
-      events: Array<{ type: string; text?: string }>;
-    }> {
-      const service = new VoiceTranscriptionService();
-      const events: Array<{ type: string; text?: string }> = [];
-      service.onEvent((e) => events.push(e));
+  // ── commitParagraphBoundary ──────────────────────────────────────────────
 
-      const p = service.start(BASE_SETTINGS);
-      const conn = deepgramMock.instances.at(-1)!;
-      conn.emit(deepgramMock.LiveTranscriptionEvents.Open);
-      await p;
+  it("commitParagraphBoundary resets state and does not touch the WebSocket", async () => {
+    const service = new VoiceTranscriptionService();
+    const { socket } = await bringSessionReady(service);
+    const sentBefore = socket.sent.length;
 
-      return { service, conn, events };
-    }
-
-    it("leading \\n\\n in is_final flushes current utterance and emits paragraph_boundary", async () => {
-      const { conn, events } = await startService();
-
-      // First paragraph — two is_final segments
-      conn.emit(
-        deepgramMock.LiveTranscriptionEvents.Transcript,
-        makeTranscriptEvent("First paragraph.", true, false)
-      );
-      conn.emit(
-        deepgramMock.LiveTranscriptionEvents.Transcript,
-        makeTranscriptEvent("More of first.", true, false)
-      );
-
-      // Deepgram signals new paragraph with leading \n\n on next is_final
-      conn.emit(
-        deepgramMock.LiveTranscriptionEvents.Transcript,
-        makeTranscriptEvent("\n\nSecond paragraph.", true, false)
-      );
-
-      const completes = events.filter((e) => e.type === "complete").map((e) => e.text);
-      const boundaries = events.filter((e) => e.type === "paragraph_boundary");
-
-      expect(completes).toEqual(["First paragraph. More of first."]);
-      expect(boundaries).toHaveLength(1);
+    socket.simulateMessage("conversation.item.input_audio_transcription.delta", {
+      delta: "Hello",
     });
+    service.commitParagraphBoundary();
 
-    it("leading \\n\\n in is_final: text after boundary accumulates for next speech_final", async () => {
-      const { conn, events } = await startService();
-
-      conn.emit(
-        deepgramMock.LiveTranscriptionEvents.Transcript,
-        makeTranscriptEvent("Para one.", true, false)
-      );
-      conn.emit(
-        deepgramMock.LiveTranscriptionEvents.Transcript,
-        makeTranscriptEvent("\n\nPara two start", true, false)
-      );
-      // speech_final finalizes para two
-      conn.emit(
-        deepgramMock.LiveTranscriptionEvents.Transcript,
-        makeTranscriptEvent("Para two start and end.", true, true)
-      );
-
-      const completes = events.filter((e) => e.type === "complete").map((e) => e.text);
-      const boundaries = events.filter((e) => e.type === "paragraph_boundary");
-
-      expect(completes[0]).toBe("Para one.");
-      expect(boundaries).toHaveLength(1);
-      // Para two is finalized by speech_final — it joins the after-boundary segment
-      expect(completes[1]).toContain("Para two");
-    });
-
-    it("embedded \\n\\n in is_final splits at boundary and accumulates remainder", async () => {
-      const { conn, events } = await startService();
-
-      conn.emit(
-        deepgramMock.LiveTranscriptionEvents.Transcript,
-        makeTranscriptEvent("End of para one.\n\nStart of para two.", true, false)
-      );
-
-      const completes = events.filter((e) => e.type === "complete").map((e) => e.text);
-      const boundaries = events.filter((e) => e.type === "paragraph_boundary");
-
-      expect(completes).toEqual(["End of para one."]);
-      expect(boundaries).toHaveLength(1);
-    });
-
-    it("\\n\\n-only is_final flushes current utterance and emits boundary with no new text", async () => {
-      const { conn, events } = await startService();
-
-      conn.emit(
-        deepgramMock.LiveTranscriptionEvents.Transcript,
-        makeTranscriptEvent("Para one text.", true, false)
-      );
-      conn.emit(
-        deepgramMock.LiveTranscriptionEvents.Transcript,
-        makeTranscriptEvent("\n\n", true, false)
-      );
-
-      const completes = events.filter((e) => e.type === "complete").map((e) => e.text);
-      const boundaries = events.filter((e) => e.type === "paragraph_boundary");
-
-      expect(completes).toEqual(["Para one text."]);
-      expect(boundaries).toHaveLength(1);
-    });
-
-    it("paragraph boundary in is_final does not emit duplicate complete when speech_final follows", async () => {
-      const { conn, events } = await startService();
-
-      conn.emit(
-        deepgramMock.LiveTranscriptionEvents.Transcript,
-        makeTranscriptEvent("Para one.", true, false)
-      );
-      conn.emit(
-        deepgramMock.LiveTranscriptionEvents.Transcript,
-        makeTranscriptEvent("\n\nPara two.", true, false)
-      );
-      // speech_final for para two
-      conn.emit(
-        deepgramMock.LiveTranscriptionEvents.Transcript,
-        makeTranscriptEvent("Para two.", true, true)
-      );
-
-      const completes = events.filter((e) => e.type === "complete").map((e) => e.text);
-      const boundaries = events.filter((e) => e.type === "paragraph_boundary");
-
-      // Para one flushed at boundary, para two finalized at speech_final — exactly 2 completes
-      expect(completes).toHaveLength(2);
-      expect(completes[0]).toBe("Para one.");
-      expect(boundaries).toHaveLength(1);
-    });
-
-    it("is_final without \\n\\n still accumulates normally", async () => {
-      const { conn, events } = await startService();
-
-      conn.emit(
-        deepgramMock.LiveTranscriptionEvents.Transcript,
-        makeTranscriptEvent("Hello world", true, false)
-      );
-      conn.emit(
-        deepgramMock.LiveTranscriptionEvents.Transcript,
-        makeTranscriptEvent("how are you", true, true)
-      );
-
-      const completes = events.filter((e) => e.type === "complete").map((e) => e.text);
-      const boundaries = events.filter((e) => e.type === "paragraph_boundary");
-
-      expect(completes).toEqual(["Hello world how are you"]);
-      expect(boundaries).toHaveLength(0);
-    });
-
-    it("leading \\n\\n on first-ever is_final (empty utteranceSegments) emits no boundary", async () => {
-      const { conn, events } = await startService();
-
-      // First segment ever received starts with \n\n — there is no previous paragraph to close
-      conn.emit(
-        deepgramMock.LiveTranscriptionEvents.Transcript,
-        makeTranscriptEvent("\n\nFirst text.", true, false)
-      );
-
-      // No complete and no boundary — nothing to close yet
-      const completesBefore = events.filter((e) => e.type === "complete");
-      const boundaries = events.filter((e) => e.type === "paragraph_boundary");
-      expect(completesBefore).toHaveLength(0);
-      expect(boundaries).toHaveLength(0);
-
-      // The text after \n\n should have been accumulated, so speech_final finalizes it
-      conn.emit(
-        deepgramMock.LiveTranscriptionEvents.Transcript,
-        makeTranscriptEvent("First text continued.", true, true)
-      );
-      const completesAfter = events.filter((e) => e.type === "complete").map((e) => e.text);
-      expect(completesAfter).toHaveLength(1);
-      expect(completesAfter[0]).toContain("First text");
-    });
-
-    it("emits events in correct order: complete → paragraph_boundary", async () => {
-      const { conn, events } = await startService();
-
-      conn.emit(
-        deepgramMock.LiveTranscriptionEvents.Transcript,
-        makeTranscriptEvent("Para one text.", true, false)
-      );
-      conn.emit(
-        deepgramMock.LiveTranscriptionEvents.Transcript,
-        makeTranscriptEvent("\n\nPara two start.", true, false)
-      );
-
-      const relevant = events.filter(
-        (e) => e.type === "complete" || e.type === "paragraph_boundary"
-      );
-      expect(relevant).toHaveLength(2);
-      expect(relevant[0]).toMatchObject({ type: "complete", text: "Para one text." });
-      expect(relevant[1]).toEqual({ type: "paragraph_boundary" });
-    });
-
-    it("UtteranceEnd after paragraph boundary flushes the new paragraph correctly", async () => {
-      const { conn, events } = await startService();
-
-      // Para one ends, \n\n detected, Para two starts
-      conn.emit(
-        deepgramMock.LiveTranscriptionEvents.Transcript,
-        makeTranscriptEvent("Para one.", true, false)
-      );
-      conn.emit(
-        deepgramMock.LiveTranscriptionEvents.Transcript,
-        makeTranscriptEvent("\n\nPara two text.", true, false)
-      );
-
-      // UtteranceEnd fires (instead of speech_final) to finalize para two
-      conn.emit(deepgramMock.LiveTranscriptionEvents.UtteranceEnd);
-
-      const completes = events.filter((e) => e.type === "complete").map((e) => e.text);
-      const boundaries = events.filter((e) => e.type === "paragraph_boundary");
-
-      expect(completes).toEqual(["Para one.", "Para two text."]);
-      expect(boundaries).toHaveLength(1);
-    });
-
-    it("three paragraphs in one session produce two boundaries", async () => {
-      const { conn, events } = await startService();
-
-      // Para one accumulates as is_final
-      conn.emit(
-        deepgramMock.LiveTranscriptionEvents.Transcript,
-        makeTranscriptEvent("Para one.", true, false)
-      );
-      // \n\n → flush Para one, boundary 1, start Para two
-      conn.emit(
-        deepgramMock.LiveTranscriptionEvents.Transcript,
-        makeTranscriptEvent("\n\nPara two.", true, false)
-      );
-      // \n\n → flush Para two, boundary 2, start Para three
-      conn.emit(
-        deepgramMock.LiveTranscriptionEvents.Transcript,
-        makeTranscriptEvent("\n\nPara three.", true, false)
-      );
-      // speech_final finalizes Para three
-      conn.emit(
-        deepgramMock.LiveTranscriptionEvents.Transcript,
-        makeTranscriptEvent("Para three end.", true, true)
-      );
-
-      const completes = events.filter((e) => e.type === "complete").map((e) => e.text);
-      const boundaries = events.filter((e) => e.type === "paragraph_boundary");
-
-      expect(completes[0]).toBe("Para one.");
-      expect(completes[1]).toBe("Para two.");
-      expect(boundaries).toHaveLength(2);
-      expect(completes.at(-1)).toContain("Para three");
-    });
-
-    it("speech_final with embedded \\n\\n splits via emitCompleteWithParagraphDetection", async () => {
-      const { conn, events } = await startService();
-
-      // speech_final itself contains \n\n — the existing speechFinal path handles this
-      conn.emit(
-        deepgramMock.LiveTranscriptionEvents.Transcript,
-        makeTranscriptEvent("Para one text.\n\nPara two text.", true, true)
-      );
-
-      const completes = events.filter((e) => e.type === "complete").map((e) => e.text);
-      const boundaries = events.filter((e) => e.type === "paragraph_boundary");
-
-      expect(completes).toEqual(["Para one text.", "Para two text."]);
-      expect(boundaries).toHaveLength(1);
-    });
+    expect(socket.sent.length).toBe(sentBefore);
+    expect(socket.closeCalls).toBe(0);
   });
 
-  describe("commitParagraphBoundary — manual paragraph flush coordination", () => {
-    async function startService() {
-      const service = new VoiceTranscriptionService();
-      const events: Array<{ type: string; text?: string }> = [];
-      service.onEvent((e) => {
-        if (e.type === "complete" || e.type === "delta" || e.type === "paragraph_boundary") {
-          events.push(e);
-        }
-      });
-      const p = service.start(BASE_SETTINGS);
-      const conn = deepgramMock.instances.at(-1)!;
-      conn.emit(deepgramMock.LiveTranscriptionEvents.Open);
-      await p;
-      return { service, events, conn };
-    }
+  // ── destroy ─────────────────────────────────────────────────────────────
 
-    it("commits empty state when no utterance is in flight (no suppression)", async () => {
-      const { service, conn, events } = await startService();
+  it("destroy closes the socket and clears listeners", async () => {
+    const service = new VoiceTranscriptionService();
+    const events: VoiceTranscriptionEvent[] = [];
+    service.onEvent((e) => events.push(e));
 
-      service.commitParagraphBoundary();
-      events.length = 0;
+    const { socket } = await bringSessionReady(service);
+    service.destroy();
+    expect(socket.closeCalls).toBe(1);
 
-      // No suppression — events flow normally
-      conn.emit(
-        deepgramMock.LiveTranscriptionEvents.Transcript,
-        makeTranscriptEvent("new text", true, true)
-      );
-
-      expect(events.filter((e) => e.type === "complete")).toHaveLength(1);
-      expect(events.find((e) => e.type === "complete")?.text).toBe("new text");
+    // Listeners cleared: subsequent emits should not reach the recorded array.
+    const lengthAtDestroy = events.length;
+    // Spawn a brand-new session — the listener from before destroy should be gone.
+    const { socket: socket2 } = await bringSessionReady(service);
+    socket2.simulateMessage("conversation.item.input_audio_transcription.completed", {
+      transcript: "after destroy",
     });
-
-    it("commits accumulated delta text and suppresses late speech_final", async () => {
-      const { service, conn, events } = await startService();
-
-      // Interim delta builds liveText
-      conn.emit(
-        deepgramMock.LiveTranscriptionEvents.Transcript,
-        makeTranscriptEvent("how are", false, false)
-      );
-
-      service.commitParagraphBoundary();
-      events.length = 0;
-
-      // Late speech_final for the committed utterance is suppressed
-      conn.emit(
-        deepgramMock.LiveTranscriptionEvents.Transcript,
-        makeTranscriptEvent("how are you", true, true)
-      );
-
-      expect(events.filter((e) => e.type === "complete")).toHaveLength(0);
-
-      // Second commit finds nothing — suppression was armed only for non-empty text
-      events.length = 0;
-      conn.emit(
-        deepgramMock.LiveTranscriptionEvents.Transcript,
-        makeTranscriptEvent("next utterance", true, true)
-      );
-
-      expect(events.filter((e) => e.type === "complete")).toHaveLength(1);
-      expect(events.find((e) => e.type === "complete")?.text).toBe("next utterance");
-    });
-
-    it("suppresses is_final accumulated utterance after commit", async () => {
-      const { service, conn, events } = await startService();
-
-      // is_final events accumulate in utteranceSegments AND update liveText via
-      // emitIncrementalDelta, so commit captures them for suppression.
-      conn.emit(
-        deepgramMock.LiveTranscriptionEvents.Transcript,
-        makeTranscriptEvent("hello world", true, false)
-      );
-      service.commitParagraphBoundary();
-      events.length = 0;
-
-      // Late is_final + speech_final is suppressed
-      conn.emit(
-        deepgramMock.LiveTranscriptionEvents.Transcript,
-        makeTranscriptEvent("hello world extended", true, true)
-      );
-
-      expect(events.filter((e) => e.type === "complete")).toHaveLength(0);
-    });
-
-    it("late speech_final after commitParagraphBoundary does not emit complete", async () => {
-      const { service, conn, events } = await startService();
-
-      // Build up some interim state
-      conn.emit(
-        deepgramMock.LiveTranscriptionEvents.Transcript,
-        makeTranscriptEvent("how are you", false, false)
-      );
-
-      service.commitParagraphBoundary();
-      events.length = 0; // Reset after capture
-
-      // Deepgram sends speech_final for the consumed utterance
-      conn.emit(
-        deepgramMock.LiveTranscriptionEvents.Transcript,
-        makeTranscriptEvent("how are you doing", true, true)
-      );
-
-      expect(events.filter((e) => e.type === "complete")).toHaveLength(0);
-    });
-
-    it("late UtteranceEnd after commitParagraphBoundary does not emit complete", async () => {
-      const { service, conn, events } = await startService();
-
-      conn.emit(
-        deepgramMock.LiveTranscriptionEvents.Transcript,
-        makeTranscriptEvent("in flight", false, false)
-      );
-
-      service.commitParagraphBoundary();
-      events.length = 0;
-
-      conn.emit(deepgramMock.LiveTranscriptionEvents.UtteranceEnd);
-
-      expect(events.filter((e) => e.type === "complete")).toHaveLength(0);
-    });
-
-    it("is_final events after commitParagraphBoundary (before speech_final) are suppressed", async () => {
-      const { service, conn, events } = await startService();
-
-      conn.emit(
-        deepgramMock.LiveTranscriptionEvents.Transcript,
-        makeTranscriptEvent("first words", false, false)
-      );
-
-      service.commitParagraphBoundary();
-      events.length = 0;
-
-      // is_final event for the suppressed utterance
-      conn.emit(
-        deepgramMock.LiveTranscriptionEvents.Transcript,
-        makeTranscriptEvent("first words extended", true, false)
-      );
-
-      expect(events.filter((e) => e.type === "delta")).toHaveLength(0);
-    });
-
-    it("suppression clears after speech_final — new utterance events flow normally", async () => {
-      const { service, conn, events } = await startService();
-
-      conn.emit(
-        deepgramMock.LiveTranscriptionEvents.Transcript,
-        makeTranscriptEvent("first paragraph", false, false)
-      );
-
-      service.commitParagraphBoundary();
-
-      // speech_final clears suppression
-      conn.emit(
-        deepgramMock.LiveTranscriptionEvents.Transcript,
-        makeTranscriptEvent("first paragraph final", true, true)
-      );
-
-      events.length = 0;
-
-      // New utterance after the boundary should flow normally
-      conn.emit(
-        deepgramMock.LiveTranscriptionEvents.Transcript,
-        makeTranscriptEvent("second paragraph", false, false)
-      );
-      conn.emit(
-        deepgramMock.LiveTranscriptionEvents.Transcript,
-        makeTranscriptEvent("second paragraph done", true, true)
-      );
-
-      expect(events.filter((e) => e.type === "delta").length).toBeGreaterThan(0);
-      expect(events.filter((e) => e.type === "complete")).toHaveLength(1);
-      expect(events.find((e) => e.type === "complete")?.text).toBe("second paragraph done");
-    });
-
-    it("suppression clears after UtteranceEnd — new utterance events flow normally", async () => {
-      const { service, conn, events } = await startService();
-
-      conn.emit(
-        deepgramMock.LiveTranscriptionEvents.Transcript,
-        makeTranscriptEvent("first", false, false)
-      );
-
-      service.commitParagraphBoundary();
-
-      conn.emit(deepgramMock.LiveTranscriptionEvents.UtteranceEnd);
-
-      events.length = 0;
-
-      // New utterance after boundary
-      conn.emit(
-        deepgramMock.LiveTranscriptionEvents.Transcript,
-        makeTranscriptEvent("after boundary", true, true)
-      );
-
-      expect(events.filter((e) => e.type === "complete")).toHaveLength(1);
-      expect(events.find((e) => e.type === "complete")?.text).toBe("after boundary");
-    });
-
-    it("rapid back-to-back commitParagraphBoundary calls are safe", async () => {
-      const { service, conn, events } = await startService();
-
-      conn.emit(
-        deepgramMock.LiveTranscriptionEvents.Transcript,
-        makeTranscriptEvent("first", false, false)
-      );
-
-      // First commit captures text and arms suppression
-      service.commitParagraphBoundary();
-      // Second call finds no in-flight text — does NOT clear the
-      // first call's suppression flag (only armed when non-empty text was captured).
-      service.commitParagraphBoundary();
-
-      events.length = 0;
-
-      // Late speech_final for the original utterance should still be suppressed.
-      conn.emit(
-        deepgramMock.LiveTranscriptionEvents.Transcript,
-        makeTranscriptEvent("first extended", true, true)
-      );
-
-      expect(events.filter((e) => e.type === "complete")).toHaveLength(0);
-
-      // New utterance after suppression clears flows normally.
-      conn.emit(
-        deepgramMock.LiveTranscriptionEvents.Transcript,
-        makeTranscriptEvent("new paragraph text", true, true)
-      );
-
-      expect(events.filter((e) => e.type === "complete")).toHaveLength(1);
-      expect(events.find((e) => e.type === "complete")?.text).toBe("new paragraph text");
-    });
-  });
-
-  describe("realistic Deepgram payload scenarios", () => {
-    it("ignores alternatives[0].paragraphs field and emits complete from transcript text only", async () => {
-      const service = new VoiceTranscriptionService();
-      const events: Array<{ type: string; text?: string }> = [];
-      service.onEvent((e) => {
-        if (e.type === "complete" || e.type === "paragraph_boundary") events.push(e);
-      });
-
-      const p = service.start(BASE_SETTINGS);
-      deepgramMock.instances.at(-1)!.emit(deepgramMock.LiveTranscriptionEvents.Open);
-      await p;
-
-      const conn = deepgramMock.instances.at(-1)!;
-      // Full-shape Deepgram response object with a paragraphs field (REST-only)
-      conn.emit(deepgramMock.LiveTranscriptionEvents.Transcript, {
-        channel: {
-          alternatives: [
-            {
-              transcript: "Hello world",
-              paragraphs: {
-                paragraphs: [
-                  {
-                    sentences: [{ text: "Hello world", start: 0, end: 1.5 }],
-                    start: 0,
-                    end: 1.5,
-                  },
-                ],
-              },
-            },
-          ],
-        },
-        is_final: true,
-        speech_final: true,
-      });
-
-      // Only transcript text is used — paragraphs field is ignored
-      expect(events).toMatchObject([{ type: "complete", text: "Hello world" }]);
-    });
-
-    it("non-prefix interim revision produces correct final text without spurious events", async () => {
-      const service = new VoiceTranscriptionService();
-      const deltas: string[] = [];
-      const completes: string[] = [];
-      service.onEvent((e) => {
-        if (e.type === "delta") deltas.push(e.text);
-        if (e.type === "complete") completes.push(e.text);
-      });
-
-      const p = service.start(BASE_SETTINGS);
-      deepgramMock.instances.at(-1)!.emit(deepgramMock.LiveTranscriptionEvents.Open);
-      await p;
-
-      const conn = deepgramMock.instances.at(-1)!;
-
-      // Interim 1: "hell" — first delta emitted
-      conn.emit(
-        deepgramMock.LiveTranscriptionEvents.Transcript,
-        makeTranscriptEvent("hell", false, false)
-      );
-      expect(deltas).toEqual(["hell"]);
-
-      // Interim 2: "help" — non-prefix revision (not an extension of "hell"),
-      // triggers the silent liveText update path (no delta emitted)
-      conn.emit(
-        deepgramMock.LiveTranscriptionEvents.Transcript,
-        makeTranscriptEvent("help", false, false)
-      );
-      expect(deltas).toEqual(["hell"]); // No new delta
-
-      // Interim 3: "help me" — prefix extension of revised "help" baseline,
-      // proves the liveText baseline was correctly updated so delta emission recovers
-      conn.emit(
-        deepgramMock.LiveTranscriptionEvents.Transcript,
-        makeTranscriptEvent("help me", false, false)
-      );
-      expect(deltas).toEqual(["hell", " me"]); // " me" delta from "help" → "help me"
-
-      // speech_final: "Hello world" — produces exactly one complete event
-      conn.emit(
-        deepgramMock.LiveTranscriptionEvents.Transcript,
-        makeTranscriptEvent("Hello world", true, true)
-      );
-
-      expect(completes).toEqual(["Hello world"]);
-      // No spurious complete for the intermediate "help" or "help me"
-      expect(completes).toHaveLength(1);
-    });
-  });
-
-  describe("status sequence regression — finishing phase", () => {
-    async function startService() {
-      const service = new VoiceTranscriptionService();
-      const statuses: string[] = [];
-      service.onEvent((e) => {
-        if (e.type === "status") statuses.push(e.status);
-      });
-      const p = service.start(BASE_SETTINGS);
-      const conn = deepgramMock.instances.at(-1)!;
-      conn.emit(deepgramMock.LiveTranscriptionEvents.Open);
-      await p;
-      return { service, statuses, conn };
-    }
-
-    it("emits finishing status during graceful stop before idle", async () => {
-      const { service, statuses, conn } = await startService();
-
-      const stopPromise = service.stopGracefully();
-      expect(statuses).toContain("finishing");
-
-      conn.emit(
-        deepgramMock.LiveTranscriptionEvents.Transcript,
-        makeTranscriptEvent("", true, true)
-      );
-      await stopPromise;
-
-      expect(statuses.at(-1)).toBe("idle");
-    });
-
-    it("full status sequence: connecting → recording → finishing → idle", async () => {
-      const service = new VoiceTranscriptionService();
-      const statuses: string[] = [];
-      service.onEvent((e) => {
-        if (e.type === "status") statuses.push(e.status);
-      });
-
-      const startPromise = service.start(BASE_SETTINGS);
-      expect(statuses).toContain("connecting");
-
-      const conn = deepgramMock.instances.at(-1)!;
-      conn.emit(deepgramMock.LiveTranscriptionEvents.Open);
-      await startPromise;
-      expect(statuses).toContain("recording");
-
-      const stopPromise = service.stopGracefully();
-      expect(statuses).toContain("finishing");
-
-      conn.emit(
-        deepgramMock.LiveTranscriptionEvents.Transcript,
-        makeTranscriptEvent("last words", true, true)
-      );
-      await stopPromise;
-
-      expect(statuses).toEqual(["connecting", "recording", "finishing", "idle"]);
-    });
-  });
-
-  describe("word-level confidence propagation", () => {
-    async function startService() {
-      const service = new VoiceTranscriptionService();
-      const events: Array<{ type: string; text?: string; confidence?: unknown }> = [];
-      service.onEvent((e) => events.push(e));
-
-      const p = service.start(BASE_SETTINGS);
-      const conn = deepgramMock.instances.at(-1)!;
-      conn.emit(deepgramMock.LiveTranscriptionEvents.Open);
-      await p;
-
-      return { service, events, conn };
-    }
-
-    it("includes confidence on complete events when words are provided", async () => {
-      const { conn, events } = await startService();
-
-      conn.emit(
-        deepgramMock.LiveTranscriptionEvents.Transcript,
-        makeTranscriptEvent("Hello world", true, true, [
-          { word: "hello", confidence: 0.99 },
-          { word: "world", confidence: 0.95 },
-        ])
-      );
-
-      const complete = events.find((e) => e.type === "complete");
-      expect(complete).toBeDefined();
-      expect(complete!.confidence).toEqual({
-        minConfidence: 0.95,
-        wordCount: 2,
-        uncertainWords: [],
-        words: [
-          { word: "hello", confidence: 0.99 },
-          { word: "world", confidence: 0.95 },
-        ],
-      });
-    });
-
-    it("marks words below tag threshold as uncertain", async () => {
-      const { conn, events } = await startService();
-
-      conn.emit(
-        deepgramMock.LiveTranscriptionEvents.Transcript,
-        makeTranscriptEvent("racked native", true, true, [
-          { word: "racked", confidence: 0.65 },
-          { word: "native", confidence: 0.92 },
-        ])
-      );
-
-      const complete = events.find((e) => e.type === "complete");
-      expect(complete!.confidence).toEqual({
-        minConfidence: 0.65,
-        wordCount: 2,
-        uncertainWords: ["racked"],
-        words: [
-          { word: "racked", confidence: 0.65 },
-          { word: "native", confidence: 0.92 },
-        ],
-      });
-    });
-
-    it("merges confidence across multiple is_final segments", async () => {
-      const { conn, events } = await startService();
-
-      conn.emit(
-        deepgramMock.LiveTranscriptionEvents.Transcript,
-        makeTranscriptEvent("Hello", true, false, [{ word: "hello", confidence: 0.99 }])
-      );
-      conn.emit(
-        deepgramMock.LiveTranscriptionEvents.Transcript,
-        makeTranscriptEvent("world", true, true, [{ word: "world", confidence: 0.75 }])
-      );
-
-      const complete = events.find((e) => e.type === "complete");
-      expect(complete!.confidence).toEqual({
-        minConfidence: 0.75,
-        wordCount: 2,
-        uncertainWords: ["world"],
-        words: [
-          { word: "hello", confidence: 0.99 },
-          { word: "world", confidence: 0.75 },
-        ],
-      });
-    });
-
-    it("returns default confidence when words array is empty", async () => {
-      const { conn, events } = await startService();
-
-      conn.emit(
-        deepgramMock.LiveTranscriptionEvents.Transcript,
-        makeTranscriptEvent("Hello world", true, true)
-      );
-
-      const complete = events.find((e) => e.type === "complete");
-      expect(complete!.confidence).toEqual({
-        minConfidence: 1.0,
-        wordCount: 0,
-        uncertainWords: [],
-        words: [],
-      });
-    });
-
-    it("resets confidence accumulator after speech_final", async () => {
-      const { conn, events } = await startService();
-
-      conn.emit(
-        deepgramMock.LiveTranscriptionEvents.Transcript,
-        makeTranscriptEvent("first", true, true, [{ word: "first", confidence: 0.5 }])
-      );
-      conn.emit(
-        deepgramMock.LiveTranscriptionEvents.Transcript,
-        makeTranscriptEvent("second", true, true, [{ word: "second", confidence: 0.99 }])
-      );
-
-      const completes = events.filter((e) => e.type === "complete");
-      expect(completes[0].confidence).toMatchObject({ minConfidence: 0.5 });
-      expect(completes[1].confidence).toMatchObject({ minConfidence: 0.99 });
-    });
-
-    it("commitParagraphBoundary commits in-flight text and arms suppression", async () => {
-      const { service, conn, events } = await startService();
-
-      conn.emit(
-        deepgramMock.LiveTranscriptionEvents.Transcript,
-        makeTranscriptEvent("in flight", false, false)
-      );
-
-      service.commitParagraphBoundary();
-      events.length = 0;
-
-      // Late speech_final suppressed — in-flight text was captured by commit
-      conn.emit(
-        deepgramMock.LiveTranscriptionEvents.Transcript,
-        makeTranscriptEvent("in flight final", true, true)
-      );
-
-      expect(events.filter((e) => e.type === "complete")).toHaveLength(0);
-    });
-
-    it("includes confidence on complete events emitted via UtteranceEnd flush", async () => {
-      const { conn, events } = await startService();
-
-      conn.emit(
-        deepgramMock.LiveTranscriptionEvents.Transcript,
-        makeTranscriptEvent("Hello", true, false, [{ word: "hello", confidence: 0.88 }])
-      );
-      conn.emit(deepgramMock.LiveTranscriptionEvents.UtteranceEnd);
-
-      const complete = events.find((e) => e.type === "complete");
-      expect(complete!.confidence).toEqual({
-        minConfidence: 0.88,
-        wordCount: 1,
-        uncertainWords: [],
-        words: [{ word: "hello", confidence: 0.88 }],
-      });
-    });
-  });
-
-  describe("Metadata event", () => {
-    it("logs request_id when Metadata event is received", async () => {
-      const logger = await import("../../utils/logger.js");
-      const logInfoSpy = vi.spyOn(logger, "logInfo");
-
-      const service = new VoiceTranscriptionService();
-      const p = service.start(BASE_SETTINGS);
-      const conn = deepgramMock.instances.at(-1)!;
-      conn.emit(deepgramMock.LiveTranscriptionEvents.Open);
-      await p;
-
-      conn.emit(deepgramMock.LiveTranscriptionEvents.Metadata, {
-        type: "Metadata",
-        request_id: "abc-123-def",
-        transaction_key: "tx-key",
-        sha256: "hash",
-        created: "2024-01-01T00:00:00Z",
-        duration: 1.0,
-        channels: 1,
-      });
-
-      expect(logInfoSpy).toHaveBeenCalled();
-      const call = logInfoSpy.mock.calls.find(
-        (c) => typeof c[0] === "string" && (c[0] as string).includes("Metadata received")
-      );
-      expect(call).toBeDefined();
-      expect(call?.[1]).toMatchObject({ request_id: "abc-123-def" });
-
-      logInfoSpy.mockRestore();
-    });
-
-    it("ignores Metadata from stale sessions", async () => {
-      const logger = await import("../../utils/logger.js");
-      const logInfoSpy = vi.spyOn(logger, "logInfo");
-
-      const service = new VoiceTranscriptionService();
-
-      // Start session A
-      const pA = service.start(BASE_SETTINGS);
-      const connA = deepgramMock.instances.at(-1)!;
-      connA.emit(deepgramMock.LiveTranscriptionEvents.Open);
-      await pA;
-
-      logInfoSpy.mockClear();
-
-      // Start session B — increments sessionId
-      const pB = service.start(BASE_SETTINGS);
-      const connB = deepgramMock.instances.at(-1)!;
-      connB.emit(deepgramMock.LiveTranscriptionEvents.Open);
-      await pB;
-
-      logInfoSpy.mockClear();
-
-      // Emit Metadata on session A's connection — should be ignored
-      connA.emit(deepgramMock.LiveTranscriptionEvents.Metadata, {
-        type: "Metadata",
-        request_id: "stale-req-id",
-        transaction_key: "tx",
-        sha256: "h",
-        created: "2024-01-01T00:00:00Z",
-        duration: 1.0,
-        channels: 1,
-      });
-
-      const metadataCalls = logInfoSpy.mock.calls.filter(
-        (c) => typeof c[0] === "string" && (c[0] as string).includes("Metadata received")
-      );
-      expect(metadataCalls).toHaveLength(0);
-
-      logInfoSpy.mockRestore();
-    });
-  });
-
-  describe("pre-connect buffer overflow", () => {
-    it("warns once when buffer reaches 100-chunk cap", async () => {
-      const logger = await import("../../utils/logger.js");
-      const logWarnSpy = vi.spyOn(logger, "logWarn");
-
-      const service = new VoiceTranscriptionService();
-      void service.start(BASE_SETTINGS);
-
-      // Send 101 chunks — the 101st should trigger overflow warning
-      for (let i = 0; i < 101; i++) {
-        service.sendAudioChunk(new ArrayBuffer(4));
-      }
-
-      const overflowCalls = logWarnSpy.mock.calls.filter(
-        (c) => typeof c[0] === "string" && (c[0] as string).includes("Pre-connect buffer full")
-      );
-      expect(overflowCalls).toHaveLength(1);
-
-      logWarnSpy.mockRestore();
-    });
-
-    it("does not warn a second time within the same session", async () => {
-      const logger = await import("../../utils/logger.js");
-      const logWarnSpy = vi.spyOn(logger, "logWarn");
-
-      const service = new VoiceTranscriptionService();
-      void service.start(BASE_SETTINGS);
-
-      // Trigger overflow
-      for (let i = 0; i < 101; i++) {
-        service.sendAudioChunk(new ArrayBuffer(4));
-      }
-
-      logWarnSpy.mockClear();
-
-      // More chunks — no second warning
-      for (let i = 0; i < 10; i++) {
-        service.sendAudioChunk(new ArrayBuffer(4));
-      }
-
-      const overflowCalls = logWarnSpy.mock.calls.filter(
-        (c) => typeof c[0] === "string" && (c[0] as string).includes("Pre-connect buffer full")
-      );
-      expect(overflowCalls).toHaveLength(0);
-
-      logWarnSpy.mockRestore();
-    });
-
-    it("resets overflow warning on new session", async () => {
-      const logger = await import("../../utils/logger.js");
-      const logWarnSpy = vi.spyOn(logger, "logWarn");
-
-      const service = new VoiceTranscriptionService();
-
-      // Session 1: overflow
-      void service.start(BASE_SETTINGS);
-      for (let i = 0; i < 101; i++) {
-        service.sendAudioChunk(new ArrayBuffer(4));
-      }
-
-      expect(
-        logWarnSpy.mock.calls.filter(
-          (c) => typeof c[0] === "string" && (c[0] as string).includes("Pre-connect buffer full")
-        )
-      ).toHaveLength(1);
-
-      logWarnSpy.mockClear();
-
-      // Session 2: should overflow again (flag reset)
-      void service.start(BASE_SETTINGS);
-      for (let i = 0; i < 101; i++) {
-        service.sendAudioChunk(new ArrayBuffer(4));
-      }
-
-      expect(
-        logWarnSpy.mock.calls.filter(
-          (c) => typeof c[0] === "string" && (c[0] as string).includes("Pre-connect buffer full")
-        )
-      ).toHaveLength(1);
-
-      logWarnSpy.mockRestore();
-    });
+    expect(events.length).toBe(lengthAtDestroy);
   });
 });

--- a/electron/services/__tests__/VoiceTranscriptionService.test.ts
+++ b/electron/services/__tests__/VoiceTranscriptionService.test.ts
@@ -1,18 +1,18 @@
 import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
 import type { VoiceInputSettings } from "../../../shared/types/ipc/api.js";
-import { VoiceTranscriptionService } from "../VoiceTranscriptionService.js";
-import type { VoiceTranscriptionEvent } from "../VoiceTranscriptionService.js";
 
-// ── Mock WebSocket ────────────────────────────────────────────────────────────
+// ── Mock the `ws` package ────────────────────────────────────────────────────
 //
-// The service uses Node 22's global `WebSocket` (Electron 41 main process). We
-// stub the global so each test can drive the lifecycle (open / message / error
-// / close) deterministically. Constructor options (`{ headers }`) are captured
-// for header assertions; `sent` records the JSON payloads the service emits.
+// The service imports `WebSocket from "ws"` (the npm package, not the WHATWG
+// global) because Node's global WebSocket constructor silently drops the
+// custom-headers option needed for OpenAI auth. We mock the entire module so
+// the constructor returns a controllable EventEmitter-style stub.
 
 interface MockOptions {
   headers: Record<string, string>;
 }
+
+type WsListener = (...args: unknown[]) => void;
 
 class MockWebSocket {
   static readonly CONNECTING = 0;
@@ -27,15 +27,35 @@ class MockWebSocket {
   closeCalls = 0;
   closeCode?: number;
 
-  onopen: (() => void) | null = null;
-  onmessage: ((event: { data: string }) => void) | null = null;
-  onerror: ((event: { message?: string; error?: unknown }) => void) | null = null;
-  onclose: ((event: { code?: number; reason?: string }) => void) | null = null;
+  private listeners: Map<string, Set<WsListener>> = new Map();
 
-  constructor(url: string, _protocols: string[] | undefined, options: MockOptions) {
+  constructor(url: string, options: MockOptions) {
     this.url = url;
     this.options = options;
     instances.push(this);
+  }
+
+  on(event: string, listener: WsListener): this {
+    if (!this.listeners.has(event)) this.listeners.set(event, new Set());
+    this.listeners.get(event)!.add(listener);
+    return this;
+  }
+
+  off(event: string, listener: WsListener): this {
+    this.listeners.get(event)?.delete(listener);
+    return this;
+  }
+
+  removeAllListeners(event?: string): this {
+    if (event) this.listeners.delete(event);
+    else this.listeners.clear();
+    return this;
+  }
+
+  private fire(event: string, ...args: unknown[]): void {
+    const set = this.listeners.get(event);
+    if (!set) return;
+    for (const listener of set) listener(...args);
   }
 
   send(payload: string): void {
@@ -51,24 +71,24 @@ class MockWebSocket {
   // Test helpers
   simulateOpen(): void {
     this.readyState = MockWebSocket.OPEN;
-    this.onopen?.();
+    this.fire("open");
   }
 
   simulateMessage(type: string, payload: Record<string, unknown> = {}): void {
-    this.onmessage?.({ data: JSON.stringify({ type, ...payload }) });
+    this.fire("message", Buffer.from(JSON.stringify({ type, ...payload })));
   }
 
-  simulateRawMessage(data: string): void {
-    this.onmessage?.({ data });
+  simulateRawMessage(data: string | Buffer): void {
+    this.fire("message", data);
   }
 
-  simulateError(error?: unknown, message?: string): void {
-    this.onerror?.({ error, message });
+  simulateError(err: Error = new Error("WebSocket error")): void {
+    this.fire("error", err);
   }
 
-  simulateClose(code?: number, reason?: string): void {
+  simulateClose(code?: number, reason?: Buffer | string): void {
     this.readyState = MockWebSocket.CLOSED;
-    this.onclose?.({ code, reason });
+    this.fire("close", code, reason);
   }
 
   sentJson(): Array<Record<string, unknown>> {
@@ -79,22 +99,20 @@ class MockWebSocket {
 const instances: MockWebSocket[] = [];
 let throwOnConstruct = false;
 let constructError: Error | null = null;
-class ThrowingWebSocket {
-  constructor(_url: string, _protocols: string[] | undefined, _options: MockOptions) {
-    throw constructError ?? new Error("WebSocket construction failed");
-  }
-}
 
-const WS_FACTORY = function (
-  url: string,
-  protocols: string[] | undefined,
-  options: MockOptions
-): MockWebSocket | ThrowingWebSocket {
-  if (throwOnConstruct) {
-    return new ThrowingWebSocket(url, protocols, options);
-  }
-  return new MockWebSocket(url, protocols, options);
-} as unknown as typeof WebSocket;
+vi.mock("ws", () => {
+  const ctor = function (this: unknown, url: string, options: MockOptions) {
+    if (throwOnConstruct) {
+      throw constructError ?? new Error("WebSocket construction failed");
+    }
+    return new MockWebSocket(url, options);
+  } as unknown as new (url: string, options: MockOptions) => MockWebSocket;
+  return { default: ctor };
+});
+
+// Import the service AFTER vi.mock so the mocked `ws` is used.
+const { VoiceTranscriptionService } = await import("../VoiceTranscriptionService.js");
+type VoiceTranscriptionEvent = import("../VoiceTranscriptionService.js").VoiceTranscriptionEvent;
 
 const BASE_SETTINGS: VoiceInputSettings = {
   enabled: true,
@@ -136,13 +154,11 @@ describe("VoiceTranscriptionService", () => {
     instances.length = 0;
     throwOnConstruct = false;
     constructError = null;
-    vi.stubGlobal("WebSocket", WS_FACTORY);
     vi.useFakeTimers();
   });
 
   afterEach(() => {
     vi.useRealTimers();
-    vi.unstubAllGlobals();
     vi.restoreAllMocks();
   });
 
@@ -246,7 +262,7 @@ describe("VoiceTranscriptionService", () => {
     await secondPromise;
   });
 
-  it("times out with an error if session.updated does not arrive within 10s", async () => {
+  it("times out and closes the socket if session.updated does not arrive within 10s", async () => {
     const service = new VoiceTranscriptionService();
     const errors: string[] = [];
     service.onEvent((e) => {
@@ -255,13 +271,15 @@ describe("VoiceTranscriptionService", () => {
 
     const startPromise = service.start(BASE_SETTINGS);
     await Promise.resolve();
-    latestInstance().simulateOpen();
+    const socket = latestInstance();
+    socket.simulateOpen();
     // Never simulate session.updated.
 
     vi.advanceTimersByTime(10_000);
 
     await expect(startPromise).resolves.toEqual({ ok: false, error: "Connection timed out" });
     expect(errors).toContain("Connection timed out");
+    expect(socket.closeCalls).toBe(1);
   });
 
   // ── Delta / complete events ──────────────────────────────────────────────
@@ -410,6 +428,7 @@ describe("VoiceTranscriptionService", () => {
     socket.simulateMessage("conversation.item.input_audio_transcription.completed", {
       transcript: "done",
     });
+    vi.advanceTimersByTime(100);
     await drainPromise;
   });
 
@@ -432,8 +451,35 @@ describe("VoiceTranscriptionService", () => {
     socket.simulateMessage("conversation.item.input_audio_transcription.completed", {
       transcript: "final",
     });
+    // The grace timer fires 100ms after the first `completed` to give late
+    // arrivals (e.g. server_vad mid-utterance commits) a chance to join.
+    vi.advanceTimersByTime(100);
     await drainPromise;
     expect(statuses.at(-1)).toBe("idle");
+  });
+
+  it("drain grace period absorbs a late completed event without losing its transcript", async () => {
+    const service = new VoiceTranscriptionService();
+    const completes: string[] = [];
+    service.onEvent((e) => {
+      if (e.type === "complete") completes.push(e.text);
+    });
+
+    const { socket } = await bringSessionReady(service);
+    const drainPromise = service.stopGracefully();
+
+    // server_vad auto-committed item A mid-utterance; its completed arrives
+    // first, then item B's completed for our explicit commit arrives ~50ms later.
+    socket.simulateMessage("conversation.item.input_audio_transcription.completed", {
+      transcript: "first half",
+    });
+    vi.advanceTimersByTime(50);
+    socket.simulateMessage("conversation.item.input_audio_transcription.completed", {
+      transcript: "second half",
+    });
+    vi.advanceTimersByTime(100);
+    await drainPromise;
+    expect(completes).toEqual(["first half", "second half"]);
   });
 
   it("drain resolves after the timeout if no completed event arrives", async () => {
@@ -459,6 +505,7 @@ describe("VoiceTranscriptionService", () => {
     socket.simulateMessage("conversation.item.input_audio_transcription.completed", {
       transcript: "ok",
     });
+    vi.advanceTimersByTime(100);
     await Promise.all([first, second]);
   });
 
@@ -473,6 +520,39 @@ describe("VoiceTranscriptionService", () => {
     expect(statuses).toEqual(["idle"]);
   });
 
+  it("start() during an in-flight drain resolves the old drain and reaches recording", async () => {
+    const service = new VoiceTranscriptionService();
+    const statuses: string[] = [];
+    service.onEvent((e) => {
+      if (e.type === "status") statuses.push(e.status);
+    });
+
+    const { socket: firstSocket } = await bringSessionReady(service);
+    const drainPromise = service.stopGracefully();
+    // Don't simulate completed — drain is still in flight when start() runs.
+
+    const secondStart = service.start(BASE_SETTINGS);
+    await Promise.resolve();
+    const secondSocket = latestInstance();
+    secondSocket.simulateOpen();
+    secondSocket.simulateMessage("session.updated");
+    await secondStart;
+
+    // The first drain resolves once cleanupPreviousSession fires from start().
+    await drainPromise;
+
+    // Old commit was sent, new commit was NOT (new session has no drain).
+    const commitsOnFirst = firstSocket
+      .sentJson()
+      .filter((p) => p.type === "input_audio_buffer.commit").length;
+    const commitsOnSecond = secondSocket
+      .sentJson()
+      .filter((p) => p.type === "input_audio_buffer.commit").length;
+    expect(commitsOnFirst).toBe(1);
+    expect(commitsOnSecond).toBe(0);
+    expect(statuses.at(-1)).toBe("recording");
+  });
+
   // ── Error handling ───────────────────────────────────────────────────────
 
   it("emits error and error status when the WebSocket reports an error", async () => {
@@ -484,7 +564,7 @@ describe("VoiceTranscriptionService", () => {
     await Promise.resolve();
     const socket = latestInstance();
     socket.simulateOpen();
-    socket.simulateError(new Error("network down"), "network down");
+    socket.simulateError(new Error("network down"));
 
     await expect(startPromise).resolves.toEqual({ ok: false, error: "network down" });
     expect(events.some((e) => e.type === "error" && /network down/.test(e.message))).toBe(true);
@@ -504,6 +584,24 @@ describe("VoiceTranscriptionService", () => {
     });
 
     expect(errors).toContain("invalid_session_config");
+  });
+
+  it("parses string message data as well as Buffer", async () => {
+    const service = new VoiceTranscriptionService();
+    const completes: string[] = [];
+    service.onEvent((e) => {
+      if (e.type === "complete") completes.push(e.text);
+    });
+
+    const { socket } = await bringSessionReady(service);
+    // `ws` can deliver messages as strings when the server sends a text frame.
+    socket.simulateRawMessage(
+      JSON.stringify({
+        type: "conversation.item.input_audio_transcription.completed",
+        transcript: "from string",
+      })
+    );
+    expect(completes).toEqual(["from string"]);
   });
 
   it("ignores malformed JSON messages without throwing", async () => {

--- a/electron/store.ts
+++ b/electron/store.ts
@@ -358,7 +358,7 @@ const storeOptions = {
       openaiApiKey: "",
       language: "en",
       customDictionary: [],
-      transcriptionModel: "nova-3",
+      transcriptionModel: "gpt-realtime-whisper",
       correctionEnabled: false,
       correctionModel: "gpt-5-mini",
       correctionCustomInstructions: "",

--- a/package-lock.json
+++ b/package-lock.json
@@ -32,7 +32,6 @@
         "@codemirror/search": "^6.6.0",
         "@codemirror/state": "^6.6.0",
         "@codemirror/view": "^6.40.0",
-        "@deepgram/sdk": "^4.11.3",
         "@dnd-kit/core": "^6.3.1",
         "@dnd-kit/modifiers": "^9.0.0",
         "@dnd-kit/sortable": "^10.0.0",
@@ -1244,54 +1243,6 @@
       "engines": {
         "node": ">=20.19.0"
       }
-    },
-    "node_modules/@deepgram/captions": {
-      "version": "1.2.0",
-      "resolved": "https://registry.npmjs.org/@deepgram/captions/-/captions-1.2.0.tgz",
-      "integrity": "sha512-8B1C/oTxTxyHlSFubAhNRgCbQ2SQ5wwvtlByn8sDYZvdDtdn/VE2yEPZ4BvUnrKWmsbTQY6/ooLV+9Ka2qmDSQ==",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "dayjs": "^1.11.10"
-      },
-      "engines": {
-        "node": ">=18.0.0"
-      }
-    },
-    "node_modules/@deepgram/sdk": {
-      "version": "4.11.3",
-      "resolved": "https://registry.npmjs.org/@deepgram/sdk/-/sdk-4.11.3.tgz",
-      "integrity": "sha512-7NujHlAX6ciBeYAkxkhE7LCZWy0JK3nvFsV2VwVZIUiFR40ykhep5fxYd7ZovM+PbNyCoM8GKNMHu9MeQ5/wTQ==",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "@deepgram/captions": "^1.1.1",
-        "@types/node": "^18.19.39",
-        "cross-fetch": "^3.1.5",
-        "deepmerge": "^4.3.1",
-        "events": "^3.3.0",
-        "ws": "^8.17.0"
-      },
-      "engines": {
-        "node": ">=18.0.0"
-      }
-    },
-    "node_modules/@deepgram/sdk/node_modules/@types/node": {
-      "version": "18.19.130",
-      "resolved": "https://registry.npmjs.org/@types/node/-/node-18.19.130.tgz",
-      "integrity": "sha512-GRaXQx6jGfL8sKfaIDD6OupbIHBr9jv7Jnaml9tB7l4v068PAOXqfcujMMo5PhbIs6ggR1XODELqahT2R8v0fg==",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "undici-types": "~5.26.4"
-      }
-    },
-    "node_modules/@deepgram/sdk/node_modules/undici-types": {
-      "version": "5.26.5",
-      "resolved": "https://registry.npmjs.org/undici-types/-/undici-types-5.26.5.tgz",
-      "integrity": "sha512-JlCMO+ehdEIKqlFxk6IfVoAUVmgz7cU7zD/h9XZ0qzeosSHmUJVOzSQvvYSYWXkFXC+IfLKSIffhv0sVZup6pA==",
-      "dev": true,
-      "license": "MIT"
     },
     "node_modules/@derhuerst/http-basic": {
       "version": "8.2.4",
@@ -10494,16 +10445,6 @@
         "node": ">=20"
       }
     },
-    "node_modules/cross-fetch": {
-      "version": "3.2.0",
-      "resolved": "https://registry.npmjs.org/cross-fetch/-/cross-fetch-3.2.0.tgz",
-      "integrity": "sha512-Q+xVJLoGOeIMXZmbUK4HYk+69cQH6LudR0Vu/pRm2YlU/hDV9CiS0gKUMaWY5f2NeUH9C1nV3bsTlCo0FsTV1Q==",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "node-fetch": "^2.7.0"
-      }
-    },
     "node_modules/cross-spawn": {
       "version": "7.0.6",
       "resolved": "https://registry.npmjs.org/cross-spawn/-/cross-spawn-7.0.6.tgz",
@@ -10592,13 +10533,6 @@
       "engines": {
         "node": "^20.19.0 || ^22.12.0 || >=24.0.0"
       }
-    },
-    "node_modules/dayjs": {
-      "version": "1.11.20",
-      "resolved": "https://registry.npmjs.org/dayjs/-/dayjs-1.11.20.tgz",
-      "integrity": "sha512-YbwwqR/uYpeoP4pu043q+LTDLFBLApUP6VxRihdfNTqu4ubqMlGDLd6ErXhEgsyvY0K6nCs7nggYumAN+9uEuQ==",
-      "dev": true,
-      "license": "MIT"
     },
     "node_modules/debounce-fn": {
       "version": "6.0.0",
@@ -10696,16 +10630,6 @@
       "integrity": "sha512-oIPzksmTg4/MriiaYGO+okXDT7ztn/w3Eptv/+gSIdMdKsJo0u4CfYNFJPy+4SKMuCqGw2wxnA+URMg3t8a/bQ==",
       "dev": true,
       "license": "MIT"
-    },
-    "node_modules/deepmerge": {
-      "version": "4.3.1",
-      "resolved": "https://registry.npmjs.org/deepmerge/-/deepmerge-4.3.1.tgz",
-      "integrity": "sha512-3sUqbMEc77XqpdNO7FRyRog+eW3ph+GYCbj+rK+uYyRMuwsVy0rMiVtPn+QJlKFvWP/1PYpapqYn0Me2knFn+A==",
-      "dev": true,
-      "license": "MIT",
-      "engines": {
-        "node": ">=0.10.0"
-      }
     },
     "node_modules/default-browser": {
       "version": "5.5.0",
@@ -16139,52 +16063,6 @@
       "license": "MIT",
       "dependencies": {
         "semver": "^7.3.5"
-      }
-    },
-    "node_modules/node-fetch": {
-      "version": "2.7.0",
-      "resolved": "https://registry.npmjs.org/node-fetch/-/node-fetch-2.7.0.tgz",
-      "integrity": "sha512-c4FRfUm/dbcWZ7U+1Wq0AwCyFL+3nt2bEw05wfxSz+DWpWsitgmSgYmy2dQdWyKC1694ELPqMs/YzUSNozLt8A==",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "whatwg-url": "^5.0.0"
-      },
-      "engines": {
-        "node": "4.x || >=6.0.0"
-      },
-      "peerDependencies": {
-        "encoding": "^0.1.0"
-      },
-      "peerDependenciesMeta": {
-        "encoding": {
-          "optional": true
-        }
-      }
-    },
-    "node_modules/node-fetch/node_modules/tr46": {
-      "version": "0.0.3",
-      "resolved": "https://registry.npmjs.org/tr46/-/tr46-0.0.3.tgz",
-      "integrity": "sha512-N3WMsuqV66lT30CrXNbEjx4GEwlow3v6rr4mCcv6prnfwhS01rkgyFdjPNBYd9br7LpXV1+Emh01fHnq2Gdgrw==",
-      "dev": true,
-      "license": "MIT"
-    },
-    "node_modules/node-fetch/node_modules/webidl-conversions": {
-      "version": "3.0.1",
-      "resolved": "https://registry.npmjs.org/webidl-conversions/-/webidl-conversions-3.0.1.tgz",
-      "integrity": "sha512-2JAn3z8AR6rjK8Sm8orRC0h/bcl/DqL7tRPdGZ4I1CjdF+EaMLmYxBHyXuKL849eucPFhvBoxMsflfOb8kxaeQ==",
-      "dev": true,
-      "license": "BSD-2-Clause"
-    },
-    "node_modules/node-fetch/node_modules/whatwg-url": {
-      "version": "5.0.0",
-      "resolved": "https://registry.npmjs.org/whatwg-url/-/whatwg-url-5.0.0.tgz",
-      "integrity": "sha512-saE57nupxk6v3HY35+jzBwYa0rKSy0XR8JSxZPwgLr7ys0IBzhGviA1/TUGJLmSVqs8pb9AnvICXEuOHLprYTw==",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "tr46": "~0.0.3",
-        "webidl-conversions": "^3.0.0"
       }
     },
     "node_modules/node-gyp": {

--- a/package-lock.json
+++ b/package-lock.json
@@ -68,6 +68,7 @@
         "@types/semver": "^7.7.1",
         "@types/stopword": "^2.0.3",
         "@types/trusted-types": "^2.0.7",
+        "@types/ws": "^8.18.1",
         "@uiw/codemirror-themes": "^4.25.8",
         "@uiw/react-codemirror": "^4.25.8",
         "@vitejs/plugin-react": "^6.0.0",
@@ -135,6 +136,7 @@
         "vite": "^8.0.0",
         "vitest": "^4.1.0",
         "wait-on": "^9.0.4",
+        "ws": "^8.18.0",
         "zod": "^4.3.6",
         "zustand": "^5.0.12"
       },
@@ -7869,6 +7871,16 @@
       "dev": true,
       "license": "MIT",
       "optional": true
+    },
+    "node_modules/@types/ws": {
+      "version": "8.18.1",
+      "resolved": "https://registry.npmjs.org/@types/ws/-/ws-8.18.1.tgz",
+      "integrity": "sha512-ThVF6DCVhA8kUGy+aazFQ4kXQ7E1Ty7A3ypFOe0IcJV8O/M511G99AW24irKrW56Wt44yG9+ij8FaqoBGkuBXg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@types/node": "*"
+      }
     },
     "node_modules/@types/yauzl": {
       "version": "2.10.3",

--- a/package.json
+++ b/package.json
@@ -163,6 +163,7 @@
     "@types/semver": "^7.7.1",
     "@types/stopword": "^2.0.3",
     "@types/trusted-types": "^2.0.7",
+    "@types/ws": "^8.18.1",
     "@uiw/codemirror-themes": "^4.25.8",
     "@uiw/react-codemirror": "^4.25.8",
     "@vitejs/plugin-react": "^6.0.0",
@@ -230,6 +231,7 @@
     "vite": "^8.0.0",
     "vitest": "^4.1.0",
     "wait-on": "^9.0.4",
+    "ws": "^8.18.0",
     "zod": "^4.3.6",
     "zustand": "^5.0.12"
   }

--- a/package.json
+++ b/package.json
@@ -127,7 +127,6 @@
     "@codemirror/search": "^6.6.0",
     "@codemirror/state": "^6.6.0",
     "@codemirror/view": "^6.40.0",
-    "@deepgram/sdk": "^4.11.3",
     "@dnd-kit/core": "^6.3.1",
     "@dnd-kit/modifiers": "^9.0.0",
     "@dnd-kit/sortable": "^10.0.0",

--- a/shared/types/ipc/api.ts
+++ b/shared/types/ipc/api.ts
@@ -1490,7 +1490,7 @@ export type MicPermissionStatus =
   | "restricted"
   | "unknown";
 
-export type VoiceTranscriptionModel = "nova-3" | "nova-2";
+export type VoiceTranscriptionModel = "gpt-realtime-whisper";
 
 export type VoiceCorrectionModel = "gpt-5-nano" | "gpt-5-mini";
 
@@ -1498,18 +1498,12 @@ export type VoiceCorrectionModel = "gpt-5-nano" | "gpt-5-mini";
  * Paragraphing strategy for voice dictation.
  *
  * "spoken-command" (default): The user says "new paragraph" to insert a paragraph break.
- *   Deepgram Dictation mode intercepts spoken commands ("new paragraph" → \n\n, "period" → ".",
- *   "new line" → \n, etc.) rather than transcribing them literally. Manual Enter is always
- *   available as a secondary mechanism.
+ *   Spoken commands ("new paragraph" → \n\n, "period" → ".", "new line" → \n, etc.) are
+ *   transcribed literally by the upstream service and rewritten post-hoc by the IPC handler
+ *   via applyDictationCommands. Manual Enter is always available as a secondary mechanism.
  *
  * "manual": Paragraph breaks are inserted only via the Enter key. No spoken commands.
  *   Best for users who prefer keyboard control or find spoken formatting commands awkward.
- *
- * Note: Deepgram's `paragraphs: true` parameter was evaluated and rejected as the primary
- * mechanism — in live streaming it populates a structured JSON object rather than injecting
- * \n\n into the transcript text, making it unreliable as an auto-paragraphing trigger.
- * Custom keyword detection was also evaluated and rejected in favor of Deepgram Dictation,
- * which natively handles the "new paragraph" command in Nova-3.
  */
 export type VoiceParagraphingStrategy = "spoken-command" | "manual";
 

--- a/src/components/Settings/VoiceInputSettingsTab.tsx
+++ b/src/components/Settings/VoiceInputSettingsTab.tsx
@@ -72,14 +72,9 @@ const TRANSCRIPTION_MODELS: {
   description: string;
 }[] = [
   {
-    value: "nova-3",
-    label: "Nova-3",
-    description: "Latest · best accuracy · $0.0077/min",
-  },
-  {
-    value: "nova-2",
-    label: "Nova-2",
-    description: "Stable fallback · $0.0043/min",
+    value: "gpt-realtime-whisper",
+    label: "Whisper (Realtime)",
+    description: "OpenAI Realtime · $0.017/min",
   },
 ];
 
@@ -88,7 +83,7 @@ const DEFAULT_SETTINGS: VoiceInputSettings = {
   openaiApiKey: "",
   language: "en",
   customDictionary: [],
-  transcriptionModel: "nova-3",
+  transcriptionModel: "gpt-realtime-whisper",
   correctionEnabled: false,
   correctionModel: "gpt-5-mini",
   correctionCustomInstructions: "",

--- a/src/components/Settings/__tests__/settingsSearchUtils.test.ts
+++ b/src/components/Settings/__tests__/settingsSearchUtils.test.ts
@@ -416,8 +416,8 @@ describe("voice tab coverage", () => {
     expect(results.length).toBeGreaterThan(0);
   });
 
-  it("returns results for 'deepgram' query", () => {
-    const results = filterSettings(SETTINGS_SEARCH_INDEX, "deepgram");
+  it("returns results for 'whisper' query", () => {
+    const results = filterSettings(SETTINGS_SEARCH_INDEX, "whisper");
     expect(results.some((r) => r.tab === "voice")).toBe(true);
   });
 
@@ -675,7 +675,7 @@ describe("requiresEnabled metadata", () => {
 
   it("Voice speech-to-text sub-settings reference voice-enable", () => {
     for (const id of [
-      "voice-deepgram-key",
+      "voice-stt-openai-key",
       "voice-language",
       "voice-transcription-model",
       "voice-paragraph-breaks",

--- a/src/components/Settings/settingsTabRegistry.tsx
+++ b/src/components/Settings/settingsTabRegistry.tsx
@@ -1128,8 +1128,8 @@ export const SETTINGS_REGISTRY = [
       "microphone",
       "speech",
       "dictation",
-      "deepgram",
       "openai",
+      "whisper",
       "transcription",
     ],
     sections: [
@@ -1141,11 +1141,11 @@ export const SETTINGS_REGISTRY = [
         keywords: ["voice", "microphone", "dictate", "speech", "recording", "enable", "mic"],
       },
       {
-        id: "voice-deepgram-key",
+        id: "voice-stt-openai-key",
         section: "Speech-to-Text",
-        title: "Deepgram API Key",
-        description: "Configure your Deepgram API key for speech recognition",
-        keywords: ["deepgram", "api", "key", "speech-to-text", "stt", "nova"],
+        title: "OpenAI API Key",
+        description: "Configure your OpenAI API key for realtime speech recognition",
+        keywords: ["openai", "api", "key", "speech-to-text", "stt", "whisper"],
         requiresEnabled: VOICE_REQUIRES_ENABLED,
       },
       {
@@ -1160,8 +1160,8 @@ export const SETTINGS_REGISTRY = [
         id: "voice-transcription-model",
         section: "Speech-to-Text",
         title: "Transcription Model",
-        description: "Choose the Deepgram model for transcription accuracy",
-        keywords: ["nova-3", "nova-2", "model", "deepgram", "accuracy", "transcription"],
+        description: "Choose the OpenAI Realtime model for transcription accuracy",
+        keywords: ["whisper", "gpt-realtime", "model", "openai", "accuracy", "transcription"],
         requiresEnabled: VOICE_REQUIRES_ENABLED,
       },
       {


### PR DESCRIPTION
## Summary

- Replaces the Deepgram streaming client in `VoiceTranscriptionService` with OpenAI's realtime WebSocket interface, using the `ws` npm package (Node's global `WebSocket` silently drops custom headers)
- IPC event shapes (`delta` / `complete` / `paragraph_boundary` / `error` / `status`) are unchanged — renderer-side consumers are untouched
- Adds drain logic: `input_audio_buffer.commit` on graceful stop, with a 100ms grace timer to absorb late `server_vad` auto-commit completions and a 3s upper-bound timeout that also closes the underlying socket

Resolves #7831

## Changes

- `electron/services/VoiceTranscriptionService.ts` — full rewrite to OpenAI realtime WS; `VoiceTranscriptionModel` collapsed to `"gpt-realtime-whisper"`; connect timeout now closes the socket
- `package.json` — adds `ws ^8.18.0` + `@types/ws ^8.18.1`; removes `@deepgram/sdk ^4.11.3`
- `shared/types/ipc/api.ts`, `electron/store.ts`, `electron/preload.cts`, settings UI — model defaults and registry key updated (`voice-stt-openai-key`, replacing the old Deepgram key entry)
- Test suite rewritten from a 1602-line Deepgram SDK mock to ~660 lines using `vi.mock("ws", ...)` with an `EventEmitter`-style `MockWebSocket`

## Testing

225/225 unit tests passing. Coverage includes: lifecycle, auth headers, `session.update` payload, language passthrough, pre-connect buffer + 100-cap, drain grace, drain timeout, drain race (`server_vad` auto-commit vs explicit commit), shared in-flight drain, stop-without-connection, WS error, server-side error event, malformed JSON, `Buffer` + string message data, connect timeout closes socket, stale session guard, `commitParagraphBoundary` no-op on socket, start-during-drain transition, and destroy.