### PR TITLE
fix(menu): close Windows/Linux gaps in native application menu

### DIFF
--- a/electron/__tests__/menu.test.ts
+++ b/electron/__tests__/menu.test.ts
@@ -138,6 +138,11 @@ vi.mock("../window/webContentsRegistry.js", () => ({
   getAppWebContents: vi.fn(() => mockWebContents),
 }));
 
+const isWindowsStoreBuildMock = vi.hoisted(() => vi.fn(() => true));
+vi.mock("../../shared/config/distribution.js", () => ({
+  isWindowsStoreBuild: isWindowsStoreBuildMock,
+}));
+
 import { createApplicationMenu } from "../menu.js";
 import { webContents, app, Menu } from "electron";
 
@@ -319,6 +324,7 @@ describe("update menu lifecycle", () => {
     beforeEach(() => {
       Object.defineProperty(process, "platform", { value: "darwin", configurable: true });
       Object.defineProperty(app, "isPackaged", { value: true, configurable: true });
+      isWindowsStoreBuildMock.mockReturnValue(false);
       createApplicationMenu(mockBrowserWindow as unknown as Electron.BrowserWindow);
     });
 
@@ -368,6 +374,7 @@ describe("update menu lifecycle", () => {
     beforeEach(() => {
       Object.defineProperty(process, "platform", { value: "linux", configurable: true });
       Object.defineProperty(app, "isPackaged", { value: true, configurable: true });
+      isWindowsStoreBuildMock.mockReturnValue(false);
       createApplicationMenu(mockBrowserWindow as unknown as Electron.BrowserWindow);
     });
 
@@ -387,6 +394,7 @@ describe("update menu lifecycle", () => {
     beforeEach(() => {
       Object.defineProperty(process, "platform", { value: "win32", configurable: true });
       Object.defineProperty(app, "isPackaged", { value: true, configurable: true });
+      isWindowsStoreBuildMock.mockReturnValue(true);
       createApplicationMenu(mockBrowserWindow as unknown as Electron.BrowserWindow);
     });
 
@@ -405,6 +413,7 @@ describe("update menu lifecycle", () => {
     beforeEach(() => {
       Object.defineProperty(process, "platform", { value: "darwin", configurable: true });
       Object.defineProperty(app, "isPackaged", { value: true, configurable: true });
+      isWindowsStoreBuildMock.mockReturnValue(false);
       createApplicationMenu(mockBrowserWindow as unknown as Electron.BrowserWindow);
     });
 
@@ -612,6 +621,7 @@ describe("update menu lifecycle", () => {
     beforeEach(() => {
       Object.defineProperty(process, "platform", { value: "darwin", configurable: true });
       Object.defineProperty(app, "isPackaged", { value: true, configurable: true });
+      isWindowsStoreBuildMock.mockReturnValue(false);
       createApplicationMenu(mockBrowserWindow as unknown as Electron.BrowserWindow);
 
       // The most-recent createApplicationMenu call registers the listener via

--- a/electron/__tests__/menu.test.ts
+++ b/electron/__tests__/menu.test.ts
@@ -451,6 +451,161 @@ describe("update menu lifecycle", () => {
     });
   });
 
+  describe("Window submenu platform conditioning (#7939)", () => {
+    function findSubmenu(
+      template: Electron.MenuItemConstructorOptions[],
+      label: string
+    ): Electron.MenuItemConstructorOptions[] {
+      const top = template.find((m) => m.label === label);
+      if (!top || !Array.isArray(top.submenu)) {
+        throw new Error(`Expected submenu for "${label}"`);
+      }
+      return top.submenu as Electron.MenuItemConstructorOptions[];
+    }
+
+    it("on darwin keeps the original [minimize, zoom, separator, front] submenu", () => {
+      Object.defineProperty(process, "platform", { value: "darwin", configurable: true });
+      createApplicationMenu(mockBrowserWindow as unknown as Electron.BrowserWindow);
+
+      const items = findSubmenu(capturedTemplate, "Window");
+      expect(items.map((i) => i.role ?? i.type)).toEqual([
+        "minimize",
+        "zoom",
+        "separator",
+        "front",
+      ]);
+    });
+
+    it("on win32 replaces the macOS-only roles with [minimize, close] and no orphan separator", () => {
+      Object.defineProperty(process, "platform", { value: "win32", configurable: true });
+      createApplicationMenu(mockBrowserWindow as unknown as Electron.BrowserWindow);
+
+      const items = findSubmenu(capturedTemplate, "Window");
+      expect(items.map((i) => i.role ?? i.type)).toEqual(["minimize", "close"]);
+      expect(items.some((i) => i.role === "zoom")).toBe(false);
+      expect(items.some((i) => i.role === "front")).toBe(false);
+      expect(items.some((i) => i.type === "separator")).toBe(false);
+    });
+
+    it("on linux replaces the macOS-only roles with [minimize, close] and no orphan separator", () => {
+      Object.defineProperty(process, "platform", { value: "linux", configurable: true });
+      createApplicationMenu(mockBrowserWindow as unknown as Electron.BrowserWindow);
+
+      const items = findSubmenu(capturedTemplate, "Window");
+      expect(items.map((i) => i.role ?? i.type)).toEqual(["minimize", "close"]);
+    });
+  });
+
+  describe("File menu Exit and Settings accelerator on non-darwin (#7939)", () => {
+    it("on darwin: no Exit item, no Settings... with accelerator (Settings... lives in app menu)", () => {
+      Object.defineProperty(process, "platform", { value: "darwin", configurable: true });
+      createApplicationMenu(mockBrowserWindow as unknown as Electron.BrowserWindow);
+
+      const fileMenu = capturedTemplate.find((m) => m.label === "File");
+      const items = fileMenu!.submenu as Electron.MenuItemConstructorOptions[];
+      expect(items.some((i) => i.label === "Exit")).toBe(false);
+      const fileSettings = items.find(
+        (i) => i.label === "Settings..." && i.accelerator === "CommandOrControl+,"
+      );
+      expect(fileSettings).toBeUndefined();
+    });
+
+    it("on win32: File menu ends with separator + Exit (role: quit) and exposes Settings... with CommandOrControl+,", () => {
+      Object.defineProperty(process, "platform", { value: "win32", configurable: true });
+      createApplicationMenu(mockBrowserWindow as unknown as Electron.BrowserWindow);
+
+      const fileMenu = capturedTemplate.find((m) => m.label === "File");
+      const items = fileMenu!.submenu as Electron.MenuItemConstructorOptions[];
+
+      const last = items[items.length - 1];
+      const penultimate = items[items.length - 2];
+      expect(last.label).toBe("Exit");
+      expect(last.role).toBe("quit");
+      expect(penultimate.type).toBe("separator");
+
+      const settings = items.find((i) => i.label === "Settings...");
+      expect(settings).toBeDefined();
+      expect(settings!.accelerator).toBe("CommandOrControl+,");
+
+      expect(items.some((i) => i.label === "Project Settings")).toBe(true);
+    });
+
+    it("on linux: File menu ends with separator + Exit (role: quit) and exposes Settings... with CommandOrControl+,", () => {
+      Object.defineProperty(process, "platform", { value: "linux", configurable: true });
+      createApplicationMenu(mockBrowserWindow as unknown as Electron.BrowserWindow);
+
+      const fileMenu = capturedTemplate.find((m) => m.label === "File");
+      const items = fileMenu!.submenu as Electron.MenuItemConstructorOptions[];
+
+      const last = items[items.length - 1];
+      expect(last.label).toBe("Exit");
+      expect(last.role).toBe("quit");
+
+      const settings = items.find((i) => i.label === "Settings...");
+      expect(settings).toBeDefined();
+      expect(settings!.accelerator).toBe("CommandOrControl+,");
+    });
+
+    it("Settings... on non-darwin dispatches open-settings", () => {
+      Object.defineProperty(process, "platform", { value: "win32", configurable: true });
+      createApplicationMenu(mockBrowserWindow as unknown as Electron.BrowserWindow);
+
+      const fileMenu = capturedTemplate.find((m) => m.label === "File");
+      const items = fileMenu!.submenu as Electron.MenuItemConstructorOptions[];
+      const settings = items.find((i) => i.label === "Settings...");
+      expect(settings).toBeDefined();
+
+      settings!.click!(
+        {} as Electron.MenuItem,
+        mockBrowserWindow as unknown as Electron.BaseWindow,
+        {} as Electron.KeyboardEvent
+      );
+      expect(mockWebContents.send).toHaveBeenCalledWith("menu-action", "open-settings");
+    });
+  });
+
+  describe("Help menu About item on non-darwin (#7939)", () => {
+    function findHelpSubmenu(
+      template: Electron.MenuItemConstructorOptions[]
+    ): Electron.MenuItemConstructorOptions[] {
+      const top = template.find((m) => m.role === "help");
+      if (!top || !Array.isArray(top.submenu)) {
+        throw new Error("Expected Help submenu");
+      }
+      return top.submenu as Electron.MenuItemConstructorOptions[];
+    }
+
+    it("on darwin: no About item in Help (About lives in the Daintree app menu)", () => {
+      Object.defineProperty(process, "platform", { value: "darwin", configurable: true });
+      createApplicationMenu(mockBrowserWindow as unknown as Electron.BrowserWindow);
+
+      const items = findHelpSubmenu(capturedTemplate);
+      expect(items.some((i) => i.role === "about")).toBe(false);
+    });
+
+    it("on win32: About is the last item in Help, preceded by a separator", () => {
+      Object.defineProperty(process, "platform", { value: "win32", configurable: true });
+      createApplicationMenu(mockBrowserWindow as unknown as Electron.BrowserWindow);
+
+      const items = findHelpSubmenu(capturedTemplate);
+      const last = items[items.length - 1];
+      const penultimate = items[items.length - 2];
+      expect(last.role).toBe("about");
+      expect(penultimate.type).toBe("separator");
+    });
+
+    it("on linux: About is the last item in Help, preceded by a separator", () => {
+      Object.defineProperty(process, "platform", { value: "linux", configurable: true });
+      createApplicationMenu(mockBrowserWindow as unknown as Electron.BrowserWindow);
+
+      const items = findHelpSubmenu(capturedTemplate);
+      const last = items[items.length - 1];
+      const penultimate = items[items.length - 2];
+      expect(last.role).toBe("about");
+      expect(penultimate.type).toBe("separator");
+    });
+  });
+
   describe("applyUpdateMenuState (via the registered listener)", () => {
     let dispatchUpdate: (state: "idle" | "checking" | "ready") => void;
 

--- a/electron/menu.ts
+++ b/electron/menu.ts
@@ -181,6 +181,16 @@ export function createApplicationMenu(
           submenu: buildRecentProjectsMenu(getTargetBrowserWindow, cliAvailabilityService),
         },
         { type: "separator" },
+        ...(process.platform !== "darwin"
+          ? [
+              {
+                label: "Settings...",
+                accelerator: "CommandOrControl+,",
+                click: (_item: Electron.MenuItem, browserWindow: Electron.BaseWindow | undefined) =>
+                  sendAction("open-settings", getTargetBrowserWindow(browserWindow)),
+              },
+            ]
+          : []),
         {
           label: "Project Settings",
           click: (_item, browserWindow) =>
@@ -201,6 +211,9 @@ export function createApplicationMenu(
           role: "close",
           registerAccelerator: false,
         },
+        ...(process.platform !== "darwin"
+          ? [{ type: "separator" as const }, { label: "Exit", role: "quit" as const }]
+          : []),
       ],
     },
     {
@@ -426,7 +439,10 @@ export function createApplicationMenu(
     },
     {
       label: "Window",
-      submenu: [{ role: "minimize" }, { role: "zoom" }, { type: "separator" }, { role: "front" }],
+      submenu:
+        process.platform === "darwin"
+          ? [{ role: "minimize" }, { role: "zoom" }, { type: "separator" }, { role: "front" }]
+          : [{ role: "minimize" }, { role: "close" }],
     },
     {
       role: "help",
@@ -467,6 +483,9 @@ export function createApplicationMenu(
           : []),
         ...(buildPluginMenuItems("help").length > 0
           ? [{ type: "separator" as const }, ...buildPluginMenuItems("help")]
+          : []),
+        ...(process.platform !== "darwin"
+          ? [{ type: "separator" as const }, { role: "about" as const }]
           : []),
       ],
     },

--- a/electron/window/__tests__/createWindow.platform-options.test.ts
+++ b/electron/window/__tests__/createWindow.platform-options.test.ts
@@ -1,0 +1,80 @@
+import { afterEach, describe, expect, it } from "vitest";
+
+/**
+ * Tests the platform-specific BrowserWindow constructor options from
+ * createWindow.ts (#7939).
+ *
+ * The options object is inlined inside setupBrowserWindow, so we replicate
+ * its exact platform branching here to verify that:
+ *   - macOS gets titleBarStyle: "hiddenInset" + trafficLightPosition, no autoHideMenuBar
+ *   - Windows gets titleBarStyle: "hidden" + titleBarOverlay + autoHideMenuBar
+ *   - Linux gets autoHideMenuBar only (no titleBarStyle override)
+ *
+ * If createWindow.ts changes, update this replica to match.
+ */
+
+type PlatformOptions = {
+  titleBarStyle?: "hidden" | "hiddenInset";
+  titleBarOverlay?: { color: string; symbolColor: string; height: number };
+  trafficLightPosition?: { x: number; y: number };
+  autoHideMenuBar?: boolean;
+};
+
+function getPlatformBrowserWindowOptions(windowBg: string): PlatformOptions {
+  if (process.platform === "darwin") {
+    return {
+      titleBarStyle: "hiddenInset" as const,
+      trafficLightPosition: { x: 12, y: 18 },
+    };
+  }
+  if (process.platform === "win32") {
+    return {
+      titleBarStyle: "hidden" as const,
+      titleBarOverlay: {
+        color: windowBg,
+        symbolColor: "#a1a1aa",
+        height: 36,
+      },
+      autoHideMenuBar: true,
+    };
+  }
+  return { autoHideMenuBar: true };
+}
+
+describe("platform BrowserWindow options (#7939)", () => {
+  const originalPlatform = process.platform;
+
+  afterEach(() => {
+    Object.defineProperty(process, "platform", { value: originalPlatform, configurable: true });
+  });
+
+  it("macOS gets hiddenInset titleBarStyle and trafficLightPosition, no autoHideMenuBar", () => {
+    Object.defineProperty(process, "platform", { value: "darwin", configurable: true });
+    const opts = getPlatformBrowserWindowOptions("#1a1a1a");
+    expect(opts.titleBarStyle).toBe("hiddenInset");
+    expect(opts.trafficLightPosition).toEqual({ x: 12, y: 18 });
+    expect(opts.autoHideMenuBar).toBeUndefined();
+    expect(opts.titleBarOverlay).toBeUndefined();
+  });
+
+  it("Windows gets hidden titleBarStyle + titleBarOverlay + autoHideMenuBar: true", () => {
+    Object.defineProperty(process, "platform", { value: "win32", configurable: true });
+    const opts = getPlatformBrowserWindowOptions("#1a1a1a");
+    expect(opts.titleBarStyle).toBe("hidden");
+    expect(opts.titleBarOverlay).toEqual({
+      color: "#1a1a1a",
+      symbolColor: "#a1a1aa",
+      height: 36,
+    });
+    expect(opts.autoHideMenuBar).toBe(true);
+  });
+
+  it("Linux gets autoHideMenuBar: true with no titleBarStyle override", () => {
+    Object.defineProperty(process, "platform", { value: "linux", configurable: true });
+    const opts = getPlatformBrowserWindowOptions("#1a1a1a");
+    expect(opts.autoHideMenuBar).toBe(true);
+    expect(opts.titleBarStyle).toBeUndefined();
+    expect(opts.titleBarOverlay).toBeUndefined();
+    expect(opts.trafficLightPosition).toBeUndefined();
+  });
+});

--- a/electron/window/createWindow.ts
+++ b/electron/window/createWindow.ts
@@ -213,8 +213,13 @@ export function setupBrowserWindow(
                 symbolColor: "#a1a1aa",
                 height: 36,
               },
+              // Hide the native menu bar so the custom 48px toolbar is the
+              // only chrome; Alt still reveals the menu. Must be set in the
+              // constructor — calling setAutoHideMenuBar after creation can
+              // cause Window Controls Overlay layout shifts.
+              autoHideMenuBar: true,
             }
-          : {}),
+          : { autoHideMenuBar: true }),
       backgroundColor: windowBg,
     },
     projectPath ?? undefined


### PR DESCRIPTION
## Summary

- Platform-conditional Window submenu: `minimize` + `close` on win32/linux, `minimize`/`zoom`/separator/`front` on darwin. The previous template used macOS-only roles (`zoom`, `front`) on all platforms, leaving Windows with a broken submenu.
- Settings (`CommandOrControl+,`), Exit (`role: quit`), and About (`role: about`) added to the File/Help menus on non-darwin — previously only reachable via the macOS app submenu.
- `autoHideMenuBar: true` set on win32 and Linux in `createWindow.ts` so the native menu bar hides by default and stays `Alt`-accessible, preventing it from stacking above the custom 48px toolbar.

Resolves #7939

## Changes

- `electron/menu.ts` — platform-conditional Window submenu, Settings/Exit on File menu (non-darwin), About on Help menu (non-darwin)
- `electron/window/createWindow.ts` — `autoHideMenuBar: true` on win32 and Linux
- `electron/__tests__/menu.test.ts` — platform-specific menu assertions, explicit `isWindowsStoreBuild` mock in each platform block
- `electron/window/__tests__/createWindow.platform-options.test.ts` — new test file covering win32/linux/darwin `BrowserWindow` option assertions, following the inline-replication pattern from `createWindow.webview-partition.test.ts`

## Testing

Typecheck, lint, format, and build all pass. Unit tests cover the platform branches for both the menu template and the `BrowserWindow` constructor options. Windows/Linux rendering confirmed by code inspection against Electron's documented role behaviour; visual confirmation on a real Windows build is noted in the issue as a follow-up.