### PR TITLE
fix(worktree): replace PR badge opacity-as-stale with Clock glyph

### DIFF
--- a/src/components/Worktree/WorktreeCard/PRBadge.tsx
+++ b/src/components/Worktree/WorktreeCard/PRBadge.tsx
@@ -69,8 +69,8 @@ export function PRBadge({
       : `Open ${prStateLabel} pull request #${prNumber} on GitHub`;
 
   const freshnessSuffixStr = useMemo(
-    () => freshnessSuffix(freshnessLevel, cacheLastUpdatedAt, now),
-    [freshnessLevel, cacheLastUpdatedAt, now]
+    () => freshnessSuffix(freshnessLevel, rowLastUpdatedAt ?? cacheLastUpdatedAt, now),
+    [freshnessLevel, rowLastUpdatedAt, cacheLastUpdatedAt, now]
   );
 
   return (

--- a/src/components/Worktree/WorktreeCard/PRBadge.tsx
+++ b/src/components/Worktree/WorktreeCard/PRBadge.tsx
@@ -1,12 +1,12 @@
 import { useMemo } from "react";
 import { cn } from "@/lib/utils";
-import { CornerDownRight, GitPullRequest } from "lucide-react";
+import { Clock, CornerDownRight, GitPullRequest } from "lucide-react";
 import type { GitHubPRCIStatus } from "@shared/types/github";
 import { Tooltip, TooltipContent, TooltipTrigger } from "../../ui/tooltip";
 import { usePRTooltip } from "@/hooks/useGitHubTooltip";
 import { useGitHubBadgeTooltip } from "./hooks/useGitHubBadgeTooltip";
 import { useGitHubBadgeFreshness } from "./hooks/useGitHubBadgeFreshness";
-import { freshnessOpacityClass, freshnessSuffix } from "@/components/Layout/FreshnessUtils";
+import { freshnessSuffix } from "@/components/Layout/FreshnessUtils";
 import { PRTooltipContent, TooltipLoading, TokenMissingTooltip } from "./GitHubTooltipContent";
 import { getPRCIStatusVisual } from "@/components/GitHub/prCIStatus";
 
@@ -81,8 +81,7 @@ export function PRBadge({
           onClick={handleClick}
           data-no-dnd
           className={cn(
-            "flex items-center gap-1 text-xs text-left cursor-pointer transition-colors focus-visible:outline focus-visible:outline-2 focus-visible:outline-daintree-accent min-w-0",
-            freshnessOpacityClass(freshnessLevel)
+            "flex items-center gap-1 text-xs text-left cursor-pointer transition-colors focus-visible:outline focus-visible:outline-2 focus-visible:outline-daintree-accent min-w-0"
           )}
           aria-disabled={!isActive || undefined}
           aria-label={ariaLabel}
@@ -120,6 +119,13 @@ export function PRBadge({
                 <span className={cn("block w-2 h-2 rounded-full", ciVisual.colorClass)} />
               )}
             </span>
+          )}
+          {freshnessLevel === "aging" && !missingToken && (
+            <Clock
+              className="w-3 h-3 shrink-0 text-text-muted"
+              strokeWidth={2.5}
+              aria-hidden="true"
+            />
           )}
         </button>
       </TooltipTrigger>

--- a/src/components/Worktree/WorktreeCard/hooks/__tests__/useGitHubBadgeFreshness.test.tsx
+++ b/src/components/Worktree/WorktreeCard/hooks/__tests__/useGitHubBadgeFreshness.test.tsx
@@ -23,6 +23,7 @@ vi.mock("@/hooks/useGlobalMinuteTicker", () => ({
 }));
 
 const PR_KEY = "/test/repo:pr:open:created";
+const ISSUE_KEY = "/test/repo:issue:open:created";
 const STALE_THRESHOLD_MS = 3 * 60 * 1000;
 const FIXED_NOW = 10_000_000;
 
@@ -163,5 +164,28 @@ describe("useGitHubBadgeFreshness", () => {
     });
     rerender();
     expect(result.current.freshnessLevel).toBe("fresh");
+  });
+
+  it("uses the issue cache key when type is 'issue'", () => {
+    const cacheTime = FIXED_NOW - 5_000;
+    cache.setCache(ISSUE_KEY, makeCacheEntry(cacheTime));
+    cache.setCache(PR_KEY, makeCacheEntry(FIXED_NOW - 50_000));
+
+    const { result } = renderHook(() => useGitHubBadgeFreshness("issue", FIXED_NOW));
+    expect(result.current.cacheLastUpdatedAt).toBe(cacheTime);
+  });
+
+  it("re-evaluates aging as wall-clock time advances past threshold", () => {
+    const rowTime = FIXED_NOW - (STALE_THRESHOLD_MS - 1);
+    const { result, rerender } = renderHook(({ row }) => useGitHubBadgeFreshness("pr", row), {
+      initialProps: { row: rowTime },
+    });
+    expect(result.current.freshnessLevel).toBe("fresh");
+
+    vi.setSystemTime(FIXED_NOW + 2);
+    mockTick = 2;
+    rerender({ row: rowTime });
+
+    expect(result.current.freshnessLevel).toBe("aging");
   });
 });

