### PR TITLE
test(e2e): add multi-window isolation coverage

### DIFF
--- a/e2e/full/platform/core-multi-window.spec.ts
+++ b/e2e/full/platform/core-multi-window.spec.ts
@@ -1,0 +1,224 @@
+import { test, expect } from "@playwright/test";
+import {
+  launchApp,
+  closeApp,
+  closeWindow,
+  focusWindow,
+  getWindowPage,
+  openSecondWindow,
+  type AppContext,
+  type WindowHandle,
+} from "../../helpers/launch";
+import { createFixtureRepos, type FixtureRepo } from "../../helpers/fixtures";
+import { openAndOnboardProject } from "../../helpers/project";
+import { spawnTerminalAndVerify } from "../../helpers/workflows";
+import { runTerminalCommand, getTerminalText, waitForTerminalText } from "../../helpers/terminal";
+import { SEL } from "../../helpers/selectors";
+import { T_LONG, T_MEDIUM } from "../../helpers/timeouts";
+import { writeFileSync } from "fs";
+import path from "path";
+import { randomUUID } from "crypto";
+
+// Multi-window isolation: per-window services (PortalManager, EventBuffer,
+// MessagePorts) must scope correctly while global singletons (PtyClient,
+// WorkspaceClient) stay shared. The spec opens two BrowserWindows with
+// distinct projects, then exercises the routing invariants from #4641,
+// #4715, and #4624.
+//
+// Helpers in launch.ts identify windows by stable `windowId` rather than the
+// Z-ordered `BrowserWindow.getAllWindows()` array — Electron 41's window list
+// reorders on focus, so index-based lookups silently target the wrong view.
+
+test.describe.serial("Multi-window isolation", () => {
+  let ctx: AppContext | null = null;
+  let fixtures: FixtureRepo[] = [];
+  let window1Id: number;
+  let window1Page: import("@playwright/test").Page;
+  let window2: WindowHandle;
+  let window2Page: import("@playwright/test").Page;
+
+  test.beforeAll(async () => {
+    fixtures = createFixtureRepos(2);
+
+    ctx = await launchApp();
+    const { app } = ctx;
+
+    // Window 1: open project A via the standard onboarding path. Capture
+    // the windowId BEFORE opening window 2 so the snapshot is unambiguous —
+    // at this point only one BrowserWindow exists.
+    window1Page = await openAndOnboardProject(app, ctx.window, fixtures[0].dir);
+    window1Id = await app.evaluate(({ BrowserWindow }) => BrowserWindow.getAllWindows()[0]!.id);
+
+    // Window 2: opened with projectPath so the new window auto-opens
+    // project B via handleDirectoryOpen — same path `app.newWindow` takes
+    // when invoked with an explicit projectPath argument.
+    window2 = await openSecondWindow(app, window1Page, { projectPath: fixtures[1].dir });
+    window2Page = await getWindowPage(app, window2.windowId, T_LONG);
+
+    // Wait for window 2's sidebar to be ready before any test body runs.
+    await window2Page
+      .locator('[aria-label="Toggle Sidebar"]')
+      .waitFor({ state: "visible", timeout: T_LONG });
+
+    // Re-resolve window 1's page by stable windowId in case the cached
+    // WebContentsView was shuffled when window 2 opened. Never use
+    // refreshActiveWindow here — it falls back to getAllWindows()[0],
+    // which is Z-ordered and would silently reassign window1Page to the
+    // newly-focused second window's view.
+    window1Page = await getWindowPage(app, window1Id, T_LONG);
+  });
+
+  test.afterAll(async () => {
+    if (ctx?.app) {
+      await closeApp(ctx.app).catch(() => undefined);
+      ctx = null;
+    }
+    for (const fixture of fixtures) {
+      fixture.cleanup();
+    }
+    fixtures = [];
+  });
+
+  test("two windows host independent projects", async () => {
+    // Confirm exactly two BrowserWindows are alive — guards against a
+    // helper bug where openSecondWindow accidentally creates more than one
+    // window or fails to detect the new one and silently grabs window 1's
+    // sentinel.
+    const aliveIds = await ctx!.app.evaluate(({ BrowserWindow }) =>
+      BrowserWindow.getAllWindows()
+        .filter((w) => !w.isDestroyed())
+        .map((w) => w.id)
+    );
+    expect(aliveIds).toHaveLength(2);
+    expect(aliveIds).toContain(window1Id);
+    expect(aliveIds).toContain(window2.windowId);
+
+    await expect(window1Page.locator(SEL.toolbar.projectSwitcherTrigger)).toContainText(
+      path.basename(fixtures[0].dir),
+      { timeout: T_LONG }
+    );
+    await expect(window2Page.locator(SEL.toolbar.projectSwitcherTrigger)).toContainText(
+      path.basename(fixtures[1].dir),
+      { timeout: T_LONG }
+    );
+
+    // Sanity: the two pages are distinct BrowserWindow contents — their
+    // projectId query params must differ.
+    const url1 = window1Page.url();
+    const url2 = window2Page.url();
+    expect(url1).not.toBe(url2);
+    expect(url1).toContain("projectId=");
+    expect(url2).toContain("projectId=");
+  });
+
+  test("terminal I/O stays scoped to its originating window", async () => {
+    const app = ctx!.app;
+
+    await focusWindow(app, window1Id, window1Page);
+    const panel1 = await spawnTerminalAndVerify(window1Page);
+
+    await focusWindow(app, window2.windowId, window2Page);
+    const panel2 = await spawnTerminalAndVerify(window2Page);
+
+    const nonceA = `mw-a-${randomUUID()}`;
+    const nonceB = `mw-b-${randomUUID()}`;
+
+    // Type nonce A in window 1's terminal — it must appear in window 1
+    // and never bleed into window 2's terminal.
+    await focusWindow(app, window1Id, window1Page);
+    await runTerminalCommand(window1Page, panel1, `echo ${nonceA}`);
+    await waitForTerminalText(panel1, nonceA, T_LONG);
+    expect(await getTerminalText(panel2)).not.toContain(nonceA);
+
+    // Type nonce B in window 2's terminal — it must appear in window 2
+    // and never bleed into window 1's terminal.
+    await focusWindow(app, window2.windowId, window2Page);
+    await runTerminalCommand(window2Page, panel2, `echo ${nonceB}`);
+    await waitForTerminalText(panel2, nonceB, T_LONG);
+    expect(await getTerminalText(panel1)).not.toContain(nonceB);
+
+    // Confirm the original nonces did not leak post-second-write.
+    expect(await getTerminalText(panel1)).not.toContain(nonceB);
+    expect(await getTerminalText(panel2)).not.toContain(nonceA);
+  });
+
+  test("worktree updates scope to the originating window's project", async () => {
+    const main1 = window1Page.locator(SEL.worktree.mainCard);
+    const main2 = window2Page.locator(SEL.worktree.mainCard);
+    await expect(main1).toBeVisible({ timeout: T_LONG });
+    await expect(main2).toBeVisible({ timeout: T_LONG });
+
+    // Both cards start clean.
+    await expect
+      .poll(() => main1.getAttribute("aria-label"), { timeout: T_LONG })
+      .not.toContain("has uncommitted changes");
+    await expect
+      .poll(() => main2.getAttribute("aria-label"), { timeout: T_LONG })
+      .not.toContain("has uncommitted changes");
+
+    // Cooldown for GIT_WATCH_SELF_TRIGGER_COOLDOWN_MS (1000ms).
+    await window1Page.waitForTimeout(1500);
+
+    // External file change in fixture A only — fixture B must remain clean.
+    writeFileSync(path.join(fixtures[0].dir, "isolation-marker.txt"), "scoped\n");
+
+    await expect
+      .poll(() => main1.getAttribute("aria-label"), {
+        timeout: T_LONG,
+        message: "Window 1's main card should detect the external change",
+      })
+      .toContain("has uncommitted changes");
+
+    // Window 2 must NOT report dirty state — its WorktreeMonitor watches
+    // fixture B, not fixture A. `expect.poll().not.toContain()` exits the
+    // moment the negative condition holds (which is immediately, since
+    // main2 starts clean), so a cross-routed event arriving 300–500ms
+    // later would escape. Sustain the window with an explicit wait, then
+    // snapshot-assert after the dwell.
+    await window2Page.waitForTimeout(T_MEDIUM);
+    expect(await main2.getAttribute("aria-label")).not.toContain("has uncommitted changes");
+  });
+
+  test("closing one window leaves the other fully functional", async () => {
+    const app = ctx!.app;
+
+    // Close window 1; assert window 2 stays alive and its services keep working.
+    await closeWindow(app, window1Id, T_LONG);
+
+    // Window 2's BrowserWindow must still be present.
+    const survivors = await app.evaluate(({ BrowserWindow }) =>
+      BrowserWindow.getAllWindows()
+        .filter((w) => !w.isDestroyed())
+        .map((w) => w.id)
+    );
+    expect(survivors).toContain(window2.windowId);
+    expect(survivors).not.toContain(window1Id);
+
+    // Re-acquire window 2's page (the closure may have nudged Z-order) and
+    // confirm a fresh terminal write still flows end-to-end — proves
+    // PtyClient (global) survived and window 2's per-window port routing
+    // is intact.
+    window2Page = await getWindowPage(app, window2.windowId, T_LONG);
+    await focusWindow(app, window2.windowId, window2Page);
+
+    const survivorNonce = `mw-survive-${randomUUID()}`;
+    const survivorPanel = await spawnTerminalAndVerify(window2Page);
+    await runTerminalCommand(window2Page, survivorPanel, `echo ${survivorNonce}`);
+    await waitForTerminalText(survivorPanel, survivorNonce, T_LONG);
+
+    // Prove window 2's worktree MessagePort is still live by triggering a
+    // fresh external file change in fixture B and asserting the dirty
+    // indicator appears. Checking the already-rendered toolbar label would
+    // only verify cached React state, not that new worktree events flow.
+    const main2 = window2Page.locator(SEL.worktree.mainCard);
+    await expect(main2).toBeVisible({ timeout: T_LONG });
+    await window2Page.waitForTimeout(1500); // GIT_WATCH_SELF_TRIGGER_COOLDOWN_MS
+    writeFileSync(path.join(fixtures[1].dir, "post-close-marker.txt"), "alive\n");
+    await expect
+      .poll(() => main2.getAttribute("aria-label"), {
+        timeout: T_LONG,
+        message: "Window 2's worktree port must still deliver updates after window 1 closes",
+      })
+      .toContain("has uncommitted changes");
+  });
+});

