### PR TITLE
fix(banner): converge banner chrome — extend severity, fix duration drift

### DIFF
--- a/src/components/Terminal/InlineStatusBanner.tsx
+++ b/src/components/Terminal/InlineStatusBanner.tsx
@@ -129,7 +129,7 @@ export function InlineStatusBanner({
       }}
       role={role}
       aria-live={ariaLive}
-      aria-atomic={ariaLive ? "true" : undefined}
+      aria-atomic={ariaLive && ariaLive !== "off" ? "true" : undefined}
     >
       <div className={cn("flex", hasDescription ? "items-start" : "items-center", "gap-2 min-w-0")}>
         <IconComponent

--- a/src/components/Terminal/InlineStatusBanner.tsx
+++ b/src/components/Terminal/InlineStatusBanner.tsx
@@ -19,22 +19,27 @@ export interface BannerAction {
   disabled?: boolean;
 }
 
+export type InlineStatusBannerSeverity = "error" | "warning" | "info" | "success";
+
 export interface InlineStatusBannerProps {
   icon: React.ComponentType<{ className?: string; style?: CSSProperties }>;
   title: React.ReactNode;
   description?: React.ReactNode;
   contextLine?: string;
-  severity?: "error" | "warning";
+  severity?: InlineStatusBannerSeverity;
   animated?: boolean;
   className?: string;
   actions: BannerAction[];
   role?: "alert" | "status";
+  ariaLive?: "off" | "polite" | "assertive";
   onClose?: () => void;
 }
 
