### PR TITLE
fix(a11y): align list/grid keyboard contracts with WAI-ARIA APG

### DIFF
--- a/src/App.tsx
+++ b/src/App.tsx
@@ -449,7 +449,7 @@ function App() {
     if (crashState.status === "pending") removeStartupSkeleton();
   }, [crashState.status]);
   useEffect(() => {
-    useNotificationSettingsStore.getState().hydrate();
+    void useNotificationSettingsStore.getState().hydrate();
   }, []);
   useProjectSwitchRehydration();
   useShortcutHints(isStateLoaded);

--- a/src/components/Browser/BrowserToolbar.tsx
+++ b/src/components/Browser/BrowserToolbar.tsx
@@ -161,8 +161,17 @@ export function BrowserToolbar({
       }
 
       if (nextIndex !== currentIndex && nextIndex >= 0 && nextIndex < buttons.length) {
-        buttons[nextIndex]?.focus();
+        const nextButton = buttons[nextIndex];
+        nextButton?.focus();
         setChipFocusedIndex(nextIndex);
+        // APG radiogroup contract: selection follows focus. Activate the newly
+        // focused chip immediately rather than requiring Space/Enter.
+        const presetId = nextButton?.getAttribute(
+          "data-viewport-preset-id"
+        ) as ViewportPresetId | null;
+        if (presetId && nextButton?.getAttribute("aria-checked") !== "true") {
+          onViewportPresetChange?.(presetId);
+        }
       }
     };
 

--- a/src/components/Browser/__tests__/BrowserToolbar.test.tsx
+++ b/src/components/Browser/__tests__/BrowserToolbar.test.tsx
@@ -721,7 +721,7 @@ describe("BrowserToolbar viewport presets", () => {
       expect(pixelRadio.getAttribute("tabindex")).toBe("0");
     });
 
