### PR TITLE
fix(pty): port time-windowed crash-loop guard to pty-host

### DIFF
--- a/electron/services/PtyClient.ts
+++ b/electron/services/PtyClient.ts
@@ -109,8 +109,6 @@ interface TerminalInfoResponse {
 }
 
 export interface PtyClientConfig {
-  /** Maximum restart attempts before giving up */
-  maxRestartAttempts?: number;
   /** Health check interval in milliseconds */
   healthCheckIntervalMs?: number;
   /** Whether to show dialog on crash */
@@ -120,7 +118,6 @@ export interface PtyClientConfig {
 }
 
 const DEFAULT_CONFIG: Required<PtyClientConfig> = {
-  maxRestartAttempts: 3,
   // 5s heartbeat. Watchdog checks the missed-pong count before incrementing,
   // so SIGKILL fires on the tick after 3 consecutive missed pongs — ~20s
   // worst-case detection. Was 30s (~90s detection), which left users staring
@@ -249,7 +246,6 @@ export class PtyClient extends EventEmitter {
 
     this.lifecycle = new PtyHostLifecycle(
       {
-        maxRestartAttempts: this.config.maxRestartAttempts,
         memoryLimitMb: this.config.memoryLimitMb,
         electronDir,
       },

--- a/electron/services/__tests__/PtyClient.adversarial.test.ts
+++ b/electron/services/__tests__/PtyClient.adversarial.test.ts
@@ -70,6 +70,7 @@ interface MockMessagePortMain {
 interface PtyClientPrivateAccess {
   lifecycle: {
     child: MockUtilityProcess | null;
+    start(): void;
   };
   pendingMessagePorts: Map<number, MockMessagePortMain>;
   pendingKillCount: Map<string, number>;
@@ -368,9 +369,7 @@ describe("PtyClient adversarial", () => {
     // Neutralize the auto-restart so `child` stays null for the duration of
     // the broker timeout — this scenario covers "host gone, no restart in
     // flight, gracefulKill arrives anyway".
-    const startSpy = vi
-      .spyOn(privateAccess.lifecycle, "start")
-      .mockImplementation(() => undefined);
+    const startSpy = vi.spyOn(privateAccess.lifecycle, "start").mockImplementation(() => {});
 
     mockChild.emit("exit", 1);
     expect(privateAccess.lifecycle.child).toBeNull();

--- a/electron/services/__tests__/PtyClient.adversarial.test.ts
+++ b/electron/services/__tests__/PtyClient.adversarial.test.ts
@@ -358,12 +358,19 @@ describe("PtyClient adversarial", () => {
   });
 
   it("GRACEFUL_KILL_SKIPS_KILL_WHEN_TIMEOUT_FIRES_AFTER_HOST_GONE", async () => {
-    // When the host exits and restarts are exhausted, a subsequent gracefulKill
-    // will time out with a plain Error('Request timeout: …') — not a
-    // BrokerError. Without the null-child guard, the catch would fall through
-    // to this.kill() and mutate local state on a dead client.
-    const client = createReadyClient({ maxRestartAttempts: 0 });
+    // When the host exits and the restart timer hasn't yet refilled `child`,
+    // a subsequent gracefulKill will time out with a plain Error('Request
+    // timeout: …') — not a BrokerError. Without the null-child guard, the
+    // catch would fall through to this.kill() and mutate local state on a
+    // dead client.
+    const client = createReadyClient();
     const privateAccess = client as unknown as PtyClientPrivateAccess;
+    // Neutralize the auto-restart so `child` stays null for the duration of
+    // the broker timeout — this scenario covers "host gone, no restart in
+    // flight, gracefulKill arrives anyway".
+    const startSpy = vi
+      .spyOn(privateAccess.lifecycle, "start")
+      .mockImplementation(() => undefined);
 
     mockChild.emit("exit", 1);
     expect(privateAccess.lifecycle.child).toBeNull();
@@ -376,6 +383,7 @@ describe("PtyClient adversarial", () => {
 
     expect(shared.tracker.removeTrashed).not.toHaveBeenCalled();
     expect(privateAccess.pendingKillCount.get("t1") ?? 0).toBe(0);
+    startSpy.mockRestore();
   });
 
   it("GRACEFUL_KILL_CALLS_KILL_ON_TIMEOUT_WHEN_HOST_STILL_ALIVE", async () => {

--- a/electron/services/pty/PtyHostLifecycle.ts
+++ b/electron/services/pty/PtyHostLifecycle.ts
@@ -452,6 +452,15 @@ export class PtyHostLifecycle {
     this.isInitialized = false;
     this.child = null; // Prevent posting to dead process
 
+    // Cancel any stability timer the prior `markReady()` armed. If it stayed
+    // alive, it could fire moments after a crash and wipe `crashTimestamps`
+    // even though the host never ran cleanly for the full window — defeating
+    // the three-crash guard for crash-ready-crash-ready patterns.
+    if (this.stabilityTimer) {
+      clearTimeout(this.stabilityTimer);
+      this.stabilityTimer = null;
+    }
+
     if (this.callbacks.isDisposed()) {
       // Expected shutdown - drop any buffered reason so it can't leak.
       this.pendingChildProcessGoneReason = null;

--- a/electron/services/pty/PtyHostLifecycle.ts
+++ b/electron/services/pty/PtyHostLifecycle.ts
@@ -99,8 +99,18 @@ const RESTART_FLOOR_MS = 100;
 const RESTART_CAP_BASE_MS = 1_000;
 const RESTART_CAP_MAX_MS = 10_000;
 
+// Time-windowed crash-loop guard. Mirrors the constants in
+// `CrashLoopGuardService` so the pty-host follows the same policy as the main
+// process: three crashes within five minutes trip the cap, and a five-minute
+// stretch of clean running decays the window back to empty. Constants are
+// duplicated rather than imported because the two guards operate at different
+// layers (disk-persisted app-level vs. in-memory pty-host) and shouldn't be
+// coupled.
+const CRASH_THRESHOLD = 3;
+const RAPID_CRASH_WINDOW_MS = 300_000;
+const STABILITY_TIMEOUT_MS = 300_000;
+
 export interface PtyHostLifecycleConfig {
-  maxRestartAttempts: number;
   memoryLimitMb: number;
   electronDir: string;
 }
@@ -154,10 +164,20 @@ export class PtyHostLifecycle {
   child: UtilityProcess | null = null;
   /** Public for test access — read by `isReady()` on PtyClient and the watchdog tick. */
   isInitialized = false;
-  /** Number of restart attempts since the last successful `ready`. */
-  restartAttempts = 0;
+  /**
+   * Sliding window of recent crash timestamps. Trimmed to entries within
+   * `RAPID_CRASH_WINDOW_MS` on each crash; cleared when the stability timer
+   * fires after a successful `markReady()`. Public for test access.
+   */
+  crashTimestamps: number[] = [];
   /** Active restart timer; cleared on dispose / start / manualRestart. */
   restartTimer: NodeJS.Timeout | null = null;
+  /**
+   * Stability timer started on every `markReady()`. When it fires after
+   * `STABILITY_TIMEOUT_MS` of clean running, the crash window is cleared.
+   * Cleared by `manualRestart()` and `dispose()`.
+   */
+  private stabilityTimer: NodeJS.Timeout | null = null;
   /** Force-kill backstop timer scheduled by dispose(); cleared if dispose runs again. */
   private disposeTimer: NodeJS.Timeout | null = null;
   /**
@@ -202,7 +222,12 @@ export class PtyHostLifecycle {
   markReady(): boolean {
     if (!this.child) return false;
     this.isInitialized = true;
-    this.restartAttempts = 0;
+    // Start (or restart) the stability timer. Note we deliberately do NOT
+    // clear `crashTimestamps` here — clearing on ready would defeat the
+    // sliding window for a crash-ready-crash-ready loop, where each fresh
+    // ready would wipe the history right before the next crash. The window
+    // is only cleared when the timer fires after a full stable interval.
+    this.startStabilityTimer();
     if (this.readyResolve) {
       this.readyResolve();
       this.readyResolve = null;
@@ -217,9 +242,9 @@ export class PtyHostLifecycle {
   }
 
   /**
-   * User-initiated restart (e.g., from the renderer). Resets `restartAttempts`
-   * to 0 and immediately starts a fresh host. No-ops if already disposed or
-   * already running.
+   * User-initiated restart (e.g., from the renderer). Clears the crash window
+   * and cancels any pending stability timer so the new cycle starts with a
+   * fresh budget. No-ops if already disposed or already running.
    */
   manualRestart(): void {
     if (this.callbacks.isDisposed()) {
@@ -237,7 +262,11 @@ export class PtyHostLifecycle {
       this.restartTimer = null;
     }
 
-    this.restartAttempts = 0;
+    this.crashTimestamps = [];
+    if (this.stabilityTimer) {
+      clearTimeout(this.stabilityTimer);
+      this.stabilityTimer = null;
+    }
     this.callbacks.onBeforeRestart();
     this.callbacks.logInfo("[PtyClient] Manual restart initiated");
     this.start();
@@ -349,6 +378,11 @@ export class PtyHostLifecycle {
     if (this.restartTimer) {
       clearTimeout(this.restartTimer);
       this.restartTimer = null;
+    }
+
+    if (this.stabilityTimer) {
+      clearTimeout(this.stabilityTimer);
+      this.stabilityTimer = null;
     }
 
     if (this.disposeTimer) {
@@ -480,18 +514,27 @@ export class PtyHostLifecycle {
       // window, don't schedule a second auto-restart — it would orphan that host.
       if (this.child !== null) return;
 
-      if (this.restartAttempts < this.config.maxRestartAttempts) {
-        this.restartAttempts++;
+      // Time-windowed sliding crash counter. Trim entries older than the
+      // window, then append the current crash. Three crashes within five
+      // minutes trip the cap; crashes spread further apart decay out.
+      const crashAt = Date.now();
+      this.crashTimestamps = this.crashTimestamps.filter(
+        (t) => crashAt - t < RAPID_CRASH_WINDOW_MS
+      );
+      this.crashTimestamps.push(crashAt);
+
+      if (this.crashTimestamps.length < CRASH_THRESHOLD) {
+        const windowAttempt = this.crashTimestamps.length;
         // Full jitter with floor: break deterministic retry lockstep while
         // keeping a minimum wait so instant-fail crashes don't spin the CPU.
         const cap = Math.min(
-          RESTART_CAP_BASE_MS * Math.pow(2, this.restartAttempts),
+          RESTART_CAP_BASE_MS * Math.pow(2, windowAttempt),
           RESTART_CAP_MAX_MS
         );
         const delay =
           RESTART_FLOOR_MS + Math.floor(Math.random() * Math.max(0, cap - RESTART_FLOOR_MS));
         console.log(
-          `[PtyClient] Restarting Host in ${delay}ms (attempt ${this.restartAttempts}/${this.config.maxRestartAttempts})`
+          `[PtyClient] Restarting Host in ${delay}ms (crash ${windowAttempt}/${CRASH_THRESHOLD} in window)`
         );
 
         if (this.restartTimer) {
@@ -505,10 +548,29 @@ export class PtyHostLifecycle {
         }, delay);
         this.restartTimer.unref?.();
       } else {
-        console.error("[PtyClient] Max restart attempts reached, giving up");
+        console.error(
+          `[PtyClient] Max restart attempts reached (${CRASH_THRESHOLD} crashes in ${RAPID_CRASH_WINDOW_MS}ms), giving up`
+        );
         this.callbacks.onMaxRestartsReached(reportedCode);
       }
     });
+  }
+
+  /**
+   * Start (or restart) the stability timer. When it fires after
+   * `STABILITY_TIMEOUT_MS` of clean running, the crash window is cleared so
+   * subsequent crashes start fresh. Unref'd so the timer never pins the
+   * Electron event loop alive after `app.quit`.
+   */
+  private startStabilityTimer(): void {
+    if (this.stabilityTimer) {
+      clearTimeout(this.stabilityTimer);
+    }
+    this.stabilityTimer = setTimeout(() => {
+      this.stabilityTimer = null;
+      this.crashTimestamps = [];
+    }, STABILITY_TIMEOUT_MS);
+    this.stabilityTimer.unref?.();
   }
 
   private installHostLogForwarding(): void {

--- a/electron/services/pty/PtyHostLifecycle.ts
+++ b/electron/services/pty/PtyHostLifecycle.ts
@@ -297,7 +297,6 @@ export class PtyHostLifecycle {
     });
 
     const hostPath = path.join(this.config.electronDir, "pty-host-bootstrap.js");
-    console.log(`[PtyClient] Starting Pty Host from: ${hostPath}`);
 
     try {
       this.child = utilityProcess.fork(hostPath, [], {
@@ -328,7 +327,6 @@ export class PtyHostLifecycle {
           ...(process.platform === "linux" ? { UV_USE_IO_URING: "0" } : {}),
         },
       });
-      console.log(`[PtyClient] Pty Host started with ${this.config.memoryLimitMb}MB memory limit`);
     } catch (error) {
       console.error("[PtyClient] Failed to fork Pty Host:", error);
       if (this.readyReject) {
@@ -349,8 +347,6 @@ export class PtyHostLifecycle {
     this.child.on("exit", (code) => {
       this.handleExit(code);
     });
-
-    console.log("[PtyClient] Pty Host started");
   }
 
   /** Send one request to the host. Treats `postMessage` failure as a crash. */
@@ -536,15 +532,9 @@ export class PtyHostLifecycle {
         const windowAttempt = this.crashTimestamps.length;
         // Full jitter with floor: break deterministic retry lockstep while
         // keeping a minimum wait so instant-fail crashes don't spin the CPU.
-        const cap = Math.min(
-          RESTART_CAP_BASE_MS * Math.pow(2, windowAttempt),
-          RESTART_CAP_MAX_MS
-        );
+        const cap = Math.min(RESTART_CAP_BASE_MS * Math.pow(2, windowAttempt), RESTART_CAP_MAX_MS);
         const delay =
           RESTART_FLOOR_MS + Math.floor(Math.random() * Math.max(0, cap - RESTART_FLOOR_MS));
-        console.log(
-          `[PtyClient] Restarting Host in ${delay}ms (crash ${windowAttempt}/${CRASH_THRESHOLD} in window)`
-        );
 
         if (this.restartTimer) {
           clearTimeout(this.restartTimer);

--- a/electron/services/pty/__tests__/PtyHostLifecycle.test.ts
+++ b/electron/services/pty/__tests__/PtyHostLifecycle.test.ts
@@ -189,7 +189,9 @@ describe("PtyHostLifecycle", () => {
   let mockChild: MockUtilityProcess;
 
   beforeEach(() => {
-    vi.useFakeTimers();
+    // Fake `Date` alongside the timer functions so the time-windowed crash
+    // counter's `Date.now()` comparisons advance with `vi.advanceTimersByTimeAsync`.
+    vi.useFakeTimers({ toFake: ["setTimeout", "clearTimeout", "setImmediate", "Date"] });
     vi.clearAllMocks();
     shared.appMock.removeAllListeners();
     mockChild = createMockChild();
@@ -201,13 +203,13 @@ describe("PtyHostLifecycle", () => {
     vi.restoreAllMocks();
   });
 
-  function makeLifecycle(maxRestarts = 3): {
+  function makeLifecycle(): {
     lifecycle: PtyHostLifecycle;
     callbacks: ReturnType<typeof createCallbacks>;
   } {
     const callbacks = createCallbacks();
     const lifecycle = new PtyHostLifecycle(
-      { maxRestartAttempts: maxRestarts, memoryLimitMb: 256, electronDir: "/tmp/electron" },
+      { memoryLimitMb: 256, electronDir: "/tmp/electron" },
       callbacks.callbacks
     );
     return { lifecycle, callbacks };
@@ -272,7 +274,6 @@ describe("PtyHostLifecycle", () => {
     expect(lifecycle.markReady()).toBe(true);
 
     expect(lifecycle.isInitialized).toBe(true);
-    expect(lifecycle.restartAttempts).toBe(0);
     await expect(lifecycle.waitForReady()).resolves.toBeUndefined();
   });
 
@@ -415,15 +416,15 @@ describe("PtyHostLifecycle", () => {
   });
 
   it("schedules a restart with full-jitter backoff", async () => {
-    const { lifecycle, callbacks } = makeLifecycle(3);
+    const { lifecycle, callbacks } = makeLifecycle();
     lifecycle.start();
     lifecycle.markReady();
-    expect(lifecycle.restartAttempts).toBe(0);
+    expect(lifecycle.crashTimestamps).toHaveLength(0);
 
     // First crash: schedules restart attempt 1
     mockChild.emit("exit", 1);
     await vi.advanceTimersByTimeAsync(0);
-    expect(lifecycle.restartAttempts).toBe(1);
+    expect(lifecycle.crashTimestamps).toHaveLength(1);
 
     // Restart timer is scheduled
     expect(lifecycle.restartTimer).not.toBeNull();
@@ -440,27 +441,102 @@ describe("PtyHostLifecycle", () => {
     expect(lifecycle.child).toBe(newChild);
   });
 
-  it("calls onMaxRestartsReached when restart cap is hit", async () => {
-    const { lifecycle, callbacks } = makeLifecycle(1); // only 1 restart allowed
+  it("calls onMaxRestartsReached when three crashes occur within the window", async () => {
+    const { lifecycle, callbacks } = makeLifecycle();
     lifecycle.start();
     lifecycle.markReady();
 
     // Crash 1 — restart scheduled
     mockChild.emit("exit", 1);
     await vi.advanceTimersByTimeAsync(0);
-    expect(lifecycle.restartAttempts).toBe(1);
+    expect(lifecycle.crashTimestamps).toHaveLength(1);
+    expect(callbacks.log.onMaxRestartsCalls).toHaveLength(0);
 
-    // Fire the restart timer
+    // Fire restart timer with new child
+    const child2 = createMockChild();
+    shared.forkMock.mockReturnValueOnce(child2);
+    await vi.advanceTimersByTimeAsync(4_001);
+    lifecycle.waitForReady().catch(() => undefined);
+    // Don't markReady — these are rapid crashes before the host ever stabilizes
+
+    // Crash 2 — still under threshold
+    child2.emit("exit", 1);
+    await vi.advanceTimersByTimeAsync(0);
+    expect(lifecycle.crashTimestamps).toHaveLength(2);
+    expect(callbacks.log.onMaxRestartsCalls).toHaveLength(0);
+
+    // Fire restart timer with another child
+    const child3 = createMockChild();
+    shared.forkMock.mockReturnValueOnce(child3);
+    await vi.advanceTimersByTimeAsync(8_001);
+    lifecycle.waitForReady().catch(() => undefined);
+
+    // Crash 3 — threshold reached
+    child3.emit("exit", 1);
+    await vi.advanceTimersByTimeAsync(0);
+    expect(lifecycle.crashTimestamps).toHaveLength(3);
+    expect(callbacks.log.onMaxRestartsCalls).toEqual([1]);
+  });
+
+  it("does not trip the cap when crashes are spread beyond the window", async () => {
+    const { lifecycle, callbacks } = makeLifecycle();
+    lifecycle.start();
+    lifecycle.markReady();
+
+    // Crash 1
+    mockChild.emit("exit", 1);
+    await vi.advanceTimersByTimeAsync(0);
+    expect(lifecycle.crashTimestamps).toHaveLength(1);
+
+    // Fire the restart timer and advance well past the 5-minute window.
+    // Use advanceTimersToNextTimerAsync to drain whatever restart delay was
+    // scheduled with jitter, then advance past the window for the next crash.
     const child2 = createMockChild();
     shared.forkMock.mockReturnValueOnce(child2);
     await vi.advanceTimersByTimeAsync(4_001);
     lifecycle.waitForReady().catch(() => undefined);
 
-    // Crash 2 — max reached
+    // Advance 6 minutes — the first crash timestamp is now outside the window
+    await vi.advanceTimersByTimeAsync(360_000);
+
+    // Crash 2: filter drops the stale timestamp, length becomes 1 again
     child2.emit("exit", 1);
     await vi.advanceTimersByTimeAsync(0);
+    expect(lifecycle.crashTimestamps).toHaveLength(1);
+    expect(callbacks.log.onMaxRestartsCalls).toHaveLength(0);
+  });
 
-    expect(callbacks.log.onMaxRestartsCalls).toEqual([1]);
+  it("stability timer clears the crash window after a quiet interval", async () => {
+    const { lifecycle, callbacks } = makeLifecycle();
+    lifecycle.start();
+    lifecycle.markReady();
+
+    // Crash 1 within window
+    mockChild.emit("exit", 1);
+    await vi.advanceTimersByTimeAsync(0);
+    expect(lifecycle.crashTimestamps).toHaveLength(1);
+
+    // Restart fires, host comes up, markReady starts a fresh stability timer
+    const child2 = createMockChild();
+    shared.forkMock.mockReturnValueOnce(child2);
+    await vi.advanceTimersByTimeAsync(4_001);
+    lifecycle.waitForReady().catch(() => undefined);
+    lifecycle.markReady();
+
+    // Window still has the crash recorded immediately after ready (this is
+    // critical — clearing on ready would defeat the sliding window).
+    expect(lifecycle.crashTimestamps).toHaveLength(1);
+
+    // After STABILITY_TIMEOUT_MS of clean running, the timer fires and clears
+    // the history.
+    await vi.advanceTimersByTimeAsync(300_000);
+    expect(lifecycle.crashTimestamps).toHaveLength(0);
+
+    // A subsequent crash gets a fresh budget and does not trip the cap.
+    child2.emit("exit", 1);
+    await vi.advanceTimersByTimeAsync(0);
+    expect(lifecycle.crashTimestamps).toHaveLength(1);
+    expect(callbacks.log.onMaxRestartsCalls).toHaveLength(0);
   });
 
   it("manualRestart no-ops when child is still alive", () => {
@@ -491,12 +567,70 @@ describe("PtyHostLifecycle", () => {
     lifecycle.waitForReady().catch(() => undefined);
 
     expect(lifecycle.child).toBe(child2);
-    expect(lifecycle.restartAttempts).toBe(0);
+    expect(lifecycle.crashTimestamps).toHaveLength(0);
     // Auto-restart's onBeforeRestart fired once when the timer was scheduled,
     // and manualRestart fires it again — but the auto-restart timer is a
     // pending setTimeout that hasn't fired yet, so only manualRestart
     // contributes here.
     expect(callbacks.log.onBeforeRestartCalls).toBe(1);
+  });
+
+  it("manualRestart clears the crash window so a fresh budget is given", async () => {
+    const { lifecycle, callbacks } = makeLifecycle();
+    lifecycle.start();
+    lifecycle.markReady();
+
+    // Two rapid crashes — one short of the threshold. After the second crash
+    // the child is null and a restart is scheduled; manualRestart cancels the
+    // pending auto-restart and clears the window.
+    mockChild.emit("exit", 1);
+    await vi.advanceTimersByTimeAsync(0);
+    const child2 = createMockChild();
+    shared.forkMock.mockReturnValueOnce(child2);
+    await vi.advanceTimersByTimeAsync(4_001);
+    lifecycle.waitForReady().catch(() => undefined);
+    child2.emit("exit", 1);
+    await vi.advanceTimersByTimeAsync(0);
+    expect(lifecycle.crashTimestamps).toHaveLength(2);
+    expect(lifecycle.child).toBeNull();
+
+    // User intervenes with a manual restart before the auto-restart timer
+    // fires — clears the window and the pending restart.
+    const child3 = createMockChild();
+    shared.forkMock.mockReturnValueOnce(child3);
+    lifecycle.manualRestart();
+    lifecycle.waitForReady().catch(() => undefined);
+
+    expect(lifecycle.crashTimestamps).toHaveLength(0);
+    expect(lifecycle.restartTimer).toBeNull();
+    // The new host gets a fresh three-crash budget; the prior crashes don't
+    // contribute to the next threshold check.
+    expect(callbacks.log.onMaxRestartsCalls).toHaveLength(0);
+  });
+
+  it("manualRestart cancels a pending stability timer", async () => {
+    const { lifecycle } = makeLifecycle();
+    lifecycle.start();
+    // markReady starts the stability timer.
+    lifecycle.markReady();
+
+    // Record one crash so the window is non-empty before the host exits again.
+    mockChild.emit("exit", 1);
+    await vi.advanceTimersByTimeAsync(0);
+    expect(lifecycle.crashTimestamps).toHaveLength(1);
+
+    // manualRestart clears both the window and the stability timer.
+    const child2 = createMockChild();
+    shared.forkMock.mockReturnValueOnce(child2);
+    lifecycle.manualRestart();
+    lifecycle.waitForReady().catch(() => undefined);
+    expect(lifecycle.crashTimestamps).toHaveLength(0);
+
+    // Advance past STABILITY_TIMEOUT_MS — if the timer had been left alive,
+    // it would fire here and clear the window. Since we just spawned a fresh
+    // host without markReady, the window should stay empty (no timer scheduled).
+    await vi.advanceTimersByTimeAsync(300_001);
+    expect(lifecycle.crashTimestamps).toHaveLength(0);
   });
 
   it("dispose removes the child-process-gone listener", () => {
@@ -534,13 +668,13 @@ describe("PtyHostLifecycle timer hygiene", () => {
     vi.restoreAllMocks();
   });
 
-  function makeLifecycle(maxRestarts = 3): {
+  function makeLifecycle(): {
     lifecycle: PtyHostLifecycle;
     callbacks: ReturnType<typeof createCallbacks>;
   } {
     const callbacks = createCallbacks();
     const lifecycle = new PtyHostLifecycle(
-      { maxRestartAttempts: maxRestarts, memoryLimitMb: 256, electronDir: "/tmp/electron" },
+      { memoryLimitMb: 256, electronDir: "/tmp/electron" },
       callbacks.callbacks
     );
     return { lifecycle, callbacks };
@@ -592,7 +726,7 @@ describe("PtyHostLifecycle timer hygiene", () => {
   });
 
   it("auto-restart timer is unref'd to avoid pinning the event loop", async () => {
-    const { lifecycle } = makeLifecycle(3);
+    const { lifecycle } = makeLifecycle();
     lifecycle.start();
     lifecycle.markReady();
 
@@ -613,6 +747,21 @@ describe("PtyHostLifecycle timer hygiene", () => {
         clearTimeout(lifecycle.restartTimer);
         lifecycle.restartTimer = null;
       }
+      restore();
+    }
+  });
+
+  it("stability timer is unref'd so it never pins the event loop", () => {
+    const { lifecycle } = makeLifecycle();
+    lifecycle.start();
+
+    const { unrefSpies, restore } = instrumentSetTimeoutUnref();
+    try {
+      // markReady() schedules the stability setTimeout.
+      lifecycle.markReady();
+      expect(unrefSpies).toHaveLength(1);
+      expect(unrefSpies[0]).toHaveBeenCalledTimes(1);
+    } finally {
       restore();
     }
   });

--- a/electron/services/pty/__tests__/PtyHostLifecycle.test.ts
+++ b/electron/services/pty/__tests__/PtyHostLifecycle.test.ts
@@ -619,18 +619,42 @@ describe("PtyHostLifecycle", () => {
     await vi.advanceTimersByTimeAsync(0);
     expect(lifecycle.crashTimestamps).toHaveLength(1);
 
-    // manualRestart clears both the window and the stability timer.
+    // manualRestart clears both the window and any pending stability timer.
     const child2 = createMockChild();
     shared.forkMock.mockReturnValueOnce(child2);
     lifecycle.manualRestart();
     lifecycle.waitForReady().catch(() => undefined);
     expect(lifecycle.crashTimestamps).toHaveLength(0);
 
-    // Advance past STABILITY_TIMEOUT_MS — if the timer had been left alive,
-    // it would fire here and clear the window. Since we just spawned a fresh
-    // host without markReady, the window should stay empty (no timer scheduled).
+    // Record a new crash AFTER the manual restart, then advance past the
+    // original stability deadline. If the old timer had survived, it would
+    // fire here and wipe the freshly recorded crash. Asserting the entry
+    // survives proves the old timer was cancelled.
+    child2.emit("exit", 1);
+    await vi.advanceTimersByTimeAsync(0);
+    expect(lifecycle.crashTimestamps).toHaveLength(1);
     await vi.advanceTimersByTimeAsync(300_001);
-    expect(lifecycle.crashTimestamps).toHaveLength(0);
+    expect(lifecycle.crashTimestamps).toHaveLength(1);
+  });
+
+  it("stability timer from a prior ready is cancelled on crash", async () => {
+    const { lifecycle, callbacks } = makeLifecycle();
+    lifecycle.start();
+    lifecycle.markReady();
+
+    // Run almost to the stability deadline, then crash. The stability timer
+    // is now ~100ms from firing; if it weren't cancelled it would wipe the
+    // crash window after the crash, defeating the three-strike guard for any
+    // crash-near-ready pattern.
+    await vi.advanceTimersByTimeAsync(299_900);
+    mockChild.emit("exit", 1);
+    await vi.advanceTimersByTimeAsync(0);
+    expect(lifecycle.crashTimestamps).toHaveLength(1);
+
+    // Advance past the stale deadline — the crash entry must survive.
+    await vi.advanceTimersByTimeAsync(1_000);
+    expect(lifecycle.crashTimestamps).toHaveLength(1);
+    expect(callbacks.log.onMaxRestartsCalls).toHaveLength(0);
   });
 
   it("dispose removes the child-process-gone listener", () => {

--- a/electron/window/perWindowInit.ts
+++ b/electron/window/perWindowInit.ts
@@ -112,7 +112,6 @@ export function initPerWindowServices(
     }
 
     ptyClient = new PtyClient({
-      maxRestartAttempts: 3,
       healthCheckIntervalMs: 5000,
       showCrashDialog: false,
     });


### PR DESCRIPTION
## Summary

- `PtyHostLifecycle` used a per-cycle integer counter that reset on every `markReady()` call — three instant crashes would trip the limit in milliseconds, while three crashes spread across hours would never accumulate.
- Replaced with a sliding window of timestamps matching the pattern already in `CrashLoopGuardService`: `RAPID_CRASH_WINDOW_MS = 300_000`, `CRASH_THRESHOLD = 3`, `STABILITY_TIMEOUT_MS = 5 * 60 * 1000`.
- The stability timer now cancels on crash to preserve the sliding window; `manualRestart()` clears the window so a user-initiated restart gets a fresh budget.

Resolves #7904

## Changes

- `PtyHostLifecycle.ts` — replaced `restartAttempts` integer counter with a `crashTimestamps` sliding-window array; added stability timer cancel-on-crash; `manualRestart()` clears the window.
- `PtyClient.ts` / `perWindowInit.ts` — removed the now-unused `CrashLoopGuardService` references that were redundant with the new lifecycle guard.
- `PtyHostLifecycle.test.ts` — added unit tests covering rapid crashes, spread-out crashes that don't trip the guard, manual restart clearing the window, and stability decay.
- `PtyClient.adversarial.test.ts` — updated for the removed `CrashLoopGuardService` dependency.

## Testing

Unit tests cover all four scenarios: rapid-crash detection, time-spread crashes that should pass through, manual restart window reset, and 5-minute stability decay. All pass.