### PR TITLE
fix(notifications): polish bell microcopy and announce DND transitions

### DIFF
--- a/src/components/Layout/NotificationCenterToolbarButton.tsx
+++ b/src/components/Layout/NotificationCenterToolbarButton.tsx
@@ -178,13 +178,21 @@ export function NotificationCenterToolbarButton({
   useEffect(() => {
     const prev = prevDndActiveRef.current;
     prevDndActiveRef.current = isDndActive;
+    if (!notificationsEnabled) {
+      // Bell is hidden; clear any prior announcement so it doesn't surface as
+      // stale text the next time notifications are re-enabled.
+      setDndAnnouncement("");
+      return;
+    }
     if (prev === isDndActive) return;
     if (isDndActive) {
-      setDndAnnouncement(isScheduledMuted ? "Quiet hours active" : "Notifications paused");
+      // Mirror the aria-label priority: isSessionMuted wins when both sources
+      // overlap, so the live region and the button label agree on the reason.
+      setDndAnnouncement(isSessionMuted ? "Notifications paused" : "Quiet hours active");
     } else {
       setDndAnnouncement("Notifications resumed");
     }
-  }, [isDndActive, isScheduledMuted]);
+  }, [isDndActive, isSessionMuted, notificationsEnabled]);
 
   if (!notificationsEnabled) return null;
 

--- a/src/components/Layout/NotificationCenterToolbarButton.tsx
+++ b/src/components/Layout/NotificationCenterToolbarButton.tsx
@@ -170,13 +170,29 @@ export function NotificationCenterToolbarButton({
     return () => clearTimeout(timer);
   }, [isBellBlipping]);
 
+  // Screen-reader announcement on DND start / end transitions. Initialize the
+  // ref to `isDndActive` so mounting while DND is already active does not
+  // synthesize a spurious "Notifications resumed" announcement.
+  const prevDndActiveRef = useRef(isDndActive);
+  const [dndAnnouncement, setDndAnnouncement] = useState("");
+  useEffect(() => {
+    const prev = prevDndActiveRef.current;
+    prevDndActiveRef.current = isDndActive;
+    if (prev === isDndActive) return;
+    if (isDndActive) {
+      setDndAnnouncement(isScheduledMuted ? "Quiet hours active" : "Notifications paused");
+    } else {
+      setDndAnnouncement("Notifications resumed");
+    }
+  }, [isDndActive, isScheduledMuted]);
+
   if (!notificationsEnabled) return null;
 
   const label = (() => {
     if (isSessionMuted) {
-      return `Notifications — muted until ${timeFormatter.format(new Date(quietUntil))}`;
+      return `Notifications — paused until ${timeFormatter.format(new Date(quietUntil))}`;
     }
-    if (isScheduledMuted) return "Notifications — scheduled quiet hours";
+    if (isScheduledMuted) return "Notifications — quiet hours active";
     if (notificationUnreadCount > 0) return `Notifications — ${notificationUnreadCount} unread`;
     return "Notifications";
   })();
@@ -226,6 +242,15 @@ export function NotificationCenterToolbarButton({
       >
         <NotificationCenter open={notificationCenterOpen} onClose={closeNotificationCenter} />
       </FixedDropdown>
+      <span
+        data-testid="notification-dnd-announcement"
+        className="sr-only"
+        role="status"
+        aria-live="polite"
+        aria-atomic="true"
+      >
+        {dndAnnouncement}
+      </span>
     </div>
   );
 }

--- a/src/components/Layout/__tests__/NotificationCenterToolbarButton.test.tsx
+++ b/src/components/Layout/__tests__/NotificationCenterToolbarButton.test.tsx
@@ -200,12 +200,12 @@ describe("NotificationCenterToolbarButton — DND state surface", () => {
       const { container } = render(<NotificationCenterToolbarButton />);
       const btn = container.querySelector("button")!;
       const label = btn.getAttribute("aria-label") ?? "";
-      expect(label.startsWith("Notifications — muted until ")).toBe(true);
+      expect(label.startsWith("Notifications — paused until ")).toBe(true);
       // Match either 12h ("2:30") or 24h ("14:30") locale outputs.
       expect(label).toMatch(/(?:^|[^0-9])(?:14|2):30/);
     });
 
