### PR TITLE
fix(review-hub): route completed states through user-cleared EmptyState

### DIFF
--- a/src/components/Worktree/ReviewHub/ConflictPanel.tsx
+++ b/src/components/Worktree/ReviewHub/ConflictPanel.tsx
@@ -16,6 +16,7 @@ import {
 } from "lucide-react";
 import { Button } from "@/components/ui/button";
 import { ConfirmDialog } from "@/components/ui/ConfirmDialog";
+import { EmptyState } from "@/components/ui/EmptyState";
 import { Spinner } from "@/components/ui/Spinner";
 import { TruncatedTooltip } from "@/components/ui/TruncatedTooltip";
 
@@ -584,7 +585,7 @@ export function ConflictPanel({
             })}
           </ul>
         ) : (
-          <div className="px-4 py-3 text-xs text-daintree-text/60">No conflicted files remain.</div>
+          <EmptyState variant="user-cleared" scale="sidebar" title="All conflicts resolved" />
         )}
 
         {/* Resolved disclosure — recedes when conflicts remain, collapsed by default. */}

--- a/src/components/Worktree/ReviewHub/ReviewHubContent.tsx
+++ b/src/components/Worktree/ReviewHub/ReviewHubContent.tsx
@@ -1782,9 +1782,11 @@ export function ReviewHubContent({
                             }
                           />
                         ) : (
-                          <div className="px-4 py-3 text-xs text-daintree-text/40 italic">
-                            No staged files
-                          </div>
+                          <EmptyState
+                            variant="user-cleared"
+                            scale="sidebar"
+                            title="Nothing staged"
+                          />
                         )}
                       </div>
 
@@ -1987,9 +1989,11 @@ export function ReviewHubContent({
                             }
                           />
                         ) : (
-                          <div className="px-4 py-3 text-xs text-daintree-text/40 italic">
-                            No unstaged changes
-                          </div>
+                          <EmptyState
+                            variant="user-cleared"
+                            scale="sidebar"
+                            title="All changes staged"
+                          />
                         )}
                       </div>
                     </div>

--- a/src/components/Worktree/ReviewHub/__tests__/ReviewHub.test.tsx
+++ b/src/components/Worktree/ReviewHub/__tests__/ReviewHub.test.tsx
@@ -1182,6 +1182,22 @@ describe("ReviewHub", () => {
       );
     });
 
