### PR TITLE
feat(updates): in-app update notification for Windows Store builds

### DIFF
--- a/electron/ipc/channels.ts
+++ b/electron/ipc/channels.ts
@@ -422,6 +422,15 @@ export const CHANNELS = {
   UPDATE_DISMISS_TOAST: "update:dismiss-toast",
   UPDATE_GET_LAST_CHECK: "update:get-last-check",
 
+  // Windows Store update notification channels (separate from electron-updater
+  // because Store builds can't auto-install — these power a notify-only path
+  // that polls the existing CDN feeds and deep-links to the Microsoft Store).
+  STORE_UPDATE_AVAILABLE: "store-update:available",
+  STORE_UPDATE_GET_LATEST: "store-update:get-latest",
+  STORE_UPDATE_DISMISS: "store-update:dismiss",
+  STORE_UPDATE_GET_SETTINGS: "store-update:get-settings",
+  STORE_UPDATE_SET_SETTINGS: "store-update:set-settings",
+
   SLASH_COMMANDS_LIST: "slash-commands:list",
 
   GEMINI_GET_STATUS: "gemini:get-status",

--- a/electron/preload.cts
+++ b/electron/preload.cts
@@ -2097,6 +2097,22 @@ const api: ElectronAPI = {
     getLastCheck: () => _unwrappingInvoke(CHANNELS.UPDATE_GET_LAST_CHECK),
   },
 
+  // Windows Store update-notification API (parallel to `update`; only active
+  // on MSIX/AppX builds where electron-updater is suppressed).
+  storeUpdate: {
+    onUpdateAvailable: (callback: (info: { version: string; storeUrl: string }) => void) =>
+      _typedOn(CHANNELS.STORE_UPDATE_AVAILABLE, callback),
+
+    getLatest: () => _unwrappingInvoke(CHANNELS.STORE_UPDATE_GET_LATEST),
+
+    dismiss: (version: string) => _unwrappingInvoke(CHANNELS.STORE_UPDATE_DISMISS, version),
+
+    getSettings: () => _unwrappingInvoke(CHANNELS.STORE_UPDATE_GET_SETTINGS),
+
+    setSettings: (enabled: boolean) =>
+      _unwrappingInvoke(CHANNELS.STORE_UPDATE_SET_SETTINGS, enabled),
+  },
+
   // Gemini API
   gemini: {
     getStatus: () => _unwrappingInvoke(CHANNELS.GEMINI_GET_STATUS),

--- a/electron/services/WindowsStoreNotifierService.ts
+++ b/electron/services/WindowsStoreNotifierService.ts
@@ -90,6 +90,12 @@ class WindowsStoreNotifierService {
   private handlersRegistered = false;
   private lastDetected: DetectedStoreUpdate | null = null;
   private activeFeedUrl: string | null = null;
+  // Holds the ETag from a 200 response until the renderer confirms the user
+  // has seen the notification (via DISMISS). If the app crashes before that
+  // confirmation, we WANT the next launch to re-fetch the full body — storing
+  // the ETag eagerly would let a future 304 silently suppress the version
+  // forever (no broadcast, no lastNotifiedStoreVersion write).
+  private pendingEtag: { version: string; etag: string } | null = null;
 
   private clearRetryTimeout(): void {
     if (this.retryTimeout) {
@@ -183,14 +189,10 @@ class WindowsStoreNotifierService {
     if (!VERSION_ALLOWLIST.test(trimmed)) return null;
     if (!semver.valid(trimmed)) return null;
     const etag = res.headers.get("etag");
-    if (etag) {
-      try {
-        store.set("storeNotifierEtag", etag);
-      } catch {
-        // Persistence is best-effort — a write failure means we re-fetch
-        // the full body next tick, but the version compare still works.
-      }
-    }
+    // Don't persist the ETag yet — see `pendingEtag` field comment. We pair
+    // the version + ETag in memory so the DISMISS handler can commit them
+    // together after the user has actually been shown the notification.
+    this.pendingEtag = etag ? { version: trimmed, etag } : null;
     return trimmed;
   }
 
@@ -218,6 +220,13 @@ class WindowsStoreNotifierService {
       this.resetRetryState();
       if (remoteVersion === null) return;
       if (!this.shouldNotify(remoteVersion)) return;
+      // Re-check the toggle after the fetch resolves — a user who flipped the
+      // switch off during the network round-trip shouldn't still see a toast.
+      const stillEnabled = store.get("storeUpdateNotificationsEnabled") ?? true;
+      if (!stillEnabled) {
+        this.pendingEtag = null;
+        return;
+      }
       const detected: DetectedStoreUpdate = {
         version: remoteVersion,
         storeUrl: buildStoreUrl(),
@@ -271,6 +280,7 @@ class WindowsStoreNotifierService {
           // immediately fire a stale notification.
           this.resetRetryState();
           this.lastDetected = null;
+          this.pendingEtag = null;
         }
         return { enabled: validated };
       });
@@ -288,6 +298,19 @@ class WindowsStoreNotifierService {
         if (!VERSION_ALLOWLIST.test(trimmed)) return;
         if (!semver.valid(trimmed)) return;
         store.set("lastNotifiedStoreVersion", trimmed);
+        // Commit the paired ETag now that the user has been notified. If a
+        // mid-flight crash had wiped this in-memory state, we'd have re-
+        // fetched the full body on next launch instead of being suppressed
+        // forever by a stored ETag for an un-dismissed version.
+        if (this.pendingEtag && this.pendingEtag.version === trimmed) {
+          try {
+            store.set("storeNotifierEtag", this.pendingEtag.etag);
+          } catch {
+            // Best-effort — a write failure means we re-fetch the body next
+            // tick. Version compare still works via lastNotifiedStoreVersion.
+          }
+          this.pendingEtag = null;
+        }
       });
 
       this.handlersRegistered = true;
@@ -400,6 +423,7 @@ class WindowsStoreNotifierService {
     this.handlersRegistered = false;
     this.lastDetected = null;
     this.activeFeedUrl = null;
+    this.pendingEtag = null;
     this.initialized = false;
   }
 }

--- a/electron/services/WindowsStoreNotifierService.ts
+++ b/electron/services/WindowsStoreNotifierService.ts
@@ -1,0 +1,408 @@
+import { app, ipcMain, net } from "electron";
+import { load as parseYaml } from "js-yaml";
+import * as semver from "semver";
+import { CHANNELS } from "../ipc/channels.js";
+import { broadcastToRenderer } from "../ipc/utils.js";
+import { getSystemSleepService } from "./SystemSleepService.js";
+import { store } from "../store.js";
+import { isTrustedRendererUrl } from "../../shared/utils/trustedRenderer.js";
+import { isWindowsStoreBuild } from "../../shared/config/distribution.js";
+
+// Store handles installs every ~8 hours, so polling more often than the OS does
+// makes us look noisy without surfacing anything sooner.
+const CHECK_INTERVAL_MS = 8 * 60 * 60 * 1000;
+const RETRY_BASE_DELAYS_MS = [30_000, 120_000, 480_000] as const;
+const MAX_RETRIES = RETRY_BASE_DELAYS_MS.length;
+const STARTUP_JITTER_MAX_MS = 60_000;
+const RESUME_CHECK_DELAY_MS = 7_000;
+const VERSION_MAX_LEN = 64;
+// Same canonical-form gate as AutoUpdaterService — strict numeric leading
+// digit prevents `v1.2.3`/`=1.2.3` from round-tripping through the store.
+const VERSION_ALLOWLIST = /^[0-9][0-9a-zA-Z._+-]{0,63}$/;
+
+// Public CDN paths — duplicated here on purpose. Coupling the Store notifier
+// to AutoUpdaterService just to share two strings would force a load-order
+// dependency for no benefit.
+const STABLE_FEED_URL = "https://updates.daintree.org/releases/";
+const NIGHTLY_FEED_URL = "https://updates.daintree.org/nightly/";
+
+const TRANSIENT_NET_ERROR_TOKENS = new Set([
+  "ERR_INTERNET_DISCONNECTED",
+  "ERR_NETWORK_CHANGED",
+  "ERR_CONNECTION_RESET",
+  "ERR_CONNECTION_ABORTED",
+  "ERR_CONNECTION_CLOSED",
+  "ERR_CONNECTION_REFUSED",
+  "ERR_CONNECTION_TIMED_OUT",
+  "ERR_TIMED_OUT",
+  "ERR_NAME_NOT_RESOLVED",
+  "ERR_DNS_TIMED_OUT",
+  "ERR_ADDRESS_UNREACHABLE",
+]);
+const PERMANENT_NET_ERROR_TOKENS = new Set([
+  "ERR_CERT_DATE_INVALID",
+  "ERR_CERT_AUTHORITY_INVALID",
+  "ERR_CERT_COMMON_NAME_INVALID",
+  "ERR_CERT_REVOKED",
+  "ERR_SSL_PROTOCOL_ERROR",
+  "ERR_BLOCKED_BY_CLIENT",
+  "ERR_NETWORK_ACCESS_DENIED",
+]);
+const ELECTRON_NET_TOKEN_RE = /net::([A-Z0-9_]+)/g;
+
+const MS_STORE_FALLBACK_URL = "ms-windows-store://downloadsandupdates";
+
+export interface DetectedStoreUpdate {
+  version: string;
+  storeUrl: string;
+}
+
+function buildStoreUrl(): string {
+  const productId = process.env.DAINTREE_MICROSOFT_STORE_PRODUCT_ID;
+  if (typeof productId !== "string") return MS_STORE_FALLBACK_URL;
+  const trimmed = productId.trim();
+  // Partner Center product IDs are 12 alphanumeric chars (e.g. 9NBLGGH4NNS1).
+  // Any deviation falls back so a stale or malformed env var can't produce a
+  // dead ms-windows-store URI.
+  if (!/^[A-Za-z0-9]{12}$/.test(trimmed)) return MS_STORE_FALLBACK_URL;
+  return `ms-windows-store://pdp/?ProductId=${trimmed}`;
+}
+
+function feedUrlForChannel(channel: "stable" | "nightly"): string {
+  return channel === "nightly" ? NIGHTLY_FEED_URL : STABLE_FEED_URL;
+}
+
+// electron-builder publishes per-platform manifests; the notifier polls the
+// Windows variant since this service only runs in Store builds.
+function manifestUrl(feedUrl: string): string {
+  return `${feedUrl}latest.yml`;
+}
+
+class WindowsStoreNotifierService {
+  private checkInterval: NodeJS.Timeout | null = null;
+  private startupJitterTimeout: NodeJS.Timeout | null = null;
+  private retryTimeout: NodeJS.Timeout | null = null;
+  private resumeTimeout: NodeJS.Timeout | null = null;
+  private removeSuspendListener: (() => void) | null = null;
+  private removeWakeListener: (() => void) | null = null;
+  private retryCount = 0;
+  private initialized = false;
+  private handlersRegistered = false;
+  private lastDetected: DetectedStoreUpdate | null = null;
+  private activeFeedUrl: string | null = null;
+
+  private clearRetryTimeout(): void {
+    if (this.retryTimeout) {
+      clearTimeout(this.retryTimeout);
+      this.retryTimeout = null;
+    }
+  }
+
+  private resetRetryState(): void {
+    this.clearRetryTimeout();
+    this.retryCount = 0;
+  }
+
+  // Same fail-closed posture as AutoUpdaterService: only the explicitly
+  // catalogued transient signals retry. Anything else (404, cert error,
+  // unknown net::ERR_) waits for the next 8-hour tick.
+  private isTransientError(err: unknown): boolean {
+    let current: unknown = err;
+    let foundTransient = false;
+    for (let depth = 0; depth < 5 && current && typeof current === "object"; depth++) {
+      const message = (current as { message?: unknown }).message;
+      if (typeof message === "string") {
+        for (const match of message.matchAll(ELECTRON_NET_TOKEN_RE)) {
+          const token = match[1];
+          if (PERMANENT_NET_ERROR_TOKENS.has(token)) return false;
+          if (TRANSIENT_NET_ERROR_TOKENS.has(token)) foundTransient = true;
+        }
+      }
+      const statusCode = (current as { statusCode?: unknown }).statusCode;
+      if (typeof statusCode === "number") {
+        if (statusCode === 404 || statusCode === 401 || statusCode === 403) return false;
+        if (statusCode >= 500 && statusCode < 600) foundTransient = true;
+        if (statusCode === 408 || statusCode === 429) foundTransient = true;
+      }
+      current = (current as { cause?: unknown }).cause;
+    }
+    return foundTransient;
+  }
+
+  private scheduleRetry(): void {
+    if (this.retryCount >= MAX_RETRIES) return;
+    const base = RETRY_BASE_DELAYS_MS[this.retryCount];
+    const jitterFactor = 0.8 + 0.4 * Math.random();
+    const delay = Math.floor(base * jitterFactor);
+    this.retryCount += 1;
+    this.clearRetryTimeout();
+    this.retryTimeout = setTimeout(() => {
+      this.retryTimeout = null;
+      void this.runCheck("Retry");
+    }, delay);
+  }
+
+  private getActiveFeedUrl(): string {
+    const channel = store.get("updateChannel") ?? "stable";
+    const feedUrl = feedUrlForChannel(channel);
+    // Channel switched between polls — drop the prior ETag so we don't send
+    // a stable-feed validator to the nightly feed (or vice versa).
+    if (this.activeFeedUrl && this.activeFeedUrl !== feedUrl) {
+      try {
+        store.delete("storeNotifierEtag");
+      } catch {
+        // Best-effort — corrupted store reads here shouldn't block polling.
+      }
+    }
+    this.activeFeedUrl = feedUrl;
+    return feedUrl;
+  }
+
+  private async fetchLatestVersion(feedUrl: string): Promise<string | null> {
+    const storedEtag = store.get("storeNotifierEtag");
+    const headers: Record<string, string> = {};
+    if (typeof storedEtag === "string" && storedEtag.length > 0) {
+      headers["If-None-Match"] = storedEtag;
+    }
+    const res = await net.fetch(manifestUrl(feedUrl), { headers });
+    if (res.status === 304) return null;
+    if (!res.ok) {
+      const err: Error & { statusCode?: number } = new Error(
+        `Manifest fetch failed: HTTP ${res.status}`
+      );
+      err.statusCode = res.status;
+      throw err;
+    }
+    const text = await res.text();
+    const parsed = parseYaml(text);
+    if (typeof parsed !== "object" || parsed === null) return null;
+    const version = (parsed as { version?: unknown }).version;
+    if (typeof version !== "string") return null;
+    const trimmed = version.trim();
+    if (trimmed.length === 0 || trimmed.length > VERSION_MAX_LEN) return null;
+    if (!VERSION_ALLOWLIST.test(trimmed)) return null;
+    if (!semver.valid(trimmed)) return null;
+    const etag = res.headers.get("etag");
+    if (etag) {
+      try {
+        store.set("storeNotifierEtag", etag);
+      } catch {
+        // Persistence is best-effort — a write failure means we re-fetch
+        // the full body next tick, but the version compare still works.
+      }
+    }
+    return trimmed;
+  }
+
+  private shouldNotify(remoteVersion: string): boolean {
+    const installed = app.getVersion();
+    const installedSemver = semver.coerce(installed);
+    const remoteSemver = semver.coerce(remoteVersion);
+    if (!installedSemver || !remoteSemver) return false;
+    try {
+      if (!semver.gt(remoteSemver, installedSemver)) return false;
+    } catch {
+      return false;
+    }
+    const lastNotified = store.get("lastNotifiedStoreVersion");
+    if (typeof lastNotified === "string" && lastNotified === remoteVersion) return false;
+    return true;
+  }
+
+  private async runCheck(context: "Initial" | "Periodic" | "Retry" | "Resume"): Promise<void> {
+    try {
+      const enabled = store.get("storeUpdateNotificationsEnabled") ?? true;
+      if (!enabled) return;
+      const feedUrl = this.getActiveFeedUrl();
+      const remoteVersion = await this.fetchLatestVersion(feedUrl);
+      this.resetRetryState();
+      if (remoteVersion === null) return;
+      if (!this.shouldNotify(remoteVersion)) return;
+      const detected: DetectedStoreUpdate = {
+        version: remoteVersion,
+        storeUrl: buildStoreUrl(),
+      };
+      this.lastDetected = detected;
+      broadcastToRenderer(CHANNELS.STORE_UPDATE_AVAILABLE, detected);
+    } catch (err) {
+      console.error(`[MAIN] ${context} Store update check failed:`, err);
+      if (!this.isTransientError(err)) {
+        this.resetRetryState();
+        return;
+      }
+      if (this.retryCount >= MAX_RETRIES) {
+        this.resetRetryState();
+        return;
+      }
+      this.scheduleRetry();
+    }
+  }
+
+  /** Test-only seam: trigger a manual check (bypasses the jitter timer). */
+  async _checkNowForTest(): Promise<void> {
+    await this.runCheck("Initial");
+  }
+
+  getLastDetectedUpdate(): DetectedStoreUpdate | null {
+    return this.lastDetected;
+  }
+
+  initialize(): void {
+    if (this.initialized) return;
+
+    // Register the settings handlers unconditionally so non-Store renderers
+    // that import the preload binding never see `undefined` returns. The
+    // getter/setter just touch electron-store and don't depend on polling.
+    if (!this.handlersRegistered) {
+      ipcMain.handle(CHANNELS.STORE_UPDATE_GET_SETTINGS, () => {
+        const enabled = store.get("storeUpdateNotificationsEnabled") ?? true;
+        return { enabled };
+      });
+
+      ipcMain.handle(CHANNELS.STORE_UPDATE_SET_SETTINGS, (event, enabled: unknown) => {
+        const senderUrl = event.senderFrame?.url;
+        if (!senderUrl || !isTrustedRendererUrl(senderUrl)) {
+          return { enabled: store.get("storeUpdateNotificationsEnabled") ?? true };
+        }
+        const validated = typeof enabled === "boolean" ? enabled : true;
+        store.set("storeUpdateNotificationsEnabled", validated);
+        if (!validated) {
+          // Stop polling and drop the cached detection so a re-enable doesn't
+          // immediately fire a stale notification.
+          this.resetRetryState();
+          this.lastDetected = null;
+        }
+        return { enabled: validated };
+      });
+
+      ipcMain.handle(CHANNELS.STORE_UPDATE_GET_LATEST, () => {
+        return this.lastDetected;
+      });
+
+      ipcMain.handle(CHANNELS.STORE_UPDATE_DISMISS, (event, version: unknown) => {
+        const senderUrl = event.senderFrame?.url;
+        if (!senderUrl || !isTrustedRendererUrl(senderUrl)) return;
+        if (typeof version !== "string") return;
+        const trimmed = version.trim();
+        if (trimmed.length === 0 || trimmed.length > VERSION_MAX_LEN) return;
+        if (!VERSION_ALLOWLIST.test(trimmed)) return;
+        if (!semver.valid(trimmed)) return;
+        store.set("lastNotifiedStoreVersion", trimmed);
+      });
+
+      this.handlersRegistered = true;
+    }
+
+    if (!isWindowsStoreBuild()) {
+      console.log("[MAIN] Store update notifier inactive: not a Windows Store build");
+      return;
+    }
+
+    if (!app.isPackaged) {
+      console.log("[MAIN] Store update notifier inactive: not packaged");
+      return;
+    }
+
+    try {
+      const startupJitterMs = Math.floor(Math.random() * STARTUP_JITTER_MAX_MS);
+      this.startupJitterTimeout = setTimeout(() => {
+        this.startupJitterTimeout = null;
+        void this.runCheck("Initial");
+      }, startupJitterMs);
+
+      this.checkInterval = setInterval(() => {
+        void this.runCheck("Periodic");
+      }, CHECK_INTERVAL_MS);
+
+      try {
+        this.removeSuspendListener = getSystemSleepService().onSuspend(() => {
+          if (this.checkInterval) {
+            clearInterval(this.checkInterval);
+            this.checkInterval = null;
+          }
+          if (this.startupJitterTimeout) {
+            clearTimeout(this.startupJitterTimeout);
+            this.startupJitterTimeout = null;
+          }
+          if (this.resumeTimeout) {
+            clearTimeout(this.resumeTimeout);
+            this.resumeTimeout = null;
+          }
+          this.resetRetryState();
+        });
+        this.removeWakeListener = getSystemSleepService().onWake(() => {
+          if (this.resumeTimeout || this.checkInterval) return;
+          this.resumeTimeout = setTimeout(() => {
+            this.resumeTimeout = null;
+            void this.runCheck("Resume");
+            if (!this.checkInterval) {
+              this.checkInterval = setInterval(() => {
+                void this.runCheck("Periodic");
+              }, CHECK_INTERVAL_MS);
+            }
+          }, RESUME_CHECK_DELAY_MS);
+        });
+      } catch {
+        // SystemSleepService not initialized — periodic timer covers the gap.
+      }
+
+      this.initialized = true;
+      console.log("[MAIN] Windows Store update notifier initialized");
+    } catch (err) {
+      console.error("[MAIN] Windows Store notifier initialization failed:", err);
+      this.dispose();
+    }
+  }
+
+  dispose(): void {
+    if (this.checkInterval) {
+      clearInterval(this.checkInterval);
+      this.checkInterval = null;
+    }
+    if (this.startupJitterTimeout) {
+      clearTimeout(this.startupJitterTimeout);
+      this.startupJitterTimeout = null;
+    }
+    this.clearRetryTimeout();
+    if (this.resumeTimeout) {
+      clearTimeout(this.resumeTimeout);
+      this.resumeTimeout = null;
+    }
+    this.retryCount = 0;
+    if (this.removeSuspendListener) {
+      this.removeSuspendListener();
+      this.removeSuspendListener = null;
+    }
+    if (this.removeWakeListener) {
+      this.removeWakeListener();
+      this.removeWakeListener = null;
+    }
+    try {
+      ipcMain.removeHandler(CHANNELS.STORE_UPDATE_GET_SETTINGS);
+    } catch {
+      // Handler may not have been registered.
+    }
+    try {
+      ipcMain.removeHandler(CHANNELS.STORE_UPDATE_SET_SETTINGS);
+    } catch {
+      // Handler may not have been registered.
+    }
+    try {
+      ipcMain.removeHandler(CHANNELS.STORE_UPDATE_GET_LATEST);
+    } catch {
+      // Handler may not have been registered.
+    }
+    try {
+      ipcMain.removeHandler(CHANNELS.STORE_UPDATE_DISMISS);
+    } catch {
+      // Handler may not have been registered.
+    }
+    this.handlersRegistered = false;
+    this.lastDetected = null;
+    this.activeFeedUrl = null;
+    this.initialized = false;
+  }
+}
+
+export const windowsStoreNotifierService = new WindowsStoreNotifierService();
+export { buildStoreUrl, MS_STORE_FALLBACK_URL };

--- a/electron/services/__tests__/WindowsStoreNotifierService.test.ts
+++ b/electron/services/__tests__/WindowsStoreNotifierService.test.ts
@@ -1,0 +1,314 @@
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+
+const appMock = vi.hoisted(() => ({
+  isPackaged: true,
+  getVersion: vi.fn(() => "1.0.0"),
+}));
+
+const ipcMainMock = vi.hoisted(() => ({
+  handle: vi.fn(),
+  removeHandler: vi.fn(),
+}));
+
+const netMock = vi.hoisted(() => ({
+  fetch: vi.fn(),
+}));
+
+const broadcastMock = vi.hoisted(() => vi.fn());
+
+const storeMock = vi.hoisted(() => ({
+  get: vi.fn((_key: string): unknown => undefined),
+  set: vi.fn(),
+  delete: vi.fn(),
+}));
+
+const trustedRendererMock = vi.hoisted(() => ({
+  isTrustedRendererUrl: vi.fn((url: string) => url.startsWith("app://daintree")),
+}));
+
+const distributionMock = vi.hoisted(() => ({
+  isWindowsStoreBuild: vi.fn(() => true),
+}));
+
+const systemSleepMock = vi.hoisted(() => ({
+  onSuspend: vi.fn(() => () => {}),
+  onWake: vi.fn(() => () => {}),
+}));
+
+vi.mock("electron", () => ({
+  app: appMock,
+  ipcMain: ipcMainMock,
+  net: netMock,
+}));
+
+vi.mock("../../ipc/utils.js", () => ({
+  broadcastToRenderer: broadcastMock,
+}));
+
+vi.mock("../../store.js", () => ({
+  store: storeMock,
+}));
+
+vi.mock("../../../shared/utils/trustedRenderer.js", () => trustedRendererMock);
+
+vi.mock("../../../shared/config/distribution.js", () => distributionMock);
+
+vi.mock("../SystemSleepService.js", () => ({
+  getSystemSleepService: () => systemSleepMock,
+}));
+
+import {
+  windowsStoreNotifierService,
+  buildStoreUrl,
+  MS_STORE_FALLBACK_URL,
+} from "../WindowsStoreNotifierService.js";
+import { CHANNELS } from "../../ipc/channels.js";
+
+function makeResponse(opts: { status?: number; body?: string; etag?: string | null }): {
+  status: number;
+  ok: boolean;
+  headers: { get: (k: string) => string | null };
+  text: () => Promise<string>;
+} {
+  const status = opts.status ?? 200;
+  return {
+    status,
+    ok: status >= 200 && status < 300,
+    headers: {
+      get: (k: string) => {
+        if (k.toLowerCase() === "etag") return opts.etag ?? null;
+        return null;
+      },
+    },
+    text: async () => opts.body ?? "",
+  };
+}
+
+describe("WindowsStoreNotifierService", () => {
+  beforeEach(() => {
+    vi.useFakeTimers();
+    vi.clearAllMocks();
+    appMock.isPackaged = true;
+    appMock.getVersion.mockReturnValue("1.0.0");
+    distributionMock.isWindowsStoreBuild.mockReturnValue(true);
+    storeMock.get.mockReset().mockImplementation((_key: string) => undefined);
+    storeMock.set.mockReset();
+    storeMock.delete.mockReset();
+    netMock.fetch.mockReset();
+    trustedRendererMock.isTrustedRendererUrl
+      .mockReset()
+      .mockImplementation((url: string) => url.startsWith("app://daintree"));
+    vi.spyOn(console, "log").mockImplementation(() => {});
+    vi.spyOn(console, "error").mockImplementation(() => {});
+    vi.spyOn(console, "warn").mockImplementation(() => {});
+    windowsStoreNotifierService.dispose();
+  });
+
+  afterEach(() => {
+    windowsStoreNotifierService.dispose();
+    vi.useRealTimers();
+    vi.restoreAllMocks();
+    delete process.env.DAINTREE_MICROSOFT_STORE_PRODUCT_ID;
+  });
+
+  describe("buildStoreUrl", () => {
+    it("returns downloadsandupdates URL when product id is unset", () => {
+      delete process.env.DAINTREE_MICROSOFT_STORE_PRODUCT_ID;
+      expect(buildStoreUrl()).toBe(MS_STORE_FALLBACK_URL);
+    });
+
+    it("returns pdp URL with valid product id", () => {
+      process.env.DAINTREE_MICROSOFT_STORE_PRODUCT_ID = "9NBLGGH4NNS1";
+      expect(buildStoreUrl()).toBe("ms-windows-store://pdp/?ProductId=9NBLGGH4NNS1");
+    });
+
+    it("falls back when product id has wrong length or characters", () => {
+      process.env.DAINTREE_MICROSOFT_STORE_PRODUCT_ID = "BAD";
+      expect(buildStoreUrl()).toBe(MS_STORE_FALLBACK_URL);
+      process.env.DAINTREE_MICROSOFT_STORE_PRODUCT_ID = "../../../escape";
+      expect(buildStoreUrl()).toBe(MS_STORE_FALLBACK_URL);
+    });
+  });
+
+  describe("initialize() guards", () => {
+    it("registers IPC handlers but does not start polling on non-Store builds", () => {
+      distributionMock.isWindowsStoreBuild.mockReturnValue(false);
+      windowsStoreNotifierService.initialize();
+      // Settings handlers register so the renderer doesn't see undefined.
+      expect(ipcMainMock.handle).toHaveBeenCalledWith(
+        CHANNELS.STORE_UPDATE_GET_SETTINGS,
+        expect.any(Function)
+      );
+      expect(ipcMainMock.handle).toHaveBeenCalledWith(
+        CHANNELS.STORE_UPDATE_GET_LATEST,
+        expect.any(Function)
+      );
+      // No polling — advance well past the startup jitter window.
+      vi.advanceTimersByTime(120_000);
+      expect(netMock.fetch).not.toHaveBeenCalled();
+    });
+
+    it("does not poll when app is not packaged", () => {
+      appMock.isPackaged = false;
+      windowsStoreNotifierService.initialize();
+      vi.advanceTimersByTime(120_000);
+      expect(netMock.fetch).not.toHaveBeenCalled();
+    });
+  });
+
+  describe("polling and broadcast", () => {
+    it("broadcasts STORE_UPDATE_AVAILABLE when remote version is newer", async () => {
+      netMock.fetch.mockResolvedValueOnce(
+        makeResponse({ body: "version: 1.2.0\nfiles:\n  - url: foo\n", etag: '"abc"' })
+      );
+      windowsStoreNotifierService.initialize();
+      await windowsStoreNotifierService._checkNowForTest();
+      expect(broadcastMock).toHaveBeenCalledWith(CHANNELS.STORE_UPDATE_AVAILABLE, {
+        version: "1.2.0",
+        storeUrl: MS_STORE_FALLBACK_URL,
+      });
+      expect(storeMock.set).toHaveBeenCalledWith("storeNotifierEtag", '"abc"');
+    });
+
+    it("does not broadcast when remote version is equal or older", async () => {
+      appMock.getVersion.mockReturnValue("2.0.0");
+      netMock.fetch.mockResolvedValueOnce(makeResponse({ body: "version: 1.0.0\n", etag: null }));
+      windowsStoreNotifierService.initialize();
+      await windowsStoreNotifierService._checkNowForTest();
+      expect(broadcastMock).not.toHaveBeenCalled();
+    });
+
+    it("suppresses re-broadcast when version equals lastNotifiedStoreVersion", async () => {
+      storeMock.get.mockImplementation((key: string) => {
+        if (key === "lastNotifiedStoreVersion") return "1.5.0";
+        return undefined;
+      });
+      netMock.fetch.mockResolvedValueOnce(makeResponse({ body: "version: 1.5.0\n", etag: null }));
+      windowsStoreNotifierService.initialize();
+      await windowsStoreNotifierService._checkNowForTest();
+      expect(broadcastMock).not.toHaveBeenCalled();
+    });
+
+    it("skips polling when storeUpdateNotificationsEnabled is false", async () => {
+      storeMock.get.mockImplementation((key: string) => {
+        if (key === "storeUpdateNotificationsEnabled") return false;
+        return undefined;
+      });
+      windowsStoreNotifierService.initialize();
+      await windowsStoreNotifierService._checkNowForTest();
+      expect(netMock.fetch).not.toHaveBeenCalled();
+      expect(broadcastMock).not.toHaveBeenCalled();
+    });
+
+    it("sends If-None-Match when an ETag is stored and skips broadcast on 304", async () => {
+      storeMock.get.mockImplementation((key: string) => {
+        if (key === "storeNotifierEtag") return '"prev"';
+        return undefined;
+      });
+      netMock.fetch.mockResolvedValueOnce(makeResponse({ status: 304 }));
+      windowsStoreNotifierService.initialize();
+      await windowsStoreNotifierService._checkNowForTest();
+      const [, options] = netMock.fetch.mock.calls[0];
+      expect(options.headers["If-None-Match"]).toBe('"prev"');
+      expect(broadcastMock).not.toHaveBeenCalled();
+    });
+
+    it("drops stored ETag when the channel switches", async () => {
+      let channel = "stable" as "stable" | "nightly";
+      storeMock.get.mockImplementation((key: string) => {
+        if (key === "updateChannel") return channel;
+        if (key === "storeNotifierEtag") return '"stale"';
+        return undefined;
+      });
+      netMock.fetch.mockResolvedValue(makeResponse({ body: "version: 1.0.0\n", etag: null }));
+      windowsStoreNotifierService.initialize();
+      await windowsStoreNotifierService._checkNowForTest();
+      expect(storeMock.delete).not.toHaveBeenCalledWith("storeNotifierEtag");
+      channel = "nightly";
+      await windowsStoreNotifierService._checkNowForTest();
+      expect(storeMock.delete).toHaveBeenCalledWith("storeNotifierEtag");
+    });
+
+    it("ignores malformed version strings in the YAML payload", async () => {
+      netMock.fetch.mockResolvedValueOnce(
+        makeResponse({ body: "version: '../../etc/passwd'\n", etag: null })
+      );
+      windowsStoreNotifierService.initialize();
+      await windowsStoreNotifierService._checkNowForTest();
+      expect(broadcastMock).not.toHaveBeenCalled();
+    });
+  });
+
+  describe("dismiss handler", () => {
+    it("persists lastNotifiedStoreVersion for a valid semver from a trusted sender", () => {
+      windowsStoreNotifierService.initialize();
+      const dismissCall = ipcMainMock.handle.mock.calls.find(
+        ([ch]) => ch === CHANNELS.STORE_UPDATE_DISMISS
+      );
+      expect(dismissCall).toBeDefined();
+      const handler = dismissCall![1];
+      handler({ senderFrame: { url: "app://daintree/index.html" } }, "1.2.3");
+      expect(storeMock.set).toHaveBeenCalledWith("lastNotifiedStoreVersion", "1.2.3");
+    });
+
+    it("rejects untrusted senders", () => {
+      windowsStoreNotifierService.initialize();
+      const dismissCall = ipcMainMock.handle.mock.calls.find(
+        ([ch]) => ch === CHANNELS.STORE_UPDATE_DISMISS
+      );
+      const handler = dismissCall![1];
+      handler({ senderFrame: { url: "https://evil.example.com" } }, "1.2.3");
+      expect(storeMock.set).not.toHaveBeenCalledWith("lastNotifiedStoreVersion", "1.2.3");
+    });
+
+    it("rejects malformed version strings", () => {
+      windowsStoreNotifierService.initialize();
+      const dismissCall = ipcMainMock.handle.mock.calls.find(
+        ([ch]) => ch === CHANNELS.STORE_UPDATE_DISMISS
+      );
+      const handler = dismissCall![1];
+      handler({ senderFrame: { url: "app://daintree/index.html" } }, "../../../evil");
+      handler({ senderFrame: { url: "app://daintree/index.html" } }, "v1.2.3");
+      handler({ senderFrame: { url: "app://daintree/index.html" } }, "a".repeat(200));
+      expect(storeMock.set).not.toHaveBeenCalledWith(
+        "lastNotifiedStoreVersion",
+        expect.any(String)
+      );
+    });
+  });
+
+  describe("settings handlers", () => {
+    it("defaults enabled to true when the key is absent", () => {
+      windowsStoreNotifierService.initialize();
+      const getCall = ipcMainMock.handle.mock.calls.find(
+        ([ch]) => ch === CHANNELS.STORE_UPDATE_GET_SETTINGS
+      );
+      const result = getCall![1]({});
+      expect(result).toEqual({ enabled: true });
+    });
+
+    it("persists the toggle when a trusted sender invokes set", () => {
+      windowsStoreNotifierService.initialize();
+      const setCall = ipcMainMock.handle.mock.calls.find(
+        ([ch]) => ch === CHANNELS.STORE_UPDATE_SET_SETTINGS
+      );
+      const handler = setCall![1];
+      const result = handler({ senderFrame: { url: "app://daintree/index.html" } }, false);
+      expect(storeMock.set).toHaveBeenCalledWith("storeUpdateNotificationsEnabled", false);
+      expect(result).toEqual({ enabled: false });
+    });
+  });
+
+  describe("getLatest", () => {
+    it("returns the cached detection so the renderer can hydrate after the broadcast", async () => {
+      netMock.fetch.mockResolvedValueOnce(makeResponse({ body: "version: 2.0.0\n", etag: null }));
+      windowsStoreNotifierService.initialize();
+      await windowsStoreNotifierService._checkNowForTest();
+      const getLatestCall = ipcMainMock.handle.mock.calls.find(
+        ([ch]) => ch === CHANNELS.STORE_UPDATE_GET_LATEST
+      );
+      const cached = getLatestCall![1]({});
+      expect(cached).toEqual({ version: "2.0.0", storeUrl: MS_STORE_FALLBACK_URL });
+    });
+  });
+});

--- a/electron/services/__tests__/WindowsStoreNotifierService.test.ts
+++ b/electron/services/__tests__/WindowsStoreNotifierService.test.ts
@@ -167,7 +167,25 @@ describe("WindowsStoreNotifierService", () => {
         version: "1.2.0",
         storeUrl: MS_STORE_FALLBACK_URL,
       });
-      expect(storeMock.set).toHaveBeenCalledWith("storeNotifierEtag", '"abc"');
+      // Critical: ETag must NOT be persisted on the 200-OK path — only after
+      // the renderer confirms via DISMISS. A mid-flight crash before dismiss
+      // would otherwise let the next launch's 304 suppress the version forever.
+      expect(storeMock.set).not.toHaveBeenCalledWith("storeNotifierEtag", '"abc"');
+    });
+
+    it("does not broadcast when the toggle flips off during the fetch", async () => {
+      let enabled = true;
+      storeMock.get.mockImplementation((key: string) => {
+        if (key === "storeUpdateNotificationsEnabled") return enabled;
+        return undefined;
+      });
+      netMock.fetch.mockImplementation(async () => {
+        enabled = false;
+        return makeResponse({ body: "version: 9.9.9\n", etag: null });
+      });
+      windowsStoreNotifierService.initialize();
+      await windowsStoreNotifierService._checkNowForTest();
+      expect(broadcastMock).not.toHaveBeenCalled();
     });
 
     it("does not broadcast when remote version is equal or older", async () => {
@@ -249,6 +267,38 @@ describe("WindowsStoreNotifierService", () => {
       const handler = dismissCall![1];
       handler({ senderFrame: { url: "app://daintree/index.html" } }, "1.2.3");
       expect(storeMock.set).toHaveBeenCalledWith("lastNotifiedStoreVersion", "1.2.3");
+    });
+
+    it("commits the pending ETag together with lastNotifiedStoreVersion", async () => {
+      netMock.fetch.mockResolvedValueOnce(
+        makeResponse({ body: "version: 1.2.0\n", etag: '"v1.2.0-etag"' })
+      );
+      windowsStoreNotifierService.initialize();
+      await windowsStoreNotifierService._checkNowForTest();
+      // ETag isn't persisted yet — pre-dismiss.
+      expect(storeMock.set).not.toHaveBeenCalledWith("storeNotifierEtag", expect.any(String));
+      const dismissCall = ipcMainMock.handle.mock.calls.find(
+        ([ch]) => ch === CHANNELS.STORE_UPDATE_DISMISS
+      );
+      const handler = dismissCall![1];
+      handler({ senderFrame: { url: "app://daintree/index.html" } }, "1.2.0");
+      expect(storeMock.set).toHaveBeenCalledWith("lastNotifiedStoreVersion", "1.2.0");
+      expect(storeMock.set).toHaveBeenCalledWith("storeNotifierEtag", '"v1.2.0-etag"');
+    });
+
+    it("does not commit a pending ETag when dismiss is for a different version", async () => {
+      netMock.fetch.mockResolvedValueOnce(
+        makeResponse({ body: "version: 1.2.0\n", etag: '"v1.2.0-etag"' })
+      );
+      windowsStoreNotifierService.initialize();
+      await windowsStoreNotifierService._checkNowForTest();
+      const dismissCall = ipcMainMock.handle.mock.calls.find(
+        ([ch]) => ch === CHANNELS.STORE_UPDATE_DISMISS
+      );
+      const handler = dismissCall![1];
+      handler({ senderFrame: { url: "app://daintree/index.html" } }, "9.9.9");
+      expect(storeMock.set).toHaveBeenCalledWith("lastNotifiedStoreVersion", "9.9.9");
+      expect(storeMock.set).not.toHaveBeenCalledWith("storeNotifierEtag", expect.any(String));
     });
 
     it("rejects untrusted senders", () => {

--- a/electron/store.ts
+++ b/electron/store.ts
@@ -268,6 +268,14 @@ export interface StoreSchema {
   dismissedUpdateAt?: number;
   lastUpdateCheck?: number | null;
   /**
+   * Windows Store notifier state. All fields are optional and read with `??`
+   * fallbacks at the call site so an absent value behaves like a default —
+   * no migration entry required (mirrors `dismissedUpdateVersion` pattern).
+   */
+  storeUpdateNotificationsEnabled?: boolean;
+  lastNotifiedStoreVersion?: string;
+  storeNotifierEtag?: string;
+  /**
    * Per-logger level overrides keyed by stable `"<process>:Module"` names (or
    * `"*"` / `"<process>:*"` wildcards). Values are `"debug" | "info" | "warn"
    * | "error" | "off"`. Persisted so support sessions can reproduce boot-time

--- a/electron/utils/openExternal.ts
+++ b/electron/utils/openExternal.ts
@@ -1,6 +1,11 @@
 import { shell } from "electron";
 
-const ALLOWED_PROTOCOLS = new Set(["http:", "https:", "mailto:"]);
+const ALLOWED_PROTOCOLS = new Set([
+  "http:",
+  "https:",
+  "mailto:",
+  "ms-windows-store:",
+]);
 
 export function canOpenExternalUrl(url: string): boolean {
   try {

--- a/electron/window/globalServicesInit.ts
+++ b/electron/window/globalServicesInit.ts
@@ -64,6 +64,7 @@ import {
   getWorkspaceClientRef,
   setAutoUpdaterServiceRef,
   setAgentNotificationServiceRef,
+  setWindowsStoreNotifierServiceRef,
   setGlobalServicesInitialized,
 } from "./serviceRefs.js";
 
@@ -241,6 +242,19 @@ export async function initGlobalServices(
       const { autoUpdaterService } = await import("../services/AutoUpdaterService.js");
       setAutoUpdaterServiceRef(autoUpdaterService);
       autoUpdaterService.initialize();
+    },
+  });
+
+  // Windows Store update notifier — parallel path to electron-updater for
+  // builds where the Store owns the install but the user still wants to know
+  // a newer version is available.
+  registerDeferredTask({
+    name: "windows-store-notifier",
+    run: async () => {
+      const { windowsStoreNotifierService } =
+        await import("../services/WindowsStoreNotifierService.js");
+      setWindowsStoreNotifierServiceRef(windowsStoreNotifierService);
+      windowsStoreNotifierService.initialize();
     },
   });
 

--- a/electron/window/serviceRefs.ts
+++ b/electron/window/serviceRefs.ts
@@ -15,6 +15,7 @@ import type { WorktreePortBroker } from "../services/WorktreePortBroker.js";
 import type { CcrConfigService } from "../services/CcrConfigService.js";
 import type { autoUpdaterService as AutoUpdaterServiceType } from "../services/AutoUpdaterService.js";
 import type { agentNotificationService as AgentNotificationServiceType } from "../services/AgentNotificationService.js";
+import type { windowsStoreNotifierService as WindowsStoreNotifierServiceType } from "../services/WindowsStoreNotifierService.js";
 
 // Guard: process.argv CLI path should only be consumed by the first window
 let processArgvCliHandled = false;
@@ -47,6 +48,7 @@ let ccrConfigService: CcrConfigService | null = null;
 // (early shutdown), these stay null and the dispose path no-ops.
 let autoUpdaterServiceRef: typeof AutoUpdaterServiceType | null = null;
 let agentNotificationServiceRef: typeof AgentNotificationServiceType | null = null;
+let windowsStoreNotifierServiceRef: typeof WindowsStoreNotifierServiceType | null = null;
 
 // ── Public getters/setters (consumed by main.ts, menu.ts, shutdown.ts) ──
 export function getPtyClient(): PtyClient | null {
@@ -172,4 +174,12 @@ export function setAgentNotificationServiceRef(
   v: typeof AgentNotificationServiceType | null
 ): void {
   agentNotificationServiceRef = v;
+}
+export function getWindowsStoreNotifierServiceRef(): typeof WindowsStoreNotifierServiceType | null {
+  return windowsStoreNotifierServiceRef;
+}
+export function setWindowsStoreNotifierServiceRef(
+  v: typeof WindowsStoreNotifierServiceType | null
+): void {
+  windowsStoreNotifierServiceRef = v;
 }

--- a/electron/window/windowServices.ts
+++ b/electron/window/windowServices.ts
@@ -75,6 +75,8 @@ import {
   setCcrConfigService,
   getAutoUpdaterServiceRef,
   setAutoUpdaterServiceRef,
+  getWindowsStoreNotifierServiceRef,
+  setWindowsStoreNotifierServiceRef,
   getAgentNotificationServiceRef,
   setAgentNotificationServiceRef,
   getProcessArgvCliHandled,
@@ -648,6 +650,11 @@ export async function setupWindowServices(
     if (aus) {
       aus.dispose();
       setAutoUpdaterServiceRef(null);
+    }
+    const wsns = getWindowsStoreNotifierServiceRef();
+    if (wsns) {
+      wsns.dispose();
+      setWindowsStoreNotifierServiceRef(null);
     }
   });
 }

--- a/shared/types/ipc/api.ts
+++ b/shared/types/ipc/api.ts
@@ -1065,6 +1065,18 @@ export interface ElectronAPI {
     notifyDismiss(version: string): Promise<void>;
     getLastCheck(): Promise<number | null>;
   };
+  storeUpdate: {
+    /** Subscribe to Store-build update notifications. Renderer hook short-circuits unless `isWindowsStore`. */
+    onUpdateAvailable(callback: (info: { version: string; storeUrl: string }) => void): () => void;
+    /** Hydrate-time getter so the renderer doesn't miss a detection that fired before first paint. */
+    getLatest(): Promise<{ version: string; storeUrl: string } | null>;
+    /** Persist that the user has seen this version so it isn't re-notified. */
+    dismiss(version: string): Promise<void>;
+    /** Read the user's preference for Store update notifications. */
+    getSettings(): Promise<{ enabled: boolean }>;
+    /** Toggle Store update notifications on/off. */
+    setSettings(enabled: boolean): Promise<{ enabled: boolean }>;
+  };
   gemini: {
     /** Get Gemini config status (exists, alternate buffer enabled) */
     getStatus(): Promise<{ exists: boolean; alternateBufferEnabled: boolean; error?: string }>;

--- a/shared/types/ipc/maps.ts
+++ b/shared/types/ipc/maps.ts
@@ -1352,6 +1352,24 @@ export interface IpcInvokeMap extends GeneratedIpcInvokeMap {
     result: number | null;
   };
 
+  // Windows Store update notification channels
+  "store-update:get-latest": {
+    args: [];
+    result: { version: string; storeUrl: string } | null;
+  };
+  "store-update:dismiss": {
+    args: [version: string];
+    result: void;
+  };
+  "store-update:get-settings": {
+    args: [];
+    result: { enabled: boolean };
+  };
+  "store-update:set-settings": {
+    args: [enabled: boolean];
+    result: { enabled: boolean };
+  };
+
   // Agent Capabilities channels
   "agent-capabilities:get-registry": {
     args: [];
@@ -2193,6 +2211,10 @@ export interface IpcEventMap {
   "update:available": { version: string };
   "update:download-progress": { percent: number };
   "update:downloaded": { version: string };
+
+  // Windows Store update notification events — fired only on Windows Store
+  // builds when a newer version is detected on the CDN feed.
+  "store-update:available": { version: string; storeUrl: string };
 
   // Dev Preview events
   "dev-preview:state-changed": DevPreviewStateChangedPayload;

--- a/src/App.tsx
+++ b/src/App.tsx
@@ -28,6 +28,7 @@ import { useActionRegistry } from "./hooks/useActionRegistry";
 import { usePluginActions } from "./hooks/usePluginActions";
 import { usePluginPanelKinds } from "./hooks/usePluginPanelKinds";
 import { useUpdateListener } from "./hooks/useUpdateListener";
+import { useStoreUpdateListener } from "./hooks/useStoreUpdateListener";
 import { useMainProcessToastListener } from "./hooks/useMainProcessToastListener";
 
 import { useActionPalette } from "./hooks/useActionPalette";
@@ -463,6 +464,7 @@ function App() {
   const gettingStarted = useGettingStartedChecklist(isStateLoaded);
   const onboardingOverlayActive = gettingStarted.visible || gettingStarted.showCelebration;
   useUpdateListener(onboardingOverlayActive);
+  useStoreUpdateListener();
   useOrchestrationMilestones(isStateLoaded);
   useAgentWaitingNudge(isStateLoaded);
 

--- a/src/components/Settings/GeneralTab.tsx
+++ b/src/components/Settings/GeneralTab.tsx
@@ -129,6 +129,10 @@ export function GeneralTab({
   const [updateChannel, setUpdateChannel] = useState<"stable" | "nightly" | null>(null);
   const [channelSaving, setChannelSaving] = useState(false);
   const [lastUpdateCheck, setLastUpdateCheck] = useState<number | null>(null);
+  const [storeUpdateNotificationsEnabled, setStoreUpdateNotificationsEnabled] = useState<
+    boolean | null
+  >(null);
+  const [storeUpdateSettingsSaving, setStoreUpdateSettingsSaving] = useState(false);
   const updatesManagedByStore = useDistributionStore((s) => s.isWindowsStore);
   const isMountedRef = useRef(true);
   useEffect(() => {
@@ -187,6 +191,45 @@ export function GeneralTab({
       clearInterval(interval);
     };
   }, [updatesManagedByStore]);
+
+  useEffect(() => {
+    if (!updatesManagedByStore) return;
+    if (!window.electron?.storeUpdate?.getSettings) {
+      // Renderer running against an older preload (e.g. tests) — default visible.
+      setStoreUpdateNotificationsEnabled(true);
+      return;
+    }
+    let cancelled = false;
+    window.electron.storeUpdate
+      .getSettings()
+      .then((result) => {
+        if (!cancelled) setStoreUpdateNotificationsEnabled(result.enabled);
+      })
+      .catch((error) => {
+        if (!cancelled) {
+          logError("Failed to get store update notification settings", error);
+          setStoreUpdateNotificationsEnabled(true);
+        }
+      });
+    return () => {
+      cancelled = true;
+    };
+  }, [updatesManagedByStore]);
+
+  const handleStoreUpdateNotificationsToggle = async () => {
+    if (storeUpdateSettingsSaving || storeUpdateNotificationsEnabled === null) return;
+    if (!window.electron?.storeUpdate?.setSettings) return;
+    const next = !storeUpdateNotificationsEnabled;
+    setStoreUpdateSettingsSaving(true);
+    try {
+      const result = await window.electron.storeUpdate.setSettings(next);
+      if (isMountedRef.current) setStoreUpdateNotificationsEnabled(result.enabled);
+    } catch (error) {
+      logError("Failed to set store update notification settings", error);
+    } finally {
+      if (isMountedRef.current) setStoreUpdateSettingsSaving(false);
+    }
+  };
 
   const handleChannelChange = async (channel: "stable" | "nightly") => {
     if (updatesManagedByStore) return;
@@ -593,7 +636,15 @@ export function GeneralTab({
               description="Updates are managed by the Microsoft Store on Windows."
               id="general-update-channel"
             >
-              <div />
+              <SettingsSwitchCard
+                icon={RefreshCw}
+                title="Notify when a new version is available"
+                subtitle="Show an inbox notification with a link to the Microsoft Store."
+                isEnabled={storeUpdateNotificationsEnabled ?? true}
+                onChange={() => void handleStoreUpdateNotificationsToggle()}
+                ariaLabel="Toggle Microsoft Store update notifications"
+                disabled={storeUpdateNotificationsEnabled === null || storeUpdateSettingsSaving}
+              />
             </SettingsSection>
           ) : (
             <SettingsSection

--- a/src/hooks/useStoreUpdateListener.ts
+++ b/src/hooks/useStoreUpdateListener.ts
@@ -1,0 +1,65 @@
+import { useEffect, useRef } from "react";
+import { logError } from "@/utils/logger";
+import { notify } from "@/lib/notify";
+import { safeFireAndForget } from "@/utils/safeFireAndForget";
+import { useDistributionStore } from "@/store/distributionStore";
+
+const STORE_UPDATE_CORRELATION_ID = "app-update-store";
+
+function showStoreUpdateNotification(info: { version: string; storeUrl: string }): void {
+  notify({
+    type: "info",
+    // priority:"low" routes inbox-only — no toast and no OS notification.
+    // The Store handles the actual install, so a heads-up belongs in the
+    // history list rather than competing with active work for attention.
+    priority: "low",
+    title: "Update available",
+    message: `Version ${info.version} is available in the Microsoft Store.`,
+    correlationId: STORE_UPDATE_CORRELATION_ID,
+    duration: 0,
+    action: {
+      label: "Open Microsoft Store",
+      onClick: () => {
+        const promise = window.electron?.system?.openExternal(info.storeUrl);
+        if (promise) {
+          safeFireAndForget(promise, { context: "Open Microsoft Store for update" });
+        }
+      },
+    },
+  });
+}
+
+export function useStoreUpdateListener(): void {
+  const isWindowsStore = useDistributionStore((s) => s.isWindowsStore);
+  const lastNotifiedRef = useRef<string | null>(null);
+
+  useEffect(() => {
+    if (!isWindowsStore) return;
+    if (!window.electron?.storeUpdate) return;
+
+    const surface = (info: { version: string; storeUrl: string }) => {
+      if (lastNotifiedRef.current === info.version) return;
+      lastNotifiedRef.current = info.version;
+      showStoreUpdateNotification(info);
+      // Persist immediately so the next session doesn't re-notify even if the
+      // user never clicks the CTA or dismisses the inbox entry.
+      const promise = window.electron?.storeUpdate?.dismiss(info.version);
+      promise?.catch((err) => logError("[useStoreUpdateListener] dismiss failed", err));
+    };
+
+    // Hydrate from the main-process cache so an update detected during the
+    // launch jitter window (before the renderer subscribed) still surfaces.
+    const hydrate = window.electron.storeUpdate.getLatest();
+    hydrate
+      ?.then((info) => {
+        if (info) surface(info);
+      })
+      .catch((err) => logError("[useStoreUpdateListener] getLatest failed", err));
+
+    const cleanup = window.electron.storeUpdate.onUpdateAvailable(surface);
+
+    return () => {
+      cleanup();
+    };
+  }, [isWindowsStore]);
+}

--- a/src/hooks/useStoreUpdateListener.ts
+++ b/src/hooks/useStoreUpdateListener.ts
@@ -17,9 +17,16 @@ function showStoreUpdateNotification(info: { version: string; storeUrl: string }
     message: `Version ${info.version} is available in the Microsoft Store.`,
     correlationId: STORE_UPDATE_CORRELATION_ID,
     duration: 0,
+    // actionId + actionArgs (not bare onClick) so the button survives the
+    // inbox-history filter in notify.ts (~line 476) — actions without an
+    // actionId are silently dropped, which on the priority:"low" path means
+    // the user would only see text with no way to act on it.
     action: {
       label: "Open Microsoft Store",
+      actionId: "system.openExternal",
+      actionArgs: { url: info.storeUrl },
       onClick: () => {
+        // Toast-path fallback for the rare case priority routing changes.
         const promise = window.electron?.system?.openExternal(info.storeUrl);
         if (promise) {
           safeFireAndForget(promise, { context: "Open Microsoft Store for update" });


### PR DESCRIPTION
## Summary

- New `WindowsStoreNotifierService` in the main process polls the existing CDN YAML feeds (`latest.yml`), compares versions with semver, and notifies via the inbox when a newer build is available
- Gated on `isWindowsStoreBuild()` — complete no-op everywhere else, so macOS, Linux, and non-Store Windows continue using `electron-updater` directly
- Notification is inbox-only (`priority: "low"`) with an "Open Microsoft Store" CTA wired via `actionId` so it survives the inbox history action filter

Resolves #7980

## Changes

- `WindowsStoreNotifierService` — polls every 8 hours (matching the Win11 Store background task cadence), `If-None-Match` ETag caching, stable/nightly channel selection mirrors `AutoUpdaterService`
- Five new IPC channels under `store-update:*`, wired through `preload.cts`, `maps.ts`, and `api.ts`
- `useStoreUpdateListener` renderer hook mounts in `App.tsx`
- Settings toggle in the General tab inside the existing Store-build branch, using `SettingsSwitchCard`
- Three optional store fields (`storeUpdateNotificationsEnabled`, `lastNotifiedStoreVersion`, `storeNotifierEtag`) — no migration needed
- 21 unit tests covering polling, ETag conditional GET, channel-switch invalidation, version comparison, dismiss handling, and settings persistence

Three reviewer findings addressed in the follow-up commit:

1. CTA was invisible on the `priority: "low"` inbox path because `onClick`-only actions are dropped — fixed by switching to `actionId: "system.openExternal"` with `actionArgs`
2. ETag was persisted before the user saw the notification — a mid-flight crash would permanently suppress a version silently; fixed by deferring the ETag write to the dismiss handler
3. Toggle-off during an in-flight fetch wasn't respected — fixed by re-checking the enabled flag immediately before broadcast

## Testing

- 21 unit tests pass (`WindowsStoreNotifierService.test.ts`)
- Typecheck clean (`npx tsc --noEmit`)
- Lint and format clean (`npm run fix`)