### PR TITLE
fix(terminal): show restarting banner during pty-host auto-restart backoff

### DIFF
--- a/electron/ipc/handlers/events.ts
+++ b/electron/ipc/handlers/events.ts
@@ -42,6 +42,7 @@ const EVENT_BUS_BRIDGED_MANIFEST = {
   "app-agent:dispatch-action-request": "external",
   "app-agent:confirmation-request": "external",
   "terminal:backend-crashed": "external",
+  "terminal:backend-recovering": "external",
   "terminal:backend-ready": "external",
 
   // Terminal observability (relayed from TypedEventBus via PtyEventsBridge)

--- a/electron/preload.cts
+++ b/electron/preload.cts
@@ -893,6 +893,15 @@ const api: ElectronAPI = {
       }) => void
     ): (() => void) => _eventBusOn("terminal:backend-crashed", callback),
 
+    onBackendRecovering: (
+      callback: (data: {
+        crashType: string;
+        code: number | null;
+        signal: string | null;
+        timestamp: number;
+      }) => void
+    ): (() => void) => _eventBusOn("terminal:backend-recovering", callback),
+
     onBackendReady: (callback: () => void): (() => void) =>
       _eventBusOn("terminal:backend-ready", () => callback()),
 

--- a/electron/window/perWindowInit.ts
+++ b/electron/window/perWindowInit.ts
@@ -122,9 +122,21 @@ export function initPerWindowServices(
     setAgentVersionService(versionSvc);
     setAgentUpdateHandler(new AgentUpdateHandler(ptyClient, versionSvc, cliAvailabilityService));
 
+    let lastCrashDetails: {
+      crashType: string;
+      code: number | null;
+      signal: string | null;
+      timestamp: number;
+    } | null = null;
+
     ptyClient.on("host-crash-details", (details) => {
       console.error(`[MAIN] Pty Host crashed:`, details);
-      // Broadcast to all windows
+      lastCrashDetails = {
+        crashType: details.crashType,
+        code: details.code,
+        signal: details.signal,
+        timestamp: details.timestamp,
+      };
       if (windowRegistry) {
         for (const wCtx of windowRegistry.all()) {
           const w = wCtx.browserWindow;
@@ -133,7 +145,7 @@ export function initPerWindowServices(
             if (!wc.isDestroyed()) {
               try {
                 wc.send(CHANNELS.EVENTS_PUSH, {
-                  name: "terminal:backend-crashed",
+                  name: "terminal:backend-recovering",
                   payload: {
                     crashType: details.crashType,
                     code: details.code,
@@ -151,6 +163,31 @@ export function initPerWindowServices(
     });
     ptyClient.on("host-crash", (code) => {
       console.error(`[MAIN] Pty Host crashed with code ${code} (max restarts exceeded)`);
+      const payload = lastCrashDetails ?? {
+        crashType: "UNKNOWN_CRASH",
+        code,
+        signal: null,
+        timestamp: Date.now(),
+      };
+      lastCrashDetails = null;
+      if (windowRegistry) {
+        for (const wCtx of windowRegistry.all()) {
+          const w = wCtx.browserWindow;
+          if (!w.isDestroyed()) {
+            const wc = getAppWebContents(w);
+            if (!wc.isDestroyed()) {
+              try {
+                wc.send(CHANNELS.EVENTS_PUSH, {
+                  name: "terminal:backend-crashed",
+                  payload,
+                });
+              } catch {
+                // Silently ignore send failures during window disposal.
+              }
+            }
+          }
+        }
+      }
     });
     ptyClient.on("host-throttled", (payload) => {
       if (!payload.isThrottled) {

--- a/shared/types/ipc/api.ts
+++ b/shared/types/ipc/api.ts
@@ -297,6 +297,14 @@ export interface ElectronAPI {
         timestamp: number;
       }) => void
     ): () => void;
+    onBackendRecovering(
+      callback: (data: {
+        crashType: string;
+        code: number | null;
+        signal: string | null;
+        timestamp: number;
+      }) => void
+    ): () => void;
     onBackendReady(callback: () => void): () => void;
     sendKey(id: string, key: string): void;
     batchDoubleEscape(ids: string[]): void;

--- a/shared/types/ipc/maps.ts
+++ b/shared/types/ipc/maps.ts
@@ -2042,6 +2042,12 @@ export interface IpcEventMap {
     signal: string | null;
     timestamp: number;
   };
+  "terminal:backend-recovering": {
+    crashType: string;
+    code: number | null;
+    signal: string | null;
+    timestamp: number;
+  };
   "terminal:backend-ready": void;
   "terminal:reduce-scrollback": { terminalIds: string[]; targetLines: number };
   "terminal:restore-scrollback": { terminalIds: string[] };
@@ -2355,6 +2361,7 @@ export type IpcEventBusMap = Pick<
   // Terminal lifecycle (non-data) — exit, spawn-result, backend crash/ready
   | "terminal:exit"
   | "terminal:backend-crashed"
+  | "terminal:backend-recovering"
   | "terminal:backend-ready"
   | "terminal:spawn-result"
   // Terminal observability

--- a/src/clients/__tests__/terminalClient.test.ts
+++ b/src/clients/__tests__/terminalClient.test.ts
@@ -42,6 +42,7 @@ const mockElectronTerminal = {
   forceResume: vi.fn(),
   onStatus: vi.fn(() => () => {}),
   onBackendCrashed: vi.fn(() => () => {}),
+  onBackendRecovering: vi.fn(() => () => {}),
   onBackendReady: vi.fn(() => () => {}),
   onSpawnResult: vi.fn(() => () => {}),
   onReduceScrollback: vi.fn(() => () => {}),

--- a/src/clients/terminalClient.ts
+++ b/src/clients/terminalClient.ts
@@ -437,6 +437,20 @@ export const terminalClient = {
   },
 
   /**
+   * Listen for backend recovering events (during auto-restart backoff).
+   */
+  onBackendRecovering: (
+    callback: (data: {
+      crashType: string;
+      code: number | null;
+      signal: string | null;
+      timestamp: number;
+    }) => void
+  ): (() => void) => {
+    return window.electron.terminal.onBackendRecovering(callback);
+  },
+
+  /**
    * Listen for backend ready events (after crash recovery).
    */
   onBackendReady: (callback: () => void): (() => void) => {

--- a/src/components/Recovery/HostCrashBanner.tsx
+++ b/src/components/Recovery/HostCrashBanner.tsx
@@ -1,9 +1,11 @@
 import { useState } from "react";
-import { AlertTriangle } from "lucide-react";
+import { AlertTriangle, Loader2 } from "lucide-react";
 import type { CrashType } from "@shared/types/pty-host";
 import { usePanelStore } from "@/store/panelStore";
 import { actionService } from "@/services/ActionService";
 import { logError } from "@/utils/logger";
+import { useDeferredLoading } from "@/hooks/useDeferredLoading";
+import { UI_DOHERTY_THRESHOLD } from "@/lib/animationUtils";
 
 interface CrashCopy {
   title: string;
@@ -45,17 +47,32 @@ export function HostCrashBanner() {
   const backendStatus = usePanelStore((s) => s.backendStatus);
   const lastCrashType = usePanelStore((s) => s.lastCrashType);
   const [isRestarting, setIsRestarting] = useState(false);
+  const recoveringShown = useDeferredLoading(backendStatus === "recovering", UI_DOHERTY_THRESHOLD);
 
-  if (backendStatus !== "disconnected") return null;
+  if (backendStatus === "connected") return null;
+
+  if (backendStatus === "recovering") {
+    if (!recoveringShown) return null;
+
+    return (
+      <div
+        role="alert"
+        className="flex items-start gap-3 px-4 py-2 bg-[var(--color-status-warning)]/10 border-b border-[var(--color-status-warning)]/25 text-[var(--color-status-warning)] text-sm shrink-0"
+      >
+        <Loader2 className="w-4 h-4 shrink-0 mt-0.5 animate-spin" aria-hidden="true" />
+        <div className="flex-1 flex flex-col gap-0.5">
+          <p className="font-medium">Terminal service restarting</p>
+          <p>The terminal backend stopped and is restarting automatically.</p>
+        </div>
+      </div>
+    );
+  }
 
   const { title, body } = copyForCrash(lastCrashType);
 
   const handleRestart = async () => {
     if (isRestarting) return;
     setIsRestarting(true);
-    // dispatch never throws — it returns { ok, error }. On a successful restart
-    // the backend status transitions out of "disconnected" and the banner
-    // unmounts, so we only need to unlock the button on failure.
     const result = await actionService.dispatch("terminal.restartService", undefined, {
       source: "user",
     });

--- a/src/components/Recovery/__tests__/HostCrashBanner.test.tsx
+++ b/src/components/Recovery/__tests__/HostCrashBanner.test.tsx
@@ -35,10 +35,51 @@ describe("HostCrashBanner", () => {
     expect(container.firstChild).toBeNull();
   });
 
-  it("renders nothing when backend is recovering", () => {
+  it("renders nothing when backend is recovering (sub-Doherty gate)", () => {
     usePanelStore.setState({ backendStatus: "recovering" });
     const { container } = render(<HostCrashBanner />);
     expect(container.firstChild).toBeNull();
+  });
+
+  it("renders recovering banner after Doherty threshold", () => {
+    vi.useFakeTimers();
+    usePanelStore.setState({ backendStatus: "recovering" });
+    const { container } = render(<HostCrashBanner />);
+    expect(container.firstChild).toBeNull();
+    act(() => {
+      vi.advanceTimersByTime(400);
+    });
+    expect(container.firstChild).not.toBeNull();
+    vi.useRealTimers();
+  });
+
+  it("shows spinner and restarting copy in recovering variant", () => {
+    vi.useFakeTimers();
+    usePanelStore.setState({ backendStatus: "recovering" });
+    render(<HostCrashBanner />);
+    act(() => {
+      vi.advanceTimersByTime(400);
+    });
+    expect(screen.getByText("Terminal service restarting")).toBeTruthy();
+    expect(
+      screen.getByText(/The terminal backend stopped and is restarting automatically/)
+    ).toBeTruthy();
+    expect(screen.queryByRole("button", { name: /Restart service/i })).toBeNull();
+    vi.useRealTimers();
+  });
+
+  it("hides recovering banner when recovering resolves within Doherty threshold", () => {
+    vi.useFakeTimers();
+    usePanelStore.setState({ backendStatus: "recovering" });
+    const { container } = render(<HostCrashBanner />);
+    act(() => {
+      usePanelStore.setState({ backendStatus: "connected", lastCrashType: null });
+    });
+    act(() => {
+      vi.advanceTimersByTime(400);
+    });
+    expect(container.firstChild).toBeNull();
+    vi.useRealTimers();
   });
 
   it("renders the OUT_OF_MEMORY copy when applicable", () => {

--- a/src/controllers/TerminalRegistryController.ts
+++ b/src/controllers/TerminalRegistryController.ts
@@ -316,6 +316,17 @@ class TerminalRegistryController {
     return terminalClient.onBackendCrashed(handler);
   }
 
+  onBackendRecovering(
+    handler: (data: {
+      crashType: string;
+      code: number | null;
+      signal: string | null;
+      timestamp: number;
+    }) => void
+  ) {
+    return terminalClient.onBackendRecovering(handler);
+  }
+
   onBackendReady(handler: () => void) {
     return terminalClient.onBackendReady(handler);
   }

--- a/src/store/__tests__/layoutUndoStore.test.ts
+++ b/src/store/__tests__/layoutUndoStore.test.ts
@@ -12,6 +12,7 @@ vi.mock("@/controllers", () => ({
     onExit: vi.fn(() => vi.fn()),
     onStatus: vi.fn(() => vi.fn()),
     onBackendCrashed: vi.fn(() => vi.fn()),
+    onBackendRecovering: vi.fn(() => vi.fn()),
     onBackendReady: vi.fn(() => vi.fn()),
     onSpawnResult: vi.fn(() => vi.fn()),
     onReduceScrollback: vi.fn(() => vi.fn()),

--- a/src/store/__tests__/panelStore.processDetectionListeners.test.ts
+++ b/src/store/__tests__/panelStore.processDetectionListeners.test.ts
@@ -39,6 +39,12 @@ type BackendCrashedHandler = (data: {
   signal: string | null;
   timestamp: number;
 }) => void;
+type BackendRecoveringHandler = (data: {
+  crashType: string;
+  code: number | null;
+  signal: string | null;
+  timestamp: number;
+}) => void;
 type BackendReadyHandler = () => void;
 type SpawnResultHandler = (id: string, result: { success: boolean; error?: unknown }) => void;
 
@@ -52,6 +58,7 @@ const handlers: {
   exit?: ExitHandler;
   status?: StatusHandler;
   backendCrashed?: BackendCrashedHandler;
+  backendRecovering?: BackendRecoveringHandler;
   backendReady?: BackendReadyHandler;
   spawnResult?: SpawnResultHandler;
 } = {};
@@ -66,6 +73,7 @@ const unsubs = {
   exit: vi.fn(),
   status: vi.fn(),
   backendCrashed: vi.fn(),
+  backendRecovering: vi.fn(),
   backendReady: vi.fn(),
   spawnResult: vi.fn(),
 };
@@ -106,6 +114,10 @@ const onBackendCrashedMock = vi.fn((cb: BackendCrashedHandler) => {
   handlers.backendCrashed = cb;
   return unsubs.backendCrashed;
 });
+const onBackendRecoveringMock = vi.fn((cb: BackendRecoveringHandler) => {
+  handlers.backendRecovering = cb;
+  return unsubs.backendRecovering;
+});
 const onBackendReadyMock = vi.fn((cb: BackendReadyHandler) => {
   handlers.backendReady = cb;
   return unsubs.backendReady;
@@ -142,6 +154,7 @@ vi.mock("@/clients", () => ({
     onRestored: onRestoredMock,
     onStatus: onStatusMock,
     onBackendCrashed: onBackendCrashedMock,
+    onBackendRecovering: onBackendRecoveringMock,
     onBackendReady: onBackendReadyMock,
     onSpawnResult: onSpawnResultMock,
     onReduceScrollback: vi.fn(() => vi.fn()),

--- a/src/store/listeners/panel/backendHealth.ts
+++ b/src/store/listeners/panel/backendHealth.ts
@@ -38,7 +38,6 @@ export function setupBackendHealthListeners(): DisposableStore {
       terminalRegistryController.onBackendCrashed((details) => {
         logError("Backend crashed", undefined, { details });
 
-        // Cancel any pending recovery timer
         if (recoveryTimer) {
           clearTimeout(recoveryTimer);
           recoveryTimer = null;
@@ -46,6 +45,24 @@ export function setupBackendHealthListeners(): DisposableStore {
 
         usePanelStore.setState({
           backendStatus: "disconnected",
+          lastCrashType: normalizeCrashType(details?.crashType),
+        });
+      })
+    )
+  );
+
+  d.add(
+    toDisposable(
+      terminalRegistryController.onBackendRecovering((details) => {
+        logError("Backend recovering (auto-restart in progress)", undefined, { details });
+
+        if (recoveryTimer) {
+          clearTimeout(recoveryTimer);
+          recoveryTimer = null;
+        }
+
+        usePanelStore.setState({
+          backendStatus: "recovering",
           lastCrashType: normalizeCrashType(details?.crashType),
         });
       })

--- a/src/store/listeners/panel/backendHealth.ts
+++ b/src/store/listeners/panel/backendHealth.ts
@@ -1,7 +1,7 @@
 import type { CrashType } from "@shared/types/pty-host";
 import { terminalRegistryController } from "@/controllers";
 import { terminalInstanceService } from "@/services/TerminalInstanceService";
-import { logInfo, logError } from "@/utils/logger";
+import { logInfo, logError, logWarn } from "@/utils/logger";
 import { DisposableStore, toDisposable } from "@/utils/disposable";
 import { usePanelStore } from "@/store/panelStore";
 
@@ -54,7 +54,7 @@ export function setupBackendHealthListeners(): DisposableStore {
   d.add(
     toDisposable(
       terminalRegistryController.onBackendRecovering((details) => {
-        logError("Backend recovering (auto-restart in progress)", undefined, { details });
+        logWarn("Backend recovering (auto-restart in progress)", { details });
 
         if (recoveryTimer) {
           clearTimeout(recoveryTimer);


### PR DESCRIPTION
## Summary
- Sets `backendStatus` to `recovering` immediately when the pty-host crashes, not after recovery succeeds. Previously it stayed `connected` through the backoff window and the terminal looked frozen.
- `HostCrashBanner` now renders a neutral spinner variant during recovery, gated behind the 400ms Doherty threshold so sub-400ms restarts don't flash.
- New `terminal:backend-recovering` IPC event bridges the main-to-renderer signal.

Resolves #7905

## Changes
- `backendHealth.ts` -- set recovering status on crash, not on recovery success
- `HostCrashBanner.tsx` -- new recovering variant with spinner + `useDeferredLoading` gate
- New `terminal:backend-recovering` IPC event wired through channels, handlers, preload, and IPC types
- `terminalClient.ts` + `TerminalRegistryController.ts` -- forward the recovering event to the renderer

## Testing
- 19 HostCrashBanner tests pass (recovering, disconnected, null states + Doherty gating)
- 13 terminalClient tests pass
- Manual verification: kill pty-host, confirm banner appears within the backoff window