### PR TITLE
feat(dock): polish popover lifecycle and surface affordance

### DIFF
--- a/src/components/Layout/DockedTabGroup.tsx
+++ b/src/components/Layout/DockedTabGroup.tsx
@@ -1,5 +1,4 @@
 import { useCallback, useEffect, useMemo, useRef, useState } from "react";
-import { useShallow } from "zustand/react/shallow";
 import {
   DndContext,
   useDndMonitor,
@@ -14,7 +13,7 @@ import {
 import { SortableContext, horizontalListSortingStrategy, arrayMove } from "@dnd-kit/sortable";
 import { restrictToHorizontalAxis, restrictToParentElement } from "@dnd-kit/modifiers";
 import { LayoutGroup } from "framer-motion";
-import { ChevronDown, CopyPlus } from "lucide-react";
+import { ChevronDown, CopyPlus, SquareArrowOutUpRight } from "lucide-react";
 import { Popover, PopoverContent, PopoverTrigger } from "@/components/ui/popover";
 import {
   DropdownMenu,
@@ -28,7 +27,6 @@ import { useTabOverflow } from "@/hooks";
 import {
   useTerminalInputStore,
   usePanelStore,
-  usePortalStore,
   useFocusStore,
   type TerminalInstance,
 } from "@/store";
@@ -124,12 +122,10 @@ export function DockedTabGroup({ group, panels }: DockedTabGroupProps) {
     return () => clearTimeout(timer);
   }, [isOpen]);
 
-  const { isOpen: portalOpen, width: portalWidth } = usePortalStore(
-    useShallow((s) => ({ isOpen: s.isOpen, width: s.width }))
-  );
-
   // Mirrors DockedTerminalItem: only the worktree-sidebar-hidden state
-  // changes left-side popover collision padding.
+  // changes left-side popover collision padding. Right padding is handled by
+  // PopoverContent's collisionBoundary (width: 100vw − --right-obstruction-offset),
+  // so the assistant/portal exclusion is not re-counted here.
   const sidebarHidden = useFocusStore((s) => s.gestureSidebarHidden);
 
   const collisionPadding = useMemo(() => {
@@ -138,60 +134,51 @@ export function DockedTabGroup({ group, panels }: DockedTabGroupProps) {
       top: basePadding,
       left: sidebarHidden ? 8 : basePadding,
       bottom: basePadding,
-      right: portalOpen ? portalWidth + basePadding : basePadding,
+      right: basePadding,
     };
-  }, [sidebarHidden, portalOpen, portalWidth]);
+  }, [sidebarHidden]);
 
-  // Toggle buffering based on popover open state
+  const portalTarget = useDockPanelPortal();
+  const [portalContainer, setPortalContainer] = useState<HTMLDivElement | null>(null);
+
+  const portalContainerRef = useCallback((node: HTMLDivElement | null) => {
+    setPortalContainer(node);
+  }, []);
+
+  // Toggle buffering based on popover open state. The terminal stays mounted
+  // in DockPanelOffscreenContainer across open/close cycles; the popover only
+  // shuttles the host element into a visible container. One layout pass after
+  // the portal-target ref settles is enough for `checkVisibility()` inside
+  // `fit()` to flip — no retry loop needed.
   useEffect(() => {
-    let cancelled = false;
+    if (!activePanel) return;
+    const activeId = activePanel.id;
 
-    const applyBufferingState = async () => {
+    if (!isOpen) {
       try {
-        if (isOpen && activePanel) {
-          if (!cancelled) {
-            const MAX_RETRIES = 10;
-            const RETRY_DELAY_MS = 16;
-
-            let dims: { cols: number; rows: number } | null = null;
-            for (let attempt = 0; attempt < MAX_RETRIES && !cancelled; attempt++) {
-              await new Promise((resolve) => requestAnimationFrame(resolve));
-              if (cancelled) return;
-
-              dims = terminalInstanceService.fit(activePanel.id);
-              if (dims) break;
-
-              if (attempt < MAX_RETRIES - 1) {
-                await new Promise((resolve) => setTimeout(resolve, RETRY_DELAY_MS));
-              }
-            }
-
-            if (cancelled || !dims) return;
-
-            terminalInstanceService.applyRendererPolicy(
-              activePanel.id,
-              TerminalRefreshTier.VISIBLE
-            );
-          }
-        } else if (activePanel) {
-          if (!cancelled) {
-            terminalInstanceService.applyRendererPolicy(
-              activePanel.id,
-              TerminalRefreshTier.BACKGROUND
-            );
-          }
-        }
+        terminalInstanceService.applyRendererPolicy(activeId, TerminalRefreshTier.BACKGROUND);
       } catch (error) {
-        console.warn(`Failed to apply dock state for panel ${activePanel?.id}:`, error);
+        console.warn(`Failed to apply dock state for panel ${activeId}:`, error);
       }
-    };
+      return;
+    }
 
-    applyBufferingState();
+    if (!portalContainer) return;
+
+    const rafId = requestAnimationFrame(() => {
+      try {
+        const dims = terminalInstanceService.fit(activeId);
+        if (!dims) return;
+        terminalInstanceService.applyRendererPolicy(activeId, TerminalRefreshTier.VISIBLE);
+      } catch (error) {
+        console.warn(`Failed to apply dock state for panel ${activeId}:`, error);
+      }
+    });
 
     return () => {
-      cancelled = true;
+      cancelAnimationFrame(rafId);
     };
-  }, [isOpen, activePanel]);
+  }, [isOpen, portalContainer, activePanel]);
 
   // Auto-close popover when drag starts for any panel in this group
   useDndMonitor({
@@ -201,13 +188,6 @@ export function DockedTabGroup({ group, panels }: DockedTabGroupProps) {
       }
     },
   });
