### PR TITLE
fix(e2e): harden online bucket retries and idle poll against API latency

### DIFF
--- a/e2e/online/terminal-identity-transitions.spec.ts
+++ b/e2e/online/terminal-identity-transitions.spec.ts
@@ -182,9 +182,10 @@ async function expectAgentChromeSurvivesIdle(
   terminalId: string,
   agentId: string
 ): Promise<void> {
+  await page.waitForTimeout(AGENT_IDLE_STICKINESS_MS * SLOW_HOST_MULTIPLIER);
   await expect
     .poll(() => panel.getAttribute("data-chrome-agent-id"), {
-      timeout: AGENT_IDLE_STICKINESS_MS + 25_000,
+      timeout: 25_000 * SLOW_HOST_MULTIPLIER,
       intervals: [1_000, 5_000],
     })
     .toBe(agentId);

--- a/e2e/online/terminal-identity-transitions.spec.ts
+++ b/e2e/online/terminal-identity-transitions.spec.ts
@@ -182,11 +182,10 @@ async function expectAgentChromeSurvivesIdle(
   terminalId: string,
   agentId: string
 ): Promise<void> {
-  await page.waitForTimeout(AGENT_IDLE_STICKINESS_MS);
   await expect
     .poll(() => panel.getAttribute("data-chrome-agent-id"), {
-      timeout: 5_000,
-      intervals: [250],
+      timeout: AGENT_IDLE_STICKINESS_MS + 25_000,
+      intervals: [1_000, 5_000],
     })
     .toBe(agentId);
   await expectPanelHeaderIcon(panel, agentId);

--- a/playwright.config.ts
+++ b/playwright.config.ts
@@ -80,7 +80,7 @@ export default defineConfig({
       name: "online",
       testDir: "./e2e/online",
       timeout: onlineTimeout,
-      retries: isCI ? 1 : 0,
+      retries: isCI ? 2 : 0,
     },
     {
       name: "nightly",


### PR DESCRIPTION
## Summary

The online E2E bucket runs against real model APIs, so it catches latency spikes and output variance that the offline buckets never see. This tightens up two things to cut down on the flakiness.

- Bumps online retries from 1 to 2 in `playwright.config.ts` to match the `full-*` buckets. Each retry costs real API time, but the bucket only has three tests so the spend is bounded.
- Widens `expectAgentChromeSurvivesIdle` poll timeout from 5 seconds to 25 seconds and spaces the intervals with a backoff pattern (1s then 5s), scaled by `SLOW_HOST_MULTIPLIER`. A single short poll after a fixed `waitForTimeout` is fragile by construction -- API latency or a transient hang blows through it. The wider window with backoff survives a blip without failing the run while still catching a genuine regression.

Resolves #7901

## Changes

- `playwright.config.ts` -- online project `retries`: 1 -> 2
- `e2e/online/terminal-identity-transitions.spec.ts` -- `expectAgentChromeSurvivesIdle`: apply `SLOW_HOST_MULTIPLIER` to the idle wait, widen poll timeout from 5s to 25s with `[1_000, 5_000]` backoff intervals

## Test plan

- [ ] Online E2E bucket passes on CI without the idle-poll timeout