### PR TITLE
feat(empty-state): tighten EmptyState contract with scale discriminant + container-query density

### DIFF
--- a/src/components/Diagnostics/LogsContent.tsx
+++ b/src/components/Diagnostics/LogsContent.tsx
@@ -268,6 +268,7 @@ export function LogsContent({ className, onSourcesChange }: LogsContentProps) {
             <div className="flex items-center justify-center h-full">
               <EmptyState
                 variant="filtered-empty"
+                scale="sidebar"
                 title="No logs match filters"
                 action={
                   <button

--- a/src/components/GitHub/GitHubResourceList.tsx
+++ b/src/components/GitHub/GitHubResourceList.tsx
@@ -557,6 +557,9 @@ export function GitHubResourceList({
   if (showNoTokenEmptyState) {
     return (
       <div className="relative w-[450px] flex flex-col h-[500px]">
+        {/* Canvas scale: this is the canonical "connection-gated panel" example
+            in CLAUDE.md — a 450×500 dropdown that warrants panel semantics so the
+            token-explanation description and "Add GitHub token" CTA stay legal. */}
         <EmptyState
           variant="zero-data"
           scale="canvas"

--- a/src/components/GitHub/GitHubResourceList.tsx
+++ b/src/components/GitHub/GitHubResourceList.tsx
@@ -525,6 +525,7 @@ export function GitHubResourceList({
       return (
         <EmptyState
           variant="filtered-empty"
+          scale="canvas"
           title={title}
           action={
             <Button
@@ -546,6 +547,7 @@ export function GitHubResourceList({
     return (
       <EmptyState
         variant="zero-data"
+        scale="canvas"
         title={`No ${resourceLabel} found`}
         className="flex-1 justify-center"
       />
@@ -557,6 +559,7 @@ export function GitHubResourceList({
       <div className="relative w-[450px] flex flex-col h-[500px]">
         <EmptyState
           variant="zero-data"
+          scale="canvas"
           icon={<Github />}
           title="GitHub not connected"
           description="Add a personal access token to browse issues and pull requests for this project."

--- a/src/components/Notifications/NotificationCenter.tsx
+++ b/src/components/Notifications/NotificationCenter.tsx
@@ -715,6 +715,7 @@ export function NotificationCenter({ open, onClose }: NotificationCenterProps) {
             filter === "unread" && entries.length > 0 ? (
               <EmptyState
                 variant="user-cleared"
+                scale="canvas"
                 title="You're all caught up"
                 icon={<Bell />}
                 className="py-10"
@@ -723,6 +724,7 @@ export function NotificationCenter({ open, onClose }: NotificationCenterProps) {
               <div data-testid="notification-muted-empty-state">
                 <EmptyState
                   variant="zero-data"
+                  scale="canvas"
                   title="Notifications paused"
                   icon={<Moon />}
                   description={mutedEmptyDescription}
@@ -732,6 +734,7 @@ export function NotificationCenter({ open, onClose }: NotificationCenterProps) {
             ) : (
               <EmptyState
                 variant="zero-data"
+                scale="canvas"
                 title="No notifications yet"
                 icon={<Bell />}
                 description={

--- a/src/components/Notifications/NotificationCenter.tsx
+++ b/src/components/Notifications/NotificationCenter.tsx
@@ -713,6 +713,11 @@ export function NotificationCenter({ open, onClose }: NotificationCenterProps) {
         >
           {totalChronoGroups === 0 && needsAttentionGroups.length === 0 ? (
             filter === "unread" && entries.length > 0 ? (
+              // Canvas scale: the bell dropdown is a 360px panel-style surface that
+              // mirrors GitHubResourceList ("connection-gated panel" example in
+              // CLAUDE.md). The "Notifications appear here" guidance and the
+              // "Adjust at Notification settings" inline link are intentional and
+              // load-bearing — popover scale would forbid them at compile time.
               <EmptyState
                 variant="user-cleared"
                 scale="canvas"

--- a/src/components/Project/RecipesTab.tsx
+++ b/src/components/Project/RecipesTab.tsx
@@ -191,7 +191,12 @@ export function RecipesTab({
             </div>
           ) : recipes.length === 0 ? (
             <div className="border border-dashed border-daintree-border rounded-[var(--radius-md)]">
-              <EmptyState variant="zero-data" icon={<Workflow />} title="No recipes" />
+              <EmptyState
+                variant="zero-data"
+                scale="sidebar"
+                icon={<Workflow />}
+                title="No recipes"
+              />
             </div>
           ) : (
             <div className="border border-daintree-border rounded-[var(--radius-md)] divide-y divide-daintree-border">

--- a/src/components/Settings/McpServerSettingsTab.tsx
+++ b/src/components/Settings/McpServerSettingsTab.tsx
@@ -327,6 +327,7 @@ export function McpServerSettingsTab() {
         <div className="border border-dashed border-daintree-border rounded-[var(--radius-md)]">
           <EmptyState
             variant="zero-data"
+            scale="canvas"
             icon={<McpServerIcon />}
             title="MCP server is off"
             description="Turn it on to expose Daintree's actions as MCP tools agents can call."

--- a/src/components/Sidebar/SidebarContent.tsx
+++ b/src/components/Sidebar/SidebarContent.tsx
@@ -614,15 +614,16 @@ function SidebarContent({ onOpenOverview }: SidebarContentProps) {
 
           <EmptyState
             variant="zero-data"
+            scale="sidebar"
             icon={<FolderOpen />}
             title="Open a Git repository to get started"
-            description={
-              <>
+            action={
+              <span className="text-xs text-daintree-text/50">
                 Use{" "}
                 <kbd className="px-1.5 py-0.5 bg-tint/[0.06] rounded text-xs">
                   File → Open Directory
                 </kbd>
-              </>
+              </span>
             }
             className="flex-1"
           />
@@ -904,6 +905,7 @@ function SidebarContent({ onOpenOverview }: SidebarContentProps) {
               {showQuickStateEmptyState ? (
                 <EmptyState
                   variant="filtered-empty"
+                  scale="sidebar"
                   title={`No ${quickStateFilter} worktrees`}
                   action={
                     <button
@@ -920,6 +922,7 @@ function SidebarContent({ onOpenOverview }: SidebarContentProps) {
                 !(mainVisible || integrationVisible) ? (
                 <EmptyState
                   variant="filtered-empty"
+                  scale="sidebar"
                   title={
                     hasQuery
                       ? `No matches for "${truncateSearchQuery(query.trim())}"`

--- a/src/components/TerminalRecipe/RecipeManager.tsx
+++ b/src/components/TerminalRecipe/RecipeManager.tsx
@@ -307,6 +307,7 @@ export function RecipeManager({
               <div className="border border-dashed border-daintree-border rounded-[var(--radius-md)]">
                 <EmptyState
                   variant="zero-data"
+                  scale="canvas"
                   icon={<Workflow />}
                   title="No global recipes"
                   description="Save a terminal layout once and launch it in any project."
@@ -365,6 +366,7 @@ export function RecipeManager({
               <div className="border border-dashed border-daintree-border rounded-[var(--radius-md)]">
                 <EmptyState
                   variant="zero-data"
+                  scale="canvas"
                   icon={<Workflow />}
                   title="No project recipes"
                   description="Project recipes stay private to this machine until you save them to the repo."

--- a/src/components/Worktree/ReviewHub/ReviewHubContent.tsx
+++ b/src/components/Worktree/ReviewHub/ReviewHubContent.tsx
@@ -72,6 +72,7 @@ import {
   matchesFilter,
   readGitErrorFields,
   sortFiles,
+  truncateFilterQuery,
   getBaseBranchStatusConfig,
 } from "./reviewHubUtils";
 
@@ -1660,7 +1661,7 @@ export function ReviewHubContent({
                       <EmptyState
                         variant="filtered-empty"
                         scale="sidebar"
-                        title={`No staged files matching "${stagedView.filterQuery}"`}
+                        title={`No staged files matching "${truncateFilterQuery(stagedView.filterQuery)}"`}
                         action={
                           <button
                             type="button"
@@ -1859,7 +1860,7 @@ export function ReviewHubContent({
                       <EmptyState
                         variant="filtered-empty"
                         scale="sidebar"
-                        title={`No changed files matching "${changesView.filterQuery}"`}
+                        title={`No changed files matching "${truncateFilterQuery(changesView.filterQuery)}"`}
                         action={
                           <button
                             type="button"

--- a/src/components/Worktree/ReviewHub/ReviewHubContent.tsx
+++ b/src/components/Worktree/ReviewHub/ReviewHubContent.tsx
@@ -1659,6 +1659,7 @@ export function ReviewHubContent({
                     ) : stagedView.filterQuery ? (
                       <EmptyState
                         variant="filtered-empty"
+                        scale="sidebar"
                         title={`No staged files matching "${stagedView.filterQuery}"`}
                         action={
                           <button
@@ -1857,6 +1858,7 @@ export function ReviewHubContent({
                     ) : changesView.filterQuery ? (
                       <EmptyState
                         variant="filtered-empty"
+                        scale="sidebar"
                         title={`No changed files matching "${changesView.filterQuery}"`}
                         action={
                           <button

--- a/src/components/Worktree/ReviewHub/reviewHubUtils.ts
+++ b/src/components/Worktree/ReviewHub/reviewHubUtils.ts
@@ -330,3 +330,14 @@ export function isSortKey(v: string): v is SortKey {
 export function isDensity(v: string): v is Density {
   return v === "comfortable" || v === "compact";
 }
+
+const FILTER_QUERY_DISPLAY_MAX = 40;
+
+// Filter-query echoes in narrow sidebar surfaces would overflow otherwise:
+// file paths regularly exceed 40 chars and the panel can sit at ~200px.
+export function truncateFilterQuery(query: string): string {
+  const codepoints = Array.from(query);
+  return codepoints.length > FILTER_QUERY_DISPLAY_MAX
+    ? `${codepoints.slice(0, FILTER_QUERY_DISPLAY_MAX).join("")}…`
+    : query;
+}

--- a/src/components/ui/AppPaletteDialog.tsx
+++ b/src/components/ui/AppPaletteDialog.tsx
@@ -450,6 +450,7 @@ AppPaletteDialog.Empty = function AppPaletteEmpty({
     return (
       <EmptyState
         variant="filtered-empty"
+        scale="popover"
         title={noMatchMessage ?? defaultNoMatchTitle(trimmedQuery)}
         action={noMatchContent}
         className="px-3 py-8"
@@ -457,6 +458,12 @@ AppPaletteDialog.Empty = function AppPaletteEmpty({
     );
   }
   return (
-    <EmptyState variant="zero-data" title={emptyMessage} action={children} className="px-3 py-8" />
+    <EmptyState
+      variant="zero-data"
+      scale="popover"
+      title={emptyMessage}
+      action={children}
+      className="px-3 py-8"
+    />
   );
 };

--- a/src/components/ui/EmptyState.tsx
+++ b/src/components/ui/EmptyState.tsx
@@ -63,7 +63,7 @@ export function EmptyState(props: EmptyStateProps) {
       aria-live="polite"
       aria-describedby={hasDescription ? descriptionId : undefined}
       className={cn(
-        "@container/empty-state flex flex-col items-center justify-center text-center px-4 py-8 @max-[280px]/empty-state:py-4",
+        "@container/empty-state flex flex-col items-center justify-center text-center px-4 py-8",
         className
       )}
     >

--- a/src/components/ui/EmptyState.tsx
+++ b/src/components/ui/EmptyState.tsx
@@ -1,35 +1,58 @@
 import { useId, type ReactNode } from "react";
 import { cn } from "@/lib/utils";
 
-type EmptyStateBaseProps = {
+type EmptyStateCommonProps = {
   title: string;
-  description?: ReactNode;
   className?: string;
 };
 
+export type EmptyStateScale = "popover" | "sidebar" | "canvas";
+
 export type EmptyStateProps =
-  | (EmptyStateBaseProps & {
+  | (EmptyStateCommonProps & {
       variant: "zero-data";
+      scale: "popover" | "sidebar";
       icon?: ReactNode;
+      description?: never;
       action?: ReactNode;
     })
-  | (EmptyStateBaseProps & {
+  | (EmptyStateCommonProps & {
+      variant: "zero-data";
+      scale: "canvas";
+      icon?: ReactNode;
+      description?: ReactNode;
+      action?: ReactNode;
+    })
+  | (EmptyStateCommonProps & {
       variant: "filtered-empty";
+      scale: "popover" | "sidebar";
+      description?: never;
       action?: ReactNode;
     })
-  | (EmptyStateBaseProps & {
+  | (EmptyStateCommonProps & {
+      variant: "filtered-empty";
+      scale: "canvas";
+      description?: ReactNode;
+      action?: ReactNode;
+    })
+  | (EmptyStateCommonProps & {
       variant: "user-cleared";
+      scale: "popover" | "sidebar" | "canvas";
       icon?: ReactNode;
+      description?: never;
+      action?: never;
     });
 
 export function EmptyState(props: EmptyStateProps) {
-  const { variant, title, description, className } = props;
+  const { variant, title, className } = props;
+  const rawDescription =
+    variant === "user-cleared" ? undefined : "description" in props ? props.description : undefined;
   const descriptionId = useId();
   const hasDescription =
-    description !== undefined &&
-    description !== null &&
-    description !== false &&
-    description !== "";
+    rawDescription !== undefined &&
+    rawDescription !== null &&
+    rawDescription !== false &&
+    rawDescription !== "";
 
   const icon = variant === "filtered-empty" ? null : props.icon;
   const action = variant === "user-cleared" ? null : props.action;
@@ -39,18 +62,24 @@ export function EmptyState(props: EmptyStateProps) {
       role="status"
       aria-live="polite"
       aria-describedby={hasDescription ? descriptionId : undefined}
-      className={cn("flex flex-col items-center justify-center text-center px-4 py-8", className)}
+      className={cn(
+        "@container/empty-state flex flex-col items-center justify-center text-center px-4 py-8 @max-[280px]/empty-state:py-4",
+        className
+      )}
     >
       <div className="motion-safe:animate-in motion-safe:fade-in motion-safe:duration-150 flex flex-col items-center gap-2">
         {icon ? (
-          <div className="text-daintree-text/30 [&_svg]:h-6 [&_svg]:w-6" aria-hidden="true">
+          <div
+            className="text-daintree-text/30 [&_svg]:h-6 [&_svg]:w-6 @max-[280px]/empty-state:[&_svg]:h-4 @max-[280px]/empty-state:[&_svg]:w-4"
+            aria-hidden="true"
+          >
             {icon}
           </div>
         ) : null}
         <p className="text-sm font-medium text-daintree-text/70">{title}</p>
         {hasDescription ? (
           <p id={descriptionId} className="text-xs text-daintree-text/50 max-w-xs">
-            {description}
+            {rawDescription}
           </p>
         ) : null}
         {action ? <div className="mt-2">{action}</div> : null}

--- a/src/components/ui/__tests__/EmptyState.test.tsx
+++ b/src/components/ui/__tests__/EmptyState.test.tsx
@@ -318,10 +318,12 @@ describe("EmptyState", () => {
       expect(status?.className).toContain("@container/empty-state");
     });
 
-    it("ships compact-density variants gated on the named container", () => {
+    it("ships compact-density variants on a descendant of the named container", () => {
       // The `@max-[280px]/empty-state:` prefix triggers when the outer
       // container's inline-size falls below 280px — comfortably above the
       // 200px minimum sidebar floor without affecting the 350px default.
+      // Container queries can only style *descendants* of the container, so
+      // density variants live on the icon wrapper, not on the container itself.
       const { container } = render(
         <EmptyState
           variant="zero-data"
@@ -331,7 +333,9 @@ describe("EmptyState", () => {
         />
       );
       const status = container.querySelector('[role="status"]');
-      expect(status?.className).toContain("@max-[280px]/empty-state:py-4");
+      // The container element itself cannot respond to its own queries, so we
+      // assert the rule is NOT here — placing it here would be a silent no-op.
+      expect(status?.className).not.toContain("@max-[280px]/empty-state:py-");
       const iconWrap = container.querySelector('[aria-hidden="true"]');
       expect(iconWrap?.className).toContain("@max-[280px]/empty-state:[&_svg]:h-4");
       expect(iconWrap?.className).toContain("@max-[280px]/empty-state:[&_svg]:w-4");

--- a/src/components/ui/__tests__/EmptyState.test.tsx
+++ b/src/components/ui/__tests__/EmptyState.test.tsx
@@ -11,14 +11,15 @@ import { EmptyState } from "../EmptyState";
 describe("EmptyState", () => {
   describe("zero-data variant", () => {
     it("renders title", () => {
-      render(<EmptyState variant="zero-data" title="No recipes yet" />);
+      render(<EmptyState variant="zero-data" scale="canvas" title="No recipes yet" />);
       expect(screen.getByText("No recipes yet")).toBeTruthy();
     });
 
-    it("renders description when provided", () => {
+    it("renders description when provided at canvas scale", () => {
       render(
         <EmptyState
           variant="zero-data"
+          scale="canvas"
           title="No recipes yet"
           description="Add a recipe to get started"
         />
@@ -28,7 +29,12 @@ describe("EmptyState", () => {
 
     it("renders icon when provided", () => {
       render(
-        <EmptyState variant="zero-data" title="No recipes yet" icon={<svg data-testid="icon" />} />
+        <EmptyState
+          variant="zero-data"
+          scale="canvas"
+          title="No recipes yet"
+          icon={<svg data-testid="icon" />}
+        />
       );
       expect(screen.getByTestId("icon")).toBeTruthy();
     });
@@ -37,6 +43,7 @@ describe("EmptyState", () => {
       render(
         <EmptyState
           variant="zero-data"
+          scale="canvas"
           title="No recipes yet"
           action={<button data-testid="cta">Add</button>}
         />
@@ -47,7 +54,7 @@ describe("EmptyState", () => {
 
   describe("filtered-empty variant", () => {
     it("renders title", () => {
-      render(<EmptyState variant="filtered-empty" title='No matches for "foo"' />);
+      render(<EmptyState variant="filtered-empty" scale="popover" title='No matches for "foo"' />);
       expect(screen.getByText('No matches for "foo"')).toBeTruthy();
     });
 
@@ -55,6 +62,7 @@ describe("EmptyState", () => {
       render(
         <EmptyState
           variant="filtered-empty"
+          scale="sidebar"
           title="No matches"
           action={<button data-testid="clear">Clear filters</button>}
         />
@@ -67,6 +75,7 @@ describe("EmptyState", () => {
       // this guards against a runtime regression if the gate is removed.
       const props = {
         variant: "filtered-empty",
+        scale: "sidebar",
         title: "No matches",
         icon: <svg data-testid="icon" />,
       } as unknown as React.ComponentProps<typeof EmptyState>;
@@ -77,7 +86,7 @@ describe("EmptyState", () => {
 
   describe("user-cleared variant", () => {
     it("renders title", () => {
-      render(<EmptyState variant="user-cleared" title="You're all caught up" />);
+      render(<EmptyState variant="user-cleared" scale="canvas" title="You're all caught up" />);
       expect(screen.getByText("You're all caught up")).toBeTruthy();
     });
 
@@ -85,6 +94,7 @@ describe("EmptyState", () => {
       render(
         <EmptyState
           variant="user-cleared"
+          scale="canvas"
           title="You're all caught up"
           icon={<svg data-testid="icon" />}
         />
@@ -95,29 +105,159 @@ describe("EmptyState", () => {
     it("does not render an action even if one is passed via type cast", () => {
       const props = {
         variant: "user-cleared",
+        scale: "canvas",
         title: "You're all caught up",
         action: <button data-testid="cta">Should not appear</button>,
       } as unknown as React.ComponentProps<typeof EmptyState>;
       render(<EmptyState {...props} />);
       expect(screen.queryByTestId("cta")).toBeNull();
     });
+
+    it("does not render a description even if one is passed via type cast", () => {
+      const props = {
+        variant: "user-cleared",
+        scale: "canvas",
+        title: "You're all caught up",
+        description: "Should not appear",
+      } as unknown as React.ComponentProps<typeof EmptyState>;
+      render(<EmptyState {...props} />);
+      expect(screen.queryByText("Should not appear")).toBeNull();
+    });
+  });
+
+  describe("scale contract (compile-time enforcement)", () => {
+    // These cases assert that the discriminated union rejects content props at
+    // narrow scales. The runtime behaviour is incidental — the value of the
+    // assertion is the @ts-expect-error directive: removing the directive must
+    // produce an "unused @ts-expect-error" diagnostic if the type widens.
+
+    it("rejects description on zero-data at popover scale", () => {
+      const element = (
+        // @ts-expect-error description is not allowed at popover scale
+        <EmptyState
+          variant="zero-data"
+          scale="popover"
+          title="No items"
+          description="should not compile"
+        />
+      );
+      expect(element).toBeTruthy();
+    });
+
+    it("rejects description on zero-data at sidebar scale", () => {
+      const element = (
+        // @ts-expect-error description is not allowed at sidebar scale
+        <EmptyState
+          variant="zero-data"
+          scale="sidebar"
+          title="No items"
+          description="should not compile"
+        />
+      );
+      expect(element).toBeTruthy();
+    });
+
+    it("accepts description on zero-data at canvas scale", () => {
+      const element = (
+        <EmptyState
+          variant="zero-data"
+          scale="canvas"
+          title="No items"
+          description="long-form copy"
+        />
+      );
+      expect(element).toBeTruthy();
+    });
+
+    it("rejects description on filtered-empty at popover scale", () => {
+      const element = (
+        // @ts-expect-error description is not allowed at popover scale
+        <EmptyState
+          variant="filtered-empty"
+          scale="popover"
+          title="No matches"
+          description="should not compile"
+        />
+      );
+      expect(element).toBeTruthy();
+    });
+
+    it("rejects description on filtered-empty at sidebar scale", () => {
+      const element = (
+        // @ts-expect-error description is not allowed at sidebar scale
+        <EmptyState
+          variant="filtered-empty"
+          scale="sidebar"
+          title="No matches"
+          description="should not compile"
+        />
+      );
+      expect(element).toBeTruthy();
+    });
+
+    it("rejects description on user-cleared at every scale", () => {
+      const element = (
+        // @ts-expect-error user-cleared never carries a description
+        <EmptyState
+          variant="user-cleared"
+          scale="canvas"
+          title="You're all caught up"
+          description="should not compile"
+        />
+      );
+      expect(element).toBeTruthy();
+    });
+
+    it("rejects action on user-cleared at every scale", () => {
+      const element = (
+        // @ts-expect-error user-cleared never carries an action
+        <EmptyState
+          variant="user-cleared"
+          scale="canvas"
+          title="You're all caught up"
+          action={<button>Nope</button>}
+        />
+      );
+      expect(element).toBeTruthy();
+    });
+
+    it("requires scale to be specified", () => {
+      const element = (
+        // @ts-expect-error scale is a required discriminant
+        <EmptyState variant="zero-data" title="No items" />
+      );
+      expect(element).toBeTruthy();
+    });
+
+    it("rejects icon on filtered-empty at every scale", () => {
+      const element = (
+        // @ts-expect-error filtered-empty never carries an icon
+        <EmptyState variant="filtered-empty" scale="canvas" title="No matches" icon={<svg />} />
+      );
+      expect(element).toBeTruthy();
+    });
   });
 
   describe("accessibility", () => {
     it('uses role="status" on the container', () => {
-      render(<EmptyState variant="zero-data" title="No items" />);
+      render(<EmptyState variant="zero-data" scale="canvas" title="No items" />);
       expect(screen.getByRole("status")).toBeTruthy();
     });
 
     it('sets aria-live="polite"', () => {
-      render(<EmptyState variant="zero-data" title="No items" />);
+      render(<EmptyState variant="zero-data" scale="canvas" title="No items" />);
       const status = screen.getByRole("status");
       expect(status.getAttribute("aria-live")).toBe("polite");
     });
 
     it("hides icon decoration from assistive tech", () => {
       const { container } = render(
-        <EmptyState variant="zero-data" title="No items" icon={<svg data-testid="icon" />} />
+        <EmptyState
+          variant="zero-data"
+          scale="canvas"
+          title="No items"
+          icon={<svg data-testid="icon" />}
+        />
       );
       const wrapper = container.querySelector('[aria-hidden="true"]');
       expect(wrapper).toBeTruthy();
@@ -126,7 +266,12 @@ describe("EmptyState", () => {
 
     it("wires aria-describedby to the description when one is present", () => {
       render(
-        <EmptyState variant="zero-data" title="No items" description="Add one to get started" />
+        <EmptyState
+          variant="zero-data"
+          scale="canvas"
+          title="No items"
+          description="Add one to get started"
+        />
       );
       const status = screen.getByRole("status");
       const describedById = status.getAttribute("aria-describedby");
@@ -136,7 +281,7 @@ describe("EmptyState", () => {
     });
 
     it("does not set aria-describedby when no description is present", () => {
-      render(<EmptyState variant="zero-data" title="No items" />);
+      render(<EmptyState variant="zero-data" scale="canvas" title="No items" />);
       const status = screen.getByRole("status");
       expect(status.getAttribute("aria-describedby")).toBeNull();
     });
@@ -144,7 +289,9 @@ describe("EmptyState", () => {
 
   describe("animation", () => {
     it("applies motion-safe entry animation classes on inner content", () => {
-      const { container } = render(<EmptyState variant="zero-data" title="No items" />);
+      const { container } = render(
+        <EmptyState variant="zero-data" scale="canvas" title="No items" />
+      );
       const inner = container.querySelector(".motion-safe\\:animate-in");
       expect(inner).toBeTruthy();
       expect(inner?.className).toContain("motion-safe:fade-in");
@@ -152,14 +299,55 @@ describe("EmptyState", () => {
     });
 
     it("does not use transition-all", () => {
-      const { container } = render(<EmptyState variant="zero-data" title="No items" />);
+      const { container } = render(
+        <EmptyState variant="zero-data" scale="canvas" title="No items" />
+      );
       expect(container.innerHTML).not.toContain("transition-all");
+    });
+  });
+
+  describe("container queries", () => {
+    it("establishes a named container on the outer wrapper", () => {
+      // The runtime fallback for wrong-scale usage and surface resize: density
+      // collapses based on the actual rendered width via Tailwind v4's
+      // `@container/empty-state` named-container utility.
+      const { container } = render(
+        <EmptyState variant="zero-data" scale="canvas" title="No items" />
+      );
+      const status = container.querySelector('[role="status"]');
+      expect(status?.className).toContain("@container/empty-state");
+    });
+
+    it("ships compact-density variants gated on the named container", () => {
+      // The `@max-[280px]/empty-state:` prefix triggers when the outer
+      // container's inline-size falls below 280px — comfortably above the
+      // 200px minimum sidebar floor without affecting the 350px default.
+      const { container } = render(
+        <EmptyState
+          variant="zero-data"
+          scale="canvas"
+          title="No items"
+          icon={<svg data-testid="icon" />}
+        />
+      );
+      const status = container.querySelector('[role="status"]');
+      expect(status?.className).toContain("@max-[280px]/empty-state:py-4");
+      const iconWrap = container.querySelector('[aria-hidden="true"]');
+      expect(iconWrap?.className).toContain("@max-[280px]/empty-state:[&_svg]:h-4");
+      expect(iconWrap?.className).toContain("@max-[280px]/empty-state:[&_svg]:w-4");
     });
   });
 
   describe("className passthrough", () => {
     it("merges custom className on the container", () => {
-      render(<EmptyState variant="zero-data" title="No items" className="my-custom-class" />);
+      render(
+        <EmptyState
+          variant="zero-data"
+          scale="canvas"
+          title="No items"
+          className="my-custom-class"
+        />
+      );
       const status = screen.getByRole("status");
       expect(status.className).toContain("my-custom-class");
     });
@@ -168,7 +356,12 @@ describe("EmptyState", () => {
   describe("falsy description handling", () => {
     it("does not render an empty paragraph when description is false", () => {
       const { container } = render(
-        <EmptyState variant="zero-data" title="No items" description={false as unknown as string} />
+        <EmptyState
+          variant="zero-data"
+          scale="canvas"
+          title="No items"
+          description={false as unknown as string}
+        />
       );
       const paragraphs = container.querySelectorAll("p");
       // Only the title paragraph should render; no empty description paragraph.
@@ -178,7 +371,7 @@ describe("EmptyState", () => {
 
     it("does not render an empty paragraph when description is null", () => {
       const { container } = render(
-        <EmptyState variant="zero-data" title="No items" description={null} />
+        <EmptyState variant="zero-data" scale="canvas" title="No items" description={null} />
       );
       expect(container.querySelectorAll("p").length).toBe(1);
     });


### PR DESCRIPTION
## Summary

- Adds a `scale` discriminant (`"popover" | "sidebar" | "canvas"`) to the `EmptyState` union type. At `popover` and `sidebar` scales, `description?: never` makes long-description usage a compile-time error — no runtime overhead, no casts needed. The `user-cleared` variant also forbids `description` and `action` at every scale, backed by a runtime guard so type casts can't bypass it.
- Adds a Tailwind v4 `@container/empty-state` query on the outer wrapper so the icon compresses at <280px regardless of assigned scale. (Padding compression on the container element itself is a CSS spec no-op — the element can't style itself — so only the descendant icon wrapper participates.)
- Updates 9 call sites with explicit scale values. The `SidebarContent` kbd hint moves from `description` to the `action` slot to satisfy the new contract while preserving the #6752 wayfinding cue. `ReviewHubContent` gains `truncateFilterQuery` so long file paths don't overflow a 200px panel.

Resolves #7844

## Changes

- `src/components/ui/EmptyState.tsx` — scale discriminant on union, `never` guards, runtime check, `@container` wrapper
- `src/components/ui/__tests__/EmptyState.test.tsx` — 9 `@ts-expect-error` compile-time cases, runtime regression test, CSS placement structural test
- `src/components/Worktree/ReviewHub/reviewHubUtils.ts` — `truncateFilterQuery` helper
- Call sites updated: `AppPaletteDialog` (popover), `SidebarContent` (sidebar), `ReviewHubContent` (sidebar), `LogsContent` (sidebar), `RecipesTab` (sidebar), `NotificationCenter` (canvas), `GitHubResourceList` (canvas), `RecipeManager` (canvas), `McpServerSettingsTab` (canvas)

## Testing

- `npm run check` clean — typecheck, lint, format all pass
- `npx vitest run` — 216 tests pass across `EmptyState`, `SidebarContent.emptyState`, and `ReviewHub` suites