### PR TITLE
fix(pty-pool): destroy pooled PTYs and add per-key circuit breaker

### DIFF
--- a/electron/services/PtyPool.ts
+++ b/electron/services/PtyPool.ts
@@ -226,6 +226,13 @@ export class PtyPool {
       }
     }
 
+    // drainAndRefill() ends with warmPool(), which would otherwise let a
+    // post-trip project switch re-enter the crash loop on the same blocked
+    // (cwd, env-empty) key. Gate warmPool with the same breaker as refillPool.
+    if (this.isKeyBlocked(makePoolKey(this.defaultCwd, POOL_ENV_EMPTY_HASH))) {
+      return;
+    }
+
     const promises: Promise<void>[] = [];
     const existing = this.countEntriesForKey(this.defaultCwd, POOL_ENV_EMPTY_HASH);
     const needed = this.poolSize - existing;
@@ -317,8 +324,13 @@ export class PtyPool {
         }
         entry.alive = false;
         entry.dataDisposable.dispose();
-        destroyPty(entry.process);
+        // Remove from the pool BEFORE destroying. Real node-pty delivers
+        // onExit via libuv (always async), so synchronous re-entry can't
+        // happen — but the invariant "removed from map → never re-observed"
+        // matches dispose()/evictIfAtCapacity()/drainAndRefill() and makes
+        // the code easier to reason about.
         this.pool.delete(id);
+        destroyPty(entry.process);
         this.recordFastExit(entry.poolKey, entry.createdAt);
         // Skip refill if this entry belonged to a prior drain cycle — a
         // newer drainAndRefill() already initiated its own refill.

--- a/electron/services/PtyPool.ts
+++ b/electron/services/PtyPool.ts
@@ -31,6 +31,13 @@ interface PooledPty {
   dataDisposable: IDisposable;
   dataHandoff?: BufferedPtyDataHandoff;
   /**
+   * Set false in the onExit handler so acquireByKey can reject entries whose
+   * process has exited even though the JS object still references a defined
+   * pid. The previous `pid !== undefined` liveness probe was always truthy
+   * because pid stays set for the lifetime of the IPty wrapper.
+   */
+  alive: boolean;
+  /**
    * Bounded buffer of shell-init output (banner, MOTD, first prompt) emitted
    * before this entry was acquired. Replayed on acquire so the consumer's
    * xterm sees the prompt the user expects. Without this, fast Macs that
@@ -39,6 +46,11 @@ interface PooledPty {
    * after the prompt and stays blank. See PR for #7625.
    */
   prelude: string;
+}
+
+interface PoolFailureState {
+  count: number;
+  blockedUntil: number;
 }
 
 const DEFAULT_POOL_SIZE = 2;
@@ -50,6 +62,45 @@ const DEFAULT_MAX_ENTRIES = 8;
  * dropped, which matches the prior (unbuffered) behaviour for that overflow.
  */
 const PRELUDE_BYTE_CAP = 64 * 1024;
