### PR TITLE
feat(plugins): built-in plugin loader

### DIFF
--- a/electron-builder.config.cjs
+++ b/electron-builder.config.cjs
@@ -52,6 +52,7 @@ module.exports = async function () {
       { from: "help", to: "help" },
       { from: "electron/resources/sounds", to: "sounds" },
       { from: "electron/services/persistence/migrations", to: "migrations" },
+      { from: "plugins/builtin", to: "plugins/builtin" },
     ],
     // node-pty and better-sqlite3 contain native .node binaries that need
     // real filesystem access for `require()` — they cannot live inside the

--- a/electron/services/PluginService.ts
+++ b/electron/services/PluginService.ts
@@ -74,6 +74,14 @@ export class PluginService {
     activate: (client: WorkspaceClient) => void;
   }> = [];
   private initialized = false;
+  /**
+   * Plugin ids that are owned by a built-in plugin but currently disabled in
+   * Preferences. Held alongside `this.plugins` so the user-dir scan cannot
+   * register a third-party plugin under a trusted first-party namespace just
+   * because the matching built-in is turned off — the namespace stays claimed
+   * even when the activation is skipped.
+   */
+  private reservedBuiltinNames = new Set<string>();
   private pluginsRoot: string;
   /**
    * Optional override for the built-in plugins directory. When unset, the
@@ -146,13 +154,21 @@ export class PluginService {
     // Built-ins load first so user plugins with a colliding manifest.name are
     // rejected by the duplicate guard in loadPlugin() — built-in wins.
     const builtinDir = this.builtinPluginsRoot ?? this.getBuiltinDir();
-    const builtinLoaded = builtinDir ? await this.loadFromDir(builtinDir, { isBuiltin: true }) : 0;
-    const userLoaded = await this.loadFromDir(this.pluginsRoot, { isBuiltin: false });
-
-    this.initialized = true;
-    console.log(
-      `[PluginService] Loaded ${builtinLoaded} built-in plugin(s) from ${builtinDir ?? "<unresolved>"} and ${userLoaded} user plugin(s) from ${this.pluginsRoot}`
-    );
+    try {
+      const builtinLoaded = builtinDir
+        ? await this.loadFromDir(builtinDir, { isBuiltin: true })
+        : 0;
+      const userLoaded = await this.loadFromDir(this.pluginsRoot, { isBuiltin: false });
+      console.log(
+        `[PluginService] Loaded ${builtinLoaded} built-in plugin(s) from ${builtinDir ?? "<unresolved>"} and ${userLoaded} user plugin(s) from ${this.pluginsRoot}`
+      );
+    } finally {
+      // Idempotency must hold even when a scan throws (e.g. EACCES on the
+      // user dir): a retry would re-run the built-in scan and trigger
+      // "already registered, overwriting" warnings from the contribution
+      // registries.
+      this.initialized = true;
+    }
   }
 
   /**
@@ -262,13 +278,16 @@ export class PluginService {
 
     // Built-ins disabled in Preferences are skipped entirely — neither
     // registered in the plugins map nor activated. The disable persists in
-    // electron-store and takes effect on next launch.
+    // electron-store and takes effect on next launch. The name is reserved
+    // so a user plugin in the next scan cannot hijack a trusted first-party
+    // namespace just because its built-in is off.
     if (opts.isBuiltin && opts.disabled?.has(manifest.name)) {
       console.log(`[PluginService] Built-in plugin "${manifest.name}" is disabled, skipping`);
+      this.reservedBuiltinNames.add(manifest.name);
       return null;
     }
 
-    if (this.plugins.has(manifest.name)) {
+    if (this.plugins.has(manifest.name) || this.reservedBuiltinNames.has(manifest.name)) {
       console.error(
         `[PluginService] Duplicate plugin name "${manifest.name}" in ${dirName} — rejecting`
       );

--- a/electron/services/PluginService.ts
+++ b/electron/services/PluginService.ts
@@ -33,6 +33,7 @@ import { broadcastToRenderer } from "../ipc/utils.js";
 import { CHANNELS } from "../ipc/channels.js";
 import type { LoadedPluginInfo } from "../../shared/types/plugin.js";
 import type { PluginToolbarButtonId } from "../../shared/types/toolbar.js";
+import { store } from "../store.js";
 
 /** Plugin action IDs must be `{pluginId}.{actionId}`. Built-in IDs use colons, so the formats cannot collide. */
 const PLUGIN_ACTION_ID_RE = /^[a-z0-9][a-z0-9-]*\.[a-z0-9][a-zA-Z0-9._-]*$/;
