### PR TITLE
fix(toolbar): gate Copy Context spinner and sentence-case label

### DIFF
--- a/src/components/Layout/Toolbar.tsx
+++ b/src/components/Layout/Toolbar.tsx
@@ -33,7 +33,13 @@ import {
 } from "@/components/ui/dropdown-menu";
 import { useToolbarOverflow } from "@/hooks/useToolbarOverflow";
 import { useWorktreeActions } from "@/hooks/useWorktreeActions";
-import { useAriaKeyshortcuts, useKeybindingDisplay, useShortcutHintHover } from "@/hooks";
+import {
+  useAriaKeyshortcuts,
+  useDeferredLoading,
+  useKeybindingDisplay,
+  useShortcutHintHover,
+} from "@/hooks";
+import { UI_DOHERTY_THRESHOLD } from "@/lib/animationUtils";
 import type { UseProjectSwitcherPaletteReturn } from "@/hooks";
 import type { SearchableProject } from "@/hooks/useProjectSwitcherPalette";
 import { useProjectStore } from "@/store/projectStore";
@@ -212,6 +218,7 @@ export function Toolbar({
   const [isFullscreen, setIsFullscreen] = useState(false);
   const [treeCopied, setTreeCopied] = useState(false);
   const [isCopyingTree, setIsCopyingTree] = useState(false);
+  const showCopyingSpinner = useDeferredLoading(isCopyingTree, UI_DOHERTY_THRESHOLD);
   const [copyFeedback, setCopyFeedback] = useState<string>("");
   const treeCopyTimeoutRef = useRef<ReturnType<typeof setTimeout> | null>(null);
 
@@ -547,11 +554,11 @@ export function Toolbar({
                   "aria-disabled:opacity-50 aria-disabled:cursor-not-allowed"
                 )}
                 aria-label={
-                  isCopyingTree ? "Copying…" : treeCopied ? "Context Copied" : "Copy Context"
+                  isCopyingTree ? "Copying…" : treeCopied ? "Context copied" : "Copy Context"
                 }
                 aria-keyshortcuts={copyTreeAriaShortcut}
               >
-                {isCopyingTree ? <Spinner /> : treeCopied ? <Check /> : <Folders />}
+                {showCopyingSpinner ? <Spinner /> : treeCopied ? <Check /> : <Folders />}
                 {!treeCopied && !isCopyingTree && (
                   <ShortcutRevealChip actionId="worktree.copyTree" />
                 )}

--- a/src/components/Layout/Toolbar.tsx
+++ b/src/components/Layout/Toolbar.tsx
@@ -642,6 +642,7 @@ export function Toolbar({
       currentProject,
       handleCopyTreeClick,
       isCopyingTree,
+      showCopyingSpinner,
       activeWorktree,
       treeCopied,
       copyFeedback,

--- a/src/components/Layout/__tests__/Toolbar.shortcuts.test.ts
+++ b/src/components/Layout/__tests__/Toolbar.shortcuts.test.ts
@@ -208,6 +208,13 @@ describe("Toolbar shortcut tooltips — issue #3443", () => {
       expect(deps).toContain("copyTreeShortcut");
     });
 
+    it("includes showCopyingSpinner in useMemo deps (issue #8179)", () => {
+      const depsMatch = source.match(/\}\),\s*\[([^\]]+)\]\s*\);/s);
+      expect(depsMatch).not.toBeNull();
+      const deps = depsMatch![1];
+      expect(deps).toContain("showCopyingSpinner");
+    });
+
     it("diagnosticsShortcut is in ToolbarProblemsButton", () => {
       expect(problemsSource).toContain('useKeybindingDisplay("panel.toggleDiagnostics")');
     });

--- a/src/components/Layout/__tests__/Toolbar.shortcuts.test.ts
+++ b/src/components/Layout/__tests__/Toolbar.shortcuts.test.ts
@@ -163,6 +163,36 @@ describe("Toolbar shortcut tooltips — issue #3443", () => {
     });
   });
 
+  describe("copy-tree button polish — issue #8179", () => {
+    it("imports useDeferredLoading from @/hooks", () => {
+      expect(source).toMatch(/useDeferredLoading[\s\S]*?from "@\/hooks"/);
+    });
+
+    it("imports UI_DOHERTY_THRESHOLD from @/lib/animationUtils", () => {
+      expect(source).toContain('import { UI_DOHERTY_THRESHOLD } from "@/lib/animationUtils"');
+    });
+
+    it("derives showCopyingSpinner via useDeferredLoading at the Doherty threshold", () => {
+      expect(source).toContain(
+        "const showCopyingSpinner = useDeferredLoading(isCopyingTree, UI_DOHERTY_THRESHOLD);"
+      );
+    });
+
+    it("renders the spinner glyph gated on showCopyingSpinner, not raw isCopyingTree", () => {
+      expect(source).toContain(
+        "{showCopyingSpinner ? <Spinner /> : treeCopied ? <Check /> : <Folders />}"
+      );
+      expect(source).not.toContain(
+        "{isCopyingTree ? <Spinner /> : treeCopied ? <Check /> : <Folders />}"
+      );
+    });
+
+    it("uses sentence-case 'Context copied' aria-label", () => {
+      expect(source).toContain('"Context copied"');
+      expect(source).not.toContain('"Context Copied"');
+    });
+  });
+
   describe("useMemo dependency array", () => {
     it("includes sidebarShortcut in useMemo deps", () => {
       const depsMatch = source.match(/\}\),\s*\[([^\]]+)\]\s*\);/s);


### PR DESCRIPTION
Closes #8179.

## Summary

- Defer the `<Spinner />` glyph in the Copy Context button via `useDeferredLoading(isCopyingTree, UI_DOHERTY_THRESHOLD)`, matching the canonical sub-400ms anti-flicker gate already used by `SidebarContent`, `BrowserPane`, and `HostCrashBanner`. Fast copies (the common case) now transition idle → check directly. Slow copies still surface the spinner once past 400ms.
- Sentence-case the success `aria-label` (`"Context Copied"` → `"Context copied"`) per the CLAUDE.md microcopy rule for past-tense status strings.
- `isCopyingTree` still drives `aria-disabled`, the click guard, `cursor-wait/opacity-70`, the in-flight `aria-label="Copying…"`, and the tooltip text — those are interaction-state signals, not loading indicators.

## Implementation notes

- The derived `showCopyingSpinner` is included in the `getToolbarItems` `useMemo` dep array. Without that, the hook's 400ms state flip wouldn't trigger a re-render, leaving slow copies stuck on the idle icon — caught in review before merge.

## Test plan

- [x] `npx vitest run src/components/Layout/__tests__/Toolbar.shortcuts.test.ts` — 37 tests pass (added 6 source-string assertions: import shape, derived constant, gated icon ternary, sentence-case label, and dep-array regression guard).
- [x] `npx tsc --noEmit -p .` — clean.
- [x] `npm run check` (lint + format + typecheck + IPC/channel/help generators) — clean; lint ratchet improved by 8 warnings.