### PR TITLE
fix(copilot): fix input field stop accepting commands after prolonged use

### DIFF
--- a/electron/services/pty/__tests__/TerminalProcess.submit.test.ts
+++ b/electron/services/pty/__tests__/TerminalProcess.submit.test.ts
@@ -127,7 +127,7 @@ describe("TerminalProcess.submit", () => {
     vi.useRealTimers();
   });
 
-  it("sends Enter immediately for Copilot with submitEnterDelayMs: 0", async () => {
+  it("delays Enter for Copilot (submitEnterDelayMs: 200) so Ink TUI registers input", async () => {
     vi.useFakeTimers();
     const terminal = createTerminal({ kind: "terminal", launchAgentId: "copilot" });
     // Input protocol is driven by detectedAgentId (live process), not the launch hint.
@@ -141,6 +141,9 @@ describe("TerminalProcess.submit", () => {
     expect(ptyWriteMock).toHaveBeenCalledTimes(1);
     expect(ptyWriteMock).toHaveBeenLastCalledWith("test");
     await vi.advanceTimersByTimeAsync(50);
+    expect(ptyWriteMock).toHaveBeenCalledTimes(1);
+    await vi.advanceTimersByTimeAsync(200);
+    expect(ptyWriteMock).toHaveBeenCalledTimes(2);
     expect(ptyWriteMock).toHaveBeenLastCalledWith("\r");
     vi.useRealTimers();
   });

--- a/shared/config/__tests__/agentRegistry.test.ts
+++ b/shared/config/__tests__/agentRegistry.test.ts
@@ -814,6 +814,11 @@ describe("copilot configuration", () => {
     expect(config?.capabilities?.submitEnterDelayMs).toBeGreaterThanOrEqual(200);
   });
 
+  it("uses single-write quit so /exit submits as one write (Ink TUI constraint)", () => {
+    const config = getAgentConfig("copilot");
+    expect(config?.capabilities?.quitSubmitMode).toBe("single-write");
+  });
+
   it("has correct npm package and GitHub repo", () => {
     const config = getAgentConfig("copilot");
     expect(config?.version?.npmPackage).toBe("@github/copilot");

--- a/shared/config/__tests__/agentRegistry.test.ts
+++ b/shared/config/__tests__/agentRegistry.test.ts
@@ -809,6 +809,11 @@ describe("copilot configuration", () => {
     expect(config?.capabilities?.blockAltScreen).toBeUndefined();
   });
 
+  it("uses submitEnterDelayMs >= 200 so Ink TUI registers input before CR (issue #5830)", () => {
+    const config = getAgentConfig("copilot");
+    expect(config?.capabilities?.submitEnterDelayMs).toBeGreaterThanOrEqual(200);
+  });
+
   it("has correct npm package and GitHub repo", () => {
     const config = getAgentConfig("copilot");
     expect(config?.version?.npmPackage).toBe("@github/copilot");

--- a/shared/config/agents/copilot.ts
+++ b/shared/config/agents/copilot.ts
@@ -86,6 +86,10 @@ export const config: AgentConfig = {
     supportsBracketedPaste: true,
     // Ink TUI needs a gap between pasted body and the CR submit; see issue #5830.
     submitEnterDelayMs: 200,
+    // Same Ink-TUI constraint applies to /exit on shutdown: the body and CR must
+    // arrive as one write, or Copilot treats the gap as slow typing and never
+    // submits the slash command. Matches Claude (also Ink-based).
+    quitSubmitMode: "single-write",
   },
   detection: {
     primaryPatterns: ["\\(Esc to cancel\\)", "[∙∘○◎◉]\\s+.+\\(Esc to cancel\\)"],

--- a/shared/config/agents/copilot.ts
+++ b/shared/config/agents/copilot.ts
@@ -84,7 +84,8 @@ export const config: AgentConfig = {
     blockMouseReporting: true,
     resizeStrategy: "settled",
     supportsBracketedPaste: true,
-    submitEnterDelayMs: 0,
+    // Ink TUI needs a gap between pasted body and the CR submit; see issue #5830.
+    submitEnterDelayMs: 200,
   },
   detection: {
     primaryPatterns: ["\\(Esc to cancel\\)", "[∙∘○◎◉]\\s+.+\\(Esc to cancel\\)"],


### PR DESCRIPTION
## Summary

- `submitEnterDelayMs` was set to `0` in `copilot.ts`, causing the carriage return to arrive at Copilot's Ink TUI in the same event-loop turn as the pasted text — before Ink's input handler had registered it. The result: commands silently dropped after a while.
- Set `submitEnterDelayMs` to `200ms` (the established codebase default) to give Ink time to register the Enter keypress.
- Set `quitSubmitMode` to `single-write` to close the same race on `/exit` shutdown.

Resolves #5830

## Changes

- `shared/config/agents/copilot.ts` — `submitEnterDelayMs` `0` → `200`, `quitSubmitMode` → `"single-write"`, explanatory comments
- `electron/services/pty/__tests__/TerminalProcess.submit.test.ts` — inverted to assert the delayed-Enter behaviour; pins the bug pre-fix
- `shared/config/__tests__/agentRegistry.test.ts` — two regression-guard assertions in the copilot describe block (`submitEnterDelayMs >= 200`, `quitSubmitMode === "single-write"`)

## Testing

- 6 tests in `TerminalProcess.submit.test.ts` — pass
- 263 tests in `agentRegistry.test.ts` — pass
- Full check (typecheck, lint:ratchet, format:check, build) — pass