### PR TITLE
fix(worktree): guard overlay events against branch identity races (#8074)

### DIFF
--- a/electron/services/PullRequestService.ts
+++ b/electron/services/PullRequestService.ts
@@ -146,7 +146,14 @@ class PullRequestService {
       this.resolvedWorktrees.delete(state.worktreeId);
       this.detectedPRs.delete(state.worktreeId);
 
-      events.emit("sys:pr:cleared", { worktreeId: state.worktreeId, timestamp: Date.now() });
+      // Tag the clear with the OLD branch so the renderer drops it if the
+      // worktree's branch has since moved on again — the clear is only valid
+      // for the branch identity at the time it was decided.
+      events.emit("sys:pr:cleared", {
+        worktreeId: state.worktreeId,
+        branchName: currentContext.branchName,
+        timestamp: Date.now(),
+      });
     }
 
     if (!shouldTrack) {
@@ -166,11 +173,12 @@ class PullRequestService {
 
   private handleWorktreeRemove({ worktreeId }: { worktreeId: string }): void {
     if (this.candidates.has(worktreeId) || this.detectedPRs.has(worktreeId)) {
+      const branchName = this.candidates.get(worktreeId)?.branchName;
       this.candidates.delete(worktreeId);
       this.resolvedWorktrees.delete(worktreeId);
       this.detectedPRs.delete(worktreeId);
 
-      events.emit("sys:pr:cleared", { worktreeId, timestamp: Date.now() });
+      events.emit("sys:pr:cleared", { worktreeId, branchName, timestamp: Date.now() });
 
       logDebug("Worktree removed - cleared PR state", { worktreeId });
     }
@@ -505,6 +513,9 @@ class PullRequestService {
     // detected PR number so GitHubService can use ETag conditional requests
     // to skip GraphQL when nothing has changed.
     const candidatesToRevalidate: PRCheckCandidate[] = [];
+    // Snapshot the lookup-time branch per worktree so a branch change during
+    // the in-flight check doesn't let a stale overlay override the new state.
+    const lookupBranchByWorktreeId = new Map<string, string | undefined>();
     for (const worktreeId of this.resolvedWorktrees) {
       const context = this.candidates.get(worktreeId);
       const detectedPR = this.detectedPRs.get(worktreeId);
@@ -515,6 +526,7 @@ class PullRequestService {
           branchName: context.branchName,
           knownPRNumber: detectedPR.number,
         });
+        lookupBranchByWorktreeId.set(worktreeId, context.branchName);
       }
     }
 
@@ -542,7 +554,11 @@ class PullRequestService {
           this.detectedPRs.delete(worktreeId);
 
           logInfo("PR no longer found during revalidation - clearing state", { worktreeId });
-          events.emit("sys:pr:cleared", { worktreeId, timestamp: Date.now() });
+          events.emit("sys:pr:cleared", {
+            worktreeId,
+            branchName: lookupBranchByWorktreeId.get(worktreeId),
+            timestamp: Date.now(),
+          });
           continue;
         }
 
@@ -590,6 +606,7 @@ class PullRequestService {
             prTitle: newPR.title,
             issueNumber,
             issueTitle: checkResult.issueTitle,
+            branchName: lookupBranchByWorktreeId.get(worktreeId),
             timestamp: Date.now(),
           });
         }
@@ -621,6 +638,9 @@ class PullRequestService {
     }
 
     const activeCandidates: PRCheckCandidate[] = [];
+    // Snapshot the lookup-time branch per worktree so a branch change during
+    // the in-flight check doesn't let a stale overlay override the new state.
+    const lookupBranchByWorktreeId = new Map<string, string | undefined>();
     for (const [worktreeId, context] of this.candidates) {
       if (!this.resolvedWorktrees.has(worktreeId)) {
         activeCandidates.push({
@@ -628,6 +648,7 @@ class PullRequestService {
           issueNumber: context.issueNumber,
           branchName: context.branchName,
         });
+        lookupBranchByWorktreeId.set(worktreeId, context.branchName);
       }
     }
 
@@ -649,6 +670,7 @@ class PullRequestService {
       this.consecutiveErrors = 0;
 
       for (const [worktreeId, checkResult] of result.results) {
+        const lookupBranch = lookupBranchByWorktreeId.get(worktreeId);
         // Emit issue metadata if we have a title (regardless of PR)
         const issueNumber = checkResult.issueNumber ?? this.candidates.get(worktreeId)?.issueNumber;
         if (issueNumber && checkResult.issueTitle) {
@@ -656,6 +678,7 @@ class PullRequestService {
             worktreeId,
             issueNumber,
             issueTitle: checkResult.issueTitle,
+            branchName: lookupBranch,
             timestamp: Date.now(),
           });
         } else if (issueNumber && !checkResult.issueTitle) {
@@ -685,6 +708,7 @@ class PullRequestService {
             prTitle: checkResult.pr.title,
             issueNumber,
             issueTitle: checkResult.issueTitle,
+            branchName: lookupBranch,
             timestamp: Date.now(),
           });
         }

--- a/electron/services/events.ts
+++ b/electron/services/events.ts
@@ -474,10 +474,14 @@ export type DaintreeEventMap = {
     prTitle?: string;
     issueNumber?: number;
     issueTitle?: string;
+    /** Branch the lookup was initiated against; receivers drop the overlay if the worktree's branch has changed. */
+    branchName?: string;
     timestamp: number;
   };
   "sys:pr:cleared": {
     worktreeId: string;
+    /** Branch the clear was initiated against; receivers drop the overlay if the worktree's branch has changed. */
+    branchName?: string;
     timestamp: number;
   };
 
@@ -485,6 +489,8 @@ export type DaintreeEventMap = {
     worktreeId: string;
     issueNumber: number;
     issueTitle: string;
+    /** Branch the lookup was initiated against; receivers drop the overlay if the worktree's branch has changed. */
+    branchName?: string;
     timestamp: number;
   };
 

--- a/electron/workspace-host/PRIntegrationService.ts
+++ b/electron/workspace-host/PRIntegrationService.ts
@@ -30,15 +30,19 @@ export interface PRIntegrationCallbacks {
       issueTitle?: string;
       prLastUpdatedAt?: number;
       issueLastUpdatedAt?: number;
+      /** Branch the lookup was initiated against — used by the renderer to drop stale overlays. */
+      branchName?: string;
     }
   ): void;
-  onPRCleared(worktreeId: string): void;
+  onPRCleared(worktreeId: string, data: { branchName?: string }): void;
   onIssueDetected(
     worktreeId: string,
     data: {
       issueNumber: number;
       issueTitle: string;
       issueLastUpdatedAt?: number;
+      /** Branch the lookup was initiated against — used by the renderer to drop stale overlays. */
+      branchName?: string;
     }
   ): void;
   onIssueNotFound(worktreeId: string, issueNumber: number): void;
@@ -88,6 +92,7 @@ export class PRIntegrationService {
           issueTitle: data.issueTitle,
           prLastUpdatedAt: Date.now(),
           issueLastUpdatedAt: data.issueTitle !== undefined ? Date.now() : undefined,
+          branchName: data.branchName,
         });
       })
     );
