### PR TITLE
fix(toolbar): reserve space for Windows native caption buttons

### DIFF
--- a/electron/ipc/handlers/__tests__/appTheme.handlers.test.ts
+++ b/electron/ipc/handlers/__tests__/appTheme.handlers.test.ts
@@ -491,6 +491,57 @@ describe("appTheme handlers", () => {
     expect(mockWindow.setBackgroundColor).not.toHaveBeenCalled();
   });
 
+  it("nativeTheme updated re-applies Windows titleBarOverlay at 48px height — issue #7951", () => {
+    const originalPlatform = process.platform;
+    Object.defineProperty(process, "platform", { value: "win32", configurable: true });
+    try {
+      const mockWindow = {
+        isDestroyed: () => false,
+        setBackgroundColor: vi.fn(),
+        setTitleBarOverlay: vi.fn(),
+      };
+      storeState.data.appTheme = { colorSchemeId: "daintree", followSystem: true };
+      nativeThemeMock.shouldUseDarkColors = true;
+
+      registerAppThemeHandlers(mockWindow as never);
+
+      const themeHandler = getNativeThemeHandler();
+      themeHandler();
+      vi.advanceTimersByTime(300);
+
+      expect(mockWindow.setTitleBarOverlay).toHaveBeenCalledWith({
+        color: "#1a1a2e",
+        symbolColor: "#a1a1aa",
+        height: 48,
+      });
+    } finally {
+      Object.defineProperty(process, "platform", { value: originalPlatform, configurable: true });
+    }
+  });
+
+  it("nativeTheme updated does not call setTitleBarOverlay on non-Windows platforms", () => {
+    const originalPlatform = process.platform;
+    Object.defineProperty(process, "platform", { value: "darwin", configurable: true });
+    try {
+      const mockWindow = {
+        isDestroyed: () => false,
+        setBackgroundColor: vi.fn(),
+        setTitleBarOverlay: vi.fn(),
+      };
+      storeState.data.appTheme = { colorSchemeId: "daintree", followSystem: true };
+
+      registerAppThemeHandlers(mockWindow as never);
+
+      const themeHandler = getNativeThemeHandler();
+      themeHandler();
+      vi.advanceTimersByTime(300);
+
+      expect(mockWindow.setTitleBarOverlay).not.toHaveBeenCalled();
+    } finally {
+      Object.defineProperty(process, "platform", { value: originalPlatform, configurable: true });
+    }
+  });
+
   it("nativeTheme updated persists new colorSchemeId to store", () => {
     const mockWindow = {
       isDestroyed: () => false,

--- a/electron/ipc/handlers/appTheme.ts
+++ b/electron/ipc/handlers/appTheme.ts
@@ -249,7 +249,7 @@ export function registerAppThemeHandlers(mainWindow?: BrowserWindow): () => void
         win.setTitleBarOverlay({
           color: scheme.tokens["surface-canvas"],
           symbolColor: "#a1a1aa",
-          height: 36,
+          height: 48,
         });
       }
     }, 300);

--- a/electron/window/createWindow.ts
+++ b/electron/window/createWindow.ts
@@ -211,7 +211,7 @@ export function setupBrowserWindow(
               titleBarOverlay: {
                 color: windowBg,
                 symbolColor: "#a1a1aa",
-                height: 36,
+                height: 48,
               },
             }
           : {}),

--- a/electron/window/skeletonCss.ts
+++ b/electron/window/skeletonCss.ts
@@ -61,6 +61,14 @@ export function injectSkeletonCss(wc: WebContents): void {
   lines.push(`  --skeleton-sidebar-width: ${sidebarWidth}px;`);
   lines.push(`  --skeleton-focus-mode: ${focusMode ? "1" : "0"};`);
 
+  // Reserve space for Windows native caption buttons (minimize/maximize/close).
+  // Static 138px ≈ 3 × 46px backplates on Windows 11 @ 96 DPI; Electron 41 has
+  // no API to read actual geometry, so the trailing toolbar spacer in Toolbar.tsx
+  // uses this var with a 138px fallback. See issue #7951.
+  if (process.platform === "win32") {
+    lines.push("  --win-caption-width: 138px;");
+  }
+
   lines.push("}");
 
   // If focus mode is active, hide the skeleton sidebar

--- a/index.html
+++ b/index.html
@@ -133,6 +133,11 @@
         align-items: center;
         justify-content: flex-end;
         gap: 6px;
+        /* Reserve space for Windows native caption controls during the
+           pre-React skeleton phase. The var is only injected on win32 by
+           injectSkeletonCss; the 0 fallback keeps macOS/Linux unaffected.
+           See issue #7951. */
+        padding-right: var(--win-caption-width, 0px);
       }
 
       /* ── Skeleton placeholder shapes (3-tier opacity hierarchy) ── */