--- a/e2e/helpers/launch.ts
+++ b/e2e/helpers/launch.ts
@@ -710,3 +710,230 @@ export async function mockOpenDialog(
     dialog.showOpenDialog = () => Promise.resolve({ canceled: false, filePaths: [dirPath] });
   }, directoryPath);
 }
+
+export interface WindowHandle {
+  page: Page;
+  windowId: number;
+}
+
+async function listKnownWindowIds(app: ElectronApplication): Promise<number[]> {
+  return app.evaluate(({ BrowserWindow }) => {
+    return BrowserWindow.getAllWindows()
+      .filter((w) => !w.isDestroyed())
+      .map((w) => w.id);
+  });
+}
+
+async function getAttachedProjectUrlForWindow(
+  app: ElectronApplication,
+  windowId: number
+): Promise<string | null> {
+  try {
+    return await app.evaluate(({ BrowserWindow }, id) => {
+      const win = BrowserWindow.fromId(id);
+      if (!win || win.isDestroyed()) return null;
+      const views = win.contentView?.children ?? [];
+      let fallback: string | null = null;
+      for (let i = views.length - 1; i >= 0; i--) {
+        const wc = (views[i] as Electron.WebContentsView).webContents;
+        if (!wc || wc.isDestroyed()) continue;
+        const url = wc.getURL();
+        if (url.includes("projectId=")) return url;
+        if (fallback === null) fallback = url;
+      }
+      return fallback;
+    }, windowId);
+  } catch {
+    return null;
+  }
+}
+
+/**
+ * Resolve the active appView Page for a specific BrowserWindow id.
+ * Use after opening a second window — the global `getActiveAppWindow`
+ * targets `BrowserWindow.getAllWindows()[0]`, which is Z-ordered and may
+ * return the wrong window once more than one exists.
+ */
+export async function getWindowPage(
+  app: ElectronApplication,
+  windowId: number,
+  timeoutMs = getRefreshTimeout()
+): Promise<Page> {
+  const deadline = Date.now() + timeoutMs;
+  let lastUrl: string | null = null;
+  while (Date.now() < deadline) {
+    const attachedUrl = await getAttachedProjectUrlForWindow(app, windowId);
+    if (attachedUrl && attachedUrl.includes("projectId=")) {
+      for (const w of app.windows()) {
+        if (w.url() === attachedUrl) return w;
+      }
+      lastUrl = attachedUrl;
+    } else if (attachedUrl) {
+      lastUrl = attachedUrl;
+    }
+    await wait(150);
+  }
+  const urls = app.windows().map((w) => w.url());
+  throw new Error(
+    `No project view found for windowId=${windowId}. Last attached URL: ${lastUrl ?? "none"}. Available pages: ${urls.join(", ")}`
+  );
+}
+
+/**
+ * Open a second BrowserWindow via `window.electron.window.openNew(projectPath?)`
+ * and return its handle (page + windowId). When `projectPath` is provided,
+ * the new window auto-opens that project via `handleDirectoryOpen` — the
+ * same path the `app.newWindow` action takes when invoked with args.
+ *
+ * Captures the BrowserWindow id-snapshot before the call so the newly-created
+ * window can be identified without relying on the Z-ordered `getAllWindows()`
+ * array order (which is unstable in Electron 41).
+ *
+ * The returned `page` is the BW sentinel page (`data:` URL). For the active
+ * project view, call `getWindowPage(app, handle.windowId)` after the
+ * project finishes loading.
+ */
+export async function openSecondWindow(
+  app: ElectronApplication,
+  driverPage: Page,
+  options: { projectPath?: string; timeoutMs?: number } = {}
+): Promise<WindowHandle> {
+  const timeoutMs = options.timeoutMs ?? getRefreshTimeout();
+  const knownIds = new Set(await listKnownWindowIds(app));
+
+  await driverPage.evaluate(async (projectPath?: string) => {
+    const api = (
+      window as unknown as {
+        electron?: { window?: { openNew?: (p?: string) => Promise<void> } };
+      }
+    ).electron?.window;
+    if (!api?.openNew) {
+      throw new Error("window.electron.window.openNew is not available");
+    }
+    await api.openNew(projectPath);
+  }, options.projectPath);
+
+  const idDeadline = Date.now() + timeoutMs;
+  let newWindowId: number | null = null;
+  while (Date.now() < idDeadline) {
+    const ids = await listKnownWindowIds(app);
+    const fresh = ids.filter((id) => !knownIds.has(id));
+    if (fresh.length > 0) {
+      newWindowId = fresh[fresh.length - 1];
+      break;
+    }
+    await wait(150);
+  }
+  if (newWindowId === null) {
+    throw new Error(`Second BrowserWindow did not appear within ${timeoutMs}ms after openNew`);
+  }
+
+  const pageDeadline = Date.now() + timeoutMs;
+  let sentinelPage: Page | null = null;
+  while (Date.now() < pageDeadline) {
+    const sentinelUrl = await app
+      .evaluate(({ BrowserWindow }, id) => {
+        const win = BrowserWindow.fromId(id);
+        if (!win || win.isDestroyed()) return null;
+        return win.webContents.getURL();
+      }, newWindowId)
+      .catch(() => null);
+
+    if (sentinelUrl) {
+      for (const w of app.windows()) {
+        if (w.url() === sentinelUrl) {
+          sentinelPage = w;
+          break;
+        }
+      }
+      if (sentinelPage) break;
+    }
+    await wait(150);
+  }
+
+  if (!sentinelPage) {
+    throw new Error(`Second window sentinel page did not appear within ${timeoutMs}ms`);
+  }
+
+  return { page: sentinelPage, windowId: newWindowId };
+}
+
+/**
+ * Focus a specific BrowserWindow + its project view so CDP keyboard input
+ * routes to that page. Mirrors the warm-up sequence in `refreshActiveWindow`
+ * but scoped to a windowId rather than the Z-ordered `getAllWindows()[0]`.
+ */
+export async function focusWindow(
+  app: ElectronApplication,
+  windowId: number,
+  page: Page
+): Promise<void> {
+  try {
+    const url = page.url();
+    const match = url.match(/[?&]projectId=([^&]+)/);
+    const projectId = match ? decodeURIComponent(match[1]) : null;
+
+    await app.evaluate(
+      ({ BrowserWindow }, { id, pid }) => {
+        const win = BrowserWindow.fromId(id);
+        if (!win || win.isDestroyed()) return;
+        win.focus();
+        if (!pid) return;
+        const views = win.contentView?.children ?? [];
+        for (const child of views) {
+          const wc = (child as Electron.WebContentsView).webContents;
+          if (!wc || wc.isDestroyed()) continue;
+          if (wc.getURL().includes(`projectId=${encodeURIComponent(pid)}`)) {
+            wc.focus();
+            break;
+          }
+        }
+      },
+      { id: windowId, pid: projectId }
+    );
+
+    await page.bringToFront().catch(() => {});
+
+    const grid = page.locator('[data-grid-container="true"]').first();
+    const clickTarget = (await grid.isVisible({ timeout: 2_000 }).catch(() => false))
+      ? grid
+      : page.locator("body");
+    for (let attempt = 0; attempt < 5; attempt++) {
+      await clickTarget.click({ position: { x: 5, y: 5 }, force: true });
+      const hasFocus = await page.evaluate(() => document.hasFocus()).catch(() => false);
+      if (hasFocus) break;
+      await wait(200);
+    }
+
+    await page.keyboard.press("Control").catch(() => {});
+  } catch {
+    // Best-effort focus; tests can still proceed.
+  }
+}
+
+/**
+ * Close a specific BrowserWindow by id and wait until it's destroyed.
+ * Used by multi-window specs that need to verify per-window cleanup
+ * without tearing down the entire ElectronApplication.
+ */
+export async function closeWindow(
+  app: ElectronApplication,
+  windowId: number,
+  timeoutMs = getRefreshTimeout()
+): Promise<void> {
+  await app.evaluate(({ BrowserWindow }, id) => {
+    const win = BrowserWindow.fromId(id);
+    if (win && !win.isDestroyed()) win.close();
+  }, windowId);
+
+  const deadline = Date.now() + timeoutMs;
+  while (Date.now() < deadline) {
+    const stillAlive = await app.evaluate(({ BrowserWindow }, id) => {
+      const win = BrowserWindow.fromId(id);
+      return !!win && !win.isDestroyed();
+    }, windowId);
+    if (!stillAlive) return;
+    await wait(150);
+  }
+  throw new Error(`Window ${windowId} did not close within ${timeoutMs}ms`);
+}


### PR DESCRIPTION
## Summary

- Adds four serial E2E tests in `e2e/full/platform/core-multi-window.spec.ts` covering the acceptance criteria from #7896: independent project hosting, terminal I/O scoping via UUID nonces, worktree dirty-state isolation, and post-close survivability of the surviving window
- Adds four helpers to `e2e/helpers/launch.ts` (`getWindowPage`, `openSecondWindow`, `focusWindow`, `closeWindow`) plus a `WindowHandle` type, all scoped by `BrowserWindow` ID — never indexed by `getAllWindows()` position, which is Z-order-unstable in Electron 41
- All four tests pass locally across multiple runs (8.3s / 15.0s on macOS); typecheck and lint ratchet both clean

Resolves #7896

## Changes

- `e2e/helpers/launch.ts` — new window management helpers and `WindowHandle` type (+227 lines)
- `e2e/full/platform/core-multi-window.spec.ts` — new spec with `describe.serial` covering all four acceptance criteria (+215 lines)

## Testing

4/4 tests pass locally on macOS with `npx playwright test core-multi-window.spec.ts --project=full-platform`. `npx tsc --noEmit` clean. Lint ratchet at baseline 895 warnings.