### PR TITLE
fix(agent-button): polish tooltip and aria copy

### DIFF
--- a/src/components/Layout/AgentButton.tsx
+++ b/src/components/Layout/AgentButton.tsx
@@ -270,14 +270,14 @@ export function AgentButton({
 
   const presetSegment = activePresetName ? ` · ${activePresetName}` : "";
   const tooltipLabel = isLoading
-    ? `Checking ${config.name} CLI availability...`
+    ? `Checking ${config.name} CLI…`
     : isLaunchable
       ? signInUnconfirmed
         ? `Start ${config.name}${presetSegment} — sign-in not detected`
         : `Start ${config.name}${presetSegment}${tooltipDetails}`
       : needsSetup
-        ? `${config.name} needs setup. Click to configure.`
-        : `${config.name} CLI not found. Click to install.`;
+        ? `Configure ${config.name}`
+        : `Install ${config.name} CLI`;
   const tooltipShortcut = isLaunchable ? displayCombo : undefined;
   const chevronTooltip = isLoading
     ? `Checking ${config.name} CLI availability...`
@@ -292,12 +292,12 @@ export function AgentButton({
   const isChevronDisabled = isLoading || !isLaunchable;
 
   const ariaLabel = isLoading
-    ? `Checking ${config.name} availability`
+    ? `Checking ${config.name} CLI`
     : isLaunchable
-      ? `Start ${config.name} Agent`
+      ? `Start ${config.name}`
       : needsSetup
-        ? `${config.name} needs setup`
-        : `${config.name} CLI not installed`;
+        ? `Configure ${config.name}`
+        : `Install ${config.name} CLI`;
 
   const handleClick = () => {
     if (isLoading) return;

--- a/src/components/Layout/__tests__/AgentButton.test.tsx
+++ b/src/components/Layout/__tests__/AgentButton.test.tsx
@@ -1169,4 +1169,88 @@ describe("AgentButton preset UX", () => {
       }
     });
   });
+
+  describe("tooltip and aria copy (issue #8173)", () => {
+    function tooltipTexts(getAllByTestId: (id: string) => HTMLElement[]): string[] {
+      return getAllByTestId("tooltip-content").map((el) => el.textContent ?? "");
+    }
+
+    it("loading tooltip uses the Unicode ellipsis and the aria-label omits it", () => {
+      mockMergedPresetsFn = () => [];
+
+      const { getByRole, getAllByTestId } = render(
+        <AgentButton type="claude" availability={undefined} />
+      );
+
+      // Tooltip carries U+2026, no redundant "availability", no ASCII "...".
+      expect(tooltipTexts(getAllByTestId)).toContain("Checking Claude CLI…");
+      // Aria-label is the plain accessible name — punctuation glyphs like the
+      // ellipsis are meaningless to screen readers and must not leak in.
+      expect(getByRole("button").getAttribute("aria-label")).toBe("Checking Claude CLI");
+    });
+
+    it("loading copy holds in the split-button (with-presets) branch", () => {
+      mockMergedPresetsFn = () => [{ id: "p", name: "P" }];
+
+      const { getByTestId, getAllByRole, getAllByTestId } = render(
+        <AgentButton type="claude" availability={undefined} />
+      );
+
+      expect(tooltipTexts(getAllByTestId)).toContain("Checking Claude CLI…");
+      const chevronIcon = getByTestId("chevron-icon");
+      const primary = getAllByRole("button").find((b) => !b.contains(chevronIcon));
+      expect(primary!.getAttribute("aria-label")).toBe("Checking Claude CLI");
+    });
+
+    it("non-launchable copy is verb-noun with no gesture language", () => {
+      const cases: Array<[string, string]> = [
+        ["missing", "Install Claude CLI"],
+        ["installed", "Configure Claude"],
+        ["blocked", "Configure Claude"],
+      ];
+      for (const [state, expected] of cases) {
+        mockMergedPresetsFn = () => [];
+        const { getByRole, getAllByTestId, unmount } = render(
+          <AgentButton
+            type="claude"
+            availability={state as unknown as CliAvailability[string]}
+          />
+        );
+        expect(tooltipTexts(getAllByTestId)).toContain(expected);
+        expect(getByRole("button").getAttribute("aria-label")).toBe(expected);
+        unmount();
+      }
+    });
+
+    it("ready aria-label drops the redundant 'Agent' suffix", () => {
+      mockMergedPresetsFn = () => [];
+
+      const { getByRole } = render(
+        <AgentButton type="claude" availability={"ready" as unknown as CliAvailability[string]} />
+      );
+
+      expect(getByRole("button").getAttribute("aria-label")).toBe("Start Claude");
+    });
+
+    it("unauthenticated state keeps the aria-label clean while the tooltip carries the sign-in cue", () => {
+      mockSettings = settingsWith({ claude: { presetId: "user-blue" } });
+      mockMergedPresetsFn = () => [{ id: "user-blue", name: "Blue" }];
+
+      const { getByTestId, getAllByRole, getAllByTestId } = render(
+        <AgentButton
+          type="claude"
+          availability={"unauthenticated" as unknown as CliAvailability[string]}
+        />
+      );
+
+      const launchTooltip = tooltipTexts(getAllByTestId).find((t) => t.startsWith("Start "));
+      expect(launchTooltip).toContain("sign-in not detected");
+
+      const chevronIcon = getByTestId("chevron-icon");
+      const primary = getAllByRole("button").find((b) => !b.contains(chevronIcon));
+      // The sign-in suffix is a tooltip-only cue; it must not bleed into the
+      // accessible name.
+      expect(primary!.getAttribute("aria-label")).toBe("Start Claude");
+    });
+  });
 });

--- a/src/components/Layout/__tests__/AgentButton.test.tsx
+++ b/src/components/Layout/__tests__/AgentButton.test.tsx
@@ -1211,10 +1211,7 @@ describe("AgentButton preset UX", () => {
       for (const [state, expected] of cases) {
         mockMergedPresetsFn = () => [];
         const { getByRole, getAllByTestId, unmount } = render(
-          <AgentButton
-            type="claude"
-            availability={state as unknown as CliAvailability[string]}
-          />
+          <AgentButton type="claude" availability={state as unknown as CliAvailability[string]} />
         );
         expect(tooltipTexts(getAllByTestId)).toContain(expected);
         expect(getByRole("button").getAttribute("aria-label")).toBe(expected);


### PR DESCRIPTION
## Summary

- Copy-only fix to the `AgentButton` tooltip and `aria-label` strings — no behavioural changes
- Loading tooltip drops the redundant word "availability" and switches to a Unicode ellipsis (`…`) to match the parallel state in `AgentTrayButton`
- Needs-setup and missing-binary tooltips rewritten as verb-noun imperatives (`Configure ${name}`, `Install ${name} CLI`) — no trailing periods, no gesture instructions
- `aria-label` ternary brought into alignment with the visible tooltip so screen-reader announcements match what sighted users see

Resolves #8173

## Changes

- `src/components/Layout/AgentButton.tsx` — 7 string literals updated across the `tooltipLabel` and `ariaLabel` ternaries
- `src/components/Layout/__tests__/AgentButton.test.tsx` — 5 copy-pin tests added under "tooltip and aria copy (issue #8173)"

## Testing

52/52 unit tests pass. `npm run check` clean (no errors, warnings are pre-existing).