### PR TITLE
fix(terminal): suppress wheel→arrow translation in agent alt-screen TUIs

### DIFF
--- a/src/services/terminal/TerminalListenerInstaller.ts
+++ b/src/services/terminal/TerminalListenerInstaller.ts
@@ -98,6 +98,27 @@ export function installTerminalBoundListeners(
     deps.onBufferModeChange(id, true);
   }
 
+  // Suppress xterm's wheel→arrow-key translation for agent terminals that
+  // are in the alt-screen buffer with no mouse tracking active. Without
+  // this, scrolling in Copilot/Crush/opencode (Ink-based TUIs using
+  // CSI ?1049h) sends Up/Down arrow sequences to the agent — visibly
+  // navigating its command history instead of revealing prior output.
+  // Returning `false` skips the synthetic arrow sequences but leaves the
+  // native WheelEvent intact so xterm's viewport still scrolls. Plain
+  // shells (vim, tmux, htop) keep their default behavior because they
+  // have no `runtimeAgentId`; mouse-reporting TUIs are passed through so
+  // wheel-as-mouse-event still works.
+  terminal.attachCustomWheelEventHandler(() => {
+    if (
+      managed.runtimeAgentId &&
+      managed.isAltBuffer &&
+      terminal.modes.mouseTrackingMode === "none"
+    ) {
+      return false;
+    }
+    return true;
+  });
+
   const oscDisposable = terminal.parser.registerOscHandler(11, () => {
     if (managed.isAltBuffer) {
       for (const callback of managed.altBufferListeners) {

--- a/src/services/terminal/__tests__/TerminalHibernationManager.adversarial.test.ts
+++ b/src/services/terminal/__tests__/TerminalHibernationManager.adversarial.test.ts
@@ -27,6 +27,7 @@ vi.mock("@xterm/xterm", () => ({
     this.options = options ?? { scrollback: 5000 };
     this.rows = 24;
     this.cols = 80;
+    this.modes = { mouseTrackingMode: "none" };
     this.buffer = {
       active: { length: 0, type: "normal", baseY: 0, viewportY: 0 },
       onBufferChange: vi.fn(() => ({ dispose: vi.fn() })),
@@ -34,6 +35,7 @@ vi.mock("@xterm/xterm", () => ({
     this.parser = {
       registerOscHandler: vi.fn(() => ({ dispose: vi.fn() })),
     };
+    this.attachCustomWheelEventHandler = vi.fn();
     this.dispose = vi.fn();
     this.open = freshTerminalOpenMock;
     this.onData = vi.fn(() => ({ dispose: vi.fn() }));
@@ -97,6 +99,7 @@ function makeMockTerminal() {
     options: { scrollback: 5000 },
     rows: 24,
     cols: 80,
+    modes: { mouseTrackingMode: "none" as const },
     buffer: {
       active: { length: 100, type: "normal", baseY: 0, viewportY: 0 },
       onBufferChange: vi.fn(() => ({ dispose: vi.fn() })),
@@ -104,6 +107,7 @@ function makeMockTerminal() {
     parser: {
       registerOscHandler: vi.fn(() => ({ dispose: vi.fn() })),
     },
+    attachCustomWheelEventHandler: vi.fn(),
     dispose: vi.fn(),
     open: vi.fn(),
     onData: vi.fn(() => ({ dispose: vi.fn() })),

--- a/src/services/terminal/__tests__/TerminalHibernationManager.test.ts
+++ b/src/services/terminal/__tests__/TerminalHibernationManager.test.ts
@@ -14,6 +14,7 @@ vi.mock("@xterm/xterm", () => ({
     this.options = { scrollback: 5000 };
     this.rows = 24;
     this.cols = 80;
+    this.modes = { mouseTrackingMode: "none" };
     this.buffer = {
       active: { length: 0, type: "normal", baseY: 0, viewportY: 0 },
       onBufferChange: vi.fn(() => ({ dispose: vi.fn() })),
@@ -21,6 +22,7 @@ vi.mock("@xterm/xterm", () => ({
     this.parser = {
       registerOscHandler: vi.fn(() => ({ dispose: vi.fn() })),
     };
+    this.attachCustomWheelEventHandler = vi.fn();
     this.dispose = vi.fn();
     this.open = freshTerminalOpenMock;
     this.onData = vi.fn(() => ({ dispose: vi.fn() }));
@@ -75,6 +77,7 @@ function makeMockTerminal() {
     options: { scrollback: 5000 },
     rows: 24,
     cols: 80,
+    modes: { mouseTrackingMode: "none" as const },
     buffer: {
       active: { length: 100, type: "normal", baseY: 0, viewportY: 0 },
       onBufferChange: vi.fn(() => ({ dispose: vi.fn() })),
@@ -82,6 +85,7 @@ function makeMockTerminal() {
     parser: {
       registerOscHandler: vi.fn(() => ({ dispose: vi.fn() })),
     },
+    attachCustomWheelEventHandler: vi.fn(),
     dispose: vi.fn(),
     open: vi.fn(),
     onData: vi.fn(() => ({ dispose: vi.fn() })),

--- a/src/services/terminal/__tests__/TerminalInstanceService.hibernation.test.ts
+++ b/src/services/terminal/__tests__/TerminalInstanceService.hibernation.test.ts
@@ -88,6 +88,7 @@ function makeMockManaged(overrides: Record<string, unknown> = {}) {
     options: { scrollback: 5000 },
     rows: 24,
     cols: 80,
+    modes: { mouseTrackingMode: "none" as const },
     buffer: {
       active: { length: 100, type: "normal", baseY: 0, viewportY: 0 },
       onBufferChange: vi.fn(() => ({ dispose: vi.fn() })),
@@ -95,6 +96,7 @@ function makeMockManaged(overrides: Record<string, unknown> = {}) {
     parser: {
       registerOscHandler: vi.fn(() => ({ dispose: vi.fn() })),
     },
+    attachCustomWheelEventHandler: vi.fn(),
     refresh: vi.fn(),
     loadAddon: vi.fn(),
     registerLinkProvider: vi.fn(() => ({ dispose: vi.fn() })),

--- a/src/services/terminal/__tests__/TerminalListenerInstaller.test.ts
+++ b/src/services/terminal/__tests__/TerminalListenerInstaller.test.ts
@@ -53,6 +53,7 @@ interface CapturedCallbacks {
   onWriteParsed?: () => void;
   onSelectionChange?: () => void;
   onScroll?: () => void;
+  wheelHandler?: (event: WheelEvent) => boolean;
 }
 
 function makeMockTerminal(captured: CapturedCallbacks) {
@@ -60,7 +61,7 @@ function makeMockTerminal(captured: CapturedCallbacks) {
     options: { scrollback: 5000 },
     rows: 24,
     cols: 80,
-    modes: { bracketedPasteMode: false },
+    modes: { bracketedPasteMode: false, mouseTrackingMode: "none" as const },
     buffer: {
       active: { length: 0, type: "normal", baseY: 0, viewportY: 0 },
       onBufferChange: vi.fn(() => ({ dispose: vi.fn() })),
@@ -68,6 +69,9 @@ function makeMockTerminal(captured: CapturedCallbacks) {
     parser: {
       registerOscHandler: vi.fn(() => ({ dispose: vi.fn() })),
     },
+    attachCustomWheelEventHandler: vi.fn((handler: (event: WheelEvent) => boolean) => {
+      captured.wheelHandler = handler;
+    }),
     dispose: vi.fn(),
     onData: vi.fn((cb: (data: string) => void) => {
       captured.onData = cb;
@@ -519,6 +523,85 @@ describe("installTerminalBoundListeners", () => {
     expect(deps.notifyXtermFocused).not.toHaveBeenCalled();
 
     document.body.removeChild(managed.hostElement);
+  });
+
+  it("suppresses wheel→arrow translation when an agent terminal is in the alt-screen buffer (issue #6621)", () => {
+    const captured: CapturedCallbacks = { onTitleChangeHandlers: [] };
+    const terminal = makeMockTerminal(captured);
+    const managed = makeMockManaged({ runtimeAgentId: "copilot" });
+    const deps = makeDeps();
+
+    managed.terminal = terminal as unknown as ManagedTerminal["terminal"];
+    installTerminalBoundListeners(
+      terminal as unknown as Parameters<typeof installTerminalBoundListeners>[0],
+      managed,
+      "t1",
+      deps
+    );
+    // The handler reads `managed.isAltBuffer` live, so mutating it after
+    // install mirrors how the real `onBufferChange` listener flips it on
+    // CSI ?1049h.
+    managed.isAltBuffer = true;
+
+    expect(captured.wheelHandler).toBeDefined();
+    expect(captured.wheelHandler!({} as WheelEvent)).toBe(false);
+  });
+
+  it("passes wheel events through for plain (non-agent) terminals even when in alt-screen", () => {
+    const captured: CapturedCallbacks = { onTitleChangeHandlers: [] };
+    const terminal = makeMockTerminal(captured);
+    const managed = makeMockManaged();
+    const deps = makeDeps();
+
+    managed.terminal = terminal as unknown as ManagedTerminal["terminal"];
+    installTerminalBoundListeners(
+      terminal as unknown as Parameters<typeof installTerminalBoundListeners>[0],
+      managed,
+      "t1",
+      deps
+    );
+    managed.isAltBuffer = true;
+
+    expect(captured.wheelHandler!({} as WheelEvent)).toBe(true);
+  });
+
+  it("passes wheel events through for agent terminals in the normal buffer", () => {
+    const captured: CapturedCallbacks = { onTitleChangeHandlers: [] };
+    const terminal = makeMockTerminal(captured);
+    const managed = makeMockManaged({ runtimeAgentId: "copilot" });
+    const deps = makeDeps();
+
+    managed.terminal = terminal as unknown as ManagedTerminal["terminal"];
+    installTerminalBoundListeners(
+      terminal as unknown as Parameters<typeof installTerminalBoundListeners>[0],
+      managed,
+      "t1",
+      deps
+    );
+    // isAltBuffer defaults to false from terminal.buffer.active.type === "normal"
+
+    expect(captured.wheelHandler!({} as WheelEvent)).toBe(true);
+  });
+
+  it("passes wheel events through when the TUI has mouse tracking enabled", () => {
+    const captured: CapturedCallbacks = { onTitleChangeHandlers: [] };
+    const terminal = makeMockTerminal(captured);
+    const managed = makeMockManaged({ runtimeAgentId: "crush" });
+    const deps = makeDeps();
+
+    managed.terminal = terminal as unknown as ManagedTerminal["terminal"];
+    installTerminalBoundListeners(
+      terminal as unknown as Parameters<typeof installTerminalBoundListeners>[0],
+      managed,
+      "t1",
+      deps
+    );
+    managed.isAltBuffer = true;
+    // Mutate the captured mode so the live read inside the handler reflects
+    // mouse-reporting TUIs that toggle this on after install.
+    (terminal.modes as { mouseTrackingMode: string }).mouseTrackingMode = "any";
+
+    expect(captured.wheelHandler!({} as WheelEvent)).toBe(true);
   });
 
   it("registers the same listener count on every call (idempotent shape)", () => {


### PR DESCRIPTION
## Summary

When running TUI applications inside an agent terminal (GitHub Copilot, Crush, opencode, etc.), mouse wheel scrolling was being translated into arrow key presses instead of scrolling the terminal scrollback. The scroll position would jump rather than scroll, making these tools awkward to use.

Resolves #6621

## Changes

- Adds a custom wheel event handler in `installTerminalBoundListeners` via `attachCustomWheelEventHandler` that suppresses xterm's default wheel-to-arrow translation
- The guard fires only when all three conditions hold: `runtimeAgentId` is set, `isAltBuffer` is true, and `mouseTrackingMode === 'none'` — so normal TUI mouse tracking and non-agent terminals are unaffected
- 4 new unit tests added; 19 passing total

## Testing

All existing terminal listener tests pass. New tests cover the three-way guard: agent + alt-screen + no mouse tracking suppresses wheel events; any condition missing leaves the default behavior intact.