### PR TITLE
fix(toolbar): use Tier 3 timing for fullscreen spacer transitions

### DIFF
--- a/src/components/Layout/Toolbar.tsx
+++ b/src/components/Layout/Toolbar.tsx
@@ -975,8 +975,9 @@ export function Toolbar({
         >
           {isMac() && (
             <div
+              data-fullscreen={isFullscreen ? "true" : undefined}
               className={cn(
-                "shrink-0 transition-[width] duration-150",
+                "shrink-0 transition-[width] duration-200 data-[fullscreen=true]:duration-[120ms]",
                 isFullscreen ? "w-0" : "w-16"
               )}
             />
@@ -1103,7 +1104,11 @@ export function Toolbar({
           {isWindows() && (
             <div
               aria-hidden="true"
-              className={cn("shrink-0 transition-[width] duration-150", isFullscreen && "w-0")}
+              data-fullscreen={isFullscreen ? "true" : undefined}
+              className={cn(
+                "shrink-0 transition-[width] duration-200 data-[fullscreen=true]:duration-[120ms]",
+                isFullscreen && "w-0"
+              )}
               style={isFullscreen ? undefined : { width: "var(--win-caption-width, 138px)" }}
             />
           )}

--- a/src/components/Layout/__tests__/Toolbar.layout.test.ts
+++ b/src/components/Layout/__tests__/Toolbar.layout.test.ts
@@ -234,6 +234,11 @@ describe("Toolbar layout — issue #2584 project switcher collision", () => {
       expect(source).toMatch(/data-fullscreen=\{isFullscreen \? "true" : undefined\}/);
     });
 
+    it("applies the Tier 3 timing to both the macOS and Windows spacers", () => {
+      const tier3 = /duration-200 data-\[fullscreen=true\]:duration-\[120ms\]/g;
+      expect((source.match(tier3) ?? []).length).toBeGreaterThanOrEqual(2);
+    });
+
     it("spacer is decorative (aria-hidden) and not focusable as a toolbar item", () => {
       const spacerBlock = source.slice(
         source.indexOf("isWindows() &&"),

--- a/src/components/Layout/__tests__/Toolbar.layout.test.ts
+++ b/src/components/Layout/__tests__/Toolbar.layout.test.ts
@@ -219,7 +219,19 @@ describe("Toolbar layout — issue #2584 project switcher collision", () => {
     });
 
     it("uses scoped transition-[width] motion, not transition-all", () => {
-      expect(source).toMatch(/transition-\[width\]\s+duration-150/);
+      expect(source).toContain("transition-[width]");
+      expect(source).not.toContain("transition-all");
+    });
+
+    it("uses Tier 3 panel timing (200ms restore / 120ms collapse), not Tier 1", () => {
+      expect(source).toMatch(
+        /transition-\[width\]\s+duration-200\s+data-\[fullscreen=true\]:duration-\[120ms\]/
+      );
+      expect(source).not.toContain("duration-150");
+    });
+
+    it("drives the asymmetric collapse duration via a data-fullscreen attribute", () => {
+      expect(source).toMatch(/data-fullscreen=\{isFullscreen \? "true" : undefined\}/);
     });
 
     it("spacer is decorative (aria-hidden) and not focusable as a toolbar item", () => {


### PR DESCRIPTION
## Summary

- The macOS traffic-light spacer and Windows caption spacer in `Toolbar.tsx` were using `duration-150` (Tier 1 motion), but collapsing these spacers is a large-area structural reflow -- the same category as panel open/close -- so they belong in Tier 3.
- Switched to asymmetric Tier 3 timing: 200ms restore, 120ms collapse, driven by a `data-fullscreen` attribute. The `transition-[width]` scope is preserved.
- The `will-enter-full-screen` / `will-leave-full-screen` approach suggested in the issue is a dead end -- those events don't exist in the Electron 41 `BrowserWindow` API (confirmed in `electron.d.ts`), so no main-process or IPC changes were needed.

Resolves #8169

## Changes

- `src/components/Layout/Toolbar.tsx` -- asymmetric Tier 3 duration classes via `data-fullscreen`, replacing flat `duration-150`
- `src/components/Layout/__tests__/Toolbar.layout.test.ts` -- updated assertions to cover both spacers at the correct restore and collapse durations

## Testing

- Vitest: `Toolbar.layout.test.ts` -- 44 tests pass
- `npm run check` clean (no new errors or warnings)