### PR TITLE
fix(worktree): surface stale state on the file-change list

### DIFF
--- a/src/components/Worktree/FileChangeList.tsx
+++ b/src/components/Worktree/FileChangeList.tsx
@@ -44,6 +44,7 @@ interface FileChangeListProps {
   maxVisible?: number;
   rootPath: string;
   groupByFolder?: boolean;
+  isStale?: boolean;
 }
 
 function splitPath(filePath: string): { dir: string; base: string } {
@@ -83,6 +84,7 @@ export function FileChangeList({
   maxVisible = 8,
   rootPath,
   groupByFolder = false,
+  isStale = false,
 }: FileChangeListProps) {
   const [selectedFile, setSelectedFile] = useState<SelectedFile | null>(null);
 
@@ -234,7 +236,13 @@ export function FileChangeList({
   if (groupByFolder && groupedChanges.length > 0) {
     return (
       <>
-        <div className="space-y-3 w-full max-h-64 overflow-y-auto overscroll-contain">
+        <div
+          className={cn(
+            "space-y-3 w-full max-h-64 overflow-y-auto overscroll-contain",
+            isStale && "surface-stale"
+          )}
+          aria-busy={isStale || undefined}
+        >
           {groupedChanges.map((group) => (
             <div key={group.dir}>
               <div className="flex items-center gap-1.5 text-[11px] text-daintree-text/40 mb-1">
@@ -273,7 +281,13 @@ export function FileChangeList({
 
   return (
     <>
-      <div className="flex flex-col gap-0.5 w-full max-h-64 overflow-y-auto overscroll-contain">
+      <div
+        className={cn(
+          "flex flex-col gap-0.5 w-full max-h-64 overflow-y-auto overscroll-contain",
+          isStale && "surface-stale"
+        )}
+        aria-busy={isStale || undefined}
+      >
         {visibleChanges.map((change) => renderFileItem(change, true))}
 
         {remainingCount > 0 && (

--- a/src/components/Worktree/WorktreeCard.tsx
+++ b/src/components/Worktree/WorktreeCard.tsx
@@ -841,6 +841,7 @@ export function WorktreeCard({
                     effectiveSummary={effectiveSummary}
                     worktreeErrors={worktreeErrors}
                     isFocused={isFocused}
+                    isStale={isStaleCard}
                     onToggleExpand={handleToggleExpand}
                     onPathClick={handlePathClick}
                     onDismissError={dismissError}

--- a/src/components/Worktree/WorktreeCard/WorktreeDetailsSection.tsx
+++ b/src/components/Worktree/WorktreeCard/WorktreeDetailsSection.tsx
@@ -41,6 +41,7 @@ export interface WorktreeDetailsSectionProps {
   effectiveSummary?: string | null;
   worktreeErrors: ErrorRecord[];
   isFocused: boolean;
+  isStale?: boolean;
   onToggleExpand: (e: React.MouseEvent) => void;
   onPathClick: () => void;
   onDismissError: (id: string) => void;
@@ -70,6 +71,7 @@ export function WorktreeDetailsSection(props: WorktreeDetailsSectionProps) {
     effectiveSummary,
     worktreeErrors,
     isFocused,
+    isStale,
     onToggleExpand,
     onPathClick,
     onDismissError,
@@ -168,6 +170,7 @@ export function WorktreeDetailsSection(props: WorktreeDetailsSectionProps) {
               worktreeErrors={worktreeErrors}
               hasChanges={hasChanges}
               isFocused={isFocused}
+              isStale={isStale}
               onPathClick={onPathClick}
               onDismissError={onDismissError}
               onRetryError={onRetryError}

--- a/src/components/Worktree/WorktreeDetails.tsx
+++ b/src/components/Worktree/WorktreeDetails.tsx
@@ -20,6 +20,7 @@ export interface WorktreeDetailsProps {
   worktreeErrors: ErrorRecord[];
   hasChanges: boolean;
   isFocused: boolean;
+  isStale?: boolean;
   showLastCommit?: boolean;
   lastActivityTimestamp?: number | null;
   showTime?: boolean;
@@ -38,6 +39,7 @@ export function WorktreeDetails({
   worktreeErrors,
   hasChanges,
   isFocused,
+  isStale = false,
   onPathClick,
   onDismissError,
   onRetryError,
@@ -160,6 +162,7 @@ export function WorktreeDetails({
                 rootPath={worktree.worktreeChanges.rootPath}
                 maxVisible={worktree.worktreeChanges.changes.length}
                 groupByFolder={worktree.worktreeChanges.changedFileCount > 5}
+                isStale={isStale}
               />
             </div>
           )}

--- a/src/components/Worktree/__tests__/FileChangeList.test.tsx
+++ b/src/components/Worktree/__tests__/FileChangeList.test.tsx
@@ -197,6 +197,15 @@ describe("FileChangeList — stale state (#8069)", () => {
     expect(el.getAttribute("aria-busy")).toBe("true");
   });
 
+  it("treats an explicit isStale={false} the same as an absent prop", () => {
+    const { container } = render(
+      <FileChangeList changes={[file("a.ts"), file("b.ts")]} rootPath={ROOT} isStale={false} />
+    );
+    const el = scroll(container);
+    expect(el.classList.contains("surface-stale")).toBe(false);
+    expect(el.getAttribute("aria-busy")).toBeNull();
+  });
+
   it("applies surface-stale and aria-busy in the grouped branch when isStale", () => {
     const { container } = render(
       <FileChangeList
@@ -209,6 +218,10 @@ describe("FileChangeList — stale state (#8069)", () => {
     const el = scroll(container);
     expect(el.classList.contains("surface-stale")).toBe(true);
     expect(el.getAttribute("aria-busy")).toBe("true");
+    // Prove the grouped code path was entered, not the flat fallback.
+    expect(el.querySelectorAll(".font-mono").length).toBeGreaterThan(0);
+    // Exactly one container carries the stale class — never both branches.
+    expect(container.querySelectorAll(".surface-stale").length).toBe(1);
   });
 
   it("clears stale styling when isStale toggles back to false", () => {

--- a/src/components/Worktree/__tests__/FileChangeList.test.tsx
+++ b/src/components/Worktree/__tests__/FileChangeList.test.tsx
@@ -167,3 +167,63 @@ describe("FileChangeList — row-recency cue (#6544)", () => {
     expect(newRows(container)).toEqual([]);
   });
 });
+
+describe("FileChangeList — stale state (#8069)", () => {
+  afterEach(() => {
+    cleanup();
+  });
+
+  function scroll(container: HTMLElement): HTMLElement {
+    const el = container.querySelector<HTMLElement>(".overflow-y-auto");
+    if (!el) throw new Error("scroll container not found");
+    return el;
+  }
+
+  it("does not apply stale styling when isStale is absent", () => {
+    const { container } = render(
+      <FileChangeList changes={[file("a.ts"), file("b.ts")]} rootPath={ROOT} />
+    );
+    const el = scroll(container);
+    expect(el.classList.contains("surface-stale")).toBe(false);
+    expect(el.getAttribute("aria-busy")).toBeNull();
+  });
+
+  it("applies surface-stale and aria-busy in the flat branch when isStale", () => {
+    const { container } = render(
+      <FileChangeList changes={[file("a.ts"), file("b.ts")]} rootPath={ROOT} isStale />
+    );
+    const el = scroll(container);
+    expect(el.classList.contains("surface-stale")).toBe(true);
+    expect(el.getAttribute("aria-busy")).toBe("true");
+  });
+
+  it("applies surface-stale and aria-busy in the grouped branch when isStale", () => {
+    const { container } = render(
+      <FileChangeList
+        changes={[file("src/a.ts"), file("test/b.ts")]}
+        rootPath={ROOT}
+        groupByFolder
+        isStale
+      />
+    );
+    const el = scroll(container);
+    expect(el.classList.contains("surface-stale")).toBe(true);
+    expect(el.getAttribute("aria-busy")).toBe("true");
+  });
+
+  it("clears stale styling when isStale toggles back to false", () => {
+    const changes = [file("a.ts"), file("b.ts")];
+    const { container, rerender } = render(
+      <FileChangeList changes={changes} rootPath={ROOT} isStale />
+    );
+    expect(scroll(container).classList.contains("surface-stale")).toBe(true);
+
+    act(() => {
+      rerender(<FileChangeList changes={changes} rootPath={ROOT} isStale={false} />);
+    });
+
+    const el = scroll(container);
+    expect(el.classList.contains("surface-stale")).toBe(false);
+    expect(el.getAttribute("aria-busy")).toBeNull();
+  });
+});


### PR DESCRIPTION
## Summary

- When a worktree enters the stale mood (heartbeat gap), `WorktreeHeader` chrome dims but `FileChangeList` previously rendered identically to the fresh state — users could read several-minute-old file-change data with no visual feedback.
- Threads an `isStale` prop from `WorktreeCard` (reusing the existing `isStaleCard = spineState === "stale"`) through `WorktreeDetailsSection` and `WorktreeDetails` into `FileChangeList`, applying the existing `surface-stale` CSS class and `aria-busy={isStale || undefined}` to both scroll containers (flat and grouped branches). Mirrors the `ReviewHubContent` pattern exactly.
- The `surface-stale` CSS already bakes in the 400ms Doherty anti-flicker gate plus `prefers-reduced-motion` and `data-performance-mode` bypasses — no new keyframes or per-row indicators needed.

Resolves #8069.

## Changes

- `FileChangeList.tsx` — accepts `isStale?: boolean`, applies `surface-stale` + `aria-busy` to both scroll containers
- `WorktreeCard.tsx` — passes `isStale` down to `WorktreeDetailsSection`
- `WorktreeDetailsSection.tsx` — forwards `isStale` to `WorktreeDetails`
- `WorktreeDetails.tsx` — forwards `isStale` to `FileChangeList`
- `FileChangeList.test.tsx` — 5 new stale-state tests (absent prop, explicit false, flat-branch stale, grouped-branch stale with single-container + path proof, toggle true→false)

## Testing

Typecheck, lint, and format all pass clean. 15 `FileChangeList` unit tests pass (10 pre-existing + 5 new). No changes to `.file-change-row-new` keyframe, `calculateStateHash`, or row keys.