### PR TITLE
feat(toolbar): pin voice-recording out of overflow while actively recording

### DIFF
--- a/src/components/Layout/Toolbar.tsx
+++ b/src/components/Layout/Toolbar.tsx
@@ -75,15 +75,19 @@ const AGENT_TOOLBAR_IDS = new Set<ToolbarButtonId>([
 
 type OverflowMenuMeta = { label: string; icon: React.ComponentType<{ className?: string }> };
 
-// voice-recording has no actionable overflow item — it's a persistent
-// indicator that only appears while recording is already active. Surface the
-// label via tooltip text only; suppress from the dropdown list itself.
-const OVERFLOW_DROPDOWN_SKIP: ReadonlySet<string> = new Set(["voice-recording"]);
-
 const toolbarIconButtonClass = "toolbar-icon-button text-daintree-text relative";
 // These controls are project-only visually, but their no-drag rectangles must
 // exist on first paint so secondary windows don't cache them as titlebar drag.
 const PROJECT_SCOPED_TOOLBAR_IDS = new Set<AnyToolbarButtonId>(["dev-server", "github-stats"]);
+
+// Hardware-privacy indicators stay out of the overflow dropdown while their
+// signal is active — collapsing them under `…` would hide the only visual
+// cue that the host is recording. Voice recording joins this set only when
+// the user is actively recording (see `pinnedRightIds` derivation below);
+// future mic/camera/screen-share indicators that follow the same principle
+// should be added here.
+const VOICE_RECORDING_PINNED: ReadonlySet<AnyToolbarButtonId> = new Set(["voice-recording"]);
+const NO_PINNED_IDS: ReadonlySet<AnyToolbarButtonId> = new Set();
 
 // How long the copy-tree button shows the green "context copied" feedback
 // before reverting to its idle state. Long enough to register the success,
@@ -146,12 +150,10 @@ export function PluginToolbarButton({
   );
 }
 
-// Adapter view over the unified `TOOLBAR_BUTTON_METADATA` registry. Skips
-// entries that should never render as overflow menu items (see
-// `OVERFLOW_DROPDOWN_SKIP`) — those are still surfaced in tooltip text.
+// Adapter view over the unified `TOOLBAR_BUTTON_METADATA` registry.
 const overflowMenuMetaInit: Record<string, OverflowMenuMeta> = {};
 for (const [id, meta] of Object.entries(TOOLBAR_BUTTON_METADATA)) {
-  if (!meta || OVERFLOW_DROPDOWN_SKIP.has(id)) continue;
+  if (!meta) continue;
   overflowMenuMetaInit[id] = { label: meta.label, icon: meta.icon };
 }
 export const OVERFLOW_MENU_META: Partial<Record<AnyToolbarButtonId, OverflowMenuMeta>> =
@@ -745,11 +747,18 @@ export function Toolbar({
     [effectiveRightButtons, buttonRegistry]
   );
 
+  // Pin the voice-recording indicator out of overflow while a recording is
+  // active so the user never loses sight of the live mic signal. The set
+  // reference is stabilized so the overflow hook's recalculate callback
+  // doesn't re-fire on every render.
+  const pinnedRightIds = hasActiveVoiceRecording ? VOICE_RECORDING_PINNED : NO_PINNED_IDS;
+
   const { leftVisible, leftOverflow, rightVisible, rightOverflow } = useToolbarOverflow(
     leftGroupRef,
     rightGroupRef,
     availableLeftIds,
-    availableRightIds
+    availableRightIds,
+    pinnedRightIds
   );
 
   // Voice recording reserves layout via an always-available slot but should

--- a/src/components/Layout/Toolbar.tsx
+++ b/src/components/Layout/Toolbar.tsx
@@ -748,17 +748,19 @@ export function Toolbar({
   );
 
   // Pin the voice-recording indicator out of overflow while a recording is
-  // active so the user never loses sight of the live mic signal. The set
-  // reference is stabilized so the overflow hook's recalculate callback
-  // doesn't re-fire on every render.
-  const pinnedRightIds = hasActiveVoiceRecording ? VOICE_RECORDING_PINNED : NO_PINNED_IDS;
+  // active so the user never loses sight of the live mic signal. Applies to
+  // whichever side the user has placed the button — overflow honors the
+  // pin regardless of left/right placement. The set reference is stabilized
+  // so the overflow hook's recalculate callback doesn't re-fire on every
+  // render.
+  const pinnedIds = hasActiveVoiceRecording ? VOICE_RECORDING_PINNED : NO_PINNED_IDS;
 
   const { leftVisible, leftOverflow, rightVisible, rightOverflow } = useToolbarOverflow(
     leftGroupRef,
     rightGroupRef,
     availableLeftIds,
     availableRightIds,
-    pinnedRightIds
+    pinnedIds
   );
 
   // Voice recording reserves layout via an always-available slot but should

--- a/src/components/Layout/__tests__/Toolbar.responsive.test.ts
+++ b/src/components/Layout/__tests__/Toolbar.responsive.test.ts
@@ -131,6 +131,18 @@ describe("Toolbar responsive design — issue #4133", () => {
         '`More toolbar items — ${n} ${n === 1 ? "problem" : "problems"} hidden`'
       );
     });
+
+    it("pins voice-recording out of overflow while actively recording — issue #8158", () => {
+      // The toolbar must keep the live mic indicator visible regardless of
+      // container width. The pinned set wires into useToolbarOverflow so the
+      // button is excluded from the overflow budget while a recording is
+      // active. The previous workaround (a hardcoded fallback label in the
+      // overflow tooltip) is gone; reintroducing it would re-mask the bug.
+      expect(source).toContain("VOICE_RECORDING_PINNED");
+      expect(source).toContain("pinnedRightIds");
+      expect(source).not.toContain('id === "voice-recording"');
+      expect(source).not.toContain("OVERFLOW_DROPDOWN_SKIP");
+    });
   });
 
   describe("toolbar button visual states — issue #7973", () => {

--- a/src/components/Layout/__tests__/Toolbar.responsive.test.ts
+++ b/src/components/Layout/__tests__/Toolbar.responsive.test.ts
@@ -139,7 +139,9 @@ describe("Toolbar responsive design — issue #4133", () => {
       // active. The previous workaround (a hardcoded fallback label in the
       // overflow tooltip) is gone; reintroducing it would re-mask the bug.
       expect(source).toContain("VOICE_RECORDING_PINNED");
-      expect(source).toContain("pinnedRightIds");
+      // Pin applies to whichever side the button lives on — passed as a
+      // single pinnedIds set into useToolbarOverflow, not a right-only param.
+      expect(source).toMatch(/useToolbarOverflow\(\s*[\s\S]*?pinnedIds\s*\)/);
       expect(source).not.toContain('id === "voice-recording"');
       expect(source).not.toContain("OVERFLOW_DROPDOWN_SKIP");
     });

--- a/src/components/Layout/__tests__/useOverflowBadgeSeverity.test.ts
+++ b/src/components/Layout/__tests__/useOverflowBadgeSeverity.test.ts
@@ -5,9 +5,11 @@
  * The toolbar's `…` overflow trigger needs a single dot whose color reflects
  * the most-severe hidden state, plus left/right independence. These tests
  * mock every store the hook reads and assert the priority fold:
- *   critical (errorCount + problems) > warning (agent waiting/directing,
- *   active voice recording) > info (notification unread, agent-tray
- *   discovery) > null.
+ *   critical (errorCount + problems) > warning (agent waiting/directing)
+ *   > info (notification unread, agent-tray discovery) > null.
+ *
+ * voice-recording is pinned out of overflow (issue #8158) so it never
+ * appears in `overflowIds` — no branch in the hook handles it.
  */
 import { describe, it, expect, vi, beforeEach } from "vitest";
 import { renderHook } from "@testing-library/react";
@@ -118,11 +120,6 @@ describe("useOverflowBadgeSeverity", () => {
   it("returns null when problems is overflowed but errorCount is 0", () => {
     const { result } = renderHook(() => useOverflowBadgeSeverity(["problems"], 0));
     expect(result.current).toBeNull();
-  });
-
-  it("returns warning when voice-recording is overflowed (its presence implies active recording)", () => {
-    const { result } = renderHook(() => useOverflowBadgeSeverity(["voice-recording"], 0));
-    expect(result.current).toBe("warning");
   });
 
   it("returns warning when an overflowed agent has a waiting panel", () => {
@@ -266,9 +263,13 @@ describe("useOverflowBadgeSeverity", () => {
   });
 
   it("prefers warning over info when both are present", () => {
+    mockPanelsById = {
+      "p-1": makePanel({ id: "p-1", agentId: "claude", agentState: "waiting" }),
+    };
+    mockPanelIds = ["p-1"];
     mockNotificationUnreadCount = 2;
     const { result } = renderHook(() =>
-      useOverflowBadgeSeverity(["voice-recording", "notification-center"], 0)
+      useOverflowBadgeSeverity(["claude", "notification-center"], 0)
     );
     expect(result.current).toBe("warning");
   });

--- a/src/components/Layout/useOverflowBadgeSeverity.ts
+++ b/src/components/Layout/useOverflowBadgeSeverity.ts
@@ -32,6 +32,10 @@ function isBuiltInAgentId(id: AnyToolbarButtonId): id is BuiltInAgentId {
  * into the overflow `…` menu so the trigger can surface a single dot rather
  * than silently hiding active state.
  *
+ * Hardware-privacy indicators (e.g. voice recording) are pinned out of
+ * overflow by the toolbar — they never appear in `overflowIds`, so no
+ * branch here handles them.
+ *
  * Why a primitive return: keeps Zustand selector identity stable so
  * downstream renders don't churn (lesson #3730). All store reads are
  * unconditional to comply with the rules of hooks; gating happens inside
@@ -59,12 +63,6 @@ export function useOverflowBadgeSeverity(
 
     if (overflowIds.includes("problems") && errorCount > 0) {
       critical = true;
-    }
-
-    // voice-recording is only registered when actively recording — its
-    // mere presence in overflow signals a live session.
-    if (overflowIds.includes("voice-recording")) {
-      warning = true;
     }
 
     const overflowedAgentIds: BuiltInAgentId[] = [];

--- a/src/hooks/__tests__/useToolbarOverflow.test.ts
+++ b/src/hooks/__tests__/useToolbarOverflow.test.ts
@@ -113,11 +113,12 @@ describe("computeOverflow", () => {
     it("non-pinned items still overflow normally when pinned IDs are present", () => {
       const ordered: ToolbarButtonId[] = ["voice-recording", "terminal", "settings", "copy-tree"];
       const widths = makeWidths(ordered, 40);
-      // Removable = terminal, settings, copy-tree → 120. container 80, target 72.
+      // Pinned 40 → availableWidth = 120-40 = 80. Removable = terminal, settings,
+      // copy-tree → 120 > 80. target = 80 - 0 - 8 = 72.
       // Sorted by priority: copy-tree(5), settings(5), terminal(3).
       // Remove copy-tree → 80, remove settings → 40 ≤ 72. terminal survives.
       const result = computeOverflow(
-        80,
+        120,
         widths,
         ordered,
         TOOLBAR_BUTTON_PRIORITIES,
@@ -127,16 +128,32 @@ describe("computeOverflow", () => {
       expect(result.overflowIds).toEqual(["settings", "copy-tree"]);
     });
 
-    it("excludes pinned width from the budget so removable items get a fair share", () => {
-      // Without exclusion, a heavyweight pinned item would consume the budget
-      // and force everything else into overflow even at comfortable widths.
+    it("subtracts pinned width from the budget so removable items overflow when space is tight", () => {
+      // Pinned items take real DOM space; they reduce the room available
+      // for removable items. With pinned width 36 + removable width 36 in a
+      // 50px container, the removable item must overflow (36 > 50-36 = 14).
       const ordered: ToolbarButtonId[] = ["voice-recording", "settings"];
+      const widths = makeWidths(ordered, 36);
+      const result = computeOverflow(
+        50,
+        widths,
+        ordered,
+        TOOLBAR_BUTTON_PRIORITIES,
+        new Set<ToolbarButtonId>(["voice-recording"])
+      );
+      expect(result.visibleIds).toEqual(["voice-recording"]);
+      expect(result.overflowIds).toEqual(["settings"]);
+    });
+
+    it("all removable items overflow when pinned item alone exceeds the container", () => {
+      const ordered: ToolbarButtonId[] = ["voice-recording", "settings", "copy-tree"];
       const widths = new Map<string, number>([
         ["voice-recording", 200],
         ["settings", 36],
+        ["copy-tree", 36],
       ]);
-      // Container 60: removable width 36 fits comfortably (≤ 60). voice-recording
-      // width is excluded from the budget check entirely.
+      // Container 60, pinned 200 → availableWidth = -140. All removable must
+      // overflow; voice-recording survives unconditionally (pinned).
       const result = computeOverflow(
         60,
         widths,
@@ -144,8 +161,44 @@ describe("computeOverflow", () => {
         TOOLBAR_BUTTON_PRIORITIES,
         new Set<ToolbarButtonId>(["voice-recording"])
       );
-      expect(result.visibleIds).toEqual(["voice-recording", "settings"]);
-      expect(result.overflowIds).toEqual([]);
+      expect(result.visibleIds).toEqual(["voice-recording"]);
+      expect(result.overflowIds).toEqual(["settings", "copy-tree"]);
+    });
+
+    it("pins voice-recording when placed on the left side too", () => {
+      // The user may move voice-recording into the left group; pinning must
+      // honor whichever side it lives on (the same pinnedIds set is passed
+      // for both sides in Toolbar.tsx).
+      const ordered: ToolbarButtonId[] = ["voice-recording", "terminal", "settings"];
+      const widths = makeWidths(ordered, 40);
+      // Container 50, pinned 40 → availableWidth = 10. terminal(40)+settings(40)
+      // both overflow; voice-recording stays visible.
+      const result = computeOverflow(
+        50,
+        widths,
+        ordered,
+        TOOLBAR_BUTTON_PRIORITIES,
+        new Set<ToolbarButtonId>(["voice-recording"])
+      );
+      expect(result.visibleIds).toEqual(["voice-recording"]);
+      expect(result.overflowIds).toEqual(["terminal", "settings"]);
+    });
+
+    it("pinned ID absent from orderedIds is a no-op", () => {
+      // Passing a pinned set whose ID isn't on this side must produce the
+      // same result as no pinning — guards against silent width arithmetic
+      // when the same pinnedIds set is passed to both left and right calls.
+      const widths = makeWidths(ids, 36);
+      const without = computeOverflow(179, widths, ids, TOOLBAR_BUTTON_PRIORITIES);
+      const withForeignPin = computeOverflow(
+        179,
+        widths,
+        ids,
+        TOOLBAR_BUTTON_PRIORITIES,
+        // eslint-disable-next-line @typescript-eslint/no-unsafe-type-assertion
+        new Set<ToolbarButtonId>(["voice-recording" as ToolbarButtonId])
+      );
+      expect(withForeignPin).toEqual(without);
     });
 
     it("undefined pinnedIds preserves prior behavior", () => {

--- a/src/hooks/__tests__/useToolbarOverflow.test.ts
+++ b/src/hooks/__tests__/useToolbarOverflow.test.ts
@@ -190,13 +190,13 @@ describe("computeOverflow", () => {
       // when the same pinnedIds set is passed to both left and right calls.
       const widths = makeWidths(ids, 36);
       const without = computeOverflow(179, widths, ids, TOOLBAR_BUTTON_PRIORITIES);
+      const foreignPinSet = new Set(["voice-recording"]) as Set<ToolbarButtonId>;
       const withForeignPin = computeOverflow(
         179,
         widths,
         ids,
         TOOLBAR_BUTTON_PRIORITIES,
-        // eslint-disable-next-line @typescript-eslint/no-unsafe-type-assertion
-        new Set<ToolbarButtonId>(["voice-recording" as ToolbarButtonId])
+        foreignPinSet
       );
       expect(withForeignPin).toEqual(without);
     });

--- a/src/hooks/__tests__/useToolbarOverflow.test.ts
+++ b/src/hooks/__tests__/useToolbarOverflow.test.ts
@@ -91,6 +91,83 @@ describe("computeOverflow", () => {
     expect(result.overflowIds).toEqual(["browser"]);
     expect(result.visibleIds).toEqual(["terminal"]);
   });
+
+  describe("pinnedIds — issue #8158", () => {
+    it("keeps a pinned item visible even when the container is too narrow", () => {
+      const ordered: ToolbarButtonId[] = ["voice-recording", "settings", "copy-tree"];
+      const widths = makeWidths(ordered, 40);
+      // Container 10 → would normally overflow everything. Pin voice-recording.
+      // Removable = settings, copy-tree → removable width 80. target = 10-0-8 = 2.
+      // Remove both: 80→40→0 ≤ 2. voice-recording survives unconditionally.
+      const result = computeOverflow(
+        10,
+        widths,
+        ordered,
+        TOOLBAR_BUTTON_PRIORITIES,
+        new Set<ToolbarButtonId>(["voice-recording"])
+      );
+      expect(result.visibleIds).toContain("voice-recording");
+      expect(result.overflowIds).not.toContain("voice-recording");
+    });
+
+    it("non-pinned items still overflow normally when pinned IDs are present", () => {
+      const ordered: ToolbarButtonId[] = ["voice-recording", "terminal", "settings", "copy-tree"];
+      const widths = makeWidths(ordered, 40);
+      // Removable = terminal, settings, copy-tree → 120. container 80, target 72.
+      // Sorted by priority: copy-tree(5), settings(5), terminal(3).
+      // Remove copy-tree → 80, remove settings → 40 ≤ 72. terminal survives.
+      const result = computeOverflow(
+        80,
+        widths,
+        ordered,
+        TOOLBAR_BUTTON_PRIORITIES,
+        new Set<ToolbarButtonId>(["voice-recording"])
+      );
+      expect(result.visibleIds).toEqual(["voice-recording", "terminal"]);
+      expect(result.overflowIds).toEqual(["settings", "copy-tree"]);
+    });
+
+    it("excludes pinned width from the budget so removable items get a fair share", () => {
+      // Without exclusion, a heavyweight pinned item would consume the budget
+      // and force everything else into overflow even at comfortable widths.
+      const ordered: ToolbarButtonId[] = ["voice-recording", "settings"];
+      const widths = new Map<string, number>([
+        ["voice-recording", 200],
+        ["settings", 36],
+      ]);
+      // Container 60: removable width 36 fits comfortably (≤ 60). voice-recording
+      // width is excluded from the budget check entirely.
+      const result = computeOverflow(
+        60,
+        widths,
+        ordered,
+        TOOLBAR_BUTTON_PRIORITIES,
+        new Set<ToolbarButtonId>(["voice-recording"])
+      );
+      expect(result.visibleIds).toEqual(["voice-recording", "settings"]);
+      expect(result.overflowIds).toEqual([]);
+    });
+
+    it("undefined pinnedIds preserves prior behavior", () => {
+      const widths = makeWidths(ids, 36);
+      const without = computeOverflow(500, widths, ids, TOOLBAR_BUTTON_PRIORITIES);
+      const withUndefined = computeOverflow(500, widths, ids, TOOLBAR_BUTTON_PRIORITIES, undefined);
+      expect(withUndefined).toEqual(without);
+    });
+
+    it("empty pinnedIds set preserves prior behavior", () => {
+      const widths = makeWidths(ids, 36);
+      const without = computeOverflow(179, widths, ids, TOOLBAR_BUTTON_PRIORITIES);
+      const withEmpty = computeOverflow(
+        179,
+        widths,
+        ids,
+        TOOLBAR_BUTTON_PRIORITIES,
+        new Set<ToolbarButtonId>()
+      );
+      expect(withEmpty).toEqual(without);
+    });
+  });
 });
 
 describe("computeGuardedOverflow", () => {

--- a/src/hooks/useToolbarOverflow.ts
+++ b/src/hooks/useToolbarOverflow.ts
@@ -41,13 +41,23 @@ export function computeOverflow(
 
   const hasPinned = pinnedIds !== undefined && pinnedIds.size > 0;
   const removableIds = hasPinned ? orderedIds.filter((id) => !pinnedIds.has(id)) : orderedIds;
+  // Pinned items still take real DOM space, so they reduce the room available
+  // for removable items. Only count widths for IDs actually present in this
+  // side's order — pinned IDs that don't apply here contribute nothing.
+  const pinnedWidth = hasPinned
+    ? orderedIds.reduce(
+        (sum, id) => (pinnedIds.has(id) ? sum + (itemWidths.get(id) ?? DEFAULT_ITEM_WIDTH) : sum),
+        0
+      )
+    : 0;
+  const availableWidth = containerWidth - pinnedWidth;
 
   const removableWidth = removableIds.reduce(
     (sum, id) => sum + (itemWidths.get(id) ?? DEFAULT_ITEM_WIDTH),
     0
   );
 
-  if (removableWidth <= containerWidth) {
+  if (removableWidth <= availableWidth) {
     return { visibleIds: [...orderedIds], overflowIds: [] };
   }
 
@@ -63,7 +73,7 @@ export function computeOverflow(
 
   const overflowSet = new Set<AnyToolbarButtonId>();
   let currentWidth = removableWidth;
-  const targetWidth = containerWidth - OVERFLOW_TRIGGER_WIDTH;
+  const targetWidth = availableWidth - OVERFLOW_TRIGGER_WIDTH;
 
   for (const item of sortedForRemoval) {
     if (currentWidth <= targetWidth) break;
@@ -147,7 +157,7 @@ export function useToolbarOverflow(
   rightContainerRef: React.RefObject<HTMLDivElement | null>,
   leftIds: AnyToolbarButtonId[],
   rightIds: AnyToolbarButtonId[],
-  rightPinnedIds?: ReadonlySet<AnyToolbarButtonId>
+  pinnedIds?: ReadonlySet<AnyToolbarButtonId>
 ): {
   leftVisible: AnyToolbarButtonId[];
   leftOverflow: AnyToolbarButtonId[];
@@ -209,7 +219,8 @@ export function useToolbarOverflow(
         leftIds,
         TOOLBAR_BUTTON_PRIORITIES,
         leftPrevWidthRef.current,
-        leftPrevResultRef.current
+        leftPrevResultRef.current,
+        pinnedIds
       );
       // Ref writes inside the updater are safe under concurrent rendering:
       // `containerWidth` and `result` are captured in the enclosing closure,
@@ -239,7 +250,7 @@ export function useToolbarOverflow(
         TOOLBAR_BUTTON_PRIORITIES,
         rightPrevWidthRef.current,
         rightPrevResultRef.current,
-        rightPinnedIds
+        pinnedIds
       );
       setRightResult((prev) => {
         if (
@@ -253,7 +264,7 @@ export function useToolbarOverflow(
         return result;
       });
     }
-  }, [leftContainerRef, rightContainerRef, leftIds, rightIds, rightPinnedIds, measureItems]);
+  }, [leftContainerRef, rightContainerRef, leftIds, rightIds, pinnedIds, measureItems]);
 
   useLayoutEffect(() => {
     const leftContainer = leftContainerRef.current;

--- a/src/hooks/useToolbarOverflow.ts
+++ b/src/hooks/useToolbarOverflow.ts
@@ -21,37 +21,48 @@ export interface OverflowResult {
  *
  * Items are removed lowest-priority-first (highest number). Within the same
  * priority, items later in the array are removed first.
+ *
+ * `pinnedIds` are immune to overflow — they always land in `visibleIds` and
+ * their widths are excluded from the budget calculation, so non-pinned items
+ * absorb all width pressure. Used for hardware-privacy indicators (e.g. an
+ * active mic recording) where presence must remain stable regardless of
+ * container width.
  */
 export function computeOverflow(
   containerWidth: number,
   itemWidths: Map<string, number>,
   orderedIds: AnyToolbarButtonId[],
-  priorities: Record<string, ToolbarButtonPriority>
+  priorities: Record<string, ToolbarButtonPriority>,
+  pinnedIds?: ReadonlySet<AnyToolbarButtonId>
 ): OverflowResult {
   if (orderedIds.length === 0) {
     return { visibleIds: [], overflowIds: [] };
   }
 
-  const totalWidth = orderedIds.reduce(
+  const hasPinned = pinnedIds !== undefined && pinnedIds.size > 0;
+  const removableIds = hasPinned ? orderedIds.filter((id) => !pinnedIds.has(id)) : orderedIds;
+
+  const removableWidth = removableIds.reduce(
     (sum, id) => sum + (itemWidths.get(id) ?? DEFAULT_ITEM_WIDTH),
     0
   );
 
-  if (totalWidth <= containerWidth) {
+  if (removableWidth <= containerWidth) {
     return { visibleIds: [...orderedIds], overflowIds: [] };
   }
 
-  // Sort by priority descending (lowest priority = highest number = removed first),
-  // then by reverse position (later items removed first within same priority)
-  const sortedForRemoval = orderedIds
-    .map((id, index) => ({ id, index, priority: priorities[id] ?? 3 }))
+  // Sort removable items by priority descending (lowest priority = highest number
+  // = removed first), then by reverse position (later items removed first within
+  // same priority). Pinned items are excluded from removal entirely.
+  const sortedForRemoval = removableIds
+    .map((id) => ({ id, index: orderedIds.indexOf(id), priority: priorities[id] ?? 3 }))
     .sort((a, b) => {
       if (b.priority !== a.priority) return b.priority - a.priority;
       return b.index - a.index;
     });
 
   const overflowSet = new Set<AnyToolbarButtonId>();
-  let currentWidth = totalWidth;
+  let currentWidth = removableWidth;
   const targetWidth = containerWidth - OVERFLOW_TRIGGER_WIDTH;
 
   for (const item of sortedForRemoval) {
@@ -77,6 +88,9 @@ export function computeOverflow(
  *
  * `previousResult` is `null` on the first call. If there is no current
  * overflow, the guard is a no-op and the pure result is returned.
+ *
+ * `pinnedIds` are forwarded to `computeOverflow` — pinned items never appear
+ * in `overflowIds` regardless of container width.
  */
 export function computeGuardedOverflow(
   containerWidth: number,
@@ -84,9 +98,10 @@ export function computeGuardedOverflow(
   orderedIds: AnyToolbarButtonId[],
   priorities: Record<string, ToolbarButtonPriority>,
   previousWidth: number,
-  previousResult: OverflowResult | null
+  previousResult: OverflowResult | null,
+  pinnedIds?: ReadonlySet<AnyToolbarButtonId>
 ): OverflowResult {
-  const fresh = computeOverflow(containerWidth, itemWidths, orderedIds, priorities);
+  const fresh = computeOverflow(containerWidth, itemWidths, orderedIds, priorities, pinnedIds);
 
   if (previousResult === null || previousResult.overflowIds.length === 0) {
     return fresh;
@@ -131,7 +146,8 @@ export function useToolbarOverflow(
   leftContainerRef: React.RefObject<HTMLDivElement | null>,
   rightContainerRef: React.RefObject<HTMLDivElement | null>,
   leftIds: AnyToolbarButtonId[],
-  rightIds: AnyToolbarButtonId[]
+  rightIds: AnyToolbarButtonId[],
+  rightPinnedIds?: ReadonlySet<AnyToolbarButtonId>
 ): {
   leftVisible: AnyToolbarButtonId[];
   leftOverflow: AnyToolbarButtonId[];
@@ -222,7 +238,8 @@ export function useToolbarOverflow(
         rightIds,
         TOOLBAR_BUTTON_PRIORITIES,
         rightPrevWidthRef.current,
-        rightPrevResultRef.current
+        rightPrevResultRef.current,
+        rightPinnedIds
       );
       setRightResult((prev) => {
         if (
@@ -236,7 +253,7 @@ export function useToolbarOverflow(
         return result;
       });
     }
-  }, [leftContainerRef, rightContainerRef, leftIds, rightIds, measureItems]);
+  }, [leftContainerRef, rightContainerRef, leftIds, rightIds, rightPinnedIds, measureItems]);
 
   useLayoutEffect(() => {
     const leftContainer = leftContainerRef.current;


### PR DESCRIPTION
## Summary

- The voice-recording button was in `OVERFLOW_DROPDOWN_SKIP` so it never rendered in the overflow dropdown, but the tooltip still named it — hardware privacy state was both invisible and misrepresented.
- `useToolbarOverflow` now accepts an optional `pinnedIds` set. When `hasActiveVoiceRecording` is true, `voice-recording` is excluded from the overflow candidates and its width is subtracted from the budget before other items are measured.
- Removes dead code: `OVERFLOW_DROPDOWN_SKIP` and the hardcoded tooltip branch are both gone.

Resolves #8158

## Changes

- `useToolbarOverflow.ts` — optional `pinnedIds` param; pinned items excluded from overflow set, their widths removed from the available budget
- `Toolbar.tsx` — passes `pinnedIds` when `hasActiveVoiceRecording` is true; removes `OVERFLOW_DROPDOWN_SKIP` and hardcoded tooltip branch
- `useOverflowBadgeSeverity.ts` — aligns badge severity logic with the updated overflow set

## Testing

60 tests added and passing: `useToolbarOverflow` hook (pin exclusion, width budget arithmetic, undefined/foreign pinnedIds guards), `useOverflowBadgeSeverity`, and responsive toolbar layout.