### PR TITLE
fix(scroll-shadow): polish gradient color, fade transitions, and thumb min-height

### DIFF
--- a/src/components/ui/AppPaletteDialog.tsx
+++ b/src/components/ui/AppPaletteDialog.tsx
@@ -1,4 +1,4 @@
-import { useCallback, useDeferredValue, useEffect, useRef } from "react";
+import { useCallback, useDeferredValue, useEffect, useRef, type CSSProperties } from "react";
 import { createPortal } from "react-dom";
 import { cn } from "@/lib/utils";
 import { TABBABLE_SELECTOR } from "@/lib/accessibility";
@@ -203,12 +203,15 @@ export function AppPaletteDialog({
           isVisible ? "opacity-100 scale-100" : "opacity-0 scale-[0.96]",
           className
         )}
-        style={{
-          transitionDuration: isVisible
-            ? `${UI_PALETTE_ENTER_DURATION}ms`
-            : `${UI_PALETTE_EXIT_DURATION}ms`,
-          transitionTimingFunction: isVisible ? UI_ENTER_EASING : UI_EXIT_EASING,
-        }}
+        style={
+          {
+            transitionDuration: isVisible
+              ? `${UI_PALETTE_ENTER_DURATION}ms`
+              : `${UI_PALETTE_EXIT_DURATION}ms`,
+            transitionTimingFunction: isVisible ? UI_ENTER_EASING : UI_EXIT_EASING,
+            "--scroll-shadow-color": "var(--color-surface-canvas)",
+          } as CSSProperties
+        }
         onClick={(e) => e.stopPropagation()}
       >
         {children}

