### PR TITLE
fix(errors): flip Retry to View errors after dock promotion, normalize error dedup

### DIFF
--- a/shared/utils/__tests__/normalizeErrorMessage.test.ts
+++ b/shared/utils/__tests__/normalizeErrorMessage.test.ts
@@ -1,0 +1,112 @@
+import { describe, expect, it } from "vitest";
+import { normalizeForDedup } from "../normalizeErrorMessage";
+
+describe("normalizeForDedup", () => {
+  it("strips UUIDs", () => {
+    expect(normalizeForDedup("Error abc12345-6789-4abc-def0-123456789abc occurred")).toBe(
+      "Error occurred"
+    );
+  });
+
+  it("strips ISO 8601 timestamps", () => {
+    expect(normalizeForDedup("Timeout at 2024-01-15T08:30:00Z for request")).toBe(
+      "Timeout at for request"
+    );
+  });
+
+  it("strips ISO timestamps with fractional seconds", () => {
+    expect(normalizeForDedup("Timeout at 2024-01-15T08:30:00.123Z for request")).toBe(
+      "Timeout at for request"
+    );
+  });
+
+  it("strips ISO timestamps with numeric timezone", () => {
+    expect(normalizeForDedup("Timeout at 2024-01-15T08:30:00+05:30 for request")).toBe(
+      "Timeout at for request"
+    );
+  });
+
+  it("strips git SHAs", () => {
+    expect(
+      normalizeForDedup(
+        "fatal: ambiguous argument 'abc123def456789012345678901234567890abcd': unknown revision"
+      )
+    ).toBe("fatal: ambiguous argument '': unknown revision");
+  });
+
+  it("strips 13-digit epoch milliseconds", () => {
+    expect(normalizeForDedup("Request 1705310400123 timed out")).toBe("Request timed out");
+  });
+
+  it("does not strip numbers that are not 13-digit epoch ms", () => {
+    expect(normalizeForDedup("Port 3000 is in use")).toBe("Port 3000 is in use");
+    expect(normalizeForDedup("Version 2.4.1 released")).toBe("Version 2.4.1 released");
+  });
+
+  it("strips PID suffixes", () => {
+    expect(normalizeForDedup("Process pid 12345 exited unexpectedly")).toBe(
+      "Process exited unexpectedly"
+    );
+  });
+
+  it("strips process number suffixes", () => {
+    expect(normalizeForDedup("Process process 67890 crashed")).toBe("Process crashed");
+  });
+
+  it("strips EADDRINUSE port after address already in use phrase", () => {
+    const a = "listen EADDRINUSE: address already in use :::3000";
+    const b = "listen EADDRINUSE: address already in use :::4000";
+    expect(normalizeForDedup(a)).toBe(normalizeForDedup(b));
+  });
+
+  it("strips EADDRINUSE port after localhost", () => {
+    const a = "connect ECONNREFUSED localhost:3000";
+    const b = "connect ECONNREFUSED localhost:4000";
+    expect(normalizeForDedup(a)).toBe(normalizeForDedup(b));
+  });
+
+  it("strips quoted absolute macOS paths", () => {
+    expect(
+      normalizeForDedup('ENOENT: no such file or directory, open "/Users/test/file.txt"')
+    ).toBe('ENOENT: no such file or directory, open ""');
+  });
+
+  it("strips quoted absolute Windows paths", () => {
+    expect(
+      normalizeForDedup('ENOENT: no such file or directory, open "C:\\Users\\test\\file.txt"')
+    ).toBe(
+      /* collapsed whitespace */ normalizeForDedup(
+        'ENOENT: no such file or directory, open "D:\\other\\file.txt"'
+      )
+    );
+  });
+
+  it("passes through messages with no volatile content", () => {
+    expect(normalizeForDedup("Git push failed")).toBe("Git push failed");
+  });
+
+  it("collapses whitespace from removed fragments", () => {
+    expect(normalizeForDedup("listen EADDRINUSE: address already in use :::3000")).toBe(
+      "listen EADDRINUSE: address already in use"
+    );
+  });
+
+  it("handles messages with multiple volatile patterns", () => {
+    const input =
+      'Error abc12345-5678-4abc-def0-123456789abc at 2024-01-15T08:30:00Z: pid 12345 failed on "/Users/test/file.txt"';
+    const result = normalizeForDedup(input);
+    expect(result).not.toContain("abc12345");
+    expect(result).not.toContain("2024-01-15");
+    expect(result).not.toContain("12345");
+    expect(result).not.toContain("/Users/test/file.txt");
+    expect(result).toContain("Error");
+  });
+
+  it("returns original message when normalization empties the string", () => {
+    expect(normalizeForDedup("1705310400123")).toBe("1705310400123");
+  });
+
+  it("returns empty string for empty input", () => {
+    expect(normalizeForDedup("")).toBe("");
+  });
+});

