### PR TITLE
fix(terminal): wake visible terminals on project view activation and worktree switch

### DIFF
--- a/src/contexts/WorktreeStoreContext.tsx
+++ b/src/contexts/WorktreeStoreContext.tsx
@@ -8,6 +8,7 @@ import type { WorktreeSnapshot } from "@shared/types";
 import { useWorktreeSelectionStore } from "@/store/worktreeStore";
 import { usePanelStore } from "@/store/panelStore";
 import { usePulseStore } from "@/store/pulseStore";
+import { wakeActiveWorktreeTerminals } from "@/store/wakeActiveWorktreeTerminals";
 import { worktreeClient } from "@/clients/worktreeClient";
 
 export const WorktreeStoreContext = createContext<WorktreeViewStoreApi | null>(null);
@@ -306,14 +307,28 @@ export function WorktreeStoreProvider({ children }: { children: ReactNode }) {
 
     // Snapshot-on-wake: when a cached view is reactivated (addChildView),
     // Chromium fires visibilitychange. Request a fresh snapshot to rehydrate
-    // state that may have changed while the view was backgrounded.
+    // state that may have changed while the view was backgrounded, and wake
+    // the renderer-side xterm buffers for visible terminals (#7999) — the
+    // DOM renderer's IntersectionObserver may have set _isPaused while
+    // hidden, so a `refresh()` alone won't recover the buffer (#5092).
     function handleVisibilityChange() {
-      if (document.visibilityState === "visible" && worktreePort.isReady()) {
+      if (document.visibilityState !== "visible") return;
+      if (worktreePort.isReady()) {
         fetchInitialState();
       }
+      wakeActiveWorktreeTerminals();
     }
     document.addEventListener("visibilitychange", handleVisibilityChange);
     cleanups.push(() => document.removeEventListener("visibilitychange", handleVisibilityChange));
+
+    // Missed-event guard: if the view is already visible by the time this
+    // listener installs (fast cached reactivation), the visibilitychange
+    // event has already fired (#4935). Worktree state is fetched via the
+    // worktreePort.isReady() / onReady paths above, so only the wake fan-out
+    // needs to run here.
+    if (document.visibilityState === "visible") {
+      wakeActiveWorktreeTerminals();
+    }
 
     return () => {
       generation++;

--- a/src/contexts/WorktreeStoreContext.tsx
+++ b/src/contexts/WorktreeStoreContext.tsx
@@ -306,11 +306,10 @@ export function WorktreeStoreProvider({ children }: { children: ReactNode }) {
     );
 
     // Snapshot-on-wake: when a cached view is reactivated (addChildView),
-    // Chromium fires visibilitychange. Request a fresh snapshot to rehydrate
-    // state that may have changed while the view was backgrounded, and wake
-    // the renderer-side xterm buffers for visible terminals (#7999) — the
-    // DOM renderer's IntersectionObserver may have set _isPaused while
-    // hidden, so a `refresh()` alone won't recover the buffer (#5092).
+    // Chromium fires visibilitychange. Request a fresh worktree snapshot to
+    // rehydrate state that may have changed while the view was backgrounded,
+    // then fan out per-terminal wake to pull the missed range from the
+    // pty-host's headless mirror into each visible xterm buffer (#7999).
     function handleVisibilityChange() {
       if (document.visibilityState !== "visible") return;
       if (worktreePort.isReady()) {

--- a/src/store/__tests__/wakeActiveWorktreeTerminals.test.ts
+++ b/src/store/__tests__/wakeActiveWorktreeTerminals.test.ts
@@ -1,13 +1,17 @@
 import { describe, it, expect, vi, beforeEach } from "vitest";
 import type { TerminalInstance } from "@shared/types";
-import { TerminalRefreshTier } from "@/types";
 
-const applyRendererPolicyMock = vi.fn();
+const wakeMock = vi.fn();
+const logWarnMock = vi.fn();
 
 vi.mock("@/services/TerminalInstanceService", () => ({
   terminalInstanceService: {
-    applyRendererPolicy: applyRendererPolicyMock,
+    wake: wakeMock,
   },
+}));
+
+vi.mock("@/utils/logger", () => ({
+  logWarn: logWarnMock,
 }));
 
 let mockActiveWorktreeId: string | null = null;
@@ -38,7 +42,8 @@ function panel(id: string, overrides: Partial<TerminalInstance> = {}): TerminalI
 }
 
 beforeEach(() => {
-  applyRendererPolicyMock.mockReset();
+  wakeMock.mockReset();
+  logWarnMock.mockReset();
   mockActiveWorktreeId = null;
   mockPanelIds = [];
   mockPanelsById = {};
@@ -54,9 +59,9 @@ describe("wakeActiveWorktreeTerminals", () => {
 
     wakeActiveWorktreeTerminals();
 
-    expect(applyRendererPolicyMock).toHaveBeenCalledTimes(2);
-    expect(applyRendererPolicyMock).toHaveBeenCalledWith("a", TerminalRefreshTier.VISIBLE);
-    expect(applyRendererPolicyMock).toHaveBeenCalledWith("b", TerminalRefreshTier.VISIBLE);
+    expect(wakeMock).toHaveBeenCalledTimes(2);
+    expect(wakeMock).toHaveBeenCalledWith("a");
+    expect(wakeMock).toHaveBeenCalledWith("b");
   });
 
   it("excludes terminals from other worktrees", () => {
@@ -68,8 +73,8 @@ describe("wakeActiveWorktreeTerminals", () => {
 
     wakeActiveWorktreeTerminals();
 
-    expect(applyRendererPolicyMock).toHaveBeenCalledTimes(1);
-    expect(applyRendererPolicyMock).toHaveBeenCalledWith("a", TerminalRefreshTier.VISIBLE);
+    expect(wakeMock).toHaveBeenCalledTimes(1);
+    expect(wakeMock).toHaveBeenCalledWith("a");
   });
 
   it("excludes dock-located terminals", () => {
@@ -81,8 +86,8 @@ describe("wakeActiveWorktreeTerminals", () => {
 
     wakeActiveWorktreeTerminals();
 
-    expect(applyRendererPolicyMock).toHaveBeenCalledTimes(1);
-    expect(applyRendererPolicyMock).toHaveBeenCalledWith("a", TerminalRefreshTier.VISIBLE);
+    expect(wakeMock).toHaveBeenCalledTimes(1);
+    expect(wakeMock).toHaveBeenCalledWith("a");
   });
 
   it("excludes trash-located terminals", () => {
@@ -94,8 +99,8 @@ describe("wakeActiveWorktreeTerminals", () => {
 
     wakeActiveWorktreeTerminals();
 
-    expect(applyRendererPolicyMock).toHaveBeenCalledTimes(1);
-    expect(applyRendererPolicyMock).toHaveBeenCalledWith("a", TerminalRefreshTier.VISIBLE);
+    expect(wakeMock).toHaveBeenCalledTimes(1);
+    expect(wakeMock).toHaveBeenCalledWith("a");
   });
 
   it("excludes non-terminal panel kinds", () => {
@@ -108,8 +113,8 @@ describe("wakeActiveWorktreeTerminals", () => {
 
     wakeActiveWorktreeTerminals();
 
-    expect(applyRendererPolicyMock).toHaveBeenCalledTimes(1);
-    expect(applyRendererPolicyMock).toHaveBeenCalledWith("term", TerminalRefreshTier.VISIBLE);
+    expect(wakeMock).toHaveBeenCalledTimes(1);
+    expect(wakeMock).toHaveBeenCalledWith("term");
   });
 
   it("treats undefined kind as terminal", () => {
@@ -120,20 +125,8 @@ describe("wakeActiveWorktreeTerminals", () => {
 
     wakeActiveWorktreeTerminals();
 
-    expect(applyRendererPolicyMock).toHaveBeenCalledTimes(1);
-    expect(applyRendererPolicyMock).toHaveBeenCalledWith("a", TerminalRefreshTier.VISIBLE);
-  });
-
-  it("treats undefined location as grid", () => {
-    mockActiveWorktreeId = "wt-1";
-    const a = { id: "a", title: "a", worktreeId: "wt-1" } as unknown as TerminalInstance;
-    mockPanelIds = ["a"];
-    mockPanelsById = { a };
-
-    wakeActiveWorktreeTerminals();
-
-    expect(applyRendererPolicyMock).toHaveBeenCalledTimes(1);
-    expect(applyRendererPolicyMock).toHaveBeenCalledWith("a", TerminalRefreshTier.VISIBLE);
+    expect(wakeMock).toHaveBeenCalledTimes(1);
+    expect(wakeMock).toHaveBeenCalledWith("a");
   });
 
   it("when no active worktree, only wakes terminals with no worktree affiliation", () => {
@@ -145,8 +138,8 @@ describe("wakeActiveWorktreeTerminals", () => {
 
     wakeActiveWorktreeTerminals();
 
-    expect(applyRendererPolicyMock).toHaveBeenCalledTimes(1);
-    expect(applyRendererPolicyMock).toHaveBeenCalledWith("a", TerminalRefreshTier.VISIBLE);
+    expect(wakeMock).toHaveBeenCalledTimes(1);
+    expect(wakeMock).toHaveBeenCalledWith("a");
   });
 
   it("no-ops when there are no panels", () => {
@@ -156,7 +149,7 @@ describe("wakeActiveWorktreeTerminals", () => {
 
     wakeActiveWorktreeTerminals();
 
-    expect(applyRendererPolicyMock).not.toHaveBeenCalled();
+    expect(wakeMock).not.toHaveBeenCalled();
   });
 
   it("skips panels missing from panelsById", () => {
@@ -165,6 +158,31 @@ describe("wakeActiveWorktreeTerminals", () => {
     mockPanelsById = {};
 
     expect(() => wakeActiveWorktreeTerminals()).not.toThrow();
-    expect(applyRendererPolicyMock).not.toHaveBeenCalled();
+    expect(wakeMock).not.toHaveBeenCalled();
+  });
+
+  it("isolates per-terminal failures so the fan-out continues", () => {
+    mockActiveWorktreeId = "wt-1";
+    const a = panel("a", { worktreeId: "wt-1" });
+    const b = panel("b", { worktreeId: "wt-1" });
+    const c = panel("c", { worktreeId: "wt-1" });
+    mockPanelIds = ["a", "b", "c"];
+    mockPanelsById = { a, b, c };
+
+    wakeMock.mockImplementation((id: string) => {
+      if (id === "b") throw new Error("broken xterm");
+    });
+
+    expect(() => wakeActiveWorktreeTerminals()).not.toThrow();
+
+    expect(wakeMock).toHaveBeenCalledTimes(3);
+    expect(wakeMock).toHaveBeenCalledWith("a");
+    expect(wakeMock).toHaveBeenCalledWith("b");
+    expect(wakeMock).toHaveBeenCalledWith("c");
+    expect(logWarnMock).toHaveBeenCalledTimes(1);
+    expect(logWarnMock).toHaveBeenCalledWith(
+      "[wakeActiveWorktreeTerminals] wake failed",
+      expect.objectContaining({ id: "b" })
+    );
   });
 });

--- a/src/store/__tests__/wakeActiveWorktreeTerminals.test.ts
+++ b/src/store/__tests__/wakeActiveWorktreeTerminals.test.ts
@@ -1,0 +1,170 @@
+import { describe, it, expect, vi, beforeEach } from "vitest";
+import type { TerminalInstance } from "@shared/types";
+import { TerminalRefreshTier } from "@/types";
+
+const applyRendererPolicyMock = vi.fn();
+
+vi.mock("@/services/TerminalInstanceService", () => ({
+  terminalInstanceService: {
+    applyRendererPolicy: applyRendererPolicyMock,
+  },
+}));
+
+let mockActiveWorktreeId: string | null = null;
+let mockPanelIds: string[] = [];
+let mockPanelsById: Record<string, TerminalInstance> = {};
+
+vi.mock("@/store/worktreeStore", () => ({
+  useWorktreeSelectionStore: {
+    getState: () => ({ activeWorktreeId: mockActiveWorktreeId }),
+  },
+}));
+
+vi.mock("@/store/panelStore", () => ({
+  usePanelStore: {
+    getState: () => ({ panelIds: mockPanelIds, panelsById: mockPanelsById }),
+  },
+}));
+
+const { wakeActiveWorktreeTerminals } = await import("@/store/wakeActiveWorktreeTerminals");
+
+function panel(id: string, overrides: Partial<TerminalInstance> = {}): TerminalInstance {
+  return {
+    id,
+    title: id,
+    location: "grid",
+    ...overrides,
+  } as TerminalInstance;
+}
+
+beforeEach(() => {
+  applyRendererPolicyMock.mockReset();
+  mockActiveWorktreeId = null;
+  mockPanelIds = [];
+  mockPanelsById = {};
+});
+
+describe("wakeActiveWorktreeTerminals", () => {
+  it("wakes grid terminals in the active worktree", () => {
+    mockActiveWorktreeId = "wt-1";
+    const a = panel("a", { worktreeId: "wt-1" });
+    const b = panel("b", { worktreeId: "wt-1" });
+    mockPanelIds = ["a", "b"];
+    mockPanelsById = { a, b };
+
+    wakeActiveWorktreeTerminals();
+
+    expect(applyRendererPolicyMock).toHaveBeenCalledTimes(2);
+    expect(applyRendererPolicyMock).toHaveBeenCalledWith("a", TerminalRefreshTier.VISIBLE);
+    expect(applyRendererPolicyMock).toHaveBeenCalledWith("b", TerminalRefreshTier.VISIBLE);
+  });
+
+  it("excludes terminals from other worktrees", () => {
+    mockActiveWorktreeId = "wt-1";
+    const a = panel("a", { worktreeId: "wt-1" });
+    const b = panel("b", { worktreeId: "wt-2" });
+    mockPanelIds = ["a", "b"];
+    mockPanelsById = { a, b };
+
+    wakeActiveWorktreeTerminals();
+
+    expect(applyRendererPolicyMock).toHaveBeenCalledTimes(1);
+    expect(applyRendererPolicyMock).toHaveBeenCalledWith("a", TerminalRefreshTier.VISIBLE);
+  });
+
+  it("excludes dock-located terminals", () => {
+    mockActiveWorktreeId = "wt-1";
+    const a = panel("a", { worktreeId: "wt-1", location: "grid" });
+    const dock = panel("dock", { worktreeId: "wt-1", location: "dock" });
+    mockPanelIds = ["a", "dock"];
+    mockPanelsById = { a, dock };
+
+    wakeActiveWorktreeTerminals();
+
+    expect(applyRendererPolicyMock).toHaveBeenCalledTimes(1);
+    expect(applyRendererPolicyMock).toHaveBeenCalledWith("a", TerminalRefreshTier.VISIBLE);
+  });
+
+  it("excludes trash-located terminals", () => {
+    mockActiveWorktreeId = "wt-1";
+    const a = panel("a", { worktreeId: "wt-1" });
+    const trash = panel("trash", { worktreeId: "wt-1", location: "trash" });
+    mockPanelIds = ["a", "trash"];
+    mockPanelsById = { a, trash };
+
+    wakeActiveWorktreeTerminals();
+
+    expect(applyRendererPolicyMock).toHaveBeenCalledTimes(1);
+    expect(applyRendererPolicyMock).toHaveBeenCalledWith("a", TerminalRefreshTier.VISIBLE);
+  });
+
+  it("excludes non-terminal panel kinds", () => {
+    mockActiveWorktreeId = "wt-1";
+    const term = panel("term", { worktreeId: "wt-1", kind: "terminal" });
+    const browser = panel("browser", { worktreeId: "wt-1", kind: "browser" });
+    const devPreview = panel("dev", { worktreeId: "wt-1", kind: "dev-preview" });
+    mockPanelIds = ["term", "browser", "dev"];
+    mockPanelsById = { term, browser, dev: devPreview };
+
+    wakeActiveWorktreeTerminals();
+
+    expect(applyRendererPolicyMock).toHaveBeenCalledTimes(1);
+    expect(applyRendererPolicyMock).toHaveBeenCalledWith("term", TerminalRefreshTier.VISIBLE);
+  });
+
+  it("treats undefined kind as terminal", () => {
+    mockActiveWorktreeId = "wt-1";
+    const a = panel("a", { worktreeId: "wt-1", kind: undefined });
+    mockPanelIds = ["a"];
+    mockPanelsById = { a };
+
+    wakeActiveWorktreeTerminals();
+
+    expect(applyRendererPolicyMock).toHaveBeenCalledTimes(1);
+    expect(applyRendererPolicyMock).toHaveBeenCalledWith("a", TerminalRefreshTier.VISIBLE);
+  });
+
+  it("treats undefined location as grid", () => {
+    mockActiveWorktreeId = "wt-1";
+    const a = { id: "a", title: "a", worktreeId: "wt-1" } as unknown as TerminalInstance;
+    mockPanelIds = ["a"];
+    mockPanelsById = { a };
+
+    wakeActiveWorktreeTerminals();
+
+    expect(applyRendererPolicyMock).toHaveBeenCalledTimes(1);
+    expect(applyRendererPolicyMock).toHaveBeenCalledWith("a", TerminalRefreshTier.VISIBLE);
+  });
+
+  it("when no active worktree, only wakes terminals with no worktree affiliation", () => {
+    mockActiveWorktreeId = null;
+    const a = panel("a", { worktreeId: undefined });
+    const b = panel("b", { worktreeId: "wt-1" });
+    mockPanelIds = ["a", "b"];
+    mockPanelsById = { a, b };
+
+    wakeActiveWorktreeTerminals();
+
+    expect(applyRendererPolicyMock).toHaveBeenCalledTimes(1);
+    expect(applyRendererPolicyMock).toHaveBeenCalledWith("a", TerminalRefreshTier.VISIBLE);
+  });
+
+  it("no-ops when there are no panels", () => {
+    mockActiveWorktreeId = "wt-1";
+    mockPanelIds = [];
+    mockPanelsById = {};
+
+    wakeActiveWorktreeTerminals();
+
+    expect(applyRendererPolicyMock).not.toHaveBeenCalled();
+  });
+
+  it("skips panels missing from panelsById", () => {
+    mockActiveWorktreeId = "wt-1";
+    mockPanelIds = ["ghost"];
+    mockPanelsById = {};
+
+    expect(() => wakeActiveWorktreeTerminals()).not.toThrow();
+    expect(applyRendererPolicyMock).not.toHaveBeenCalled();
+  });
+});

--- a/src/store/wakeActiveWorktreeTerminals.ts
+++ b/src/store/wakeActiveWorktreeTerminals.ts
@@ -1,18 +1,28 @@
-import { TerminalRefreshTier } from "@/types";
 import { terminalInstanceService } from "@/services/TerminalInstanceService";
 import { usePanelStore } from "@/store/panelStore";
 import { useWorktreeSelectionStore } from "@/store/worktreeStore";
+import { logWarn } from "@/utils/logger";
 
 /**
- * Apply VISIBLE renderer policy to every grid terminal in the active worktree.
+ * Wake every grid terminal in the active worktree (#7999).
  *
- * Used on project view activation (cached `WebContentsView` reactivation in
- * Electron 41). Chromium fires `visibilitychange` when the view returns, but
- * the xterm DOM renderer's IntersectionObserver may have set `_isPaused=true`
- * while backgrounded — a bare `refresh()` is insufficient (#5092). Calling
- * `applyRendererPolicy(VISIBLE)` routes through `wakeAndRestore`, which
- * re-syncs the renderer buffer from the pty-host headless mirror. Dock and
- * trash terminals are excluded — they manage their own visibility.
+ * Called on cached `WebContentsView` reactivation (project view activation
+ * via Electron 41 `addChildView`). The pty-host headless mirror keeps
+ * receiving every byte regardless of tier, so the authoritative buffer is
+ * always current — but the renderer's xterm.js buffer accumulates only what
+ * arrives over the active stream. After the view returns, the missed range
+ * needs to be pulled from the headless mirror via the `wake-terminal` IPC
+ * and applied via `restoreFromSerialized`.
+ *
+ * Uses `terminalInstanceService.wake(id)` directly rather than
+ * `applyRendererPolicy(VISIBLE)` because the renderer-policy path returns
+ * early when tier equality holds (`TerminalRendererPolicy.applyRendererPolicy`),
+ * and a backgrounded view's terminals stay at VISIBLE the whole time —
+ * so the policy guard would prevent the wake from ever firing. `wake()`
+ * also unhibernates and uses its own rate-limit guard against rapid
+ * view-toggle floods.
+ *
+ * Dock and trash terminals are excluded — they manage their own visibility.
  */
 export function wakeActiveWorktreeTerminals(): void {
   const activeWorktreeId = useWorktreeSelectionStore.getState().activeWorktreeId ?? null;
@@ -26,6 +36,12 @@ export function wakeActiveWorktreeTerminals(): void {
     const location = panel.location ?? "grid";
     if (location === "dock" || location === "trash") continue;
 
-    terminalInstanceService.applyRendererPolicy(id, TerminalRefreshTier.VISIBLE);
+    try {
+      terminalInstanceService.wake(id);
+    } catch (error) {
+      // One broken terminal must not abort the fan-out — the next visible
+      // terminal still needs its missed range pulled from the headless mirror.
+      logWarn("[wakeActiveWorktreeTerminals] wake failed", { id, error });
+    }
   }
 }

--- a/src/store/wakeActiveWorktreeTerminals.ts
+++ b/src/store/wakeActiveWorktreeTerminals.ts
@@ -1,0 +1,31 @@
+import { TerminalRefreshTier } from "@/types";
+import { terminalInstanceService } from "@/services/TerminalInstanceService";
+import { usePanelStore } from "@/store/panelStore";
+import { useWorktreeSelectionStore } from "@/store/worktreeStore";
+
+/**
+ * Apply VISIBLE renderer policy to every grid terminal in the active worktree.
+ *
+ * Used on project view activation (cached `WebContentsView` reactivation in
+ * Electron 41). Chromium fires `visibilitychange` when the view returns, but
+ * the xterm DOM renderer's IntersectionObserver may have set `_isPaused=true`
+ * while backgrounded — a bare `refresh()` is insufficient (#5092). Calling
+ * `applyRendererPolicy(VISIBLE)` routes through `wakeAndRestore`, which
+ * re-syncs the renderer buffer from the pty-host headless mirror. Dock and
+ * trash terminals are excluded — they manage their own visibility.
+ */
+export function wakeActiveWorktreeTerminals(): void {
+  const activeWorktreeId = useWorktreeSelectionStore.getState().activeWorktreeId ?? null;
+  const { panelIds, panelsById } = usePanelStore.getState();
+
+  for (const id of panelIds) {
+    const panel = panelsById[id];
+    if (!panel) continue;
+    if ((panel.kind ?? "terminal") !== "terminal") continue;
+    if ((panel.worktreeId ?? null) !== activeWorktreeId) continue;
+    const location = panel.location ?? "grid";
+    if (location === "dock" || location === "trash") continue;
+
+    terminalInstanceService.applyRendererPolicy(id, TerminalRefreshTier.VISIBLE);
+  }
+}


### PR DESCRIPTION
## Summary

- When a project view becomes active, fans out `wake()` across all visible terminals in the active worktree so their xterm.js buffers catch up with the backend mirror
- When the active worktree changes, does the same fan-out for the destination worktree terminals
- The backend half already worked (`recomputeActivityTiers()` lifts terminals from `BACKGROUND` to active on project switch); this fills the renderer-side gap

Resolves #7999

## Changes

- `src/store/wakeActiveWorktreeTerminals.ts` — new helper that collects terminal panel IDs for the current worktree and fans out `terminalInstanceService.wake()` calls
- `src/contexts/WorktreeStoreContext.tsx` — calls the helper on `activeWorktreeId` change and on project view activation
- `src/store/__tests__/wakeActiveWorktreeTerminals.test.ts` — 188-line test covering both the project-activation and worktree-switch paths, including the no-op case when there are no terminal panels

## Testing

Unit tests cover both trigger paths. Manual repro: run `seq 1 1000; sleep 1` in a terminal, switch away (Opt+Cmd+= or change active worktree), wait a few seconds, switch back — the missing range now appears instead of showing a silent gap.