### PR TITLE
feat(terminal): bring Windows agent command-launch to parity with POSIX

### DIFF
--- a/electron/ipc/handlers/terminal/__tests__/commandLaunch.test.ts
+++ b/electron/ipc/handlers/terminal/__tests__/commandLaunch.test.ts
@@ -1,0 +1,163 @@
+import { afterEach, describe, expect, it } from "vitest";
+import { buildCommandLaunchShell } from "../commandLaunch.js";
+
+const originalPlatformDescriptor = Object.getOwnPropertyDescriptor(process, "platform");
+
+function setPlatform(platform: NodeJS.Platform): void {
+  Object.defineProperty(process, "platform", {
+    value: platform,
+    configurable: true,
+  });
+}
+
+function decodePowerShellEncodedCommand(encoded: string): string {
+  return Buffer.from(encoded, "base64").toString("utf16le");
+}
+
+describe("buildCommandLaunchShell", () => {
+  afterEach(() => {
+    if (originalPlatformDescriptor) {
+      Object.defineProperty(process, "platform", originalPlatformDescriptor);
+    }
+  });
+
+  describe("Windows + PowerShell", () => {
+    it("returns -NoLogo -NoExit -EncodedCommand with the command encoded as UTF-16LE base64", () => {
+      setPlatform("win32");
+
+      const result = buildCommandLaunchShell("claude", "pwsh.exe");
+
+      expect(result).not.toBeNull();
+      expect(result?.shell).toBe("pwsh.exe");
+      expect(result?.args.slice(0, 3)).toEqual(["-NoLogo", "-NoExit", "-EncodedCommand"]);
+      expect(result?.args).toHaveLength(4);
+      expect(decodePowerShellEncodedCommand(result!.args[3])).toBe("claude");
+    });
+
+    it("preserves Windows-style paths with spaces verbatim through the base64 payload", () => {
+      setPlatform("win32");
+
+      const command =
+        "claude --mcp-config 'C:\\Users\\Test User\\AppData\\Roaming\\Daintree\\pane.json'";
+      const result = buildCommandLaunchShell(command, "C:\\Program Files\\PowerShell\\7\\pwsh.exe");
+
+      expect(result).not.toBeNull();
+      expect(decodePowerShellEncodedCommand(result!.args[3])).toBe(command);
+    });
+
+    it("preserves paths with embedded apostrophes (PowerShell '' escaping survives intact)", () => {
+      setPlatform("win32");
+
+      const command =
+        "claude --mcp-config 'C:\\Users\\O''Brien\\AppData\\Roaming\\Daintree\\pane.json'";
+      const result = buildCommandLaunchShell(command, "pwsh.exe");
+
+      expect(result).not.toBeNull();
+      // The base64 payload round-trips the exact string; PowerShell parses
+      // '' inside single-quote strings as a literal '.
+      expect(decodePowerShellEncodedCommand(result!.args[3])).toBe(command);
+    });
+
+    it("matches powershell.exe (Windows PowerShell 5.1) the same way as pwsh", () => {
+      setPlatform("win32");
+
+      const result = buildCommandLaunchShell(
+        "claude",
+        "C:\\Windows\\System32\\WindowsPowerShell\\v1.0\\powershell.exe"
+      );
+
+      expect(result).not.toBeNull();
+      expect(result?.args[0]).toBe("-NoLogo");
+      expect(result?.args[1]).toBe("-NoExit");
+      expect(result?.args[2]).toBe("-EncodedCommand");
+    });
+  });
+
+  describe("Windows + cmd.exe", () => {
+    it("returns /K with the command as a single argv element", () => {
+      setPlatform("win32");
+
+      const result = buildCommandLaunchShell("codex", "cmd.exe");
+
+      expect(result).toEqual({ shell: "cmd.exe", args: ["/K", "codex"] });
+    });
+
+    it("passes complex commands with quoting through /K unchanged", () => {
+      setPlatform("win32");
+
+      const command = 'codex --mcp-config "C:\\path\\to\\config.json"';
+      const result = buildCommandLaunchShell(command, "C:\\Windows\\System32\\cmd.exe");
+
+      expect(result?.shell).toBe("C:\\Windows\\System32\\cmd.exe");
+      expect(result?.args).toEqual(["/K", command]);
+    });
+  });
+
+  describe("Windows fallback", () => {
+    it("returns null for unknown Windows shells so the caller falls back to PTY write", () => {
+      setPlatform("win32");
+
+      // git-bash on Windows is not pwsh/powershell/cmd — we don't have a
+      // recognized command-launch path for it, so let the existing PTY-write
+      // fallback handle it rather than guess.
+      expect(buildCommandLaunchShell("claude", "C:\\Program Files\\Git\\bin\\bash.exe")).toBeNull();
+    });
+  });
+
+  describe("POSIX (regression)", () => {
+    it("wraps zsh/bash commands in the trap-wrapped interactive script on Linux", () => {
+      setPlatform("linux");
+
+      const result = buildCommandLaunchShell("claude", "/bin/zsh");
+
+      expect(result).not.toBeNull();
+      expect(result?.shell).toBe("/bin/zsh");
+      expect(result?.args[0]).toBe("-lic");
+      // The script must contain a trap, the command, and an exec of the login shell.
+      expect(result?.args[1]).toContain("trap : INT");
+      expect(result?.args[1]).toContain("claude");
+      expect(result?.args[1]).toContain("exec '/bin/zsh' -l");
+    });
+
+    it("defers the macOS interactive shell with a sleep wrapper", () => {
+      setPlatform("darwin");
+
+      const result = buildCommandLaunchShell("claude", "/bin/zsh");
+
+      expect(result).not.toBeNull();
+      expect(result?.args[0]).toBe("-c");
+      expect(result?.args[1]).toContain("sleep 0.05");
+      expect(result?.args[1]).toContain("exec '/bin/zsh'");
+    });
+
+    it("uses -i -c for plain /bin/sh on Linux", () => {
+      setPlatform("linux");
+
+      const result = buildCommandLaunchShell("claude", "/bin/sh");
+
+      expect(result).not.toBeNull();
+      expect(result?.args.slice(0, 2)).toEqual(["-i", "-c"]);
+      expect(result?.args[2]).toContain("trap : INT");
+    });
+
+    it("returns null for unsupported POSIX shells (e.g. nushell)", () => {
+      setPlatform("linux");
+
+      expect(buildCommandLaunchShell("claude", "/usr/bin/nu")).toBeNull();
+    });
+  });
+
+  describe("common edge cases", () => {
+    it("returns null for empty commands on all platforms", () => {
+      setPlatform("win32");
+      expect(buildCommandLaunchShell("", "pwsh.exe")).toBeNull();
+      expect(buildCommandLaunchShell("", "cmd.exe")).toBeNull();
+
+      setPlatform("linux");
+      expect(buildCommandLaunchShell("", "/bin/zsh")).toBeNull();
+
+      setPlatform("darwin");
+      expect(buildCommandLaunchShell("", "/bin/zsh")).toBeNull();
+    });
+  });
+});

