### PR TITLE
fix(toolbar): polish interaction states and severity dot

### DIFF
--- a/src/components/Layout/Toolbar.tsx
+++ b/src/components/Layout/Toolbar.tsx
@@ -884,7 +884,7 @@ export function Toolbar({
                   data-testid="toolbar-overflow-badge"
                   data-severity={severity}
                   data-visible={severity !== null}
-                  className="toolbar-overflow-badge toolbar-badge absolute top-1.5 right-1.5 h-1.5 w-1.5 rounded-full ring-1 ring-daintree-bg/60 pointer-events-none"
+                  className="toolbar-overflow-badge toolbar-badge absolute top-1.5 right-1.5 h-1.5 w-1.5 pointer-events-none"
                 />
               </Button>
             </DropdownMenuTrigger>

--- a/src/components/Layout/__tests__/Toolbar.responsive.test.ts
+++ b/src/components/Layout/__tests__/Toolbar.responsive.test.ts
@@ -118,6 +118,73 @@ describe("Toolbar responsive design — issue #4133", () => {
     });
   });
 
+  describe("toolbar button visual states — issue #7973", () => {
+    it("focus-visible relies on outline alone — no hover background paint", () => {
+      // Block-scan the :focus-visible rule(s) to assert no `background:`
+      // declaration leaks back in (which would make keyboard focus
+      // indistinguishable from mouse hover apart from the ring).
+      const focusBlock = css.match(/\.toolbar-icon-button:focus-visible[\s\S]*?\{[\s\S]*?\}/)?.[0];
+      expect(focusBlock).toBeDefined();
+      expect(focusBlock).toContain("outline: 2px solid var(--theme-accent-primary)");
+      expect(focusBlock).not.toMatch(/\bbackground\b\s*:/);
+    });
+
+    it("armed selectors carry an inset shadow on top of the emphasis background", () => {
+      // The armed selector block must include both background AND box-shadow
+      // so the state reads as anchored/pressed, not "still hovering".
+      const armedBlock = css.match(
+        /\.toolbar-icon-button\[aria-pressed="true"\][\s\S]*?\{[\s\S]*?\}/
+      )?.[0];
+      expect(armedBlock).toBeDefined();
+      expect(armedBlock).toContain("--toolbar-control-armed-bg");
+      expect(armedBlock).toContain("--toolbar-control-armed-shadow");
+      expect(armedBlock).toMatch(/inset\s+0\s+1px\s+2px/);
+    });
+
+    it("press transform is owned by base Button cva, not the toolbar transition list", () => {
+      // The .toolbar-icon-button transition list must NOT include `transform` —
+      // adding it would slow the cva's 1ms press-snap to 150ms.
+      const baseBlock = css.match(
+        /\.toolbar-icon-button,\s*\n\s*\.toolbar-agent-button\s*\{[\s\S]*?\}/
+      )?.[0];
+      expect(baseBlock).toBeDefined();
+      expect(baseBlock).toMatch(/transition:[\s\S]*?;/);
+      const transitionMatch = baseBlock!.match(/transition:[\s\S]*?;/)![0];
+      expect(transitionMatch).not.toContain("transform");
+
+      // The :active rule contributes background only; transform belongs to the cva.
+      const activeBlock = css.match(
+        /\.toolbar-icon-button:active,\s*\n\s*\.toolbar-agent-button:active\s*\{[\s\S]*?\}/
+      )?.[0];
+      expect(activeBlock).toBeDefined();
+      expect(activeBlock).not.toMatch(/transform\s*:\s*scale/);
+    });
+
+    it("overflow severity dot uses a non-color shape differentiator per tier — WCAG 1.4.1", () => {
+      // Tier 1 evidence: each severity owns its own border-radius in CSS, so
+      // critical/warning/info are distinguishable without relying on color.
+      expect(css).toMatch(
+        /\.toolbar-overflow-badge\[data-severity="critical"\][\s\S]*?border-radius:\s*0;/
+      );
+      expect(css).toMatch(
+        /\.toolbar-overflow-badge\[data-severity="warning"\][\s\S]*?border-radius:\s*2px;/
+      );
+      expect(css).toMatch(
+        /\.toolbar-overflow-badge\[data-severity="info"\][\s\S]*?border-radius:\s*9999px;/
+      );
+
+      // Tier 2 evidence: the JSX className must NOT carry `rounded-full` or a
+      // round `ring-*` utility — CSS data-attribute selectors own shape/ring so
+      // they always agree (a round ring on a square dot would look like a bug).
+      const badgeMatch = source.match(
+        /<span[\s\S]*?data-testid="toolbar-overflow-badge"[\s\S]*?\/>/
+      );
+      expect(badgeMatch).toBeDefined();
+      expect(badgeMatch![0]).not.toContain("rounded-full");
+      expect(badgeMatch![0]).not.toMatch(/\bring-\d/);
+    });
+  });
+
   describe("overflow menu focus ring after pointer dismissal — issue #6119", () => {
     it("declares the overflowMenuPointerCloseRef", () => {
       expect(source).toContain("overflowMenuPointerCloseRef");

--- a/src/components/Layout/__tests__/Toolbar.responsive.test.ts
+++ b/src/components/Layout/__tests__/Toolbar.responsive.test.ts
@@ -120,13 +120,18 @@ describe("Toolbar responsive design — issue #4133", () => {
 
   describe("toolbar button visual states — issue #7973", () => {
     it("focus-visible relies on outline alone — no hover background paint", () => {
-      // Block-scan the :focus-visible rule(s) to assert no `background:`
-      // declaration leaks back in (which would make keyboard focus
-      // indistinguishable from mouse hover apart from the ring).
-      const focusBlock = css.match(/\.toolbar-icon-button:focus-visible[\s\S]*?\{[\s\S]*?\}/)?.[0];
-      expect(focusBlock).toBeDefined();
-      expect(focusBlock).toContain("outline: 2px solid var(--theme-accent-primary)");
-      expect(focusBlock).not.toMatch(/\bbackground\b\s*:/);
+      // Adversarial scan: walk every :focus-visible rule that targets a
+      // toolbar button and assert none of them re-introduce a `background`
+      // declaration (which would make keyboard focus indistinguishable from
+      // mouse hover apart from the ring).
+      const focusBlocks = Array.from(
+        css.matchAll(/\.toolbar-(?:icon|agent)-button[^{]*?:focus-visible[^{]*?\{[^}]*?\}/g)
+      ).map((m) => m[0]);
+      expect(focusBlocks.length).toBeGreaterThan(0);
+      for (const block of focusBlocks) {
+        expect(block).toContain("outline: 2px solid var(--theme-accent-primary)");
+        expect(block).not.toMatch(/\bbackground\b\s*:/);
+      }
     });
 
     it("armed selectors carry an inset shadow on top of the emphasis background", () => {
@@ -181,7 +186,10 @@ describe("Toolbar responsive design — issue #4133", () => {
       );
       expect(badgeMatch).toBeDefined();
       expect(badgeMatch![0]).not.toContain("rounded-full");
-      expect(badgeMatch![0]).not.toMatch(/\bring-\d/);
+      // Adversarial: catches both numeric (`ring-1`) and named (`ring-daintree-bg/60`)
+      // forms — a future contributor re-adding either would re-introduce a
+      // round ring that contradicts the CSS shape rules.
+      expect(badgeMatch![0]).not.toContain("ring-");
     });
   });
 

--- a/src/styles/components/toolbar.css
+++ b/src/styles/components/toolbar.css
@@ -24,11 +24,13 @@
 .toolbar-agent-button {
   --_hover-fg: var(--toolbar-control-hover-fg, var(--theme-accent-primary));
   --_hover-shadow: var(--toolbar-control-hover-shadow, none);
+  /* Press-scale is owned by the base Button cva (`active:scale-[0.98] active:duration-[1ms]`),
+   * so transform is intentionally absent from this transition list — adding it would slow
+   * the snap to 150ms and override the cva's intent. */
   transition:
     color 150ms ease,
     background-color 150ms ease,
-    box-shadow 150ms ease,
-    transform 150ms ease;
+    box-shadow 150ms ease;
 }
 
 .toolbar-icon-button:hover {
@@ -44,21 +46,21 @@
   box-shadow: var(--_hover-shadow);
 }
 
-.toolbar-icon-button:focus-visible {
-  outline: 2px solid var(--theme-accent-primary);
-  outline-offset: 2px;
-  background: var(--toolbar-control-hover-bg, var(--theme-overlay-elevated));
-}
-
+/* Keyboard focus reads against the idle surface — the 2px accent outline is the
+ * sole signal. Painting the hover background here makes focus-visible look
+ * identical to mouse hover apart from the ring. */
+.toolbar-icon-button:focus-visible,
 .toolbar-agent-button:focus-visible {
   outline: 2px solid var(--theme-accent-primary);
   outline-offset: 2px;
-  background: var(
-    --toolbar-agent-hover-bg,
-    var(--toolbar-control-hover-bg, var(--theme-overlay-elevated))
-  );
 }
 
+/* Armed state ("anchored" — dropdown open, toggle on) gets an inset shadow on top
+ * of the emphasis background. The inset cue reads as pressed-into-surface and
+ * distinguishes armed from hover (which only differs by an overlay tier). The
+ * accent color is reserved per CLAUDE.md, so the directional cue carries the
+ * signal instead. Comes after :hover in source order so the inset shadow
+ * survives hover-over-armed (equal specificity, later wins). */
 .toolbar-icon-button[aria-pressed="true"],
 .toolbar-icon-button[aria-expanded="true"],
 .toolbar-icon-button[data-state="open"],
@@ -66,11 +68,14 @@
 .toolbar-agent-button[aria-expanded="true"],
 .toolbar-agent-button[data-state="open"] {
   background: var(--toolbar-control-armed-bg, var(--theme-overlay-emphasis));
+  box-shadow: var(--toolbar-control-armed-shadow, inset 0 1px 2px rgba(0, 0, 0, 0.15));
 }
 
+/* The press snap (transform: scale(0.98) at 1ms) comes from the base Button cva.
+ * This rule only contributes the momentary click background for non-armed
+ * buttons. */
 .toolbar-icon-button:active,
 .toolbar-agent-button:active {
-  transform: scale(0.98);
   background: var(--toolbar-control-active-bg, var(--theme-overlay-emphasis));
 }
 
@@ -211,17 +216,28 @@ html[data-shortcut-reveal] .shortcut-reveal-chip {
     transform 120ms ease;
 }
 
+/* WCAG 1.4.1: non-color shape differentiator per tier. Critical reads as a
+ * square (border-radius: 0), warning as a slightly rounded square, info as a
+ * pill — color still carries primary semantic weight but is no longer the sole
+ * cue. The ring (box-shadow) lives here too so shape and ring always match —
+ * a round ring on a square dot would look like a bug. */
 .toolbar-overflow-badge[data-severity="critical"] {
   --overflow-badge-color: var(--color-status-error);
+  border-radius: 0;
+  box-shadow: none;
 }
 
 .toolbar-overflow-badge[data-severity="warning"] {
   --overflow-badge-color: var(--color-state-waiting);
+  border-radius: 2px;
+  box-shadow: 0 0 0 1px rgb(from var(--color-daintree-bg) r g b / 0.6);
 }
 
 .toolbar-overflow-badge[data-severity="info"] {
   --overflow-badge-color: var(--color-daintree-text, #94a3b8);
   opacity: 0.5;
+  border-radius: 9999px;
+  box-shadow: 0 0 0 1px rgb(from var(--color-daintree-bg) r g b / 0.6);
 }
 
 /* ── Problems dot ──


### PR DESCRIPTION
## Summary

- `:focus-visible` no longer paints the hover background — the outline alone signals keyboard focus, keeping it visually distinct from mouse hover
- Armed buttons (`[aria-pressed]`, `[aria-expanded]`, `[data-state=open]`) get an inset `box-shadow` on top of the emphasis background as a directional pressed cue, so the state reads as anchored rather than "still hovering"
- Removes the `transform` conflict with the base `Button` cva so the 1ms press-snap works as intended
- Overflow severity dot gains distinct shapes per tier (`critical` = square, `warning` = `rounded-sm`, `info` = pill) with the ring re-expressed as `box-shadow` so shape and ring always match — fixes the WCAG 1.4.1 color-only differentiator

Resolves #7973

## Changes

- `src/styles/components/toolbar.css` — focus-visible, armed state, transform conflict, severity dot shape/ring
- `src/components/Layout/Toolbar.tsx` — removed `rounded-full` + `ring` utilities from overflow badge (shape now owned by CSS)
- `src/components/Layout/__tests__/Toolbar.responsive.test.ts` — 4 regression tests under "toolbar button visual states — issue #7973"

## Testing

All 24 tests in `Toolbar.responsive.test.ts` pass. Full check suite (typecheck, lint, format, build) clean.