### PR TITLE
fix(pty-host): surface ResourceGovernor state with warning band, triage, and profile awareness

### DIFF
--- a/electron/pty-host.ts
+++ b/electron/pty-host.ts
@@ -251,6 +251,14 @@ const resourceGovernor = new ResourceGovernor({
     backpressureManager.stats.pauseCount += count;
   },
   sendEvent,
+  emitTerminalStatus: (...args) => backpressureManager.emitTerminalStatus(...args),
+  getTerminalActivity: () =>
+    ptyManager.getAll().map((t) => ({
+      id: t.id,
+      lastOutputTime: t.lastOutputTime,
+      lastInputTime: t.lastInputTime,
+      agentState: t.agentState,
+    })),
   getPendingBytesSnapshot: () => {
     // Merge SAB-path, IPC-path, and per-window MessagePort-path queue depths so
     // the reliability gauge captures every in-flight byte the pty-host is holding.

--- a/electron/pty-host/ResourceGovernor.ts
+++ b/electron/pty-host/ResourceGovernor.ts
@@ -1,8 +1,17 @@
 import v8 from "node:v8";
-import type { PtyHostEvent } from "../../shared/types/pty-host.js";
+import type { AgentState } from "../../shared/types/agent.js";
+import type { PtyHostEvent, TerminalFlowStatus } from "../../shared/types/pty-host.js";
+import type { ResourceProfile } from "../../shared/types/resourceProfile.js";
 import { FdMonitor } from "./FdMonitor.js";
 import { metricsEnabled } from "./metrics.js";
 import type { PtyPauseCoordinator } from "./PtyPauseCoordinator.js";
+
+export interface TerminalActivityInfo {
+  id: string;
+  lastOutputTime: number;
+  lastInputTime: number;
+  agentState?: AgentState;
+}
 
 export interface ResourceGovernorDeps {
   getTerminalIds: () => string[];
@@ -10,6 +19,14 @@ export interface ResourceGovernorDeps {
   getTerminalPids: () => Array<{ id: string; pid: number | undefined }>;
   incrementPauseCount: (count: number) => void;
   sendEvent: (event: PtyHostEvent) => void;
+  emitTerminalStatus: (
+    id: string,
+    status: TerminalFlowStatus,
+    bufferUtilization?: number,
+    pauseDuration?: number,
+    reason?: string
+  ) => void;
+  getTerminalActivity: () => TerminalActivityInfo[];
   getPendingBytesSnapshot?: () => {
     totalPendingBytes: number;
     perTerminal: Array<{ terminalId: string; pendingBytes: number }>;
@@ -28,6 +45,13 @@ export class ResourceGovernor {
   private readonly RESUME_THRESHOLD_PERCENT = 60;
   private readonly FORCE_RESUME_MS = 10000;
   private readonly CHECK_INTERVAL_MS = 2000;
+  private readonly WARNING_THRESHOLD_PERCENT = 70;
+  private readonly WARNING_CLEAR_PERCENT = 65;
+  private readonly CRITICAL_PERCENT = 95;
+  private readonly EFFICIENCY_MEMORY_LIMIT_PERCENT = 70;
+  private readonly EFFICIENCY_RESUME_PERCENT = 50;
+  private readonly EFFICIENCY_WARNING_PERCENT = 55;
+  private readonly EFFICIENCY_WARNING_CLEAR_PERCENT = 45;
   private isThrottling = false;
   private checkInterval: NodeJS.Timeout | null = null;
   private throttleStartTime = 0;
@@ -36,6 +60,9 @@ export class ResourceGovernor {
   private readonly ORPHAN_GRACE_MS = 4000;
   private prevThroughputTimestamp = 0;
   private prevPauseCount = 0;
+  private readonly pausedTerminalIds = new Set<string>();
+  private isWarning = false;
+  private profileOverride: ResourceProfile | null = null;
 
   constructor(private readonly deps: ResourceGovernorDeps) {
     this.fdMonitor = new FdMonitor();
@@ -53,6 +80,43 @@ export class ResourceGovernor {
     this.killedPids.set(pid, Date.now());
   }
 
+  setResourceProfile(profile: ResourceProfile): void {
+    this.profileOverride = profile;
+    if (profile === "efficiency") {
+      console.log(
+        `[ResourceGovernor] Efficiency profile active — lowering thresholds ` +
+          `(throttle: ${this.EFFICIENCY_MEMORY_LIMIT_PERCENT}%, ` +
+          `warning: ${this.EFFICIENCY_WARNING_PERCENT}%)`
+      );
+    } else {
+      console.log(`[ResourceGovernor] Profile set to ${profile} — using default thresholds`);
+    }
+  }
+
+  private get memoryLimitPercent(): number {
+    return this.profileOverride === "efficiency"
+      ? this.EFFICIENCY_MEMORY_LIMIT_PERCENT
+      : this.MEMORY_LIMIT_PERCENT;
+  }
+
+  private get resumeThresholdPercent(): number {
+    return this.profileOverride === "efficiency"
+      ? this.EFFICIENCY_RESUME_PERCENT
+      : this.RESUME_THRESHOLD_PERCENT;
+  }
+
+  private get warningThresholdPercent(): number {
+    return this.profileOverride === "efficiency"
+      ? this.EFFICIENCY_WARNING_PERCENT
+      : this.WARNING_THRESHOLD_PERCENT;
+  }
+
+  private get warningClearPercent(): number {
+    return this.profileOverride === "efficiency"
+      ? this.EFFICIENCY_WARNING_CLEAR_PERCENT
+      : this.WARNING_CLEAR_PERCENT;
+  }
+
   private checkResources(): void {
     const memory = process.memoryUsage();
     const heapUsedMb = memory.heapUsed / 1024 / 1024;
@@ -60,12 +124,43 @@ export class ResourceGovernor {
     const heapLimitMb = heapStats.heap_size_limit / 1024 / 1024;
     const utilizationPercent = (heapUsedMb / heapLimitMb) * 100;
 
-    if (!this.isThrottling && utilizationPercent > this.MEMORY_LIMIT_PERCENT) {
+    // Warning band — fires once per transition, not per tick
+    const warnThreshold = this.warningThresholdPercent;
+    const warnClear = this.warningClearPercent;
+    if (!this.isWarning && utilizationPercent > warnThreshold) {
+      this.isWarning = true;
+      console.warn(
+        `[ResourceGovernor] Memory warning: ${utilizationPercent.toFixed(1)}% heap used ` +
+          `(threshold: ${warnThreshold}%).`
+      );
+      this.deps.sendEvent({
+        type: "host-memory-warning",
+        isWarning: true,
+        utilizationPercent: Math.round(utilizationPercent),
+        timestamp: Date.now(),
+      });
+    } else if (this.isWarning && utilizationPercent < warnClear) {
+      this.isWarning = false;
+      console.log(
+        `[ResourceGovernor] Memory warning cleared: ${utilizationPercent.toFixed(1)}% heap used.`
+      );
+      this.deps.sendEvent({
+        type: "host-memory-warning",
+        isWarning: false,
+        utilizationPercent: Math.round(utilizationPercent),
+        timestamp: Date.now(),
+      });
+    }
+
+    const limitPercent = this.memoryLimitPercent;
+    const resumePercent = this.resumeThresholdPercent;
+
+    if (!this.isThrottling && utilizationPercent > limitPercent) {
       this.engageThrottle(heapUsedMb, utilizationPercent);
     } else if (this.isThrottling) {
       const throttleDuration = Date.now() - this.throttleStartTime;
       const shouldForceResume = throttleDuration > this.FORCE_RESUME_MS;
-      const belowThreshold = utilizationPercent < this.RESUME_THRESHOLD_PERCENT;
+      const belowThreshold = utilizationPercent < resumePercent;
 
       if (shouldForceResume || belowThreshold) {
         this.disengageThrottle(heapUsedMb, utilizationPercent, shouldForceResume);
@@ -204,11 +299,49 @@ export class ResourceGovernor {
     this.throttleStartTime = Date.now();
 
     const ids = this.deps.getTerminalIds();
+    const isCritical = percent >= this.CRITICAL_PERCENT;
+
+    // Build ordered list: idle first, active-agent terminals last.
+    // At critical pressure (95%+), skip triage — pause everything immediately.
+    let orderedIds: string[];
+    if (!isCritical && ids.length > 1) {
+      const activity = new Map(this.deps.getTerminalActivity().map((a) => [a.id, a] as const));
+      orderedIds = [...ids].sort((a, b) => {
+        const aa = activity.get(a);
+        const bb = activity.get(b);
+        const aAgentActive = aa?.agentState === "working" || aa?.agentState === "directing";
+        const bAgentActive = bb?.agentState === "working" || bb?.agentState === "directing";
+        // Active-agent terminals sort last (paused last)
+        if (aAgentActive && !bAgentActive) return 1;
+        if (!aAgentActive && bAgentActive) return -1;
+        // Among peers, most recently active sorts last
+        const aTime = aa?.lastOutputTime ?? 0;
+        const bTime = bb?.lastOutputTime ?? 0;
+        return bTime - aTime;
+      });
+    } else {
+      orderedIds = ids;
+    }
+
+    if (isCritical) {
+      console.warn(
+        `[ResourceGovernor] Critical pressure (${percent.toFixed(1)}%) — pausing all terminals immediately.`
+      );
+    }
+
     let pausedCount = 0;
-    for (const id of ids) {
+    for (const id of orderedIds) {
       const coordinator = this.deps.getPauseCoordinator(id);
       if (coordinator) {
         coordinator.pause("resource-governor");
+        this.pausedTerminalIds.add(id);
+        this.deps.emitTerminalStatus(
+          id,
+          "paused-resource-governor",
+          undefined,
+          undefined,
+          `Memory pressure: ${Math.round(currentUsageMb)}MB (${percent.toFixed(1)}%)`
+        );
         pausedCount++;
       }
     }
@@ -240,7 +373,12 @@ export class ResourceGovernor {
         coordinator.resume("resource-governor");
         resumedCount++;
       }
+      // Emit "running" only if no other pause tokens remain
+      if (!coordinator?.isPaused) {
+        this.deps.emitTerminalStatus(id, "running", undefined, duration);
+      }
     }
+    this.pausedTerminalIds.clear();
     console.log(`[ResourceGovernor] Resumed ${resumedCount}/${ids.length} terminals`);
 
     this.deps.sendEvent({
@@ -260,11 +398,18 @@ export class ResourceGovernor {
     }
     if (this.isThrottling) {
       for (const id of this.deps.getTerminalIds()) {
-        this.deps.getPauseCoordinator(id)?.resume("resource-governor");
+        const coordinator = this.deps.getPauseCoordinator(id);
+        coordinator?.resume("resource-governor");
+        if (!coordinator?.isPaused) {
+          this.deps.emitTerminalStatus(id, "running");
+        }
       }
       this.isThrottling = false;
       this.throttleStartTime = 0;
     }
+    this.pausedTerminalIds.clear();
+    this.isWarning = false;
+    this.profileOverride = null;
     this.killedPids.clear();
     console.log("[ResourceGovernor] Disposed");
   }

--- a/electron/pty-host/ResourceGovernor.ts
+++ b/electron/pty-host/ResourceGovernor.ts
@@ -370,12 +370,17 @@ export class ResourceGovernor {
     for (const id of ids) {
       const coordinator = this.deps.getPauseCoordinator(id);
       if (coordinator) {
-        coordinator.resume("resource-governor");
-        resumedCount++;
+        if (coordinator.hasToken("resource-governor")) {
+          coordinator.resume("resource-governor");
+          resumedCount++;
+        }
       }
-      // Emit "running" only if no other pause tokens remain
       if (!coordinator?.isPaused) {
         this.deps.emitTerminalStatus(id, "running", undefined, duration);
+      } else if (coordinator.hasToken("backpressure")) {
+        // Restore backpressure status — the governor's pause
+        // overwrote it in the dedup map during engage.
+        this.deps.emitTerminalStatus(id, "paused-backpressure", undefined, duration);
       }
     }
     this.pausedTerminalIds.clear();

--- a/electron/pty-host/__tests__/ResourceGovernor.test.ts
+++ b/electron/pty-host/__tests__/ResourceGovernor.test.ts
@@ -45,6 +45,8 @@ function createMockDeps(overrides?: Partial<ResourceGovernorDeps>): ResourceGove
     getTerminalPids: vi.fn().mockReturnValue([]),
     incrementPauseCount: vi.fn(),
     sendEvent: vi.fn(),
+    emitTerminalStatus: vi.fn(),
+    getTerminalActivity: vi.fn().mockReturnValue([]),
     ...overrides,
   };
 }
@@ -162,6 +164,11 @@ describe("ResourceGovernor", () => {
       const deps = createMockDeps({
         getTerminalIds: vi.fn().mockReturnValue(["t1"]),
         getPauseCoordinator: vi.fn().mockReturnValue(coordinator),
+        getTerminalActivity: vi
+          .fn()
+          .mockReturnValue([
+            { id: "t1", lastOutputTime: 100, lastInputTime: 100, agentState: "idle" },
+          ]),
       });
 
       vi.spyOn(process, "memoryUsage").mockReturnValue({
@@ -179,6 +186,13 @@ describe("ResourceGovernor", () => {
       expect(raw.pause).toHaveBeenCalled();
       expect(coordinator.hasToken("resource-governor")).toBe(true);
       expect(deps.incrementPauseCount).toHaveBeenCalledWith(1);
+      expect(deps.emitTerminalStatus).toHaveBeenCalledWith(
+        "t1",
+        "paused-resource-governor",
+        undefined,
+        undefined,
+        expect.stringContaining("Memory pressure")
+      );
       expect(deps.sendEvent).toHaveBeenCalledWith(
         expect.objectContaining({
           type: "host-throttled",
@@ -194,6 +208,9 @@ describe("ResourceGovernor", () => {
       const deps = createMockDeps({
         getTerminalIds: vi.fn().mockReturnValue(["t1"]),
         getPauseCoordinator: vi.fn().mockReturnValue(coordinator),
+        getTerminalActivity: vi
+          .fn()
+          .mockReturnValue([{ id: "t1", lastOutputTime: 100, lastInputTime: 100 }]),
       });
 
       vi.spyOn(process, "memoryUsage").mockReturnValue({
@@ -226,6 +243,14 @@ describe("ResourceGovernor", () => {
       expect(event?.forced).toBe(false);
       expect(event?.reason).toContain("High memory usage");
       expect(event?.duration).toBeGreaterThan(0);
+
+      // Should emit "running" when no other tokens hold
+      expect(deps.emitTerminalStatus).toHaveBeenCalledWith(
+        "t1",
+        "running",
+        undefined,
+        expect.any(Number)
+      );
 
       governor.dispose();
     });
@@ -316,6 +341,9 @@ describe("ResourceGovernor", () => {
       const deps = createMockDeps({
         getTerminalIds: vi.fn().mockReturnValue(["t1"]),
         getPauseCoordinator: vi.fn().mockReturnValue(coordinator),
+        getTerminalActivity: vi
+          .fn()
+          .mockReturnValue([{ id: "t1", lastOutputTime: 100, lastInputTime: 100 }]),
       });
 
       vi.spyOn(process, "memoryUsage").mockReturnValue({
@@ -344,6 +372,7 @@ describe("ResourceGovernor", () => {
       } as ReturnType<typeof process.memoryUsage>);
 
       raw.resume.mockClear();
+      (deps.emitTerminalStatus as ReturnType<typeof vi.fn>).mockClear();
       vi.advanceTimersByTime(2000);
 
       // Governor released its hold, but backpressure still holds — PTY must stay paused
@@ -351,6 +380,12 @@ describe("ResourceGovernor", () => {
       expect(coordinator.hasToken("backpressure")).toBe(true);
       expect(coordinator.isPaused).toBe(true);
       expect(raw.resume).not.toHaveBeenCalled();
+
+      // Should NOT emit "running" because backpressure still holds
+      const terminalStatusCalls = (
+        deps.emitTerminalStatus as ReturnType<typeof vi.fn>
+      ).mock.calls.filter((c: unknown[]) => (c as string[])[1] === "running");
+      expect(terminalStatusCalls).toHaveLength(0);
 
       governor.dispose();
     });
@@ -644,6 +679,254 @@ describe("ResourceGovernor", () => {
       expect((gaugeCalls[1][0] as Record<string, unknown>).payload).toMatchObject({
         pauseCountDelta: 3,
       });
+
+      governor.dispose();
+    });
+  });
+
+  describe("host-memory-warning", () => {
+    it("emits host-memory-warning when crossing warning threshold", () => {
+      const deps = createMockDeps();
+      vi.spyOn(process, "memoryUsage").mockReturnValue({
+        heapUsed: 750 * 1024 * 1024,
+        rss: 1024 * 1024 * 1024,
+        external: 0,
+        arrayBuffers: 0,
+      } as ReturnType<typeof process.memoryUsage>);
+
+      const governor = new ResourceGovernor(deps);
+      governor.start();
+
+      vi.advanceTimersByTime(2000);
+
+      expect(deps.sendEvent).toHaveBeenCalledWith(
+        expect.objectContaining({
+          type: "host-memory-warning",
+          isWarning: true,
+        })
+      );
+
+      governor.dispose();
+    });
+
+    it("clears warning when memory drops below clear threshold", () => {
+      const deps = createMockDeps();
+      vi.spyOn(process, "memoryUsage").mockReturnValue({
+        heapUsed: 750 * 1024 * 1024,
+        rss: 1024 * 1024 * 1024,
+        external: 0,
+        arrayBuffers: 0,
+      } as ReturnType<typeof process.memoryUsage>);
+
+      const governor = new ResourceGovernor(deps);
+      governor.start();
+      vi.advanceTimersByTime(2000);
+
+      // Drop below clear threshold
+      vi.spyOn(process, "memoryUsage").mockReturnValue({
+        heapUsed: 600 * 1024 * 1024,
+        rss: 1024 * 1024 * 1024,
+        external: 0,
+        arrayBuffers: 0,
+      } as ReturnType<typeof process.memoryUsage>);
+      vi.advanceTimersByTime(2000);
+
+      expect(deps.sendEvent).toHaveBeenCalledWith(
+        expect.objectContaining({
+          type: "host-memory-warning",
+          isWarning: false,
+        })
+      );
+
+      governor.dispose();
+    });
+
+    it("does not re-emit warning on consecutive ticks above threshold", () => {
+      const deps = createMockDeps();
+      vi.spyOn(process, "memoryUsage").mockReturnValue({
+        heapUsed: 750 * 1024 * 1024,
+        rss: 1024 * 1024 * 1024,
+        external: 0,
+        arrayBuffers: 0,
+      } as ReturnType<typeof process.memoryUsage>);
+
+      const governor = new ResourceGovernor(deps);
+      governor.start();
+
+      vi.advanceTimersByTime(2000);
+      vi.advanceTimersByTime(2000);
+
+      const warningCalls = (deps.sendEvent as ReturnType<typeof vi.fn>).mock.calls.filter(
+        (c: unknown[]) => (c[0] as Record<string, unknown>)?.type === "host-memory-warning"
+      );
+      expect(warningCalls).toHaveLength(1);
+
+      governor.dispose();
+    });
+  });
+
+  describe("triage ordering", () => {
+    it("pauses idle terminals before active-agent terminals", () => {
+      const c1 = createMockCoordinator();
+      const c2 = createMockCoordinator();
+      const c3 = createMockCoordinator();
+      const coordinators: Record<string, ReturnType<typeof createMockCoordinator>> = {
+        t1: c1,
+        t2: c2,
+        t3: c3,
+      };
+
+      const deps = createMockDeps({
+        getTerminalIds: vi.fn().mockReturnValue(["t1", "t2", "t3"]),
+        getPauseCoordinator: vi.fn((id: string) => coordinators[id]?.coordinator),
+        getTerminalActivity: vi.fn().mockReturnValue([
+          { id: "t1", lastOutputTime: 1000, lastInputTime: 1000, agentState: "idle" },
+          { id: "t2", lastOutputTime: 3000, lastInputTime: 2000, agentState: "working" },
+          { id: "t3", lastOutputTime: 2000, lastInputTime: 1000, agentState: "idle" },
+        ]),
+      });
+
+      vi.spyOn(process, "memoryUsage").mockReturnValue({
+        heapUsed: 900 * 1024 * 1024,
+        rss: 1024 * 1024 * 1024,
+        external: 0,
+        arrayBuffers: 0,
+      } as ReturnType<typeof process.memoryUsage>);
+
+      const governor = new ResourceGovernor(deps);
+      governor.start();
+      vi.advanceTimersByTime(2000);
+
+      const emitCalls = (deps.emitTerminalStatus as ReturnType<typeof vi.fn>).mock.calls;
+      const pausedOrder = emitCalls.map((c: unknown[]) => (c as string[])[0]);
+
+      // t2 (working agent) should be paused last
+      expect(pausedOrder[pausedOrder.length - 1]).toBe("t2");
+
+      governor.dispose();
+    });
+  });
+
+  describe("critical pressure", () => {
+    it("pauses all terminals immediately at 95%+ without triage ordering", () => {
+      const c1 = createMockCoordinator();
+      const c2 = createMockCoordinator();
+      const coordinators: Record<string, ReturnType<typeof createMockCoordinator>> = {
+        t1: c1,
+        t2: c2,
+      };
+
+      const deps = createMockDeps({
+        getTerminalIds: vi.fn().mockReturnValue(["t1", "t2"]),
+        getPauseCoordinator: vi.fn((id: string) => coordinators[id]?.coordinator),
+        getTerminalActivity: vi.fn().mockReturnValue([
+          { id: "t1", lastOutputTime: 1000, lastInputTime: 1000, agentState: "working" },
+          { id: "t2", lastOutputTime: 100, lastInputTime: 100, agentState: "idle" },
+        ]),
+      });
+
+      vi.spyOn(process, "memoryUsage").mockReturnValue({
+        heapUsed: 980 * 1024 * 1024,
+        rss: 1024 * 1024 * 1024,
+        external: 0,
+        arrayBuffers: 0,
+      } as ReturnType<typeof process.memoryUsage>);
+
+      const governor = new ResourceGovernor(deps);
+      governor.start();
+      vi.advanceTimersByTime(2000);
+
+      // At critical, both should be paused — order follows getTerminalIds (no sort)
+      const emitCalls = (deps.emitTerminalStatus as ReturnType<typeof vi.fn>).mock.calls;
+      expect(emitCalls).toHaveLength(2);
+
+      governor.dispose();
+    });
+  });
+
+  describe("setResourceProfile", () => {
+    it("lowers throttle threshold on efficiency profile", () => {
+      const { coordinator } = createMockCoordinator();
+      const deps = createMockDeps({
+        getTerminalIds: vi.fn().mockReturnValue(["t1"]),
+        getPauseCoordinator: vi.fn().mockReturnValue(coordinator),
+        getTerminalActivity: vi
+          .fn()
+          .mockReturnValue([{ id: "t1", lastOutputTime: 100, lastInputTime: 100 }]),
+      });
+
+      const governor = new ResourceGovernor(deps);
+      governor.setResourceProfile("efficiency");
+      governor.start();
+
+      // 75% heap — below default 85% but above efficiency 70%
+      vi.spyOn(process, "memoryUsage").mockReturnValue({
+        heapUsed: 768 * 1024 * 1024,
+        rss: 1024 * 1024 * 1024,
+        external: 0,
+        arrayBuffers: 0,
+      } as ReturnType<typeof process.memoryUsage>);
+
+      vi.advanceTimersByTime(2000);
+
+      expect(coordinator.hasToken("resource-governor")).toBe(true);
+
+      governor.dispose();
+    });
+
+    it("restores default thresholds when switching back to balanced", () => {
+      const { coordinator } = createMockCoordinator();
+      const deps = createMockDeps({
+        getTerminalIds: vi.fn().mockReturnValue(["t1"]),
+        getPauseCoordinator: vi.fn().mockReturnValue(coordinator),
+        getTerminalActivity: vi
+          .fn()
+          .mockReturnValue([{ id: "t1", lastOutputTime: 100, lastInputTime: 100 }]),
+      });
+
+      const governor = new ResourceGovernor(deps);
+      governor.setResourceProfile("efficiency");
+      governor.setResourceProfile("balanced");
+      governor.start();
+
+      // 75% heap — above efficiency 70% but below default 85%
+      vi.spyOn(process, "memoryUsage").mockReturnValue({
+        heapUsed: 768 * 1024 * 1024,
+        rss: 1024 * 1024 * 1024,
+        external: 0,
+        arrayBuffers: 0,
+      } as ReturnType<typeof process.memoryUsage>);
+
+      vi.advanceTimersByTime(2000);
+
+      // Should NOT throttle at 75% on balanced profile
+      expect(coordinator.hasToken("resource-governor")).toBe(false);
+
+      governor.dispose();
+    });
+
+    it("lowers warning threshold on efficiency profile", () => {
+      const deps = createMockDeps();
+      const governor = new ResourceGovernor(deps);
+      governor.setResourceProfile("efficiency");
+      governor.start();
+
+      // 60% heap — below default warning 70% but above efficiency warning 55%
+      vi.spyOn(process, "memoryUsage").mockReturnValue({
+        heapUsed: 614 * 1024 * 1024,
+        rss: 1024 * 1024 * 1024,
+        external: 0,
+        arrayBuffers: 0,
+      } as ReturnType<typeof process.memoryUsage>);
+
+      vi.advanceTimersByTime(2000);
+
+      expect(deps.sendEvent).toHaveBeenCalledWith(
+        expect.objectContaining({
+          type: "host-memory-warning",
+          isWarning: true,
+        })
+      );
 
       governor.dispose();
     });

--- a/electron/pty-host/handlers/resourceConfig.ts
+++ b/electron/pty-host/handlers/resourceConfig.ts
@@ -14,13 +14,15 @@ export function createResourceConfigHandlers(ctx: HostContext): HandlerMap {
     },
 
     "set-resource-profile": (msg) => {
-      const profileConfig = RESOURCE_PROFILE_CONFIGS[msg.profile as ResourceProfile];
+      const profile = msg.profile as ResourceProfile;
+      const profileConfig = RESOURCE_PROFILE_CONFIGS[profile];
       if (profileConfig) {
         processTreeCache.setPollInterval(profileConfig.processTreePollInterval);
         console.log(
           `[PtyHost] Resource profile set to: ${msg.profile} (processTree poll: ${profileConfig.processTreePollInterval}ms)`
         );
       }
+      ctx.resourceGovernor.setResourceProfile(profile);
     },
 
     "set-process-tree-poll-interval": (msg) => {

--- a/electron/services/events.ts
+++ b/electron/services/events.ts
@@ -3,7 +3,10 @@ import type { NotificationPayload, AgentState, TaskState, EventCategory } from "
 import type { EventContext } from "../../shared/types/events.js";
 import type { GitHubPRCIStatus } from "../../shared/types/github.js";
 import type { WorktreeSnapshot as WorktreeState } from "../../shared/types/workspace-host.js";
-import type { TerminalReliabilityMetricPayload } from "../../shared/types/pty-host.js";
+import type {
+  TerminalReliabilityMetricPayload,
+  TerminalFlowStatus,
+} from "../../shared/types/pty-host.js";
 import type { ExitReason } from "./pty/types.js";
 
 export type { EventCategory };
@@ -683,7 +686,7 @@ export type DaintreeEventMap = {
    */
   "terminal:status": {
     id: string;
-    status: "running" | "paused-backpressure" | "paused-user" | "suspended" | "data-loss";
+    status: TerminalFlowStatus;
     bufferUtilization?: number;
     pauseDuration?: number;
     reason?: string;

--- a/electron/services/pty/PtyEventRouter.ts
+++ b/electron/services/pty/PtyEventRouter.ts
@@ -258,6 +258,15 @@ export function routeHostEvent(event: PtyHostEvent, deps: PtyEventRouterDeps): b
       return true;
     }
 
+    case "host-memory-warning": {
+      emitter.emit("host-memory-warning", {
+        isWarning: event.isWarning,
+        utilizationPercent: event.utilizationPercent,
+        timestamp: event.timestamp,
+      });
+      return true;
+    }
+
     case "fd-leak-warning": {
       const flwEvent: FdLeakWarningPayload = {
         fdCount: event.fdCount,

--- a/electron/window/perWindowInit.ts
+++ b/electron/window/perWindowInit.ts
@@ -162,6 +162,25 @@ export function initPerWindowServices(
           utilizationPercent: payload.utilizationPercent,
         });
       }
+      // Broadcast to all windows so renderer can surface the warning
+      if (windowRegistry) {
+        for (const wCtx of windowRegistry.all()) {
+          const w = wCtx.browserWindow;
+          if (!w.isDestroyed()) {
+            try {
+              sendToRenderer(w, CHANNELS.EVENTS_PUSH, {
+                name: "window:memory-warning",
+                payload: {
+                  isWarning: payload.isWarning,
+                  utilizationPercent: payload.utilizationPercent,
+                },
+              });
+            } catch {
+              /* non-critical */
+            }
+          }
+        }
+      }
     });
     ptyClient.on("host-throttled", (payload) => {
       if (!payload.isThrottled) {

--- a/electron/window/perWindowInit.ts
+++ b/electron/window/perWindowInit.ts
@@ -152,6 +152,17 @@ export function initPerWindowServices(
     ptyClient.on("host-crash", (code) => {
       console.error(`[MAIN] Pty Host crashed with code ${code} (max restarts exceeded)`);
     });
+    ptyClient.on("host-memory-warning", (payload) => {
+      if (payload.isWarning) {
+        logInfo("pty-host-memory-warning", {
+          utilizationPercent: payload.utilizationPercent,
+        });
+      } else {
+        logInfo("pty-host-memory-warning-cleared", {
+          utilizationPercent: payload.utilizationPercent,
+        });
+      }
+    });
     ptyClient.on("host-throttled", (payload) => {
       if (!payload.isThrottled) {
         logInfo("pty-host-resumed", { duration: payload.duration });

--- a/shared/types/panel.ts
+++ b/shared/types/panel.ts
@@ -85,6 +85,7 @@ export enum TerminalRefreshTier {
 export type TerminalFlowStatus =
   | "running"
   | "paused-backpressure"
+  | "paused-resource-governor"
   | "paused-user"
   | "suspended"
   | "data-loss";

--- a/shared/types/pty-host.ts
+++ b/shared/types/pty-host.ts
@@ -259,6 +259,12 @@ export type PtyHostEvent =
       timestamp: number;
     }
   | {
+      type: "host-memory-warning";
+      isWarning: boolean;
+      utilizationPercent: number;
+      timestamp: number;
+    }
+  | {
       type: "host-throttled";
       isThrottled: boolean;
       reason?: string;

--- a/src/components/Terminal/TerminalContextMenu.tsx
+++ b/src/components/Terminal/TerminalContextMenu.tsx
@@ -114,7 +114,9 @@ export function TerminalContextMenu({
     [terminalId]
   );
 
-  const isPaused = terminal?.flowStatus === "paused-backpressure";
+  const isPaused =
+    terminal?.flowStatus === "paused-backpressure" ||
+    terminal?.flowStatus === "paused-resource-governor";
 
   const currentLocation: PanelLocation = forceLocation ?? terminal?.location ?? "grid";
 

--- a/src/components/Terminal/TerminalHeaderContent.tsx
+++ b/src/components/Terminal/TerminalHeaderContent.tsx
@@ -373,6 +373,28 @@ export function TerminalHeaderContent({
         </Tooltip>
       )}
 
+      {/* Resource governor pause badge */}
+      {flowStatus === "paused-resource-governor" && (
+        <Tooltip>
+          <TooltipTrigger asChild>
+            <div
+              className="flex items-center gap-1 text-xs font-sans bg-status-warning/15 text-status-warning px-1.5 py-0.5 rounded ml-1"
+              role="status"
+              aria-live="polite"
+            >
+              <Pause className="w-3 h-3" aria-hidden="true" />
+              Paused (memory)
+            </div>
+          </TooltipTrigger>
+          <TooltipContent side="bottom" className="max-w-xs">
+            <div className="flex flex-col gap-0.5">
+              <span className="font-medium">System memory pressure</span>
+              <span>Paused to reduce memory pressure. Recovers automatically.</span>
+            </div>
+          </TooltipContent>
+        </Tooltip>
+      )}
+
       {/* Suspended badge */}
       {flowStatus === "suspended" && (
         <Tooltip>


### PR DESCRIPTION
## Summary
The ResourceGovernor was silently pausing every terminal when heap hit 85%, with no user-visible signal, no pre-warning, and no triage. Terminals just froze with no explanation until GC ran.

This gives users and the system real information about what's happening under memory pressure. Terminals now show a `paused-resource-governor` flow status in the header, there's a warning band at 70% heap before the hard pause, and triage ordering prioritises idle terminals for pause while protecting active agent terminals until last. The efficiency profile from `ResourceProfileService` is wired into the governor so it reacts sooner when the machine is already under pressure.

Resolves #7910.

## Changes
- Added `paused-resource-governor` flow status variant with a header badge in `TerminalHeaderContent`
- Added a 70% heap warning band that fires `host-memory-warning` to the renderer before the 85% hard throttle
- Activity-based triage: idle terminals pause first, active agent terminals last; 95% critical escape hatch skips triage and pauses everything
- Wired `ResourceProfileService` efficiency profile into the governor (70% throttle / 55% warning on efficiency)
- Fixed a `resumedCount` inflation bug for terminals created while the governor was already throttling
- Guards `disengage` from emitting "running" when backpressure tokens are still held

## Testing
- Unit tests for throttle/disengage with triage ordering, warning band thresholds, critical pressure escape hatch, efficiency profile thresholds, mid-throttle terminal creation, and held-token overlap on disengage
- Manual verification of flow status badge in terminal headers under simulated memory pressure