### PR TITLE
refactor(voice): clean up settings tab for single OpenAI provider

### DIFF
--- a/src/components/Settings/VoiceInputSettingsTab.tsx
+++ b/src/components/Settings/VoiceInputSettingsTab.tsx
@@ -31,7 +31,6 @@ import { CORE_CORRECTION_PROMPT } from "@shared/config/voiceCorrection";
 import type {
   VoiceInputSettings,
   MicPermissionStatus,
-  VoiceTranscriptionModel,
   VoiceCorrectionModel,
   VoiceParagraphingStrategy,
 } from "@shared/types";
@@ -63,18 +62,6 @@ const CORRECTION_MODELS: {
     value: "gpt-5-nano",
     label: "GPT-5 Nano",
     description: "Faster · lower cost",
-  },
-];
-
-const TRANSCRIPTION_MODELS: {
-  value: VoiceTranscriptionModel;
-  label: string;
-  description: string;
-}[] = [
-  {
-    value: "gpt-realtime-whisper",
-    label: "Whisper (Realtime)",
-    description: "OpenAI Realtime · $0.017/min",
   },
 ];
 
@@ -245,17 +232,6 @@ export function VoiceInputSettingsTab() {
               value={settings.language}
               onValueChange={(v) => update({ language: v })}
               options={LANGUAGES.map(({ code, label }) => ({ value: code, label }))}
-            />
-
-            <SettingsSelect
-              label="Transcription Model"
-              value={settings.transcriptionModel}
-              onValueChange={(v) => update({ transcriptionModel: v as VoiceTranscriptionModel })}
-              options={TRANSCRIPTION_MODELS.map(({ value, label, description }) => ({
-                value,
-                label,
-                description,
-              }))}
             />
 
             <ParagraphingStrategyRow

--- a/src/components/Settings/__tests__/settingsSearchUtils.test.ts
+++ b/src/components/Settings/__tests__/settingsSearchUtils.test.ts
@@ -731,6 +731,15 @@ describe("requiresEnabled metadata", () => {
     const voiceEnable = byId("voice-enable");
     expect(voiceEnable?.requiresEnabled).toBeUndefined();
   });
+
+  it("legacy voice registry IDs are not re-introduced", () => {
+    for (const id of ["voice-transcription-model", "voice-openai-key"]) {
+      expect(
+        byId(id),
+        `${id} was removed for the OpenAI-only rebuild and must not return`
+      ).toBeUndefined();
+    }
+  });
 });
 
 describe("help dock discoverability", () => {

--- a/src/components/Settings/__tests__/settingsSearchUtils.test.ts
+++ b/src/components/Settings/__tests__/settingsSearchUtils.test.ts
@@ -677,7 +677,6 @@ describe("requiresEnabled metadata", () => {
     for (const id of [
       "voice-stt-openai-key",
       "voice-language",
-      "voice-transcription-model",
       "voice-paragraph-breaks",
       "voice-custom-dictionary",
       "voice-ai-correction-enable",
@@ -691,7 +690,7 @@ describe("requiresEnabled metadata", () => {
   });
 
   it("Voice AI correction sub-settings reference voice-ai-correction-enable", () => {
-    for (const id of ["voice-openai-key", "voice-correction-model", "voice-custom-instructions"]) {
+    for (const id of ["voice-correction-model", "voice-custom-instructions"]) {
       const entry = byId(id);
       expect(
         entry?.requiresEnabled?.settingId,
@@ -725,8 +724,8 @@ describe("requiresEnabled metadata", () => {
   });
 
   it("two-level dependency chain is fully connected", () => {
-    const openaiKey = byId("voice-openai-key");
-    expect(openaiKey?.requiresEnabled?.settingId).toBe("voice-ai-correction-enable");
+    const correctionModel = byId("voice-correction-model");
+    expect(correctionModel?.requiresEnabled?.settingId).toBe("voice-ai-correction-enable");
     const aiCorrection = byId("voice-ai-correction-enable");
     expect(aiCorrection?.requiresEnabled?.settingId).toBe("voice-enable");
     const voiceEnable = byId("voice-enable");

--- a/src/components/Settings/settingsTabRegistry.tsx
+++ b/src/components/Settings/settingsTabRegistry.tsx
@@ -1157,14 +1157,6 @@ export const SETTINGS_REGISTRY = [
         requiresEnabled: VOICE_REQUIRES_ENABLED,
       },
       {
-        id: "voice-transcription-model",
-        section: "Speech-to-Text",
-        title: "Transcription Model",
-        description: "Choose the OpenAI Realtime model for transcription accuracy",
-        keywords: ["whisper", "gpt-realtime", "model", "openai", "accuracy", "transcription"],
-        requiresEnabled: VOICE_REQUIRES_ENABLED,
-      },
-      {
         id: "voice-paragraph-breaks",
         section: "Speech-to-Text",
         title: "Paragraph Breaks",
@@ -1187,14 +1179,6 @@ export const SETTINGS_REGISTRY = [
         description: "Enable AI-powered post-processing to clean up transcribed text",
         keywords: ["correction", "ai", "cleanup", "post-process", "filler"],
         requiresEnabled: VOICE_REQUIRES_ENABLED,
-      },
-      {
-        id: "voice-openai-key",
-        section: "AI Text Correction",
-        title: "OpenAI API Key",
-        description: "Configure your OpenAI API key for AI text correction",
-        keywords: ["openai", "api", "key", "correction", "gpt"],
-        requiresEnabled: VOICE_AI_REQUIRES_ENABLED,
       },
       {
         id: "voice-correction-model",

--- a/src/services/VoiceRecordingService.ts
+++ b/src/services/VoiceRecordingService.ts
@@ -152,7 +152,7 @@ class VoiceRecordingService {
 
     this.unsubscribers.push(
       voiceInput.onParagraphBoundary(({ rawText }) => {
-        logDebug(`${LOG_PREFIX} Received paragraph boundary from Deepgram`, { rawText });
+        logDebug(`${LOG_PREFIX} Received paragraph boundary`, { rawText });
         const voiceState = useVoiceRecordingStore.getState();
         const currentTarget = voiceState.activeTarget;
         if (!currentTarget) return;
@@ -528,7 +528,7 @@ class VoiceRecordingService {
       .getState()
       .announce(`Dictation started in ${formatTargetLabel(target)}.`);
 
-    // Connect to Deepgram in parallel — audio is already flowing.
+    // Connect in parallel — audio is already flowing.
     logDebug(`${LOG_PREFIX} Calling voiceInput.start() IPC`);
     const result = await window.electron.voiceInput.start();
     logDebug(`${LOG_PREFIX} voiceInput.start() returned`, {


### PR DESCRIPTION
## Summary

- Removes the transcription model selector from the Voice settings tab — `gpt-realtime-whisper` is an implementation detail, not a user choice
- Removes orphaned registry IDs (`voice-transcription-model`, duplicate `voice-openai-key`) and sweeps Deepgram-specific log strings to be provider-agnostic
- Updates tests to guard against re-introducing the removed IDs

Resolves #7835

## Changes

- `VoiceInputSettingsTab.tsx` — removed `TRANSCRIPTION_MODELS` constant, `VoiceTranscriptionModel` import, and the single-option model selector row
- `settingsTabRegistry.tsx` — removed orphaned `voice-transcription-model` entry and duplicate `voice-openai-key` (canonical is `voice-stt-openai-key`)
- `VoiceRecordingService.ts` — two Deepgram log strings made provider-agnostic
- `settingsSearchUtils.test.ts` — dropped removed IDs, rewrote the two-level chain test to anchor on `voice-correction-model`, added absence guards

## Testing

Typecheck, lint, format, build, channels check, IPC check, and vitest (102 tests) all pass.