### PR TITLE
feat(terminal): anchor resource sparkline and add asymmetric severity hysteresis

### DIFF
--- a/src/components/Terminal/TerminalHeaderContent.tsx
+++ b/src/components/Terminal/TerminalHeaderContent.tsx
@@ -73,9 +73,16 @@ function getResourceSeverity(cpuPercent: number, memoryKb: number): ResourceSeve
   return "muted";
 }
 
-// Three consecutive same-direction polls before the displayed band changes —
-// prevents flicker at threshold boundaries (CPU 50/80, mem 1G/2G).
-const SEVERITY_HYSTERESIS_POLLS = 3;
+const SEVERITY_ORDER: Record<ResourceSeverity, number> = { muted: 0, amber: 1, red: 2 };
+
+// Asymmetric same-direction poll hysteresis before the displayed band changes —
+// prevents flicker at threshold boundaries (CPU 50/80, mem 1G/2G). Escalating to
+// a hotter band reacts quickly (3 polls); de-escalating back down lingers longer
+// (5 polls) so hot states don't vanish on a single quiet poll. This deliberately
+// diverges from ProcessDetector's symmetric hysteresis: a missed spike is worse
+// than a slightly stale calm reading.
+const ESCALATION_HYSTERESIS_POLLS = 3;
+const DE_ESCALATION_HYSTERESIS_POLLS = 5;
 
 export function TerminalHeaderContent({
   id,
@@ -122,7 +129,11 @@ export function TerminalHeaderContent({
         pendingCountRef.current = 1;
       }
 
-      if (pendingCountRef.current < SEVERITY_HYSTERESIS_POLLS) {
+      const threshold =
+        SEVERITY_ORDER[rawSeverity] > SEVERITY_ORDER[current]
+          ? ESCALATION_HYSTERESIS_POLLS
+          : DE_ESCALATION_HYSTERESIS_POLLS;
+      if (pendingCountRef.current < threshold) {
         return current;
       }
 

--- a/src/components/Terminal/TerminalResourceSparkline.tsx
+++ b/src/components/Terminal/TerminalResourceSparkline.tsx
@@ -30,6 +30,7 @@ export function TerminalResourceSparkline({ history, className }: TerminalResour
       viewBox={`0 0 ${width} ${height}`}
       width={width}
       height={height}
+      overflow="visible"
       className={className}
       aria-hidden="true"
     >

--- a/src/components/Terminal/TerminalResourceSparkline.tsx
+++ b/src/components/Terminal/TerminalResourceSparkline.tsx
@@ -18,11 +18,11 @@ export function TerminalResourceSparkline({ history, className }: TerminalResour
     .join(" ");
 
   const dotRadius = 2;
-  const lastValue = history[history.length - 1];
+  const lastValue = history[history.length - 1]!;
   const lastX = width;
   const lastY = Math.max(
     dotRadius,
-    Math.min(height - dotRadius, height - (Math.min(lastValue, 100) / 100) * height),
+    Math.min(height - dotRadius, height - (Math.min(lastValue, 100) / 100) * height)
   );
 
   return (

--- a/src/components/Terminal/TerminalResourceSparkline.tsx
+++ b/src/components/Terminal/TerminalResourceSparkline.tsx
@@ -17,6 +17,14 @@ export function TerminalResourceSparkline({ history, className }: TerminalResour
     })
     .join(" ");
 
+  const dotRadius = 2;
+  const lastValue = history[history.length - 1];
+  const lastX = width;
+  const lastY = Math.max(
+    dotRadius,
+    Math.min(height - dotRadius, height - (Math.min(lastValue, 100) / 100) * height),
+  );
+
   return (
     <svg
       viewBox={`0 0 ${width} ${height}`}
@@ -33,6 +41,7 @@ export function TerminalResourceSparkline({ history, className }: TerminalResour
         strokeLinecap="round"
         strokeLinejoin="round"
       />
+      <circle cx={lastX} cy={lastY} r={dotRadius} fill="currentColor" stroke="none" />
     </svg>
   );
 }

--- a/src/components/Terminal/__tests__/TerminalHeaderContent.test.tsx
+++ b/src/components/Terminal/__tests__/TerminalHeaderContent.test.tsx
@@ -465,6 +465,40 @@ describe("TerminalHeaderContent — resource severity hysteresis", () => {
     const wrapperFor = () =>
       container.querySelector(".inline-flex.items-center.gap-1.text-\\[11px\\]")!;
 
+    // Escalation reacts in 3 polls.
+    pollResource(rerender, 90, 1);
+    pollResource(rerender, 90, 2);
+    pollResource(rerender, 90, 3);
+    expect(wrapperFor().getAttribute("class")).toContain("text-status-error");
+
+    // De-escalation lingers — requires 5 polls per downward step.
+    pollResource(rerender, 60, 4);
+    pollResource(rerender, 60, 5);
+    pollResource(rerender, 60, 6);
+    pollResource(rerender, 60, 7);
+    pollResource(rerender, 60, 8);
+    expect(wrapperFor().getAttribute("class")).toContain("text-status-warning");
+    expect(wrapperFor().getAttribute("class")).not.toContain("text-status-error");
+
+    pollResource(rerender, 10, 9);
+    pollResource(rerender, 10, 10);
+    pollResource(rerender, 10, 11);
+    pollResource(rerender, 10, 12);
+    pollResource(rerender, 10, 13);
+    expect(wrapperFor().getAttribute("class")).toContain("text-daintree-text/40");
+    expect(wrapperFor().getAttribute("class")).not.toContain("text-status-warning");
+  });
+
+  it("does not de-escalate after only 4 polls below the threshold", () => {
+    mockResourceEnabled = true;
+    mockResourceState = makeResourceState(10);
+
+    const { rerender, container } = render(
+      <TerminalHeaderContent id="t1" kind="terminal" queueCount={0} />
+    );
+    const wrapperFor = () =>
+      container.querySelector(".inline-flex.items-center.gap-1.text-\\[11px\\]")!;
+
     pollResource(rerender, 90, 1);
     pollResource(rerender, 90, 2);
     pollResource(rerender, 90, 3);
@@ -473,13 +507,66 @@ describe("TerminalHeaderContent — resource severity hysteresis", () => {
     pollResource(rerender, 60, 4);
     pollResource(rerender, 60, 5);
     pollResource(rerender, 60, 6);
+    pollResource(rerender, 60, 7);
+    expect(wrapperFor().getAttribute("class")).toContain("text-status-error");
+    expect(wrapperFor().getAttribute("class")).not.toContain("text-status-warning");
+  });
+
+  it("de-escalates on exactly the 5th poll below the threshold", () => {
+    mockResourceEnabled = true;
+    mockResourceState = makeResourceState(10);
+
+    const { rerender, container } = render(
+      <TerminalHeaderContent id="t1" kind="terminal" queueCount={0} />
+    );
+    const wrapperFor = () =>
+      container.querySelector(".inline-flex.items-center.gap-1.text-\\[11px\\]")!;
+
+    pollResource(rerender, 90, 1);
+    pollResource(rerender, 90, 2);
+    pollResource(rerender, 90, 3);
+    expect(wrapperFor().getAttribute("class")).toContain("text-status-error");
+
+    pollResource(rerender, 60, 4);
+    pollResource(rerender, 60, 5);
+    pollResource(rerender, 60, 6);
+    pollResource(rerender, 60, 7);
+    pollResource(rerender, 60, 8);
     expect(wrapperFor().getAttribute("class")).toContain("text-status-warning");
     expect(wrapperFor().getAttribute("class")).not.toContain("text-status-error");
+  });
 
-    pollResource(rerender, 10, 7);
-    pollResource(rerender, 10, 8);
-    pollResource(rerender, 10, 9);
-    expect(wrapperFor().getAttribute("class")).toContain("text-daintree-text/40");
+  it("keeps the hotter band when severity oscillates within the 3-5 de-escalation gap", () => {
+    mockResourceEnabled = true;
+    mockResourceState = makeResourceState(10);
+
+    const { rerender, container } = render(
+      <TerminalHeaderContent id="t1" kind="terminal" queueCount={0} />
+    );
+    const wrapperFor = () =>
+      container.querySelector(".inline-flex.items-center.gap-1.text-\\[11px\\]")!;
+
+    pollResource(rerender, 90, 1);
+    pollResource(rerender, 90, 2);
+    pollResource(rerender, 90, 3);
+    expect(wrapperFor().getAttribute("class")).toContain("text-status-error");
+
+    // 4 cool polls — one short of the 5-poll de-escalation commit.
+    pollResource(rerender, 60, 4);
+    pollResource(rerender, 60, 5);
+    pollResource(rerender, 60, 6);
+    pollResource(rerender, 60, 7);
+    expect(wrapperFor().getAttribute("class")).toContain("text-status-error");
+
+    // A single hot poll matches the displayed band and resets the pending counter.
+    pollResource(rerender, 90, 8);
+
+    // The de-escalation count restarts from zero; 4 more cool polls still hold red.
+    pollResource(rerender, 60, 9);
+    pollResource(rerender, 60, 10);
+    pollResource(rerender, 60, 11);
+    pollResource(rerender, 60, 12);
+    expect(wrapperFor().getAttribute("class")).toContain("text-status-error");
     expect(wrapperFor().getAttribute("class")).not.toContain("text-status-warning");
   });
 

--- a/src/components/Terminal/__tests__/TerminalHeaderContent.test.tsx
+++ b/src/components/Terminal/__tests__/TerminalHeaderContent.test.tsx
@@ -570,6 +570,31 @@ describe("TerminalHeaderContent — resource severity hysteresis", () => {
     expect(wrapperFor().getAttribute("class")).not.toContain("text-status-warning");
   });
 
+  it("de-escalates red straight to muted without stepping through amber", () => {
+    mockResourceEnabled = true;
+    mockResourceState = makeResourceState(10);
+
+    const { rerender, container } = render(
+      <TerminalHeaderContent id="t1" kind="terminal" queueCount={0} />
+    );
+    const wrapperFor = () =>
+      container.querySelector(".inline-flex.items-center.gap-1.text-\\[11px\\]")!;
+
+    pollResource(rerender, 90, 1);
+    pollResource(rerender, 90, 2);
+    pollResource(rerender, 90, 3);
+    expect(wrapperFor().getAttribute("class")).toContain("text-status-error");
+
+    pollResource(rerender, 10, 4);
+    pollResource(rerender, 10, 5);
+    pollResource(rerender, 10, 6);
+    pollResource(rerender, 10, 7);
+    pollResource(rerender, 10, 8);
+    expect(wrapperFor().getAttribute("class")).toContain("text-daintree-text/40");
+    expect(wrapperFor().getAttribute("class")).not.toContain("text-status-warning");
+    expect(wrapperFor().getAttribute("class")).not.toContain("text-status-error");
+  });
+
   it("commits to red via the memory threshold alone", () => {
     mockResourceEnabled = true;
     mockResourceState = makeResourceState(10, 200_000);

--- a/src/components/Terminal/__tests__/TerminalResourceSparkline.test.tsx
+++ b/src/components/Terminal/__tests__/TerminalResourceSparkline.test.tsx
@@ -49,6 +49,6 @@ describe("TerminalResourceSparkline", () => {
     const { container } = render(<TerminalResourceSparkline history={[10, 20, 30]} />);
     const svg = container.querySelector("svg")!;
     const children = Array.from(svg.children);
-    expect(children[children.length - 1].tagName.toLowerCase()).toBe("circle");
+    expect(children[children.length - 1]!.tagName.toLowerCase()).toBe("circle");
   });
 });

--- a/src/components/Terminal/__tests__/TerminalResourceSparkline.test.tsx
+++ b/src/components/Terminal/__tests__/TerminalResourceSparkline.test.tsx
@@ -1,0 +1,47 @@
+// @vitest-environment jsdom
+import { describe, it, expect } from "vitest";
+import { render } from "@testing-library/react";
+import { TerminalResourceSparkline } from "../TerminalResourceSparkline";
+
+describe("TerminalResourceSparkline", () => {
+  it("renders nothing with fewer than 2 data points", () => {
+    const { container } = render(<TerminalResourceSparkline history={[50]} />);
+    expect(container.querySelector("svg")).toBeNull();
+  });
+
+  it("renders an end-cap dot that inherits color via currentColor", () => {
+    const { container } = render(<TerminalResourceSparkline history={[10, 40, 70]} />);
+    const circle = container.querySelector("circle");
+    expect(circle).not.toBeNull();
+    // The dot must inherit the parent severity tint, never carry its own color.
+    expect(circle!.getAttribute("fill")).toBe("currentColor");
+    expect(circle!.getAttribute("stroke")).toBe("none");
+  });
+
+  it("anchors the dot to the last data point at the right edge", () => {
+    const { container } = render(<TerminalResourceSparkline history={[0, 0, 50]} />);
+    const circle = container.querySelector("circle")!;
+    // width=48; last x is the right edge.
+    expect(circle.getAttribute("cx")).toBe("48");
+    // 50% CPU over a 14px height => y = 14 - 7 = 7.
+    expect(circle.getAttribute("cy")).toBe("7");
+  });
+
+  it("clamps the dot cy so it stays inside the viewBox at extremes", () => {
+    const radius = 2;
+    const { container: hot } = render(<TerminalResourceSparkline history={[0, 100]} />);
+    // 100% CPU => raw y = 0, clamped up to the radius.
+    expect(hot.querySelector("circle")!.getAttribute("cy")).toBe(String(radius));
+
+    const { container: cold } = render(<TerminalResourceSparkline history={[100, 0]} />);
+    // 0% CPU => raw y = 14, clamped down to height - radius.
+    expect(cold.querySelector("circle")!.getAttribute("cy")).toBe(String(14 - radius));
+  });
+
+  it("renders the dot after the polyline so it draws on top", () => {
+    const { container } = render(<TerminalResourceSparkline history={[10, 20, 30]} />);
+    const svg = container.querySelector("svg")!;
+    const children = Array.from(svg.children);
+    expect(children[children.length - 1].tagName.toLowerCase()).toBe("circle");
+  });
+});

--- a/src/components/Terminal/__tests__/TerminalResourceSparkline.test.tsx
+++ b/src/components/Terminal/__tests__/TerminalResourceSparkline.test.tsx
@@ -27,6 +27,13 @@ describe("TerminalResourceSparkline", () => {
     expect(circle.getAttribute("cy")).toBe("7");
   });
 
+  it("lets the edge-anchored dot render fully via overflow visible", () => {
+    // cx=48 sits on the viewBox right edge; without overflow:visible the dot
+    // would clip to a half-disk.
+    const { container } = render(<TerminalResourceSparkline history={[10, 20, 30]} />);
+    expect(container.querySelector("svg")!.getAttribute("overflow")).toBe("visible");
+  });
+
   it("clamps the dot cy so it stays inside the viewBox at extremes", () => {
     const radius = 2;
     const { container: hot } = render(<TerminalResourceSparkline history={[0, 100]} />);


### PR DESCRIPTION
## Summary

Two additive polish changes to the per-pane resource strip in the terminal header (closes #8092).

### 1. Sparkline end-cap dot

Added a small dot at the final CPU data point in `TerminalResourceSparkline` so the trend line visually anchors to the adjacent numeric readout instead of trailing off into empty space. The dot inherits the surrounding severity tint via `fill="currentColor"` (and `stroke="none"`) — no independent color logic, so muted/amber/red track the parent automatically. `cy` is clamped to `[r, height-r]` and the SVG carries `overflow="visible"` so the edge-anchored dot (`cx=48`, on the viewBox right edge) renders as a full circle rather than clipping to a half-disk at the 0%/100% CPU extremes.

### 2. Asymmetric severity hysteresis

Split the symmetric `SEVERITY_HYSTERESIS_POLLS = 3` into direction-sensitive thresholds via a `SEVERITY_ORDER` ordinal map:

- `ESCALATION_HYSTERESIS_POLLS = 3` — escalating to a hotter band stays responsive.
- `DE_ESCALATION_HYSTERESIS_POLLS = 5` — de-escalating back down lingers, so a hot state doesn't vanish on a single quiet poll.

**Deliberate divergence from precedent:** this intentionally does *not* follow `ProcessDetector`'s symmetric hysteresis. For a resource indicator, a missed spike is worse than a slightly stale calm reading — the asymmetry biases toward keeping hot signals visible, matching standard observability tooling practice (and the established asymmetric-band pattern in `ResourceProfileService`, #4629). The existing candidate-reset / oscillation refs are reused unchanged.

## Tests

- Updated the downward-cascade test to drive 5 polls per de-escalation step.
- Added cases: 4-poll de-escalation hold, exact 5-poll commit, oscillation within the 3–5 gap holding the hotter band, and red→muted skip-step (no stepping through amber).
- New `TerminalResourceSparkline.test.tsx` suite covering the end-cap dot: `currentColor` inheritance, right-edge anchoring, `cy` clamping at extremes, `overflow="visible"`, and draw order.

All checks green (typecheck / lint / format); 39 unit tests passing.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
