### PR TITLE
enhance(onboarding): add tooltips and Escape key to checklist header

### DIFF
--- a/src/components/Onboarding/GettingStartedChecklist.tsx
+++ b/src/components/Onboarding/GettingStartedChecklist.tsx
@@ -1,10 +1,12 @@
-import { useEffect, useRef, useState } from "react";
+import { useCallback, useEffect, useRef, useState } from "react";
 import { createPortal } from "react-dom";
 import { Check, ChevronDown, ChevronUp, X } from "lucide-react";
 import { useReducedMotion } from "framer-motion";
 import { DURATION_200 } from "@/lib/animationUtils";
 import { cn } from "@/lib/utils";
 import { actionService } from "@/services/ActionService";
+import { Tooltip, TooltipTrigger, TooltipContent } from "@/components/ui/tooltip";
+import { useEscapeStack } from "@/hooks/useEscapeStack";
 import { AnimatedLabel } from "@/components/ui/AnimatedLabel";
 import type { ChecklistState, ChecklistItemId } from "@shared/types/ipc/maps";
 import { CHECKLIST_ITEMS } from "./checklistItems";
@@ -133,6 +135,15 @@ export function GettingStartedChecklist({
   const counterLabel = allComplete ? "All set" : `${completedCount}/${totalCount}`;
   const counterAnimateKey = allComplete ? "all-set" : String(completedCount);
 
+  const panelRef = useRef<HTMLDivElement>(null);
+  const [isFocusWithin, setIsFocusWithin] = useState(false);
+
+  const handleEscape = useCallback(() => {
+    onToggleCollapse();
+  }, [onToggleCollapse]);
+
+  useEscapeStack(isFocusWithin, handleEscape);
+
   return createPortal(
     <div
       className={cn(
@@ -142,9 +153,16 @@ export function GettingStartedChecklist({
       style={{ right: "calc(var(--right-obstruction-offset, 0px))" }}
     >
       <div
+        ref={panelRef}
         role="region"
         aria-label="Getting started checklist"
         data-getting-started-checklist=""
+        onFocus={() => setIsFocusWithin(true)}
+        onBlur={(e) => {
+          if (!panelRef.current?.contains(e.relatedTarget as Node | null)) {
+            setIsFocusWithin(false);
+          }
+        }}
         className={cn(
           "pointer-events-auto relative w-full",
           "rounded-[var(--radius-sm)] border",
@@ -164,44 +182,54 @@ export function GettingStartedChecklist({
       >
         {/* Header */}
         <div className="flex items-center justify-between px-3 py-2.5">
-          <button
-            type="button"
-            onClick={onToggleCollapse}
-            aria-expanded={!collapsed}
-            aria-controls={CHECKLIST_BODY_ID}
-            className="flex items-center gap-2 text-left flex-1 min-w-0"
-          >
-            <h4 className="font-medium leading-tight tracking-tight text-xs font-mono text-daintree-accent">
-              Getting Started
-            </h4>
-            <AnimatedLabel
-              label={counterLabel}
-              animateKey={counterAnimateKey}
-              textClassName={cn(
-                "text-[10px] font-mono tabular-nums",
-                allComplete ? "text-daintree-accent" : "text-daintree-text/50"
-              )}
-            />
-            {collapsed ? (
-              <ChevronUp className="h-3 w-3 text-daintree-text/50 shrink-0" />
-            ) : (
-              <ChevronDown className="h-3 w-3 text-daintree-text/50 shrink-0" />
-            )}
-          </button>
-          <button
-            type="button"
-            onClick={onDismiss}
-            aria-label="Dismiss checklist"
-            className={cn(
-              "rounded-[var(--radius-xs)]",
-              "h-6 w-6 flex items-center justify-center shrink-0",
-              "text-daintree-text/60 transition-colors",
-              "hover:text-daintree-text/90 hover:bg-tint/10",
-              "focus-visible:outline focus-visible:outline-2 focus-visible:outline-daintree-accent focus-visible:outline-offset-2"
-            )}
-          >
-            <X className="h-3.5 w-3.5" />
-          </button>
+          <Tooltip>
+            <TooltipTrigger asChild>
+              <button
+                type="button"
+                onClick={onToggleCollapse}
+                aria-expanded={!collapsed}
+                aria-controls={CHECKLIST_BODY_ID}
+                className="flex items-center gap-2 text-left flex-1 min-w-0"
+              >
+                <h4 className="font-medium leading-tight tracking-tight text-xs font-mono text-daintree-accent">
+                  Getting Started
+                </h4>
+                <AnimatedLabel
+                  label={counterLabel}
+                  animateKey={counterAnimateKey}
+                  textClassName={cn(
+                    "text-[10px] font-mono tabular-nums",
+                    allComplete ? "text-daintree-accent" : "text-daintree-text/50"
+                  )}
+                />
+                {collapsed ? (
+                  <ChevronUp className="h-3 w-3 text-daintree-text/50 shrink-0" />
+                ) : (
+                  <ChevronDown className="h-3 w-3 text-daintree-text/50 shrink-0" />
+                )}
+              </button>
+            </TooltipTrigger>
+            <TooltipContent side="bottom">{collapsed ? "Expand" : "Collapse"}</TooltipContent>
+          </Tooltip>
+          <Tooltip>
+            <TooltipTrigger asChild>
+              <button
+                type="button"
+                onClick={onDismiss}
+                aria-label="Dismiss checklist"
+                className={cn(
+                  "rounded-[var(--radius-xs)]",
+                  "h-6 w-6 flex items-center justify-center shrink-0",
+                  "text-daintree-text/60 transition-colors",
+                  "hover:text-daintree-text/90 hover:bg-tint/10",
+                  "focus-visible:outline focus-visible:outline-2 focus-visible:outline-daintree-accent focus-visible:outline-offset-2"
+                )}
+              >
+                <X className="h-3.5 w-3.5" />
+              </button>
+            </TooltipTrigger>
+            <TooltipContent side="bottom">Hide checklist</TooltipContent>
+          </Tooltip>
         </div>
 
         {/* Collapsible body */}

--- a/src/components/Onboarding/__tests__/GettingStartedChecklist.test.tsx
+++ b/src/components/Onboarding/__tests__/GettingStartedChecklist.test.tsx
@@ -1,10 +1,16 @@
 // @vitest-environment jsdom
-import { render, screen, fireEvent } from "@testing-library/react";
+import { render, screen, fireEvent, act } from "@testing-library/react";
 import { describe, expect, it, vi, beforeEach } from "vitest";
+import { dispatchEscape, _resetForTests } from "@/lib/escapeStack";
 
 const { dispatchMock, useReducedMotionMock } = vi.hoisted(() => ({
   dispatchMock: vi.fn(() => Promise.resolve()),
   useReducedMotionMock: vi.fn(() => false),
+}));
+
+vi.mock("@/components/ui/radix-loader", () => ({
+  useRadixPrimitives: () => null,
+  primeOnEvent: () => {},
 }));
 
 vi.mock("@/services/ActionService", () => ({
@@ -67,6 +73,7 @@ describe("GettingStartedChecklist", () => {
 
   beforeEach(() => {
     vi.clearAllMocks();
+    _resetForTests();
   });
 
   it("renders incomplete steps as buttons", () => {
@@ -261,6 +268,108 @@ describe("GettingStartedChecklist", () => {
       const accented = screen.getByText("All set");
       expect(accented.className).toContain("text-daintree-accent");
       expect(accented.className).not.toContain("text-daintree-text/50");
+    });
+  });
+
+  describe("dismiss button", () => {
+    it("calls onDismiss when the dismiss button is clicked", () => {
+      render(<GettingStartedChecklist {...defaultProps} checklist={allIncomplete} />);
+      const dismissBtn = screen.getByRole("button", { name: "Dismiss checklist" });
+      fireEvent.click(dismissBtn);
+      expect(defaultProps.onDismiss).toHaveBeenCalledTimes(1);
+    });
+
+    it("does not call onToggleCollapse when dismiss button is clicked", () => {
+      render(<GettingStartedChecklist {...defaultProps} checklist={allIncomplete} />);
+      const dismissBtn = screen.getByRole("button", { name: "Dismiss checklist" });
+      fireEvent.click(dismissBtn);
+      expect(defaultProps.onToggleCollapse).not.toHaveBeenCalled();
+    });
+  });
+
+  describe("Escape key", () => {
+    it("calls onToggleCollapse when Escape is pressed while focus is inside the panel", () => {
+      render(<GettingStartedChecklist {...defaultProps} checklist={allIncomplete} />);
+      const region = screen.getByRole("region", { name: "Getting started checklist" });
+
+      act(() => {
+        region.dispatchEvent(new FocusEvent("focusin", { bubbles: true }));
+      });
+
+      act(() => {
+        dispatchEscape();
+      });
+
+      expect(defaultProps.onToggleCollapse).toHaveBeenCalledTimes(1);
+      expect(defaultProps.onDismiss).not.toHaveBeenCalled();
+    });
+
+    it("does nothing when Escape is pressed while focus is outside the panel", () => {
+      render(<GettingStartedChecklist {...defaultProps} checklist={allIncomplete} />);
+
+      act(() => {
+        dispatchEscape();
+      });
+
+      expect(defaultProps.onToggleCollapse).not.toHaveBeenCalled();
+      expect(defaultProps.onDismiss).not.toHaveBeenCalled();
+    });
+
+    it("does nothing when Escape is pressed after focus has left the panel", () => {
+      render(<GettingStartedChecklist {...defaultProps} checklist={allIncomplete} />);
+      const region = screen.getByRole("region", { name: "Getting started checklist" });
+
+      act(() => {
+        region.dispatchEvent(new FocusEvent("focusin", { bubbles: true }));
+      });
+
+      act(() => {
+        region.dispatchEvent(new FocusEvent("focusout", { bubbles: true }));
+      });
+
+      act(() => {
+        dispatchEscape();
+      });
+
+      expect(defaultProps.onToggleCollapse).not.toHaveBeenCalled();
+      expect(defaultProps.onDismiss).not.toHaveBeenCalled();
+    });
+
+    it("cleans up its escape handler on unmount", () => {
+      const { unmount } = render(
+        <GettingStartedChecklist {...defaultProps} checklist={allIncomplete} />
+      );
+      const region = screen.getByRole("region", { name: "Getting started checklist" });
+
+      act(() => {
+        region.dispatchEvent(new FocusEvent("focusin", { bubbles: true }));
+      });
+
+      unmount();
+
+      act(() => {
+        dispatchEscape();
+      });
+
+      expect(defaultProps.onToggleCollapse).not.toHaveBeenCalled();
+    });
+  });
+
+  describe("tooltip structure", () => {
+    it("preserves aria-expanded and aria-controls on the toggle button after tooltip wrapping", () => {
+      render(
+        <GettingStartedChecklist {...defaultProps} checklist={allIncomplete} collapsed={false} />
+      );
+      const toggle = screen.getByRole("button", { name: /getting started/i });
+      expect(toggle.getAttribute("aria-expanded")).toBe("true");
+      expect(toggle.getAttribute("aria-controls")).toBe("getting-started-checklist-body");
+    });
+
+    it("preserves aria-label on the dismiss button after tooltip wrapping", () => {
+      render(<GettingStartedChecklist {...defaultProps} checklist={allIncomplete} />);
+      const dismissBtn = screen.getByRole("button", { name: "Dismiss checklist" });
+      expect(dismissBtn).toBeTruthy();
+      expect(dismissBtn.getAttribute("aria-label")).toBe("Dismiss checklist");
     });
   });
 


### PR DESCRIPTION
## Summary
The Getting Started checklist header now has tooltips so users can tell whether the chevron collapses the panel or the X dismisses it entirely. Escape toggles collapse when focus is inside the panel.

Resolves #7849

## Changes
- Added Radix Tooltip wrappers on the chevron button (dynamic "Collapse" / "Expand" depending on state) and the X button ("Hide checklist")
- Added a panel-scoped Escape key handler that toggles collapse — the less destructive of the two actions, matching ARIA APG expectations for dismissible floating surfaces
- Added 6 new unit tests covering Escape behavior, dismiss click, and tooltip structure

## Testing
All 32 unit tests pass. New tests cover Escape key behavior, dismiss click, and tooltip structure. The `aria-label` on the X button stays as the screen-reader name.