### PR TITLE
feat(layout): add ErrorsContainer toolbar pill for silent pane failures

### DIFF
--- a/src/components/Layout/ContentDock.tsx
+++ b/src/components/Layout/ContentDock.tsx
@@ -16,6 +16,7 @@ import { DockedTerminalItem } from "./DockedTerminalItem";
 import { DockedTabGroup } from "./DockedTabGroup";
 import { TrashContainer } from "./TrashContainer";
 import { WaitingContainer } from "./WaitingContainer";
+import { ErrorsContainer } from "./ErrorsContainer";
 import { BackgroundContainer } from "./BackgroundContainer";
 import { DockLaunchButton } from "./DockLaunchButton";
 import {
@@ -360,10 +361,11 @@ export function ContentDock({ density = "normal" }: ContentDockProps) {
             <div className="w-px h-5 bg-[var(--dock-border)] mx-1 shrink-0" />
           )}
 
-          {/* Action containers: Background + Waiting + Trash */}
+          {/* Action containers: Background + Waiting + Errors + Trash */}
           <div className="shrink-0 pl-1 flex items-center gap-2">
             <BackgroundContainer compact={isCompact} />
             <WaitingContainer compact={isCompact} />
+            <ErrorsContainer compact={isCompact} />
             <TrashContainer trashedTerminals={trashedItems} compact={isCompact} />
           </div>
         </div>

--- a/src/components/Layout/ErrorsContainer.tsx
+++ b/src/components/Layout/ErrorsContainer.tsx
@@ -1,0 +1,24 @@
+import { useErrorTerminals } from "@/hooks/useTerminalSelectors";
+import { STATE_ICONS } from "@/components/Worktree/terminalStateConfig";
+import { StatusContainer, type StatusContainerConfig } from "./StatusContainer";
+
+const errorsConfig: StatusContainerConfig = {
+  icon: STATE_ICONS.exited,
+  iconColor: "text-status-error",
+  badgeColor: "bg-status-error",
+  badgeTextColor: "text-daintree-bg",
+  headerLabel: "Errored agents",
+  buttonLabel: "Errors",
+  statusAriaLabel: "Exited with error",
+  contentAriaLabel: "Errored terminals",
+  contentId: "errors-container-popover",
+};
+
+interface ErrorsContainerProps {
+  compact?: boolean;
+}
+
+export function ErrorsContainer({ compact = false }: ErrorsContainerProps) {
+  const terminals = useErrorTerminals();
+  return <StatusContainer config={errorsConfig} terminals={terminals} compact={compact} />;
+}

