### PR TITLE
fix(panel): make title edit input feel inline

### DIFF
--- a/src/components/Panel/PanelHeader.tsx
+++ b/src/components/Panel/PanelHeader.tsx
@@ -664,7 +664,7 @@ function PanelHeaderComponent({
               onChange={(e) => onEditingValueChange(e.target.value)}
               onKeyDown={onTitleInputKeyDown}
               onBlur={onTitleSave}
-              className="text-sm font-medium bg-daintree-bg/60 border border-border-strong px-1 h-5 min-w-32 text-daintree-text select-text focus-visible:outline focus-visible:outline-2 focus-visible:outline-daintree-accent focus-visible:outline-offset-1"
+              className="text-xs font-medium bg-overlay-soft border border-transparent px-1 h-5 min-w-32 text-daintree-text select-text transition-colors focus:outline-hidden"
               aria-label={getAriaLabel()}
             />
           ) : (

--- a/src/components/Panel/TabButton.tsx
+++ b/src/components/Panel/TabButton.tsx
@@ -322,10 +322,10 @@ const TabButtonComponent = forwardRef<HTMLDivElement, TabButtonProps>(function T
               animate={{ opacity: 1 }}
               transition={{ duration: 0.1 }}
               className={cn(
-                "text-xs bg-daintree-bg/80 border px-1 h-4 min-w-[60px] max-w-[100px] text-daintree-text select-text transition-colors focus-visible:outline focus-visible:outline-1 focus-visible:outline-daintree-accent",
+                "text-xs bg-overlay-soft border px-1 h-4 min-w-[60px] max-w-[100px] text-daintree-text select-text transition-colors focus:outline-hidden",
                 showRenameError
                   ? "border-status-error duration-150"
-                  : "border-border-strong duration-250",
+                  : "border-transparent duration-250",
                 showRenameErrorTint && "bg-status-error/5"
               )}
               aria-label={`Rename tab ${title}`}

--- a/src/components/Panel/__tests__/PanelHeader.test.tsx
+++ b/src/components/Panel/__tests__/PanelHeader.test.tsx
@@ -773,10 +773,10 @@ describe("PanelHeader", () => {
       expect(cls).not.toContain("bg-daintree-bg/60");
     });
 
-    it("does not use the accent color for the focus outline", () => {
+    it("does not use the accent color for any focus indicator", () => {
       render(<PanelHeader {...makeProps({ isEditingTitle: true, editingValue: "Test" })} />);
       const cls = getRenameInput().className;
-      expect(cls).not.toContain("outline-daintree-accent");
+      expect(cls).not.toMatch(/(outline|ring|border)-daintree-accent/);
       expect(cls).toContain("focus:outline-hidden");
     });
   });

--- a/src/components/Panel/__tests__/PanelHeader.test.tsx
+++ b/src/components/Panel/__tests__/PanelHeader.test.tsx
@@ -754,4 +754,30 @@ describe("PanelHeader", () => {
       expect(tooltipContent).toBeDefined();
     });
   });
+
+  describe("title edit input styling (#7926)", () => {
+    const getRenameInput = () => screen.getByLabelText("Edit terminal title") as HTMLInputElement;
+
+    it("matches the static label font size (text-xs)", () => {
+      render(<PanelHeader {...makeProps({ isEditingTitle: true, editingValue: "Test" })} />);
+      expect(getRenameInput().className).toContain("text-xs");
+      expect(getRenameInput().className).not.toContain("text-sm");
+    });
+
+    it("uses a transparent border and subtle background lift instead of a heavy chrome", () => {
+      render(<PanelHeader {...makeProps({ isEditingTitle: true, editingValue: "Test" })} />);
+      const cls = getRenameInput().className;
+      expect(cls).toContain("border-transparent");
+      expect(cls).toContain("bg-overlay-soft");
+      expect(cls).not.toContain("border-border-strong");
+      expect(cls).not.toContain("bg-daintree-bg/60");
+    });
+
+    it("does not use the accent color for the focus outline", () => {
+      render(<PanelHeader {...makeProps({ isEditingTitle: true, editingValue: "Test" })} />);
+      const cls = getRenameInput().className;
+      expect(cls).not.toContain("outline-daintree-accent");
+      expect(cls).toContain("focus:outline-hidden");
+    });
+  });
 });

