### PR TITLE
fix(worktree): remove duplicate focus ring on sidebar row inner button

### DIFF
--- a/src/components/Sidebar/__tests__/SidebarContent.grid.test.ts
+++ b/src/components/Sidebar/__tests__/SidebarContent.grid.test.ts
@@ -54,11 +54,12 @@ describe("Worktree list keyboard grid — issue #6422", () => {
     });
 
     it("keeps outline-hidden on the inner click-target button to preserve forced-colors UA outline (#8094)", () => {
-      expect(source).toContain("outline-hidden");
+      expect(source).toMatch(/"absolute inset-0 z-0 outline-hidden"/);
     });
 
     it("does not paint a duplicate accent focus ring on the inner button — card-level :has(> button:focus-visible) ring is canonical (#8094)", () => {
       expect(source).not.toContain("focus-visible:outline-daintree-accent");
+      expect(source).not.toContain("focus-visible:ring-daintree-accent");
     });
   });
 

--- a/src/components/Sidebar/__tests__/SidebarContent.grid.test.ts
+++ b/src/components/Sidebar/__tests__/SidebarContent.grid.test.ts
@@ -52,6 +52,14 @@ describe("Worktree list keyboard grid — issue #6422", () => {
     it('only applies role="group" in the overview grid variant — sidebar rows defer to the row wrapper', () => {
       expect(source).toContain('role={variant === "grid" ? "group" : undefined}');
     });
+
+    it("keeps outline-hidden on the inner click-target button to preserve forced-colors UA outline (#8094)", () => {
+      expect(source).toContain("outline-hidden");
+    });
+
+    it("does not paint a duplicate accent focus ring on the inner button — card-level :has(> button:focus-visible) ring is canonical (#8094)", () => {
+      expect(source).not.toContain("focus-visible:outline-daintree-accent");
+    });
   });
 
   describe("WorktreeHeader actions toolbar", () => {

--- a/src/components/Worktree/WorktreeCard.tsx
+++ b/src/components/Worktree/WorktreeCard.tsx
@@ -625,7 +625,7 @@ export function WorktreeCard({
           <button
             type="button"
             className={cn(
-              "absolute inset-0 z-0 outline-hidden focus-visible:outline focus-visible:outline-2 focus-visible:outline-offset-[-2px] focus-visible:outline-daintree-accent",
+              "absolute inset-0 z-0 outline-hidden",
               variant === "grid" && "rounded-lg",
               (isDraggingSort || isWorktreeSortDragging) && "pointer-events-none"
             )}


### PR DESCRIPTION
## Summary

- Worktree sidebar rows were drawing two concentric focus rings on the same focus event — one from the card-level `:has(> button:focus-visible)` rule in `sidebar.css` (box-shadow using `--sidebar-ring`), and one from `focus-visible:outline` classes on the inner button itself
- Removed the `focus-visible:outline*` classes from the inner button in `WorktreeCard.tsx`; `outline-hidden` is kept as a baseline so forced-colors UA outlines still fire correctly
- The card-level rule is the canonical focus indicator — no need for the button to also paint one

Resolves #8094

## Changes

- `src/components/Worktree/WorktreeCard.tsx` — dropped `focus-visible:outline focus-visible:outline-2 focus-visible:outline-offset-[-2px] focus-visible:outline-daintree-accent` from the inner button's `className`; `outline-hidden` remains
- `src/components/Sidebar/__tests__/SidebarContent.grid.test.ts` — two regression test blocks added to the `WorktreeCard role conditional` describe to lock the fix in place

## Testing

- `npx vitest run src/components/Sidebar/__tests__/SidebarContent.grid.test.ts` — 60 tests pass
- `npx vitest run src/components/Worktree` — 865 tests pass
- `npm run check` — typecheck, lint, format all clean