### PR TITLE
feat(dock): add keyboard navigation to chip rail (#8170)

### DIFF
--- a/src/components/Layout/ContentDock.tsx
+++ b/src/components/Layout/ContentDock.tsx
@@ -1,7 +1,7 @@
-import { useMemo, useRef, useCallback } from "react";
+import { useMemo, useRef, useCallback, useLayoutEffect } from "react";
 
 import { SortableContext, horizontalListSortingStrategy } from "@dnd-kit/sortable";
-import { useDroppable } from "@dnd-kit/core";
+import { useDndContext, useDroppable } from "@dnd-kit/core";
 import { ChevronLeft, ChevronRight } from "lucide-react";
 import { cn } from "@/lib/utils";
 import { Tooltip, TooltipContent, TooltipTrigger } from "@/components/ui/tooltip";
@@ -154,8 +154,95 @@ export function ContentDock({ density = "normal" }: ContentDockProps) {
     : undefined;
 
   const scrollContainerRef = useRef<HTMLDivElement>(null);
+  const activeDockIndexRef = useRef(0);
   const { canScrollLeft, canScrollRight, scrollLeft, scrollRight } =
     useHorizontalScrollControls(scrollContainerRef);
+
+  // Issue #8170 — roving tabindex over [data-dock-item] chips. The rail is an
+  // ARIA toolbar with a single tab stop; Arrow/Home/End move focus across
+  // chips. Mirrors the canonical pattern in Toolbar.tsx (lines 324-393);
+  // deliberately not lifted into a shared hook — the issue calls that out
+  // until a fourth use case appears.
+  const { active: dndActive } = useDndContext();
+  const isDndActive = dndActive !== null;
+
+  const getDockItems = useCallback(
+    () =>
+      scrollContainerRef.current
+        ? Array.from(
+            scrollContainerRef.current.querySelectorAll<HTMLElement>("[data-dock-item]")
+          ).filter((el) => el.offsetParent !== null)
+        : [],
+    []
+  );
+
+  const syncDockTabStops = useCallback((items: HTMLElement[], activeIdx: number) => {
+    for (const el of items) el.tabIndex = -1;
+    if (items[activeIdx]) items[activeIdx].tabIndex = 0;
+  }, []);
+
+  useLayoutEffect(() => {
+    const items = getDockItems();
+    if (items.length === 0) return;
+    const clamped = Math.min(activeDockIndexRef.current, items.length - 1);
+    activeDockIndexRef.current = clamped;
+    syncDockTabStops(items, clamped);
+  });
+
+  const handleDockFocusCapture = useCallback(
+    (e: React.FocusEvent<HTMLElement>) => {
+      const target = e.target as HTMLElement;
+      const items = getDockItems();
+      const idx = items.indexOf(target);
+      if (idx !== -1) {
+        activeDockIndexRef.current = idx;
+        syncDockTabStops(items, idx);
+      }
+    },
+    [getDockItems, syncDockTabStops]
+  );
+
+  const handleDockKeyDown = useCallback(
+    (e: React.KeyboardEvent<HTMLElement>) => {
+      // dnd-kit's KeyboardSensor owns Space/Enter (lift) and arrows (move)
+      // while a drag is active. Early-return so reordering still works.
+      if (dndActive !== null) return;
+      if (e.metaKey || e.altKey || e.ctrlKey) return;
+
+      const items = getDockItems();
+      if (items.length === 0) return;
+
+      const currentIdx = activeDockIndexRef.current;
+      let newIdx: number | null = null;
+
+      switch (e.key) {
+        case "ArrowRight":
+          newIdx = (currentIdx + 1) % items.length;
+          break;
+        case "ArrowLeft":
+          newIdx = (currentIdx - 1 + items.length) % items.length;
+          break;
+        case "Home":
+          newIdx = 0;
+          break;
+        case "End":
+          newIdx = items.length - 1;
+          break;
+      }
+
+      if (newIdx !== null) {
+        e.preventDefault();
+        activeDockIndexRef.current = newIdx;
+        syncDockTabStops(items, newIdx);
+        const target = items[newIdx]!;
+        // .focus() must precede scrollIntoView — the browser's own
+        // scroll-on-focus would otherwise override the explicit instant scroll.
+        target.focus();
+        target.scrollIntoView({ behavior: "instant", block: "nearest", inline: "nearest" });
+      }
+    },
+    [dndActive, getDockItems, syncDockTabStops]
+  );
 
   // Make the dock terminals area droppable
   const { setNodeRef: setDockDropRef, isOver } = useDroppable({
@@ -280,6 +367,12 @@ export function ContentDock({ density = "normal" }: ContentDockProps) {
             {/* Scrollable Container */}
             <div
               ref={combinedRef}
+              role="toolbar"
+              aria-label="Docked terminals"
+              aria-orientation="horizontal"
+              aria-busy={isDndActive || undefined}
+              onKeyDown={handleDockKeyDown}
+              onFocusCapture={handleDockFocusCapture}
               className={cn(
                 "flex items-center gap-[var(--dock-gap)] overflow-x-auto overscroll-x-none flex-1 min-h-[var(--dock-item-height)] no-scrollbar scroll-smooth px-1 transition-[color,background-color,box-shadow]",
                 isWorktreeSortDragging && "cursor-no-drop",

--- a/src/components/Layout/DockedTabGroup.tsx
+++ b/src/components/Layout/DockedTabGroup.tsx
@@ -472,6 +472,7 @@ export function DockedTabGroup({ group, panels }: DockedTabGroupProps) {
       <TerminalContextMenu terminalId={activePanel.id} forceLocation="dock">
         <PopoverTrigger asChild>
           <button
+            data-dock-item=""
             className={cn(
               "flex items-center gap-1.5 px-3 h-[var(--dock-item-height)] rounded-[var(--radius-md)] text-xs border transition duration-150 max-w-[280px]",
               "bg-[var(--dock-item-bg)] border-[var(--dock-item-border)] text-daintree-text/70",

--- a/src/components/Layout/DockedTerminalItem.tsx
+++ b/src/components/Layout/DockedTerminalItem.tsx
@@ -286,6 +286,7 @@ export function DockedTerminalItem({ terminal }: DockedTerminalItemProps) {
       <TerminalContextMenu terminalId={terminal.id} forceLocation="dock">
         <PopoverTrigger asChild>
           <button
+            data-dock-item=""
             className={cn(
               "flex items-center gap-1.5 px-3 h-[var(--dock-item-height)] rounded-[var(--radius-md)] text-xs border transition duration-150 max-w-[280px]",
               "bg-[var(--dock-item-bg)] border-[var(--dock-item-border)] text-daintree-text/70",

--- a/src/components/Layout/__tests__/ContentDock.test.tsx
+++ b/src/components/Layout/__tests__/ContentDock.test.tsx
@@ -145,4 +145,107 @@ describe("ContentDock regression test", () => {
     expect(panelsByIdGuard).toBeGreaterThan(effectStart);
     expect(panelsByIdGuard).toBeLessThan(closeCall);
   });
+
+  // Issue #8170 — the scrollable chip rail is an ARIA toolbar with a single
+  // tab stop and roving tabindex Arrow/Home/End navigation. dnd-kit's
+  // KeyboardSensor owns the keys during an active drag; the rail handler
+  // must early-return when useDndContext().active != null. Focusing an
+  // off-screen chip scrolls it into view with behavior:"instant".
+  describe("keyboard navigation — issue #8170", () => {
+    it("marks the scrollable rail as an ARIA toolbar", () => {
+      const content = readFileSync(resolve(__dirname, "../ContentDock.tsx"), "utf-8");
+
+      expect(content).toContain('role="toolbar"');
+      expect(content).toContain('aria-label="Docked terminals"');
+      expect(content).toContain('aria-orientation="horizontal"');
+    });
+
+    it("flips aria-busy on the rail while a dnd-kit drag is active", () => {
+      const content = readFileSync(resolve(__dirname, "../ContentDock.tsx"), "utf-8");
+
+      expect(content).toMatch(/const\s+\{\s*active:\s*dndActive\s*\}\s*=\s*useDndContext\(\)/);
+      expect(content).toContain("const isDndActive = dndActive !== null");
+      expect(content).toContain("aria-busy={isDndActive || undefined}");
+    });
+
+    it("queries [data-dock-item] chips inside the scroll container", () => {
+      const content = readFileSync(resolve(__dirname, "../ContentDock.tsx"), "utf-8");
+
+      expect(content).toContain('querySelectorAll<HTMLElement>("[data-dock-item]")');
+      expect(content).toContain("offsetParent !== null");
+    });
+
+    it("uses a ref (not state) for the active dock index", () => {
+      const content = readFileSync(resolve(__dirname, "../ContentDock.tsx"), "utf-8");
+
+      expect(content).toContain("activeDockIndexRef = useRef(0)");
+    });
+
+    it("syncs roving tab stops via useLayoutEffect", () => {
+      const content = readFileSync(resolve(__dirname, "../ContentDock.tsx"), "utf-8");
+
+      expect(content).toContain("useLayoutEffect");
+      expect(content).toContain("syncDockTabStops");
+      // Clamp matches Toolbar.tsx pattern when chips are added/removed.
+      expect(content).toMatch(/Math\.min\(activeDockIndexRef\.current,\s*items\.length\s*-\s*1\)/);
+    });
+
+    it("wires onKeyDown and onFocusCapture to the rail container", () => {
+      const content = readFileSync(resolve(__dirname, "../ContentDock.tsx"), "utf-8");
+
+      expect(content).toContain("onKeyDown={handleDockKeyDown}");
+      expect(content).toContain("onFocusCapture={handleDockFocusCapture}");
+    });
+
+    it("early-returns the key handler when dnd-kit has an active drag", () => {
+      const content = readFileSync(resolve(__dirname, "../ContentDock.tsx"), "utf-8");
+
+      // The guard must appear inside handleDockKeyDown, before any
+      // preventDefault or arrow-key handling.
+      const handlerStart = content.indexOf("handleDockKeyDown = useCallback");
+      const guard = content.indexOf("if (dndActive !== null) return", handlerStart);
+      const switchStart = content.indexOf("switch (e.key)", handlerStart);
+
+      expect(handlerStart).toBeGreaterThan(0);
+      expect(guard).toBeGreaterThan(handlerStart);
+      expect(guard).toBeLessThan(switchStart);
+    });
+
+    it("handles Arrow/Home/End with wrap and preventDefault inside the switch", () => {
+      const content = readFileSync(resolve(__dirname, "../ContentDock.tsx"), "utf-8");
+
+      expect(content).toContain('case "ArrowRight"');
+      expect(content).toContain('case "ArrowLeft"');
+      expect(content).toContain('case "Home"');
+      expect(content).toContain('case "End"');
+      // Wrap arithmetic on both ends.
+      expect(content).toMatch(/\(currentIdx \+ 1\) % items\.length/);
+      expect(content).toMatch(/\(currentIdx - 1 \+ items\.length\) % items\.length/);
+    });
+
+    it("focuses then scrolls instantly — focus must precede scrollIntoView", () => {
+      const content = readFileSync(resolve(__dirname, "../ContentDock.tsx"), "utf-8");
+
+      expect(content).toContain('scrollIntoView({ behavior: "instant"');
+      expect(content).toContain('block: "nearest"');
+      expect(content).toContain('inline: "nearest"');
+
+      // .focus() must come before scrollIntoView in handleDockKeyDown so the
+      // browser's own scroll-on-focus does not override the explicit call.
+      const handlerStart = content.indexOf("handleDockKeyDown = useCallback");
+      const focusCall = content.indexOf("target.focus()", handlerStart);
+      const scrollCall = content.indexOf("target.scrollIntoView", handlerStart);
+
+      expect(focusCall).toBeGreaterThan(0);
+      expect(scrollCall).toBeGreaterThan(focusCall);
+    });
+
+    it("preserves data-dock-item attribute on chip buttons", () => {
+      const terminalItem = readFileSync(resolve(__dirname, "../DockedTerminalItem.tsx"), "utf-8");
+      const tabGroup = readFileSync(resolve(__dirname, "../DockedTabGroup.tsx"), "utf-8");
+
+      expect(terminalItem).toContain('data-dock-item=""');
+      expect(tabGroup).toContain('data-dock-item=""');
+    });
+  });
 });


### PR DESCRIPTION
## Summary

The dock chip rail held 10-20+ chips, each its own tab stop — keyboard users had to Tab through every chip to reach anything past the rail. That's a WCAG 2.4.3 Focus Order failure on what's also the highest-traffic switching surface in the app.

Promotes the scrollable rail to an ARIA toolbar with a single tab stop and roving tabindex Arrow/Home/End navigation. Off-screen chips scroll into view instantly on focus.

- `ContentDock.tsx` — scrollable wrapper gets `role="toolbar"`, `aria-label="Docked terminals"`, `aria-orientation="horizontal"`, plus `aria-busy` while a dnd-kit drag is active. `handleDockKeyDown` walks `[data-dock-item]` chips, wraps at both ends, and early-returns when `useDndContext().active != null` so dnd-kit's `KeyboardSensor` still owns Space/Enter and arrows during keyboard-driven reorder. Focus precedes `scrollIntoView({behavior:"instant", block:"nearest", inline:"nearest"})` so the browser's scroll-on-focus does not override the explicit call.
- `DockedTerminalItem.tsx` / `DockedTabGroup.tsx` — add `data-dock-item=""` to the chip buttons. The popover-internal tablist in `DockedTabGroup` (lines 338-392) is untouched.

Pattern mirrors `Toolbar.tsx` (lines 324-393) verbatim; deliberately not lifted into a shared hook per the issue's guidance until a fourth use case appears.

## Test plan

- [x] `npm test -- src/components/Layout/__tests__/ContentDock.test.tsx --run` — 23/23 pass (13 existing + 10 new)
- [x] `npm run check` (typecheck + lint + ratchet + format) — clean; lint warnings decreased by 8
- [ ] Manual: Tab into the dock — only one chip receives focus; remaining chips are skipped on Tab
- [ ] Manual: Arrow Left/Right/Home/End cycle through chips with wrap; off-screen chips scroll into view instantly
- [ ] Manual: Start a dnd-kit keyboard drag (focus a chip, Space) — arrows reorder rather than re-focus

Fixes #8170