--- a/electron/ipc/handlers/terminal/__tests__/lifecycle.spawn.test.ts
+++ b/electron/ipc/handlers/terminal/__tests__/lifecycle.spawn.test.ts
@@ -359,6 +359,67 @@ describe("terminal spawn handler - projectId resolution", () => {
   });
 });
 
+describe("terminal spawn handler - PTY pool eligibility (#7945 regression guard)", () => {
+  let ptyClient: {
+    spawn: ReturnType<typeof vi.fn>;
+    hasTerminal: ReturnType<typeof vi.fn>;
+    write: ReturnType<typeof vi.fn>;
+  };
+
+  beforeEach(() => {
+    vi.clearAllMocks();
+    ptyClient = {
+      spawn: vi.fn(),
+      hasTerminal: vi.fn(() => false),
+      write: vi.fn(),
+    };
+    mockGetCurrentProject.mockReturnValue({ id: "p1", path: "/tmp", name: "p" });
+    mockGetProjectById.mockReturnValue(null);
+    mockGetProjectSettings.mockResolvedValue({});
+  });
+
+  it("leaves shell undefined in the spawn options for plain terminals so the PTY pool can match", async () => {
+    // The PTY pool gate in `acquirePtyProcess` (terminalSpawn.ts) requires
+    // `!options.shell`. Promoting the renderer-side default into the spawn
+    // options would silently disable the pool for every plain terminal —
+    // including the cost of `where pwsh.exe` PATH probes on Windows.
+    // The renderer-side `getDefaultShell()` fallback that #7945 introduced
+    // is for quoting decisions only; it must not leak into spawnShell.
+    const deps = { ptyClient } as unknown as HandlerDependencies;
+    registerTerminalLifecycleHandlers(deps);
+
+    const handler = getSpawnHandler();
+    await handler({} as Electron.IpcMainInvokeEvent, {
+      cwd: "/tmp",
+      cols: 80,
+      rows: 24,
+    });
+
+    const spawnArgs = ptyClient.spawn.mock.calls[0][1];
+    expect(spawnArgs.shell).toBeUndefined();
+    expect(spawnArgs.command).toBeUndefined();
+  });
+
+  it("passes the explicit shell through to spawn options when one is set", async () => {
+    const deps = { ptyClient } as unknown as HandlerDependencies;
+    registerTerminalLifecycleHandlers(deps);
+
+    const handler = getSpawnHandler();
+    await handler(
+      {} as Electron.IpcMainInvokeEvent,
+      {
+        cwd: "/tmp",
+        cols: 80,
+        rows: 24,
+        shell: "/bin/bash",
+      } as unknown as Parameters<typeof handler>[1]
+    );
+
+    const spawnArgs = ptyClient.spawn.mock.calls[0][1];
+    expect(spawnArgs.shell).toBe("/bin/bash");
+  });
+});
+
 describe("terminal spawn handler - cwd fallback (#5139: worktree is now renderer-owned)", () => {
   let ptyClient: {
     spawn: ReturnType<typeof vi.fn>;

--- a/electron/ipc/handlers/terminal/commandLaunch.ts
+++ b/electron/ipc/handlers/terminal/commandLaunch.ts
@@ -84,10 +84,11 @@ export function buildCommandLaunchShell(
     }
     if (isCmdShell(shell)) {
       // cmd /K runs <command> and then returns to an interactive prompt.
-      // node-pty passes the args array to CreateProcess directly, so we
-      // don't need to re-quote `command` for cmd's parser at this layer —
-      // upstream uses `quoteCommandArg` with cmd-style escaping for any
-      // app-controlled values it spliced in.
+      // node-pty's Windows agent joins the args array into a command-line
+      // string for CreateProcess, and cmd.exe then parses everything after
+      // `/K` — `%VAR%` expansion and `^` escape sequences apply. Upstream
+      // is responsible for embedding only cmd-safe values via
+      // `quoteCommandArg` (double-quote escaping); we do not re-quote here.
       return { shell, args: ["/K", command] };
     }
     return null;

--- a/electron/ipc/handlers/terminal/commandLaunch.ts
+++ b/electron/ipc/handlers/terminal/commandLaunch.ts
@@ -1,0 +1,134 @@
+/**
+ * Build the shell + args that run an agent launch command as shell startup
+ * work instead of typing it into the PTY. Keeping the command out of the
+ * input stream prevents the raw command from echoing across the buffer
+ * before the agent starts, and (on POSIX) lets the launched CLI own the
+ * PTY foreground process group so Ctrl-C reaches the agent.
+ *
+ * The function is pure: given a command string and the configured shell, it
+ * returns the spawn options or `null` to signal "fall back to writing the
+ * command into the PTY." `null` is returned when:
+ *   - the command is empty, or
+ *   - the shell isn't one we know how to launch through (e.g. fish on Linux,
+ *     an unrecognized Windows shell).
+ *
+ * Trust boundary: `command` is interpolated raw into the shell payload. Shell
+ * metacharacters (pipes, redirects, `$(...)`) are intentional — QuickRun and
+ * resource-connect commands rely on them. Defenses upstream:
+ *   (1) TerminalSpawnOptionsSchema rejects control characters at the IPC
+ *       boundary.
+ *   (2) The multiline guard in the spawn handler drops embedded `\n` / `\r`
+ *       as defense-in-depth.
+ *   (3) `WorktreeLifecycleService.substituteVariables` shell-quotes every
+ *       templated fragment via `shellEscapeValue` before it reaches the
+ *       `command` field.
+ * Any new call site that interpolates user-controlled data into `command`
+ * MUST quote the substituted fragment via `quoteCommandArg`, not rely on
+ * this layer.
+ */
+
+import { getDefaultShell } from "../../../services/pty/terminalShell.js";
+import { isCmdShell, isPowerShellShell } from "../../../../shared/utils/shellEscape.js";
+
+const MACOS_COMMAND_LAUNCH_STARTUP_DELAY_SECONDS = "0.05";
+
+function shellQuote(value: string): string {
+  return `'${value.replace(/'/g, "'\\''")}'`;
+}
+
+function supportsPosixCommandLaunchShell(shell: string): boolean {
+  const name = shell.split(/[\\/]/).pop()?.toLowerCase() ?? "";
+  return (
+    name === "zsh" ||
+    name === "bash" ||
+    name === "sh" ||
+    name.endsWith("zsh") ||
+    name.endsWith("bash") ||
+    name.endsWith("sh")
+  );
+}
+
+/**
+ * Encode a PowerShell script as a `-EncodedCommand` payload: UTF-16LE bytes,
+ * Base64-encoded. This sidesteps all quote-nesting through node-pty and
+ * CreateProcess, which is fragile for paths with embedded quotes or
+ * Windows-style backslash escaping. Works identically on pwsh (7+) and
+ * powershell.exe (5.1).
+ */
+function encodePowerShellCommand(script: string): string {
+  return Buffer.from(script, "utf16le").toString("base64");
+}
+
+export function buildCommandLaunchShell(
+  command: string,
+  configuredShell: string | undefined
+): { shell: string; args: string[] } | null {
+  if (command.length === 0) {
+    return null;
+  }
+
+  const shell = configuredShell || getDefaultShell();
+
+  if (process.platform === "win32") {
+    if (isPowerShellShell(shell)) {
+      // -NoExit keeps the shell interactive after the command finishes so the
+      // user can keep working in the same pane. -EncodedCommand takes a
+      // UTF-16LE-Base64 payload, completely bypassing PowerShell's argument
+      // parser and CommandLineToArgvW — quoting inside `command` (paths with
+      // spaces, embedded quotes) survives intact. -NoLogo matches the
+      // banner-free spawn behaviour we use elsewhere.
+      return {
+        shell,
+        args: ["-NoLogo", "-NoExit", "-EncodedCommand", encodePowerShellCommand(command)],
+      };
+    }
+    if (isCmdShell(shell)) {
+      // cmd /K runs <command> and then returns to an interactive prompt.
+      // node-pty passes the args array to CreateProcess directly, so we
+      // don't need to re-quote `command` for cmd's parser at this layer —
+      // upstream uses `quoteCommandArg` with cmd-style escaping for any
+      // app-controlled values it spliced in.
+      return { shell, args: ["/K", command] };
+    }
+    return null;
+  }
+
+  if (!supportsPosixCommandLaunchShell(shell)) {
+    return null;
+  }
+
+  const name = shell.split(/[\\/]/).pop()?.toLowerCase() ?? "";
+  const execInteractiveShell =
+    name.includes("zsh") || name.includes("bash")
+      ? `exec ${shellQuote(shell)} -l`
+      : `exec ${shellQuote(shell)}`;
+
+  // Run the command as interactive shell startup work instead of typing it into
+  // the PTY. This prevents the tail of long absolute launch commands from being
+  // echoed while preserving job control: zsh/bash only move the launched CLI
+  // into the PTY foreground process group when the shell is interactive. The
+  // foreground-pgid detector relies on that, and agent CLIs rely on it for raw
+  // input. The wrapper shell traps SIGINT so Ctrl-C reaches the foreground
+  // agent without killing the wrapper before it can exec the follow-up shell.
+  // Use a no-op trap rather than SIG_IGN so child CLIs don't inherit ignored
+  // SIGINT.
+  const script = `trap : INT\n${command}\ntrap - INT\n${execInteractiveShell}`;
+  const interactiveArgs =
+    name.includes("zsh") || name.includes("bash")
+      ? `-lic ${shellQuote(script)}`
+      : `-i -c ${shellQuote(script)}`;
+  // macOS CI can emit the first shell/agent bytes before node-pty returns
+  // from spawn. Defer the interactive shell by one tick so the PTY data
+  // handoff listener is installed before startup output begins.
+  const args =
+    process.platform === "darwin"
+      ? [
+          "-c",
+          `sleep ${MACOS_COMMAND_LAUNCH_STARTUP_DELAY_SECONDS}\nexec ${shellQuote(shell)} ${interactiveArgs}`,
+        ]
+      : name.includes("zsh") || name.includes("bash")
+        ? ["-lic", script]
+        : ["-i", "-c", script];
+
+  return { shell, args };
+}

--- a/electron/ipc/handlers/terminal/lifecycle.ts
+++ b/electron/ipc/handlers/terminal/lifecycle.ts
@@ -32,83 +32,8 @@ import {
 } from "../../../services/pty/agentSessionHistory.js";
 import { getDefaultShell } from "../../../services/pty/terminalShell.js";
 import { formatErrorMessage } from "../../../../shared/utils/errorMessage.js";
-
-function shellQuote(value: string): string {
-  return `'${value.replace(/'/g, "'\\''")}'`;
-}
-
-const MACOS_COMMAND_LAUNCH_STARTUP_DELAY_SECONDS = "0.05";
-
-function supportsCommandLaunchShell(shell: string): boolean {
-  const name = shell.split(/[\\/]/).pop()?.toLowerCase() ?? "";
-  return (
-    name === "zsh" ||
-    name === "bash" ||
-    name === "sh" ||
-    name.endsWith("zsh") ||
-    name.endsWith("bash") ||
-    name.endsWith("sh")
-  );
-}
-
-// Trust boundary: `command` is interpolated raw into the shell script below.
-// Shell metacharacters (pipes, redirects, env-var expansion, $()) are
-// intentional — QuickRun and resource-connect commands rely on them. Defenses
-// upstream of this point: (1) TerminalSpawnOptionsSchema rejects control
-// characters at the IPC boundary; (2) the multiline guard in the spawn handler
-// drops embedded \n / \r as defense-in-depth; (3) WorktreeLifecycleService.
-// substituteVariables shell-quotes every templated fragment via
-// shellEscapeValue before it reaches the command field. Anyone adding a new
-// call site that interpolates user-controlled data into `command` MUST quote
-// the substituted fragment, not rely on this layer.
-function buildCommandLaunchShell(
-  command: string,
-  configuredShell: string | undefined
-): { shell: string; args: string[] } | null {
-  if (process.platform === "win32" || command.length === 0) {
-    return null;
-  }
-
-  const shell = configuredShell || getDefaultShell();
-  if (!supportsCommandLaunchShell(shell)) {
-    return null;
-  }
-
-  const name = shell.split(/[\\/]/).pop()?.toLowerCase() ?? "";
-  const execInteractiveShell =
-    name.includes("zsh") || name.includes("bash")
-      ? `exec ${shellQuote(shell)} -l`
-      : `exec ${shellQuote(shell)}`;
-
-  // Run the command as interactive shell startup work instead of typing it into
-  // the PTY. This prevents the tail of long absolute launch commands from being
-  // echoed while preserving job control: zsh/bash only move the launched CLI
-  // into the PTY foreground process group when the shell is interactive. The
-  // foreground-pgid detector relies on that, and agent CLIs rely on it for raw
-  // input. The wrapper shell traps SIGINT so Ctrl-C reaches the foreground
-  // agent without killing the wrapper before it can exec the follow-up shell.
-  // Use a no-op trap rather than SIG_IGN so child CLIs don't inherit ignored
-  // SIGINT.
-  const script = `trap : INT\n${command}\ntrap - INT\n${execInteractiveShell}`;
-  const interactiveArgs =
-    name.includes("zsh") || name.includes("bash")
-      ? `-lic ${shellQuote(script)}`
-      : `-i -c ${shellQuote(script)}`;
-  // macOS CI can emit the first shell/agent bytes before node-pty returns
-  // from spawn. Defer the interactive shell by one tick so the PTY data
-  // handoff listener is installed before startup output begins.
-  const args =
-    process.platform === "darwin"
-      ? [
-          "-c",
-          `sleep ${MACOS_COMMAND_LAUNCH_STARTUP_DELAY_SECONDS}\nexec ${shellQuote(shell)} ${interactiveArgs}`,
-        ]
-      : name.includes("zsh") || name.includes("bash")
-        ? ["-lic", script]
-        : ["-i", "-c", script];
-
-  return { shell, args };
-}
+import { quoteCommandArg } from "../../../../shared/utils/shellEscape.js";
+import { buildCommandLaunchShell } from "./commandLaunch.js";
 
 export function registerTerminalLifecycleHandlers(deps: HandlerDependencies): () => void {
   const { ptyClient } = deps;
@@ -231,6 +156,14 @@ export function registerTerminalLifecycleHandlers(deps: HandlerDependencies): ()
     let safeCommand = hasMultilineCommand ? "" : trimmedCommand;
     let spawnEnv: Record<string, string> | undefined = validatedOptions.env;
 
+    // Resolve the target shell early — every command-arg quote below feeds
+    // into `safeCommand`, which will eventually run inside this shell
+    // (POSIX `sh -lic`, PowerShell `-EncodedCommand`, or `cmd /K`). Each
+    // shell parses single/double quotes and backslashes differently, so
+    // quoting must match. `validatedOptions.shell` wins over project
+    // overrides; both fall back to the default shell for the platform.
+    const resolvedShell = validatedOptions.shell || projectShell || getDefaultShell();
+
     // Help-assistant launches arrive with a pre-provisioned session dir whose
     // .mcp.json is already in cwd, baked with the literal session token, and
     // a .claude/settings.json that sets `enableAllProjectMcpServers: true` so
@@ -311,7 +244,7 @@ export function registerTerminalLifecycleHandlers(deps: HandlerDependencies): ()
           );
         }
         if (codexArgs.length > 0) {
-          safeCommand = `${safeCommand} ${codexArgs.map(shellQuote).join(" ")}`;
+          safeCommand = `${safeCommand} ${codexArgs.map((arg) => quoteCommandArg(arg, resolvedShell)).join(" ")}`;
         }
       }
       // Gemini help sessions are pinned to `--approval-mode=plan` (strict
@@ -340,7 +273,8 @@ export function registerTerminalLifecycleHandlers(deps: HandlerDependencies): ()
           .replace(/\s{2,}/g, " ")
           .trim();
         if (geminiArgs.length > 0) {
-          safeCommand = `${safeCommand} ${geminiArgs.map(shellQuote).join(" ")}`.trim();
+          safeCommand =
+            `${safeCommand} ${geminiArgs.map((arg) => quoteCommandArg(arg, resolvedShell)).join(" ")}`.trim();
         }
         // Merge any per-agent env returned by `getGeminiSpawnEnv` into the
         // PTY spawn env. Today this is a no-op (Gemini's MCP isolation is
@@ -375,7 +309,8 @@ export function registerTerminalLifecycleHandlers(deps: HandlerDependencies): ()
           .replace(/\s{2,}/g, " ")
           .trim();
         if (copilotArgs.length > 0) {
-          safeCommand = `${safeCommand} ${copilotArgs.map(shellQuote).join(" ")}`.trim();
+          safeCommand =
+            `${safeCommand} ${copilotArgs.map((arg) => quoteCommandArg(arg, resolvedShell)).join(" ")}`.trim();
         }
       }
 