+    it("renders user-cleared empty state when all conflicts are resolved", async () => {
+      getStagingStatusMock.mockResolvedValue(
+        makeMergingStatus({
+          conflicted: [],
+          conflictedFiles: [],
+          staged: [{ path: "src/app.ts", status: "modified", insertions: 1, deletions: 1 }],
+        })
+      );
+
+      render(<ReviewHub isOpen={true} worktreePath={WORKTREE_PATH} onClose={vi.fn()} />);
+
+      await waitFor(() => screen.getByTestId("conflict-panel"));
+      expect(screen.getByText("All conflicts resolved")).toBeTruthy();
+      expect(screen.getAllByTestId("empty-state-user-cleared").length).toBeGreaterThan(0);
+    });
+
     it("stages a file when Mark resolved is clicked", async () => {
       getStagingStatusMock.mockResolvedValue(makeMergingStatus());
 
@@ -2486,7 +2502,8 @@ describe("ReviewHub", () => {
 
       render(<ReviewHub isOpen={true} worktreePath={WORKTREE_PATH} onClose={vi.fn()} />);
 
-      await waitFor(() => screen.getByText("No unstaged changes"));
+      await waitFor(() => screen.getByText("All changes staged"));
+      expect(screen.getAllByTestId("empty-state-user-cleared").length).toBeGreaterThan(0);
       // Stage all button (for Changes section) should be hidden when there are no unstaged files
       expect(screen.queryByTestId("review-hub-stage-section-button")).toBeNull();
       // Unstage all button (for Staged section) should be visible with 1 file
@@ -2509,7 +2526,7 @@ describe("ReviewHub", () => {
       expect((filters[0]! as HTMLInputElement).value).toBe("src");
     });
 
-    it("shows No staged files when section is empty but filter is not active", async () => {
+    it("shows Nothing staged user-cleared empty state when section is empty but filter is not active", async () => {
       getStagingStatusMock.mockResolvedValue(
         makeStatus({
           staged: [],
@@ -2520,9 +2537,10 @@ describe("ReviewHub", () => {
       render(<ReviewHub isOpen={true} worktreePath={WORKTREE_PATH} onClose={vi.fn()} />);
 
       await waitFor(() => {
-        screen.getByText("No staged files");
+        screen.getByText("Nothing staged");
         screen.getByText("b.ts");
       });
+      expect(screen.getAllByTestId("empty-state-user-cleared").length).toBeGreaterThan(0);
     });
 
     it("renders files sorted by path ascending by default", async () => {

--- a/src/components/Worktree/ReviewHub/__tests__/ReviewHub.test.tsx
+++ b/src/components/Worktree/ReviewHub/__tests__/ReviewHub.test.tsx
@@ -248,14 +248,16 @@ vi.mock("@/components/ui/dropdown-menu", () => ({
 vi.mock("@/components/ui/EmptyState", () => ({
   EmptyState: ({
     variant,
+    scale,
     title,
     action,
   }: {
     variant: string;
+    scale?: string;
     title: string;
     action?: ReactNode;
   }) => (
-    <div data-testid={`empty-state-${variant}`}>
+    <div data-testid={`empty-state-${variant}`} data-scale={scale}>
       <p>{title}</p>
       {action && <div>{action}</div>}
     </div>
@@ -1194,8 +1196,10 @@ describe("ReviewHub", () => {
       render(<ReviewHub isOpen={true} worktreePath={WORKTREE_PATH} onClose={vi.fn()} />);
 
       await waitFor(() => screen.getByTestId("conflict-panel"));
-      expect(screen.getByText("All conflicts resolved")).toBeTruthy();
-      expect(screen.getAllByTestId("empty-state-user-cleared").length).toBeGreaterThan(0);
+      const resolvedTitle = screen.getByText("All conflicts resolved");
+      const resolvedEmpty = resolvedTitle.closest('[data-testid="empty-state-user-cleared"]');
+      expect(resolvedEmpty).not.toBeNull();
+      expect(resolvedEmpty?.getAttribute("data-scale")).toBe("sidebar");
     });
 
     it("stages a file when Mark resolved is clicked", async () => {
@@ -2502,8 +2506,10 @@ describe("ReviewHub", () => {
 
       render(<ReviewHub isOpen={true} worktreePath={WORKTREE_PATH} onClose={vi.fn()} />);
 
-      await waitFor(() => screen.getByText("All changes staged"));
-      expect(screen.getAllByTestId("empty-state-user-cleared").length).toBeGreaterThan(0);
+      const allStagedTitle = await screen.findByText("All changes staged");
+      const allStagedEmpty = allStagedTitle.closest('[data-testid="empty-state-user-cleared"]');
+      expect(allStagedEmpty).not.toBeNull();
+      expect(allStagedEmpty?.getAttribute("data-scale")).toBe("sidebar");
       // Stage all button (for Changes section) should be hidden when there are no unstaged files
       expect(screen.queryByTestId("review-hub-stage-section-button")).toBeNull();
       // Unstage all button (for Staged section) should be visible with 1 file
@@ -2540,7 +2546,12 @@ describe("ReviewHub", () => {
         screen.getByText("Nothing staged");
         screen.getByText("b.ts");
       });
-      expect(screen.getAllByTestId("empty-state-user-cleared").length).toBeGreaterThan(0);
+      const nothingStagedTitle = screen.getByText("Nothing staged");
+      const nothingStagedEmpty = nothingStagedTitle.closest(
+        '[data-testid="empty-state-user-cleared"]'
+      );
+      expect(nothingStagedEmpty).not.toBeNull();
+      expect(nothingStagedEmpty?.getAttribute("data-scale")).toBe("sidebar");
     });
 
     it("renders files sorted by path ascending by default", async () => {


### PR DESCRIPTION
## Summary

Three completed-state surfaces in ReviewHub were rendering as bare italic `<div>` prose instead of routing through the canonical `EmptyState` component — two in `ReviewHubContent.tsx` (nothing staged, all changes staged) and one in `ConflictPanel.tsx` (all conflicts resolved). All three now use `<EmptyState variant="user-cleared" scale="sidebar" />`. The `ConflictPanel` copy also had a trailing full stop that violated microcopy rules, fixed here.

Resolves #8020

## Changes

- `ReviewHubContent.tsx`: replaced bare `<div>` prose for the "nothing staged" and "all changes staged" states with `EmptyState`
- `ConflictPanel.tsx`: replaced bare `<div>` prose for the "all conflicts resolved" state with `EmptyState`; removed trailing full stop from copy
- Updated 2 existing tests to assert `EmptyState` with `variant="user-cleared"` and `data-scale="sidebar"`; added 1 new test for `ConflictPanel`

## Testing

- Existing `ReviewHub.test.tsx` suite updated and passing
- New assertion scoped with `closest()` to confirm `scale="sidebar"` on the wrapping element