--- a/src/components/ui/ScrollShadow.tsx
+++ b/src/components/ui/ScrollShadow.tsx
@@ -10,19 +10,21 @@ import {
 import { cn } from "@/lib/utils";
 import { useVerticalScrollShadows } from "@/hooks/useVerticalScrollShadows";
 
-const TOP_SHADOW = (
-  <div
-    aria-hidden="true"
-    className="pointer-events-none absolute inset-x-0 top-0 z-10 h-8 bg-gradient-to-b from-black/15 to-transparent"
-  />
-);
-
-const BOTTOM_SHADOW = (
-  <div
-    aria-hidden="true"
-    className="pointer-events-none absolute inset-x-0 bottom-0 z-10 h-8 bg-gradient-to-t from-black/15 to-transparent"
-  />
-);
+function ScrollShadowOverlay({ edge, visible }: { edge: "top" | "bottom"; visible: boolean }) {
+  return (
+    <div
+      aria-hidden="true"
+      data-visible={visible}
+      className={cn(
+        "pointer-events-none absolute inset-x-0 z-10 h-8 transition-opacity duration-150 ease-out",
+        edge === "top"
+          ? "top-0 bg-gradient-to-b from-[var(--scroll-shadow-color)] to-transparent"
+          : "bottom-0 bg-gradient-to-t from-[var(--scroll-shadow-color)] to-transparent",
+        visible ? "opacity-100" : "opacity-0"
+      )}
+    />
+  );
+}
 
 function mergeRefs<T>(...refs: (Ref<T> | undefined)[]) {
   return (el: T | null) => {
@@ -49,7 +51,7 @@ export const ScrollShadow = forwardRef<HTMLDivElement, ScrollShadowProps>(
 
     return (
       <div className={cn("relative overflow-hidden min-h-0 flex flex-col", className)}>
-        {canScrollUp && TOP_SHADOW}
+        <ScrollShadowOverlay edge="top" visible={canScrollUp} />
         <div
           ref={mergeRefs(internalRef, forwardedRef)}
           className={cn("flex-1 overflow-y-auto", scrollClassName)}
@@ -57,7 +59,7 @@ export const ScrollShadow = forwardRef<HTMLDivElement, ScrollShadowProps>(
         >
           {children}
         </div>
-        {canScrollDown && BOTTOM_SHADOW}
+        <ScrollShadowOverlay edge="bottom" visible={canScrollDown} />
       </div>
     );
   }
@@ -88,7 +90,7 @@ export function useScrollShadowOverlays(externalRef?: Ref<HTMLElement>) {
 
   return {
     ref,
-    topShadow: canScrollUp ? TOP_SHADOW : null,
-    bottomShadow: canScrollDown ? BOTTOM_SHADOW : null,
+    topShadow: <ScrollShadowOverlay edge="top" visible={canScrollUp} />,
+    bottomShadow: <ScrollShadowOverlay edge="bottom" visible={canScrollDown} />,
   };
 }

--- a/src/components/ui/ScrollShadow.tsx
+++ b/src/components/ui/ScrollShadow.tsx
@@ -88,9 +88,13 @@ export function useScrollShadowOverlays(externalRef?: Ref<HTMLElement>) {
     }
   }, []);
 
+  // Conditional rendering here is load-bearing: `useVerticalScrollShadows`
+  // observes `el.firstElementChild` to detect content-size changes. If the
+  // top overlay were always mounted as the first child, the ResizeObserver
+  // would track a fixed-height overlay instead of the actual content.
   return {
     ref,
-    topShadow: <ScrollShadowOverlay edge="top" visible={canScrollUp} />,
-    bottomShadow: <ScrollShadowOverlay edge="bottom" visible={canScrollDown} />,
+    topShadow: canScrollUp ? <ScrollShadowOverlay edge="top" visible /> : null,
+    bottomShadow: canScrollDown ? <ScrollShadowOverlay edge="bottom" visible /> : null,
   };
 }

--- a/src/components/ui/__tests__/ScrollShadow.test.tsx
+++ b/src/components/ui/__tests__/ScrollShadow.test.tsx
@@ -60,8 +60,23 @@ describe("ScrollShadow", () => {
         <p>Short content</p>
       </ScrollShadow>
     );
-    const gradients = container.querySelectorAll("[aria-hidden='true']");
-    expect(gradients).toHaveLength(0);
+    const visible = container.querySelectorAll("[data-visible='true']");
+    expect(visible).toHaveLength(0);
+  });
+
+  it("always mounts both overlays for opacity-transition continuity", () => {
+    const { container } = render(
+      <ScrollShadow>
+        <p>Short content</p>
+      </ScrollShadow>
+    );
+    const overlays = container.querySelectorAll("[aria-hidden='true']");
+    expect(overlays).toHaveLength(2);
+    for (const overlay of overlays) {
+      expect(overlay.getAttribute("data-visible")).toBe("false");
+      expect(overlay.className).toContain("transition-opacity");
+      expect(overlay.className).toContain("opacity-0");
+    }
   });
 
   it("shows bottom shadow when content overflows and scrolled to top", () => {
@@ -82,7 +97,7 @@ describe("ScrollShadow", () => {
       fireEvent.scroll(scrollDiv);
     });
 
-    const gradients = container.querySelectorAll("[aria-hidden='true']");
+    const gradients = container.querySelectorAll("[data-visible='true']");
     expect(gradients).toHaveLength(1);
     expect(gradients[0]!.className).toContain("bottom-0");
   });
@@ -105,7 +120,7 @@ describe("ScrollShadow", () => {
       fireEvent.scroll(scrollDiv);
     });
 
-    const gradients = container.querySelectorAll("[aria-hidden='true']");
+    const gradients = container.querySelectorAll("[data-visible='true']");
     expect(gradients).toHaveLength(1);
     expect(gradients[0]!.className).toContain("top-0");
   });
@@ -128,7 +143,7 @@ describe("ScrollShadow", () => {
       fireEvent.scroll(scrollDiv);
     });
 
