### PR TITLE
fix(keybinding): chord HUD click-passthrough and invalid-key echo

### DIFF
--- a/src/components/Layout/ChordIndicator.tsx
+++ b/src/components/Layout/ChordIndicator.tsx
@@ -2,12 +2,13 @@ import { useState, useEffect, useRef } from "react";
 import { createPortal } from "react-dom";
 import { cn } from "@/lib/utils";
 import { useAnimatedPresence } from "@/hooks/useAnimatedPresence";
-import { usePendingChord } from "@/hooks/useGlobalKeybindings";
+import { usePendingChord, useLastInvalidKey } from "@/hooks/useGlobalKeybindings";
 import { keybindingService } from "@/services/KeybindingService";
 import { CHORD_SHOW_DELAY_MS } from "@/lib/animationUtils";
 
 export function ChordIndicator() {
   const pendingChord = usePendingChord();
+  const lastInvalidKey = useLastInvalidKey();
   const [showOverlay, setShowOverlay] = useState(false);
   const timerRef = useRef<ReturnType<typeof setTimeout> | null>(null);
   // Cache last chord/completions so exit animation doesn't show empty content
@@ -21,10 +22,14 @@ export function ChordIndicator() {
 
   const { isVisible, shouldRender } = useAnimatedPresence({
     isOpen: showOverlay,
+    onAnimateOut: () => keybindingService.clearLastInvalidKey(),
   });
 
   useEffect(() => {
     if (pendingChord) {
+      // A fresh chord prefix supersedes any lingering invalid-key echo from a
+      // prior attempt; clear it so the new prefix renders its completions.
+      keybindingService.clearLastInvalidKey();
       lastChordRef.current = pendingChord;
       lastCompletionsRef.current = keybindingService.getChordCompletions(pendingChord);
       setLastChord(lastChordRef.current);
@@ -36,6 +41,14 @@ export function ChordIndicator() {
         }, CHORD_SHOW_DELAY_MS);
       }
     } else {
+      // Close the overlay; useAnimatedPresence's exit animation runs while
+      // the JSX echoes lastInvalidKey, then onAnimateOut clears it. If the
+      // HUD never opened (invalid key arrived inside the 200ms show delay),
+      // there's no exit animation, so clear lastInvalidKey directly to avoid
+      // a stuck-state leak.
+      if (lastInvalidKey && !showOverlay) {
+        keybindingService.clearLastInvalidKey();
+      }
       setShowOverlay(false);
     }
 
@@ -45,11 +58,14 @@ export function ChordIndicator() {
         timerRef.current = null;
       }
     };
-  }, [pendingChord, showOverlay]);
+  }, [pendingChord, lastInvalidKey, showOverlay]);
 
   if (!shouldRender) return null;
 
   const displayChord = keybindingService.formatComboForDisplay(lastChord);
+  const displayInvalidKey = lastInvalidKey
+    ? keybindingService.formatComboForDisplay(lastInvalidKey)
+    : null;
   const completions = lastCompletions;
 
   // Group completions by category
