### PR TITLE
refactor(terminal): decouple BURST refresh tier from focus events

### DIFF
--- a/src/components/Terminal/TerminalPane.tsx
+++ b/src/components/Terminal/TerminalPane.tsx
@@ -718,7 +718,6 @@ function TerminalPaneComponent({
     }
 
     setFocused(id);
-    terminalInstanceService.boostRefreshRate(id);
   };
 
   const handleXtermPointerDownCapture = (e: React.PointerEvent<HTMLDivElement>) => {
@@ -749,7 +748,6 @@ function TerminalPaneComponent({
     e.stopPropagation();
 
     setFocused(id);
-    terminalInstanceService.boostRefreshRate(id);
     requestAnimationFrame(() => terminalInstanceService.focus(id));
   };
 

--- a/src/components/Terminal/XtermAdapter.tsx
+++ b/src/components/Terminal/XtermAdapter.tsx
@@ -477,12 +477,6 @@ export function XtermAdapter({
     // Use the stable proxy to avoid stale closures in the service
     terminalInstanceService.updateRefreshTierProvider(terminalId, stableRefreshTierProvider);
     terminalInstanceService.applyRendererPolicy(terminalId, currentTier);
-
-    // If moving to a high-priority state (Focused or Burst), boost the writer
-    // to flush any background buffer immediately.
-    if (currentTier === TerminalRefreshTier.FOCUSED || currentTier === TerminalRefreshTier.BURST) {
-      terminalInstanceService.boostRefreshRate(terminalId);
-    }
   }, [terminalId, stableRefreshTierProvider, currentTier]);
 
   // Refit terminal when window becomes visible again after being hidden.

--- a/src/services/terminal/TerminalInstanceService.ts
+++ b/src/services/terminal/TerminalInstanceService.ts
@@ -9,6 +9,7 @@ import {
   AgentStateCallback,
   PostCompleteHook,
   isWebGLEligibleTier,
+  WRITE_BURST_DECAY_MS,
 } from "./types";
 import {
   setupTerminalAddons,
@@ -116,6 +117,7 @@ class TerminalInstanceService {
       notifyWriteComplete: (id, bytes) => this.dataBuffer.notifyWriteComplete(id, bytes),
       incrementUnseen: (id, isScrolledBack) =>
         this.unseenTracker.incrementUnseen(id, isScrolledBack),
+      onWrite: (id) => this.onPtyWrite(id),
     });
 
     this.hibernationManager = new TerminalHibernationManager({
@@ -437,6 +439,51 @@ class TerminalInstanceService {
     }, 1000);
 
     this.agentStateController.onUserInput(id, data);
+  }
+
+  /**
+   * Write-driven BURST tier: each PTY write extends the burst window in O(1)
+   * by bumping `writeBurstDeadline`. A single self-rearming timer handles
+   * decay — it re-checks the deadline on fire and either reschedules for the
+   * remaining time (if a write extended the window while it was pending) or
+   * reverts the tier via the panel's current `getRefreshTier()`.
+   *
+   * Avoiding per-write clearTimeout/setTimeout matters: at 60fps+ output the
+   * naive pattern thrashes Chromium's timer queue and produces GC pressure.
+   */
+  private onPtyWrite(id: string): void {
+    const managed = this.instances.get(id);
+    if (!managed) return;
+
+    const now = Date.now();
+    const previousDeadline = managed.writeBurstDeadline;
+    managed.writeBurstDeadline = now + WRITE_BURST_DECAY_MS;
+
+    if (previousDeadline === undefined || now >= previousDeadline) {
+      this.rendererPolicy.applyRendererPolicy(id, TerminalRefreshTier.BURST);
+    }
+
+    if (managed.writeBurstTimer === undefined) {
+      this.scheduleWriteBurstDecay(id, WRITE_BURST_DECAY_MS);
+    }
+  }
+
+  private scheduleWriteBurstDecay(id: string, delayMs: number): void {
+    const managed = this.instances.get(id);
+    if (!managed) return;
+    managed.writeBurstTimer = window.setTimeout(() => {
+      const current = this.instances.get(id);
+      if (!current) return;
+      current.writeBurstTimer = undefined;
+      const deadline = current.writeBurstDeadline;
+      const nowFire = Date.now();
+      if (deadline !== undefined && nowFire < deadline) {
+        this.scheduleWriteBurstDecay(id, deadline - nowFire);
+        return;
+      }
+      current.writeBurstDeadline = undefined;
+      this.rendererPolicy.applyRendererPolicy(id, current.getRefreshTier());
+    }, delayMs);
   }
 
   private onEnterPressed(id: string): void {
@@ -1860,6 +1907,11 @@ class TerminalInstanceService {
       clearTimeout(managed.inputBurstTimer);
       managed.inputBurstTimer = undefined;
     }
+    if (managed.writeBurstTimer !== undefined) {
+      clearTimeout(managed.writeBurstTimer);
+      managed.writeBurstTimer = undefined;
+    }
+    managed.writeBurstDeadline = undefined;
     if (managed.titleReportTimer !== undefined) {
       clearTimeout(managed.titleReportTimer);
       managed.titleReportTimer = undefined;

--- a/src/services/terminal/TerminalInstanceService.ts
+++ b/src/services/terminal/TerminalInstanceService.ts
@@ -450,18 +450,20 @@ class TerminalInstanceService {
    *
    * Avoiding per-write clearTimeout/setTimeout matters: at 60fps+ output the
    * naive pattern thrashes Chromium's timer queue and produces GC pressure.
+   *
+   * `applyRendererPolicy(BURST)` is called on every write: when BURST is
+   * already applied the policy returns early (line 50 of
+   * TerminalRendererPolicy) and as a load-bearing side-effect clears any
+   * pending tierChangeTimer — that cancellation is what prevents a
+   * concurrent focus-loss-scheduled downgrade from firing unopposed and
+   * stranding the terminal at FOCUSED/VISIBLE/BACKGROUND mid-stream.
    */
   private onPtyWrite(id: string): void {
     const managed = this.instances.get(id);
     if (!managed) return;
 
-    const now = Date.now();
-    const previousDeadline = managed.writeBurstDeadline;
-    managed.writeBurstDeadline = now + WRITE_BURST_DECAY_MS;
-
-    if (previousDeadline === undefined || now >= previousDeadline) {
-      this.rendererPolicy.applyRendererPolicy(id, TerminalRefreshTier.BURST);
-    }
+    managed.writeBurstDeadline = Date.now() + WRITE_BURST_DECAY_MS;
+    this.rendererPolicy.applyRendererPolicy(id, TerminalRefreshTier.BURST);
 
     if (managed.writeBurstTimer === undefined) {
       this.scheduleWriteBurstDecay(id, WRITE_BURST_DECAY_MS);

--- a/src/services/terminal/TerminalWriteController.ts
+++ b/src/services/terminal/TerminalWriteController.ts
@@ -8,6 +8,11 @@ export interface WriteControllerDeps {
   acknowledgeData: (id: string, bytes: number) => void;
   notifyWriteComplete: (id: string, bytes: number) => void;
   incrementUnseen: (id: string, isScrolledBack: boolean) => void;
+  // Synchronous notification that a real PTY write is about to paint —
+  // fires only on the actual write path (after hibernated / deferred-restore
+  // early-exits), before terminal.write(). Used by TerminalInstanceService
+  // to drive the BURST refresh tier from real activity instead of focus.
+  onWrite?: (id: string) => void;
 }
 
 /**
@@ -48,6 +53,8 @@ export class TerminalWriteController {
       this.deps.notifyWriteComplete(id, deferredBytes);
       return;
     }
+
+    this.deps.onWrite?.(id);
 
     this.deps.incrementUnseen(id, managed.isUserScrolledBack);
 

--- a/src/services/terminal/__tests__/TerminalInstanceService.lastActivity.test.ts
+++ b/src/services/terminal/__tests__/TerminalInstanceService.lastActivity.test.ts
@@ -1,5 +1,6 @@
 // @vitest-environment jsdom
 import { beforeEach, describe, expect, it, vi } from "vitest";
+import { TerminalRefreshTier } from "../../../../shared/types/panel";
 
 vi.mock("@/clients", () => ({
   terminalClient: {
@@ -80,6 +81,9 @@ interface MockManaged {
   isSerializedRestoreInProgress: boolean;
   isUserScrolledBack: boolean;
   pendingWrites?: number;
+  isHibernated?: boolean;
+  lastAppliedTier?: TerminalRefreshTier;
+  getRefreshTier?: () => TerminalRefreshTier;
 }
 
 type LastActivityTestService = {
@@ -112,6 +116,12 @@ function makeMockManaged(overrides: Partial<MockManaged> = {}): MockManaged {
     isAltBuffer: false,
     isSerializedRestoreInProgress: false,
     isUserScrolledBack: false,
+    // Pre-set to BURST so the write-driven tier promotion in writeToTerminal
+    // (decoupled from focus in #8085) is an idempotent no-op for this test
+    // — these specs exercise lastActivityMarker bookkeeping, not tier
+    // transitions or the downstream addon/scrollback restore path.
+    lastAppliedTier: TerminalRefreshTier.BURST,
+    getRefreshTier: () => TerminalRefreshTier.FOCUSED,
     ...overrides,
   };
 }

--- a/src/services/terminal/__tests__/TerminalInstanceService.tier.test.ts
+++ b/src/services/terminal/__tests__/TerminalInstanceService.tier.test.ts
@@ -9,6 +9,8 @@ const mockTerminalClient = {
   wake: vi.fn(),
   getSerializedState: vi.fn(),
   getSharedBuffer: vi.fn(() => null),
+  acknowledgePortData: vi.fn(),
+  acknowledgeData: vi.fn(),
 };
 
 vi.mock("@/clients", () => ({
@@ -60,6 +62,7 @@ type TierTestService = {
   applyAgentPromotion: (id: string, agentId: string) => void;
   clearAgentPromotion: (id: string) => void;
   reduceScrollbackAllBackground: (targetLines: number) => void;
+  writeController: { write: (id: string, data: string | Uint8Array) => void };
 };
 
 function makeMockManaged(overrides: Record<string, unknown> = {}) {
@@ -384,6 +387,107 @@ describe("TerminalInstanceService - Activity Tier", () => {
 
       // Plain at FOCUSED → blink on.
       expect(managed.terminal.options.cursorBlink).toBe(true);
+    });
+  });
+
+  describe("Write-driven BURST tier", () => {
+    it("promotes a FOCUSED terminal to BURST on first PTY write", () => {
+      const managed = makeMockManaged({ lastAppliedTier: TerminalRefreshTier.FOCUSED });
+      service.instances.set("t1", managed as unknown as Record<string, unknown>);
+
+      service.writeController.write("t1", "hello");
+
+      expect(managed.lastAppliedTier).toBe(TerminalRefreshTier.BURST);
+    });
+
+    it("decays back to the panel's current tier after the idle window", () => {
+      const managed = makeMockManaged({ lastAppliedTier: TerminalRefreshTier.FOCUSED });
+      managed.getRefreshTier = () => TerminalRefreshTier.FOCUSED;
+      service.instances.set("t1", managed as unknown as Record<string, unknown>);
+
+      service.writeController.write("t1", "hello");
+      expect(managed.lastAppliedTier).toBe(TerminalRefreshTier.BURST);
+
+      // 500ms write-burst decay + 500ms downgrade hysteresis in the policy.
+      vi.advanceTimersByTime(1100);
+
+      expect(managed.lastAppliedTier).toBe(TerminalRefreshTier.FOCUSED);
+    });
+
+    it("rapid-fire writes do not churn the decay timer (deadline extension is O(1))", () => {
+      const managed = makeMockManaged({ lastAppliedTier: TerminalRefreshTier.FOCUSED });
+      const clearSpy = vi.spyOn(globalThis, "clearTimeout");
+      const setSpy = vi.spyOn(globalThis, "setTimeout");
+      service.instances.set("t1", managed as unknown as Record<string, unknown>);
+
+      // 100 back-to-back writes — naive per-write clearTimeout/setTimeout
+      // would produce ~200 timer-table touches. The deadline-timestamp
+      // pattern caps it at the single decay timer (≤ 2) regardless of
+      // write count, which is the load-bearing perf invariant.
+      const setCallsBefore = setSpy.mock.calls.length;
+      const clearCallsBefore = clearSpy.mock.calls.length;
+      for (let i = 0; i < 100; i++) {
+        service.writeController.write("t1", "x");
+      }
+      const setCallsAfter = setSpy.mock.calls.length;
+      const clearCallsAfter = clearSpy.mock.calls.length;
+
+      expect(setCallsAfter - setCallsBefore).toBeLessThanOrEqual(2);
+      expect(clearCallsAfter - clearCallsBefore).toBe(0);
+
+      clearSpy.mockRestore();
+      setSpy.mockRestore();
+    });
+
+    it("re-arms the decay timer when writes extend the deadline mid-flight", () => {
+      const managed = makeMockManaged({ lastAppliedTier: TerminalRefreshTier.FOCUSED });
+      managed.getRefreshTier = () => TerminalRefreshTier.FOCUSED;
+      service.instances.set("t1", managed as unknown as Record<string, unknown>);
+
+      service.writeController.write("t1", "x"); // arms 500ms timer
+      vi.advanceTimersByTime(400); // 400ms in, 100ms to go
+      service.writeController.write("t1", "y"); // bumps deadline to t+900
+
+      vi.advanceTimersByTime(150); // t=550, original timer fires, re-arms for 350ms
+      // Tier must NOT have decayed yet — the write extended the window.
+      expect(managed.lastAppliedTier).toBe(TerminalRefreshTier.BURST);
+
+      // Advance past the new deadline + policy hysteresis.
+      vi.advanceTimersByTime(900);
+      expect(managed.lastAppliedTier).toBe(TerminalRefreshTier.FOCUSED);
+    });
+
+    it("destroy clears the pending write-burst timer", () => {
+      const managed = makeMockManaged({ lastAppliedTier: TerminalRefreshTier.FOCUSED });
+      service.instances.set("t1", managed as unknown as Record<string, unknown>);
+
+      service.writeController.write("t1", "x");
+      const writeBurstTimer = (managed as unknown as { writeBurstTimer?: number }).writeBurstTimer;
+      expect(writeBurstTimer).toBeDefined();
+
+      service.destroy("t1");
+
+      expect((managed as unknown as { writeBurstTimer?: number }).writeBurstTimer).toBeUndefined();
+      expect(
+        (managed as unknown as { writeBurstDeadline?: number }).writeBurstDeadline
+      ).toBeUndefined();
+
+      // Advancing past the original window must not throw or re-touch the tier.
+      const tierAtDestroy = managed.lastAppliedTier;
+      vi.advanceTimersByTime(1100);
+      expect(managed.lastAppliedTier).toBe(tierAtDestroy);
+    });
+
+    it("does not fire BURST on the hibernated write path", () => {
+      const managed = makeMockManaged({
+        lastAppliedTier: TerminalRefreshTier.BACKGROUND,
+        isHibernated: true,
+      });
+      service.instances.set("t1", managed as unknown as Record<string, unknown>);
+
+      service.writeController.write("t1", "x");
+
+      expect(managed.lastAppliedTier).toBe(TerminalRefreshTier.BACKGROUND);
     });
   });
 

--- a/src/services/terminal/__tests__/TerminalInstanceService.tier.test.ts
+++ b/src/services/terminal/__tests__/TerminalInstanceService.tier.test.ts
@@ -432,11 +432,94 @@ describe("TerminalInstanceService - Activity Tier", () => {
       const setCallsAfter = setSpy.mock.calls.length;
       const clearCallsAfter = clearSpy.mock.calls.length;
 
+      // Lower bound: at least the single decay timer must be armed,
+      // otherwise the test would pass even on a no-op implementation.
+      expect(setCallsAfter - setCallsBefore).toBeGreaterThanOrEqual(1);
       expect(setCallsAfter - setCallsBefore).toBeLessThanOrEqual(2);
       expect(clearCallsAfter - clearCallsBefore).toBe(0);
 
       clearSpy.mockRestore();
       setSpy.mockRestore();
+    });
+
+    it("writes during an active burst cancel a pending downgrade timer", () => {
+      // Regression: previously the deadline-gated re-promotion skipped
+      // applyRendererPolicy(BURST) for in-window writes, so a
+      // focus-loss-scheduled downgrade fired unopposed and stranded the
+      // terminal at the lower tier mid-stream. Writes must always
+      // re-assert BURST so the policy's tier===currentApplied early-return
+      // cancels any pending tierChangeTimer.
+      const managed = makeMockManaged({ lastAppliedTier: TerminalRefreshTier.FOCUSED });
+      managed.getRefreshTier = () => TerminalRefreshTier.VISIBLE;
+      service.instances.set("t1", managed as unknown as Record<string, unknown>);
+
+      service.writeController.write("t1", "x");
+      expect(managed.lastAppliedTier).toBe(TerminalRefreshTier.BURST);
+
+      // Simulate focus loss: schedule a downgrade to VISIBLE. This arms
+      // the policy's tierChangeTimer with 500ms hysteresis.
+      service.applyRendererPolicy("t1", TerminalRefreshTier.VISIBLE);
+      const pendingTier = (managed as unknown as { pendingTier?: TerminalRefreshTier }).pendingTier;
+      expect(pendingTier).toBe(TerminalRefreshTier.VISIBLE);
+
+      // A new write 200ms later (still inside the burst window) must
+      // cancel that pending downgrade.
+      vi.advanceTimersByTime(200);
+      service.writeController.write("t1", "y");
+
+      expect(
+        (managed as unknown as { pendingTier?: TerminalRefreshTier }).pendingTier
+      ).toBeUndefined();
+      expect((managed as unknown as { tierChangeTimer?: number }).tierChangeTimer).toBeUndefined();
+      expect(managed.lastAppliedTier).toBe(TerminalRefreshTier.BURST);
+
+      // Confirm: advancing past the original 500ms hysteresis does NOT
+      // drop to VISIBLE, since the timer was cancelled.
+      vi.advanceTimersByTime(400);
+      expect(managed.lastAppliedTier).toBe(TerminalRefreshTier.BURST);
+    });
+
+    it("does not arm a write-burst timer on the deferred-restore path", () => {
+      const managed = makeMockManaged({
+        lastAppliedTier: TerminalRefreshTier.FOCUSED,
+        isSerializedRestoreInProgress: true,
+      });
+      service.instances.set("t1", managed as unknown as Record<string, unknown>);
+
+      service.writeController.write("t1", "x");
+
+      expect((managed as unknown as { writeBurstTimer?: number }).writeBurstTimer).toBeUndefined();
+      expect(
+        (managed as unknown as { writeBurstDeadline?: number }).writeBurstDeadline
+      ).toBeUndefined();
+      expect(managed.lastAppliedTier).toBe(TerminalRefreshTier.FOCUSED);
+    });
+
+    it("isolates write-burst state across terminals", () => {
+      const t1 = makeMockManaged({ lastAppliedTier: TerminalRefreshTier.FOCUSED });
+      const t2 = makeMockManaged({ lastAppliedTier: TerminalRefreshTier.FOCUSED });
+      service.instances.set("t1", t1 as unknown as Record<string, unknown>);
+      service.instances.set("t2", t2 as unknown as Record<string, unknown>);
+
+      service.writeController.write("t1", "x");
+
+      expect(t1.lastAppliedTier).toBe(TerminalRefreshTier.BURST);
+      expect(t2.lastAppliedTier).toBe(TerminalRefreshTier.FOCUSED);
+      expect((t1 as unknown as { writeBurstTimer?: number }).writeBurstTimer).toBeDefined();
+      expect((t2 as unknown as { writeBurstTimer?: number }).writeBurstTimer).toBeUndefined();
+    });
+
+    it("focus-only tier changes do not manufacture BURST (regression guard)", () => {
+      // Before this refactor, focus events promoted to BURST. The fix is
+      // that BURST is exclusively write-driven; a pure focus transition
+      // must land at FOCUSED, not BURST.
+      const managed = makeMockManaged({ lastAppliedTier: TerminalRefreshTier.VISIBLE });
+      service.instances.set("t1", managed as unknown as Record<string, unknown>);
+
+      service.applyRendererPolicy("t1", TerminalRefreshTier.FOCUSED);
+
+      expect(managed.lastAppliedTier).toBe(TerminalRefreshTier.FOCUSED);
+      expect((managed as unknown as { writeBurstTimer?: number }).writeBurstTimer).toBeUndefined();
     });
 
     it("re-arms the decay timer when writes extend the deadline mid-flight", () => {

--- a/src/services/terminal/__tests__/TerminalWriteController.test.ts
+++ b/src/services/terminal/__tests__/TerminalWriteController.test.ts
@@ -237,4 +237,62 @@ describe("TerminalWriteController.write", () => {
     controller.write("t1", "abc");
     expect(managed.pendingWrites ?? 0).toBe(0);
   });
+
+  describe("onWrite hook (write-driven BURST signal)", () => {
+    it("fires synchronously on the normal write path, before terminal.write resolves", () => {
+      const onWrite = vi.fn();
+      const localDeps = makeDeps(store, { onWrite });
+      const localController = new TerminalWriteController(localDeps);
+
+      // Defer the terminal callback so the assertion captures the
+      // pre-resolve moment.
+      const term = managed.terminal as unknown as MockTerminal;
+      let captured: (() => void) | undefined;
+      term.write = vi.fn((_data: string | Uint8Array, cb?: () => void) => {
+        captured = cb;
+      });
+
+      localController.write("t1", "abc");
+
+      expect(onWrite).toHaveBeenCalledTimes(1);
+      expect(onWrite).toHaveBeenCalledWith("t1");
+      // Sanity: the actual write hasn't resolved yet — the hook fires
+      // synchronously, not from the async write callback.
+      expect(localDeps.acknowledgeData).not.toHaveBeenCalled();
+
+      captured?.();
+    });
+
+    it("does NOT fire on the hibernated path (ack-only)", () => {
+      managed.isHibernated = true;
+      const onWrite = vi.fn();
+      const localDeps = makeDeps(store, { onWrite });
+      const localController = new TerminalWriteController(localDeps);
+
+      localController.write("t1", "hello");
+
+      expect(onWrite).not.toHaveBeenCalled();
+    });
+
+    it("does NOT fire on the deferred-restore path", () => {
+      managed.isSerializedRestoreInProgress = true;
+      const onWrite = vi.fn();
+      const localDeps = makeDeps(store, { onWrite });
+      const localController = new TerminalWriteController(localDeps);
+
+      localController.write("t1", "abc");
+
+      expect(onWrite).not.toHaveBeenCalled();
+    });
+
+    it("does NOT fire when the terminal id is unknown", () => {
+      const onWrite = vi.fn();
+      const localDeps = makeDeps(store, { onWrite });
+      const localController = new TerminalWriteController(localDeps);
+
+      localController.write("nope", "abc");
+
+      expect(onWrite).not.toHaveBeenCalled();
+    });
+  });
 });

--- a/src/services/terminal/__tests__/TerminalWriteController.test.ts
+++ b/src/services/terminal/__tests__/TerminalWriteController.test.ts
@@ -239,28 +239,27 @@ describe("TerminalWriteController.write", () => {
   });
 
   describe("onWrite hook (write-driven BURST signal)", () => {
-    it("fires synchronously on the normal write path, before terminal.write resolves", () => {
-      const onWrite = vi.fn();
+    it("fires synchronously before terminal.write() is called on the normal path", () => {
+      const callOrder: string[] = [];
+      const onWrite = vi.fn(() => {
+        callOrder.push("onWrite");
+      });
       const localDeps = makeDeps(store, { onWrite });
       const localController = new TerminalWriteController(localDeps);
 
-      // Defer the terminal callback so the assertion captures the
-      // pre-resolve moment.
+      // Capture the moment terminal.write is invoked relative to onWrite.
       const term = managed.terminal as unknown as MockTerminal;
-      let captured: (() => void) | undefined;
-      term.write = vi.fn((_data: string | Uint8Array, cb?: () => void) => {
-        captured = cb;
+      term.write = vi.fn((_data: string | Uint8Array, _cb?: () => void) => {
+        callOrder.push("terminal.write");
       });
 
       localController.write("t1", "abc");
 
       expect(onWrite).toHaveBeenCalledTimes(1);
       expect(onWrite).toHaveBeenCalledWith("t1");
-      // Sanity: the actual write hasn't resolved yet — the hook fires
-      // synchronously, not from the async write callback.
-      expect(localDeps.acknowledgeData).not.toHaveBeenCalled();
-
-      captured?.();
+      // Load-bearing: onWrite must run BEFORE terminal.write so the tier
+      // is BURST at paint time, not one frame late.
+      expect(callOrder).toEqual(["onWrite", "terminal.write"]);
     });
 
     it("does NOT fire on the hibernated path (ack-only)", () => {

--- a/src/services/terminal/types.ts
+++ b/src/services/terminal/types.ts
@@ -101,6 +101,16 @@ export interface ManagedTerminal {
   // Typing burst timer
   inputBurstTimer?: number;
 
+  // PTY write-burst decay state. `writeBurstDeadline` is a timestamp
+  // (Date.now() + WRITE_BURST_DECAY_MS) refreshed on every write — used as an
+  // O(1) extension instead of churning clearTimeout/setTimeout per write,
+  // which would jank Chromium's timer queue under 60fps output floods. The
+  // single `writeBurstTimer` self-rearms if the deadline was extended while
+  // it was pending; on fire with the deadline elapsed it reverts the tier via
+  // managed.getRefreshTier().
+  writeBurstTimer?: number;
+  writeBurstDeadline?: number;
+
   // Directing state: renderer-only ephemeral state for user typing into waiting agent
   canonicalAgentState?: AgentState;
 
@@ -171,6 +181,14 @@ export interface ManagedTerminal {
 }
 
 export const TIER_DOWNGRADE_HYSTERESIS_MS = 500;
+
+// Idle window after the last PTY write before the BURST tier decays back to
+// the panel's natural tier (FOCUSED/VISIBLE/...). Independent of
+// TIER_DOWNGRADE_HYSTERESIS_MS — that is the policy's downgrade debounce
+// inside TerminalRendererPolicy; this is the activity-window inside
+// TerminalInstanceService. They are separately tunable even though they
+// happen to share the same default value.
+export const WRITE_BURST_DECAY_MS = 500;
 
 // Cooldown between consecutive reduceScrollback() calls for the same terminal.
 // Each call mutates `terminal.options.scrollback`, which xterm 6.0 turns into


### PR DESCRIPTION
Closes #8085.

## Summary

`BURST` (16ms, 60fps) used to be manufactured from focus state at three sites: `XtermAdapter`'s `useLayoutEffect` and two click/pointer handlers in `TerminalPane`. That made `BURST` a "user is looking at this pane" indicator instead of a real-activity signal — `isWebGLEligibleTier` and the planned #8084 pool-pressure eviction can now treat `BURST` as evidence the terminal is actually producing output.

`TerminalWriteController` is the single chokepoint for PTY data, so authority for `BURST` moves there. `WriteControllerDeps` gains an optional `onWrite` hook fired synchronously after the hibernated / deferred-restore early-exits and before `terminal.write()` — synchronous because deferring the boost into the write callback would render the first chunk at the slower tier.

The decay path uses a deadline-timestamp pattern: a single self-rearming `setTimeout` per decay window, plus an O(1) deadline extension on every write. Per-write `clearTimeout`/`setTimeout` would jank Chromium 146's timer queue under 60fps output floods, which is the load-bearing constraint here. `WRITE_BURST_DECAY_MS = 500` lives alongside `TIER_DOWNGRADE_HYSTERESIS_MS` but is independently tunable.

`applyRendererPolicy(BURST)` is called on every write, not gated on the deadline — the policy's `tier === currentAppliedTier` early-return makes the no-op cheap, and as a load-bearing side-effect it clears any pending `tierChangeTimer`. Without that, a focus-loss that scheduled a downgrade mid-burst would fire unopposed 500ms later and strand the terminal at `FOCUSED`/`VISIBLE`/`BACKGROUND` until the output stopped.

## Test plan

- [x] `TerminalWriteController.test.ts` — `onWrite` fires before `terminal.write()`; not on hibernated; not on deferred-restore; not on unknown id
- [x] `TerminalInstanceService.tier.test.ts` — first write promotes to `BURST`; decay reverts to `getRefreshTier()` after the idle window; 100 rapid writes produce ≤2 (and ≥1) `setTimeout` calls; deadline-extended timer re-arms instead of firing early; `destroy()` clears `writeBurstTimer`/`writeBurstDeadline`; hibernated and deferred-restore paths don't arm the timer; multi-terminal isolation; focus-only tier changes don't manufacture `BURST`; pending downgrade is cancelled when a write lands inside its hysteresis window
- [x] `TerminalInstanceService.lastActivity.test.ts` updated to pre-set `lastAppliedTier=BURST` so write-driven promotion is idempotent in the marker-bookkeeping specs
- [x] Full unit suite: 22844 tests passing (1 skipped, 1 todo)
- [x] `npm run check` clean — typecheck, lint (warnings −3 from baseline), format, build all pass