### PR TITLE
fix(project-switcher): describe waiting state instead of asserting review needed

### DIFF
--- a/src/components/Project/ProjectSwitcherPalette.tsx
+++ b/src/components/Project/ProjectSwitcherPalette.tsx
@@ -183,7 +183,7 @@ function ProjectListItem({
     if (project.activeAgentCount > 0)
       return { secondaryText: "Agent working\u2026", secondaryClass: "text-activity-working" };
     if (project.waitingAgentCount > 0)
-      return { secondaryText: "Needs review", secondaryClass: "text-status-warning/80" };
+      return { secondaryText: "Agent waiting…", secondaryClass: "text-activity-waiting" };
     if (project.lastOpened > 0)
       return {
         secondaryText: formatTimeAgo(project.lastOpened),

--- a/src/components/Project/__tests__/ProjectSwitcherPalette.render.test.tsx
+++ b/src/components/Project/__tests__/ProjectSwitcherPalette.render.test.tsx
@@ -177,11 +177,11 @@ describe("ProjectSwitcherPalette secondary text waterfall", () => {
     expect(screen.getByText("Agent working\u2026")).toBeTruthy();
   });
 
-  it("shows 'Needs review' when only waitingAgentCount > 0", () => {
+  it("shows 'Agent waiting…' when only waitingAgentCount > 0", () => {
     render(
       <ProjectSwitcherPalette {...baseProps} results={[makeProject({ waitingAgentCount: 1 })]} />
     );
-    expect(screen.getByText("Needs review")).toBeTruthy();
+    expect(screen.getByText("Agent waiting…")).toBeTruthy();
   });
 
   it("shows relative time when lastOpened > 0 and no agents active", () => {


### PR DESCRIPTION
## Summary

- `Needs review` was shown in the project switcher when a project had waiting agents, but waiting just means the agent stopped and is waiting on the user — it doesn't imply review is required
- Replaced the string with `Agent waiting...` and swapped the colour class from `text-status-warning/80` to `text-activity-waiting`, mirroring the `Agent working...` pattern on the line directly above

Resolves #8002

## Changes

- `src/components/Project/ProjectSwitcherPalette.tsx` — updated label and colour class for the waiting-agent state
- `src/components/Project/__tests__/ProjectSwitcherPalette.render.test.tsx` — updated test description and assertion to match

## Testing

23 vitest tests pass. Full `npm run check` and build pass.