@@ -45,6 +46,7 @@ interface LoadedPlugin {
   dir: string;
   resolvedMain?: string;
   loadedAt: number;
+  isBuiltin: boolean;
 }
 
 const ACTIVATE_TIMEOUT_MS = 5000;
@@ -73,6 +75,13 @@ export class PluginService {
   }> = [];
   private initialized = false;
   private pluginsRoot: string;
+  /**
+   * Optional override for the built-in plugins directory. When unset, the
+   * canonical app-bundled path is resolved lazily at `initialize()` time via
+   * {@link getBuiltinDir}. Tests pass an explicit path so they don't depend
+   * on `app.isPackaged` / `process.resourcesPath`.
+   */
+  private builtinPluginsRoot: string | undefined;
   private appVersion: string;
   /**
    * Coalesces multiple registry events fired in the same tick (e.g., when a
@@ -84,9 +93,14 @@ export class PluginService {
   private disposed = false;
   private readonly disposeRegistrySubscriptions: () => void;
 
-  constructor(pluginsRoot?: string, appVersion?: string) {
+  constructor(
+    pluginsRoot?: string,
+    appVersion?: string,
+    options?: { builtinPluginsRoot?: string }
+  ) {
     this.pluginsRoot = pluginsRoot ?? path.join(os.homedir(), ".daintree", "plugins");
     this.appVersion = appVersion ?? app.getVersion();
+    this.builtinPluginsRoot = options?.builtinPluginsRoot;
 
     const offRegister = onPanelKindRegistered(() => this.schedulePanelKindsBroadcast());
     const offUnregister = onPanelKindUnregistered(() => this.schedulePanelKindsBroadcast());
@@ -129,20 +143,77 @@ export class PluginService {
   async initialize(): Promise<void> {
     if (this.initialized) return;
 
+    // Built-ins load first so user plugins with a colliding manifest.name are
+    // rejected by the duplicate guard in loadPlugin() — built-in wins.
+    const builtinDir = this.builtinPluginsRoot ?? this.getBuiltinDir();
+    const builtinLoaded = builtinDir ? await this.loadFromDir(builtinDir, { isBuiltin: true }) : 0;
+    const userLoaded = await this.loadFromDir(this.pluginsRoot, { isBuiltin: false });
+
+    this.initialized = true;
+    console.log(
+      `[PluginService] Loaded ${builtinLoaded} built-in plugin(s) from ${builtinDir ?? "<unresolved>"} and ${userLoaded} user plugin(s) from ${this.pluginsRoot}`
+    );
+  }
+
+  /**
+   * Canonical app-bundled built-in plugins directory. Resolved at call time
+   * because `app.isPackaged` / `process.resourcesPath` are not valid at module
+   * evaluation. Mirrors the pattern in HelpService / SoundService — built-ins
+   * ship via electron-builder's `extraResources`, so the source directory at
+   * the repo root maps 1:1 to `<Resources>/plugins/builtin/` in packaged
+   * builds. Returns `null` when the Electron app API is unavailable (tests
+   * that mock `electron` with a minimal stub) — the built-in scan is then
+   * skipped without aborting user-plugin loading.
+   */
+  private getBuiltinDir(): string | null {
+    try {
+      if (app.isPackaged) {
+        return path.join(process.resourcesPath, "plugins", "builtin");
+      }
+      if (typeof app.getAppPath !== "function") return null;
+      return path.join(app.getAppPath(), "plugins", "builtin");
+    } catch (err) {
+      console.warn("[PluginService] Failed to resolve built-in plugins directory:", err);
+      return null;
+    }
+  }
+
+  /**
+   * Read disabled built-in plugin ids from the user store. Defensive against
+   * missing keys (in-memory fallback during tests) and read failures —
+   * a failed read returns an empty set so all built-ins activate, matching
+   * the safest startup behavior.
+   */
+  private getDisabledBuiltinIds(): Set<string> {
+    try {
+      const value = store.get("plugins") as { disabledBuiltins?: unknown } | undefined;
+      const list = Array.isArray(value?.disabledBuiltins) ? value.disabledBuiltins : [];
+      return new Set(list.filter((id): id is string => typeof id === "string"));
+    } catch (err) {
+      console.warn("[PluginService] Failed to read disabled built-in plugins from store:", err);
+      return new Set();
+    }
+  }
+
+  private async loadFromDir(root: string, opts: { isBuiltin: boolean }): Promise<number> {
     let entries: import("fs").Dirent[];
     try {
-      entries = await fs.readdir(this.pluginsRoot, { withFileTypes: true });
+      entries = await fs.readdir(root, { withFileTypes: true });
     } catch (err) {
       if ((err as NodeJS.ErrnoException).code === "ENOENT") {
-        console.log("[PluginService] No plugins directory found, skipping");
-        this.initialized = true;
-        return;
+        console.log(
+          `[PluginService] No ${opts.isBuiltin ? "built-in" : "user"} plugins directory at ${root}, skipping`
+        );
+        return 0;
       }
       throw err;
     }
 
     const pluginDirs = entries.filter((e) => e.isDirectory());
-    const results = await Promise.allSettled(pluginDirs.map((d) => this.loadPlugin(d.name)));
+    const disabled = opts.isBuiltin ? this.getDisabledBuiltinIds() : null;
+    const results = await Promise.allSettled(
+      pluginDirs.map((d) => this.loadPlugin(root, d.name, { isBuiltin: opts.isBuiltin, disabled }))
+    );
 
     let loaded = 0;
     for (const result of results) {
@@ -150,13 +221,15 @@ export class PluginService {
         loaded++;
       }
     }
-
-    this.initialized = true;
-    console.log(`[PluginService] Loaded ${loaded} plugin(s) from ${this.pluginsRoot}`);
+    return loaded;
   }
 