@@ -66,7 +82,7 @@ export function ChordIndicator() {
   return createPortal(
     <div
       className={cn(
-        "fixed bottom-6 left-1/2 -translate-x-1/2 z-[var(--z-toast)]",
+        "fixed bottom-6 left-1/2 -translate-x-1/2 z-[var(--z-toast)] pointer-events-none",
         "transition-opacity duration-150",
         "motion-reduce:transition-none motion-reduce:duration-0",
         isVisible ? "opacity-100" : "opacity-0"
@@ -89,11 +105,23 @@ export function ChordIndicator() {
           <kbd className="text-sm font-semibold text-daintree-text tracking-wide">
             {displayChord}
           </kbd>
-          <span className="text-daintree-text/40">&mdash;</span>
-          <span className="text-xs text-daintree-text/50">Backspace or Esc to cancel</span>
+          {displayInvalidKey ? (
+            <>
+              <kbd className="text-sm font-medium text-daintree-text/50 tracking-wide line-through">
+                {displayInvalidKey}
+              </kbd>
+              <span className="text-daintree-text/40">&mdash;</span>
+              <span className="text-xs text-daintree-text/50">Unrecognized</span>
+            </>
+          ) : (
+            <>
+              <span className="text-daintree-text/40">&mdash;</span>
+              <span className="text-xs text-daintree-text/50">Backspace or Esc to cancel</span>
+            </>
+          )}
         </div>
 
-        {completions.length > 0 && (
+        {!displayInvalidKey && completions.length > 0 && (
           <div className="border-t border-[var(--border-overlay)] px-3 py-2 max-h-48 overflow-y-auto">
             {Array.from(grouped.entries()).map(([category, items], groupIdx) => (
               <div key={category}>

--- a/src/hooks/__tests__/useKeybinding.test.tsx
+++ b/src/hooks/__tests__/useKeybinding.test.tsx
@@ -5,6 +5,7 @@ import { renderHook, act } from "@testing-library/react";
 const subscribers = new Set<() => void>();
 const overrides = new Map<string, string | undefined>();
 const displayOverrides = new Map<string, string>();
+const lastInvalidKeyRef = { current: null as string | null };
 
 vi.mock("@/services/KeybindingService", () => ({
   keybindingService: {
@@ -16,10 +17,14 @@ vi.mock("@/services/KeybindingService", () => ({
     }),
     getEffectiveCombo: vi.fn((actionId: string) => overrides.get(actionId)),
     getDisplayCombo: vi.fn((actionId: string) => displayOverrides.get(actionId) ?? ""),
+    getPendingChord: vi.fn(() => null),
+    getLastInvalidKey: vi.fn(() => lastInvalidKeyRef.current),
   },
+  normalizeKeyForBinding: (event: KeyboardEvent) => event.key,
 }));
 
 import { useEffectiveCombo, useKeybindingDisplay } from "../useKeybinding";
+import { useLastInvalidKey } from "../useGlobalKeybindings";
 import { keybindingService } from "@/services/KeybindingService";
 
 function notifyAll(): void {
@@ -120,5 +125,50 @@ describe("useKeybindingDisplay", () => {
     displayOverrides.set("agent.claude", "⌘+⇧+X");
     act(() => notifyAll());
     expect(result.current).toBe("⌘+⇧+X");
+  });
+});
+
+describe("useLastInvalidKey — issue #8105", () => {
+  beforeEach(() => {
+    subscribers.clear();
+    lastInvalidKeyRef.current = null;
+    vi.clearAllMocks();
+  });
+
+  it("returns null initially", () => {
+    const { result } = renderHook(() => useLastInvalidKey());
+    expect(result.current).toBeNull();
+  });
+
+  it("re-renders with the new value after subscribers are notified", () => {
+    const { result } = renderHook(() => useLastInvalidKey());
+    expect(result.current).toBeNull();
+
+    lastInvalidKeyRef.current = "y";
+    act(() => notifyAll());
+    expect(result.current).toBe("y");
+  });
+
+  it("re-renders to null after clear + notify", () => {
+    lastInvalidKeyRef.current = "y";
+    const { result } = renderHook(() => useLastInvalidKey());
+    expect(result.current).toBe("y");
+
+    lastInvalidKeyRef.current = null;
+    act(() => notifyAll());
+    expect(result.current).toBeNull();
+  });
+
+  it("uses a stable subscribe reference across renders (no churn)", () => {
+    const { rerender } = renderHook(() => useLastInvalidKey());
+    const callsAfterMount = (keybindingService.subscribe as ReturnType<typeof vi.fn>).mock.calls
+      .length;
+
+    rerender();
+    rerender();
+
+    expect((keybindingService.subscribe as ReturnType<typeof vi.fn>).mock.calls.length).toBe(
+      callsAfterMount
+    );
   });
 });

--- a/src/hooks/useGlobalKeybindings.ts
+++ b/src/hooks/useGlobalKeybindings.ts
@@ -189,3 +189,10 @@ const getPendingChordSnapshot = () => keybindingService.getPendingChord();
 export function usePendingChord(): string | null {
   return useSyncExternalStore(subscribeToPendingChord, getPendingChordSnapshot);
 }
+
+const subscribeToLastInvalidKey = (callback: () => void) => keybindingService.subscribe(callback);
+const getLastInvalidKeySnapshot = () => keybindingService.getLastInvalidKey();
+
+export function useLastInvalidKey(): string | null {
+  return useSyncExternalStore(subscribeToLastInvalidKey, getLastInvalidKeySnapshot);
+}

--- a/src/services/KeybindingService.ts
+++ b/src/services/KeybindingService.ts
@@ -411,14 +411,20 @@ class KeybindingService {
       };
     }
 
+    // When a pending chord exists and the second key is neither a chord
+    // completion nor a recognized standalone, surface the attempted combo
+    // so the HUD can echo it, AND consume the event so the key doesn't
+    // leak through to xterm (bare key types in the terminal) or fire a
+    // side-effecting standalone action (e.g. Cmd+T → terminal.duplicate)
+    // that the user only pressed as part of the cancelled chord.
+    const invalidChordKey = this.pendingChord !== null && !bestMatch && !foundChordPrefix;
+
     // Clear pending chord if we found a match or no chord prefix
     if (bestMatch || !foundChordPrefix) {
-      // When a pending chord exists and the second key is neither a chord
-      // completion nor a recognized standalone, surface the attempted combo
-      // so the HUD can echo it before the exit animation. Must be set
-      // before clearPendingChord() — the synchronous notifyListeners() call
-      // inside that method is when subscribers read the snapshot.
-      if (this.pendingChord && !bestMatch && !foundChordPrefix) {
+      // lastInvalidKey must be set before clearPendingChord() — the
+      // synchronous notifyListeners() call inside that method is when
+      // subscribers read the snapshot.
+      if (invalidChordKey) {
         this.lastInvalidKey = currentCombo;
       }
       this.clearPendingChord();
@@ -427,7 +433,7 @@ class KeybindingService {
     return {
       match: bestMatch,
       chordPrefix: foundChordPrefix,
-      shouldConsume: !!bestMatch || foundChordPrefix,
+      shouldConsume: !!bestMatch || foundChordPrefix || invalidChordKey,
     };
   }
 

--- a/src/services/KeybindingService.ts
+++ b/src/services/KeybindingService.ts
@@ -26,6 +26,7 @@ class KeybindingService {
   private scopeStack: KeyScope[] = ["global"];
   private currentScope: KeyScope = "global";
   private pendingChord: string | null = null;
+  private lastInvalidKey: string | null = null;
   private chordTimeout: NodeJS.Timeout | null = null;
   private listeners = new Set<() => void>();
 
@@ -310,6 +311,16 @@ class KeybindingService {
     this.clearPendingChord();
   }
 
+  getLastInvalidKey(): string | null {
+    return this.lastInvalidKey;
+  }
+
+  clearLastInvalidKey(): void {
+    if (this.lastInvalidKey === null) return;
+    this.lastInvalidKey = null;
+    this.notifyListeners();
+  }
+
   normalizeKeyForBinding(event: KeyboardEvent): string {
     return normalizeKeyForBinding(event);
   }
@@ -402,6 +413,14 @@ class KeybindingService {
 
     // Clear pending chord if we found a match or no chord prefix
     if (bestMatch || !foundChordPrefix) {
+      // When a pending chord exists and the second key is neither a chord
+      // completion nor a recognized standalone, surface the attempted combo
+      // so the HUD can echo it before the exit animation. Must be set
+      // before clearPendingChord() — the synchronous notifyListeners() call
+      // inside that method is when subscribers read the snapshot.
+      if (this.pendingChord && !bestMatch && !foundChordPrefix) {
+        this.lastInvalidKey = currentCombo;
+      }
       this.clearPendingChord();
     }
 

--- a/src/services/__tests__/KeybindingService.test.ts
+++ b/src/services/__tests__/KeybindingService.test.ts
@@ -740,6 +740,164 @@ describe("KeybindingService", () => {
     });
   });
 
+  describe("lastInvalidKey echo — issue #8105", () => {
+    function startCmdKChord(service: KeybindingService): void {
+      setPlatform("MacIntel");
+      const cmdK = createKeyboardEvent({
+        key: "k",
+        code: "KeyK",
+        metaKey: true,
+      });
+      service.resolveKeybinding(cmdK);
+      expect(service.getPendingChord()).not.toBeNull();
+    }
+
+    it("returns null initially", () => {
+      const service = new KeybindingService();
+      expect(service.getLastInvalidKey()).toBeNull();
+    });
+
+    it("captures the attempted combo when a second key is unrecognized after a chord prefix", () => {
+      setPlatform("MacIntel");
+      const service = new KeybindingService();
+      startCmdKChord(service);
+
+      // Press an unrecognized second key — bare "Y" with no modifier is neither
+      // a chord completion under Cmd+K nor a standalone shortcut.
+      const bareY = createKeyboardEvent({
+        key: "y",
+        code: "KeyY",
+      });
+      service.resolveKeybinding(bareY);
+
+      expect(service.getPendingChord()).toBeNull();
+      expect(service.getLastInvalidKey()).toBe("y");
+    });
+
+    it("notifies listeners synchronously when lastInvalidKey is set via resolveKeybinding", () => {
+      setPlatform("MacIntel");
+      const service = new KeybindingService();
+      startCmdKChord(service);
+
+      // Snapshot the listener captured value at notify-time. The renderer
+      // pattern reads getLastInvalidKey() inside the subscriber, so the field
+      // MUST already be populated before clearPendingChord() fires the notify.
+      let observedAtNotify: string | null | undefined;
+      service.subscribe(() => {
+        observedAtNotify = service.getLastInvalidKey();
+      });
+
+      const bareY = createKeyboardEvent({
+        key: "y",
+        code: "KeyY",
+      });
+      service.resolveKeybinding(bareY);
+
+      expect(observedAtNotify).toBe("y");
+    });
+
+    it("does not set lastInvalidKey when a chord completes successfully", () => {
+      setPlatform("MacIntel");
+      const service = new KeybindingService();
+      service.registerBinding({
+        actionId: "test.chordOk",
+        combo: "Cmd+K Cmd+Z",
+        scope: "global",
+        priority: 99,
+      });
+      startCmdKChord(service);
+
+      const cmdZ = createKeyboardEvent({
+        key: "z",
+        code: "KeyZ",
+        metaKey: true,
+      });
+      const match = service.findMatchingAction(cmdZ);
+      expect(match?.actionId).toBe("test.chordOk");
+      expect(service.getLastInvalidKey()).toBeNull();
+    });
+
+    it("does not set lastInvalidKey when clearPendingChord is called directly (Escape/Backspace path)", () => {
+      const service = new KeybindingService();
+      startCmdKChord(service);
+
+      service.clearPendingChord();
+      expect(service.getPendingChord()).toBeNull();
+      expect(service.getLastInvalidKey()).toBeNull();
+    });
+
+    it("does not set lastInvalidKey when the chord auto-clear timeout fires", () => {
+      vi.useFakeTimers();
+      try {
+        const service = new KeybindingService();
+        startCmdKChord(service);
+
+        vi.advanceTimersByTime(2000);
+        expect(service.getPendingChord()).toBeNull();
+        expect(service.getLastInvalidKey()).toBeNull();
+      } finally {
+        vi.useRealTimers();
+      }
+    });
+
+    it("does not set lastInvalidKey for an unrecognized standalone key with no pending chord", () => {
+      setPlatform("MacIntel");
+      const service = new KeybindingService();
+
+      // No chord pending — a bare unrecognized key must not surface as invalid;
+      // it's just a key the app doesn't bind.
+      const bareY = createKeyboardEvent({
+        key: "y",
+        code: "KeyY",
+      });
+      service.resolveKeybinding(bareY);
+
+      expect(service.getLastInvalidKey()).toBeNull();
+    });
+
+    it("clearLastInvalidKey resets to null and notifies listeners", () => {
+      setPlatform("MacIntel");
+      const service = new KeybindingService();
+      startCmdKChord(service);
+      const bareY = createKeyboardEvent({ key: "y", code: "KeyY" });
+      service.resolveKeybinding(bareY);
+      expect(service.getLastInvalidKey()).toBe("y");
+
+      const listener = vi.fn();
+      service.subscribe(listener);
+
+      service.clearLastInvalidKey();
+      expect(service.getLastInvalidKey()).toBeNull();
+      expect(listener).toHaveBeenCalledTimes(1);
+    });
+
+    it("clearLastInvalidKey is a no-op (no notify) when already null", () => {
+      const service = new KeybindingService();
+      const listener = vi.fn();
+      service.subscribe(listener);
+
+      service.clearLastInvalidKey();
+      expect(listener).not.toHaveBeenCalled();
+    });
+
+    it("setting a new pending chord after an invalid key does not auto-clear lastInvalidKey at the service layer", () => {
+      // The renderer side (ChordIndicator) clears the echo when a new prefix
+      // starts. The service should NOT silently overwrite — that's the
+      // component's concern, and keeping the boundary clean lets the renderer
+      // sequence the echo against the new prefix as it sees fit.
+      setPlatform("MacIntel");
+      const service = new KeybindingService();
+      startCmdKChord(service);
+      const bareY = createKeyboardEvent({ key: "y", code: "KeyY" });
+      service.resolveKeybinding(bareY);
+      expect(service.getLastInvalidKey()).toBe("y");
+
+      // Start a new chord — service-side lastInvalidKey is unchanged.
+      startCmdKChord(service);
+      expect(service.getLastInvalidKey()).toBe("y");
+    });
+  });
+
   describe("popPendingChord", () => {
     it("is a no-op when no chord is pending", () => {
       const service = new KeybindingService();

--- a/src/services/__tests__/KeybindingService.test.ts
+++ b/src/services/__tests__/KeybindingService.test.ts
@@ -774,6 +774,42 @@ describe("KeybindingService", () => {
       expect(service.getLastInvalidKey()).toBe("y");
     });
 
+    it("consumes the event for an invalid bare-key second press so it does not leak to xterm", () => {
+      setPlatform("MacIntel");
+      const service = new KeybindingService();
+      startCmdKChord(service);
+
+      const bareY = createKeyboardEvent({ key: "y", code: "KeyY" });
+      const result = service.resolveKeybinding(bareY);
+
+      // shouldConsume must be true — useGlobalKeybindings only calls
+      // preventDefault when this is set. Without it, bare keys land in
+      // the focused terminal as input.
+      expect(result.shouldConsume).toBe(true);
+      expect(result.match).toBeUndefined();
+      expect(result.chordPrefix).toBe(false);
+    });
+
+    it("does not fire a standalone modified shortcut as the invalid second key (Cmd+K then Cmd+T)", () => {
+      setPlatform("MacIntel");
+      const service = new KeybindingService();
+      startCmdKChord(service);
+
+      // Cmd+T is normally bound to terminal.duplicate. As an invalid second
+      // key after Cmd+K, it must NOT resolve to that action — the user pressed
+      // it as part of a cancelled chord, not as an intentional duplicate.
+      const cmdT = createKeyboardEvent({
+        key: "t",
+        code: "KeyT",
+        metaKey: true,
+      });
+      const result = service.resolveKeybinding(cmdT);
+
+      expect(result.match).toBeUndefined();
+      expect(result.shouldConsume).toBe(true);
+      expect(service.getLastInvalidKey()).toBe("Cmd+t");
+    });
+
     it("notifies listeners synchronously when lastInvalidKey is set via resolveKeybinding", () => {
       setPlatform("MacIntel");
       const service = new KeybindingService();


### PR DESCRIPTION
## Summary

- `ChordIndicator`'s root element was missing `pointer-events-none`, so the HUD could intercept clicks meant for content underneath — the same fix `ShortcutHint` already applies for the same reason
- When a user presses an unrecognised second key after a chord prefix the HUD would silently disappear; now `KeybindingService` tracks the last invalid key via `lastInvalidKey` and a new `useLastInvalidKey` hook wires it into `ChordIndicator` to show a brief inline echo of the failed key before the exit animation plays
- Invalid chord second-key events were leaking through to xterm — `shouldConsume` was returning `false` on that path, which let bare keys fire standalone shortcuts (e.g. `Cmd+T` opening a duplicate terminal). Hoisted `invalidChordKey` into a local boolean and OR'd it into `shouldConsume`

Resolves #8105

## Changes

- `KeybindingService.ts` — `lastInvalidKey` field, getter, and clearer; `invalidChordKey` boolean used to gate `shouldConsume`
- `useGlobalKeybindings.ts` — `useLastInvalidKey` hook
- `ChordIndicator.tsx` — `pointer-events-none` on root; consumes `useLastInvalidKey`, renders echo with animation-out cleanup and rapid-fire guard
- `KeybindingService.test.ts` — `lastInvalidKey` lifecycle tests + consume regression tests
- `useKeybinding.test.tsx` — `useLastInvalidKey` hook tests

## Testing

117 unit tests pass. Typecheck, lint, and format all clean. Two targeted regression tests cover the `shouldConsume` fix to prevent future regressions on the key-leak path.