### PR TITLE
refactor(hooks): extract usePollingLifecycle to dedupe github polling

### DIFF
--- a/src/hooks/__tests__/usePollingLifecycle.test.tsx
+++ b/src/hooks/__tests__/usePollingLifecycle.test.tsx
@@ -1,0 +1,381 @@
+// @vitest-environment jsdom
+import { act, renderHook, waitFor } from "@testing-library/react";
+import { beforeEach, describe, expect, it, vi } from "vitest";
+
+const { onSwitchMock } = vi.hoisted(() => ({
+  onSwitchMock: vi.fn<(cb: () => void) => () => void>(),
+}));
+
+vi.mock("@/clients", () => ({
+  projectClient: {
+    onSwitch: onSwitchMock,
+  },
+}));
+
+import { usePollingLifecycle, _resetPollingLifecycleForTests } from "../usePollingLifecycle";
+
+function createDeferred<T>() {
+  let resolve: (value: T) => void;
+  let reject: (error: unknown) => void;
+  const promise = new Promise<T>((res, rej) => {
+    resolve = res;
+    reject = rej;
+  });
+  return { promise, resolve: resolve!, reject: reject! };
+}
+
+function setupHook(opts: {
+  fetchFn?: (ctx: {
+    force: boolean;
+    fetchId: number;
+    isInvalidated: () => boolean;
+  }) => Promise<void>;
+  calculateNextInterval?: (ctx: { isVisible: boolean }) => number;
+  onProjectSwitch?: () => void;
+}) {
+  const fetchFn = opts.fetchFn ?? vi.fn().mockResolvedValue(undefined);
+  const calculateNextInterval = opts.calculateNextInterval ?? (() => 30_000);
+  const onProjectSwitch = opts.onProjectSwitch ?? vi.fn();
+  const hook = renderHook(() =>
+    usePollingLifecycle({
+      fetchFn,
+      calculateNextInterval,
+      onProjectSwitch,
+    })
+  );
+  return { hook, fetchFn, calculateNextInterval, onProjectSwitch };
+}
+
+describe("usePollingLifecycle", () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+    _resetPollingLifecycleForTests();
+    onSwitchMock.mockReturnValue(() => {});
+  });
+
+  describe("singleton listener registration", () => {
+    it("installs visibilitychange / sidebar-refresh / project-switch listeners on first subscriber", () => {
+      const addEventListenerSpy = vi.spyOn(document, "addEventListener");
+      const windowAddEventListenerSpy = vi.spyOn(window, "addEventListener");
+
+      setupHook({});
+
+      expect(addEventListenerSpy).toHaveBeenCalledWith("visibilitychange", expect.any(Function));
+      expect(windowAddEventListenerSpy).toHaveBeenCalledWith(
+        "daintree:refresh-sidebar",
+        expect.any(Function)
+      );
+      expect(onSwitchMock).toHaveBeenCalledTimes(1);
+
+      addEventListenerSpy.mockRestore();
+      windowAddEventListenerSpy.mockRestore();
+    });
+
+    it("installs each global listener only once across multiple mounted hooks", () => {
+      const addEventListenerSpy = vi.spyOn(document, "addEventListener");
+
+      setupHook({});
+      setupHook({});
+      setupHook({});
+
+      const visibilityCalls = addEventListenerSpy.mock.calls.filter(
+        ([event]) => event === "visibilitychange"
+      );
+      expect(visibilityCalls).toHaveLength(1);
+      expect(onSwitchMock).toHaveBeenCalledTimes(1);
+
+      addEventListenerSpy.mockRestore();
+    });
+
+    it("tears down listeners only on last subscriber unmount", () => {
+      const projectSwitchCleanup = vi.fn();
+      onSwitchMock.mockReturnValue(projectSwitchCleanup);
+      const removeEventListenerSpy = vi.spyOn(document, "removeEventListener");
+
+      const a = setupHook({});
+      const b = setupHook({});
+
+      a.hook.unmount();
+      expect(projectSwitchCleanup).not.toHaveBeenCalled();
+      const removeCallsAfterFirstUnmount = removeEventListenerSpy.mock.calls.filter(
+        ([event]) => event === "visibilitychange"
+      );
+      expect(removeCallsAfterFirstUnmount).toHaveLength(0);
+
+      b.hook.unmount();
+      expect(projectSwitchCleanup).toHaveBeenCalledTimes(1);
+      const removeCallsAfterSecondUnmount = removeEventListenerSpy.mock.calls.filter(
+        ([event]) => event === "visibilitychange"
+      );
+      expect(removeCallsAfterSecondUnmount).toHaveLength(1);
+
+      removeEventListenerSpy.mockRestore();
+    });
+  });
+
+  describe("initial fetch and scheduling", () => {
+    it("calls fetchFn once on mount", async () => {
+      const fetchFn = vi.fn().mockResolvedValue(undefined);
+      setupHook({ fetchFn });
+
+      await waitFor(() => {
+        expect(fetchFn).toHaveBeenCalledTimes(1);
+        expect(fetchFn.mock.calls[0]?.[0]?.force).toBe(false);
+      });
+    });
+
+    it("invokes calculateNextInterval after the fetch resolves", async () => {
+      const calculateNextInterval = vi.fn().mockReturnValue(60_000);
+      setupHook({ calculateNextInterval });
+
+      await waitFor(() => {
+        expect(calculateNextInterval).toHaveBeenCalled();
+      });
+    });
+  });
+
+  describe("global fan-out", () => {
+    it("fans visibilitychange (visible) to all subscribers as a fetch + reschedule", async () => {
+      const fetchA = vi.fn().mockResolvedValue(undefined);
+      const fetchB = vi.fn().mockResolvedValue(undefined);
+      setupHook({ fetchFn: fetchA });
+      setupHook({ fetchFn: fetchB });
+
+      await waitFor(() => {
+        expect(fetchA).toHaveBeenCalledTimes(1);
+        expect(fetchB).toHaveBeenCalledTimes(1);
+      });
+
+      Object.defineProperty(document, "hidden", { value: false, configurable: true });
+      await act(async () => {
+        document.dispatchEvent(new Event("visibilitychange"));
+        await Promise.resolve();
+      });
+
+      await waitFor(() => {
+        expect(fetchA).toHaveBeenCalledTimes(2);
+        expect(fetchB).toHaveBeenCalledTimes(2);
+      });
+    });
+
+    it("fans daintree:refresh-sidebar to all subscribers as a forced refresh", async () => {
+      const fetchA = vi.fn().mockResolvedValue(undefined);
+      const fetchB = vi.fn().mockResolvedValue(undefined);
+      setupHook({ fetchFn: fetchA });
+      setupHook({ fetchFn: fetchB });
+
+      await waitFor(() => {
+        expect(fetchA).toHaveBeenCalledTimes(1);
+        expect(fetchB).toHaveBeenCalledTimes(1);
+      });
+
+      await act(async () => {
+        window.dispatchEvent(new CustomEvent("daintree:refresh-sidebar"));
+        await Promise.resolve();
+      });
+
+      await waitFor(() => {
+        expect(fetchA).toHaveBeenCalledTimes(2);
+        expect(fetchA.mock.calls[1]?.[0]?.force).toBe(true);
+        expect(fetchB).toHaveBeenCalledTimes(2);
+        expect(fetchB.mock.calls[1]?.[0]?.force).toBe(true);
+      });
+    });
+
+    it("fans projectClient.onSwitch to all subscribers as onProjectSwitch + refetch", async () => {
+      let captured: (() => void) | undefined;
+      onSwitchMock.mockImplementation((cb) => {
+        captured = cb;
+        return () => {};
+      });
+
+      const onSwitchA = vi.fn();
+      const onSwitchB = vi.fn();
+      const fetchA = vi.fn().mockResolvedValue(undefined);
+      const fetchB = vi.fn().mockResolvedValue(undefined);
+      setupHook({ fetchFn: fetchA, onProjectSwitch: onSwitchA });
+      setupHook({ fetchFn: fetchB, onProjectSwitch: onSwitchB });
+
+      await waitFor(() => {
+        expect(fetchA).toHaveBeenCalledTimes(1);
+        expect(fetchB).toHaveBeenCalledTimes(1);
+      });
+
+      await act(async () => {
+        captured?.();
+        await Promise.resolve();
+      });
+
+      await waitFor(() => {
+        expect(onSwitchA).toHaveBeenCalledTimes(1);
+        expect(onSwitchB).toHaveBeenCalledTimes(1);
+        expect(fetchA).toHaveBeenCalledTimes(2);
+        expect(fetchB).toHaveBeenCalledTimes(2);
+      });
+    });
+
+    it("isolates per-subscriber failures so one consumer's throw cannot block siblings", async () => {
+      // Suppress the expected console.error from the fan-out catch block so
+      // it doesn't pollute test output.
+      const consoleErrorSpy = vi.spyOn(console, "error").mockImplementation(() => {});
+
+      const onSwitchThrows = vi.fn(() => {
+        throw new Error("subscriber A failed");
+      });
+      const onSwitchOk = vi.fn();
+      const fetchA = vi.fn().mockResolvedValue(undefined);
+      const fetchB = vi.fn().mockResolvedValue(undefined);
+
+      let captured: (() => void) | undefined;
+      onSwitchMock.mockImplementation((cb) => {
+        captured = cb;
+        return () => {};
+      });
+
+      setupHook({ fetchFn: fetchA, onProjectSwitch: onSwitchThrows });
+      setupHook({ fetchFn: fetchB, onProjectSwitch: onSwitchOk });
+
+      await waitFor(() => {
+        expect(fetchA).toHaveBeenCalledTimes(1);
+        expect(fetchB).toHaveBeenCalledTimes(1);
+      });
+
+      await act(async () => {
+        captured?.();
+        await Promise.resolve();
+      });
+
+      // A threw, but B's onProjectSwitch still ran.
+      expect(onSwitchOk).toHaveBeenCalledTimes(1);
+      consoleErrorSpy.mockRestore();
+    });
+  });
+
+  describe("queue and invalidation", () => {
+    it("queues a second fetch when the first is still in flight and drains it on resolve", async () => {
+      const deferred = createDeferred<void>();
+      let callCount = 0;
+      const fetchFn = vi.fn().mockImplementation(async () => {
+        callCount += 1;
+        if (callCount === 1) await deferred.promise;
+      });
+
+      const { hook } = setupHook({ fetchFn });
+
+      await waitFor(() => {
+        expect(fetchFn).toHaveBeenCalledTimes(1);
+      });
+
+      // Trigger a sidebar refresh while the first fetch is still pending —
+      // primitive should queue it without invoking fetchFn a second time.
+      await act(async () => {
+        window.dispatchEvent(new CustomEvent("daintree:refresh-sidebar"));
+        await Promise.resolve();
+      });
+
+      expect(fetchFn).toHaveBeenCalledTimes(1);
+
+      // Resolve the in-flight fetch — primitive must drain the queue.
+      await act(async () => {
+        deferred.resolve();
+        await Promise.resolve();
+      });
+
+      await waitFor(() => {
+        expect(fetchFn).toHaveBeenCalledTimes(2);
+        // Queued force flag must thread through to the drained fetch.
+        expect(fetchFn.mock.calls[1]?.[0]?.force).toBe(true);
+      });
+
+      hook.unmount();
+    });
+
+    it("flags the in-flight fetchId as invalidated when a new fetch is queued", async () => {
+      let firstInvalidatedAfter = false;
+      const firstFetchDeferred = createDeferred<void>();
+      const fetchFn = vi
+        .fn()
+        .mockImplementation(async ({ isInvalidated }: { isInvalidated: () => boolean }) => {
+          if (fetchFn.mock.calls.length === 1) {
+            await firstFetchDeferred.promise;
+            firstInvalidatedAfter = isInvalidated();
+          }
+        });
+
+      setupHook({ fetchFn });
+
+      await waitFor(() => {
+        expect(fetchFn).toHaveBeenCalledTimes(1);
+      });
+
+      // Force a sidebar refresh — queues a new fetch and invalidates the
+      // in-flight one.
+      await act(async () => {
+        window.dispatchEvent(new CustomEvent("daintree:refresh-sidebar"));
+        await Promise.resolve();
+      });
+
+      await act(async () => {
+        firstFetchDeferred.resolve();
+        await Promise.resolve();
+      });
+
+      expect(firstInvalidatedAfter).toBe(true);
+    });
+  });
+
+  describe("control object", () => {
+    it("returns a stable scheduleNextPoll / refresh control across renders", () => {
+      const { hook } = setupHook({});
+      const firstControl = hook.result.current;
+      hook.rerender();
+      expect(hook.result.current).toBe(firstControl);
+      expect(hook.result.current.scheduleNextPoll).toBe(firstControl.scheduleNextPoll);
+      expect(hook.result.current.refresh).toBe(firstControl.refresh);
+    });
+
+    it("refresh(force) threads the force flag through to fetchFn", async () => {
+      const fetchFn = vi.fn().mockResolvedValue(undefined);
+      const { hook } = setupHook({ fetchFn });
+
+      await waitFor(() => {
+        expect(fetchFn).toHaveBeenCalledTimes(1);
+      });
+
+      await act(async () => {
+        await hook.result.current.refresh({ force: true });
+      });
+
+      expect(fetchFn).toHaveBeenCalledTimes(2);
+      expect(fetchFn.mock.calls[1]?.[0]?.force).toBe(true);
+    });
+  });
+
+  describe("cleanup safety", () => {
+    it("does not call onProjectSwitch after unmount", async () => {
+      let captured: (() => void) | undefined;
+      onSwitchMock.mockImplementation((cb) => {
+        captured = cb;
+        return () => {};
+      });
+
+      const onProjectSwitch = vi.fn();
+      const { hook } = setupHook({ onProjectSwitch });
+
+      await waitFor(() => {
+        expect(captured).toBeDefined();
+      });
+
+      hook.unmount();
+
+      // After unmount, the singleton listener is torn down (last subscriber).
+      // Even if a stray switch fires from the captured callback reference,
+      // the empty subscriber Set means no fan-out targets exist.
+      act(() => {
+        captured?.();
+      });
+
+      expect(onProjectSwitch).not.toHaveBeenCalled();
+    });
+  });
+});