@@ -426,7 +361,7 @@ export function registerTerminalLifecycleHandlers(deps: HandlerDependencies): ()
               port,
               tier,
             });
-            safeCommand = `${safeCommand} --mcp-config ${shellQuote(configPath)}`;
+            safeCommand = `${safeCommand} --mcp-config ${quoteCommandArg(configPath, resolvedShell)}`;
             spawnEnv = { ...(spawnEnv ?? {}), DAINTREE_MCP_TOKEN: token };
           }
         }
@@ -438,10 +373,10 @@ export function registerTerminalLifecycleHandlers(deps: HandlerDependencies): ()
       }
     }
 
-    // Resolve shell and args: project overrides > spawn options > defaults.
-    // For command launches on POSIX, run the command through the shell's
-    // startup script instead of echoing it into the PTY.
-    const resolvedShell = validatedOptions.shell || projectShell;
+    // Resolve spawn shell and args: project overrides > spawn options >
+    // defaults. For command launches, run the command through the shell's
+    // startup arguments (POSIX `-lic` trap-wrap, PowerShell `-EncodedCommand`,
+    // or cmd `/K`) instead of echoing it into the PTY.
     const commandLaunchShell = buildCommandLaunchShell(safeCommand, resolvedShell);
     const resolvedArgs = commandLaunchShell ? commandLaunchShell.args : projectArgs;
     const spawnShell = commandLaunchShell ? commandLaunchShell.shell : resolvedShell;

