### PR TITLE
fix(worktree): show commit composer dialog before commit & push

### DIFF
--- a/shared/utils/gitConstants.ts
+++ b/shared/utils/gitConstants.ts
@@ -1,0 +1,8 @@
+export const PROTECTED_BRANCHES = ["main", "master", "develop", "development"] as const;
+
+export type ProtectedBranch = (typeof PROTECTED_BRANCHES)[number];
+
+export function isProtectedBranch(branch: string | null | undefined): boolean {
+  if (!branch) return false;
+  return (PROTECTED_BRANCHES as readonly string[]).includes(branch);
+}

--- a/src/components/Worktree/CommitComposerDialog.tsx
+++ b/src/components/Worktree/CommitComposerDialog.tsx
@@ -1,0 +1,271 @@
+import { useEffect, useId, useMemo, useRef, useState } from "react";
+import { AlertTriangle, Send } from "lucide-react";
+import { AppDialog } from "@/components/ui/AppDialog";
+import { Spinner } from "@/components/ui/Spinner";
+import { DiffViewer } from "./DiffViewer";
+import { FileChangeList } from "./FileChangeList";
+import { useDeferredLoading } from "@/hooks/useDeferredLoading";
+import { UI_DOHERTY_THRESHOLD } from "@/lib/animationUtils";
+import { isProtectedBranch } from "@shared/utils/gitConstants";
+import { cn } from "@/lib/utils";
+import type { FileChangeDetail } from "@shared/types/git";
+
+export interface CommitComposerDialogProps {
+  isOpen: boolean;
+  onClose: () => void;
+  onConfirm: (message: string) => void;
+  isSubmitting: boolean;
+  commitMessage: string;
+  onCommitMessageChange: (next: string) => void;
+  branch: string | undefined;
+  tracking: string | null | undefined;
+  changes: FileChangeDetail[];
+  rootPath: string;
+  diff: string | null;
+  isDiffLoading: boolean;
+  diffError: string | null;
+  submitError: string | null;
+}
+
+export function CommitComposerDialog({
+  isOpen,
+  onClose,
+  onConfirm,
+  isSubmitting,
+  commitMessage,
+  onCommitMessageChange,
+  branch,
+  tracking,
+  changes,
+  rootPath,
+  diff,
+  isDiffLoading,
+  diffError,
+  submitError,
+}: CommitComposerDialogProps) {
+  const textareaRef = useRef<HTMLTextAreaElement>(null);
+  const messageId = useId();
+  const confirmId = useId();
+
+  const protectedBranch = isProtectedBranch(branch?.toLowerCase());
+  const [confirmedProtected, setConfirmedProtected] = useState(false);
+
+  const trackedChanges = useMemo(
+    () => changes.filter((c) => c.status !== "untracked" && c.status !== "ignored"),
+    [changes]
+  );
+  const trackedCount = trackedChanges.length;
+  const totalCount = changes.length;
+
+  const showDiffSkeleton = useDeferredLoading(isDiffLoading, UI_DOHERTY_THRESHOLD);
+
+  useEffect(() => {
+    if (!isOpen) {
+      setConfirmedProtected(false);
+    }
+  }, [isOpen]);
+
+  useEffect(() => {
+    if (!isOpen) return;
+    // AppDialog auto-focuses the first tabbable element in a requestAnimationFrame
+    // (close button in the header). Schedule our textarea focus in the next frame
+    // so it wins, putting the cursor where the user actually wants it.
+    let raf2 = 0;
+    const raf1 = requestAnimationFrame(() => {
+      raf2 = requestAnimationFrame(() => {
+        textareaRef.current?.focus();
+        textareaRef.current?.select();
+      });
+    });
+    return () => {
+      cancelAnimationFrame(raf1);
+      if (raf2) cancelAnimationFrame(raf2);
+    };
+  }, [isOpen]);
+
+  const trimmedMessage = commitMessage.trim();
+  const canSubmit =
+    !isSubmitting && trimmedMessage.length > 0 && (!protectedBranch || confirmedProtected);
+
+  const handleSubmit = () => {
+    if (!canSubmit) return;
+    onConfirm(trimmedMessage);
+  };
+
+  const handleKeyDown = (e: React.KeyboardEvent<HTMLTextAreaElement>) => {
+    if ((e.metaKey || e.ctrlKey) && e.key === "Enter") {
+      e.preventDefault();
+      handleSubmit();
+    }
+  };
+
+  const branchLabel = branch ?? "detached HEAD";
+  const remoteLabel = tracking ?? null;
+
+  return (
+    <AppDialog
+      isOpen={isOpen}
+      onClose={onClose}
+      size="xl"
+      dismissible={!isSubmitting}
+      maxHeight="max-h-[85vh]"
+      data-testid="commit-composer-dialog"
+    >
+      <AppDialog.Header>
+        <div className="flex flex-col gap-0.5 min-w-0">
+          <AppDialog.Title icon={<Send className="w-4 h-4 text-status-success" />}>
+            Commit &amp; push
+          </AppDialog.Title>
+          <div className="text-xs text-text-muted flex items-center gap-1.5 truncate">
+            <span className="truncate">
+              <span className="font-mono">{branchLabel}</span>
+              {remoteLabel ? (
+                <>
+                  <span className="px-1">→</span>
+                  <span className="font-mono">{remoteLabel}</span>
+                </>
+              ) : null}
+            </span>
+            <span aria-hidden="true">·</span>
+            <span>
+              {trackedCount} file{trackedCount === 1 ? "" : "s"}
+              {totalCount > trackedCount && trackedCount > 0 ? " tracked" : ""}
+            </span>
+          </div>
+        </div>
+        <AppDialog.CloseButton />
+      </AppDialog.Header>
+
+      <AppDialog.Body>
+        <div className="flex flex-col gap-4">
+          <div className="flex flex-col gap-1.5">
+            <label htmlFor={messageId} className="text-xs font-medium text-text-secondary">
+              Commit message
+            </label>
+            <textarea
+              id={messageId}
+              ref={textareaRef}
+              value={commitMessage}
+              onChange={(e) => onCommitMessageChange(e.target.value)}
+              onKeyDown={handleKeyDown}
+              rows={3}
+              placeholder="Describe what changed"
+              disabled={isSubmitting}
+              aria-label="Commit message"
+              className={cn(
+                "w-full resize-y rounded-[var(--radius-md)] border border-border-default bg-surface-inset px-3 py-2",
+                "text-sm text-text-primary placeholder:text-text-muted",
+                "focus:outline-hidden focus:ring-2 focus:ring-daintree-accent focus:border-transparent",
+                "disabled:opacity-60"
+              )}
+            />
+            <p className="text-[11px] text-text-muted">
+              {trimmedMessage.length === 0
+                ? "A message is required."
+                : "⌘/Ctrl + Enter to commit & push"}
+            </p>
+          </div>
+
+          {protectedBranch && (
+            <div className="flex items-start gap-2 rounded-[var(--radius-md)] border border-status-warning/40 bg-status-warning/10 px-3 py-2.5 text-xs text-status-warning">
+              <AlertTriangle className="w-3.5 h-3.5 shrink-0 mt-0.5" aria-hidden="true" />
+              <div className="flex flex-col gap-1.5 min-w-0">
+                <span className="font-medium">
+                  Committing directly to <span className="font-mono">{branchLabel}</span>
+                </span>
+                <span className="text-text-secondary">
+                  This is a protected branch. Most teams use pull requests instead.
+                </span>
+                <label
+                  htmlFor={confirmId}
+                  className="flex items-center gap-2 cursor-pointer text-text-primary"
+                >
+                  <input
+                    id={confirmId}
+                    type="checkbox"
+                    checked={confirmedProtected}
+                    onChange={(e) => setConfirmedProtected(e.target.checked)}
+                    disabled={isSubmitting}
+                    className="rounded"
+                  />
+                  I understand I'm committing directly to{" "}
+                  <span className="font-mono">{branchLabel}</span>
+                </label>
+              </div>
+            </div>
+          )}
+
+          {changes.length > 0 && (
+            <div className="flex flex-col gap-1.5">
+              <h3 className="text-xs font-medium text-text-secondary">
+                Files ({trackedCount}
+                {totalCount > trackedCount ? `, ${totalCount - trackedCount} untracked` : ""})
+              </h3>
+              <FileChangeList changes={changes} maxVisible={50} rootPath={rootPath} />
+            </div>
+          )}
+
+          <div className="flex flex-col gap-1.5">
+            <h3 className="text-xs font-medium text-text-secondary">Changes</h3>
+            {isDiffLoading ? (
+              showDiffSkeleton ? (
+                <div
+                  className="animate-pulse-delayed h-40 rounded-[var(--radius-md)] bg-surface-inset"
+                  aria-label="Loading diff"
+                  role="status"
+                />
+              ) : (
+                <div className="h-40" aria-hidden="true" />
+              )
+            ) : diffError ? (
+              <div className="flex items-start gap-2 rounded-[var(--radius-md)] border border-status-error/40 bg-status-error/10 px-3 py-2.5 text-xs text-status-error">
+                <AlertTriangle className="w-3.5 h-3.5 shrink-0 mt-0.5" aria-hidden="true" />
+                <span className="flex-1 break-words">
+                  Couldn't load diff preview. {diffError} You can still commit using the message
+                  above.
+                </span>
+              </div>
+            ) : diff && diff.trim().length > 0 ? (
+              <div className="rounded-[var(--radius-md)] border border-border-default overflow-hidden">
+                <DiffViewer diff={diff} filePath="" rootPath={rootPath} viewType="unified" />
+              </div>
+            ) : (
+              <div className="rounded-[var(--radius-md)] border border-border-default bg-surface-inset px-3 py-6 text-center text-xs text-text-muted">
+                No textual changes to preview.
+              </div>
+            )}
+          </div>
+
+          {submitError && (
+            <div className="flex items-start gap-2 rounded-[var(--radius-md)] border border-status-error/40 bg-status-error/10 px-3 py-2.5 text-xs text-status-error">
+              <AlertTriangle className="w-3.5 h-3.5 shrink-0 mt-0.5" aria-hidden="true" />
+              <span className="flex-1 break-words">{submitError}</span>
+            </div>
+          )}
+        </div>
+      </AppDialog.Body>
+
+      <AppDialog.Footer
+        hint={
+          isSubmitting ? (
+            <span className="flex items-center gap-1.5">
+              <Spinner size="xs" />
+              <span>Committing &amp; pushing…</span>
+            </span>
+          ) : undefined
+        }
+        primaryAction={{
+          label: protectedBranch ? `Commit & push to ${branchLabel}` : "Commit & push",
+          onClick: handleSubmit,
+          disabled: !canSubmit,
+          loading: isSubmitting,
+        }}
+        secondaryAction={{
+          label: "Cancel",
+          onClick: onClose,
+          disabled: isSubmitting,
+        }}
+      />
+    </AppDialog>
+  );
+}

