### PR TITLE
fix(trash): cap 'moved to trash' hint repetition and flip popover to LIFO

### DIFF
--- a/src/components/Layout/TrashContainer.tsx
+++ b/src/components/Layout/TrashContainer.tsx
@@ -19,6 +19,8 @@ import type { TrashedTerminal, TrashedTerminalGroupMetadata } from "@/store/slic
 import { TrashBinItem } from "./TrashBinItem";
 import { TrashGroupItem } from "./TrashGroupItem";
 
+const MOVED_HINT_MAX_SHOWS = 3;
+
 interface TrashContainerProps {
   trashedTerminals: Array<{
     terminal: TerminalInstance;
@@ -43,6 +45,7 @@ interface GroupedTrashGroup {
     trashedInfo: TrashedTerminal;
   }>;
   earliestExpiry: number;
+  latestExpiry: number;
   sortKey: number;
 }
 
@@ -53,6 +56,7 @@ export function TrashContainer({ trashedTerminals, compact = false }: TrashConta
   const [isTrashPulsing, setIsTrashPulsing] = useState(false);
   const [showMovedHint, setShowMovedHint] = useState(false);
   const prevLengthRef = useRef(trashedTerminals.length);
+  const hintShowCountRef = useRef(0);
   const { worktreeMap } = useWorktrees();
   // Only show the ghost pill for panel drags — worktree-card sort drags also flip
   // isDragging but cannot drop on trash, and a phantom drop target is misleading.
@@ -69,7 +73,12 @@ export function TrashContainer({ trashedTerminals, compact = false }: TrashConta
       return;
     }
     setIsTrashPulsing(true);
-    setShowMovedHint(true);
+    // Cap the visual coachmark; aria-live still fires below on every close.
+    // Session-scoped — restart gives a fresh teaching window without persistence.
+    if (hintShowCountRef.current < MOVED_HINT_MAX_SHOWS) {
+      hintShowCountRef.current += 1;
+      setShowMovedHint(true);
+    }
     const shortcut = isMac() ? "Cmd+Shift+T" : "Ctrl+Shift+T";
     useAnnouncerStore.getState().announce(`Panel closed — press ${shortcut} to restore`);
   }, [trashedTerminals.length]);
@@ -102,6 +111,7 @@ export function TrashContainer({ trashedTerminals, compact = false }: TrashConta
         metadata: TrashedTerminalGroupMetadata | undefined;
         terminals: Array<{ terminal: TerminalInstance; trashedInfo: TrashedTerminal }>;
         earliestExpiry: number;
+        latestExpiry: number;
       }
     >();
     const singles: Array<{ terminal: TerminalInstance; trashedInfo: TrashedTerminal }> = [];
@@ -113,6 +123,7 @@ export function TrashContainer({ trashedTerminals, compact = false }: TrashConta
         if (existing) {
           existing.terminals.push(item);
           existing.earliestExpiry = Math.min(existing.earliestExpiry, trashedInfo.expiresAt);
+          existing.latestExpiry = Math.max(existing.latestExpiry, trashedInfo.expiresAt);
           if (trashedInfo.groupMetadata) {
             existing.metadata = trashedInfo.groupMetadata;
           }
@@ -121,6 +132,7 @@ export function TrashContainer({ trashedTerminals, compact = false }: TrashConta
             metadata: trashedInfo.groupMetadata,
             terminals: [item],
             earliestExpiry: trashedInfo.expiresAt,
+            latestExpiry: trashedInfo.expiresAt,
           });
         }
       } else {
@@ -140,7 +152,10 @@ export function TrashContainer({ trashedTerminals, compact = false }: TrashConta
           groupMetadata: group.metadata,
           terminals: group.terminals,
           earliestExpiry: group.earliestExpiry,
-          sortKey: group.earliestExpiry,
+          latestExpiry: group.latestExpiry,
+          // earliestExpiry drives the displayed countdown; sortKey uses
+          // latestExpiry so LIFO order reflects most-recent trash time.
+          sortKey: group.latestExpiry,
         });
       } else {
         // Show as individual items if no metadata or single panel
@@ -165,8 +180,8 @@ export function TrashContainer({ trashedTerminals, compact = false }: TrashConta
       });
     }
 
-    // Sort by earliest expiry
-    return items.sort((a, b) => a.sortKey - b.sortKey);
+    // LIFO: newest-trashed item first.
+    return items.sort((a, b) => b.sortKey - a.sortKey);
   }, [trashedTerminals]);
 
   if (trashedTerminals.length === 0 && !isPanelDragging) return null;

--- a/src/components/Layout/__tests__/TrashContainer.test.tsx
+++ b/src/components/Layout/__tests__/TrashContainer.test.tsx
@@ -68,6 +68,23 @@ vi.mock("@/components/DragDrop", () => ({
   TRASH_DROPPABLE_ID: "__trash-droppable__",
 }));
 
