### PR TITLE
fix(github): drop opacity-as-stale from GitHub stats toolbar pill

### DIFF
--- a/src/components/Layout/FreshnessUtils.tsx
+++ b/src/components/Layout/FreshnessUtils.tsx
@@ -16,7 +16,7 @@ export function freshnessOpacityClass(level: FreshnessLevel): string {
 }
 
 export function FreshnessGlyph({ level }: { level: FreshnessLevel }) {
-  if (level === "stale-disk") {
+  if (level === "stale-disk" || level === "aging") {
     return <Clock className="h-3 w-3 text-muted-foreground" aria-hidden="true" />;
   }
   return null;

--- a/src/components/Layout/GitHubStatsToolbarButton.tsx
+++ b/src/components/Layout/GitHubStatsToolbarButton.tsx
@@ -31,7 +31,7 @@ import { buildCacheKey, getCache, setCache } from "@/lib/githubResourceCache";
 import { useGitHubConfigStore } from "@/store/githubConfigStore";
 import type { Project } from "@shared/types";
 import type { GitHubRateLimitDetails, RepositoryStats } from "@shared/types";
-import { freshnessOpacityClass, FreshnessGlyph, freshnessSuffix } from "./FreshnessUtils";
+import { FreshnessGlyph, freshnessSuffix } from "./FreshnessUtils";
 import {
   formatRateLimitCountdown,
   msUntilNextLabelChange,
@@ -629,8 +629,7 @@ export const GitHubStatsToolbarButton = memo(
           openRingClassName="ring-1 ring-github-open/20"
           className={cn(
             isTokenError && "opacity-40",
-            !isTokenError && stats?.issueCount === 0 && "opacity-50",
-            !isTokenError && freshnessOpacityClass(freshnessLevel)
+            !isTokenError && stats?.issueCount === 0 && "opacity-50"
           )}
           dropdownContent={
             ResourceListComponent ? (
@@ -735,8 +734,7 @@ export const GitHubStatsToolbarButton = memo(
           openRingClassName="ring-1 ring-github-merged/20"
           className={cn(
             isTokenError && "opacity-40",
-            !isTokenError && stats?.prCount === 0 && "opacity-50",
-            !isTokenError && freshnessOpacityClass(freshnessLevel)
+            !isTokenError && stats?.prCount === 0 && "opacity-50"
           )}
           dropdownContent={
             ResourceListComponent ? (
@@ -827,10 +825,7 @@ export const GitHubStatsToolbarButton = memo(
           }
           icon={GitCommit}
           openRingClassName="ring-1 ring-border-strong"
-          className={cn(
-            stats?.commitCount === 0 && "opacity-50",
-            freshnessOpacityClass(commitFreshnessLevel)
-          )}
+          className={cn(stats?.commitCount === 0 && "opacity-50")}
           dropdownContent={
             CommitListComponent ? (
               <CommitListComponent

--- a/src/components/Layout/__tests__/FreshnessUtils.test.tsx
+++ b/src/components/Layout/__tests__/FreshnessUtils.test.tsx
@@ -42,7 +42,10 @@ describe("FreshnessGlyph", () => {
 
   it("renders a clock glyph for stale-disk level", () => {
     const { container } = render(<FreshnessGlyph level="stale-disk" />);
-    expect(container.querySelector("svg")).not.toBeNull();
+    const svg = container.querySelector("svg");
+    expect(svg).not.toBeNull();
+    expect(svg?.getAttribute("aria-hidden")).toBe("true");
+    expect(svg?.getAttribute("class")).toContain("text-muted-foreground");
   });
 
   it("renders nothing for errored level (covered by GitHubStatusIndicator)", () => {

--- a/src/components/Layout/__tests__/FreshnessUtils.test.tsx
+++ b/src/components/Layout/__tests__/FreshnessUtils.test.tsx
@@ -1,5 +1,12 @@
+// @vitest-environment jsdom
 import { describe, it, expect } from "vitest";
-import { freshnessOpacityClass, formatTimeSince, freshnessSuffix } from "../FreshnessUtils";
+import { render } from "@testing-library/react";
+import {
+  freshnessOpacityClass,
+  FreshnessGlyph,
+  formatTimeSince,
+  freshnessSuffix,
+} from "../FreshnessUtils";
 
 describe("freshnessOpacityClass", () => {
   it("returns empty string for fresh level", () => {
@@ -16,6 +23,31 @@ describe("freshnessOpacityClass", () => {
 
   it("returns opacity-50 for errored level", () => {
     expect(freshnessOpacityClass("errored")).toBe("opacity-50");
+  });
+});
+
+describe("FreshnessGlyph", () => {
+  it("renders nothing for fresh level", () => {
+    const { container } = render(<FreshnessGlyph level="fresh" />);
+    expect(container.querySelector("svg")).toBeNull();
+  });
+
+  it("renders a clock glyph for aging level (issue #8180 — replaces opacity dim)", () => {
+    const { container } = render(<FreshnessGlyph level="aging" />);
+    const svg = container.querySelector("svg");
+    expect(svg).not.toBeNull();
+    expect(svg?.getAttribute("aria-hidden")).toBe("true");
+    expect(svg?.getAttribute("class")).toContain("text-muted-foreground");
+  });
+
+  it("renders a clock glyph for stale-disk level", () => {
+    const { container } = render(<FreshnessGlyph level="stale-disk" />);
+    expect(container.querySelector("svg")).not.toBeNull();
+  });
+
+  it("renders nothing for errored level (covered by GitHubStatusIndicator)", () => {
+    const { container } = render(<FreshnessGlyph level="errored" />);
+    expect(container.querySelector("svg")).toBeNull();
   });
 });
 

--- a/src/components/Layout/__tests__/GitHubStatsToolbarButton.freshness.test.ts
+++ b/src/components/Layout/__tests__/GitHubStatsToolbarButton.freshness.test.ts
@@ -49,6 +49,16 @@ describe("GitHubStatsToolbarButton freshness wiring", () => {
     // zero-count de-emphasis (opacity-50) — both distinct from freshness.
     expect(source).not.toMatch(/freshnessOpacityClass\(commitFreshnessLevel\)/);
     expect(source).not.toMatch(/freshnessOpacityClass\(freshnessLevel\)/);
+    // Guard the inline equivalents too — the freshness opacity tiers were
+    // opacity-75 (aging) and opacity-60 (stale-disk); neither should reappear.
+    expect(source).not.toContain("opacity-75");
+    expect(source).not.toContain("opacity-60");
+  });
+
+  it("wires the commits pill glyph to commitFreshnessLevel, not freshnessLevel", () => {
+    // Commits are git-local — a GitHub connectivity error must not dim or
+    // glyph the commits pill. commitFreshnessLevel maps errored→fresh.
+    expect(source).toContain("<FreshnessGlyph level={commitFreshnessLevel} />");
   });
 
   it("uses freshnessSuffix in ariaLabel and tooltipContent for freshness-aware copy", () => {

--- a/src/components/Layout/__tests__/GitHubStatsToolbarButton.freshness.test.ts
+++ b/src/components/Layout/__tests__/GitHubStatsToolbarButton.freshness.test.ts
@@ -26,9 +26,15 @@ describe("GitHubStatsToolbarButton freshness wiring", () => {
 
   it("imports freshness helpers from co-located FreshnessUtils", () => {
     expect(source).toContain('from "./FreshnessUtils"');
-    expect(source).toContain("freshnessOpacityClass");
     expect(source).toContain("FreshnessGlyph");
     expect(source).toContain("freshnessSuffix");
+  });
+
+  it("does not import or use freshnessOpacityClass (issue #8180)", () => {
+    // Opacity-as-stale reads as a disabled control on always-clickable pills
+    // (WCAG 1.4.3/1.4.11/4.1.2). Staleness is carried by FreshnessGlyph + the
+    // freshnessSuffix tooltip copy instead.
+    expect(source).not.toContain("freshnessOpacityClass");
   });
 
   it("passes FreshnessGlyph to all three GitHubStatPill instances", () => {
@@ -37,14 +43,12 @@ describe("GitHubStatsToolbarButton freshness wiring", () => {
     expect(glyphs?.length).toBe(3);
   });
 
-  it("uses freshnessOpacityClass in className for all three pills", () => {
-    // Commits uses commitFreshnessLevel (errored→fresh); issues + PRs use freshnessLevel.
-    const commitsMatch = source.match(/freshnessOpacityClass\(commitFreshnessLevel\)/g);
-    const sharedMatch = source.match(/freshnessOpacityClass\(freshnessLevel\)/g);
-    expect(commitsMatch).not.toBeNull();
-    expect(commitsMatch?.length).toBe(1);
-    expect(sharedMatch).not.toBeNull();
-    expect(sharedMatch?.length).toBe(2);
+  it("does not dim any pill className via freshness opacity (issue #8180)", () => {
+    // The freshness signal moved off opacity entirely. The only remaining
+    // opacity classes are the token-error disabled state (opacity-40) and the
+    // zero-count de-emphasis (opacity-50) — both distinct from freshness.
+    expect(source).not.toMatch(/freshnessOpacityClass\(commitFreshnessLevel\)/);
+    expect(source).not.toMatch(/freshnessOpacityClass\(freshnessLevel\)/);
   });
 
   it("uses freshnessSuffix in ariaLabel and tooltipContent for freshness-aware copy", () => {


### PR DESCRIPTION
## Summary

- `freshnessOpacityClass` was dimming always-clickable issues/PRs/commits pills in the toolbar, which reads as disabled under WCAG 1.4.3/1.4.11/4.1.2 — same anti-pattern PR #8118 fixed for the worktree PR badge
- Removed the three `freshnessOpacityClass` calls from `GitHubStatsToolbarButton.tsx` and extended `FreshnessGlyph` in `FreshnessUtils.tsx` to render a low-prominence Clock for `aging` as well as `stale-disk`, preserving the ambient staleness signal
- `freshnessOpacityClass` is left intact for `IssueBadge.tsx` — worktree card behaviour unchanged; token-error (`opacity-40`) and zero-count (`opacity-50`) dims are kept as they encode distinct semantic concerns, not freshness state

Resolves #8180

## Changes

- `GitHubStatsToolbarButton.tsx` — removed `freshnessOpacityClass` from all three pill `cn()` calls
- `FreshnessUtils.tsx` — `FreshnessGlyph` now renders the Clock glyph for both `aging` and `stale-disk` (previously `stale-disk` only)
- `FreshnessUtils.test.tsx` — added `FreshnessGlyph` render coverage for `aging`
- `GitHubStatsToolbarButton.freshness.test.ts` — flipped opacity assertions to negative form; added glyph render assertions

## Testing

33 targeted tests pass. Typecheck, lint, format, and build all clean.