### PR TITLE
feat(notifications): add Done state and supersede machinery

### DIFF
--- a/src/components/Notifications/NotificationCenter.tsx
+++ b/src/components/Notifications/NotificationCenter.tsx
@@ -1,5 +1,14 @@
 import { useCallback, useEffect, useMemo, useRef, useState } from "react";
-import { ArrowDown, Bell, CheckCheck, Ellipsis, Layers, Moon, Trash2 } from "lucide-react";
+import {
+  Archive,
+  ArrowDown,
+  Bell,
+  CheckCheck,
+  Ellipsis,
+  Layers,
+  Moon,
+  Trash2,
+} from "lucide-react";
 import { useShallow } from "zustand/react/shallow";
 import {
   useNotificationHistoryStore,
@@ -164,6 +173,8 @@ export function NotificationCenter({ open, onClose }: NotificationCenterProps) {
   const markUnseenAsToast = useNotificationHistoryStore((s) => s.markUnseenAsToast);
   const dismissEntry = useNotificationHistoryStore((s) => s.dismissEntry);
   const dismissByCorrelationId = useNotificationHistoryStore((s) => s.dismissByCorrelationId);
+  const archiveEntry = useNotificationHistoryStore((s) => s.archiveEntry);
+  const archiveByCorrelationId = useNotificationHistoryStore((s) => s.archiveByCorrelationId);
 
   const {
     quietUntil,
@@ -188,7 +199,7 @@ export function NotificationCenter({ open, onClose }: NotificationCenterProps) {
   const lastClosedAt = useUIStore((s) => s.lastNotificationCenterClosedAt);
   const resetLastClosedAt = useUIStore((s) => s.resetNotificationCenterLastClosedAt);
 
-  const [filter, setFilter] = useState<"all" | "unread">("all");
+  const [filter, setFilter] = useState<"all" | "unread" | "archived">("all");
   const [frozenUnreadIds, setFrozenUnreadIds] = useState<Set<string> | null>(null);
   const [scrollContainer, setScrollContainer] = useState<HTMLDivElement | null>(null);
   const [dividerEl, setDividerEl] = useState<HTMLDivElement | null>(null);
@@ -279,31 +290,42 @@ export function NotificationCenter({ open, onClose }: NotificationCenterProps) {
   }, [showJumpPill]);
 
   const filteredEntries = useMemo(() => {
-    if (filter === "all") return entries;
-    if (frozenUnreadIds) {
-      return entries.filter((e) => !e.seenAsToast || frozenUnreadIds.has(e.id));
+    if (filter === "archived") {
+      return entries.filter((e) => e.archivedAt !== null);
     }
-    return entries.filter((e) => !e.seenAsToast);
+    if (filter === "all") {
+      // Archived entries belong to the Archived tab only — they're done.
+      return entries.filter((e) => e.archivedAt === null);
+    }
+    if (frozenUnreadIds) {
+      return entries.filter(
+        (e) => e.archivedAt === null && (!e.seenAsToast || frozenUnreadIds.has(e.id))
+      );
+    }
+    return entries.filter((e) => e.archivedAt === null && !e.seenAsToast);
   }, [entries, filter, frozenUnreadIds]);
 
   const { needsAttentionGroups, chronoSections, dividerGroupId } = useMemo(() => {
     // Pinned reflects the global unread severe-threads set so it stays the
-    // same in All and Unread filter views. Chrono respects the active filter.
-    const rawGroups = groupByCorrelationId(entries);
-    const pinned = rawGroups
-      .filter((g) => {
-        if (!isUnreadGroup(g)) return false;
-        const sev = getWorstSeverity(g.entries);
-        return sev === "error" || sev === "warning";
-      })
-      .sort((a, b) => {
-        const sevDiff =
-          SEVERITY_WEIGHTS[getWorstSeverity(b.entries)] -
-          SEVERITY_WEIGHTS[getWorstSeverity(a.entries)];
-        if (sevDiff !== 0) return sevDiff;
-        return b.latestTimestamp - a.latestTimestamp;
-      })
-      .slice(0, NEEDS_ATTENTION_CAP);
+    // same in All and Unread filter views. Hidden in Archived — pinned is for
+    // active items only. Chrono respects the active filter.
+    const pinned =
+      filter === "archived"
+        ? []
+        : groupByCorrelationId(entries.filter((e) => e.archivedAt === null))
+            .filter((g) => {
+              if (!isUnreadGroup(g)) return false;
+              const sev = getWorstSeverity(g.entries);
+              return sev === "error" || sev === "warning";
+            })
+            .sort((a, b) => {
+              const sevDiff =
+                SEVERITY_WEIGHTS[getWorstSeverity(b.entries)] -
+                SEVERITY_WEIGHTS[getWorstSeverity(a.entries)];
+              if (sevDiff !== 0) return sevDiff;
+              return b.latestTimestamp - a.latestTimestamp;
+            })
+            .slice(0, NEEDS_ATTENTION_CAP);
 
     const chronoGroups = groupByCorrelationId(filteredEntries);
     const sections: ContextSection[] = groupByContext
@@ -311,7 +333,7 @@ export function NotificationCenter({ open, onClose }: NotificationCenterProps) {
       : [{ key: "all", groups: chronoGroups }];
 
     let divider: string | null = null;
-    if (lastClosedAt > 0) {
+    if (lastClosedAt > 0 && filter !== "archived") {
       for (const g of chronoGroups) {
         if (g.latestTimestamp > lastClosedAt) {
           divider = g.correlationId ?? g.entries[0]?.id ?? null;
@@ -325,7 +347,7 @@ export function NotificationCenter({ open, onClose }: NotificationCenterProps) {
       chronoSections: sections,
       dividerGroupId: divider,
     };
-  }, [entries, filteredEntries, groupByContext, lastClosedAt]);
+  }, [entries, filteredEntries, groupByContext, lastClosedAt, filter]);
 
   const totalChronoGroups = chronoSections.reduce((sum, s) => sum + s.groups.length, 0);
 
@@ -455,6 +477,17 @@ export function NotificationCenter({ open, onClose }: NotificationCenterProps) {
     [dismissByCorrelationId, dismissEntry]
   );
 
+  const archiveRow = useCallback(
+    (row: FlatRow) => {
+      if (row.isThread && row.correlationId) {
+        archiveByCorrelationId(row.correlationId);
+      } else {
+        archiveEntry(row.entryId);
+      }
+    },
+    [archiveByCorrelationId, archiveEntry]
+  );
+
   const moveFocusTo = useCallback((index: number) => {
     const target = rowRefs.current.get(index);
     if (target) {
@@ -504,7 +537,14 @@ export function NotificationCenter({ open, onClose }: NotificationCenterProps) {
         case "e": {
           e.preventDefault();
           const row = flatRows[activeIndex];
-          if (row) dismissRow(row);
+          if (!row) return;
+          // In the Archived tab, 'e' acts as a permanent delete — there's no
+          // re-archive to perform and users still need a one-key purge path.
+          if (filter === "archived") {
+            dismissRow(row);
+          } else {
+            archiveRow(row);
+          }
           return;
         }
         case "Enter": {
@@ -518,7 +558,7 @@ export function NotificationCenter({ open, onClose }: NotificationCenterProps) {
           return;
       }
     },
-    [rowCount, flatRows, moveFocusTo, dismissRow, dispatchPrimaryAction]
+    [rowCount, flatRows, moveFocusTo, dismissRow, archiveRow, dispatchPrimaryAction, filter]
   );
 
   const handleMarkAllRead = () => {
@@ -603,6 +643,22 @@ export function NotificationCenter({ open, onClose }: NotificationCenterProps) {
                 )}
               >
                 Unread
+              </button>
+              <button
+                type="button"
+                aria-pressed={filter === "archived"}
+                onClick={() => {
+                  setFilter("archived");
+                  setFrozenUnreadIds(null);
+                }}
+                className={cn(
+                  "inline-flex items-center px-2 py-0.5 text-[11px] rounded-full transition-colors",
+                  filter === "archived"
+                    ? "bg-filter-selected-bg-strong text-daintree-text font-medium"
+                    : "text-daintree-text/60 hover:text-daintree-text hover:bg-tint/[0.04]"
+                )}
+              >
+                Archived
               </button>
             </>
           )}
@@ -715,7 +771,15 @@ export function NotificationCenter({ open, onClose }: NotificationCenterProps) {
           className="h-full overflow-y-auto"
         >
           {totalChronoGroups === 0 && needsAttentionGroups.length === 0 ? (
-            filter === "unread" && entries.length > 0 ? (
+            filter === "archived" && entries.length > 0 ? (
+              <EmptyState
+                variant="user-cleared"
+                scale="canvas"
+                title="No archived notifications"
+                icon={<Archive />}
+                className="py-10"
+              />
+            ) : filter === "unread" && entries.length > 0 ? (
               // Canvas scale: the bell dropdown is a 360px panel-style surface that
               // mirrors GitHubResourceList ("connection-gated panel" example in
               // CLAUDE.md). The "Notifications appear here" guidance and the

--- a/src/components/Notifications/NotificationCenter.tsx
+++ b/src/components/Notifications/NotificationCenter.tsx
@@ -466,17 +466,6 @@ export function NotificationCenter({ open, onClose }: NotificationCenterProps) {
     void actionService.dispatch(action.actionId as ActionId, action.actionArgs);
   }, []);
 
-  const dismissRow = useCallback(
-    (row: FlatRow) => {
-      if (row.isThread && row.correlationId) {
-        dismissByCorrelationId(row.correlationId);
-      } else {
-        dismissEntry(row.entryId);
-      }
-    },
-    [dismissByCorrelationId, dismissEntry]
-  );
-
   const archiveRow = useCallback(
     (row: FlatRow) => {
       if (row.isThread && row.correlationId) {
@@ -538,10 +527,11 @@ export function NotificationCenter({ open, onClose }: NotificationCenterProps) {
           e.preventDefault();
           const row = flatRows[activeIndex];
           if (!row) return;
-          // In the Archived tab, 'e' acts as a permanent delete — there's no
-          // re-archive to perform and users still need a one-key purge path.
+          // In the Archived tab, 'e' permanently deletes the visible (head)
+          // entry. Do NOT route threads through dismissByCorrelationId — a
+          // live entry sharing the same correlationId would also be destroyed.
           if (filter === "archived") {
-            dismissRow(row);
+            dismissEntry(row.entryId);
           } else {
             archiveRow(row);
           }
@@ -558,11 +548,13 @@ export function NotificationCenter({ open, onClose }: NotificationCenterProps) {
           return;
       }
     },
-    [rowCount, flatRows, moveFocusTo, dismissRow, archiveRow, dispatchPrimaryAction, filter]
+    [rowCount, flatRows, moveFocusTo, dismissEntry, archiveRow, dispatchPrimaryAction, filter]
   );
 
   const handleMarkAllRead = () => {
-    const ids = entries.filter((e) => !e.seenAsToast).map((e) => e.id);
+    // Archived entries are already done; they must never appear in the
+    // mark-all-read undo set or the "Marked N as read" count.
+    const ids = entries.filter((e) => !e.seenAsToast && !e.archivedAt).map((e) => e.id);
     if (filter === "unread") {
       setFrozenUnreadIds(new Set(ids));
     }

--- a/src/components/Notifications/NotificationCenter.tsx
+++ b/src/components/Notifications/NotificationCenter.tsx
@@ -1,14 +1,5 @@
 import { useCallback, useEffect, useMemo, useRef, useState } from "react";
-import {
-  Archive,
-  ArrowDown,
-  Bell,
-  CheckCheck,
-  Ellipsis,
-  Layers,
-  Moon,
-  Trash2,
-} from "lucide-react";
+import { Archive, ArrowDown, Bell, CheckCheck, Ellipsis, Layers, Moon, Trash2 } from "lucide-react";
 import { useShallow } from "zustand/react/shallow";
 import {
   useNotificationHistoryStore,

--- a/src/components/Notifications/__tests__/NotificationCenter.test.tsx
+++ b/src/components/Notifications/__tests__/NotificationCenter.test.tsx
@@ -45,12 +45,15 @@ function makeEntry(overrides: Partial<NotificationHistoryEntry> = {}): Notificat
     seenAsToast: true,
     summarized: false,
     countable: true,
+    archivedAt: null,
     ...overrides,
   };
 }
 
 function setEntries(entries: NotificationHistoryEntry[]) {
-  const unreadCount = entries.filter((e) => !e.seenAsToast && e.countable !== false).length;
+  const unreadCount = entries.filter(
+    (e) => !e.seenAsToast && e.countable !== false && !e.archivedAt
+  ).length;
   useNotificationHistoryStore.setState({ entries, unreadCount });
 }
 
@@ -2247,5 +2250,153 @@ describe("NotificationCenter — keyboard navigation", () => {
 
     fireEvent.keyDown(list, { key: "e" });
     expect(useNotificationHistoryStore.getState().entries.length).toBe(2);
+  });
+});
+
+describe("archived tab and 'e' archive keybinding", () => {
+  function getRows(container: HTMLElement) {
+    return Array.from(container.querySelectorAll('[role="listitem"]')) as HTMLElement[];
+  }
+
+  it("'e' archives the focused row without destroying the entry", async () => {
+    setEntries([
+      makeEntry({ id: "a", message: "Keep" }),
+      makeEntry({ id: "b", message: "Archive me" }),
+    ]);
+    const { container } = render(<NotificationCenter open onClose={vi.fn()} />);
+    const list = container.querySelector('[role="list"]') as HTMLElement;
+
+    act(() => {
+      getRows(container)[1]?.focus();
+    });
+
+    await act(async () => {
+      fireEvent.keyDown(list, { key: "e" });
+    });
+
+    // The All view filters archived entries out, so the row disappears.
+    await waitFor(() => {
+      expect(getRows(container)).toHaveLength(1);
+    });
+    // But the underlying entry survives — it moved to the Archived tab.
+    const entries = useNotificationHistoryStore.getState().entries;
+    expect(entries).toHaveLength(2);
+    const archived = entries.find((e) => e.id === "b")!;
+    expect(archived.archivedAt).not.toBeNull();
+    expect(archived.seenAsToast).toBe(true);
+  });
+
+  it("'e' on a thread archives every non-archived entry in the thread", async () => {
+    setEntries([
+      makeEntry({ id: "t1", message: "first", correlationId: "thread" }),
+      makeEntry({ id: "t2", message: "second", correlationId: "thread" }),
+    ]);
+    const { container } = render(<NotificationCenter open onClose={vi.fn()} />);
+    const list = container.querySelector('[role="list"]') as HTMLElement;
+
+    act(() => {
+      getRows(container)[0]?.focus();
+    });
+
+    await act(async () => {
+      fireEvent.keyDown(list, { key: "e" });
+    });
+
+    const entries = useNotificationHistoryStore.getState().entries;
+    expect(entries.find((e) => e.id === "t1")!.archivedAt).not.toBeNull();
+    expect(entries.find((e) => e.id === "t2")!.archivedAt).not.toBeNull();
+  });
+
+  it("All view hides archived entries", () => {
+    setEntries([
+      makeEntry({ id: "live", message: "Live entry" }),
+      makeEntry({ id: "done", message: "Archived entry", archivedAt: Date.now() }),
+    ]);
+    render(<NotificationCenter open onClose={vi.fn()} />);
+    expect(screen.queryByText("Live entry")).not.toBeNull();
+    expect(screen.queryByText("Archived entry")).toBeNull();
+  });
+
+  it("Archived tab shows only archived entries", () => {
+    setEntries([
+      makeEntry({ id: "live", message: "Live entry" }),
+      makeEntry({ id: "done", message: "Archived entry", archivedAt: Date.now() }),
+    ]);
+    render(<NotificationCenter open onClose={vi.fn()} />);
+    fireEvent.click(screen.getByRole("button", { name: "Archived" }));
+    expect(screen.queryByText("Archived entry")).not.toBeNull();
+    expect(screen.queryByText("Live entry")).toBeNull();
+  });
+
+  it("Unread tab hides archived entries", () => {
+    setEntries([
+      makeEntry({ id: "unread", message: "Unread live", seenAsToast: false }),
+      makeEntry({
+        id: "archived-unread",
+        message: "Archived ignored",
+        seenAsToast: false,
+        archivedAt: Date.now(),
+      }),
+    ]);
+    render(<NotificationCenter open onClose={vi.fn()} />);
+    fireEvent.click(screen.getByRole("button", { name: "Unread" }));
+    expect(screen.queryByText("Unread live")).not.toBeNull();
+    expect(screen.queryByText("Archived ignored")).toBeNull();
+  });
+
+  it("Archived tab does not render the Needs attention pinned section", () => {
+    setEntries([
+      makeEntry({
+        id: "err",
+        type: "error",
+        message: "Pinned error",
+        seenAsToast: false,
+      }),
+      makeEntry({
+        id: "done",
+        message: "Archived entry",
+        archivedAt: Date.now(),
+      }),
+    ]);
+    const { container } = render(<NotificationCenter open onClose={vi.fn()} />);
+    expect(container.querySelector('[data-testid="needs-attention-section"]')).not.toBeNull();
+    fireEvent.click(screen.getByRole("button", { name: "Archived" }));
+    expect(container.querySelector('[data-testid="needs-attention-section"]')).toBeNull();
+  });
+
+  it("Archived tab shows the empty state when no archived entries exist", () => {
+    setEntries([makeEntry({ id: "live", message: "Live" })]);
+    render(<NotificationCenter open onClose={vi.fn()} />);
+    fireEvent.click(screen.getByRole("button", { name: "Archived" }));
+    expect(screen.queryByText("No archived notifications")).not.toBeNull();
+  });
+
+  it("'e' in the Archived tab permanently deletes the focused entry", async () => {
+    setEntries([
+      makeEntry({ id: "live", message: "Live entry" }),
+      makeEntry({ id: "done", message: "Archived entry", archivedAt: Date.now() }),
+    ]);
+    const { container } = render(<NotificationCenter open onClose={vi.fn()} />);
+    fireEvent.click(screen.getByRole("button", { name: "Archived" }));
+    const list = container.querySelector('[role="list"]') as HTMLElement;
+
+    act(() => {
+      getRows(container)[0]?.focus();
+    });
+
+    await act(async () => {
+      fireEvent.keyDown(list, { key: "e" });
+    });
+
+    // Archived entry is gone from store entirely.
+    const entries = useNotificationHistoryStore.getState().entries;
+    expect(entries.find((e) => e.id === "done")).toBeUndefined();
+    expect(entries.find((e) => e.id === "live")).not.toBeUndefined();
+  });
+
+  it("the Archived button is not rendered when there are zero entries", () => {
+    setEntries([]);
+    render(<NotificationCenter open onClose={vi.fn()} />);
+    expect(screen.queryByRole("button", { name: "Archived" })).toBeNull();
   });
 });

--- a/src/components/Notifications/__tests__/NotificationCenter.test.tsx
+++ b/src/components/Notifications/__tests__/NotificationCenter.test.tsx
@@ -2399,4 +2399,67 @@ describe("archived tab and 'e' archive keybinding", () => {
     render(<NotificationCenter open onClose={vi.fn()} />);
     expect(screen.queryByRole("button", { name: "Archived" })).toBeNull();
   });
+
+  it("'e' on an archived thread does not destroy live entries sharing the correlationId", async () => {
+    setEntries([
+      makeEntry({
+        id: "live",
+        message: "Active partner",
+        correlationId: "panel-1",
+        archivedAt: null,
+        seenAsToast: false,
+      }),
+      makeEntry({
+        id: "arch-a",
+        message: "Done A",
+        correlationId: "panel-1",
+        archivedAt: Date.now(),
+      }),
+      makeEntry({
+        id: "arch-b",
+        message: "Done B",
+        correlationId: "panel-1",
+        archivedAt: Date.now(),
+      }),
+    ]);
+    const { container } = render(<NotificationCenter open onClose={vi.fn()} />);
+    fireEvent.click(screen.getByRole("button", { name: "Archived" }));
+    const list = container.querySelector('[role="list"]') as HTMLElement;
+
+    act(() => {
+      getRows(container)[0]?.focus();
+    });
+
+    await act(async () => {
+      fireEvent.keyDown(list, { key: "e" });
+    });
+
+    // The live entry must survive — pressing 'e' on the archived thread must
+    // not call dismissByCorrelationId across the correlationId boundary.
+    const entries = useNotificationHistoryStore.getState().entries;
+    expect(entries.find((e) => e.id === "live")).not.toBeUndefined();
+  });
+
+  it("Mark all read excludes archived entries from its undo set", () => {
+    setEntries([
+      makeEntry({ id: "live-unread", message: "Live unread", seenAsToast: false }),
+      makeEntry({
+        id: "archived-unread",
+        message: "Archived unread",
+        seenAsToast: false,
+        archivedAt: Date.now(),
+      }),
+    ]);
+    render(<NotificationCenter open onClose={vi.fn()} />);
+    fireEvent.click(screen.getByRole("button", { name: "Mark all read" }));
+    const archived = useNotificationHistoryStore
+      .getState()
+      .entries.find((e) => e.id === "archived-unread");
+    // Archived entry's seenAsToast must stay false — it's done, not unread.
+    expect(archived!.seenAsToast).toBe(false);
+    // The toast message should report only the live unread count.
+    expect(vi.mocked(notifyLib.notify)).toHaveBeenCalledWith(
+      expect.objectContaining({ message: "Marked 1 as read" })
+    );
+  });
 });

--- a/src/components/Notifications/__tests__/NotificationCenterEntry.test.tsx
+++ b/src/components/Notifications/__tests__/NotificationCenterEntry.test.tsx
@@ -19,6 +19,7 @@ function makeEntry(overrides: Partial<NotificationHistoryEntry> = {}): Notificat
     seenAsToast: true,
     summarized: false,
     countable: true,
+    archivedAt: null,
     ...overrides,
   };
 }

--- a/src/components/ui/__tests__/reentry-summary.test.tsx
+++ b/src/components/ui/__tests__/reentry-summary.test.tsx
@@ -24,6 +24,7 @@ function makeEntry(overrides: Partial<NotificationHistoryEntry> = {}): Notificat
     seenAsToast: false,
     summarized: false,
     countable: true,
+    archivedAt: null,
     ...overrides,
   };
 }

--- a/src/lib/__tests__/notify.test.ts
+++ b/src/lib/__tests__/notify.test.ts
@@ -169,6 +169,63 @@ describe("notify()", () => {
       });
       expect(useNotificationHistoryStore.getState().entries[0]!.correlationId).toBe("panel-abc");
     });
+
+    it("forwards supersedeKey to the history entry", () => {
+      vi.spyOn(document, "hasFocus").mockReturnValue(true);
+      notify({
+        type: "error",
+        message: "Disconnected",
+        priority: "high",
+        supersedeKey: "host.conn",
+      });
+      expect(useNotificationHistoryStore.getState().entries[0]!.supersedeKey).toBe("host.conn");
+    });
+
+    it("supersedeKey on a later notify archives the prior matching entry", () => {
+      vi.spyOn(document, "hasFocus").mockReturnValue(true);
+      notify({
+        type: "error",
+        message: "Disconnected",
+        priority: "high",
+        supersedeKey: "host.conn",
+      });
+      const errId = useNotificationHistoryStore.getState().entries[0]!.id;
+      notify({
+        type: "success",
+        message: "Reconnected",
+        priority: "high",
+        supersedeKey: "host.conn",
+      });
+      const entries = useNotificationHistoryStore.getState().entries;
+      expect(entries.find((e) => e.id === errId)!.archivedAt).not.toBeNull();
+    });
+
+    it("supersedes (exact id) on a later notify archives the named entry", () => {
+      vi.spyOn(document, "hasFocus").mockReturnValue(true);
+      notify({
+        type: "error",
+        message: "Disconnected",
+        priority: "high",
+      });
+      const errId = useNotificationHistoryStore.getState().entries[0]!.id;
+      notify({
+        type: "success",
+        message: "Recovered",
+        priority: "high",
+        supersedes: errId,
+      });
+      expect(
+        useNotificationHistoryStore.getState().entries.find((e) => e.id === errId)!.archivedAt
+      ).not.toBeNull();
+    });
+
+    it("supersede has no effect when fields are absent (existing callers unchanged)", () => {
+      vi.spyOn(document, "hasFocus").mockReturnValue(true);
+      notify({ type: "info", message: "a", priority: "high" });
+      notify({ type: "info", message: "b", priority: "high" });
+      const entries = useNotificationHistoryStore.getState().entries;
+      expect(entries.every((e) => e.archivedAt === null)).toBe(true);
+    });
   });
 
   describe("history actions — forwards serializable descriptors", () => {

--- a/src/lib/notify.ts
+++ b/src/lib/notify.ts
@@ -90,6 +90,21 @@ export interface NotifyPayload {
   priority?: NotificationPriority;
   /** Groups related notifications into a thread in the notification center */
   correlationId?: string;
+  /**
+   * Logical pairing key. When a later `notify()` carries the same
+   * `supersedeKey`, the prior non-archived inbox entry with that key is
+   * archived automatically — used for resolving-event pairs like
+   * "disconnected" → "reconnected" so the inbox doesn't accumulate stale
+   * stateful rows. Independent of `correlationId`: `correlationId` threads
+   * conversational entries; `supersedeKey` retires them.
+   */
+  supersedeKey?: string;
+  /**
+   * Exact id of a prior inbox entry to archive when this one is added.
+   * Takes precedence over `supersedeKey`. No-op when the target is missing
+   * or already archived.
+   */
+  supersedes?: string;
   /** When set, rapidly fired notifications with the same key coalesce into a single updating toast */
   coalesce?: CoalesceOptions;
   /** When false, the history entry exists but does not increment the unread badge. Defaults to true. */
@@ -500,6 +515,8 @@ export function notify(payload: NotifyPayload): string {
             countable: payload.countable,
             actions: historyActions.length > 0 ? historyActions : undefined,
             context,
+            supersedeKey: payload.supersedeKey,
+            supersedes: payload.supersedes,
           })
         : undefined;
     if (!notificationsEnabled || isQuiet) return "";
@@ -527,6 +544,8 @@ export function notify(payload: NotifyPayload): string {
           countable: payload.countable,
           actions: historyActions.length > 0 ? historyActions : undefined,
           context,
+          supersedeKey: payload.supersedeKey,
+          supersedes: payload.supersedes,
         })
       : undefined;
 

--- a/src/store/__tests__/notificationHistoryStore.test.ts
+++ b/src/store/__tests__/notificationHistoryStore.test.ts
@@ -664,4 +664,237 @@ describe("notificationHistorySlice", () => {
       expect(getState().unreadCount).toBe(0);
     });
   });
+
+  describe("archive (Done state)", () => {
+    it("defaults archivedAt to null on new entries", () => {
+      addEntry({ message: "test" });
+      expect(getState().entries[0]!.archivedAt).toBeNull();
+    });
+
+    it("archiveEntry sets archivedAt and seenAsToast atomically", () => {
+      const id = getState().addEntry({ type: "info", message: "live" });
+      expect(getState().entries[0]!.archivedAt).toBeNull();
+      expect(getState().entries[0]!.seenAsToast).toBe(false);
+      const before = Date.now();
+      getState().archiveEntry(id);
+      const after = Date.now();
+      const entry = getState().entries[0]!;
+      expect(entry.archivedAt).not.toBeNull();
+      expect(entry.archivedAt!).toBeGreaterThanOrEqual(before);
+      expect(entry.archivedAt!).toBeLessThanOrEqual(after);
+      expect(entry.seenAsToast).toBe(true);
+    });
+
+    it("archiveEntry decrements unreadCount", () => {
+      addEntry({ message: "a" });
+      addEntry({ message: "b" });
+      expect(getState().unreadCount).toBe(2);
+      const id = getState().entries[0]!.id;
+      getState().archiveEntry(id);
+      expect(getState().unreadCount).toBe(1);
+    });
+
+    it("archiveEntry preserves the entry (non-destructive)", () => {
+      const id = getState().addEntry({ type: "info", message: "still here" });
+      getState().archiveEntry(id);
+      expect(getState().entries).toHaveLength(1);
+      expect(getState().entries[0]!.message).toBe("still here");
+    });
+
+    it("archiveEntry is a no-op when entry is already archived", () => {
+      const id = getState().addEntry({ type: "info", message: "test" });
+      getState().archiveEntry(id);
+      const firstArchived = getState().entries[0]!.archivedAt;
+      const before = getState().entries[0];
+      getState().archiveEntry(id);
+      const after = getState().entries[0];
+      expect(after).toBe(before!);
+      expect(after!.archivedAt).toBe(firstArchived);
+    });
+
+    it("archiveEntry is a no-op when id does not exist", () => {
+      addEntry({ message: "test" });
+      const before = getState();
+      getState().archiveEntry("nonexistent-id");
+      const after = getState();
+      expect(after.entries).toBe(before.entries);
+      expect(after.unreadCount).toBe(before.unreadCount);
+    });
+
+    it("unreadCount excludes archived entries even when seenAsToast resets", () => {
+      const id = getState().addEntry({ type: "info", message: "live" });
+      getState().archiveEntry(id);
+      expect(getState().unreadCount).toBe(0);
+      // markUnseenAsToast checks `!entry.seenAsToast` first; since archive
+      // already set seenAsToast to true, this is a regular re-evict path.
+      getState().markUnseenAsToast(id);
+      // unreadCount must still exclude the archived entry even though it's
+      // now seenAsToast=false again.
+      expect(getState().unreadCount).toBe(0);
+    });
+
+    it("archiveByCorrelationId archives all non-archived entries in the thread", () => {
+      addEntry({ message: "a", correlationId: "panel-1" });
+      addEntry({ message: "b", correlationId: "panel-1" });
+      addEntry({ message: "c", correlationId: "panel-2" });
+      getState().archiveByCorrelationId("panel-1");
+      const entries = getState().entries;
+      expect(entries.find((e) => e.message === "a")!.archivedAt).not.toBeNull();
+      expect(entries.find((e) => e.message === "b")!.archivedAt).not.toBeNull();
+      expect(entries.find((e) => e.message === "c")!.archivedAt).toBeNull();
+    });
+
+    it("archiveByCorrelationId leaves already-archived entries untouched", () => {
+      addEntry({ message: "a", correlationId: "panel-1" });
+      const liveId = getState().addEntry({
+        type: "info",
+        message: "b",
+        correlationId: "panel-1",
+      });
+      const oldId = getState().entries.find((e) => e.message === "a")!.id;
+      getState().archiveEntry(oldId);
+      const oldArchivedAt = getState().entries.find((e) => e.id === oldId)!.archivedAt;
+      // Force a measurable delta so equality is meaningful even on machines
+      // where Date.now() returns the same value between calls.
+      const realDateNow = Date.now;
+      Date.now = () => realDateNow() + 50;
+      try {
+        getState().archiveByCorrelationId("panel-1");
+      } finally {
+        Date.now = realDateNow;
+      }
+      expect(getState().entries.find((e) => e.id === oldId)!.archivedAt).toBe(oldArchivedAt);
+      expect(getState().entries.find((e) => e.id === liveId)!.archivedAt).not.toBeNull();
+    });
+
+    it("archiveByCorrelationId is a no-op when nothing matches", () => {
+      addEntry({ message: "a", correlationId: "panel-1" });
+      const before = getState();
+      getState().archiveByCorrelationId("panel-99");
+      const after = getState();
+      expect(after.entries).toBe(before.entries);
+      expect(after.unreadCount).toBe(before.unreadCount);
+    });
+
+    it("archiveByCorrelationId decrements unreadCount only for newly-archived entries", () => {
+      addEntry({ message: "missed", correlationId: "panel-1" });
+      getState().addEntry({
+        type: "info",
+        message: "seen",
+        correlationId: "panel-1",
+        seenAsToast: true,
+      });
+      expect(getState().unreadCount).toBe(1);
+      getState().archiveByCorrelationId("panel-1");
+      expect(getState().unreadCount).toBe(0);
+    });
+  });
+
+  describe("supersede on addEntry", () => {
+    it("supersedes by exact id archives the target entry", () => {
+      const oldId = getState().addEntry({ type: "error", message: "Disconnected" });
+      getState().addEntry({
+        type: "success",
+        message: "Reconnected",
+        supersedes: oldId,
+      });
+      const old = getState().entries.find((e) => e.id === oldId)!;
+      expect(old.archivedAt).not.toBeNull();
+      expect(old.seenAsToast).toBe(true);
+    });
+
+    it("supersedes by id is a no-op when the target is missing", () => {
+      addEntry({ message: "live" });
+      const before = getState().entries.length;
+      getState().addEntry({
+        type: "success",
+        message: "Reconnected",
+        supersedes: "ghost-id",
+      });
+      // The new entry is still added; only the supersede lookup is a no-op.
+      expect(getState().entries.length).toBe(before + 1);
+    });
+
+    it("supersedes by id is a no-op when target is already archived", () => {
+      const oldId = getState().addEntry({ type: "error", message: "Disconnected" });
+      getState().archiveEntry(oldId);
+      const firstArchivedAt = getState().entries.find((e) => e.id === oldId)!.archivedAt;
+      const realDateNow = Date.now;
+      Date.now = () => realDateNow() + 100;
+      try {
+        getState().addEntry({
+          type: "success",
+          message: "Reconnected",
+          supersedes: oldId,
+        });
+      } finally {
+        Date.now = realDateNow;
+      }
+      // archivedAt stays at the original archive time — not re-archived.
+      expect(getState().entries.find((e) => e.id === oldId)!.archivedAt).toBe(firstArchivedAt);
+    });
+
+    it("supersedeKey archives the latest non-archived entry with the matching key", () => {
+      const key = "terminal.A.fallback";
+      getState().addEntry({ type: "error", message: "Disconnected", supersedeKey: key });
+      const errId = getState().entries[0]!.id;
+      getState().addEntry({ type: "success", message: "Reconnected", supersedeKey: key });
+      expect(getState().entries.find((e) => e.id === errId)!.archivedAt).not.toBeNull();
+    });
+
+    it("supersedeKey stores the key on the new entry for future archival", () => {
+      const key = "terminal.A.fallback";
+      getState().addEntry({ type: "error", message: "Disconnected", supersedeKey: key });
+      expect(getState().entries[0]!.supersedeKey).toBe(key);
+    });
+
+    it("supersedeKey skips already-archived entries with the same key", () => {
+      const key = "terminal.A.fallback";
+      getState().addEntry({ type: "error", message: "old", supersedeKey: key });
+      const oldId = getState().entries[0]!.id;
+      getState().archiveEntry(oldId);
+      const oldArchivedAt = getState().entries.find((e) => e.id === oldId)!.archivedAt;
+      getState().addEntry({ type: "info", message: "newer", supersedeKey: key });
+      // The pre-archived old entry stays untouched (archiveAt unchanged).
+      expect(getState().entries.find((e) => e.id === oldId)!.archivedAt).toBe(oldArchivedAt);
+    });
+
+    it("supersedes takes precedence over supersedeKey when both are present", () => {
+      const key = "k";
+      const targetId = getState().addEntry({ type: "error", message: "target", supersedeKey: key });
+      const otherId = getState().addEntry({
+        type: "error",
+        message: "decoy",
+        supersedeKey: key,
+      });
+      // newer non-archived match would be `otherId` via supersedeKey, but
+      // explicit supersedes:targetId wins.
+      getState().addEntry({
+        type: "success",
+        message: "fix",
+        supersedes: targetId,
+        supersedeKey: key,
+      });
+      expect(getState().entries.find((e) => e.id === targetId)!.archivedAt).not.toBeNull();
+      expect(getState().entries.find((e) => e.id === otherId)!.archivedAt).toBeNull();
+    });
+
+    it("addEntry without supersede fields does not archive anything", () => {
+      addEntry({ message: "a" });
+      addEntry({ message: "b" });
+      expect(getState().entries.every((e) => e.archivedAt === null)).toBe(true);
+    });
+
+    it("supersedes does not persist on the new entry", () => {
+      const oldId = getState().addEntry({ type: "error", message: "old" });
+      const newId = getState().addEntry({
+        type: "success",
+        message: "new",
+        supersedes: oldId,
+      });
+      // `supersedes` is a write-time directive, not stored state.
+      expect((getState().entries.find((e) => e.id === newId)! as { supersedes?: string }).supersedes)
+        .toBeUndefined();
+    });
+  });
 });