--- a/shared/utils/__tests__/normalizeErrorMessage.test.ts
+++ b/shared/utils/__tests__/normalizeErrorMessage.test.ts
@@ -1,5 +1,5 @@
 import { describe, expect, it } from "vitest";
-import { normalizeForDedup } from "../normalizeErrorMessage";
+import { normalizeForDedup } from "../normalizeErrorMessage.js";
 
 describe("normalizeForDedup", () => {
   it("strips UUIDs", () => {

--- a/shared/utils/normalizeErrorMessage.ts
+++ b/shared/utils/normalizeErrorMessage.ts
@@ -1,0 +1,52 @@
+/**
+ * Strip volatile suffixes from error messages for dedup comparison.
+ * Returns a stable key while leaving the original message intact for display.
+ *
+ * Conservative patterns only: strips well-known volatile noise (UUIDs,
+ * timestamps, git SHAs, port syntax in EADDRINUSE, PID/process suffixes,
+ * quoted absolute paths) that signal the same underlying fault arriving
+ * with different runtime details.
+ */
+export function normalizeForDedup(message: string): string {
+  let normalized = message;
+
+  // UUID v4 and v1 (36-char hex with dashes)
+  normalized = normalized.replace(
+    /[0-9a-f]{8}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{12}/gi,
+    ""
+  );
+
+  // ISO 8601 timestamps (with optional fractional seconds and timezone)
+  normalized = normalized.replace(
+    /\d{4}-\d{2}-\d{2}T\d{2}:\d{2}:\d{2}(?:\.\d+)?(?:Z|[+-]\d{2}:\d{2})?/g,
+    ""
+  );
+
+  // Git SHAs (40-char hex)
+  normalized = normalized.replace(/\b[0-9a-f]{40}\b/gi, "");
+
+  // 13-digit epoch milliseconds (standalone)
+  normalized = normalized.replace(/\b\d{13}\b/g, "");
+
+  // PID/proc suffixes: "pid 12345", "PID: 12345", "process 12345"
+  normalized = normalized.replace(/\b(?:pid|process)\s*:?\s*\d+/gi, "");
+
+  // EADDRINUSE trailing port: "EADDRINUSE: address already in use :::3000"
+  // Preserve the stable text, strip only the port syntax.
+  normalized = normalized.replace(/\b(address already in use)\s*:+\d{1,5}\b/gi, "$1");
+
+  // localhost port: "localhost:3000", "127.0.0.1:4000", "0.0.0.0:8080"
+  normalized = normalized.replace(/\b((?:localhost|127\.0\.0\.1|0\.0\.0\.0)):\d{1,5}\b/gi, "$1");
+
+  // Quoted absolute paths: "/Users/.../foo", "C:\Users\...\foo"
+  normalized = normalized.replace(/"[A-Za-z]:[/\\][^"]+"/g, '""');
+  normalized = normalized.replace(/"\/[^"]+"/g, '""');
+
+  // Collapse multiple spaces from removed fragments
+  normalized = normalized.replace(/\s{2,}/g, " ").trim();
+
+  // Fall back to original if normalization emptied the string
+  if (!normalized) return message;
+
+  return normalized;
+}

--- a/src/components/Diagnostics/DiagnosticsDock.tsx
+++ b/src/components/Diagnostics/DiagnosticsDock.tsx
@@ -89,6 +89,7 @@ export function DiagnosticsDock({ onRetry, onCancelRetry, className }: Diagnosti
   useEffect(() => {
     if (errorCount > 0 && prevErrorCountRef.current === 0 && !isOpen) {
       openDock("problems");
+      useErrorStore.getState().promoteErrors();
     }
     prevErrorCountRef.current = errorCount;
   }, [errorCount, isOpen, openDock]);

--- a/src/components/Diagnostics/DiagnosticsDock.tsx
+++ b/src/components/Diagnostics/DiagnosticsDock.tsx
@@ -91,8 +91,17 @@ export function DiagnosticsDock({ onRetry, onCancelRetry, className }: Diagnosti
       openDock("problems");
       useErrorStore.getState().promoteErrors();
     }
+    // Promote new errors arriving while the dock is already open on problems
+    if (
+      errorCount > prevErrorCountRef.current &&
+      prevErrorCountRef.current > 0 &&
+      isOpen &&
+      activeTab === "problems"
+    ) {
+      useErrorStore.getState().promoteErrors();
+    }
     prevErrorCountRef.current = errorCount;
-  }, [errorCount, isOpen, openDock]);
+  }, [errorCount, isOpen, openDock, activeTab]);
 
   const [isResizing, setIsResizing] = useState(false);
   const resizeStartY = useRef(0);
@@ -335,7 +344,12 @@ export function DiagnosticsDock({ onRetry, onCancelRetry, className }: Diagnosti
               tab={tab.id}
               label={tab.label}
               isActive={activeTab === tab.id}
-              onClick={() => setActiveTab(tab.id)}
+              onClick={() => {
+                if (tab.id === "problems" && activeTab !== "problems") {
+                  useErrorStore.getState().promoteErrors();
+                }
+                setActiveTab(tab.id);
+              }}
               badge={tab.badge}
             />
           ))}