--- a/src/components/Worktree/WorktreeCard.tsx
+++ b/src/components/Worktree/WorktreeCard.tsx
@@ -438,11 +438,18 @@ export function WorktreeCard({
   const [isCommittingAndPushing, setIsCommittingAndPushing] = useState(false);
   const [commitAndPushError, setCommitAndPushError] = useState<string | null>(null);
   const commitAndPushInFlightRef = useRef(false);
+  // Tracks whether `commit` already succeeded for the currently-open composer
+  // session. If it did and `push` failed, a retry must skip stage+commit
+  // (which would no-op then fail "nothing to commit") and go straight to push.
+  const commitSucceededRef = useRef(false);
   const [showCommitComposer, setShowCommitComposer] = useState(false);
   const [commitMessage, setCommitMessage] = useState("");
   const [commitComposerDiff, setCommitComposerDiff] = useState<string | null>(null);
   const [isDiffLoading, setIsDiffLoading] = useState(false);
   const [diffError, setDiffError] = useState<string | null>(null);
+  // Monotonic ID per open — late responses from a prior open are dropped
+  // even when the worktree path stays the same.
+  const diffRequestIdRef = useRef(0);
 
   const onCloseReviewHub = () => setShowReviewHub(false);
   const onClosePlanViewer = () => setShowPlanViewer(false);
@@ -494,19 +501,20 @@ export function WorktreeCard({
     setIsDiffLoading(true);
     setDiffError(null);
     setCommitAndPushError(null);
+    commitSucceededRef.current = false;
     setShowCommitComposer(true);
 
+    const requestId = ++diffRequestIdRef.current;
     const requestPath = worktree.path;
     void window.electron.git
       .getWorkingDiff(requestPath, "unstaged")
       .then((raw) => {
-        // Drop late responses from a previous worktree path or after close.
-        if (requestPath !== worktree.path) return;
+        if (requestId !== diffRequestIdRef.current) return;
         setCommitComposerDiff(raw ?? "");
         setIsDiffLoading(false);
       })
       .catch((err) => {
-        if (requestPath !== worktree.path) return;
+        if (requestId !== diffRequestIdRef.current) return;
         setDiffError(formatErrorMessage(err, "Couldn't load diff preview"));
         setIsDiffLoading(false);
       });
@@ -514,6 +522,7 @@ export function WorktreeCard({
 
   const handleCloseCommitComposer = () => {
     if (commitAndPushInFlightRef.current) return;
+    commitSucceededRef.current = false;
     setShowCommitComposer(false);
   };
 
@@ -525,17 +534,20 @@ export function WorktreeCard({
     setIsCommittingAndPushing(true);
     setCommitAndPushError(null);
     try {
-      try {
-        await window.electron.git.stageAll(worktree.path);
-      } catch (err) {
-        setCommitAndPushError(formatErrorMessage(err, "Couldn't stage changes"));
-        return;
-      }
-      try {
-        await window.electron.git.commit(worktree.path, trimmed);
-      } catch (err) {
-        setCommitAndPushError(formatErrorMessage(err, "Couldn't commit changes"));
-        return;
+      if (!commitSucceededRef.current) {
+        try {
+          await window.electron.git.stageAll(worktree.path);
+        } catch (err) {
+          setCommitAndPushError(formatErrorMessage(err, "Couldn't stage changes"));
+          return;
+        }
+        try {
+          await window.electron.git.commit(worktree.path, trimmed);
+        } catch (err) {
+          setCommitAndPushError(formatErrorMessage(err, "Couldn't commit changes"));
+          return;
+        }
+        commitSucceededRef.current = true;
       }
       try {
         await window.electron.git.push(worktree.path);
@@ -543,6 +555,7 @@ export function WorktreeCard({
         setCommitAndPushError(formatErrorMessage(err, "Couldn't push to remote"));
         return;
       }
+      commitSucceededRef.current = false;
       setShowCommitComposer(false);
     } finally {
       setIsCommittingAndPushing(false);

--- a/src/components/Worktree/WorktreeCard.tsx
+++ b/src/components/Worktree/WorktreeCard.tsx
@@ -438,6 +438,11 @@ export function WorktreeCard({
   const [isCommittingAndPushing, setIsCommittingAndPushing] = useState(false);
   const [commitAndPushError, setCommitAndPushError] = useState<string | null>(null);
   const commitAndPushInFlightRef = useRef(false);
+  const [showCommitComposer, setShowCommitComposer] = useState(false);
+  const [commitMessage, setCommitMessage] = useState("");
+  const [commitComposerDiff, setCommitComposerDiff] = useState<string | null>(null);
+  const [isDiffLoading, setIsDiffLoading] = useState(false);
+  const [diffError, setDiffError] = useState<string | null>(null);
 
   const onCloseReviewHub = () => setShowReviewHub(false);
   const onClosePlanViewer = () => setShowPlanViewer(false);
@@ -472,10 +477,7 @@ export function WorktreeCard({
   }, [worktree.id]);
 
   const aiNoteFirstLine = effectiveNote?.split("\n")[0]?.trim() ?? "";
-  const lastCommitFirstLine =
-    worktree.worktreeChanges?.lastCommitMessage?.trim().split("\n")[0]?.trim() ?? "";
-  const commitMessageDefault = aiNoteFirstLine || lastCommitFirstLine;
-  const hasCommitMessageSource = commitMessageDefault.length > 0;
+  const commitMessageDefault = aiNoteFirstLine;
 
   const clearCommitAndPushError = () => setCommitAndPushError(null);
 
@@ -485,9 +487,40 @@ export function WorktreeCard({
     }
   }, [reviewState]);
 
-  const handleCommitAndPush = async () => {
+  const handleOpenCommitComposer = () => {
     if (commitAndPushInFlightRef.current) return;
-    if (!commitMessageDefault) return;
+    setCommitMessage(commitMessageDefault);
+    setCommitComposerDiff(null);
+    setIsDiffLoading(true);
+    setDiffError(null);
+    setCommitAndPushError(null);
+    setShowCommitComposer(true);
+
+    const requestPath = worktree.path;
+    void window.electron.git
+      .getWorkingDiff(requestPath, "unstaged")
+      .then((raw) => {
+        // Drop late responses from a previous worktree path or after close.
+        if (requestPath !== worktree.path) return;
+        setCommitComposerDiff(raw ?? "");
+        setIsDiffLoading(false);
+      })
+      .catch((err) => {
+        if (requestPath !== worktree.path) return;
+        setDiffError(formatErrorMessage(err, "Couldn't load diff preview"));
+        setIsDiffLoading(false);
+      });
+  };
+
+  const handleCloseCommitComposer = () => {
+    if (commitAndPushInFlightRef.current) return;
+    setShowCommitComposer(false);
+  };
+
+  const handleConfirmCommitAndPush = async (message: string) => {
+    if (commitAndPushInFlightRef.current) return;
+    const trimmed = message.trim();
+    if (!trimmed) return;
     commitAndPushInFlightRef.current = true;
     setIsCommittingAndPushing(true);
     setCommitAndPushError(null);
@@ -499,7 +532,7 @@ export function WorktreeCard({
         return;
       }
       try {
-        await window.electron.git.commit(worktree.path, commitMessageDefault);
+        await window.electron.git.commit(worktree.path, trimmed);
       } catch (err) {
         setCommitAndPushError(formatErrorMessage(err, "Couldn't commit changes"));
         return;
@@ -510,6 +543,7 @@ export function WorktreeCard({
         setCommitAndPushError(formatErrorMessage(err, "Couldn't push to remote"));
         return;
       }
+      setShowCommitComposer(false);
     } finally {
       setIsCommittingAndPushing(false);
       commitAndPushInFlightRef.current = false;
@@ -897,11 +931,10 @@ export function WorktreeCard({
                     onDismissError={dismissError}
                     onRetryError={handleErrorRetry}
                     onOpenReviewHub={openReviewHubForThisWorktree}
-                    onCommitAndPush={() => void handleCommitAndPush()}
+                    onCommitAndPush={handleOpenCommitComposer}
                     isCommitting={isCommittingAndPushing}
                     commitError={commitAndPushError}
                     clearCommitError={clearCommitAndPushError}
-                    hasCommitMessageSource={hasCommitMessageSource}
                     isLifecycleRunning={isLifecycleRunning}
                     lifecycleLabel={lifecycleLabel}
                     hasResourceConfig={hasResourceConfig}
@@ -941,6 +974,16 @@ export function WorktreeCard({
                 onCloseReviewHub={onCloseReviewHub}
                 showPlanViewer={showPlanViewer}
                 onClosePlanViewer={onClosePlanViewer}
+                showCommitComposer={showCommitComposer}
+                onCloseCommitComposer={handleCloseCommitComposer}
+                onConfirmCommitAndPush={(msg) => void handleConfirmCommitAndPush(msg)}
+                commitMessage={commitMessage}
+                onCommitMessageChange={setCommitMessage}
+                commitComposerDiff={commitComposerDiff}
+                isCommitComposerDiffLoading={isDiffLoading}
+                commitComposerDiffError={diffError}
+                isCommittingAndPushing={isCommittingAndPushing}
+                commitAndPushSubmitError={commitAndPushError}
               />
             </div>
           </div>

--- a/src/components/Worktree/WorktreeCard/WorktreeDetailsSection.tsx
+++ b/src/components/Worktree/WorktreeCard/WorktreeDetailsSection.tsx
@@ -51,7 +51,6 @@ export interface WorktreeDetailsSectionProps {
   isCommitting?: boolean;
   commitError?: string | null;
   clearCommitError?: () => void;
-  hasCommitMessageSource?: boolean;
   isLifecycleRunning?: boolean;
   lifecycleLabel?: string;
 
@@ -85,7 +84,6 @@ export function WorktreeDetailsSection(props: WorktreeDetailsSectionProps) {
     isCommitting,
     commitError,
     clearCommitError,
-    hasCommitMessageSource,
     reviewState,
     isLifecycleRunning,
     lifecycleLabel,
@@ -134,7 +132,7 @@ export function WorktreeDetailsSection(props: WorktreeDetailsSectionProps) {
 
   const isConflicted = reviewState === "conflicted";
   const showCommitAndPushButton =
-    !!onCommitAndPush && !!hasCommitMessageSource && reviewState === "has-changes" && !isCommitting;
+    !!onCommitAndPush && reviewState === "has-changes" && !isCommitting;
   const showReviewHubButton = !!onOpenReviewHub && hasChanges;
   const rightButtonGroupShown = showReviewHubButton || showCommitAndPushButton || !!isCommitting;
 

--- a/src/components/Worktree/WorktreeCard/WorktreeDialogs.tsx
+++ b/src/components/Worktree/WorktreeCard/WorktreeDialogs.tsx
@@ -5,6 +5,7 @@ import { WorktreeDeleteDialog } from "../WorktreeDeleteDialog";
 import { IssuePickerDialog } from "../IssuePickerDialog";
 import { ReviewHub } from "../ReviewHub/ReviewHub";
 import { PlanFileViewer } from "@/components/FileViewer/PlanFileViewer";
+import { CommitComposerDialog } from "../CommitComposerDialog";
 import type { ConfirmDialogState } from "./hooks/useWorktreeActions";
 
 export interface WorktreeDialogsProps {
@@ -21,6 +22,16 @@ export interface WorktreeDialogsProps {
   onCloseReviewHub: () => void;
   showPlanViewer: boolean;
   onClosePlanViewer: () => void;
+  showCommitComposer: boolean;
+  onCloseCommitComposer: () => void;
+  onConfirmCommitAndPush: (message: string) => void;
+  commitMessage: string;
+  onCommitMessageChange: (next: string) => void;
+  commitComposerDiff: string | null;
+  isCommitComposerDiffLoading: boolean;
+  commitComposerDiffError: string | null;
+  isCommittingAndPushing: boolean;
+  commitAndPushSubmitError: string | null;
 }
 
 export function WorktreeDialogs({
@@ -37,6 +48,16 @@ export function WorktreeDialogs({
   onCloseReviewHub,
   showPlanViewer,
   onClosePlanViewer,
+  showCommitComposer,
+  onCloseCommitComposer,
+  onConfirmCommitAndPush,
+  commitMessage,
+  onCommitMessageChange,
+  commitComposerDiff,
+  isCommitComposerDiffLoading,
+  commitComposerDiffError,
+  isCommittingAndPushing,
+  commitAndPushSubmitError,
 }: WorktreeDialogsProps) {
   return (
     <>
@@ -72,6 +93,23 @@ export function WorktreeDialogs({
         filePath={worktree.planFilePath}
         rootPath={worktree.path}
         onClose={onClosePlanViewer}
+      />
+
+      <CommitComposerDialog
+        isOpen={showCommitComposer}
+        onClose={onCloseCommitComposer}
+        onConfirm={onConfirmCommitAndPush}
+        isSubmitting={isCommittingAndPushing}
+        commitMessage={commitMessage}
+        onCommitMessageChange={onCommitMessageChange}
+        branch={worktree.branch}
+        tracking={worktree.worktreeChanges?.tracking}
+        changes={worktree.worktreeChanges?.changes ?? []}
+        rootPath={worktree.path}
+        diff={commitComposerDiff}
+        isDiffLoading={isCommitComposerDiffLoading}
+        diffError={commitComposerDiffError}
+        submitError={commitAndPushSubmitError}
       />
     </>
   );

--- a/src/components/Worktree/WorktreeCard/__tests__/WorktreeDetailsSection.test.tsx
+++ b/src/components/Worktree/WorktreeCard/__tests__/WorktreeDetailsSection.test.tsx
@@ -304,11 +304,10 @@ describe("WorktreeDetailsSection — reviewState surfaces", () => {
     expect(screen.queryByText(/files/)).toBeNull();
   });
 
-  it("renders the Commit & push button when gated", () => {
+  it("renders the Commit & push button when there are changes", () => {
     const onCommitAndPush = vi.fn();
     renderSection({
       reviewState: "has-changes",
-      hasCommitMessageSource: true,
       onCommitAndPush,
     });
     const button = screen.getByLabelText("Commit and push");
@@ -317,19 +316,19 @@ describe("WorktreeDetailsSection — reviewState surfaces", () => {
     expect(onCommitAndPush).toHaveBeenCalledTimes(1);
   });
 
-  it("hides the Commit & push button when there is no commit message source", () => {
+  it("renders the Commit & push button even when no AI note is present", () => {
     renderSection({
       reviewState: "has-changes",
-      hasCommitMessageSource: false,
       onCommitAndPush: vi.fn(),
     });
-    expect(screen.queryByLabelText("Commit and push")).toBeNull();
+    // The composer dialog now collects the message, so the button must show
+    // whenever there are changes — even without a prefilled message source.
+    expect(screen.queryByLabelText("Commit and push")).not.toBeNull();
   });
 
   it('hides the Commit & push button when reviewState is "conflicted"', () => {
     renderSection({
       reviewState: "conflicted",
-      hasCommitMessageSource: true,
       onCommitAndPush: vi.fn(),
       worktree: withChanges({
         changedFileCount: 2,
@@ -342,7 +341,6 @@ describe("WorktreeDetailsSection — reviewState surfaces", () => {
   it("swaps the button for a spinner while committing", () => {
     renderSection({
       reviewState: "has-changes",
-      hasCommitMessageSource: true,
       onCommitAndPush: vi.fn(),
       isCommitting: true,
     });
@@ -353,7 +351,6 @@ describe("WorktreeDetailsSection — reviewState surfaces", () => {
   it("renders an inline error banner with commitError", () => {
     renderSection({
       reviewState: "has-changes",
-      hasCommitMessageSource: true,
       onCommitAndPush: vi.fn(),
       commitError: "Couldn't push to remote",
       clearCommitError: vi.fn(),
@@ -368,7 +365,6 @@ describe("WorktreeDetailsSection — reviewState surfaces", () => {
     const onOpenReviewHub = vi.fn();
     renderSection({
       reviewState: "has-changes",
-      hasCommitMessageSource: true,
       onCommitAndPush: vi.fn(),
       commitError: "Couldn't push to remote",
       clearCommitError,
@@ -383,7 +379,6 @@ describe("WorktreeDetailsSection — reviewState surfaces", () => {
     const clearCommitError = vi.fn();
     renderSection({
       reviewState: "has-changes",
-      hasCommitMessageSource: true,
       commitError: "Couldn't push to remote",
       clearCommitError,
     });
@@ -395,7 +390,6 @@ describe("WorktreeDetailsSection — reviewState surfaces", () => {
     renderSection({
       reviewState: "unpushed-clean",
       hasChanges: false,
-      hasCommitMessageSource: true,
       onCommitAndPush: vi.fn(),
       computedSubtitle: { text: "fix: stuff", tone: "muted" },
       worktree: {
@@ -416,7 +410,6 @@ describe("WorktreeDetailsSection — reviewState surfaces", () => {
     renderSection({
       isExpanded: true,
       reviewState: "has-changes",
-      hasCommitMessageSource: true,
       commitError: "Couldn't push to remote",
       clearCommitError: vi.fn(),
     });

--- a/src/components/Worktree/WorktreeDeleteDialog.tsx
+++ b/src/components/Worktree/WorktreeDeleteDialog.tsx
@@ -9,14 +9,13 @@ import { actionService } from "@/services/ActionService";
 import type { WorktreeState } from "@/types";
 import { cn } from "@/lib/utils";
 import { formatErrorMessage } from "@shared/utils/errorMessage";
+import { isProtectedBranch as isProtectedBranchName } from "@shared/utils/gitConstants";
 
 interface WorktreeDeleteDialogProps {
   isOpen: boolean;
   onClose: () => void;
   worktree: WorktreeState;
 }
-
-const PROTECTED_BRANCHES = ["main", "master", "develop", "development"];
 
 export function WorktreeDeleteDialog({ isOpen, onClose, worktree }: WorktreeDeleteDialogProps) {
   const [isDeleting, setIsDeleting] = useState(false);
@@ -39,8 +38,7 @@ export function WorktreeDeleteDialog({ isOpen, onClose, worktree }: WorktreeDele
   const hasChanges = hasTrackedChanges || hasUntrackedFiles;
   const hasTerminals = terminalCounts.total > 0;
 
-  const isProtectedBranch =
-    !!worktree.branch && PROTECTED_BRANCHES.includes(worktree.branch.toLowerCase());
+  const isProtectedBranch = isProtectedBranchName(worktree.branch?.toLowerCase());
   const isDetachedHead = !worktree.branch;
   const canDeleteBranch =
     !isProtectedBranch && !isDetachedHead && worktree.isMainWorktree === false;

--- a/src/components/Worktree/__tests__/CommitComposerDialog.test.tsx
+++ b/src/components/Worktree/__tests__/CommitComposerDialog.test.tsx
@@ -220,6 +220,31 @@ describe("CommitComposerDialog", () => {
     expect(submit.disabled).toBe(false);
   });
 
+  it("treats 'development' as a protected branch", () => {
+    const { container } = render(
+      <CommitComposerDialog
+        {...makeProps({ branch: "development", commitMessage: "chore: bump" })}
+      />
+    );
+    expect(container.textContent).toContain("Committing directly to");
+    expect(
+      (screen.getByRole("button", { name: /Commit & push/ }) as HTMLButtonElement).disabled
+    ).toBe(true);
+  });
+
+  it("normalizes mixed-case branch names when checking protection", () => {
+    const mainCase = render(
+      <CommitComposerDialog {...makeProps({ branch: "Main", commitMessage: "x" })} />
+    );
+    expect(mainCase.container.textContent).toContain("Committing directly to");
+    cleanup();
+
+    render(<CommitComposerDialog {...makeProps({ branch: "DEVELOP", commitMessage: "x" })} />);
+    expect(
+      (screen.getByRole("button", { name: /Commit & push/ }) as HTMLButtonElement).disabled
+    ).toBe(true);
+  });
+
   it("treats main and master as protected branches", () => {
     const mainRender = render(
       <CommitComposerDialog {...makeProps({ branch: "main", commitMessage: "x" })} />

--- a/src/components/Worktree/__tests__/CommitComposerDialog.test.tsx
+++ b/src/components/Worktree/__tests__/CommitComposerDialog.test.tsx
@@ -1,0 +1,319 @@
+/**
+ * @vitest-environment jsdom
+ */
+import { describe, it, expect, vi, beforeEach, afterEach } from "vitest";
+import { render, screen, cleanup, fireEvent } from "@testing-library/react";
+import type { FileChangeDetail } from "@shared/types/git";
+
+vi.stubGlobal(
+  "ResizeObserver",
+  class {
+    observe() {}
+    unobserve() {}
+    disconnect() {}
+  }
+);
+
+vi.mock("@/components/ui/AppDialog", () => {
+  const Dialog = ({
+    children,
+    isOpen,
+  }: {
+    children: React.ReactNode;
+    isOpen: boolean;
+    onClose?: () => void;
+    size?: string;
+    dismissible?: boolean;
+    maxHeight?: string;
+    variant?: string;
+    "data-testid"?: string;
+  }) => (isOpen ? <div data-testid="commit-composer-dialog">{children}</div> : null);
+  Dialog.Header = ({ children }: { children: React.ReactNode }) => <div>{children}</div>;
+  Dialog.Title = ({ children }: { children: React.ReactNode }) => <h2>{children}</h2>;
+  Dialog.CloseButton = () => <button aria-label="Close dialog">×</button>;
+  Dialog.Body = ({ children }: { children: React.ReactNode }) => <div>{children}</div>;
+  Dialog.Footer = ({
+    primaryAction,
+    secondaryAction,
+  }: {
+    primaryAction?: {
+      label: string;
+      onClick: () => void;
+      disabled?: boolean;
+      loading?: boolean;
+    };
+    secondaryAction?: { label: string; onClick: () => void; disabled?: boolean };
+    hint?: React.ReactNode;
+  }) => (
+    <div>
+      {secondaryAction && (
+        <button onClick={secondaryAction.onClick} disabled={secondaryAction.disabled}>
+          {secondaryAction.label}
+        </button>
+      )}
+      {primaryAction && (
+        <button
+          onClick={primaryAction.onClick}
+          disabled={primaryAction.disabled || primaryAction.loading}
+        >
+          {primaryAction.label}
+        </button>
+      )}
+    </div>
+  );
+  return { AppDialog: Dialog };
+});
+
+vi.mock("@/components/Worktree/DiffViewer", () => ({
+  DiffViewer: ({ diff }: { diff: string }) => <div data-testid="mock-diff-viewer">{diff}</div>,
+}));
+
+vi.mock("@/components/Worktree/FileChangeList", () => ({
+  FileChangeList: ({ changes }: { changes: FileChangeDetail[] }) => (
+    <ul data-testid="mock-file-list">
+      {changes.map((c) => (
+        <li key={c.path}>{c.path}</li>
+      ))}
+    </ul>
+  ),
+}));
+
+vi.mock("@/hooks/useDeferredLoading", () => ({
+  // Make the loading skeleton appear synchronously in tests
+  useDeferredLoading: (isPending: boolean) => isPending,
+}));
+
+vi.mock("@/services/ActionService", () => ({
+  actionService: { dispatch: vi.fn() },
+}));
+
+import { CommitComposerDialog, type CommitComposerDialogProps } from "../CommitComposerDialog";
+
+const baseProps: CommitComposerDialogProps = {
+  isOpen: true,
+  onClose: vi.fn(),
+  onConfirm: vi.fn(),
+  isSubmitting: false,
+  commitMessage: "",
+  onCommitMessageChange: vi.fn(),
+  branch: "feature/x",
+  tracking: "origin/feature/x",
+  changes: [
+    {
+      path: "src/a.ts",
+      status: "modified",
+      insertions: 3,
+      deletions: 1,
+    },
+  ],
+  rootPath: "/repo",
+  diff: "diff --git a/src/a.ts b/src/a.ts\n@@ -1,1 +1,1 @@\n-old\n+new\n",
+  isDiffLoading: false,
+  diffError: null,
+  submitError: null,
+};
+
+function makeProps(overrides: Partial<CommitComposerDialogProps> = {}): CommitComposerDialogProps {
+  return { ...baseProps, ...overrides };
+}
+
+describe("CommitComposerDialog", () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+  });
+
+  afterEach(() => {
+    cleanup();
+  });
+
+  it("renders nothing when closed", () => {
+    render(<CommitComposerDialog {...makeProps({ isOpen: false })} />);
+    expect(screen.queryByTestId("commit-composer-dialog")).toBeNull();
+  });
+
+  it("renders with an empty textarea when no commit message is provided", () => {
+    render(<CommitComposerDialog {...makeProps({ commitMessage: "" })} />);
+    const textarea = screen.getByLabelText("Commit message") as HTMLTextAreaElement;
+    expect(textarea.value).toBe("");
+  });
+
+  it("displays the prefilled commit message (e.g. from an AI note)", () => {
+    render(<CommitComposerDialog {...makeProps({ commitMessage: "fix(thing): do X" })} />);
+    const textarea = screen.getByLabelText("Commit message") as HTMLTextAreaElement;
+    expect(textarea.value).toBe("fix(thing): do X");
+  });
+
+  it("disables the submit button when the message is empty", () => {
+    render(<CommitComposerDialog {...makeProps({ commitMessage: "" })} />);
+    const submit = screen.getByRole("button", { name: /Commit & push/ }) as HTMLButtonElement;
+    expect(submit.disabled).toBe(true);
+  });
+
+  it("disables the submit button when the message is whitespace only", () => {
+    render(<CommitComposerDialog {...makeProps({ commitMessage: "   " })} />);
+    const submit = screen.getByRole("button", { name: /Commit & push/ }) as HTMLButtonElement;
+    expect(submit.disabled).toBe(true);
+  });
+
+  it("enables the submit button with a non-empty message on a non-protected branch", () => {
+    render(<CommitComposerDialog {...makeProps({ commitMessage: "fix: bug" })} />);
+    const submit = screen.getByRole("button", { name: /Commit & push/ }) as HTMLButtonElement;
+    expect(submit.disabled).toBe(false);
+  });
+
+  it("calls onConfirm with the trimmed message on submit", () => {
+    const onConfirm = vi.fn();
+    render(<CommitComposerDialog {...makeProps({ commitMessage: "  fix: bug  ", onConfirm })} />);
+    fireEvent.click(screen.getByRole("button", { name: /Commit & push/ }));
+    expect(onConfirm).toHaveBeenCalledWith("fix: bug");
+  });
+
+  it("calls onClose when Cancel is clicked", () => {
+    const onClose = vi.fn();
+    render(<CommitComposerDialog {...makeProps({ onClose })} />);
+    fireEvent.click(screen.getByRole("button", { name: "Cancel" }));
+    expect(onClose).toHaveBeenCalledTimes(1);
+  });
+
+  it("does NOT call onConfirm or any git mutation when Cancel is clicked", () => {
+    const onConfirm = vi.fn();
+    const onClose = vi.fn();
+    render(
+      <CommitComposerDialog {...makeProps({ commitMessage: "fix: bug", onConfirm, onClose })} />
+    );
+    fireEvent.click(screen.getByRole("button", { name: "Cancel" }));
+    expect(onConfirm).not.toHaveBeenCalled();
+    expect(onClose).toHaveBeenCalledTimes(1);
+  });
+
+  it("propagates textarea edits via onCommitMessageChange", () => {
+    const onCommitMessageChange = vi.fn();
+    render(
+      <CommitComposerDialog {...makeProps({ commitMessage: "fix:", onCommitMessageChange })} />
+    );
+    const textarea = screen.getByLabelText("Commit message");
+    fireEvent.change(textarea, { target: { value: "fix: thing" } });
+    expect(onCommitMessageChange).toHaveBeenCalledWith("fix: thing");
+  });
+
+  it("on a protected branch, shows a warning and gates submit behind the 'I understand' checkbox", () => {
+    const { container } = render(
+      <CommitComposerDialog
+        {...makeProps({
+          branch: "develop",
+          tracking: "origin/develop",
+          commitMessage: "chore: bump",
+        })}
+      />
+    );
+
+    // Warning copy mentioning the protected branch
+    expect(container.textContent).toContain("Committing directly to");
+    expect(container.textContent).toContain("develop");
+
+    const submit = screen.getByRole("button", { name: /Commit & push/ }) as HTMLButtonElement;
+    expect(submit.disabled).toBe(true);
+
+    const checkbox = screen.getByRole("checkbox");
+    fireEvent.click(checkbox);
+
+    expect(submit.disabled).toBe(false);
+  });
+
+  it("treats main and master as protected branches", () => {
+    const mainRender = render(
+      <CommitComposerDialog {...makeProps({ branch: "main", commitMessage: "x" })} />
+    );
+    expect(mainRender.container.textContent).toContain("Committing directly to");
+    expect(
+      (screen.getByRole("button", { name: /Commit & push/ }) as HTMLButtonElement).disabled
+    ).toBe(true);
+
+    cleanup();
+
+    render(<CommitComposerDialog {...makeProps({ branch: "master", commitMessage: "x" })} />);
+    expect(
+      (screen.getByRole("button", { name: /Commit & push/ }) as HTMLButtonElement).disabled
+    ).toBe(true);
+  });
+
+  it("does not show a protected-branch warning on a feature branch", () => {
+    const { container } = render(
+      <CommitComposerDialog
+        {...makeProps({
+          branch: "feature/whatever",
+          commitMessage: "feat: x",
+        })}
+      />
+    );
+    expect(container.textContent).not.toContain("Committing directly to");
+    expect(screen.queryByRole("checkbox")).toBeNull();
+  });
+
+  it("renders the diff when loaded", () => {
+    render(<CommitComposerDialog {...makeProps({ commitMessage: "x" })} />);
+    expect(screen.getByTestId("mock-diff-viewer")).toBeDefined();
+  });
+
+  it("shows a loading skeleton while the diff is loading", () => {
+    render(
+      <CommitComposerDialog
+        {...makeProps({ isDiffLoading: true, diff: null, commitMessage: "x" })}
+      />
+    );
+    expect(screen.getByLabelText("Loading diff")).toBeDefined();
+    expect(screen.queryByTestId("mock-diff-viewer")).toBeNull();
+  });
+
+  it("renders a diff-error message instead of the diff viewer when diffError is set", () => {
+    render(
+      <CommitComposerDialog
+        {...makeProps({
+          diff: null,
+          diffError: "EPERM: read denied",
+          commitMessage: "fix: x",
+        })}
+      />
+    );
+    expect(screen.getByText(/Couldn't load diff preview/)).toBeDefined();
+    expect(screen.queryByTestId("mock-diff-viewer")).toBeNull();
+    // The user can still commit
+    expect(
+      (screen.getByRole("button", { name: /Commit & push/ }) as HTMLButtonElement).disabled
+    ).toBe(false);
+  });
+
+  it("displays the tracked file count in the header", () => {
+    const changes: FileChangeDetail[] = [
+      { path: "a.ts", status: "modified", insertions: 1, deletions: 0 },
+      { path: "b.ts", status: "added", insertions: 1, deletions: 0 },
+      { path: "untracked.txt", status: "untracked", insertions: null, deletions: null },
+    ];
+    const { container } = render(
+      <CommitComposerDialog {...makeProps({ changes, commitMessage: "x" })} />
+    );
+    // Header shows tracked-only count (2 of 3)
+    expect(container.textContent).toContain("2 files tracked");
+  });
+
+  it("shows a submit-error banner when submitError is set", () => {
+    render(
+      <CommitComposerDialog
+        {...makeProps({ submitError: "Couldn't push to remote", commitMessage: "x" })}
+      />
+    );
+    expect(screen.getByText("Couldn't push to remote")).toBeDefined();
+  });
+
+  it("disables submit and cancel while isSubmitting", () => {
+    render(
+      <CommitComposerDialog {...makeProps({ isSubmitting: true, commitMessage: "fix: x" })} />
+    );
+    expect(
+      (screen.getByRole("button", { name: /Commit & push/ }) as HTMLButtonElement).disabled
+    ).toBe(true);
+    expect((screen.getByRole("button", { name: "Cancel" }) as HTMLButtonElement).disabled).toBe(
+      true
+    );
+  });
+});


### PR DESCRIPTION
## Summary

- The one-click commit & push button on worktree cards ran `git.stageAll` → `git.commit` → `git.push` with no review step, and silently fell back to the previous commit's subject when no AI note was attached. A real incident on `origin/develop` pushed a commit whose message was copied from a merge commit, making it look like a duplicate PR merge while actually containing three unrelated UI files.
- This adds a `CommitComposerDialog` that intercepts the button click. The dialog shows a per-file diff, an editable commit message pre-filled from the AI note only (never from the previous commit subject), and the target branch. Pushing to `develop`, `main`, or `master` adds an extra confirmation step before the push fires.
- The `lastCommitFirstLine` fallback in `WorktreeCard.tsx` is removed entirely — there's no scenario where reusing the previous subject is correct.

Resolves #7880

## Changes

- `src/components/Worktree/CommitComposerDialog.tsx` — new dialog component with diff view, message editor, branch confirmation, and protected-branch guard
- `src/components/Worktree/WorktreeCard.tsx` — button now opens the dialog instead of committing inline; `lastCommitFirstLine` fallback removed
- `src/components/Worktree/WorktreeCard/WorktreeDialogs.tsx` — dialog slot wired into the card's dialog layer
- `src/components/Worktree/WorktreeCard/WorktreeDetailsSection.tsx` — button handler threaded through to open dialog
- `shared/utils/gitConstants.ts` — `PROTECTED_BRANCHES` constant (`develop`, `main`, `master`) shared between dialog and any future callers
- `src/__tests__/CommitComposerDialog.test.tsx` — 344-line unit test suite covering message pre-fill, protected-branch guard, cancel, and push-retry
- `src/components/Worktree/__tests__/WorktreeDetailsSection.test.tsx` — updated to reflect handler change

## Testing

- Unit tests pass: `CommitComposerDialog.test.tsx` covers message pre-fill from AI note, blank default when no note, protected-branch extra-confirmation step, cancel without side effects, and push-retry on failure.
- Manually verified: clicking commit & push on a worktree card opens the dialog, diff renders correctly, message field is editable, pushing to `develop` shows the confirmation step, cancel leaves the worktree unchanged.