### PR TITLE
feat(settings): gate primitive errors behind touched state, finish transition-all fence

### DIFF
--- a/src/components/Settings/PresetColorPicker.tsx
+++ b/src/components/Settings/PresetColorPicker.tsx
@@ -99,7 +99,7 @@ export function PresetColorPicker({
       <PopoverTrigger asChild>
         <button
           type="button"
-          className="shrink-0 rounded-full ring-1 ring-transparent hover:ring-daintree-accent/50 focus-visible:ring-daintree-accent focus-visible:outline-hidden transition-all"
+          className="shrink-0 rounded-full ring-1 ring-transparent hover:ring-daintree-accent/50 focus-visible:ring-daintree-accent focus-visible:outline-hidden transition-shadow"
           aria-label={ariaLabel}
           title={ariaLabel}
           data-testid="preset-color-picker-trigger"

--- a/src/components/Settings/SettingsCheckbox.tsx
+++ b/src/components/Settings/SettingsCheckbox.tsx
@@ -13,6 +13,7 @@ interface SettingsCheckboxProps {
   onChange: (value: boolean) => void;
   disabled?: boolean;
   error?: string;
+  touched?: boolean;
   scope?: "default" | "global" | "project";
 }
 
@@ -24,6 +25,7 @@ export function SettingsCheckbox({
   onChange,
   disabled,
   error,
+  touched = true,
   scope,
 }: SettingsCheckboxProps) {
   const generatedId = useId();
@@ -31,7 +33,7 @@ export function SettingsCheckbox({
   const descriptionId = useId();
   const errorId = useId();
 
-  const isError = error !== undefined && error !== "";
+  const isError = touched && error !== undefined && error !== "";
   const describedBy = [isError ? errorId : null, descriptionId].filter(Boolean).join(" ");
 
   const scopeBadge = scope ? (

--- a/src/components/Settings/SettingsChoicebox.tsx
+++ b/src/components/Settings/SettingsChoicebox.tsx
@@ -17,6 +17,7 @@ interface SettingsChoiceboxProps<T extends string = string> extends Omit<
   label?: string;
   description?: ReactNode;
   error?: string;
+  touched?: boolean;
   isModified?: boolean;
   onReset?: () => void;
   resetAriaLabel?: string;
@@ -40,6 +41,7 @@ export function SettingsChoicebox<T extends string = string>({
   label,
   description,
   error,
+  touched = true,
   isModified,
   onReset,
   resetAriaLabel,
@@ -56,9 +58,10 @@ export function SettingsChoicebox<T extends string = string>({
   const descriptionId = useId();
   const errorId = useId();
   const showReset = isModified && onReset && !disabled;
+  const isError = !!error && touched;
 
   const describedBy =
-    [error ? errorId : null, description ? descriptionId : null].filter(Boolean).join(" ") ||
+    [isError ? errorId : null, description ? descriptionId : null].filter(Boolean).join(" ") ||
     undefined;
 
   const [focusedIndex, setFocusedIndex] = useState<number>(-1);
@@ -169,7 +172,7 @@ export function SettingsChoicebox<T extends string = string>({
         role="radiogroup"
         aria-labelledby={label && labelId}
         aria-describedby={describedBy}
-        aria-invalid={error ? true : undefined}
+        aria-invalid={isError ? true : undefined}
         className={cn("flex gap-2", {
           "grid grid-cols-2": columns === 2,
           "grid grid-cols-3": columns === 3,
@@ -222,7 +225,7 @@ export function SettingsChoicebox<T extends string = string>({
           {description}
         </p>
       )}
-      {error && (
+      {isError && (
         <p id={errorId} className="text-xs text-status-error">
           {error}
         </p>

--- a/src/components/Settings/SettingsInput.tsx
+++ b/src/components/Settings/SettingsInput.tsx
@@ -10,6 +10,7 @@ interface SettingsInputProps extends Omit<ComponentPropsWithoutRef<"input">, "id
   label: string;
   description?: ReactNode;
   error?: string;
+  touched?: boolean;
   isModified?: boolean;
   onReset?: () => void;
   resetAriaLabel?: string;
@@ -21,6 +22,7 @@ export function SettingsInput({
   label,
   description,
   error,
+  touched = true,
   isModified,
   onReset,
   resetAriaLabel,
@@ -34,9 +36,10 @@ export function SettingsInput({
   const descriptionId = useId();
   const errorId = useId();
   const showReset = isModified && onReset && !disabled;
+  const isError = !!error && touched;
 
   const describedBy =
-    [error ? errorId : null, description ? descriptionId : null].filter(Boolean).join(" ") ||
+    [isError ? errorId : null, description ? descriptionId : null].filter(Boolean).join(" ") ||
     undefined;
 
   const scopeBadge = scope ? (
@@ -84,8 +87,8 @@ export function SettingsInput({
         ref={ref}
         disabled={disabled}
         aria-describedby={describedBy}
-        aria-invalid={error ? true : undefined}
-        className={cn(INPUT_CLASSES, error && "border-status-error", className)}
+        aria-invalid={isError ? true : undefined}
+        className={cn(INPUT_CLASSES, isError && "border-status-error", className)}
         {...props}
       />
       {description && (
@@ -93,7 +96,7 @@ export function SettingsInput({
           {description}
         </p>
       )}
-      {error && (
+      {isError && (
         <p id={errorId} className="text-xs text-status-error">
           {error}
         </p>

--- a/src/components/Settings/SettingsNumberInput.tsx
+++ b/src/components/Settings/SettingsNumberInput.tsx
@@ -5,6 +5,7 @@ interface SettingsNumberInputProps extends Omit<ComponentPropsWithoutRef<"input"
   label: string;
   description?: ReactNode;
   error?: string;
+  touched?: boolean;
   isModified?: boolean;
   onReset?: () => void;
   resetAriaLabel?: string;

--- a/src/components/Settings/SettingsSelect.tsx
+++ b/src/components/Settings/SettingsSelect.tsx
@@ -21,6 +21,7 @@ interface SettingsSelectProps {
   label: string;
   description?: ReactNode;
   error?: string;
+  touched?: boolean;
   isModified?: boolean;
   onReset?: () => void;
   resetAriaLabel?: string;
@@ -38,6 +39,7 @@ export function SettingsSelect({
   label,
   description,
   error,
+  touched = true,
   isModified,
   onReset,
   resetAriaLabel,
@@ -54,9 +56,10 @@ export function SettingsSelect({
   const descriptionId = useId();
   const errorId = useId();
   const showReset = isModified && onReset && !disabled;
+  const isError = !!error && touched;
 
   const describedBy =
-    [error ? errorId : null, description ? descriptionId : null].filter(Boolean).join(" ") ||
+    [isError ? errorId : null, description ? descriptionId : null].filter(Boolean).join(" ") ||
     undefined;
 
   const scopeBadge = scope ? (
@@ -103,8 +106,8 @@ export function SettingsSelect({
         <SelectTrigger
           id={id}
           aria-describedby={describedBy}
-          aria-invalid={error ? true : undefined}
-          className={cn(error && "border-status-error focus:border-status-error", className)}
+          aria-invalid={isError ? true : undefined}
+          className={cn(isError && "border-status-error focus:border-status-error", className)}
         >
           <SelectValue placeholder={placeholder} />
         </SelectTrigger>
@@ -126,7 +129,7 @@ export function SettingsSelect({
           {description}
         </p>
       )}
-      {error && (
+      {isError && (
         <p id={errorId} className="text-xs text-status-error">
           {error}
         </p>

--- a/src/components/Settings/SettingsTextarea.tsx
+++ b/src/components/Settings/SettingsTextarea.tsx
@@ -10,6 +10,7 @@ interface SettingsTextareaProps extends Omit<ComponentPropsWithoutRef<"textarea"
   label: string;
   description?: ReactNode;
   error?: string;
+  touched?: boolean;
   isModified?: boolean;
   onReset?: () => void;
   resetAriaLabel?: string;
@@ -20,6 +21,7 @@ export function SettingsTextarea({
   label,
   description,
   error,
+  touched = true,
   isModified,
   onReset,
   resetAriaLabel,
@@ -32,9 +34,10 @@ export function SettingsTextarea({
   const descriptionId = useId();
   const errorId = useId();
   const showReset = isModified && onReset && !disabled;
+  const isError = !!error && touched;
 
   const describedBy =
-    [error ? errorId : null, description ? descriptionId : null].filter(Boolean).join(" ") ||
+    [isError ? errorId : null, description ? descriptionId : null].filter(Boolean).join(" ") ||
     undefined;
 
   return (
@@ -67,8 +70,8 @@ export function SettingsTextarea({
         ref={ref}
         disabled={disabled}
         aria-describedby={describedBy}
-        aria-invalid={error ? true : undefined}
-        className={cn(TEXTAREA_CLASSES, error && "border-status-error", className)}
+        aria-invalid={isError ? true : undefined}
+        className={cn(TEXTAREA_CLASSES, isError && "border-status-error", className)}
         {...props}
       />
       {description && (
@@ -76,7 +79,7 @@ export function SettingsTextarea({
           {description}
         </p>
       )}
-      {error && (
+      {isError && (
         <p id={errorId} className="text-xs text-status-error">
           {error}
         </p>

--- a/src/components/Settings/__tests__/SettingsFormPrimitives.test.tsx
+++ b/src/components/Settings/__tests__/SettingsFormPrimitives.test.tsx
@@ -8,6 +8,7 @@ import { SettingsTextarea } from "../SettingsTextarea";
 import { SettingsChoicebox, type ChoiceboxOption } from "../SettingsChoicebox";
 import { SettingsCheckbox } from "../SettingsCheckbox";
 import { SettingsSwitch } from "../SettingsSwitch";
+import { PresetColorPicker } from "../PresetColorPicker";
 
 describe("SettingsInput", () => {
   it("renders label associated to input", () => {
@@ -1032,5 +1033,233 @@ describe("layout contract — subgrid participation", () => {
       <SettingsCheckbox label="Test" description="desc" checked={false} onChange={vi.fn()} />
     );
     expect(getRoot(container).classList.contains("grid-cols-subgrid")).toBe(true);
+  });
+});
+
+describe("touched prop — error gating", () => {
+  const ERR = "This field is required";
+
+  const hasInvalid = (container: HTMLElement) =>
+    container.querySelector('[aria-invalid="true"]') !== null;
+
+  const hasErrorBorder = (container: HTMLElement) =>
+    Array.from(container.querySelectorAll("*")).some((el) =>
+      el.className.toString().includes("border-status-error")
+    );
+
+  it("SettingsInput hides error styling when touched={false}", () => {
+    const { container } = render(<SettingsInput label="Name" error={ERR} touched={false} />);
+    expect(hasInvalid(container)).toBe(false);
+    expect(hasErrorBorder(container)).toBe(false);
+    expect(screen.queryByText(ERR)).toBeNull();
+  });
+
+  it("SettingsInput shows error styling when touched omitted (backward compat)", () => {
+    const { container } = render(<SettingsInput label="Name" error={ERR} />);
+    expect(hasInvalid(container)).toBe(true);
+    expect(hasErrorBorder(container)).toBe(true);
+    expect(screen.getByText(ERR)).toBeTruthy();
+  });
+
+  it("SettingsInput shows error styling when touched={true}", () => {
+    const { container } = render(<SettingsInput label="Name" error={ERR} touched={true} />);
+    expect(hasInvalid(container)).toBe(true);
+    expect(screen.getByText(ERR)).toBeTruthy();
+  });
+
+  it("SettingsNumberInput hides error styling when touched={false}", () => {
+    const { container } = render(<SettingsNumberInput label="Count" error={ERR} touched={false} />);
+    expect(hasInvalid(container)).toBe(false);
+    expect(hasErrorBorder(container)).toBe(false);
+    expect(screen.queryByText(ERR)).toBeNull();
+  });
+
+  it("SettingsNumberInput shows error styling when touched omitted (backward compat)", () => {
+    const { container } = render(<SettingsNumberInput label="Count" error={ERR} />);
+    expect(hasInvalid(container)).toBe(true);
+    expect(screen.getByText(ERR)).toBeTruthy();
+  });
+
+  it("SettingsTextarea hides error styling when touched={false}", () => {
+    const { container } = render(<SettingsTextarea label="Bio" error={ERR} touched={false} />);
+    expect(hasInvalid(container)).toBe(false);
+    expect(hasErrorBorder(container)).toBe(false);
+    expect(screen.queryByText(ERR)).toBeNull();
+  });
+
+  it("SettingsTextarea shows error styling when touched omitted (backward compat)", () => {
+    const { container } = render(<SettingsTextarea label="Bio" error={ERR} />);
+    expect(hasInvalid(container)).toBe(true);
+    expect(hasErrorBorder(container)).toBe(true);
+    expect(screen.getByText(ERR)).toBeTruthy();
+  });
+
+  it("SettingsSelect hides error styling when touched={false}", () => {
+    const { container } = render(
+      <SettingsSelect
+        label="Lang"
+        value="en"
+        onValueChange={vi.fn()}
+        options={[{ value: "en", label: "English" }]}
+        error={ERR}
+        touched={false}
+      />
+    );
+    expect(hasInvalid(container)).toBe(false);
+    expect(hasErrorBorder(container)).toBe(false);
+    expect(screen.queryByText(ERR)).toBeNull();
+  });
+
+  it("SettingsSelect shows error styling when touched omitted (backward compat)", () => {
+    const { container } = render(
+      <SettingsSelect
+        label="Lang"
+        value="en"
+        onValueChange={vi.fn()}
+        options={[{ value: "en", label: "English" }]}
+        error={ERR}
+      />
+    );
+    expect(hasInvalid(container)).toBe(true);
+    expect(hasErrorBorder(container)).toBe(true);
+    expect(screen.getByText(ERR)).toBeTruthy();
+  });
+
+  it("SettingsChoicebox hides error styling when touched={false}", () => {
+    const { container } = render(
+      <SettingsChoicebox
+        label="Density"
+        value="normal"
+        onChange={vi.fn()}
+        options={MOCK_OPTIONS}
+        error={ERR}
+        touched={false}
+      />
+    );
+    expect(hasInvalid(container)).toBe(false);
+    expect(screen.queryByText(ERR)).toBeNull();
+  });
+
+  it("SettingsChoicebox shows error styling when touched omitted (backward compat)", () => {
+    const { container } = render(
+      <SettingsChoicebox
+        label="Density"
+        value="normal"
+        onChange={vi.fn()}
+        options={MOCK_OPTIONS}
+        error={ERR}
+      />
+    );
+    expect(hasInvalid(container)).toBe(true);
+    expect(screen.getByText(ERR)).toBeTruthy();
+  });
+
+  it("SettingsCheckbox hides error styling when touched={false}", () => {
+    const { container } = render(
+      <SettingsCheckbox
+        label="Agree"
+        description="desc"
+        checked={false}
+        onChange={vi.fn()}
+        error={ERR}
+        touched={false}
+      />
+    );
+    expect(hasInvalid(container)).toBe(false);
+    expect(hasErrorBorder(container)).toBe(false);
+    expect(screen.queryByText(ERR)).toBeNull();
+  });
+
+  it("SettingsCheckbox shows error styling when touched omitted (backward compat)", () => {
+    const { container } = render(
+      <SettingsCheckbox
+        label="Agree"
+        description="desc"
+        checked={false}
+        onChange={vi.fn()}
+        error={ERR}
+      />
+    );
+    expect(hasInvalid(container)).toBe(true);
+    expect(hasErrorBorder(container)).toBe(true);
+    expect(screen.getByText(ERR)).toBeTruthy();
+  });
+
+  it("SettingsInput drops dangling aria-describedby errorId when touched={false}", () => {
+    const { container } = render(<SettingsInput label="Name" error={ERR} touched={false} />);
+    const input = container.querySelector("input");
+    expect(input?.getAttribute("aria-describedby")).toBeNull();
+  });
+});
+
+describe("transition-all regression — field primitives", () => {
+  const expectNoTransitionAll = (container: HTMLElement) => {
+    container.querySelectorAll("*").forEach((el) => {
+      expect(el.className.toString()).not.toContain("transition-all");
+    });
+  };
+
+  it("SettingsInput uses no transition-all", () => {
+    const { container } = render(<SettingsInput label="Test" error="err" />);
+    expectNoTransitionAll(container);
+  });
+
+  it("SettingsNumberInput uses no transition-all", () => {
+    const { container } = render(<SettingsNumberInput label="Test" error="err" />);
+    expectNoTransitionAll(container);
+  });
+
+  it("SettingsTextarea uses no transition-all", () => {
+    const { container } = render(<SettingsTextarea label="Test" error="err" />);
+    expectNoTransitionAll(container);
+  });
+
+  it("SettingsSelect uses no transition-all", () => {
+    const { container } = render(
+      <SettingsSelect
+        label="Test"
+        value="en"
+        onValueChange={vi.fn()}
+        options={[{ value: "en", label: "English" }]}
+        error="err"
+      />
+    );
+    expectNoTransitionAll(container);
+  });
+
+  it("SettingsChoicebox uses no transition-all", () => {
+    const { container } = render(
+      <SettingsChoicebox
+        label="Test"
+        value="normal"
+        onChange={vi.fn()}
+        options={MOCK_OPTIONS}
+        error="err"
+      />
+    );
+    expectNoTransitionAll(container);
+  });
+
+  it("SettingsCheckbox uses no transition-all", () => {
+    const { container } = render(
+      <SettingsCheckbox
+        label="Test"
+        description="desc"
+        checked={false}
+        onChange={vi.fn()}
+        error="err"
+      />
+    );
+    expectNoTransitionAll(container);
+  });
+
+  it("PresetColorPicker trigger uses transition-shadow, not transition-all", () => {
+    const { container } = render(
+      <PresetColorPicker color="#e06c75" onChange={vi.fn()} agentColor="#e06c75" />
+    );
+    const trigger = container.querySelector('[data-testid="preset-color-picker-trigger"]');
+    expect(trigger?.className).toContain("transition-shadow");
+    expect(trigger?.className).not.toContain("transition-all");
+    expectNoTransitionAll(container);
   });
 });

--- a/src/components/Settings/__tests__/SettingsFormPrimitives.test.tsx
+++ b/src/components/Settings/__tests__/SettingsFormPrimitives.test.tsx
@@ -1190,6 +1190,98 @@ describe("touched prop — error gating", () => {
     const input = container.querySelector("input");
     expect(input?.getAttribute("aria-describedby")).toBeNull();
   });
+
+  // Each entry: control selector + a render() of the primitive with
+  // error + description + touched=false. aria-describedby must resolve to
+  // exactly the description node — never the (non-rendered) error node.
+  const DESC = "Helps explain the field";
+  const describedByCases: ReadonlyArray<{
+    name: string;
+    selector: string;
+    render: () => ReturnType<typeof render>;
+  }> = [
+    {
+      name: "SettingsInput",
+      selector: "input",
+      render: () =>
+        render(<SettingsInput label="Name" error={ERR} description={DESC} touched={false} />),
+    },
+    {
+      name: "SettingsNumberInput",
+      selector: "input",
+      render: () =>
+        render(
+          <SettingsNumberInput label="Count" error={ERR} description={DESC} touched={false} />
+        ),
+    },
+    {
+      name: "SettingsTextarea",
+      selector: "textarea",
+      render: () =>
+        render(<SettingsTextarea label="Bio" error={ERR} description={DESC} touched={false} />),
+    },
+    {
+      name: "SettingsSelect",
+      selector: '[role="combobox"]',
+      render: () =>
+        render(
+          <SettingsSelect
+            label="Lang"
+            value="en"
+            onValueChange={vi.fn()}
+            options={[{ value: "en", label: "English" }]}
+            error={ERR}
+            description={DESC}
+            touched={false}
+          />
+        ),
+    },
+    {
+      name: "SettingsChoicebox",
+      selector: '[role="radiogroup"]',
+      render: () =>
+        render(
+          <SettingsChoicebox
+            label="Density"
+            value="normal"
+            onChange={vi.fn()}
+            options={MOCK_OPTIONS}
+            error={ERR}
+            description={DESC}
+            touched={false}
+          />
+        ),
+    },
+    {
+      name: "SettingsCheckbox",
+      selector: '[role="checkbox"]',
+      render: () =>
+        render(
+          <SettingsCheckbox
+            label="Agree"
+            description={DESC}
+            checked={false}
+            onChange={vi.fn()}
+            error={ERR}
+            touched={false}
+          />
+        ),
+    },
+  ];
+
+  describedByCases.forEach(({ name, selector, render: renderPrimitive }) => {
+    it(`${name} aria-describedby resolves to description only (not errorId) when touched={false}`, () => {
+      const { container } = renderPrimitive();
+      const control = container.querySelector(selector);
+      const describedBy = control?.getAttribute("aria-describedby");
+      expect(describedBy).toBeTruthy();
+      const ids = describedBy!.split(" ").filter(Boolean);
+      const texts = ids.map((id) => document.getElementById(id)?.textContent);
+      expect(texts).toContain(DESC);
+      expect(texts).not.toContain(ERR);
+      expect(screen.queryByText(ERR)).toBeNull();
+    });
+  });
 });
 
 describe("transition-all regression — field primitives", () => {


### PR DESCRIPTION
## Summary

- Adds an optional `touched?: boolean` prop (default `true`) to the six Settings field primitives: `SettingsInput`, `SettingsNumberInput`, `SettingsTextarea`, `SettingsSelect`, `SettingsChoicebox`, and `SettingsCheckbox`. When `touched` is `false`, `aria-invalid`, the error border, the error text, and `aria-describedby` are all suppressed. Existing callers are unaffected.
- Replaces the remaining `transition-all` in `PresetColorPicker.tsx` (line 102) with `transition-shadow` — the last straggler left after PR #4738.
- Extends the `transition-all` regression test in `SettingsFormPrimitives.test.tsx` from `SettingsSwitch`-only to all six field primitives plus `PresetColorPicker`, so the fence holds.

Resolves #8096

## Changes

- `SettingsInput`, `SettingsNumberInput`, `SettingsTextarea`, `SettingsSelect`, `SettingsChoicebox`, `SettingsCheckbox` — `touched` prop gates all error-state styling and ARIA attributes
- `PresetColorPicker.tsx` — `transition-all` → `transition-shadow`
- `SettingsFormPrimitives.test.tsx` — regression tests for `touched` gating (described-by, aria-invalid, error text visibility) across all six primitives; `transition-all` assertion extended to cover `PresetColorPicker` and all six primitives

## Testing

105 unit tests pass. `npm run check` (typecheck, lint, format, build) clean.