### PR TITLE
test(voice): update unit tests and docs for OpenAI Realtime backend

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,12 @@
 # Changelog
 
+## [Unreleased]
+
+### Breaking Changes
+
+- **Voice transcription backend switched from Deepgram to OpenAI Realtime API.** The voice subsystem now connects to `wss://api.openai.com/v1/realtime` and uses the `input_audio_transcription` event family (`delta` / `completed`) for streaming results. Spoken dictation commands ("new paragraph", "period", etc.) are reproduced in post-processing via `applyDictationCommands` since the Realtime API has no native equivalent.
+- **API key settings unified into a single `openaiApiKey`.** The separate `deepgramApiKey` and `correctionApiKey` fields have been removed. Settings are auto-migrated on first launch: existing `correctionApiKey` values move into `openaiApiKey`; a `deepgramApiKey` is dropped. Users who only had a Deepgram key configured need to add an OpenAI API key in Settings → Voice for transcription to resume.
+
 ## [0.9.1] - 2026-05-10
 
 Same-day follow-up to 0.9.0. Polish on the Daintree Assistant pip and help panel, GitHub bulk-selection cleanup, and several PTY/terminal robustness fixes.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,7 +5,7 @@
 ### Breaking Changes
 
 - **Voice transcription backend switched from Deepgram to OpenAI Realtime API.** The voice subsystem now connects to `wss://api.openai.com/v1/realtime` and uses the `input_audio_transcription` event family (`delta` / `completed`) for streaming results. Spoken dictation commands ("new paragraph", "period", etc.) are reproduced in post-processing via `applyDictationCommands` since the Realtime API has no native equivalent.
-- **API key settings unified into a single `openaiApiKey`.** The separate `deepgramApiKey` and `correctionApiKey` fields have been removed. Settings are auto-migrated on first launch: existing `correctionApiKey` values move into `openaiApiKey`; a `deepgramApiKey` is dropped. Users who only had a Deepgram key configured need to add an OpenAI API key in Settings → Voice for transcription to resume.
+- **API key settings unified into a single `openaiApiKey`.** The separate `deepgramApiKey` and `correctionApiKey` fields have been removed. Settings are auto-migrated the first time Voice settings are read after upgrade: existing `correctionApiKey` or `apiKey` values beginning with `sk-` move into `openaiApiKey`; `deepgramApiKey` is dropped. Users who only had a Deepgram key configured need to add an OpenAI API key in Settings → Voice for transcription to resume.
 
 ## [0.9.1] - 2026-05-10
 

--- a/electron/ipc/handlers/__tests__/voiceInput.paragraph.test.ts
+++ b/electron/ipc/handlers/__tests__/voiceInput.paragraph.test.ts
@@ -229,6 +229,159 @@ describe("voiceInput — IPC handler surface", () => {
   });
 });
 