--- a/src/store/__tests__/notificationHistoryStore.test.ts
+++ b/src/store/__tests__/notificationHistoryStore.test.ts
@@ -725,12 +725,23 @@ describe("notificationHistorySlice", () => {
       const id = getState().addEntry({ type: "info", message: "live" });
       getState().archiveEntry(id);
       expect(getState().unreadCount).toBe(0);
-      // markUnseenAsToast checks `!entry.seenAsToast` first; since archive
-      // already set seenAsToast to true, this is a regular re-evict path.
+      // markUnseenAsToast is a no-op on archived entries — see the guard in
+      // the slice. Asserting unreadCount stays 0 regardless.
       getState().markUnseenAsToast(id);
-      // unreadCount must still exclude the archived entry even though it's
-      // now seenAsToast=false again.
       expect(getState().unreadCount).toBe(0);
+    });
+
+    it("markUnseenAsToast on archived entry is a no-op (no eviction count tick)", () => {
+      const id = getState().addEntry({ type: "info", message: "seen", seenAsToast: true });
+      getState().archiveEntry(id);
+      expect(getState().evictedToInboxCount).toBe(0);
+      const beforeEntry = getState().entries[0];
+      getState().markUnseenAsToast(id);
+      // Archived entry survives unmodified; evicted counter does not tick.
+      const afterEntry = getState().entries[0];
+      expect(afterEntry).toBe(beforeEntry!);
+      expect(afterEntry!.seenAsToast).toBe(true);
+      expect(getState().evictedToInboxCount).toBe(0);
     });
 
     it("archiveByCorrelationId archives all non-archived entries in the thread", () => {
@@ -840,6 +851,45 @@ describe("notificationHistorySlice", () => {
       const errId = getState().entries[0]!.id;
       getState().addEntry({ type: "success", message: "Reconnected", supersedeKey: key });
       expect(getState().entries.find((e) => e.id === errId)!.archivedAt).not.toBeNull();
+    });
+
+    it("supersedeKey picks the newest live match when two priors share the key", () => {
+      // Normal addEntry auto-archives the prior on every same-key write, so
+      // two live priors only coexist via direct seeding (e.g., from a test or
+      // a future restore-from-disk path). The find() must still pick the
+      // newest (index 0) so the lookup is robust against that shape.
+      const key = "terminal.A.fallback";
+      useNotificationHistoryStore.setState({
+        entries: [
+          {
+            id: "b-newer",
+            type: "error",
+            message: "newer",
+            timestamp: Date.now(),
+            seenAsToast: false,
+            summarized: false,
+            countable: true,
+            archivedAt: null,
+            supersedeKey: key,
+          },
+          {
+            id: "a-older",
+            type: "error",
+            message: "older",
+            timestamp: Date.now() - 1000,
+            seenAsToast: false,
+            summarized: false,
+            countable: true,
+            archivedAt: null,
+            supersedeKey: key,
+          },
+        ],
+        unreadCount: 2,
+      });
+      getState().addEntry({ type: "success", message: "resolve", supersedeKey: key });
+      const entries = getState().entries;
+      expect(entries.find((e) => e.id === "b-newer")!.archivedAt).not.toBeNull();
+      expect(entries.find((e) => e.id === "a-older")!.archivedAt).toBeNull();
     });
 
     it("supersedeKey stores the key on the new entry for future archival", () => {

--- a/src/store/__tests__/notificationHistoryStore.test.ts
+++ b/src/store/__tests__/notificationHistoryStore.test.ts
@@ -943,8 +943,9 @@ describe("notificationHistorySlice", () => {
         supersedes: oldId,
       });
       // `supersedes` is a write-time directive, not stored state.
-      expect((getState().entries.find((e) => e.id === newId)! as { supersedes?: string }).supersedes)
-        .toBeUndefined();
+      expect(
+        (getState().entries.find((e) => e.id === newId)! as { supersedes?: string }).supersedes
+      ).toBeUndefined();
     });
   });
 });

