### PR TITLE
fix(hydration): normalize path separators in worktree-id inference

### DIFF
--- a/src/utils/stateHydration/__tests__/statePatcher.test.ts
+++ b/src/utils/stateHydration/__tests__/statePatcher.test.ts
@@ -1113,6 +1113,21 @@ describe("inferWorktreeIdFromCwd", () => {
     const worktrees = [{ id: "C:\\repo\\wt-a", path: "C:\\repo\\wt-a" }];
     expect(inferWorktreeIdFromCwd("C:\\repo\\wt-a\\src\\lib", worktrees)).toBe("C:\\repo\\wt-a");
   });
+
+  it("matches when cwd uses backslashes but worktree path uses forward slashes", () => {
+    const worktrees = [{ id: "C:/repo/wt-a", path: "C:/repo/wt-a" }];
+    expect(inferWorktreeIdFromCwd("C:\\repo\\wt-a\\src\\lib", worktrees)).toBe("C:/repo/wt-a");
+  });
+
+  it("matches when cwd uses forward slashes but worktree path uses backslashes", () => {
+    const worktrees = [{ id: "C:\\repo\\wt-a", path: "C:\\repo\\wt-a" }];
+    expect(inferWorktreeIdFromCwd("C:/repo/wt-a/src/lib", worktrees)).toBe("C:\\repo\\wt-a");
+  });
+
+  it("ignores trailing separators on worktree paths", () => {
+    const worktrees = [{ id: "C:/repo/wt-a", path: "C:/repo/wt-a/" }];
+    expect(inferWorktreeIdFromCwd("C:/repo/wt-a/src", worktrees)).toBe("C:/repo/wt-a");
+  });
 });
 
 describe("buildArgsForBackendTerminal — extensionState", () => {

--- a/src/utils/stateHydration/__tests__/statePatcher.test.ts
+++ b/src/utils/stateHydration/__tests__/statePatcher.test.ts
@@ -1124,9 +1124,22 @@ describe("inferWorktreeIdFromCwd", () => {
     expect(inferWorktreeIdFromCwd("C:/repo/wt-a/src/lib", worktrees)).toBe("C:\\repo\\wt-a");
   });
 
-  it("ignores trailing separators on worktree paths", () => {
+  it("returns the worktree id unchanged when it differs from the path", () => {
+    const worktrees = [{ id: "worktree-uuid-123", path: "C:/repo/wt-a" }];
+    expect(inferWorktreeIdFromCwd("C:\\repo\\wt-a\\src\\lib", worktrees)).toBe(
+      "worktree-uuid-123"
+    );
+  });
+
+  it("ignores trailing separators on either side", () => {
     const worktrees = [{ id: "C:/repo/wt-a", path: "C:/repo/wt-a/" }];
     expect(inferWorktreeIdFromCwd("C:/repo/wt-a/src", worktrees)).toBe("C:/repo/wt-a");
+    expect(inferWorktreeIdFromCwd("C:\\repo\\wt-a\\", worktrees)).toBe("C:/repo/wt-a");
+  });
+
+  it("does not match Windows sibling directories that share a prefix across separator styles", () => {
+    const worktrees = [{ id: "C:/repo/wt-a", path: "C:/repo/wt-a" }];
+    expect(inferWorktreeIdFromCwd("C:\\repo\\wt-a-long\\src", worktrees)).toBeUndefined();
   });
 });
 

--- a/src/utils/stateHydration/__tests__/statePatcher.test.ts
+++ b/src/utils/stateHydration/__tests__/statePatcher.test.ts
@@ -1126,9 +1126,7 @@ describe("inferWorktreeIdFromCwd", () => {
 
   it("returns the worktree id unchanged when it differs from the path", () => {
     const worktrees = [{ id: "worktree-uuid-123", path: "C:/repo/wt-a" }];
-    expect(inferWorktreeIdFromCwd("C:\\repo\\wt-a\\src\\lib", worktrees)).toBe(
-      "worktree-uuid-123"
-    );
+    expect(inferWorktreeIdFromCwd("C:\\repo\\wt-a\\src\\lib", worktrees)).toBe("worktree-uuid-123");
   });
 
   it("ignores trailing separators on either side", () => {

--- a/src/utils/stateHydration/statePatcher.ts
+++ b/src/utils/stateHydration/statePatcher.ts
@@ -462,23 +462,32 @@ export function buildArgsForNonPtyRecreation(
   return base;
 }
 
+// Normalizes separators (backslash → forward slash) and trims trailing slashes
+// so cwd and worktree paths compare apples-to-apples on Windows, where node-pty
+// returns backslashes but simple-git returns forward slashes.
+function normalizeForComparison(p: string): string {
+  return p.replace(/\\/g, "/").replace(/\/+$/, "");
+}
+
 /**
  * Infer a worktreeId from a terminal's cwd by longest-prefix matching against the
  * worktrees list. Returns undefined when no worktree's path is a prefix of cwd.
- * Uses segment-aware matching (both POSIX and Windows separators) to avoid false
- * positives where `/repo/wt` would match `/repo/wt-long`.
+ * Uses segment-aware matching after normalizing separators on both sides, so
+ * mixed POSIX/Windows separators between cwd and worktree paths still match.
  */
 export function inferWorktreeIdFromCwd(
   cwd: string | undefined,
   worktrees: ReadonlyArray<{ id: string; path: string }> | undefined
 ): string | undefined {
   if (!cwd || !worktrees || worktrees.length === 0) return undefined;
-  let best: { id: string; path: string } | undefined;
+  const normalizedCwd = normalizeForComparison(cwd);
+  let best: { id: string; normalizedLength: number } | undefined;
   for (const wt of worktrees) {
     if (!wt.path) continue;
-    if (cwd === wt.path || cwd.startsWith(wt.path + "/") || cwd.startsWith(wt.path + "\\")) {
-      if (!best || wt.path.length > best.path.length) {
-        best = wt;
+    const normalizedWtPath = normalizeForComparison(wt.path);
+    if (normalizedCwd === normalizedWtPath || normalizedCwd.startsWith(normalizedWtPath + "/")) {
+      if (!best || normalizedWtPath.length > best.normalizedLength) {
+        best = { id: wt.id, normalizedLength: normalizedWtPath.length };
       }
     }
   }


### PR DESCRIPTION
## Summary

- `node-pty` returns Windows `cwd` with backslashes; `simple-git` returns worktree paths with forward slashes. The previous `inferWorktreeIdFromCwd` code never normalized both sides, so mixed-separator pairs silently failed and panels fell back to `activeWorktreeId`.
- Adds a private `normalizeForComparison` helper that replaces `\` with `/` and trims trailing slashes, applied to both `cwd` and worktree paths before the prefix check. Also refactors the longest-prefix tiebreaker to compare normalized lengths.
- Five new test fixtures cover the mixed-separator cases, distinct-id paths, trailing-slash variants, and the mixed-separator sibling negative case.

Resolves #7950

## Changes

- `src/utils/stateHydration/statePatcher.ts` — `normalizeForComparison` helper + updated `inferWorktreeIdFromCwd`
- `src/utils/stateHydration/__tests__/statePatcher.test.ts` — 5 new fixtures (137 tests passing)

## Testing

All 137 `statePatcher` tests pass. New fixtures confirm that mixed backslash/forward-slash pairs now resolve correctly and that the sibling-path negative case doesn't regress.