### PR TITLE
feat(forge): ForgeProviderRegistry — remote-URL routing

### DIFF
--- a/electron/services/PluginService.ts
+++ b/electron/services/PluginService.ts
@@ -29,6 +29,7 @@ import {
   unregisterPluginToolbarButtons,
 } from "../../shared/config/toolbarButtonRegistry.js";
 import { registerPluginMenuItem, unregisterPluginMenuItems } from "./pluginMenuRegistry.js";
+import { registerForgeProviders, unregisterForgeProviders } from "./forgeProviderRegistry.js";
 import { broadcastToRenderer } from "../ipc/utils.js";
 import { CHANNELS } from "../ipc/channels.js";
 import type { LoadedPluginInfo } from "../../shared/types/plugin.js";
@@ -381,9 +382,7 @@ export class PluginService {
     }
 
     if (manifest.contributes.forgeProviders.length > 0) {
-      console.warn(
-        `[PluginService] Plugin "${manifest.name}": contributes.forgeProviders is not yet implemented and will be ignored`
-      );
+      registerForgeProviders(manifest.name, manifest.contributes.forgeProviders);
     }
 
     // Insert the plugin into the registry BEFORE importing its main module so
@@ -683,6 +682,7 @@ export class PluginService {
     unregisterPluginMenuItems(pluginId);
     unregisterPluginToolbarButtons(pluginId);
     unregisterPluginPanelKinds(pluginId);
+    unregisterForgeProviders(pluginId);
     this.plugins.delete(pluginId);
   }
 

--- a/electron/services/__tests__/PluginService.integration.test.ts
+++ b/electron/services/__tests__/PluginService.integration.test.ts
@@ -81,6 +81,9 @@ type PluginManifestShape = {
     panels?: unknown[];
     toolbarButtons?: unknown[];
     menuItems?: unknown[];
+    views?: unknown[];
+    mcpServers?: unknown[];
+    forgeProviders?: unknown[];
   };
 };
 

--- a/electron/services/__tests__/PluginService.integration.test.ts
+++ b/electron/services/__tests__/PluginService.integration.test.ts
@@ -56,6 +56,11 @@ import {
   getToolbarButtonConfig,
 } from "../../../shared/config/toolbarButtonRegistry.js";
 import { clearPluginMenuRegistry, getPluginMenuItems } from "../pluginMenuRegistry.js";
+import {
+  clearForgeProviderRegistry,
+  getRegisteredForgeProviders,
+  listMatchingProviders,
+} from "../forgeProviderRegistry.js";
 
 function makeCtx(pluginId: string, overrides: Partial<PluginIpcContext> = {}): PluginIpcContext {
   return {
@@ -120,6 +125,7 @@ afterEach(async () => {
     clearPanelKindRegistry();
     clearToolbarButtonRegistry();
     clearPluginMenuRegistry();
+    clearForgeProviderRegistry();
     storeState.clear();
     for (const key of globalMarkers) {
       delete (globalThis as Record<string, unknown>)[key];
@@ -371,6 +377,69 @@ describe("PluginService integration — menu item contributions", () => {
         location: "terminal",
       },
     });
+  });
+});
+
+describe("PluginService integration — forge provider contributions", () => {
+  it("registers a manifest forgeProviders entry and unregisters it on unload", async () => {
+    await writePlugin("acme.forge-plugin", {
+      name: "acme.forge-plugin",
+      version: "1.0.0",
+      contributes: {
+        forgeProviders: [
+          {
+            id: "github",
+            name: "GitHub",
+            matches: ["github.com"],
+            capabilities: ["issues", "pulls"],
+          },
+        ],
+      },
+    });
+
+    const service = new PluginService(tmpDir, "0.0.0");
+    await service.initialize();
+
+    const registered = getRegisteredForgeProviders();
+    expect(registered).toHaveLength(1);
+    expect(registered[0]).toEqual({
+      pluginId: "acme.forge-plugin",
+      contribution: {
+        id: "github",
+        name: "GitHub",
+        matches: ["github.com"],
+        capabilities: ["issues", "pulls"],
+      },
+    });
+
+    const matches = listMatchingProviders("https://github.com/owner/repo.git");
+    expect(matches).toHaveLength(1);
+    expect(matches[0].pluginId).toBe("acme.forge-plugin");
+
+    service.unloadPlugin("acme.forge-plugin");
+
+    expect(getRegisteredForgeProviders()).toHaveLength(0);
+    expect(listMatchingProviders("https://github.com/owner/repo.git")).toEqual([]);
+  });
+
+  it("registers multiple forgeProviders entries from one manifest", async () => {
+    await writePlugin("acme.multi-forge", {
+      name: "acme.multi-forge",
+      version: "1.0.0",
+      contributes: {
+        forgeProviders: [
+          { id: "primary", name: "Primary", matches: ["primary.example"] },
+          { id: "secondary", name: "Secondary", matches: ["secondary.example"] },
+        ],
+      },
+    });
+
+    const service = new PluginService(tmpDir, "0.0.0");
+    await service.initialize();
+
+    expect(getRegisteredForgeProviders()).toHaveLength(2);
+    expect(listMatchingProviders("https://primary.example/repo")).toHaveLength(1);
+    expect(listMatchingProviders("https://secondary.example/repo")).toHaveLength(1);
   });
 });
 

