### PR TITLE
fix(worktree): partial-dim UpstreamSyncBadge count on transient fetch failure

### DIFF
--- a/electron/workspace-host/WorkspaceService.ts
+++ b/electron/workspace-host/WorkspaceService.ts
@@ -732,6 +732,12 @@ export class WorkspaceService {
    *
    * `getGitCommonDir` is synchronous and cached, so the O(n) scan is cheap
    * after the first call per worktree.
+   *
+   * Note: `isFetchInFlight` is intentionally excluded from this fan-out —
+   * propagating per-monitor in-flight state to N sibling rows would produce
+   * simultaneous pulse animations across the sidebar, recreating the visual
+   * fatigue pattern that drove removal of the `panel-state-working` breathe
+   * loop. Only the row that triggered the fetch shows the in-flight pulse.
    */
   private applyFetchResultToSiblings(
     triggering: WorktreeMonitor,

--- a/src/components/Worktree/WorktreeCard/UpstreamSyncBadge.tsx
+++ b/src/components/Worktree/WorktreeCard/UpstreamSyncBadge.tsx
@@ -83,10 +83,12 @@ export function UpstreamSyncBadge({
           className={cn(
             "flex items-center text-[10px] font-mono tabular-nums",
             containerGapClass,
-            isFetchInFlight && showPulse && "animate-pulse-immediate"
+            isFetchInFlight && showPulse && "animate-pulse-immediate",
+            fetchNetworkFailed && "opacity-75"
           )}
           data-testid="upstream-sync-indicator"
           data-fetch-in-flight={isFetchInFlight ? "true" : undefined}
+          data-fetch-network-failed={fetchNetworkFailed ? "true" : undefined}
         >
           {hasAhead && <span className="text-status-success">↑{aheadCount}</span>}
           {hasBehind && <span className="text-status-warning">↓{behindCount}</span>}

--- a/src/components/Worktree/WorktreeCard/__tests__/WorktreeHeader.test.tsx
+++ b/src/components/Worktree/WorktreeCard/__tests__/WorktreeHeader.test.tsx
@@ -1227,9 +1227,38 @@ describe("WorktreeHeader upstream sync indicator", () => {
     // auth-failure treatment.
     const indicator = screen.getByTestId("upstream-sync-indicator");
     expect(indicator).toBeDefined();
+    expect(indicator.textContent).toContain("↑1");
     expect(indicator.className).toContain("opacity-75");
     expect(indicator.className).not.toContain("grayscale");
     expect(indicator.className).not.toContain("opacity-50");
     expect(indicator.getAttribute("data-fetch-network-failed")).toBe("true");
+  });
+
+  it("does not dim the count display on a healthy worktree", () => {
+    renderHeader({
+      worktree: { ...baseWorktree, aheadCount: 1 },
+    });
+    const indicator = screen.getByTestId("upstream-sync-indicator");
+    expect(indicator).toBeDefined();
+    expect(indicator.className).not.toContain("opacity-75");
+    expect(indicator.getAttribute("data-fetch-network-failed")).toBeNull();
+  });
+
+  it("prefers the auth-failed treatment over the network-failed dim", () => {
+    // Mutually exclusive at source (RepoFetchCoordinator), but pin the
+    // precedence so a regression can't surface both treatments at once.
+    renderHeader({
+      worktree: {
+        ...baseWorktree,
+        aheadCount: 1,
+        fetchAuthFailed: true,
+        fetchNetworkFailed: true,
+        isGitHubRemote: true,
+      },
+    });
+    const indicator = screen.getByTestId("upstream-sync-indicator");
+    expect(indicator.getAttribute("data-fetch-auth-failed")).toBe("true");
+    expect(indicator.getAttribute("data-fetch-network-failed")).toBeNull();
+    expect(indicator.className).not.toContain("opacity-75");
   });
 });

--- a/src/components/Worktree/WorktreeCard/__tests__/WorktreeHeader.test.tsx
+++ b/src/components/Worktree/WorktreeCard/__tests__/WorktreeHeader.test.tsx
@@ -1221,7 +1221,15 @@ describe("WorktreeHeader upstream sync indicator", () => {
       },
     });
     // The badge still renders the count display (transient failure doesn't
-    // replace the indicator — only auth+github gets dimmed).
-    expect(screen.getByTestId("upstream-sync-indicator")).toBeDefined();
+    // replace the indicator like the auth+github path does), but it carries a
+    // partial dim so the failed row is distinguishable from a healthy one at
+    // the row level — without grayscale, which is reserved for the persistent
+    // auth-failure treatment.
+    const indicator = screen.getByTestId("upstream-sync-indicator");
+    expect(indicator).toBeDefined();
+    expect(indicator.className).toContain("opacity-75");
+    expect(indicator.className).not.toContain("grayscale");
+    expect(indicator.className).not.toContain("opacity-50");
+    expect(indicator.getAttribute("data-fetch-network-failed")).toBe("true");
   });
 });


### PR DESCRIPTION
## Summary

- A worktree row that just failed a background `git fetch` looked identical to a healthy idle row — the only signal was a tooltip you'd only see on hover. Auth failures already dim the row to grayscale; transient network failures had no parallel row-level treatment.
- Adds a static `opacity-75` partial dim to the count display in `UpstreamSyncBadge.tsx` when `fetchNetworkFailed && !fetchAuthFailed`. No grayscale (reserved for persistent auth failures), no motion — ambient Tier 1 signal only. The dim is applied via a `data-fetch-network-failed` attribute. `opacity-75` sits one tier lighter than auth-failed's `opacity-50`, matching the `FreshnessUtils` severity scale.
- Documents in `WorkspaceService.ts` why `applyFetchResultToSiblings` deliberately excludes `isFetchInFlight` from the sibling fan-out — fanning per-row in-flight state across siblings would recreate the multi-row parallel pulse fatigue pattern the `panel-state-working` breathe-loop removal was explicitly meant to fix.

Resolves #8067

## Changes

- `UpstreamSyncBadge.tsx` — count display gets `opacity-75` + `data-fetch-network-failed` when `fetchNetworkFailed && !fetchAuthFailed`
- `WorkspaceService.ts` — inline comment explaining the deliberate `isFetchInFlight` exclusion from sibling fan-out
- `WorktreeHeader.test.tsx` — extended fetch-failure test to assert the dim; added healthy-baseline negative test and auth-failed-precedence regression anchor

## Testing

`npm run check` clean. 82 tests pass. A no-delta worktree (ahead=0, behind=0) + `fetchNetworkFailed` still renders nothing at the row level — the badge short-circuits to `null` and there's no count surface to dim. Intentional, matches the issue spec.