-  private async loadPlugin(dirName: string): Promise<LoadedPlugin | null> {
-    const pluginDir = path.join(this.pluginsRoot, dirName);
+  private async loadPlugin(
+    root: string,
+    dirName: string,
+    opts: { isBuiltin: boolean; disabled: Set<string> | null }
+  ): Promise<LoadedPlugin | null> {
+    const pluginDir = path.join(root, dirName);
     const manifestPath = path.join(pluginDir, "plugin.json");
 
     let content: string;
@@ -186,6 +259,14 @@ export class PluginService {
     }
 
     const manifest = parseResult.data;
+
+    // Built-ins disabled in Preferences are skipped entirely — neither
+    // registered in the plugins map nor activated. The disable persists in
+    // electron-store and takes effect on next launch.
+    if (opts.isBuiltin && opts.disabled?.has(manifest.name)) {
+      console.log(`[PluginService] Built-in plugin "${manifest.name}" is disabled, skipping`);
+      return null;
+    }
 
     if (this.plugins.has(manifest.name)) {
       console.error(
@@ -223,6 +304,7 @@ export class PluginService {
       manifest,
       dir: pluginDir,
       loadedAt: Date.now(),
+      isBuiltin: opts.isBuiltin,
     };
 
     if (manifest.main) {
@@ -608,6 +690,7 @@ export class PluginService {
       manifest: p.manifest,
       dir: p.dir,
       loadedAt: p.loadedAt,
+      isBuiltin: p.isBuiltin,
     }));
   }
 

--- a/electron/services/__tests__/PluginService.integration.test.ts
+++ b/electron/services/__tests__/PluginService.integration.test.ts
@@ -31,11 +31,18 @@ import { randomUUID } from "crypto";
  *   produces a distinct URL and re-executes module-level side effects.
  */
 
+const storeState = new Map<string, unknown>();
 vi.mock("electron", () => ({
   app: { getVersion: vi.fn(() => "0.0.0") },
 }));
 vi.mock("../../ipc/utils.js", () => ({
   broadcastToRenderer: vi.fn(),
+}));
+vi.mock("../../store.js", () => ({
+  store: {
+    get: (key: string) => storeState.get(key),
+    set: (key: string, value: unknown) => storeState.set(key, value),
+  },
 }));
 
 import { PluginService } from "../PluginService.js";
@@ -113,6 +120,7 @@ afterEach(async () => {
     clearPanelKindRegistry();
     clearToolbarButtonRegistry();
     clearPluginMenuRegistry();
+    storeState.clear();
     for (const key of globalMarkers) {
       delete (globalThis as Record<string, unknown>)[key];
     }
@@ -731,5 +739,100 @@ describe("PluginService integration — full contribution fan-out", () => {
       },
     ]);
     expect(readMarker(markerKey)).toBe(1);
+  });
+});
+
+describe("PluginService integration — built-in plugin loading", () => {
+  let builtinDir: string;
+
+  async function writeBuiltinPlugin(
+    pluginDirName: string,
+    manifest: PluginManifestShape
+  ): Promise<string> {
+    const dir = path.join(builtinDir, pluginDirName);
+    await fs.mkdir(dir, { recursive: true });
+    await fs.writeFile(path.join(dir, "plugin.json"), JSON.stringify(manifest));
+    return dir;
+  }
+
+  beforeEach(async () => {
+    builtinDir = await fs.mkdtemp(path.join(os.tmpdir(), "daintree-builtin-int-"));
+  });
+
+  afterEach(async () => {
+    await fs.rm(builtinDir, { recursive: true, force: true });
+  });
+
+  it("loads contributions from both built-in and user directories into the real registries", async () => {
+    await writeBuiltinPlugin("daintree.builtin-panels", {
+      name: "daintree.builtin-panels",
+      version: "1.0.0",
+      contributes: {
+        panels: [{ id: "main", name: "Main", iconId: "eye", color: "#abc" }],
+      },
+    });
+    await writePlugin("acme.user-panels", {
+      name: "acme.user-panels",
+      version: "1.0.0",
+      contributes: {
+        panels: [{ id: "side", name: "Side", iconId: "box", color: "#def" }],
+      },
+    });
+
+    const service = new PluginService(tmpDir, "0.0.0", { builtinPluginsRoot: builtinDir });
+    await service.initialize();
+
+    expect(getPanelKindConfig("daintree.builtin-panels.main")?.extensionId).toBe(
+      "daintree.builtin-panels"
+    );
+    expect(getPanelKindConfig("acme.user-panels.side")?.extensionId).toBe("acme.user-panels");
+
+    const plugins = service.listPlugins();
+    expect(plugins.find((p) => p.manifest.name === "daintree.builtin-panels")?.isBuiltin).toBe(
+      true
+    );
+    expect(plugins.find((p) => p.manifest.name === "acme.user-panels")?.isBuiltin).toBe(false);
+  });
+
+  it("does not register contributions for a disabled built-in", async () => {
+    storeState.set("plugins", { disabledBuiltins: ["daintree.disabled"] });
+    await writeBuiltinPlugin("daintree.disabled", {
+      name: "daintree.disabled",
+      version: "1.0.0",
+      contributes: {
+        panels: [{ id: "x", name: "X", iconId: "eye", color: "#000" }],
+        toolbarButtons: [{ id: "b", label: "B", iconId: "i", actionId: "daintree.disabled.act" }],
+      },
+    });
+
+    const service = new PluginService(tmpDir, "0.0.0", { builtinPluginsRoot: builtinDir });
+    await service.initialize();
+
+    expect(getPanelKindConfig("daintree.disabled.x")).toBeUndefined();
+    expect(getToolbarButtonConfig("plugin.daintree.disabled.b")).toBeUndefined();
+    expect(service.listPlugins()).toEqual([]);
+  });
+
+  it("activates a built-in plugin's main entry through the standard lifecycle", async () => {
+    const markerKey = makeMarkerKey();
+    const pluginDir = await writeBuiltinPlugin("daintree.activate-test", {
+      name: "daintree.activate-test",
+      version: "1.0.0",
+    });
+    const mainFile = await writeMainFixture(pluginDir, markerKey);
+    await fs.writeFile(
+      path.join(pluginDir, "plugin.json"),
+      JSON.stringify({
+        name: "daintree.activate-test",
+        version: "1.0.0",
+        main: mainFile,
+      })
+    );
+
+    const service = new PluginService(tmpDir, "0.0.0", { builtinPluginsRoot: builtinDir });
+    await service.initialize();
+
+    expect(readMarker(markerKey)).toBe(1);
+    expect(service.listPlugins()[0].isBuiltin).toBe(true);
   });
 });

