### PR TITLE
fix(updater): detect MSIX builds via process.windowsStore, not platform

### DIFF
--- a/electron/__tests__/menu.test.ts
+++ b/electron/__tests__/menu.test.ts
@@ -289,15 +289,26 @@ describe("createApplicationMenu", () => {
 
 describe("update menu lifecycle", () => {
   const originalPlatform = process.platform;
+  const originalWindowsStore = (
+    process as Partial<NodeJS.Process & { windowsStore?: boolean }> & NodeJS.Process
+  ).windowsStore;
 
   beforeEach(() => {
     vi.clearAllMocks();
     capturedTemplate = [];
     autoUpdaterServiceMock.__setMenuState("idle");
+    Object.defineProperty(process, "windowsStore", {
+      value: originalWindowsStore,
+      configurable: true,
+    });
   });
 
   afterEach(() => {
     Object.defineProperty(process, "platform", { value: originalPlatform, configurable: true });
+    Object.defineProperty(process, "windowsStore", {
+      value: originalWindowsStore,
+      configurable: true,
+    });
     Object.defineProperty(app, "isPackaged", { value: false, configurable: true });
   });
 
@@ -386,6 +397,7 @@ describe("update menu lifecycle", () => {
   describe("on Windows Store builds (packaged)", () => {
     beforeEach(() => {
       Object.defineProperty(process, "platform", { value: "win32", configurable: true });
+      Object.defineProperty(process, "windowsStore", { value: true, configurable: true });
       Object.defineProperty(app, "isPackaged", { value: true, configurable: true });
       createApplicationMenu(mockBrowserWindow as unknown as Electron.BrowserWindow);
     });

--- a/electron/preload.cts
+++ b/electron/preload.cts
@@ -2484,6 +2484,8 @@ const api: ElectronAPI = {
     }) => ipcRenderer.send(CHANNELS.PERF_FLUSH_RENDERER_MARKS, payload),
   },
 
+  isWindowsStoreBuild: process.windowsStore === true,
+
   // Demo API — channel constants live in `./ipc/handlers/demo.preload.ts` and
   // back the main-side `defineIpcNamespace`, but the renderer-facing shape
   // takes positional args (moveTo(x, y, durationMs)) while channels carry a

--- a/electron/services/__tests__/AutoUpdaterService.test.ts
+++ b/electron/services/__tests__/AutoUpdaterService.test.ts
@@ -100,6 +100,8 @@ const CHECKING_MENU_DELAY_MS = 400;
 describe("AutoUpdaterService", () => {
   const originalPlatform = process.platform;
   const originalResourcesPath = process.resourcesPath;
+  const originalWindowsStore = (process as NodeJS.Process & { windowsStore?: boolean })
+    .windowsStore;
 
   beforeEach(() => {
     vi.useFakeTimers();
@@ -110,6 +112,7 @@ describe("AutoUpdaterService", () => {
     delete process.env.PORTABLE_EXECUTABLE_FILE;
     delete process.env.APPIMAGE;
     Object.defineProperty(process, "platform", { value: "darwin", configurable: true });
+    delete (process as NodeJS.Process & { windowsStore?: boolean }).windowsStore;
     Object.defineProperty(process, "resourcesPath", {
       value: "/mock/resources",
       configurable: true,
@@ -144,6 +147,14 @@ describe("AutoUpdaterService", () => {
       value: originalResourcesPath,
       configurable: true,
     });
+    if (originalWindowsStore === undefined) {
+      delete (process as NodeJS.Process & { windowsStore?: boolean }).windowsStore;
+    } else {
+      Object.defineProperty(process, "windowsStore", {
+        value: originalWindowsStore,
+        configurable: true,
+      });
+    }
     delete process.env.APPIMAGE;
     vi.useRealTimers();
     vi.restoreAllMocks();
@@ -567,8 +578,9 @@ describe("AutoUpdaterService", () => {
   });
 
   describe("Windows Store updater guard", () => {
-    it("registers only channel-preference IPC handlers on Windows", () => {
+    it("registers only channel-preference IPC handlers on MSIX (Windows Store) builds", () => {
       Object.defineProperty(process, "platform", { value: "win32", configurable: true });
+      Object.defineProperty(process, "windowsStore", { value: true, configurable: true });
 
       autoUpdaterService.initialize();
 
@@ -581,13 +593,25 @@ describe("AutoUpdaterService", () => {
       expect(autoUpdaterMock.checkForUpdatesAndNotify).not.toHaveBeenCalled();
     });
 
-    it("manual checks are no-ops on Windows", () => {
+    it("manual checks are no-ops on MSIX (Windows Store) builds", () => {
       Object.defineProperty(process, "platform", { value: "win32", configurable: true });
+      Object.defineProperty(process, "windowsStore", { value: true, configurable: true });
 
       autoUpdaterService.initialize();
       autoUpdaterService.checkForUpdatesManually();
 
       expect(autoUpdaterMock.checkForUpdates).not.toHaveBeenCalled();
+    });
+
+    it("does NOT suppress the updater on non-Store Windows builds (NSIS/Squirrel)", () => {
+      Object.defineProperty(process, "platform", { value: "win32", configurable: true });
+      delete (process as NodeJS.Process & { windowsStore?: boolean }).windowsStore;
+
+      autoUpdaterService.initialize();
+
+      const registeredChannels = (ipcMainMock.handle as Mock).mock.calls.map((args) => args[0]);
+      expect(registeredChannels).toContain(CHANNELS.UPDATE_CHECK_FOR_UPDATES);
+      expect(registeredChannels).toContain(CHANNELS.UPDATE_QUIT_AND_INSTALL);
     });
   });
 

--- a/electron/services/__tests__/AutoUpdaterService.test.ts
+++ b/electron/services/__tests__/AutoUpdaterService.test.ts
@@ -594,18 +594,48 @@ describe("AutoUpdaterService", () => {
     });
 
     it("manual checks are no-ops on MSIX (Windows Store) builds", () => {
+      // Initialize first on non-Store platform so `this.initialized` is true —
+      // proves the `isWindowsStoreBuild()` guard in checkForUpdatesManually()
+      // fires independently of the `!this.initialized` short-circuit.
+      Object.defineProperty(process, "platform", { value: "darwin", configurable: true });
+      autoUpdaterService.initialize();
+      autoUpdaterMock.checkForUpdates.mockClear();
+
       Object.defineProperty(process, "platform", { value: "win32", configurable: true });
       Object.defineProperty(process, "windowsStore", { value: true, configurable: true });
-
-      autoUpdaterService.initialize();
       autoUpdaterService.checkForUpdatesManually();
 
       expect(autoUpdaterMock.checkForUpdates).not.toHaveBeenCalled();
     });
 
+    it("quitAndInstallIfReady is a no-op on MSIX (Windows Store) builds", () => {
+      Object.defineProperty(process, "platform", { value: "win32", configurable: true });
+      Object.defineProperty(process, "windowsStore", { value: true, configurable: true });
+
+      autoUpdaterService.initialize();
+      const result = autoUpdaterService.quitAndInstallIfReady();
+
+      expect(result).toBe(false);
+      expect(autoUpdaterMock.quitAndInstall).not.toHaveBeenCalled();
+    });
+
     it("does NOT suppress the updater on non-Store Windows builds (NSIS/Squirrel)", () => {
       Object.defineProperty(process, "platform", { value: "win32", configurable: true });
       delete (process as NodeJS.Process & { windowsStore?: boolean }).windowsStore;
+
+      autoUpdaterService.initialize();
+
+      const registeredChannels = (ipcMainMock.handle as Mock).mock.calls.map((args) => args[0]);
+      expect(registeredChannels).toContain(CHANNELS.UPDATE_CHECK_FOR_UPDATES);
+      expect(registeredChannels).toContain(CHANNELS.UPDATE_QUIT_AND_INSTALL);
+      // Setup runs end-to-end: feed URL configured and event listeners attached.
+      expect(autoUpdaterMock.setFeedURL).toHaveBeenCalled();
+      expect(autoUpdaterMock.on).toHaveBeenCalled();
+    });
+
+    it("does NOT suppress the updater when process.windowsStore is explicitly false", () => {
+      Object.defineProperty(process, "platform", { value: "win32", configurable: true });
+      Object.defineProperty(process, "windowsStore", { value: false, configurable: true });
 
       autoUpdaterService.initialize();
 

--- a/electron/services/__tests__/AutoUpdaterService.test.ts
+++ b/electron/services/__tests__/AutoUpdaterService.test.ts
@@ -100,8 +100,9 @@ const CHECKING_MENU_DELAY_MS = 400;
 describe("AutoUpdaterService", () => {
   const originalPlatform = process.platform;
   const originalResourcesPath = process.resourcesPath;
-  const originalWindowsStore = (process as NodeJS.Process & { windowsStore?: boolean })
-    .windowsStore;
+  const originalWindowsStore = (
+    process as Partial<NodeJS.Process & { windowsStore?: boolean }> & NodeJS.Process
+  ).windowsStore;
 
   beforeEach(() => {
     vi.useFakeTimers();
@@ -112,7 +113,7 @@ describe("AutoUpdaterService", () => {
     delete process.env.PORTABLE_EXECUTABLE_FILE;
     delete process.env.APPIMAGE;
     Object.defineProperty(process, "platform", { value: "darwin", configurable: true });
-    delete (process as NodeJS.Process & { windowsStore?: boolean }).windowsStore;
+    Object.defineProperty(process, "windowsStore", { value: undefined, configurable: true });
     Object.defineProperty(process, "resourcesPath", {
       value: "/mock/resources",
       configurable: true,
@@ -148,7 +149,7 @@ describe("AutoUpdaterService", () => {
       configurable: true,
     });
     if (originalWindowsStore === undefined) {
-      delete (process as NodeJS.Process & { windowsStore?: boolean }).windowsStore;
+      Object.defineProperty(process, "windowsStore", { value: undefined, configurable: true });
     } else {
       Object.defineProperty(process, "windowsStore", {
         value: originalWindowsStore,
@@ -621,7 +622,7 @@ describe("AutoUpdaterService", () => {
 
     it("does NOT suppress the updater on non-Store Windows builds (NSIS/Squirrel)", () => {
       Object.defineProperty(process, "platform", { value: "win32", configurable: true });
-      delete (process as NodeJS.Process & { windowsStore?: boolean }).windowsStore;
+      Object.defineProperty(process, "windowsStore", { value: undefined, configurable: true });
 
       autoUpdaterService.initialize();
 

--- a/shared/config/__tests__/distribution.test.ts
+++ b/shared/config/__tests__/distribution.test.ts
@@ -1,21 +1,17 @@
-import { afterEach, beforeEach, describe, expect, it } from "vitest";
+import { afterEach, describe, expect, it } from "vitest";
 import { getRuntimePlatform, isWindowsStoreBuild } from "../distribution.js";
 
-type WindowsStoreProcess = NodeJS.Process & { windowsStore?: boolean };
+type WindowsStoreProcess = Partial<NodeJS.Process & { windowsStore?: boolean }>;
 
 describe("distribution config", () => {
   describe("isWindowsStoreBuild", () => {
     const originalWindowsStore = (process as WindowsStoreProcess).windowsStore;
 
     afterEach(() => {
-      if (originalWindowsStore === undefined) {
-        delete (process as WindowsStoreProcess).windowsStore;
-      } else {
-        Object.defineProperty(process, "windowsStore", {
-          value: originalWindowsStore,
-          configurable: true,
-        });
-      }
+      Object.defineProperty(process, "windowsStore", {
+        value: originalWindowsStore,
+        configurable: true,
+      });
     });
 
     it("returns the explicit override when provided", () => {
@@ -29,7 +25,10 @@ describe("distribution config", () => {
     });
 
     it("returns false when process.windowsStore is undefined (NSIS/Squirrel build)", () => {
-      delete (process as WindowsStoreProcess).windowsStore;
+      Object.defineProperty(process, "windowsStore", {
+        value: undefined,
+        configurable: true,
+      });
       expect(isWindowsStoreBuild()).toBe(false);
     });
 
@@ -43,11 +42,7 @@ describe("distribution config", () => {
     const originalWindow = (globalThis as { window?: unknown }).window;
 
     afterEach(() => {
-      if (originalWindow === undefined) {
-        delete (globalThis as { window?: unknown }).window;
-      } else {
-        (globalThis as { window?: unknown }).window = originalWindow;
-      }
+      (globalThis as { window?: unknown }).window = originalWindow;
     });
 
     it("reads window.electron.isWindowsStoreBuild when window is defined", () => {
@@ -74,7 +69,10 @@ describe("distribution config", () => {
       try {
         expect(isWindowsStoreBuild()).toBe(false);
       } finally {
-        delete (process as WindowsStoreProcess).windowsStore;
+        Object.defineProperty(process, "windowsStore", {
+          value: undefined,
+          configurable: true,
+        });
       }
     });
   });

--- a/shared/config/__tests__/distribution.test.ts
+++ b/shared/config/__tests__/distribution.test.ts
@@ -1,40 +1,97 @@
-import { describe, expect, it } from "vitest";
+import { afterEach, beforeEach, describe, expect, it } from "vitest";
 import { getRuntimePlatform, isWindowsStoreBuild } from "../distribution.js";
 
+type WindowsStoreProcess = NodeJS.Process & { windowsStore?: boolean };
+
 describe("distribution config", () => {
-  it("treats win32 as the Store-managed update channel", () => {
-    expect(isWindowsStoreBuild("win32")).toBe(true);
-  });
+  describe("isWindowsStoreBuild", () => {
+    const originalWindowsStore = (process as WindowsStoreProcess).windowsStore;
 
-  it("keeps macOS and Linux on the in-app updater path", () => {
-    expect(isWindowsStoreBuild("darwin")).toBe(false);
-    expect(isWindowsStoreBuild("linux")).toBe(false);
-  });
-
-  it("falls back to navigator detection when process.platform is not an OS platform", () => {
-    const originalProcess = globalThis.process;
-    const originalNavigator = globalThis.navigator;
-
-    Object.defineProperty(globalThis, "process", {
-      value: { platform: "browser" },
-      configurable: true,
-    });
-    Object.defineProperty(globalThis, "navigator", {
-      value: { platform: "Win32", userAgent: "Mozilla/5.0 (Windows NT 10.0; Win64; x64)" },
-      configurable: true,
+    afterEach(() => {
+      if (originalWindowsStore === undefined) {
+        delete (process as WindowsStoreProcess).windowsStore;
+      } else {
+        Object.defineProperty(process, "windowsStore", {
+          value: originalWindowsStore,
+          configurable: true,
+        });
+      }
     });
 
-    try {
-      expect(getRuntimePlatform()).toBe("win32");
-    } finally {
+    it("returns the explicit override when provided", () => {
+      expect(isWindowsStoreBuild(true)).toBe(true);
+      expect(isWindowsStoreBuild(false)).toBe(false);
+    });
+
+    it("returns true when process.windowsStore is true (MSIX build)", () => {
+      Object.defineProperty(process, "windowsStore", { value: true, configurable: true });
+      expect(isWindowsStoreBuild()).toBe(true);
+    });
+
+    it("returns false when process.windowsStore is undefined (NSIS/Squirrel build)", () => {
+      delete (process as WindowsStoreProcess).windowsStore;
+      expect(isWindowsStoreBuild()).toBe(false);
+    });
+
+    it("returns false when process.windowsStore is false", () => {
+      Object.defineProperty(process, "windowsStore", { value: false, configurable: true });
+      expect(isWindowsStoreBuild()).toBe(false);
+    });
+  });
+
+  describe("isWindowsStoreBuild in renderer context", () => {
+    const originalWindow = (globalThis as { window?: unknown }).window;
+
+    afterEach(() => {
+      if (originalWindow === undefined) {
+        delete (globalThis as { window?: unknown }).window;
+      } else {
+        (globalThis as { window?: unknown }).window = originalWindow;
+      }
+    });
+
+    it("reads window.electron.isWindowsStoreBuild when window is defined", () => {
+      (globalThis as { window?: unknown }).window = { electron: { isWindowsStoreBuild: true } };
+      expect(isWindowsStoreBuild()).toBe(true);
+    });
+
+    it("returns false when window.electron is missing", () => {
+      (globalThis as { window?: unknown }).window = {};
+      expect(isWindowsStoreBuild()).toBe(false);
+    });
+
+    it("returns false when window.electron.isWindowsStoreBuild is false", () => {
+      (globalThis as { window?: unknown }).window = { electron: { isWindowsStoreBuild: false } };
+      expect(isWindowsStoreBuild()).toBe(false);
+    });
+  });
+
+  describe("getRuntimePlatform", () => {
+    it("falls back to navigator detection when process.platform is not an OS platform", () => {
+      const originalProcess = globalThis.process;
+      const originalNavigator = globalThis.navigator;
+
       Object.defineProperty(globalThis, "process", {
-        value: originalProcess,
+        value: { platform: "browser" },
         configurable: true,
       });
       Object.defineProperty(globalThis, "navigator", {
-        value: originalNavigator,
+        value: { platform: "Win32", userAgent: "Mozilla/5.0 (Windows NT 10.0; Win64; x64)" },
         configurable: true,
       });
-    }
+
+      try {
+        expect(getRuntimePlatform()).toBe("win32");
+      } finally {
+        Object.defineProperty(globalThis, "process", {
+          value: originalProcess,
+          configurable: true,
+        });
+        Object.defineProperty(globalThis, "navigator", {
+          value: originalNavigator,
+          configurable: true,
+        });
+      }
+    });
   });
 });

--- a/shared/config/__tests__/distribution.test.ts
+++ b/shared/config/__tests__/distribution.test.ts
@@ -64,6 +64,19 @@ describe("distribution config", () => {
       (globalThis as { window?: unknown }).window = { electron: { isWindowsStoreBuild: false } };
       expect(isWindowsStoreBuild()).toBe(false);
     });
+
+    it("prefers the renderer bridge over process.windowsStore when window is defined", () => {
+      // Renderer bridge says false, but process.windowsStore is true — the
+      // renderer must trust the bridge (which was stamped from the preload's
+      // authoritative read) and not the renderer-side process global.
+      Object.defineProperty(process, "windowsStore", { value: true, configurable: true });
+      (globalThis as { window?: unknown }).window = { electron: { isWindowsStoreBuild: false } };
+      try {
+        expect(isWindowsStoreBuild()).toBe(false);
+      } finally {
+        delete (process as WindowsStoreProcess).windowsStore;
+      }
+    });
   });
 
   describe("getRuntimePlatform", () => {

--- a/shared/config/distribution.ts
+++ b/shared/config/distribution.ts
@@ -22,6 +22,19 @@ export function getRuntimePlatform(): string {
   return "unknown";
 }
 
-export function isWindowsStoreBuild(platform = getRuntimePlatform()): boolean {
-  return platform === "win32";
+export function isWindowsStoreBuild(override?: boolean): boolean {
+  if (override !== undefined) {
+    return override;
+  }
+
+  if (typeof window !== "undefined") {
+    return (window as { electron?: { isWindowsStoreBuild?: boolean } }).electron
+      ?.isWindowsStoreBuild === true;
+  }
+
+  if (typeof process !== "undefined") {
+    return (process as NodeJS.Process & { windowsStore?: boolean }).windowsStore === true;
+  }
+
+  return false;
 }

--- a/shared/config/distribution.ts
+++ b/shared/config/distribution.ts
@@ -28,8 +28,10 @@ export function isWindowsStoreBuild(override?: boolean): boolean {
   }
 
   if (typeof window !== "undefined") {
-    return (window as { electron?: { isWindowsStoreBuild?: boolean } }).electron
-      ?.isWindowsStoreBuild === true;
+    return (
+      (window as { electron?: { isWindowsStoreBuild?: boolean } }).electron?.isWindowsStoreBuild ===
+      true
+    );
   }
 
   if (typeof process !== "undefined") {

--- a/shared/types/ipc/api.ts
+++ b/shared/types/ipc/api.ts
@@ -1442,6 +1442,7 @@ export interface ElectronAPI {
   perf: {
     flushMarks(payload: import("../../perf/marks.js").RendererPerfFlushPayload): void;
   };
+  isWindowsStoreBuild: boolean;
   demo?: {
     moveTo(x: number, y: number, durationMs?: number): Promise<void>;
     moveToSelector(

--- a/src/hooks/__tests__/useMainProcessToastListener.test.tsx
+++ b/src/hooks/__tests__/useMainProcessToastListener.test.tsx
@@ -110,6 +110,8 @@ describe("useMainProcessToastListener", () => {
 
   it("ignores update retry toast actions on Windows Store builds", () => {
     Object.defineProperty(process, "platform", { value: "win32", configurable: true });
+    // eslint-disable-next-line @typescript-eslint/no-explicit-any
+    (window.electron as any).isWindowsStoreBuild = true;
     const checkForUpdatesMock = vi.fn(() => Promise.resolve());
     // eslint-disable-next-line @typescript-eslint/no-explicit-any
     (window.electron as any).update = {

--- a/src/hooks/__tests__/useUpdateListener.test.tsx
+++ b/src/hooks/__tests__/useUpdateListener.test.tsx
@@ -165,6 +165,8 @@ describe("useUpdateListener", () => {
 
   it("does not subscribe to update events on Windows Store builds", () => {
     Object.defineProperty(process, "platform", { value: "win32", configurable: true });
+    // eslint-disable-next-line @typescript-eslint/no-explicit-any
+    (window.electron as any).isWindowsStoreBuild = true;
 
     renderHook(() => useUpdateListener());
 


### PR DESCRIPTION
## Summary

- `isWindowsStoreBuild()` in `shared/config/distribution.ts` was returning `true` for any `win32` platform, not just MSIX-packaged builds — meaning `electron-updater` was silently disabled on non-Store Windows builds
- Fixed by reading `process.windowsStore` (the authoritative MSIX signal) and bridging it to the renderer as a synchronous boolean via `contextBridge`, so all 7 call sites across main and renderer get the correct value without any interface changes
- Strengthened tests to cover all 3 main-process call sites in `AutoUpdaterService` independently and the renderer bridge/`process` precedence

Resolves #7940

## Changes

- `shared/config/distribution.ts` — `isWindowsStoreBuild()` now reads `process.windowsStore` with a `win32` platform guard as a fallback; accepts an optional override for testability
- `shared/types/ipc/api.ts` — adds `windowsStore: boolean` to the preload API surface
- `electron/preload.cts` — bridges `process.windowsStore` to the renderer
- `shared/config/__tests__/distribution.test.ts` — comprehensive coverage of the new logic including `process.windowsStore` precedence
- `electron/services/__tests__/AutoUpdaterService.test.ts` — isolated tests for all 3 guard call sites

## Testing

Unit tests cover the corrected `isWindowsStoreBuild()` behaviour, `process.windowsStore` precedence over platform, and all `AutoUpdaterService` guard paths. No call sites needed updating — the function signature is unchanged.