### PR TITLE
perf(terminal): visibility-gate WebGL release with 500ms hide-dwell hysteresis

### DIFF
--- a/src/services/terminal/TerminalHibernationManager.ts
+++ b/src/services/terminal/TerminalHibernationManager.ts
@@ -45,6 +45,16 @@ export class TerminalHibernationManager {
       clearTimeout(managed.hibernationTimer);
       managed.hibernationTimer = undefined;
     }
+    // Cancel any in-flight visibility-driven hide-dwell — hibernation is
+    // authoritative and routes through onTerminalDestroyed (bypassing
+    // releaseContext), so we don't want a stray timer firing later. Done
+    // here, after the early-return guards above, so a hibernate() call that
+    // bails on an active agent leaves the dwell timer running to handle the
+    // release on its own.
+    if (managed.webGLHideTimer !== undefined) {
+      clearTimeout(managed.webGLHideTimer);
+      managed.webGLHideTimer = undefined;
+    }
 
     this.deps.destroyRestoreState(id);
     this.deps.resetBufferedOutput(id);

--- a/src/services/terminal/TerminalInstanceService.ts
+++ b/src/services/terminal/TerminalInstanceService.ts
@@ -46,10 +46,17 @@ export { isNonKeyboardInput } from "./inputUtils";
 // `forceXtermReflow` from this module don't need to update their imports.
 export { forceXtermReflow };
 
-// Debounce on the visibility-driven WebGL restore path. Hide is immediate;
-// show waits this long before re-acquiring so rapid tab/panel toggles don't
-// thrash WebglAddon load/unload (each cycle reallocates GPU resources).
+// Debounce on the visibility-driven WebGL restore path. Show waits this long
+// before re-acquiring so rapid tab/panel toggles don't thrash WebglAddon
+// load/unload (each cycle reallocates GPU resources).
 const WEBGL_RESTORE_DEBOUNCE_MS = 100;
