### PR TITLE
feat(banners): converge banner family on shared InlineStatusBanner chrome

### DIFF
--- a/src/components/Recovery/CloudSyncBanner.tsx
+++ b/src/components/Recovery/CloudSyncBanner.tsx
@@ -1,4 +1,5 @@
 import { AlertTriangle } from "lucide-react";
+import { InlineStatusBanner } from "@/components/Terminal/InlineStatusBanner";
 import { useCloudSyncBannerStore } from "@/store/cloudSyncBannerStore";
 import { useProjectStore } from "@/store/projectStore";
 import { useProjectSettingsStore } from "@/store/projectSettingsStore";
@@ -46,25 +47,20 @@ export function CloudSyncBanner() {
   };
 
   return (
-    <div
+    <InlineStatusBanner
+      icon={AlertTriangle}
+      title="Project in a synced folder"
+      description={`This project is in a ${service}-synced folder, which can interfere with terminal operations and git. Consider moving it to a local folder.`}
+      severity="warning"
       role="status"
-      className="flex items-center gap-3 px-4 py-2 bg-[var(--color-status-warning)]/15 border-b border-[var(--color-status-warning)]/30 text-[var(--color-status-warning)] text-sm shrink-0"
-    >
-      <AlertTriangle className="w-4 h-4 shrink-0" aria-hidden="true" />
-      <div className="flex-1 flex flex-col gap-0.5">
-        <p className="font-medium">Project in a synced folder</p>
-        <p>
-          This project is in a {service}-synced folder, which can interfere with terminal operations
-          and git. Consider moving it to a local folder.
-        </p>
-      </div>
-      <button
-        type="button"
-        onClick={handleDismiss}
-        className="text-xs px-2 py-1 rounded border border-[var(--color-status-warning)]/30 hover:bg-[var(--color-status-warning)]/10 transition-colors shrink-0"
-      >
-        Don&rsquo;t warn for this project
-      </button>
-    </div>
+      actions={[
+        {
+          id: "dismiss",
+          label: "Don't warn for this project",
+          variant: "primary",
+          onClick: handleDismiss,
+        },
+      ]}
+    />
   );
 }

--- a/src/components/Recovery/GitHubTokenBanner.tsx
+++ b/src/components/Recovery/GitHubTokenBanner.tsx
@@ -1,5 +1,6 @@
 import { AlertTriangle } from "lucide-react";
 import { useGitHubTokenHealthStore } from "@/store/githubTokenHealthStore";
+import { InlineStatusBanner } from "@/components/Terminal/InlineStatusBanner";
 
 export function GitHubTokenBanner() {
   const isUnhealthy = useGitHubTokenHealthStore((s) => s.isUnhealthy);
@@ -13,22 +14,20 @@ export function GitHubTokenBanner() {
   };
 
   return (
-    <div
+    <InlineStatusBanner
+      icon={AlertTriangle}
+      title="GitHub token expired"
+      description="Reconnect to restore issue, PR, and repository data."
+      severity="warning"
       role="status"
-      className="flex items-center gap-3 px-4 py-2 bg-[var(--color-status-warning)]/15 border-b border-[var(--color-status-warning)]/30 text-[var(--color-status-warning)] text-sm shrink-0"
-    >
-      <AlertTriangle className="w-4 h-4 shrink-0" aria-hidden="true" />
-      <div className="flex-1 flex flex-col gap-0.5">
-        <p className="font-medium">GitHub token expired</p>
-        <p>Reconnect to restore issue, PR, and repository data.</p>
-      </div>
-      <button
-        type="button"
-        onClick={handleReconnect}
-        className="text-xs px-2 py-1 rounded border border-[var(--color-status-warning)]/30 hover:bg-[var(--color-status-warning)]/10 transition-colors shrink-0"
-      >
-        Reconnect to GitHub
-      </button>
-    </div>
+      actions={[
+        {
+          id: "reconnect",
+          label: "Reconnect to GitHub",
+          variant: "primary",
+          onClick: handleReconnect,
+        },
+      ]}
+    />
   );
 }

--- a/src/components/Recovery/HostCrashBanner.tsx
+++ b/src/components/Recovery/HostCrashBanner.tsx
@@ -1,11 +1,23 @@
-import { useState } from "react";
+import { useState, type CSSProperties } from "react";
 import { AlertTriangle, Loader2 } from "lucide-react";
 import type { CrashType } from "@shared/types/pty-host";
+import { cn } from "@/lib/utils";
 import { usePanelStore } from "@/store/panelStore";
 import { actionService } from "@/services/ActionService";
+import { InlineStatusBanner } from "@/components/Terminal/InlineStatusBanner";
 import { logError } from "@/utils/logger";
 import { useDeferredLoading } from "@/hooks/useDeferredLoading";
 import { UI_DOHERTY_THRESHOLD } from "@/lib/animationUtils";
+
+function SpinnerIcon({ className, style }: { className?: string; style?: CSSProperties }) {
+  return (
+    <Loader2
+      className={cn("animate-spin motion-reduce:animate-none", className)}
+      style={style}
+      aria-hidden="true"
+    />
+  );
+}
 
 interface CrashCopy {
   title: string;
@@ -55,16 +67,15 @@ export function HostCrashBanner() {
     if (!recoveringShown) return null;
 
     return (
-      <div
+      <InlineStatusBanner
+        icon={SpinnerIcon}
+        title="Terminal service restarting"
+        description="The terminal backend stopped and is restarting automatically."
+        severity="warning"
         role="alert"
-        className="flex items-start gap-3 px-4 py-2 bg-[var(--color-status-warning)]/10 border-b border-[var(--color-status-warning)]/25 text-[var(--color-status-warning)] text-sm shrink-0"
-      >
-        <Loader2 className="w-4 h-4 shrink-0 mt-0.5 animate-spin" aria-hidden="true" />
-        <div className="flex-1 flex flex-col gap-0.5">
-          <p className="font-medium">Terminal service restarting</p>
-          <p>The terminal backend stopped and is restarting automatically.</p>
-        </div>
-      </div>
+        animated={false}
+        actions={[]}
+      />
     );
   }
 
@@ -83,23 +94,22 @@ export function HostCrashBanner() {
   };
 
   return (
-    <div
+    <InlineStatusBanner
+      icon={AlertTriangle}
+      title={title}
+      description={body}
+      severity="error"
       role="alert"
-      className="flex items-start gap-3 px-4 py-2 bg-[var(--color-status-error)]/15 border-b border-[var(--color-status-error)]/30 text-[var(--color-status-error)] text-sm shrink-0"
-    >
-      <AlertTriangle className="w-4 h-4 shrink-0 mt-0.5" aria-hidden="true" />
-      <div className="flex-1 flex flex-col gap-0.5">
-        <p className="font-medium">{title}</p>
-        <p>{body}</p>
-      </div>
-      <button
-        type="button"
-        onClick={handleRestart}
-        disabled={isRestarting}
-        className="text-xs px-2 py-1 rounded border border-[var(--color-status-error)]/30 hover:bg-[var(--color-status-error)]/10 transition-colors shrink-0 disabled:opacity-50 disabled:cursor-not-allowed mt-0.5"
-      >
-        {isRestarting ? "Restarting…" : "Restart service"}
-      </button>
-    </div>
+      animated={false}
+      actions={[
+        {
+          id: "restart",
+          label: isRestarting ? "Restarting…" : "Restart service",
+          variant: "dangerFilled",
+          onClick: handleRestart,
+          disabled: isRestarting,
+        },
+      ]}
+    />
   );
 }

