### PR TITLE
perf(terminal): priority-based WebGL context eviction under tiled-layout pool pressure

### DIFF
--- a/src/services/terminal/TerminalWebGLManager.ts
+++ b/src/services/terminal/TerminalWebGLManager.ts
@@ -479,7 +479,7 @@ export class TerminalWebGLManager {
   //   0  done/idle (no agent, or completed/exited/idle) — DOM renderer is fine
   //   1  waiting, unfocused, not recently writing — idle between prompts
   //   2  working but drained (pendingWrites 0, no recent write), unfocused
-  //   3  in an active write burst (lastWriteAt within window), not working
+  //   3  waiting + in an active write burst (lastWriteAt within window)
   //   4  focused — user is looking at it; glyph quality matters
   //   5  working with queued writes — actively streaming output
   //   6  focused + directing — user typing into a live agent; never evict first
@@ -512,7 +512,11 @@ export class TerminalWebGLManager {
         tier = 5;
       } else if (focused) {
         tier = 4;
-      } else if (recentlyWriting && state !== "working") {
+      } else if (recentlyWriting && state === "waiting") {
+        // Burst protection only applies to "waiting" — an agent between prompts
+        // that just streamed output. A recent lastWriteAt on a done state
+        // (idle/completed/exited) is a final flush, not an ongoing burst, so
+        // those fall through to tier 0 below.
         tier = 3;
       } else if (state === "working" && pending === 0 && !recentlyWriting) {
         tier = 2;
@@ -543,7 +547,7 @@ export class TerminalWebGLManager {
     const now = Date.now();
     if (now - this.lastEvictionWarnAt > TerminalWebGLManager.EVICTION_WARN_INTERVAL_MS) {
       console.warn(
-        `[TerminalWebGLManager] Pool pressure: evicted ${this.evictionCount} WebGL context(s) in the last minute (pool=${this.pool.size}/${getMaxContexts()})`
+        `[TerminalWebGLManager] Pool pressure: evicted ${this.evictionCount} WebGL context(s) since last warning (pool=${this.pool.size}/${getMaxContexts()})`
       );
       this.evictionCount = 0;
       this.lastEvictionWarnAt = now;

--- a/src/services/terminal/TerminalWebGLManager.ts
+++ b/src/services/terminal/TerminalWebGLManager.ts
@@ -489,7 +489,7 @@ export class TerminalWebGLManager {
   private pickEvictTarget(): string | undefined {
     const lruIndex = new Map<string, number>();
     for (let i = 0; i < this.lruOrder.length; i++) {
-      lruIndex.set(this.lruOrder[i], i);
+      lruIndex.set(this.lruOrder[i]!, i);
     }
 
     const now = Date.now();
@@ -539,7 +539,7 @@ export class TerminalWebGLManager {
     }
 
     // Fall back to the LRU front if the pool/LRU ever desynchronise.
-    return bestId ?? this.lruOrder[0];
+    return bestId ?? this.lruOrder[0]!;
   }
 
   private recordEvictionForDiagnostics(): void {

--- a/src/services/terminal/TerminalWebGLManager.ts
+++ b/src/services/terminal/TerminalWebGLManager.ts
@@ -1,7 +1,7 @@
 import type { WebglAddon as WebglAddonType } from "@xterm/addon-webgl";
 import type { IDisposable } from "@xterm/xterm";
 import { getMaxContexts, setMaxContexts as setConfiguredMaxContexts } from "./TerminalWebGLConfig";
-import type { ManagedTerminal } from "./types";
+import { WRITE_BURST_RECENCY_MS, type ManagedTerminal } from "./types";
 
 const WEBGL_DISABLED = import.meta.env.DAINTREE_DISABLE_WEBGL === "1";
 
@@ -104,6 +104,15 @@ export class TerminalWebGLManager {
   private hasLoggedSoftwareSkip = false;
   private lossTimestamps: number[] = [];
   private hasLoggedBreakerTrip = false;
+  // Pool-pressure diagnostics (Tier 0 — silent log). Eviction at a full pool is
+  // expected behaviour in 20–30 terminal tiled fleets and falls back seamlessly
+  // to the DOM renderer, so this is observable-only, not user-facing. Rate
+  // limited to one console.warn per minute, mirroring hasLoggedBreakerTrip.
+  private evictionCount = 0;
+  // -Infinity so the first eviction always crosses the interval and warns,
+  // independent of the absolute clock value (real epoch or a faked time of 0).
+  private lastEvictionWarnAt = Number.NEGATIVE_INFINITY;
+  private static readonly EVICTION_WARN_INTERVAL_MS = 60_000;
   // Queue of pending ensure requests: drained one-per-rAF so each context
   // allocation completes its GPU IPC roundtrip before the next is requested.
   private pendingEnsures = new Map<string, ManagedTerminal>();
@@ -312,9 +321,10 @@ export class TerminalWebGLManager {
     }
 
     if (this.pool.size >= getMaxContexts()) {
-      const evictId = this.lruOrder[0];
+      const evictId = this.pickEvictTarget();
       if (evictId) {
         this.doRelease(evictId);
+        this.recordEvictionForDiagnostics();
       }
     }
 
@@ -458,6 +468,85 @@ export class TerminalWebGLManager {
         );
         this.hasLoggedBreakerTrip = true;
       }
+    }
+  }
+
+  // Eviction priority scorer. Returns the pool id that should give up its
+  // WebGL slot first under pool pressure. Lower tier = evict sooner; LRU
+  // position breaks ties within a tier so existing recency semantics survive.
+  //
+  // Tiers (most → least evictable):
+  //   0  done/idle (no agent, or completed/exited/idle) — DOM renderer is fine
+  //   1  waiting, unfocused, not recently writing — idle between prompts
+  //   2  working but drained (pendingWrites 0, no recent write), unfocused
+  //   3  in an active write burst (lastWriteAt within window), not working
+  //   4  focused — user is looking at it; glyph quality matters
+  //   5  working with queued writes — actively streaming output
+  //   6  focused + directing — user typing into a live agent; never evict first
+  //
+  // Reads the live `managed` ref on each pool entry (mutated in place by the
+  // write and agent-state controllers), so no cross-controller coupling.
+  private pickEvictTarget(): string | undefined {
+    const lruIndex = new Map<string, number>();
+    for (let i = 0; i < this.lruOrder.length; i++) {
+      lruIndex.set(this.lruOrder[i], i);
+    }
+
+    const now = Date.now();
+    let bestId: string | undefined;
+    let bestTier = Number.POSITIVE_INFINITY;
+    let bestLru = Number.POSITIVE_INFINITY;
+
+    for (const [id, entry] of this.pool) {
+      const m = entry.managed;
+      const state = m.agentState ?? "idle";
+      const focused = m.isFocused === true;
+      const pending = m.pendingWrites ?? 0;
+      const recentlyWriting =
+        m.lastWriteAt !== undefined && now - m.lastWriteAt < WRITE_BURST_RECENCY_MS;
+
+      let tier: number;
+      if (state === "directing" && focused) {
+        tier = 6;
+      } else if (state === "working" && pending > 0) {
+        tier = 5;
+      } else if (focused) {
+        tier = 4;
+      } else if (recentlyWriting && state !== "working") {
+        tier = 3;
+      } else if (state === "working" && pending === 0 && !recentlyWriting) {
+        tier = 2;
+      } else if (state === "waiting" && !recentlyWriting) {
+        tier = 1;
+      } else if (state === "idle" || state === "completed" || state === "exited") {
+        tier = 0;
+      } else {
+        // "waiting" while recently writing, or any unmapped state — keep it
+        // above the cleanly-idle tier but below focused/active work.
+        tier = 2;
+      }
+
+      const lru = lruIndex.get(id) ?? Number.POSITIVE_INFINITY;
+      if (tier < bestTier || (tier === bestTier && lru < bestLru)) {
+        bestTier = tier;
+        bestLru = lru;
+        bestId = id;
+      }
+    }
+
+    // Fall back to the LRU front if the pool/LRU ever desynchronise.
+    return bestId ?? this.lruOrder[0];
+  }
+
+  private recordEvictionForDiagnostics(): void {
+    this.evictionCount += 1;
+    const now = Date.now();
+    if (now - this.lastEvictionWarnAt > TerminalWebGLManager.EVICTION_WARN_INTERVAL_MS) {
+      console.warn(
+        `[TerminalWebGLManager] Pool pressure: evicted ${this.evictionCount} WebGL context(s) in the last minute (pool=${this.pool.size}/${getMaxContexts()})`
+      );
+      this.evictionCount = 0;
+      this.lastEvictionWarnAt = now;
     }
   }
 

--- a/src/services/terminal/TerminalWriteController.ts
+++ b/src/services/terminal/TerminalWriteController.ts
@@ -79,6 +79,7 @@ export class TerminalWriteController {
       if (this.deps.getInstance(id) !== managed) return;
 
       managed.pendingWrites = Math.max(0, (managed.pendingWrites ?? 1) - 1);
+      managed.lastWriteAt = Date.now();
 
       this.deps.acknowledgePortData(id, acknowledgedBytes);
       this.deps.acknowledgeData(id, acknowledgedBytes);

--- a/src/services/terminal/__tests__/TerminalWebGLManager.test.ts
+++ b/src/services/terminal/__tests__/TerminalWebGLManager.test.ts
@@ -1051,6 +1051,99 @@ describe("TerminalWebGLManager", () => {
       expect(localManager.isActive("idle1")).toBe(true);
     });
 
+    it("evicts a recently-flushed done terminal (tier 0) before a waiting one (tier 1)", async () => {
+      // Regression: an exited/completed agent that just printed a final line
+      // has a recent lastWriteAt, but that flush is not an ongoing burst — it
+      // must stay tier 0 and be evicted before an idle "waiting" terminal.
+      vi.useFakeTimers();
+      vi.setSystemTime(1_000_000);
+      installRafShim();
+      try {
+        const { TerminalWebGLManager } = await import("../TerminalWebGLManager");
+        const max = TerminalWebGLManager.MAX_CONTEXTS;
+        const { localManager, disposeFor } = await makePriorityManager();
+
+        // Filler streaming terminals (tier 5) — never the target.
+        for (let i = 0; i < max - 2; i++) {
+          localManager.ensureContext(
+            `work${i}`,
+            makeManagedTerminal({ agentState: "working", pendingWrites: 2 })
+          );
+        }
+        // Waiting, no recent write → tier 1.
+        localManager.ensureContext(
+          "waiting",
+          makeManagedTerminal({ agentState: "waiting", pendingWrites: 0, isFocused: false })
+        );
+        // Exited, just flushed a final line → must remain tier 0, not tier 3.
+        localManager.ensureContext(
+          "exited",
+          makeManagedTerminal({
+            agentState: "exited",
+            pendingWrites: 0,
+            isFocused: false,
+            lastWriteAt: Date.now() - 1,
+          })
+        );
+
+        localManager.ensureContext("extra", makeManagedTerminal({ agentState: "working" }));
+
+        expect(localManager.isActive("exited")).toBe(false);
+        expect(disposeFor("exited")).toHaveBeenCalledTimes(1);
+        expect(localManager.isActive("waiting")).toBe(true);
+      } finally {
+        vi.useRealTimers();
+      }
+    });
+
+    it("treats exactly WRITE_BURST_RECENCY_MS ago as stale (strict < boundary)", async () => {
+      vi.useFakeTimers();
+      vi.setSystemTime(1_000_000);
+      installRafShim();
+      try {
+        const { TerminalWebGLManager } = await import("../TerminalWebGLManager");
+        const { WRITE_BURST_RECENCY_MS } = await import("../types");
+        const max = TerminalWebGLManager.MAX_CONTEXTS;
+        const { localManager, disposeFor } = await makePriorityManager();
+
+        const now = Date.now();
+        for (let i = 0; i < max - 2; i++) {
+          localManager.ensureContext(
+            `work${i}`,
+            makeManagedTerminal({ agentState: "working", pendingWrites: 2 })
+          );
+        }
+        // Exactly at the window edge → stale (tier 1), since the check is `<`.
+        localManager.ensureContext(
+          "edge",
+          makeManagedTerminal({
+            agentState: "waiting",
+            pendingWrites: 0,
+            isFocused: false,
+            lastWriteAt: now - WRITE_BURST_RECENCY_MS,
+          })
+        );
+        // One millisecond inside the window → recent (tier 3).
+        localManager.ensureContext(
+          "inside",
+          makeManagedTerminal({
+            agentState: "waiting",
+            pendingWrites: 0,
+            isFocused: false,
+            lastWriteAt: now - WRITE_BURST_RECENCY_MS + 1,
+          })
+        );
+
+        localManager.ensureContext("extra", makeManagedTerminal({ agentState: "working" }));
+
+        expect(localManager.isActive("edge")).toBe(false);
+        expect(disposeFor("edge")).toHaveBeenCalledTimes(1);
+        expect(localManager.isActive("inside")).toBe(true);
+      } finally {
+        vi.useRealTimers();
+      }
+    });
+
     it("rate-limits the pool-pressure warning to once per minute", async () => {
       vi.useFakeTimers();
       vi.setSystemTime(0);

--- a/src/services/terminal/__tests__/TerminalWebGLManager.test.ts
+++ b/src/services/terminal/__tests__/TerminalWebGLManager.test.ts
@@ -879,6 +879,216 @@ describe("TerminalWebGLManager", () => {
     });
   });
 
+  describe("eviction priority", () => {
+    // Builds a fresh manager whose addons each carry an id-tagged dispose mock,
+    // so a test can assert exactly which pooled terminal lost its slot.
+    async function makePriorityManager(): Promise<{
+      localManager: import("../TerminalWebGLManager").TerminalWebGLManager;
+      disposeFor: (id: string) => ReturnType<typeof vi.fn>;
+    }> {
+      const { TerminalWebGLManager } = await import("../TerminalWebGLManager");
+      const disposeById = new Map<string, ReturnType<typeof vi.fn>>();
+      let pendingId: string | null = null;
+      WebglAddonMock.mockImplementation(function () {
+        const d = vi.fn();
+        if (pendingId) disposeById.set(pendingId, d);
+        return { dispose: d, onContextLoss: mockOnContextLoss };
+      });
+      const localManager = new TerminalWebGLManager();
+      const origEnsure = localManager.ensureContext.bind(localManager);
+      // Tag the next-constructed addon with the id being ensured.
+      localManager.ensureContext = (id: string, m: ManagedTerminal): void => {
+        pendingId = id;
+        origEnsure(id, m);
+        pendingId = null;
+      };
+      return {
+        localManager,
+        disposeFor: (id: string) => {
+          const d = disposeById.get(id);
+          if (!d) throw new Error(`no addon constructed for ${id}`);
+          return d;
+        },
+      };
+    }
+
+    it("evicts the idle terminal over actively-working ones regardless of LRU order", async () => {
+      const { TerminalWebGLManager } = await import("../TerminalWebGLManager");
+      const max = TerminalWebGLManager.MAX_CONTEXTS;
+      const { localManager, disposeFor } = await makePriorityManager();
+
+      // Oldest LRU entries are actively streaming (tier 5). Pure LRU would evict
+      // t0; the priority scorer must instead evict the idle terminal even though
+      // it is the newest entry.
+      for (let i = 0; i < max - 1; i++) {
+        localManager.ensureContext(
+          `work${i}`,
+          makeManagedTerminal({ agentState: "working", pendingWrites: 2, isFocused: false })
+        );
+      }
+      localManager.ensureContext(
+        "idle",
+        makeManagedTerminal({ agentState: "idle", pendingWrites: 0, isFocused: false })
+      );
+
+      localManager.ensureContext("extra", makeManagedTerminal({ agentState: "working" }));
+
+      expect(localManager.isActive("idle")).toBe(false);
+      expect(disposeFor("idle")).toHaveBeenCalledTimes(1);
+      expect(localManager.isActive("work0")).toBe(true);
+      expect(localManager.isActive("extra")).toBe(true);
+    });
+
+    it("treats undefined agentState as tier-0 and evicts it before a working terminal", async () => {
+      const { TerminalWebGLManager } = await import("../TerminalWebGLManager");
+      const max = TerminalWebGLManager.MAX_CONTEXTS;
+      const { localManager, disposeFor } = await makePriorityManager();
+
+      for (let i = 0; i < max - 1; i++) {
+        localManager.ensureContext(
+          `work${i}`,
+          makeManagedTerminal({ agentState: "working", pendingWrites: 1 })
+        );
+      }
+      // No agentState at all (non-agent terminal).
+      localManager.ensureContext("plain", makeManagedTerminal());
+
+      localManager.ensureContext("extra", makeManagedTerminal());
+
+      expect(localManager.isActive("plain")).toBe(false);
+      expect(disposeFor("plain")).toHaveBeenCalledTimes(1);
+    });
+
+    it("protects a streaming terminal (tier 5) over a focused-idle one (tier 4)", async () => {
+      const { TerminalWebGLManager } = await import("../TerminalWebGLManager");
+      const max = TerminalWebGLManager.MAX_CONTEXTS;
+      const { localManager, disposeFor } = await makePriorityManager();
+
+      for (let i = 0; i < max - 1; i++) {
+        localManager.ensureContext(
+          `work${i}`,
+          makeManagedTerminal({ agentState: "working", pendingWrites: 3, isFocused: false })
+        );
+      }
+      // Focused but idle — the user clicked through it but it isn't doing work.
+      localManager.ensureContext(
+        "focused",
+        makeManagedTerminal({ agentState: "waiting", pendingWrites: 0, isFocused: true })
+      );
+
+      localManager.ensureContext("extra", makeManagedTerminal({ agentState: "working" }));
+
+      expect(localManager.isActive("focused")).toBe(false);
+      expect(disposeFor("focused")).toHaveBeenCalledTimes(1);
+      for (let i = 0; i < max - 1; i++) {
+        expect(localManager.isActive(`work${i}`)).toBe(true);
+      }
+    });
+
+    it("classifies recent-write recency at the WRITE_BURST_RECENCY_MS boundary", async () => {
+      vi.useFakeTimers();
+      vi.setSystemTime(1_000_000);
+      installRafShim();
+      try {
+        const { TerminalWebGLManager } = await import("../TerminalWebGLManager");
+        const { WRITE_BURST_RECENCY_MS } = await import("../types");
+        const max = TerminalWebGLManager.MAX_CONTEXTS;
+        const { localManager, disposeFor } = await makePriorityManager();
+
+        const now = Date.now();
+        // Filler: streaming terminals (tier 5) — never the eviction target.
+        for (let i = 0; i < max - 2; i++) {
+          localManager.ensureContext(
+            `work${i}`,
+            makeManagedTerminal({ agentState: "working", pendingWrites: 2 })
+          );
+        }
+        // A: waiting, wrote just inside the window → recently-writing → tier 3.
+        localManager.ensureContext(
+          "recent",
+          makeManagedTerminal({
+            agentState: "waiting",
+            pendingWrites: 0,
+            isFocused: false,
+            lastWriteAt: now - (WRITE_BURST_RECENCY_MS - 1),
+          })
+        );
+        // B: waiting, wrote just outside the window → not recently-writing → tier 1.
+        localManager.ensureContext(
+          "stale",
+          makeManagedTerminal({
+            agentState: "waiting",
+            pendingWrites: 0,
+            isFocused: false,
+            lastWriteAt: now - (WRITE_BURST_RECENCY_MS + 1),
+          })
+        );
+
+        localManager.ensureContext("extra", makeManagedTerminal({ agentState: "working" }));
+
+        // Tier 1 (stale) outranks tier 3 (recent) for eviction.
+        expect(localManager.isActive("stale")).toBe(false);
+        expect(disposeFor("stale")).toHaveBeenCalledTimes(1);
+        expect(localManager.isActive("recent")).toBe(true);
+      } finally {
+        vi.useRealTimers();
+      }
+    });
+
+    it("falls back to LRU order to break ties within the same tier", async () => {
+      const { TerminalWebGLManager } = await import("../TerminalWebGLManager");
+      const max = TerminalWebGLManager.MAX_CONTEXTS;
+      const { localManager, disposeFor } = await makePriorityManager();
+
+      // Every entry is tier 0 (idle). Oldest LRU entry must lose its slot.
+      for (let i = 0; i < max; i++) {
+        localManager.ensureContext(`idle${i}`, makeManagedTerminal({ agentState: "idle" }));
+      }
+      localManager.ensureContext("extra", makeManagedTerminal({ agentState: "idle" }));
+
+      expect(localManager.isActive("idle0")).toBe(false);
+      expect(disposeFor("idle0")).toHaveBeenCalledTimes(1);
+      expect(localManager.isActive("idle1")).toBe(true);
+    });
+
+    it("rate-limits the pool-pressure warning to once per minute", async () => {
+      vi.useFakeTimers();
+      vi.setSystemTime(0);
+      installRafShim();
+      const warnSpy = vi.spyOn(console, "warn").mockImplementation(() => {});
+      try {
+        const { TerminalWebGLManager } = await import("../TerminalWebGLManager");
+        const max = TerminalWebGLManager.MAX_CONTEXTS;
+        const { localManager } = await makePriorityManager();
+
+        for (let i = 0; i < max; i++) {
+          localManager.ensureContext(`idle${i}`, makeManagedTerminal({ agentState: "idle" }));
+        }
+
+        const poolWarnings = () =>
+          warnSpy.mock.calls.filter(
+            (args) => typeof args[0] === "string" && args[0].includes("Pool pressure")
+          );
+
+        // First eviction warns immediately.
+        localManager.ensureContext("e1", makeManagedTerminal({ agentState: "idle" }));
+        expect(poolWarnings()).toHaveLength(1);
+
+        // Second eviction within the same minute is suppressed.
+        localManager.ensureContext("e2", makeManagedTerminal({ agentState: "idle" }));
+        expect(poolWarnings()).toHaveLength(1);
+
+        // After the interval elapses, the next eviction warns again.
+        vi.setSystemTime(60_001);
+        localManager.ensureContext("e3", makeManagedTerminal({ agentState: "idle" }));
+        expect(poolWarnings()).toHaveLength(2);
+      } finally {
+        warnSpy.mockRestore();
+        vi.useRealTimers();
+      }
+    });
+  });
+
   describe("lazy WebglAddon loading", () => {
     // These tests exercise the dynamic-import path. They reset loader state in
     // beforeEach so the queue behavior runs against a real (mocked) import().

--- a/src/services/terminal/__tests__/TerminalWriteController.test.ts
+++ b/src/services/terminal/__tests__/TerminalWriteController.test.ts
@@ -181,6 +181,10 @@ describe("TerminalWriteController.write", () => {
     // managed object is being torn down, so leaving its counter at 1 is
     // harmless. This mirrors the pre-extraction behavior in TIS.
     expect(managed.pendingWrites).toBe(1);
+
+    // The stale-identity guard returns before the lastWriteAt stamp, so the
+    // torn-down instance never gets burst protection it no longer needs.
+    expect(managed.lastWriteAt).toBeUndefined();
   });
 
   it("posts ack/notify only after terminal.write resolves, not synchronously", () => {
@@ -195,6 +199,7 @@ describe("TerminalWriteController.write", () => {
     controller.write("t1", "abc");
 
     expect(managed.pendingWrites).toBe(1);
+    expect(managed.lastWriteAt).toBeUndefined();
     expect(deps.acknowledgePortData).not.toHaveBeenCalled();
     expect(deps.acknowledgeData).not.toHaveBeenCalled();
     expect(deps.notifyWriteComplete).not.toHaveBeenCalled();
@@ -202,6 +207,7 @@ describe("TerminalWriteController.write", () => {
     captured?.();
 
     expect(managed.pendingWrites).toBe(0);
+    expect(managed.lastWriteAt).toBeTypeOf("number");
     expect(deps.acknowledgePortData).toHaveBeenCalledWith("t1", 3);
     expect(deps.acknowledgeData).toHaveBeenCalledWith("t1", 3);
     expect(deps.notifyWriteComplete).toHaveBeenCalledWith("t1", 3);

--- a/src/services/terminal/types.ts
+++ b/src/services/terminal/types.ts
@@ -70,6 +70,12 @@ export interface ManagedTerminal {
   // suppress the "new output" indicator while the user is actively scrolling.
   lastWheelAt?: number;
 
+  // Timestamp of the most recent completed terminal.write() parse. Used by the
+  // WebGL pool eviction scorer to protect terminals in an active write burst
+  // even when pendingWrites has since drained to 0. Stamped on write-complete,
+  // not write-enqueue, so it tracks rendered output rather than queue depth.
+  lastWriteAt?: number;
+
   // Last activity marker for scroll-to-last-activity
   lastActivityMarker?: IMarker;
 
@@ -174,6 +180,13 @@ export const TIER_DOWNGRADE_HYSTERESIS_MS = 500;
 // that a real BACKGROUND dwell still trims memory before the 30s hibernation
 // window. The 500ms tier-downgrade hysteresis is additive, not a replacement.
 export const SCROLLBACK_REDUCE_COOLDOWN_MS = 2000;
+
+// Recency window for classifying a terminal as "in an active write burst" in
+// the WebGL pool eviction scorer. A terminal whose lastWriteAt is within this
+// window is protected from eviction even after pendingWrites drains to 0, so a
+// streaming agent doesn't lose its slot in the gap between output chunks.
+// Mirrors SCROLLBACK_REDUCE_COOLDOWN_MS — same 2s burst-cadence assumption.
+export const WRITE_BURST_RECENCY_MS = 2000;
 
 export const HIBERNATION_DELAY_MS = 30_000;
 


### PR DESCRIPTION
## Summary

- WebGL context pool was evicting by last-touch LRU. In tiled layouts with 20-30 agent terminals and a pool budget of 12, actively-writing agent terminals were losing their slot to terminals that had just been focused but weren't writing.
- Replaces the single LRU eviction site in `attachWithLoadedAddon` with a priority-based scorer, `pickEvictTarget`, that tiers pool entries by agent state, write-burst recency, and focus. LRU position is still used as a within-tier tiebreaker.
- Adds a `lastWriteAt` timestamp stamped in `TerminalWriteController` and a `WRITE_BURST_RECENCY_MS` (2000ms) constant to `ManagedTerminal`. Adds rate-limited (once per minute) Tier-0 `console.warn` pool-pressure diagnostics.

Resolves #8084

## Changes

Eviction tier order (evict first to last):

1. Idle / completed / exited / no agent
2. Waiting, not recently writing
3. Working, drained (catch-all)
4. Waiting, in active write burst
5. Focused
6. Working with queued writes
7. Focused + directing

Files touched: `src/services/terminal/types.ts`, `TerminalWebGLManager.ts`, `TerminalWriteController.ts`.

Test additions: 9 eviction-priority cases in `TerminalWebGLManager.test.ts`; `lastWriteAt` stamp and stale-guard tests in `TerminalWriteController.test.ts`.

## Testing

83 unit tests pass. `npm run check` clean (lint warnings down 3 from baseline).