### PR TITLE
feat(dock-tab-popover): polish duplicate icon, hidden-active cue, dropdown marker

### DIFF
--- a/src/components/Layout/DockedTabGroup.tsx
+++ b/src/components/Layout/DockedTabGroup.tsx
@@ -276,6 +276,10 @@ export function DockedTabGroup({ group, panels }: DockedTabGroupProps) {
   const tabIds = useMemo(() => panels.map((p) => p.id), [panels]);
 
   const hiddenTabIds = useTabOverflow(tabListEl, tabIds);
+  const hiddenPanels = useMemo(
+    () => panels.filter((p) => hiddenTabIds.has(p.id)),
+    [panels, hiddenTabIds]
+  );
   const activeTabIsHidden = activeTabId !== "" && hiddenTabIds.has(activeTabId);
 
   // Handle tab reorder drag end
@@ -645,7 +649,7 @@ export function DockedTabGroup({ group, panels }: DockedTabGroupProps) {
                     <TooltipContent side="bottom">Duplicate panel as new tab</TooltipContent>
                   </Tooltip>
                 </div>
-                {hiddenTabIds.size > 0 && (
+                {hiddenPanels.length > 0 && (
                   <DropdownMenu>
                     <Tooltip>
                       <TooltipTrigger asChild>
@@ -656,8 +660,8 @@ export function DockedTabGroup({ group, panels }: DockedTabGroupProps) {
                             className="relative shrink-0 p-1.5 hover:bg-daintree-text/10 text-daintree-text/40 hover:text-daintree-text transition-colors focus-visible:outline focus-visible:outline-2 focus-visible:outline-daintree-accent focus-visible:outline-offset-1"
                             aria-label={
                               activeTabIsHidden
-                                ? "Show hidden tabs, including active"
-                                : "Show hidden tabs"
+                                ? `Show ${hiddenPanels.length} hidden tabs, including active`
+                                : `Show ${hiddenPanels.length} hidden tabs`
                             }
                             aria-haspopup="menu"
                             data-testid="dock-tabs-overflow"
@@ -665,15 +669,10 @@ export function DockedTabGroup({ group, panels }: DockedTabGroupProps) {
                             <ChevronDown className="w-3 h-3" aria-hidden="true" />
                             {activeTabIsHidden && (
                               <span
-                                className="absolute top-1 right-1 w-1.5 h-1.5 rounded-full bg-daintree-text/70"
+                                className="absolute top-0.5 right-0.5 w-1.5 h-1.5 rounded-full bg-daintree-text/70"
                                 aria-hidden="true"
                               />
                             )}
-                            <span className="sr-only">
-                              {" "}
-                              ({hiddenTabIds.size} hidden
-                              {activeTabIsHidden ? ", including active" : ""})
-                            </span>
                           </button>
                         </DropdownMenuTrigger>
                       </TooltipTrigger>
@@ -683,9 +682,7 @@ export function DockedTabGroup({ group, panels }: DockedTabGroupProps) {
                       align="end"
                       className="min-w-[200px] max-w-[320px] max-h-[var(--radix-dropdown-menu-content-available-height)] overflow-y-auto"
                     >
-                      {panels
-                        .filter((p) => hiddenTabIds.has(p.id))
-                        .map((panel) => {
+                      {hiddenPanels.map((panel) => {
                           const tabChrome = deriveTerminalChrome({
                             kind: panel.kind,
                             launchAgentId: panel.launchAgentId,

--- a/src/components/Layout/DockedTabGroup.tsx
+++ b/src/components/Layout/DockedTabGroup.tsx
@@ -14,7 +14,7 @@ import {
 import { SortableContext, horizontalListSortingStrategy, arrayMove } from "@dnd-kit/sortable";
 import { restrictToHorizontalAxis, restrictToParentElement } from "@dnd-kit/modifiers";
 import { LayoutGroup } from "framer-motion";
-import { ChevronDown, Plus } from "lucide-react";
+import { ChevronDown, CopyPlus } from "lucide-react";
 import { Popover, PopoverContent, PopoverTrigger } from "@/components/ui/popover";
 import {
   DropdownMenu,
@@ -276,6 +276,7 @@ export function DockedTabGroup({ group, panels }: DockedTabGroupProps) {
   const tabIds = useMemo(() => panels.map((p) => p.id), [panels]);
 
   const hiddenTabIds = useTabOverflow(tabListEl, tabIds);
+  const activeTabIsHidden = activeTabId !== "" && hiddenTabIds.has(activeTabId);
 
   // Handle tab reorder drag end
   const handleTabDragEnd = useCallback(
@@ -638,7 +639,7 @@ export function DockedTabGroup({ group, panels }: DockedTabGroupProps) {
                         aria-label="Duplicate panel as new tab"
                         type="button"
                       >
-                        <Plus className="w-3 h-3" aria-hidden="true" />
+                        <CopyPlus className="w-3 h-3" aria-hidden="true" />
                       </button>
                     </TooltipTrigger>
                     <TooltipContent side="bottom">Duplicate panel as new tab</TooltipContent>
@@ -652,13 +653,27 @@ export function DockedTabGroup({ group, panels }: DockedTabGroupProps) {
                           <button
                             type="button"
                             onPointerDown={(e) => e.stopPropagation()}
-                            className="shrink-0 p-1.5 hover:bg-daintree-text/10 text-daintree-text/40 hover:text-daintree-text transition-colors focus-visible:outline focus-visible:outline-2 focus-visible:outline-daintree-accent focus-visible:outline-offset-1"
-                            aria-label="Show hidden tabs"
+                            className="relative shrink-0 p-1.5 hover:bg-daintree-text/10 text-daintree-text/40 hover:text-daintree-text transition-colors focus-visible:outline focus-visible:outline-2 focus-visible:outline-daintree-accent focus-visible:outline-offset-1"
+                            aria-label={
+                              activeTabIsHidden
+                                ? "Show hidden tabs, including active"
+                                : "Show hidden tabs"
+                            }
                             aria-haspopup="menu"
                             data-testid="dock-tabs-overflow"
                           >
                             <ChevronDown className="w-3 h-3" aria-hidden="true" />
-                            <span className="sr-only"> ({hiddenTabIds.size} hidden)</span>
+                            {activeTabIsHidden && (
+                              <span
+                                className="absolute top-1 right-1 w-1.5 h-1.5 rounded-full bg-daintree-text/70"
+                                aria-hidden="true"
+                              />
+                            )}
+                            <span className="sr-only">
+                              {" "}
+                              ({hiddenTabIds.size} hidden
+                              {activeTabIsHidden ? ", including active" : ""})
+                            </span>
                           </button>
                         </DropdownMenuTrigger>
                       </TooltipTrigger>
@@ -688,7 +703,10 @@ export function DockedTabGroup({ group, panels }: DockedTabGroupProps) {
                               key={panel.id}
                               onSelect={() => handleTabClick(panel.id)}
                               aria-current={isActive ? "true" : undefined}
-                              className={cn(isActive && "font-medium")}
+                              className={cn(
+                                isActive &&
+                                  "font-medium before:absolute before:left-0 before:top-2 before:bottom-2 before:w-[2px] before:rounded-r before:bg-daintree-accent before:content-['']"
+                              )}
                             >
                               <span className="shrink-0 mr-2 inline-flex items-center justify-center w-3.5 h-3.5">
                                 <TerminalIcon

--- a/src/components/Layout/DockedTabGroup.tsx
+++ b/src/components/Layout/DockedTabGroup.tsx
@@ -683,39 +683,39 @@ export function DockedTabGroup({ group, panels }: DockedTabGroupProps) {
                       className="min-w-[200px] max-w-[320px] max-h-[var(--radix-dropdown-menu-content-available-height)] overflow-y-auto"
                     >
                       {hiddenPanels.map((panel) => {
-                          const tabChrome = deriveTerminalChrome({
-                            kind: panel.kind,
-                            launchAgentId: panel.launchAgentId,
-                            runtimeIdentity: panel.runtimeIdentity,
-                            detectedAgentId: panel.detectedAgentId,
-                            detectedProcessId: panel.detectedProcessId,
-                            agentState: panel.agentState,
-                            runtimeStatus: panel.runtimeStatus,
-                            exitCode: panel.exitCode,
-                            presetColor: panelPresetColors.get(panel.id),
-                          });
-                          const isActive = panel.id === activeTabId;
-                          return (
-                            <DropdownMenuItem
-                              key={panel.id}
-                              onSelect={() => handleTabClick(panel.id)}
-                              aria-current={isActive ? "true" : undefined}
-                              className={cn(
-                                isActive &&
-                                  "font-medium before:absolute before:left-0 before:top-2 before:bottom-2 before:w-[2px] before:rounded-r before:bg-daintree-accent before:content-['']"
-                              )}
-                            >
-                              <span className="shrink-0 mr-2 inline-flex items-center justify-center w-3.5 h-3.5">
-                                <TerminalIcon
-                                  kind={panel.kind ?? "terminal"}
-                                  chrome={tabChrome}
-                                  className="w-3.5 h-3.5"
-                                />
-                              </span>
-                              <span className="truncate">{getBaseTitle(panel.title)}</span>
-                            </DropdownMenuItem>
-                          );
-                        })}
+                        const tabChrome = deriveTerminalChrome({
+                          kind: panel.kind,
+                          launchAgentId: panel.launchAgentId,
+                          runtimeIdentity: panel.runtimeIdentity,
+                          detectedAgentId: panel.detectedAgentId,
+                          detectedProcessId: panel.detectedProcessId,
+                          agentState: panel.agentState,
+                          runtimeStatus: panel.runtimeStatus,
+                          exitCode: panel.exitCode,
+                          presetColor: panelPresetColors.get(panel.id),
+                        });
+                        const isActive = panel.id === activeTabId;
+                        return (
+                          <DropdownMenuItem
+                            key={panel.id}
+                            onSelect={() => handleTabClick(panel.id)}
+                            aria-current={isActive ? "true" : undefined}
+                            className={cn(
+                              isActive &&
+                                "font-medium before:absolute before:left-0 before:top-2 before:bottom-2 before:w-[2px] before:rounded-r before:bg-daintree-accent before:content-['']"
+                            )}
+                          >
+                            <span className="shrink-0 mr-2 inline-flex items-center justify-center w-3.5 h-3.5">
+                              <TerminalIcon
+                                kind={panel.kind ?? "terminal"}
+                                chrome={tabChrome}
+                                className="w-3.5 h-3.5"
+                              />
+                            </span>
+                            <span className="truncate">{getBaseTitle(panel.title)}</span>
+                          </DropdownMenuItem>
+                        );
+                      })}
                     </DropdownMenuContent>
                   </DropdownMenu>
                 )}

--- a/src/components/Layout/__tests__/DockedTabGroup.polish.test.tsx
+++ b/src/components/Layout/__tests__/DockedTabGroup.polish.test.tsx
@@ -302,7 +302,7 @@ describe("DockedTabGroup dock-popover polish (#8164)", () => {
   });
 
   describe("overflow chevron hidden-active cue (item 2)", () => {
-    it("renders no dot and reads only the count when the active tab is visible", () => {
+    it("folds the count into aria-label and renders no dot when the active tab is visible", () => {
       mockHiddenTabIds = new Set<string>(["t-3"]);
       const panels = [
         makePanel({ id: "t-1" }),
@@ -318,8 +318,10 @@ describe("DockedTabGroup dock-popover polish (#8164)", () => {
         '[data-testid="dock-tabs-overflow"]'
       ) as HTMLElement | null;
       expect(overflowButton).not.toBeNull();
-      expect(overflowButton!.getAttribute("aria-label")).toBe("Show hidden tabs");
-      expect(overflowButton!.textContent ?? "").toContain("(1 hidden)");
+      // aria-label carries the count directly — the inner sr-only span would be
+      // shadowed by aria-label per the accessible-name algorithm, so the count
+      // lives in the label itself.
+      expect(overflowButton!.getAttribute("aria-label")).toBe("Show 1 hidden tabs");
       expect(overflowButton!.querySelector("span.bg-daintree-text\\/70")).toBeNull();
     });
 
@@ -342,9 +344,8 @@ describe("DockedTabGroup dock-popover polish (#8164)", () => {
       ) as HTMLElement | null;
       expect(overflowButton).not.toBeNull();
       expect(overflowButton!.getAttribute("aria-label")).toBe(
-        "Show hidden tabs, including active"
+        "Show 2 hidden tabs, including active"
       );
-      expect(overflowButton!.textContent ?? "").toContain("(2 hidden, including active)");
 
       const dot = overflowButton!.querySelector("span.bg-daintree-text\\/70");
       expect(dot).not.toBeNull();

--- a/src/components/Layout/__tests__/DockedTabGroup.polish.test.tsx
+++ b/src/components/Layout/__tests__/DockedTabGroup.polish.test.tsx
@@ -1,0 +1,393 @@
+// @vitest-environment jsdom
+/**
+ * DockedTabGroup — dock-popover polish (#8164).
+ *
+ * Covers three small UI/a11y polish items on the dock tab strip:
+ *   1. Duplicate-tab button uses the CopyPlus icon (not the generic Plus).
+ *   2. When the active tab has scrolled into the overflow set, the chevron
+ *      surfaces a neutral dot and the sr-only/aria-label text discloses it.
+ *   3. The active row in the overflow dropdown carries a leading accent bar.
+ */
+import { describe, it, expect, vi, beforeEach, afterEach } from "vitest";
+import { render } from "@testing-library/react";
+import { useEffect } from "react";
+import type { TerminalInstance } from "@/store";
+import type { TabGroup } from "@/types";
+
+const trashPanelMock = vi.fn();
+const setActiveTabMock = vi.fn();
+const setFocusedMock = vi.fn();
+const openDockTerminalMock = vi.fn();
+const closeDockTerminalMock = vi.fn();
+const moveTerminalToGridMock = vi.fn();
+const updateTitleMock = vi.fn();
+const reorderPanelsInGroupMock = vi.fn();
+const addPanelMock = vi.fn();
+const addPanelToGroupMock = vi.fn();
+
+let mockActiveDockTerminalId: string | null = null;
+let mockTabGroups = new Map<string, TabGroup>();
+let mockHiddenTabIds = new Set<string>();
+
+vi.mock("@/store", () => ({
+  usePanelStore: (selector: (s: Record<string, unknown>) => unknown) =>
+    selector({
+      activeDockTerminalId: mockActiveDockTerminalId,
+      openDockTerminal: openDockTerminalMock,
+      closeDockTerminal: closeDockTerminalMock,
+      moveTerminalToGrid: moveTerminalToGridMock,
+      backendStatus: "connected",
+      setActiveTab: setActiveTabMock,
+      setFocused: setFocusedMock,
+      trashPanel: trashPanelMock,
+      updateTitle: updateTitleMock,
+      reorderPanelsInGroup: reorderPanelsInGroupMock,
+      addPanel: addPanelMock,
+      addPanelToGroup: addPanelToGroupMock,
+      tabGroups: mockTabGroups,
+    }),
+  useTerminalInputStore: (
+    selector: (s: { hybridInputEnabled: boolean; hybridInputAutoFocus: boolean }) => unknown
+  ) => selector({ hybridInputEnabled: false, hybridInputAutoFocus: false }),
+  usePortalStore: (selector: (s: { isOpen: boolean; width: number }) => unknown) =>
+    selector({ isOpen: false, width: 0 }),
+  useFocusStore: (
+    selector: (s: { isFocusMode: boolean; gestureSidebarHidden: boolean }) => unknown
+  ) => selector({ isFocusMode: false, gestureSidebarHidden: false }),
+  usePreferencesStore: (selector: (s: { showDockAgentHighlights: boolean }) => unknown) =>
+    selector({ showDockAgentHighlights: false }),
+}));
+
+vi.mock("@/hooks", () => ({
+  useTabOverflow: () => mockHiddenTabIds,
+}));
+
+vi.mock("@/store/agentSettingsStore", () => ({
+  useAgentSettingsStore: (selector: (s: { settings: null }) => unknown) =>
+    selector({ settings: null }),
+}));
+
+vi.mock("@/store/ccrPresetsStore", () => ({
+  useCcrPresetsStore: (selector: (s: { ccrPresetsByAgent: Record<string, unknown> }) => unknown) =>
+    selector({ ccrPresetsByAgent: {} }),
+}));
+
+vi.mock("@/store/projectPresetsStore", () => ({
+  useProjectPresetsStore: (selector: (s: { presetsByAgent: Record<string, unknown> }) => unknown) =>
+    selector({ presetsByAgent: {} }),
+}));
+
+vi.mock("@/config/agents", () => ({
+  getMergedPresets: () => [],
+}));
+
+vi.mock("@/services/terminal/panelDuplicationService", () => ({
+  buildPanelDuplicateOptions: vi.fn(),
+}));
+
+vi.mock("@/services/TerminalInstanceService", () => ({
+  terminalInstanceService: {
+    fit: () => ({ cols: 80, rows: 24 }),
+    applyRendererPolicy: vi.fn(),
+    focus: vi.fn(),
+  },
+}));
+
+vi.mock("../DockPanelOffscreenContainer", () => ({
+  useDockPanelPortal: () => vi.fn(),
+}));
+
+vi.mock("../useDockBlockedState", () => ({
+  useDockBlockedState: () => null,
+  getDockDisplayAgentState: () => undefined,
+  getGroupBlockedAgentState: () => null,
+  isGroupDeprioritized: () => false,
+}));
+
+vi.mock("../dockPopoverGuard", () => ({
+  handleDockInteractOutside: vi.fn(),
+  handleDockEscapeKeyDown: vi.fn(),
+}));
+
+vi.mock("@/utils/terminalChrome", () => ({
+  deriveTerminalChrome: () => ({ isAgent: false, color: "#abc" }),
+}));
+
+vi.mock("@/utils/logger", () => ({
+  logError: vi.fn(),
+}));
+
+vi.mock("@/components/Worktree/terminalStateConfig", () => ({
+  getEffectiveStateIcon: () => null,
+  getEffectiveStateColor: () => "",
+}));
+
+vi.mock("@/components/Terminal/TerminalContextMenu", () => ({
+  TerminalContextMenu: ({ children }: { children: React.ReactNode }) => <>{children}</>,
+}));
+
+vi.mock("@/components/Terminal/TerminalIcon", () => ({
+  TerminalIcon: () => <span data-testid="terminal-icon" />,
+}));
+
+vi.mock("@/components/Terminal/terminalFocus", () => ({
+  getTerminalFocusTarget: () => "terminal",
+}));
+
+// Same mount-time guard simulation as DockedTabGroup.mountGuard.test.tsx; not the
+// subject under test here but required for the component to mount cleanly.
+vi.mock("@/components/ui/popover", () => ({
+  Popover: ({
+    children,
+    open,
+    onOpenChange,
+  }: {
+    children: React.ReactNode;
+    open?: boolean;
+    onOpenChange?: (open: boolean) => void;
+  }) => {
+    useEffect(() => {
+      if (open && onOpenChange) {
+        onOpenChange(false);
+      }
+      // eslint-disable-next-line react-hooks/exhaustive-deps
+    }, []);
+    return <>{children}</>;
+  },
+  PopoverTrigger: ({ children }: { children: React.ReactNode }) => <>{children}</>,
+  PopoverContent: ({ children }: { children: React.ReactNode }) => <div>{children}</div>,
+}));
+
+vi.mock("@/components/ui/tooltip", () => ({
+  Tooltip: ({ children }: { children: React.ReactNode }) => <>{children}</>,
+  TooltipTrigger: ({ children }: { children: React.ReactNode }) => <>{children}</>,
+  TooltipContent: ({ children }: { children: React.ReactNode }) => <>{children}</>,
+}));
+
+vi.mock("@/components/Panel/SortableTabButton", () => ({
+  SortableTabButton: ({
+    id,
+    isActive,
+    onClick,
+  }: {
+    id: string;
+    isActive?: boolean;
+    onClick?: () => void;
+  }) => (
+    <button
+      data-testid={`tab-${id}`}
+      data-tab-id={id}
+      role="tab"
+      aria-selected={!!isActive}
+      tabIndex={isActive ? 0 : -1}
+      onClick={onClick}
+    >
+      {id}
+    </button>
+  ),
+}));
+
+// Forward className on DropdownMenuItem so we can assert the active-row marker.
+vi.mock("@/components/ui/dropdown-menu", () => ({
+  DropdownMenu: ({ children }: { children: React.ReactNode }) => <>{children}</>,
+  DropdownMenuTrigger: ({ children }: { children: React.ReactNode }) => <>{children}</>,
+  DropdownMenuContent: ({ children }: { children: React.ReactNode }) => <div>{children}</div>,
+  DropdownMenuItem: ({
+    children,
+    className,
+    onSelect,
+    ...rest
+  }: {
+    children: React.ReactNode;
+    className?: string;
+    onSelect?: () => void;
+  } & React.ButtonHTMLAttributes<HTMLButtonElement>) => (
+    <button className={className} onClick={onSelect} {...rest}>
+      {children}
+    </button>
+  ),
+}));
+
+vi.mock("@dnd-kit/core", () => ({
+  DndContext: ({ children }: { children: React.ReactNode }) => <>{children}</>,
+  useDndMonitor: vi.fn(),
+  closestCenter: vi.fn(),
+  useSensor: vi.fn(() => ({})),
+  useSensors: vi.fn(() => []),
+  PointerSensor: class {},
+  TouchSensor: class {},
+}));
+
+vi.mock("@dnd-kit/sortable", () => ({
+  SortableContext: ({ children }: { children: React.ReactNode }) => <>{children}</>,
+  horizontalListSortingStrategy: vi.fn(),
+  arrayMove: <T,>(arr: T[]) => arr,
+}));
+
+vi.mock("@dnd-kit/modifiers", () => ({
+  restrictToHorizontalAxis: vi.fn(),
+  restrictToParentElement: vi.fn(),
+}));
+
+vi.mock("framer-motion", () => ({
+  LayoutGroup: ({ children }: { children: React.ReactNode }) => <>{children}</>,
+  LazyMotion: ({ children }: { children: React.ReactNode }) => <>{children}</>,
+  domMax: {},
+}));
+
+vi.mock("@/components/ui/ConfirmDialog", () => ({
+  ConfirmDialog: () => null,
+}));
+
+import { DockedTabGroup } from "../DockedTabGroup";
+
+function makePanel(overrides: Partial<TerminalInstance> = {}): TerminalInstance {
+  return {
+    id: "t-1",
+    title: "Terminal",
+    location: "dock",
+    kind: "terminal",
+    ...overrides,
+  } as TerminalInstance;
+}
+
+function makeGroup(panelIds: string[], activeTabId = panelIds[0]!): TabGroup {
+  return {
+    id: "g-1",
+    location: "dock",
+    worktreeId: "wt-1",
+    activeTabId,
+    panelIds,
+  };
+}
+
+describe("DockedTabGroup dock-popover polish (#8164)", () => {
+  beforeEach(() => {
+    vi.useFakeTimers();
+    trashPanelMock.mockClear();
+    setActiveTabMock.mockClear();
+    setFocusedMock.mockClear();
+    openDockTerminalMock.mockClear();
+    closeDockTerminalMock.mockClear();
+    moveTerminalToGridMock.mockClear();
+    mockActiveDockTerminalId = "t-1";
+    mockTabGroups = new Map();
+    mockTabGroups.set("g-1", makeGroup(["t-1", "t-2", "t-3"]));
+    mockHiddenTabIds = new Set<string>();
+  });
+
+  afterEach(() => {
+    vi.useRealTimers();
+  });
+
+  describe("duplicate-tab button icon (item 1)", () => {
+    it("renders the CopyPlus glyph, not the generic Plus", () => {
+      const panels = [makePanel({ id: "t-1" }), makePanel({ id: "t-2" })];
+      const { container } = render(
+        <DockedTabGroup group={makeGroup(["t-1", "t-2"], "t-1")} panels={panels} />
+      );
+
+      const addTabButton = container.querySelector(
+        '[aria-label="Duplicate panel as new tab"]'
+      ) as HTMLElement | null;
+      expect(addTabButton).not.toBeNull();
+
+      // CopyPlus is a stacked-rectangle glyph (two <rect> elements), Plus is two
+      // single <path>s with no rect. This catches an accidental regression to
+      // the generic add-tab icon without coupling to internal SVG ids.
+      const svg = addTabButton!.querySelector("svg");
+      expect(svg).not.toBeNull();
+      expect(svg!.querySelectorAll("rect").length).toBeGreaterThan(0);
+    });
+  });
+
+  describe("overflow chevron hidden-active cue (item 2)", () => {
+    it("renders no dot and reads only the count when the active tab is visible", () => {
+      mockHiddenTabIds = new Set<string>(["t-3"]);
+      const panels = [
+        makePanel({ id: "t-1" }),
+        makePanel({ id: "t-2" }),
+        makePanel({ id: "t-3" }),
+      ];
+
+      const { container } = render(
+        <DockedTabGroup group={makeGroup(["t-1", "t-2", "t-3"], "t-1")} panels={panels} />
+      );
+
+      const overflowButton = container.querySelector(
+        '[data-testid="dock-tabs-overflow"]'
+      ) as HTMLElement | null;
+      expect(overflowButton).not.toBeNull();
+      expect(overflowButton!.getAttribute("aria-label")).toBe("Show hidden tabs");
+      expect(overflowButton!.textContent ?? "").toContain("(1 hidden)");
+      expect(overflowButton!.querySelector("span.bg-daintree-text\\/70")).toBeNull();
+    });
+
+    it("renders the neutral dot and discloses 'including active' when the active tab is hidden", () => {
+      mockHiddenTabIds = new Set<string>(["t-1", "t-3"]);
+      mockActiveDockTerminalId = "t-1";
+      mockTabGroups.set("g-1", makeGroup(["t-1", "t-2", "t-3"], "t-1"));
+      const panels = [
+        makePanel({ id: "t-1" }),
+        makePanel({ id: "t-2" }),
+        makePanel({ id: "t-3" }),
+      ];
+
+      const { container } = render(
+        <DockedTabGroup group={makeGroup(["t-1", "t-2", "t-3"], "t-1")} panels={panels} />
+      );
+
+      const overflowButton = container.querySelector(
+        '[data-testid="dock-tabs-overflow"]'
+      ) as HTMLElement | null;
+      expect(overflowButton).not.toBeNull();
+      expect(overflowButton!.getAttribute("aria-label")).toBe(
+        "Show hidden tabs, including active"
+      );
+      expect(overflowButton!.textContent ?? "").toContain("(2 hidden, including active)");
+
+      const dot = overflowButton!.querySelector("span.bg-daintree-text\\/70");
+      expect(dot).not.toBeNull();
+      expect(dot!.className).toContain("rounded-full");
+      // Accent restraint: the neutral cue must NOT use any accent token.
+      expect(dot!.className).not.toContain("daintree-accent");
+    });
+  });
+
+  describe("overflow dropdown active marker (item 3)", () => {
+    it("marks the active row with the leading accent bar and inactive rows without it", () => {
+      mockHiddenTabIds = new Set<string>(["t-2", "t-3"]);
+      mockActiveDockTerminalId = "t-2";
+      mockTabGroups.set("g-1", makeGroup(["t-1", "t-2", "t-3"], "t-2"));
+      const panels = [
+        makePanel({ id: "t-1", title: "Visible" }),
+        makePanel({ id: "t-2", title: "Active hidden" }),
+        makePanel({ id: "t-3", title: "Inactive hidden" }),
+      ];
+
+      const { container } = render(
+        <DockedTabGroup group={makeGroup(["t-1", "t-2", "t-3"], "t-2")} panels={panels} />
+      );
+
+      const rows = Array.from(
+        container.querySelectorAll<HTMLButtonElement>("[aria-current]")
+      );
+      expect(rows.length).toBe(1);
+      const activeRow = rows[0]!;
+      expect(activeRow.getAttribute("aria-current")).toBe("true");
+      expect(activeRow.className).toContain("font-medium");
+      expect(activeRow.className).toContain("before:w-[2px]");
+      expect(activeRow.className).toContain("before:bg-daintree-accent");
+
+      // The non-active hidden row must NOT carry the active marker.
+      const allRows = Array.from(
+        container.querySelectorAll<HTMLButtonElement>("button")
+      ).filter((b) => b !== activeRow && b.textContent?.includes("Inactive hidden"));
+      expect(allRows.length).toBeGreaterThan(0);
+      for (const row of allRows) {
+        expect(row.className).not.toContain("before:bg-daintree-accent");
+        expect(row.className).not.toContain("font-medium");
+      }
+    });
+  });
+});

--- a/src/components/Layout/__tests__/DockedTabGroup.polish.test.tsx
+++ b/src/components/Layout/__tests__/DockedTabGroup.polish.test.tsx
@@ -304,11 +304,7 @@ describe("DockedTabGroup dock-popover polish (#8164)", () => {
   describe("overflow chevron hidden-active cue (item 2)", () => {
     it("folds the count into aria-label and renders no dot when the active tab is visible", () => {
       mockHiddenTabIds = new Set<string>(["t-3"]);
-      const panels = [
-        makePanel({ id: "t-1" }),
-        makePanel({ id: "t-2" }),
-        makePanel({ id: "t-3" }),
-      ];
+      const panels = [makePanel({ id: "t-1" }), makePanel({ id: "t-2" }), makePanel({ id: "t-3" })];
 
       const { container } = render(
         <DockedTabGroup group={makeGroup(["t-1", "t-2", "t-3"], "t-1")} panels={panels} />
@@ -329,11 +325,7 @@ describe("DockedTabGroup dock-popover polish (#8164)", () => {
       mockHiddenTabIds = new Set<string>(["t-1", "t-3"]);
       mockActiveDockTerminalId = "t-1";
       mockTabGroups.set("g-1", makeGroup(["t-1", "t-2", "t-3"], "t-1"));
-      const panels = [
-        makePanel({ id: "t-1" }),
-        makePanel({ id: "t-2" }),
-        makePanel({ id: "t-3" }),
-      ];
+      const panels = [makePanel({ id: "t-1" }), makePanel({ id: "t-2" }), makePanel({ id: "t-3" })];
 
       const { container } = render(
         <DockedTabGroup group={makeGroup(["t-1", "t-2", "t-3"], "t-1")} panels={panels} />
@@ -370,9 +362,7 @@ describe("DockedTabGroup dock-popover polish (#8164)", () => {
         <DockedTabGroup group={makeGroup(["t-1", "t-2", "t-3"], "t-2")} panels={panels} />
       );
 
-      const rows = Array.from(
-        container.querySelectorAll<HTMLButtonElement>("[aria-current]")
-      );
+      const rows = Array.from(container.querySelectorAll<HTMLButtonElement>("[aria-current]"));
       expect(rows.length).toBe(1);
       const activeRow = rows[0]!;
       expect(activeRow.getAttribute("aria-current")).toBe("true");
@@ -381,9 +371,9 @@ describe("DockedTabGroup dock-popover polish (#8164)", () => {
       expect(activeRow.className).toContain("before:bg-daintree-accent");
 
       // The non-active hidden row must NOT carry the active marker.
-      const allRows = Array.from(
-        container.querySelectorAll<HTMLButtonElement>("button")
-      ).filter((b) => b !== activeRow && b.textContent?.includes("Inactive hidden"));
+      const allRows = Array.from(container.querySelectorAll<HTMLButtonElement>("button")).filter(
+        (b) => b !== activeRow && b.textContent?.includes("Inactive hidden")
+      );
       expect(allRows.length).toBeGreaterThan(0);
       for (const row of allRows) {
         expect(row.className).not.toContain("before:bg-daintree-accent");


### PR DESCRIPTION
## Summary

Three small polish fixes to the dock tab popover tab strip in `DockedTabGroup.tsx`.

Resolves #8164

## Changes

**Duplicate-tab button icon** — swaps `Plus` for `CopyPlus` to match the existing convention in `TerminalContextMenu.tsx` and `PanelHeader.tsx`. `Plus` at the end of a tab strip reads as "new blank tab"; `CopyPlus` is unambiguous.

**Hidden-active cue on overflow chevron** — when the active tab scrolls into the hidden set, a neutral dot (`bg-daintree-text/70`) appears in the button corner. The `aria-label` now folds in the hidden count plus "including active" so screen readers get the full picture. The previous `sr-only` span was shadowed by the `aria-label` per the accessible-name algorithm, so it was delivering nothing.

**Active-row marker in overflow dropdown** — the active row gets a 2px leading accent bar (`before:bg-daintree-accent`) alongside the existing `font-medium`. Went with the `DropdownMenuItem`-with-bar path over a `RadioGroup` refactor because the `pl-8` `ItemIndicator` slot collides with the existing `TerminalIcon` on each row. Accent is justified here as the single load-bearing signal in the dropdown.

## Testing

New `src/components/Layout/__tests__/DockedTabGroup.polish.test.tsx` — 4 tests across 3 describes: `CopyPlus` glyph, visible vs hidden-active chevron variants, active-row marker presence and non-active rows clean. All 16 tests pass (polish + existing mount guard).