--- a/src/components/Worktree/WorktreeCard/hooks/__tests__/useGitHubBadgeFreshness.test.tsx
+++ b/src/components/Worktree/WorktreeCard/hooks/__tests__/useGitHubBadgeFreshness.test.tsx
@@ -23,79 +23,96 @@ vi.mock("@/hooks/useGlobalMinuteTicker", () => ({
 }));
 
 const PR_KEY = "/test/repo:pr:open:created";
-const ISSUE_KEY = "/test/repo:issue:open:created";
+const STALE_THRESHOLD_MS = 3 * 60 * 1000;
+const FIXED_NOW = 10_000_000;
 
 describe("useGitHubBadgeFreshness", () => {
   beforeEach(() => {
     cache._resetForTests();
     useGitHubRateLimitStore.setState({ blocked: false, kind: null, resetAt: null });
     mockTick = 1;
+    vi.useFakeTimers();
+    vi.setSystemTime(FIXED_NOW);
   });
 
   afterEach(() => {
     cache._resetForTests();
     useGitHubRateLimitStore.setState({ blocked: false, kind: null, resetAt: null });
+    vi.useRealTimers();
   });
 
-  it("returns fresh when no row timestamp", () => {
+  it("returns fresh when row timestamp is undefined", () => {
     const { result } = renderHook(() => useGitHubBadgeFreshness("pr", undefined));
     expect(result.current.freshnessLevel).toBe("fresh");
   });
 
-  it("returns fresh when no cache entry exists", () => {
-    const { result } = renderHook(() => useGitHubBadgeFreshness("pr", Date.now()));
+  it("returns fresh when row timestamp is null (cast)", () => {
+    const { result } = renderHook(() =>
+      useGitHubBadgeFreshness("pr", null as unknown as number | undefined)
+    );
     expect(result.current.freshnessLevel).toBe("fresh");
-    expect(result.current.cacheLastUpdatedAt).toBeNull();
   });
 
-  it("returns aging when cache timestamp is newer than row", () => {
-    const rowTime = 1000;
-    const cacheTime = 2000;
-    cache.setCache(PR_KEY, makeCacheEntry(cacheTime));
+  it("returns fresh when row was just updated (age 0)", () => {
+    const { result } = renderHook(() => useGitHubBadgeFreshness("pr", FIXED_NOW));
+    expect(result.current.freshnessLevel).toBe("fresh");
+  });
 
+  it("returns fresh when row age is just below threshold", () => {
+    const rowTime = FIXED_NOW - (STALE_THRESHOLD_MS - 1);
+    const { result } = renderHook(() => useGitHubBadgeFreshness("pr", rowTime));
+    expect(result.current.freshnessLevel).toBe("fresh");
+  });
+
+  it("returns fresh when row age equals threshold exactly (strict >)", () => {
+    const rowTime = FIXED_NOW - STALE_THRESHOLD_MS;
+    const { result } = renderHook(() => useGitHubBadgeFreshness("pr", rowTime));
+    expect(result.current.freshnessLevel).toBe("fresh");
+  });
+
+  it("returns aging when row age is just over threshold", () => {
+    const rowTime = FIXED_NOW - (STALE_THRESHOLD_MS + 1);
     const { result } = renderHook(() => useGitHubBadgeFreshness("pr", rowTime));
     expect(result.current.freshnessLevel).toBe("aging");
+  });
+
+  it("returns aging when row age is well past threshold", () => {
+    const rowTime = FIXED_NOW - 10 * 60 * 1000;
+    const { result } = renderHook(() => useGitHubBadgeFreshness("pr", rowTime));
+    expect(result.current.freshnessLevel).toBe("aging");
+  });
+
+  it("returns fresh when row timestamp is in the future (clock skew)", () => {
+    const rowTime = FIXED_NOW + 60_000;
+    const { result } = renderHook(() => useGitHubBadgeFreshness("pr", rowTime));
+    expect(result.current.freshnessLevel).toBe("fresh");
+  });
+
+  it("does not use cache timestamp to determine aging", () => {
+    const rowTime = FIXED_NOW - 1000;
+    cache.setCache(PR_KEY, makeCacheEntry(FIXED_NOW));
+
+    const { result } = renderHook(() => useGitHubBadgeFreshness("pr", rowTime));
+    expect(result.current.freshnessLevel).toBe("fresh");
+  });
+
+  it("still returns cacheLastUpdatedAt for tooltip suffix consumers", () => {
+    const cacheTime = FIXED_NOW - 5_000;
+    cache.setCache(PR_KEY, makeCacheEntry(cacheTime));
+
+    const { result } = renderHook(() => useGitHubBadgeFreshness("pr", FIXED_NOW));
     expect(result.current.cacheLastUpdatedAt).toBe(cacheTime);
   });
 
-  it("returns fresh when cache timestamp equals row", () => {
-    const time = Date.now();
-    cache.setCache(PR_KEY, makeCacheEntry(time));
-
-    const { result } = renderHook(() => useGitHubBadgeFreshness("pr", time));
-    expect(result.current.freshnessLevel).toBe("fresh");
+  it("returns null cacheLastUpdatedAt when no cache entry exists", () => {
+    const { result } = renderHook(() => useGitHubBadgeFreshness("pr", FIXED_NOW));
+    expect(result.current.cacheLastUpdatedAt).toBeNull();
   });
 
-  it("returns fresh when cache timestamp is older than row", () => {
-    const rowTime = 2000;
-    const cacheTime = 1000;
-    cache.setCache(PR_KEY, makeCacheEntry(cacheTime));
-
-    const { result } = renderHook(() => useGitHubBadgeFreshness("pr", rowTime));
-    expect(result.current.freshnessLevel).toBe("fresh");
-  });
-
-  it("uses correct cache key for issue type", () => {
-    const rowTime = 1000;
-    const cacheTime = 2000;
-    cache.setCache(ISSUE_KEY, makeCacheEntry(cacheTime));
-
-    const { result } = renderHook(() => useGitHubBadgeFreshness("issue", rowTime));
-    expect(result.current.freshnessLevel).toBe("aging");
-  });
-
-  it("returns fresh when cache timestamp is not newer than row", () => {
-    const rowTime = 2000;
-    cache.setCache(PR_KEY, makeCacheEntry(1500));
-
-    const { result } = renderHook(() => useGitHubBadgeFreshness("pr", rowTime));
-    expect(result.current.freshnessLevel).toBe("fresh");
-  });
-
-  it("provides now from Date.now when ticker is active", () => {
+  it("returns now reflecting wall-clock time", () => {
     mockTick = 5;
     const { result } = renderHook(() => useGitHubBadgeFreshness("pr", undefined));
-    expect(result.current.now).toBeGreaterThan(0);
+    expect(result.current.now).toBe(FIXED_NOW);
   });
 
   it("treats badges as aging while rate-limit pause is active, even with no cache", () => {

--- a/src/components/Worktree/WorktreeCard/hooks/useGitHubBadgeFreshness.ts
+++ b/src/components/Worktree/WorktreeCard/hooks/useGitHubBadgeFreshness.ts
@@ -8,6 +8,8 @@ import { useGitHubRateLimitStore } from "@/store/githubRateLimitStore";
 const DEFAULT_FILTER_STATE = "open";
 const DEFAULT_SORT_ORDER = "created";
 
+const STALE_THRESHOLD_MS = 3 * 60 * 1000;
+
 const noopSubscribe = () => () => {};
 
 interface UseGitHubBadgeFreshnessResult {
@@ -40,11 +42,9 @@ export function useGitHubBadgeFreshness(
   // would be misleading. Treat as `aging` until the block clears.
   const freshnessLevel: FreshnessLevel = rateLimitBlocked
     ? "aging"
-    : rowLastUpdatedAt == null || cacheLastUpdatedAt == null
-      ? "fresh"
-      : cacheLastUpdatedAt > rowLastUpdatedAt
-        ? "aging"
-        : "fresh";
+    : rowLastUpdatedAt != null && now - rowLastUpdatedAt > STALE_THRESHOLD_MS
+      ? "aging"
+      : "fresh";
 
   return { freshnessLevel, cacheLastUpdatedAt, now };
 }


### PR DESCRIPTION
## Summary

- Drops `opacity-75` from `PRBadge` — opacity is the WCAG disabled-element cue and made a clickable badge read as non-interactive
- Replaces it with a small neutral Clock glyph (lucide-react, `w-3 h-3`, `text-text-muted`, `aria-hidden`) shown only when the PR row hasn't been refreshed in over 3 minutes
- Widens the aging rule in `useGitHubBadgeFreshness` from a cache-vs-row recency comparison (which fired on every normal refresh) to a wall-clock check: `now - rowLastUpdatedAt > 180_000`

Resolves #8076

## Changes

- `PRBadge.tsx` — removed `freshnessOpacityClass`, added stale Clock glyph driven by `rowLastUpdatedAt`; passes `rowLastUpdatedAt` through to `freshnessSuffix` so the "updated N ago" tooltip age matches the glyph signal
- `useGitHubBadgeFreshness.ts` — aging rule now compares wall-clock elapsed time against the 180s threshold; subscribes to the existing global ticker so the component rerenders when the threshold is crossed
- `useGitHubBadgeFreshness.test.tsx` — 14 tests covering threshold boundaries (0, threshold-1, threshold, threshold+1, future skew), issue-type cache key path, `cacheLastUpdatedAt` tooltip data path, and a ticker rerender that crosses the threshold

`FreshnessUtils.tsx`, `IssueBadge.tsx`, and `GitHubStatsToolbarButton.tsx` are untouched.

## Testing

Unit tests cover the full threshold boundary set and the ticker-driven rerender. The aging rule previously fired on every normal list refresh — the wall-clock approach means the glyph only appears when data is genuinely old.