### PR TITLE
fix(diagnostics): route dock empty states through canonical EmptyState

### DIFF
--- a/src/components/Diagnostics/LogsContent.tsx
+++ b/src/components/Diagnostics/LogsContent.tsx
@@ -281,10 +281,16 @@ export function LogsContent({ className, onSourcesChange }: LogsContentProps) {
               />
             </div>
           ) : (
-            <div className="flex items-center justify-center h-full text-daintree-text/60 text-sm">
-              {logs.length === 0 && !previousSessionEntry
-                ? "No logs yet"
-                : "No new logs this session"}
+            <div className="flex items-center justify-center h-full">
+              {logs.length === 0 && !previousSessionEntry ? (
+                <EmptyState variant="zero-data" scale="sidebar" title="No logs yet" />
+              ) : (
+                <EmptyState
+                  variant="user-cleared"
+                  scale="sidebar"
+                  title="No new logs this session"
+                />
+              )}
             </div>
           )
         ) : (

--- a/src/components/Diagnostics/LogsContent.tsx
+++ b/src/components/Diagnostics/LogsContent.tsx
@@ -264,7 +264,7 @@ export function LogsContent({ className, onSourcesChange }: LogsContentProps) {
 
       <div className="flex-1 relative min-h-0">
         {displayEntries.length === 0 ? (
-          logs.length > 0 && hasActiveFilters ? (
+          logs.some((l) => l.id !== "previous-session-separator") && hasActiveFilters ? (
             <div className="flex items-center justify-center h-full">
               <EmptyState
                 variant="filtered-empty"

--- a/src/components/Diagnostics/ProblemsContent.tsx
+++ b/src/components/Diagnostics/ProblemsContent.tsx
@@ -3,6 +3,7 @@ import { cn } from "@/lib/utils";
 import { useErrorStore, type ErrorRecord, type RetryAction, RECURRENCE_THRESHOLD } from "@/store";
 import { Copy, Check, Lightbulb } from "lucide-react";
 import { Tooltip, TooltipContent, TooltipTrigger } from "@/components/ui/tooltip";
+import { EmptyState } from "@/components/ui/EmptyState";
 import { logError } from "@/utils/logger";
 
 const ERROR_TYPE_LABELS: Record<string, string> = {
@@ -256,8 +257,12 @@ export function ProblemsContent({ onRetry, onCancelRetry, className }: ProblemsC
   return (
     <div className={cn("h-full overflow-auto", className)}>
       {activeErrors.length === 0 ? (
-        <div className="flex items-center justify-center h-full text-daintree-text/60 text-sm">
-          No problems detected
+        <div className="flex items-center justify-center h-full">
+          {errors.length > 0 ? (
+            <EmptyState variant="user-cleared" scale="sidebar" title="All problems resolved" />
+          ) : (
+            <EmptyState variant="zero-data" scale="sidebar" title="No problems detected" />
+          )}
         </div>
       ) : (
         <table className="w-full">

--- a/src/components/Diagnostics/TelemetryContent.tsx
+++ b/src/components/Diagnostics/TelemetryContent.tsx
@@ -3,6 +3,7 @@ import { useShallow } from "zustand/react/shallow";
 import { Check, Copy, ShieldCheck } from "lucide-react";
 import { cn } from "@/lib/utils";
 import { Button } from "@/components/ui/button";
+import { EmptyState } from "@/components/ui/EmptyState";
 import { useTelemetryPreviewStore } from "@/store/telemetryPreviewStore";
 import { telemetryPreviewClient } from "@/clients";
 import { actionService } from "@/services/ActionService";
@@ -110,8 +111,12 @@ function TelemetryDetail({ event }: DetailProps) {
 
   if (!event) {
     return (
-      <div className="flex items-center justify-center h-full text-sm text-daintree-text/60">
-        <p>Select an event to view the sanitised payload</p>
+      <div className="flex items-center justify-center h-full">
+        <EmptyState
+          variant="zero-data"
+          scale="sidebar"
+          title="Select an event to view its payload"
+        />
       </div>
     );
   }
@@ -162,30 +167,35 @@ function TelemetryDetail({ event }: DetailProps) {
   );
 }
 
-function EmptyState({ active }: { active: boolean }) {
+function TelemetryEmptyState({ active }: { active: boolean }) {
   const handleEnable = useCallback(() => {
     void actionService.dispatch("telemetry.togglePreview", { active: true }, { source: "user" });
   }, []);
 
-  return (
-    <div className="h-full flex items-center justify-center p-6">
-      <div className="max-w-sm text-center space-y-3">
-        <ShieldCheck className="w-8 h-8 mx-auto text-daintree-accent/70" aria-hidden />
-        <h3 className="text-sm font-medium text-daintree-text">
-          {active ? "No events captured yet" : "Telemetry preview is off"}
-        </h3>
-        <p className="text-xs text-daintree-text/60">
-          {active
-            ? "Perform an action that emits an analytics event (e.g. finishing onboarding) to see its sanitised payload here. Crash reports only appear in preview once telemetry is set to Errors Only or Full Usage. Nothing is transmitted until you opt in."
-            : "Turn on preview to mirror the sanitised payloads Daintree would transmit — inspect them before deciding whether to enable telemetry."}
-        </p>
-        {!active && (
+  if (!active) {
+    return (
+      <EmptyState
+        variant="zero-data"
+        scale="canvas"
+        title="Telemetry preview is off"
+        icon={<ShieldCheck />}
+        description="Turn it on to mirror the sanitised payloads Daintree would transmit — inspect them before deciding whether to enable telemetry."
+        action={
           <Button variant="subtle" size="xs" onClick={handleEnable}>
-            Enable preview
+            Turn on telemetry preview
           </Button>
-        )}
-      </div>
-    </div>
+        }
+      />
+    );
+  }
+
+  return (
+    <EmptyState
+      variant="zero-data"
+      scale="canvas"
+      title="No events captured yet"
+      description="Perform an action that emits an analytics event (e.g. finishing onboarding) to see its sanitised payload here. Crash reports only appear in preview once telemetry is set to Errors Only or Full Usage. Nothing is transmitted until you opt in."
+    />
   );
 }
 
@@ -239,8 +249,8 @@ export function TelemetryContent({ className }: TelemetryContentProps) {
 
   if (events.length === 0) {
     return (
-      <div className={cn("h-full", className)}>
-        <EmptyState active={active} />
+      <div className={cn("h-full flex items-center justify-center", className)}>
+        <TelemetryEmptyState active={active} />
       </div>
     );
   }

--- a/src/components/Diagnostics/__tests__/LogsContent.test.tsx
+++ b/src/components/Diagnostics/__tests__/LogsContent.test.tsx
@@ -95,6 +95,18 @@ describe("LogsContent — filtered-empty recovery", () => {
     expect(queryByText("Clear filters")).toBeNull();
   });
 
+  it("does not mistake the separator-only state for filtered-empty when a filter is active", async () => {
+    mockGetAll.mockResolvedValue([
+      makeLog("previous-session-separator", { context: { tail: "old log line" } }),
+    ]);
+    useLogsStore.setState({ filters: { levels: ["error"] } });
+    const { findByText, queryByText } = render(<LogsContent />);
+
+    expect(await findByText("No new logs this session")).toBeTruthy();
+    expect(queryByText("No logs match filters")).toBeNull();
+    expect(queryByText("Clear filters")).toBeNull();
+  });
+
   it("does not show the filtered-empty action when filters are inactive", async () => {
     mockGetAll.mockResolvedValue([makeLog("a", { level: "info" })]);
     useLogsStore.setState({ filters: {} });

--- a/src/components/Diagnostics/__tests__/LogsContent.test.tsx
+++ b/src/components/Diagnostics/__tests__/LogsContent.test.tsx
@@ -84,6 +84,17 @@ describe("LogsContent — filtered-empty recovery", () => {
     expect(queryByText("Clear filters")).toBeNull();
   });
 
+  it("shows user-cleared empty state when only the previous-session separator remains", async () => {
+    mockGetAll.mockResolvedValue([
+      makeLog("previous-session-separator", { context: { tail: "old log line" } }),
+    ]);
+    const { findByText, queryByText } = render(<LogsContent />);
+
+    expect(await findByText("No new logs this session")).toBeTruthy();
+    expect(queryByText("No logs yet")).toBeNull();
+    expect(queryByText("Clear filters")).toBeNull();
+  });
+
   it("does not show the filtered-empty action when filters are inactive", async () => {
     mockGetAll.mockResolvedValue([makeLog("a", { level: "info" })]);
     useLogsStore.setState({ filters: {} });


### PR DESCRIPTION
## Summary

- Three diagnostics dock components were bypassing the canonical `EmptyState` component — `TelemetryContent` had a local shim, `LogsContent` fell back to a bare `div` for zero-data, and `ProblemsContent` handled empty states inconsistently
- All three now route through `EmptyState` with correct variant discrimination (`zero-data`, `filtered-empty`, `user-cleared`), so copy drift gets caught at compile time rather than silently
- Discovered and fixed a false-positive: the filtered-empty discriminator in `LogsContent` was counting separator items, so a separator-only list could trigger the wrong empty state

Resolves #8015

## Changes

- `TelemetryContent`: removed the in-file `EmptyState` shim; all three empty-state branches (active-empty, toggle-gated, no-selection detail) now use the canonical component
- `LogsContent`: replaced the bare `div` zero-data fallback with proper `zero-data` and `user-cleared` variants; fixed the separator false-positive in the filtered-empty check
- `ProblemsContent`: split inconsistent handling into correct `user-cleared` / `zero-data` variants

## Testing

- Added 2 `LogsContent` unit tests covering the `zero-data` and `user-cleared` empty states
- Typechecks clean, no lint errors in changed files