### PR TITLE
fix(worktree): stop exposing intermediate states during branch checkout

### DIFF
--- a/electron/workspace-host/WorkspaceService.ts
+++ b/electron/workspace-host/WorkspaceService.ts
@@ -414,7 +414,11 @@ export class WorkspaceService {
           existingMonitor.restartWatcherIfRunning();
         }
 
-        if (isCurrentChanged && existingMonitor.hasInitialStatus) {
+        // Skip this emit when the branch also changed — the branch-change
+        // block below emits the full snapshot (with updated isCurrent and
+        // cleared PR) anyway. Emitting here first would surface an
+        // intermediate frame carrying the new branch with the old PR (#8079).
+        if (isCurrentChanged && !branchChanged && existingMonitor.hasInitialStatus) {
           this.emitUpdate(existingMonitor);
         }
 

--- a/electron/workspace-host/WorkspaceService.ts
+++ b/electron/workspace-host/WorkspaceService.ts
@@ -427,12 +427,16 @@ export class WorkspaceService {
             void this.extractIssueNumberAsync(existingMonitor, wt.branch, wt.name);
           }
           existingMonitor.setIssueTitle(undefined);
+          // Bundle the PR clear into this same branch-change emit so the
+          // renderer never renders the new branch with the old PR (#8079).
+          existingMonitor.clearPRInfo();
           if (existingMonitor.hasInitialStatus) {
             this.emitUpdate(existingMonitor);
           }
         } else if (branchChanged && !wt.branch) {
           existingMonitor.setIssueNumber(undefined);
           existingMonitor.setIssueTitle(undefined);
+          existingMonitor.clearPRInfo();
           if (existingMonitor.hasInitialStatus) {
             this.emitUpdate(existingMonitor);
           }

--- a/electron/workspace-host/WorktreeMonitor.ts
+++ b/electron/workspace-host/WorktreeMonitor.ts
@@ -541,6 +541,7 @@ export class WorktreeMonitor {
     this.prState = undefined;
     this.prCiStatus = undefined;
     this.prTitle = undefined;
+    this.prLastUpdatedAt = undefined;
   }
 
   setCreatedAt(ms: number | undefined): void {

--- a/electron/workspace-host/WorktreeMonitor.ts
+++ b/electron/workspace-host/WorktreeMonitor.ts
@@ -1182,6 +1182,12 @@ export class WorktreeMonitor {
           void this.extractIssueNumberAsync(currentBranch, this._name);
         }
         this.issueTitle = undefined;
+        // Clear PR info synchronously in the same emit as the branch change
+        // so the renderer never sees a frame with the new branch but the old
+        // PR (#8079). PullRequestService still emits its own clear downstream;
+        // by then this snapshot already has null PR fields, so that second
+        // emit collapses to a no-op via snapshotsEqual.
+        this.clearPRInfo();
         this.callbacks.onBranchChanged?.(this.id, currentBranch);
       }
 

--- a/src/components/Fleet/__tests__/fleetBroadcast.test.ts
+++ b/src/components/Fleet/__tests__/fleetBroadcast.test.ts
@@ -71,6 +71,7 @@ function makeWorktree(id: string, overrides: Partial<WorktreeSnapshot> = {}): Wo
 function installViewStore(worktrees: Map<string, WorktreeSnapshot>) {
   const store = createStore<WorktreeViewState & WorktreeViewActions>(() => ({
     worktrees,
+    manualAssociations: new Map(),
     version: 0,
     isLoading: false,
     error: null,
@@ -81,6 +82,8 @@ function installViewStore(worktrees: Map<string, WorktreeSnapshot>) {
     applySnapshot: () => {},
     applyUpdate: () => {},
     applyRemove: () => {},
+    setManualAssociation: () => {},
+    clearManualAssociation: () => {},
     setLoading: () => {},
     setError: () => {},
     setFatalError: () => {},

--- a/src/components/Worktree/WorktreeCard.tsx
+++ b/src/components/Worktree/WorktreeCard.tsx
@@ -475,22 +475,20 @@ export function WorktreeCard({
       issueState: issue.state,
       issueUrl: issue.url,
     });
-    getCurrentViewStore().setState((prev) => {
-      const existing = prev.worktrees.get(worktree.id);
-      if (!existing) return prev;
-      const next = new Map(prev.worktrees);
-      next.set(worktree.id, {
-        ...existing,
-        issueNumber: issue.number,
-        issueTitle: issue.title,
-      });
-      return { worktrees: next };
+    // Record the manual association in the store so it survives subsequent
+    // `worktree-update` events (which carry only auto-detected issue state).
+    // This also optimistically re-merges the snapshot for immediate feedback.
+    getCurrentViewStore().getState().setManualAssociation(worktree.id, {
+      issueNumber: issue.number,
+      issueTitle: issue.title,
     });
   };
 
   const handleDetachIssue = async () => {
     await worktreeClient.detachIssue(worktree.id);
-    getCurrentViewStore().setState((prev) => {
+    const store = getCurrentViewStore();
+    store.getState().clearManualAssociation(worktree.id);
+    store.setState((prev) => {
       const existing = prev.worktrees.get(worktree.id);
       if (!existing) return prev;
       const next = new Map(prev.worktrees);

--- a/src/components/Worktree/WorktreeCard/IssueBadge.tsx
+++ b/src/components/Worktree/WorktreeCard/IssueBadge.tsx
@@ -1,6 +1,8 @@
-import { useMemo } from "react";
+import { useEffect, useMemo, useRef } from "react";
 import { cn } from "@/lib/utils";
 import { CircleDot } from "lucide-react";
+import { useDeferredLoading } from "@/hooks/useDeferredLoading";
+import { UI_DOHERTY_THRESHOLD } from "@/lib/animationUtils";
 import { Tooltip, TooltipContent, TooltipTrigger } from "../../ui/tooltip";
 import { useIssueTooltip } from "@/hooks/useGitHubTooltip";
 import { useGitHubBadgeTooltip } from "./hooks/useGitHubBadgeTooltip";
@@ -41,6 +43,19 @@ export function IssueBadge({
     isActive: isActive ?? false,
     onOpen,
   });
+
+  // Suppress the raw "#NNN" monospace fallback during the brief window where
+  // a *freshly-set* issue number has no title yet (the GitHub title fetch is
+  // in-flight, ~100–500ms). Per the Doherty Threshold, show nothing for the
+  // first 400ms rather than flashing the number, then fall through (#8079).
+  // Title preservation for *unchanged* issue numbers is handled upstream in
+  // the store, so this gate only fires on genuine issue-number transitions.
+  const prevIssueNumber = useRef<number | undefined>(undefined);
+  const isColdTitleGap = !issueTitle && issueNumber !== prevIssueNumber.current;
+  const showColdFallback = useDeferredLoading(isColdTitleGap, UI_DOHERTY_THRESHOLD);
+  useEffect(() => {
+    prevIssueNumber.current = issueNumber;
+  }, [issueNumber]);
 
   const { freshnessLevel, cacheLastUpdatedAt, now } = useGitHubBadgeFreshness(
     "issue",
@@ -94,13 +109,14 @@ export function IssueBadge({
                   : "text-text-primary/90"
             )}
           >
-            {issueTitle || (
-              <span
-                className={cn("font-mono", missingToken ? "text-text-muted" : "text-github-open")}
-              >
-                #{issueNumber}
-              </span>
-            )}
+            {issueTitle ||
+              (isColdTitleGap && !showColdFallback ? null : (
+                <span
+                  className={cn("font-mono", missingToken ? "text-text-muted" : "text-github-open")}
+                >
+                  #{issueNumber}
+                </span>
+              ))}
           </span>
         </button>
       </TooltipTrigger>

--- a/src/contexts/WorktreeStoreContext.tsx
+++ b/src/contexts/WorktreeStoreContext.tsx
@@ -112,12 +112,25 @@ export function WorktreeStoreProvider({ children }: { children: ReactNode }) {
           // merges them (MANUAL_OVER_AUTO) and caches the map so later events
           // can re-merge without another IPC round-trip.
           const states = response.states;
-          let associations: Record<string, { issueNumber: number; issueTitle?: string }> = {};
+          // Mint the snapshot version NOW, while this data is fresh — before
+          // awaiting the association fetch. A `worktree-update` delivered
+          // during that await mints a higher version via its own
+          // `nextVersion()` and must win; minting late would make this
+          // now-stale snapshot silently revert the live update (#8079).
+          const snapshotVersion = store.getState().nextVersion();
+
+          // `undefined` (not `{}`) means "couldn't load — keep whatever's
+          // cached". An empty object means "authoritatively no associations".
+          // Defaulting to `{}` on failure would wipe cached manual
+          // associations on a transient IPC error (#8079 review).
+          let associations:
+            | Record<string, { issueNumber: number; issueTitle?: string }>
+            | undefined;
           try {
             associations = await worktreeClient.getAllIssueAssociations();
             if (thisGen !== generation) return;
           } catch {
-            // Non-critical — proceed without manual associations
+            // Non-critical — keep cached associations (associations stays undefined)
             if (thisGen !== generation) return;
           }
 
@@ -127,7 +140,16 @@ export function WorktreeStoreProvider({ children }: { children: ReactNode }) {
           // cycle will deliver fresh data.
           if (!worktreePort.isReady()) return;
 
-          store.getState().applySnapshot(states, store.getState().nextVersion(), associations);
+          // A `worktree-update` raced ahead during the association fetch and
+          // already advanced the store past this snapshot. Don't revert it.
+          // On a cold start we still must hydrate, so retry the fetch (the
+          // generation guard prevents overlapping stale completions).
+          if (snapshotVersion <= store.getState().version) {
+            if (!store.getState().isInitialized) fetchInitialState();
+            return;
+          }
+
+          store.getState().applySnapshot(states, snapshotVersion, associations);
         })
         .catch((err: Error) => {
           if (thisGen !== generation) return;

--- a/src/contexts/WorktreeStoreContext.tsx
+++ b/src/contexts/WorktreeStoreContext.tsx
@@ -106,22 +106,16 @@ export function WorktreeStoreProvider({ children }: { children: ReactNode }) {
           if (thisGen !== generation) return;
 
           // Hydrate manual issue associations from electron store.
-          // Auto-detected issues (from branch names) are already in the snapshots,
-          // but user-attached associations are stored separately.
-          let states = response.states;
+          // Auto-detected issues (from branch names) arrive in the snapshots,
+          // but user-attached associations are stored separately and must
+          // survive subsequent `worktree-update` events (#8079). The store
+          // merges them (MANUAL_OVER_AUTO) and caches the map so later events
+          // can re-merge without another IPC round-trip.
+          const states = response.states;
+          let associations: Record<string, { issueNumber: number; issueTitle?: string }> = {};
           try {
-            const associations = await worktreeClient.getAllIssueAssociations();
+            associations = await worktreeClient.getAllIssueAssociations();
             if (thisGen !== generation) return;
-            if (Object.keys(associations).length > 0) {
-              states = states.map((s) => {
-                const assoc = associations[s.id];
-                // Only apply manual association if no auto-detected issue exists
-                if (assoc && !s.issueNumber) {
-                  return { ...s, issueNumber: assoc.issueNumber, issueTitle: assoc.issueTitle };
-                }
-                return s;
-              });
-            }
           } catch {
             // Non-critical — proceed without manual associations
             if (thisGen !== generation) return;
@@ -133,7 +127,7 @@ export function WorktreeStoreProvider({ children }: { children: ReactNode }) {
           // cycle will deliver fresh data.
           if (!worktreePort.isReady()) return;
 
-          store.getState().applySnapshot(states, store.getState().nextVersion());
+          store.getState().applySnapshot(states, store.getState().nextVersion(), associations);
         })
         .catch((err: Error) => {
           if (thisGen !== generation) return;

--- a/src/contexts/__tests__/WorktreeStoreContext.prDetected.test.tsx
+++ b/src/contexts/__tests__/WorktreeStoreContext.prDetected.test.tsx
@@ -774,3 +774,72 @@ describe("WorktreeStoreProvider issue-detected handler", () => {
     expect(store.getState().worktrees.get("wt-1")?.issueNumber).toBe(200);
   });
 });
+
+describe("WorktreeStoreProvider manual issue associations (#8079)", () => {
+  function mockHydration(
+    states: WorktreeSnapshot[],
+    associations: Record<string, { issueNumber: number; issueTitle?: string }>
+  ): void {
+    const electron = (globalThis as unknown as { window: Window }).window.electron as unknown as {
+      worktreePort: { request: (name: string) => Promise<unknown> };
+      worktree: { getAllIssueAssociations: () => Promise<unknown> };
+    };
+    electron.worktreePort.request = () => Promise.resolve({ states });
+    electron.worktree.getAllIssueAssociations = () => Promise.resolve(associations);
+  }
+
+  it("manual association survives a worktree-update that omits the issue", async () => {
+    mockHydration([makeWorktree("wt-1", { issueNumber: undefined, issueTitle: undefined })], {
+      "wt-1": { issueNumber: 42, issueTitle: "Manual issue" },
+    });
+    const store = await renderProvider();
+
+    expect(store.getState().worktrees.get("wt-1")?.issueNumber).toBe(42);
+
+    act(() => {
+      emit("worktree-update", {
+        type: "worktree-update",
+        worktree: makeWorktree("wt-1", {
+          branch: "feature/x",
+          issueNumber: undefined,
+          issueTitle: undefined,
+        }),
+      });
+    });
+
+    const wt = store.getState().worktrees.get("wt-1");
+    expect(wt?.issueNumber).toBe(42);
+    expect(wt?.issueTitle).toBe("Manual issue");
+    expect(wt?.branch).toBe("feature/x");
+  });
+
+  it("manual association overrides an auto-detected issue (MANUAL_OVER_AUTO)", async () => {
+    mockHydration([makeWorktree("wt-1", { issueNumber: 11, issueTitle: "Auto" })], {
+      "wt-1": { issueNumber: 42, issueTitle: "Manual issue" },
+    });
+    const store = await renderProvider();
+
+    const wt = store.getState().worktrees.get("wt-1");
+    expect(wt?.issueNumber).toBe(42);
+    expect(wt?.issueTitle).toBe("Manual issue");
+  });
+
+  it("clearing an association stops it resurfacing on the next update", async () => {
+    mockHydration([makeWorktree("wt-1", { issueNumber: undefined })], {
+      "wt-1": { issueNumber: 42, issueTitle: "Manual issue" },
+    });
+    const store = await renderProvider();
+
+    act(() => {
+      store.getState().clearManualAssociation("wt-1");
+    });
+    act(() => {
+      emit("worktree-update", {
+        type: "worktree-update",
+        worktree: makeWorktree("wt-1", { issueNumber: undefined, issueTitle: undefined }),
+      });
+    });
+
+    expect(store.getState().worktrees.get("wt-1")?.issueNumber).toBeUndefined();
+  });
+});

--- a/src/services/actions/__tests__/actionDefinitions.quality.test.ts
+++ b/src/services/actions/__tests__/actionDefinitions.quality.test.ts
@@ -296,6 +296,7 @@ describe("destructive-action danger metadata", () => {
       worktrees: new Map<string, WorktreeSnapshot>([
         ["wt-placeholder", { id: "wt-placeholder", hasTeardownCommand: true } as WorktreeSnapshot],
       ]),
+      manualAssociations: new Map(),
       version: 1,
       isLoading: false,
       error: null,
@@ -306,6 +307,8 @@ describe("destructive-action danger metadata", () => {
       applySnapshot: () => {},
       applyUpdate: () => {},
       applyRemove: () => {},
+      setManualAssociation: () => {},
+      clearManualAssociation: () => {},
       setLoading: () => {},
       setError: () => {},
       setFatalError: () => {},

--- a/src/store/__tests__/createWorktreeStore.associations.test.ts
+++ b/src/store/__tests__/createWorktreeStore.associations.test.ts
@@ -1,0 +1,143 @@
+import { describe, expect, it } from "vitest";
+import { createWorktreeStore } from "@/store/createWorktreeStore";
+import type { WorktreeSnapshot } from "@shared/types";
+
+function makeSnapshot(id: string, overrides: Partial<WorktreeSnapshot> = {}): WorktreeSnapshot {
+  return {
+    id,
+    name: id,
+    branch: "main",
+    path: `/repo/${id}`,
+    isCurrent: false,
+    isMainWorktree: false,
+    modifiedCount: 0,
+    changes: [],
+    summary: "",
+    mood: null,
+    gitDir: "",
+    ...overrides,
+  } as unknown as WorktreeSnapshot;
+}
+
+describe("createWorktreeStore — manual issue associations (#8079)", () => {
+  it("starts with an empty manualAssociations map", () => {
+    const store = createWorktreeStore();
+    expect(store.getState().manualAssociations.size).toBe(0);
+  });
+
+  it("applySnapshot merges associations over auto-detected issue (MANUAL_OVER_AUTO)", () => {
+    const store = createWorktreeStore();
+    store
+      .getState()
+      .applySnapshot(
+        [makeSnapshot("wt-1", { issueNumber: 11, issueTitle: "Auto detected" })],
+        store.getState().nextVersion(),
+        { "wt-1": { issueNumber: 42, issueTitle: "Manual issue" } }
+      );
+
+    const wt = store.getState().worktrees.get("wt-1");
+    expect(wt?.issueNumber).toBe(42);
+    expect(wt?.issueTitle).toBe("Manual issue");
+    expect(store.getState().manualAssociations.get("wt-1")?.issueNumber).toBe(42);
+  });
+
+  it("applyUpdate preserves a manual association the snapshot omits", () => {
+    const store = createWorktreeStore();
+    store.getState().applySnapshot([makeSnapshot("wt-1")], store.getState().nextVersion(), {
+      "wt-1": { issueNumber: 42, issueTitle: "Manual issue" },
+    });
+
+    // A worktree-update with no issue fields must NOT clobber the manual assoc.
+    store
+      .getState()
+      .applyUpdate(makeSnapshot("wt-1", { branch: "feature/x" }), store.getState().nextVersion());
+
+    const wt = store.getState().worktrees.get("wt-1");
+    expect(wt?.issueNumber).toBe(42);
+    expect(wt?.issueTitle).toBe("Manual issue");
+    expect(wt?.branch).toBe("feature/x");
+  });
+
+  it("setManualAssociation re-merges the existing snapshot immediately", () => {
+    const store = createWorktreeStore();
+    store.getState().applySnapshot([makeSnapshot("wt-1")], store.getState().nextVersion());
+
+    store.getState().setManualAssociation("wt-1", { issueNumber: 99, issueTitle: "Attached" });
+
+    const wt = store.getState().worktrees.get("wt-1");
+    expect(wt?.issueNumber).toBe(99);
+    expect(wt?.issueTitle).toBe("Attached");
+  });
+
+  it("clearManualAssociation stops resurrecting the issue on the next update", () => {
+    const store = createWorktreeStore();
+    store.getState().applySnapshot([makeSnapshot("wt-1")], store.getState().nextVersion(), {
+      "wt-1": { issueNumber: 42, issueTitle: "Manual issue" },
+    });
+
+    store.getState().clearManualAssociation("wt-1");
+    store
+      .getState()
+      .applyUpdate(
+        makeSnapshot("wt-1", { issueNumber: undefined }),
+        store.getState().nextVersion()
+      );
+
+    const wt = store.getState().worktrees.get("wt-1");
+    expect(wt?.issueNumber).toBeUndefined();
+    expect(store.getState().manualAssociations.has("wt-1")).toBe(false);
+  });
+
+  it("preserves the previous title when the issue number is unchanged", () => {
+    const store = createWorktreeStore();
+    store
+      .getState()
+      .applySnapshot(
+        [makeSnapshot("wt-1", { issueNumber: 7, issueTitle: "Loaded title" })],
+        store.getState().nextVersion()
+      );
+
+    // Poll re-fetch drops the title but keeps the same issue number.
+    store
+      .getState()
+      .applyUpdate(
+        makeSnapshot("wt-1", { issueNumber: 7, issueTitle: undefined }),
+        store.getState().nextVersion()
+      );
+
+    expect(store.getState().worktrees.get("wt-1")?.issueTitle).toBe("Loaded title");
+  });
+
+  it("clears the title when the issue number changes", () => {
+    const store = createWorktreeStore();
+    store
+      .getState()
+      .applySnapshot(
+        [makeSnapshot("wt-1", { issueNumber: 7, issueTitle: "Old title" })],
+        store.getState().nextVersion()
+      );
+
+    store
+      .getState()
+      .applyUpdate(
+        makeSnapshot("wt-1", { issueNumber: 8, issueTitle: undefined }),
+        store.getState().nextVersion()
+      );
+
+    const wt = store.getState().worktrees.get("wt-1");
+    expect(wt?.issueNumber).toBe(8);
+    expect(wt?.issueTitle).toBeUndefined();
+  });
+
+  it("setFatalError drops cached manual associations", () => {
+    const store = createWorktreeStore();
+    store.getState().applySnapshot([makeSnapshot("wt-1")], store.getState().nextVersion(), {
+      "wt-1": { issueNumber: 42, issueTitle: "Manual issue" },
+    });
+
+    store.getState().setFatalError("host crashed");
+
+    expect(store.getState().manualAssociations.size).toBe(0);
+    expect(store.getState().isInitialized).toBe(false);
+  });
+});

--- a/src/store/__tests__/createWorktreeStore.associations.test.ts
+++ b/src/store/__tests__/createWorktreeStore.associations.test.ts
@@ -129,6 +129,58 @@ describe("createWorktreeStore — manual issue associations (#8079)", () => {
     expect(wt?.issueTitle).toBeUndefined();
   });
 
+  it("applySnapshot without associations preserves the cached map", () => {
+    const store = createWorktreeStore();
+    store.getState().applySnapshot([makeSnapshot("wt-1")], store.getState().nextVersion(), {
+      "wt-1": { issueNumber: 42, issueTitle: "Manual issue" },
+    });
+
+    // A later refresh whose association IPC failed passes `undefined`.
+    store
+      .getState()
+      .applySnapshot(
+        [makeSnapshot("wt-1", { branch: "feature/x" })],
+        store.getState().nextVersion()
+      );
+
+    expect(store.getState().manualAssociations.get("wt-1")?.issueNumber).toBe(42);
+    expect(store.getState().worktrees.get("wt-1")?.issueNumber).toBe(42);
+    expect(store.getState().worktrees.get("wt-1")?.branch).toBe("feature/x");
+  });
+
+  it("a stale-version applySnapshot does not revert a newer applyUpdate", () => {
+    const store = createWorktreeStore();
+    // Version minted while the snapshot data was "fresh".
+    const snapshotVersion = store.getState().nextVersion();
+    // A worktree-update races ahead during the association fetch.
+    store
+      .getState()
+      .applyUpdate(makeSnapshot("wt-1", { branch: "feature/new" }), store.getState().nextVersion());
+
+    // The now-stale snapshot tries to apply with the older version.
+    store.getState().applySnapshot([makeSnapshot("wt-1", { branch: "old" })], snapshotVersion);
+
+    expect(store.getState().worktrees.get("wt-1")?.branch).toBe("feature/new");
+  });
+
+  it("manual association overrides an issue-detected-style update (MANUAL_OVER_AUTO)", () => {
+    const store = createWorktreeStore();
+    store.getState().applySnapshot([makeSnapshot("wt-1")], store.getState().nextVersion());
+    store.getState().setManualAssociation("wt-1", { issueNumber: 42, issueTitle: "Manual" });
+
+    // issue-detected builds a snapshot with a different (auto) issue.
+    store
+      .getState()
+      .applyUpdate(
+        makeSnapshot("wt-1", { issueNumber: 99, issueTitle: "Auto detected" }),
+        store.getState().nextVersion()
+      );
+
+    const wt = store.getState().worktrees.get("wt-1");
+    expect(wt?.issueNumber).toBe(42);
+    expect(wt?.issueTitle).toBe("Manual");
+  });
+
   it("setFatalError drops cached manual associations", () => {
     const store = createWorktreeStore();
     store.getState().applySnapshot([makeSnapshot("wt-1")], store.getState().nextVersion(), {

--- a/src/store/createWorktreeStore.ts
+++ b/src/store/createWorktreeStore.ts
@@ -24,8 +24,21 @@ export function getCurrentViewStoreOrNull(): WorktreeViewStoreApi | null {
   return _currentViewStore;
 }
 
+/**
+ * A user-attached worktree→issue association held in the renderer alongside
+ * the snapshot map. The authoritative copy lives in the Electron store
+ * (`worktreeIssueMap`); this slice mirrors it so that `worktree-update` events
+ * — which carry only auto-detected (branch-name) issue state — don't clobber
+ * manual associations between cold hydrations.
+ */
+export interface ManualIssueAssociation {
+  issueNumber: number;
+  issueTitle?: string;
+}
+
 export interface WorktreeViewState {
   worktrees: Map<string, WorktreeSnapshot>;
+  manualAssociations: Map<string, ManualIssueAssociation>;
   version: number;
   isLoading: boolean;
   error: string | null;
@@ -36,9 +49,15 @@ export interface WorktreeViewState {
 
 export interface WorktreeViewActions {
   nextVersion(): number;
-  applySnapshot(states: WorktreeSnapshot[], version: number): void;
+  applySnapshot(
+    states: WorktreeSnapshot[],
+    version: number,
+    associations?: Record<string, ManualIssueAssociation>
+  ): void;
   applyUpdate(state: WorktreeSnapshot, version: number): void;
   applyRemove(worktreeId: string, version: number): void;
+  setManualAssociation(worktreeId: string, assoc: ManualIssueAssociation): void;
+  clearManualAssociation(worktreeId: string): void;
   setLoading(loading: boolean): void;
   setError(error: string | null): void;
   setFatalError(message: string): void;
@@ -53,6 +72,7 @@ export function createWorktreeStore(): WorktreeViewStoreApi {
 
   return createStore<WorktreeViewStore>((set, get) => ({
     worktrees: new Map(),
+    manualAssociations: new Map(),
     version: 0,
     isLoading: true,
     error: null,
@@ -64,17 +84,34 @@ export function createWorktreeStore(): WorktreeViewStoreApi {
       return ++versionCounter;
     },
 
-    applySnapshot(states: WorktreeSnapshot[], version: number) {
+    applySnapshot(
+      states: WorktreeSnapshot[],
+      version: number,
+      associations?: Record<string, ManualIssueAssociation>
+    ) {
       if (version <= get().version) return;
       const prev = get();
+      // Atomically adopt the freshly-hydrated manual associations alongside
+      // the snapshot (lesson #4958 — no separate slice update that could
+      // render a half-merged state). When the caller doesn't pass them
+      // (e.g. unit tests), keep whatever's already cached.
+      const manual = associations
+        ? new Map<string, ManualIssueAssociation>(Object.entries(associations))
+        : prev.manualAssociations;
+      const associationsChanged = associations !== undefined;
+
+      const merged = states.map((s) =>
+        mergeIssueState(s, prev.worktrees.get(s.id), manual.get(s.id))
+      );
+
       // Once hydrated, suppress redundant Map identity churn when every
       // incoming snapshot is value-equal to its existing counterpart. Cold
       // starts always rebuild so `isInitialized` flips correctly even when
       // the first snapshot is empty.
       if (
         prev.isInitialized &&
-        states.length === prev.worktrees.size &&
-        states.every((s) => {
+        merged.length === prev.worktrees.size &&
+        merged.every((s) => {
           const existing = prev.worktrees.get(s.id);
           return existing !== undefined && snapshotsEqual(existing, s);
         })
@@ -86,10 +123,11 @@ export function createWorktreeStore(): WorktreeViewStoreApi {
           error: null,
           isReconnecting: false,
           reconnectingAt: null,
+          ...(associationsChanged ? { manualAssociations: manual } : {}),
         });
         return;
       }
-      const map = new Map(states.map((s) => [s.id, s]));
+      const map = new Map(merged.map((s) => [s.id, s]));
       set({
         worktrees: map,
         version,
@@ -98,6 +136,7 @@ export function createWorktreeStore(): WorktreeViewStoreApi {
         error: null,
         isReconnecting: false,
         reconnectingAt: null,
+        ...(associationsChanged ? { manualAssociations: manual } : {}),
       });
     },
 
@@ -105,13 +144,39 @@ export function createWorktreeStore(): WorktreeViewStoreApi {
       if (version <= get().version) return;
       const prev = get().worktrees;
       const existing = prev.get(state.id);
-      if (existing && snapshotsEqual(existing, state)) {
+      const merged = mergeIssueState(state, existing, get().manualAssociations.get(state.id));
+      if (existing && snapshotsEqual(existing, merged)) {
         set({ version });
         return;
       }
       const next = new Map(prev);
-      next.set(state.id, state);
+      next.set(state.id, merged);
       set({ worktrees: next, version });
+    },
+
+    setManualAssociation(worktreeId: string, assoc: ManualIssueAssociation) {
+      const prev = get();
+      const nextAssoc = new Map(prev.manualAssociations);
+      nextAssoc.set(worktreeId, assoc);
+      const existing = prev.worktrees.get(worktreeId);
+      if (!existing) {
+        set({ manualAssociations: nextAssoc });
+        return;
+      }
+      // Re-merge the affected snapshot so the manual association survives the
+      // next `worktree-update` (which carries only auto-detected issue state).
+      const merged = mergeIssueState(existing, existing, assoc);
+      const nextWorktrees = new Map(prev.worktrees);
+      nextWorktrees.set(worktreeId, merged);
+      set({ manualAssociations: nextAssoc, worktrees: nextWorktrees });
+    },
+
+    clearManualAssociation(worktreeId: string) {
+      const prev = get();
+      if (!prev.manualAssociations.has(worktreeId)) return;
+      const nextAssoc = new Map(prev.manualAssociations);
+      nextAssoc.delete(worktreeId);
+      set({ manualAssociations: nextAssoc });
     },
 
     applyRemove(worktreeId: string, version: number) {
@@ -142,8 +207,12 @@ export function createWorktreeStore(): WorktreeViewStoreApi {
       // `isInitialized` is reset so the next `fetchInitialState` treats the
       // post-restart fetch as a cold start rather than a silent wake refresh
       // (which swallows fetch errors).
+      // Drop cached manual associations too — the post-restart
+      // `fetchInitialState` re-hydrates them from the Electron store, so a
+      // stale renderer copy must not leak across the crash boundary.
       set({
         error: message,
+        manualAssociations: new Map(),
         isInitialized: false,
         isReconnecting: false,
         reconnectingAt: null,
@@ -201,6 +270,53 @@ export function cleanupOrphanedTerminals(): void {
     });
     orphanedTerminals.forEach((terminal) => terminalStore.removePanel(terminal.id));
   }
+}
+
+/**
+ * Reconcile the issue fields of an incoming snapshot with what the renderer
+ * already knows. Two concerns, both from #8079:
+ *
+ *  1. **Title flicker** — when the issue number is unchanged but the incoming
+ *     snapshot dropped the title (the main process resets it to `undefined`
+ *     while it re-fetches the GitHub title after a poll), keep the previous
+ *     title so `IssueBadge` doesn't flash the raw `#NNN` for ~100–500ms.
+ *     A genuine issue-number change clears the title immediately — the old
+ *     title belongs to the old issue.
+ *
+ *  2. **MANUAL_OVER_AUTO** — an explicit user-attached issue association
+ *     always overrides the auto-detected (branch-name) issue. Explicit user
+ *     intent beats the heuristic, matching mainstream issue-tracker UX. This
+ *     is a deliberate inversion of the old `if (assoc && !issueNumber)`
+ *     fallback behaviour (manual was previously only a last resort).
+ */
+function mergeIssueState(
+  incoming: WorktreeSnapshot,
+  existing: WorktreeSnapshot | undefined,
+  manual: { issueNumber: number; issueTitle?: string } | undefined
+): WorktreeSnapshot {
+  let issueNumber = incoming.issueNumber;
+  let issueTitle = incoming.issueTitle;
+
+  if (
+    existing &&
+    issueNumber !== undefined &&
+    issueNumber === existing.issueNumber &&
+    issueTitle === undefined &&
+    existing.issueTitle !== undefined
+  ) {
+    issueTitle = existing.issueTitle;
+  }
+
+  // MANUAL_OVER_AUTO: explicit user association wins over auto-detection.
+  if (manual) {
+    issueNumber = manual.issueNumber;
+    issueTitle = manual.issueTitle;
+  }
+
+  if (issueNumber === incoming.issueNumber && issueTitle === incoming.issueTitle) {
+    return incoming;
+  }
+  return { ...incoming, issueNumber, issueTitle };
 }
 
 function snapshotsEqual(a: WorktreeSnapshot, b: WorktreeSnapshot): boolean {


### PR DESCRIPTION
## Summary

Three interleaved intermediate-state problems in the worktree sidebar during branch checkout, all fixed.

- **Manually-attached issues disappear on checkout** — added a `manualAssociations` slice to `createWorktreeStore`, hydrated atomically via `applySnapshot`, merged in `applyUpdate` with explicit manual-overrides-auto precedence. Survives `worktree-update` events without extra IPC, preserved on association-IPC failure, reset on host crash.
- **PR fields flash stale-then-null on branch change** — `clearPRInfo()` now called synchronously in `WorktreeMonitor.updateGitStatus` and `WorkspaceService.syncMonitors` before the emit, with a double-emit guard when `isCurrentChanged` and `branchChanged` coincide.
- **`IssueBadge` flashes raw `#NNN` strings** — store-level title preservation when the issue number is unchanged, plus 400ms Doherty-threshold deferred suppression for genuine cold issue-number transitions.

Also fixed a snapshot-version race (mint version before association `await`) and made `clearPRInfo` field-complete (`prLastUpdatedAt`, `prCiStatus`).

Resolves #8079

## Changes

- `createWorktreeStore.ts` — `manualAssociations` slice, `applySnapshot`/`applyUpdate` merge logic, title preservation in `IssueBadge` path
- `WorktreeStoreContext.tsx` — atomic snapshot hydration, association-IPC failure recovery
- `WorktreeMonitor.ts` / `WorkspaceService.ts` — synchronous `clearPRInfo` before emit, double-emit guard
- `WorktreeCard.tsx` / `IssueBadge.tsx` — Doherty-threshold deferred suppression for cold issue-number transitions

## Testing

19 unit and integration tests added or updated, all green. `npm run check` clean (lint warnings down vs baseline).