--- a/src/components/Recovery/RestoreConfirmationBanner.tsx
+++ b/src/components/Recovery/RestoreConfirmationBanner.tsx
@@ -1,6 +1,6 @@
-import { useEffect, useRef } from "react";
-import { AlertTriangle, X } from "lucide-react";
+import { AlertTriangle } from "lucide-react";
 import { useRestoreConfirmationStore } from "@/store/restoreConfirmationStore";
+import { InlineStatusBanner } from "@/components/Terminal/InlineStatusBanner";
 
 const AUTO_DISMISS_MS = 10_000;
 
@@ -8,44 +8,23 @@ export function RestoreConfirmationBanner() {
   const visible = useRestoreConfirmationStore((s) => s.visible);
   const suspectCount = useRestoreConfirmationStore((s) => s.suspectCount);
   const dismiss = useRestoreConfirmationStore((s) => s.dismiss);
-  const timerRef = useRef<ReturnType<typeof setTimeout> | null>(null);
-
-  useEffect(() => {
-    if (!visible || suspectCount > 0) return;
-
-    timerRef.current = setTimeout(() => {
-      dismiss();
-    }, AUTO_DISMISS_MS);
-
-    return () => {
-      if (timerRef.current !== null) {
-        clearTimeout(timerRef.current);
-        timerRef.current = null;
-      }
-    };
-  }, [visible, suspectCount, dismiss]);
 
   if (!visible) return null;
 
   return (
-    <div
-      role="status"
-      className="flex items-center gap-3 px-4 py-2 bg-[var(--color-status-warning)]/15 border-b border-[var(--color-status-warning)]/30 text-[var(--color-status-warning)] text-sm shrink-0"
-    >
-      <AlertTriangle className="w-4 h-4 shrink-0" aria-hidden="true" />
-      <span className="flex-1">
-        {suspectCount > 0
+    <InlineStatusBanner
+      icon={AlertTriangle}
+      title={
+        suspectCount > 0
           ? `Session recovered after unexpected exit — ${suspectCount} ${suspectCount === 1 ? "panel" : "panels"} created near the crash may be affected.`
-          : "Session recovered after unexpected exit."}
-      </span>
-      <button
-        type="button"
-        onClick={dismiss}
-        aria-label="Dismiss recovery confirmation"
-        className="p-1 rounded hover:bg-[var(--color-status-warning)]/10 transition-colors shrink-0"
-      >
-        <X className="w-3.5 h-3.5" aria-hidden="true" />
-      </button>
-    </div>
+          : "Session recovered after unexpected exit."
+      }
+      severity="warning"
+      role="status"
+      actions={[]}
+      onClose={dismiss}
+      closeAriaLabel="Dismiss recovery confirmation"
+      autoDismissAfter={suspectCount > 0 ? undefined : AUTO_DISMISS_MS}
+    />
   );
 }

--- a/src/components/Recovery/SafeModeBanner.tsx
+++ b/src/components/Recovery/SafeModeBanner.tsx
@@ -1,7 +1,8 @@
 import { useState } from "react";
-import { AlertTriangle, X } from "lucide-react";
+import { AlertTriangle } from "lucide-react";
 import { useSafeModeStore } from "@/store/safeModeStore";
 import { Popover, PopoverTrigger, PopoverContent } from "@/components/ui/popover";