-    it("says 'scheduled quiet hours' during the configured window", () => {
+    it("says 'quiet hours active' during the configured window", () => {
       vi.useFakeTimers();
       vi.setSystemTime(new Date(2024, 0, 1, 23, 0));
       useNotificationSettingsStore.setState({
@@ -215,7 +215,7 @@ describe("NotificationCenterToolbarButton — DND state surface", () => {
       });
       const { container } = render(<NotificationCenterToolbarButton />);
       const btn = container.querySelector("button")!;
-      expect(btn.getAttribute("aria-label")).toBe("Notifications — scheduled quiet hours");
+      expect(btn.getAttribute("aria-label")).toBe("Notifications — quiet hours active");
     });
 
     it("session mute label takes priority over unread count", () => {
@@ -227,7 +227,7 @@ describe("NotificationCenterToolbarButton — DND state surface", () => {
       });
       const { container } = render(<NotificationCenterToolbarButton />);
       const btn = container.querySelector("button")!;
-      expect(btn.getAttribute("aria-label")).toMatch(/^Notifications — muted until /);
+      expect(btn.getAttribute("aria-label")).toMatch(/^Notifications — paused until /);
     });
 
     it("button carries data-dnd-active='true' while DND is active", () => {
@@ -580,6 +580,71 @@ describe("NotificationCenterToolbarButton — DND state surface", () => {
         "animate-activity-blip"
       );
       vi.useRealTimers();
+    });
+  });
+
+  // Issue #8178 — screen-reader users get no signal when DND ends because the
+  // BellOff → Bell icon swap is purely visual. A polite live region announces
+  // transitions in both directions so SR users hear the state change.
+  describe("DND screen-reader announcement (issue #8178)", () => {
+    it("renders empty on mount with DND inactive", () => {
+      const { getByTestId } = render(<NotificationCenterToolbarButton />);
+      const announcement = getByTestId("notification-dnd-announcement");
+      expect(announcement.textContent).toBe("");
+      expect(announcement.getAttribute("role")).toBe("status");
+      expect(announcement.getAttribute("aria-live")).toBe("polite");
+    });
+
+    it("renders empty on mount while DND is already active (no spurious announcement)", () => {
+      useNotificationSettingsStore.setState({ quietUntil: Date.now() + 60 * 60 * 1000 });
+      const { getByTestId } = render(<NotificationCenterToolbarButton />);
+      expect(getByTestId("notification-dnd-announcement").textContent).toBe("");
+    });
+
+    it("announces 'Notifications paused' when session mute begins", async () => {
+      const { getByTestId } = render(<NotificationCenterToolbarButton />);
+      await act(async () => {
+        useNotificationSettingsStore.setState({ quietUntil: Date.now() + 60 * 60 * 1000 });
+      });
+      expect(getByTestId("notification-dnd-announcement").textContent).toBe("Notifications paused");
+    });
+
+    it("announces 'Quiet hours active' when scheduled quiet hours begin", async () => {
+      vi.useFakeTimers();
+      vi.setSystemTime(new Date(2024, 0, 1, 21, 59, 30));
+      useNotificationSettingsStore.setState({
+        quietHoursEnabled: true,
+        quietHoursStartMin: 22 * 60,
+        quietHoursEndMin: 6 * 60,
+      });
+      const { getByTestId } = render(<NotificationCenterToolbarButton />);
+      // Not yet in the window.
+      expect(getByTestId("notification-dnd-announcement").textContent).toBe("");
+
+      // Cross 22:00 — minute-poll re-arm fires and DND flips active.
+      await act(async () => {
+        await vi.advanceTimersByTimeAsync(31_000);
+      });
+      expect(getByTestId("notification-dnd-announcement").textContent).toBe("Quiet hours active");
+    });
+
+    it("announces 'Notifications resumed' when DND ends", async () => {
+      vi.useFakeTimers();
+      vi.setSystemTime(new Date(2024, 0, 1, 12, 0));
+      useNotificationSettingsStore.setState({
+        quietUntil: new Date(2024, 0, 1, 12, 0, 30).getTime(),
+      });
+      const { getByTestId } = render(<NotificationCenterToolbarButton />);
+      // Mounted during active DND — initial render is silent.
+      expect(getByTestId("notification-dnd-announcement").textContent).toBe("");
+
+      // Advance past the session-mute expiry; boundary timer fires and DND ends.
+      await act(async () => {
+        await vi.advanceTimersByTimeAsync(31_000);
+      });
+      expect(getByTestId("notification-dnd-announcement").textContent).toBe(
+        "Notifications resumed"
+      );
     });
   });
 });

--- a/src/components/Layout/__tests__/NotificationCenterToolbarButton.test.tsx
+++ b/src/components/Layout/__tests__/NotificationCenterToolbarButton.test.tsx
@@ -336,6 +336,11 @@ describe("NotificationCenterToolbarButton — DND state surface", () => {
         configurable: true,
         writable: true,
       });
+      Object.defineProperty(document, "visibilityState", {
+        value: "visible",
+        configurable: true,
+        writable: true,
+      });
     });
 
     function fireVisibilityChange(state: DocumentVisibilityState) {


### PR DESCRIPTION
## Summary

- Renames the session-mute tooltip from `muted until` to `paused until` to match the existing inbox empty-state wording (`Notifications paused`)
- Tightens the scheduled quiet hours label from `scheduled quiet hours` to `quiet hours active` — the schedule is the configured state, so "scheduled" doesn't add anything
- Adds a visually-hidden `role="status" aria-live="polite"` announcement so screen readers hear when DND ends, matching the pattern already used in `Toolbar.tsx`, `EmptyState.tsx`, and `GitHubStatusIndicator.tsx`

Resolves #8178

## Changes

- `src/components/Layout/NotificationCenterToolbarButton.tsx` — label updates and DND-end announcement node
- `src/components/Layout/NotificationCenterToolbarButton.test.tsx` — test coverage for all three changes

## Testing

34 unit tests pass, typecheck clean, lint/format clean.