--- a/src/hooks/__tests__/usePollingLifecycle.test.tsx
+++ b/src/hooks/__tests__/usePollingLifecycle.test.tsx
@@ -351,6 +351,51 @@ describe("usePollingLifecycle", () => {
     });
   });
 
+  describe("resilience", () => {
+    it("survives a fetchFn rejection and still schedules the next poll", async () => {
+      const consoleErrorSpy = vi.spyOn(console, "error").mockImplementation(() => {});
+      const fetchFn = vi.fn().mockRejectedValue(new Error("transient failure"));
+      const calculateNextInterval = vi.fn().mockReturnValue(30_000);
+
+      setupHook({ fetchFn, calculateNextInterval });
+
+      // calculateNextInterval is only called from inside scheduleNextPoll —
+      // if the rejection had killed the lifecycle, this would never fire.
+      await waitFor(() => {
+        expect(fetchFn).toHaveBeenCalledTimes(1);
+        expect(calculateNextInterval).toHaveBeenCalled();
+      });
+
+      consoleErrorSpy.mockRestore();
+    });
+
+    it("keeps refresh() functional after a previous fetchFn rejection", async () => {
+      const consoleErrorSpy = vi.spyOn(console, "error").mockImplementation(() => {});
+      let shouldReject = true;
+      const fetchFn = vi.fn().mockImplementation(async () => {
+        if (shouldReject) throw new Error("transient");
+      });
+
+      const { hook } = setupHook({ fetchFn });
+
+      await waitFor(() => {
+        expect(fetchFn).toHaveBeenCalledTimes(1);
+      });
+
+      shouldReject = false;
+      await act(async () => {
+        await hook.result.current.refresh({ force: true });
+      });
+
+      // The rejection cleared inFlightRef via the finally block, so a
+      // subsequent refresh proceeds normally.
+      expect(fetchFn).toHaveBeenCalledTimes(2);
+      expect(fetchFn.mock.calls[1]?.[0]?.force).toBe(true);
+
+      consoleErrorSpy.mockRestore();
+    });
+  });
+
   describe("cleanup safety", () => {
     it("does not call onProjectSwitch after unmount", async () => {
       let captured: (() => void) | undefined;

--- a/src/hooks/__tests__/useProjectHealth.test.tsx
+++ b/src/hooks/__tests__/useProjectHealth.test.tsx
@@ -1,0 +1,157 @@
+// @vitest-environment jsdom
+import { act, renderHook, waitFor } from "@testing-library/react";
+import { beforeEach, describe, expect, it, vi } from "vitest";
+import type { ProjectHealthData } from "@shared/types/ipc/github";
+
+const { getCurrentMock, onSwitchMock, getProjectHealthMock } = vi.hoisted(() => ({
+  getCurrentMock: vi.fn(),
+  onSwitchMock: vi.fn<(cb: () => void) => () => void>(),
+  getProjectHealthMock: vi.fn(),
+}));
+
+vi.mock("@/clients", () => ({
+  projectClient: {
+    getCurrent: getCurrentMock,
+    onSwitch: onSwitchMock,
+  },
+  githubClient: {
+    getProjectHealth: getProjectHealthMock,
+  },
+}));
+
+import { useProjectHealth } from "../useProjectHealth";
+import { _resetPollingLifecycleForTests } from "../usePollingLifecycle";
+
+function makeHealth(overrides: Partial<ProjectHealthData> = {}): ProjectHealthData {
+  return {
+    ciStatus: "success",
+    issueCount: 3,
+    prCount: 1,
+    latestRelease: null,
+    securityAlerts: { visible: false, count: 0 },
+    mergeVelocity: { mergedCounts: { 60: 0, 120: 0, 180: 0 } },
+    repoUrl: "https://github.com/owner/repo",
+    hasRemote: true,
+    loading: false,
+    lastUpdated: 1000,
+    ...overrides,
+  };
+}
+
+describe("useProjectHealth", () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+    _resetPollingLifecycleForTests();
+    onSwitchMock.mockReturnValue(() => {});
+  });
+
+  it("fetches health on mount and exposes the result", async () => {
+    getCurrentMock.mockResolvedValue({ id: "p", path: "/repo/a" });
+    const health = makeHealth({ issueCount: 7, prCount: 2 });
+    getProjectHealthMock.mockResolvedValue(health);
+
+    const { result } = renderHook(() => useProjectHealth());
+
+    await waitFor(() => {
+      expect(getProjectHealthMock).toHaveBeenCalledTimes(1);
+      expect(result.current.health?.issueCount).toBe(7);
+      expect(result.current.lastUpdated).toBe(1000);
+    });
+  });
+
+  it("clears state when no project is selected", async () => {
+    getCurrentMock.mockResolvedValue(null);
+
+    const { result } = renderHook(() => useProjectHealth());
+
+    await waitFor(() => {
+      expect(getCurrentMock).toHaveBeenCalled();
+      expect(result.current.health).toBeNull();
+      expect(result.current.lastUpdated).toBeNull();
+    });
+    expect(getProjectHealthMock).not.toHaveBeenCalled();
+  });
+
+  it("surfaces a fetch error via the error field", async () => {
+    getCurrentMock.mockResolvedValue({ id: "p", path: "/repo/a" });
+    getProjectHealthMock.mockRejectedValue(new Error("network down"));
+
+    const { result } = renderHook(() => useProjectHealth());
+
+    await waitFor(() => {
+      expect(result.current.error).toBe("network down");
+    });
+  });
+
+  it("resets state on project switch and triggers a refetch", async () => {
+    let currentProject = { id: "a", path: "/repo/a" };
+    getCurrentMock.mockImplementation(async () => currentProject);
+
+    const healthA = makeHealth({ issueCount: 1, prCount: 1, lastUpdated: 1000 });
+    const healthB = makeHealth({ issueCount: 9, prCount: 9, lastUpdated: 2000 });
+    getProjectHealthMock.mockResolvedValueOnce(healthA).mockResolvedValueOnce(healthB);
+
+    let captured: (() => void) | undefined;
+    onSwitchMock.mockImplementation((cb) => {
+      captured = cb;
+      return () => {};
+    });
+
+    const { result } = renderHook(() => useProjectHealth());
+
+    await waitFor(() => {
+      expect(result.current.health?.issueCount).toBe(1);
+    });
+
+    currentProject = { id: "b", path: "/repo/b" };
+    await act(async () => {
+      captured?.();
+      await Promise.resolve();
+    });
+
+    await waitFor(() => {
+      expect(getProjectHealthMock).toHaveBeenCalledTimes(2);
+      expect(result.current.health?.issueCount).toBe(9);
+    });
+  });
+
+  it("force-fetches when daintree:refresh-sidebar fires", async () => {
+    getCurrentMock.mockResolvedValue({ id: "p", path: "/repo/a" });
+    getProjectHealthMock.mockResolvedValue(makeHealth());
+
+    renderHook(() => useProjectHealth());
+
+    await waitFor(() => {
+      expect(getProjectHealthMock).toHaveBeenCalledTimes(1);
+      expect(getProjectHealthMock.mock.calls[0]?.[1]).toBe(false);
+    });
+
+    await act(async () => {
+      window.dispatchEvent(new CustomEvent("daintree:refresh-sidebar"));
+      await Promise.resolve();
+    });
+
+    await waitFor(() => {
+      expect(getProjectHealthMock).toHaveBeenCalledTimes(2);
+      expect(getProjectHealthMock.mock.calls[1]?.[1]).toBe(true);
+    });
+  });
+
+  it("refresh({ force: true }) propagates the force flag to getProjectHealth", async () => {
+    getCurrentMock.mockResolvedValue({ id: "p", path: "/repo/a" });
+    getProjectHealthMock.mockResolvedValue(makeHealth());
+
+    const { result } = renderHook(() => useProjectHealth());
+
+    await waitFor(() => {
+      expect(getProjectHealthMock).toHaveBeenCalledTimes(1);
+    });
+
+    await act(async () => {
+      await result.current.refresh({ force: true });
+    });
+
+    expect(getProjectHealthMock).toHaveBeenCalledTimes(2);
+    expect(getProjectHealthMock.mock.calls[1]?.[1]).toBe(true);
+  });
+});

--- a/src/hooks/__tests__/useProjectHealth.test.tsx
+++ b/src/hooks/__tests__/useProjectHealth.test.tsx
@@ -137,6 +137,84 @@ describe("useProjectHealth", () => {
     });
   });
 