--- a/src/components/Errors/ErrorBanner.tsx
+++ b/src/components/Errors/ErrorBanner.tsx
@@ -12,6 +12,7 @@ import {
   type LucideIcon,
 } from "lucide-react";
 import type { ErrorRecord, RetryAction } from "@/store/errorStore";
+import { useErrorStore } from "@/store/errorStore";
 import { useDiagnosticsStore } from "@/store/diagnosticsStore";
 import { actionService } from "@/services/ActionService";
 
@@ -26,6 +27,12 @@ import { actionService } from "@/services/ActionService";
 type BannerAction = "retry" | "recovery" | "view-errors";
 
 function bannerActionFor(error: ErrorRecord, hasOnRetry: boolean): BannerAction {
+  // Once an error has been promoted to the diagnostics dock, the dock owns
+  // recovery — flip the banner CTA to "View errors" so the user is routed
+  // to the dock instead of seeing a stale Retry next to the open dock.
+  if (error.promotedToDock) {
+    return "view-errors";
+  }
   if (error.retryability === "auto" && error.retryAction && hasOnRetry) {
     return "retry";
   }
@@ -112,7 +119,8 @@ export function ErrorBanner({
 
   const handleViewErrors = useCallback(() => {
     useDiagnosticsStore.getState().openDock("problems");
-  }, []);
+    useErrorStore.getState().promoteErrors([error.id]);
+  }, [error.id]);
 
   const handleCopyCorrelationId = useCallback(() => {
     if (!error.correlationId) return;

--- a/src/components/Errors/__tests__/ErrorBanner.test.tsx
+++ b/src/components/Errors/__tests__/ErrorBanner.test.tsx
@@ -3,6 +3,7 @@ import { act, fireEvent, render, screen } from "@testing-library/react";
 import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
 import { ErrorBanner } from "../ErrorBanner";
 import type { ErrorRecord } from "@/store/errorStore";
+import { useErrorStore } from "@/store/errorStore";
 import { useDiagnosticsStore } from "@/store/diagnosticsStore";
 
 vi.mock("@/lib/utils", () => ({
@@ -410,6 +411,90 @@ describe("ErrorBanner", () => {
         vi.advanceTimersByTime(600);
       });
       expect(screen.queryByText("Ref: Copied")).toBeNull();
+    });
+  });
+
+  describe("promotedToDock", () => {
+    beforeEach(() => {
+      useErrorStore.getState().reset();
+      useDiagnosticsStore.getState().reset();
+    });
+
+    it("does not show Retry button in compact when promotedToDock is true", () => {
+      render(
+        <ErrorBanner
+          error={makeError({
+            retryability: "auto",
+            retryAction: "git",
+            promotedToDock: true,
+          })}
+          onDismiss={onDismiss}
+          onRetry={vi.fn()}
+          compact
+        />
+      );
+      expect(screen.queryByRole("button", { name: "Retry" })).toBeNull();
+      expect(screen.getByRole("button", { name: "View errors" })).toBeTruthy();
+    });
+
+    it("does not show Retry button in full when promotedToDock is true", () => {
+      render(
+        <ErrorBanner
+          error={makeError({
+            retryability: "auto",
+            retryAction: "git",
+            promotedToDock: true,
+          })}
+          onDismiss={onDismiss}
+          onRetry={vi.fn()}
+        />
+      );
+      expect(screen.queryByRole("button", { name: "Retry" })).toBeNull();
+      expect(screen.getByRole("button", { name: "View errors" })).toBeTruthy();
+    });
+
+    it("full variant with promotedToDock and details does not show View errors", () => {
+      render(
+        <ErrorBanner
+          error={makeError({
+            retryability: "auto",
+            retryAction: "git",
+            promotedToDock: true,
+            details: "stack trace here",
+          })}
+          onDismiss={onDismiss}
+          onRetry={vi.fn()}
+        />
+      );
+      expect(screen.queryByRole("button", { name: "Retry" })).toBeNull();
+      expect(screen.queryByRole("button", { name: "View errors" })).toBeNull();
+      expect(screen.getByRole("button", { name: "Details" })).toBeTruthy();
+    });
+
+    it("handleViewErrors opens dock and promotes error", () => {
+      // Add an error to the store first, then promote via View errors
+      const id = useErrorStore.getState().addError({
+        type: "git",
+        message: "push rejected",
+        source: "git",
+        retryability: "none",
+      });
+
+      render(
+        <ErrorBanner
+          error={makeError({ id, retryability: "none" })}
+          onDismiss={onDismiss}
+          compact
+        />
+      );
+
+      fireEvent.click(screen.getByRole("button", { name: "View errors" }));
+      expect(useDiagnosticsStore.getState().isOpen).toBe(true);
+      expect(useDiagnosticsStore.getState().activeTab).toBe("problems");
+
+      const storeErrors = useErrorStore.getState().errors;
+      const promoted = storeErrors.find((e) => e.id === id);
+      expect(promoted?.promotedToDock).toBe(true);
     });
   });
 });

