### PR TITLE
fix(onboarding): stop auto-exiting Getting Started checklist on completion

### DIFF
--- a/src/hooks/app/__tests__/useGettingStartedChecklist.test.tsx
+++ b/src/hooks/app/__tests__/useGettingStartedChecklist.test.tsx
@@ -311,7 +311,7 @@ describe("useGettingStartedChecklist", () => {
       });
     }
 
-    it("does not emit a toast or read keybinding when the final item completes", async () => {
+    it("does not emit a toast, read keybinding, or auto-dismiss when the final item completes", async () => {
       // Regression guard for #7499: the on-screen CelebrationConfetti is the
       // sole completion signal. A toast would be redundant (Visible-another-way)
       // and its CTA would point to an action the user just finished (Helpful).
@@ -327,12 +327,13 @@ describe("useGettingStartedChecklist", () => {
       expect(onboardingMock.markChecklistItem).toHaveBeenCalledWith("ranSecondParallelAgent");
       expect(notifyMock).not.toHaveBeenCalled();
       expect(getDisplayComboMock).not.toHaveBeenCalled();
+      expect(onboardingMock.dismissChecklist).not.toHaveBeenCalled();
       expect(onboardingMock.markChecklistCelebrationShown).toHaveBeenCalledTimes(1);
       expect(result.current.showCelebration).toBe(true);
     });
   });
 
-  describe("milestone-beat hold", () => {
+  describe("completion behavior", () => {
     beforeEach(() => {
       onboardingMock.getChecklist.mockResolvedValue({
         items: {
@@ -346,7 +347,7 @@ describe("useGettingStartedChecklist", () => {
       });
     });
 
-    it("keeps panel visible during the hold, then dismisses after 800ms", async () => {
+    it("keeps panel visible after all items complete (no auto-dismiss)", async () => {
       const { result } = renderHook(() => useGettingStartedChecklist(true));
       await act(async () => {
         await vi.advanceTimersByTimeAsync(0);
@@ -356,77 +357,21 @@ describe("useGettingStartedChecklist", () => {
         result.current.markItem("ranSecondParallelAgent");
       });
 
-      // IPC dismiss fires immediately for restart safety.
-      expect(onboardingMock.dismissChecklist).toHaveBeenCalledTimes(1);
-      // Panel stays visible during the hold.
+      // Panel stays visible after completion — no auto-dismiss.
       expect(result.current.visible).toBe(true);
       expect(result.current.checklist?.dismissed).toBe(false);
+      // dismissChecklist is NOT called on completion.
+      expect(onboardingMock.dismissChecklist).not.toHaveBeenCalled();
 
+      // Advance well past the old 800ms hold — panel remains visible.
       await act(async () => {
-        await vi.advanceTimersByTimeAsync(799);
+        await vi.advanceTimersByTimeAsync(2000);
       });
       expect(result.current.visible).toBe(true);
-
-      await act(async () => {
-        await vi.advanceTimersByTimeAsync(1);
-      });
-      expect(result.current.visible).toBe(false);
-      expect(result.current.checklist?.dismissed).toBe(true);
+      expect(result.current.checklist?.dismissed).toBe(false);
     });
 
-    it("ignores onChecklistPush(dismissed:true) during the hold window", async () => {
-      let pushHandler: ((next: ChecklistStateLike) => void) | null = null;
-      const onChecklistPushMock = vi.fn((fn: (next: ChecklistStateLike) => void) => {
-        pushHandler = fn;
-        return () => {};
-      });
-      const augmentedMock = onboardingMock as typeof onboardingMock & {
-        onChecklistPush: typeof onChecklistPushMock;
-      };
-      augmentedMock.onChecklistPush = onChecklistPushMock;
-
-      try {
-        const { result } = renderHook(() => useGettingStartedChecklist(true));
-        await act(async () => {
-          await vi.advanceTimersByTimeAsync(0);
-        });
-
-        await act(async () => {
-          result.current.markItem("ranSecondParallelAgent");
-        });
-
-        expect(result.current.visible).toBe(true);
-        expect(pushHandler).not.toBeNull();
-
-        // Main process broadcasts the persisted dismissed:true mid-hold;
-        // the panel must stay visible until the local timer fires.
-        await act(async () => {
-          pushHandler!({
-            items: {
-              openedProject: true,
-              launchedAgent: true,
-              createdWorktree: true,
-              ranSecondParallelAgent: true,
-            },
-            dismissed: true,
-            celebrationShown: true,
-          });
-        });
-
-        expect(result.current.visible).toBe(true);
-        expect(result.current.checklist?.dismissed).toBe(false);
-
-        await act(async () => {
-          await vi.advanceTimersByTimeAsync(800);
-        });
-        expect(result.current.visible).toBe(false);
-        expect(result.current.checklist?.dismissed).toBe(true);
-      } finally {
-        delete (augmentedMock as Partial<typeof augmentedMock>).onChecklistPush;
-      }
-    });
-
-    it("applies onChecklistPush(dismissed:true) immediately when no hold is active", async () => {
+    it("onChecklistPush with dismissed:true hides the panel", async () => {
       let pushHandler: ((next: ChecklistStateLike) => void) | null = null;
       const onChecklistPushMock = vi.fn((fn: (next: ChecklistStateLike) => void) => {
         pushHandler = fn;
@@ -446,8 +391,7 @@ describe("useGettingStartedChecklist", () => {
         expect(result.current.visible).toBe(true);
         expect(pushHandler).not.toBeNull();
 
-        // No markItem(allDone), so pendingDismissRef is false. The push gate
-        // must be inactive and dismissed:true must take effect immediately.
+        // Push with dismissed:true takes effect immediately.
         await act(async () => {
           pushHandler!({
             items: {
@@ -468,7 +412,7 @@ describe("useGettingStartedChecklist", () => {
       }
     });
 
-    it("manual dismiss() during the hold dismisses the panel immediately", async () => {
+    it("manual dismiss after completion hides panel and persists dismissal", async () => {
       const { result } = renderHook(() => useGettingStartedChecklist(true));
       await act(async () => {
         await vi.advanceTimersByTimeAsync(0);
@@ -485,8 +429,9 @@ describe("useGettingStartedChecklist", () => {
 
       expect(result.current.visible).toBe(false);
       expect(result.current.checklist?.dismissed).toBe(true);
+      expect(onboardingMock.dismissChecklist).toHaveBeenCalledTimes(1);
 
-      // Pending timer must be a no-op after manual dismiss.
+      // Advancing time does not change anything.
       await act(async () => {
         await vi.advanceTimersByTimeAsync(800);
       });
@@ -507,26 +452,6 @@ describe("useGettingStartedChecklist", () => {
         dismissed: false,
         celebrationShown: false,
       });
-    });
-
-    it("completes pending dismiss in 0ms when reduced motion is preferred", async () => {
-      const { result } = renderHook(() => useGettingStartedChecklist(true));
-      await act(async () => {
-        await vi.advanceTimersByTimeAsync(0);
-      });
-
-      await act(async () => {
-        result.current.markItem("ranSecondParallelAgent");
-      });
-
-      expect(result.current.visible).toBe(true);
-
-      // Timer fires immediately (0ms).
-      await act(async () => {
-        await vi.advanceTimersByTimeAsync(0);
-      });
-      expect(result.current.visible).toBe(false);
-      expect(result.current.checklist?.dismissed).toBe(true);
     });
 
     it("completes celebration auto-clear in 0ms when reduced motion is preferred", async () => {

--- a/src/hooks/app/useGettingStartedChecklist.ts
+++ b/src/hooks/app/useGettingStartedChecklist.ts
@@ -64,9 +64,6 @@ function reconcileCurrentState(
   }
 }
 
-// Hold the panel visible briefly after the final tick so AnimatedLabel can
-// crossfade the counter to a milestone label before the panel exits.
-const PENDING_DISMISS_HOLD_MS = 800;
 const CELEBRATION_CLEAR_MS = 1500;
 
 export function useGettingStartedChecklist(isStateLoaded: boolean): GettingStartedChecklistState {
@@ -75,16 +72,10 @@ export function useGettingStartedChecklist(isStateLoaded: boolean): GettingStart
   const [collapsed, setCollapsed] = useState(false);
   const [forceShow, setForceShow] = useState(false);
   const [showCelebration, setShowCelebration] = useState(false);
-  const [pendingDismiss, setPendingDismiss] = useState(false);
   const checklistRef = useRef(checklist);
-  // Mirror pendingDismiss into a ref so the onChecklistPush merge (which runs
-  // inside a setChecklist functional updater and can't read React state) can
-  // gate the incoming dismissed:true during the hold window.
-  const pendingDismissRef = useRef(false);
 
   const prefersReducedMotion = useReducedMotion();
   const celebrationClearMs = prefersReducedMotion ? 0 : CELEBRATION_CLEAR_MS;
-  const pendingDismissHoldMs = prefersReducedMotion ? 0 : PENDING_DISMISS_HOLD_MS;
 
   useEffect(() => {
     checklistRef.current = checklist;
@@ -104,9 +95,6 @@ export function useGettingStartedChecklist(isStateLoaded: boolean): GettingStart
 
     const updatedItems = { ...prev.items, [item]: true };
     const allDone = Object.values(updatedItems).every(Boolean);
-    // Defer local `dismissed: true` until the hold timer fires so the panel
-    // can show the milestone beat. Persistence via dismissChecklist() runs
-    // immediately for restart safety.
     const next: ChecklistState = allDone
       ? { ...prev, items: updatedItems, celebrationShown: true }
       : { ...prev, items: updatedItems };
@@ -114,18 +102,11 @@ export function useGettingStartedChecklist(isStateLoaded: boolean): GettingStart
     setChecklist(next);
     checklistRef.current = next;
 
-    if (allDone) {
-      pendingDismissRef.current = true;
-      setPendingDismiss(true);
-      safeFireAndForget(window.electron.onboarding.dismissChecklist(), {
-        context: "Dismissing onboarding checklist",
+    if (allDone && !prev.celebrationShown) {
+      setShowCelebration(true);
+      safeFireAndForget(window.electron.onboarding.markChecklistCelebrationShown(), {
+        context: "Marking onboarding celebration shown",
       });
-      if (!prev.celebrationShown) {
-        setShowCelebration(true);
-        safeFireAndForget(window.electron.onboarding.markChecklistCelebrationShown(), {
-          context: "Marking onboarding celebration shown",
-        });
-      }
     }
   }, []);
 
@@ -134,8 +115,6 @@ export function useGettingStartedChecklist(isStateLoaded: boolean): GettingStart
     safeFireAndForget(window.electron.onboarding.dismissChecklist(), {
       context: "Dismissing onboarding checklist (user action)",
     });
-    pendingDismissRef.current = false;
-    setPendingDismiss(false);
     const prev = checklistRef.current;
     if (prev) {
       const next = { ...prev, dismissed: true };
@@ -181,13 +160,10 @@ export function useGettingStartedChecklist(isStateLoaded: boolean): GettingStart
         for (const key of Object.keys(next.items) as Array<keyof typeof next.items>) {
           if (next.items[key] || prev.items[key]) mergedItems[key] = true;
         }
-        // Suppress incoming dismissed:true during the milestone-beat hold —
-        // the timer below applies the local dismissal once the beat finishes.
-        const incomingDismissed = pendingDismissRef.current ? false : next.dismissed;
         const merged: ChecklistState = {
           ...next,
           items: mergedItems,
-          dismissed: prev.dismissed || incomingDismissed,
+          dismissed: prev.dismissed || next.dismissed,
           celebrationShown: prev.celebrationShown || next.celebrationShown,
         };
         checklistRef.current = merged;
@@ -286,26 +262,8 @@ export function useGettingStartedChecklist(isStateLoaded: boolean): GettingStart
     return () => clearTimeout(timer);
   }, [showCelebration, celebrationClearMs]);
 
-  // Hold the panel for a brief milestone beat after the final tick, then
-  // commit the local dismissal so the panel exits.
-  useEffect(() => {
-    if (!pendingDismiss) return;
-    const timer = setTimeout(() => {
-      pendingDismissRef.current = false;
-      setPendingDismiss(false);
-      setChecklist((prev) => (prev ? { ...prev, dismissed: true } : prev));
-      // forceShow keeps `visible` true even after `dismissed:true`. If the
-      // user reached completion via Help > Getting Started, clear it here
-      // so the panel exits with the rest of the beat.
-      setForceShow(false);
-    }, pendingDismissHoldMs);
-    return () => clearTimeout(timer);
-  }, [pendingDismiss, pendingDismissHoldMs]);
-
-  const allDone = checklist ? Object.values(checklist.items).every(Boolean) : false;
   const visible =
-    checklist !== null &&
-    (forceShow || (onboardingCompleted && !checklist.dismissed && (!allDone || pendingDismiss)));
+    checklist !== null && (forceShow || (onboardingCompleted && !checklist.dismissed));
 
   return {
     visible,


### PR DESCRIPTION
Fixes #7850

## Summary

The Getting Started checklist used to auto-dismiss 800ms after the last item completed. The timer made the panel disappear right as the user registered finishing, which felt abrupt and robbed them of the completion moment.

This removes the auto-dismiss entirely. The panel stays visible after all four items complete, shows celebration confetti, and only dismisses when the user clicks the manual X button.

## Changes

- Removed `PENDING_DISMISS_HOLD_MS` (800ms) constant and all `pendingDismiss` / `pendingDismissRef` infrastructure
- Removed the auto-call to `dismissChecklist()` in the `markItem` all-done branch -- `dismissChecklist()` now only fires on explicit user dismiss
- Simplified the `visible` calculation -- no more `pendingDismiss` gate, panel visibility tracks `forceShow || (onboardingCompleted && !checklist.dismissed)`
- Updated tests: no more auto-dismiss assertions, no more hold-window gate tests, manual dismiss is the only path

## Testing

- Unit tests cover the new behavior: panel stays visible after completion (even after 2s+), `dismissChecklist` is not called on completion, manual dismiss hides the panel and persists
- Onboarding completion celebration (confetti) behavior unchanged