--- a/src/components/Layout/__tests__/ErrorsContainer.test.tsx
+++ b/src/components/Layout/__tests__/ErrorsContainer.test.tsx
@@ -1,0 +1,101 @@
+// @vitest-environment jsdom
+import { describe, it, expect, vi } from "vitest";
+import { render } from "@testing-library/react";
+import { ErrorsContainer } from "../ErrorsContainer";
+import type { TerminalInstance } from "@/store/panelStore";
+
+const mockErrored: TerminalInstance[] = [
+  {
+    id: "t1",
+    title: "Agent 1",
+    type: "claude",
+    kind: "terminal",
+    worktreeId: "w1",
+    location: "grid",
+    agentState: "exited",
+    exitCode: 1,
+  } as TerminalInstance,
+];
+
+vi.mock("@/hooks/useTerminalSelectors", () => ({
+  useErrorTerminals: () => mockErrored,
+}));
+
+vi.mock("@/store/panelStore", async () => {
+  const { create } = await import("zustand");
+  const store = create(() => ({
+    activateTerminal: vi.fn(),
+    pingTerminal: vi.fn(),
+  }));
+  return { usePanelStore: store };
+});
+
+vi.mock("@/store/worktreeStore", async () => {
+  const { create } = await import("zustand");
+  const store = create(() => ({
+    activeWorktreeId: null,
+    selectWorktree: vi.fn(),
+    trackTerminalFocus: vi.fn(),
+  }));
+  return { useWorktreeSelectionStore: store };
+});
+
+vi.mock("@/components/ui/popover", () => ({
+  Popover: ({ children }: { children: React.ReactNode }) => <div>{children}</div>,
+  PopoverTrigger: ({ children }: { children: React.ReactNode }) => <div>{children}</div>,
+  PopoverContent: ({ children }: { children: React.ReactNode }) => <div>{children}</div>,
+}));
+
+vi.mock("@/components/ui/button", () => ({
+  Button: ({
+    children,
+    ...props
+  }: { children: React.ReactNode } & React.HTMLAttributes<HTMLButtonElement>) => (
+    <button {...props}>{children}</button>
+  ),
+}));
+
+vi.mock("@/components/ui/tooltip", () => ({
+  Tooltip: ({ children }: { children: React.ReactNode }) => <div>{children}</div>,
+  TooltipContent: ({ children }: { children: React.ReactNode }) => <div>{children}</div>,
+  TooltipProvider: ({ children }: { children: React.ReactNode }) => <div>{children}</div>,
+  TooltipTrigger: ({ children }: { children: React.ReactNode }) => <div>{children}</div>,
+}));
+
+vi.mock("@/components/Terminal/TerminalIcon", () => ({
+  TerminalIcon: () => <span data-testid="terminal-icon" />,
+}));
+
+describe("ErrorsContainer icon", () => {
+  it("renders ExitedCircle (circle with horizontal dash) for errored terminals", () => {
+    const { container } = render(<ErrorsContainer />);
+    const svgs = container.querySelectorAll("svg");
+    expect(svgs.length).toBeGreaterThan(0);
+
+    // ExitedCircle has a circle + a single horizontal line (cx=8, cy=8, r=6;
+    // line at y=8). Distinguishes it from HollowCircle (circle only) and
+    // InteractingCircle (circle + cross).
+    const hasExitedCircle = Array.from(svgs).some((svg) => {
+      const circles = svg.querySelectorAll("circle");
+      const lines = svg.querySelectorAll("line");
+      if (circles.length !== 1) return false;
+      if (lines.length !== 1) return false;
+      const circle = circles[0]!;
+      const line = lines[0]!;
+      return (
+        circle.getAttribute("cx") === "8" &&
+        circle.getAttribute("cy") === "8" &&
+        circle.getAttribute("r") === "6" &&
+        line.getAttribute("y1") === "8" &&
+        line.getAttribute("y2") === "8"
+      );
+    });
+    expect(hasExitedCircle).toBe(true);
+  });
+
+  it("uses the error-status color tokens on the pill icon", () => {
+    const { container } = render(<ErrorsContainer />);
+    const errorIcon = container.querySelector("svg.text-status-error");
+    expect(errorIcon).not.toBeNull();
+  });
+});

--- a/src/components/Layout/index.ts
+++ b/src/components/Layout/index.ts
@@ -2,5 +2,6 @@ export { AppLayout } from "./AppLayout";
 export { Toolbar } from "./Toolbar";
 export { Sidebar } from "./Sidebar";
 export { WaitingContainer } from "./WaitingContainer";
+export { ErrorsContainer } from "./ErrorsContainer";
 export { AgentButton } from "./AgentButton";
 export { ChordIndicator } from "./ChordIndicator";

--- a/src/hooks/__tests__/useTerminalSelectors.test.tsx
+++ b/src/hooks/__tests__/useTerminalSelectors.test.tsx
@@ -507,6 +507,27 @@ describe("useErrorTerminals", () => {
     const { result } = renderHook(() => useErrorTerminals());
     expect(result.current).toEqual([]);
   });
