### PR TITLE
fix(toolbar): replace soft armed-state shadow with hairline ring (#8175)

### DIFF
--- a/shared/theme/__tests__/builtInThemes.test.ts
+++ b/shared/theme/__tests__/builtInThemes.test.ts
@@ -205,4 +205,44 @@ describe("built-in themes", () => {
       ).toBeGreaterThanOrEqual(0.25);
     }
   });
+
+  it("dark themes override toolbar-control-armed-shadow with a white-tinted hairline; light themes inherit the black-tinted CSS fallback", () => {
+    // Dark themes must provide a white-tinted hairline override — the CSS fallback
+    // is black-tinted (rgba(0,0,0,0.18)) so on dark surfaces it would render
+    // invisibly. Light themes must NOT define this extension; a copy-paste from a
+    // dark theme would put a white ring on a light toolbar, which inverts the
+    // original #8175 bug.
+    const parseAlpha = (value: string): number => {
+      const match = value.match(/rgba?\([^)]*?,\s*([0-9.]+)\s*\)/);
+      return match ? Number(match[1]) : NaN;
+    };
+    for (const source of BUILT_IN_THEME_SOURCES) {
+      const armed = source.extensions?.["toolbar-control-armed-shadow"];
+      if (source.type === "dark") {
+        expect(
+          armed,
+          `${source.id} (dark) missing toolbar-control-armed-shadow override`
+        ).toBeTruthy();
+        expect(
+          armed,
+          `${source.id} toolbar-control-armed-shadow must use the hairline geometry`
+        ).toMatch(/inset\s+0\s+0\s+0\s+1px/);
+        expect(
+          armed,
+          `${source.id} toolbar-control-armed-shadow must be white-tinted on a dark theme`
+        ).toMatch(/rgba\(\s*255\s*,\s*255\s*,\s*255/);
+        const alpha = parseAlpha(armed!);
+        expect(
+          alpha,
+          `${source.id} toolbar-control-armed-shadow alpha ${alpha} outside [0.08, 0.25]`
+        ).toBeGreaterThanOrEqual(0.08);
+        expect(alpha).toBeLessThanOrEqual(0.25);
+      } else {
+        expect(
+          armed,
+          `${source.id} (light) must not override toolbar-control-armed-shadow; it should inherit the black-tinted CSS fallback`
+        ).toBeUndefined();
+      }
+    }
+  });
 });