+
+// Release hysteresis on the visibility-driven hide path. Holding the context
+// for this long before releasing covers normal panel-toggle and focus-cycle
+// cadences (~100–300ms) without over-occupying the 12-slot WebGL pool under
+// multi-terminal hide. Authoritative release paths (tier demotion, agent
+// demotion, destroy, hibernation) cancel this timer and release immediately.
+const WEBGL_HIDE_DWELL_MS = 500;
 
 function canAutoInitializeTerminalIngest(): boolean {
   return (
@@ -248,6 +255,9 @@ class TerminalInstanceService {
             this.webGLManager.ensureContext(id, managed);
           } else if (!managed.isVisible) {
             // Keep WebGL while visible — releasing here causes a one-frame renderer gap.
+            // Tier demotion is an authoritative signal — cancel any pending
+            // hide-dwell and release immediately.
+            this.cancelWebGLHideTimer(managed);
             const hadWebGL = this.webGLManager.isActive(id);
             this.webGLManager.releaseContext(id);
             // Only refresh for a visible terminal — repainting an offscreen
@@ -511,6 +521,7 @@ class TerminalInstanceService {
         clearTimeout(managed.webGLRestoreTimer);
         managed.webGLRestoreTimer = undefined;
       }
+      this.cancelWebGLHideTimer(managed);
 
       if (isVisible) {
         // Revealing an on-screen terminal — make sure it doesn't get hibernated.
@@ -569,10 +580,18 @@ class TerminalInstanceService {
           this.webGLManager.ensureContext(id, current);
         }, WEBGL_RESTORE_DEBOUNCE_MS);
       } else {
-        // Going offscreen. Release the WebGL context immediately to free a
-        // pool slot — xterm falls back to the DOM renderer until the
-        // terminal becomes visible again.
-        this.webGLManager.releaseContext(id);
+        // Going offscreen. Hold the WebGL context for WEBGL_HIDE_DWELL_MS so
+        // rapid hide→show cycles (panel toggles, focus oscillation) don't
+        // churn the pool. The timer callback re-fetches `managed` to avoid
+        // stale refs (same pattern as webGLRestoreTimer above) and re-checks
+        // isVisible so a show during the dwell window keeps the context.
+        managed.webGLHideTimer = window.setTimeout(() => {
+          const current = this.instances.get(id);
+          if (!current) return;
+          current.webGLHideTimer = undefined;
+          if (current.isVisible) return;
+          this.webGLManager.releaseContext(id);
+        }, WEBGL_HIDE_DWELL_MS);
 
         // If we're already in a hibernation-eligible tier, onTierApplied
         // won't fire to start the timer — do it here instead.
@@ -946,6 +965,13 @@ class TerminalInstanceService {
       managed.attachRevealDisposable = undefined;
     }
     managed.hostElement.style.opacity = "";
+  }
+
+  private cancelWebGLHideTimer(managed: ManagedTerminal): void {
+    if (managed.webGLHideTimer !== undefined) {
+      clearTimeout(managed.webGLHideTimer);
+      managed.webGLHideTimer = undefined;
+    }
   }
 
   attach(id: string, container: HTMLElement): ManagedTerminal | null {
@@ -1727,6 +1753,9 @@ class TerminalInstanceService {
     // pane gets its blinking cursor back.
     this.applyCursorBlinkPolicy(managed);
     restoreScrollback(managed);
+    // Agent demotion is authoritative — cancel any pending hide-dwell so the
+    // timer can't fire later and call releaseContext on a stale slot.
+    this.cancelWebGLHideTimer(managed);
     this.webGLManager.releaseContext(id);
     this.maybeReflowTerminal(managed);
   }
@@ -1760,6 +1789,13 @@ class TerminalInstanceService {
   }
 
   hibernate(id: string): void {
+    const managed = this.instances.get(id);
+    if (managed) {
+      // Hibernation routes through onTerminalDestroyed (bypassing
+      // releaseContext) — cancel the dwell timer so it can't fire after
+      // the pool entry is gone.
+      this.cancelWebGLHideTimer(managed);
+    }
     this.hibernationManager.hibernate(id);
   }
 
@@ -1848,6 +1884,10 @@ class TerminalInstanceService {
     if (managed.webGLRestoreTimer !== undefined) {
       clearTimeout(managed.webGLRestoreTimer);
       managed.webGLRestoreTimer = undefined;
+    }
+    if (managed.webGLHideTimer !== undefined) {
+      clearTimeout(managed.webGLHideTimer);
+      managed.webGLHideTimer = undefined;
     }
 
     managed.lastActivityMarker?.dispose();

--- a/src/services/terminal/TerminalInstanceService.ts
+++ b/src/services/terminal/TerminalInstanceService.ts
@@ -1789,13 +1789,6 @@ class TerminalInstanceService {
   }
 
   hibernate(id: string): void {
-    const managed = this.instances.get(id);
-    if (managed) {
-      // Hibernation routes through onTerminalDestroyed (bypassing
-      // releaseContext) — cancel the dwell timer so it can't fire after
-      // the pool entry is gone.
-      this.cancelWebGLHideTimer(managed);
-    }
     this.hibernationManager.hibernate(id);
   }
 

--- a/src/services/terminal/__tests__/TerminalInstanceService.webglVisibility.test.ts
+++ b/src/services/terminal/__tests__/TerminalInstanceService.webglVisibility.test.ts
@@ -122,6 +122,7 @@ function makeMockManaged(overrides: Record<string, unknown> = {}) {
     deferredOutput: [] as Array<string | Uint8Array>,
     hibernationTimer: undefined as ReturnType<typeof setTimeout> | undefined,
     webGLRestoreTimer: undefined as number | undefined,
+    webGLHideTimer: undefined as number | undefined,
     isInputLocked: false,
     ipcListenerCount: 0,
     attachGeneration: 0,
@@ -164,7 +165,7 @@ describe("TerminalInstanceService - visibility-driven WebGL lease", () => {
     vi.useRealTimers();
   });
 
-  it("setVisible(false) immediately releases the WebGL context", () => {
+  it("setVisible(false) holds the WebGL context for the dwell window, then releases", () => {
     const managed = makeMockManaged();
     service.instances.set("t1", managed as unknown as Record<string, unknown>);
     service.webGLManager.ensureContext("t1", managed);
@@ -172,8 +173,28 @@ describe("TerminalInstanceService - visibility-driven WebGL lease", () => {
 
     service.setVisible("t1", false);
 
-    // No timer advance — release happens synchronously on the hide path
+    // Within the dwell window — context still held.
+    vi.advanceTimersByTime(499);
+    expect(service.webGLManager.isActive("t1")).toBe(true);
+
+    // Dwell elapses — context released.
+    vi.advanceTimersByTime(1);
     expect(service.webGLManager.isActive("t1")).toBe(false);
+  });
+
+  it("setVisible(true) within dwell window cancels the hide timer and keeps WebGL", () => {
+    const managed = makeMockManaged();
+    service.instances.set("t1", managed as unknown as Record<string, unknown>);
+    service.webGLManager.ensureContext("t1", managed);
+
+    service.setVisible("t1", false);
+    expect(service.webGLManager.isActive("t1")).toBe(true);
+
+    service.setVisible("t1", true);
+    vi.advanceTimersByTime(500);
+
+    // Hide timer was cancelled on show — context still held.
+    expect(service.webGLManager.isActive("t1")).toBe(true);
   });
 
   it("setVisible(false) does not call terminal.refresh after WebGL release", () => {
@@ -230,23 +251,24 @@ describe("TerminalInstanceService - visibility-driven WebGL lease", () => {
     expect(managed.terminal.refresh).not.toHaveBeenCalled();
   });
 
-  it("rapid hide→show→hide before debounce expires keeps context released", () => {
+  it("rapid hide→show→hide keeps context held through dwell, then releases", () => {
     const managed = makeMockManaged();
     service.instances.set("t1", managed as unknown as Record<string, unknown>);
     service.webGLManager.ensureContext("t1", managed);
 
     service.setVisible("t1", false);
-    expect(service.webGLManager.isActive("t1")).toBe(false);
+    // Hide dwell in flight — context still held.
+    expect(service.webGLManager.isActive("t1")).toBe(true);
 
     service.setVisible("t1", true);
-    // Within debounce — not yet restored
-    expect(service.webGLManager.isActive("t1")).toBe(false);
+    // Show cancels the hide timer — context never lost.
+    expect(service.webGLManager.isActive("t1")).toBe(true);
 
     service.setVisible("t1", false);
-    // Restore timer cancelled, still released
-    expect(service.webGLManager.isActive("t1")).toBe(false);
+    // Restore timer cancelled and a new hide dwell scheduled — still held.
+    expect(service.webGLManager.isActive("t1")).toBe(true);
 
-    vi.advanceTimersByTime(200);
+    vi.advanceTimersByTime(500);
     expect(service.webGLManager.isActive("t1")).toBe(false);
   });
 
@@ -321,10 +343,12 @@ describe("TerminalInstanceService - visibility-driven WebGL lease", () => {
 
     // Stale generation from a previous mount — should be ignored entirely
     service.setVisible("t1", false, 4);
+    vi.advanceTimersByTime(500);
     expect(service.webGLManager.isActive("t1")).toBe(true);
 
-    // Matching generation — release proceeds
+    // Matching generation — release proceeds (deferred by the dwell window).
     service.setVisible("t1", false, 5);
+    vi.advanceTimersByTime(500);
     expect(service.webGLManager.isActive("t1")).toBe(false);
   });
 
@@ -367,6 +391,42 @@ describe("TerminalInstanceService - visibility-driven WebGL lease", () => {
 
     expect(service.webGLManager.isActive("t1")).toBe(true);
     expect(managed.terminal.refresh).not.toHaveBeenCalled();
+  });
+
+  it("destroy cancels the pending WebGL hide-dwell timer", () => {
+    const managed = makeMockManaged();
+    service.instances.set("t1", managed as unknown as Record<string, unknown>);
+    service.webGLManager.ensureContext("t1", managed);
+
+    service.setVisible("t1", false);
+    expect(managed.webGLHideTimer).toBeDefined();
+
+    service.destroy("t1");
+
+    // Timer cleared (won't fire and won't crash after instances.delete)
+    vi.advanceTimersByTime(500);
+    expect(service.webGLManager.isActive("t1")).toBe(false);
+  });
+
+  it("tier demotion during hide-dwell cancels dwell and releases immediately", () => {
+    // Tier demotion is an authoritative signal — it should release the WebGL
+    // context immediately rather than waiting for the visibility hide-dwell.
+    const managed = makeMockManaged({
+      lastAppliedTier: TerminalRefreshTier.FOCUSED,
+      getRefreshTier: () => TerminalRefreshTier.BACKGROUND,
+    });
+    service.instances.set("t1", managed as unknown as Record<string, unknown>);
+    service.webGLManager.ensureContext("t1", managed);
+
+    service.setVisible("t1", false);
+    expect(service.webGLManager.isActive("t1")).toBe(true);
+
+    // Tier demotion fires — should release immediately, dwell cancelled.
+    service.applyRendererPolicy("t1", TerminalRefreshTier.BACKGROUND);
+    vi.advanceTimersByTime(500); // tier hysteresis
+
+    expect(service.webGLManager.isActive("t1")).toBe(false);
+    expect(managed.webGLHideTimer).toBeUndefined();
   });
 
   it("agent demotion during debounce window cancels WebGL restore", () => {

--- a/src/services/terminal/__tests__/TerminalInstanceService.webglVisibility.test.ts
+++ b/src/services/terminal/__tests__/TerminalInstanceService.webglVisibility.test.ts
@@ -408,9 +408,13 @@ describe("TerminalInstanceService - visibility-driven WebGL lease", () => {
     expect(service.webGLManager.isActive("t1")).toBe(false);
   });
 
-  it("tier demotion during hide-dwell cancels dwell and releases immediately", () => {
-    // Tier demotion is an authoritative signal — it should release the WebGL
-    // context immediately rather than waiting for the visibility hide-dwell.
+  it("tier demotion during hide-dwell releases WebGL and leaves no dangling timer", () => {
+    // Tier demotion is an authoritative signal — when it fires (via the
+    // TIER_DOWNGRADE_HYSTERESIS_MS=500 timer) the onTierApplied BACKGROUND
+    // branch calls cancelWebGLHideTimer + releaseContext. Both the hide-dwell
+    // (500ms) and the tier-hysteresis (500ms) timers are scheduled in the
+    // same tick, so the cancel here is the defensive guarantee that the dwell
+    // timer can't fire later on a stale pool slot.
     const managed = makeMockManaged({
       lastAppliedTier: TerminalRefreshTier.FOCUSED,
       getRefreshTier: () => TerminalRefreshTier.BACKGROUND,
@@ -420,10 +424,10 @@ describe("TerminalInstanceService - visibility-driven WebGL lease", () => {
 
     service.setVisible("t1", false);
     expect(service.webGLManager.isActive("t1")).toBe(true);
+    expect(managed.webGLHideTimer).toBeDefined();
 
-    // Tier demotion fires — should release immediately, dwell cancelled.
     service.applyRendererPolicy("t1", TerminalRefreshTier.BACKGROUND);
-    vi.advanceTimersByTime(500); // tier hysteresis
+    vi.advanceTimersByTime(500);
 
     expect(service.webGLManager.isActive("t1")).toBe(false);
     expect(managed.webGLHideTimer).toBeUndefined();

--- a/src/services/terminal/types.ts
+++ b/src/services/terminal/types.ts
@@ -145,10 +145,16 @@ export interface ManagedTerminal {
   hibernationTimer?: ReturnType<typeof setTimeout>;
   ipcListenerCount: number;
 
-  // Visibility-driven WebGL restore debounce. Hide path releases the WebGL
-  // context immediately; show path waits ~100ms before re-acquiring so rapid
-  // tab/panel toggles don't thrash addon load/unload.
+  // Visibility-driven WebGL restore debounce. Show path waits ~100ms before
+  // re-acquiring so rapid tab/panel toggles don't thrash addon load/unload.
   webGLRestoreTimer?: number;
+
+  // Visibility-driven WebGL release hysteresis. Hide path holds the context
+  // for ~500ms before releasing so rapid hide→show cycles (panel toggles,
+  // focus oscillation) don't churn the WebGL pool. Authoritative release
+  // paths (tier demotion, agent demotion, destroy, hibernation) cancel this
+  // timer and release immediately.
+  webGLHideTimer?: number;
 
   // Timestamp of the most recent successful reduceScrollback() — gates the
   // BACKGROUND-tier scrollback shrink path so rapid tab oscillation doesn't


### PR DESCRIPTION
## Summary

- Defers WebGL context release by 500ms when a terminal is hidden, preventing thrash on quick hide/show sequences and focus cycling across tiled panes
- Adds authoritative `cancelWebGLHideTimer` calls at every path that re-shows or promotes a terminal (`setVisible(true)`, `onTierApplied BACKGROUND`, `clearAgentPromotion`, `destroy`)
- Moves the hibernation manager cancel to fire after the active-agent early-return so the dwell handles release naturally when hibernation bails out

Resolves #8083

> **Merge dependency:** This PR has a hard gate on #8080. The `isWebGLEligibleTier` helper cannot be flipped to include `VISIBLE` until the atlas corruption root cause tracked in #8080 is resolved. The hysteresis implementation can be reviewed and merged independently; flipping the eligibility tier is a one-line follow-up once #8080 lands.

## Changes

- `shared/types` (`types.ts`): `webGLHideTimer` field on `ManagedTerminal`
- `TerminalInstanceService.ts`: `WEBGL_HIDE_DWELL_MS = 500` constant, `cancelWebGLHideTimer` helper, deferred release in `setVisible(false)`, authoritative cancels in `setVisible(true)` / `onTierApplied BACKGROUND` / `clearAgentPromotion` / `destroy`
- `TerminalHibernationManager.ts`: cancel moved to after the active-agent early-return so the dwell fires naturally on hibernation bail-out
- `TerminalInstanceService.webglVisibility.test.ts`: updated existing visibility/stale-generation tests for deferred release; added dwell, cancel-on-reshow, destroy-during-dwell, and tier-demotion-during-dwell coverage

## Testing

745 terminal-services unit tests pass. `npm run check` clean.