### PR TITLE
refactor(theme): add filter-selected-bg-{soft,strong} semantic tokens

### DIFF
--- a/shared/theme/themes.ts
+++ b/shared/theme/themes.ts
@@ -179,6 +179,10 @@ export function createDaintreeTokens(
     "overlay-active": tokens["overlay-active"] ?? withAlpha(overlayTone, dark ? 0.08 : 0.06),
     "overlay-selected": tokens["overlay-selected"] ?? withAlpha(overlayTone, dark ? 0.04 : 0.05),
     "overlay-elevated": tokens["overlay-elevated"] ?? withAlpha(overlayTone, dark ? 0.06 : 0.08),
+    "filter-selected-bg-soft":
+      tokens["filter-selected-bg-soft"] ?? withAlpha(tint, dark ? 0.08 : 0.06),
+    "filter-selected-bg-strong":
+      tokens["filter-selected-bg-strong"] ?? withAlpha(tint, dark ? 0.12 : 0.1),
     "wash-subtle": tokens["wash-subtle"] ?? withAlpha(overlayBase, 0.02),
     "wash-medium": tokens["wash-medium"] ?? withAlpha(overlayBase, 0.04),
     "wash-strong": tokens["wash-strong"] ?? withAlpha(overlayBase, 0.08),

--- a/shared/theme/types.ts
+++ b/shared/theme/types.ts
@@ -73,6 +73,10 @@ export const APP_THEME_TOKEN_KEYS = [
   "overlay-selected",
   "overlay-elevated",
 
+  // Selected-state pill backgrounds (tint-derived; neutral across hued themes)
+  "filter-selected-bg-soft",
+  "filter-selected-bg-strong",
+
   // Atmospheric wash
   "wash-subtle",
   "wash-medium",

--- a/src/components/Notifications/NotificationCenter.tsx
+++ b/src/components/Notifications/NotificationCenter.tsx
@@ -601,7 +601,7 @@ export function NotificationCenter({ open, onClose }: NotificationCenterProps) {
                 className={cn(
                   "inline-flex items-center px-2 py-0.5 text-[11px] rounded-full transition-colors",
                   filter === "all"
-                    ? "bg-tint/[0.12] text-daintree-text font-medium"
+                    ? "bg-filter-selected-bg-strong text-daintree-text font-medium"
                     : "text-daintree-text/60 hover:text-daintree-text hover:bg-tint/[0.04]"
                 )}
               >
@@ -614,7 +614,7 @@ export function NotificationCenter({ open, onClose }: NotificationCenterProps) {
                 className={cn(
                   "inline-flex items-center px-2 py-0.5 text-[11px] rounded-full transition-colors",
                   filter === "unread"
-                    ? "bg-tint/[0.12] text-daintree-text font-medium"
+                    ? "bg-filter-selected-bg-strong text-daintree-text font-medium"
                     : "text-daintree-text/60 hover:text-daintree-text hover:bg-tint/[0.04]"
                 )}
               >

--- a/src/components/Worktree/QuickStateFilterBar.tsx
+++ b/src/components/Worktree/QuickStateFilterBar.tsx
@@ -46,7 +46,7 @@ export function QuickStateFilterBar({ value, onChange, counts }: QuickStateFilte
             className={cn(
               "inline-flex items-center gap-1.5 px-3 py-1 text-xs rounded-full transition-colors",
               isActive
-                ? "bg-overlay-strong ring-1 ring-inset ring-border-strong text-daintree-text font-medium"
+                ? "bg-filter-selected-bg-soft ring-1 ring-inset ring-border-strong text-daintree-text font-medium"
                 : "text-daintree-text/60 hover:text-daintree-text hover:bg-tint/[0.04]"
             )}
           >

--- a/src/components/Worktree/ReviewHub/ReviewHubContent.tsx
+++ b/src/components/Worktree/ReviewHub/ReviewHubContent.tsx
@@ -1191,7 +1191,7 @@ export function ReviewHubContent({
                   "px-2 py-1 transition-colors",
                   "focus-visible:outline-hidden focus-visible:ring-1 focus-visible:ring-daintree-accent",
                   diffMode === "working-tree"
-                    ? "bg-tint/[0.12] text-daintree-text"
+                    ? "bg-filter-selected-bg-strong text-daintree-text"
                     : "text-daintree-text/50 hover:text-daintree-text hover:bg-tint/[0.06]"
                 )}
                 aria-pressed={diffMode === "working-tree"}
@@ -1206,7 +1206,7 @@ export function ReviewHubContent({
                   "focus-visible:outline-hidden focus-visible:ring-1 focus-visible:ring-daintree-accent",
                   "disabled:opacity-40 disabled:cursor-not-allowed",
                   diffMode === "base-branch"
-                    ? "bg-tint/[0.12] text-daintree-text"
+                    ? "bg-filter-selected-bg-strong text-daintree-text"
                     : "text-daintree-text/50 hover:text-daintree-text hover:bg-tint/[0.06]"
                 )}
                 aria-pressed={diffMode === "base-branch"}
@@ -1303,7 +1303,7 @@ export function ReviewHubContent({
                   "disabled:opacity-50 disabled:cursor-not-allowed",
                   isPrimary
                     ? "bg-status-warning/20 hover:bg-status-warning/30 text-status-warning"
-                    : "bg-tint/[0.08] hover:bg-tint/[0.14] text-daintree-text/80"
+                    : "bg-filter-selected-bg-soft hover:bg-tint/[0.14] text-daintree-text/80"
                 )}
               >
                 {isLoading && cta.kind === "pull-rebase" ? "Pulling…" : cta.label}

--- a/src/components/Worktree/WorktreeFilterPopover.tsx
+++ b/src/components/Worktree/WorktreeFilterPopover.tsx
@@ -66,7 +66,7 @@ function FilterChip({ label, isActive, onClick, count }: FilterChipProps) {
       className={cn(
         "inline-flex items-center px-2 py-0.5 text-[11px] rounded-full border transition-colors",
         isActive
-          ? "bg-tint/[0.08] border-daintree-border text-daintree-text"
+          ? "bg-filter-selected-bg-soft border-daintree-border text-daintree-text"
           : isDimmed
             ? "bg-daintree-bg border-daintree-border text-daintree-text/30 hover:bg-overlay-soft hover:text-daintree-text/50"
             : "bg-daintree-bg border-daintree-border text-daintree-text/60 hover:bg-overlay-medium hover:text-daintree-text/80"

--- a/src/components/Worktree/__tests__/QuickStateFilterBar.test.tsx
+++ b/src/components/Worktree/__tests__/QuickStateFilterBar.test.tsx
@@ -93,12 +93,12 @@ describe("QuickStateFilterBar", () => {
     expect(active.className).toContain("ring-1");
     expect(active.className).toContain("ring-inset");
     expect(active.className).toContain("ring-border-strong");
-    expect(active.className).toContain("bg-overlay-strong");
+    expect(active.className).toContain("bg-filter-selected-bg-soft");
     expect(active.className).toContain("font-medium");
 
     const inactive = screen.getByRole("button", { name: /Waiting/ });
     expect(inactive.className).not.toContain("ring-border-strong");
-    expect(inactive.className).not.toContain("bg-overlay-strong");
+    expect(inactive.className).not.toContain("bg-filter-selected-bg-soft");
   });
 
   it("marks the active pill with aria-pressed=true", () => {
@@ -218,7 +218,7 @@ describe("QuickStateFilterBar", () => {
     );
     const working = screen.getByRole("button", { name: /Working/ });
     expect(working.getAttribute("aria-pressed")).toBe("true");
-    expect(working.className).toContain("bg-overlay-strong");
+    expect(working.className).toContain("bg-filter-selected-bg-soft");
     const svg = working.querySelector("svg");
     expect(svg).not.toBeNull();
     expect(svg?.getAttribute("class") ?? "").toContain("animate-spin-slow");

--- a/src/config/__tests__/colorSystem.contract.test.ts
+++ b/src/config/__tests__/colorSystem.contract.test.ts
@@ -68,7 +68,7 @@ describe("color system contract", () => {
 
   it("uses only exported theme-style color utilities in renderer source", () => {
     const utilityRegex =
-      /\b(?:bg|text|border|ring|outline|placeholder|fill|stroke)-((?:daintree|surface|text|accent|status|activity|category|github|overlay|scrim|state|server|terminal|cat)[a-z0-9-]*)(?:\/[^\s"'`)]+)?/g;
+      /\b(?:bg|text|border|ring|outline|placeholder|fill|stroke)-((?:daintree|surface|text|accent|status|activity|category|github|overlay|scrim|state|server|terminal|cat|filter)[a-z0-9-]*)(?:\/[^\s"'`)]+)?/g;
 
     const missing = new Map<string, string[]>();
 

--- a/src/index.css
+++ b/src/index.css
@@ -70,6 +70,8 @@
   --color-overlay-active: var(--theme-overlay-active);
   --color-overlay-selected: var(--theme-overlay-selected);
   --color-overlay-elevated: var(--theme-overlay-elevated);
+  --color-filter-selected-bg-soft: var(--theme-filter-selected-bg-soft);
+  --color-filter-selected-bg-strong: var(--theme-filter-selected-bg-strong);
   --color-wash-subtle: var(--theme-wash-subtle);
   --color-wash-medium: var(--theme-wash-medium);
   --color-wash-strong: var(--theme-wash-strong);


### PR DESCRIPTION
## Summary

- Adds `filter-selected-bg-soft` and `filter-selected-bg-strong` semantic tokens for selected-state pill backgrounds, using the pure tint ladder (0.08/0.06 soft, 0.12/0.10 strong).
- Replaces seven ad-hoc `bg-tint` and `bg-overlay-strong` instances across `QuickStateFilterBar`, `WorktreeFilterPopover`, `NotificationCenter`, and `ReviewHubContent`.
- Ring decorations and hover states stay inline per issue scope.

Resolves #7857

## Changes

- `shared/theme/types.ts` — two new token fields on `SemanticColorTokens`
- `shared/theme/themes.ts` — token values for all built-in themes
- `src/index.css` — Tailwind utilities for the two new tokens
- `QuickStateFilterBar`, `WorktreeFilterPopover`, `NotificationCenter`, `ReviewHubContent` — migrated to the new tokens
- `QuickStateFilterBar.test.tsx`, `colorSystem.contract.test.ts` — assertions updated for new class names and `filter` prefix

## Testing

- Updated unit tests confirm the new class names are applied.
- `colorSystem.contract.test.ts` regex extended to cover the `filter-*` prefix.
- `npm run check` passes cleanly.