+// TrashGroupItem pulls in panel/worktree stores and the second-ticker — mock
+// it to a minimal shape so we can assert TrashContainer's display-ordering
+// logic and prop-passing without the heavy dependency surface.
+vi.mock("../TrashGroupItem", () => ({
+  TrashGroupItem: ({
+    groupRestoreId,
+    earliestExpiry,
+  }: {
+    groupRestoreId: string;
+    earliestExpiry: number;
+  }) => (
+    <div data-testid={`trash-group-item-${groupRestoreId}`} data-earliest={String(earliestExpiry)}>
+      GROUP {groupRestoreId}
+    </div>
+  ),
+}));
+
 function makeTrashedItem(
   id: string,
   expiresAt: number = Date.now() + 10_000
@@ -81,6 +98,44 @@ function makeTrashedItem(
       id,
       expiresAt,
       originalLocation: "grid",
+    },
+  };
+}
+
+function makeGroupAnchor(
+  id: string,
+  groupRestoreId: string,
+  expiresAt: number
+): { terminal: TerminalInstance; trashedInfo: TrashedTerminal } {
+  return {
+    terminal: { id, title: `Terminal ${id}` } as TerminalInstance,
+    trashedInfo: {
+      id,
+      expiresAt,
+      originalLocation: "grid",
+      groupRestoreId,
+      groupMetadata: {
+        panelIds: [id],
+        activeTabId: id,
+        location: "grid",
+        worktreeId: null,
+      },
+    },
+  };
+}
+
+function makeGroupMember(
+  id: string,
+  groupRestoreId: string,
+  expiresAt: number
+): { terminal: TerminalInstance; trashedInfo: TrashedTerminal } {
+  return {
+    terminal: { id, title: `Terminal ${id}` } as TerminalInstance,
+    trashedInfo: {
+      id,
+      expiresAt,
+      originalLocation: "grid",
+      groupRestoreId,
     },
   };
 }
@@ -301,5 +356,31 @@ describe("TrashContainer", () => {
     expect(newerIdx).toBeGreaterThanOrEqual(0);
     expect(olderIdx).toBeGreaterThanOrEqual(0);
     expect(newerIdx).toBeLessThan(olderIdx);
+  });
+
+  it("sorts groups by latestExpiry, not earliestExpiry, when interleaved with singles", () => {
+    // Group's members span expiry [1000, 9000]. A single sits at 5000.
+    // LIFO must use the group's latestExpiry (9000) so the group comes first.
+    const anchor = makeGroupAnchor("g-a", "grp", 1_000);
+    const member = makeGroupMember("g-b", "grp", 9_000);
+    const single = makeTrashedItem("solo", 5_000);
+    const { container } = render(<TrashContainer trashedTerminals={[anchor, member, single]} />);
+
+    const text = container.textContent ?? "";
+    const groupIdx = text.indexOf("GROUP grp");
+    const singleIdx = text.indexOf("Terminal solo");
+    expect(groupIdx).toBeGreaterThanOrEqual(0);
+    expect(singleIdx).toBeGreaterThanOrEqual(0);
+    expect(groupIdx).toBeLessThan(singleIdx);
+  });
+
+  it("passes earliestExpiry (not latestExpiry) to TrashGroupItem for the countdown", () => {
+    const anchor = makeGroupAnchor("g-a", "grp", 1_000);
+    const member = makeGroupMember("g-b", "grp", 9_000);
+    const { getByTestId } = render(<TrashContainer trashedTerminals={[anchor, member]} />);
+
+    // The countdown displayed by TrashGroupItem must use the soonest-to-expire
+    // member; the sortKey/LIFO change must not bleed into this prop.
+    expect(getByTestId("trash-group-item-grp").getAttribute("data-earliest")).toBe("1000");
   });
 });

--- a/src/components/Layout/__tests__/TrashContainer.test.tsx
+++ b/src/components/Layout/__tests__/TrashContainer.test.tsx
@@ -3,6 +3,7 @@ import { describe, it, expect, vi, beforeEach, afterEach } from "vitest";
 import { render, act } from "@testing-library/react";
 import { TrashContainer } from "../TrashContainer";
 import { useAnnouncerStore } from "@/store/accessibilityAnnouncerStore";
+import { UI_TRANSIENT_HINT_DWELL_MS } from "@/lib/animationUtils";
 import type { TerminalInstance } from "@/store";
 import type { TrashedTerminal } from "@/store/slices";
 
