### PR TITLE
fix(project-switcher): remove dead 'open in background' affordance

### DIFF
--- a/src/components/Project/ProjectSwitcher.tsx
+++ b/src/components/Project/ProjectSwitcher.tsx
@@ -11,7 +11,6 @@ import { useKeybindingDisplay } from "@/hooks/useKeybinding";
 import { useProjectSwitcherPalette } from "@/hooks";
 import { useCopyWithFeedback } from "@/hooks/useCopyWithFeedback";
 import { actionService } from "@/services/ActionService";
-import { notify } from "@/lib/notify";
 import { ProjectSwitcherPalette } from "./ProjectSwitcherPalette";
 import type { SearchableProject } from "@/hooks/useProjectSwitcherPalette";
 
@@ -95,20 +94,6 @@ export function ProjectSwitcher() {
     [copyProjectPath]
   );
 
-  const handleSelectBackground = useCallback(
-    (project: SearchableProject) => {
-      if (project.isActive || project.isMissing) return;
-      projectSwitcher.close();
-      notify({
-        type: "info",
-        title: "Background open",
-        message: "Background open is not yet available — coming soon",
-        duration: 3000,
-      });
-    },
-    [projectSwitcher]
-  );
-
   const handleSelectNewWindow = useCallback(
     (project: SearchableProject) => {
       if (project.isMissing) return;
@@ -173,7 +158,6 @@ export function ProjectSwitcher() {
             onLocateProject={handleLocateProject}
             onTogglePinProject={handleTogglePinProject}
             onCopyPath={handleCopyPath}
-            onSelectBackground={handleSelectBackground}
             onSelectNewWindow={handleSelectNewWindow}
             onHoverProject={projectSwitcher.onHoverProject}
             onHoverProjectEnd={projectSwitcher.onHoverProjectEnd}
@@ -243,7 +227,6 @@ export function ProjectSwitcher() {
         onTogglePinProject={handleTogglePinProject}
         onOpenProjectSettings={handleOpenSettings}
         onCopyPath={handleCopyPath}
-        onSelectBackground={handleSelectBackground}
         onHoverProject={projectSwitcher.onHoverProject}
         onHoverProjectEnd={projectSwitcher.onHoverProjectEnd}
         removeConfirmProject={projectSwitcher.removeConfirmProject}

--- a/src/components/Project/ProjectSwitcherPalette.tsx
+++ b/src/components/Project/ProjectSwitcherPalette.tsx
@@ -70,7 +70,6 @@ export interface ProjectSwitcherPaletteProps {
   onLocateProject?: (projectId: string) => void;
   onTogglePinProject?: (projectId: string) => void;
   onCopyPath?: (path: string) => void;
-  onSelectBackground?: (project: SearchableProject) => void;
   onSelectNewWindow?: (project: SearchableProject) => void;
   /** Pointer-enter callback used to schedule a hover prefetch of the project's hydrate payload. */
   onHoverProject?: (projectId: string, pointerType: string) => void;
@@ -664,11 +663,9 @@ function ScratchSection({
 function ProjectSwitcherFooter({ mode }: { mode?: ProjectSwitcherMode }) {
   const modifiers = useModifierKeys();
 
-  const hint = modifiers.alt
-    ? { keys: "⌥↵", label: "Background" }
-    : modifiers.meta
-      ? { keys: "⌘↵", label: "New window" }
-      : { keys: "↵", label: "Switch" };
+  const hint = modifiers.meta
+    ? { keys: "⌘↵", label: "New window" }
+    : { keys: "↵", label: "Switch" };
 
   return (
     <div className="w-full flex items-center justify-between">
@@ -705,7 +702,6 @@ interface ProjectPaletteInnerProps {
   mode?: ProjectSwitcherMode;
   onQueryChange: (query: string) => void;
   onSelect: (project: SearchableProject) => void;
-  onSelectBackground?: (project: SearchableProject) => void;
   onSelectNewWindow?: (project: SearchableProject) => void;
   onClose: () => void;
   onSelectPrevious: () => void;
@@ -737,7 +733,6 @@ function ProjectPaletteInner({
   mode,
   onQueryChange,
   onSelect,
-  onSelectBackground,
   onSelectNewWindow,
   onClose,
   onSelectPrevious,
@@ -790,9 +785,7 @@ function ProjectPaletteInner({
           e.stopPropagation();
           if (results.length > 0 && selectedIndex >= 0 && selectedIndex < results.length) {
             const selected = results[selectedIndex]!;
-            if (e.altKey && onSelectBackground) {
-              onSelectBackground(selected);
-            } else if (
+            if (
               (e.metaKey || e.ctrlKey) &&
               onSelectNewWindow &&
               !selected.isActive &&
@@ -830,7 +823,6 @@ function ProjectPaletteInner({
       onSelectPrevious,
       onSelectNext,
       onSelect,
-      onSelectBackground,
       onSelectNewWindow,
       onClose,
       onCloseProject,
@@ -1063,7 +1055,6 @@ function ModalContent({
           onLocateProject={innerProps.onLocateProject}
           onTogglePinProject={innerProps.onTogglePinProject}
           onCopyPath={innerProps.onCopyPath}
-          onSelectBackground={innerProps.onSelectBackground}
           onSelectNewWindow={innerProps.onSelectNewWindow}
           onHoverProject={innerProps.onHoverProject}
           onHoverProjectEnd={innerProps.onHoverProjectEnd}
@@ -1152,7 +1143,6 @@ function DropdownContent({
           onLocateProject={innerProps.onLocateProject}
           onTogglePinProject={innerProps.onTogglePinProject}
           onCopyPath={innerProps.onCopyPath}
-          onSelectBackground={innerProps.onSelectBackground}
           onSelectNewWindow={innerProps.onSelectNewWindow}
           onHoverProject={innerProps.onHoverProject}
           onHoverProjectEnd={innerProps.onHoverProjectEnd}
@@ -1186,7 +1176,6 @@ export function ProjectSwitcherPalette({
   onLocateProject,
   onTogglePinProject,
   onCopyPath,
-  onSelectBackground,
   onSelectNewWindow,
   onHoverProject,
   onHoverProjectEnd,
@@ -1234,7 +1223,6 @@ export function ProjectSwitcherPalette({
         onLocateProject={onLocateProject}
         onTogglePinProject={onTogglePinProject}
         onCopyPath={onCopyPath}
-        onSelectBackground={onSelectBackground}
         onSelectNewWindow={onSelectNewWindow}
         onHoverProject={onHoverProject}
         onHoverProjectEnd={onHoverProjectEnd}
@@ -1268,7 +1256,6 @@ export function ProjectSwitcherPalette({
         onLocateProject={onLocateProject}
         onTogglePinProject={onTogglePinProject}
         onCopyPath={onCopyPath}
-        onSelectBackground={onSelectBackground}
         onSelectNewWindow={onSelectNewWindow}
         onHoverProject={onHoverProject}
         onHoverProjectEnd={onHoverProjectEnd}

--- a/src/components/Project/__tests__/ProjectSwitcherPalette.keyboard.test.tsx
+++ b/src/components/Project/__tests__/ProjectSwitcherPalette.keyboard.test.tsx
@@ -103,8 +103,9 @@ vi.mock("@/components/ui/context-menu", () => ({
   ContextMenuSeparator: () => null,
 }));
 
+const modifierKeysState = { meta: false, alt: false };
 vi.mock("@/hooks/useModifierKeys", () => ({
-  useModifierKeys: () => ({ meta: false, alt: false }),
+  useModifierKeys: () => modifierKeysState,
 }));
 
 vi.mock("@/utils/timeAgo", () => ({
@@ -158,6 +159,8 @@ describe("ProjectSwitcherPalette keyboard navigation", () => {
 
   beforeEach(() => {
     vi.clearAllMocks();
+    modifierKeysState.meta = false;
+    modifierKeysState.alt = false;
   });
 
   afterEach(() => {
@@ -261,5 +264,22 @@ describe("ProjectSwitcherPalette keyboard navigation", () => {
     expect(footer.textContent).toContain("Switch");
     expect(footer.textContent).not.toContain("Remove");
     expect(footer.textContent).not.toContain("Right-click for more");
+  });
+
+  it("Alt+Enter performs a normal switch (no background-open affordance)", () => {
+    render(<ProjectSwitcherPalette {...defaultProps} />);
+    const input = screen.getByTestId("palette-input");
+    fireEvent.keyDown(input, { key: "Enter", altKey: true });
+    expect(defaultProps.onSelect).toHaveBeenCalledTimes(1);
+    expect(defaultProps.onSelect).toHaveBeenCalledWith(defaultProps.results[0]);
+  });
+
+  it("footer never shows a background hint when Alt is held", () => {
+    modifierKeysState.alt = true;
+    render(<ProjectSwitcherPalette {...defaultProps} />);
+    const footer = screen.getByTestId("palette-footer");
+    expect(footer.textContent).not.toContain("Background");
+    expect(footer.textContent).not.toContain("⌥↵");
+    expect(footer.textContent).toContain("Switch");
   });
 });

--- a/src/components/Project/__tests__/ProjectSwitcherPalette.keyboard.test.tsx
+++ b/src/components/Project/__tests__/ProjectSwitcherPalette.keyboard.test.tsx
@@ -266,17 +266,38 @@ describe("ProjectSwitcherPalette keyboard navigation", () => {
     expect(footer.textContent).not.toContain("Right-click for more");
   });
 
-  it("Alt+Enter performs a normal switch (no background-open affordance)", () => {
-    render(<ProjectSwitcherPalette {...defaultProps} />);
+  it("Alt+Enter performs a normal switch and never triggers new-window", () => {
+    const onSelectNewWindow = vi.fn();
+    render(<ProjectSwitcherPalette {...defaultProps} onSelectNewWindow={onSelectNewWindow} />);
     const input = screen.getByTestId("palette-input");
     fireEvent.keyDown(input, { key: "Enter", altKey: true });
     expect(defaultProps.onSelect).toHaveBeenCalledTimes(1);
     expect(defaultProps.onSelect).toHaveBeenCalledWith(defaultProps.results[0]);
+    expect(onSelectNewWindow).not.toHaveBeenCalled();
   });
 
-  it("footer never shows a background hint when Alt is held", () => {
+  it("Meta+Enter still triggers the new-window shortcut", () => {
+    const onSelectNewWindow = vi.fn();
+    render(<ProjectSwitcherPalette {...defaultProps} onSelectNewWindow={onSelectNewWindow} />);
+    const input = screen.getByTestId("palette-input");
+    fireEvent.keyDown(input, { key: "Enter", metaKey: true });
+    expect(onSelectNewWindow).toHaveBeenCalledTimes(1);
+    expect(onSelectNewWindow).toHaveBeenCalledWith(defaultProps.results[0]);
+    expect(defaultProps.onSelect).not.toHaveBeenCalled();
+  });
+
+  it("footer never shows a background hint when Alt is held (modal mode)", () => {
     modifierKeysState.alt = true;
     render(<ProjectSwitcherPalette {...defaultProps} />);
+    const footer = screen.getByTestId("palette-footer");
+    expect(footer.textContent).not.toContain("Background");
+    expect(footer.textContent).not.toContain("⌥↵");
+    expect(footer.textContent).toContain("Switch");
+  });
+
+  it("footer never shows a background hint when Alt is held (dropdown mode)", () => {
+    modifierKeysState.alt = true;
+    render(<ProjectSwitcherPalette {...defaultProps} mode="dropdown" />);
     const footer = screen.getByTestId("palette-footer");
     expect(footer.textContent).not.toContain("Background");
     expect(footer.textContent).not.toContain("⌥↵");


### PR DESCRIPTION
## Summary

- The project switcher had a dead affordance for opening a project in the background: an `Alt+Enter` keyboard shortcut and a `⌥↵ Background` footer hint. Pressing it fired a `notify()` toast saying "coming soon" — fails the four-question checklist (no next step, already visible another way), and trains users to ignore notifications.
- Removed the entire affordance and its prop chain across `ProjectSwitcher.tsx` and `ProjectSwitcherPalette.tsx` — `onSelectBackground`, `handleSelectBackground`, the keyboard handler branch, the footer hint ternary, and the now-unused `notify` import. `Alt+Enter` falls through to a normal switch.
- The real background-open feature is tracked in #4424 and can re-introduce the affordance when it ships.

Resolves #8027

## Changes

- `ProjectSwitcher.tsx` — removed `onSelectBackground` prop, `handleSelectBackground` handler, unused `notify` import, and the `Alt+Enter` branch
- `ProjectSwitcherPalette.tsx` — removed `onSelectBackground` from the interface and all pass-throughs; simplified footer hint ternary (kept `useModifierKeys` for the `⌘↵ New window` hint)
- `ProjectSwitcherPalette.keyboard.test.tsx` — added regression tests covering `Alt+Enter` no-op behaviour and absence of the background hint

## Testing

All typecheck, lint, format, and build checks pass. 12 keyboard and render tests pass, including the new regression coverage.