### PR TITLE
feat(empty-state): popover recovery, fade-through transitions, and user-cleared JSDoc

### DIFF
--- a/src/components/Diagnostics/LogsContent.tsx
+++ b/src/components/Diagnostics/LogsContent.tsx
@@ -283,9 +283,15 @@ export function LogsContent({ className, onSourcesChange }: LogsContentProps) {
           ) : (
             <div className="flex items-center justify-center h-full">
               {logs.length === 0 && !previousSessionEntry ? (
-                <EmptyState variant="zero-data" scale="sidebar" title="No logs yet" />
+                <EmptyState
+                  key="zero-data"
+                  variant="zero-data"
+                  scale="sidebar"
+                  title="No logs yet"
+                />
               ) : (
                 <EmptyState
+                  key="user-cleared"
                   variant="user-cleared"
                   scale="sidebar"
                   title="No new logs this session"

--- a/src/components/Sidebar/SidebarContent.tsx
+++ b/src/components/Sidebar/SidebarContent.tsx
@@ -1035,6 +1035,7 @@ function SidebarContent({ onOpenOverview }: SidebarContentProps) {
                 <EmptyState
                   variant="filtered-empty"
                   scale="sidebar"
+                  instant
                   title={
                     hasFacetFiltersActive && activeFacetFilterCount > 0
                       ? `No worktrees match ${QUICK_STATE_LABELS[quickStateFilter]} with ${activeFacetFilterCount} ${
@@ -1058,6 +1059,7 @@ function SidebarContent({ onOpenOverview }: SidebarContentProps) {
                 <EmptyState
                   variant="filtered-empty"
                   scale="sidebar"
+                  instant
                   title={
                     hasQuery
                       ? `No matches for "${truncateSearchQuery(query.trim())}"`

--- a/src/components/Worktree/IssuePickerDialog.tsx
+++ b/src/components/Worktree/IssuePickerDialog.tsx
@@ -240,6 +240,15 @@ export function IssuePickerDialog({
               variant="filtered-empty"
               scale="popover"
               title={`No matches for "${search.trim()}"`}
+              action={
+                <button
+                  type="button"
+                  onClick={() => setSearch("")}
+                  className="text-xs px-3 py-1.5 text-daintree-text/60 hover:text-daintree-text hover:bg-overlay-soft rounded transition-colors"
+                >
+                  Clear search
+                </button>
+              }
             />
           ) : (
             <EmptyState variant="zero-data" scale="popover" title="No issues found" />

--- a/src/components/Worktree/views/BaseBranchCombobox.tsx
+++ b/src/components/Worktree/views/BaseBranchCombobox.tsx
@@ -127,6 +127,15 @@ export function BaseBranchCombobox({
                   variant="filtered-empty"
                   scale="popover"
                   title={`No matches for "${branchQuery.trim()}"`}
+                  action={
+                    <button
+                      type="button"
+                      onClick={() => onQueryChange("")}
+                      className="text-xs px-3 py-1.5 text-daintree-text/60 hover:text-daintree-text hover:bg-overlay-soft rounded transition-colors"
+                    >
+                      Clear search
+                    </button>
+                  }
                 />
               ) : (
                 <EmptyState variant="zero-data" scale="popover" title="No branches available" />

--- a/src/components/Worktree/views/ExistingBranchPicker.tsx
+++ b/src/components/Worktree/views/ExistingBranchPicker.tsx
@@ -76,6 +76,15 @@ export function ExistingBranchPicker({
                   variant="filtered-empty"
                   scale="popover"
                   title={`No matches for "${query.trim()}"`}
+                  action={
+                    <button
+                      type="button"
+                      onClick={() => onQueryChange("")}
+                      className="text-xs px-3 py-1.5 text-daintree-text/60 hover:text-daintree-text hover:bg-overlay-soft rounded transition-colors"
+                    >
+                      Clear search
+                    </button>
+                  }
                 />
               ) : (
                 <EmptyState

--- a/src/components/ui/EmptyState.tsx
+++ b/src/components/ui/EmptyState.tsx
@@ -1,4 +1,4 @@
-import { useId, type ReactNode } from "react";
+import { useEffect, useId, useRef, useState, type ReactNode } from "react";
 import { cn } from "@/lib/utils";
 
 type EmptyStateCommonProps = {
@@ -15,6 +15,7 @@ export type EmptyStateProps =
       icon?: ReactNode;
       description?: never;
       action?: ReactNode;
+      instant?: boolean;
     })
   | (EmptyStateCommonProps & {
       variant: "zero-data";
@@ -22,40 +23,139 @@ export type EmptyStateProps =
       icon?: ReactNode;
       description?: ReactNode;
       action?: ReactNode;
+      instant?: boolean;
     })
   | (EmptyStateCommonProps & {
       variant: "filtered-empty";
       scale: "popover" | "sidebar";
       description?: never;
       action?: ReactNode;
+      instant?: boolean;
     })
   | (EmptyStateCommonProps & {
       variant: "filtered-empty";
       scale: "canvas";
       description?: ReactNode;
       action?: ReactNode;
+      instant?: boolean;
     })
+  /**
+   * Completed-result "Blank Slate" — the user intentionally reached this state
+   * (cleared queue, inbox zero, dismissed all notifications). Atlassian's
+   * distinction: a Blank Slate celebrates a finished task and stays quiet,
+   * while an Empty State invites action. Recovery for completed-result states
+   * lives in global undo surfaces (snackbar, Trash) — adding a per-instance
+   * recovery action implies the user made a mistake and creates cognitive
+   * friction. The title alone conveys completion (canonical example:
+   * NotificationCenter "You're all caught up"), so `description` and `action`
+   * are forbidden by design. `instant` is irrelevant: completed-result states
+   * are reached deliberately, not by rapid keystroke flips.
+   */
   | (EmptyStateCommonProps & {
       variant: "user-cleared";
       scale: "popover" | "sidebar" | "canvas";
       icon?: ReactNode;
       description?: never;
       action?: never;
+      instant?: never;
     });
 
+const EXIT_SAFETY_MS = 250;
+
+function renderInner(
+  props: EmptyStateProps,
+  descriptionId: string,
+  hasDescription: boolean,
+  rawDescription: ReactNode
+) {
+  const icon = props.variant === "filtered-empty" ? null : props.icon;
+  const action = props.variant === "user-cleared" ? null : props.action;
+  return (
+    <>
+      {icon ? (
+        <div
+          className="text-daintree-text/30 [&_svg]:h-6 [&_svg]:w-6 @max-[280px]/empty-state:[&_svg]:h-4 @max-[280px]/empty-state:[&_svg]:w-4"
+          aria-hidden="true"
+        >
+          {icon}
+        </div>
+      ) : null}
+      <p className="text-sm font-medium text-daintree-text/70">{props.title}</p>
+      {hasDescription ? (
+        <p id={descriptionId} className="text-xs text-daintree-text/50 max-w-xs">
+          {rawDescription}
+        </p>
+      ) : null}
+      {action ? <div className="mt-2">{action}</div> : null}
+    </>
+  );
+}
+
+function getRawDescription(props: EmptyStateProps): ReactNode {
+  if (props.variant === "user-cleared") return undefined;
+  return "description" in props ? props.description : undefined;
+}
+
+function getTransitionKey(props: EmptyStateProps): string {
+  const desc = getRawDescription(props);
+  const descKey = desc === undefined || desc === null || desc === false ? "" : String(desc);
+  return `${props.variant}|${props.scale}|${props.title}|${descKey}`;
+}
+
 export function EmptyState(props: EmptyStateProps) {
-  const { variant, title, className } = props;
-  const rawDescription =
-    variant === "user-cleared" ? undefined : "description" in props ? props.description : undefined;
+  const { className } = props;
+  const instant = "instant" in props ? props.instant === true : false;
+
   const descriptionId = useId();
+  const rawDescription = getRawDescription(props);
   const hasDescription =
     rawDescription !== undefined &&
     rawDescription !== null &&
     rawDescription !== false &&
     rawDescription !== "";
 
-  const icon = variant === "filtered-empty" ? null : props.icon;
-  const action = variant === "user-cleared" ? null : props.action;
+  // Fade Through state machine — follows AnimatedLabel: a generation counter
+  // remounts the cells on every change so rapid flips restart the animation
+  // even when a new transition arrives inside the previous one's window.
+  const transitionKey = getTransitionKey(props);
+  const prevKeyRef = useRef(transitionKey);
+  const prevPropsRef = useRef<EmptyStateProps>(props);
+  const [generation, setGeneration] = useState(0);
+  const [outgoing, setOutgoing] = useState<EmptyStateProps | null>(null);
+
+  useEffect(() => {
+    if (prevKeyRef.current === transitionKey) {
+      prevPropsRef.current = props;
+      return;
+    }
+    if (!instant) {
+      setOutgoing(prevPropsRef.current);
+      setGeneration((g) => g + 1);
+    } else {
+      setOutgoing(null);
+    }
+    prevKeyRef.current = transitionKey;
+    prevPropsRef.current = props;
+  }, [transitionKey, instant, props]);
+
+  // Safety cleanup — under reduced-motion / performance-mode the CSS animation
+  // is suppressed entirely, so `animationend` never fires from the outgoing
+  // cell. Without this timeout the previous content latches in the DOM.
+  useEffect(() => {
+    if (outgoing === null) return;
+    const timer = setTimeout(() => setOutgoing(null), EXIT_SAFETY_MS);
+    return () => clearTimeout(timer);
+  }, [outgoing, generation]);
+
+  const isAnimating = outgoing !== null;
+  const handleExitEnd = () => setOutgoing(null);
+
+  const outgoingDescription = outgoing ? getRawDescription(outgoing) : undefined;
+  const outgoingHasDescription =
+    outgoingDescription !== undefined &&
+    outgoingDescription !== null &&
+    outgoingDescription !== false &&
+    outgoingDescription !== "";
 
   return (
     <div
@@ -67,22 +167,28 @@ export function EmptyState(props: EmptyStateProps) {
         className
       )}
     >
-      <div className="motion-safe:animate-in motion-safe:fade-in motion-safe:duration-150 flex flex-col items-center gap-2">
-        {icon ? (
+      <div className="grid">
+        <div
+          key={`current-${generation}`}
+          className="[grid-area:1/1] flex flex-col items-center gap-2 motion-safe:animate-in motion-safe:fade-in motion-safe:duration-150"
+        >
+          {renderInner(props, descriptionId, hasDescription, rawDescription)}
+        </div>
+        {isAnimating && outgoing ? (
           <div
-            className="text-daintree-text/30 [&_svg]:h-6 [&_svg]:w-6 @max-[280px]/empty-state:[&_svg]:h-4 @max-[280px]/empty-state:[&_svg]:w-4"
+            key={`prev-${generation}`}
             aria-hidden="true"
+            className="[grid-area:1/1] flex flex-col items-center gap-2 pointer-events-none motion-safe:animate-out motion-safe:fade-out motion-safe:duration-[100ms]"
+            onAnimationEnd={handleExitEnd}
           >
-            {icon}
+            {renderInner(
+              outgoing,
+              `${descriptionId}-out`,
+              outgoingHasDescription,
+              outgoingDescription
+            )}
           </div>
         ) : null}
-        <p className="text-sm font-medium text-daintree-text/70">{title}</p>
-        {hasDescription ? (
-          <p id={descriptionId} className="text-xs text-daintree-text/50 max-w-xs">
-            {rawDescription}
-          </p>
-        ) : null}
-        {action ? <div className="mt-2">{action}</div> : null}
       </div>
     </div>
   );

--- a/src/components/ui/EmptyState.tsx
+++ b/src/components/ui/EmptyState.tsx
@@ -98,7 +98,17 @@ function getRawDescription(props: EmptyStateProps): ReactNode {
 
 function getTransitionKey(props: EmptyStateProps): string {
   const desc = getRawDescription(props);
-  const descKey = desc === undefined || desc === null || desc === false ? "" : String(desc);
+  // Stringify only string/number descriptions for the key; JSX descriptions
+  // serialize to "[object Object]" which would collapse distinct nodes into
+  // the same key. For JSX descriptions, fall back to a sentinel — the
+  // transition will fire on any other prop change (title, variant, scale)
+  // and JSX-description-only swaps are an edge case at canvas scale.
+  let descKey = "";
+  if (typeof desc === "string" || typeof desc === "number") {
+    descKey = String(desc);
+  } else if (desc !== undefined && desc !== null && desc !== false) {
+    descKey = "[node]";
+  }
   return `${props.variant}|${props.scale}|${props.title}|${descKey}`;
 }
 
@@ -178,6 +188,11 @@ export function EmptyState(props: EmptyStateProps) {
           <div
             key={`prev-${generation}`}
             aria-hidden="true"
+            // `inert` removes the outgoing subtree from the tab order *and*
+            // the accessibility tree so the stale `action` button (e.g.,
+            // "Clear search") can't take focus during the 100–250ms exit.
+            // `aria-hidden` alone leaves it focusable via keyboard.
+            inert
             className="[grid-area:1/1] flex flex-col items-center gap-2 pointer-events-none motion-safe:animate-out motion-safe:fade-out motion-safe:duration-[100ms]"
             onAnimationEnd={handleExitEnd}
           >

--- a/src/components/ui/__tests__/EmptyState.test.tsx
+++ b/src/components/ui/__tests__/EmptyState.test.tsx
@@ -1,6 +1,6 @@
 // @vitest-environment jsdom
-import { render, screen } from "@testing-library/react";
-import { describe, expect, it, vi } from "vitest";
+import { act, render, screen } from "@testing-library/react";
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
 
 vi.mock("@/lib/utils", () => ({
   cn: (...args: unknown[]) => args.filter(Boolean).join(" "),
@@ -288,7 +288,7 @@ describe("EmptyState", () => {
   });
 
   describe("animation", () => {
-    it("applies motion-safe entry animation classes on inner content", () => {
+    it("applies motion-safe entry animation classes on the current cell", () => {
       const { container } = render(
         <EmptyState variant="zero-data" scale="canvas" title="No items" />
       );
@@ -303,6 +303,150 @@ describe("EmptyState", () => {
         <EmptyState variant="zero-data" scale="canvas" title="No items" />
       );
       expect(container.innerHTML).not.toContain("transition-all");
+    });
+  });
+
+  describe("fade-through transition", () => {
+    beforeEach(() => {
+      vi.useFakeTimers({ toFake: ["setTimeout", "clearTimeout"] });
+    });
+    afterEach(() => {
+      vi.useRealTimers();
+    });
+
+    it("renders only the current cell on initial mount", () => {
+      const { container } = render(
+        <EmptyState variant="filtered-empty" scale="sidebar" title='No matches for "fo"' />
+      );
+      // No outgoing cell — only the current title is rendered.
+      expect(screen.getByText('No matches for "fo"')).toBeTruthy();
+      expect(container.querySelectorAll(".motion-safe\\:animate-out").length).toBe(0);
+    });
+
+    it("renders both outgoing and incoming cells during a variant flip", () => {
+      const { rerender, container } = render(
+        <EmptyState variant="filtered-empty" scale="sidebar" title='No matches for "fo"' />
+      );
+      rerender(
+        <EmptyState variant="filtered-empty" scale="sidebar" title='No matches for "foo"' />
+      );
+      // Outgoing cell mounted with the previous title.
+      expect(screen.getByText('No matches for "fo"')).toBeTruthy();
+      // Incoming cell mounted with the new title.
+      expect(screen.getByText('No matches for "foo"')).toBeTruthy();
+      // Exit-animation class is on the outgoing cell.
+      expect(container.querySelectorAll(".motion-safe\\:animate-out").length).toBe(1);
+    });
+
+    it("wires onAnimationEnd on the outgoing cell to drive cleanup", () => {
+      // The keyframe animationend event is the primary cleanup path. We can't
+      // reliably trigger React's `onAnimationEnd` from jsdom (it doesn't route
+      // synthetic AnimationEvents through React's event delegation), so we
+      // verify the handler is bound; the safety-timeout test below covers the
+      // fallback path that runs under reduced-motion / performance-mode where
+      // the keyframe is suppressed and animationend never fires.
+      const { rerender, container } = render(
+        <EmptyState variant="filtered-empty" scale="sidebar" title='No matches for "fo"' />
+      );
+      rerender(
+        <EmptyState variant="filtered-empty" scale="sidebar" title='No matches for "foo"' />
+      );
+      const outgoing = container.querySelector(".motion-safe\\:animate-out");
+      expect(outgoing).toBeTruthy();
+      // React stores props on the fiber, not the DOM, so we can't introspect
+      // `onAnimationEnd` directly. Instead, assert the structural contract:
+      // outgoing cell carries the exit-animation class and is mounted in
+      // the same grid cell as the incoming cell.
+      expect(outgoing?.className).toContain("[grid-area:1/1]");
+      const incoming = container.querySelector(".motion-safe\\:animate-in");
+      expect(incoming?.className).toContain("[grid-area:1/1]");
+    });
+
+    it("safety-timeout clears outgoing cell when animationend never fires", () => {
+      const { rerender, container } = render(
+        <EmptyState variant="filtered-empty" scale="sidebar" title='No matches for "fo"' />
+      );
+      rerender(
+        <EmptyState variant="filtered-empty" scale="sidebar" title='No matches for "foo"' />
+      );
+      expect(container.querySelectorAll(".motion-safe\\:animate-out").length).toBe(1);
+      act(() => {
+        vi.advanceTimersByTime(260);
+      });
+      expect(container.querySelectorAll(".motion-safe\\:animate-out").length).toBe(0);
+      expect(screen.queryByText('No matches for "fo"')).toBeNull();
+    });
+
+    it("restarts the animation when a new flip arrives mid-transition", () => {
+      const { rerender, container } = render(
+        <EmptyState variant="filtered-empty" scale="sidebar" title='No matches for "fo"' />
+      );
+      rerender(
+        <EmptyState variant="filtered-empty" scale="sidebar" title='No matches for "foo"' />
+      );
+      // Mid-exit, a new flip arrives — the outgoing cell should now show "foo",
+      // and the incoming should show "fooz".
+      rerender(
+        <EmptyState variant="filtered-empty" scale="sidebar" title='No matches for "fooz"' />
+      );
+      expect(screen.getByText('No matches for "foo"')).toBeTruthy();
+      expect(screen.getByText('No matches for "fooz"')).toBeTruthy();
+      expect(screen.queryByText('No matches for "fo"')).toBeNull();
+      expect(container.querySelectorAll(".motion-safe\\:animate-out").length).toBe(1);
+    });
+
+    it("marks the outgoing cell as aria-hidden", () => {
+      const { rerender, container } = render(
+        <EmptyState variant="filtered-empty" scale="sidebar" title='No matches for "fo"' />
+      );
+      rerender(
+        <EmptyState variant="filtered-empty" scale="sidebar" title='No matches for "foo"' />
+      );
+      const outgoing = container.querySelector(".motion-safe\\:animate-out");
+      expect(outgoing?.getAttribute("aria-hidden")).toBe("true");
+    });
+  });
+
+  describe("instant prop", () => {
+    beforeEach(() => {
+      vi.useFakeTimers({ toFake: ["setTimeout", "clearTimeout"] });
+    });
+    afterEach(() => {
+      vi.useRealTimers();
+    });
+
+    it("suppresses the outgoing cell during a flip", () => {
+      const { rerender, container } = render(
+        <EmptyState variant="filtered-empty" scale="sidebar" title='No matches for "fo"' instant />
+      );
+      rerender(
+        <EmptyState variant="filtered-empty" scale="sidebar" title='No matches for "foo"' instant />
+      );
+      expect(container.querySelectorAll(".motion-safe\\:animate-out").length).toBe(0);
+      expect(screen.queryByText('No matches for "fo"')).toBeNull();
+      expect(screen.getByText('No matches for "foo"')).toBeTruthy();
+    });
+  });
+
+  describe("instant prop (compile-time enforcement)", () => {
+    it("rejects instant on user-cleared", () => {
+      const element = (
+        // @ts-expect-error user-cleared never carries instant
+        <EmptyState variant="user-cleared" scale="canvas" title="You're all caught up" instant />
+      );
+      expect(element).toBeTruthy();
+    });
+
+    it("accepts instant on filtered-empty", () => {
+      const element = (
+        <EmptyState variant="filtered-empty" scale="sidebar" title="No matches" instant />
+      );
+      expect(element).toBeTruthy();
+    });
+
+    it("accepts instant on zero-data", () => {
+      const element = <EmptyState variant="zero-data" scale="canvas" title="No items" instant />;
+      expect(element).toBeTruthy();
     });
   });
 

--- a/src/components/ui/__tests__/EmptyState.test.tsx
+++ b/src/components/ui/__tests__/EmptyState.test.tsx
@@ -405,6 +405,31 @@ describe("EmptyState", () => {
       const outgoing = container.querySelector(".motion-safe\\:animate-out");
       expect(outgoing?.getAttribute("aria-hidden")).toBe("true");
     });
+
+    it("marks the outgoing cell as inert so stale actions can't take focus", () => {
+      // Regression guard: an `aria-hidden` cell still keeps its descendants
+      // in the tab order. `inert` removes both. The stale `action` button in
+      // an outgoing filtered-empty cell (e.g. "Clear search") would otherwise
+      // be focusable for up to 250ms during the exit animation.
+      const { rerender, container } = render(
+        <EmptyState
+          variant="filtered-empty"
+          scale="popover"
+          title='No matches for "fo"'
+          action={<button data-testid="stale-action">Clear search</button>}
+        />
+      );
+      rerender(
+        <EmptyState
+          variant="filtered-empty"
+          scale="popover"
+          title='No matches for "foo"'
+          action={<button data-testid="fresh-action">Clear search</button>}
+        />
+      );
+      const outgoing = container.querySelector(".motion-safe\\:animate-out");
+      expect(outgoing?.hasAttribute("inert")).toBe(true);
+    });
   });
 
   describe("instant prop", () => {


### PR DESCRIPTION
## Summary

- Adds inline "Clear search" recovery actions to three popover-scale filtered-empty call sites (`BaseBranchCombobox`, `ExistingBranchPicker`, `IssuePickerDialog`) that were showing `No matches for "X"` with nothing to click
- Cross-fades `EmptyState` transitions via the AnimatedLabel pattern — generation counter, overlapping grid cells, 100ms exit / 150ms entry — so state flips in pickers and palettes read as deliberate rather than hard cuts
- New `instant` prop suppresses the cross-fade on rapid-flip surfaces (sidebar quick-state filter, text-search inputs); forbidden on `user-cleared` at the type level so the silent-result variant can never accidentally animate in

Resolves #8095

## Changes

- `EmptyState.tsx` — generation counter + grid-cell overlap cross-fade; `instant` prop with type-level guard on `user-cleared`; `inert` on outgoing cell so stale interactive descendants (e.g. "Clear search") can't receive keyboard focus during the exit window; JSDoc on `user-cleared` explaining the Atlassian Blank Slate rationale for forbidding `description` and `action`
- `SidebarContent.tsx` — passes `instant` on the quick-state filtered-empty
- `BaseBranchCombobox.tsx`, `ExistingBranchPicker.tsx`, `IssuePickerDialog.tsx` — each gets a "Clear search" action wired to reset the query

## Testing

- Sidebar worktree filter: typing a non-matching query shows the empty state instantly (no fade), action button clears the filter
- `BaseBranchCombobox` / `ExistingBranchPicker` / `IssuePickerDialog`: search a missing term, "Clear search" appears, is keyboard-focusable, resets query on click
- `prefers-reduced-motion: reduce`: cross-fade suppressed, outgoing cell still unmounts after the safety timeout
- Tab through a popover mid-transition: stale "Clear search" button does not receive focus