@@ -41,7 +42,17 @@ vi.mock("@/components/ui/button", () => ({
 }));
 
 vi.mock("@/components/ui/tooltip", () => ({
-  Tooltip: ({ children }: { children: React.ReactNode }) => <>{children}</>,
+  // Only the controlled (open-prop-driven) Tooltip — i.e. the trash hint —
+  // gets a testable wrapper. Uncontrolled Tooltips inside child components
+  // (TrashBinItem actions) stay transparent.
+  Tooltip: ({ children, open }: { children: React.ReactNode; open?: boolean }) =>
+    open !== undefined ? (
+      <div data-testid="trash-hint-tooltip" data-open={open ? "true" : "false"}>
+        {children}
+      </div>
+    ) : (
+      <>{children}</>
+    ),
   TooltipContent: ({ children }: { children: React.ReactNode }) => <>{children}</>,
   TooltipProvider: ({ children }: { children: React.ReactNode }) => <>{children}</>,
   TooltipTrigger: ({ children }: { children: React.ReactNode }) => <>{children}</>,
@@ -57,7 +68,10 @@ vi.mock("@/components/DragDrop", () => ({
   TRASH_DROPPABLE_ID: "__trash-droppable__",
 }));
 
-function makeTrashedItem(id: string): {
+function makeTrashedItem(
+  id: string,
+  expiresAt: number = Date.now() + 10_000
+): {
   terminal: TerminalInstance;
   trashedInfo: TrashedTerminal;
 } {
@@ -65,7 +79,7 @@ function makeTrashedItem(id: string): {
     terminal: { id, title: `Terminal ${id}` } as TerminalInstance,
     trashedInfo: {
       id,
-      expiresAt: Date.now() + 10_000,
+      expiresAt,
       originalLocation: "grid",
     },
   };
@@ -227,5 +241,65 @@ describe("TrashContainer", () => {
       vi.advanceTimersByTime(300);
     });
     expect(container.querySelector(".animate-trash-pulse")).toBeNull();
+  });
+
+  it("caps the 'Moved to trash' hint after three shows", () => {
+    const items = [makeTrashedItem("1")];
+    const { getByTestId, rerender } = render(<TrashContainer trashedTerminals={items} />);
+
+    // Closes 1, 2, 3: hint shows each time. Advance past dwell between closes
+    // so the previous hint clears and we can assert a fresh open=true.
+    const next = [...items];
+    for (let i = 2; i <= 4; i++) {
+      next.push(makeTrashedItem(String(i)));
+      rerender(<TrashContainer trashedTerminals={next} />);
+      expect(getByTestId("trash-hint-tooltip").getAttribute("data-open")).toBe("true");
+      act(() => {
+        vi.advanceTimersByTime(UI_TRANSIENT_HINT_DWELL_MS + 10);
+      });
+      expect(getByTestId("trash-hint-tooltip").getAttribute("data-open")).toBe("false");
+    }
+
+    // Close 4: cap reached, hint must not re-open.
+    next.push(makeTrashedItem("5"));
+    rerender(<TrashContainer trashedTerminals={next} />);
+    expect(getByTestId("trash-hint-tooltip").getAttribute("data-open")).toBe("false");
+  });
+
+  it("continues announcing on every close after the hint cap is reached", () => {
+    const items = [makeTrashedItem("1")];
+    const { rerender } = render(<TrashContainer trashedTerminals={items} />);
+
+    // Burn through the cap (3 closes), advancing dwell between each.
+    const next = [...items];
+    for (let i = 2; i <= 4; i++) {
+      next.push(makeTrashedItem(String(i)));
+      rerender(<TrashContainer trashedTerminals={next} />);
+      act(() => {
+        vi.advanceTimersByTime(UI_TRANSIENT_HINT_DWELL_MS + 10);
+      });
+    }
+
+    // Clear announcer and trigger a post-cap close — aria-live must still fire.
+    useAnnouncerStore.setState({ polite: null });
+    next.push(makeTrashedItem("post-cap"));
+    rerender(<TrashContainer trashedTerminals={next} />);
+
+    const { polite } = useAnnouncerStore.getState();
+    expect(polite).not.toBeNull();
+    expect(polite!.msg).toMatch(/Panel closed/);
+  });
+
+  it("renders items in LIFO order (newest-trashed first)", () => {
+    const older = makeTrashedItem("older", 1_000);
+    const newer = makeTrashedItem("newer", 5_000);
+    const { container } = render(<TrashContainer trashedTerminals={[older, newer]} />);
+
+    const text = container.textContent ?? "";
+    const newerIdx = text.indexOf("Terminal newer");
+    const olderIdx = text.indexOf("Terminal older");
+    expect(newerIdx).toBeGreaterThanOrEqual(0);
+    expect(olderIdx).toBeGreaterThanOrEqual(0);
+    expect(newerIdx).toBeLessThan(olderIdx);
   });
 });


### PR DESCRIPTION
## Summary

- Caps the 'Moved to trash' tooltip coachmark at 3 shows per session using a `useRef` counter — the `aria-live` announcer keeps firing on every close so screen-reader users still get the signal every time.
- Flips the popover sort to LIFO: `sortKey` uses `Math.max` over `latestExpiry` so the most recently trashed item sits at the top, while `earliestExpiry` (the countdown display) stays on `Math.min` and is unaffected.

Resolves #7977

## Changes

- `TrashContainer.tsx`: hint-cap counter, decoupled `sortKey`/`earliestExpiry`, descending sort.
- `TrashContainer.test.tsx`: five new tests — hint cap at 3, `aria-live` continues post-cap, LIFO order for singles, group-vs-single interleaving, `earliestExpiry` prop passthrough.

## Testing

All five new cases pass. Ran the existing suite to confirm no regressions.