### PR TITLE
feat(keybindings): add Ctrl+F4 and ContextMenu key Windows shortcuts

### DIFF
--- a/src/hooks/app/__tests__/useCloudSyncWarning.test.tsx
+++ b/src/hooks/app/__tests__/useCloudSyncWarning.test.tsx
@@ -5,6 +5,7 @@ import { renderHook } from "@testing-library/react";
 vi.mock("@/lib/platform", () => ({
   isMac: () => true,
   isLinux: () => false,
+  isWindows: () => false,
 }));
 
 import { useCloudSyncWarning } from "../useCloudSyncWarning";

--- a/src/services/__tests__/KeybindingService.test.ts
+++ b/src/services/__tests__/KeybindingService.test.ts
@@ -1213,4 +1213,88 @@ describe("KeybindingService", () => {
       expect(match?.actionId).toBe("window.zoomIn");
     });
   });
+
+  describe("Windows shortcut conventions — issue #7943", () => {
+    it("registers both Shift+F10 and ContextMenu as defaults for terminal.contextMenu", () => {
+      const combos = DEFAULT_KEYBINDINGS.filter((b) => b.actionId === "terminal.contextMenu").map(
+        (b) => b.combo
+      );
+      expect(combos).toEqual(expect.arrayContaining(["Shift+F10", "ContextMenu"]));
+      expect(combos).toHaveLength(2);
+    });
+
+    it("resolves the ContextMenu key to terminal.contextMenu at runtime", () => {
+      setPlatform("Win32");
+      const service = new KeybindingService();
+      const match = service.findMatchingAction(
+        createKeyboardEvent({ key: "ContextMenu", code: "ContextMenu" })
+      );
+      expect(match?.actionId).toBe("terminal.contextMenu");
+    });
+
+    it("includes Ctrl+F4 entries in DEFAULT_KEYBINDINGS on Win32", async () => {
+      setPlatform("Win32");
+      vi.resetModules();
+      const { DEFAULT_KEYBINDINGS: WIN_BINDINGS } = await import("../defaultKeybindings");
+
+      const closeEntry = WIN_BINDINGS.find(
+        (b) => b.actionId === "terminal.close" && b.combo === "Ctrl+F4"
+      );
+      const portalEntry = WIN_BINDINGS.find(
+        (b) => b.actionId === "portal.closeTab" && b.combo === "Ctrl+F4"
+      );
+
+      expect(closeEntry?.scope).toBe("global");
+      expect(closeEntry?.priority).toBe(10);
+      expect(portalEntry?.scope).toBe("portal");
+      expect(portalEntry?.priority).toBe(20);
+    });
+
+    it("omits Ctrl+F4 entries from DEFAULT_KEYBINDINGS on macOS", async () => {
+      setPlatform("MacIntel");
+      vi.resetModules();
+      const { DEFAULT_KEYBINDINGS: MAC_BINDINGS } = await import("../defaultKeybindings");
+
+      const ctrlF4Entries = MAC_BINDINGS.filter((b) => b.combo === "Ctrl+F4");
+      expect(ctrlF4Entries).toEqual([]);
+    });
+
+    it("resolves Ctrl+F4 to terminal.close in global scope on Win32", async () => {
+      setPlatform("Win32");
+      vi.resetModules();
+      const { KeybindingService: WinKeybindingService } = await import("../KeybindingService");
+
+      const service = new WinKeybindingService();
+      const match = service.findMatchingAction(
+        createKeyboardEvent({ key: "F4", code: "F4", ctrlKey: true })
+      );
+      expect(match?.actionId).toBe("terminal.close");
+    });
+
+    it("resolves Ctrl+F4 to portal.closeTab (priority 20) over terminal.close (priority 10) in portal scope on Win32", async () => {
+      setPlatform("Win32");
+      vi.resetModules();
+      const { KeybindingService: WinKeybindingService } = await import("../KeybindingService");
+
+      const service = new WinKeybindingService();
+      service.setScope("portal");
+      const match = service.findMatchingAction(
+        createKeyboardEvent({ key: "F4", code: "F4", ctrlKey: true })
+      );
+      expect(match?.actionId).toBe("portal.closeTab");
+      expect(match?.priority).toBe(20);
+    });
+
+    it("does NOT resolve Ctrl+F4 to any action on macOS", async () => {
+      setPlatform("MacIntel");
+      vi.resetModules();
+      const { KeybindingService: MacKeybindingService } = await import("../KeybindingService");
+
+      const service = new MacKeybindingService();
+      const match = service.findMatchingAction(
+        createKeyboardEvent({ key: "F4", code: "F4", ctrlKey: true })
+      );
+      expect(match).toBeUndefined();
+    });
+  });
 });