-    it("arrow keys move focus without changing selection", () => {
+    it("ArrowRight on the focused radio activates the next preset immediately (APG automatic activation)", () => {
       renderWithViewport();
       const iphoneRadio = document.querySelector(
         '[data-viewport-preset-id="iphone"]'
@@ -729,11 +729,39 @@ describe("BrowserToolbar viewport presets", () => {
 
       iphoneRadio.focus();
       fireEvent.keyDown(iphoneRadio, { key: "ArrowRight" });
-      fireEvent.keyDown(document.activeElement!, { key: "ArrowDown" });
-      fireEvent.keyDown(document.activeElement!, { key: "ArrowLeft" });
 
-      expect(onViewportPresetChange).not.toHaveBeenCalled();
-      expect(iphoneRadio.getAttribute("aria-checked")).toBe("true");
+      expect(onViewportPresetChange).toHaveBeenCalledWith("pixel");
+    });
+
+    it("ArrowDown also fires onViewportPresetChange (automatic activation along secondary axis)", () => {
+      renderWithViewport();
+      const iphoneRadio = document.querySelector(
+        '[data-viewport-preset-id="iphone"]'
+      )! as HTMLElement;
+
+      iphoneRadio.focus();
+      fireEvent.keyDown(iphoneRadio, { key: "ArrowDown" });
+
+      expect(onViewportPresetChange).toHaveBeenCalledWith("pixel");
+    });
+
+    it("Home/End fire onViewportPresetChange for the new endpoint", () => {
+      renderWithViewport();
+      const pixelRadio = document.querySelector(
+        '[data-viewport-preset-id="pixel"]'
+      )! as HTMLElement;
+      const galaxyRadio = document.querySelector(
+        '[data-viewport-preset-id="galaxy"]'
+      )! as HTMLElement;
+
+      pixelRadio.focus();
+      fireEvent.keyDown(pixelRadio, { key: "Home" });
+      expect(onViewportPresetChange).toHaveBeenCalledWith("galaxy");
+
+      onViewportPresetChange.mockClear();
+      galaxyRadio.focus();
+      fireEvent.keyDown(galaxyRadio, { key: "End" });
+      expect(onViewportPresetChange).toHaveBeenCalledWith("ipad");
     });
 
     it("keyboard listener attaches after deferred chip row mount", () => {

--- a/src/components/Layout/DockedTabGroup.tsx
+++ b/src/components/Layout/DockedTabGroup.tsx
@@ -299,12 +299,23 @@ export function DockedTabGroup({ group, panels }: DockedTabGroupProps) {
     [updateTitle]
   );
 
-  // Arrow key navigation for tabs (standard tablist behavior)
+  // APG manual activation: arrow keys move focus only; Space/Enter activates.
+  // Activation triggers PTY refit + buffering-state work, so following
+  // automatic-activation would re-run that on every arrow press while skimming.
+  // Space/Enter activation is handled by `TabButton.handleKeyDown` on each tab
+  // (it calls `onClick` which routes to `handleTabClick`), so we intentionally
+  // do not handle those keys here — doing so would double-activate.
   const handleTabListKeyDown = useCallback(
     (e: React.KeyboardEvent) => {
       if (panels.length < 2) return;
 
-      const currentIndex = panels.findIndex((p) => p.id === activeTabId);
+      // Anchor arrow movement to the currently focused tab when one is
+      // focused (so successive arrows roam without activating), else to the
+      // active tab (first arrow after entering the tablist via Tab).
+      const focused = document.activeElement as HTMLElement | null;
+      const focusedTabId = focused?.getAttribute("data-tab-id");
+      const anchorId = focusedTabId ?? activeTabId;
+      const currentIndex = panels.findIndex((p) => p.id === anchorId);
       let nextIndex: number | undefined;
 
       switch (e.key) {
@@ -327,15 +338,13 @@ export function DockedTabGroup({ group, panels }: DockedTabGroupProps) {
       e.preventDefault();
       const nextPanel = panels[nextIndex];
       if (nextPanel) {
-        handleTabClick(nextPanel.id);
-        // Focus the new tab button
         const tabButton = tabListEl?.querySelector(
           `[data-tab-id="${nextPanel.id}"]`
         ) as HTMLElement | null;
         tabButton?.focus();
       }
     },
-    [panels, activeTabId, handleTabClick, tabListEl]
+    [panels, activeTabId, tabListEl]
   );
 
   // Handle add tab - duplicate the current panel as a new tab

--- a/src/components/Layout/DockedTabGroup.tsx
+++ b/src/components/Layout/DockedTabGroup.tsx
@@ -312,8 +312,16 @@ export function DockedTabGroup({ group, panels }: DockedTabGroupProps) {
       // Anchor arrow movement to the currently focused tab when one is
       // focused (so successive arrows roam without activating), else to the
       // active tab (first arrow after entering the tablist via Tab).
+      //
+      // The `+` (duplicate) button lives inside the tablist container but is
+      // not itself a tab. If focus is on a non-tab element in the tablist
+      // (i.e. the `+` button), bail out so arrows don't yank focus back into
+      // the tab strip from the user's current position.
       const focused = document.activeElement as HTMLElement | null;
       const focusedTabId = focused?.getAttribute("data-tab-id");
+      if (!focusedTabId && focused && tabListEl?.contains(focused)) {
+        return;
+      }
       const anchorId = focusedTabId ?? activeTabId;
       const currentIndex = panels.findIndex((p) => p.id === anchorId);
       let nextIndex: number | undefined;
@@ -337,11 +345,17 @@ export function DockedTabGroup({ group, panels }: DockedTabGroupProps) {
 
       e.preventDefault();
       const nextPanel = panels[nextIndex];
-      if (nextPanel) {
-        const tabButton = tabListEl?.querySelector(
-          `[data-tab-id="${nextPanel.id}"]`
-        ) as HTMLElement | null;
-        tabButton?.focus();
+      if (nextPanel && tabListEl) {
+        // Iterate rather than build a `[data-tab-id="${id}"]` selector so we
+        // don't need to escape panel IDs containing quotes or other CSS-special
+        // characters (and so the lookup works in jsdom, which lacks CSS.escape).
+        const tabs = tabListEl.querySelectorAll<HTMLElement>("[data-tab-id]");
+        for (const el of tabs) {
+          if (el.getAttribute("data-tab-id") === nextPanel.id) {
+            el.focus();
+            break;
+          }
+        }
       }
     },
     [panels, activeTabId, tabListEl]

--- a/src/components/Layout/__tests__/DockedTabGroup.mountGuard.test.tsx
+++ b/src/components/Layout/__tests__/DockedTabGroup.mountGuard.test.tsx
@@ -8,7 +8,7 @@
  * dock terminal). The fix initializes wasJustOpenedRef = useRef(isOpen).
  */
 import { describe, it, expect, vi, beforeEach, afterEach } from "vitest";
-import { act, render } from "@testing-library/react";
+import { act, fireEvent, render } from "@testing-library/react";
 import { useEffect } from "react";
 import type { TerminalInstance } from "@/store";
 import type { TabGroup } from "@/types";
@@ -175,7 +175,33 @@ vi.mock("@/components/ui/tooltip", () => ({
 }));
 
 vi.mock("@/components/Panel/SortableTabButton", () => ({
-  SortableTabButton: ({ id }: { id: string }) => <button data-testid={`tab-${id}`}>{id}</button>,
+  SortableTabButton: ({
+    id,
+    isActive,
+    onClick,
+  }: {
+    id: string;
+    isActive?: boolean;
+    onClick?: () => void;
+  }) => (
+    <button
+      data-testid={`tab-${id}`}
+      data-tab-id={id}
+      role="tab"
+      aria-selected={!!isActive}
+      tabIndex={isActive ? 0 : -1}
+      onClick={onClick}
+      onKeyDown={(e) => {
+        // Mirror TabButton's own Space/Enter activation.
+        if (e.key === "Enter" || e.key === " ") {
+          e.preventDefault();
+          onClick?.();
+        }
+      }}
+    >
+      {id}
+    </button>
+  ),
 }));
 
 vi.mock("@/components/ui/dropdown-menu", () => ({
@@ -356,5 +382,96 @@ describe("DockedTabGroup mount-time close guard (#6602)", () => {
 
     expect(preventDefault).toHaveBeenCalledOnce();
     expect(terminalInstanceService.focus).not.toHaveBeenCalled();
+  });
+
+  describe("tablist keyboard contract (APG manual activation)", () => {
+    it("ArrowRight moves DOM focus to next tab without activating it", () => {
+      mockActiveDockTerminalId = "t-1";
+      const panels = [makePanel({ id: "t-1" }), makePanel({ id: "t-2" })];
+      const { container } = render(
+        <DockedTabGroup group={makeGroup(["t-1", "t-2"], "t-1")} panels={panels} />
+      );
+
+      const tab1 = container.querySelector('[data-tab-id="t-1"]') as HTMLElement;
+      const tab2 = container.querySelector('[data-tab-id="t-2"]') as HTMLElement;
+      const tablist = container.querySelector('[role="tablist"]') as HTMLElement;
+      expect(tab1).not.toBeNull();
+      expect(tab2).not.toBeNull();
+
+      tab1.focus();
+      setActiveTabMock.mockClear();
+      openDockTerminalMock.mockClear();
+      setFocusedMock.mockClear();
+      fireEvent.keyDown(tablist, { key: "ArrowRight" });
+
+      expect(document.activeElement).toBe(tab2);
+      // No activation side effects fired by the arrow key itself.
+      expect(setActiveTabMock).not.toHaveBeenCalled();
+      expect(openDockTerminalMock).not.toHaveBeenCalled();
+      expect(setFocusedMock).not.toHaveBeenCalled();
+    });
+
+    it("Enter on a focused-but-not-active tab activates it", () => {
+      mockActiveDockTerminalId = "t-1";
+      const panels = [makePanel({ id: "t-1" }), makePanel({ id: "t-2" })];
+      const { container } = render(
+        <DockedTabGroup group={makeGroup(["t-1", "t-2"], "t-1")} panels={panels} />
+      );
+
+      const tab2 = container.querySelector('[data-tab-id="t-2"]') as HTMLElement;
+      tab2.focus();
+      setActiveTabMock.mockClear();
+      openDockTerminalMock.mockClear();
+      setFocusedMock.mockClear();
+
+      fireEvent.keyDown(tab2, { key: "Enter" });
+
+      expect(setActiveTabMock).toHaveBeenCalledWith("g-1", "t-2");
+      expect(openDockTerminalMock).toHaveBeenCalledWith("t-2");
+      expect(setFocusedMock).toHaveBeenCalledWith("t-2");
+    });
+
+    it("Space on a focused-but-not-active tab activates it and prevents default scroll", () => {
+      mockActiveDockTerminalId = "t-1";
+      const panels = [makePanel({ id: "t-1" }), makePanel({ id: "t-2" })];
+      const { container } = render(
+        <DockedTabGroup group={makeGroup(["t-1", "t-2"], "t-1")} panels={panels} />
+      );
+
+      const tab2 = container.querySelector('[data-tab-id="t-2"]') as HTMLElement;
+      tab2.focus();
+      setActiveTabMock.mockClear();
+      openDockTerminalMock.mockClear();
+
+      const event = new KeyboardEvent("keydown", { key: " ", bubbles: true, cancelable: true });
+      const dispatched = tab2.dispatchEvent(event);
+
+      // dispatchEvent returns false when defaultPrevented; activation should also fire.
+      expect(dispatched).toBe(false);
+      expect(setActiveTabMock).toHaveBeenCalledWith("g-1", "t-2");
+      expect(openDockTerminalMock).toHaveBeenCalledWith("t-2");
+    });
+
+    it("Home moves focus to the first tab without activating", () => {
+      mockActiveDockTerminalId = "t-2";
+      const panels = [makePanel({ id: "t-1" }), makePanel({ id: "t-2" })];
+      const { container } = render(
+        <DockedTabGroup group={makeGroup(["t-1", "t-2"], "t-2")} panels={panels} />
+      );
+
+      const tab1 = container.querySelector('[data-tab-id="t-1"]') as HTMLElement;
+      const tab2 = container.querySelector('[data-tab-id="t-2"]') as HTMLElement;
+      const tablist = container.querySelector('[role="tablist"]') as HTMLElement;
+
+      tab2.focus();
+      setActiveTabMock.mockClear();
+      openDockTerminalMock.mockClear();
+
+      fireEvent.keyDown(tablist, { key: "Home" });
+
+      expect(document.activeElement).toBe(tab1);
+      expect(setActiveTabMock).not.toHaveBeenCalled();
+      expect(openDockTerminalMock).not.toHaveBeenCalled();
+    });
   });
 });

--- a/src/components/Layout/__tests__/DockedTabGroup.mountGuard.test.tsx
+++ b/src/components/Layout/__tests__/DockedTabGroup.mountGuard.test.tsx
@@ -452,6 +452,29 @@ describe("DockedTabGroup mount-time close guard (#6602)", () => {
       expect(openDockTerminalMock).toHaveBeenCalledWith("t-2");
     });
 
+    it("ArrowRight while the duplicate-as-new-tab (+) button is focused does not yank focus into the tab strip", () => {
+      mockActiveDockTerminalId = "t-1";
+      const panels = [makePanel({ id: "t-1" }), makePanel({ id: "t-2" })];
+      const { container } = render(
+        <DockedTabGroup group={makeGroup(["t-1", "t-2"], "t-1")} panels={panels} />
+      );
+
+      const addTabButton = container.querySelector(
+        '[aria-label="Duplicate panel as new tab"]'
+      ) as HTMLElement;
+      const tab1 = container.querySelector('[data-tab-id="t-1"]') as HTMLElement;
+      const tablist = container.querySelector('[role="tablist"]') as HTMLElement;
+      expect(addTabButton).not.toBeNull();
+
+      addTabButton.focus();
+      fireEvent.keyDown(tablist, { key: "ArrowRight" });
+
+      // Focus stays on the + button — the handler bails out for non-tab focus
+      // anchors inside the tablist.
+      expect(document.activeElement).toBe(addTabButton);
+      expect(document.activeElement).not.toBe(tab1);
+    });
+
     it("Home moves focus to the first tab without activating", () => {
       mockActiveDockTerminalId = "t-2";
       const panels = [makePanel({ id: "t-1" }), makePanel({ id: "t-2" })];

--- a/src/components/ThemeBrowser/ThemeBrowser.tsx
+++ b/src/components/ThemeBrowser/ThemeBrowser.tsx
@@ -21,6 +21,22 @@ import { useOverlayClaim, useImageError } from "@/hooks";
 const PANEL_WIDTH = 380;
 const EMPTY_WARNINGS: AppThemeValidationWarning[] = [];
 
+// Mirrors `computeGridPageSize` in `useWorktreeGridRovingFocus.ts` — sample a
+// live row to measure row height, divide viewport height. Fall back to 10 when
+// sizes aren't measurable yet (initial layout, jsdom).
+const PAGE_SIZE_FALLBACK = 10;
+function computeListPageSize(
+  container: HTMLElement | null,
+  sampleItem: HTMLElement | null
+): number {
+  if (!container || !sampleItem) return PAGE_SIZE_FALLBACK;
+  const viewportHeight = container.clientHeight;
+  if (viewportHeight <= 0) return PAGE_SIZE_FALLBACK;
+  const sampleHeight = sampleItem.getBoundingClientRect().height;
+  if (sampleHeight <= 0) return PAGE_SIZE_FALLBACK;
+  return Math.max(1, Math.floor(viewportHeight / sampleHeight));
+}
+
 function ThemeRow({
   scheme,
   isCommitted,
@@ -348,6 +364,32 @@ export function ThemeBrowser() {
           handlePreview(scheme.id, true);
           focusRow(scheme.id);
         }
+      } else if (e.key === "PageDown") {
+        e.preventDefault();
+        const sampleItem = rowRefs.current.values().next().value ?? null;
+        const pageSize = computeListPageSize(listRef.current, sampleItem);
+        const next = Math.min(keyboardIndex + pageSize, filteredThemes.length - 1);
+        if (next !== keyboardIndex) {
+          setKeyboardIndex(next);
+          const scheme = filteredThemes[next];
+          if (scheme && scheme.id !== activeSchemeId) {
+            handlePreview(scheme.id, true);
+            focusRow(scheme.id);
+          }
+        }
+      } else if (e.key === "PageUp") {
+        e.preventDefault();
+        const sampleItem = rowRefs.current.values().next().value ?? null;
+        const pageSize = computeListPageSize(listRef.current, sampleItem);
+        const next = Math.max(keyboardIndex - pageSize, 0);
+        if (next !== keyboardIndex) {
+          setKeyboardIndex(next);
+          const scheme = filteredThemes[next];
+          if (scheme && scheme.id !== activeSchemeId) {
+            handlePreview(scheme.id, true);
+            focusRow(scheme.id);
+          }
+        }
       } else if (e.key === "Enter") {
         e.preventDefault();
         void handleCommit();
@@ -364,7 +406,13 @@ export function ThemeBrowser() {
         setQuery("");
         return;
       }
-      if (e.key === "ArrowDown" || e.key === "ArrowUp" || e.key === "Enter") {
+      if (
+        e.key === "ArrowDown" ||
+        e.key === "ArrowUp" ||
+        e.key === "PageDown" ||
+        e.key === "PageUp" ||
+        e.key === "Enter"
+      ) {
         handleListKeyDown(e as unknown as React.KeyboardEvent<HTMLDivElement>);
       }
     },

--- a/src/components/ThemeBrowser/__tests__/ThemeBrowser.test.tsx
+++ b/src/components/ThemeBrowser/__tests__/ThemeBrowser.test.tsx
@@ -507,6 +507,60 @@ describe("ThemeBrowser", () => {
     expect(afterUp).toBe(DEFAULT_APP_SCHEME_ID);
   });
 
+  describe("Page navigation", () => {
+    it("PageDown advances by the computed page size and previews the new row", () => {
+      render(<Harness />);
+
+      const darkSchemes = BUILT_IN_APP_SCHEMES.filter((s) => s.type !== "light");
+      const initialIndex = darkSchemes.findIndex((s) => s.id === DEFAULT_APP_SCHEME_ID);
+      // jsdom returns 0 for clientHeight / getBoundingClientRect, so
+      // computeListPageSize falls back to PAGE_SIZE_FALLBACK (10).
+      const expected = darkSchemes[Math.min(initialIndex + 10, darkSchemes.length - 1)];
+
+      const list = screen.getByRole("listbox", { name: "Theme list" });
+      fireEvent.keyDown(list, { key: "PageDown" });
+
+      expect(useAppThemeStore.getState().previewSchemeId).toBe(expected?.id);
+    });
+
+    it("PageUp at index 0 stays at index 0 (clamped, no preview change)", () => {
+      render(<Harness />);
+
+      const list = screen.getByRole("listbox", { name: "Theme list" });
+      // We start at the committed scheme (index 0 of darkSchemes by default).
+      // PageUp should not move beyond the first row.
+      fireEvent.keyDown(list, { key: "PageUp" });
+
+      // No preview was set because we're already at the first index.
+      expect(useAppThemeStore.getState().previewSchemeId).toBeNull();
+    });
+
+    it("PageDown then PageUp returns preview to the original committed scheme", () => {
+      render(<Harness />);
+
+      const list = screen.getByRole("listbox", { name: "Theme list" });
+      fireEvent.keyDown(list, { key: "PageDown" });
+      expect(useAppThemeStore.getState().previewSchemeId).not.toBeNull();
+
+      fireEvent.keyDown(list, { key: "PageUp" });
+      expect(useAppThemeStore.getState().previewSchemeId).toBe(DEFAULT_APP_SCHEME_ID);
+    });
+
+    it("PageDown from the search input delegates to list navigation", () => {
+      render(<Harness />);
+
+      const searchInput = screen.getByLabelText("Filter themes") as HTMLInputElement;
+
+      const darkSchemes = BUILT_IN_APP_SCHEMES.filter((s) => s.type !== "light");
+      const initialIndex = darkSchemes.findIndex((s) => s.id === DEFAULT_APP_SCHEME_ID);
+      const expected = darkSchemes[Math.min(initialIndex + 10, darkSchemes.length - 1)];
+
+      fireEvent.keyDown(searchInput, { key: "PageDown" });
+
+      expect(useAppThemeStore.getState().previewSchemeId).toBe(expected?.id);
+    });
+  });
+
   describe("image error fallback", () => {
     it("shows fallback background div instead of broken thumbnail image", () => {
       render(<Harness />);


### PR DESCRIPTION
## Summary

- `DockedTabGroup` was using activation-follows-focus for tabs, triggering PTY refit and `applyRendererPolicy` retry loops on every arrow keypress. Switched to manual activation: arrows move DOM focus only, Space/Enter activates. Also fixed tablist arrow nav to skip non-tab elements (the `+` button) so they don't pull focus back into the tab sequence.
- `BrowserToolbar` viewport-preset chips (`role="radio"`) were gating activation on Space/Enter. APG radiogroup contract requires immediate activation on focus — fixed.
- `ThemeBrowser` listbox was missing PageUp/PageDown. Added using the same `computeGridPageSize` helper from `useWorktreeGridRovingFocus` (fallback 10).

Resolves #8012

## Changes

- `DockedTabGroup.tsx` — manual activation model, `+` button excluded from tablist arrow traversal
- `BrowserToolbar.tsx` — radiogroup fires `onViewportPresetChange` on focus, not just Space/Enter
- `ThemeBrowser.tsx` — PageUp/PageDown navigation added to `handleListKeyDown`
- Tests updated across all three components

## Testing

- Unit tests updated and passing for all three components
- Manual keyboard walkthrough: tab strip skimming no longer triggers spurious PTY refits; viewport chips change immediately on arrow; theme list pages correctly