### PR TITLE
fix(errors): stop infinite retry loop and track cross-session error recurrence

### DIFF
--- a/electron/ipc/__tests__/errorHandlers.test.ts
+++ b/electron/ipc/__tests__/errorHandlers.test.ts
@@ -23,7 +23,7 @@ const loggerMock = vi.hoisted(() => ({
 
 const storeMock = vi.hoisted(() => ({
   store: {
-    get: vi.fn((): unknown[] => []),
+    get: vi.fn((_key?: string): unknown[] => []),
     set: vi.fn(),
   },
 }));
@@ -1775,7 +1775,6 @@ describe("errorHandlers", () => {
     });
 
     it("persists fingerprint to store after recording", async () => {
-      const CHANNELS = await getChannels();
       createMockWindow();
       storeMock.store.get.mockImplementation((key: string) => {
         if (key === "errorFingerprints") return {};
@@ -1802,7 +1801,6 @@ describe("errorHandlers", () => {
     });
 
     it("caps fingerprint entries at 200 with LRU eviction", async () => {
-      const CHANNELS = await getChannels();
       createMockWindow();
 
       const entries: Record<string, { count: number; firstSeen: number; lastSeen: number }> = {};

--- a/electron/ipc/__tests__/errorHandlers.test.ts
+++ b/electron/ipc/__tests__/errorHandlers.test.ts
@@ -23,7 +23,7 @@ const loggerMock = vi.hoisted(() => ({
 
 const storeMock = vi.hoisted(() => ({
   store: {
-    get: vi.fn((_key?: string): unknown[] => []),
+    get: vi.fn((_key?: string): unknown => []),
     set: vi.fn(),
   },
 }));

--- a/electron/ipc/__tests__/errorHandlers.test.ts
+++ b/electron/ipc/__tests__/errorHandlers.test.ts
@@ -1712,7 +1712,7 @@ describe("errorHandlers", () => {
     it("sets occurrenceCount to 1 on first occurrence", async () => {
       const CHANNELS = await getChannels();
       const mockWindow = createMockWindow();
-      storeMock.store.get.mockImplementation((key: string) => {
+      storeMock.store.get.mockImplementation((key?: string) => {
         if (key === "errorFingerprints") return {};
         return [];
       });
@@ -1735,7 +1735,7 @@ describe("errorHandlers", () => {
       const mockWindow = createMockWindow();
 
       const existing = { "unknown|test|spawn failed": { count: 3, firstSeen: 1, lastSeen: 1 } };
-      storeMock.store.get.mockImplementation((key: string) => {
+      storeMock.store.get.mockImplementation((key?: string) => {
         if (key === "errorFingerprints") return { ...existing };
         return [];
       });
@@ -1757,7 +1757,7 @@ describe("errorHandlers", () => {
       const mockWindow = createMockWindow();
 
       const existing = { "unknown|test|error A": { count: 5, firstSeen: 1, lastSeen: 1 } };
-      storeMock.store.get.mockImplementation((key: string) => {
+      storeMock.store.get.mockImplementation((key?: string) => {
         if (key === "errorFingerprints") return { ...existing };
         return [];
       });
@@ -1776,7 +1776,7 @@ describe("errorHandlers", () => {
 
     it("persists fingerprint to store after recording", async () => {
       createMockWindow();
-      storeMock.store.get.mockImplementation((key: string) => {
+      storeMock.store.get.mockImplementation((key?: string) => {
         if (key === "errorFingerprints") return {};
         return [];
       });
@@ -1807,7 +1807,7 @@ describe("errorHandlers", () => {
       for (let i = 0; i < 200; i++) {
         entries[`unknown||entry-${i}`] = { count: 1, firstSeen: i, lastSeen: i };
       }
-      storeMock.store.get.mockImplementation((key: string) => {
+      storeMock.store.get.mockImplementation((key?: string) => {
         if (key === "errorFingerprints") return { ...entries };
         return [];
       });

--- a/electron/ipc/__tests__/errorHandlers.test.ts
+++ b/electron/ipc/__tests__/errorHandlers.test.ts
@@ -296,7 +296,7 @@ describe("errorHandlers", () => {
 
     it("exhausts max terminal attempts (3) and rethrows", async () => {
       const CHANNELS = await getChannels();
-      createMockWindow();
+      const mockWindow = createMockWindow();
       const spawn = vi.fn(() => {
         throw createTransientError("EBUSY");
       });
@@ -313,11 +313,21 @@ describe("errorHandlers", () => {
 
       expect(spawn).toHaveBeenCalledTimes(3);
       expect(sleepMock).toHaveBeenCalledTimes(2);
+
+      const notifyCalls = mockWindow.webContents.send.mock.calls.filter(
+        ([channel]: string[]) => channel === CHANNELS.ERROR_NOTIFY
+      );
+      expect(notifyCalls.length).toBe(1);
+      expect(notifyCalls[0][1]).toMatchObject({
+        retryExhausted: true,
+        source: "retry-terminal",
+        message: "EBUSY",
+      });
     });
 
     it("exhausts max worktree attempts (5) and rethrows", async () => {
       const CHANNELS = await getChannels();
-      createMockWindow();
+      const mockWindow = createMockWindow();
       const refresh = vi.fn().mockRejectedValue(createTransientError("ETIMEDOUT"));
 
       registerErrorHandlers({ refresh } as never, null);
@@ -329,6 +339,15 @@ describe("errorHandlers", () => {
 
       expect(refresh).toHaveBeenCalledTimes(5);
       expect(sleepMock).toHaveBeenCalledTimes(4);
+
+      const notifyCalls = mockWindow.webContents.send.mock.calls.filter(
+        ([channel]: string[]) => channel === CHANNELS.ERROR_NOTIFY
+      );
+      expect(notifyCalls.length).toBe(1);
+      expect(notifyCalls[0][1]).toMatchObject({
+        retryExhausted: true,
+        source: "retry-worktree",
+      });
     });
 
     it("aborts immediately on non-transient error without sleeping", async () => {
@@ -1686,6 +1705,130 @@ describe("errorHandlers", () => {
       for (const error of sentErrors) {
         expect(error.fromPreviousSession).toBeUndefined();
       }
+    });
+  });
+
+  describe("error fingerprint tracking", () => {
+    it("sets occurrenceCount to 1 on first occurrence", async () => {
+      const CHANNELS = await getChannels();
+      const mockWindow = createMockWindow();
+      storeMock.store.get.mockImplementation((key: string) => {
+        if (key === "errorFingerprints") return {};
+        return [];
+      });
+
+      const { notifyError } = await import("../errorHandlers.js");
+      const err = new Error("test fingerprint");
+      (err as NodeJS.ErrnoException).code = "EBUSY";
+
+      notifyError(err, { source: "test" });
+
+      const sentError = mockWindow.webContents.send.mock.calls.find(
+        ([channel]: string[]) => channel === CHANNELS.ERROR_NOTIFY
+      )?.[1];
+      expect(sentError.occurrenceCount).toBe(1);
+      expect(sentError.retryExhausted).toBe(false);
+    });
+
+    it("increments occurrenceCount for repeated fingerprints", async () => {
+      const CHANNELS = await getChannels();
+      const mockWindow = createMockWindow();
+
+      const existing = { "unknown|test|spawn failed": { count: 3, firstSeen: 1, lastSeen: 1 } };
+      storeMock.store.get.mockImplementation((key: string) => {
+        if (key === "errorFingerprints") return { ...existing };
+        return [];
+      });
+
+      const { notifyError } = await import("../errorHandlers.js");
+      const err = new Error("spawn failed");
+      (err as NodeJS.ErrnoException).code = "EBUSY";
+
+      notifyError(err, { source: "test" });
+
+      const sentError = mockWindow.webContents.send.mock.calls.find(
+        ([channel]: string[]) => channel === CHANNELS.ERROR_NOTIFY
+      )?.[1];
+      expect(sentError.occurrenceCount).toBe(4);
+    });
+
+    it("treats different type|source|message combinations as separate fingerprints", async () => {
+      const CHANNELS = await getChannels();
+      const mockWindow = createMockWindow();
+
+      const existing = { "unknown|test|error A": { count: 5, firstSeen: 1, lastSeen: 1 } };
+      storeMock.store.get.mockImplementation((key: string) => {
+        if (key === "errorFingerprints") return { ...existing };
+        return [];
+      });
+
+      const { notifyError } = await import("../errorHandlers.js");
+      const err = new Error("error B");
+      (err as NodeJS.ErrnoException).code = "EBUSY";
+
+      notifyError(err, { source: "test" });
+
+      const sentError = mockWindow.webContents.send.mock.calls.find(
+        ([channel]: string[]) => channel === CHANNELS.ERROR_NOTIFY
+      )?.[1];
+      expect(sentError.occurrenceCount).toBe(1);
+    });
+
+    it("persists fingerprint to store after recording", async () => {
+      const CHANNELS = await getChannels();
+      createMockWindow();
+      storeMock.store.get.mockImplementation((key: string) => {
+        if (key === "errorFingerprints") return {};
+        return [];
+      });
+      storeMock.store.set.mockClear();
+
+      const { notifyError } = await import("../errorHandlers.js");
+      const err = new Error("save test");
+      (err as NodeJS.ErrnoException).code = "EBUSY";
+
+      notifyError(err, { source: "test" });
+
+      expect(storeMock.store.set).toHaveBeenCalledWith(
+        "errorFingerprints",
+        expect.objectContaining({
+          "unknown|test|save test": {
+            count: 1,
+            firstSeen: expect.any(Number),
+            lastSeen: expect.any(Number),
+          },
+        })
+      );
+    });
+
+    it("caps fingerprint entries at 200 with LRU eviction", async () => {
+      const CHANNELS = await getChannels();
+      createMockWindow();
+
+      const entries: Record<string, { count: number; firstSeen: number; lastSeen: number }> = {};
+      for (let i = 0; i < 200; i++) {
+        entries[`unknown||entry-${i}`] = { count: 1, firstSeen: i, lastSeen: i };
+      }
+      storeMock.store.get.mockImplementation((key: string) => {
+        if (key === "errorFingerprints") return { ...entries };
+        return [];
+      });
+
+      const { notifyError } = await import("../errorHandlers.js");
+      const err = new Error("new error");
+      (err as NodeJS.ErrnoException).code = "EBUSY";
+
+      notifyError(err, { source: undefined });
+
+      const setCall = (storeMock.store.set as Mock).mock.calls.find(
+        ([key]: string[]) => key === "errorFingerprints"
+      );
+      const fingerprintArg = setCall?.[1] as Record<string, unknown> | undefined;
+      const keys = fingerprintArg ? Object.keys(fingerprintArg) : [];
+      expect(keys.length).toBe(200);
+      expect(keys).toContain("unknown||new error");
+      // The oldest entry (entry-0, lastSeen=0) should be evicted
+      expect(keys).not.toContain("unknown||entry-0");
     });
   });
 });

--- a/electron/ipc/errorHandlers.ts
+++ b/electron/ipc/errorHandlers.ts
@@ -14,9 +14,46 @@ import type { WorkspaceClient } from "../services/WorkspaceClient.js";
 import type {
   ErrorRecord,
   ErrorRetryability,
+  ErrorType,
   RetryAction,
 } from "../../shared/types/ipc/errors.js";
 import type { SpawnResult } from "../../shared/types/pty-host.js";
+
+const MAX_FINGERPRINT_ENTRIES = 200;
+
+function buildFingerprintKey(type: ErrorType, source: string | undefined, message: string): string {
+  return `${type}|${source ?? ""}|${message}`;
+}
+
+function recordErrorFingerprint(
+  type: ErrorType,
+  source: string | undefined,
+  message: string
+): number {
+  const key = buildFingerprintKey(type, source, message);
+  const raw = store.get("errorFingerprints");
+  const fingerprints: Record<string, { count: number; firstSeen: number; lastSeen: number }> =
+    raw && typeof raw === "object" && !Array.isArray(raw)
+      ? (raw as Record<string, { count: number; firstSeen: number; lastSeen: number }>)
+      : {};
+  const now = Date.now();
+  const existing = fingerprints[key];
+  const count = (existing?.count ?? 0) + 1;
+  fingerprints[key] = { count, firstSeen: existing?.firstSeen ?? now, lastSeen: now };
+
+  const entries = Object.entries(fingerprints);
+  if (entries.length > MAX_FINGERPRINT_ENTRIES) {
+    entries.sort((a, b) => a[1].lastSeen - b[1].lastSeen);
+    for (const [k] of entries.slice(0, entries.length - MAX_FINGERPRINT_ENTRIES)) {
+      delete fingerprints[k];
+    }
+    store.set("errorFingerprints", fingerprints);
+  } else {
+    store.set("errorFingerprints", fingerprints);
+  }
+
+  return count;
+}
 
 interface RetryPayload {
   errorId: string;
@@ -94,6 +131,14 @@ function createErrorRecord(
      * exhaustion is loop state, not an intrinsic of the error itself.
      */
     retryability?: ErrorRetryability;
+    /**
+     * Companion flag set when the retry loop exhausted its budget. The
+     * `"exhausted"` retryability above already encodes this for retryability-
+     * aware consumers; this boolean keeps backwards-compatible gating in the
+     * banner / toast / problems-content paths and is what the recurrence
+     * tracking persists to detect runaway retry loops across sessions.
+     */
+    retryExhausted?: boolean;
   } = {}
 ): ErrorRecord {
   const details = getErrorDetails(error);
@@ -117,6 +162,8 @@ function createErrorRecord(
     gitReason: classification.gitReason,
     recoveryAction: classification.recoveryAction,
     isCritical: classification.isCritical,
+    retryExhausted: options.retryExhausted ?? false,
+    occurrenceCount: 0,
   };
 }
 
@@ -206,6 +253,16 @@ class ErrorService {
 
   notifyError(error: unknown, options: Parameters<typeof createErrorRecord>[1] = {}) {
     const appError = createErrorRecord(error, options);
+
+    appError.occurrenceCount = recordErrorFingerprint(
+      appError.type,
+      appError.source,
+      appError.message
+    );
+    if (options.retryExhausted) {
+      appError.retryExhausted = true;
+    }
+
     logErrorUtil(`[${appError.correlationId}] ${appError.message}`, error, {
       correlationId: appError.correlationId,
       type: appError.type,
@@ -492,6 +549,7 @@ export function registerErrorHandlers(
         retryAction: actionForError,
         retryArgs: argsForError,
         retryability: intrinsic === "auto" ? "exhausted" : intrinsic,
+        retryExhausted: true,
       });
       throw error;
     }

--- a/electron/store.ts
+++ b/electron/store.ts
@@ -232,6 +232,7 @@ export interface StoreSchema {
     auditRetention: 7 | 30 | 0;
   };
   pendingErrors: ErrorRecord[];
+  errorFingerprints: Record<string, { count: number; firstSeen: number; lastSeen: number }>;
   gpu: {
     hardwareAccelerationDisabled: boolean;
   };
@@ -383,6 +384,7 @@ const storeOptions = {
       auditRetention: 7 as const,
     },
     pendingErrors: [],
+    errorFingerprints: {},
     gpu: {
       hardwareAccelerationDisabled: false,
     },

--- a/shared/types/ipc/errors.ts
+++ b/shared/types/ipc/errors.ts
@@ -229,4 +229,12 @@ export interface ErrorRecord {
   gitReason?: GitOperationReason;
   /** Structured CTA the renderer can surface alongside the error */
   recoveryAction?: RecoveryAction;
+  /** Whether retry has been exhausted (max attempts reached) */
+  retryExhausted: boolean;
+  /**
+   * How many times this error fingerprint has been seen across all sessions.
+   * Set by the main process from persisted fingerprint counters; 1 = first
+   * occurrence including this one.
+   */
+  occurrenceCount: number;
 }

--- a/shared/types/ipc/errors.ts
+++ b/shared/types/ipc/errors.ts
@@ -230,11 +230,11 @@ export interface ErrorRecord {
   /** Structured CTA the renderer can surface alongside the error */
   recoveryAction?: RecoveryAction;
   /** Whether retry has been exhausted (max attempts reached) */
-  retryExhausted: boolean;
+  retryExhausted?: boolean;
   /**
    * How many times this error fingerprint has been seen across all sessions.
    * Set by the main process from persisted fingerprint counters; 1 = first
    * occurrence including this one.
    */
-  occurrenceCount: number;
+  occurrenceCount?: number;
 }

--- a/src/components/Diagnostics/ProblemsContent.tsx
+++ b/src/components/Diagnostics/ProblemsContent.tsx
@@ -1,6 +1,6 @@
 import { useMemo, useCallback, useState, useRef, useEffect } from "react";
 import { cn } from "@/lib/utils";
-import { useErrorStore, type ErrorRecord, type RetryAction } from "@/store";
+import { useErrorStore, type ErrorRecord, type RetryAction, RECURRENCE_THRESHOLD } from "@/store";
 import { Copy, Check, Lightbulb } from "lucide-react";
 import { Tooltip, TooltipContent, TooltipTrigger } from "@/components/ui/tooltip";
 import { logError } from "@/utils/logger";
@@ -53,7 +53,12 @@ function ErrorRow({
   const typeLabel = ERROR_TYPE_LABELS[error.type] || "Error";
   const typeColor = ERROR_TYPE_COLORS[error.type] || "text-status-error";
   const isRetrying = !!error.retryProgress;
-  const canRetry = error.retryability === "auto" && error.retryAction && onRetry;
+  const canRetry =
+    error.retryability === "auto" &&
+    error.retryAction &&
+    onRetry &&
+    !error.retryExhausted &&
+    (error.occurrenceCount ?? 0) < RECURRENCE_THRESHOLD;
   const [copied, setCopied] = useState(false);
   const copyTimeoutRef = useRef<NodeJS.Timeout | null>(null);
 

--- a/src/components/Errors/ErrorBanner.tsx
+++ b/src/components/Errors/ErrorBanner.tsx
@@ -12,7 +12,7 @@ import {
   type LucideIcon,
 } from "lucide-react";
 import type { ErrorRecord, RetryAction } from "@/store/errorStore";
-import { useErrorStore } from "@/store/errorStore";
+import { RECURRENCE_THRESHOLD, useErrorStore } from "@/store/errorStore";
 import { useDiagnosticsStore } from "@/store/diagnosticsStore";
 import { actionService } from "@/services/ActionService";
 
@@ -31,6 +31,13 @@ function bannerActionFor(error: ErrorRecord, hasOnRetry: boolean): BannerAction 
   // recovery — flip the banner CTA to "View errors" so the user is routed
   // to the dock instead of seeing a stale Retry next to the open dock.
   if (error.promotedToDock) {
+    return "view-errors";
+  }
+  // Hard exit for runaway-retry conditions: the loop already gave up
+  // (retryExhausted) or the same fingerprint has fired ≥ RECURRENCE_THRESHOLD
+  // times across sessions. Either way, surfacing Retry would re-run a known
+  // failure path. Route to the dock instead so the user sees the full history.
+  if (error.retryExhausted || (error.occurrenceCount ?? 0) >= RECURRENCE_THRESHOLD) {
     return "view-errors";
   }
   if (error.retryability === "auto" && error.retryAction && hasOnRetry) {

--- a/src/components/Errors/__tests__/ErrorBanner.test.tsx
+++ b/src/components/Errors/__tests__/ErrorBanner.test.tsx
@@ -318,7 +318,7 @@ describe("ErrorBanner", () => {
       render(
         <ErrorBanner
           error={makeError({
-            isTransient: true,
+            retryability: "auto",
             retryAction: "git",
             retryExhausted: true,
           })}
@@ -335,7 +335,7 @@ describe("ErrorBanner", () => {
       render(
         <ErrorBanner
           error={makeError({
-            isTransient: true,
+            retryability: "auto",
             retryAction: "git",
             retryExhausted: true,
           })}
@@ -351,7 +351,7 @@ describe("ErrorBanner", () => {
       render(
         <ErrorBanner
           error={makeError({
-            isTransient: true,
+            retryability: "auto",
             retryAction: "git",
             occurrenceCount: 5,
           })}
@@ -368,7 +368,7 @@ describe("ErrorBanner", () => {
       render(
         <ErrorBanner
           error={makeError({
-            isTransient: true,
+            retryability: "auto",
             retryAction: "git",
             occurrenceCount: 4,
           })}
@@ -381,11 +381,11 @@ describe("ErrorBanner", () => {
       expect(screen.getByRole("button", { name: "Retry" })).toBeTruthy();
     });
 
-    it("remains non-retryable (0 occurrenceCount) when isTransient is false", () => {
+    it("remains non-retryable (0 occurrenceCount) when retryability is 'none'", () => {
       render(
         <ErrorBanner
           error={makeError({
-            isTransient: false,
+            retryability: "none",
             occurrenceCount: 0,
             retryAction: undefined,
           })}

--- a/src/components/Errors/__tests__/ErrorBanner.test.tsx
+++ b/src/components/Errors/__tests__/ErrorBanner.test.tsx
@@ -309,6 +309,95 @@ describe("ErrorBanner", () => {
     });
   });
 
+  describe("retryExhausted and occurrenceCount gating", () => {
+    afterEach(() => {
+      useDiagnosticsStore.getState().reset();
+    });
+
+    it("shows 'View errors' not 'Retry' when retryExhausted is true (compact)", () => {
+      render(
+        <ErrorBanner
+          error={makeError({
+            isTransient: true,
+            retryAction: "git",
+            retryExhausted: true,
+          })}
+          onDismiss={onDismiss}
+          onRetry={vi.fn()}
+          compact
+        />
+      );
+      expect(screen.getByRole("button", { name: "View errors" })).toBeTruthy();
+      expect(screen.queryByRole("button", { name: "Retry" })).toBeNull();
+    });
+
+    it("shows 'View errors' not 'Retry' when retryExhausted is true (full)", () => {
+      render(
+        <ErrorBanner
+          error={makeError({
+            isTransient: true,
+            retryAction: "git",
+            retryExhausted: true,
+          })}
+          onDismiss={onDismiss}
+          onRetry={vi.fn()}
+        />
+      );
+      expect(screen.getByRole("button", { name: "View errors" })).toBeTruthy();
+      expect(screen.queryByRole("button", { name: "Retry" })).toBeNull();
+    });
+
+    it("shows 'View errors' not 'Retry' when occurrenceCount reaches threshold 5 (compact)", () => {
+      render(
+        <ErrorBanner
+          error={makeError({
+            isTransient: true,
+            retryAction: "git",
+            occurrenceCount: 5,
+          })}
+          onDismiss={onDismiss}
+          onRetry={vi.fn()}
+          compact
+        />
+      );
+      expect(screen.getByRole("button", { name: "View errors" })).toBeTruthy();
+      expect(screen.queryByRole("button", { name: "Retry" })).toBeNull();
+    });
+
+    it("still shows 'Retry' when occurrenceCount is below threshold 5", () => {
+      render(
+        <ErrorBanner
+          error={makeError({
+            isTransient: true,
+            retryAction: "git",
+            occurrenceCount: 4,
+          })}
+          onDismiss={onDismiss}
+          onRetry={vi.fn()}
+          compact
+        />
+      );
+      expect(screen.queryByRole("button", { name: "View errors" })).toBeNull();
+      expect(screen.getByRole("button", { name: "Retry" })).toBeTruthy();
+    });
+
+    it("remains non-retryable (0 occurrenceCount) when isTransient is false", () => {
+      render(
+        <ErrorBanner
+          error={makeError({
+            isTransient: false,
+            occurrenceCount: 0,
+            retryAction: undefined,
+          })}
+          onDismiss={onDismiss}
+          compact
+        />
+      );
+      expect(screen.getByRole("button", { name: "View errors" })).toBeTruthy();
+      expect(screen.queryByRole("button", { name: "Retry" })).toBeNull();
+    });
+  });
+
   describe("correlation ID copy", () => {
     let writeText: ReturnType<typeof vi.fn>;
     const fullId = "abcd1234-5678-90ef-1234-567890abcdef";

--- a/src/hooks/useErrors.ts
+++ b/src/hooks/useErrors.ts
@@ -1,5 +1,5 @@
 import { useEffect, useCallback, useRef } from "react";
-import { useErrorStore, type ErrorRecord, type RetryAction } from "@/store";
+import { useErrorStore, RECURRENCE_THRESHOLD, type ErrorRecord, type RetryAction } from "@/store";
 import { isElectronAvailable } from "./useElectron";
 import { errorsClient } from "@/clients";
 import { logErrorWithContext } from "@/utils/errorContext";
@@ -68,6 +68,8 @@ function routeError(error: ErrorRecord): void {
     recoveryHint: error.recoveryHint,
     recoveryAction: error.recoveryAction,
     gitReason: error.gitReason,
+    retryExhausted: error.retryExhausted,
+    occurrenceCount: error.occurrenceCount,
   });
 
   const { title, body } = humanizeAppError(error);
@@ -82,7 +84,14 @@ function routeError(error: ErrorRecord): void {
   // retryability means the retry loop already exhausted (or the failure was
   // never auto-retryable) — surfacing a Retry button would re-run the same
   // failed loop. "user-gated" surfaces its own recovery CTA elsewhere.
-  if (error.retryAction && error.retryability === "auto") {
+  // Also gate on the cross-session recurrence counter so a fingerprint that
+  // has fired ≥ RECURRENCE_THRESHOLD times is escalated past Retry.
+  if (
+    error.retryAction &&
+    error.retryability === "auto" &&
+    !error.retryExhausted &&
+    (error.occurrenceCount ?? 0) < RECURRENCE_THRESHOLD
+  ) {
     retryNotificationAction = {
       label: "Retry",
       successLabel: "Retried",

--- a/src/store/errorStore.ts
+++ b/src/store/errorStore.ts
@@ -123,10 +123,10 @@ const createErrorStore: StateCreator<ErrorStore> = (set, get) => ({
                 recoveryHint: e.recoveryHint ?? error.recoveryHint,
                 correlationId: e.correlationId ?? error.correlationId,
                 promotedToDock: e.promotedToDock,
-                // Always overwrite recurrence tracking from the incoming
-                // record — the main process owns these counters (persisted
-                // fingerprint store) and a stale dedup-cached value would
-                // mask escalation across the RECURRENCE_THRESHOLD gate.
+                // Recurrence tracking is owned by the main process (persisted
+                // fingerprint store) — prefer the incoming value so a stale
+                // dedup-cached counter never masks escalation across the
+                // RECURRENCE_THRESHOLD gate.
                 retryExhausted: error.retryExhausted ?? e.retryExhausted,
                 occurrenceCount: error.occurrenceCount ?? e.occurrenceCount,
               }

--- a/src/store/errorStore.ts
+++ b/src/store/errorStore.ts
@@ -37,6 +37,14 @@ export interface ErrorRecord {
   recoveryAction?: RecoveryAction;
   /** Set when the error has been promoted to the diagnostics dock (auto-open or user click) */
   promotedToDock?: boolean;
+  /** Whether retry has been exhausted (max attempts reached) */
+  retryExhausted?: boolean;
+  /**
+   * How many times this error fingerprint has been seen across all sessions.
+   * Set by the main process from persisted fingerprint counters; 1 = first
+   * occurrence including this one.
+   */
+  occurrenceCount?: number;
 }
 
 interface ErrorStore {
@@ -115,6 +123,12 @@ const createErrorStore: StateCreator<ErrorStore> = (set, get) => ({
                 recoveryHint: e.recoveryHint ?? error.recoveryHint,
                 correlationId: e.correlationId ?? error.correlationId,
                 promotedToDock: e.promotedToDock,
+                // Always overwrite recurrence tracking from the incoming
+                // record — the main process owns these counters (persisted
+                // fingerprint store) and a stale dedup-cached value would
+                // mask escalation across the RECURRENCE_THRESHOLD gate.
+                retryExhausted: error.retryExhausted ?? e.retryExhausted,
+                occurrenceCount: error.occurrenceCount ?? e.occurrenceCount,
               }
             : e
         ),
@@ -208,5 +222,7 @@ const createErrorStore: StateCreator<ErrorStore> = (set, get) => ({
       lastErrorTime: 0,
     }),
 });
+
+export const RECURRENCE_THRESHOLD = 5;
 
 export const useErrorStore = create<ErrorStore>()(createErrorStore);

--- a/src/store/index.ts
+++ b/src/store/index.ts
@@ -10,7 +10,7 @@ export type { WorktreeViewStoreApi } from "./createWorktreeStore";
 export { useLogsStore, filterLogs, collapseConsecutiveDuplicates } from "./logsStore";
 export type { DisplayEntry } from "./logsStore";
 
-export { useErrorStore } from "./errorStore";
+export { useErrorStore, RECURRENCE_THRESHOLD } from "./errorStore";
 export type { ErrorRecord, ErrorType, RetryAction } from "./errorStore";
 
 export { useEventStore } from "./eventStore";


### PR DESCRIPTION
## Summary

The error banner was treating every failure as a first occurrence. Two gaps: retry exhaustion wasn't tracked, letting users trigger infinite retry loops, and cross-session recurrence went undetected so the same error appearing dozens of times looked identical to the first.

This adds an error fingerprint store in electron-store that tracks occurrence counts across sessions, gates `canRetry` on both `retryExhausted` and a `RECURRENCE_THRESHOLD` of 5, and preserves those fields through the dedup path.

Resolves #7908.

## Changes

- Added `retryExhausted` and `occurrenceCount` optional fields to `ErrorRecord` in shared types
- Added `errorFingerprints` store to electron-store (LRU-capped at 200)
- `ErrorService.notifyError()` now fingerprints errors and sets `occurrenceCount` from the store
- `handleRetry` exhaustion catch path sets `retryExhausted: true`
- `ErrorBanner.canRetry`, `ProblemsContent.canRetry`, and toast retry gated on `!retryExhausted && occurrenceCount < RECURRENCE_THRESHOLD`
- Extracted `RECURRENCE_THRESHOLD` as a shared constant from `errorStore.ts`
- `retryExhausted` and `occurrenceCount` preserved in the dedup path
- 10 tests: 5 for fingerprint tracking, 5 for `canRetry` gating, 2 updated exhausted tests

## Testing

Fingerprint store correctly tracks and increments occurrence counts. `canRetry` returns `false` when `retryExhausted` is set or `occurrenceCount` reaches the threshold. Dedup preserves both fields. Typecheck, format, and lint all pass.