-    const gradients = container.querySelectorAll("[aria-hidden='true']");
+    const gradients = container.querySelectorAll("[data-visible='true']");
     expect(gradients).toHaveLength(2);
     expect(gradients[0]!.className).toContain("top-0");
     expect(gradients[1]!.className).toContain("bottom-0");
@@ -204,7 +219,7 @@ describe("ScrollShadow", () => {
       fireEvent.scroll(scrollDiv);
     });
 
-    const gradients = container.querySelectorAll("[aria-hidden='true']");
+    const gradients = container.querySelectorAll("[data-visible='true']");
     for (const gradient of gradients) {
       expect(gradient.className).toContain("pointer-events-none");
     }

--- a/src/index.css
+++ b/src/index.css
@@ -626,6 +626,7 @@ code.hljs {
     color-mix(in oklab, var(--scrollbar-thumb) 85%, var(--color-text-primary))
   );
   --scrollbar-track: var(--theme-scrollbar-track, transparent);
+  --scroll-shadow-color: var(--color-surface-panel);
   --panel-state-edge-width: var(--theme-panel-state-edge-width, 2px);
   --panel-state-edge-inset-block: var(--theme-panel-state-edge-inset-block, 4px);
   --panel-state-edge-radius: var(--theme-panel-state-edge-radius, 2px);
@@ -740,6 +741,8 @@ code.hljs {
   *::-webkit-scrollbar-thumb {
     background: var(--scrollbar-thumb);
     border-radius: 3px;
+    min-height: 20px;
+    min-width: 20px;
   }
 
   *::-webkit-scrollbar-thumb:hover {
@@ -2679,6 +2682,7 @@ body[data-performance-mode="true"] [class*="backdrop-blur"] {
 
 @layer utilities {
   .surface-overlay {
+    --scroll-shadow-color: var(--color-surface-sidebar);
     background-color: var(--color-surface-sidebar);
     background-color: color-mix(in oklab, var(--color-surface-sidebar) 94%, transparent);
     border: 1px solid var(--border-overlay);

--- a/src/index.css
+++ b/src/index.css
@@ -742,7 +742,6 @@ code.hljs {
     background: var(--scrollbar-thumb);
     border-radius: 3px;
     min-height: 20px;
-    min-width: 20px;
   }
 
   *::-webkit-scrollbar-thumb:hover {


### PR DESCRIPTION
## Summary

- Gradient overlays were hardcoded as black-alpha, which looked muddy on light themes. Replaced with a `--scroll-shadow-color` CSS variable that tracks the local surface; `AppPaletteDialog` sets it to `--color-surface-canvas`, `.surface-overlay` defaults to `--color-surface-sidebar`.
- Overlays were mount/unmounting via React booleans, causing a snap-on/off effect. Both overlays now always mount as siblings of the scrollable div and toggle via `opacity` with a 150ms `ease-out` transition (`data-visible` attribute drives the fade).
- `*::-webkit-scrollbar-thumb` had no `min-height`, so the thumb shrank to an ungrabbable sliver on tall containers in Chromium 146. Added `min-height: 20px`.

Resolves #8010

## Changes

- `ScrollShadow.tsx` — `ScrollShadowOverlay` component; always-mounted overlays with `transition-opacity duration-150 ease-out` and `data-visible` toggle; `useScrollShadowOverlays` preserves null-gated rendering to keep the `firstElementChild` content-observation contract intact for dropdown/context-menu consumers.
- `index.css` — `--scroll-shadow-color` variable, `.surface-overlay` override, `min-height: 20px` on `*::-webkit-scrollbar-thumb`.
- `AppPaletteDialog.tsx` — sets `--scroll-shadow-color` inline to `var(--color-surface-canvas)`.
- `ScrollShadow.test.tsx` — visibility assertions updated from `[aria-hidden='true']` to `[data-visible='true']`; new test asserting both overlays always mount with `opacity-0`.

## Testing

11 unit tests pass. Full verify (typecheck, IPC check, lint, format, build) clean.