### PR TITLE
fix(destructive): wire missing confirm dialogs across UI surfaces

### DIFF
--- a/docs/architecture/destructive-action-safeguards.md
+++ b/docs/architecture/destructive-action-safeguards.md
@@ -59,9 +59,9 @@ Columns:
 | --- | --- | --- | --- | --- | --- | --- | --- |
 | `worktree.create` / `worktree.quickCreate` / `worktree.createDialog.open` | safe | n/a (creation) | reversible (delete the worktree) | one new worktree | D0 | Leave | — |
 | `worktree.delete` | confirm | yes (`WorktreeDeleteDialog`) | shared-state (working tree + branch on disk) | one worktree, optionally one branch | D2 | Leave — preview shows file count split (tracked vs untracked, see #4927) | — |
-| `worktree.delete` with `force: true` | confirm | yes; force flag is a separate toggle in the dialog | shared-state, may discard uncommitted work | one worktree | D2 → escalates to D3 when worktree has uncommitted tracked changes | Treat the "force delete with uncommitted changes" path as D3 — require typed-name confirmation | TBD |
+| `worktree.delete` with `force: true` | confirm | yes; force flag is a separate toggle in the dialog, escalates to typed-name gate | shared-state, may discard uncommitted work | one worktree | D2 → escalates to D3 when worktree has uncommitted tracked changes | Done (#8023) — `WorktreeDeleteDialog.isHighTier` escalates to the typed-name gate when `force && hasTrackedChanges` (in addition to protected branch / main worktree); uses `hasTrackedChanges` not `hasChanges` so untracked-only deletes don't escalate (#4927) | — |
 | `worktree.resource.provision` | safe | n/a | reversible (teardown) | one resource | D0 | Leave | — |
-| `worktree.resource.teardown` | safe | none in action; depends on resource client | shared-state (cloud resource destroyed) | one resource | D2 | Add confirm + show what teardown will run / which resource | TBD |
+| `worktree.resource.teardown` | **confirm** (updated #8023) | yes (`ConfirmDialog` via `useWorktreeActions` / `WorktreeCard`) — preview lists the actual teardown commands | shared-state (cloud resource destroyed) | one resource | D2 | Done (#8023) — confirm shows the resolved teardown command list before dispatch | — |
 | `worktree.resource.pause` / `worktree.resource.resume` | safe | n/a | reversible | one resource | D0 | Leave | — |
 
 ### Worktree sessions
@@ -100,7 +100,7 @@ Columns:
 | `fleet.armMatchingFilter` / `fleet.armFocused` / `fleet.armAll` | safe | n/a | reversible (disarm) | armed set | D0 | Leave | — |
 | `fleet.saveNamedFleet` | safe | n/a | reversible (delete fleet) | one saved fleet | D0 | Leave | — |
 | `fleet.recallNamedFleet` | safe | n/a | reversible (re-arm) | armed set | D0 | Leave | — |
-| `fleet.deleteNamedFleet` | safe | none | local-irreversible (settings entry gone) | one saved fleet | D1 | Add confirm at the SavedFleetsSection delete button | TBD |
+| `fleet.deleteNamedFleet` | **confirm** (updated #8023) | yes (`ConfirmDialog` hoisted to `FleetArmingRibbon`, outside the dropdown tree) | local-irreversible (settings entry gone) | one saved fleet | D1 | Done (#8023) — confirm state lifted above the Radix `DropdownMenu` so the dialog survives the menu closing (#2828) | — |
 | `fleet.retryFailures` | safe | n/a | local-undo (just re-fires the last broadcast) | failed broadcast targets | D0 | Leave | — |
 
 ### Project / window
@@ -140,7 +140,7 @@ The current GitHub action set is read-only (`openIssues`, `listPullRequests`, et
 | Action / call site | Current | UI confirm | Reversibility | Blast | Tier | Recommendation | Follow-up |
 | --- | --- | --- | --- | --- | --- | --- | --- |
 | `portal.links.add` / `update` / `toggle` / `reorder` | safe | n/a | reversible | one link | D0 | Leave | — |
-| `portal.links.remove` | safe | none | local-irreversible (link gone) | one link | D1 | Add confirm at the SettingsPanel delete control | TBD |
+| `portal.links.remove` | **confirm** (updated #8023) | yes (`ConfirmDialog` in `PortalSettingsTab`) | local-irreversible (link gone) | one link | D1 | Done (#8023) — confirm wired at the Custom links delete control | — |
 | `portal.closeTab` / `closeOthers` / `closeToRight` / `closeAllTabs` | safe | none | local-irreversible (tab history lost) | 1..N tabs | D0 (single) → D1 (bulk) | Add confirm for `closeAllTabs` and `closeOthers` when 3+ tabs would close | TBD |
 | `portal.duplicateTab` / `reload` / `goBack` / `goForward` | safe | n/a | reversible | one tab | D0 | Leave | — |
 

--- a/src/components/Fleet/FleetArmingRibbon.tsx
+++ b/src/components/Fleet/FleetArmingRibbon.tsx
@@ -1,6 +1,7 @@
 import { useCallback, useEffect, useRef, useState, type ReactElement } from "react";
 import { MoreHorizontal, X } from "lucide-react";
 import { AnimatePresence, m, useReducedMotion } from "framer-motion";
+import { useShallow } from "zustand/react/shallow";
 import { cn } from "@/lib/utils";
 import { isMac } from "@/lib/platform";
 import { useEscapeStack } from "@/hooks";
@@ -31,7 +32,9 @@ import { useFleetBroadcastProgressStore } from "@/store/fleetBroadcastProgressSt
 import { useFleetPendingActionStore } from "@/store/fleetPendingActionStore";
 import { useAnnouncerStore } from "@/store/accessibilityAnnouncerStore";
 import { usePanelStore } from "@/store/panelStore";
+import { useProjectSettingsStore } from "@/store/projectSettingsStore";
 import { actionService } from "@/services/ActionService";
+import { ConfirmDialog } from "@/components/ui/ConfirmDialog";
 import {
   DropdownMenu,
   DropdownMenuContent,
@@ -60,6 +63,14 @@ export function FleetArmingRibbon(): ReactElement | null {
   const progressActive = useFleetBroadcastProgressStore((s) => s.isActive);
 
   const [popoverOpen, setPopoverOpen] = useState(false);
+  // The selection menu is controlled so a fleet-delete request can close it
+  // before the confirm dialog opens — keeping the modal dropdown layer from
+  // colliding with the dialog's focus trap (#8023, lesson #2828).
+  const [selectionMenuOpen, setSelectionMenuOpen] = useState(false);
+  const [pendingDeleteFleetId, setPendingDeleteFleetId] = useState<string | null>(null);
+  const savedScopes = useProjectSettingsStore(
+    useShallow((s) => s.settings?.fleetSavedScopes ?? [])
+  );
   const pasteCancelRef = useRef<HTMLButtonElement | null>(null);
   const ribbonRef = useRef<HTMLDivElement | null>(null);
   const reduceMotion = useReducedMotion();
@@ -199,6 +210,18 @@ export function FleetArmingRibbon(): ReactElement | null {
     resolveFleetBroadcastConfirmation();
   }, [pendingBroadcast]);
 
+  const handleRequestDeleteFleet = useCallback((id: string) => {
+    // Close the selection menu first so its modal layer tears down before
+    // the confirm dialog mounts; React 19 batches both state updates.
+    setSelectionMenuOpen(false);
+    setPendingDeleteFleetId(id);
+  }, []);
+
+  const pendingDeleteScope =
+    pendingDeleteFleetId !== null
+      ? (savedScopes.find((s) => s.id === pendingDeleteFleetId) ?? null)
+      : null;
+
   const setPreviewArmedIds = useFleetArmingStore((s) => s.setPreviewArmedIds);
   const clearPreviewArmedIds = useFleetArmingStore((s) => s.clearPreviewArmedIds);
 
@@ -300,7 +323,7 @@ export function FleetArmingRibbon(): ReactElement | null {
           </DropdownMenuItem>
         </>
       ) : null}
-      <SavedFleetsSection />
+      <SavedFleetsSection onRequestDelete={handleRequestDeleteFleet} />
     </>
   );
 
@@ -401,6 +424,24 @@ export function FleetArmingRibbon(): ReactElement | null {
 
   return (
     <div data-testid="fleet-arming-ribbon-group">
+      <ConfirmDialog
+        isOpen={pendingDeleteFleetId !== null}
+        variant="destructive"
+        title={`Delete '${pendingDeleteScope?.name ?? "fleet"}'?`}
+        description="This removes the saved fleet. The terminals it points to are not affected."
+        confirmLabel="Delete fleet"
+        onConfirm={() => {
+          if (pendingDeleteFleetId !== null) {
+            void actionService.dispatch(
+              "fleet.deleteNamedFleet",
+              { id: pendingDeleteFleetId },
+              { source: "user" }
+            );
+          }
+          setPendingDeleteFleetId(null);
+        }}
+        onClose={() => setPendingDeleteFleetId(null)}
+      />
       <AnimatePresence initial={false}>
         <m.div
           ref={ribbonRef}
@@ -466,7 +507,9 @@ export function FleetArmingRibbon(): ReactElement | null {
             </button>
           )}
           <DropdownMenu
+            open={selectionMenuOpen}
             onOpenChange={(open) => {
+              setSelectionMenuOpen(open);
               if (!open) clearPreviewArmedIds();
             }}
           >

--- a/src/components/Fleet/FleetArmingRibbon.tsx
+++ b/src/components/Fleet/FleetArmingRibbon.tsx
@@ -93,6 +93,18 @@ export function FleetArmingRibbon(): ReactElement | null {
     }
   }, [armedCount, popoverOpen]);
 
+  // The fleet-delete confirm renders only in the armedCount>=2 branch. If the
+  // armed set drains below 2 while it's pending, the dialog unmounts without
+  // an onClose — clear the id so it can't resurface for a stale fleet when
+  // the count climbs back. Also drop it if the scope disappears entirely
+  // (deleted from another window) so the title can't show a phantom name.
+  useEffect(() => {
+    if (pendingDeleteFleetId === null) return;
+    if (armedCount < 2 || !savedScopes.some((s) => s.id === pendingDeleteFleetId)) {
+      setPendingDeleteFleetId(null);
+    }
+  }, [armedCount, pendingDeleteFleetId, savedScopes]);
+
   // Escape stack: confirmation cancel is owned here so a pending confirm
   // absorbs bare Escape before it reaches the targets. The armed-list
   // popover gets its own entry so bare Escape closes the list without
@@ -335,12 +347,18 @@ export function FleetArmingRibbon(): ReactElement | null {
     (e: React.KeyboardEvent<HTMLDivElement>) => {
       if (e.key !== "Escape") return;
       if (e.metaKey || e.ctrlKey || e.altKey || e.shiftKey) return;
-      if (pendingBroadcast !== null || popoverOpen || pending !== null) return;
+      if (
+        pendingBroadcast !== null ||
+        popoverOpen ||
+        pending !== null ||
+        pendingDeleteFleetId !== null
+      )
+        return;
       e.preventDefault();
       e.stopPropagation();
       exitFleet();
     },
-    [exitFleet, pendingBroadcast, popoverOpen, pending]
+    [exitFleet, pendingBroadcast, popoverOpen, pending, pendingDeleteFleetId]
   );
 
   // Render confirmation before the armedCount<2 null guard so single-agent

--- a/src/components/Fleet/SavedFleetRow.tsx
+++ b/src/components/Fleet/SavedFleetRow.tsx
@@ -7,9 +7,10 @@ import { DropdownMenuItem } from "@/components/ui/dropdown-menu";
 
 interface SavedFleetRowProps {
   scope: FleetSavedScope;
+  onRequestDelete: (id: string) => void;
 }
 
-export function SavedFleetRow({ scope }: SavedFleetRowProps): ReactElement {
+export function SavedFleetRow({ scope, onRequestDelete }: SavedFleetRowProps): ReactElement {
   // Counts are computed at render time — the dropdown opens fresh each time,
   // so re-running this on every paint of the open menu is fine and there's no
   // need for a panelStore subscription that would burn cycles while closed.
@@ -33,14 +34,12 @@ export function SavedFleetRow({ scope }: SavedFleetRowProps): ReactElement {
         data-testid="fleet-saved-row-delete"
         onClick={(e) => {
           // Stop the parent DropdownMenuItem's onSelect from firing the recall
-          // when the user clicks the trash icon.
+          // when the user clicks the trash icon. The confirm dialog is hoisted
+          // to FleetArmingRibbon (outside this dropdown tree) so it survives
+          // the menu closing — see #8023.
           e.preventDefault();
           e.stopPropagation();
-          void actionService.dispatch(
-            "fleet.deleteNamedFleet",
-            { id: scope.id },
-            { source: "user" }
-          );
+          onRequestDelete(scope.id);
         }}
         onPointerDown={(e) => {
           // Radix DropdownMenuItem also commits on pointerdown — guard the

--- a/src/components/Fleet/SavedFleetsSection.tsx
+++ b/src/components/Fleet/SavedFleetsSection.tsx
@@ -6,7 +6,11 @@ import { DropdownMenuLabel, DropdownMenuSeparator } from "@/components/ui/dropdo
 import { SavedFleetRow } from "./SavedFleetRow";
 import { SaveFleetForm } from "./SaveFleetForm";
 
-export function SavedFleetsSection(): ReactElement {
+interface SavedFleetsSectionProps {
+  onRequestDelete: (id: string) => void;
+}
+
+export function SavedFleetsSection({ onRequestDelete }: SavedFleetsSectionProps): ReactElement {
   const armedCount = useFleetArmingStore((s) => s.armedIds.size);
   const savedScopes = useProjectSettingsStore(
     useShallow((s) => s.settings?.fleetSavedScopes ?? [])
@@ -18,7 +22,7 @@ export function SavedFleetsSection(): ReactElement {
         <>
           <DropdownMenuLabel>Saved fleets</DropdownMenuLabel>
           {savedScopes.map((scope) => (
-            <SavedFleetRow key={scope.id} scope={scope} />
+            <SavedFleetRow key={scope.id} scope={scope} onRequestDelete={onRequestDelete} />
           ))}
         </>
       ) : null}

--- a/src/components/Fleet/__tests__/FleetArmingRibbon.test.tsx
+++ b/src/components/Fleet/__tests__/FleetArmingRibbon.test.tsx
@@ -1171,4 +1171,50 @@ describe("FleetArmingRibbon — saved fleet delete confirm (#8023)", () => {
 
     dispatchSpy.mockRestore();
   });
+
+  it("cancelling the dialog does not dispatch and closes the dialog", async () => {
+    const actionServiceModule = await import("@/services/ActionService");
+    const dispatchSpy = vi.spyOn(actionServiceModule.actionService, "dispatch");
+
+    useFleetArmingStore.getState().armIds(["a", "b"]);
+    render(<FleetArmingRibbon />);
+
+    await act(async () => {
+      fireEvent.click(screen.getByTestId("fleet-saved-row-delete"));
+    });
+    expect(screen.getByText("Delete 'My fleet'?")).toBeTruthy();
+
+    await act(async () => {
+      fireEvent.click(screen.getByRole("button", { name: "Cancel" }));
+    });
+
+    expect(
+      dispatchSpy.mock.calls.some((c) => c[0] === "fleet.deleteNamedFleet")
+    ).toBe(false);
+    expect(screen.queryByText("Delete 'My fleet'?")).toBeNull();
+
+    dispatchSpy.mockRestore();
+  });
+
+  it("clears the pending delete when the armed set drains below 2", async () => {
+    useFleetArmingStore.getState().armIds(["a", "b"]);
+    render(<FleetArmingRibbon />);
+
+    await act(async () => {
+      fireEvent.click(screen.getByTestId("fleet-saved-row-delete"));
+    });
+    expect(screen.getByText("Delete 'My fleet'?")).toBeTruthy();
+
+    // Drain to 1 — the ribbon (and dialog) unmount via the armedCount<2 guard.
+    await act(async () => {
+      useFleetArmingStore.getState().armIds(["a"]);
+    });
+    expect(screen.queryByText("Delete 'My fleet'?")).toBeNull();
+
+    // Re-arm: the dialog must NOT resurface for the stale fleet id.
+    await act(async () => {
+      useFleetArmingStore.getState().armIds(["a", "b"]);
+    });
+    expect(screen.queryByText("Delete 'My fleet'?")).toBeNull();
+  });
 });

--- a/src/components/Fleet/__tests__/FleetArmingRibbon.test.tsx
+++ b/src/components/Fleet/__tests__/FleetArmingRibbon.test.tsx
@@ -1139,9 +1139,7 @@ describe("FleetArmingRibbon — saved fleet delete confirm (#8023)", () => {
     });
 
     // No immediate dispatch — the confirm must gate the deletion.
-    expect(
-      dispatchSpy.mock.calls.some((c) => c[0] === "fleet.deleteNamedFleet")
-    ).toBe(false);
+    expect(dispatchSpy.mock.calls.some((c) => c[0] === "fleet.deleteNamedFleet")).toBe(false);
     expect(screen.getByText("Delete 'My fleet'?")).toBeTruthy();
 
     dispatchSpy.mockRestore();
@@ -1188,9 +1186,7 @@ describe("FleetArmingRibbon — saved fleet delete confirm (#8023)", () => {
       fireEvent.click(screen.getByRole("button", { name: "Cancel" }));
     });
 
-    expect(
-      dispatchSpy.mock.calls.some((c) => c[0] === "fleet.deleteNamedFleet")
-    ).toBe(false);
+    expect(dispatchSpy.mock.calls.some((c) => c[0] === "fleet.deleteNamedFleet")).toBe(false);
     expect(screen.queryByText("Delete 'My fleet'?")).toBeNull();
 
     dispatchSpy.mockRestore();

--- a/src/components/Fleet/__tests__/FleetArmingRibbon.test.tsx
+++ b/src/components/Fleet/__tests__/FleetArmingRibbon.test.tsx
@@ -26,6 +26,16 @@ vi.mock("@/hooks/useWorktreeColorMap", () => ({
   useWorktreeColorMap: () => null,
 }));
 
+// ConfirmDialog (via AppDialog/Radix) observes layout; jsdom lacks this.
+vi.stubGlobal(
+  "ResizeObserver",
+  class {
+    observe() {}
+    unobserve() {}
+    disconnect() {}
+  }
+);
+
 vi.mock("@/components/ui/dropdown-menu", () => ({
   DropdownMenu: ({ children }: { children: React.ReactNode }) => <>{children}</>,
   DropdownMenuTrigger: ({ children }: { children: React.ReactNode; asChild?: boolean }) => (
@@ -68,6 +78,8 @@ import { useFleetBroadcastConfirmStore } from "@/store/fleetBroadcastConfirmStor
 import { useFleetBroadcastProgressStore } from "@/store/fleetBroadcastProgressStore";
 import { useFleetPickerSessionStore } from "@/store/fleetPickerSessionStore";
 import { usePanelStore } from "@/store/panelStore";
+import { useProjectSettingsStore } from "@/store/projectSettingsStore";
+import type { ProjectSettings } from "@shared/types/project";
 import { useWorktreeSelectionStore } from "@/store/worktreeStore";
 import { useWorktreeFilterStore } from "@/store/worktreeFilterStore";
 import { useAnnouncerStore } from "@/store/accessibilityAnnouncerStore";
@@ -1098,5 +1110,65 @@ describe("FleetArmingRibbon", () => {
       });
       expect(screen.queryByTestId("fleet-picker-add-root")).toBeNull();
     });
+  });
+});
+
+describe("FleetArmingRibbon — saved fleet delete confirm (#8023)", () => {
+  beforeEach(() => {
+    resetStores();
+    useProjectSettingsStore.setState({
+      settings: {
+        runCommands: [],
+        fleetSavedScopes: [
+          { kind: "snapshot", id: "fs-1", name: "My fleet", terminalIds: [], createdAt: 1 },
+        ],
+      } as ProjectSettings,
+    });
+  });
+
+  it("trash button opens a confirm dialog instead of deleting immediately", async () => {
+    const actionServiceModule = await import("@/services/ActionService");
+    const dispatchSpy = vi.spyOn(actionServiceModule.actionService, "dispatch");
+
+    useFleetArmingStore.getState().armIds(["a", "b"]);
+    render(<FleetArmingRibbon />);
+
+    const trash = screen.getByTestId("fleet-saved-row-delete");
+    await act(async () => {
+      fireEvent.click(trash);
+    });
+
+    // No immediate dispatch — the confirm must gate the deletion.
+    expect(
+      dispatchSpy.mock.calls.some((c) => c[0] === "fleet.deleteNamedFleet")
+    ).toBe(false);
+    expect(screen.getByText("Delete 'My fleet'?")).toBeTruthy();
+
+    dispatchSpy.mockRestore();
+  });
+
+  it("confirming the dialog dispatches fleet.deleteNamedFleet with the scope id", async () => {
+    const actionServiceModule = await import("@/services/ActionService");
+    const dispatchSpy = vi.spyOn(actionServiceModule.actionService, "dispatch");
+
+    useFleetArmingStore.getState().armIds(["a", "b"]);
+    render(<FleetArmingRibbon />);
+
+    await act(async () => {
+      fireEvent.click(screen.getByTestId("fleet-saved-row-delete"));
+    });
+
+    const confirmBtn = screen.getByRole("button", { name: "Delete fleet" });
+    await act(async () => {
+      fireEvent.click(confirmBtn);
+    });
+
+    expect(dispatchSpy).toHaveBeenCalledWith(
+      "fleet.deleteNamedFleet",
+      { id: "fs-1" },
+      { source: "user" }
+    );
+
+    dispatchSpy.mockRestore();
   });
 });

--- a/src/components/Settings/PortalSettingsTab.tsx
+++ b/src/components/Settings/PortalSettingsTab.tsx
@@ -5,6 +5,7 @@ import { usePortalStore } from "@/store/portalStore";
 import { getAgentConfig, isRegisteredAgent } from "@/config/agents";
 import { BrandMark } from "@/components/icons";
 import { actionService } from "@/services/ActionService";
+import { ConfirmDialog } from "@/components/ui/ConfirmDialog";
 import { SettingsSection } from "./SettingsSection";
 import { SettingsSelect } from "./SettingsSelect";
 import { SettingsSwitch } from "./SettingsSwitch";
@@ -64,6 +65,7 @@ export function PortalSettingsTab() {
   const [showCustomUrlInput, setShowCustomUrlInput] = useState(false);
   const [customDefaultUrl, setCustomDefaultUrl] = useState("");
   const [customUrlError, setCustomUrlError] = useState("");
+  const [pendingRemoveId, setPendingRemoveId] = useState<string | null>(null);
   const customUrlErrorId = useId();
   const addLinkErrorId = useId();
 
@@ -287,13 +289,7 @@ export function PortalSettingsTab() {
           />
           {allowDelete && (
             <button
-              onClick={() =>
-                void actionService.dispatch(
-                  "portal.links.remove",
-                  { id: link.id },
-                  { source: "user" }
-                )
-              }
+              onClick={() => setPendingRemoveId(link.id)}
               disabled={link.alwaysEnabled}
               className="p-1.5 rounded hover:bg-daintree-border/50 text-daintree-text/50 hover:text-status-error disabled:opacity-50 disabled:cursor-not-allowed disabled:pointer-events-none"
             >
@@ -305,8 +301,29 @@ export function PortalSettingsTab() {
     );
   };
 
+  const pendingRemoveLink = links.find((l) => l.id === pendingRemoveId) ?? null;
+
   return (
     <div className="space-y-6">
+      <ConfirmDialog
+        isOpen={pendingRemoveId !== null}
+        variant="destructive"
+        title={`Remove '${pendingRemoveLink?.title || "this link"}'?`}
+        description="This removes the link from your portal tab bar. You can add it back later."
+        confirmLabel="Remove link"
+        onConfirm={() => {
+          if (pendingRemoveId !== null) {
+            void actionService.dispatch(
+              "portal.links.remove",
+              { id: pendingRemoveId },
+              { source: "user" }
+            );
+          }
+          setPendingRemoveId(null);
+        }}
+        onClose={() => setPendingRemoveId(null)}
+      />
+
       <SettingsSection
         icon={PanelRight}
         title="Default new tab agent"

--- a/src/components/Worktree/WorktreeCard.tsx
+++ b/src/components/Worktree/WorktreeCard.tsx
@@ -305,6 +305,10 @@ export function WorktreeCard({
   const hasPauseCommand = !!worktree.hasPauseCommand;
   const hasResumeCommand = !!worktree.hasResumeCommand;
   const hasTeardownCommand = !!worktree.hasTeardownCommand;
+  const teardownCommands =
+    worktree.worktreeMode && worktree.worktreeMode !== "local"
+      ? (resourceEnvironments?.[worktree.worktreeMode]?.teardown ?? [])
+      : [];
   const hasStatusCommand = !!worktree.hasStatusCommand;
   const hasProvisionCommand = !!worktree.hasProvisionCommand;
 
@@ -323,9 +327,11 @@ export function WorktreeCard({
     handleSelectWorkingAgents,
     handleCloseAll,
     handleTerminateAll,
+    handleResourceTeardown,
   } = useWorktreeActions({
     worktree,
     onCopyTree,
+    teardownCommands,
   });
 
   const handleOpenIssuePortal = () => {
@@ -397,14 +403,6 @@ export function WorktreeCard({
   const handleResourceProvision = () => {
     void actionService.dispatch(
       "worktree.resource.provision",
-      { worktreeId: worktree.id },
-      { source: "context-menu" }
-    );
-  };
-
-  const handleResourceTeardown = () => {
-    void actionService.dispatch(
-      "worktree.resource.teardown",
       { worktreeId: worktree.id },
       { source: "context-menu" }
     );

--- a/src/components/Worktree/WorktreeCard/WorktreeDialogs.tsx
+++ b/src/components/Worktree/WorktreeCard/WorktreeDialogs.tsx
@@ -52,7 +52,9 @@ export function WorktreeDialogs({
         variant={confirmDialog.isOpen ? confirmDialog.variant : "default"}
         onConfirm={confirmDialog.isOpen ? confirmDialog.onConfirm : () => {}}
         onClose={onCloseConfirm}
-      />
+      >
+        {confirmDialog.isOpen ? confirmDialog.children : undefined}
+      </ConfirmDialog>
 
       <WorktreeDeleteDialog
         isOpen={showDeleteDialog}

--- a/src/components/Worktree/WorktreeCard/hooks/useWorktreeActions.ts
+++ b/src/components/Worktree/WorktreeCard/hooks/useWorktreeActions.ts
@@ -1,4 +1,4 @@
-import { useCallback, useState } from "react";
+import { createElement, useCallback, useState, type ReactNode } from "react";
 import type { WorktreeState } from "@/types";
 import { logError } from "@/utils/logger";
 import { actionService } from "@/services/ActionService";
@@ -15,6 +15,7 @@ export type ConfirmDialogState =
       confirmLabel: string;
       variant: "default" | "destructive" | "info";
       onConfirm: () => void;
+      children?: ReactNode;
     };
 
 export interface UseWorktreeActionsResult {
@@ -38,14 +39,17 @@ export interface UseWorktreeActionsResult {
   handleSelectWorkingAgents: () => void;
   handleCloseAll: () => void;
   handleTerminateAll: () => void;
+  handleResourceTeardown: () => void;
 }
 
 export function useWorktreeActions({
   worktree,
   onCopyTree,
+  teardownCommands,
 }: {
   worktree: WorktreeState;
   onCopyTree: () => Promise<string | undefined> | void;
+  teardownCommands: string[];
 }): UseWorktreeActionsResult {
   const runRecipe = useRecipeStore((state) => state.runRecipe);
 
@@ -147,6 +151,54 @@ export function useWorktreeActions({
     });
   }, [worktree.id, worktree.issueTitle, worktree.branch]);
 
+  const handleResourceTeardown = useCallback(() => {
+    const label = worktree.issueTitle ?? worktree.branch ?? worktree.name;
+    const hasCommands = teardownCommands.length > 0;
+    const preview = createElement(
+      "div",
+      { className: "space-y-1.5" },
+      createElement(
+        "span",
+        {
+          className:
+            "text-[11px] font-semibold uppercase tracking-wider text-daintree-text/60",
+        },
+        hasCommands ? "Commands that will run" : "Teardown commands"
+      ),
+      createElement(
+        "pre",
+        {
+          className:
+            "text-xs text-daintree-text/80 bg-daintree-bg/50 p-3 rounded border border-daintree-border font-mono whitespace-pre-wrap break-all",
+        },
+        hasCommands ? teardownCommands.join("\n") : "No teardown commands found."
+      )
+    );
+    setConfirmDialog({
+      isOpen: true,
+      title: `Teardown resource for '${label}'?`,
+      description:
+        "This runs the project's resource-teardown commands for this worktree. Tearing down a remote or shared environment may require manual steps to recreate.",
+      confirmLabel: "Teardown resource",
+      variant: "destructive",
+      children: preview,
+      onConfirm: () => {
+        void actionService.dispatch(
+          "worktree.resource.teardown",
+          { worktreeId: worktree.id },
+          { source: "context-menu" }
+        );
+        setConfirmDialog({ isOpen: false });
+      },
+    });
+  }, [
+    worktree.id,
+    worktree.issueTitle,
+    worktree.branch,
+    worktree.name,
+    teardownCommands,
+  ]);
+
   const handleCopyTree = useCallback(async () => {
     await onCopyTree();
   }, [onCopyTree]);
@@ -164,6 +216,7 @@ export function useWorktreeActions({
     handleMaximizeAll,
     handleCloseAll,
     handleTerminateAll,
+    handleResourceTeardown,
     handleSelectAllAgents,
     handleSelectWaitingAgents,
     handleSelectWorkingAgents,

--- a/src/components/Worktree/WorktreeCard/hooks/useWorktreeActions.ts
+++ b/src/components/Worktree/WorktreeCard/hooks/useWorktreeActions.ts
@@ -160,8 +160,7 @@ export function useWorktreeActions({
       createElement(
         "span",
         {
-          className:
-            "text-[11px] font-semibold uppercase tracking-wider text-daintree-text/60",
+          className: "text-[11px] font-semibold uppercase tracking-wider text-daintree-text/60",
         },
         hasCommands ? "Commands that will run" : "Teardown commands"
       ),
@@ -191,13 +190,7 @@ export function useWorktreeActions({
         setConfirmDialog({ isOpen: false });
       },
     });
-  }, [
-    worktree.id,
-    worktree.issueTitle,
-    worktree.branch,
-    worktree.name,
-    teardownCommands,
-  ]);
+  }, [worktree.id, worktree.issueTitle, worktree.branch, worktree.name, teardownCommands]);
 
   const handleCopyTree = useCallback(async () => {
     await onCopyTree();

--- a/src/components/Worktree/WorktreeDeleteDialog.tsx
+++ b/src/components/Worktree/WorktreeDeleteDialog.tsx
@@ -44,7 +44,12 @@ export function WorktreeDeleteDialog({ isOpen, onClose, worktree }: WorktreeDele
     !isProtectedBranch && !isDetachedHead && worktree.isMainWorktree === false;
 
   const confirmTarget = worktree.branch || worktree.name;
-  const isHighTier = force && (isProtectedBranch || worktree.isMainWorktree === true);
+  const highTierPreamble =
+    isProtectedBranch || worktree.isMainWorktree === true
+      ? "Force-deleting this protected worktree is irreversible."
+      : "Force-deleting this worktree discards uncommitted tracked changes — this is irreversible.";
+  const isHighTier =
+    force && (isProtectedBranch || worktree.isMainWorktree === true || hasTrackedChanges);
   const isConfirmMatched = confirmInput === confirmTarget;
   const canSubmit = !isDeleting && (!isHighTier || isConfirmMatched);
 
@@ -278,7 +283,7 @@ export function WorktreeDeleteDialog({ isOpen, onClose, worktree }: WorktreeDele
                 value={confirmInput}
                 onChange={setConfirmInput}
                 onMatchSubmit={() => void handleDelete()}
-                preamble="Force-deleting this protected worktree is irreversible."
+                preamble={highTierPreamble}
                 data-testid="delete-worktree-confirm-input"
               />
             )}

--- a/src/components/Worktree/__tests__/WorktreeDeleteDialog.test.tsx
+++ b/src/components/Worktree/__tests__/WorktreeDeleteDialog.test.tsx
@@ -426,8 +426,11 @@ describe("WorktreeDeleteDialog — medium tier (no name confirmation)", () => {
     cleanup();
   });
 
-  it("non-protected branch + force does not require name confirmation", () => {
-    const worktree = makeWorktree(makeChanges([{ path: "src/app.ts", status: "modified" }]));
+  it("non-protected branch + force with only untracked files does not require name confirmation", () => {
+    // Untracked-only force-delete loses no committed/tracked work, so it stays
+    // medium tier — escalating here would train users to dismiss the gate
+    // (#4927: escalate on hasTrackedChanges, not hasChanges).
+    const worktree = makeWorktree(makeChanges([{ path: "new.txt", status: "untracked" }]));
     render(<WorktreeDeleteDialog isOpen={true} onClose={vi.fn()} worktree={worktree} />);
 
     const forceCheckbox = screen.getByRole("checkbox", { name: /force delete/i });
@@ -499,6 +502,29 @@ describe("WorktreeDeleteDialog — high tier (name confirmation)", () => {
     const button = screen.getByTestId("delete-worktree-confirm") as HTMLButtonElement;
     expect(button.textContent).toBe("Delete worktree");
     expect(button.disabled).toBe(true);
+  });
+
+  it("renders type-to-confirm input when force-deleting with uncommitted tracked changes", () => {
+    // #8023: force-delete + tracked changes is catastrophic enough (loses
+    // uncommitted work git can't recover) to warrant the typed-name gate
+    // even on a non-protected, non-main worktree.
+    const worktree = makeWorktree(makeChanges([{ path: "src/app.ts", status: "modified" }]), {
+      branch: "feature/x",
+      name: "feature/x",
+    });
+    render(<WorktreeDeleteDialog isOpen={true} onClose={vi.fn()} worktree={worktree} />);
+
+    expect(screen.queryByTestId("delete-worktree-confirm-input")).toBeNull();
+
+    fireEvent.click(screen.getByRole("checkbox", { name: /force delete/i }));
+
+    expect(screen.getByTestId("delete-worktree-confirm-input")).toBeDefined();
+    const button = screen.getByTestId("delete-worktree-confirm") as HTMLButtonElement;
+    expect(button.disabled).toBe(true);
+
+    const input = screen.getByTestId("delete-worktree-confirm-input") as HTMLInputElement;
+    fireEvent.change(input, { target: { value: "feature/x" } });
+    expect(button.disabled).toBe(false);
   });
 
   it("renders type-to-confirm input when force-deleting the main worktree", () => {

--- a/src/services/actions/__tests__/actionDefinitions.quality.test.ts
+++ b/src/services/actions/__tests__/actionDefinitions.quality.test.ts
@@ -1,4 +1,8 @@
 import { describe, it, expect } from "vitest";
+import { createStore } from "zustand/vanilla";
+import { setCurrentViewStore } from "@/store/createWorktreeStore";
+import type { WorktreeViewStore, WorktreeViewStoreApi } from "@/store/createWorktreeStore";
+import type { WorktreeSnapshot } from "@shared/types";
 import { KEY_ACTION_VALUES } from "@shared/types/keymap";
 import { BUILT_IN_ACTION_IDS } from "@shared/config/actionIds";
 import type { ActionId } from "@shared/types/actions";
@@ -238,6 +242,9 @@ const EXPECTED_CONFIRM_DANGER: ReadonlyArray<ActionId> = [
   "fleet.kill",
   "fleet.trash",
   "fleet.restart",
+  "fleet.deleteNamedFleet",
+  "worktree.resource.teardown",
+  "portal.links.remove",
 ];
 
 describe("destructive-action danger metadata", () => {
@@ -274,14 +281,47 @@ describe("destructive-action danger metadata", () => {
       if (factory) service.register(factory());
     }
 
-    // Many destructive actions require a `worktreeId` arg; arg validation runs
-    // before the confirm gate, so undefined args would short-circuit with
-    // VALIDATION_ERROR. Provide a placeholder so the danger gate is what fires.
-    const placeholderArgs = { worktreeId: "wt-placeholder" };
+    // Many destructive actions require a `worktreeId` or `id` arg; arg
+    // validation runs before the confirm gate, so undefined args would
+    // short-circuit with VALIDATION_ERROR. Provide both placeholder keys —
+    // zod object schemas strip unknown keys, so the irrelevant one is a no-op.
+    const placeholderArgs = { worktreeId: "wt-placeholder", id: "id-placeholder" };
+
+    // Some listed actions (e.g. worktree.resource.teardown) gate availability
+    // via `isEnabled`, which runs *before* the confirm gate. Without a view
+    // store its predicate throws → DISABLED, masking the confirm gate we want
+    // to assert. Seed a placeholder worktree that satisfies those predicates
+    // and pass the matching context so the danger gate is what fires.
+    const viewStore: WorktreeViewStoreApi = createStore<WorktreeViewStore>(() => ({
+      worktrees: new Map<string, WorktreeSnapshot>([
+        ["wt-placeholder", { id: "wt-placeholder", hasTeardownCommand: true } as WorktreeSnapshot],
+      ]),
+      version: 1,
+      isLoading: false,
+      error: null,
+      isInitialized: true,
+      isReconnecting: false,
+      nextVersion: () => 1,
+      applySnapshot: () => {},
+      applyUpdate: () => {},
+      applyRemove: () => {},
+      setLoading: () => {},
+      setError: () => {},
+      setFatalError: () => {},
+      setReconnecting: () => {},
+    }));
+    setCurrentViewStore(viewStore);
+    const contextOverride = {
+      activeWorktreeId: "wt-placeholder",
+      focusedWorktreeId: "wt-placeholder",
+    };
 
     const failures: string[] = [];
     for (const id of EXPECTED_CONFIRM_DANGER) {
-      const result = await service.dispatch(id, placeholderArgs, { source: "agent" });
+      const result = await service.dispatch(id, placeholderArgs, {
+        source: "agent",
+        contextOverride,
+      });
       if (result.ok) {
         failures.push(`${id} (agent dispatch succeeded without confirmed:true)`);
         continue;

--- a/src/services/actions/definitions/__tests__/worktreeResourceActions.test.ts
+++ b/src/services/actions/definitions/__tests__/worktreeResourceActions.test.ts
@@ -71,7 +71,7 @@ describe("worktree resource action definitions", () => {
 
   it.each([
     ["worktree.resource.provision", "safe"],
-    ["worktree.resource.teardown", "safe"],
+    ["worktree.resource.teardown", "confirm"],
     ["worktree.resource.resume", "safe"],
     ["worktree.resource.pause", "safe"],
     ["worktree.resource.status", "safe"],

--- a/src/services/actions/definitions/fleetActions.ts
+++ b/src/services/actions/definitions/fleetActions.ts
@@ -459,7 +459,7 @@ export function registerFleetActions(actions: ActionRegistry): void {
     description: "Remove a saved fleet by id. Idempotent — unknown ids are silently ignored.",
     category: "terminal",
     kind: "command",
-    danger: "safe",
+    danger: "confirm",
     scope: "renderer",
     argsSchema: idArgSchema,
     run: async (args: unknown) => {

--- a/src/services/actions/definitions/portalActions.ts
+++ b/src/services/actions/definitions/portalActions.ts
@@ -82,7 +82,7 @@ export function registerPortalActions(actions: ActionRegistry, _callbacks: Actio
     description: "Remove a portal link by ID",
     category: "portal",
     kind: "command",
-    danger: "safe",
+    danger: "confirm",
     scope: "renderer",
     argsSchema: z.object({ id: z.string() }),
     run: async (args: unknown) => {

--- a/src/services/actions/definitions/worktreeResourceActions.ts
+++ b/src/services/actions/definitions/worktreeResourceActions.ts
@@ -76,7 +76,7 @@ export function registerWorktreeResourceActions(
       description: "Run resource teardown commands for a worktree",
       category: "worktree",
       kind: "command",
-      danger: "safe",
+      danger: "confirm",
       scope: "renderer",
       argsSchema: z.object({ worktreeId: z.string().optional() }).optional(),
       isEnabled: (ctx: ActionContext) => {


### PR DESCRIPTION
## Summary

- Wired confirm dialogs for three actions that were classified `danger: "safe"` but required a gate: `worktree.resource.teardown` (D2 with teardown-command preview), `portal.links.remove` (D1 in `PortalSettingsTab`), and `fleet.deleteNamedFleet` (D1 hoisted out of the Radix dropdown tree into `FleetArmingRibbon` with controlled state + cleanup so confirm can't go stale)
- `WorktreeDeleteDialog` typed-name escalation now also fires on force-delete with tracked changes, using `hasTrackedChanges` not `hasChanges` per #4927
- Promoted `danger: "safe"` to `"confirm"` for all three actions; refreshed TBD rows in the destructive-action audit doc

Resolves #8023

## Changes

- `FleetArmingRibbon.tsx` — hoisted `fleet.deleteNamedFleet` confirm out of the Radix dropdown with controlled open state and `useEffect` cleanup
- `SavedFleetRow.tsx` / `SavedFleetsSection.tsx` — threading controlled dropdown props
- `PortalSettingsTab.tsx` — D1 `ConfirmDialog` for `portal.links.remove`
- `useWorktreeActions.ts` / `WorktreeCard.tsx` / `WorktreeDialogs.tsx` — D2 confirm for `worktree.resource.teardown` with teardown-command preview
- `WorktreeDeleteDialog.tsx` — typed-name escalation on `force && hasTrackedChanges`
- `fleetActions.ts`, `portalActions.ts`, `worktreeResourceActions.ts` — `danger` promoted to `"confirm"`
- `docs/architecture/destructive-action-safeguards.md` — TBD rows resolved
- Tests: `FleetArmingRibbon.test.tsx`, `WorktreeDeleteDialog.test.tsx`, `actionDefinitions.quality.test.ts`, `worktreeResourceActions.test.ts`

## Testing

179 unit tests pass. `tsc`, lint, format, channels, IPC, and help checks all clean.