### PR TITLE
feat(dnd): add canScroll and per-surface ARIA announcements to nested DndContexts

### DIFF
--- a/src/components/DragDrop/__tests__/dndAnnouncements.test.ts
+++ b/src/components/DragDrop/__tests__/dndAnnouncements.test.ts
@@ -1,4 +1,5 @@
 import { describe, it, expect } from "vitest";
+import { makeSortableAnnouncements } from "../sortableAnnouncements";
 
 // We test the announcement logic by recreating the same branching that
 // `getDragLabel` uses inside DndProvider. The production helper is
@@ -181,5 +182,108 @@ describe("drag announcements — worktree sort", () => {
     expect(announcements.onDragCancel(activeFor("wt-issue"))).toBe(
       "Drag cancelled. Add OAuth support returned to its original position"
     );
+  });
+});
+
+describe("makeSortableAnnouncements — nested DndContext factory", () => {
+  // The dnd-kit `Active` / `Over` types include refs and rects we don't need
+  // for announcement-string assertions. Construct the minimum shape and cast.
+  const active = (id: string) => ({ id }) as never;
+  const over = (id: string) => ({ id }) as never;
+
+  describe("panel tab surface", () => {
+    const labels = new Map<string, string>([
+      ["panel-1", "Claude Agent"],
+      ["panel-2", "Codex"],
+    ]);
+    const announcements = makeSortableAnnouncements((id) => labels.get(String(id)), "panel tab");
+
+    it("onDragStart announces resolved label", () => {
+      expect(announcements.onDragStart({ active: active("panel-1") })).toBe(
+        "Picked up Claude Agent"
+      );
+    });
+
+    it("onDragStart falls back to noun + id when label is missing", () => {
+      expect(announcements.onDragStart({ active: active("panel-unknown") })).toBe(
+        "Picked up panel tab panel-unknown"
+      );
+    });
+
+    it("onDragOver with target announces both labels", () => {
+      expect(announcements.onDragOver({ active: active("panel-1"), over: over("panel-2") })).toBe(
+        "Claude Agent is over Codex"
+      );
+    });
+
+    it("onDragOver without target announces no droppable area", () => {
+      expect(announcements.onDragOver({ active: active("panel-1"), over: null })).toBe(
+        "Claude Agent is no longer over a droppable area"
+      );
+    });
+
+    it("onDragEnd with target announces drop", () => {
+      expect(announcements.onDragEnd({ active: active("panel-1"), over: over("panel-2") })).toBe(
+        "Dropped Claude Agent"
+      );
+    });
+
+    it("onDragEnd without target announces return to original position", () => {
+      expect(announcements.onDragEnd({ active: active("panel-1"), over: null })).toBe(
+        "Claude Agent returned to its original position"
+      );
+    });
+
+    it("onDragCancel announces cancellation with resolved label", () => {
+      expect(announcements.onDragCancel({ active: active("panel-1"), over: null })).toBe(
+        "Drag cancelled. Claude Agent returned to its original position"
+      );
+    });
+
+    it("treats empty-string labels as missing and falls back to noun + id", () => {
+      const emptyLabels = makeSortableAnnouncements(() => "", "panel tab");
+      expect(emptyLabels.onDragStart({ active: active("panel-99") })).toBe(
+        "Picked up panel tab panel-99"
+      );
+    });
+
+    it("never includes 'undefined' in the announcement string", () => {
+      const nullLabels = makeSortableAnnouncements(() => null, "panel tab");
+      const result = nullLabels.onDragStart({ active: active("panel-x") });
+      expect(result).not.toContain("undefined");
+      expect(result).toBe("Picked up panel tab panel-x");
+    });
+  });
+
+  describe("toolbar button surface", () => {
+    const labels = new Map<string, string>([
+      ["btn-portal", "Portal"],
+      ["btn-recipes", "Recipes"],
+    ]);
+    const announcements = makeSortableAnnouncements(
+      (id) => labels.get(String(id)),
+      "toolbar button"
+    );
+
+    it("uses the surface noun in the fallback", () => {
+      expect(announcements.onDragStart({ active: active("btn-mystery") })).toBe(
+        "Picked up toolbar button btn-mystery"
+      );
+    });
+
+    it("resolves known IDs to labels", () => {
+      expect(announcements.onDragStart({ active: active("btn-portal") })).toBe("Picked up Portal");
+    });
+  });
+
+  describe("browser tab surface", () => {
+    const labels = new Map<string, string>([["tab-a", "Daintree Docs"]]);
+    const announcements = makeSortableAnnouncements((id) => labels.get(String(id)), "browser tab");
+
+    it("uses the browser tab noun in the fallback", () => {
+      expect(announcements.onDragStart({ active: active("tab-z") })).toBe(
+        "Picked up browser tab tab-z"
+      );
+    });
   });
 });

