### PR TITLE
feat(worktree): show circuit-breaker state on PR badges

### DIFF
--- a/electron/services/PullRequestService.ts
+++ b/electron/services/PullRequestService.ts
@@ -95,6 +95,11 @@ class PullRequestService {
   private isPolling: boolean = false;
   private consecutiveErrors: number = 0;
   private nextRetryAt: number = 0;
+  // Tracks whether we've told the renderer the breaker is tripped. Decoupled
+  // from `nextRetryAt`/`isEnabled` so a rate-limit pause never reads as a
+  // circuit-breaker trip, and so the trip/recovery events stay perfectly
+  // paired across every reset path (recovery poll, manual refresh, reset).
+  private circuitBreakerTripped: boolean = false;
   private boostExpiresAt: number | null = null;
   private lastCheckAt: number = Number.NEGATIVE_INFINITY;
   private startupDelayTimer: NodeJS.Timeout | null = null;
@@ -393,6 +398,9 @@ class PullRequestService {
     this.nextRetryAt = 0;
     this.boostExpiresAt = null;
     this.lastCheckAt = Number.NEGATIVE_INFINITY;
+    // Service is being torn down / re-pointed — clear any tripped state so a
+    // stale errored badge doesn't outlive the project it belonged to.
+    this.setCircuitBreakerState(false);
   }
 
   /**
@@ -492,9 +500,12 @@ class PullRequestService {
           this.pollTimer = null;
           if (!this.isPolling) return;
           logDebug("Circuit breaker recovery - running immediate check");
+          // Reset counters so `isEnabled` is true and the check actually runs,
+          // but DON'T clear the renderer state here — a recovery check that
+          // fails again would briefly flash badges healthy. The breaker state
+          // is cleared only on a genuinely successful check (see checkForPRs).
           this.consecutiveErrors = 0;
           this.nextRetryAt = 0;
-          events.emit("sys:pr:detection-paused", { tripped: false });
           void this.checkForPRs()
             .catch((err) => this.handleError(formatErrorMessage(err, "PR check failed")))
             .finally(() => this.scheduleNextPoll());
@@ -779,6 +790,10 @@ class PullRequestService {
       }
 
       this.consecutiveErrors = 0;
+      // A successful batch check is the canonical "detection is working
+      // again" signal — covers the recovery poll, manual refresh, and focus
+      // catch-up paths in one place. Idempotent when never tripped.
+      this.setCircuitBreakerState(false);
 
       for (const [worktreeId, checkResult] of result.results) {
         const lookupBranch = lookupBranchByWorktreeId.get(worktreeId);
@@ -831,6 +846,15 @@ class PullRequestService {
     }
   }
 
+  // Single source of truth for the renderer-visible breaker state. Idempotent:
+  // only emits on an actual transition, so repeated trips (4th+ error) and
+  // every reset path stay paired without duplicate or orphaned events.
+  private setCircuitBreakerState(tripped: boolean): void {
+    if (this.circuitBreakerTripped === tripped) return;
+    this.circuitBreakerTripped = tripped;
+    events.emit("sys:pr:detection-paused", { tripped });
+  }
+
   private handleError(
     errorMsg: string,
     rateLimit?: { kind: "primary" | "secondary"; resumeAt: number }
@@ -862,7 +886,7 @@ class PullRequestService {
         message: "PR detection paused due to errors. Will retry automatically.",
         id: "pr-service-circuit-breaker",
       });
-      events.emit("sys:pr:detection-paused", { tripped: true });
+      this.setCircuitBreakerState(true);
     }
   }
 

--- a/electron/services/PullRequestService.ts
+++ b/electron/services/PullRequestService.ts
@@ -494,6 +494,7 @@ class PullRequestService {
           logDebug("Circuit breaker recovery - running immediate check");
           this.consecutiveErrors = 0;
           this.nextRetryAt = 0;
+          events.emit("sys:pr:detection-paused", { tripped: false });
           void this.checkForPRs()
             .catch((err) => this.handleError(formatErrorMessage(err, "PR check failed")))
             .finally(() => this.scheduleNextPoll());
@@ -852,7 +853,7 @@ class PullRequestService {
     this.consecutiveErrors++;
     logWarn("PR check failed", { error: errorMsg, consecutiveErrors: this.consecutiveErrors });
 
-    if (this.consecutiveErrors >= MAX_CONSECUTIVE_ERRORS) {
+    if (this.consecutiveErrors === MAX_CONSECUTIVE_ERRORS) {
       const backoffMs = computeBackoff(this.consecutiveErrors);
       this.nextRetryAt = Date.now() + backoffMs;
       logWarn("Too many consecutive errors - pausing PR polling", { retryInMs: backoffMs });
@@ -861,6 +862,7 @@ class PullRequestService {
         message: "PR detection paused due to errors. Will retry automatically.",
         id: "pr-service-circuit-breaker",
       });
+      events.emit("sys:pr:detection-paused", { tripped: true });
     }
   }
 

--- a/electron/services/WorkspaceHostProcess.ts
+++ b/electron/services/WorkspaceHostProcess.ts
@@ -718,6 +718,7 @@ export class WorkspaceHostProcess extends EventEmitter {
       case "worktree-removed":
       case "pr-detected":
       case "pr-cleared":
+      case "pr-detection-paused":
       case "issue-detected":
       case "issue-not-found":
       case "copytree:progress":

--- a/electron/services/__tests__/PullRequestService.test.ts
+++ b/electron/services/__tests__/PullRequestService.test.ts
@@ -212,6 +212,47 @@ describe("PullRequestService", () => {
     pullRequestService.destroy();
   });
 
+  it("emits sys:pr:detection-paused once on trip and again on recovery", async () => {
+    let callCount = 0;
+    const batchCheckLinkedPRs = vi.fn(async () => {
+      callCount++;
+      if (callCount <= 3) {
+        return { results: new Map(), error: "API rate limit exceeded" };
+      }
+      return { results: new Map() };
+    });
+    const clearPRCaches = vi.fn();
+    vi.doMock("../GitHubService.js", () => ({ batchCheckLinkedPRs, clearPRCaches }));
+
+    const { pullRequestService } = await import("../PullRequestService.js");
+    const { events } = await import("../events.js");
+
+    const paused: DaintreeEventMap["sys:pr:detection-paused"][] = [];
+    const unsubscribe = events.on("sys:pr:detection-paused", (payload) => paused.push(payload));
+
+    pullRequestService.initialize("/repo");
+    events.emit(
+      "sys:worktree:update",
+      makeWorktreeSnapshot({ worktreeId: "wt-1", branch: "feature/test" })
+    );
+
+    await pullRequestService.start();
+    await vi.advanceTimersToNextTimerAsync();
+    await vi.advanceTimersToNextTimerAsync();
+
+    // Trip: exactly one tripped:true on the 3rd consecutive error.
+    expect(pullRequestService.getStatus().consecutiveErrors).toBe(3);
+    expect(paused).toEqual([{ tripped: true }]);
+
+    // Recovery: backoff window fires, resets the breaker, emits tripped:false.
+    await vi.advanceTimersByTimeAsync(5 * 60 * 1000);
+    expect(pullRequestService.getStatus().isEnabled).toBe(true);
+    expect(paused).toEqual([{ tripped: true }, { tripped: false }]);
+
+    unsubscribe();
+    pullRequestService.destroy();
+  });
+
   it("revalidates resolved PRs at 90-second intervals", async () => {
     let checkCallCount = 0;
     const batchCheckLinkedPRs = vi.fn(async (_cwd: string, candidates: PRCheckCandidate[]) => {

--- a/electron/services/__tests__/PullRequestService.test.ts
+++ b/electron/services/__tests__/PullRequestService.test.ts
@@ -253,6 +253,79 @@ describe("PullRequestService", () => {
     pullRequestService.destroy();
   });
 
+  it("clears the tripped state when a manual refresh succeeds", async () => {
+    let callCount = 0;
+    const batchCheckLinkedPRs = vi.fn(async () => {
+      callCount++;
+      if (callCount <= 3) {
+        return { results: new Map(), error: "API rate limit exceeded" };
+      }
+      return { results: new Map() };
+    });
+    const clearPRCaches = vi.fn();
+    vi.doMock("../GitHubService.js", () => ({ batchCheckLinkedPRs, clearPRCaches }));
+
+    const { pullRequestService } = await import("../PullRequestService.js");
+    const { events } = await import("../events.js");
+
+    const paused: DaintreeEventMap["sys:pr:detection-paused"][] = [];
+    const unsubscribe = events.on("sys:pr:detection-paused", (payload) => paused.push(payload));
+
+    pullRequestService.initialize("/repo");
+    events.emit(
+      "sys:worktree:update",
+      makeWorktreeSnapshot({ worktreeId: "wt-1", branch: "feature/test" })
+    );
+
+    await pullRequestService.start();
+    await vi.advanceTimersToNextTimerAsync();
+    await vi.advanceTimersToNextTimerAsync();
+    expect(paused).toEqual([{ tripped: true }]);
+
+    // A manual refresh that succeeds must clear the renderer-visible errored
+    // badge — without this the badges stay stuck until project re-open.
+    await pullRequestService.refresh();
+    expect(paused).toEqual([{ tripped: true }, { tripped: false }]);
+
+    unsubscribe();
+    pullRequestService.destroy();
+  });
+
+  it("does not re-emit tripped:true on the 4th+ consecutive error", async () => {
+    const batchCheckLinkedPRs = vi.fn(async () => ({
+      results: new Map(),
+      error: "API rate limit exceeded",
+    }));
+    const clearPRCaches = vi.fn();
+    vi.doMock("../GitHubService.js", () => ({ batchCheckLinkedPRs, clearPRCaches }));
+
+    const { pullRequestService } = await import("../PullRequestService.js");
+    const { events } = await import("../events.js");
+
+    const paused: DaintreeEventMap["sys:pr:detection-paused"][] = [];
+    const unsubscribe = events.on("sys:pr:detection-paused", (payload) => paused.push(payload));
+
+    pullRequestService.initialize("/repo");
+    events.emit(
+      "sys:worktree:update",
+      makeWorktreeSnapshot({ worktreeId: "wt-1", branch: "feature/test" })
+    );
+
+    await pullRequestService.start();
+    // Drive several backoff cycles: each recovery poll resets the counter,
+    // fails again, and re-reaches the trip threshold. The state is already
+    // tripped, so no duplicate tripped:true and no spurious tripped:false.
+    await vi.advanceTimersToNextTimerAsync();
+    await vi.advanceTimersToNextTimerAsync();
+    await vi.advanceTimersByTimeAsync(5 * 60 * 1000);
+    await vi.advanceTimersByTimeAsync(5 * 60 * 1000);
+
+    expect(paused).toEqual([{ tripped: true }]);
+
+    unsubscribe();
+    pullRequestService.destroy();
+  });
+
   it("revalidates resolved PRs at 90-second intervals", async () => {
     let checkCallCount = 0;
     const batchCheckLinkedPRs = vi.fn(async (_cwd: string, candidates: PRCheckCandidate[]) => {

--- a/electron/services/events.ts
+++ b/electron/services/events.ts
@@ -100,6 +100,12 @@ export const EVENT_META: Record<keyof DaintreeEventMap, EventMetadata> = {
     requiresTimestamp: true,
     description: "Pull request association cleared",
   },
+  "sys:pr:detection-paused": {
+    category: "system",
+    requiresContext: false,
+    requiresTimestamp: false,
+    description: "PR detection circuit breaker tripped or recovered",
+  },
   "sys:issue:detected": {
     category: "system",
     requiresContext: true,
@@ -451,6 +457,7 @@ export type DaintreeEventMap = {
     branchName?: string;
     timestamp: number;
   };
+  "sys:pr:detection-paused": { tripped: boolean };
 
   "sys:issue:detected": {
     worktreeId: string;
@@ -783,6 +790,7 @@ export const ALL_EVENT_TYPES: Array<keyof DaintreeEventMap> = [
   "watcher:change",
   "sys:pr:detected",
   "sys:pr:cleared",
+  "sys:pr:detection-paused",
   "sys:issue:detected",
   "sys:issue:not-found",
   "agent:spawned",

--- a/electron/workspace-host.ts
+++ b/electron/workspace-host.ts
@@ -54,6 +54,7 @@ const DIRECT_RENDERER_EVENTS = new Set([
   "worktree-removed",
   "pr-detected",
   "pr-cleared",
+  "pr-detection-paused",
   "issue-detected",
   "issue-not-found",
 ]);

--- a/electron/workspace-host/PRIntegrationService.ts
+++ b/electron/workspace-host/PRIntegrationService.ts
@@ -46,6 +46,7 @@ export interface PRIntegrationCallbacks {
     }
   ): void;
   onIssueNotFound(worktreeId: string, issueNumber: number): void;
+  onDetectionPaused(tripped: boolean): void;
 }
 
 export class PRIntegrationService {
@@ -117,6 +118,12 @@ export class PRIntegrationService {
     this.prEventUnsubscribers.push(
       this.eventBus.on("sys:pr:cleared", (data) => {
         this.callbacks.onPRCleared(data.worktreeId, { branchName: data.branchName });
+      })
+    );
+
+    this.prEventUnsubscribers.push(
+      this.eventBus.on("sys:pr:detection-paused", (data) => {
+        this.callbacks.onDetectionPaused(data.tripped);
       })
     );
 

--- a/electron/workspace-host/WorkspaceService.ts
+++ b/electron/workspace-host/WorkspaceService.ts
@@ -247,6 +247,9 @@ export class WorkspaceService {
           issueNumber,
         });
       },
+      onDetectionPaused: (tripped) => {
+        this.sendEvent({ type: "pr-detection-paused", tripped });
+      },
     });
 
     this.resourceActionExecutor = new ResourceActionExecutor({

--- a/electron/workspace-host/__tests__/PRIntegrationService.test.ts
+++ b/electron/workspace-host/__tests__/PRIntegrationService.test.ts
@@ -33,6 +33,7 @@ function makeCallbacks(): PRIntegrationCallbacks {
     onPRCleared: vi.fn(),
     onIssueDetected: vi.fn(),
     onIssueNotFound: vi.fn(),
+    onDetectionPaused: vi.fn(),
   };
 }
 

--- a/shared/types/workspace-host.ts
+++ b/shared/types/workspace-host.ts
@@ -417,6 +417,9 @@ export type WorkspaceHostEvent =
       /** Branch the clear was initiated against — receiver drops the overlay if the worktree's branch has since changed. */
       branchName?: string;
     }
