### PR TITLE
feat(shortcut-hints): tighten milestone stack, focus parity, visibility teardown

### DIFF
--- a/src/components/Layout/ToolbarSettingsButton.tsx
+++ b/src/components/Layout/ToolbarSettingsButton.tsx
@@ -55,6 +55,8 @@ export function ToolbarSettingsButton({
               }}
               onPointerLeave={settingsHover.onPointerLeave}
               onPointerDown={settingsHover.onPointerDown}
+              onFocus={settingsHover.onFocus}
+              onBlur={settingsHover.onBlur}
               className={toolbarIconButtonClass}
               aria-label="Open settings"
               aria-keyshortcuts={settingsAriaShortcut}

--- a/src/hooks/__tests__/useHeldShortcutReveal.test.tsx
+++ b/src/hooks/__tests__/useHeldShortcutReveal.test.tsx
@@ -20,6 +20,14 @@ function isRevealed(): boolean {
   return document.documentElement.dataset[REVEAL_DATASET_KEY] === "true";
 }
 
+function setVisibility(state: "visible" | "hidden") {
+  Object.defineProperty(document, "visibilityState", {
+    value: state,
+    configurable: true,
+  });
+  document.dispatchEvent(new Event("visibilitychange"));
+}
+
 describe("useHeldShortcutReveal", () => {
   beforeEach(() => {
     vi.useFakeTimers();
@@ -30,6 +38,10 @@ describe("useHeldShortcutReveal", () => {
   afterEach(() => {
     vi.useRealTimers();
     delete document.documentElement.dataset[REVEAL_DATASET_KEY];
+    Object.defineProperty(document, "visibilityState", {
+      value: "visible",
+      configurable: true,
+    });
   });
 
   it("does not reveal before 500ms threshold", () => {
@@ -168,6 +180,49 @@ describe("useHeldShortcutReveal", () => {
     });
 
     expect(isRevealed()).toBe(false);
+  });
+
+  it("clears reveal when the document becomes hidden (Linux WM workspace switch)", () => {
+    renderHook(() => useHeldShortcutReveal());
+
+    act(() => dispatchKey("keydown", "Meta"));
+    act(() => {
+      vi.advanceTimersByTime(500);
+    });
+    expect(isRevealed()).toBe(true);
+
+    act(() => setVisibility("hidden"));
+
+    expect(isRevealed()).toBe(false);
+  });
+
+  it("cancels a pending reveal timer when the document becomes hidden", () => {
+    renderHook(() => useHeldShortcutReveal());
+
+    act(() => dispatchKey("keydown", "Meta"));
+    act(() => {
+      vi.advanceTimersByTime(400);
+    });
+    act(() => setVisibility("hidden"));
+    act(() => {
+      vi.advanceTimersByTime(2000);
+    });
+
+    expect(isRevealed()).toBe(false);
+  });
+
+  it("does not clear reveal when visibilitychange fires while still visible", () => {
+    renderHook(() => useHeldShortcutReveal());
+
+    act(() => dispatchKey("keydown", "Meta"));
+    act(() => {
+      vi.advanceTimersByTime(500);
+    });
+    expect(isRevealed()).toBe(true);
+
+    act(() => setVisibility("visible"));
+
+    expect(isRevealed()).toBe(true);
   });
 
   it("ignores OS auto-repeat keydown events", () => {

--- a/src/hooks/__tests__/useShortcutHintHover.test.ts
+++ b/src/hooks/__tests__/useShortcutHintHover.test.ts
@@ -24,6 +24,31 @@ function createPointerEvent(
   return { clientX, clientY, currentTarget } as unknown as React.PointerEvent<HTMLButtonElement>;
 }
 
+function createFocusTarget(
+  rect: { left: number; top: number },
+  dataState?: string
+): HTMLButtonElement {
+  const el = document.createElement("button");
+  if (dataState) el.setAttribute("data-state", dataState);
+  el.getBoundingClientRect = () =>
+    ({
+      left: rect.left,
+      top: rect.top,
+      right: 0,
+      bottom: 0,
+      width: 0,
+      height: 0,
+      x: rect.left,
+      y: rect.top,
+      toJSON: () => ({}),
+    }) as DOMRect;
+  return el;
+}
+
+function createFocusEvent(currentTarget: HTMLButtonElement): React.FocusEvent<HTMLButtonElement> {
+  return { currentTarget } as unknown as React.FocusEvent<HTMLButtonElement>;
+}
+
 describe("useShortcutHintHover", () => {
   beforeEach(() => {
     shortcutHintStore.setState({
@@ -148,8 +173,8 @@ describe("useShortcutHintHover", () => {
 
   it("suppresses hint for non-milestone non-zero count", () => {
     getDisplayComboMock.mockReturnValue("⌘B");
-    // Count 4 is not a milestone
-    shortcutHintStore.getState().hydrateCounts({ "nav.toggleSidebar": 4 });
+    // Count 3 is not a milestone
+    shortcutHintStore.getState().hydrateCounts({ "nav.toggleSidebar": 3 });
 
     const { result } = renderHook(() => useShortcutHintHover("nav.toggleSidebar"));
 
@@ -297,6 +322,140 @@ describe("useShortcutHintHover", () => {
     });
     act(() => {
       vi.advanceTimersByTime(1500);
+    });
+    expect(shortcutHintStore.getState().activeHint).toBeNull();
+  });
+
+  // --- Focus parity tests (WCAG 1.4.13) ---
+
+  it("shows hint immediately on focus, positioned from getBoundingClientRect", () => {
+    getDisplayComboMock.mockReturnValue("⌘B");
+    shortcutHintStore.getState().hydrateCounts({ "nav.toggleSidebar": 0 });
+
+    const { result } = renderHook(() => useShortcutHintHover("nav.toggleSidebar"));
+
+    act(() => {
+      vi.advanceTimersByTime(10);
+    });
+
+    act(() => {
+      result.current.onFocus(createFocusEvent(createFocusTarget({ left: 42, top: 84 })));
+    });
+
+    // No timer advance — focus fires synchronously.
+    const hint = shortcutHintStore.getState().activeHint;
+    expect(hint).not.toBeNull();
+    expect(hint!.actionId).toBe("nav.toggleSidebar");
+    expect(hint!.displayCombo).toBe("⌘B");
+    expect(hint!.x).toBe(42);
+    expect(hint!.y).toBe(84);
+  });
+
+  it("skips focus hint when displayCombo is empty", () => {
+    getDisplayComboMock.mockReturnValue("");
+    shortcutHintStore.getState().hydrateCounts({ "nav.toggleSidebar": 0 });
+
+    const { result } = renderHook(() => useShortcutHintHover("nav.toggleSidebar"));
+
+    act(() => {
+      vi.advanceTimersByTime(10);
+    });
+
+    act(() => {
+      result.current.onFocus(createFocusEvent(createFocusTarget({ left: 10, top: 20 })));
+    });
+
+    expect(shortcutHintStore.getState().activeHint).toBeNull();
+  });
+
+  it("suppresses focus hint when trigger data-state is delayed-open", () => {
+    getDisplayComboMock.mockReturnValue("⌘B");
+    shortcutHintStore.getState().hydrateCounts({ "nav.toggleSidebar": 0 });
+
+    const { result } = renderHook(() => useShortcutHintHover("nav.toggleSidebar"));
+
+    act(() => {
+      vi.advanceTimersByTime(10);
+    });
+
+    act(() => {
+      result.current.onFocus(
+        createFocusEvent(createFocusTarget({ left: 1, top: 2 }, "delayed-open"))
+      );
+    });
+
+    expect(shortcutHintStore.getState().activeHint).toBeNull();
+  });
+
+  it("suppresses focus hint for non-milestone non-zero count", () => {
+    getDisplayComboMock.mockReturnValue("⌘B");
+    // Count 3 is not a milestone
+    shortcutHintStore.getState().hydrateCounts({ "nav.toggleSidebar": 3 });
+
+    const { result } = renderHook(() => useShortcutHintHover("nav.toggleSidebar"));
+
+    act(() => {
+      vi.advanceTimersByTime(10);
+    });
+
+    act(() => {
+      result.current.onFocus(createFocusEvent(createFocusTarget({ left: 5, top: 6 })));
+    });
+
+    expect(shortcutHintStore.getState().activeHint).toBeNull();
+  });
+
+  it("hides the hint on blur", () => {
+    getDisplayComboMock.mockReturnValue("⌘B");
+    shortcutHintStore.getState().hydrateCounts({ "nav.toggleSidebar": 0 });
+
+    const { result } = renderHook(() => useShortcutHintHover("nav.toggleSidebar"));
+
+    act(() => {
+      vi.advanceTimersByTime(10);
+    });
+
+    act(() => {
+      result.current.onFocus(createFocusEvent(createFocusTarget({ left: 1, top: 1 })));
+    });
+    expect(shortcutHintStore.getState().activeHint).not.toBeNull();
+
+    act(() => {
+      result.current.onBlur();
+    });
+    expect(shortcutHintStore.getState().activeHint).toBeNull();
+  });
+
+  it("focus cancels a pending pointer dwell timer (no double-show)", () => {
+    getDisplayComboMock.mockReturnValue("⌘B");
+    shortcutHintStore.getState().hydrateCounts({ "nav.toggleSidebar": 0 });
+
+    const { result } = renderHook(() => useShortcutHintHover("nav.toggleSidebar"));
+
+    act(() => {
+      vi.advanceTimersByTime(10);
+    });
+
+    // Pointer enter starts the 1500ms dwell.
+    act(() => {
+      result.current.onPointerEnter(createPointerEvent(100, 200));
+    });
+    act(() => {
+      vi.advanceTimersByTime(500);
+    });
+
+    // Focus fires immediately and must cancel the pending dwell.
+    act(() => {
+      result.current.onFocus(createFocusEvent(createFocusTarget({ left: 7, top: 8 })));
+    });
+    const focusHint = shortcutHintStore.getState().activeHint;
+    expect(focusHint!.x).toBe(7);
+    expect(focusHint!.y).toBe(8);
+
+    // One-shot gating + cancelled timer: no second show, position stays the focus one.
+    shortcutHintStore.getState().hide();
+    act(() => {
+      vi.advanceTimersByTime(2000);
     });
     expect(shortcutHintStore.getState().activeHint).toBeNull();
   });

--- a/src/hooks/__tests__/useShortcutHintHover.test.ts
+++ b/src/hooks/__tests__/useShortcutHintHover.test.ts
@@ -426,6 +426,43 @@ describe("useShortcutHintHover", () => {
     expect(shortcutHintStore.getState().activeHint).toBeNull();
   });
 
+  it("blur does not hide a hint owned by a different element", () => {
+    getDisplayComboMock.mockReturnValue("⌘B");
+    shortcutHintStore.getState().hydrateCounts({
+      "nav.toggleSidebar": 0,
+      "panel.togglePortal": 0,
+    });
+
+    const { result: a } = renderHook(() => useShortcutHintHover("nav.toggleSidebar"));
+    const { result: b } = renderHook(() => useShortcutHintHover("panel.togglePortal"));
+
+    act(() => {
+      vi.advanceTimersByTime(10);
+    });
+
+    // A is focused and showed its hint.
+    act(() => {
+      a.current.onFocus(createFocusEvent(createFocusTarget({ left: 1, top: 1 })));
+    });
+    // B's hint then takes over (simulating a pointer dwell on B).
+    act(() => {
+      shortcutHintStore.getState().show("panel.togglePortal", "⌘P", { x: 9, y: 9 });
+    });
+    expect(shortcutHintStore.getState().activeHint!.actionId).toBe("panel.togglePortal");
+
+    // A blurs — must NOT clear B's hint.
+    act(() => {
+      a.current.onBlur();
+    });
+    expect(shortcutHintStore.getState().activeHint!.actionId).toBe("panel.togglePortal");
+
+    // B blurring its own hint does clear it.
+    act(() => {
+      b.current.onBlur();
+    });
+    expect(shortcutHintStore.getState().activeHint).toBeNull();
+  });
+
   it("focus cancels a pending pointer dwell timer (no double-show)", () => {
     getDisplayComboMock.mockReturnValue("⌘B");
     shortcutHintStore.getState().hydrateCounts({ "nav.toggleSidebar": 0 });

--- a/src/hooks/useHeldShortcutReveal.ts
+++ b/src/hooks/useHeldShortcutReveal.ts
@@ -52,14 +52,22 @@ export function useHeldShortcutReveal(): void {
       clearReveal();
     };
 
+    // Defense-in-depth for Linux WMs (Wayland / some X11) that swallow the
+    // modifier keyup on a virtual-workspace switch without firing window blur.
+    const handleVisibilityChange = () => {
+      if (document.visibilityState !== "visible") clearReveal();
+    };
+
     window.addEventListener("keydown", handleKeyDown);
     window.addEventListener("keyup", handleKeyUp);
     window.addEventListener("blur", handleBlur);
+    document.addEventListener("visibilitychange", handleVisibilityChange);
 
     return () => {
       window.removeEventListener("keydown", handleKeyDown);
       window.removeEventListener("keyup", handleKeyUp);
       window.removeEventListener("blur", handleBlur);
+      document.removeEventListener("visibilitychange", handleVisibilityChange);
       clearReveal();
     };
   }, []);

--- a/src/hooks/useShortcutHintHover.ts
+++ b/src/hooks/useShortcutHintHover.ts
@@ -125,7 +125,12 @@ export function useShortcutHintHover(actionId: string) {
 
   const onBlur = () => {
     clearTimer();
-    shortcutHintStore.getState().hide();
+    // Only clear the hint this element owns — a blur here must not dismiss a
+    // hint another trigger raised (e.g. a pointer dwell on a different button).
+    const store = shortcutHintStore;
+    if (store.getState().activeHint?.actionId === actionId) {
+      store.getState().hide();
+    }
   };
 
   return { onPointerEnter, onPointerLeave, onPointerDown, onFocus, onBlur };

--- a/src/hooks/useShortcutHintHover.ts
+++ b/src/hooks/useShortcutHintHover.ts
@@ -10,9 +10,13 @@ const HOVER_DWELL_MS = 1500;
  * HOVER_DWELL_MS. Only triggers for actions at count 0 (pre-use discovery)
  * or at a milestone count, with one-shot gating per count level.
  *
+ * Keyboard parity (WCAG 1.4.13): focus shows the same hint immediately, with
+ * no dwell delay — keyboard users expect content on focus without a wait.
+ *
  * Returns handlers to spread onto the target element's root node:
- *   const { onPointerEnter, onPointerLeave, onPointerDown } = useShortcutHintHover("nav.toggleSidebar");
- *   <button onPointerEnter={onPointerEnter} onPointerLeave={onPointerLeave} onPointerDown={onPointerDown} />
+ *   const { onPointerEnter, onPointerLeave, onPointerDown, onFocus, onBlur } =
+ *     useShortcutHintHover("nav.toggleSidebar");
+ *   <button onPointerEnter={onPointerEnter} ... onFocus={onFocus} onBlur={onBlur} />
  */
 export function useShortcutHintHover(actionId: string) {
   const timerRef = useRef<ReturnType<typeof setTimeout> | null>(null);
@@ -92,5 +96,37 @@ export function useShortcutHintHover(actionId: string) {
     clearTimer();
   };
 
-  return { onPointerEnter, onPointerLeave, onPointerDown };
+  const onFocus = (e: React.FocusEvent) => {
+    // Cancel any racing pointer dwell so it can't double-show after focus did.
+    clearTimer();
+
+    const displayCombo = displayComboRef.current;
+    if (!displayCombo) return;
+
+    const target = e.currentTarget;
+
+    // Suppress when a Radix tooltip is already teaching the same shortcut on
+    // this trigger (data-state is merged onto the trigger child via asChild).
+    const tooltipState = target.getAttribute("data-state");
+    if (tooltipState === "delayed-open" || tooltipState === "instant-open") return;
+
+    const store = shortcutHintStore;
+    if (!store.getState().isHoverEligible(actionId)) return;
+
+    const rect = target.getBoundingClientRect();
+    const shown = store.getState().show(actionId, displayCombo, {
+      x: rect.left,
+      y: rect.top,
+    });
+    if (shown) {
+      store.getState().markHoverShown(actionId);
+    }
+  };
+
+  const onBlur = () => {
+    clearTimer();
+    shortcutHintStore.getState().hide();
+  };
+
+  return { onPointerEnter, onPointerLeave, onPointerDown, onFocus, onBlur };
 }

--- a/src/store/__tests__/shortcutHintStore.test.ts
+++ b/src/store/__tests__/shortcutHintStore.test.ts
@@ -59,7 +59,7 @@ describe("shortcutHintStore", () => {
 
   it("returns false when count is not a milestone", () => {
     const s = shortcutHintStore.getState();
-    s.hydrateCounts({ "nav.quickSwitcher": 4 });
+    s.hydrateCounts({ "nav.quickSwitcher": 3 });
     s.recordPointer(100, 200);
     const result = s.show("nav.quickSwitcher", "⌘K");
 
@@ -83,7 +83,7 @@ describe("shortcutHintStore", () => {
   });
 
   it("does not show hint at non-milestone values", () => {
-    const nonMilestones = [0, 4, 5, 9, 11, 25, 31, 49, 51, 151, 999];
+    const nonMilestones = [0, 3, 5, 9, 11, 17, 25, 31, 33, 49, 51, 999];
     for (const count of nonMilestones) {
       shortcutHintStore.setState({
         counts: { "nav.quickSwitcher": count },
@@ -100,7 +100,7 @@ describe("shortcutHintStore", () => {
 
   it("stops showing hints after the last milestone", () => {
     const s = shortcutHintStore.getState();
-    s.hydrateCounts({ "nav.quickSwitcher": 151 });
+    s.hydrateCounts({ "nav.quickSwitcher": 33 });
     s.recordPointer(100, 200);
     const result = s.show("nav.quickSwitcher", "⌘K");
 
@@ -170,18 +170,18 @@ describe("shortcutHintStore", () => {
 
   it("does not show hint after last milestone is reached via increment", () => {
     const s = shortcutHintStore.getState();
-    s.hydrateCounts({ "nav.quickSwitcher": 150 });
+    s.hydrateCounts({ "nav.quickSwitcher": 32 });
     s.recordPointer(100, 200);
     s.incrementCount("nav.quickSwitcher");
     const result = s.show("nav.quickSwitcher", "⌘K");
 
     expect(result).toBe(false);
-    expect(shortcutHintStore.getState().counts["nav.quickSwitcher"]).toBe(151);
+    expect(shortcutHintStore.getState().counts["nav.quickSwitcher"]).toBe(33);
   });
 
   it("tracks actions independently", () => {
     const s = shortcutHintStore.getState();
-    s.hydrateCounts({ "nav.quickSwitcher": 4 });
+    s.hydrateCounts({ "nav.quickSwitcher": 3 });
     s.recordPointer(100, 200);
 
     s.incrementCount("terminal.new");
@@ -236,7 +236,7 @@ describe("shortcutHintStore", () => {
 
   it("isHoverEligible returns false for non-milestone non-zero count", () => {
     const s = shortcutHintStore.getState();
-    s.hydrateCounts({ "nav.quickSwitcher": 4 });
+    s.hydrateCounts({ "nav.quickSwitcher": 3 });
     expect(s.isHoverEligible("nav.quickSwitcher")).toBe(false);
   });
 

--- a/src/store/__tests__/shortcutHintStore.test.ts
+++ b/src/store/__tests__/shortcutHintStore.test.ts
@@ -67,6 +67,25 @@ describe("shortcutHintStore", () => {
     expect(shortcutHintStore.getState().activeHint).toBeNull();
   });
 
+  it("encodes exactly the 6-entry geometric milestone curve", () => {
+    expect(Array.from(HINT_MILESTONES)).toEqual([1, 2, 4, 8, 16, 32]);
+    expect(HINT_MILESTONES.size).toBe(6);
+  });
+
+  it("does not show hint for powers of two beyond the cap", () => {
+    for (const count of [64, 128, 256, 1024]) {
+      shortcutHintStore.setState({
+        counts: { "nav.quickSwitcher": count },
+        hydrated: true,
+        pointer: null,
+        activeHint: null,
+      });
+      const s = shortcutHintStore.getState();
+      s.recordPointer(100, 200);
+      expect(s.show("nav.quickSwitcher", "⌘K")).toBe(false);
+    }
+  });
+
   it("shows hint at each milestone value", () => {
     for (const milestone of HINT_MILESTONES) {
       shortcutHintStore.setState({

--- a/src/store/shortcutHintStore.ts
+++ b/src/store/shortcutHintStore.ts
@@ -1,7 +1,7 @@
 import { createStore } from "zustand/vanilla";
 
 /** Invocation counts at which a shortcut hint is shown. Encodes the lifetime cap (set size). */
-export const HINT_MILESTONES = new Set([1, 2, 3, 10, 20, 30, 50, 75, 100, 150]);
+export const HINT_MILESTONES = new Set([1, 2, 4, 8, 16, 32]);
 const POINTER_STALE_MS = 2000;
 
 function hoverOneShotKey(actionId: string, count: number): string {


### PR DESCRIPTION
## Summary

- Cuts `HINT_MILESTONES` from 10 entries to a 6-entry geometric curve `[1,2,4,8,16,32]` — re-teaches past the early invocations stop reading as helpful nudges and start reading as noise
- Adds `onFocus`/`onBlur` to `useShortcutHintHover` for WCAG 1.4.13 keyboard parity — keyboard users tabbing through toolbar buttons now see the same `ShortcutHint` as pointer users
- Adds a `document.visibilitychange` listener in `useHeldShortcutReveal` that clears `data-shortcut-reveal` when the document is hidden, fixing the attribute getting stuck on Linux WMs that swallow modifier keyups on workspace switches

Resolves #8171

## Changes

**`src/store/shortcutHintStore.ts`** — `HINT_MILESTONES` reduced from `[1,2,3,10,20,30,50,75,100,150]` to `[1,2,4,8,16,32]`

**`src/hooks/useShortcutHintHover.ts`** — new `onFocus` and `onBlur` handlers. `onFocus` fires immediately (no dwell delay), positions via `getBoundingClientRect`, cancels any racing pointer dwell. `onBlur` is scoped so it only clears the hint if the element owns it.

**`src/components/Layout/ToolbarSettingsButton.tsx`** — `onFocus`/`onBlur` wired explicitly because the component has a custom `onPointerEnter` wrapper; all other call-sites pick them up automatically by spreading the hook.

**`src/hooks/useHeldShortcutReveal.ts`** — `document.visibilitychange` listener clears `data-shortcut-reveal` when `document.visibilityState !== "visible"`, belt-and-suspenders alongside the existing `window.blur` guard.

## Testing

61 tests passing across 3 suites (`shortcutHintStore.test.ts`, `useShortcutHintHover.test.ts`, `useHeldShortcutReveal.test.tsx`). New coverage includes exact milestone contract, focus-parity flows, cross-element `onBlur` ownership, and the visibility-teardown path.