### PR TITLE
fix(ui): polish ActionPalette empty and warm-start states

### DIFF
--- a/src/App.tsx
+++ b/src/App.tsx
@@ -993,7 +993,6 @@ function App() {
                     results={actionPalette.results}
                     totalResults={actionPalette.totalResults}
                     selectedIndex={actionPalette.selectedIndex}
-                    isShowingRecentlyUsed={actionPalette.isShowingRecentlyUsed}
                     isStale={actionPalette.isStale}
                     close={actionPalette.close}
                     setQuery={actionPalette.setQuery}

--- a/src/components/ActionPalette/ActionPalette.test.tsx
+++ b/src/components/ActionPalette/ActionPalette.test.tsx
@@ -62,53 +62,7 @@ function makeItem(id: string, title: string): ActionPaletteItemType {
 const noop = () => {};
 
 describe("ActionPalette", () => {
-  it("renders the 'Recently used' header when surfacing MRU on the empty state", () => {
-    render(
-      <ActionPalette
-        isOpen
-        query=""
-        results={[makeItem("a.action", "Alpha"), makeItem("b.action", "Bravo")]}
-        totalResults={2}
-        selectedIndex={0}
-        isShowingRecentlyUsed
-        isStale={false}
-        close={noop}
-        setQuery={noop}
-        setSelectedIndex={noop}
-        selectPrevious={noop}
-        selectNext={noop}
-        executeAction={noop}
-        confirmSelection={noop}
-      />
-    );
-
-    expect(screen.getByText("Recently used")).toBeTruthy();
-  });
-
-  it("does not render the header when the user has typed a query", () => {
-    render(
-      <ActionPalette
-        isOpen
-        query="alp"
-        results={[makeItem("a.action", "Alpha")]}
-        totalResults={1}
-        selectedIndex={0}
-        isShowingRecentlyUsed={false}
-        isStale={false}
-        close={noop}
-        setQuery={noop}
-        setSelectedIndex={noop}
-        selectPrevious={noop}
-        selectNext={noop}
-        executeAction={noop}
-        confirmSelection={noop}
-      />
-    );
-
-    expect(screen.queryByText("Recently used")).toBeNull();
-  });
-
-  it("renders neither the header nor the hint when a typed query has zero matches", () => {
+  it("does not render the empty message when a typed query has zero matches", () => {
     render(
       <ActionPalette
         isOpen
@@ -116,7 +70,6 @@ describe("ActionPalette", () => {
         results={[]}
         totalResults={0}
         selectedIndex={0}
-        isShowingRecentlyUsed={false}
         isStale={false}
         close={noop}
         setQuery={noop}
@@ -128,8 +81,7 @@ describe("ActionPalette", () => {
       />
     );
 
-    expect(screen.queryByText("Recently used")).toBeNull();
-    expect(screen.queryByText("Type to search actions")).toBeNull();
+    expect(screen.queryByText("No actions yet")).toBeNull();
   });
 
   it("shows the empty message when no MRU exists and no query is typed", () => {
@@ -140,7 +92,6 @@ describe("ActionPalette", () => {
         results={[]}
         totalResults={0}
         selectedIndex={0}
-        isShowingRecentlyUsed={false}
         isStale={false}
         close={noop}
         setQuery={noop}
@@ -152,8 +103,7 @@ describe("ActionPalette", () => {
       />
     );
 
-    expect(screen.queryByText("Recently used")).toBeNull();
-    expect(screen.getByText("Type to search actions")).toBeTruthy();
+    expect(screen.getByText("No actions yet")).toBeTruthy();
   });
 
   it("forwards isStale to SearchablePalette as isFiltering", () => {
@@ -164,7 +114,6 @@ describe("ActionPalette", () => {
         results={[makeItem("a.action", "Alpha")]}
         totalResults={1}
         selectedIndex={0}
-        isShowingRecentlyUsed={false}
         isStale
         close={noop}
         setQuery={noop}

--- a/src/components/ActionPalette/ActionPalette.tsx
+++ b/src/components/ActionPalette/ActionPalette.tsx
@@ -22,7 +22,6 @@ type ActionPaletteProps = Pick<
   | "results"
   | "totalResults"
   | "selectedIndex"
-  | "isShowingRecentlyUsed"
   | "isStale"
   | "close"
   | "setQuery"
@@ -39,7 +38,6 @@ export function ActionPalette({
   results,
   totalResults,
   selectedIndex,
-  isShowingRecentlyUsed,
   isStale,
   close,
   setQuery,
@@ -90,13 +88,8 @@ export function ActionPalette({
       searchAriaLabel="Search actions"
       listId="action-palette-list"
       itemIdPrefix="action-option"
-      emptyMessage="Type to search actions"
+      emptyMessage="No actions yet"
       totalResults={totalResults}
-      beforeList={
-        isShowingRecentlyUsed ? (
-          <div className="px-3 pt-2 pb-1 text-xs text-daintree-text/40">Recently used</div>
-        ) : null
-      }
     />
   );
 }


### PR DESCRIPTION
## Summary
Two subtle copy and chrome adjustments to the ActionPalette empty and warm-start states.

- The empty-query copy was `Type to search actions` -- imperative, overlapping with the input placeholder. Changed to `No actions yet`, a stative title aligned with every sibling palette.
- The warm-start view showed a `Recently used` section header above the only section in the listbox. Since there's no second section, the label was redundant and ate vertical space on short MRU lists. Removed it, which also let us drop the `isShowingRecentlyUsed` prop.

Resolves #7843

## Changes
- `ActionPalette.tsx` -- changed empty message from `"Type to search actions"` to `"No actions yet"`, removed the `beforeList` / `isShowingRecentlyUsed` header
- `App.tsx` -- removed `isShowingRecentlyUsed` prop pass-through
- `ActionPalette.test.tsx` -- updated assertions to match new copy and removed stale header tests