### PR TITLE
fix(setup): harden agent install-command path against paste-jacking

### DIFF
--- a/src/components/Setup/AgentCliStep.tsx
+++ b/src/components/Setup/AgentCliStep.tsx
@@ -13,7 +13,11 @@ import { AGENT_REGISTRY, getAgentConfig } from "@/config/agents";
 import { resolveBrandChip } from "@/lib/brandIcon";
 import { useActiveAppScheme } from "@/hooks/useActiveAppScheme";
 import { BUILT_IN_AGENT_IDS } from "@shared/config/agentIds";
-import { getInstallBlocksForCurrentOS, isBlockExecutable } from "@/lib/agentInstall";
+import {
+  extractInspectUrl,
+  getInstallBlocksForCurrentOS,
+  isBlockExecutable,
+} from "@/lib/agentInstall";
 import { systemClient } from "@/clients";
 import { useAgentSettingsStore } from "@/store";
 import { DEFAULT_DANGEROUS_ARGS } from "@shared/types/agentSettings";
@@ -327,7 +331,7 @@ export function AgentCliStep({ availability, selections, onInstallComplete }: Ag
                     Run this command in your terminal. It will be detected automatically.
                   </div>
                   {currentBlock.commands.map((cmd) => (
-                    <CopyableCommand key={cmd} command={cmd} />
+                    <CopyableCommand key={cmd} command={cmd} inspectUrl={extractInspectUrl(cmd)} />
                   ))}
                 </div>
               )}
@@ -363,7 +367,11 @@ export function AgentCliStep({ availability, selections, onInstallComplete }: Ag
                     <div className="space-y-1">
                       <div className="text-[11px] text-daintree-text/40">Or install manually:</div>
                       {currentBlock.commands.map((cmd) => (
-                        <CopyableCommand key={cmd} command={cmd} />
+                        <CopyableCommand
+                          key={cmd}
+                          command={cmd}
+                          inspectUrl={extractInspectUrl(cmd)}
+                        />
                       ))}
                     </div>
                   )}

--- a/src/components/Setup/CopyableCommand.tsx
+++ b/src/components/Setup/CopyableCommand.tsx
@@ -3,6 +3,7 @@ import { cn } from "@/lib/utils";
 import { useCopyWithFeedback } from "@/hooks/useCopyWithFeedback";
 import { Tooltip, TooltipTrigger, TooltipContent } from "@/components/ui/tooltip";
 import { systemClient } from "@/clients/systemClient";
