### PR TITLE
feat(voice): add microphone input device selector

### DIFF
--- a/electron/ipc/handlers/voiceInput.ts
+++ b/electron/ipc/handlers/voiceInput.ts
@@ -35,6 +35,7 @@ const VOICE_INPUT_DEFAULTS: VoiceInputSettings = {
   correctionCustomInstructions: "",
   paragraphingStrategy: "spoken-command",
   resolveFileLinks: true,
+  deviceId: "",
 };
 
 /** Read voiceInput settings with defaults for fields added after initial store creation. */

--- a/electron/preload.cts
+++ b/electron/preload.cts
@@ -2328,6 +2328,7 @@ const api: ElectronAPI = {
         correctionCustomInstructions: string;
         paragraphingStrategy: "spoken-command" | "manual";
         resolveFileLinks: boolean;
+        deviceId: string;
       }>
     ) => _unwrappingInvoke(CHANNELS.VOICE_INPUT_SET_SETTINGS, patch),
     start: () => _unwrappingInvoke(CHANNELS.VOICE_INPUT_START),

--- a/electron/services/__tests__/VoiceTranscriptionService.integration.test.ts
+++ b/electron/services/__tests__/VoiceTranscriptionService.integration.test.ts
@@ -34,6 +34,7 @@ describe("VoiceTranscriptionService integration", () => {
         correctionCustomInstructions: "",
         paragraphingStrategy: "spoken-command",
         resolveFileLinks: true,
+        deviceId: "",
       });
 
       expect(result).toEqual({ ok: true });

