### PR TITLE
fix(worktree): add confirm dialog before restarting workspace service

### DIFF
--- a/src/components/Sidebar/SidebarContent.tsx
+++ b/src/components/Sidebar/SidebarContent.tsx
@@ -51,6 +51,7 @@ import { computeChipState } from "@/components/Worktree/utils/computeChipState";
 import { parseExactNumber } from "@/lib/parseExactNumber";
 import type { WorktreeState } from "@/types";
 import { actionService } from "@/services/ActionService";
+import { ConfirmDialog } from "@/components/ui/ConfirmDialog";
 import { SidebarWorktreeRow } from "./SidebarWorktreeRow";
 import { StaticWorktreeRow } from "./StaticWorktreeRow";
 import { useScrollIndicator } from "./useScrollIndicator";
@@ -130,6 +131,7 @@ function SidebarContent({ onOpenOverview }: SidebarContentProps) {
   }, [createDialog.isOpen]);
 
   const [isFleetPickerOpen, setIsFleetPickerOpen] = useState(false);
+  const [isRestartConfirmOpen, setIsRestartConfirmOpen] = useState(false);
   const openFleetPicker = useCallback(() => setIsFleetPickerOpen(true), []);
   const closeFleetPicker = useCallback(() => setIsFleetPickerOpen(false), []);
   const armedIds = useFleetArmingStore((s) => s.armedIds);
@@ -614,13 +616,23 @@ function SidebarContent({ onOpenOverview }: SidebarContentProps) {
         <div className="px-4 py-4">
           <div className="text-[var(--color-status-error)] text-sm mb-2">{error}</div>
           <button
-            onClick={() => {
-              void actionService.dispatch("worktree.restartService", undefined, { source: "user" });
-            }}
+            onClick={() => setIsRestartConfirmOpen(true)}
             className="text-xs px-2 py-1 border border-divider rounded hover:bg-tint/[0.06] text-daintree-text"
           >
             Restart Service
           </button>
+          <ConfirmDialog
+            isOpen={isRestartConfirmOpen}
+            onClose={() => setIsRestartConfirmOpen(false)}
+            title="Restart workspace service?"
+            description="Restarts the workspace monitoring process. Git status and worktree data will be temporarily unavailable."
+            confirmLabel="Restart service"
+            variant="destructive"
+            onConfirm={() => {
+              void actionService.dispatch("worktree.restartService", undefined, { source: "user" });
+              setIsRestartConfirmOpen(false);
+            }}
+          />
         </div>
       </div>
     );

--- a/src/components/Sidebar/SidebarContent.tsx
+++ b/src/components/Sidebar/SidebarContent.tsx
@@ -134,6 +134,9 @@ function SidebarContent({ onOpenOverview }: SidebarContentProps) {
   const [isRestartConfirmOpen, setIsRestartConfirmOpen] = useState(false);
   const openFleetPicker = useCallback(() => setIsFleetPickerOpen(true), []);
   const closeFleetPicker = useCallback(() => setIsFleetPickerOpen(false), []);
+  useEffect(() => {
+    if (!error) setIsRestartConfirmOpen(false);
+  }, [error]);
   const armedIds = useFleetArmingStore((s) => s.armedIds);
   const armedSize = armedIds.size;
 

--- a/src/services/actions/definitions/worktreeServiceActions.ts
+++ b/src/services/actions/definitions/worktreeServiceActions.ts
@@ -47,7 +47,7 @@ export function registerWorktreeServiceActions(
       "Restart the workspace host. Available after the service has crashed and could not recover automatically.",
     category: "worktree",
     kind: "command",
-    danger: "safe",
+    danger: "confirm",
     scope: "renderer",
     keywords: ["workspace", "backend", "recover", "host"],
     isEnabled: () => {


### PR DESCRIPTION
## Summary
- Adds a `ConfirmDialog` gate before restarting the workspace service from the sidebar.
- Reclassifies `worktree.restartService` from `danger: "safe"` to `danger: "confirm"` so it's excluded from `repeatLast` and the MRU rail.
- Adds a stale-state cleanup effect that resets the confirm dialog when the underlying error clears.

Resolves #7909.

## Changes
- `src/components/Sidebar/SidebarContent.tsx` — wired `ConfirmDialog` (variant `"destructive"`) at the error-branch call site, plus the cleanup `useEffect`.
- `src/services/actions/definitions/worktreeServiceActions.ts` — changed `danger` metadata from `"safe"` to `"confirm"`.

## Testing
- Confirmed the dialog appears on restart trigger and dismisses cleanly on cancel.
- Confirmed the dialog state resets when the error condition clears before the user acts.
- Typecheck, lint, and format all pass.