### PR TITLE
feat(github): propagate rate-limit pause across all GitHub-aware views

### DIFF
--- a/src/App.tsx
+++ b/src/App.tsx
@@ -24,6 +24,7 @@ import { useHibernationNotifications } from "./hooks/useHibernationNotifications
 import { useIdleTerminalNotifications } from "./hooks/useIdleTerminalNotifications";
 import { useDiskSpaceWarnings } from "./hooks/useDiskSpaceWarnings";
 import { useGitHubTokenHealth } from "./hooks/useGitHubTokenHealth";
+import { useGitHubRateLimit } from "./hooks/useGitHubRateLimit";
 import { useActionRegistry } from "./hooks/useActionRegistry";
 import { usePluginActions } from "./hooks/usePluginActions";
 import { usePluginPanelKinds } from "./hooks/usePluginPanelKinds";
@@ -283,6 +284,7 @@ function App() {
   useIdleTerminalNotifications();
   useDiskSpaceWarnings();
   useGitHubTokenHealth();
+  useGitHubRateLimit();
   useUnloadCleanup();
   useResourceProfile();
 

--- a/src/components/GitHub/GitHubResourceList.tsx
+++ b/src/components/GitHub/GitHubResourceList.tsx
@@ -10,6 +10,7 @@ import {
   X,
   Filter,
   Github,
+  Clock,
 } from "lucide-react";
 import { isTokenRelatedError, isTransientNetworkError } from "@/lib/githubErrors";
 import { Button } from "@/components/ui/button";
@@ -172,6 +173,7 @@ export function GitHubResourceList({
     lastUpdatedAt,
     exactNumberNotFound,
     isTokenError,
+    isRateLimited,
     handleLoadMore,
     handleRetry,
     handleManualRefresh,
@@ -872,6 +874,19 @@ export function GitHubResourceList({
           </div>
         ) : data.length > 0 ? (
           <div key="github-content" className="flex-1 min-h-0 flex flex-col">
+            {isRateLimited && !error && (
+              <div className="px-3 py-2 border-b border-[var(--border-divider)] flex items-center gap-2 text-muted-foreground bg-overlay-soft shrink-0">
+                <Clock className="h-3.5 w-3.5 shrink-0" />
+                <span className="text-xs truncate">
+                  GitHub requests are paused. Showing last known results.
+                </span>
+                {lastUpdatedAt != null && !debouncedSearch && (
+                  <span className="text-xs text-muted-foreground/70 shrink-0 whitespace-nowrap">
+                    · Updated <LiveTimeAgo timestamp={lastUpdatedAt} />
+                  </span>
+                )}
+              </div>
+            )}
             {error && (
               <div className="px-3 py-2 border-b border-[var(--border-divider)] flex items-center gap-2 text-muted-foreground bg-overlay-soft shrink-0">
                 <WifiOff className="h-3.5 w-3.5 shrink-0" />
@@ -950,34 +965,47 @@ export function GitHubResourceList({
             </div>
           </div>
         ) : null}
-        {!loading && !data.length && error && (
+        {!loading && !data.length && error && !isTokenError && !isRateLimited && (
           <div className="p-8 text-center text-muted-foreground">
             <WifiOff className="h-5 w-5 mx-auto mb-2 opacity-50" />
             <p className="text-sm">{sanitizeIpcError(error)}</p>
-            {isTokenError ? (
-              <Button
-                variant="ghost"
-                size="sm"
-                onClick={handleOpenGitHubSettings}
-                className="mt-2 text-muted-foreground hover:text-daintree-text"
-              >
-                <Settings className="h-3.5 w-3.5" />
-                Open GitHub Settings
-              </Button>
-            ) : (
-              <Button
-                variant="ghost"
-                size="sm"
-                onClick={handleRetry}
-                className="mt-2 text-muted-foreground hover:text-daintree-text"
-              >
-                <RefreshCw className="h-3.5 w-3.5" />
-                Retry
-              </Button>
-            )}
+            <Button
+              variant="ghost"
+              size="sm"
+              onClick={handleRetry}
+              className="mt-2 text-muted-foreground hover:text-daintree-text"
+            >
+              <RefreshCw className="h-3.5 w-3.5" />
+              Retry
+            </Button>
           </div>
         )}
-        {!loading && !error && !data.length && renderEmpty()}
+        {!loading && !data.length && error && isTokenError && (
+          <div className="p-8 text-center text-muted-foreground">
+            <WifiOff className="h-5 w-5 mx-auto mb-2 opacity-50" />
+            <p className="text-sm">{sanitizeIpcError(error)}</p>
+            <Button
+              variant="ghost"
+              size="sm"
+              onClick={handleOpenGitHubSettings}
+              className="mt-2 text-muted-foreground hover:text-daintree-text"
+            >
+              <Settings className="h-3.5 w-3.5" />
+              Open GitHub Settings
+            </Button>
+          </div>
+        )}
+        {!loading && !data.length && isRateLimited && !isTokenError && (
+          <EmptyState
+            variant="zero-data"
+            scale="canvas"
+            icon={<Clock />}
+            title="GitHub requests are paused"
+            description="The current rate-limit window has been exhausted. The dropdown will resume automatically once GitHub clears the quota."
+            className="flex-1 justify-center"
+          />
+        )}
+        {!loading && !error && !isRateLimited && !data.length && renderEmpty()}
       </div>
 
       <div className="p-3 border-t border-[var(--border-divider)] grid grid-cols-[1fr_auto_1fr] items-center shrink-0">

--- a/src/components/GitHub/__tests__/GitHubResourceList.swr.test.tsx
+++ b/src/components/GitHub/__tests__/GitHubResourceList.swr.test.tsx
@@ -8,6 +8,7 @@ import type { GitHubIssue, GitHubListResponse, GitHubListOptions } from "@shared
 import { setCache, buildCacheKey, _resetForTests } from "@/lib/githubResourceCache";
 import { useGitHubFilterStore } from "@/store/githubFilterStore";
 import { useIssueSelectionStore } from "@/store/issueSelectionStore";
+import { useGitHubRateLimitStore } from "@/store/githubRateLimitStore";
 
 const mockListIssues = vi.fn();
 const mockListPRs = vi.fn();
@@ -199,6 +200,7 @@ beforeEach(() => {
   initializeMock.mockClear();
   mockSelectionClear.mockReset();
   useIssueSelectionStore.setState({ selections: new Map() });
+  useGitHubRateLimitStore.setState({ blocked: false, kind: null, resetAt: null });
   mockIsSelectionActive = false;
   mockGitHubConfig = { hasToken: true };
   mockGitHubConfigInitialized = true;
@@ -998,18 +1000,66 @@ describe("GitHubResourceList retry behavior", () => {
     expect(mockListIssues).toHaveBeenCalledTimes(1);
   });
 
-  it("does not retry rate-limit errors", async () => {
+  it("does not retry rate-limit errors and surfaces the paused empty state", async () => {
     mockListIssues.mockRejectedValue(
       new Error("GitHub rate limit exceeded. Try again in a few minutes.")
     );
 
     render(<GitHubResourceList type="issue" projectPath="/test/proj" />);
 
+    // Raw IPC message is suppressed; the dropdown shows the paused empty state
+    // sourced from the new rate-limit signal instead of the noisy error string.
     await waitFor(() => {
-      expect(screen.getByText(/rate limit exceeded/)).toBeTruthy();
+      expect(screen.getByText(/GitHub requests are paused/)).toBeTruthy();
     });
+    expect(screen.queryByText(/rate limit exceeded\./)).toBeNull();
 
     expect(mockListIssues).toHaveBeenCalledTimes(1);
+  });
+
+  it("skips fetches entirely when the rate-limit store reports blocked", async () => {
+    useGitHubRateLimitStore.setState({
+      blocked: true,
+      kind: "primary",
+      resetAt: Date.now() + 60_000,
+    });
+    mockListIssues.mockResolvedValue(makeResponse([makeIssue(1)]));
+
+    render(<GitHubResourceList type="issue" projectPath="/test/proj" />);
+
+    await waitFor(() => {
+      expect(screen.getByText(/GitHub requests are paused/)).toBeTruthy();
+    });
+    expect(mockListIssues).not.toHaveBeenCalled();
+  });
+
+  it("shows an inline paused banner over cached data while rate-limited", async () => {
+    const cacheKey = buildCacheKey("/test/proj", "issue", "open", "created");
+    setCache(cacheKey, {
+      items: [makeIssue(60)],
+      endCursor: null,
+      hasNextPage: false,
+      timestamp: Date.now(),
+    });
+
+    useGitHubRateLimitStore.setState({
+      blocked: true,
+      kind: "primary",
+      resetAt: Date.now() + 60_000,
+    });
+    mockListIssues.mockResolvedValue(makeResponse([makeIssue(60)]));
+
+    render(<GitHubResourceList type="issue" projectPath="/test/proj" />);
+
+    // Cached row stays visible; inline paused banner appears above it.
+    expect(screen.getByTestId("item-60")).toBeTruthy();
+    await waitFor(() => {
+      expect(
+        screen.getByText(/GitHub requests are paused\. Showing last known results\./)
+      ).toBeTruthy();
+    });
+    // Fetch never fires because the store-driven guard short-circuits.
+    expect(mockListIssues).not.toHaveBeenCalled();
   });
 
   it("retries transient errors in the numeric (single) fetch path", async () => {

--- a/src/components/GitHub/__tests__/GitHubResourceList.swr.test.tsx
+++ b/src/components/GitHub/__tests__/GitHubResourceList.swr.test.tsx
@@ -1033,6 +1033,45 @@ describe("GitHubResourceList retry behavior", () => {
     expect(mockListIssues).not.toHaveBeenCalled();
   });
 
+  it("clears the sticky paused state once the rate-limit store unblocks", async () => {
+    // Reproduces the race window: a fetch fails with a rate-limit error
+    // (catch path sets the sticky flag), the push arrives blocking the
+    // store, then the block later clears. The sticky flag MUST auto-clear
+    // when `rateLimitBlocked` returns to false — otherwise the dropdown
+    // would stay paused forever despite the empty-state copy promising
+    // automatic resume.
+    mockListIssues.mockRejectedValueOnce(
+      new Error("GitHub rate limit exceeded. Try again in a few minutes.")
+    );
+
+    render(<GitHubResourceList type="issue" projectPath="/test/proj" />);
+
+    await waitFor(() => {
+      expect(screen.getByText(/GitHub requests are paused/)).toBeTruthy();
+    });
+
+    // Push arrives, confirming the block at the store level.
+    act(() => {
+      useGitHubRateLimitStore.setState({
+        blocked: true,
+        kind: "primary",
+        resetAt: Date.now() + 60_000,
+      });
+    });
+    expect(screen.getByText(/GitHub requests are paused/)).toBeTruthy();
+
+    // Quota resets — push arrives clearing the block. Sticky flag must
+    // auto-clear so `isRateLimited` returns to false.
+    mockListIssues.mockResolvedValue(makeResponse([makeIssue(1)]));
+    act(() => {
+      useGitHubRateLimitStore.setState({ blocked: false, kind: null, resetAt: null });
+    });
+
+    await waitFor(() => {
+      expect(screen.queryByText(/GitHub requests are paused/)).toBeNull();
+    });
+  });
+
   it("shows an inline paused banner over cached data while rate-limited", async () => {
     const cacheKey = buildCacheKey("/test/proj", "issue", "open", "created");
     setCache(cacheKey, {

--- a/src/components/GitHub/useGitHubResourceListSWR.ts
+++ b/src/components/GitHub/useGitHubResourceListSWR.ts
@@ -7,8 +7,9 @@ import {
   nextGeneration,
   getGeneration,
 } from "@/lib/githubResourceCache";
-import { isTokenRelatedError, isTransientNetworkError } from "@/lib/githubErrors";
+import { isRateLimitError, isTokenRelatedError, isTransientNetworkError } from "@/lib/githubErrors";
 import { githubClient } from "@/clients/githubClient";
+import { useGitHubRateLimitStore } from "@/store/githubRateLimitStore";
 import type { GitHubIssue, GitHubPR, GitHubSortOrder } from "@shared/types/github";
 import { parseNumberQuery } from "@/lib/parseNumberQuery";
 import { formatErrorMessage } from "@shared/utils/errorMessage";
@@ -59,6 +60,8 @@ export interface UseGitHubResourceListSWRReturn {
   lastUpdatedAt: number | null;
   exactNumberNotFound: number | null;
   isTokenError: boolean;
+  isRateLimited: boolean;
+  rateLimitResetAt: number | null;
   handleLoadMore: () => void;
   handleRetry: () => void;
   handleManualRefresh: () => void;
@@ -133,6 +136,22 @@ export function useGitHubResourceListSWR({
     githubConfigRef.current = githubConfig;
   }, [githubConfig]);
 
+  // Rate-limit state: a single store push fans out to every consuming hook,
+  // so we read directly here and mirror into a ref for `fetchData` (same
+  // rationale as `githubConfigRef` — adding `rateLimitBlocked` to fetchData's
+  // deps would recreate the callback on every rate-limit flip and reflash
+  // the skeleton). `recentlyHitRateLimit` covers the brief race window where
+  // a fetch fires just before the store-push lands: the catch path sets it,
+  // a successful fetch clears it. `isRateLimited` is the OR.
+  const rateLimitBlocked = useGitHubRateLimitStore((s) => s.blocked);
+  const rateLimitResetAt = useGitHubRateLimitStore((s) => s.resetAt);
+  const rateLimitBlockedRef = useRef(rateLimitBlocked);
+  useEffect(() => {
+    rateLimitBlockedRef.current = rateLimitBlocked;
+  }, [rateLimitBlocked]);
+  const [recentlyHitRateLimit, setRecentlyHitRateLimit] = useState(false);
+  const isRateLimited = rateLimitBlocked || recentlyHitRateLimit;
+
   const fetchData = useCallback(
     async (
       currentCursor: string | null | undefined,
@@ -146,6 +165,11 @@ export function useGitHubResourceListSWR({
       // a token-error toast for users who haven't set up GitHub yet.
       const cfg = githubConfigRef.current;
       if (cfg && !cfg.hasToken) return;
+
+      // Skip fetches while GitHub-wide rate-limit pause is active — the main
+      // process would block the request and surface a rate-limit error, but
+      // the render path already shows the paused state from store push.
+      if (rateLimitBlockedRef.current) return;
 
       const isRevalidate = options?.revalidating ?? false;
 
@@ -224,6 +248,9 @@ export function useGitHubResourceListSWR({
             }
             setCursor(result.pageInfo.endCursor);
             setHasMore(result.pageInfo.hasNextPage);
+            // Successful response clears the sticky catch-path flag. The
+            // store-driven `rateLimitBlocked` continues to gate the UI.
+            setRecentlyHitRateLimit(false);
 
             // Write first-page results to cache (skip search-filtered results)
             if (!append && options?.cacheKey && !debouncedSearch) {
@@ -258,7 +285,8 @@ export function useGitHubResourceListSWR({
               canRetry &&
               attempt < maxAttempts - 1 &&
               isTransientNetworkError(message) &&
-              !isTokenRelatedError(message);
+              !isTokenRelatedError(message) &&
+              !isRateLimitError(message);
             if (!retryable) break;
             try {
               await abortableDelay(FETCH_RETRY_DELAYS_MS[attempt]!, abortSignal);
@@ -277,7 +305,17 @@ export function useGitHubResourceListSWR({
             if (getGeneration(options.cacheKey) !== options.generation) return;
           }
           const message = formatErrorMessage(lastError, "Failed to fetch data");
-          if (append) {
+          if (isRateLimitError(message)) {
+            // Sticky-flag the rate-limited surface for the brief window
+            // before the rate-limit store push lands. The render path
+            // (`isRateLimited`) ORs this with the store flag.
+            setRecentlyHitRateLimit(true);
+            if (append) {
+              setLoadMoreError(null);
+            } else {
+              setError(null);
+            }
+          } else if (append) {
             setLoadMoreError(message);
           } else {
             setError(message);
@@ -471,6 +509,11 @@ export function useGitHubResourceListSWR({
     if (githubConfig && !githubConfig.hasToken) {
       return;
     }
+    // Skip numeric fetches while rate-limit pause is active. The render
+    // path shows the paused state instead of firing a doomed lookup.
+    if (rateLimitBlocked) {
+      return;
+    }
 
     exactNumberAbortRef.current?.abort();
     loadMoreAbortRef.current?.abort();
@@ -564,6 +607,7 @@ export function useGitHubResourceListSWR({
           try {
             await runNumericAttempt();
             if (abortController.signal.aborted) return;
+            setRecentlyHitRateLimit(false);
             lastError = null;
             return;
           } catch (err) {
@@ -573,7 +617,8 @@ export function useGitHubResourceListSWR({
             const retryable =
               attempt < FETCH_MAX_ATTEMPTS - 1 &&
               isTransientNetworkError(message) &&
-              !isTokenRelatedError(message);
+              !isTokenRelatedError(message) &&
+              !isRateLimitError(message);
             if (!retryable) break;
             try {
               await abortableDelay(FETCH_RETRY_DELAYS_MS[attempt]!, abortController.signal);
@@ -585,7 +630,12 @@ export function useGitHubResourceListSWR({
         }
         if (lastError != null) {
           const message = formatErrorMessage(lastError, "Failed to fetch data");
-          setError(message);
+          if (isRateLimitError(message)) {
+            setRecentlyHitRateLimit(true);
+            setError(null);
+          } else {
+            setError(message);
+          }
         }
       } finally {
         if (!abortController.signal.aborted) {
@@ -599,7 +649,7 @@ export function useGitHubResourceListSWR({
     return () => {
       abortController.abort();
     };
-  }, [numberQuery, projectPath, type, filterState, retryKey, githubConfig]);
+  }, [numberQuery, projectPath, type, filterState, retryKey, githubConfig, rateLimitBlocked]);
 
   const handleLoadMore = useCallback(() => {
     if (!loadingMore && hasMore) {
@@ -649,6 +699,8 @@ export function useGitHubResourceListSWR({
     lastUpdatedAt,
     exactNumberNotFound,
     isTokenError,
+    isRateLimited,
+    rateLimitResetAt,
     handleLoadMore,
     handleRetry,
     handleManualRefresh,

--- a/src/components/GitHub/useGitHubResourceListSWR.ts
+++ b/src/components/GitHub/useGitHubResourceListSWR.ts
@@ -150,6 +150,15 @@ export function useGitHubResourceListSWR({
     rateLimitBlockedRef.current = rateLimitBlocked;
   }, [rateLimitBlocked]);
   const [recentlyHitRateLimit, setRecentlyHitRateLimit] = useState(false);
+  // Clear the catch-path sticky flag the moment the store reports unblocked.
+  // Without this, a fetch that races the block-push leaves `isRateLimited`
+  // true until some unrelated successful fetch arrives — contradicting the
+  // empty-state copy promising the dropdown will resume automatically.
+  useEffect(() => {
+    if (!rateLimitBlocked) {
+      setRecentlyHitRateLimit(false);
+    }
+  }, [rateLimitBlocked]);
   const isRateLimited = rateLimitBlocked || recentlyHitRateLimit;
 
   const fetchData = useCallback(

--- a/src/components/Worktree/WorktreeCard/hooks/__tests__/useGitHubBadgeFreshness.test.tsx
+++ b/src/components/Worktree/WorktreeCard/hooks/__tests__/useGitHubBadgeFreshness.test.tsx
@@ -6,6 +6,7 @@ import { renderHook } from "@testing-library/react";
 import { useGitHubBadgeFreshness } from "../useGitHubBadgeFreshness";
 import * as cache from "@/lib/githubResourceCache";
 import type { GitHubResourceCacheEntry } from "@/lib/githubResourceCache";
+import { useGitHubRateLimitStore } from "@/store/githubRateLimitStore";
 
 function makeCacheEntry(timestamp: number): GitHubResourceCacheEntry {
   return { items: [], endCursor: null, hasNextPage: false, timestamp };
@@ -27,11 +28,13 @@ const ISSUE_KEY = "/test/repo:issue:open:created";
 describe("useGitHubBadgeFreshness", () => {
   beforeEach(() => {
     cache._resetForTests();
+    useGitHubRateLimitStore.setState({ blocked: false, kind: null, resetAt: null });
     mockTick = 1;
   });
 
   afterEach(() => {
     cache._resetForTests();
+    useGitHubRateLimitStore.setState({ blocked: false, kind: null, resetAt: null });
   });
 
   it("returns fresh when no row timestamp", () => {
@@ -93,5 +96,30 @@ describe("useGitHubBadgeFreshness", () => {
     mockTick = 5;
     const { result } = renderHook(() => useGitHubBadgeFreshness("pr", undefined));
     expect(result.current.now).toBeGreaterThan(0);
+  });
+
+  it("treats badges as aging while rate-limit pause is active, even with no cache", () => {
+    useGitHubRateLimitStore.setState({
+      blocked: true,
+      kind: "primary",
+      resetAt: Date.now() + 60_000,
+    });
+
+    const { result } = renderHook(() => useGitHubBadgeFreshness("pr", Date.now()));
+    expect(result.current.freshnessLevel).toBe("aging");
+  });
+
+  it("treats badges as aging while rate-limit pause is active, regardless of cache freshness", () => {
+    const time = Date.now();
+    cache.setCache(PR_KEY, makeCacheEntry(time));
+    useGitHubRateLimitStore.setState({
+      blocked: true,
+      kind: "secondary",
+      resetAt: null,
+    });
+
+    // Without rate-limit, this would be "fresh" (cache time equals row time).
+    const { result } = renderHook(() => useGitHubBadgeFreshness("pr", time));
+    expect(result.current.freshnessLevel).toBe("aging");
   });
 });

--- a/src/components/Worktree/WorktreeCard/hooks/__tests__/useGitHubBadgeFreshness.test.tsx
+++ b/src/components/Worktree/WorktreeCard/hooks/__tests__/useGitHubBadgeFreshness.test.tsx
@@ -122,4 +122,29 @@ describe("useGitHubBadgeFreshness", () => {
     const { result } = renderHook(() => useGitHubBadgeFreshness("pr", time));
     expect(result.current.freshnessLevel).toBe("aging");
   });
+
+  it("transitions between fresh and aging as the rate-limit store flips", async () => {
+    const { act } = await import("@testing-library/react");
+    const time = Date.now();
+    cache.setCache(PR_KEY, makeCacheEntry(time));
+
+    const { result, rerender } = renderHook(() => useGitHubBadgeFreshness("pr", time));
+    expect(result.current.freshnessLevel).toBe("fresh");
+
+    act(() => {
+      useGitHubRateLimitStore.setState({
+        blocked: true,
+        kind: "primary",
+        resetAt: Date.now() + 60_000,
+      });
+    });
+    rerender();
+    expect(result.current.freshnessLevel).toBe("aging");
+
+    act(() => {
+      useGitHubRateLimitStore.setState({ blocked: false, kind: null, resetAt: null });
+    });
+    rerender();
+    expect(result.current.freshnessLevel).toBe("fresh");
+  });
 });

--- a/src/components/Worktree/WorktreeCard/hooks/useGitHubBadgeFreshness.ts
+++ b/src/components/Worktree/WorktreeCard/hooks/useGitHubBadgeFreshness.ts
@@ -3,6 +3,7 @@ import type { FreshnessLevel } from "@/hooks/useRepositoryStats";
 import { getCache, buildCacheKey } from "@/lib/githubResourceCache";
 import { useGlobalMinuteTicker } from "@/hooks/useGlobalMinuteTicker";
 import { useProjectStore } from "@/store/projectStore";
+import { useGitHubRateLimitStore } from "@/store/githubRateLimitStore";
 
 const DEFAULT_FILTER_STATE = "open";
 const DEFAULT_SORT_ORDER = "created";
@@ -21,6 +22,7 @@ export function useGitHubBadgeFreshness(
 ): UseGitHubBadgeFreshnessResult {
   const projectPath = useProjectStore((s) => s.currentProject?.path);
   const tick = useGlobalMinuteTicker();
+  const rateLimitBlocked = useGitHubRateLimitStore((s) => s.blocked);
 
   const cacheKey = projectPath
     ? buildCacheKey(projectPath, type, DEFAULT_FILTER_STATE, DEFAULT_SORT_ORDER)
@@ -33,8 +35,12 @@ export function useGitHubBadgeFreshness(
   const cacheLastUpdatedAt = cacheEntry?.timestamp ?? null;
   const now = tick > 0 ? Date.now() : Date.now();
 
-  const freshnessLevel: FreshnessLevel =
-    rowLastUpdatedAt == null || cacheLastUpdatedAt == null
+  // While GitHub-wide rate-limit pause is active, badge data may be older
+  // than its timestamp suggests — polling is suspended, so a `fresh` badge
+  // would be misleading. Treat as `aging` until the block clears.
+  const freshnessLevel: FreshnessLevel = rateLimitBlocked
+    ? "aging"
+    : rowLastUpdatedAt == null || cacheLastUpdatedAt == null
       ? "fresh"
       : cacheLastUpdatedAt > rowLastUpdatedAt
         ? "aging"

--- a/src/hooks/__tests__/useGitHubRateLimit.test.ts
+++ b/src/hooks/__tests__/useGitHubRateLimit.test.ts
@@ -108,6 +108,21 @@ describe("useGitHubRateLimit", () => {
     expect(useGitHubRateLimitStore.getState().blocked).toBe(false);
   });
 
+  it("hydrates as blocked when only the graphql bucket is exhausted", async () => {
+    const futureResetAt = Date.now() + 30_000;
+    getRateLimitDetailsMock.mockResolvedValueOnce(
+      makeDetails({ graphql: makeBucket(0, futureResetAt) })
+    );
+
+    renderHook(() => useGitHubRateLimit());
+    await act(async () => {});
+
+    const state = useGitHubRateLimitStore.getState();
+    expect(state.blocked).toBe(true);
+    expect(state.kind).toBe("primary");
+    expect(state.resetAt).toBe(futureResetAt);
+  });
+
   it("ignores a stale replay after a live push has already landed", async () => {
     const futureResetAt = Date.now() + 30_000;
     let resolveReplay!: (details: GitHubRateLimitDetails | null) => void;

--- a/src/hooks/__tests__/useGitHubRateLimit.test.ts
+++ b/src/hooks/__tests__/useGitHubRateLimit.test.ts
@@ -1,0 +1,142 @@
+// @vitest-environment jsdom
+import { describe, it, expect, beforeEach, vi } from "vitest";
+import { renderHook, act } from "@testing-library/react";
+import type { GitHubRateLimitDetails, GitHubRateLimitPayload } from "@shared/types/ipc/github";
+
+let rateLimitListener: ((payload: GitHubRateLimitPayload) => void) | null = null;
+const cleanupMock = vi.fn();
+const onRateLimitChangedMock = vi.fn(
+  (callback: (payload: GitHubRateLimitPayload) => void): (() => void) => {
+    rateLimitListener = callback;
+    return cleanupMock;
+  }
+);
+const getRateLimitDetailsMock = vi.fn(
+  (): Promise<GitHubRateLimitDetails | null> => Promise.resolve(null)
+);
+
+vi.mock("@/clients/githubClient", () => ({
+  githubClient: {
+    onRateLimitChanged: (cb: (payload: GitHubRateLimitPayload) => void) =>
+      onRateLimitChangedMock(cb),
+    getRateLimitDetails: () => getRateLimitDetailsMock(),
+  },
+}));
+
+import { useGitHubRateLimit } from "../useGitHubRateLimit";
+import { useGitHubRateLimitStore } from "@/store/githubRateLimitStore";
+
+function makeBucket(remaining: number, resetAt: number) {
+  return { limit: 5000, used: 5000 - remaining, remaining, resetAt };
+}
+
+function makeDetails(overrides?: Partial<GitHubRateLimitDetails>): GitHubRateLimitDetails {
+  return {
+    core: makeBucket(5000, 0),
+    graphql: makeBucket(5000, 0),
+    search: makeBucket(30, 0),
+    fetchedAt: Date.now(),
+    ...overrides,
+  };
+}
+
+describe("useGitHubRateLimit", () => {
+  beforeEach(() => {
+    rateLimitListener = null;
+    onRateLimitChangedMock.mockClear();
+    cleanupMock.mockClear();
+    getRateLimitDetailsMock.mockReset().mockResolvedValue(null);
+    useGitHubRateLimitStore.setState({ blocked: false, kind: null, resetAt: null });
+  });
+
+  it("subscribes on mount and cleans up on unmount", () => {
+    const { unmount } = renderHook(() => useGitHubRateLimit());
+    expect(onRateLimitChangedMock).toHaveBeenCalledOnce();
+    unmount();
+    expect(cleanupMock).toHaveBeenCalledOnce();
+  });
+
+  it("flips the store to blocked on a primary push", async () => {
+    renderHook(() => useGitHubRateLimit());
+    await act(async () => {});
+
+    const resetAt = Date.now() + 60_000;
+    act(() => rateLimitListener?.({ blocked: true, kind: "primary", resetAt }));
+
+    const state = useGitHubRateLimitStore.getState();
+    expect(state.blocked).toBe(true);
+    expect(state.kind).toBe("primary");
+    expect(state.resetAt).toBe(resetAt);
+  });
+
+  it("clears the store when the block clears", async () => {
+    renderHook(() => useGitHubRateLimit());
+    await act(async () => {});
+
+    act(() => rateLimitListener?.({ blocked: true, kind: "secondary", resetAt: 1 }));
+    expect(useGitHubRateLimitStore.getState().blocked).toBe(true);
+
+    act(() => rateLimitListener?.({ blocked: false, kind: null }));
+    expect(useGitHubRateLimitStore.getState().blocked).toBe(false);
+    expect(useGitHubRateLimitStore.getState().kind).toBeNull();
+    expect(useGitHubRateLimitStore.getState().resetAt).toBeNull();
+  });
+
+  it("hydrates from /rate_limit when the core bucket is exhausted on mount", async () => {
+    const futureResetAt = Date.now() + 30_000;
+    getRateLimitDetailsMock.mockResolvedValueOnce(
+      makeDetails({ core: makeBucket(0, futureResetAt) })
+    );
+
+    renderHook(() => useGitHubRateLimit());
+    await act(async () => {});
+
+    const state = useGitHubRateLimitStore.getState();
+    expect(state.blocked).toBe(true);
+    expect(state.kind).toBe("primary");
+    expect(state.resetAt).toBe(futureResetAt);
+  });
+
+  it("does not hydrate as blocked when /rate_limit shows quota remaining", async () => {
+    getRateLimitDetailsMock.mockResolvedValueOnce(
+      makeDetails({ core: makeBucket(4500, Date.now() + 3_600_000) })
+    );
+
+    renderHook(() => useGitHubRateLimit());
+    await act(async () => {});
+
+    expect(useGitHubRateLimitStore.getState().blocked).toBe(false);
+  });
+
+  it("ignores a stale replay after a live push has already landed", async () => {
+    const futureResetAt = Date.now() + 30_000;
+    let resolveReplay!: (details: GitHubRateLimitDetails | null) => void;
+    getRateLimitDetailsMock.mockImplementationOnce(
+      () =>
+        new Promise<GitHubRateLimitDetails | null>((resolve) => {
+          resolveReplay = resolve;
+        })
+    );
+
+    renderHook(() => useGitHubRateLimit());
+    await act(async () => {});
+
+    act(() => rateLimitListener?.({ blocked: true, kind: "primary", resetAt: futureResetAt }));
+    expect(useGitHubRateLimitStore.getState().blocked).toBe(true);
+
+    // Replay resolves later with stale "unblocked" data — must not overwrite.
+    await act(async () => {
+      resolveReplay(makeDetails({ core: makeBucket(4500, futureResetAt) }));
+    });
+    expect(useGitHubRateLimitStore.getState().blocked).toBe(true);
+  });
+
+  it("ignores payloads delivered after unmount", async () => {
+    const { unmount } = renderHook(() => useGitHubRateLimit());
+    await act(async () => {});
+    unmount();
+
+    act(() => rateLimitListener?.({ blocked: true, kind: "primary", resetAt: 1_700_000_000_000 }));
+    expect(useGitHubRateLimitStore.getState().blocked).toBe(false);
+  });
+});

--- a/src/hooks/useGitHubRateLimit.ts
+++ b/src/hooks/useGitHubRateLimit.ts
@@ -1,0 +1,56 @@
+import { useEffect } from "react";
+import { githubClient } from "@/clients/githubClient";
+import { useGitHubRateLimitStore } from "@/store/githubRateLimitStore";
+import type { GitHubRateLimitDetails, GitHubRateLimitPayload } from "@shared/types/ipc/github";
+
+/**
+ * Subscribes to main-process GitHub rate-limit pushes and mirrors the current
+ * state into a thin Zustand store. Consumers (resource-list dropdowns, badge
+ * freshness hooks, etc.) read from the store so a single subscription drives
+ * every GitHub-aware view — no per-hook IPC listeners that would leak or
+ * desynchronize. Mirrors the `useGitHubTokenHealth` wiring pattern.
+ */
+export function useGitHubRateLimit(): void {
+  useEffect(() => {
+    let cancelled = false;
+    let pushApplied = false;
+
+    const apply = (payload: GitHubRateLimitPayload, source: "push" | "replay") => {
+      if (cancelled) return;
+      if (source === "replay" && pushApplied) return;
+      if (source === "push") pushApplied = true;
+      useGitHubRateLimitStore.getState().apply(payload);
+    };
+
+    const cleanup = githubClient.onRateLimitChanged((payload) => apply(payload, "push"));
+
+    // Replay current state on mount so secondary windows / late mounts see the
+    // blocked flag without waiting for the next transition. `/rate_limit` is
+    // free, so we infer primary-block state from the `core` bucket; secondary
+    // blocks aren't visible in the snapshot but will arrive via push.
+    void githubClient
+      .getRateLimitDetails()
+      .then((details) => {
+        if (!details) return;
+        const payload = inferReplayPayload(details);
+        apply(payload, "replay");
+      })
+      .catch(() => {
+        // Best-effort replay; pushes still drive transitions.
+      });
+
+    return () => {
+      cancelled = true;
+      cleanup();
+    };
+  }, []);
+}
+
+function inferReplayPayload(details: GitHubRateLimitDetails): GitHubRateLimitPayload {
+  const now = Date.now();
+  const coreBlocked = details.core.remaining === 0 && details.core.resetAt > now;
+  if (coreBlocked) {
+    return { blocked: true, kind: "primary", resetAt: details.core.resetAt };
+  }
+  return { blocked: false, kind: null };
+}

--- a/src/hooks/useGitHubRateLimit.ts
+++ b/src/hooks/useGitHubRateLimit.ts
@@ -48,9 +48,17 @@ export function useGitHubRateLimit(): void {
 
 function inferReplayPayload(details: GitHubRateLimitDetails): GitHubRateLimitPayload {
   const now = Date.now();
+  // Check both core and graphql buckets — a graphql-only block (e.g. heavy
+  // GraphQL caller exhausted its quota while REST still has budget) wouldn't
+  // show up if we only inspected core, and the doomed first fetch on mount
+  // would surface a raw error before the push arrived. Secondary blocks
+  // aren't represented in the `/rate_limit` snapshot at all; those still
+  // rely on the push.
   const coreBlocked = details.core.remaining === 0 && details.core.resetAt > now;
-  if (coreBlocked) {
-    return { blocked: true, kind: "primary", resetAt: details.core.resetAt };
+  const graphqlBlocked = details.graphql.remaining === 0 && details.graphql.resetAt > now;
+  if (coreBlocked || graphqlBlocked) {
+    const resetAt = coreBlocked ? details.core.resetAt : details.graphql.resetAt;
+    return { blocked: true, kind: "primary", resetAt };
   }
   return { blocked: false, kind: null };
 }

--- a/src/lib/__tests__/githubErrors.test.ts
+++ b/src/lib/__tests__/githubErrors.test.ts
@@ -1,5 +1,5 @@
 import { describe, it, expect } from "vitest";
-import { isTokenRelatedError, isTransientNetworkError } from "@/lib/githubErrors";
+import { isRateLimitError, isTokenRelatedError, isTransientNetworkError } from "@/lib/githubErrors";
 
 describe("isTokenRelatedError", () => {
   it("matches the documented token error strings", () => {
@@ -77,5 +77,50 @@ describe("isTransientNetworkError", () => {
   it("is case-sensitive (matches the canonical capitalization only)", () => {
     expect(isTransientNetworkError("cannot reach GitHub.")).toBe(false);
     expect(isTransientNetworkError("CANNOT REACH GITHUB.")).toBe(false);
+  });
+});
+
+describe("isRateLimitError", () => {
+  it("matches the primary rate-limit error from GitHubRateLimitError", () => {
+    expect(isRateLimitError("GitHub rate limit exceeded. Waiting for quota reset.")).toBe(true);
+  });
+
+  it("matches the secondary rate-limit error from GitHubRateLimitError", () => {
+    expect(isRateLimitError("GitHub secondary rate limit triggered. Pausing requests.")).toBe(true);
+  });
+
+  it("matches the duration-bearing variants from GitHubErrors.parseGitHubError", () => {
+    expect(isRateLimitError("GitHub rate limit exceeded. Resets in 2m 30s.")).toBe(true);
+    expect(isRateLimitError("GitHub secondary rate limit triggered. Resuming in 45s.")).toBe(true);
+  });
+
+  it("matches any string starting with either canonical prefix", () => {
+    expect(isRateLimitError("GitHub rate limit exceeded.")).toBe(true);
+    expect(isRateLimitError("GitHub secondary rate limit triggered.")).toBe(true);
+  });
+
+  it("returns false for token, transient, and unrelated errors", () => {
+    expect(isRateLimitError("GitHub token not configured. Set it in Settings.")).toBe(false);
+    expect(isRateLimitError("Invalid GitHub token. Please update in Settings.")).toBe(false);
+    expect(isRateLimitError("Cannot reach GitHub. Check your internet connection.")).toBe(false);
+    expect(isRateLimitError("GitHub is temporarily unavailable. Please retry.")).toBe(false);
+    expect(isRateLimitError("Repository not found or token lacks access.")).toBe(false);
+  });
+
+  it("returns false for the legacy non-prefixed rate-limit message", () => {
+    // `parseGitHubError` returns "GitHub rate limit exceeded. Try again in a few minutes."
+    // which already matches; this guard is for a hypothetical generic form.
+    expect(isRateLimitError("API rate limit exceeded")).toBe(false);
+  });
+
+  it("returns false for null/undefined/empty", () => {
+    expect(isRateLimitError(null)).toBe(false);
+    expect(isRateLimitError(undefined)).toBe(false);
+    expect(isRateLimitError("")).toBe(false);
+  });
+
+  it("is case-sensitive (matches the canonical capitalization only)", () => {
+    expect(isRateLimitError("github rate limit exceeded.")).toBe(false);
+    expect(isRateLimitError("GITHUB RATE LIMIT EXCEEDED.")).toBe(false);
   });
 });

--- a/src/lib/githubErrors.ts
+++ b/src/lib/githubErrors.ts
@@ -14,3 +14,11 @@ export function isTransientNetworkError(msg: string | null | undefined): boolean
     msg.startsWith("Cannot reach GitHub.") || msg.startsWith("GitHub is temporarily unavailable.")
   );
 }
+
+export function isRateLimitError(msg: string | null | undefined): boolean {
+  if (!msg) return false;
+  return (
+    msg.startsWith("GitHub rate limit exceeded.") ||
+    msg.startsWith("GitHub secondary rate limit triggered.")
+  );
+}

--- a/src/store/__tests__/githubRateLimitStore.test.ts
+++ b/src/store/__tests__/githubRateLimitStore.test.ts
@@ -1,0 +1,79 @@
+import { describe, it, expect, beforeEach } from "vitest";
+import { useGitHubRateLimitStore } from "@/store/githubRateLimitStore";
+
+describe("githubRateLimitStore", () => {
+  beforeEach(() => {
+    useGitHubRateLimitStore.setState({ blocked: false, kind: null, resetAt: null });
+  });
+
+  it("starts in the unblocked state", () => {
+    const state = useGitHubRateLimitStore.getState();
+    expect(state.blocked).toBe(false);
+    expect(state.kind).toBeNull();
+    expect(state.resetAt).toBeNull();
+  });
+
+  it("applies a primary-block payload with all fields", () => {
+    const resetAt = Date.now() + 60_000;
+    useGitHubRateLimitStore.getState().apply({
+      blocked: true,
+      kind: "primary",
+      resetAt,
+      resource: "core",
+    });
+
+    const state = useGitHubRateLimitStore.getState();
+    expect(state.blocked).toBe(true);
+    expect(state.kind).toBe("primary");
+    expect(state.resetAt).toBe(resetAt);
+  });
+
+  it("applies a secondary-block payload", () => {
+    useGitHubRateLimitStore.getState().apply({
+      blocked: true,
+      kind: "secondary",
+      resetAt: 1_700_000_000_000,
+    });
+
+    const state = useGitHubRateLimitStore.getState();
+    expect(state.blocked).toBe(true);
+    expect(state.kind).toBe("secondary");
+    expect(state.resetAt).toBe(1_700_000_000_000);
+  });
+
+  it("normalizes missing resetAt to null on blocked payloads", () => {
+    useGitHubRateLimitStore.getState().apply({ blocked: true, kind: "secondary" });
+    expect(useGitHubRateLimitStore.getState().resetAt).toBeNull();
+  });
+
+  it("clears kind and resetAt when an unblocked payload arrives", () => {
+    useGitHubRateLimitStore.getState().apply({
+      blocked: true,
+      kind: "primary",
+      resetAt: 1_700_000_000_000,
+    });
+    useGitHubRateLimitStore.getState().apply({ blocked: false, kind: null });
+
+    const state = useGitHubRateLimitStore.getState();
+    expect(state.blocked).toBe(false);
+    expect(state.kind).toBeNull();
+    expect(state.resetAt).toBeNull();
+  });
+
+  it("replaces stale state on repeated apply() calls", () => {
+    useGitHubRateLimitStore.getState().apply({
+      blocked: true,
+      kind: "primary",
+      resetAt: 1_700_000_000_000,
+    });
+    useGitHubRateLimitStore.getState().apply({
+      blocked: true,
+      kind: "secondary",
+      resetAt: 1_700_000_500_000,
+    });
+
+    const state = useGitHubRateLimitStore.getState();
+    expect(state.kind).toBe("secondary");
+    expect(state.resetAt).toBe(1_700_000_500_000);
+  });
+});

--- a/src/store/githubRateLimitStore.ts
+++ b/src/store/githubRateLimitStore.ts
@@ -1,0 +1,29 @@
+import { create } from "zustand";
+import type { GitHubRateLimitKind, GitHubRateLimitPayload } from "@shared/types";
+
+interface GitHubRateLimitState {
+  blocked: boolean;
+  kind: GitHubRateLimitKind | null;
+  resetAt: number | null;
+  apply: (payload: GitHubRateLimitPayload) => void;
+}
+
+export const useGitHubRateLimitStore = create<GitHubRateLimitState>((set) => ({
+  blocked: false,
+  kind: null,
+  resetAt: null,
+  apply: (payload) =>
+    set(
+      payload.blocked
+        ? {
+            blocked: true,
+            kind: payload.kind ?? null,
+            resetAt: payload.resetAt ?? null,
+          }
+        : {
+            blocked: false,
+            kind: null,
+            resetAt: null,
+          }
+    ),
+}));


### PR DESCRIPTION
## Summary

When the GitHub API returns a rate-limit response, the app previously surfaced raw error strings and kept attempting fetches. This PR wires up a shared rate-limit state so all GitHub-aware views pause gracefully, show cached data where available, and resume automatically once the window expires.

Resolves #8073

## Changes

- **`useGitHubRateLimitStore`** — new singleton store holding the blocked/reset-at state, mirroring the `useGitHubTokenHealth` pattern
- **`useGitHubRateLimit`** — new IPC-wiring hook mounted in `App.tsx`; replays state on mount via `getRateLimitDetails` covering both core and graphql bucket exhaustion
- **`isRateLimitError`** in `githubErrors.ts` — helper for catch-path classification of rate-limit responses
- **`useGitHubResourceListSWR`** — skips fetches while blocked, suppresses raw rate-limit error strings, surfaces `isRateLimited` and `rateLimitResetAt`; a sticky `recentlyHitRateLimit` flag covers the brief race window before the store push lands and auto-clears on unblock
- **`GitHubResourceList`** — paused inline banner over cached results; dedicated "GitHub requests are paused" empty state when no data is present; token-error precedence preserved
- **`useGitHubBadgeFreshness`** — returns `"aging"` while blocked so worktree-card PR/issue badges don't appear deceptively fresh while polling is suspended

## Testing

New unit tests cover `useGitHubRateLimitStore`, `useGitHubRateLimit`, `useGitHubBadgeFreshness` rate-limit cases, and `useGitHubResourceListSWR` paused/resume behaviour. Updated the existing rate-limit retry test for the new paused empty-state. 125 tests pass. Local verify (typecheck + lint + format + build) clean.