### PR TITLE
fix(github): plumb prCiStatus through pr-detected event so dropdown and sidebar agree

### DIFF
--- a/electron/preload.cts
+++ b/electron/preload.cts
@@ -257,6 +257,7 @@ ipcRenderer.on("workspace-port", (event: Electron.IpcRendererEvent) => {
           prNumber: data.prNumber,
           prUrl: data.prUrl,
           prState: data.prState,
+          prCiStatus: data.prCiStatus,
           prTitle: data.prTitle,
           issueNumber: data.issueNumber,
           issueTitle: data.issueTitle,

--- a/src/contexts/WorktreeStoreContext.tsx
+++ b/src/contexts/WorktreeStoreContext.tsx
@@ -202,13 +202,17 @@ export function WorktreeStoreProvider({ children }: { children: ReactNode }) {
         const { worktrees } = store.getState();
         const existing = worktrees.get(event.worktreeId);
         if (!existing) return;
+        // Full-replace semantics for prCiStatus mirror the backend
+        // (WorktreeMonitor.setPRInfo): undefined means "no checks", not
+        // "preserve prior value." Merging with ?? would let stale CI rollups
+        // linger after checks disappear.
         store.getState().applyUpdate(
           {
             ...existing,
             prNumber: event.prNumber,
             prUrl: event.prUrl,
             prState: event.prState,
-            prCiStatus: event.prCiStatus ?? existing.prCiStatus,
+            prCiStatus: event.prCiStatus,
             prTitle: event.prTitle ?? existing.prTitle,
             issueNumber: event.issueNumber ?? existing.issueNumber,
             issueTitle: event.issueTitle ?? existing.issueTitle,
@@ -221,10 +225,7 @@ export function WorktreeStoreProvider({ children }: { children: ReactNode }) {
         // Sync the GitHub PR dropdown cache so the sidebar PRBadge and the
         // dropdown row can't drift. Read the project path at event time —
         // capturing it in the effect closure would corrupt cache slots after
-        // a project switch (#4670). Skip when prCiStatus is missing (don't
-        // overwrite a cached value with undefined) or when the project store
-        // hasn't been hydrated yet.
-        if (event.prCiStatus === undefined) return;
+        // a project switch (#4670).
         const projectPath = useProjectStore.getState().currentProject?.path;
         if (!projectPath) return;
         mutateCacheEntries(projectPath, "pr", (entry) => {

--- a/src/contexts/WorktreeStoreContext.tsx
+++ b/src/contexts/WorktreeStoreContext.tsx
@@ -198,6 +198,7 @@ export function WorktreeStoreProvider({ children }: { children: ReactNode }) {
 
     cleanups.push(
       worktreePort.onEvent("pr-detected", (data) => {
+        // eslint-disable-next-line @typescript-eslint/no-unsafe-type-assertion
         const event = data as PRDetectedEvent;
         const { worktrees } = store.getState();
         const existing = worktrees.get(event.worktreeId);

--- a/src/contexts/WorktreeStoreContext.tsx
+++ b/src/contexts/WorktreeStoreContext.tsx
@@ -5,11 +5,14 @@ import {
   type WorktreeViewStoreApi,
 } from "@/store/createWorktreeStore";
 import type { WorktreeSnapshot } from "@shared/types";
+import type { GitHubPR, GitHubPRCIStatus } from "@shared/types/github";
 import { useWorktreeSelectionStore } from "@/store/worktreeStore";
 import { usePanelStore } from "@/store/panelStore";
 import { usePulseStore } from "@/store/pulseStore";
+import { useProjectStore } from "@/store/projectStore";
 import { wakeActiveWorktreeTerminals } from "@/store/wakeActiveWorktreeTerminals";
 import { worktreeClient } from "@/clients/worktreeClient";
+import { mutateCacheEntries } from "@/lib/githubResourceCache";
 
 export const WorktreeStoreContext = createContext<WorktreeViewStoreApi | null>(null);
 
@@ -29,6 +32,7 @@ interface PRDetectedEvent {
   prNumber: number;
   prUrl: string;
   prState: "open" | "merged" | "closed";
+  prCiStatus?: GitHubPRCIStatus;
   prTitle?: string;
   issueNumber?: number;
   issueTitle?: string;
@@ -204,6 +208,7 @@ export function WorktreeStoreProvider({ children }: { children: ReactNode }) {
             prNumber: event.prNumber,
             prUrl: event.prUrl,
             prState: event.prState,
+            prCiStatus: event.prCiStatus ?? existing.prCiStatus,
             prTitle: event.prTitle ?? existing.prTitle,
             issueNumber: event.issueNumber ?? existing.issueNumber,
             issueTitle: event.issueTitle ?? existing.issueTitle,
@@ -212,6 +217,28 @@ export function WorktreeStoreProvider({ children }: { children: ReactNode }) {
           },
           store.getState().nextVersion()
         );
+
+        // Sync the GitHub PR dropdown cache so the sidebar PRBadge and the
+        // dropdown row can't drift. Read the project path at event time —
+        // capturing it in the effect closure would corrupt cache slots after
+        // a project switch (#4670). Skip when prCiStatus is missing (don't
+        // overwrite a cached value with undefined) or when the project store
+        // hasn't been hydrated yet.
+        if (event.prCiStatus === undefined) return;
+        const projectPath = useProjectStore.getState().currentProject?.path;
+        if (!projectPath) return;
+        mutateCacheEntries(projectPath, "pr", (entry) => {
+          let changed = false;
+          const items = entry.items.map((item) => {
+            const pr = item as GitHubPR;
+            if (pr.number !== event.prNumber) return item;
+            if (pr.ciStatus === event.prCiStatus) return item;
+            changed = true;
+            return { ...pr, ciStatus: event.prCiStatus };
+          });
+          if (!changed) return null;
+          return { ...entry, items };
+        });
       })
     );
 

--- a/src/contexts/__tests__/WorktreeStoreContext.prDetected.test.tsx
+++ b/src/contexts/__tests__/WorktreeStoreContext.prDetected.test.tsx
@@ -138,7 +138,7 @@ describe("WorktreeStoreProvider pr-detected handler", () => {
     expect(store.getState().worktrees.get("wt-1")?.prCiStatus).toBe("SUCCESS");
   });
 
-  it("preserves the existing prCiStatus when the event omits it", async () => {
+  it("clears prCiStatus when the event omits it (full-replace, matches backend)", async () => {
     const store = await renderProvider();
     act(() => {
       store
@@ -156,7 +156,7 @@ describe("WorktreeStoreProvider pr-detected handler", () => {
       });
     });
 
-    expect(store.getState().worktrees.get("wt-1")?.prCiStatus).toBe("FAILURE");
+    expect(store.getState().worktrees.get("wt-1")?.prCiStatus).toBeUndefined();
   });
 
   it("updates the GitHub PR cache so the dropdown stays in sync", async () => {
@@ -222,7 +222,7 @@ describe("WorktreeStoreProvider pr-detected handler", () => {
     expect(getGeneration(key)).toBe(genBefore);
   });
 
-  it("skips the cache mutation when prCiStatus is undefined", async () => {
+  it("clears the cached ciStatus when prCiStatus is undefined (full-replace)", async () => {
     const store = await renderProvider();
     act(() => {
       store.getState().applyUpdate(makeWorktree("wt-1"), store.getState().nextVersion());
@@ -247,8 +247,8 @@ describe("WorktreeStoreProvider pr-detected handler", () => {
       });
     });
 
-    expect((getCache(key)?.items[0] as GitHubPR).ciStatus).toBe("SUCCESS");
-    expect(getGeneration(key)).toBe(genBefore);
+    expect((getCache(key)?.items[0] as GitHubPR).ciStatus).toBeUndefined();
+    expect(getGeneration(key)).toBe(genBefore + 1);
   });
 
   it("skips the cache mutation when there is no current project", async () => {
@@ -316,6 +316,64 @@ describe("WorktreeStoreProvider pr-detected handler", () => {
 
     expect((getCache(sameProj)?.items[0] as GitHubPR).ciStatus).toBe("SUCCESS");
     expect((getCache(otherProj)?.items[0] as GitHubPR).ciStatus).toBe("PENDING");
+  });
+
+  it("applies last-write-wins across rapid successive events for the same PR", async () => {
+    const store = await renderProvider();
+    act(() => {
+      store.getState().applyUpdate(makeWorktree("wt-1"), store.getState().nextVersion());
+    });
+
+    const key = buildCacheKey("/repo/proj", "pr", "open", "created");
+    setCache(key, {
+      items: [makePR(42, "PENDING")],
+      endCursor: null,
+      hasNextPage: false,
+      timestamp: 1,
+    });
+
+    act(() => {
+      for (const ciStatus of ["PENDING", "FAILURE", "SUCCESS"] as const) {
+        emit("pr-detected", {
+          type: "pr-detected",
+          worktreeId: "wt-1",
+          prNumber: 42,
+          prUrl: "https://example.test/pr/42",
+          prState: "open",
+          prCiStatus: ciStatus,
+        });
+      }
+    });
+
+    expect(store.getState().worktrees.get("wt-1")?.prCiStatus).toBe("SUCCESS");
+    expect((getCache(key)?.items[0] as GitHubPR).ciStatus).toBe("SUCCESS");
+  });
+
+  it("does nothing when the worktree is not in the store", async () => {
+    const store = await renderProvider();
+    const key = buildCacheKey("/repo/proj", "pr", "open", "created");
+    setCache(key, {
+      items: [makePR(42, "PENDING")],
+      endCursor: null,
+      hasNextPage: false,
+      timestamp: 1,
+    });
+    const genBefore = getGeneration(key);
+
+    act(() => {
+      emit("pr-detected", {
+        type: "pr-detected",
+        worktreeId: "wt-missing",
+        prNumber: 42,
+        prUrl: "https://example.test/pr/42",
+        prState: "open",
+        prCiStatus: "SUCCESS",
+      });
+    });
+
+    expect(store.getState().worktrees.get("wt-missing")).toBeUndefined();
+    expect((getCache(key)?.items[0] as GitHubPR).ciStatus).toBe("PENDING");
+    expect(getGeneration(key)).toBe(genBefore);
   });
 
   it("uses the project path read at event time so closures cannot go stale", async () => {

--- a/src/contexts/__tests__/WorktreeStoreContext.prDetected.test.tsx
+++ b/src/contexts/__tests__/WorktreeStoreContext.prDetected.test.tsx
@@ -1,0 +1,359 @@
+// @vitest-environment jsdom
+import { describe, it, expect, beforeEach, afterEach } from "vitest";
+import { renderHook, act } from "@testing-library/react";
+import { useContext } from "react";
+
+import {
+  buildCacheKey,
+  setCache,
+  getCache,
+  getGeneration,
+  _resetForTests as resetCache,
+} from "@/lib/githubResourceCache";
+import { useProjectStore } from "@/store/projectStore";
+import type { GitHubPR, GitHubPRCIStatus } from "@shared/types/github";
+import type { WorktreeSnapshot } from "@shared/types";
+import type { Project } from "@shared/types/project";
+
+type PortEventName =
+  | "worktree-update"
+  | "worktree-removed"
+  | "worktree-activated"
+  | "pr-detected"
+  | "pr-cleared"
+  | "issue-detected"
+  | "issue-not-found";
+
+const listeners = new Map<PortEventName, Set<(data: unknown) => void>>();
+
+function emit(name: PortEventName, data: unknown): void {
+  const set = listeners.get(name);
+  if (!set) return;
+  for (const cb of set) cb(data);
+}
+
+function makeWorktree(id: string, overrides: Partial<WorktreeSnapshot> = {}): WorktreeSnapshot {
+  return {
+    id,
+    worktreeId: id,
+    path: `/repo/${id}`,
+    name: id,
+    isCurrent: false,
+    branch: "main",
+    isMainWorktree: true,
+    prNumber: 42,
+    prUrl: "https://example.test/pr/42",
+    prState: "open",
+    prCiStatus: "PENDING",
+    ...overrides,
+  } as WorktreeSnapshot;
+}
+
+function makePR(number: number, ciStatus?: GitHubPRCIStatus): GitHubPR {
+  return {
+    number,
+    title: `PR #${number}`,
+    url: `https://example.test/pr/${number}`,
+    state: "OPEN",
+    isDraft: false,
+    updatedAt: "",
+    author: { login: "u", avatarUrl: "" },
+    ciStatus,
+  };
+}
+
+function setCurrentProject(path: string | null): void {
+  const project = path ? ({ id: "p1", name: "p1", path } as unknown as Project) : null;
+  useProjectStore.setState({ currentProject: project });
+}
+
+beforeEach(() => {
+  listeners.clear();
+  resetCache();
+  setCurrentProject("/repo/proj");
+
+  (globalThis as unknown as { window: Window }).window.electron = {
+    worktreePort: {
+      isReady: () => true,
+      request: (_name: string) => Promise.resolve({ states: [] as WorktreeSnapshot[] }),
+      onEvent: (name: PortEventName, cb: (data: unknown) => void) => {
+        let set = listeners.get(name);
+        if (!set) {
+          set = new Set();
+          listeners.set(name, set);
+        }
+        set.add(cb);
+        return () => set?.delete(cb);
+      },
+      onReady: (_cb: () => void) => () => {},
+      onDisconnected: (_cb: () => void) => () => {},
+      onFatalDisconnect: (_cb: () => void) => () => {},
+    },
+    worktree: {
+      getAllIssueAssociations: () => Promise.resolve({}),
+    },
+  } as unknown as typeof window.electron;
+});
+
+afterEach(() => {
+  listeners.clear();
+  resetCache();
+  setCurrentProject(null);
+});
+
+async function renderProvider() {
+  const { WorktreeStoreProvider, WorktreeStoreContext } = await import("../WorktreeStoreContext");
+  const wrapper = ({ children }: { children: React.ReactNode }) => (
+    <WorktreeStoreProvider>{children}</WorktreeStoreProvider>
+  );
+  const { result } = renderHook(() => useContext(WorktreeStoreContext), { wrapper });
+  // Let the initial fetchInitialState promise chain resolve so the store is
+  // marked initialized before the test body runs.
+  await act(async () => {
+    await Promise.resolve();
+    await Promise.resolve();
+  });
+  if (!result.current) throw new Error("WorktreeStoreContext is null");
+  return result.current;
+}
+
+describe("WorktreeStoreProvider pr-detected handler", () => {
+  it("writes prCiStatus to the worktree store", async () => {
+    const store = await renderProvider();
+    act(() => {
+      store.getState().applyUpdate(makeWorktree("wt-1"), store.getState().nextVersion());
+    });
+
+    act(() => {
+      emit("pr-detected", {
+        type: "pr-detected",
+        worktreeId: "wt-1",
+        prNumber: 42,
+        prUrl: "https://example.test/pr/42",
+        prState: "open",
+        prCiStatus: "SUCCESS",
+      });
+    });
+
+    expect(store.getState().worktrees.get("wt-1")?.prCiStatus).toBe("SUCCESS");
+  });
+
+  it("preserves the existing prCiStatus when the event omits it", async () => {
+    const store = await renderProvider();
+    act(() => {
+      store
+        .getState()
+        .applyUpdate(makeWorktree("wt-1", { prCiStatus: "FAILURE" }), store.getState().nextVersion());
+    });
+
+    act(() => {
+      emit("pr-detected", {
+        type: "pr-detected",
+        worktreeId: "wt-1",
+        prNumber: 42,
+        prUrl: "https://example.test/pr/42",
+        prState: "open",
+      });
+    });
+
+    expect(store.getState().worktrees.get("wt-1")?.prCiStatus).toBe("FAILURE");
+  });
+
+  it("updates the GitHub PR cache so the dropdown stays in sync", async () => {
+    const store = await renderProvider();
+    act(() => {
+      store.getState().applyUpdate(makeWorktree("wt-1"), store.getState().nextVersion());
+    });
+
+    const key = buildCacheKey("/repo/proj", "pr", "open", "created");
+    setCache(key, {
+      items: [makePR(42, "PENDING"), makePR(43, "SUCCESS")],
+      endCursor: null,
+      hasNextPage: false,
+      timestamp: 1,
+    });
+    const genBefore = getGeneration(key);
+
+    act(() => {
+      emit("pr-detected", {
+        type: "pr-detected",
+        worktreeId: "wt-1",
+        prNumber: 42,
+        prUrl: "https://example.test/pr/42",
+        prState: "open",
+        prCiStatus: "FAILURE",
+      });
+    });
+
+    const entry = getCache(key);
+    const pr42 = entry?.items.find((it) => (it as GitHubPR).number === 42) as GitHubPR;
+    const pr43 = entry?.items.find((it) => (it as GitHubPR).number === 43) as GitHubPR;
+    expect(pr42.ciStatus).toBe("FAILURE");
+    expect(pr43.ciStatus).toBe("SUCCESS");
+    expect(getGeneration(key)).toBe(genBefore + 1);
+  });
+
+  it("does not bump the cache generation when the CI status is unchanged", async () => {
+    const store = await renderProvider();
+    act(() => {
+      store.getState().applyUpdate(makeWorktree("wt-1"), store.getState().nextVersion());
+    });
+
+    const key = buildCacheKey("/repo/proj", "pr", "open", "created");
+    setCache(key, {
+      items: [makePR(42, "SUCCESS")],
+      endCursor: null,
+      hasNextPage: false,
+      timestamp: 1,
+    });
+    const genBefore = getGeneration(key);
+
+    act(() => {
+      emit("pr-detected", {
+        type: "pr-detected",
+        worktreeId: "wt-1",
+        prNumber: 42,
+        prUrl: "https://example.test/pr/42",
+        prState: "open",
+        prCiStatus: "SUCCESS",
+      });
+    });
+
+    expect(getGeneration(key)).toBe(genBefore);
+  });
+
+  it("skips the cache mutation when prCiStatus is undefined", async () => {
+    const store = await renderProvider();
+    act(() => {
+      store.getState().applyUpdate(makeWorktree("wt-1"), store.getState().nextVersion());
+    });
+
+    const key = buildCacheKey("/repo/proj", "pr", "open", "created");
+    setCache(key, {
+      items: [makePR(42, "SUCCESS")],
+      endCursor: null,
+      hasNextPage: false,
+      timestamp: 1,
+    });
+    const genBefore = getGeneration(key);
+
+    act(() => {
+      emit("pr-detected", {
+        type: "pr-detected",
+        worktreeId: "wt-1",
+        prNumber: 42,
+        prUrl: "https://example.test/pr/42",
+        prState: "open",
+      });
+    });
+
+    expect((getCache(key)?.items[0] as GitHubPR).ciStatus).toBe("SUCCESS");
+    expect(getGeneration(key)).toBe(genBefore);
+  });
+
+  it("skips the cache mutation when there is no current project", async () => {
+    const store = await renderProvider();
+    act(() => {
+      store.getState().applyUpdate(makeWorktree("wt-1"), store.getState().nextVersion());
+    });
+
+    setCurrentProject(null);
+    const key = buildCacheKey("/repo/proj", "pr", "open", "created");
+    setCache(key, {
+      items: [makePR(42, "PENDING")],
+      endCursor: null,
+      hasNextPage: false,
+      timestamp: 1,
+    });
+    const genBefore = getGeneration(key);
+
+    act(() => {
+      emit("pr-detected", {
+        type: "pr-detected",
+        worktreeId: "wt-1",
+        prNumber: 42,
+        prUrl: "https://example.test/pr/42",
+        prState: "open",
+        prCiStatus: "FAILURE",
+      });
+    });
+
+    expect((getCache(key)?.items[0] as GitHubPR).ciStatus).toBe("PENDING");
+    expect(getGeneration(key)).toBe(genBefore);
+  });
+
+  it("targets the cache slot for the current project, not a sibling", async () => {
+    const store = await renderProvider();
+    act(() => {
+      store.getState().applyUpdate(makeWorktree("wt-1"), store.getState().nextVersion());
+    });
+
+    const sameProj = buildCacheKey("/repo/proj", "pr", "open", "created");
+    const otherProj = buildCacheKey("/repo/other", "pr", "open", "created");
+    setCache(sameProj, {
+      items: [makePR(42, "PENDING")],
+      endCursor: null,
+      hasNextPage: false,
+      timestamp: 1,
+    });
+    setCache(otherProj, {
+      items: [makePR(42, "PENDING")],
+      endCursor: null,
+      hasNextPage: false,
+      timestamp: 1,
+    });
+
+    act(() => {
+      emit("pr-detected", {
+        type: "pr-detected",
+        worktreeId: "wt-1",
+        prNumber: 42,
+        prUrl: "https://example.test/pr/42",
+        prState: "open",
+        prCiStatus: "SUCCESS",
+      });
+    });
+
+    expect((getCache(sameProj)?.items[0] as GitHubPR).ciStatus).toBe("SUCCESS");
+    expect((getCache(otherProj)?.items[0] as GitHubPR).ciStatus).toBe("PENDING");
+  });
+
+  it("uses the project path read at event time so closures cannot go stale", async () => {
+    const store = await renderProvider();
+    act(() => {
+      store.getState().applyUpdate(makeWorktree("wt-1"), store.getState().nextVersion());
+    });
+
+    // Project switches AFTER the provider mounts; the handler must read the
+    // new path at fire time, not the path captured at mount.
+    setCurrentProject("/repo/proj-new");
+    const newKey = buildCacheKey("/repo/proj-new", "pr", "open", "created");
+    const oldKey = buildCacheKey("/repo/proj", "pr", "open", "created");
+    setCache(newKey, {
+      items: [makePR(42, "PENDING")],
+      endCursor: null,
+      hasNextPage: false,
+      timestamp: 1,
+    });
+    setCache(oldKey, {
+      items: [makePR(42, "PENDING")],
+      endCursor: null,
+      hasNextPage: false,
+      timestamp: 1,
+    });
+
+    act(() => {
+      emit("pr-detected", {
+        type: "pr-detected",
+        worktreeId: "wt-1",
+        prNumber: 42,
+        prUrl: "https://example.test/pr/42",
+        prState: "open",
+        prCiStatus: "SUCCESS",
+      });
+    });
+
+    expect((getCache(newKey)?.items[0] as GitHubPR).ciStatus).toBe("SUCCESS");
+    expect((getCache(oldKey)?.items[0] as GitHubPR).ciStatus).toBe("PENDING");
+  });
+});

--- a/src/contexts/__tests__/WorktreeStoreContext.prDetected.test.tsx
+++ b/src/contexts/__tests__/WorktreeStoreContext.prDetected.test.tsx
@@ -143,7 +143,10 @@ describe("WorktreeStoreProvider pr-detected handler", () => {
     act(() => {
       store
         .getState()
-        .applyUpdate(makeWorktree("wt-1", { prCiStatus: "FAILURE" }), store.getState().nextVersion());
+        .applyUpdate(
+          makeWorktree("wt-1", { prCiStatus: "FAILURE" }),
+          store.getState().nextVersion()
+        );
     });
 
     act(() => {


### PR DESCRIPTION
## Summary

- The CI rollup status for a PR was drifting between the GitHub dropdown and the worktree sidebar badge because `prCiStatus` was silently dropped in three places along the data pipeline
- Fix plumbs `prCiStatus` through the `pr-detected` event relay in `preload.cts`, adds it to the `WorktreeStoreContext` `PRDetectedEvent` interface and handler, and calls `mutateCacheEntries` to keep the renderer-side PR list cache in sync with the workspace-host poll
- Switches to full-replace semantics so `undefined` clears the field rather than preserving stale data, matching the intent of `WorktreeMonitor.setPRInfo`

Resolves #8006

## Changes

- `electron/preload.cts` — forward `prCiStatus` in the legacy `CHANNELS.PR_DETECTED` relay
- `src/contexts/WorktreeStoreContext.tsx` — add `prCiStatus` to `PRDetectedEvent`, apply it in the handler, call `mutateCacheEntries` to sync the renderer PR list cache, read `currentProject` path at event time to avoid stale closure; adopt full-replace semantics (no `??` merge)

## Testing

10 new unit tests in `WorktreeStoreContext.prDetected.test.tsx` covering: apply logic, full-replace, cache update, no-op generation guard, `undefined` clears, project scoping, switch-safe path, rapid-fire last-write-wins, and worktree-not-in-store guard. 22 existing cache tests pass with no regressions.