### PR TITLE
fix(notifications): polish NotificationCenter inbox chrome and toast copy

### DIFF
--- a/src/components/Notifications/NotificationCenter.tsx
+++ b/src/components/Notifications/NotificationCenter.tsx
@@ -346,9 +346,11 @@ export function NotificationCenter({ open, onClose }: NotificationCenterProps) {
     }
     notify({
       type: "success",
-      message: `Marked ${ids.length} read`,
-      // Action-bearing toasts default to sticky (duration: 0). Keep the undo
-      // window short and explicit so the toast clears itself.
+      message: `Marked ${ids.length} as read`,
+      // WCAG 2.2.1: the 5 s auto-dismiss is permitted under the "available
+      // elsewhere without a time limit" exception — the notification history
+      // inbox is always accessible as the recovery surface, and Undo provides
+      // a reversal mechanism within the time limit.
       duration: 5000,
       priority: "high",
       // Time-bound undo — surface even during quiet hours so the user has a
@@ -564,31 +566,7 @@ export function NotificationCenter({ open, onClose }: NotificationCenterProps) {
     <div className="w-[360px] max-h-[420px] flex flex-col">
       <div className="flex items-center justify-between px-3 py-2 border-b border-divider gap-2">
         <div className="flex items-center gap-1.5 min-w-0">
-          {showMutedPill ? (
-            <span
-              data-testid="notification-muted-pill"
-              className="inline-flex items-center gap-1 rounded-full bg-overlay-medium px-2 py-0.5 text-[11px] text-daintree-text/70"
-            >
-              <span className="font-medium text-daintree-text/80">Notifications</span>
-              <span aria-hidden="true" className="text-daintree-text/40">
-                ·
-              </span>
-              <span className="truncate">{pillLabel}</span>
-              {isSessionMuted && (
-                <button
-                  type="button"
-                  onClick={handleResumeNotifications}
-                  aria-label="Resume notifications"
-                  title="Resume notifications"
-                  className="ml-0.5 inline-flex shrink-0 items-center justify-center rounded-[var(--radius-sm)] px-1.5 py-0.5 text-[11px] font-medium text-daintree-text/70 hover:bg-overlay-emphasis hover:text-daintree-text transition-colors"
-                >
-                  Resume
-                </button>
-              )}
-            </span>
-          ) : (
-            <span className="text-xs font-medium text-daintree-text/80">Notifications</span>
-          )}
+          <span className="text-xs font-medium text-daintree-text/80">Notifications</span>
           {entries.length > 0 && (
             <>
               <button
@@ -703,6 +681,25 @@ export function NotificationCenter({ open, onClose }: NotificationCenterProps) {
           )}
         </div>
       </div>
+      {showMutedPill && (
+        <div
+          data-testid="notification-muted-pill"
+          className="flex items-center gap-1.5 px-3 py-1 bg-overlay-subtle text-[11px] font-medium uppercase tracking-wide text-daintree-text/70"
+        >
+          <span className="truncate">{pillLabel}</span>
+          {isSessionMuted && (
+            <button
+              type="button"
+              onClick={handleResumeNotifications}
+              aria-label="Resume notifications"
+              title="Resume notifications"
+              className="ml-0.5 inline-flex shrink-0 items-center justify-center rounded-[var(--radius-sm)] px-1.5 py-0.5 text-[11px] font-medium text-daintree-text/70 hover:bg-overlay-emphasis hover:text-daintree-text transition-colors"
+            >
+              Resume
+            </button>
+          )}
+        </div>
+      )}
       <div className="relative flex-1 min-h-0">
         <div
           ref={setScrollContainer}
@@ -1022,7 +1019,7 @@ function ContextSectionHeader({
           <button
             type="button"
             onClick={onMarkRead}
-            className="invisible opacity-0 pointer-events-none transition-[opacity,visibility] duration-150 motion-reduce:transition-none group-hover/section:visible group-hover/section:opacity-100 group-hover/section:pointer-events-auto group-focus-within/section:visible group-focus-within/section:opacity-100 group-focus-within/section:pointer-events-auto inline-flex items-center rounded-[var(--radius-sm)] px-1.5 py-0.5 normal-case tracking-normal text-daintree-text/60 hover:bg-overlay-emphasis hover:text-daintree-text"
+            className="inline-flex items-center rounded-[var(--radius-sm)] px-1.5 py-0.5 normal-case tracking-normal text-daintree-text/50 hover:text-daintree-text/80 hover:bg-overlay-emphasis focus-visible:text-daintree-text/80 focus-visible:bg-overlay-emphasis transition-colors"
           >
             Mark read
           </button>
@@ -1049,20 +1046,18 @@ function NewSinceLastLookedDivider({
       ref={ref}
       tabIndex={-1}
       data-testid="new-since-last-looked"
-      className="flex items-center gap-2 px-3 py-1 text-[10px] font-medium text-daintree-text/50 outline-hidden"
+      className="flex items-center gap-2 px-3 py-1 bg-overlay-subtle text-[10px] font-medium uppercase tracking-wide text-daintree-text/50 outline-hidden"
     >
-      <span className="h-px flex-1 bg-divider" aria-hidden="true" />
       <span>New since you last looked</span>
       {unreadCount > 0 && (
         <button
           type="button"
           onClick={onMarkRead}
-          className="inline-flex items-center rounded-[var(--radius-sm)] px-1.5 py-0.5 text-daintree-text/60 hover:bg-overlay-emphasis hover:text-daintree-text transition-colors"
+          className="inline-flex items-center rounded-[var(--radius-sm)] px-1.5 py-0.5 normal-case tracking-normal text-daintree-text/60 hover:bg-overlay-emphasis hover:text-daintree-text transition-colors"
         >
           Mark these {unreadCount} read
         </button>
       )}
-      <span className="h-px flex-1 bg-divider" aria-hidden="true" />
     </div>
   );
 }

--- a/src/components/Notifications/NotificationCenter.tsx
+++ b/src/components/Notifications/NotificationCenter.tsx
@@ -341,6 +341,9 @@ export function NotificationCenter({ open, onClose }: NotificationCenterProps) {
     });
     if (ids.length === 0) return;
     markIdsRead(ids);
+    const prevLastClosedAt = options.resetLastClosed
+      ? useUIStore.getState().lastNotificationCenterClosedAt
+      : undefined;
     if (options.resetLastClosed) {
       resetLastClosedAt();
     }
@@ -364,6 +367,9 @@ export function NotificationCenter({ open, onClose }: NotificationCenterProps) {
         onClick: () => {
           for (const id of ids) {
             markUnseenAsToast(id, { silent: true });
+          }
+          if (prevLastClosedAt !== undefined) {
+            useUIStore.setState({ lastNotificationCenterClosedAt: prevLastClosedAt });
           }
         },
       },
@@ -693,7 +699,7 @@ export function NotificationCenter({ open, onClose }: NotificationCenterProps) {
               onClick={handleResumeNotifications}
               aria-label="Resume notifications"
               title="Resume notifications"
-              className="ml-0.5 inline-flex shrink-0 items-center justify-center rounded-[var(--radius-sm)] px-1.5 py-0.5 text-[11px] font-medium text-daintree-text/70 hover:bg-overlay-emphasis hover:text-daintree-text transition-colors"
+              className="ml-0.5 inline-flex shrink-0 items-center justify-center rounded-[var(--radius-sm)] px-1.5 py-0.5 text-[11px] font-medium normal-case tracking-normal text-daintree-text/70 hover:bg-overlay-emphasis hover:text-daintree-text transition-colors"
             >
               Resume
             </button>
@@ -1055,7 +1061,7 @@ function NewSinceLastLookedDivider({
           onClick={onMarkRead}
           className="inline-flex items-center rounded-[var(--radius-sm)] px-1.5 py-0.5 normal-case tracking-normal text-daintree-text/60 hover:bg-overlay-emphasis hover:text-daintree-text transition-colors"
         >
-          Mark these {unreadCount} read
+          {unreadCount === 1 ? "Mark this read" : `Mark these ${unreadCount} read`}
         </button>
       )}
     </div>

--- a/src/components/Notifications/__tests__/NotificationCenter.test.tsx
+++ b/src/components/Notifications/__tests__/NotificationCenter.test.tsx
@@ -431,7 +431,6 @@ describe("NotificationCenter muted pill", () => {
 
     const pill = screen.getByTestId("notification-muted-pill");
     expect(pill).toBeTruthy();
-    expect(pill.textContent).toContain("Notifications");
     expect(pill.textContent).toMatch(/Muted until /);
     const resume = screen.getByLabelText("Resume notifications");
     expect(resume).toBeTruthy();
@@ -1285,7 +1284,7 @@ describe("NotificationCenter — bulk mark-read with Undo", () => {
 
     const payload = getLastNotifyPayload();
     expect(payload.type).toBe("success");
-    expect(payload.message).toBe("Marked 2 read");
+    expect(payload.message).toBe("Marked 2 as read");
     expect(payload.duration).toBe(5000);
     expect(payload.urgent).toBe(true);
     expect(payload.transient).toBe(true);
@@ -1395,7 +1394,7 @@ describe("NotificationCenter — bulk mark-read with Undo", () => {
     expect(entries.find((e) => e.id === "old-1")?.seenAsToast).toBe(false);
 
     const payload = getLastNotifyPayload();
-    expect(payload.message).toBe("Marked 2 read");
+    expect(payload.message).toBe("Marked 2 as read");
     expect(useUIStore.getState().lastNotificationCenterClosedAt).toBe(0);
   });
 
@@ -1431,8 +1430,12 @@ describe("NotificationCenter — bulk mark-read with Undo", () => {
     const loginHeader = headers.find((h) => (h.textContent ?? "").includes("feature/login"));
     expect(loginHeader).toBeTruthy();
 
+    // Mark read button is always visible (not gated on hover).
+    const markReadBtn = within(loginHeader!).getByText("Mark read");
+    expect(markReadBtn.className).not.toContain("invisible");
+
     await act(async () => {
-      fireEvent.click(within(loginHeader!).getByText("Mark read"));
+      fireEvent.click(markReadBtn);
     });
 
     const entries = useNotificationHistoryStore.getState().entries;
@@ -1444,7 +1447,7 @@ describe("NotificationCenter — bulk mark-read with Undo", () => {
     expect(useUIStore.getState().lastNotificationCenterClosedAt).toBe(99999);
 
     const payload = getLastNotifyPayload();
-    expect(payload.message).toBe("Marked 2 read");
+    expect(payload.message).toBe("Marked 2 as read");
   });
 
   it("section header 'Mark read' button is not rendered when the section has no unread entries", () => {


### PR DESCRIPTION
## Summary

Four small polish changes to the NotificationCenter inbox. The muted-state pill gets its own strip so it doesn't compete with the filter pills, the Mark-read button is always visible at low opacity, the milestone divider reads as a waypoint instead of a row break, and the mark-all-read toast copy works at both singular and plural.

Resolves #7854

## Changes

- Muted-state pill moved to a dedicated strip below the title row, styled to match `ContextSectionHeader` (`bg-overlay-subtle`, `uppercase tracking-wide`)
- Section-header Mark-read button always visible at `text-daintree-text/50`, lifting to `/80` on hover/focus
- Milestone divider replaced with a tinted band (`bg-overlay-subtle`, `uppercase tracking-wide` label) that reads as a waypoint sibling to the section headers
- Mark-all-read toast copy changed from `Marked N read` to `Marked N as read` so it reads correctly at N=1 and N>1, with inline WCAG 2.2.1 documentation
- Undo restores previous `lastClosedAt` value so the milestone doesn't disappear permanently on undo
- Divider Mark-read button uses singular copy at count 1

## Testing

Test assertions updated for the new toast copy. The `notification-muted-pill` and `new-since-last-looked` testIds persist on the new elements.