### PR TITLE
feat(help): add Cmd+L default keybinding for Daintree Assistant

### DIFF
--- a/src/components/FileViewer/FileViewerModal.tsx
+++ b/src/components/FileViewer/FileViewerModal.tsx
@@ -250,15 +250,16 @@ export function FileViewerModal({
         const target = e.target as HTMLElement;
         if (target.tagName === "INPUT" || target.tagName === "TEXTAREA") return;
         e.preventDefault();
+        e.stopImmediatePropagation();
         codeViewerRef.current?.openGotoLine();
       }
     };
 
     window.addEventListener("daintree:find-in-panel", handleFindInPanel);
-    window.addEventListener("keydown", handleKeyDown);
+    window.addEventListener("keydown", handleKeyDown, { capture: true });
     return () => {
       window.removeEventListener("daintree:find-in-panel", handleFindInPanel);
-      window.removeEventListener("keydown", handleKeyDown);
+      window.removeEventListener("keydown", handleKeyDown, { capture: true });
     };
   }, [isOpen, isImageMode, mode]);
 

--- a/src/components/HelpPanel/HelpPanel.tsx
+++ b/src/components/HelpPanel/HelpPanel.tsx
@@ -12,6 +12,7 @@ import { cn } from "@/lib/utils";
 import { DaintreeIcon } from "@/components/icons/DaintreeIcon";
 import { XtermAdapter } from "@/components/Terminal/XtermAdapter";
 import { MissingCliGate } from "@/components/Terminal/MissingCliGate";
+import { terminalInstanceService } from "@/services/TerminalInstanceService";
 import { HelpIntroBanner } from "./HelpIntroBanner";
 import { HelpPanelHeader } from "./HelpPanelHeader";
 import { HelpPanelBanners } from "./HelpPanelBanners";
