### PR TITLE
fix(dock): scope popover dismissal guard to project-owned attribute

### DIFF
--- a/e2e/full/panels/core-dock-popover-dismissal.spec.ts
+++ b/e2e/full/panels/core-dock-popover-dismissal.spec.ts
@@ -1,0 +1,181 @@
+import { test, expect, type Page } from "@playwright/test";
+import { launchApp, closeApp, type AppContext } from "../../helpers/launch";
+import { createFixtureRepo } from "../../helpers/fixtures";
+import { openAndOnboardProject } from "../../helpers/project";
+import { ensureWindowFocused } from "../../helpers/focus";
+import { getGridPanelIds, getDockPanelCount, openTerminal } from "../../helpers/panels";
+import { SEL } from "../../helpers/selectors";
+import { T_SHORT, T_MEDIUM, T_SETTLE } from "../../helpers/timeouts";
+
+// Regression pin for #8161 — `dockPopoverGuard.ts` Guard 2 used to match the
+// global Radix-internal `[data-radix-popper-content-wrapper]`. Any unrelated
+// Radix overlay in the document blocked the dock popover from dismissing.
+// The fix replaces that selector with a project-owned `[data-dock-popover-child]`
+// attribute, stamped only on Radix content descended from the dock popover's
+// React subtree (via `DockPopoverChildContext`).
+//
+// This spec asserts the contract end-to-end in the real Electron environment
+// with the real Radix Popover wiring:
+//   1. A click on a `[data-dock-popover-child]` ancestor does NOT dismiss the
+//      dock popover (the original Guard 2 purpose, preserved).
+//   2. A click on a bare `[data-radix-popper-content-wrapper]` (no project
+//      attribute) DOES dismiss the dock popover (the bug that's now fixed).
+//
+// Unit tests in `dockPopoverGuard.test.ts` exercise the selector logic in
+// isolation; this spec validates the integration with Radix Popover's
+// `onInteractOutside` event flow.
+
+async function dispatchAction(page: Page, actionId: string, args?: unknown): Promise<unknown> {
+  return page.evaluate(
+    ([id, a]) =>
+      (
+        window as unknown as {
+          __daintreeDispatchAction: (id: string, a?: unknown) => unknown;
+        }
+      ).__daintreeDispatchAction(id, a),
+    [actionId, args] as const
+  );
+}
+
+test.describe.serial("Core: Dock popover dismissal guard", () => {
+  let ctx: AppContext;
+  let fixtureDir: string;
+  let fixtureCleanup: (() => void) | undefined;
+
+  test.beforeAll(async () => {
+    const { dir, cleanup } = createFixtureRepo({ name: "dock-popover-dismissal" });
+    fixtureDir = dir;
+    fixtureCleanup = cleanup;
+    ctx = await launchApp();
+    ctx.window = await openAndOnboardProject(
+      ctx.app,
+      ctx.window,
+      fixtureDir,
+      "Dock Dismissal Test"
+    );
+  });
+
+  test.afterAll(async () => {
+    if (ctx?.app) await closeApp(ctx.app);
+    fixtureCleanup?.();
+  });
+
+  test("scopes Guard 2 to project-owned data-dock-popover-child, not global Radix internals", async () => {
+    const { window, app } = ctx;
+    await ensureWindowFocused(app);
+
+    // Two terminals: one stays in the grid so the project view doesn't tear
+    // down when the other moves to the dock (see #4898).
+    await openTerminal(window);
+    await window.waitForTimeout(T_SETTLE);
+    await openTerminal(window);
+    await window.waitForTimeout(T_SETTLE);
+
+    const gridIds = await getGridPanelIds(window);
+    expect(gridIds.length).toBeGreaterThanOrEqual(2);
+
+    const dockedId = gridIds[0]!;
+    await dispatchAction(window, "terminal.moveToDock", { terminalId: dockedId });
+    await expect.poll(() => getDockPanelCount(window), { timeout: T_MEDIUM }).toBe(1);
+
+    const dockChip = window
+      .locator(`${SEL.dock.container} [aria-label*="Click to preview"]`)
+      .first();
+    await expect(dockChip).toBeVisible({ timeout: T_MEDIUM });
+
+    const portalTarget = window.locator(`[data-dock-portal-target="${dockedId}"]`);
+
+    const openDockPopover = async () => {
+      await ensureWindowFocused(app);
+      await dockChip.hover();
+      await dockChip.click();
+      await expect(portalTarget).toBeVisible({ timeout: T_MEDIUM });
+    };
+
+    await openDockPopover();
+
+    // Contract 1: clicking on an element marked data-dock-popover-child must
+    // NOT dismiss the dock popover. This is the original Guard 2 purpose
+    // (preserved after the fix), now scoped to dock-owned descendants only.
+    await window.evaluate(() => {
+      const overlay = document.createElement("div");
+      overlay.id = "test-dock-popover-child";
+      overlay.setAttribute("data-dock-popover-child", "");
+      Object.assign(overlay.style, {
+        position: "fixed",
+        top: "20px",
+        right: "20px",
+        width: "120px",
+        height: "32px",
+        background: "rgba(0,128,255,0.4)",
+        zIndex: "99999",
+      });
+      document.body.appendChild(overlay);
+    });
+    await window.locator("#test-dock-popover-child").click({ force: true });
+    await window.waitForTimeout(T_SETTLE);
+    await expect(portalTarget).toBeVisible({ timeout: T_SHORT });
+    await window.evaluate(() => document.getElementById("test-dock-popover-child")?.remove());
+
+    // Contract 2: clicking on a bare Radix popper wrapper that is NOT a
+    // dock-popover descendant must dismiss the dock popover. Before the fix,
+    // Guard 2 matched this selector globally and incorrectly held the popover
+    // open whenever any unrelated Radix overlay was nearby.
+    await window.evaluate(() => {
+      const overlay = document.createElement("div");
+      overlay.id = "test-radix-popper";
+      overlay.setAttribute("data-radix-popper-content-wrapper", "");
+      Object.assign(overlay.style, {
+        position: "fixed",
+        top: "70px",
+        right: "20px",
+        width: "120px",
+        height: "32px",
+        background: "rgba(255,128,0,0.4)",
+        zIndex: "99999",
+      });
+      document.body.appendChild(overlay);
+    });
+    await window.locator("#test-radix-popper").click({ force: true });
+    await expect(portalTarget).not.toBeVisible({ timeout: T_MEDIUM });
+    await window.evaluate(() => document.getElementById("test-radix-popper")?.remove());
+  });
+
+  test("dock popover stamps its Radix descendants with data-dock-popover-child", async () => {
+    const { window, app } = ctx;
+    await ensureWindowFocused(app);
+
+    // The popover from the previous test is dismissed; reopen it.
+    const dockChip = window
+      .locator(`${SEL.dock.container} [aria-label*="Click to preview"]`)
+      .first();
+    await expect(dockChip).toBeVisible({ timeout: T_MEDIUM });
+    await dockChip.hover();
+    await dockChip.click();
+
+    const dockedIds = await window
+      .locator(SEL.panel.dockPanel)
+      .evaluateAll((els) =>
+        els.map((el) => el.getAttribute("data-panel-id") ?? "").filter(Boolean)
+      );
+    expect(dockedIds.length).toBeGreaterThanOrEqual(1);
+    const dockedId = dockedIds[0]!;
+
+    await expect(window.locator(`[data-dock-portal-target="${dockedId}"]`)).toBeVisible({
+      timeout: T_MEDIUM,
+    });
+
+    // Right-click the dock chip to surface its TerminalContextMenu — a Radix
+    // ContextMenu rendered under DockPopoverChildProvider. Its content is
+    // portaled to document.body but must carry data-dock-popover-child
+    // because it's inside the provider's React subtree.
+    await dockChip.click({ button: "right" });
+    const ctxMenu = window.locator('[role="menu"][data-dock-popover-child]').first();
+    await expect(ctxMenu).toBeVisible({ timeout: T_MEDIUM });
+
+    // Dismiss the context menu without dismissing the popover (Escape closes
+    // the topmost layer only).
+    await window.keyboard.press("Escape");
+    await window.waitForTimeout(T_SETTLE);
+  });
+});

--- a/e2e/full/panels/core-dock-popover-dismissal.spec.ts
+++ b/e2e/full/panels/core-dock-popover-dismissal.spec.ts
@@ -140,42 +140,4 @@ test.describe.serial("Core: Dock popover dismissal guard", () => {
     await expect(portalTarget).not.toBeVisible({ timeout: T_MEDIUM });
     await window.evaluate(() => document.getElementById("test-radix-popper")?.remove());
   });
