### PR TITLE
feat(toolbar): render plugin buttons as hideable rows in settings

### DIFF
--- a/electron/ipc/handlers/events.ts
+++ b/electron/ipc/handlers/events.ts
@@ -54,6 +54,7 @@ const EVENT_BUS_BRIDGED_MANIFEST = {
   "sound:cancel": "external",
   "plugin:actions-changed": "external",
   "plugin:panel-kinds-changed": "external",
+  "plugin:toolbar-buttons-changed": "external",
   "terminal:exit": "external",
   "terminal:spawn-result": "external",
 } as const satisfies Record<keyof IpcEventBusMap, "bus" | "external">;

--- a/electron/preload.cts
+++ b/electron/preload.cts
@@ -100,6 +100,7 @@ import type { ShowContextMenuPayload } from "../shared/types/menu.js";
 import type { ResourceProfilePayload } from "../shared/types/resourceProfile.js";
 import type { PluginActionDescriptor } from "../shared/types/plugin.js";
 import type { PanelKindConfig } from "../shared/config/panelKindRegistry.js";
+import type { ToolbarButtonConfig } from "../shared/config/toolbarButtonRegistry.js";
 
 export type { ElectronAPI };
 
@@ -2476,6 +2477,8 @@ const api: ElectronAPI = {
       _eventBusOn("plugin:actions-changed", callback),
     onPanelKindsChanged: (callback: (payload: { kinds: PanelKindConfig[] }) => void) =>
       _eventBusOn("plugin:panel-kinds-changed", callback),
+    onToolbarButtonsChanged: (callback: (payload: { buttons: ToolbarButtonConfig[] }) => void) =>
+      _eventBusOn("plugin:toolbar-buttons-changed", callback),
   },
 
   crashRecovery: {

--- a/electron/preload.cts
+++ b/electron/preload.cts
@@ -2477,8 +2477,9 @@ const api: ElectronAPI = {
       _eventBusOn("plugin:actions-changed", callback),
     onPanelKindsChanged: (callback: (payload: { kinds: PanelKindConfig[] }) => void) =>
       _eventBusOn("plugin:panel-kinds-changed", callback),
-    onToolbarButtonsChanged: (callback: (payload: { buttons: ToolbarButtonConfig[] }) => void) =>
-      _eventBusOn("plugin:toolbar-buttons-changed", callback),
+    onToolbarButtonsChanged: (
+      callback: (payload: { buttons: ToolbarButtonConfig[]; complete: boolean }) => void
+    ) => _eventBusOn("plugin:toolbar-buttons-changed", callback),
   },
 
   crashRecovery: {

--- a/electron/services/PluginService.ts
+++ b/electron/services/PluginService.ts
@@ -27,6 +27,7 @@ import {
 import {
   registerToolbarButton,
   unregisterPluginToolbarButtons,
+  getAllPluginToolbarButtonConfigs,
 } from "../../shared/config/toolbarButtonRegistry.js";
 import { registerPluginMenuItem, unregisterPluginMenuItems } from "./pluginMenuRegistry.js";
 import { registerForgeProviders, unregisterForgeProviders } from "./forgeProviderRegistry.js";
@@ -99,6 +100,13 @@ export class PluginService {
    * snapshot.
    */
   private panelKindsBroadcastPending = false;
+  /**
+   * Same coalescing rationale as {@link panelKindsBroadcastPending}: a plugin
+   * contributing N toolbar buttons calls `registerToolbarButton` N times in
+   * `loadPlugin()`, and `unregisterPluginToolbarButtons` removes them in one
+   * call on unload — batch into a single snapshot broadcast per tick.
+   */
+  private toolbarButtonsBroadcastPending = false;
   private disposed = false;
   private readonly disposeRegistrySubscriptions: () => void;
 
@@ -363,6 +371,9 @@ export class PluginService {
         priority: btn.priority ?? 3,
         pluginId: manifest.name,
       });
+    }
+    if (manifest.contributes.toolbarButtons.length > 0) {
+      this.scheduleToolbarButtonsBroadcast();
     }
 
     for (const menuItem of manifest.contributes.menuItems) {
@@ -681,6 +692,7 @@ export class PluginService {
     this.unregisterPluginActions(pluginId);
     unregisterPluginMenuItems(pluginId);
     unregisterPluginToolbarButtons(pluginId);
+    this.scheduleToolbarButtonsBroadcast();
     unregisterPluginPanelKinds(pluginId);
     unregisterForgeProviders(pluginId);
     this.plugins.delete(pluginId);
@@ -848,6 +860,30 @@ export class PluginService {
     broadcastToRenderer(CHANNELS.EVENTS_PUSH, {
       name: "plugin:panel-kinds-changed",
       payload: { kinds: getPluginPanelKinds() },
+    });
+  }
+
+  /**
+   * Coalesce toolbar-button registry mutations the same way panel kinds are
+   * batched (see {@link schedulePanelKindsBroadcast}). Toolbar buttons are only
+   * ever mutated from `loadPlugin()` / `unloadPlugin()`, so the two call sites
+   * invoke this directly rather than via registry event listeners.
+   */
+  private scheduleToolbarButtonsBroadcast(): void {
+    if (this.disposed) return;
+    if (this.toolbarButtonsBroadcastPending) return;
+    this.toolbarButtonsBroadcastPending = true;
+    queueMicrotask(() => {
+      this.toolbarButtonsBroadcastPending = false;
+      if (this.disposed) return;
+      this.broadcastPluginToolbarButtons();
+    });
+  }
+
+  private broadcastPluginToolbarButtons(): void {
+    broadcastToRenderer(CHANNELS.EVENTS_PUSH, {
+      name: "plugin:toolbar-buttons-changed",
+      payload: { buttons: getAllPluginToolbarButtonConfigs() },
     });
   }
 }

--- a/electron/services/PluginService.ts
+++ b/electron/services/PluginService.ts
@@ -107,6 +107,14 @@ export class PluginService {
    * call on unload — batch into a single snapshot broadcast per tick.
    */
   private toolbarButtonsBroadcastPending = false;
+  /**
+   * OR-accumulated across triggers coalesced into one tick: true if any was an
+   * unload (uninstall). The registry at microtask-drain time always reflects
+   * the current set, so a tick that included an unload is an authoritative
+   * snapshot the renderer may safely sweep against; a tick of only loads is a
+   * partial/growing snapshot (concurrent load + deferred init) and must not.
+   */
+  private toolbarButtonsBroadcastComplete = false;
   private disposed = false;
   private readonly disposeRegistrySubscriptions: () => void;
 
@@ -373,7 +381,7 @@ export class PluginService {
       });
     }
     if (manifest.contributes.toolbarButtons.length > 0) {
-      this.scheduleToolbarButtonsBroadcast();
+      this.scheduleToolbarButtonsBroadcast(false);
     }
 
     for (const menuItem of manifest.contributes.menuItems) {
@@ -692,7 +700,7 @@ export class PluginService {
     this.unregisterPluginActions(pluginId);
     unregisterPluginMenuItems(pluginId);
     unregisterPluginToolbarButtons(pluginId);
-    this.scheduleToolbarButtonsBroadcast();
+    this.scheduleToolbarButtonsBroadcast(true);
     unregisterPluginPanelKinds(pluginId);
     unregisterForgeProviders(pluginId);
     this.plugins.delete(pluginId);
@@ -869,21 +877,24 @@ export class PluginService {
    * ever mutated from `loadPlugin()` / `unloadPlugin()`, so the two call sites
    * invoke this directly rather than via registry event listeners.
    */
-  private scheduleToolbarButtonsBroadcast(): void {
+  private scheduleToolbarButtonsBroadcast(complete: boolean): void {
     if (this.disposed) return;
+    if (complete) this.toolbarButtonsBroadcastComplete = true;
     if (this.toolbarButtonsBroadcastPending) return;
     this.toolbarButtonsBroadcastPending = true;
     queueMicrotask(() => {
       this.toolbarButtonsBroadcastPending = false;
+      const complete = this.toolbarButtonsBroadcastComplete;
+      this.toolbarButtonsBroadcastComplete = false;
       if (this.disposed) return;
-      this.broadcastPluginToolbarButtons();
+      this.broadcastPluginToolbarButtons(complete);
     });
   }
 
-  private broadcastPluginToolbarButtons(): void {
+  private broadcastPluginToolbarButtons(complete: boolean): void {
     broadcastToRenderer(CHANNELS.EVENTS_PUSH, {
       name: "plugin:toolbar-buttons-changed",
-      payload: { buttons: getAllPluginToolbarButtonConfigs() },
+      payload: { buttons: getAllPluginToolbarButtonConfigs(), complete },
     });
   }
 }

--- a/electron/services/__tests__/PluginService.test.ts
+++ b/electron/services/__tests__/PluginService.test.ts
@@ -37,6 +37,7 @@ vi.mock("../../../shared/config/panelKindRegistry.js", () => ({
 vi.mock("../../../shared/config/toolbarButtonRegistry.js", () => ({
   registerToolbarButton: vi.fn(),
   unregisterPluginToolbarButtons: vi.fn(),
+  getAllPluginToolbarButtonConfigs: vi.fn(() => []),
 }));
 vi.mock("../pluginMenuRegistry.js", () => ({
   registerPluginMenuItem: vi.fn(),

--- a/shared/config/toolbarButtonRegistry.ts
+++ b/shared/config/toolbarButtonRegistry.ts
@@ -26,6 +26,10 @@ export function getPluginToolbarButtonIds(): PluginToolbarButtonId[] {
   return Object.keys(TOOLBAR_BUTTON_REGISTRY) as PluginToolbarButtonId[];
 }
 
+export function getAllPluginToolbarButtonConfigs(): ToolbarButtonConfig[] {
+  return Object.values(TOOLBAR_BUTTON_REGISTRY);
+}
+
 export function isRegisteredPluginButton(id: string): boolean {
   return id.startsWith("plugin.") && id in TOOLBAR_BUTTON_REGISTRY;
 }

--- a/shared/types/ipc/api.ts
+++ b/shared/types/ipc/api.ts
@@ -1420,6 +1420,7 @@ export interface ElectronAPI {
     onToolbarButtonsChanged(
       callback: (payload: {
         buttons: import("../../config/toolbarButtonRegistry.js").ToolbarButtonConfig[];
+        complete: boolean;
       }) => void
     ): () => void;
   };

--- a/shared/types/ipc/api.ts
+++ b/shared/types/ipc/api.ts
@@ -1416,6 +1416,12 @@ export interface ElectronAPI {
         kinds: import("../../config/panelKindRegistry.js").PanelKindConfig[];
       }) => void
     ): () => void;
+    /** Subscribe to plugin toolbar button registry changes. Returns a cleanup. */
+    onToolbarButtonsChanged(
+      callback: (payload: {
+        buttons: import("../../config/toolbarButtonRegistry.js").ToolbarButtonConfig[];
+      }) => void
+    ): () => void;
   };
   crashRecovery: {
     getPending(): Promise<import("./crashRecovery.js").PendingCrash | null>;

--- a/shared/types/ipc/maps.ts
+++ b/shared/types/ipc/maps.ts
@@ -2294,9 +2294,15 @@ export interface IpcEventMap {
     kinds: import("../../config/panelKindRegistry.js").PanelKindConfig[];
   };
 
-  // Plugin toolbar button registry events (main → renderer)
+  // Plugin toolbar button registry events (main → renderer).
+  // `complete` is true only for an authoritative snapshot (a plugin unload —
+  // i.e. uninstall — where the registry reflects exactly the currently-loaded
+  // set). Load-time broadcasts are partial/growing because plugins load
+  // concurrently and `initialize()` is deferred, so the renderer must NOT
+  // prune persisted hide preferences off a non-`complete` snapshot.
   "plugin:toolbar-buttons-changed": {
     buttons: import("../../config/toolbarButtonRegistry.js").ToolbarButtonConfig[];
+    complete: boolean;
   };
 
   // Resource profile change (main → renderer)

--- a/shared/types/ipc/maps.ts
+++ b/shared/types/ipc/maps.ts
@@ -2294,6 +2294,11 @@ export interface IpcEventMap {
     kinds: import("../../config/panelKindRegistry.js").PanelKindConfig[];
   };
 
+  // Plugin toolbar button registry events (main → renderer)
+  "plugin:toolbar-buttons-changed": {
+    buttons: import("../../config/toolbarButtonRegistry.js").ToolbarButtonConfig[];
+  };
+
   // Resource profile change (main → renderer)
   "resource:profile-changed": import("../resourceProfile.js").ResourceProfilePayload;
 
@@ -2366,6 +2371,8 @@ export type IpcEventBusMap = Pick<
   | "plugin:actions-changed"
   // Plugin panel kind registry (global broadcast)
   | "plugin:panel-kinds-changed"
+  // Plugin toolbar button registry (global broadcast)
+  | "plugin:toolbar-buttons-changed"
   // Terminal lifecycle (non-data) — exit, spawn-result, backend crash/ready
   | "terminal:exit"
   | "terminal:backend-crashed"

--- a/src/components/Settings/ToolbarSettingsTab.tsx
+++ b/src/components/Settings/ToolbarSettingsTab.tsx
@@ -106,6 +106,46 @@ function SortableButtonItem({
   );
 }
 
+interface PluginButtonRowProps {
+  buttonId: AnyToolbarButtonId;
+  isVisible: boolean;
+  onToggle: (buttonId: AnyToolbarButtonId) => void;
+  metadata: ToolbarButtonMetadata | undefined;
+}
+
+// Plugin buttons are hide-only — they're never persisted into
+// `layout.rightButtons`, so they get no drag handle. Reusing
+// `SortableButtonItem` would call `useSortable` outside a `SortableContext`
+// and crash; this is a plain non-sortable row mirroring its visual structure.
+function PluginButtonRow({ buttonId, isVisible, onToggle, metadata }: PluginButtonRowProps) {
+  if (!metadata) return null;
+  const Icon = metadata.icon;
+
+  return (
+    <div
+      style={{ opacity: isVisible ? 1 : 0.5 }}
+      className="flex items-center gap-3 p-3 rounded-[var(--radius-md)] border border-daintree-border bg-daintree-bg/30"
+    >
+      <div className="flex items-center gap-2 flex-1">
+        <div className="text-daintree-text">
+          <Icon className="h-4 w-4" />
+        </div>
+        <div className="flex-1">
+          <div className="text-sm font-medium text-daintree-text">{metadata.label}</div>
+          <div className="text-xs text-daintree-text/50 select-text">{metadata.description}</div>
+        </div>
+      </div>
+      <input
+        type="checkbox"
+        checked={isVisible}
+        onChange={() => onToggle(buttonId)}
+        aria-label={`Toggle ${metadata.label} visibility`}
+        className="w-4 h-4 rounded border-border-strong bg-daintree-bg text-daintree-accent focus:ring-daintree-accent focus:ring-2"
+      />
+    </div>
+  );
+}
+
 export function ToolbarSettingsTab() {
   const layout = useToolbarPreferencesStore((s) => s.layout);
   const launcher = useToolbarPreferencesStore((s) => s.launcher);
@@ -280,6 +320,35 @@ export function ToolbarSettingsTab() {
           </SortableContext>
         </DndContext>
       </SettingsSection>
+
+      {pluginButtonIds.length > 0 && (
+        <SettingsSection
+          icon={McpServerIcon}
+          title="Plugin buttons"
+          description={`Uncheck to hide. ${pluginButtonIds.filter((id) => isToolbarButtonVisible(id, layout.pinnedButtons, agentSettings, agentAvailability)).length} of ${pluginButtonIds.length} visible.`}
+        >
+          <div className="space-y-2">
+            {pluginButtonIds.map((buttonId) => (
+              <PluginButtonRow
+                key={buttonId}
+                buttonId={buttonId}
+                isVisible={isToolbarButtonVisible(
+                  buttonId,
+                  layout.pinnedButtons,
+                  agentSettings,
+                  agentAvailability
+                )}
+                onToggle={(id) => toggleButtonVisibility(id, "right")}
+                metadata={
+                  (allMetadata as Partial<Record<AnyToolbarButtonId, ToolbarButtonMetadata>>)[
+                    buttonId
+                  ]
+                }
+              />
+            ))}
+          </div>
+        </SettingsSection>
+      )}
 
       <SettingsSection
         icon={Rocket}

--- a/src/hooks/__tests__/usePluginToolbarButtons.test.ts
+++ b/src/hooks/__tests__/usePluginToolbarButtons.test.ts
@@ -1,0 +1,91 @@
+// @vitest-environment jsdom
+import { describe, it, expect, beforeEach, vi } from "vitest";
+import { renderHook, waitFor } from "@testing-library/react";
+import type { ToolbarButtonConfig } from "@shared/config/toolbarButtonRegistry";
+
+const { toolbarButtonsMock, onToolbarButtonsChangedMock, sweepMock } = vi.hoisted(() => ({
+  toolbarButtonsMock: vi.fn(),
+  onToolbarButtonsChangedMock: vi.fn(),
+  sweepMock: vi.fn(),
+}));
+
+vi.mock("@/store", () => ({
+  useToolbarPreferencesStore: {
+    getState: () => ({ sweepStalePluginPinnedButtons: sweepMock }),
+  },
+}));
+
+function pluginButton(id: string): ToolbarButtonConfig {
+  return {
+    id: id as ToolbarButtonConfig["id"],
+    label: "Button",
+    iconId: "star",
+    actionId: "acme.do",
+    priority: 3,
+    pluginId: "acme",
+  };
+}
+
+beforeEach(() => {
+  vi.clearAllMocks();
+  (globalThis as unknown as { window: unknown }).window = Object.assign(globalThis.window ?? {}, {
+    electron: {
+      plugin: {
+        toolbarButtons: toolbarButtonsMock,
+        onToolbarButtonsChanged: onToolbarButtonsChangedMock,
+      },
+    },
+  });
+  vi.resetModules();
+  toolbarButtonsMock.mockResolvedValue([]);
+  onToolbarButtonsChangedMock.mockReturnValue(() => {});
+});
+
+describe("usePluginToolbarButtons", () => {
+  it("exposes plugin buttons from the mount-time pull without sweeping", async () => {
+    toolbarButtonsMock.mockResolvedValue([pluginButton("plugin.acme.foo")]);
+    const { usePluginToolbarButtons } = await import("../usePluginToolbarButtons");
+
+    const { result } = renderHook(() => usePluginToolbarButtons());
+
+    await waitFor(() => {
+      expect(result.current.buttonIds).toContain("plugin.acme.foo");
+    });
+    // Pull is partial under deferred init — must never prune persisted prefs.
+    expect(sweepMock).not.toHaveBeenCalled();
+  });
+
+  it("does not sweep on a partial (complete=false) load push", async () => {
+    let emit: ((p: { buttons: ToolbarButtonConfig[]; complete: boolean }) => void) | null = null;
+    onToolbarButtonsChangedMock.mockImplementation(
+      (cb: (p: { buttons: ToolbarButtonConfig[]; complete: boolean }) => void) => {
+        emit = cb;
+        return () => {};
+      }
+    );
+    const { usePluginToolbarButtons } = await import("../usePluginToolbarButtons");
+    renderHook(() => usePluginToolbarButtons());
+
+    await waitFor(() => expect(emit).not.toBeNull());
+    emit!({ buttons: [pluginButton("plugin.acme.foo")], complete: false });
+
+    expect(sweepMock).not.toHaveBeenCalled();
+  });
+
+  it("sweeps stale pinned buttons on an authoritative (complete=true) push", async () => {
+    let emit: ((p: { buttons: ToolbarButtonConfig[]; complete: boolean }) => void) | null = null;
+    onToolbarButtonsChangedMock.mockImplementation(
+      (cb: (p: { buttons: ToolbarButtonConfig[]; complete: boolean }) => void) => {
+        emit = cb;
+        return () => {};
+      }
+    );
+    const { usePluginToolbarButtons } = await import("../usePluginToolbarButtons");
+    renderHook(() => usePluginToolbarButtons());
+
+    await waitFor(() => expect(emit).not.toBeNull());
+    emit!({ buttons: [pluginButton("plugin.acme.foo")], complete: true });
+
+    expect(sweepMock).toHaveBeenCalledWith(["plugin.acme.foo"]);
+  });
+});

--- a/src/hooks/usePluginToolbarButtons.ts
+++ b/src/hooks/usePluginToolbarButtons.ts
@@ -17,10 +17,13 @@ export interface PluginToolbarButtonState {
  * once a push arrives, a later-resolving mount-time pull is dropped to avoid
  * rolling back state (mirrors `usePluginPanelKinds`).
  *
- * Each accepted snapshot also sweeps stale `plugin.` entries from the
- * `toolbarPreferencesStore` `pinnedButtons` map. That map is renderer-local
- * persisted state with no main-process access, so an uninstalled plugin's
- * leftover hide entry can only be pruned here off the lifecycle snapshot.
+ * Stale `plugin.` entries in the `toolbarPreferencesStore` `pinnedButtons`
+ * map (renderer-local persisted state, no main-process access) are pruned
+ * here off the lifecycle snapshot — but ONLY off an authoritative one. The
+ * pull and load-time pushes are partial/growing (plugins load concurrently
+ * and `initialize()` is deferred), so sweeping against them would wipe a
+ * not-yet-loaded plugin's hide preference. Only a `complete` push (a plugin
+ * unload — i.e. uninstall, the exact case the sweep exists for) is swept.
  */
 export function usePluginToolbarButtons(): PluginToolbarButtonState {
   const [configs, setConfigs] = useState<Map<string, ToolbarButtonConfig>>(new Map());
@@ -29,14 +32,16 @@ export function usePluginToolbarButtons(): PluginToolbarButtonState {
     let disposed = false;
     let pushReceived = false;
 
-    const sync = (buttons: ToolbarButtonConfig[]): void => {
+    const sync = (buttons: ToolbarButtonConfig[], complete: boolean): void => {
       if (disposed) return;
       const map = new Map<string, ToolbarButtonConfig>();
       for (const btn of buttons) {
         map.set(btn.id, btn);
       }
       setConfigs(map);
-      useToolbarPreferencesStore.getState().sweepStalePluginPinnedButtons(Array.from(map.keys()));
+      if (complete) {
+        useToolbarPreferencesStore.getState().sweepStalePluginPinnedButtons(Array.from(map.keys()));
+      }
     };
 
     const electron = typeof window !== "undefined" ? window.electron : undefined;
@@ -47,7 +52,9 @@ export function usePluginToolbarButtons(): PluginToolbarButtonState {
       .then((buttons) => {
         if (disposed) return;
         if (pushReceived) return;
-        sync(buttons);
+        // Pull is a display-only safety net: deferred `initialize()` means it
+        // can resolve before all plugins have registered, so never sweep here.
+        sync(buttons, false);
       })
       .catch((err: unknown) => {
         logWarn("[PluginToolbarButtons] Failed to fetch initial plugin toolbar buttons", {
@@ -57,7 +64,7 @@ export function usePluginToolbarButtons(): PluginToolbarButtonState {
 
     const cleanup = electron.plugin.onToolbarButtonsChanged((payload) => {
       pushReceived = true;
-      sync(payload.buttons);
+      sync(payload.buttons, payload.complete);
     });
 
     return () => {

--- a/src/hooks/usePluginToolbarButtons.ts
+++ b/src/hooks/usePluginToolbarButtons.ts
@@ -1,7 +1,8 @@
 import { useState, useEffect } from "react";
 import type { ToolbarButtonConfig } from "@shared/config/toolbarButtonRegistry";
 import type { PluginToolbarButtonId } from "@shared/types/toolbar";
-import { safeFireAndForget } from "@/utils/safeFireAndForget";
+import { useToolbarPreferencesStore } from "@/store";
+import { logWarn } from "@/utils/logger";
 
 export interface PluginToolbarButtonState {
   buttonIds: PluginToolbarButtonId[];
@@ -9,20 +10,60 @@ export interface PluginToolbarButtonState {
   isRegistered: (id: string) => boolean;
 }
 
+/**
+ * Pull plugin-contributed toolbar buttons on mount and keep them in sync with
+ * main's authoritative set via push. Pull-on-mount is a safety net for cached
+ * `WebContentsView`s that may have missed a broadcast; push is authoritative —
+ * once a push arrives, a later-resolving mount-time pull is dropped to avoid
+ * rolling back state (mirrors `usePluginPanelKinds`).
+ *
+ * Each accepted snapshot also sweeps stale `plugin.` entries from the
+ * `toolbarPreferencesStore` `pinnedButtons` map. That map is renderer-local
+ * persisted state with no main-process access, so an uninstalled plugin's
+ * leftover hide entry can only be pruned here off the lifecycle snapshot.
+ */
 export function usePluginToolbarButtons(): PluginToolbarButtonState {
   const [configs, setConfigs] = useState<Map<string, ToolbarButtonConfig>>(new Map());
 
   useEffect(() => {
-    safeFireAndForget(
-      window.electron.plugin.toolbarButtons().then((buttons) => {
-        const map = new Map<string, ToolbarButtonConfig>();
-        for (const btn of buttons) {
-          map.set(btn.id, btn);
-        }
-        setConfigs(map);
-      }),
-      { context: "Loading plugin toolbar buttons" }
-    );
+    let disposed = false;
+    let pushReceived = false;
+
+    const sync = (buttons: ToolbarButtonConfig[]): void => {
+      if (disposed) return;
+      const map = new Map<string, ToolbarButtonConfig>();
+      for (const btn of buttons) {
+        map.set(btn.id, btn);
+      }
+      setConfigs(map);
+      useToolbarPreferencesStore.getState().sweepStalePluginPinnedButtons(Array.from(map.keys()));
+    };
+
+    const electron = typeof window !== "undefined" ? window.electron : undefined;
+    if (!electron?.plugin) return;
+
+    void electron.plugin
+      .toolbarButtons()
+      .then((buttons) => {
+        if (disposed) return;
+        if (pushReceived) return;
+        sync(buttons);
+      })
+      .catch((err: unknown) => {
+        logWarn("[PluginToolbarButtons] Failed to fetch initial plugin toolbar buttons", {
+          error: err,
+        });
+      });
+
+    const cleanup = electron.plugin.onToolbarButtonsChanged((payload) => {
+      pushReceived = true;
+      sync(payload.buttons);
+    });
+
+    return () => {
+      disposed = true;
+      cleanup();
+    };
   }, []);
 
   const buttonIds = Array.from(configs.keys()) as PluginToolbarButtonId[];

--- a/src/store/__tests__/toolbarPreferencesStore.test.ts
+++ b/src/store/__tests__/toolbarPreferencesStore.test.ts
@@ -1,5 +1,6 @@
 // @vitest-environment jsdom
 import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+import type { AnyToolbarButtonId } from "@/../../shared/types/toolbar";
 
 // Mirror the production agent IDs so the v5 migration is exercised against
 // the real set, not a subset. Keeping the mock in sync guards against
@@ -137,6 +138,53 @@ describe("toolbarPreferencesStore", () => {
 
       store.getState().toggleButtonVisibility("terminal", "left");
       expect(store.getState().layout.pinnedButtons["terminal"]).toBeUndefined();
+    });
+
+    it("does not mutate launcher.defaultSelection when toggling a plugin button", async () => {
+      const store = await loadStore();
+      store.getState().setDefaultSelection("terminal");
+      const before = store.getState().launcher.defaultSelection;
+
+      store.getState().toggleButtonVisibility("plugin.acme.foo" as AnyToolbarButtonId, "right");
+
+      expect(store.getState().launcher.defaultSelection).toBe(before);
+      expect(store.getState().layout.pinnedButtons["plugin.acme.foo"]).toBe(false);
+    });
+  });
+
+  describe("sweepStalePluginPinnedButtons", () => {
+    it("removes plugin entries absent from the valid id set", async () => {
+      const store = await loadStore();
+      store.getState().toggleButtonVisibility("plugin.acme.old" as AnyToolbarButtonId, "right");
+      store.getState().toggleButtonVisibility("plugin.acme.active" as AnyToolbarButtonId, "right");
+
+      store.getState().sweepStalePluginPinnedButtons(["plugin.acme.active"]);
+
+      const { pinnedButtons } = store.getState().layout;
+      expect(pinnedButtons["plugin.acme.old"]).toBeUndefined();
+      expect(pinnedButtons["plugin.acme.active"]).toBe(false);
+    });
+
+    it("never touches built-in (non-plugin) keys", async () => {
+      const store = await loadStore();
+      store.getState().toggleButtonVisibility("copy-tree", "right");
+      store.getState().toggleButtonVisibility("plugin.acme.gone" as AnyToolbarButtonId, "right");
+
+      store.getState().sweepStalePluginPinnedButtons([]);
+
+      const { pinnedButtons } = store.getState().layout;
+      expect(pinnedButtons["copy-tree"]).toBe(false);
+      expect(pinnedButtons["plugin.acme.gone"]).toBeUndefined();
+    });
+
+    it("is a no-op (preserves layout reference) when nothing is stale", async () => {
+      const store = await loadStore();
+      store.getState().toggleButtonVisibility("copy-tree", "right");
+      const layoutBefore = store.getState().layout;
+
+      store.getState().sweepStalePluginPinnedButtons([]);
+
+      expect(store.getState().layout).toBe(layoutBefore);
     });
   });
 

--- a/src/store/toolbarPreferencesStore.ts
+++ b/src/store/toolbarPreferencesStore.ts
@@ -83,6 +83,16 @@ interface ToolbarPreferencesState extends ToolbarPreferences {
     toIndex: number
   ) => void;
   toggleButtonVisibility: (buttonId: AnyToolbarButtonId, side: "left" | "right") => void;
+  /**
+   * Prune `pinnedButtons` entries for plugin buttons (`plugin.` prefix) that
+   * are no longer in the loaded plugin set. `pinnedButtons` is renderer-local
+   * persisted state with no main-process access, so an uninstalled plugin's
+   * stale hide entry can only be swept here, driven by the plugin lifecycle
+   * snapshot in `usePluginToolbarButtons`. Built-in (non-`plugin.`) keys are
+   * never touched. No-ops (returns state unchanged) when nothing is stale so
+   * the per-snapshot call doesn't churn the persist layer.
+   */
+  sweepStalePluginPinnedButtons: (validIds: string[]) => void;
   setAlwaysShowDevServer: (value: boolean) => void;
   setDefaultSelection: (selection: ToolbarPreferences["launcher"]["defaultSelection"]) => void;
   setDefaultAgent: (agent: ToolbarPreferences["launcher"]["defaultAgent"]) => void;
@@ -135,6 +145,21 @@ export const useToolbarPreferencesStore = create<ToolbarPreferencesState>()(
             delete pinned[buttonId];
           } else {
             pinned[buttonId] = false;
+          }
+          return {
+            layout: { ...state.layout, pinnedButtons: pinned },
+          };
+        }),
+      sweepStalePluginPinnedButtons: (validIds) =>
+        set((state) => {
+          const validSet = new Set(validIds);
+          const staleKeys = Object.keys(state.layout.pinnedButtons).filter(
+            (key) => key.startsWith("plugin.") && !validSet.has(key)
+          );
+          if (staleKeys.length === 0) return state;
+          const pinned: ToolbarPinnedState = { ...state.layout.pinnedButtons };
+          for (const key of staleKeys) {
+            delete pinned[key as AnyToolbarButtonId];
           }
           return {
             layout: { ...state.layout, pinnedButtons: pinned },


### PR DESCRIPTION
## Summary

- Plugin-contributed toolbar buttons now appear in `ToolbarSettingsTab` as a non-sortable hideable section with the same checkbox affordance as built-in buttons
- Plugin IDs are never persisted into `layout.rightButtons` — visibility is controlled exclusively through `pinnedButtons`
- Adds a `plugin:toolbar-buttons-changed` push event mirroring `plugin:panel-kinds-changed`, upgrades `usePluginToolbarButtons` to pull+push with a disposed guard, and adds a `sweepStalePluginPinnedButtons` store action that prunes stale `pinnedButtons` entries on authoritative unload snapshots (gated on `complete` to avoid false-sweeping during partial concurrent-load broadcasts)

Resolves #8183

## Changes

- `ToolbarSettingsTab.tsx` — new "Plugin buttons" section rendered below the right-buttons list; non-sortable, checkbox-only
- `usePluginToolbarButtons.ts` — pull+push hybrid; subscribes to `plugin:toolbar-buttons-changed`; disposed guard prevents state updates after unmount
- `toolbarPreferencesStore.ts` — `sweepStalePluginPinnedButtons` action; `complete` flag gates sweep to authoritative unload snapshots only
- `PluginService.ts` — emits `plugin:toolbar-buttons-changed` alongside existing panel-kinds event
- `shared/config/toolbarButtonRegistry.ts`, `shared/types/ipc/api.ts`, `shared/types/ipc/maps.ts` — type and registry plumbing for the new event

## Testing

- Unit tests in `toolbarPreferencesStore.test.ts`: `launcher.defaultSelection` invariant (hidden default still pre-selects in the launcher palette) and `sweepStalePluginPinnedButtons` complete-gating behaviour
- New `usePluginToolbarButtons.test.ts`: pull+push lifecycle, disposed guard, and complete-flag gating