+  // PR detection circuit breaker tripped (true) or recovered (false).
+  // Service-wide, not per-worktree — drives the ambient errored badge state.
+  | { type: "pr-detection-paused"; tripped: boolean }
   // Issue events
   | {
       type: "issue-detected";

--- a/src/components/Fleet/__tests__/fleetBroadcast.test.ts
+++ b/src/components/Fleet/__tests__/fleetBroadcast.test.ts
@@ -78,6 +78,7 @@ function installViewStore(worktrees: Map<string, WorktreeSnapshot>) {
     isInitialized: true,
     isReconnecting: false,
     reconnectingAt: null,
+    prDetectionPaused: false,
     nextVersion: () => 0,
     applySnapshot: () => {},
     applyUpdate: () => {},
@@ -88,6 +89,7 @@ function installViewStore(worktrees: Map<string, WorktreeSnapshot>) {
     setError: () => {},
     setFatalError: () => {},
     setReconnecting: () => {},
+    setPrDetectionPaused: () => {},
   }));
   setCurrentViewStore(store);
 }

--- a/src/components/Worktree/WorktreeCard/hooks/__tests__/useGitHubBadgeFreshness.test.tsx
+++ b/src/components/Worktree/WorktreeCard/hooks/__tests__/useGitHubBadgeFreshness.test.tsx
@@ -62,10 +62,7 @@ describe("useGitHubBadgeFreshness", () => {
   });
 
   it("returns fresh when row timestamp is null (cast)", () => {
-    const { result } = renderFreshness(
-      "pr",
-      null as unknown as number | undefined
-    );
+    const { result } = renderFreshness("pr", null as unknown as number | undefined);
     expect(result.current.freshnessLevel).toBe("fresh");
   });
 