--- a/electron/services/__tests__/PluginService.integration.test.ts
+++ b/electron/services/__tests__/PluginService.integration.test.ts
@@ -835,4 +835,59 @@ describe("PluginService integration — built-in plugin loading", () => {
     expect(readMarker(markerKey)).toBe(1);
     expect(service.listPlugins()[0].isBuiltin).toBe(true);
   });
+
+  it("does not execute the main entry of a disabled built-in", async () => {
+    const markerKey = makeMarkerKey();
+    const pluginDir = await writeBuiltinPlugin("daintree.disabled-main", {
+      name: "daintree.disabled-main",
+      version: "1.0.0",
+    });
+    const mainFile = await writeMainFixture(pluginDir, markerKey);
+    await fs.writeFile(
+      path.join(pluginDir, "plugin.json"),
+      JSON.stringify({
+        name: "daintree.disabled-main",
+        version: "1.0.0",
+        main: mainFile,
+      })
+    );
+    storeState.set("plugins", { disabledBuiltins: ["daintree.disabled-main"] });
+
+    const service = new PluginService(tmpDir, "0.0.0", { builtinPluginsRoot: builtinDir });
+    await service.initialize();
+
+    expect(readMarker(markerKey)).toBeUndefined();
+    expect(service.listPlugins()).toEqual([]);
+  });
+
+  it("loads remaining built-ins and user plugins when one built-in has a malformed manifest", async () => {
+    const errorSpy = vi.spyOn(console, "error").mockImplementation(() => {});
+    try {
+      const badDir = path.join(builtinDir, "broken");
+      await fs.mkdir(badDir, { recursive: true });
+      await fs.writeFile(path.join(badDir, "plugin.json"), "{not json");
+
+      await writeBuiltinPlugin("daintree.good-builtin", {
+        name: "daintree.good-builtin",
+        version: "1.0.0",
+        contributes: {
+          panels: [{ id: "ok", name: "Ok", iconId: "i", color: "#abc" }],
+        },
+      });
+      await writePlugin("acme.good-user", {
+        name: "acme.good-user",
+        version: "1.0.0",
+      });
+
+      const service = new PluginService(tmpDir, "0.0.0", { builtinPluginsRoot: builtinDir });
+      await service.initialize();
+
+      const names = service.listPlugins().map((p) => p.manifest.name);
+      expect(names).toEqual(expect.arrayContaining(["daintree.good-builtin", "acme.good-user"]));
+      expect(names).toHaveLength(2);
+      expect(getPanelKindConfig("daintree.good-builtin.ok")).toBeDefined();
+    } finally {
+      errorSpy.mockRestore();
+    }
+  });
 });