--- a/electron/ipc/handlers/terminal/lifecycle.ts
+++ b/electron/ipc/handlers/terminal/lifecycle.ts
@@ -156,13 +156,20 @@ export function registerTerminalLifecycleHandlers(deps: HandlerDependencies): ()
     let safeCommand = hasMultilineCommand ? "" : trimmedCommand;
     let spawnEnv: Record<string, string> | undefined = validatedOptions.env;
 
-    // Resolve the target shell early — every command-arg quote below feeds
-    // into `safeCommand`, which will eventually run inside this shell
-    // (POSIX `sh -lic`, PowerShell `-EncodedCommand`, or `cmd /K`). Each
-    // shell parses single/double quotes and backslashes differently, so
-    // quoting must match. `validatedOptions.shell` wins over project
-    // overrides; both fall back to the default shell for the platform.
-    const resolvedShell = validatedOptions.shell || projectShell || getDefaultShell();
+    // Resolve a shell identity early for quoting decisions only. Every
+    // `quoteCommandArg` call below feeds into `safeCommand`, which will
+    // eventually run inside this shell (POSIX `sh -lic`, PowerShell
+    // `-EncodedCommand`, or `cmd /K`). Each shell parses single/double
+    // quotes and backslashes differently, so quoting must match. We fall
+    // back to `getDefaultShell()` here so the quoter always sees a concrete
+    // shell — even when neither the request nor the project sets one.
+    //
+    // IMPORTANT: this value is *not* what we pass into `ptyClient.spawn`.
+    // For plain terminals the PTY pool only matches when `options.shell` is
+    // undefined (see `acquirePtyProcess` in `terminalSpawn.ts`); promoting
+    // `getDefaultShell()` into the spawn options would silently disable the
+    // pool for every spawn. The spawn-side fallback stays absent below.
+    const quotingShell = validatedOptions.shell || projectShell || getDefaultShell();
 
     // Help-assistant launches arrive with a pre-provisioned session dir whose
     // .mcp.json is already in cwd, baked with the literal session token, and
