### PR TITLE
feat(pulse): keep pulse panel current after first fetch

### DIFF
--- a/e2e/full/panels/core-pulse.spec.ts
+++ b/e2e/full/panels/core-pulse.spec.ts
@@ -62,6 +62,17 @@ test.describe.serial("Core: Project Pulse", () => {
     await expect(window.locator(SEL.pulse.heatmap)).toBeVisible({ timeout: T_MEDIUM });
   });
 
+  test("last-updated label is visible and triggers a refresh on click", async () => {
+    const { window } = ctx;
+    const lastUpdated = window.locator(SEL.pulse.lastUpdated);
+    await expect(lastUpdated).toBeVisible({ timeout: T_MEDIUM });
+    await expect(lastUpdated).toContainText(/Updated /, { timeout: T_SHORT });
+    await lastUpdated.click();
+    // Heatmap should remain visible after the click-driven refresh completes.
+    await expect(lastUpdated).toBeEnabled({ timeout: T_LONG });
+    await expect(window.locator(SEL.pulse.heatmap)).toBeVisible({ timeout: T_MEDIUM });
+  });
+
   test("settings toggle hides pulse card", async () => {
     const { window } = ctx;
 

--- a/e2e/helpers/selectors.ts
+++ b/e2e/helpers/selectors.ts
@@ -140,6 +140,7 @@ export const SEL = {
     heatmap: '[data-testid="pulse-heatmap"]',
     rangeTrigger: '[aria-label="Activity range"]',
     refreshButton: '[aria-label="Refresh"]',
+    lastUpdated: '[data-testid="pulse-last-updated"]',
   },
   reviewHub: {
     container: '[data-testid="review-hub"]',

--- a/electron/services/ProjectPulseService.ts
+++ b/electron/services/ProjectPulseService.ts
@@ -16,12 +16,27 @@ import type {
 interface CacheEntry {
   pulse: ProjectPulse;
   timestamp: number;
+  headSha: string | null;
 }
 
 const CACHE_TTL_MS = 60_000;
 const MAX_CACHE_SIZE = 100;
 const MAX_COMMITS_FOR_HEATMAP = 20_000;
 const VERBOSE_PROJECT_PULSE_LOGGING = process.env.DAINTREE_VERBOSE === "1";
+
+const NO_COMMITS_PATTERNS = [
+  "fatal: ambiguous argument 'head'",
+  "unknown revision",
+  "needed a single revision",
+  "does not have any commits yet",
+  "not a valid object name",
+  "bad default revision 'head'",
+];
+
+function isNoCommitsError(errorMessage: string): boolean {
+  const lower = errorMessage.toLowerCase();
+  return NO_COMMITS_PATTERNS.some((p) => lower.includes(p));
+}
 
 function logProjectPulseDebug(message: string, context?: Record<string, unknown>): void {
   if (!VERBOSE_PROJECT_PULSE_LOGGING) return;
@@ -103,8 +118,19 @@ export class ProjectPulseService {
     const cached = this.cache.get(cacheKey);
 
     if (!options.forceRefresh && cached && Date.now() - cached.timestamp < CACHE_TTL_MS) {
-      logProjectPulseDebug("ProjectPulse cache hit", { cacheKey });
-      return cached.pulse;
+      // Lightweight probe: if HEAD hasn't moved, serve the cached pulse.
+      // Falls through to recompute when the SHA differs so commits, rebases,
+      // and branch switches surface inside the TTL window.
+      const currentSha = await this.probeHeadSha(options.worktreePath);
+      if (currentSha === cached.headSha) {
+        logProjectPulseDebug("ProjectPulse cache hit", { cacheKey });
+        return cached.pulse;
+      }
+      logProjectPulseDebug("ProjectPulse SHA changed, recomputing", {
+        cacheKey,
+        cachedSha: cached.headSha,
+        currentSha,
+      });
     }
 
     const existing = this.inFlight.get(cacheKey);
@@ -121,9 +147,9 @@ export class ProjectPulseService {
 
     const promise = (async () => {
       try {
-        const pulse = await this.computePulse(options, controller!.signal);
+        const { pulse, headSha } = await this.computePulse(options, controller!.signal);
         if (!controller!.signal.aborted) {
-          this.cache.set(cacheKey, { pulse, timestamp: Date.now() });
+          this.cache.set(cacheKey, { pulse, timestamp: Date.now(), headSha });
           this.pruneCache();
         }
         return pulse;
@@ -154,10 +180,33 @@ export class ProjectPulseService {
     }
   }
 
+  // Reads HEAD with the shared no-commits taxonomy. Used by the cheap probe in
+  // getPulse — no signal so a pending invalidate can't abort the validity check
+  // and trick the caller into a needless recompute.
+  private async probeHeadSha(worktreePath: string): Promise<string | null> {
+    if (!existsSync(worktreePath)) {
+      return null;
+    }
+    try {
+      const git = createHardenedGit(worktreePath);
+      const out = await git.raw(["rev-parse", "--verify", "HEAD"]);
+      return out.trim() || null;
+    } catch (error) {
+      const message = formatErrorMessage(error, "Failed to probe git HEAD");
+      if (isNoCommitsError(message)) {
+        return null;
+      }
+      // Unexpected error: fall through to recompute rather than silently
+      // serving stale data.
+      logProjectPulseDebug("ProjectPulse HEAD probe failed", { worktreePath, error: message });
+      return "__probe-error__";
+    }
+  }
+
   private async computePulse(
     options: GetProjectPulseOptions,
     signal?: AbortSignal
-  ): Promise<ProjectPulse> {
+  ): Promise<{ pulse: ProjectPulse; headSha: string | null }> {
     const {
       worktreePath,
       worktreeId,
@@ -179,28 +228,22 @@ export class ProjectPulseService {
       throw new Error(`Not a git repository: ${worktreePath}`);
     }
 
+    let headSha: string | null;
     try {
-      await git.raw(["rev-parse", "--verify", "HEAD"]);
+      const headOut = await git.raw(["rev-parse", "--verify", "HEAD"]);
+      headSha = headOut.trim() || null;
     } catch (error) {
       const errorMessage = formatErrorMessage(error, "Failed to read git HEAD");
-      const noCommitsPatterns = [
-        "fatal: ambiguous argument 'HEAD'",
-        "unknown revision",
-        "needed a single revision",
-        "does not have any commits yet",
-        "not a valid object name",
-        "bad default revision 'HEAD'",
-      ];
-      if (noCommitsPatterns.some((p) => errorMessage.toLowerCase().includes(p.toLowerCase()))) {
+      if (isNoCommitsError(errorMessage)) {
         logProjectPulseDebug("Repository has no commits, returning empty pulse", { worktreeId });
-        return this.createEmptyPulse(options);
+        return { pulse: this.createEmptyPulse(options), headSha: null };
       }
       logError("Failed to get HEAD revision", {
         error: errorMessage,
         worktreeId,
         worktreePath,
       });
-      throw new Error(`Failed to read git HEAD: ${errorMessage}`);
+      throw new Error(`Failed to read git HEAD: ${errorMessage}`, { cause: error });
     }
 
     let branch: string | undefined;
@@ -287,7 +330,7 @@ export class ProjectPulseService {
       durationMs: Date.now() - startTime,
     });
 
-    return pulse;
+    return { pulse, headSha };
   }
 
   private async computeHeatmap(git: SimpleGit, rangeDays: PulseRangeDays): Promise<HeatCell[]> {

--- a/electron/services/ProjectPulseService.ts
+++ b/electron/services/ProjectPulseService.ts
@@ -17,7 +17,22 @@ interface CacheEntry {
   pulse: ProjectPulse;
   timestamp: number;
   headSha: string | null;
+  headBranch: string | undefined;
 }
+
+interface HeadProbeResult {
+  sha: string | null;
+  branch: string | undefined;
+}
+
+// Sentinel returned by probeHeadSha when the worktree path was deleted —
+// distinct from `null` (which means "valid repo with no commits"). Keeps the
+// equality check honest so a missing path doesn't silently match a cached
+// empty pulse.
+const PROBE_MISSING_PATH_SENTINEL = "__missing__";
+// Sentinel for unexpected probe errors. Never matches a cached SHA so the
+// caller always falls through to a real recompute (fail open to freshness).
+const PROBE_ERROR_SENTINEL = "__probe-error__";
 
 const CACHE_TTL_MS = 60_000;
 const MAX_CACHE_SIZE = 100;
@@ -118,18 +133,26 @@ export class ProjectPulseService {
     const cached = this.cache.get(cacheKey);
 
     if (!options.forceRefresh && cached && Date.now() - cached.timestamp < CACHE_TTL_MS) {
-      // Lightweight probe: if HEAD hasn't moved, serve the cached pulse.
-      // Falls through to recompute when the SHA differs so commits, rebases,
-      // and branch switches surface inside the TTL window.
-      const currentSha = await this.probeHeadSha(options.worktreePath);
-      if (currentSha === cached.headSha) {
+      // Lightweight probe: if HEAD and the current branch both still match
+      // the cached entry, serve the cache. Falls through to recompute when
+      // either changes so commits, rebases, AND branch switches (e.g.
+      // checkout to a new branch at the same SHA) surface inside the TTL.
+      const probe = await this.probeHead(options.worktreePath);
+      // Re-check the cache entry: invalidate() may have fired during the
+      // await above, deleting the entry. Use the freshly-fetched entry so
+      // we don't serve data that was just invalidated.
+      const fresh = this.cache.get(cacheKey);
+      if (fresh === cached && probe.sha === cached.headSha && probe.branch === cached.headBranch) {
         logProjectPulseDebug("ProjectPulse cache hit", { cacheKey });
         return cached.pulse;
       }
-      logProjectPulseDebug("ProjectPulse SHA changed, recomputing", {
+      logProjectPulseDebug("ProjectPulse cache invalidated by probe", {
         cacheKey,
         cachedSha: cached.headSha,
-        currentSha,
+        currentSha: probe.sha,
+        cachedBranch: cached.headBranch,
+        currentBranch: probe.branch,
+        entryStillPresent: fresh === cached,
       });
     }
 
@@ -147,9 +170,14 @@ export class ProjectPulseService {
 
     const promise = (async () => {
       try {
-        const { pulse, headSha } = await this.computePulse(options, controller!.signal);
+        const { pulse, headSha, headBranch } = await this.computePulse(options, controller!.signal);
         if (!controller!.signal.aborted) {
-          this.cache.set(cacheKey, { pulse, timestamp: Date.now(), headSha });
+          this.cache.set(cacheKey, {
+            pulse,
+            timestamp: Date.now(),
+            headSha,
+            headBranch,
+          });
           this.pruneCache();
         }
         return pulse;
@@ -180,33 +208,45 @@ export class ProjectPulseService {
     }
   }
 
-  // Reads HEAD with the shared no-commits taxonomy. Used by the cheap probe in
-  // getPulse — no signal so a pending invalidate can't abort the validity check
-  // and trick the caller into a needless recompute.
-  private async probeHeadSha(worktreePath: string): Promise<string | null> {
+  // Reads HEAD + current branch with the shared no-commits taxonomy. Used by
+  // the cheap probe in getPulse — no signal so a pending invalidate can't
+  // abort the validity check and trick the caller into a needless recompute.
+  private async probeHead(worktreePath: string): Promise<HeadProbeResult> {
     if (!existsSync(worktreePath)) {
-      return null;
+      // Distinct from no-commits null so a deleted worktree falls through to
+      // computePulse (which throws "Worktree path does not exist") instead of
+      // serving a stale empty-repo cache.
+      return { sha: PROBE_MISSING_PATH_SENTINEL, branch: undefined };
     }
     try {
       const git = createHardenedGit(worktreePath);
-      const out = await git.raw(["rev-parse", "--verify", "HEAD"]);
-      return out.trim() || null;
+      const shaOut = await git.raw(["rev-parse", "--verify", "HEAD"]);
+      const sha = shaOut.trim() || null;
+      let branch: string | undefined;
+      try {
+        const branchOut = await git.raw(["rev-parse", "--abbrev-ref", "HEAD"]);
+        const trimmed = branchOut.trim();
+        branch = trimmed === "HEAD" ? undefined : trimmed;
+      } catch {
+        branch = undefined;
+      }
+      return { sha, branch };
     } catch (error) {
       const message = formatErrorMessage(error, "Failed to probe git HEAD");
       if (isNoCommitsError(message)) {
-        return null;
+        return { sha: null, branch: undefined };
       }
       // Unexpected error: fall through to recompute rather than silently
       // serving stale data.
       logProjectPulseDebug("ProjectPulse HEAD probe failed", { worktreePath, error: message });
-      return "__probe-error__";
+      return { sha: PROBE_ERROR_SENTINEL, branch: undefined };
     }
   }
 
   private async computePulse(
     options: GetProjectPulseOptions,
     signal?: AbortSignal
-  ): Promise<{ pulse: ProjectPulse; headSha: string | null }> {
+  ): Promise<{ pulse: ProjectPulse; headSha: string | null; headBranch: string | undefined }> {
     const {
       worktreePath,
       worktreeId,
@@ -236,7 +276,7 @@ export class ProjectPulseService {
       const errorMessage = formatErrorMessage(error, "Failed to read git HEAD");
       if (isNoCommitsError(errorMessage)) {
         logProjectPulseDebug("Repository has no commits, returning empty pulse", { worktreeId });
-        return { pulse: this.createEmptyPulse(options), headSha: null };
+        return { pulse: this.createEmptyPulse(options), headSha: null, headBranch: undefined };
       }
       logError("Failed to get HEAD revision", {
         error: errorMessage,
@@ -330,7 +370,7 @@ export class ProjectPulseService {
       durationMs: Date.now() - startTime,
     });
 
-    return { pulse, headSha };
+    return { pulse, headSha, headBranch: branch };
   }
 
   private async computeHeatmap(git: SimpleGit, rangeDays: PulseRangeDays): Promise<HeatCell[]> {

--- a/electron/services/__tests__/ProjectPulseService.test.ts
+++ b/electron/services/__tests__/ProjectPulseService.test.ts
@@ -1,7 +1,12 @@
 import { describe, it, expect, vi, beforeEach, afterEach } from "vitest";
 
+// existsSync is a controllable vi.fn so tests that need the worktree path to
+// "disappear" mid-run can override it (see the path-missing recompute test).
+const { existsSyncMock } = vi.hoisted(() => ({
+  existsSyncMock: vi.fn(() => true),
+}));
 vi.mock("fs", () => ({
-  existsSync: () => true,
+  existsSync: existsSyncMock,
 }));
 
 type SimpleGitStub = {
@@ -20,12 +25,14 @@ describe("ProjectPulseService", () => {
   beforeEach(() => {
     vi.useFakeTimers();
     vi.setSystemTime(new Date("2025-01-15T12:00:00.000Z"));
+    existsSyncMock.mockReturnValue(true);
   });
 
   afterEach(() => {
     vi.useRealTimers();
     vi.resetModules();
     vi.clearAllMocks();
+    existsSyncMock.mockReturnValue(true);
   });
 
   it("dedupes concurrent requests with same cache key", async () => {
@@ -1034,6 +1041,149 @@ describe("ProjectPulseService", () => {
     expect(second.heatmap).toEqual(first.heatmap);
     // Only the probe runs — no recompute (which would call rev-parse again then bail).
     expect(raw.mock.calls.length).toBe(callsAfterFirst + 1);
+  });
+
+  it("recomputes when HEAD is unchanged but the branch has switched", async () => {
+    let currentBranch = "main";
+    const raw = vi.fn(async (args: string[]) => {
+      const cmd = args[0];
+      if (cmd === "rev-parse" && args[1] === "--verify" && args[2] === "HEAD") return "sha-aaa\n";
+      if (cmd === "rev-parse" && args.includes("--abbrev-ref")) return `${currentBranch}\n`;
+      if (cmd === "log") return "";
+      return "";
+    });
+
+    vi.doMock("../../utils/hardenedGit.js", () => ({
+      createHardenedGit: () => createGitStub(raw),
+    }));
+
+    const { ProjectPulseService } = await import("../ProjectPulseService.js");
+    const svc = new ProjectPulseService();
+
+    const opts = {
+      worktreePath: "/repo",
+      worktreeId: "wt-1",
+      mainBranch: "main",
+      rangeDays: 60 as const,
+      includeDelta: false,
+      includeRecentCommits: false,
+    };
+
+    await svc.getPulse(opts);
+    const heatmapCallsBefore = raw.mock.calls.filter(([args]) => {
+      const argv = args as string[];
+      return argv[0] === "log" && argv.some((a) => a.startsWith("--since="));
+    }).length;
+
+    // `git checkout -b feature` at the same commit: HEAD-SHA is unchanged but
+    // the branch name differs. Cache must invalidate so deltaToMain rebuilds.
+    currentBranch = "feature";
+    await svc.getPulse(opts);
+
+    const heatmapCallsAfter = raw.mock.calls.filter(([args]) => {
+      const argv = args as string[];
+      return argv[0] === "log" && argv.some((a) => a.startsWith("--since="));
+    }).length;
+    expect(heatmapCallsAfter).toBe(heatmapCallsBefore + 1);
+  });
+
+  it("re-checks cache entry after probe to avoid post-invalidation stale read", async () => {
+    let probeResolve: ((value: string) => void) | undefined;
+    const raw = vi.fn(async (args: string[]) => {
+      const cmd = args[0];
+      if (cmd === "rev-parse" && args[1] === "--verify" && args[2] === "HEAD") {
+        if (probeResolve) {
+          // Suspend the probe so invalidate() can fire mid-await.
+          return new Promise<string>((resolve) => {
+            probeResolve = resolve;
+          });
+        }
+        return "sha-aaa\n";
+      }
+      if (cmd === "rev-parse" && args.includes("--abbrev-ref")) return "main\n";
+      if (cmd === "log") return "";
+      return "";
+    });
+
+    vi.doMock("../../utils/hardenedGit.js", () => ({
+      createHardenedGit: () => createGitStub(raw),
+    }));
+
+    const { ProjectPulseService } = await import("../ProjectPulseService.js");
+    const svc = new ProjectPulseService();
+
+    const opts = {
+      worktreePath: "/repo",
+      worktreeId: "wt-1",
+      mainBranch: "main",
+      rangeDays: 60 as const,
+      includeDelta: false,
+      includeRecentCommits: false,
+    };
+
+    await svc.getPulse(opts);
+    const heatmapCallsBefore = raw.mock.calls.filter(([args]) => {
+      const argv = args as string[];
+      return argv[0] === "log" && argv.some((a) => a.startsWith("--since="));
+    }).length;
+
+    // Arm the probe to suspend on the next sha read.
+    probeResolve = () => {};
+
+    const pulsePromise = svc.getPulse(opts);
+    await vi.advanceTimersByTimeAsync(0);
+
+    // Probe is now suspended on the SHA call. Invalidate while it's in flight.
+    svc.invalidate("wt-1");
+
+    // Release the probe with the same SHA. Without the re-check guard, this
+    // would happily return the now-deleted cached pulse.
+    probeResolve!("sha-aaa\n");
+    probeResolve = undefined;
+
+    await pulsePromise;
+
+    // A recompute MUST have happened — the cached entry was invalidated.
+    const heatmapCallsAfter = raw.mock.calls.filter(([args]) => {
+      const argv = args as string[];
+      return argv[0] === "log" && argv.some((a) => a.startsWith("--since="));
+    }).length;
+    expect(heatmapCallsAfter).toBe(heatmapCallsBefore + 1);
+  });
+
+  it("falls through to recompute when the worktree path disappears", async () => {
+    const raw = vi.fn(async (args: string[]) => {
+      const cmd = args[0];
+      if (cmd === "rev-parse" && args[1] === "--verify" && args[2] === "HEAD")
+        throw new Error("fatal: ambiguous argument 'HEAD': unknown revision");
+      return "";
+    });
+
+    vi.doMock("../../utils/hardenedGit.js", () => ({
+      createHardenedGit: () => createGitStub(raw),
+    }));
+
+    const { ProjectPulseService } = await import("../ProjectPulseService.js");
+    const svc = new ProjectPulseService();
+
+    const opts = {
+      worktreePath: "/repo-gone",
+      worktreeId: "wt-vanish",
+      mainBranch: "main",
+      rangeDays: 60 as const,
+      includeDelta: false,
+      includeRecentCommits: false,
+    };
+
+    // First call: empty pulse cached with headSha=null.
+    await svc.getPulse(opts);
+
+    // Path disappears before second call. The probe must NOT return null and
+    // match the cached empty entry; it must signal "missing" so we recompute
+    // and surface the real error from computePulse.
+    existsSyncMock.mockReturnValue(false);
+
+    await expect(svc.getPulse(opts)).rejects.toThrow("Worktree path does not exist");
   });
 
   it("recomputes when HEAD-SHA probe throws an unexpected error", async () => {

--- a/electron/services/__tests__/ProjectPulseService.test.ts
+++ b/electron/services/__tests__/ProjectPulseService.test.ts
@@ -875,8 +875,14 @@ describe("ProjectPulseService", () => {
 
     svc.invalidate("wt-a");
 
-    // wt-a should recompute (cache miss), wt-b should still be cached
-    const logCallsAfter = raw.mock.calls.length;
+    // wt-a should recompute (cache miss), wt-b should still be cached.
+    // Track heatmap calls — the probe now adds a HEAD read on cache hit,
+    // so a raw-count assertion isn't the right shape anymore.
+    const heatmapCallsBefore = raw.mock.calls.filter(([args]) => {
+      const argv = args as string[];
+      return argv[0] === "log" && argv.some((a) => a.startsWith("--since="));
+    }).length;
+
     await svc.getPulse({
       worktreePath: "/repo-a",
       worktreeId: "wt-a",
@@ -885,10 +891,13 @@ describe("ProjectPulseService", () => {
       includeDelta: false,
       includeRecentCommits: false,
     });
-    // Additional raw calls for wt-a recompute
-    expect(raw.mock.calls.length).toBeGreaterThan(logCallsAfter);
 
-    const callsBeforeB = raw.mock.calls.length;
+    const heatmapCallsAfterA = raw.mock.calls.filter(([args]) => {
+      const argv = args as string[];
+      return argv[0] === "log" && argv.some((a) => a.startsWith("--since="));
+    }).length;
+    expect(heatmapCallsAfterA).toBe(heatmapCallsBefore + 1);
+
     await svc.getPulse({
       worktreePath: "/repo-b",
       worktreeId: "wt-b",
@@ -897,8 +906,183 @@ describe("ProjectPulseService", () => {
       includeDelta: false,
       includeRecentCommits: false,
     });
-    // No additional raw calls for wt-b — it was cached
-    expect(raw.mock.calls.length).toBe(callsBeforeB);
+
+    // wt-b was cached — probe matches, no heatmap recompute.
+    const heatmapCallsAfterB = raw.mock.calls.filter(([args]) => {
+      const argv = args as string[];
+      return argv[0] === "log" && argv.some((a) => a.startsWith("--since="));
+    }).length;
+    expect(heatmapCallsAfterB).toBe(heatmapCallsAfterA);
+  });
+
+  it("serves cached pulse when HEAD-SHA probe matches within TTL", async () => {
+    const raw = vi.fn(async (args: string[]) => {
+      const cmd = args[0];
+      if (cmd === "rev-parse" && args[1] === "--verify" && args[2] === "HEAD") return "sha-aaa\n";
+      if (cmd === "rev-parse" && args.includes("--abbrev-ref")) return "main\n";
+      if (cmd === "log") return "";
+      return "";
+    });
+
+    vi.doMock("../../utils/hardenedGit.js", () => ({
+      createHardenedGit: () => createGitStub(raw),
+    }));
+
+    const { ProjectPulseService } = await import("../ProjectPulseService.js");
+    const svc = new ProjectPulseService();
+
+    const opts = {
+      worktreePath: "/repo",
+      worktreeId: "wt-1",
+      mainBranch: "main",
+      rangeDays: 60 as const,
+      includeDelta: false,
+      includeRecentCommits: false,
+    };
+
+    await svc.getPulse(opts);
+    const heatmapCallsBefore = raw.mock.calls.filter(([args]) => {
+      const argv = args as string[];
+      return argv[0] === "log" && argv.some((a) => a.startsWith("--since="));
+    }).length;
+
+    // Second call within TTL — probe returns same SHA, cache hit served.
+    await svc.getPulse(opts);
+
+    const heatmapCallsAfter = raw.mock.calls.filter(([args]) => {
+      const argv = args as string[];
+      return argv[0] === "log" && argv.some((a) => a.startsWith("--since="));
+    }).length;
+    expect(heatmapCallsAfter).toBe(heatmapCallsBefore);
+  });
+
+  it("recomputes within TTL when HEAD-SHA has moved", async () => {
+    let currentSha = "sha-aaa";
+    const raw = vi.fn(async (args: string[]) => {
+      const cmd = args[0];
+      if (cmd === "rev-parse" && args[1] === "--verify" && args[2] === "HEAD")
+        return `${currentSha}\n`;
+      if (cmd === "rev-parse" && args.includes("--abbrev-ref")) return "main\n";
+      if (cmd === "log") return "";
+      return "";
+    });
+
+    vi.doMock("../../utils/hardenedGit.js", () => ({
+      createHardenedGit: () => createGitStub(raw),
+    }));
+
+    const { ProjectPulseService } = await import("../ProjectPulseService.js");
+    const svc = new ProjectPulseService();
+
+    const opts = {
+      worktreePath: "/repo",
+      worktreeId: "wt-1",
+      mainBranch: "main",
+      rangeDays: 60 as const,
+      includeDelta: false,
+      includeRecentCommits: false,
+    };
+
+    await svc.getPulse(opts);
+    const heatmapCallsBefore = raw.mock.calls.filter(([args]) => {
+      const argv = args as string[];
+      return argv[0] === "log" && argv.some((a) => a.startsWith("--since="));
+    }).length;
+
+    // HEAD moves — next call's probe sees mismatch, falls through to recompute.
+    currentSha = "sha-bbb";
+    await svc.getPulse(opts);
+
+    const heatmapCallsAfter = raw.mock.calls.filter(([args]) => {
+      const argv = args as string[];
+      return argv[0] === "log" && argv.some((a) => a.startsWith("--since="));
+    }).length;
+    expect(heatmapCallsAfter).toBe(heatmapCallsBefore + 1);
+  });
+
+  it("serves cached empty pulse when repo still has no commits", async () => {
+    const raw = vi.fn(async (args: string[]) => {
+      const cmd = args[0];
+      if (cmd === "rev-parse" && args[1] === "--verify" && args[2] === "HEAD")
+        throw new Error("fatal: ambiguous argument 'HEAD': unknown revision");
+      return "";
+    });
+
+    vi.doMock("../../utils/hardenedGit.js", () => ({
+      createHardenedGit: () => createGitStub(raw),
+    }));
+
+    const { ProjectPulseService } = await import("../ProjectPulseService.js");
+    const svc = new ProjectPulseService();
+
+    const opts = {
+      worktreePath: "/repo",
+      worktreeId: "wt-empty",
+      mainBranch: "main",
+      rangeDays: 60 as const,
+      includeDelta: false,
+      includeRecentCommits: false,
+    };
+
+    const first = await svc.getPulse(opts);
+    const callsAfterFirst = raw.mock.calls.length;
+
+    // Second call within TTL: probe also throws no-commits → null === null → serve cached.
+    const second = await svc.getPulse(opts);
+
+    expect(second.commitsInRange).toBe(0);
+    expect(second.heatmap).toEqual(first.heatmap);
+    // Only the probe runs — no recompute (which would call rev-parse again then bail).
+    expect(raw.mock.calls.length).toBe(callsAfterFirst + 1);
+  });
+
+  it("recomputes when HEAD-SHA probe throws an unexpected error", async () => {
+    let probeMode: "ok" | "throw" = "ok";
+    const raw = vi.fn(async (args: string[]) => {
+      const cmd = args[0];
+      if (cmd === "rev-parse" && args[1] === "--verify" && args[2] === "HEAD") {
+        if (probeMode === "throw") throw new Error("fatal: some unexpected git failure");
+        return "sha-aaa\n";
+      }
+      if (cmd === "rev-parse" && args.includes("--abbrev-ref")) return "main\n";
+      if (cmd === "log") return "";
+      return "";
+    });
+
+    vi.doMock("../../utils/hardenedGit.js", () => ({
+      createHardenedGit: () => createGitStub(raw),
+    }));
+
+    const { ProjectPulseService } = await import("../ProjectPulseService.js");
+    const svc = new ProjectPulseService();
+
+    const opts = {
+      worktreePath: "/repo",
+      worktreeId: "wt-1",
+      mainBranch: "main",
+      rangeDays: 60 as const,
+      includeDelta: false,
+      includeRecentCommits: false,
+    };
+
+    await svc.getPulse(opts);
+    const heatmapCallsBefore = raw.mock.calls.filter(([args]) => {
+      const argv = args as string[];
+      return argv[0] === "log" && argv.some((a) => a.startsWith("--since="));
+    }).length;
+
+    // Probe throws → fall through. computePulse will also throw (mock returns
+    // same behavior for both calls) so the call rejects; but we just want to
+    // verify it didn't short-circuit to the cached value.
+    probeMode = "throw";
+    await expect(svc.getPulse(opts)).rejects.toThrow();
+
+    // No new heatmap call (computePulse failed at HEAD), but we did go past the cache.
+    const heatmapCallsAfter = raw.mock.calls.filter(([args]) => {
+      const argv = args as string[];
+      return argv[0] === "log" && argv.some((a) => a.startsWith("--since="));
+    }).length;
+    expect(heatmapCallsAfter).toBe(heatmapCallsBefore);
   });
 
   it("getPulse creates a fresh controller after invalidation", async () => {

--- a/src/components/Pulse/ProjectPulseCard.tsx
+++ b/src/components/Pulse/ProjectPulseCard.tsx
@@ -25,7 +25,14 @@ import { Activity } from "@/components/icons";
 import { PulseHeatmap } from "./PulseHeatmap";
 import { PulseSummary } from "./PulseSummary";
 import { useProjectHealth } from "@/hooks/useProjectHealth";
+import { useGlobalMinuteTicker } from "@/hooks/useGlobalMinuteTicker";
 import { systemClient } from "@/clients/systemClient";
+import { formatTimeSince } from "@/components/Layout/FreshnessUtils";
+
+// Collapses paired window.focus + visibilitychange events that fire together
+// on restore-from-minimize. Short enough that legitimate user actions
+// (refocus after a few seconds away) still trigger a probe.
+const FOCUS_REFRESH_DEDUPE_MS = 500;
 
 interface ProjectPulseCardProps {
   worktreeId: string;
@@ -340,6 +347,8 @@ export function ProjectPulseCard({ worktreeId, className }: ProjectPulseCardProp
   const [refreshAnnouncement, setRefreshAnnouncement] = useState("");
   const wasLoadingRef = useRef(false);
   const hasEverLoadedRef = useRef(false);
+  const lastFocusProbeRef = useRef(0);
+  const minuteTick = useGlobalMinuteTicker();
   useEffect(() => {
     const hadPulse = !!pulse;
     if (isLoading && hadPulse) {
@@ -364,6 +373,26 @@ export function ProjectPulseCard({ worktreeId, className }: ProjectPulseCardProp
       fetchPulse(worktreeId);
     }
   }, [worktreeId, pulse, isLoading, error, fetchPulse]);
+
+  // Re-fetch when the window regains focus or the tab becomes visible. The
+  // service runs a HEAD-SHA probe under the 60s TTL, so non-forced requests
+  // stay cheap when nothing changed. Both events fire together on
+  // restore-from-minimize — the cooldown ref collapses them into one call.
+  useEffect(() => {
+    const handleFocusOrVisible = () => {
+      if (document.hidden) return;
+      const now = Date.now();
+      if (now - lastFocusProbeRef.current < FOCUS_REFRESH_DEDUPE_MS) return;
+      lastFocusProbeRef.current = now;
+      void fetchPulse(worktreeId);
+    };
+    window.addEventListener("focus", handleFocusOrVisible);
+    document.addEventListener("visibilitychange", handleFocusOrVisible);
+    return () => {
+      window.removeEventListener("focus", handleFocusOrVisible);
+      document.removeEventListener("visibilitychange", handleFocusOrVisible);
+    };
+  }, [worktreeId, fetchPulse]);
 
   const handleRefresh = useCallback(() => {
     fetchPulse(worktreeId, true);
@@ -474,6 +503,11 @@ export function ProjectPulseCard({ worktreeId, className }: ProjectPulseCardProp
     return null;
   }
 
+  // minuteTick is read so the freshness label re-renders on each 30s tick.
+  // useGlobalMinuteTicker pauses while hidden and emits on visibility restore.
+  void minuteTick;
+  const updatedLabel = formatTimeSince(pulse.generatedAt, Date.now());
+
   return (
     <div
       className={cn(
@@ -563,6 +597,16 @@ export function ProjectPulseCard({ worktreeId, className }: ProjectPulseCardProp
 
         <div className="border-t border-daintree-border pt-3">
           <PulseSummary pulse={pulse} />
+          <button
+            type="button"
+            onClick={handleRefresh}
+            disabled={isLoading}
+            className="pulse-control mt-2 inline-flex items-center text-[11px] text-daintree-text/55 transition-colors hover:text-daintree-text/80 disabled:opacity-50 disabled:pointer-events-none"
+            aria-label={`Refresh — last updated ${updatedLabel}`}
+            data-testid="pulse-last-updated"
+          >
+            <span>Updated {updatedLabel}</span>
+          </button>
         </div>
       </div>
     </div>


### PR DESCRIPTION
The pulse panel cached its data after the first fetch and never refreshed it. New commits, branch switches, rebases, and cherry-picks all went undetected until the user removed the worktree or switched projects.

Resolves #8077.

## Changes

**`ProjectPulseService`** — adds SHA and branch tracking to the cache entry. On every TTL-valid cache hit, `probeHead()` runs `rev-parse --verify HEAD` and `rev-parse --abbrev-ref HEAD` against the worktree. Any mismatch falls through to the existing `inFlight`/abort path and triggers a recompute. Distinct sentinels for path-missing, no-commits, and probe-error keep cache invariants correct. A second `cache.get()` after the await guards against a concurrent invalidation completing mid-probe.

**`ProjectPulseCard`** — registers `window.focus` and `document.visibilitychange` listeners on mount. A 500ms cooldown ref collapses the paired events you get on restore-from-minimize. Each trigger calls `fetchPulse(worktreeId)` without forcing, so the SHA probe gates any real recompute. A "Updated N ago" button rendered below `PulseSummary` force-refreshes on click; `useGlobalMinuteTicker` keeps the label live and pauses while the document is hidden.

**Tests** — 6 new unit tests in `ProjectPulseService.test.ts` covering same-SHA cache hit, SHA-mismatch recompute, branch-switch recompute, probe+invalidate race, path-missing fall-through, and probe-error recompute. New smoke test in `e2e/full/panels/core-pulse.spec.ts` asserts the last-updated button is visible and triggers a refresh on click.

## Testing

- Unit tests: `npm run test -- ProjectPulseService`
- E2E smoke: `npx playwright test e2e/full/panels/core-pulse.spec.ts`
- Manual: open a worktree pulse panel, make a commit in the worktree, alt-tab away and back — panel refreshes without a manual click