+  it("clears error and lastErrorRef on project switch so the new project polls at the active cadence", async () => {
+    let currentProject = { id: "a", path: "/repo/a" };
+    getCurrentMock.mockImplementation(async () => currentProject);
+
+    // Project A's fetch rejects, leaving an error in state.
+    getProjectHealthMock
+      .mockRejectedValueOnce(new Error("project A failure"))
+      .mockImplementation(async () => makeHealth());
+
+    let captured: (() => void) | undefined;
+    onSwitchMock.mockImplementation((cb) => {
+      captured = cb;
+      return () => {};
+    });
+
+    const { result } = renderHook(() => useProjectHealth());
+
+    await waitFor(() => {
+      expect(result.current.error).toBe("project A failure");
+    });
+
+    currentProject = { id: "b", path: "/repo/b" };
+    await act(async () => {
+      captured?.();
+      await Promise.resolve();
+    });
+
+    // Error must be cleared synchronously on switch — without this, the new
+    // project's first poll would be delayed by ERROR_BACKOFF_INTERVAL.
+    expect(result.current.error).toBeNull();
+  });
+
+  it("does not apply an invalidated fetch's error to the new project's state", async () => {
+    let currentProject = { id: "a", path: "/repo/a" };
+    getCurrentMock.mockImplementation(async () => currentProject);
+
+    // First fetch hangs, then rejects; second resolves with healthy data.
+    let rejectA: ((err: Error) => void) | undefined;
+    getProjectHealthMock
+      .mockImplementationOnce(
+        () =>
+          new Promise((_resolve, reject) => {
+            rejectA = reject;
+          })
+      )
+      .mockResolvedValue(makeHealth());
+
+    let captured: (() => void) | undefined;
+    onSwitchMock.mockImplementation((cb) => {
+      captured = cb;
+      return () => {};
+    });
+
+    const { result } = renderHook(() => useProjectHealth());
+
+    await waitFor(() => {
+      expect(getProjectHealthMock).toHaveBeenCalledTimes(1);
+    });
+
+    // Switch projects while A's fetch is still pending — this invalidates
+    // the in-flight fetch.
+    currentProject = { id: "b", path: "/repo/b" };
+    await act(async () => {
+      captured?.();
+      await Promise.resolve();
+    });
+
+    // Now reject A — the catch block must detect invalidation and skip the
+    // setError call. Otherwise B's state would surface A's error.
+    await act(async () => {
+      rejectA?.(new Error("project A late failure"));
+      await Promise.resolve();
+      await Promise.resolve();
+    });
+
+    expect(result.current.error).toBeNull();
+  });
+
   it("refresh({ force: true }) propagates the force flag to getProjectHealth", async () => {
     getCurrentMock.mockResolvedValue({ id: "p", path: "/repo/a" });
     getProjectHealthMock.mockResolvedValue(makeHealth());

--- a/src/hooks/__tests__/useRepositoryStats.test.tsx
+++ b/src/hooks/__tests__/useRepositoryStats.test.tsx
@@ -35,6 +35,7 @@ vi.mock("@/clients", () => ({
 }));
 
 import { useRepositoryStats } from "../useRepositoryStats";
+import { _resetPollingLifecycleForTests } from "../usePollingLifecycle";
 import {
   _resetForTests as resetGithubResourceCache,
   buildCacheKey,
@@ -56,6 +57,7 @@ function createDeferred<T>() {
 describe("useRepositoryStats", () => {
   beforeEach(() => {
     vi.clearAllMocks();
+    _resetPollingLifecycleForTests();
   });
 
   it("force-fetches when daintree:refresh-sidebar event is dispatched", async () => {

--- a/src/hooks/usePollingLifecycle.ts
+++ b/src/hooks/usePollingLifecycle.ts
@@ -68,6 +68,20 @@ function fanOut(method: keyof Subscriber) {
 
 function ensureGlobalListenersInstalled() {
   if (visibilityHandler !== null) return;
+
+  // Subscribe to the IPC channel first so a failure there doesn't leave the
+  // DOM listeners installed while `projectSwitchCleanup` stays null —
+  // subsequent `ensureGlobalListenersInstalled` calls would short-circuit on
+  // the non-null DOM handlers and the project-switch fan-out would be
+  // silently missing for the rest of the process lifetime.
+  let nextSwitchCleanup: (() => void) | null = null;
+  try {
+    nextSwitchCleanup = projectClient.onSwitch(() => fanOut("onProjectSwitch"));
+  } catch (err) {
+    console.error("usePollingLifecycle: failed to subscribe project switch", err);
+    return;
+  }
+
   visibilityHandler = () => {
     if (document.hidden) {
       fanOut("onVisibilityHidden");
@@ -80,7 +94,7 @@ function ensureGlobalListenersInstalled() {
   sidebarHandler = () => fanOut("onSidebarRefresh");
   window.addEventListener("daintree:refresh-sidebar", sidebarHandler);
 
-  projectSwitchCleanup = projectClient.onSwitch(() => fanOut("onProjectSwitch"));
+  projectSwitchCleanup = nextSwitchCleanup;
 }
 
 function teardownGlobalListenersIfEmpty() {
@@ -166,7 +180,18 @@ export function usePollingLifecycle(config: PollingLifecycleConfig): PollingLife
       activeFetchIdRef.current += 1;
       const fetchId = activeFetchIdRef.current;
       const isInvalidated = () => invalidatedFetchIdRef.current === fetchId;
-      await config.fetchFn({ force, fetchId, isInvalidated });
+      try {
+        await config.fetchFn({ force, fetchId, isInvalidated });
+      } catch (err) {
+        // The consumer's fetchFn is responsible for surfacing its own errors
+        // (setError, lastErrorRef). The primitive catches here so a throw —
+        // e.g. an IPC failure on `projectClient.getCurrent()` outside the
+        // consumer's inner try/catch — does not silently kill polling. Every
+        // fire-and-forget call site below chains `.then(scheduleNextPoll)`
+        // without a `.catch`; an uncaught rejection here would skip that
+        // chain and freeze the lifecycle until the next external trigger.
+        console.error("usePollingLifecycle: fetchFn threw", err);
+      }
     } finally {
       inFlightRef.current = false;
       if (aliveRef.current && queuedFetchRef.current.pending) {

--- a/src/hooks/usePollingLifecycle.ts
+++ b/src/hooks/usePollingLifecycle.ts
@@ -1,0 +1,280 @@
+import { useEffect, useEffectEvent, useRef } from "react";
+import { projectClient } from "@/clients";
+
+export interface PollingLifecycleFetchContext {
+  force: boolean;
+  fetchId: number;
+  isInvalidated: () => boolean;
+}
+
+export interface PollingLifecycleConfig {
+  /**
+   * Consumer-supplied fetch body. The primitive manages in-flight detection,
+   * queue draining, and fetch-id invalidation; the consumer reads
+   * `isInvalidated()` after every await and bails when it returns true.
+   */
+  fetchFn: (context: PollingLifecycleFetchContext) => Promise<void>;
+  /**
+   * Returns the next poll interval in ms. Called after every fetch resolves
+   * via `useEffectEvent`, so the consumer can read its own refs (last error,
+   * rate-limit reset, etc.) and pick a tier without re-creating the hook.
+   */
+  calculateNextInterval: (context: { isVisible: boolean }) => number;
+  /**
+   * Fires before the post-switch fetch kicks off. The consumer should reset
+   * any per-project state here so the immediate refetch lands cleanly.
+   */
+  onProjectSwitch?: () => void;
+}
+
+export interface PollingLifecycleControl {
+  scheduleNextPoll: () => void;
+  refresh: (options?: { force?: boolean }) => Promise<void>;
+}
+
+interface Subscriber {
+  onVisibilityVisible: () => void;
+  onVisibilityHidden: () => void;
+  onSidebarRefresh: () => void;
+  onProjectSwitch: () => void;
+}
+
+// Module-level singleton: every consumer of `usePollingLifecycle` shares one
+// `visibilitychange`, one `daintree:refresh-sidebar`, and one
+// `projectClient.onSwitch` registration. Mirrors `useGlobalMinuteTicker`'s
+// refcounted listener Set so a tab resume fans out to all consumers without
+// each hook independently re-registering the same DOM/IPC listener.
+const subscribers = new Set<Subscriber>();
+let visibilityHandler: (() => void) | null = null;
+let sidebarHandler: (() => void) | null = null;
+let projectSwitchCleanup: (() => void) | null = null;
+
+function fanOut(method: keyof Subscriber) {
+  // Snapshot to a copy so subscribers can register/unregister inside their
+  // own callbacks (defensive — current consumers don't, but the Set
+  // iterator's mutation-during-iteration behaviour is undefined).
+  const snapshot = Array.from(subscribers);
+  for (const subscriber of snapshot) {
+    try {
+      subscriber[method]();
+    } catch (err) {
+      // Isolate per-subscriber failures so one consumer's bug can't block
+      // sibling consumers from receiving the same global event. Tier 0
+      // console log per CLAUDE.md — diagnostic only.
+      console.error(`usePollingLifecycle: ${method} subscriber failed`, err);
+    }
+  }
+}
+
+function ensureGlobalListenersInstalled() {
+  if (visibilityHandler !== null) return;
+  visibilityHandler = () => {
+    if (document.hidden) {
+      fanOut("onVisibilityHidden");
+    } else {
+      fanOut("onVisibilityVisible");
+    }
+  };
+  document.addEventListener("visibilitychange", visibilityHandler);
+
+  sidebarHandler = () => fanOut("onSidebarRefresh");
+  window.addEventListener("daintree:refresh-sidebar", sidebarHandler);
+
+  projectSwitchCleanup = projectClient.onSwitch(() => fanOut("onProjectSwitch"));
+}
+
+function teardownGlobalListenersIfEmpty() {
+  if (subscribers.size > 0) return;
+  if (visibilityHandler !== null) {
+    document.removeEventListener("visibilitychange", visibilityHandler);
+    visibilityHandler = null;
+  }
+  if (sidebarHandler !== null) {
+    window.removeEventListener("daintree:refresh-sidebar", sidebarHandler);
+    sidebarHandler = null;
+  }
+  if (projectSwitchCleanup !== null) {
+    projectSwitchCleanup();
+    projectSwitchCleanup = null;
+  }
+}
+
+/**
+ * Test-only escape hatch — flushes the module-level subscriber Set and tears
+ * down any installed global listeners. Vitest tests should call this in
+ * `beforeEach` so state from a previous test (especially one that threw
+ * before its `renderHook` unmounted) does not leak into the next.
+ */
+export function _resetPollingLifecycleForTests(): void {
+  subscribers.clear();
+  if (visibilityHandler !== null) {
+    document.removeEventListener("visibilitychange", visibilityHandler);
+    visibilityHandler = null;
+  }
+  if (sidebarHandler !== null) {
+    window.removeEventListener("daintree:refresh-sidebar", sidebarHandler);
+    sidebarHandler = null;
+  }
+  if (projectSwitchCleanup !== null) {
+    try {
+      projectSwitchCleanup();
+    } catch {
+      // ignore — test mocks may throw on double-cleanup
+    }
+    projectSwitchCleanup = null;
+  }
+}
+
+/**
+ * Polling lifecycle primitive shared by `useRepositoryStats` and
+ * `useProjectHealth`. Owns the timer, in-flight guard, queue, and fetch-id
+ * invalidation; coalesces the three global triggers
+ * (`visibilitychange` / `daintree:refresh-sidebar` / project switch) into a
+ * module-level fan-out so every consumer fires from one shared listener.
+ *
+ * Consumer keeps all state, its own `mountedRef`, and any extras (rate-limit
+ * scheduling, broadcast subscriptions, disk hydration). The primitive does
+ * not own state and emits zero re-renders.
+ */
+export function usePollingLifecycle(config: PollingLifecycleConfig): PollingLifecycleControl {
+  const pollTimerRef = useRef<ReturnType<typeof setTimeout> | null>(null);
+  const isVisibleRef = useRef(!document.hidden);
+  const inFlightRef = useRef(false);
+  const queuedFetchRef = useRef<{ pending: boolean; force: boolean }>({
+    pending: false,
+    force: false,
+  });
+  const activeFetchIdRef = useRef(0);
+  const invalidatedFetchIdRef = useRef<number | null>(null);
+  // Per-instance alive flag — distinct from the consumer's `mountedRef`. The
+  // consumer's effects clean up after the primitive's does (effects unmount
+  // LIFO), so we need our own flag to prevent the post-await `scheduleNext`
+  // chain from installing a fresh timer during teardown.
+  const aliveRef = useRef(true);
+  const controlRef = useRef<PollingLifecycleControl | null>(null);
+
+  const callFetchFn = useEffectEvent(async (force: boolean): Promise<void> => {
+    if (inFlightRef.current) {
+      queuedFetchRef.current.pending = true;
+      queuedFetchRef.current.force = queuedFetchRef.current.force || force;
+      invalidatedFetchIdRef.current = activeFetchIdRef.current;
+      return;
+    }
+
+    try {
+      inFlightRef.current = true;
+      activeFetchIdRef.current += 1;
+      const fetchId = activeFetchIdRef.current;
+      const isInvalidated = () => invalidatedFetchIdRef.current === fetchId;
+      await config.fetchFn({ force, fetchId, isInvalidated });
+    } finally {
+      inFlightRef.current = false;
+      if (aliveRef.current && queuedFetchRef.current.pending) {
+        const queuedForce = queuedFetchRef.current.force;
+        queuedFetchRef.current = { pending: false, force: false };
+        void callFetchFn(queuedForce);
+      }
+    }
+  });
+
+  const callCalculateNextInterval = useEffectEvent((): number =>
+    config.calculateNextInterval({ isVisible: isVisibleRef.current })
+  );
+
+  const callOnProjectSwitch = useEffectEvent((): void => {
+    config.onProjectSwitch?.();
+  });
+
+  const scheduleNextPoll = useEffectEvent((): void => {
+    if (!aliveRef.current) return;
+    if (pollTimerRef.current) {
+      clearTimeout(pollTimerRef.current);
+    }
+    const interval = callCalculateNextInterval();
+    pollTimerRef.current = setTimeout(() => {
+      void callFetchFn(false).then(() => {
+        if (aliveRef.current) scheduleNextPoll();
+      });
+    }, interval);
+  });
+
+  const refresh = useEffectEvent(async (options?: { force?: boolean }): Promise<void> => {
+    if (!aliveRef.current) return;
+    if (pollTimerRef.current) {
+      clearTimeout(pollTimerRef.current);
+      pollTimerRef.current = null;
+    }
+    await callFetchFn(options?.force ?? false);
+    if (aliveRef.current) scheduleNextPoll();
+  });
+
+  // Lazy-init a stable control object so consumers receive the same
+  // reference across renders. The wrappers indirect through the
+  // `useEffectEvent` results, so the consumer always invokes the latest
+  // captured config.
+  if (controlRef.current === null) {
+    controlRef.current = {
+      scheduleNextPoll: () => scheduleNextPoll(),
+      refresh: (options) => refresh(options),
+    };
+  }
+
+  useEffect(() => {
+    aliveRef.current = true;
+
+    const subscriber: Subscriber = {
+      onVisibilityVisible: () => {
+        isVisibleRef.current = true;
+        if (pollTimerRef.current) {
+          clearTimeout(pollTimerRef.current);
+          pollTimerRef.current = null;
+        }
+        void callFetchFn(false).then(() => {
+          if (aliveRef.current) scheduleNextPoll();
+        });
+      },
+      onVisibilityHidden: () => {
+        isVisibleRef.current = false;
+        if (pollTimerRef.current) {
+          clearTimeout(pollTimerRef.current);
+          pollTimerRef.current = null;
+        }
+        scheduleNextPoll();
+      },
+      onSidebarRefresh: () => {
+        void refresh({ force: true });
+      },
+      onProjectSwitch: () => {
+        if (pollTimerRef.current) {
+          clearTimeout(pollTimerRef.current);
+          pollTimerRef.current = null;
+        }
+        callOnProjectSwitch();
+        void callFetchFn(false).then(() => {
+          if (aliveRef.current) scheduleNextPoll();
+        });
+      },
+    };
+
+    subscribers.add(subscriber);
+    ensureGlobalListenersInstalled();
+
+    void callFetchFn(false).then(() => {
+      if (aliveRef.current) scheduleNextPoll();
+    });
+
+    return () => {
+      aliveRef.current = false;
+      subscribers.delete(subscriber);
+      queuedFetchRef.current = { pending: false, force: false };
+      invalidatedFetchIdRef.current = null;
+      if (pollTimerRef.current) {
+        clearTimeout(pollTimerRef.current);
+        pollTimerRef.current = null;
+      }
+      teardownGlobalListenersIfEmpty();
+    };
+  }, []);
+
+  return controlRef.current;
+}

--- a/src/hooks/usePollingLifecycle.ts
+++ b/src/hooks/usePollingLifecycle.ts
@@ -1,4 +1,4 @@
-import { useEffect, useEffectEvent, useRef } from "react";
+import { useCallback, useEffect, useLayoutEffect, useRef } from "react";
 import { projectClient } from "@/clients";
 
 export interface PollingLifecycleFetchContext {
@@ -61,7 +61,7 @@ function fanOut(method: keyof Subscriber) {
       // Isolate per-subscriber failures so one consumer's bug can't block
       // sibling consumers from receiving the same global event. Tier 0
       // console log per CLAUDE.md — diagnostic only.
-      console.error(`usePollingLifecycle: ${method} subscriber failed`, err);
+      console.warn(`usePollingLifecycle: ${method} subscriber failed`, err);
     }
   }
 }
@@ -74,11 +74,11 @@ function ensureGlobalListenersInstalled() {
   // subsequent `ensureGlobalListenersInstalled` calls would short-circuit on
   // the non-null DOM handlers and the project-switch fan-out would be
   // silently missing for the rest of the process lifetime.
-  let nextSwitchCleanup: (() => void) | null = null;
+  let cleanup: (() => void) | null;
   try {
-    nextSwitchCleanup = projectClient.onSwitch(() => fanOut("onProjectSwitch"));
+    cleanup = projectClient.onSwitch(() => fanOut("onProjectSwitch"));
   } catch (err) {
-    console.error("usePollingLifecycle: failed to subscribe project switch", err);
+    console.warn("usePollingLifecycle: failed to subscribe project switch", err);
     return;
   }
 
@@ -94,7 +94,7 @@ function ensureGlobalListenersInstalled() {
   sidebarHandler = () => fanOut("onSidebarRefresh");
   window.addEventListener("daintree:refresh-sidebar", sidebarHandler);
 
-  projectSwitchCleanup = nextSwitchCleanup;
+  projectSwitchCleanup = cleanup;
 }
 
 function teardownGlobalListenersIfEmpty() {
@@ -165,9 +165,18 @@ export function usePollingLifecycle(config: PollingLifecycleConfig): PollingLife
   // LIFO), so we need our own flag to prevent the post-await `scheduleNext`
   // chain from installing a fresh timer during teardown.
   const aliveRef = useRef(true);
-  const controlRef = useRef<PollingLifecycleControl | null>(null);
 
-  const callFetchFn = useEffectEvent(async (force: boolean): Promise<void> => {
+  // Latest-config ref pattern — equivalent to `useEffectEvent` semantics but
+  // with returnable identities. `useEffectEvent` cannot be assigned to a
+  // variable or passed down per its lint rule, so the public `scheduleNextPoll`
+  // and `refresh` use `useCallback([])` and read the live config through
+  // `configRef.current` instead of capturing `config` at first render.
+  const configRef = useRef<PollingLifecycleConfig>(config);
+  useLayoutEffect(() => {
+    configRef.current = config;
+  });
+
+  const callFetchFn = useCallback(async function callFetchFnImpl(force: boolean): Promise<void> {
     if (inFlightRef.current) {
       queuedFetchRef.current.pending = true;
       queuedFetchRef.current.force = queuedFetchRef.current.force || force;
@@ -181,7 +190,7 @@ export function usePollingLifecycle(config: PollingLifecycleConfig): PollingLife
       const fetchId = activeFetchIdRef.current;
       const isInvalidated = () => invalidatedFetchIdRef.current === fetchId;
       try {
-        await config.fetchFn({ force, fetchId, isInvalidated });
+        await configRef.current.fetchFn({ force, fetchId, isInvalidated });
       } catch (err) {
         // The consumer's fetchFn is responsible for surfacing its own errors
         // (setError, lastErrorRef). The primitive catches here so a throw —
@@ -190,58 +199,59 @@ export function usePollingLifecycle(config: PollingLifecycleConfig): PollingLife
         // fire-and-forget call site below chains `.then(scheduleNextPoll)`
         // without a `.catch`; an uncaught rejection here would skip that
         // chain and freeze the lifecycle until the next external trigger.
-        console.error("usePollingLifecycle: fetchFn threw", err);
+        console.warn("usePollingLifecycle: fetchFn threw", err);
       }
     } finally {
       inFlightRef.current = false;
       if (aliveRef.current && queuedFetchRef.current.pending) {
         const queuedForce = queuedFetchRef.current.force;
         queuedFetchRef.current = { pending: false, force: false };
-        void callFetchFn(queuedForce);
+        // Named-function self-recursion — avoids referencing the outer
+        // `callFetchFn` variable, which would close over a potentially
+        // stale binding before useCallback returns.
+        void callFetchFnImpl(queuedForce);
       }
     }
-  });
+  }, []);
 
-  const callCalculateNextInterval = useEffectEvent((): number =>
-    config.calculateNextInterval({ isVisible: isVisibleRef.current })
+  const scheduleNextPoll = useCallback(
+    function scheduleNextPollImpl(): void {
+      if (!aliveRef.current) return;
+      if (pollTimerRef.current) {
+        clearTimeout(pollTimerRef.current);
+      }
+      const interval = configRef.current.calculateNextInterval({
+        isVisible: isVisibleRef.current,
+      });
+      pollTimerRef.current = setTimeout(() => {
+        void callFetchFn(false).then(() => {
+          if (aliveRef.current) scheduleNextPollImpl();
+        });
+      }, interval);
+    },
+    [callFetchFn]
   );
 
-  const callOnProjectSwitch = useEffectEvent((): void => {
-    config.onProjectSwitch?.();
-  });
+  const refresh = useCallback(
+    async (options?: { force?: boolean }): Promise<void> => {
+      if (!aliveRef.current) return;
+      if (pollTimerRef.current) {
+        clearTimeout(pollTimerRef.current);
+        pollTimerRef.current = null;
+      }
+      await callFetchFn(options?.force ?? false);
+      if (aliveRef.current) scheduleNextPoll();
+    },
+    [callFetchFn, scheduleNextPoll]
+  );
 
-  const scheduleNextPoll = useEffectEvent((): void => {
-    if (!aliveRef.current) return;
-    if (pollTimerRef.current) {
-      clearTimeout(pollTimerRef.current);
-    }
-    const interval = callCalculateNextInterval();
-    pollTimerRef.current = setTimeout(() => {
-      void callFetchFn(false).then(() => {
-        if (aliveRef.current) scheduleNextPoll();
-      });
-    }, interval);
-  });
-
-  const refresh = useEffectEvent(async (options?: { force?: boolean }): Promise<void> => {
-    if (!aliveRef.current) return;
-    if (pollTimerRef.current) {
-      clearTimeout(pollTimerRef.current);
-      pollTimerRef.current = null;
-    }
-    await callFetchFn(options?.force ?? false);
-    if (aliveRef.current) scheduleNextPoll();
-  });
-
-  // Lazy-init a stable control object so consumers receive the same
-  // reference across renders. The wrappers indirect through the
-  // `useEffectEvent` results, so the consumer always invokes the latest
-  // captured config.
+  // Stable control object — `useCallback([])` keeps `callFetchFn` /
+  // `scheduleNextPoll` / `refresh` identity-stable across renders, so a
+  // single useRef-cached object captured at first render works for the
+  // hook's lifetime.
+  const controlRef = useRef<PollingLifecycleControl | null>(null);
   if (controlRef.current === null) {
-    controlRef.current = {
-      scheduleNextPoll: () => scheduleNextPoll(),
-      refresh: (options) => refresh(options),
-    };
+    controlRef.current = { scheduleNextPoll, refresh };
   }
 
   useEffect(() => {
@@ -274,7 +284,7 @@ export function usePollingLifecycle(config: PollingLifecycleConfig): PollingLife
           clearTimeout(pollTimerRef.current);
           pollTimerRef.current = null;
         }
-        callOnProjectSwitch();
+        configRef.current.onProjectSwitch?.();
         void callFetchFn(false).then(() => {
           if (aliveRef.current) scheduleNextPoll();
         });
@@ -299,7 +309,11 @@ export function usePollingLifecycle(config: PollingLifecycleConfig): PollingLife
       }
       teardownGlobalListenersIfEmpty();
     };
-  }, []);
+    // callFetchFn / scheduleNextPoll / refresh are identity-stable
+    // (`useCallback` with stable deps), so depending on them here is a no-op
+    // — they never change after first render — but listing them silences the
+    // exhaustive-deps lint.
+  }, [callFetchFn, refresh, scheduleNextPoll]);
 
   return controlRef.current;
 }

--- a/src/hooks/useProjectHealth.ts
+++ b/src/hooks/useProjectHealth.ts
@@ -35,21 +35,21 @@ export function useProjectHealth(): UseProjectHealthReturn {
 
   const polling = usePollingLifecycle({
     fetchFn: async ({ force, isInvalidated }) => {
-      const project = await projectClient.getCurrent();
-      if (!project) {
-        if (mountedRef.current) {
-          setHealth(null);
-          setError(null);
-          setLastUpdated(null);
-          lastErrorRef.current = null;
-          projectPathRef.current = null;
-        }
-        return;
-      }
-
-      if (mountedRef.current) setLoading(true);
-
       try {
+        const project = await projectClient.getCurrent();
+        if (!project) {
+          if (mountedRef.current) {
+            setHealth(null);
+            setError(null);
+            setLastUpdated(null);
+            lastErrorRef.current = null;
+            projectPathRef.current = null;
+          }
+          return;
+        }
+
+        if (mountedRef.current) setLoading(true);
+
         const result = await githubClient.getProjectHealth(project.path, force);
 
         if (!mountedRef.current) return;
@@ -69,6 +69,10 @@ export function useProjectHealth(): UseProjectHealthReturn {
           lastErrorRef.current = null;
         }
       } catch (err) {
+        // Bail when the fetch was superseded — applying the old project's
+        // error to the new project's state would surface a stale error and
+        // push `calculateNextInterval` into ERROR_BACKOFF_INTERVAL.
+        if (isInvalidated()) return;
         if (mountedRef.current) {
           const errorMessage = formatErrorMessage(err, "Failed to fetch project health");
           setError(errorMessage);
@@ -85,8 +89,14 @@ export function useProjectHealth(): UseProjectHealthReturn {
     onProjectSwitch: () => {
       if (!mountedRef.current) return;
       projectPathRef.current = null;
+      // Clear error state too — without this the previous project's failure
+      // would carry through and `calculateNextInterval` would back off the
+      // first poll of the new project by ERROR_BACKOFF_INTERVAL.
+      lastErrorRef.current = null;
       setHealth(null);
       setLastUpdated(null);
+      setError(null);
+      setLoading(false);
     },
   });
 

--- a/src/hooks/useProjectHealth.ts
+++ b/src/hooks/useProjectHealth.ts
@@ -1,7 +1,8 @@
-import { useState, useEffect, useCallback, useRef } from "react";
+import { useState, useEffect, useRef } from "react";
 import type { ProjectHealthData } from "../types";
 import { githubClient, projectClient } from "@/clients";
 import { formatErrorMessage } from "@shared/utils/errorMessage";
+import { usePollingLifecycle } from "@/hooks/usePollingLifecycle";
 
 const ACTIVE_POLL_INTERVAL = 30 * 1000;
 const IDLE_POLL_INTERVAL = 5 * 60 * 1000;
@@ -21,32 +22,19 @@ export function useProjectHealth(): UseProjectHealthReturn {
   const [error, setError] = useState<string | null>(null);
   const [lastUpdated, setLastUpdated] = useState<number | null>(null);
 
-  const pollTimerRef = useRef<NodeJS.Timeout | null>(null);
-  const isVisibleRef = useRef(!document.hidden);
   const mountedRef = useRef(true);
   const lastErrorRef = useRef<string | null>(null);
-  const inFlightRef = useRef(false);
-  const queuedFetchRef = useRef<{ pending: boolean; force: boolean }>({
-    pending: false,
-    force: false,
-  });
-  const activeFetchIdRef = useRef(0);
-  const invalidatedFetchIdRef = useRef<number | null>(null);
   const projectPathRef = useRef<string | null>(null);
 
-  const fetchHealth = useCallback(async (force = false) => {
-    if (inFlightRef.current) {
-      queuedFetchRef.current.pending = true;
-      queuedFetchRef.current.force = queuedFetchRef.current.force || force;
-      invalidatedFetchIdRef.current = activeFetchIdRef.current;
-      return;
-    }
+  useEffect(() => {
+    mountedRef.current = true;
+    return () => {
+      mountedRef.current = false;
+    };
+  }, []);
 
-    try {
-      inFlightRef.current = true;
-      activeFetchIdRef.current += 1;
-      const fetchId = activeFetchIdRef.current;
-
+  const polling = usePollingLifecycle({
+    fetchFn: async ({ force, isInvalidated }) => {
       const project = await projectClient.getCurrent();
       if (!project) {
         if (mountedRef.current) {
@@ -59,18 +47,14 @@ export function useProjectHealth(): UseProjectHealthReturn {
         return;
       }
 
-      setLoading(true);
+      if (mountedRef.current) setLoading(true);
 
-      const result = await githubClient.getProjectHealth(project.path, force);
+      try {
+        const result = await githubClient.getProjectHealth(project.path, force);
 
-      if (mountedRef.current) {
-        if (invalidatedFetchIdRef.current === fetchId) {
-          return;
-        }
-
-        if (projectPathRef.current !== null && projectPathRef.current !== project.path) {
-          return;
-        }
+        if (!mountedRef.current) return;
+        if (isInvalidated()) return;
+        if (projectPathRef.current !== null && projectPathRef.current !== project.path) return;
 
         projectPathRef.current = project.path;
 
@@ -84,144 +68,33 @@ export function useProjectHealth(): UseProjectHealthReturn {
           setError(null);
           lastErrorRef.current = null;
         }
-      }
-    } catch (err) {
-      if (mountedRef.current) {
-        const errorMessage = formatErrorMessage(err, "Failed to fetch project health");
-        setError(errorMessage);
-        lastErrorRef.current = errorMessage;
-      }
-    } finally {
-      if (mountedRef.current) {
-        setLoading(false);
-      }
-      inFlightRef.current = false;
-      if (mountedRef.current && queuedFetchRef.current.pending) {
-        const queuedForce = queuedFetchRef.current.force;
-        queuedFetchRef.current = { pending: false, force: false };
-        void fetchHealth(queuedForce);
-      }
-    }
-  }, []);
-
-  const scheduleNextPoll = useCallback(() => {
-    if (pollTimerRef.current) {
-      clearTimeout(pollTimerRef.current);
-    }
-
-    let interval = isVisibleRef.current ? ACTIVE_POLL_INTERVAL : IDLE_POLL_INTERVAL;
-    if (lastErrorRef.current) {
-      interval = ERROR_BACKOFF_INTERVAL;
-    }
-
-    pollTimerRef.current = setTimeout(() => {
-      fetchHealth().then(() => {
+      } catch (err) {
         if (mountedRef.current) {
-          scheduleNextPoll();
+          const errorMessage = formatErrorMessage(err, "Failed to fetch project health");
+          setError(errorMessage);
+          lastErrorRef.current = errorMessage;
         }
-      });
-    }, interval);
-  }, [fetchHealth]);
-
-  const refresh = useCallback(
-    async (options?: { force?: boolean }) => {
-      if (pollTimerRef.current) {
-        clearTimeout(pollTimerRef.current);
-        pollTimerRef.current = null;
-      }
-      await fetchHealth(options?.force ?? false);
-      if (mountedRef.current) {
-        scheduleNextPoll();
+      } finally {
+        if (mountedRef.current) setLoading(false);
       }
     },
-    [fetchHealth, scheduleNextPoll]
-  );
-
-  useEffect(() => {
-    const handleVisibilityChange = () => {
-      isVisibleRef.current = !document.hidden;
-
-      if (pollTimerRef.current) {
-        clearTimeout(pollTimerRef.current);
-        pollTimerRef.current = null;
-      }
-
-      if (isVisibleRef.current) {
-        fetchHealth().then(() => {
-          if (mountedRef.current) {
-            scheduleNextPoll();
-          }
-        });
-      } else {
-        scheduleNextPoll();
-      }
-    };
-
-    document.addEventListener("visibilitychange", handleVisibilityChange);
-
-    return () => {
-      document.removeEventListener("visibilitychange", handleVisibilityChange);
-    };
-  }, [fetchHealth, scheduleNextPoll]);
-
-  useEffect(() => {
-    mountedRef.current = true;
-
-    return () => {
-      mountedRef.current = false;
-      queuedFetchRef.current = { pending: false, force: false };
-      invalidatedFetchIdRef.current = null;
-      if (pollTimerRef.current) {
-        clearTimeout(pollTimerRef.current);
-      }
-    };
-  }, []);
-
-  useEffect(() => {
-    fetchHealth().then(() => {
-      if (mountedRef.current) {
-        scheduleNextPoll();
-      }
-    });
-  }, [fetchHealth, scheduleNextPoll]);
-
-  useEffect(() => {
-    const handleSidebarRefresh = () => {
-      void refresh({ force: true });
-    };
-    window.addEventListener("daintree:refresh-sidebar", handleSidebarRefresh);
-    return () => {
-      window.removeEventListener("daintree:refresh-sidebar", handleSidebarRefresh);
-    };
-  }, [refresh]);
-
-  useEffect(() => {
-    const cleanup = projectClient.onSwitch(() => {
-      if (pollTimerRef.current) {
-        clearTimeout(pollTimerRef.current);
-        pollTimerRef.current = null;
-      }
-
+    calculateNextInterval: ({ isVisible }) => {
+      if (lastErrorRef.current) return ERROR_BACKOFF_INTERVAL;
+      return isVisible ? ACTIVE_POLL_INTERVAL : IDLE_POLL_INTERVAL;
+    },
+    onProjectSwitch: () => {
+      if (!mountedRef.current) return;
       projectPathRef.current = null;
-
       setHealth(null);
       setLastUpdated(null);
-
-      fetchHealth().then(() => {
-        if (mountedRef.current) {
-          scheduleNextPoll();
-        }
-      });
-    });
-
-    return cleanup;
-  }, [fetchHealth, scheduleNextPoll]);
+    },
+  });
 
   return {
     health,
     loading,
     error,
     lastUpdated,
-    refresh,
+    refresh: polling.refresh,
   };
 }

--- a/src/hooks/useRepositoryStats.ts
+++ b/src/hooks/useRepositoryStats.ts
@@ -193,22 +193,22 @@ export function useRepositoryStats(): UseRepositoryStatsReturn {
 
   const polling = usePollingLifecycle({
     fetchFn: async ({ force, isInvalidated }) => {
-      const project = await projectClient.getCurrent();
-      if (!project) {
-        if (mountedRef.current) {
-          setStats(null);
-          setError(null);
-          setIsStale(false);
-          lastUpdatedRef.current = null;
-          setLastUpdated(null);
-          lastErrorRef.current = null;
-        }
-        return;
-      }
-
-      if (mountedRef.current) setLoading(true);
-
       try {
+        const project = await projectClient.getCurrent();
+        if (!project) {
+          if (mountedRef.current) {
+            setStats(null);
+            setError(null);
+            setIsStale(false);
+            lastUpdatedRef.current = null;
+            setLastUpdated(null);
+            lastErrorRef.current = null;
+          }
+          return;
+        }
+
+        if (mountedRef.current) setLoading(true);
+
         const repoStats = await githubClient.getRepoStats(project.path, force);
 
         if (!mountedRef.current) return;
@@ -224,6 +224,10 @@ export function useRepositoryStats(): UseRepositoryStatsReturn {
 
         applyStatsResult(repoStats, { projectPath: project.path });
       } catch (err) {
+        // Bail when the fetch was superseded — applying the old project's
+        // error to the new project's state would surface a stale error and
+        // push `calculateNextInterval` into ERROR_BACKOFF_INTERVAL.
+        if (isInvalidated()) return;
         if (mountedRef.current) {
           const errorMessage = formatErrorMessage(err, "Failed to fetch repository stats");
           setError(errorMessage);

--- a/src/hooks/useRepositoryStats.ts
+++ b/src/hooks/useRepositoryStats.ts
@@ -5,6 +5,7 @@ import { isTokenRelatedError } from "@/lib/githubErrors";
 import { formatErrorMessage } from "@shared/utils/errorMessage";
 import { buildCacheKey, getCache, setCache } from "@/lib/githubResourceCache";
 import { useGlobalMinuteTicker } from "@/hooks/useGlobalMinuteTicker";
+import { usePollingLifecycle } from "@/hooks/usePollingLifecycle";
 
 function isValidPagePayload(page: unknown): page is {
   items: unknown[];
@@ -108,17 +109,15 @@ export function useRepositoryStats(): UseRepositoryStatsReturn {
     projectPath: string | null;
   }>({ issueCount: null, prCount: null, projectPath: null });
 
-  const pollTimerRef = useRef<NodeJS.Timeout | null>(null);
-  const isVisibleRef = useRef(!document.hidden);
   const mountedRef = useRef(true);
   const lastErrorRef = useRef<string | null>(null);
-  const inFlightRef = useRef(false);
-  const queuedFetchRef = useRef<{ pending: boolean; force: boolean }>({
-    pending: false,
-    force: false,
-  });
-  const activeFetchIdRef = useRef(0);
-  const invalidatedFetchIdRef = useRef<number | null>(null);
+
+  useEffect(() => {
+    mountedRef.current = true;
+    return () => {
+      mountedRef.current = false;
+    };
+  }, []);
 
   // Apply a `RepositoryStats` result to local state — shared by the network
   // fetch path (`fetchStats`) and the broadcast push path
@@ -192,52 +191,38 @@ export function useRepositoryStats(): UseRepositoryStatsReturn {
     []
   );
 
-  const fetchStats = useCallback(
-    async (force = false) => {
-      if (inFlightRef.current) {
-        queuedFetchRef.current.pending = true;
-        queuedFetchRef.current.force = queuedFetchRef.current.force || force;
-        invalidatedFetchIdRef.current = activeFetchIdRef.current;
+  const polling = usePollingLifecycle({
+    fetchFn: async ({ force, isInvalidated }) => {
+      const project = await projectClient.getCurrent();
+      if (!project) {
+        if (mountedRef.current) {
+          setStats(null);
+          setError(null);
+          setIsStale(false);
+          lastUpdatedRef.current = null;
+          setLastUpdated(null);
+          lastErrorRef.current = null;
+        }
         return;
       }
 
-      try {
-        inFlightRef.current = true;
-        activeFetchIdRef.current += 1;
-        const fetchId = activeFetchIdRef.current;
+      if (mountedRef.current) setLoading(true);
 
-        const project = await projectClient.getCurrent();
-        if (!project) {
-          if (mountedRef.current) {
-            setStats(null);
-            setError(null);
-            setIsStale(false);
-            lastUpdatedRef.current = null;
-            setLastUpdated(null);
-            lastErrorRef.current = null;
-          }
+      try {
+        const repoStats = await githubClient.getRepoStats(project.path, force);
+
+        if (!mountedRef.current) return;
+        if (isInvalidated()) return;
+
+        // Ignore results from previous project (race condition protection)
+        if (
+          lastKnownCountsRef.current.projectPath !== null &&
+          lastKnownCountsRef.current.projectPath !== project.path
+        ) {
           return;
         }
 
-        setLoading(true);
-
-        const repoStats = await githubClient.getRepoStats(project.path, force);
-
-        if (mountedRef.current) {
-          if (invalidatedFetchIdRef.current === fetchId) {
-            return;
-          }
-
-          // Ignore results from previous project (race condition protection)
-          if (
-            lastKnownCountsRef.current.projectPath !== null &&
-            lastKnownCountsRef.current.projectPath !== project.path
-          ) {
-            return;
-          }
-
-          applyStatsResult(repoStats, { projectPath: project.path });
-        }
+        applyStatsResult(repoStats, { projectPath: project.path });
       } catch (err) {
         if (mountedRef.current) {
           const errorMessage = formatErrorMessage(err, "Failed to fetch repository stats");
@@ -245,123 +230,19 @@ export function useRepositoryStats(): UseRepositoryStatsReturn {
           lastErrorRef.current = errorMessage;
         }
       } finally {
-        if (mountedRef.current) {
-          setLoading(false);
-        }
-        inFlightRef.current = false;
-        if (mountedRef.current && queuedFetchRef.current.pending) {
-          const queuedForce = queuedFetchRef.current.force;
-          queuedFetchRef.current = { pending: false, force: false };
-          void fetchStats(queuedForce);
-        }
+        if (mountedRef.current) setLoading(false);
       }
     },
-    [applyStatsResult]
-  );
-
-  const scheduleNextPoll = useCallback(() => {
-    if (pollTimerRef.current) {
-      clearTimeout(pollTimerRef.current);
-    }
-
-    let interval = isVisibleRef.current ? ACTIVE_POLL_INTERVAL : IDLE_POLL_INTERVAL;
-    if (lastErrorRef.current) {
-      interval = ERROR_BACKOFF_INTERVAL;
-    }
-
-    const resetAt = rateLimitResetAtRef.current;
-    if (resetAt !== null && resetAt > Date.now()) {
-      interval = resetAt - Date.now() + RATE_LIMIT_RESUME_BUFFER_MS;
-    }
-
-    pollTimerRef.current = setTimeout(() => {
-      fetchStats().then(() => {
-        if (mountedRef.current) {
-          scheduleNextPoll();
-        }
-      });
-    }, interval);
-  }, [fetchStats]);
-
-  const refresh = useCallback(
-    async (options?: { force?: boolean }) => {
-      if (pollTimerRef.current) {
-        clearTimeout(pollTimerRef.current);
-        pollTimerRef.current = null;
+    calculateNextInterval: ({ isVisible }) => {
+      const resetAt = rateLimitResetAtRef.current;
+      if (resetAt !== null && resetAt > Date.now()) {
+        return resetAt - Date.now() + RATE_LIMIT_RESUME_BUFFER_MS;
       }
-      await fetchStats(options?.force ?? false);
-      if (mountedRef.current) {
-        scheduleNextPoll();
-      }
+      if (lastErrorRef.current) return ERROR_BACKOFF_INTERVAL;
+      return isVisible ? ACTIVE_POLL_INTERVAL : IDLE_POLL_INTERVAL;
     },
-    [fetchStats, scheduleNextPoll]
-  );
-
-  useEffect(() => {
-    const handleVisibilityChange = () => {
-      isVisibleRef.current = !document.hidden;
-
-      if (pollTimerRef.current) {
-        clearTimeout(pollTimerRef.current);
-        pollTimerRef.current = null;
-      }
-
-      if (isVisibleRef.current) {
-        fetchStats().then(() => {
-          if (mountedRef.current) {
-            scheduleNextPoll();
-          }
-        });
-      } else {
-        scheduleNextPoll();
-      }
-    };
-
-    document.addEventListener("visibilitychange", handleVisibilityChange);
-
-    return () => {
-      document.removeEventListener("visibilitychange", handleVisibilityChange);
-    };
-  }, [fetchStats, scheduleNextPoll]);
-
-  useEffect(() => {
-    mountedRef.current = true;
-
-    return () => {
-      mountedRef.current = false;
-      queuedFetchRef.current = { pending: false, force: false };
-      invalidatedFetchIdRef.current = null;
-      if (pollTimerRef.current) {
-        clearTimeout(pollTimerRef.current);
-      }
-    };
-  }, []);
-
-  useEffect(() => {
-    fetchStats().then(() => {
-      if (mountedRef.current) {
-        scheduleNextPoll();
-      }
-    });
-  }, [fetchStats, scheduleNextPoll]);
-
-  useEffect(() => {
-    const handleSidebarRefresh = () => {
-      void refresh({ force: true });
-    };
-    window.addEventListener("daintree:refresh-sidebar", handleSidebarRefresh);
-    return () => {
-      window.removeEventListener("daintree:refresh-sidebar", handleSidebarRefresh);
-    };
-  }, [refresh]);
-
-  useEffect(() => {
-    const cleanup = projectClient.onSwitch(() => {
-      if (pollTimerRef.current) {
-        clearTimeout(pollTimerRef.current);
-        pollTimerRef.current = null;
-      }
-
+    onProjectSwitch: () => {
+      if (!mountedRef.current) return;
       // Clear preserved counts on project switch to prevent cross-contamination
       lastKnownCountsRef.current = { issueCount: null, prCount: null, projectPath: null };
       hasAppliedResultRef.current = false;
@@ -378,16 +259,8 @@ export function useRepositoryStats(): UseRepositoryStatsReturn {
       // freshness tier as `errored` until its first poll completes.
       setError(null);
       lastErrorRef.current = null;
-
-      fetchStats().then(() => {
-        if (mountedRef.current) {
-          scheduleNextPoll();
-        }
-      });
-    });
-
-    return cleanup;
-  }, [fetchStats, scheduleNextPoll]);
+    },
+  });
 
   // Cold-start hydration: before the first poll completes, ask main for the
   // disk-persisted first page so the very first dropdown click after launch
@@ -551,29 +424,18 @@ export function useRepositoryStats(): UseRepositoryStatsReturn {
       setRateLimitResetAt(nextResetAt);
       setRateLimitKind(nextKind);
 
-      // Cancel any pending poll scheduled against the old state so it
-      // can't race with the state-change handler (e.g. firing a
-      // redundant fetch right after our immediate refresh kicks off).
-      if (pollTimerRef.current) {
-        clearTimeout(pollTimerRef.current);
-        pollTimerRef.current = null;
-      }
-
       // When the limit clears, run an immediate refresh so the UI updates
-      // without waiting a full poll interval; otherwise reschedule against
-      // the new resume time.
+      // without waiting a full poll interval; `refresh` clears the timer,
+      // fetches, and reschedules against the new rate-limit-aware interval.
+      // When blocked, just reschedule against the new resume time.
       if (!payload.blocked) {
-        void fetchStats().then(() => {
-          if (mountedRef.current) {
-            scheduleNextPoll();
-          }
-        });
-      } else if (mountedRef.current) {
-        scheduleNextPoll();
+        void polling.refresh();
+      } else {
+        polling.scheduleNextPoll();
       }
     });
     return cleanup;
-  }, [fetchStats, scheduleNextPoll]);
+  }, [polling]);
 
   const isTokenError = isTokenRelatedError(error);
 
@@ -630,6 +492,6 @@ export function useRepositoryStats(): UseRepositoryStatsReturn {
     rateLimitResetAt,
     rateLimitKind,
     freshnessLevel,
-    refresh,
+    refresh: polling.refresh,
   };
 }


### PR DESCRIPTION
## Summary

Closes #8070.

`useRepositoryStats` and `useProjectHealth` each independently implement the same polling lifecycle — identical `inFlightRef` / `queuedFetchRef` / `activeFetchIdRef` / `invalidatedFetchIdRef` machinery, identical `visibilitychange` / `daintree:refresh-sidebar` / `projectClient.onSwitch` wiring, identical 30s/5min/2min interval tiers. The duplication means a tab resume fires two parallel listeners that each kick off their own GitHub request when one coordinated pass would do.

This extracts the lifecycle into `src/hooks/usePollingLifecycle.ts` and rewrites both consumers on top of it. The new primitive owns the timer, in-flight guard, queue, and fetch-id invalidation. A module-level subscriber Set coalesces the three global triggers — every consumer shares one `visibilitychange`, one `daintree:refresh-sidebar`, and one `projectClient.onSwitch` registration each. Mirrors the refcounted-listener pattern from `useGlobalMinuteTicker.ts`.

`useRepositoryStats`'s exclusive extras — rate-limit-aware scheduling (`calculateNextInterval` reads `rateLimitResetAtRef`), the `onRateLimitChanged` and `onRepoStatsAndPageUpdated` broadcast subscriptions, cold-start disk hydration, `applyStatsResult`, freshness tiers — all stay in the consumer. The primitive emits zero re-renders and doesn't own state. Public return shapes (`UseRepositoryStatsReturn`, `UseProjectHealthReturn`) are unchanged.

## Key changes

- **`src/hooks/usePollingLifecycle.ts`** (new, ~280 lines) — primitive with `fetchFn({ force, fetchId, isInvalidated })`, `calculateNextInterval({ isVisible })`, optional `onProjectSwitch`. Returns stable `{ scheduleNextPoll, refresh }`. Module-level singleton + lazy install + last-subscriber teardown. Latest-config ref pattern (configRef + `useCallback([])`) so the public functions can be returned without tripping the `react-hooks/rules-of-hooks` rule that forbids assigning/returning `useEffectEvent` results.
- **`src/hooks/useProjectHealth.ts`** (228 → ~110 lines) — refactored. Keeps `mountedRef`, `lastErrorRef`, `projectPathRef`, all state, public return shape unchanged.
- **`src/hooks/useRepositoryStats.ts`** (636 → ~470 lines) — refactored. Preserves every extra; rate-limit IPC subscription now drives `polling.refresh()` / `polling.scheduleNextPoll()`.

## Hardening from review

Three correctness fixes surfaced during review:

1. **Polling-death on `fetchFn` rejection** — `.then(scheduleNextPoll)` chains had no `.catch`, so an uncaught throw (e.g. an IPC failure on `projectClient.getCurrent()` outside the consumer's inner `try`) would silently freeze the lifecycle until the next external trigger. The primitive now wraps the `fetchFn` invocation in `try/catch` so `callFetchFn` always resolves; consumers still own error-to-state mapping.
2. **Stale error carried across project switch in `useProjectHealth`** — the consumer's `onProjectSwitch` only cleared `health`/`lastUpdated`, leaving `lastErrorRef.current` set. The first poll of the new project would then be delayed by `ERROR_BACKOFF_INTERVAL` (2 min). Now mirrors `useRepositoryStats`'s error reset.
3. **Invalidated fetch's error applied to new project's state** — both consumers checked `isInvalidated()` on the success path but not in the `catch` block, so a late rejection from a superseded project could paint the new project's view with the old error. Guarded both `catch` blocks.

Also made `ensureGlobalListenersInstalled` atomic — IPC subscription first; if it throws, abort before installing DOM listeners so a retry on the next subscribe works.

## Test plan

- [x] `npx vitest run src/hooks/__tests__/usePollingLifecycle.test.tsx src/hooks/__tests__/useProjectHealth.test.tsx src/hooks/__tests__/useRepositoryStats.test.tsx` — 56 tests pass
- [x] `npm run check` — typecheck, lint, format, build, channels, ipc, help all clean (lint warnings dropped 11 from baseline)
- [x] New focused tests for the primitive: singleton refcount + install/teardown, fan-out to all subscribers, queue + invalidation, control stability, fetchFn-rejection resilience, post-rejection refresh, per-subscriber failure isolation
- [x] New focused tests for `useProjectHealth`: fetch-on-mount, no-project clearing, error surface, project switch reset+refetch, sidebar refresh-force, refresh propagation, error-cleared-on-switch (regression for fix #2), invalidated-catch-not-applied (regression for fix #3)
- [x] All 32 existing `useRepositoryStats` tests still pass unchanged