@@ -244,7 +251,7 @@ export function registerTerminalLifecycleHandlers(deps: HandlerDependencies): ()
           );
         }
         if (codexArgs.length > 0) {
-          safeCommand = `${safeCommand} ${codexArgs.map((arg) => quoteCommandArg(arg, resolvedShell)).join(" ")}`;
+          safeCommand = `${safeCommand} ${codexArgs.map((arg) => quoteCommandArg(arg, quotingShell)).join(" ")}`;
         }
       }
       // Gemini help sessions are pinned to `--approval-mode=plan` (strict
@@ -274,7 +281,7 @@ export function registerTerminalLifecycleHandlers(deps: HandlerDependencies): ()
           .trim();
         if (geminiArgs.length > 0) {
           safeCommand =
-            `${safeCommand} ${geminiArgs.map((arg) => quoteCommandArg(arg, resolvedShell)).join(" ")}`.trim();
+            `${safeCommand} ${geminiArgs.map((arg) => quoteCommandArg(arg, quotingShell)).join(" ")}`.trim();
         }
         // Merge any per-agent env returned by `getGeminiSpawnEnv` into the
         // PTY spawn env. Today this is a no-op (Gemini's MCP isolation is
@@ -310,7 +317,7 @@ export function registerTerminalLifecycleHandlers(deps: HandlerDependencies): ()
           .trim();
         if (copilotArgs.length > 0) {
           safeCommand =
-            `${safeCommand} ${copilotArgs.map((arg) => quoteCommandArg(arg, resolvedShell)).join(" ")}`.trim();
+            `${safeCommand} ${copilotArgs.map((arg) => quoteCommandArg(arg, quotingShell)).join(" ")}`.trim();
         }
       }
 
@@ -361,7 +368,7 @@ export function registerTerminalLifecycleHandlers(deps: HandlerDependencies): ()
               port,
               tier,
             });
-            safeCommand = `${safeCommand} --mcp-config ${quoteCommandArg(configPath, resolvedShell)}`;
+            safeCommand = `${safeCommand} --mcp-config ${quoteCommandArg(configPath, quotingShell)}`;
             spawnEnv = { ...(spawnEnv ?? {}), DAINTREE_MCP_TOKEN: token };
           }
         }
@@ -376,10 +383,15 @@ export function registerTerminalLifecycleHandlers(deps: HandlerDependencies): ()
     // Resolve spawn shell and args: project overrides > spawn options >
     // defaults. For command launches, run the command through the shell's
     // startup arguments (POSIX `-lic` trap-wrap, PowerShell `-EncodedCommand`,
-    // or cmd `/K`) instead of echoing it into the PTY.
-    const commandLaunchShell = buildCommandLaunchShell(safeCommand, resolvedShell);
+    // or cmd `/K`) instead of echoing it into the PTY. Plain terminals
+    // intentionally leave `spawnShell` as the original undefined-when-unset
+    // value (no `getDefaultShell()` fallback) so the PTY pool can match —
+    // see `acquirePtyProcess` in `terminalSpawn.ts`.
+    const commandLaunchShell = buildCommandLaunchShell(safeCommand, quotingShell);
     const resolvedArgs = commandLaunchShell ? commandLaunchShell.args : projectArgs;
