### PR TITLE
polish(worktree): clarify combined-axis empty state and lift active-count contrast

### DIFF
--- a/src/components/Sidebar/SidebarContent.tsx
+++ b/src/components/Sidebar/SidebarContent.tsx
@@ -77,6 +77,12 @@ function formatButtonTitle(label: string, shortcut?: string | null): string {
 
 const NO_MATCH_QUERY_MAX = 40;
 
+const QUICK_STATE_LABELS: Record<"working" | "waiting" | "finished", string> = {
+  working: "Working",
+  waiting: "Waiting",
+  finished: "Finished",
+};
+
 function truncateSearchQuery(trimmedQuery: string) {
   const codepoints = Array.from(trimmedQuery);
   return codepoints.length > NO_MATCH_QUERY_MAX
@@ -176,6 +182,12 @@ function SidebarContent({ onOpenOverview }: SidebarContentProps) {
   const hasActiveFilters = useWorktreeFilterStore((state) => state.hasActiveFilters);
   const hasFacetFilters = useWorktreeFilterStore((state) => state.hasFacetFilters);
   const hasFacetFiltersActive = hasFacetFilters();
+  const activeFacetFilterCount =
+    statusFilters.size +
+    typeFilters.size +
+    githubFilters.size +
+    sessionFilters.size +
+    activityFilters.size;
   const collapsedWorktrees = useWorktreeFilterStore((state) => state.collapsedWorktrees);
   const pruneStaleWorktreeIds = useWorktreeFilterStore((state) => state.pruneStaleWorktreeIds);
   const setQuickStateFilter = useWorktreeFilterStore((state) => state.setQuickStateFilter);
@@ -953,13 +965,19 @@ function SidebarContent({ onOpenOverview }: SidebarContentProps) {
                 <EmptyState
                   variant="filtered-empty"
                   scale="sidebar"
-                  title={`No ${quickStateFilter} worktrees`}
+                  title={
+                    hasFacetFiltersActive && activeFacetFilterCount > 0
+                      ? `No worktrees match ${QUICK_STATE_LABELS[quickStateFilter]} with ${activeFacetFilterCount} ${
+                          activeFacetFilterCount === 1 ? "filter" : "filters"
+                        }`
+                      : `No ${quickStateFilter} worktrees`
+                  }
                   action={
                     <button
                       onClick={clearAllFilters}
                       className="text-xs px-3 py-1.5 text-daintree-text/60 hover:text-daintree-text hover:bg-overlay-soft rounded transition-colors"
                     >
-                      Clear filters
+                      Show all worktrees
                     </button>
                   }
                 />
@@ -980,7 +998,7 @@ function SidebarContent({ onOpenOverview }: SidebarContentProps) {
                       onClick={clearAllFilters}
                       className="text-xs px-3 py-1.5 text-daintree-text/60 hover:text-daintree-text hover:bg-overlay-soft rounded transition-colors"
                     >
-                      Clear filters
+                      Show all worktrees
                     </button>
                   }
                 />

--- a/src/components/Sidebar/__tests__/SidebarContent.emptyState.test.ts
+++ b/src/components/Sidebar/__tests__/SidebarContent.emptyState.test.ts
@@ -85,7 +85,43 @@ describe("SidebarContent quick-state empty state — issue #6333 (CTA collapsed 
     });
 
     it("titles the quick-state empty state with the active filter label via the EmptyState primitive", () => {
-      expect(source).toMatch(/title=\{`No \$\{quickStateFilter\} worktrees`\}/);
+      // Single-axis fallback when no facet filters are active alongside the
+      // quick-state filter (still the default copy).
+      expect(source).toMatch(/: `No \$\{quickStateFilter\} worktrees`/);
+    });
+
+    it("names both axes when a facet filter is active alongside the quick-state — issue #7971", () => {
+      // When the quick-state filter and one or more facet filters are active
+      // together and produce zero results, the title must call out both axes
+      // (e.g. "No worktrees match Working with 2 filters") instead of picking
+      // only one. The fallback to "No {quickStateFilter} worktrees" stays for
+      // the quick-state-only case.
+      const branchStart = source.indexOf("showQuickStateEmptyState ?");
+      const branchEnd = source.indexOf(") : filteredWorktrees.length === 0 &&", branchStart);
+      const branch = source.slice(branchStart, branchEnd);
+      expect(branch).toContain("hasFacetFiltersActive && activeFacetFilterCount > 0");
+      expect(branch).toMatch(
+        /`No worktrees match \$\{QUICK_STATE_LABELS\[quickStateFilter\]\} with \$\{activeFacetFilterCount\} \$\{[\s\S]*?activeFacetFilterCount === 1 \? "filter" : "filters"[\s\S]*?\}`/
+      );
+    });
+
+    it("derives the active facet filter count from the five facet Set sizes — issue #7971", () => {
+      // The combined-axis title needs the actual number of facet filters
+      // selected. Sum the five facet axes (status, type, github, session,
+      // activity) — the same axes hasFacetFilters() reads. Do not include
+      // query or quickStateFilter, which are named separately in the title.
+      expect(source).toMatch(
+        /const activeFacetFilterCount =\s*statusFilters\.size \+\s*typeFilters\.size \+\s*githubFilters\.size \+\s*sessionFilters\.size \+\s*activityFilters\.size;/
+      );
+    });
+
+    it("maps quick-state filter values to title-cased labels for the combined-axis title — issue #7971", () => {
+      // The raw quickStateFilter values are lowercase ("working", "waiting",
+      // "finished"). The combined-axis title displays them title-cased via a
+      // module-level QUICK_STATE_LABELS map so the prose reads naturally.
+      expect(source).toMatch(
+        /const QUICK_STATE_LABELS: Record<"working" \| "waiting" \| "finished", string> = \{\s*working: "Working",\s*waiting: "Waiting",\s*finished: "Finished",\s*\};/
+      );
     });
 
     it("uses the EmptyState filtered-empty variant for the quick-state branch", () => {
@@ -99,14 +135,15 @@ describe("SidebarContent quick-state empty state — issue #6333 (CTA collapsed 
       expect(branch).toContain('variant="filtered-empty"');
     });
 
-    it("collapses the quick-state empty state to a single 'Clear filters' CTA wired to clearAllFilters", () => {
-      // #6934: the dual-CTA shape ('Show all states' + conditional 'Clear all filters')
-      // was an empty-state anti-pattern. clearAll() resets every dimension including
-      // quickStateFilter, so a single button is the natural recovery shape.
+    it("collapses the quick-state empty state to a single 'Show all worktrees' CTA wired to clearAllFilters — issue #7971", () => {
+      // #6934 collapsed the dual-CTA shape ('Show all states' + 'Clear all
+      // filters') to a single button wired to clearAll(); #7971 renamed the
+      // label from "Clear filters" to "Show all worktrees" so the button
+      // describes the outcome rather than the action.
       const branchStart = source.indexOf("showQuickStateEmptyState ?");
       const branchEnd = source.indexOf(") : filteredWorktrees.length === 0 &&", branchStart);
       const branch = source.slice(branchStart, branchEnd);
-      expect(branch).toMatch(/onClick=\{clearAllFilters\}[\s\S]*?>\s*Clear filters\s*</);
+      expect(branch).toMatch(/onClick=\{clearAllFilters\}[\s\S]*?>\s*Show all worktrees\s*</);
       expect(branch).not.toContain("Show all states");
       expect(branch).not.toContain("clearQuickStateFilter");
       // Exactly one button — guards against the dual-CTA pattern returning by
@@ -142,7 +179,7 @@ describe("SidebarContent quick-state empty state — issue #6333 (CTA collapsed 
       expect(branch).toContain('"No matching worktrees"');
       expect(branch).toMatch(/hasQuery/);
       expect(branch).toMatch(/truncateSearchQuery/);
-      expect(branch).toMatch(/onClick=\{clearAllFilters\}[\s\S]*?>\s*Clear filters\s*</);
+      expect(branch).toMatch(/onClick=\{clearAllFilters\}[\s\S]*?>\s*Show all worktrees\s*</);
     });
   });
 });

--- a/src/components/Worktree/QuickStateFilterBar.tsx
+++ b/src/components/Worktree/QuickStateFilterBar.tsx
@@ -101,7 +101,7 @@ export function QuickStateFilterBar({
                     aria-hidden="true"
                     className={cn(
                       "text-xs tabular-nums",
-                      isActive ? "text-daintree-text/70" : "text-daintree-text/50"
+                      isActive ? "text-daintree-text" : "text-daintree-text/50"
                     )}
                   >
                     {rawCount}

--- a/src/components/Worktree/__tests__/QuickStateFilterBar.test.tsx
+++ b/src/components/Worktree/__tests__/QuickStateFilterBar.test.tsx
@@ -230,6 +230,28 @@ describe("QuickStateFilterBar", () => {
     }
   });
 
+  it("renders the active count at full text opacity and inactive counts at /50 — issue #7971", () => {
+    // The count digit is the load-bearing signal in icon-only segments — the
+    // active segment must read at full neutral text opacity (no /N suffix);
+    // inactive segments stay muted at /50 to preserve the active hierarchy.
+    renderBar(
+      <QuickStateFilterBar
+        value="working"
+        onChange={() => {}}
+        counts={{ all: 9, working: 3, waiting: 1, finished: 2 }}
+      />
+    );
+    const working = screen.getByRole("button", { name: /Working/ });
+    const waiting = screen.getByRole("button", { name: /Waiting/ });
+    const activeCount = within(working).getByText("3");
+    const inactiveCount = within(waiting).getByText("1");
+    const activeClass = activeCount.getAttribute("class") ?? "";
+    const inactiveClass = inactiveCount.getAttribute("class") ?? "";
+    expect(activeClass).toContain("text-daintree-text");
+    expect(activeClass).not.toContain("text-daintree-text/");
+    expect(inactiveClass).toContain("text-daintree-text/50");
+  });
+
   it("renders the optional trailing slot past a divider", () => {
     renderBar(
       <QuickStateFilterBar


### PR DESCRIPTION
## Summary

- When both the quick-state filter and facet filters combine to produce an empty list, the title now names both axes -- e.g. `No worktrees match Working with 2 filters` -- instead of a single-axis message that leaves the user guessing which constraint is responsible
- Recovery button renamed from `Clear filters` to `Show all worktrees`, which describes the outcome rather than the removal action
- Active-segment count in `QuickStateFilterBar` bumped from `text/70` opacity to full opacity so the count reads clearly on the selected segment

Pure display polish. No behaviour changes.

Resolves #7971

## Changes

- `SidebarContent.tsx` -- combined-axis empty-state title + `Show all worktrees` button label on both empty-state branches
- `QuickStateFilterBar.tsx` -- active count opacity lifted to full
- `SidebarContent.emptyState.test.ts` -- updated 3 stale assertions, added 4 regression guards
- `QuickStateFilterBar.test.tsx` -- added contrast regression guard

## Testing

34 `SidebarContent` empty-state tests and 17 `QuickStateFilterBar` tests pass locally. All 6 CI checks (typecheck, channel/IPC/help checks, lint ratchet, prettier, build) passed on the implementation branch.