### PR TITLE
fix(ui): harden ConfirmDialog against destructive-confirmation drift

### DIFF
--- a/src/components/Worktree/WorktreeDeleteDialog.tsx
+++ b/src/components/Worktree/WorktreeDeleteDialog.tsx
@@ -246,15 +246,7 @@ export function WorktreeDeleteDialog({ isOpen, onClose, worktree }: WorktreeDele
                 value={confirmInput}
                 onChange={setConfirmInput}
                 onMatchSubmit={() => void handleDelete()}
-                instructions={
-                  <>
-                    Force-deleting this protected worktree is irreversible. Type{" "}
-                    <code className="font-mono text-xs bg-daintree-bg/50 px-1.5 py-0.5 rounded border border-daintree-border">
-                      {confirmTarget}
-                    </code>{" "}
-                    to confirm.
-                  </>
-                }
+                preamble="Force-deleting this protected worktree is irreversible."
                 data-testid="delete-worktree-confirm-input"
               />
             )}

--- a/src/components/ui/ConfirmDialog.tsx
+++ b/src/components/ui/ConfirmDialog.tsx
@@ -6,7 +6,22 @@ import { TypedNameConfirmInput } from "@/components/ui/TypedNameConfirmInput";
 const DESTRUCTIVE_CONFIRM_LABEL_RE =
   /^\s*(delete|remove|destroy|erase|wipe|purge|abort|reset|revoke|terminate|uninstall)\b/i;
 