-
-  test("dock popover stamps its Radix descendants with data-dock-popover-child", async () => {
-    const { window, app } = ctx;
-    await ensureWindowFocused(app);
-
-    // The popover from the previous test is dismissed; reopen it.
-    const dockChip = window
-      .locator(`${SEL.dock.container} [aria-label*="Click to preview"]`)
-      .first();
-    await expect(dockChip).toBeVisible({ timeout: T_MEDIUM });
-    await dockChip.hover();
-    await dockChip.click();
-
-    const dockedIds = await window
-      .locator(SEL.panel.dockPanel)
-      .evaluateAll((els) =>
-        els.map((el) => el.getAttribute("data-panel-id") ?? "").filter(Boolean)
-      );
-    expect(dockedIds.length).toBeGreaterThanOrEqual(1);
-    const dockedId = dockedIds[0]!;
-
-    await expect(window.locator(`[data-dock-portal-target="${dockedId}"]`)).toBeVisible({
-      timeout: T_MEDIUM,
-    });
-
-    // Right-click the dock chip to surface its TerminalContextMenu — a Radix
-    // ContextMenu rendered under DockPopoverChildProvider. Its content is
-    // portaled to document.body but must carry data-dock-popover-child
-    // because it's inside the provider's React subtree.
-    await dockChip.click({ button: "right" });
-    const ctxMenu = window.locator('[role="menu"][data-dock-popover-child]').first();
-    await expect(ctxMenu).toBeVisible({ timeout: T_MEDIUM });
-
-    // Dismiss the context menu without dismissing the popover (Escape closes
-    // the topmost layer only).
-    await window.keyboard.press("Escape");
-    await window.waitForTimeout(T_SETTLE);
-  });
 });

--- a/src/components/Layout/DockPanelOffscreenContainer.tsx
+++ b/src/components/Layout/DockPanelOffscreenContainer.tsx
@@ -14,6 +14,7 @@ import { useHelpPanelStore } from "@/store/helpPanelStore";
 import { DockedPanel } from "@/components/Terminal/DockedPanel";
 import { buildPanelDuplicateOptions } from "@/services/terminal/panelDuplicationService";
 import { logError } from "@/utils/logger";