-    const spawnShell = commandLaunchShell ? commandLaunchShell.shell : resolvedShell;
+    const spawnShell = commandLaunchShell
+      ? commandLaunchShell.shell
+      : validatedOptions.shell || projectShell;
 
     try {
       // Every terminal is an interactive shell. Agent launches inject their

--- a/electron/services/pty/__tests__/terminalShell.test.ts
+++ b/electron/services/pty/__tests__/terminalShell.test.ts
@@ -32,7 +32,14 @@ describe("getDefaultShellArgs", () => {
     expect(getDefaultShellArgs("/bin/zsh")).toEqual(["-l"]);
   });
 
-  describe("Windows fallback shells (UTF-8 bootstrap)", () => {
+  describe("Windows fallback shells (UTF-8 bootstrap + -NoLogo)", () => {
+    const PS_BOOTSTRAP_ARGS = [
+      "-NoLogo",
+      "-NoExit",
+      "-Command",
+      "[Console]::OutputEncoding = [System.Text.UTF8Encoding]::new($false); $OutputEncoding = [System.Text.UTF8Encoding]::new($false)",
+    ];
+
     it("forces UTF-8 code page for cmd.exe", () => {
       setPlatform("win32");
 
@@ -48,15 +55,10 @@ describe("getDefaultShellArgs", () => {
       ]);
     });
 
-    it("forces UTF-8 console encoding for Windows PowerShell 5.1", () => {
+    it("forces UTF-8 console encoding + suppresses banner for Windows PowerShell 5.1", () => {
       setPlatform("win32");
 
-      expect(getDefaultShellArgs("powershell.exe")).toEqual([
-        "-NoLogo",
-        "-NoExit",
-        "-Command",
-        "[Console]::OutputEncoding = [System.Text.UTF8Encoding]::new($false); $OutputEncoding = [System.Text.UTF8Encoding]::new($false)",
-      ]);
+      expect(getDefaultShellArgs("powershell.exe")).toEqual(PS_BOOTSTRAP_ARGS);
     });
 
     it("forces UTF-8 console encoding for fully-qualified PowerShell path", () => {
@@ -64,43 +66,33 @@ describe("getDefaultShellArgs", () => {
 
       expect(
         getDefaultShellArgs("C:\\Windows\\System32\\WindowsPowerShell\\v1.0\\powershell.exe")
-      ).toEqual([
-        "-NoLogo",
-        "-NoExit",
-        "-Command",
-        "[Console]::OutputEncoding = [System.Text.UTF8Encoding]::new($false); $OutputEncoding = [System.Text.UTF8Encoding]::new($false)",
-      ]);
+      ).toEqual(PS_BOOTSTRAP_ARGS);
+    });
+
+    it("forces UTF-8 console encoding + suppresses banner for pwsh.exe (PowerShell 7+)", () => {
+      // PowerShell 7+ defaults to UTF-8 internally, but [Console]::OutputEncoding
+      // still drives decoding of native tools (git, docker, etc.) — bootstrap
+      // is needed for end-to-end UTF-8 reliability.
+      setPlatform("win32");
+
+      expect(getDefaultShellArgs("pwsh.exe")).toEqual(PS_BOOTSTRAP_ARGS);
+      expect(getDefaultShellArgs("C:\\Program Files\\PowerShell\\7\\pwsh.exe")).toEqual(
+        PS_BOOTSTRAP_ARGS
+      );
     });
 
     it("matches Windows shell basenames case-insensitively", () => {
       setPlatform("win32");
 
       expect(getDefaultShellArgs("CMD.EXE")).toEqual(["/K", "chcp 65001 >NUL"]);
-      expect(getDefaultShellArgs("PowerShell.EXE")).toEqual([
-        "-NoLogo",
-        "-NoExit",
-        "-Command",
-        "[Console]::OutputEncoding = [System.Text.UTF8Encoding]::new($false); $OutputEncoding = [System.Text.UTF8Encoding]::new($false)",
-      ]);
+      expect(getDefaultShellArgs("PowerShell.EXE")).toEqual(PS_BOOTSTRAP_ARGS);
     });
 
-    it("returns no bootstrap args for pwsh.exe (PowerShell 7+ defaults to UTF-8)", () => {
-      setPlatform("win32");
-
-      expect(getDefaultShellArgs("pwsh.exe")).toEqual([]);
-      expect(getDefaultShellArgs("C:\\Program Files\\PowerShell\\7\\pwsh.exe")).toEqual([]);
-    });
-
-    it("returns no args for unrecognized Windows shells", () => {
+    it("returns no args for unrecognized Windows shells (e.g. git-bash, nushell)", () => {
       setPlatform("win32");
 
       expect(getDefaultShellArgs("C:\\tools\\nushell\\nu.exe")).toEqual([]);
-    });
-
-    it("does not misclassify pwsh.exe via substring match against powershell.exe", () => {
-      setPlatform("win32");
-
-      expect(getDefaultShellArgs("pwsh.exe")).toEqual([]);
+      expect(getDefaultShellArgs("C:\\Program Files\\Git\\bin\\bash.exe")).toEqual([]);
     });
   });
 });

--- a/electron/services/pty/terminalShell.ts
+++ b/electron/services/pty/terminalShell.ts
@@ -1,5 +1,6 @@
 import { existsSync } from "fs";
 import { execFileSync } from "child_process";
+import { isPowerShellShell } from "../../../shared/utils/shellEscape.js";
 
 export interface ShellArgsOptions {
   nonInteractive?: boolean;
@@ -57,7 +58,11 @@ export function getDefaultShellArgs(shell: string, _options?: ShellArgsOptions):
     if (basename === "cmd.exe") {
       return ["/K", "chcp 65001 >NUL"];
     }
-    if (basename === "powershell.exe") {
+    // PowerShell 7+ defaults are UTF-8 internally, but [Console]::OutputEncoding
+    // still drives decoding of native tools (git, docker, etc.) — keep the
+    // bootstrap on both pwsh.exe and powershell.exe. -NoLogo suppresses the
+    // startup banner for both. cmd.exe has no equivalent flag.
+    if (isPowerShellShell(shell)) {
       return ["-NoLogo", "-NoExit", "-Command", WINDOWS_PS_UTF8_BOOTSTRAP];
     }
     return [];

--- a/shared/utils/__tests__/shellEscape.test.ts
+++ b/shared/utils/__tests__/shellEscape.test.ts
@@ -1,11 +1,31 @@
-import { describe, it, expect } from "vitest";
+import { afterEach, describe, it, expect } from "vitest";
 import {
   escapeShellArg,
   escapeShellArgOptional,
+  escapeWindowsArg,
   hasShellMetachar,
+  isCmdShell,
+  isPowerShellShell,
   isSafeUnescaped,
   isWindows,
+  quoteCommandArg,
+  quotePowerShellArg,
 } from "../shellEscape.js";
+
+const originalPlatformDescriptor = Object.getOwnPropertyDescriptor(process, "platform");
+
+function setPlatform(platform: NodeJS.Platform): void {
+  Object.defineProperty(process, "platform", {
+    value: platform,
+    configurable: true,
+  });
+}
+
+function restorePlatform(): void {
+  if (originalPlatformDescriptor) {
+    Object.defineProperty(process, "platform", originalPlatformDescriptor);
+  }
+}
 
 describe("shellEscape", () => {
   describe("escapeShellArg - POSIX", () => {
@@ -251,6 +271,162 @@ describe("shellEscape", () => {
       const withNull = "before\0after";
       const escaped = escapeShellArg(withNull, "posix");
       expect(escaped.includes("\0")).toBe(true);
+    });
+  });
+
+  describe("quotePowerShellArg", () => {
+    it("wraps simple strings in single quotes", () => {
+      expect(quotePowerShellArg("hello")).toBe("'hello'");
+      expect(quotePowerShellArg("hello world")).toBe("'hello world'");
+    });
+
+    it("doubles embedded single quotes (PowerShell literal-string escape)", () => {
+      expect(quotePowerShellArg("it's working")).toBe("'it''s working'");
+      expect(quotePowerShellArg("O'Brien")).toBe("'O''Brien'");
+    });
+
+    it("handles paths with spaces and apostrophes", () => {
+      expect(quotePowerShellArg("C:\\Users\\O'Brien\\config.json")).toBe(
+        "'C:\\Users\\O''Brien\\config.json'"
+      );
+    });
+
+    it("leaves double quotes untouched (single-quote literal strings)", () => {
+      expect(quotePowerShellArg('say "hi"')).toBe("'say \"hi\"'");
+    });
+
+    it("handles empty strings", () => {
+      expect(quotePowerShellArg("")).toBe("''");
+    });
+
+    it("handles consecutive single quotes", () => {
+      expect(quotePowerShellArg("''")).toBe("''''''");
+    });
+
+    it("leaves $variable expansion safely literal (single-quote strings don't expand)", () => {
+      expect(quotePowerShellArg("$env:PATH")).toBe("'$env:PATH'");
+    });
+  });
+
+  describe("isPowerShellShell", () => {
+    it("matches pwsh and powershell with .exe", () => {
+      expect(isPowerShellShell("pwsh.exe")).toBe(true);
+      expect(isPowerShellShell("powershell.exe")).toBe(true);
+    });
+
+    it("matches pwsh and powershell without .exe", () => {
+      expect(isPowerShellShell("pwsh")).toBe(true);
+      expect(isPowerShellShell("powershell")).toBe(true);
+    });
+
+    it("matches with mixed case", () => {
+      expect(isPowerShellShell("PowerShell.exe")).toBe(true);
+      expect(isPowerShellShell("PWSH.EXE")).toBe(true);
+    });
+
+    it("matches full Windows paths", () => {
+      expect(isPowerShellShell("C:\\Program Files\\PowerShell\\7\\pwsh.exe")).toBe(true);
+      expect(
+        isPowerShellShell("C:\\Windows\\System32\\WindowsPowerShell\\v1.0\\powershell.exe")
+      ).toBe(true);
+    });
+
+    it("uses basename-exact matching, not substring", () => {
+      // A binary named "powerwash.exe" should NOT match (substring landmine).
+      expect(isPowerShellShell("C:\\tools\\powerwash.exe")).toBe(false);
+      expect(isPowerShellShell("C:\\src\\tools\\bash.exe")).toBe(false);
+    });
+
+    it("does not match cmd or POSIX shells", () => {
+      expect(isPowerShellShell("cmd.exe")).toBe(false);
+      expect(isPowerShellShell("/bin/bash")).toBe(false);
+      expect(isPowerShellShell("/bin/zsh")).toBe(false);
+    });
+  });
+
+  describe("isCmdShell", () => {
+    it("matches cmd.exe and cmd", () => {
+      expect(isCmdShell("cmd.exe")).toBe(true);
+      expect(isCmdShell("cmd")).toBe(true);
+    });
+
+    it("matches full Windows paths", () => {
+      expect(isCmdShell("C:\\Windows\\System32\\cmd.exe")).toBe(true);
+    });
+
+    it("matches mixed case", () => {
+      expect(isCmdShell("CMD.EXE")).toBe(true);
+      expect(isCmdShell("Cmd.exe")).toBe(true);
+    });
+
+    it("uses basename-exact matching, not substring", () => {
+      // Lesson #2398: never substring-match on shell names.
+      expect(isCmdShell("C:\\tools\\cmder\\bin\\bash.exe")).toBe(false);
+      expect(isCmdShell("C:\\src\\command\\bin\\zsh.exe")).toBe(false);
+    });
+
+    it("does not match PowerShell or POSIX shells", () => {
+      expect(isCmdShell("pwsh.exe")).toBe(false);
+      expect(isCmdShell("powershell.exe")).toBe(false);
+      expect(isCmdShell("/bin/bash")).toBe(false);
+    });
+  });
+
+  describe("escapeWindowsArg (exported)", () => {
+    it("is now a public export usable from other modules", () => {
+      expect(escapeWindowsArg("hello")).toBe('"hello"');
+      expect(escapeWindowsArg('say "hi"')).toBe('"say ""hi"""');
+    });
+  });
+
+  describe("quoteCommandArg", () => {
+    afterEach(() => {
+      restorePlatform();
+    });
+
+    it("uses PowerShell single-quote escaping on Windows + pwsh", () => {
+      setPlatform("win32");
+      expect(quoteCommandArg("C:\\Users\\O'Brien\\config.json", "pwsh.exe")).toBe(
+        "'C:\\Users\\O''Brien\\config.json'"
+      );
+    });
+
+    it("uses PowerShell single-quote escaping on Windows + powershell.exe", () => {
+      setPlatform("win32");
+      expect(
+        quoteCommandArg(
+          "hello world",
+          "C:\\Windows\\System32\\WindowsPowerShell\\v1.0\\powershell.exe"
+        )
+      ).toBe("'hello world'");
+    });
+
+    it("uses cmd double-quote escaping on Windows + cmd.exe", () => {
+      setPlatform("win32");
+      expect(quoteCommandArg('say "hi"', "cmd.exe")).toBe('"say ""hi"""');
+      expect(quoteCommandArg("C:\\path\\to\\file.json", "cmd.exe")).toBe(
+        '"C:\\path\\to\\file.json"'
+      );
+    });
+
+    it("falls back to POSIX escaping on Windows for unknown shells", () => {
+      setPlatform("win32");
+      // git-bash on Windows would be /usr/bin/bash — falls through to POSIX.
+      expect(quoteCommandArg("it's working", "/usr/bin/bash")).toBe("'it'\\''s working'");
+    });
+
+    it("uses POSIX escaping on macOS regardless of shell", () => {
+      setPlatform("darwin");
+      expect(quoteCommandArg("it's working", "/bin/zsh")).toBe("'it'\\''s working'");
+      // Even if a Windows-style shell is configured on POSIX (unusual but
+      // not impossible during testing), POSIX wins because process.platform
+      // gates the Windows branches.
+      expect(quoteCommandArg("hello", "pwsh.exe")).toBe("'hello'");
+    });
+
+    it("uses POSIX escaping on Linux", () => {
+      setPlatform("linux");
+      expect(quoteCommandArg("path with spaces", "/bin/bash")).toBe("'path with spaces'");
     });
   });
 

--- a/shared/utils/shellEscape.ts
+++ b/shared/utils/shellEscape.ts
@@ -58,7 +58,7 @@ export function escapeShellArg(arg: string, platform?: "windows" | "posix"): str
  * - Escape internal double quotes by doubling them (" → "")
  * - Backslashes before quotes need special handling
  */
-function escapeWindowsArg(arg: string): string {
+export function escapeWindowsArg(arg: string): string {
   // Replace double quotes with escaped double quotes
   // Windows uses "" to escape a double quote inside a double-quoted string
   let escaped = arg.replace(/"/g, '""');
@@ -73,6 +73,82 @@ function escapeWindowsArg(arg: string): string {
   }
 
   return `"${escaped}"`;
+}
+
+/**
+ * Escapes a string for PowerShell `-Command` / `-EncodedCommand` script input.
+ * Wraps the value in single quotes and escapes embedded single quotes by
+ * doubling them (PowerShell's literal-string escape rule). Single-quoted
+ * PowerShell strings are literal: no variable expansion, no subexpression
+ * evaluation. Use this for values interpolated into a PowerShell script body.
+ *
+ * @example
+ *   quotePowerShellArg("C:\\Users\\O'Brien\\config.json")
+ *   // "'C:\\Users\\O''Brien\\config.json'"
+ */
+export function quotePowerShellArg(arg: string): string {
+  return `'${arg.replace(/'/g, "''")}'`;
+}
+
+/**
+ * Returns true if `shellPath` resolves to a PowerShell host (`pwsh` or
+ * `powershell`, with or without the `.exe` suffix). Basename-exact match —
+ * never substring — so paths like `C:\src\tools\powerwash.exe` don't false-
+ * match. Platform-agnostic: the caller decides whether to gate on Windows.
+ */
+export function isPowerShellShell(shellPath: string): boolean {
+  const name =
+    shellPath
+      .split(/[\\/]/)
+      .pop()
+      ?.toLowerCase()
+      .replace(/\.exe$/, "") ?? "";
+  return name === "pwsh" || name === "powershell";
+}
+
+/**
+ * Returns true if `shellPath` resolves to Windows cmd.exe. Basename-exact
+ * match — never substring — so paths like `C:\tools\cmder\bin\bash.exe`
+ * don't false-match. Platform-agnostic: the caller decides whether to gate
+ * on Windows.
+ */
+export function isCmdShell(shellPath: string): boolean {
+  const name =
+    shellPath
+      .split(/[\\/]/)
+      .pop()
+      ?.toLowerCase()
+      .replace(/\.exe$/, "") ?? "";
+  return name === "cmd";
+}
+
+/**
+ * Platform- and shell-aware quoting for values interpolated into a launch
+ * command string. The returned token is safe to splice into a command line
+ * that will be executed by `shellPath` on `process.platform`:
+ *
+ * - POSIX (any shell): POSIX single-quote escaping.
+ * - Windows + PowerShell (pwsh / powershell): PowerShell single-quote
+ *   escaping (single quotes doubled).
+ * - Windows + cmd.exe: cmd-style double-quote escaping.
+ * - Windows + unknown shell: POSIX-style as a least-bad fallback. Callers
+ *   should validate the shell against {@link isPowerShellShell} /
+ *   {@link isCmdShell} upstream when correctness matters.
+ *
+ * Use this at every site that previously called a hand-rolled POSIX
+ * `shellQuote` to embed an internal app-controlled value (config path,
+ * subcommand flag) into a command that may run on Windows.
+ */
+export function quoteCommandArg(value: string, shellPath: string): string {
+  if (typeof process !== "undefined" && process.platform === "win32") {
+    if (isPowerShellShell(shellPath)) {
+      return quotePowerShellArg(value);
+    }
+    if (isCmdShell(shellPath)) {
+      return escapeWindowsArg(value);
+    }
+  }
+  return escapePosixArg(value);
 }
 
 /**


### PR DESCRIPTION
## Summary

On Windows, agent commands were echoing into the PTY buffer instead of running as shell startup work — so long absolute launch commands would scroll across the buffer before the agent started. This PR fixes that by routing Windows launches through the shell's startup arguments, the same way POSIX uses the interactive shell wrapper.

Resolves #7945

## Changes

- New `commandLaunch.ts` module with `buildCommandLaunchShell` handling Windows PowerShell (`-EncodedCommand` base64 UTF-16LE) and cmd.exe (`/K`), alongside the existing POSIX path
- New quoting helpers in `shellEscape.ts`: `quotePowerShellArg`, `isPowerShellShell`, `isCmdShell`, `quoteCommandArg`; `escapeWindowsArg` also exported for external use
- `getDefaultShellArgs` now emits `-NoLogo` for PowerShell shells so the startup banner doesn't render on every spawn
- Four call sites in `lifecycle.ts` (Codex/Gemini/Copilot args, MCP config path injection) switched to `quoteCommandArg(value, quotingShell)` for correct per-shell quoting
- Critical fix: split `resolvedShell` into `quotingShell` (always concrete for quoting decisions) and `spawnShell` (preserves `undefined`-when-unset semantics) so PTY pool eligibility is preserved for plain terminal spawns

## Testing

- `commandLaunch.test.ts` — decodes the `-EncodedCommand` base64 payload at the byte level to verify quoting survives round-trip through PowerShell and cmd.exe paths; 30+ new cases covering paths with spaces, special characters, and POSIX regression
- Pool eligibility regression guard added to `lifecycle.spawn.test.ts` — confirms that plain terminal spawns still hit the PTY pool after the `quotingShell`/`spawnShell` split
- Shell classifier and PowerShell quoting tests in `shellEscape.test.ts` covering basename-exact matching
- `terminalShell.test.ts` extended with Windows `getDefaultShellArgs` cases
- `npm run check` passes; build passes