### PR TITLE
feat(panel): add review as the fourth built-in panel kind

### DIFF
--- a/shared/config/panelKindRegistry.ts
+++ b/shared/config/panelKindRegistry.ts
@@ -9,7 +9,7 @@ import { PANEL_KIND_BRAND_COLORS } from "../theme/index.js";
  * built-in kind is a one-line change here — every guard and registry helper
  * derives from this array.
  */
-export const BUILT_IN_PANEL_KINDS = ["terminal", "browser", "dev-preview"] as const;
+export const BUILT_IN_PANEL_KINDS = ["terminal", "browser", "dev-preview", "review"] as const;
 
 /** Built-in panel kinds — derived from `BUILT_IN_PANEL_KINDS` */
 export type BuiltInPanelKind = (typeof BUILT_IN_PANEL_KINDS)[number];
@@ -99,6 +99,19 @@ const PANEL_KIND_REGISTRY: Record<string, PanelKindConfig> = {
     keepAliveOnProjectSwitch: true,
     showInPalette: true,
     searchAliases: ["localhost", "server", "preview", "port"],
+  },
+  review: {
+    id: "review",
+    name: "Review",
+    iconId: "git-pull-request",
+    color: PANEL_KIND_BRAND_COLORS.review,
+    hasPty: false,
+    canRestart: false,
+    canConvert: false,
+    usesTerminalUi: false,
+    keepAliveOnProjectSwitch: true,
+    showInPalette: true,
+    searchAliases: ["diff", "commit", "stage", "git"],
   },
 };
 

--- a/shared/theme/__tests__/runtimeDefaults.test.ts
+++ b/shared/theme/__tests__/runtimeDefaults.test.ts
@@ -135,7 +135,7 @@ describe("PANEL_KIND_BRAND_COLORS — agent vs dev-preview distinctness", () => 
     expect(PANEL_KIND_BRAND_COLORS["dev-preview"]).not.toBe("var(--theme-category-violet)");
   });
 