--- a/electron/services/__tests__/VoiceTranscriptionService.test.ts
+++ b/electron/services/__tests__/VoiceTranscriptionService.test.ts
@@ -126,6 +126,7 @@ const BASE_SETTINGS: VoiceInputSettings = {
   correctionCustomInstructions: "",
   paragraphingStrategy: "spoken-command",
   resolveFileLinks: true,
+  deviceId: "",
 };
 
 function latestInstance(): MockWebSocket {

--- a/electron/store.ts
+++ b/electron/store.ts
@@ -189,6 +189,7 @@ export interface StoreSchema {
     correctionCustomInstructions: string;
     paragraphingStrategy: string;
     resolveFileLinks: boolean;
+    deviceId: string;
   };
   mcpServer: {
     enabled: boolean;
@@ -364,6 +365,7 @@ const storeOptions = {
       correctionCustomInstructions: "",
       paragraphingStrategy: "spoken-command",
       resolveFileLinks: true,
+      deviceId: "",
     },
     mcpServer: {
       enabled: false,

--- a/shared/types/ipc/api.ts
+++ b/shared/types/ipc/api.ts
@@ -1525,6 +1525,8 @@ export interface VoiceInputSettings {
   paragraphingStrategy: VoiceParagraphingStrategy;
   /** When enabled, voice commands like "link to X" resolve to @file references. Defaults to true. */
   resolveFileLinks: boolean;
+  /** Microphone device ID to use for recording. Empty string means system default. */
+  deviceId: string;
 }
 
 export type HelpAssistantAuditRetention = 7 | 30 | 0;

--- a/src/components/Settings/VoiceInputSettingsTab.tsx
+++ b/src/components/Settings/VoiceInputSettingsTab.tsx
@@ -15,6 +15,7 @@ import {
   ChevronDown,
   ChevronUp,
   FileSearch,
+  RotateCcw,
 } from "lucide-react";
 import { Spinner } from "@/components/ui/Spinner";
 import { cn } from "@/lib/utils";
@@ -26,6 +27,7 @@ import { SettingsTextarea } from "./SettingsTextarea";
 import { useSettingsTabValidation } from "./SettingsValidationRegistry";
 import { dispatchVoiceInputSettingsChanged } from "@/lib/voiceInputSettingsEvents";
 import { logWarn } from "@/utils/logger";
+import { useAudioDevices } from "@/hooks/useAudioDevices";
 import { formatErrorMessage } from "@shared/utils/errorMessage";
 import { CORE_CORRECTION_PROMPT } from "@shared/config/voiceCorrection";
 import type {
@@ -76,6 +78,7 @@ const DEFAULT_SETTINGS: VoiceInputSettings = {
   correctionCustomInstructions: "",
   paragraphingStrategy: "spoken-command",
   resolveFileLinks: true,
+  deviceId: "",
 };
 
 type LoadState = "loading" | "ready" | "error";
@@ -88,6 +91,8 @@ export function VoiceInputSettingsTab() {
   const [isRequestingMic, setIsRequestingMic] = useState(false);
   const [newDictionaryWord, setNewDictionaryWord] = useState("");
   const dictionaryInputRef = useRef<HTMLInputElement>(null);
+
+  const { devices, loading: devicesLoading, refresh: refreshDevices } = useAudioDevices();
 
   useEffect(() => {
     let settled = false;
@@ -216,6 +221,29 @@ export function VoiceInputSettingsTab() {
               onOpenSettings={handleOpenMicSettings}
               onRefresh={handleRefreshMicPermission}
             />
+
+            <div className="flex items-center justify-between">
+              <SettingsSelect
+                label="Microphone"
+                description={
+                  devicesLoading
+                    ? "Detecting devices..."
+                    : "Select which microphone to use for dictation"
+                }
+                value={settings.deviceId}
+                onValueChange={(v) => update({ deviceId: v })}
+                options={devices}
+                disabled={devicesLoading && devices.length <= 1}
+              />
+              <button
+                type="button"
+                onClick={refreshDevices}
+                className="mt-0.5 p-1.5 rounded-sm text-daintree-text/40 hover:text-daintree-text/70 transition-colors"
+                aria-label="Refresh microphone list"
+              >
+                <RotateCcw className="w-3.5 h-3.5" />
+              </button>
+            </div>
 
             <ApiKeyRow
               label="OpenAI API Key"

--- a/src/components/Settings/VoiceInputSettingsTab.tsx
+++ b/src/components/Settings/VoiceInputSettingsTab.tsx
@@ -27,7 +27,7 @@ import { SettingsTextarea } from "./SettingsTextarea";
 import { useSettingsTabValidation } from "./SettingsValidationRegistry";
 import { dispatchVoiceInputSettingsChanged } from "@/lib/voiceInputSettingsEvents";
 import { logWarn } from "@/utils/logger";
-import { useAudioDevices } from "@/hooks/useAudioDevices";
+import { useAudioDevices, SYSTEM_DEFAULT_VALUE } from "@/hooks/useAudioDevices";
 import { formatErrorMessage } from "@shared/utils/errorMessage";
 import { CORE_CORRECTION_PROMPT } from "@shared/config/voiceCorrection";
 import type {
@@ -92,7 +92,12 @@ export function VoiceInputSettingsTab() {
   const [newDictionaryWord, setNewDictionaryWord] = useState("");
   const dictionaryInputRef = useRef<HTMLInputElement>(null);
 
-  const { devices, loading: devicesLoading, refresh: refreshDevices } = useAudioDevices();
+  const {
+    devices,
+    loading: devicesLoading,
+    error: devicesError,
+    refresh: refreshDevices,
+  } = useAudioDevices();
 
   useEffect(() => {
     let settled = false;
@@ -226,12 +231,15 @@ export function VoiceInputSettingsTab() {
               <SettingsSelect
                 label="Microphone"
                 description={
-                  devicesLoading
-                    ? "Detecting devices..."
-                    : "Select which microphone to use for dictation"
+                  devicesError
+                    ? devicesError
+                    : devicesLoading
+                      ? "Detecting devices..."
+                      : "Select which microphone to use for dictation"
                 }
-                value={settings.deviceId}
-                onValueChange={(v) => update({ deviceId: v })}
+                error={devicesError ?? undefined}
+                value={settings.deviceId || SYSTEM_DEFAULT_VALUE}
+                onValueChange={(v) => update({ deviceId: v === SYSTEM_DEFAULT_VALUE ? "" : v })}
                 options={devices}
                 disabled={devicesLoading && devices.length <= 1}
               />

--- a/src/hooks/__tests__/useAudioDevices.test.ts
+++ b/src/hooks/__tests__/useAudioDevices.test.ts
@@ -1,7 +1,7 @@
 // @vitest-environment jsdom
 import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
 import { act, renderHook, waitFor } from "@testing-library/react";
-import { useAudioDevices, __resetForTesting } from "@/hooks/useAudioDevices";
+import { useAudioDevices, __resetForTesting, SYSTEM_DEFAULT_VALUE } from "@/hooks/useAudioDevices";
 
 describe("useAudioDevices", () => {
   let enumerateSpy: ReturnType<typeof vi.fn>;
@@ -36,7 +36,7 @@ describe("useAudioDevices", () => {
     await waitFor(() => expect(result.current.loading).toBe(false));
 
     expect(result.current.devices).toEqual([
-      { value: "", label: "System default" },
+      { value: SYSTEM_DEFAULT_VALUE, label: "System default" },
       { value: "mic1", label: "Built-in Mic" },
     ]);
     expect(result.current.error).toBeNull();
@@ -54,7 +54,10 @@ describe("useAudioDevices", () => {
     await waitFor(() => expect(result.current.loading).toBe(false));
 
     expect(result.current.devices).toHaveLength(2);
-    expect(result.current.devices[0]).toEqual({ value: "", label: "System default" });
+    expect(result.current.devices[0]).toEqual({
+      value: SYSTEM_DEFAULT_VALUE,
+      label: "System default",
+    });
     expect(result.current.devices[1]).toEqual({ value: "default", label: "Default" });
   });
 
@@ -69,7 +72,7 @@ describe("useAudioDevices", () => {
     await waitFor(() => expect(result.current.loading).toBe(false));
 
     expect(result.current.devices).toEqual([
-      { value: "", label: "System default" },
+      { value: SYSTEM_DEFAULT_VALUE, label: "System default" },
       { value: "a", label: "Microphone 1" },
       { value: "b", label: "Microphone 2" },
     ]);
@@ -82,7 +85,9 @@ describe("useAudioDevices", () => {
 
     await waitFor(() => expect(result.current.loading).toBe(false));
 
-    expect(result.current.devices).toEqual([{ value: "", label: "System default" }]);
+    expect(result.current.devices).toEqual([
+      { value: SYSTEM_DEFAULT_VALUE, label: "System default" },
+    ]);
     expect(result.current.error).toContain("Could not enumerate audio devices");
   });
 
@@ -92,7 +97,9 @@ describe("useAudioDevices", () => {
     const { result } = renderHook(() => useAudioDevices());
 
     expect(result.current.loading).toBe(false);
-    expect(result.current.devices).toEqual([{ value: "", label: "System default" }]);
+    expect(result.current.devices).toEqual([
+      { value: SYSTEM_DEFAULT_VALUE, label: "System default" },
+    ]);
     expect(result.current.error).toContain("Media devices API not available");
   });
 

--- a/src/hooks/__tests__/useAudioDevices.test.ts
+++ b/src/hooks/__tests__/useAudioDevices.test.ts
@@ -1,0 +1,149 @@
+// @vitest-environment jsdom
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+import { act, renderHook, waitFor } from "@testing-library/react";
+import { useAudioDevices, __resetForTesting } from "@/hooks/useAudioDevices";
+
+describe("useAudioDevices", () => {
+  let enumerateSpy: ReturnType<typeof vi.fn>;
+  let addEventListenerSpy: ReturnType<typeof vi.fn>;
+
+  beforeEach(() => {
+    __resetForTesting();
+    enumerateSpy = vi.fn().mockResolvedValue([]);
+    addEventListenerSpy = vi.fn();
+
+    vi.stubGlobal("navigator", {
+      mediaDevices: {
+        enumerateDevices: enumerateSpy,
+        addEventListener: addEventListenerSpy,
+        removeEventListener: vi.fn(),
+      },
+    });
+  });
+
+  afterEach(() => {
+    vi.unstubAllGlobals();
+  });
+
+  it("returns system default as first option", async () => {
+    enumerateSpy.mockResolvedValue([
+      { deviceId: "mic1", kind: "audioinput", label: "Built-in Mic" },
+      { deviceId: "cam1", kind: "videoinput", label: "Camera" },
+    ]);
+
+    const { result } = renderHook(() => useAudioDevices());
+
+    await waitFor(() => expect(result.current.loading).toBe(false));
+
+    expect(result.current.devices).toEqual([
+      { value: "", label: "System default" },
+      { value: "mic1", label: "Built-in Mic" },
+    ]);
+    expect(result.current.error).toBeNull();
+  });
+
+  it("filters out non-audioinput devices", async () => {
+    enumerateSpy.mockResolvedValue([
+      { deviceId: "default", kind: "audioinput", label: "Default" },
+      { deviceId: "webcam", kind: "videoinput", label: "Webcam" },
+      { deviceId: "speaker", kind: "audiooutput", label: "Speakers" },
+    ]);
+
+    const { result } = renderHook(() => useAudioDevices());
+
+    await waitFor(() => expect(result.current.loading).toBe(false));
+
+    expect(result.current.devices).toHaveLength(2);
+    expect(result.current.devices[0]).toEqual({ value: "", label: "System default" });
+    expect(result.current.devices[1]).toEqual({ value: "default", label: "Default" });
+  });
+
+  it("assigns fallback labels to unlabeled devices", async () => {
+    enumerateSpy.mockResolvedValue([
+      { deviceId: "a", kind: "audioinput", label: "" },
+      { deviceId: "b", kind: "audioinput", label: "" },
+    ]);
+
+    const { result } = renderHook(() => useAudioDevices());
+
+    await waitFor(() => expect(result.current.loading).toBe(false));
+
+    expect(result.current.devices).toEqual([
+      { value: "", label: "System default" },
+      { value: "a", label: "Microphone 1" },
+      { value: "b", label: "Microphone 2" },
+    ]);
+  });
+
+  it("handles enumerateDevices rejection gracefully", async () => {
+    enumerateSpy.mockRejectedValue(new Error("Not allowed"));
+
+    const { result } = renderHook(() => useAudioDevices());
+
+    await waitFor(() => expect(result.current.loading).toBe(false));
+
+    expect(result.current.devices).toEqual([{ value: "", label: "System default" }]);
+    expect(result.current.error).toContain("Could not enumerate audio devices");
+  });
+
+  it("handles missing mediaDevices API", async () => {
+    vi.stubGlobal("navigator", {});
+
+    const { result } = renderHook(() => useAudioDevices());
+
+    expect(result.current.loading).toBe(false);
+    expect(result.current.devices).toEqual([{ value: "", label: "System default" }]);
+    expect(result.current.error).toContain("Media devices API not available");
+  });
+
+  it("subscribes to devicechange event on mount", async () => {
+    enumerateSpy.mockResolvedValue([]);
+
+    renderHook(() => useAudioDevices());
+
+    expect(addEventListenerSpy).toHaveBeenCalledWith("devicechange", expect.any(Function));
+    await waitFor(() => expect(enumerateSpy).toHaveBeenCalled());
+  });
+
+  it("re-enumerates when devicechange fires", async () => {
+    enumerateSpy.mockResolvedValue([{ deviceId: "mic1", kind: "audioinput", label: "Mic 1" }]);
+
+    renderHook(() => useAudioDevices());
+    await waitFor(() => expect(enumerateSpy).toHaveBeenCalledTimes(1));
+
+    const deviceChangeHandler = addEventListenerSpy.mock.calls[0][1] as () => void;
+
+    enumerateSpy.mockClear();
+    enumerateSpy.mockResolvedValue([
+      { deviceId: "mic1", kind: "audioinput", label: "Mic 1" },
+      { deviceId: "mic2", kind: "audioinput", label: "USB Mic" },
+    ]);
+
+    act(() => {
+      deviceChangeHandler();
+    });
+
+    await waitFor(() => expect(enumerateSpy).toHaveBeenCalledTimes(1));
+  });
+
+  it("re-enumerates on manual refresh() call", async () => {
+    enumerateSpy.mockResolvedValue([{ deviceId: "mic1", kind: "audioinput", label: "Mic 1" }]);
+
+    const { result } = renderHook(() => useAudioDevices());
+    await waitFor(() => expect(result.current.loading).toBe(false));
+
+    enumerateSpy.mockClear();
+    enumerateSpy.mockResolvedValue([
+      { deviceId: "mic1", kind: "audioinput", label: "Mic 1" },
+      { deviceId: "mic2", kind: "audioinput", label: "USB Mic" },
+    ]);
+
+    act(() => {
+      result.current.refresh();
+    });
+
+    await waitFor(() => expect(result.current.loading).toBe(false));
+    expect(enumerateSpy).toHaveBeenCalledTimes(1);
+    expect(result.current.devices).toHaveLength(3);
+  });
+});

--- a/src/hooks/__tests__/useAudioDevices.test.ts
+++ b/src/hooks/__tests__/useAudioDevices.test.ts
@@ -118,7 +118,7 @@ describe("useAudioDevices", () => {
     renderHook(() => useAudioDevices());
     await waitFor(() => expect(enumerateSpy).toHaveBeenCalledTimes(1));
 
-    const deviceChangeHandler = addEventListenerSpy.mock.calls[0][1] as () => void;
+    const deviceChangeHandler = addEventListenerSpy.mock.calls[0]?.[1] as () => void;
 
     enumerateSpy.mockClear();
     enumerateSpy.mockResolvedValue([

--- a/src/hooks/useAudioDevices.ts
+++ b/src/hooks/useAudioDevices.ts
@@ -6,6 +6,9 @@ export interface AudioDevice {
   label: string;
 }
 
+/** Sentinel value for the "System default" option in Radix Select (which rejects empty strings). */
+export const SYSTEM_DEFAULT_VALUE = "__system_default__";
+
 interface Snapshot {
   devices: AudioDevice[];
   loading: boolean;
@@ -16,17 +19,18 @@ let cachedDevices: AudioDevice[] | null = null;
 let cachedError: string | null = null;
 let cachedLoading = true;
 let listeners: Array<() => void> = [];
+let listenerCount = 0;
 let subscribedToDeviceChange = false;
+let enumerationGen = 0;
 let stableSnapshot: Snapshot = {
-  devices: [{ value: "", label: "System default" }],
+  devices: [{ value: SYSTEM_DEFAULT_VALUE, label: "System default" }],
   loading: true,
   error: null,
 };
 
 function notifyListeners() {
-  // Always update the stable snapshot before firing listeners
   stableSnapshot = {
-    devices: cachedDevices ?? [{ value: "", label: "System default" }],
+    devices: cachedDevices ?? [{ value: SYSTEM_DEFAULT_VALUE, label: "System default" }],
     loading: cachedLoading,
     error: cachedError,
   };
@@ -36,8 +40,10 @@ function notifyListeners() {
 }
 
 async function refreshDevices(): Promise<void> {
+  const gen = ++enumerationGen;
+
   if (!navigator?.mediaDevices?.enumerateDevices) {
-    cachedDevices = [{ value: "", label: "System default" }];
+    cachedDevices = [{ value: SYSTEM_DEFAULT_VALUE, label: "System default" }];
     cachedError = "Media devices API not available";
     cachedLoading = false;
     notifyListeners();
@@ -46,9 +52,10 @@ async function refreshDevices(): Promise<void> {
 
   try {
     const devices = await navigator.mediaDevices.enumerateDevices();
+    if (gen !== enumerationGen) return;
     const audioInputs = devices.filter((d) => d.kind === "audioinput");
     cachedDevices = [
-      { value: "", label: "System default" },
+      { value: SYSTEM_DEFAULT_VALUE, label: "System default" },
       ...audioInputs.map((d, i) => ({
         value: d.deviceId,
         label: d.label || `Microphone ${i + 1}`,
@@ -56,11 +63,13 @@ async function refreshDevices(): Promise<void> {
     ];
     cachedError = null;
   } catch (err) {
-    cachedDevices = [{ value: "", label: "System default" }];
+    if (gen !== enumerationGen) return;
+    cachedDevices = [{ value: SYSTEM_DEFAULT_VALUE, label: "System default" }];
     cachedError = `Could not enumerate audio devices: ${err instanceof Error ? err.message : String(err)}`;
     logWarn("useAudioDevices enumerateDevices failed", { err });
   }
 
+  if (gen !== enumerationGen) return;
   cachedLoading = false;
   notifyListeners();
 }
@@ -71,6 +80,7 @@ function getSnapshot(): Snapshot {
 
 function subscribe(callback: () => void): () => void {
   listeners = [...listeners, callback];
+  listenerCount++;
 
   if (!subscribedToDeviceChange && navigator?.mediaDevices?.addEventListener) {
     subscribedToDeviceChange = true;
@@ -79,14 +89,23 @@ function subscribe(callback: () => void): () => void {
       notifyListeners();
       void refreshDevices();
     });
+  }
 
-    void refreshDevices();
-  } else if (cachedDevices === null) {
+  if (cachedDevices === null) {
     void refreshDevices();
   }
 
   return () => {
     listeners = listeners.filter((l) => l !== callback);
+    listenerCount--;
+    if (
+      listenerCount === 0 &&
+      subscribedToDeviceChange &&
+      navigator?.mediaDevices?.removeEventListener
+    ) {
+      subscribedToDeviceChange = false;
+      // devicechange listener is long-lived; keep it as it's harmless and idempotent
+    }
   };
 }
 
@@ -108,9 +127,11 @@ export function __resetForTesting(): void {
   cachedError = null;
   cachedLoading = true;
   listeners = [];
+  listenerCount = 0;
   subscribedToDeviceChange = false;
+  enumerationGen = 0;
   stableSnapshot = {
-    devices: [{ value: "", label: "System default" }],
+    devices: [{ value: SYSTEM_DEFAULT_VALUE, label: "System default" }],
     loading: true,
     error: null,
   };

--- a/src/hooks/useAudioDevices.ts
+++ b/src/hooks/useAudioDevices.ts
@@ -1,4 +1,5 @@
 import { useCallback, useSyncExternalStore } from "react";
+import { formatErrorMessage } from "@shared/utils/errorMessage";
 import { logWarn } from "@/utils/logger";
 
 export interface AudioDevice {
@@ -65,8 +66,7 @@ async function refreshDevices(): Promise<void> {
   } catch (err) {
     if (gen !== enumerationGen) return;
     cachedDevices = [{ value: SYSTEM_DEFAULT_VALUE, label: "System default" }];
-    const message = err instanceof Error ? err.message : String(err);
-    cachedError = `Could not enumerate audio devices: ${message}`;
+    cachedError = `Could not enumerate audio devices: ${formatErrorMessage(err, "enumerate audio devices")}`;
     logWarn("useAudioDevices enumerateDevices failed", { err });
   }
 
@@ -108,8 +108,8 @@ function subscribe(callback: () => void): () => void {
 export function useAudioDevices(): Snapshot & { refresh: () => void } {
   const snapshot = useSyncExternalStore(subscribe, getSnapshot, getSnapshot);
 
-  // eslint-disable-next-line react-compiler/react-compiler -- module-level state writes are the point of this useSyncExternalStore hook
   const refresh = useCallback(() => {
+    // eslint-disable-next-line react-compiler/react-compiler -- module-level state writes are the point of this useSyncExternalStore hook
     cachedLoading = true;
     notifyListeners();
     void refreshDevices();

--- a/src/hooks/useAudioDevices.ts
+++ b/src/hooks/useAudioDevices.ts
@@ -1,0 +1,117 @@
+import { useCallback, useSyncExternalStore } from "react";
+import { logWarn } from "@/utils/logger";
+
+export interface AudioDevice {
+  value: string;
+  label: string;
+}
+
+interface Snapshot {
+  devices: AudioDevice[];
+  loading: boolean;
+  error: string | null;
+}
+
+let cachedDevices: AudioDevice[] | null = null;
+let cachedError: string | null = null;
+let cachedLoading = true;
+let listeners: Array<() => void> = [];
+let subscribedToDeviceChange = false;
+let stableSnapshot: Snapshot = {
+  devices: [{ value: "", label: "System default" }],
+  loading: true,
+  error: null,
+};
+
+function notifyListeners() {
+  // Always update the stable snapshot before firing listeners
+  stableSnapshot = {
+    devices: cachedDevices ?? [{ value: "", label: "System default" }],
+    loading: cachedLoading,
+    error: cachedError,
+  };
+  for (const listener of listeners) {
+    listener();
+  }
+}
+
+async function refreshDevices(): Promise<void> {
+  if (!navigator?.mediaDevices?.enumerateDevices) {
+    cachedDevices = [{ value: "", label: "System default" }];
+    cachedError = "Media devices API not available";
+    cachedLoading = false;
+    notifyListeners();
+    return;
+  }
+
+  try {
+    const devices = await navigator.mediaDevices.enumerateDevices();
+    const audioInputs = devices.filter((d) => d.kind === "audioinput");
+    cachedDevices = [
+      { value: "", label: "System default" },
+      ...audioInputs.map((d, i) => ({
+        value: d.deviceId,
+        label: d.label || `Microphone ${i + 1}`,
+      })),
+    ];
+    cachedError = null;
+  } catch (err) {
+    cachedDevices = [{ value: "", label: "System default" }];
+    cachedError = `Could not enumerate audio devices: ${err instanceof Error ? err.message : String(err)}`;
+    logWarn("useAudioDevices enumerateDevices failed", { err });
+  }
+
+  cachedLoading = false;
+  notifyListeners();
+}
+
+function getSnapshot(): Snapshot {
+  return stableSnapshot;
+}
+
+function subscribe(callback: () => void): () => void {
+  listeners = [...listeners, callback];
+
+  if (!subscribedToDeviceChange && navigator?.mediaDevices?.addEventListener) {
+    subscribedToDeviceChange = true;
+    navigator.mediaDevices.addEventListener("devicechange", () => {
+      cachedLoading = true;
+      notifyListeners();
+      void refreshDevices();
+    });
+
+    void refreshDevices();
+  } else if (cachedDevices === null) {
+    void refreshDevices();
+  }
+
+  return () => {
+    listeners = listeners.filter((l) => l !== callback);
+  };
+}
+
+export function useAudioDevices(): Snapshot & { refresh: () => void } {
+  const snapshot = useSyncExternalStore(subscribe, getSnapshot, getSnapshot);
+
+  const refresh = useCallback(() => {
+    cachedLoading = true;
+    notifyListeners();
+    void refreshDevices();
+  }, []);
+
+  return { ...snapshot, refresh };
+}
+
+/** Reset all module-level state. Only for test isolation. */
+export function __resetForTesting(): void {
+  cachedDevices = null;
+  cachedError = null;
+  cachedLoading = true;
+  listeners = [];
+  subscribedToDeviceChange = false;
+  stableSnapshot = {
+    devices: [{ value: "", label: "System default" }],
+    loading: true,
+    error: null,
+  };
+}

--- a/src/hooks/useAudioDevices.ts
+++ b/src/hooks/useAudioDevices.ts
@@ -65,7 +65,8 @@ async function refreshDevices(): Promise<void> {
   } catch (err) {
     if (gen !== enumerationGen) return;
     cachedDevices = [{ value: SYSTEM_DEFAULT_VALUE, label: "System default" }];
-    cachedError = `Could not enumerate audio devices: ${err instanceof Error ? err.message : String(err)}`;
+    const message = err instanceof Error ? err.message : String(err);
+    cachedError = `Could not enumerate audio devices: ${message}`;
     logWarn("useAudioDevices enumerateDevices failed", { err });
   }
 
@@ -98,13 +99,8 @@ function subscribe(callback: () => void): () => void {
   return () => {
     listeners = listeners.filter((l) => l !== callback);
     listenerCount--;
-    if (
-      listenerCount === 0 &&
-      subscribedToDeviceChange &&
-      navigator?.mediaDevices?.removeEventListener
-    ) {
+    if (listenerCount === 0 && subscribedToDeviceChange) {
       subscribedToDeviceChange = false;
-      // devicechange listener is long-lived; keep it as it's harmless and idempotent
     }
   };
 }
@@ -112,6 +108,7 @@ function subscribe(callback: () => void): () => void {
 export function useAudioDevices(): Snapshot & { refresh: () => void } {
   const snapshot = useSyncExternalStore(subscribe, getSnapshot, getSnapshot);
 
+  // eslint-disable-next-line react-compiler/react-compiler -- module-level state writes are the point of this useSyncExternalStore hook
   const refresh = useCallback(() => {
     cachedLoading = true;
     notifyListeners();

--- a/src/services/VoiceRecordingService.ts
+++ b/src/services/VoiceRecordingService.ts
@@ -42,6 +42,7 @@ class VoiceRecordingService {
   private stream: MediaStream | null = null;
   private elapsedTimer: ReturnType<typeof setInterval> | null = null;
   private sessionStartedAt = 0;
+  private selectedDeviceId = "";
   private unsubscribers: Array<() => void> = [];
   private isStoppingSession = false;
   private stopPromise: Promise<void> | null = null;
@@ -283,6 +284,7 @@ class VoiceRecordingService {
   async refreshConfiguration(): Promise<boolean> {
     const settings = await window.electron.voiceInput.getSettings();
     const isConfigured = settings.enabled && !!settings.openaiApiKey;
+    this.selectedDeviceId = settings.deviceId ?? "";
     logDebug(`${LOG_PREFIX} refreshConfiguration`, {
       enabled: settings.enabled,
       hasApiKey: !!settings.openaiApiKey,
@@ -378,7 +380,10 @@ class VoiceRecordingService {
     logDebug(`${LOG_PREFIX} Requesting microphone access`);
     let stream: MediaStream;
     try {
-      stream = await navigator.mediaDevices.getUserMedia({ audio: true, video: false });
+      const constraints: MediaStreamConstraints = this.selectedDeviceId
+        ? { audio: { deviceId: { ideal: this.selectedDeviceId } }, video: false }
+        : { audio: true, video: false };
+      stream = await navigator.mediaDevices.getUserMedia(constraints);
     } catch (error) {
       const message =
         error instanceof DOMException && error.name === "NotAllowedError"
@@ -419,6 +424,15 @@ class VoiceRecordingService {
           };
         }),
       });
+      if (this.selectedDeviceId) {
+        const actualId = stream.getAudioTracks()[0]?.getSettings?.().deviceId;
+        if (actualId && actualId !== this.selectedDeviceId) {
+          logWarn(`${LOG_PREFIX} Microphone device mismatch`, {
+            requested: this.selectedDeviceId,
+            actual: actualId,
+          });
+        }
+      }
     } catch (err) {
       logDebug(`${LOG_PREFIX} Could not read microphone track settings`, { err });
     }

--- a/src/services/__tests__/VoiceRecordingService.test.ts
+++ b/src/services/__tests__/VoiceRecordingService.test.ts
@@ -363,3 +363,105 @@ describe("isActiveVoiceSession helper", () => {
     expect(isActiveVoiceSession("error")).toBe(false);
   });
 });
+
+describe("VoiceRecordingService — microphone device selection", () => {
+  beforeEach(() => {
+    vi.resetModules();
+    suspendCallbacks.length = 0;
+  });
+
+  afterEach(() => {
+    vi.unstubAllGlobals();
+    vi.restoreAllMocks();
+  });
+
+  it("passes audio: true when selectedDeviceId is empty", async () => {
+    setupGlobals();
+
+    const { voiceRecordingService } = await import("../VoiceRecordingService");
+    voiceRecordingService.initialize();
+
+    // Default electron stub returns getSettings without deviceId,
+    // so selectedDeviceId stays "".
+    const getUserMediaSpy = vi.mocked(navigator.mediaDevices.getUserMedia);
+
+    await voiceRecordingService.start({ panelId: "panel-1", panelTitle: "Test" });
+
+    expect(getUserMediaSpy).toHaveBeenCalledWith({ audio: true, video: false });
+  });
+
+  it("passes ideal deviceId constraint when selectedDeviceId is set", async () => {
+    const electron = buildElectronStub();
+    electron.voiceInput.getSettings.mockResolvedValue({
+      enabled: true,
+      openaiApiKey: "sk-key",
+      correctionEnabled: false,
+      deviceId: "preferred-mic-id",
+    });
+
+    setupGlobals(electron);
+
+    const { voiceRecordingService } = await import("../VoiceRecordingService");
+    voiceRecordingService.initialize();
+
+    // refreshConfiguration runs async; wait it out.
+    await vi.waitFor(() => {
+      expect(electron.voiceInput.getSettings).toHaveBeenCalled();
+    });
+
+    const getUserMediaSpy = vi.mocked(navigator.mediaDevices.getUserMedia);
+
+    await voiceRecordingService.start({ panelId: "panel-1", panelTitle: "Test" });
+
+    expect(getUserMediaSpy).toHaveBeenCalledWith({
+      audio: { deviceId: { ideal: "preferred-mic-id" } },
+      video: false,
+    });
+  });
+
+  it("logs mismatch when actual deviceId differs from requested", async () => {
+    const electron = buildElectronStub();
+    electron.voiceInput.getSettings.mockResolvedValue({
+      enabled: true,
+      openaiApiKey: "sk-key",
+      correctionEnabled: false,
+      deviceId: "preferred-mic-id",
+    });
+
+    setupGlobals(electron);
+
+    // Override getUserMedia to return a track with a different deviceId
+    const getUserMediaMock = vi.mocked(navigator.mediaDevices.getUserMedia);
+    getUserMediaMock.mockResolvedValue({
+      getTracks: () => [{ stop: vi.fn() }],
+      getAudioTracks: () => [
+        {
+          label: "Other Mic",
+          enabled: true,
+          muted: false,
+          readyState: "live",
+          getSettings: () => ({ deviceId: "different-mic-id" }),
+        },
+      ],
+    } as unknown as MediaStream);
+
+    const { logWarn } = await import("@/utils/logger");
+
+    const { voiceRecordingService } = await import("../VoiceRecordingService");
+    voiceRecordingService.initialize();
+
+    await vi.waitFor(() => {
+      expect(electron.voiceInput.getSettings).toHaveBeenCalled();
+    });
+
+    await voiceRecordingService.start({ panelId: "panel-1", panelTitle: "Test" });
+
+    expect(logWarn).toHaveBeenCalledWith(
+      expect.stringContaining("Microphone device mismatch"),
+      expect.objectContaining({
+        requested: "preferred-mic-id",
+        actual: "different-mic-id",
+      })
+    );
+  });
+});


### PR DESCRIPTION
## Summary
Voice dictation used to always target the OS default input device, which meant you could not pick a different microphone from inside Daintree. This was fine for most setups, but on a machine where the default was a USB audio interface, the captured stream was silent and the transcription pipeline returned empty results with no error surfaced.

This PR adds a microphone selector to the Voice Input settings tab. You can now pick any available input device or keep the system default.

Resolves #7902.

## Changes
- New `useAudioDevices` hook that enumerates input devices via `navigator.mediaDevices.enumerateDevices()` and exposes them as a `useSyncExternalStore`-based subscription
- Microphone dropdown in `VoiceInputSettingsTab` with a refresh button and loading/error states
- `VoiceRecordingService` passes the selected `deviceId` as an `ideal` constraint to `getUserMedia`, and logs a warning when the actual device does not match
- Sentinel value (`__system_default__`) for the "System default" option since Radix Select rejects empty strings
- `deviceId` field added to `VoiceInputSettings` type, persist layer, and IPC bridge
- Tests for `useAudioDevices`, `VoiceRecordingService`, and `VoiceTranscriptionService` fixture

## Testing
- Unit tests for the `useAudioDevices` hook cover enumeration, empty/failure states, and listener subscription
- Unit tests for `VoiceRecordingService` cover device selection forwarding to `getUserMedia`
- Integration test fixture updated for `VoiceTranscriptionService`
- `npm run check` passes (typecheck, lint, format)