--- a/shared/theme/builtInThemes/arashiyama.ts
+++ b/shared/theme/builtInThemes/arashiyama.ts
@@ -113,6 +113,7 @@ export const theme: BuiltInThemeSource = {
     "sidebar-active-bg": "rgba(255,255,255,0.05)",
     "sidebar-hover-bg": "rgba(255,255,255,0.03)",
     "toolbar-agent-hover-bg": "rgba(241,235,228,0.08)",
+    "toolbar-control-armed-shadow": "inset 0 0 0 1px rgba(255,255,255,0.12)",
     "toolbar-control-hover-bg": "rgba(241,235,228,0.08)",
     "toolbar-control-hover-fg": "#B85733",
     "toolbar-divider": "rgba(67,58,50,0.5)",

--- a/shared/theme/builtInThemes/daintree.ts
+++ b/shared/theme/builtInThemes/daintree.ts
@@ -108,6 +108,7 @@ export const theme: BuiltInThemeSource = {
     "sidebar-active-bg": "rgba(255,255,255,0.05)",
     "sidebar-hover-bg": "rgba(255,255,255,0.03)",
     "toolbar-agent-hover-bg": "rgba(255,255,255,0.06)",
+    "toolbar-control-armed-shadow": "inset 0 0 0 1px rgba(255,255,255,0.12)",
     "toolbar-control-hover-bg": "rgba(255,255,255,0.10)",
     "toolbar-divider": "rgba(40,40,40,0.5)",
     "toolbar-project-bg": "rgba(255,255,255,0.05)",

--- a/shared/theme/builtInThemes/fiordland.ts
+++ b/shared/theme/builtInThemes/fiordland.ts
@@ -117,6 +117,7 @@ export const theme: BuiltInThemeSource = {
     "sidebar-active-bg": "rgba(255,255,255,0.05)",
     "sidebar-hover-bg": "rgba(255,255,255,0.03)",
     "toolbar-agent-hover-bg": "rgba(180,220,240,0.06)",
+    "toolbar-control-armed-shadow": "inset 0 0 0 1px rgba(255,255,255,0.12)",
     "toolbar-control-hover-bg": "rgba(180,220,240,0.10)",
     "toolbar-divider": "rgba(28,46,64,0.5)",
     "toolbar-project-bg": "rgba(180,220,240,0.05)",

--- a/shared/theme/builtInThemes/galapagos.ts
+++ b/shared/theme/builtInThemes/galapagos.ts
@@ -116,6 +116,7 @@ export const theme: BuiltInThemeSource = {
     "sidebar-active-bg": "rgba(255,255,255,0.05)",
     "sidebar-hover-bg": "rgba(255,255,255,0.03)",
     "toolbar-agent-hover-bg": "rgba(74,158,127,0.06)",
+    "toolbar-control-armed-shadow": "inset 0 0 0 1px rgba(255,255,255,0.12)",
     "toolbar-control-hover-bg": "rgba(74,158,127,0.10)",
     "toolbar-divider": "rgba(42,58,53,0.5)",
     "toolbar-project-bg": "rgba(140,200,180,0.05)",

--- a/shared/theme/builtInThemes/highlands.ts
+++ b/shared/theme/builtInThemes/highlands.ts
@@ -113,6 +113,7 @@ export const theme: BuiltInThemeSource = {
     "sidebar-active-bg": "rgba(255,255,255,0.05)",
     "sidebar-hover-bg": "rgba(255,255,255,0.03)",
     "toolbar-agent-hover-bg": "rgba(195,185,210,0.06)",
+    "toolbar-control-armed-shadow": "inset 0 0 0 1px rgba(255,255,255,0.12)",
     "toolbar-control-hover-bg": "rgba(195,185,210,0.10)",
     "toolbar-divider": "rgba(60,55,66,0.5)",
     "toolbar-project-bg": "rgba(195,185,210,0.05)",

--- a/shared/theme/builtInThemes/namib.ts
+++ b/shared/theme/builtInThemes/namib.ts
@@ -116,6 +116,7 @@ export const theme: BuiltInThemeSource = {
     "sidebar-active-bg": "rgba(255,255,255,0.05)",
     "sidebar-hover-bg": "rgba(255,255,255,0.03)",
     "toolbar-agent-hover-bg": "rgba(200,180,150,0.05)",
+    "toolbar-control-armed-shadow": "inset 0 0 0 1px rgba(255,255,255,0.12)",
     "toolbar-control-hover-bg": "rgba(200,180,150,0.06)",
     "toolbar-divider": "rgba(51,45,37,0.5)",
     "toolbar-project-bg": "rgba(200,180,150,0.035)",

--- a/shared/theme/builtInThemes/redwoods.ts
+++ b/shared/theme/builtInThemes/redwoods.ts
@@ -110,6 +110,7 @@ export const theme: BuiltInThemeSource = {
     "sidebar-active-bg": "rgba(255,255,255,0.05)",
     "sidebar-hover-bg": "rgba(255,255,255,0.03)",
     "toolbar-agent-hover-bg": "rgba(180,140,120,0.08)",
+    "toolbar-control-armed-shadow": "inset 0 0 0 1px rgba(255,255,255,0.12)",
     "toolbar-control-hover-bg": "rgba(180,140,120,0.10)",
     "toolbar-divider": "rgba(54,36,26,0.5)",
     "toolbar-project-bg": "rgba(180,140,120,0.06)",

--- a/src/components/Layout/__tests__/Toolbar.responsive.test.ts
+++ b/src/components/Layout/__tests__/Toolbar.responsive.test.ts
@@ -162,6 +162,18 @@ describe("Toolbar responsive design — issue #4133", () => {
       expect(armedBlock).toContain("--toolbar-control-armed-bg");
       expect(armedBlock).toContain("--toolbar-control-armed-shadow");
       expect(armedBlock).toMatch(/inset\s+0\s+0\s+0\s+1px/);
+      expect(armedBlock).toContain('.toolbar-agent-button[aria-pressed="true"]');
+    });
+
+    it("armed selectors appear after :hover in source order so armed survives hover-over-armed", () => {
+      // Hover and armed have equal specificity, so later-in-source wins. If a
+      // refactor moves the armed block above hover, hovering an armed button
+      // would erase the ring — silently regressing #8175.
+      const hoverIndex = css.search(/\.toolbar-icon-button:hover\s*[,{]/);
+      const armedIndex = css.search(/\.toolbar-icon-button\[aria-pressed="true"\]/);
+      expect(hoverIndex).toBeGreaterThan(-1);
+      expect(armedIndex).toBeGreaterThan(-1);
+      expect(armedIndex).toBeGreaterThan(hoverIndex);
     });
 
     it("press transform is owned by base Button cva, not the toolbar transition list", () => {

--- a/src/components/Layout/__tests__/Toolbar.responsive.test.ts
+++ b/src/components/Layout/__tests__/Toolbar.responsive.test.ts
@@ -151,14 +151,17 @@ describe("Toolbar responsive design — issue #4133", () => {
 
     it("armed selectors carry an inset shadow on top of the emphasis background", () => {
       // The armed selector block must include both background AND box-shadow
-      // so the state reads as anchored/pressed, not "still hovering".
+      // so the state reads as anchored/pressed, not "still hovering". The shadow
+      // shape is asserted as an inset hairline ring (0 0 0 1px) — the geometry
+      // that distinguishes the state edge from a soft directional shadow that
+      // reads as fog on low-contrast light themes (#7XXX).
       const armedBlock = css.match(
         /\.toolbar-icon-button\[aria-pressed="true"\][\s\S]*?\{[\s\S]*?\}/
       )?.[0];
       expect(armedBlock).toBeDefined();
       expect(armedBlock).toContain("--toolbar-control-armed-bg");
       expect(armedBlock).toContain("--toolbar-control-armed-shadow");
-      expect(armedBlock).toMatch(/inset\s+0\s+1px\s+2px/);
+      expect(armedBlock).toMatch(/inset\s+0\s+0\s+0\s+1px/);
     });
 
     it("press transform is owned by base Button cva, not the toolbar transition list", () => {

--- a/src/styles/components/toolbar.css
+++ b/src/styles/components/toolbar.css
@@ -81,12 +81,15 @@
   outline-offset: 2px;
 }
 
-/* Armed state ("anchored" — dropdown open, toggle on) gets an inset shadow on top
- * of the emphasis background. The inset cue reads as pressed-into-surface and
- * distinguishes armed from hover (which only differs by an overlay tier). The
- * accent color is reserved per CLAUDE.md, so the directional cue carries the
- * signal instead. Comes after :hover in source order so the inset shadow
- * survives hover-over-armed (equal specificity, later wins). */
+/* Armed state ("anchored" — dropdown open, toggle on) gets an inset hairline ring on
+ * top of the emphasis background. The 1px ring reads as a crisp state edge and
+ * distinguishes armed from hover (which only differs by an overlay tier) — the
+ * previous soft directional shadow (inset 0 1px 2px) read as fog on low-contrast
+ * light themes (#7XXX). The accent color is reserved per CLAUDE.md, so the ring
+ * carries the signal instead. Dark themes override --toolbar-control-armed-shadow
+ * to a white-tinted ring; a black ring goes invisible on dark surfaces. Comes
+ * after :hover in source order so the ring survives hover-over-armed (equal
+ * specificity, later wins). */
 .toolbar-icon-button[aria-pressed="true"],
 .toolbar-icon-button[aria-expanded="true"],
 .toolbar-icon-button[data-state="open"],
@@ -94,7 +97,7 @@
 .toolbar-agent-button[aria-expanded="true"],
 .toolbar-agent-button[data-state="open"] {
   background: var(--toolbar-control-armed-bg, var(--theme-overlay-emphasis));
-  box-shadow: var(--toolbar-control-armed-shadow, inset 0 1px 2px rgba(0, 0, 0, 0.15));
+  box-shadow: var(--toolbar-control-armed-shadow, inset 0 0 0 1px rgba(0, 0, 0, 0.18));
 }
 
 /* The press snap (transform: scale(0.98) at 1ms) comes from the base Button cva.


### PR DESCRIPTION
## Summary

- Armed state on `.toolbar-icon-button` and `.toolbar-agent-button` (triggered by `aria-pressed="true"`, `aria-expanded="true"`, or `data-state="open"`) previously used a soft `inset 0 1px 2px rgba(0,0,0,0.15)`. On low-contrast light themes (Bondi `#F0F1F4`, Svalbard `#E6EDF3`) it read as fog — indistinguishable from hover.
- Replaced with `inset 0 0 0 1px rgba(0,0,0,0.18)` — a crisp hairline ring that clearly signals "anchored/pressed". All 7 dark themes get a white-tinted override (`inset 0 0 0 1px rgba(255,255,255,0.12)`) via the existing `--toolbar-control-armed-shadow` token so the ring stays visible on dark surfaces.
- No accent color, no widened transition list, no per-theme `bg` bumps.

Resolves #8175

## Changes

- `src/styles/components/toolbar.css` — swap `box-shadow` value on the armed selector; add per-theme dark overrides
- `shared/theme/builtInThemes/{arashiyama,daintree,fiordland,galapagos,highlands,namib,redwoods}.ts` — set `--toolbar-control-armed-shadow` token on each dark theme
- `shared/theme/__tests__/builtInThemes.test.ts` — regression guard: dark themes must use a white-tinted ring, light themes must use a black-tinted ring (polarity check)
- `src/components/Layout/__tests__/Toolbar.responsive.test.ts` — source-order guard: armed rule must follow `:hover` in the stylesheet, or hover would erase the ring on armed+hovered buttons; existing armed regex relaxed from the specific `1px 2px` shape to the ring geometry

## Testing

Two new tests cover the regression surface. The polarity check in `builtInThemes.test.ts` confirms dark/light themes use the correct ring colour. The source-order check in `Toolbar.responsive.test.ts` confirms the CSS cascade is correct. Visually verified on Bondi and Svalbard (light) as well as Daintree (dark) — armed and hover are now clearly distinct states.