### PR TITLE
fix(notifications): restrict per-row action reveal to keyboard focus

### DIFF
--- a/src/components/Notifications/NotificationCenterEntry.tsx
+++ b/src/components/Notifications/NotificationCenterEntry.tsx
@@ -244,7 +244,7 @@ export function NotificationCenterEntry({
                     type="button"
                     aria-label="Notification options"
                     onClick={(e) => e.stopPropagation()}
-                    className="opacity-0 group-hover:opacity-100 group-focus-within:opacity-100 focus:opacity-100 data-[state=open]:opacity-100 h-4 w-4 flex items-center justify-center rounded text-daintree-text/40 hover:text-daintree-text/70 transition-opacity"
+                    className="opacity-0 group-hover:opacity-100 group-has-[:focus-visible]:opacity-100 focus:opacity-100 data-[state=open]:opacity-100 h-4 w-4 flex items-center justify-center rounded text-daintree-text/40 hover:text-daintree-text/70 transition-opacity"
                   >
                     <MoreHorizontal className="h-3 w-3" />
                   </button>
@@ -290,7 +290,7 @@ export function NotificationCenterEntry({
               e.stopPropagation();
               onDismiss();
             }}
-            className="opacity-0 group-hover:opacity-100 group-focus-within:opacity-100 focus:opacity-100 h-4 w-4 flex items-center justify-center rounded text-daintree-text/40 hover:text-daintree-text/70 transition-opacity"
+            className="opacity-0 group-hover:opacity-100 group-has-[:focus-visible]:opacity-100 focus:opacity-100 h-4 w-4 flex items-center justify-center rounded text-daintree-text/40 hover:text-daintree-text/70 transition-opacity"
           >
             <X className="h-3 w-3" />
           </button>

--- a/src/components/Notifications/NotificationCenterEntry.tsx
+++ b/src/components/Notifications/NotificationCenterEntry.tsx
@@ -244,7 +244,7 @@ export function NotificationCenterEntry({
                     type="button"
                     aria-label="Notification options"
                     onClick={(e) => e.stopPropagation()}
-                    className="opacity-0 group-hover:opacity-100 group-has-[:focus-visible]:opacity-100 focus:opacity-100 data-[state=open]:opacity-100 h-4 w-4 flex items-center justify-center rounded text-daintree-text/40 hover:text-daintree-text/70 transition-opacity"
+                    className="opacity-0 group-hover:opacity-100 group-focus-visible:opacity-100 group-has-[:focus-visible]:opacity-100 focus:opacity-100 data-[state=open]:opacity-100 h-4 w-4 flex items-center justify-center rounded text-daintree-text/40 hover:text-daintree-text/70 transition-opacity"
                   >
                     <MoreHorizontal className="h-3 w-3" />
                   </button>
@@ -290,7 +290,7 @@ export function NotificationCenterEntry({
               e.stopPropagation();
               onDismiss();
             }}
-            className="opacity-0 group-hover:opacity-100 group-has-[:focus-visible]:opacity-100 focus:opacity-100 h-4 w-4 flex items-center justify-center rounded text-daintree-text/40 hover:text-daintree-text/70 transition-opacity"
+            className="opacity-0 group-hover:opacity-100 group-focus-visible:opacity-100 group-has-[:focus-visible]:opacity-100 focus:opacity-100 h-4 w-4 flex items-center justify-center rounded text-daintree-text/40 hover:text-daintree-text/70 transition-opacity"
           >
             <X className="h-3 w-3" />
           </button>

--- a/src/components/Notifications/__tests__/NotificationCenterEntry.test.tsx
+++ b/src/components/Notifications/__tests__/NotificationCenterEntry.test.tsx
@@ -518,16 +518,18 @@ describe("NotificationCenterEntry roving focus props", () => {
     expect((container.firstElementChild as HTMLElement).className).toMatch(/focus-visible:ring/);
   });
 
-  it("reveals the dismiss button on descendant focus-visible (keyboard focus inside the row)", () => {
+  it("reveals the dismiss button on keyboard focus (row or descendant)", () => {
     render(<NotificationCenterEntry entry={makeEntry()} onDismiss={vi.fn()} />);
     const dismiss = screen.getByLabelText("Dismiss notification");
+    expect(dismiss.className).toMatch(/group-focus-visible:opacity-100/);
     expect(dismiss.className).toMatch(/group-has-\[:focus-visible\]:opacity-100/);
     expect(dismiss.className).not.toMatch(/group-focus-within:opacity-100/);
   });
 
-  it("reveals the kebab trigger on descendant focus-visible (keyboard focus inside the row)", () => {
+  it("reveals the kebab trigger on keyboard focus (row or descendant)", () => {
     render(<NotificationCenterEntry entry={makeEntry({ context: { projectId: "p1" } })} />);
     const kebab = screen.getByLabelText("Notification options");
+    expect(kebab.className).toMatch(/group-focus-visible:opacity-100/);
     expect(kebab.className).toMatch(/group-has-\[:focus-visible\]:opacity-100/);
     expect(kebab.className).not.toMatch(/group-focus-within:opacity-100/);
   });

--- a/src/components/Notifications/__tests__/NotificationCenterEntry.test.tsx
+++ b/src/components/Notifications/__tests__/NotificationCenterEntry.test.tsx
@@ -518,16 +518,18 @@ describe("NotificationCenterEntry roving focus props", () => {
     expect((container.firstElementChild as HTMLElement).className).toMatch(/focus-visible:ring/);
   });
 
-  it("reveals the dismiss button on group-focus-within (focus inside the row)", () => {
+  it("reveals the dismiss button on descendant focus-visible (keyboard focus inside the row)", () => {
     render(<NotificationCenterEntry entry={makeEntry()} onDismiss={vi.fn()} />);
     const dismiss = screen.getByLabelText("Dismiss notification");
-    expect(dismiss.className).toMatch(/group-focus-within:opacity-100/);
+    expect(dismiss.className).toMatch(/group-has-\[:focus-visible\]:opacity-100/);
+    expect(dismiss.className).not.toMatch(/group-focus-within:opacity-100/);
   });
 
-  it("reveals the kebab trigger on group-focus-within", () => {
+  it("reveals the kebab trigger on descendant focus-visible (keyboard focus inside the row)", () => {
     render(<NotificationCenterEntry entry={makeEntry({ context: { projectId: "p1" } })} />);
     const kebab = screen.getByLabelText("Notification options");
-    expect(kebab.className).toMatch(/group-focus-within:opacity-100/);
+    expect(kebab.className).toMatch(/group-has-\[:focus-visible\]:opacity-100/);
+    expect(kebab.className).not.toMatch(/group-focus-within:opacity-100/);
   });
 
   it("invokes onDropdownOpenChange when the kebab menu opens and closes", async () => {


### PR DESCRIPTION
## Summary
- The dismiss and more-options buttons in `NotificationCenterEntry` were revealing on all mouse clicks, not just keyboard focus. The culprit was `group-focus-within`, which matches click events too.
- Replaced `group-focus-within` with `group-focus-visible` and `group-has-[:focus-visible]` so the buttons only surface on keyboard focus. This is the first use of `has-[:focus-visible]` in the codebase, which landed cleanly in Tailwind v4.
- Updated the two relevant test assertions to check for the new classes and confirm the old one is gone.

Resolves #7855

## Changes
- `NotificationCenterEntry.tsx` — swapped `group-focus-within:opacity-100` for `group-focus-visible:opacity-100 group-has-[:focus-visible]:opacity-100` on both the dismiss and kebab buttons
- `NotificationCenterEntry.test.tsx` — rewired two assertions to match the new variants and assert `group-focus-within` is absent

## Testing
- Unit tests pass with updated class assertions
- Confirmed `has-[:focus-visible]` compiles to the expected CSS rule in this Tailwind v4 setup