### PR TITLE
fix(worktree): align Finished filter circle and arm button with complete blue

### DIFF
--- a/src/components/Sidebar/SidebarContent.tsx
+++ b/src/components/Sidebar/SidebarContent.tsx
@@ -818,7 +818,7 @@ function SidebarContent({ onOpenOverview }: SidebarContentProps) {
           }}
           className={`inline-flex items-center justify-center self-stretch px-1.5 transition-colors focus-visible:outline focus-visible:outline-2 focus-visible:-outline-offset-2 focus-visible:outline-daintree-accent ${
             canArmMatching
-              ? "text-daintree-text/60 hover:text-daintree-text hover:bg-tint/[0.06]"
+              ? "text-category-blue hover:text-category-blue/80 hover:bg-tint/[0.06]"
               : "text-daintree-text/25 cursor-not-allowed"
           }`}
           aria-label={armMatchingLabel}

--- a/src/components/Worktree/QuickStateFilterBar.tsx
+++ b/src/components/Worktree/QuickStateFilterBar.tsx
@@ -17,7 +17,7 @@ const FILTER_VISUALS: Record<
 > = {
   working: { Icon: HollowCircle, color: STATE_COLORS.working },
   waiting: { Icon: HollowCircle, color: STATE_COLORS.waiting },
-  finished: { Icon: HollowCircle, color: STATE_COLORS.completed },
+  finished: { Icon: HollowCircle, color: "text-category-blue" },
 };
 
 interface QuickStateFilterBarProps {


### PR DESCRIPTION
## Summary

- The Finished filter circle in `QuickStateFilterBar` and the arm-matching Zap button in `SidebarContent` were using the wrong color tokens — they now use `text-category-blue` to match the `bg-category-blue` corner chip on `WorktreeCard`
- `STATE_COLORS.completed` stays `text-category-slate` for the in-card agent-state icon, which is a separate context and shouldn't change

Resolves #8184

## Changes

- `src/components/Worktree/QuickStateFilterBar.tsx` — Finished filter circle: hardcoded `text-category-blue` instead of `STATE_COLORS.completed`
- `src/components/Sidebar/SidebarContent.tsx` — arm-matching Zap button: `text-category-blue` instead of `text-daintree-text/60`

## Testing

- vitest: 25 tests pass across `QuickStateFilterBar` and `terminalStateConfig` (confirms `STATE_COLORS.completed` is unchanged)
- typecheck, lint ratchet (-8 warnings), format check, and build all pass