### PR TITLE
feat(layout): bring Waiting popover up to Background popover chrome

### DIFF
--- a/src/components/Layout/WaitingContainer.tsx
+++ b/src/components/Layout/WaitingContainer.tsx
@@ -57,19 +57,23 @@ export function WaitingContainer({ compact = false }: WaitingContainerProps) {
   const { worktreeMap } = useWorktrees();
 
   const displayItems = useMemo((): WaitingDisplayItem[] => {
-    const waitingById = new Map<string, TerminalInstance>();
-    for (const terminal of terminals) waitingById.set(terminal.id, terminal);
-
+    // Build panelId -> group, applying the same location guard as
+    // getPanelGroup so a stale group whose location no longer matches the
+    // panel falls through to a single row instead of mis-routing setActiveTab.
     const panelToGroup = new Map<string, TabGroup>();
+    const waitingByPanelId = new Map<string, TerminalInstance>();
+    for (const terminal of terminals) waitingByPanelId.set(terminal.id, terminal);
     for (const group of tabGroups.values()) {
       for (const panelId of group.panelIds) {
-        if (waitingById.has(panelId)) {
-          panelToGroup.set(panelId, group);
-        }
+        const panel = waitingByPanelId.get(panelId);
+        if (!panel) continue;
+        const panelLocation = panel.location === "dock" ? "dock" : "grid";
+        if (panelLocation !== group.location) continue;
+        panelToGroup.set(panelId, group);
       }
     }
 
-    const groupBuckets = new Map<string, TerminalInstance[]>();
+    const groupBuckets = new Map<string, { group: TabGroup; waitingMembers: TerminalInstance[] }>();
     const singles: WaitingDisplaySingle[] = [];
 
     for (const terminal of terminals) {
@@ -77,9 +81,9 @@ export function WaitingContainer({ compact = false }: WaitingContainerProps) {
       if (group) {
         const bucket = groupBuckets.get(group.id);
         if (bucket) {
-          bucket.push(terminal);
+          bucket.waitingMembers.push(terminal);
         } else {
-          groupBuckets.set(group.id, [terminal]);
+          groupBuckets.set(group.id, { group, waitingMembers: [terminal] });
         }
       } else {
         singles.push({ type: "single", terminal, groupId: null });
@@ -88,19 +92,12 @@ export function WaitingContainer({ compact = false }: WaitingContainerProps) {
 
     const items: WaitingDisplayItem[] = [];
 
-    for (const [groupId, waitingMembers] of groupBuckets) {
-      const group = tabGroups.get(groupId);
-      if (!group) {
-        for (const terminal of waitingMembers) {
-          items.push({ type: "single", terminal, groupId: null });
-        }
-        continue;
-      }
+    for (const { group, waitingMembers } of groupBuckets.values()) {
       if (waitingMembers.length > 1) {
         items.push({ type: "group", group, waitingTerminals: waitingMembers });
       } else {
         for (const terminal of waitingMembers) {
-          items.push({ type: "single", terminal, groupId });
+          items.push({ type: "single", terminal, groupId: group.id });
         }
       }
     }
@@ -286,13 +283,26 @@ function WaitingSingleItem({
   const title = terminal.title || "Terminal";
 
   return (
-    <button
-      type="button"
+    // The row is a div + role="button" rather than a native <button>
+    // because the kill icon-button is a sibling target inside this row;
+    // nesting <button> inside <button> is invalid HTML and breaks
+    // keyboard / screen-reader semantics.
+    <div
       data-testid="waiting-single-item"
       data-agent-state={agentState ?? "unknown"}
+      role="button"
+      tabIndex={0}
       onClick={() => onActivate(terminal, groupId)}
+      onKeyDown={(e) => {
+        // Ignore Enter / Space bubbled from the inner kill button.
+        if (e.target !== e.currentTarget) return;
+        if (e.key === "Enter" || e.key === " ") {
+          e.preventDefault();
+          onActivate(terminal, groupId);
+        }
+      }}
       className={cn(
-        "flex items-start gap-2 px-2 py-1.5 rounded-[var(--radius-sm)] border-l-2 border-l-transparent hover:bg-tint/5 focus:bg-tint/5 outline-hidden transition-colors group text-left w-full",
+        "flex items-start gap-2 px-2 py-1.5 rounded-[var(--radius-sm)] border-l-2 border-l-transparent hover:bg-tint/5 focus:bg-tint/5 focus-visible:outline-2 focus-visible:outline-daintree-accent outline-hidden transition-colors group cursor-pointer w-full",
         compact && "py-1 pl-1.5"
       )}
       aria-label={`Focus ${title}`}
@@ -363,7 +373,7 @@ function WaitingSingleItem({
           <TooltipContent side="bottom">{`Kill ${title}`}</TooltipContent>
         </Tooltip>
       </div>
-    </button>
+    </div>
   );
 }
 

--- a/src/components/Layout/WaitingContainer.tsx
+++ b/src/components/Layout/WaitingContainer.tsx
@@ -1,24 +1,453 @@
+import { useState, useMemo, useCallback } from "react";
+import { ChevronDown, ChevronRight, Layers, X } from "lucide-react";
+import { useShallow } from "zustand/react/shallow";
+import { Popover, PopoverContent, PopoverTrigger } from "@/components/ui/popover";
+import { Button } from "@/components/ui/button";
+import { Tooltip, TooltipContent, TooltipTrigger } from "@/components/ui/tooltip";
+import { ConfirmDialog } from "@/components/ui/ConfirmDialog";
+import { cn } from "@/lib/utils";
+import { usePanelStore, type TerminalInstance } from "@/store";
+import { useWorktreeSelectionStore } from "@/store/worktreeStore";
 import { useWaitingTerminals } from "@/hooks/useTerminalSelectors";
-import { STATE_ICONS } from "@/components/Worktree/terminalStateConfig";
-import { StatusContainer, type StatusContainerConfig } from "./StatusContainer";
-
-const waitingConfig: StatusContainerConfig = {
-  icon: STATE_ICONS.waiting,
-  iconColor: "text-status-warning",
-  badgeColor: "bg-status-warning",
-  badgeTextColor: "text-daintree-bg",
-  headerLabel: "Waiting For Input",
-  buttonLabel: "Waiting",
-  statusAriaLabel: "Waiting for input",
-  contentAriaLabel: "Waiting terminals",
-  contentId: "waiting-container-popover",
-};
+import { useWorktrees } from "@/hooks/useWorktrees";
+import { TerminalIcon } from "@/components/Terminal/TerminalIcon";
+import { deriveTerminalChrome } from "@/utils/terminalChrome";
+import { LiveTimeAgo } from "@/components/Worktree/LiveTimeAgo";
+import { STATE_ICONS, STATE_LABELS, STATE_COLORS } from "@/components/Worktree/terminalStateConfig";
+import type { TabGroup } from "@/types";
 
 interface WaitingContainerProps {
   compact?: boolean;
 }
 
+interface WaitingDisplaySingle {
+  type: "single";
+  terminal: TerminalInstance;
+  groupId: string | null;
+}
+
+interface WaitingDisplayGroup {
+  type: "group";
+  group: TabGroup;
+  waitingTerminals: TerminalInstance[];
+}
+
+type WaitingDisplayItem = WaitingDisplaySingle | WaitingDisplayGroup;
+
 export function WaitingContainer({ compact = false }: WaitingContainerProps) {
+  const [isOpen, setIsOpen] = useState(false);
+  const [killConfirmId, setKillConfirmId] = useState<string | null>(null);
   const terminals = useWaitingTerminals();
-  return <StatusContainer config={waitingConfig} terminals={terminals} compact={compact} />;
+  const tabGroups = usePanelStore((state) => state.tabGroups);
+  const { activateTerminal, pingTerminal, removePanel, setActiveTab } = usePanelStore(
+    useShallow((state) => ({
+      activateTerminal: state.activateTerminal,
+      pingTerminal: state.pingTerminal,
+      removePanel: state.removePanel,
+      setActiveTab: state.setActiveTab,
+    }))
+  );
+  const { activeWorktreeId, selectWorktree, trackTerminalFocus } = useWorktreeSelectionStore(
+    useShallow((state) => ({
+      activeWorktreeId: state.activeWorktreeId,
+      selectWorktree: state.selectWorktree,
+      trackTerminalFocus: state.trackTerminalFocus,
+    }))
+  );
+  const { worktreeMap } = useWorktrees();
+
+  const displayItems = useMemo((): WaitingDisplayItem[] => {
+    const waitingById = new Map<string, TerminalInstance>();
+    for (const terminal of terminals) waitingById.set(terminal.id, terminal);
+
+    const panelToGroup = new Map<string, TabGroup>();
+    for (const group of tabGroups.values()) {
+      for (const panelId of group.panelIds) {
+        if (waitingById.has(panelId)) {
+          panelToGroup.set(panelId, group);
+        }
+      }
+    }
+
+    const groupBuckets = new Map<string, TerminalInstance[]>();
+    const singles: WaitingDisplaySingle[] = [];
+
+    for (const terminal of terminals) {
+      const group = panelToGroup.get(terminal.id);
+      if (group) {
+        const bucket = groupBuckets.get(group.id);
+        if (bucket) {
+          bucket.push(terminal);
+        } else {
+          groupBuckets.set(group.id, [terminal]);
+        }
+      } else {
+        singles.push({ type: "single", terminal, groupId: null });
+      }
+    }
+
+    const items: WaitingDisplayItem[] = [];
+
+    for (const [groupId, waitingMembers] of groupBuckets) {
+      const group = tabGroups.get(groupId);
+      if (!group) {
+        for (const terminal of waitingMembers) {
+          items.push({ type: "single", terminal, groupId: null });
+        }
+        continue;
+      }
+      if (waitingMembers.length > 1) {
+        items.push({ type: "group", group, waitingTerminals: waitingMembers });
+      } else {
+        for (const terminal of waitingMembers) {
+          items.push({ type: "single", terminal, groupId });
+        }
+      }
+    }
+
+    for (const single of singles) {
+      items.push(single);
+    }
+
+    return items;
+  }, [terminals, tabGroups]);
+
+  const handleActivate = useCallback(
+    (terminal: TerminalInstance, groupId: string | null) => {
+      const worktreeId = terminal.worktreeId?.trim();
+      if (worktreeId && worktreeId !== activeWorktreeId) {
+        trackTerminalFocus(worktreeId, terminal.id);
+        selectWorktree(worktreeId);
+      }
+      if (groupId) {
+        setActiveTab(groupId, terminal.id);
+      }
+      activateTerminal(terminal.id);
+      pingTerminal(terminal.id);
+      setIsOpen(false);
+    },
+    [
+      activeWorktreeId,
+      trackTerminalFocus,
+      selectWorktree,
+      setActiveTab,
+      activateTerminal,
+      pingTerminal,
+    ]
+  );
+
+  const killTarget = useMemo(
+    () => (killConfirmId ? terminals.find((t) => t.id === killConfirmId) : undefined),
+    [killConfirmId, terminals]
+  );
+
+  const handleKillConfirm = useCallback(() => {
+    if (killConfirmId) {
+      removePanel(killConfirmId);
+    }
+    setKillConfirmId(null);
+  }, [killConfirmId, removePanel]);
+
+  if (terminals.length === 0) return null;
+
+  const count = terminals.length;
+  const WaitingIcon = STATE_ICONS.waiting;
+
+  return (
+    <Popover open={isOpen} onOpenChange={setIsOpen}>
+      <PopoverTrigger asChild>
+        <Button
+          type="button"
+          variant="pill"
+          size="sm"
+          className={cn(
+            compact ? "px-1.5 min-w-0" : "px-3",
+            isOpen && "bg-overlay-emphasis border-border-default"
+          )}
+          aria-haspopup="dialog"
+          aria-expanded={isOpen}
+          aria-controls="waiting-container-popover"
+          aria-label={`Waiting (${count})`}
+        >
+          <span className="relative">
+            <WaitingIcon className="w-3.5 h-3.5 text-state-waiting" aria-hidden="true" />
+            {compact && count > 0 && (
+              <span className="absolute -top-1.5 -right-1.5 z-10 flex items-center justify-center min-w-[14px] h-[14px] px-0.5 rounded-full text-[10px] font-bold tabular-nums shadow-sm bg-state-waiting text-daintree-bg">
+                {count > 9 ? "9+" : count}
+              </span>
+            )}
+          </span>
+          {!compact && (
+            <span className="font-medium tabular-nums">
+              Waiting (<span className="text-state-waiting">{count}</span>)
+            </span>
+          )}
+        </Button>
+      </PopoverTrigger>
+
+      <PopoverContent
+        id="waiting-container-popover"
+        role="dialog"
+        aria-label="Waiting panels"
+        className="w-96 p-0"
+        side="top"
+        align="end"
+        sideOffset={8}
+        onOpenAutoFocus={(e) => e.preventDefault()}
+        onCloseAutoFocus={(e) => e.preventDefault()}
+        onPointerDownOutside={(e) => {
+          if (killConfirmId !== null) e.preventDefault();
+        }}
+        onInteractOutside={(e) => {
+          if (killConfirmId !== null) e.preventDefault();
+        }}
+        onEscapeKeyDown={(e) => {
+          if (killConfirmId !== null) e.preventDefault();
+        }}
+      >
+        <div className="flex flex-col">
+          <div className="px-3 py-2 border-b border-divider bg-daintree-bg/50 flex justify-between items-center">
+            <span className="text-xs font-medium text-daintree-text/70">Waiting for input</span>
+            <span className="text-[10px] font-medium text-state-waiting tabular-nums">
+              {count} {count === 1 ? "agent" : "agents"}
+            </span>
+          </div>
+
+          <div className="p-1 flex flex-col gap-1 max-h-[360px] overflow-y-auto">
+            {displayItems.map((item) => {
+              if (item.type === "group") {
+                return (
+                  <WaitingGroupItem
+                    key={item.group.id}
+                    group={item.group}
+                    waitingTerminals={item.waitingTerminals}
+                    worktreeMap={worktreeMap}
+                    onActivate={handleActivate}
+                    onKill={(id) => setKillConfirmId(id)}
+                  />
+                );
+              }
+              const worktreeName = item.terminal.worktreeId
+                ? worktreeMap.get(item.terminal.worktreeId)?.name
+                : undefined;
+              return (
+                <WaitingSingleItem
+                  key={item.terminal.id}
+                  terminal={item.terminal}
+                  groupId={item.groupId}
+                  worktreeName={worktreeName}
+                  onActivate={handleActivate}
+                  onKill={(id) => setKillConfirmId(id)}
+                />
+              );
+            })}
+          </div>
+        </div>
+      </PopoverContent>
+
+      <ConfirmDialog
+        isOpen={killConfirmId !== null}
+        onClose={() => setKillConfirmId(null)}
+        title="Kill terminal?"
+        description={
+          killTarget
+            ? `${killTarget.title || "The terminal"} will be terminated and cannot be recovered.`
+            : "The terminal will be terminated and cannot be recovered."
+        }
+        variant="destructive"
+        confirmLabel="Kill terminal"
+        onConfirm={handleKillConfirm}
+      />
+    </Popover>
+  );
+}
+
+interface WaitingSingleItemProps {
+  terminal: TerminalInstance;
+  groupId: string | null;
+  worktreeName: string | undefined;
+  onActivate: (terminal: TerminalInstance, groupId: string | null) => void;
+  onKill: (terminalId: string) => void;
+  compact?: boolean;
+}
+
+function WaitingSingleItem({
+  terminal,
+  groupId,
+  worktreeName,
+  onActivate,
+  onKill,
+  compact = false,
+}: WaitingSingleItemProps) {
+  const agentState = terminal.agentState;
+  const StateIcon = agentState ? STATE_ICONS[agentState] : null;
+  const stateLabel = agentState ? STATE_LABELS[agentState] : null;
+  const stateColor = agentState ? STATE_COLORS[agentState] : null;
+  const title = terminal.title || "Terminal";
+
+  return (
+    <button
+      type="button"
+      data-testid="waiting-single-item"
+      data-agent-state={agentState ?? "unknown"}
+      onClick={() => onActivate(terminal, groupId)}
+      className={cn(
+        "flex items-start gap-2 px-2 py-1.5 rounded-[var(--radius-sm)] border-l-2 border-l-transparent hover:bg-tint/5 focus:bg-tint/5 outline-hidden transition-colors group text-left w-full",
+        compact && "py-1 pl-1.5"
+      )}
+      aria-label={`Focus ${title}`}
+    >
+      <div className="shrink-0 mt-0.5 opacity-70 group-hover:opacity-100 transition-opacity">
+        <TerminalIcon
+          kind={terminal.kind}
+          chrome={deriveTerminalChrome(terminal)}
+          className={compact ? "h-2.5 w-2.5" : "h-3 w-3"}
+        />
+      </div>
+
+      <div className="flex-1 min-w-0">
+        <div className="flex items-center gap-1.5 min-w-0">
+          <span
+            className={cn(
+              "truncate font-medium text-daintree-text/80 group-hover:text-daintree-text transition-colors",
+              compact ? "text-[11px]" : "text-xs"
+            )}
+          >
+            {title}
+          </span>
+          {terminal.lastStateChange != null && (
+            <LiveTimeAgo
+              timestamp={terminal.lastStateChange}
+              className="text-[10px] text-daintree-text/40 shrink-0"
+            />
+          )}
+        </div>
+        <div className="flex items-center gap-1.5 mt-0.5 text-[11px] text-daintree-text/55">
+          {worktreeName && <span className="truncate">{worktreeName}</span>}
+          {worktreeName && (stateLabel || terminal.activityHeadline) && (
+            <span className="text-daintree-text/30">·</span>
+          )}
+          {StateIcon && stateLabel && (
+            <span className={cn("inline-flex items-center gap-1 shrink-0", stateColor)}>
+              <StateIcon className="h-2.5 w-2.5" />
+              <span>{stateLabel}</span>
+            </span>
+          )}
+          {terminal.activityHeadline && (
+            <>
+              {(worktreeName || stateLabel) && <span className="text-daintree-text/30">·</span>}
+              <span className="truncate italic text-daintree-text/50">
+                {terminal.activityHeadline}
+              </span>
+            </>
+          )}
+        </div>
+      </div>
+
+      <div className="flex gap-0.5 shrink-0 mt-0.5">
+        <Tooltip>
+          <TooltipTrigger asChild>
+            <Button
+              variant="ghost-danger"
+              size="icon-sm"
+              onClick={(e) => {
+                e.stopPropagation();
+                onKill(terminal.id);
+              }}
+              aria-label={`Kill ${title}`}
+              data-testid="waiting-kill-button"
+            >
+              <X aria-hidden="true" />
+            </Button>
+          </TooltipTrigger>
+          <TooltipContent side="bottom">{`Kill ${title}`}</TooltipContent>
+        </Tooltip>
+      </div>
+    </button>
+  );
+}
+
+interface WaitingGroupItemProps {
+  group: TabGroup;
+  waitingTerminals: TerminalInstance[];
+  worktreeMap: ReturnType<typeof useWorktrees>["worktreeMap"];
+  onActivate: (terminal: TerminalInstance, groupId: string | null) => void;
+  onKill: (terminalId: string) => void;
+}
+
+function WaitingGroupItem({
+  group,
+  waitingTerminals,
+  worktreeMap,
+  onActivate,
+  onKill,
+}: WaitingGroupItemProps) {
+  const [isExpanded, setIsExpanded] = useState(true);
+  const tabCount = waitingTerminals.length;
+  const groupName = `Tab group (${tabCount} waiting)`;
+
+  return (
+    <div className="rounded-[var(--radius-sm)] bg-transparent hover:bg-tint/5 transition-colors">
+      <div className="flex items-center gap-2 px-2.5 py-1.5 group">
+        <Button
+          variant="ghost"
+          size="icon-sm"
+          className="shrink-0 h-4 w-4 p-0 hover:bg-transparent"
+          onClick={() => setIsExpanded(!isExpanded)}
+          aria-label={isExpanded ? "Collapse group" : "Expand group"}
+          aria-expanded={isExpanded}
+          aria-controls={`waiting-group-${group.id}`}
+        >
+          {isExpanded ? (
+            <ChevronDown className="w-3 h-3 text-daintree-text/60" />
+          ) : (
+            <ChevronRight className="w-3 h-3 text-daintree-text/60" />
+          )}
+        </Button>
+
+        <div className="shrink-0 opacity-60 group-hover:opacity-100 transition-opacity">
+          <Layers className="w-3 h-3 text-daintree-text/70" />
+        </div>
+
+        <div className="flex-1 min-w-0">
+          <div className="text-xs font-medium text-daintree-text/70 group-hover:text-daintree-text truncate transition-colors">
+            {groupName}
+          </div>
+        </div>
+      </div>
+
+      {isExpanded && (
+        <div
+          id={`waiting-group-${group.id}`}
+          role="region"
+          aria-label="Group panels"
+          className="pl-5 pr-1 pb-1.5 space-y-0.5"
+        >
+          {[...waitingTerminals]
+            .sort((a, b) => {
+              const aIndex = group.panelIds.indexOf(a.id);
+              const bIndex = group.panelIds.indexOf(b.id);
+              if (aIndex !== -1 && bIndex !== -1) return aIndex - bIndex;
+              return 0;
+            })
+            .map((terminal) => {
+              const worktreeName = terminal.worktreeId
+                ? worktreeMap.get(terminal.worktreeId)?.name
+                : undefined;
+              return (
+                <WaitingSingleItem
+                  key={terminal.id}
+                  terminal={terminal}
+                  groupId={group.id}
+                  worktreeName={worktreeName}
+                  onActivate={onActivate}
+                  onKill={onKill}
+                  compact
+                />
+              );
+            })}
+        </div>
+      )}
+    </div>
+  );
 }

--- a/src/components/Layout/__tests__/WaitingContainer.test.tsx
+++ b/src/components/Layout/__tests__/WaitingContainer.test.tsx
@@ -270,6 +270,22 @@ describe("WaitingContainer", () => {
       expect(screen.queryByTestId("bg-watch-button")).toBeNull();
       expect(screen.queryByTestId("waiting-watch-button")).toBeNull();
     });
+
+    it("does not nest a <button> inside a <button> (invalid HTML)", () => {
+      mockTerminals = [makeTerminal({ id: "t1" })];
+      const { container } = render(<WaitingContainer />);
+      const nested = container.querySelectorAll("button button");
+      expect(nested.length).toBe(0);
+    });
+
+    it("exposes the row as a button via role + tabIndex (not a native <button>)", () => {
+      mockTerminals = [makeTerminal({ id: "t1" })];
+      render(<WaitingContainer />);
+      const row = screen.getByTestId("waiting-single-item");
+      expect(row.tagName).toBe("DIV");
+      expect(row.getAttribute("role")).toBe("button");
+      expect(row.getAttribute("tabindex")).toBe("0");
+    });
   });
 
   describe("row activation", () => {
@@ -394,6 +410,25 @@ describe("WaitingContainer", () => {
       render(<WaitingContainer />);
       fireEvent.click(screen.getByTestId("waiting-single-item"));
       expect(setActiveTabMock).not.toHaveBeenCalled();
+    });
+
+    it("renders independent collapse state across multiple groups", () => {
+      mockTerminals = [
+        makeTerminal({ id: "a1" }),
+        makeTerminal({ id: "a2" }),
+        makeTerminal({ id: "b1" }),
+        makeTerminal({ id: "b2" }),
+      ];
+      mockTabGroups = new Map([
+        ["gA", makeGroup({ id: "gA", panelIds: ["a1", "a2"], activeTabId: "a1" })],
+        ["gB", makeGroup({ id: "gB", panelIds: ["b1", "b2"], activeTabId: "b1" })],
+      ]);
+      render(<WaitingContainer />);
+      expect(screen.getAllByTestId("waiting-single-item").length).toBe(4);
+      const collapseButtons = screen.getAllByRole("button", { name: "Collapse group" });
+      expect(collapseButtons.length).toBe(2);
+      fireEvent.click(collapseButtons[0]!);
+      expect(screen.getAllByTestId("waiting-single-item").length).toBe(2);
     });
   });
 

--- a/src/components/Layout/__tests__/WaitingContainer.test.tsx
+++ b/src/components/Layout/__tests__/WaitingContainer.test.tsx
@@ -1,84 +1,429 @@
 // @vitest-environment jsdom
-import { describe, it, expect, vi } from "vitest";
-import { render } from "@testing-library/react";
-import { WaitingContainer } from "../WaitingContainer";
-import type { TerminalInstance } from "@/store/panelStore";
+import { describe, it, expect, vi, beforeEach } from "vitest";
+import { fireEvent, render, screen, within } from "@testing-library/react";
+import type { TerminalInstance } from "@/store";
+import type { TabGroup, AgentState } from "@/types";
 
-const mockWaiting: TerminalInstance[] = [
-  {
-    id: "t1",
-    title: "Agent 1",
-    type: "claude",
-    kind: "terminal",
-    worktreeId: "w1",
-    location: "grid",
-  } as TerminalInstance,
-];
+const activateTerminalMock = vi.fn();
+const pingTerminalMock = vi.fn();
+const removePanelMock = vi.fn();
+const setActiveTabMock = vi.fn();
+const selectWorktreeMock = vi.fn();
+const trackTerminalFocusMock = vi.fn();
+
+let mockTerminals: TerminalInstance[] = [];
+let mockTabGroups = new Map<string, TabGroup>();
 
 vi.mock("@/hooks/useTerminalSelectors", () => ({
-  useWaitingTerminals: () => mockWaiting,
+  useWaitingTerminals: () => mockTerminals,
 }));
 
-vi.mock("@/store/panelStore", async () => {
-  const { create } = await import("zustand");
-  const store = create(() => ({
-    activateTerminal: vi.fn(),
-    pingTerminal: vi.fn(),
-  }));
-  return { usePanelStore: store };
-});
-
-vi.mock("@/store/worktreeStore", async () => {
-  const { create } = await import("zustand");
-  const store = create(() => ({
-    activeWorktreeId: null,
-    selectWorktree: vi.fn(),
-    trackTerminalFocus: vi.fn(),
-  }));
-  return { useWorktreeSelectionStore: store };
-});
-
-vi.mock("@/components/ui/popover", () => ({
-  Popover: ({ children }: { children: React.ReactNode }) => <div>{children}</div>,
-  PopoverTrigger: ({ children }: { children: React.ReactNode }) => <div>{children}</div>,
-  PopoverContent: ({ children }: { children: React.ReactNode }) => <div>{children}</div>,
+vi.mock("@/hooks/useWorktrees", () => ({
+  useWorktrees: () => ({
+    worktreeMap: new Map([
+      ["wt-1", { id: "wt-1", name: "feature-auth" }],
+      ["wt-2", { id: "wt-2", name: "feature-ui" }],
+    ]),
+  }),
 }));
 
-vi.mock("@/components/ui/button", () => ({
-  Button: ({
-    children,
-    ...props
-  }: { children: React.ReactNode } & React.HTMLAttributes<HTMLButtonElement>) => (
-    <button {...props}>{children}</button>
-  ),
+vi.mock("@/store", () => ({
+  usePanelStore: (selector?: (state: unknown) => unknown) => {
+    const state = {
+      tabGroups: mockTabGroups,
+      activateTerminal: activateTerminalMock,
+      pingTerminal: pingTerminalMock,
+      removePanel: removePanelMock,
+      setActiveTab: setActiveTabMock,
+    };
+    return selector ? selector(state) : state;
+  },
 }));
 
-vi.mock("@/components/ui/tooltip", () => ({
-  Tooltip: ({ children }: { children: React.ReactNode }) => <div>{children}</div>,
-  TooltipContent: ({ children }: { children: React.ReactNode }) => <div>{children}</div>,
-  TooltipProvider: ({ children }: { children: React.ReactNode }) => <div>{children}</div>,
-  TooltipTrigger: ({ children }: { children: React.ReactNode }) => <div>{children}</div>,
+vi.mock("@/store/worktreeStore", () => ({
+  useWorktreeSelectionStore: (selector: (s: unknown) => unknown) =>
+    selector({
+      activeWorktreeId: "wt-1",
+      selectWorktree: selectWorktreeMock,
+      trackTerminalFocus: trackTerminalFocusMock,
+    }),
 }));
 
 vi.mock("@/components/Terminal/TerminalIcon", () => ({
   TerminalIcon: () => <span data-testid="terminal-icon" />,
 }));
 
-describe("WaitingContainer icon", () => {
-  it("renders HollowCircle (simple circle SVG) not AlertCircle", () => {
-    const { container } = render(<WaitingContainer />);
-    const svgs = container.querySelectorAll("svg");
-    expect(svgs.length).toBeGreaterThan(0);
+vi.mock("@/utils/terminalChrome", () => ({
+  deriveTerminalChrome: () => ({
+    iconId: null,
+    label: "Terminal",
+    isAgent: false,
+    agentId: null,
+    processId: null,
+    runtimeKind: "none",
+  }),
+}));
 
-    const hasHollowCircle = Array.from(svgs).some((svg) => {
-      const circles = svg.querySelectorAll("circle");
-      return (
-        circles.length === 1 &&
-        circles[0]!.getAttribute("cx") === "8" &&
-        circles[0]!.getAttribute("cy") === "8" &&
-        circles[0]!.getAttribute("r") === "6"
-      );
+vi.mock("@/components/Worktree/LiveTimeAgo", () => ({
+  LiveTimeAgo: ({ timestamp }: { timestamp: number }) => (
+    <span data-testid="live-time-ago">{`@${timestamp}`}</span>
+  ),
+}));
+
+vi.mock("@/components/ui/button", () => ({
+  Button: ({
+    children,
+    ...props
+  }: { children: React.ReactNode } & React.ButtonHTMLAttributes<HTMLButtonElement>) => (
+    <button {...props}>{children}</button>
+  ),
+}));
+
+vi.mock("@/components/ui/tooltip", () => {
+  const Pass = ({ children }: { children: React.ReactNode }) => <>{children}</>;
+  return {
+    Tooltip: Pass,
+    TooltipContent: Pass,
+    TooltipProvider: Pass,
+    TooltipTrigger: Pass,
+  };
+});
+
+type DismissHandler = (e: { preventDefault: () => void; target?: Element | null }) => void;
+
+const popoverHandlers: {
+  onPointerDownOutside: DismissHandler | undefined;
+  onInteractOutside: DismissHandler | undefined;
+  onEscapeKeyDown: DismissHandler | undefined;
+} = {
+  onPointerDownOutside: undefined,
+  onInteractOutside: undefined,
+  onEscapeKeyDown: undefined,
+};
+
+vi.mock("@/components/ui/popover", () => ({
+  Popover: ({ children, open }: { children: React.ReactNode; open?: boolean }) => (
+    <div data-testid="popover" data-open={open ? "true" : "false"}>
+      {children}
+    </div>
+  ),
+  PopoverTrigger: ({ children }: { children: React.ReactNode }) => (
+    <div data-testid="popover-trigger">{children}</div>
+  ),
+  PopoverContent: ({
+    children,
+    onPointerDownOutside,
+    onInteractOutside,
+    onEscapeKeyDown,
+  }: {
+    children: React.ReactNode;
+    onPointerDownOutside?: DismissHandler;
+    onInteractOutside?: DismissHandler;
+    onEscapeKeyDown?: DismissHandler;
+  }) => {
+    popoverHandlers.onPointerDownOutside = onPointerDownOutside;
+    popoverHandlers.onInteractOutside = onInteractOutside;
+    popoverHandlers.onEscapeKeyDown = onEscapeKeyDown;
+    return <div data-testid="popover-content">{children}</div>;
+  },
+}));
+
+vi.mock("@/components/ui/ConfirmDialog", () => ({
+  ConfirmDialog: ({
+    isOpen,
+    title,
+    confirmLabel,
+    onConfirm,
+    onClose,
+  }: {
+    isOpen: boolean;
+    title: React.ReactNode;
+    confirmLabel: string;
+    onConfirm: () => void;
+    onClose: () => void;
+  }) => {
+    if (!isOpen) return null;
+    return (
+      <div role="dialog" data-testid="kill-confirm-dialog">
+        <div data-testid="confirm-title">{title}</div>
+        <button type="button" onClick={onConfirm}>
+          {confirmLabel}
+        </button>
+        <button type="button" onClick={onClose}>
+          Cancel
+        </button>
+      </div>
+    );
+  },
+}));
+
+import { WaitingContainer } from "../WaitingContainer";
+
+function makeTerminal(overrides: Partial<TerminalInstance> = {}): TerminalInstance {
+  return {
+    id: "t1",
+    kind: "terminal",
+    title: "claude",
+    location: "grid",
+    worktreeId: "wt-1",
+    agentState: "waiting" as AgentState,
+    lastStateChange: 1700000000000,
+    ...overrides,
+  } as TerminalInstance;
+}
+
+function makeGroup(overrides: Partial<TabGroup> = {}): TabGroup {
+  return {
+    id: "g1",
+    location: "grid",
+    worktreeId: "wt-1",
+    activeTabId: "t1",
+    panelIds: ["t1", "t2"],
+    ...overrides,
+  };
+}
+
+beforeEach(() => {
+  activateTerminalMock.mockReset();
+  pingTerminalMock.mockReset();
+  removePanelMock.mockReset();
+  setActiveTabMock.mockReset();
+  selectWorktreeMock.mockReset();
+  trackTerminalFocusMock.mockReset();
+  popoverHandlers.onPointerDownOutside = undefined;
+  popoverHandlers.onInteractOutside = undefined;
+  popoverHandlers.onEscapeKeyDown = undefined;
+  mockTerminals = [];
+  mockTabGroups = new Map();
+});
+
+describe("WaitingContainer", () => {
+  it("renders nothing when there are no waiting terminals", () => {
+    const { container } = render(<WaitingContainer />);
+    expect(container.textContent).toBe("");
+  });
+
+  describe("trigger", () => {
+    it("renders HollowCircle (simple circle SVG) not AlertCircle", () => {
+      mockTerminals = [makeTerminal({ id: "t1" })];
+      const { container } = render(<WaitingContainer />);
+      const svgs = container.querySelectorAll("svg");
+      expect(svgs.length).toBeGreaterThan(0);
+
+      const hasHollowCircle = Array.from(svgs).some((svg) => {
+        const circles = svg.querySelectorAll("circle");
+        return (
+          circles.length === 1 &&
+          circles[0]!.getAttribute("cx") === "8" &&
+          circles[0]!.getAttribute("cy") === "8" &&
+          circles[0]!.getAttribute("r") === "6"
+        );
+      });
+      expect(hasHollowCircle).toBe(true);
     });
-    expect(hasHollowCircle).toBe(true);
+
+    it("shows the waiting count in the trigger label", () => {
+      mockTerminals = [
+        makeTerminal({ id: "t1" }),
+        makeTerminal({ id: "t2" }),
+        makeTerminal({ id: "t3" }),
+      ];
+      render(<WaitingContainer />);
+      const trigger = screen.getByRole("button", { name: "Waiting (3)" });
+      expect(trigger).toBeTruthy();
+    });
+  });
+
+  describe("row metadata", () => {
+    it("renders worktree name, state label, headline, and live time", () => {
+      mockTerminals = [
+        makeTerminal({
+          id: "t1",
+          title: "Fix auth bug",
+          activityHeadline: "Awaiting permission",
+          lastStateChange: 1700000000123,
+        }),
+      ];
+      render(<WaitingContainer />);
+      const row = screen.getByTestId("waiting-single-item");
+      const text = row.textContent ?? "";
+      expect(text).toContain("Fix auth bug");
+      expect(text).toContain("feature-auth");
+      expect(text).toContain("waiting");
+      expect(text).toContain("Awaiting permission");
+      expect(within(row).getByTestId("live-time-ago")).toBeTruthy();
+    });
+
+    it("uses a transparent border placeholder (no amber tint on every row)", () => {
+      mockTerminals = [makeTerminal({ id: "t1" })];
+      render(<WaitingContainer />);
+      const row = screen.getByTestId("waiting-single-item");
+      expect(row.className).toContain("border-l-2");
+      expect(row.className).toContain("border-l-transparent");
+      expect(row.className).not.toContain("color-activity-waiting");
+      expect(row.className).not.toContain("panel-state-waiting");
+    });
+
+    it("does not render a watch button", () => {
+      mockTerminals = [makeTerminal({ id: "t1" })];
+      render(<WaitingContainer />);
+      expect(screen.queryByTestId("bg-watch-button")).toBeNull();
+      expect(screen.queryByTestId("waiting-watch-button")).toBeNull();
+    });
+  });
+
+  describe("row activation", () => {
+    it("activates a single (non-grouped) terminal without setActiveTab", () => {
+      mockTerminals = [makeTerminal({ id: "t1" })];
+      render(<WaitingContainer />);
+      fireEvent.click(screen.getByTestId("waiting-single-item"));
+      expect(activateTerminalMock).toHaveBeenCalledWith("t1");
+      expect(pingTerminalMock).toHaveBeenCalledWith("t1");
+      expect(setActiveTabMock).not.toHaveBeenCalled();
+    });
+
+    it("switches worktrees when activating a terminal from another worktree", () => {
+      mockTerminals = [makeTerminal({ id: "t1", worktreeId: "wt-2" })];
+      render(<WaitingContainer />);
+      fireEvent.click(screen.getByTestId("waiting-single-item"));
+      expect(trackTerminalFocusMock).toHaveBeenCalledWith("wt-2", "t1");
+      expect(selectWorktreeMock).toHaveBeenCalledWith("wt-2");
+    });
+
+    it("does not switch worktrees when the terminal belongs to the active worktree", () => {
+      mockTerminals = [makeTerminal({ id: "t1", worktreeId: "wt-1" })];
+      render(<WaitingContainer />);
+      fireEvent.click(screen.getByTestId("waiting-single-item"));
+      expect(selectWorktreeMock).not.toHaveBeenCalled();
+    });
+  });
+
+  describe("kill confirm flow", () => {
+    it("opens the ConfirmDialog when kill is clicked, does not call removePanel yet", () => {
+      mockTerminals = [makeTerminal({ id: "t1", title: "Fix auth" })];
+      render(<WaitingContainer />);
+      expect(screen.queryByTestId("kill-confirm-dialog")).toBeNull();
+      fireEvent.click(screen.getByTestId("waiting-kill-button"));
+      expect(screen.getByTestId("kill-confirm-dialog")).toBeTruthy();
+      expect(removePanelMock).not.toHaveBeenCalled();
+    });
+
+    it("calls removePanel and closes the dialog when confirmed", () => {
+      mockTerminals = [makeTerminal({ id: "t1" })];
+      render(<WaitingContainer />);
+      fireEvent.click(screen.getByTestId("waiting-kill-button"));
+      fireEvent.click(screen.getByRole("button", { name: "Kill terminal" }));
+      expect(removePanelMock).toHaveBeenCalledWith("t1");
+      expect(screen.queryByTestId("kill-confirm-dialog")).toBeNull();
+    });
+
+    it("does not call removePanel when the dialog is cancelled", () => {
+      mockTerminals = [makeTerminal({ id: "t1" })];
+      render(<WaitingContainer />);
+      fireEvent.click(screen.getByTestId("waiting-kill-button"));
+      fireEvent.click(screen.getByRole("button", { name: "Cancel" }));
+      expect(removePanelMock).not.toHaveBeenCalled();
+      expect(screen.queryByTestId("kill-confirm-dialog")).toBeNull();
+    });
+
+    it("does not bubble the kill click through to the row activation handler", () => {
+      mockTerminals = [makeTerminal({ id: "t1" })];
+      render(<WaitingContainer />);
+      fireEvent.click(screen.getByTestId("waiting-kill-button"));
+      expect(activateTerminalMock).not.toHaveBeenCalled();
+    });
+  });
+
+  describe("tab-group rendering", () => {
+    it("groups multiple waiting members of the same tab group under a group row", () => {
+      mockTerminals = [
+        makeTerminal({ id: "t1", title: "A" }),
+        makeTerminal({ id: "t2", title: "B" }),
+      ];
+      mockTabGroups = new Map([["g1", makeGroup({ panelIds: ["t1", "t2"] })]]);
+      render(<WaitingContainer />);
+      const rows = screen.getAllByTestId("waiting-single-item");
+      expect(rows.length).toBe(2);
+      expect(screen.getByRole("button", { name: "Collapse group" })).toBeTruthy();
+    });
+
+    it("falls through to a single row when the group has only one waiting member", () => {
+      mockTerminals = [makeTerminal({ id: "t1", title: "A" })];
+      mockTabGroups = new Map([["g1", makeGroup({ panelIds: ["t1", "t-other"] })]]);
+      render(<WaitingContainer />);
+      expect(screen.queryByRole("button", { name: /group/i })).toBeNull();
+      expect(screen.getAllByTestId("waiting-single-item").length).toBe(1);
+    });
+
+    it("collapses and expands a group row when the chevron is clicked", () => {
+      mockTerminals = [
+        makeTerminal({ id: "t1", title: "A" }),
+        makeTerminal({ id: "t2", title: "B" }),
+      ];
+      mockTabGroups = new Map([["g1", makeGroup({ panelIds: ["t1", "t2"] })]]);
+      render(<WaitingContainer />);
+      expect(screen.getAllByTestId("waiting-single-item").length).toBe(2);
+      fireEvent.click(screen.getByRole("button", { name: "Collapse group" }));
+      expect(screen.queryAllByTestId("waiting-single-item").length).toBe(0);
+      fireEvent.click(screen.getByRole("button", { name: "Expand group" }));
+      expect(screen.getAllByTestId("waiting-single-item").length).toBe(2);
+    });
+
+    it("calls setActiveTab BEFORE activateTerminal for grouped panels", () => {
+      mockTerminals = [
+        makeTerminal({ id: "t1", title: "A" }),
+        makeTerminal({ id: "t2", title: "B" }),
+      ];
+      mockTabGroups = new Map([["g1", makeGroup({ panelIds: ["t1", "t2"] })]]);
+
+      const callOrder: string[] = [];
+      setActiveTabMock.mockImplementation(() => callOrder.push("setActiveTab"));
+      activateTerminalMock.mockImplementation(() => callOrder.push("activateTerminal"));
+
+      render(<WaitingContainer />);
+      const rows = screen.getAllByTestId("waiting-single-item");
+      fireEvent.click(rows[0]!);
+
+      expect(setActiveTabMock).toHaveBeenCalledWith("g1", "t1");
+      expect(activateTerminalMock).toHaveBeenCalledWith("t1");
+      expect(callOrder).toEqual(["setActiveTab", "activateTerminal"]);
+    });
+
+    it("does not call setActiveTab for ungrouped panels", () => {
+      mockTerminals = [makeTerminal({ id: "t1" })];
+      render(<WaitingContainer />);
+      fireEvent.click(screen.getByTestId("waiting-single-item"));
+      expect(setActiveTabMock).not.toHaveBeenCalled();
+    });
+  });
+
+  describe("popover dismiss guard during kill confirm", () => {
+    it("does not prevent dismiss when no kill confirm is open", () => {
+      mockTerminals = [makeTerminal({ id: "t1" })];
+      render(<WaitingContainer />);
+      const preventDefault = vi.fn();
+      popoverHandlers.onPointerDownOutside?.({ preventDefault });
+      popoverHandlers.onInteractOutside?.({ preventDefault });
+      popoverHandlers.onEscapeKeyDown?.({ preventDefault });
+      expect(preventDefault).not.toHaveBeenCalled();
+    });
+
+    it("prevents dismiss when the kill confirm dialog is open", () => {
+      mockTerminals = [makeTerminal({ id: "t1" })];
+      render(<WaitingContainer />);
+      fireEvent.click(screen.getByTestId("waiting-kill-button"));
+      expect(screen.getByTestId("kill-confirm-dialog")).toBeTruthy();
+
+      const pointer = { preventDefault: vi.fn() };
+      const interact = { preventDefault: vi.fn() };
+      const escape = { preventDefault: vi.fn() };
+      popoverHandlers.onPointerDownOutside?.(pointer);
+      popoverHandlers.onInteractOutside?.(interact);
+      popoverHandlers.onEscapeKeyDown?.(escape);
+
+      expect(pointer.preventDefault).toHaveBeenCalledTimes(1);
+      expect(interact.preventDefault).toHaveBeenCalledTimes(1);
+      expect(escape.preventDefault).toHaveBeenCalledTimes(1);
+    });
   });
 });


### PR DESCRIPTION
## Summary

- Enriches `WaitingContainer` to match the Background popover chrome: state dots, worktree names, activity headlines, `LiveTimeAgo`, kill button with confirm dialog, and tab-group expand/collapse parity
- Watch button intentionally omitted — every row is already waiting, so subscribing to a state change that's already active is pointless; no amber per-row tint for the same reason (no signal differential when all rows share the same state)
- `StatusContainer.tsx` kept intact since `ErrorsContainer` still consumes it; rows use `div role="button" tabIndex={0}` to avoid nested-button HTML invalidity with the inner kill icon-button

Resolves #8168

## Changes

- `WaitingContainer.tsx` — full rewrite to match Background popover structure: `WaitingGroupItem` with chevron expand/collapse, `WaitingPanelRow` with state dot, worktree name, activity headline, `LiveTimeAgo`, and kill button
- `WaitingContainer.test.tsx` — coverage for group expansion, kill confirm dialog, keyboard nav, and edge cases (ungrouped panels, empty list)

## Testing

- Unit tests pass covering group expand/collapse, kill flow (button → confirm dialog → IPC), keyboard navigation on rows, and edge cases
- Verified no regressions on `StatusContainer` / `ErrorsContainer` path