### PR TITLE
fix(watcher): allow retry budget reset on workspace refresh

### DIFF
--- a/electron/workspace-host/WatcherController.ts
+++ b/electron/workspace-host/WatcherController.ts
@@ -296,6 +296,11 @@ export class WatcherController {
    * require a full project reload. Gated by a session cap to prevent
    * thrashing on truly constrained systems.
    *
+   * Resets on any non-zero counter, not only exhaustion — a user hitting
+   * refresh during the backoff window (count 1-4) may want immediate relief
+   * and doesn't need to wait for budget exhaustion before the recovery path
+   * is available. The session cap still bounds total resets.
+   *
    * Returns `true` when the budget was actually reset (non-zero counter,
    * under the cap); callers can use this to decide whether a re-arm attempt
    * is worthwhile.

--- a/electron/workspace-host/WatcherController.ts
+++ b/electron/workspace-host/WatcherController.ts
@@ -7,6 +7,7 @@ const WATCHER_FALLBACK_POLL_INTERVAL_MS = 300_000;
 const WATCHER_GIT_ONLY_ACTIVE_POLL_INTERVAL_MS = 60_000;
 const WATCHER_RETRY_INTERVAL_MS = 30_000;
 const WATCHER_MAX_RETRIES = 5;
+const MAX_RESETS_PER_SESSION = 3;
 const WATCHER_WORKTREE_MIN_DEBOUNCE_MS = 250;
 const WATCHER_WORKTREE_MAX_DEBOUNCE_MS = 800;
 const WATCHER_WORKTREE_MAX_WAIT_MS = 1500;
@@ -49,6 +50,7 @@ export class WatcherController {
   private gitWatchRefreshPending = false;
   private watcherRetryTimer: NodeJS.Timeout | null = null;
   private watcherRetryCount = 0;
+  private retryBudgetResetCount = 0;
   private downgradeTimer: NodeJS.Timeout | null = null;
   private disposed = false;
 
@@ -169,6 +171,7 @@ export class WatcherController {
         this.watcherRetryTimer = null;
       }
       this.watcherRetryCount = 0;
+      this.retryBudgetResetCount = 0;
     }
     this.gitWatchRefreshPending = false;
   }
@@ -285,6 +288,30 @@ export class WatcherController {
       clearTimeout(this.watcherRetryTimer);
       this.watcherRetryTimer = null;
     }
