### PR TITLE
fix(notifications): throttle bell blip + prefix divergent thread previews

### DIFF
--- a/src/components/Layout/NotificationCenterToolbarButton.tsx
+++ b/src/components/Layout/NotificationCenterToolbarButton.tsx
@@ -9,7 +9,7 @@ import { useNotificationSettingsStore } from "@/store/notificationSettingsStore"
 import { useUIStore } from "@/store/uiStore";
 import { useShallow } from "zustand/react/shallow";
 import { isScheduledQuietNow } from "@shared/utils/quietHours";
-import { DURATION_200 } from "@/lib/animationUtils";
+import { DURATION_200, DURATION_250 } from "@/lib/animationUtils";
 
 const toolbarIconButtonClass = "toolbar-icon-button text-daintree-text";
 
@@ -131,18 +131,29 @@ export function NotificationCenterToolbarButton({
   // cleanup (matching AgentStatusIndicator) instead of key-based remounting, so
   // no will-change layer hint lingers on the long-lived toolbar element.
   const prevEvictedRef = useRef(evictedToInboxCount);
+  const lastBellBumpTimeRef = useRef(0);
   const [isBellBlipping, setIsBellBlipping] = useState(false);
   useEffect(() => {
     const prev = prevEvictedRef.current;
     prevEvictedRef.current = evictedToInboxCount;
 
-    // Count decreased — clear any in-flight animation state.
+    // Count decreased — clear any in-flight animation state and reset the
+    // throttle clock so the next burst animates immediately. Acknowledging the
+    // inbox should not gate a fresh arrival behind a stale throttle window.
     if (evictedToInboxCount < prev) {
       setIsBellBlipping(false);
+      lastBellBumpTimeRef.current = 0;
       return;
     }
 
     if (evictedToInboxCount > prev && !isDndActive) {
+      // Leading-edge throttle: drop bumps that arrive inside the previous
+      // animation window so rapid-fire evictions don't strobe the bell. DND
+      // suppression skips updating the ref so the first post-DND notification
+      // still animates immediately.
+      const now = Date.now();
+      if (now - lastBellBumpTimeRef.current < DURATION_250) return;
+      lastBellBumpTimeRef.current = now;
       setIsBellBlipping(true);
     }
   }, [evictedToInboxCount, isDndActive]);

--- a/src/components/Layout/NotificationCenterToolbarButton.tsx
+++ b/src/components/Layout/NotificationCenterToolbarButton.tsx
@@ -148,9 +148,9 @@ export function NotificationCenterToolbarButton({
 
     if (evictedToInboxCount > prev && !isDndActive) {
       // Leading-edge throttle: drop bumps that arrive inside the previous
-      // animation window so rapid-fire evictions don't strobe the bell. DND
-      // suppression skips updating the ref so the first post-DND notification
-      // still animates immediately.
+      // animation window so rapid-fire evictions don't strobe the bell. The
+      // ref is only advanced when a blip actually fires, so DND-suppressed
+      // increments don't consume the throttle window.
       const now = Date.now();
       if (now - lastBellBumpTimeRef.current < DURATION_250) return;
       lastBellBumpTimeRef.current = now;

--- a/src/components/Layout/__tests__/NotificationCenterToolbarButton.test.tsx
+++ b/src/components/Layout/__tests__/NotificationCenterToolbarButton.test.tsx
@@ -530,20 +530,35 @@ describe("NotificationCenterToolbarButton — DND state surface", () => {
       expect(useNotificationHistoryStore.getState().evictedToInboxCount).toBe(0);
     });
 
-    it("animation class persists across multiple subsequent increments", async () => {
+    it("uses a leading-edge throttle: in-window bumps do not push out the next allowed fire", async () => {
+      vi.useFakeTimers();
       const { getByTestId } = render(<NotificationCenterToolbarButton />);
+      const bell = getByTestId("notification-bell-icon");
+
+      // T0: first eviction. Leading-edge fires; throttle ref is captured here.
       await act(async () => {
         useNotificationHistoryStore.setState({ evictedToInboxCount: 1 });
       });
-      expect(getByTestId("notification-bell-icon").className).toContain("animate-activity-blip");
+      expect(bell.className).toContain("animate-activity-blip");
+
+      // T0+100: a second eviction lands inside the 250ms window. A correct
+      // leading-edge throttle drops it without advancing the ref. (A naive
+      // "trailing" implementation that updates the ref on every bump would
+      // delay the next allowed fire to T0+350.)
       await act(async () => {
+        vi.advanceTimersByTime(100);
         useNotificationHistoryStore.setState({ evictedToInboxCount: 2 });
       });
-      expect(getByTestId("notification-bell-icon").className).toContain("animate-activity-blip");
+
+      // T0+260: the safety timeout from the first bump fired at T0+250 and
+      // cleared the class. A fresh eviction now should re-fire because the
+      // ref still points at T0 (260 - 0 = 260 ≥ DURATION_250). If the ref
+      // had drifted to T0+100, this bump would be wrongly throttled.
       await act(async () => {
+        vi.advanceTimersByTime(160);
         useNotificationHistoryStore.setState({ evictedToInboxCount: 3 });
       });
-      expect(getByTestId("notification-bell-icon").className).toContain("animate-activity-blip");
+      expect(bell.className).toContain("animate-activity-blip");
     });
 
     it("removes the animation class via safety timeout when the animation completes", async () => {

--- a/src/components/Notifications/NotificationCenter.tsx
+++ b/src/components/Notifications/NotificationCenter.tsx
@@ -1090,6 +1090,15 @@ function NotificationThread({
 
   const displayType = getWorstSeverity(group.entries);
 
+  // When the worst-severity icon disagrees with the latest entry's type (e.g.
+  // an "error" thread whose newest entry is a "success" recovery), prefix the
+  // preview text so the icon/message divergence reads as intentional rather
+  // than a mismatch.
+  const displayEntry =
+    displayType !== latest.type && latest.message.length > 0
+      ? { ...latest, message: `Latest: ${latest.message}` }
+      : latest;
+
   return (
     <div
       ref={rowRef}
@@ -1104,7 +1113,7 @@ function NotificationThread({
       )}
     >
       <NotificationCenterEntry
-        entry={latest}
+        entry={displayEntry}
         displayType={displayType}
         threadCount={group.entries.length}
         isNew={isNew}

--- a/src/components/Notifications/__tests__/NotificationCenter.test.tsx
+++ b/src/components/Notifications/__tests__/NotificationCenter.test.tsx
@@ -101,8 +101,10 @@ describe("NotificationThread worst severity", () => {
 
     const { container } = render(<NotificationCenter open onClose={vi.fn()} />);
 
+    // Worst severity (error) disagrees with the latest entry (success), so the
+    // preview is prefixed to flag the icon/text divergence.
     await waitFor(() => {
-      expect(screen.queryAllByText("Deploy successful").length).toBeGreaterThan(0);
+      expect(screen.queryAllByText("Latest: Deploy successful").length).toBeGreaterThan(0);
     });
 
     const errorIcon = container.querySelector(".text-status-error");
@@ -283,7 +285,7 @@ describe("NotificationThread with single entry", () => {
 });
 
 describe("NotificationThread message content", () => {
-  it("shows latest entry message even when worst severity is different", async () => {
+  it("prefixes the preview with 'Latest:' when worst severity disagrees with the latest entry", async () => {
     const correlationId = "thread-6";
     useNotificationHistoryStore.getState().addEntry(
       makeEntry({
@@ -307,8 +309,40 @@ describe("NotificationThread message content", () => {
     render(<NotificationCenter open onClose={vi.fn()} />);
 
     await waitFor(() => {
-      expect(screen.queryAllByText("Build retried and succeeded").length).toBeGreaterThan(0);
+      expect(screen.queryAllByText("Latest: Build retried and succeeded").length).toBeGreaterThan(
+        0
+      );
     });
+    expect(screen.queryByText("Build retried and succeeded")).toBeNull();
+  });
+
+  it("omits the 'Latest:' prefix when the latest entry already matches the worst severity", async () => {
+    const correlationId = "thread-7";
+    useNotificationHistoryStore.getState().addEntry(
+      makeEntry({
+        id: "error-entry-1",
+        type: "error",
+        message: "Build failed",
+        correlationId,
+        timestamp: Date.now() - 2000,
+      })
+    );
+    useNotificationHistoryStore.getState().addEntry(
+      makeEntry({
+        id: "error-entry-2",
+        type: "error",
+        message: "Build failed again",
+        correlationId,
+        timestamp: Date.now() - 1000,
+      })
+    );
+
+    render(<NotificationCenter open onClose={vi.fn()} />);
+
+    await waitFor(() => {
+      expect(screen.queryAllByText("Build failed again").length).toBeGreaterThan(0);
+    });
+    expect(screen.queryByText("Latest: Build failed again")).toBeNull();
   });
 });
 


### PR DESCRIPTION
Two small notification polish fixes.

The toolbar bell in `NotificationCenterToolbarButton.tsx` has no protection against sustained eviction churn — every `evictedToInboxCount` increment fires `animate-activity-blip`, so the bell strobes at the same rate as agent-state updates. This applies the same leading-edge throttle pattern already used in `NotificationCenterEntry.tsx` (`lastBumpTimeRef` + `DURATION_250`). The throttle ref resets when the count drops (inbox acknowledged), so a fresh arrival after a quiet period isn't gated by a stale window.

The collapsed thread preview in `NotificationCenter.tsx` renders the latest entry's message but shows the worst-severity icon. When a thread fires an error then a recovery, you get a red icon next to "Connection restored" — no signal that they describe different events. Fixed by prefixing the message with `Latest:` when `latest.type` disagrees with the worst-severity icon. No prefix when they already agree.

Resolves #7967

## Changes

- `NotificationCenterToolbarButton.tsx` — leading-edge throttle on `animate-activity-blip` mirroring `NotificationCenterEntry` pattern
- `NotificationCenter.tsx` — prefix collapsed thread preview with `Latest:` when icon severity diverges from latest entry type
- `NotificationCenterToolbarButton.test.tsx` — rewrote rapid-increment test as a leading-edge-correctness probe
- `NotificationCenter.test.tsx` — added no-prefix case for matching severities; updated divergence assertion for new prefix

## Testing

130 targeted tests passing. Full check suite (typecheck, `lint:ratchet` at baseline 895, `format:check`, channels/IPC/help generators) clean. No new dependencies.