### PR TITLE
feat(help-assistant): add dedicated scratch folder for the Daintree Assistant

### DIFF
--- a/electron/ipc/handlers/terminal/__tests__/lifecycle.spawn.test.ts
+++ b/electron/ipc/handlers/terminal/__tests__/lifecycle.spawn.test.ts
@@ -167,6 +167,10 @@ const mockUnbindTerminal = vi.hoisted(() => vi.fn<(terminalId: string) => void>(
 
 const mockGetBypassPermissions = vi.hoisted(() => vi.fn<(token: string) => boolean>(() => false));
 
+const mockGetAssistantScratchEnv = vi.hoisted(() =>
+  vi.fn<(token: string) => Record<string, string> | null>(() => null)
+);
+
 vi.mock("../../../../services/HelpSessionService.js", () => ({
   helpSessionService: {
     validateToken: (token: string) => mockValidateToken(token),
@@ -174,6 +178,7 @@ vi.mock("../../../../services/HelpSessionService.js", () => ({
     getGeminiLaunchArgs: (token: string) => mockGetGeminiLaunchArgs(token),
     getCopilotLaunchArgs: (token: string) => mockGetCopilotLaunchArgs(token),
     getGeminiSpawnEnv: (token: string) => mockGetGeminiSpawnEnv(token),
+    getAssistantScratchEnv: (token: string) => mockGetAssistantScratchEnv(token),
     getBypassPermissions: (token: string) => mockGetBypassPermissions(token),
     markTerminalForToken: (token: string, terminalId: string) =>
       mockMarkTerminalForToken(token, terminalId),
@@ -664,6 +669,8 @@ describe("terminal spawn handler - help session detection (#6524)", () => {
     mockMarkTerminalForToken.mockReset();
     mockMarkTerminalForToken.mockReturnValue(true);
     mockUnbindTerminal.mockReset();
+    mockGetAssistantScratchEnv.mockReset();
+    mockGetAssistantScratchEnv.mockReturnValue(null);
   });
 
   it("skips per-pane MCP injection when DAINTREE_MCP_TOKEN is a valid help token (session-dir owns the .mcp.json)", async () => {
@@ -1515,5 +1522,61 @@ describe("terminal spawn handler - help session detection (#6524)", () => {
     );
 
     expect(mockMarkTerminalForToken).not.toHaveBeenCalled();
+  });
+
+  it("merges DAINTREE_ASSISTANT_SCRATCH_DIR into spawn env for a help launch (#7947)", async () => {
+    mockValidateToken.mockImplementation((token) => (token === "help-token" ? "action" : false));
+    mockGetAssistantScratchEnv.mockImplementation((token) =>
+      token === "help-token"
+        ? { DAINTREE_ASSISTANT_SCRATCH_DIR: "/var/user-data/assistant-scratch/abc/sess-1" }
+        : null
+    );
+
+    const deps = { ptyClient } as unknown as HandlerDependencies;
+    registerTerminalLifecycleHandlers(deps);
+
+    const handler = getSpawnHandler();
+    await handler(
+      {} as Electron.IpcMainInvokeEvent,
+      {
+        cols: 80,
+        rows: 24,
+        cwd: tmpDir,
+        command: "claude",
+        launchAgentId: "claude",
+        env: { DAINTREE_MCP_TOKEN: "help-token" },
+      } as unknown as Parameters<typeof handler>[1]
+    );
+
+    expect(ptyClient.spawn).toHaveBeenCalledTimes(1);
+    const spawnArgs = ptyClient.spawn.mock.calls[0][1];
+    expect(spawnArgs.env?.DAINTREE_ASSISTANT_SCRATCH_DIR).toBe(
+      "/var/user-data/assistant-scratch/abc/sess-1"
+    );
+    // Original env keys (the help token) must be preserved.
+    expect(spawnArgs.env?.DAINTREE_MCP_TOKEN).toBe("help-token");
+  });
+
+  it("does not set DAINTREE_ASSISTANT_SCRATCH_DIR for a non-help launch", async () => {
+    mockValidateToken.mockReturnValue(false);
+
+    const deps = { ptyClient } as unknown as HandlerDependencies;
+    registerTerminalLifecycleHandlers(deps);
+
+    const handler = getSpawnHandler();
+    await handler(
+      {} as Electron.IpcMainInvokeEvent,
+      {
+        cols: 80,
+        rows: 24,
+        cwd: tmpDir,
+        command: "claude",
+        launchAgentId: "claude",
+      } as unknown as Parameters<typeof handler>[1]
+    );
+
+    const spawnArgs = ptyClient.spawn.mock.calls[0][1];
+    expect(spawnArgs.env?.DAINTREE_ASSISTANT_SCRATCH_DIR).toBeUndefined();
+    expect(mockGetAssistantScratchEnv).not.toHaveBeenCalled();
   });
 });

--- a/electron/ipc/handlers/terminal/lifecycle.ts
+++ b/electron/ipc/handlers/terminal/lifecycle.ts
@@ -379,6 +379,18 @@ export function registerTerminalLifecycleHandlers(deps: HandlerDependencies): ()
         }
       }
 
+      // Inject the per-session assistant scratch dir into the PTY spawn env
+      // for every help-session agent (Claude, Codex, Gemini, Copilot).
+      // Paired with the markdown addendum written into the session dir at
+      // provision time so the agent has both a literal path in its
+      // instruction surface and an env var for shell substitution. Merged
+      // unconditionally — the path is cleared on every app start and stays
+      // valid for the lifetime of this process.
+      const scratchEnv = helpSessionService.getAssistantScratchEnv(helpToken);
+      if (scratchEnv) {
+        spawnEnv = { ...(spawnEnv ?? {}), ...scratchEnv };
+      }
+
       // Bind this terminalId to the help session so HelpSessionService can
       // kill the PTY when the session is displaced or revoked (#7509). Owns
       // the binding from main-process spawn time, so it doesn't depend on

--- a/electron/main.ts
+++ b/electron/main.ts
@@ -80,6 +80,7 @@ import { initializeCrashRecoveryService } from "./services/CrashRecoveryService.
 import { initializeGpuCrashMonitor } from "./services/GpuCrashMonitorService.js";
 import { initializeTrashedPidCleanup } from "./services/TrashedPidTracker.js";
 import { initializeScratchCleanup } from "./services/ScratchCleanupService.js";
+import { startAssistantScratchCleanup } from "./services/AssistantScratchService.js";
 import { initializeCrashLoopGuard, getCrashLoopGuard } from "./services/CrashLoopGuardService.js";
 import { initializeDatabaseMaintenance } from "./services/DatabaseMaintenanceService.js";
 import { readLastActiveProjectIdSync } from "./services/persistence/readLastProjectId.js";
@@ -172,6 +173,7 @@ if (!gotTheLock) {
   initializeDatabaseMaintenance();
   initializeTrashedPidCleanup();
   initializeScratchCleanup();
+  startAssistantScratchCleanup();
   initializeGpuCrashMonitor();
 
   const windowRegistry = new WindowRegistry();

--- a/electron/services/AssistantScratchService.ts
+++ b/electron/services/AssistantScratchService.ts
@@ -1,0 +1,141 @@
+/**
+ * Dedicated scratch folder for the Daintree Assistant.
+ *
+ * Each agent help session (Claude, Codex, Gemini, Copilot) gets a private
+ * directory under `userData/assistant-scratch/<instanceId>/<sessionId>/` that
+ * it can write to without polluting the project workspace or persisting
+ * across launches. Two design choices keep this safe for concurrent app
+ * instances (smoke tests, e2e harness) and crash recovery:
+ *
+ *   1. **Per-instance subdir** — every main-process boot generates a fresh
+ *      `instanceId` at module load. All scratch dirs from this run live
+ *      under that ID; the boot-time cleanup leaves it alone and removes
+ *      every other top-level entry.
+ *   2. **Filesystem listing IS the ledger** — no DB tracking. Anything on
+ *      disk under the scratch root that doesn't match the current instance
+ *      ID is a stale orphan from a prior boot (or a crashed sibling instance)
+ *      and is eligible for removal.
+ *
+ * Cleanup mirrors the fire-and-forget pattern of `initializeScratchCleanup`:
+ * called once at app boot from `main.ts`, never awaited, never throws — a
+ * locked file from a still-running concurrent instance (`EBUSY`/`EPERM`)
+ * must not block startup. The `fs.rm` retry options
+ * (`maxRetries: 5, retryDelay: 100`) handle transient locks; per-entry
+ * failures are logged and skipped.
+ */
+import fs from "fs/promises";
+import path from "path";
+import { randomUUID } from "node:crypto";
+import { app } from "electron";
+import { logError, logInfo } from "../utils/logger.js";
+
+const SCRATCH_DIR_NAME = "assistant-scratch";
+
+/** Env var injected into the assistant PTY spawn pointing at its scratch dir. */
+export const ASSISTANT_SCRATCH_ENV_VAR = "DAINTREE_ASSISTANT_SCRATCH_DIR";
+
+/**
+ * Stable for the lifetime of the main process. Generated at module load so
+ * any service that imports this module sees the same value and the cleanup
+ * sweep can identify "our" dir without needing it to exist yet.
+ */
+const instanceId = randomUUID();
+
+/** Lazy because `app.getPath('userData')` is only valid once Electron's app module is initialized. */
+export function getAssistantScratchRoot(): string {
+  return path.join(app.getPath("userData"), SCRATCH_DIR_NAME);
+}
+
+/** The current-instance container, parent of every per-session subdir. */
+export function getCurrentInstanceScratchRoot(): string {
+  return path.join(getAssistantScratchRoot(), instanceId);
+}
+
+/**
+ * Path the assistant should write to for a given help-session id. Caller is
+ * responsible for `fs.mkdir({ recursive: true })`-ing this before handing
+ * the path to the agent — the directory does not exist until provisioned.
+ */
+export function getScratchDirForSession(sessionId: string): string {
+  return path.join(getCurrentInstanceScratchRoot(), sessionId);
+}
+
+/** Exposed for the in-process injection helper in `HelpSessionService`. */
+export function getAssistantScratchInstanceId(): string {
+  return instanceId;
+}
+
+interface CleanupResult {
+  /** Top-level entries under the scratch root that were considered. */
+  candidates: number;
+  /** Entries successfully removed (or already absent). */
+  removed: number;
+  /** Entries that failed to remove (logged, not rethrown). */
+  failed: number;
+}
+
+/**
+ * Sweep stale per-instance subdirs from the scratch root. Anything that
+ * isn't the current `instanceId` is considered stale — either a crashed
+ * prior instance, or a concurrent instance that hasn't started its own
+ * sweep yet. The retry options on `fs.rm` (`maxRetries: 5, retryDelay: 100`)
+ * cover the transient-lock case; if a concurrent instance still holds a
+ * file open, the per-entry failure is logged and skipped so the next boot
+ * picks it up.
+ *
+ * Exported for tests. Production callers use {@link startAssistantScratchCleanup}
+ * which discards the result and never throws.
+ */
+export async function runAssistantScratchCleanup(): Promise<CleanupResult> {
+  const result: CleanupResult = { candidates: 0, removed: 0, failed: 0 };
+  const root = getAssistantScratchRoot();
+
+  let entries: string[];
+  try {
+    entries = await fs.readdir(root);
+  } catch (err) {
+    if ((err as NodeJS.ErrnoException).code === "ENOENT") return result;
+    logError("[AssistantScratchCleanup] Failed to read scratch root", err);
+    return result;
+  }
+
+  result.candidates = entries.length;
+  for (const entry of entries) {
+    if (entry === instanceId) continue;
+    const target = path.join(root, entry);
+    try {
+      await fs.rm(target, { recursive: true, force: true, maxRetries: 5, retryDelay: 100 });
+      result.removed += 1;
+    } catch (err) {
+      result.failed += 1;
+      logError(`[AssistantScratchCleanup] Failed to remove ${target}`, err);
+    }
+  }
+
+  if (result.removed > 0 || result.failed > 0) {
+    logInfo(
+      `[AssistantScratchCleanup] sweep complete: ${result.removed} removed, ${result.failed} failed`
+    );
+  }
+
+  return result;
+}
+
+/**
+ * Fire-and-forget entry point invoked from `electron/main.ts` at startup.
+ * Errors are caught and logged; never propagate to the boot path. Also
+ * ensures the current-instance dir exists so callers don't have to race
+ * the first `mkdir` with the cleanup sweep. Returns a Promise that resolves
+ * once both operations complete — production callers can safely discard it;
+ * tests can await it to observe the post-cleanup filesystem state.
+ */
+export function startAssistantScratchCleanup(): Promise<void> {
+  const currentRoot = getCurrentInstanceScratchRoot();
+  const mkdir = fs.mkdir(currentRoot, { recursive: true }).catch((err) => {
+    logError("[AssistantScratchCleanup] Failed to create instance scratch root", err);
+  });
+  const sweep = runAssistantScratchCleanup().catch((err) => {
+    logError("[AssistantScratchCleanup] sweep threw", err);
+  });
+  return Promise.all([mkdir, sweep]).then(() => undefined);
+}

--- a/electron/services/HelpSessionService.ts
+++ b/electron/services/HelpSessionService.ts
@@ -446,7 +446,7 @@ export class HelpSessionService {
     // (rather than being swallowed) because launching with a stale or missing
     // scratch path is worse than a clean provision failure.
     const scratchPath = getScratchDirForSession(sessionId);
-    await fs.mkdir(scratchPath, { recursive: true });
+    await fs.mkdir(scratchPath, { recursive: true, mode: 0o700 });
     await fs.chmod(scratchPath, 0o700).catch(() => {});
 
     // Write the scratch-path addendum to each per-agent markdown file in the

--- a/electron/services/HelpSessionService.ts
+++ b/electron/services/HelpSessionService.ts
@@ -11,6 +11,7 @@ import { probeMcpServer, probeMcpSseServer } from "./mcp-server/readinessProbe.j
 import { getAssistantWiredAgentIds } from "../../shared/config/agentRegistry.js";
 import type { HelpAssistantTier } from "../../shared/types/ipc/maps.js";
 import type { PtyClient } from "./PtyClient.js";
+import { ASSISTANT_SCRATCH_ENV_VAR, getScratchDirForSession } from "./AssistantScratchService.js";
 
 // Narrow type so the test suite (and any future caller) can satisfy this
 // dependency without instantiating a full PtyClient. Only `kill` is needed —
@@ -83,6 +84,13 @@ interface HelpSessionRecord {
   geminiLaunchArgs?: string[];
   /** Computed at provision for copilot sessions; consumed by lifecycle.ts. */
   copilotLaunchArgs?: string[];
+  /**
+   * Per-session scratch directory under
+   * `userData/assistant-scratch/<instanceId>/<sessionId>/`. Cleared on every
+   * app start; injected into the PTY spawn env as `DAINTREE_ASSISTANT_SCRATCH_DIR`
+   * and mentioned in the per-agent CLAUDE.md / AGENTS.md / GEMINI.md addendum.
+   */
+  scratchPath: string;
 }
 
 interface SessionMeta {
@@ -430,6 +438,25 @@ export class HelpSessionService {
     }
     await fs.chmod(sessionPath, 0o700).catch(() => {});
 
+    // Per-session scratch dir under `userData/assistant-scratch/<instanceId>/`.
+    // Cleared on every app start by `AssistantScratchService`. Created
+    // unconditionally outside the template hash gate so the path is always
+    // valid for this provision — agents won't see a missing dir behind the
+    // `DAINTREE_ASSISTANT_SCRATCH_DIR` env var. Failure to create propagates
+    // (rather than being swallowed) because launching with a stale or missing
+    // scratch path is worse than a clean provision failure.
+    const scratchPath = getScratchDirForSession(sessionId);
+    await fs.mkdir(scratchPath, { recursive: true });
+    await fs.chmod(scratchPath, 0o700).catch(() => {});
+
+    // Write the scratch-path addendum to each per-agent markdown file in the
+    // session dir. Unconditional — must run even when the template hash gate
+    // above skips `fs.cp`, otherwise a stale path from a prior session would
+    // persist (`scratchPath` changes every provision because `sessionId` does).
+    // Uses managed markers so re-provision replaces the block in place instead
+    // of accumulating duplicate stanzas.
+    await this.writeScratchAddendum(sessionPath, scratchPath);
+
     const port = await this.getMcpPort(settings.daintreeControl);
     if (input.agentId === "claude") {
       await this.writeMcpConfig(sessionPath, settings, port, token);
@@ -499,6 +526,7 @@ export class HelpSessionService {
       codexLaunchArgs,
       geminiLaunchArgs,
       copilotLaunchArgs,
+      scratchPath,
     };
 
     await this.writeSessionMeta(sessionPath, {
@@ -907,6 +935,22 @@ export class HelpSessionService {
   }
 
   /**
+   * Returns the per-session env vars for the assistant scratch folder.
+   * Injected into the PTY spawn env for every help-session agent — Claude,
+   * Codex, Gemini, and Copilot all read env vars from their PTY parent, so
+   * this single getter covers all four. Pairs with the markdown addendum
+   * written into the session dir at provision time, which tells the agent
+   * to use this dir for any temporary or scratch files. Returns null for
+   * unknown / revoked tokens so the spawn handler skips the merge.
+   */
+  getAssistantScratchEnv(token: string): Record<string, string> | null {
+    if (!token) return null;
+    const record = this.sessionsByToken.get(token);
+    if (!record || record.revoked) return null;
+    return { [ASSISTANT_SCRATCH_ENV_VAR]: record.scratchPath };
+  }
+
+  /**
    * Returns the snapshot of the user's CLI bypass preference taken at
    * provision time. `lifecycle.ts` reads this to decide whether to append
    * `--dangerously-skip-permissions` to the assistant spawn command —
@@ -1207,6 +1251,88 @@ export class HelpSessionService {
         deny: ["Write(**)", "Edit(**)", "MultiEdit(**)", "Bash(**)"],
       },
     };
+  }
+
+  /**
+   * Writes the assistant-scratch addendum block into each per-agent markdown
+   * file in the session dir (`CLAUDE.md`, `AGENTS.md`, `GEMINI.md`). The
+   * block is bracketed by `<!-- DAINTREE_ASSISTANT_SCRATCH_START -->` /
+   * `<!-- DAINTREE_ASSISTANT_SCRATCH_END -->` markers so re-provision replaces
+   * it in place instead of appending duplicates. We write to all three
+   * unconditionally rather than agent-specific because:
+   *
+   *   - The session dir is per-project and reused across launches, so the
+   *     same dir may have been provisioned for a different agent last time.
+   *     A stale addendum in the "wrong" file would point at a now-deleted
+   *     scratch dir (the cleanup sweep nukes prior-instance subdirs every
+   *     boot).
+   *   - The bundled help template has all three files in it anyway, so any
+   *     agent that happens to read the wrong file gets correct guidance.
+   *
+   * Copilot doesn't have a dedicated `COPILOT.md` and currently relies on
+   * env-only injection — recent Copilot CLI does read `AGENTS.md` from cwd,
+   * so the AGENTS.md addendum doubles as Copilot's instruction surface.
+   *
+   * The file MUST already exist (copied by `fs.cp` from the help template).
+   * If the template hash gate skipped the copy but the file is somehow
+   * missing (manual deletion), we log and skip rather than fabricating one.
+   */
+  private async writeScratchAddendum(sessionPath: string, scratchPath: string): Promise<void> {
+    const addendum = this.buildScratchAddendum(scratchPath);
+    const targets = ["CLAUDE.md", "AGENTS.md", "GEMINI.md"];
+    await Promise.all(
+      targets.map((name) =>
+        this.replaceOrAppendScratchBlock(path.join(sessionPath, name), addendum)
+      )
+    );
+  }
+
+  private buildScratchAddendum(scratchPath: string): string {
+    return [
+      "## Assistant Scratch Folder",
+      "",
+      `You have a dedicated scratch folder for any temporary or working files you need to create: \`${scratchPath}\`.`,
+      "",
+      `The same path is available in the environment variable \`${ASSISTANT_SCRATCH_ENV_VAR}\` for use in shell commands.`,
+      "",
+      "Use this folder — not the project workspace, not the system temp dir — for any notes, drafts, intermediate output, or other scratch work. The folder is cleared on every Daintree launch, so don't put anything you want to keep there.",
+      "",
+    ].join("\n");
+  }
+
+  private async replaceOrAppendScratchBlock(filePath: string, addendum: string): Promise<void> {
+    const start = "<!-- DAINTREE_ASSISTANT_SCRATCH_START -->";
+    const end = "<!-- DAINTREE_ASSISTANT_SCRATCH_END -->";
+    const block = `${start}\n${addendum}${end}\n`;
+
+    let existing: string;
+    try {
+      existing = await fs.readFile(filePath, "utf-8");
+    } catch (err) {
+      if ((err as NodeJS.ErrnoException).code === "ENOENT") {
+        console.warn("[HelpSessionService] Scratch addendum target missing; skipping:", filePath);
+        return;
+      }
+      throw err;
+    }
+
+    // Replace existing block if present (preserves surrounding content);
+    // otherwise append with a leading blank line so the marker isn't glued
+    // to the end of the prior section.
+    const startIdx = existing.indexOf(start);
+    const endIdx = existing.indexOf(end);
+    let next: string;
+    if (startIdx !== -1 && endIdx !== -1 && endIdx > startIdx) {
+      const before = existing.slice(0, startIdx);
+      const after = existing.slice(endIdx + end.length).replace(/^\n/, "");
+      next = `${before}${block}${after}`;
+    } else {
+      const separator = existing.endsWith("\n") ? "\n" : "\n\n";
+      next = `${existing}${separator}${block}`;
+    }
+
+    if (next === existing) return;
+    await resilientAtomicWriteFile(filePath, next, "utf-8", { mode: 0o600 });
   }
 
   private async writeSessionMeta(sessionPath: string, meta: SessionMeta): Promise<void> {

--- a/electron/services/__tests__/AssistantScratchService.test.ts
+++ b/electron/services/__tests__/AssistantScratchService.test.ts
@@ -1,5 +1,6 @@
 import { describe, it, expect, beforeEach, afterEach, vi } from "vitest";
 import fs from "fs/promises";
+import { PathLike } from "fs";
 import os from "os";
 import path from "path";
 
@@ -139,7 +140,7 @@ describe("runAssistantScratchCleanup", () => {
     await fs.mkdir(stale, { recursive: true });
 
     const originalRm = fs.rm;
-    const rmSpy = vi.spyOn(fs, "rm").mockImplementation(async (target: fs.PathLike, options) => {
+    const rmSpy = vi.spyOn(fs, "rm").mockImplementation(async (target: PathLike, options) => {
       if (typeof target === "string" && target === stale) {
         const err = new Error("EBUSY") as NodeJS.ErrnoException;
         err.code = "EBUSY";

--- a/electron/services/__tests__/AssistantScratchService.test.ts
+++ b/electron/services/__tests__/AssistantScratchService.test.ts
@@ -1,0 +1,181 @@
+import { describe, it, expect, beforeEach, afterEach, vi } from "vitest";
+import fs from "fs/promises";
+import os from "os";
+import path from "path";
+
+// Mock electron `app.getPath('userData')` to a per-test temp dir so the
+// service's `getAssistantScratchRoot()` resolves under it. The module pins
+// `instanceId` at import time, so we import after the mock is set up.
+const userDataRoot = { current: "" };
+
+vi.mock("electron", () => ({
+  app: {
+    getPath: (key: string) => {
+      if (key === "userData") return userDataRoot.current;
+      throw new Error(`unexpected getPath: ${key}`);
+    },
+  },
+}));
+
+vi.mock("../../utils/logger.js", () => ({
+  logError: vi.fn(),
+  logInfo: vi.fn(),
+}));
+
+let runAssistantScratchCleanup: typeof import("../AssistantScratchService.js").runAssistantScratchCleanup;
+let startAssistantScratchCleanup: typeof import("../AssistantScratchService.js").startAssistantScratchCleanup;
+let getAssistantScratchRoot: typeof import("../AssistantScratchService.js").getAssistantScratchRoot;
+let getCurrentInstanceScratchRoot: typeof import("../AssistantScratchService.js").getCurrentInstanceScratchRoot;
+let getScratchDirForSession: typeof import("../AssistantScratchService.js").getScratchDirForSession;
+let getAssistantScratchInstanceId: typeof import("../AssistantScratchService.js").getAssistantScratchInstanceId;
+
+let tmpDir: string;
+
+beforeEach(async () => {
+  tmpDir = await fs.mkdtemp(path.join(os.tmpdir(), "assistant-scratch-test-"));
+  userDataRoot.current = tmpDir;
+  vi.resetModules();
+  const mod = await import("../AssistantScratchService.js");
+  runAssistantScratchCleanup = mod.runAssistantScratchCleanup;
+  startAssistantScratchCleanup = mod.startAssistantScratchCleanup;
+  getAssistantScratchRoot = mod.getAssistantScratchRoot;
+  getCurrentInstanceScratchRoot = mod.getCurrentInstanceScratchRoot;
+  getScratchDirForSession = mod.getScratchDirForSession;
+  getAssistantScratchInstanceId = mod.getAssistantScratchInstanceId;
+});
+
+afterEach(async () => {
+  await fs.rm(tmpDir, { recursive: true, force: true });
+});
+
+describe("AssistantScratchService paths", () => {
+  it("roots under userData/assistant-scratch", () => {
+    expect(getAssistantScratchRoot()).toBe(path.join(tmpDir, "assistant-scratch"));
+  });
+
+  it("places the current-instance subdir under the root", () => {
+    const instanceId = getAssistantScratchInstanceId();
+    expect(getCurrentInstanceScratchRoot()).toBe(
+      path.join(tmpDir, "assistant-scratch", instanceId)
+    );
+  });
+
+  it("places each session subdir under the current instance", () => {
+    const instanceId = getAssistantScratchInstanceId();
+    expect(getScratchDirForSession("session-a")).toBe(
+      path.join(tmpDir, "assistant-scratch", instanceId, "session-a")
+    );
+  });
+
+  it("uses a stable instance id across calls within a process", () => {
+    const a = getAssistantScratchInstanceId();
+    const b = getAssistantScratchInstanceId();
+    expect(a).toBe(b);
+    expect(a).toMatch(/^[0-9a-f-]{36}$/);
+  });
+});
+
+describe("runAssistantScratchCleanup", () => {
+  it("returns zero candidates when the root does not exist", async () => {
+    const result = await runAssistantScratchCleanup();
+    expect(result.candidates).toBe(0);
+    expect(result.removed).toBe(0);
+    expect(result.failed).toBe(0);
+  });
+
+  it("removes prior-instance subdirs but keeps the current one", async () => {
+    const root = getAssistantScratchRoot();
+    const instanceId = getAssistantScratchInstanceId();
+    await fs.mkdir(path.join(root, instanceId), { recursive: true });
+    const stale1 = path.join(root, "11111111-1111-4111-8111-111111111111");
+    const stale2 = path.join(root, "22222222-2222-4222-8222-222222222222");
+    await fs.mkdir(stale1, { recursive: true });
+    await fs.mkdir(stale2, { recursive: true });
+    await fs.writeFile(path.join(stale1, "scratch.txt"), "old work");
+
+    const result = await runAssistantScratchCleanup();
+
+    expect(result.candidates).toBe(3);
+    expect(result.removed).toBe(2);
+    expect(result.failed).toBe(0);
+    await expect(fs.access(path.join(root, instanceId))).resolves.toBeUndefined();
+    await expect(fs.access(stale1)).rejects.toBeDefined();
+    await expect(fs.access(stale2)).rejects.toBeDefined();
+  });
+
+  it("leaves the root alone when only the current instance dir is present", async () => {
+    const root = getAssistantScratchRoot();
+    const instanceId = getAssistantScratchInstanceId();
+    await fs.mkdir(path.join(root, instanceId), { recursive: true });
+    await fs.writeFile(path.join(root, instanceId, "live.txt"), "live work");
+
+    const result = await runAssistantScratchCleanup();
+
+    expect(result.candidates).toBe(1);
+    expect(result.removed).toBe(0);
+    expect(result.failed).toBe(0);
+    await expect(fs.readFile(path.join(root, instanceId, "live.txt"), "utf-8")).resolves.toBe(
+      "live work"
+    );
+  });
+
+  it("removes loose files at the root that aren't the current instance", async () => {
+    const root = getAssistantScratchRoot();
+    await fs.mkdir(root, { recursive: true });
+    await fs.writeFile(path.join(root, "stray-file"), "not a dir");
+
+    const result = await runAssistantScratchCleanup();
+
+    expect(result.candidates).toBe(1);
+    expect(result.removed).toBe(1);
+    await expect(fs.access(path.join(root, "stray-file"))).rejects.toBeDefined();
+  });
+
+  it("logs and reports per-entry failures without throwing", async () => {
+    const root = getAssistantScratchRoot();
+    const instanceId = getAssistantScratchInstanceId();
+    await fs.mkdir(path.join(root, instanceId), { recursive: true });
+    const stale = path.join(root, "ffffffff-ffff-4fff-8fff-ffffffffffff");
+    await fs.mkdir(stale, { recursive: true });
+
+    const originalRm = fs.rm;
+    const rmSpy = vi.spyOn(fs, "rm").mockImplementation(async (target: fs.PathLike, options) => {
+      if (typeof target === "string" && target === stale) {
+        const err = new Error("EBUSY") as NodeJS.ErrnoException;
+        err.code = "EBUSY";
+        throw err;
+      }
+      return originalRm(target, options);
+    });
+
+    try {
+      const result = await runAssistantScratchCleanup();
+      expect(result.failed).toBe(1);
+      expect(result.removed).toBe(0);
+    } finally {
+      rmSpy.mockRestore();
+    }
+  });
+});
+
+describe("startAssistantScratchCleanup", () => {
+  it("creates the current-instance dir even when nothing exists yet", async () => {
+    await startAssistantScratchCleanup();
+    const root = getAssistantScratchRoot();
+    const instanceId = getAssistantScratchInstanceId();
+    await expect(fs.access(path.join(root, instanceId))).resolves.toBeUndefined();
+  });
+
+  it("does not throw on cleanup errors", async () => {
+    const root = getAssistantScratchRoot();
+    await fs.mkdir(root, { recursive: true });
+    const spy = vi.spyOn(fs, "readdir").mockImplementation(async () => {
+      throw new Error("boom");
+    });
+    try {
+      await expect(startAssistantScratchCleanup()).resolves.toBeUndefined();
+    } finally {
+      spy.mockRestore();
+    }
+  });
+});

--- a/electron/services/__tests__/HelpSessionService.test.ts
+++ b/electron/services/__tests__/HelpSessionService.test.ts
@@ -1636,6 +1636,7 @@ describe("HelpSessionService", () => {
       await fs.mkdir(path.join(altHelp, ".gemini"), { recursive: true });
       // Write in REVERSE order from makeBundledHelpFolder to test stability.
       await fs.writeFile(path.join(altHelp, "GEMINI.md"), "# Gemini Help");
+      await fs.writeFile(path.join(altHelp, "AGENTS.md"), "# Agents Help");
       await fs.writeFile(path.join(altHelp, "CLAUDE.md"), "# Help");
       await fs.writeFile(
         path.join(altHelp, ".gemini", "settings.json"),

--- a/electron/services/__tests__/HelpSessionService.test.ts
+++ b/electron/services/__tests__/HelpSessionService.test.ts
@@ -103,7 +103,22 @@ async function makeBundledHelpFolder(root: string): Promise<string> {
   );
   await fs.writeFile(path.join(helpDir, "CLAUDE.md"), "# Help");
   await fs.writeFile(path.join(helpDir, "GEMINI.md"), "# Gemini Help");
+  await fs.writeFile(path.join(helpDir, "AGENTS.md"), "# Agents Help");
   return helpDir;
+}
+
+/**
+ * Removes the scratch-folder addendum block (#7947) plus its trailing
+ * whitespace from a markdown file body so a template-body equality assertion
+ * can ignore the addendum that `doProvision` appends unconditionally.
+ */
+function stripScratchAddendum(content: string): string {
+  return content
+    .replace(
+      /\n*<!-- DAINTREE_ASSISTANT_SCRATCH_START -->[\s\S]*?<!-- DAINTREE_ASSISTANT_SCRATCH_END -->\n*/,
+      ""
+    )
+    .replace(/\n+$/, "");
 }
 
 describe("HelpSessionService", () => {
@@ -1476,7 +1491,10 @@ describe("HelpSessionService", () => {
       expect(cpSpy).not.toHaveBeenCalled();
 
       const claude = await fs.readFile(path.join(second.sessionPath, "CLAUDE.md"), "utf-8");
-      expect(claude).toBe("# mutated");
+      // The user's session-dir mutation must be preserved across the
+      // hash-gate short-circuit. The scratch-folder addendum is appended
+      // unconditionally outside the gate (#7947) — strip it before checking.
+      expect(stripScratchAddendum(claude)).toBe("# mutated");
       cpSpy.mockRestore();
     });
 
@@ -1494,7 +1512,9 @@ describe("HelpSessionService", () => {
       if (!second) throw new Error("expected second provision");
 
       const claude = await fs.readFile(path.join(second.sessionPath, "CLAUDE.md"), "utf-8");
-      expect(claude).toBe("# Help v2");
+      // Strip the unconditional scratch-folder addendum (#7947) before
+      // comparing against the bundled template body.
+      expect(stripScratchAddendum(claude)).toBe("# Help v2");
 
       const secondStamp = (
         await fs.readFile(path.join(second.sessionPath, ".template-hash"), "utf-8")
@@ -1558,7 +1578,9 @@ describe("HelpSessionService", () => {
       readSpy.mockRestore();
 
       const claude = await fs.readFile(path.join(first.sessionPath, "CLAUDE.md"), "utf-8");
-      expect(claude).toBe("# Help");
+      // Scratch-folder addendum (#7947) is appended unconditionally outside
+      // the hash gate. Strip it to compare against the bundled template body.
+      expect(stripScratchAddendum(claude)).toBe("# Help");
     });
 
     it("rewrites .mcp.json with a fresh bearer on every provision, even when the template copy is skipped", async () => {
@@ -1701,6 +1723,86 @@ describe("HelpSessionService", () => {
       expect(mockMcpServerService.recordTurnOutcome).toHaveBeenCalledWith(
         expect.objectContaining({ outcome: "mcp-not-ready" })
       );
+    });
+  });
+
+  describe("assistant scratch folder", () => {
+    it("creates a per-session scratch dir under userData/assistant-scratch", async () => {
+      const result = await service.provisionSession(provisionInput());
+      if (!result) throw new Error("expected result");
+
+      const expectedRoot = path.join(userData, "assistant-scratch");
+      const stat = await fs.stat(expectedRoot);
+      expect(stat.isDirectory()).toBe(true);
+
+      // The exact path is exposed via getAssistantScratchEnv — verify the
+      // directory it points at exists and lives under the assistant-scratch
+      // root (under a per-instance subdir).
+      const env = service.getAssistantScratchEnv(result.token);
+      expect(env).not.toBeNull();
+      if (!env) throw new Error("expected env");
+      const scratchDir = env.DAINTREE_ASSISTANT_SCRATCH_DIR;
+      expect(scratchDir).toBeDefined();
+      expect(scratchDir.startsWith(expectedRoot + path.sep)).toBe(true);
+      const scratchStat = await fs.stat(scratchDir);
+      expect(scratchStat.isDirectory()).toBe(true);
+    });
+
+    it("exposes DAINTREE_ASSISTANT_SCRATCH_DIR via getAssistantScratchEnv", async () => {
+      const result = await service.provisionSession(provisionInput());
+      if (!result) throw new Error("expected result");
+
+      const env = service.getAssistantScratchEnv(result.token);
+      expect(env).not.toBeNull();
+      expect(env!.DAINTREE_ASSISTANT_SCRATCH_DIR).toMatch(/assistant-scratch/);
+    });
+
+    it("returns null from getAssistantScratchEnv for unknown or revoked tokens", async () => {
+      expect(service.getAssistantScratchEnv("")).toBeNull();
+      expect(service.getAssistantScratchEnv("unknown-token")).toBeNull();
+
+      const result = await service.provisionSession(provisionInput());
+      if (!result) throw new Error("expected result");
+      await service.revokeSession(result.sessionId);
+      expect(service.getAssistantScratchEnv(result.token)).toBeNull();
+    });
+
+    it("writes the scratch-path addendum into CLAUDE.md, AGENTS.md, and GEMINI.md", async () => {
+      const result = await service.provisionSession(provisionInput());
+      if (!result) throw new Error("expected result");
+
+      const env = service.getAssistantScratchEnv(result.token);
+      const scratchDir = env!.DAINTREE_ASSISTANT_SCRATCH_DIR;
+
+      for (const name of ["CLAUDE.md", "AGENTS.md", "GEMINI.md"]) {
+        const content = await fs.readFile(path.join(result.sessionPath, name), "utf-8");
+        expect(content).toContain("<!-- DAINTREE_ASSISTANT_SCRATCH_START -->");
+        expect(content).toContain("<!-- DAINTREE_ASSISTANT_SCRATCH_END -->");
+        expect(content).toContain(scratchDir);
+        expect(content).toContain("DAINTREE_ASSISTANT_SCRATCH_DIR");
+      }
+    });
+
+    it("replaces the managed addendum block on re-provision rather than duplicating it", async () => {
+      const first = await service.provisionSession(provisionInput());
+      if (!first) throw new Error("expected result");
+      const second = await service.provisionSession(provisionInput());
+      if (!second) throw new Error("expected result");
+
+      // The session dir is reused per-project, so both provisions write into
+      // the same CLAUDE.md. The marker block must appear exactly once and
+      // contain the second (current) scratch path — never the first.
+      const claudeMd = await fs.readFile(path.join(second.sessionPath, "CLAUDE.md"), "utf-8");
+      const startMatches = claudeMd.match(/<!-- DAINTREE_ASSISTANT_SCRATCH_START -->/g) ?? [];
+      expect(startMatches).toHaveLength(1);
+
+      const firstEnv = service.getAssistantScratchEnv(first.token);
+      const secondEnv = service.getAssistantScratchEnv(second.token);
+      // First session was displaced (single-backend invariant) — its env
+      // getter returns null; the addendum should reference the live session.
+      expect(firstEnv).toBeNull();
+      expect(secondEnv).not.toBeNull();
+      expect(claudeMd).toContain(secondEnv!.DAINTREE_ASSISTANT_SCRATCH_DIR);
     });
   });
 });


### PR DESCRIPTION
## Summary

- Adds `AssistantScratchService` to manage a per-instance, per-session scratch directory under `userData/assistant-scratch/<instanceId>/<sessionId>/`. Each app instance gets a UUID at module load, so concurrent instances write to isolated subdirs with no collision.
- Boot-time cleanup sweeps stale instance subdirs in the background, tolerating `EBUSY`/`EPERM` errors from files a crashed instance left locked.
- `HelpSessionService.doProvision` creates the scratch dir with mode `0o700`, then writes a managed block into `CLAUDE.md`, `AGENTS.md`, and `GEMINI.md` so agents know to use `DAINTREE_ASSISTANT_SCRATCH_DIR` for temporary work. Re-provision replaces the block rather than duplicating it.
- `lifecycle.ts` injects `DAINTREE_ASSISTANT_SCRATCH_DIR` into the PTY spawn env for every help-session agent (Claude, Codex, Gemini, Copilot).

Resolves #7947

## Changes

- `electron/services/AssistantScratchService.ts` — new service; per-instance UUID, session dir creation (`mkdir` with `0o700`), boot-time GC
- `electron/services/HelpSessionService.ts` — `doProvision` creates scratch dir and writes the managed block addendum
- `electron/ipc/handlers/terminal/lifecycle.ts` — merges `DAINTREE_ASSISTANT_SCRATCH_DIR` into PTY spawn env for help sessions
- `electron/main.ts` — registers `AssistantScratchService` and triggers boot cleanup
- Tests in `electron/services/__tests__/AssistantScratchService.test.ts` and `HelpSessionService.test.ts`; 174/174 vitest pass

## Testing

- Unit tests cover dir creation, GC sweep (lock-tolerant), managed-block write/replace, and env injection
- Typecheck, lint, format, and build all clean