### PR TITLE
perf(pr-service): stagger and throttle post-host-restart PR refetch burst

### DIFF
--- a/electron/services/PullRequestService.ts
+++ b/electron/services/PullRequestService.ts
@@ -95,7 +95,6 @@ class PullRequestService {
   private isPolling: boolean = false;
   private consecutiveErrors: number = 0;
   private nextRetryAt: number = 0;
-  private lastFocusCatchupAt: number = Number.NEGATIVE_INFINITY;
   private boostExpiresAt: number | null = null;
   private lastCheckAt: number = Number.NEGATIVE_INFINITY;
   private startupDelayTimer: NodeJS.Timeout | null = null;
@@ -392,7 +391,6 @@ class PullRequestService {
     this.detectedPRs.clear();
     this.consecutiveErrors = 0;
     this.nextRetryAt = 0;
-    this.lastFocusCatchupAt = Number.NEGATIVE_INFINITY;
     this.boostExpiresAt = null;
     this.lastCheckAt = Number.NEGATIVE_INFINITY;
   }

--- a/electron/services/PullRequestService.ts
+++ b/electron/services/PullRequestService.ts
@@ -15,9 +15,26 @@ import { formatErrorMessage } from "../../shared/utils/errorMessage.js";
 // GitHub API quota during background sessions.
 const FOCUSED_POLL_INTERVAL_MS = 30 * 1000;
 const BLURRED_POLL_INTERVAL_MS = 2 * 60 * 1000;
-// Minimum gap between blur→focus catch-up polls. Matches SWR's 5s
-// `focusThrottleInterval` convention so rapid alt-tabbing doesn't burst the API.
+// Minimum gap between automatic checkForPRs() invocations (focus catch-up,
+// debounced branch-change recheck, post-restart startup check, poll backoff).
+// Matches SWR's 5s `focusThrottleInterval` convention so rapid alt-tabbing —
+// and a fleet-wide host-restart burst — don't hammer the GitHub API. Manual
+// refresh() bypasses this by resetting `lastCheckAt` first.
 const FOCUS_CATCHUP_THROTTLE_MS = 5 * 1000;
+
+// Randomised delay before the first checkForPRs() after start(). The
+// workspace-host's own restart is jittered, but the singleton's resolved-PR
+// state wipes on restart, so without this every candidate worktree refetches
+// at once — and across many windows whose hosts crashed together, that's a
+// synchronised GitHub API burst right when GitHub itself may still be flaky.
+// A short uniform spread (not the error-indexed `computeBackoff`) decorrelates
+// the fleet. `resume()` (focus-restore) passes 0 to skip the jitter.
+const STARTUP_JITTER_MIN_MS = 500;
+const STARTUP_JITTER_MAX_MS = 2_500;
+
+function randomBetween(min: number, max: number): number {
+  return min + Math.random() * (max - min);
+}
 
 // AWS full-jitter backoff: sleep = random_between(floor, min(cap, base * 2^attempt))
 // See https://aws.amazon.com/blogs/architecture/exponential-backoff-and-jitter/
@@ -80,6 +97,9 @@ class PullRequestService {
   private nextRetryAt: number = 0;
   private lastFocusCatchupAt: number = Number.NEGATIVE_INFINITY;
   private boostExpiresAt: number | null = null;
+  private lastCheckAt: number = Number.NEGATIVE_INFINITY;
+  private startupDelayTimer: NodeJS.Timeout | null = null;
+  private startupDelayResolve: (() => void) | null = null;
 
   get isEnabled(): boolean {
     return this.nextRetryAt === 0 || Date.now() >= this.nextRetryAt;
@@ -184,7 +204,7 @@ class PullRequestService {
     }
   }
 
-  private scheduleDebounceCheck(): void {
+  private scheduleDebounceCheck(delayMs: number = UPDATE_DEBOUNCE_MS): void {
     if (this.updateDebounceTimer) {
       clearTimeout(this.updateDebounceTimer);
     }
@@ -192,19 +212,40 @@ class PullRequestService {
     this.updateDebounceTimer = setTimeout(() => {
       this.updateDebounceTimer = null;
 
-      if (this.hasUnresolvedCandidates() && this.isEnabled) {
-        logDebug("Running debounced PR check", { candidateCount: this.candidates.size });
-        void this.checkForPRs().catch((err) =>
-          logWarn("Debounced PR check failed", {
-            error: formatErrorMessage(err, "Debounced PR check failed"),
-          })
-        );
-
-        if (!this.pollTimer) {
-          this.scheduleNextPoll();
-        }
+      if (!this.hasUnresolvedCandidates() || !this.isEnabled) {
+        return;
       }
-    }, UPDATE_DEBOUNCE_MS);
+
+      // A branch-change recheck inside the 5s floor is deferred until the
+      // floor clears rather than dropped to the next poll tick — keeps
+      // branch switches responsive (≤5s) without bursting the API.
+      const waitMs = this.msUntilCheckAllowed();
+      if (waitMs > 0) {
+        this.scheduleDebounceCheck(waitMs);
+        return;
+      }
+
+      logDebug("Running debounced PR check", { candidateCount: this.candidates.size });
+      void this.checkForPRs().catch((err) =>
+        logWarn("Debounced PR check failed", {
+          error: formatErrorMessage(err, "Debounced PR check failed"),
+        })
+      );
+
+      if (!this.pollTimer) {
+        this.scheduleNextPoll();
+      }
+    }, delayMs);
+  }
+
+  /**
+   * Milliseconds until an automatic checkForPRs() is allowed again under the
+   * 5s floor. 0 means a check may proceed now. `lastCheckAt` is only advanced
+   * when a real GitHub batch is attempted, so throttled/skipped calls never
+   * push this window forward (avoids a no-progress reschedule loop).
+   */
+  private msUntilCheckAllowed(): number {
+    return Math.max(0, FOCUS_CATCHUP_THROTTLE_MS - (Date.now() - this.lastCheckAt));
   }
 
   public initialize(cwd: string): void {
@@ -212,7 +253,15 @@ class PullRequestService {
     logInfo("PullRequestService initialized", { cwd });
   }
 
-  public start(intervalMs?: number): Promise<void> {
+  /**
+   * Start polling. The first check is delayed by a randomised
+   * STARTUP_JITTER_MIN..MAX window so a fleet-wide host restart doesn't fire a
+   * synchronised PR refetch burst. Pass `startupDelayMs = 0` to check
+   * immediately (focus-restore / resume(), which is not a crash-recovery
+   * path). The returned promise resolves after the (delayed) first check, or
+   * immediately if stop()/reset() cancels the pending delay.
+   */
+  public start(startupDelayMs?: number): Promise<void> {
     if (this.isPolling) {
       logWarn("PullRequestService already polling");
       return Promise.resolve();
@@ -223,23 +272,55 @@ class PullRequestService {
       return Promise.resolve();
     }
 
-    if (intervalMs) {
-      this.pollIntervalMs = intervalMs;
-    }
-
     this.isPolling = true;
     this.nextRetryAt = 0;
     this.consecutiveErrors = 0;
 
-    logInfo("PullRequestService started", { intervalMs: this.pollIntervalMs });
+    const delay = startupDelayMs ?? randomBetween(STARTUP_JITTER_MIN_MS, STARTUP_JITTER_MAX_MS);
 
+    logInfo("PullRequestService started", {
+      intervalMs: this.pollIntervalMs,
+      startupDelayMs: Math.round(delay),
+    });
+
+    if (delay <= 0) {
+      return this.runInitialCheck();
+    }
+
+    return new Promise<void>((resolve) => {
+      this.startupDelayResolve = resolve;
+      this.startupDelayTimer = setTimeout(() => {
+        this.startupDelayTimer = null;
+        this.startupDelayResolve = null;
+        void this.runInitialCheck().finally(resolve);
+      }, delay);
+    });
+  }
+
+  private runInitialCheck(): Promise<void> {
     return this.checkForPRs().finally(() => {
       this.scheduleNextPoll();
       this.scheduleRevalidation();
     });
   }
 
+  private clearStartupDelay(): void {
+    if (this.startupDelayTimer) {
+      clearTimeout(this.startupDelayTimer);
+      this.startupDelayTimer = null;
+    }
+    // Resolve a still-pending start() promise so callers awaiting it (e.g.
+    // PRIntegrationService.initialize) don't hang when stop()/reset() cancels
+    // the jitter before the first check runs.
+    if (this.startupDelayResolve) {
+      const resolve = this.startupDelayResolve;
+      this.startupDelayResolve = null;
+      resolve();
+    }
+  }
+
   public stop(): void {
+    this.clearStartupDelay();
     if (this.pollTimer) {
       clearTimeout(this.pollTimer);
       this.pollTimer = null;
@@ -282,6 +363,9 @@ class PullRequestService {
     // their CI status — which contradicts the "I want fresh data now"
     // semantics of a manual refresh.
     this.resolvedWorktrees.clear();
+    // Manual refresh is an explicit "I want fresh data now" — bypass the 5s
+    // floor by clearing the throttle clock before the direct checkForPRs().
+    this.lastCheckAt = Number.NEGATIVE_INFINITY;
     await this.checkForPRs();
 
     if (this.isPolling) {
@@ -301,6 +385,7 @@ class PullRequestService {
     this.nextRetryAt = 0;
     this.lastFocusCatchupAt = Number.NEGATIVE_INFINITY;
     this.boostExpiresAt = null;
+    this.lastCheckAt = Number.NEGATIVE_INFINITY;
   }
 
   /**
@@ -325,19 +410,20 @@ class PullRequestService {
       return;
     }
 
-    const now = Date.now();
-    if (now - this.lastFocusCatchupAt < FOCUS_CATCHUP_THROTTLE_MS) {
-      logDebug("Skipping PR focus catch-up — within throttle window", {
-        sinceLastMs: now - this.lastFocusCatchupAt,
-      });
-      return;
-    }
-
     if (!this.hasUnresolvedCandidates() || !this.isEnabled) {
       return;
     }
 
-    this.lastFocusCatchupAt = now;
+    // Cheap pre-filter against the shared 5s floor. checkForPRs() is the
+    // authoritative throttle gate (lesson #3333 — one guard at the choke
+    // point), but skipping the pollTimer clear/reschedule here avoids
+    // starving the poll loop when a user alt-tabs rapidly.
+    if (this.msUntilCheckAllowed() > 0) {
+      logDebug("Skipping PR focus catch-up — within throttle window", {
+        waitMs: this.msUntilCheckAllowed(),
+      });
+      return;
+    }
 
     // Cancel the scheduled poll and run an immediate check; the .finally
     // re-arms the timer at the new (focused) cadence. Avoids waiting up to
@@ -419,6 +505,11 @@ class PullRequestService {
       interval = computeBackoff(this.consecutiveErrors);
       logDebug("Using backoff interval", { errors: this.consecutiveErrors, intervalMs: interval });
     }
+
+    // computeBackoff can return sub-5s intervals; raise the next tick to the
+    // throttle boundary so the timer fires exactly when checkForPRs() would
+    // be admitted again, instead of churning through throttled no-op wakeups.
+    interval = Math.max(interval, this.msUntilCheckAllowed());
 
     this.pollTimer = setTimeout(() => {
       this.pollTimer = null;
@@ -656,6 +747,18 @@ class PullRequestService {
       logDebug("No candidates to check for PRs");
       return;
     }
+
+    // Shared 5s floor across all automatic trigger paths (startup, poll,
+    // backoff, focus catch-up, debounced branch-change). Manual refresh()
+    // bypasses by resetting lastCheckAt first. The clock advances only here —
+    // on an admitted real batch attempt — so skipped calls never push the
+    // window forward.
+    const waitMs = this.msUntilCheckAllowed();
+    if (waitMs > 0) {
+      logDebug("Skipping PR check — within throttle window", { waitMs });
+      return;
+    }
+    this.lastCheckAt = Date.now();
 
     logDebug("Checking PRs for candidates", { count: activeCandidates.length });
 

--- a/electron/services/PullRequestService.ts
+++ b/electron/services/PullRequestService.ts
@@ -216,6 +216,15 @@ class PullRequestService {
         return;
       }
 
+      // Startup jitter still pending: skip entirely. handleWorktreeUpdate
+      // already updated the candidate map synchronously, so the upcoming
+      // jittered initial check (runInitialCheck → checkForPRs) will pick
+      // this candidate up. Running here would bypass the jitter and recreate
+      // the synchronised post-restart burst (#8072).
+      if (this.startupDelayTimer !== null) {
+        return;
+      }
+
       // A branch-change recheck inside the 5s floor is deferred until the
       // floor clears rather than dropped to the next poll tick — keeps
       // branch switches responsive (≤5s) without bursting the API.

--- a/electron/services/__tests__/PullRequestService.test.ts
+++ b/electron/services/__tests__/PullRequestService.test.ts
@@ -1527,4 +1527,77 @@ describe("PullRequestService", () => {
 
     pullRequestService.destroy();
   });
+
+  it("does not bypass the startup jitter via a debounced worktree update", async () => {
+    const batchCheckLinkedPRs = vi.fn(async () => ({ results: new Map() }));
+    const clearPRCaches = vi.fn();
+    vi.doMock("../GitHubService.js", () => ({ batchCheckLinkedPRs, clearPRCaches }));
+
+    const { pullRequestService } = await import("../PullRequestService.js");
+    const { events } = await import("../events.js");
+
+    pullRequestService.initialize("/repo");
+    events.emit(
+      "sys:worktree:update",
+      makeWorktreeSnapshot({ worktreeId: "wt-1", branch: "feature/seed" })
+    );
+
+    const started = pullRequestService.start();
+
+    // A worktree update arrives during the jitter window (e.g. the
+    // WorkspaceService initial scan after a host restart) → 100ms debounce.
+    events.emit(
+      "sys:worktree:update",
+      makeWorktreeSnapshot({ worktreeId: "wt-2", branch: "feature/burst" })
+    );
+
+    // Past the debounce (100ms) but still inside the jitter floor (<500ms):
+    // the debounced check must defer to the pending jitter, not fire.
+    await vi.advanceTimersByTimeAsync(400);
+    expect(batchCheckLinkedPRs).not.toHaveBeenCalled();
+
+    // Once the jitter clears, a single initial check covers both candidates.
+    await vi.advanceTimersByTimeAsync(2500);
+    await started;
+    expect(batchCheckLinkedPRs).toHaveBeenCalledTimes(1);
+    expect(batchCheckLinkedPRs.mock.calls[0][1]).toEqual(
+      expect.arrayContaining([
+        expect.objectContaining({ worktreeId: "wt-1" }),
+        expect.objectContaining({ worktreeId: "wt-2" }),
+      ])
+    );
+
+    pullRequestService.destroy();
+  });
+
+  it("wires the normal poll timer after the jittered initial check", async () => {
+    const randomSpy = vi.spyOn(Math, "random").mockReturnValue(0); // jitter → 500ms
+    let callCount = 0;
+    const batchCheckLinkedPRs = vi.fn(async () => {
+      callCount++;
+      return { results: new Map() };
+    });
+    const clearPRCaches = vi.fn();
+    vi.doMock("../GitHubService.js", () => ({ batchCheckLinkedPRs, clearPRCaches }));
+
+    const { pullRequestService } = await import("../PullRequestService.js");
+    const { events } = await import("../events.js");
+
+    pullRequestService.initialize("/repo");
+    events.emit(
+      "sys:worktree:update",
+      makeWorktreeSnapshot({ worktreeId: "wt-1", branch: "feature/jitter-poll" })
+    );
+
+    const started = pullRequestService.start();
+    await vi.advanceTimersByTimeAsync(500);
+    await started;
+    expect(callCount).toBe(1); // jittered initial check
+
+    await vi.advanceTimersByTimeAsync(30 * 1000);
+    expect(callCount).toBe(2); // normal 30s poll wired in the jittered path
+
+    randomSpy.mockRestore();
+    pullRequestService.destroy();
+  });
 });

--- a/electron/services/__tests__/PullRequestService.test.ts
+++ b/electron/services/__tests__/PullRequestService.test.ts
@@ -1560,7 +1560,7 @@ describe("PullRequestService", () => {
     await vi.advanceTimersByTimeAsync(2500);
     await started;
     expect(batchCheckLinkedPRs).toHaveBeenCalledTimes(1);
-    expect(batchCheckLinkedPRs.mock.calls[0][1]).toEqual(
+    expect((batchCheckLinkedPRs.mock.calls[0] as unknown[])[1]).toEqual(
       expect.arrayContaining([
         expect.objectContaining({ worktreeId: "wt-1" }),
         expect.objectContaining({ worktreeId: "wt-2" }),

--- a/electron/services/__tests__/PullRequestService.test.ts
+++ b/electron/services/__tests__/PullRequestService.test.ts
@@ -187,7 +187,7 @@ describe("PullRequestService", () => {
       makeWorktreeSnapshot({ worktreeId: "wt-1", branch: "feature/test" })
     );
 
-    await pullRequestService.start();
+    await pullRequestService.start(0);
     expect(callCount).toBe(1);
 
     // Step through the first two backoff polls. Using
@@ -251,7 +251,7 @@ describe("PullRequestService", () => {
       makeWorktreeSnapshot({ worktreeId: "wt-1", branch: "feature/reval" })
     );
 
-    await pullRequestService.start();
+    await pullRequestService.start(0);
     // start() calls checkForPRs (resolves wt-1), then schedules revalidation
     expect(checkCallCount).toBe(1);
 
@@ -311,7 +311,7 @@ describe("PullRequestService", () => {
       makeWorktreeSnapshot({ worktreeId: "wt-1", branch: "feature/throw-test" })
     );
 
-    await pullRequestService.start();
+    await pullRequestService.start(0);
     expect(callCount).toBe(1);
 
     // Advance to the normal poll timer (30s focused default) — checkForPRs throws
@@ -396,7 +396,7 @@ describe("PullRequestService", () => {
       makeWorktreeSnapshot({ worktreeId: "wt-1", branch: "feature/reval-throw" })
     );
 
-    await pullRequestService.start();
+    await pullRequestService.start(0);
     expect(revalidationCallCount).toBe(1);
 
     // Advance 90s — first revalidation fires and throws
@@ -441,7 +441,7 @@ describe("PullRequestService", () => {
       "sys:worktree:update",
       makeWorktreeSnapshot({ worktreeId: "wt-1", branch: "feature/debounce-throw" })
     );
-    await pullRequestService.start();
+    await pullRequestService.start(0);
     expect(callCount).toBe(1);
 
     // Trigger a branch change to cause a debounced check
@@ -450,8 +450,10 @@ describe("PullRequestService", () => {
       makeWorktreeSnapshot({ worktreeId: "wt-1", branch: "feature/debounce-throw-2" })
     );
 
-    // Advance past debounce timer (100ms) to trigger the throwing checkForPRs
-    await vi.advanceTimersByTimeAsync(100);
+    // The debounce (100ms) lands inside the 5s floor opened by start(0)'s
+    // initial check, so it re-arms and the throwing checkForPRs only fires
+    // once the floor clears (~5s).
+    await vi.advanceTimersByTimeAsync(5000);
     expect(callCount).toBe(2);
     expect(logWarnMock).toHaveBeenCalledWith("PR check failed", {
       error: "Debounce kaboom",
@@ -581,7 +583,7 @@ describe("PullRequestService", () => {
       makeWorktreeSnapshot({ worktreeId: "wt-1", branch: "feature/cadence" })
     );
 
-    await pullRequestService.start();
+    await pullRequestService.start(0);
     expect(callCount).toBe(1);
 
     pullRequestService.setFocusCadence(false);
@@ -615,7 +617,7 @@ describe("PullRequestService", () => {
       makeWorktreeSnapshot({ worktreeId: "wt-1", branch: "feature/catchup" })
     );
 
-    await pullRequestService.start();
+    await pullRequestService.start(0);
     expect(callCount).toBe(1);
 
     // Blur, then focus — should immediately catch up
@@ -648,16 +650,20 @@ describe("PullRequestService", () => {
       makeWorktreeSnapshot({ worktreeId: "wt-1", branch: "feature/throttle" })
     );
 
-    await pullRequestService.start();
+    await pullRequestService.start(0);
     expect(callCount).toBe(1);
 
-    // First focus → catch-up fires
+    // start(0)'s initial check opened the 5s floor, so let it clear before
+    // exercising the focus catch-up throttle.
+    await vi.advanceTimersByTimeAsync(6 * 1000);
+
+    // First focus after the floor cleared → catch-up fires
     pullRequestService.setFocusCadence(false);
     pullRequestService.setFocusCadence(true);
     await vi.advanceTimersByTimeAsync(0);
     expect(callCount).toBe(2);
 
-    // Second blur→focus within 5s → no extra poll
+    // Second blur→focus within 5s of that catch-up → no extra poll
     await vi.advanceTimersByTimeAsync(2 * 1000);
     pullRequestService.setFocusCadence(false);
     pullRequestService.setFocusCadence(true);
@@ -691,7 +697,7 @@ describe("PullRequestService", () => {
     pullRequestService.setFocusCadence(false);
     expect(batchCheckLinkedPRs).not.toHaveBeenCalled();
 
-    await pullRequestService.start();
+    await pullRequestService.start(0);
     // start() preserves the blurred cadence set while idle
     expect(batchCheckLinkedPRs).toHaveBeenCalledTimes(1);
 
@@ -733,8 +739,12 @@ describe("PullRequestService", () => {
       makeWorktreeSnapshot({ worktreeId: "wt-1", branch: "feature/leak" })
     );
 
-    await pullRequestService.start();
+    await pullRequestService.start(0);
     expect(callCount).toBe(1);
+
+    // Clear the 5s floor opened by start(0)'s initial check so the focus
+    // catch-up below isn't throttled.
+    await vi.advanceTimersByTimeAsync(6 * 1000);
 
     // Focus regain — fires catch-up that hangs awaiting `resolveCheck`.
     pullRequestService.setFocusCadence(true);
@@ -756,7 +766,7 @@ describe("PullRequestService", () => {
     pullRequestService.destroy();
   });
 
-  it("polls at 30s by default after start() with no interval argument", async () => {
+  it("polls at the 30s focused cadence by default after start(0)", async () => {
     let callCount = 0;
     const batchCheckLinkedPRs = vi.fn(async () => {
       callCount++;
@@ -774,7 +784,7 @@ describe("PullRequestService", () => {
       makeWorktreeSnapshot({ worktreeId: "wt-1", branch: "feature/default" })
     );
 
-    await pullRequestService.start();
+    await pullRequestService.start(0);
     expect(callCount).toBe(1);
 
     // Under the old 60s clamp this would have required 60s
@@ -806,7 +816,7 @@ describe("PullRequestService", () => {
       makeWorktreeSnapshot({ worktreeId: "wt-1", branch: "feature/backoff" })
     );
 
-    await pullRequestService.start();
+    await pullRequestService.start(0);
     expect(pullRequestService.getStatus().consecutiveErrors).toBe(1);
 
     // Step two backoff polls to trip the circuit breaker.
@@ -867,10 +877,11 @@ describe("PullRequestService", () => {
       makeWorktreeSnapshot({ worktreeId: "wt-rev", branch: "feature/rev" })
     );
 
-    // start() schedules the revalidation timer (refresh() alone doesn't).
+    // start(0) schedules the revalidation timer (refresh() alone doesn't) and
+    // bypasses the startup jitter so the first check runs synchronously.
     // The first poll returns PENDING, so the adaptive boost activates and the
     // next revalidation fires at the 30s boosted cadence, not the 90s baseline.
-    await pullRequestService.start();
+    await pullRequestService.start(0);
     expect(detected.at(-1)?.prCiStatus).toBe("PENDING");
 
     // After CI flips to SUCCESS, the change-detection should re-emit.
@@ -966,7 +977,7 @@ describe("PullRequestService", () => {
       makeWorktreeSnapshot({ worktreeId: "wt-1", branch: "feature/boost" })
     );
 
-    await pullRequestService.start();
+    await pullRequestService.start(0);
     expect(checkCallCount).toBe(1);
 
     // 30s boosted revalidation fires because the first poll returned PENDING.
@@ -1017,7 +1028,7 @@ describe("PullRequestService", () => {
       makeWorktreeSnapshot({ worktreeId: "wt-1", branch: "feature/expected" })
     );
 
-    await pullRequestService.start();
+    await pullRequestService.start(0);
     expect(checkCallCount).toBe(1);
 
     await vi.advanceTimersByTimeAsync(30 * 1000);
@@ -1065,7 +1076,7 @@ describe("PullRequestService", () => {
       makeWorktreeSnapshot({ worktreeId: "wt-1", branch: "feature/decay" })
     );
 
-    await pullRequestService.start();
+    await pullRequestService.start(0);
     expect(checkCallCount).toBe(1); // initial check, PENDING → boost armed
 
     // 30s boosted reval fires, also returns PENDING (extends the boost).
@@ -1124,7 +1135,7 @@ describe("PullRequestService", () => {
       makeWorktreeSnapshot({ worktreeId: "wt-1", branch: "feature/green" })
     );
 
-    await pullRequestService.start();
+    await pullRequestService.start(0);
     expect(checkCallCount).toBe(1);
 
     // 30s should NOT fire a revalidation — boost is not armed for SUCCESS.
@@ -1185,7 +1196,7 @@ describe("PullRequestService", () => {
       makeWorktreeSnapshot({ worktreeId: "wt-1", branch: "feature/ceiling" })
     );
 
-    await pullRequestService.start();
+    await pullRequestService.start(0);
     expect(checkCallCount).toBe(1); // PENDING → boost armed, expires in 15 min
 
     // From here on, every revalidation returns result.error. The boost
@@ -1261,7 +1272,7 @@ describe("PullRequestService", () => {
       makeWorktreeSnapshot({ worktreeId: "wt-1", branch: "feature/refresh-clears-boost" })
     );
 
-    await pullRequestService.start();
+    await pullRequestService.start(0);
     expect(checkCallCount).toBe(1); // PENDING → boost armed
 
     // Flip CI to SUCCESS and refresh — refresh should clear the boost, run a
@@ -1318,7 +1329,7 @@ describe("PullRequestService", () => {
       makeWorktreeSnapshot({ worktreeId: "wt-1", branch: "feature/de-track" })
     );
 
-    await pullRequestService.start();
+    await pullRequestService.start(0);
     expect(checkCallCount).toBe(1); // PENDING → boost armed
 
     // Same branch, but the worktree is now the main worktree — de-track without
@@ -1384,7 +1395,7 @@ describe("PullRequestService", () => {
       makeWorktreeSnapshot({ worktreeId: "wt-1", branch: "feature/reset-clears-boost" })
     );
 
-    await pullRequestService.start();
+    await pullRequestService.start(0);
     expect(checkCallCount).toBe(1); // PENDING → boost armed
 
     // Reset wipes all state; restart with a non-pending result, the cadence
@@ -1396,7 +1407,7 @@ describe("PullRequestService", () => {
       "sys:worktree:update",
       makeWorktreeSnapshot({ worktreeId: "wt-2", branch: "feature/reset-clears-boost-2" })
     );
-    await pullRequestService.start();
+    await pullRequestService.start(0);
     expect(checkCallCount).toBe(2);
 
     // 30s after restart — no boost.
@@ -1406,6 +1417,113 @@ describe("PullRequestService", () => {
     // 90s after restart — baseline cadence.
     await vi.advanceTimersByTimeAsync(60 * 1000);
     expect(checkCallCount).toBe(3);
+
+    pullRequestService.destroy();
+  });
+
+  it("delays the first check by a randomised startup jitter (default start())", async () => {
+    const batchCheckLinkedPRs = vi.fn(async () => ({ results: new Map() }));
+    const clearPRCaches = vi.fn();
+    vi.doMock("../GitHubService.js", () => ({ batchCheckLinkedPRs, clearPRCaches }));
+
+    const { pullRequestService } = await import("../PullRequestService.js");
+    const { events } = await import("../events.js");
+
+    pullRequestService.initialize("/repo");
+    events.emit(
+      "sys:worktree:update",
+      makeWorktreeSnapshot({ worktreeId: "wt-1", branch: "feature/jitter" })
+    );
+
+    const started = pullRequestService.start();
+    // No synchronous burst — the post-restart fleet decorrelation guarantee.
+    expect(batchCheckLinkedPRs).not.toHaveBeenCalled();
+
+    // Below STARTUP_JITTER_MIN_MS (500ms) the check cannot have fired yet.
+    await vi.advanceTimersByTimeAsync(499);
+    expect(batchCheckLinkedPRs).not.toHaveBeenCalled();
+
+    // Past STARTUP_JITTER_MAX_MS (2500ms) it must have fired exactly once.
+    await vi.advanceTimersByTimeAsync(2500);
+    await started;
+    expect(batchCheckLinkedPRs).toHaveBeenCalledTimes(1);
+
+    pullRequestService.destroy();
+  });
+
+  it("stop() during the startup jitter cancels the check and resolves start()", async () => {
+    const batchCheckLinkedPRs = vi.fn(async () => ({ results: new Map() }));
+    const clearPRCaches = vi.fn();
+    vi.doMock("../GitHubService.js", () => ({ batchCheckLinkedPRs, clearPRCaches }));
+
+    const { pullRequestService } = await import("../PullRequestService.js");
+    const { events } = await import("../events.js");
+
+    pullRequestService.initialize("/repo");
+    events.emit(
+      "sys:worktree:update",
+      makeWorktreeSnapshot({ worktreeId: "wt-1", branch: "feature/jitter-stop" })
+    );
+
+    const started = pullRequestService.start();
+    pullRequestService.stop();
+
+    // start() must not hang when the pending jitter is cancelled.
+    await started;
+    await vi.advanceTimersByTimeAsync(5000);
+    expect(batchCheckLinkedPRs).not.toHaveBeenCalled();
+
+    pullRequestService.destroy();
+  });
+
+  it("reset() during the startup jitter cancels the check and resolves start()", async () => {
+    const batchCheckLinkedPRs = vi.fn(async () => ({ results: new Map() }));
+    const clearPRCaches = vi.fn();
+    vi.doMock("../GitHubService.js", () => ({ batchCheckLinkedPRs, clearPRCaches }));
+
+    const { pullRequestService } = await import("../PullRequestService.js");
+    const { events } = await import("../events.js");
+
+    pullRequestService.initialize("/repo");
+    events.emit(
+      "sys:worktree:update",
+      makeWorktreeSnapshot({ worktreeId: "wt-1", branch: "feature/jitter-reset" })
+    );
+
+    const started = pullRequestService.start();
+    pullRequestService.reset();
+
+    await started;
+    await vi.advanceTimersByTimeAsync(5000);
+    expect(batchCheckLinkedPRs).not.toHaveBeenCalled();
+
+    pullRequestService.destroy();
+  });
+
+  it("manual refresh() bypasses the 5s floor opened by the prior check", async () => {
+    let callCount = 0;
+    const batchCheckLinkedPRs = vi.fn(async () => {
+      callCount++;
+      return { results: new Map() };
+    });
+    const clearPRCaches = vi.fn();
+    vi.doMock("../GitHubService.js", () => ({ batchCheckLinkedPRs, clearPRCaches }));
+
+    const { pullRequestService } = await import("../PullRequestService.js");
+    const { events } = await import("../events.js");
+
+    pullRequestService.initialize("/repo");
+    events.emit(
+      "sys:worktree:update",
+      makeWorktreeSnapshot({ worktreeId: "wt-1", branch: "feature/refresh-bypass" })
+    );
+
+    await pullRequestService.start(0);
+    expect(callCount).toBe(1);
+
+    // Immediately (well inside the 5s floor) a manual refresh still runs.
+    await pullRequestService.refresh();
+    expect(callCount).toBe(2);
 
     pullRequestService.destroy();
   });

--- a/electron/workspace-host/PRIntegrationService.ts
+++ b/electron/workspace-host/PRIntegrationService.ts
@@ -5,7 +5,7 @@ import { GitHubAuth } from "../services/github/GitHubAuth.js";
 
 interface PullRequestServiceLike {
   initialize(rootPath: string): void;
-  start(): Promise<void>;
+  start(startupDelayMs?: number): Promise<void>;
   stop(): void;
   reset(): void;
   refresh(): Promise<void>;
@@ -161,7 +161,10 @@ export class PRIntegrationService {
   }
 
   resume(): void {
-    void this.prService.start();
+    // Focus-restore, not a crash-recovery path — skip the startup jitter so
+    // the user sees fresh PR state promptly. The 5s checkForPRs() floor still
+    // prevents a double-check if a poll just ran.
+    void this.prService.start(0);
   }
 
   updateToken(token: string | null, projectRootPath: string | null): void {

--- a/electron/workspace-host/__tests__/PRIntegrationService.test.ts
+++ b/electron/workspace-host/__tests__/PRIntegrationService.test.ts
@@ -41,7 +41,7 @@ describe("PRIntegrationService", () => {
   let callbacks: PRIntegrationCallbacks;
   interface PullRequestServiceLike {
     initialize(rootPath: string): void;
-    start(): Promise<void>;
+    start(startupDelayMs?: number): Promise<void>;
     stop(): void;
     reset(): void;
     refresh(): Promise<void>;
@@ -181,10 +181,12 @@ describe("PRIntegrationService", () => {
       expect(prServiceMock.stop).toHaveBeenCalledTimes(1);
     });
 
-    it("resume() starts the underlying service", () => {
+    it("resume() starts the underlying service with no startup jitter", () => {
       const service = new PRIntegrationService(prServiceMock, eventBus, callbacks);
       service.resume();
       expect(prServiceMock.start).toHaveBeenCalledTimes(1);
+      // Focus-restore is not a crash-recovery path — jitter is skipped.
+      expect(prServiceMock.start).toHaveBeenCalledWith(0);
     });
   });
 


### PR DESCRIPTION
## Summary

- `PullRequestService.start()` now waits a random 500–2500ms before the first `checkForPRs()` call, spreading out post-restart traffic across worktrees. The jitter is cancellable — `stop()` or `reset()` clears the pending timer, and `resume()` / focus-restore both call `start(0)` to skip it entirely.
- A unified 5-second throttle floor now covers all automatic `checkForPRs()` paths. `FOCUS_CATCHUP_THROTTLE_MS` and a single `lastCheckAt` field replace the narrower `lastFocusCatchupAt` idiom, applied at the choke point so no call site can slip through. Manual `refresh()` is explicitly unthrottled.
- Backoff is now clamped via `msUntilCheckAllowed()` to prevent no-progress churn when the floor and backoff intervals would otherwise stack. The branch-change debounce re-arms within the floor and skips while jitter is pending so the startup burst can't leak through that path either.

Resolves #8072

## Changes

- `electron/services/PullRequestService.ts` — startup jitter, unified throttle floor (`FOCUS_CATCHUP_THROTTLE_MS` / `lastCheckAt`), `msUntilCheckAllowed()` backoff clamp, debounce jitter-guard
- `electron/workspace-host/PRIntegrationService.ts` — `resume()` / focus-restore updated to call `start(0)`
- Tests updated to cover jitter, throttle, debounce-skip, and backoff-clamp behaviour

## Testing

- 38 unit tests pass (`npm run check` green)
- Jitter cancellation, throttle bypass via `refresh()`, debounce skip-while-jitter-pending, and backoff-floor clamping all have dedicated test cases

## Notes

One pre-existing minor: the circuit-breaker zeroes `consecutiveErrors` before the recovery check runs, meaning a service that just crossed the error threshold can immediately re-arm itself. Left unchanged — fixing it would alter circuit-breaker semantics in a way that's out of scope here. Worth a follow-up if the error pattern ever surfaces in practice.