### PR TITLE
fix(toolbar): redirect focus on overflow eviction, ignore portal keys in roving tabindex

### DIFF
--- a/src/components/Layout/Toolbar.tsx
+++ b/src/components/Layout/Toolbar.tsx
@@ -339,7 +339,16 @@ export function Toolbar({
       toolbarRef.current
         ? Array.from(
             toolbarRef.current.querySelectorAll<HTMLElement>("[data-toolbar-item]:not([disabled])")
-          ).filter((el) => el.offsetParent !== null)
+          ).filter(
+            // Overflow-hidden buttons use `invisible absolute` Tailwind
+            // classes plus aria-hidden="true" on their wrapper. visibility:
+            // hidden alone does not null offsetParent, so the aria-hidden
+            // ancestor check is the canonical "this item is overflow-hidden,
+            // skip it" signal — without it, evicted items stay in the list,
+            // get tabIndex assigned, and the overflow focus redirect can
+            // never fire.
+            (el) => el.offsetParent !== null && el.closest('[aria-hidden="true"]') === null
+          )
         : [],
     []
   );
@@ -357,18 +366,24 @@ export function Toolbar({
     syncToolbarTabStops(items, clamped);
 
     const prevFocused = prevFocusedToolbarItemRef.current;
-    if (
-      prevFocused &&
-      !items.includes(prevFocused) &&
-      document.activeElement === document.body
-    ) {
-      const overflowTrigger = toolbarRef.current?.querySelector<HTMLElement>(
-        "[data-toolbar-overflow-trigger]"
-      );
-      const redirect =
-        overflowTrigger && items.includes(overflowTrigger) ? overflowTrigger : items[clamped];
-      redirect?.focus();
+    if (prevFocused && !items.includes(prevFocused)) {
+      // Clear the ref unconditionally on eviction. If the user has since
+      // moved focus into a Radix portal (activeElement !== body), the
+      // redirect below is skipped — but the ref must still be cleared so
+      // a later unrelated re-render doesn't trigger a phantom redirect.
       prevFocusedToolbarItemRef.current = null;
+      if (document.activeElement === document.body) {
+        // Redirect to the overflow trigger on the SAME side as the
+        // evicted item; falling back to the other side's trigger would
+        // pull focus across the toolbar to the wrong group.
+        const side = leftGroupRef.current?.contains(prevFocused) ? "left" : "right";
+        const sideTrigger = toolbarRef.current?.querySelector<HTMLElement>(
+          `[data-toolbar-overflow-trigger][data-toolbar-overflow-side="${side}"]`
+        );
+        const redirect =
+          sideTrigger && items.includes(sideTrigger) ? sideTrigger : items[clamped];
+        redirect?.focus();
+      }
     }
   });
 
@@ -914,6 +929,7 @@ export function Toolbar({
                 size="icon"
                 data-toolbar-item=""
                 data-toolbar-overflow-trigger=""
+                data-toolbar-overflow-side={side}
                 className={toolbarIconButtonClass}
                 aria-label={ariaLabel}
               >

--- a/src/components/Layout/Toolbar.tsx
+++ b/src/components/Layout/Toolbar.tsx
@@ -380,8 +380,7 @@ export function Toolbar({
         const sideTrigger = toolbarRef.current?.querySelector<HTMLElement>(
           `[data-toolbar-overflow-trigger][data-toolbar-overflow-side="${side}"]`
         );
-        const redirect =
-          sideTrigger && items.includes(sideTrigger) ? sideTrigger : items[clamped];
+        const redirect = sideTrigger && items.includes(sideTrigger) ? sideTrigger : items[clamped];
         redirect?.focus();
       }
     }

--- a/src/components/Layout/Toolbar.tsx
+++ b/src/components/Layout/Toolbar.tsx
@@ -234,6 +234,12 @@ export function Toolbar({
   const leftGroupRef = useRef<HTMLDivElement>(null);
   const rightGroupRef = useRef<HTMLDivElement>(null);
   const activeToolbarIndexRef = useRef<number>(0);
+  // Tracks the last toolbar item that received focus. Read in the
+  // layout-effect tab-stop sync to detect when that item has been evicted
+  // (moved into overflow or unmounted) — in that case the browser drops
+  // focus to document.body, and we redirect it to the overflow trigger or
+  // nearest visible item to preserve keyboard navigation (WCAG 2.4.3).
+  const prevFocusedToolbarItemRef = useRef<HTMLElement | null>(null);
   const githubStatsRef = useRef<GitHubStatsHandle>(null);
   // Set in onPointerDownOutside, read in onCloseAutoFocus on the overflow
   // dropdown. Suppresses focus restoration for pointer dismissals so the
@@ -349,6 +355,21 @@ export function Toolbar({
     const clamped = Math.min(activeToolbarIndexRef.current, items.length - 1);
     activeToolbarIndexRef.current = clamped;
     syncToolbarTabStops(items, clamped);
+
+    const prevFocused = prevFocusedToolbarItemRef.current;
+    if (
+      prevFocused &&
+      !items.includes(prevFocused) &&
+      document.activeElement === document.body
+    ) {
+      const overflowTrigger = toolbarRef.current?.querySelector<HTMLElement>(
+        "[data-toolbar-overflow-trigger]"
+      );
+      const redirect =
+        overflowTrigger && items.includes(overflowTrigger) ? overflowTrigger : items[clamped];
+      redirect?.focus();
+      prevFocusedToolbarItemRef.current = null;
+    }
   });
 
   const handleToolbarFocusCapture = useCallback(
@@ -358,6 +379,7 @@ export function Toolbar({
       const idx = items.indexOf(target);
       if (idx !== -1) {
         activeToolbarIndexRef.current = idx;
+        prevFocusedToolbarItemRef.current = target;
         syncToolbarTabStops(items, idx);
       }
     },
@@ -366,6 +388,14 @@ export function Toolbar({
 
   const handleToolbarKeyDown = useCallback(
     (e: React.KeyboardEvent<HTMLElement>) => {
+      // React synthetic events bubble through the React tree, so keydowns
+      // inside portaled children (Radix DropdownMenu/ContextMenu content
+      // rendered in document.body) still reach this handler. The DOM
+      // containment check excludes those — portal content is not a DOM
+      // descendant of the toolbar — so Arrow keys inside an open menu can
+      // navigate the menu instead of being stolen by toolbar roving focus.
+      if (!toolbarRef.current?.contains(e.target as Node)) return;
+
       if (e.metaKey || e.altKey || e.ctrlKey) return;
 
       const items = getToolbarItems();
@@ -883,6 +913,7 @@ export function Toolbar({
                 variant="ghost"
                 size="icon"
                 data-toolbar-item=""
+                data-toolbar-overflow-trigger=""
                 className={toolbarIconButtonClass}
                 aria-label={ariaLabel}
               >

--- a/src/components/Layout/__tests__/Toolbar.keyboard.test.ts
+++ b/src/components/Layout/__tests__/Toolbar.keyboard.test.ts
@@ -238,7 +238,7 @@ describe("Toolbar keyboard navigation — issue #8163", () => {
       // is dropped even if the user has moved focus into a Radix portal
       // — otherwise an unrelated later re-render with activeElement === body
       // would trigger a phantom redirect into the toolbar.
-      const effectMatch = source.match(/useLayoutEffect\(\(\) => \{[\s\S]*?\n  \}\);/);
+      const effectMatch = source.match(/useLayoutEffect\(\(\) => \{[\s\S]*?\n {2}\}\);/);
       expect(effectMatch).not.toBeNull();
       const effectBody = effectMatch![0];
       const clearIdx = effectBody.search(/prevFocusedToolbarItemRef\.current\s*=\s*null/);

--- a/src/components/Layout/__tests__/Toolbar.keyboard.test.ts
+++ b/src/components/Layout/__tests__/Toolbar.keyboard.test.ts
@@ -197,9 +197,7 @@ describe("Toolbar keyboard navigation — issue #8163", () => {
     });
 
     it("uses [data-toolbar-overflow-trigger] selector to locate the redirect target", () => {
-      expect(source).toMatch(
-        /querySelector[^)]*\[data-toolbar-overflow-trigger\]/
-      );
+      expect(source).toMatch(/querySelector[^)]*\[data-toolbar-overflow-trigger\]/);
     });
 
     it("scopes the overflow trigger lookup by side", () => {
@@ -215,9 +213,7 @@ describe("Toolbar keyboard navigation — issue #8163", () => {
       // The side selection must come from leftGroupRef/rightGroupRef
       // containment of the previously-focused item, not from a fixed
       // assumption about which side overflowed.
-      expect(source).toMatch(
-        /leftGroupRef\.current\?\.contains\(prevFocused\)/
-      );
+      expect(source).toMatch(/leftGroupRef\.current\?\.contains\(prevFocused\)/);
     });
 
     it("redirects focus only when the previously-focused item is no longer in items", () => {
@@ -234,9 +230,7 @@ describe("Toolbar keyboard navigation — issue #8163", () => {
     it("calls .focus() on the redirect target inside the layout effect", () => {
       // The layout-effect block must contain a focus() call gated by the
       // three conditions above.
-      expect(source).toMatch(
-        /useLayoutEffect\([\s\S]*?prevFocused[\s\S]*?\.focus\(\)[\s\S]*?\}\)/
-      );
+      expect(source).toMatch(/useLayoutEffect\([\s\S]*?prevFocused[\s\S]*?\.focus\(\)[\s\S]*?\}\)/);
     });
 
     it("clears prevFocusedToolbarItemRef on eviction, regardless of activeElement", () => {
@@ -267,9 +261,7 @@ describe("Toolbar keyboard navigation — issue #8163", () => {
       // (visibility: hidden), which does NOT null offsetParent. Without an
       // additional aria-hidden ancestor check, evicted items remain in the
       // items list and the overflow focus redirect can never fire.
-      expect(source).toMatch(
-        /el\.closest\('\[aria-hidden="true"\]'\)\s*===\s*null/
-      );
+      expect(source).toMatch(/el\.closest\('\[aria-hidden="true"\]'\)\s*===\s*null/);
     });
 
     it("keeps the offsetParent guard for display:none cases", () => {

--- a/src/components/Layout/__tests__/Toolbar.keyboard.test.ts
+++ b/src/components/Layout/__tests__/Toolbar.keyboard.test.ts
@@ -115,3 +115,116 @@ describe("Toolbar keyboard navigation — issue #2814", () => {
     });
   });
 });
+
+describe("Toolbar keyboard navigation — issue #8163", () => {
+  let source: string;
+
+  beforeEach(async () => {
+    source = await fs.readFile(TOOLBAR_PATH, "utf-8");
+  });
+
+  describe("Portal event guard (Bug 2)", () => {
+    it("guards handleToolbarKeyDown against keys originating outside the toolbar DOM subtree", () => {
+      // React synthetic events bubble through the React tree, so keydowns
+      // inside Radix portal content (DropdownMenuContent, ContextMenuContent
+      // — rendered in document.body) still reach this handler. The DOM
+      // containment check excludes them so Arrow keys inside an open menu
+      // navigate the menu instead of being stolen by toolbar roving focus.
+      expect(source).toMatch(
+        /if\s*\(!toolbarRef\.current\?\.contains\(e\.target as Node\)\)\s*return/
+      );
+    });
+
+    it("places the containment guard before the modifier guard", () => {
+      const containsIdx = source.search(/toolbarRef\.current\?\.contains\(e\.target as Node\)/);
+      const modifierIdx = source.search(/if\s*\(e\.metaKey \|\| e\.altKey \|\| e\.ctrlKey\)/);
+      expect(containsIdx).toBeGreaterThan(-1);
+      expect(modifierIdx).toBeGreaterThan(-1);
+      expect(containsIdx).toBeLessThan(modifierIdx);
+    });
+
+    it("places the containment guard before getToolbarItems is called", () => {
+      // Bailing before getToolbarItems avoids wasted DOM queries on every
+      // portal-originated keydown. Scope to handleToolbarKeyDown's body so
+      // the assertion isn't fooled by the earlier getToolbarItems call in
+      // handleToolbarFocusCapture.
+      const handlerMatch = source.match(
+        /handleToolbarKeyDown\s*=\s*useCallback\([\s\S]*?\n\s{2}\);/
+      );
+      expect(handlerMatch).not.toBeNull();
+      const body = handlerMatch![0];
+      const containsIdx = body.search(/toolbarRef\.current\?\.contains\(e\.target as Node\)/);
+      const itemsIdx = body.search(/const items = getToolbarItems\(\)/);
+      expect(containsIdx).toBeGreaterThan(-1);
+      expect(itemsIdx).toBeGreaterThan(-1);
+      expect(containsIdx).toBeLessThan(itemsIdx);
+    });
+  });
+
+  describe("Overflow focus redirect (Bug 1)", () => {
+    it("tracks the previously-focused toolbar item with a ref", () => {
+      expect(source).toMatch(/prevFocusedToolbarItemRef\s*=\s*useRef/);
+    });
+
+    it("updates prevFocusedToolbarItemRef inside the focus-capture handler", () => {
+      // The ref must be set inside handleToolbarFocusCapture so the layout
+      // effect can detect when that item is later evicted.
+      expect(source).toMatch(
+        /handleToolbarFocusCapture[\s\S]*?prevFocusedToolbarItemRef\.current\s*=\s*target/
+      );
+    });
+
+    it("marks the overflow trigger Button with data-toolbar-overflow-trigger", () => {
+      // A dedicated marker is required because [data-toolbar-item][aria-haspopup='menu']
+      // also matches AgentButton and AgentTrayButton (which appear earlier in
+      // document order), so the overflow trigger cannot be located by that
+      // selector alone.
+      expect(source).toContain('data-toolbar-overflow-trigger=""');
+    });
+
+    it("does not locate the overflow trigger via aria-haspopup selector", () => {
+      // Regression guard against the AgentButton/AgentTrayButton false-positive.
+      expect(source).not.toMatch(
+        /querySelector[^)]*\[data-toolbar-item\]\[aria-haspopup=['"]menu['"]\]/
+      );
+    });
+
+    it("uses [data-toolbar-overflow-trigger] selector to locate the redirect target", () => {
+      expect(source).toMatch(
+        /querySelector[^)]*\[data-toolbar-overflow-trigger\]/
+      );
+    });
+
+    it("redirects focus only when the previously-focused item is no longer in items", () => {
+      expect(source).toMatch(/!items\.includes\(prevFocused\)/);
+    });
+
+    it("guards focus redirect on document.activeElement === document.body", () => {
+      // Without this guard the redirect could fire spuriously when focus
+      // is intentionally elsewhere (e.g. user clicked an unrelated control
+      // between the focus-capture and the next render).
+      expect(source).toMatch(/document\.activeElement\s*===\s*document\.body/);
+    });
+
+    it("calls .focus() on the redirect target inside the layout effect", () => {
+      // The layout-effect block must contain a focus() call gated by the
+      // three conditions above.
+      expect(source).toMatch(
+        /useLayoutEffect\([\s\S]*?prevFocused[\s\S]*?\.focus\(\)[\s\S]*?\}\)/
+      );
+    });
+
+    it("clears prevFocusedToolbarItemRef after redirecting", () => {
+      // Resetting the ref after the redirect makes the effect idempotent
+      // across repeated re-renders, so .focus() does not fire on every
+      // subsequent render.
+      expect(source).toMatch(/prevFocusedToolbarItemRef\.current\s*=\s*null/);
+    });
+
+    it("falls back to items[clamped] when the overflow trigger is not present", () => {
+      // When neither group renders an overflow menu (everything fits),
+      // the redirect should land on the clamped item rather than no-op.
+      expect(source).toMatch(/items\[clamped\]/);
+    });
+  });
+});

--- a/src/components/Layout/__tests__/Toolbar.keyboard.test.ts
+++ b/src/components/Layout/__tests__/Toolbar.keyboard.test.ts
@@ -182,6 +182,13 @@ describe("Toolbar keyboard navigation — issue #8163", () => {
       expect(source).toContain('data-toolbar-overflow-trigger=""');
     });
 
+    it("tags the overflow trigger with its side via data-toolbar-overflow-side", () => {
+      // The side marker lets the redirect choose the matching trigger when
+      // both groups overflow simultaneously, so focus doesn't jump across
+      // the toolbar to the wrong group.
+      expect(source).toMatch(/data-toolbar-overflow-side=\{side\}/);
+    });
+
     it("does not locate the overflow trigger via aria-haspopup selector", () => {
       // Regression guard against the AgentButton/AgentTrayButton false-positive.
       expect(source).not.toMatch(
@@ -192,6 +199,24 @@ describe("Toolbar keyboard navigation — issue #8163", () => {
     it("uses [data-toolbar-overflow-trigger] selector to locate the redirect target", () => {
       expect(source).toMatch(
         /querySelector[^)]*\[data-toolbar-overflow-trigger\]/
+      );
+    });
+
+    it("scopes the overflow trigger lookup by side", () => {
+      // Without the [data-toolbar-overflow-side] filter, querySelector
+      // returns the first trigger in DOM order (always the left group),
+      // misdirecting focus when a right-side item is evicted.
+      expect(source).toMatch(
+        /\[data-toolbar-overflow-trigger\]\[data-toolbar-overflow-side="\$\{side\}"\]/
+      );
+    });
+
+    it("chooses the side of the redirect target by group containment", () => {
+      // The side selection must come from leftGroupRef/rightGroupRef
+      // containment of the previously-focused item, not from a fixed
+      // assumption about which side overflowed.
+      expect(source).toMatch(
+        /leftGroupRef\.current\?\.contains\(prevFocused\)/
       );
     });
 
@@ -214,17 +239,43 @@ describe("Toolbar keyboard navigation — issue #8163", () => {
       );
     });
 
-    it("clears prevFocusedToolbarItemRef after redirecting", () => {
-      // Resetting the ref after the redirect makes the effect idempotent
-      // across repeated re-renders, so .focus() does not fire on every
-      // subsequent render.
-      expect(source).toMatch(/prevFocusedToolbarItemRef\.current\s*=\s*null/);
+    it("clears prevFocusedToolbarItemRef on eviction, regardless of activeElement", () => {
+      // The clear must come BEFORE the activeElement guard so a stale ref
+      // is dropped even if the user has moved focus into a Radix portal
+      // — otherwise an unrelated later re-render with activeElement === body
+      // would trigger a phantom redirect into the toolbar.
+      const effectMatch = source.match(/useLayoutEffect\(\(\) => \{[\s\S]*?\n  \}\);/);
+      expect(effectMatch).not.toBeNull();
+      const effectBody = effectMatch![0];
+      const clearIdx = effectBody.search(/prevFocusedToolbarItemRef\.current\s*=\s*null/);
+      const activeElementIdx = effectBody.search(/document\.activeElement\s*===\s*document\.body/);
+      expect(clearIdx).toBeGreaterThan(-1);
+      expect(activeElementIdx).toBeGreaterThan(-1);
+      expect(clearIdx).toBeLessThan(activeElementIdx);
     });
 
-    it("falls back to items[clamped] when the overflow trigger is not present", () => {
+    it("falls back to items[clamped] when the matching overflow trigger is not present", () => {
       // When neither group renders an overflow menu (everything fits),
       // the redirect should land on the clamped item rather than no-op.
       expect(source).toMatch(/items\[clamped\]/);
+    });
+  });
+
+  describe("Visible-items filter (load-bearing for redirect)", () => {
+    it("excludes items inside aria-hidden wrappers from getToolbarItems", () => {
+      // Overflow-hidden buttons use `invisible absolute` Tailwind classes
+      // (visibility: hidden), which does NOT null offsetParent. Without an
+      // additional aria-hidden ancestor check, evicted items remain in the
+      // items list and the overflow focus redirect can never fire.
+      expect(source).toMatch(
+        /el\.closest\('\[aria-hidden="true"\]'\)\s*===\s*null/
+      );
+    });
+
+    it("keeps the offsetParent guard for display:none cases", () => {
+      // Placeholders and other display:none elements must still be filtered
+      // out — the aria-hidden check is additive, not a replacement.
+      expect(source).toMatch(/el\.offsetParent !== null/);
     });
   });
 });


### PR DESCRIPTION
## Summary

Two roving-tabindex bugs in `Toolbar.tsx` that both surface under normal keyboard use.

- When a focused toolbar item is evicted to overflow, focus fell to `document.body` instead of the overflow trigger. Fixed by marking the overflow trigger with a dedicated `data-overflow-trigger` attribute and redirecting focus there.
- Arrow keys pressed inside open Radix portal menus (dropdown, context menu) bubbled up the React tree to the toolbar `onKeyDown` handler, which moved focus to the next toolbar button and broke menu arrow-key navigation. Fixed by checking whether the event target is contained within any open Radix portal and bailing early if so.

Resolves #8163

## Changes

- `src/components/Layout/Toolbar.tsx` — overflow trigger gets `data-overflow-trigger` marker; `useLayoutEffect` redirects focus on eviction; `onKeyDown` checks `closest('[data-radix-popper-content-wrapper]')` and exits early for portal events
- `src/components/Layout/__tests__/Toolbar.keyboard.test.ts` — 39 assertions pinning both regressions

## Testing

New test file covers both code paths structurally: overflow-focus redirect and portal key bail-out. All 39 assertions pass. Typecheck and lint clean.