### PR TITLE
feat(sidebar): directional drop indicator and Alt+Arrow keyboard reorder

### DIFF
--- a/src/components/DragDrop/SortableWorktreeCard.tsx
+++ b/src/components/DragDrop/SortableWorktreeCard.tsx
@@ -2,6 +2,7 @@ import React from "react";
 import { useSortable } from "@dnd-kit/sortable";
 import { CSS } from "@dnd-kit/utilities";
 import type { SyntheticListenerMap } from "@dnd-kit/core/dist/hooks/utilities";
+import { cn } from "@/lib/utils";
 
 export interface WorktreeSortDragData {
   type: "worktree-sort";
@@ -85,12 +86,29 @@ export const SortableWorktreeCard = React.memo(function SortableWorktreeCard({
     transform,
     transition,
     isDragging,
+    isOver,
+    active,
+    over,
   } = useSortable({
     id: getWorktreeSortDragId(worktreeId),
     data: dragData,
     disabled,
     animateLayoutChanges: () => false,
   });
+
+  // Directional insertion-line indicator: only fire for sort drags (a terminal
+  // or browser drag would also raise isOver on the inner droppable, but not on
+  // the sortable), and only when dnd-kit has measured the dragged rect.
+  // Compare midpoints — index comparison gives the optimistic visual slot, not
+  // the user's intent relative to the hovered row.
+  const isSortDragOver = isOver && active?.data.current?.type === "worktree-sort";
+  const translatedRect = active?.rect.current.translated;
+  let dropDirection: "above" | "below" | null = null;
+  if (isSortDragOver && translatedRect && over) {
+    const draggedMid = translatedRect.top + translatedRect.height / 2;
+    const overMid = over.rect.top + over.rect.height / 2;
+    dropDirection = draggedMid < overMid ? "above" : "below";
+  }
 
   const style: React.CSSProperties = {
     transform: CSS.Transform.toString(transform),
@@ -117,10 +135,22 @@ export const SortableWorktreeCard = React.memo(function SortableWorktreeCard({
       aria-roledescription="sortable worktree"
       aria-rowindex={ariaRowIndex}
       aria-current={isActive ? "true" : undefined}
+      aria-keyshortcuts={disabled ? undefined : "Alt+ArrowUp Alt+ArrowDown"}
       data-worktree-row={worktreeId}
       tabIndex={-1}
+      className="relative"
       {...filteredAttributes}
     >
+      {dropDirection !== null && (
+        <div
+          aria-hidden="true"
+          data-worktree-drop-indicator={dropDirection}
+          className={cn(
+            "pointer-events-none absolute inset-x-0 z-10 h-0.5 bg-border-strong",
+            dropDirection === "above" ? "-top-px" : "-bottom-px"
+          )}
+        />
+      )}
       <div role="gridcell">
         <div
           className={`h-full transition-opacity duration-150 motion-reduce:transition-none ${

--- a/src/components/DragDrop/__tests__/SortableWorktreeCard.test.tsx
+++ b/src/components/DragDrop/__tests__/SortableWorktreeCard.test.tsx
@@ -3,7 +3,17 @@ import { describe, it, expect, vi } from "vitest";
 import { render } from "@testing-library/react";
 import { SortableWorktreeCard } from "../SortableWorktreeCard";
 
-let mockIsDragging = false;
+interface MockSortableState {
+  isDragging?: boolean;
+  isOver?: boolean;
+  active?: {
+    data: { current: { type?: string } };
+    rect: { current: { translated: { top: number; height: number } | null } };
+  } | null;
+  over?: { rect: { top: number; height: number } } | null;
+}
+
+let mockState: MockSortableState = { isDragging: false };
 
 vi.mock("@dnd-kit/sortable", () => ({
   useSortable: () => ({
@@ -13,7 +23,10 @@ vi.mock("@dnd-kit/sortable", () => ({
     setActivatorNodeRef: vi.fn(),
     transform: null,
     transition: undefined,
-    isDragging: mockIsDragging,
+    isDragging: mockState.isDragging ?? false,
+    isOver: mockState.isOver ?? false,
+    active: mockState.active ?? null,
+    over: mockState.over ?? null,
   }),
 }));
 
@@ -27,7 +40,7 @@ vi.mock("@dnd-kit/utilities", () => ({
 
 describe("SortableWorktreeCard", () => {
   it("isolates the card at idle so the flash overlay's blend mode anchors to the active background", () => {
-    mockIsDragging = false;
+    mockState = { isDragging: false };
     const { container } = render(
       <SortableWorktreeCard
         worktreeId="wt1"
@@ -38,14 +51,13 @@ describe("SortableWorktreeCard", () => {
         {() => <div data-testid="child" />}
       </SortableWorktreeCard>
     );
-    // outer m.div wraps inner div
     const wrapper = container.firstChild as HTMLElement;
     expect(wrapper.style.isolation).toBe("isolate");
     expect(wrapper.style.contentVisibility).toBe("auto");
   });
 
   it("clears isolation during drag so dnd-kit transforms compose with the card root", () => {
-    mockIsDragging = true;
+    mockState = { isDragging: true };
     const { container } = render(
       <SortableWorktreeCard
         worktreeId="wt1"
@@ -62,7 +74,7 @@ describe("SortableWorktreeCard", () => {
   });
 
   it("keeps data-worktree-row and tabIndex on the inner div for roving focus compatibility", () => {
-    mockIsDragging = false;
+    mockState = { isDragging: false };
     const { container } = render(
       <SortableWorktreeCard
         worktreeId="wt1"
@@ -80,7 +92,7 @@ describe("SortableWorktreeCard", () => {
   });
 
   it("applies opacity-40 to the inner gridcell wrapper while dragging", () => {
-    mockIsDragging = true;
+    mockState = { isDragging: true };
     const { container } = render(
       <SortableWorktreeCard
         worktreeId="wt1"
@@ -96,5 +108,153 @@ describe("SortableWorktreeCard", () => {
     const ghost = wrapper.querySelector("[role='gridcell'] > div") as HTMLElement;
     expect(ghost.className).toContain("opacity-40");
     expect(ghost.className).toContain("transition-opacity");
+  });
+
+  it("marks the outer wrapper relative so the drop indicator can position absolutely against it", () => {
+    mockState = { isDragging: false };
+    const { container } = render(
+      <SortableWorktreeCard
+        worktreeId="wt1"
+        dragStartOrder={["wt1"]}
+        ariaRowIndex={1}
+        isActive={false}
+      >
+        {() => <div data-testid="child" />}
+      </SortableWorktreeCard>
+    );
+    const wrapper = container.firstChild as HTMLElement;
+    expect(wrapper.className).toContain("relative");
+  });
+
+  it("advertises Alt+Arrow keyboard reorder via aria-keyshortcuts when sortable", () => {
+    mockState = { isDragging: false };
+    const { container } = render(
+      <SortableWorktreeCard
+        worktreeId="wt1"
+        dragStartOrder={["wt1"]}
+        ariaRowIndex={1}
+        isActive={false}
+      >
+        {() => <div data-testid="child" />}
+      </SortableWorktreeCard>
+    );
+    const wrapper = container.firstChild as HTMLElement;
+    expect(wrapper.getAttribute("aria-keyshortcuts")).toBe("Alt+ArrowUp Alt+ArrowDown");
+  });
+
+  it("omits aria-keyshortcuts when the row is sort-disabled (pinned or grouped)", () => {
+    mockState = { isDragging: false };
+    const { container } = render(
+      <SortableWorktreeCard
+        worktreeId="wt1"
+        dragStartOrder={["wt1"]}
+        ariaRowIndex={1}
+        isActive={false}
+        disabled
+      >
+        {() => <div data-testid="child" />}
+      </SortableWorktreeCard>
+    );
+    const wrapper = container.firstChild as HTMLElement;
+    expect(wrapper.hasAttribute("aria-keyshortcuts")).toBe(false);
+  });
+
+  it("renders an above-edge insertion line when the dragged row midpoint is above the hovered row midpoint", () => {
+    mockState = {
+      isDragging: false,
+      isOver: true,
+      active: {
+        data: { current: { type: "worktree-sort" } },
+        rect: { current: { translated: { top: 10, height: 60 } } }, // midpoint 40
+      },
+      over: { rect: { top: 100, height: 60 } }, // midpoint 130 — 40 < 130 → above
+    };
+    const { container } = render(
+      <SortableWorktreeCard
+        worktreeId="wt1"
+        dragStartOrder={["wt1", "wt2"]}
+        ariaRowIndex={1}
+        isActive={false}
+      >
+        {() => <div data-testid="child" />}
+      </SortableWorktreeCard>
+    );
+    const indicator = container.querySelector("[data-worktree-drop-indicator]") as HTMLElement;
+    expect(indicator).not.toBeNull();
+    expect(indicator.getAttribute("data-worktree-drop-indicator")).toBe("above");
+    expect(indicator.className).toContain("-top-px");
+    expect(indicator.className).toContain("bg-border-strong");
+  });
+
+  it("renders a below-edge insertion line when the dragged row midpoint is below the hovered row midpoint", () => {
+    mockState = {
+      isDragging: false,
+      isOver: true,
+      active: {
+        data: { current: { type: "worktree-sort" } },
+        rect: { current: { translated: { top: 200, height: 60 } } }, // midpoint 230
+      },
+      over: { rect: { top: 100, height: 60 } }, // midpoint 130 — 230 > 130 → below
+    };
+    const { container } = render(
+      <SortableWorktreeCard
+        worktreeId="wt1"
+        dragStartOrder={["wt1", "wt2"]}
+        ariaRowIndex={1}
+        isActive={false}
+      >
+        {() => <div data-testid="child" />}
+      </SortableWorktreeCard>
+    );
+    const indicator = container.querySelector("[data-worktree-drop-indicator]") as HTMLElement;
+    expect(indicator).not.toBeNull();
+    expect(indicator.getAttribute("data-worktree-drop-indicator")).toBe("below");
+    expect(indicator.className).toContain("-bottom-px");
+  });
+
+  it("suppresses the insertion line for non-worktree-sort drags (terminal/browser drops)", () => {
+    mockState = {
+      isDragging: false,
+      isOver: true,
+      active: {
+        data: { current: { type: "terminal-panel" } },
+        rect: { current: { translated: { top: 10, height: 60 } } },
+      },
+      over: { rect: { top: 100, height: 60 } },
+    };
+    const { container } = render(
+      <SortableWorktreeCard
+        worktreeId="wt1"
+        dragStartOrder={["wt1"]}
+        ariaRowIndex={1}
+        isActive={false}
+      >
+        {() => <div data-testid="child" />}
+      </SortableWorktreeCard>
+    );
+    expect(container.querySelector("[data-worktree-drop-indicator]")).toBeNull();
+  });
+
+  it("suppresses the insertion line until dnd-kit measures the dragged rect", () => {
+    mockState = {
+      isDragging: false,
+      isOver: true,
+      active: {
+        data: { current: { type: "worktree-sort" } },
+        rect: { current: { translated: null } },
+      },
+      over: { rect: { top: 100, height: 60 } },
+    };
+    const { container } = render(
+      <SortableWorktreeCard
+        worktreeId="wt1"
+        dragStartOrder={["wt1"]}
+        ariaRowIndex={1}
+        isActive={false}
+      >
+        {() => <div data-testid="child" />}
+      </SortableWorktreeCard>
+    );
+    expect(container.querySelector("[data-worktree-drop-indicator]")).toBeNull();
   });
 });

--- a/src/components/Sidebar/SidebarContent.tsx
+++ b/src/components/Sidebar/SidebarContent.tsx
@@ -103,11 +103,17 @@ function SidebarContent({ onOpenOverview }: SidebarContentProps) {
   const refreshAriaShortcut = useAriaKeyshortcuts("worktree.refresh");
   const createWorktreeAriaShortcut = useAriaKeyshortcuts("worktree.createDialog.open");
   const scrollContainerRef = useRef<HTMLDivElement>(null);
-  // Latest dragStartOrder, captured in a ref so the keyboard-reorder callback
-  // identity stays stable across renders without skipping new visible orders.
+  // Latest dragStartOrder + sort-disabled state captured in refs so the
+  // keyboard-reorder callback identity stays stable across renders without
+  // missing new visible orders or going stale on group/search toggles.
   const dragStartOrderRef = useRef<readonly string[]>([]);
+  const isSortDisabledRef = useRef(false);
   const [keyboardReorderAnnouncement, setKeyboardReorderAnnouncement] = useState("");
   const handleKeyboardReorder = useCallback((rowEl: HTMLElement, delta: -1 | 1) => {
+    // Grouped-by-type and active-search modes hide the drag handle; keyboard
+    // reorder must mirror that — writing to manualOrder here would silently
+    // mutate ordering the user can't see being applied.
+    if (isSortDisabledRef.current) return;
     const worktreeId = rowEl.dataset.worktreeRow;
     if (!worktreeId) return;
     const visible = dragStartOrderRef.current;
@@ -826,6 +832,7 @@ function SidebarContent({ onOpenOverview }: SidebarContentProps) {
 
   const hasQuery = query.trim().length > 0;
   const isSortDisabled = isGroupedByType || hasQuery;
+  isSortDisabledRef.current = isSortDisabled;
 
   // 1-based aria-rowindex slots for the pinned rows.
   const mainRowIndex = mainVisible ? 1 : 0;

--- a/src/components/Sidebar/SidebarContent.tsx
+++ b/src/components/Sidebar/SidebarContent.tsx
@@ -30,6 +30,7 @@ import { Tooltip, TooltipContent, TooltipTrigger } from "@/components/ui/tooltip
 import { ErrorBoundary } from "@/components/ErrorBoundary";
 import { SortableContext, verticalListSortingStrategy } from "@dnd-kit/sortable";
 import { getWorktreeSortDragId } from "@/components/DragDrop/SortableWorktreeCard";
+import { applyManualWorktreeReorder } from "@/lib/worktreeReorder";
 import { usePanelStore, useWorktreeSelectionStore, useProjectStore } from "@/store";
 import { useFleetArmingStore, collectFilterArmEligibleIds } from "@/store/fleetArmingStore";
 import { useShallow } from "zustand/react/shallow";
@@ -102,8 +103,33 @@ function SidebarContent({ onOpenOverview }: SidebarContentProps) {
   const refreshAriaShortcut = useAriaKeyshortcuts("worktree.refresh");
   const createWorktreeAriaShortcut = useAriaKeyshortcuts("worktree.createDialog.open");
   const scrollContainerRef = useRef<HTMLDivElement>(null);
-  const { gridRef, handleGridKeyDown, handleGridFocusCapture } =
-    useWorktreeGridRovingFocus(scrollContainerRef);
+  // Latest dragStartOrder, captured in a ref so the keyboard-reorder callback
+  // identity stays stable across renders without skipping new visible orders.
+  const dragStartOrderRef = useRef<readonly string[]>([]);
+  const [keyboardReorderAnnouncement, setKeyboardReorderAnnouncement] = useState("");
+  const handleKeyboardReorder = useCallback((rowEl: HTMLElement, delta: -1 | 1) => {
+    const worktreeId = rowEl.dataset.worktreeRow;
+    if (!worktreeId) return;
+    const visible = dragStartOrderRef.current;
+    const currentIdx = visible.indexOf(worktreeId);
+    if (currentIdx === -1) return;
+    const targetIdx = currentIdx + delta;
+    if (targetIdx < 0 || targetIdx >= visible.length) return;
+    const filterStore = useWorktreeFilterStore.getState();
+    const merged = applyManualWorktreeReorder(
+      filterStore.manualOrder,
+      visible,
+      currentIdx,
+      targetIdx
+    );
+    filterStore.setManualOrder(merged);
+    filterStore.setOrderBy("manual");
+    setKeyboardReorderAnnouncement(`Moved to position ${targetIdx + 1} of ${visible.length}`);
+  }, []);
+  const { gridRef, handleGridKeyDown, handleGridFocusCapture } = useWorktreeGridRovingFocus(
+    scrollContainerRef,
+    { onKeyboardReorder: handleKeyboardReorder }
+  );
   const { worktrees, isLoading, isReconnecting, error, refresh } = useWorktrees();
   const deferredWorktrees = useDeferredValue(worktrees);
   const [isRefreshing, startRefreshTransition] = useTransition();
@@ -551,6 +577,7 @@ function SidebarContent({ onOpenOverview }: SidebarContentProps) {
   );
 
   const dragStartOrder = useMemo(() => filteredWorktrees.map((w) => w.id), [filteredWorktrees]);
+  dragStartOrderRef.current = dragStartOrder;
 
   // Fleet-eligible terminals inside the currently visible worktrees, split so an
   // arm/disarm elsewhere only re-walks the unarmed tally rather than re-scanning
@@ -903,6 +930,12 @@ function SidebarContent({ onOpenOverview }: SidebarContentProps) {
         <WorktreeSidebarSearchBar inputRef={searchInputRef} chipCounts={chipCounts} />
       )}
 
+      {/* SR-only live region for keyboard reorder announcements. dnd-kit's
+          built-in announcer can't see external mutations like Alt+Arrow, so
+          announce here. */}
+      <div className="sr-only" role="status" aria-live="polite" aria-atomic="true">
+        {keyboardReorderAnnouncement}
+      </div>
       {/* Worktree list — single role="grid" with roving tab stop spans pinned + scrollable rows */}
       <div
         ref={gridRef}

--- a/src/components/Sidebar/__tests__/SidebarContent.grid.test.ts
+++ b/src/components/Sidebar/__tests__/SidebarContent.grid.test.ts
@@ -107,10 +107,11 @@ describe("Worktree list keyboard grid — issue #6422", () => {
     });
 
     it('wires gridRef + handlers from the hook into a role="grid" container', () => {
-      // Hook now takes a scrollContainerRef so PageUp/PageDown can size the page
-      // from the viewport. The destructured return shape is unchanged.
+      // Hook takes a scrollContainerRef (for PageUp/PageDown sizing) and an
+      // options object (for the Alt+Arrow keyboard reorder callback). The
+      // destructured return shape is unchanged.
       expect(source).toMatch(
-        /const \{ gridRef, handleGridKeyDown, handleGridFocusCapture \} =\s*useWorktreeGridRovingFocus\(scrollContainerRef\);/
+        /const \{ gridRef, handleGridKeyDown, handleGridFocusCapture \} = useWorktreeGridRovingFocus\(\s*scrollContainerRef,/
       );
       expect(source).toContain('role="grid"');
       expect(source).toContain('aria-label="Worktrees"');
@@ -312,9 +313,117 @@ describe("Worktree list keyboard grid — issue #6422", () => {
     });
 
     describe("SidebarContent passes scrollContainerRef into the roving-focus hook", () => {
-      it("calls useWorktreeGridRovingFocus with the scroll container ref", async () => {
+      it("calls useWorktreeGridRovingFocus with the scroll container ref and a reorder callback", async () => {
         const source = await fs.readFile(SIDEBAR_CONTENT_PATH, "utf-8");
-        expect(source).toMatch(/useWorktreeGridRovingFocus\(scrollContainerRef\)/);
+        expect(source).toMatch(
+          /useWorktreeGridRovingFocus\(\s*scrollContainerRef,\s*\{\s*onKeyboardReorder:\s*handleKeyboardReorder\s*\}\s*\)/
+        );
+      });
+    });
+  });
+
+  describe("issue #7972 — sortable sidebar drop indicator and keyboard reorder", () => {
+    describe("SortableWorktreeCard directional drop indicator", () => {
+      let source: string;
+      beforeEach(async () => {
+        source = await fs.readFile(SORTABLE_CARD_PATH, "utf-8");
+      });
+
+      it("computes drop direction from active vs over rect midpoints", () => {
+        expect(source).toContain("active?.rect.current.translated");
+        expect(source).toMatch(/translatedRect\.top \+ translatedRect\.height \/ 2/);
+        expect(source).toMatch(/over\.rect\.top \+ over\.rect\.height \/ 2/);
+      });
+
+      it("gates the insertion line on a worktree-sort drag (not terminal/browser drags)", () => {
+        expect(source).toMatch(/active\?\.data\.current\?\.type === "worktree-sort"/);
+      });
+
+      it("marks the outer wrapper relative so the absolute indicator positions against the row", () => {
+        expect(source).toContain('className="relative"');
+      });
+
+      it("uses neutral bg-border-strong (no accent tokens) for the indicator", () => {
+        expect(source).toContain("bg-border-strong");
+        expect(source).not.toMatch(/daintree-accent|accent-primary/);
+      });
+
+      it("renders the indicator above (-top-px) or below (-bottom-px) based on drop direction", () => {
+        expect(source).toContain('"-top-px"');
+        expect(source).toContain('"-bottom-px"');
+      });
+
+      it("marks the indicator pointer-events-none so it never blocks the drop target", () => {
+        expect(source).toContain("pointer-events-none");
+      });
+
+      it("exposes the indicator via data-worktree-drop-indicator for E2E and DOM assertions", () => {
+        expect(source).toContain("data-worktree-drop-indicator");
+      });
+
+      it("advertises Alt+ArrowUp/Down via aria-keyshortcuts when the row is sortable", () => {
+        expect(source).toMatch(
+          /aria-keyshortcuts=\{disabled \? undefined : "Alt\+ArrowUp Alt\+ArrowDown"\}/
+        );
+      });
+    });
+
+    describe("useWorktreeGridRovingFocus Alt+Arrow carve", () => {
+      let source: string;
+      beforeEach(async () => {
+        source = await fs.readFile(HOOK_PATH, "utf-8");
+      });
+
+      it("accepts an onKeyboardReorder option", () => {
+        expect(source).toMatch(/onKeyboardReorder\??:\s*\(/);
+      });
+
+      it("splits the modifier guard so Alt+Arrow carves through but other Alt combos bail", () => {
+        // The guard is split into a metaKey bail and an altKey-non-arrow bail
+        // so Alt+Arrow can reach the list-mode handler.
+        expect(source).toMatch(/if \(e\.metaKey\) return;/);
+        expect(source).toMatch(/e\.altKey && \(e\.key === "ArrowUp" \|\| e\.key === "ArrowDown"\)/);
+        expect(source).toMatch(/if \(e\.altKey && !isAltArrowReorder\) return;/);
+      });
+
+      it("preventDefaults Alt+Arrow so navigation never fires alongside reorder", () => {
+        const reorderBranch = source.match(/if \(isAltArrowReorder\) \{[\s\S]*?return;\s*\}/);
+        expect(reorderBranch).toBeTruthy();
+        expect(reorderBranch?.[0]).toContain("e.preventDefault()");
+        expect(reorderBranch?.[0]).toContain("e.stopPropagation()");
+      });
+
+      it("invokes the reorder callback with the focused row and a -1/+1 delta", () => {
+        expect(source).toMatch(
+          /onKeyboardReorderRef\.current\(row,\s*e\.key === "ArrowDown" \? 1 : -1\)/
+        );
+      });
+    });
+
+    describe("SidebarContent wires keyboard reorder to applyManualWorktreeReorder", () => {
+      let source: string;
+      beforeEach(async () => {
+        source = await fs.readFile(SIDEBAR_CONTENT_PATH, "utf-8");
+      });
+
+      it("imports the shared reorder helper used by drag-end (single source of truth)", () => {
+        expect(source).toContain('from "@/lib/worktreeReorder"');
+        expect(source).toContain("applyManualWorktreeReorder");
+      });
+
+      it("renders a sr-only aria-live polite region for keyboard reorder announcements", () => {
+        expect(source).toMatch(/className="sr-only"[\s\S]*?aria-live="polite"/);
+        expect(source).toContain("keyboardReorderAnnouncement");
+      });
+
+      it("derives the worktree id from data-worktree-row and bounds-clamps the move", () => {
+        expect(source).toContain("rowEl.dataset.worktreeRow");
+        expect(source).toMatch(/targetIdx < 0 \|\| targetIdx >= visible\.length/);
+      });
+
+      it("routes the reorder through useWorktreeFilterStore (manualOrder + manual sort)", () => {
+        expect(source).toMatch(/filterStore\.setManualOrder\(merged\)/);
+        expect(source).toMatch(/filterStore\.setOrderBy\("manual"\)/);
       });
     });
   });

--- a/src/components/Sidebar/__tests__/SidebarContent.grid.test.ts
+++ b/src/components/Sidebar/__tests__/SidebarContent.grid.test.ts
@@ -425,6 +425,17 @@ describe("Worktree list keyboard grid — issue #6422", () => {
         expect(source).toMatch(/filterStore\.setManualOrder\(merged\)/);
         expect(source).toMatch(/filterStore\.setOrderBy\("manual"\)/);
       });
+
+      it("guards the reorder against grouped-by-type / active-search modes so it never silently mutates manualOrder when the drag handle is hidden", () => {
+        // Grouped mode and active search both flip isSortDisabled true; the
+        // drag handle hides in those modes, so Alt+Arrow must mirror that or
+        // it'd write to the manual order behind the user's back.
+        expect(source).toMatch(/isSortDisabledRef\s*=\s*useRef\(false\)/);
+        expect(source).toMatch(/isSortDisabledRef\.current\s*=\s*isSortDisabled/);
+        const guard = source.match(/handleKeyboardReorder = useCallback\([\s\S]*?\}, \[\]\);/);
+        expect(guard).toBeTruthy();
+        expect(guard?.[0]).toMatch(/if \(isSortDisabledRef\.current\) return;/);
+      });
     });
   });
 });

--- a/src/components/Sidebar/__tests__/useWorktreeGridRovingFocus.altArrow.test.tsx
+++ b/src/components/Sidebar/__tests__/useWorktreeGridRovingFocus.altArrow.test.tsx
@@ -126,6 +126,25 @@ describe("useWorktreeGridRovingFocus — Alt+Arrow keyboard reorder", () => {
     expect(event.defaultPrevented).toBe(true);
   });
 
+  it("still invokes the reorder callback at top/bottom boundaries — the caller decides whether to no-op", () => {
+    // The hook stays generic: it only translates the keystroke. The caller's
+    // own bounds check (in SidebarContent.handleKeyboardReorder) handles the
+    // boundary no-op. Without this contract, the boundary behavior would be
+    // ambiguous (hook clamp vs. caller clamp). Lock it down here.
+    const onKeyboardReorder = vi.fn();
+    const { getByTestId } = render(<Harness onKeyboardReorder={onKeyboardReorder} />);
+    const topRow = getByTestId("row-wt1");
+    topRow.focus();
+    fireEvent.keyDown(topRow, { key: "ArrowUp", altKey: true });
+    expect(onKeyboardReorder).toHaveBeenLastCalledWith(topRow, -1);
+
+    const bottomRow = getByTestId("row-wt3");
+    bottomRow.focus();
+    fireEvent.keyDown(bottomRow, { key: "ArrowDown", altKey: true });
+    expect(onKeyboardReorder).toHaveBeenLastCalledWith(bottomRow, 1);
+    expect(onKeyboardReorder).toHaveBeenCalledTimes(2);
+  });
+
   it("ignores Alt+ArrowDown when focus is not on a row wrapper", () => {
     const onKeyboardReorder = vi.fn();
     const Wrap = () => {

--- a/src/components/Sidebar/__tests__/useWorktreeGridRovingFocus.altArrow.test.tsx
+++ b/src/components/Sidebar/__tests__/useWorktreeGridRovingFocus.altArrow.test.tsx
@@ -1,0 +1,158 @@
+// @vitest-environment jsdom
+import { describe, it, expect, vi, beforeAll, afterAll } from "vitest";
+import { render, fireEvent } from "@testing-library/react";
+import { useRef } from "react";
+import { useWorktreeGridRovingFocus } from "../useWorktreeGridRovingFocus";
+
+// jsdom doesn't compute layout, so offsetParent is always null and
+// getClientRects() is empty. The hook's isElementVisible check rejects
+// every row under those defaults. Patch HTMLElement to look visible for
+// the duration of this suite so the behavior tests can exercise the real
+// keydown branch.
+const originalGetClientRects = HTMLElement.prototype.getClientRects;
+beforeAll(() => {
+  HTMLElement.prototype.getClientRects = function () {
+    return [{ width: 1, height: 1 } as DOMRect] as unknown as DOMRectList;
+  };
+});
+afterAll(() => {
+  HTMLElement.prototype.getClientRects = originalGetClientRects;
+});
+
+function Harness({
+  onKeyboardReorder,
+}: {
+  onKeyboardReorder?: (rowEl: HTMLElement, delta: -1 | 1) => void;
+}) {
+  const scrollContainerRef = useRef<HTMLDivElement>(null);
+  const { gridRef, handleGridKeyDown, handleGridFocusCapture } = useWorktreeGridRovingFocus(
+    scrollContainerRef,
+    { onKeyboardReorder }
+  );
+  return (
+    <div ref={scrollContainerRef} style={{ height: 600 }}>
+      <div
+        ref={gridRef}
+        role="grid"
+        onKeyDown={handleGridKeyDown}
+        onFocusCapture={handleGridFocusCapture}
+      >
+        <div data-worktree-row="wt1" role="row" tabIndex={0} data-testid="row-wt1" />
+        <div data-worktree-row="wt2" role="row" tabIndex={-1} data-testid="row-wt2" />
+        <div data-worktree-row="wt3" role="row" tabIndex={-1} data-testid="row-wt3" />
+      </div>
+    </div>
+  );
+}
+
+describe("useWorktreeGridRovingFocus — Alt+Arrow keyboard reorder", () => {
+  it("calls onKeyboardReorder(row, 1) for Alt+ArrowDown on a focused row", () => {
+    const onKeyboardReorder = vi.fn();
+    const { getByTestId } = render(<Harness onKeyboardReorder={onKeyboardReorder} />);
+    const row = getByTestId("row-wt1");
+    row.focus();
+    fireEvent.keyDown(row, { key: "ArrowDown", altKey: true });
+    expect(onKeyboardReorder).toHaveBeenCalledTimes(1);
+    expect(onKeyboardReorder).toHaveBeenCalledWith(row, 1);
+  });
+
+  it("calls onKeyboardReorder(row, -1) for Alt+ArrowUp on a focused row", () => {
+    const onKeyboardReorder = vi.fn();
+    const { getByTestId } = render(<Harness onKeyboardReorder={onKeyboardReorder} />);
+    const row = getByTestId("row-wt2");
+    row.focus();
+    fireEvent.keyDown(row, { key: "ArrowUp", altKey: true });
+    expect(onKeyboardReorder).toHaveBeenCalledTimes(1);
+    expect(onKeyboardReorder).toHaveBeenCalledWith(row, -1);
+  });
+
+  it("preventDefault prevents Alt+ArrowDown from falling through to row navigation", () => {
+    const onKeyboardReorder = vi.fn();
+    const { getByTestId } = render(<Harness onKeyboardReorder={onKeyboardReorder} />);
+    const row = getByTestId("row-wt1");
+    row.focus();
+    // Capture the prevented event by spying on the dispatched KeyboardEvent.
+    const event = new KeyboardEvent("keydown", {
+      key: "ArrowDown",
+      altKey: true,
+      bubbles: true,
+      cancelable: true,
+    });
+    row.dispatchEvent(event);
+    expect(event.defaultPrevented).toBe(true);
+  });
+
+  it("does not invoke onKeyboardReorder for Alt+ArrowLeft (non-reorder Alt combo)", () => {
+    const onKeyboardReorder = vi.fn();
+    const { getByTestId } = render(<Harness onKeyboardReorder={onKeyboardReorder} />);
+    const row = getByTestId("row-wt1");
+    row.focus();
+    fireEvent.keyDown(row, { key: "ArrowLeft", altKey: true });
+    expect(onKeyboardReorder).not.toHaveBeenCalled();
+  });
+
+  it("does not invoke onKeyboardReorder for Meta+ArrowDown", () => {
+    const onKeyboardReorder = vi.fn();
+    const { getByTestId } = render(<Harness onKeyboardReorder={onKeyboardReorder} />);
+    const row = getByTestId("row-wt1");
+    row.focus();
+    fireEvent.keyDown(row, { key: "ArrowDown", metaKey: true });
+    expect(onKeyboardReorder).not.toHaveBeenCalled();
+  });
+
+  it("does not move focus on Alt+ArrowDown (reorder happens in place, focus stays)", () => {
+    const onKeyboardReorder = vi.fn();
+    const { getByTestId } = render(<Harness onKeyboardReorder={onKeyboardReorder} />);
+    const row = getByTestId("row-wt1");
+    row.focus();
+    expect(document.activeElement).toBe(row);
+    fireEvent.keyDown(row, { key: "ArrowDown", altKey: true });
+    expect(document.activeElement).toBe(row);
+  });
+
+  it("silently no-ops when no onKeyboardReorder is wired but still preventDefaults", () => {
+    const { getByTestId } = render(<Harness />);
+    const row = getByTestId("row-wt1");
+    row.focus();
+    const event = new KeyboardEvent("keydown", {
+      key: "ArrowDown",
+      altKey: true,
+      bubbles: true,
+      cancelable: true,
+    });
+    row.dispatchEvent(event);
+    // No throw, and the event is still prevented so it never falls through
+    // to navigation (which would move focus the user didn't intend).
+    expect(event.defaultPrevented).toBe(true);
+  });
+
+  it("ignores Alt+ArrowDown when focus is not on a row wrapper", () => {
+    const onKeyboardReorder = vi.fn();
+    const Wrap = () => {
+      const scrollContainerRef = useRef<HTMLDivElement>(null);
+      const { gridRef, handleGridKeyDown, handleGridFocusCapture } = useWorktreeGridRovingFocus(
+        scrollContainerRef,
+        { onKeyboardReorder }
+      );
+      return (
+        <div ref={scrollContainerRef}>
+          <div
+            ref={gridRef}
+            role="grid"
+            onKeyDown={handleGridKeyDown}
+            onFocusCapture={handleGridFocusCapture}
+          >
+            <div data-worktree-row="wt1" role="row" tabIndex={0}>
+              <button data-testid="inside-button">btn</button>
+            </div>
+          </div>
+        </div>
+      );
+    };
+    const { getByTestId } = render(<Wrap />);
+    const btn = getByTestId("inside-button");
+    btn.focus();
+    fireEvent.keyDown(btn, { key: "ArrowDown", altKey: true });
+    expect(onKeyboardReorder).not.toHaveBeenCalled();
+  });
+});

--- a/src/components/Sidebar/useWorktreeGridRovingFocus.ts
+++ b/src/components/Sidebar/useWorktreeGridRovingFocus.ts
@@ -37,6 +37,16 @@ function computeGridPageSize(
   return Math.max(1, Math.floor(viewportHeight / sampleHeight));
 }
 
+export interface UseWorktreeGridRovingFocusOptions {
+  /**
+   * Called when the user presses Alt+ArrowUp/ArrowDown on a focused row.
+   * The hook resolves the row element and the move delta; the caller owns
+   * the reorder mutation (Alt+Arrow is a sidebar-specific shortcut, not a
+   * generic roving-focus concern).
+   */
+  onKeyboardReorder?: (rowElement: HTMLElement, delta: -1 | 1) => void;
+}
+
 export interface UseWorktreeGridRovingFocusReturn {
   gridRef: React.RefObject<HTMLDivElement | null>;
   handleGridKeyDown: (e: React.KeyboardEvent<HTMLDivElement>) => void;
@@ -44,12 +54,20 @@ export interface UseWorktreeGridRovingFocusReturn {
 }
 
 export function useWorktreeGridRovingFocus(
-  scrollContainerRef?: React.RefObject<HTMLDivElement | null>
+  scrollContainerRef?: React.RefObject<HTMLDivElement | null>,
+  options?: UseWorktreeGridRovingFocusOptions
 ): UseWorktreeGridRovingFocusReturn {
   const gridRef = useRef<HTMLDivElement | null>(null);
   const modeRef = useRef<GridMode>("list");
   const activeRowIndexRef = useRef<number>(0);
   const activeToolbarIndexRef = useRef<number>(0);
+  // Stash the callback in a ref so a fresh `options` identity each render
+  // doesn't re-create handleGridKeyDown (which would re-run useEffect deps
+  // and rebind tab stops unnecessarily).
+  const onKeyboardReorderRef = useRef<UseWorktreeGridRovingFocusOptions["onKeyboardReorder"]>(
+    options?.onKeyboardReorder
+  );
+  onKeyboardReorderRef.current = options?.onKeyboardReorder;
 
   const getRows = useCallback((): HTMLElement[] => {
     if (!gridRef.current) return [];
@@ -241,7 +259,14 @@ export function useWorktreeGridRovingFocus(
 
   const handleGridKeyDown = useCallback(
     (e: React.KeyboardEvent<HTMLDivElement>) => {
-      if (e.metaKey || e.altKey) return;
+      if (e.metaKey) return;
+      // Carve Alt+ArrowUp / Alt+ArrowDown through the modifier guard so a
+      // focused row can be reordered without leaving the keyboard. Every
+      // other Alt combo still bails so global shortcuts keep firing. Arrow
+      // keys don't get Option-transformed on macOS (lesson #1678), so
+      // checking e.key is safe cross-platform.
+      const isAltArrowReorder = e.altKey && (e.key === "ArrowUp" || e.key === "ArrowDown");
+      if (e.altKey && !isAltArrowReorder) return;
       // Allow Ctrl+Home / Ctrl+End through (mandatory APG grid shortcuts);
       // bail on every other Ctrl combo so global shortcuts (Ctrl+C, Ctrl+T,
       // Ctrl+W, …) still reach their handlers.
@@ -261,6 +286,23 @@ export function useWorktreeGridRovingFocus(
         if (!isOnRow) return;
 
         const currentIdx = Math.min(activeRowIndexRef.current, rows.length - 1);
+
+        if (isAltArrowReorder) {
+          // Reorder the focused row in place. The hook stays unaware of
+          // worktrees — it just hands the focused row element + direction
+          // back to the caller, which owns the persistence mutation. Always
+          // preventDefault so Alt+Arrow never falls through to row navigation
+          // (which would move focus and confuse the user) even if no
+          // reorder handler is wired.
+          e.preventDefault();
+          e.stopPropagation();
+          const row = rows[currentIdx];
+          if (row && onKeyboardReorderRef.current) {
+            onKeyboardReorderRef.current(row, e.key === "ArrowDown" ? 1 : -1);
+          }
+          return;
+        }
+
         let newIdx: number | null = null;
 
         if (e.key === "Enter" || e.key === "ArrowRight") {


### PR DESCRIPTION
## Summary

- Replaces the `ring-2` drag-over highlight with a 2px insertion line at the top or bottom edge of the target row, computed from `active.rect` vs `over.rect` midpoints via `useSortable` geometry. Direction is unambiguous; neutral tokens only (`bg-border-strong`).
- Adds `Alt+ArrowUp` / `Alt+ArrowDown` as a direct keyboard shortcut for reordering the focused row. Reuses `applyManualWorktreeReorder` (same path as drag-end), so no parallel state logic. Blocked when rows are grouped or search is active.
- Accessibility: `aria-keyshortcuts` on each sortable row, `sr-only aria-live="polite"` status region announces each move to screen readers.

Resolves #7972

## Changes

- `SortableWorktreeCard.tsx` — drop direction computed from rect midpoints; renders `-top-px` or `-bottom-px` insertion line; wrapper marked `relative`; `aria-keyshortcuts` added.
- `useWorktreeGridRovingFocus.ts` — splits the `altKey` bail-out so `Alt+Arrow` carves through for reorder; `onKeyboardReorder` option captured in a ref; `preventDefault` fires on `Alt+Arrow` even with no callback wired.
- `SidebarContent.tsx` — `handleKeyboardReorder` wires the callback; guards on `isSortDisabled`; adds `sr-only` announcer region.

## Testing

Three test files updated (one new `useWorktreeGridRovingFocus.altArrow.test.tsx`, two extended). 78 tests pass. Verified drop direction toggles correctly at the row midpoint, `Alt+Arrow` is a no-op when grouped or searching, and announcer text updates on each move.