+
+  it("excludes orphaned errored terminals when worktree IDs are known", () => {
+    const worktrees = new Map([["wt-1", { worktreeId: "wt-1" }]]);
+    setupBoth(
+      [
+        { id: "t-live", agentState: "exited", location: "grid", exitCode: 1, worktreeId: "wt-1" },
+        {
+          id: "t-orphan",
+          agentState: "exited",
+          location: "grid",
+          exitCode: 1,
+          worktreeId: "wt-gone",
+        },
+      ],
+      worktrees
+    );
+
+    const { result } = renderHook(() => useErrorTerminals());
+    expect(result.current).toHaveLength(1);
+    expect(result.current[0]!.id).toBe("t-live");
+  });
 });
 
 function setupWorktreesWithChanges(

--- a/src/hooks/__tests__/useTerminalSelectors.test.tsx
+++ b/src/hooks/__tests__/useTerminalSelectors.test.tsx
@@ -20,6 +20,7 @@ import {
   useConflictedWorktrees,
   useWaitingTerminals,
   useBackgroundedTerminals,
+  useErrorTerminals,
   useWaitingTerminalIds,
   isTerminalVisible,
   isTerminalOrphaned,
@@ -42,6 +43,8 @@ function setupTerminals(
     agentState?: string;
     location?: string;
     lastStateChange?: number;
+    exitCode?: number;
+    hasPty?: boolean;
   }>
 ) {
   const state = {
@@ -67,6 +70,8 @@ function setupBoth(
     agentState?: string;
     location?: string;
     lastStateChange?: number;
+    exitCode?: number;
+    hasPty?: boolean;
   }>,
   worktrees?: Map<string, { worktreeId?: string }>
 ) {
@@ -441,6 +446,66 @@ describe("useBackgroundedTerminals", () => {
     const { result } = renderHook(() => useBackgroundedTerminals());
     expect(result.current).toHaveLength(1);
     expect(result.current[0]!.id).toBe("t1");
+  });
+});
+
+describe("useErrorTerminals", () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+    _resetWorktreeIdCacheForTests();
+  });
+
+  it("returns terminals that exited with a non-zero exit code", () => {
+    setupBoth([
+      { id: "t-error", agentState: "exited", location: "grid", exitCode: 1 },
+      { id: "t-clean", agentState: "exited", location: "grid", exitCode: 0 },
+      { id: "t-running", agentState: "working", location: "grid" },
+      { id: "t-waiting", agentState: "waiting", location: "grid" },
+    ]);
+
+    const { result } = renderHook(() => useErrorTerminals());
+    expect(result.current.map((t) => t.id)).toEqual(["t-error"]);
+  });
+
+  it("excludes exited terminals without a numeric exitCode", () => {
+    setupBoth([
+      { id: "t-noexit", agentState: "exited", location: "grid" },
+      { id: "t-error", agentState: "exited", location: "grid", exitCode: 1 },
+    ]);
+
+    const { result } = renderHook(() => useErrorTerminals());
+    expect(result.current).toHaveLength(1);
+    expect(result.current[0]!.id).toBe("t-error");
+  });
+
+  it("excludes errored terminals in trash, background, or dock", () => {
+    setupBoth([
+      { id: "t-grid", agentState: "exited", location: "grid", exitCode: 1 },
+      { id: "t-trash", agentState: "exited", location: "trash", exitCode: 1 },
+      { id: "t-bg", agentState: "exited", location: "background", exitCode: 1 },
+      { id: "t-dock", agentState: "exited", location: "dock", exitCode: 1 },
+    ]);
+
+    const { result } = renderHook(() => useErrorTerminals());
+    expect(result.current.map((t) => t.id)).toEqual(["t-grid"]);
+  });
+
+  it("excludes terminals where hasPty is explicitly false", () => {
+    setupBoth([
+      { id: "t-ok", agentState: "exited", location: "grid", exitCode: 1 },
+      { id: "t-nopty", agentState: "exited", location: "grid", exitCode: 1, hasPty: false },
+    ]);
+
+    const { result } = renderHook(() => useErrorTerminals());
+    expect(result.current).toHaveLength(1);
+    expect(result.current[0]!.id).toBe("t-ok");
+  });
+
+  it("returns an empty array when no terminals match", () => {
+    setupBoth([{ id: "t1", agentState: "working", location: "grid" }]);
+
+    const { result } = renderHook(() => useErrorTerminals());
+    expect(result.current).toEqual([]);
   });
 });
 

