### PR TITLE
fix(toolbar): derive Windows caption spacer width from WCO env() vars

### DIFF
--- a/electron/window/skeletonCss.ts
+++ b/electron/window/skeletonCss.ts
@@ -61,10 +61,12 @@ export function injectSkeletonCss(wc: WebContents): void {
   lines.push(`  --skeleton-sidebar-width: ${sidebarWidth}px;`);
   lines.push(`  --skeleton-focus-mode: ${focusMode ? "1" : "0"};`);
 
-  // Reserve space for Windows native caption buttons (minimize/maximize/close).
-  // Static 138px ≈ 3 × 46px backplates on Windows 11 @ 96 DPI; Electron 41 has
-  // no API to read actual geometry, so the trailing toolbar spacer in Toolbar.tsx
-  // uses this var with a 138px fallback. See issue #7951.
+  // Reserve space for Windows native caption buttons in the pre-React skeleton
+  // (consumed by index.html's .skeleton-toolbar-right). The live Toolbar reads
+  // env(titlebar-area-width) directly via the Window Controls Overlay API, so
+  // this variable only covers the brief skeleton phase before WCO env vars are
+  // wired up in the renderer. 138px ≈ 3 × 46px backplates on Windows 11 @ 96 DPI.
+  // See issues #7951 and #8167.
   if (process.platform === "win32") {
     lines.push("  --win-caption-width: 138px;");
   }

--- a/src/components/Layout/Toolbar.tsx
+++ b/src/components/Layout/Toolbar.tsx
@@ -1161,7 +1161,11 @@ export function Toolbar({
                 "shrink-0 transition-[width] duration-200 data-[fullscreen=true]:duration-[120ms]",
                 isFullscreen && "w-0"
               )}
-              style={isFullscreen ? undefined : { width: "var(--win-caption-width, 138px)" }}
+              style={
+                isFullscreen
+                  ? undefined
+                  : { width: "calc(100% - env(titlebar-area-width, calc(100% - 138px)))" }
+              }
             />
           )}
         </div>

--- a/src/components/Layout/Toolbar.tsx
+++ b/src/components/Layout/Toolbar.tsx
@@ -1164,7 +1164,7 @@ export function Toolbar({
               style={
                 isFullscreen
                   ? undefined
-                  : { width: "calc(100% - env(titlebar-area-width, calc(100% - 138px)))" }
+                  : { width: "calc(100vw - env(titlebar-area-width, calc(100vw - 138px)))" }
               }
             />
           )}

--- a/src/components/Layout/__tests__/Toolbar.layout.test.ts
+++ b/src/components/Layout/__tests__/Toolbar.layout.test.ts
@@ -200,8 +200,9 @@ describe("Toolbar layout — issue #2584 project switcher collision", () => {
     });
 
     it("derives spacer width from the WCO env(titlebar-area-width) expression", () => {
-      expect(source).toContain("env(titlebar-area-width");
-      expect(source).toContain("calc(100% - 138px)");
+      expect(source).toContain(
+        "calc(100vw - env(titlebar-area-width, calc(100vw - 138px)))"
+      );
       expect(source).not.toContain("var(--win-caption-width");
     });
 

--- a/src/components/Layout/__tests__/Toolbar.layout.test.ts
+++ b/src/components/Layout/__tests__/Toolbar.layout.test.ts
@@ -200,9 +200,7 @@ describe("Toolbar layout — issue #2584 project switcher collision", () => {
     });
 
     it("derives spacer width from the WCO env(titlebar-area-width) expression", () => {
-      expect(source).toContain(
-        "calc(100vw - env(titlebar-area-width, calc(100vw - 138px)))"
-      );
+      expect(source).toContain("calc(100vw - env(titlebar-area-width, calc(100vw - 138px)))");
       expect(source).not.toContain("var(--win-caption-width");
     });
 

--- a/src/components/Layout/__tests__/Toolbar.layout.test.ts
+++ b/src/components/Layout/__tests__/Toolbar.layout.test.ts
@@ -186,7 +186,7 @@ describe("Toolbar layout — issue #2584 project switcher collision", () => {
     });
   });
 
-  describe("Windows caption control spacer — issue #7951", () => {
+  describe("Windows caption control spacer — issues #7951 / #8167", () => {
     it("imports isWindows from the platform helper", () => {
       expect(source).toMatch(/import\s*{[^}]*\bisWindows\b[^}]*}\s*from\s*"@\/lib\/platform"/);
     });
@@ -199,8 +199,10 @@ describe("Toolbar layout — issue #2584 project switcher collision", () => {
       expect(source).toMatch(/isWindows\(\)\s*&&\s*\(/);
     });
 
-    it("reserves space via the --win-caption-width CSS variable", () => {
-      expect(source).toContain("var(--win-caption-width, 138px)");
+    it("derives spacer width from the WCO env(titlebar-area-width) expression", () => {
+      expect(source).toContain("env(titlebar-area-width");
+      expect(source).toContain("calc(100% - 138px)");
+      expect(source).not.toContain("var(--win-caption-width");
     });
 
     it("collapses the spacer to zero width when entering fullscreen", () => {
@@ -209,7 +211,7 @@ describe("Toolbar layout — issue #2584 project switcher collision", () => {
 
     it("places the spacer inside the right toolbar group, after the portal toggle", () => {
       const rightGroupIndex = source.indexOf('aria-label="Tools and settings"');
-      const spacerIndex = source.indexOf("var(--win-caption-width, 138px)");
+      const spacerIndex = source.indexOf("env(titlebar-area-width");
       const portalToggleIndex = source.indexOf('buttonRegistry["portal-toggle"]');
       expect(rightGroupIndex).toBeGreaterThan(-1);
       expect(spacerIndex).toBeGreaterThan(-1);
@@ -242,7 +244,7 @@ describe("Toolbar layout — issue #2584 project switcher collision", () => {
     it("spacer is decorative (aria-hidden) and not focusable as a toolbar item", () => {
       const spacerBlock = source.slice(
         source.indexOf("isWindows() &&"),
-        source.indexOf("var(--win-caption-width, 138px)") + 200
+        source.indexOf("env(titlebar-area-width") + 200
       );
       expect(spacerBlock).toContain('aria-hidden="true"');
       expect(spacerBlock).not.toContain("data-toolbar-item");


### PR DESCRIPTION
## Summary

- The Windows caption spacer in `Toolbar.tsx` was hard-coded to `var(--win-caption-width, 138px)`, which doesn't update on DPI changes or window resize.
- Replaces it with `calc(100vw - env(titlebar-area-width, calc(100vw - 138px)))` so it live-tracks the Window Controls Overlay API — 138px stays as the fallback for non-WCO contexts.
- `skeletonCss.ts` still injects `--win-caption-width` for the pre-React skeleton phase (the `.skeleton-toolbar-right` element needs it before React loads). Updated the comment to make that scope clear and cross-reference #7951.

Resolves #8167

## Changes

- `src/components/Layout/Toolbar.tsx` — replace hard-coded CSS var with `env(titlebar-area-width)` calc expression
- `electron/window/skeletonCss.ts` — clarify comment scope, cross-reference #7951 and #8167
- `src/components/Layout/__tests__/Toolbar.layout.test.ts` — update assertions to match new expression

## Testing

- Vitest: 41 tests passing
- Format, lint, and typecheck clean