--- a/src/lib/__tests__/notify.test.ts
+++ b/src/lib/__tests__/notify.test.ts
@@ -2100,6 +2100,45 @@ describe("shouldEscalateTransientError", () => {
     expect(shouldEscalateTransientError(error2)).toBe(false); // count=2, not yet threshold
   });
 
+  it("groups errors whose messages differ only by volatile suffixes (normalized dedup)", () => {
+    const error1 = {
+      type: "process" as const,
+      message: "listen EADDRINUSE: address already in use :::3000",
+      source: "http",
+      retryability: "auto",
+    };
+    const error2 = {
+      type: "process" as const,
+      message: "listen EADDRINUSE: address already in use :::4000",
+      source: "http",
+      retryability: "auto",
+    };
+
+    // Same normalized key — grouped together
+    shouldEscalateTransientError(error1);
+    shouldEscalateTransientError(error2);
+    expect(shouldEscalateTransientError(error1)).toBe(true);
+  });
+
+  it("groups errors with UUID-only message differences", () => {
+    const error1 = {
+      type: "network" as const,
+      message: "Timeout abc12345-6789-4abc-def0-123456789abc for request",
+      source: "fetcher",
+      retryability: "auto",
+    };
+    const error2 = {
+      type: "network" as const,
+      message: "Timeout deadbeef-1111-4abc-def0-222222222222 for request",
+      source: "fetcher",
+      retryability: "auto",
+    };
+
+    shouldEscalateTransientError(error1);
+    shouldEscalateTransientError(error2);
+    expect(shouldEscalateTransientError(error1)).toBe(true);
+  });
+
   it("caps tracking entries and prunes LRU", () => {
     const realDateNow = Date.now;
     Date.now = () => 1000;

--- a/src/lib/notify.ts
+++ b/src/lib/notify.ts
@@ -12,6 +12,7 @@ import {
 } from "@/store/slices/notificationHistorySlice";
 import { useNotificationSettingsStore } from "@/store/notificationSettingsStore";
 import { isScheduledQuietNow, nextOccurrenceTimestamp } from "@shared/utils/quietHours";
+import { normalizeForDedup } from "@shared/utils/normalizeErrorMessage";
 import type { ErrorRetryability, ErrorType } from "@/store/errorStore";
 import type { NotificationSettings } from "@shared/types/ipc/api";
 
@@ -228,7 +229,7 @@ function classifyErrorType(type: ErrorType): EscalationProfile {
 }
 
 function buildEscalationKey(error: { type: ErrorType; message: string; source?: string }): string {
-  return `${error.type}|${error.source ?? ""}|${error.message}`;
+  return `${error.type}|${error.source ?? ""}|${normalizeForDedup(error.message)}`;
 }
 
 const _escalationTrackers = new Map<string, EscalationTracker>();

--- a/src/services/actions/definitions/panelCoreActions.ts
+++ b/src/services/actions/definitions/panelCoreActions.ts
@@ -1,6 +1,7 @@
 import type { ActionCallbacks, ActionRegistry } from "../actionTypes";
 import { z } from "zod";
 import { useDiagnosticsStore } from "@/store/diagnosticsStore";
+import { useErrorStore } from "@/store/errorStore";
 import { usePortalStore } from "@/store/portalStore";
 import { usePanelStore, type TerminalInstance } from "@/store/panelStore";
 
@@ -160,6 +161,7 @@ export function registerPanelCoreActions(
     keywords: ["errors", "warnings", "issues", "lint"],
     run: async () => {
       useDiagnosticsStore.getState().openDock("problems");
+      useErrorStore.getState().promoteErrors();
     },
   }));
 

