### PR TITLE
fix(worktree): align sidebar search clearing with ARIA APG combobox pattern

### DIFF
--- a/src/components/Worktree/WorktreeFilterPopover.tsx
+++ b/src/components/Worktree/WorktreeFilterPopover.tsx
@@ -135,13 +135,19 @@ const ORDER_OPTIONS: { value: OrderBy; label: string }[] = [
 interface WorktreeFilterPopoverProps {
   hideSearchInput?: boolean;
   chipCounts?: ChipCounts;
+  open?: boolean;
+  onOpenChange?: (open: boolean) => void;
 }
 
 export function WorktreeFilterPopover({
   hideSearchInput = false,
   chipCounts,
+  open,
+  onOpenChange,
 }: WorktreeFilterPopoverProps) {
-  const [isOpen, setIsOpen] = useState(false);
+  const [internalOpen, setInternalOpen] = useState(false);
+  const isOpen = open ?? internalOpen;
+  const setIsOpen = onOpenChange ?? setInternalOpen;
   const [localQuery, setLocalQuery] = useState("");
   const debounceRef = useRef<NodeJS.Timeout | null>(null);
 

--- a/src/components/Worktree/WorktreeSidebarSearchBar.tsx
+++ b/src/components/Worktree/WorktreeSidebarSearchBar.tsx
@@ -24,11 +24,13 @@ export function WorktreeSidebarSearchBar({ inputRef, chipCounts }: WorktreeSideb
   const clearAll = useWorktreeFilterStore((state) => state.clearAll);
   const quickStateFilter = useWorktreeFilterStore((state) => state.quickStateFilter);
   const hasFacetFilters = useWorktreeFilterStore((state) => state.hasFacetFilters());
+  const hasActiveFiltersValue = useWorktreeFilterStore((state) => state.hasActiveFilters());
 
   const [localQuery, setLocalQuery] = useState("");
   const [isPopoverOpen, setIsPopoverOpen] = useState(false);
   const debounceRef = useRef<NodeJS.Timeout | null>(null);
   const internalRef = useRef<HTMLInputElement | null>(null);
+  const prevHasActiveFiltersRef = useRef(hasActiveFiltersValue);
 
   useEffect(() => {
     if (debounceRef.current) {
@@ -37,6 +39,23 @@ export function WorktreeSidebarSearchBar({ inputRef, chipCounts }: WorktreeSideb
     }
     setLocalQuery(query);
   }, [query]);
+
+  // Cancel any pending debounce when ANY filter is cleared externally
+  // (popover footer "Clear all filters", sidebar empty-state CTA, etc.).
+  // The `[query]` effect above only catches transitions of `query` itself;
+  // when the typed-but-uncommitted query coincides with an external clearAll,
+  // the store's `query` stays "" and the debounce would silently resurrect
+  // the typed value 200 ms later.
+  useEffect(() => {
+    if (prevHasActiveFiltersRef.current && !hasActiveFiltersValue) {
+      if (debounceRef.current) {
+        clearTimeout(debounceRef.current);
+        debounceRef.current = null;
+      }
+      setLocalQuery("");
+    }
+    prevHasActiveFiltersRef.current = hasActiveFiltersValue;
+  }, [hasActiveFiltersValue]);
 
   useEffect(() => {
     return () => {
@@ -66,6 +85,9 @@ export function WorktreeSidebarSearchBar({ inputRef, chipCounts }: WorktreeSideb
     }
     setLocalQuery("");
     setQuery("");
+    // Keep focus on input after clearing, per ARIA APG combobox guidance —
+    // the X button unmounts when localQuery clears, so focus would otherwise fall to body.
+    internalRef.current?.focus();
   }, [setQuery]);
 
   const handleClearAll = useCallback(() => {
@@ -106,7 +128,7 @@ export function WorktreeSidebarSearchBar({ inputRef, chipCounts }: WorktreeSideb
 
   const showClear = !!localQuery;
   const activeAxisCount =
-    (localQuery ? 1 : 0) + (quickStateFilter !== "all" ? 1 : 0) + (hasFacetFilters ? 1 : 0);
+    (localQuery.trim() ? 1 : 0) + (quickStateFilter !== "all" ? 1 : 0) + (hasFacetFilters ? 1 : 0);
   const showClearAll = activeAxisCount >= 2;
 
   return (

--- a/src/components/Worktree/WorktreeSidebarSearchBar.tsx
+++ b/src/components/Worktree/WorktreeSidebarSearchBar.tsx
@@ -22,9 +22,11 @@ export function WorktreeSidebarSearchBar({ inputRef, chipCounts }: WorktreeSideb
   const query = useWorktreeFilterStore((state) => state.query);
   const setQuery = useWorktreeFilterStore((state) => state.setQuery);
   const clearAll = useWorktreeFilterStore((state) => state.clearAll);
-  const hasActiveFilters = useWorktreeFilterStore((state) => state.hasActiveFilters());
+  const quickStateFilter = useWorktreeFilterStore((state) => state.quickStateFilter);
+  const hasFacetFilters = useWorktreeFilterStore((state) => state.hasFacetFilters());
 
   const [localQuery, setLocalQuery] = useState("");
+  const [isPopoverOpen, setIsPopoverOpen] = useState(false);
   const debounceRef = useRef<NodeJS.Timeout | null>(null);
   const internalRef = useRef<HTMLInputElement | null>(null);
 
@@ -57,7 +59,16 @@ export function WorktreeSidebarSearchBar({ inputRef, chipCounts }: WorktreeSideb
     [setQuery]
   );
 
-  const handleClear = useCallback(() => {
+  const handleClearSearch = useCallback(() => {
+    if (debounceRef.current) {
+      clearTimeout(debounceRef.current);
+      debounceRef.current = null;
+    }
+    setLocalQuery("");
+    setQuery("");
+  }, [setQuery]);
+
+  const handleClearAll = useCallback(() => {
     if (debounceRef.current) {
       clearTimeout(debounceRef.current);
       debounceRef.current = null;
@@ -68,16 +79,21 @@ export function WorktreeSidebarSearchBar({ inputRef, chipCounts }: WorktreeSideb
 
   const handleKeyDown = useCallback(
     (e: React.KeyboardEvent) => {
-      if (e.key === "Escape") {
+      if (e.key !== "Escape") return;
+      // ARIA APG combobox sequence: close popup → clear text → blur.
+      if (isPopoverOpen) {
         e.stopPropagation();
-        if (localQuery || useWorktreeFilterStore.getState().hasActiveFilters()) {
-          handleClear();
-        } else {
-          internalRef.current?.blur();
-        }
+        setIsPopoverOpen(false);
+        return;
       }
+      if (localQuery) {
+        e.stopPropagation();
+        handleClearSearch();
+        return;
+      }
+      internalRef.current?.blur();
     },
-    [localQuery, handleClear]
+    [isPopoverOpen, localQuery, handleClearSearch]
   );
 
   const setRefs = useCallback(
@@ -88,7 +104,10 @@ export function WorktreeSidebarSearchBar({ inputRef, chipCounts }: WorktreeSideb
     [inputRef]
   );
 
-  const showClear = localQuery || hasActiveFilters;
+  const showClear = !!localQuery;
+  const activeAxisCount =
+    (localQuery ? 1 : 0) + (quickStateFilter !== "all" ? 1 : 0) + (hasFacetFilters ? 1 : 0);
+  const showClearAll = activeAxisCount >= 2;
 
   return (
     <div className="px-3 py-2 border-b border-divider shrink-0">
@@ -118,16 +137,32 @@ export function WorktreeSidebarSearchBar({ inputRef, chipCounts }: WorktreeSideb
           {showClear && (
             <button
               type="button"
-              onClick={handleClear}
+              onClick={handleClearSearch}
               className="flex items-center justify-center w-5 h-5 rounded text-daintree-text/40 hover:text-daintree-text"
-              aria-label="Clear search and filters"
+              aria-label="Clear search"
             >
               <X className="w-3 h-3" />
             </button>
           )}
-          <WorktreeFilterPopover hideSearchInput chipCounts={chipCounts} />
+          <WorktreeFilterPopover
+            hideSearchInput
+            chipCounts={chipCounts}
+            open={isPopoverOpen}
+            onOpenChange={setIsPopoverOpen}
+          />
         </div>
       </div>
+      {showClearAll && (
+        <div className="flex justify-end pt-1">
+          <button
+            type="button"
+            onClick={handleClearAll}
+            className="text-[11px] text-daintree-text/50 hover:text-daintree-text transition-colors"
+          >
+            Clear all
+          </button>
+        </div>
+      )}
     </div>
   );
 }

--- a/src/components/Worktree/__tests__/WorktreeSidebarSearchBar.test.tsx
+++ b/src/components/Worktree/__tests__/WorktreeSidebarSearchBar.test.tsx
@@ -1,0 +1,217 @@
+// @vitest-environment jsdom
+import { afterEach, beforeEach, describe, expect, it } from "vitest";
+import { act, fireEvent, render, screen } from "@testing-library/react";
+import { TooltipProvider } from "@/components/ui/tooltip";
+import { useWorktreeFilterStore } from "@/store/worktreeFilterStore";
+import { WorktreeSidebarSearchBar } from "../WorktreeSidebarSearchBar";
+
+function resetWorktreeFilterStore() {
+  useWorktreeFilterStore.setState({
+    query: "",
+    orderBy: "created",
+    groupByType: false,
+    statusFilters: new Set(),
+    typeFilters: new Set(),
+    githubFilters: new Set(),
+    sessionFilters: new Set(),
+    activityFilters: new Set(),
+    alwaysShowActive: true,
+    alwaysShowWaiting: true,
+    hideMainWorktree: false,
+    pinnedWorktrees: [],
+    collapsedWorktrees: [],
+    manualOrder: [],
+    quickStateFilter: "all",
+  });
+}
+
+function renderBar() {
+  return render(<WorktreeSidebarSearchBar />, { wrapper: TooltipProvider });
+}
+
+function getInput() {
+  return screen.getByRole("textbox", { name: "Search worktrees" }) as HTMLInputElement;
+}
+
+function getFilterTrigger() {
+  return screen.getByRole("button", { name: "Filter and sort worktrees" });
+}
+
+describe("WorktreeSidebarSearchBar", () => {
+  beforeEach(() => {
+    resetWorktreeFilterStore();
+  });
+
+  afterEach(() => {
+    resetWorktreeFilterStore();
+  });
+
+  it("renders the X clear button with the 'Clear search' aria-label when text is typed", () => {
+    renderBar();
+    fireEvent.change(getInput(), { target: { value: "foo" } });
+    const clearBtn = screen.getByRole("button", { name: "Clear search" });
+    expect(clearBtn).toBeTruthy();
+  });
+
+  it("does not render the X button when only facets are active (no typed text)", () => {
+    renderBar();
+    act(() => {
+      useWorktreeFilterStore.getState().toggleStatusFilter("active");
+    });
+    expect(screen.queryByRole("button", { name: "Clear search" })).toBeNull();
+    expect(screen.queryByRole("button", { name: /Clear search/i })).toBeNull();
+  });
+
+  it("X button clears only the search query and preserves facets + quick-state", () => {
+    renderBar();
+    act(() => {
+      useWorktreeFilterStore.getState().toggleStatusFilter("active");
+      useWorktreeFilterStore.getState().toggleTypeFilter("feature");
+      useWorktreeFilterStore.getState().setQuickStateFilter("working");
+    });
+    fireEvent.change(getInput(), { target: { value: "foo" } });
+    // Flush the 200 ms debounce so store.query reflects the typed value.
+    act(() => {
+      // Force-set the store value directly; the debounce path is exercised
+      // implicitly by the input's onChange already updating localQuery.
+      useWorktreeFilterStore.getState().setQuery("foo");
+    });
+    expect(useWorktreeFilterStore.getState().query).toBe("foo");
+
+    fireEvent.click(screen.getByRole("button", { name: "Clear search" }));
+
+    const state = useWorktreeFilterStore.getState();
+    expect(state.query).toBe("");
+    expect(state.statusFilters.has("active")).toBe(true);
+    expect(state.typeFilters.has("feature")).toBe(true);
+    expect(state.quickStateFilter).toBe("working");
+    expect(getInput().value).toBe("");
+  });
+
+  it("Escape with popover open closes the popover, leaves query intact, and keeps focus", () => {
+    renderBar();
+    fireEvent.change(getInput(), { target: { value: "foo" } });
+    act(() => {
+      useWorktreeFilterStore.getState().setQuery("foo");
+    });
+    // Open the filter popover via its trigger.
+    fireEvent.click(getFilterTrigger());
+    expect(getFilterTrigger().getAttribute("aria-expanded")).toBe("true");
+
+    const input = getInput();
+    input.focus();
+    fireEvent.keyDown(input, { key: "Escape" });
+
+    expect(getFilterTrigger().getAttribute("aria-expanded")).toBe("false");
+    expect(useWorktreeFilterStore.getState().query).toBe("foo");
+    expect(input.value).toBe("foo");
+    expect(document.activeElement).toBe(input);
+  });
+
+  it("Escape with popover closed and text present clears only the text", () => {
+    renderBar();
+    act(() => {
+      useWorktreeFilterStore.getState().toggleStatusFilter("active");
+    });
+    fireEvent.change(getInput(), { target: { value: "foo" } });
+    act(() => {
+      useWorktreeFilterStore.getState().setQuery("foo");
+    });
+
+    fireEvent.keyDown(getInput(), { key: "Escape" });
+
+    const state = useWorktreeFilterStore.getState();
+    expect(state.query).toBe("");
+    expect(state.statusFilters.has("active")).toBe(true);
+    expect(getInput().value).toBe("");
+  });
+
+  it("Escape with no popover, no text, and no facets blurs the input", () => {
+    renderBar();
+    const input = getInput();
+    input.focus();
+    expect(document.activeElement).toBe(input);
+
+    fireEvent.keyDown(input, { key: "Escape" });
+
+    expect(document.activeElement).not.toBe(input);
+  });
+
+  it("does not show the cross-axis 'Clear all' button when no axes are active", () => {
+    renderBar();
+    expect(screen.queryByRole("button", { name: "Clear all" })).toBeNull();
+  });
+
+  it("does not show 'Clear all' when only the search query is non-default", () => {
+    renderBar();
+    fireEvent.change(getInput(), { target: { value: "foo" } });
+    expect(screen.queryByRole("button", { name: "Clear all" })).toBeNull();
+  });
+
+  it("does not show 'Clear all' when only facets are non-default", () => {
+    renderBar();
+    act(() => {
+      useWorktreeFilterStore.getState().toggleStatusFilter("active");
+      useWorktreeFilterStore.getState().toggleTypeFilter("feature");
+    });
+    // Two facet toggles count as a single "facet axis"; still one axis overall.
+    expect(screen.queryByRole("button", { name: "Clear all" })).toBeNull();
+  });
+
+  it("does not show 'Clear all' when only quick-state is non-default", () => {
+    renderBar();
+    act(() => {
+      useWorktreeFilterStore.getState().setQuickStateFilter("working");
+    });
+    expect(screen.queryByRole("button", { name: "Clear all" })).toBeNull();
+  });
+
+  it("shows 'Clear all' when query + facets are both active", () => {
+    renderBar();
+    act(() => {
+      useWorktreeFilterStore.getState().toggleStatusFilter("active");
+    });
+    fireEvent.change(getInput(), { target: { value: "foo" } });
+    expect(screen.getByRole("button", { name: "Clear all" })).toBeTruthy();
+  });
+
+  it("shows 'Clear all' when query + quick-state are both active", () => {
+    renderBar();
+    act(() => {
+      useWorktreeFilterStore.getState().setQuickStateFilter("working");
+    });
+    fireEvent.change(getInput(), { target: { value: "foo" } });
+    expect(screen.getByRole("button", { name: "Clear all" })).toBeTruthy();
+  });
+
+  it("shows 'Clear all' when facets + quick-state are both active", () => {
+    renderBar();
+    act(() => {
+      useWorktreeFilterStore.getState().toggleStatusFilter("active");
+      useWorktreeFilterStore.getState().setQuickStateFilter("waiting");
+    });
+    expect(screen.getByRole("button", { name: "Clear all" })).toBeTruthy();
+  });
+
+  it("'Clear all' click resets query, facets, and quick-state via clearAll()", () => {
+    renderBar();
+    act(() => {
+      useWorktreeFilterStore.getState().toggleStatusFilter("active");
+      useWorktreeFilterStore.getState().toggleTypeFilter("feature");
+      useWorktreeFilterStore.getState().setQuickStateFilter("working");
+    });
+    fireEvent.change(getInput(), { target: { value: "foo" } });
+    act(() => {
+      useWorktreeFilterStore.getState().setQuery("foo");
+    });
+
+    fireEvent.click(screen.getByRole("button", { name: "Clear all" }));
+
+    const state = useWorktreeFilterStore.getState();
+    expect(state.query).toBe("");
+    expect(state.statusFilters.size).toBe(0);
+    expect(state.typeFilters.size).toBe(0);
+    expect(state.quickStateFilter).toBe("all");
+    expect(getInput().value).toBe("");
+  });
+});

--- a/src/components/Worktree/__tests__/WorktreeSidebarSearchBar.test.tsx
+++ b/src/components/Worktree/__tests__/WorktreeSidebarSearchBar.test.tsx
@@ -1,5 +1,5 @@
 // @vitest-environment jsdom
-import { afterEach, beforeEach, describe, expect, it } from "vitest";
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
 import { act, fireEvent, render, screen } from "@testing-library/react";
 import { TooltipProvider } from "@/components/ui/tooltip";
 import { useWorktreeFilterStore } from "@/store/worktreeFilterStore";
@@ -191,6 +191,91 @@ describe("WorktreeSidebarSearchBar", () => {
       useWorktreeFilterStore.getState().setQuickStateFilter("waiting");
     });
     expect(screen.getByRole("button", { name: "Clear all" })).toBeTruthy();
+  });
+
+  it("X click via keyboard activation keeps focus on the input", () => {
+    renderBar();
+    fireEvent.change(getInput(), { target: { value: "foo" } });
+    act(() => {
+      useWorktreeFilterStore.getState().setQuery("foo");
+    });
+    const clearBtn = screen.getByRole("button", { name: "Clear search" });
+    // Simulate keyboard activation: focus the button then click via fireEvent
+    // (jsdom fires keydown→keypress→click for Enter, but a direct .click() is
+    // a closer model of what tests assert about activation behaviour).
+    clearBtn.focus();
+    fireEvent.click(clearBtn);
+    expect(document.activeElement).toBe(getInput());
+  });
+
+  it("whitespace-only query does not count as an active axis for 'Clear all'", () => {
+    renderBar();
+    act(() => {
+      useWorktreeFilterStore.getState().toggleStatusFilter("active");
+    });
+    fireEvent.change(getInput(), { target: { value: "   " } });
+    // Only one real axis is active (facets). The whitespace input should not
+    // inflate the count and surface "Clear all".
+    expect(screen.queryByRole("button", { name: "Clear all" })).toBeNull();
+  });
+
+  it("'Clear all' disappears after a partial clear leaves only one axis", () => {
+    renderBar();
+    act(() => {
+      useWorktreeFilterStore.getState().toggleStatusFilter("active");
+    });
+    fireEvent.change(getInput(), { target: { value: "foo" } });
+    expect(screen.getByRole("button", { name: "Clear all" })).toBeTruthy();
+    // The X button only clears query; one axis (facets) remains.
+    fireEvent.click(screen.getByRole("button", { name: "Clear search" }));
+    expect(screen.queryByRole("button", { name: "Clear all" })).toBeNull();
+  });
+
+  it("stale debounce: external clearAll cancels the pending query write", () => {
+    vi.useFakeTimers();
+    try {
+      renderBar();
+      // Seed a facet so hasActiveFilters is true while debounce is pending.
+      act(() => {
+        useWorktreeFilterStore.getState().toggleStatusFilter("active");
+      });
+      fireEvent.change(getInput(), { target: { value: "foo" } });
+      // Debounce is now scheduled; store.query is still "".
+      expect(useWorktreeFilterStore.getState().query).toBe("");
+      // External clearAll (e.g., popover footer) fires before the 200 ms elapses.
+      act(() => {
+        useWorktreeFilterStore.getState().clearAll();
+      });
+      // Advance past the debounce window.
+      act(() => {
+        vi.advanceTimersByTime(250);
+      });
+      // Query must NOT be silently resurrected to "foo".
+      expect(useWorktreeFilterStore.getState().query).toBe("");
+      // The visible input should mirror the cleared state.
+      expect(getInput().value).toBe("");
+    } finally {
+      vi.useRealTimers();
+    }
+  });
+
+  it("stale debounce: X click during pending debounce commits an empty query", () => {
+    vi.useFakeTimers();
+    try {
+      renderBar();
+      fireEvent.change(getInput(), { target: { value: "foo" } });
+      // Debounce is pending; store.query is still "".
+      // Click X immediately — this triggers handleClearSearch which cancels the
+      // pending debounce and calls setQuery("").
+      fireEvent.click(screen.getByRole("button", { name: "Clear search" }));
+      act(() => {
+        vi.advanceTimersByTime(250);
+      });
+      expect(useWorktreeFilterStore.getState().query).toBe("");
+      expect(getInput().value).toBe("");
+    } finally {
+      vi.useRealTimers();
+    }
   });
 
   it("'Clear all' click resets query, facets, and quick-state via clearAll()", () => {


### PR DESCRIPTION
## Summary

- The X button in the worktree sidebar search input was clearing all facet filters, not just the search text. Escape did the same. Both are now scoped correctly.
- Escape follows the ARIA APG combobox sequence: close the popover if open, then clear the input text, then blur. X clears the query only, with its `aria-label` updated to match.
- A cross-axis "Clear all" micro-button appears when two or more filter dimensions are active, giving users a single-click reset path without hijacking the X or Escape behaviours.

Resolves #7970

## Changes

- `WorktreeSidebarSearchBar.tsx` — scoped X to query-only, implemented ARIA APG Escape sequence, added "Clear all" micro-button, debounce-race guard, and focus restoration after clearing
- `WorktreeFilterPopover.tsx` — added optional controlled `open`/`onOpenChange` props so the search bar can drive popover state during the Escape sequence
- `WorktreeSidebarSearchBar.test.tsx` — 18 new tests covering X scoping, Escape sequence steps, "Clear all" visibility and behaviour, debounce-race guard, and focus restoration

## Testing

66/66 vitest tests pass. `tsc --noEmit` clean. Lint, format, and build clean.