### PR TITLE
fix(github): fix stranded tooltips in GitHub list dropdowns

### DIFF
--- a/src/components/ui/__tests__/FixedDropdown.test.tsx
+++ b/src/components/ui/__tests__/FixedDropdown.test.tsx
@@ -1,8 +1,8 @@
 // @vitest-environment jsdom
 import { render, act } from "@testing-library/react";
-import { useState } from "react";
+import { useContext, useState } from "react";
 import { describe, expect, it, vi, beforeEach, afterEach } from "vitest";
-import { FixedDropdown } from "../fixed-dropdown";
+import { FixedDropdown, FixedDropdownVisibleContext } from "../fixed-dropdown";
 import { _resetForTests } from "@/lib/escapeStack";
 import { useGlobalEscapeDispatcher } from "@/hooks/useGlobalEscapeDispatcher";
 
@@ -550,6 +550,124 @@ describe("FixedDropdown keepMounted behavior", () => {
     );
 
     expect(document.querySelector('[data-testid="body"]')).toBeNull();
+  });
+});
+
+describe("FixedDropdownVisibleContext tooltip strand gate (issue #8001)", () => {
+  // Regression coverage for the strand-in-top-left ghost: when a keepMounted
+  // FixedDropdown transitions to Activity-hidden, the shared `Tooltip`
+  // wrapper consumes this context to force `open={false}` on any Radix
+  // Tooltip whose dismiss path was skipped by the synchronous `display:none`.
+  // Portaled overlay content otherwise escapes Activity and falls back to
+  // (0,0) on document.body. These tests assert the context contract.
+  let onOpenChange: ReturnType<typeof vi.fn<(open: boolean) => void>>;
+  let anchorRef: React.RefObject<HTMLElement | null>;
+
+  beforeEach(() => {
+    _resetForTests();
+    setOverlayStackLength(0);
+    onOpenChange = vi.fn();
+    anchorRef = createAnchor();
+    vi.stubGlobal("matchMedia", vi.fn().mockReturnValue({ matches: false }));
+    vi.useFakeTimers();
+  });
+
+  afterEach(() => {
+    _resetForTests();
+    vi.useRealTimers();
+  });
+
+  function ContextProbe({ id }: { id: string }) {
+    const visible = useContext(FixedDropdownVisibleContext);
+    return <span data-testid={id} data-visible={String(visible)} />;
+  }
+
+  it("provides context value `true` while a keepMounted dropdown is visible", () => {
+    render(
+      <FixedDropdown open={true} onOpenChange={onOpenChange} anchorRef={anchorRef} keepMounted>
+        <ContextProbe id="probe-open" />
+      </FixedDropdown>
+    );
+
+    const probe = document.querySelector('[data-testid="probe-open"]');
+    expect(probe?.getAttribute("data-visible")).toBe("true");
+  });
+
+  it("flips context value to `false` once the keepMounted dropdown closes", () => {
+    const { rerender } = render(
+      <FixedDropdown open={true} onOpenChange={onOpenChange} anchorRef={anchorRef} keepMounted>
+        <ContextProbe id="probe" />
+      </FixedDropdown>
+    );
+
+    expect(document.querySelector('[data-testid="probe"]')?.getAttribute("data-visible")).toBe(
+      "true"
+    );
+
+    rerender(
+      <FixedDropdown open={false} onOpenChange={onOpenChange} anchorRef={anchorRef} keepMounted>
+        <ContextProbe id="probe" />
+      </FixedDropdown>
+    );
+
+    // Body stays mounted (Activity hidden), but context value must flip so
+    // that descendant `Tooltip` wrappers force-close before any portaled
+    // overlay content can strand at (0,0).
+    expect(document.querySelector('[data-testid="probe"]')?.getAttribute("data-visible")).toBe(
+      "false"
+    );
+  });
+
+  it("restores context value to `true` when the keepMounted dropdown reopens", () => {
+    const { rerender } = render(
+      <FixedDropdown open={true} onOpenChange={onOpenChange} anchorRef={anchorRef} keepMounted>
+        <ContextProbe id="probe" />
+      </FixedDropdown>
+    );
+
+    rerender(
+      <FixedDropdown open={false} onOpenChange={onOpenChange} anchorRef={anchorRef} keepMounted>
+        <ContextProbe id="probe" />
+      </FixedDropdown>
+    );
+    expect(document.querySelector('[data-testid="probe"]')?.getAttribute("data-visible")).toBe(
+      "false"
+    );
+
+    rerender(
+      <FixedDropdown open={true} onOpenChange={onOpenChange} anchorRef={anchorRef} keepMounted>
+        <ContextProbe id="probe" />
+      </FixedDropdown>
+    );
+    expect(document.querySelector('[data-testid="probe"]')?.getAttribute("data-visible")).toBe(
+      "true"
+    );
+  });
+
+  it("defaults to `true` outside any FixedDropdown so standalone tooltips are unaffected", () => {
+    render(<ContextProbe id="probe-standalone" />);
+    expect(
+      document.querySelector('[data-testid="probe-standalone"]')?.getAttribute("data-visible")
+    ).toBe("true");
+  });
+
+  it("does not wrap non-keepMounted dropdowns in the provider (default `true` flows through)", () => {
+    // Non-keepMounted dropdowns unmount their body on close, so they don't
+    // need the gate. The provider must be scoped to the keepMounted branch
+    // only — otherwise the gate would fire during normal open/close cycles
+    // and pre-emptively close tooltips that are still in their fade-out.
+    render(
+      <FixedDropdown open={true} onOpenChange={onOpenChange} anchorRef={anchorRef}>
+        <ContextProbe id="probe-non-keep" />
+      </FixedDropdown>
+    );
+
+    // The default context value is `true`, so without an inner provider this
+    // probe reads `true`. Confirms the provider is correctly scoped to the
+    // keepMounted branch.
+    expect(
+      document.querySelector('[data-testid="probe-non-keep"]')?.getAttribute("data-visible")
+    ).toBe("true");
   });
 });
 

