### PR TITLE
fix(ui): tighten palette highlight rendering and footer microcopy

### DIFF
--- a/src/components/PanelPalette/PanelPalette.tsx
+++ b/src/components/PanelPalette/PanelPalette.tsx
@@ -236,8 +236,8 @@ export function PanelPalette({
             label: selectedKind ? `to create ${selectedKind.name.toLowerCase()}` : "to create",
           }}
           hints={[
-            { keys: ["↑", "↓"], label: "to navigate" },
-            { keys: ["Esc"], label: "to close" },
+            { keys: ["↑", "↓"], label: "navigate" },
+            { keys: ["Esc"], label: "close" },
           ]}
         />
       </AppPaletteDialog.Footer>

--- a/src/components/QuickSwitcher/QuickSwitcher.tsx
+++ b/src/components/QuickSwitcher/QuickSwitcher.tsx
@@ -69,8 +69,8 @@ export function QuickSwitcher({
           <PaletteFooterHints
             primaryHint={{ keys: ["↵"], label }}
             hints={[
-              { keys: ["↑", "↓"], label: "to navigate" },
-              { keys: ["Esc"], label: "to close" },
+              { keys: ["↑", "↓"], label: "navigate" },
+              { keys: ["Esc"], label: "close" },
             ]}
           />
         </div>

--- a/src/components/Settings/__tests__/settingsSearchUtils.test.ts
+++ b/src/components/Settings/__tests__/settingsSearchUtils.test.ts
@@ -153,7 +153,9 @@ describe("HighlightText", () => {
   it("wraps matching text in a highlight span", () => {
     const html = renderToStaticMarkup(HighlightText({ text: "Font size setting", query: "font" }));
     expect(html).toContain("text-search-highlight-text");
-    expect(html).toContain("font-semibold");
+    // Bold weight removed — color alone differentiates the match, so width
+    // does not shift as the user types.
+    expect(html).not.toContain("font-semibold");
     // The matched portion should be inside the highlight span
     expect(html.toLowerCase()).toContain(">font<");
   });

--- a/src/components/Settings/settingsSearchUtils.tsx
+++ b/src/components/Settings/settingsSearchUtils.tsx
@@ -174,7 +174,7 @@ export function HighlightText({ text, query }: HighlightTextProps) {
       <span>
         {parts.map((part, i) =>
           lowerTokens.some((t) => part.toLowerCase() === t) ? (
-            <span key={i} className="text-search-highlight-text font-semibold">
+            <span key={i} className="text-search-highlight-text">
               {part}
             </span>
           ) : (

--- a/src/components/Terminal/PromptHistoryPalette.tsx
+++ b/src/components/Terminal/PromptHistoryPalette.tsx
@@ -133,8 +133,8 @@ export function PromptHistoryPalette({ onOpenRef, ...props }: PromptHistoryPalet
         <PaletteFooterHints
           primaryHint={{ keys: ["↵"], label: "to recall" }}
           hints={[
-            { keys: ["↑", "↓"], label: "to navigate" },
-            { keys: ["Esc"], label: "to close" },
+            { keys: ["↑", "↓"], label: "navigate" },
+            { keys: ["Esc"], label: "close" },
           ]}
         />
       </div>

--- a/src/components/TerminalPalette/NewTerminalPalette.tsx
+++ b/src/components/TerminalPalette/NewTerminalPalette.tsx
@@ -162,8 +162,8 @@ export function NewTerminalPalette({
             label: selectedOption ? `to launch ${selectedOption.label.toLowerCase()}` : "to launch",
           }}
           hints={[
-            { keys: ["↑", "↓"], label: "to navigate" },
-            { keys: ["Esc"], label: "to close" },
+            { keys: ["↑", "↓"], label: "navigate" },
+            { keys: ["Esc"], label: "close" },
           ]}
         />
       </AppPaletteDialog.Footer>

--- a/src/components/Worktree/QuickCreatePalette.tsx
+++ b/src/components/Worktree/QuickCreatePalette.tsx
@@ -178,7 +178,7 @@ export function QuickCreatePalette({ palette }: QuickCreatePaletteProps) {
       footer={
         <PaletteFooterHints
           primaryHint={{ keys: ["↵"], label: palette.isPending ? "creating…" : "to create" }}
-          hints={[{ keys: ["Esc"], label: "to cancel" }]}
+          hints={[{ keys: ["Esc"], label: "cancel" }]}
         />
       }
     />

--- a/src/components/ui/AppPaletteDialog.tsx
+++ b/src/components/ui/AppPaletteDialog.tsx
@@ -388,8 +388,8 @@ function DefaultKeyboardHints() {
     <PaletteFooterHints
       primaryHint={{ keys: ["↵"], label: "to select" }}
       hints={[
-        { keys: ["↑", "↓"], label: "to navigate" },
-        { keys: ["Esc"], label: "to close" },
+        { keys: ["↑", "↓"], label: "navigate" },
+        { keys: ["Esc"], label: "close" },
       ]}
     />
   );

--- a/src/components/ui/HighlightedText.tsx
+++ b/src/components/ui/HighlightedText.tsx
@@ -12,7 +12,9 @@ export function HighlightedText({ text, indices }: HighlightedTextProps) {
   // can emit unsorted/overlapping indices when a query is split across
   // BitapSearch chunks; using `prev.end + 1` as the merge threshold unifies
   // adjacency (touching ranges) and overlap.
-  const sorted = [...indices].filter(([s, e]) => s <= e).sort((a, b) => a[0] - b[0]);
+  const sorted = [...indices]
+    .filter(([s, e]) => s >= 0 && s <= e && e < text.length)
+    .sort((a, b) => a[0] - b[0]);
   const merged: [number, number][] = [];
   for (const [s, e] of sorted) {
     const last = merged[merged.length - 1];

--- a/src/components/ui/HighlightedText.tsx
+++ b/src/components/ui/HighlightedText.tsx
@@ -7,18 +7,27 @@ interface HighlightedTextProps {
 
 export function HighlightedText({ text, indices }: HighlightedTextProps) {
   if (!indices?.length) return <>{text}</>;
-  const sorted = [...indices].sort((a, b) => a[0] - b[0]);
+  // Merge adjacent and overlapping ranges so a contiguous match renders as a
+  // single span (sub-pixel gaps otherwise appear between adjacent spans). Fuse
+  // can emit unsorted/overlapping indices when a query is split across
+  // BitapSearch chunks; using `prev.end + 1` as the merge threshold unifies
+  // adjacency (touching ranges) and overlap.
+  const sorted = [...indices].filter(([s, e]) => s <= e).sort((a, b) => a[0] - b[0]);
+  const merged: [number, number][] = [];
+  for (const [s, e] of sorted) {
+    const last = merged[merged.length - 1];
+    if (last && s <= last[1] + 1) {
+      last[1] = Math.max(last[1], e);
+    } else {
+      merged.push([s, e]);
+    }
+  }
   const parts: React.ReactNode[] = [];
   let lastIndex = 0;
-  sorted.forEach(([rawStart, rawEnd], i) => {
-    // Clamp overlapping ranges — Fuse can emit unsorted/overlapping indices
-    // when a query is split across BitapSearch chunks.
-    const start = Math.max(rawStart, lastIndex);
-    const end = Math.max(rawEnd, lastIndex - 1);
-    if (start > end) return;
+  merged.forEach(([start, end], i) => {
     if (start > lastIndex) parts.push(text.substring(lastIndex, start));
     parts.push(
-      <span key={i} className="text-search-highlight-text font-semibold">
+      <span key={i} className="text-search-highlight-text">
         {text.substring(start, end + 1)}
       </span>
     );

--- a/src/components/ui/PaletteOverflowNotice.tsx
+++ b/src/components/ui/PaletteOverflowNotice.tsx
@@ -6,12 +6,14 @@ interface PaletteOverflowNoticeProps {
 export function PaletteOverflowNotice({ shown, total }: PaletteOverflowNoticeProps) {
   if (total <= shown) return null;
 
+  const hidden = total - shown;
   return (
     <div
       role="status"
+      aria-label={`${hidden} more results not shown — refine your search to see them`}
       className="px-3 py-2 text-xs tabular-nums text-daintree-text/40 text-center border-t border-daintree-border/30"
     >
-      +{total - shown} more
+      +{hidden} more
     </div>
   );
 }

--- a/src/components/ui/PaletteOverflowNotice.tsx
+++ b/src/components/ui/PaletteOverflowNotice.tsx
@@ -11,7 +11,7 @@ export function PaletteOverflowNotice({ shown, total }: PaletteOverflowNoticePro
       role="status"
       className="px-3 py-2 text-xs tabular-nums text-daintree-text/40 text-center border-t border-daintree-border/30"
     >
-      Showing {shown} of {total} — refine your search to see more
+      +{total - shown} more
     </div>
   );
 }

--- a/src/components/ui/SearchablePalette.tsx
+++ b/src/components/ui/SearchablePalette.tsx
@@ -264,8 +264,8 @@ export function SearchablePalette<T>({
       <PaletteFooterHints
         primaryHint={{ keys: ["↵"], label: phrase }}
         hints={[
-          { keys: ["↑", "↓"], label: "to navigate" },
-          { keys: ["Esc"], label: "to close" },
+          { keys: ["↑", "↓"], label: "navigate" },
+          { keys: ["Esc"], label: "close" },
         ]}
       />
     );

--- a/src/components/ui/__tests__/HighlightedText.test.tsx
+++ b/src/components/ui/__tests__/HighlightedText.test.tsx
@@ -24,7 +24,9 @@ describe("HighlightedText", () => {
     const marks = container.querySelectorAll(".text-search-highlight-text");
     expect(marks).toHaveLength(1);
     expect(marks[0]?.textContent).toBe("Terminal");
-    expect(marks[0]?.classList.contains("font-semibold")).toBe(true);
+    // Color alone differentiates — bold weight caused character-width jitter
+    // as the user typed, so the highlight span must not change the weight.
+    expect(marks[0]?.classList.contains("font-semibold")).toBe(false);
   });
 
   it("highlights a single character", () => {
@@ -52,9 +54,10 @@ describe("HighlightedText", () => {
     expect(marks[1]?.textContent).toBe("font");
   });
 
-  it("clamps overlapping indices without duplicating text", () => {
+  it("merges overlapping indices into a single span without duplicating text", () => {
     // Fuse.js can emit overlapping/unsorted ranges when patterns split across
-    // BitapSearch chunks. The component must not render duplicate characters.
+    // BitapSearch chunks. Merging into one span avoids both duplicate characters
+    // and sub-pixel rendering gaps between adjacent spans.
     const { container } = render(
       <HighlightedText
         text="abcdefghij"
@@ -65,6 +68,27 @@ describe("HighlightedText", () => {
       />
     );
     expect(container.textContent).toBe("abcdefghij");
+    const marks = container.querySelectorAll(".text-search-highlight-text");
+    expect(marks).toHaveLength(1);
+    expect(marks[0]?.textContent).toBe("abcdefg");
+  });
+
+  it("merges adjacent (touching) indices into a single span", () => {
+    // Two ranges that touch (end+1 === nextStart) should render as one span
+    // to avoid sub-pixel gaps between visually contiguous highlights.
+    const { container } = render(
+      <HighlightedText
+        text="abcdefghi"
+        indices={[
+          [0, 2],
+          [3, 5],
+        ]}
+      />
+    );
+    expect(container.textContent).toBe("abcdefghi");
+    const marks = container.querySelectorAll(".text-search-highlight-text");
+    expect(marks).toHaveLength(1);
+    expect(marks[0]?.textContent).toBe("abcdef");
   });
 });
 

--- a/src/components/ui/__tests__/HighlightedText.test.tsx
+++ b/src/components/ui/__tests__/HighlightedText.test.tsx
@@ -90,6 +90,42 @@ describe("HighlightedText", () => {
     expect(marks).toHaveLength(1);
     expect(marks[0]?.textContent).toBe("abcdef");
   });
+
+  it("keeps ranges with a one-character gap separate", () => {
+    // A non-zero gap between ranges must NOT merge — only adjacency (gap=0)
+    // and overlap collapse into one span.
+    const { container } = render(
+      <HighlightedText
+        text="abcXefg"
+        indices={[
+          [0, 2],
+          [4, 6],
+        ]}
+      />
+    );
+    expect(container.textContent).toBe("abcXefg");
+    const marks = container.querySelectorAll(".text-search-highlight-text");
+    expect(marks).toHaveLength(2);
+    expect(marks[0]?.textContent).toBe("abc");
+    expect(marks[1]?.textContent).toBe("efg");
+  });
+
+  it("silently drops out-of-bounds and negative indices", () => {
+    // Malformed indices from a future consumer must not produce empty/phantom
+    // spans — Fuse itself never emits these, but the filter guards future
+    // callers and keeps the rendered output stable.
+    const { container } = render(
+      <HighlightedText
+        text="abc"
+        indices={[
+          [-1, 1],
+          [10, 12],
+        ]}
+      />
+    );
+    expect(container.textContent).toBe("abc");
+    expect(container.querySelectorAll(".text-search-highlight-text")).toHaveLength(0);
+  });
 });
 
 describe("findMatchIndices", () => {

--- a/src/components/ui/__tests__/PaletteFooterHints.test.tsx
+++ b/src/components/ui/__tests__/PaletteFooterHints.test.tsx
@@ -20,8 +20,8 @@ describe("PaletteFooterHints", () => {
   const defaultProps = {
     primaryHint: { keys: ["↵"], label: "to create" },
     hints: [
-      { keys: ["↑", "↓"], label: "to navigate" },
-      { keys: ["Esc"], label: "to close" },
+      { keys: ["↑", "↓"], label: "navigate" },
+      { keys: ["Esc"], label: "close" },
     ],
   };
 
@@ -33,29 +33,27 @@ describe("PaletteFooterHints", () => {
 
   it("renders all secondary hints ambient — no popover, no help button", () => {
     render(<PaletteFooterHints {...defaultProps} />);
-    expect(screen.getByText("to navigate")).toBeTruthy();
-    expect(screen.getByText("to close")).toBeTruthy();
+    expect(screen.getByText("navigate")).toBeTruthy();
+    expect(screen.getByText("close")).toBeTruthy();
     expect(screen.queryByRole("button", { name: /keyboard shortcuts/i })).toBeNull();
   });
 
   it("renders all keys for a multi-key hint", () => {
-    render(
-      <PaletteFooterHints primaryHint={{ keys: ["↑", "↓"], label: "to navigate" }} hints={[]} />
-    );
+    render(<PaletteFooterHints primaryHint={{ keys: ["↑", "↓"], label: "navigate" }} hints={[]} />);
     expect(screen.getByText("↑")).toBeTruthy();
     expect(screen.getByText("↓")).toBeTruthy();
   });
 
   it("renders no secondary chips when hints is empty", () => {
     render(<PaletteFooterHints primaryHint={defaultProps.primaryHint} hints={[]} />);
-    expect(screen.queryByText("to navigate")).toBeNull();
-    expect(screen.queryByText("to close")).toBeNull();
+    expect(screen.queryByText("navigate")).toBeNull();
+    expect(screen.queryByText("close")).toBeNull();
   });
 
   it("applies width-priority drop classes — last hint hides earliest", () => {
     const { container } = render(<PaletteFooterHints {...defaultProps} />);
-    const escChip = screen.getByText("to close").parentElement;
-    const navChip = screen.getByText("to navigate").parentElement;
+    const escChip = screen.getByText("close").parentElement;
+    const navChip = screen.getByText("navigate").parentElement;
     // Esc is rightmost (index 1 of 2) → from-end index 0 → highest breakpoint.
     expect(escChip?.className).toContain("@max-[380px]/palette-footer:hidden");
     // ↑↓ is index 0 of 2 → from-end index 1 → lower breakpoint, hides only when narrower.

--- a/src/components/ui/__tests__/PaletteOverflowNotice.test.tsx
+++ b/src/components/ui/__tests__/PaletteOverflowNotice.test.tsx
@@ -25,4 +25,16 @@ describe("PaletteOverflowNotice", () => {
     expect(notice).toBeTruthy();
     expect(notice.textContent).toBe("+27 more");
   });
+
+  it("exposes a descriptive aria-label so screen readers get context", () => {
+    // The visible text is terse for visual scanning, so AT users get a
+    // fuller phrase via aria-label that mentions "results" and the recovery
+    // ("refine your search").
+    render(<PaletteOverflowNotice shown={20} total={47} />);
+    const notice = screen.getByRole("status");
+    const label = notice.getAttribute("aria-label") ?? "";
+    expect(label).toContain("27");
+    expect(label.toLowerCase()).toContain("results");
+    expect(label.toLowerCase()).toContain("refine");
+  });
 });

--- a/src/components/ui/__tests__/PaletteOverflowNotice.test.tsx
+++ b/src/components/ui/__tests__/PaletteOverflowNotice.test.tsx
@@ -6,7 +6,7 @@ import { PaletteOverflowNotice } from "../PaletteOverflowNotice";
 describe("PaletteOverflowNotice", () => {
   it("renders when total exceeds shown", () => {
     render(<PaletteOverflowNotice shown={20} total={47} />);
-    expect(screen.getByText(/Showing 20 of 47/)).toBeTruthy();
+    expect(screen.getByText("+27 more")).toBeTruthy();
   });
 
   it("renders nothing when total equals shown", () => {
@@ -23,6 +23,6 @@ describe("PaletteOverflowNotice", () => {
     render(<PaletteOverflowNotice shown={20} total={47} />);
     const notice = screen.getByRole("status");
     expect(notice).toBeTruthy();
-    expect(notice.textContent).toContain("Showing 20 of 47");
+    expect(notice.textContent).toBe("+27 more");
   });
 });


### PR DESCRIPTION
## Summary

- Drops `font-semibold` from match-highlight spans in `HighlightedText` and `settingsSearchUtils` — the weight bump on 13px UI text was causing character-width jitter as users type; color-only emphasis is sufficient
- Merges adjacent Fuse match ranges into one span via a two-pass sort+merge (collapses ranges where `next.start <= prev.end + 1`), eliminating the sub-pixel gap that fragmented contiguous runs into separate spans
- Replaces the verbose `PaletteOverflowNotice` copy with `+N more` and adds an `aria-label` that spells out the count and recovery path for screen readers
- Drops "to" from secondary footer chips (`↑↓ navigate`, `Esc close`, `Esc cancel`) across 7 palette consumers; primary chips (`↵ to select`, `↵ to create`, etc.) keep "to" deliberately

Resolves #8108

## Changes

- `src/components/ui/HighlightedText.tsx` — drop `font-semibold`, replace clamp loop with sort+merge, filter out-of-bounds ranges
- `src/components/Settings/settingsSearchUtils.tsx` — drop `font-semibold` from regex highlight path
- `src/components/ui/PaletteOverflowNotice.tsx` — `+N more` copy + `aria-label`
- `AppPaletteDialog`, `QuickSwitcher`, `QuickCreatePalette`, `SearchablePalette`, `PanelPalette`, `PromptHistoryPalette`, `NewTerminalPalette` — secondary footer chip copy
- Tests: new adjacent-merge, one-char-gap-no-merge, out-of-bounds-drop cases in `HighlightedText.test.tsx`; aria-label contract test in `PaletteOverflowNotice.test.tsx`

## Testing

131 targeted tests pass. All 6 checks clean (typecheck, channels, ipc, help, lint at -3 below baseline, format).