--- a/src/hooks/useTerminalSelectors.ts
+++ b/src/hooks/useTerminalSelectors.ts
@@ -103,6 +103,8 @@ export function useWaitingTerminalIds(): string[] {
 }
 
 export function useErrorTerminals(): TerminalInstance[] {
+  const worktreeIds = useWorktreeIds();
+
   return usePanelStore(
     useShallow((state) => {
       const out: TerminalInstance[] = [];
@@ -111,6 +113,11 @@ export function useErrorTerminals(): TerminalInstance[] {
         if (!t) continue;
         if (t.agentState !== "exited") continue;
         if (typeof t.exitCode !== "number" || t.exitCode === 0) continue;
+        // isTerminalVisible rejects trash/background/ephemeral/orphaned;
+        // isTerminalErrorClusterEligible adds the dock-location exclusion.
+        // Without the orphan gate, clicking an entry from a deleted worktree
+        // would call selectWorktree() on a stale ID and persist it.
+        if (!isTerminalVisible(t, state.isInTrash, worktreeIds)) continue;
         if (!isTerminalErrorClusterEligible(t)) continue;
         out.push(t);
       }

--- a/src/hooks/useTerminalSelectors.ts
+++ b/src/hooks/useTerminalSelectors.ts
@@ -4,6 +4,7 @@ import { usePanelStore, type TerminalInstance } from "@/store/panelStore";
 import { useWorktreeStore } from "@/hooks/useWorktreeStore";
 import type { WorktreeSnapshot } from "@shared/types";
 import { isTerminalOrphaned, isTerminalVisible } from "@/lib/terminalVisibility";
+import { isTerminalErrorClusterEligible } from "@/store/fleetEligibility";
 export { isTerminalOrphaned, isTerminalVisible };
 
 let _cachedWorktrees: Map<string, WorktreeSnapshot> | null = null;
@@ -99,6 +100,23 @@ export function useWaitingTerminals(): TerminalInstance[] {
 export function useWaitingTerminalIds(): string[] {
   const waiting = useWaitingTerminals();
   return useMemo(() => waiting.map((t) => t.id), [waiting]);
+}
+
+export function useErrorTerminals(): TerminalInstance[] {
+  return usePanelStore(
+    useShallow((state) => {
+      const out: TerminalInstance[] = [];
+      for (const id of state.panelIds) {
+        const t = state.panelsById[id];
+        if (!t) continue;
+        if (t.agentState !== "exited") continue;
+        if (typeof t.exitCode !== "number" || t.exitCode === 0) continue;
+        if (!isTerminalErrorClusterEligible(t)) continue;
+        out.push(t);
+      }
+      return out;
+    })
+  );
 }
 
 export function useBackgroundedTerminals(): TerminalInstance[] {


### PR DESCRIPTION
## Summary

A terminal that exits with a non-zero code today is silent — the pane stays visible, but nothing in the toolbar tells you anything went wrong. If you weren't watching, you don't know. This PR adds an `ErrorsContainer` pill alongside the existing `BackgroundContainer` / `WaitingContainer` / `TrashContainer` family in `ContentDock`, surfacing those errored panes one click away.

- New thin-wrapper component over `StatusContainer` — exited-circle icon, `text-status-error` / `bg-status-error` tokens, popover lists the errored panes and routes back to them on click.
- New `useErrorTerminals` selector in `useTerminalSelectors.ts`. Predicate matches the `useAgentClusters` error-bucket definition: `agentState === "exited" && exitCode !== 0 && isTerminalErrorClusterEligible(t)`, additionally gated on `isTerminalVisible` so orphaned terminals from deleted worktrees don't appear (and don't get clicked through to a stale `selectWorktree(orphanedId)`, which would corrupt the persisted active worktree).
- Placed between `WaitingContainer` and `TrashContainer` in `ContentDock`; exported from the Layout barrel.

### Scope decisions

- **`spawnError`, `restartError`, `runtimeStatus === "error"` are intentionally NOT in the predicate.** Those failures already have inline pane banners (`SpawnErrorBanner`, `TerminalRestartStatusBanner`) — they are not silent. Doubling them into a toolbar count would be noise.
- **OS dock badge integration is deferred to a follow-up.** Wiring `errorCount` through `useTerminalNotificationCounts` → preload → `NotificationService` is a parallel signal surface and an electron-main-side change. Worth doing, but separately — the toolbar pill is the in-app surface this issue asks for.

## Test plan

- [x] `npx vitest run src/hooks/__tests__/useTerminalSelectors.test.tsx src/components/Layout/__tests__/ErrorsContainer.test.tsx` — 6 new predicate tests (positive case, `exitCode === 0` excluded, missing `exitCode` excluded, dock/trash/background excluded, `hasPty === false` excluded, orphan excluded, empty result) + 2 component tests (ExitedCircle SVG shape, `text-status-error` token applied).
- [x] `npx tsc --noEmit` clean
- [x] `npm run check:channels`, `check:ipc`, `check:help`, `lint:ratchet`, `format:check` all clean
- [ ] Manual: exit a terminal with `exit 1`, confirm pill appears with the right count and the popover entry routes back to the pane.
- [ ] Manual: delete the worktree containing an errored pane, confirm the count drops (orphan gate working).

Closes #8089