### PR TITLE
feat(layout): surface agent state and quick actions in Background popover

### DIFF
--- a/src/components/Layout/BackgroundContainer.tsx
+++ b/src/components/Layout/BackgroundContainer.tsx
@@ -286,16 +286,16 @@ export function BackgroundContainer({ compact = false }: BackgroundContainerProp
         onOpenAutoFocus={(e) => e.preventDefault()}
         onCloseAutoFocus={(e) => e.preventDefault()}
         onPointerDownOutside={(e) => {
-          const target = e.target as Element | null;
-          if (target?.closest("[data-radix-portal]")) {
-            e.preventDefault();
-          }
+          // Keep the popover anchored while the kill confirm dialog is open;
+          // AppDialog is a react-dom portal with no Radix marker on its root,
+          // so we gate on local state rather than a DOM selector.
+          if (killConfirmId !== null) e.preventDefault();
         }}
         onInteractOutside={(e) => {
-          const target = e.target as Element | null;
-          if (target?.closest("[data-radix-portal]")) {
-            e.preventDefault();
-          }
+          if (killConfirmId !== null) e.preventDefault();
+        }}
+        onEscapeKeyDown={(e) => {
+          if (killConfirmId !== null) e.preventDefault();
         }}
       >
         <div className="flex flex-col">
@@ -454,7 +454,7 @@ function BackgroundSingleItem({
                 e.stopPropagation();
                 onWatchToggle(terminal);
               }}
-              aria-label="Watch for completion"
+              aria-label={isWatched ? "Stop watching" : "Watch for completion"}
               aria-pressed={isWatched}
               data-testid="bg-watch-button"
               className={cn(isWatched && "text-status-info")}
@@ -467,23 +467,25 @@ function BackgroundSingleItem({
           </TooltipContent>
         </Tooltip>
 
-        <Tooltip>
-          <TooltipTrigger asChild>
-            <Button
-              variant="ghost-success"
-              size="icon-sm"
-              onClick={(e) => {
-                e.stopPropagation();
-                onRestore(terminal);
-              }}
-              aria-label={`Restore ${title}`}
-              data-testid="bg-restore-button"
-            >
-              <RotateCcw aria-hidden="true" />
-            </Button>
-          </TooltipTrigger>
-          <TooltipContent side="bottom">{`Restore ${title}`}</TooltipContent>
-        </Tooltip>
+        {!compact && (
+          <Tooltip>
+            <TooltipTrigger asChild>
+              <Button
+                variant="ghost-success"
+                size="icon-sm"
+                onClick={(e) => {
+                  e.stopPropagation();
+                  onRestore(terminal);
+                }}
+                aria-label={`Restore ${title}`}
+                data-testid="bg-restore-button"
+              >
+                <RotateCcw aria-hidden="true" />
+              </Button>
+            </TooltipTrigger>
+            <TooltipContent side="bottom">{`Restore ${title}`}</TooltipContent>
+          </Tooltip>
+        )}
 
         <Tooltip>
           <TooltipTrigger asChild>

--- a/src/components/Layout/BackgroundContainer.tsx
+++ b/src/components/Layout/BackgroundContainer.tsx
@@ -1,15 +1,22 @@
-import { useState, useMemo } from "react";
-import { Moon, Layers, ChevronDown, ChevronRight } from "lucide-react";
+import { useState, useMemo, useCallback } from "react";
+import { Moon, Layers, ChevronDown, ChevronRight, RotateCcw, X, Bell, BellOff } from "lucide-react";
 import { useShallow } from "zustand/react/shallow";
 import { Popover, PopoverContent, PopoverTrigger } from "@/components/ui/popover";
 import { Button } from "@/components/ui/button";
+import { Tooltip, TooltipContent, TooltipTrigger } from "@/components/ui/tooltip";
+import { ConfirmDialog } from "@/components/ui/ConfirmDialog";
 import { cn } from "@/lib/utils";
 import { usePanelStore, type TerminalInstance } from "@/store";
 import type { TrashedTerminalGroupMetadata } from "@/store/slices";
 import { useWorktreeSelectionStore } from "@/store/worktreeStore";
 import { useBackgroundedTerminals } from "@/hooks/useTerminalSelectors";
+import { useWorktrees } from "@/hooks/useWorktrees";
 import { TerminalIcon } from "@/components/Terminal/TerminalIcon";
 import { deriveTerminalChrome } from "@/utils/terminalChrome";
+import { LiveTimeAgo } from "@/components/Worktree/LiveTimeAgo";
+import { STATE_ICONS, STATE_LABELS, STATE_COLORS } from "@/components/Worktree/terminalStateConfig";
+import { fireWatchNotification } from "@/lib/watchNotification";
+import type { AgentState } from "@/types";
 
 interface BackgroundContainerProps {
   compact?: boolean;
@@ -29,25 +36,56 @@ interface BackgroundDisplayGroup {
 
 type BackgroundDisplayItem = BackgroundDisplaySingle | BackgroundDisplayGroup;
 
+// PopoverContent has overflow-hidden, which clips the box-shadow used by
+// panel-state-waiting / panel-state-working. Use a left-border + tint instead
+// so the ambient signal survives at popover row scale.
+function rowAmbientClass(agentState: AgentState | undefined): string {
+  if (agentState === "waiting") {
+    return "border-l-2 border-l-[color:var(--color-activity-waiting)] bg-[color-mix(in_oklab,var(--color-activity-waiting)_8%,transparent)]";
+  }
+  if (agentState === "working") {
+    return "border-l-2 border-l-[color:var(--color-activity-working)] bg-[color-mix(in_oklab,var(--color-activity-working)_6%,transparent)]";
+  }
+  return "border-l-2 border-l-transparent";
+}
+
 export function BackgroundContainer({ compact = false }: BackgroundContainerProps) {
   const [isOpen, setIsOpen] = useState(false);
+  const [killConfirmId, setKillConfirmId] = useState<string | null>(null);
   const terminals = useBackgroundedTerminals();
   const backgroundedTerminals = usePanelStore((state) => state.backgroundedTerminals);
-  const { restoreBackgroundTerminal, restoreBackgroundGroup, activateTerminal, pingTerminal } =
-    usePanelStore(
-      useShallow((state) => ({
-        restoreBackgroundTerminal: state.restoreBackgroundTerminal,
-        restoreBackgroundGroup: state.restoreBackgroundGroup,
-        activateTerminal: state.activateTerminal,
-        pingTerminal: state.pingTerminal,
-      }))
-    );
+  const watchedPanels = usePanelStore((state) => state.watchedPanels);
+  const {
+    restoreBackgroundTerminal,
+    restoreBackgroundGroup,
+    activateTerminal,
+    pingTerminal,
+    removePanel,
+    watchPanel,
+    unwatchPanel,
+  } = usePanelStore(
+    useShallow((state) => ({
+      restoreBackgroundTerminal: state.restoreBackgroundTerminal,
+      restoreBackgroundGroup: state.restoreBackgroundGroup,
+      activateTerminal: state.activateTerminal,
+      pingTerminal: state.pingTerminal,
+      removePanel: state.removePanel,
+      watchPanel: state.watchPanel,
+      unwatchPanel: state.unwatchPanel,
+    }))
+  );
   const { activeWorktreeId, selectWorktree, trackTerminalFocus } = useWorktreeSelectionStore(
     useShallow((state) => ({
       activeWorktreeId: state.activeWorktreeId,
       selectWorktree: state.selectWorktree,
       trackTerminalFocus: state.trackTerminalFocus,
     }))
+  );
+  const { worktreeMap } = useWorktrees();
+
+  const waitingCount = useMemo(
+    () => terminals.filter((t) => t.agentState === "waiting").length,
+    [terminals]
   );
 
   const displayItems = useMemo((): BackgroundDisplayItem[] => {
@@ -104,41 +142,92 @@ export function BackgroundContainer({ compact = false }: BackgroundContainerProp
     return items;
   }, [terminals, backgroundedTerminals]);
 
+  const handleRestoreSingle = useCallback(
+    (terminal: TerminalInstance) => {
+      const worktreeId = terminal.worktreeId?.trim();
+      if (worktreeId && worktreeId !== activeWorktreeId) {
+        trackTerminalFocus(worktreeId, terminal.id);
+        selectWorktree(worktreeId);
+      }
+      restoreBackgroundTerminal(terminal.id);
+      activateTerminal(terminal.id);
+      pingTerminal(terminal.id);
+      setIsOpen(false);
+    },
+    [
+      activeWorktreeId,
+      trackTerminalFocus,
+      selectWorktree,
+      restoreBackgroundTerminal,
+      activateTerminal,
+      pingTerminal,
+    ]
+  );
+
+  const handleRestoreGroup = useCallback(
+    (groupRestoreId: string, groupMetadata: TrashedTerminalGroupMetadata) => {
+      const worktreeId = groupMetadata.worktreeId?.trim();
+      if (worktreeId && worktreeId !== activeWorktreeId) {
+        selectWorktree(worktreeId);
+      }
+      restoreBackgroundGroup(groupRestoreId);
+      const activeId = groupMetadata.activeTabId;
+      if (activeId) {
+        if (worktreeId) {
+          trackTerminalFocus(worktreeId, activeId);
+        }
+        activateTerminal(activeId);
+        pingTerminal(activeId);
+      }
+      setIsOpen(false);
+    },
+    [
+      activeWorktreeId,
+      trackTerminalFocus,
+      selectWorktree,
+      restoreBackgroundGroup,
+      activateTerminal,
+      pingTerminal,
+    ]
+  );
+
+  const handleWatchToggle = useCallback(
+    (terminal: TerminalInstance) => {
+      const id = terminal.id;
+      if (watchedPanels.has(id)) {
+        unwatchPanel(id);
+        return;
+      }
+      if (
+        terminal.agentState === "completed" ||
+        terminal.agentState === "waiting" ||
+        terminal.agentState === "exited"
+      ) {
+        fireWatchNotification(id, terminal.title ?? id, terminal.agentState);
+        return;
+      }
+      watchPanel(id);
+    },
+    [watchedPanels, watchPanel, unwatchPanel]
+  );
+
+  const killTarget = useMemo(
+    () => (killConfirmId ? terminals.find((t) => t.id === killConfirmId) : undefined),
+    [killConfirmId, terminals]
+  );
+
+  const handleKillConfirm = useCallback(() => {
+    if (killConfirmId) {
+      removePanel(killConfirmId);
+    }
+    setKillConfirmId(null);
+  }, [killConfirmId, removePanel]);
+
   if (terminals.length === 0) return null;
 
   const count = terminals.length;
-
-  const handleRestoreSingle = (terminal: TerminalInstance) => {
-    const worktreeId = terminal.worktreeId?.trim();
-    if (worktreeId && worktreeId !== activeWorktreeId) {
-      trackTerminalFocus(worktreeId, terminal.id);
-      selectWorktree(worktreeId);
-    }
-    restoreBackgroundTerminal(terminal.id);
-    activateTerminal(terminal.id);
-    pingTerminal(terminal.id);
-    setIsOpen(false);
-  };
-
-  const handleRestoreGroup = (
-    groupRestoreId: string,
-    groupMetadata: TrashedTerminalGroupMetadata
-  ) => {
-    const worktreeId = groupMetadata.worktreeId?.trim();
-    if (worktreeId && worktreeId !== activeWorktreeId) {
-      selectWorktree(worktreeId);
-    }
-    restoreBackgroundGroup(groupRestoreId);
-    const activeId = groupMetadata.activeTabId;
-    if (activeId) {
-      if (worktreeId) {
-        trackTerminalFocus(worktreeId, activeId);
-      }
-      activateTerminal(activeId);
-      pingTerminal(activeId);
-    }
-    setIsOpen(false);
-  };
+  const triggerLabel =
+    waitingCount > 0 ? `Background (${count} · ${waitingCount} waiting)` : `Background (${count})`;
 
   return (
     <Popover open={isOpen} onOpenChange={setIsOpen}>
@@ -154,17 +243,35 @@ export function BackgroundContainer({ compact = false }: BackgroundContainerProp
           aria-haspopup="dialog"
           aria-expanded={isOpen}
           aria-controls="background-container-popover"
-          aria-label={`Background: ${count} panel${count === 1 ? "" : "s"}`}
+          aria-label={triggerLabel}
         >
           <span className="relative">
             <Moon className="w-3.5 h-3.5 text-daintree-text/50" aria-hidden="true" />
             {compact && count > 0 && (
-              <span className="absolute -top-1.5 -right-1.5 z-10 flex items-center justify-center min-w-[14px] h-[14px] px-0.5 rounded-full text-[10px] font-bold tabular-nums shadow-sm bg-daintree-text/20 text-daintree-text">
+              <span
+                className={cn(
+                  "absolute -top-1.5 -right-1.5 z-10 flex items-center justify-center min-w-[14px] h-[14px] px-0.5 rounded-full text-[10px] font-bold tabular-nums shadow-sm",
+                  waitingCount > 0
+                    ? "bg-state-waiting text-daintree-bg"
+                    : "bg-daintree-text/20 text-daintree-text"
+                )}
+              >
                 {count > 9 ? "9+" : count}
               </span>
             )}
           </span>
-          {!compact && <span className="font-medium tabular-nums">Background ({count})</span>}
+          {!compact && (
+            <span className="font-medium tabular-nums">
+              Background ({count}
+              {waitingCount > 0 && (
+                <>
+                  {" · "}
+                  <span className="text-state-waiting">{waitingCount} waiting</span>
+                </>
+              )}
+              )
+            </span>
+          )}
         </Button>
       </PopoverTrigger>
 
@@ -172,19 +279,36 @@ export function BackgroundContainer({ compact = false }: BackgroundContainerProp
         id="background-container-popover"
         role="dialog"
         aria-label="Backgrounded panels"
-        className="w-80 p-0"
+        className="w-96 p-0"
         side="top"
         align="end"
         sideOffset={8}
         onOpenAutoFocus={(e) => e.preventDefault()}
         onCloseAutoFocus={(e) => e.preventDefault()}
+        onPointerDownOutside={(e) => {
+          const target = e.target as Element | null;
+          if (target?.closest("[data-radix-portal]")) {
+            e.preventDefault();
+          }
+        }}
+        onInteractOutside={(e) => {
+          const target = e.target as Element | null;
+          if (target?.closest("[data-radix-portal]")) {
+            e.preventDefault();
+          }
+        }}
       >
         <div className="flex flex-col">
           <div className="px-3 py-2 border-b border-divider bg-daintree-bg/50 flex justify-between items-center">
-            <span className="text-xs font-medium text-daintree-text/70">Background Panels</span>
+            <span className="text-xs font-medium text-daintree-text/70">Background panels</span>
+            {waitingCount > 0 && (
+              <span className="text-[10px] font-medium text-state-waiting tabular-nums">
+                {waitingCount} waiting
+              </span>
+            )}
           </div>
 
-          <div className="p-1 flex flex-col gap-1 max-h-[300px] overflow-y-auto">
+          <div className="p-1 flex flex-col gap-1 max-h-[360px] overflow-y-auto">
             {displayItems.map((item) => {
               if (item.type === "group") {
                 return (
@@ -193,38 +317,193 @@ export function BackgroundContainer({ compact = false }: BackgroundContainerProp
                     groupRestoreId={item.groupRestoreId}
                     groupMetadata={item.groupMetadata}
                     terminals={item.terminals}
+                    worktreeMap={worktreeMap}
+                    watchedPanels={watchedPanels}
                     onRestoreGroup={handleRestoreGroup}
                     onRestoreSingle={handleRestoreSingle}
+                    onWatchToggle={handleWatchToggle}
+                    onKill={(id) => setKillConfirmId(id)}
                   />
                 );
               }
+              const worktreeName = item.terminal.worktreeId
+                ? worktreeMap.get(item.terminal.worktreeId)?.name
+                : undefined;
               return (
-                <button
+                <BackgroundSingleItem
                   key={item.terminal.id}
-                  type="button"
-                  onClick={() => handleRestoreSingle(item.terminal)}
-                  className="flex items-center justify-between gap-2.5 w-full px-2.5 py-1.5 rounded-[var(--radius-sm)] transition-colors group text-left outline-hidden hover:bg-tint/5 focus:bg-tint/5"
-                >
-                  <div className="flex items-center gap-2 min-w-0 flex-1">
-                    <div className="shrink-0 opacity-60 group-hover:opacity-100 transition-opacity">
-                      <TerminalIcon
-                        kind={item.terminal.kind}
-                        chrome={deriveTerminalChrome(item.terminal)}
-                        className="h-3 w-3"
-                      />
-                    </div>
-                    <span className="text-xs truncate font-medium text-daintree-text/70 group-hover:text-daintree-text transition-colors">
-                      {item.terminal.title}
-                    </span>
-                  </div>
-                  <span className="text-[10px] text-daintree-text/40 shrink-0">Restore</span>
-                </button>
+                  terminal={item.terminal}
+                  worktreeName={worktreeName}
+                  isWatched={watchedPanels.has(item.terminal.id)}
+                  onRestore={handleRestoreSingle}
+                  onWatchToggle={handleWatchToggle}
+                  onKill={(id) => setKillConfirmId(id)}
+                />
               );
             })}
           </div>
         </div>
       </PopoverContent>
+
+      <ConfirmDialog
+        isOpen={killConfirmId !== null}
+        onClose={() => setKillConfirmId(null)}
+        title="Kill terminal?"
+        description={
+          killTarget
+            ? `${killTarget.title || "The terminal"} will be terminated and cannot be recovered.`
+            : "The terminal will be terminated and cannot be recovered."
+        }
+        variant="destructive"
+        confirmLabel="Kill terminal"
+        onConfirm={handleKillConfirm}
+      />
     </Popover>
+  );
+}
+
+interface BackgroundSingleItemProps {
+  terminal: TerminalInstance;
+  worktreeName: string | undefined;
+  isWatched: boolean;
+  onRestore: (terminal: TerminalInstance) => void;
+  onWatchToggle: (terminal: TerminalInstance) => void;
+  onKill: (terminalId: string) => void;
+  compact?: boolean;
+}
+
+function BackgroundSingleItem({
+  terminal,
+  worktreeName,
+  isWatched,
+  onRestore,
+  onWatchToggle,
+  onKill,
+  compact = false,
+}: BackgroundSingleItemProps) {
+  const agentState = terminal.agentState;
+  const StateIcon = agentState ? STATE_ICONS[agentState] : null;
+  const stateLabel = agentState ? STATE_LABELS[agentState] : null;
+  const stateColor = agentState ? STATE_COLORS[agentState] : null;
+  const title = terminal.title || "Terminal";
+
+  return (
+    <div
+      data-testid="background-single-item"
+      data-agent-state={agentState ?? "unknown"}
+      className={cn(
+        "flex items-start gap-2 px-2 py-1.5 rounded-[var(--radius-sm)] hover:bg-tint/5 transition-colors group",
+        rowAmbientClass(agentState),
+        compact && "py-1 pl-1.5"
+      )}
+    >
+      <div className="shrink-0 mt-0.5 opacity-70 group-hover:opacity-100 transition-opacity">
+        <TerminalIcon
+          kind={terminal.kind}
+          chrome={deriveTerminalChrome(terminal)}
+          className={compact ? "h-2.5 w-2.5" : "h-3 w-3"}
+        />
+      </div>
+
+      <div className="flex-1 min-w-0">
+        <div className="flex items-center gap-1.5 min-w-0">
+          <span
+            className={cn(
+              "truncate font-medium text-daintree-text/80 group-hover:text-daintree-text transition-colors",
+              compact ? "text-[11px]" : "text-xs"
+            )}
+          >
+            {title}
+          </span>
+          {terminal.lastStateChange != null && (
+            <LiveTimeAgo
+              timestamp={terminal.lastStateChange}
+              className="text-[10px] text-daintree-text/40 shrink-0"
+            />
+          )}
+        </div>
+        <div className="flex items-center gap-1.5 mt-0.5 text-[11px] text-daintree-text/55">
+          {worktreeName && <span className="truncate">{worktreeName}</span>}
+          {worktreeName && (stateLabel || terminal.activityHeadline) && (
+            <span className="text-daintree-text/30">·</span>
+          )}
+          {StateIcon && stateLabel && (
+            <span className={cn("inline-flex items-center gap-1 shrink-0", stateColor)}>
+              <StateIcon className="h-2.5 w-2.5" />
+              <span>{stateLabel}</span>
+            </span>
+          )}
+          {terminal.activityHeadline && (
+            <>
+              {(worktreeName || stateLabel) && <span className="text-daintree-text/30">·</span>}
+              <span className="truncate italic text-daintree-text/50">
+                {terminal.activityHeadline}
+              </span>
+            </>
+          )}
+        </div>
+      </div>
+
+      <div className="flex gap-0.5 shrink-0 mt-0.5">
+        <Tooltip>
+          <TooltipTrigger asChild>
+            <Button
+              variant="ghost"
+              size="icon-sm"
+              onClick={(e) => {
+                e.stopPropagation();
+                onWatchToggle(terminal);
+              }}
+              aria-label="Watch for completion"
+              aria-pressed={isWatched}
+              data-testid="bg-watch-button"
+              className={cn(isWatched && "text-status-info")}
+            >
+              {isWatched ? <BellOff aria-hidden="true" /> : <Bell aria-hidden="true" />}
+            </Button>
+          </TooltipTrigger>
+          <TooltipContent side="bottom">
+            {isWatched ? "Stop watching" : "Watch for completion"}
+          </TooltipContent>
+        </Tooltip>
+
+        <Tooltip>
+          <TooltipTrigger asChild>
+            <Button
+              variant="ghost-success"
+              size="icon-sm"
+              onClick={(e) => {
+                e.stopPropagation();
+                onRestore(terminal);
+              }}
+              aria-label={`Restore ${title}`}
+              data-testid="bg-restore-button"
+            >
+              <RotateCcw aria-hidden="true" />
+            </Button>
+          </TooltipTrigger>
+          <TooltipContent side="bottom">{`Restore ${title}`}</TooltipContent>
+        </Tooltip>
+
+        <Tooltip>
+          <TooltipTrigger asChild>
+            <Button
+              variant="ghost-danger"
+              size="icon-sm"
+              onClick={(e) => {
+                e.stopPropagation();
+                onKill(terminal.id);
+              }}
+              aria-label={`Kill ${title}`}
+              data-testid="bg-kill-button"
+            >
+              <X aria-hidden="true" />
+            </Button>
+          </TooltipTrigger>
+          <TooltipContent side="bottom">{`Kill ${title}`}</TooltipContent>
+        </Tooltip>
+      </div>
+    </div>
   );
 }
 
@@ -232,18 +511,27 @@ function BackgroundGroupItem({
   groupRestoreId,
   groupMetadata,
   terminals,
+  worktreeMap,
+  watchedPanels,
   onRestoreGroup,
   onRestoreSingle,
+  onWatchToggle,
+  onKill,
 }: {
   groupRestoreId: string;
   groupMetadata: TrashedTerminalGroupMetadata;
   terminals: TerminalInstance[];
+  worktreeMap: ReturnType<typeof useWorktrees>["worktreeMap"];
+  watchedPanels: Set<string>;
   onRestoreGroup: (groupRestoreId: string, metadata: TrashedTerminalGroupMetadata) => void;
   onRestoreSingle: (terminal: TerminalInstance) => void;
+  onWatchToggle: (terminal: TerminalInstance) => void;
+  onKill: (terminalId: string) => void;
 }) {
   const [isExpanded, setIsExpanded] = useState(false);
   const tabCount = terminals.length;
   const groupName = `Tab Group (${tabCount} ${tabCount === 1 ? "tab" : "tabs"})`;
+  const groupWaiting = terminals.filter((t) => t.agentState === "waiting").length;
 
   return (
     <div className="rounded-[var(--radius-sm)] bg-transparent hover:bg-tint/5 transition-colors">
@@ -271,6 +559,11 @@ function BackgroundGroupItem({
         <div className="flex-1 min-w-0">
           <div className="text-xs font-medium text-daintree-text/70 group-hover:text-daintree-text truncate transition-colors">
             {groupName}
+            {groupWaiting > 0 && (
+              <span className="ml-1.5 text-[10px] text-state-waiting font-normal tabular-nums">
+                · {groupWaiting} waiting
+              </span>
+            )}
           </div>
         </div>
 
@@ -279,7 +572,7 @@ function BackgroundGroupItem({
           className="text-[10px] text-daintree-text/40 shrink-0 hover:text-daintree-text transition-colors"
           onClick={() => onRestoreGroup(groupRestoreId, groupMetadata)}
         >
-          Restore All
+          Restore all
         </button>
       </div>
 
@@ -288,7 +581,7 @@ function BackgroundGroupItem({
           id={`bg-group-${groupRestoreId}`}
           role="region"
           aria-label="Group panels"
-          className="pl-6 pr-2 pb-1.5 space-y-0.5"
+          className="pl-5 pr-1 pb-1.5 space-y-0.5"
         >
           {[...terminals]
             .sort((a, b) => {
@@ -298,27 +591,20 @@ function BackgroundGroupItem({
               return 0;
             })
             .map((terminal) => {
-              const isActiveTab = groupMetadata.activeTabId === terminal.id;
+              const worktreeName = terminal.worktreeId
+                ? worktreeMap.get(terminal.worktreeId)?.name
+                : undefined;
               return (
-                <button
+                <BackgroundSingleItem
                   key={terminal.id}
-                  type="button"
-                  onClick={() => onRestoreSingle(terminal)}
-                  className="flex items-center gap-2 w-full px-2 py-1 text-[11px] rounded hover:bg-tint/5 text-left"
-                >
-                  <TerminalIcon
-                    kind={terminal.kind}
-                    chrome={deriveTerminalChrome(terminal)}
-                    className="w-2.5 h-2.5 opacity-60"
-                  />
-                  <span
-                    className={`truncate flex-1 ${isActiveTab ? "text-daintree-text/70 font-medium" : "text-daintree-text/50"}`}
-                  >
-                    {terminal.title}
-                    {isActiveTab && <span className="ml-1 text-daintree-text/40">(active)</span>}
-                  </span>
-                  <span className="text-[10px] text-daintree-text/30 shrink-0">Restore</span>
-                </button>
+                  terminal={terminal}
+                  worktreeName={worktreeName}
+                  isWatched={watchedPanels.has(terminal.id)}
+                  onRestore={onRestoreSingle}
+                  onWatchToggle={onWatchToggle}
+                  onKill={onKill}
+                  compact
+                />
               );
             })}
         </div>

--- a/src/components/Layout/__tests__/BackgroundContainer.test.tsx
+++ b/src/components/Layout/__tests__/BackgroundContainer.test.tsx
@@ -1,0 +1,334 @@
+// @vitest-environment jsdom
+import { describe, it, expect, vi, beforeEach } from "vitest";
+import { fireEvent, render, screen, within } from "@testing-library/react";
+import type { TerminalInstance } from "@/store";
+import type { AgentState } from "@/types";
+
+const watchPanelMock = vi.fn();
+const unwatchPanelMock = vi.fn();
+const removePanelMock = vi.fn();
+const restoreBackgroundTerminalMock = vi.fn();
+const activateTerminalMock = vi.fn();
+const pingTerminalMock = vi.fn();
+const fireWatchNotificationMock = vi.fn();
+
+let mockTerminals: TerminalInstance[] = [];
+let mockBackgroundedTerminals = new Map<string, { groupRestoreId?: string }>();
+let mockWatchedPanels = new Set<string>();
+
+vi.mock("@/hooks/useTerminalSelectors", () => ({
+  useBackgroundedTerminals: () => mockTerminals,
+}));
+
+vi.mock("@/hooks/useWorktrees", () => ({
+  useWorktrees: () => ({
+    worktreeMap: new Map([
+      ["wt-1", { id: "wt-1", name: "feature-auth" }],
+      ["wt-2", { id: "wt-2", name: "feature-ui" }],
+    ]),
+  }),
+}));
+
+vi.mock("@/store", () => ({
+  usePanelStore: (selector?: (state: unknown) => unknown) => {
+    const state = {
+      backgroundedTerminals: mockBackgroundedTerminals,
+      watchedPanels: mockWatchedPanels,
+      restoreBackgroundTerminal: restoreBackgroundTerminalMock,
+      restoreBackgroundGroup: vi.fn(),
+      activateTerminal: activateTerminalMock,
+      pingTerminal: pingTerminalMock,
+      removePanel: removePanelMock,
+      watchPanel: watchPanelMock,
+      unwatchPanel: unwatchPanelMock,
+    };
+    return selector ? selector(state) : state;
+  },
+}));
+
+vi.mock("@/store/worktreeStore", () => ({
+  useWorktreeSelectionStore: (selector: (s: unknown) => unknown) =>
+    selector({
+      activeWorktreeId: "wt-1",
+      selectWorktree: vi.fn(),
+      trackTerminalFocus: vi.fn(),
+    }),
+}));
+
+vi.mock("@/lib/watchNotification", () => ({
+  fireWatchNotification: (...args: unknown[]) => fireWatchNotificationMock(...args),
+}));
+
+vi.mock("@/components/Terminal/TerminalIcon", () => ({
+  TerminalIcon: () => null,
+}));
+
+vi.mock("@/utils/terminalChrome", () => ({
+  deriveTerminalChrome: () => ({
+    iconId: null,
+    label: "Terminal",
+    isAgent: false,
+    agentId: null,
+    processId: null,
+    runtimeKind: "none",
+  }),
+}));
+
+vi.mock("@/components/Worktree/LiveTimeAgo", () => ({
+  LiveTimeAgo: ({ timestamp }: { timestamp: number }) => (
+    <span data-testid="live-time-ago">{`@${timestamp}`}</span>
+  ),
+}));
+
+vi.mock("@/components/ui/button", () => ({
+  Button: ({
+    children,
+    ...props
+  }: { children: React.ReactNode } & React.ButtonHTMLAttributes<HTMLButtonElement>) => (
+    <button {...props}>{children}</button>
+  ),
+}));
+
+vi.mock("@/components/ui/tooltip", () => {
+  const Pass = ({ children }: { children: React.ReactNode }) => <>{children}</>;
+  return {
+    Tooltip: Pass,
+    TooltipContent: Pass,
+    TooltipProvider: Pass,
+    TooltipTrigger: Pass,
+  };
+});
+
+vi.mock("@/components/ui/popover", () => ({
+  Popover: ({ children, open }: { children: React.ReactNode; open?: boolean }) => (
+    <div data-testid="popover" data-open={open ? "true" : "false"}>
+      {children}
+    </div>
+  ),
+  PopoverTrigger: ({ children }: { children: React.ReactNode }) => (
+    <div data-testid="popover-trigger">{children}</div>
+  ),
+  PopoverContent: ({ children }: { children: React.ReactNode }) => (
+    <div data-testid="popover-content">{children}</div>
+  ),
+}));
+
+vi.mock("@/components/ui/ConfirmDialog", () => ({
+  ConfirmDialog: ({
+    isOpen,
+    title,
+    confirmLabel,
+    onConfirm,
+    onClose,
+  }: {
+    isOpen: boolean;
+    title: React.ReactNode;
+    confirmLabel: string;
+    onConfirm: () => void;
+    onClose: () => void;
+  }) => {
+    if (!isOpen) return null;
+    return (
+      <div role="dialog" data-testid="kill-confirm-dialog">
+        <div data-testid="confirm-title">{title}</div>
+        <button type="button" onClick={onConfirm}>
+          {confirmLabel}
+        </button>
+        <button type="button" onClick={onClose}>
+          Cancel
+        </button>
+      </div>
+    );
+  },
+}));
+
+import { BackgroundContainer } from "../BackgroundContainer";
+
+function makeTerminal(overrides: Partial<TerminalInstance> = {}): TerminalInstance {
+  return {
+    id: "t1",
+    kind: "terminal",
+    title: "claude",
+    location: "background",
+    worktreeId: "wt-1",
+    agentState: "idle" as AgentState,
+    lastStateChange: 1700000000000,
+    ...overrides,
+  } as TerminalInstance;
+}
+
+beforeEach(() => {
+  watchPanelMock.mockReset();
+  unwatchPanelMock.mockReset();
+  removePanelMock.mockReset();
+  restoreBackgroundTerminalMock.mockReset();
+  activateTerminalMock.mockReset();
+  pingTerminalMock.mockReset();
+  fireWatchNotificationMock.mockReset();
+  mockTerminals = [];
+  mockBackgroundedTerminals = new Map();
+  mockWatchedPanels = new Set();
+});
+
+describe("BackgroundContainer", () => {
+  it("renders nothing when there are no backgrounded terminals", () => {
+    const { container } = render(<BackgroundContainer />);
+    expect(container.textContent).toBe("");
+  });
+
+  describe("trigger label", () => {
+    it("shows only the count when no terminals are waiting", () => {
+      mockTerminals = [
+        makeTerminal({ id: "t1", agentState: "idle" }),
+        makeTerminal({ id: "t2", agentState: "working" }),
+        makeTerminal({ id: "t3", agentState: "completed" }),
+      ];
+      render(<BackgroundContainer />);
+      const trigger = screen.getByRole("button", { name: /Background \(3\)/ });
+      expect(trigger).toBeTruthy();
+      expect(trigger.getAttribute("aria-label")).toBe("Background (3)");
+    });
+
+    it("appends waiting count when terminals are waiting", () => {
+      mockTerminals = [
+        makeTerminal({ id: "t1", agentState: "waiting" }),
+        makeTerminal({ id: "t2", agentState: "waiting" }),
+        makeTerminal({ id: "t3", agentState: "working" }),
+      ];
+      render(<BackgroundContainer />);
+      const trigger = screen.getByRole("button", {
+        name: /Background \(3 · 2 waiting\)/,
+      });
+      expect(trigger).toBeTruthy();
+      expect(trigger.getAttribute("aria-label")).toBe("Background (3 · 2 waiting)");
+    });
+  });
+
+  describe("row metadata", () => {
+    it("renders worktree name, state label, headline, and live time", () => {
+      mockTerminals = [
+        makeTerminal({
+          id: "t1",
+          title: "Fix auth bug",
+          agentState: "waiting",
+          activityHeadline: "Awaiting permission",
+          lastStateChange: 1700000000123,
+        }),
+      ];
+      render(<BackgroundContainer />);
+      const row = screen.getByTestId("background-single-item");
+      const text = row.textContent ?? "";
+      expect(text).toContain("Fix auth bug");
+      expect(text).toContain("feature-auth");
+      expect(text).toContain("waiting");
+      expect(text).toContain("Awaiting permission");
+      expect(within(row).getByTestId("live-time-ago")).toBeTruthy();
+    });
+
+    it("uses ambient border + tint for waiting state, not panel-state classes", () => {
+      mockTerminals = [makeTerminal({ id: "t1", agentState: "waiting" })];
+      render(<BackgroundContainer />);
+      const row = screen.getByTestId("background-single-item");
+      expect(row.className).toContain("border-l-2");
+      expect(row.className).toContain("border-l-[color:var(--color-activity-waiting)]");
+      expect(row.className).toContain(
+        "bg-[color-mix(in_oklab,var(--color-activity-waiting)_8%,transparent)]"
+      );
+      expect(row.className).not.toContain("panel-state-waiting");
+    });
+
+    it("uses working ambient styling without panel-state classes", () => {
+      mockTerminals = [makeTerminal({ id: "t1", agentState: "working" })];
+      render(<BackgroundContainer />);
+      const row = screen.getByTestId("background-single-item");
+      expect(row.className).toContain("border-l-[color:var(--color-activity-working)]");
+      expect(row.className).not.toContain("panel-state-working");
+    });
+
+    it("uses a transparent border placeholder for passive states (no layout shift)", () => {
+      mockTerminals = [makeTerminal({ id: "t1", agentState: "idle" })];
+      render(<BackgroundContainer />);
+      const row = screen.getByTestId("background-single-item");
+      expect(row.className).toContain("border-l-2");
+      expect(row.className).toContain("border-l-transparent");
+    });
+  });
+
+  describe("watch toggle", () => {
+    it("calls watchPanel for unwatched terminals not in a terminal state", () => {
+      mockTerminals = [makeTerminal({ id: "t1", agentState: "working" })];
+      mockWatchedPanels = new Set();
+      render(<BackgroundContainer />);
+      fireEvent.click(screen.getByTestId("bg-watch-button"));
+      expect(watchPanelMock).toHaveBeenCalledWith("t1");
+      expect(fireWatchNotificationMock).not.toHaveBeenCalled();
+    });
+
+    it("fires immediate notification for already-waiting terminals instead of subscribing", () => {
+      mockTerminals = [makeTerminal({ id: "t1", agentState: "waiting", title: "claude task" })];
+      mockWatchedPanels = new Set();
+      render(<BackgroundContainer />);
+      fireEvent.click(screen.getByTestId("bg-watch-button"));
+      expect(fireWatchNotificationMock).toHaveBeenCalledWith("t1", "claude task", "waiting");
+      expect(watchPanelMock).not.toHaveBeenCalled();
+    });
+
+    it("fires immediate notification for completed terminals", () => {
+      mockTerminals = [makeTerminal({ id: "t1", agentState: "completed" })];
+      mockWatchedPanels = new Set();
+      render(<BackgroundContainer />);
+      fireEvent.click(screen.getByTestId("bg-watch-button"));
+      expect(fireWatchNotificationMock).toHaveBeenCalledWith("t1", "claude", "completed");
+      expect(watchPanelMock).not.toHaveBeenCalled();
+    });
+
+    it("calls unwatchPanel when the terminal is already watched", () => {
+      mockTerminals = [makeTerminal({ id: "t1", agentState: "working" })];
+      mockWatchedPanels = new Set(["t1"]);
+      render(<BackgroundContainer />);
+      fireEvent.click(screen.getByTestId("bg-watch-button"));
+      expect(unwatchPanelMock).toHaveBeenCalledWith("t1");
+      expect(watchPanelMock).not.toHaveBeenCalled();
+    });
+  });
+
+  describe("kill confirm flow", () => {
+    it("opens the ConfirmDialog when kill is clicked, does not call removePanel yet", () => {
+      mockTerminals = [makeTerminal({ id: "t1", title: "Fix auth" })];
+      render(<BackgroundContainer />);
+      expect(screen.queryByTestId("kill-confirm-dialog")).toBeNull();
+      fireEvent.click(screen.getByTestId("bg-kill-button"));
+      expect(screen.getByTestId("kill-confirm-dialog")).toBeTruthy();
+      expect(removePanelMock).not.toHaveBeenCalled();
+    });
+
+    it("calls removePanel and closes the dialog when confirmed", () => {
+      mockTerminals = [makeTerminal({ id: "t1" })];
+      render(<BackgroundContainer />);
+      fireEvent.click(screen.getByTestId("bg-kill-button"));
+      fireEvent.click(screen.getByRole("button", { name: "Kill terminal" }));
+      expect(removePanelMock).toHaveBeenCalledWith("t1");
+      expect(screen.queryByTestId("kill-confirm-dialog")).toBeNull();
+    });
+
+    it("does not call removePanel when the dialog is cancelled", () => {
+      mockTerminals = [makeTerminal({ id: "t1" })];
+      render(<BackgroundContainer />);
+      fireEvent.click(screen.getByTestId("bg-kill-button"));
+      fireEvent.click(screen.getByRole("button", { name: "Cancel" }));
+      expect(removePanelMock).not.toHaveBeenCalled();
+      expect(screen.queryByTestId("kill-confirm-dialog")).toBeNull();
+    });
+  });
+
+  describe("restore action", () => {
+    it("invokes restoreBackgroundTerminal and activateTerminal", () => {
+      mockTerminals = [makeTerminal({ id: "t1" })];
+      render(<BackgroundContainer />);
+      fireEvent.click(screen.getByTestId("bg-restore-button"));
+      expect(restoreBackgroundTerminalMock).toHaveBeenCalledWith("t1");
+      expect(activateTerminalMock).toHaveBeenCalledWith("t1");
+      expect(pingTerminalMock).toHaveBeenCalledWith("t1");
+    });
+  });
+});

--- a/src/components/Layout/__tests__/BackgroundContainer.test.tsx
+++ b/src/components/Layout/__tests__/BackgroundContainer.test.tsx
@@ -11,6 +11,8 @@ const restoreBackgroundTerminalMock = vi.fn();
 const activateTerminalMock = vi.fn();
 const pingTerminalMock = vi.fn();
 const fireWatchNotificationMock = vi.fn();
+const selectWorktreeMock = vi.fn();
+const trackTerminalFocusMock = vi.fn();
 
 let mockTerminals: TerminalInstance[] = [];
 let mockBackgroundedTerminals = new Map<string, { groupRestoreId?: string }>();
@@ -50,8 +52,8 @@ vi.mock("@/store/worktreeStore", () => ({
   useWorktreeSelectionStore: (selector: (s: unknown) => unknown) =>
     selector({
       activeWorktreeId: "wt-1",
-      selectWorktree: vi.fn(),
-      trackTerminalFocus: vi.fn(),
+      selectWorktree: selectWorktreeMock,
+      trackTerminalFocus: trackTerminalFocusMock,
     }),
 }));
 
@@ -99,6 +101,18 @@ vi.mock("@/components/ui/tooltip", () => {
   };
 });
 
+type DismissHandler = (e: { preventDefault: () => void; target?: Element | null }) => void;
+
+const popoverHandlers: {
+  onPointerDownOutside: DismissHandler | undefined;
+  onInteractOutside: DismissHandler | undefined;
+  onEscapeKeyDown: DismissHandler | undefined;
+} = {
+  onPointerDownOutside: undefined,
+  onInteractOutside: undefined,
+  onEscapeKeyDown: undefined,
+};
+
 vi.mock("@/components/ui/popover", () => ({
   Popover: ({ children, open }: { children: React.ReactNode; open?: boolean }) => (
     <div data-testid="popover" data-open={open ? "true" : "false"}>
@@ -108,9 +122,22 @@ vi.mock("@/components/ui/popover", () => ({
   PopoverTrigger: ({ children }: { children: React.ReactNode }) => (
     <div data-testid="popover-trigger">{children}</div>
   ),
-  PopoverContent: ({ children }: { children: React.ReactNode }) => (
-    <div data-testid="popover-content">{children}</div>
-  ),
+  PopoverContent: ({
+    children,
+    onPointerDownOutside,
+    onInteractOutside,
+    onEscapeKeyDown,
+  }: {
+    children: React.ReactNode;
+    onPointerDownOutside?: DismissHandler;
+    onInteractOutside?: DismissHandler;
+    onEscapeKeyDown?: DismissHandler;
+  }) => {
+    popoverHandlers.onPointerDownOutside = onPointerDownOutside;
+    popoverHandlers.onInteractOutside = onInteractOutside;
+    popoverHandlers.onEscapeKeyDown = onEscapeKeyDown;
+    return <div data-testid="popover-content">{children}</div>;
+  },
 }));
 
 vi.mock("@/components/ui/ConfirmDialog", () => ({
@@ -165,6 +192,11 @@ beforeEach(() => {
   activateTerminalMock.mockReset();
   pingTerminalMock.mockReset();
   fireWatchNotificationMock.mockReset();
+  selectWorktreeMock.mockReset();
+  trackTerminalFocusMock.mockReset();
+  popoverHandlers.onPointerDownOutside = undefined;
+  popoverHandlers.onInteractOutside = undefined;
+  popoverHandlers.onEscapeKeyDown = undefined;
   mockTerminals = [];
   mockBackgroundedTerminals = new Map();
   mockWatchedPanels = new Set();
@@ -290,6 +322,30 @@ describe("BackgroundContainer", () => {
       expect(unwatchPanelMock).toHaveBeenCalledWith("t1");
       expect(watchPanelMock).not.toHaveBeenCalled();
     });
+
+    it("fires immediate notification for exited terminals instead of subscribing", () => {
+      mockTerminals = [makeTerminal({ id: "t1", agentState: "exited", title: "claude task" })];
+      mockWatchedPanels = new Set();
+      render(<BackgroundContainer />);
+      fireEvent.click(screen.getByTestId("bg-watch-button"));
+      expect(fireWatchNotificationMock).toHaveBeenCalledWith("t1", "claude task", "exited");
+      expect(watchPanelMock).not.toHaveBeenCalled();
+    });
+
+    it("uses a state-matched aria-label so screen readers announce the toggle target", () => {
+      mockTerminals = [makeTerminal({ id: "t1", agentState: "working" })];
+      mockWatchedPanels = new Set();
+      const { unmount } = render(<BackgroundContainer />);
+      expect(screen.getByTestId("bg-watch-button").getAttribute("aria-label")).toBe(
+        "Watch for completion"
+      );
+      unmount();
+      mockWatchedPanels = new Set(["t1"]);
+      render(<BackgroundContainer />);
+      expect(screen.getByTestId("bg-watch-button").getAttribute("aria-label")).toBe(
+        "Stop watching"
+      );
+    });
   });
 
   describe("kill confirm flow", () => {
@@ -329,6 +385,52 @@ describe("BackgroundContainer", () => {
       expect(restoreBackgroundTerminalMock).toHaveBeenCalledWith("t1");
       expect(activateTerminalMock).toHaveBeenCalledWith("t1");
       expect(pingTerminalMock).toHaveBeenCalledWith("t1");
+    });
+
+    it("switches worktrees when restoring a terminal from a different worktree", () => {
+      mockTerminals = [makeTerminal({ id: "t1", worktreeId: "wt-2" })];
+      render(<BackgroundContainer />);
+      fireEvent.click(screen.getByTestId("bg-restore-button"));
+      expect(trackTerminalFocusMock).toHaveBeenCalledWith("wt-2", "t1");
+      expect(selectWorktreeMock).toHaveBeenCalledWith("wt-2");
+    });
+
+    it("does not switch worktrees when the terminal already belongs to the active worktree", () => {
+      mockTerminals = [makeTerminal({ id: "t1", worktreeId: "wt-1" })];
+      render(<BackgroundContainer />);
+      fireEvent.click(screen.getByTestId("bg-restore-button"));
+      expect(selectWorktreeMock).not.toHaveBeenCalled();
+    });
+  });
+
+  describe("popover dismiss guard during kill confirm", () => {
+    it("does not prevent dismiss when no kill confirm is open", () => {
+      mockTerminals = [makeTerminal({ id: "t1" })];
+      render(<BackgroundContainer />);
+      const preventDefault = vi.fn();
+      popoverHandlers.onPointerDownOutside?.({ preventDefault });
+      popoverHandlers.onInteractOutside?.({ preventDefault });
+      popoverHandlers.onEscapeKeyDown?.({ preventDefault });
+      expect(preventDefault).not.toHaveBeenCalled();
+    });
+
+    it("prevents dismiss when the kill confirm dialog is open", () => {
+      mockTerminals = [makeTerminal({ id: "t1" })];
+      render(<BackgroundContainer />);
+      // Open kill confirm to enter the guarded state.
+      fireEvent.click(screen.getByTestId("bg-kill-button"));
+      expect(screen.getByTestId("kill-confirm-dialog")).toBeTruthy();
+
+      const pointer = { preventDefault: vi.fn() };
+      const interact = { preventDefault: vi.fn() };
+      const escape = { preventDefault: vi.fn() };
+      popoverHandlers.onPointerDownOutside?.(pointer);
+      popoverHandlers.onInteractOutside?.(interact);
+      popoverHandlers.onEscapeKeyDown?.(escape);
+
+      expect(pointer.preventDefault).toHaveBeenCalledTimes(1);
+      expect(interact.preventDefault).toHaveBeenCalledTimes(1);
+      expect(escape.preventDefault).toHaveBeenCalledTimes(1);
     });
   });
 });


### PR DESCRIPTION
## Summary

- Each backgrounded panel row now shows an agent state dot, activity headline, worktree name, and time since last state change — everything you need to scan three agents and know which one is waiting on you
- Waiting rows get the same ambient `panel-state-waiting` border treatment used in `ContentPanel`; the trigger button gains a waiting count (`Background (5 · 2 waiting)`) so the signal reaches you without opening the popover
- Quick actions added inline: restore to dock, watch toggle (notifications without restoring), trash, and kill — kill is D1 destructive and goes through a `ConfirmDialog` with a verb-noun label

Resolves #8082

## Changes

- `BackgroundContainer.tsx` — reworked row template to match the `TrashBinItem` two-line density pattern; wired `AgentStatusIndicator`, `LiveTimeAgo`, watch toggle via `terminal.watch` action, and the kill/trash/restore action buttons
- `panel-state-waiting` / `panel-state-working` ambient border applied at the row level for waiting panels
- Trigger button label logic updated to surface a waiting count when one or more panels need attention
- `BackgroundContainer.test.tsx` (new) — unit tests covering state rendering, waiting count display, watch toggle, and action button wiring

## Testing

- New test file exercises the full range of row states (idle, working, waiting, completed) and verifies the trigger label, watch toggle, and confirm dialog wiring
- Manually verified with two and five backgrounded panels across two worktrees — state dots, headlines, and timing all update live; waiting border treatment matches the in-dock chrome