### PR TITLE
feat(terminal): add handoff actions to AgentCompletionBanner

### DIFF
--- a/src/components/Terminal/AgentCompletionBanner.tsx
+++ b/src/components/Terminal/AgentCompletionBanner.tsx
@@ -1,5 +1,5 @@
-import { FileEdit } from "lucide-react";
-import { InlineStatusBanner } from "./InlineStatusBanner";
+import { FileEdit, MessageSquare, Forward } from "lucide-react";
+import { InlineStatusBanner, type BannerAction } from "./InlineStatusBanner";
 
 export interface AgentCompletionBannerProps {
   /**
@@ -11,6 +11,14 @@ export interface AgentCompletionBannerProps {
   fileCount?: number;
   onReview: () => void;
   onDismiss: () => void;
+  /**
+   * Relay the completion into the active assistant session. Omitted (button
+   * hidden) when no assistant terminal exists or it's mid-stream — a missing
+   * guard would inject text into a working agent.
+   */
+  onSendToAssistant?: () => void;
+  /** Open the send-to-agent palette pre-populated with the agent's output. */
+  onSendToAgent?: () => void;
   className?: string;
 }
 
@@ -26,8 +34,42 @@ export function AgentCompletionBanner({
   fileCount,
   onReview,
   onDismiss,
+  onSendToAssistant,
+  onSendToAgent,
   className,
 }: AgentCompletionBannerProps) {
+  const actions: BannerAction[] = [
+    {
+      id: "review",
+      label: "Review",
+      variant: "primary",
+      onClick: onReview,
+    },
+  ];
+
+  if (onSendToAssistant) {
+    actions.push({
+      id: "send-to-assistant",
+      label: "Send to assistant",
+      icon: MessageSquare,
+      variant: "dismiss",
+      onClick: onSendToAssistant,
+    });
+  }
+
+  if (onSendToAgent) {
+    actions.push({
+      id: "send-to-agent",
+      label: "Send to agent",
+      icon: Forward,
+      variant: "dismiss",
+      iconOnly: true,
+      ariaLabel: "Send to agent",
+      title: "Send to another agent…",
+      onClick: onSendToAgent,
+    });
+  }
+
   return (
     <InlineStatusBanner
       icon={FileEdit}
@@ -35,14 +77,7 @@ export function AgentCompletionBanner({
       severity="neutral"
       role="status"
       className={className ? `border-t border-divider ${className}` : "border-t border-divider"}
-      actions={[
-        {
-          id: "review",
-          label: "Review",
-          variant: "primary",
-          onClick: onReview,
-        },
-      ]}
+      actions={actions}
       onClose={onDismiss}
     />
   );

--- a/src/components/Terminal/TerminalPane.tsx
+++ b/src/components/Terminal/TerminalPane.tsx
@@ -57,6 +57,9 @@ import { useAgentSettingsStore } from "@/store/agentSettingsStore";
 import { useCcrPresetsStore } from "@/store/ccrPresetsStore";
 import { useProjectPresetsStore } from "@/store/projectPresetsStore";
 import { terminalClient } from "@/clients";
+import { useHelpPanelStore } from "@/store/helpPanelStore";
+import { openSendToAgentPaletteWithText } from "@/hooks/useSendToAgentPalette";
+import { formatWithBracketedPaste } from "@shared/utils/terminalInputProtocol";
 import type { HybridInputBarHandle } from "./HybridInputBar";
 const LazyHybridInputBar = lazy(() =>
   import("./HybridInputBar").then((m) => ({ default: m.HybridInputBar }))
@@ -890,6 +893,45 @@ function TerminalPaneComponent({
     }
   };
 
+  // "Send to assistant" relays this agent's completion output into the active
+  // assistant session. It's only offered when the assistant terminal exists
+  // and is idle/waiting — writing into a working or directing agent would
+  // corrupt its input mid-stream.
+  const helpTerminalId = useHelpPanelStore((s) => s.terminalId);
+  const helpAgentState = usePanelStore((s) =>
+    helpTerminalId ? s.panelsById[helpTerminalId]?.agentState : undefined
+  );
+  const assistantAvailable =
+    !!helpTerminalId &&
+    helpTerminalId !== id &&
+    (helpAgentState === "idle" || helpAgentState === "waiting");
+
+  const handleSendToAssistant = useCallback(() => {
+    const help = useHelpPanelStore.getState();
+    const helpTid = help.terminalId;
+    if (!helpTid || helpTid === id) return;
+    const state = terminalInstanceService.getAgentState(helpTid);
+    if (state !== "idle" && state !== "waiting") return;
+    const text = terminalInstanceService.captureBufferText(id, 20000);
+    if (!text) return;
+
+    const managed = terminalInstanceService.get(helpTid);
+    if (managed && !managed.terminal.modes.bracketedPasteMode) {
+      terminalClient.write(helpTid, text.replace(/\r?\n/g, "\r"));
+    } else {
+      terminalClient.write(helpTid, formatWithBracketedPaste(text));
+    }
+    terminalInstanceService.notifyUserInput(helpTid);
+    help.setOpen(true);
+    help.requestFocus();
+  }, [id]);
+
+  const handleSendToAgent = useCallback(() => {
+    const text = terminalInstanceService.captureBufferText(id, 20000);
+    if (!text) return;
+    openSendToAgentPaletteWithText(text, id);
+  }, [id]);
+
   const isWorking = agentState === "working";
   const allowPing = !isMaximized && (location !== "grid" || (gridPanelCount ?? 2) > 1);
 
@@ -1158,6 +1200,8 @@ function TerminalPaneComponent({
                 fileCount={changedFileCount}
                 onReview={handleOpenReviewHub}
                 onDismiss={() => setCompletionBannerDismissed(true)}
+                onSendToAssistant={assistantAvailable ? handleSendToAssistant : undefined}
+                onSendToAgent={handleSendToAgent}
               />
             )}
 

--- a/src/components/Terminal/TerminalPane.tsx
+++ b/src/components/Terminal/TerminalPane.tsx
@@ -60,6 +60,7 @@ import { terminalClient } from "@/clients";
 import { useHelpPanelStore } from "@/store/helpPanelStore";
 import { openSendToAgentPaletteWithText } from "@/hooks/useSendToAgentPalette";
 import { formatWithBracketedPaste } from "@shared/utils/terminalInputProtocol";
+import { panelKindHasPty } from "@shared/config/panelKindRegistry";
 import type { HybridInputBarHandle } from "./HybridInputBar";
 const LazyHybridInputBar = lazy(() =>
   import("./HybridInputBar").then((m) => ({ default: m.HybridInputBar }))
@@ -901,10 +902,30 @@ function TerminalPaneComponent({
   const helpAgentState = usePanelStore((s) =>
     helpTerminalId ? s.panelsById[helpTerminalId]?.agentState : undefined
   );
+  const helpInputLocked = usePanelStore((s) =>
+    helpTerminalId ? s.panelsById[helpTerminalId]?.isInputLocked === true : false
+  );
   const assistantAvailable =
     !!helpTerminalId &&
     helpTerminalId !== id &&
+    !helpInputLocked &&
     (helpAgentState === "idle" || helpAgentState === "waiting");
+
+  // The "Send to agent" palette has nothing to offer when this is the only
+  // eligible PTY pane — hide it rather than render a button that no-ops.
+  const hasAgentTargets = usePanelStore((s) =>
+    s.panelIds.some((tid) => {
+      const t = s.panelsById[tid];
+      return (
+        !!t &&
+        t.id !== id &&
+        t.location !== "trash" &&
+        t.location !== "background" &&
+        (t.kind ? panelKindHasPty(t.kind) : true) &&
+        t.hasPty !== false
+      );
+    })
+  );
 
   const handleSendToAssistant = useCallback(() => {
     const help = useHelpPanelStore.getState();
@@ -912,6 +933,7 @@ function TerminalPaneComponent({
     if (!helpTid || helpTid === id) return;
     const state = terminalInstanceService.getAgentState(helpTid);
     if (state !== "idle" && state !== "waiting") return;
+    if (usePanelStore.getState().panelsById[helpTid]?.isInputLocked === true) return;
     const text = terminalInstanceService.captureBufferText(id, 20000);
     if (!text) return;
 
@@ -1201,7 +1223,7 @@ function TerminalPaneComponent({
                 onReview={handleOpenReviewHub}
                 onDismiss={() => setCompletionBannerDismissed(true)}
                 onSendToAssistant={assistantAvailable ? handleSendToAssistant : undefined}
-                onSendToAgent={handleSendToAgent}
+                onSendToAgent={hasAgentTargets ? handleSendToAgent : undefined}
               />
             )}
 

--- a/src/components/Terminal/__tests__/AgentCompletionBanner.test.tsx
+++ b/src/components/Terminal/__tests__/AgentCompletionBanner.test.tsx
@@ -1,7 +1,19 @@
 // @vitest-environment jsdom
 import { beforeAll, describe, it, expect, vi } from "vitest";
-import { render, screen, fireEvent } from "@testing-library/react";
+import { render as rtlRender, screen, fireEvent, type RenderOptions } from "@testing-library/react";
+import type { ReactElement, ReactNode } from "react";
+import { TooltipProvider } from "@/components/ui/tooltip";
 import { AgentCompletionBanner } from "../AgentCompletionBanner";
+
+// The icon-only "Send to agent" action wraps its button in a Radix Tooltip,
+// which requires a TooltipProvider ancestor (supplied app-wide in App.tsx).
+function Providers({ children }: { children: ReactNode }) {
+  return <TooltipProvider>{children}</TooltipProvider>;
+}
+
+function render(ui: ReactElement, options?: Omit<RenderOptions, "wrapper">) {
+  return rtlRender(ui, { wrapper: Providers, ...options });
+}
 
 vi.mock("@/lib/utils", () => ({
   cn: (...args: unknown[]) => {
@@ -66,6 +78,52 @@ describe("AgentCompletionBanner", () => {
     render(<AgentCompletionBanner onReview={() => {}} onDismiss={onDismiss} />);
     fireEvent.click(screen.getByRole("button", { name: /dismiss/i }));
     expect(onDismiss).toHaveBeenCalledTimes(1);
+  });
+
+  it("hides the handoff buttons when their callbacks are omitted", () => {
+    render(<AgentCompletionBanner onReview={() => {}} onDismiss={() => {}} />);
+    expect(screen.queryByRole("button", { name: /send to assistant/i })).toBeNull();
+    expect(screen.queryByRole("button", { name: /send to agent/i })).toBeNull();
+  });
+
+  it("renders and fires onSendToAssistant when provided", () => {
+    const onSendToAssistant = vi.fn();
+    render(
+      <AgentCompletionBanner
+        onReview={() => {}}
+        onDismiss={() => {}}
+        onSendToAssistant={onSendToAssistant}
+      />
+    );
+    fireEvent.click(screen.getByRole("button", { name: /send to assistant/i }));
+    expect(onSendToAssistant).toHaveBeenCalledTimes(1);
+  });
+
+  it("renders and fires onSendToAgent when provided", () => {
+    const onSendToAgent = vi.fn();
+    render(
+      <AgentCompletionBanner
+        onReview={() => {}}
+        onDismiss={() => {}}
+        onSendToAgent={onSendToAgent}
+      />
+    );
+    fireEvent.click(screen.getByRole("button", { name: /send to agent/i }));
+    expect(onSendToAgent).toHaveBeenCalledTimes(1);
+  });
+
+  it("renders all three action buttons when both handoff callbacks are provided", () => {
+    render(
+      <AgentCompletionBanner
+        onReview={() => {}}
+        onDismiss={() => {}}
+        onSendToAssistant={() => {}}
+        onSendToAgent={() => {}}
+      />
+    );
+    expect(screen.getByRole("button", { name: /review/i })).toBeTruthy();
+    expect(screen.getByRole("button", { name: /send to assistant/i })).toBeTruthy();
+    expect(screen.getByRole("button", { name: /send to agent/i })).toBeTruthy();
   });
 
   it("stops click propagation on both buttons so the pane doesn't grab focus", () => {

--- a/src/components/Terminal/__tests__/AgentCompletionBanner.test.tsx
+++ b/src/components/Terminal/__tests__/AgentCompletionBanner.test.tsx
@@ -126,14 +126,20 @@ describe("AgentCompletionBanner", () => {
     expect(screen.getByRole("button", { name: /send to agent/i })).toBeTruthy();
   });
 
-  it("stops click propagation on both buttons so the pane doesn't grab focus", () => {
+  it("stops click propagation on all buttons (incl. handoff) so the pane doesn't grab focus", () => {
     const onParentClick = vi.fn();
     const { container } = render(
       <div onClick={onParentClick}>
-        <AgentCompletionBanner onReview={() => {}} onDismiss={() => {}} />
+        <AgentCompletionBanner
+          onReview={() => {}}
+          onDismiss={() => {}}
+          onSendToAssistant={() => {}}
+          onSendToAgent={() => {}}
+        />
       </div>
     );
     const buttons = container.querySelectorAll("button");
+    expect(buttons.length).toBe(4); // review + assistant + agent + dismiss
     buttons.forEach((b) => fireEvent.click(b));
     expect(onParentClick).not.toHaveBeenCalled();
   });

--- a/src/hooks/__tests__/useSendToAgentPalette.test.ts
+++ b/src/hooks/__tests__/useSendToAgentPalette.test.ts
@@ -51,6 +51,11 @@ describe("openSendToAgentPaletteWithText", () => {
     expect(openPalette).not.toHaveBeenCalled();
   });
 
+  it("returns false for whitespace-only text", () => {
+    expect(openSendToAgentPaletteWithText("   \n\t ", "a")).toBe(false);
+    expect(openPalette).not.toHaveBeenCalled();
+  });
+
   it("returns false when there are no eligible targets", () => {
     panelState = { panelIds: ["a"], panelsById: { a: { id: "a" } } };
     expect(openSendToAgentPaletteWithText("hello", "a")).toBe(false);

--- a/src/hooks/__tests__/useSendToAgentPalette.test.ts
+++ b/src/hooks/__tests__/useSendToAgentPalette.test.ts
@@ -1,0 +1,83 @@
+import { describe, it, expect, vi, beforeEach } from "vitest";
+
+const getCachedSelection = vi.fn<(id: string) => string>();
+const openPalette = vi.fn<(id: string) => void>();
+
+let panelState: {
+  panelIds: string[];
+  panelsById: Record<string, { id: string; location?: string; kind?: string; hasPty?: boolean }>;
+} = { panelIds: [], panelsById: {} };
+
+vi.mock("@/store", () => ({
+  usePanelStore: { getState: () => panelState },
+}));
+
+vi.mock("@/store/paletteStore", () => ({
+  usePaletteStore: { getState: () => ({ openPalette }) },
+}));
+
+vi.mock("@/services/TerminalInstanceService", () => ({
+  terminalInstanceService: {
+    getCachedSelection: (id: string) => getCachedSelection(id),
+    get: () => undefined,
+  },
+}));
+
+vi.mock("@/clients", () => ({ terminalClient: { write: vi.fn() } }));
+vi.mock("@shared/utils/terminalInputProtocol", () => ({
+  formatWithBracketedPaste: (t: string) => t,
+}));
+vi.mock("@shared/config/panelKindRegistry", () => ({ panelKindHasPty: () => true }));
+vi.mock("@/utils/terminalChrome", () => ({ deriveTerminalChrome: () => ({ label: "" }) }));
+vi.mock("./useSearchablePalette", () => ({ useSearchablePalette: () => ({}) }));
+
+import { openSendToAgentPalette, openSendToAgentPaletteWithText } from "../useSendToAgentPalette";
+
+beforeEach(() => {
+  getCachedSelection.mockReset();
+  openPalette.mockReset();
+  panelState = {
+    panelIds: ["a", "b"],
+    panelsById: {
+      a: { id: "a" },
+      b: { id: "b" },
+    },
+  };
+});
+
+describe("openSendToAgentPaletteWithText", () => {
+  it("returns false and does not open the palette for empty text", () => {
+    expect(openSendToAgentPaletteWithText("")).toBe(false);
+    expect(openPalette).not.toHaveBeenCalled();
+  });
+
+  it("returns false when there are no eligible targets", () => {
+    panelState = { panelIds: ["a"], panelsById: { a: { id: "a" } } };
+    expect(openSendToAgentPaletteWithText("hello", "a")).toBe(false);
+    expect(openPalette).not.toHaveBeenCalled();
+  });
+
+  it("opens the send-to-agent palette with arbitrary text when targets exist", () => {
+    expect(openSendToAgentPaletteWithText("hello", "a")).toBe(true);
+    expect(openPalette).toHaveBeenCalledWith("send-to-agent");
+  });
+
+  it("does not require a cached terminal selection", () => {
+    getCachedSelection.mockReturnValue("");
+    expect(openSendToAgentPaletteWithText("from-banner")).toBe(true);
+    expect(getCachedSelection).not.toHaveBeenCalled();
+    expect(openPalette).toHaveBeenCalledWith("send-to-agent");
+  });
+});
+
+describe("openSendToAgentPalette (regression)", () => {
+  it("still gates on the cached selection", () => {
+    getCachedSelection.mockReturnValue("");
+    expect(openSendToAgentPalette("a")).toBe(false);
+    expect(openPalette).not.toHaveBeenCalled();
+
+    getCachedSelection.mockReturnValue("selected text");
+    expect(openSendToAgentPalette("a")).toBe(true);
+    expect(openPalette).toHaveBeenCalledWith("send-to-agent");
+  });
+});

--- a/src/hooks/useSendToAgentPalette.ts
+++ b/src/hooks/useSendToAgentPalette.ts
@@ -55,7 +55,7 @@ export function openSendToAgentPalette(sourceTerminalId: string): boolean {
  * own output back to itself.
  */
 export function openSendToAgentPaletteWithText(text: string, sourceTerminalId?: string): boolean {
-  if (!text) return false;
+  if (!text.trim()) return false;
   const sourceId = sourceTerminalId ?? null;
   if (!hasSendTargets(sourceId)) return false;
 

--- a/src/hooks/useSendToAgentPalette.ts
+++ b/src/hooks/useSendToAgentPalette.ts
@@ -21,12 +21,9 @@ export interface SendToAgentItem {
 // Module-level state for the opener function (object to avoid react-compiler reassignment warning)
 const pendingState = { sourceId: null as string | null, selection: "" };
 
-export function openSendToAgentPalette(sourceTerminalId: string): boolean {
-  const selection = terminalInstanceService.getCachedSelection(sourceTerminalId);
-  if (!selection) return false;
-
+function hasSendTargets(sourceTerminalId: string | null): boolean {
   const { panelsById, panelIds } = usePanelStore.getState();
-  const hasTargets = panelIds.some((id) => {
+  return panelIds.some((id) => {
     const t = panelsById[id];
     return (
       t &&
@@ -37,10 +34,33 @@ export function openSendToAgentPalette(sourceTerminalId: string): boolean {
       t.hasPty !== false
     );
   });
-  if (!hasTargets) return false;
+}
+
+export function openSendToAgentPalette(sourceTerminalId: string): boolean {
+  const selection = terminalInstanceService.getCachedSelection(sourceTerminalId);
+  if (!selection) return false;
+  if (!hasSendTargets(sourceTerminalId)) return false;
 
   pendingState.sourceId = sourceTerminalId;
   pendingState.selection = selection;
+  usePaletteStore.getState().openPalette("send-to-agent");
+  return true;
+}
+
+/**
+ * Opens the send-to-agent palette pre-populated with arbitrary text instead of
+ * a cached terminal selection. Used by handoff surfaces (e.g. the agent
+ * completion banner) that already have the text to relay. `sourceTerminalId`,
+ * when provided, is excluded from the target list so an agent doesn't send its
+ * own output back to itself.
+ */
+export function openSendToAgentPaletteWithText(text: string, sourceTerminalId?: string): boolean {
+  if (!text) return false;
+  const sourceId = sourceTerminalId ?? null;
+  if (!hasSendTargets(sourceId)) return false;
+
+  pendingState.sourceId = sourceId;
+  pendingState.selection = text;
   usePaletteStore.getState().openPalette("send-to-agent");
   return true;
 }


### PR DESCRIPTION
## Summary

- Adds two handoff buttons to `AgentCompletionBanner` so output from a completing agent can be routed to another session without copy-pasting
- Extracts `openSendToAgentPaletteWithText(text, sourceId?)` from `useSendToAgentPalette` so arbitrary text can seed the palette without relying on a cached selection or adding a new IPC surface
- Buttons are scoped to `completedWithChanges` state only; eligibility is reactive with a click-time recheck

Resolves #8087

## Changes

- **Send to assistant** -- injects the completing agent's last 20k chars of output into the active help terminal. Reactively gated on the help terminal existing, not being the source, being idle/waiting, and not input-locked. Click-time recheck guards against stale state.
- **Send to agent** (icon-only) -- opens `SendToAgentPalette` pre-populated with the same output. Hidden when no eligible PTY target exists.
- `openSendToAgentPaletteWithText` extracted from `useSendToAgentPalette` as a reusable export; existing callers unchanged.
- Handoff button eligibility logic lives in `TerminalPane` and flows down as props so the banner stays presentation-only.

## Testing

- 18 unit tests covering eligibility gating, click-time rechecks, palette seeding, and the `openSendToAgentPaletteWithText` extraction
- Manual smoke: send-to-assistant fires correctly when help terminal is idle; button absent when help terminal is the source or input-locked; send-to-agent palette opens pre-populated