+
+/**
+ * Window in which an exit is treated as a crash rather than a normal exit.
+ * Combined with `MAX_KEY_FAILURES` and `KEY_BACKOFF_MS`, this gates the
+ * onExit→refill cascade for a misconfigured (cwd, envHash) key whose shell
+ * exits immediately on spawn (rc syntax error, missing binary, etc.).
+ */
+const FAST_EXIT_THRESHOLD_MS = 2_000;
+const MAX_KEY_FAILURES = 3;
+const KEY_BACKOFF_MS = 30_000;
+
+/**
+ * Closes a pooled PTY's master/slave file descriptors. node-pty's `kill()`
+ * only signals the child process; on Unix the `/dev/ptmx` master FD stays
+ * open until `destroy()` is called (or the IPty wrapper is GC'd, but the
+ * native binding retains a reference until then). Without this, every
+ * pool-exit path leaks an FD — and #7892 showed the crash-loop multiplied
+ * the leak by ~60 FDs/iter until the system-wide `ptmx_max` (≈511 on macOS)
+ * was hit.
+ *
+ * `destroy()` exists on UnixTerminal and WindowsTerminal but is not on the
+ * exported `IPty` TypeScript interface; access it structurally and fall back
+ * to `kill()` when missing (e.g. test mocks). Both calls are wrapped in
+ * try/catch because either may throw on an already-dead handle.
+ */
+export function destroyPty(p: pty.IPty): void {
+  const withDestroy = p as pty.IPty & { destroy?: () => void };
+  try {
+    withDestroy.destroy?.();
+  } catch {
+    // Already destroyed or socket closed — destroy() is idempotent in node-pty,
+    // but mocks/future versions may throw.
+  }
+  try {
+    p.kill();
+  } catch {
+    // Already dead — ESRCH on Unix, similar on Windows.
+  }
+}
 
 export interface AcquiredPty {
   process: pty.IPty;
@@ -139,6 +190,14 @@ export class PtyPool {
    */
   private readonly warmsInFlight: Set<string> = new Set();
   /**
+   * Per-key fast-exit accounting. Incremented whenever a pool entry's onExit
+   * fires within FAST_EXIT_THRESHOLD_MS of spawn; trips the circuit breaker
+   * at MAX_KEY_FAILURES and holds it for KEY_BACKOFF_MS. Without this the
+   * onExit→refillPool cascade for a doomed (cwd, envHash) is unbounded and
+   * leaks an FD per cycle (#7892).
+   */
+  private readonly keyFailures: Map<string, PoolFailureState> = new Map();
+  /**
    * Generation counter incremented on each drainAndRefill() call.
    * Captured in createPoolEntry closures so async spawns from a prior
    * drain cycle can be rejected instead of registering at the new cwd.
@@ -222,6 +281,7 @@ export class PtyPool {
         env,
         createdAt: Date.now(),
         dataDisposable: { dispose: () => {} },
+        alive: true,
         prelude: "",
       };
 
@@ -251,11 +311,15 @@ export class PtyPool {
         const entry = this.pool.get(id);
         if (!entry) {
           // Entry was already removed (drain, evict, or acquire path). Those
-          // paths handle their own followup; refilling here would race them.
+          // paths handle their own followup and FD cleanup; refilling or
+          // counting failures here would race them.
           return;
         }
+        entry.alive = false;
         entry.dataDisposable.dispose();
+        destroyPty(entry.process);
         this.pool.delete(id);
+        this.recordFastExit(entry.poolKey, entry.createdAt);
         // Skip refill if this entry belonged to a prior drain cycle — a
         // newer drainAndRefill() already initiated its own refill.
         if (!this.isDisposed && this.drainEpoch === epoch) {
@@ -265,11 +329,7 @@ export class PtyPool {
 
       if (this.isDisposed || this.drainEpoch !== epoch) {
         dataDisposable.dispose();
-        try {
-          ptyProcess.kill();
-        } catch {
-          // already dead
-        }
+        destroyPty(ptyProcess);
         return;
       }
 
@@ -328,17 +388,29 @@ export class PtyPool {
     const { id, entry } = matched;
     this.pool.delete(id);
 
-    try {
-      const pid = entry.process.pid;
-      if (pid === undefined) {
-        console.warn(`[PtyPool] Pooled PTY ${id} has no PID (already dead), discarding`);
-        entry.dataDisposable.dispose();
-        this.warmForKey(cwd, entry.env, envHash);
-        return null;
+    // Liveness check. `alive` is set false by the onExit handler — it tracks
+    // actual process exit, unlike the prior `pid !== undefined` probe which
+    // was always truthy because pid persists on the IPty JS wrapper after the
+    // child has exited. The pid undefined branch is kept as a defensive check
+    // for a corrupted spawn handle that never received a pid; both paths fall
+    // through to discard + background warm.
+    let dead = !entry.alive;
+    if (!dead) {
+      try {
+        if (entry.process.pid === undefined) {
+          dead = true;
+        }
+      } catch (error) {
+        console.warn(`[PtyPool] Pooled PTY ${id} health check failed:`, error);
+        dead = true;
       }
-    } catch (error) {
-      console.warn(`[PtyPool] Pooled PTY ${id} health check failed:`, error);
+    }
+
+    if (dead) {
+      console.warn(`[PtyPool] Pooled PTY ${id} already dead, discarding`);
+      entry.alive = false;
       entry.dataDisposable.dispose();
+      destroyPty(entry.process);
       this.warmForKey(cwd, entry.env, envHash);
       return null;
     }
@@ -373,6 +445,7 @@ export class PtyPool {
     if (this.isDisposed) return;
 
     const key = makePoolKey(cwd, envHash);
+    if (this.isKeyBlocked(key)) return;
     if (this.warmsInFlight.has(key)) return;
     if (this.countEntriesForKey(cwd, envHash) >= this.poolSize) return;
 
@@ -388,6 +461,14 @@ export class PtyPool {
 
   refillPool(): void {
     if (this.isDisposed || this.refillInProgress) {
+      return;
+    }
+
+    // Circuit-break before claiming `refillInProgress` so a blocked key
+    // doesn't lock the flag for the cooldown window. The (defaultCwd,
+    // POOL_ENV_EMPTY_HASH) key is the only one refillPool ever warms; the
+    // arbitrary-key path is `warmForKey`, which has its own breaker check.
+    if (this.isKeyBlocked(makePoolKey(this.defaultCwd, POOL_ENV_EMPTY_HASH))) {
       return;
     }
 
@@ -468,18 +549,13 @@ export class PtyPool {
     this.pool.clear();
 
     for (const entry of snapshot) {
+      entry.alive = false;
       try {
         entry.dataDisposable.dispose();
       } catch {
         // ignore
       }
-      try {
-        entry.process.kill();
-      } catch (error) {
-        if (process.env.DAINTREE_VERBOSE) {
-          console.warn("[PtyPool] Error killing pooled PTY during drain:", error);
-        }
-      }
+      destroyPty(entry.process);
     }
 
     if (process.env.DAINTREE_VERBOSE) {
@@ -518,19 +594,26 @@ export class PtyPool {
 
     this.isDisposed = true;
 
-    for (const [id, entry] of this.pool) {
+    // Snapshot + clear BEFORE destroying so the destroyPty→kill→onExit chain
+    // sees an empty pool and skips re-processing the same entry (which would
+    // double-call destroy and dataDisposable.dispose for every entry).
+    const entries = Array.from(this.pool.entries());
+    this.pool.clear();
+
+    for (const [id, entry] of entries) {
+      entry.alive = false;
       try {
         entry.dataDisposable.dispose();
-        entry.process.kill();
-        if (process.env.DAINTREE_VERBOSE) {
-          console.log(`[PtyPool] Killed pooled PTY ${id}`);
-        }
       } catch (error) {
-        console.warn(`[PtyPool] Error killing pooled PTY ${id}:`, error);
+        console.warn(`[PtyPool] Error disposing pooled PTY ${id} data listener:`, error);
+      }
+      destroyPty(entry.process);
+      if (process.env.DAINTREE_VERBOSE) {
+        console.log(`[PtyPool] Killed pooled PTY ${id}`);
       }
     }
 
-    this.pool.clear();
+    this.keyFailures.clear();
     console.log("[PtyPool] Disposed");
   }
 
@@ -559,22 +642,64 @@ export class PtyPool {
     if (!chosen) return;
 
     this.pool.delete(chosen.id);
+    chosen.entry.alive = false;
     try {
       chosen.entry.dataDisposable.dispose();
     } catch {
       // ignore
     }
-    try {
-      chosen.entry.process.kill();
-    } catch {
-      // already dead
-    }
+    destroyPty(chosen.entry.process);
 
     if (process.env.DAINTREE_VERBOSE) {
       console.log(
         `[PtyPool] Evicted ${chosen.id} (key ${chosen.entry.poolKey}) to make room for ${incomingKey}`
       );
     }
+  }
+
+  /**
+   * Circuit-breaker check for the automatic refill paths. Returns true while
+   * `blockedUntil` is in the future. On expiry the entry is deleted so the
+   * count resets lazily — eager reset on a single non-fast exit would let a
+   * borderline-fast shell oscillate the breaker open/closed (lesson from
+   * the powerMonitor circuit breaker, #518).
+   *
+   * `acquireByKey` does NOT consult this — explicit user-triggered acquires
+   * must still get a fresh fall-through spawn. The breaker only gates the
+   * background `refillPool` / `warmForKey` paths that would otherwise burn
+   * FDs in a spawn-exit loop.
+   */
+  private isKeyBlocked(poolKey: string): boolean {
+    const state = this.keyFailures.get(poolKey);
+    if (!state) return false;
+    if (state.blockedUntil > Date.now()) return true;
+    if (state.blockedUntil > 0) {
+      // Cooldown expired — reset so the next fast-exit starts a fresh count.
+      this.keyFailures.delete(poolKey);
+    }
+    return false;
+  }
+
+  /**
+   * Record a pool entry exit. Counts toward the circuit breaker only if the
+   * entry lived <FAST_EXIT_THRESHOLD_MS — a normal long-lived idle exit
+   * (system going to sleep, user killing the shell after acquire, etc.)
+   * shouldn't accumulate failures.
+   */
+  private recordFastExit(poolKey: string, createdAt: number): void {
+    const lifetime = Date.now() - createdAt;
+    if (lifetime >= FAST_EXIT_THRESHOLD_MS) return;
+
+    const state = this.keyFailures.get(poolKey) ?? { count: 0, blockedUntil: 0 };
+    state.count += 1;
+    if (state.count >= MAX_KEY_FAILURES) {
+      state.blockedUntil = Date.now() + KEY_BACKOFF_MS;
+      console.warn(
+        `[PtyPool] Circuit breaker tripped for key ${poolKey} after ${state.count} fast exits — ` +
+          `pausing refill for ${KEY_BACKOFF_MS}ms`
+      );
+    }
+    this.keyFailures.set(poolKey, state);
   }
 
   /**

--- a/electron/services/__tests__/PtyPool.test.ts
+++ b/electron/services/__tests__/PtyPool.test.ts
@@ -12,6 +12,7 @@ interface FakePtyProcess {
   onData: ReturnType<typeof vi.fn>;
   onExit: ReturnType<typeof vi.fn>;
   kill: ReturnType<typeof vi.fn>;
+  destroy: ReturnType<typeof vi.fn>;
   emitExit: (exitCode: number) => void;
 }
 
@@ -22,7 +23,7 @@ interface FakePtyProcessWithEmit extends FakePtyProcess {
 
 function createFakeProcess(
   pid: number | "missing" = 100,
-  options: { emitDuringOnData?: string[] } = {}
+  options: { emitDuringOnData?: string[]; markDeadOnAcquire?: boolean } = {}
 ): FakePtyProcessWithEmit {
   let onExitHandler: ((event: { exitCode: number }) => void) | null = null;
   const dataHandlers = new Set<(chunk: string) => void>();
@@ -54,6 +55,10 @@ function createFakeProcess(
         onExitHandler?.({ exitCode: 0 });
       }
     }),
+    // destroy() is called by destroyPty() to close the master FD. Real node-pty
+    // also fires onExit via SIGHUP, but the helper calls kill() too so the
+    // mock doesn't need to double-emit here.
+    destroy: vi.fn(),
     emitExit: (exitCode: number) => {
       alive = false;
       onExitHandler?.({ exitCode });
@@ -70,6 +75,17 @@ function createFakeProcess(
  * to flush the microtask queue before asserting on its side effects.
  */
 const flushMicrotasks = () => Promise.resolve();
+
+/**
+ * Drain enough microtask ticks for `refillPool`'s `.then().catch().finally()`
+ * chain to clear `refillInProgress`. A single `await Promise.resolve()` only
+ * advances one microtask, but the chain needs ~3-4 to settle.
+ */
+const settleRefill = async () => {
+  for (let i = 0; i < 6; i++) {
+    await Promise.resolve();
+  }
+};
 
 describe("PtyPool", () => {
   const originalShell = process.env.SHELL;
@@ -535,6 +551,265 @@ describe("PtyPool", () => {
 
       expect(spawnMock).toHaveBeenCalledTimes(1);
       pool.dispose();
+    });
+
+    it("destroys the pooled PTY on unexpected exit so the master FD is released (#7892)", async () => {
+      const first = createFakeProcess(2001);
+      const second = createFakeProcess(2002);
+      spawnMock.mockReturnValueOnce(first).mockReturnValueOnce(second);
+
+      const pool = new PtyPool({ poolSize: 1, defaultCwd: "/repo" });
+      await pool.warmPool();
+
+      // emitExit simulates the kernel teardown (e.g. shell rc syntax error
+      // killing the shell on startup). destroy() must be called by the pool
+      // so /dev/ptmx is closed; kill() alone leaves it open and contributes
+      // to the system-wide ptmx_max leak that #7892 reported.
+      first.emitExit(1);
+
+      expect(first.destroy).toHaveBeenCalledTimes(1);
+      pool.dispose();
+    });
+
+    it("destroys pooled PTYs during dispose() so dispose leaks no FDs", async () => {
+      const proc = createFakeProcess(2101);
+      spawnMock.mockReturnValueOnce(proc);
+      const pool = new PtyPool({ poolSize: 1, defaultCwd: "/repo" });
+      await pool.warmPool();
+
+      pool.dispose();
+
+      expect(proc.destroy).toHaveBeenCalledTimes(1);
+    });
+
+    it("destroys pooled PTYs during drainAndRefill() so cwd transitions leak no FDs", async () => {
+      const initial = createFakeProcess(2201);
+      const refilled = createFakeProcess(2202);
+      spawnMock.mockReturnValueOnce(initial).mockReturnValueOnce(refilled);
+
+      const pool = new PtyPool({ poolSize: 1, defaultCwd: "/home/tester" });
+      await pool.warmPool();
+
+      await pool.drainAndRefill("/repo");
+
+      expect(initial.destroy).toHaveBeenCalledTimes(1);
+      pool.dispose();
+    });
+
+    it("destroys pooled PTYs during LRU eviction so capacity transitions leak no FDs", async () => {
+      const procs = [createFakeProcess(2301), createFakeProcess(2302), createFakeProcess(2303)];
+      let i = 0;
+      spawnMock.mockImplementation(() => procs[i++] ?? createFakeProcess(2399));
+
+      const pool = new PtyPool({ poolSize: 1, defaultCwd: "/repo", maxEntries: 2 });
+
+      pool.warmForKey("/repo", undefined, "env-a");
+      await flushMicrotasks();
+      pool.warmForKey("/repo", undefined, "env-b");
+      await flushMicrotasks();
+      pool.warmForKey("/repo", undefined, "env-c");
+      await flushMicrotasks();
+
+      // env-a was the victim — must be destroyed (not just killed).
+      expect(procs[0]?.destroy).toHaveBeenCalledTimes(1);
+      pool.dispose();
+    });
+
+    it("blocks refill after MAX_KEY_FAILURES fast exits to prevent crash-loop FD leak (#7892)", async () => {
+      // Consecutive fast exits should trip the circuit breaker. The refill
+      // that would otherwise be triggered by the post-trip onExit→refillPool
+      // must NOT happen — otherwise a misconfigured shell crash-loops the
+      // pool and burns ~60 FDs per cycle (the FD leak in #7892).
+      const procs = Array.from({ length: 8 }, (_, idx) => createFakeProcess(3000 + idx));
+      let i = 0;
+      spawnMock.mockImplementation(() => procs[i++] ?? createFakeProcess(3999));
+
+      const pool = new PtyPool({ poolSize: 1, defaultCwd: "/repo" });
+      await pool.warmPool();
+
+      // Walk the chain: each emitExit removes the current entry and (when
+      // the breaker is open) refillPool replaces it synchronously. We must
+      // drain the `.then().finally()` chain between exits to clear
+      // `refillInProgress`; otherwise sequential refills are dropped.
+      let callIdx = 0;
+      while (callIdx < procs.length) {
+        const before = spawnMock.mock.calls.length;
+        procs[callIdx]?.emitExit(1);
+        await settleRefill();
+        const after = spawnMock.mock.calls.length;
+        callIdx += 1;
+        if (after === before) {
+          // No new spawn — breaker is now blocking refill.
+          break;
+        }
+      }
+
+      // The breaker should have tripped before exhausting all the procs.
+      // We don't pin the exact spawn count (it depends on timing of
+      // `refillInProgress` clearing across microtasks); we pin the
+      // observable invariant: pool ends up empty AND the next fast exit
+      // does not trigger a new spawn.
+      expect(pool.getPoolSize()).toBe(0);
+      const spawnsAtBlock = spawnMock.mock.calls.length;
+      procs[callIdx]?.emitExit(1);
+      await settleRefill();
+      expect(spawnMock).toHaveBeenCalledTimes(spawnsAtBlock);
+      pool.dispose();
+    });
+
+    it("blocks warmForKey for a key whose breaker has tripped", async () => {
+      // Force the breaker on env-x by tripping fast exits via warmForKey,
+      // then verify a fresh warmForKey for the same key is a no-op.
+      const procs = Array.from({ length: 6 }, (_, idx) => createFakeProcess(3500 + idx));
+      let i = 0;
+      spawnMock.mockImplementation(() => procs[i++] ?? createFakeProcess(3599));
+
+      const pool = new PtyPool({ poolSize: 1, defaultCwd: "/repo" });
+
+      // First warmForKey + immediate fast exit, repeated. Each fast exit
+      // calls refillPool, but refillPool only warms the env-empty key — for
+      // arbitrary keys we drive the loop manually via warmForKey.
+      for (let k = 0; k < 5; k++) {
+        pool.warmForKey("/repo", undefined, "env-x");
+        await settleRefill();
+        // Find the entry in the pool for env-x (if any) and emit exit on
+        // the underlying fake. We use the test-known proc index since each
+        // warmForKey produces exactly one spawn until the breaker trips.
+        const spawnedCount = spawnMock.mock.calls.length;
+        const proc = procs[spawnedCount - 1];
+        if (proc) proc.emitExit(1);
+        await settleRefill();
+      }
+
+      const spawnsAtBlock = spawnMock.mock.calls.length;
+      pool.warmForKey("/repo", undefined, "env-x");
+      await settleRefill();
+      // No new spawn — breaker is gating warmForKey.
+      expect(spawnMock).toHaveBeenCalledTimes(spawnsAtBlock);
+      pool.dispose();
+    });
+
+    it("does not count long-lived idle exits toward the circuit breaker", async () => {
+      // Long-lived (>FAST_EXIT_THRESHOLD_MS) exits should never trip the
+      // breaker — only fast exits indicate a misconfigured key. Use a
+      // monotonically-advancing Date.now mock so each entry's lifetime
+      // crosses the threshold without relying on fake timers (which
+      // wouldn't help since the implementation reads Date.now() directly).
+      const procs = Array.from({ length: 8 }, (_, idx) => createFakeProcess(4000 + idx));
+      let i = 0;
+      spawnMock.mockImplementation(() => procs[i++] ?? createFakeProcess(4999));
+
+      const realNow = Date.now.bind(Date);
+      let nowOffset = 0;
+      const nowSpy = vi.spyOn(Date, "now").mockImplementation(() => realNow() + nowOffset);
+
+      try {
+        const pool = new PtyPool({ poolSize: 1, defaultCwd: "/repo" });
+        await pool.warmPool();
+
+        // Walk many exits, advancing well past the fast-exit window between
+        // them. If long-lived exits counted, the breaker would trip after
+        // MAX_KEY_FAILURES; with the threshold check they should not.
+        for (let k = 0; k < 6; k++) {
+          nowOffset += 10_000;
+          const spawned = spawnMock.mock.calls.length;
+          const proc = procs[spawned - 1];
+          if (!proc) break;
+          proc.emitExit(0);
+          await settleRefill();
+        }
+
+        // The pool should still be refilling; if the breaker had tripped,
+        // the pool would be empty for at least the cooldown window.
+        expect(pool.getPoolSize()).toBe(1);
+        pool.dispose();
+      } finally {
+        nowSpy.mockRestore();
+      }
+    });
+
+    it("circuit breaker is per-key — a tripped key does not block other keys", async () => {
+      // Trip env-a's breaker; env-b must still warm freely.
+      const procs = Array.from({ length: 10 }, (_, idx) => createFakeProcess(5000 + idx));
+      let i = 0;
+      spawnMock.mockImplementation(() => procs[i++] ?? createFakeProcess(5999));
+
+      const pool = new PtyPool({ poolSize: 1, defaultCwd: "/repo" });
+
+      // Drive env-a into a fast-exit loop until warmForKey is gated.
+      let lastSpawnCount = 0;
+      for (let k = 0; k < 6; k++) {
+        pool.warmForKey("/repo", undefined, "env-a");
+        await settleRefill();
+        const spawned = spawnMock.mock.calls.length;
+        const proc = procs[spawned - 1];
+        if (proc && spawned > lastSpawnCount) {
+          lastSpawnCount = spawned;
+          proc.emitExit(1);
+          await settleRefill();
+        } else {
+          // warmForKey was a no-op → breaker is now blocking env-a.
+          break;
+        }
+      }
+
+      const callsAfterEnvA = spawnMock.mock.calls.length;
+
+      // env-b should still warm freely — distinct key, distinct breaker.
+      pool.warmForKey("/repo", undefined, "env-b");
+      await settleRefill();
+
+      expect(spawnMock).toHaveBeenCalledTimes(callsAfterEnvA + 1);
+      expect(spawnMock.mock.calls[callsAfterEnvA]?.[2]).toMatchObject({ cwd: "/repo" });
+      pool.dispose();
+    });
+
+    it("circuit breaker cools down and resumes refill after the backoff window", async () => {
+      // Drive the breaker into the blocked state for env-empty, advance
+      // virtual time past KEY_BACKOFF_MS, then verify a fresh warmForKey
+      // succeeds. We mock Date.now directly because the implementation
+      // reads it inline and fake timers wouldn't intercept that.
+      const procs = Array.from({ length: 12 }, (_, idx) => createFakeProcess(6000 + idx));
+      let i = 0;
+      spawnMock.mockImplementation(() => procs[i++] ?? createFakeProcess(6999));
+
+      const realNow = Date.now.bind(Date);
+      let nowOffset = 0;
+      const nowSpy = vi.spyOn(Date, "now").mockImplementation(() => realNow() + nowOffset);
+
+      try {
+        const pool = new PtyPool({ poolSize: 1, defaultCwd: "/repo" });
+        await pool.warmPool();
+
+        // Drive fast exits until the breaker engages.
+        let lastSpawn = 0;
+        for (let k = 0; k < 8; k++) {
+          const spawned = spawnMock.mock.calls.length;
+          const proc = procs[spawned - 1];
+          if (!proc) break;
+          proc.emitExit(1);
+          await settleRefill();
+          const after = spawnMock.mock.calls.length;
+          if (after === spawned) {
+            lastSpawn = after;
+            break;
+          }
+        }
+
+        // Breaker should now be blocking — additional emitExit drives no
+        // new spawn. (Pool is empty at this point.)
+        expect(pool.getPoolSize()).toBe(0);
+
+        // Advance virtual time past the 30s cooldown.
+        nowOffset += 31_000;
+        pool.warmForKey("/repo", undefined, "env-empty");
+        await settleRefill();
+
+        expect(spawnMock.mock.calls.length).toBeGreaterThan(lastSpawn);
+        pool.dispose();
+      } finally {
+        nowSpy.mockRestore();
+      }
     });
 
     it("evicts an idle entry from a different key when global cap is reached", async () => {

--- a/electron/services/__tests__/PtyPool.test.ts
+++ b/electron/services/__tests__/PtyPool.test.ts
@@ -764,6 +764,48 @@ describe("PtyPool", () => {
       pool.dispose();
     });
 
+    it("warmPool respects the breaker — drainAndRefill back to a blocked cwd is a no-op", async () => {
+      // Regression for #7892: drainAndRefill() ends with warmPool(). Without
+      // a breaker check in warmPool, switching to /repo-b and back to /repo
+      // after the breaker tripped on /repo would re-enter the crash loop.
+      const procs = Array.from({ length: 12 }, (_, idx) => createFakeProcess(8000 + idx));
+      let i = 0;
+      spawnMock.mockImplementation(() => procs[i++] ?? createFakeProcess(8999));
+
+      const pool = new PtyPool({ poolSize: 1, defaultCwd: "/repo" });
+      await pool.warmPool();
+
+      // Trip the breaker on /repo env-empty via fast exits.
+      let lastSpawn = 1;
+      for (let k = 0; k < 8; k++) {
+        const spawned = spawnMock.mock.calls.length;
+        const proc = procs[spawned - 1];
+        if (!proc) break;
+        proc.emitExit(1);
+        await settleRefill();
+        const after = spawnMock.mock.calls.length;
+        if (after === spawned) {
+          lastSpawn = after;
+          break;
+        }
+      }
+
+      const spawnsAtBlock = spawnMock.mock.calls.length;
+      expect(lastSpawn).toBeGreaterThan(0);
+
+      // Switch away to /repo-b (warmPool there is fine — different key).
+      await pool.drainAndRefill("/repo-b");
+      // /repo-b warm did spawn one entry.
+      expect(spawnMock.mock.calls.length).toBe(spawnsAtBlock + 1);
+      const spawnsAfterB = spawnMock.mock.calls.length;
+
+      // Switch back to /repo — warmPool must see the still-blocked breaker
+      // and refuse to spawn. Without the fix, this re-enters the crash loop.
+      await pool.drainAndRefill("/repo");
+      expect(spawnMock).toHaveBeenCalledTimes(spawnsAfterB);
+      pool.dispose();
+    });
+
     it("circuit breaker cools down and resumes refill after the backoff window", async () => {
       // Drive the breaker into the blocked state for env-empty, advance
       // virtual time past KEY_BACKOFF_MS, then verify a fresh warmForKey

--- a/electron/services/pty/__tests__/terminalSpawn.pool.test.ts
+++ b/electron/services/pty/__tests__/terminalSpawn.pool.test.ts
@@ -13,6 +13,7 @@ interface FakePooledPty {
   write: ReturnType<typeof vi.fn>;
   resize: ReturnType<typeof vi.fn>;
   kill: ReturnType<typeof vi.fn>;
+  destroy: ReturnType<typeof vi.fn>;
 }
 
 interface FakeDataHandoff {
@@ -31,6 +32,7 @@ function createFakePooledPty(): FakePooledPty {
     write: vi.fn(),
     resize: vi.fn(),
     kill: vi.fn(),
+    destroy: vi.fn(),
   };
 }
 
@@ -170,6 +172,10 @@ describe("acquirePtyProcess pool handling", () => {
     const result = acquirePtyProcess("t1", baseOptions, {}, "/bin/bash", [], pool, () => {});
 
     expect(dataHandoff.dispose).toHaveBeenCalledTimes(1);
+    // destroyPty() closes the master FD (destroy) and signals the process
+    // (kill); without destroy the /dev/ptmx FD leaks on every resize-failure
+    // fallback. See #7892.
+    expect(pooled.destroy).toHaveBeenCalledTimes(1);
     expect(pooled.kill).toHaveBeenCalledTimes(1);
     expect(spawnMock).toHaveBeenCalledTimes(1);
     expect(result.ptyProcess).toBe(spawnedPty);

--- a/electron/services/pty/terminalSpawn.ts
+++ b/electron/services/pty/terminalSpawn.ts
@@ -8,7 +8,12 @@ import {
 import { getDefaultShell, getDefaultShellArgs } from "./terminalShell.js";
 import { computePoolEnvHash } from "./ptyPoolEnvHash.js";
 import type { PtySpawnOptions } from "./types.js";
-import { BufferedPtyDataHandoff, type PooledPtyDataHandoff, type PtyPool } from "../PtyPool.js";
+import {
+  BufferedPtyDataHandoff,
+  destroyPty,
+  type PooledPtyDataHandoff,
+  type PtyPool,
+} from "../PtyPool.js";
 
 // Agent CLIs that ship as Node binaries and benefit from V8 bytecode
 // caching across launches. Codex is a Rust binary and would silently
@@ -173,11 +178,9 @@ export function acquirePtyProcess(
       } catch {
         // Ignore disposal errors
       }
-      try {
-        pooled.process.kill();
-      } catch {
-        // Process may already be dead
-      }
+      // Use destroyPty so the master FD is closed too — kill() alone leaves
+      // /dev/ptmx open and stacks toward the system-wide ptmx_max (#7892).
+      destroyPty(pooled.process);
       pooled = null;
     }
   }


### PR DESCRIPTION
## Summary

- Pooled PTYs were never destroyed on exit, just killed — `kill()` in `node-pty` sends a signal but doesn't close the master/slave fds. Added `destroyPty()` and called it everywhere the pool abandons an entry (exit, dispose, drain, evict, and the `ENOTTY` resize fallback in `terminalSpawn.ts`).
- `refillPool` had no crash-loop guard, so a single bad `(cwd, envHash)` key (broken `.zshrc`, failing `.envrc`, dead `mise`/`asdf` hook) turned into an infinite spawn-exit-refill loop. Combined with the leak above, that's ~60 leaked fds per cycle.
- Added a per-key circuit breaker: trips after 3 exits faster than `FAST_EXIT_THRESHOLD_MS` (2 s), backs off for `KEY_BACKOFF_MS` (30 s). `warmPool` and `warmForKey` are gated behind the breaker; direct user spawns are not affected.

Resolves #7892

## Changes

- `electron/services/PtyPool.ts` — `destroyPty()` helper with `alive` guard; per-key breaker state; `onExit` reordered to `pool.delete` before `destroyPty` for consistency; `refillPool`, `warmForKey`, `warmPool` all check the breaker before spawning
- `electron/services/pty/terminalSpawn.ts` — `destroyPty()` in the `ENOTTY` resize-fallback block
- `electron/services/__tests__/PtyPool.test.ts` — destroy mock on the fake PTY; 9 new tests: destroy on exit/dispose/drain/evict, breaker tripping, per-key isolation, cooldown, long-lived exits exempt, `warmPool`/`drainAndRefill` regression
- `electron/services/pty/__tests__/terminalSpawn.pool.test.ts` — destroy mock; resize-fallback test asserts `destroy()` called

## Testing

51 tests pass, typecheck clean, lint clean, build clean.