### PR TITLE
refactor(workspace-host): move PR-poller wiring into PRIntegrationService

### DIFF
--- a/electron/workspace-host/PRIntegrationService.ts
+++ b/electron/workspace-host/PRIntegrationService.ts
@@ -1,10 +1,12 @@
 import type { TypedEventBus } from "../services/events.js";
 import type { GitHubPRCIStatus } from "../../shared/types/github.js";
-import type { WorktreeSnapshot } from "../../shared/types/workspace-host.js";
+import type { PRServiceStatus, WorktreeSnapshot } from "../../shared/types/workspace-host.js";
+import { GitHubAuth } from "../services/github/GitHubAuth.js";
 
 interface PullRequestServiceLike {
   initialize(rootPath: string): void;
   start(): Promise<void>;
+  stop(): void;
   reset(): void;
   refresh(): void;
   getStatus(): {
@@ -127,6 +129,46 @@ export class PRIntegrationService {
     }
 
     return this.prService.start();
+  }
+
+  getStatus(): PRServiceStatus {
+    const status = this.prService.getStatus();
+    return {
+      isRunning: status.isPolling,
+      candidateCount: status.candidateCount,
+      resolvedPRCount: status.resolvedCount,
+      lastCheckTime: undefined,
+      circuitBreakerTripped: !status.isEnabled,
+    };
+  }
+
+  resetPRState(projectRootPath: string | null): void {
+    this.prService.reset();
+    if (projectRootPath) {
+      this.prService.initialize(projectRootPath);
+      void this.prService.start();
+    }
+  }
+
+  pause(): void {
+    this.prService.stop();
+  }
+
+  resume(): void {
+    void this.prService.start();
+  }
+
+  updateToken(token: string | null, projectRootPath: string | null): void {
+    GitHubAuth.setMemoryToken(token);
+    if (token) {
+      this.prService.refresh();
+    } else {
+      this.prService.reset();
+      if (projectRootPath) {
+        this.prService.initialize(projectRootPath);
+        void this.prService.start();
+      }
+    }
   }
 
   cleanup(): void {

--- a/electron/workspace-host/PRIntegrationService.ts
+++ b/electron/workspace-host/PRIntegrationService.ts
@@ -8,7 +8,7 @@ interface PullRequestServiceLike {
   start(): Promise<void>;
   stop(): void;
   reset(): void;
-  refresh(): void;
+  refresh(): Promise<void>;
   getStatus(): {
     isPolling: boolean;
     candidateCount: number;
@@ -161,7 +161,7 @@ export class PRIntegrationService {
   updateToken(token: string | null, projectRootPath: string | null): void {
     GitHubAuth.setMemoryToken(token);
     if (token) {
-      this.prService.refresh();
+      void this.prService.refresh();
     } else {
       this.prService.reset();
       if (projectRootPath) {

--- a/electron/workspace-host/WorkspaceService.ts
+++ b/electron/workspace-host/WorkspaceService.ts
@@ -1790,6 +1790,7 @@ ${lines.map((l) => "+" + l).join("\n")}`;
   }
 
   updateGitHubToken(token: string | null): void {
+    this.prService.updateToken(token, this.projectRootPath);
     if (token) {
       // A new token may resolve previously-failing auth — drop suspensions so
       // the next scheduled fetch retries. Network/transient entries stay so we
@@ -1803,7 +1804,6 @@ ${lines.map((l) => "+" + l).join("\n")}`;
         }
       }
     }
-    this.prService.updateToken(token, this.projectRootPath);
   }
 
   private initializePRService(): Promise<void> {

--- a/electron/workspace-host/WorkspaceService.ts
+++ b/electron/workspace-host/WorkspaceService.ts
@@ -15,7 +15,6 @@ import type {
   MonitorConfig,
   CreateWorktreeOptions,
   BranchInfo,
-  PRServiceStatus,
 } from "../../shared/types/workspace-host.js";
 import { invalidateGitStatusCache } from "../utils/git.js";
 import { detectWslPath, listFirstWslDistro } from "../utils/wsl.js";
@@ -26,7 +25,6 @@ import {
   clearGitCommonDirCache,
 } from "../utils/gitUtils.js";
 import { extractIssueNumberSync, extractIssueNumber } from "../services/issueExtractor.js";
-import { GitHubAuth } from "../services/github/GitHubAuth.js";
 import { pullRequestService } from "../services/PullRequestService.js";
 import { events } from "../services/events.js";
 import { WorktreeLifecycleService, type WorkspaceHostContext } from "./WorktreeLifecycleService.js";
@@ -1762,7 +1760,7 @@ ${lines.map((l) => "+" + l).join("\n")}`;
   pause(): void {
     console.log("[WorkspaceService] Pausing (backgrounded)");
     this.setPollingEnabled(false);
-    pullRequestService.stop();
+    this.prService.pause();
     try {
       os.setPriority(process.pid, os.constants.priority.PRIORITY_LOW);
     } catch {
@@ -1778,32 +1776,20 @@ ${lines.map((l) => "+" + l).join("\n")}`;
       // Sandboxed environments may deny setpriority — non-fatal
     }
     this.setPollingEnabled(true);
-    pullRequestService.start();
+    this.prService.resume();
   }
 
   getPRStatus(requestId: string): void {
-    const status = pullRequestService.getStatus();
-    const prStatus: PRServiceStatus = {
-      isRunning: status.isPolling,
-      candidateCount: status.candidateCount,
-      resolvedPRCount: status.resolvedCount,
-      lastCheckTime: undefined,
-      circuitBreakerTripped: !status.isEnabled,
-    };
+    const prStatus = this.prService.getStatus();
     this.sendEvent({ type: "get-pr-status-result", requestId, status: prStatus });
   }
 
   resetPRState(requestId: string): void {
-    pullRequestService.reset();
-    if (this.projectRootPath) {
-      pullRequestService.initialize(this.projectRootPath);
-      pullRequestService.start();
-    }
+    this.prService.resetPRState(this.projectRootPath);
     this.sendEvent({ type: "reset-pr-state-result", requestId, success: true });
   }
 
   updateGitHubToken(token: string | null): void {
-    GitHubAuth.setMemoryToken(token);
     if (token) {
       // A new token may resolve previously-failing auth — drop suspensions so
       // the next scheduled fetch retries. Network/transient entries stay so we
@@ -1816,14 +1802,8 @@ ${lines.map((l) => "+" + l).join("\n")}`;
           void monitor.triggerFetchNow();
         }
       }
-      pullRequestService.refresh();
-    } else {
-      pullRequestService.reset();
-      if (this.projectRootPath) {
-        pullRequestService.initialize(this.projectRootPath);
-        pullRequestService.start();
-      }
     }
+    this.prService.updateToken(token, this.projectRootPath);
   }
 
   private initializePRService(): Promise<void> {

--- a/electron/workspace-host/__tests__/PRIntegrationService.test.ts
+++ b/electron/workspace-host/__tests__/PRIntegrationService.test.ts
@@ -44,7 +44,7 @@ describe("PRIntegrationService", () => {
     start(): Promise<void>;
     stop(): void;
     reset(): void;
-    refresh(): void;
+    refresh(): Promise<void>;
     getStatus(): {
       isPolling: boolean;
       candidateCount: number;
@@ -63,7 +63,7 @@ describe("PRIntegrationService", () => {
       start: vi.fn<() => Promise<void>>().mockResolvedValue(undefined),
       stop: vi.fn(),
       reset: vi.fn(),
-      refresh: vi.fn(),
+      refresh: vi.fn<() => Promise<void>>().mockResolvedValue(undefined),
       getStatus: vi.fn(() => ({
         isPolling: false,
         candidateCount: 0,

--- a/electron/workspace-host/__tests__/PRIntegrationService.test.ts
+++ b/electron/workspace-host/__tests__/PRIntegrationService.test.ts
@@ -2,6 +2,14 @@ import { describe, it, expect, vi, beforeEach } from "vitest";
 import { PRIntegrationService, type PRIntegrationCallbacks } from "../PRIntegrationService.js";
 import type { TypedEventBus } from "../../services/events.js";
 
+vi.mock("../../services/github/GitHubAuth.js", () => ({
+  GitHubAuth: {
+    setMemoryToken: vi.fn(),
+  },
+}));
+
+const { GitHubAuth } = await import("../../services/github/GitHubAuth.js");
+
 function makeEventBus(): TypedEventBus {
   type Handler = (...args: unknown[]) => void;
   const listeners = new Map<string, Set<Handler>>();
@@ -34,6 +42,7 @@ describe("PRIntegrationService", () => {
   interface PullRequestServiceLike {
     initialize(rootPath: string): void;
     start(): Promise<void>;
+    stop(): void;
     reset(): void;
     refresh(): void;
     getStatus(): {
@@ -52,6 +61,7 @@ describe("PRIntegrationService", () => {
     prServiceMock = {
       initialize: vi.fn(),
       start: vi.fn<() => Promise<void>>().mockResolvedValue(undefined),
+      stop: vi.fn(),
       reset: vi.fn(),
       refresh: vi.fn(),
       getStatus: vi.fn(() => ({
@@ -97,5 +107,128 @@ describe("PRIntegrationService", () => {
     expect(updateCalls).toHaveLength(2);
     expect(updateCalls[0][1]).toMatchObject({ worktreeId: "wt-root", isMainWorktree: true });
     expect(updateCalls[1][1]).toMatchObject({ worktreeId: "wt-linked", isMainWorktree: false });
+  });
+
+  describe("getStatus", () => {
+    it("maps PullRequestService status to PRServiceStatus shape", () => {
+      prServiceMock.getStatus = vi.fn(() => ({
+        isPolling: true,
+        candidateCount: 7,
+        resolvedCount: 3,
+        isEnabled: true,
+      }));
+      const service = new PRIntegrationService(prServiceMock, eventBus, callbacks);
+
+      const status = service.getStatus();
+
+      expect(status).toEqual({
+        isRunning: true,
+        candidateCount: 7,
+        resolvedPRCount: 3,
+        lastCheckTime: undefined,
+        circuitBreakerTripped: false,
+      });
+    });
+
+    it("reports circuitBreakerTripped when service is disabled", () => {
+      prServiceMock.getStatus = vi.fn(() => ({
+        isPolling: false,
+        candidateCount: 0,
+        resolvedCount: 0,
+        isEnabled: false,
+      }));
+      const service = new PRIntegrationService(prServiceMock, eventBus, callbacks);
+
+      const status = service.getStatus();
+
+      expect(status.circuitBreakerTripped).toBe(true);
+      expect(status.isRunning).toBe(false);
+    });
+  });
+
+  describe("resetPRState", () => {
+    it("calls reset, then initialize, then start when projectRootPath is provided", () => {
+      const callOrder: string[] = [];
+      prServiceMock.reset = vi.fn(() => callOrder.push("reset"));
+      prServiceMock.initialize = vi.fn(() => callOrder.push("initialize"));
+      prServiceMock.start = vi.fn<() => Promise<void>>().mockImplementation(async () => {
+        callOrder.push("start");
+      });
+      const service = new PRIntegrationService(prServiceMock, eventBus, callbacks);
+
+      service.resetPRState("/repo");
+
+      expect(callOrder.slice(0, 2)).toEqual(["reset", "initialize"]);
+      expect(prServiceMock.initialize).toHaveBeenCalledWith("/repo");
+      expect(prServiceMock.start).toHaveBeenCalled();
+    });
+
+    it("only calls reset when projectRootPath is null", () => {
+      const service = new PRIntegrationService(prServiceMock, eventBus, callbacks);
+
+      service.resetPRState(null);
+
+      expect(prServiceMock.reset).toHaveBeenCalled();
+      expect(prServiceMock.initialize).not.toHaveBeenCalled();
+      expect(prServiceMock.start).not.toHaveBeenCalled();
+    });
+  });
+
+  describe("pause / resume", () => {
+    it("pause() stops the underlying service", () => {
+      const service = new PRIntegrationService(prServiceMock, eventBus, callbacks);
+      service.pause();
+      expect(prServiceMock.stop).toHaveBeenCalledTimes(1);
+    });
+
+    it("resume() starts the underlying service", () => {
+      const service = new PRIntegrationService(prServiceMock, eventBus, callbacks);
+      service.resume();
+      expect(prServiceMock.start).toHaveBeenCalledTimes(1);
+    });
+  });
+
+  describe("updateToken", () => {
+    beforeEach(() => {
+      vi.mocked(GitHubAuth.setMemoryToken).mockClear();
+    });
+
+    it("sets memory token and refreshes when token is truthy", () => {
+      const service = new PRIntegrationService(prServiceMock, eventBus, callbacks);
+
+      service.updateToken("ghp_abc123", "/repo");
+
+      expect(GitHubAuth.setMemoryToken).toHaveBeenCalledWith("ghp_abc123");
+      expect(prServiceMock.refresh).toHaveBeenCalledTimes(1);
+      expect(prServiceMock.reset).not.toHaveBeenCalled();
+    });
+
+    it("resets and reinitializes when token is null and path is provided", () => {
+      const callOrder: string[] = [];
+      prServiceMock.reset = vi.fn(() => callOrder.push("reset"));
+      prServiceMock.initialize = vi.fn(() => callOrder.push("initialize"));
+      prServiceMock.start = vi.fn<() => Promise<void>>().mockImplementation(async () => {
+        callOrder.push("start");
+      });
+      const service = new PRIntegrationService(prServiceMock, eventBus, callbacks);
+
+      service.updateToken(null, "/repo");
+
+      expect(GitHubAuth.setMemoryToken).toHaveBeenCalledWith(null);
+      expect(prServiceMock.refresh).not.toHaveBeenCalled();
+      expect(callOrder.slice(0, 2)).toEqual(["reset", "initialize"]);
+      expect(prServiceMock.initialize).toHaveBeenCalledWith("/repo");
+    });
+
+    it("only clears the memory token and resets when token and path are null", () => {
+      const service = new PRIntegrationService(prServiceMock, eventBus, callbacks);
+
+      service.updateToken(null, null);
+
+      expect(GitHubAuth.setMemoryToken).toHaveBeenCalledWith(null);
+      expect(prServiceMock.reset).toHaveBeenCalledTimes(1);
+      expect(prServiceMock.initialize).not.toHaveBeenCalled();
+      expect(prServiceMock.start).not.toHaveBeenCalled();
+    });
   });
 });


### PR DESCRIPTION
## Summary

- Moves `getStatus`, `resetPRState`, `pause`, `resume`, and `updateToken` out of `WorkspaceService` and into `PRIntegrationService`, where the PR-poller lifecycle actually belongs
- `WorkspaceService` keeps thin delegating wrappers so it stays the IPC entry point — no IPC surface changes
- Drops unused `GitHubAuth` and `PRServiceStatus` imports from `WorkspaceService`

Resolves #7691

## Changes

- `PRIntegrationService` grows from ~131 lines to ~180 lines with the moved methods
- `WorkspaceService` sheds ~30 lines, leaving only delegation calls
- 9 new unit tests in `PRIntegrationService.test.ts` covering status mapping, `reset`/`init`/`start` ordering in `resetPRState`, `pause`/`resume` delegation, and `updateToken` truthy/null paths
- All existing `pauseResume` tests still green

## Testing

Typecheck, lint, format, and build all clean. Full unit test suite passes.