-export interface ConfirmDialogProps {
+const GENERIC_CONFIRM_LABEL_RE =
+  /^\s*(ok|confirm|yes|save|continue|proceed|done|got it|accept|apply|submit)\s*$/i;
+
+const devWarnedKeys = new Set<string>();
+
+export const __devWarnedKeys = devWarnedKeys;
+
+function warnOnce(key: string, message: string) {
+  if (!import.meta.env.DEV) return;
+  if (devWarnedKeys.has(key)) return;
+  devWarnedKeys.add(key);
+  // eslint-disable-next-line no-console
+  console.error(message);
+}
+
+type ConfirmDialogBaseProps = {
   isOpen: boolean;
   onClose?: () => void;
   title: React.ReactNode;
@@ -16,25 +31,36 @@ export interface ConfirmDialogProps {
   cancelLabel?: string;
   onConfirm: () => void | Promise<void>;
   isConfirmLoading?: boolean;
-  variant: "default" | "destructive" | "info";
   zIndex?: DialogZIndex;
-  typedNameTarget?: string;
-}
+};
 
-export function ConfirmDialog({
-  isOpen,
-  onClose,
-  title,
-  description,
-  children,
-  confirmLabel,
-  cancelLabel = "Cancel",
-  onConfirm,
-  isConfirmLoading = false,
-  variant,
-  zIndex,
-  typedNameTarget,
-}: ConfirmDialogProps) {
+export type ConfirmDialogProps =
+  | (ConfirmDialogBaseProps & {
+      variant: "destructive";
+      typedNameTarget?: string;
+    })
+  | (ConfirmDialogBaseProps & {
+      variant: "default" | "info";
+      typedNameTarget?: never;
+    });
+
+export function ConfirmDialog(props: ConfirmDialogProps) {
+  const {
+    isOpen,
+    onClose,
+    title,
+    description,
+    children,
+    confirmLabel,
+    cancelLabel = "Cancel",
+    onConfirm,
+    isConfirmLoading = false,
+    variant,
+    zIndex,
+  } = props;
+  const rawTypedNameTarget = (props as { typedNameTarget?: string }).typedNameTarget;
+  const typedNameTarget = variant === "destructive" ? rawTypedNameTarget : undefined;
+
   const handleClose = onClose ?? (() => {});
   const [typedValue, setTypedValue] = useState("");
 
@@ -42,21 +68,24 @@ export function ConfirmDialog({
     if (!isOpen) setTypedValue("");
   }, [isOpen]);
 
-  if (
-    import.meta.env.DEV &&
-    variant !== "destructive" &&
-    DESTRUCTIVE_CONFIRM_LABEL_RE.test(confirmLabel)
-  ) {
-    // eslint-disable-next-line no-console
-    console.error(
+  if (variant !== "destructive" && DESTRUCTIVE_CONFIRM_LABEL_RE.test(confirmLabel)) {
+    warnOnce(
+      `forward-label:${variant}:${confirmLabel.trim().toLowerCase()}`,
       `[ConfirmDialog] Destructive confirmLabel "${confirmLabel}" rendered with variant="${variant}". Use variant="destructive" so the primary button gets the destructive styling.`
     );
   }
 
-  if (import.meta.env.DEV && typedNameTarget && variant !== "destructive") {
-    // eslint-disable-next-line no-console
-    console.error(
-      `[ConfirmDialog] typedNameTarget="${typedNameTarget}" was set with variant="${variant}". The typed-name gate is intended for destructive actions; use variant="destructive".`
+  if (variant === "destructive" && GENERIC_CONFIRM_LABEL_RE.test(confirmLabel)) {
+    warnOnce(
+      `inverse-label:${confirmLabel.trim().toLowerCase()}`,
+      `[ConfirmDialog] Destructive variant rendered with generic confirmLabel "${confirmLabel}". Use a verb-noun label like "Delete worktree" so the button names the action.`
+    );
+  }
+
+  if (rawTypedNameTarget && variant !== "destructive") {
+    warnOnce(
+      `typed-name-variant:${variant}`,
+      `[ConfirmDialog] typedNameTarget="${rawTypedNameTarget}" was set with variant="${variant}". The typed-name gate is intended for destructive actions; use variant="destructive".`
     );
   }
 

--- a/src/components/ui/TypedNameConfirmInput.tsx
+++ b/src/components/ui/TypedNameConfirmInput.tsx
@@ -6,6 +6,7 @@ export interface TypedNameConfirmInputProps {
   value: string;
   onChange: (value: string) => void;
   onMatchSubmit?: () => void;
+  preamble?: React.ReactNode;
   instructions?: React.ReactNode;
   "data-testid"?: string;
 }
@@ -15,11 +16,14 @@ export function TypedNameConfirmInput({
   value,
   onChange,
   onMatchSubmit,
+  preamble,
   instructions,
   "data-testid": testId,
 }: TypedNameConfirmInputProps) {
   const instructionsId = useId();
+  const preambleId = useId();
   const isMatched = value === target;
+  const hasPreamble = preamble !== undefined && preamble !== null && !instructions;
 
   const defaultInstructions = (
     <>
@@ -33,6 +37,11 @@ export function TypedNameConfirmInput({
 
   return (
     <div className="space-y-2 p-3 bg-status-error/5 border border-status-error/20 rounded">
+      {hasPreamble && (
+        <p id={preambleId} className="text-sm text-daintree-text">
+          {preamble}
+        </p>
+      )}
       <p id={instructionsId} className="text-sm text-daintree-text">
         {instructions ?? defaultInstructions}
       </p>
@@ -46,7 +55,7 @@ export function TypedNameConfirmInput({
             onMatchSubmit();
           }
         }}
-        aria-describedby={instructionsId}
+        aria-describedby={hasPreamble ? `${preambleId} ${instructionsId}` : instructionsId}
         aria-label={`Type ${target} to confirm`}
         autoComplete="off"
         spellCheck={false}

--- a/src/components/ui/TypedNameConfirmInput.tsx
+++ b/src/components/ui/TypedNameConfirmInput.tsx
@@ -23,7 +23,7 @@ export function TypedNameConfirmInput({
   const instructionsId = useId();
   const preambleId = useId();
   const isMatched = value === target;
-  const hasPreamble = preamble !== undefined && preamble !== null && !instructions;
+  const hasPreamble = preamble != null && instructions == null;
 
   const defaultInstructions = (
     <>

--- a/src/components/ui/__tests__/ConfirmDialog.test.tsx
+++ b/src/components/ui/__tests__/ConfirmDialog.test.tsx
@@ -146,7 +146,19 @@ describe("ConfirmDialog inverse-label dev guard", () => {
     vi.unstubAllEnvs();
   });
 
-  it.each(["OK", "Confirm", "Yes", "Save", "Continue", "Proceed", "Done", "Got it", "Accept", "Apply", "Submit"])(
+  it.each([
+    "OK",
+    "Confirm",
+    "Yes",
+    "Save",
+    "Continue",
+    "Proceed",
+    "Done",
+    "Got it",
+    "Accept",
+    "Apply",
+    "Submit",
+  ])(
     "warns when variant is destructive and confirmLabel is a generic recovery label: %s",
     (label) => {
       render(
@@ -515,6 +527,7 @@ describe("ConfirmDialog — typed-name gate", () => {
 
   it("warns in dev when typedNameTarget is set with a non-destructive variant", () => {
     render(
+      // @ts-expect-error — intentionally violates the discriminated union to exercise the runtime fallback guard
       <ConfirmDialog
         isOpen={true}
         onClose={() => {}}
@@ -522,15 +535,14 @@ describe("ConfirmDialog — typed-name gate", () => {
         confirmLabel="Continue"
         onConfirm={() => {}}
         variant="default"
-        // @ts-expect-error — intentionally violates the discriminated union to exercise the runtime fallback guard
         typedNameTarget="thing"
       />
     );
 
     expect(errorSpy).toHaveBeenCalled();
-    const messages = errorSpy.mock.calls.map((call) => String(call[0] ?? ""));
-    expect(messages.some((m) => m.includes("typedNameTarget"))).toBe(true);
-    expect(messages.some((m) => m.includes('variant="default"'))).toBe(true);
+    const messages = errorSpy.mock.calls.map((call: unknown[]) => String(call[0] ?? ""));
+    expect(messages.some((m: string) => m.includes("typedNameTarget"))).toBe(true);
+    expect(messages.some((m: string) => m.includes('variant="default"'))).toBe(true);
   });
 
   it("is silent for typedNameTarget on a destructive variant", () => {
@@ -553,6 +565,7 @@ describe("ConfirmDialog — typed-name gate", () => {
     vi.stubEnv("DEV", false);
 
     render(
+      // @ts-expect-error — intentionally violates the discriminated union to exercise the runtime fallback guard
       <ConfirmDialog
         isOpen={true}
         onClose={() => {}}
@@ -560,7 +573,6 @@ describe("ConfirmDialog — typed-name gate", () => {
         confirmLabel="Continue"
         onConfirm={() => {}}
         variant="default"
-        // @ts-expect-error — intentionally violates the discriminated union to exercise the runtime fallback guard
         typedNameTarget="thing"
       />
     );
@@ -591,12 +603,7 @@ describe("TypedNameConfirmInput preamble prop", () => {
 
   it("links the preamble id into aria-describedby alongside the instructions id", () => {
     render(
-      <TypedNameConfirmInput
-        target="my-thing"
-        value=""
-        onChange={() => {}}
-        preamble="Heads up."
-      />
+      <TypedNameConfirmInput target="my-thing" value="" onChange={() => {}} preamble="Heads up." />
     );
 
     const input = screen.getByLabelText(/^Type my-thing to confirm$/i);
@@ -610,7 +617,9 @@ describe("TypedNameConfirmInput preamble prop", () => {
   it("renders only the default instruction when preamble is absent", () => {
     render(<TypedNameConfirmInput target="my-thing" value="" onChange={() => {}} />);
 
-    expect(screen.queryByText("Force-deleting this protected worktree is irreversible.")).toBeNull();
+    expect(
+      screen.queryByText("Force-deleting this protected worktree is irreversible.")
+    ).toBeNull();
     expect(screen.getByText(/to confirm\.?/)).toBeDefined();
   });
 

--- a/src/components/ui/__tests__/ConfirmDialog.test.tsx
+++ b/src/components/ui/__tests__/ConfirmDialog.test.tsx
@@ -600,8 +600,11 @@ describe("TypedNameConfirmInput preamble prop", () => {
     );
 
     const input = screen.getByLabelText(/^Type my-thing to confirm$/i);
-    const describedBy = input.getAttribute("aria-describedby") ?? "";
-    expect(describedBy.split(" ").length).toBe(2);
+    const tokens = (input.getAttribute("aria-describedby") ?? "").split(" ").filter(Boolean);
+    expect(tokens).toHaveLength(2);
+    const [first, second] = tokens.map((id) => document.getElementById(id));
+    expect(first?.textContent).toBe("Heads up.");
+    expect(second?.textContent).toMatch(/to confirm\.?/);
   });
 
   it("renders only the default instruction when preamble is absent", () => {

--- a/src/components/ui/__tests__/ConfirmDialog.test.tsx
+++ b/src/components/ui/__tests__/ConfirmDialog.test.tsx
@@ -1,7 +1,8 @@
 // @vitest-environment jsdom
 import { cleanup, fireEvent, render, screen } from "@testing-library/react";
 import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
-import { ConfirmDialog } from "../ConfirmDialog";
+import { ConfirmDialog, __devWarnedKeys } from "../ConfirmDialog";
+import { TypedNameConfirmInput } from "../TypedNameConfirmInput";
 
 vi.mock("zustand/react/shallow", () => ({
   useShallow: (fn: unknown) => fn,
@@ -39,6 +40,7 @@ describe("ConfirmDialog destructive-label dev guard", () => {
   let errorSpy: ReturnType<typeof vi.spyOn>;
 
   beforeEach(() => {
+    __devWarnedKeys.clear();
     errorSpy = vi.spyOn(console, "error").mockImplementation(() => {});
     vi.stubGlobal("matchMedia", vi.fn().mockReturnValue({ matches: false }));
   });
@@ -129,10 +131,217 @@ describe("ConfirmDialog destructive-label dev guard", () => {
   });
 });
 
+describe("ConfirmDialog inverse-label dev guard", () => {
+  let errorSpy: ReturnType<typeof vi.spyOn>;
+
+  beforeEach(() => {
+    __devWarnedKeys.clear();
+    errorSpy = vi.spyOn(console, "error").mockImplementation(() => {});
+    vi.stubGlobal("matchMedia", vi.fn().mockReturnValue({ matches: false }));
+  });
+
+  afterEach(() => {
+    cleanup();
+    errorSpy.mockRestore();
+    vi.unstubAllEnvs();
+  });
+
+  it.each(["OK", "Confirm", "Yes", "Save", "Continue", "Proceed", "Done", "Got it", "Accept", "Apply", "Submit"])(
+    "warns when variant is destructive and confirmLabel is a generic recovery label: %s",
+    (label) => {
+      render(
+        <ConfirmDialog
+          isOpen={true}
+          onClose={() => {}}
+          title="Delete it?"
+          confirmLabel={label}
+          onConfirm={() => {}}
+          variant="destructive"
+        />
+      );
+
+      expect(errorSpy).toHaveBeenCalledTimes(1);
+      const message = String(errorSpy.mock.calls[0]?.[0] ?? "");
+      expect(message).toContain("[ConfirmDialog]");
+      expect(message).toContain(label);
+      expect(message).toContain("verb-noun");
+    }
+  );
+
+  it("matches case-insensitively and tolerates surrounding whitespace", () => {
+    render(
+      <ConfirmDialog
+        isOpen={true}
+        onClose={() => {}}
+        title="Delete it?"
+        confirmLabel="  ok  "
+        onConfirm={() => {}}
+        variant="destructive"
+      />
+    );
+
+    expect(errorSpy).toHaveBeenCalledTimes(1);
+  });
+
+  it("is silent for verb-noun destructive labels", () => {
+    render(
+      <ConfirmDialog
+        isOpen={true}
+        onClose={() => {}}
+        title="Delete it?"
+        confirmLabel="Delete worktree"
+        onConfirm={() => {}}
+        variant="destructive"
+      />
+    );
+
+    expect(errorSpy).not.toHaveBeenCalled();
+  });
+
+  it("is silent when a generic word is part of a longer label", () => {
+    render(
+      <ConfirmDialog
+        isOpen={true}
+        onClose={() => {}}
+        title="Confirm?"
+        confirmLabel="Confirm deletion"
+        onConfirm={() => {}}
+        variant="destructive"
+      />
+    );
+
+    expect(errorSpy).not.toHaveBeenCalled();
+  });
+
+  it("is silent when variant is not destructive", () => {
+    render(
+      <ConfirmDialog
+        isOpen={true}
+        onClose={() => {}}
+        title="Continue?"
+        confirmLabel="Continue"
+        onConfirm={() => {}}
+        variant="default"
+      />
+    );
+
+    expect(errorSpy).not.toHaveBeenCalled();
+  });
+
+  it("is silent in production builds", () => {
+    vi.stubEnv("DEV", false);
+
+    render(
+      <ConfirmDialog
+        isOpen={true}
+        onClose={() => {}}
+        title="Delete it?"
+        confirmLabel="OK"
+        onConfirm={() => {}}
+        variant="destructive"
+      />
+    );
+
+    expect(errorSpy).not.toHaveBeenCalled();
+  });
+});
+
+describe("ConfirmDialog warning dedup", () => {
+  let errorSpy: ReturnType<typeof vi.spyOn>;
+
+  beforeEach(() => {
+    __devWarnedKeys.clear();
+    errorSpy = vi.spyOn(console, "error").mockImplementation(() => {});
+    vi.stubGlobal("matchMedia", vi.fn().mockReturnValue({ matches: false }));
+  });
+
+  afterEach(() => {
+    cleanup();
+    errorSpy.mockRestore();
+    vi.unstubAllEnvs();
+  });
+
+  it("logs the forward guard only once across multiple renders of the same label", () => {
+    render(
+      <ConfirmDialog
+        isOpen={true}
+        onClose={() => {}}
+        title="Delete it?"
+        confirmLabel="Delete worktree"
+        onConfirm={() => {}}
+        variant="default"
+      />
+    );
+    render(
+      <ConfirmDialog
+        isOpen={true}
+        onClose={() => {}}
+        title="Delete it?"
+        confirmLabel="Delete worktree"
+        onConfirm={() => {}}
+        variant="default"
+      />
+    );
+
+    expect(errorSpy).toHaveBeenCalledTimes(1);
+  });
+
+  it("logs the inverse guard only once across multiple renders of the same label", () => {
+    render(
+      <ConfirmDialog
+        isOpen={true}
+        onClose={() => {}}
+        title="Delete?"
+        confirmLabel="OK"
+        onConfirm={() => {}}
+        variant="destructive"
+      />
+    );
+    render(
+      <ConfirmDialog
+        isOpen={true}
+        onClose={() => {}}
+        title="Delete?"
+        confirmLabel="OK"
+        onConfirm={() => {}}
+        variant="destructive"
+      />
+    );
+
+    expect(errorSpy).toHaveBeenCalledTimes(1);
+  });
+
+  it("does not cross-suppress forward and inverse keys", () => {
+    render(
+      <ConfirmDialog
+        isOpen={true}
+        onClose={() => {}}
+        title="A"
+        confirmLabel="Delete worktree"
+        onConfirm={() => {}}
+        variant="default"
+      />
+    );
+    render(
+      <ConfirmDialog
+        isOpen={true}
+        onClose={() => {}}
+        title="B"
+        confirmLabel="OK"
+        onConfirm={() => {}}
+        variant="destructive"
+      />
+    );
+
+    expect(errorSpy).toHaveBeenCalledTimes(2);
+  });
+});
+
 describe("ConfirmDialog — typed-name gate", () => {
   let errorSpy: ReturnType<typeof vi.spyOn>;
 
   beforeEach(() => {
+    __devWarnedKeys.clear();
     errorSpy = vi.spyOn(console, "error").mockImplementation(() => {});
     vi.stubGlobal("matchMedia", vi.fn().mockReturnValue({ matches: false }));
   });
@@ -313,14 +522,15 @@ describe("ConfirmDialog — typed-name gate", () => {
         confirmLabel="Continue"
         onConfirm={() => {}}
         variant="default"
+        // @ts-expect-error — intentionally violates the discriminated union to exercise the runtime fallback guard
         typedNameTarget="thing"
       />
     );
 
     expect(errorSpy).toHaveBeenCalled();
-    const firstMessage = String(errorSpy.mock.calls[0]?.[0] ?? "");
-    expect(firstMessage).toContain("typedNameTarget");
-    expect(firstMessage).toContain('variant="default"');
+    const messages = errorSpy.mock.calls.map((call) => String(call[0] ?? ""));
+    expect(messages.some((m) => m.includes("typedNameTarget"))).toBe(true);
+    expect(messages.some((m) => m.includes('variant="default"'))).toBe(true);
   });
 
   it("is silent for typedNameTarget on a destructive variant", () => {
@@ -350,10 +560,69 @@ describe("ConfirmDialog — typed-name gate", () => {
         confirmLabel="Continue"
         onConfirm={() => {}}
         variant="default"
+        // @ts-expect-error — intentionally violates the discriminated union to exercise the runtime fallback guard
         typedNameTarget="thing"
       />
     );
 
     expect(errorSpy).not.toHaveBeenCalled();
+  });
+});
+
+describe("TypedNameConfirmInput preamble prop", () => {
+  it("renders the preamble before the canonical instruction when no override is provided", () => {
+    render(
+      <TypedNameConfirmInput
+        target="my-thing"
+        value=""
+        onChange={() => {}}
+        preamble="Force-deleting this protected worktree is irreversible."
+      />
+    );
+
+    const preamble = screen.getByText("Force-deleting this protected worktree is irreversible.");
+    const instruction = screen.getByText(/to confirm\.?/);
+    expect(preamble).toBeDefined();
+    expect(instruction).toBeDefined();
+
+    const position = preamble.compareDocumentPosition(instruction);
+    expect(position & Node.DOCUMENT_POSITION_FOLLOWING).toBeTruthy();
+  });
+
+  it("links the preamble id into aria-describedby alongside the instructions id", () => {
+    render(
+      <TypedNameConfirmInput
+        target="my-thing"
+        value=""
+        onChange={() => {}}
+        preamble="Heads up."
+      />
+    );
+
+    const input = screen.getByLabelText(/^Type my-thing to confirm$/i);
+    const describedBy = input.getAttribute("aria-describedby") ?? "";
+    expect(describedBy.split(" ").length).toBe(2);
+  });
+
+  it("renders only the default instruction when preamble is absent", () => {
+    render(<TypedNameConfirmInput target="my-thing" value="" onChange={() => {}} />);
+
+    expect(screen.queryByText("Force-deleting this protected worktree is irreversible.")).toBeNull();
+    expect(screen.getByText(/to confirm\.?/)).toBeDefined();
+  });
+
+  it("suppresses the preamble when an explicit instructions override is provided", () => {
+    render(
+      <TypedNameConfirmInput
+        target="my-thing"
+        value=""
+        onChange={() => {}}
+        preamble="Preamble text."
+        instructions={<>Custom instructions only.</>}
+      />
+    );
+
+    expect(screen.queryByText("Preamble text.")).toBeNull();
+    expect(screen.getByText("Custom instructions only.")).toBeDefined();
   });
 });


### PR DESCRIPTION
## Summary

- Adds the inverse dev guard: warns when `variant="destructive"` is paired with a generic recovery label (`OK`, `Confirm`, `Yes`, `Save`, `Continue`, etc.) — symmetric with the existing forward guard that catches destructive verbs on non-destructive variants.
- Routes all three dev guards through a module-scoped `Set<string>` so React 19 StrictMode and Vite HMR re-renders no longer flood the console with duplicates. The set is exported as `__devWarnedKeys` so tests can clear it in `beforeEach`.
- Splits `ConfirmDialogProps` into a discriminated union — `typedNameTarget` is now `never` on non-destructive variants, promoting the runtime invariant to a compile-time error for typed call sites. The runtime guard stays as a fallback for untyped/spread callers.
- Adds `preamble?: React.ReactNode` to `TypedNameConfirmInput`. `WorktreeDeleteDialog` now passes only its lead-in sentence; the canonical `Type {target} to confirm.` trailer lives in one place.

Resolves #7846

## Changes

- `src/components/ui/ConfirmDialog.tsx` — inverse guard, dedup set, discriminated union
- `src/components/ui/TypedNameConfirmInput.tsx` — `preamble` prop
- `src/components/Worktree/WorktreeDeleteDialog.tsx` — migrates to `preamble`
- `src/components/ui/__tests__/ConfirmDialog.test.tsx` — 37 tests covering all guards and the new union constraints

## Testing

Unit tests: 37 passing across all four gaps (forward guard, inverse guard, dedup behaviour, `typedNameTarget`/variant invariant). TypeScript compile confirms the discriminated union catches misuse at the type level.