--- a/src/components/DragDrop/__tests__/dndAnnouncements.test.ts
+++ b/src/components/DragDrop/__tests__/dndAnnouncements.test.ts
@@ -253,6 +253,39 @@ describe("makeSortableAnnouncements — nested DndContext factory", () => {
       expect(result).not.toContain("undefined");
       expect(result).toBe("Picked up panel tab panel-x");
     });
+
+    it("treats whitespace-only labels as missing and falls back to noun + id", () => {
+      const blankLabels = makeSortableAnnouncements(() => "   \n\t", "panel tab");
+      expect(blankLabels.onDragStart({ active: active("panel-blank") })).toBe(
+        "Picked up panel tab panel-blank"
+      );
+    });
+
+    it("applies fallback to over slot when over label is missing", () => {
+      // Active resolves to "Claude Agent" (panel-1); over uses an unknown id.
+      expect(
+        announcements.onDragOver({ active: active("panel-1"), over: over("panel-mystery") })
+      ).toBe("Claude Agent is over panel tab panel-mystery");
+    });
+
+    it("uses fallbacks across all lifecycle methods when label is null", () => {
+      const nullLabels = makeSortableAnnouncements(() => null, "panel tab");
+      const a = active("panel-x");
+      const o = over("panel-y");
+      expect(nullLabels.onDragOver({ active: a, over: o })).toBe(
+        "panel tab panel-x is over panel tab panel-y"
+      );
+      expect(nullLabels.onDragOver({ active: a, over: null })).toBe(
+        "panel tab panel-x is no longer over a droppable area"
+      );
+      expect(nullLabels.onDragEnd({ active: a, over: o })).toBe("Dropped panel tab panel-x");
+      expect(nullLabels.onDragEnd({ active: a, over: null })).toBe(
+        "panel tab panel-x returned to its original position"
+      );
+      expect(nullLabels.onDragCancel({ active: a, over: null })).toBe(
+        "Drag cancelled. panel tab panel-x returned to its original position"
+      );
+    });
   });
 
   describe("toolbar button surface", () => {

--- a/src/components/DragDrop/sortableAnnouncements.ts
+++ b/src/components/DragDrop/sortableAnnouncements.ts
@@ -16,7 +16,7 @@ export function makeSortableAnnouncements(
 ): Announcements {
   const resolve = (id: UniqueIdentifier): string => {
     const label = getLabel(id);
-    return label != null && label !== "" ? label : `${itemNoun} ${String(id)}`;
+    return label != null && label.trim() !== "" ? label : `${itemNoun} ${String(id)}`;
   };
 
   return {

--- a/src/components/DragDrop/sortableAnnouncements.ts
+++ b/src/components/DragDrop/sortableAnnouncements.ts
@@ -1,0 +1,45 @@
+import type { Announcements, UniqueIdentifier } from "@dnd-kit/core";
+
+export type SortableLabelResolver = (id: UniqueIdentifier) => string | null | undefined;
+
+/**
+ * Build a stable `Announcements` object for a sortable list whose items are
+ * looked up by `id`. Designed for nested `DndContext` instances inside a
+ * surface that doesn't share the global DndProvider's data model.
+ *
+ * The returned object is pure — wrap the call in `useMemo` so dnd-kit's
+ * accessibility live region isn't torn down on every render.
+ */
+export function makeSortableAnnouncements(
+  getLabel: SortableLabelResolver,
+  itemNoun: string
+): Announcements {
+  const resolve = (id: UniqueIdentifier): string => {
+    const label = getLabel(id);
+    return label != null && label !== "" ? label : `${itemNoun} ${String(id)}`;
+  };
+
+  return {
+    onDragStart({ active }) {
+      return `Picked up ${resolve(active.id)}`;
+    },
+    onDragOver({ active, over }) {
+      const label = resolve(active.id);
+      if (over) {
+        return `${label} is over ${resolve(over.id)}`;
+      }
+      return `${label} is no longer over a droppable area`;
+    },
+    onDragEnd({ active, over }) {
+      const label = resolve(active.id);
+      if (over) {
+        return `Dropped ${label}`;
+      }
+      return `${label} returned to its original position`;
+    },
+    onDragCancel({ active }) {
+      const label = resolve(active.id);
+      return `Drag cancelled. ${label} returned to its original position`;
+    },
+  };
+}

--- a/src/components/Layout/DockedTabGroup.tsx
+++ b/src/components/Layout/DockedTabGroup.tsx
@@ -62,6 +62,10 @@ import { handleDockInteractOutside, handleDockEscapeKeyDown } from "./dockPopove
 import { usePreferencesStore } from "@/store";
 import { Tooltip, TooltipContent, TooltipTrigger } from "@/components/ui/tooltip";
 
+// Defer terminal focus by one frame's worth so Radix Popover finishes its
+// open animation before we steal focus into the PTY.
+const TERMINAL_FOCUS_DELAY_MS = 50;
+
 interface DockedTabGroupProps {
   group: TabGroup;
   panels: TerminalInstance[];
@@ -571,7 +575,7 @@ export function DockedTabGroup({ group, panels }: DockedTabGroupProps) {
             return;
           }
 
-          setTimeout(() => terminalInstanceService.focus(activePanel.id), 50);
+          setTimeout(() => terminalInstanceService.focus(activePanel.id), TERMINAL_FOCUS_DELAY_MS);
         }}
       >
         {/* Tab bar at top of popover */}

--- a/src/components/Layout/DockedTabGroup.tsx
+++ b/src/components/Layout/DockedTabGroup.tsx
@@ -9,6 +9,7 @@ import {
   PointerSensor,
   TouchSensor,
   type DragEndEvent,
+  type UniqueIdentifier,
 } from "@dnd-kit/core";
 import { SortableContext, horizontalListSortingStrategy, arrayMove } from "@dnd-kit/sortable";
 import { restrictToHorizontalAxis, restrictToParentElement } from "@dnd-kit/modifiers";
@@ -54,6 +55,7 @@ import {
   isGroupDeprioritized,
 } from "./useDockBlockedState";
 import { SortableTabButton } from "@/components/Panel/SortableTabButton";
+import { makeSortableAnnouncements } from "@/components/DragDrop/sortableAnnouncements";
 import type { TabGroup } from "@/types";
 import { buildPanelDuplicateOptions } from "@/services/terminal/panelDuplicationService";
 import { handleDockInteractOutside, handleDockEscapeKeyDown } from "./dockPopoverGuard";
@@ -290,6 +292,30 @@ export function DockedTabGroup({ group, panels }: DockedTabGroupProps) {
       }
     },
     [panels, group.id, reorderPanelsInGroup]
+  );
+
+  // Surface-specific ARIA announcements for the dock tab strip. Without this
+  // dnd-kit reads the generic English defaults ("Picked up draggable item"),
+  // which obscures which tab the user grabbed when multiple groups are docked.
+  const getPanelTabLabel = useCallback(
+    (id: UniqueIdentifier) => {
+      const panel = panels.find((p) => p.id === id);
+      return panel ? getBaseTitle(panel.title) : null;
+    },
+    [panels]
+  );
+  const tabAnnouncements = useMemo(
+    () => makeSortableAnnouncements(getPanelTabLabel, "panel tab"),
+    [getPanelTabLabel]
+  );
+
+  // Restrict dnd-kit's autoscroller to the horizontal tab strip itself. The
+  // DndContext lives inside a Radix Popover portaled to document.body, so its
+  // scrollable-ancestor walk would otherwise reach `body`/`html` and scroll
+  // the page when the user drags a tab near the popover edge.
+  const tabAutoScroll = useMemo(
+    () => ({ canScroll: (el: Element) => el === tabListEl }),
+    [tabListEl]
   );
 
   const handleTabRename = useCallback(
@@ -554,13 +580,15 @@ export function DockedTabGroup({ group, panels }: DockedTabGroupProps) {
           collisionDetection={closestCenter}
           onDragEnd={handleTabDragEnd}
           modifiers={[restrictToHorizontalAxis, restrictToParentElement]}
+          autoScroll={tabAutoScroll}
+          accessibility={{ announcements: tabAnnouncements }}
         >
           <SortableContext items={tabIds} strategy={horizontalListSortingStrategy}>
             <LayoutGroup id={`dock-tabs-${group.id}`}>
               <div className="flex items-stretch border-b border-divider bg-daintree-sidebar shrink-0">
                 <div
                   ref={setTabListEl}
-                  className="flex items-center min-w-0 flex-1 overflow-x-auto scrollbar-none"
+                  className="flex items-center min-w-0 flex-1 overflow-x-auto overscroll-x-none scrollbar-none"
                   role="tablist"
                   aria-label="Dock panel tabs"
                   onKeyDown={handleTabListKeyDown}

--- a/src/components/Portal/PortalToolbar.tsx
+++ b/src/components/Portal/PortalToolbar.tsx
@@ -1,3 +1,4 @@
+import { useCallback, useMemo } from "react";
 import { ArrowLeft, ArrowRight, RotateCw, X, Plus, ExternalLink, Link2 } from "lucide-react";
 import {
   DndContext,
@@ -7,6 +8,7 @@ import {
   useSensor,
   useSensors,
   type DragEndEvent,
+  type UniqueIdentifier,
 } from "@dnd-kit/core";
 import {
   SortableContext,
@@ -15,6 +17,7 @@ import {
   horizontalListSortingStrategy,
 } from "@dnd-kit/sortable";
 import { CSS } from "@dnd-kit/utilities";
+import { makeSortableAnnouncements } from "@/components/DragDrop/sortableAnnouncements";
 import type { PortalTab, PortalLink } from "@shared/types";
 import { cn } from "@/lib/utils";
 import { createTooltipContent } from "@/lib/tooltipShortcut";
@@ -232,6 +235,15 @@ export function PortalToolbar({
     }
   };
 
+  const getBrowserTabLabel = useCallback(
+    (id: UniqueIdentifier) => tabs.find((t) => t.id === id)?.title,
+    [tabs]
+  );
+  const browserTabAnnouncements = useMemo(
+    () => makeSortableAnnouncements(getBrowserTabLabel, "browser tab"),
+    [getBrowserTabLabel]
+  );
+
   return (
     <div className="flex flex-col bg-daintree-bg border-b border-daintree-border">
       {/* Top Row: Navigation Controls */}
@@ -325,7 +337,12 @@ export function PortalToolbar({
 
       {/* Bottom Row: Tab Pills */}
       <div className="px-2 pb-2">
-        <DndContext sensors={sensors} collisionDetection={closestCorners} onDragEnd={handleDragEnd}>
+        <DndContext
+          sensors={sensors}
+          collisionDetection={closestCorners}
+          onDragEnd={handleDragEnd}
+          accessibility={{ announcements: browserTabAnnouncements }}
+        >
           <SortableContext items={tabs.map((t) => t.id)} strategy={horizontalListSortingStrategy}>
             <div
               className="flex flex-wrap gap-2 items-center"

--- a/src/components/Settings/ToolbarSettingsTab.tsx
+++ b/src/components/Settings/ToolbarSettingsTab.tsx
@@ -1,4 +1,4 @@
-import { useMemo } from "react";
+import { useCallback, useMemo } from "react";
 import {
   DndContext,
   closestCenter,
@@ -7,6 +7,7 @@ import {
   useSensor,
   useSensors,
   type DragEndEvent,
+  type UniqueIdentifier,
 } from "@dnd-kit/core";
 import {
   SortableContext,
@@ -32,6 +33,7 @@ import { usePluginToolbarButtons } from "@/hooks/usePluginToolbarButtons";
 import { McpServerIcon } from "@/components/icons";
 import { cn } from "@/lib/utils";
 import { DRAG_GHOST_OPACITY } from "@/lib/animationUtils";
+import { makeSortableAnnouncements } from "@/components/DragDrop/sortableAnnouncements";
 import { SettingsSection } from "./SettingsSection";
 import { SettingsSwitchCard } from "./SettingsSwitchCard";
 
@@ -142,6 +144,18 @@ export function ToolbarSettingsTab() {
     return { ...TOOLBAR_BUTTON_METADATA, ...pluginMeta };
   }, [pluginButtonIds, pluginConfigs]);
 
+  const getToolbarButtonLabel = useCallback(
+    (id: UniqueIdentifier) => {
+      const meta = allMetadata as Partial<Record<AnyToolbarButtonId, ToolbarButtonMetadata>>;
+      return meta[id as AnyToolbarButtonId]?.label;
+    },
+    [allMetadata]
+  );
+  const toolbarButtonAnnouncements = useMemo(
+    () => makeSortableAnnouncements(getToolbarButtonLabel, "toolbar button"),
+    [getToolbarButtonLabel]
+  );
+
   const handleLeftDragEnd = (event: DragEndEvent) => {
     const { active, over } = event;
     if (!over || active.id === over.id) return;
@@ -212,6 +226,7 @@ export function ToolbarSettingsTab() {
           sensors={sensors}
           collisionDetection={closestCenter}
           onDragEnd={handleLeftDragEnd}
+          accessibility={{ announcements: toolbarButtonAnnouncements }}
         >
           <SortableContext items={layout.leftButtons} strategy={verticalListSortingStrategy}>
             <div className="space-y-2">
@@ -243,6 +258,7 @@ export function ToolbarSettingsTab() {
           sensors={sensors}
           collisionDetection={closestCenter}
           onDragEnd={handleRightDragEnd}
+          accessibility={{ announcements: toolbarButtonAnnouncements }}
         >
           <SortableContext items={layout.rightButtons} strategy={verticalListSortingStrategy}>
             <div className="space-y-2">


### PR DESCRIPTION
## Summary

- The four nested `DndContext` instances in `DockedTabGroup.tsx`, `PortalToolbar.tsx`, and `ToolbarSettingsTab.tsx` were inheriting dnd-kit's default English announcement strings, so screen readers announced "sortable item" instead of the actual domain noun (tab, browser tab, toolbar button).
- `DockedTabGroup` also had the autoscroller walking all overflow ancestors, which caused the sidebar to scroll simultaneously with the tab strip during a tab drag. dnd-kit's `canScroll` callback is the prescribed fix for this.

Closes #8016

## Changes

- New `sortableAnnouncements.ts` factory that accepts a surface label and returns a full `Announcements` object with domain-aware strings for pick-up, move, drop, and cancel events.
- Wired the factory into all four nested `DndContext` instances (`DockedTabGroup`, `PortalToolbar`, left and right button lists in `ToolbarSettingsTab`).
- Added `canScroll` to `DockedTabGroup`'s `DndContext` to exclude the sidebar from the scroll ancestor chain.
- New `dndAnnouncements.test.ts` with coverage for the factory output and the whitespace-only label fallback.

## Testing

- Unit tests cover the announcement factory and the fallback path for whitespace-only labels.
- Manually verified drag behaviour in `DockedTabGroup` — sidebar no longer scrolls during a tab drag near the popover boundary.