--- a/src/components/Layout/Toolbar.tsx
+++ b/src/components/Layout/Toolbar.tsx
@@ -18,7 +18,7 @@ import { Folders, McpServerIcon } from "@/components/icons";
 import { TOOLBAR_BUTTON_METADATA, isToolbarButtonVisible } from "./toolbarButtonMetadata";
 import { cn } from "@/lib/utils";
 import { shortcutHintStore } from "@/store/shortcutHintStore";
-import { isMac, isLinux } from "@/lib/platform";
+import { isMac, isLinux, isWindows } from "@/lib/platform";
 import { createTooltipContent } from "@/lib/tooltipShortcut";
 import { AgentButton } from "./AgentButton";
 import { AgentTrayButton } from "./AgentTrayButton";
@@ -1097,6 +1097,14 @@ export function Toolbar({
             {buttonRegistry["assistant-toggle"]!.render()}
             {buttonRegistry["portal-toggle"]!.render()}
           </div>
+
+          {isWindows() && (
+            <div
+              aria-hidden="true"
+              className={cn("shrink-0 transition-[width] duration-150", isFullscreen && "w-0")}
+              style={isFullscreen ? undefined : { width: "var(--win-caption-width, 138px)" }}
+            />
+          )}
         </div>
       </div>
     </header>

--- a/src/components/Layout/__tests__/Toolbar.layout.test.ts
+++ b/src/components/Layout/__tests__/Toolbar.layout.test.ts
@@ -185,4 +185,50 @@ describe("Toolbar layout — issue #2584 project switcher collision", () => {
       expect(source).not.toContain("onRecomputeDragRegions");
     });
   });
+
+  describe("Windows caption control spacer — issue #7951", () => {
+    it("imports isWindows from the platform helper", () => {
+      expect(source).toMatch(/import\s*{[^}]*\bisWindows\b[^}]*}\s*from\s*"@\/lib\/platform"/);
+    });
+
+    it("does not inline navigator.platform checks", () => {
+      expect(source).not.toContain("navigator.platform");
+    });
+
+    it("guards the trailing spacer with isWindows()", () => {
+      expect(source).toMatch(/isWindows\(\)\s*&&\s*\(/);
+    });
+
+    it("reserves space via the --win-caption-width CSS variable", () => {
+      expect(source).toContain("var(--win-caption-width, 138px)");
+    });
+
+    it("collapses the spacer to zero width when entering fullscreen", () => {
+      expect(source).toMatch(/isFullscreen\s*&&\s*"w-0"/);
+    });
+
+    it("places the spacer inside the right toolbar group, after the portal toggle", () => {
+      const rightGroupIndex = source.indexOf('aria-label="Tools and settings"');
+      const spacerIndex = source.indexOf("var(--win-caption-width, 138px)");
+      const portalToggleIndex = source.indexOf('buttonRegistry["portal-toggle"]');
+      expect(rightGroupIndex).toBeGreaterThan(-1);
+      expect(spacerIndex).toBeGreaterThan(-1);
+      expect(portalToggleIndex).toBeGreaterThan(-1);
+      expect(spacerIndex).toBeGreaterThan(rightGroupIndex);
+      expect(spacerIndex).toBeGreaterThan(portalToggleIndex);
+    });
+
+    it("uses scoped transition-[width] motion, not transition-all", () => {
+      expect(source).toMatch(/transition-\[width\]\s+duration-150/);
+    });
+
+    it("spacer is decorative (aria-hidden) and not focusable as a toolbar item", () => {
+      const spacerBlock = source.slice(
+        source.indexOf("isWindows() &&"),
+        source.indexOf("var(--win-caption-width, 138px)") + 200
+      );
+      expect(spacerBlock).toContain('aria-hidden="true"');
+      expect(spacerBlock).not.toContain("data-toolbar-item");
+    });
+  });
 });


### PR DESCRIPTION
## Summary

- Windows toolbar buttons were overlapping the native caption controls (minimize, maximize, close). This fixes it end-to-end — from the Electron overlay config through to the pre-React skeleton phase.
- The approach mirrors the existing macOS traffic-light spacer pattern: a Windows-only trailing spacer in `Toolbar.tsx` driven by a `--win-caption-width` CSS variable injected before React mounts.

Resolves #7951

## Changes

- **`createWindow.ts` + `appTheme.ts`:** bump `titleBarOverlay` height from 36 to 48 to match the actual 48px toolbar height
- **`skeletonCss.ts`:** inject `--win-caption-width: 138px` on Windows via the existing skeleton CSS path so the spacer is sized correctly before React mounts
- **`Toolbar.tsx`:** add a Windows-only trailing spacer after the portal-toggle div in the right group, collapsing to `w-0` in fullscreen — mirrors the macOS traffic-light pattern
- **`index.html`:** add `padding-right: var(--win-caption-width, 0px)` to `.skeleton-toolbar-right` so the pre-React skeleton phase also stays clear of the caption zone

## Testing

78 vitest tests pass (`Toolbar.layout` source-scan + `appTheme.handlers` behavior). All 6 verify checks clean: typecheck, channels, IPC, help, lint ratchet, format, and build.