@@ -203,13 +200,10 @@ describe("useGitHubBadgeFreshness", () => {
 
   it("re-evaluates aging as wall-clock time advances past threshold", () => {
     const rowTime = FIXED_NOW - (STALE_THRESHOLD_MS - 1);
-    const { result, rerender } = renderHook(
-      ({ row }) => useGitHubBadgeFreshness("pr", row),
-      {
-        initialProps: { row: rowTime },
-        wrapper,
-      }
-    );
+    const { result, rerender } = renderHook(({ row }) => useGitHubBadgeFreshness("pr", row), {
+      initialProps: { row: rowTime },
+      wrapper,
+    });
     expect(result.current.freshnessLevel).toBe("fresh");
 
     vi.setSystemTime(FIXED_NOW + 2);

--- a/src/components/Worktree/WorktreeCard/hooks/__tests__/useGitHubBadgeFreshness.test.tsx
+++ b/src/components/Worktree/WorktreeCard/hooks/__tests__/useGitHubBadgeFreshness.test.tsx
@@ -2,14 +2,27 @@
  * @vitest-environment jsdom
  */
 import { describe, it, expect, vi, beforeEach, afterEach } from "vitest";
+import { createElement, type ReactNode } from "react";
 import { renderHook } from "@testing-library/react";
 import { useGitHubBadgeFreshness } from "../useGitHubBadgeFreshness";
 import * as cache from "@/lib/githubResourceCache";
 import type { GitHubResourceCacheEntry } from "@/lib/githubResourceCache";
 import { useGitHubRateLimitStore } from "@/store/githubRateLimitStore";
+import { WorktreeStoreContext } from "@/contexts/WorktreeStoreContext";
+import { createWorktreeStore, type WorktreeViewStoreApi } from "@/store/createWorktreeStore";
 
 function makeCacheEntry(timestamp: number): GitHubResourceCacheEntry {
   return { items: [], endCursor: null, hasNextPage: false, timestamp };
+}
+
+let store: WorktreeViewStoreApi;
+
+function wrapper({ children }: { children: ReactNode }) {
+  return createElement(WorktreeStoreContext.Provider, { value: store }, children);
+}
+
+function renderFreshness(type: "pr" | "issue", rowLastUpdatedAt?: number) {
+  return renderHook(() => useGitHubBadgeFreshness(type, rowLastUpdatedAt), { wrapper });
 }
 
 vi.mock("@/store/projectStore", () => ({
@@ -34,6 +47,7 @@ describe("useGitHubBadgeFreshness", () => {
     mockTick = 1;
     vi.useFakeTimers();
     vi.setSystemTime(FIXED_NOW);
+    store = createWorktreeStore();
   });
 
   afterEach(() => {
@@ -43,49 +57,55 @@ describe("useGitHubBadgeFreshness", () => {
   });
 
   it("returns fresh when row timestamp is undefined", () => {
-    const { result } = renderHook(() => useGitHubBadgeFreshness("pr", undefined));
+    const { result } = renderFreshness("pr", undefined);
     expect(result.current.freshnessLevel).toBe("fresh");
   });
 
   it("returns fresh when row timestamp is null (cast)", () => {
-    const { result } = renderHook(() =>
-      useGitHubBadgeFreshness("pr", null as unknown as number | undefined)
+    const { result } = renderFreshness(
+      "pr",
+      null as unknown as number | undefined
     );
     expect(result.current.freshnessLevel).toBe("fresh");
   });
 
+  it("returns fresh when no cache entry exists", () => {
+    const { result } = renderFreshness("pr", FIXED_NOW);
+    expect(result.current.freshnessLevel).toBe("fresh");
+  });
+
   it("returns fresh when row was just updated (age 0)", () => {
-    const { result } = renderHook(() => useGitHubBadgeFreshness("pr", FIXED_NOW));
+    const { result } = renderFreshness("pr", FIXED_NOW);
     expect(result.current.freshnessLevel).toBe("fresh");
   });
 
   it("returns fresh when row age is just below threshold", () => {
     const rowTime = FIXED_NOW - (STALE_THRESHOLD_MS - 1);
-    const { result } = renderHook(() => useGitHubBadgeFreshness("pr", rowTime));
+    const { result } = renderFreshness("pr", rowTime);
     expect(result.current.freshnessLevel).toBe("fresh");
   });
 
   it("returns fresh when row age equals threshold exactly (strict >)", () => {
     const rowTime = FIXED_NOW - STALE_THRESHOLD_MS;
-    const { result } = renderHook(() => useGitHubBadgeFreshness("pr", rowTime));
+    const { result } = renderFreshness("pr", rowTime);
     expect(result.current.freshnessLevel).toBe("fresh");
   });
 
   it("returns aging when row age is just over threshold", () => {
     const rowTime = FIXED_NOW - (STALE_THRESHOLD_MS + 1);
-    const { result } = renderHook(() => useGitHubBadgeFreshness("pr", rowTime));
+    const { result } = renderFreshness("pr", rowTime);
     expect(result.current.freshnessLevel).toBe("aging");
   });
 
   it("returns aging when row age is well past threshold", () => {
     const rowTime = FIXED_NOW - 10 * 60 * 1000;
-    const { result } = renderHook(() => useGitHubBadgeFreshness("pr", rowTime));
+    const { result } = renderFreshness("pr", rowTime);
     expect(result.current.freshnessLevel).toBe("aging");
   });
 
   it("returns fresh when row timestamp is in the future (clock skew)", () => {
     const rowTime = FIXED_NOW + 60_000;
-    const { result } = renderHook(() => useGitHubBadgeFreshness("pr", rowTime));
+    const { result } = renderFreshness("pr", rowTime);
     expect(result.current.freshnessLevel).toBe("fresh");
   });
 
@@ -93,7 +113,7 @@ describe("useGitHubBadgeFreshness", () => {
     const rowTime = FIXED_NOW - 1000;
     cache.setCache(PR_KEY, makeCacheEntry(FIXED_NOW));
 
-    const { result } = renderHook(() => useGitHubBadgeFreshness("pr", rowTime));
+    const { result } = renderFreshness("pr", rowTime);
     expect(result.current.freshnessLevel).toBe("fresh");
   });
 
@@ -101,18 +121,18 @@ describe("useGitHubBadgeFreshness", () => {
     const cacheTime = FIXED_NOW - 5_000;
     cache.setCache(PR_KEY, makeCacheEntry(cacheTime));
 
-    const { result } = renderHook(() => useGitHubBadgeFreshness("pr", FIXED_NOW));
+    const { result } = renderFreshness("pr", FIXED_NOW);
     expect(result.current.cacheLastUpdatedAt).toBe(cacheTime);
   });
 
   it("returns null cacheLastUpdatedAt when no cache entry exists", () => {
-    const { result } = renderHook(() => useGitHubBadgeFreshness("pr", FIXED_NOW));
+    const { result } = renderFreshness("pr", FIXED_NOW);
     expect(result.current.cacheLastUpdatedAt).toBeNull();
   });
 
   it("returns now reflecting wall-clock time", () => {
     mockTick = 5;
-    const { result } = renderHook(() => useGitHubBadgeFreshness("pr", undefined));
+    const { result } = renderFreshness("pr", undefined);
     expect(result.current.now).toBe(FIXED_NOW);
   });
 
@@ -123,7 +143,9 @@ describe("useGitHubBadgeFreshness", () => {
       resetAt: Date.now() + 60_000,
     });
 
-    const { result } = renderHook(() => useGitHubBadgeFreshness("pr", Date.now()));
+    const { result } = renderHook(() => useGitHubBadgeFreshness("pr", Date.now()), {
+      wrapper,
+    });
     expect(result.current.freshnessLevel).toBe("aging");
   });
 
@@ -137,7 +159,9 @@ describe("useGitHubBadgeFreshness", () => {
     });
 
     // Without rate-limit, this would be "fresh" (cache time equals row time).
-    const { result } = renderHook(() => useGitHubBadgeFreshness("pr", time));
+    const { result } = renderHook(() => useGitHubBadgeFreshness("pr", time), {
+      wrapper,
+    });
     expect(result.current.freshnessLevel).toBe("aging");
   });
 
@@ -146,7 +170,9 @@ describe("useGitHubBadgeFreshness", () => {
     const time = Date.now();
     cache.setCache(PR_KEY, makeCacheEntry(time));
 
-    const { result, rerender } = renderHook(() => useGitHubBadgeFreshness("pr", time));
+    const { result, rerender } = renderHook(() => useGitHubBadgeFreshness("pr", time), {
+      wrapper,
+    });
     expect(result.current.freshnessLevel).toBe("fresh");
 
     act(() => {
@@ -171,21 +197,58 @@ describe("useGitHubBadgeFreshness", () => {
     cache.setCache(ISSUE_KEY, makeCacheEntry(cacheTime));
     cache.setCache(PR_KEY, makeCacheEntry(FIXED_NOW - 50_000));
 
-    const { result } = renderHook(() => useGitHubBadgeFreshness("issue", FIXED_NOW));
+    const { result } = renderFreshness("issue", FIXED_NOW);
     expect(result.current.cacheLastUpdatedAt).toBe(cacheTime);
   });
 
   it("re-evaluates aging as wall-clock time advances past threshold", () => {
     const rowTime = FIXED_NOW - (STALE_THRESHOLD_MS - 1);
-    const { result, rerender } = renderHook(({ row }) => useGitHubBadgeFreshness("pr", row), {
-      initialProps: { row: rowTime },
-    });
+    const { result, rerender } = renderHook(
+      ({ row }) => useGitHubBadgeFreshness("pr", row),
+      {
+        initialProps: { row: rowTime },
+        wrapper,
+      }
+    );
     expect(result.current.freshnessLevel).toBe("fresh");
 
     vi.setSystemTime(FIXED_NOW + 2);
     mockTick = 2;
     rerender({ row: rowTime });
 
+    expect(result.current.freshnessLevel).toBe("aging");
+  });
+
+  it("returns errored when PR detection circuit breaker is tripped", () => {
+    store.getState().setPrDetectionPaused(true);
+    const { result } = renderFreshness("pr", undefined);
+    expect(result.current.freshnessLevel).toBe("errored");
+  });
+
+  it("overrides aging with errored while the circuit breaker is tripped", () => {
+    cache.setCache(PR_KEY, makeCacheEntry(2000));
+    store.getState().setPrDetectionPaused(true);
+
+    const { result } = renderFreshness("pr", 1000);
+    expect(result.current.freshnessLevel).toBe("errored");
+  });
+
+  it("applies errored to issue badges too", () => {
+    store.getState().setPrDetectionPaused(true);
+    const { result } = renderFreshness("issue", 1000);
+    expect(result.current.freshnessLevel).toBe("errored");
+  });
+
+  it("reverts to cache-age freshness after the circuit breaker recovers", () => {
+    const rowTime = 1000;
+    cache.setCache(PR_KEY, makeCacheEntry(2000));
+
+    store.getState().setPrDetectionPaused(true);
+    const { result, rerender } = renderFreshness("pr", rowTime);
+    expect(result.current.freshnessLevel).toBe("errored");
+
+    store.getState().setPrDetectionPaused(false);
+    rerender();
     expect(result.current.freshnessLevel).toBe("aging");
   });
 });

--- a/src/components/Worktree/WorktreeCard/hooks/useGitHubBadgeFreshness.ts
+++ b/src/components/Worktree/WorktreeCard/hooks/useGitHubBadgeFreshness.ts
@@ -4,6 +4,7 @@ import { getCache, buildCacheKey } from "@/lib/githubResourceCache";
 import { useGlobalMinuteTicker } from "@/hooks/useGlobalMinuteTicker";
 import { useProjectStore } from "@/store/projectStore";
 import { useGitHubRateLimitStore } from "@/store/githubRateLimitStore";
+import { useWorktreeStore } from "@/hooks/useWorktreeStore";
 
 const DEFAULT_FILTER_STATE = "open";
 const DEFAULT_SORT_ORDER = "created";
@@ -23,6 +24,7 @@ export function useGitHubBadgeFreshness(
   rowLastUpdatedAt?: number
 ): UseGitHubBadgeFreshnessResult {
   const projectPath = useProjectStore((s) => s.currentProject?.path);
+  const prDetectionPaused = useWorktreeStore((s) => s.prDetectionPaused);
   const tick = useGlobalMinuteTicker();
   const rateLimitBlocked = useGitHubRateLimitStore((s) => s.blocked);
 
@@ -37,14 +39,21 @@ export function useGitHubBadgeFreshness(
   const cacheLastUpdatedAt = cacheEntry?.timestamp ?? null;
   const now = tick > 0 ? Date.now() : Date.now();
 
+  // When the workspace-host PR detection circuit breaker is tripped, polling
+  // is paused service-wide and every badge is showing potentially stale data.
+  // Surface the ambient "errored" tier regardless of cache age so the signal
+  // persists after the transient toast fades.
+  //
   // While GitHub-wide rate-limit pause is active, badge data may be older
   // than its timestamp suggests — polling is suspended, so a `fresh` badge
   // would be misleading. Treat as `aging` until the block clears.
-  const freshnessLevel: FreshnessLevel = rateLimitBlocked
-    ? "aging"
-    : rowLastUpdatedAt != null && now - rowLastUpdatedAt > STALE_THRESHOLD_MS
+  const freshnessLevel: FreshnessLevel = prDetectionPaused
+    ? "errored"
+    : rateLimitBlocked
       ? "aging"
-      : "fresh";
+      : rowLastUpdatedAt != null && now - rowLastUpdatedAt > STALE_THRESHOLD_MS
+        ? "aging"
+        : "fresh";
 
   return { freshnessLevel, cacheLastUpdatedAt, now };
 }

--- a/src/components/Worktree/WorktreeCard/hooks/useGitHubBadgeFreshness.ts
+++ b/src/components/Worktree/WorktreeCard/hooks/useGitHubBadgeFreshness.ts
@@ -4,7 +4,7 @@ import { getCache, buildCacheKey } from "@/lib/githubResourceCache";
 import { useGlobalMinuteTicker } from "@/hooks/useGlobalMinuteTicker";
 import { useProjectStore } from "@/store/projectStore";
 import { useGitHubRateLimitStore } from "@/store/githubRateLimitStore";
-import { useWorktreeStore } from "@/hooks/useWorktreeStore";
+import { useWorktreeStoreOptional } from "@/hooks/useWorktreeStore";
 
 const DEFAULT_FILTER_STATE = "open";
 const DEFAULT_SORT_ORDER = "created";
@@ -24,7 +24,7 @@ export function useGitHubBadgeFreshness(
   rowLastUpdatedAt?: number
 ): UseGitHubBadgeFreshnessResult {
   const projectPath = useProjectStore((s) => s.currentProject?.path);
-  const prDetectionPaused = useWorktreeStore((s) => s.prDetectionPaused);
+  const prDetectionPaused = useWorktreeStoreOptional((s) => s.prDetectionPaused);
   const tick = useGlobalMinuteTicker();
   const rateLimitBlocked = useGitHubRateLimitStore((s) => s.blocked);
 

--- a/src/contexts/WorktreeStoreContext.tsx
+++ b/src/contexts/WorktreeStoreContext.tsx
@@ -47,6 +47,11 @@ interface PRClearedEvent {
   branchName?: string;
 }
 
+interface PRDetectionPausedEvent {
+  type: "pr-detection-paused";
+  tripped: boolean;
+}
+
 interface IssueDetectedEvent {
   type: "issue-detected";
   worktreeId: string;
@@ -326,6 +331,13 @@ export function WorktreeStoreProvider({ children }: { children: ReactNode }) {
           },
           store.getState().nextVersion()
         );
+      })
+    );
+
+    cleanups.push(
+      worktreePort.onEvent("pr-detection-paused", (data) => {
+        const event = data as PRDetectionPausedEvent;
+        store.getState().setPrDetectionPaused(event.tripped);
       })
     );
 

--- a/src/contexts/__tests__/WorktreeStoreContext.prDetected.test.tsx
+++ b/src/contexts/__tests__/WorktreeStoreContext.prDetected.test.tsx
@@ -21,6 +21,7 @@ type PortEventName =
   | "worktree-activated"
   | "pr-detected"
   | "pr-cleared"
+  | "pr-detection-paused"
   | "issue-detected"
   | "issue-not-found";
 
@@ -1040,5 +1041,32 @@ describe("WorktreeStoreProvider manual issue associations (#8079)", () => {
     });
 
     expect(store.getState().worktrees.get("wt-1")?.issueNumber).toBeUndefined();
+  });
+});
+
+describe("WorktreeStoreProvider pr-detection-paused handler", () => {
+  it("mirrors the circuit-breaker trip into the store", async () => {
+    const store = await renderProvider();
+    expect(store.getState().prDetectionPaused).toBe(false);
+
+    act(() => {
+      emit("pr-detection-paused", { type: "pr-detection-paused", tripped: true });
+    });
+
+    expect(store.getState().prDetectionPaused).toBe(true);
+  });
+
+  it("clears the flag on recovery", async () => {
+    const store = await renderProvider();
+    act(() => {
+      emit("pr-detection-paused", { type: "pr-detection-paused", tripped: true });
+    });
+    expect(store.getState().prDetectionPaused).toBe(true);
+
+    act(() => {
+      emit("pr-detection-paused", { type: "pr-detection-paused", tripped: false });
+    });
+
+    expect(store.getState().prDetectionPaused).toBe(false);
   });
 });

--- a/src/hooks/useWorktreeStore.ts
+++ b/src/hooks/useWorktreeStore.ts
@@ -1,7 +1,11 @@
 import { use } from "react";
 import { useStore } from "zustand";
 import { WorktreeStoreContext } from "@/contexts/WorktreeStoreContext";
-import type { WorktreeViewState, WorktreeViewActions } from "@/store/createWorktreeStore";
+import {
+  createWorktreeStore,
+  type WorktreeViewState,
+  type WorktreeViewActions,
+} from "@/store/createWorktreeStore";
 
 export function useWorktreeStore<T>(
   selector: (state: WorktreeViewState & WorktreeViewActions) => T
@@ -11,4 +15,23 @@ export function useWorktreeStore<T>(
     throw new Error("useWorktreeStore must be used within WorktreeStoreProvider");
   }
   return useStore(store, selector);
+}
+
+// Stable, never-mutated fallback so the optional variant can call `useStore`
+// unconditionally (Rules of Hooks) when no provider is mounted. Defaults are
+// the cold-start state, so consumers read safe values (e.g. prDetectionPaused
+// = false) instead of crashing in isolated component tests / stray renders.
+const fallbackWorktreeStore = createWorktreeStore();
+
+/**
+ * Like {@link useWorktreeStore} but does not throw when rendered outside a
+ * `WorktreeStoreProvider` — it reads from a stable default store instead.
+ * Use only for ambient, non-authoritative reads (badge freshness) where a
+ * missing provider should degrade gracefully rather than crash.
+ */
+export function useWorktreeStoreOptional<T>(
+  selector: (state: WorktreeViewState & WorktreeViewActions) => T
+): T {
+  const store = use(WorktreeStoreContext);
+  return useStore(store ?? fallbackWorktreeStore, selector);
 }

--- a/src/services/actions/__tests__/actionDefinitions.quality.test.ts
+++ b/src/services/actions/__tests__/actionDefinitions.quality.test.ts
@@ -303,6 +303,7 @@ describe("destructive-action danger metadata", () => {
       isInitialized: true,
       isReconnecting: false,
       reconnectingAt: null,
+      prDetectionPaused: false,
       nextVersion: () => 1,
       applySnapshot: () => {},
       applyUpdate: () => {},
@@ -313,6 +314,7 @@ describe("destructive-action danger metadata", () => {
       setError: () => {},
       setFatalError: () => {},
       setReconnecting: () => {},
+      setPrDetectionPaused: () => {},
     }));
     setCurrentViewStore(viewStore);
     const contextOverride = {

--- a/src/store/__tests__/createWorktreeStore.reconnecting.test.ts
+++ b/src/store/__tests__/createWorktreeStore.reconnecting.test.ts
@@ -185,6 +185,33 @@ describe("createWorktreeStore — reconnectingAt timestamp", () => {
   });
 });
 
+describe("createWorktreeStore — PR detection paused state", () => {
+  it("starts with prDetectionPaused=false", () => {
+    const store = createWorktreeStore();
+    expect(store.getState().prDetectionPaused).toBe(false);
+  });
+
+  it("setPrDetectionPaused(true) flips the flag", () => {
+    const store = createWorktreeStore();
+    store.getState().setPrDetectionPaused(true);
+    expect(store.getState().prDetectionPaused).toBe(true);
+  });
+
+  it("setPrDetectionPaused(false) clears the flag", () => {
+    const store = createWorktreeStore();
+    store.getState().setPrDetectionPaused(true);
+    store.getState().setPrDetectionPaused(false);
+    expect(store.getState().prDetectionPaused).toBe(false);
+  });
+
+  it("no-ops (same state reference) when the value is unchanged", () => {
+    const store = createWorktreeStore();
+    const before = store.getState();
+    store.getState().setPrDetectionPaused(false);
+    expect(store.getState()).toBe(before);
+  });
+});
+
 describe("createWorktreeStore — applySnapshot identity preservation", () => {
   it("preserves Map identity when every snapshot is value-equal", () => {
     const store = createWorktreeStore();

--- a/src/store/createWorktreeStore.ts
+++ b/src/store/createWorktreeStore.ts
@@ -45,6 +45,11 @@ export interface WorktreeViewState {
   isInitialized: boolean;
   isReconnecting: boolean;
   reconnectingAt: number | null;
+  /**
+   * True when the workspace-host PR detection circuit breaker is tripped.
+   * Service-wide (not per-worktree); drives the ambient errored PR badge.
+   */
+  prDetectionPaused: boolean;
 }
 
 export interface WorktreeViewActions {
@@ -62,6 +67,7 @@ export interface WorktreeViewActions {
   setError(error: string | null): void;
   setFatalError(message: string): void;
   setReconnecting(reconnecting: boolean): void;
+  setPrDetectionPaused(tripped: boolean): void;
 }
 
 export type WorktreeViewStore = WorktreeViewState & WorktreeViewActions;
@@ -79,6 +85,7 @@ export function createWorktreeStore(): WorktreeViewStoreApi {
     isInitialized: false,
     isReconnecting: false,
     reconnectingAt: null,
+    prDetectionPaused: false,
 
     nextVersion() {
       return ++versionCounter;
@@ -236,6 +243,11 @@ export function createWorktreeStore(): WorktreeViewStoreApi {
             : Date.now()
           : null,
       });
+    },
+
+    setPrDetectionPaused(tripped: boolean) {
+      if (get().prDetectionPaused === tripped) return;
+      set({ prDetectionPaused: tripped });
     },
   }));
 }


### PR DESCRIPTION
## Summary

- When the PR detection service trips its circuit breaker (3 consecutive GitHub API errors), the existing toast was the only signal — once it faded, affected PR badges had no indication their data might be stale
- Adds a persistent ambient `errored` tier to each badge: `opacity-50` + a `· couldn't reach GitHub` tooltip suffix that stays visible until the service recovers
- Uses a new `sys:pr:detection-paused` event on the typed app bus, forwarded through `PRIntegrationService` → `WorkspaceService` → `pr-detection-paused` workspace host event → per-view `createWorktreeStore.prDetectionPaused` flag → `useGitHubBadgeFreshness` returns `errored`

Resolves #8078

## Changes

- `PullRequestService` emits `sys:pr:detection-paused` on trip and recovery via the typed app bus
- `PRIntegrationService` forwards the event; `WorkspaceService` emits `pr-detection-paused` (added to `DIRECT_RENDERER_EVENTS`)
- `createWorktreeStore` adds `prDetectionPaused` state and an `onDetectionPaused` handler wired through `WorktreeStoreContext`
- `useGitHubBadgeFreshness` returns `"errored"` when `prDetectionPaused` is set
- Trip/recovery emissions are paired and idempotent via a tracked `circuitBreakerTripped` flag; recovery only fires on a genuinely successful check, so it doesn't fire on a failed recovery poll

## Testing

- New unit tests in `PullRequestService.test.ts` cover trip and recovery emission, idempotency, and reset-on-teardown
- `useGitHubBadgeFreshness.test.tsx` extended with `prDetectionPaused` → `errored` and recovery → `fresh` cases
- `createWorktreeStore.reconnecting.test.ts` and `WorktreeStoreContext.prDetected.test.tsx` cover the store handler and context wiring
- All 122+ unit/integration tests pass; tsc, eslint, format, and build are clean