### PR TITLE
feat(mcp): tighten MCP confirm — rotate gate, severity, label

### DIFF
--- a/src/components/McpConfirmDialog.tsx
+++ b/src/components/McpConfirmDialog.tsx
@@ -1,4 +1,5 @@
-import { useEffect } from "react";
+import { useCallback, useEffect, useRef } from "react";
+import type { McpConfirmationDecision } from "@shared/types/ipc/mcpServer";
 import { ConfirmDialog } from "@/components/ui/ConfirmDialog";
 import { ErrorBoundary } from "@/components/ErrorBoundary";
 import { useMcpConfirmStore } from "@/store/mcpConfirmStore";
@@ -23,19 +24,36 @@ export function McpConfirmDialog() {
   const resolveCurrent = useMcpConfirmStore((state) => state.resolveCurrent);
   const resetKey = current?.requestId ?? "null";
 
+  // `resolveCurrent` is synchronous: it resolves the promise and advances the
+  // queue so `current` becomes the next item before React re-renders. A rapid
+  // double-click would otherwise fire a second `resolveCurrent("approved")`
+  // that lands on the freshly-promoted queued item — silently approving a
+  // destructive action the user never saw. Gate every resolution on the
+  // requestId we've already handled so a given dialog can resolve exactly once.
+  const handledRequestIdRef = useRef<string | null>(null);
+  const resolveOnce = useCallback(
+    (requestId: string, decision: McpConfirmationDecision) => {
+      if (handledRequestIdRef.current === requestId) return;
+      handledRequestIdRef.current = requestId;
+      resolveCurrent(decision);
+    },
+    [resolveCurrent]
+  );
+
   useEffect(() => {
     if (current === null) return;
+    const { requestId, enqueuedAt } = current;
     // Subtract time the request already spent queued behind a prior modal so
     // every dispatch races against the same wall-clock budget; otherwise a
     // queued item could outlive main's 30s deadline and degrade to a generic
     // timeout error instead of `CONFIRMATION_TIMEOUT`.
-    const elapsed = Date.now() - current.enqueuedAt;
+    const elapsed = Date.now() - enqueuedAt;
     const remaining = Math.max(500, CONFIRMATION_TIMEOUT_MS - elapsed);
     const timer = setTimeout(() => {
-      resolveCurrent("timeout");
+      resolveOnce(requestId, "timeout");
     }, remaining);
     return () => clearTimeout(timer);
-  }, [current, resolveCurrent]);
+  }, [current, resolveOnce]);
 
   if (current === null) {
     return (
@@ -60,12 +78,12 @@ export function McpConfirmDialog() {
     <ErrorBoundary variant="component" componentName="McpConfirmDialog" resetKeys={[resetKey]}>
       <ConfirmDialog
         isOpen={true}
-        onClose={() => resolveCurrent("rejected")}
+        onClose={() => resolveOnce(current.requestId, "rejected")}
         title={`Run '${current.actionTitle}'?`}
         description={current.actionDescription}
         confirmLabel={current.actionTitle}
         cancelLabel="Cancel"
-        onConfirm={() => resolveCurrent("approved")}
+        onConfirm={() => resolveOnce(current.requestId, "approved")}
         variant={variant}
       >
         <div className="space-y-2">

--- a/src/components/McpConfirmDialog.tsx
+++ b/src/components/McpConfirmDialog.tsx
@@ -43,13 +43,18 @@ export function McpConfirmDialog() {
         <ConfirmDialog
           isOpen={false}
           title=""
-          confirmLabel="Run action"
+          confirmLabel="Run"
           onConfirm={() => {}}
-          variant="destructive"
+          variant="default"
         />
       </ErrorBoundary>
     );
   }
+
+  // Severity follows the action's registry classification, not the fact that
+  // an MCP client dispatched it. Provenance is already conveyed by the
+  // "Run '…'?" framing; only genuinely destructive dispatches earn red.
+  const variant = current.danger === "confirm" ? "destructive" : "default";
 
   return (
     <ErrorBoundary variant="component" componentName="McpConfirmDialog" resetKeys={[resetKey]}>
@@ -58,10 +63,10 @@ export function McpConfirmDialog() {
         onClose={() => resolveCurrent("rejected")}
         title={`Run '${current.actionTitle}'?`}
         description={current.actionDescription}
-        confirmLabel="Run action"
+        confirmLabel={current.actionTitle}
         cancelLabel="Cancel"
         onConfirm={() => resolveCurrent("approved")}
-        variant="destructive"
+        variant={variant}
       >
         <div className="space-y-2">
           <div className="text-xs text-daintree-text/60 uppercase tracking-wide">Arguments</div>

--- a/src/components/Settings/McpServerSettingsTab.tsx
+++ b/src/components/Settings/McpServerSettingsTab.tsx
@@ -489,8 +489,9 @@ export function McpServerSettingsTab() {
                   </button>
                   <button
                     onClick={() => setShowRotateConfirm(true)}
-                    className="flex items-center gap-1.5 px-3 py-2 text-xs font-medium rounded-[var(--radius-md)] border border-daintree-border text-daintree-text/70 hover:text-daintree-text hover:bg-overlay-soft transition-colors"
-                    title="Rotate API key"
+                    disabled={!apiKeySuffix}
+                    className="flex items-center gap-1.5 px-3 py-2 text-xs font-medium rounded-[var(--radius-md)] border border-daintree-border text-daintree-text/70 hover:text-daintree-text hover:bg-overlay-soft transition-colors disabled:opacity-50 disabled:cursor-not-allowed disabled:hover:bg-transparent disabled:hover:text-daintree-text/70"
+                    title={apiKeySuffix ? "Rotate API key" : "Waiting for the MCP key to load…"}
                   >
                     <RefreshCw className="w-3.5 h-3.5" />
                     Rotate API key

--- a/src/components/Settings/McpServerSettingsTab.tsx
+++ b/src/components/Settings/McpServerSettingsTab.tsx
@@ -311,6 +311,11 @@ export function McpServerSettingsTab() {
 
   const sseUrl = status.port ? `http://127.0.0.1:${status.port}/sse` : null;
 
+  // Rotation is the revoke-all primitive — it invalidates every external
+  // client holding the current key in one shot (Tier D3). Gate it behind
+  // typing the last 4 characters, matching DaintreeAssistantSettingsTab.
+  const apiKeySuffix = status.apiKey && status.apiKey.length >= 8 ? status.apiKey.slice(-4) : "";
+
   return (
     <div className="space-y-6">
       <SettingsSwitchCard
@@ -584,13 +589,29 @@ export function McpServerSettingsTab() {
         isOpen={showRotateConfirm}
         onClose={isRotating ? undefined : handleCancelRotate}
         title="Rotate API key?"
-        description="The current key will be invalidated immediately. External clients using this key will need to update their configuration."
+        description={
+          <>
+            The current key will be invalidated immediately. External clients using this key will
+            need to update their configuration.
+            {apiKeySuffix && (
+              <>
+                {" "}
+                Type the last 4 characters of the current key (
+                <code className="font-mono text-xs bg-daintree-bg/50 px-1.5 py-0.5 rounded border border-daintree-border">
+                  {apiKeySuffix}
+                </code>
+                ) to confirm.
+              </>
+            )}
+          </>
+        }
         confirmLabel="Rotate key"
         cancelLabel="Cancel"
         onConfirm={confirmRotateApiKey}
         isConfirmLoading={isRotating}
         variant="destructive"
         zIndex="nested"
+        typedNameTarget={apiKeySuffix || undefined}
       />
 
       <ConfirmDialog

--- a/src/components/Settings/__tests__/McpServerSettingsTab.test.tsx
+++ b/src/components/Settings/__tests__/McpServerSettingsTab.test.tsx
@@ -199,7 +199,16 @@ describe("McpServerSettingsTab", () => {
     });
     expect(window.electron.mcpServer.rotateApiKey).not.toHaveBeenCalled();
 
-    fireEvent.click(screen.getByRole("button", { name: /^rotate key$/i }));
+    const confirmButton = screen.getByRole("button", {
+      name: /^rotate key$/i,
+    }) as HTMLButtonElement;
+    expect(confirmButton.disabled).toBe(true);
+
+    const typedInput = screen.getByLabelText(/^Type .* to confirm$/i) as HTMLInputElement;
+    fireEvent.change(typedInput, { target: { value: "c123" } });
+    expect(confirmButton.disabled).toBe(false);
+
+    fireEvent.click(confirmButton);
 
     await waitFor(() => {
       expect(window.electron.mcpServer.rotateApiKey).toHaveBeenCalledTimes(1);
@@ -252,6 +261,9 @@ describe("McpServerSettingsTab", () => {
       expect(screen.getByRole("heading", { name: /rotate api key\?/i })).toBeTruthy();
     });
 
+    fireEvent.change(screen.getByLabelText(/^Type .* to confirm$/i), {
+      target: { value: "c123" },
+    });
     fireEvent.click(screen.getByRole("button", { name: /^rotate key$/i }));
 
     await waitFor(() => {
@@ -281,6 +293,9 @@ describe("McpServerSettingsTab", () => {
       expect(screen.getByRole("heading", { name: /rotate api key\?/i })).toBeTruthy();
     });
 
+    fireEvent.change(screen.getByLabelText(/^Type .* to confirm$/i), {
+      target: { value: "c123" },
+    });
     fireEvent.click(screen.getByRole("button", { name: /^rotate key$/i }));
 
     await waitForContent(container, "rotate failed");

--- a/src/components/__tests__/McpConfirmDialog.test.tsx
+++ b/src/components/__tests__/McpConfirmDialog.test.tsx
@@ -1,0 +1,115 @@
+// @vitest-environment jsdom
+import { act, cleanup, render, screen } from "@testing-library/react";
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+import { McpConfirmDialog } from "../McpConfirmDialog";
+import { __resetMcpConfirmStoreForTesting, requestMcpConfirmation } from "@/store/mcpConfirmStore";
+import type { ActionDanger } from "@shared/types/actions";
+
+vi.mock("zustand/react/shallow", () => ({
+  useShallow: (fn: unknown) => fn,
+}));
+
+vi.mock("@/store", () => ({
+  usePortalStore: () => ({ isOpen: false, width: 0 }),
+}));
+
+vi.mock("@/hooks", async (importOriginal) => {
+  const actual = (await importOriginal()) as Record<string, unknown>;
+  return { ...actual, useOverlayState: () => {} };
+});
+
+vi.mock("@/hooks/useAnimatedPresence", () => ({
+  useAnimatedPresence: ({ isOpen }: { isOpen: boolean }) => ({
+    isVisible: isOpen,
+    shouldRender: isOpen,
+  }),
+}));
+
+vi.stubGlobal(
+  "ResizeObserver",
+  class {
+    observe() {}
+    unobserve() {}
+    disconnect() {}
+  }
+);
+
+function enqueue(
+  overrides: { requestId?: string; actionTitle?: string; danger?: ActionDanger } = {}
+) {
+  return requestMcpConfirmation({
+    requestId: overrides.requestId ?? "req-1",
+    actionId: "worktree.delete",
+    actionTitle: overrides.actionTitle ?? "Delete worktree",
+    actionDescription: "Permanently delete a worktree.",
+    argsSummary: '{"worktreeId":"wt-1"}',
+    danger: overrides.danger ?? "confirm",
+  });
+}
+
+describe("McpConfirmDialog", () => {
+  beforeEach(() => {
+    __resetMcpConfirmStoreForTesting();
+    vi.spyOn(console, "error").mockImplementation(() => {});
+    vi.stubGlobal("matchMedia", vi.fn().mockReturnValue({ matches: false }));
+  });
+
+  afterEach(() => {
+    __resetMcpConfirmStoreForTesting();
+    cleanup();
+    vi.restoreAllMocks();
+  });
+
+  it("labels the confirm button with the action title, not a generic verb", () => {
+    void enqueue({ actionTitle: "Delete worktree" });
+    render(<McpConfirmDialog />);
+
+    expect(screen.getByRole("button", { name: "Delete worktree" })).toBeTruthy();
+    expect(screen.queryByRole("button", { name: /^run action$/i })).toBeNull();
+  });
+
+  it("renders destructive styling only for danger:confirm dispatches", () => {
+    void enqueue({ actionTitle: "Delete worktree", danger: "confirm" });
+    const { unmount } = render(<McpConfirmDialog />);
+
+    expect(screen.getByRole("button", { name: "Delete worktree" }).className).toContain(
+      "bg-destructive"
+    );
+
+    unmount();
+    __resetMcpConfirmStoreForTesting();
+
+    void enqueue({ actionTitle: "List worktrees", danger: "safe" });
+    render(<McpConfirmDialog />);
+
+    expect(screen.getByRole("button", { name: "List worktrees" }).className).not.toContain(
+      "bg-destructive"
+    );
+  });
+
+  it("resolves exactly once on a rapid double-confirm, never approving the queued item", async () => {
+    const pA = enqueue({ requestId: "A", actionTitle: "Delete worktree" });
+    const pB = enqueue({ requestId: "B", actionTitle: "Push branch" });
+
+    render(<McpConfirmDialog />);
+
+    const confirmBtn = screen.getByRole("button", { name: "Delete worktree" });
+
+    // Two native clicks dispatched within a single batched update — both
+    // handlers run against the same render snapshot (item A visible) before
+    // React advances the queue, mirroring a real double-click.
+    act(() => {
+      confirmBtn.dispatchEvent(new MouseEvent("click", { bubbles: true }));
+      confirmBtn.dispatchEvent(new MouseEvent("click", { bubbles: true }));
+    });
+
+    await expect(pA).resolves.toBe("approved");
+
+    const sentinel = Symbol("pending");
+    const bOutcome = await Promise.race([
+      pB,
+      new Promise((resolve) => setTimeout(() => resolve(sentinel), 20)),
+    ]);
+    expect(bOutcome).toBe(sentinel);
+  });
+});

--- a/src/hooks/__tests__/useMcpBridge.test.tsx
+++ b/src/hooks/__tests__/useMcpBridge.test.tsx
@@ -192,6 +192,7 @@ describe("useMcpBridge", () => {
     const pending = useMcpConfirmStore.getState().current;
     expect(pending).not.toBeNull();
     expect(pending?.actionTitle).toBe("Delete Worktree");
+    expect(pending?.danger).toBe("confirm");
     expect(pending?.argsSummary).toContain("wt-1");
     expect(mocks.dispatch).not.toHaveBeenCalled();
 

--- a/src/hooks/useMcpBridge.ts
+++ b/src/hooks/useMcpBridge.ts
@@ -102,6 +102,7 @@ export function useMcpBridge(): void {
                   actionTitle: definition.title,
                   actionDescription: definition.description,
                   argsSummary: summarizeMcpArgs(args),
+                  danger: definition.danger,
                 });
               } finally {
                 inFlightConfirms.delete(requestId);

--- a/src/store/__tests__/mcpConfirmStore.test.ts
+++ b/src/store/__tests__/mcpConfirmStore.test.ts
@@ -12,6 +12,7 @@ function pendingFixture(overrides: { requestId?: string; actionId?: string } = {
     actionTitle: "Delete Worktree",
     actionDescription: "Permanently delete a worktree.",
     argsSummary: '{"worktreeId":"wt-1"}',
+    danger: "confirm" as const,
   };
 }
 

--- a/src/store/mcpConfirmStore.ts
+++ b/src/store/mcpConfirmStore.ts
@@ -1,4 +1,5 @@
 import { create } from "zustand";
+import type { ActionDanger } from "@shared/types/actions";
 import type { McpConfirmationDecision } from "@shared/types/ipc/mcpServer";
 
 /**
@@ -12,6 +13,12 @@ export interface PendingMcpConfirm {
   actionTitle: string;
   actionDescription: string;
   argsSummary: string;
+  /**
+   * The dispatched action's registry `danger` classification. Drives the
+   * confirm dialog's visual severity — only `"confirm"` renders destructive
+   * (red) styling; read-only/safe dispatches must not borrow that weight.
+   */
+  danger: ActionDanger;
   enqueuedAt: number;
 }
 


### PR DESCRIPTION
## Summary

- Adds a typed-name gate (last 4 chars of API key) to the MCP server rotate-API-key dialog, matching the existing gate in `DaintreeAssistantSettingsTab` — both surfaces now consistently treat key rotation as Tier D3
- Fixes `McpConfirmDialog` to derive `variant` from the action's `danger` classification rather than hard-coding `destructive` for every dispatch; adds `danger` field to `PendingMcpConfirm` and threads it through `useMcpBridge`
- Changes the confirm button label from the generic `Run action` to the actual action title, and adds a per-`requestId` idempotency guard so a rapid double-click can't silently approve the next queued dispatch

Resolves #8028

## Changes

- `McpConfirmDialog` — variant derives from `danger`, confirm label uses action title, idempotency guard on `requestId`
- `useMcpBridge` — threads `definition.danger` into `PendingMcpConfirm`
- `mcpConfirmStore` — `danger` field on `PendingMcpConfirm` type
- `McpServerSettingsTab` — rotate dialog now requires typing the key suffix before the button enables
- Tests updated for all four changes; new `McpConfirmDialog` regression test covers variant/label mapping and double-confirm guard

## Testing

All 58 targeted tests pass. Full verify (typecheck, lint, format, build) clean.