### PR TITLE
refactor(errors): replace isTransient boolean with retryability discriminant

### DIFF
--- a/e2e/full/resilience/core-error-buffering.spec.ts
+++ b/e2e/full/resilience/core-error-buffering.spec.ts
@@ -12,7 +12,7 @@ interface ErrorPayload {
   timestamp: number;
   type: string;
   message: string;
-  isTransient: boolean;
+  retryability: "auto" | "user-gated" | "exhausted" | "none";
   dismissed: boolean;
 }
 
@@ -23,7 +23,7 @@ function buildError(overrides: Partial<ErrorPayload> = {}): ErrorPayload {
     timestamp: Date.now(),
     type: "unknown",
     message: `E2E buffered error ${errorSeq}`,
-    isTransient: false,
+    retryability: "none",
     dismissed: false,
     ...overrides,
   };

--- a/e2e/full/resilience/core-error-retry-persistence.spec.ts
+++ b/e2e/full/resilience/core-error-retry-persistence.spec.ts
@@ -25,7 +25,7 @@ interface ErrorPayload {
   details?: string;
   source?: string;
   context?: Record<string, unknown>;
-  isTransient: boolean;
+  retryability: "auto" | "user-gated" | "exhausted" | "none";
   dismissed: boolean;
   retryAction?: string;
   retryArgs?: Record<string, unknown>;
@@ -43,7 +43,7 @@ function buildError(overrides: Partial<ErrorPayload> = {}): ErrorPayload {
     timestamp: Date.now(),
     type: "unknown",
     message: "E2E retry test error",
-    isTransient: false,
+    retryability: "none",
     dismissed: false,
     ...overrides,
   };
@@ -125,7 +125,7 @@ test.describe.serial("Core: Error Retry & Cancellation", () => {
       type: "git",
       message: msg,
       source: "ProgressTest",
-      isTransient: true,
+      retryability: "auto",
       retryAction: "terminal",
     });
 
@@ -154,7 +154,7 @@ test.describe.serial("Core: Error Retry & Cancellation", () => {
       type: "git",
       message: msg,
       source: "SuccessTest",
-      isTransient: true,
+      retryability: "auto",
       retryAction: "terminal",
     });
 
@@ -178,7 +178,7 @@ test.describe.serial("Core: Error Retry & Cancellation", () => {
       type: "git",
       message: msg,
       source: "CancelTest",
-      isTransient: true,
+      retryability: "auto",
       retryAction: "terminal",
     });
 
@@ -253,7 +253,7 @@ test.describe.serial("Core: Error Persistence Across Restart", () => {
       type: "config",
       message: "Critical config error from previous session",
       source: "ConfigService",
-      isTransient: false,
+      retryability: "none",
       fromPreviousSession: true,
     });
 

--- a/e2e/full/resilience/core-ipc-error-propagation.spec.ts
+++ b/e2e/full/resilience/core-ipc-error-propagation.spec.ts
@@ -18,7 +18,7 @@ interface ErrorPayload {
   details?: string;
   source?: string;
   context?: Record<string, unknown>;
-  isTransient: boolean;
+  retryability: "auto" | "user-gated" | "exhausted" | "none";
   dismissed: boolean;
   retryAction?: string;
   retryArgs?: Record<string, unknown>;
@@ -35,7 +35,7 @@ function buildError(overrides: Partial<ErrorPayload> = {}): ErrorPayload {
     timestamp: Date.now(),
     type: "unknown",
     message: "E2E test error",
-    isTransient: false,
+    retryability: "none",
     dismissed: false,
     ...overrides,
   };
@@ -136,7 +136,7 @@ test.describe.serial("Core: IPC Error Propagation", () => {
       type: "git",
       message: "Authentication failed for repository",
       source: "GitService",
-      isTransient: true,
+      retryability: "auto",
       retryAction: "git",
       recoveryHint: "Check your Git credentials or SSH key configuration.",
     });
@@ -203,7 +203,7 @@ test.describe.serial("Core: IPC Error Propagation", () => {
       type: "git",
       message: "ETIMEDOUT: connection timed out",
       source: "GitService",
-      isTransient: true,
+      retryability: "auto",
       retryAction: "git",
     });
 
@@ -212,7 +212,7 @@ test.describe.serial("Core: IPC Error Propagation", () => {
       type: "config",
       message: "Invalid configuration file",
       source: "ConfigService",
-      isTransient: false,
+      retryability: "none",
     });
 
     const panel = ctx.window.locator(SEL.diagnostics.panel("problems"));
@@ -233,7 +233,7 @@ test.describe.serial("Core: IPC Error Propagation", () => {
       type: "git",
       message: "E2E dedup test error",
       source: "DeduplicationTest",
-      isTransient: false,
+      retryability: "none",
     });
 
     // Send 5 identical errors in a single evaluate to ensure they arrive within 500ms
@@ -271,7 +271,7 @@ test.describe.serial("Core: IPC Error Propagation", () => {
       type: "git",
       message: "E2E dedup test error",
       source: "DeduplicationTest",
-      isTransient: false,
+      retryability: "none",
     });
 
     await ctx.window.waitForTimeout(300);

--- a/electron/ipc/__tests__/errorHandlers.test.ts
+++ b/electron/ipc/__tests__/errorHandlers.test.ts
@@ -1580,7 +1580,7 @@ describe("errorHandlers", () => {
 
       registerErrorHandlers(null, null);
       const handler = getInvokeHandler(CHANNELS.ERROR_GET_PENDING);
-      const result = handler({} as never) as Array<Record<string, unknown>>;
+      const result = (await handler({} as never)) as Array<Record<string, unknown>>;
 
       expect(result[0]).toMatchObject({
         id: "error-legacy-transient",
@@ -1615,7 +1615,7 @@ describe("errorHandlers", () => {
 
       registerErrorHandlers(null, null);
       const handler = getInvokeHandler(CHANNELS.ERROR_GET_PENDING);
-      const result = handler({} as never) as Array<Record<string, unknown>>;
+      const result = (await handler({} as never)) as Array<Record<string, unknown>>;
 
       expect(result[0].retryability).toBe("auto");
       expect(result[0].isTransient).toBeUndefined();

--- a/electron/ipc/__tests__/errorHandlers.test.ts
+++ b/electron/ipc/__tests__/errorHandlers.test.ts
@@ -352,6 +352,61 @@ describe("errorHandlers", () => {
       expect(sleepMock).not.toHaveBeenCalled();
     });
 
+    it("emits retryability='exhausted' when an auto-retryable error uses up its budget", async () => {
+      const CHANNELS = await getChannels();
+      const mockWindow = createMockWindow();
+      const spawn = vi.fn(() => {
+        throw createTransientError("EBUSY");
+      });
+
+      registerErrorHandlers(null, createPtyClientMock(spawn));
+      const retryHandler = getInvokeHandler(CHANNELS.ERROR_RETRY);
+
+      await expect(
+        retryHandler(
+          {} as never,
+          {
+            errorId: "e-exh-1",
+            action: "terminal",
+            args: { id: "t-exh-1", cwd: "/tmp" },
+          } as never
+        )
+      ).rejects.toThrow("EBUSY");
+
+      const notifyCall = mockWindow.webContents.send.mock.calls.find(
+        ([channel]: string[]) => channel === CHANNELS.ERROR_NOTIFY
+      );
+      expect(notifyCall?.[1]?.retryability).toBe("exhausted");
+    });
+
+    it("preserves intrinsic retryability when the loop bails on a non-transient error", async () => {
+      const CHANNELS = await getChannels();
+      const mockWindow = createMockWindow();
+      const { GitOperationError } = await import("../../utils/errorTypes.js");
+      const spawn = vi.fn(() => {
+        throw new GitOperationError("auth-failed", "auth required");
+      });
+
+      registerErrorHandlers(null, createPtyClientMock(spawn));
+      const retryHandler = getInvokeHandler(CHANNELS.ERROR_RETRY);
+
+      await expect(
+        retryHandler(
+          {} as never,
+          {
+            errorId: "e-auth-1",
+            action: "terminal",
+            args: { id: "t-auth-1", cwd: "/tmp" },
+          } as never
+        )
+      ).rejects.toThrow("auth required");
+
+      const notifyCall = mockWindow.webContents.send.mock.calls.find(
+        ([channel]: string[]) => channel === CHANNELS.ERROR_NOTIFY
+      );
+      expect(notifyCall?.[1]?.retryability).toBe("user-gated");
+    });
+
     it("stops retrying when a transient error becomes non-transient mid-loop", async () => {
       const CHANNELS = await getChannels();
       createMockWindow();
@@ -1539,6 +1594,31 @@ describe("errorHandlers", () => {
         fromPreviousSession: true,
       });
       expect(result[1].isTransient).toBeUndefined();
+    });
+
+    it("rejects an invalid retryability value from the persisted store", async () => {
+      const CHANNELS = await getChannels();
+      // Corrupted/dev store with an unrecognised retryability string. We fall
+      // back to the same isTransient-based default rather than surfacing the
+      // bogus value to the renderer.
+      storeMock.store.get.mockReturnValue([
+        {
+          id: "error-bogus",
+          timestamp: 1,
+          type: "filesystem",
+          message: "bogus retryability",
+          retryability: "transient",
+          isTransient: true,
+          dismissed: false,
+        },
+      ]);
+
+      registerErrorHandlers(null, null);
+      const handler = getInvokeHandler(CHANNELS.ERROR_GET_PENDING);
+      const result = handler({} as never) as Array<Record<string, unknown>>;
+
+      expect(result[0].retryability).toBe("auto");
+      expect(result[0].isTransient).toBeUndefined();
     });
 
     it("clears persisted errors after retrieval", async () => {

--- a/electron/ipc/__tests__/errorHandlers.test.ts
+++ b/electron/ipc/__tests__/errorHandlers.test.ts
@@ -730,7 +730,7 @@ describe("errorHandlers", () => {
         message: `seeded ${i}`,
         timestamp: i,
         source: "main-process",
-        isTransient: false,
+        retryability: "none",
         dismissed: false,
       }));
       storeMock.store.get.mockReturnValue(seeded);
@@ -1480,7 +1480,7 @@ describe("errorHandlers", () => {
           timestamp: Date.now() - 60000,
           type: "config" as const,
           message: "Config error from last session",
-          isTransient: false,
+          retryability: "none" as const,
           dismissed: false,
           correlationId: "aabbccdd-1111-2222-3333-444455556666",
         },
@@ -1501,6 +1501,46 @@ describe("errorHandlers", () => {
       ]);
     });
 
+    it("migrates legacy isTransient field on persisted errors", async () => {
+      const CHANNELS = await getChannels();
+      // Pre-#7912 persisted shape with the boolean field.
+      storeMock.store.get.mockReturnValue([
+        {
+          id: "error-legacy-transient",
+          timestamp: 1,
+          type: "filesystem",
+          message: "EBUSY: legacy persisted",
+          isTransient: true,
+          dismissed: false,
+        },
+        {
+          id: "error-legacy-permanent",
+          timestamp: 2,
+          type: "config",
+          message: "config corrupt",
+          isTransient: false,
+          dismissed: false,
+        },
+      ]);
+
+      registerErrorHandlers(null, null);
+      const handler = getInvokeHandler(CHANNELS.ERROR_GET_PENDING);
+      const result = handler({} as never) as Array<Record<string, unknown>>;
+
+      expect(result[0]).toMatchObject({
+        id: "error-legacy-transient",
+        retryability: "auto",
+        fromPreviousSession: true,
+      });
+      expect(result[0].isTransient).toBeUndefined();
+      expect(result[1]).toMatchObject({
+        id: "error-legacy-permanent",
+        retryability: "none",
+        fromPreviousSession: true,
+      });
+      expect(result[1].isTransient).toBeUndefined();
+    });
+
     it("clears persisted errors after retrieval", async () => {
       const CHANNELS = await getChannels();
       storeMock.store.get.mockReturnValue([
@@ -1509,7 +1549,7 @@ describe("errorHandlers", () => {
           timestamp: Date.now(),
           type: "filesystem",
           message: "test",
-          isTransient: false,
+          retryability: "none",
           dismissed: false,
         },
       ]);

--- a/electron/ipc/errorHandlers.ts
+++ b/electron/ipc/errorHandlers.ts
@@ -13,6 +13,7 @@ import {
   ConfigError,
   getUserMessage,
   getErrorDetails,
+  getRetryability,
   isTransientError,
 } from "../utils/errorTypes.js";
 import { getGitRecoveryAction, getGitRecoveryHint } from "../../shared/utils/gitOperationErrors.js";
@@ -21,7 +22,12 @@ import { appendPendingError, MAX_PENDING_ERRORS } from "./pendingErrorsStore.js"
 import { FAULT_MODE_ENABLED } from "./faultRegistry.js";
 import type { PtyClient } from "../services/PtyClient.js";
 import type { WorkspaceClient } from "../services/WorkspaceClient.js";
-import type { ErrorRecord, ErrorType, RetryAction } from "../../shared/types/ipc/errors.js";
+import type {
+  ErrorRecord,
+  ErrorRetryability,
+  ErrorType,
+  RetryAction,
+} from "../../shared/types/ipc/errors.js";
 import type { SpawnResult } from "../../shared/types/pty-host.js";
 
 interface RetryPayload {
@@ -227,6 +233,12 @@ function createErrorRecord(
     context?: ErrorRecord["context"];
     retryAction?: RetryAction;
     retryArgs?: Record<string, unknown>;
+    /**
+     * Explicit override for the retryability classification. Callers use this
+     * to mark a record as `"exhausted"` from the retry loop's final catch —
+     * exhaustion is loop state, not an intrinsic of the error itself.
+     */
+    retryability?: ErrorRetryability;
   } = {}
 ): ErrorRecord {
   const details = getErrorDetails(error);
@@ -243,7 +255,7 @@ function createErrorRecord(
     details: details.stack as string | undefined,
     source: options.source,
     context: options.context,
-    isTransient: isTransientError(error),
+    retryability: options.retryability ?? getRetryability(error, gitReason),
     dismissed: false,
     retryAction: options.retryAction,
     retryArgs: options.retryArgs,
@@ -256,6 +268,22 @@ function createErrorRecord(
 
 function isCriticalErrorType(type: ErrorType): boolean {
   return type === "config" || type === "filesystem";
+}
+
+/**
+ * Read-time migration for records persisted by older builds that wrote the
+ * legacy `isTransient: boolean` field. Maps `true → "auto"` and `false → "none"`
+ * and strips the legacy key so subsequent writes use the new shape.
+ */
+function migrateLegacyPersistedError(entry: unknown): ErrorRecord {
+  const record = (entry ?? {}) as Partial<ErrorRecord> & { isTransient?: boolean };
+  let { retryability } = record;
+  if (!retryability) {
+    retryability = record.isTransient === true ? "auto" : "none";
+  }
+  const { isTransient: _legacy, ...rest } = record;
+  void _legacy;
+  return { ...(rest as ErrorRecord), retryability, fromPreviousSession: true };
 }
 
 function isAbortError(error: unknown): boolean {
@@ -286,7 +314,7 @@ class ErrorService {
       this.pendingQueue.shift();
     }
 
-    if (isCriticalErrorType(error.type) && !error.isTransient) {
+    if (isCriticalErrorType(error.type) && error.retryability !== "auto") {
       this.persistError(error);
     }
   }
@@ -350,9 +378,9 @@ class ErrorService {
 
   getPendingPersistedErrors(): ErrorRecord[] {
     try {
-      const persisted = (store.get("pendingErrors") as ErrorRecord[] | undefined) ?? [];
+      const persisted = (store.get("pendingErrors") as unknown[] | undefined) ?? [];
       this.clearPersistedErrors();
-      return persisted.map((e) => ({ ...e, fromPreviousSession: true }));
+      return persisted.map((entry) => migrateLegacyPersistedError(entry));
     } catch {
       return [];
     }
@@ -591,6 +619,7 @@ export function registerErrorHandlers(
         source: `retry-${actionForError ?? "unknown"}`,
         retryAction: actionForError,
         retryArgs: argsForError,
+        retryability: "exhausted",
       });
       throw error;
     }

--- a/electron/ipc/errorHandlers.ts
+++ b/electron/ipc/errorHandlers.ts
@@ -270,15 +270,25 @@ function isCriticalErrorType(type: ErrorType): boolean {
   return type === "config" || type === "filesystem";
 }
 
+const VALID_RETRYABILITY: ReadonlySet<ErrorRetryability> = new Set([
+  "auto",
+  "user-gated",
+  "exhausted",
+  "none",
+]);
+
 /**
  * Read-time migration for records persisted by older builds that wrote the
  * legacy `isTransient: boolean` field. Maps `true → "auto"` and `false → "none"`
- * and strips the legacy key so subsequent writes use the new shape.
+ * and strips the legacy key so subsequent writes use the new shape. An invalid
+ * retryability string (corrupted store, dev-time write) is rejected and falls
+ * back to the same `isTransient`-based default so we never surface an
+ * unrecognised discriminant to the renderer.
  */
 function migrateLegacyPersistedError(entry: unknown): ErrorRecord {
   const record = (entry ?? {}) as Partial<ErrorRecord> & { isTransient?: boolean };
   let { retryability } = record;
-  if (!retryability) {
+  if (!retryability || !VALID_RETRYABILITY.has(retryability)) {
     retryability = record.isTransient === true ? "auto" : "none";
   }
   const { isTransient: _legacy, ...rest } = record;
@@ -615,11 +625,18 @@ export function registerErrorHandlers(
       if (isAbortError(error)) {
         throw error;
       }
+      // Only label as "exhausted" when the loop actually used up its retry
+      // budget — that requires the error to have been intrinsically auto-
+      // retryable in the first place. A first-attempt throw of a non-
+      // transient error (e.g. GitOperationError("auth-failed")) needs to
+      // keep its intrinsic classification so the renderer can still surface
+      // the recovery CTA.
+      const intrinsic = getRetryability(error);
       errorService.notifyError(error, {
         source: `retry-${actionForError ?? "unknown"}`,
         retryAction: actionForError,
         retryArgs: argsForError,
-        retryability: "exhausted",
+        retryability: intrinsic === "auto" ? "exhausted" : intrinsic,
       });
       throw error;
     }

--- a/electron/setup/__tests__/globalErrorHandlers.test.ts
+++ b/electron/setup/__tests__/globalErrorHandlers.test.ts
@@ -157,7 +157,7 @@ describe("globalErrorHandlers", () => {
             type: "unknown",
             message: expect.stringContaining("test crash"),
             source: "main-process",
-            isTransient: false,
+            retryability: "none",
             dismissed: false,
             fromPreviousSession: true,
             recoveryHint: "The application encountered a fatal error and will restart.",
@@ -183,7 +183,7 @@ describe("globalErrorHandlers", () => {
         type: "unknown",
         message: `seeded ${i}`,
         source: "main-process",
-        isTransient: false,
+        retryability: "none",
         dismissed: false,
       }));
       storeMock.get.mockReturnValue(seeded);
@@ -353,7 +353,7 @@ describe("globalErrorHandlers", () => {
       expect(sentPayload.source).toBe("main-process");
       expect(sentPayload.message).toContain("rejected");
       expect(sentPayload.recoveryHint).toContain("degraded state");
-      expect(sentPayload.isTransient).toBe(false);
+      expect(sentPayload.retryability).toBe("none");
       expect(sentPayload.dismissed).toBe(false);
     });
 
@@ -381,7 +381,7 @@ describe("globalErrorHandlers", () => {
             type: "unknown",
             message: expect.stringContaining("rejected"),
             source: "main-process",
-            isTransient: false,
+            retryability: "none",
             dismissed: false,
             fromPreviousSession: true,
             recoveryHint: expect.stringContaining("degraded state"),
@@ -407,7 +407,7 @@ describe("globalErrorHandlers", () => {
         type: "unknown",
         message: `seeded ${i}`,
         source: "main-process",
-        isTransient: false,
+        retryability: "none",
         dismissed: false,
       }));
       storeMock.get.mockReturnValue(seeded);

--- a/electron/setup/globalErrorHandlers.ts
+++ b/electron/setup/globalErrorHandlers.ts
@@ -27,7 +27,7 @@ function buildFatalErrorRecord(kind: string, error: unknown): ErrorRecord {
     message: `[${kind}] ${message}`,
     details: error instanceof Error ? error.stack : undefined,
     source: "main-process",
-    isTransient: false,
+    retryability: "none",
     dismissed: false,
     recoveryHint:
       kind === "UNCAUGHT_EXCEPTION"

--- a/electron/utils/__tests__/errorTypes.test.ts
+++ b/electron/utils/__tests__/errorTypes.test.ts
@@ -8,6 +8,7 @@ import {
   isAppError,
   toGitOperationError,
   getUserMessage,
+  getRetryability,
 } from "../errorTypes.js";
 import { serializeError, deserializeError } from "../../../shared/utils/ipcErrorSerialization.js";
 
@@ -168,5 +169,70 @@ describe("getUserMessage", () => {
   it("falls back to AppError.message when userMessage is absent", () => {
     const err = new AppError({ code: "VALIDATION", message: "Invalid payload" });
     expect(getUserMessage(err)).toBe("Invalid payload");
+  });
+});
+
+describe("getRetryability", () => {
+  it("classifies transient errno codes as 'auto'", () => {
+    for (const code of ["EBUSY", "EAGAIN", "ETIMEDOUT", "ECONNRESET", "ENOTFOUND"]) {
+      const err = Object.assign(new Error("net"), { code });
+      expect(getRetryability(err)).toBe("auto");
+    }
+  });
+
+  it("classifies non-transient errno codes as 'none'", () => {
+    for (const code of ["ENOENT", "EACCES", "EMFILE", "ENOMEM", "ENXIO"]) {
+      const err = Object.assign(new Error("permanent"), { code });
+      expect(getRetryability(err)).toBe("none");
+    }
+  });
+
+  it("maps git auth/config reasons to 'user-gated'", () => {
+    for (const reason of ["auth-failed", "config-missing", "dubious-ownership"] as const) {
+      const err = new GitOperationError(reason, "boom");
+      expect(getRetryability(err)).toBe("user-gated");
+    }
+  });
+
+  it("maps git transient reasons to 'auto'", () => {
+    for (const reason of ["network-unavailable", "system-io-error"] as const) {
+      const err = new GitOperationError(reason, "boom");
+      expect(getRetryability(err)).toBe("auto");
+    }
+  });
+
+  it("maps git terminal-policy reasons to 'none'", () => {
+    for (const reason of [
+      "repository-not-found",
+      "not-a-repository",
+      "worktree-dirty",
+      "conflict-unresolved",
+      "push-rejected-outdated",
+      "push-rejected-policy",
+      "pathspec-invalid",
+      "lfs-missing",
+      "lfs-quota-exceeded",
+      "hook-rejected",
+    ] as const) {
+      const err = new GitOperationError(reason, "boom");
+      expect(getRetryability(err)).toBe("none");
+    }
+  });
+
+  it("falls through to errno when gitReason is 'unknown'", () => {
+    const err = new GitOperationError("unknown", "boom");
+    Object.assign(err, { code: "ETIMEDOUT" });
+    expect(getRetryability(err)).toBe("auto");
+  });
+
+  it("prefers explicit gitReason argument over instance reason", () => {
+    const err = new GitOperationError("auth-failed", "boom");
+    expect(getRetryability(err, "network-unavailable")).toBe("auto");
+  });
+
+  it("returns 'none' for unknown shapes", () => {
+    expect(getRetryability(null)).toBe("none");
+    expect(getRetryability(undefined)).toBe("none");
+    expect(getRetryability(new Error("plain"))).toBe("none");
   });
 });

--- a/electron/utils/errorTypes.ts
+++ b/electron/utils/errorTypes.ts
@@ -1,5 +1,5 @@
 import { classifyGitError, extractGitErrorMessage } from "../../shared/utils/gitOperationErrors.js";
-import type { GitOperationReason } from "../../shared/types/ipc/errors.js";
+import type { ErrorRetryability, GitOperationReason } from "../../shared/types/ipc/errors.js";
 import type { AppErrorCode } from "../../shared/types/appError.js";
 import { formatErrorMessage } from "../../shared/utils/errorMessage.js";
 
@@ -162,6 +162,44 @@ export function isTransientError(error: unknown): boolean {
   // EMFILE, ENOMEM, ENXIO intentionally excluded — resource exhaustion
   // requires user remediation before retry (close terminals, free memory).
   return ["EBUSY", "EAGAIN", "ETIMEDOUT", "ECONNRESET", "ENOTFOUND"].includes(code || "");
+}
+
+/**
+ * Classify an error into one of the {@link ErrorRetryability} buckets. The
+ * git-reason check runs first so a classified git failure (e.g.
+ * `repository-not-found`) is never reclassified as "auto" by an unrelated
+ * errno on the cause chain. The errno fallback mirrors {@link isTransientError}.
+ *
+ * "exhausted" is never derived from intrinsics — it is a retry-loop state
+ * set explicitly by the caller via the `createErrorRecord` override.
+ */
+export function getRetryability(error: unknown, gitReason?: GitOperationReason): ErrorRetryability {
+  const reason = gitReason ?? (error instanceof GitOperationError ? error.reason : undefined);
+  if (reason) {
+    switch (reason) {
+      case "auth-failed":
+      case "config-missing":
+      case "dubious-ownership":
+        return "user-gated";
+      case "network-unavailable":
+      case "system-io-error":
+        return "auto";
+      case "repository-not-found":
+      case "not-a-repository":
+      case "worktree-dirty":
+      case "conflict-unresolved":
+      case "push-rejected-outdated":
+      case "push-rejected-policy":
+      case "pathspec-invalid":
+      case "lfs-missing":
+      case "lfs-quota-exceeded":
+      case "hook-rejected":
+        return "none";
+      case "unknown":
+        break;
+    }
+  }
+  return isTransientError(error) ? "auto" : "none";
 }
 
 export function getUserMessage(error: unknown): string {

--- a/shared/types/ipc/errors.ts
+++ b/shared/types/ipc/errors.ts
@@ -165,6 +165,20 @@ export interface RecoveryAction {
 /** Action that can be retried after an error */
 export type RetryAction = "terminal" | "git" | "worktree";
 
+/**
+ * Discriminant classifying how (or whether) an error can be recovered from.
+ *
+ * - `"auto"`: transient failure where silent retry is appropriate (e.g.,
+ *   `EBUSY`, `ETIMEDOUT`, `ECONNRESET`). UI may surface a Retry button.
+ * - `"user-gated"`: recoverable only after user action (e.g., re-auth,
+ *   missing config). UI surfaces the structured `recoveryAction` CTA.
+ * - `"exhausted"`: the retry loop ran to its retry budget and gave up.
+ *   Treated as a permanent failure for UI/persistence purposes.
+ * - `"none"`: permanent failure with no retry path (programmer error,
+ *   resource exhaustion, push-rejected-by-policy, etc.).
+ */
+export type ErrorRetryability = "auto" | "user-gated" | "exhausted" | "none";
+
 /** Payload sent from main to renderer to report retry progress */
 export interface RetryProgressPayload {
   id: string;
@@ -193,8 +207,8 @@ export interface ErrorRecord {
     filePath?: string;
     command?: string;
   };
-  /** Whether this error will auto-dismiss */
-  isTransient: boolean;
+  /** Classifies whether and how this error can be recovered from. */
+  retryability: ErrorRetryability;
   /** Whether user has dismissed this error */
   dismissed: boolean;
   /** Action that can be retried */

--- a/src/App.tsx
+++ b/src/App.tsx
@@ -303,7 +303,7 @@ function App() {
       useErrorStore.getState().addError({
         type: "unknown",
         message,
-        isTransient: false,
+        retryability: "none",
         source: "e2e-test",
       });
     };

--- a/src/components/Diagnostics/ProblemsContent.tsx
+++ b/src/components/Diagnostics/ProblemsContent.tsx
@@ -53,7 +53,7 @@ function ErrorRow({
   const typeLabel = ERROR_TYPE_LABELS[error.type] || "Error";
   const typeColor = ERROR_TYPE_COLORS[error.type] || "text-status-error";
   const isRetrying = !!error.retryProgress;
-  const canRetry = error.isTransient && error.retryAction && onRetry;
+  const canRetry = error.retryability === "auto" && error.retryAction && onRetry;
   const [copied, setCopied] = useState(false);
   const copyTimeoutRef = useRef<NodeJS.Timeout | null>(null);
 

--- a/src/components/ErrorBoundary/ErrorBoundary.tsx
+++ b/src/components/ErrorBoundary/ErrorBoundary.tsx
@@ -79,7 +79,7 @@ export class ErrorBoundary extends Component<ErrorBoundaryProps, ErrorBoundarySt
         details: `${error.stack || ""}\n\nComponent Stack:${componentStack}`,
         source: componentName || "ErrorBoundary",
         context,
-        isTransient: false,
+        retryability: "none",
         correlationId,
       });
     } catch (storeError) {

--- a/src/components/Errors/ErrorBanner.tsx
+++ b/src/components/Errors/ErrorBanner.tsx
@@ -13,6 +13,27 @@ import {
 } from "lucide-react";
 import type { ErrorRecord, RetryAction } from "@/store/errorStore";
 import { useDiagnosticsStore } from "@/store/diagnosticsStore";
+import { actionService } from "@/services/ActionService";
+
+/**
+ * Decide which CTA the banner should render. Pure function of `retryability`
+ * plus the optional wiring (`retryAction`, `recoveryAction`, `onRetry` prop):
+ *
+ *   - `"auto"` + retryAction + onRetry → Retry
+ *   - `"user-gated"` + recoveryAction  → run the structured recovery action
+ *   - everything else                  → View errors
+ */
+type BannerAction = "retry" | "recovery" | "view-errors";
+
+function bannerActionFor(error: ErrorRecord, hasOnRetry: boolean): BannerAction {
+  if (error.retryability === "auto" && error.retryAction && hasOnRetry) {
+    return "retry";
+  }
+  if (error.retryability === "user-gated" && error.recoveryAction) {
+    return "recovery";
+  }
+  return "view-errors";
+}
 
 export interface ErrorBannerProps {
   error: ErrorRecord;
@@ -115,7 +136,16 @@ export function ErrorBanner({
 
   const typeLabel = ERROR_TYPE_LABELS[error.type] || "Error";
   const TypeIcon = ERROR_TYPE_ICONS[error.type] ?? XCircle;
-  const canRetry = error.isTransient && error.retryAction && onRetry;
+  const action = bannerActionFor(error, Boolean(onRetry));
+  const canRetry = action === "retry";
+  const showRecovery = action === "recovery";
+
+  const handleRecovery = useCallback(() => {
+    if (!error.recoveryAction) return;
+    void actionService.dispatch(error.recoveryAction.actionId, error.recoveryAction.args, {
+      source: "user",
+    });
+  }, [error.recoveryAction]);
 
   const retryLabel = error.retryProgress
     ? `Retrying ${error.retryProgress.attempt}/${error.retryProgress.maxAttempts}...`
@@ -149,7 +179,12 @@ export function ErrorBanner({
             Retry
           </Button>
         )}
-        {!isRetrying && !canRetry && (
+        {!isRetrying && showRecovery && error.recoveryAction && (
+          <Button variant="ghost-danger" size="xs" onClick={handleRecovery}>
+            {error.recoveryAction.label}
+          </Button>
+        )}
+        {!isRetrying && !canRetry && !showRecovery && (
           <Button variant="ghost-danger" size="xs" onClick={handleViewErrors}>
             View errors
           </Button>
@@ -226,7 +261,12 @@ export function ErrorBanner({
               Retry
             </Button>
           )}
-          {!isRetrying && !canRetry && !error.details && (
+          {!isRetrying && showRecovery && error.recoveryAction && (
+            <Button variant="ghost-danger" size="xs" onClick={handleRecovery}>
+              {error.recoveryAction.label}
+            </Button>
+          )}
+          {!isRetrying && !canRetry && !showRecovery && !error.details && (
             <Button variant="ghost-danger" size="xs" onClick={handleViewErrors}>
               View errors
             </Button>

--- a/src/components/Errors/__tests__/ErrorBanner.test.tsx
+++ b/src/components/Errors/__tests__/ErrorBanner.test.tsx
@@ -15,7 +15,7 @@ function makeError(overrides: Partial<ErrorRecord> = {}): ErrorRecord {
     timestamp: Date.now(),
     type: "unknown",
     message: "Something failed",
-    isTransient: false,
+    retryability: "none",
     dismissed: false,
     ...overrides,
   };
@@ -117,7 +117,7 @@ describe("ErrorBanner", () => {
     it("does not render 'View errors' when retry is available", () => {
       render(
         <ErrorBanner
-          error={makeError({ isTransient: true, retryAction: "git" })}
+          error={makeError({ retryability: "auto", retryAction: "git" })}
           onDismiss={onDismiss}
           onRetry={vi.fn()}
           compact
@@ -127,10 +127,10 @@ describe("ErrorBanner", () => {
       expect(screen.getByRole("button", { name: "Retry" })).toBeTruthy();
     });
 
-    it("renders 'View errors' when isTransient is true but onRetry is missing", () => {
+    it("renders 'View errors' when retryability is 'auto' but onRetry is missing", () => {
       render(
         <ErrorBanner
-          error={makeError({ isTransient: true, retryAction: "git" })}
+          error={makeError({ retryability: "auto", retryAction: "git" })}
           onDismiss={onDismiss}
           compact
         />
@@ -178,7 +178,7 @@ describe("ErrorBanner", () => {
     it("does not render 'View errors' when retry is available", () => {
       render(
         <ErrorBanner
-          error={makeError({ isTransient: true, retryAction: "git" })}
+          error={makeError({ retryability: "auto", retryAction: "git" })}
           onDismiss={onDismiss}
           onRetry={vi.fn()}
         />
@@ -209,10 +209,10 @@ describe("ErrorBanner", () => {
       expect(screen.getByRole("button", { name: "Cancel" })).toBeTruthy();
     });
 
-    it("renders 'View errors' when isTransient is true but onRetry is missing", () => {
+    it("renders 'View errors' when retryability is 'auto' but onRetry is missing", () => {
       render(
         <ErrorBanner
-          error={makeError({ isTransient: true, retryAction: "git" })}
+          error={makeError({ retryability: "auto", retryAction: "git" })}
           onDismiss={onDismiss}
         />
       );
@@ -221,11 +221,62 @@ describe("ErrorBanner", () => {
     });
   });
 
+  describe("retryability-driven action slot", () => {
+    afterEach(() => {
+      useDiagnosticsStore.getState().reset();
+    });
+
+    it("renders Retry for 'auto' + retryAction + onRetry", () => {
+      render(
+        <ErrorBanner
+          error={makeError({ retryability: "auto", retryAction: "git" })}
+          onDismiss={onDismiss}
+          onRetry={vi.fn()}
+        />
+      );
+      expect(screen.getByRole("button", { name: "Retry" })).toBeTruthy();
+      expect(screen.queryByRole("button", { name: "View errors" })).toBeNull();
+    });
+
+    it("renders 'View errors' for 'exhausted' even when retryAction is wired", () => {
+      render(
+        <ErrorBanner
+          error={makeError({ retryability: "exhausted", retryAction: "git" })}
+          onDismiss={onDismiss}
+          onRetry={vi.fn()}
+        />
+      );
+      expect(screen.getByRole("button", { name: "View errors" })).toBeTruthy();
+      expect(screen.queryByRole("button", { name: "Retry" })).toBeNull();
+    });
+
+    it("renders the recovery CTA for 'user-gated' + recoveryAction", () => {
+      render(
+        <ErrorBanner
+          error={makeError({
+            retryability: "user-gated",
+            recoveryAction: { label: "Reconnect", actionId: "github.connect" },
+          })}
+          onDismiss={onDismiss}
+        />
+      );
+      expect(screen.getByRole("button", { name: "Reconnect" })).toBeTruthy();
+      expect(screen.queryByRole("button", { name: "View errors" })).toBeNull();
+    });
+
+    it("falls back to 'View errors' for 'user-gated' without recoveryAction", () => {
+      render(
+        <ErrorBanner error={makeError({ retryability: "user-gated" })} onDismiss={onDismiss} />
+      );
+      expect(screen.getByRole("button", { name: "View errors" })).toBeTruthy();
+    });
+  });
+
   describe("retry button styling", () => {
     it("does not use success-green classes on the compact retry button", () => {
       render(
         <ErrorBanner
-          error={makeError({ isTransient: true, retryAction: "git" })}
+          error={makeError({ retryability: "auto", retryAction: "git" })}
           onDismiss={onDismiss}
           onRetry={vi.fn()}
           compact
@@ -239,7 +290,7 @@ describe("ErrorBanner", () => {
     it("does not use success-green classes on the full retry button", () => {
       render(
         <ErrorBanner
-          error={makeError({ isTransient: true, retryAction: "git" })}
+          error={makeError({ retryability: "auto", retryAction: "git" })}
           onDismiss={onDismiss}
           onRetry={vi.fn()}
         />

--- a/src/hooks/__tests__/useErrors.test.ts
+++ b/src/hooks/__tests__/useErrors.test.ts
@@ -140,6 +140,38 @@ describe("useErrors — onError path", () => {
     expect(notifyMock).toHaveBeenCalledWith(expect.objectContaining({ priority: "low" }));
     unmount();
   });
+
+  it("includes a Retry action in the toast for retryability='auto' + retryAction", async () => {
+    const { useErrors } = await import("../useErrors");
+    const { unmount } = renderHook(() => useErrors());
+
+    const error = makeError({
+      type: "network",
+      retryability: "auto",
+      retryAction: "git",
+    });
+    act(() => capturedOnError(error));
+
+    const call = notifyMock.mock.calls.at(-1)?.[0] as { action?: { label?: string } };
+    expect(call?.action?.label).toBe("Retry");
+    unmount();
+  });
+
+  it("does NOT include a Retry action for retryability='exhausted' even with retryAction set", async () => {
+    const { useErrors } = await import("../useErrors");
+    const { unmount } = renderHook(() => useErrors());
+
+    const error = makeError({
+      type: "network",
+      retryability: "exhausted",
+      retryAction: "git",
+    });
+    act(() => capturedOnError(error));
+
+    const call = notifyMock.mock.calls.at(-1)?.[0] as { action?: { label?: string } };
+    expect(call?.action?.label).not.toBe("Retry");
+    unmount();
+  });
 });
 
 describe("useErrors — getPending path", () => {
@@ -513,7 +545,7 @@ describe("useErrors — retry action on toast", () => {
 
     const error = makeError({
       type: "git",
-      retryability: "none",
+      retryability: "auto",
       retryAction: "git",
       retryArgs: { branch: "main" },
     });
@@ -540,13 +572,17 @@ describe("useErrors — retry action on toast", () => {
     unmount();
   });
 
-  it("includes Copy details as a secondary action when both retry and copy are present", async () => {
+  it("includes Copy details as a secondary action when an auto error escalates to high priority", async () => {
+    // copyAction is gated on `priority === "high"` (toast scale) — an "auto"
+    // error normally routes low-priority to the inbox, so it has no Copy
+    // details secondary. Escalation lifts it to high and surfaces both.
+    shouldEscalateMock.mockReturnValueOnce(true);
     const { useErrors } = await import("../useErrors");
     const { unmount } = renderHook(() => useErrors());
 
     const error = makeError({
       type: "git",
-      retryability: "none",
+      retryability: "auto",
       retryAction: "git",
     });
     act(() => capturedOnError(error));
@@ -564,7 +600,7 @@ describe("useErrors — retry action on toast", () => {
 
     const error = makeError({
       type: "network",
-      retryability: "none",
+      retryability: "auto",
       retryAction: "terminal",
       retryArgs: { terminalId: "term-1" },
     });
@@ -586,7 +622,7 @@ describe("useErrors — retry action on toast", () => {
 
     const error = makeError({
       type: "network",
-      retryability: "none",
+      retryability: "auto",
       retryAction: "terminal",
     });
     act(() => capturedOnError(error));
@@ -607,7 +643,7 @@ describe("useErrors — retry action on toast", () => {
 
     const error = makeError({
       type: "network",
-      retryability: "none",
+      retryability: "auto",
       retryAction: "git",
     });
     act(() => capturedOnError(error));
@@ -626,7 +662,7 @@ describe("useErrors — retry action on toast", () => {
       type: "git",
       message: "fetch failed",
       source: "GitService",
-      retryability: "none",
+      retryability: "auto",
     });
     act(() => capturedOnError(first));
 
@@ -635,7 +671,7 @@ describe("useErrors — retry action on toast", () => {
       type: "git",
       message: "fetch failed",
       source: "GitService",
-      retryability: "none",
+      retryability: "auto",
       retryAction: "git",
       retryArgs: { branch: "main" },
     });
@@ -660,7 +696,7 @@ describe("useErrors — retry action on toast", () => {
       type: "git",
       message: "fetch failed",
       source: "GitService",
-      retryability: "none",
+      retryability: "auto",
       retryAction: "git",
       retryArgs: { branch: "old" },
     });
@@ -670,7 +706,7 @@ describe("useErrors — retry action on toast", () => {
       type: "git",
       message: "fetch failed",
       source: "GitService",
-      retryability: "none",
+      retryability: "auto",
       retryAction: "git",
       retryArgs: { branch: "new" },
     });
@@ -692,7 +728,7 @@ describe("useErrors — retry action on toast", () => {
 
     const error = makeError({
       type: "network",
-      retryability: "none",
+      retryability: "auto",
       retryAction: "git",
     });
     act(() => capturedOnError(error));

--- a/src/hooks/__tests__/useErrors.test.ts
+++ b/src/hooks/__tests__/useErrors.test.ts
@@ -50,7 +50,7 @@ function makeError(overrides: Partial<ErrorRecord> = {}): ErrorRecord {
     timestamp: Date.now(),
     type: "unknown",
     message: "Something went wrong",
-    isTransient: false,
+    retryability: "none",
     dismissed: false,
     ...overrides,
   };
@@ -63,37 +63,37 @@ describe("getErrorPriority", () => {
     ({ getErrorPriority } = await import("../useErrors"));
   });
 
-  it("returns 'low' for transient errors regardless of type", () => {
-    expect(getErrorPriority({ type: "process", isTransient: true })).toBe("low");
-    expect(getErrorPriority({ type: "config", isTransient: true })).toBe("low");
-    expect(getErrorPriority({ type: "git", isTransient: true })).toBe("low");
-    expect(getErrorPriority({ type: "network", isTransient: true })).toBe("low");
-    expect(getErrorPriority({ type: "filesystem", isTransient: true })).toBe("low");
-    expect(getErrorPriority({ type: "unknown", isTransient: true })).toBe("low");
+  it("returns 'low' for retryability='auto' regardless of type", () => {
+    expect(getErrorPriority({ type: "process", retryability: "auto" })).toBe("low");
+    expect(getErrorPriority({ type: "config", retryability: "auto" })).toBe("low");
+    expect(getErrorPriority({ type: "git", retryability: "auto" })).toBe("low");
+    expect(getErrorPriority({ type: "network", retryability: "auto" })).toBe("low");
+    expect(getErrorPriority({ type: "filesystem", retryability: "auto" })).toBe("low");
+    expect(getErrorPriority({ type: "unknown", retryability: "auto" })).toBe("low");
   });
 
-  it("returns 'high' for non-transient process errors", () => {
-    expect(getErrorPriority({ type: "process", isTransient: false })).toBe("high");
+  it("returns 'high' for retryability='none' process errors", () => {
+    expect(getErrorPriority({ type: "process", retryability: "none" })).toBe("high");
   });
 
-  it("returns 'high' for non-transient config errors", () => {
-    expect(getErrorPriority({ type: "config", isTransient: false })).toBe("high");
+  it("returns 'high' for retryability='none' config errors", () => {
+    expect(getErrorPriority({ type: "config", retryability: "none" })).toBe("high");
   });
 
-  it("returns 'high' for non-transient git errors", () => {
-    expect(getErrorPriority({ type: "git", isTransient: false })).toBe("high");
+  it("returns 'high' for retryability='none' git errors", () => {
+    expect(getErrorPriority({ type: "git", retryability: "none" })).toBe("high");
   });
 
-  it("returns 'high' for non-transient network errors", () => {
-    expect(getErrorPriority({ type: "network", isTransient: false })).toBe("high");
+  it("returns 'high' for retryability='none' network errors", () => {
+    expect(getErrorPriority({ type: "network", retryability: "none" })).toBe("high");
   });
 
-  it("returns 'high' for non-transient filesystem errors", () => {
-    expect(getErrorPriority({ type: "filesystem", isTransient: false })).toBe("high");
+  it("returns 'high' for retryability='none' filesystem errors", () => {
+    expect(getErrorPriority({ type: "filesystem", retryability: "none" })).toBe("high");
   });
 
-  it("returns 'high' for non-transient unknown errors", () => {
-    expect(getErrorPriority({ type: "unknown", isTransient: false })).toBe("high");
+  it("returns 'high' for retryability='none' unknown errors", () => {
+    expect(getErrorPriority({ type: "unknown", retryability: "none" })).toBe("high");
   });
 });
 
@@ -119,22 +119,22 @@ describe("useErrors — onError path", () => {
     vi.restoreAllMocks();
   });
 
-  it("calls notify with 'high' priority for non-transient process error", async () => {
+  it("calls notify with 'high' priority for retryability='none' process error", async () => {
     const { useErrors } = await import("../useErrors");
     const { unmount } = renderHook(() => useErrors());
 
-    const error = makeError({ type: "process", isTransient: false });
+    const error = makeError({ type: "process", retryability: "none" });
     act(() => capturedOnError(error));
 
     expect(notifyMock).toHaveBeenCalledWith(expect.objectContaining({ priority: "high" }));
     unmount();
   });
 
-  it("calls notify with 'low' priority for transient error", async () => {
+  it("calls notify with 'low' priority for retryability='auto' error", async () => {
     const { useErrors } = await import("../useErrors");
     const { unmount } = renderHook(() => useErrors());
 
-    const error = makeError({ type: "network", isTransient: true });
+    const error = makeError({ type: "network", retryability: "auto" });
     act(() => capturedOnError(error));
 
     expect(notifyMock).toHaveBeenCalledWith(expect.objectContaining({ priority: "low" }));
@@ -158,10 +158,10 @@ describe("useErrors — getPending path", () => {
     vi.restoreAllMocks();
   });
 
-  it("calls notify with 'high' priority for pending non-transient errors", async () => {
+  it("calls notify with 'high' priority for pending retryability='none' errors", async () => {
     const pendingError = makeError({
       type: "config",
-      isTransient: false,
+      retryability: "none",
       fromPreviousSession: true,
     });
     getPendingMock.mockResolvedValue([pendingError]);
@@ -179,10 +179,10 @@ describe("useErrors — getPending path", () => {
     unmount();
   });
 
-  it("calls notify with 'low' priority for pending transient errors", async () => {
+  it("calls notify with 'low' priority for pending retryability='auto' errors", async () => {
     const pendingError = makeError({
       type: "git",
-      isTransient: true,
+      retryability: "auto",
       fromPreviousSession: true,
     });
     getPendingMock.mockResolvedValue([pendingError]);
@@ -232,7 +232,7 @@ describe("useErrors — escalation of persistent transient errors", () => {
     const { useErrors } = await import("../useErrors");
     const { unmount } = renderHook(() => useErrors());
 
-    const error = makeError({ type: "network", isTransient: true });
+    const error = makeError({ type: "network", retryability: "auto" });
     act(() => capturedOnError(error));
 
     expect(notifyMock).toHaveBeenCalledWith(expect.objectContaining({ priority: "high" }));
@@ -244,7 +244,7 @@ describe("useErrors — escalation of persistent transient errors", () => {
     const { useErrors } = await import("../useErrors");
     const { unmount } = renderHook(() => useErrors());
 
-    const error = makeError({ type: "network", isTransient: true });
+    const error = makeError({ type: "network", retryability: "auto" });
     act(() => capturedOnError(error));
 
     expect(notifyMock).toHaveBeenCalledWith(expect.objectContaining({ priority: "low" }));
@@ -260,7 +260,7 @@ describe("useErrors — escalation of persistent transient errors", () => {
     const { useErrors } = await import("../useErrors");
     const { unmount } = renderHook(() => useErrors());
 
-    const error = makeError({ type: "filesystem", isTransient: true });
+    const error = makeError({ type: "filesystem", retryability: "auto" });
     act(() => capturedOnError(error));
 
     expect(callOrder[0]).toBe("escalate");
@@ -274,7 +274,7 @@ describe("useErrors — escalation of persistent transient errors", () => {
     const { useErrors } = await import("../useErrors");
     const { unmount } = renderHook(() => useErrors());
 
-    const error = makeError({ type: "network", isTransient: true });
+    const error = makeError({ type: "network", retryability: "auto" });
     act(() => capturedOnError(error));
 
     expect(consumeEscalationMock).toHaveBeenCalled();
@@ -287,7 +287,7 @@ describe("useErrors — escalation of persistent transient errors", () => {
     const { useErrors } = await import("../useErrors");
     const { unmount } = renderHook(() => useErrors());
 
-    const error = makeError({ type: "network", isTransient: true });
+    const error = makeError({ type: "network", retryability: "auto" });
     act(() => capturedOnError(error));
 
     expect(consumeEscalationMock).not.toHaveBeenCalled();
@@ -328,7 +328,7 @@ describe("useErrors — humanized toast payload", () => {
       type: "filesystem",
       source: "WorktreeMonitor",
       message: "EBUSY: resource busy or locked",
-      isTransient: false,
+      retryability: "none",
     });
     act(() => capturedOnError(error));
 
@@ -346,7 +346,7 @@ describe("useErrors — humanized toast payload", () => {
       type: "filesystem",
       source: "WorktreeMonitor",
       message: "EBUSY: resource busy or locked /Users/me/proj",
-      isTransient: false,
+      retryability: "none",
     });
     act(() => capturedOnError(error));
 
@@ -364,7 +364,7 @@ describe("useErrors — humanized toast payload", () => {
       type: "git",
       gitReason: "auth-failed",
       message: "fatal: Authentication failed for 'https://...'",
-      isTransient: false,
+      retryability: "none",
     });
     act(() => capturedOnError(error));
 
@@ -378,7 +378,7 @@ describe("useErrors — humanized toast payload", () => {
     const { useErrors } = await import("../useErrors");
     const { unmount } = renderHook(() => useErrors());
 
-    const error = makeError({ type: "process", isTransient: false });
+    const error = makeError({ type: "process", retryability: "none" });
     act(() => capturedOnError(error));
 
     const payload = notifyMock.mock.calls.at(-1)?.[0] ?? {};
@@ -391,7 +391,7 @@ describe("useErrors — humanized toast payload", () => {
     const { useErrors } = await import("../useErrors");
     const { unmount } = renderHook(() => useErrors());
 
-    const error = makeError({ type: "network", isTransient: true });
+    const error = makeError({ type: "network", retryability: "auto" });
     act(() => capturedOnError(error));
 
     const payload = notifyMock.mock.calls.at(-1)?.[0] ?? {};
@@ -417,7 +417,7 @@ describe("useErrors — humanized toast payload", () => {
       details: "stack trace goes here",
       correlationId: "corr-1",
       context: { worktreeId: "wt-42", filePath: "/tmp/proj/src/foo.ts" },
-      isTransient: false,
+      retryability: "none",
     });
     act(() => capturedOnError(error));
 
@@ -443,7 +443,7 @@ describe("useErrors — humanized toast payload", () => {
       gitReason: "auth-failed",
       source: "GitHubService",
       message: "fatal: Authentication failed for 'https://ghp_secrettoken@github.com/org/repo'",
-      isTransient: false,
+      retryability: "none",
     });
     act(() => capturedOnError(error));
 
@@ -468,7 +468,7 @@ describe("useErrors — humanized toast payload", () => {
     const { useErrors } = await import("../useErrors");
     const { unmount } = renderHook(() => useErrors());
 
-    const error = makeError({ type: "process", isTransient: false });
+    const error = makeError({ type: "process", retryability: "none" });
     act(() => capturedOnError(error));
 
     const payload = notifyMock.mock.calls.at(-1)?.[0] ?? {};
@@ -513,7 +513,7 @@ describe("useErrors — retry action on toast", () => {
 
     const error = makeError({
       type: "git",
-      isTransient: false,
+      retryability: "none",
       retryAction: "git",
       retryArgs: { branch: "main" },
     });
@@ -530,7 +530,7 @@ describe("useErrors — retry action on toast", () => {
     const { useErrors } = await import("../useErrors");
     const { unmount } = renderHook(() => useErrors());
 
-    const error = makeError({ type: "git", isTransient: false });
+    const error = makeError({ type: "git", retryability: "none" });
     act(() => capturedOnError(error));
 
     const payload = notifyMock.mock.calls.at(-1)?.[0] ?? {};
@@ -546,7 +546,7 @@ describe("useErrors — retry action on toast", () => {
 
     const error = makeError({
       type: "git",
-      isTransient: false,
+      retryability: "none",
       retryAction: "git",
     });
     act(() => capturedOnError(error));
@@ -564,7 +564,7 @@ describe("useErrors — retry action on toast", () => {
 
     const error = makeError({
       type: "network",
-      isTransient: false,
+      retryability: "none",
       retryAction: "terminal",
       retryArgs: { terminalId: "term-1" },
     });
@@ -586,7 +586,7 @@ describe("useErrors — retry action on toast", () => {
 
     const error = makeError({
       type: "network",
-      isTransient: false,
+      retryability: "none",
       retryAction: "terminal",
     });
     act(() => capturedOnError(error));
@@ -607,7 +607,7 @@ describe("useErrors — retry action on toast", () => {
 
     const error = makeError({
       type: "network",
-      isTransient: false,
+      retryability: "none",
       retryAction: "git",
     });
     act(() => capturedOnError(error));
@@ -626,7 +626,7 @@ describe("useErrors — retry action on toast", () => {
       type: "git",
       message: "fetch failed",
       source: "GitService",
-      isTransient: false,
+      retryability: "none",
     });
     act(() => capturedOnError(first));
 
@@ -635,7 +635,7 @@ describe("useErrors — retry action on toast", () => {
       type: "git",
       message: "fetch failed",
       source: "GitService",
-      isTransient: false,
+      retryability: "none",
       retryAction: "git",
       retryArgs: { branch: "main" },
     });
@@ -660,7 +660,7 @@ describe("useErrors — retry action on toast", () => {
       type: "git",
       message: "fetch failed",
       source: "GitService",
-      isTransient: false,
+      retryability: "none",
       retryAction: "git",
       retryArgs: { branch: "old" },
     });
@@ -670,7 +670,7 @@ describe("useErrors — retry action on toast", () => {
       type: "git",
       message: "fetch failed",
       source: "GitService",
-      isTransient: false,
+      retryability: "none",
       retryAction: "git",
       retryArgs: { branch: "new" },
     });
@@ -692,7 +692,7 @@ describe("useErrors — retry action on toast", () => {
 
     const error = makeError({
       type: "network",
-      isTransient: false,
+      retryability: "none",
       retryAction: "git",
     });
     act(() => capturedOnError(error));

--- a/src/hooks/useContextInjection.ts
+++ b/src/hooks/useContextInjection.ts
@@ -377,7 +377,7 @@ export function useContextInjection(targetTerminalId?: string): UseContextInject
             worktreeId,
             terminalId: activeTerminal,
           },
-          isTransient: true,
+          retryability: "auto",
           correlationId: crypto.randomUUID(),
         });
 

--- a/src/hooks/useErrors.ts
+++ b/src/hooks/useErrors.ts
@@ -78,7 +78,11 @@ function routeError(error: ErrorRecord): void {
   const copyAction = priority === "low" ? undefined : buildCopyDetailsAction(error);
 
   let retryNotificationAction: NotificationAction | undefined;
-  if (error.retryAction) {
+  // Match ErrorBanner's gate: a stored retryAction without "auto"
+  // retryability means the retry loop already exhausted (or the failure was
+  // never auto-retryable) — surfacing a Retry button would re-run the same
+  // failed loop. "user-gated" surfaces its own recovery CTA elsewhere.
+  if (error.retryAction && error.retryability === "auto") {
     retryNotificationAction = {
       label: "Retry",
       successLabel: "Retried",

--- a/src/hooks/useErrors.ts
+++ b/src/hooks/useErrors.ts
@@ -8,9 +8,9 @@ import type { NotificationAction, NotificationPriority } from "@/store/notificat
 import { humanizeAppError } from "@shared/utils/errorMessage";
 
 export function getErrorPriority(
-  error: Pick<ErrorRecord, "type" | "isTransient">
+  error: Pick<ErrorRecord, "type" | "retryability">
 ): NotificationPriority {
-  if (error.isTransient) return "low";
+  if (error.retryability === "auto") return "low";
   return "high";
 }
 
@@ -60,13 +60,14 @@ function routeError(error: ErrorRecord): void {
     details: error.details,
     source: error.source,
     context: error.context,
-    isTransient: error.isTransient,
+    retryability: error.retryability,
     retryAction: error.retryAction,
     retryArgs: error.retryArgs,
     fromPreviousSession: error.fromPreviousSession,
     correlationId: error.correlationId,
     recoveryHint: error.recoveryHint,
     gitReason: error.gitReason,
+    recoveryAction: error.recoveryAction,
   });
 
   const { title, body } = humanizeAppError(error);

--- a/src/hooks/useWorktreeActions.ts
+++ b/src/hooks/useWorktreeActions.ts
@@ -99,7 +99,7 @@ export async function copyContextWithFeedback(
       details: e instanceof Error ? e.stack : undefined,
       source: "WorktreeCard",
       context: { worktreeId },
-      isTransient: true,
+      retryability: "auto",
       correlationId: crypto.randomUUID(),
     });
   }
@@ -168,7 +168,7 @@ export function useWorktreeActions({
           context: {
             worktreeId: worktree.id,
           },
-          isTransient: true,
+          retryability: "auto",
           correlationId: crypto.randomUUID(),
         });
 
@@ -216,7 +216,7 @@ export function useWorktreeActions({
           type: "config",
           message: "No active terminals to save in this worktree.",
           source: "Save Layout",
-          isTransient: true,
+          retryability: "auto",
           correlationId: crypto.randomUUID(),
         });
         return;

--- a/src/lib/__tests__/notify.test.ts
+++ b/src/lib/__tests__/notify.test.ts
@@ -1958,55 +1958,55 @@ describe("shouldEscalateTransientError", () => {
     _resetEscalationTrackers();
   });
 
-  it("returns false for non-transient errors", () => {
+  it("returns false for retryability='none' errors", () => {
     expect(
       shouldEscalateTransientError({
         type: "process",
         message: "spawn failed",
-        isTransient: false,
+        retryability: "none",
       })
     ).toBe(false);
   });
 
-  it("returns false for first occurrence of a transient error", () => {
+  it("returns false for first occurrence of a retryability='auto' error", () => {
     expect(
       shouldEscalateTransientError({
         type: "filesystem",
         message: "EBUSY: resource locked",
-        isTransient: true,
+        retryability: "auto",
       })
     ).toBe(false);
   });
 
   it("returns false for second occurrence within window", () => {
-    const error = { type: "process" as const, message: "EAGAIN", isTransient: true };
+    const error = { type: "process" as const, message: "EAGAIN", retryability: "auto" };
     shouldEscalateTransientError(error);
     expect(shouldEscalateTransientError(error)).toBe(false);
   });
 
   it("returns true when local-resource error hits threshold (3) within 5s window", () => {
-    const error = { type: "filesystem" as const, message: "EBUSY", isTransient: true };
+    const error = { type: "filesystem" as const, message: "EBUSY", retryability: "auto" };
     shouldEscalateTransientError(error);
     shouldEscalateTransientError(error);
     expect(shouldEscalateTransientError(error)).toBe(true);
   });
 
   it("returns true when network error hits threshold (3) within 120s window", () => {
-    const error = { type: "network" as const, message: "ETIMEDOUT", isTransient: true };
+    const error = { type: "network" as const, message: "ETIMEDOUT", retryability: "auto" };
     shouldEscalateTransientError(error);
     shouldEscalateTransientError(error);
     expect(shouldEscalateTransientError(error)).toBe(true);
   });
 
   it("treats 'unknown' as network profile", () => {
-    const error = { type: "unknown" as const, message: "something failed", isTransient: true };
+    const error = { type: "unknown" as const, message: "something failed", retryability: "auto" };
     shouldEscalateTransientError(error);
     shouldEscalateTransientError(error);
     expect(shouldEscalateTransientError(error)).toBe(true);
   });
 
   it("resets counter after local-resource window expires (5s)", () => {
-    const error = { type: "filesystem" as const, message: "EBUSY", isTransient: true };
+    const error = { type: "filesystem" as const, message: "EBUSY", retryability: "auto" };
     const realDateNow = Date.now;
 
     let now = 1000;
@@ -2022,7 +2022,7 @@ describe("shouldEscalateTransientError", () => {
   });
 
   it("does not re-escalate after escalation is consumed (one-shot per group)", () => {
-    const error = { type: "network" as const, message: "ETIMEDOUT", isTransient: true };
+    const error = { type: "network" as const, message: "ETIMEDOUT", retryability: "auto" };
     shouldEscalateTransientError(error);
     shouldEscalateTransientError(error);
     const escalated = shouldEscalateTransientError(error);
@@ -2035,7 +2035,7 @@ describe("shouldEscalateTransientError", () => {
   });
 
   it("re-escalates if first escalation was not consumed (toast suppressed)", () => {
-    const error = { type: "network" as const, message: "ETIMEDOUT", isTransient: true };
+    const error = { type: "network" as const, message: "ETIMEDOUT", retryability: "auto" };
     shouldEscalateTransientError(error);
     shouldEscalateTransientError(error);
     expect(shouldEscalateTransientError(error)).toBe(true);
@@ -2050,7 +2050,7 @@ describe("shouldEscalateTransientError", () => {
   });
 
   it("allows re-escalation after cooldown expires", () => {
-    const error = { type: "network" as const, message: "ETIMEDOUT", isTransient: true };
+    const error = { type: "network" as const, message: "ETIMEDOUT", retryability: "auto" };
     const realDateNow = Date.now;
 
     let now = 1000;
@@ -2077,13 +2077,13 @@ describe("shouldEscalateTransientError", () => {
       type: "network" as const,
       message: "ECONNRESET",
       source: "git-poll",
-      isTransient: true,
+      retryability: "auto",
     };
     const error2 = {
       type: "network" as const,
       message: "ECONNRESET",
       source: "terminal",
-      isTransient: true,
+      retryability: "auto",
     };
 
     // Different source = different group
@@ -2106,7 +2106,7 @@ describe("shouldEscalateTransientError", () => {
         shouldEscalateTransientError({
           type: "network",
           message: `error-${i}`,
-          isTransient: true,
+          retryability: "auto",
         })
       ).not.toThrow();
     }

--- a/src/lib/__tests__/notify.test.ts
+++ b/src/lib/__tests__/notify.test.ts
@@ -1979,34 +1979,38 @@ describe("shouldEscalateTransientError", () => {
   });
 
   it("returns false for second occurrence within window", () => {
-    const error = { type: "process" as const, message: "EAGAIN", retryability: "auto" };
+    const error = { type: "process" as const, message: "EAGAIN", retryability: "auto" as const };
     shouldEscalateTransientError(error);
     expect(shouldEscalateTransientError(error)).toBe(false);
   });
 
   it("returns true when local-resource error hits threshold (3) within 5s window", () => {
-    const error = { type: "filesystem" as const, message: "EBUSY", retryability: "auto" };
+    const error = { type: "filesystem" as const, message: "EBUSY", retryability: "auto" as const };
     shouldEscalateTransientError(error);
     shouldEscalateTransientError(error);
     expect(shouldEscalateTransientError(error)).toBe(true);
   });
 
   it("returns true when network error hits threshold (3) within 120s window", () => {
-    const error = { type: "network" as const, message: "ETIMEDOUT", retryability: "auto" };
+    const error = { type: "network" as const, message: "ETIMEDOUT", retryability: "auto" as const };
     shouldEscalateTransientError(error);
     shouldEscalateTransientError(error);
     expect(shouldEscalateTransientError(error)).toBe(true);
   });
 
   it("treats 'unknown' as network profile", () => {
-    const error = { type: "unknown" as const, message: "something failed", retryability: "auto" };
+    const error = {
+      type: "unknown" as const,
+      message: "something failed",
+      retryability: "auto" as const,
+    };
     shouldEscalateTransientError(error);
     shouldEscalateTransientError(error);
     expect(shouldEscalateTransientError(error)).toBe(true);
   });
 
   it("resets counter after local-resource window expires (5s)", () => {
-    const error = { type: "filesystem" as const, message: "EBUSY", retryability: "auto" };
+    const error = { type: "filesystem" as const, message: "EBUSY", retryability: "auto" as const };
     const realDateNow = Date.now;
 
     let now = 1000;
@@ -2022,7 +2026,7 @@ describe("shouldEscalateTransientError", () => {
   });
 
   it("does not re-escalate after escalation is consumed (one-shot per group)", () => {
-    const error = { type: "network" as const, message: "ETIMEDOUT", retryability: "auto" };
+    const error = { type: "network" as const, message: "ETIMEDOUT", retryability: "auto" as const };
     shouldEscalateTransientError(error);
     shouldEscalateTransientError(error);
     const escalated = shouldEscalateTransientError(error);
@@ -2035,7 +2039,7 @@ describe("shouldEscalateTransientError", () => {
   });
 
   it("re-escalates if first escalation was not consumed (toast suppressed)", () => {
-    const error = { type: "network" as const, message: "ETIMEDOUT", retryability: "auto" };
+    const error = { type: "network" as const, message: "ETIMEDOUT", retryability: "auto" as const };
     shouldEscalateTransientError(error);
     shouldEscalateTransientError(error);
     expect(shouldEscalateTransientError(error)).toBe(true);
@@ -2050,7 +2054,7 @@ describe("shouldEscalateTransientError", () => {
   });
 
   it("allows re-escalation after cooldown expires", () => {
-    const error = { type: "network" as const, message: "ETIMEDOUT", retryability: "auto" };
+    const error = { type: "network" as const, message: "ETIMEDOUT", retryability: "auto" as const };
     const realDateNow = Date.now;
 
     let now = 1000;
@@ -2077,13 +2081,13 @@ describe("shouldEscalateTransientError", () => {
       type: "network" as const,
       message: "ECONNRESET",
       source: "git-poll",
-      retryability: "auto",
+      retryability: "auto" as const,
     };
     const error2 = {
       type: "network" as const,
       message: "ECONNRESET",
       source: "terminal",
-      retryability: "auto",
+      retryability: "auto" as const,
     };
 
     // Different source = different group

--- a/src/lib/notify.ts
+++ b/src/lib/notify.ts
@@ -12,7 +12,7 @@ import {
 } from "@/store/slices/notificationHistorySlice";
 import { useNotificationSettingsStore } from "@/store/notificationSettingsStore";
 import { isScheduledQuietNow, nextOccurrenceTimestamp } from "@shared/utils/quietHours";
-import type { ErrorType } from "@/store/errorStore";
+import type { ErrorRetryability, ErrorType } from "@/store/errorStore";
 import type { NotificationSettings } from "@shared/types/ipc/api";
 
 export type NotificationEventKind = "completed" | "waiting" | "workingPulse" | "uiFeedback";
@@ -253,9 +253,9 @@ export function shouldEscalateTransientError(error: {
   type: ErrorType;
   message: string;
   source?: string;
-  isTransient: boolean;
+  retryability: ErrorRetryability;
 }): boolean {
-  if (!error.isTransient) return false;
+  if (error.retryability !== "auto") return false;
 
   const key = buildEscalationKey(error);
   const now = Date.now();
@@ -296,9 +296,9 @@ export function consumeEscalation(error: {
   type: ErrorType;
   message: string;
   source?: string;
-  isTransient: boolean;
+  retryability: ErrorRetryability;
 }): void {
-  if (!error.isTransient) return;
+  if (error.retryability !== "auto") return;
 
   const key = buildEscalationKey(error);
   const tracker = _escalationTrackers.get(key);

--- a/src/store/__tests__/errorStore.test.ts
+++ b/src/store/__tests__/errorStore.test.ts
@@ -17,7 +17,7 @@ describe("errorStore", () => {
       type: "process",
       message: "Process crashed",
       source: "pty",
-      isTransient: true,
+      retryability: "auto",
       context: { terminalId: "term-1" },
     });
 
@@ -26,7 +26,7 @@ describe("errorStore", () => {
       type: "process",
       message: "Process crashed",
       source: "pty",
-      isTransient: true,
+      retryability: "auto",
       context: { terminalId: "term-1" },
     });
 
@@ -42,7 +42,7 @@ describe("errorStore", () => {
       type: "network",
       message: "Timeout",
       source: "fetcher",
-      isTransient: true,
+      retryability: "auto",
     });
 
     vi.setSystemTime(new Date("2026-01-01T00:00:00.600Z"));
@@ -50,7 +50,7 @@ describe("errorStore", () => {
       type: "network",
       message: "Timeout",
       source: "fetcher",
-      isTransient: true,
+      retryability: "auto",
     });
 
     expect(useErrorStore.getState().errors).toHaveLength(2);
@@ -62,7 +62,7 @@ describe("errorStore", () => {
         type: "unknown",
         message: `error-${index}`,
         source: "test",
-        isTransient: false,
+        retryability: "none",
       });
       vi.advanceTimersByTime(600);
     }
@@ -78,7 +78,7 @@ describe("errorStore", () => {
       type: "git",
       message: "push rejected",
       source: "git",
-      isTransient: false,
+      retryability: "none",
       correlationId: "test-corr-1234",
     });
 
@@ -92,7 +92,7 @@ describe("errorStore", () => {
       type: "git",
       message: "push rejected",
       source: "git",
-      isTransient: false,
+      retryability: "none",
       correlationId: "original-corr-id",
     });
 
@@ -101,7 +101,7 @@ describe("errorStore", () => {
       type: "git",
       message: "push rejected",
       source: "git",
-      isTransient: false,
+      retryability: "none",
       correlationId: "new-corr-id",
     });
 
@@ -115,7 +115,7 @@ describe("errorStore", () => {
       type: "filesystem",
       message: "EACCES: permission denied",
       source: "fs",
-      isTransient: false,
+      retryability: "none",
       recoveryHint: "Check file permissions or run with elevated privileges.",
     });
 
@@ -129,7 +129,7 @@ describe("errorStore", () => {
       type: "network",
       message: "Timeout",
       source: "fetcher",
-      isTransient: true,
+      retryability: "auto",
       recoveryHint: "Check your network connection and try again.",
     });
 
@@ -138,7 +138,7 @@ describe("errorStore", () => {
       type: "network",
       message: "Timeout",
       source: "fetcher",
-      isTransient: true,
+      retryability: "auto",
       recoveryHint: "Different hint text.",
     });
 
@@ -153,7 +153,7 @@ describe("errorStore", () => {
         type: "process",
         message: "spawn failed",
         source: "pty",
-        isTransient: true,
+        retryability: "auto",
       });
 
       useErrorStore.getState().updateRetryProgress(id, 2, 3);
@@ -167,7 +167,7 @@ describe("errorStore", () => {
         type: "process",
         message: "spawn failed",
         source: "pty",
-        isTransient: true,
+        retryability: "auto",
       });
 
       useErrorStore.getState().updateRetryProgress(id, 1, 3);
@@ -182,7 +182,7 @@ describe("errorStore", () => {
         type: "process",
         message: "spawn failed",
         source: "pty",
-        isTransient: true,
+        retryability: "auto",
       });
 
       useErrorStore.getState().updateRetryProgress(id, 1, 3);
@@ -192,13 +192,36 @@ describe("errorStore", () => {
     });
   });
 
+  it("overwrites retryability on dedup so 'exhausted' transitions are visible", () => {
+    vi.setSystemTime(new Date("2026-01-01T00:00:00.000Z"));
+    const firstId = useErrorStore.getState().addError({
+      type: "process",
+      message: "Process crashed",
+      source: "pty",
+      retryability: "auto",
+      context: { terminalId: "term-1" },
+    });
+
+    vi.setSystemTime(new Date("2026-01-01T00:00:00.200Z"));
+    useErrorStore.getState().addError({
+      type: "process",
+      message: "Process crashed",
+      source: "pty",
+      retryability: "exhausted",
+      context: { terminalId: "term-1" },
+    });
+
+    const stored = useErrorStore.getState().errors.find((e) => e.id === firstId);
+    expect(stored?.retryability).toBe("exhausted");
+  });
+
   it("reset fully clears error panel state", () => {
     useErrorStore.getState().setPanelOpen(true);
     useErrorStore.getState().addError({
       type: "git",
       message: "Bad HEAD",
       source: "git",
-      isTransient: false,
+      retryability: "none",
     });
 
     const before = useErrorStore.getState();

--- a/src/store/__tests__/errorStore.test.ts
+++ b/src/store/__tests__/errorStore.test.ts
@@ -192,6 +192,33 @@ describe("errorStore", () => {
     });
   });
 
+  it("propagates recoveryAction and gitReason on dedup when classification upgrades", () => {
+    vi.setSystemTime(new Date("2026-01-01T00:00:00.000Z"));
+    const firstId = useErrorStore.getState().addError({
+      type: "git",
+      message: "Push failed",
+      source: "git",
+      retryability: "auto",
+      context: { worktreeId: "w-1" },
+    });
+
+    vi.setSystemTime(new Date("2026-01-01T00:00:00.200Z"));
+    useErrorStore.getState().addError({
+      type: "git",
+      message: "Push failed",
+      source: "git",
+      retryability: "user-gated",
+      gitReason: "auth-failed",
+      recoveryAction: { label: "Reconnect", actionId: "github.connect" },
+      context: { worktreeId: "w-1" },
+    });
+
+    const stored = useErrorStore.getState().errors.find((e) => e.id === firstId);
+    expect(stored?.retryability).toBe("user-gated");
+    expect(stored?.recoveryAction?.actionId).toBe("github.connect");
+    expect(stored?.gitReason).toBe("auth-failed");
+  });
+
   it("overwrites retryability on dedup so 'exhausted' transitions are visible", () => {
     vi.setSystemTime(new Date("2026-01-01T00:00:00.000Z"));
     const firstId = useErrorStore.getState().addError({

--- a/src/store/errorStore.ts
+++ b/src/store/errorStore.ts
@@ -91,10 +91,16 @@ const createErrorStore: StateCreator<ErrorStore> = (set, get) => ({
                 timestamp: now,
                 // Overwrite retryability from the incoming record so state
                 // transitions (e.g. an auto-retrying error landing as
-                // "exhausted" after the retry loop gives up) become visible
-                // even when the duplicate-suppression window collapses the
-                // two records into one.
+                // "exhausted" after the retry loop gives up, or upgrading
+                // from "auto" to "user-gated" once the classifier sees a
+                // gitReason) become visible even when the duplicate-
+                // suppression window collapses the two records into one.
+                // recoveryAction and gitReason are part of that state — a
+                // banner that ends up "user-gated" without its CTA would
+                // silently fall back to "View errors".
                 retryability: error.retryability,
+                recoveryAction: error.recoveryAction ?? e.recoveryAction,
+                gitReason: error.gitReason ?? e.gitReason,
                 retryAction: error.retryAction ?? e.retryAction,
                 retryArgs: error.retryArgs ?? e.retryArgs,
                 recoveryHint: e.recoveryHint ?? error.recoveryHint,

--- a/src/store/errorStore.ts
+++ b/src/store/errorStore.ts
@@ -1,16 +1,13 @@
 import { create, type StateCreator } from "zustand";
-import type { GitOperationReason } from "@shared/types/ipc/errors";
+import type {
+  ErrorRetryability,
+  ErrorType,
+  GitOperationReason,
+  RecoveryAction,
+  RetryAction,
+} from "@shared/types/ipc/errors";
 
-export type ErrorType =
-  | "git"
-  | "process"
-  | "filesystem"
-  | "network"
-  | "config"
-  | "validation"
-  | "unknown";
-
-export type RetryAction = "terminal" | "git" | "worktree";
+export type { ErrorRetryability, ErrorType, RetryAction } from "@shared/types/ipc/errors";
 
 export interface ErrorRecord {
   id: string;
@@ -25,7 +22,7 @@ export interface ErrorRecord {
     filePath?: string;
     command?: string;
   };
-  isTransient: boolean;
+  retryability: ErrorRetryability;
   dismissed: boolean;
   retryAction?: RetryAction;
   retryArgs?: Record<string, unknown>;
@@ -35,6 +32,8 @@ export interface ErrorRecord {
   retryProgress?: { attempt: number; maxAttempts: number };
   /** Classified reason when this error originated from a git operation */
   gitReason?: GitOperationReason;
+  /** Structured CTA the renderer can surface alongside the error */
+  recoveryAction?: RecoveryAction;
 }
 
 interface ErrorStore {
@@ -90,6 +89,12 @@ const createErrorStore: StateCreator<ErrorStore> = (set, get) => ({
             ? {
                 ...e,
                 timestamp: now,
+                // Overwrite retryability from the incoming record so state
+                // transitions (e.g. an auto-retrying error landing as
+                // "exhausted" after the retry loop gives up) become visible
+                // even when the duplicate-suppression window collapses the
+                // two records into one.
+                retryability: error.retryability,
                 retryAction: error.retryAction ?? e.retryAction,
                 retryArgs: error.retryArgs ?? e.retryArgs,
                 recoveryHint: e.recoveryHint ?? error.recoveryHint,

--- a/src/utils/__tests__/errorContext.test.ts
+++ b/src/utils/__tests__/errorContext.test.ts
@@ -1,5 +1,10 @@
 import { describe, expect, it } from "vitest";
-import { classifyError, isTransientError, getErrorMessage } from "../errorContext";
+import {
+  classifyError,
+  getErrorMessage,
+  getRetryabilityFromError,
+  isTransientError,
+} from "../errorContext";
 
 /** Helper: create an error-like object with structured properties */
 function makeError(
@@ -218,6 +223,25 @@ describe("isTransientError", () => {
     it("returns false for string errors without transient keywords", () => {
       expect(isTransientError("permanent failure")).toBe(false);
     });
+  });
+});
+
+describe("getRetryabilityFromError", () => {
+  it("returns 'auto' for transient errno codes", () => {
+    expect(getRetryabilityFromError(makeError("busy", { code: "EBUSY" }))).toBe("auto");
+    expect(getRetryabilityFromError(makeError("dns", { code: "ENOTFOUND" }))).toBe("auto");
+  });
+
+  it("returns 'auto' for transient-keyword messages (timeout, 429, 503)", () => {
+    expect(getRetryabilityFromError(new Error("connection timeout"))).toBe("auto");
+    expect(getRetryabilityFromError(new Error("HTTP 429 rate limited"))).toBe("auto");
+    expect(getRetryabilityFromError(new Error("upstream 503"))).toBe("auto");
+  });
+
+  it("returns 'none' for permanent errors", () => {
+    expect(getRetryabilityFromError(new Error("file not found"))).toBe("none");
+    expect(getRetryabilityFromError(makeError("denied", { code: "EACCES" }))).toBe("none");
+    expect(getRetryabilityFromError(null)).toBe("none");
   });
 });
 

--- a/src/utils/__tests__/reactRootErrorCallbacks.test.ts
+++ b/src/utils/__tests__/reactRootErrorCallbacks.test.ts
@@ -78,7 +78,7 @@ describe("reactRootErrorCallbacks", () => {
         message: "fatal render crash",
         details: componentStack,
         source: "React Uncaught Render Error",
-        isTransient: false,
+        retryability: "none",
       });
 
       expect(mockedLogError).toHaveBeenCalledOnce();

--- a/src/utils/errorContext.ts
+++ b/src/utils/errorContext.ts
@@ -1,4 +1,5 @@
 import { logError } from "@/utils/logger";
+import type { ErrorRetryability } from "@shared/types/ipc/errors";
 
 export type ErrorCategory = "network" | "filesystem" | "validation" | "git" | "process" | "unknown";
 
@@ -160,4 +161,14 @@ export function isTransientError(error: unknown): boolean {
     message.includes("429") ||
     message.includes("503")
   );
+}
+
+/**
+ * Map a renderer-thrown error to its {@link ErrorRetryability} classification.
+ * Transient codes/phrases collapse to "auto"; everything else falls through
+ * to "none" because the renderer has no signal for `user-gated` or `exhausted`
+ * (those are produced by main-process error sources).
+ */
+export function getRetryabilityFromError(error: unknown): ErrorRetryability {
+  return isTransientError(error) ? "auto" : "none";
 }

--- a/src/utils/reactRootErrorCallbacks.ts
+++ b/src/utils/reactRootErrorCallbacks.ts
@@ -38,7 +38,7 @@ export function onUncaughtError(error: unknown, errorInfo: { componentStack?: st
         message: getErrorMessage(error),
         details: errorInfo.componentStack,
         source: "React Uncaught Render Error",
-        isTransient: false,
+        retryability: "none",
       });
     } catch (storeError) {
       // Last-resort sink: the error store has already failed.

--- a/src/utils/rendererGlobalErrorHandlers.ts
+++ b/src/utils/rendererGlobalErrorHandlers.ts
@@ -4,7 +4,7 @@ import { logError } from "@/utils/logger";
 import {
   getErrorMessage,
   classifyError,
-  isTransientError,
+  getRetryabilityFromError,
   type ErrorCategory,
 } from "@/utils/errorContext";
 
@@ -63,7 +63,7 @@ export function reportRendererGlobalError(
       metadata.message || getErrorMessage(rawError) || `Unhandled ${kind} (no reason provided)`;
     const category = classifyError(rawError);
     const storeType = mapCategoryToStoreType(category);
-    const transient = isTransientError(rawError);
+    const retryability = getRetryabilityFromError(rawError);
     const stack = getStack(rawError);
     const correlationId = crypto.randomUUID();
 
@@ -86,7 +86,7 @@ export function reportRendererGlobalError(
         details: details || undefined,
         source,
         context: metadata.filename ? { filePath: metadata.filename } : undefined,
-        isTransient: transient,
+        retryability,
         correlationId,
       });
     } catch (storeError) {


### PR DESCRIPTION
## Summary

- Replaces the `isTransient` boolean on `ErrorRecord` with a `retryability` string discriminant: `"auto"` | `"user-gated"` | `"exhausted"` | `"none"`, giving the error system four distinct states instead of two
- The `ErrorBanner` action slot is now a pure function of `retryability` — `"auto"` shows Retry, `"user-gated"` shows the recovery action, `"exhausted"` and `"none"` show View errors
- Closes the gap where `ENOTFOUND` from a misconfigured remote got the same Retry button as `EBUSY`

Resolves #7912

## Changes

- `shared/types/ipc/errors.ts` — new `ErrorRetryability` type, `retryability` field replaces `isTransient` on `ErrorRecord`
- `electron/utils/errorTypes.ts` — `isTransientError()` replaced by `classifyRetryability()` mapping error codes to the four-value enum
- `electron/ipc/errorHandlers.ts` — IPC error construction updated to populate `retryability`
- `electron/setup/globalErrorHandlers.ts` — same
- `src/store/errorStore.ts` — dedup merge updated; `retryability` governs precedence, not the old boolean
- `src/hooks/useErrors.ts` — `canRetry` derived from `retryability === "auto"`
- `src/components/Errors/ErrorBanner.tsx` — action slot is a switch on `retryability`; `user-gated` shows recovery action, `auto` shows Retry, others fall through to View errors
- `src/lib/notify.ts`, `src/utils/errorContext.ts`, related hooks — call sites updated
- Tests across all touched modules

## Testing

- Unit tests updated and passing for `errorTypes`, `errorHandlers`, `errorStore`, `useErrors`, `ErrorBanner`, `notify`, and `errorContext`
- E2E resilience specs (`core-error-buffering`, `core-error-retry-persistence`, `core-ipc-error-propagation`) updated and passing