--- a/src/components/ui/__tests__/Tooltip.test.tsx
+++ b/src/components/ui/__tests__/Tooltip.test.tsx
@@ -1,10 +1,14 @@
 // @vitest-environment jsdom
 import { render } from "@testing-library/react";
+import { useState } from "react";
 import { describe, expect, it, vi, beforeEach } from "vitest";
 import { FixedDropdownVisibleContext } from "../fixed-dropdown";
 import { Tooltip, TooltipTrigger, TooltipContent } from "../tooltip";
 
-const { rootSpy } = vi.hoisted(() => ({ rootSpy: vi.fn() }));
+const { rootSpy, mountSpy } = vi.hoisted(() => ({
+  rootSpy: vi.fn(),
+  mountSpy: vi.fn(),
+}));
 
 vi.mock("../radix-loader", () => ({
   primeOnEvent: vi.fn(),
@@ -13,7 +17,21 @@ vi.mock("../radix-loader", () => ({
       Provider: ({ children }: { children: React.ReactNode }) => <>{children}</>,
       Root: (props: { open?: boolean; children: React.ReactNode }) => {
         rootSpy(props);
-        return <>{props.children}</>;
+        // Each new mount of the stub creates a fresh closure id. Reading it
+        // back from rendered DOM lets tests assert when React remounted the
+        // Root (e.g., via key change) vs. when it just re-rendered it. This
+        // is the test-side proxy for "Radix internal state would have been
+        // reset" since the real `useControllableState` retains its
+        // `uncontrolledProp` across re-renders of the same instance only.
+        const [mountId] = useState(() => {
+          mountSpy();
+          return Math.random().toString(36).slice(2);
+        });
+        return (
+          <span data-testid="root-mount" data-mount-id={mountId}>
+            {props.children}
+          </span>
+        );
       },
       Trigger: ({ children }: { children: React.ReactNode }) => <button>{children}</button>,
       Portal: ({ children }: { children: React.ReactNode }) => <>{children}</>,
@@ -25,6 +43,7 @@ vi.mock("../radix-loader", () => ({
 describe("Tooltip wrapper — FixedDropdownVisibleContext gate (issue #8001)", () => {
   beforeEach(() => {
     rootSpy.mockClear();
+    mountSpy.mockClear();
   });
 
   function TooltipNode({ open }: { open?: boolean }) {
@@ -89,5 +108,49 @@ describe("Tooltip wrapper — FixedDropdownVisibleContext gate (issue #8001)", (
 
     const lastCall = rootSpy.mock.calls.at(-1)?.[0];
     expect(lastCall?.open).toBeUndefined();
+  });
+
+  it("remounts the Radix Root on each hidden/visible transition to clear stale internal state", () => {
+    // Regression for the controlled/uncontrolled flip identified in
+    // review: Radix's `useControllableState` only updates its internal
+    // `uncontrolledProp` via uncontrolled `setValue` calls. The
+    // controlled-close path (open: undefined → open: false) skips that
+    // update entirely, so the next switch back to uncontrolled
+    // (open: undefined) would re-read the stale pre-hide value and
+    // immediately re-open the tooltip without any user hover.
+    //
+    // Keying the Root on `dropdownVisible` forces a remount each time
+    // the dropdown transitions, which is observable here by a fresh
+    // mount id on the rendered Root stub.
+    function Harness({ visible }: { visible: boolean }) {
+      return (
+        <FixedDropdownVisibleContext.Provider value={visible}>
+          <TooltipNode />
+        </FixedDropdownVisibleContext.Provider>
+      );
+    }
+
+    const { rerender, container } = render(<Harness visible={true} />);
+    const initialMountId = container
+      .querySelector('[data-testid="root-mount"]')
+      ?.getAttribute("data-mount-id");
+    expect(initialMountId).toBeTruthy();
+
+    rerender(<Harness visible={false} />);
+    const hiddenMountId = container
+      .querySelector('[data-testid="root-mount"]')
+      ?.getAttribute("data-mount-id");
+    expect(hiddenMountId).toBeTruthy();
+    expect(hiddenMountId).not.toBe(initialMountId);
+
+    rerender(<Harness visible={true} />);
+    const revealedMountId = container
+      .querySelector('[data-testid="root-mount"]')
+      ?.getAttribute("data-mount-id");
+    expect(revealedMountId).toBeTruthy();
+    expect(revealedMountId).not.toBe(hiddenMountId);
+    // The reveal mount id must also differ from the initial one — both are
+    // distinct mounts, just both share the "visible" key.
+    expect(revealedMountId).not.toBe(initialMountId);
   });
 });

--- a/src/components/ui/__tests__/Tooltip.test.tsx
+++ b/src/components/ui/__tests__/Tooltip.test.tsx
@@ -1,0 +1,93 @@
+// @vitest-environment jsdom
+import { render } from "@testing-library/react";
+import { describe, expect, it, vi, beforeEach } from "vitest";
+import { FixedDropdownVisibleContext } from "../fixed-dropdown";
+import { Tooltip, TooltipTrigger, TooltipContent } from "../tooltip";
+
+const { rootSpy } = vi.hoisted(() => ({ rootSpy: vi.fn() }));
+
+vi.mock("../radix-loader", () => ({
+  primeOnEvent: vi.fn(),
+  useRadixPrimitives: () => ({
+    TooltipPrimitive: {
+      Provider: ({ children }: { children: React.ReactNode }) => <>{children}</>,
+      Root: (props: { open?: boolean; children: React.ReactNode }) => {
+        rootSpy(props);
+        return <>{props.children}</>;
+      },
+      Trigger: ({ children }: { children: React.ReactNode }) => <button>{children}</button>,
+      Portal: ({ children }: { children: React.ReactNode }) => <>{children}</>,
+      Content: ({ children }: { children: React.ReactNode }) => <div>{children}</div>,
+    },
+  }),
+}));
+
+describe("Tooltip wrapper — FixedDropdownVisibleContext gate (issue #8001)", () => {
+  beforeEach(() => {
+    rootSpy.mockClear();
+  });
+
+  function TooltipNode({ open }: { open?: boolean }) {
+    return (
+      <Tooltip open={open}>
+        <TooltipTrigger>trigger</TooltipTrigger>
+        <TooltipContent>content</TooltipContent>
+      </Tooltip>
+    );
+  }
+
+  it("preserves the caller's `open` prop when the context value is `true`", () => {
+    render(
+      <FixedDropdownVisibleContext.Provider value={true}>
+        <TooltipNode open={true} />
+      </FixedDropdownVisibleContext.Provider>
+    );
+
+    const lastCall = rootSpy.mock.calls.at(-1)?.[0];
+    expect(lastCall?.open).toBe(true);
+  });
+
+  it("forces `open={false}` on the Radix Root when the context value is `false`", () => {
+    // The bug fixed by issue #8001: with `open={true}` from the caller, the
+    // Radix Root would otherwise keep the tooltip portal mounted on
+    // document.body when the surrounding keepMounted FixedDropdown
+    // transitions to Activity-hidden. Floating UI then falls back to (0,0)
+    // and the tooltip strands in the top-left until reload.
+    render(
+      <FixedDropdownVisibleContext.Provider value={false}>
+        <TooltipNode open={true} />
+      </FixedDropdownVisibleContext.Provider>
+    );
+
+    const lastCall = rootSpy.mock.calls.at(-1)?.[0];
+    expect(lastCall?.open).toBe(false);
+  });
+
+  it("forces `open={false}` even when the caller leaves the tooltip uncontrolled", () => {
+    // The five GitHub list tooltips are uncontrolled — they rely on Radix's
+    // internal pointer-event-driven state. The gate must still apply to
+    // those by switching them to controlled-closed on the hidden transition.
+    render(
+      <FixedDropdownVisibleContext.Provider value={false}>
+        <TooltipNode />
+      </FixedDropdownVisibleContext.Provider>
+    );
+
+    const lastCall = rootSpy.mock.calls.at(-1)?.[0];
+    expect(lastCall?.open).toBe(false);
+  });
+
+  it("leaves uncontrolled tooltips uncontrolled when the context is `true`", () => {
+    // Outside the hidden state, the wrapper must not force a value — the
+    // caller's `undefined` should pass through so Radix continues to
+    // manage open/close internally.
+    render(
+      <FixedDropdownVisibleContext.Provider value={true}>
+        <TooltipNode />
+      </FixedDropdownVisibleContext.Provider>
+    );
+
+    const lastCall = rootSpy.mock.calls.at(-1)?.[0];
+    expect(lastCall?.open).toBeUndefined();
+  });
+});

--- a/src/components/ui/fixed-dropdown.tsx
+++ b/src/components/ui/fixed-dropdown.tsx
@@ -19,6 +19,15 @@ import { useUIStore } from "@/store/uiStore";
 // GitHub toolbar dropdown.
 const OVERLAY_RACE_GRACE_MS = 300;
 
+// Signals to descendants whether the keepMounted dropdown body is currently
+// visible (`true`) or has transitioned to Activity-hidden (`false`). The
+// shared `Tooltip` wrapper consumes this to force `open={false}` on Radix
+// Tooltip roots once the body is hidden, killing strand-in-top-left ghosts
+// caused by portaled overlay content escaping Activity's `display:none`
+// (issue #8001). Default `true` keeps non-keepMounted dropdowns and any
+// tooltip rendered outside a FixedDropdown unaffected.
+export const FixedDropdownVisibleContext = React.createContext<boolean>(true);
+
 interface FixedDropdownProps {
   open: boolean;
   onOpenChange: (open: boolean) => void;
@@ -167,14 +176,21 @@ export function FixedDropdown({
   // The outer pointer-events:none wrapper stays in the DOM so layout doesn't
   // thrash; Activity only hides its child.
   //
-  // INVARIANT for descendants: do NOT use exit-retaining `AnimatePresence`
-  // inside a keepMounted dropdown. React 19's Activity hidden mode defers
-  // effects and animation lifecycles, which strands AnimatePresence's exiting
-  // children in the DOM with stale closures — they stay fully interactive but
-  // disconnected from current state. Enter-only animation is fine; exit
-  // animation is not. Use plain conditional render for show/hide UI inside
-  // here. See `BulkActionBar.tsx` and `GitHubResourceList.tsx`'s
-  // skeleton/content switch for examples of the safe pattern.
+  // INVARIANT for descendants: do NOT rely on exit-retaining portal overlays
+  // inside a keepMounted dropdown. React 19's Activity hidden mode applies
+  // `display:none` synchronously but defers effect cleanups, so any overlay
+  // whose dismiss path depends on browser events (`pointerleave`, `blur`)
+  // never receives them once the trigger DOM is hidden. Portaled content
+  // (Radix Tooltip / Popover / HoverCard / DropdownMenu content, Framer
+  // Motion `AnimatePresence` exit children) escapes the Activity subtree
+  // entirely — it stays mounted on `document.body` with stale state and,
+  // in Floating-UI-positioned cases, falls back to (0,0) (issue #8001).
+  // For exit animation: use plain conditional render. For uncontrolled
+  // overlays: route through the shared `Tooltip` wrapper, which consumes
+  // `FixedDropdownVisibleContext` and force-closes on the hidden transition.
+  // Direct Radix primitive usage bypasses this guard. See `BulkActionBar.tsx`
+  // and `GitHubResourceList.tsx`'s skeleton/content switch for the safe
+  // exit-animation pattern.
   const inner = (
     <div
       ref={contentRef}
@@ -201,7 +217,11 @@ export function FixedDropdown({
   return createPortal(
     <div className="fixed inset-0 z-[var(--z-popover)] pointer-events-none">
       {keepMounted ? (
-        <Activity mode={shouldRender ? "visible" : "hidden"}>{inner}</Activity>
+        <Activity mode={shouldRender ? "visible" : "hidden"}>
+          <FixedDropdownVisibleContext.Provider value={shouldRender}>
+            {inner}
+          </FixedDropdownVisibleContext.Provider>
+        </Activity>
       ) : (
         inner
       )}

--- a/src/components/ui/tooltip.tsx
+++ b/src/components/ui/tooltip.tsx
@@ -3,6 +3,7 @@ import type * as TooltipPrimitiveType from "@radix-ui/react-tooltip";
 import { Slot } from "@radix-ui/react-slot";
 import { cn } from "@/lib/utils";
 import { primeOnEvent, useRadixPrimitives } from "./radix-loader";
+import { FixedDropdownVisibleContext } from "./fixed-dropdown";
 
 type TooltipProviderProps = React.ComponentProps<typeof TooltipPrimitiveType.Provider>;
 
@@ -16,11 +17,24 @@ TooltipProvider.displayName = "TooltipProvider";
 
 type TooltipRootProps = React.ComponentProps<typeof TooltipPrimitiveType.Root>;
 
-const Tooltip = ({ children, ...props }: TooltipRootProps) => {
+const Tooltip = ({ children, open, ...props }: TooltipRootProps) => {
   const radix = useRadixPrimitives();
+  // When the surrounding keepMounted FixedDropdown has transitioned to the
+  // Activity-hidden state, force `open={false}` on the Radix Root so any
+  // tooltip whose dismiss path was skipped by the synchronous `display:none`
+  // gets explicitly closed before its portaled content can strand at (0,0)
+  // on document.body (issue #8001). Outside that subtree the context default
+  // (`true`) preserves the caller's `open` value, so uncontrolled tooltips
+  // and any explicit `open={true}` callers keep working unchanged.
+  const dropdownVisible = React.useContext(FixedDropdownVisibleContext);
+  const effectiveOpen = dropdownVisible ? open : false;
   if (!radix) return <>{children}</>;
   const Root = radix.TooltipPrimitive.Root;
-  return <Root {...props}>{children}</Root>;
+  return (
+    <Root {...props} open={effectiveOpen}>
+      {children}
+    </Root>
+  );
 };
 Tooltip.displayName = "Tooltip";
 

--- a/src/components/ui/tooltip.tsx
+++ b/src/components/ui/tooltip.tsx
@@ -30,8 +30,17 @@ const Tooltip = ({ children, open, ...props }: TooltipRootProps) => {
   const effectiveOpen = dropdownVisible ? open : false;
   if (!radix) return <>{children}</>;
   const Root = radix.TooltipPrimitive.Root;
+  // Key on visibility so the Radix Root remounts on each hidden/visible
+  // transition. Without this, a tooltip that was uncontrolled-open when
+  // the dropdown hid would leave Radix's internal `uncontrolledProp` stuck
+  // at `true` — the controlled-close path only fires `onOpenChange` and
+  // never resets the uncontrolled state. On reopen, releasing back to
+  // `open={undefined}` would then read that stale `true` and re-open the
+  // tooltip with no user hover. Remounting clears it; the hidden tree has
+  // no user-visible state worth preserving since the prop-forced close
+  // already invalidated it.
   return (
-    <Root {...props} open={effectiveOpen}>
+    <Root key={dropdownVisible ? "visible" : "hidden"} {...props} open={effectiveOpen}>
       {children}
     </Root>
   );


### PR DESCRIPTION
## Summary

- GitHub list tooltips could strand in the top-left corner after their parent `FixedDropdown` closed. The root cause is React 19.2 Activity hidden mode: it applies `display:none` synchronously but defers effect cleanups, and Radix Tooltip portals its content to `document.body` where it escapes the `Activity` entirely and falls back to coordinates `(0, 0)`.
- Fix exports a `FixedDropdownVisibleContext` from `fixed-dropdown.tsx`, providing `shouldRender` as its value inside the `keepMounted` `Activity` branch. The shared `Tooltip` wrapper consumes it to force `open={false}` on the Radix `Root` when the dropdown isn't visible.
- The `Root` is also keyed on visibility so React remounts it on each transition, clearing the stale `useControllableState` value in Radix that would otherwise re-open the tooltip on dropdown reopen without a hover.

Resolves #8001

## Changes

- `fixed-dropdown.tsx` — export `FixedDropdownVisibleContext`; provide `shouldRender` as context value inside the `keepMounted` `Activity` branch; broadened `INVARIANT` comment to name `Tooltip`, `Popover`, `HoverCard`, `DropdownMenu`, and `AnimatePresence` as the same class of exit-retaining portal hazard
- `tooltip.tsx` — consume `FixedDropdownVisibleContext`; force `open={false}` and key the Radix `Root` on visibility when the dropdown is hidden
- 9 new unit tests covering the context contract and the `Tooltip` wrapper gate, including the controlled/uncontrolled flip regression

## Testing

- Manual: opened GitHub issues/PRs dropdown, hovered over "Create worktree" to trigger tooltip, closed dropdown — tooltip no longer strands
- Unit tests: `FixedDropdown.test.tsx` (context value contract) and `Tooltip.test.tsx` (wrapper gate + controlled/uncontrolled flip regression) — all 9 pass