### PR TITLE
feat(sidebar): escalate reconnecting badge after 10s

### DIFF
--- a/src/components/Fleet/__tests__/fleetBroadcast.test.ts
+++ b/src/components/Fleet/__tests__/fleetBroadcast.test.ts
@@ -76,6 +76,7 @@ function installViewStore(worktrees: Map<string, WorktreeSnapshot>) {
     error: null,
     isInitialized: true,
     isReconnecting: false,
+    reconnectingAt: null,
     nextVersion: () => 0,
     applySnapshot: () => {},
     applyUpdate: () => {},

--- a/src/components/Sidebar/SidebarContent.tsx
+++ b/src/components/Sidebar/SidebarContent.tsx
@@ -23,6 +23,7 @@ import {
   useDeferredLoading,
 } from "@/hooks";
 import { UI_DOHERTY_THRESHOLD } from "@/lib/animationUtils";
+import { formatRelativeTime } from "@/lib/formatRelativeTime";
 import { WorktreeSidebarSearchBar, QuickStateFilterBar } from "@/components/Worktree";
 import { BulkCreateWorktreeDialog } from "@/components/GitHub/BulkCreateWorktreeDialog";
 import { FleetPickerPalette } from "@/components/Fleet/FleetPickerPalette";
@@ -85,6 +86,12 @@ const QUICK_STATE_LABELS: Record<"working" | "waiting" | "finished", string> = {
 };
 
 const KEYBOARD_REORDER_ANNOUNCEMENT_DEBOUNCE_MS = 150;
+
+// Threshold for escalating the "Reconnecting…" badge to include the time
+// since data last arrived. 10s sits above the Doherty 400ms gate so the
+// indicator never flickers on transient reconnects, and below the worst-case
+// ~14s workspace-host restart budget so it fires before `setFatalError`.
+const RECONNECT_ESCALATE_MS = 10_000;
 
 function truncateSearchQuery(trimmedQuery: string) {
   const codepoints = Array.from(trimmedQuery);
@@ -155,8 +162,24 @@ function SidebarContent({ onOpenOverview }: SidebarContentProps) {
     scrollContainerRef,
     { onKeyboardReorder: handleKeyboardReorder }
   );
-  const { worktrees, isLoading, isReconnecting, error, refresh } = useWorktrees();
+  const { worktrees, isLoading, isReconnecting, reconnectingAt, error, refresh } = useWorktrees();
   worktreesRef.current = worktrees;
+
+  // 1Hz tick that drives the escalated "Reconnecting… last updated X ago"
+  // copy. The store holds the start timestamp; this state forces a render so
+  // `formatRelativeTime(reconnectingAt)` recomputes against the latest clock.
+  // Effect re-runs on every new disconnect via `reconnectingAt` dep, so the
+  // baseline is always fresh — no stale-closure risk.
+  const [, setReconnectTick] = useState(0);
+  useEffect(() => {
+    if (!isReconnecting || reconnectingAt == null) return;
+    const id = setInterval(() => setReconnectTick((n) => n + 1), 1000);
+    return () => clearInterval(id);
+  }, [isReconnecting, reconnectingAt]);
+  const showReconnectingEscalated =
+    isReconnecting &&
+    reconnectingAt !== null &&
+    Date.now() - reconnectingAt >= RECONNECT_ESCALATE_MS;
   const deferredWorktrees = useDeferredValue(worktrees);
   const [isRefreshing, startRefreshTransition] = useTransition();
   const showRefreshSpinner = useDeferredLoading(isRefreshing, UI_DOHERTY_THRESHOLD);
@@ -905,9 +928,12 @@ function SidebarContent({ onOpenOverview }: SidebarContentProps) {
               role="status"
               aria-live="polite"
               className="flex items-center gap-1 text-daintree-text/60 text-xs"
+              data-reconnect-escalated={showReconnectingEscalated ? "true" : undefined}
             >
               <RefreshCw className="w-3 h-3 animate-spin" aria-hidden="true" />
-              Reconnecting…
+              {showReconnectingEscalated && reconnectingAt !== null
+                ? `Reconnecting… last updated ${formatRelativeTime(reconnectingAt)}`
+                : "Reconnecting…"}
             </span>
           )}
         </div>

--- a/src/components/Worktree/WorktreeCard/UpstreamSyncBadge.tsx
+++ b/src/components/Worktree/WorktreeCard/UpstreamSyncBadge.tsx
@@ -4,20 +4,7 @@ import { Tooltip, TooltipContent, TooltipTrigger } from "../../ui/tooltip";
 import { actionService } from "@/services/ActionService";
 import { useDeferredLoading } from "@/hooks/useDeferredLoading";
 import { UI_SKELETON_GATE_MS } from "@/lib/animationUtils";
-
-const RELATIVE_TIME_FORMATTER = new Intl.RelativeTimeFormat("en", { numeric: "auto" });
-
-function formatLastFetched(epochMs: number, now: number = Date.now()): string {
-  const deltaSeconds = Math.round((epochMs - now) / 1000);
-  const absSeconds = Math.abs(deltaSeconds);
-  if (absSeconds < 60) return RELATIVE_TIME_FORMATTER.format(deltaSeconds, "second");
-  const deltaMinutes = Math.round(deltaSeconds / 60);
-  if (Math.abs(deltaMinutes) < 60) return RELATIVE_TIME_FORMATTER.format(deltaMinutes, "minute");
-  const deltaHours = Math.round(deltaMinutes / 60);
-  if (Math.abs(deltaHours) < 24) return RELATIVE_TIME_FORMATTER.format(deltaHours, "hour");
-  const deltaDays = Math.round(deltaHours / 24);
-  return RELATIVE_TIME_FORMATTER.format(deltaDays, "day");
-}
+import { formatRelativeTime } from "@/lib/formatRelativeTime";
 
 interface UpstreamSyncBadgeProps {
   aheadCount: number | undefined;
@@ -80,7 +67,7 @@ export function UpstreamSyncBadge({
           <div>GitHub authentication failed</div>
           <div className="text-daintree-text/70 mt-0.5">Click to reconnect GitHub</div>
           {lastFetchedAt != null && (
-            <div className="text-text-muted">Last fetched {formatLastFetched(lastFetchedAt)}</div>
+            <div className="text-text-muted">Last fetched {formatRelativeTime(lastFetchedAt)}</div>
           )}
         </TooltipContent>
       </Tooltip>
@@ -126,7 +113,7 @@ export function UpstreamSyncBadge({
           </div>
         )}
         {lastFetchedAt != null && (
-          <div className="text-text-muted">Last fetched {formatLastFetched(lastFetchedAt)}</div>
+          <div className="text-text-muted">Last fetched {formatRelativeTime(lastFetchedAt)}</div>
         )}
       </TooltipContent>
     </Tooltip>

--- a/src/hooks/useWorktrees.ts
+++ b/src/hooks/useWorktrees.ts
@@ -10,6 +10,7 @@ export interface UseWorktreesReturn {
   isLoading: boolean;
   isInitialized: boolean;
   isReconnecting: boolean;
+  reconnectingAt: number | null;
   error: string | null;
   refresh: () => Promise<void>;
   setActive: (id: string) => void;
@@ -28,6 +29,7 @@ export function useWorktrees(): UseWorktreesReturn {
   const isLoading = useWorktreeStore((state) => state.isLoading);
   const isInitialized = useWorktreeStore((state) => state.isInitialized);
   const isReconnecting = useWorktreeStore((state) => state.isReconnecting);
+  const reconnectingAt = useWorktreeStore((state) => state.reconnectingAt);
   const error = useWorktreeStore((state) => state.error);
 
   const refresh = useCallback(async () => {
@@ -68,6 +70,7 @@ export function useWorktrees(): UseWorktreesReturn {
     isLoading,
     isInitialized,
     isReconnecting,
+    reconnectingAt,
     error,
     refresh,
     setActive,

--- a/src/lib/formatRelativeTime.ts
+++ b/src/lib/formatRelativeTime.ts
@@ -1,0 +1,13 @@
+const RELATIVE_TIME_FORMATTER = new Intl.RelativeTimeFormat("en", { numeric: "auto" });
+
+export function formatRelativeTime(epochMs: number, now: number = Date.now()): string {
+  const deltaSeconds = Math.round((epochMs - now) / 1000);
+  const absSeconds = Math.abs(deltaSeconds);
+  if (absSeconds < 60) return RELATIVE_TIME_FORMATTER.format(deltaSeconds, "second");
+  const deltaMinutes = Math.round(deltaSeconds / 60);
+  if (Math.abs(deltaMinutes) < 60) return RELATIVE_TIME_FORMATTER.format(deltaMinutes, "minute");
+  const deltaHours = Math.round(deltaMinutes / 60);
+  if (Math.abs(deltaHours) < 24) return RELATIVE_TIME_FORMATTER.format(deltaHours, "hour");
+  const deltaDays = Math.round(deltaHours / 24);
+  return RELATIVE_TIME_FORMATTER.format(deltaDays, "day");
+}

--- a/src/services/actions/__tests__/actionDefinitions.quality.test.ts
+++ b/src/services/actions/__tests__/actionDefinitions.quality.test.ts
@@ -301,6 +301,7 @@ describe("destructive-action danger metadata", () => {
       error: null,
       isInitialized: true,
       isReconnecting: false,
+      reconnectingAt: null,
       nextVersion: () => 1,
       applySnapshot: () => {},
       applyUpdate: () => {},

--- a/src/store/__tests__/createWorktreeStore.reconnecting.test.ts
+++ b/src/store/__tests__/createWorktreeStore.reconnecting.test.ts
@@ -1,4 +1,4 @@
-import { describe, expect, it } from "vitest";
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
 import { createWorktreeStore } from "@/store/createWorktreeStore";
 import type { WorktreeSnapshot } from "@shared/types";
 
@@ -76,6 +76,97 @@ describe("createWorktreeStore — reconnecting state", () => {
     store.getState().setReconnecting(true);
     store.getState().setReconnecting(false);
     expect(store.getState().isReconnecting).toBe(false);
+  });
+});
+
+describe("createWorktreeStore — reconnectingAt timestamp", () => {
+  beforeEach(() => {
+    vi.useFakeTimers();
+    vi.setSystemTime(new Date("2026-01-01T00:00:00Z"));
+  });
+
+  afterEach(() => {
+    vi.useRealTimers();
+  });
+
+  it("starts with reconnectingAt=null", () => {
+    const store = createWorktreeStore();
+    expect(store.getState().reconnectingAt).toBeNull();
+  });
+
+  it("setReconnecting(true) captures Date.now() in reconnectingAt", () => {
+    const store = createWorktreeStore();
+    const before = Date.now();
+    store.getState().setReconnecting(true);
+    expect(store.getState().reconnectingAt).toBe(before);
+  });
+
+  it("setReconnecting(false) clears reconnectingAt to null", () => {
+    const store = createWorktreeStore();
+    store.getState().setReconnecting(true);
+    expect(store.getState().reconnectingAt).not.toBeNull();
+    store.getState().setReconnecting(false);
+    expect(store.getState().reconnectingAt).toBeNull();
+  });
+
+  it("repeated setReconnecting(true) refreshes the timestamp baseline", () => {
+    const store = createWorktreeStore();
+    store.getState().setReconnecting(true);
+    const first = store.getState().reconnectingAt;
+    vi.advanceTimersByTime(5000);
+    store.getState().setReconnecting(true);
+    const second = store.getState().reconnectingAt;
+    expect(second).not.toBeNull();
+    expect(second).toBeGreaterThan(first ?? 0);
+  });
+
+  it("applySnapshot normal-path clears reconnectingAt", () => {
+    const store = createWorktreeStore();
+    store.getState().setReconnecting(true);
+    expect(store.getState().reconnectingAt).not.toBeNull();
+
+    const version = store.getState().nextVersion();
+    store.getState().applySnapshot([makeSnapshot("wt-1")], version);
+
+    expect(store.getState().reconnectingAt).toBeNull();
+  });
+
+  it("applySnapshot no-op early-return path clears reconnectingAt", () => {
+    const store = createWorktreeStore();
+
+    // Hydrate so the value-equality early-return path triggers on the next call
+    const v1 = store.getState().nextVersion();
+    store.getState().applySnapshot([makeSnapshot("wt-1")], v1);
+    store.getState().setReconnecting(true);
+    expect(store.getState().reconnectingAt).not.toBeNull();
+
+    const v2 = store.getState().nextVersion();
+    store.getState().applySnapshot([makeSnapshot("wt-1")], v2);
+
+    expect(store.getState().reconnectingAt).toBeNull();
+  });
+
+  it("setFatalError clears reconnectingAt", () => {
+    const store = createWorktreeStore();
+    store.getState().setReconnecting(true);
+    expect(store.getState().reconnectingAt).not.toBeNull();
+
+    store.getState().setFatalError("host crashed");
+
+    expect(store.getState().reconnectingAt).toBeNull();
+  });
+
+  it("stale-version applySnapshot does NOT clear reconnectingAt", () => {
+    const store = createWorktreeStore();
+
+    const v1 = store.getState().nextVersion();
+    store.getState().applySnapshot([makeSnapshot("wt-1")], v1);
+
+    store.getState().setReconnecting(true);
+    const captured = store.getState().reconnectingAt;
+    store.getState().applySnapshot([makeSnapshot("wt-stale")], v1);
+
+    expect(store.getState().reconnectingAt).toBe(captured);
   });
 });
 

--- a/src/store/__tests__/createWorktreeStore.reconnecting.test.ts
+++ b/src/store/__tests__/createWorktreeStore.reconnecting.test.ts
@@ -109,11 +109,26 @@ describe("createWorktreeStore — reconnectingAt timestamp", () => {
     expect(store.getState().reconnectingAt).toBeNull();
   });
 
-  it("repeated setReconnecting(true) refreshes the timestamp baseline", () => {
+  it("repeated setReconnecting(true) preserves the original baseline", () => {
+    // During a workspace-host crash-retry loop, `onDisconnected` fires on
+    // every restart. If `reconnectingAt` were re-stamped on each call, the
+    // elapsed clock would reset and the escalation copy would never appear
+    // before the restart budget exhausts (~14s) and `setFatalError` fires.
     const store = createWorktreeStore();
     store.getState().setReconnecting(true);
     const first = store.getState().reconnectingAt;
     vi.advanceTimersByTime(5000);
+    store.getState().setReconnecting(true);
+    expect(store.getState().reconnectingAt).toBe(first);
+  });
+
+  it("setReconnecting(true) after recovery captures a fresh timestamp", () => {
+    const store = createWorktreeStore();
+    store.getState().setReconnecting(true);
+    const first = store.getState().reconnectingAt;
+    vi.advanceTimersByTime(5000);
+    store.getState().setReconnecting(false);
+    vi.advanceTimersByTime(1000);
     store.getState().setReconnecting(true);
     const second = store.getState().reconnectingAt;
     expect(second).not.toBeNull();

--- a/src/store/createWorktreeStore.ts
+++ b/src/store/createWorktreeStore.ts
@@ -31,6 +31,7 @@ export interface WorktreeViewState {
   error: string | null;
   isInitialized: boolean;
   isReconnecting: boolean;
+  reconnectingAt: number | null;
 }
 
 export interface WorktreeViewActions {
@@ -57,6 +58,7 @@ export function createWorktreeStore(): WorktreeViewStoreApi {
     error: null,
     isInitialized: false,
     isReconnecting: false,
+    reconnectingAt: null,
 
     nextVersion() {
       return ++versionCounter;
@@ -83,6 +85,7 @@ export function createWorktreeStore(): WorktreeViewStoreApi {
           isInitialized: true,
           error: null,
           isReconnecting: false,
+          reconnectingAt: null,
         });
         return;
       }
@@ -94,6 +97,7 @@ export function createWorktreeStore(): WorktreeViewStoreApi {
         isInitialized: true,
         error: null,
         isReconnecting: false,
+        reconnectingAt: null,
       });
     },
 
@@ -142,12 +146,16 @@ export function createWorktreeStore(): WorktreeViewStoreApi {
         error: message,
         isInitialized: false,
         isReconnecting: false,
+        reconnectingAt: null,
         isLoading: false,
       });
     },
 
     setReconnecting(reconnecting: boolean) {
-      set({ isReconnecting: reconnecting });
+      set({
+        isReconnecting: reconnecting,
+        reconnectingAt: reconnecting ? Date.now() : null,
+      });
     },
   }));
 }

--- a/src/store/createWorktreeStore.ts
+++ b/src/store/createWorktreeStore.ts
@@ -152,9 +152,20 @@ export function createWorktreeStore(): WorktreeViewStoreApi {
     },
 
     setReconnecting(reconnecting: boolean) {
+      // Preserve the original disconnect timestamp across repeated
+      // setReconnecting(true) calls. During a workspace-host crash-retry
+      // loop, `onDisconnected` can fire on every restart attempt; resetting
+      // the baseline on each fire would keep the elapsed clock under the
+      // escalation threshold for the entire ~14s restart budget, so the
+      // escalated copy would never appear before `setFatalError` fires.
+      const prev = get();
       set({
         isReconnecting: reconnecting,
-        reconnectingAt: reconnecting ? Date.now() : null,
+        reconnectingAt: reconnecting
+          ? prev.isReconnecting && prev.reconnectingAt !== null
+            ? prev.reconnectingAt
+            : Date.now()
+          : null,
       });
     },
   }));


### PR DESCRIPTION
## Summary

Adds a tier-2 escalation to the sidebar's "Reconnecting…" badge so that after sustained disconnect (~10s) it upgrades to include how long ago data was last fresh, sitting between the immediate badge (tier 1) and the fatal-error state (tier 3) of the workspace-host reconnect lifecycle.

- Add `reconnectingAt: number | null` to `WorktreeViewStore`. Captured on the **first** `setReconnecting(true)` and preserved across subsequent calls during the same disconnect episode, so a workspace-host crash-retry loop (`maxRestartAttempts=3`, exponential backoff up to ~14s) doesn't keep resetting the elapsed clock and starving the escalation. Cleared on recovery, `applySnapshot` (both the normal path and the value-equal early-return), and `setFatalError`.
- `SidebarContent` runs a 1Hz tick effect keyed on `[isReconnecting, reconnectingAt]` and renders `Reconnecting… last updated {formatRelativeTime}` after `RECONNECT_ESCALATE_MS` (10s) — `text-daintree-text/60`, no accent, same `text-xs` chrome.
- Extracts the `Intl.RelativeTimeFormat` helper from `UpstreamSyncBadge` into `src/lib/formatRelativeTime.ts` for reuse by both call sites.
- 8 new store tests covering the timestamp lifecycle, including the idempotency invariant uncovered during review.

Closes #8075.

## Test plan

- [x] `npx vitest run src/store/__tests__/createWorktreeStore.reconnecting.test.ts` — 26 tests pass (was 18 before)
- [x] `npx tsc --noEmit` — clean (fixture updates in `fleetBroadcast.test.ts` and `actionDefinitions.quality.test.ts` for the new required `reconnectingAt` field)
- [x] `npm run check` (typecheck, channels, ipc, help, format, lint) — pass, 0 errors
- [ ] Manual: disconnect the workspace host, watch the badge upgrade at ~10s, confirm copy reads `Reconnecting… last updated 12 seconds ago` (and rolls to minutes after 60s)
- [ ] Manual: trigger a crash-retry loop (e.g., force-kill the host repeatedly) and confirm the escalated copy appears before `setFatalError` fires