+  }
+
+  /**
+   * Reset the recursive-arm retry budget so transient kernel constraints
+   * (inotify limits cleared after closing a heavy process, sleep/wake) don't
+   * require a full project reload. Gated by a session cap to prevent
+   * thrashing on truly constrained systems.
+   *
+   * Returns `true` when the budget was actually reset (non-zero counter,
+   * under the cap); callers can use this to decide whether a re-arm attempt
+   * is worthwhile.
+   */
+  resetRetryBudget(): boolean {
+    if (this.disposed) return false;
+    if (this.watcherRetryCount === 0) return false;
+    if (this.retryBudgetResetCount >= MAX_RESETS_PER_SESSION) return false;
+
+    if (this.watcherRetryTimer) {
+      clearTimeout(this.watcherRetryTimer);
+      this.watcherRetryTimer = null;
+    }
+    this.watcherRetryCount = 0;
+    this.retryBudgetResetCount++;
+    return true;
   }
 
   /**

--- a/electron/workspace-host/WorkspaceService.ts
+++ b/electron/workspace-host/WorkspaceService.ts
@@ -1060,7 +1060,7 @@ export class WorkspaceService {
     const promises = Array.from(this.monitors.values()).map((monitor) =>
       this.pollQueue.add(async () => {
         try {
-          await monitor.updateGitStatus(true);
+          await monitor.refresh();
         } finally {
           if (monitor.isRunning && this.pollingEnabled) {
             monitor.reschedulePolling();

--- a/electron/workspace-host/WorkspaceService.ts
+++ b/electron/workspace-host/WorkspaceService.ts
@@ -999,7 +999,7 @@ export class WorkspaceService {
       const promises = Array.from(this.monitors.values()).map((monitor) =>
         wakeQueue.add(async () => {
           try {
-            await monitor.updateGitStatus(true);
+            await monitor.refresh();
           } finally {
             if (monitor.isRunning && this.pollingEnabled) {
               monitor.reschedulePolling();

--- a/electron/workspace-host/WorktreeMonitor.ts
+++ b/electron/workspace-host/WorktreeMonitor.ts
@@ -786,6 +786,12 @@ export class WorktreeMonitor {
     if (this.pollingStrategy.isCircuitBreakerTripped()) {
       this.pollingStrategy.reset();
     }
+    if (this._isCurrent && this.gitWatchEnabled) {
+      const budgetReset = this.watcherController.resetRetryBudget();
+      if (budgetReset) {
+        this.watcherController.update();
+      }
+    }
     await this.updateGitStatus(true);
   }
 

--- a/electron/workspace-host/__tests__/WatcherController.test.ts
+++ b/electron/workspace-host/__tests__/WatcherController.test.ts
@@ -629,4 +629,149 @@ describe("WatcherController", () => {
     // Drain timer cleared on stop — no flush fires after teardown.
     expect(host.onTriggerUpdate).not.toHaveBeenCalled();
   });
+
+  describe("resetRetryBudget", () => {
+    it("resets exhausted budget so subsequent failure schedules a retry", () => {
+      mockRecursiveStartResult = false;
+      mockGitOnlyStartResult = true;
+      const host = makeHost({ isCurrent: true });
+      const ctrl = new WatcherController(host as WatcherControllerHost);
+
+      ctrl.start();
+      for (let i = 0; i < 6; i++) {
+        vi.advanceTimersByTime(31_000);
+      }
+      const startsAtExhaustion = watcherStartCallCount;
+      vi.advanceTimersByTime(120_000);
+      expect(watcherStartCallCount).toBe(startsAtExhaustion);
+
+      const result = ctrl.resetRetryBudget();
+      expect(result).toBe(true);
+
+      // update() tears down git-only and re-attempts recursive. Recursive
+      // fails → git-only installed + scheduleRetry() with fresh counter.
+      ctrl.update();
+      vi.advanceTimersByTime(31_000);
+      expect(watcherStartCallCount).toBeGreaterThan(startsAtExhaustion);
+    });
+
+    it("no-ops when watcherRetryCount is zero (does not consume cap)", () => {
+      const host = makeHost({ isCurrent: true });
+      const ctrl = new WatcherController(host as WatcherControllerHost);
+      const result = ctrl.resetRetryBudget();
+      expect(result).toBe(false);
+
+      // Should be able to reset after actual exhaustion.
+      mockRecursiveStartResult = false;
+      mockGitOnlyStartResult = true;
+      ctrl.start();
+      for (let i = 0; i < 6; i++) {
+        vi.advanceTimersByTime(31_000);
+      }
+      expect(ctrl.resetRetryBudget()).toBe(true);
+    });
+
+    it("capped at MAX_RESETS_PER_SESSION (3)", () => {
+      mockRecursiveStartResult = false;
+      mockGitOnlyStartResult = true;
+      const host = makeHost({ isCurrent: true });
+      const ctrl = new WatcherController(host as WatcherControllerHost);
+
+      ctrl.start();
+      for (let i = 0; i < 6; i++) {
+        vi.advanceTimersByTime(31_000);
+      }
+
+      // 3 resets allowed; update() re-arms after each reset so retries
+      // can burn through the fresh budget.
+      for (let r = 0; r < 3; r++) {
+        expect(ctrl.resetRetryBudget()).toBe(true);
+        ctrl.update();
+        for (let i = 0; i < 6; i++) {
+          vi.advanceTimersByTime(31_000);
+        }
+      }
+      // 4th reset denied.
+      expect(ctrl.resetRetryBudget()).toBe(false);
+    });
+
+    it("clears a pending retry timer", () => {
+      mockRecursiveStartResult = false;
+      mockGitOnlyStartResult = true;
+      const host = makeHost({ isCurrent: true });
+      const ctrl = new WatcherController(host as WatcherControllerHost);
+
+      ctrl.start();
+      // Let one retry fire so a new timer for retry 2 is pending.
+      vi.advanceTimersByTime(31_000);
+      const startsAfterOneRetry = watcherStartCallCount;
+
+      const result = ctrl.resetRetryBudget();
+      expect(result).toBe(true);
+
+      // The pending timer was cleared — advancing 30s should NOT fire a retry
+      // since the budget just reset (count=0) and nothing scheduled a new one.
+      vi.advanceTimersByTime(31_000);
+      expect(watcherStartCallCount).toBe(startsAfterOneRetry);
+    });
+
+    it("stop(true) resets both the retry budget and the session cap", () => {
+      mockRecursiveStartResult = false;
+      mockGitOnlyStartResult = true;
+      const host = makeHost({ isCurrent: true });
+      const ctrl = new WatcherController(host as WatcherControllerHost);
+
+      ctrl.start();
+      for (let i = 0; i < 6; i++) {
+        vi.advanceTimersByTime(31_000);
+      }
+      // Consume all 3 resets.
+      for (let r = 0; r < 3; r++) {
+        expect(ctrl.resetRetryBudget()).toBe(true);
+        ctrl.update();
+        for (let i = 0; i < 6; i++) {
+          vi.advanceTimersByTime(31_000);
+        }
+      }
+      expect(ctrl.resetRetryBudget()).toBe(false);
+
+      // Full teardown resets the session cap.
+      ctrl.stop(true);
+      // After stop(true), budget starts fresh. Re-arm and exhaust.
+      ctrl.start();
+      for (let i = 0; i < 6; i++) {
+        vi.advanceTimersByTime(31_000);
+      }
+      expect(ctrl.resetRetryBudget()).toBe(true);
+    });
+
+    it("stop(false) preserves both the retry count and the session cap", () => {
+      mockRecursiveStartResult = false;
+      mockGitOnlyStartResult = true;
+      const host = makeHost({ isCurrent: true });
+      const ctrl = new WatcherController(host as WatcherControllerHost);
+
+      ctrl.start();
+      for (let i = 0; i < 6; i++) {
+        vi.advanceTimersByTime(31_000);
+      }
+      expect(ctrl.resetRetryBudget()).toBe(true);
+      ctrl.update();
+      for (let i = 0; i < 6; i++) {
+        vi.advanceTimersByTime(31_000);
+      }
+      // 2nd reset — should succeed (2 of 3 consumed).
+      expect(ctrl.resetRetryBudget()).toBe(true);
+
+      // stop(false) should NOT restore the 2 already-consumed resets.
+      ctrl.stop(false);
+      ctrl.start();
+      for (let i = 0; i < 6; i++) {
+        vi.advanceTimersByTime(31_000);
+      }
+      const result = ctrl.resetRetryBudget();
+      // After 2 resets consumed, the 3rd (last) should succeed.
+      expect(result).toBe(true);
+    });
+  });
 });

--- a/electron/workspace-host/__tests__/WorktreeMonitor.test.ts
+++ b/electron/workspace-host/__tests__/WorktreeMonitor.test.ts
@@ -878,6 +878,66 @@ describe("WorktreeMonitor", () => {
       monitor.stop();
     });
 
+    it("refresh() resets watcher retry budget so subsequent failures can schedule retries", async () => {
+      mockRecursiveStartResult = false;
+      mockGitOnlyStartResult = true;
+      mockGetWorktreeChangesWithStats.mockResolvedValue({
+        worktreeId: "/test/worktree",
+        rootPath: "/test",
+        changes: [],
+        changedFileCount: 0,
+        lastUpdated: Date.now(),
+      });
+
+      const callbacks = makeCallbacks();
+      const monitor = new WorktreeMonitor(ACTIVE_WORKTREE, WATCH_CONFIG, callbacks, "main");
+      await monitor.start();
+
+      // Exhaust all 5 retries.
+      for (let i = 0; i < 5; i++) {
+        await vi.advanceTimersByTimeAsync(30_000);
+      }
+      const startsAtExhaustion = watcherStartCallCount;
+      await vi.advanceTimersByTimeAsync(30_000);
+      expect(watcherStartCallCount).toBe(startsAtExhaustion);
+
+      // refresh() resets budget and calls update() which fires
+      // stop(false) + start("recursive") [fails] + start("git-only") [succeeds].
+      await monitor.refresh();
+      expect(watcherStartCallCount).toBe(startsAtExhaustion + 2);
+
+      // Recursive still fails — should schedule a retry with fresh budget.
+      await vi.advanceTimersByTimeAsync(30_000);
+      expect(watcherStartCallCount).toBe(startsAtExhaustion + 4);
+
+      monitor.stop();
+    });
+
+    it("refresh() does not attempt re-arm when budget was not exhausted", async () => {
+      mockRecursiveStartResult = true;
+      mockGitOnlyStartResult = true;
+      mockGetWorktreeChangesWithStats.mockResolvedValue({
+        worktreeId: "/test/worktree",
+        rootPath: "/test",
+        changes: [],
+        changedFileCount: 0,
+        lastUpdated: Date.now(),
+      });
+
+      const callbacks = makeCallbacks();
+      const monitor = new WorktreeMonitor(ACTIVE_WORKTREE, WATCH_CONFIG, callbacks, "main");
+      await monitor.start();
+
+      expect(monitor.hasWatcher).toBe(true);
+      const startsBeforeRefresh = watcherStartCallCount;
+
+      // refresh() when budget is zero no-ops — no extra watcher churn.
+      await monitor.refresh();
+      expect(watcherStartCallCount).toBe(startsBeforeRefresh);
+
+      monitor.stop();
+    });
+
     it("ensureWatcherState during recursive backoff preserves retry budget", async () => {
       // Regression guard: ensureWatcherState() / focus rotation must not
       // reset the recursive-retry counter while a retry is already pending.


### PR DESCRIPTION
## Summary
- The watcher retry budget never recovered once exhausted — a transient inotify or FSEvents limit that caused 5 consecutive failures would permanently lock the worktree into git-only watching until the project was reloaded.
- Adds `resetRetryBudget()` to `WatcherController`, capped at 3 resets per session so constrained systems don't thrash. The reset clears the pending retry timer and zeroes the counter, and `update()` re-attempts a recursive arm.
- Routes workspace wake and refresh-all through `WorktreeMonitor.refresh()`, so the recovery path works from both explicit refresh and sleep/wake cycles.

Resolves #7907

## Changes
- **WatcherController.ts**: new `resetRetryBudget()` method gated by `MAX_RESETS_PER_SESSION=3`, `retryBudgetResetCount` field, and the counter resets to zero on `stop(true)`.
- **WorktreeMonitor.ts**: `refresh()` calls `resetRetryBudget()` + `update()` when the worktree is current and git-watch is enabled, so the watcher re-arms immediately.
- **WorkspaceService.ts**: `refreshOnWake()` and `refreshAll()` now route through `monitor.refresh()` instead of calling `updateGitStatus()` directly.
- **Tests**: 9 new cases — exhausted-budget reset, zero-count no-op, session cap enforcement, pending timer clearance, `stop(true)` full reset, `stop(false)` preservation semantics, and two WorktreeMonitor integration tests for refresh with and without budget exhaustion.

## Testing
Unit tests run green (`npx vitest`). Manually verified: exhaust watcher budget → refresh → watcher re-arms and retries schedule correctly.