### PR TITLE
refactor(toolbar): extract shared helper for toolbar visibility dispatch

### DIFF
--- a/shared/utils/__tests__/agentPinned.test.ts
+++ b/shared/utils/__tests__/agentPinned.test.ts
@@ -1,5 +1,11 @@
 import { describe, expect, it } from "vitest";
-import { isAgentPinned, isAgentPinnedById, isAgentToolbarVisible } from "../agentPinned.js";
+import { BUILT_IN_AGENT_IDS } from "../../config/agentIds.js";
+import {
+  BUILT_IN_AGENT_ID_SET,
+  isAgentPinned,
+  isAgentPinnedById,
+  isAgentToolbarVisible,
+} from "../agentPinned.js";
 
 describe("isAgentPinned — opt-in semantics", () => {
   it("returns false for undefined entry", () => {
@@ -91,5 +97,22 @@ describe("isAgentToolbarVisible — tri-state with availability fallback", () =>
   it("treats empty entry as follows-availability", () => {
     expect(isAgentToolbarVisible({}, "ready")).toBe(true);
     expect(isAgentToolbarVisible({}, "missing")).toBe(false);
+  });
+});
+
+describe("BUILT_IN_AGENT_ID_SET", () => {
+  it("contains every BUILT_IN_AGENT_ID and nothing else", () => {
+    expect(BUILT_IN_AGENT_ID_SET.size).toBe(BUILT_IN_AGENT_IDS.length);
+    for (const id of BUILT_IN_AGENT_IDS) {
+      expect(BUILT_IN_AGENT_ID_SET.has(id)).toBe(true);
+    }
+  });
+
+  it("returns false for non-agent toolbar IDs", () => {
+    expect(BUILT_IN_AGENT_ID_SET.has("agent-tray")).toBe(false);
+    expect(BUILT_IN_AGENT_ID_SET.has("terminal")).toBe(false);
+    expect(BUILT_IN_AGENT_ID_SET.has("browser")).toBe(false);
+    expect(BUILT_IN_AGENT_ID_SET.has("settings")).toBe(false);
+    expect(BUILT_IN_AGENT_ID_SET.has("")).toBe(false);
   });
 });

--- a/shared/utils/agentPinned.ts
+++ b/shared/utils/agentPinned.ts
@@ -1,6 +1,16 @@
+import { BUILT_IN_AGENT_IDS } from "../config/agentIds.js";
 import type { AgentSettings, AgentSettingsEntry } from "../types/agentSettings.js";
 import type { AgentAvailabilityState } from "../types/ipc/system.js";
 import { isAgentInstalled } from "./agentAvailability.js";
+
+/**
+ * Frozen lookup set for the built-in agent IDs — shared by the three places
+ * that need to discriminate agent IDs from non-agent toolbar buttons
+ * (`ToolbarSettingsTab`, `toolbarButtonMetadata`, `useOverflowBadgeSeverity`).
+ * Use {@link isBuiltInAgentId} from `@shared/config/agentIds` when you need a
+ * type guard; this set is for hot-path `.has(id)` checks against `string`s.
+ */
+export const BUILT_IN_AGENT_ID_SET: ReadonlySet<string> = new Set<string>(BUILT_IN_AGENT_IDS);
 
 /**
  * Returns true only when the entry explicitly sets `pinned: true`. Missing

--- a/src/components/Layout/AgentButton.tsx
+++ b/src/components/Layout/AgentButton.tsx
@@ -19,6 +19,7 @@ import { BrandMark } from "@/components/icons";
 import { getAgentConfig, getMergedPresets } from "@/config/agents";
 import { useAriaKeyshortcuts, useKeybindingDisplay } from "@/hooks";
 import { createTooltipContent } from "@/lib/tooltipShortcut";
+import { dispatchToolbarVisibility } from "@/lib/toolbarVisibilityDispatch";
 import { useWorktrees } from "@/hooks/useWorktrees";
 import { actionService } from "@/services/ActionService";
 import {
@@ -319,7 +320,7 @@ export function AgentButton({
   };
 
   const handleUnpinFromToolbar = () => {
-    void useAgentSettingsStore.getState().setAgentPinned(type, false);
+    dispatchToolbarVisibility(type, "left", false);
   };
 
   // Persist the toolbar pick to the worktree-scoped slot so repeated launches

--- a/src/components/Layout/__tests__/AgentButton.test.tsx
+++ b/src/components/Layout/__tests__/AgentButton.test.tsx
@@ -23,6 +23,11 @@ import type { AgentSettings, CliAvailability } from "@shared/types";
 const dispatchMock = vi.fn();
 const updateWorktreePresetMock = vi.fn();
 const updateAgentMock = vi.fn().mockResolvedValue(undefined);
+// Hoisted so the vi.mock factory (also hoisted) can reference it; a plain
+// `const` would initialize after the mock factory runs.
+const { dispatchToolbarVisibilityMock } = vi.hoisted(() => ({
+  dispatchToolbarVisibilityMock: vi.fn(),
+}));
 let dropdownCloseAutoFocusSpy: ((e: { preventDefault: () => void }) => void) | null = null;
 let dropdownPointerDownOutsideSpy: (() => void) | null = null;
 
@@ -299,6 +304,10 @@ vi.mock("lucide-react", () => ({
   Unplug: () => <span data-testid="unplug-icon" />,
 }));
 
+vi.mock("@/lib/toolbarVisibilityDispatch", () => ({
+  dispatchToolbarVisibility: dispatchToolbarVisibilityMock,
+}));
+
 import { AgentButton } from "../AgentButton";
 
 function settingsWith(agents: Record<string, unknown>): AgentSettings {
@@ -310,6 +319,7 @@ describe("AgentButton preset UX", () => {
     dispatchMock.mockClear();
     updateWorktreePresetMock.mockClear();
     updateAgentMock.mockClear();
+    dispatchToolbarVisibilityMock.mockClear();
     mockSettings = null;
     mockActiveWorktreeId = null;
     mockCcrPresetsByAgent = {};
@@ -908,6 +918,24 @@ describe("AgentButton preset UX", () => {
   });
 
   describe("context menu", () => {
+    it("Unpin from Toolbar dispatches the shared helper with explicitPinned=false", () => {
+      // Locks the contract between AgentButton and dispatchToolbarVisibility:
+      // the "Unpin" action must force pinned=false regardless of current
+      // visibility (it's not a toggle). The "left" side argument is a sentinel
+      // — the helper ignores `side` for agent IDs — but locking it here
+      // catches an accidental "right" pass that would still work today but
+      // could become a meaningful signal if the helper ever changes.
+      mockSettings = settingsWith({ claude: { pinned: true } });
+
+      const { getByText } = render(
+        <AgentButton type="claude" availability={"ready" as unknown as CliAvailability[string]} />
+      );
+      fireEvent.click(getByText("Unpin from Toolbar"));
+
+      expect(dispatchToolbarVisibilityMock).toHaveBeenCalledTimes(1);
+      expect(dispatchToolbarVisibilityMock).toHaveBeenCalledWith("claude", "left", false);
+    });
+
     it("exposes Manage Presets that deep-links to the presets section (no-presets branch)", () => {
       mockSettings = settingsWith({ claude: {} });
       mockMergedPresetsFn = () => [];

--- a/src/components/Layout/toolbarButtonMetadata.ts
+++ b/src/components/Layout/toolbarButtonMetadata.ts
@@ -14,7 +14,7 @@ import { Folders } from "@/components/icons";
 import { BUILT_IN_AGENT_IDS } from "@shared/config/agentIds";
 import type { AnyToolbarButtonId, ToolbarPinnedState } from "@/../../shared/types/toolbar";
 import type { AgentSettings, CliAvailability } from "@shared/types";
-import { isAgentToolbarVisible } from "../../../shared/utils/agentPinned";
+import { BUILT_IN_AGENT_ID_SET, isAgentToolbarVisible } from "../../../shared/utils/agentPinned";
 import { getAgentConfig } from "@/config/agents";
 
 export interface ToolbarButtonIconProps {
@@ -26,8 +26,6 @@ export interface ToolbarButtonMetadata {
   icon: ComponentType<ToolbarButtonIconProps>;
   description: string;
 }
-
-const AGENT_ID_SET = new Set<string>(BUILT_IN_AGENT_IDS);
 
 // Built-in agent entries are derived from the canonical agent registry so the
 // icon shown in Settings, the agent tray, and the overflow dropdown all
@@ -119,7 +117,7 @@ export function isToolbarButtonVisible(
   agentSettings: AgentSettings | null | undefined,
   agentAvailability: CliAvailability | null | undefined
 ): boolean {
-  if (AGENT_ID_SET.has(buttonId)) {
+  if (BUILT_IN_AGENT_ID_SET.has(buttonId)) {
     return isAgentToolbarVisible(agentSettings?.agents?.[buttonId], agentAvailability?.[buttonId]);
   }
   return pinnedButtons[buttonId] !== false;

--- a/src/components/Layout/useOverflowBadgeSeverity.ts
+++ b/src/components/Layout/useOverflowBadgeSeverity.ts
@@ -7,11 +7,7 @@ import { useCliAvailabilityStore } from "@/store/cliAvailabilityStore";
 import { useAgentDiscoveryOnboarding } from "@/hooks/app/useAgentDiscoveryOnboarding";
 import { agentStateDotColor } from "@/components/Worktree/AgentStatusIndicator";
 import { getRuntimeOrBootAgentId } from "@/utils/terminalType";
-import {
-  BUILT_IN_AGENT_IDS,
-  isBuiltInAgentId,
-  type BuiltInAgentId,
-} from "@shared/config/agentIds";
+import { BUILT_IN_AGENT_IDS, isBuiltInAgentId, type BuiltInAgentId } from "@shared/config/agentIds";
 import type { AgentState } from "@shared/types";
 import { isAgentLaunchable } from "../../../shared/utils/agentAvailability";
 import type { AnyToolbarButtonId } from "@/../../shared/types/toolbar";

--- a/src/components/Layout/useOverflowBadgeSeverity.ts
+++ b/src/components/Layout/useOverflowBadgeSeverity.ts
@@ -7,7 +7,11 @@ import { useCliAvailabilityStore } from "@/store/cliAvailabilityStore";
 import { useAgentDiscoveryOnboarding } from "@/hooks/app/useAgentDiscoveryOnboarding";
 import { agentStateDotColor } from "@/components/Worktree/AgentStatusIndicator";
 import { getRuntimeOrBootAgentId } from "@/utils/terminalType";
-import { BUILT_IN_AGENT_IDS, type BuiltInAgentId } from "@shared/config/agentIds";
+import {
+  BUILT_IN_AGENT_IDS,
+  isBuiltInAgentId,
+  type BuiltInAgentId,
+} from "@shared/config/agentIds";
 import type { AgentState } from "@shared/types";
 import { isAgentLaunchable } from "../../../shared/utils/agentAvailability";
 import type { AnyToolbarButtonId } from "@/../../shared/types/toolbar";
@@ -20,12 +24,6 @@ const ACTIVE_AGENT_STATES: ReadonlySet<AgentState | undefined> = new Set<AgentSt
   "waiting",
   "directing",
 ]);
-
-const BUILT_IN_AGENT_ID_SET: ReadonlySet<string> = new Set<string>(BUILT_IN_AGENT_IDS);
-
-function isBuiltInAgentId(id: AnyToolbarButtonId): id is BuiltInAgentId {
-  return BUILT_IN_AGENT_ID_SET.has(id);
-}
 
 /**
  * Aggregates the highest-severity badge state from buttons currently pushed

--- a/src/components/Settings/ToolbarSettingsTab.tsx
+++ b/src/components/Settings/ToolbarSettingsTab.tsx
@@ -181,12 +181,9 @@ export function ToolbarSettingsTab() {
     setRightButtons(newButtons);
   };
 
-  const handleToggle = useCallback(
-    (buttonId: AnyToolbarButtonId, side: "left" | "right") => {
-      dispatchToolbarVisibility(buttonId, side);
-    },
-    []
-  );
+  const handleToggle = useCallback((buttonId: AnyToolbarButtonId, side: "left" | "right") => {
+    dispatchToolbarVisibility(buttonId, side);
+  }, []);
 
   return (
     <div className="space-y-6">

--- a/src/components/Settings/ToolbarSettingsTab.tsx
+++ b/src/components/Settings/ToolbarSettingsTab.tsx
@@ -22,7 +22,6 @@ import { useAgentSettingsStore } from "@/store/agentSettingsStore";
 import { useCliAvailabilityStore } from "@/store/cliAvailabilityStore";
 import type { AnyToolbarButtonId } from "@/../../shared/types/toolbar";
 import { BUILT_IN_AGENT_IDS } from "@shared/config/agentIds";
-import { isAgentToolbarVisible } from "../../../shared/utils/agentPinned";
 import {
   TOOLBAR_BUTTON_METADATA,
   isToolbarButtonVisible,
@@ -33,27 +32,23 @@ import { usePluginToolbarButtons } from "@/hooks/usePluginToolbarButtons";
 import { McpServerIcon } from "@/components/icons";
 import { cn } from "@/lib/utils";
 import { DRAG_GHOST_OPACITY } from "@/lib/animationUtils";
+import { dispatchToolbarVisibility } from "@/lib/toolbarVisibilityDispatch";
 import { makeSortableAnnouncements } from "@/components/DragDrop/sortableAnnouncements";
 import { SettingsSection } from "./SettingsSection";
 import { SettingsSwitchCard } from "./SettingsSwitchCard";
 
-// Agent-ID writes for visibility route to `agentSettingsStore` (the
-// authoritative IPC-persisted store). Non-agent buttons (including
-// `agent-tray` and plugin buttons) live in `toolbarPreferencesStore`'s
-// `pinnedButtons` map. A version: 5 migration strips stale agent IDs from
-// pre-unification state so they can't shadow the canonical pinned state.
-const AGENT_ID_SET = new Set<string>(BUILT_IN_AGENT_IDS);
-
 interface SortableButtonItemProps {
   buttonId: AnyToolbarButtonId;
   isVisible: boolean;
-  onToggle: (buttonId: AnyToolbarButtonId) => void;
+  side: "left" | "right";
+  onToggle: (buttonId: AnyToolbarButtonId, side: "left" | "right") => void;
   allMetadata: Partial<Record<AnyToolbarButtonId, ToolbarButtonMetadata>>;
 }
 
 function SortableButtonItem({
   buttonId,
   isVisible,
+  side,
   onToggle,
   allMetadata,
 }: SortableButtonItemProps) {
@@ -98,7 +93,7 @@ function SortableButtonItem({
       <input
         type="checkbox"
         checked={isVisible}
-        onChange={() => onToggle(buttonId)}
+        onChange={() => onToggle(buttonId, side)}
         aria-label={`Toggle ${metadata.label} visibility`}
         className="w-4 h-4 rounded border-border-strong bg-daintree-bg text-daintree-accent focus:ring-daintree-accent focus:ring-2"
       />
@@ -111,13 +106,11 @@ export function ToolbarSettingsTab() {
   const launcher = useToolbarPreferencesStore((s) => s.launcher);
   const setLeftButtons = useToolbarPreferencesStore((s) => s.setLeftButtons);
   const setRightButtons = useToolbarPreferencesStore((s) => s.setRightButtons);
-  const toggleButtonVisibility = useToolbarPreferencesStore((s) => s.toggleButtonVisibility);
   const setAlwaysShowDevServer = useToolbarPreferencesStore((s) => s.setAlwaysShowDevServer);
   const setDefaultSelection = useToolbarPreferencesStore((s) => s.setDefaultSelection);
   const reset = useToolbarPreferencesStore((s) => s.reset);
 
   const agentSettings = useAgentSettingsStore((s) => s.settings);
-  const setAgentPinned = useAgentSettingsStore((s) => s.setAgentPinned);
   const agentAvailability = useCliAvailabilityStore((s) => s.availability);
 
   const sensors = useSensors(
@@ -188,32 +181,12 @@ export function ToolbarSettingsTab() {
     setRightButtons(newButtons);
   };
 
-  const handleToggleLeft = (buttonId: AnyToolbarButtonId) => {
-    if (AGENT_ID_SET.has(buttonId)) {
-      // Toggle the *currently visible* state so undefined-pinned agents
-      // resolve to the opposite of the derived state (installed→hide,
-      // missing→show) — see #7673 tri-state semantics.
-      const nextPinned = !isAgentToolbarVisible(
-        agentSettings?.agents?.[buttonId],
-        agentAvailability?.[buttonId]
-      );
-      void setAgentPinned(buttonId, nextPinned);
-      return;
-    }
-    toggleButtonVisibility(buttonId, "left");
-  };
-
-  const handleToggleRight = (buttonId: AnyToolbarButtonId) => {
-    if (AGENT_ID_SET.has(buttonId)) {
-      const nextPinned = !isAgentToolbarVisible(
-        agentSettings?.agents?.[buttonId],
-        agentAvailability?.[buttonId]
-      );
-      void setAgentPinned(buttonId, nextPinned);
-      return;
-    }
-    toggleButtonVisibility(buttonId, "right");
-  };
+  const handleToggle = useCallback(
+    (buttonId: AnyToolbarButtonId, side: "left" | "right") => {
+      dispatchToolbarVisibility(buttonId, side);
+    },
+    []
+  );
 
   return (
     <div className="space-y-6">
@@ -240,7 +213,8 @@ export function ToolbarSettingsTab() {
                     agentSettings,
                     agentAvailability
                   )}
-                  onToggle={handleToggleLeft}
+                  side="left"
+                  onToggle={handleToggle}
                   allMetadata={allMetadata}
                 />
               ))}
@@ -272,7 +246,8 @@ export function ToolbarSettingsTab() {
                     agentSettings,
                     agentAvailability
                   )}
-                  onToggle={handleToggleRight}
+                  side="right"
+                  onToggle={handleToggle}
                   allMetadata={allMetadata}
                 />
               ))}
@@ -335,7 +310,7 @@ export function ToolbarSettingsTab() {
           )}
         >
           <RotateCcw className="w-3.5 h-3.5" />
-          Reset to Defaults
+          Reset toolbar
         </button>
       </div>
     </div>

--- a/src/components/Settings/__tests__/ToolbarSettingsTab.test.tsx
+++ b/src/components/Settings/__tests__/ToolbarSettingsTab.test.tsx
@@ -2,6 +2,7 @@
 import { describe, it, expect, vi, beforeEach } from "vitest";
 import { render, fireEvent } from "@testing-library/react";
 import type { AgentSettings } from "@shared/types";
+import type { CliAvailability } from "@shared/types/ipc/system";
 
 const setLeftButtonsMock = vi.fn();
 const setRightButtonsMock = vi.fn();
@@ -42,6 +43,7 @@ let mockToolbarState: ToolbarState = {
 };
 
 let mockAgentSettings: AgentSettings | null = null;
+let mockCliAvailability: CliAvailability | undefined = undefined;
 
 vi.mock("@/store", () => ({
   useToolbarPreferencesStore: (selector: (s: ToolbarState) => unknown) =>
@@ -54,8 +56,9 @@ vi.mock("@/store/agentSettingsStore", () => ({
 }));
 
 vi.mock("@/store/cliAvailabilityStore", () => ({
-  useCliAvailabilityStore: (selector: (s: { availability: undefined }) => unknown) =>
-    selector({ availability: undefined }),
+  useCliAvailabilityStore: (
+    selector: (s: { availability: CliAvailability | undefined }) => unknown
+  ) => selector({ availability: mockCliAvailability }),
 }));
 
 // The component delegates all visibility writes to dispatchToolbarVisibility.
@@ -178,6 +181,7 @@ describe("ToolbarSettingsTab — agent visibility routing", () => {
       reset: resetMock,
     };
     mockAgentSettings = null;
+    mockCliAvailability = undefined;
   });
 
   it("shows agent rows as checked when pinned in agentSettingsStore", () => {
@@ -273,6 +277,22 @@ describe("ToolbarSettingsTab — agent visibility routing", () => {
     expect(claudeCheckbox.checked).toBe(false);
   });
 
+  it("renders an agent as visible when pinned is undefined and CLI is ready (tri-state)", () => {
+    // #7673 tri-state: an agent with no explicit `pinned` flag follows live
+    // CLI availability — `ready` means visible. Locks the UI-side rendering
+    // of the path the helper covers in isolation.
+    mockAgentSettings = agentSettings({ claude: {} });
+    mockCliAvailability = { claude: "ready" } as CliAvailability;
+
+    const { getByLabelText, getByTestId } = render(<ToolbarSettingsTab />);
+    const claudeCheckbox = getByLabelText("Toggle Claude Agent visibility") as HTMLInputElement;
+    expect(claudeCheckbox.checked).toBe(true);
+    // Left layout: agent-tray, claude (tri-state visible), gemini (no pin,
+    // missing/undefined → hidden), terminal (no hide) = 3 of 4 visible.
+    const leftSection = getByTestId("section-Left side buttons");
+    expect(leftSection.getAttribute("data-description")).toContain("3 of 4 visible");
+  });
+
   it("dispatches a right-side agent toggle with side=right", () => {
     // Relocate codex to the right side — an unlikely but possible layout.
     mockToolbarState.layout = {
@@ -313,6 +333,7 @@ describe("ToolbarSettingsTab — drag-source vs hidden opacity deconfliction", (
       reset: resetMock,
     };
     mockAgentSettings = null;
+    mockCliAvailability = undefined;
   });
 
   function rowFor(label: string, container: HTMLElement): HTMLElement {

--- a/src/components/Settings/__tests__/ToolbarSettingsTab.test.tsx
+++ b/src/components/Settings/__tests__/ToolbarSettingsTab.test.tsx
@@ -5,11 +5,14 @@ import type { AgentSettings } from "@shared/types";
 
 const setLeftButtonsMock = vi.fn();
 const setRightButtonsMock = vi.fn();
-const toggleButtonVisibilityMock = vi.fn();
 const setAlwaysShowDevServerMock = vi.fn();
 const setDefaultSelectionMock = vi.fn();
 const resetMock = vi.fn();
-const setAgentPinnedMock = vi.fn().mockResolvedValue(undefined);
+// Hoisted so the vi.mock factory below (also hoisted) can reference it; a
+// plain `const` initializes after the mock factory runs.
+const { dispatchToolbarVisibilityMock } = vi.hoisted(() => ({
+  dispatchToolbarVisibilityMock: vi.fn(),
+}));
 
 interface ToolbarState {
   layout: {
@@ -23,7 +26,6 @@ interface ToolbarState {
   };
   setLeftButtons: typeof setLeftButtonsMock;
   setRightButtons: typeof setRightButtonsMock;
-  toggleButtonVisibility: typeof toggleButtonVisibilityMock;
   setAlwaysShowDevServer: typeof setAlwaysShowDevServerMock;
   setDefaultSelection: typeof setDefaultSelectionMock;
   reset: typeof resetMock;
@@ -34,7 +36,6 @@ let mockToolbarState: ToolbarState = {
   launcher: { alwaysShowDevServer: false, defaultSelection: undefined },
   setLeftButtons: setLeftButtonsMock,
   setRightButtons: setRightButtonsMock,
-  toggleButtonVisibility: toggleButtonVisibilityMock,
   setAlwaysShowDevServer: setAlwaysShowDevServerMock,
   setDefaultSelection: setDefaultSelectionMock,
   reset: resetMock,
@@ -48,17 +49,20 @@ vi.mock("@/store", () => ({
 }));
 
 vi.mock("@/store/agentSettingsStore", () => ({
-  useAgentSettingsStore: (
-    selector: (s: {
-      settings: AgentSettings | null;
-      setAgentPinned: typeof setAgentPinnedMock;
-    }) => unknown
-  ) => selector({ settings: mockAgentSettings, setAgentPinned: setAgentPinnedMock }),
+  useAgentSettingsStore: (selector: (s: { settings: AgentSettings | null }) => unknown) =>
+    selector({ settings: mockAgentSettings }),
 }));
 
 vi.mock("@/store/cliAvailabilityStore", () => ({
   useCliAvailabilityStore: (selector: (s: { availability: undefined }) => unknown) =>
     selector({ availability: undefined }),
+}));
+
+// The component delegates all visibility writes to dispatchToolbarVisibility.
+// Tests assert on the dispatch directly rather than reaching through three
+// store mocks for what is now a single-call boundary.
+vi.mock("@/lib/toolbarVisibilityDispatch", () => ({
+  dispatchToolbarVisibility: dispatchToolbarVisibilityMock,
 }));
 
 vi.mock("@shared/config/agentIds", () => ({
@@ -154,11 +158,10 @@ describe("ToolbarSettingsTab — agent visibility routing", () => {
   beforeEach(() => {
     setLeftButtonsMock.mockClear();
     setRightButtonsMock.mockClear();
-    toggleButtonVisibilityMock.mockClear();
     setAlwaysShowDevServerMock.mockClear();
     setDefaultSelectionMock.mockClear();
     resetMock.mockClear();
-    setAgentPinnedMock.mockClear();
+    dispatchToolbarVisibilityMock.mockClear();
 
     mockToolbarState = {
       layout: {
@@ -170,7 +173,6 @@ describe("ToolbarSettingsTab — agent visibility routing", () => {
       launcher: { alwaysShowDevServer: false, defaultSelection: undefined },
       setLeftButtons: setLeftButtonsMock,
       setRightButtons: setRightButtonsMock,
-      toggleButtonVisibility: toggleButtonVisibilityMock,
       setAlwaysShowDevServer: setAlwaysShowDevServerMock,
       setDefaultSelection: setDefaultSelectionMock,
       reset: resetMock,
@@ -206,7 +208,7 @@ describe("ToolbarSettingsTab — agent visibility routing", () => {
     expect(claudeCheckbox.checked).toBe(true);
   });
 
-  it("routes agent checkbox toggle to setAgentPinned (not toggleButtonVisibility)", () => {
+  it("dispatches agent checkbox toggle through dispatchToolbarVisibility", () => {
     mockAgentSettings = agentSettings({
       claude: { pinned: true },
     });
@@ -214,12 +216,14 @@ describe("ToolbarSettingsTab — agent visibility routing", () => {
     const { getByLabelText } = render(<ToolbarSettingsTab />);
     fireEvent.click(getByLabelText("Toggle Claude Agent visibility"));
 
-    expect(setAgentPinnedMock).toHaveBeenCalledTimes(1);
-    expect(setAgentPinnedMock).toHaveBeenCalledWith("claude", false);
-    expect(toggleButtonVisibilityMock).not.toHaveBeenCalled();
+    expect(dispatchToolbarVisibilityMock).toHaveBeenCalledTimes(1);
+    expect(dispatchToolbarVisibilityMock).toHaveBeenCalledWith("claude", "left");
   });
 
-  it("routes agent checkbox toggle upward (unpinned → pinned) via setAgentPinned", () => {
+  it("dispatches an agent toggle on the left side (helper routes by ID, not by side)", () => {
+    // Locks the contract: the component forwards the buttonId + side it
+    // rendered for; routing to setAgentPinned vs toggleButtonVisibility is
+    // the helper's responsibility — covered in toolbarVisibilityDispatch.test.ts.
     mockAgentSettings = agentSettings({
       gemini: { pinned: false },
     });
@@ -227,28 +231,25 @@ describe("ToolbarSettingsTab — agent visibility routing", () => {
     const { getByLabelText } = render(<ToolbarSettingsTab />);
     fireEvent.click(getByLabelText("Toggle Gemini Agent visibility"));
 
-    expect(setAgentPinnedMock).toHaveBeenCalledWith("gemini", true);
-    expect(toggleButtonVisibilityMock).not.toHaveBeenCalled();
+    expect(dispatchToolbarVisibilityMock).toHaveBeenCalledWith("gemini", "left");
   });
 
-  it("keeps non-agent checkbox toggle on toggleButtonVisibility", () => {
+  it("dispatches non-agent checkbox toggle with the left side argument", () => {
     const { getByLabelText } = render(<ToolbarSettingsTab />);
     fireEvent.click(getByLabelText("Toggle Terminal visibility"));
 
-    expect(toggleButtonVisibilityMock).toHaveBeenCalledTimes(1);
-    expect(toggleButtonVisibilityMock).toHaveBeenCalledWith("terminal", "left");
-    expect(setAgentPinnedMock).not.toHaveBeenCalled();
+    expect(dispatchToolbarVisibilityMock).toHaveBeenCalledTimes(1);
+    expect(dispatchToolbarVisibilityMock).toHaveBeenCalledWith("terminal", "left");
   });
 
-  it("dispatches `'right'` as the side argument for right-side non-agent toggles", () => {
-    // Locks the side argument so future side-aware store changes can't
-    // silently swallow the right-side branch — both handlers (left, right)
-    // are nominally identical today but each is independently wired.
+  it("forwards `'right'` as the side argument for right-side toggles", () => {
+    // Locks the side argument so a future regression to a single-side
+    // handler can't silently collapse left and right into one call shape.
     const { getByLabelText } = render(<ToolbarSettingsTab />);
     fireEvent.click(getByLabelText("Toggle Copy Context visibility"));
 
-    expect(toggleButtonVisibilityMock).toHaveBeenCalledTimes(1);
-    expect(toggleButtonVisibilityMock).toHaveBeenCalledWith("copy-tree", "right");
+    expect(dispatchToolbarVisibilityMock).toHaveBeenCalledTimes(1);
+    expect(dispatchToolbarVisibilityMock).toHaveBeenCalledWith("copy-tree", "right");
   });
 
   it("reflects pinned agents in the section visible-count summary", () => {
@@ -272,7 +273,7 @@ describe("ToolbarSettingsTab — agent visibility routing", () => {
     expect(claudeCheckbox.checked).toBe(false);
   });
 
-  it("handles a right-side agent correctly (routes through setAgentPinned)", () => {
+  it("dispatches a right-side agent toggle with side=right", () => {
     // Relocate codex to the right side — an unlikely but possible layout.
     mockToolbarState.layout = {
       leftButtons: ["agent-tray", "terminal"],
@@ -286,8 +287,7 @@ describe("ToolbarSettingsTab — agent visibility routing", () => {
     const { getByLabelText } = render(<ToolbarSettingsTab />);
     fireEvent.click(getByLabelText("Toggle Codex Agent visibility"));
 
-    expect(setAgentPinnedMock).toHaveBeenCalledWith("codex", false);
-    expect(toggleButtonVisibilityMock).not.toHaveBeenCalled();
+    expect(dispatchToolbarVisibilityMock).toHaveBeenCalledWith("codex", "right");
   });
 });
 
@@ -297,7 +297,7 @@ describe("ToolbarSettingsTab — drag-source vs hidden opacity deconfliction", (
   // magic 0.5. These tests lock the deconfliction so the two values can't
   // silently collapse back together.
   beforeEach(() => {
-    setAgentPinnedMock.mockClear();
+    dispatchToolbarVisibilityMock.mockClear();
     vi.mocked(useSortable).mockImplementation(defaultSortable);
     mockToolbarState = {
       layout: {
@@ -308,7 +308,6 @@ describe("ToolbarSettingsTab — drag-source vs hidden opacity deconfliction", (
       launcher: { alwaysShowDevServer: false, defaultSelection: undefined },
       setLeftButtons: setLeftButtonsMock,
       setRightButtons: setRightButtonsMock,
-      toggleButtonVisibility: toggleButtonVisibilityMock,
       setAlwaysShowDevServer: setAlwaysShowDevServerMock,
       setDefaultSelection: setDefaultSelectionMock,
       reset: resetMock,

--- a/src/lib/__tests__/toolbarVisibilityDispatch.test.ts
+++ b/src/lib/__tests__/toolbarVisibilityDispatch.test.ts
@@ -1,0 +1,121 @@
+// @vitest-environment jsdom
+import { beforeEach, describe, expect, it, vi } from "vitest";
+import type { AgentSettings } from "@shared/types";
+import type { CliAvailability } from "@shared/types/ipc/system";
+
+const setAgentPinnedMock = vi.fn().mockResolvedValue(undefined);
+const toggleButtonVisibilityMock = vi.fn();
+
+let mockAgentSettings: AgentSettings | null = null;
+let mockAvailability: CliAvailability | undefined = undefined;
+
+vi.mock("@/store/agentSettingsStore", () => ({
+  useAgentSettingsStore: {
+    getState: () => ({
+      settings: mockAgentSettings,
+      setAgentPinned: setAgentPinnedMock,
+    }),
+  },
+}));
+
+vi.mock("@/store/cliAvailabilityStore", () => ({
+  useCliAvailabilityStore: {
+    getState: () => ({ availability: mockAvailability }),
+  },
+}));
+
+vi.mock("@/store/toolbarPreferencesStore", () => ({
+  useToolbarPreferencesStore: {
+    getState: () => ({ toggleButtonVisibility: toggleButtonVisibilityMock }),
+  },
+}));
+
+import { dispatchToolbarVisibility } from "../toolbarVisibilityDispatch";
+
+function settings(overrides: Record<string, { pinned?: boolean }>): AgentSettings {
+  return { agents: overrides } as unknown as AgentSettings;
+}
+
+describe("dispatchToolbarVisibility — agent branch", () => {
+  beforeEach(() => {
+    setAgentPinnedMock.mockClear();
+    toggleButtonVisibilityMock.mockClear();
+    mockAgentSettings = null;
+    mockAvailability = undefined;
+  });
+
+  it("toggles pinned=true → false when agent is currently visible", () => {
+    mockAgentSettings = settings({ claude: { pinned: true } });
+    dispatchToolbarVisibility("claude", "left");
+    expect(setAgentPinnedMock).toHaveBeenCalledWith("claude", false);
+    expect(toggleButtonVisibilityMock).not.toHaveBeenCalled();
+  });
+
+  it("toggles pinned=false → true when agent is currently hidden", () => {
+    mockAgentSettings = settings({ gemini: { pinned: false } });
+    dispatchToolbarVisibility("gemini", "right");
+    expect(setAgentPinnedMock).toHaveBeenCalledWith("gemini", true);
+  });
+
+  it("flips tri-state undefined according to live availability (installed → hide)", () => {
+    mockAgentSettings = settings({ claude: {} });
+    mockAvailability = { claude: "ready" } as CliAvailability;
+    dispatchToolbarVisibility("claude", "left");
+    expect(setAgentPinnedMock).toHaveBeenCalledWith("claude", false);
+  });
+
+  it("flips tri-state undefined according to live availability (missing → show)", () => {
+    mockAgentSettings = settings({ claude: {} });
+    mockAvailability = { claude: "missing" } as CliAvailability;
+    dispatchToolbarVisibility("claude", "left");
+    expect(setAgentPinnedMock).toHaveBeenCalledWith("claude", true);
+  });
+
+  it("forces explicit unpin (explicitPinned=false) without reading current state", () => {
+    mockAgentSettings = settings({ codex: { pinned: true } });
+    dispatchToolbarVisibility("codex", "left", false);
+    expect(setAgentPinnedMock).toHaveBeenCalledWith("codex", false);
+  });
+
+  it("accepts explicitPinned=true to force pinned even when currently visible", () => {
+    mockAgentSettings = settings({ codex: { pinned: true } });
+    dispatchToolbarVisibility("codex", "right", true);
+    expect(setAgentPinnedMock).toHaveBeenCalledWith("codex", true);
+  });
+
+  it("does not call toggleButtonVisibility for agent IDs regardless of side", () => {
+    dispatchToolbarVisibility("claude", "left");
+    dispatchToolbarVisibility("gemini", "right");
+    expect(toggleButtonVisibilityMock).not.toHaveBeenCalled();
+  });
+});
+
+describe("dispatchToolbarVisibility — non-agent branch", () => {
+  beforeEach(() => {
+    setAgentPinnedMock.mockClear();
+    toggleButtonVisibilityMock.mockClear();
+  });
+
+  it("dispatches toggleButtonVisibility for non-agent IDs (left side)", () => {
+    dispatchToolbarVisibility("terminal", "left");
+    expect(toggleButtonVisibilityMock).toHaveBeenCalledWith("terminal", "left");
+    expect(setAgentPinnedMock).not.toHaveBeenCalled();
+  });
+
+  it("forwards the right side to toggleButtonVisibility", () => {
+    dispatchToolbarVisibility("copy-tree", "right");
+    expect(toggleButtonVisibilityMock).toHaveBeenCalledWith("copy-tree", "right");
+  });
+
+  it("ignores explicitPinned for non-agent IDs (still toggles via the store)", () => {
+    dispatchToolbarVisibility("settings", "left", false);
+    expect(toggleButtonVisibilityMock).toHaveBeenCalledWith("settings", "left");
+    expect(setAgentPinnedMock).not.toHaveBeenCalled();
+  });
+
+  it("routes the agent-tray (non-agent) ID to toggleButtonVisibility", () => {
+    dispatchToolbarVisibility("agent-tray", "left");
+    expect(toggleButtonVisibilityMock).toHaveBeenCalledWith("agent-tray", "left");
+    expect(setAgentPinnedMock).not.toHaveBeenCalled();
+  });
+});

--- a/src/lib/toolbarVisibilityDispatch.ts
+++ b/src/lib/toolbarVisibilityDispatch.ts
@@ -1,0 +1,39 @@
+import { useAgentSettingsStore } from "@/store/agentSettingsStore";
+import { useCliAvailabilityStore } from "@/store/cliAvailabilityStore";
+import { useToolbarPreferencesStore } from "@/store/toolbarPreferencesStore";
+import { BUILT_IN_AGENT_ID_SET, isAgentToolbarVisible } from "@shared/utils/agentPinned";
+import type { AnyToolbarButtonId } from "@/../../shared/types/toolbar";
+
+/**
+ * Single dispatch point for toolbar visibility changes. Routes built-in agent
+ * IDs to `agentSettingsStore` (preserving the tri-state semantics from #7673)
+ * and every other ID — including `agent-tray` and plugin buttons — to
+ * `toolbarPreferencesStore.toggleButtonVisibility`.
+ *
+ * Pass `explicitPinned: false` for "Unpin from toolbar" actions where the
+ * intent is to hide regardless of the current state; omit it for checkbox
+ * toggles that should flip whatever is currently visible. The flag is ignored
+ * for non-agent IDs (their store has no tri-state — visibility is a plain
+ * `pinnedButtons[id] !== false`).
+ *
+ * `side` is forwarded to `toggleButtonVisibility` for non-agent IDs only —
+ * agent IDs ignore it. Right-click "unpin" callers that don't have a side
+ * available may pass `"left"` as a sentinel.
+ */
+export function dispatchToolbarVisibility(
+  buttonId: AnyToolbarButtonId,
+  side: "left" | "right",
+  explicitPinned?: boolean
+): void {
+  if (BUILT_IN_AGENT_ID_SET.has(buttonId)) {
+    const nextPinned =
+      explicitPinned ??
+      !isAgentToolbarVisible(
+        useAgentSettingsStore.getState().settings?.agents?.[buttonId],
+        useCliAvailabilityStore.getState().availability?.[buttonId]
+      );
+    void useAgentSettingsStore.getState().setAgentPinned(buttonId, nextPinned);
+    return;
+  }
+  useToolbarPreferencesStore.getState().toggleButtonVisibility(buttonId, side);
+}


### PR DESCRIPTION
## Summary

- `BUILT_IN_AGENT_ID_SET` was defined in three places (`ToolbarSettingsTab.tsx`, `toolbarButtonMetadata.ts`, `useOverflowBadgeSeverity.ts`). It now lives in `shared/utils/agentPinned.ts` next to its sibling resolvers and the local copies are gone.
- New `src/lib/toolbarVisibilityDispatch.ts` handles the agent-vs-non-agent branch in one place: agent IDs route to `setAgentPinned` (preserving tri-state semantics from #7673), non-agent IDs to `toggleButtonVisibility`, with an optional `explicitPinned` for unpin actions.
- `handleToggleLeft`/`handleToggleRight` in `ToolbarSettingsTab` collapsed into a single `handleToggle`; `AgentButton.handleUnpinFromToolbar` updated to use the same helper. Third call site is ready for the follow-up.

Resolves #8181

## Changes

- Export `BUILT_IN_AGENT_ID_SET` from `shared/utils/agentPinned.ts`, remove three local copies
- Add `src/lib/toolbarVisibilityDispatch.ts` with the unified dispatch helper
- Collapse `handleToggleLeft`/`handleToggleRight` into `handleToggle` in `ToolbarSettingsTab`
- Unify `AgentButton.handleUnpinFromToolbar` to the helper
- Switch `useOverflowBadgeSeverity` to `isBuiltInAgentId` from `@shared/config/agentIds`
- Rename "Reset to Defaults" to "Reset toolbar" per verb-noun microcopy rule

## Testing

93 unit tests pass across the 4 affected files. Added 2 new tests covering the unpin path and tri-state semantics. ESLint and tsc clean.