--- a/src/store/listeners/panel/lifecycle.ts
+++ b/src/store/listeners/panel/lifecycle.ts
@@ -62,6 +62,11 @@ export async function handleFallbackTriggered(data: {
   const fromPreset = mergedPresets.find((p) => p.id === fromPresetId);
   const fromName = fromPreset?.name ?? fromPresetId;
 
+  // Pair the fallback error/success notifications so a later "switched to
+  // fallback preset" success archives the prior error from the inbox instead
+  // of leaving a stale "unavailable" row behind.
+  const fallbackSupersedeKey = `terminal.${terminalId}.fallback`;
+
   if (!nextPresetId) {
     // Chain exhausted: surface a single error notification. No respawn.
     const isExhausted = chain.length > 0;
@@ -73,6 +78,7 @@ export async function handleFallbackTriggered(data: {
         ? `All fallback presets were tried. Configure fallback presets or restart the terminal manually.`
         : `${fromName} provider is unreachable. Configure fallbacks in Settings to auto-recover.`,
       duration: 12000,
+      supersedeKey: fallbackSupersedeKey,
       action: {
         label: "Open agent settings",
         actionId: "app.settings.openTab",
@@ -98,6 +104,7 @@ export async function handleFallbackTriggered(data: {
       title: "Fallback preset missing",
       message: `Preset "${nextPresetId}" is no longer configured. Check fallback settings or restart the terminal.`,
       duration: 12000,
+      supersedeKey: fallbackSupersedeKey,
       action: {
         label: "Open agent settings",
         actionId: "app.settings.openTab",
@@ -139,6 +146,7 @@ export async function handleFallbackTriggered(data: {
           reason === "auth"
             ? `${fromName} authentication failed — now running "${nextPreset.name}".`
             : `${fromName} unreachable — now running "${nextPreset.name}".`,
+        supersedeKey: fallbackSupersedeKey,
       });
     } else {
       notify({
@@ -147,6 +155,7 @@ export async function handleFallbackTriggered(data: {
         title: "Fallback activation failed",
         message: `Could not switch to "${nextPreset.name}": ${result.error ?? "unknown error"}`,
         duration: 12000,
+        supersedeKey: fallbackSupersedeKey,
       });
     }
   } finally {

--- a/src/store/slices/notificationHistorySlice.ts
+++ b/src/store/slices/notificationHistorySlice.ts
@@ -22,6 +22,19 @@ export interface NotificationHistoryEntry {
   summarized: boolean;
   /** When false, the entry exists in history but does not increment the unread badge. Defaults to true. */
   countable: boolean;
+  /**
+   * Timestamp at which the entry was archived (moved to the Done state).
+   * Archived entries are hidden from All/Unread views and only appear in the
+   * Archived tab. Null until archived.
+   */
+  archivedAt: number | null;
+  /**
+   * Logical pairing key. When a later `notify()` is called with the same
+   * `supersedeKey`, the prior non-archived entry sharing this key is archived
+   * automatically — used for resolving-event pairs like
+   * "disconnected" → "reconnected".
+   */
+  supersedeKey?: string;
   context?: {
     projectId?: string;
     worktreeId?: string;
@@ -33,13 +46,23 @@ export interface NotificationHistoryEntry {
 
 type AddEntryInput = Omit<
   NotificationHistoryEntry,
-  "id" | "timestamp" | "seenAsToast" | "summarized" | "countable"
+  "id" | "timestamp" | "seenAsToast" | "summarized" | "countable" | "archivedAt"
 > & {
   seenAsToast?: boolean;
   countable?: boolean;
+  /**
+   * Exact id of a prior entry to archive when this entry is added. Consumed
+   * at write-time and not stored on the new entry. No-op if the target is
+   * missing or already archived. Takes precedence over `supersedeKey`.
+   */
+  supersedes?: string;
 };
 
 const MAX_ENTRIES = 200;
+
+function computeUnreadCount(entries: NotificationHistoryEntry[]): number {
+  return entries.filter((e) => !e.seenAsToast && e.countable !== false && !e.archivedAt).length;
+}
 
 interface NotificationHistoryState {
   entries: NotificationHistoryEntry[];
@@ -60,6 +83,16 @@ interface NotificationHistoryState {
   markUnseenAsToast: (id: string, options?: { silent?: boolean }) => void;
   dismissEntry: (id: string) => void;
   dismissByCorrelationId: (correlationId: string) => void;
+  /**
+   * Non-destructive archive (Done state). Sets `archivedAt` + `seenAsToast`
+   * atomically so the badge clears immediately and the entry leaves All/Unread
+   * for the Archived tab. No-op if the entry is missing or already archived.
+   */
+  archiveEntry: (id: string) => void;
+  /**
+   * Archives every non-archived entry in the thread. No-op when nothing matches.
+   */
+  archiveByCorrelationId: (correlationId: string) => void;
   clearAll: () => void;
   markAllRead: () => void;
   /**
@@ -78,23 +111,45 @@ export const useNotificationHistoryStore = create<NotificationHistoryState>((set
   unreadCount: 0,
   evictedToInboxCount: 0,
   addEntry: (entry) => {
-    const seenAsToast = entry.seenAsToast ?? false;
-    const countable = entry.countable ?? true;
+    const { supersedes, ...rest } = entry;
+    const seenAsToast = rest.seenAsToast ?? false;
+    const countable = rest.countable ?? true;
     const newEntry: NotificationHistoryEntry = {
-      ...entry,
+      ...rest,
       seenAsToast,
       summarized: false,
       countable,
+      archivedAt: null,
       id: crypto.randomUUID(),
       timestamp: Date.now(),
     };
     set((state) => {
-      const updated = [newEntry, ...state.entries];
+      // Resolve supersede target inside the same set() so the insert + archive
+      // land atomically — observers never see an unread count that omits one
+      // change but includes the other.
+      let archiveId: string | undefined;
+      if (supersedes) {
+        const target = state.entries.find((e) => e.id === supersedes);
+        if (target && !target.archivedAt) archiveId = target.id;
+      } else if (rest.supersedeKey) {
+        const target = state.entries.find(
+          (e) => e.supersedeKey === rest.supersedeKey && !e.archivedAt
+        );
+        if (target) archiveId = target.id;
+      }
+
+      const now = Date.now();
+      const sourceEntries = archiveId
+        ? state.entries.map((e) =>
+            e.id === archiveId ? { ...e, archivedAt: now, seenAsToast: true } : e
+          )
+        : state.entries;
+
+      const updated = [newEntry, ...sourceEntries];
       if (updated.length > MAX_ENTRIES) {
         updated.length = MAX_ENTRIES;
       }
-      const unreadCount = updated.filter((e) => !e.seenAsToast && e.countable !== false).length;
-      return { entries: updated, unreadCount };
+      return { entries: updated, unreadCount: computeUnreadCount(updated) };
     });
     return newEntry.id;
   },
@@ -105,7 +160,7 @@ export const useNotificationHistoryStore = create<NotificationHistoryState>((set
       const entries = state.entries.map((e) => (e.id === id ? { ...e, seenAsToast: false } : e));
       return {
         entries,
-        unreadCount: entries.filter((e) => !e.seenAsToast && e.countable !== false).length,
+        unreadCount: computeUnreadCount(entries),
         evictedToInboxCount: options?.silent
           ? state.evictedToInboxCount
           : state.evictedToInboxCount + 1,
@@ -116,7 +171,7 @@ export const useNotificationHistoryStore = create<NotificationHistoryState>((set
       const entries = state.entries.filter((e) => e.id !== id);
       return {
         entries,
-        unreadCount: entries.filter((e) => !e.seenAsToast && e.countable !== false).length,
+        unreadCount: computeUnreadCount(entries),
       };
     }),
   dismissByCorrelationId: (correlationId) =>
@@ -124,7 +179,37 @@ export const useNotificationHistoryStore = create<NotificationHistoryState>((set
       const entries = state.entries.filter((e) => e.correlationId !== correlationId);
       return {
         entries,
-        unreadCount: entries.filter((e) => !e.seenAsToast && e.countable !== false).length,
+        unreadCount: computeUnreadCount(entries),
+      };
+    }),
+  archiveEntry: (id) =>
+    set((state) => {
+      const entry = state.entries.find((e) => e.id === id);
+      if (!entry || entry.archivedAt) return state;
+      const now = Date.now();
+      const entries = state.entries.map((e) =>
+        e.id === id ? { ...e, archivedAt: now, seenAsToast: true } : e
+      );
+      return {
+        entries,
+        unreadCount: computeUnreadCount(entries),
+      };
+    }),
+  archiveByCorrelationId: (correlationId) =>
+    set((state) => {
+      let mutated = false;
+      const now = Date.now();
+      const entries = state.entries.map((e) => {
+        if (e.correlationId === correlationId && !e.archivedAt) {
+          mutated = true;
+          return { ...e, archivedAt: now, seenAsToast: true };
+        }
+        return e;
+      });
+      if (!mutated) return state;
+      return {
+        entries,
+        unreadCount: computeUnreadCount(entries),
       };
     }),
   clearAll: () => set({ entries: [], unreadCount: 0, evictedToInboxCount: 0 }),
@@ -148,7 +233,7 @@ export const useNotificationHistoryStore = create<NotificationHistoryState>((set
       if (!mutated) return state;
       return {
         entries,
-        unreadCount: entries.filter((e) => !e.seenAsToast && e.countable !== false).length,
+        unreadCount: computeUnreadCount(entries),
       };
     }),
   markSummarized: (ids) =>

--- a/src/store/slices/notificationHistorySlice.ts
+++ b/src/store/slices/notificationHistorySlice.ts
@@ -156,7 +156,11 @@ export const useNotificationHistoryStore = create<NotificationHistoryState>((set
   markUnseenAsToast: (id, options) =>
     set((state) => {
       const entry = state.entries.find((e) => e.id === id);
-      if (!entry || !entry.seenAsToast) return state;
+      // Archived entries are done — never re-evict them into the unread/
+      // overflow path. Without this guard a late toast expiry would flip
+      // seenAsToast back to false on an archived entry and inflate
+      // evictedToInboxCount even though unreadCount stays correct.
+      if (!entry || !entry.seenAsToast || entry.archivedAt) return state;
       const entries = state.entries.map((e) => (e.id === id ? { ...e, seenAsToast: false } : e));
       return {
         entries,


### PR DESCRIPTION
## Summary

- Adds a non-destructive archive ("Done") state to the notification inbox: `archivedAt` field, `archiveEntry` / `archiveByCorrelationId` actions, an Archived filter tab in `NotificationCenter`, and an `e` keybinding that archives in All/Unread tabs but only deletes the head row in Archived (avoids cross-correlation destruction).
- Adds supersede machinery via `supersedeKey` / `supersedes` on `NotifyPayload`: when a second notification lands with the same key, the prior entry is archived atomically in a single `set()` so observers never see partial state.
- Wires one reference call site in `lifecycle.ts` — the terminal fallback chain shares `terminal.${id}.fallback` so a successful preset switch archives the prior error notification.

Resolves #8098

## Changes

- `notificationHistorySlice.ts` — `archivedAt: number | null` field; `archiveEntry` / `archiveByCorrelationId` actions; `unreadCount` excludes archived; `markUnseenAsToast` and `handleMarkAllRead` guard against re-eviction of archived entries
- `notify.ts` — `supersedeKey` / `supersedes` fields threaded into both `addEntry` call sites (grid-bar and standard)
- `NotificationCenter.tsx` — Archived filter tab; `e` keybinding wired per-tab with correct semantics
- `lifecycle.ts` — reference call site for the fallback-error/success supersede pair
- 5 test files updated; existing `dismissEntry` / `dismissByCorrelationId` (explicit delete/clear-all) left intact

## Testing

- 422 notification suite tests pass
- Typecheck clean, lint ratchet at -3 warnings, format clean, build passes