-  it("all four panel kinds have distinct colors", () => {
+  it("all panel kinds have distinct colors", () => {
     const values = Object.values(PANEL_KIND_BRAND_COLORS);
     expect(new Set(values).size).toBe(values.length);
   });

--- a/shared/theme/entityColors.ts
+++ b/shared/theme/entityColors.ts
@@ -3,6 +3,7 @@ export const PANEL_KIND_BRAND_COLORS = {
   agent: "var(--theme-accent-primary)",
   browser: "var(--theme-category-blue)",
   "dev-preview": "var(--theme-category-teal)",
+  review: "var(--theme-category-violet)",
 } as const;
 
 export const BRANCH_TYPE_COLOR_CLASSES = {

--- a/shared/types/addPanelOptions.ts
+++ b/shared/types/addPanelOptions.ts
@@ -152,6 +152,16 @@ export interface DevPreviewPanelOptions extends AddPanelOptionsBase {
 }
 
 /**
+ * Options for creating a review panel. Mounts the worktree's Review & Commit
+ * surface in a grid cell. Carries no kind-specific fields beyond the base:
+ * `worktreeId` from `AddPanelOptionsBase` is the sole binding, and the
+ * worktree path is resolved at render time from the worktree store.
+ */
+export interface ReviewPanelOptions extends AddPanelOptionsBase {
+  kind: "review";
+}
+
+/**
  * Options for extension-provided panel kinds.
  *
  * NOTE: intentionally excluded from the `AddPanelOptions` union below. Including
@@ -166,4 +176,8 @@ export interface ExtensionPanelOptions extends AddPanelOptionsBase {
 }
 
 /** Discriminated union of all built-in panel creation option types */
-export type AddPanelOptions = TerminalPanelOptions | BrowserPanelOptions | DevPreviewPanelOptions;
+export type AddPanelOptions =
+  | TerminalPanelOptions
+  | BrowserPanelOptions
+  | DevPreviewPanelOptions
+  | ReviewPanelOptions;

--- a/shared/types/panel.ts
+++ b/shared/types/panel.ts
@@ -417,7 +417,7 @@ export function isDevPreviewPanel(
 
 export function isReviewPanel(panel: PanelInstance | TerminalInstance): panel is ReviewPanelData {
   const kind = panel.kind ?? "terminal";
-  // eslint-disable-next-line no-restricted-syntax -- sanctioned panel-kind type guard
+
   return kind === "review";
 }
 

--- a/shared/types/panel.ts
+++ b/shared/types/panel.ts
@@ -382,7 +382,18 @@ export interface DevPreviewPanelData extends BasePanelData {
   devPreviewScrollPosition?: { url: string; scrollY: number };
 }
 
-export type PanelInstance = PtyPanelData | BrowserPanelData | DevPreviewPanelData;
+/**
+ * Review panel — mounts the worktree's Review & Commit surface inside a grid
+ * cell instead of (or in addition to) the modal `ReviewHub`. Carries no
+ * kind-specific persisted fields: `worktreeId` from `BasePanelData` is the
+ * sole binding, and the worktree path is resolved fresh from the worktree
+ * store at render time so renames or moves don't leave a stale reference.
+ */
+export interface ReviewPanelData extends BasePanelData {
+  kind: "review";
+}
+
+export type PanelInstance = PtyPanelData | BrowserPanelData | DevPreviewPanelData | ReviewPanelData;
 
 export function isPtyPanel(panel: PanelInstance | TerminalInstance): panel is PtyPanelData {
   const kind = panel.kind ?? "terminal";
@@ -402,6 +413,12 @@ export function isDevPreviewPanel(
   const kind = panel.kind ?? "terminal";
   // eslint-disable-next-line no-restricted-syntax -- sanctioned panel-kind type guard
   return kind === "dev-preview";
+}
+
+export function isReviewPanel(panel: PanelInstance | TerminalInstance): panel is ReviewPanelData {
+  const kind = panel.kind ?? "terminal";
+  // eslint-disable-next-line no-restricted-syntax -- sanctioned panel-kind type guard
+  return kind === "review";
 }
 
 /**

--- a/src/components/DragDrop/PlaceholderContent.tsx
+++ b/src/components/DragDrop/PlaceholderContent.tsx
@@ -24,6 +24,8 @@ export function PlaceholderContent({ kind, agentId, compact = false }: Placehold
       return <BrowserPlaceholder color={color} compact={compact} />;
     case "dev-preview":
       return <DevPreviewPlaceholder color={color} compact={compact} />;
+    case "review":
+      return <ReviewPlaceholder color={color} compact={compact} />;
     default:
       return <TerminalPlaceholder color={color} compact={compact} />;
   }
@@ -195,6 +197,93 @@ function BrowserPlaceholder({ color, compact }: PlaceholderProps) {
             style={{
               height: 5,
               width: "80%",
+              backgroundColor: `color-mix(in srgb, ${color} 8%, transparent)`,
+              borderRadius: "var(--radius-sm)",
+            }}
+          />
+        )}
+      </div>
+    </div>
+  );
+}
+
+/**
+ * Review placeholder: Two-column diff view (file list + diff hunks)
+ */
+function ReviewPlaceholder({ color, compact }: PlaceholderProps) {
+  const lineHeight = compact ? 4 : 5;
+
+  return (
+    <div style={{ display: "flex", gap: compact ? 4 : 6, width: "100%" }}>
+      {/* File list (narrower, left) */}
+      <div
+        style={{
+          width: "32%",
+          display: "flex",
+          flexDirection: "column",
+          gap: compact ? 3 : 4,
+        }}
+      >
+        <div
+          style={{
+            height: lineHeight,
+            width: "85%",
+            backgroundColor: `color-mix(in srgb, ${color} 12%, transparent)`,
+            borderRadius: "var(--radius-sm)",
+          }}
+        />
+        <div
+          style={{
+            height: lineHeight,
+            width: "70%",
+            backgroundColor: `color-mix(in srgb, ${color} 10%, transparent)`,
+            borderRadius: "var(--radius-sm)",
+          }}
+        />
+        {!compact && (
+          <div
+            style={{
+              height: lineHeight,
+              width: "60%",
+              backgroundColor: `color-mix(in srgb, ${color} 8%, transparent)`,
+              borderRadius: "var(--radius-sm)",
+            }}
+          />
+        )}
+      </div>
+      {/* Diff hunks (wider, right) */}
+      <div
+        style={{
+          flex: 1,
+          padding: compact ? 3 : 4,
+          backgroundColor: `color-mix(in srgb, ${color} 5%, transparent)`,
+          borderRadius: "var(--radius-sm)",
+          display: "flex",
+          flexDirection: "column",
+          gap: compact ? 2 : 3,
+        }}
+      >
+        <div
+          style={{
+            height: lineHeight,
+            width: "90%",
+            backgroundColor: `color-mix(in srgb, ${color} 10%, transparent)`,
+            borderRadius: "var(--radius-sm)",
+          }}
+        />
+        <div
+          style={{
+            height: lineHeight,
+            width: "75%",
+            backgroundColor: `color-mix(in srgb, ${color} 10%, transparent)`,
+            borderRadius: "var(--radius-sm)",
+          }}
+        />
+        {!compact && (
+          <div
+            style={{
+              height: lineHeight,
+              width: "65%",
               backgroundColor: `color-mix(in srgb, ${color} 8%, transparent)`,
               borderRadius: "var(--radius-sm)",
             }}

--- a/src/components/Panel/PanelHeader.tsx
+++ b/src/components/Panel/PanelHeader.tsx
@@ -364,6 +364,7 @@ function PanelHeaderComponent({
 
   const getAriaLabel = () => {
     if (kind === "browser") return "Edit browser title";
+    if (kind === "review") return "Edit review title";
     if (!chrome.isAgent && kind === "terminal") return "Edit terminal title";
     return "Edit agent title";
   };
@@ -372,9 +373,11 @@ function PanelHeaderComponent({
     const prefix =
       kind === "browser"
         ? "Browser title"
-        : !chrome.isAgent && kind === "terminal"
-          ? "Terminal title"
-          : "Agent title";
+        : kind === "review"
+          ? "Review title"
+          : !chrome.isAgent && kind === "terminal"
+            ? "Terminal title"
+            : "Agent title";
     return `${prefix}: ${title}. Press Enter or F2 to edit`;
   };
 

--- a/src/components/Recovery/CrashRecoveryDialog.tsx
+++ b/src/components/Recovery/CrashRecoveryDialog.tsx
@@ -9,6 +9,7 @@ import {
   SquareTerminal,
   Globe,
   MonitorPlay,
+  GitPullRequest,
 } from "lucide-react";
 import { Plug } from "@/components/icons";
 import { AppDialog } from "../ui/AppDialog";
@@ -42,6 +43,8 @@ function getPanelIcon(kind: string) {
       return <Globe className="h-3.5 w-3.5" />;
     case "dev-preview":
       return <MonitorPlay className="h-3.5 w-3.5" />;
+    case "review":
+      return <GitPullRequest className="h-3.5 w-3.5" />;
     default:
       return <SquareTerminal className="h-3.5 w-3.5" />;
   }

--- a/src/components/Terminal/TerminalContextMenu.tsx
+++ b/src/components/Terminal/TerminalContextMenu.tsx
@@ -499,6 +499,10 @@ export function TerminalContextMenu({
             <Trash2 className={ICON_CLASS} aria-hidden="true" />
             Close Review
           </ContextMenuItem>
+          <ContextMenuItem destructive onSelect={() => handleAction("kill")}>
+            <OctagonX className={ICON_CLASS} aria-hidden="true" />
+            Remove Review
+          </ContextMenuItem>
         </ContextMenuContent>
       </ContextMenu>
     );

--- a/src/components/Terminal/TerminalContextMenu.tsx
+++ b/src/components/Terminal/TerminalContextMenu.tsx
@@ -9,7 +9,7 @@ import { useFleetArmingStore, isFleetArmEligible } from "@/store/fleetArmingStor
 import { isValidBrowserUrl } from "@/components/Browser/browserUtils";
 import { actionService } from "@/services/ActionService";
 import { panelKindHasPty } from "@shared/config/panelKindRegistry";
-import { isBrowserPanel, isDevPreviewPanel } from "@shared/types/panel";
+import { isBrowserPanel, isDevPreviewPanel, isReviewPanel } from "@shared/types/panel";
 import { terminalInstanceService } from "@/services/TerminalInstanceService";
 import {
   ArrowDownFromLine,
@@ -301,6 +301,7 @@ export function TerminalContextMenu({
 
   const isBrowser = isBrowserPanel(terminal);
   const isDevPreview = isDevPreviewPanel(terminal);
+  const isReview = isReviewPanel(terminal);
   const hasPty = terminal.kind ? panelKindHasPty(terminal.kind) : true;
 
   const layoutSection = (
@@ -464,6 +465,39 @@ export function TerminalContextMenu({
           <ContextMenuItem destructive onSelect={() => handleAction("kill")}>
             <OctagonX className={ICON_CLASS} aria-hidden="true" />
             Stop Dev Server
+          </ContextMenuItem>
+        </ContextMenuContent>
+      </ContextMenu>
+    );
+  }
+
+  if (isReview) {
+    return (
+      <ContextMenu>
+        <ContextMenuTrigger asChild>
+          <div className="contents" data-context-trigger={terminalId}>
+            {children}
+          </div>
+        </ContextMenuTrigger>
+        <ContextMenuContent onCloseAutoFocus={handleCloseAutoFocus}>
+          {layoutSection}
+          <ContextMenuSeparator />
+          <ContextMenuItem onSelect={() => handleAction("duplicate")}>
+            <CopyPlus className={ICON_CLASS} aria-hidden="true" />
+            Duplicate Review
+          </ContextMenuItem>
+          <ContextMenuItem onSelect={() => handleAction("rename")}>
+            <Pencil className={ICON_CLASS} aria-hidden="true" />
+            Rename Review
+          </ContextMenuItem>
+          <ContextMenuSeparator />
+          <ContextMenuItem onSelect={() => handleAction("background")}>
+            <ArrowDownFromLine className={ICON_CLASS} aria-hidden="true" />
+            Send to Background
+          </ContextMenuItem>
+          <ContextMenuItem onSelect={() => handleAction("trash")}>
+            <Trash2 className={ICON_CLASS} aria-hidden="true" />
+            Close Review
           </ContextMenuItem>
         </ContextMenuContent>
       </ContextMenu>

--- a/src/components/Terminal/TerminalIcon.tsx
+++ b/src/components/Terminal/TerminalIcon.tsx
@@ -1,4 +1,4 @@
-import { SquareTerminal, Globe, MonitorPlay } from "lucide-react";
+import { SquareTerminal, Globe, MonitorPlay, GitPullRequest } from "lucide-react";
 import { useEffect } from "react";
 import { cn } from "@/lib/utils";
 import { BrandMark } from "@/components/icons";
@@ -66,6 +66,16 @@ export function TerminalIcon({ kind, chrome, className, brandColor }: TerminalIc
   ) {
     return withIconMarker(
       <MonitorPlay {...finalProps} className={cn(finalProps.className, "text-status-info")} />
+    );
+  }
+
+  // Review panes get a git-pull-request icon
+  if (kind === "review" || resolvedChrome.iconId === "git-pull-request") {
+    return withIconMarker(
+      <GitPullRequest
+        {...finalProps}
+        className={cn(finalProps.className, "text-category-violet")}
+      />
     );
   }
 

--- a/src/components/Terminal/TwoPaneSplitLayout.tsx
+++ b/src/components/Terminal/TwoPaneSplitLayout.tsx
@@ -10,7 +10,7 @@ import { GridPanel } from "./GridPanel";
 import { TwoPaneSplitDivider, DIVIDER_WIDTH_PX } from "./TwoPaneSplitDivider";
 import { MIN_TERMINAL_WIDTH_PX } from "@/lib/terminalLayout";
 import { terminalInstanceService } from "@/services/TerminalInstanceService";
-import { isBrowserPanel, isDevPreviewPanel } from "@shared/types/panel";
+import { isBrowserPanel, isDevPreviewPanel, isReviewPanel } from "@shared/types/panel";
 import {
   isSidebarLayoutTransitionLocked,
   subscribeSidebarLayoutTransitionUnlock,
@@ -93,8 +93,9 @@ export function TwoPaneSplitLayout({
     if (!preferPreview) return defaultRatio;
 
     const [left, right] = terminals;
-    const leftIsPreview = isBrowserPanel(left) || isDevPreviewPanel(left);
-    const rightIsPreview = isBrowserPanel(right) || isDevPreviewPanel(right);
+    const leftIsPreview = isBrowserPanel(left) || isDevPreviewPanel(left) || isReviewPanel(left);
+    const rightIsPreview =
+      isBrowserPanel(right) || isDevPreviewPanel(right) || isReviewPanel(right);
 
     if (leftIsPreview && !rightIsPreview) {
       return 0.65;

--- a/src/lib/actionPaletteSearch.ts
+++ b/src/lib/actionPaletteSearch.ts
@@ -170,6 +170,10 @@ export function getBoostedCategories(context: RankContext | undefined): Set<stri
         boosted.add("devserver");
         boosted.add("panel");
         break;
+      case "review":
+        boosted.add("git");
+        boosted.add("panel");
+        break;
     }
   }
 

--- a/src/panels/__tests__/registry.adversarial.test.ts
+++ b/src/panels/__tests__/registry.adversarial.test.ts
@@ -47,6 +47,12 @@ function mockRegistryImports(options?: { throwBrowserDefaults?: boolean }): void
   vi.doMock("../dev-preview/defaults", () => ({
     createDevPreviewDefaults: vi.fn(() => ({ devCommand: "npm run dev" })),
   }));
+  vi.doMock("../review/serializer", () => ({
+    serializeReview: vi.fn(() => ({})),
+  }));
+  vi.doMock("../review/defaults", () => ({
+    createReviewDefaults: vi.fn(() => ({})),
+  }));
 }
 
 describe("panel registry adversarial", () => {

--- a/src/panels/__tests__/registry.defaults.test.ts
+++ b/src/panels/__tests__/registry.defaults.test.ts
@@ -66,4 +66,13 @@ describe("panelKindRegistry createDefaults (co-located)", () => {
     } as AddPanelOptions);
     expect(Object.keys(result)).toHaveLength(0);
   });
+
+  it("review factory returns empty object (worktreeId carried by base)", () => {
+    const config = getPanelKindConfig("review")!;
+    const result = config.createDefaults!({
+      kind: "review",
+      worktreeId: "wt-1",
+    } as AddPanelOptions);
+    expect(Object.keys(result)).toHaveLength(0);
+  });
 });

--- a/src/panels/__tests__/registry.fieldcoverage.test.ts
+++ b/src/panels/__tests__/registry.fieldcoverage.test.ts
@@ -71,6 +71,7 @@ const BUILT_IN_KINDS = [
   "terminal",
   "browser",
   "dev-preview",
+  "review",
 ] as const satisfies readonly BuiltInPanelKind[];
 
 // Compile-time exhaustiveness pin: if a new BuiltInPanelKind is added and not

--- a/src/panels/__tests__/registry.init.test.ts
+++ b/src/panels/__tests__/registry.init.test.ts
@@ -6,7 +6,7 @@ describe("initBuiltInPanelKinds", () => {
   it("registers serialize and createDefaults on built-in kinds", () => {
     initBuiltInPanelKinds();
 
-    for (const kind of ["terminal", "browser", "dev-preview"]) {
+    for (const kind of ["terminal", "browser", "dev-preview", "review"]) {
       const config = getPanelKindConfig(kind);
       expect(config?.serialize, `${kind} should have serialize`).toBeTypeOf("function");
       expect(config?.createDefaults, `${kind} should have createDefaults`).toBeTypeOf("function");

--- a/src/panels/__tests__/registry.serialization.test.ts
+++ b/src/panels/__tests__/registry.serialization.test.ts
@@ -127,6 +127,14 @@ describe("panelKindRegistry serialize hooks (co-located)", () => {
     });
   });
 
+  describe("review", () => {
+    it("serializes review panel as empty fragment (worktreeId carried by base)", () => {
+      const config = getPanelKindConfig("review");
+      const result = config!.serialize!(makePanel({ kind: "review", worktreeId: "wt-1" }));
+      expect(result).toEqual({});
+    });
+  });
+
   describe("unknown kind", () => {
     it("returns undefined config for unregistered kind", () => {
       const config = getPanelKindConfig("custom-ext");

--- a/src/panels/registry.tsx
+++ b/src/panels/registry.tsx
@@ -1,12 +1,18 @@
 import { Suspense, lazy, type ComponentProps, type ComponentType } from "react";
 import type { PanelKindConfig } from "@shared/config/panelKindRegistry";
 import { getPanelKindConfig } from "@shared/config/panelKindRegistry";
-import type { PtyPanelData, BrowserPanelData, DevPreviewPanelData } from "@shared/types/panel";
+import type {
+  PtyPanelData,
+  BrowserPanelData,
+  DevPreviewPanelData,
+  ReviewPanelData,
+} from "@shared/types/panel";
 import { isBuiltInPanelKind } from "@shared/types/panel";
 import type {
   TerminalPanelOptions,
   BrowserPanelOptions,
   DevPreviewPanelOptions,
+  ReviewPanelOptions,
 } from "@shared/types/addPanelOptions";
 import type { PanelSnapshot } from "@shared/types/project";
 import { TerminalPane } from "@/components/Terminal/TerminalPane";
@@ -21,6 +27,8 @@ import { serializeBrowser } from "./browser/serializer";
 import { createBrowserDefaults } from "./browser/defaults";
 import { serializeDevPreview } from "./dev-preview/serializer";
 import { createDevPreviewDefaults } from "./dev-preview/defaults";
+import { serializeReview } from "./review/serializer";
+import { createReviewDefaults } from "./review/defaults";
 
 export interface PanelComponentProps {
   id: string;
@@ -49,6 +57,9 @@ const LazyBrowserPane = lazy(() =>
 );
 const LazyDevPreviewPane = lazy(() =>
   import("@/components/DevPreview/DevPreviewPane").then((m) => ({ default: m.DevPreviewPane }))
+);
+const LazyReviewPane = lazy(() =>
+  import("./review/ReviewPane").then((m) => ({ default: m.ReviewPane }))
 );
 
 // Wrapper providing Suspense fallback for the lazy dynamic import and
@@ -79,6 +90,18 @@ function DevPreviewPaneWrapper(props: ComponentProps<typeof LazyDevPreviewPane>)
   );
 }
 
+function ReviewPaneWrapper(props: ComponentProps<typeof LazyReviewPane>) {
+  return (
+    <ErrorBoundary variant="component" componentName="ReviewPane">
+      <Suspense fallback={<BrowserPaneSkeleton label="Loading review panel" />}>
+        <ContentFadeIn className="flex flex-col h-full w-full">
+          <LazyReviewPane {...props} />
+        </ContentFadeIn>
+      </Suspense>
+    </ErrorBoundary>
+  );
+}
+
 /**
  * Maps each built-in panel kind to its panel data variant. `createdAt` is
  * intentionally widened on the PTY and dev-preview entries so serializers can
@@ -88,12 +111,14 @@ interface BuiltInPanelMap {
   terminal: PtyPanelData & { createdAt?: number };
   browser: BrowserPanelData;
   "dev-preview": DevPreviewPanelData & { createdAt?: number };
+  review: ReviewPanelData;
 }
 
 interface BuiltInPanelOptionsMap {
   terminal: TerminalPanelOptions;
   browser: BrowserPanelOptions;
   "dev-preview": DevPreviewPanelOptions;
+  review: ReviewPanelOptions;
 }
 
 type BuiltInSerializeDefaults = {
@@ -107,6 +132,7 @@ const BUILT_IN_SERIALIZE_DEFAULTS = {
   terminal: { serialize: serializePtyPanel, createDefaults: createTerminalDefaults },
   browser: { serialize: serializeBrowser, createDefaults: createBrowserDefaults },
   "dev-preview": { serialize: serializeDevPreview, createDefaults: createDevPreviewDefaults },
+  review: { serialize: serializeReview, createDefaults: createReviewDefaults },
 } satisfies BuiltInSerializeDefaults;
 
 export function initBuiltInPanelKinds(): void {
@@ -145,6 +171,7 @@ const PANEL_KIND_DEFINITION_REGISTRY: Record<string, PanelKindDefinition> = {
   terminal: { ...requirePanelKindConfig("terminal"), component: TerminalPane },
   browser: { ...requirePanelKindConfig("browser"), component: BrowserPaneWrapper },
   "dev-preview": { ...requirePanelKindConfig("dev-preview"), component: DevPreviewPaneWrapper },
+  review: { ...requirePanelKindConfig("review"), component: ReviewPaneWrapper },
 };
 
 /**

--- a/src/panels/review/ReviewPane.tsx
+++ b/src/panels/review/ReviewPane.tsx
@@ -1,4 +1,4 @@
-import { useCallback, useRef } from "react";
+import { useCallback, useState } from "react";
 import { GitPullRequest } from "lucide-react";
 import { useWorktreeStore } from "@/hooks/useWorktreeStore";
 import { ReviewHubContent } from "@/components/Worktree/ReviewHub/ReviewHubContent";
@@ -12,10 +12,15 @@ export interface ReviewPaneProps {
 const noop = () => {};
 
 export function ReviewPane({ worktreeId }: ReviewPaneProps) {
-  const containerRef = useRef<HTMLDivElement>(null);
+  // Callback ref via useState so React re-renders once the container element
+  // commits to the DOM. A plain useRef would freeze `current` at `null` for
+  // the lifetime of the first render and `keyboardScope` would never receive
+  // the element — `ReviewHubContent` would fall back to a document-scoped
+  // Escape listener that swallows the key across the whole app.
+  const [containerEl, setContainerEl] = useState<HTMLDivElement | null>(null);
 
   // Resolve worktree path fresh from the worktree store so renames/moves are
-  // reflected without restarting the panel. `null` worktreeId yields an empty
+  // reflected without restarting the panel. Missing worktreeId yields an empty
   // state instead of an IPC call with an empty path.
   const worktreePath = useWorktreeStore(
     useCallback(
@@ -26,7 +31,7 @@ export function ReviewPane({ worktreeId }: ReviewPaneProps) {
 
   if (!worktreePath) {
     return (
-      <div ref={containerRef} className="flex h-full w-full items-center justify-center">
+      <div ref={setContainerEl} className="flex h-full w-full items-center justify-center">
         <EmptyState
           variant="zero-data"
           scale="canvas"
@@ -39,12 +44,12 @@ export function ReviewPane({ worktreeId }: ReviewPaneProps) {
   }
 
   return (
-    <div ref={containerRef} className="flex h-full w-full flex-col bg-daintree-bg">
+    <div ref={setContainerEl} className="flex h-full w-full flex-col bg-daintree-bg">
       <ReviewHubContent
         isOpen={true}
         worktreePath={worktreePath}
         onClose={noop}
-        keyboardScope={containerRef.current ?? undefined}
+        keyboardScope={containerEl ?? undefined}
       />
     </div>
   );

--- a/src/panels/review/ReviewPane.tsx
+++ b/src/panels/review/ReviewPane.tsx
@@ -1,0 +1,51 @@
+import { useCallback, useRef } from "react";
+import { GitPullRequest } from "lucide-react";
+import { useWorktreeStore } from "@/hooks/useWorktreeStore";
+import { ReviewHubContent } from "@/components/Worktree/ReviewHub/ReviewHubContent";
+import { EmptyState } from "@/components/ui/EmptyState";
+
+export interface ReviewPaneProps {
+  id: string;
+  worktreeId?: string;
+}
+
+const noop = () => {};
+
+export function ReviewPane({ worktreeId }: ReviewPaneProps) {
+  const containerRef = useRef<HTMLDivElement>(null);
+
+  // Resolve worktree path fresh from the worktree store so renames/moves are
+  // reflected without restarting the panel. `null` worktreeId yields an empty
+  // state instead of an IPC call with an empty path.
+  const worktreePath = useWorktreeStore(
+    useCallback(
+      (state) => (worktreeId ? (state.worktrees.get(worktreeId)?.path ?? "") : ""),
+      [worktreeId]
+    )
+  );
+
+  if (!worktreePath) {
+    return (
+      <div ref={containerRef} className="flex h-full w-full items-center justify-center">
+        <EmptyState
+          variant="zero-data"
+          scale="canvas"
+          icon={<GitPullRequest className="h-6 w-6" />}
+          title="Worktree unavailable"
+          description="Open a worktree to review and commit changes."
+        />
+      </div>
+    );
+  }
+
+  return (
+    <div ref={containerRef} className="flex h-full w-full flex-col bg-daintree-bg">
+      <ReviewHubContent
+        isOpen={true}
+        worktreePath={worktreePath}
+        onClose={noop}
+        keyboardScope={containerRef.current ?? undefined}
+      />
+    </div>
+  );
+}

--- a/src/panels/review/defaults.ts
+++ b/src/panels/review/defaults.ts
@@ -3,7 +3,7 @@ import type { ReviewPanelOptions } from "@shared/types/addPanelOptions";
 
 // Review panels have no kind-specific defaults — id/title/location/worktreeId
 // are filled in by addTerminal from the common base.
-// eslint-disable-next-line @typescript-eslint/no-unused-vars
+
 export function createReviewDefaults(_options: ReviewPanelOptions): Partial<ReviewPanelData> {
   return {};
 }

--- a/src/panels/review/defaults.ts
+++ b/src/panels/review/defaults.ts
@@ -1,0 +1,9 @@
+import type { ReviewPanelData } from "@shared/types/panel";
+import type { ReviewPanelOptions } from "@shared/types/addPanelOptions";
+
+// Review panels have no kind-specific defaults — id/title/location/worktreeId
+// are filled in by addTerminal from the common base.
+// eslint-disable-next-line @typescript-eslint/no-unused-vars
+export function createReviewDefaults(_options: ReviewPanelOptions): Partial<ReviewPanelData> {
+  return {};
+}

--- a/src/panels/review/serializer.ts
+++ b/src/panels/review/serializer.ts
@@ -4,7 +4,7 @@ import type { PanelSnapshot } from "@shared/types/project";
 // Review panels persist nothing beyond BasePanelData — the worktree path is
 // resolved fresh from the worktree store at render time, so there is no kind-
 // specific snapshot fragment.
-// eslint-disable-next-line @typescript-eslint/no-unused-vars
+
 export function serializeReview(_panel: ReviewPanelData): Partial<PanelSnapshot> {
   return {};
 }

--- a/src/panels/review/serializer.ts
+++ b/src/panels/review/serializer.ts
@@ -1,0 +1,10 @@
+import type { ReviewPanelData } from "@shared/types/panel";
+import type { PanelSnapshot } from "@shared/types/project";
+
+// Review panels persist nothing beyond BasePanelData — the worktree path is
+// resolved fresh from the worktree store at render time, so there is no kind-
+// specific snapshot fragment.
+// eslint-disable-next-line @typescript-eslint/no-unused-vars
+export function serializeReview(_panel: ReviewPanelData): Partial<PanelSnapshot> {
+  return {};
+}

--- a/src/services/terminal/panelDuplicationService.ts
+++ b/src/services/terminal/panelDuplicationService.ts
@@ -166,6 +166,13 @@ export function buildPanelSnapshotOptions(panel: TerminalInstance): AddPanelOpti
     };
   }
 
+  if (kind === "review") {
+    return {
+      kind: "review",
+      worktreeId: panel.worktreeId,
+    };
+  }
+
   return {
     kind: "terminal",
     launchAgentId: panel.launchAgentId,
@@ -252,6 +259,14 @@ export async function buildPanelDuplicateOptions(
       exitBehavior: sourcePanel.exitBehavior,
       isInputLocked: sourcePanel.isInputLocked,
       ...buildDevPreviewOptions(sourcePanel),
+    };
+  }
+
+  if (kind === "review") {
+    return {
+      kind: "review",
+      worktreeId: sourcePanel.worktreeId,
+      location: targetLocation,
     };
   }
 

--- a/src/utils/__tests__/terminalChrome.test.ts
+++ b/src/utils/__tests__/terminalChrome.test.ts
@@ -88,6 +88,20 @@ describe("deriveTerminalChrome", () => {
     });
   });
 
+  it("returns panel chrome for review kind (not terminal)", () => {
+    // Regression guard: review must take the non-PTY panel-chrome branch so it
+    // does not inherit terminal/agent restart buttons or activity badges.
+    expect(deriveTerminalChrome({ kind: "review" })).toMatchObject({
+      iconId: "git-pull-request",
+      label: "Review",
+      isAgent: false,
+      agentId: null,
+      processId: null,
+      runtimeKind: "panel",
+      hasExited: false,
+    });
+  });
+
   it("returns agent chrome from live detection", () => {
     expect(deriveTerminalChrome({ detectedAgentId: "claude" })).toMatchObject({
       iconId: "claude",

--- a/src/utils/terminalChrome.ts
+++ b/src/utils/terminalChrome.ts
@@ -186,7 +186,7 @@ export function terminalChromeDescriptorsEqual(
 
 export function deriveTerminalChrome(input: TerminalChromeInput = {}): TerminalChromeDescriptor {
   const kind = input.kind ?? "terminal";
-  if (kind === "browser" || kind === "dev-preview") {
+  if (kind === "browser" || kind === "dev-preview" || kind === "review") {
     const config = getPanelKindConfig(kind);
     return {
       iconId: config?.iconId ?? null,


### PR DESCRIPTION
This adds `review` as a fourth built-in panel kind, alongside `terminal`, `browser`, and `dev-preview`.

## Summary

- Registers `review` in `BUILT_IN_PANEL_KINDS` and adds `ReviewPanelData` to the panel discriminated union
- Creates `src/panels/review/` (`ReviewPane.tsx`, `defaults.ts`, `serializer.ts`) — a thin wrapper around the existing `ReviewHubContent` surface, resolving `worktreeId` fresh from the worktree store at render time
- Extends `deriveTerminalChrome`, `panelDuplicationService`, and the Escape handler scope to cover the new kind correctly

Resolves #7792

## Changes

- `shared/types/panel.ts` — `ReviewPanelData` added to discriminated union; `isReviewPanel` type guard
- `shared/config/panelKindRegistry.ts` — `review` registered with `--theme-category-violet` brand color and `GitPullRequest` icon
- `src/panels/review/ReviewPane.tsx` — mounts `ReviewHubContent` inside the grid panel; Escape handler scoped to container via `useState` callback ref
- `src/panels/review/defaults.ts` + `serializer.ts` — round-trip safe; `worktreeId` is the only binding
- `src/utils/terminalChrome.ts` — `deriveTerminalChrome` guard extended so `review` gets panel chrome, not terminal/agent restart buttons
- `src/services/terminal/panelDuplicationService.ts` — both build paths handle `review`
- Tests — registry `init`/`defaults`/`serialization`/`fieldcoverage` enumerate `review`; `terminalChrome` runtimeKind guard updated; `runtimeDefaults` "four kinds" assertion updated; adversarial mocks added

## Testing

All 70 targeted tests pass. `tsc --noEmit` clean. Lint and format clean. The modal `ReviewHub.tsx` wrapper is preserved unchanged — existing review flows are unaffected.