--- a/src/store/__tests__/errorStore.test.ts
+++ b/src/store/__tests__/errorStore.test.ts
@@ -262,4 +262,168 @@ describe("errorStore", () => {
     expect(after.lastErrorTime).toBe(0);
     expect(after.isPanelOpen).toBe(false);
   });
+
+  describe("normalized dedup", () => {
+    it("deduplicates errors whose messages differ only by a UUID", () => {
+      vi.setSystemTime(new Date("2026-01-01T00:00:00.000Z"));
+      useErrorStore.getState().addError({
+        type: "process",
+        message: "Error abc12345-6789-4abc-def0-123456789abc occurred",
+        source: "pty",
+        retryability: "auto",
+      });
+
+      vi.setSystemTime(new Date("2026-01-01T00:00:00.200Z"));
+      useErrorStore.getState().addError({
+        type: "process",
+        message: "Error deadbeef-1111-4abc-def0-222222222222 occurred",
+        source: "pty",
+        retryability: "auto",
+      });
+
+      const state = useErrorStore.getState();
+      expect(state.errors).toHaveLength(1);
+      // First message preserved for display
+      expect(state.errors[0]?.message).toBe("Error abc12345-6789-4abc-def0-123456789abc occurred");
+    });
+
+    it("deduplicates EADDRINUSE errors with different port numbers", () => {
+      vi.setSystemTime(new Date("2026-01-01T00:00:00.000Z"));
+      useErrorStore.getState().addError({
+        type: "process",
+        message: "listen EADDRINUSE: address already in use :::3000",
+        source: "http",
+        retryability: "auto",
+      });
+
+      vi.setSystemTime(new Date("2026-01-01T00:00:00.200Z"));
+      useErrorStore.getState().addError({
+        type: "process",
+        message: "listen EADDRINUSE: address already in use :::4000",
+        source: "http",
+        retryability: "auto",
+      });
+
+      expect(useErrorStore.getState().errors).toHaveLength(1);
+    });
+
+    it("does not deduplicate errors with genuinely different messages", () => {
+      vi.setSystemTime(new Date("2026-01-01T00:00:00.000Z"));
+      useErrorStore.getState().addError({
+        type: "process",
+        message: "EBUSY: resource busy or locked",
+        source: "pty",
+        retryability: "auto",
+      });
+
+      vi.setSystemTime(new Date("2026-01-01T00:00:00.200Z"));
+      useErrorStore.getState().addError({
+        type: "process",
+        message: "EACCES: permission denied",
+        source: "pty",
+        retryability: "auto",
+      });
+
+      expect(useErrorStore.getState().errors).toHaveLength(2);
+    });
+
+    it("does not deduplicate outside rate limit window even with normalized-identical messages", () => {
+      vi.setSystemTime(new Date("2026-01-01T00:00:00.000Z"));
+      useErrorStore.getState().addError({
+        type: "process",
+        message: "Error abc12345-6789-4abc-def0-123456789abc occurred",
+        source: "pty",
+        retryability: "auto",
+      });
+
+      vi.setSystemTime(new Date("2026-01-01T00:00:00.600Z"));
+      useErrorStore.getState().addError({
+        type: "process",
+        message: "Error deadbeef-1111-4abc-def0-222222222222 occurred",
+        source: "pty",
+        retryability: "auto",
+      });
+
+      expect(useErrorStore.getState().errors).toHaveLength(2);
+    });
+  });
+
+  describe("promoteErrors", () => {
+    let errorIds: string[] = [];
+
+    beforeEach(() => {
+      errorIds = [];
+      vi.setSystemTime(new Date("2026-01-01T00:00:00.000Z"));
+      for (const msg of ["err-a", "err-b", "err-c"]) {
+        const id = useErrorStore.getState().addError({
+          type: "process",
+          message: msg,
+          source: "test",
+          retryability: "auto",
+        });
+        errorIds.push(id);
+      }
+    });
+
+    it("promotes only specified errors when ids are provided", () => {
+      useErrorStore.getState().promoteErrors([errorIds[0]!]);
+
+      const state = useErrorStore.getState();
+      expect(state.errors.find((e) => e.id === errorIds[0])?.promotedToDock).toBe(true);
+      expect(state.errors.find((e) => e.id === errorIds[1])?.promotedToDock).toBeUndefined();
+      expect(state.errors.find((e) => e.id === errorIds[2])?.promotedToDock).toBeUndefined();
+    });
+
+    it("promotes all non-dismissed errors when no ids are provided", () => {
+      useErrorStore.getState().promoteErrors();
+
+      const state = useErrorStore.getState();
+      for (const id of errorIds) {
+        expect(state.errors.find((e) => e.id === id)?.promotedToDock).toBe(true);
+      }
+    });
+
+    it("does not promote dismissed errors", () => {
+      useErrorStore.getState().dismissError(errorIds[0]!);
+      useErrorStore.getState().promoteErrors();
+
+      const state = useErrorStore.getState();
+      expect(state.errors.find((e) => e.id === errorIds[0])?.promotedToDock).toBeUndefined();
+      expect(state.errors.find((e) => e.id === errorIds[1])?.promotedToDock).toBe(true);
+    });
+
+    it("is idempotent", () => {
+      useErrorStore.getState().promoteErrors([errorIds[0]!]);
+      useErrorStore.getState().promoteErrors([errorIds[0]!]);
+
+      expect(
+        useErrorStore.getState().errors.find((e) => e.id === errorIds[0])?.promotedToDock
+      ).toBe(true);
+    });
+
+    it("preserves promotedToDock when a matching error is deduplicated", () => {
+      vi.setSystemTime(new Date("2026-01-01T00:00:00.000Z"));
+      useErrorStore.getState().promoteErrors([errorIds[0]!]);
+
+      // Fire a duplicate that normalizes to the same message
+      vi.setSystemTime(new Date("2026-01-01T00:00:00.200Z"));
+      useErrorStore.getState().addError({
+        type: "process",
+        message: "err-a",
+        source: "test",
+        retryability: "auto",
+      });
+
+      const state = useErrorStore.getState();
+      expect(state.errors).toHaveLength(3);
+      expect(state.errors.find((e) => e.id === errorIds[0])?.promotedToDock).toBe(true);
+    });
+
+    it("is a no-op with empty ids array", () => {
+      const before = useErrorStore.getState().errors;
+      useErrorStore.getState().promoteErrors([]);
+      const after = useErrorStore.getState().errors;
+      expect(after).toEqual(before);
+    });
+  });
 });

