### PR TITLE
fix(github): evict stale PR rows from dropdown cache on state transitions

### DIFF
--- a/src/contexts/WorktreeStoreContext.tsx
+++ b/src/contexts/WorktreeStoreContext.tsx
@@ -261,15 +261,38 @@ export function WorktreeStoreProvider({ children }: { children: ReactNode }) {
         // a project switch (#4670).
         const projectPath = useProjectStore.getState().currentProject?.path;
         if (!projectPath) return;
-        mutateCacheEntries(projectPath, "pr", (entry) => {
+        mutateCacheEntries(projectPath, "pr", (entry, keyRemainder) => {
+          // keyRemainder is `${filterState}:${sortOrder}`; filterState values
+          // ("open" | "closed" | "merged" | "all") contain no colons. Unknown
+          // values fall back to "all" semantics (keep the row, only patch CI)
+          // so a malformed key can never silently evict a PR.
+          const filterState = keyRemainder.split(":")[0];
+          const isFilteredSlot =
+            filterState === "open" || filterState === "closed" || filterState === "merged";
+
           let changed = false;
-          const items = entry.items.map((item) => {
+          const items: (typeof entry.items)[number][] = [];
+          for (const item of entry.items) {
             const pr = item as GitHubPR;
-            if (pr.number !== event.prNumber) return item;
-            if (pr.ciStatus === event.prCiStatus) return item;
+            if (pr.number !== event.prNumber) {
+              items.push(item);
+              continue;
+            }
+            // The PR's state no longer matches this filtered slot (e.g. a
+            // closed PR still sitting in the "open" slot). Drop the row so the
+            // sidebar badge and dropdown converge on the next filter switch
+            // instead of waiting out the 45s TTL.
+            if (isFilteredSlot && pr.state.toLowerCase() !== event.prState) {
+              changed = true;
+              continue;
+            }
+            if (pr.ciStatus === event.prCiStatus) {
+              items.push(item);
+              continue;
+            }
             changed = true;
-            return { ...pr, ciStatus: event.prCiStatus };
-          });
+            items.push({ ...pr, ciStatus: event.prCiStatus });
+          }
           if (!changed) return null;
           return { ...entry, items };
         });

--- a/src/contexts/WorktreeStoreContext.tsx
+++ b/src/contexts/WorktreeStoreContext.tsx
@@ -281,8 +281,11 @@ export function WorktreeStoreProvider({ children }: { children: ReactNode }) {
             // The PR's state no longer matches this filtered slot (e.g. a
             // closed PR still sitting in the "open" slot). Drop the row so the
             // sidebar badge and dropdown converge on the next filter switch
-            // instead of waiting out the 45s TTL.
-            if (isFilteredSlot && pr.state.toLowerCase() !== event.prState) {
+            // instead of waiting out the 45s TTL. This eviction branch must
+            // stay ahead of the CI-only branch below: it sets changed=true on
+            // removal even when ciStatus is unchanged, which is what triggers
+            // the generation bump in mutateCacheEntries.
+            if (isFilteredSlot && pr.state && pr.state.toLowerCase() !== event.prState) {
               changed = true;
               continue;
             }

--- a/src/contexts/__tests__/WorktreeStoreContext.prDetected.test.tsx
+++ b/src/contexts/__tests__/WorktreeStoreContext.prDetected.test.tsx
@@ -597,6 +597,46 @@ describe("WorktreeStoreProvider pr-detected handler", () => {
     expect(getGeneration(key)).toBe(genBefore + 1);
   });
 
+  it("evicts a closed PR from every 'open' sort slot in one event", async () => {
+    const store = await renderProvider();
+    act(() => {
+      store.getState().applyUpdate(makeWorktree("wt-1"), store.getState().nextVersion());
+    });
+
+    const createdKey = buildCacheKey("/repo/proj", "pr", "open", "created");
+    const updatedKey = buildCacheKey("/repo/proj", "pr", "open", "updated");
+    for (const key of [createdKey, updatedKey]) {
+      setCache(key, {
+        items: [{ ...makePR(42, "PENDING"), state: "OPEN" }],
+        endCursor: null,
+        hasNextPage: false,
+        timestamp: 1,
+      });
+    }
+    const genCreatedBefore = getGeneration(createdKey);
+    const genUpdatedBefore = getGeneration(updatedKey);
+
+    act(() => {
+      emit("pr-detected", {
+        type: "pr-detected",
+        worktreeId: "wt-1",
+        prNumber: 42,
+        prUrl: "https://example.test/pr/42",
+        prState: "closed",
+        prCiStatus: "FAILURE",
+      });
+    });
+
+    expect(
+      (getCache(createdKey)?.items as GitHubPR[]).find((it) => it.number === 42)
+    ).toBeUndefined();
+    expect(
+      (getCache(updatedKey)?.items as GitHubPR[]).find((it) => it.number === 42)
+    ).toBeUndefined();
+    expect(getGeneration(createdKey)).toBe(genCreatedBefore + 1);
+    expect(getGeneration(updatedKey)).toBe(genUpdatedBefore + 1);
+  });
+
   it("evicts a PR from the 'open' slot once it merges", async () => {
     const store = await renderProvider();
     act(() => {

--- a/src/contexts/__tests__/WorktreeStoreContext.prDetected.test.tsx
+++ b/src/contexts/__tests__/WorktreeStoreContext.prDetected.test.tsx
@@ -561,6 +561,165 @@ describe("WorktreeStoreProvider pr-detected handler", () => {
     expect((getCache(newKey)?.items[0] as GitHubPR).ciStatus).toBe("SUCCESS");
     expect((getCache(oldKey)?.items[0] as GitHubPR).ciStatus).toBe("PENDING");
   });
+
+  it("evicts a PR from the 'open' slot once it closes", async () => {
+    const store = await renderProvider();
+    act(() => {
+      store.getState().applyUpdate(makeWorktree("wt-1"), store.getState().nextVersion());
+    });
+
+    const key = buildCacheKey("/repo/proj", "pr", "open", "created");
+    setCache(key, {
+      items: [
+        { ...makePR(42, "PENDING"), state: "OPEN" },
+        { ...makePR(43, "SUCCESS"), state: "OPEN" },
+      ],
+      endCursor: null,
+      hasNextPage: false,
+      timestamp: 1,
+    });
+    const genBefore = getGeneration(key);
+
+    act(() => {
+      emit("pr-detected", {
+        type: "pr-detected",
+        worktreeId: "wt-1",
+        prNumber: 42,
+        prUrl: "https://example.test/pr/42",
+        prState: "closed",
+        prCiStatus: "FAILURE",
+      });
+    });
+
+    const items = getCache(key)?.items as GitHubPR[];
+    expect(items.find((it) => it.number === 42)).toBeUndefined();
+    expect(items.find((it) => it.number === 43)).toBeDefined();
+    expect(getGeneration(key)).toBe(genBefore + 1);
+  });
+
+  it("evicts a PR from the 'open' slot once it merges", async () => {
+    const store = await renderProvider();
+    act(() => {
+      store.getState().applyUpdate(makeWorktree("wt-1"), store.getState().nextVersion());
+    });
+
+    const key = buildCacheKey("/repo/proj", "pr", "open", "created");
+    setCache(key, {
+      items: [{ ...makePR(42, "SUCCESS"), state: "OPEN" }],
+      endCursor: null,
+      hasNextPage: false,
+      timestamp: 1,
+    });
+    const genBefore = getGeneration(key);
+
+    act(() => {
+      emit("pr-detected", {
+        type: "pr-detected",
+        worktreeId: "wt-1",
+        prNumber: 42,
+        prUrl: "https://example.test/pr/42",
+        prState: "merged",
+        prCiStatus: "SUCCESS",
+      });
+    });
+
+    expect((getCache(key)?.items as GitHubPR[]).find((it) => it.number === 42)).toBeUndefined();
+    expect(getGeneration(key)).toBe(genBefore + 1);
+  });
+
+  it("evicts a PR from the 'closed' slot once it reopens", async () => {
+    const store = await renderProvider();
+    act(() => {
+      store.getState().applyUpdate(makeWorktree("wt-1"), store.getState().nextVersion());
+    });
+
+    const key = buildCacheKey("/repo/proj", "pr", "closed", "created");
+    setCache(key, {
+      items: [{ ...makePR(42, "FAILURE"), state: "CLOSED" }],
+      endCursor: null,
+      hasNextPage: false,
+      timestamp: 1,
+    });
+    const genBefore = getGeneration(key);
+
+    act(() => {
+      emit("pr-detected", {
+        type: "pr-detected",
+        worktreeId: "wt-1",
+        prNumber: 42,
+        prUrl: "https://example.test/pr/42",
+        prState: "open",
+        prCiStatus: "PENDING",
+      });
+    });
+
+    expect((getCache(key)?.items as GitHubPR[]).find((it) => it.number === 42)).toBeUndefined();
+    expect(getGeneration(key)).toBe(genBefore + 1);
+  });
+
+  it("keeps the row in a CI-only rollup where the state is unchanged", async () => {
+    const store = await renderProvider();
+    act(() => {
+      store.getState().applyUpdate(makeWorktree("wt-1"), store.getState().nextVersion());
+    });
+
+    const key = buildCacheKey("/repo/proj", "pr", "open", "created");
+    setCache(key, {
+      items: [{ ...makePR(42, "PENDING"), state: "OPEN" }],
+      endCursor: null,
+      hasNextPage: false,
+      timestamp: 1,
+    });
+    const genBefore = getGeneration(key);
+
+    act(() => {
+      emit("pr-detected", {
+        type: "pr-detected",
+        worktreeId: "wt-1",
+        prNumber: 42,
+        prUrl: "https://example.test/pr/42",
+        prState: "open",
+        prCiStatus: "SUCCESS",
+      });
+    });
+
+    const pr42 = (getCache(key)?.items as GitHubPR[]).find((it) => it.number === 42);
+    expect(pr42).toBeDefined();
+    expect(pr42?.ciStatus).toBe("SUCCESS");
+    expect(getGeneration(key)).toBe(genBefore + 1);
+  });
+
+  it("keeps a state-changed PR in the 'all' slot, only patching CI", async () => {
+    const store = await renderProvider();
+    act(() => {
+      store.getState().applyUpdate(makeWorktree("wt-1"), store.getState().nextVersion());
+    });
+
+    const key = buildCacheKey("/repo/proj", "pr", "all", "created");
+    setCache(key, {
+      items: [{ ...makePR(42, "PENDING"), state: "OPEN" }],
+      endCursor: null,
+      hasNextPage: false,
+      timestamp: 1,
+    });
+    const genBefore = getGeneration(key);
+
+    act(() => {
+      emit("pr-detected", {
+        type: "pr-detected",
+        worktreeId: "wt-1",
+        prNumber: 42,
+        prUrl: "https://example.test/pr/42",
+        prState: "merged",
+        prCiStatus: "SUCCESS",
+      });
+    });
+
+    const pr42 = (getCache(key)?.items as GitHubPR[]).find((it) => it.number === 42);
+    expect(pr42).toBeDefined();
+    expect(pr42?.ciStatus).toBe("SUCCESS");
+    expect(getGeneration(key)).toBe(genBefore + 1);
+  });
 });
 
 describe("WorktreeStoreProvider pr-cleared handler", () => {

--- a/src/lib/githubResourceCache.ts
+++ b/src/lib/githubResourceCache.ts
@@ -52,9 +52,11 @@ export function getGeneration(key: string): number {
  * pair, regardless of filter or sort. Use after a mutation (close, merge,
  * reopen) so sibling filter slots don't serve stale rows on the next switch.
  *
- * The transform receives each entry and returns either a new entry (write
- * back + bump generation to discard any concurrent in-flight SWR for that
- * slot) or null (leave untouched, no generation bump).
+ * The transform receives each entry plus the key remainder after the
+ * `${projectPath}:${type}:` prefix (i.e. `${filterState}:${sortOrder}`), so it
+ * can tell which filter slot it is mutating. It returns either a new entry
+ * (write back + bump generation to discard any concurrent in-flight SWR for
+ * that slot) or null (leave untouched, no generation bump).
  *
  * Prefix-matches on `${projectPath}:${type}:` rather than splitting on `:`
  * because `projectPath` can contain colons on Windows (e.g., `C:\projects`).
@@ -62,12 +64,15 @@ export function getGeneration(key: string): number {
 export function mutateCacheEntries(
   projectPath: string,
   type: string,
-  transform: (entry: GitHubResourceCacheEntry) => GitHubResourceCacheEntry | null
+  transform: (
+    entry: GitHubResourceCacheEntry,
+    keyRemainder: string
+  ) => GitHubResourceCacheEntry | null
 ): void {
   const prefix = `${projectPath}:${type}:`;
   for (const [key, entry] of cache.entries()) {
     if (!key.startsWith(prefix)) continue;
-    const next = transform(entry);
+    const next = transform(entry, key.slice(prefix.length));
     if (next === null) continue;
     setCache(key, next);
     nextGeneration(key);


### PR DESCRIPTION
## Summary

The `pr-detected` event handler was patching `ciStatus` on cached rows but not removing them when a PR changed state (open→closed, open→merged, closed→reopened). The stale row stayed in the wrong filter slot and was missing from the correct one until the 45-second TTL expired, causing the sidebar `PRBadge` count to drift against the dropdown list.

- Pass the cache key remainder (`${filterState}:${sortOrder}`) to the `mutateCacheEntries` transform so the handler can identify each slot's filter
- Drop the PR row from any filtered slot whose filter no longer matches the new `prState`; CI-only rollups (unchanged `prState`) keep the row and only patch `ciStatus`
- Stateless cache rows are skipped; convergence happens on the next filter switch or dropdown mount

Resolves #8068

## Changes

- `src/contexts/WorktreeStoreContext.tsx` — `pr-detected` handler now evicts rows from mismatched filter slots
- `src/lib/githubResourceCache.ts` — `mutateCacheEntries` exposes the key remainder to the transform callback
- `src/contexts/__tests__/WorktreeStoreContext.prDetected.test.tsx` — 6 new tests: open→closed, open→merged, closed→reopened, CI-only rollup keeps row, `all`-slot keeps state-changed row, single event evicts from every open sort slot

## Testing

16/16 vitest pass. `npm run check` clean.