### PR TITLE
fix(layout): complete drop-armed visual on dock receptacles

### DIFF
--- a/src/components/Layout/ContentDock.tsx
+++ b/src/components/Layout/ContentDock.tsx
@@ -273,10 +273,10 @@ export function ContentDock({ density = "normal" }: ContentDockProps) {
             <div
               ref={combinedRef}
               className={cn(
-                "flex items-center gap-[var(--dock-gap)] overflow-x-auto overscroll-x-none flex-1 min-h-[var(--dock-item-height)] no-scrollbar scroll-smooth px-1 transition-colors",
+                "flex items-center gap-[var(--dock-gap)] overflow-x-auto overscroll-x-none flex-1 min-h-[var(--dock-item-height)] no-scrollbar scroll-smooth px-1 transition-[color,background-color,box-shadow]",
                 isPanelDragging && "bg-overlay-subtle",
                 isOver &&
-                  "bg-overlay-soft ring-2 ring-border-default ring-inset rounded-[var(--radius-md)]"
+                  "cursor-copy bg-overlay-soft ring-2 ring-border-default ring-inset rounded-[var(--radius-md)]"
               )}
             >
               <SortableContext

--- a/src/components/Layout/TrashContainer.tsx
+++ b/src/components/Layout/TrashContainer.tsx
@@ -232,7 +232,9 @@ export function TrashContainer({ trashedTerminals, compact = false }: TrashConta
                 className={cn(
                   compact ? "px-1.5 min-w-0" : "px-3",
                   isOpen && "bg-overlay-emphasis border-border-default",
-                  isOver && "cursor-copy bg-overlay-soft ring-2 ring-inset ring-border-default"
+                  isOver &&
+                    isPanelDragging &&
+                    "cursor-copy bg-overlay-soft ring-2 ring-inset ring-border-default"
                 )}
                 aria-haspopup="dialog"
                 aria-expanded={isOpen}

--- a/src/components/Layout/TrashContainer.tsx
+++ b/src/components/Layout/TrashContainer.tsx
@@ -204,7 +204,8 @@ export function TrashContainer({ trashedTerminals, compact = false }: TrashConta
           className={cn(
             compact ? "px-1.5 min-w-0" : "px-3",
             "opacity-70 animate-in fade-in",
-            isOver && "opacity-100 bg-overlay-soft ring-2 ring-inset ring-border-default"
+            isOver &&
+              "cursor-copy opacity-100 bg-overlay-soft ring-2 ring-inset ring-border-default"
           )}
         >
           <Trash2 className="w-3.5 h-3.5 text-daintree-text/60" aria-hidden="true" />
@@ -231,7 +232,7 @@ export function TrashContainer({ trashedTerminals, compact = false }: TrashConta
                 className={cn(
                   compact ? "px-1.5 min-w-0" : "px-3",
                   isOpen && "bg-overlay-emphasis border-border-default",
-                  isOver && "bg-overlay-soft ring-2 ring-inset ring-border-default"
+                  isOver && "cursor-copy bg-overlay-soft ring-2 ring-inset ring-border-default"
                 )}
                 aria-haspopup="dialog"
                 aria-expanded={isOpen}

--- a/src/components/Layout/__tests__/TrashContainer.test.tsx
+++ b/src/components/Layout/__tests__/TrashContainer.test.tsx
@@ -183,6 +183,7 @@ describe("TrashContainer", () => {
     const ghost = getByTestId("trash-container-ghost");
     expect(ghost.className).toContain("bg-overlay-soft");
     expect(ghost.className).toContain("ring-border-default");
+    expect(ghost.className).toContain("cursor-copy");
     expect(ghost.className).not.toContain("daintree-accent");
   });
 
@@ -193,6 +194,7 @@ describe("TrashContainer", () => {
     const pill = getByTestId("trash-container");
     expect(pill.className).toContain("bg-overlay-soft");
     expect(pill.className).toContain("ring-border-default");
+    expect(pill.className).toContain("cursor-copy");
     expect(pill.className).not.toContain("daintree-accent");
   });
 

--- a/src/components/Layout/__tests__/TrashContainer.test.tsx
+++ b/src/components/Layout/__tests__/TrashContainer.test.tsx
@@ -205,6 +205,17 @@ describe("TrashContainer", () => {
     expect(container.innerHTML).toBe("");
   });
 
+  it("does not apply armed classes on populated pill during worktree-sort drags", () => {
+    dndMocks.isDragging = true;
+    dndMocks.isWorktreeSortDragging = true;
+    dndMocks.isOver = true;
+    const { getByTestId } = render(<TrashContainer trashedTerminals={[makeTrashedItem("1")]} />);
+    const pill = getByTestId("trash-container");
+    expect(pill.className).not.toContain("cursor-copy");
+    expect(pill.className).not.toContain("bg-overlay-soft");
+    expect(pill.className).not.toContain("ring-border-default");
+  });
+
   it("does not pulse on initial mount", () => {
     const { container } = render(<TrashContainer trashedTerminals={[makeTrashedItem("1")]} />);
     expect(container.querySelector(".animate-trash-pulse")).toBeNull();


### PR DESCRIPTION
## Summary

- `transition-colors` doesn't cover `box-shadow`, so the inset ring on the dock scroll container was snapping in rather than fading. Replaced with `transition-[color,background-color,box-shadow]` so it respects the Tier 1 150ms timing.
- `cursor-copy` was missing on both receptacles — added on `isOver` for `ContentDock` and for the ghost pill and populated button in `TrashContainer`.
- The populated trash pill was triggering its armed visual during worktree-sort drags. Gated the armed state on `isPanelDragging` so only actual panel drags arm it.

Resolves #7978

## Changes

- `ContentDock.tsx`: widened transition to cover `box-shadow`; added `cursor-copy` on `isOver`
- `TrashContainer.tsx`: added `cursor-copy` on `isOver` for both pill variants; gated populated-pill armed state on `isPanelDragging`
- `TrashContainer.test.tsx`: extended two armed-state tests with `cursor-copy` assertions; added worktree-sort-drag test asserting armed classes are absent on the populated pill

## Testing

15 tests passing in `TrashContainer.test.tsx`. All 6 CI checks pass (typecheck, `check:channels`, `check:ipc`, `check:help`, `lint:ratchet`, `format:check`).