--- a/src/store/__tests__/errorStore.test.ts
+++ b/src/store/__tests__/errorStore.test.ts
@@ -401,22 +401,32 @@ describe("errorStore", () => {
       ).toBe(true);
     });
 
-    it("preserves promotedToDock when a matching error is deduplicated", () => {
+    it("preserves promotedToDock when a normalized-identical error is deduplicated", () => {
       vi.setSystemTime(new Date("2026-01-01T00:00:00.000Z"));
-      useErrorStore.getState().promoteErrors([errorIds[0]!]);
+      // Add an error with a UUID suffix and promote it
+      const id = useErrorStore.getState().addError({
+        type: "process",
+        message: "Spawn failed abc12345-6789-4abc-def0-123456789abc",
+        source: "pty",
+        retryability: "auto",
+      });
+      useErrorStore.getState().promoteErrors([id]);
 
-      // Fire a duplicate that normalizes to the same message
+      // Fire a duplicate with a different UUID that normalizes to the same key
       vi.setSystemTime(new Date("2026-01-01T00:00:00.200Z"));
       useErrorStore.getState().addError({
         type: "process",
-        message: "err-a",
-        source: "test",
+        message: "Spawn failed deadbeef-1111-4abc-def0-222222222222",
+        source: "pty",
         retryability: "auto",
       });
 
       const state = useErrorStore.getState();
-      expect(state.errors).toHaveLength(3);
-      expect(state.errors.find((e) => e.id === errorIds[0])?.promotedToDock).toBe(true);
+      expect(state.errors).toHaveLength(4); // 3 from beforeEach + 1 promoted (duplicate merged)
+      const promoted = state.errors.find((e) => e.id === id);
+      expect(promoted?.promotedToDock).toBe(true);
+      // Original message preserved for display
+      expect(promoted?.message).toBe("Spawn failed abc12345-6789-4abc-def0-123456789abc");
     });
 
     it("is a no-op with empty ids array", () => {

--- a/src/store/errorStore.ts
+++ b/src/store/errorStore.ts
@@ -6,6 +6,7 @@ import type {
   RecoveryAction,
   RetryAction,
 } from "@shared/types/ipc/errors";
+import { normalizeForDedup } from "@shared/utils/normalizeErrorMessage";
 
 export type { ErrorRetryability, ErrorType, RetryAction } from "@shared/types/ipc/errors";
 
@@ -34,6 +35,8 @@ export interface ErrorRecord {
   gitReason?: GitOperationReason;
   /** Structured CTA the renderer can surface alongside the error */
   recoveryAction?: RecoveryAction;
+  /** Set when the error has been promoted to the diagnostics dock (auto-open or user click) */
+  promotedToDock?: boolean;
 }
 
 interface ErrorStore {
@@ -41,7 +44,9 @@ interface ErrorStore {
   isPanelOpen: boolean;
   lastErrorTime: number;
 
-  addError: (error: Omit<ErrorRecord, "id" | "timestamp" | "dismissed">) => string;
+  addError: (
+    error: Omit<ErrorRecord, "id" | "timestamp" | "dismissed" | "promotedToDock">
+  ) => string;
   dismissError: (id: string) => void;
   removeError: (id: string) => void;
   togglePanel: () => void;
@@ -51,6 +56,7 @@ interface ErrorStore {
   getActiveErrors: () => ErrorRecord[];
   updateRetryProgress: (id: string, attempt: number, maxAttempts: number) => void;
   clearRetryProgress: (id: string) => void;
+  promoteErrors: (ids?: string[]) => void;
   reset: () => void;
 }
 
@@ -70,12 +76,15 @@ const createErrorStore: StateCreator<ErrorStore> = (set, get) => ({
     const now = Date.now();
     const state = get();
 
-    // Deduplicate rapid-fire errors with same type/message/context to avoid UI flooding
+    // Deduplicate rapid-fire errors with same normalized type/message/context to avoid UI flooding.
+    // Messages are normalized to strip volatile suffixes (UUIDs, timestamps, ports, PIDs)
+    // so variant-suffix errors collapse into a single record.
+    const normMsg = normalizeForDedup(error.message);
     const recentDuplicate = state.errors.find(
       (e) =>
         !e.dismissed &&
         e.type === error.type &&
-        e.message === error.message &&
+        normalizeForDedup(e.message) === normMsg &&
         e.source === error.source &&
         e.context?.terminalId === error.context?.terminalId &&
         e.context?.worktreeId === error.context?.worktreeId &&
@@ -105,6 +114,7 @@ const createErrorStore: StateCreator<ErrorStore> = (set, get) => ({
                 retryArgs: error.retryArgs ?? e.retryArgs,
                 recoveryHint: e.recoveryHint ?? error.recoveryHint,
                 correlationId: e.correlationId ?? error.correlationId,
+                promotedToDock: e.promotedToDock,
               }
             : e
         ),
@@ -175,6 +185,20 @@ const createErrorStore: StateCreator<ErrorStore> = (set, get) => ({
     set((state) => ({
       errors: state.errors.map((e) => (e.id === id ? { ...e, retryProgress: undefined } : e)),
     }));
+  },
+
+  promoteErrors: (ids) => {
+    set((state) => {
+      if (ids && ids.length === 0) return state;
+      const targetIds = ids ? new Set(ids) : null;
+      return {
+        errors: state.errors.map((e) => {
+          if (e.dismissed || e.promotedToDock) return e;
+          if (targetIds && !targetIds.has(e.id)) return e;
+          return { ...e, promotedToDock: true };
+        }),
+      };
+    });
   },
 
   reset: () =>


### PR DESCRIPTION
## Summary
- Closes two gaps in the error banner escalation path. A `promotedToDock` flag on `ErrorRecord` now flips the banner action from "Retry" to "View errors" once the error has been escalated to the diagnostics dock.
- Added `normalizeErrorMessage()` to strip UUIDs, timestamps, port numbers, and similar trailing noise from error messages before computing the dedup key. Messages that only differ in these suffixes now collapse into a single record.
- Errors arriving while the diagnostics dock is already open are promoted immediately, and the dock switches to the problems tab so they're visible right away.

Resolves #7914

## Changes
- `shared/utils/normalizeErrorMessage.ts` — new normalization function with regex patterns for common suffix noise
- `src/store/errorStore.ts` — `promotedToDock` flag on `ErrorRecord`, normalization applied during dedup, auto-promotion logic
- `src/components/Errors/ErrorBanner.tsx` — flips action button based on `promotedToDock`
- `src/components/Diagnostics/DiagnosticsDock.tsx` — sets `promotedToDock` and switches to problems tab on promotion
- `src/services/actions/definitions/panelCoreActions.ts` — switches dock to problems tab when opening diagnostics
- `src/lib/notify.ts` — normalizes before notifying

## Testing
- Unit tests for `normalizeErrorMessage` covering UUIDs, timestamps, port numbers, hex IDs, and edge cases
- Unit tests for `errorStore` dedup behavior verifying that timestamp-suffixed messages collapse into one record
- Unit tests for `ErrorBanner` confirming the action slot flips when `promotedToDock` is set
- Unit tests for `notify` normalization path