### PR TITLE
fix(worktree): polish row affordances — reveal timing, focus rings, drag handle

### DIFF
--- a/src/components/Worktree/WorktreeCard/EnvironmentPopover.tsx
+++ b/src/components/Worktree/WorktreeCard/EnvironmentPopover.tsx
@@ -93,7 +93,7 @@ export function EnvironmentPopover({
         <button
           type="button"
           data-no-dnd
-          className="shrink-0 rounded focus-visible:outline-hidden focus-visible:ring-1 focus-visible:ring-daintree-accent"
+          className="shrink-0 rounded focus-visible:outline focus-visible:outline-2 focus-visible:outline-daintree-accent"
           aria-label={`${worktreeMode ?? "Remote"} environment status`}
         >
           <EnvironmentIcon className={cn(iconClass, className)} />

--- a/src/components/Worktree/WorktreeCard/WorktreeActionsToolbar.tsx
+++ b/src/components/Worktree/WorktreeCard/WorktreeActionsToolbar.tsx
@@ -126,7 +126,7 @@ export function WorktreeActionsToolbar({
           ? "opacity-100"
           : isActive
             ? "opacity-100"
-            : "opacity-50 group-hover/card:opacity-100 group-focus-within/card:opacity-100 group-has-[[data-state=open]]/card:opacity-100"
+            : "opacity-50 delay-0 group-hover/card:opacity-100 group-hover/card:delay-[75ms] group-has-[:focus-visible]/card:opacity-100 group-has-[:focus-visible]/card:delay-0 group-has-[[data-state=open]]/card:opacity-100 group-has-[[data-state=open]]/card:delay-0"
       )}
     >
       {onCleanupWorktree && (

--- a/src/components/Worktree/WorktreeCard/WorktreeDetailsSection.tsx
+++ b/src/components/Worktree/WorktreeCard/WorktreeDetailsSection.tsx
@@ -313,7 +313,7 @@ export function WorktreeDetailsSection(props: WorktreeDetailsSectionProps) {
                             e.stopPropagation();
                             onResourceResume();
                           }}
-                          className="shrink-0 p-1 rounded transition-colors text-status-success/70 hover:text-status-success hover:bg-overlay-emphasis focus-visible:outline-hidden focus-visible:ring-2 focus-visible:ring-daintree-accent"
+                          className="shrink-0 p-1 rounded transition-colors text-status-success/70 hover:text-status-success hover:bg-overlay-emphasis focus-visible:outline focus-visible:outline-2 focus-visible:outline-daintree-accent"
                           aria-label="Resume Resource"
                         >
                           <Play className="w-3 h-3" />
@@ -330,7 +330,7 @@ export function WorktreeDetailsSection(props: WorktreeDetailsSectionProps) {
                             e.stopPropagation();
                             onResourcePause();
                           }}
-                          className="shrink-0 p-1 rounded transition-colors text-status-error/70 hover:text-status-error hover:bg-overlay-emphasis focus-visible:outline-hidden focus-visible:ring-2 focus-visible:ring-daintree-accent"
+                          className="shrink-0 p-1 rounded transition-colors text-status-error/70 hover:text-status-error hover:bg-overlay-emphasis focus-visible:outline focus-visible:outline-2 focus-visible:outline-daintree-accent"
                           aria-label="Pause Resource"
                         >
                           <Square className="w-3 h-3" />
@@ -347,7 +347,7 @@ export function WorktreeDetailsSection(props: WorktreeDetailsSectionProps) {
                             e.stopPropagation();
                             onResourceConnect!();
                           }}
-                          className="shrink-0 p-1 rounded transition-colors text-status-info/70 hover:text-status-info hover:bg-overlay-emphasis focus-visible:outline-hidden focus-visible:ring-2 focus-visible:ring-daintree-accent"
+                          className="shrink-0 p-1 rounded transition-colors text-status-info/70 hover:text-status-info hover:bg-overlay-emphasis focus-visible:outline focus-visible:outline-2 focus-visible:outline-daintree-accent"
                           aria-label="Connect to Resource"
                         >
                           <Plug className="w-3 h-3" />
@@ -392,7 +392,7 @@ export function WorktreeDetailsSection(props: WorktreeDetailsSectionProps) {
                     "shrink-0 border-l border-border-default px-2 py-1 transition-colors",
                     "text-[var(--color-state-active)]/70 hover:bg-[var(--color-state-active)]/10 hover:text-[var(--color-state-active)]",
                     "rounded-r-[var(--radius-lg)]",
-                    "focus-visible:outline-hidden focus-visible:ring-2 focus-visible:ring-daintree-accent"
+                    "focus-visible:outline focus-visible:outline-2 focus-visible:outline-daintree-accent focus-visible:outline-offset-[-2px]"
                   )}
                   aria-label="Open Review & Commit"
                 >

