### PR TITLE
fix(fleet): use canonical EmptyState in picker popovers

### DIFF
--- a/src/components/Fleet/FleetDraftingPill.tsx
+++ b/src/components/Fleet/FleetDraftingPill.tsx
@@ -1,6 +1,7 @@
 import { type ReactElement } from "react";
 import { RadioTower, ChevronDown, AlertTriangle } from "lucide-react";
 import { cn } from "@/lib/utils";
+import { EmptyState } from "@/components/ui/EmptyState";
 import { useFleetArmingStore } from "@/store/fleetArmingStore";
 import { useFleetResolutionPreviewStore } from "@/store/fleetResolutionPreviewStore";
 import { useEscapeStack } from "@/hooks/useEscapeStack";
@@ -64,7 +65,12 @@ export function FleetDraftingPill(): ReactElement | null {
             Fleet broadcast preview
           </div>
           {previews.length === 0 ? (
-            <div className="px-2 py-1 text-[12px] text-daintree-text/60">No armed terminals</div>
+            <EmptyState
+              variant="zero-data"
+              scale="popover"
+              title="No armed terminals"
+              className="py-3"
+            />
           ) : (
             <ul className="flex flex-col gap-0.5">
               {previews.map((p) => (

--- a/src/components/Fleet/FleetPickerContent.tsx
+++ b/src/components/Fleet/FleetPickerContent.tsx
@@ -165,14 +165,14 @@ export function FleetPickerContent({
             variant="zero-data"
             scale="popover"
             title="No terminals available"
-            className="min-h-[120px]"
+            className="h-full min-h-[120px]"
           />
         ) : visibleTerminals.length === 0 ? (
           <EmptyState
             variant="filtered-empty"
             scale="popover"
             title="No terminals match"
-            className="min-h-[120px]"
+            className="h-full min-h-[120px]"
           />
         ) : (
           groupedVisible.map((group) => (

--- a/src/components/Fleet/FleetPickerContent.tsx
+++ b/src/components/Fleet/FleetPickerContent.tsx
@@ -1,6 +1,7 @@
 import { useCallback, useMemo, type ReactElement } from "react";
 import * as Checkbox from "@radix-ui/react-checkbox";
 import { CheckIcon, MinusIcon, Search } from "lucide-react";
+import { EmptyState } from "@/components/ui/EmptyState";
 import { Kbd } from "@/components/ui/Kbd";
 import { isMac } from "@/lib/platform";
 import { cn } from "@/lib/utils";
@@ -161,15 +162,17 @@ export function FleetPickerContent({
       >
         {eligibleTerminals.length === 0 ? (
           <EmptyState
+            variant="zero-data"
+            scale="popover"
             title="No terminals available"
-            hint="Open or focus a terminal to add it to the fleet."
-            testId={`${testIdPrefix}-empty`}
+            className="min-h-[120px]"
           />
         ) : visibleTerminals.length === 0 ? (
           <EmptyState
+            variant="filtered-empty"
+            scale="popover"
             title="No terminals match"
-            hint="Adjust the search to see more terminals."
-            testId={`${testIdPrefix}-empty`}
+            className="min-h-[120px]"
           />
         ) : (
           groupedVisible.map((group) => (
@@ -293,24 +296,6 @@ function deriveGroupCheckedState(
   if (selected === 0) return false;
   if (selected === groupIds.length) return true;
   return "indeterminate";
-}
-
-interface EmptyStateProps {
-  title: string;
-  hint: string;
-  testId: string;
-}
-
-function EmptyState({ title, hint, testId }: EmptyStateProps): ReactElement {
-  return (
-    <div
-      className="flex h-full min-h-[120px] flex-col items-center justify-center gap-1 px-6 text-center"
-      data-testid={testId}
-    >
-      <div className="text-[13px] font-medium text-daintree-text">{title}</div>
-      <div className="text-[12px] text-daintree-text/60">{hint}</div>
-    </div>
-  );
 }
 
 interface WorktreeGroupSectionProps {

--- a/src/components/Fleet/__tests__/FleetPickerContent.test.tsx
+++ b/src/components/Fleet/__tests__/FleetPickerContent.test.tsx
@@ -443,5 +443,25 @@ describe("FleetPickerContent + useFleetPicker", () => {
       await act(async () => {});
       expect(screen.getByRole("status").textContent).toContain("No terminals available");
     });
+
+    it("renders 'No terminals match' when the search filters out all eligibles", async () => {
+      seedTerminals([
+        makeTerminal("t1", { title: "alpha" }),
+        makeTerminal("t2", { title: "beta" }),
+      ]);
+      useWorktreeSelectionStore.setState({ activeWorktreeId: null });
+      renderHarness([makeWorktreeSnap("wt-1", "main")], {
+        mode: "cold-start",
+        onCommit: () => {},
+      });
+      await act(async () => {});
+      const search = screen.getByTestId("fp-search") as HTMLInputElement;
+      await act(async () => {
+        fireEvent.change(search, { target: { value: "zzz-no-match" } });
+      });
+      await act(async () => {});
+      expect(screen.getByRole("status").textContent).toContain("No terminals match");
+      expect(screen.queryAllByRole("option")).toHaveLength(0);
+    });
   });
 });

--- a/src/components/Fleet/__tests__/FleetPickerContent.test.tsx
+++ b/src/components/Fleet/__tests__/FleetPickerContent.test.tsx
@@ -441,7 +441,7 @@ describe("FleetPickerContent + useFleetPicker", () => {
       useWorktreeSelectionStore.setState({ activeWorktreeId: null });
       renderHarness([], { mode: "cold-start", onCommit: () => {} });
       await act(async () => {});
-      expect(screen.getByTestId("fp-empty").textContent).toContain("No terminals available");
+      expect(screen.getByRole("status").textContent).toContain("No terminals available");
     });
   });
 });

--- a/src/components/Fleet/__tests__/FleetPickerPalette.test.tsx
+++ b/src/components/Fleet/__tests__/FleetPickerPalette.test.tsx
@@ -269,9 +269,7 @@ describe("FleetPickerPalette", () => {
     ]);
     renderPalette([makeWorktreeSnap("wt-1", "main")]);
     await act(async () => {});
-    expect(screen.getByTestId("fleet-picker-cold-start-empty").textContent).toContain(
-      "No terminals available"
-    );
+    expect(screen.getByText("No terminals available")).toBeTruthy();
     const confirm = screen.getByTestId("fleet-picker-cold-start-confirm") as HTMLButtonElement;
     expect(confirm.disabled).toBe(true);
   });


### PR DESCRIPTION
## Summary

- `FleetPickerContent` was using a local empty-state shim instead of `EmptyState`. Migrated both empty branches to the canonical component: `zero-data` variant for the unfiltered case, `filtered-empty` for the search case, both at popover scale with `h-full min-h-[120px]` for vertical centering in the scrollable listbox area.
- `FleetDraftingPill` had a bare `div` standing in for an empty state. Replaced with canonical `EmptyState` (`zero-data` variant, `py-3` sizing for the compact 320px popover).
- Tests updated from removed `data-testid` selectors to `role=status` / `getByText` queries. Added coverage for the previously-untested `filtered-empty` path ("No terminals match").

Resolves #8018

## Changes

- `FleetPickerContent.tsx` — removed local shim, migrated to `EmptyState` with correct variant and sizing
- `FleetDraftingPill.tsx` — replaced bare `div` with canonical `EmptyState`
- `FleetPickerContent.test.tsx` — updated selectors, added filtered-empty coverage
- `FleetPickerPalette.test.tsx` — updated selectors to match new DOM

## Testing

38 tests pass. All `check:*` scripts pass (typecheck, lint, format). The popover-scale rule in `CLAUDE.md` (≤5-word titles, no description, no primary-weight button) was used as the rationale for omitting hint copy.