--- a/src/services/defaultKeybindings.ts
+++ b/src/services/defaultKeybindings.ts
@@ -1,6 +1,7 @@
+import { isWindows } from "@/lib/platform";
 import type { KeybindingConfig } from "./keybindingUtils";
 
-export const DEFAULT_KEYBINDINGS: KeybindingConfig[] = [
+const CORE_KEYBINDINGS: KeybindingConfig[] = [
   {
     actionId: "terminal.close",
     combo: "Cmd+W",
@@ -1005,6 +1006,14 @@ export const DEFAULT_KEYBINDINGS: KeybindingConfig[] = [
     description: "Open focused panel context menu",
     category: "Panels",
   },
+  {
+    actionId: "terminal.contextMenu",
+    combo: "ContextMenu",
+    scope: "global",
+    priority: 0,
+    description: "Open focused panel context menu",
+    category: "Panels",
+  },
   // Git write operations (Cmd+K chord prefix)
   {
     actionId: "git.stageAll",
@@ -1055,4 +1064,30 @@ export const DEFAULT_KEYBINDINGS: KeybindingConfig[] = [
     description: "Reset renderers for all sessions in active worktree",
     category: "Worktree Sessions",
   },
+];
+
+const WINDOWS_KEYBINDINGS: KeybindingConfig[] = isWindows()
+  ? [
+      {
+        actionId: "terminal.close",
+        combo: "Ctrl+F4",
+        scope: "global",
+        priority: 10,
+        description: "Close focused terminal",
+        category: "Terminal",
+      },
+      {
+        actionId: "portal.closeTab",
+        combo: "Ctrl+F4",
+        scope: "portal",
+        priority: 20,
+        description: "Close active portal tab",
+        category: "Portal",
+      },
+    ]
+  : [];
+
+export const DEFAULT_KEYBINDINGS: KeybindingConfig[] = [
+  ...CORE_KEYBINDINGS,
+  ...WINDOWS_KEYBINDINGS,
 ];


### PR DESCRIPTION
## Summary

- Adds `Ctrl+F4` as the Windows close-tab shortcut, mirroring the existing `Cmd+W` path: global binding maps to `terminal.close` (priority 10), portal-scoped binding maps to `portal.closeTab` (priority 20). Gated by `isWindows()`.
- Adds the dedicated `ContextMenu` key (the Menu/Application key on Windows keyboards) as an unconditional entry for `terminal.contextMenu` — same action as `Shift+F10`. Display and override work through the keybinding registry; dispatch is already handled in `useGlobalKeybindings` and `XtermAdapter`.
- Refactors the top-level array in `defaultKeybindings.ts` into `CORE_KEYBINDINGS` and `WINDOWS_KEYBINDINGS` to keep platform-specific entries clearly separated.

Resolves #7943

## Changes

- `src/services/defaultKeybindings.ts` — imports `isWindows()`; splits bindings into `CORE_KEYBINDINGS` + `WINDOWS_KEYBINDINGS`; adds `ContextMenu` entry (unconditional) and `Ctrl+F4` entries (Win-only)
- `src/services/__tests__/KeybindingService.test.ts` — 7 new tests covering dual-combo registration, `ContextMenu` key resolution, Win32 inclusion and macOS exclusion of `Ctrl+F4`, global and portal-scoped resolution, and scope priority

## Testing

All 81 existing tests pass. New tests cover:

- Dual-combo registration for `terminal.contextMenu`
- `ContextMenu` key resolves to `terminal.contextMenu`
- `Ctrl+F4` present on Win32, absent on macOS
- `Ctrl+F4` resolves to `terminal.close` in global scope on Win32
- `portal.closeTab` wins via priority in portal scope on Win32