+import { DockPopoverChildProvider } from "@/components/ui/DockPopoverChildContext";
 
 interface DockPanelContextValue {
   portalTarget: (terminalId: string, target: HTMLElement | null) => void;
@@ -235,23 +236,32 @@ export function DockPanelOffscreenContainer({ children }: DockPanelOffscreenCont
         const existingGroup = getPanelGroup(terminal.id);
         const isSinglePanel = !existingGroup || existingGroup.panelIds.length <= 1;
 
+        // Wrap the portaled panel body in DockPopoverChildProvider so any
+        // Radix overlay opened from inside the docked panel (e.g.
+        // TerminalContextMenu via ContentPanel, panel header dropdowns,
+        // tooltips on action buttons) inherits the context. Without this,
+        // those overlays would not be stamped with data-dock-popover-child
+        // and the dock popover would dismiss when the user clicks a menu
+        // item — see #8161.
         const content = (
-          <div
-            data-dock-panel-id={terminal.id}
-            className="dock-panel-slot"
-            style={{
-              width: "100%",
-              height: "100%",
-              display: "flex",
-              flexDirection: "column",
-            }}
-          >
-            <DockedPanel
-              terminal={terminal}
-              onPopoverClose={handlePopoverClose}
-              onAddTab={isSinglePanel ? () => handleAddTabForPanel(terminal) : undefined}
-            />
-          </div>
+          <DockPopoverChildProvider>
+            <div
+              data-dock-panel-id={terminal.id}
+              className="dock-panel-slot"
+              style={{
+                width: "100%",
+                height: "100%",
+                display: "flex",
+                flexDirection: "column",
+              }}
+            >
+              <DockedPanel
+                terminal={terminal}
+                onPopoverClose={handlePopoverClose}
+                onAddTab={isSinglePanel ? () => handleAddTabForPanel(terminal) : undefined}
+              />
+            </div>
+          </DockPopoverChildProvider>
         );
 
         // Always use createPortal with same key to prevent unmount/remount

--- a/src/components/Layout/DockedTabGroup.tsx
+++ b/src/components/Layout/DockedTabGroup.tsx
@@ -59,6 +59,7 @@ import { buildPanelDuplicateOptions } from "@/services/terminal/panelDuplication
 import { handleDockInteractOutside, handleDockEscapeKeyDown } from "./dockPopoverGuard";
 import { usePreferencesStore } from "@/store";
 import { Tooltip, TooltipContent, TooltipTrigger } from "@/components/ui/tooltip";
+import { DockPopoverChildProvider } from "@/components/ui/DockPopoverChildContext";
 
 // Defer terminal focus by one frame's worth so Radix Popover finishes its
 // open animation before we steal focus into the PTY.
@@ -454,287 +455,289 @@ export function DockedTabGroup({ group, panels }: DockedTabGroupProps) {
   const StateIcon = displayAgentState ? getEffectiveStateIcon(displayAgentState) : null;
 
   return (
-    <Popover open={isOpen} onOpenChange={handleOpenChange}>
-      <TerminalContextMenu terminalId={activePanel.id} forceLocation="dock">
-        <PopoverTrigger asChild>
-          <button
-            data-dock-item=""
-            className={cn(
-              "flex items-center gap-1.5 px-3 h-[var(--dock-item-height)] rounded-[var(--radius-md)] text-xs border transition duration-150 max-w-[280px]",
-              "bg-[var(--dock-item-bg)] border-[var(--dock-item-border)] text-daintree-text/70",
-              "hover:text-daintree-text hover:bg-[var(--dock-item-bg-hover)]",
-              "focus-visible:outline focus-visible:outline-2 focus-visible:outline-daintree-accent focus-visible:outline-offset-[-2px]",
-              "cursor-grab active:cursor-grabbing",
-              isOpen &&
-                "bg-[var(--dock-item-bg-active)] text-daintree-text border-[var(--dock-item-border-active)] ring-1 ring-inset ring-daintree-accent/30",
-              !isOpen &&
-                showDockAgentHighlights &&
-                blockedState === "waiting" &&
-                "bg-[var(--dock-item-bg-waiting)] border-[var(--dock-item-border-waiting)]",
-              isDeprioritized && "opacity-50"
-            )}
-            onClick={(e) => {
-              e.preventDefault();
-              e.stopPropagation();
-              if (e.detail >= 2) return;
-              if (isOpen) {
-                closeDockTerminal();
-              } else {
-                openDockTerminal(activeTabId);
-              }
-            }}
-            onDoubleClick={(e) => {
-              e.preventDefault();
-              e.stopPropagation();
-              const moved = moveTerminalToGrid(activePanel.id);
-              if (moved) closeDockTerminal();
-            }}
-            aria-label={`${activePanel.title} (${panels.length} tabs) - Click to preview, double-click to move to grid, drag to reorder`}
-          >
-            <div className="flex items-center justify-center shrink-0">
-              <TerminalIcon kind={activePanel.kind} chrome={activeChrome} className="w-3.5 h-3.5" />
-            </div>
-            <span className="truncate min-w-[48px] max-w-[140px] font-sans font-medium">
-              {displayTitle}
-            </span>
+    <DockPopoverChildProvider>
+      <Popover open={isOpen} onOpenChange={handleOpenChange}>
+        <TerminalContextMenu terminalId={activePanel.id} forceLocation="dock">
+          <PopoverTrigger asChild>
+            <button
+              data-dock-item=""
+              className={cn(
+                "flex items-center gap-1.5 px-3 h-[var(--dock-item-height)] rounded-[var(--radius-md)] text-xs border transition duration-150 max-w-[280px]",
+                "bg-[var(--dock-item-bg)] border-[var(--dock-item-border)] text-daintree-text/70",
+                "hover:text-daintree-text hover:bg-[var(--dock-item-bg-hover)]",
+                "focus-visible:outline focus-visible:outline-2 focus-visible:outline-daintree-accent focus-visible:outline-offset-[-2px]",
+                "cursor-grab active:cursor-grabbing",
+                isOpen &&
+                  "bg-[var(--dock-item-bg-active)] text-daintree-text border-[var(--dock-item-border-active)] ring-1 ring-inset ring-daintree-accent/30",
+                !isOpen &&
+                  showDockAgentHighlights &&
+                  blockedState === "waiting" &&
+                  "bg-[var(--dock-item-bg-waiting)] border-[var(--dock-item-border-waiting)]",
+                isDeprioritized && "opacity-50"
+              )}
+              onClick={(e) => {
+                e.preventDefault();
+                e.stopPropagation();
+                if (e.detail >= 2) return;
+                if (isOpen) {
+                  closeDockTerminal();
+                } else {
+                  openDockTerminal(activeTabId);
+                }
+              }}
+              onDoubleClick={(e) => {
+                e.preventDefault();
+                e.stopPropagation();
+                const moved = moveTerminalToGrid(activePanel.id);
+                if (moved) closeDockTerminal();
+              }}
+              aria-label={`${activePanel.title} (${panels.length} tabs) - Click to preview, double-click to move to grid, drag to reorder`}
+            >
+              <div className="flex items-center justify-center shrink-0">
+                <TerminalIcon kind={activePanel.kind} chrome={activeChrome} className="w-3.5 h-3.5" />
+              </div>
+              <span className="truncate min-w-[48px] max-w-[140px] font-sans font-medium">
+                {displayTitle}
+              </span>
 
-            {/* Tab count indicator */}
-            <span className="text-[10px] text-daintree-text/40 tabular-nums shrink-0">
-              ({panels.length})
-            </span>
+              {/* Tab count indicator */}
+              <span className="text-[10px] text-daintree-text/40 tabular-nums shrink-0">
+                ({panels.length})
+              </span>
 
-            {isActive && commandText && (
-              <>
-                <div className="h-3 w-px bg-border-subtle shrink-0" aria-hidden="true" />
+              {isActive && commandText && (
+                <>
+                  <div className="h-3 w-px bg-border-subtle shrink-0" aria-hidden="true" />
+                  <Tooltip>
+                    <TooltipTrigger asChild>
+                      <span className="truncate flex-1 min-w-0 text-[11px] text-daintree-text/50 font-mono">
+                        {commandText}
+                      </span>
+                    </TooltipTrigger>
+                    <TooltipContent side="bottom">{commandText}</TooltipContent>
+                  </Tooltip>
+                </>
+              )}
+
+              {displayAgentState && StateIcon && (
                 <Tooltip>
                   <TooltipTrigger asChild>
-                    <span className="truncate flex-1 min-w-0 text-[11px] text-daintree-text/50 font-mono">
-                      {commandText}
-                    </span>
-                  </TooltipTrigger>
-                  <TooltipContent side="bottom">{commandText}</TooltipContent>
-                </Tooltip>
-              </>
-            )}
-
-            {displayAgentState && StateIcon && (
-              <Tooltip>
-                <TooltipTrigger asChild>
-                  <div
-                    className={cn(
-                      "flex items-center shrink-0",
-                      getEffectiveStateColor(displayAgentState)
-                    )}
-                  >
-                    <StateIcon
+                    <div
                       className={cn(
-                        "w-3.5 h-3.5",
-                        displayAgentState === "working" && "animate-spin-slow",
-                        "motion-reduce:animate-none"
+                        "flex items-center shrink-0",
+                        getEffectiveStateColor(displayAgentState)
                       )}
-                      aria-hidden="true"
-                    />
-                  </div>
-                </TooltipTrigger>
-                <TooltipContent side="bottom">{`Agent ${displayAgentState}`}</TooltipContent>
-              </Tooltip>
-            )}
-          </button>
-        </PopoverTrigger>
-      </TerminalContextMenu>
-
-      <PopoverContent
-        className="w-[700px] max-w-[90vw] h-[500px] max-h-[80vh] p-0 bg-daintree-bg/95 backdrop-blur-sm border border-[var(--border-dock-popup)] shadow-[var(--shadow-dock-panel-popover)] rounded-[var(--radius-lg)] overflow-hidden"
-        side="top"
-        align="start"
-        sideOffset={10}
-        collisionPadding={collisionPadding}
-        onInteractOutside={(e) => handleDockInteractOutside(e, portalContainer)}
-        onEscapeKeyDown={(e) => handleDockEscapeKeyDown(e, portalContainer)}
-        onOpenAutoFocus={(event) => {
-          event.preventDefault();
-          if (activePanel.spawnedBy === "mcp") {
-            return;
-          }
-          const focusTarget = getTerminalFocusTarget({
-            preferredTarget: preferredTerminalFocusTarget,
-            hasHybridInputSurface: activeChrome.isAgent,
-            isInputDisabled: backendStatus === "disconnected" || backendStatus === "recovering",
-            hybridInputEnabled,
-          });
-
-          if (focusTarget === "hybridInput") {
-            return;
-          }
-
-          setTimeout(() => terminalInstanceService.focus(activePanel.id), TERMINAL_FOCUS_DELAY_MS);
-        }}
-      >
-        {/* Tab bar at top of popover */}
-        <DndContext
-          sensors={tabSensors}
-          collisionDetection={closestCenter}
-          onDragEnd={handleTabDragEnd}
-          modifiers={[restrictToHorizontalAxis, restrictToParentElement]}
-          autoScroll={tabAutoScroll}
-          accessibility={{ announcements: tabAnnouncements }}
-        >
-          <SortableContext items={tabIds} strategy={horizontalListSortingStrategy}>
-            <LayoutGroup id={`dock-tabs-${group.id}`}>
-              <div className="group flex items-stretch border-b border-divider bg-daintree-sidebar shrink-0">
-                <div
-                  ref={setTabListEl}
-                  className="flex items-center min-w-0 flex-1 overflow-x-auto overscroll-x-none scrollbar-none"
-                  role="tablist"
-                  aria-label="Dock panel tabs"
-                  onKeyDown={handleTabListKeyDown}
-                >
-                  {panels.map((panel) => {
-                    const tabChrome = deriveTerminalChrome({
-                      kind: panel.kind,
-                      launchAgentId: panel.launchAgentId,
-                      runtimeIdentity: panel.runtimeIdentity,
-                      detectedAgentId: panel.detectedAgentId,
-                      detectedProcessId: panel.detectedProcessId,
-                      agentState: panel.agentState,
-                      runtimeStatus: panel.runtimeStatus,
-                      exitCode: panel.exitCode,
-                      presetColor: panelPresetColors.get(panel.id),
-                    });
-                    return (
-                      <SortableTabButton
-                        key={panel.id}
-                        id={panel.id}
-                        title={getBaseTitle(panel.title)}
-                        chrome={tabChrome}
-                        kind={panel.kind ?? "terminal"}
-                        agentState={getDockDisplayAgentState(panel)}
-                        isActive={panel.id === activeTabId}
-                        presetColor={panelPresetColors.get(panel.id)}
-                        isUsingFallback={panel.isUsingFallback}
-                        onClick={() => handleTabClick(panel.id)}
-                        onClose={() => handleTabClose(panel.id)}
-                        onRename={(newTitle) => handleTabRename(panel.id, newTitle)}
+                    >
+                      <StateIcon
+                        className={cn(
+                          "w-3.5 h-3.5",
+                          displayAgentState === "working" && "animate-spin-slow",
+                          "motion-reduce:animate-none"
+                        )}
+                        aria-hidden="true"
                       />
-                    );
-                  })}
+                    </div>
+                  </TooltipTrigger>
+                  <TooltipContent side="bottom">{`Agent ${displayAgentState}`}</TooltipContent>
+                </Tooltip>
+              )}
+            </button>
+          </PopoverTrigger>
+        </TerminalContextMenu>
+
+        <PopoverContent
+          className="w-[700px] max-w-[90vw] h-[500px] max-h-[80vh] p-0 bg-daintree-bg/95 backdrop-blur-sm border border-[var(--border-dock-popup)] shadow-[var(--shadow-dock-panel-popover)] rounded-[var(--radius-lg)] overflow-hidden"
+          side="top"
+          align="start"
+          sideOffset={10}
+          collisionPadding={collisionPadding}
+          onInteractOutside={(e) => handleDockInteractOutside(e, portalContainer)}
+          onEscapeKeyDown={(e) => handleDockEscapeKeyDown(e, portalContainer)}
+          onOpenAutoFocus={(event) => {
+            event.preventDefault();
+            if (activePanel.spawnedBy === "mcp") {
+              return;
+            }
+            const focusTarget = getTerminalFocusTarget({
+              preferredTarget: preferredTerminalFocusTarget,
+              hasHybridInputSurface: activeChrome.isAgent,
+              isInputDisabled: backendStatus === "disconnected" || backendStatus === "recovering",
+              hybridInputEnabled,
+            });
+
+            if (focusTarget === "hybridInput") {
+              return;
+            }
+
+            setTimeout(() => terminalInstanceService.focus(activePanel.id), TERMINAL_FOCUS_DELAY_MS);
+          }}
+        >
+          {/* Tab bar at top of popover */}
+          <DndContext
+            sensors={tabSensors}
+            collisionDetection={closestCenter}
+            onDragEnd={handleTabDragEnd}
+            modifiers={[restrictToHorizontalAxis, restrictToParentElement]}
+            autoScroll={tabAutoScroll}
+            accessibility={{ announcements: tabAnnouncements }}
+          >
+            <SortableContext items={tabIds} strategy={horizontalListSortingStrategy}>
+              <LayoutGroup id={`dock-tabs-${group.id}`}>
+                <div className="group flex items-stretch border-b border-divider bg-daintree-sidebar shrink-0">
+                  <div
+                    ref={setTabListEl}
+                    className="flex items-center min-w-0 flex-1 overflow-x-auto overscroll-x-none scrollbar-none"
+                    role="tablist"
+                    aria-label="Dock panel tabs"
+                    onKeyDown={handleTabListKeyDown}
+                  >
+                    {panels.map((panel) => {
+                      const tabChrome = deriveTerminalChrome({
+                        kind: panel.kind,
+                        launchAgentId: panel.launchAgentId,
+                        runtimeIdentity: panel.runtimeIdentity,
+                        detectedAgentId: panel.detectedAgentId,
+                        detectedProcessId: panel.detectedProcessId,
+                        agentState: panel.agentState,
+                        runtimeStatus: panel.runtimeStatus,
+                        exitCode: panel.exitCode,
+                        presetColor: panelPresetColors.get(panel.id),
+                      });
+                      return (
+                        <SortableTabButton
+                          key={panel.id}
+                          id={panel.id}
+                          title={getBaseTitle(panel.title)}
+                          chrome={tabChrome}
+                          kind={panel.kind ?? "terminal"}
+                          agentState={getDockDisplayAgentState(panel)}
+                          isActive={panel.id === activeTabId}
+                          presetColor={panelPresetColors.get(panel.id)}
+                          isUsingFallback={panel.isUsingFallback}
+                          onClick={() => handleTabClick(panel.id)}
+                          onClose={() => handleTabClose(panel.id)}
+                          onRename={(newTitle) => handleTabRename(panel.id, newTitle)}
+                        />
+                      );
+                    })}
+                    <Tooltip>
+                      <TooltipTrigger asChild>
+                        <button
+                          onClick={(e) => {
+                            e.stopPropagation();
+                            handleAddTab();
+                          }}
+                          onPointerDown={(e) => e.stopPropagation()}
+                          className="shrink-0 p-1.5 hover:bg-daintree-text/10 text-daintree-text/40 hover:text-daintree-text transition-colors focus-visible:outline focus-visible:outline-2 focus-visible:outline-daintree-accent focus-visible:outline-offset-1"
+                          aria-label="Duplicate panel as new tab"
+                          type="button"
+                        >
+                          <CopyPlus className="w-3 h-3" aria-hidden="true" />
+                        </button>
+                      </TooltipTrigger>
+                      <TooltipContent side="bottom">Duplicate panel as new tab</TooltipContent>
+                    </Tooltip>
+                  </div>
                   <Tooltip>
                     <TooltipTrigger asChild>
                       <button
+                        type="button"
                         onClick={(e) => {
                           e.stopPropagation();
-                          handleAddTab();
+                          handlePopOut();
                         }}
                         onPointerDown={(e) => e.stopPropagation()}
-                        className="shrink-0 p-1.5 hover:bg-daintree-text/10 text-daintree-text/40 hover:text-daintree-text transition-colors focus-visible:outline focus-visible:outline-2 focus-visible:outline-daintree-accent focus-visible:outline-offset-1"
-                        aria-label="Duplicate panel as new tab"
-                        type="button"
+                        className="shrink-0 p-1.5 text-daintree-text/40 hover:text-daintree-text hover:bg-daintree-text/10 opacity-0 group-hover:opacity-100 focus-visible:opacity-100 transition-opacity duration-150 focus-visible:outline focus-visible:outline-2 focus-visible:outline-daintree-accent focus-visible:outline-offset-1"
+                        aria-label="Open in grid"
                       >
-                        <CopyPlus className="w-3 h-3" aria-hidden="true" />
+                        <SquareArrowOutUpRight className="w-3 h-3" aria-hidden="true" />
                       </button>
                     </TooltipTrigger>
-                    <TooltipContent side="bottom">Duplicate panel as new tab</TooltipContent>
+                    <TooltipContent side="bottom">Open in grid</TooltipContent>
                   </Tooltip>
+                  {hiddenPanels.length > 0 && (
+                    <DropdownMenu>
+                      <Tooltip>
+                        <TooltipTrigger asChild>
+                          <DropdownMenuTrigger asChild>
+                            <button
+                              type="button"
+                              onPointerDown={(e) => e.stopPropagation()}
+                              className="relative shrink-0 p-1.5 hover:bg-daintree-text/10 text-daintree-text/40 hover:text-daintree-text transition-colors focus-visible:outline focus-visible:outline-2 focus-visible:outline-daintree-accent focus-visible:outline-offset-1"
+                              aria-label={
+                                activeTabIsHidden
+                                  ? `Show ${hiddenPanels.length} hidden tabs, including active`
+                                  : `Show ${hiddenPanels.length} hidden tabs`
+                              }
+                              aria-haspopup="menu"
+                              data-testid="dock-tabs-overflow"
+                            >
+                              <ChevronDown className="w-3 h-3" aria-hidden="true" />
+                              {activeTabIsHidden && (
+                                <span
+                                  className="absolute top-0.5 right-0.5 w-1.5 h-1.5 rounded-full bg-daintree-text/70"
+                                  aria-hidden="true"
+                                />
+                              )}
+                            </button>
+                          </DropdownMenuTrigger>
+                        </TooltipTrigger>
+                        <TooltipContent side="bottom">Show hidden tabs</TooltipContent>
+                      </Tooltip>
+                      <DropdownMenuContent
+                        align="end"
+                        className="min-w-[200px] max-w-[320px] max-h-[var(--radix-dropdown-menu-content-available-height)] overflow-y-auto"
+                      >
+                        {hiddenPanels.map((panel) => {
+                          const tabChrome = deriveTerminalChrome({
+                            kind: panel.kind,
+                            launchAgentId: panel.launchAgentId,
+                            runtimeIdentity: panel.runtimeIdentity,
+                            detectedAgentId: panel.detectedAgentId,
+                            detectedProcessId: panel.detectedProcessId,
+                            agentState: panel.agentState,
+                            runtimeStatus: panel.runtimeStatus,
+                            exitCode: panel.exitCode,
+                            presetColor: panelPresetColors.get(panel.id),
+                          });
+                          const isActive = panel.id === activeTabId;
+                          return (
+                            <DropdownMenuItem
+                              key={panel.id}
+                              onSelect={() => handleTabClick(panel.id)}
+                              aria-current={isActive ? "true" : undefined}
+                              className={cn(
+                                isActive &&
+                                  "font-medium before:absolute before:left-0 before:top-2 before:bottom-2 before:w-[2px] before:rounded-r before:bg-daintree-accent before:content-['']"
+                              )}
+                            >
+                              <span className="shrink-0 mr-2 inline-flex items-center justify-center w-3.5 h-3.5">
+                                <TerminalIcon
+                                  kind={panel.kind ?? "terminal"}
+                                  chrome={tabChrome}
+                                  className="w-3.5 h-3.5"
+                                />
+                              </span>
+                              <span className="truncate">{getBaseTitle(panel.title)}</span>
+                            </DropdownMenuItem>
+                          );
+                        })}
+                      </DropdownMenuContent>
+                    </DropdownMenu>
+                  )}
                 </div>
-                <Tooltip>
-                  <TooltipTrigger asChild>
-                    <button
-                      type="button"
-                      onClick={(e) => {
-                        e.stopPropagation();
-                        handlePopOut();
-                      }}
-                      onPointerDown={(e) => e.stopPropagation()}
-                      className="shrink-0 p-1.5 text-daintree-text/40 hover:text-daintree-text hover:bg-daintree-text/10 opacity-0 group-hover:opacity-100 focus-visible:opacity-100 transition-opacity duration-150 focus-visible:outline focus-visible:outline-2 focus-visible:outline-daintree-accent focus-visible:outline-offset-1"
-                      aria-label="Open in grid"
-                    >
-                      <SquareArrowOutUpRight className="w-3 h-3" aria-hidden="true" />
-                    </button>
-                  </TooltipTrigger>
-                  <TooltipContent side="bottom">Open in grid</TooltipContent>
-                </Tooltip>
-                {hiddenPanels.length > 0 && (
-                  <DropdownMenu>
-                    <Tooltip>
-                      <TooltipTrigger asChild>
-                        <DropdownMenuTrigger asChild>
-                          <button
-                            type="button"
-                            onPointerDown={(e) => e.stopPropagation()}
-                            className="relative shrink-0 p-1.5 hover:bg-daintree-text/10 text-daintree-text/40 hover:text-daintree-text transition-colors focus-visible:outline focus-visible:outline-2 focus-visible:outline-daintree-accent focus-visible:outline-offset-1"
-                            aria-label={
-                              activeTabIsHidden
-                                ? `Show ${hiddenPanels.length} hidden tabs, including active`
-                                : `Show ${hiddenPanels.length} hidden tabs`
-                            }
-                            aria-haspopup="menu"
-                            data-testid="dock-tabs-overflow"
-                          >
-                            <ChevronDown className="w-3 h-3" aria-hidden="true" />
-                            {activeTabIsHidden && (
-                              <span
-                                className="absolute top-0.5 right-0.5 w-1.5 h-1.5 rounded-full bg-daintree-text/70"
-                                aria-hidden="true"
-                              />
-                            )}
-                          </button>
-                        </DropdownMenuTrigger>
-                      </TooltipTrigger>
-                      <TooltipContent side="bottom">Show hidden tabs</TooltipContent>
-                    </Tooltip>
-                    <DropdownMenuContent
-                      align="end"
-                      className="min-w-[200px] max-w-[320px] max-h-[var(--radix-dropdown-menu-content-available-height)] overflow-y-auto"
-                    >
-                      {hiddenPanels.map((panel) => {
-                        const tabChrome = deriveTerminalChrome({
-                          kind: panel.kind,
-                          launchAgentId: panel.launchAgentId,
-                          runtimeIdentity: panel.runtimeIdentity,
-                          detectedAgentId: panel.detectedAgentId,
-                          detectedProcessId: panel.detectedProcessId,
-                          agentState: panel.agentState,
-                          runtimeStatus: panel.runtimeStatus,
-                          exitCode: panel.exitCode,
-                          presetColor: panelPresetColors.get(panel.id),
-                        });
-                        const isActive = panel.id === activeTabId;
-                        return (
-                          <DropdownMenuItem
-                            key={panel.id}
-                            onSelect={() => handleTabClick(panel.id)}
-                            aria-current={isActive ? "true" : undefined}
-                            className={cn(
-                              isActive &&
-                                "font-medium before:absolute before:left-0 before:top-2 before:bottom-2 before:w-[2px] before:rounded-r before:bg-daintree-accent before:content-['']"
-                            )}
-                          >
-                            <span className="shrink-0 mr-2 inline-flex items-center justify-center w-3.5 h-3.5">
-                              <TerminalIcon
-                                kind={panel.kind ?? "terminal"}
-                                chrome={tabChrome}
-                                className="w-3.5 h-3.5"
-                              />
-                            </span>
-                            <span className="truncate">{getBaseTitle(panel.title)}</span>
-                          </DropdownMenuItem>
-                        );
-                      })}
-                    </DropdownMenuContent>
-                  </DropdownMenu>
-                )}
-              </div>
-            </LayoutGroup>
-          </SortableContext>
-        </DndContext>
+              </LayoutGroup>
+            </SortableContext>
+          </DndContext>
 
-        {/* Portal target - content is rendered in DockPanelOffscreenContainer and portaled here */}
-        <div
-          ref={portalContainerRef}
-          className="flex-1 min-h-0 flex flex-col"
-          data-dock-portal-target={activePanel.id}
-        />
-      </PopoverContent>
-    </Popover>
+          {/* Portal target - content is rendered in DockPanelOffscreenContainer and portaled here */}
+          <div
+            ref={portalContainerRef}
+            className="flex-1 min-h-0 flex flex-col"
+            data-dock-portal-target={activePanel.id}
+          />
+        </PopoverContent>
+      </Popover>
+    </DockPopoverChildProvider>
   );
 }

--- a/src/components/Layout/DockedTerminalItem.tsx
+++ b/src/components/Layout/DockedTerminalItem.tsx
@@ -29,6 +29,7 @@ import { getDockDisplayAgentState, useDockBlockedState } from "./useDockBlockedS
 import { handleDockInteractOutside, handleDockEscapeKeyDown } from "./dockPopoverGuard";
 import { usePreferencesStore } from "@/store";
 import { Tooltip, TooltipContent, TooltipTrigger } from "@/components/ui/tooltip";
+import { DockPopoverChildProvider } from "@/components/ui/DockPopoverChildContext";
 
 interface DockedTerminalItemProps {
   terminal: TerminalInstance;
@@ -257,145 +258,147 @@ export function DockedTerminalItem({ terminal }: DockedTerminalItemProps) {
     (!agentState || agentState === "idle" || agentState === "completed" || agentState === "exited");
 
   return (
-    <Popover open={isOpen} onOpenChange={handleOpenChange}>
-      <TerminalContextMenu terminalId={terminal.id} forceLocation="dock">
-        <PopoverTrigger asChild>
-          <button
-            data-dock-item=""
-            className={cn(
-              "flex items-center gap-1.5 px-3 h-[var(--dock-item-height)] rounded-[var(--radius-md)] text-xs border transition duration-150 max-w-[280px]",
-              "bg-[var(--dock-item-bg)] border-[var(--dock-item-border)] text-daintree-text/70",
-              "hover:text-daintree-text hover:bg-[var(--dock-item-bg-hover)]",
-              "focus-visible:outline focus-visible:outline-2 focus-visible:outline-daintree-accent focus-visible:outline-offset-[-2px]",
-              "cursor-grab active:cursor-grabbing",
-              isOpen &&
-                "bg-[var(--dock-item-bg-active)] text-daintree-text border-[var(--dock-item-border-active)] ring-1 ring-inset ring-daintree-accent/30",
-              !isOpen &&
-                showDockAgentHighlights &&
-                blockedState === "waiting" &&
-                "bg-[var(--dock-item-bg-waiting)] border-[var(--dock-item-border-waiting)]",
-              isDeprioritized && "opacity-50"
-            )}
-            onClick={(e) => {
-              e.preventDefault();
-              e.stopPropagation();
-              if (e.detail >= 2) return;
-              if (isOpen) {
-                closeDockTerminal();
-              } else {
-                openDockTerminal(terminal.id);
-              }
-            }}
-            onDoubleClick={(e) => {
-              e.preventDefault();
-              e.stopPropagation();
-              const moved = moveTerminalToGrid(terminal.id);
-              if (moved) closeDockTerminal();
-            }}
-            aria-label={`${terminal.title} - Click to preview, double-click to move to grid, drag to reorder`}
-          >
-            <div className="flex items-center justify-center shrink-0">
-              <TerminalIcon kind={terminal.kind} chrome={chrome} className="w-3.5 h-3.5" />
-            </div>
-            <span className="truncate min-w-[48px] max-w-[140px] font-sans font-medium">
-              {displayTitle}
-            </span>
+    <DockPopoverChildProvider>
+      <Popover open={isOpen} onOpenChange={handleOpenChange}>
+        <TerminalContextMenu terminalId={terminal.id} forceLocation="dock">
+          <PopoverTrigger asChild>
+            <button
+              data-dock-item=""
+              className={cn(
+                "flex items-center gap-1.5 px-3 h-[var(--dock-item-height)] rounded-[var(--radius-md)] text-xs border transition duration-150 max-w-[280px]",
+                "bg-[var(--dock-item-bg)] border-[var(--dock-item-border)] text-daintree-text/70",
+                "hover:text-daintree-text hover:bg-[var(--dock-item-bg-hover)]",
+                "focus-visible:outline focus-visible:outline-2 focus-visible:outline-daintree-accent focus-visible:outline-offset-[-2px]",
+                "cursor-grab active:cursor-grabbing",
+                isOpen &&
+                  "bg-[var(--dock-item-bg-active)] text-daintree-text border-[var(--dock-item-border-active)] ring-1 ring-inset ring-daintree-accent/30",
+                !isOpen &&
+                  showDockAgentHighlights &&
+                  blockedState === "waiting" &&
+                  "bg-[var(--dock-item-bg-waiting)] border-[var(--dock-item-border-waiting)]",
+                isDeprioritized && "opacity-50"
+              )}
+              onClick={(e) => {
+                e.preventDefault();
+                e.stopPropagation();
+                if (e.detail >= 2) return;
+                if (isOpen) {
+                  closeDockTerminal();
+                } else {
+                  openDockTerminal(terminal.id);
+                }
+              }}
+              onDoubleClick={(e) => {
+                e.preventDefault();
+                e.stopPropagation();
+                const moved = moveTerminalToGrid(terminal.id);
+                if (moved) closeDockTerminal();
+              }}
+              aria-label={`${terminal.title} - Click to preview, double-click to move to grid, drag to reorder`}
+            >
+              <div className="flex items-center justify-center shrink-0">
+                <TerminalIcon kind={terminal.kind} chrome={chrome} className="w-3.5 h-3.5" />
+              </div>
+              <span className="truncate min-w-[48px] max-w-[140px] font-sans font-medium">
+                {displayTitle}
+              </span>
 
-            {isActive && commandText && (
-              <>
-                <div className="h-3 w-px bg-border-subtle shrink-0" aria-hidden="true" />
+              {isActive && commandText && (
+                <>
+                  <div className="h-3 w-px bg-border-subtle shrink-0" aria-hidden="true" />
+                  <Tooltip>
+                    <TooltipTrigger asChild>
+                      <span className="truncate flex-1 min-w-0 text-[11px] text-daintree-text/50 font-mono">
+                        {commandText}
+                      </span>
+                    </TooltipTrigger>
+                    <TooltipContent side="bottom">{commandText}</TooltipContent>
+                  </Tooltip>
+                </>
+              )}
+
+              {/* State icon (compact spacing from title) */}
+              {displayAgentState && StateIcon && (
                 <Tooltip>
                   <TooltipTrigger asChild>
-                    <span className="truncate flex-1 min-w-0 text-[11px] text-daintree-text/50 font-mono">
-                      {commandText}
-                    </span>
-                  </TooltipTrigger>
-                  <TooltipContent side="bottom">{commandText}</TooltipContent>
-                </Tooltip>
-              </>
-            )}
-
-            {/* State icon (compact spacing from title) */}
-            {displayAgentState && StateIcon && (
-              <Tooltip>
-                <TooltipTrigger asChild>
-                  <div
-                    className={cn(
-                      "flex items-center shrink-0",
-                      getEffectiveStateColor(displayAgentState)
-                    )}
-                  >
-                    <StateIcon
+                    <div
                       className={cn(
-                        "w-3.5 h-3.5",
-                        displayAgentState === "working" && "animate-spin-slow",
-                        "motion-reduce:animate-none"
+                        "flex items-center shrink-0",
+                        getEffectiveStateColor(displayAgentState)
                       )}
-                      aria-hidden="true"
-                    />
-                  </div>
-                </TooltipTrigger>
-                <TooltipContent side="bottom">{`Agent ${displayAgentState}`}</TooltipContent>
-              </Tooltip>
-            )}
-          </button>
-        </PopoverTrigger>
-      </TerminalContextMenu>
+                    >
+                      <StateIcon
+                        className={cn(
+                          "w-3.5 h-3.5",
+                          displayAgentState === "working" && "animate-spin-slow",
+                          "motion-reduce:animate-none"
+                        )}
+                        aria-hidden="true"
+                      />
+                    </div>
+                  </TooltipTrigger>
+                  <TooltipContent side="bottom">{`Agent ${displayAgentState}`}</TooltipContent>
+                </Tooltip>
+              )}
+            </button>
+          </PopoverTrigger>
+        </TerminalContextMenu>
 
-      <PopoverContent
-        className="w-[700px] max-w-[90vw] h-[500px] max-h-[80vh] p-0 bg-daintree-bg/95 backdrop-blur-sm border border-[var(--border-dock-popup)] shadow-[var(--shadow-dock-panel-popover)] rounded-[var(--radius-lg)] overflow-hidden data-[state=open]:animate-in data-[state=closed]:animate-out data-[state=open]:duration-200 data-[state=closed]:duration-[120ms] data-[state=closed]:fade-out-0 data-[state=open]:fade-in-0 data-[state=closed]:zoom-out-95 data-[state=open]:zoom-in-95 data-[side=bottom]:slide-in-from-top-2 data-[side=left]:slide-in-from-right-2 data-[side=right]:slide-in-from-left-2 data-[side=top]:slide-in-from-bottom-2"
-        side="top"
-        align="start"
-        sideOffset={10}
-        collisionPadding={collisionPadding}
-        onInteractOutside={(e) => handleDockInteractOutside(e, portalContainer)}
-        onEscapeKeyDown={(e) => handleDockEscapeKeyDown(e, portalContainer)}
-        onOpenAutoFocus={(event) => {
-          event.preventDefault();
-          if (terminal.spawnedBy === "mcp") {
-            return;
-          }
-          const focusTarget = getTerminalFocusTarget({
-            preferredTarget: preferredTerminalFocusTarget,
-            hasHybridInputSurface: chrome.isAgent,
-            isInputDisabled: backendStatus === "disconnected" || backendStatus === "recovering",
-            hybridInputEnabled,
-          });
+        <PopoverContent
+          className="w-[700px] max-w-[90vw] h-[500px] max-h-[80vh] p-0 bg-daintree-bg/95 backdrop-blur-sm border border-[var(--border-dock-popup)] shadow-[var(--shadow-dock-panel-popover)] rounded-[var(--radius-lg)] overflow-hidden data-[state=open]:animate-in data-[state=closed]:animate-out data-[state=open]:duration-200 data-[state=closed]:duration-[120ms] data-[state=closed]:fade-out-0 data-[state=open]:fade-in-0 data-[state=closed]:zoom-out-95 data-[state=open]:zoom-in-95 data-[side=bottom]:slide-in-from-top-2 data-[side=left]:slide-in-from-right-2 data-[side=right]:slide-in-from-left-2 data-[side=top]:slide-in-from-bottom-2"
+          side="top"
+          align="start"
+          sideOffset={10}
+          collisionPadding={collisionPadding}
+          onInteractOutside={(e) => handleDockInteractOutside(e, portalContainer)}
+          onEscapeKeyDown={(e) => handleDockEscapeKeyDown(e, portalContainer)}
+          onOpenAutoFocus={(event) => {
+            event.preventDefault();
+            if (terminal.spawnedBy === "mcp") {
+              return;
+            }
+            const focusTarget = getTerminalFocusTarget({
+              preferredTarget: preferredTerminalFocusTarget,
+              hasHybridInputSurface: chrome.isAgent,
+              isInputDisabled: backendStatus === "disconnected" || backendStatus === "recovering",
+              hybridInputEnabled,
+            });
 
-          if (focusTarget === "hybridInput") {
-            return;
-          }
+            if (focusTarget === "hybridInput") {
+              return;
+            }
 
-          // Small delay to ensure xterm is fully mounted before focusing
-          setTimeout(() => terminalInstanceService.focus(terminal.id), 50);
-        }}
-      >
-        <div className="relative w-full h-full group">
-          {/* Portal target - content is rendered in DockPanelOffscreenContainer and portaled here */}
-          <div
-            ref={portalContainerRef}
-            className="w-full h-full flex flex-col"
-            data-dock-portal-target={terminal.id}
-          />
-          <Tooltip>
-            <TooltipTrigger asChild>
-              <button
-                type="button"
-                onClick={(e) => {
-                  e.stopPropagation();
-                  handlePopOut();
-                }}
-                onPointerDown={(e) => e.stopPropagation()}
-                className="absolute top-1.5 right-1.5 p-1 rounded text-daintree-text/40 hover:text-daintree-text hover:bg-daintree-text/10 opacity-0 group-hover:opacity-100 focus-visible:opacity-100 transition-opacity duration-150 focus-visible:outline focus-visible:outline-2 focus-visible:outline-daintree-accent focus-visible:outline-offset-1"
-                aria-label="Open in grid"
-              >
-                <SquareArrowOutUpRight className="w-3.5 h-3.5" aria-hidden="true" />
-              </button>
-            </TooltipTrigger>
-            <TooltipContent side="bottom">Open in grid</TooltipContent>
-          </Tooltip>
-        </div>
-      </PopoverContent>
-    </Popover>
+            // Small delay to ensure xterm is fully mounted before focusing
+            setTimeout(() => terminalInstanceService.focus(terminal.id), 50);
+          }}
+        >
+          <div className="relative w-full h-full group">
+            {/* Portal target - content is rendered in DockPanelOffscreenContainer and portaled here */}
+            <div
+              ref={portalContainerRef}
+              className="w-full h-full flex flex-col"
+              data-dock-portal-target={terminal.id}
+            />
+            <Tooltip>
+              <TooltipTrigger asChild>
+                <button
+                  type="button"
+                  onClick={(e) => {
+                    e.stopPropagation();
+                    handlePopOut();
+                  }}
+                  onPointerDown={(e) => e.stopPropagation()}
+                  className="absolute top-1.5 right-1.5 p-1 rounded text-daintree-text/40 hover:text-daintree-text hover:bg-daintree-text/10 opacity-0 group-hover:opacity-100 focus-visible:opacity-100 transition-opacity duration-150 focus-visible:outline focus-visible:outline-2 focus-visible:outline-daintree-accent focus-visible:outline-offset-1"
+                  aria-label="Open in grid"
+                >
+                  <SquareArrowOutUpRight className="w-3.5 h-3.5" aria-hidden="true" />
+                </button>
+              </TooltipTrigger>
+              <TooltipContent side="bottom">Open in grid</TooltipContent>
+            </Tooltip>
+          </div>
+        </PopoverContent>
+      </Popover>
+    </DockPopoverChildProvider>
   );
 }

--- a/src/components/Layout/__tests__/dockPopoverGuard.test.ts
+++ b/src/components/Layout/__tests__/dockPopoverGuard.test.ts
@@ -21,7 +21,26 @@ describe("handleDockInteractOutside", () => {
     container.remove();
   });
 
-  it("prevents dismissal when target is inside a Radix popper wrapper", () => {
+  it("prevents dismissal when target is inside a dock-popover-child element", () => {
+    const wrapper = document.createElement("div");
+    wrapper.setAttribute("data-dock-popover-child", "");
+    const menuItem = document.createElement("div");
+    wrapper.appendChild(menuItem);
+    document.body.appendChild(wrapper);
+
+    const event = makeEvent(menuItem);
+    handleDockInteractOutside(event, null);
+
+    expect(event.preventDefault).toHaveBeenCalled();
+    wrapper.remove();
+  });
+
+  it("allows dismissal when target is on an unrelated Radix popper wrapper", () => {
+    // Regression for #8161: the previous Guard 2 selector matched any
+    // [data-radix-popper-content-wrapper] in the document, blocking dismissal
+    // even when the click originated in an unrelated Radix overlay. The
+    // project-owned data-dock-popover-child attribute must NOT match such
+    // wrappers — only Radix content rendered inside a DockPopoverChildProvider.
     const wrapper = document.createElement("div");
     wrapper.setAttribute("data-radix-popper-content-wrapper", "");
     const menuItem = document.createElement("div");
@@ -31,7 +50,7 @@ describe("handleDockInteractOutside", () => {
     const event = makeEvent(menuItem);
     handleDockInteractOutside(event, null);
 
-    expect(event.preventDefault).toHaveBeenCalled();
+    expect(event.preventDefault).not.toHaveBeenCalled();
     wrapper.remove();
   });
 
@@ -57,12 +76,31 @@ describe("handleDockInteractOutside", () => {
 
   it("handles null portal container gracefully", () => {
     const wrapper = document.createElement("div");
-    wrapper.setAttribute("data-radix-popper-content-wrapper", "");
+    wrapper.setAttribute("data-dock-popover-child", "");
     const child = document.createElement("span");
     wrapper.appendChild(child);
     document.body.appendChild(wrapper);
 
     const event = makeEvent(child);
+    handleDockInteractOutside(event, null);
+
+    expect(event.preventDefault).toHaveBeenCalled();
+    wrapper.remove();
+  });
+
+  it("matches when the data-dock-popover-child attribute is on an ancestor", () => {
+    // Radix content nodes stamp the attribute on themselves; clicks frequently
+    // land on a descendant (a menu item, an inner span). `closest` should walk
+    // up the tree and find the stamped ancestor.
+    const wrapper = document.createElement("div");
+    wrapper.setAttribute("data-dock-popover-child", "");
+    const middle = document.createElement("div");
+    const leaf = document.createElement("span");
+    middle.appendChild(leaf);
+    wrapper.appendChild(middle);
+    document.body.appendChild(wrapper);
+
+    const event = makeEvent(leaf);
     handleDockInteractOutside(event, null);
 
     expect(event.preventDefault).toHaveBeenCalled();

--- a/src/components/Layout/dockPopoverGuard.ts
+++ b/src/components/Layout/dockPopoverGuard.ts
@@ -16,9 +16,13 @@ export function handleDockInteractOutside(
     return;
   }
 
-  // Guard 2: Click is on a Radix floating element (DropdownMenu, Tooltip, Select, etc.)
-  // portaled to document.body — these carry data-radix-popper-content-wrapper
-  if (target.closest("[data-radix-popper-content-wrapper]")) {
+  // Guard 2: Click is on a Radix floating element (DropdownMenu, Tooltip, Select,
+  // ContextMenu) descended from this dock popover. These portal to document.body,
+  // so we can't rely on DOM containment — the dock popover's React subtree stamps
+  // `data-dock-popover-child` on its own Radix content via DockPopoverChildContext,
+  // which scopes the guard to *its* descendants rather than every Radix overlay
+  // in the document.
+  if (target.closest("[data-dock-popover-child]")) {
     event.preventDefault();
     return;
   }

--- a/src/components/ui/DockPopoverChildContext.tsx
+++ b/src/components/ui/DockPopoverChildContext.tsx
@@ -1,0 +1,13 @@
+import * as React from "react";
+
+const DockPopoverChildContext = React.createContext<boolean>(false);
+
+export function DockPopoverChildProvider({ children }: { children: React.ReactNode }) {
+  return (
+    <DockPopoverChildContext.Provider value={true}>{children}</DockPopoverChildContext.Provider>
+  );
+}
+
+export function useIsDockPopoverChild(): boolean {
+  return React.useContext(DockPopoverChildContext);
+}

--- a/src/components/ui/__tests__/DockPopoverChildContext.test.tsx
+++ b/src/components/ui/__tests__/DockPopoverChildContext.test.tsx
@@ -1,0 +1,48 @@
+// @vitest-environment jsdom
+import { cleanup, render } from "@testing-library/react";
+import { afterEach, beforeAll, describe, expect, it } from "vitest";
+import * as DropdownMenuPrimitive from "@radix-ui/react-dropdown-menu";
+import { DropdownMenuContent } from "../dropdown-menu";
+import { primeRadix } from "../radix-loader";
+import { DockPopoverChildProvider } from "../DockPopoverChildContext";
+
+beforeAll(async () => {
+  await primeRadix();
+});
+
+afterEach(cleanup);
+
+function renderDropdown(wrapInProvider: boolean) {
+  const tree = (
+    <DropdownMenuPrimitive.Root open>
+      <DropdownMenuPrimitive.Trigger>trigger</DropdownMenuPrimitive.Trigger>
+      <DropdownMenuContent forceMount>
+        <span>item</span>
+      </DropdownMenuContent>
+    </DropdownMenuPrimitive.Root>
+  );
+  render(wrapInProvider ? <DockPopoverChildProvider>{tree}</DockPopoverChildProvider> : tree);
+  return document.querySelector("[role='menu']") as HTMLElement;
+}
+
+describe("data-dock-popover-child stamping via DockPopoverChildProvider", () => {
+  it("stamps the attribute on Radix content rendered inside the provider", () => {
+    const content = renderDropdown(true);
+    expect(content).not.toBeNull();
+    expect(content.hasAttribute("data-dock-popover-child")).toBe(true);
+  });
+
+  it("omits the attribute when the same content renders outside the provider", () => {
+    const content = renderDropdown(false);
+    expect(content).not.toBeNull();
+    expect(content.hasAttribute("data-dock-popover-child")).toBe(false);
+  });
+
+  it("the attribute is empty-string when present (matches `closest()` predicate)", () => {
+    // `target.closest("[data-dock-popover-child]")` in dockPopoverGuard.ts
+    // requires the attribute to be present, not value-equal. Confirm we
+    // stamp an empty string rather than e.g. `"true"` so `closest` matches.
+    const content = renderDropdown(true);
+    expect(content.getAttribute("data-dock-popover-child")).toBe("");
+  });
+});

--- a/src/components/ui/context-menu.tsx
+++ b/src/components/ui/context-menu.tsx
@@ -5,6 +5,7 @@ import { Check, ChevronRight } from "lucide-react";
 import { cn } from "@/lib/utils";
 import { useScrollShadowOverlays } from "@/components/ui/ScrollShadow";
 import { primeOnEvent, useRadixPrimitives } from "./radix-loader";
+import { useIsDockPopoverChild } from "./DockPopoverChildContext";
 
 type ContextMenuRootProps = React.ComponentProps<typeof ContextMenuPrimitiveType.Root>;
 
@@ -169,6 +170,7 @@ const ContextMenuSubContent = React.forwardRef<
 >(({ className, sideOffset = 4, collisionPadding = 8, children, style, ...props }, ref) => {
   const radix = useRadixPrimitives();
   const { ref: shadowRef, topShadow, bottomShadow } = useScrollShadowOverlays(ref);
+  const isDockPopoverChild = useIsDockPopoverChild();
   if (!radix) return null;
   const Portal = radix.ContextMenuPrimitive.Portal;
   const SubContent = radix.ContextMenuPrimitive.SubContent;
@@ -185,6 +187,7 @@ const ContextMenuSubContent = React.forwardRef<
           className
         )}
         {...props}
+        data-dock-popover-child={isDockPopoverChild ? "" : undefined}
       >
         {topShadow}
         {children}
@@ -205,6 +208,7 @@ const ContextMenuContent = React.forwardRef<
 >(({ className, collisionPadding = 8, children, style, ...props }, ref) => {
   const radix = useRadixPrimitives();
   const { ref: shadowRef, topShadow, bottomShadow } = useScrollShadowOverlays(ref);
+  const isDockPopoverChild = useIsDockPopoverChild();
   if (!radix) return null;
   const Portal = radix.ContextMenuPrimitive.Portal;
   const Content = radix.ContextMenuPrimitive.Content;
@@ -220,6 +224,7 @@ const ContextMenuContent = React.forwardRef<
           className
         )}
         {...props}
+        data-dock-popover-child={isDockPopoverChild ? "" : undefined}
       >
         {topShadow}
         {children}

--- a/src/components/ui/dropdown-menu.tsx
+++ b/src/components/ui/dropdown-menu.tsx
@@ -5,6 +5,7 @@ import { Check, ChevronRight } from "lucide-react";
 import { cn } from "@/lib/utils";
 import { useScrollShadowOverlays } from "@/components/ui/ScrollShadow";
 import { primeOnEvent, useRadixPrimitives } from "./radix-loader";
+import { useIsDockPopoverChild } from "./DockPopoverChildContext";
 
 const DropdownMenuIntentContext = React.createContext<((next: boolean) => void) | null>(null);
 
@@ -215,6 +216,7 @@ const DropdownMenuSubContent = React.forwardRef<
 >(({ className, sideOffset = 4, collisionPadding = 8, children, style, ...props }, ref) => {
   const radix = useRadixPrimitives();
   const { ref: shadowRef, topShadow, bottomShadow } = useScrollShadowOverlays(ref);
+  const isDockPopoverChild = useIsDockPopoverChild();
   if (!radix) return null;
   const Portal = radix.DropdownMenuPrimitive.Portal;
   const SubContent = radix.DropdownMenuPrimitive.SubContent;
@@ -231,6 +233,7 @@ const DropdownMenuSubContent = React.forwardRef<
           className
         )}
         {...props}
+        data-dock-popover-child={isDockPopoverChild ? "" : undefined}
       >
         {topShadow}
         {children}
@@ -251,6 +254,7 @@ const DropdownMenuContent = React.forwardRef<
 >(({ className, sideOffset = 4, children, style, ...props }, ref) => {
   const radix = useRadixPrimitives();
   const { ref: shadowRef, topShadow, bottomShadow } = useScrollShadowOverlays(ref);
+  const isDockPopoverChild = useIsDockPopoverChild();
   if (!radix) return null;
   const Portal = radix.DropdownMenuPrimitive.Portal;
   const Content = radix.DropdownMenuPrimitive.Content;
@@ -266,6 +270,7 @@ const DropdownMenuContent = React.forwardRef<
           className
         )}
         {...props}
+        data-dock-popover-child={isDockPopoverChild ? "" : undefined}
       >
         {topShadow}
         {children}

--- a/src/components/ui/select.tsx
+++ b/src/components/ui/select.tsx
@@ -3,6 +3,7 @@ import type * as SelectPrimitiveType from "@radix-ui/react-select";
 import { Check, ChevronDown, ChevronUp } from "lucide-react";
 import { cn } from "@/lib/utils";
 import { composeHandlers, primeOnEvent, useRadixPrimitives } from "./radix-loader";
+import { useIsDockPopoverChild } from "./DockPopoverChildContext";
 
 const SelectIntentContext = React.createContext<((next: boolean) => void) | null>(null);
 
@@ -198,6 +199,7 @@ const SelectContent = React.forwardRef<
     ref
   ) => {
     const radix = useRadixPrimitives();
+    const isDockPopoverChild = useIsDockPopoverChild();
     if (!radix) return null;
     const Portal = radix.SelectPrimitive.Portal;
     const Content = radix.SelectPrimitive.Content;
@@ -221,6 +223,7 @@ const SelectContent = React.forwardRef<
             className
           )}
           {...props}
+          data-dock-popover-child={isDockPopoverChild ? "" : undefined}
         >
           <SelectScrollUpButton />
           <Viewport

--- a/src/components/ui/tooltip.tsx
+++ b/src/components/ui/tooltip.tsx
@@ -4,6 +4,7 @@ import { Slot } from "@radix-ui/react-slot";
 import { cn } from "@/lib/utils";
 import { primeOnEvent, useRadixPrimitives } from "./radix-loader";
 import { FixedDropdownVisibleContext } from "./fixed-dropdown";
+import { useIsDockPopoverChild } from "./DockPopoverChildContext";
 
 type TooltipProviderProps = React.ComponentProps<typeof TooltipPrimitiveType.Provider>;
 
@@ -160,6 +161,7 @@ const TooltipContent = React.forwardRef<
     ref
   ) => {
     const radix = useRadixPrimitives();
+    const isDockPopoverChild = useIsDockPopoverChild();
     if (!radix) return null;
     const Portal = radix.TooltipPrimitive.Portal;
     const Content = radix.TooltipPrimitive.Content;
@@ -178,6 +180,7 @@ const TooltipContent = React.forwardRef<
             className
           )}
           {...props}
+          data-dock-popover-child={isDockPopoverChild ? "" : undefined}
         />
       </Portal>
     );


### PR DESCRIPTION
## Summary

- Guard 2 in `dockPopoverGuard.ts` was matching against `[data-radix-popper-content-wrapper]`, a Radix-internal selector that could change with any upstream release. It now matches `[data-dock-popover-child]`, an attribute we own and stamp ourselves.
- `DockPopoverChildContext` provides the attribute to all Radix overlay primitives (`DropdownMenuContent`, `SubContent`, `TooltipContent`, `SelectContent`, `ContextMenuContent`). The attribute is stamped after `{...props}` so callers can't accidentally override it.
- Because Radix portals break the React tree, the portaled panel body in `DockPanelOffscreenContainer` is wrapped in a `DockPopoverChildProvider` so overlays opened inside docked panels — terminal context menus, header dropdowns — inherit the context correctly.

Resolves #8161

## Changes

- `dockPopoverGuard.ts` — replaced internal Radix selector with `[data-dock-popover-child]`
- `DockPopoverChildContext.tsx` — new context + provider
- `DockedTabGroup.tsx` / `DockedTerminalItem.tsx` — wrapped Popover subtrees in `DockPopoverChildProvider`
- `DockPanelOffscreenContainer.tsx` — wrapped portaled body in `DockPopoverChildProvider`
- `dropdown-menu.tsx`, `context-menu.tsx`, `tooltip.tsx`, `select.tsx` — stamped `data-dock-popover-child` on all content/subcontent components

## Testing

- New unit test `DockPopoverChildContext.test.tsx` validates the stamping contract end-to-end with the React provider
- `dockPopoverGuard.test.ts` updated: positive case rewritten with new attribute, regression test confirming bare `[data-radix-popper-content-wrapper]` no longer matches, ancestor-walk case added
- New Playwright spec `e2e/full/panels/core-dock-popover-dismissal.spec.ts` pins the contract against a real Radix Popover flow via synthetic overlay injection
- 16 tests across new and updated specs; `npm run check` and build both clean