### PR TITLE
style(palette): align row chrome across palette family (#7969)

### DIFF
--- a/src/components/ActionPalette/ActionPaletteItem.tsx
+++ b/src/components/ActionPalette/ActionPaletteItem.tsx
@@ -40,7 +40,7 @@ export function ActionPaletteItem({
         "hover:bg-overlay-subtle hover:text-daintree-text",
         "aria-selected:bg-overlay-soft aria-selected:border-overlay aria-selected:text-daintree-text",
         "aria-selected:before:absolute aria-selected:before:left-0 aria-selected:before:top-2 aria-selected:before:bottom-2",
-        "aria-selected:before:w-[2px] aria-selected:before:rounded-r aria-selected:before:bg-daintree-accent aria-selected:before:content-['']",
+        "aria-selected:before:w-[2px] aria-selected:before:bg-daintree-accent aria-selected:before:content-['']",
         !item.enabled && "opacity-40 cursor-not-allowed"
       )}
       onClick={() => onSelect(item)}

--- a/src/components/QuickSwitcher/QuickSwitcherItem.tsx
+++ b/src/components/QuickSwitcher/QuickSwitcherItem.tsx
@@ -32,7 +32,7 @@ export function QuickSwitcherItem({
         "hover:bg-overlay-subtle hover:text-daintree-text",
         "aria-selected:bg-overlay-soft aria-selected:border-overlay aria-selected:text-daintree-text",
         "aria-selected:before:absolute aria-selected:before:left-0 aria-selected:before:top-2 aria-selected:before:bottom-2",
-        "aria-selected:before:w-[2px] aria-selected:before:rounded-r aria-selected:before:bg-daintree-accent aria-selected:before:content-['']"
+        "aria-selected:before:w-[2px] aria-selected:before:bg-daintree-accent aria-selected:before:content-['']"
       )}
       onClick={() => onSelect(item)}
       aria-selected={isSelected}
@@ -67,7 +67,9 @@ export function QuickSwitcherItem({
         {item.subtitle && (
           <Tooltip>
             <TooltipTrigger asChild>
-              <div className="text-xs text-daintree-text/50 truncate">{item.subtitle}</div>
+              <div className="text-xs text-daintree-text/50 truncate transition-colors group-aria-selected:text-daintree-text/60">
+                {item.subtitle}
+              </div>
             </TooltipTrigger>
             <TooltipContent side="bottom">{item.subtitle}</TooltipContent>
           </Tooltip>

--- a/src/components/Terminal/PromptHistoryPalette.tsx
+++ b/src/components/Terminal/PromptHistoryPalette.tsx
@@ -26,6 +26,55 @@ function truncatePrompt(text: string, maxLen = 80): string {
   return firstLine.slice(0, maxLen) + "…";
 }
 
+interface PromptHistoryRowProps {
+  item: PromptHistoryEntry;
+  index: number;
+  isSelected: boolean;
+  onSelect: (item: PromptHistoryEntry) => void;
+  onHoverIndex: (index: number) => void;
+}
+
+export function PromptHistoryRow({
+  item,
+  index,
+  isSelected,
+  onSelect,
+  onHoverIndex,
+}: PromptHistoryRowProps) {
+  return (
+    <button
+      type="button"
+      id={`prompt-history-option-${item.id}`}
+      tabIndex={-1}
+      onPointerDown={(e) => e.preventDefault()}
+      onPointerMove={() => onHoverIndex(index)}
+      role="option"
+      aria-selected={isSelected}
+      className={cn(
+        "group relative w-full flex items-center justify-between gap-2 px-3 py-2 rounded-[var(--radius-md)] text-sm text-left transition-colors",
+        "border border-transparent text-daintree-text/80",
+        "hover:bg-overlay-subtle hover:text-daintree-text",
+        "aria-selected:bg-overlay-soft aria-selected:border-overlay aria-selected:text-daintree-text",
+        "aria-selected:before:absolute aria-selected:before:left-0 aria-selected:before:top-2 aria-selected:before:bottom-2",
+        "aria-selected:before:w-[2px] aria-selected:before:bg-daintree-accent aria-selected:before:content-['']"
+      )}
+      onClick={() => onSelect(item)}
+    >
+      <span className="truncate font-mono text-xs">{truncatePrompt(item.prompt)}</span>
+      <div className="flex items-center gap-2 shrink-0">
+        {item.agentId && (
+          <span className="text-[10px] px-1.5 py-0.5 rounded bg-daintree-border text-daintree-text/60">
+            {item.agentId}
+          </span>
+        )}
+        <span className="text-[10px] text-daintree-text/40 transition-colors group-aria-selected:text-daintree-text/60">
+          {formatRelativeTime(item.addedAt)}
+        </span>
+      </div>
+    </button>
+  );
+}
+
 export interface PromptHistoryPaletteProps extends UsePromptHistoryPaletteOptions {
   onOpenRef?: React.MutableRefObject<(() => void) | null>;
 }
@@ -38,6 +87,7 @@ export function PromptHistoryPalette({ onOpenRef, ...props }: PromptHistoryPalet
     totalResults,
     selectedIndex,
     setQuery,
+    setSelectedIndex,
     selectPrevious,
     selectNext,
     confirmSelection,
@@ -59,32 +109,20 @@ export function PromptHistoryPalette({ onOpenRef, ...props }: PromptHistoryPalet
   const getItemId = useCallback((item: PromptHistoryEntry) => item.id, []);
 
   const renderItem = useCallback(
-    (item: PromptHistoryEntry, _index: number, isSelected: boolean) => (
-      <div
+    (
+      item: PromptHistoryEntry,
+      index: number,
+      isSelected: boolean,
+      onHoverIndex: (index: number) => void
+    ) => (
+      <PromptHistoryRow
         key={item.id}
-        id={`prompt-history-option-${item.id}`}
-        role="option"
-        aria-selected={isSelected}
-        className={cn(
-          "flex items-center justify-between gap-2 px-3 py-2 rounded-[var(--radius-md)] cursor-pointer text-sm",
-          isSelected
-            ? "bg-overlay-soft text-daintree-text"
-            : "text-daintree-text/80 hover:bg-daintree-sidebar"
-        )}
-        onClick={() => selectEntry(item)}
-      >
-        <span className="truncate font-mono text-xs">{truncatePrompt(item.prompt)}</span>
-        <div className="flex items-center gap-2 shrink-0">
-          {item.agentId && (
-            <span className="text-[10px] px-1.5 py-0.5 rounded bg-daintree-border text-daintree-text/60">
-              {item.agentId}
-            </span>
-          )}
-          <span className="text-[10px] text-daintree-text/40">
-            {formatRelativeTime(item.addedAt)}
-          </span>
-        </div>
-      </div>
+        item={item}
+        index={index}
+        isSelected={isSelected}
+        onSelect={selectEntry}
+        onHoverIndex={onHoverIndex}
+      />
     ),
     [selectEntry]
   );
@@ -122,6 +160,7 @@ export function PromptHistoryPalette({ onOpenRef, ...props }: PromptHistoryPalet
       onSelectNext={selectNext}
       onConfirm={confirmSelection}
       onClose={close}
+      onHoverIndex={setSelectedIndex}
       getItemId={getItemId}
       renderItem={renderItem}
       label="Prompt History"

--- a/src/components/Terminal/SendToAgentPalette.tsx
+++ b/src/components/Terminal/SendToAgentPalette.tsx
@@ -39,14 +39,16 @@ function SendToAgentItemRow({
       tabIndex={-1}
       onPointerDown={(e) => e.preventDefault()}
       className={cn(
-        "relative w-full flex items-center gap-3 px-3 py-2 rounded-[var(--radius-md)] text-left",
-        "transition-colors",
-        "border",
+        "group relative w-full flex items-center gap-3 px-3 py-2 rounded-[var(--radius-md)] text-left transition-colors",
         item.isInputLocked
-          ? "opacity-40 cursor-not-allowed border-transparent"
-          : isSelected
-            ? "bg-overlay-soft border-overlay text-daintree-text before:absolute before:left-0 before:top-2 before:bottom-2 before:w-[2px] before:rounded-r before:bg-daintree-accent before:content-['']"
-            : "border-transparent text-daintree-text/70 hover:bg-overlay-subtle hover:text-daintree-text"
+          ? "opacity-40 cursor-not-allowed border border-transparent"
+          : [
+              "border border-transparent text-daintree-text/70",
+              "hover:bg-overlay-subtle hover:text-daintree-text",
+              "aria-selected:bg-overlay-soft aria-selected:border-overlay aria-selected:text-daintree-text",
+              "aria-selected:before:absolute aria-selected:before:left-0 aria-selected:before:top-2 aria-selected:before:bottom-2",
+              "aria-selected:before:w-[2px] aria-selected:before:bg-daintree-accent aria-selected:before:content-['']",
+            ]
       )}
       onClick={() => !item.isInputLocked && onSelect(item)}
       aria-selected={isSelected}

--- a/src/components/Terminal/__tests__/PromptHistoryPalette.row.test.tsx
+++ b/src/components/Terminal/__tests__/PromptHistoryPalette.row.test.tsx
@@ -1,0 +1,201 @@
+// @vitest-environment jsdom
+import { fireEvent, render, screen } from "@testing-library/react";
+import { describe, expect, it, vi } from "vitest";
+import { PromptHistoryRow } from "../PromptHistoryPalette";
+import type { PromptHistoryEntry } from "@/store/commandHistoryStore";
+
+vi.mock("@/lib/utils", () => ({
+  cn: (...args: unknown[]) => args.filter(Boolean).join(" "),
+}));
+
+function makeEntry(overrides: Partial<PromptHistoryEntry> = {}): PromptHistoryEntry {
+  return {
+    id: "entry-1",
+    prompt: "fix the login bug",
+    agentId: "claude",
+    addedAt: Date.now(),
+    ...overrides,
+  };
+}
+
+describe("PromptHistoryRow", () => {
+  it("renders as a <button> with role=option", () => {
+    const { container } = render(
+      <PromptHistoryRow
+        item={makeEntry()}
+        index={0}
+        isSelected={false}
+        onSelect={vi.fn()}
+        onHoverIndex={vi.fn()}
+      />
+    );
+
+    const button = container.querySelector("button");
+    expect(button).toBeTruthy();
+    expect(button?.getAttribute("type")).toBe("button");
+    expect(button?.getAttribute("role")).toBe("option");
+  });
+
+  it("sets aria-selected from isSelected prop", () => {
+    const { container: selectedContainer } = render(
+      <PromptHistoryRow
+        item={makeEntry()}
+        index={0}
+        isSelected={true}
+        onSelect={vi.fn()}
+        onHoverIndex={vi.fn()}
+      />
+    );
+    const { container: unselectedContainer } = render(
+      <PromptHistoryRow
+        item={makeEntry()}
+        index={0}
+        isSelected={false}
+        onSelect={vi.fn()}
+        onHoverIndex={vi.fn()}
+      />
+    );
+
+    expect(selectedContainer.querySelector("button")?.getAttribute("aria-selected")).toBe("true");
+    expect(unselectedContainer.querySelector("button")?.getAttribute("aria-selected")).toBe(
+      "false"
+    );
+  });
+
+  it("does not branch styling on isSelected — selection is purely aria-driven", () => {
+    const { container: selectedContainer } = render(
+      <PromptHistoryRow
+        item={makeEntry()}
+        index={0}
+        isSelected={true}
+        onSelect={vi.fn()}
+        onHoverIndex={vi.fn()}
+      />
+    );
+    const { container: unselectedContainer } = render(
+      <PromptHistoryRow
+        item={makeEntry()}
+        index={0}
+        isSelected={false}
+        onSelect={vi.fn()}
+        onHoverIndex={vi.fn()}
+      />
+    );
+
+    expect(selectedContainer.querySelector("button")?.className).toBe(
+      unselectedContainer.querySelector("button")?.className
+    );
+  });
+
+  it("applies the canonical aria-selected variant classes", () => {
+    const { container } = render(
+      <PromptHistoryRow
+        item={makeEntry()}
+        index={0}
+        isSelected={true}
+        onSelect={vi.fn()}
+        onHoverIndex={vi.fn()}
+      />
+    );
+
+    const className = container.querySelector("button")?.className ?? "";
+    expect(className).toContain("group");
+    expect(className).toContain("aria-selected:bg-overlay-soft");
+    expect(className).toContain("aria-selected:before:content-['']");
+    expect(className).toContain("hover:bg-overlay-subtle");
+  });
+
+  it("does NOT include before:rounded-r on the accent stripe", () => {
+    const { container } = render(
+      <PromptHistoryRow
+        item={makeEntry()}
+        index={0}
+        isSelected={true}
+        onSelect={vi.fn()}
+        onHoverIndex={vi.fn()}
+      />
+    );
+
+    const className = container.querySelector("button")?.className ?? "";
+    expect(className).not.toContain("rounded-r");
+  });
+
+  it("calls onHoverIndex with the row's index on pointer move", () => {
+    const onHoverIndex = vi.fn();
+    const { container } = render(
+      <PromptHistoryRow
+        item={makeEntry()}
+        index={3}
+        isSelected={false}
+        onSelect={vi.fn()}
+        onHoverIndex={onHoverIndex}
+      />
+    );
+
+    fireEvent.pointerMove(container.querySelector("button")!);
+    expect(onHoverIndex).toHaveBeenCalledTimes(1);
+    expect(onHoverIndex).toHaveBeenCalledWith(3);
+  });
+
+  it("calls onSelect with the item when clicked", () => {
+    const onSelect = vi.fn();
+    const entry = makeEntry();
+    const { container } = render(
+      <PromptHistoryRow
+        item={entry}
+        index={0}
+        isSelected={false}
+        onSelect={onSelect}
+        onHoverIndex={vi.fn()}
+      />
+    );
+
+    fireEvent.click(container.querySelector("button")!);
+    expect(onSelect).toHaveBeenCalledTimes(1);
+    expect(onSelect).toHaveBeenCalledWith(entry);
+  });
+
+  it("renders the timestamp with group-aria-selected brightness lift", () => {
+    render(
+      <PromptHistoryRow
+        item={makeEntry()}
+        index={0}
+        isSelected={true}
+        onSelect={vi.fn()}
+        onHoverIndex={vi.fn()}
+      />
+    );
+
+    const timestamp = screen.getByText(/ago|just now|\d/);
+    expect(timestamp.className).toContain("text-daintree-text/40");
+    expect(timestamp.className).toContain("group-aria-selected:text-daintree-text/60");
+  });
+
+  it("renders the agentId chip when provided", () => {
+    render(
+      <PromptHistoryRow
+        item={makeEntry({ agentId: "gemini" })}
+        index={0}
+        isSelected={false}
+        onSelect={vi.fn()}
+        onHoverIndex={vi.fn()}
+      />
+    );
+
+    expect(screen.getByText("gemini")).toBeTruthy();
+  });
+
+  it("omits the agentId chip when agentId is null", () => {
+    render(
+      <PromptHistoryRow
+        item={makeEntry({ agentId: null })}
+        index={0}
+        isSelected={false}
+        onSelect={vi.fn()}
+        onHoverIndex={vi.fn()}
+      />
+    );
+
+    expect(screen.queryByText("claude")).toBeNull();
+  });
+});

--- a/src/components/TerminalPalette/NewTerminalPalette.tsx
+++ b/src/components/TerminalPalette/NewTerminalPalette.tsx
@@ -135,10 +135,12 @@ export function NewTerminalPalette({
                 role="option"
                 aria-selected={index === selectedIndex}
                 className={cn(
-                  "relative w-full flex items-center gap-3 px-3 py-2 rounded-[var(--radius-md)] text-left transition-colors border",
-                  index === selectedIndex
-                    ? "bg-overlay-soft border-overlay text-daintree-text before:absolute before:left-0 before:top-2 before:bottom-2 before:w-[2px] before:rounded-r before:bg-daintree-accent before:content-['']"
-                    : "border-transparent text-daintree-text/70 hover:bg-overlay-subtle hover:text-daintree-text"
+                  "group relative w-full flex items-center gap-3 px-3 py-2 rounded-[var(--radius-md)] text-left transition-colors",
+                  "border border-transparent text-daintree-text/70",
+                  "hover:bg-overlay-subtle hover:text-daintree-text",
+                  "aria-selected:bg-overlay-soft aria-selected:border-overlay aria-selected:text-daintree-text",
+                  "aria-selected:before:absolute aria-selected:before:left-0 aria-selected:before:top-2 aria-selected:before:bottom-2",
+                  "aria-selected:before:w-[2px] aria-selected:before:bg-daintree-accent aria-selected:before:content-['']"
                 )}
                 onClick={() => onSelect(option)}
               >

--- a/src/components/ThemePalette/ThemePalette.tsx
+++ b/src/components/ThemePalette/ThemePalette.tsx
@@ -40,10 +40,10 @@ function ThemeListItem({
       role="option"
       aria-selected={isSelected}
       className={cn(
-        "relative w-full text-left px-3 py-2 rounded-[var(--radius-md)] border flex items-center gap-3 transition-colors",
+        "group relative w-full text-left px-3 py-2 rounded-[var(--radius-md)] border flex items-center gap-3 transition-colors",
         "border-daintree-border/40 hover:border-daintree-border/60 hover:bg-surface",
         isSelected &&
-          "border-overlay bg-overlay-soft text-daintree-text before:absolute before:left-0 before:top-2 before:bottom-2 before:w-[2px] before:rounded-r before:bg-daintree-accent before:content-['']"
+          "border-overlay bg-overlay-soft text-daintree-text before:absolute before:left-0 before:top-2 before:bottom-2 before:w-[2px] before:bg-daintree-accent before:content-['']"
       )}
     >
       <PaletteStrip scheme={scheme} />
@@ -54,7 +54,7 @@ function ThemeListItem({
         )}
       </div>
       <div className="flex items-center gap-2 shrink-0">
-        <span className="text-[10px] uppercase tracking-wider text-daintree-text/40">
+        <span className="text-[10px] uppercase tracking-wider text-daintree-text/40 transition-colors group-aria-selected:text-daintree-text/60">
           {scheme.type === "light" ? "Light" : "Dark"}
         </span>
         {isActive && (

--- a/src/components/Worktree/WorktreePalette.tsx
+++ b/src/components/Worktree/WorktreePalette.tsx
@@ -25,11 +25,11 @@ function WorktreeListItem({ worktree, isActive, isSelected, onClick }: WorktreeL
         id={`worktree-option-${worktree.id}`}
         onClick={onClick}
         className={cn(
-          "relative w-full text-left px-3 py-2 rounded-[var(--radius-lg)] border flex flex-col gap-0.5",
+          "group relative w-full text-left px-3 py-2 rounded-[var(--radius-lg)] border flex flex-col gap-0.5",
           "border-daintree-border/40 hover:border-daintree-border/60",
           "bg-daintree-bg hover:bg-surface transition-colors",
           isSelected &&
-            "border-overlay bg-overlay-soft text-daintree-text before:absolute before:left-0 before:top-2 before:bottom-2 before:w-[2px] before:rounded-r before:bg-daintree-accent before:content-['']"
+            "border-overlay bg-overlay-soft text-daintree-text before:absolute before:left-0 before:top-2 before:bottom-2 before:w-[2px] before:bg-daintree-accent before:content-['']"
         )}
         aria-selected={isSelected}
         role="option"
@@ -47,7 +47,10 @@ function WorktreeListItem({ worktree, isActive, isSelected, onClick }: WorktreeL
             )}
           </div>
         </div>
-        <div ref={ref} className="text-[11px] text-daintree-text/50 truncate">
+        <div
+          ref={ref}
+          className="text-[11px] text-daintree-text/50 truncate transition-colors group-aria-selected:text-daintree-text/60"
+        >
           {worktree.path}
         </div>
       </button>

--- a/src/components/ui/AppPaletteDialog.tsx
+++ b/src/components/ui/AppPaletteDialog.tsx
@@ -1,4 +1,4 @@
-import { useCallback, useEffect, useRef } from "react";
+import { useCallback, useDeferredValue, useEffect, useRef } from "react";
 import { createPortal } from "react-dom";
 import { cn } from "@/lib/utils";
 import { TABBABLE_SELECTOR } from "@/lib/accessibility";
@@ -446,12 +446,18 @@ AppPaletteDialog.Empty = function AppPaletteEmpty({
   children,
 }: AppPaletteEmptyProps) {
   const trimmedQuery = query.trim();
+  // Defer the *displayed* query so the title doesn't redraw every keystroke
+  // while a fast typist is filling the input. The branch decision still uses
+  // the immediate `trimmedQuery` so clearing the input flips back to
+  // zero-data without a stale "No matches for ..." flash.
+  const deferredTrimmedQuery = useDeferredValue(trimmedQuery);
   if (trimmedQuery) {
+    const displayQuery = deferredTrimmedQuery || trimmedQuery;
     return (
       <EmptyState
         variant="filtered-empty"
         scale="popover"
-        title={noMatchMessage ?? defaultNoMatchTitle(trimmedQuery)}
+        title={noMatchMessage ?? defaultNoMatchTitle(displayQuery)}
         action={noMatchContent}
         className="px-3 py-8"
       />


### PR DESCRIPTION
## Summary

- Brings two outlier rows onto the canonical `ActionPaletteItem` pattern: `PromptHistoryPalette` was a `<div>` with wrong hover token and no accent stripe; `NewTerminalPalette` used ternary-based selection styling instead of `aria-selected:` variants and had no `group` class
- Right-aligned metadata in `QuickSwitcherItem`, `WorktreePalette`, and `ThemePalette` now picks up the `group-aria-selected:` brightness lift that keybinding glyphs in `ActionPaletteItem` already had
- Wraps the `AppPaletteDialog.Empty` query in `useDeferredValue` (gated on `query !== ""`) so the "No matches for ..." title settles after typing instead of updating per keystroke; removes a no-op `before:rounded-r` from all six accent-stripe sites; adds a `PromptHistoryRow` contract test

Resolves #7969

## Changes

- `PromptHistoryPalette.tsx` — `<div>` → `<button>`, `hover:bg-daintree-sidebar` → `hover:bg-overlay-subtle`, `border-overlay` divider and `before:bg-daintree-accent` stripe added, `onPointerMove` pointer-sync wired
- `NewTerminalPalette.tsx` — ternary selection classes replaced with `aria-selected:` variants, `group` added to the row
- `QuickSwitcherItem.tsx`, `WorktreePalette.tsx`, `ThemePalette.tsx` — neutral metadata wrapped in `group` + `group-aria-selected:text-daintree-text/60` brightness lift
- `AppPaletteDialog.tsx` — `useDeferredValue` on the displayed query, guarded so stale text doesn't linger after clear
- Six accent-stripe sites — `before:rounded-r` removed
- `PromptHistoryPalette.row.test.tsx` — contract test covering selection, pointer-sync, and hover token

## Testing

49 vitest tests across 5 files pass. Full `npm run check` (typecheck, lint ratchet, format, build, channels, ipc, help) green.