+describe("voiceInput — spoken-command paragraphing", () => {
+  let win: ReturnType<typeof buildMainWindow>;
+  let cleanup: () => void;
+
+  beforeEach(async () => {
+    vi.clearAllMocks();
+    shared.transcriptionEventCallback = null;
+    shared.drainResolve = null;
+    shared.useDeferredDrain = false;
+
+    win = buildMainWindow();
+    cleanup = registerVoiceInputHandlers({
+      mainWindow: win as unknown as Electron.BrowserWindow,
+    } as Parameters<typeof registerVoiceInputHandlers>[0]);
+
+    const handleStart = getHandler("voice-input:start");
+    await (handleStart as (e: unknown) => Promise<unknown>)(fakeEvent);
+  });
+
+  afterEach(() => {
+    cleanup?.();
+  });
+
+  it("splits text containing a literal \\n\\n into separate completes with a paragraph-boundary between", () => {
+    // OpenAI may emit a `\n\n` inside a single completed item when the model
+    // detects a paragraph break. The handler is expected to split on that
+    // boundary and interleave a paragraph-boundary event.
+    emitTranscriptionEvent({
+      type: "complete",
+      text: "first sentence\n\nsecond sentence",
+    });
+
+    const splitEvents = win.__sent.filter(
+      (m) =>
+        m.channel === "voice-input:transcription-complete" ||
+        m.channel === "voice-input:paragraph-boundary"
+    );
+    expect(splitEvents).toEqual([
+      {
+        channel: "voice-input:transcription-complete",
+        payload: { text: "first sentence", willCorrect: false },
+      },
+      {
+        channel: "voice-input:paragraph-boundary",
+        payload: { rawText: null, correctionId: null },
+      },
+      {
+        channel: "voice-input:transcription-complete",
+        payload: { text: "second sentence", willCorrect: false },
+      },
+    ]);
+  });
+
+  it("strips a trailing 'new paragraph' command and emits only the prefix as one complete", () => {
+    // applyDictationCommands turns "hello new paragraph" into "hello\n\n";
+    // the handler's split + filter(Boolean) drops the trailing empty part,
+    // so a single complete fires with no paragraph-boundary.
+    emitTranscriptionEvent({ type: "complete", text: "hello new paragraph" });
+
+    const completes = win.__sent.filter((m) => m.channel === "voice-input:transcription-complete");
+    const boundaries = win.__sent.filter((m) => m.channel === "voice-input:paragraph-boundary");
+    expect(completes).toHaveLength(1);
+    expect(completes[0]?.payload).toEqual({ text: "hello", willCorrect: false });
+    expect(boundaries).toHaveLength(0);
+  });
+
+  it("emits nothing when the utterance is just a paragraph command", () => {
+    emitTranscriptionEvent({ type: "complete", text: "new paragraph" });
+
+    const completes = win.__sent.filter((m) => m.channel === "voice-input:transcription-complete");
+    const boundaries = win.__sent.filter((m) => m.channel === "voice-input:paragraph-boundary");
+    expect(completes).toHaveLength(0);
+    expect(boundaries).toHaveLength(0);
+  });
+
+  it("rewrites a trailing 'period' command into '.' on the emitted text", () => {
+    emitTranscriptionEvent({ type: "complete", text: "hello period" });
+
+    const complete = win.__sent.find((m) => m.channel === "voice-input:transcription-complete");
+    expect(complete?.payload).toEqual({ text: "hello.", willCorrect: false });
+  });
+
+  it("leaves a mid-sentence 'new paragraph' literal (applyDictationCommands is trailing-only)", () => {
+    emitTranscriptionEvent({
+      type: "complete",
+      text: "hello new paragraph world",
+    });
+
+    const completes = win.__sent.filter((m) => m.channel === "voice-input:transcription-complete");
+    const boundaries = win.__sent.filter((m) => m.channel === "voice-input:paragraph-boundary");
+    expect(completes).toHaveLength(1);
+    expect(completes[0]?.payload).toEqual({
+      text: "hello new paragraph world",
+      willCorrect: false,
+    });
+    expect(boundaries).toHaveLength(0);
+  });
+});
+
+describe("voiceInput — manual paragraphing strategy", () => {
+  let win: ReturnType<typeof buildMainWindow>;
+  let cleanup: () => void;
+
+  beforeEach(async () => {
+    vi.clearAllMocks();
+    shared.transcriptionEventCallback = null;
+    shared.drainResolve = null;
+    shared.useDeferredDrain = false;
+
+    const { store } = await import("../../../store.js");
+    vi.mocked(store.get).mockReturnValue({
+      enabled: true,
+      openaiApiKey: "sk-test",
+      correctionEnabled: true,
+      correctionModel: "gpt-5-mini",
+      customDictionary: [],
+      correctionCustomInstructions: "",
+      language: "en",
+      transcriptionModel: "gpt-realtime-whisper",
+      paragraphingStrategy: "manual",
+      resolveFileLinks: true,
+    });
+
+    win = buildMainWindow();
+    cleanup = registerVoiceInputHandlers({
+      mainWindow: win as unknown as Electron.BrowserWindow,
+    } as Parameters<typeof registerVoiceInputHandlers>[0]);
+
+    const handleStart = getHandler("voice-input:start");
+    await (handleStart as (e: unknown) => Promise<unknown>)(fakeEvent);
+  });
+
+  afterEach(() => {
+    cleanup?.();
+  });
+
+  it("leaves spoken commands literal and does not emit paragraph boundaries", () => {
+    emitTranscriptionEvent({
+      type: "complete",
+      text: "hello new paragraph world",
+    });
+
+    const completes = win.__sent.filter((m) => m.channel === "voice-input:transcription-complete");
+    const boundaries = win.__sent.filter((m) => m.channel === "voice-input:paragraph-boundary");
+    expect(completes).toHaveLength(1);
+    expect(completes[0]?.payload).toEqual({
+      text: "hello new paragraph world",
+      willCorrect: false,
+    });
+    expect(boundaries).toHaveLength(0);
+  });
+});
+
 describe("getVoiceSettings migration", () => {
   beforeEach(async () => {
     const { store } = await import("../../../store.js");

--- a/electron/services/__tests__/voiceContextKeyterms.test.ts
+++ b/electron/services/__tests__/voiceContextKeyterms.test.ts
@@ -118,10 +118,10 @@ describe("extractTerminalIdentifiers", () => {
 describe("assembleKeyterms", () => {
   it("preserves custom dictionary with highest priority", async () => {
     const result = await assembleKeyterms({
-      customDictionary: ["Daintree", "Deepgram", "xterm"],
+      customDictionary: ["Daintree", "Whisper", "xterm"],
     });
     expect(result[0]).toBe("Daintree");
-    expect(result[1]).toBe("Deepgram");
+    expect(result[1]).toBe("Whisper");
     expect(result[2]).toBe("xterm");
   });
 

--- a/electron/services/__tests__/voiceDictationCommands.test.ts
+++ b/electron/services/__tests__/voiceDictationCommands.test.ts
@@ -171,8 +171,8 @@ describe("applyDictationCommands", () => {
   describe("documented limitations", () => {
     // The trailing-anchor design is end-of-utterance only. Legitimate trailing
     // nouns that happen to be command words will convert. This is the same
-    // tradeoff Deepgram dictation mode makes — kept for parity. If a user
-    // dislikes it, the manual paragraphing strategy disables the post-processor.
+    // tradeoff the legacy Deepgram dictation mode made — kept for parity. If a
+    // user dislikes it, the manual paragraphing strategy disables the post-processor.
     it("converts a trailing noun that happens to spell a command (known tradeoff)", () => {
       expect(applyDictationCommands("I studied the Jurassic period")).toBe(
         "I studied the Jurassic."

--- a/electron/services/voiceDictationCommands.ts
+++ b/electron/services/voiceDictationCommands.ts
@@ -1,9 +1,9 @@
 /**
  * Dictation-command post-processor for the OpenAI realtime transcription path.
  *
- * Deepgram Dictation mode intercepts spoken commands ("new paragraph" → \n\n,
- * "period" → ".", etc.) at the transcription layer. OpenAI Realtime has no
- * equivalent — those phrases arrive as literal text. This module reproduces
+ * The legacy Deepgram Dictation mode intercepted spoken commands ("new paragraph"
+ * → \n\n, "period" → ".", etc.) at the transcription layer. OpenAI Realtime has
+ * no equivalent — those phrases arrive as literal text. This module reproduces
  * the behavior in post-processing so users get the same UX.
  *
  * Safety: commands only fire when they form a trailing chain at the end of the

--- a/shared/types/voice.ts
+++ b/shared/types/voice.ts
@@ -23,7 +23,7 @@ export type VoiceInputStatus = "idle" | "connecting" | "recording" | "finishing"
  *
  * - idle: No active transcription in this panel buffer.
  * - interim: A live segment is in flight; liveText is non-empty.
- * - utterance_final: OpenAI finalized the transcription item; liveText cleared.
+ * - utterance_final: A final transcript segment was accepted; liveText cleared.
  * - stable: Ready for the next utterance.
  */
 export type VoiceTranscriptPhase = "idle" | "interim" | "utterance_final" | "stable";

--- a/shared/types/voice.ts
+++ b/shared/types/voice.ts
@@ -9,9 +9,9 @@
  * The phase of the voice recording session as reported over IPC.
  *
  * - idle: No active session.
- * - connecting: WebSocket to Deepgram is being established.
+ * - connecting: WebSocket to OpenAI Realtime is being established.
  * - recording: Connected and receiving audio; live transcription in progress.
- * - finishing: Session stop requested; draining final transcription from Deepgram.
+ * - finishing: Session stop requested; draining final transcription from OpenAI.
  * - error: Session terminated due to a connection or transcription error.
  */
 export type VoiceInputStatus = "idle" | "connecting" | "recording" | "finishing" | "error";
@@ -23,7 +23,7 @@ export type VoiceInputStatus = "idle" | "connecting" | "recording" | "finishing"
  *
  * - idle: No active transcription in this panel buffer.
  * - interim: A live segment is in flight; liveText is non-empty.
- * - utterance_final: Deepgram finalized the utterance; liveText cleared.
+ * - utterance_final: OpenAI finalized the transcription item; liveText cleared.
  * - stable: Ready for the next utterance.
  */
 export type VoiceTranscriptPhase = "idle" | "interim" | "utterance_final" | "stable";


### PR DESCRIPTION
## Summary

- Updated `VoiceInputStatus` and `VoiceTranscriptPhase` JSDoc to reference OpenAI Realtime instead of Deepgram; loosened `utterance_final` wording so it doesn't overstate a 1:1 mapping to OpenAI events
- Past-tensed legacy Deepgram references in `voiceDictationCommands.ts` and its test, and swapped the `voiceContextKeyterms` fixture from Deepgram to a neutral Whisper label
- Added 5 new paragraph-handling tests covering `\n\n` splits into two completes, trailing "new paragraph" stripping, command-only utterances, "period" rewriting, and the manual strategy bypassing `applyDictationCommands`

Resolves #7836

## Changes

- `shared/types/voice.ts` — JSDoc updated for `VoiceInputStatus` and `VoiceTranscriptPhase`
- `electron/services/voiceDictationCommands.ts` — opening JSDoc and inline tradeoff comment past-tensed
- `electron/services/__tests__/voiceDictationCommands.test.ts` — matching doc and comment updates
- `electron/services/__tests__/voiceContextKeyterms.test.ts` — fixture updated from Deepgram to Whisper
- `electron/ipc/handlers/__tests__/voiceInput.paragraph.test.ts` — 5 new tests under two new describe blocks
- `CHANGELOG.md` — `[Unreleased]` section with breaking changes for the Deepgram → OpenAI Realtime switch and `openaiApiKey` unification

## Testing

All 114 voice unit tests pass. Typecheck, lint (ratcheted -1 warning), format, IPC map, and help map all pass.