+import { sanitizeForClipboard } from "@/lib/clipboardSanitize";
 
 export function CopyableCommand({ command, inspectUrl }: { command: string; inspectUrl?: string }) {
   const { copied, copy } = useCopyWithFeedback();
@@ -29,7 +30,7 @@ export function CopyableCommand({ command, inspectUrl }: { command: string; insp
         <TooltipTrigger asChild>
           <button
             type="button"
-            onClick={() => void copy(command)}
+            onClick={() => void copy(sanitizeForClipboard(command))}
             className="shrink-0 p-0.5 rounded hover:bg-overlay transition-colors duration-150 text-daintree-text/60 hover:text-daintree-text/80"
             aria-label="Copy command to clipboard"
           >

--- a/src/components/Setup/CopyableCommand.tsx
+++ b/src/components/Setup/CopyableCommand.tsx
@@ -1,14 +1,30 @@
-import { Check, Copy } from "lucide-react";
+import { Check, Copy, ExternalLink } from "lucide-react";
 import { cn } from "@/lib/utils";
 import { useCopyWithFeedback } from "@/hooks/useCopyWithFeedback";
 import { Tooltip, TooltipTrigger, TooltipContent } from "@/components/ui/tooltip";
+import { systemClient } from "@/clients/systemClient";
 
-export function CopyableCommand({ command }: { command: string }) {
+export function CopyableCommand({ command, inspectUrl }: { command: string; inspectUrl?: string }) {
   const { copied, copy } = useCopyWithFeedback();
 
   return (
     <div className="flex items-center gap-2 px-3 py-1.5 rounded-[var(--radius-sm)] bg-overlay-subtle border border-daintree-border font-mono text-xs select-text group">
       <span className="flex-1 truncate text-daintree-text/70">{command}</span>
+      {inspectUrl && (
+        <Tooltip>
+          <TooltipTrigger asChild>
+            <button
+              type="button"
+              onClick={() => void systemClient.openExternal(inspectUrl)}
+              className="shrink-0 p-0.5 rounded hover:bg-overlay transition-colors duration-150 text-daintree-text/60 hover:text-daintree-text/80"
+              aria-label="Inspect install script in browser"
+            >
+              <ExternalLink className="w-3.5 h-3.5" />
+            </button>
+          </TooltipTrigger>
+          <TooltipContent>Inspect install script</TooltipContent>
+        </Tooltip>
+      )}
       <Tooltip>
         <TooltipTrigger asChild>
           <button

--- a/src/components/Setup/InstallBlock.tsx
+++ b/src/components/Setup/InstallBlock.tsx
@@ -1,4 +1,5 @@
 import type { AgentInstallBlock } from "@shared/config/agentRegistry";
+import { extractInspectUrl } from "@/lib/agentInstall";
 import { CopyableCommand } from "./CopyableCommand";
 
 export { CopyableCommand };
@@ -19,7 +20,7 @@ export function InstallBlock({ block }: { block: AgentInstallBlock }) {
       {block.commands && block.commands.length > 0 && (
         <div className="space-y-1.5">
           {block.commands.map((cmd) => (
-            <CopyableCommand key={cmd} command={cmd} />
+            <CopyableCommand key={cmd} command={cmd} inspectUrl={extractInspectUrl(cmd)} />
           ))}
         </div>
       )}

--- a/src/components/Setup/__tests__/CopyableCommand.test.tsx
+++ b/src/components/Setup/__tests__/CopyableCommand.test.tsx
@@ -1,0 +1,81 @@
+// @vitest-environment jsdom
+import type { ReactElement } from "react";
+import { fireEvent, render, screen } from "@testing-library/react";
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+import { TooltipProvider } from "@/components/ui/tooltip";
+import { CopyableCommand } from "../CopyableCommand";
+
+const openExternalMock = vi.fn().mockResolvedValue(undefined);
+vi.mock("@/clients/systemClient", () => ({
+  systemClient: {
+    openExternal: (...args: unknown[]) => openExternalMock(...args),
+  },
+}));
+
+const writeTextMock = vi.fn().mockResolvedValue(undefined);
+
+function renderWithProviders(ui: ReactElement) {
+  return render(<TooltipProvider>{ui}</TooltipProvider>);
+}
+
+describe("CopyableCommand", () => {
+  beforeEach(() => {
+    openExternalMock.mockClear();
+    writeTextMock.mockClear();
+    Object.defineProperty(globalThis.navigator, "clipboard", {
+      value: { writeText: writeTextMock },
+      configurable: true,
+      writable: true,
+    });
+  });
+
+  afterEach(() => {
+    vi.restoreAllMocks();
+  });
+
+  it("renders the command text", () => {
+    renderWithProviders(<CopyableCommand command="brew install kiro" />);
+    expect(screen.getByText("brew install kiro")).toBeTruthy();
+  });
+
+  it("does not render the inspect button when inspectUrl is omitted", () => {
+    renderWithProviders(<CopyableCommand command="brew install kiro" />);
+    expect(screen.queryByLabelText("Inspect install script in browser")).toBeNull();
+  });
+
+  it("renders the inspect button when inspectUrl is provided", () => {
+    renderWithProviders(
+      <CopyableCommand
+        command="curl https://kiro.dev/install.sh | bash"
+        inspectUrl="https://kiro.dev/install.sh"
+      />
+    );
+    expect(screen.getByLabelText("Inspect install script in browser")).toBeTruthy();
+  });
+
+  it("opens the inspect URL externally when the inspect button is clicked", () => {
+    renderWithProviders(
+      <CopyableCommand
+        command="curl https://kiro.dev/install.sh | bash"
+        inspectUrl="https://kiro.dev/install.sh"
+      />
+    );
+    fireEvent.click(screen.getByLabelText("Inspect install script in browser"));
+    expect(openExternalMock).toHaveBeenCalledWith("https://kiro.dev/install.sh");
+  });
+
+  it("strips paste-jacking characters before writing to the clipboard", async () => {
+    renderWithProviders(<CopyableCommand command={"npm install foo\nrm -rf /"} />);
+    fireEvent.click(screen.getByLabelText("Copy command to clipboard"));
+    // Microtask drain so the awaited writeText resolves before the assertion.
+    await Promise.resolve();
+    expect(writeTextMock).toHaveBeenCalledWith("npm install foorm -rf /");
+  });
+
+  it("passes a clean command through to the clipboard unchanged", async () => {
+    renderWithProviders(<CopyableCommand command="brew install kiro" />);
+    fireEvent.click(screen.getByLabelText("Copy command to clipboard"));
+    await Promise.resolve();
+    expect(writeTextMock).toHaveBeenCalledWith("brew install kiro");
+  });
+});

--- a/src/hooks/__tests__/useCopyWithFeedback.test.tsx
+++ b/src/hooks/__tests__/useCopyWithFeedback.test.tsx
@@ -99,4 +99,17 @@ describe("useCopyWithFeedback", () => {
     });
     expect(useAnnouncerStore.getState().polite?.msg).toBe("Path copied");
   });
+
+  // Regression guard: the hook is a general-purpose clipboard primitive shared
+  // by crash-report and stack-trace copy paths. Paste-jacking sanitization
+  // belongs at the install-command boundary (CopyableCommand), not here —
+  // stripping newlines from a multi-line crash report would mangle it.
+  it("preserves newlines and tabs in multi-line content (does not sanitize)", async () => {
+    const { result } = renderHook(() => useCopyWithFeedback());
+    const crashReport = "## Crash Report\nDaintree 1.0.0\n\tstack:\n\t  at foo";
+    await act(async () => {
+      await result.current.copy(crashReport);
+    });
+    expect(writeText).toHaveBeenCalledWith(crashReport);
+  });
 });

--- a/src/hooks/useCopyWithFeedback.ts
+++ b/src/hooks/useCopyWithFeedback.ts
@@ -1,6 +1,7 @@
 import { useCallback, useEffect, useRef, useState } from "react";
 import { useAnnouncerStore } from "@/store/accessibilityAnnouncerStore";
 import { UI_ACTION_SUCCESS_DWELL_MS } from "@/lib/animationUtils";
+import { sanitizeForClipboard } from "@/lib/clipboardSanitize";
 
 export interface UseCopyWithFeedbackOptions {
   /** How long the `copied` flag stays true. Defaults to UI_ACTION_SUCCESS_DWELL_MS. */
@@ -42,7 +43,7 @@ export function useCopyWithFeedback(
   const copy = useCallback(
     async (text: string): Promise<boolean> => {
       try {
-        await navigator.clipboard.writeText(text);
+        await navigator.clipboard.writeText(sanitizeForClipboard(text));
       } catch {
         return false;
       }

--- a/src/hooks/useCopyWithFeedback.ts
+++ b/src/hooks/useCopyWithFeedback.ts
@@ -1,7 +1,6 @@
 import { useCallback, useEffect, useRef, useState } from "react";
 import { useAnnouncerStore } from "@/store/accessibilityAnnouncerStore";
 import { UI_ACTION_SUCCESS_DWELL_MS } from "@/lib/animationUtils";
-import { sanitizeForClipboard } from "@/lib/clipboardSanitize";
 
 export interface UseCopyWithFeedbackOptions {
   /** How long the `copied` flag stays true. Defaults to UI_ACTION_SUCCESS_DWELL_MS. */
@@ -43,7 +42,7 @@ export function useCopyWithFeedback(
   const copy = useCallback(
     async (text: string): Promise<boolean> => {
       try {
-        await navigator.clipboard.writeText(sanitizeForClipboard(text));
+        await navigator.clipboard.writeText(text);
       } catch {
         return false;
       }

--- a/src/lib/__tests__/agentInstall.test.ts
+++ b/src/lib/__tests__/agentInstall.test.ts
@@ -435,6 +435,55 @@ describe("agentInstall", () => {
     });
   });
 
+  describe("extractInspectUrl", () => {
+    it("returns the URL for a curl | bash command", async () => {
+      const { extractInspectUrl } = await import("../agentInstall");
+      expect(extractInspectUrl("curl -fsSL https://kiro.dev/install.sh | bash")).toBe(
+        "https://kiro.dev/install.sh"
+      );
+    });
+
+    it("returns the URL for a curl | sh command", async () => {
+      const { extractInspectUrl } = await import("../agentInstall");
+      expect(extractInspectUrl("curl https://example.com/install.sh | sh")).toBe(
+        "https://example.com/install.sh"
+      );
+    });
+
+    it("returns the URL for an irm | iex Windows command", async () => {
+      const { extractInspectUrl } = await import("../agentInstall");
+      expect(extractInspectUrl("irm 'https://example.com/install.ps1' | iex")).toBe(
+        "https://example.com/install.ps1"
+      );
+    });
+
+    it("trims trailing punctuation from process-substitution forms", async () => {
+      const { extractInspectUrl } = await import("../agentInstall");
+      expect(extractInspectUrl("bash <(curl https://example.com/install.sh) | bash")).toBe(
+        "https://example.com/install.sh"
+      );
+    });
+
+    it("returns undefined for non-pipe-to-shell commands", async () => {
+      const { extractInspectUrl } = await import("../agentInstall");
+      expect(extractInspectUrl("npm install -g @anthropic-ai/claude-code")).toBeUndefined();
+      expect(extractInspectUrl("brew install opencode")).toBeUndefined();
+      expect(extractInspectUrl("scoop install extras/opencode")).toBeUndefined();
+    });
+
+    it("returns undefined for pipe-to-shell commands without a URL", async () => {
+      const { extractInspectUrl } = await import("../agentInstall");
+      expect(extractInspectUrl("echo hello | bash")).toBeUndefined();
+    });
+
+    it("returns the first URL when multiple are present", async () => {
+      const { extractInspectUrl } = await import("../agentInstall");
+      expect(
+        extractInspectUrl("curl https://primary.example.com/install.sh https://other.com | bash")
+      ).toBe("https://primary.example.com/install.sh");
+    });
+  });
+
   describe("isBlockExecutable", () => {
     it("should return true for npm-only blocks", async () => {
       const { isBlockExecutable } = await import("../agentInstall");

--- a/src/lib/__tests__/clipboardSanitize.test.ts
+++ b/src/lib/__tests__/clipboardSanitize.test.ts
@@ -1,0 +1,69 @@
+import { describe, it, expect } from "vitest";
+import { sanitizeForClipboard } from "../clipboardSanitize";
+
+describe("sanitizeForClipboard", () => {
+  it("returns plain ASCII commands unchanged", () => {
+    expect(sanitizeForClipboard("curl -fsSL https://example.com/install.sh | bash")).toBe(
+      "curl -fsSL https://example.com/install.sh | bash"
+    );
+    expect(sanitizeForClipboard("npm install -g @anthropic-ai/claude-code")).toBe(
+      "npm install -g @anthropic-ai/claude-code"
+    );
+  });
+
+  it("preserves shell metacharacters", () => {
+    expect(sanitizeForClipboard("a | b ; c && d `e`")).toBe("a | b ; c && d `e`");
+  });
+
+  it("strips newlines (LF/CR/CRLF auto-execute vector)", () => {
+    expect(sanitizeForClipboard("curl x | bash\nrm -rf /")).toBe("curl x | bashrm -rf /");
+    expect(sanitizeForClipboard("a\rb")).toBe("ab");
+    expect(sanitizeForClipboard("a\r\nb")).toBe("ab");
+  });
+
+  it("strips tabs and other C0 controls", () => {
+    expect(sanitizeForClipboard("a\tb\x01c\x1fd")).toBe("abcd");
+  });
+
+  it("strips ESC (ANSI escape sequence injection vector)", () => {
+    expect(sanitizeForClipboard("ls\x1b[31mred\x1b[0m")).toBe("ls[31mred[0m");
+  });
+
+  it("strips DEL and C1 controls", () => {
+    expect(sanitizeForClipboard("a\x7fb\x80c\x9fd")).toBe("abcd");
+  });
+
+  it("strips zero-width and Bidi format characters", () => {
+    // U+200B ZWSP, U+200C ZWNJ, U+200D ZWJ, U+200E LRM, U+200F RLM
+    expect(sanitizeForClipboard("a​b‌c‍d‎e‏f")).toBe("abcdef");
+    // U+202A–U+202E Bidi embedding/override (incl. RIGHT-TO-LEFT OVERRIDE)
+    expect(sanitizeForClipboard("a‪b‫c‬d‭e‮f")).toBe("abcdef");
+    // U+2066–U+2069 Bidi isolate marks
+    expect(sanitizeForClipboard("a⁦b⁧c⁨d⁩e")).toBe("abcde");
+    // U+FEFF BOM / zero-width no-break space
+    expect(sanitizeForClipboard("a﻿b")).toBe("ab");
+  });
+
+  it("neutralises the canonical paste-jacking payload", () => {
+    // Displayed-as: `npm install foo` but smuggles a destructive line via LF.
+    const malicious = "npm install foo\nrm -rf $HOME";
+    expect(sanitizeForClipboard(malicious)).toBe("npm install foorm -rf $HOME");
+    expect(sanitizeForClipboard(malicious).includes("\n")).toBe(false);
+  });
+
+  it("neutralises the RIGHT-TO-LEFT OVERRIDE display-spoofing attack", () => {
+    // U+202E reverses display order: visible `hsab/lrucrm.sh` while clipboard
+    // holds `hs/lcurl.bash sm` — strip it so what you see is what you paste.
+    const spoofed = "curl https://x.com/install.sh ‮ | bash";
+    const cleaned = sanitizeForClipboard(spoofed);
+    expect(cleaned.includes("‮")).toBe(false);
+  });
+
+  it("handles empty strings", () => {
+    expect(sanitizeForClipboard("")).toBe("");
+  });
+
+  it("does not strip ordinary Unicode (em dash, ellipsis, non-Latin scripts)", () => {
+    expect(sanitizeForClipboard("install — done … 安裝")).toBe("install — done … 安裝");
+  });
+});

--- a/src/lib/agentInstall.ts
+++ b/src/lib/agentInstall.ts
@@ -46,6 +46,18 @@ export function isManualOnlyCommand(command: string): boolean {
   return /\|\s*(bash|sh|zsh)\b/.test(command) || /\|\s*iex\b/.test(command);
 }
 
+// For `curl … | bash` / `irm … | iex`-style commands, return the install
+// script URL so the UI can offer an inspect-before-running affordance.
+// Returns undefined for commands without a pipe-to-shell or without a URL.
+export function extractInspectUrl(command: string): string | undefined {
+  if (!isManualOnlyCommand(command)) return undefined;
+  const match = command.match(/https?:\/\/[^\s|]+/);
+  if (!match) return undefined;
+  // Trim trailing punctuation that often surrounds inline URLs, e.g. the `)`
+  // in `bash <(curl https://x/install.sh)`.
+  return match[0].replace(/[)\]'">]+$/, "");
+}
+
 export function isBlockExecutable(block: AgentInstallBlock): boolean {
   if (!block.commands || block.commands.length === 0) return false;
   return block.commands.every((cmd) => !isManualOnlyCommand(cmd));

--- a/src/lib/clipboardSanitize.ts
+++ b/src/lib/clipboardSanitize.ts
@@ -1,0 +1,19 @@
+// Paste-jacking defence: strip characters that can either auto-execute when
+// pasted into a shell (LF/CR/ESC and other C0/C1 controls) or visually
+// disguise the real payload (zero-width and Bidi format controls). Shell
+// metacharacters (`|`, `;`, `&`, backtick) are intentionally preserved —
+// `curl … | bash` pipes are legitimate command syntax we render verbatim.
+//
+// Ranges covered:
+//   \x00-\x1f  C0 controls (NUL, LF, CR, ESC, TAB, …)
+//   \x7f       DEL
+//   \x80-\x9f  C1 controls
+//   ​-‏  ZWSP, ZWNJ, ZWJ, LRM, RLM
+//   ‪-‮  Bidi embedding/override (incl. RIGHT-TO-LEFT OVERRIDE)
+//   ⁦-⁩  Bidi isolate marks
+//   ﻿         BOM / zero-width no-break space
+const PASTE_JACK_RE = /[\x00-\x1f\x7f-\x9f​-‏‪-‮⁦-⁩﻿]/g;
+
+export function sanitizeForClipboard(text: string): string {
+  return text.replace(PASTE_JACK_RE, "");
+}

--- a/src/lib/clipboardSanitize.ts
+++ b/src/lib/clipboardSanitize.ts
@@ -8,10 +8,11 @@
 //   \x00-\x1f  C0 controls (NUL, LF, CR, ESC, TAB, …)
 //   \x7f       DEL
 //   \x80-\x9f  C1 controls
-//   ​-‏  ZWSP, ZWNJ, ZWJ, LRM, RLM
-//   ‪-‮  Bidi embedding/override (incl. RIGHT-TO-LEFT OVERRIDE)
-//   ⁦-⁩  Bidi isolate marks
-//   ﻿         BOM / zero-width no-break space
+//   U+200B-U+200F: ZWSP, ZWNJ, ZWJ, LRM, RLM
+//   U+202A-U+202E: Bidi embedding/override (including RIGHT-TO-LEFT OVERRIDE)
+//   U+2066-U+2069: Bidi isolate marks
+//   U+FEFF: BOM / zero-width no-break space
+// eslint-disable-next-line no-control-regex, no-irregular-whitespace
 const PASTE_JACK_RE = /[\x00-\x1f\x7f-\x9f​-‏‪-‮⁦-⁩﻿]/g;
 
 export function sanitizeForClipboard(text: string): string {


### PR DESCRIPTION
## Summary

Closes #8093. Adds two defences to the agent setup wizard's install-command path:

1. **Boundary sanitization at the install-command copy point** — `CopyableCommand` now passes the displayed command through `sanitizeForClipboard()` before writing to the system clipboard. The sanitizer strips C0/C1 control characters (NUL, LF, CR, ESC, …) plus zero-width and Bidi format controls (U+200B–U+200F, U+202A–U+202E, U+2066–U+2069, U+FEFF). This neutralises the canonical paste-jacking payload — a hidden `\n` that auto-executes the line after the visible one — and the RIGHT-TO-LEFT OVERRIDE display-spoofing variant. Shell metacharacters (\`|\`, \`;\`, \`&\`, backtick) are intentionally preserved; \`curl … | bash\` is a legitimate command we render verbatim.

2. **Inspect-in-browser affordance** — \`curl … | bash\` and \`irm … | iex\`-style install commands now render an external-link icon button next to the copy button. Clicking it opens the install script URL in the system browser via the existing \`system.openExternal\` IPC, so users can review the script before running it. Detection reuses \`isManualOnlyCommand\` and a new \`extractInspectUrl\` helper which pulls the first \`https?://\` URL and trims trailing punctuation from process-substitution forms like \`bash <(curl https://…/install.sh)\`.

### Scope choice

The sanitizer initially lived inside \`useCopyWithFeedback\` — the shared clipboard hook — but that scope corrupts multi-line content elsewhere in the app (crash reports in \`CrashRecoveryDialog\`, stack traces in \`ErrorFallback\`, etc.). The threat surface is shell-install commands specifically, so sanitization is scoped to \`CopyableCommand\`'s click site, and the hook has a regression-guard test asserting it preserves newlines/tabs.

## Test plan
- [x] \`npx vitest run\` on the affected suites — 68 tests pass (10 new for \`clipboardSanitize\`, 7 new for \`extractInspectUrl\`, 6 new for \`CopyableCommand\` inspect/sanitize branches, 1 new regression guard for the hook).
- [x] \`npm run check\` — typecheck, lint, format, channel/IPC drift, ratchet all pass.
- [x] \`npm run build\` — production build clean.
- [ ] Manual: open the agent setup wizard, paste a known-good \`curl … | bash\` command from an agent registry entry, confirm the inspect button appears and opens the script URL in the system browser. Confirm the copy button still produces the expected command text.

### Threat coverage tested

- LF/CR auto-execute (\`npm install foo\\nrm -rf $HOME\`)
- ESC / ANSI injection (\`ls\\x1b[31m…\`)
- DEL / C1 control characters
- RIGHT-TO-LEFT OVERRIDE (U+202E) display spoofing
- Zero-width characters (U+200B/U+200C/U+200D/U+200E/U+200F)
- Bidi embedding/override (U+202A–U+202E) and isolate marks (U+2066–U+2069)
- BOM / zero-width no-break space (U+FEFF)