### PR TITLE
fix(github): keep IssueSelector results visible during typeahead re-fetch

### DIFF
--- a/src/components/GitHub/IssueSelector.tsx
+++ b/src/components/GitHub/IssueSelector.tsx
@@ -29,8 +29,13 @@ export function IssueSelector({
   const [loading, setLoading] = useState(false);
   const debouncedQuery = useDebounce(query, 300);
   const requestGenRef = useRef(0);
+  const prevProjectPathRef = useRef(projectPath);
 
   useEffect(() => {
+    if (prevProjectPathRef.current !== projectPath) {
+      prevProjectPathRef.current = projectPath;
+      setIssues([]);
+    }
     if (!open) return;
 
     const abortController = new AbortController();
@@ -63,7 +68,10 @@ export function IssueSelector({
 
   const handleOpenChange = (nextOpen: boolean) => {
     setOpen(nextOpen);
-    if (!nextOpen) setQuery("");
+    if (!nextOpen) {
+      setQuery("");
+      setIssues([]);
+    }
   };
 
   const handleClear = (e: React.MouseEvent) => {

--- a/src/components/GitHub/IssueSelector.tsx
+++ b/src/components/GitHub/IssueSelector.tsx
@@ -1,4 +1,4 @@
-import { useState, useEffect } from "react";
+import { useState, useEffect, useRef } from "react";
 import { useDebounce } from "@/hooks/useDebounce";
 import { Check, ChevronsUpDown, Search, CircleDot, X } from "lucide-react";
 import { cn } from "@/lib/utils";
@@ -28,11 +28,13 @@ export function IssueSelector({
   const [issues, setIssues] = useState<GitHubIssue[]>([]);
   const [loading, setLoading] = useState(false);
   const debouncedQuery = useDebounce(query, 300);
+  const requestGenRef = useRef(0);
 
   useEffect(() => {
     if (!open) return;
 
     const abortController = new AbortController();
+    const gen = ++requestGenRef.current;
     setLoading(true);
     githubClient
       .listIssues({
@@ -41,18 +43,17 @@ export function IssueSelector({
         search: debouncedQuery || undefined,
       })
       .then((res) => {
-        if (!abortController.signal.aborted) {
+        if (!abortController.signal.aborted && requestGenRef.current === gen) {
           setIssues(res.items);
         }
       })
       .catch((err) => {
-        if (!abortController.signal.aborted) {
+        if (!abortController.signal.aborted && requestGenRef.current === gen) {
           logError("Failed to fetch issues", err);
-          setIssues([]);
         }
       })
       .finally(() => {
-        if (!abortController.signal.aborted) {
+        if (!abortController.signal.aborted && requestGenRef.current === gen) {
           setLoading(false);
         }
       });
@@ -135,8 +136,17 @@ export function IssueSelector({
             aria-expanded={open}
           />
         </div>
-        <div id="issue-list" role="listbox" className="max-h-[300px] overflow-y-auto p-1">
-          {loading ? (
+        <div
+          id="issue-list"
+          role="listbox"
+          className={cn(
+            "max-h-[300px] overflow-y-auto p-1",
+            loading && issues.length > 0 && "palette-results-stale"
+          )}
+          data-stale={loading && issues.length > 0 ? "true" : undefined}
+          aria-busy={loading || undefined}
+        >
+          {loading && issues.length === 0 ? (
             <GitHubResourceRowsSkeleton count={3} immediate />
           ) : issues.length === 0 ? (
             <div className="py-6 text-center text-sm text-muted-foreground">

--- a/src/components/GitHub/__tests__/IssueSelector.test.tsx
+++ b/src/components/GitHub/__tests__/IssueSelector.test.tsx
@@ -1,0 +1,283 @@
+/**
+ * @vitest-environment jsdom
+ */
+import { describe, it, expect, vi, beforeEach, afterEach } from "vitest";
+import { render, screen, waitFor, act, fireEvent } from "@testing-library/react";
+import { IssueSelector } from "../IssueSelector";
+import type { GitHubIssue } from "@shared/types/github";
+
+const mockListIssues = vi.fn();
+
+vi.mock("@/clients/githubClient", () => ({
+  githubClient: {
+    listIssues: (opts: unknown) => mockListIssues(opts),
+  },
+}));
+
+vi.mock("@/hooks/useDebounce", () => ({
+  useDebounce: (value: string) => value,
+}));
+
+const mockIssue = (overrides: Partial<GitHubIssue> = {}): GitHubIssue => ({
+  number: 1,
+  title: "Test issue",
+  state: "OPEN",
+  url: "https://github.com/test/repo/issues/1",
+  updatedAt: "2025-01-01T00:00:00Z",
+  author: { login: "testuser", avatarUrl: "" },
+  commentCount: 0,
+  assignees: [],
+  ...overrides,
+});
+
+describe("IssueSelector", () => {
+  beforeEach(() => {
+    mockListIssues.mockReset();
+  });
+
+  afterEach(() => {
+    vi.restoreAllMocks();
+  });
+
+  const defaultProps = {
+    projectPath: "/test/project",
+    selectedIssue: null,
+    onSelect: vi.fn(),
+  };
+
+  it("shows skeleton on initial open when loading and no issues exist", async () => {
+    let resolvePromise!: (value: { items: GitHubIssue[] }) => void;
+    mockListIssues.mockReturnValue(
+      new Promise((r) => {
+        resolvePromise = r;
+      })
+    );
+
+    render(<IssueSelector {...defaultProps} />);
+    const trigger = screen.getByRole("combobox");
+    fireEvent.click(trigger);
+
+    await waitFor(() => {
+      expect(screen.getByRole("listbox").getAttribute("aria-busy")).toBe("true");
+    });
+    // Skeleton rows are aria-hidden, should be present
+    const listbox = screen.getByRole("listbox");
+    expect(listbox.querySelectorAll('[aria-hidden="true"] > div').length).toBeGreaterThan(0);
+
+    // Resolve the promise
+    await act(async () => resolvePromise({ items: [mockIssue()] }));
+    await waitFor(() => {
+      expect(screen.getByRole("listbox").getAttribute("aria-busy")).toBeNull();
+    });
+    expect(screen.getByRole("option", { name: /test issue/i })).toBeDefined();
+  });
+
+  it("keeps existing rows visible with palette-results-stale class during refetch", async () => {
+    let resolveFirst!: (value: { items: GitHubIssue[] }) => void;
+    let resolveSecond!: (value: { items: GitHubIssue[] }) => void;
+    mockListIssues
+      .mockReturnValueOnce(
+        new Promise((r) => {
+          resolveFirst = r;
+        })
+      )
+      .mockReturnValueOnce(
+        new Promise((r) => {
+          resolveSecond = r;
+        })
+      );
+
+    render(<IssueSelector {...defaultProps} />);
+    const trigger = screen.getByRole("combobox");
+    fireEvent.click(trigger);
+
+    // First fetch completes — rows render
+    await act(async () =>
+      resolveFirst({ items: [mockIssue({ number: 1, title: "First issue" })] })
+    );
+    await waitFor(() => {
+      expect(screen.getByRole("option", { name: /First issue/i })).toBeDefined();
+    });
+
+    // Type to trigger refetch
+    const input = screen.getByPlaceholderText("Search issues...");
+    fireEvent.change(input, { target: { value: "bug" } });
+
+    // Rows should still be visible, now with palette-results-stale
+    await waitFor(() => {
+      const listbox = screen.getByRole("listbox");
+      expect(listbox.className).toContain("palette-results-stale");
+      expect(listbox.getAttribute("data-stale")).toBe("true");
+      expect(listbox.getAttribute("aria-busy")).toBe("true");
+      // Existing rows still visible
+      expect(screen.getByRole("option", { name: /First issue/i })).toBeDefined();
+    });
+
+    // Second fetch completes — stale class removed
+    await act(async () => resolveSecond({ items: [mockIssue({ number: 2, title: "Bug issue" })] }));
+    await waitFor(() => {
+      const listbox = screen.getByRole("listbox");
+      expect(listbox.className).not.toContain("palette-results-stale");
+      expect(listbox.getAttribute("data-stale")).toBeNull();
+      expect(screen.getByRole("option", { name: /Bug issue/i })).toBeDefined();
+    });
+  });
+
+  it("prevents stale response from overwriting newer results when visible", async () => {
+    let resolveFirst!: (value: { items: GitHubIssue[] }) => void;
+    let resolveSecond!: (value: { items: GitHubIssue[] }) => void;
+    mockListIssues
+      .mockReturnValueOnce(
+        new Promise((r) => {
+          resolveFirst = r;
+        })
+      )
+      .mockReturnValueOnce(
+        new Promise((r) => {
+          resolveSecond = r;
+        })
+      );
+
+    render(<IssueSelector {...defaultProps} />);
+    const trigger = screen.getByRole("combobox");
+    fireEvent.click(trigger);
+
+    // First fetch starts, but don't resolve yet
+    await waitFor(() => expect(mockListIssues).toHaveBeenCalledTimes(1));
+
+    // Type to trigger second fetch (first hasn't resolved)
+    const input = screen.getByPlaceholderText("Search issues...");
+    fireEvent.change(input, { target: { value: "x" } });
+
+    // Second fetch is now in-flight. Resolve it first.
+    await act(async () => resolveSecond({ items: [mockIssue({ number: 2, title: "Newer" })] }));
+    await waitFor(() => {
+      expect(screen.getByRole("option", { name: /Newer/i })).toBeDefined();
+    });
+
+    // Now resolve stale first fetch — it must NOT overwrite the newer results
+    await act(async () => resolveFirst({ items: [mockIssue({ number: 1, title: "Stale" })] }));
+
+    // Results should still be the newer ones
+    expect(screen.getByRole("option", { name: /Newer/i })).toBeDefined();
+    expect(screen.queryByRole("option", { name: /Stale/i })).toBeNull();
+  });
+
+  it("preserves existing rows on refetch failure", async () => {
+    let resolveFirst!: (value: { items: GitHubIssue[] }) => void;
+    let rejectSecond!: (reason: Error) => void;
+    mockListIssues
+      .mockReturnValueOnce(
+        new Promise((r) => {
+          resolveFirst = r;
+        })
+      )
+      .mockReturnValueOnce(
+        new Promise((_, reject) => {
+          rejectSecond = reject;
+        })
+      );
+
+    render(<IssueSelector {...defaultProps} />);
+    const trigger = screen.getByRole("combobox");
+    fireEvent.click(trigger);
+
+    await act(async () => resolveFirst({ items: [mockIssue({ number: 1, title: "Survives" })] }));
+    await waitFor(() => {
+      expect(screen.getByRole("option", { name: /Survives/i })).toBeDefined();
+    });
+
+    // Trigger refetch that will fail
+    const input = screen.getByPlaceholderText("Search issues...");
+    fireEvent.change(input, { target: { value: "bug" } });
+
+    await act(async () => rejectSecond(new Error("Network error")));
+
+    // Existing rows preserved, loading ended
+    await waitFor(() => {
+      expect(screen.getByRole("listbox").getAttribute("aria-busy")).toBeNull();
+    });
+    expect(screen.getByRole("option", { name: /Survives/i })).toBeDefined();
+  });
+
+  it("renders empty state when latest success returns no results", async () => {
+    let resolveFirst!: (value: { items: GitHubIssue[] }) => void;
+    let resolveSecond!: (value: { items: GitHubIssue[] }) => void;
+    mockListIssues
+      .mockReturnValueOnce(
+        new Promise((r) => {
+          resolveFirst = r;
+        })
+      )
+      .mockReturnValueOnce(
+        new Promise((r) => {
+          resolveSecond = r;
+        })
+      );
+
+    render(<IssueSelector {...defaultProps} />);
+    const trigger = screen.getByRole("combobox");
+    fireEvent.click(trigger);
+
+    await act(async () => resolveFirst({ items: [mockIssue()] }));
+    await waitFor(() => {
+      expect(screen.getByRole("option")).toBeDefined();
+    });
+
+    // Type query that returns empty
+    const input = screen.getByPlaceholderText("Search issues...");
+    fireEvent.change(input, { target: { value: "nonexistent" } });
+
+    await act(async () => resolveSecond({ items: [] }));
+
+    await waitFor(() => {
+      expect(screen.getByText("No issues found")).toBeDefined();
+    });
+  });
+
+  it("removes stale attributes after fetch resolves", async () => {
+    let resolveFirst!: (value: { items: GitHubIssue[] }) => void;
+    mockListIssues.mockReturnValue(
+      new Promise((r) => {
+        resolveFirst = r;
+      })
+    );
+
+    render(<IssueSelector {...defaultProps} />);
+    const trigger = screen.getByRole("combobox");
+    fireEvent.click(trigger);
+
+    // While loading, skeleton shown with aria-busy
+    await waitFor(() => {
+      expect(screen.getByRole("listbox").getAttribute("aria-busy")).toBe("true");
+    });
+
+    await act(async () => resolveFirst({ items: [mockIssue()] }));
+
+    await waitFor(() => {
+      const listbox = screen.getByRole("listbox");
+      expect(listbox.getAttribute("aria-busy")).toBeNull();
+      expect(listbox.getAttribute("data-stale")).toBeNull();
+      expect(listbox.className).not.toContain("palette-results-stale");
+    });
+  });
+
+  it("renders no-open-issues message when popover opens with no results", async () => {
+    let resolvePromise!: (value: { items: GitHubIssue[] }) => void;
+    mockListIssues.mockReturnValue(
+      new Promise((r) => {
+        resolvePromise = r;
+      })
+    );
+
+    render(<IssueSelector {...defaultProps} />);
+    const trigger = screen.getByRole("combobox");
+    fireEvent.click(trigger);
+
+    await act(async () => resolvePromise({ items: [] }));
+
+    await waitFor(() => {
+      expect(screen.getByText("No open issues")).toBeDefined();
+    });
+  });
+});

--- a/src/components/GitHub/__tests__/IssueSelector.test.tsx
+++ b/src/components/GitHub/__tests__/IssueSelector.test.tsx
@@ -109,6 +109,9 @@ describe("IssueSelector", () => {
       expect(listbox.className).toContain("palette-results-stale");
       expect(listbox.getAttribute("data-stale")).toBe("true");
       expect(listbox.getAttribute("aria-busy")).toBe("true");
+      // Skeleton must NOT be present during refetch (pulse animation absent)
+      expect(listbox.querySelector(".animate-pulse-immediate")).toBeNull();
+      expect(listbox.querySelector(".animate-pulse-delayed")).toBeNull();
       // Existing rows still visible
       expect(screen.getByRole("option", { name: /First issue/i })).toBeDefined();
     });
@@ -193,11 +196,95 @@ describe("IssueSelector", () => {
 
     await act(async () => rejectSecond(new Error("Network error")));
 
-    // Existing rows preserved, loading ended
+    // Existing rows preserved, loading ended, stale attributes removed
     await waitFor(() => {
-      expect(screen.getByRole("listbox").getAttribute("aria-busy")).toBeNull();
+      const listbox = screen.getByRole("listbox");
+      expect(listbox.getAttribute("aria-busy")).toBeNull();
+      expect(listbox.className).not.toContain("palette-results-stale");
+      expect(listbox.getAttribute("data-stale")).toBeNull();
     });
     expect(screen.getByRole("option", { name: /Survives/i })).toBeDefined();
+  });
+
+  it("clears issues on close and does not restore stale results on reopen", async () => {
+    let resolvePromise!: (value: { items: GitHubIssue[] }) => void;
+    mockListIssues.mockReturnValue(
+      new Promise((r) => {
+        resolvePromise = r;
+      })
+    );
+
+    render(<IssueSelector {...defaultProps} />);
+    const trigger = screen.getByRole("combobox");
+    fireEvent.click(trigger);
+
+    await act(async () => resolvePromise({ items: [mockIssue({ title: "Should not survive" })] }));
+    await waitFor(() => {
+      expect(screen.getByRole("option")).toBeDefined();
+    });
+
+    // Close popover
+    fireEvent.click(trigger);
+
+    // Reopen — should start fresh with empty issues (skeleton, then fetch)
+    let resolveSecond!: (value: { items: GitHubIssue[] }) => void;
+    mockListIssues.mockReturnValue(
+      new Promise((r) => {
+        resolveSecond = r;
+      })
+    );
+
+    fireEvent.click(trigger);
+
+    // Skeleton should be present (no stale rows)
+    await waitFor(() => {
+      expect(screen.getByRole("listbox").getAttribute("aria-busy")).toBe("true");
+    });
+    expect(screen.queryByRole("option", { name: /Should not survive/i })).toBeNull();
+
+    await act(async () => resolveSecond({ items: [mockIssue({ title: "Fresh" })] }));
+    await waitFor(() => {
+      expect(screen.getByRole("option", { name: /Fresh/i })).toBeDefined();
+    });
+  });
+
+  it("clears issues when projectPath changes", async () => {
+    let resolvePromise!: (value: { items: GitHubIssue[] }) => void;
+    mockListIssues.mockReturnValue(
+      new Promise((r) => {
+        resolvePromise = r;
+      })
+    );
+
+    const { rerender } = render(<IssueSelector {...defaultProps} />);
+    const trigger = screen.getByRole("combobox");
+    fireEvent.click(trigger);
+
+    await act(async () => resolvePromise({ items: [mockIssue({ title: "Repo A issue" })] }));
+    await waitFor(() => {
+      expect(screen.getByRole("option", { name: /Repo A issue/i })).toBeDefined();
+    });
+
+    // Change projectPath — should clear stale issues and refetch
+    let resolveSecond!: (value: { items: GitHubIssue[] }) => void;
+    mockListIssues.mockReturnValue(
+      new Promise((r) => {
+        resolveSecond = r;
+      })
+    );
+
+    rerender(<IssueSelector {...defaultProps} projectPath="/test/project-b" />);
+
+    // Old issues cleared, loading state active
+    await waitFor(() => {
+      expect(screen.queryByRole("option", { name: /Repo A issue/i })).toBeNull();
+      expect(screen.getByRole("listbox").getAttribute("aria-busy")).toBe("true");
+    });
+
+    await act(async () => resolveSecond({ items: [mockIssue({ title: "Repo B issue" })] }));
+    await waitFor(() => {
+      expect(screen.getByRole("option", { name: /Repo B issue/i })).toBeDefined();
+    });
   });
 
   it("renders empty state when latest success returns no results", async () => {


### PR DESCRIPTION
## Summary
Fixes a bug where the IssueSelector typeahead would drop all its results and swap in a skeleton on every keystroke whenever the debounce settled. The results now stay visible during re-fetch, with a `palette-results-stale` opacity utility applied so the user keeps a spatial anchor while waiting.

Resolves #7852

## Changes
- **`IssueSelector.tsx`** — gate skeleton on `loading && issues.length === 0` instead of `loading` alone; add `palette-results-stale` class with `data-stale` / `aria-busy` attributes during re-fetch; use a monotonic `requestGenRef` counter to prevent stale responses from clobbering newer results; preserve existing rows on fetch failure instead of clearing to the empty state; clear issues on popover close and `projectPath` change
- **`IssueSelector.test.tsx`** — 9 new tests covering initial skeleton display, stale attributes during refetch, stale-overwrite prevention, error preservation, cleanup on close and projectPath change, empty state, and stale attribute removal

## Testing
9 unit tests cover every fix path: initial load, refetch preservation, stale-overwrite gating, error resilience, close-during-request cleanup, projectPath-change cleanup, empty states, and stale-attribute teardown.