### PR TITLE
fix(wsl): use * marker to identify default distro (#7944)

### DIFF
--- a/electron/services/CliAvailabilityService.ts
+++ b/electron/services/CliAvailabilityService.ts
@@ -430,8 +430,10 @@ export class CliAvailabilityService {
    *    been executed once via `npx <pkg>`, populating `~/.npm/_npx` without
    *    installing a launchable bin shim (issue #5641).
    * 4. WSL probe on Windows — only fires when `AgentConfig.supportsWsl` is
-   *    true. Probes `wsl.exe --list --quiet` then `wsl.exe -d <distro> -e
-   *    <cmd> --version` against the first listed distribution.
+   *    true. Resolves the default distro via `wsl.exe --list --verbose` (the
+   *    `*`-marked line) then probes `wsl.exe -d <distro> -e <cmd> --version`
+   *    against it. Identifying the default by marker rather than list order
+   *    matters on multi-distro hosts (issue #7944).
    *
    * A `blocked` result from the shell probe short-circuits the fallbacks:
    * the same endpoint security policy that blocked the PATH binary will

--- a/electron/services/CliAvailabilityService.ts
+++ b/electron/services/CliAvailabilityService.ts
@@ -18,7 +18,7 @@ import { refreshPath, expandWindowsEnvVars } from "../setup/environment.js";
 import { store } from "../store.js";
 import { CHANNELS } from "../ipc/channels.js";
 import { broadcastToRenderer } from "../ipc/utils.js";
-import { listFirstWslDistro } from "../utils/wsl.js";
+import { getDefaultWslDistro } from "../utils/wsl.js";
 
 interface ProbeSuccess {
   status: "found";
@@ -737,7 +737,7 @@ export class CliAvailabilityService {
   }
 
   private async probeWsl(command: string): Promise<ProbeResult> {
-    const distro = await listFirstWslDistro();
+    const distro = await getDefaultWslDistro();
     if (!distro) return { status: "missing" };
 
     return new Promise((resolve) => {

--- a/electron/services/__tests__/CliAvailabilityService.test.ts
+++ b/electron/services/__tests__/CliAvailabilityService.test.ts
@@ -1745,13 +1745,18 @@ describe("CliAvailabilityService", () => {
           (a): a is (err: unknown, stdout?: unknown) => void => typeof a === "function"
         );
 
-        // wsl.exe --list --quiet: return a UTF-16LE-encoded distro list
+        // wsl.exe --list --verbose: return a UTF-16LE-encoded distro list
         // with a BOM, simulating older Windows builds that don't honor
-        // WSL_UTF8=1.
+        // WSL_UTF8=1. The `*` marker on Ubuntu identifies it as the default;
+        // Debian is registered first but is not the default (issue #7944).
         if (argv?.[0] === "--list") {
+          const text =
+            "  NAME            STATE           VERSION\r\n" +
+            "  Debian          Stopped         2\r\n" +
+            "* Ubuntu          Running         2\r\n";
           const utf16 = Buffer.concat([
             Buffer.from([0xff, 0xfe]), // BOM
-            Buffer.from("Ubuntu\r\nDebian\r\n", "utf16le"),
+            Buffer.from(text, "utf16le"),
           ]);
           queueMicrotask(() => callback?.(null, utf16));
           return {} as never;

--- a/electron/utils/__tests__/wsl.test.ts
+++ b/electron/utils/__tests__/wsl.test.ts
@@ -1,4 +1,4 @@
-import { describe, it, expect } from "vitest";
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
 import { detectWslPath } from "../wsl.js";
 
 describe("detectWslPath", () => {
@@ -61,5 +61,152 @@ describe("detectWslPath", () => {
       distro: "Ubuntu",
       posixPath: "/home/user/my repo/src",
     });
+  });
+});
+
+type ExecFileCallback = (
+  err: Error | null,
+  stdout: Buffer | string,
+  stderr?: Buffer | string
+) => void;
+const execFileMock = vi.fn();
+vi.mock("child_process", () => ({
+  execFile: (...args: unknown[]) => execFileMock(...args),
+}));
+
+/** Build a UTF-16LE buffer with BOM, mirroring real `wsl.exe` output. */
+function utf16le(text: string): Buffer {
+  const body = Buffer.from(text, "utf16le");
+  const bom = Buffer.from([0xff, 0xfe]);
+  return Buffer.concat([bom, body]);
+}
+
+/** Build a UTF-8 buffer, mirroring `WSL_UTF8=1` output. */
+function utf8(text: string): Buffer {
+  return Buffer.from(text, "utf8");
+}
+
+const originalPlatform = process.platform;
+
+describe("getDefaultWslDistro", () => {
+  beforeEach(() => {
+    vi.resetModules();
+    execFileMock.mockReset();
+  });
+
+  afterEach(() => {
+    Object.defineProperty(process, "platform", { value: originalPlatform, writable: true });
+  });
+
+  it("returns null on non-Windows platforms without spawning wsl.exe", async () => {
+    Object.defineProperty(process, "platform", { value: "darwin", writable: true });
+    const { getDefaultWslDistro } = await import("../wsl.js");
+    const result = await getDefaultWslDistro();
+    expect(result).toBeNull();
+    expect(execFileMock).not.toHaveBeenCalled();
+  });
+
+  it("returns the distro marked with * (UTF-16LE) when default is NOT first", async () => {
+    Object.defineProperty(process, "platform", { value: "win32", writable: true });
+    // Real `wsl --list --verbose` output: header + entries, with `*` on the
+    // default. Here Ubuntu-22.04 is registered first but Debian is the default.
+    const stdout =
+      "  NAME            STATE           VERSION\r\n" +
+      "  Ubuntu-22.04    Stopped         2\r\n" +
+      "* Debian          Running         2\r\n" +
+      "  Alpine          Stopped         2\r\n";
+    execFileMock.mockImplementation((_file, _args, _opts, cb: ExecFileCallback) =>
+      cb(null, utf16le(stdout))
+    );
+
+    const { getDefaultWslDistro } = await import("../wsl.js");
+    expect(await getDefaultWslDistro()).toBe("Debian");
+  });
+
+  it("returns the distro marked with * (UTF-8) on single-distro hosts", async () => {
+    Object.defineProperty(process, "platform", { value: "win32", writable: true });
+    const stdout = "  NAME      STATE           VERSION\r\n" + "* Ubuntu    Running         2\r\n";
+    execFileMock.mockImplementation((_file, _args, _opts, cb: ExecFileCallback) =>
+      cb(null, utf8(stdout))
+    );
+
+    const { getDefaultWslDistro } = await import("../wsl.js");
+    expect(await getDefaultWslDistro()).toBe("Ubuntu");
+  });
+
+  it("handles distro names containing spaces (e.g. 'Ubuntu 22.04 LTS')", async () => {
+    Object.defineProperty(process, "platform", { value: "win32", writable: true });
+    const stdout =
+      "  NAME                STATE           VERSION\r\n" +
+      "* Ubuntu 22.04 LTS    Running         2\r\n";
+    execFileMock.mockImplementation((_file, _args, _opts, cb: ExecFileCallback) =>
+      cb(null, utf8(stdout))
+    );
+
+    const { getDefaultWslDistro } = await import("../wsl.js");
+    expect(await getDefaultWslDistro()).toBe("Ubuntu 22.04 LTS");
+  });
+
+  it("still finds the default on a localized Windows host (translated header/state)", async () => {
+    // German Windows: header "NAME STATUS VERSION", state "Wird ausgeführt"
+    // ("Running"). The `*` marker is the only locale-independent signal.
+    Object.defineProperty(process, "platform", { value: "win32", writable: true });
+    const stdout =
+      "  NAME            STATUS               VERSION\r\n" +
+      "* Ubuntu          Wird ausgeführt      2\r\n" +
+      "  Debian          Beendet              2\r\n";
+    execFileMock.mockImplementation((_file, _args, _opts, cb: ExecFileCallback) =>
+      cb(null, utf16le(stdout))
+    );
+
+    const { getDefaultWslDistro } = await import("../wsl.js");
+    expect(await getDefaultWslDistro()).toBe("Ubuntu");
+  });
+
+  it("returns null when no line is marked with *", async () => {
+    Object.defineProperty(process, "platform", { value: "win32", writable: true });
+    const stdout =
+      "  NAME            STATE           VERSION\r\n" + "  Ubuntu          Stopped         2\r\n";
+    execFileMock.mockImplementation((_file, _args, _opts, cb: ExecFileCallback) =>
+      cb(null, utf8(stdout))
+    );
+
+    const { getDefaultWslDistro } = await import("../wsl.js");
+    expect(await getDefaultWslDistro()).toBeNull();
+  });
+
+  it("returns null when stdout is empty (no distros installed)", async () => {
+    Object.defineProperty(process, "platform", { value: "win32", writable: true });
+    execFileMock.mockImplementation((_file, _args, _opts, cb: ExecFileCallback) =>
+      cb(null, utf8(""))
+    );
+
+    const { getDefaultWslDistro } = await import("../wsl.js");
+    expect(await getDefaultWslDistro()).toBeNull();
+  });
+
+  it("returns null when wsl.exe fails to spawn", async () => {
+    Object.defineProperty(process, "platform", { value: "win32", writable: true });
+    execFileMock.mockImplementation((_file, _args, _opts, cb: ExecFileCallback) =>
+      cb(new Error("ENOENT: wsl.exe not found"), Buffer.alloc(0))
+    );
+
+    const { getDefaultWslDistro } = await import("../wsl.js");
+    expect(await getDefaultWslDistro()).toBeNull();
+  });
+
+  it("invokes wsl.exe with --list --verbose (not --quiet)", async () => {
+    Object.defineProperty(process, "platform", { value: "win32", writable: true });
+    execFileMock.mockImplementation((_file, _args, _opts, cb: ExecFileCallback) =>
+      cb(null, utf8("  NAME  STATE  VERSION\r\n* Ubuntu  Running  2\r\n"))
+    );
+
+    const { getDefaultWslDistro } = await import("../wsl.js");
+    await getDefaultWslDistro();
+
+    expect(execFileMock).toHaveBeenCalledOnce();
+    const [file, args] = execFileMock.mock.calls[0];
+    expect(file).toBe("wsl.exe");
+    expect(args).toEqual(["--list", "--verbose"]);
   });
 });

--- a/electron/utils/__tests__/wsl.test.ts
+++ b/electron/utils/__tests__/wsl.test.ts
@@ -195,7 +195,7 @@ describe("getDefaultWslDistro", () => {
     expect(await getDefaultWslDistro()).toBeNull();
   });
 
-  it("invokes wsl.exe with --list --verbose (not --quiet)", async () => {
+  it("invokes wsl.exe with --list --verbose and the decode-critical options", async () => {
     Object.defineProperty(process, "platform", { value: "win32", writable: true });
     execFileMock.mockImplementation((_file, _args, _opts, cb: ExecFileCallback) =>
       cb(null, utf8("  NAME  STATE  VERSION\r\n* Ubuntu  Running  2\r\n"))
@@ -205,8 +205,47 @@ describe("getDefaultWslDistro", () => {
     await getDefaultWslDistro();
 
     expect(execFileMock).toHaveBeenCalledOnce();
-    const [file, args] = execFileMock.mock.calls[0];
+    const [file, args, opts] = execFileMock.mock.calls[0];
     expect(file).toBe("wsl.exe");
     expect(args).toEqual(["--list", "--verbose"]);
+    // These options are load-bearing: `encoding: "buffer"` is what lets the
+    // UTF-16LE heuristic run; without it Node decodes stdout as UTF-8 and the
+    // pre-WSL_UTF8 path silently mangles distro names.
+    expect(opts).toMatchObject({
+      encoding: "buffer",
+      windowsHide: true,
+      timeout: 5_000,
+    });
+    expect(opts.env.WSL_UTF8).toBe("1");
+  });
+
+  it("decodes UTF-16LE without BOM via the null-byte heuristic", async () => {
+    Object.defineProperty(process, "platform", { value: "win32", writable: true });
+    // No BOM; rely on the >1/3-null-bytes heuristic to pick UTF-16LE.
+    const stdout =
+      "  NAME            STATE           VERSION\r\n" + "* Fedora          Running         2\r\n";
+    const buf = Buffer.from(stdout, "utf16le");
+    execFileMock.mockImplementation((_file, _args, _opts, cb: ExecFileCallback) => cb(null, buf));
+
+    const { getDefaultWslDistro } = await import("../wsl.js");
+    expect(await getDefaultWslDistro()).toBe("Fedora");
+  });
+
+  it("ignores a `*`-prefixed banner line and still finds the real default", async () => {
+    Object.defineProperty(process, "platform", { value: "win32", writable: true });
+    // Some WSL builds emit advisory/banner text before the table — guard
+    // against a `*`-prefixed banner being mistaken for the default-marker row.
+    // A banner line lacks the 2+ space column gap that signals a real entry.
+    const stdout =
+      "*ImportantNotice: update WSL via Windows Update*\r\n" +
+      "  NAME            STATE           VERSION\r\n" +
+      "  Ubuntu          Stopped         2\r\n" +
+      "* Debian          Running         2\r\n";
+    execFileMock.mockImplementation((_file, _args, _opts, cb: ExecFileCallback) =>
+      cb(null, utf8(stdout))
+    );
+
+    const { getDefaultWslDistro } = await import("../wsl.js");
+    expect(await getDefaultWslDistro()).toBe("Debian");
   });
 });

--- a/electron/utils/wsl.ts
+++ b/electron/utils/wsl.ts
@@ -38,19 +38,26 @@ export function detectWslPath(p: string): WslPathInfo | null {
 }
 
 /**
- * Return the name of the first WSL distro listed by `wsl.exe --list --quiet`.
+ * Return the name of the user's default WSL distro by parsing
+ * `wsl.exe --list --verbose` output for the line marked with `*`.
  * On non-Windows or when wsl.exe is unavailable, returns `null`.
+ *
+ * The `*` marker is the only locale-independent signal — the header row
+ * and the STATE column are both translated on non-English Windows, but
+ * the marker stays put. `--list --quiet` does not include the marker and
+ * does not order entries by default-status, so on multi-distro hosts the
+ * first-listed distro is not necessarily the default (issue #7944).
  *
  * Encoding handling mirrors the CliAvailabilityService probe: WSL has
  * historically emitted UTF-16LE (with BOM); newer Windows builds honour
  * `WSL_UTF8=1`. We pick the encoding heuristically.
  */
-export function listFirstWslDistro(): Promise<string | null> {
+export function getDefaultWslDistro(): Promise<string | null> {
   if (process.platform !== "win32") return Promise.resolve(null);
   return new Promise((resolve) => {
     execFile(
       "wsl.exe",
-      ["--list", "--quiet"],
+      ["--list", "--verbose"],
       {
         env: { ...process.env, WSL_UTF8: "1" },
         timeout: WSL_LIST_TIMEOUT_MS,
@@ -82,11 +89,23 @@ export function listFirstWslDistro(): Promise<string | null> {
           ? buf.toString("utf16le").replace(/^\uFEFF/, "")
           : buf.toString("utf8");
 
-        const lines = decoded
-          .split(/\r?\n/)
-          .map((l) => l.trim())
-          .filter(Boolean);
-        resolve(lines[0] ?? null);
+        // `--verbose` lines look like:
+        //   "* Ubuntu          Running         2"   (default)
+        //   "  Debian          Stopped         2"   (non-default)
+        // The NAME column is separated from STATE by 2+ spaces, which lets
+        // names with internal spaces (e.g. "Ubuntu 22.04 LTS") parse cleanly.
+        const lines = decoded.split(/\r?\n/);
+        for (const line of lines) {
+          const match = /^\*\s+(.+?)\s{2,}/.exec(line);
+          if (match) {
+            const name = match[1]?.trim();
+            if (name) {
+              resolve(name);
+              return;
+            }
+          }
+        }
+        resolve(null);
       }
     );
   });

--- a/electron/workspace-host/WorkspaceService.ts
+++ b/electron/workspace-host/WorkspaceService.ts
@@ -17,7 +17,7 @@ import type {
   BranchInfo,
 } from "../../shared/types/workspace-host.js";
 import { invalidateGitStatusCache } from "../utils/git.js";
-import { detectWslPath, listFirstWslDistro } from "../utils/wsl.js";
+import { detectWslPath, getDefaultWslDistro } from "../utils/wsl.js";
 import {
   getGitDir,
   getGitCommonDir,
@@ -432,10 +432,10 @@ export class WorkspaceService {
     if (!detected) return wt;
 
     if (!this.wslDefaultDistroPromise) {
-      this.wslDefaultDistroPromise = listFirstWslDistro().catch(() => null);
+      this.wslDefaultDistroPromise = getDefaultWslDistro().catch(() => null);
     }
     const defaultDistro = await this.wslDefaultDistroPromise;
-    // UNC paths are case-insensitive on Windows; `wsl --list --quiet` returns
+    // UNC paths are case-insensitive on Windows; `wsl --list --verbose` returns
     // the canonical case (e.g. "Ubuntu"). Normalize before comparing so a
     // worktree opened via `\\wsl$\ubuntu\...` still matches the default.
     const eligible =


### PR DESCRIPTION
## Summary

- On multi-distro WSL hosts, `wsl --list --quiet` returns distros in registration order, not default-first. The fast-path git gate was picking the wrong distro as a result.
- Switches to `wsl --list --verbose` and reads the `*`-marked line, which is the only locale-independent default-distro signal.
- Renames `listFirstWslDistro` to `getDefaultWslDistro` and updates both call sites (`WorkspaceService`, `CliAvailabilityService`).

Resolves #7944

## Changes

- `electron/utils/wsl.ts` — parser swap; UTF-16LE/UTF-8 decode heuristic preserved
- `electron/workspace-host/WorkspaceService.ts` — updated import and call site
- `electron/services/CliAvailabilityService.ts` — updated import, call site, and JSDoc
- `electron/utils/__tests__/wsl.test.ts` — 12 new tests for `getDefaultWslDistro`
- `electron/services/__tests__/CliAvailabilityService.test.ts` — WSL probe mock updated to `--verbose` format

## Testing

- New unit tests cover: multi-distro where default is not first (UTF-16LE with BOM), single-distro default (UTF-8), distro names with spaces, localized Windows output (German headers — only `*` is universal), no `*` line, empty stdout, spawn errors, `execFile` invocation options, UTF-16LE without BOM (null-byte heuristic), and `*`-prefixed banner false-positive guard.
- Targeted vitest run: 99 tests pass across `wsl.test.ts` and `CliAvailabilityService.test.ts`.
- Full `npm run check` clean — typecheck, lint, format, build all pass with no new warnings.