--- a/src/components/Worktree/WorktreeCard/WorktreeTerminalSection.tsx
+++ b/src/components/Worktree/WorktreeCard/WorktreeTerminalSection.tsx
@@ -156,7 +156,7 @@ function TerminalRow({ term, onClick }: TerminalRowProps) {
             ref={dragHandle?.setActivatorNodeRef}
             type="button"
             data-drag-handle
-            className="cursor-grab rounded text-text-muted opacity-0 group-hover/termrow:opacity-100 focus-visible:opacity-100 transition-opacity hover:text-text-secondary focus-visible:outline focus-visible:outline-2 focus-visible:outline-daintree-accent focus-visible:outline-offset-1 active:cursor-grabbing"
+            className="cursor-grab rounded text-text-primary/25 group-hover/termrow:text-text-primary/40 transition-colors hover:text-text-secondary focus-visible:outline focus-visible:outline-2 focus-visible:outline-daintree-accent focus-visible:outline-offset-1 active:cursor-grabbing"
             aria-label="Drag to move terminal"
             {...(dragHandle?.listeners as React.HTMLAttributes<HTMLElement> | undefined)}
           >

--- a/src/components/Worktree/WorktreeCard/WorktreeTerminalSection.tsx
+++ b/src/components/Worktree/WorktreeCard/WorktreeTerminalSection.tsx
@@ -156,7 +156,7 @@ function TerminalRow({ term, onClick }: TerminalRowProps) {
             ref={dragHandle?.setActivatorNodeRef}
             type="button"
             data-drag-handle
-            className="cursor-grab rounded text-text-primary/25 group-hover/termrow:text-text-primary/40 transition-colors hover:text-text-secondary focus-visible:outline focus-visible:outline-2 focus-visible:outline-daintree-accent focus-visible:outline-offset-1 active:cursor-grabbing"
+            className="cursor-grab rounded text-text-primary/25 group-hover/termrow:text-text-primary/40 transition-colors hover:text-text-secondary focus-visible:text-text-secondary focus-visible:outline focus-visible:outline-2 focus-visible:outline-daintree-accent focus-visible:outline-offset-1 active:cursor-grabbing"
             aria-label="Drag to move terminal"
             {...(dragHandle?.listeners as React.HTMLAttributes<HTMLElement> | undefined)}
           >

--- a/src/components/Worktree/WorktreeCard/__tests__/WorktreeCardInteraction.test.tsx
+++ b/src/components/Worktree/WorktreeCard/__tests__/WorktreeCardInteraction.test.tsx
@@ -13,6 +13,13 @@ const sidebarCss = readFileSync(
   resolve(__dirname, "../../../../styles/components/sidebar.css"),
   "utf-8"
 );
+const toolbarSource = readFileSync(resolve(__dirname, "../WorktreeActionsToolbar.tsx"), "utf-8");
+const detailsSource = readFileSync(resolve(__dirname, "../WorktreeDetailsSection.tsx"), "utf-8");
+const terminalSectionSource = readFileSync(
+  resolve(__dirname, "../WorktreeTerminalSection.tsx"),
+  "utf-8"
+);
+const envPopoverSource = readFileSync(resolve(__dirname, "../EnvironmentPopover.tsx"), "utf-8");
 
 describe("WorktreeCard interaction-state axes (issue #6963)", () => {
   it("uses ring-inset (no background) for the isOver drop-target", () => {
@@ -72,5 +79,49 @@ describe("WorktreeCard focused sub-line (issue #7699)", () => {
 
   it("passes worktree.lastActivityTimestamp (not latestFileMtime) to the sub-line", () => {
     expect(cardSource).toMatch(/lastActivityTimestamp=\{\s*worktree\.lastActivityTimestamp\s*\}/);
+  });
+});
+
+// Issue #8099 — polish four interaction-fidelity gaps in the worktree row:
+// (1) toolbar reveal switches from :focus-within to :focus-visible so mousedown
+// no longer triggers a pre-click flash; (2) terminal sub-row drag handle stays
+// visible-but-dimmed instead of opacity-0 at rest; (3) ring-2 focus rings on
+// resource buttons and Review & Commit migrate to outline-based vocabulary for
+// forced-colors survival; (4) toolbar hover-reveal adds a 75ms delay (keyboard
+// focus bypasses) to filter fast cursor sweeps across many rows.
+describe("WorktreeCard row affordances polish (issue #8099)", () => {
+  it("toolbar reveal uses focus-visible (not focus-within) so mousedown does not flash", () => {
+    expect(toolbarSource).toContain("group-has-[:focus-visible]/card:opacity-100");
+    expect(toolbarSource).not.toContain("group-focus-within/card:opacity-100");
+  });
+
+  it("toolbar hover reveal is delayed 75ms but keyboard focus bypasses the delay", () => {
+    expect(toolbarSource).toContain("group-hover/card:delay-[75ms]");
+    expect(toolbarSource).toContain("group-has-[:focus-visible]/card:delay-0");
+    expect(toolbarSource).toContain("group-has-[[data-state=open]]/card:delay-0");
+  });
+
+  it("terminal sub-row drag handle stays visible-but-dimmed (no opacity-0 at rest)", () => {
+    expect(terminalSectionSource).toContain("text-text-primary/25");
+    expect(terminalSectionSource).toContain("group-hover/termrow:text-text-primary/40");
+    expect(terminalSectionSource).not.toMatch(/data-drag-handle[\s\S]{0,400}opacity-0/);
+  });
+
+  it("resource action buttons use outline (not ring-2) for forced-colors survival", () => {
+    expect(detailsSource).not.toMatch(/focus-visible:ring-2\s+focus-visible:ring-daintree-accent/);
+    expect(detailsSource).not.toMatch(
+      /focus-visible:outline-hidden\s+focus-visible:ring-2\s+focus-visible:ring-daintree-accent/
+    );
+  });
+
+  it("Review & Commit button uses inset outline (-2px offset) for its flush rounded-r edge", () => {
+    expect(detailsSource).toContain("focus-visible:outline-offset-[-2px]");
+  });
+
+  it("environment popover trigger uses outline (not ring-1) for forced-colors survival", () => {
+    expect(envPopoverSource).not.toMatch(
+      /focus-visible:ring-1\s+focus-visible:ring-daintree-accent/
+    );
+    expect(envPopoverSource).toContain("focus-visible:outline-2");
   });
 });

--- a/src/components/Worktree/WorktreeCard/__tests__/WorktreeCardInteraction.test.tsx
+++ b/src/components/Worktree/WorktreeCard/__tests__/WorktreeCardInteraction.test.tsx
@@ -115,7 +115,21 @@ describe("WorktreeCard row affordances polish (issue #8099)", () => {
   });
 
   it("Review & Commit button uses inset outline (-2px offset) for its flush rounded-r edge", () => {
-    expect(detailsSource).toContain("focus-visible:outline-offset-[-2px]");
+    expect(detailsSource).toMatch(
+      /rounded-r-\[var\(--radius-lg\)\][\s\S]{0,200}focus-visible:outline-offset-\[-2px\][\s\S]{0,400}aria-label="Open Review & Commit"/
+    );
+  });
+
+  it("sidebar row CSS reveal rules use :has(:focus-visible) so mousedown does not flash", () => {
+    expect(sidebarCss).toMatch(
+      /\[data-worktree-row\]:has\(:focus-visible\)\s+\[data-worktree-row-toolbar\]/
+    );
+    expect(sidebarCss).not.toMatch(
+      /\[data-worktree-row\]:focus-within\s+\[data-worktree-row-toolbar\]/
+    );
+    expect(sidebarCss).not.toMatch(
+      /\[data-worktree-row\]:focus-within\s+\[data-worktree-row-drag-handle\]/
+    );
   });
 
   it("environment popover trigger uses outline (not ring-1) for forced-colors survival", () => {

--- a/src/components/Worktree/WorktreeCard/__tests__/WorktreeHeader.test.tsx
+++ b/src/components/Worktree/WorktreeCard/__tests__/WorktreeHeader.test.tsx
@@ -105,7 +105,7 @@ describe("WorktreeHeader menu button", () => {
     expect(wrapper.className).not.toContain("opacity-0");
     expect(wrapper.className).toContain("opacity-50");
     expect(wrapper.className).toContain("group-hover/card:opacity-100");
-    expect(wrapper.className).toContain("group-focus-within/card:opacity-100");
+    expect(wrapper.className).toContain("group-has-[:focus-visible]/card:opacity-100");
     expect(wrapper.className).toContain("group-has-[[data-state=open]]/card:opacity-100");
   });
 
@@ -850,7 +850,7 @@ describe("WorktreeHeader cleanup button", () => {
     expect(wrapper.className).toContain("opacity-50");
     expect(wrapper.className).not.toContain("pointer-events-none");
     expect(wrapper.className).toContain("group-hover/card:opacity-100");
-    expect(wrapper.className).toContain("group-focus-within/card:opacity-100");
+    expect(wrapper.className).toContain("group-has-[:focus-visible]/card:opacity-100");
     expect(wrapper.className).toContain("group-has-[[data-state=open]]/card:opacity-100");
     // The cleanup button inherits visibility through the wrapper, not its own classes.
     expect(wrapper.contains(button)).toBe(true);

--- a/src/components/Worktree/WorktreeCard/__tests__/WorktreeTerminalSection.test.tsx
+++ b/src/components/Worktree/WorktreeCard/__tests__/WorktreeTerminalSection.test.tsx
@@ -639,23 +639,27 @@ describe("WorktreeTerminalSection collapsed pill state indicators", () => {
   });
 });
 
-describe("WorktreeTerminalSection drag handle visibility", () => {
-  it("has opacity-0 at rest and group-hover/termrow:opacity-100 on hover", () => {
+describe("WorktreeTerminalSection drag handle visibility (issue #8099)", () => {
+  it("stays visible-but-dimmed at rest and brightens on group-hover/termrow", () => {
     renderSection({ isExpanded: true });
     const handles = screen.getAllByRole("button", { name: "Drag to move terminal" });
     expect(handles.length).toBeGreaterThanOrEqual(1);
     for (const handle of handles) {
-      expect(handle.className).toContain("opacity-0");
-      expect(handle.className).toContain("group-hover/termrow:opacity-100");
+      expect(handle.className).toContain("text-text-primary/25");
+      expect(handle.className).toContain("group-hover/termrow:text-text-primary/40");
+      expect(handle.className).toContain("transition-colors");
+      expect(handle.className).not.toContain("opacity-0");
+      expect(handle.className).not.toContain("transition-opacity");
     }
   });
 
-  it("has focus-visible:opacity-100 for keyboard users", () => {
+  it("brightens to text-text-secondary on focus-visible for keyboard users", () => {
     renderSection({ isExpanded: true });
     const handles = screen.getAllByRole("button", { name: "Drag to move terminal" });
     expect(handles.length).toBeGreaterThanOrEqual(1);
     for (const handle of handles) {
-      expect(handle.className).toContain("focus-visible:opacity-100");
+      expect(handle.className).toContain("focus-visible:text-text-secondary");
+      expect(handle.className).not.toContain("focus-visible:opacity-100");
     }
   });
 });

--- a/src/styles/components/sidebar.css
+++ b/src/styles/components/sidebar.css
@@ -51,20 +51,20 @@ html[data-dragging="true"] .sidebar-worktree-card[data-hovered="true"] {
     inset 0 0 0 2px var(--sidebar-ring);
 }
 
-/* Reveal the per-row action toolbar whenever the row is focused (or any
-   descendant has focus). The card-internal `group-focus-within/card`
-   reveal only fires when focus lands inside the card; this rule handles
-   focus on the row wrapper itself. */
-[data-worktree-row]:focus [data-worktree-row-toolbar],
-[data-worktree-row]:focus-within [data-worktree-row-toolbar] {
+/* Reveal the per-row action toolbar whenever the row has keyboard focus
+   (or any descendant does). Uses `:focus-visible` / `:has(:focus-visible)`
+   rather than `:focus` / `:focus-within` so mousedown on a button does not
+   flash the toolbar before the click resolves. */
+[data-worktree-row]:focus-visible [data-worktree-row-toolbar],
+[data-worktree-row]:has(:focus-visible) [data-worktree-row-toolbar] {
   opacity: 1;
   pointer-events: auto;
 }
 
 /* Reveal the drag handle whenever the row has keyboard focus, matching the
    toolbar reveal pattern above. */
-[data-worktree-row]:focus [data-worktree-row-drag-handle],
-[data-worktree-row]:focus-within [data-worktree-row-drag-handle] {
+[data-worktree-row]:focus-visible [data-worktree-row-drag-handle],
+[data-worktree-row]:has(:focus-visible) [data-worktree-row-drag-handle] {
   color: color-mix(in srgb, var(--theme-text-primary) 30%, transparent);
   background-color: var(--theme-overlay-soft);
 }


### PR DESCRIPTION
## Summary

- Toolbar reveal switched from `group-focus-within` to `group-has-[:focus-visible]/card:` to prevent the mousedown flash when clicking rows
- Terminal-row drag handle made always visible at reduced opacity, matching the parent `WorktreeCard` pattern
- Focus ring vocabulary unified to `outline` + `outline-offset:-2px` + `outline-daintree-accent` across `WorktreeActionsToolbar`, `WorktreeDetailsSection`, and `WorktreeTerminalSection` for HCM survival and visual consistency

Resolves #8099

## Changes

- `WorktreeActionsToolbar.tsx` — toolbar reveal gated on `group-has-[:focus-visible]/card:` instead of `group-focus-within`; hover-in delay added to prevent piano-key flicker across long worktree lists; focus ring offsets corrected on collapse chevron and more-actions trigger
- `WorktreeDetailsSection.tsx` — `ring-2`/`ring-daintree-accent` replaced with `outline`/`outline-offset-[-2px]`/`outline-daintree-accent` on resource action buttons and Review & Commit button
- `WorktreeTerminalSection.tsx` — drag handle changed from `opacity-0` to `opacity-25 group-hover/terminal-row:opacity-40` so it's always discoverable
- `EnvironmentPopover.tsx` — focus ring unified to match dominant pattern
- `sidebar.css` — hover-in delay utilities added (`worktree-toolbar-delay` + `worktree-toolbar-focus-delay`)
- `WorktreeCardInteraction.test.tsx` — new unit tests covering mousedown-flash fix and keyboard focus behaviour
- `WorktreeTerminalSection.test.tsx` — extended to cover drag handle visibility

## Testing

Unit tests added for the two main behavioural fixes (mousedown flash, keyboard focus). Focus ring and drag handle changes verified visually across light/dark themes and forced-colors mode.