+import { InlineStatusBanner } from "@/components/Terminal/InlineStatusBanner";
 import { logError } from "@/utils/logger";
 
 function formatRelativeTime(timestamp: number): string {
@@ -61,52 +62,48 @@ export function SafeModeBanner() {
     crashMetaText = `Last crash ${formatRelativeTime(crashTimestamp)}`;
   }
 
+  const detailsPopover = hasDetails ? (
+    <Popover>
+      <PopoverTrigger
+        type="button"
+        className="text-xs px-2 py-1 rounded border border-[var(--color-status-warning)]/30 hover:bg-[var(--color-status-warning)]/10 transition-colors shrink-0"
+      >
+        Show details
+      </PopoverTrigger>
+      <PopoverContent
+        align="end"
+        sideOffset={8}
+        className="p-3 text-xs max-w-xs space-y-2 text-daintree-text"
+      >
+        {crashMetaText && <p className="font-medium">{crashMetaText}</p>}
+        {skipped > 0 && (
+          <p className="text-daintree-text/70">
+            {skipped} {skipped === 1 ? "panel was" : "panels were"} skipped so you can recover the
+            app. Restart normally to reload them.
+          </p>
+        )}
+      </PopoverContent>
+    </Popover>
+  ) : undefined;
+
   return (
-    <div
+    <InlineStatusBanner
+      icon={AlertTriangle}
+      title="Safe mode — panels weren't restored"
+      severity="warning"
       role="status"
-      className="flex items-center gap-3 px-4 py-2 bg-[var(--color-status-warning)]/15 border-b border-[var(--color-status-warning)]/30 text-[var(--color-status-warning)] text-sm shrink-0"
-    >
-      <AlertTriangle className="w-4 h-4 shrink-0" aria-hidden="true" />
-      <span className="flex-1">Safe mode — panels weren't restored</span>
-      {hasDetails && (
-        <Popover>
-          <PopoverTrigger
-            type="button"
-            className="text-xs px-2 py-1 rounded border border-[var(--color-status-warning)]/30 hover:bg-[var(--color-status-warning)]/10 transition-colors shrink-0"
-          >
-            Show details
-          </PopoverTrigger>
-          <PopoverContent
-            align="end"
-            sideOffset={8}
-            className="p-3 text-xs max-w-xs space-y-2 text-daintree-text"
-          >
-            {crashMetaText && <p className="font-medium">{crashMetaText}</p>}
-            {skipped > 0 && (
-              <p className="text-daintree-text/70">
-                {skipped} {skipped === 1 ? "panel was" : "panels were"} skipped so you can recover
-                the app. Restart normally to reload them.
-              </p>
-            )}
-          </PopoverContent>
-        </Popover>
-      )}
-      <button
-        type="button"
-        onClick={handleRestart}
-        disabled={isRestarting}
-        className="text-xs px-2 py-1 rounded border border-[var(--color-status-warning)]/30 hover:bg-[var(--color-status-warning)]/10 transition-colors shrink-0 disabled:opacity-50 disabled:cursor-not-allowed"
-      >
-        {isRestarting ? "Restarting…" : "Restart normally"}
-      </button>
-      <button
-        type="button"
-        onClick={dismiss}
-        aria-label="Dismiss safe mode banner"
-        className="p-1 rounded hover:bg-[var(--color-status-warning)]/10 transition-colors shrink-0"
-      >
-        <X className="w-3.5 h-3.5" aria-hidden="true" />
-      </button>
-    </div>
+      trailingSlot={detailsPopover}
+      actions={[
+        {
+          id: "restart",
+          label: isRestarting ? "Restarting…" : "Restart normally",
+          variant: "primary",
+          onClick: handleRestart,
+          disabled: isRestarting,
+        },
+      ]}
+      onClose={dismiss}
+      closeAriaLabel="Dismiss safe mode banner"
+    />
   );
 }

--- a/src/components/Recovery/__tests__/CloudSyncBanner.test.tsx
+++ b/src/components/Recovery/__tests__/CloudSyncBanner.test.tsx
@@ -1,5 +1,5 @@
 // @vitest-environment jsdom
-import { describe, it, expect, beforeEach, vi } from "vitest";
+import { describe, it, expect, beforeAll, beforeEach, vi } from "vitest";
 import { render, screen, fireEvent, cleanup, waitFor } from "@testing-library/react";
 
 const saveSettingsMock = vi.fn(() => Promise.resolve());
@@ -24,6 +24,22 @@ function setProject(id: string | null) {
     currentProject: id ? ({ id, path: "/x" } as never) : null,
   });
 }
