### PR TITLE
fix(ui): move GitInitDialog action buttons into AppDialog.Footer

### DIFF
--- a/src/components/Project/GitInitDialog.tsx
+++ b/src/components/Project/GitInitDialog.tsx
@@ -280,44 +280,44 @@ export function GitInitDialog({ isOpen, directoryPath, onSuccess, onCancel }: Gi
             </div>
           </div>
         )}
-
-        <div className="flex justify-end gap-2">
-          {isComplete ? (
-            <Button onClick={handleClose} className="gap-2">
-              <Check className="h-4 w-4" />
-              Continue
-            </Button>
-          ) : error ? (
-            <>
-              <Button variant="outline" onClick={onCancel}>
-                Cancel
-              </Button>
-              <Button onClick={() => void startInitialization()} disabled={isInitializing}>
-                Try again
-              </Button>
-            </>
-          ) : (
-            <>
-              <Button variant="outline" onClick={onCancel} disabled={isInitializing}>
-                Cancel
-              </Button>
-              <Button
-                onClick={() => void startInitialization()}
-                disabled={isInitializing || !canStart}
-              >
-                {isInitializing ? (
-                  <>
-                    <Spinner size="md" />
-                    Initializing...
-                  </>
-                ) : (
-                  "Initialize repository"
-                )}
-              </Button>
-            </>
-          )}
-        </div>
       </AppDialog.Body>
+
+      <AppDialog.Footer>
+        {isComplete ? (
+          <Button onClick={handleClose} className="gap-2">
+            <Check className="h-4 w-4" />
+            Continue
+          </Button>
+        ) : error ? (
+          <>
+            <Button variant="outline" onClick={onCancel}>
+              Cancel
+            </Button>
+            <Button onClick={() => void startInitialization()} disabled={isInitializing}>
+              Try again
+            </Button>
+          </>
+        ) : (
+          <>
+            <Button variant="outline" onClick={onCancel} disabled={isInitializing}>
+              Cancel
+            </Button>
+            <Button
+              onClick={() => void startInitialization()}
+              disabled={isInitializing || !canStart}
+            >
+              {isInitializing ? (
+                <>
+                  <Spinner size="md" />
+                  Initializing...
+                </>
+              ) : (
+                "Initialize repository"
+              )}
+            </Button>
+          </>
+        )}
+      </AppDialog.Footer>
     </AppDialog>
   );
 }

--- a/src/components/Project/__tests__/GitInitDialog.test.tsx
+++ b/src/components/Project/__tests__/GitInitDialog.test.tsx
@@ -52,6 +52,7 @@ vi.mock("@/components/ui/AppDialog", () => {
   AppDialog.Title = ({ children }: AppDialogSectionProps) => <h2>{children}</h2>;
   AppDialog.CloseButton = () => <button type="button">close</button>;
   AppDialog.Body = ({ children }: AppDialogSectionProps) => <div>{children}</div>;
+  AppDialog.Footer = ({ children }: AppDialogSectionProps) => <div>{children}</div>;
 
   return { AppDialog };
 });


### PR DESCRIPTION
## Summary

- `GitInitDialog` was placing the Cancel and Initialize repository buttons inside `AppDialog.Body`, leaving them visually crammed against the commit message input with no separator
- Moves the button row into `AppDialog.Footer`, which renders with a top border and consistent padding — the pattern every other action dialog in the app already uses
- Updates the test mock to include `AppDialog.Footer` so the existing suite stays green

Resolves #8081

## Changes

- `src/components/Project/GitInitDialog.tsx` — extracted the `flex justify-end gap-2` button div from `AppDialog.Body` and wrapped it in `AppDialog.Footer`
- `src/components/Project/__tests__/GitInitDialog.test.tsx` — added `AppDialog.Footer` to the mock

## Testing

7 vitest unit tests pass. Lint ratchet dropped 893 → 890. Format, typecheck, IPC channels, and help checks all clean.