### PR TITLE
fix(ui): replace last full-area Spinners with shape-faithful skeletons

### DIFF
--- a/src/components/Setup/AgentSetupWizard.tsx
+++ b/src/components/Setup/AgentSetupWizard.tsx
@@ -826,7 +826,7 @@ function SelectionStep({
         </p>
         {isLoading ? (
           <Skeleton label="Loading agents" className="space-y-2">
-            {Array.from({ length: 3 }).map((_, i) => (
+            {Array.from({ length: 5 }).map((_, i) => (
               <div
                 key={i}
                 className="flex items-center gap-3 px-3 py-2.5 rounded-[var(--radius-md)] border border-daintree-border bg-daintree-bg/30"

--- a/src/components/Setup/AgentSetupWizard.tsx
+++ b/src/components/Setup/AgentSetupWizard.tsx
@@ -1,7 +1,7 @@
 import { useCallback, useEffect, useId, useMemo, useReducer, useRef, useState } from "react";
 import { AppDialog } from "@/components/ui/AppDialog";
 import { Button } from "@/components/ui/button";
-import { Spinner } from "@/components/ui/Spinner";
+import { Skeleton, SkeletonBone } from "@/components/ui/Skeleton";
 import { AgentCliStep } from "./AgentCliStep";
 import { SystemRequirementsSection } from "./SystemRequirementsSection";
 import { AGENT_REGISTRY } from "@/config/agents";
@@ -825,9 +825,22 @@ function SelectionStep({
           <span className="text-daintree-text/80">Settings &gt; Agents</span>.
         </p>
         {isLoading ? (
-          <div className="flex items-center justify-center py-8">
-            <Spinner size="lg" className="text-daintree-text/40" />
-          </div>
+          <Skeleton label="Loading agents" className="space-y-2">
+            {Array.from({ length: 3 }).map((_, i) => (
+              <div
+                key={i}
+                className="flex items-center gap-3 px-3 py-2.5 rounded-[var(--radius-md)] border border-daintree-border bg-daintree-bg/30"
+              >
+                <SkeletonBone className="w-4 h-4 shrink-0" />
+                <SkeletonBone className="w-8 h-8 rounded-[var(--radius-sm)] shrink-0" />
+                <div className="flex-1 min-w-0 space-y-1.5">
+                  <SkeletonBone className="h-4 w-28" />
+                  <SkeletonBone className="h-3 w-48" />
+                </div>
+                <SkeletonBone className="h-3 w-16 shrink-0" />
+              </div>
+            ))}
+          </Skeleton>
         ) : (
           <div className="space-y-2">
             {featuredAgents.map((agentId) => (

--- a/src/components/Worktree/CrossWorktreeDiff.tsx
+++ b/src/components/Worktree/CrossWorktreeDiff.tsx
@@ -279,7 +279,7 @@ export function CrossWorktreeDiff({ isOpen, onClose, initialWorktreeId }: CrossW
             <div className="p-4 space-y-3">
               <Skeleton label="Loading diff">
                 <SkeletonBone className="h-7 w-3/4" />
-                <SkeletonText lines={8} className="mt-3" />
+                <SkeletonText lines={8} />
               </Skeleton>
             </div>
           )}

--- a/src/components/Worktree/CrossWorktreeDiff.tsx
+++ b/src/components/Worktree/CrossWorktreeDiff.tsx
@@ -1,6 +1,6 @@
 import { useEffect, useRef, useState, useCallback, useMemo } from "react";
 import { GitCompare, FileIcon, AlertCircle } from "lucide-react";
-import { Spinner } from "@/components/ui/Spinner";
+import { Skeleton, SkeletonBone, SkeletonText } from "@/components/ui/Skeleton";
 import { cn } from "@/lib/utils";
 import { useWorktreeStore } from "@/hooks/useWorktreeStore";
 import { AppDialog } from "@/components/ui/AppDialog";
@@ -233,10 +233,15 @@ export function CrossWorktreeDiff({ isOpen, onClose, initialWorktreeId }: CrossW
           </div>
           <div className="flex-1 overflow-y-auto">
             {loading && (
-              <div className="flex items-center justify-center gap-2 p-6 text-text-muted text-sm">
-                <Spinner size="md" />
-                Comparing…
-              </div>
+              <Skeleton label="Comparing files" className="py-1">
+                {Array.from({ length: 8 }).map((_, i) => (
+                  <div key={i} className="flex items-center gap-2 px-3 py-1.5">
+                    <SkeletonBone className="w-3 h-3 shrink-0" />
+                    <SkeletonBone className="w-3 h-3 shrink-0" />
+                    <SkeletonBone className={cn("h-3", i % 2 === 0 ? "w-32" : "w-24")} />
+                  </div>
+                ))}
+              </Skeleton>
             )}
             {error && (
               <div className="flex items-start gap-2 p-4 text-status-error text-xs">
@@ -271,9 +276,11 @@ export function CrossWorktreeDiff({ isOpen, onClose, initialWorktreeId }: CrossW
             </div>
           )}
           {selectedFile && fileDiffLoading && (
-            <div className="flex items-center justify-center gap-2 h-full text-text-muted text-sm">
-              <Spinner size="md" />
-              Loading diff…
+            <div className="p-4 space-y-3">
+              <Skeleton label="Loading diff">
+                <SkeletonBone className="h-7 w-3/4" />
+                <SkeletonText lines={8} className="mt-3" />
+              </Skeleton>
             </div>
           )}
           {selectedFile && !fileDiffLoading && fileDiffError && (

--- a/src/components/Worktree/IssuePickerDialog.tsx
+++ b/src/components/Worktree/IssuePickerDialog.tsx
@@ -2,8 +2,7 @@ import { useState, useCallback, useEffect, useRef } from "react";
 import { AppDialog } from "@/components/ui/AppDialog";
 import { Button } from "@/components/ui/button";
 import { CircleDot, Search, Link, Unlink, CircleCheck } from "lucide-react";
-import { Skeleton } from "@/components/ui/Skeleton";
-import { GitHubResourceRowsSkeleton } from "@/components/GitHub/GitHubDropdownSkeletons";
+import { Skeleton, SkeletonBone } from "@/components/ui/Skeleton";
 import { cn } from "@/lib/utils";
 import { githubClient } from "@/clients";
 import type { GitHubIssue } from "@shared/types/github";
@@ -218,8 +217,19 @@ export function IssuePickerDialog({
 
       <div className="flex-1 overflow-y-auto min-h-0 px-6 pb-4">
         {isLoading && issues.length === 0 ? (
-          <Skeleton label="Loading issues">
-            <GitHubResourceRowsSkeleton count={6} />
+          <Skeleton label="Loading issues" className="space-y-1">
+            {Array.from({ length: 6 }).map((_, i) => (
+              <div
+                key={i}
+                className="px-3 py-2.5 rounded-[var(--radius-md)] flex items-start gap-3"
+              >
+                <SkeletonBone className="w-4 h-4 rounded-full shrink-0 mt-0.5" />
+                <div className="min-w-0 flex-1 space-y-1.5">
+                  <SkeletonBone className={cn("h-4", i % 2 === 0 ? "w-3/4" : "w-1/2")} />
+                  <SkeletonBone className="h-3 w-12" />
+                </div>
+              </div>
+            ))}
           </Skeleton>
         ) : error ? (
           <div className="text-center py-8 text-sm text-status-error">{error}</div>

--- a/src/components/Worktree/IssuePickerDialog.tsx
+++ b/src/components/Worktree/IssuePickerDialog.tsx
@@ -2,7 +2,8 @@ import { useState, useCallback, useEffect, useRef } from "react";
 import { AppDialog } from "@/components/ui/AppDialog";
 import { Button } from "@/components/ui/button";
 import { CircleDot, Search, Link, Unlink, CircleCheck } from "lucide-react";
-import { Spinner } from "@/components/ui/Spinner";
+import { Skeleton } from "@/components/ui/Skeleton";
+import { GitHubResourceRowsSkeleton } from "@/components/GitHub/GitHubDropdownSkeletons";
 import { cn } from "@/lib/utils";
 import { githubClient } from "@/clients";
 import type { GitHubIssue } from "@shared/types/github";
@@ -217,10 +218,9 @@ export function IssuePickerDialog({
 
       <div className="flex-1 overflow-y-auto min-h-0 px-6 pb-4">
         {isLoading && issues.length === 0 ? (
-          <div className="flex items-center justify-center py-8 text-daintree-text/50">
-            <Spinner size="lg" className="mr-2" />
-            <span className="text-sm">Loading issues...</span>
-          </div>
+          <Skeleton label="Loading issues">
+            <GitHubResourceRowsSkeleton count={6} />
+          </Skeleton>
         ) : error ? (
           <div className="text-center py-8 text-sm text-status-error">{error}</div>
         ) : issues.length === 0 ? (

--- a/src/components/Worktree/NewWorktreeDialog.tsx
+++ b/src/components/Worktree/NewWorktreeDialog.tsx
@@ -3,6 +3,7 @@ import { Button } from "@/components/ui/button";
 import { AppDialog } from "@/components/ui/AppDialog";
 import { FolderGit2, Check, AlertCircle, ChevronDown } from "lucide-react";
 import { Spinner } from "@/components/ui/Spinner";
+import { Skeleton, SkeletonBone } from "@/components/ui/Skeleton";
 import type { BranchInfo, CreateWorktreeOptions } from "@/types/electron";
 import type { GitHubIssue, GitHubPR } from "@shared/types/github";
 import { worktreeClient, githubClient } from "@/clients";
@@ -696,10 +697,20 @@ export function NewWorktreeDialog({
 
       <AppDialog.Body>
         {loading ? (
-          <div className="flex items-center justify-center py-12">
-            <Spinner size="xl" className="text-daintree-accent" />
-            <span className="ml-2 text-sm text-daintree-text/60">Loading branches...</span>
-          </div>
+          <Skeleton label="Loading branches" className="space-y-4 py-2">
+            <div className="space-y-2">
+              <SkeletonBone className="h-4 w-24" />
+              <SkeletonBone className="h-9 w-full" />
+            </div>
+            <div className="space-y-2">
+              <SkeletonBone className="h-4 w-28" />
+              <SkeletonBone className="h-9 w-full" />
+            </div>
+            <div className="space-y-2">
+              <SkeletonBone className="h-4 w-20" />
+              <SkeletonBone className="h-9 w-full" />
+            </div>
+          </Skeleton>
         ) : (
           <div className="space-y-4">
             {initialPR ? (


### PR DESCRIPTION
## Summary

- Replaces the remaining 5 full-area `Spinner` loading states with shape-faithful skeletons, per the CLAUDE.md loading-indicator rule (nothing <400ms, skeleton when shape is predictable)
- Skeletons mirror the actual content rows in each surface: `IssuePickerDialog` (icon circle + title + number), `NewWorktreeDialog` (label/input bones), `CrossWorktreeDiff` sidebar (file-row bones) and diff pane (heading bone + 8-line text block), `AgentSetupWizard` (5 `AgentCard`-shaped rows)
- All use `animate-pulse-delayed` for the 400ms anti-flicker gate; unused `Spinner` imports removed

Resolves #8014

## Changes

- `IssuePickerDialog` — inline bones mirroring `IssueOptionRow` (icon circle, title bar, `#number` chip)
- `NewWorktreeDialog` — form-shaped label/input bones during branch list load
- `CrossWorktreeDiff` — file-row bones in the sidebar; `h-7` heading bone + `SkeletonText` block in the diff pane (precedent: `FileViewerModal`)
- `AgentSetupWizard` — 5 `AgentCard`-shaped rows during availability resolve
- Button-inline `Spinner` in `NewWorktreeDialog` retained (out of scope per issue)
- Continues the arc of #7781 and #7851

## Testing

- tsc, lint, format, IPC channel check all green
- vitest: 21 passed
- `lint:ratchet` at baseline