+
+beforeAll(() => {
+  Object.defineProperty(window, "matchMedia", {
+    writable: true,
+    value: vi.fn().mockImplementation((query: string) => ({
+      matches: false,
+      media: query,
+      onchange: null,
+      addListener: vi.fn(),
+      removeListener: vi.fn(),
+      addEventListener: vi.fn(),
+      removeEventListener: vi.fn(),
+      dispatchEvent: vi.fn(),
+    })),
+  });
+});
 
 describe("CloudSyncBanner", () => {
   beforeEach(() => {

--- a/src/components/Recovery/__tests__/GitHubTokenBanner.test.tsx
+++ b/src/components/Recovery/__tests__/GitHubTokenBanner.test.tsx
@@ -1,8 +1,24 @@
 // @vitest-environment jsdom
-import { describe, it, expect, beforeEach, vi } from "vitest";
+import { describe, it, expect, beforeAll, beforeEach, vi } from "vitest";
 import { render, screen, fireEvent, cleanup, act } from "@testing-library/react";
 import { GitHubTokenBanner } from "../GitHubTokenBanner";
 import { useGitHubTokenHealthStore } from "@/store/githubTokenHealthStore";
+
+beforeAll(() => {
+  Object.defineProperty(window, "matchMedia", {
+    writable: true,
+    value: vi.fn().mockImplementation((query: string) => ({
+      matches: false,
+      media: query,
+      onchange: null,
+      addListener: vi.fn(),
+      removeListener: vi.fn(),
+      addEventListener: vi.fn(),
+      removeEventListener: vi.fn(),
+      dispatchEvent: vi.fn(),
+    })),
+  });
+});
 
 describe("GitHubTokenBanner", () => {
   beforeEach(() => {

--- a/src/components/Recovery/__tests__/HostCrashBanner.test.tsx
+++ b/src/components/Recovery/__tests__/HostCrashBanner.test.tsx
@@ -1,5 +1,5 @@
 // @vitest-environment jsdom
-import { describe, it, expect, beforeEach, vi } from "vitest";
+import { describe, it, expect, beforeAll, beforeEach, vi } from "vitest";
 import { render, screen, fireEvent, cleanup, act } from "@testing-library/react";
 import type { CrashType } from "@shared/types/pty-host";
 
@@ -27,6 +27,22 @@ beforeEach(() => {
   mockedDispatch.mockResolvedValue({ ok: true, result: undefined } as never);
   usePanelStore.setState({ backendStatus: "connected", lastCrashType: null });
   cleanup();
+});
+
+beforeAll(() => {
+  Object.defineProperty(window, "matchMedia", {
+    writable: true,
+    value: vi.fn().mockImplementation((query: string) => ({
+      matches: false,
+      media: query,
+      onchange: null,
+      addListener: vi.fn(),
+      removeListener: vi.fn(),
+      addEventListener: vi.fn(),
+      removeEventListener: vi.fn(),
+      dispatchEvent: vi.fn(),
+    })),
+  });
 });
 
 describe("HostCrashBanner", () => {

--- a/src/components/Recovery/__tests__/RestoreConfirmationBanner.test.tsx
+++ b/src/components/Recovery/__tests__/RestoreConfirmationBanner.test.tsx
@@ -1,8 +1,24 @@
 // @vitest-environment jsdom
-import { describe, it, expect, beforeEach, vi, afterEach } from "vitest";
+import { describe, it, expect, beforeAll, beforeEach, vi, afterEach } from "vitest";
 import { render, screen, fireEvent, act } from "@testing-library/react";
 import { RestoreConfirmationBanner } from "../RestoreConfirmationBanner";
 import { useRestoreConfirmationStore } from "@/store/restoreConfirmationStore";
+
+beforeAll(() => {
+  Object.defineProperty(window, "matchMedia", {
+    writable: true,
+    value: vi.fn().mockImplementation((query: string) => ({
+      matches: false,
+      media: query,
+      onchange: null,
+      addListener: vi.fn(),
+      removeListener: vi.fn(),
+      addEventListener: vi.fn(),
+      removeEventListener: vi.fn(),
+      dispatchEvent: vi.fn(),
+    })),
+  });
+});
 
 beforeEach(() => {
   vi.useFakeTimers();

--- a/src/components/Recovery/__tests__/SafeModeBanner.test.tsx
+++ b/src/components/Recovery/__tests__/SafeModeBanner.test.tsx
@@ -1,10 +1,26 @@
 // @vitest-environment jsdom
-import { describe, it, expect, beforeEach, vi } from "vitest";
+import { describe, it, expect, beforeAll, beforeEach, vi } from "vitest";
 import { render, screen, fireEvent, cleanup, act } from "@testing-library/react";
 import { SafeModeBanner } from "../SafeModeBanner";
 import { useSafeModeStore } from "@/store/safeModeStore";
 
 const resetAndRelaunch = vi.fn();
+
+beforeAll(() => {
+  Object.defineProperty(window, "matchMedia", {
+    writable: true,
+    value: vi.fn().mockImplementation((query: string) => ({
+      matches: false,
+      media: query,
+      onchange: null,
+      addListener: vi.fn(),
+      removeListener: vi.fn(),
+      addEventListener: vi.fn(),
+      removeEventListener: vi.fn(),
+      dispatchEvent: vi.fn(),
+    })),
+  });
+});
 
 beforeEach(() => {
   resetAndRelaunch.mockReset();

--- a/src/components/Terminal/AgentCompletionBanner.tsx
+++ b/src/components/Terminal/AgentCompletionBanner.tsx
@@ -1,5 +1,5 @@
-import { FileEdit, X } from "lucide-react";
-import { cn } from "@/lib/utils";
+import { FileEdit } from "lucide-react";
+import { InlineStatusBanner } from "./InlineStatusBanner";
 
 export interface AgentCompletionBannerProps {
   /**
@@ -29,52 +29,21 @@ export function AgentCompletionBanner({
   className,
 }: AgentCompletionBannerProps) {
   return (
-    <div
-      className={cn(
-        "flex items-center justify-between gap-3 px-3 py-2 shrink-0",
-        "bg-overlay-subtle border-t border-divider",
-        className
-      )}
+    <InlineStatusBanner
+      icon={FileEdit}
+      title={formatBannerCopy(fileCount)}
+      severity="neutral"
       role="status"
-      aria-label="Agent completed with file changes"
-    >
-      <div className="flex items-center gap-2 min-w-0">
-        <FileEdit className="w-4 h-4 shrink-0 text-daintree-text/60" aria-hidden="true" />
-        <span className="text-sm text-daintree-text truncate">{formatBannerCopy(fileCount)}</span>
-      </div>
-
-      <div className="flex items-center gap-1 shrink-0">
-        <button
-          type="button"
-          onClick={(e) => {
-            e.stopPropagation();
-            onReview();
-          }}
-          className={cn(
-            "px-2 py-1 text-xs font-medium rounded",
-            "bg-daintree-border text-daintree-text hover:bg-daintree-border/80",
-            "transition-colors",
-            "outline-hidden focus-visible:outline focus-visible:outline-2 focus-visible:outline-offset-2 focus-visible:outline-daintree-accent"
-          )}
-        >
-          Review
-        </button>
-        <button
-          type="button"
-          onClick={(e) => {
-            e.stopPropagation();
-            onDismiss();
-          }}
-          aria-label="Dismiss"
-          className={cn(
-            "p-1 rounded text-daintree-text/60 hover:text-daintree-text hover:bg-daintree-border/50",
-            "transition-colors",
-            "outline-hidden focus-visible:outline focus-visible:outline-2 focus-visible:outline-offset-2 focus-visible:outline-daintree-accent"
-          )}
-        >
-          <X className="h-3.5 w-3.5" aria-hidden="true" />
-        </button>
-      </div>
-    </div>
+      className={className ? `border-t border-divider ${className}` : "border-t border-divider"}
+      actions={[
+        {
+          id: "review",
+          label: "Review",
+          variant: "primary",
+          onClick: onReview,
+        },
+      ]}
+      onClose={onDismiss}
+    />
   );
 }

--- a/src/components/Terminal/InlineStatusBanner.tsx
+++ b/src/components/Terminal/InlineStatusBanner.tsx
@@ -37,14 +37,15 @@ export interface InlineStatusBannerProps {
   closeAriaLabel?: string;
   /**
    * Non-button control rendered alongside the actions (e.g. a Popover
-   * trigger). Sits before the dismiss button so the reading order stays
-   * content → secondary control → primary actions → dismiss.
+   * trigger). Rendered first in the controls row, before the dismiss
+   * button and the primary action buttons.
    */
   trailingSlot?: React.ReactNode;
   /**
    * Interactive content rendered as a sibling after the description
    * paragraph. Use this instead of nesting buttons/links inside
-   * `description` (which would produce invalid `<p>` markup).
+   * `description` (which would produce invalid `<p>` markup). Passing
+   * this forces the multi-line layout even without a `description`.
    */
   descriptionExtras?: React.ReactNode;
   /**
@@ -120,11 +121,14 @@ export function InlineStatusBanner({
   const isNeutral = severity === "neutral";
   const colorVar = isNeutral ? undefined : SEVERITY_VAR[severity];
 
+  const onCloseRef = useRef(onClose);
+  onCloseRef.current = onClose;
+
   useEffect(() => {
-    if (!autoDismissAfter || !onClose) return;
-    const timer = setTimeout(onClose, autoDismissAfter);
+    if (!autoDismissAfter || !onCloseRef.current) return;
+    const timer = setTimeout(() => onCloseRef.current?.(), autoDismissAfter);
     return () => clearTimeout(timer);
-  }, [autoDismissAfter, onClose]);
+  }, [autoDismissAfter]);
 
   useEffect(() => {
     if (!shouldAnimate) return;
@@ -142,7 +146,7 @@ export function InlineStatusBanner({
     };
   }, [shouldAnimate]);
 
-  const hasDescription = description || contextLine;
+  const hasDescription = description || contextLine || descriptionExtras;
 
   return (
     <div

--- a/src/components/Terminal/InlineStatusBanner.tsx
+++ b/src/components/Terminal/InlineStatusBanner.tsx
@@ -19,7 +19,7 @@ export interface BannerAction {
   disabled?: boolean;
 }
 
-export type InlineStatusBannerSeverity = "error" | "warning" | "info" | "success";
+export type InlineStatusBannerSeverity = "error" | "warning" | "info" | "success" | "neutral";
 
 export interface InlineStatusBannerProps {
   icon: React.ComponentType<{ className?: string; style?: CSSProperties }>;
@@ -33,9 +33,29 @@ export interface InlineStatusBannerProps {
   role?: "alert" | "status";
   ariaLive?: "off" | "polite" | "assertive";
   onClose?: () => void;
+  /** Accessible label for the dismiss button. Defaults to "Dismiss". */
+  closeAriaLabel?: string;
+  /**
+   * Non-button control rendered alongside the actions (e.g. a Popover
+   * trigger). Sits before the dismiss button so the reading order stays
+   * content → secondary control → primary actions → dismiss.
+   */
+  trailingSlot?: React.ReactNode;
+  /**
+   * Interactive content rendered as a sibling after the description
+   * paragraph. Use this instead of nesting buttons/links inside
+   * `description` (which would produce invalid `<p>` markup).
+   */
+  descriptionExtras?: React.ReactNode;
+  /**
+   * Fire `onClose` automatically after this many milliseconds. The timer
+   * clears on unmount and resets if the value or `onClose` changes. Pass
+   * `undefined` to disable (callers gate their own conditions this way).
+   */
+  autoDismissAfter?: number;
 }
 
-const SEVERITY_VAR: Record<InlineStatusBannerSeverity, string> = {
+const SEVERITY_VAR: Record<Exclude<InlineStatusBannerSeverity, "neutral">, string> = {
   error: "--color-status-error",
   warning: "--color-status-warning",
   info: "--color-status-info",
@@ -86,6 +106,10 @@ export function InlineStatusBanner({
   role = "alert",
   ariaLive,
   onClose,
+  closeAriaLabel = "Dismiss",
+  trailingSlot,
+  descriptionExtras,
+  autoDismissAfter,
 }: InlineStatusBannerProps) {
   const prefersReducedMotion =
     typeof window !== "undefined" && window.matchMedia("(prefers-reduced-motion: reduce)").matches;
@@ -93,7 +117,14 @@ export function InlineStatusBanner({
 
   const [isVisible, setIsVisible] = useState(!shouldAnimate);
   const rafRef = useRef<number | null>(null);
-  const colorVar = SEVERITY_VAR[severity];
+  const isNeutral = severity === "neutral";
+  const colorVar = isNeutral ? undefined : SEVERITY_VAR[severity];
+
+  useEffect(() => {
+    if (!autoDismissAfter || !onClose) return;
+    const timer = setTimeout(onClose, autoDismissAfter);
+    return () => clearTimeout(timer);
+  }, [autoDismissAfter, onClose]);
 
   useEffect(() => {
     if (!shouldAnimate) return;
@@ -121,53 +152,81 @@ export function InlineStatusBanner({
           : "flex items-center justify-between gap-3 px-3 py-2 shrink-0",
         shouldAnimate && "transition duration-250",
         shouldAnimate && (isVisible ? "opacity-100 translate-y-0" : "opacity-0 -translate-y-2"),
+        isNeutral && "bg-overlay-subtle",
         className
       )}
-      style={{
-        backgroundColor: `color-mix(in oklab, var(${colorVar}) 10%, transparent)`,
-        borderBottom: `1px solid color-mix(in oklab, var(${colorVar}) 20%, transparent)`,
-      }}
+      style={
+        isNeutral
+          ? undefined
+          : {
+              backgroundColor: `color-mix(in oklab, var(${colorVar}) 10%, transparent)`,
+              borderBottom: `1px solid color-mix(in oklab, var(${colorVar}) 20%, transparent)`,
+            }
+      }
       role={role}
       aria-live={ariaLive}
       aria-atomic={ariaLive && ariaLive !== "off" ? "true" : undefined}
     >
       <div className={cn("flex", hasDescription ? "items-start" : "items-center", "gap-2 min-w-0")}>
         <IconComponent
-          className={cn("w-4 h-4 shrink-0", hasDescription && "mt-0.5")}
-          style={{ color: `var(${colorVar})` }}
+          className={cn(
+            "w-4 h-4 shrink-0",
+            hasDescription && "mt-0.5",
+            isNeutral && "text-daintree-text/60"
+          )}
+          style={isNeutral ? undefined : { color: `var(${colorVar})` }}
           aria-hidden="true"
         />
         {hasDescription ? (
           <div className="flex-1 min-w-0">
-            <span className="text-sm font-medium" style={{ color: `var(${colorVar})` }}>
+            <span
+              className={cn("text-sm font-medium", isNeutral && "text-daintree-text")}
+              style={isNeutral ? undefined : { color: `var(${colorVar})` }}
+            >
               {title}
             </span>
             {description && (
               <p
-                className="text-xs mt-0.5 break-words"
-                style={{ color: `color-mix(in oklab, var(${colorVar}) 80%, transparent)` }}
+                className={cn("text-xs mt-0.5 break-words", isNeutral && "text-daintree-text/70")}
+                style={
+                  isNeutral
+                    ? undefined
+                    : { color: `color-mix(in oklab, var(${colorVar}) 80%, transparent)` }
+                }
               >
                 {description}
               </p>
             )}
             {contextLine && (
               <p
-                className="text-xs font-mono mt-1 truncate"
-                style={{ color: `color-mix(in oklab, var(${colorVar}) 60%, transparent)` }}
+                className={cn(
+                  "text-xs font-mono mt-1 truncate",
+                  isNeutral && "text-daintree-text/60"
+                )}
+                style={
+                  isNeutral
+                    ? undefined
+                    : { color: `color-mix(in oklab, var(${colorVar}) 60%, transparent)` }
+                }
                 title={contextLine}
               >
                 {contextLine}
               </p>
             )}
+            {descriptionExtras}
           </div>
         ) : (
-          <span className="text-sm" style={{ color: `var(${colorVar})` }}>
+          <span
+            className={cn("text-sm", isNeutral && "text-daintree-text")}
+            style={isNeutral ? undefined : { color: `var(${colorVar})` }}
+          >
             {title}
           </span>
         )}
       </div>
 
       <div className={cn("flex items-center shrink-0", hasDescription ? "gap-2 ml-6" : "gap-1")}>
+        {trailingSlot}
         {onClose && (
           <button
             type="button"
@@ -175,8 +234,8 @@ export function InlineStatusBanner({
               e.stopPropagation();
               onClose();
             }}
-            aria-label="Dismiss"
-            className="p-1 rounded text-daintree-text/60 hover:text-daintree-text hover:bg-daintree-border/50 outline-hidden focus-visible:outline focus-visible:outline-2 focus-visible:outline-offset-2 focus-visible:outline-daintree-accent"
+            aria-label={closeAriaLabel}
+            className="p-1 rounded text-daintree-text/60 hover:text-daintree-text hover:bg-daintree-border/50 transition-colors outline-hidden focus-visible:outline focus-visible:outline-2 focus-visible:outline-offset-2 focus-visible:outline-daintree-accent"
           >
             <X className="h-3.5 w-3.5" aria-hidden="true" />
           </button>
@@ -184,7 +243,7 @@ export function InlineStatusBanner({
         {actions.map((action) => {
           const variant = action.variant ?? "primary";
           const variantClasses = getButtonClasses(variant);
-          const variantStyle = getButtonStyle(variant, colorVar);
+          const variantStyle = colorVar ? getButtonStyle(variant, colorVar) : undefined;
           const isDisabled = action.disabled || action.loading;
           const iconClasses = action.iconOnly ? "w-3.5 h-3.5" : "w-3 h-3";
           const spinnerSize = action.iconOnly ? "sm" : "xs";
@@ -201,7 +260,7 @@ export function InlineStatusBanner({
               }}
               className={cn(
                 action.iconOnly ? "p-1" : "flex items-center gap-1.5 px-2 py-1 text-xs font-medium",
-                "outline-hidden focus-visible:outline focus-visible:outline-2 focus-visible:outline-offset-2 focus-visible:outline-daintree-accent",
+                "transition-colors outline-hidden focus-visible:outline focus-visible:outline-2 focus-visible:outline-offset-2 focus-visible:outline-daintree-accent",
                 variantClasses,
                 (variant === "danger" || variant === "dangerFilled") &&
                   "hover:[color:var(--hover-color)] hover:[background:var(--hover-bg)]",

--- a/src/components/Terminal/TerminalCountWarning.tsx
+++ b/src/components/Terminal/TerminalCountWarning.tsx
@@ -1,10 +1,10 @@
 import { useState, useEffect, useCallback, useRef } from "react";
-import { X, AlertTriangle, Trash2 } from "lucide-react";
-import { cn } from "@/lib/utils";
+import { AlertTriangle, Trash2 } from "lucide-react";
 import { BANNER_ENTER_DURATION } from "@/lib/animationUtils";
 import { usePanelStore } from "@/store/panelStore";
 import { useShallow } from "zustand/react/shallow";
 import { usePanelLimitStore, shouldShowSoftWarning } from "@/store/panelLimitStore";
+import { InlineStatusBanner } from "./InlineStatusBanner";
 
 interface TerminalCountWarningProps {
   className?: string;
@@ -38,29 +38,10 @@ export function TerminalCountWarning({ className, onOpenBulkActions }: TerminalC
   }, [initializeFromHardware]);
 
   const [isDismissed, setIsDismissed] = useState(false);
-  const [isVisible, setIsVisible] = useState(false);
-  const rafRef = useRef<number | null>(null);
 
   const showWarning =
     !isDismissed &&
     shouldShowSoftWarning(activeCount, softLimit, warningsDisabled, lastDismissedAt);
-
-  useEffect(() => {
-    if (!showWarning) {
-      setIsVisible(false);
-      return;
-    }
-    rafRef.current = requestAnimationFrame(() => {
-      rafRef.current = null;
-      setIsVisible(true);
-    });
-    return () => {
-      if (rafRef.current !== null) {
-        cancelAnimationFrame(rafRef.current);
-        rafRef.current = null;
-      }
-    };
-  }, [showWarning]);
 
   useEffect(() => {
     if (
@@ -74,7 +55,6 @@ export function TerminalCountWarning({ className, onOpenBulkActions }: TerminalC
   const dismissTimeoutRef = useRef<ReturnType<typeof setTimeout> | null>(null);
 
   const handleDismiss = useCallback(() => {
-    setIsVisible(false);
     if (dismissTimeoutRef.current !== null) {
       clearTimeout(dismissTimeoutRef.current);
     }
@@ -116,58 +96,30 @@ export function TerminalCountWarning({ className, onOpenBulkActions }: TerminalC
   if (!showWarning) return null;
 
   return (
-    <div
-      className={cn(
-        "flex items-center justify-between gap-4 px-4 py-3 rounded-[var(--radius-lg)]",
-        "bg-[color-mix(in_oklab,var(--color-status-warning)_12%,transparent)]",
-        "border border-status-warning/30",
-        "transition duration-250",
-        isVisible ? "opacity-100 translate-y-0" : "opacity-0 -translate-y-2",
-        className
-      )}
+    <InlineStatusBanner
+      icon={AlertTriangle}
+      title={`${activeCount} panels open`}
+      description="Consider closing idle panels to keep the board light."
+      descriptionExtras={
+        completedCount > 0 ? (
+          <button
+            type="button"
+            onClick={handleCleanup}
+            className="mt-1 text-xs underline text-daintree-text/70 hover:text-daintree-text transition-colors inline-flex items-center gap-1 outline-hidden focus-visible:outline focus-visible:outline-2 focus-visible:outline-offset-2 focus-visible:outline-daintree-accent rounded-sm"
+          >
+            <Trash2 className="h-3 w-3" />
+            Close <span className="tabular-nums">{completedCount}</span> completed agent
+            {completedCount !== 1 ? "s" : ""}
+          </button>
+        ) : undefined
+      }
+      severity="warning"
       role="status"
-      aria-live="polite"
-      aria-atomic="true"
-    >
-      <div className="flex items-center gap-3">
-        <AlertTriangle className="h-5 w-5 text-status-warning shrink-0" />
-        <div>
-          <p className="text-sm font-medium tabular-nums text-status-warning">
-            {activeCount} panels open
-          </p>
-          <p className="text-xs text-daintree-text/70 mt-0.5">
-            Consider closing idle panels to keep the board light.
-            {completedCount > 0 && (
-              <>
-                {" "}
-                <button
-                  type="button"
-                  onClick={handleCleanup}
-                  className="underline hover:text-daintree-text transition-colors inline-flex items-center gap-1 outline-hidden focus-visible:outline focus-visible:outline-2 focus-visible:outline-offset-2 focus-visible:outline-daintree-accent rounded-sm"
-                >
-                  <Trash2 className="h-3 w-3" />
-                  Close <span className="tabular-nums">{completedCount}</span> completed agent
-                  {completedCount !== 1 ? "s" : ""}
-                </button>
-              </>
-            )}
-          </p>
-        </div>
-      </div>
-
-      <button
-        type="button"
-        onClick={handleDismiss}
-        className={cn(
-          "rounded-[var(--radius-sm)] p-1",
-          "text-status-warning/60 transition-colors",
-          "hover:text-status-warning hover:bg-status-warning/10",
-          "outline-hidden focus-visible:outline focus-visible:outline-2 focus-visible:outline-offset-2 focus-visible:outline-daintree-accent"
-        )}
-        aria-label="Dismiss warning"
-      >
-        <X className="h-4 w-4" />
-      </button>
-    </div>
+      ariaLive="polite"
+      className={className}
+      actions={[]}
+      onClose={handleDismiss}
+      closeAriaLabel="Dismiss warning"
+    />
   );
 }

--- a/src/components/Terminal/__tests__/AgentCompletionBanner.test.tsx
+++ b/src/components/Terminal/__tests__/AgentCompletionBanner.test.tsx
@@ -1,5 +1,5 @@
 // @vitest-environment jsdom
-import { describe, it, expect, vi } from "vitest";
+import { beforeAll, describe, it, expect, vi } from "vitest";
 import { render, screen, fireEvent } from "@testing-library/react";
 import { AgentCompletionBanner } from "../AgentCompletionBanner";
 
@@ -18,6 +18,22 @@ vi.mock("@/lib/utils", () => ({
     return out.join(" ");
   },
 }));
+
+beforeAll(() => {
+  Object.defineProperty(window, "matchMedia", {
+    writable: true,
+    value: vi.fn().mockImplementation((query: string) => ({
+      matches: false,
+      media: query,
+      onchange: null,
+      addListener: vi.fn(),
+      removeListener: vi.fn(),
+      addEventListener: vi.fn(),
+      removeEventListener: vi.fn(),
+      dispatchEvent: vi.fn(),
+    })),
+  });
+});
 
 describe("AgentCompletionBanner", () => {
   it("renders artifact-first copy with file count and plural noun", () => {

--- a/src/components/Terminal/__tests__/InlineStatusBanner.test.tsx
+++ b/src/components/Terminal/__tests__/InlineStatusBanner.test.tsx
@@ -1,7 +1,7 @@
 // @vitest-environment jsdom
 import { beforeAll, describe, expect, it, vi } from "vitest";
-import { render, screen } from "@testing-library/react";
-import { AlertTriangle, CheckCircle2, Info, XCircle } from "lucide-react";
+import { act, render, screen } from "@testing-library/react";
+import { AlertTriangle, CheckCircle2, FileEdit, Info, XCircle } from "lucide-react";
 import { InlineStatusBanner } from "../InlineStatusBanner";
 
 vi.mock("@/components/ui/tooltip", () => ({
@@ -109,6 +109,147 @@ describe("InlineStatusBanner", () => {
     );
     expect(screen.getByRole("status")).toBeTruthy();
     expect(screen.queryByRole("alert")).toBeNull();
+  });
+
+  it("renders neutral severity without leaking a status-color var into inline styles", () => {
+    const { container } = render(
+      <InlineStatusBanner
+        icon={FileEdit}
+        title="Files changed"
+        severity="neutral"
+        animated={false}
+        role="status"
+        actions={[]}
+      />
+    );
+    const root = container.firstElementChild as HTMLElement;
+    // No inline color-mix surface: neutral uses the overlay-subtle token class.
+    expect(root.style.backgroundColor).toBe("");
+    expect(root.style.borderBottom).toBe("");
+    expect(root.className).toContain("bg-overlay-subtle");
+    expect(root.outerHTML).not.toContain("var(undefined)");
+  });
+
+  it("renders trailingSlot before the dismiss button in DOM order", () => {
+    const onClose = vi.fn();
+    render(
+      <InlineStatusBanner
+        icon={Info}
+        title="With slot"
+        severity="info"
+        animated={false}
+        trailingSlot={<button type="button">Show details</button>}
+        actions={[]}
+        onClose={onClose}
+      />
+    );
+    const slot = screen.getByRole("button", { name: "Show details" });
+    const dismiss = screen.getByRole("button", { name: "Dismiss" });
+    expect(slot).toBeTruthy();
+    expect(slot.compareDocumentPosition(dismiss) & Node.DOCUMENT_POSITION_FOLLOWING).toBeTruthy();
+  });
+
+  it("renders descriptionExtras as a sibling, never inside the description paragraph", () => {
+    const { container } = render(
+      <InlineStatusBanner
+        icon={AlertTriangle}
+        title="Lots open"
+        description="Consider closing idle panels."
+        descriptionExtras={
+          <button type="button" className="extras-btn">
+            Close completed
+          </button>
+        }
+        severity="warning"
+        animated={false}
+        actions={[]}
+      />
+    );
+    const extras = container.querySelector(".extras-btn") as HTMLElement;
+    expect(extras).toBeTruthy();
+    expect(extras.closest("p")).toBeNull();
+  });
+
+  it("uses a custom closeAriaLabel for the dismiss button", () => {
+    render(
+      <InlineStatusBanner
+        icon={Info}
+        title="Custom"
+        severity="info"
+        animated={false}
+        actions={[]}
+        onClose={() => {}}
+        closeAriaLabel="Dismiss recovery confirmation"
+      />
+    );
+    expect(screen.getByRole("button", { name: "Dismiss recovery confirmation" })).toBeTruthy();
+  });
+
+  it("fires onClose after autoDismissAfter elapses and clears the timer on unmount", () => {
+    vi.useFakeTimers();
+    try {
+      const onClose = vi.fn();
+      const { unmount, rerender } = render(
+        <InlineStatusBanner
+          icon={Info}
+          title="Auto"
+          severity="info"
+          animated={false}
+          actions={[]}
+          onClose={onClose}
+          autoDismissAfter={10_000}
+        />
+      );
+      act(() => {
+        vi.advanceTimersByTime(9_999);
+      });
+      expect(onClose).not.toHaveBeenCalled();
+      act(() => {
+        vi.advanceTimersByTime(1);
+      });
+      expect(onClose).toHaveBeenCalledTimes(1);
+
+      // Re-mounting then unmounting must not fire onClose again.
+      rerender(
+        <InlineStatusBanner
+          icon={Info}
+          title="Auto"
+          severity="info"
+          animated={false}
+          actions={[]}
+          onClose={onClose}
+          autoDismissAfter={10_000}
+        />
+      );
+      unmount();
+      act(() => {
+        vi.advanceTimersByTime(20_000);
+      });
+      expect(onClose).toHaveBeenCalledTimes(1);
+    } finally {
+      vi.useRealTimers();
+    }
+  });
+
+  it("does not schedule an auto-dismiss when onClose is absent", () => {
+    vi.useFakeTimers();
+    try {
+      const setTimeoutSpy = vi.spyOn(globalThis, "setTimeout");
+      render(
+        <InlineStatusBanner
+          icon={Info}
+          title="No close"
+          severity="info"
+          animated={false}
+          actions={[]}
+          autoDismissAfter={5_000}
+        />
+      );
+      const scheduledAutoDismiss = setTimeoutSpy.mock.calls.some(([, delay]) => delay === 5_000);
+      expect(scheduledAutoDismiss).toBe(false);
+    } finally {
+      vi.useRealTimers();
+    }
   });
 
   it("uses the 250ms entrance duration class when animated", () => {

--- a/src/components/Terminal/__tests__/InlineStatusBanner.test.tsx
+++ b/src/components/Terminal/__tests__/InlineStatusBanner.test.tsx
@@ -1,4 +1,5 @@
 // @vitest-environment jsdom
+import { useEffect, useState } from "react";
 import { beforeAll, describe, expect, it, vi } from "vitest";
 import { act, render, screen } from "@testing-library/react";
 import { AlertTriangle, CheckCircle2, FileEdit, Info, XCircle } from "lucide-react";
@@ -168,6 +169,58 @@ describe("InlineStatusBanner", () => {
     const extras = container.querySelector(".extras-btn") as HTMLElement;
     expect(extras).toBeTruthy();
     expect(extras.closest("p")).toBeNull();
+  });
+
+  it("still renders descriptionExtras when no description or contextLine is set", () => {
+    const { container } = render(
+      <InlineStatusBanner
+        icon={AlertTriangle}
+        title="Title only"
+        descriptionExtras={
+          <button type="button" className="extras-only-btn">
+            Extra
+          </button>
+        }
+        severity="warning"
+        animated={false}
+        actions={[]}
+      />
+    );
+    const extras = container.querySelector(".extras-only-btn") as HTMLElement;
+    expect(extras).toBeTruthy();
+    expect(extras.closest("p")).toBeNull();
+  });
+
+  it("does not reset the auto-dismiss timer when onClose is an unstable reference", () => {
+    vi.useFakeTimers();
+    try {
+      const spy = vi.fn();
+      function Wrapper() {
+        const [, setTick] = useState(0);
+        useEffect(() => {
+          const id = setInterval(() => setTick((t) => t + 1), 100);
+          return () => clearInterval(id);
+        }, []);
+        return (
+          <InlineStatusBanner
+            icon={Info}
+            title="Unstable onClose"
+            severity="info"
+            animated={false}
+            actions={[]}
+            onClose={() => spy()}
+            autoDismissAfter={1_000}
+          />
+        );
+      }
+      render(<Wrapper />);
+      act(() => {
+        vi.advanceTimersByTime(2_000);
+      });
+      expect(spy).toHaveBeenCalledTimes(1);
+    } finally {
+      vi.useRealTimers();
+    }
   });
 
   it("uses a custom closeAriaLabel for the dismiss button", () => {


### PR DESCRIPTION
## Summary

- Seven banner components were sharing nearly identical chrome — this consolidates them onto `InlineStatusBanner` with five additive props rather than maintaining parallel implementations
- `InlineStatusBanner` gains `neutral` severity, `trailingSlot`, `descriptionExtras`, `autoDismissAfter`, and `closeAriaLabel`; chrome buttons also get `transition-colors` for a smoother hover
- `GridNotificationBar` is untouched — it's structurally different enough that convergence would be net-negative

Resolves #8026

## Changes

- `InlineStatusBanner` — five new props, `transition-colors` on chrome buttons
- Migrated: `AgentCompletionBanner`, `RestoreConfirmationBanner`, `GitHubTokenBanner`, `CloudSyncBanner`, `SafeModeBanner`, `TerminalCountWarning`, `HostCrashBanner`
- `InlineStatusBanner` test suite expanded to cover all new props and behaviour

## Testing

84 banner tests pass. `tsc`, lint, and format all clean.