### PR TITLE
feat(forge): foundation types and forgeProviders contribution schema

### DIFF
--- a/electron/schemas/plugin.ts
+++ b/electron/schemas/plugin.ts
@@ -82,9 +82,9 @@ export const ForgeProviderContributionSchema = z.object({
   id: z.string().min(1).max(64).regex(SAFE_ID_PATTERN),
   name: z.string().min(1),
   matches: z.array(z.string().min(1)).min(1),
-  capabilities: z.array(z.string()).optional(),
-  settingsScopeRef: z.string().optional(),
-  viewRefs: z.array(z.string()).optional(),
+  capabilities: z.array(z.string().min(1)).optional(),
+  settingsScopeRef: z.string().min(1).optional(),
+  viewRefs: z.array(z.string().min(1)).optional(),
 });
 
 export const PluginPermissionSchema = z.enum(BUILT_IN_PLUGIN_PERMISSIONS);

--- a/electron/schemas/plugin.ts
+++ b/electron/schemas/plugin.ts
@@ -10,6 +10,7 @@ import type {
   McpServerContribution,
   PluginPermission,
 } from "../../shared/types/plugin.js";
+import type { ForgeProviderContribution } from "../../shared/types/forge.js";
 
 const SAFE_ID_PATTERN = /^[a-zA-Z0-9._-]+$/;
 
@@ -70,6 +71,22 @@ export const McpServerContributionSchema = z.object({
   env: z.record(z.string(), z.string()).optional(),
 });
 
+/**
+ * Reserved contribution point. Shape is validated but the runtime does not
+ * yet act on these entries — `PluginService` logs a warning and skips them.
+ * See `docs/architecture/forge-provider-abstraction.md`. `capabilities` is an
+ * uninterpreted advisory list (informational only); the host gates behavior
+ * on the runtime `ForgeProviderImpl` shape, not these strings.
+ */
+export const ForgeProviderContributionSchema = z.object({
+  id: z.string().min(1).max(64).regex(SAFE_ID_PATTERN),
+  name: z.string().min(1),
+  matches: z.array(z.string().min(1)).min(1),
+  capabilities: z.array(z.string()).optional(),
+  settingsScopeRef: z.string().optional(),
+  viewRefs: z.array(z.string()).optional(),
+});
+
 export const PluginPermissionSchema = z.enum(BUILT_IN_PLUGIN_PERMISSIONS);
 
 export const PluginManifestSchema = z
@@ -101,6 +118,7 @@ export const PluginManifestSchema = z
         menuItems: z.array(MenuItemContributionSchema).default([]),
         views: z.array(ViewContributionSchema).default([]),
         mcpServers: z.array(McpServerContributionSchema).default([]),
+        forgeProviders: z.array(ForgeProviderContributionSchema).default([]),
       })
       .default({
         panels: [],
@@ -108,6 +126,7 @@ export const PluginManifestSchema = z
         menuItems: [],
         views: [],
         mcpServers: [],
+        forgeProviders: [],
       }),
   })
   .strict();
@@ -121,3 +140,4 @@ export type {
   McpServerContribution,
   PluginPermission,
 };
+export type { ForgeProviderContribution };

--- a/electron/services/PluginService.ts
+++ b/electron/services/PluginService.ts
@@ -279,6 +279,12 @@ export class PluginService {
       );
     }
 
+    if (manifest.contributes.forgeProviders.length > 0) {
+      console.warn(
+        `[PluginService] Plugin "${manifest.name}": contributes.forgeProviders is not yet implemented and will be ignored`
+      );
+    }
+
     // Insert the plugin into the registry BEFORE importing its main module so
     // synchronous host-API calls made during module evaluation (e.g., a plugin
     // that calls host.registerAction/registerHandler at import time) see the

--- a/electron/services/__tests__/PluginService.test.ts
+++ b/electron/services/__tests__/PluginService.test.ts
@@ -257,6 +257,88 @@ describe("PluginManifestSchema permissions field", () => {
   });
 });
 