--- a/electron/services/__tests__/PluginService.test.ts
+++ b/electron/services/__tests__/PluginService.test.ts
@@ -42,6 +42,10 @@ vi.mock("../pluginMenuRegistry.js", () => ({
   registerPluginMenuItem: vi.fn(),
   unregisterPluginMenuItems: vi.fn(),
 }));
+vi.mock("../forgeProviderRegistry.js", () => ({
+  registerForgeProviders: vi.fn(),
+  unregisterForgeProviders: vi.fn(),
+}));
 
 import { PluginService } from "../PluginService.js";
 import { PluginManifestSchema } from "../../schemas/plugin.js";
@@ -58,6 +62,7 @@ import {
   unregisterPluginToolbarButtons,
 } from "../../../shared/config/toolbarButtonRegistry.js";
 import { registerPluginMenuItem, unregisterPluginMenuItems } from "../pluginMenuRegistry.js";
+import { registerForgeProviders, unregisterForgeProviders } from "../forgeProviderRegistry.js";
 import { CHANNELS } from "../../ipc/channels.js";
 
 function makeCtx(pluginId: string, overrides: Partial<PluginIpcContext> = {}): PluginIpcContext {
@@ -1315,6 +1320,7 @@ describe("Plugin unload lifecycle", () => {
     expect(unregisterPluginMenuItems).toHaveBeenCalledWith("acme.unloadable");
     expect(unregisterPluginToolbarButtons).toHaveBeenCalledWith("acme.unloadable");
     expect(unregisterPluginPanelKinds).toHaveBeenCalledWith("acme.unloadable");
+    expect(unregisterForgeProviders).toHaveBeenCalledWith("acme.unloadable");
   });
 
   it("unloadPlugin removes the plugin from hasPlugin and listPlugins", async () => {
@@ -1356,6 +1362,7 @@ describe("Plugin unload lifecycle", () => {
     expect(unregisterPluginMenuItems).not.toHaveBeenCalled();
     expect(unregisterPluginToolbarButtons).not.toHaveBeenCalled();
     expect(unregisterPluginPanelKinds).not.toHaveBeenCalled();
+    expect(unregisterForgeProviders).not.toHaveBeenCalled();
   });
 
   it("unloadPlugin is idempotent across repeated calls", async () => {
@@ -1372,6 +1379,7 @@ describe("Plugin unload lifecycle", () => {
     expect(unregisterPluginMenuItems).toHaveBeenCalledTimes(1);
     expect(unregisterPluginToolbarButtons).toHaveBeenCalledTimes(1);
     expect(unregisterPluginPanelKinds).toHaveBeenCalledTimes(1);
+    expect(unregisterForgeProviders).toHaveBeenCalledTimes(1);
   });
 
   it("registers plugin before importing main so sync host-API calls see it as loaded", async () => {
@@ -2300,7 +2308,7 @@ describe("reserved contribution point warnings", () => {
     );
   });
 
-  it("accepts a contributes.forgeProviders entry and logs a 'not yet implemented' warning", async () => {
+  it("registers a contributes.forgeProviders entry with the forge provider registry", async () => {
     await writePlugin("forge", {
       name: "acme.forge",
       version: "1.0.0",
@@ -2323,15 +2331,35 @@ describe("reserved contribution point warnings", () => {
     await service.initialize();
 
     expect(service.listPlugins()).toHaveLength(1);
-    expect(warnSpy).toHaveBeenCalledWith(
-      expect.stringContaining(
-        'Plugin "acme.forge": contributes.forgeProviders is not yet implemented'
-      )
-    );
-    // Reserved + ignored: a forge-only manifest has no registry side effects.
+    expect(registerForgeProviders).toHaveBeenCalledWith("acme.forge", [
+      {
+        id: "github",
+        name: "GitHub",
+        matches: ["github.com"],
+        capabilities: ["issues", "pulls", "reviews"],
+        settingsScopeRef: "github",
+        viewRefs: ["github-issues"],
+      },
+    ]);
+    expect(warnSpy).not.toHaveBeenCalledWith(expect.stringContaining("contributes.forgeProviders"));
+    // A forge-only manifest does not touch the other registries.
     expect(registerPanelKind).not.toHaveBeenCalled();
     expect(registerToolbarButton).not.toHaveBeenCalled();
     expect(registerPluginMenuItem).not.toHaveBeenCalled();
+  });
+
+  it("does not call registerForgeProviders when the manifest declares no forgeProviders", async () => {
+    await writePlugin("forge-none", {
+      name: "acme.forge-none",
+      version: "1.0.0",
+      engines: { daintree: "^0.7.0" },
+    });
+
+    const service = new PluginService(tmpDir, "0.7.5");
+    await service.initialize();
+
+    expect(service.listPlugins()).toHaveLength(1);
+    expect(registerForgeProviders).not.toHaveBeenCalled();
   });
 
   it("does not warn about reserved points when the manifest omits them", async () => {

--- a/electron/services/__tests__/forgeProviderRegistry.test.ts
+++ b/electron/services/__tests__/forgeProviderRegistry.test.ts
@@ -91,6 +91,29 @@ describe("forgeProviderRegistry — registration", () => {
     expect(entries).toHaveLength(1);
     expect(entries[0].contribution.id).toBe("a");
   });
+
+  it("freezes stored contributions so callers cannot corrupt the registry", () => {
+    registerForgeProviders("acme.frozen", [
+      makeContribution("x", ["frozen.example"], {
+        capabilities: ["issues"],
+        viewRefs: ["v"],
+      }),
+    ]);
+
+    const entries = getRegisteredForgeProviders();
+    expect(() => entries[0].contribution.matches.push("evil.example")).toThrow();
+    expect(() => (entries[0].contribution.capabilities as string[])?.push("evil")).toThrow();
+    expect(() => (entries[0].contribution.viewRefs as string[])?.push("evil")).toThrow();
+    expect(listMatchingProviders("https://evil.example/r")).toEqual([]);
+  });
+
+  it("treats an empty contributions array as an unregister (replace-with-nothing)", () => {
+    registerForgeProviders("acme.reset", [makeContribution("a", ["reset.example"])]);
+    expect(getRegisteredForgeProviders()).toHaveLength(1);
+
+    registerForgeProviders("acme.reset", []);
+    expect(getRegisteredForgeProviders()).toHaveLength(0);
+  });
 });
 
 describe("forgeProviderRegistry — unregister and clear", () => {

--- a/electron/services/__tests__/forgeProviderRegistry.test.ts
+++ b/electron/services/__tests__/forgeProviderRegistry.test.ts
@@ -1,0 +1,277 @@
+import { beforeEach, describe, expect, it } from "vitest";
+import type { ForgeProviderContribution, RepoRef } from "../../../shared/types/forge.js";
+import {
+  clearForgeProviderRegistry,
+  getActiveProvider,
+  getRegisteredForgeProviders,
+  listMatchingProviders,
+  registerForgeProviders,
+  unregisterForgeProviders,
+} from "../forgeProviderRegistry.js";
+
+beforeEach(() => {
+  clearForgeProviderRegistry();
+});
+
+function makeContribution(
+  id: string,
+  matches: string[],
+  extra: Partial<ForgeProviderContribution> = {}
+): ForgeProviderContribution {
+  return {
+    id,
+    name: id,
+    matches,
+    ...extra,
+  };
+}
+
+function makeRepoRef(host: string): RepoRef {
+  return { host, owner: "o", repo: "r", rawData: null };
+}
+
+describe("forgeProviderRegistry — registration", () => {
+  it("stores registered contributions and exposes them via getRegisteredForgeProviders", () => {
+    registerForgeProviders("acme.github", [makeContribution("github", ["github.com"])]);
+    const entries = getRegisteredForgeProviders();
+    expect(entries).toHaveLength(1);
+    expect(entries[0]).toEqual({
+      pluginId: "acme.github",
+      contribution: makeContribution("github", ["github.com"]),
+    });
+  });
+
+  it("preserves registration order across plugins (first-registered first)", () => {
+    registerForgeProviders("acme.first", [makeContribution("a", ["a.example"])]);
+    registerForgeProviders("acme.second", [makeContribution("b", ["b.example"])]);
+    registerForgeProviders("acme.third", [makeContribution("c", ["c.example"])]);
+
+    const entries = getRegisteredForgeProviders();
+    expect(entries.map((e) => e.pluginId)).toEqual(["acme.first", "acme.second", "acme.third"]);
+  });
+
+  it("supports multiple contributions per plugin and preserves their order", () => {
+    registerForgeProviders("acme.multi", [
+      makeContribution("primary", ["one.example"]),
+      makeContribution("secondary", ["two.example"]),
+    ]);
+
+    const entries = getRegisteredForgeProviders();
+    expect(entries.map((e) => e.contribution.id)).toEqual(["primary", "secondary"]);
+  });
+
+  it("replaces existing contributions for the same plugin when re-registered", () => {
+    registerForgeProviders("acme.repeat", [makeContribution("initial", ["initial.example"])]);
+    registerForgeProviders("acme.repeat", [
+      makeContribution("replacement", ["replacement.example"]),
+    ]);
+
+    const entries = getRegisteredForgeProviders();
+    expect(entries).toHaveLength(1);
+    expect(entries[0].contribution.id).toBe("replacement");
+  });
+
+  it("is a no-op when registering an empty array", () => {
+    registerForgeProviders("acme.empty", []);
+    expect(getRegisteredForgeProviders()).toHaveLength(0);
+  });
+
+  it("is a no-op when pluginId is empty or non-string", () => {
+    registerForgeProviders("", [makeContribution("x", ["x.example"])]);
+    registerForgeProviders(undefined as unknown as string, [makeContribution("y", ["y.example"])]);
+    expect(getRegisteredForgeProviders()).toHaveLength(0);
+  });
+
+  it("copies the input array so external mutation does not leak in", () => {
+    const contributions = [makeContribution("a", ["a.example"])];
+    registerForgeProviders("acme.copy", contributions);
+    contributions.push(makeContribution("b", ["b.example"]));
+
+    const entries = getRegisteredForgeProviders();
+    expect(entries).toHaveLength(1);
+    expect(entries[0].contribution.id).toBe("a");
+  });
+});
+
+describe("forgeProviderRegistry — unregister and clear", () => {
+  it("unregisters only the target plugin's contributions", () => {
+    registerForgeProviders("acme.keep", [makeContribution("k", ["keep.example"])]);
+    registerForgeProviders("acme.drop", [makeContribution("d", ["drop.example"])]);
+
+    unregisterForgeProviders("acme.drop");
+
+    const entries = getRegisteredForgeProviders();
+    expect(entries).toHaveLength(1);
+    expect(entries[0].pluginId).toBe("acme.keep");
+  });
+
+  it("is a no-op when unregistering an unknown pluginId", () => {
+    registerForgeProviders("acme.solo", [makeContribution("s", ["solo.example"])]);
+    expect(() => unregisterForgeProviders("never-loaded")).not.toThrow();
+    expect(getRegisteredForgeProviders()).toHaveLength(1);
+  });
+
+  it("is a no-op for empty or non-string pluginId", () => {
+    registerForgeProviders("acme.solo", [makeContribution("s", ["solo.example"])]);
+    expect(() => unregisterForgeProviders("")).not.toThrow();
+    expect(() => unregisterForgeProviders(undefined as unknown as string)).not.toThrow();
+    expect(getRegisteredForgeProviders()).toHaveLength(1);
+  });
+
+  it("is a no-op when unregistering twice", () => {
+    registerForgeProviders("acme.twice", [makeContribution("t", ["twice.example"])]);
+    unregisterForgeProviders("acme.twice");
+    expect(() => unregisterForgeProviders("acme.twice")).not.toThrow();
+    expect(getRegisteredForgeProviders()).toHaveLength(0);
+  });
+
+  it("supports register → unregister → re-register round-trip", () => {
+    registerForgeProviders("acme.cycle", [makeContribution("c", ["cycle.example"])]);
+    unregisterForgeProviders("acme.cycle");
+    expect(getRegisteredForgeProviders()).toHaveLength(0);
+
+    registerForgeProviders("acme.cycle", [makeContribution("fresh", ["fresh.example"])]);
+    const entries = getRegisteredForgeProviders();
+    expect(entries).toHaveLength(1);
+    expect(entries[0].contribution.id).toBe("fresh");
+  });
+
+  it("clearForgeProviderRegistry removes all entries", () => {
+    registerForgeProviders("acme.a", [makeContribution("a", ["a.example"])]);
+    registerForgeProviders("acme.b", [makeContribution("b", ["b.example"])]);
+
+    clearForgeProviderRegistry();
+    expect(getRegisteredForgeProviders()).toHaveLength(0);
+  });
+});
+
+describe("forgeProviderRegistry — listMatchingProviders", () => {
+  it("matches an HTTPS URL against a hostname pattern", () => {
+    registerForgeProviders("acme.github", [makeContribution("github", ["github.com"])]);
+    const matches = listMatchingProviders("https://github.com/owner/repo.git");
+    expect(matches).toHaveLength(1);
+    expect(matches[0].pluginId).toBe("acme.github");
+  });
+
+  it("matches an SCP URL (git@host:path) against a hostname pattern", () => {
+    registerForgeProviders("acme.gitlab", [makeContribution("gitlab", ["gitlab.com"])]);
+    const matches = listMatchingProviders("git@gitlab.com:group/repo.git");
+    expect(matches).toHaveLength(1);
+    expect(matches[0].pluginId).toBe("acme.gitlab");
+  });
+
+  it("matches an SCP URL without a user prefix", () => {
+    registerForgeProviders("acme.bare", [makeContribution("bare", ["bare.example.com"])]);
+    const matches = listMatchingProviders("bare.example.com:group/repo.git");
+    expect(matches).toHaveLength(1);
+    expect(matches[0].pluginId).toBe("acme.bare");
+  });
+
+  it("matches an ssh:// URL", () => {
+    registerForgeProviders("acme.github", [makeContribution("github", ["github.com"])]);
+    const matches = listMatchingProviders("ssh://git@github.com/owner/repo.git");
+    expect(matches).toHaveLength(1);
+  });
+
+  it("does not misclassify HTTPS-with-port as SCP form", () => {
+    registerForgeProviders("acme.host", [makeContribution("host", ["host.example.com"])]);
+    const matches = listMatchingProviders("https://host.example.com:443/owner/repo.git");
+    expect(matches).toHaveLength(1);
+    expect(matches[0].pluginId).toBe("acme.host");
+  });
+
+  it("strips a www. prefix from the URL hostname before matching", () => {
+    registerForgeProviders("acme.github", [makeContribution("github", ["github.com"])]);
+    const matches = listMatchingProviders("https://www.github.com/owner/repo");
+    expect(matches).toHaveLength(1);
+  });
+
+  it("strips a www. prefix from the pattern before matching", () => {
+    registerForgeProviders("acme.github", [makeContribution("github", ["www.github.com"])]);
+    const matches = listMatchingProviders("https://github.com/owner/repo");
+    expect(matches).toHaveLength(1);
+  });
+
+  it("matches case-insensitively", () => {
+    registerForgeProviders("acme.github", [makeContribution("github", ["GitHub.com"])]);
+    const matches = listMatchingProviders("https://GITHUB.COM/owner/repo");
+    expect(matches).toHaveLength(1);
+  });
+
+  it("returns all matching providers in registration order", () => {
+    registerForgeProviders("acme.first", [makeContribution("first", ["github.com"])]);
+    registerForgeProviders("acme.second", [makeContribution("second", ["github.com"])]);
+
+    const matches = listMatchingProviders("https://github.com/owner/repo");
+    expect(matches.map((m) => m.pluginId)).toEqual(["acme.first", "acme.second"]);
+  });
+
+  it("returns empty when no provider matches", () => {
+    registerForgeProviders("acme.github", [makeContribution("github", ["github.com"])]);
+    const matches = listMatchingProviders("https://gitlab.com/owner/repo");
+    expect(matches).toEqual([]);
+  });
+
+  it("returns empty when the registry has no entries", () => {
+    expect(listMatchingProviders("https://github.com/owner/repo")).toEqual([]);
+  });
+
+  it("returns empty for an unparseable URL", () => {
+    registerForgeProviders("acme.github", [makeContribution("github", ["github.com"])]);
+    expect(listMatchingProviders("")).toEqual([]);
+    expect(listMatchingProviders("   ")).toEqual([]);
+    expect(listMatchingProviders("not a url")).toEqual([]);
+    expect(listMatchingProviders(undefined as unknown as string)).toEqual([]);
+  });
+
+  it("matches multiple patterns within a single contribution", () => {
+    registerForgeProviders("acme.multi", [
+      makeContribution("forge", ["primary.example.com", "secondary.example.com"]),
+    ]);
+
+    expect(listMatchingProviders("https://primary.example.com/x")).toHaveLength(1);
+    expect(listMatchingProviders("https://secondary.example.com/x")).toHaveLength(1);
+    expect(listMatchingProviders("https://other.example.com/x")).toHaveLength(0);
+  });
+});
+
+describe("forgeProviderRegistry — getActiveProvider", () => {
+  it("returns the first matching provider for a URL", () => {
+    registerForgeProviders("acme.first", [makeContribution("first", ["github.com"])]);
+    registerForgeProviders("acme.second", [makeContribution("second", ["github.com"])]);
+
+    const active = getActiveProvider("https://github.com/owner/repo");
+    expect(active?.pluginId).toBe("acme.first");
+  });
+
+  it("returns the first matching provider for a RepoRef", () => {
+    registerForgeProviders("acme.github", [makeContribution("github", ["github.com"])]);
+    const active = getActiveProvider(makeRepoRef("github.com"));
+    expect(active?.pluginId).toBe("acme.github");
+  });
+
+  it("uses RepoRef.host directly without re-parsing a URL", () => {
+    registerForgeProviders("acme.github", [makeContribution("github", ["github.com"])]);
+    // RepoRef.host is already the hostname; passing a full URL should not match.
+    const active = getActiveProvider(makeRepoRef("https://github.com/owner/repo"));
+    expect(active).toBeUndefined();
+  });
+
+  it("normalizes RepoRef.host case and www. prefix", () => {
+    registerForgeProviders("acme.github", [makeContribution("github", ["github.com"])]);
+    expect(getActiveProvider(makeRepoRef("GITHUB.COM"))?.pluginId).toBe("acme.github");
+    expect(getActiveProvider(makeRepoRef("www.github.com"))?.pluginId).toBe("acme.github");
+  });
+
+  it("returns undefined when no provider matches", () => {
+    registerForgeProviders("acme.github", [makeContribution("github", ["github.com"])]);
+    expect(getActiveProvider("https://gitlab.com/x/y")).toBeUndefined();
+    expect(getActiveProvider(makeRepoRef("gitlab.com"))).toBeUndefined();
+  });
+
+  it("returns undefined for a malformed RepoRef", () => {
+    registerForgeProviders("acme.github", [makeContribution("github", ["github.com"])]);
+    expect(getActiveProvider({ host: "", owner: "", repo: "", rawData: null })).toBeUndefined();
+    expect(getActiveProvider(null as unknown as RepoRef)).toBeUndefined();
+  });
+});

--- a/electron/services/forgeProviderRegistry.ts
+++ b/electron/services/forgeProviderRegistry.ts
@@ -24,8 +24,27 @@ export function registerForgeProviders(
   contributions: ForgeProviderContribution[]
 ): void {
   if (typeof pluginId !== "string" || pluginId.length === 0) return;
-  if (!Array.isArray(contributions) || contributions.length === 0) return;
-  PLUGIN_FORGE_PROVIDERS.set(pluginId, [...contributions]);
+  if (!Array.isArray(contributions) || contributions.length === 0) {
+    PLUGIN_FORGE_PROVIDERS.delete(pluginId);
+    return;
+  }
+  PLUGIN_FORGE_PROVIDERS.set(pluginId, contributions.map(freezeContribution));
+}
+
+function freezeContribution(c: ForgeProviderContribution): ForgeProviderContribution {
+  const frozen: ForgeProviderContribution = {
+    ...c,
+    matches: Object.freeze([...c.matches]) as unknown as string[],
+  };
+  if (c.capabilities) {
+    frozen.capabilities = Object.freeze([
+      ...c.capabilities,
+    ]) as unknown as ForgeProviderContribution["capabilities"];
+  }
+  if (c.viewRefs) {
+    frozen.viewRefs = Object.freeze([...c.viewRefs]) as unknown as string[];
+  }
+  return Object.freeze(frozen);
 }
 
 export function unregisterForgeProviders(pluginId: string): void {

--- a/electron/services/forgeProviderRegistry.ts
+++ b/electron/services/forgeProviderRegistry.ts
@@ -1,0 +1,122 @@
+import type { ForgeProviderContribution, RepoRef } from "../../shared/types/forge.js";
+
+/**
+ * Host-side registry of `forgeProviders` contributions, keyed by pluginId.
+ *
+ * Populated eagerly from each plugin's manifest during `loadPlugin` so the
+ * Preferences UI and remote-URL routing table are usable before any plugin's
+ * `activate()` runs. Cleared on plugin unload via the existing disposable
+ * cascade in `PluginService.unloadPlugin`.
+ *
+ * The runtime implementation handler (`ForgeProviderImpl`) is wired separately
+ * in #8058 via `host.registerForgeProvider`. This registry tracks only the
+ * descriptor surface declared in the manifest.
+ */
+const PLUGIN_FORGE_PROVIDERS = new Map<string, ForgeProviderContribution[]>();
+
+export interface RegisteredForgeProvider {
+  pluginId: string;
+  contribution: ForgeProviderContribution;
+}
+
+export function registerForgeProviders(
+  pluginId: string,
+  contributions: ForgeProviderContribution[]
+): void {
+  if (typeof pluginId !== "string" || pluginId.length === 0) return;
+  if (!Array.isArray(contributions) || contributions.length === 0) return;
+  PLUGIN_FORGE_PROVIDERS.set(pluginId, [...contributions]);
+}
+
+export function unregisterForgeProviders(pluginId: string): void {
+  if (typeof pluginId !== "string" || pluginId.length === 0) return;
+  PLUGIN_FORGE_PROVIDERS.delete(pluginId);
+}
+
+export function clearForgeProviderRegistry(): void {
+  PLUGIN_FORGE_PROVIDERS.clear();
+}
+
+export function getRegisteredForgeProviders(): RegisteredForgeProvider[] {
+  const result: RegisteredForgeProvider[] = [];
+  for (const [pluginId, contributions] of PLUGIN_FORGE_PROVIDERS) {
+    for (const contribution of contributions) {
+      result.push({ pluginId, contribution });
+    }
+  }
+  return result;
+}
+
+export function listMatchingProviders(remoteUrl: string): RegisteredForgeProvider[] {
+  const hostname = extractHostname(remoteUrl);
+  if (hostname === null) return [];
+  return listProvidersByHostname(hostname);
+}
+
+export function getActiveProvider(remoteUrl: string): RegisteredForgeProvider | undefined;
+export function getActiveProvider(repoRef: RepoRef): RegisteredForgeProvider | undefined;
+export function getActiveProvider(arg: string | RepoRef): RegisteredForgeProvider | undefined {
+  if (typeof arg === "string") {
+    return listMatchingProviders(arg)[0];
+  }
+  if (arg === null || typeof arg !== "object" || typeof arg.host !== "string") {
+    return undefined;
+  }
+  const hostname = normalizeHostname(arg.host);
+  if (hostname === null) return undefined;
+  return listProvidersByHostname(hostname)[0];
+}
+
+function listProvidersByHostname(hostname: string): RegisteredForgeProvider[] {
+  const matches: RegisteredForgeProvider[] = [];
+  for (const [pluginId, contributions] of PLUGIN_FORGE_PROVIDERS) {
+    for (const contribution of contributions) {
+      if (hostnameMatchesAny(hostname, contribution.matches)) {
+        matches.push({ pluginId, contribution });
+      }
+    }
+  }
+  return matches;
+}
+
+function hostnameMatchesAny(hostname: string, patterns: string[]): boolean {
+  for (const pattern of patterns) {
+    const normalized = normalizeHostname(pattern);
+    if (normalized !== null && normalized === hostname) return true;
+  }
+  return false;
+}
+
+function normalizeHostname(host: string): string | null {
+  if (typeof host !== "string") return null;
+  const trimmed = host.trim().toLowerCase();
+  if (trimmed.length === 0) return null;
+  return trimmed.startsWith("www.") ? trimmed.slice(4) : trimmed;
+}
+
+/**
+ * Extract a normalized hostname from a git remote URL. Handles SCP form
+ * (`user@host:path`), HTTPS, and SSH (`ssh://...`). Returns `null` for
+ * malformed input — callers treat that as "no match".
+ */
+function extractHostname(url: string): string | null {
+  if (typeof url !== "string") return null;
+  const trimmed = url.trim();
+  if (trimmed.length === 0) return null;
+
+  // SCP form: `user@host:path` — no scheme, host terminated by the first colon.
+  // The `!includes("://")` discriminator distinguishes this from URLs that
+  // carry a port (`https://host:443/...`), which never have an SCP shape.
+  if (!trimmed.includes("://") && trimmed.includes(":")) {
+    const match = /^(?:[^@/:]+@)?([^:/]+):/.exec(trimmed);
+    if (match) return normalizeHostname(match[1]);
+    return null;
+  }
+
+  try {
+    const parsed = new URL(trimmed);
+    return normalizeHostname(parsed.hostname);
+  } catch {
+    return null;
+  }
+}


### PR DESCRIPTION
## Summary

- Introduces `ForgeProviderRegistry` — a main-process singleton that maps plugin IDs to `ForgeProviderContribution[]` and resolves them against a worktree's remote URL via hostname matching.
- `PluginService.loadPlugin` now does eager manifest-driven registration of forge providers (replacing the old stub warning); `unloadPlugin` cascades to `unregisterForgeProviders`.
- Contributions are frozen on ingest; an empty array is treated as delete.

Resolves #8057

## Changes

- `electron/services/forgeProviderRegistry.ts` — new registry with `register`/`unregister`/`clear` lifecycle and two lookup APIs: `listMatchingProviders(remoteUrl)` returns all providers whose hostname patterns match; `getActiveProvider(repoRef|remoteUrl)` returns the first match. Hostname extraction handles SCP-form (`git@host:path`), HTTPS, and `ssh://` URLs, stripping `www.` and lowercasing both sides.
- `electron/services/PluginService.ts` — wires `registerForgeProviders` on load and `unregisterForgeProviders` on unload, matching the existing panel-kind/toolbar/menu disposal pattern.
- Tests: 34 unit tests covering hostname normalisation, ordering, lifecycle, and mutation safety; integration tests covering load → match → unload and multi-contribution cases. Existing `PluginService` tests updated to assert the new registration calls.

Companion to #8056 (foundation types/schema). Host-API binding (`host.registerForgeProvider`) is deferred to #8058.

## Testing

Unit and integration test suite covers the full registry lifecycle, all URL forms, edge cases (empty array, frozen mutation, `www.` stripping, case folding), and the `PluginService` load/unload round-trip.