--- a/electron/services/__tests__/PluginService.test.ts
+++ b/electron/services/__tests__/PluginService.test.ts
@@ -9,12 +9,23 @@ const appMock = vi.hoisted(() => ({
   getVersion: vi.fn(() => "0.0.0"),
 }));
 const broadcastToRendererMock = vi.hoisted(() => vi.fn());
+const storeMock = vi.hoisted(() => {
+  const state = new Map<string, unknown>();
+  return {
+    get: vi.fn((key: string) => state.get(key)),
+    set: vi.fn((key: string, value: unknown) => state.set(key, value)),
+    _state: state,
+  };
+});
 
 vi.mock("electron", () => ({
   app: appMock,
 }));
 vi.mock("../../ipc/utils.js", () => ({
   broadcastToRenderer: broadcastToRendererMock,
+}));
+vi.mock("../../store.js", () => ({
+  store: storeMock,
 }));
 vi.mock("../../../shared/config/panelKindRegistry.js", () => ({
   registerPanelKind: vi.fn(),
@@ -71,6 +82,7 @@ function writePlugin(name: string, manifest: Record<string, unknown>): Promise<v
 beforeEach(async () => {
   tmpDir = await fs.mkdtemp(path.join(os.tmpdir(), "daintree-plugin-test-"));
   vi.clearAllMocks();
+  storeMock._state.clear();
 });
 
 afterEach(async () => {
@@ -690,6 +702,166 @@ describe("PluginService", () => {
 
     expect(registerToolbarButton).not.toHaveBeenCalled();
     expect(registerPluginMenuItem).not.toHaveBeenCalled();
+  });
+});
+
+describe("PluginService built-in plugin loading", () => {
+  let builtinDir: string;
+
+  async function writeBuiltinPlugin(
+    name: string,
+    manifest: Record<string, unknown>
+  ): Promise<void> {
+    const dir = path.join(builtinDir, name);
+    await fs.mkdir(dir, { recursive: true });
+    await fs.writeFile(path.join(dir, "plugin.json"), JSON.stringify(manifest));
+  }
+
+  beforeEach(async () => {
+    builtinDir = await fs.mkdtemp(path.join(os.tmpdir(), "daintree-builtin-plugin-test-"));
+  });
+
+  afterEach(async () => {
+    await fs.rm(builtinDir, { recursive: true, force: true });
+  });
+
+  it("tags plugins loaded from the built-in directory with isBuiltin=true", async () => {
+    await writeBuiltinPlugin("daintree.helper", {
+      name: "daintree.helper",
+      version: "1.0.0",
+    });
+    await writePlugin("acme.user-plugin", {
+      name: "acme.user-plugin",
+      version: "1.0.0",
+    });
+
+    const service = new PluginService(tmpDir, "0.0.0", { builtinPluginsRoot: builtinDir });
+    await service.initialize();
+
+    const plugins = service.listPlugins();
+    expect(plugins).toHaveLength(2);
+    const builtin = plugins.find((p) => p.manifest.name === "daintree.helper");
+    const user = plugins.find((p) => p.manifest.name === "acme.user-plugin");
+    expect(builtin?.isBuiltin).toBe(true);
+    expect(user?.isBuiltin).toBe(false);
+  });
+
+  it("user plugins receive isBuiltin=false even when no built-in dir is configured", async () => {
+    await writePlugin("acme.user-only", {
+      name: "acme.user-only",
+      version: "1.0.0",
+    });
+
+    const service = new PluginService(tmpDir, "0.0.0");
+    await service.initialize();
+
+    const plugins = service.listPlugins();
+    expect(plugins).toHaveLength(1);
+    expect(plugins[0].isBuiltin).toBe(false);
+  });
+
+  it("skips built-in scan cleanly when the directory is absent", async () => {
+    const missingDir = path.join(builtinDir, "does-not-exist");
+    await writePlugin("acme.user-plugin", {
+      name: "acme.user-plugin",
+      version: "1.0.0",
+    });
+
+    const service = new PluginService(tmpDir, "0.0.0", { builtinPluginsRoot: missingDir });
+    await service.initialize();
+
+    const plugins = service.listPlugins();
+    expect(plugins).toHaveLength(1);
+    expect(plugins[0].manifest.name).toBe("acme.user-plugin");
+    expect(plugins[0].isBuiltin).toBe(false);
+  });
+
+  it("built-ins win when a user plugin declares the same manifest name", async () => {
+    const errorSpy = vi.spyOn(console, "error").mockImplementation(() => {});
+    try {
+      await writeBuiltinPlugin("collision", {
+        name: "daintree.dupe",
+        version: "1.0.0",
+        description: "builtin",
+      });
+      await writePlugin("collision-user", {
+        name: "daintree.dupe",
+        version: "2.0.0",
+        description: "user",
+      });
+
+      const service = new PluginService(tmpDir, "0.0.0", { builtinPluginsRoot: builtinDir });
+      await service.initialize();
+
+      const plugins = service.listPlugins();
+      expect(plugins).toHaveLength(1);
+      expect(plugins[0].manifest.description).toBe("builtin");
+      expect(plugins[0].isBuiltin).toBe(true);
+      expect(errorSpy).toHaveBeenCalledWith(
+        expect.stringContaining(`Duplicate plugin name "daintree.dupe"`)
+      );
+    } finally {
+      errorSpy.mockRestore();
+    }
+  });
+
+  it("skips built-ins listed in plugins.disabledBuiltins", async () => {
+    storeMock._state.set("plugins", { disabledBuiltins: ["daintree.muted"] });
+    await writeBuiltinPlugin("muted", {
+      name: "daintree.muted",
+      version: "1.0.0",
+    });
+    await writeBuiltinPlugin("kept", {
+      name: "daintree.kept",
+      version: "1.0.0",
+    });
+
+    const service = new PluginService(tmpDir, "0.0.0", { builtinPluginsRoot: builtinDir });
+    await service.initialize();
+
+    const plugins = service.listPlugins();
+    expect(plugins.map((p) => p.manifest.name)).toEqual(["daintree.kept"]);
+  });
+
+  it("disabledBuiltins does not affect user plugins with the same name", async () => {
+    storeMock._state.set("plugins", { disabledBuiltins: ["acme.user-plugin"] });
+    await writePlugin("acme.user-plugin", {
+      name: "acme.user-plugin",
+      version: "1.0.0",
+    });
+
+    const service = new PluginService(tmpDir, "0.0.0", { builtinPluginsRoot: builtinDir });
+    await service.initialize();
+
+    const plugins = service.listPlugins();
+    expect(plugins).toHaveLength(1);
+    expect(plugins[0].isBuiltin).toBe(false);
+  });
+
+  it("treats missing plugins.disabledBuiltins as empty (no exception)", async () => {
+    // store has no "plugins" key at all (in-memory fallback shape)
+    await writeBuiltinPlugin("daintree.helper", {
+      name: "daintree.helper",
+      version: "1.0.0",
+    });
+
+    const service = new PluginService(tmpDir, "0.0.0", { builtinPluginsRoot: builtinDir });
+    await service.initialize();
+
+    expect(service.listPlugins()).toHaveLength(1);
+  });
+
+  it("ignores malformed disabledBuiltins values defensively", async () => {
+    storeMock._state.set("plugins", { disabledBuiltins: "not-an-array" });
+    await writeBuiltinPlugin("daintree.helper", {
+      name: "daintree.helper",
+      version: "1.0.0",
+    });
+
+    const service = new PluginService(tmpDir, "0.0.0", { builtinPluginsRoot: builtinDir });
+    await service.initialize();
+
+    expect(service.listPlugins()).toHaveLength(1);
   });
 });
 

--- a/electron/services/__tests__/PluginService.test.ts
+++ b/electron/services/__tests__/PluginService.test.ts
@@ -863,6 +863,33 @@ describe("PluginService built-in plugin loading", () => {
 
     expect(service.listPlugins()).toHaveLength(1);
   });
+
+  it("reserves a disabled built-in's namespace against a hijacking user plugin", async () => {
+    const errorSpy = vi.spyOn(console, "error").mockImplementation(() => {});
+    try {
+      storeMock._state.set("plugins", { disabledBuiltins: ["daintree.github"] });
+      await writeBuiltinPlugin("github", {
+        name: "daintree.github",
+        version: "1.0.0",
+        description: "first-party",
+      });
+      await writePlugin("hijacker", {
+        name: "daintree.github",
+        version: "9.9.9",
+        description: "third-party impostor",
+      });
+
+      const service = new PluginService(tmpDir, "0.0.0", { builtinPluginsRoot: builtinDir });
+      await service.initialize();
+
+      expect(service.listPlugins()).toEqual([]);
+      expect(errorSpy).toHaveBeenCalledWith(
+        expect.stringContaining(`Duplicate plugin name "daintree.github"`)
+      );
+    } finally {
+      errorSpy.mockRestore();
+    }
+  });
 });
 
 describe("Plugin IPC handler registration", () => {

--- a/electron/store.ts
+++ b/electron/store.ts
@@ -282,6 +282,15 @@ export interface StoreSchema {
    * issues without reconfiguring on every launch.
    */
   logLevelOverrides: Record<string, string>;
+  /**
+   * Plugin runtime state. `disabledBuiltins` lists built-in plugin ids
+   * (manifest.name) the user has disabled from Preferences. PluginService
+   * filters these out at startup; built-ins cannot be uninstalled, only
+   * disabled — disable takes effect on next launch.
+   */
+  plugins: {
+    disabledBuiltins: string[];
+  };
 }
 
 const storeOptions = {
@@ -426,6 +435,9 @@ const storeOptions = {
     updateChannel: "stable" as const,
     lastUpdateCheck: null,
     logLevelOverrides: {},
+    plugins: {
+      disabledBuiltins: [],
+    },
   },
   cwd: process.env.DAINTREE_USER_DATA,
 };

--- a/shared/types/plugin.ts
+++ b/shared/types/plugin.ts
@@ -101,6 +101,13 @@ export interface LoadedPluginInfo {
   manifest: PluginManifest;
   dir: string;
   loadedAt: number;
+  /**
+   * True for plugins loaded from the app-bundled `plugins/builtin/` directory.
+   * Built-ins skip the install-time capability disclosure dialog and cannot be
+   * uninstalled — they can only be disabled (effect on next startup).
+   * Determined by load path, never declared in the manifest.
+   */
+  isBuiltin: boolean;
 }
 
 export interface PluginIpcContext {


### PR DESCRIPTION
## Summary

- `PluginService` now scans `plugins/builtin/` (app-bundled via `extraResources`) before `~/.daintree/plugins/`, so first-party plugins ship with the app without an install step
- Built-ins load through the same lifecycle as user plugins; `isBuiltin: true` is tagged at load time, never authored in the manifest
- Disabling a built-in via `plugins.disabledBuiltins` in electron-store skips it on next startup and reserves its manifest name so a user plugin can't claim a trusted namespace (e.g. `daintree.github`)

Resolves #8059

## Changes

- `shared/types/plugin.ts` — adds `isBuiltin` flag to `LoadedPlugin`
- `electron/store.ts` — adds `plugins.disabledBuiltins: string[]` to the store schema
- `electron/services/PluginService.ts` — `getBuiltinDir()` resolves the bundled dir (returns `null` in test envs where the Electron app surface is partially stubbed); dual-dir scan with load-order guarantee; namespace reservation for disabled built-ins
- `electron-builder.config.cjs` — adds `plugins/builtin/` to `extraResources`
- `plugins/builtin/.gitkeep` — placeholder so the directory exists in the repo
- 11 new tests (9 unit + 3 integration) covering tagging, dual-dir registration, namespace reservation, disabled-skip, disabled-main-not-running, and mixed partial-failure loads

## Out of scope (follow-ups)

- Preferences UI plugin tab and `plugin:disable-builtin` IPC (#8059 notes these; no UI consumer yet)
- `docs/plugins/architecture.md` update can land with the first actual built-in plugin

## Testing

All 11 new tests pass. The integration suite covers the full dual-directory load path including partial failures and namespace reservation under the disabled state.