+describe("PluginManifestSchema forgeProviders contribution", () => {
+  const validBase = { name: "acme.forge", version: "1.0.0" };
+
+  it("defaults contributes.forgeProviders to [] when contributes is absent", () => {
+    const result = PluginManifestSchema.safeParse(validBase);
+    expect(result.success).toBe(true);
+    if (result.success) {
+      expect(result.data.contributes.forgeProviders).toEqual([]);
+    }
+  });
+
+  it("defaults contributes.forgeProviders to [] when contributes is an empty object", () => {
+    const result = PluginManifestSchema.safeParse({ ...validBase, contributes: {} });
+    expect(result.success).toBe(true);
+    if (result.success) {
+      expect(result.data.contributes.forgeProviders).toEqual([]);
+    }
+  });
+
+  it("accepts a fully specified forgeProviders entry", () => {
+    const result = PluginManifestSchema.safeParse({
+      ...validBase,
+      contributes: {
+        forgeProviders: [
+          {
+            id: "github",
+            name: "GitHub",
+            matches: ["github.com"],
+            capabilities: ["issues", "pulls", "reviews", "required-checks", "releases"],
+            settingsScopeRef: "github",
+            viewRefs: ["github-issues", "github-prs"],
+          },
+        ],
+      },
+    });
+    expect(result.success).toBe(true);
+  });
+
+  it("accepts a forgeProviders entry with only required fields", () => {
+    const result = PluginManifestSchema.safeParse({
+      ...validBase,
+      contributes: {
+        forgeProviders: [{ id: "gh", name: "GitHub", matches: ["github.com"] }],
+      },
+    });
+    expect(result.success).toBe(true);
+  });
+
+  it("rejects a forgeProviders entry with an empty matches array", () => {
+    const result = PluginManifestSchema.safeParse({
+      ...validBase,
+      contributes: {
+        forgeProviders: [{ id: "gh", name: "GitHub", matches: [] }],
+      },
+    });
+    expect(result.success).toBe(false);
+  });
+
+  it("rejects a forgeProviders entry missing required fields", () => {
+    const result = PluginManifestSchema.safeParse({
+      ...validBase,
+      contributes: {
+        forgeProviders: [{ id: "gh" }],
+      },
+    });
+    expect(result.success).toBe(false);
+  });
+
+  it("strips unknown keys on a forgeProviders entry (matches sibling contribution schemas)", () => {
+    const result = PluginManifestSchema.safeParse({
+      ...validBase,
+      contributes: {
+        forgeProviders: [{ id: "gh", name: "GitHub", matches: ["github.com"], unknownKey: true }],
+      },
+    });
+    expect(result.success).toBe(true);
+    if (result.success) {
+      expect(result.data.contributes.forgeProviders[0]).not.toHaveProperty("unknownKey");
+    }
+  });
+});
+
 describe("PluginService", () => {
   it("returns empty list when plugins directory does not exist", async () => {
     const service = new PluginService(path.join(tmpDir, "nonexistent"));
@@ -2007,6 +2089,36 @@ describe("reserved contribution point warnings", () => {
     );
   });
 
+  it("accepts a contributes.forgeProviders entry and logs a 'not yet implemented' warning", async () => {
+    await writePlugin("forge", {
+      name: "acme.forge",
+      version: "1.0.0",
+      engines: { daintree: "^0.7.0" },
+      contributes: {
+        forgeProviders: [
+          {
+            id: "github",
+            name: "GitHub",
+            matches: ["github.com"],
+            capabilities: ["issues", "pulls", "reviews"],
+            settingsScopeRef: "github",
+            viewRefs: ["github-issues"],
+          },
+        ],
+      },
+    });
+
+    const service = new PluginService(tmpDir, "0.7.5");
+    await service.initialize();
+
+    expect(service.listPlugins()).toHaveLength(1);
+    expect(warnSpy).toHaveBeenCalledWith(
+      expect.stringContaining(
+        'Plugin "acme.forge": contributes.forgeProviders is not yet implemented'
+      )
+    );
+  });
+
   it("does not warn about reserved points when the manifest omits them", async () => {
     await writePlugin("plain", {
       name: "acme.plain",
@@ -2021,6 +2133,7 @@ describe("reserved contribution point warnings", () => {
     const warnMessages = warnSpy.mock.calls.map((call: unknown[]) => String(call[0]));
     expect(warnMessages.some((m: string) => m.includes("contributes.views"))).toBe(false);
     expect(warnMessages.some((m: string) => m.includes("contributes.mcpServers"))).toBe(false);
+    expect(warnMessages.some((m: string) => m.includes("contributes.forgeProviders"))).toBe(false);
   });
 
   it("does not warn when reserved arrays are explicitly present but empty", async () => {
@@ -2028,7 +2141,7 @@ describe("reserved contribution point warnings", () => {
       name: "acme.explicit-empty",
       version: "1.0.0",
       engines: { daintree: "^0.7.0" },
-      contributes: { views: [], mcpServers: [] },
+      contributes: { views: [], mcpServers: [], forgeProviders: [] },
     });
 
     const service = new PluginService(tmpDir, "0.7.5");
@@ -2038,6 +2151,7 @@ describe("reserved contribution point warnings", () => {
     const warnMessages = warnSpy.mock.calls.map((call: unknown[]) => String(call[0]));
     expect(warnMessages.some((m: string) => m.includes("contributes.views"))).toBe(false);
     expect(warnMessages.some((m: string) => m.includes("contributes.mcpServers"))).toBe(false);
+    expect(warnMessages.some((m: string) => m.includes("contributes.forgeProviders"))).toBe(false);
   });
 
   it("still processes other contributions when reserved points are present", async () => {

--- a/electron/services/__tests__/PluginService.test.ts
+++ b/electron/services/__tests__/PluginService.test.ts
@@ -293,6 +293,18 @@ describe("PluginManifestSchema forgeProviders contribution", () => {
       },
     });
     expect(result.success).toBe(true);
+    if (result.success) {
+      expect(result.data.contributes.forgeProviders).toEqual([
+        {
+          id: "github",
+          name: "GitHub",
+          matches: ["github.com"],
+          capabilities: ["issues", "pulls", "reviews", "required-checks", "releases"],
+          settingsScopeRef: "github",
+          viewRefs: ["github-issues", "github-prs"],
+        },
+      ]);
+    }
   });
 
   it("accepts a forgeProviders entry with only required fields", () => {
@@ -2117,6 +2129,10 @@ describe("reserved contribution point warnings", () => {
         'Plugin "acme.forge": contributes.forgeProviders is not yet implemented'
       )
     );
+    // Reserved + ignored: a forge-only manifest has no registry side effects.
+    expect(registerPanelKind).not.toHaveBeenCalled();
+    expect(registerToolbarButton).not.toHaveBeenCalled();
+    expect(registerPluginMenuItem).not.toHaveBeenCalled();
   });
 
   it("does not warn about reserved points when the manifest omits them", async () => {

--- a/shared/types/forge.ts
+++ b/shared/types/forge.ts
@@ -266,9 +266,14 @@ export interface MilestoneCapability {
 /**
  * Runtime contract a forge plugin implements and registers via
  * `host.registerForgeProvider`. Every provider implements the base methods;
- * optional capabilities are sibling fields the host probes with the `in`
- * operator at runtime. Adding a new capability adds a sibling field — the
- * base interface never changes.
+ * optional capabilities are sibling fields the host probes at runtime.
+ * Adding a new capability adds a sibling field — the base interface never
+ * changes.
+ *
+ * Capability presence check: use a truthiness/`!= null` guard
+ * (`if (provider.reviews)`), NOT the `in` operator. An optional property
+ * explicitly set to `undefined` still satisfies `"reviews" in provider`,
+ * so `in` would falsely report the capability as available.
  */
 export interface ForgeProviderImpl {
   // Auth — fully owned by the plugin; the host never inspects credentials.
@@ -294,7 +299,7 @@ export interface ForgeProviderImpl {
   // Host-visible rate-limit state, parsed from the provider's own transport.
   getRateLimit?(): Promise<RateLimitInfo>;
 
-  // Optional capabilities — host checks via the `in` operator at runtime.
+  // Optional capabilities — host checks presence via a truthiness guard (see above).
   reviews?: ReviewCapability;
   approvals?: ApprovalCapability;
   releases?: ReleaseCapability;

--- a/shared/types/forge.ts
+++ b/shared/types/forge.ts
@@ -1,0 +1,359 @@
+/**
+ * Forge provider abstraction — foundation types.
+ *
+ * A "forge" is the developer-platform layer that sits on top of git: issues,
+ * pull/merge requests, reviews, CI roll-up, releases, project boards, and
+ * auth. See `docs/architecture/forge-provider-abstraction.md` for the design.
+ *
+ * This module is the runtime contract a forge plugin implements
+ * (`ForgeProviderImpl`) plus the manifest entry that registers it
+ * (`ForgeProviderContribution`). It is type-only and carries zero runtime
+ * behavior — the host registry, SDK host API, and GitHub built-in plugin
+ * land in later PRs of the migration plan.
+ *
+ * The host abstracts deliberately little: a thin shared interface for what
+ * genuinely converges, a capability mechanism for what does not, and a
+ * `rawData` escape hatch on every returned shape. The host never inspects
+ * `rawData`; it exists for plugin-shipped views to consume their own data.
+ * A first-party read of `rawData` is an interface-review signal — the missing
+ * field should be promoted to the typed surface or a capability instead.
+ */
+
+/**
+ * Identity of a repository on a forge, derived from a git remote URL via
+ * {@link ForgeProviderImpl.parseRemote}.
+ */
+export interface RepoRef {
+  host: string;
+  owner: string;
+  repo: string;
+  rawData: unknown;
+}
+
+/**
+ * Provider-agnostic reference to a single resource (issue or PR). Used by
+ * branch→PR linkage payloads so consumers can route back through the owning
+ * provider without re-parsing.
+ */
+export interface ResourceRef {
+  providerId: string;
+  owner: string;
+  repo: string;
+  number: number;
+  rawData: unknown;
+}
+
+/**
+ * Normalized PR state. Provider enums diverge (GitHub `OPEN|CLOSED|MERGED`,
+ * GitLab `opened|closed|locked|merged`, Bitbucket `OPEN|MERGED|DECLINED|
+ * SUPERSEDED`, Gitea `open|closed`); the host normalizes to this set and
+ * preserves the verbatim provider value as `rawState`. When submitting state
+ * back to a provider API, plugins use `rawState`, never the normalized value.
+ */
+export type NormalizedPRState = "open" | "merged" | "closed" | "declined";
+
+/** Normalized issue state. `rawState` preserves the verbatim provider value. */
+export type NormalizedIssueState = "open" | "closed";
+
+/**
+ * Uniform rate-limit projection. Plugins parse their own transport (e.g. the
+ * GitHub GraphQL `rateLimit` node) and populate this shape; the host renders
+ * the rate-limit indicator from it. `null` means the provider does not report
+ * that dimension.
+ */
+export interface RateLimitInfo {
+  limit: number | null;
+  remaining: number | null;
+  /** Epoch milliseconds. */
+  resetAt: number | null;
+  secondaryThrottled?: boolean;
+}
+
+/** Boolean-ish CI roll-up. The host renders a summary; it does not graph checks. */
+export type CIStatusState = "success" | "failure" | "pending" | "neutral" | "unknown";
+
+export interface CIStatus {
+  state: CIStatusState;
+  total: number;
+  passed: number;
+  failed: number;
+  pending: number;
+  /** Whether required-checks gating is currently satisfied, if the provider gates. */
+  requiredChecksPassing?: boolean;
+  rawData: unknown;
+}
+
+/** Result of validating stored credentials against the provider. */
+export interface AuthValidation {
+  valid: boolean;
+  scopes?: string[];
+  /** Epoch milliseconds, or `null` when the token does not expire. */
+  expiresAt?: number | null;
+  error?: string;
+}
+
+/**
+ * Opaque credential the host passes through without inspecting. Token
+ * storage, refresh, SSO, scope validation, and OAuth flows are fully owned
+ * by the plugin.
+ */
+export interface Credentials {
+  kind: "bearer" | "basic";
+  value: string;
+}
+
+/** Repository metadata roll-up. */
+export interface RepoMetadata {
+  defaultBranch: string;
+  isPrivate: boolean;
+  isFork: boolean;
+  isArchived: boolean;
+  description?: string | null;
+  license?: string | null;
+  topics?: string[];
+  rawData: unknown;
+}
+
+/**
+ * Paged-listing options. All fields advisory — providers ignore options they
+ * do not support. `cursor` is opaque and provider-defined.
+ */
+export interface ListOptions {
+  state?: "open" | "closed" | "all";
+  cursor?: string | null;
+  perPage?: number;
+  labels?: string[];
+  assignee?: string;
+  sort?: string;
+  direction?: "asc" | "desc";
+}
+
+/**
+ * One page of results. `nextCursor` is `null` when there are no more pages.
+ * Client-side filtering across pages is forbidden — listing filters go
+ * through {@link ListOptions} and the provider's native query.
+ */
+export interface Page<T> {
+  items: T[];
+  nextCursor: string | null;
+  hasMore: boolean;
+  totalCount?: number;
+}
+
+/** Minimal actor projection. */
+export interface ForgeUser {
+  login: string;
+  avatarUrl?: string;
+  rawData: unknown;
+}
+
+export interface ForgeLabel {
+  name: string;
+  color?: string;
+}
+
+export interface Issue {
+  number: number;
+  title: string;
+  body: string;
+  state: NormalizedIssueState;
+  /** Verbatim provider state value — use this when submitting state back. */
+  rawState: string;
+  url: string;
+  author?: ForgeUser;
+  assignees: ForgeUser[];
+  labels: ForgeLabel[];
+  /** Epoch milliseconds. */
+  createdAt: number;
+  /** Epoch milliseconds. */
+  updatedAt: number;
+  /** Epoch milliseconds, or `null` while open. */
+  closedAt?: number | null;
+  rawData: unknown;
+}
+
+export interface PR {
+  number: number;
+  title: string;
+  body: string;
+  state: NormalizedPRState;
+  /** Verbatim provider state value — use this when submitting state back. */
+  rawState: string;
+  isDraft: boolean;
+  merged: boolean;
+  url: string;
+  author?: ForgeUser;
+  baseRef: string;
+  headRef: string;
+  /** `null` when the provider has not computed mergeability yet. */
+  mergeable?: boolean | null;
+  /** Epoch milliseconds. */
+  createdAt: number;
+  /** Epoch milliseconds. */
+  updatedAt: number;
+  /** Epoch milliseconds, or `null` while open. */
+  closedAt?: number | null;
+  /** Epoch milliseconds, or `null` when not merged. */
+  mergedAt?: number | null;
+  rawData: unknown;
+}
+
+export interface Release {
+  id: string;
+  tagName: string;
+  name: string;
+  body: string;
+  isDraft: boolean;
+  isPrerelease: boolean;
+  url: string;
+  /** Epoch milliseconds, or `null` for an unpublished draft. */
+  publishedAt?: number | null;
+  /** Epoch milliseconds. */
+  createdAt: number;
+  rawData: unknown;
+}
+
+/**
+ * Review threads diverge too much across providers to normalize. The host
+ * exposes only an opaque shape; plugins ship their own review-thread UI.
+ */
+export interface ReviewThread {
+  id: string;
+  rawData: unknown;
+}
+
+export interface ApprovalState {
+  approved: boolean;
+  required: number;
+  approvedCount: number;
+  changesRequested: boolean;
+  rawData: unknown;
+}
+
+/** Stub shape — fields beyond identity are validated when a provider implements it. */
+export interface ProjectBoard {
+  id: string;
+  rawData: unknown;
+}
+
+/** Stub shape — fields beyond identity are validated when a provider implements it. */
+export interface Milestone {
+  id: string;
+  rawData: unknown;
+}
+
+export interface ReviewCapability {
+  getReviewThreads(repo: RepoRef, prNumber: number): Promise<ReviewThread[]>;
+}
+
+export interface ApprovalCapability {
+  getApprovalState(repo: RepoRef, prNumber: number): Promise<ApprovalState>;
+}
+
+export interface ReleaseCapability {
+  listReleases(repo: RepoRef, opts: ListOptions): Promise<Page<Release>>;
+  getLatestRelease(repo: RepoRef): Promise<Release | null>;
+}
+
+export interface ProjectBoardCapability {
+  listBoards(repo: RepoRef, opts: ListOptions): Promise<Page<ProjectBoard>>;
+}
+
+export interface MilestoneCapability {
+  listMilestones(repo: RepoRef, opts: ListOptions): Promise<Page<Milestone>>;
+}
+
+/**
+ * Runtime contract a forge plugin implements and registers via
+ * `host.registerForgeProvider`. Every provider implements the base methods;
+ * optional capabilities are sibling fields the host probes with the `in`
+ * operator at runtime. Adding a new capability adds a sibling field — the
+ * base interface never changes.
+ */
+export interface ForgeProviderImpl {
+  // Auth — fully owned by the plugin; the host never inspects credentials.
+  getCredentials(): Promise<Credentials | null>;
+  validateCredentials(): Promise<AuthValidation>;
+
+  // Repository identity.
+  parseRemote(url: string): RepoRef | null;
+
+  // Core CRUD — every provider implements these.
+  listIssues(repo: RepoRef, opts: ListOptions): Promise<Page<Issue>>;
+  listPRs(repo: RepoRef, opts: ListOptions): Promise<Page<PR>>;
+  getIssue(repo: RepoRef, number: number): Promise<Issue | null>;
+  getPR(repo: RepoRef, number: number): Promise<PR | null>;
+  findPRByBranch(repo: RepoRef, branchName: string): Promise<PR | null>;
+  getCIStatus(repo: RepoRef, prNumber: number): Promise<CIStatus | null>;
+  getRepoMetadata(repo: RepoRef): Promise<RepoMetadata>;
+
+  // URL builders — the provider knows its own URL shape.
+  buildIssueUrl(repo: RepoRef, number: number): string;
+  buildPRUrl(repo: RepoRef, number: number): string;
+
+  // Host-visible rate-limit state, parsed from the provider's own transport.
+  getRateLimit?(): Promise<RateLimitInfo>;
+
+  // Optional capabilities — host checks via the `in` operator at runtime.
+  reviews?: ReviewCapability;
+  approvals?: ApprovalCapability;
+  releases?: ReleaseCapability;
+  projectBoards?: ProjectBoardCapability;
+  milestones?: MilestoneCapability;
+}
+
+/**
+ * Suggested capability vocabulary surfaced in the manifest's `capabilities`
+ * array. The host does not interpret these strings — they are informational,
+ * driving the Preferences "supports: …" display only. Behavior gates on
+ * whether the matching {@link ForgeProviderImpl} capability field is present
+ * at runtime, which keeps the claim honest. The open union preserves
+ * autocomplete while allowing provider-defined strings.
+ */
+export type ForgeCapabilityHint =
+  | "issues"
+  | "pulls"
+  | "reviews"
+  | "approvals"
+  | "merge-trains"
+  | "required-checks"
+  | "draft-prs"
+  | "assignees"
+  | "releases"
+  | "project-boards"
+  | "milestones"
+  | (string & {});
+
+/**
+ * `forgeProviders` manifest entry. Eager (manifest-driven) registration
+ * populates the Preferences UI and remote-routing table before any plugin
+ * code runs; the implementation handler binds lazily on first use.
+ */
+export interface ForgeProviderContribution {
+  /** Namespaced at runtime as `{pluginId}.{id}`; the built-in GitHub plugin uses bare `github`. */
+  id: string;
+  /** Display label in Preferences → Forge Integrations. */
+  name: string;
+  /** Hostname or glob patterns for git remote URLs; first matching provider wins. */
+  matches: string[];
+  /** Informational capability hints; the host does not interpret these. */
+  capabilities?: ForgeCapabilityHint[];
+  /** ID prefix in this plugin's `settings` contributions, used to group provider settings. */
+  settingsScopeRef?: string;
+  /** IDs of `views` contributions shown under this provider's panel section. */
+  viewRefs?: string[];
+}
+
+/**
+ * Passed to `host.registerForgeProvider` alongside the implementation. Mirrors
+ * the manifest entry; the plugin can omit fields already declared statically
+ * in `plugin.json`, so only `id` is required here.
+ */
+export interface ForgeProviderDescriptor {
+  id: string;
+  name?: string;
+  matches?: string[];
+  capabilities?: ForgeCapabilityHint[];
+  settingsScopeRef?: string;
+  viewRefs?: string[];
+}

--- a/shared/types/plugin.ts
+++ b/shared/types/plugin.ts
@@ -1,3 +1,5 @@
+import type { ForgeProviderContribution } from "./forge.js";
+
 export interface PanelContribution {
   id: string;
   name: string;
@@ -91,6 +93,7 @@ export interface PluginManifest {
     menuItems: MenuItemContribution[];
     views: ViewContribution[];
     mcpServers: McpServerContribution[];
+    forgeProviders: ForgeProviderContribution[];
   };
 }
 


### PR DESCRIPTION
## Summary

- Adds `shared/types/forge.ts` — the full runtime contract for forge providers: `ForgeProviderImpl`, `ForgeProviderDescriptor`, domain types (`Issue`, `PR`, `Release`, `RepoRef`, `Page<T>`, `ListOptions`, `CIStatus`, `RateLimitInfo`), a normalized PR state enum (`open | merged | closed | declined`), and optional capability sub-interfaces (`ReviewCapability`, `ApprovalCapability`, `ReleaseCapability`, `ProjectBoardCapability`, `MilestoneCapability`).
- Extends the plugin manifest Zod schema in `electron/schemas/plugin.ts` with a strict-mode `forgeProviders` contribution point; updates `shared/types/plugin.ts` to surface `ForgeProviderContribution` on `contributes`; adds a reserved-contribution warning in `PluginService.ts`.
- Zero behavior change — purely foundational. Step 1 of the forge migration that supersedes the internal-service approach in #5167.

Resolves #8056

## Changes

- `shared/types/forge.ts` (new) — full provider contract. All domain objects carry `rawData: unknown`; `PR` and `Issue` carry `rawState: string` so plugins can round-trip state to the provider API without translation loss.
- `electron/schemas/plugin.ts` — `forgeProviders` contribution point added with strict Zod validation; also fixes a double-default on an existing field.
- `shared/types/plugin.ts` — `ForgeProviderContribution` added to `PluginManifest.contributes`.
- `electron/services/PluginService.ts` — logs a warning when a plugin declares a `forgeProviders` contribution (reserved until wiring lands).
- `electron/services/__tests__/PluginService.test.ts` — schema validation, double-default coverage, and warning/side-effect tests.

## Testing

`npm run check` passes clean. New tests cover schema acceptance/rejection cases, the double-default fix, and the reserved-contribution warning path.