-const SEVERITY_VAR: Record<"error" | "warning", string> = {
+const SEVERITY_VAR: Record<InlineStatusBannerSeverity, string> = {
   error: "--color-status-error",
   warning: "--color-status-warning",
+  info: "--color-status-info",
+  success: "--color-status-success",
 };
 
 function getButtonClasses(variant: ButtonVariant): string {
@@ -79,6 +84,7 @@ export function InlineStatusBanner({
   className,
   actions,
   role = "alert",
+  ariaLive,
   onClose,
 }: InlineStatusBannerProps) {
   const prefersReducedMotion =
@@ -113,7 +119,7 @@ export function InlineStatusBanner({
         hasDescription
           ? "flex flex-col gap-2 px-3 py-2 shrink-0"
           : "flex items-center justify-between gap-3 px-3 py-2 shrink-0",
-        shouldAnimate && "transition duration-150",
+        shouldAnimate && "transition duration-250",
         shouldAnimate && (isVisible ? "opacity-100 translate-y-0" : "opacity-0 -translate-y-2"),
         className
       )}
@@ -122,6 +128,8 @@ export function InlineStatusBanner({
         borderBottom: `1px solid color-mix(in oklab, var(${colorVar}) 20%, transparent)`,
       }}
       role={role}
+      aria-live={ariaLive}
+      aria-atomic={ariaLive ? "true" : undefined}
     >
       <div className={cn("flex", hasDescription ? "items-start" : "items-center", "gap-2 min-w-0")}>
         <IconComponent

--- a/src/components/Terminal/TerminalCountWarning.tsx
+++ b/src/components/Terminal/TerminalCountWarning.tsx
@@ -1,6 +1,7 @@
 import { useState, useEffect, useCallback, useRef } from "react";
 import { X, AlertTriangle, Trash2 } from "lucide-react";
 import { cn } from "@/lib/utils";
+import { BANNER_ENTER_DURATION } from "@/lib/animationUtils";
 import { usePanelStore } from "@/store/panelStore";
 import { useShallow } from "zustand/react/shallow";
 import { usePanelLimitStore, shouldShowSoftWarning } from "@/store/panelLimitStore";
@@ -81,7 +82,7 @@ export function TerminalCountWarning({ className, onOpenBulkActions }: TerminalC
       dismissTimeoutRef.current = null;
       dismissSoftWarning(activeCount);
       setIsDismissed(true);
-    }, 200);
+    }, BANNER_ENTER_DURATION);
   }, [activeCount, dismissSoftWarning]);
 
   useEffect(() => {

--- a/src/components/Terminal/TerminalCountWarning.tsx
+++ b/src/components/Terminal/TerminalCountWarning.tsx
@@ -120,7 +120,7 @@ export function TerminalCountWarning({ className, onOpenBulkActions }: TerminalC
         "flex items-center justify-between gap-4 px-4 py-3 rounded-[var(--radius-lg)]",
         "bg-[color-mix(in_oklab,var(--color-status-warning)_12%,transparent)]",
         "border border-status-warning/30",
-        "transition duration-200",
+        "transition duration-250",
         isVisible ? "opacity-100 translate-y-0" : "opacity-0 -translate-y-2",
         className
       )}

--- a/src/components/Terminal/TerminalRestartStatusBanner.tsx
+++ b/src/components/Terminal/TerminalRestartStatusBanner.tsx
@@ -1,5 +1,6 @@
-import { AlertTriangle, RotateCcw } from "lucide-react";
-import { Spinner } from "@/components/ui/Spinner";
+import type { CSSProperties } from "react";
+import { AlertTriangle, Loader2, RotateCcw } from "lucide-react";
+import { cn } from "@/lib/utils";
 import { InlineStatusBanner } from "./InlineStatusBanner";
 import type { RestartBannerVariant } from "./restartStatus";
 
@@ -7,6 +8,16 @@ export interface TerminalRestartStatusBannerProps {
   variant: RestartBannerVariant;
   onRestart: () => void;
   onDismiss: () => void;
+}
+
+function SpinnerIcon({ className, style }: { className?: string; style?: CSSProperties }) {
+  return (
+    <Loader2
+      className={cn("animate-spin motion-reduce:animate-none", className)}
+      style={style}
+      aria-hidden="true"
+    />
+  );
 }
 
 export function TerminalRestartStatusBanner({
@@ -20,15 +31,15 @@ export function TerminalRestartStatusBanner({
 
     case "auto-restarting":
       return (
-        <div
-          className="flex items-center gap-2 px-3 py-1.5 text-xs text-daintree-text/60 bg-status-info/10 border-b border-daintree-border shrink-0"
+        <InlineStatusBanner
+          icon={SpinnerIcon}
+          title="Auto-restarting…"
+          severity="info"
+          animated={false}
           role="status"
-          aria-live="polite"
-          aria-atomic="true"
-        >
-          <Spinner size="xs" className="text-activity-working" />
-          <span>Auto-restarting…</span>
-        </div>
+          ariaLive="polite"
+          actions={[]}
+        />
       );
 
     case "exit-error":

--- a/src/components/Terminal/__tests__/InlineStatusBanner.test.tsx
+++ b/src/components/Terminal/__tests__/InlineStatusBanner.test.tsx
@@ -1,0 +1,136 @@
+// @vitest-environment jsdom
+import { beforeAll, describe, expect, it, vi } from "vitest";
+import { render, screen } from "@testing-library/react";
+import { AlertTriangle, CheckCircle2, Info, XCircle } from "lucide-react";
+import { InlineStatusBanner } from "../InlineStatusBanner";
+
+vi.mock("@/components/ui/tooltip", () => ({
+  Tooltip: ({ children }: { children: React.ReactNode }) => <>{children}</>,
+  TooltipContent: ({ children }: { children: React.ReactNode }) => <>{children}</>,
+  TooltipProvider: ({ children }: { children: React.ReactNode }) => <>{children}</>,
+  TooltipTrigger: ({ children }: { children: React.ReactNode }) => <>{children}</>,
+}));
+
+beforeAll(() => {
+  Object.defineProperty(window, "matchMedia", {
+    writable: true,
+    value: vi.fn().mockImplementation((query: string) => ({
+      matches: false,
+      media: query,
+      onchange: null,
+      addListener: vi.fn(),
+      removeListener: vi.fn(),
+      addEventListener: vi.fn(),
+      removeEventListener: vi.fn(),
+      dispatchEvent: vi.fn(),
+    })),
+  });
+});
+
+describe("InlineStatusBanner", () => {
+  it("defaults to role='alert' and emits no aria-live attribute", () => {
+    render(
+      <InlineStatusBanner
+        icon={XCircle}
+        title="Something broke"
+        severity="error"
+        animated={false}
+        actions={[]}
+      />
+    );
+    const region = screen.getByRole("alert");
+    expect(region.hasAttribute("aria-live")).toBe(false);
+    expect(region.hasAttribute("aria-atomic")).toBe(false);
+  });
+
+  it("renders info severity using the info status token", () => {
+    render(
+      <InlineStatusBanner
+        icon={Info}
+        title="Heads up"
+        severity="info"
+        animated={false}
+        actions={[]}
+      />
+    );
+    const region = screen.getByRole("alert");
+    expect(region.style.backgroundColor).toContain("--color-status-info");
+    expect(region.style.borderBottom).toContain("--color-status-info");
+  });
+
+  it("renders success severity using the success status token", () => {
+    render(
+      <InlineStatusBanner
+        icon={CheckCircle2}
+        title="All set"
+        severity="success"
+        animated={false}
+        actions={[]}
+      />
+    );
+    const region = screen.getByRole("alert");
+    expect(region.style.backgroundColor).toContain("--color-status-success");
+    expect(region.style.borderBottom).toContain("--color-status-success");
+  });
+
+  it("renders warning severity using the warning status token", () => {
+    render(
+      <InlineStatusBanner
+        icon={AlertTriangle}
+        title="Careful"
+        severity="warning"
+        animated={false}
+        actions={[]}
+      />
+    );
+    const region = screen.getByRole("alert");
+    expect(region.style.backgroundColor).toContain("--color-status-warning");
+  });
+
+  it("applies aria-live and aria-atomic when ariaLive is provided", () => {
+    render(
+      <InlineStatusBanner
+        icon={Info}
+        title="Working"
+        severity="info"
+        animated={false}
+        role="status"
+        ariaLive="polite"
+        actions={[]}
+      />
+    );
+    const region = screen.getByRole("status");
+    expect(region.getAttribute("aria-live")).toBe("polite");
+    expect(region.getAttribute("aria-atomic")).toBe("true");
+  });
+
+  it("supports role='status' override", () => {
+    render(
+      <InlineStatusBanner
+        icon={Info}
+        title="Status"
+        severity="info"
+        animated={false}
+        role="status"
+        actions={[]}
+      />
+    );
+    expect(screen.getByRole("status")).toBeTruthy();
+    expect(screen.queryByRole("alert")).toBeNull();
+  });
+
+  it("uses the 250ms entrance duration class when animated", () => {
+    const { container } = render(
+      <InlineStatusBanner
+        icon={Info}
+        title="Animated"
+        severity="info"
+        animated={true}
+        actions={[]}
+      />
+    );
+    const root = container.firstElementChild as HTMLElement;
+    expect(root.className).toContain("duration-250");
+    expect(root.className).not.toContain("duration-150");
+  });
+});

--- a/src/components/Terminal/__tests__/InlineStatusBanner.test.tsx
+++ b/src/components/Terminal/__tests__/InlineStatusBanner.test.tsx
@@ -43,48 +43,40 @@ describe("InlineStatusBanner", () => {
     expect(region.hasAttribute("aria-atomic")).toBe(false);
   });
 
-  it("renders info severity using the info status token", () => {
+  it.each([
+    ["error", XCircle, "--color-status-error"],
+    ["warning", AlertTriangle, "--color-status-warning"],
+    ["info", Info, "--color-status-info"],
+    ["success", CheckCircle2, "--color-status-success"],
+  ] as const)("renders %s severity using its status token", (severity, icon, token) => {
+    render(
+      <InlineStatusBanner
+        icon={icon}
+        title={severity}
+        severity={severity}
+        animated={false}
+        actions={[]}
+      />
+    );
+    const region = screen.getByRole("alert");
+    expect(region.style.backgroundColor).toContain(token);
+    expect(region.style.borderBottom).toContain(token);
+  });
+
+  it("emits aria-live='off' without aria-atomic", () => {
     render(
       <InlineStatusBanner
         icon={Info}
-        title="Heads up"
+        title="Quiet"
         severity="info"
         animated={false}
+        ariaLive="off"
         actions={[]}
       />
     );
     const region = screen.getByRole("alert");
-    expect(region.style.backgroundColor).toContain("--color-status-info");
-    expect(region.style.borderBottom).toContain("--color-status-info");
-  });
-
-  it("renders success severity using the success status token", () => {
-    render(
-      <InlineStatusBanner
-        icon={CheckCircle2}
-        title="All set"
-        severity="success"
-        animated={false}
-        actions={[]}
-      />
-    );
-    const region = screen.getByRole("alert");
-    expect(region.style.backgroundColor).toContain("--color-status-success");
-    expect(region.style.borderBottom).toContain("--color-status-success");
-  });
-
-  it("renders warning severity using the warning status token", () => {
-    render(
-      <InlineStatusBanner
-        icon={AlertTriangle}
-        title="Careful"
-        severity="warning"
-        animated={false}
-        actions={[]}
-      />
-    );
-    const region = screen.getByRole("alert");
-    expect(region.style.backgroundColor).toContain("--color-status-warning");
+    expect(region.getAttribute("aria-live")).toBe("off");
+    expect(region.hasAttribute("aria-atomic")).toBe(false);
   });
 
   it("applies aria-live and aria-atomic when ariaLive is provided", () => {

--- a/src/components/Terminal/__tests__/TerminalCountWarning.test.tsx
+++ b/src/components/Terminal/__tests__/TerminalCountWarning.test.tsx
@@ -133,6 +133,27 @@ describe("TerminalCountWarning", () => {
     expect(className).not.toMatch(/(^|\s)focus:ring-/);
   });
 
+  it("waits the full 250ms exit animation before unmounting on dismiss", () => {
+    vi.useFakeTimers();
+    try {
+      render(<TerminalCountWarning />);
+      const dismissBtn = screen.getByRole("button", { name: /dismiss warning/i });
+      act(() => {
+        fireEvent.click(dismissBtn);
+      });
+      act(() => {
+        vi.advanceTimersByTime(200);
+      });
+      expect(limitState.dismissSoftWarning).not.toHaveBeenCalled();
+      act(() => {
+        vi.advanceTimersByTime(50);
+      });
+      expect(limitState.dismissSoftWarning).toHaveBeenCalledTimes(1);
+    } finally {
+      vi.useRealTimers();
+    }
+  });
+
   it("does not call dismissSoftWarning if unmounted before the dismiss delay fires", () => {
     vi.useFakeTimers();
     try {


### PR DESCRIPTION
## Summary

- Extended `InlineStatusBanner` severity union with `"info"` and `"success"` (theme tokens already existed; the component just didn't expose them)
- Fixed animation duration drift across `InlineStatusBanner` and `TerminalCountWarning` — entrance duration is `BANNER_ENTER_DURATION` (250ms), not 150/200ms
- Migrated the auto-restarting variant of `TerminalRestartStatusBanner` from a hand-rolled `div` to `InlineStatusBanner`, using a local `SpinnerIcon` wrapper for the `Loader2` icon

Resolves #7974

## Changes

- `InlineStatusBanner.tsx` — added `"info"` | `"success"` to the severity union; added opt-in `ariaLive` prop that emits `aria-live` + `aria-atomic="true"` only when set and not `"off"`; fixed `duration-150` → `duration-250` on the entrance transition
- `TerminalRestartStatusBanner.tsx` — auto-restarting variant now renders via `InlineStatusBanner` instead of a bespoke layout; local `SpinnerIcon` wrapper passes `className` + `style` through cleanly
- `TerminalCountWarning.tsx` — fixed `duration-200` → `duration-250`; dismiss timeout now uses `BANNER_ENTER_DURATION` so the exit animation fully completes before unmount
- `InlineStatusBanner.test.tsx` (new) — severity matrix coverage + `ariaLive` boundary tests
- `TerminalCountWarning.test.tsx` — one additional test for the new dismiss-timing behaviour

`MissingCliGate`'s `StateBanner` is deliberately excluded — its rounded card layout is structurally different from the chrome-strip `InlineStatusBanner` pattern.

## Testing

44 banner-related vitest tests pass. `npm run check` (typecheck + lint + format) green. `npm run build` green.