### PR TITLE
feat(help): wire Gemini CLI and GitHub Copilot CLI into Daintree Assistant

### DIFF
--- a/electron/ipc/handlers/terminal/__tests__/lifecycle.spawn.test.ts
+++ b/electron/ipc/handlers/terminal/__tests__/lifecycle.spawn.test.ts
@@ -75,7 +75,7 @@ vi.mock("../../../utils.js", () => ({
 
 vi.mock("../../../../shared/config/agentRegistry.js", () => ({
   isRegisteredAgent: vi.fn(() => false),
-  getAssistantWiredAgentIds: vi.fn(() => ["claude", "codex", "gemini"]),
+  getAssistantWiredAgentIds: vi.fn(() => ["claude", "codex", "gemini", "copilot"]),
   getEffectiveAgentConfig: vi.fn((id: string) => {
     if (id === "claude") {
       return {
@@ -102,6 +102,18 @@ vi.mock("../../../../shared/config/agentRegistry.js", () => ({
       };
     }
     if (id === "gemini") {
+      return {
+        supports: {
+          mcpInjection: "project-config",
+          settingsOverlay: true,
+          permissionBypass: false,
+          trustDialog: true,
+          versionProbe: true,
+          tier: "experimental",
+        },
+      };
+    }
+    if (id === "copilot") {
       return {
         supports: {
           mcpInjection: "project-config",
@@ -139,6 +151,14 @@ const mockGetGeminiLaunchArgs = vi.hoisted(() =>
   vi.fn<(token: string) => string[] | null>(() => null)
 );
 
+const mockGetCopilotLaunchArgs = vi.hoisted(() =>
+  vi.fn<(token: string) => string[] | null>(() => null)
+);
+
+const mockGetGeminiSpawnEnv = vi.hoisted(() =>
+  vi.fn<(token: string) => Record<string, string> | null>(() => null)
+);
+
 const mockMarkTerminalForToken = vi.hoisted(() =>
   vi.fn<(token: string, terminalId: string) => boolean>(() => true)
 );
@@ -152,6 +172,8 @@ vi.mock("../../../../services/HelpSessionService.js", () => ({
     validateToken: (token: string) => mockValidateToken(token),
     getCodexLaunchArgs: (token: string) => mockGetCodexLaunchArgs(token),
     getGeminiLaunchArgs: (token: string) => mockGetGeminiLaunchArgs(token),
+    getCopilotLaunchArgs: (token: string) => mockGetCopilotLaunchArgs(token),
+    getGeminiSpawnEnv: (token: string) => mockGetGeminiSpawnEnv(token),
     getBypassPermissions: (token: string) => mockGetBypassPermissions(token),
     markTerminalForToken: (token: string, terminalId: string) =>
       mockMarkTerminalForToken(token, terminalId),
@@ -1261,6 +1283,169 @@ describe("terminal spawn handler - help session detection (#6524)", () => {
     );
 
     expect(mockGetGeminiLaunchArgs).not.toHaveBeenCalled();
+  });
+
+  it("merges per-agent env from getGeminiSpawnEnv into the PTY env when non-empty (#7542)", async () => {
+    // Today `getGeminiSpawnEnv` returns `{}` for Gemini sessions — we don't
+    // redirect `GEMINI_CLI_HOME` because it would break OAuth credential
+    // lookup. This test guards the merge plumbing so future per-agent env
+    // additions land in the PTY env without regression. Uses a sentinel
+    // key that isn't actually injected today.
+    mockValidateToken.mockImplementation((token) => (token === "help-token" ? "action" : false));
+    mockGetGeminiLaunchArgs.mockReturnValue(["--approval-mode=plan"]);
+    mockGetGeminiSpawnEnv.mockImplementation((token) =>
+      token === "help-token" ? { GEMINI_TEST_SENTINEL: "1" } : null
+    );
+
+    const deps = { ptyClient } as unknown as HandlerDependencies;
+    registerTerminalLifecycleHandlers(deps);
+
+    const handler = getSpawnHandler();
+    await handler(
+      {} as Electron.IpcMainInvokeEvent,
+      {
+        cols: 80,
+        rows: 24,
+        cwd: tmpDir,
+        command: "gemini",
+        launchAgentId: "gemini",
+        env: { DAINTREE_MCP_TOKEN: "help-token" },
+      } as unknown as Parameters<typeof handler>[1]
+    );
+
+    const spawnArgs = ptyClient.spawn.mock.calls[0][1];
+    expect(spawnArgs.env).toMatchObject({
+      DAINTREE_MCP_TOKEN: "help-token",
+      GEMINI_TEST_SENTINEL: "1",
+    });
+  });
+
+  it("does not inject GEMINI_CLI_HOME when getGeminiSpawnEnv returns {} (#7542)", async () => {
+    // OAuth-only Gemini users would lose auth if we redirected `os.homedir()`
+    // via `GEMINI_CLI_HOME`. Guard that the renderer + main both honor the
+    // empty-env return value.
+    mockValidateToken.mockImplementation((token) => (token === "help-token" ? "action" : false));
+    mockGetGeminiLaunchArgs.mockReturnValue(["--approval-mode=plan"]);
+    mockGetGeminiSpawnEnv.mockReturnValue({});
+
+    const deps = { ptyClient } as unknown as HandlerDependencies;
+    registerTerminalLifecycleHandlers(deps);
+
+    const handler = getSpawnHandler();
+    await handler(
+      {} as Electron.IpcMainInvokeEvent,
+      {
+        cols: 80,
+        rows: 24,
+        cwd: tmpDir,
+        command: "gemini",
+        launchAgentId: "gemini",
+        env: { DAINTREE_MCP_TOKEN: "help-token" },
+      } as unknown as Parameters<typeof handler>[1]
+    );
+
+    const spawnArgs = ptyClient.spawn.mock.calls[0][1];
+    expect(spawnArgs.env.GEMINI_CLI_HOME).toBeUndefined();
+    expect(spawnArgs.env.DAINTREE_MCP_TOKEN).toBe("help-token");
+  });
+
+  it("appends --plan to a Copilot help-session spawn (#7542)", async () => {
+    mockValidateToken.mockImplementation((token) => (token === "help-token" ? "action" : false));
+    mockGetCopilotLaunchArgs.mockImplementation((token) =>
+      token === "help-token" ? ["--plan"] : null
+    );
+
+    const deps = { ptyClient } as unknown as HandlerDependencies;
+    registerTerminalLifecycleHandlers(deps);
+
+    const handler = getSpawnHandler();
+    await handler(
+      {} as Electron.IpcMainInvokeEvent,
+      {
+        cols: 80,
+        rows: 24,
+        cwd: tmpDir,
+        command: "copilot",
+        launchAgentId: "copilot",
+        env: { DAINTREE_MCP_TOKEN: "help-token" },
+      } as unknown as Parameters<typeof handler>[1]
+    );
+
+    const spawnArgs = ptyClient.spawn.mock.calls[0][1];
+    expect(spawnArgs.command).toContain("'--plan'");
+    // Copilot help launches don't flow through the Claude per-pane MCP path.
+    expect(mockPreparePaneConfig).not.toHaveBeenCalled();
+  });
+
+  it("refuses to spawn a Copilot help session when getCopilotLaunchArgs returns null — cross-agent token reuse signal (#7542)", async () => {
+    mockValidateToken.mockImplementation((token) => (token === "help-token" ? "action" : false));
+    mockGetCopilotLaunchArgs.mockReturnValue(null);
+
+    const deps = { ptyClient } as unknown as HandlerDependencies;
+    registerTerminalLifecycleHandlers(deps);
+
+    const handler = getSpawnHandler();
+    await expect(
+      handler(
+        {} as Electron.IpcMainInvokeEvent,
+        {
+          cols: 80,
+          rows: 24,
+          cwd: tmpDir,
+          command: "copilot",
+          launchAgentId: "copilot",
+          env: { DAINTREE_MCP_TOKEN: "help-token" },
+        } as unknown as Parameters<typeof handler>[1]
+      )
+    ).rejects.toThrow(/does not belong to a Copilot session/);
+    expect(ptyClient.spawn).not.toHaveBeenCalled();
+  });
+
+  it("strips a smuggled --plan from a Copilot command so the appended flag is unambiguously authoritative (#7542)", async () => {
+    mockValidateToken.mockImplementation((token) => (token === "help-token" ? "action" : false));
+    mockGetCopilotLaunchArgs.mockReturnValue(["--plan"]);
+
+    const deps = { ptyClient } as unknown as HandlerDependencies;
+    registerTerminalLifecycleHandlers(deps);
+
+    const handler = getSpawnHandler();
+    await handler(
+      {} as Electron.IpcMainInvokeEvent,
+      {
+        cols: 80,
+        rows: 24,
+        cwd: tmpDir,
+        command: "copilot --plan",
+        launchAgentId: "copilot",
+        env: { DAINTREE_MCP_TOKEN: "help-token" },
+      } as unknown as Parameters<typeof handler>[1]
+    );
+
+    const spawnArgs = ptyClient.spawn.mock.calls[0][1];
+    const matches = spawnArgs.command.match(/--plan/g) ?? [];
+    expect(matches).toHaveLength(1);
+    expect(spawnArgs.command).toContain("'--plan'");
+  });
+
+  it("does not query Copilot launch args for a non-help Copilot launch (#7542)", async () => {
+    mockValidateToken.mockReturnValue(false);
+
+    const deps = { ptyClient } as unknown as HandlerDependencies;
+    registerTerminalLifecycleHandlers(deps);
+
+    const handler = getSpawnHandler();
+    await handler(
+      {} as Electron.IpcMainInvokeEvent,
+      {
+        cols: 80,
+        rows: 24,
+        cwd: tmpDir,
+        command: "copilot",
+        launchAgentId: "copilot",
+      } as unknown as Parameters<typeof handler>[1]
+    );
+
+    expect(mockGetCopilotLaunchArgs).not.toHaveBeenCalled();
   });
 
   it("binds terminalId to the help session before spawn so HelpSessionService can kill it on displacement (#7509)", async () => {

--- a/electron/ipc/handlers/terminal/lifecycle.ts
+++ b/electron/ipc/handlers/terminal/lifecycle.ts
@@ -342,6 +342,41 @@ export function registerTerminalLifecycleHandlers(deps: HandlerDependencies): ()
         if (geminiArgs.length > 0) {
           safeCommand = `${safeCommand} ${geminiArgs.map(shellQuote).join(" ")}`.trim();
         }
+        // Merge any per-agent env returned by `getGeminiSpawnEnv` into the
+        // PTY spawn env. Today this is a no-op (Gemini's MCP isolation is
+        // achieved via workspace-level `.gemini/settings.json` precedence
+        // rather than `GEMINI_CLI_HOME` redirection — see
+        // `getGeminiSpawnEnv` in HelpSessionService for the rationale).
+        // The merge stays so future per-agent env additions land here
+        // consistently with the existing pattern.
+        const geminiEnv = helpSessionService.getGeminiSpawnEnv(helpToken);
+        if (geminiEnv && Object.keys(geminiEnv).length > 0) {
+          spawnEnv = { ...(spawnEnv ?? {}), ...geminiEnv };
+        }
+      }
+      // Copilot help sessions get the `--plan` read-only flag appended at
+      // spawn time (same pattern as `--approval-mode=plan` for Gemini). MCP
+      // wiring lives in `<sessionPath>/.mcp.json` via `writeCopilotMcpConfig`
+      // and is auto-discovered from cwd — no flag injection needed for that.
+      //
+      // A `null` return is the agent-mismatch signal (e.g. a Claude help
+      // token reused with `launchAgentId: "copilot"`) — refuse to spawn.
+      // Strip any user-supplied `--plan` first so the appended flag is
+      // unambiguously authoritative.
+      if (launchAgentId === "copilot") {
+        const copilotArgs = helpSessionService.getCopilotLaunchArgs(helpToken);
+        if (copilotArgs === null) {
+          throw new Error(
+            "Daintree Assistant help token does not belong to a Copilot session; refusing to spawn"
+          );
+        }
+        safeCommand = safeCommand
+          .replace(/(^|\s)--plan(?:=\S*)?(?=\s|$)/g, "$1")
+          .replace(/\s{2,}/g, " ")
+          .trim();
+        if (copilotArgs.length > 0) {
+          safeCommand = `${safeCommand} ${copilotArgs.map(shellQuote).join(" ")}`.trim();
+        }
       }
 
       // Bind this terminalId to the help session so HelpSessionService can

--- a/electron/services/HelpSessionService.ts
+++ b/electron/services/HelpSessionService.ts
@@ -81,6 +81,8 @@ interface HelpSessionRecord {
   codexLaunchArgs?: string[];
   /** Computed at provision for gemini sessions; consumed by lifecycle.ts. */
   geminiLaunchArgs?: string[];
+  /** Computed at provision for copilot sessions; consumed by lifecycle.ts. */
+  copilotLaunchArgs?: string[];
 }
 
 interface SessionMeta {
@@ -96,6 +98,12 @@ interface BundledClaudeSettings {
   };
   defaultMode?: string;
   enableAllProjectMcpServers?: boolean;
+  [key: string]: unknown;
+}
+
+interface BundledGeminiSettings {
+  toolsAllowlist?: string[];
+  mcpServers?: Record<string, unknown>;
   [key: string]: unknown;
 }
 
@@ -426,15 +434,24 @@ export class HelpSessionService {
     if (input.agentId === "claude") {
       await this.writeMcpConfig(sessionPath, settings, port, token);
       await this.writeClaudeSettings(sessionPath, helpFolder, settings);
+    } else if (input.agentId === "copilot") {
+      await this.writeCopilotMcpConfig(sessionPath, settings, port);
+    } else if (input.agentId === "gemini") {
+      await this.writeGeminiSettings(sessionPath, helpFolder, settings, port);
+      // The bundled `.mcp.json` still gets copied into the session via
+      // `fs.cp`; ensure no Claude-shaped daintree entry (with a literal
+      // dead bearer) survives from a prior provision under this same
+      // sessionPath.
+      await this.stripStaleDaintreeMcpEntry(sessionPath);
     } else {
-      // Codex and Gemini both skip `writeMcpConfig`, so when the template
-      // hash gate (#7525) also skips `fs.cp`, a `.mcp.json` from a prior
-      // Claude provision for this same project keeps its stale `daintree`
-      // Bearer in cwd. The bearer is already revoked in-memory (single-
-      // backend invariant), but before the gate, `fs.cp` would have
-      // restored the bundled `.mcp.json` and wiped the entry. Strip it now
-      // to preserve that hygiene — no-op when the entry is absent or its
-      // bearer is still live.
+      // Codex and any other agent skip `writeMcpConfig`, so when the
+      // template hash gate (#7525) also skips `fs.cp`, a `.mcp.json` from a
+      // prior Claude provision for this same project keeps its stale
+      // `daintree` Bearer in cwd. The bearer is already revoked in-memory
+      // (single-backend invariant), but before the gate, `fs.cp` would
+      // have restored the bundled `.mcp.json` and wiped the entry. Strip
+      // it now to preserve that hygiene — no-op when the entry is absent
+      // or its bearer is still live.
       await this.stripStaleDaintreeMcpEntry(sessionPath);
     }
     // Codex doesn't read project-scoped `.codex/config.toml` from cwd —
@@ -443,18 +460,27 @@ export class HelpSessionService {
     // to the spawn command in `lifecycle.ts` via the `getCodexLaunchArgs`
     // accessor below; nothing is written to disk for Codex.
     //
-    // Gemini reads its workspace-level `.gemini/settings.json` from cwd
-    // (already copied via `fs.cp`), which carries the docs MCP entry and
-    // the tool allowlist. The `--approval-mode=plan` flag is appended at
-    // spawn time via `getGeminiLaunchArgs` because it is a CLI flag, not a
-    // settings key — Gemini Phase 1 also skips the local Daintree MCP, so
-    // there is no per-session bearer to mint.
+    // Gemini reads `<sessionPath>/.gemini/settings.json` (written above by
+    // `writeGeminiSettings`). The workspace-level settings file takes
+    // precedence over `~/.gemini/settings.json` for same-name MCP entries
+    // (Gemini's merge order: workspace > user), which gives us the
+    // isolation we need without redirecting `os.homedir()` — see
+    // `getGeminiSpawnEnv` for why `GEMINI_CLI_HOME` is intentionally not
+    // injected. The `--approval-mode=plan` flag is appended at spawn time
+    // via `getGeminiLaunchArgs` because it is a CLI flag, not a settings
+    // key.
+    //
+    // Copilot reads `<sessionPath>/.mcp.json` (written above by
+    // `writeCopilotMcpConfig`). The `--plan` read-only flag is appended at
+    // spawn time via `getCopilotLaunchArgs`.
 
     const codexLaunchArgs =
       input.agentId === "codex"
         ? this.buildCodexLaunchArgs(settings.daintreeControl, settings.docSearch, port)
         : undefined;
     const geminiLaunchArgs = input.agentId === "gemini" ? this.buildGeminiLaunchArgs() : undefined;
+    const copilotLaunchArgs =
+      input.agentId === "copilot" ? this.buildCopilotLaunchArgs() : undefined;
 
     const now = Date.now();
     const record: HelpSessionRecord = {
@@ -472,6 +498,7 @@ export class HelpSessionService {
       revoked: false,
       codexLaunchArgs,
       geminiLaunchArgs,
+      copilotLaunchArgs,
     };
 
     await this.writeSessionMeta(sessionPath, {
@@ -483,23 +510,30 @@ export class HelpSessionService {
     this.sessionsByToken.set(token, record);
     this.sessionsById.set(sessionId, record);
 
-    if (settings.daintreeControl && port && input.agentId !== "gemini") {
+    if (settings.daintreeControl && port) {
       try {
-        if (input.agentId === "codex") {
-          // Codex's MCP transport is Streamable HTTP at /mcp; Claude Code
-          // reads SSE at /sse. Both probes warm the same in-memory MCP token
-          // map, so neither leaks across agents. Gemini Phase 1 doesn't
-          // connect to the Daintree MCP server, so neither probe runs.
-          await probeMcpServer(port, token);
-        } else {
+        if (input.agentId === "claude") {
+          // Claude Code reads SSE at /sse with a literal bearer baked into
+          // `.mcp.json`. Both probes warm the same in-memory MCP token
+          // map, so neither leaks across agents.
           await probeMcpSseServer(port, token);
+        } else {
+          // Codex, Gemini, and Copilot all speak Streamable HTTP at /mcp.
+          // Codex reads the bearer from `DAINTREE_MCP_TOKEN` PTY env via
+          // `bearer_token_env_var`. Gemini and Copilot read the bearer
+          // from PTY env via `${DAINTREE_MCP_TOKEN}` / `$DAINTREE_MCP_TOKEN`
+          // substitution in their respective settings files.
+          await probeMcpServer(port, token);
         }
       } catch (err) {
         record.revoked = true;
         this.sessionsByToken.delete(token);
         this.sessionsById.delete(sessionId);
-        if (input.agentId === "claude") {
+        if (input.agentId === "claude" || input.agentId === "copilot") {
           await this.stripStaleDaintreeMcpEntry(sessionPath);
+        }
+        if (input.agentId === "gemini") {
+          await this.stripStaleGeminiDaintreeEntry(sessionPath);
         }
         const reason = formatErrorMessage(err, "assistant MCP session isn't ready");
         await this.recordMcpNotReady(sessionId, reason);
@@ -520,12 +554,10 @@ export class HelpSessionService {
     port: number | null
   ): string | null {
     if (!daintreeControl || !port) return null;
-    // Gemini Phase 1 does not connect to the local Daintree MCP server;
-    // returning null keeps the renderer from advertising an SSE URL the
-    // agent will never call.
-    if (agentId === "gemini") return null;
-    if (agentId === "codex") return `http://127.0.0.1:${port}/mcp`;
-    return `http://127.0.0.1:${port}/sse`;
+    // Claude reads SSE at /sse with a literal bearer; everyone else speaks
+    // Streamable HTTP at /mcp with env-var substitution.
+    if (agentId === "claude") return `http://127.0.0.1:${port}/sse`;
+    return `http://127.0.0.1:${port}/mcp`;
   }
 
   /**
@@ -609,6 +641,53 @@ export class HelpSessionService {
   }
 
   /**
+   * Returns the per-session env vars that must be injected into the PTY
+   * spawn for a Gemini help session. Today this is just a placeholder for
+   * the per-session env contract; the daintree MCP entry travels with the
+   * workspace-level `<sessionPath>/.gemini/settings.json` written at
+   * provision time, which Gemini's merge precedence (workspace > user)
+   * lets shadow same-name user-level entries without redirecting
+   * `os.homedir()`. We intentionally do NOT set `GEMINI_CLI_HOME` here —
+   * the CLI uses `os.homedir()` for OAuth credential lookup at
+   * `~/.gemini/oauth_creds.json`, and redirecting it would break auth for
+   * any user who hasn't set `GEMINI_API_KEY`. Returns null for unknown /
+   * revoked tokens or non-Gemini sessions.
+   */
+  getGeminiSpawnEnv(token: string): Record<string, string> | null {
+    if (!token) return null;
+    const record = this.sessionsByToken.get(token);
+    if (!record || record.revoked) return null;
+    if (record.agentId !== "gemini") return null;
+    return {};
+  }
+
+  /**
+   * Builds the CLI flags that constrain a Copilot help-session spawn to
+   * read-only behaviour. Pins `--plan` (read-only mode, available since
+   * Copilot CLI v1.0.40 — gated by `assistantMinVersion` in
+   * `copilot.ts`). MCP servers are written into `<sessionPath>/.mcp.json`
+   * via `writeCopilotMcpConfig` and read from cwd at launch — no flag
+   * injection needed for MCP discovery.
+   */
+  private buildCopilotLaunchArgs(): string[] {
+    return ["--plan"];
+  }
+
+  /**
+   * Returns the cached CLI flags for a Copilot help session. lifecycle.ts
+   * appends them to the spawn command after the help token validates.
+   * Returns null for unknown / revoked tokens or non-Copilot sessions, so
+   * the spawn handler never injects flags for the wrong agent.
+   */
+  getCopilotLaunchArgs(token: string): string[] | null {
+    if (!token) return null;
+    const record = this.sessionsByToken.get(token);
+    if (!record || record.revoked) return null;
+    if (record.agentId !== "copilot") return null;
+    return record.copilotLaunchArgs ?? [];
+  }
+
+  /**
    * Invalidates the in-memory bearer for this session. The on-disk dir is
    * intentionally preserved across launches so the user's one-time Claude
    * Code workspace-trust acceptance for this project carries over to the
@@ -638,12 +717,17 @@ export class HelpSessionService {
       this.killTerminal(terminalId, "help-session-revoked");
     }
 
-    // Only Claude writes a managed `.mcp.json` carrying a literal session
-    // bearer (Codex uses `-c` flags; Gemini reads its settings.json from
-    // cwd and skips the local MCP in Phase 1), so the file-strip dance is
-    // Claude-only.
-    if (record.agentId === "claude") {
+    // Claude bakes a literal session bearer into `.mcp.json`; Copilot
+    // references the same file with `$DAINTREE_MCP_TOKEN` substitution.
+    // Both need the daintree entry stripped on revoke so a stray agent
+    // started outside the help-panel flow in that cwd can't keep talking
+    // to the now-revoked MCP route. Gemini writes its entry into
+    // `.gemini/settings.json` instead — strip that. Codex stores nothing
+    // on disk (uses `-c` flags), so no file-strip is needed.
+    if (record.agentId === "claude" || record.agentId === "copilot") {
       await this.stripStaleDaintreeMcpEntry(record.sessionPath);
+    } else if (record.agentId === "gemini") {
+      await this.stripStaleGeminiDaintreeEntry(record.sessionPath);
     }
   }
 
@@ -739,6 +823,7 @@ export class HelpSessionService {
         const entryPath = path.join(sessionsRoot, entry);
         if (this.isProjectHashDirName(entry)) {
           await this.stripStaleDaintreeMcpEntry(entryPath);
+          await this.stripStaleGeminiDaintreeEntry(entryPath);
           return;
         }
         await this.removeSessionDir(entryPath);
@@ -968,6 +1053,109 @@ export class HelpSessionService {
     );
   }
 
+  /**
+   * Writes `<sessionPath>/.mcp.json` for a Copilot help session. Copilot's
+   * MCP discovery is CWD-only and the file shape is `{ mcpServers: { name: {
+   * type: "http", url, headers } } }`. Auth uses Copilot's native env-var
+   * substitution (`$VAR`, single-dollar form) so the literal session token
+   * never lands on disk — the bearer is delivered through
+   * `DAINTREE_MCP_TOKEN` in PTY spawn env.
+   */
+  private async writeCopilotMcpConfig(
+    sessionPath: string,
+    settings: { daintreeControl: boolean; docSearch: boolean },
+    port: number | null
+  ): Promise<void> {
+    const mcpServers: Record<string, unknown> = {};
+    if (settings.docSearch) {
+      mcpServers["daintree-docs"] = {
+        type: "http",
+        url: "https://daintree.org/api/mcp",
+      };
+    }
+    if (settings.daintreeControl && port) {
+      mcpServers["daintree"] = {
+        type: "http",
+        url: `http://127.0.0.1:${port}/mcp`,
+        headers: { Authorization: "Bearer $DAINTREE_MCP_TOKEN" },
+      };
+    }
+    const target = path.join(sessionPath, ".mcp.json");
+    await resilientAtomicWriteFile(
+      target,
+      JSON.stringify({ mcpServers }, null, 2) + "\n",
+      "utf-8",
+      { mode: 0o600 }
+    );
+  }
+
+  /**
+   * Writes `<sessionPath>/.gemini/settings.json` for a Gemini help session.
+   * Reads the bundled settings as a baseline (tool allowlist + the
+   * `daintree-docs` MCP entry) and overlays the local `daintree` MCP entry
+   * when daintreeControl is on. Uses `httpUrl` to select Streamable HTTP
+   * transport (Gemini's `url` key is reserved for SSE) and Gemini's native
+   * `${VAR}` env-var substitution for the bearer so no literal token lands
+   * on disk.
+   *
+   * The session-dir settings file is workspace-scoped (Gemini reads it
+   * because `cwd === sessionPath`). Workspace settings take precedence over
+   * `~/.gemini/settings.json` for same-name MCP entries, so our daintree
+   * entry shadows any user-level `daintree` server. We do NOT redirect
+   * `os.homedir()` — see `getGeminiSpawnEnv` for the rationale.
+   */
+  private async writeGeminiSettings(
+    sessionPath: string,
+    bundledHelpFolder: string,
+    settings: { daintreeControl: boolean; docSearch: boolean },
+    port: number | null
+  ): Promise<void> {
+    const bundledSettingsPath = path.join(bundledHelpFolder, ".gemini", "settings.json");
+    const baseline = await this.readBundledGeminiSettings(bundledSettingsPath);
+
+    const merged = deepClonePlainJson(baseline);
+    if (!merged.mcpServers || typeof merged.mcpServers !== "object") {
+      merged.mcpServers = {};
+    }
+    const mcpServers = merged.mcpServers as Record<string, unknown>;
+
+    if (!settings.docSearch) {
+      delete mcpServers["daintree-docs"];
+    }
+
+    if (settings.daintreeControl && port) {
+      mcpServers["daintree"] = {
+        httpUrl: `http://127.0.0.1:${port}/mcp`,
+        headers: { Authorization: "Bearer ${DAINTREE_MCP_TOKEN}" },
+        trust: true,
+      };
+    } else {
+      delete mcpServers["daintree"];
+    }
+
+    const target = path.join(sessionPath, ".gemini", "settings.json");
+    await fs.mkdir(path.dirname(target), { recursive: true });
+    await resilientAtomicWriteFile(target, JSON.stringify(merged, null, 2) + "\n", "utf-8", {
+      mode: 0o600,
+    });
+  }
+
+  private async readBundledGeminiSettings(settingsPath: string): Promise<BundledGeminiSettings> {
+    try {
+      const raw = await fs.readFile(settingsPath, "utf-8");
+      const parsed = JSON.parse(raw) as BundledGeminiSettings;
+      if (parsed && typeof parsed === "object") return parsed;
+    } catch {
+      // fall through to baseline
+    }
+    return {
+      toolsAllowlist: ["read_file", "list_directory", "search_files", "web_search", "shell"],
+      mcpServers: {
+        "daintree-docs": { httpUrl: "https://daintree.org/api/mcp", trust: true },
+      },
+    };
+  }
+
   private async writeClaudeSettings(
     sessionPath: string,
     bundledHelpFolder: string,
@@ -1079,6 +1267,52 @@ export class HelpSessionService {
     } catch (err) {
       console.warn(
         "[HelpSessionService] Failed to strip stale daintree entry from .mcp.json:",
+        target,
+        err
+      );
+    }
+  }
+
+  /**
+   * Removes the `daintree` MCP entry from `<sessionPath>/.gemini/settings.json`.
+   * Gemini's bearer is delivered via `${DAINTREE_MCP_TOKEN}` substitution
+   * (not a literal in the file), so a stray `gemini` in this cwd would fail
+   * authentication anyway — but stripping the entry is hygiene so the CLI
+   * doesn't surface a configured-but-broken server. The `daintree-docs`
+   * entry is preserved (session-independent). No-op on ENOENT.
+   */
+  private async stripStaleGeminiDaintreeEntry(sessionPath: string): Promise<void> {
+    const target = path.join(sessionPath, ".gemini", "settings.json");
+    let raw: string;
+    try {
+      raw = await fs.readFile(target, "utf-8");
+    } catch (err) {
+      if ((err as NodeJS.ErrnoException).code === "ENOENT") return;
+      console.warn(
+        "[HelpSessionService] Failed to read .gemini/settings.json for stale-entry strip:",
+        target,
+        err
+      );
+      return;
+    }
+    let parsed: { mcpServers?: Record<string, unknown> };
+    try {
+      parsed = JSON.parse(raw) as { mcpServers?: Record<string, unknown> };
+    } catch {
+      return;
+    }
+    const servers = parsed.mcpServers;
+    if (!servers || typeof servers !== "object") return;
+    if (!("daintree" in servers)) return;
+
+    delete servers["daintree"];
+    try {
+      await resilientAtomicWriteFile(target, JSON.stringify(parsed, null, 2) + "\n", "utf-8", {
+        mode: 0o600,
+      });
+    } catch (err) {
+      console.warn(
+        "[HelpSessionService] Failed to strip stale daintree entry from .gemini/settings.json:",
         target,
         err
       );

--- a/electron/services/__tests__/HelpSessionService.test.ts
+++ b/electron/services/__tests__/HelpSessionService.test.ts
@@ -975,7 +975,7 @@ describe("HelpSessionService", () => {
     });
   });
 
-  describe("Gemini (#7533)", () => {
+  describe("Gemini (#7542)", () => {
     function geminiInput() {
       return { ...provisionInput(), agentId: "gemini" };
     }
@@ -985,25 +985,73 @@ describe("HelpSessionService", () => {
       expect(result).not.toBeNull();
     });
 
-    it("returns mcpUrl=null for Gemini even when daintreeControl is enabled", async () => {
-      // Phase 1: Gemini does not connect to the local Daintree MCP server.
-      // The renderer must not advertise an SSE URL the agent never calls.
+    it("returns the /mcp Streamable HTTP URL for Gemini when daintreeControl is on", async () => {
       const result = await service.provisionSession(geminiInput());
       if (!result) throw new Error("expected result");
-      expect(result.mcpUrl).toBeNull();
+      expect(result.mcpUrl).toBe("http://127.0.0.1:45454/mcp");
     });
 
     it("does NOT rewrite .mcp.json with a Claude-shaped daintree entry", async () => {
       const result = await service.provisionSession(geminiInput());
       if (!result) throw new Error("expected result");
 
-      // The bundled help template carries a `.mcp.json` (copied via fs.cp),
-      // so the file exists on disk — but the Gemini branch must not bake a
-      // literal bearer token into it the way the Claude branch does.
+      // Gemini reads `.gemini/settings.json`, not `.mcp.json` — the latter
+      // must not carry a Claude-shaped entry that would only be a stale
+      // bearer here.
       const mcp = JSON.parse(
         await fs.readFile(path.join(result.sessionPath, ".mcp.json"), "utf-8")
       );
       expect(mcp.mcpServers.daintree).toBeUndefined();
+    });
+
+    it("writes .gemini/settings.json with daintree using httpUrl + ${DAINTREE_MCP_TOKEN} + trust:true", async () => {
+      const result = await service.provisionSession(geminiInput());
+      if (!result) throw new Error("expected result");
+
+      const settings = JSON.parse(
+        await fs.readFile(path.join(result.sessionPath, ".gemini", "settings.json"), "utf-8")
+      );
+      expect(settings.mcpServers.daintree).toEqual({
+        httpUrl: "http://127.0.0.1:45454/mcp",
+        headers: { Authorization: "Bearer ${DAINTREE_MCP_TOKEN}" },
+        trust: true,
+      });
+      // The bundled docs entry must survive the overlay.
+      expect(settings.mcpServers["daintree-docs"]).toEqual({
+        httpUrl: "https://daintree.org/api/mcp",
+        trust: true,
+      });
+      // No literal token is ever embedded — the bearer is delivered via
+      // PTY env. The literal `${...}` substitution placeholder is the
+      // expected form.
+      expect(JSON.stringify(settings)).not.toContain(result.token);
+      expect(settings.toolsAllowlist).toContain("read_file");
+    });
+
+    it("omits the daintree entry from .gemini/settings.json when daintreeControl is off", async () => {
+      mockStoreGet.mockReturnValue({ daintreeControl: false });
+
+      const result = await service.provisionSession(geminiInput());
+      if (!result) throw new Error("expected result");
+
+      const settings = JSON.parse(
+        await fs.readFile(path.join(result.sessionPath, ".gemini", "settings.json"), "utf-8")
+      );
+      expect(settings.mcpServers.daintree).toBeUndefined();
+      expect(settings.mcpServers["daintree-docs"]).toBeDefined();
+    });
+
+    it("omits the daintree-docs entry from .gemini/settings.json when docSearch is off", async () => {
+      mockStoreGet.mockReturnValue({ daintreeControl: true, docSearch: false });
+
+      const result = await service.provisionSession(geminiInput());
+      if (!result) throw new Error("expected result");
+
+      const settings = JSON.parse(
+        await fs.readFile(path.join(result.sessionPath, ".gemini", "settings.json"), "utf-8")
+      );
+      expect(settings.mcpServers["daintree-docs"]).toBeUndefined();
+      expect(settings.mcpServers.daintree).toBeDefined();
     });
 
     it("does NOT rewrite .claude/settings.json with help-assistant overrides (Claude-only overlay)", async () => {
@@ -1022,14 +1070,16 @@ describe("HelpSessionService", () => {
       expect(settings.permissions?.allow ?? []).not.toContain("mcp__daintree__*");
     });
 
-    it("does NOT call probeMcpServer or probeMcpSseServer with the session token", async () => {
+    it("probes /mcp (Streamable HTTP) for Gemini with the session token", async () => {
       // ensureMcpServerReady runs probeMcpServer once with the API key
-      // before provision; Gemini Phase 1 skips both post-provision probes.
+      // before provision; the Gemini branch then probes /mcp with the
+      // freshly minted session token. Total: probeMcpServer twice,
+      // probeMcpSseServer never.
       const result = await service.provisionSession(geminiInput());
       if (!result) throw new Error("expected result");
 
-      expect(mockProbeMcpServer).toHaveBeenCalledTimes(1);
-      expect(mockProbeMcpServer).toHaveBeenLastCalledWith(45454, "test-api-key");
+      expect(mockProbeMcpServer).toHaveBeenCalledTimes(2);
+      expect(mockProbeMcpServer).toHaveBeenLastCalledWith(45454, result.token);
       expect(mockProbeMcpSseServer).not.toHaveBeenCalled();
     });
 
@@ -1073,10 +1123,306 @@ describe("HelpSessionService", () => {
       expect(service.getGeminiLaunchArgs(result.token)).toBeNull();
     });
 
+    it("getGeminiSpawnEnv returns {} for a Gemini session (intentionally no GEMINI_CLI_HOME)", async () => {
+      // Redirecting `os.homedir()` via `GEMINI_CLI_HOME` would break OAuth
+      // credential lookup at `~/.gemini/oauth_creds.json`. MCP isolation is
+      // achieved via workspace-level `.gemini/settings.json` precedence
+      // instead — the shape returned is a typed extension point for
+      // future per-agent env without breaking the contract.
+      const result = await service.provisionSession(geminiInput());
+      if (!result) throw new Error("expected result");
+
+      expect(service.getGeminiSpawnEnv(result.token)).toEqual({});
+    });
+
+    it("getGeminiSpawnEnv returns null for a Claude session (cross-agent defense)", async () => {
+      const result = await service.provisionSession(provisionInput());
+      if (!result) throw new Error("expected result");
+
+      expect(service.getGeminiSpawnEnv(result.token)).toBeNull();
+    });
+
+    it("getGeminiSpawnEnv returns null for unknown / revoked tokens", async () => {
+      const result = await service.provisionSession(geminiInput());
+      if (!result) throw new Error("expected result");
+
+      expect(service.getGeminiSpawnEnv("not-a-real-token")).toBeNull();
+      expect(service.getGeminiSpawnEnv("")).toBeNull();
+
+      await service.revokeSession(result.sessionId);
+      expect(service.getGeminiSpawnEnv(result.token)).toBeNull();
+    });
+
+    it("revokeSession strips the daintree entry from .gemini/settings.json", async () => {
+      const result = await service.provisionSession(geminiInput());
+      if (!result) throw new Error("expected result");
+
+      const target = path.join(result.sessionPath, ".gemini", "settings.json");
+      const before = JSON.parse(await fs.readFile(target, "utf-8"));
+      expect(before.mcpServers.daintree).toBeDefined();
+      expect(before.mcpServers["daintree-docs"]).toBeDefined();
+
+      await service.revokeSession(result.sessionId);
+
+      const after = JSON.parse(await fs.readFile(target, "utf-8"));
+      expect(after.mcpServers.daintree).toBeUndefined();
+      // The docs entry doesn't depend on a live session.
+      expect(after.mcpServers["daintree-docs"]).toBeDefined();
+    });
+
+    it("gcStaleSessions strips a stale daintree entry from .gemini/settings.json (post-restart cleanup)", async () => {
+      // Models the post-restart state: a previous run left
+      // `.gemini/settings.json` carrying the daintree MCP entry whose
+      // session record didn't survive boot. The settings file is hygiene
+      // only (the literal token is never in the file — it's a
+      // `${DAINTREE_MCP_TOKEN}` placeholder), but stripping keeps the CLI
+      // from surfacing a configured-but-broken server.
+      const sessionsRoot = path.join(userData, "help-sessions");
+      const staleDir = path.join(sessionsRoot, "cafebabecafebabe");
+      await fs.mkdir(path.join(staleDir, ".gemini"), { recursive: true });
+      await fs.writeFile(
+        path.join(staleDir, ".gemini", "settings.json"),
+        JSON.stringify(
+          {
+            mcpServers: {
+              daintree: {
+                httpUrl: "http://127.0.0.1:45454/mcp",
+                headers: { Authorization: "Bearer ${DAINTREE_MCP_TOKEN}" },
+                trust: true,
+              },
+              "daintree-docs": { httpUrl: "https://daintree.org/api/mcp", trust: true },
+            },
+          },
+          null,
+          2
+        )
+      );
+
+      await service.gcStaleSessions();
+
+      await fs.access(staleDir);
+      const cleaned = JSON.parse(
+        await fs.readFile(path.join(staleDir, ".gemini", "settings.json"), "utf-8")
+      );
+      expect(cleaned.mcpServers.daintree).toBeUndefined();
+      expect(cleaned.mcpServers["daintree-docs"]).toBeDefined();
+    });
+
+    it("strips a prior Claude bearer from .mcp.json on Gemini hash-skip switch (no stale Authorization in cwd)", async () => {
+      // Provision Claude first — writes `.mcp.json` with a literal Bearer.
+      const claudeResult = await service.provisionSession(provisionInput());
+      if (!claudeResult) throw new Error("expected claude provision");
+      const claudeMcp = JSON.parse(
+        await fs.readFile(path.join(claudeResult.sessionPath, ".mcp.json"), "utf-8")
+      );
+      expect(claudeMcp.mcpServers.daintree.headers.Authorization).toBe(
+        `Bearer ${claudeResult.token}`
+      );
+
+      // Provision Gemini for the same project. Template hash unchanged →
+      // `fs.cp` is skipped. Gemini doesn't rewrite `.mcp.json`, so the dead
+      // Claude bearer would survive in cwd without the explicit strip in
+      // the Gemini branch.
+      const geminiResult = await service.provisionSession(geminiInput());
+      if (!geminiResult) throw new Error("expected gemini provision");
+      expect(geminiResult.sessionPath).toBe(claudeResult.sessionPath);
+
+      const afterMcp = JSON.parse(
+        await fs.readFile(path.join(geminiResult.sessionPath, ".mcp.json"), "utf-8")
+      );
+      expect(afterMcp.mcpServers.daintree).toBeUndefined();
+      expect(afterMcp.mcpServers["daintree-docs"]).toBeDefined();
+
+      // And the new Gemini entry is in .gemini/settings.json.
+      const geminiSettings = JSON.parse(
+        await fs.readFile(path.join(geminiResult.sessionPath, ".gemini", "settings.json"), "utf-8")
+      );
+      expect(geminiSettings.mcpServers.daintree.httpUrl).toBe("http://127.0.0.1:45454/mcp");
+    });
+
+    it("throws MCP_NOT_READY and strips the daintree entry when the Gemini /mcp probe fails", async () => {
+      // First probe call (ensureMcpServerReady) succeeds; second (session
+      // token probe) fails.
+      mockProbeMcpServer.mockResolvedValueOnce(undefined);
+      mockProbeMcpServer.mockRejectedValueOnce(new Error("/mcp returned status 500"));
+
+      await expect(service.provisionSession(geminiInput())).rejects.toMatchObject({
+        name: "HelpSessionError",
+        code: "MCP_NOT_READY",
+      });
+
+      // Session dir survives — but the daintree entry must be gone.
+      const sessionsRoot = path.join(userData, "help-sessions");
+      const entries = await fs.readdir(sessionsRoot);
+      expect(entries.length).toBe(1);
+      const settings = JSON.parse(
+        await fs.readFile(path.join(sessionsRoot, entries[0]!, ".gemini", "settings.json"), "utf-8")
+      );
+      expect(settings.mcpServers.daintree).toBeUndefined();
+      expect(settings.mcpServers["daintree-docs"]).toBeDefined();
+    });
+
     it("rejects an unknown agentId via the wired-list gate", async () => {
       await expect(
         service.provisionSession({ ...provisionInput(), agentId: "not-an-agent" })
       ).rejects.toThrow(/not assistant-supported/);
+    });
+  });
+
+  describe("Copilot (#7542)", () => {
+    function copilotInput() {
+      return { ...provisionInput(), agentId: "copilot" };
+    }
+
+    it("accepts agentId: 'copilot'", async () => {
+      const result = await service.provisionSession(copilotInput());
+      expect(result).not.toBeNull();
+    });
+
+    it("returns the /mcp Streamable HTTP URL for Copilot when daintreeControl is on", async () => {
+      const result = await service.provisionSession(copilotInput());
+      if (!result) throw new Error("expected result");
+      expect(result.mcpUrl).toBe("http://127.0.0.1:45454/mcp");
+    });
+
+    it("writes .mcp.json with daintree using type:http + url + $DAINTREE_MCP_TOKEN substitution", async () => {
+      const result = await service.provisionSession(copilotInput());
+      if (!result) throw new Error("expected result");
+
+      const mcp = JSON.parse(
+        await fs.readFile(path.join(result.sessionPath, ".mcp.json"), "utf-8")
+      );
+      expect(mcp.mcpServers.daintree).toEqual({
+        type: "http",
+        url: "http://127.0.0.1:45454/mcp",
+        // Copilot supports `$VAR` (no braces) — keeps cross-platform portability.
+        headers: { Authorization: "Bearer $DAINTREE_MCP_TOKEN" },
+      });
+      // No literal token on disk — bearer is delivered via PTY env.
+      expect(JSON.stringify(mcp)).not.toContain(result.token);
+      // docs entry preserved
+      expect(mcp.mcpServers["daintree-docs"]).toEqual({
+        type: "http",
+        url: "https://daintree.org/api/mcp",
+      });
+    });
+
+    it("omits the daintree entry when daintreeControl is off but keeps daintree-docs", async () => {
+      mockStoreGet.mockReturnValue({ daintreeControl: false });
+
+      const result = await service.provisionSession(copilotInput());
+      if (!result) throw new Error("expected result");
+
+      const mcp = JSON.parse(
+        await fs.readFile(path.join(result.sessionPath, ".mcp.json"), "utf-8")
+      );
+      expect(mcp.mcpServers.daintree).toBeUndefined();
+      expect(mcp.mcpServers["daintree-docs"]).toBeDefined();
+    });
+
+    it("omits the daintree-docs entry from .mcp.json when docSearch is off", async () => {
+      mockStoreGet.mockReturnValue({ daintreeControl: true, docSearch: false });
+
+      const result = await service.provisionSession(copilotInput());
+      if (!result) throw new Error("expected result");
+
+      const mcp = JSON.parse(
+        await fs.readFile(path.join(result.sessionPath, ".mcp.json"), "utf-8")
+      );
+      expect(mcp.mcpServers["daintree-docs"]).toBeUndefined();
+      expect(mcp.mcpServers.daintree).toBeDefined();
+    });
+
+    it("does NOT rewrite .claude/settings.json with help-assistant overrides (Claude-only overlay)", async () => {
+      const result = await service.provisionSession(copilotInput());
+      if (!result) throw new Error("expected result");
+      const settings = JSON.parse(
+        await fs.readFile(path.join(result.sessionPath, ".claude", "settings.json"), "utf-8")
+      );
+      expect(settings.enableAllProjectMcpServers).toBeUndefined();
+      expect(settings.permissions?.allow ?? []).not.toContain("mcp__daintree__*");
+    });
+
+    it("probes /mcp (Streamable HTTP) for Copilot with the session token", async () => {
+      const result = await service.provisionSession(copilotInput());
+      if (!result) throw new Error("expected result");
+
+      expect(mockProbeMcpServer).toHaveBeenCalledTimes(2);
+      expect(mockProbeMcpServer).toHaveBeenLastCalledWith(45454, result.token);
+      expect(mockProbeMcpSseServer).not.toHaveBeenCalled();
+    });
+
+    it("getCopilotLaunchArgs returns ['--plan'] for a Copilot session", async () => {
+      const result = await service.provisionSession(copilotInput());
+      if (!result) throw new Error("expected result");
+
+      expect(service.getCopilotLaunchArgs(result.token)).toEqual(["--plan"]);
+    });
+
+    it("getCopilotLaunchArgs returns null for a Claude session (cross-agent defense)", async () => {
+      const result = await service.provisionSession(provisionInput());
+      if (!result) throw new Error("expected result");
+
+      expect(service.getCopilotLaunchArgs(result.token)).toBeNull();
+    });
+
+    it("getCopilotLaunchArgs returns null for a Gemini session (cross-agent defense)", async () => {
+      const result = await service.provisionSession({ ...provisionInput(), agentId: "gemini" });
+      if (!result) throw new Error("expected result");
+
+      expect(service.getCopilotLaunchArgs(result.token)).toBeNull();
+    });
+
+    it("getCopilotLaunchArgs returns null for unknown / revoked tokens", async () => {
+      const result = await service.provisionSession(copilotInput());
+      if (!result) throw new Error("expected result");
+
+      expect(service.getCopilotLaunchArgs("not-a-real-token")).toBeNull();
+      expect(service.getCopilotLaunchArgs("")).toBeNull();
+
+      await service.revokeSession(result.sessionId);
+      expect(service.getCopilotLaunchArgs(result.token)).toBeNull();
+    });
+
+    it("getGeminiSpawnEnv returns null for a Copilot session (cross-agent defense)", async () => {
+      const result = await service.provisionSession(copilotInput());
+      if (!result) throw new Error("expected result");
+
+      expect(service.getGeminiSpawnEnv(result.token)).toBeNull();
+    });
+
+    it("revokeSession strips the daintree entry from .mcp.json", async () => {
+      const result = await service.provisionSession(copilotInput());
+      if (!result) throw new Error("expected result");
+
+      const target = path.join(result.sessionPath, ".mcp.json");
+      const before = JSON.parse(await fs.readFile(target, "utf-8"));
+      expect(before.mcpServers.daintree).toBeDefined();
+
+      await service.revokeSession(result.sessionId);
+
+      const after = JSON.parse(await fs.readFile(target, "utf-8"));
+      expect(after.mcpServers.daintree).toBeUndefined();
+      expect(after.mcpServers["daintree-docs"]).toBeDefined();
+    });
+
+    it("throws MCP_NOT_READY and strips the daintree entry when the Copilot /mcp probe fails", async () => {
+      mockProbeMcpServer.mockResolvedValueOnce(undefined); // ensureMcpServerReady
+      mockProbeMcpServer.mockRejectedValueOnce(new Error("/mcp returned status 401"));
+
+      await expect(service.provisionSession(copilotInput())).rejects.toMatchObject({
+        name: "HelpSessionError",
+        code: "MCP_NOT_READY",
+      });
+
+      const sessionsRoot = path.join(userData, "help-sessions");
+      const entries = await fs.readdir(sessionsRoot);
+      expect(entries.length).toBe(1);
+      const mcp = JSON.parse(
+        await fs.readFile(path.join(sessionsRoot, entries[0]!, ".mcp.json"), "utf-8")
+      );
+      expect(mcp.mcpServers.daintree).toBeUndefined();
+      expect(mcp.mcpServers["daintree-docs"]).toBeDefined();
     });
   });
 

--- a/shared/config/__tests__/agentRegistry.test.ts
+++ b/shared/config/__tests__/agentRegistry.test.ts
@@ -325,9 +325,9 @@ describe("agentRegistry", () => {
       const gemini = getAgentConfig("gemini");
       expect(gemini?.supports).toMatchObject({
         mcpInjection: "project-config",
-        settingsOverlay: false,
+        settingsOverlay: true,
         permissionBypass: false,
-        trustDialog: false,
+        trustDialog: true,
         versionProbe: true,
         tier: "experimental",
       });

--- a/shared/config/agents/copilot.ts
+++ b/shared/config/agents/copilot.ts
@@ -7,6 +7,23 @@ export const config: AgentConfig = {
   color: "#8957e5",
   iconId: "copilot",
   supportsContextInjection: true,
+  // Copilot help sessions read MCP from `.mcp.json` written into the
+  // per-session cwd (root key `mcpServers`, `type: "http"`, `$VAR` env-var
+  // substitution in headers). `--plan` is appended at spawn time via
+  // `HelpSessionService.buildCopilotLaunchArgs` to pin the session to
+  // read-only mode. Held at `"experimental"` until end-to-end validation
+  // lands.
+  supports: {
+    mcpInjection: "project-config",
+    settingsOverlay: false,
+    permissionBypass: false,
+    trustDialog: false,
+    versionProbe: true,
+    tier: "experimental",
+  },
+  // `--plan` flag landed in Copilot CLI v1.0.40; below this floor we'd
+  // launch without the read-only guardrail.
+  assistantMinVersion: "1.0.40",
   tooltip: "GitHub's AI coding agent",
   usageUrl: "https://github.com/features/copilot",
   contextWindow: 160_000,

--- a/shared/config/agents/gemini.ts
+++ b/shared/config/agents/gemini.ts
@@ -8,16 +8,23 @@ export const config: AgentConfig = {
   color: "#4285F4",
   iconId: "gemini",
   supportsContextInjection: true,
-  // Gemini help sessions read MCP from the bundled `.gemini/settings.json`
-  // copied into the per-session cwd; `--approval-mode=plan` is injected at
-  // spawn time via `HelpSessionService.buildGeminiLaunchArgs`. Held at the
-  // `"experimental"` tier so the help-panel picker stays Claude/Codex only
-  // until end-to-end validation lands.
+  // Gemini help sessions read MCP from `<sessionPath>/.gemini/settings.json`
+  // (written at provision time with the daintree entry using `httpUrl` +
+  // streamable HTTP + `${DAINTREE_MCP_TOKEN}` substitution + `trust: true`).
+  // The workspace-level settings file takes precedence over user-level
+  // `~/.gemini/settings.json` for same-name MCP entries, which gives us
+  // the isolation we need without redirecting `os.homedir()` (Gemini reads
+  // OAuth credentials from `~/.gemini/oauth_creds.json` and `~/.gemini/
+  // google_accounts.json`, so a redirect would break auth for users
+  // without `GEMINI_API_KEY`). The `--approval-mode=plan` flag is appended
+  // at spawn time via `HelpSessionService.buildGeminiLaunchArgs`. Held at
+  // the `"experimental"` tier so the help-panel picker stays Claude/Codex
+  // only until end-to-end validation lands.
   supports: {
     mcpInjection: "project-config",
-    settingsOverlay: false,
+    settingsOverlay: true,
     permissionBypass: false,
-    trustDialog: false,
+    trustDialog: true,
     versionProbe: true,
     tier: "experimental",
   },

--- a/src/controllers/HelpSessionController.ts
+++ b/src/controllers/HelpSessionController.ts
@@ -114,6 +114,22 @@ interface HelpSessionRef {
   windowId: number;
 }
 
+/**
+ * Per-agent env injection for help-session launches. Today this is a
+ * placeholder shape — no agent currently requires renderer-side env beyond
+ * the universal `DAINTREE_MCP_TOKEN` / `DAINTREE_WINDOW_ID` set in
+ * `buildHelpEnv`. Gemini intentionally does NOT receive `GEMINI_CLI_HOME`:
+ * its OAuth credentials live under `os.homedir()` and redirecting them
+ * would break auth for users who haven't set `GEMINI_API_KEY`. MCP-server
+ * isolation for Gemini comes from the workspace-level
+ * `<sessionPath>/.gemini/settings.json` written at provision time, which
+ * Gemini's merge precedence (workspace > user) lets shadow same-name
+ * user-level entries.
+ */
+function agentSpawnEnv(_agentId: string, _sessionPath: string): Record<string, string> {
+  return {};
+}
+
 type ProvisionOutcome =
   | { ok: true; session: HelpSessionRef }
   | { ok: false; code: "MCP_NOT_READY"; message: string }
@@ -199,12 +215,14 @@ async function loadCustomLaunchFlags(): Promise<string[]> {
 
 function buildHelpEnv(
   session: HelpSessionRef | null,
-  projectId: string | null
+  projectId: string | null,
+  agentId: string
 ): Record<string, string> | undefined {
   if (!session) return undefined;
   const env: Record<string, string> = {
     DAINTREE_MCP_TOKEN: session.token,
     DAINTREE_WINDOW_ID: String(session.windowId),
+    ...agentSpawnEnv(agentId, session.sessionPath),
   };
   if (session.mcpUrl) env.DAINTREE_MCP_URL = session.mcpUrl;
   if (projectId) env.DAINTREE_PROJECT_ID = projectId;
@@ -1007,7 +1025,7 @@ export class HelpSessionController {
 
     const cwd = session?.sessionPath ?? hibernated.cwd ?? folderPath;
     const projectId = useProjectStore.getState().currentProject?.id ?? null;
-    const env = buildHelpEnv(session, projectId);
+    const env = buildHelpEnv(session, projectId, launchAgentId);
 
     const newId = await usePanelStore.getState().addPanel({
       kind: "terminal",
@@ -1085,7 +1103,7 @@ export class HelpSessionController {
       session = outcome.session;
       this._pendingSessionId = session.sessionId;
       const cwd = session.sessionPath;
-      const env = buildHelpEnv(session, launchProject.id);
+      const env = buildHelpEnv(session, launchProject.id, launchAgentId);
 
       const hibernated = useHelpPanelStore.getState().hibernateSessions[launchProject.id];
       if (hibernated && hibernated.agentId === launchAgentId) {
@@ -1265,7 +1283,7 @@ export class HelpSessionController {
         this._pendingSessionId = session.sessionId;
       }
       const cwd = session.sessionPath;
-      const helpEnv = buildHelpEnv(session, launchProject.id);
+      const helpEnv = buildHelpEnv(session, launchProject.id, launchAgentId);
       const env: Record<string, string> | undefined =
         helpEnv || presetEnv ? { ...(presetEnv ?? {}), ...(helpEnv ?? {}) } : undefined;
 


### PR DESCRIPTION
## Summary

- Wires Gemini CLI and GitHub Copilot CLI as help-session assistants in the Daintree MCP layer. Both stay at `tier: "experimental"` so they're hidden from the picker until end-to-end validation passes.
- Gemini gets `<sessionPath>/.gemini/settings.json` written at provision time with the `httpUrl` and `${DAINTREE_MCP_TOKEN}` substitution. Copilot gets `<sessionPath>/.mcp.json` written at provision time, matching the existing Claude pattern.
- Per-agent probe routing: Claude probes `/sse` (SSE); Codex, Gemini, and Copilot probe `/mcp` (Streamable HTTP).

Resolves #7542

## Changes

- `shared/config/agents/gemini.ts` — adds `mcpInjection` strategy (`gemini-settings`) and sets `supportsAssistant: true`
- `shared/config/agents/copilot.ts` — adds `mcpInjection` strategy (`mcp-json`) and sets `supportsAssistant: true`, `assistantMinVersion: "1.0.40"`, spawns with `--plan` read-only flag
- `electron/services/HelpSessionService.ts` — writes `.gemini/settings.json` at provision, probe routing split per agent, cross-agent token-reuse defense for Copilot
- `electron/ipc/handlers/terminal/lifecycle.ts` — MCP injection gated on `mcpInjection` strategy rather than hardcoded `launchAgentId === "claude"` check
- `src/controllers/HelpSessionController.ts` — Copilot session wiring
- Removed `GEMINI_CLI_HOME` injection — it redirects the entire user config dir, which breaks OAuth credential lookup at `~/.gemini/oauth_creds.json`; workspace-level settings precedence handles MCP isolation without the env var

## Testing

- 168 tests pass covering `HelpSessionService` and `lifecycle.spawn`
- 30+ new tests added: Gemini settings file write, Copilot `.mcp.json` write, per-agent probe routing, token-reuse defense for Copilot
- `typecheck`, `lint`, `format`, `build`, `check:channels`, `check:ipc`, `check:help` all pass