--- a/src/components/Panel/__tests__/TabButton.test.tsx
+++ b/src/components/Panel/__tests__/TabButton.test.tsx
@@ -539,11 +539,11 @@ describe("TabButton", () => {
       expect(input.className).not.toContain("bg-daintree-bg/80");
     });
 
-    it("does not use the accent color for the focus outline", () => {
+    it("does not use the accent color for any focus indicator", () => {
       render(<TabButton {...defaultProps} onRename={vi.fn()} />);
       fireEvent.doubleClick(screen.getByText("Test Agent"));
       const input = screen.getByTestId("motion-input") as HTMLInputElement;
-      expect(input.className).not.toContain("outline-daintree-accent");
+      expect(input.className).not.toMatch(/(outline|ring|border)-daintree-accent/);
       expect(input.className).toContain("focus:outline-hidden");
     });
 
@@ -554,6 +554,7 @@ describe("TabButton", () => {
       fireEvent.change(input, { target: { value: "" } });
       fireEvent.keyDown(input, { key: "Enter" });
       expect(input.className).toContain("border-status-error");
+      expect(input.className).not.toContain("border-transparent");
     });
   });
 

--- a/src/components/Panel/__tests__/TabButton.test.tsx
+++ b/src/components/Panel/__tests__/TabButton.test.tsx
@@ -528,6 +528,35 @@ describe("TabButton", () => {
     });
   });
 
+  describe("rename input feels inline (#7926)", () => {
+    it("uses a transparent border and subtle background lift instead of chrome", () => {
+      render(<TabButton {...defaultProps} onRename={vi.fn()} />);
+      fireEvent.doubleClick(screen.getByText("Test Agent"));
+      const input = screen.getByTestId("motion-input") as HTMLInputElement;
+      expect(input.className).toContain("border-transparent");
+      expect(input.className).toContain("bg-overlay-soft");
+      expect(input.className).not.toContain("border-border-strong");
+      expect(input.className).not.toContain("bg-daintree-bg/80");
+    });
+
+    it("does not use the accent color for the focus outline", () => {
+      render(<TabButton {...defaultProps} onRename={vi.fn()} />);
+      fireEvent.doubleClick(screen.getByText("Test Agent"));
+      const input = screen.getByTestId("motion-input") as HTMLInputElement;
+      expect(input.className).not.toContain("outline-daintree-accent");
+      expect(input.className).toContain("focus:outline-hidden");
+    });
+
+    it("preserves the status-error border in the validation-failure state", () => {
+      render(<TabButton {...defaultProps} onRename={vi.fn()} />);
+      fireEvent.doubleClick(screen.getByText("Test Agent"));
+      const input = screen.getByTestId("motion-input") as HTMLInputElement;
+      fireEvent.change(input, { target: { value: "" } });
+      fireEvent.keyDown(input, { key: "Enter" });
+      expect(input.className).toContain("border-status-error");
+    });
+  });
+
   // The state indicator must rise and fall with the agent chrome, plus stay
   // visible during the identity-boot window where state can arrive before the
   // chrome commits (#6650). Once chrome is live, the indicator never silently


### PR DESCRIPTION
## Summary

- The inline title edit input in `PanelHeader` and `TabButton` had a larger font size than the static label, so the title visually grew the moment editing started
- The input also had a prominent accent-colored focus outline, which conflicts with the CLAUDE.md rule that the accent is a scarce resource and shouldn't be a default focus indicator
- Switches the input to `text-xs` (matching the static label), drops the accent outline, and uses `bg-overlay-soft` as a subtle lift instead; the full-text selection on entry is already a clear-enough editing signal

Resolves #7926

## Changes

- `src/components/Panel/PanelHeader.tsx` — `text-sm` → `text-xs`, `border-border-strong bg-daintree-bg/60` → `border-transparent bg-overlay-soft`, replaced `focus-visible` accent outline with `focus:outline-hidden`
- `src/components/Panel/TabButton.tsx` — same treatment; `border-status-error` preserved in the validation-failure branch
- `src/components/Panel/__tests__/PanelHeader.test.tsx` — new describe block with 3 assertions covering font size, background/border, and absence of accent in any focus/ring/border class
- `src/components/Panel/__tests__/TabButton.test.tsx` — matching describe block; also asserts `border-transparent` is absent when the error state wins

## Testing

90 unit tests pass. `npm run check` clean (typecheck, lint, format, channels, ipc, help, lint:ratchet). Build passes.