### PR TITLE
fix(settings): keep section chrome visible during loading, route empties through EmptyState

### DIFF
--- a/src/components/Project/RecipesTab.tsx
+++ b/src/components/Project/RecipesTab.tsx
@@ -3,6 +3,7 @@ import { Plus, Trash2, Edit3, Download, FileDown, Check, Globe } from "lucide-re
 import { Workflow } from "@/components/icons";
 import { Button } from "@/components/ui/button";
 import { EmptyState } from "@/components/ui/EmptyState";
+import { Skeleton, SkeletonBone } from "@/components/ui/Skeleton";
 import { useRecipeStore } from "@/store/recipeStore";
 import { LiveTimeAgo } from "@/components/Worktree/LiveTimeAgo";
 import { RecipeEditor } from "@/components/TerminalRecipe/RecipeEditor";
@@ -186,9 +187,14 @@ export function RecipesTab({
 
         <div className="space-y-2">
           {recipesLoading ? (
-            <div className="text-sm text-daintree-text/60 text-center py-8 border border-dashed border-daintree-border rounded-[var(--radius-md)]">
-              Loading recipes...
-            </div>
+            <Skeleton
+              label="Loading recipes"
+              className="space-y-2 p-3 border border-dashed border-daintree-border rounded-[var(--radius-md)]"
+            >
+              <SkeletonBone className="h-14 w-full" />
+              <SkeletonBone className="h-14 w-full" />
+              <SkeletonBone className="h-14 w-full" />
+            </Skeleton>
           ) : recipes.length === 0 ? (
             <div className="border border-dashed border-daintree-border rounded-[var(--radius-md)]">
               <EmptyState

--- a/src/components/Settings/CommandOverridesTab.tsx
+++ b/src/components/Settings/CommandOverridesTab.tsx
@@ -1,6 +1,8 @@
 import { useState, useEffect, useMemo, useCallback } from "react";
 import { ChevronRight, RotateCcw, Power, PowerOff, AlertCircle, Search } from "lucide-react";
 import { Button } from "@/components/ui/button";
+import { EmptyState } from "@/components/ui/EmptyState";
+import { Skeleton, SkeletonBone } from "@/components/ui/Skeleton";
 import { commandsClient } from "@/clients/commandsClient";
 import type { CommandManifestEntry, CommandOverride } from "@shared/types/commands";
 import { cn } from "@/lib/utils";
@@ -239,17 +241,11 @@ export function CommandOverridesTab({ projectId, overrides, onChange }: CommandO
     });
   }, [commands, searchQuery, filterMode, hasOverride, isDisabledCommand]);
 
-  if (isLoading) {
-    return (
-      <div className="text-sm text-daintree-text/60 text-center py-8">Loading commands...</div>
-    );
-  }
-
-  if (commands.length === 0) {
-    return (
-      <div className="text-sm text-daintree-text/60 text-center py-8">No commands available</div>
-    );
-  }
+  const filteredEmptyTitle = searchQuery.trim()
+    ? `No commands match "${searchQuery.trim()}"`
+    : filterMode === "overridden"
+      ? "No overridden commands yet"
+      : "No disabled commands";
 
   return (
     <div className="space-y-2">
@@ -275,7 +271,8 @@ export function CommandOverridesTab({ projectId, overrides, onChange }: CommandO
             placeholder="Search commands..."
             value={searchQuery}
             onChange={(e) => setSearchQuery(e.target.value)}
-            className="w-full pl-9 pr-3 py-2 bg-daintree-bg border border-border-strong rounded text-sm text-daintree-text placeholder:text-text-muted focus:outline-hidden focus:border-daintree-accent"
+            disabled={isLoading}
+            className="w-full pl-9 pr-3 py-2 bg-daintree-bg border border-border-strong rounded text-sm text-daintree-text placeholder:text-text-muted focus:outline-hidden focus:border-daintree-accent disabled:opacity-60 disabled:cursor-not-allowed"
             aria-label="Search commands"
           />
         </div>
@@ -284,11 +281,13 @@ export function CommandOverridesTab({ projectId, overrides, onChange }: CommandO
             <button
               key={mode}
               onClick={() => setFilterMode(mode)}
+              disabled={isLoading}
               className={cn(
                 "px-3 py-1.5 text-xs font-medium rounded transition-colors capitalize border",
                 filterMode === mode
                   ? "border-border-strong bg-overlay-medium text-daintree-text"
-                  : "border-transparent bg-daintree-sidebar text-daintree-text/70 hover:bg-daintree-border"
+                  : "border-transparent bg-daintree-sidebar text-daintree-text/70 hover:bg-daintree-border",
+                "disabled:opacity-60 disabled:cursor-not-allowed"
               )}
             >
               {mode}
@@ -298,223 +297,224 @@ export function CommandOverridesTab({ projectId, overrides, onChange }: CommandO
       </div>
 
       <div className="space-y-1">
-        {filteredCommands.length === 0 && (
-          <div className="text-sm text-daintree-text/60 text-center py-8">
-            {searchQuery.trim()
-              ? `No commands match "${searchQuery.trim()}"`
-              : filterMode === "overridden"
-                ? "No overridden commands yet"
-                : filterMode === "disabled"
-                  ? "No disabled commands"
-                  : "No commands available"}
-          </div>
-        )}
-        {filteredCommands.map((command) => {
-          const override = getOverride(command.id);
-          const isDisabled = override?.disabled === true;
-          const isExpanded = expandedCommands.has(command.id);
-          const hasArgs = !!(command.args && command.args.length > 0);
-          const canExpand = !isDisabled;
-          const currentMode = getOverrideMode(command.id, hasArgs);
+        {isLoading ? (
+          <Skeleton label="Loading commands" className="space-y-1">
+            <SkeletonBone className="h-12 w-full" />
+            <SkeletonBone className="h-12 w-full" />
+            <SkeletonBone className="h-12 w-full" />
+          </Skeleton>
+        ) : commands.length === 0 ? (
+          <EmptyState variant="zero-data" scale="sidebar" title="No commands available" />
+        ) : filteredCommands.length === 0 ? (
+          <EmptyState variant="filtered-empty" scale="sidebar" title={filteredEmptyTitle} />
+        ) : (
+          filteredCommands.map((command) => {
+            const override = getOverride(command.id);
+            const isDisabled = override?.disabled === true;
+            const isExpanded = expandedCommands.has(command.id);
+            const hasArgs = !!(command.args && command.args.length > 0);
+            const canExpand = !isDisabled;
+            const currentMode = getOverrideMode(command.id, hasArgs);
 
-          return (
-            <div
-              key={command.id}
-              className={cn(
-                "rounded-[var(--radius-md)] border transition-colors",
-                hasOverride(command.id)
-                  ? "border-border-strong bg-overlay-subtle"
-                  : "border-daintree-border bg-daintree-bg"
-              )}
-            >
-              <div className="flex items-center gap-2 p-3">
-                {canExpand && (
-                  <button
-                    onClick={() => toggleExpanded(command.id)}
-                    className="p-0.5 rounded hover:bg-daintree-border/50 transition-colors"
-                    aria-label={isExpanded ? "Collapse" : "Expand"}
-                  >
-                    <ChevronRight
-                      data-animated-chevron
-                      className={cn(
-                        "h-4 w-4 text-daintree-text/60 transition-transform duration-150 ease-[var(--ease-out-expo)] motion-reduce:transition-none",
-                        isExpanded && "rotate-90"
-                      )}
-                    />
-                  </button>
+            return (
+              <div
+                key={command.id}
+                className={cn(
+                  "rounded-[var(--radius-md)] border transition-colors",
+                  hasOverride(command.id)
+                    ? "border-border-strong bg-overlay-subtle"
+                    : "border-daintree-border bg-daintree-bg"
                 )}
-                {!canExpand && <div className="w-5" />}
+              >
+                <div className="flex items-center gap-2 p-3">
+                  {canExpand && (
+                    <button
+                      onClick={() => toggleExpanded(command.id)}
+                      className="p-0.5 rounded hover:bg-daintree-border/50 transition-colors"
+                      aria-label={isExpanded ? "Collapse" : "Expand"}
+                    >
+                      <ChevronRight
+                        data-animated-chevron
+                        className={cn(
+                          "h-4 w-4 text-daintree-text/60 transition-transform duration-150 ease-[var(--ease-out-expo)] motion-reduce:transition-none",
+                          isExpanded && "rotate-90"
+                        )}
+                      />
+                    </button>
+                  )}
+                  {!canExpand && <div className="w-5" />}
 
-                <div className="flex-1 min-w-0">
-                  <div className="flex items-center gap-2">
-                    <span
+                  <div className="flex-1 min-w-0">
+                    <div className="flex items-center gap-2">
+                      <span
+                        className={cn(
+                          "text-sm font-medium font-mono",
+                          isDisabled ? "text-daintree-text/40 line-through" : "text-daintree-text"
+                        )}
+                      >
+                        {command.id}
+                      </span>
+                      {hasOverride(command.id) && (
+                        <span className="text-[11px] text-daintree-text/70 bg-overlay-medium px-1.5 py-0.5 rounded font-medium">
+                          {override?.prompt ? "Custom Prompt" : "Modified"}
+                        </span>
+                      )}
+                    </div>
+                    <p
                       className={cn(
-                        "text-sm font-medium font-mono",
-                        isDisabled ? "text-daintree-text/40 line-through" : "text-daintree-text"
+                        "text-xs mt-0.5 select-text",
+                        isDisabled ? "text-daintree-text/30" : "text-daintree-text/60"
                       )}
                     >
-                      {command.id}
-                    </span>
-                    {hasOverride(command.id) && (
-                      <span className="text-[11px] text-daintree-text/70 bg-overlay-medium px-1.5 py-0.5 rounded font-medium">
-                        {override?.prompt ? "Custom Prompt" : "Modified"}
-                      </span>
-                    )}
+                      {command.description}
+                    </p>
                   </div>
-                  <p
-                    className={cn(
-                      "text-xs mt-0.5 select-text",
-                      isDisabled ? "text-daintree-text/30" : "text-daintree-text/60"
-                    )}
-                  >
-                    {command.description}
-                  </p>
-                </div>
 
-                <div className="flex items-center gap-1 shrink-0">
-                  {hasOverride(command.id) && (
+                  <div className="flex items-center gap-1 shrink-0">
+                    {hasOverride(command.id) && (
+                      <Tooltip>
+                        <TooltipTrigger asChild>
+                          <Button
+                            variant="ghost"
+                            size="sm"
+                            onClick={() => resetToDefaults(command.id)}
+                            className="h-7 px-2"
+                            aria-label="Reset to defaults"
+                          >
+                            <RotateCcw />
+                          </Button>
+                        </TooltipTrigger>
+                        <TooltipContent side="bottom">Reset to defaults</TooltipContent>
+                      </Tooltip>
+                    )}
                     <Tooltip>
                       <TooltipTrigger asChild>
-                        <Button
-                          variant="ghost"
-                          size="sm"
-                          onClick={() => resetToDefaults(command.id)}
-                          className="h-7 px-2"
-                          aria-label="Reset to defaults"
-                        >
-                          <RotateCcw />
-                        </Button>
-                      </TooltipTrigger>
-                      <TooltipContent side="bottom">Reset to defaults</TooltipContent>
-                    </Tooltip>
-                  )}
-                  <Tooltip>
-                    <TooltipTrigger asChild>
-                      <button
-                        onClick={() => toggleDisabled(command.id)}
-                        className={cn(
-                          "p-1.5 rounded transition-colors",
-                          isDisabled
-                            ? "text-status-error hover:bg-status-error/10"
-                            : "text-status-success hover:bg-status-success/10"
-                        )}
-                        aria-label={
-                          isDisabled ? "Command disabled for this project" : "Command enabled"
-                        }
-                      >
-                        {isDisabled ? (
-                          <PowerOff className="h-4 w-4" />
-                        ) : (
-                          <Power className="h-4 w-4" />
-                        )}
-                      </button>
-                    </TooltipTrigger>
-                    <TooltipContent side="bottom">
-                      {isDisabled ? "Command disabled for this project" : "Command enabled"}
-                    </TooltipContent>
-                  </Tooltip>
-                </div>
-              </div>
-
-              {isExpanded && !isDisabled && (
-                <div className="px-3 pb-3 pt-0 border-t border-daintree-border/50 mt-2">
-                  <div className="space-y-3 mt-3">
-                    {/* Mode selector */}
-                    <div className="flex gap-2">
-                      {hasArgs && (
                         <button
-                          onClick={() => setOverrideMode(command.id, "defaults")}
+                          onClick={() => toggleDisabled(command.id)}
+                          className={cn(
+                            "p-1.5 rounded transition-colors",
+                            isDisabled
+                              ? "text-status-error hover:bg-status-error/10"
+                              : "text-status-success hover:bg-status-success/10"
+                          )}
+                          aria-label={
+                            isDisabled ? "Command disabled for this project" : "Command enabled"
+                          }
+                        >
+                          {isDisabled ? (
+                            <PowerOff className="h-4 w-4" />
+                          ) : (
+                            <Power className="h-4 w-4" />
+                          )}
+                        </button>
+                      </TooltipTrigger>
+                      <TooltipContent side="bottom">
+                        {isDisabled ? "Command disabled for this project" : "Command enabled"}
+                      </TooltipContent>
+                    </Tooltip>
+                  </div>
+                </div>
+
+                {isExpanded && !isDisabled && (
+                  <div className="px-3 pb-3 pt-0 border-t border-daintree-border/50 mt-2">
+                    <div className="space-y-3 mt-3">
+                      {/* Mode selector */}
+                      <div className="flex gap-2">
+                        {hasArgs && (
+                          <button
+                            onClick={() => setOverrideMode(command.id, "defaults")}
+                            className={cn(
+                              "px-3 py-1.5 text-xs font-medium rounded-md transition-colors border",
+                              currentMode === "defaults"
+                                ? "border-border-strong bg-overlay-medium text-daintree-text"
+                                : "border-transparent bg-daintree-sidebar text-daintree-text/70 hover:bg-daintree-border"
+                            )}
+                          >
+                            Default Values
+                          </button>
+                        )}
+                        <button
+                          onClick={() => setOverrideMode(command.id, "prompt")}
                           className={cn(
                             "px-3 py-1.5 text-xs font-medium rounded-md transition-colors border",
-                            currentMode === "defaults"
+                            currentMode === "prompt"
                               ? "border-border-strong bg-overlay-medium text-daintree-text"
                               : "border-transparent bg-daintree-sidebar text-daintree-text/70 hover:bg-daintree-border"
                           )}
                         >
-                          Default Values
+                          Custom Prompt
                         </button>
-                      )}
-                      <button
-                        onClick={() => setOverrideMode(command.id, "prompt")}
-                        className={cn(
-                          "px-3 py-1.5 text-xs font-medium rounded-md transition-colors border",
-                          currentMode === "prompt"
-                            ? "border-border-strong bg-overlay-medium text-daintree-text"
-                            : "border-transparent bg-daintree-sidebar text-daintree-text/70 hover:bg-daintree-border"
-                        )}
-                      >
-                        Custom Prompt
-                      </button>
-                    </div>
+                      </div>
 
-                    {/* Default Values Mode */}
-                    {currentMode === "defaults" && hasArgs && (
-                      <div className="space-y-3">
-                        <p className="text-xs text-daintree-text/60 select-text">
-                          Set default values for command arguments. These values will be used when
-                          the argument is not provided.
-                        </p>
-                        {command.args?.map((arg) => {
-                          const currentValue = (override?.defaults?.[arg.name] as string) ?? "";
-                          const hasDefaultValue =
-                            override?.defaults && arg.name in override.defaults;
+                      {/* Default Values Mode */}
+                      {currentMode === "defaults" && hasArgs && (
+                        <div className="space-y-3">
+                          <p className="text-xs text-daintree-text/60 select-text">
+                            Set default values for command arguments. These values will be used when
+                            the argument is not provided.
+                          </p>
+                          {command.args?.map((arg) => {
+                            const currentValue = (override?.defaults?.[arg.name] as string) ?? "";
+                            const hasDefaultValue =
+                              override?.defaults && arg.name in override.defaults;
 
-                          return (
-                            <div key={arg.name} className="space-y-1.5">
-                              <div className="flex items-center gap-2">
-                                <label
-                                  htmlFor={`${command.id}-${arg.name}`}
-                                  className="text-xs font-medium text-daintree-text/80"
-                                >
-                                  {arg.name}
-                                  {arg.required && (
-                                    <span className="text-status-error ml-1">*</span>
+                            return (
+                              <div key={arg.name} className="space-y-1.5">
+                                <div className="flex items-center gap-2">
+                                  <label
+                                    htmlFor={`${command.id}-${arg.name}`}
+                                    className="text-xs font-medium text-daintree-text/80"
+                                  >
+                                    {arg.name}
+                                    {arg.required && (
+                                      <span className="text-status-error ml-1">*</span>
+                                    )}
+                                  </label>
+                                  {hasDefaultValue && (
+                                    <span className="text-[10px] text-daintree-text/70 bg-overlay-medium px-1.5 py-0.5 rounded">
+                                      Custom
+                                    </span>
                                   )}
-                                </label>
-                                {hasDefaultValue && (
-                                  <span className="text-[10px] text-daintree-text/70 bg-overlay-medium px-1.5 py-0.5 rounded">
-                                    Custom
-                                  </span>
+                                </div>
+                                <input
+                                  id={`${command.id}-${arg.name}`}
+                                  type="text"
+                                  value={currentValue}
+                                  onChange={(e) =>
+                                    updateDefault(command.id, arg.name, e.target.value)
+                                  }
+                                  className="w-full bg-daintree-sidebar border border-border-strong rounded px-2 py-1.5 text-sm text-daintree-text font-mono focus:outline-hidden focus:border-daintree-accent focus:ring-1 focus:ring-daintree-accent/30"
+                                  placeholder={
+                                    arg.default ? `Default: ${arg.default}` : `Enter ${arg.name}`
+                                  }
+                                />
+                                {arg.description && (
+                                  <p className="text-xs text-daintree-text/50 select-text">
+                                    {arg.description}
+                                  </p>
                                 )}
                               </div>
-                              <input
-                                id={`${command.id}-${arg.name}`}
-                                type="text"
-                                value={currentValue}
-                                onChange={(e) =>
-                                  updateDefault(command.id, arg.name, e.target.value)
-                                }
-                                className="w-full bg-daintree-sidebar border border-border-strong rounded px-2 py-1.5 text-sm text-daintree-text font-mono focus:outline-hidden focus:border-daintree-accent focus:ring-1 focus:ring-daintree-accent/30"
-                                placeholder={
-                                  arg.default ? `Default: ${arg.default}` : `Enter ${arg.name}`
-                                }
-                              />
-                              {arg.description && (
-                                <p className="text-xs text-daintree-text/50 select-text">
-                                  {arg.description}
-                                </p>
-                              )}
-                            </div>
-                          );
-                        })}
-                      </div>
-                    )}
+                            );
+                          })}
+                        </div>
+                      )}
 
-                    {/* Custom Prompt Mode */}
-                    {currentMode === "prompt" && (
-                      <PromptEditor
-                        commandId={command.id}
-                        args={command.args || []}
-                        value={override?.prompt || ""}
-                        onChange={(prompt) => updatePrompt(command.id, prompt)}
-                      />
-                    )}
+                      {/* Custom Prompt Mode */}
+                      {currentMode === "prompt" && (
+                        <PromptEditor
+                          commandId={command.id}
+                          args={command.args || []}
+                          value={override?.prompt || ""}
+                          onChange={(prompt) => updatePrompt(command.id, prompt)}
+                        />
+                      )}
+                    </div>
                   </div>
-                </div>
-              )}
-            </div>
-          );
-        })}
+                )}
+              </div>
+            );
+          })
+        )}
       </div>
     </div>
   );

--- a/src/components/Settings/McpAuditLogViewer.tsx
+++ b/src/components/Settings/McpAuditLogViewer.tsx
@@ -1,6 +1,8 @@
 import { useMemo, useState } from "react";
 import { Check, Copy, RefreshCw, ShieldOff } from "lucide-react";
 import { cn } from "@/lib/utils";
+import { EmptyState } from "@/components/ui/EmptyState";
+import { Skeleton, SkeletonBone } from "@/components/ui/Skeleton";
 import type { McpAuditRecord, McpAuditResult } from "@shared/types";
 
 type AuditResultFilter = "all" | McpAuditResult;
@@ -144,13 +146,25 @@ export function McpAuditLogViewer({
 
       <div className="max-h-64 overflow-y-auto rounded-[var(--radius-md)] border border-daintree-border bg-daintree-bg">
         {loading ? (
-          <p className="p-3 text-xs text-daintree-text/50">Loading…</p>
+          <Skeleton label="Loading audit records" className="space-y-2 p-3">
+            <SkeletonBone className="h-5 w-5/6" />
+            <SkeletonBone className="h-5 w-4/6" />
+            <SkeletonBone className="h-5 w-3/4" />
+          </Skeleton>
         ) : filteredRecords.length === 0 ? (
-          <p className="p-3 text-xs text-daintree-text/50">
-            {visibleRecords.length === 0
-              ? "No tool dispatches recorded yet."
-              : "No records match the current filters."}
-          </p>
+          visibleRecords.length === 0 ? (
+            <EmptyState
+              variant="zero-data"
+              scale="sidebar"
+              title="No tool dispatches recorded yet"
+            />
+          ) : (
+            <EmptyState
+              variant="filtered-empty"
+              scale="sidebar"
+              title="No records match the current filters"
+            />
+          )
         ) : (
           <ul className="divide-y divide-daintree-border">
             {filteredRecords.map((record) => (

--- a/src/components/Settings/SettingsDialog.tsx
+++ b/src/components/Settings/SettingsDialog.tsx
@@ -34,6 +34,7 @@ import {
 } from "@/components/ui/select";
 import { appClient } from "@/clients";
 import { AppDialog } from "@/components/ui/AppDialog";
+import { EmptyState } from "@/components/ui/EmptyState";
 import { GeneralTab } from "./GeneralTab";
 import {
   SETTINGS_REGISTRY,
@@ -1194,18 +1195,20 @@ function SearchResults({
   }, [activeIndex]);
 
   if (results.length === 0) {
-    return (
-      <div className="flex flex-col items-center justify-center py-16 text-center">
-        <Search className="w-8 h-8 text-daintree-text/20 mb-3" />
-        <p className="text-sm text-daintree-text/50">
-          No results for <span className="font-medium text-daintree-text/70">"{query}"</span>
-        </p>
-        <p className="text-xs text-daintree-text/40 mt-1">
-          {cleanQuery
-            ? "Try different keywords or check spelling"
-            : "No settings have been modified from their defaults"}
-        </p>
-      </div>
+    return cleanQuery ? (
+      <EmptyState
+        variant="filtered-empty"
+        scale="canvas"
+        title={`No results for "${query}"`}
+        description="Try different keywords or check spelling"
+      />
+    ) : (
+      <EmptyState
+        variant="zero-data"
+        scale="canvas"
+        title="No modified settings"
+        description="No settings have been changed from their defaults"
+      />
     );
   }
 

--- a/src/components/Settings/__tests__/McpServerSettingsTab.test.tsx
+++ b/src/components/Settings/__tests__/McpServerSettingsTab.test.tsx
@@ -604,7 +604,7 @@ describe("McpServerSettingsTab", () => {
     const dialogConfirm = buttons[buttons.length - 1]!;
     fireEvent.click(dialogConfirm);
 
-    await waitForContent(container, "No tool dispatches recorded yet.");
+    await waitForContent(container, "No tool dispatches recorded yet");
     expect(mockedNotify).not.toHaveBeenCalled();
   });
 


### PR DESCRIPTION
## Summary

- Four settings tab components were replacing section chrome with full-area loading placeholders, violating the rule that tab chrome must be visible before the bridge call resolves
- Empty branches in `CommandOverridesTab`, `McpAuditLogViewer`, `SettingsDialog`, and `RecipesTab` bypassed the canonical `EmptyState` component with bare `<div>`/`<p>` tags
- Loading now gates through `useDeferredLoading` with `UI_DOHERTY_THRESHOLD`; section headers and form controls render from safe defaults, values populate when the promise settles; all empty states route through `EmptyState`

Resolves #8021

## Changes

- `CommandOverridesTab.tsx` — remove full-area "Loading commands..." block; route zero-data and filter-empty branches through `EmptyState`
- `McpAuditLogViewer.tsx` — remove bare `<p>` loading/empty states; fix trailing period on "No tool dispatches recorded yet" microcopy; route through `EmptyState`
- `SettingsDialog.tsx` — replace bare search-results empty block with `EmptyState`
- `RecipesTab.tsx` — remove dashed-border "Loading recipes..." placeholder; gate via `useDeferredLoading`

## Testing

- Opened each affected settings tab and verified section chrome renders immediately, no layout shift when data resolves
- Confirmed empty states render correctly with `EmptyState` for zero-data, filter-empty, and loading branches
- Verified Doherty threshold gate suppresses skeleton for fast resolutions (<400ms)