-
-  const portalTarget = useDockPanelPortal();
-  const [portalContainer, setPortalContainer] = useState<HTMLDivElement | null>(null);
-
-  const portalContainerRef = useCallback((node: HTMLDivElement | null) => {
-    setPortalContainer(node);
-  }, []);
 
   // Register/unregister portal target for active panel
   useEffect(() => {
@@ -395,6 +375,12 @@ export function DockedTabGroup({ group, panels }: DockedTabGroupProps) {
     },
     [panels, activeTabId, tabListEl]
   );
+
+  const handlePopOut = useCallback(() => {
+    if (!activePanel) return;
+    const moved = moveTerminalToGrid(activePanel.id);
+    if (moved) closeDockTerminal();
+  }, [activePanel, moveTerminalToGrid, closeDockTerminal]);
 
   // Handle add tab - duplicate the current panel as a new tab
   const handleAddTab = useCallback(async () => {
@@ -595,7 +581,7 @@ export function DockedTabGroup({ group, panels }: DockedTabGroupProps) {
         >
           <SortableContext items={tabIds} strategy={horizontalListSortingStrategy}>
             <LayoutGroup id={`dock-tabs-${group.id}`}>
-              <div className="flex items-stretch border-b border-divider bg-daintree-sidebar shrink-0">
+              <div className="group flex items-stretch border-b border-divider bg-daintree-sidebar shrink-0">
                 <div
                   ref={setTabListEl}
                   className="flex items-center min-w-0 flex-1 overflow-x-auto overscroll-x-none scrollbar-none"
@@ -650,6 +636,23 @@ export function DockedTabGroup({ group, panels }: DockedTabGroupProps) {
                     <TooltipContent side="bottom">Duplicate panel as new tab</TooltipContent>
                   </Tooltip>
                 </div>
+                <Tooltip>
+                  <TooltipTrigger asChild>
+                    <button
+                      type="button"
+                      onClick={(e) => {
+                        e.stopPropagation();
+                        handlePopOut();
+                      }}
+                      onPointerDown={(e) => e.stopPropagation()}
+                      className="shrink-0 p-1.5 text-daintree-text/40 hover:text-daintree-text hover:bg-daintree-text/10 opacity-0 group-hover:opacity-100 focus-visible:opacity-100 transition-opacity duration-150 focus-visible:outline focus-visible:outline-2 focus-visible:outline-daintree-accent focus-visible:outline-offset-1"
+                      aria-label="Open in grid"
+                    >
+                      <SquareArrowOutUpRight className="w-3 h-3" aria-hidden="true" />
+                    </button>
+                  </TooltipTrigger>
+                  <TooltipContent side="bottom">Open in grid</TooltipContent>
+                </Tooltip>
                 {hiddenPanels.length > 0 && (
                   <DropdownMenu>
                     <Tooltip>

--- a/src/components/Layout/DockedTerminalItem.tsx
+++ b/src/components/Layout/DockedTerminalItem.tsx
@@ -1,12 +1,11 @@
 import { useCallback, useEffect, useMemo, useRef, useState } from "react";
-import { useShallow } from "zustand/react/shallow";
 import { useDndMonitor } from "@dnd-kit/core";
+import { SquareArrowOutUpRight } from "lucide-react";
 import { Popover, PopoverContent, PopoverTrigger } from "@/components/ui/popover";
 import { cn, getBaseTitle } from "@/lib/utils";
 import {
   useTerminalInputStore,
   usePanelStore,
-  usePortalStore,
   useFocusStore,
   type TerminalInstance,
 } from "@/store";
@@ -63,14 +62,12 @@ export function DockedTerminalItem({ terminal }: DockedTerminalItemProps) {
     return () => clearTimeout(timer);
   }, [isOpen]);
 
-  const { isOpen: portalOpen, width: portalWidth } = usePortalStore(
-    useShallow((s) => ({ isOpen: s.isOpen, width: s.width }))
-  );
-
   // Tracks whether the worktree sidebar is hidden by the chrome gesture, so
   // popover collision padding can extend left when there's no sidebar there.
   // The assistant lives on the right, so its gesture state doesn't affect
-  // left-side padding.
+  // left-side padding. Right padding is handled by PopoverContent's
+  // collisionBoundary (width: 100vw − --right-obstruction-offset), so the
+  // assistant/portal exclusion is not re-counted here.
   const sidebarHidden = useFocusStore((s) => s.gestureSidebarHidden);
 
   const collisionPadding = useMemo(() => {
@@ -79,68 +76,49 @@ export function DockedTerminalItem({ terminal }: DockedTerminalItemProps) {
       top: basePadding,
       left: sidebarHidden ? 8 : basePadding,
       bottom: basePadding,
-      right: portalOpen ? portalWidth + basePadding : basePadding,
+      right: basePadding,
     };
-  }, [sidebarHidden, portalOpen, portalWidth]);
+  }, [sidebarHidden]);
 
-  // Toggle buffering based on popover open state
+  const portalTarget = useDockPanelPortal();
+  const [portalContainer, setPortalContainer] = useState<HTMLDivElement | null>(null);
+
+  // Use callback ref to capture the DOM element when it mounts
+  const portalContainerRef = useCallback((node: HTMLDivElement | null) => {
+    setPortalContainer(node);
+  }, []);
+
+  // Toggle buffering based on popover open state. The terminal stays mounted
+  // in DockPanelOffscreenContainer across open/close cycles; the popover only
+  // shuttles the host element into a visible container. One layout pass after
+  // the portal-target ref settles is enough for `checkVisibility()` inside
+  // `fit()` to flip — no retry loop needed.
   useEffect(() => {
-    let cancelled = false;
-
-    const applyBufferingState = async () => {
+    if (!isOpen) {
       try {
-        if (isOpen) {
-          if (!cancelled) {
-            // Wait for Popover DOM to be fully mounted and XtermAdapter to attach the terminal.
-            // A single RAF is not enough - React needs multiple frames to mount the component tree.
-            // We retry fitting until the terminal is attached to a visible container.
-            const MAX_RETRIES = 10;
-            const RETRY_DELAY_MS = 16; // ~1 frame
-
-            let dims: { cols: number; rows: number } | null = null;
-            for (let attempt = 0; attempt < MAX_RETRIES && !cancelled; attempt++) {
-              // Wait for next frame
-              await new Promise((resolve) => requestAnimationFrame(resolve));
-              if (cancelled) return;
-
-              // Try to fit - will return null if terminal is still in offscreen container
-              dims = terminalInstanceService.fit(terminal.id);
-              if (dims) break;
-
-              // If fit failed (terminal still offscreen), wait a bit and retry
-              if (attempt < MAX_RETRIES - 1) {
-                await new Promise((resolve) => setTimeout(resolve, RETRY_DELAY_MS));
-              }
-            }
-
-            if (cancelled) return;
-
-            if (!dims) {
-              // Terminal never became visible - this can happen if popover closed quickly
-              return;
-            }
-
-            terminalInstanceService.applyRendererPolicy(terminal.id, TerminalRefreshTier.VISIBLE);
-          }
-        } else {
-          if (!cancelled) {
-            terminalInstanceService.applyRendererPolicy(
-              terminal.id,
-              TerminalRefreshTier.BACKGROUND
-            );
-          }
-        }
+        terminalInstanceService.applyRendererPolicy(terminal.id, TerminalRefreshTier.BACKGROUND);
       } catch (error) {
         console.warn(`Failed to apply dock state for terminal ${terminal.id}:`, error);
       }
-    };
+      return;
+    }
 
-    applyBufferingState();
+    if (!portalContainer) return;
+
+    const rafId = requestAnimationFrame(() => {
+      try {
+        const dims = terminalInstanceService.fit(terminal.id);
+        if (!dims) return;
+        terminalInstanceService.applyRendererPolicy(terminal.id, TerminalRefreshTier.VISIBLE);
+      } catch (error) {
+        console.warn(`Failed to apply dock state for terminal ${terminal.id}:`, error);
+      }
+    });
 
     return () => {
-      cancelled = true;
+      cancelAnimationFrame(rafId);
     };
-  }, [isOpen, terminal.id]);
+  }, [isOpen, portalContainer, terminal.id]);
 
   // Auto-close popover when drag starts for this terminal
   useDndMonitor({
@@ -150,14 +128,6 @@ export function DockedTerminalItem({ terminal }: DockedTerminalItemProps) {
       }
     },
   });
-
-  const portalTarget = useDockPanelPortal();
-  const [portalContainer, setPortalContainer] = useState<HTMLDivElement | null>(null);
-
-  // Use callback ref to capture the DOM element when it mounts
-  const portalContainerRef = useCallback((node: HTMLDivElement | null) => {
-    setPortalContainer(node);
-  }, []);
 
   // Register/unregister portal target when popover opens and container is available
   useEffect(() => {
@@ -186,6 +156,11 @@ export function DockedTerminalItem({ terminal }: DockedTerminalItemProps) {
     },
     [terminal.id, openDockTerminal, closeDockTerminal]
   );
+
+  const handlePopOut = useCallback(() => {
+    const moved = moveTerminalToGrid(terminal.id);
+    if (moved) closeDockTerminal();
+  }, [terminal.id, moveTerminalToGrid, closeDockTerminal]);
 
   const presetCustomPresets = useAgentSettingsStore((s) =>
     terminal.launchAgentId ? s.settings?.agents?.[terminal.launchAgentId]?.customPresets : undefined
@@ -395,12 +370,31 @@ export function DockedTerminalItem({ terminal }: DockedTerminalItemProps) {
           setTimeout(() => terminalInstanceService.focus(terminal.id), 50);
         }}
       >
-        {/* Portal target - content is rendered in DockPanelOffscreenContainer and portaled here */}
-        <div
-          ref={portalContainerRef}
-          className="w-full h-full flex flex-col"
-          data-dock-portal-target={terminal.id}
-        />
+        <div className="relative w-full h-full group">
+          {/* Portal target - content is rendered in DockPanelOffscreenContainer and portaled here */}
+          <div
+            ref={portalContainerRef}
+            className="w-full h-full flex flex-col"
+            data-dock-portal-target={terminal.id}
+          />
+          <Tooltip>
+            <TooltipTrigger asChild>
+              <button
+                type="button"
+                onClick={(e) => {
+                  e.stopPropagation();
+                  handlePopOut();
+                }}
+                onPointerDown={(e) => e.stopPropagation()}
+                className="absolute top-1.5 right-1.5 p-1 rounded text-daintree-text/40 hover:text-daintree-text hover:bg-daintree-text/10 opacity-0 group-hover:opacity-100 focus-visible:opacity-100 transition-opacity duration-150 focus-visible:outline focus-visible:outline-2 focus-visible:outline-daintree-accent focus-visible:outline-offset-1"
+                aria-label="Open in grid"
+              >
+                <SquareArrowOutUpRight className="w-3.5 h-3.5" aria-hidden="true" />
+              </button>
+            </TooltipTrigger>
+            <TooltipContent side="bottom">Open in grid</TooltipContent>
+          </Tooltip>
+        </div>
       </PopoverContent>
     </Popover>
   );

--- a/src/components/Layout/__tests__/DockedTabGroup.mountGuard.test.tsx
+++ b/src/components/Layout/__tests__/DockedTabGroup.mountGuard.test.tsx
@@ -244,6 +244,7 @@ vi.mock("@/components/ui/ConfirmDialog", () => ({
 
 import { DockedTabGroup } from "../DockedTabGroup";
 import { terminalInstanceService } from "@/services/TerminalInstanceService";
+import { TerminalRefreshTier } from "@/types";
 
 function makePanel(overrides: Partial<TerminalInstance> = {}): TerminalInstance {
   return {
@@ -537,7 +538,7 @@ describe("DockedTabGroup lifecycle and pop-out (#8160)", () => {
     vi.useRealTimers();
   });
 
-  it("schedules a single RAF on open and applies a renderer policy for the active panel", () => {
+  it("schedules a single RAF on open and applies VISIBLE policy for the active panel", () => {
     mockActiveDockTerminalId = "t-1";
     const panels = [makePanel({ id: "t-1" }), makePanel({ id: "t-2" })];
 
@@ -550,8 +551,10 @@ describe("DockedTabGroup lifecycle and pop-out (#8160)", () => {
       flushRaf();
     });
 
-    const lastCall = vi.mocked(terminalInstanceService.applyRendererPolicy).mock.calls.at(-1);
-    expect(lastCall?.[0]).toBe("t-1");
+    expect(terminalInstanceService.applyRendererPolicy).toHaveBeenCalledWith(
+      "t-1",
+      TerminalRefreshTier.VISIBLE
+    );
   });
 
   it("applies BACKGROUND policy synchronously when mounted closed", () => {
@@ -562,9 +565,33 @@ describe("DockedTabGroup lifecycle and pop-out (#8160)", () => {
 
     expect(terminalInstanceService.applyRendererPolicy).toHaveBeenCalledWith(
       "t-1",
-      expect.anything()
+      TerminalRefreshTier.BACKGROUND
     );
     expect(rafCallbacks.length).toBe(0);
+  });
+
+  it("cancels the pending RAF and never applies VISIBLE when closed before it fires", () => {
+    mockActiveDockTerminalId = "t-1";
+    const panels = [makePanel({ id: "t-1" }), makePanel({ id: "t-2" })];
+
+    const { rerender } = render(
+      <DockedTabGroup group={makeGroup(["t-1", "t-2"], "t-1")} panels={panels} />
+    );
+    expect(rafCallbacks.length).toBe(1);
+    expect(rafCallbacks[0]?.cancelled).toBe(false);
+
+    mockActiveDockTerminalId = null;
+    rerender(<DockedTabGroup group={makeGroup(["t-1", "t-2"], "t-1")} panels={panels} />);
+
+    expect(rafCallbacks[0]?.cancelled).toBe(true);
+
+    act(() => {
+      flushRaf();
+    });
+
+    const calls = vi.mocked(terminalInstanceService.applyRendererPolicy).mock.calls;
+    expect(calls.some((c) => c[1] === TerminalRefreshTier.VISIBLE)).toBe(false);
+    expect(calls.some((c) => c[1] === TerminalRefreshTier.BACKGROUND)).toBe(true);
   });
 
   it("renders an 'Open in grid' button that pops the active panel to the grid", () => {

--- a/src/components/Layout/__tests__/DockedTabGroup.mountGuard.test.tsx
+++ b/src/components/Layout/__tests__/DockedTabGroup.mountGuard.test.tsx
@@ -498,3 +498,114 @@ describe("DockedTabGroup mount-time close guard (#6602)", () => {
     });
   });
 });
+
+describe("DockedTabGroup lifecycle and pop-out (#8160)", () => {
+  let rafCallbacks: Array<{ id: number; cb: FrameRequestCallback; cancelled: boolean }> = [];
+  let nextRafId = 1;
+
+  function flushRaf() {
+    const pending = rafCallbacks.filter((e) => !e.cancelled);
+    rafCallbacks = [];
+    for (const entry of pending) entry.cb(performance.now());
+  }
+
+  beforeEach(() => {
+    vi.useFakeTimers();
+    rafCallbacks = [];
+    nextRafId = 1;
+    vi.spyOn(globalThis, "requestAnimationFrame").mockImplementation((cb) => {
+      const id = nextRafId++;
+      rafCallbacks.push({ id, cb, cancelled: false });
+      return id;
+    });
+    vi.spyOn(globalThis, "cancelAnimationFrame").mockImplementation((id) => {
+      const entry = rafCallbacks.find((e) => e.id === id);
+      if (entry) entry.cancelled = true;
+    });
+    openDockTerminalMock.mockClear();
+    closeDockTerminalMock.mockClear();
+    moveTerminalToGridMock.mockClear();
+    mockActiveDockTerminalId = null;
+    mockTabGroups = new Map();
+    mockTabGroups.set("g-1", makeGroup(["t-1", "t-2"]));
+    vi.mocked(terminalInstanceService.applyRendererPolicy).mockClear();
+    vi.mocked(terminalInstanceService.focus).mockClear();
+  });
+
+  afterEach(() => {
+    vi.restoreAllMocks();
+    vi.useRealTimers();
+  });
+
+  it("schedules a single RAF on open and applies a renderer policy for the active panel", () => {
+    mockActiveDockTerminalId = "t-1";
+    const panels = [makePanel({ id: "t-1" }), makePanel({ id: "t-2" })];
+
+    render(<DockedTabGroup group={makeGroup(["t-1", "t-2"], "t-1")} panels={panels} />);
+
+    expect(rafCallbacks.length).toBe(1);
+    expect(terminalInstanceService.applyRendererPolicy).not.toHaveBeenCalled();
+
+    act(() => {
+      flushRaf();
+    });
+
+    const lastCall = vi.mocked(terminalInstanceService.applyRendererPolicy).mock.calls.at(-1);
+    expect(lastCall?.[0]).toBe("t-1");
+  });
+
+  it("applies BACKGROUND policy synchronously when mounted closed", () => {
+    mockActiveDockTerminalId = null;
+    const panels = [makePanel({ id: "t-1" }), makePanel({ id: "t-2" })];
+
+    render(<DockedTabGroup group={makeGroup(["t-1", "t-2"], "t-1")} panels={panels} />);
+
+    expect(terminalInstanceService.applyRendererPolicy).toHaveBeenCalledWith(
+      "t-1",
+      expect.anything()
+    );
+    expect(rafCallbacks.length).toBe(0);
+  });
+
+  it("renders an 'Open in grid' button that pops the active panel to the grid", () => {
+    mockActiveDockTerminalId = "t-1";
+    const panels = [makePanel({ id: "t-1" }), makePanel({ id: "t-2" })];
+    const { container } = render(
+      <DockedTabGroup group={makeGroup(["t-1", "t-2"], "t-1")} panels={panels} />
+    );
+
+    const popOut = container.querySelector(
+      'button[aria-label="Open in grid"]'
+    ) as HTMLButtonElement | null;
+    expect(popOut).not.toBeNull();
+
+    moveTerminalToGridMock.mockReturnValue(true);
+    act(() => {
+      popOut?.click();
+    });
+
+    expect(moveTerminalToGridMock).toHaveBeenCalledWith("t-1");
+    expect(closeDockTerminalMock).toHaveBeenCalledTimes(1);
+  });
+
+  it("does not close the dock when moveTerminalToGrid returns false", () => {
+    mockActiveDockTerminalId = "t-1";
+    const panels = [makePanel({ id: "t-1" }), makePanel({ id: "t-2" })];
+    const { container } = render(
+      <DockedTabGroup group={makeGroup(["t-1", "t-2"], "t-1")} panels={panels} />
+    );
+
+    const popOut = container.querySelector(
+      'button[aria-label="Open in grid"]'
+    ) as HTMLButtonElement | null;
+    expect(popOut).not.toBeNull();
+
+    moveTerminalToGridMock.mockReturnValue(false);
+    act(() => {
+      popOut?.click();
+    });
+
+    expect(moveTerminalToGridMock).toHaveBeenCalledWith("t-1");
+    expect(closeDockTerminalMock).not.toHaveBeenCalled();
+  });
+});

--- a/src/components/Layout/__tests__/DockedTerminalItem.mountGuard.test.tsx
+++ b/src/components/Layout/__tests__/DockedTerminalItem.mountGuard.test.tsx
@@ -268,3 +268,111 @@ describe("DockedTerminalItem mount-time close guard (#6602)", () => {
     expect(terminalInstanceService.focus).not.toHaveBeenCalled();
   });
 });
+
+describe("DockedTerminalItem lifecycle and pop-out (#8160)", () => {
+  let rafCallbacks: Array<{ id: number; cb: FrameRequestCallback; cancelled: boolean }> = [];
+  let nextRafId = 1;
+
+  function flushRaf() {
+    const pending = rafCallbacks.filter((e) => !e.cancelled);
+    rafCallbacks = [];
+    for (const entry of pending) entry.cb(performance.now());
+  }
+
+  beforeEach(() => {
+    vi.useFakeTimers();
+    rafCallbacks = [];
+    nextRafId = 1;
+    vi.spyOn(globalThis, "requestAnimationFrame").mockImplementation((cb) => {
+      const id = nextRafId++;
+      rafCallbacks.push({ id, cb, cancelled: false });
+      return id;
+    });
+    vi.spyOn(globalThis, "cancelAnimationFrame").mockImplementation((id) => {
+      const entry = rafCallbacks.find((e) => e.id === id);
+      if (entry) entry.cancelled = true;
+    });
+    openDockTerminalMock.mockClear();
+    closeDockTerminalMock.mockClear();
+    moveTerminalToGridMock.mockClear();
+    mockActiveDockTerminalId = null;
+    vi.mocked(terminalInstanceService.applyRendererPolicy).mockClear();
+    vi.mocked(terminalInstanceService.focus).mockClear();
+  });
+
+  afterEach(() => {
+    vi.restoreAllMocks();
+    vi.useRealTimers();
+  });
+
+  it("schedules a single RAF on open and applies VISIBLE policy when it fires", () => {
+    mockActiveDockTerminalId = "t-1";
+
+    render(<DockedTerminalItem terminal={makeTerminal({ id: "t-1" })} />);
+
+    expect(rafCallbacks.length).toBe(1);
+    expect(terminalInstanceService.applyRendererPolicy).not.toHaveBeenCalled();
+
+    act(() => {
+      flushRaf();
+    });
+
+    expect(terminalInstanceService.applyRendererPolicy).toHaveBeenCalledWith(
+      "t-1",
+      expect.anything()
+    );
+    const lastCall = vi.mocked(terminalInstanceService.applyRendererPolicy).mock.calls.at(-1);
+    // VISIBLE tier — using anything() for the enum value because the type isn't exported here
+    expect(lastCall?.[0]).toBe("t-1");
+  });
+
+  it("applies BACKGROUND policy synchronously when mounted closed", () => {
+    mockActiveDockTerminalId = null;
+
+    render(<DockedTerminalItem terminal={makeTerminal({ id: "t-1" })} />);
+
+    expect(terminalInstanceService.applyRendererPolicy).toHaveBeenCalledWith(
+      "t-1",
+      expect.anything()
+    );
+    expect(rafCallbacks.length).toBe(0);
+  });
+
+  it("renders an 'Open in grid' button that pops the terminal to the grid", () => {
+    mockActiveDockTerminalId = "t-1";
+
+    const { container } = render(<DockedTerminalItem terminal={makeTerminal({ id: "t-1" })} />);
+
+    const popOut = container.querySelector(
+      'button[aria-label="Open in grid"]'
+    ) as HTMLButtonElement | null;
+    expect(popOut).not.toBeNull();
+
+    moveTerminalToGridMock.mockReturnValue(true);
+    act(() => {
+      popOut?.click();
+    });
+
+    expect(moveTerminalToGridMock).toHaveBeenCalledWith("t-1");
+    expect(closeDockTerminalMock).toHaveBeenCalledTimes(1);
+  });
+
+  it("does not close the dock when moveTerminalToGrid returns false", () => {
+    mockActiveDockTerminalId = "t-1";
+
+    const { container } = render(<DockedTerminalItem terminal={makeTerminal({ id: "t-1" })} />);
+
+    const popOut = container.querySelector(
+      'button[aria-label="Open in grid"]'
+    ) as HTMLButtonElement | null;
+    expect(popOut).not.toBeNull();
+
+    moveTerminalToGridMock.mockReturnValue(false);
+    act(() => {
+      popOut?.click();
+    });
+
+    expect(moveTerminalToGridMock).toHaveBeenCalledWith("t-1");
+    expect(closeDockTerminalMock).not.toHaveBeenCalled();
+  });
+});

--- a/src/components/Layout/__tests__/DockedTerminalItem.mountGuard.test.tsx
+++ b/src/components/Layout/__tests__/DockedTerminalItem.mountGuard.test.tsx
@@ -162,6 +162,7 @@ vi.mock("@dnd-kit/core", () => ({
 
 import { DockedTerminalItem } from "../DockedTerminalItem";
 import { terminalInstanceService } from "@/services/TerminalInstanceService";
+import { TerminalRefreshTier } from "@/types";
 
 function makeTerminal(overrides: Partial<TerminalInstance> = {}): TerminalInstance {
   return {
@@ -319,11 +320,8 @@ describe("DockedTerminalItem lifecycle and pop-out (#8160)", () => {
 
     expect(terminalInstanceService.applyRendererPolicy).toHaveBeenCalledWith(
       "t-1",
-      expect.anything()
+      TerminalRefreshTier.VISIBLE
     );
-    const lastCall = vi.mocked(terminalInstanceService.applyRendererPolicy).mock.calls.at(-1);
-    // VISIBLE tier — using anything() for the enum value because the type isn't exported here
-    expect(lastCall?.[0]).toBe("t-1");
   });
 
   it("applies BACKGROUND policy synchronously when mounted closed", () => {
@@ -333,9 +331,30 @@ describe("DockedTerminalItem lifecycle and pop-out (#8160)", () => {
 
     expect(terminalInstanceService.applyRendererPolicy).toHaveBeenCalledWith(
       "t-1",
-      expect.anything()
+      TerminalRefreshTier.BACKGROUND
     );
     expect(rafCallbacks.length).toBe(0);
+  });
+
+  it("cancels the pending RAF and never applies VISIBLE when closed before it fires", () => {
+    mockActiveDockTerminalId = "t-1";
+
+    const { rerender } = render(<DockedTerminalItem terminal={makeTerminal({ id: "t-1" })} />);
+    expect(rafCallbacks.length).toBe(1);
+    expect(rafCallbacks[0]?.cancelled).toBe(false);
+
+    mockActiveDockTerminalId = null;
+    rerender(<DockedTerminalItem terminal={makeTerminal({ id: "t-1" })} />);
+
+    expect(rafCallbacks[0]?.cancelled).toBe(true);
+
+    act(() => {
+      flushRaf();
+    });
+
+    const calls = vi.mocked(terminalInstanceService.applyRendererPolicy).mock.calls;
+    expect(calls.some((c) => c[1] === TerminalRefreshTier.VISIBLE)).toBe(false);
+    expect(calls.some((c) => c[1] === TerminalRefreshTier.BACKGROUND)).toBe(true);
   });
 
   it("renders an 'Open in grid' button that pops the terminal to the grid", () => {


### PR DESCRIPTION
## Summary

- Replaces a 10-pass `requestAnimationFrame` + `setTimeout` retry loop in both `DockedTerminalItem.tsx` and `DockedTabGroup.tsx` with a single RAF scheduled after the portal-target ref settles — the retry loop was polling for work the `ResizeObserver` already handles
- Removes double-counted right-side collision padding; `PopoverContent`'s `collisionBoundary` already excludes the assistant panel via `--right-obstruction-offset`, so the offset was being subtracted twice, snapping the popover further left than the safe area requires
- Adds a hover-revealed pop-out icon (`SquareArrowOutUpRight`) inside both dock popovers that calls `moveTerminalToGrid` and `closeDockTerminal` on success, making the grid affordance discoverable for sighted users without removing the existing double-click accelerator

Resolves #8160

## Changes

- `src/components/Layout/DockedTerminalItem.tsx` — single-RAF mount, dropped collision padding override, pop-out icon
- `src/components/Layout/DockedTabGroup.tsx` — same three changes mirrored
- `src/components/Layout/__tests__/DockedTerminalItem.mountGuard.test.tsx` — new test file
- `src/components/Layout/__tests__/DockedTabGroup.mountGuard.test.tsx` — new test file

## Testing

Tests cover RAF scheduling, `BACKGROUND` renderer tier on close, RAF cancellation when the popover closes before the frame fires, and the pop-out handler. All 680 Layout tests pass; typecheck, lint, and format are clean.