### PR TITLE
feat(plugins): registerForgeProvider host API + PluginWorktreeSnapshot breaking change

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,15 @@
 # Changelog
 
+## [Unreleased]
+
+### Breaking Changes
+
+- **Plugin SDK: `PluginWorktreeSnapshot` forge fields replaced.** The GitHub-shaped fields `issueNumber`, `issueTitle`, `prNumber`, `prUrl`, `prState`, and `prTitle` are removed and replaced by a single provider-agnostic `linked` field (`{ providerId, issue?, pr? } | null`) typed against `ResourceRef`/`NormalizedPRState`. Plugins reading the old fields must migrate to `snapshot.linked`. `linked` is currently `null` for all worktrees until the forge-provider routing lands (`PRIntegrationService` rewrite). Plugins must declare `engines.daintree: "^0.11.0"` (or lower) to be gated out on this version; the SDK is pre-1.0 so this clean break ships without a migration shim. (#8058)
+
+### Features
+
+- **Plugin SDK: `host.registerForgeProvider(descriptor, impl)`.** New host API for forge plugins to register a provider implementation during `activate()`, backed by the new `ForgeProviderRegistry` (host-side routing by git remote hostname). Manifest `contributes.forgeProviders` entries now register eagerly instead of logging "not yet implemented"; the runtime implementation binds lazily and is auto-disposed on plugin unload. (#8058, #8057)
+
 ## [0.11.1] - 2026-05-17
 
 Stability follow-up to v0.11.0. Walks back two terminal rendering regressions, refreshes project stats on trash and restore without waiting for the 5s poll, and lets the Daintree Assistant resume across project-view LRU eviction. The release pipeline also splits into three independent per-OS workflows.

--- a/electron/services/ForgeProviderRegistry.ts
+++ b/electron/services/ForgeProviderRegistry.ts
@@ -1,0 +1,172 @@
+import type {
+  ForgeProviderContribution,
+  ForgeProviderDescriptor,
+  ForgeProviderImpl,
+} from "../../shared/types/forge.js";
+
+/**
+ * Composed provider id (`{pluginId}.{descriptorId}`) format. Mirrors
+ * `PLUGIN_ACTION_ID_RE` in PluginService — duplicated rather than shared
+ * because the two checks evolve independently and the constant is tiny.
+ */
+const PROVIDER_FULL_ID_RE = /^[a-z0-9][a-z0-9-]*\.[a-z0-9][a-zA-Z0-9._-]*$/;
+
+interface RegistryEntry {
+  pluginId: string;
+  fullId: string;
+  /** Manifest contribution (eager) or runtime descriptor (lazy), merged. */
+  descriptor: ForgeProviderDescriptor & { id: string };
+  /**
+   * `null` for a manifest-only (eager) registration whose `activate()` has not
+   * yet bound the implementation. `listMatchingProviders` excludes null-impl
+   * entries — a descriptor without an impl is not callable.
+   */
+  impl: ForgeProviderImpl | null;
+}
+
+/**
+ * Host-side registry of plugin-contributed forge providers (issue #8057).
+ *
+ * Two registration paths, matching the forge contribution-point lifecycle:
+ *
+ * - **Eager / manifest-driven** (`registerDescriptorOnly`): called from
+ *   `PluginService.loadPlugin()` for each `contributes.forgeProviders` entry.
+ *   Populates the routing table and Preferences UI before any plugin code
+ *   runs; `impl` is `null` until bound.
+ * - **Lazy / implementation binding** (`register`): called from the
+ *   `host.registerForgeProvider` API during `activate(host)`. Binds the
+ *   runtime `impl`, upgrading a matching eager entry in place when present.
+ *
+ * Remote-URL routing uses exact hostname matching via `new URL().hostname`.
+ * SSH scp-style remotes (`git@github.com:org/repo.git`) do NOT parse through
+ * `new URL()` — callers must normalize remotes to HTTPS form before querying.
+ * Glob patterns in `descriptor.matches` are out of scope for this stage.
+ */
+export class ForgeProviderRegistry {
+  /** Keyed by pluginId; one plugin may contribute several providers. */
+  private byPlugin = new Map<string, RegistryEntry[]>();
+
+  private composeFullId(pluginId: string, descriptorId: string): string {
+    if (typeof descriptorId !== "string" || descriptorId.length === 0) {
+      throw new Error("Forge provider descriptor.id must be a non-empty string");
+    }
+    const fullId = `${pluginId}.${descriptorId}`;
+    if (!PROVIDER_FULL_ID_RE.test(fullId)) {
+      throw new Error(
+        `Forge provider id "${fullId}" is invalid. Expected "{pluginId}.{providerId}" ` +
+          `(lowercase start, alphanumerics, dot/dash/underscore).`
+      );
+    }
+    return fullId;
+  }
+
+  private getList(pluginId: string): RegistryEntry[] {
+    let list = this.byPlugin.get(pluginId);
+    if (!list) {
+      list = [];
+      this.byPlugin.set(pluginId, list);
+    }
+    return list;
+  }
+
+  /**
+   * Eager manifest registration. Records the descriptor with no impl. Calling
+   * it again for the same provider replaces the descriptor while preserving
+   * any impl already bound (load order between manifest scan and activate is
+   * not guaranteed).
+   */
+  registerDescriptorOnly(pluginId: string, contribution: ForgeProviderContribution): void {
+    const fullId = this.composeFullId(pluginId, contribution.id);
+    const list = this.getList(pluginId);
+    const existing = list.find((e) => e.fullId === fullId);
+    if (existing) {
+      existing.descriptor = { ...contribution };
+      return;
+    }
+    list.push({ pluginId, fullId, descriptor: { ...contribution }, impl: null });
+  }
+
+  /**
+   * Bind a runtime implementation. Upgrades a matching eager entry in place
+   * (merging descriptor fields the runtime descriptor supplies) or creates a
+   * new entry when registered purely at runtime. Returns an idempotent
+   * disposer that removes exactly this registration.
+   */
+  register(
+    pluginId: string,
+    descriptor: ForgeProviderDescriptor,
+    impl: ForgeProviderImpl
+  ): () => void {
+    const fullId = this.composeFullId(pluginId, descriptor.id);
+    if (impl == null || typeof impl !== "object") {
+      throw new Error(`Forge provider "${fullId}" implementation must be an object`);
+    }
+    const list = this.getList(pluginId);
+    let entry = list.find((e) => e.fullId === fullId);
+    if (entry) {
+      // Merge: runtime descriptor fields override/extend the manifest entry.
+      entry.descriptor = { ...entry.descriptor, ...descriptor, id: descriptor.id };
+      entry.impl = impl;
+    } else {
+      entry = { pluginId, fullId, descriptor: { ...descriptor }, impl };
+      list.push(entry);
+    }
+
+    const target = entry;
+    let disposed = false;
+    return () => {
+      if (disposed) return;
+      disposed = true;
+      const current = this.byPlugin.get(pluginId);
+      if (!current) return;
+      const idx = current.indexOf(target);
+      if (idx >= 0) current.splice(idx, 1);
+      if (current.length === 0) this.byPlugin.delete(pluginId);
+    };
+  }
+
+  /** Remove every provider owned by a plugin. Idempotent. */
+  unregisterAll(pluginId: string): void {
+    this.byPlugin.delete(pluginId);
+  }
+
+  /**
+   * All callable (impl-bound) providers whose `matches` contains the remote
+   * URL's hostname. Registration order is preserved so the first match wins.
+   * Returns `[]` for an unparseable URL (including SSH scp-style remotes).
+   */
+  listMatchingProviders(remoteUrl: string): ForgeProviderImpl[] {
+    let hostname: string;
+    try {
+      hostname = new URL(remoteUrl).hostname;
+    } catch {
+      return [];
+    }
+    const matched: ForgeProviderImpl[] = [];
+    for (const list of this.byPlugin.values()) {
+      for (const entry of list) {
+        if (entry.impl == null) continue;
+        if (entry.descriptor.matches?.includes(hostname)) {
+          matched.push(entry.impl);
+        }
+      }
+    }
+    return matched;
+  }
+
+  /**
+   * The first registered impl-bound provider matching the remote URL, or
+   * `null`. Used by remote-URL routing (PRIntegrationService rewrite, #8058
+   * step 8).
+   */
+  getActiveProvider(remoteUrl: string): ForgeProviderImpl | null {
+    return this.listMatchingProviders(remoteUrl)[0] ?? null;
+  }
+
+  /** Test-only: drop all registrations. */
+  clear(): void {
+    this.byPlugin.clear();
+  }
+}
+
+export const forgeProviderRegistry = new ForgeProviderRegistry();

--- a/electron/services/ForgeProviderRegistry.ts
+++ b/electron/services/ForgeProviderRegistry.ts
@@ -11,6 +11,19 @@ import type {
  */
 const PROVIDER_FULL_ID_RE = /^[a-z0-9][a-z0-9-]*\.[a-z0-9][a-zA-Z0-9._-]*$/;
 
+/**
+ * Strip keys whose value is `undefined` so a JS plugin passing
+ * `{ id, matches: undefined }` cannot clobber a statically-declared manifest
+ * field when the runtime descriptor is merged over the eager one.
+ */
+function definedOnly<T extends object>(obj: T): Partial<T> {
+  const out: Partial<T> = {};
+  for (const [k, v] of Object.entries(obj)) {
+    if (v !== undefined) (out as Record<string, unknown>)[k] = v;
+  }
+  return out;
+}
+
 interface RegistryEntry {
   pluginId: string;
   fullId: string;
@@ -103,9 +116,23 @@ export class ForgeProviderRegistry {
     }
     const list = this.getList(pluginId);
     let entry = list.find((e) => e.fullId === fullId);
+    if (entry && entry.impl != null) {
+      // A second register() for an already-bound provider would force two
+      // disposers to share one entry reference — disposing either silently
+      // removes the live provider. Re-registration must go through the
+      // disposer first; this keeps each disposer bound to its own entry.
+      throw new Error(
+        `Forge provider "${fullId}" is already registered. Dispose the previous ` +
+          `registration before registering it again.`
+      );
+    }
     if (entry) {
-      // Merge: runtime descriptor fields override/extend the manifest entry.
-      entry.descriptor = { ...entry.descriptor, ...descriptor, id: descriptor.id };
+      // Intended eager→lazy upgrade: bind the impl onto the manifest-declared
+      // descriptor. Runtime descriptor fields override/extend it; explicit
+      // `undefined` values must NOT clobber statically-declared manifest
+      // fields (e.g. `matches`), so they are filtered before merging. This is
+      // the only disposer for this entry (registerDescriptorOnly returns void).
+      entry.descriptor = { ...entry.descriptor, ...definedOnly(descriptor), id: descriptor.id };
       entry.impl = impl;
     } else {
       entry = { pluginId, fullId, descriptor: { ...descriptor }, impl };

--- a/electron/services/PluginService.ts
+++ b/electron/services/PluginService.ts
@@ -29,6 +29,7 @@ import {
   unregisterPluginToolbarButtons,
 } from "../../shared/config/toolbarButtonRegistry.js";
 import { registerPluginMenuItem, unregisterPluginMenuItems } from "./pluginMenuRegistry.js";
+import { forgeProviderRegistry } from "./ForgeProviderRegistry.js";
 import { broadcastToRenderer } from "../ipc/utils.js";
 import { CHANNELS } from "../ipc/channels.js";
 import type { LoadedPluginInfo } from "../../shared/types/plugin.js";
@@ -380,10 +381,18 @@ export class PluginService {
       );
     }
 
-    if (manifest.contributes.forgeProviders.length > 0) {
-      console.warn(
-        `[PluginService] Plugin "${manifest.name}": contributes.forgeProviders is not yet implemented and will be ignored`
-      );
+    // Eager (manifest-driven) registration: populates the routing table and
+    // Preferences UI before any plugin code runs. The runtime implementation
+    // binds lazily via host.registerForgeProvider during activate().
+    for (const provider of manifest.contributes.forgeProviders) {
+      try {
+        forgeProviderRegistry.registerDescriptorOnly(manifest.name, provider);
+      } catch (err) {
+        console.error(
+          `[PluginService] Plugin "${manifest.name}": invalid forge provider "${provider.id}", skipping:`,
+          err
+        );
+      }
     }
 
     // Insert the plugin into the registry BEFORE importing its main module so
@@ -509,6 +518,31 @@ export class PluginService {
           disposeUpdate();
           disposeRemove();
         };
+      },
+      registerForgeProvider: (descriptor, impl) => {
+        if (revoked) {
+          throw new Error(
+            `Plugin "${pluginId}" host revoked: registerForgeProvider called after activate() returned or timed out`
+          );
+        }
+        const dispose = forgeProviderRegistry.register(pluginId, descriptor, impl);
+        // Track via the same per-plugin cleanup list as event subscriptions so
+        // flushPluginEventCleanups() disposes it automatically on unload.
+        let list = this.pluginEventCleanups.get(pluginId);
+        if (!list) {
+          list = [];
+          this.pluginEventCleanups.set(pluginId, list);
+        }
+        const tracked = (): void => {
+          dispose();
+          const current = this.pluginEventCleanups.get(pluginId);
+          if (!current) return;
+          const idx = current.indexOf(tracked);
+          if (idx >= 0) current.splice(idx, 1);
+          if (current.length === 0) this.pluginEventCleanups.delete(pluginId);
+        };
+        list.push(tracked);
+        return tracked;
       },
     };
     return {
@@ -680,6 +714,10 @@ export class PluginService {
     this.flushPluginEventCleanups(pluginId);
     this.removeHandlers(pluginId);
     this.unregisterPluginActions(pluginId);
+    // Defensive: event-cleanup flush already disposes runtime-bound providers;
+    // this also clears manifest-only (eager) descriptors that never got an
+    // impl. Both unregisterAll and the per-registration disposer are idempotent.
+    forgeProviderRegistry.unregisterAll(pluginId);
     unregisterPluginMenuItems(pluginId);
     unregisterPluginToolbarButtons(pluginId);
     unregisterPluginPanelKinds(pluginId);

--- a/electron/services/__tests__/ForgeProviderRegistry.test.ts
+++ b/electron/services/__tests__/ForgeProviderRegistry.test.ts
@@ -61,6 +61,17 @@ describe("ForgeProviderRegistry", () => {
       expect(() => dispose()).not.toThrow();
     });
 
+    it("throws on a second register() for an already-bound provider", () => {
+      const implA = makeImpl("a");
+      const implB = makeImpl("b");
+      const d1 = registry.register("acme.gh", ghDescriptor, implA);
+      expect(() => registry.register("acme.gh", ghDescriptor, implB)).toThrow(/already registered/);
+      // The original registration is untouched and still disposable.
+      expect(registry.getActiveProvider("https://github.com/x/y")).toBe(implA);
+      d1();
+      expect(registry.getActiveProvider("https://github.com/x/y")).toBeNull();
+    });
+
     it("supports multiple providers from one plugin, first registered wins", () => {
       const a = makeImpl("a");
       const b = makeImpl("b");
@@ -83,6 +94,15 @@ describe("ForgeProviderRegistry", () => {
       registry.registerDescriptorOnly("acme.gh", ghContribution);
       // Runtime descriptor omits `matches` (declared statically in manifest).
       registry.register("acme.gh", { id: "github" }, impl);
+      expect(registry.getActiveProvider("https://github.com/a/b")).toBe(impl);
+    });
+
+    it("preserves manifest matches when register() passes an explicit undefined", () => {
+      const impl = makeImpl();
+      registry.registerDescriptorOnly("acme.gh", ghContribution);
+      // JS plugin explicitly sets matches to undefined — must not clobber the
+      // statically-declared manifest matches.
+      registry.register("acme.gh", { id: "github", matches: undefined }, impl);
       expect(registry.getActiveProvider("https://github.com/a/b")).toBe(impl);
     });
 

--- a/electron/services/__tests__/ForgeProviderRegistry.test.ts
+++ b/electron/services/__tests__/ForgeProviderRegistry.test.ts
@@ -1,0 +1,133 @@
+import { beforeEach, describe, expect, it } from "vitest";
+import { ForgeProviderRegistry } from "../ForgeProviderRegistry.js";
+import type {
+  ForgeProviderContribution,
+  ForgeProviderDescriptor,
+  ForgeProviderImpl,
+} from "../../../shared/types/forge.js";
+
+/** Minimal stub — only the fields the registry inspects are exercised. */
+function makeImpl(tag = "impl"): ForgeProviderImpl {
+  return { __tag: tag } as unknown as ForgeProviderImpl;
+}
+
+const ghContribution: ForgeProviderContribution = {
+  id: "github",
+  name: "GitHub",
+  matches: ["github.com"],
+};
+
+const ghDescriptor: ForgeProviderDescriptor = { id: "github", matches: ["github.com"] };
+
+describe("ForgeProviderRegistry", () => {
+  let registry: ForgeProviderRegistry;
+
+  beforeEach(() => {
+    registry = new ForgeProviderRegistry();
+  });
+
+  describe("register", () => {
+    it("registers a runtime provider and routes by hostname", () => {
+      const impl = makeImpl();
+      registry.register("acme.gh", ghDescriptor, impl);
+      expect(registry.getActiveProvider("https://github.com/acme/repo")).toBe(impl);
+      expect(registry.listMatchingProviders("https://github.com/acme/repo")).toEqual([impl]);
+    });
+
+    it("rejects an empty descriptor id", () => {
+      expect(() =>
+        registry.register("acme.gh", { id: "" } as ForgeProviderDescriptor, makeImpl())
+      ).toThrow(/non-empty string/);
+    });
+
+    it("rejects a composed id that violates the id pattern", () => {
+      // pluginId starting with an uppercase letter cannot form a valid full id.
+      expect(() => registry.register("Acme", ghDescriptor, makeImpl())).toThrow(/is invalid/);
+    });
+
+    it("rejects a non-object implementation", () => {
+      expect(() =>
+        registry.register("acme.gh", ghDescriptor, null as unknown as ForgeProviderImpl)
+      ).toThrow(/must be an object/);
+    });
+
+    it("returns an idempotent disposer that removes only its registration", () => {
+      const impl = makeImpl();
+      const dispose = registry.register("acme.gh", ghDescriptor, impl);
+      expect(registry.getActiveProvider("https://github.com/x/y")).toBe(impl);
+      dispose();
+      expect(registry.getActiveProvider("https://github.com/x/y")).toBeNull();
+      // Second call is a no-op and must not throw.
+      expect(() => dispose()).not.toThrow();
+    });
+
+    it("supports multiple providers from one plugin, first registered wins", () => {
+      const a = makeImpl("a");
+      const b = makeImpl("b");
+      registry.register("acme.multi", { id: "a", matches: ["git.example.com"] }, a);
+      registry.register("acme.multi", { id: "b", matches: ["git.example.com"] }, b);
+      expect(registry.listMatchingProviders("https://git.example.com/o/r")).toEqual([a, b]);
+      expect(registry.getActiveProvider("https://git.example.com/o/r")).toBe(a);
+    });
+  });
+
+  describe("registerDescriptorOnly", () => {
+    it("registers a manifest descriptor with no callable impl", () => {
+      registry.registerDescriptorOnly("acme.gh", ghContribution);
+      expect(registry.listMatchingProviders("https://github.com/a/b")).toEqual([]);
+      expect(registry.getActiveProvider("https://github.com/a/b")).toBeNull();
+    });
+
+    it("is upgraded in place by a later register() call, preserving manifest matches", () => {
+      const impl = makeImpl();
+      registry.registerDescriptorOnly("acme.gh", ghContribution);
+      // Runtime descriptor omits `matches` (declared statically in manifest).
+      registry.register("acme.gh", { id: "github" }, impl);
+      expect(registry.getActiveProvider("https://github.com/a/b")).toBe(impl);
+    });
+
+    it("does not duplicate when the manifest entry is re-registered", () => {
+      registry.registerDescriptorOnly("acme.gh", ghContribution);
+      registry.registerDescriptorOnly("acme.gh", ghContribution);
+      const impl = makeImpl();
+      registry.register("acme.gh", { id: "github" }, impl);
+      expect(registry.listMatchingProviders("https://github.com/a/b")).toEqual([impl]);
+    });
+  });
+
+  describe("unregisterAll", () => {
+    it("removes every provider owned by a plugin", () => {
+      registry.register("acme.gh", ghDescriptor, makeImpl());
+      registry.unregisterAll("acme.gh");
+      expect(registry.getActiveProvider("https://github.com/a/b")).toBeNull();
+    });
+
+    it("is idempotent and silent for an unknown plugin", () => {
+      expect(() => registry.unregisterAll("nobody.here")).not.toThrow();
+    });
+  });
+
+  describe("listMatchingProviders", () => {
+    it("returns [] for an unparseable / SSH scp-style remote", () => {
+      registry.register("acme.gh", ghDescriptor, makeImpl());
+      expect(registry.listMatchingProviders("git@github.com:acme/repo.git")).toEqual([]);
+      expect(registry.listMatchingProviders("not a url")).toEqual([]);
+    });
+
+    it("excludes descriptor-only (null-impl) entries", () => {
+      registry.registerDescriptorOnly("acme.gh", ghContribution);
+      expect(registry.listMatchingProviders("https://github.com/a/b")).toEqual([]);
+    });
+
+    it("does not match a different hostname", () => {
+      registry.register("acme.gh", ghDescriptor, makeImpl());
+      expect(registry.listMatchingProviders("https://gitlab.com/a/b")).toEqual([]);
+    });
+  });
+
+  it("clear() drops all registrations", () => {
+    registry.register("acme.gh", ghDescriptor, makeImpl());
+    registry.clear();
+    expect(registry.getActiveProvider("https://github.com/a/b")).toBeNull();
+  });
+});

--- a/electron/services/__tests__/PluginService.integration.test.ts
+++ b/electron/services/__tests__/PluginService.integration.test.ts
@@ -56,6 +56,7 @@ import {
   getToolbarButtonConfig,
 } from "../../../shared/config/toolbarButtonRegistry.js";
 import { clearPluginMenuRegistry, getPluginMenuItems } from "../pluginMenuRegistry.js";
+import { forgeProviderRegistry } from "../ForgeProviderRegistry.js";
 
 function makeCtx(pluginId: string, overrides: Partial<PluginIpcContext> = {}): PluginIpcContext {
   return {
@@ -76,6 +77,7 @@ type PluginManifestShape = {
     panels?: unknown[];
     toolbarButtons?: unknown[];
     menuItems?: unknown[];
+    forgeProviders?: unknown[];
   };
 };
 
@@ -120,6 +122,7 @@ afterEach(async () => {
     clearPanelKindRegistry();
     clearToolbarButtonRegistry();
     clearPluginMenuRegistry();
+    forgeProviderRegistry.clear();
     storeState.clear();
     for (const key of globalMarkers) {
       delete (globalThis as Record<string, unknown>)[key];
@@ -889,5 +892,118 @@ describe("PluginService integration — built-in plugin loading", () => {
     } finally {
       errorSpy.mockRestore();
     }
+  });
+});
+
+describe("PluginService integration — forge provider contributions", () => {
+  async function writeForgeActivateFixture(pluginDir: string): Promise<string> {
+    const fileName = `forge-activate-${randomUUID()}.mjs`;
+    await fs.writeFile(
+      path.join(pluginDir, fileName),
+      `export function activate(host) {
+  const impl = {
+    parseRemote: () => null,
+    getCredentials: async () => null,
+    validateCredentials: async () => ({ valid: false }),
+    listIssues: async () => ({ items: [], nextCursor: null, hasMore: false }),
+    listPRs: async () => ({ items: [], nextCursor: null, hasMore: false }),
+    getIssue: async () => null,
+    getPR: async () => null,
+    findPRByBranch: async () => null,
+    getCIStatus: async () => null,
+    getRepoMetadata: async () => ({ defaultBranch: "main", isPrivate: false, isFork: false, isArchived: false, rawData: null }),
+    buildIssueUrl: () => "",
+    buildPRUrl: () => "",
+  };
+  host.registerForgeProvider({ id: "gh" }, impl);
+}
+`
+    );
+    return fileName;
+  }
+
+  it("registers a manifest forge provider eagerly without the 'not implemented' warning", async () => {
+    const warnSpy = vi.spyOn(console, "warn").mockImplementation(() => {});
+    try {
+      await writePlugin("acme.forge-eager", {
+        name: "acme.forge-eager",
+        version: "1.0.0",
+        contributes: {
+          forgeProviders: [{ id: "gh", name: "GitHub", matches: ["github.com"] }],
+        },
+      });
+
+      const service = new PluginService(tmpDir, "0.0.0");
+      await service.initialize();
+
+      // Descriptor is registered (routing table populated) but not callable
+      // until activate() binds an impl.
+      expect(forgeProviderRegistry.getActiveProvider("https://github.com/o/r")).toBeNull();
+      expect(service.hasPlugin("acme.forge-eager")).toBe(true);
+      expect(
+        warnSpy.mock.calls.some((c) =>
+          String(c[0]).includes("forgeProviders is not yet implemented")
+        )
+      ).toBe(false);
+    } finally {
+      warnSpy.mockRestore();
+    }
+  });
+
+  it("binds the runtime impl via host.registerForgeProvider and routes by hostname", async () => {
+    const pluginDir = await writePlugin("acme.forge-impl", {
+      name: "acme.forge-impl",
+      version: "1.0.0",
+      contributes: {
+        forgeProviders: [{ id: "gh", name: "GitHub", matches: ["github.com"] }],
+      },
+    });
+    const mainFile = await writeForgeActivateFixture(pluginDir);
+    await fs.writeFile(
+      path.join(pluginDir, "plugin.json"),
+      JSON.stringify({
+        name: "acme.forge-impl",
+        version: "1.0.0",
+        main: mainFile,
+        contributes: {
+          forgeProviders: [{ id: "gh", name: "GitHub", matches: ["github.com"] }],
+        },
+      })
+    );
+
+    const service = new PluginService(tmpDir, "0.0.0");
+    await service.initialize();
+
+    // Eager manifest matches merge with the lazily-bound impl.
+    expect(forgeProviderRegistry.getActiveProvider("https://github.com/o/r")).not.toBeNull();
+  });
+
+  it("unregisters the provider on plugin unload", async () => {
+    const pluginDir = await writePlugin("acme.forge-unload", {
+      name: "acme.forge-unload",
+      version: "1.0.0",
+      contributes: {
+        forgeProviders: [{ id: "gh", name: "GitHub", matches: ["github.com"] }],
+      },
+    });
+    const mainFile = await writeForgeActivateFixture(pluginDir);
+    await fs.writeFile(
+      path.join(pluginDir, "plugin.json"),
+      JSON.stringify({
+        name: "acme.forge-unload",
+        version: "1.0.0",
+        main: mainFile,
+        contributes: {
+          forgeProviders: [{ id: "gh", name: "GitHub", matches: ["github.com"] }],
+        },
+      })
+    );
+
+    const service = new PluginService(tmpDir, "0.0.0");
+    await service.initialize();
+    expect(forgeProviderRegistry.getActiveProvider("https://github.com/o/r")).not.toBeNull();
+
+    service.unloadPlugin("acme.forge-unload");
+    expect(forgeProviderRegistry.getActiveProvider("https://github.com/o/r")).toBeNull();
   });
 });

--- a/electron/services/__tests__/PluginService.integration.test.ts
+++ b/electron/services/__tests__/PluginService.integration.test.ts
@@ -1006,4 +1006,24 @@ describe("PluginService integration — forge provider contributions", () => {
     service.unloadPlugin("acme.forge-unload");
     expect(forgeProviderRegistry.getActiveProvider("https://github.com/o/r")).toBeNull();
   });
+
+  it("unregisters an eager descriptor-only provider on unload (no activate)", async () => {
+    await writePlugin("acme.forge-eager-unload", {
+      name: "acme.forge-eager-unload",
+      version: "1.0.0",
+      contributes: {
+        forgeProviders: [{ id: "gh", name: "GitHub", matches: ["github.com"] }],
+      },
+    });
+
+    const service = new PluginService(tmpDir, "0.0.0");
+    await service.initialize();
+    expect(service.hasPlugin("acme.forge-eager-unload")).toBe(true);
+
+    service.unloadPlugin("acme.forge-eager-unload");
+    // The defensive unregisterAll() in unloadPlugin clears descriptor-only
+    // entries that never had an impl bound (flushPluginEventCleanups alone
+    // would miss them — no host disposer was ever created).
+    expect(forgeProviderRegistry.listMatchingProviders("https://github.com/o/r")).toEqual([]);
+  });
 });

--- a/electron/services/__tests__/PluginService.test.ts
+++ b/electron/services/__tests__/PluginService.test.ts
@@ -1442,6 +1442,7 @@ type CreateHostShape = (pluginId: string) => {
     pluginId: string;
     registerHandler: (channel: string, handler: (...args: unknown[]) => unknown) => void;
     broadcastToRenderer: (channel: string, payload: unknown) => void;
+    registerForgeProvider: (descriptor: { id: string }, impl: unknown) => () => void;
   };
   revoke: () => void;
 };
@@ -1512,6 +1513,9 @@ describe("createHost (plugin activation API)", () => {
       /host revoked: registerHandler/
     );
     expect(() => host.broadcastToRenderer("x", null)).toThrow(/host revoked: broadcastToRenderer/);
+    expect(() => host.registerForgeProvider({ id: "gh" }, {})).toThrow(
+      /host revoked: registerForgeProvider/
+    );
   });
 });
 

--- a/electron/services/__tests__/PluginService.test.ts
+++ b/electron/services/__tests__/PluginService.test.ts
@@ -58,6 +58,7 @@ import {
   unregisterPluginToolbarButtons,
 } from "../../../shared/config/toolbarButtonRegistry.js";
 import { registerPluginMenuItem, unregisterPluginMenuItems } from "../pluginMenuRegistry.js";
+import { forgeProviderRegistry } from "../ForgeProviderRegistry.js";
 import { CHANNELS } from "../../ipc/channels.js";
 
 function makeCtx(pluginId: string, overrides: Partial<PluginIpcContext> = {}): PluginIpcContext {
@@ -2216,16 +2217,11 @@ describe("Plugin worktree host API", () => {
       "id",
       "isCurrent",
       "isMainWorktree",
-      "issueNumber",
-      "issueTitle",
       "lastActivityTimestamp",
+      "linked",
       "mood",
       "name",
       "path",
-      "prNumber",
-      "prState",
-      "prTitle",
-      "prUrl",
       "worktreeId",
     ];
     expect(Object.keys(active).sort()).toEqual(expected);
@@ -2300,7 +2296,7 @@ describe("reserved contribution point warnings", () => {
     );
   });
 
-  it("accepts a contributes.forgeProviders entry and logs a 'not yet implemented' warning", async () => {
+  it("registers a contributes.forgeProviders entry eagerly without a 'not implemented' warning", async () => {
     await writePlugin("forge", {
       name: "acme.forge",
       version: "1.0.0",
@@ -2319,19 +2315,25 @@ describe("reserved contribution point warnings", () => {
       },
     });
 
-    const service = new PluginService(tmpDir, "0.7.5");
-    await service.initialize();
+    try {
+      const service = new PluginService(tmpDir, "0.7.5");
+      await service.initialize();
 
-    expect(service.listPlugins()).toHaveLength(1);
-    expect(warnSpy).toHaveBeenCalledWith(
-      expect.stringContaining(
-        'Plugin "acme.forge": contributes.forgeProviders is not yet implemented'
-      )
-    );
-    // Reserved + ignored: a forge-only manifest has no registry side effects.
-    expect(registerPanelKind).not.toHaveBeenCalled();
-    expect(registerToolbarButton).not.toHaveBeenCalled();
-    expect(registerPluginMenuItem).not.toHaveBeenCalled();
+      expect(service.listPlugins()).toHaveLength(1);
+      const warnMessages = warnSpy.mock.calls.map((call: unknown[]) => String(call[0]));
+      expect(
+        warnMessages.some((m: string) => m.includes("contributes.forgeProviders is not yet"))
+      ).toBe(false);
+      // Eager: the descriptor is recorded but not callable until activate()
+      // binds an impl, so the routing table reports no active provider yet.
+      expect(forgeProviderRegistry.getActiveProvider("https://github.com/o/r")).toBeNull();
+      // Forge-only manifest still has no panel/toolbar/menu side effects.
+      expect(registerPanelKind).not.toHaveBeenCalled();
+      expect(registerToolbarButton).not.toHaveBeenCalled();
+      expect(registerPluginMenuItem).not.toHaveBeenCalled();
+    } finally {
+      forgeProviderRegistry.clear();
+    }
   });
 
   it("does not warn about reserved points when the manifest omits them", async () => {

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "daintree",
   "productName": "Daintree",
-  "version": "0.11.1",
+  "version": "0.12.0",
   "description": "Daintree IDE - An Electron-based development environment",
   "license": "Apache-2.0",
   "author": {

--- a/shared/types/forge.ts
+++ b/shared/types/forge.ts
@@ -339,7 +339,12 @@ export interface ForgeProviderContribution {
   id: string;
   /** Display label in Preferences → Forge Integrations. */
   name: string;
-  /** Hostname or glob patterns for git remote URLs; first matching provider wins. */
+  /**
+   * Git-remote hostnames this provider handles; the first registered provider
+   * whose list contains a remote's hostname wins. Exact-hostname matching only
+   * at this stage — glob patterns are reserved for later work. SSH scp-style
+   * remotes must be normalized to HTTPS before routing.
+   */
   matches: string[];
   /** Informational capability hints; the host does not interpret these. */
   capabilities?: ForgeCapabilityHint[];

--- a/shared/types/plugin.ts
+++ b/shared/types/plugin.ts
@@ -1,4 +1,10 @@
-import type { ForgeProviderContribution } from "./forge.js";
+import type {
+  ForgeProviderContribution,
+  ForgeProviderDescriptor,
+  ForgeProviderImpl,
+  NormalizedPRState,
+  ResourceRef,
+} from "./forge.js";
 
 export interface PanelContribution {
   id: string;
@@ -138,12 +144,23 @@ export interface PluginWorktreeSnapshot {
   readonly isMainWorktree?: boolean;
   readonly aheadCount?: number;
   readonly behindCount?: number;
-  readonly issueNumber?: number;
-  readonly issueTitle?: string;
-  readonly prNumber?: number;
-  readonly prUrl?: string;
-  readonly prState?: "open" | "merged" | "closed";
-  readonly prTitle?: string;
+  /**
+   * Provider-agnostic branch→forge linkage. Replaces the GitHub-shaped
+   * `issueNumber`/`prNumber`/`prUrl`/`prState`/… fields removed in the
+   * forge-provider abstraction. `null` when the worktree is not linked to a
+   * forge resource (or no provider has resolved the linkage yet). See
+   * `docs/architecture/forge-provider-abstraction.md`.
+   */
+  readonly linked: {
+    readonly providerId: string;
+    readonly issue?: { readonly ref: ResourceRef; readonly title?: string };
+    readonly pr?: {
+      readonly ref: ResourceRef;
+      readonly title?: string;
+      readonly url: string;
+      readonly state: NormalizedPRState;
+    };
+  } | null;
   readonly mood?: "stable" | "active" | "stale" | "error";
   readonly lastActivityTimestamp?: number | null;
   readonly createdAt?: number;
@@ -178,6 +195,15 @@ export interface PluginHostApi {
    * disposed when the plugin is unloaded.
    */
   onDidChangeWorktrees(callback: (snapshots: PluginWorktreeSnapshot[]) => void): () => void;
+  /**
+   * Register a forge provider implementation. Call from `activate(host)`.
+   * `descriptor` mirrors the plugin's `forgeProviders` manifest entry; fields
+   * already declared statically in `plugin.json` may be omitted (only `id` is
+   * required). The provider is namespaced at runtime as `{pluginId}.{id}`.
+   * Returns a disposer; calling it more than once is a no-op. The provider is
+   * automatically unregistered when the plugin is unloaded.
+   */
+  registerForgeProvider(descriptor: ForgeProviderDescriptor, impl: ForgeProviderImpl): () => void;
 }
 
 export type PluginActivate = (

--- a/shared/utils/__tests__/pluginWorktreeSnapshot.test.ts
+++ b/shared/utils/__tests__/pluginWorktreeSnapshot.test.ts
@@ -1,0 +1,72 @@
+import { describe, expect, it } from "vitest";
+import { toPluginWorktreeSnapshot } from "../pluginWorktreeSnapshot.js";
+import type { WorktreeSnapshot } from "../../types/workspace-host.js";
+
+function makeSnapshot(overrides: Partial<WorktreeSnapshot> = {}): WorktreeSnapshot {
+  return {
+    id: "wt-1",
+    worktreeId: "wt-1",
+    path: "/repo/wt-1",
+    name: "feature-x",
+    isCurrent: true,
+    branch: "feature/x",
+    isMainWorktree: false,
+    aheadCount: 2,
+    behindCount: 0,
+    mood: "active",
+    lastActivityTimestamp: 1234,
+    createdAt: 1000,
+    // GitHub-shaped fields still live on the INTERNAL snapshot — the
+    // projection must NOT leak them onto PluginWorktreeSnapshot.
+    issueNumber: 42,
+    issueTitle: "Some issue",
+    prNumber: 7,
+    prUrl: "https://github.com/o/r/pull/7",
+    prState: "open",
+    prTitle: "Some PR",
+    ...overrides,
+  } as WorktreeSnapshot;
+}
+
+describe("toPluginWorktreeSnapshot", () => {
+  it("projects identity fields and freezes the result", () => {
+    const out = toPluginWorktreeSnapshot(makeSnapshot());
+    expect(out.id).toBe("wt-1");
+    expect(out.worktreeId).toBe("wt-1");
+    expect(out.path).toBe("/repo/wt-1");
+    expect(out.name).toBe("feature-x");
+    expect(out.isCurrent).toBe(true);
+    expect(out.branch).toBe("feature/x");
+    expect(out.aheadCount).toBe(2);
+    expect(out.mood).toBe("active");
+    expect(Object.isFrozen(out)).toBe(true);
+  });
+
+  it("does not leak the removed GitHub-shaped fields", () => {
+    const out = toPluginWorktreeSnapshot(makeSnapshot()) as unknown as Record<string, unknown>;
+    for (const k of ["issueNumber", "issueTitle", "prNumber", "prUrl", "prState", "prTitle"]) {
+      expect(out).not.toHaveProperty(k);
+    }
+  });
+
+  it("sets `linked` to null (provider routing not yet wired)", () => {
+    expect(toPluginWorktreeSnapshot(makeSnapshot()).linked).toBeNull();
+    // Even when the internal snapshot carries no PR/issue data at all.
+    const bare = toPluginWorktreeSnapshot(
+      makeSnapshot({
+        issueNumber: undefined,
+        issueTitle: undefined,
+        prNumber: undefined,
+        prUrl: undefined,
+        prState: undefined,
+        prTitle: undefined,
+      })
+    );
+    expect(bare.linked).toBeNull();
+  });
+
+  it("normalizes a missing lastActivityTimestamp to null", () => {
+    const out = toPluginWorktreeSnapshot(makeSnapshot({ lastActivityTimestamp: undefined }));
+    expect(out.lastActivityTimestamp).toBeNull();
+  });
+});

--- a/shared/utils/__tests__/pluginWorktreeSnapshot.test.ts
+++ b/shared/utils/__tests__/pluginWorktreeSnapshot.test.ts
@@ -49,6 +49,25 @@ describe("toPluginWorktreeSnapshot", () => {
     }
   });
 
+  it("projects exactly the documented allowlist keys", () => {
+    const out = toPluginWorktreeSnapshot(makeSnapshot());
+    expect(Object.keys(out).sort()).toEqual([
+      "aheadCount",
+      "behindCount",
+      "branch",
+      "createdAt",
+      "id",
+      "isCurrent",
+      "isMainWorktree",
+      "lastActivityTimestamp",
+      "linked",
+      "mood",
+      "name",
+      "path",
+      "worktreeId",
+    ]);
+  });
+
   it("sets `linked` to null (provider routing not yet wired)", () => {
     expect(toPluginWorktreeSnapshot(makeSnapshot()).linked).toBeNull();
     // Even when the internal snapshot carries no PR/issue data at all.

--- a/shared/utils/pluginWorktreeSnapshot.ts
+++ b/shared/utils/pluginWorktreeSnapshot.ts
@@ -19,12 +19,12 @@ export function toPluginWorktreeSnapshot(snapshot: WorktreeSnapshot): PluginWork
     isMainWorktree: snapshot.isMainWorktree,
     aheadCount: snapshot.aheadCount,
     behindCount: snapshot.behindCount,
-    issueNumber: snapshot.issueNumber,
-    issueTitle: snapshot.issueTitle,
-    prNumber: snapshot.prNumber,
-    prUrl: snapshot.prUrl,
-    prState: snapshot.prState,
-    prTitle: snapshot.prTitle,
+    // `linked` is provider-routed. The internal WorktreeSnapshot does not yet
+    // carry provider identity (providerId/owner/repo), so there is nothing to
+    // project here without coupling this allowlist to GitHub's URL shape.
+    // Stays `null` until the ForgeProviderRegistry resolves linkage and
+    // PRIntegrationService populates it (see forge-provider-abstraction.md).
+    linked: null,
     mood: snapshot.mood,
     lastActivityTimestamp: snapshot.lastActivityTimestamp ?? null,
     createdAt: snapshot.createdAt,


### PR DESCRIPTION
## Summary

- Adds `ForgeProviderRegistry` singleton (fulfills #8057): eager manifest registration, lazy implementation binding, exact-hostname routing, and idempotent disposers with a defensive `unregisterAll` on plugin unload
- Adds `registerForgeProvider(descriptor, impl)` to `PluginHostApi`, wired through `PluginService.createHost` with a revocation guard and auto-disposal via `pluginEventCleanups`; eager registration replaces the old "not yet implemented" warning
- **Breaking SDK change:** replaces six GitHub-shaped `PluginWorktreeSnapshot` fields (`issueNumber`, `issueTitle`, `prNumber`, `prUrl`, `prState`, `prTitle`) with a single provider-agnostic `linked` field (`ResourceRef | NormalizedPRState`); stays `null` until forge routing lands in step 8 (PRIntegrationService rewrite)

Resolves #8058

## Changes

- `electron/services/ForgeProviderRegistry.ts` — new singleton; 153-line test suite in `__tests__/ForgeProviderRegistry.test.ts`
- `electron/services/PluginService.ts` — `registerForgeProvider` wired into host factory; 136-line integration test suite added
- `shared/types/plugin.ts` — `PluginHostApi` updated; `PluginWorktreeSnapshot` breaking field swap
- `shared/types/forge.ts` — `ResourceRef` / `NormalizedPRState` additions
- `shared/utils/pluginWorktreeSnapshot.ts` — snapshot builder updated; 91-line test suite covering the new shape
- `package.json` — version `0.11.1` → `0.12.0`
- `CHANGELOG.md` — breaking change + feature notes; plugins must declare `engines.daintree ^0.11.0` or lower to be gated out

## Testing

186 unit tests + 28 integration tests pass. Typecheck, lint (-8 warnings, all pre-existing), format, and production build all clean.