### PR TITLE
fix(toolbar): polish voice-recording indicator

### DIFF
--- a/src/components/Layout/Toolbar.tsx
+++ b/src/components/Layout/Toolbar.tsx
@@ -557,8 +557,11 @@ export function Toolbar({
         isAvailable: true,
       },
       "voice-recording": {
+        // Slot is always available so the right-aligned items keep a stable
+        // footprint when a session starts/stops. The button itself returns
+        // an invisible placeholder when inactive (mirrors DevServerPlaceholder).
         render: () => <VoiceRecordingToolbarButton key="voice-recording" data-toolbar-item="" />,
-        isAvailable: hasActiveVoiceRecording,
+        isAvailable: true,
       },
       "github-stats": {
         render: () =>
@@ -682,7 +685,6 @@ export function Toolbar({
       copyTreeShortcut,
       copyTreeAriaShortcut,
       copyTreeHintHover,
-      hasActiveVoiceRecording,
       currentProject,
       handleCopyTreeClick,
       isCopyingTree,
@@ -750,8 +752,27 @@ export function Toolbar({
     availableRightIds
   );
 
-  const leftOverflowSeverity = useOverflowBadgeSeverity(leftOverflow, errorCount);
-  const rightOverflowSeverity = useOverflowBadgeSeverity(rightOverflow, errorCount);
+  // Voice recording reserves layout via an always-available slot but should
+  // not pollute the overflow badge or dropdown when no session is active —
+  // an inactive placeholder pushed into overflow would otherwise count as a
+  // hidden item and trigger the warning severity in useOverflowBadgeSeverity.
+  const visibleLeftOverflow = useMemo(
+    () =>
+      hasActiveVoiceRecording
+        ? leftOverflow
+        : leftOverflow.filter((id) => id !== "voice-recording"),
+    [leftOverflow, hasActiveVoiceRecording]
+  );
+  const visibleRightOverflow = useMemo(
+    () =>
+      hasActiveVoiceRecording
+        ? rightOverflow
+        : rightOverflow.filter((id) => id !== "voice-recording"),
+    [rightOverflow, hasActiveVoiceRecording]
+  );
+
+  const leftOverflowSeverity = useOverflowBadgeSeverity(visibleLeftOverflow, errorCount);
+  const rightOverflowSeverity = useOverflowBadgeSeverity(visibleRightOverflow, errorCount);
 
   const leftVisibleSet = useMemo(() => new Set<AnyToolbarButtonId>(leftVisible), [leftVisible]);
   const rightVisibleSet = useMemo(() => new Set<AnyToolbarButtonId>(rightVisible), [rightVisible]);
@@ -1045,7 +1066,7 @@ export function Toolbar({
             {renderLeftButtons(effectiveLeftButtons, leftVisibleSet)}
           </div>
           <div className="app-no-drag">
-            {renderOverflowMenu(leftOverflow, "left", leftOverflowSeverity)}
+            {renderOverflowMenu(visibleLeftOverflow, "left", leftOverflowSeverity)}
           </div>
         </div>
 
@@ -1143,7 +1164,7 @@ export function Toolbar({
             {renderButtons(effectiveRightButtons, rightVisibleSet)}
           </div>
           <div className="app-no-drag">
-            {renderOverflowMenu(rightOverflow, "right", rightOverflowSeverity)}
+            {renderOverflowMenu(visibleRightOverflow, "right", rightOverflowSeverity)}
           </div>
 
           <div className={toolbarDividerClass} />

--- a/src/components/Layout/VoiceRecordingToolbarButton.tsx
+++ b/src/components/Layout/VoiceRecordingToolbarButton.tsx
@@ -1,17 +1,44 @@
+import { useEffect, useRef } from "react";
 import { Mic } from "lucide-react";
-import { Spinner } from "@/components/ui/Spinner";
 import { Button } from "@/components/ui/button";
 import { Tooltip, TooltipContent, TooltipTrigger } from "@/components/ui/tooltip";
 import { ShortcutRevealChip } from "@/components/ui/ShortcutRevealChip";
 import { cn } from "@/lib/utils";
 import { useAriaKeyshortcuts, useKeybindingDisplay } from "@/hooks";
+import { useDeferredLoading } from "@/hooks/useDeferredLoading";
+import { UI_DOHERTY_THRESHOLD } from "@/lib/animationUtils";
 import { useVoiceRecordingStore } from "@/store/voiceRecordingStore";
 import { voiceRecordingService } from "@/services/VoiceRecordingService";
+
+// Flywheel — matches VoiceInputButton so the toolbar and panel-header
+// indicators behave identically.
+const IDLE_SPEED = 72; // deg/sec — 1 revolution per 5s
+const ACTIVE_SPEED = 288; // deg/sec — 1 revolution per 1.25s
+const TAU_ATTACK = 0.22;
+const TAU_RELEASE = 0.5;
+const AUDIO_SMOOTH = 0.15;
+const BASE_THICKNESS = 2; // px
 
 function formatDuration(seconds: number): string {
   const minutes = Math.floor(seconds / 60);
   const remainder = seconds % 60;
   return `${minutes}:${remainder.toString().padStart(2, "0")}`;
+}
+
+function VoiceRecordingPlaceholder({
+  "data-toolbar-item": dataToolbarItem,
+}: {
+  "data-toolbar-item"?: string;
+}) {
+  // Reserves the slot footprint so right-aligned toolbar items don't shift
+  // when a session starts/stops. Matches DevServerPlaceholder's pattern.
+  return (
+    <div
+      data-toolbar-item={dataToolbarItem}
+      className="toolbar-icon-button relative mr-0.5 h-9 w-9 opacity-0 pointer-events-none"
+      aria-hidden="true"
+    />
+  );
 }
 
 export function VoiceRecordingToolbarButton({
@@ -26,32 +53,124 @@ export function VoiceRecordingToolbarButton({
   const shortcut = useKeybindingDisplay("voiceInput.toggle");
   const ariaShortcut = useAriaKeyshortcuts("voiceInput.toggle");
 
-  if (
-    !activeTarget ||
-    (status !== "connecting" && status !== "recording" && status !== "finishing")
-  ) {
-    return null;
+  const isConnecting = status === "connecting";
+  const isRecording = status === "recording";
+  const isFinishing = status === "finishing";
+  const isActive = Boolean(activeTarget) && (isConnecting || isRecording || isFinishing);
+
+  // Doherty gate — under 400ms of "connecting" should never paint the orbit;
+  // it would flash before the recording state arrives.
+  const showConnecting = useDeferredLoading(isConnecting, UI_DOHERTY_THRESHOLD);
+  const showOrbit = isRecording || isFinishing || showConnecting;
+
+  // Mutable bridge: audioLevel updates ~60Hz; we read it inside the RAF tick
+  // rather than re-rendering on every change. Pattern lifted from
+  // VoiceInputButton.
+  const audioLevelRef = useRef(0);
+  useEffect(() => {
+    audioLevelRef.current = audioLevel;
+  }, [audioLevel]);
+
+  const wrapperRef = useRef<HTMLDivElement>(null);
+  const ringRef = useRef<HTMLSpanElement>(null);
+  const dotCoreRef = useRef<HTMLSpanElement>(null);
+  const dotHaloRef = useRef<HTMLSpanElement>(null);
+  const trackRef = useRef<HTMLSpanElement>(null);
+  const rafRef = useRef<number>(0);
+
+  useEffect(() => {
+    if (!showOrbit) return;
+
+    let lastTime = performance.now();
+    let angle = 0;
+    let v1 = IDLE_SPEED;
+    let velocity = IDLE_SPEED;
+    let smoothLevel = 0;
+
+    const tick = (now: number) => {
+      const dt = Math.min((now - lastTime) / 1000, 0.1);
+      lastTime = now;
+
+      // Force level to 0 during finishing so the ring decelerates gracefully.
+      const rawLevel = isFinishing ? 0 : audioLevelRef.current;
+      smoothLevel += (rawLevel - smoothLevel) * AUDIO_SMOOTH;
+      const level = Math.pow(smoothLevel, 1.5);
+
+      // Double-smoothed flywheel
+      const targetVelocity = IDLE_SPEED + level * (ACTIVE_SPEED - IDLE_SPEED);
+      const tau = targetVelocity > velocity ? TAU_ATTACK : TAU_RELEASE;
+      const alpha = 1 - Math.exp(-dt / tau);
+      v1 += (targetVelocity - v1) * alpha;
+      velocity += (v1 - velocity) * alpha;
+      angle = (angle + velocity * dt) % 360;
+
+      const opacity = (0.45 + level * 0.55).toFixed(3);
+      const opacityNum = Number(opacity);
+
+      const wrapper = wrapperRef.current;
+      if (wrapper) {
+        wrapper.style.transform = `rotate(${angle}deg) translateZ(0)`;
+      }
+
+      const ring = ringRef.current;
+      if (ring) {
+        ring.style.background = [
+          `conic-gradient(from 0deg,`,
+          `transparent 200deg,`,
+          `rgb(from var(--theme-accent-primary) r g b / ${(opacityNum * 0.05).toFixed(3)}) 248deg,`,
+          `rgb(from var(--theme-accent-primary) r g b / ${(opacityNum * 0.18).toFixed(3)}) 292deg,`,
+          `rgb(from var(--theme-accent-primary) r g b / ${(opacityNum * 0.42).toFixed(3)}) 326deg,`,
+          `rgb(from var(--theme-accent-primary) r g b / ${(opacityNum * 0.82).toFixed(3)}) 348deg,`,
+          `rgb(from var(--theme-accent-primary) r g b / ${opacity}) 355deg,`,
+          `transparent 360deg)`,
+        ].join(" ");
+      }
+
+      const core = dotCoreRef.current;
+      if (core) {
+        core.style.opacity = String(0.82 + level * 0.18);
+      }
+
+      const halo = dotHaloRef.current;
+      if (halo) {
+        const haloAlpha = (0.18 + level * 0.22).toFixed(3);
+        const haloBlur = 6 + level * 6;
+        halo.style.boxShadow = `0 0 ${haloBlur}px rgb(from var(--theme-accent-primary) r g b / ${haloAlpha})`;
+        halo.style.opacity = String(0.5 + level * 0.5);
+      }
+
+      const track = trackRef.current;
+      if (track) {
+        track.style.opacity = String(0.08 + level * 0.04);
+      }
+
+      rafRef.current = requestAnimationFrame(tick);
+    };
+
+    rafRef.current = requestAnimationFrame(tick);
+    return () => cancelAnimationFrame(rafRef.current);
+  }, [showOrbit, isFinishing]);
+
+  if (!isActive || !showOrbit) {
+    return <VoiceRecordingPlaceholder data-toolbar-item={dataToolbarItem} />;
   }
 
-  const isRecording = status === "recording";
-
-  const contextLabel = [activeTarget.projectName, activeTarget.worktreeLabel]
+  const contextLabel = [activeTarget?.projectName, activeTarget?.worktreeLabel]
     .filter(Boolean)
     .join(" / ");
-  const tooltipTitle =
-    status === "connecting"
-      ? "Preparing dictation..."
-      : status === "finishing"
-        ? "Finishing transcription..."
-        : contextLabel
-          ? `Recording: ${contextLabel}`
-          : "Recording in another panel";
+  const tooltipTitle = isConnecting
+    ? "Preparing dictation..."
+    : isFinishing
+      ? "Finishing transcription..."
+      : contextLabel
+        ? `Recording: ${contextLabel}`
+        : "Recording in another panel";
   const tooltipExtra = [
-    status === "recording" ? formatDuration(elapsedSeconds) : null,
+    isRecording ? formatDuration(elapsedSeconds) : null,
     shortcut ? `Press ${shortcut} to stop` : "Click to jump to panel",
   ]
     .filter(Boolean)
-    .join(" \u00B7 ");
+    .join(" · ");
 
   return (
     <Tooltip>
@@ -64,33 +183,71 @@ export function VoiceRecordingToolbarButton({
             void voiceRecordingService.focusActiveTarget();
           }}
           className={cn(
-            "toolbar-icon-button relative mr-0.5",
-            isRecording
-              ? "text-daintree-text hover:text-[var(--toolbar-control-hover-fg,var(--theme-accent-primary))]"
-              : status === "connecting"
-                ? "text-daintree-text/60 hover:text-[var(--toolbar-control-hover-fg,var(--theme-accent-primary))]"
-                : "text-daintree-accent hover:text-daintree-accent"
+            "toolbar-icon-button relative mr-0.5 text-daintree-text",
+            "hover:text-[var(--toolbar-control-hover-fg,var(--theme-accent-primary))]"
           )}
           aria-label={tooltipTitle}
           aria-keyshortcuts={ariaShortcut}
         >
-          {status === "finishing" ? (
-            <Spinner size="md" />
-          ) : (
-            <div className="relative">
-              <Mic className="h-4 w-4" />
-              <span
-                className="absolute -right-0.5 -top-0.5 h-1.5 w-1.5 rounded-full transition-colors"
-                style={{
-                  backgroundColor:
-                    status === "connecting"
-                      ? "rgb(from var(--theme-accent-primary) r g b / 0.4)"
-                      : `rgb(from var(--theme-accent-primary) r g b / ${0.3 + audioLevel * 0.7})`,
-                  transitionDuration: "80ms",
-                }}
-              />
-            </div>
-          )}
+          <Mic className="h-4 w-4" />
+          {/* Orbit overlay — absolute inset on the relative Button. No
+              contain:strict at this scale: the toolbar button is a flex
+              child and clipping the orbit would crop the ring. */}
+          <span
+            ref={trackRef}
+            aria-hidden="true"
+            className="absolute inset-1 rounded-full pointer-events-none"
+            style={{
+              opacity: 0.08,
+              background: `var(--theme-accent-primary)`,
+              mask: `linear-gradient(#fff 0 0) content-box, linear-gradient(#fff 0 0)`,
+              WebkitMask: `linear-gradient(#fff 0 0) content-box, linear-gradient(#fff 0 0)`,
+              maskComposite: "exclude",
+              WebkitMaskComposite: "xor",
+              padding: `${BASE_THICKNESS}px`,
+              transition: "opacity 80ms ease-out",
+            }}
+          />
+          <div
+            ref={wrapperRef}
+            aria-hidden="true"
+            className="absolute inset-1 pointer-events-none"
+            style={{ willChange: "transform" }}
+          >
+            <span
+              ref={ringRef}
+              className="absolute inset-0 rounded-full"
+              style={{
+                padding: `${BASE_THICKNESS}px`,
+                mask: `linear-gradient(#fff 0 0) content-box, linear-gradient(#fff 0 0)`,
+                WebkitMask: `linear-gradient(#fff 0 0) content-box, linear-gradient(#fff 0 0)`,
+                maskComposite: "exclude",
+                WebkitMaskComposite: "xor",
+              }}
+            />
+            <span
+              ref={dotHaloRef}
+              className="absolute rounded-full bg-daintree-accent/30"
+              style={{
+                width: "6px",
+                height: "6px",
+                top: 0,
+                left: "50%",
+                transform: "translate(-50%, -35%)",
+              }}
+            />
+            <span
+              ref={dotCoreRef}
+              className="absolute rounded-full bg-daintree-accent"
+              style={{
+                width: "3.5px",
+                height: "3.5px",
+                top: 0,
+                left: "50%",
+                transform: "translate(-50%, -15%)",
+              }}
+            />
+          </div>
           <ShortcutRevealChip actionId="voiceInput.toggle" />
         </Button>
       </TooltipTrigger>

--- a/src/components/Layout/VoiceRecordingToolbarButton.tsx
+++ b/src/components/Layout/VoiceRecordingToolbarButton.tsx
@@ -25,16 +25,14 @@ function formatDuration(seconds: number): string {
   return `${minutes}:${remainder.toString().padStart(2, "0")}`;
 }
 
-function VoiceRecordingPlaceholder({
-  "data-toolbar-item": dataToolbarItem,
-}: {
-  "data-toolbar-item"?: string;
-}) {
+function VoiceRecordingPlaceholder() {
   // Reserves the slot footprint so right-aligned toolbar items don't shift
   // when a session starts/stops. Matches DevServerPlaceholder's pattern.
+  // No data-toolbar-item — the placeholder is non-interactive and must not
+  // appear in the toolbar's roving tabindex (Toolbar.getToolbarItems filters
+  // by offsetParent, which opacity-0 does NOT null out).
   return (
     <div
-      data-toolbar-item={dataToolbarItem}
       className="toolbar-icon-button relative mr-0.5 h-9 w-9 opacity-0 pointer-events-none"
       aria-hidden="true"
     />
@@ -61,7 +59,11 @@ export function VoiceRecordingToolbarButton({
   // Doherty gate — under 400ms of "connecting" should never paint the orbit;
   // it would flash before the recording state arrives.
   const showConnecting = useDeferredLoading(isConnecting, UI_DOHERTY_THRESHOLD);
-  const showOrbit = isRecording || isFinishing || showConnecting;
+  // Gate the orbit on isActive too — protects against a transient teardown
+  // race where status briefly stays "recording"/"finishing" while
+  // activeTarget has already been cleared, which would otherwise leave the
+  // RAF loop spinning on null refs.
+  const showOrbit = isActive && (isRecording || isFinishing || showConnecting);
 
   // Mutable bridge: audioLevel updates ~60Hz; we read it inside the RAF tick
   // rather than re-rendering on every change. Pattern lifted from
@@ -152,7 +154,7 @@ export function VoiceRecordingToolbarButton({
   }, [showOrbit, isFinishing]);
 
   if (!isActive || !showOrbit) {
-    return <VoiceRecordingPlaceholder data-toolbar-item={dataToolbarItem} />;
+    return <VoiceRecordingPlaceholder />;
   }
 
   const contextLabel = [activeTarget?.projectName, activeTarget?.worktreeLabel]

--- a/src/components/Layout/__tests__/Toolbar.responsive.test.ts
+++ b/src/components/Layout/__tests__/Toolbar.responsive.test.ts
@@ -78,8 +78,8 @@ describe("Toolbar responsive design — issue #4133", () => {
 
   describe("overflow trigger surfaces hidden state — issue #6416", () => {
     it("calls useOverflowBadgeSeverity for both left and right overflow", () => {
-      expect(source).toContain("useOverflowBadgeSeverity(leftOverflow");
-      expect(source).toContain("useOverflowBadgeSeverity(rightOverflow");
+      expect(source).toContain("useOverflowBadgeSeverity(visibleLeftOverflow");
+      expect(source).toContain("useOverflowBadgeSeverity(visibleRightOverflow");
     });
 
     it("passes left and right severities into renderOverflowMenu independently", () => {

--- a/src/components/Layout/__tests__/VoiceRecordingToolbarButton.test.ts
+++ b/src/components/Layout/__tests__/VoiceRecordingToolbarButton.test.ts
@@ -1,0 +1,116 @@
+import { describe, it, expect, beforeEach } from "vitest";
+import fs from "fs/promises";
+import path from "path";
+
+const BUTTON_PATH = path.resolve(__dirname, "../VoiceRecordingToolbarButton.tsx");
+const TOOLBAR_PATH = path.resolve(__dirname, "../Toolbar.tsx");
+
+describe("VoiceRecordingToolbarButton polish — issue #8176", () => {
+  let source: string;
+  let toolbar: string;
+
+  beforeEach(async () => {
+    [source, toolbar] = await Promise.all([
+      fs.readFile(BUTTON_PATH, "utf-8"),
+      fs.readFile(TOOLBAR_PATH, "utf-8"),
+    ]);
+  });
+
+  describe("footprint reservation prevents layout shift", () => {
+    it("the voice-recording toolbar slot is always available so right-aligned items stay stable", () => {
+      // Slot must mount unconditionally — `isAvailable: hasActiveVoiceRecording`
+      // was the cause of the shift when a session started/ended.
+      expect(toolbar).not.toContain("isAvailable: hasActiveVoiceRecording");
+      expect(toolbar).toMatch(/"voice-recording":\s*{[\s\S]*?isAvailable:\s*true/);
+    });
+
+    it("renders an invisible placeholder with the same h-9 w-9 footprint as the active button", () => {
+      expect(source).toContain("VoiceRecordingPlaceholder");
+      expect(source).toMatch(/h-9\s+w-9\s+opacity-0\s+pointer-events-none/);
+      expect(source).toContain('aria-hidden="true"');
+    });
+
+    it("placeholder is returned via early-return so an inactive slot never paints orbit chrome", () => {
+      // The early return must come AFTER hooks (RAF, refs) but BEFORE the
+      // active button JSX, mirroring VoiceInputButton's gating.
+      expect(source).toMatch(/if\s*\(!isActive\s*\|\|\s*!showOrbit\)\s*{/);
+      expect(source).toMatch(/return\s+<VoiceRecordingPlaceholder/);
+    });
+
+    it("toolbar overflow ignores inactive voice-recording so the badge never warns on a placeholder", () => {
+      // Reserving footprint must not pollute the overflow severity — the
+      // dropdown badge would otherwise show warning for a hidden placeholder.
+      expect(toolbar).toContain("visibleLeftOverflow");
+      expect(toolbar).toContain("visibleRightOverflow");
+      expect(toolbar).toMatch(/filter\(\(id\)\s*=>\s*id\s*!==\s*"voice-recording"\)/);
+    });
+  });
+
+  describe("Doherty anti-flicker gate", () => {
+    it("imports useDeferredLoading and UI_DOHERTY_THRESHOLD", () => {
+      expect(source).toContain('from "@/hooks/useDeferredLoading"');
+      expect(source).toContain('from "@/lib/animationUtils"');
+      expect(source).toContain("UI_DOHERTY_THRESHOLD");
+    });
+
+    it("gates the connecting-state orbit reveal behind the 400ms Doherty threshold", () => {
+      // Sub-400ms connections must never paint the orbit ring — the
+      // placeholder stays visible throughout.
+      expect(source).toMatch(/useDeferredLoading\(isConnecting,\s*UI_DOHERTY_THRESHOLD\)/);
+    });
+  });
+
+  describe("RAF-driven orbit ring (off-React animation)", () => {
+    it("uses an audioLevelRef bridge so per-frame audio updates do not trigger React work", () => {
+      expect(source).toContain("audioLevelRef");
+      expect(source).toMatch(
+        /useEffect\(\(\)\s*=>\s*{\s*audioLevelRef\.current\s*=\s*audioLevel;?\s*},\s*\[audioLevel\]\)/
+      );
+    });
+
+    it("drives the ring with requestAnimationFrame and cleans up via cancelAnimationFrame", () => {
+      expect(source).toContain("requestAnimationFrame");
+      expect(source).toContain("cancelAnimationFrame(rafRef.current)");
+    });
+
+    it("RAF effect deps are primitive booleans only — adding object refs would restart on every render", () => {
+      // [showOrbit, isFinishing] both derive from `status` (string from store)
+      // — keeping the dep array primitive-only avoids the off-React perf win
+      // collapsing into per-render RAF teardown/setup.
+      expect(source).toMatch(/},\s*\[showOrbit,\s*isFinishing\]\);/);
+    });
+
+    it("forces level=0 during finishing so the ring decelerates instead of snapping off", () => {
+      expect(source).toMatch(/isFinishing\s*\?\s*0\s*:\s*audioLevelRef\.current/);
+    });
+  });
+
+  describe("unified visual primitive across all active states", () => {
+    it("no longer swaps in a Spinner for the finishing state", () => {
+      // The Spinner-for-finishing path is the visual inconsistency this
+      // polish removes — orbit ring stays visible through finishing.
+      expect(source).not.toContain('from "@/components/ui/Spinner"');
+      expect(source).not.toContain("<Spinner");
+    });
+
+    it("renders a single Mic icon across all states (no per-state icon swap)", () => {
+      // Mic must appear exactly once — the orbit overlays it consistently.
+      const micMatches = source.match(/<Mic\b/g) ?? [];
+      expect(micMatches.length).toBe(1);
+    });
+
+    it("does NOT use contain:strict on the wrapper — clips orbit overflow at toolbar scale", () => {
+      // VoiceInputButton uses contain:strict on a fixed 24×24 box with
+      // inset-0 children. At the toolbar's 36×36 button-shell scale, the
+      // ring uses inset-1 within a relative Button — adding contain:strict
+      // would clip the ring edges.
+      expect(source).not.toContain('contain: "strict"');
+      expect(source).not.toMatch(/contain:\s*['"]strict['"]/);
+    });
+
+    it("uses scoped transition durations — never the broad transition-all", () => {
+      // Motion timing rule: never widen scoped transitions to transition-all.
+      expect(source).not.toContain("transition-all");
+    });
+  });
+});

--- a/src/components/Layout/__tests__/VoiceRecordingToolbarButton.test.ts
+++ b/src/components/Layout/__tests__/VoiceRecordingToolbarButton.test.ts
@@ -30,6 +30,20 @@ describe("VoiceRecordingToolbarButton polish — issue #8176", () => {
       expect(source).toContain('aria-hidden="true"');
     });
 
+    it("placeholder is excluded from the roving tabindex — opacity-0 does NOT null offsetParent", () => {
+      // Toolbar.getToolbarItems filters [data-toolbar-item] by offsetParent;
+      // opacity-0 leaves offsetParent intact, so a placeholder carrying
+      // data-toolbar-item would absorb arrow-key focus while being
+      // aria-hidden + non-interactive. DevServerPlaceholder follows the
+      // same rule — it has no data-toolbar-item either.
+      const placeholderBlock = source.match(/function VoiceRecordingPlaceholder[\s\S]*?\n\}/)?.[0];
+      expect(placeholderBlock).toBeDefined();
+      // Look only at the rendered JSX, not the explanatory comments above it.
+      const placeholderJsx = placeholderBlock!.match(/return\s*\(([\s\S]*?)\);/)?.[1];
+      expect(placeholderJsx).toBeDefined();
+      expect(placeholderJsx!).not.toContain("data-toolbar-item");
+    });
+
     it("placeholder is returned via early-return so an inactive slot never paints orbit chrome", () => {
       // The early return must come AFTER hooks (RAF, refs) but BEFORE the
       // active button JSX, mirroring VoiceInputButton's gating.
@@ -78,6 +92,15 @@ describe("VoiceRecordingToolbarButton polish — issue #8176", () => {
       // — keeping the dep array primitive-only avoids the off-React perf win
       // collapsing into per-render RAF teardown/setup.
       expect(source).toMatch(/},\s*\[showOrbit,\s*isFinishing\]\);/);
+    });
+
+    it("gates showOrbit on isActive so a status race with a cleared activeTarget cannot spin a ghost loop", () => {
+      // Without this gate, a transient (status=recording, activeTarget=null)
+      // state would let the RAF loop run while the placeholder is rendered,
+      // leaving the tick to no-op against null refs every frame.
+      expect(source).toMatch(
+        /const\s+showOrbit\s*=\s*isActive\s*&&\s*\(isRecording\s*\|\|\s*isFinishing\s*\|\|\s*showConnecting\)/
+      );
     });
 
     it("forces level=0 during finishing so the ring decelerates instead of snapping off", () => {


### PR DESCRIPTION
## Summary

- Unifies the visual language across all three states (`connecting`, `recording`, `finishing`) with a single RAF-driven orbit ring, matching the pattern already used in `VoiceInputButton`
- Replaces the per-render audio-level re-render with a ref-based approach that updates outside React's render cycle
- Adds a zero-footprint placeholder so toolbar items no longer shift when the voice slot mounts and unmounts

Resolves #8176

## Changes

- `VoiceRecordingToolbarButton.tsx` — single orbit ring across all states; `audioLevelRef` replaces the subscription-driven state; `useDeferredLoading` gates the `connecting` indicator at the 400ms Doherty threshold to suppress sub-threshold flicker
- `Toolbar.tsx` — always-mounted placeholder reserves the voice slot's footprint; placeholder excluded from the roving tabindex so it does not steal keyboard focus
- `VoiceRecordingToolbarButton.test.ts` (new) — covers orbit ring rendering, audio-level ref updates, deferred-loading gate, and tabindex exclusion
- `Toolbar.responsive.test.ts` — minor assertion updates for the new placeholder shape

## Testing

Unit tests cover the new behaviour. Manually verified toolbar layout stability across session start/end, and confirmed the connecting state no longer flickers on fast connections.