### PR TITLE
feat(settings): sticky-position SettingsSection headers on long tabs

### DIFF
--- a/src/components/Settings/GeneralTab.tsx
+++ b/src/components/Settings/GeneralTab.tsx
@@ -756,7 +756,7 @@ export function GeneralTab({
               />
 
               {idleNotifyConfig.enabled && (
-                <div id="general-idle-terminal-threshold" className="space-y-2">
+                <div id="general-idle-terminal-threshold" className="space-y-2 scroll-mt-12">
                   <label className="text-sm text-daintree-text/70">Idle Threshold</label>
                   <div className="flex gap-2">
                     {IDLE_TERMINAL_THRESHOLD_PRESETS.map(({ value, label }) => (
@@ -807,7 +807,7 @@ export function GeneralTab({
               />
 
               {hibernationConfig.enabled && (
-                <div id="general-hibernation-threshold" className="space-y-2">
+                <div id="general-hibernation-threshold" className="space-y-2 scroll-mt-12">
                   <label className="text-sm text-daintree-text/70">Inactivity Threshold</label>
                   <div className="flex gap-2">
                     {THRESHOLD_PRESETS.map(({ value, label }) => (

--- a/src/components/Settings/SettingsSection.tsx
+++ b/src/components/Settings/SettingsSection.tsx
@@ -25,12 +25,14 @@ export function SettingsSection({
 
   return (
     <div
-      className="grid grid-cols-[minmax(0,1fr)] gap-3"
+      className="grid grid-cols-[minmax(0,1fr)] gap-3 scroll-mt-12"
       id={id}
       role="group"
       aria-labelledby={headingId}
     >
-      <div>
+      {/* -mx-6/px-6 mirror the SettingsDialog scrollport's p-6 padding so the
+          sticky header background bleeds edge-to-edge; keep them in sync. */}
+      <div className="settings-section-header sticky top-0 z-20 -mx-6 px-6 pb-1.5">
         <h4
           id={headingId}
           className="text-sm font-medium text-daintree-text mb-1.5 flex items-center gap-2 flex-wrap"

--- a/src/components/Settings/__tests__/SettingsSection.test.tsx
+++ b/src/components/Settings/__tests__/SettingsSection.test.tsx
@@ -47,4 +47,31 @@ describe("SettingsSection", () => {
     expect(root.classList.contains("grid-cols-[minmax(0,1fr)]")).toBe(true);
     expect(root.classList.contains("gap-3")).toBe(true);
   });
+
+  it("offsets the scroll anchor so scrollIntoView clears the sticky header", () => {
+    const { container } = render(
+      <SettingsSection icon={TestIcon} title="My Section" description="desc" id="my-section">
+        <div>child</div>
+      </SettingsSection>
+    );
+    const root = container.firstElementChild as HTMLElement;
+    expect(root.id).toBe("my-section");
+    expect(root.classList.contains("scroll-mt-12")).toBe(true);
+  });
+
+  it("pins the heading wrapper with a translucent sticky header", () => {
+    const { container } = render(
+      <SettingsSection icon={TestIcon} title="My Section" description="desc">
+        <div>child</div>
+      </SettingsSection>
+    );
+    const header = container.querySelector(".settings-section-header") as HTMLElement;
+    expect(header).toBeTruthy();
+    for (const cls of ["sticky", "top-0", "z-20", "-mx-6", "px-6", "pb-1.5"]) {
+      expect(header.classList.contains(cls)).toBe(true);
+    }
+    // The heading and description live inside the sticky wrapper.
+    expect(header.contains(screen.getByText("My Section"))).toBe(true);
+    expect(header.contains(screen.getByText("desc"))).toBe(true);
+  });
 });

--- a/src/index.css
+++ b/src/index.css
@@ -2580,6 +2580,12 @@ body[data-performance-mode="true"] .surface-toolbar {
   background-color: var(--color-surface-toolbar) !important;
 }
 
+body[data-performance-mode="true"] .settings-section-header {
+  -webkit-backdrop-filter: none !important;
+  backdrop-filter: none !important;
+  background: var(--settings-section-header-bg-solid, var(--theme-surface-panel)) !important;
+}
+
 /* Disable terminal glow in performance mode */
 body[data-performance-mode="true"] .terminal-selected,
 body[data-performance-mode="true"] .terminal-focused {

--- a/src/styles/components/settings.css
+++ b/src/styles/components/settings.css
@@ -48,6 +48,24 @@
   border-color: var(--settings-kbd-border, var(--theme-border-default));
 }
 
+.settings-section-header {
+  --_bg: var(
+    --settings-section-header-bg,
+    color-mix(in oklch, var(--theme-surface-panel) 80%, transparent)
+  );
+  background: var(--_bg);
+  backdrop-filter: blur(8px);
+  -webkit-backdrop-filter: blur(8px);
+}
+
+@media (prefers-reduced-transparency: reduce) {
+  .settings-section-header {
+    --_bg: var(--settings-section-header-bg-solid, var(--theme-surface-panel));
+    backdrop-filter: none;
+    -webkit-backdrop-filter: none;
+  }
+}
+
 .settings-card {
   background: var(--settings-card-bg, var(--theme-surface-panel));
 }


### PR DESCRIPTION
## Summary

- Long settings tabs lose positional context as you scroll — it's easy to forget which section you're in. This PR makes `SettingsSection` headers sticky so the section label stays visible.
- The header row uses a translucent `backdrop-blur` background (`.settings-section-header` in `settings.css`), with a solid fallback under `prefers-reduced-transparency` and a separate performance-mode override in `index.css`. Background bleeds edge-to-edge with `-mx-6 px-6` to match the scrollport padding.
- `z-20` on the sticky row clears the `ScrollShadow` `z-10` overlays. `scroll-mt-12` added to id-bearing section `div`s so `scrollAndHighlightSettingsSection` doesn't land headings behind the sticky row.

Resolves #8103

## Changes

- `settings.css` — `.settings-section-header` sticky row with backdrop-blur and reduced-transparency fallback
- `index.css` — performance-mode override suppresses blur on the sticky header
- `SettingsSection.tsx` — applies sticky header class, `-mx-6 px-6` bleed, `z-20`
- `GeneralTab.tsx` — `scroll-mt-12` on the two conditionally-rendered threshold section divs
- `SettingsSection.test.tsx` — extended unit tests (6 passing)

## Testing

- Verified sticky headers on General, Terminal, and Appearance tabs (all have enough content to scroll)
- Confirmed `scrollAndHighlightSettingsSection` lands correctly with the new scroll margin
- Checked reduced-transparency and performance-mode overrides render the solid fallback
- Unit tests: 6 passing