### PR TITLE
fix(worktree): use blue chip and slate circle for finished card state

### DIFF
--- a/src/components/Worktree/WorktreeCard.tsx
+++ b/src/components/Worktree/WorktreeCard.tsx
@@ -666,7 +666,7 @@ export function WorktreeCard({
                     "absolute w-3 h-3 z-10 cursor-default",
                     chipState === "waiting" && "bg-activity-waiting",
                     chipState === "cleanup" && "bg-github-merged",
-                    chipState === "complete" && "bg-github-open",
+                    chipState === "complete" && "bg-category-blue",
                     variant === "sidebar" ? "top-0 left-[1px]" : "top-0 left-0 rounded-tl-lg"
                   )}
                   style={{ clipPath: "polygon(0 0, 100% 0, 0 100%)" }}

--- a/src/components/Worktree/__tests__/terminalStateConfig.test.ts
+++ b/src/components/Worktree/__tests__/terminalStateConfig.test.ts
@@ -35,6 +35,10 @@ describe("getEffectiveStateColor", () => {
   it("returns default color for non-waiting states", () => {
     expect(getEffectiveStateColor("working")).toBe(STATE_COLORS.working);
   });
+
+  it("uses slate (not info) for completed state", () => {
+    expect(STATE_COLORS.completed).toBe("text-category-slate");
+  });
 });
 
 describe("getEffectiveStateLabel", () => {

--- a/src/components/Worktree/terminalStateConfig.tsx
+++ b/src/components/Worktree/terminalStateConfig.tsx
@@ -16,7 +16,7 @@ export const STATE_COLORS = {
   waiting: "text-state-waiting",
   directing: "text-category-blue",
   idle: "text-daintree-text/40",
-  completed: "text-status-info",
+  completed: "text-category-slate",
   exited: "text-daintree-text/40",
 } as const satisfies Record<AgentState, string>;
 


### PR DESCRIPTION
## Summary

- The finished worktree card state was using green for both its corner chip and status indicator circle, which conflicts with the app's green working state — a finished card read as still active
- Swaps the chip background from `bg-github-open` to `bg-category-blue` and the indicator circle from `text-status-info` to `text-category-slate`

Resolves #7925

## Changes

- `WorktreeCard.tsx` — chip color swap for `chipState === "complete"`
- `terminalStateConfig.tsx` — `STATE_COLORS.completed` token swap
- `terminalStateConfig.test.ts` — assertion updated to match new token

## Testing

Unit tests pass (55 across 3 files). Visual: finished worktree cards now show a blue chip and slate circle, distinct from the green working state.