@@ -98,6 +103,7 @@ export class PRIntegrationService {
           issueNumber: data.issueNumber,
           issueTitle: data.issueTitle,
           issueLastUpdatedAt: Date.now(),
+          branchName: data.branchName,
         });
       })
     );
@@ -110,7 +116,7 @@ export class PRIntegrationService {
 
     this.prEventUnsubscribers.push(
       this.eventBus.on("sys:pr:cleared", (data) => {
-        this.callbacks.onPRCleared(data.worktreeId);
+        this.callbacks.onPRCleared(data.worktreeId, { branchName: data.branchName });
       })
     );
 

--- a/electron/workspace-host/WorkspaceService.ts
+++ b/electron/workspace-host/WorkspaceService.ts
@@ -159,9 +159,10 @@ export class WorkspaceService {
           issueTitle: data.issueTitle,
           prLastUpdatedAt: data.prLastUpdatedAt,
           issueLastUpdatedAt: data.issueLastUpdatedAt,
+          branchName: data.branchName,
         });
       },
-      onPRCleared: (worktreeId) => {
+      onPRCleared: (worktreeId, data) => {
         const monitor = this.monitors.get(worktreeId);
         if (!monitor) return;
 
@@ -173,6 +174,7 @@ export class WorkspaceService {
         this.sendEvent({
           type: "pr-cleared",
           worktreeId,
+          branchName: data.branchName,
         });
       },
       onIssueDetected: (worktreeId, data) => {
@@ -193,6 +195,7 @@ export class WorkspaceService {
           issueNumber: data.issueNumber,
           issueTitle: data.issueTitle,
           issueLastUpdatedAt: data.issueLastUpdatedAt,
+          branchName: data.branchName,
         });
       },
       onIssueNotFound: (worktreeId, issueNumber) => {

--- a/electron/workspace-host/WorkspaceService.ts
+++ b/electron/workspace-host/WorkspaceService.ts
@@ -132,6 +132,17 @@ export class WorkspaceService {
       onPRDetected: (worktreeId, data) => {
         const monitor = this.monitors.get(worktreeId);
         if (!monitor) return;
+        // Drop stale overlays whose lookup branch no longer matches the
+        // monitor's current branch. Without this, monitor.setPRInfo +
+        // emitUpdate would bake the stale PR into the worktree-update
+        // snapshot — bypassing the renderer's branch guard (#8074).
+        if (
+          data.branchName !== undefined &&
+          monitor.branch !== undefined &&
+          monitor.branch !== data.branchName
+        ) {
+          return;
+        }
 
         monitor.setPRInfo({
           prNumber: data.prNumber,
@@ -165,6 +176,17 @@ export class WorkspaceService {
       onPRCleared: (worktreeId, data) => {
         const monitor = this.monitors.get(worktreeId);
         if (!monitor) return;
+        // Drop stale clears whose lookup branch no longer matches the
+        // monitor's current branch — see #8074. Same bypass concern as
+        // onPRDetected: emitUpdate would otherwise clear the new branch's
+        // valid PR via the worktree-update snapshot.
+        if (
+          data.branchName !== undefined &&
+          monitor.branch !== undefined &&
+          monitor.branch !== data.branchName
+        ) {
+          return;
+        }
 
         monitor.clearPRInfo();
         if (monitor.hasInitialStatus) {
@@ -180,6 +202,16 @@ export class WorkspaceService {
       onIssueDetected: (worktreeId, data) => {
         const monitor = this.monitors.get(worktreeId);
         if (!monitor) return;
+        // Drop stale overlays whose lookup branch no longer matches the
+        // monitor's current branch — see #8074. emitUpdate would otherwise
+        // carry the stale issue title into the worktree-update snapshot.
+        if (
+          data.branchName !== undefined &&
+          monitor.branch !== undefined &&
+          monitor.branch !== data.branchName
+        ) {
+          return;
+        }
 
         monitor.setIssueTitle(data.issueTitle);
         if (data.issueLastUpdatedAt !== undefined) {

--- a/electron/workspace-host/__tests__/WorkspaceService.prBranchGuard.test.ts
+++ b/electron/workspace-host/__tests__/WorkspaceService.prBranchGuard.test.ts
@@ -1,0 +1,56 @@
+import { describe, it, expect, beforeAll } from "vitest";
+import fs from "fs/promises";
+import path from "path";
+
+const WORKSPACE_SERVICE_PATH = path.resolve(__dirname, "../WorkspaceService.ts");
+
+describe("WorkspaceService PR callback branch guards — issue #8074", () => {
+  let source: string;
+
+  beforeAll(async () => {
+    source = await fs.readFile(WORKSPACE_SERVICE_PATH, "utf-8");
+  });
+
+  it("guards onPRDetected against stale lookup branches before mutating the monitor", () => {
+    // Without this host-side guard, monitor.setPRInfo + emitUpdate bake the
+    // stale PR into the worktree-update snapshot, bypassing the renderer's
+    // branch guard on the pr-detected event.
+    const onPRDetectedStart = source.indexOf("onPRDetected: (worktreeId, data) =>");
+    const onPRDetectedEnd = source.indexOf("onPRCleared:", onPRDetectedStart);
+    expect(onPRDetectedStart).toBeGreaterThan(0);
+    const block = source.slice(onPRDetectedStart, onPRDetectedEnd);
+    expect(block).toMatch(/data\.branchName !== undefined/);
+    expect(block).toMatch(/monitor\.branch !== undefined/);
+    expect(block).toMatch(/monitor\.branch !== data\.branchName/);
+    // The guard must precede the monitor.setPRInfo write.
+    expect(block.indexOf("monitor.branch !== data.branchName")).toBeLessThan(
+      block.indexOf("monitor.setPRInfo(")
+    );
+  });
+
+  it("guards onPRCleared against stale lookup branches before clearing the monitor", () => {
+    const onPRClearedStart = source.indexOf("onPRCleared: (worktreeId, data) =>");
+    const onPRClearedEnd = source.indexOf("onIssueDetected:", onPRClearedStart);
+    expect(onPRClearedStart).toBeGreaterThan(0);
+    const block = source.slice(onPRClearedStart, onPRClearedEnd);
+    expect(block).toMatch(/data\.branchName !== undefined/);
+    expect(block).toMatch(/monitor\.branch !== undefined/);
+    expect(block).toMatch(/monitor\.branch !== data\.branchName/);
+    expect(block.indexOf("monitor.branch !== data.branchName")).toBeLessThan(
+      block.indexOf("monitor.clearPRInfo()")
+    );
+  });
+
+  it("guards onIssueDetected against stale lookup branches before mutating the monitor", () => {
+    const onIssueDetectedStart = source.indexOf("onIssueDetected: (worktreeId, data) =>");
+    const onIssueDetectedEnd = source.indexOf("onIssueNotFound:", onIssueDetectedStart);
+    expect(onIssueDetectedStart).toBeGreaterThan(0);
+    const block = source.slice(onIssueDetectedStart, onIssueDetectedEnd);
+    expect(block).toMatch(/data\.branchName !== undefined/);
+    expect(block).toMatch(/monitor\.branch !== undefined/);
+    expect(block).toMatch(/monitor\.branch !== data\.branchName/);
+    expect(block.indexOf("monitor.branch !== data.branchName")).toBeLessThan(
+      block.indexOf("monitor.setIssueTitle(")
+    );
+  });
+});

--- a/shared/types/workspace-host.ts
+++ b/shared/types/workspace-host.ts
@@ -410,8 +410,15 @@ export type WorkspaceHostEvent =
       issueTitle?: string;
       prLastUpdatedAt?: number;
       issueLastUpdatedAt?: number;
+      /** Branch the lookup was initiated against — receiver drops the overlay if the worktree's branch has since changed. */
+      branchName?: string;
     }
-  | { type: "pr-cleared"; worktreeId: string }
+  | {
+      type: "pr-cleared";
+      worktreeId: string;
+      /** Branch the clear was initiated against — receiver drops the overlay if the worktree's branch has since changed. */
+      branchName?: string;
+    }
   // Issue events
   | {
       type: "issue-detected";
@@ -419,6 +426,8 @@ export type WorkspaceHostEvent =
       issueNumber: number;
       issueTitle: string;
       issueLastUpdatedAt?: number;
+      /** Branch the lookup was initiated against — receiver drops the overlay if the worktree's branch has since changed. */
+      branchName?: string;
     }
   | {
       type: "issue-not-found";

--- a/src/components/Sidebar/SidebarContent.tsx
+++ b/src/components/Sidebar/SidebarContent.tsx
@@ -183,6 +183,10 @@ function SidebarContent({ onOpenOverview }: SidebarContentProps) {
   const deferredWorktrees = useDeferredValue(worktrees);
   const [isRefreshing, startRefreshTransition] = useTransition();
   const showRefreshSpinner = useDeferredLoading(isRefreshing, UI_DOHERTY_THRESHOLD);
+  // Gate the "Reconnecting…" indicator behind the Doherty threshold so routine
+  // sub-400ms port replacements don't flash the spinner. A real host crash
+  // takes 2–4s to recover, well past the threshold.
+  const showReconnecting = useDeferredLoading(isReconnecting, UI_DOHERTY_THRESHOLD);
   const currentProject = useProjectStore((state) => state.currentProject);
   useProjectSettings();
   const { availability, agentSettings } = useAgentLauncher();
@@ -923,7 +927,7 @@ function SidebarContent({ onOpenOverview }: SidebarContentProps) {
       <div className="group/header flex items-center justify-between px-4 py-2 border-b border-divider bg-transparent shrink-0">
         <div className="flex items-baseline gap-1.5">
           <h2 className="text-daintree-text font-semibold text-sm tracking-wide">Worktrees</h2>
-          {isReconnecting && (
+          {showReconnecting && (
             <span
               role="status"
               aria-live="polite"

--- a/src/components/Sidebar/__tests__/SidebarContent.reconnecting.test.ts
+++ b/src/components/Sidebar/__tests__/SidebarContent.reconnecting.test.ts
@@ -1,0 +1,33 @@
+import { describe, it, expect, beforeAll } from "vitest";
+import fs from "fs/promises";
+import path from "path";
+
+const SIDEBAR_CONTENT_PATH = path.resolve(__dirname, "../SidebarContent.tsx");
+
+describe("SidebarContent reconnecting indicator — issue #8074", () => {
+  let source: string;
+
+  beforeAll(async () => {
+    source = await fs.readFile(SIDEBAR_CONTENT_PATH, "utf-8");
+  });
+
+  it("gates the reconnecting indicator behind useDeferredLoading with UI_DOHERTY_THRESHOLD", () => {
+    // Doherty Threshold (400ms): routine sub-second port replacements must not
+    // flash a spinner. The reconnecting state mirrors the existing
+    // showRefreshSpinner pattern on the same component.
+    expect(source).toMatch(
+      /const showReconnecting = useDeferredLoading\(isReconnecting, UI_DOHERTY_THRESHOLD\)/
+    );
+  });
+
+  it("renders the Reconnecting… span behind showReconnecting, not raw isReconnecting", () => {
+    // Regression guard: anything in the render tree that reads isReconnecting
+    // directly bypasses the deferred gate and flickers on every sub-400ms
+    // disconnect→reconnect.
+    const reconnectingSpan = source.match(
+      /\{showReconnecting && \(\s*<span[\s\S]*?Reconnecting…[\s\S]*?<\/span>\s*\)\}/
+    );
+    expect(reconnectingSpan).not.toBeNull();
+    expect(source).not.toMatch(/\{isReconnecting && \(\s*<span/);
+  });
+});

--- a/src/contexts/WorktreeStoreContext.tsx
+++ b/src/contexts/WorktreeStoreContext.tsx
@@ -267,12 +267,17 @@ export function WorktreeStoreProvider({ children }: { children: ReactNode }) {
         const existing = worktrees.get(event.worktreeId);
         if (!existing) return;
         if (!branchesMatch(event.branchName, existing.branch)) return;
+        // Mirror the host: clearing the PR drops the CI rollup too. Without
+        // this, an early-startup window where monitor.hasInitialStatus is
+        // false would skip the worktree-update path and leave prCiStatus
+        // hanging without an associated PR.
         store.getState().applyUpdate(
           {
             ...existing,
             prNumber: undefined,
             prUrl: undefined,
             prState: undefined,
+            prCiStatus: undefined,
             prTitle: undefined,
             prLastUpdatedAt: undefined,
             issueLastUpdatedAt: undefined,

--- a/src/contexts/WorktreeStoreContext.tsx
+++ b/src/contexts/WorktreeStoreContext.tsx
@@ -38,11 +38,13 @@ interface PRDetectedEvent {
   issueTitle?: string;
   prLastUpdatedAt?: number;
   issueLastUpdatedAt?: number;
+  branchName?: string;
 }
 
 interface PRClearedEvent {
   type: "pr-cleared";
   worktreeId: string;
+  branchName?: string;
 }
 
 interface IssueDetectedEvent {
@@ -51,12 +53,25 @@ interface IssueDetectedEvent {
   issueNumber: number;
   issueTitle: string;
   issueLastUpdatedAt?: number;
+  branchName?: string;
 }
 
 interface IssueNotFoundEvent {
   type: "issue-not-found";
   worktreeId: string;
   issueNumber: number;
+}
+
+// Drop overlays whose lookup branch no longer matches the worktree's current
+// branch — they raced against a branch change and would corrupt the row.
+// Treat undefined on either side as "allow" (older host code may omit the
+// field, and detached HEAD has no branch to compare against).
+function branchesMatch(
+  eventBranch: string | undefined,
+  currentBranch: string | undefined
+): boolean {
+  if (eventBranch === undefined || currentBranch === undefined) return true;
+  return eventBranch === currentBranch;
 }
 
 interface WorktreeActivatedEvent {
@@ -203,6 +218,7 @@ export function WorktreeStoreProvider({ children }: { children: ReactNode }) {
         const { worktrees } = store.getState();
         const existing = worktrees.get(event.worktreeId);
         if (!existing) return;
+        if (!branchesMatch(event.branchName, existing.branch)) return;
         // Full-replace semantics for prCiStatus mirror the backend
         // (WorktreeMonitor.setPRInfo): undefined means "no checks", not
         // "preserve prior value." Merging with ?? would let stale CI rollups
@@ -250,6 +266,7 @@ export function WorktreeStoreProvider({ children }: { children: ReactNode }) {
         const { worktrees } = store.getState();
         const existing = worktrees.get(event.worktreeId);
         if (!existing) return;
+        if (!branchesMatch(event.branchName, existing.branch)) return;
         store.getState().applyUpdate(
           {
             ...existing,
@@ -271,6 +288,7 @@ export function WorktreeStoreProvider({ children }: { children: ReactNode }) {
         const { worktrees } = store.getState();
         const existing = worktrees.get(event.worktreeId);
         if (!existing) return;
+        if (!branchesMatch(event.branchName, existing.branch)) return;
         store.getState().applyUpdate(
           {
             ...existing,

--- a/src/contexts/__tests__/WorktreeStoreContext.prDetected.test.tsx
+++ b/src/contexts/__tests__/WorktreeStoreContext.prDetected.test.tsx
@@ -379,6 +379,108 @@ describe("WorktreeStoreProvider pr-detected handler", () => {
     expect(getGeneration(key)).toBe(genBefore);
   });
 
+  it("drops the overlay when event.branchName mismatches the worktree's current branch", async () => {
+    const store = await renderProvider();
+    act(() => {
+      store
+        .getState()
+        .applyUpdate(
+          makeWorktree("wt-1", { branch: "feature/bar", prCiStatus: "FAILURE", prNumber: 99 }),
+          store.getState().nextVersion()
+        );
+    });
+
+    act(() => {
+      emit("pr-detected", {
+        type: "pr-detected",
+        worktreeId: "wt-1",
+        prNumber: 42,
+        prUrl: "https://example.test/pr/42",
+        prState: "open",
+        prCiStatus: "SUCCESS",
+        branchName: "feature/foo",
+      });
+    });
+
+    const wt = store.getState().worktrees.get("wt-1");
+    expect(wt?.prNumber).toBe(99);
+    expect(wt?.prCiStatus).toBe("FAILURE");
+  });
+
+  it("applies the overlay when event.branchName matches the worktree's current branch", async () => {
+    const store = await renderProvider();
+    act(() => {
+      store
+        .getState()
+        .applyUpdate(
+          makeWorktree("wt-1", { branch: "feature/foo" }),
+          store.getState().nextVersion()
+        );
+    });
+
+    act(() => {
+      emit("pr-detected", {
+        type: "pr-detected",
+        worktreeId: "wt-1",
+        prNumber: 42,
+        prUrl: "https://example.test/pr/42",
+        prState: "open",
+        prCiStatus: "SUCCESS",
+        branchName: "feature/foo",
+      });
+    });
+
+    expect(store.getState().worktrees.get("wt-1")?.prCiStatus).toBe("SUCCESS");
+  });
+
+  it("applies the overlay when the event omits branchName (older host backward compat)", async () => {
+    const store = await renderProvider();
+    act(() => {
+      store
+        .getState()
+        .applyUpdate(
+          makeWorktree("wt-1", { branch: "feature/foo" }),
+          store.getState().nextVersion()
+        );
+    });
+
+    act(() => {
+      emit("pr-detected", {
+        type: "pr-detected",
+        worktreeId: "wt-1",
+        prNumber: 42,
+        prUrl: "https://example.test/pr/42",
+        prState: "open",
+        prCiStatus: "SUCCESS",
+      });
+    });
+
+    expect(store.getState().worktrees.get("wt-1")?.prCiStatus).toBe("SUCCESS");
+  });
+
+  it("applies the overlay when the worktree has no branch (detached HEAD)", async () => {
+    const store = await renderProvider();
+    act(() => {
+      store
+        .getState()
+        .applyUpdate(makeWorktree("wt-1", { branch: undefined }), store.getState().nextVersion());
+    });
+
+    act(() => {
+      emit("pr-detected", {
+        type: "pr-detected",
+        worktreeId: "wt-1",
+        prNumber: 42,
+        prUrl: "https://example.test/pr/42",
+        prState: "open",
+        prCiStatus: "SUCCESS",
+        branchName: "feature/foo",
+      });
+    });
+
+    expect(store.getState().worktrees.get("wt-1")?.prCiStatus).toBe("SUCCESS");
+  });
+
   it("uses the project path read at event time so closures cannot go stale", async () => {
     const store = await renderProvider();
     act(() => {
@@ -416,5 +518,169 @@ describe("WorktreeStoreProvider pr-detected handler", () => {
 
     expect((getCache(newKey)?.items[0] as GitHubPR).ciStatus).toBe("SUCCESS");
     expect((getCache(oldKey)?.items[0] as GitHubPR).ciStatus).toBe("PENDING");
+  });
+});
+
+describe("WorktreeStoreProvider pr-cleared handler", () => {
+  it("drops the clear when event.branchName mismatches the worktree's current branch", async () => {
+    const store = await renderProvider();
+    act(() => {
+      store
+        .getState()
+        .applyUpdate(
+          makeWorktree("wt-1", {
+            branch: "feature/bar",
+            prNumber: 42,
+            prUrl: "https://example.test/pr/42",
+            prState: "open",
+          }),
+          store.getState().nextVersion()
+        );
+    });
+
+    act(() => {
+      emit("pr-cleared", {
+        type: "pr-cleared",
+        worktreeId: "wt-1",
+        branchName: "feature/foo",
+      });
+    });
+
+    const wt = store.getState().worktrees.get("wt-1");
+    expect(wt?.prNumber).toBe(42);
+    expect(wt?.prUrl).toBe("https://example.test/pr/42");
+    expect(wt?.prState).toBe("open");
+  });
+
+  it("applies the clear when event.branchName matches the worktree's current branch", async () => {
+    const store = await renderProvider();
+    act(() => {
+      store
+        .getState()
+        .applyUpdate(
+          makeWorktree("wt-1", {
+            branch: "feature/foo",
+            prNumber: 42,
+            prUrl: "https://example.test/pr/42",
+            prState: "open",
+          }),
+          store.getState().nextVersion()
+        );
+    });
+
+    act(() => {
+      emit("pr-cleared", {
+        type: "pr-cleared",
+        worktreeId: "wt-1",
+        branchName: "feature/foo",
+      });
+    });
+
+    const wt = store.getState().worktrees.get("wt-1");
+    expect(wt?.prNumber).toBeUndefined();
+    expect(wt?.prUrl).toBeUndefined();
+    expect(wt?.prState).toBeUndefined();
+  });
+
+  it("applies the clear when the event omits branchName (older host backward compat)", async () => {
+    const store = await renderProvider();
+    act(() => {
+      store
+        .getState()
+        .applyUpdate(
+          makeWorktree("wt-1", { branch: "feature/foo", prNumber: 42 }),
+          store.getState().nextVersion()
+        );
+    });
+
+    act(() => {
+      emit("pr-cleared", {
+        type: "pr-cleared",
+        worktreeId: "wt-1",
+      });
+    });
+
+    expect(store.getState().worktrees.get("wt-1")?.prNumber).toBeUndefined();
+  });
+});
+
+describe("WorktreeStoreProvider issue-detected handler", () => {
+  it("drops the overlay when event.branchName mismatches the worktree's current branch", async () => {
+    const store = await renderProvider();
+    act(() => {
+      store
+        .getState()
+        .applyUpdate(
+          makeWorktree("wt-1", {
+            branch: "feature/bar",
+            issueNumber: 100,
+            issueTitle: "Old issue",
+          }),
+          store.getState().nextVersion()
+        );
+    });
+
+    act(() => {
+      emit("issue-detected", {
+        type: "issue-detected",
+        worktreeId: "wt-1",
+        issueNumber: 200,
+        issueTitle: "New issue",
+        branchName: "feature/foo",
+      });
+    });
+
+    const wt = store.getState().worktrees.get("wt-1");
+    expect(wt?.issueNumber).toBe(100);
+    expect(wt?.issueTitle).toBe("Old issue");
+  });
+
+  it("applies the overlay when event.branchName matches the worktree's current branch", async () => {
+    const store = await renderProvider();
+    act(() => {
+      store
+        .getState()
+        .applyUpdate(
+          makeWorktree("wt-1", { branch: "feature/foo" }),
+          store.getState().nextVersion()
+        );
+    });
+
+    act(() => {
+      emit("issue-detected", {
+        type: "issue-detected",
+        worktreeId: "wt-1",
+        issueNumber: 200,
+        issueTitle: "Issue title",
+        branchName: "feature/foo",
+      });
+    });
+
+    const wt = store.getState().worktrees.get("wt-1");
+    expect(wt?.issueNumber).toBe(200);
+    expect(wt?.issueTitle).toBe("Issue title");
+  });
+
+  it("applies the overlay when the event omits branchName (older host backward compat)", async () => {
+    const store = await renderProvider();
+    act(() => {
+      store
+        .getState()
+        .applyUpdate(
+          makeWorktree("wt-1", { branch: "feature/foo" }),
+          store.getState().nextVersion()
+        );
+    });
+
+    act(() => {
+      emit("issue-detected", {
+        type: "issue-detected",
+        worktreeId: "wt-1",
+        issueNumber: 200,
+        issueTitle: "Issue title",
+      });
+    });
+
+    expect(store.getState().worktrees.get("wt-1")?.issueNumber).toBe(200);
   });
 });

--- a/src/contexts/__tests__/WorktreeStoreContext.prDetected.test.tsx
+++ b/src/contexts/__tests__/WorktreeStoreContext.prDetected.test.tsx
@@ -458,6 +458,48 @@ describe("WorktreeStoreProvider pr-detected handler", () => {
     expect(store.getState().worktrees.get("wt-1")?.prCiStatus).toBe("SUCCESS");
   });
 
+  it("drops a stale pr-detected that arrives after a worktree-update changed the branch", async () => {
+    // End-to-end race scenario: worktree starts on feature/foo, a PR lookup
+    // was queued against it, the worktree switches to feature/bar (arrives as
+    // a worktree-update snapshot), then the stale pr-detected from the
+    // feature/foo lookup completes and tries to land on the now-bar row.
+    const store = await renderProvider();
+    act(() => {
+      store
+        .getState()
+        .applyUpdate(
+          makeWorktree("wt-1", { branch: "feature/foo" }),
+          store.getState().nextVersion()
+        );
+    });
+
+    // Worktree-update arrives reflecting the branch change to feature/bar.
+    act(() => {
+      emit("worktree-update", {
+        type: "worktree-update",
+        worktree: makeWorktree("wt-1", { branch: "feature/bar", prCiStatus: undefined }),
+      });
+    });
+
+    // The stale pr-detected from the feature/foo lookup arrives late.
+    act(() => {
+      emit("pr-detected", {
+        type: "pr-detected",
+        worktreeId: "wt-1",
+        prNumber: 999,
+        prUrl: "https://example.test/pr/999",
+        prState: "open",
+        prCiStatus: "FAILURE",
+        branchName: "feature/foo",
+      });
+    });
+
+    const wt = store.getState().worktrees.get("wt-1");
+    expect(wt?.branch).toBe("feature/bar");
+    expect(wt?.prNumber).not.toBe(999);
+    expect(wt?.prCiStatus).not.toBe("FAILURE");
+  });
+
   it("applies the overlay when the worktree has no branch (detached HEAD)", async () => {
     const store = await renderProvider();
     act(() => {
@@ -525,17 +567,15 @@ describe("WorktreeStoreProvider pr-cleared handler", () => {
   it("drops the clear when event.branchName mismatches the worktree's current branch", async () => {
     const store = await renderProvider();
     act(() => {
-      store
-        .getState()
-        .applyUpdate(
-          makeWorktree("wt-1", {
-            branch: "feature/bar",
-            prNumber: 42,
-            prUrl: "https://example.test/pr/42",
-            prState: "open",
-          }),
-          store.getState().nextVersion()
-        );
+      store.getState().applyUpdate(
+        makeWorktree("wt-1", {
+          branch: "feature/bar",
+          prNumber: 42,
+          prUrl: "https://example.test/pr/42",
+          prState: "open",
+        }),
+        store.getState().nextVersion()
+      );
     });
 
     act(() => {
@@ -555,17 +595,15 @@ describe("WorktreeStoreProvider pr-cleared handler", () => {
   it("applies the clear when event.branchName matches the worktree's current branch", async () => {
     const store = await renderProvider();
     act(() => {
-      store
-        .getState()
-        .applyUpdate(
-          makeWorktree("wt-1", {
-            branch: "feature/foo",
-            prNumber: 42,
-            prUrl: "https://example.test/pr/42",
-            prState: "open",
-          }),
-          store.getState().nextVersion()
-        );
+      store.getState().applyUpdate(
+        makeWorktree("wt-1", {
+          branch: "feature/foo",
+          prNumber: 42,
+          prUrl: "https://example.test/pr/42",
+          prState: "open",
+        }),
+        store.getState().nextVersion()
+      );
     });
 
     act(() => {
@@ -602,22 +640,74 @@ describe("WorktreeStoreProvider pr-cleared handler", () => {
 
     expect(store.getState().worktrees.get("wt-1")?.prNumber).toBeUndefined();
   });
+
+  it("clears prCiStatus alongside the PR fields (no orphaned CI rollup)", async () => {
+    const store = await renderProvider();
+    act(() => {
+      store
+        .getState()
+        .applyUpdate(
+          makeWorktree("wt-1", { branch: "feature/foo", prNumber: 42, prCiStatus: "FAILURE" }),
+          store.getState().nextVersion()
+        );
+    });
+
+    act(() => {
+      emit("pr-cleared", {
+        type: "pr-cleared",
+        worktreeId: "wt-1",
+        branchName: "feature/foo",
+      });
+    });
+
+    const wt = store.getState().worktrees.get("wt-1");
+    expect(wt?.prNumber).toBeUndefined();
+    expect(wt?.prCiStatus).toBeUndefined();
+  });
+
+  it("drops a stale pr-cleared after a multi-hop branch switch (foo → bar → baz)", async () => {
+    const store = await renderProvider();
+    // Start on baz with a valid PR (the survivor)
+    act(() => {
+      store.getState().applyUpdate(
+        makeWorktree("wt-1", {
+          branch: "feature/baz",
+          prNumber: 999,
+          prUrl: "https://example.test/pr/999",
+          prState: "open",
+          prCiStatus: "SUCCESS",
+        }),
+        store.getState().nextVersion()
+      );
+    });
+
+    // Stale clear arrives from the long-ago `foo` lookup
+    act(() => {
+      emit("pr-cleared", {
+        type: "pr-cleared",
+        worktreeId: "wt-1",
+        branchName: "feature/foo",
+      });
+    });
+
+    const wt = store.getState().worktrees.get("wt-1");
+    expect(wt?.prNumber).toBe(999);
+    expect(wt?.prCiStatus).toBe("SUCCESS");
+  });
 });
 
 describe("WorktreeStoreProvider issue-detected handler", () => {
   it("drops the overlay when event.branchName mismatches the worktree's current branch", async () => {
     const store = await renderProvider();
     act(() => {
-      store
-        .getState()
-        .applyUpdate(
-          makeWorktree("wt-1", {
-            branch: "feature/bar",
-            issueNumber: 100,
-            issueTitle: "Old issue",
-          }),
-          store.getState().nextVersion()
-        );
+      store.getState().applyUpdate(
+        makeWorktree("wt-1", {
+          branch: "feature/bar",
+          issueNumber: 100,
+          issueTitle: "Old issue",
+        }),
+        store.getState().nextVersion()
+      );
     });
 
     act(() => {


### PR DESCRIPTION
## Summary

Closes #8074.

Worktree PR/issue overlays raced against branch identity in two ways:

1. **Stale overlay attribution** — When a worktree's branch changed mid-flight on a PR or issue lookup, the late-arriving `pr-detected`, `pr-cleared`, or `issue-detected` event landed on the now-different branch and corrupted the row (wrong PR number, wrong CI rollup, wrong issue title). The existing `issue-not-found` handler had the right pattern (guard on identity, drop silently); the other three didn't.

2. **Reconnecting flicker** — The "Reconnecting…" indicator in the Sidebar rendered synchronously on every `onDisconnected`, so routine sub-400ms port replacements flashed a spinner. Violates the Doherty Threshold rule already applied to `showRefreshSpinner` on the same component.

## Fix

The lookup branch is now captured at candidate-build time in `PullRequestService` (before `await batchCheckLinkedPRs`) and threaded through the event chain: `events.ts` payload types → `PRIntegrationCallbacks` → `WorkspaceService.sendEvent` → `WorkspaceEvent` wire format → renderer handlers. Reading `monitor.branch` at `sendEvent` time would defeat the guard because the branch field already reflects the post-switch state by then — Codex caught this during planning.

Three layers of guard, each addressing a distinct injection vector:

- **Host (`WorkspaceService` callbacks)** — drop the host write when `data.branchName !== monitor.branch`. Without this, `monitor.setPRInfo` + `emitUpdate` would bake stale PR data into the `worktree-update` snapshot and bypass the renderer guard entirely. Caught during /work:review.
- **Renderer overlay events** — `branchesMatch(event.branchName, existing.branch)` guard at the start of `pr-detected`, `pr-cleared`, `issue-detected` handlers. `undefined` on either side allows through (detached HEAD + backward compat with older host code).
- **Renderer `pr-cleared`** — also clears `prCiStatus` so an early-startup window (`monitor.hasInitialStatus` false) can't leave a CI rollup hanging without a PR.

The reconnecting indicator now uses `useDeferredLoading(isReconnecting, UI_DOHERTY_THRESHOLD)` — mirroring the existing `showRefreshSpinner` pattern one line above it.

## Files changed

- `electron/services/events.ts` — `branchName?` added to `sys:pr:detected`, `sys:pr:cleared`, `sys:issue:detected`
- `electron/services/PullRequestService.ts` — snapshot lookup-time branch per worktree before each `await batchCheckLinkedPRs`; thread to `handleWorktreeUpdate`, `handleWorktreeRemove`, `checkForPRs`, and `revalidateResolvedPRs` emits
- `electron/workspace-host/PRIntegrationService.ts` — added `branchName?` to `PRIntegrationCallbacks` signatures; threaded through event subscribers
- `electron/workspace-host/WorkspaceService.ts` — host-side branch guard in `onPRDetected`, `onPRCleared`, `onIssueDetected`; forward `branchName` in `sendEvent`
- `shared/types/workspace-host.ts` — added `branchName?` to wire-format event types
- `src/contexts/WorktreeStoreContext.tsx` — `branchesMatch` helper + guards in three handlers; clear `prCiStatus` in `pr-cleared`
- `src/components/Sidebar/SidebarContent.tsx` — `useDeferredLoading` on `isReconnecting`
- `src/contexts/__tests__/WorktreeStoreContext.prDetected.test.tsx` — 13 new tests
- `src/components/Sidebar/__tests__/SidebarContent.reconnecting.test.ts` — new
- `electron/workspace-host/__tests__/WorkspaceService.prBranchGuard.test.ts` — new

## Test plan

- [x] Targeted vitest (60 tests across 5 files) — pass
- [x] `npm run check` (typecheck + lint + format) — pass; lint ratchet dropped 3 warnings
- [x] `npm run build` — pass
- [ ] Manual: switch worktree branches rapidly during PR detection cycle, confirm no row corruption
- [ ] Manual: trigger a fast workspace-host restart, confirm no "Reconnecting…" flash