### PR TITLE
fix(worktree): route picker/combobox empty states through EmptyState

### DIFF
--- a/src/components/Worktree/IssuePickerDialog.tsx
+++ b/src/components/Worktree/IssuePickerDialog.tsx
@@ -1,8 +1,11 @@
-import { useState, useCallback, useEffect, useRef } from "react";
+import { useState, useCallback, useEffect, useRef, useDeferredValue } from "react";
 import { AppDialog } from "@/components/ui/AppDialog";
 import { Button } from "@/components/ui/button";
-import { CircleDot, Search, Link, Unlink, CircleCheck } from "lucide-react";
+import { CircleDot, Search, Link, Unlink, CircleCheck, AlertCircle, RefreshCw } from "lucide-react";
 import { Spinner } from "@/components/ui/Spinner";
+import { EmptyState } from "@/components/ui/EmptyState";
+import { useDeferredLoading } from "@/hooks/useDeferredLoading";
+import { UI_DOHERTY_THRESHOLD } from "@/lib/animationUtils";
 import { cn } from "@/lib/utils";
 import { githubClient } from "@/clients";
 import type { GitHubIssue } from "@shared/types/github";
@@ -87,6 +90,11 @@ export function IssuePickerDialog({
   const inputRef = useRef<HTMLInputElement>(null);
   const listRef = useRef<HTMLDivElement>(null);
   const debounceRef = useRef<ReturnType<typeof setTimeout> | null>(null);
+
+  const isInitialLoading = isLoading && issues.length === 0;
+  const showLoader = useDeferredLoading(isInitialLoading, UI_DOHERTY_THRESHOLD);
+  const trimmedSearch = search.trim();
+  const deferredSearch = useDeferredValue(trimmedSearch);
 
   const fetchIssues = useCallback(
     async (searchTerm: string, state: StateFilter) => {
@@ -216,17 +224,43 @@ export function IssuePickerDialog({
       </div>
 
       <div className="flex-1 overflow-y-auto min-h-0 px-6 pb-4">
-        {isLoading && issues.length === 0 ? (
+        {showLoader ? (
           <div className="flex items-center justify-center py-8 text-daintree-text/50">
             <Spinner size="lg" className="mr-2" />
             <span className="text-sm">Loading issues...</span>
           </div>
-        ) : error ? (
-          <div className="text-center py-8 text-sm text-status-error">{error}</div>
-        ) : issues.length === 0 ? (
-          <div className="text-center py-8 text-sm text-daintree-text/50">
-            {search ? "No issues match your search" : "No issues found"}
+        ) : isInitialLoading ? null : error ? (
+          <div role="alert" className="flex items-start gap-2 px-3 py-8 text-sm text-status-error">
+            <AlertCircle className="w-4 h-4 shrink-0 mt-0.5" />
+            <div className="flex-1 min-w-0">
+              <p>{error}</p>
+              <Button
+                variant="ghost"
+                size="sm"
+                onClick={() => fetchIssues(search, stateFilter)}
+                className="mt-2 text-status-error hover:text-status-error"
+              >
+                <RefreshCw className="w-3.5 h-3.5 mr-1.5" />
+                Retry
+              </Button>
+            </div>
           </div>
+        ) : issues.length === 0 ? (
+          trimmedSearch ? (
+            <EmptyState
+              scale="popover"
+              variant="filtered-empty"
+              title={`No matches for "${deferredSearch}"`}
+              className="px-3 py-8"
+            />
+          ) : (
+            <EmptyState
+              scale="popover"
+              variant="zero-data"
+              title="No issues found"
+              className="px-3 py-8"
+            />
+          )
         ) : (
           <div ref={listRef} className="space-y-1" role="listbox">
             {issues.map((issue, index) => (

--- a/src/components/Worktree/IssuePickerDialog.tsx
+++ b/src/components/Worktree/IssuePickerDialog.tsx
@@ -6,6 +6,7 @@ import { Spinner } from "@/components/ui/Spinner";
 import { EmptyState } from "@/components/ui/EmptyState";
 import { useDeferredLoading } from "@/hooks/useDeferredLoading";
 import { UI_DOHERTY_THRESHOLD } from "@/lib/animationUtils";
+import { truncateSearchQuery } from "@/lib/searchQuery";
 import { cn } from "@/lib/utils";
 import { githubClient } from "@/clients";
 import type { GitHubIssue } from "@shared/types/github";
@@ -127,7 +128,7 @@ export function IssuePickerDialog({
     if (!isOpen) return;
     if (debounceRef.current) clearTimeout(debounceRef.current);
     debounceRef.current = setTimeout(() => {
-      fetchIssues(search, stateFilter);
+      fetchIssues(search.trim(), stateFilter);
     }, 300);
     return () => {
       if (debounceRef.current) clearTimeout(debounceRef.current);
@@ -237,7 +238,7 @@ export function IssuePickerDialog({
               <Button
                 variant="ghost"
                 size="sm"
-                onClick={() => fetchIssues(search, stateFilter)}
+                onClick={() => fetchIssues(trimmedSearch, stateFilter)}
                 className="mt-2 text-status-error hover:text-status-error"
               >
                 <RefreshCw className="w-3.5 h-3.5 mr-1.5" />
@@ -250,7 +251,7 @@ export function IssuePickerDialog({
             <EmptyState
               scale="popover"
               variant="filtered-empty"
-              title={`No matches for "${deferredSearch}"`}
+              title={`No matches for "${truncateSearchQuery(deferredSearch || trimmedSearch)}"`}
               className="px-3 py-8"
             />
           ) : (

--- a/src/components/Worktree/__tests__/IssuePickerDialog.test.tsx
+++ b/src/components/Worktree/__tests__/IssuePickerDialog.test.tsx
@@ -125,4 +125,55 @@ describe("IssuePickerDialog", () => {
 
     expect(screen.getByRole("option", { name: /test issue/i })).toBeDefined();
   });
+
+  it("trims the search term before sending it to the client", async () => {
+    mockListIssues.mockResolvedValue({ items: [] });
+
+    render(<IssuePickerDialog {...defaultProps} />, { wrapper: TooltipProvider });
+
+    const input = screen.getByPlaceholderText("Search issues by title or number...");
+    fireEvent.change(input, { target: { value: "  bug  " } });
+
+    await act(async () => {
+      await vi.advanceTimersByTimeAsync(800);
+    });
+
+    expect(mockListIssues).toHaveBeenCalledWith(
+      expect.objectContaining({ search: "bug", state: "open" })
+    );
+  });
+
+  it("treats a whitespace-only query as no search and shows the zero-data state", async () => {
+    mockListIssues.mockResolvedValue({ items: [] });
+
+    render(<IssuePickerDialog {...defaultProps} />, { wrapper: TooltipProvider });
+
+    const input = screen.getByPlaceholderText("Search issues by title or number...");
+    fireEvent.change(input, { target: { value: "   " } });
+
+    await act(async () => {
+      await vi.advanceTimersByTimeAsync(800);
+    });
+
+    expect(mockListIssues).toHaveBeenLastCalledWith(expect.objectContaining({ search: undefined }));
+    expect(screen.getByRole("status").textContent).toContain("No issues found");
+  });
+
+  it("truncates an overly long query in the filtered-empty title", async () => {
+    mockListIssues.mockResolvedValue({ items: [] });
+
+    render(<IssuePickerDialog {...defaultProps} />, { wrapper: TooltipProvider });
+
+    const longQuery = "x".repeat(80);
+    const input = screen.getByPlaceholderText("Search issues by title or number...");
+    fireEvent.change(input, { target: { value: longQuery } });
+
+    await act(async () => {
+      await vi.advanceTimersByTimeAsync(800);
+    });
+
+    const status = screen.getByRole("status");
+    expect(status.textContent).toContain("…");
+    expect(status.textContent).not.toContain("x".repeat(80));
+  });
 });

--- a/src/components/Worktree/__tests__/IssuePickerDialog.test.tsx
+++ b/src/components/Worktree/__tests__/IssuePickerDialog.test.tsx
@@ -1,0 +1,128 @@
+/**
+ * @vitest-environment jsdom
+ */
+import { describe, it, expect, vi, beforeEach, afterEach } from "vitest";
+import { render, screen, act, fireEvent } from "@testing-library/react";
+import { IssuePickerDialog } from "../IssuePickerDialog";
+import { TooltipProvider } from "@/components/ui/tooltip";
+import type { GitHubIssue } from "@shared/types/github";
+import type { WorktreeState } from "@/types";
+
+const mockListIssues = vi.fn();
+
+vi.mock("@/clients/githubClient", () => ({
+  githubClient: {
+    listIssues: (opts: unknown) => mockListIssues(opts),
+  },
+}));
+
+const mockIssue = (overrides: Partial<GitHubIssue> = {}): GitHubIssue => ({
+  number: 1,
+  title: "Test issue",
+  state: "OPEN",
+  url: "https://github.com/test/repo/issues/1",
+  updatedAt: "2025-01-01T00:00:00Z",
+  author: { login: "testuser", avatarUrl: "" },
+  commentCount: 0,
+  assignees: [],
+  ...overrides,
+});
+
+const worktree = { path: "/test/project" } as WorktreeState;
+
+const defaultProps = {
+  isOpen: true,
+  onClose: vi.fn(),
+  worktree,
+  onAttach: vi.fn(),
+  onDetach: vi.fn(),
+};
+
+describe("IssuePickerDialog", () => {
+  beforeEach(() => {
+    mockListIssues.mockReset();
+    vi.useFakeTimers();
+  });
+
+  afterEach(() => {
+    vi.useRealTimers();
+    vi.restoreAllMocks();
+  });
+
+  it("does not show the spinner before the 400ms Doherty gate, then shows it while still loading", async () => {
+    mockListIssues.mockReturnValue(new Promise(() => {}));
+
+    render(<IssuePickerDialog {...defaultProps} />, { wrapper: TooltipProvider });
+
+    // Before the gate elapses there is no spinner (sub-threshold guard renders null)
+    await act(async () => {
+      await vi.advanceTimersByTimeAsync(300);
+    });
+    expect(screen.queryByText("Loading issues...")).toBeNull();
+
+    // After the 400ms gate, the spinner appears since the fetch is still pending
+    await act(async () => {
+      await vi.advanceTimersByTimeAsync(200);
+    });
+    expect(screen.getByText("Loading issues...")).toBeDefined();
+  });
+
+  it("never shows the spinner when the fetch resolves before the gate and renders the zero-data EmptyState", async () => {
+    mockListIssues.mockResolvedValue({ items: [] });
+
+    render(<IssuePickerDialog {...defaultProps} />, { wrapper: TooltipProvider });
+
+    await act(async () => {
+      await vi.advanceTimersByTimeAsync(100);
+    });
+
+    expect(screen.queryByText("Loading issues...")).toBeNull();
+
+    await act(async () => {
+      await vi.advanceTimersByTimeAsync(500);
+    });
+
+    expect(screen.queryByText("Loading issues...")).toBeNull();
+    const status = screen.getByRole("status");
+    expect(status.textContent).toContain("No issues found");
+  });
+
+  it("renders the filtered-empty EmptyState with the query when a search yields no results", async () => {
+    mockListIssues.mockResolvedValue({ items: [] });
+
+    render(<IssuePickerDialog {...defaultProps} />, { wrapper: TooltipProvider });
+
+    const input = screen.getByPlaceholderText("Search issues by title or number...");
+    fireEvent.change(input, { target: { value: "nonexistent" } });
+
+    await act(async () => {
+      await vi.advanceTimersByTimeAsync(800);
+    });
+
+    const status = screen.getByRole("status");
+    expect(status.textContent).toContain('No matches for "nonexistent"');
+  });
+
+  it("renders an inline error alert with a Retry button that refetches", async () => {
+    mockListIssues.mockRejectedValue(new Error("boom"));
+
+    render(<IssuePickerDialog {...defaultProps} />, { wrapper: TooltipProvider });
+
+    await act(async () => {
+      await vi.advanceTimersByTimeAsync(800);
+    });
+
+    const alert = screen.getByRole("alert");
+    expect(alert.textContent).toContain("boom");
+
+    mockListIssues.mockResolvedValue({ items: [mockIssue()] });
+    const retry = screen.getByRole("button", { name: /retry/i });
+
+    await act(async () => {
+      fireEvent.click(retry);
+      await vi.advanceTimersByTimeAsync(800);
+    });
+
+    expect(screen.getByRole("option", { name: /test issue/i })).toBeDefined();
+  });
+});

--- a/src/components/Worktree/views/BaseBranchCombobox.tsx
+++ b/src/components/Worktree/views/BaseBranchCombobox.tsx
@@ -1,6 +1,7 @@
 import { Button } from "@/components/ui/button";
 import { Popover, PopoverContent, PopoverTrigger } from "@/components/ui/popover";
 import { ScrollShadow } from "@/components/ui/ScrollShadow";
+import { EmptyState } from "@/components/ui/EmptyState";
 import { Tooltip, TooltipContent, TooltipTrigger } from "@/components/ui/tooltip";
 import { Check, ChevronsUpDown, Info, Search } from "lucide-react";
 import { cn } from "@/lib/utils";
@@ -121,9 +122,11 @@ export function BaseBranchCombobox({
             scrollClassName="p-1"
           >
             {selectableRows.length === 0 ? (
-              <div className="py-6 text-center text-sm text-muted-foreground">
-                {branchQuery ? "No branches found" : "No branches available"}
-              </div>
+              branchQuery ? (
+                <EmptyState scale="popover" variant="filtered-empty" title="No branches found" />
+              ) : (
+                <EmptyState scale="popover" variant="zero-data" title="No branches available" />
+              )
             ) : (
               (() => {
                 let optionIndex = 0;

--- a/src/components/Worktree/views/ExistingBranchPicker.tsx
+++ b/src/components/Worktree/views/ExistingBranchPicker.tsx
@@ -1,6 +1,7 @@
 import { Button } from "@/components/ui/button";
 import { Popover, PopoverContent, PopoverTrigger } from "@/components/ui/popover";
 import { ScrollShadow } from "@/components/ui/ScrollShadow";
+import { EmptyState } from "@/components/ui/EmptyState";
 import { Check, ChevronsUpDown, GitBranch, Search } from "lucide-react";
 import { cn } from "@/lib/utils";
 import type { BranchInfo } from "@/types/electron";
@@ -70,9 +71,11 @@ export function ExistingBranchPicker({
           </div>
           <ScrollShadow role="listbox" className="max-h-[300px]" scrollClassName="p-1">
             {filteredBranches.length === 0 ? (
-              <div className="py-6 text-center text-sm text-muted-foreground">
-                {query ? "No matching branches" : "No available local branches"}
-              </div>
+              query ? (
+                <EmptyState scale="popover" variant="filtered-empty" title="No matching branches" />
+              ) : (
+                <EmptyState scale="popover" variant="zero-data" title="No local branches" />
+              )
             ) : (
               filteredBranches.map((branch) => (
                 <div

--- a/src/lib/searchQuery.ts
+++ b/src/lib/searchQuery.ts
@@ -1,0 +1,13 @@
+const NO_MATCH_QUERY_MAX = 40;
+
+/**
+ * Codepoint-safe truncation for search queries echoed back in "No matches for
+ * …" empty-state titles. Prevents long pastes from overflowing popover/palette
+ * layouts. Mirrors the convention used in SidebarContent and AppPaletteDialog.
+ */
+export function truncateSearchQuery(trimmedQuery: string): string {
+  const codepoints = Array.from(trimmedQuery);
+  return codepoints.length > NO_MATCH_QUERY_MAX
+    ? `${codepoints.slice(0, NO_MATCH_QUERY_MAX).join("")}…`
+    : trimmedQuery;
+}


### PR DESCRIPTION
## Summary

Three worktree picker surfaces (`IssuePickerDialog`, `BaseBranchCombobox`, `ExistingBranchPicker`) were rendering empty states as bare divs instead of using the canonical `<EmptyState scale="popover">`. This PR fixes that, along with a few other issues found in the same area.

- `IssuePickerDialog` had a `<Spinner>` with no delay gate — it would fire on first paint with no Doherty threshold. Now gated via `useDeferredLoading` + `UI_DOHERTY_THRESHOLD`.
- The error path in `IssuePickerDialog` was also a bare div. Replaced with a `role="alert"` inline banner with a Retry action.
- Added a `searchQuery` util (`src/lib/searchQuery.ts`) to trim and truncate the echoed search query in the empty state title.

Resolves #8022

## Changes

- `IssuePickerDialog.tsx` — canonical `EmptyState`, Doherty-gated spinner, inline error banner
- `BaseBranchCombobox.tsx` — canonical `EmptyState`
- `ExistingBranchPicker.tsx` — canonical `EmptyState`
- `src/lib/searchQuery.ts` — new shared trim/truncate util
- `src/components/Worktree/__tests__/IssuePickerDialog.test.tsx` — 7 unit tests covering empty, loading, and error states

## Testing

7 unit tests cover the new empty/loading/error states in `IssuePickerDialog`. Manual verification: empty state renders correctly in all three picker surfaces, spinner no longer flashes on fast loads, error banner shows with Retry.