### PR TITLE
fix(setup): boost CopyableCommand contrast and replace native title with Tooltip

### DIFF
--- a/src/components/Setup/AgentCliStep.tsx
+++ b/src/components/Setup/AgentCliStep.tsx
@@ -18,6 +18,7 @@ import { systemClient } from "@/clients";
 import { useAgentSettingsStore } from "@/store";
 import { DEFAULT_DANGEROUS_ARGS } from "@shared/types/agentSettings";
 import { CopyableCommand } from "./CopyableCommand";
+import { Tooltip, TooltipTrigger, TooltipContent } from "@/components/ui/tooltip";
 import { AGENT_DESCRIPTIONS } from "@/config/agents";
 import type { CliAvailability } from "@shared/types";
 import { isAgentInstalled } from "@shared/utils/agentAvailability";
@@ -250,14 +251,19 @@ export function AgentCliStep({ availability, selections, onInstallComplete }: Ag
                 </div>
                 <div className="flex items-center gap-2 shrink-0">
                   {config.install?.docsUrl && (
-                    <button
-                      type="button"
-                      className="text-daintree-text/30 hover:text-daintree-text transition-colors p-0.5 cursor-pointer"
-                      onClick={() => systemClient.openExternal(config.install!.docsUrl!)}
-                      title="View documentation"
-                    >
-                      <ExternalLink className="w-3 h-3" />
-                    </button>
+                    <Tooltip>
+                      <TooltipTrigger asChild>
+                        <button
+                          type="button"
+                          className="text-daintree-text/30 hover:text-daintree-text transition-colors p-0.5 cursor-pointer"
+                          onClick={() => systemClient.openExternal(config.install!.docsUrl!)}
+                          aria-label="View documentation"
+                        >
+                          <ExternalLink className="w-3 h-3" />
+                        </button>
+                      </TooltipTrigger>
+                      <TooltipContent>View documentation</TooltipContent>
+                    </Tooltip>
                   )}
                   {isInstalled ? (
                     <span className="inline-flex items-center gap-1 text-[11px] text-status-success font-medium">

--- a/src/components/Setup/AgentCliStep.tsx
+++ b/src/components/Setup/AgentCliStep.tsx
@@ -257,7 +257,7 @@ export function AgentCliStep({ availability, selections, onInstallComplete }: Ag
                           type="button"
                           className="text-daintree-text/30 hover:text-daintree-text transition-colors p-0.5 cursor-pointer"
                           onClick={() => systemClient.openExternal(config.install!.docsUrl!)}
-                          aria-label="View documentation"
+                          aria-label="Open documentation"
                         >
                           <ExternalLink className="w-3 h-3" />
                         </button>

--- a/src/components/Setup/CopyableCommand.tsx
+++ b/src/components/Setup/CopyableCommand.tsx
@@ -1,6 +1,7 @@
 import { Check, Copy } from "lucide-react";
 import { cn } from "@/lib/utils";
 import { useCopyWithFeedback } from "@/hooks/useCopyWithFeedback";
+import { Tooltip, TooltipTrigger, TooltipContent } from "@/components/ui/tooltip";
 
 export function CopyableCommand({ command }: { command: string }) {
   const { copied, copy } = useCopyWithFeedback();
@@ -8,19 +9,26 @@ export function CopyableCommand({ command }: { command: string }) {
   return (
     <div className="flex items-center gap-2 px-3 py-1.5 rounded-[var(--radius-sm)] bg-overlay-subtle border border-daintree-border font-mono text-xs select-text group">
       <span className="flex-1 truncate text-daintree-text/70">{command}</span>
-      <button
-        type="button"
-        onClick={() => void copy(command)}
-        className="shrink-0 p-0.5 rounded hover:bg-overlay transition-colors duration-150 text-daintree-text/30 hover:text-daintree-text/60"
-        aria-label="Copy command to clipboard"
-        title="Copy to clipboard"
-      >
-        {copied ? (
-          <Check key="check" className={cn("w-3.5 h-3.5 text-status-success animate-badge-bump")} />
-        ) : (
-          <Copy key="copy" className="w-3.5 h-3.5" />
-        )}
-      </button>
+      <Tooltip>
+        <TooltipTrigger asChild>
+          <button
+            type="button"
+            onClick={() => void copy(command)}
+            className="shrink-0 p-0.5 rounded hover:bg-overlay transition-colors duration-150 text-daintree-text/60 hover:text-daintree-text/80"
+            aria-label="Copy command to clipboard"
+          >
+            {copied ? (
+              <Check
+                key="check"
+                className={cn("w-3.5 h-3.5 text-status-success animate-badge-bump")}
+              />
+            ) : (
+              <Copy key="copy" className="w-3.5 h-3.5" />
+            )}
+          </button>
+        </TooltipTrigger>
+        <TooltipContent>Copy to clipboard</TooltipContent>
+      </Tooltip>
     </div>
   );
 }

--- a/src/components/Terminal/__tests__/MissingCliGate.test.tsx
+++ b/src/components/Terminal/__tests__/MissingCliGate.test.tsx
@@ -20,6 +20,13 @@ vi.mock("@/lib/utils", () => ({
   cn: (...args: (string | false | undefined | null)[]) => args.filter(Boolean).join(" "),
 }));
 
+vi.mock("@/components/ui/tooltip", () => ({
+  TooltipProvider: ({ children }: { children: React.ReactNode }) => <>{children}</>,
+  Tooltip: ({ children }: { children: React.ReactNode }) => <>{children}</>,
+  TooltipTrigger: ({ children }: { children: React.ReactNode }) => <>{children}</>,
+  TooltipContent: ({ children }: { children: React.ReactNode }) => <>{children}</>,
+}));
+
 // Mock agent config
 vi.mock("@/config/agents", () => ({
   getAgentConfig: (agentId: string) => {


### PR DESCRIPTION
## Summary
Polished the CopyableCommand component used in the agent CLI setup: lifted the copy icon opacity to hit WCAG contrast, swapped native `title` attributes for the Radix Tooltip primitive we already use, and gave the docs link its own `aria-label`.

Resolves #7848

## Changes
- `CopyableCommand.tsx` — copy icon opacity raised to `text/60` (rest) / `text/80` (hover), native `title` replaced with `<Tooltip>` / `<TooltipContent>`
- `AgentCliStep.tsx` — docs-link native `title` replaced with `<Tooltip>`, added `aria-label="Open documentation"` to differentiate from the tooltip text "View documentation"

## Testing
Verified locally: icon contrast is visibly stronger at rest and on hover, tooltip fires on both keyboard focus and hover with the global 500ms delay, and the docs-link aria-label reads correctly.