@@ -116,6 +117,7 @@ export function HelpPanel({
     preferredAgentId,
     introDismissed,
     conversationTouched,
+    focusRequest,
     markConversationStarted,
     setWidth,
     setOpen,
@@ -266,6 +268,8 @@ export function HelpPanel({
   }, []);
 
   // Move keyboard focus into the panel on open and restore it on close.
+  // focusRequest re-triggers this effect so repeated Cmd+L presses can
+  // re-focus a blurred panel without closing it.
   useEffect(() => {
     if (isOpen && isVisible) {
       const active = document.activeElement;
@@ -273,10 +277,24 @@ export function HelpPanel({
         previousFocusRef.current = active;
       }
       const raf = requestAnimationFrame(() => {
+        const state = useHelpPanelStore.getState();
+        if (!state.isOpen) return;
+
         const current = document.activeElement;
         if (current?.closest?.(".xterm-helper-textarea") && panelRef.current?.contains(current)) {
           return;
         }
+
+        // When an agent terminal is running, target its xterm input first.
+        // Falls back to the first-tabbable sweep for pre-launch / missing-CLI.
+        if (terminalId && terminal && terminal.spawnStatus !== "missing-cli") {
+          terminalInstanceService.focus(terminalId);
+          const after = document.activeElement;
+          if (after?.closest?.(".xterm-helper-textarea") && panelRef.current?.contains(after)) {
+            return;
+          }
+        }
+
         const candidates = panelRef.current?.querySelectorAll<HTMLElement>(TABBABLE_SELECTOR);
         let first: HTMLElement | undefined;
         for (const el of candidates ?? []) {
@@ -298,7 +316,7 @@ export function HelpPanel({
       el.focus();
     }
     return undefined;
-  }, [isOpen, isVisible]);
+  }, [isOpen, isVisible, focusRequest, terminalId, terminal]);
 
   // Resize via mouse drag
   const handleResizeStart = useCallback(

--- a/src/components/HelpPanel/__tests__/HelpPanel.helpLaunch.test.tsx
+++ b/src/components/HelpPanel/__tests__/HelpPanel.helpLaunch.test.tsx
@@ -153,6 +153,7 @@ vi.mock("@/config/agents", () => ({
       codex: { name: "Codex", icon: () => null, models: [] },
     })[id],
   getAssistantSupportedAgentIds: () => mockGetAssistantSupportedAgentIds(),
+  getAgentIds: () => ["claude", "gemini", "codex"],
 }));
 
 vi.mock("@/services/ActionService", () => ({

--- a/src/components/HelpPanel/__tests__/HelpPanel.hibernate.test.tsx
+++ b/src/components/HelpPanel/__tests__/HelpPanel.hibernate.test.tsx
@@ -135,10 +135,12 @@ vi.mock("@/config/agents", () => ({
   },
   getAgentConfig: () => ({ name: "Claude", icon: () => null, models: [] }),
   getAssistantSupportedAgentIds: () => mockGetAssistantSupportedAgentIds(),
+  getAgentIds: () => ["claude"],
 }));
 
 vi.mock("@shared/types/agentSettings", () => ({
   buildResumeCommand: (...args: unknown[]) => mockBuildResumeCommand(...args),
+  AgentRoutingConfigSchema: { optional: () => undefined },
 }));
 
 vi.mock("@/services/ActionService", () => ({

--- a/src/services/actions/definitions/helpActions.ts
+++ b/src/services/actions/definitions/helpActions.ts
@@ -9,6 +9,7 @@ import { useCliAvailabilityStore } from "@/store/cliAvailabilityStore";
 import { useFocusStore } from "@/store/focusStore";
 import { useHelpPanelStore } from "@/store/helpPanelStore";
 import { useProjectStore } from "@/store/projectStore";
+import { isAssistantFocused } from "@/store/macroFocusStore";
 import { logError } from "@/utils/logger";
 import { getDefaultAgentId } from "@/lib/resolveAgentId";
 
@@ -171,8 +172,21 @@ export function registerHelpActions(actions: ActionRegistry, callbacks: ActionCa
     keywords: ["docs", "support", "guide", "assistant"],
     run: async () => {
       suppressSidebarResizes();
-      useFocusStore.getState().clearAssistantGesture();
-      useHelpPanelStore.getState().toggle();
+      const store = useHelpPanelStore.getState();
+
+      if (!store.isOpen) {
+        // Closed → open and focus the input
+        useFocusStore.getState().clearAssistantGesture();
+        store.setOpen(true);
+        store.requestFocus();
+      } else if (!isAssistantFocused()) {
+        // Open but blurred → focus the input without closing
+        useFocusStore.getState().clearAssistantGesture();
+        store.requestFocus();
+      } else {
+        // Open and focused → close
+        store.setOpen(false);
+      }
     },
   }));
 }

--- a/src/services/defaultKeybindings.ts
+++ b/src/services/defaultKeybindings.ts
@@ -836,6 +836,14 @@ export const DEFAULT_KEYBINDINGS: KeybindingConfig[] = [
     category: "Help",
   },
   {
+    actionId: "help.togglePanel",
+    combo: "Cmd+L",
+    scope: "global",
+    priority: 0,
+    description: "Toggle Daintree Assistant panel",
+    category: "Help",
+  },
+  {
     actionId: "app.newWindow",
     combo: "Cmd+Shift+Alt+N",
     scope: "global",

--- a/src/store/helpPanelStore.ts
+++ b/src/store/helpPanelStore.ts
@@ -39,6 +39,8 @@ interface HelpPanelState {
    * the assistant session for project A must not leak into project B.
    */
   hibernateSessions: Record<string, HelpHibernateSession>;
+  /** Monotonic counter bumped by requestFocus() so repeated Cmd+L presses re-trigger the focus effect. */
+  focusRequest: number;
 }
 
 interface HelpPanelActions {
@@ -50,6 +52,7 @@ interface HelpPanelActions {
   setPreferredAgent: (agentId: string | null) => void;
   dismissIntro: () => void;
   markConversationStarted: () => void;
+  requestFocus: () => void;
   setHibernateSession: (
     projectId: string,
     entry: { sessionId: string; cwd: string; agentId: string }
@@ -67,6 +70,7 @@ const initialState: HelpPanelState = {
   introDismissed: false,
   conversationTouched: false,
   hibernateSessions: {},
+  focusRequest: 0,
 };
 
 function isRecordOfUnknown(value: unknown): value is Record<string, unknown> {
@@ -121,6 +125,8 @@ export const useHelpPanelStore = create<HelpPanelState & HelpPanelActions>()(
       dismissIntro: () => set({ introDismissed: true }),
 
       markConversationStarted: () => set({ conversationTouched: true }),
+
+      requestFocus: () => set((s) => ({ focusRequest: s.focusRequest + 1 })),
 
       setHibernateSession: (projectId, entry) =>
         set((s) => ({


### PR DESCRIPTION
## Summary
Adds a default `Cmd+L` (`Ctrl+L` on Windows/Linux) keybinding that toggles the Daintree Assistant side panel with a three-state semantic — open and focus, refocus if blurred, close if already focused. When an agent is running, focus lands on the xterm input rather than the first header button.

Resolves #7842.

## Changes
- Added `help.togglePanel` → `Cmd+L` to the default keybindings in `src/services/defaultKeybindings.ts`
- Extended the `help.togglePanel` action handler in `helpActions.ts` with three-state toggle logic
- Added `focusRequest` counter to `helpPanelStore` so repeated keypresses reliably re-trigger the focus effect
- Updated the focus effect in `HelpPanel.tsx` to target the agent xterm input first, falling back to the first tabbable element

## Testing
Manual verification:
- Confirmed `Cmd+L` is intercepted by the renderer before any embedded `WebContentsView` sees it
- Tested all three toggle states: closed → open+focus, blurred → refocus, focused → close
- Verified focus lands on `.xterm-helper-textarea` when an agent is running
- Confirmed Ctrl+L works correctly on Windows/Linux via keymap translation