### PR TITLE
fix(drag): thread DRAG_GHOST_OPACITY through outlier drag-source dim sites

### DIFF
--- a/src/components/Panel/SortableTabButton.tsx
+++ b/src/components/Panel/SortableTabButton.tsx
@@ -2,7 +2,7 @@ import React, { useCallback } from "react";
 import { useSortable } from "@dnd-kit/sortable";
 import { CSS } from "@dnd-kit/utilities";
 import { m } from "framer-motion";
-import { cn } from "@/lib/utils";
+import { DRAG_GHOST_OPACITY } from "@/lib/animationUtils";
 import { TabButton, type TabButtonProps } from "./TabButton";
 
 export interface SortableTabButtonProps extends TabButtonProps {
@@ -33,6 +33,7 @@ function SortableTabButtonComponent({
     transform: CSS.Transform.toString(transform),
     transition,
     zIndex: isDragging ? 10 : undefined,
+    opacity: isDragging ? DRAG_GHOST_OPACITY : undefined,
   };
 
   // Wrap handlers to prevent activation of sortable when clicking or closing
@@ -55,7 +56,7 @@ function SortableTabButtonComponent({
   const performanceMode = document.body.dataset.performanceMode === "true";
 
   return (
-    <div ref={setNodeRef} style={style} className={cn(isDragging && "opacity-50")}>
+    <div ref={setNodeRef} style={style}>
       {performanceMode ? (
         <TabButton
           ref={setActivatorNodeRef}

--- a/src/components/Settings/ToolbarSettingsTab.tsx
+++ b/src/components/Settings/ToolbarSettingsTab.tsx
@@ -31,6 +31,7 @@ import { getAgentConfig } from "@/config/agents";
 import { usePluginToolbarButtons } from "@/hooks/usePluginToolbarButtons";
 import { McpServerIcon } from "@/components/icons";
 import { cn } from "@/lib/utils";
+import { DRAG_GHOST_OPACITY } from "@/lib/animationUtils";
 import { SettingsSection } from "./SettingsSection";
 import { SettingsSwitchCard } from "./SettingsSwitchCard";
 
@@ -63,7 +64,7 @@ function SortableButtonItem({
   const style = {
     transform: CSS.Transform.toString(transform),
     transition,
-    opacity: isDragging ? 0.5 : isVisible ? 1 : 0.5,
+    opacity: isDragging ? DRAG_GHOST_OPACITY : isVisible ? 1 : 0.5,
   };
 
   if (!metadata) return null;

--- a/src/components/Settings/__tests__/ToolbarSettingsTab.test.tsx
+++ b/src/components/Settings/__tests__/ToolbarSettingsTab.test.tsx
@@ -92,16 +92,27 @@ vi.mock("@dnd-kit/core", () => ({
 vi.mock("@dnd-kit/sortable", () => ({
   SortableContext: ({ children }: { children: React.ReactNode }) => <>{children}</>,
   sortableKeyboardCoordinates: vi.fn(),
-  useSortable: () => ({
+  useSortable: vi.fn(() => ({
     attributes: {},
     listeners: {},
     setNodeRef: vi.fn(),
     transform: null,
     transition: null,
     isDragging: false,
-  }),
+  })),
   verticalListSortingStrategy: vi.fn(),
 }));
+
+// Test-time helper for restoring the default useSortable return between
+// cases (the mock factory above is hoisted, so it can't reference this).
+const defaultSortable = () => ({
+  attributes: {},
+  listeners: {},
+  setNodeRef: vi.fn(),
+  transform: null,
+  transition: null,
+  isDragging: false,
+});
 
 vi.mock("@dnd-kit/utilities", () => ({
   CSS: { Transform: { toString: () => "" } },
@@ -127,6 +138,8 @@ vi.mock("../SettingsSwitchCard", () => ({
   SettingsSwitchCard: () => null,
 }));
 
+import { useSortable } from "@dnd-kit/sortable";
+import { DRAG_GHOST_OPACITY } from "@/lib/animationUtils";
 import { ToolbarSettingsTab } from "../ToolbarSettingsTab";
 
 function agentSettings(overrides: Record<string, { pinned?: boolean }>): AgentSettings {
@@ -271,5 +284,68 @@ describe("ToolbarSettingsTab — agent visibility routing", () => {
 
     expect(setAgentPinnedMock).toHaveBeenCalledWith("codex", false);
     expect(toggleButtonVisibilityMock).not.toHaveBeenCalled();
+  });
+});
+
+describe("ToolbarSettingsTab — drag-source vs hidden opacity deconfliction", () => {
+  // The drag-source ghost (DRAG_GHOST_OPACITY) and the hidden-in-toolbar
+  // preview (0.5) are semantically distinct states that previously shared a
+  // magic 0.5. These tests lock the deconfliction so the two values can't
+  // silently collapse back together.
+  beforeEach(() => {
+    setAgentPinnedMock.mockClear();
+    vi.mocked(useSortable).mockImplementation(defaultSortable);
+    mockToolbarState = {
+      layout: {
+        leftButtons: ["agent-tray", "claude", "gemini", "terminal"],
+        rightButtons: ["copy-tree", "settings"],
+        pinnedButtons: {},
+      },
+      launcher: { alwaysShowDevServer: false, defaultSelection: undefined },
+      setLeftButtons: setLeftButtonsMock,
+      setRightButtons: setRightButtonsMock,
+      toggleButtonVisibility: toggleButtonVisibilityMock,
+      setAlwaysShowDevServer: setAlwaysShowDevServerMock,
+      setDefaultSelection: setDefaultSelectionMock,
+      reset: resetMock,
+    };
+    mockAgentSettings = null;
+  });
+
+  function rowFor(label: string, container: HTMLElement): HTMLElement {
+    const checkbox = container.querySelector(
+      `input[aria-label="Toggle ${label} visibility"]`
+    ) as HTMLInputElement;
+    return checkbox.parentElement as HTMLElement;
+  }
+
+  it("applies DRAG_GHOST_OPACITY to a dragged row (not the legacy 0.5)", () => {
+    vi.mocked(useSortable).mockImplementation(() => ({
+      ...defaultSortable(),
+      isDragging: true,
+    }));
+
+    const { getByLabelText, container } = render(<ToolbarSettingsTab />);
+    getByLabelText("Toggle Terminal visibility");
+    const row = rowFor("Terminal", container);
+    expect(row.style.opacity).toBe(String(DRAG_GHOST_OPACITY));
+    expect(row.style.opacity).not.toBe("0.5");
+  });
+
+  it("keeps the hidden-in-toolbar preview at 0.5 (distinct from the drag ghost)", () => {
+    // gemini unpinned → not visible → hidden-preview opacity.
+    mockAgentSettings = agentSettings({ gemini: { pinned: false } });
+
+    const { container } = render(<ToolbarSettingsTab />);
+    const row = rowFor("Gemini Agent", container);
+    expect(row.style.opacity).toBe("0.5");
+  });
+
+  it("renders a visible, non-dragged row at full opacity", () => {
+    mockAgentSettings = agentSettings({ claude: { pinned: true } });
+
+    const { container } = render(<ToolbarSettingsTab />);
+    const row = rowFor("Claude Agent", container);
+    expect(row.style.opacity).toBe("1");
   });
 });

--- a/src/components/Settings/__tests__/ToolbarSettingsTab.test.tsx
+++ b/src/components/Settings/__tests__/ToolbarSettingsTab.test.tsx
@@ -105,14 +105,18 @@ vi.mock("@dnd-kit/sortable", () => ({
 
 // Test-time helper for restoring the default useSortable return between
 // cases (the mock factory above is hoisted, so it can't reference this).
-const defaultSortable = () => ({
-  attributes: {},
-  listeners: {},
-  setNodeRef: vi.fn(),
-  transform: null,
-  transition: null,
-  isDragging: false,
-});
+// The component only reads transform/transition/isDragging/listeners/
+// attributes/setNodeRef; the cast keeps the partial shape without
+// reconstructing dnd-kit's full ~20-field return type.
+const defaultSortable = (): ReturnType<typeof useSortable> =>
+  ({
+    attributes: {},
+    listeners: {},
+    setNodeRef: vi.fn(),
+    transform: null,
+    transition: null,
+    isDragging: false,
+  }) as unknown as ReturnType<typeof useSortable>;
 
 vi.mock("@dnd-kit/utilities", () => ({
   CSS: { Transform: { toString: () => "" } },
@@ -330,6 +334,22 @@ describe("ToolbarSettingsTab — drag-source vs hidden opacity deconfliction", (
     const row = rowFor("Terminal", container);
     expect(row.style.opacity).toBe(String(DRAG_GHOST_OPACITY));
     expect(row.style.opacity).not.toBe("0.5");
+  });
+
+  it("prefers DRAG_GHOST_OPACITY over the hidden preview when dragging a hidden row", () => {
+    // Unreachable in production today (useSortable is called with
+    // `disabled: !isVisible`, so a hidden row can't drag), but this locks
+    // the ternary's `isDragging`-first ordering against a future refactor
+    // that drops the disabled guard.
+    mockAgentSettings = agentSettings({ gemini: { pinned: false } });
+    vi.mocked(useSortable).mockImplementation(() => ({
+      ...defaultSortable(),
+      isDragging: true,
+    }));
+
+    const { container } = render(<ToolbarSettingsTab />);
+    const row = rowFor("Gemini Agent", container);
+    expect(row.style.opacity).toBe(String(DRAG_GHOST_OPACITY));
   });
 
   it("keeps the hidden-in-toolbar preview at 0.5 (distinct from the drag ghost)", () => {


### PR DESCRIPTION
Closes #8017.

`DRAG_GHOST_OPACITY` (`src/lib/animationUtils.ts:111`, `0.4`) is the single source of truth for drag-source dimming, but two components bypassed it with hard-coded magic values. This threads the token through both.

## Changes

- **`SortableTabButton.tsx`** — replaced the `opacity-50` Tailwind class with `opacity: isDragging ? DRAG_GHOST_OPACITY : undefined` on the existing dnd-kit `style` object (the idiomatic spot — this component uses plain dnd-kit, not Framer Motion, so inline style keeps opacity co-located with `transform`/`transition`). Dropped the now-unused `cn` import.
- **`ToolbarSettingsTab.tsx`** — the ternary `opacity: isDragging ? 0.5 : isVisible ? 1 : 0.5` collapsed two semantically distinct states into one magic number. Only the `isDragging` branch now uses `DRAG_GHOST_OPACITY`. The `!isVisible` "hidden in toolbar" preview deliberately **stays at `0.5`** — it's a persistent de-emphasis state, not a transient drag ghost, and conflating the two values again is exactly what this fix prevents.
- **`ToolbarSettingsTab.test.tsx`** — typed the hoisted `useSortable` mock and added a deconfliction describe block (dragged → `DRAG_GHOST_OPACITY`, hidden → `0.5`, visible → `1`, plus a precedence-lock for `isDragging`-first ordering). Assertions import the real token so future token changes cascade automatically.

No other drag-source outliers: `SortableWorktreeCard` already uses `opacity-40` (= token value), `PortalToolbar`'s `opacity-80` is an intentional drag-*overlay* lift, not a source ghost.

No new dependencies; no transition utilities added (per the #4738 scoped-transition rule).

## Verification

- `vitest` ToolbarSettingsTab suite: 13 passing
- typecheck / lint / format / main build: clean

🤖 Generated with [Claude Code](https://claude.com/claude-code)