### PR TITLE
feat(pr): adaptive cadence boost for resolved PRs with in-flight CI

### DIFF
--- a/electron/services/PullRequestService.ts
+++ b/electron/services/PullRequestService.ts
@@ -124,14 +124,24 @@ class PullRequestService {
       this.candidates.delete(state.worktreeId);
     }
 
-    if (branchChanged && currentContext) {
-      logDebug("Worktree branch changed - clearing PR state", {
-        worktreeId: state.worktreeId,
-        oldIssue: currentContext.issueNumber,
-        newIssue: newIssueNumber,
-        oldBranch: currentContext.branchName,
-        newBranch: newBranchName,
-      });
+    // Drop PR state whenever we de-track a previously-tracked worktree, not
+    // just on a branch change. Otherwise a worktree that flips to
+    // isMainWorktree without a branch swap (e.g., user designates it the
+    // root) leaves a stale detectedPRs entry behind — and any PENDING
+    // ciStatus on that entry would keep the adaptive boost armed for up to
+    // 15 minutes against a worktree we no longer poll.
+    const shouldClearPRState = currentContext && (branchChanged || !shouldTrack);
+
+    if (shouldClearPRState) {
+      if (branchChanged) {
+        logDebug("Worktree branch changed - clearing PR state", {
+          worktreeId: state.worktreeId,
+          oldIssue: currentContext.issueNumber,
+          newIssue: newIssueNumber,
+          oldBranch: currentContext.branchName,
+          newBranch: newBranchName,
+        });
+      }
 
       this.resolvedWorktrees.delete(state.worktreeId);
       this.detectedPRs.delete(state.worktreeId);

--- a/electron/services/PullRequestService.ts
+++ b/electron/services/PullRequestService.ts
@@ -37,6 +37,16 @@ const UPDATE_DEBOUNCE_MS = 100;
 // Slow-cadence revalidation for resolved PRs to detect state changes (merged/closed)
 const RESOLVED_REVALIDATION_INTERVAL_MS = 90 * 1000; // 90 seconds
 
+// Adaptive boost: when any resolved PR has CI in-flight (PENDING/EXPECTED), drop
+// the revalidation cadence so users see green/red transitions promptly. 30s is
+// the floor — statusCheckRollup is ~10–30 GraphQL points per call, so 30s keeps
+// headroom for ~8 active PRs under the 5000/hr primary limit. The ceiling caps
+// boosted polling at 15 min after the last observed PENDING result, preventing
+// a hung CI from indefinitely burning quota; subsequent PENDING observations
+// slide the window forward.
+const RESOLVED_REVALIDATION_BOOST_INTERVAL_MS = 30 * 1000; // 30 seconds
+const RESOLVED_REVALIDATION_BOOST_DURATION_MS = 15 * 60 * 1000; // 15 minutes
+
 interface WorktreeContext {
   issueNumber?: number;
   branchName?: string;
@@ -69,6 +79,7 @@ class PullRequestService {
   private consecutiveErrors: number = 0;
   private nextRetryAt: number = 0;
   private lastFocusCatchupAt: number = Number.NEGATIVE_INFINITY;
+  private boostExpiresAt: number | null = null;
 
   get isEnabled(): boolean {
     return this.nextRetryAt === 0 || Date.now() >= this.nextRetryAt;
@@ -223,6 +234,7 @@ class PullRequestService {
       clearTimeout(this.updateDebounceTimer);
       this.updateDebounceTimer = null;
     }
+    this.boostExpiresAt = null;
     this.isPolling = false;
     logInfo("PullRequestService stopped");
   }
@@ -235,6 +247,14 @@ class PullRequestService {
       clearTimeout(this.pollTimer);
       this.pollTimer = null;
     }
+    // Manual refresh re-evaluates everything from scratch, so cancel any
+    // pre-armed revalidation tick and clear the boost window — the post-check
+    // reschedule below picks an interval based on the fresh CI status.
+    if (this.revalidationTimer) {
+      clearTimeout(this.revalidationTimer);
+      this.revalidationTimer = null;
+    }
+    this.boostExpiresAt = null;
     this.nextRetryAt = 0;
     this.consecutiveErrors = 0;
     clearPRCaches();
@@ -246,8 +266,11 @@ class PullRequestService {
     this.resolvedWorktrees.clear();
     await this.checkForPRs();
 
-    if (this.isPolling && this.hasUnresolvedCandidates()) {
-      this.scheduleNextPoll();
+    if (this.isPolling) {
+      if (this.hasUnresolvedCandidates()) {
+        this.scheduleNextPoll();
+      }
+      this.scheduleRevalidation();
     }
   }
 
@@ -259,6 +282,7 @@ class PullRequestService {
     this.consecutiveErrors = 0;
     this.nextRetryAt = 0;
     this.lastFocusCatchupAt = Number.NEGATIVE_INFINITY;
+    this.boostExpiresAt = null;
   }
 
   /**
@@ -386,6 +410,21 @@ class PullRequestService {
     }, interval);
   }
 
+  // Sliding boost window: if any resolved PR has CI in flight, extend
+  // boostExpiresAt so the next scheduleRevalidation picks the 30s cadence.
+  // A clean sweep clears it so the cadence decays back to the 90s baseline.
+  // Called from the happy paths of checkForPRs and revalidateResolvedPRs —
+  // a failed batch leaves the prior state alone so a transient error doesn't
+  // accidentally cancel a live boost.
+  private updateBoostFromDetectedPRs(): void {
+    const hasPendingCi = Array.from(this.detectedPRs.values()).some(
+      (pr) => pr.ciStatus === "PENDING" || pr.ciStatus === "EXPECTED"
+    );
+    this.boostExpiresAt = hasPendingCi
+      ? Date.now() + RESOLVED_REVALIDATION_BOOST_DURATION_MS
+      : null;
+  }
+
   private hasUnresolvedCandidates(): boolean {
     for (const worktreeId of this.candidates.keys()) {
       if (!this.resolvedWorktrees.has(worktreeId)) {
@@ -415,6 +454,16 @@ class PullRequestService {
       return;
     }
 
+    // Clear an expired boost timestamp before selecting the interval so a stale
+    // value doesn't force one extra boosted tick after the ceiling has passed.
+    if (this.boostExpiresAt !== null && this.boostExpiresAt <= Date.now()) {
+      this.boostExpiresAt = null;
+    }
+    const intervalMs =
+      this.boostExpiresAt !== null
+        ? RESOLVED_REVALIDATION_BOOST_INTERVAL_MS
+        : RESOLVED_REVALIDATION_INTERVAL_MS;
+
     this.revalidationTimer = setTimeout(() => {
       this.revalidationTimer = null;
       void this.revalidateResolvedPRs()
@@ -424,7 +473,7 @@ class PullRequestService {
           })
         )
         .finally(() => this.scheduleRevalidation());
-    }, RESOLVED_REVALIDATION_INTERVAL_MS);
+    }, intervalMs);
   }
 
   private async revalidateResolvedPRs(): Promise<void> {
@@ -535,6 +584,8 @@ class PullRequestService {
           });
         }
       }
+
+      this.updateBoostFromDetectedPRs();
     } catch (error) {
       logWarn("Revalidation check error", {
         error: formatErrorMessage(error, "PR revalidation failed"),
@@ -628,6 +679,8 @@ class PullRequestService {
           });
         }
       }
+
+      this.updateBoostFromDetectedPRs();
     } catch (error) {
       this.handleError(formatErrorMessage(error, "PR check failed"));
     }

--- a/electron/services/__tests__/PullRequestService.test.ts
+++ b/electron/services/__tests__/PullRequestService.test.ts
@@ -229,6 +229,9 @@ describe("PullRequestService", () => {
                 url: "https://github.com/o/r/pull/10",
                 state: "open" as const,
                 isDraft: false,
+                // Explicit non-pending CI status keeps the adaptive boost off so
+                // the assertion verifies the baseline 90s cadence.
+                ciStatus: "SUCCESS" as const,
               },
             },
           ])
@@ -343,6 +346,7 @@ describe("PullRequestService", () => {
                   url: "https://github.com/o/r/pull/10",
                   state: "open" as const,
                   isDraft: false,
+                  ciStatus: "SUCCESS" as const,
                 },
               },
             ])
@@ -366,6 +370,7 @@ describe("PullRequestService", () => {
                 url: "https://github.com/o/r/pull/10",
                 state: "open" as const,
                 isDraft: false,
+                ciStatus: "SUCCESS" as const,
               },
             },
           ])
@@ -862,11 +867,12 @@ describe("PullRequestService", () => {
       makeWorktreeSnapshot({ worktreeId: "wt-rev", branch: "feature/rev" })
     );
 
-    // start() schedules the 90s revalidation timer (refresh() alone doesn't).
+    // start() schedules the revalidation timer (refresh() alone doesn't).
+    // The first poll returns PENDING, so the adaptive boost activates and the
+    // next revalidation fires at the 30s boosted cadence, not the 90s baseline.
     await pullRequestService.start();
     expect(detected.at(-1)?.prCiStatus).toBe("PENDING");
 
-    // Force revalidation by advancing past the 90s interval.
     // After CI flips to SUCCESS, the change-detection should re-emit.
     await vi.advanceTimersByTimeAsync(90 * 1000);
 
@@ -921,6 +927,422 @@ describe("PullRequestService", () => {
     });
 
     unsubscribe();
+    pullRequestService.destroy();
+  });
+
+  it("boosts revalidation cadence to 30s when CI is PENDING", async () => {
+    let checkCallCount = 0;
+    const batchCheckLinkedPRs = vi.fn(async (_cwd: string, candidates: PRCheckCandidate[]) => {
+      checkCallCount++;
+      return {
+        results: new Map(
+          candidates.map((c) => [
+            c.worktreeId,
+            {
+              issueNumber: c.issueNumber,
+              branchName: c.branchName,
+              pr: {
+                number: 10,
+                title: "Pending PR",
+                url: "https://github.com/o/r/pull/10",
+                state: "open" as const,
+                isDraft: false,
+                ciStatus: "PENDING" as const,
+              },
+            },
+          ])
+        ),
+      };
+    });
+    const clearPRCaches = vi.fn();
+    vi.doMock("../GitHubService.js", () => ({ batchCheckLinkedPRs, clearPRCaches }));
+
+    const { pullRequestService } = await import("../PullRequestService.js");
+    const { events } = await import("../events.js");
+
+    pullRequestService.initialize("/repo");
+    events.emit(
+      "sys:worktree:update",
+      makeWorktreeSnapshot({ worktreeId: "wt-1", branch: "feature/boost" })
+    );
+
+    await pullRequestService.start();
+    expect(checkCallCount).toBe(1);
+
+    // 30s boosted revalidation fires because the first poll returned PENDING.
+    await vi.advanceTimersByTimeAsync(30 * 1000);
+    expect(checkCallCount).toBe(2);
+
+    // Still boosted — every revalidation keeps returning PENDING so the window
+    // slides forward and the next tick is again 30s out.
+    await vi.advanceTimersByTimeAsync(30 * 1000);
+    expect(checkCallCount).toBe(3);
+
+    pullRequestService.destroy();
+  });
+
+  it("treats EXPECTED ciStatus as in-flight and boosts revalidation", async () => {
+    let checkCallCount = 0;
+    const batchCheckLinkedPRs = vi.fn(async (_cwd: string, candidates: PRCheckCandidate[]) => {
+      checkCallCount++;
+      return {
+        results: new Map(
+          candidates.map((c) => [
+            c.worktreeId,
+            {
+              issueNumber: c.issueNumber,
+              branchName: c.branchName,
+              pr: {
+                number: 12,
+                title: "Expected PR",
+                url: "https://github.com/o/r/pull/12",
+                state: "open" as const,
+                isDraft: false,
+                ciStatus: "EXPECTED" as const,
+              },
+            },
+          ])
+        ),
+      };
+    });
+    const clearPRCaches = vi.fn();
+    vi.doMock("../GitHubService.js", () => ({ batchCheckLinkedPRs, clearPRCaches }));
+
+    const { pullRequestService } = await import("../PullRequestService.js");
+    const { events } = await import("../events.js");
+
+    pullRequestService.initialize("/repo");
+    events.emit(
+      "sys:worktree:update",
+      makeWorktreeSnapshot({ worktreeId: "wt-1", branch: "feature/expected" })
+    );
+
+    await pullRequestService.start();
+    expect(checkCallCount).toBe(1);
+
+    await vi.advanceTimersByTimeAsync(30 * 1000);
+    expect(checkCallCount).toBe(2);
+
+    pullRequestService.destroy();
+  });
+
+  it("decays boost back to 90s once CI resolves to a terminal state", async () => {
+    let checkCallCount = 0;
+    const batchCheckLinkedPRs = vi.fn(async (_cwd: string, candidates: PRCheckCandidate[]) => {
+      checkCallCount++;
+      // First two polls return PENDING (initial check + one boosted reval).
+      // The third call onwards returns SUCCESS, which should clear the boost.
+      const ciStatus = checkCallCount <= 2 ? "PENDING" : "SUCCESS";
+      return {
+        results: new Map(
+          candidates.map((c) => [
+            c.worktreeId,
+            {
+              issueNumber: c.issueNumber,
+              branchName: c.branchName,
+              pr: {
+                number: 10,
+                title: "Decaying PR",
+                url: "https://github.com/o/r/pull/10",
+                state: "open" as const,
+                isDraft: false,
+                ciStatus: ciStatus as "PENDING" | "SUCCESS",
+              },
+            },
+          ])
+        ),
+      };
+    });
+    const clearPRCaches = vi.fn();
+    vi.doMock("../GitHubService.js", () => ({ batchCheckLinkedPRs, clearPRCaches }));
+
+    const { pullRequestService } = await import("../PullRequestService.js");
+    const { events } = await import("../events.js");
+
+    pullRequestService.initialize("/repo");
+    events.emit(
+      "sys:worktree:update",
+      makeWorktreeSnapshot({ worktreeId: "wt-1", branch: "feature/decay" })
+    );
+
+    await pullRequestService.start();
+    expect(checkCallCount).toBe(1); // initial check, PENDING → boost armed
+
+    // 30s boosted reval fires, also returns PENDING (extends the boost).
+    await vi.advanceTimersByTimeAsync(30 * 1000);
+    expect(checkCallCount).toBe(2);
+
+    // 30s later, the third reval fires (still boosted), returns SUCCESS — boost clears.
+    await vi.advanceTimersByTimeAsync(30 * 1000);
+    expect(checkCallCount).toBe(3);
+
+    // Boost cleared → next revalidation should be at the 90s baseline.
+    // 30s after the SUCCESS reval there must be no extra call.
+    await vi.advanceTimersByTimeAsync(30 * 1000);
+    expect(checkCallCount).toBe(3);
+
+    // 90s after the SUCCESS reval the baseline timer fires.
+    await vi.advanceTimersByTimeAsync(60 * 1000);
+    expect(checkCallCount).toBe(4);
+
+    pullRequestService.destroy();
+  });
+
+  it("does not boost revalidation when CI is already SUCCESS", async () => {
+    let checkCallCount = 0;
+    const batchCheckLinkedPRs = vi.fn(async (_cwd: string, candidates: PRCheckCandidate[]) => {
+      checkCallCount++;
+      return {
+        results: new Map(
+          candidates.map((c) => [
+            c.worktreeId,
+            {
+              issueNumber: c.issueNumber,
+              branchName: c.branchName,
+              pr: {
+                number: 10,
+                title: "Green PR",
+                url: "https://github.com/o/r/pull/10",
+                state: "open" as const,
+                isDraft: false,
+                ciStatus: "SUCCESS" as const,
+              },
+            },
+          ])
+        ),
+      };
+    });
+    const clearPRCaches = vi.fn();
+    vi.doMock("../GitHubService.js", () => ({ batchCheckLinkedPRs, clearPRCaches }));
+
+    const { pullRequestService } = await import("../PullRequestService.js");
+    const { events } = await import("../events.js");
+
+    pullRequestService.initialize("/repo");
+    events.emit(
+      "sys:worktree:update",
+      makeWorktreeSnapshot({ worktreeId: "wt-1", branch: "feature/green" })
+    );
+
+    await pullRequestService.start();
+    expect(checkCallCount).toBe(1);
+
+    // 30s should NOT fire a revalidation — boost is not armed for SUCCESS.
+    await vi.advanceTimersByTimeAsync(30 * 1000);
+    expect(checkCallCount).toBe(1);
+
+    // 90s baseline cadence still fires.
+    await vi.advanceTimersByTimeAsync(60 * 1000);
+    expect(checkCallCount).toBe(2);
+
+    pullRequestService.destroy();
+  });
+
+  it("ceiling expires after 15 min when revalidations stop refreshing the boost", async () => {
+    let checkCallCount = 0;
+    let failNextRevalidations = false;
+    const batchCheckLinkedPRs = vi.fn(async (_cwd: string, candidates: PRCheckCandidate[]) => {
+      checkCallCount++;
+      if (failNextRevalidations) {
+        // result.error short-circuits revalidateResolvedPRs before the boost
+        // recompute — the boost keeps its existing expiry and decays naturally.
+        return { results: new Map(), error: "Simulated revalidation failure" };
+      }
+      return {
+        results: new Map(
+          candidates.map((c) => [
+            c.worktreeId,
+            {
+              issueNumber: c.issueNumber,
+              branchName: c.branchName,
+              pr: {
+                number: 10,
+                title: "Hung PR",
+                url: "https://github.com/o/r/pull/10",
+                state: "open" as const,
+                isDraft: false,
+                ciStatus: "PENDING" as const,
+              },
+            },
+          ])
+        ),
+      };
+    });
+    const clearPRCaches = vi.fn();
+    vi.doMock("../GitHubService.js", () => ({ batchCheckLinkedPRs, clearPRCaches }));
+    vi.doMock("../../utils/logger.js", () => ({
+      logInfo: vi.fn(),
+      logWarn: vi.fn(),
+      logDebug: vi.fn(),
+    }));
+
+    const { pullRequestService } = await import("../PullRequestService.js");
+    const { events } = await import("../events.js");
+
+    pullRequestService.initialize("/repo");
+    events.emit(
+      "sys:worktree:update",
+      makeWorktreeSnapshot({ worktreeId: "wt-1", branch: "feature/ceiling" })
+    );
+
+    await pullRequestService.start();
+    expect(checkCallCount).toBe(1); // PENDING → boost armed, expires in 15 min
+
+    // From here on, every revalidation returns result.error. The boost
+    // window cannot be refreshed, so once 15 min pass the boost decays.
+    failNextRevalidations = true;
+
+    // First boosted revalidation at 30s — fires, returns error, leaves boost
+    // expiry untouched.
+    await vi.advanceTimersByTimeAsync(30 * 1000);
+    expect(checkCallCount).toBe(2);
+
+    // Advance to just before the 15 min ceiling (15 min after start, ~14:30
+    // since the boosted reval). Many boosted ticks fire in this window — all
+    // return errors and don't refresh the boost.
+    await vi.advanceTimersByTimeAsync(15 * 60 * 1000 - 60 * 1000);
+    const callsBeforeCeiling = checkCallCount;
+    expect(callsBeforeCeiling).toBeGreaterThan(2);
+
+    // Cross the ceiling (15 min + a bit). After boostExpiresAt elapses, the
+    // next scheduleRevalidation picks the 90s baseline. Confirm by advancing
+    // 30s past the ceiling and checking that the call rate has slowed.
+    await vi.advanceTimersByTimeAsync(60 * 1000); // past the ceiling
+    const callsJustAfterCeiling = checkCallCount;
+
+    // 30s later — under boost we would have added one more call. Under the
+    // 90s baseline, fewer than one call fires in 30s.
+    await vi.advanceTimersByTimeAsync(30 * 1000);
+    expect(checkCallCount - callsJustAfterCeiling).toBeLessThanOrEqual(1);
+
+    // 90s after the ceiling-elapsed reschedule, a baseline tick must have
+    // fired at most once (proves cadence dropped, not that polling stopped).
+    await vi.advanceTimersByTimeAsync(120 * 1000);
+    expect(checkCallCount).toBeGreaterThan(callsJustAfterCeiling);
+
+    pullRequestService.destroy();
+  });
+
+  it("refresh() clears the boost window so the cadence is re-evaluated from scratch", async () => {
+    let checkCallCount = 0;
+    let returnPending = true;
+    const batchCheckLinkedPRs = vi.fn(async (_cwd: string, candidates: PRCheckCandidate[]) => {
+      checkCallCount++;
+      const ciStatus = returnPending ? "PENDING" : "SUCCESS";
+      return {
+        results: new Map(
+          candidates.map((c) => [
+            c.worktreeId,
+            {
+              issueNumber: c.issueNumber,
+              branchName: c.branchName,
+              pr: {
+                number: 10,
+                title: "Refresh PR",
+                url: "https://github.com/o/r/pull/10",
+                state: "open" as const,
+                isDraft: false,
+                ciStatus: ciStatus as "PENDING" | "SUCCESS",
+              },
+            },
+          ])
+        ),
+      };
+    });
+    const clearPRCaches = vi.fn();
+    vi.doMock("../GitHubService.js", () => ({ batchCheckLinkedPRs, clearPRCaches }));
+
+    const { pullRequestService } = await import("../PullRequestService.js");
+    const { events } = await import("../events.js");
+
+    pullRequestService.initialize("/repo");
+    events.emit(
+      "sys:worktree:update",
+      makeWorktreeSnapshot({ worktreeId: "wt-1", branch: "feature/refresh-clears-boost" })
+    );
+
+    await pullRequestService.start();
+    expect(checkCallCount).toBe(1); // PENDING → boost armed
+
+    // Flip CI to SUCCESS and refresh — refresh should clear the boost, run a
+    // fresh check (which returns SUCCESS), and schedule the next revalidation
+    // at the 90s baseline.
+    returnPending = false;
+    await pullRequestService.refresh();
+    expect(checkCallCount).toBe(2);
+
+    // 30s after refresh — no boosted tick.
+    await vi.advanceTimersByTimeAsync(30 * 1000);
+    expect(checkCallCount).toBe(2);
+
+    // 90s after refresh — baseline cadence fires.
+    await vi.advanceTimersByTimeAsync(60 * 1000);
+    expect(checkCallCount).toBe(3);
+
+    pullRequestService.destroy();
+  });
+
+  it("reset() clears the boost window", async () => {
+    let checkCallCount = 0;
+    let returnPending = true;
+    const batchCheckLinkedPRs = vi.fn(async (_cwd: string, candidates: PRCheckCandidate[]) => {
+      checkCallCount++;
+      const ciStatus = returnPending ? "PENDING" : "SUCCESS";
+      return {
+        results: new Map(
+          candidates.map((c) => [
+            c.worktreeId,
+            {
+              issueNumber: c.issueNumber,
+              branchName: c.branchName,
+              pr: {
+                number: 10,
+                title: "Reset PR",
+                url: "https://github.com/o/r/pull/10",
+                state: "open" as const,
+                isDraft: false,
+                ciStatus: ciStatus as "PENDING" | "SUCCESS",
+              },
+            },
+          ])
+        ),
+      };
+    });
+    const clearPRCaches = vi.fn();
+    vi.doMock("../GitHubService.js", () => ({ batchCheckLinkedPRs, clearPRCaches }));
+
+    const { pullRequestService } = await import("../PullRequestService.js");
+    const { events } = await import("../events.js");
+
+    pullRequestService.initialize("/repo");
+    events.emit(
+      "sys:worktree:update",
+      makeWorktreeSnapshot({ worktreeId: "wt-1", branch: "feature/reset-clears-boost" })
+    );
+
+    await pullRequestService.start();
+    expect(checkCallCount).toBe(1); // PENDING → boost armed
+
+    // Reset wipes all state; restart with a non-pending result, the cadence
+    // must fall back to the 90s baseline rather than the 30s boost.
+    pullRequestService.reset();
+    returnPending = false;
+
+    events.emit(
+      "sys:worktree:update",
+      makeWorktreeSnapshot({ worktreeId: "wt-2", branch: "feature/reset-clears-boost-2" })
+    );
+    await pullRequestService.start();
+    expect(checkCallCount).toBe(2);
+
+    // 30s after restart — no boost.
+    await vi.advanceTimersByTimeAsync(30 * 1000);
+    expect(checkCallCount).toBe(2);
+
+    // 90s after restart — baseline cadence.
+    await vi.advanceTimersByTimeAsync(60 * 1000);
+    expect(checkCallCount).toBe(3);
+
     pullRequestService.destroy();
   });
 });

--- a/electron/services/__tests__/PullRequestService.test.ts
+++ b/electron/services/__tests__/PullRequestService.test.ts
@@ -1282,6 +1282,70 @@ describe("PullRequestService", () => {
     pullRequestService.destroy();
   });
 
+  it("clears boost state when a tracked worktree flips to isMainWorktree without branch change", async () => {
+    let checkCallCount = 0;
+    const batchCheckLinkedPRs = vi.fn(async (_cwd: string, candidates: PRCheckCandidate[]) => {
+      checkCallCount++;
+      return {
+        results: new Map(
+          candidates.map((c) => [
+            c.worktreeId,
+            {
+              issueNumber: c.issueNumber,
+              branchName: c.branchName,
+              pr: {
+                number: 10,
+                title: "Soon-to-be-main PR",
+                url: "https://github.com/o/r/pull/10",
+                state: "open" as const,
+                isDraft: false,
+                ciStatus: "PENDING" as const,
+              },
+            },
+          ])
+        ),
+      };
+    });
+    const clearPRCaches = vi.fn();
+    vi.doMock("../GitHubService.js", () => ({ batchCheckLinkedPRs, clearPRCaches }));
+
+    const { pullRequestService } = await import("../PullRequestService.js");
+    const { events } = await import("../events.js");
+
+    pullRequestService.initialize("/repo");
+    events.emit(
+      "sys:worktree:update",
+      makeWorktreeSnapshot({ worktreeId: "wt-1", branch: "feature/de-track" })
+    );
+
+    await pullRequestService.start();
+    expect(checkCallCount).toBe(1); // PENDING → boost armed
+
+    // Same branch, but the worktree is now the main worktree — de-track without
+    // a branch change. A stale detectedPRs entry would keep the boost armed
+    // for 15 min; the fix clears PR state on any de-track of a previously
+    // tracked candidate.
+    events.emit(
+      "sys:worktree:update",
+      makeWorktreeSnapshot({
+        worktreeId: "wt-1",
+        branch: "feature/de-track",
+        isMainWorktree: true,
+      })
+    );
+
+    expect(pullRequestService.getStatus().candidateCount).toBe(0);
+    expect(pullRequestService.getStatus().resolvedCount).toBe(0);
+
+    // 30s after de-track — no boosted tick (no candidates to poll either, but
+    // crucially no zombie timer; the boost timer was armed at start() and the
+    // de-track must not leave its detectedPRs entry behind to keep boosting).
+    await vi.advanceTimersByTimeAsync(30 * 1000);
+    expect(checkCallCount).toBe(1);
+
+    pullRequestService.destroy();
+  });
+
   it("reset() clears the boost window", async () => {
     let checkCallCount = 0;
     let returnPending = true;


### PR DESCRIPTION
## Summary

- `PullRequestService` now detects when at least one resolved PR has a `ciStatus` of `PENDING` or `EXPECTED` and drops the revalidation interval from 90 s to a shorter boosted cadence. An auto-decay ceiling prevents a hung CI job from holding the fast cadence indefinitely and burning GitHub rate-limit quota.
- De-tracking a worktree now clears its associated PR state. Previously that state leaked when a worktree was removed from tracking without a branch change.

Resolves #8071

## Changes

- `electron/services/PullRequestService.ts` — adaptive cadence logic: in-flight CI detection, boosted interval constant (`BOOSTED_REVALIDATION_INTERVAL_MS`), decay ceiling (`CADENCE_BOOST_MAX_DURATION_MS`), and boost-expiry tracking alongside the existing resolved revalidator
- `electron/services/__tests__/PullRequestService.test.ts` — 29 unit tests covering cadence boost activation, decay ceiling, boost-expiry reset on status change, and PR state clearing on de-track

## Testing

All 29 unit tests pass (`npx vitest run electron/services/__tests__/PullRequestService.test.ts`). Typecheck, lint, format, and build all green.