### PR TITLE
feat(assistant): wire HybridInputBar into Daintree Assistant

### DIFF
--- a/src/components/HelpPanel/HelpPanel.tsx
+++ b/src/components/HelpPanel/HelpPanel.tsx
@@ -1,5 +1,6 @@
 import {
   Suspense,
+  lazy,
   useCallback,
   useEffect,
   useMemo,
@@ -12,7 +13,11 @@ import { cn } from "@/lib/utils";
 import { DaintreeIcon } from "@/components/icons/DaintreeIcon";
 import { XtermAdapter } from "@/components/Terminal/XtermAdapter";
 import { MissingCliGate } from "@/components/Terminal/MissingCliGate";
+import { shouldShowHybridInputBar } from "@/components/Terminal/terminalFocus";
+import type { HybridInputBarHandle } from "@/components/Terminal/HybridInputBar";
 import { terminalInstanceService } from "@/services/TerminalInstanceService";
+import { terminalClient } from "@/clients";
+import { isBuiltInAgentId } from "@shared/config/agentIds";
 import { HelpIntroBanner } from "./HelpIntroBanner";
 import { HelpPanelHeader } from "./HelpPanelHeader";
 import { HelpPanelBanners } from "./HelpPanelBanners";
@@ -28,6 +33,7 @@ import {
   useCliAvailabilityStore,
   useProjectStore,
   useWorktreeSelectionStore,
+  useTerminalInputStore,
 } from "@/store";
 import { useMacroFocusStore } from "@/store/macroFocusStore";
 import { getAgentConfig, getAssistantSupportedAgentIds } from "@/config/agents";
@@ -40,6 +46,10 @@ import { CLOSE_CONFIRM_AGENT_STATES } from "@shared/types/agent";
 import { ConfirmDialog } from "@/components/ui/ConfirmDialog";
 import { TABBABLE_SELECTOR } from "@/lib/accessibility";
 import { HelpSessionController } from "@/controllers/HelpSessionController";
+
+const LazyHybridInputBar = lazy(() =>
+  import("@/components/Terminal/HybridInputBar").then((m) => ({ default: m.HybridInputBar }))
+);
 
 const RESIZE_STEP = 10;
 const RESIZE_PAGE_STEP = 50;
@@ -88,6 +98,7 @@ export function HelpPanel({
 }: HelpPanelProps) {
   const panelRef = useRef<HTMLElement>(null);
   const contentRef = useRef<HTMLDivElement>(null);
+  const inputBarRef = useRef<HybridInputBarHandle>(null);
   // Element that owned focus when the panel last opened. We restore focus to
   // it on close so keyboard users return to where they were rather than
   // body. Mirrors the pattern in AppDialog/AppPaletteDialog.
@@ -139,8 +150,16 @@ export function HelpPanel({
   const cliAvailability = useCliAvailabilityStore((s) => s.availability);
   const cliHasRealData = useCliAvailabilityStore((s) => s.hasRealData);
   const currentProject = useProjectStore((s) => s.currentProject);
+  const hybridInputEnabled = useTerminalInputStore((s) => s.hybridInputEnabled);
 
   const agentConfig = agentId ? getAgentConfig(agentId) : undefined;
+  const effectiveAgentId = isBuiltInAgentId(agentId) ? agentId : undefined;
+  const showHybridInputBar = shouldShowHybridInputBar({
+    hasAgentIdentity: effectiveAgentId !== undefined,
+    hybridInputEnabled,
+    isFleetArmed: false,
+    fleetSize: 0,
+  });
 
   // Intersection of "wired for the assistant overlay" and "CLI is installed".
   // Drives the single-supported-agent auto-skip in the controller.
@@ -262,13 +281,25 @@ export function HelpPanel({
         if (!state.isOpen) return;
 
         const current = document.activeElement;
-        if (current?.closest?.(".xterm-helper-textarea") && panelRef.current?.contains(current)) {
+        if (
+          (current?.closest?.(".xterm-helper-textarea") || current?.closest?.(".cm-editor")) &&
+          panelRef.current?.contains(current)
+        ) {
           return;
         }
 
-        // When an agent terminal is running, target its xterm input first.
-        // Falls back to the first-tabbable sweep for pre-launch / missing-CLI.
+        // When an agent terminal is running, target the HybridInputBar editor
+        // first (when available), then the xterm input as fallback. The bar
+        // ref is null during the lazy Suspense window — in that case fall back
+        // to xterm so cold-load opens still focus something.
         if (terminalId && terminal && terminal.spawnStatus !== "missing-cli") {
+          if (showHybridInputBar && inputBarRef.current) {
+            inputBarRef.current.focusWithCursorAtEnd();
+            const after = document.activeElement;
+            if (after?.closest?.(".cm-editor") && panelRef.current?.contains(after)) {
+              return;
+            }
+          }
           terminalInstanceService.focus(terminalId);
           const after = document.activeElement;
           if (after?.closest?.(".xterm-helper-textarea") && panelRef.current?.contains(after)) {
@@ -297,7 +328,7 @@ export function HelpPanel({
       el.focus();
     }
     return undefined;
-  }, [isOpen, isVisible, focusRequest, terminalId, terminal]);
+  }, [isOpen, isVisible, focusRequest, terminalId, terminal, showHybridInputBar]);
 
   // Resize via mouse drag
   const handleResizeStart = useCallback(
@@ -409,10 +440,12 @@ export function HelpPanel({
   const alwaysAllowTier = useCallback(() => controller.alwaysAllowTier(), [controller]);
 
   // Esc-to-close. The xterm-helper-textarea check lets Escape reach the
-  // running PTY when the assistant terminal has focus.
+  // running PTY when the assistant terminal has focus; the .cm-editor check
+  // lets the HybridInputBar dismiss its autocomplete / expanded modal first.
   const handleEscape = useCallback(() => {
     const active = document.activeElement as HTMLElement | null;
     if (active?.closest(".xterm-helper-textarea")) return;
+    if (active?.closest(".cm-editor")) return;
     handleClose();
   }, [handleClose]);
   useEscapeStack(isOpen, handleEscape);
@@ -510,6 +543,29 @@ export function HelpPanel({
                   />
                 </Suspense>
               </div>
+              {showHybridInputBar && (
+                <Suspense fallback={null}>
+                  <LazyHybridInputBar
+                    ref={inputBarRef}
+                    terminalId={terminalId}
+                    cwd={terminal.cwd}
+                    agentId={effectiveAgentId}
+                    agentHasLifecycleEvent={terminal?.stateChangeTrigger !== undefined}
+                    agentState={terminal?.agentState}
+                    disabled={terminal?.isInputLocked === true}
+                    onSend={({ text }) => {
+                      if (terminal?.isInputLocked === true) return;
+                      terminalInstanceService.notifyUserInput(terminalId);
+                      void terminalClient.submit(terminalId, text);
+                    }}
+                    onSendKey={(key) => {
+                      if (terminal?.isInputLocked === true) return;
+                      terminalInstanceService.notifyUserInput(terminalId);
+                      terminalClient.sendKey(terminalId, key);
+                    }}
+                  />
+                </Suspense>
+              )}
             </>
           )
         ) : session.assistantVersionTooOld ? (

--- a/src/components/HelpPanel/HelpPanel.tsx
+++ b/src/components/HelpPanel/HelpPanel.tsx
@@ -557,7 +557,7 @@ export function HelpPanel({
                   <LazyHybridInputBar
                     ref={inputBarRef}
                     terminalId={terminalId}
-                    cwd={terminal.cwd}
+                    cwd={terminal?.cwd ?? ""}
                     agentId={effectiveAgentId}
                     agentHasLifecycleEvent={terminal?.stateChangeTrigger !== undefined}
                     agentState={terminal?.agentState}

--- a/src/components/HelpPanel/HelpPanel.tsx
+++ b/src/components/HelpPanel/HelpPanel.tsx
@@ -292,13 +292,17 @@ export function HelpPanel({
         // first (when available), then the xterm input as fallback. The bar
         // ref is null during the lazy Suspense window — in that case fall back
         // to xterm so cold-load opens still focus something.
+        //
+        // `focusWithCursorAtEnd()` schedules `view.focus()` inside its own
+        // requestAnimationFrame (HybridInputBar.tsx:538), so we cannot
+        // synchronously check `document.activeElement` after calling it. We
+        // trust the bar's internal rAF to take focus when its ref is present
+        // — no xterm fallback in that branch, otherwise CodeMirror would
+        // steal focus from xterm one frame later and produce a focus flicker.
         if (terminalId && terminal && terminal.spawnStatus !== "missing-cli") {
           if (showHybridInputBar && inputBarRef.current) {
             inputBarRef.current.focusWithCursorAtEnd();
-            const after = document.activeElement;
-            if (after?.closest?.(".cm-editor") && panelRef.current?.contains(after)) {
-              return;
-            }
+            return;
           }
           terminalInstanceService.focus(terminalId);
           const after = document.activeElement;
@@ -442,10 +446,14 @@ export function HelpPanel({
   // Esc-to-close. The xterm-helper-textarea check lets Escape reach the
   // running PTY when the assistant terminal has focus; the .cm-editor check
   // lets the HybridInputBar dismiss its autocomplete / expanded modal first.
+  // Both guards are scoped to the panel so a focused CodeMirror or xterm in a
+  // different panel (e.g. FileViewer, a grid terminal) can't trap Escape here.
   const handleEscape = useCallback(() => {
     const active = document.activeElement as HTMLElement | null;
-    if (active?.closest(".xterm-helper-textarea")) return;
-    if (active?.closest(".cm-editor")) return;
+    if (active && panelRef.current?.contains(active)) {
+      if (active.closest(".xterm-helper-textarea")) return;
+      if (active.closest(".cm-editor")) return;
+    }
     handleClose();
   }, [handleClose]);
   useEscapeStack(isOpen, handleEscape);
@@ -540,6 +548,7 @@ export function HelpPanel({
                     launchAgentId={agentId ?? undefined}
                     getRefreshTier={getRefreshTier}
                     cwd={terminal.cwd}
+                    hasBottomBar={showHybridInputBar}
                   />
                 </Suspense>
               </div>

--- a/src/components/HelpPanel/__tests__/HelpPanel.helpLaunch.test.tsx
+++ b/src/components/HelpPanel/__tests__/HelpPanel.helpLaunch.test.tsx
@@ -2729,13 +2729,15 @@ describe("HelpPanel — HybridInputBar wiring (issue #8185)", () => {
 
     const { container } = render(<HelpPanel width={380} />);
 
-    // Simulate CodeMirror focus by attaching a fake element to document.body
-    // that matches `.cm-editor` via `.closest`.
+    // Simulate CodeMirror focus inside the assistant panel — `closest(".cm-editor")`
+    // matches and `panelRef.current?.contains(active)` is true.
+    const panel = container.querySelector("#daintree-assistant-panel");
+    expect(panel).not.toBeNull();
     const editor = document.createElement("div");
     editor.className = "cm-editor";
     const textarea = document.createElement("textarea");
     editor.appendChild(textarea);
-    container.appendChild(editor);
+    panel!.appendChild(editor);
     textarea.focus();
     expect(document.activeElement).toBe(textarea);
 
@@ -2748,5 +2750,34 @@ describe("HelpPanel — HybridInputBar wiring (issue #8185)", () => {
     });
 
     expect(helpPanelState.setOpen).not.toHaveBeenCalledWith(false);
+  });
+
+  it("Escape with focus inside a .cm-editor OUTSIDE the panel still closes it", () => {
+    setupBoundTerminal();
+
+    render(<HelpPanel width={380} />);
+
+    // Simulate a CodeMirror editor in a different panel (e.g. FileViewer) by
+    // attaching it to document.body — outside the assistant panel root.
+    const editor = document.createElement("div");
+    editor.className = "cm-editor";
+    const textarea = document.createElement("textarea");
+    editor.appendChild(textarea);
+    document.body.appendChild(editor);
+    textarea.focus();
+    expect(document.activeElement).toBe(textarea);
+
+    const escapeMock = vi.mocked(useEscapeStack);
+    const callback = escapeMock.mock.calls.at(-1)?.[1];
+    expect(callback).toBeTypeOf("function");
+
+    act(() => {
+      callback?.();
+    });
+
+    // External CodeMirror must not trap the assistant's Escape handler.
+    expect(helpPanelState.setOpen).toHaveBeenCalledWith(false);
+
+    document.body.removeChild(editor);
   });
 });

--- a/src/components/HelpPanel/__tests__/HelpPanel.helpLaunch.test.tsx
+++ b/src/components/HelpPanel/__tests__/HelpPanel.helpLaunch.test.tsx
@@ -24,6 +24,10 @@ const {
   agentSettingsState,
   projectStoreState,
   preferencesState,
+  terminalInputState,
+  mockTerminalSubmit,
+  mockTerminalSendKey,
+  mockNotifyUserInput,
 } = vi.hoisted(() => ({
   mockDispatch: vi.fn(),
   mockNotify: vi.fn().mockReturnValue(""),
@@ -103,6 +107,10 @@ const {
     currentProject: { id: "proj-default", path: "/repo" } as { id: string; path: string } | null,
   },
   preferencesState: { reduceAnimations: false },
+  terminalInputState: { hybridInputEnabled: true } as { hybridInputEnabled: boolean },
+  mockTerminalSubmit: vi.fn(),
+  mockTerminalSendKey: vi.fn(),
+  mockNotifyUserInput: vi.fn(),
 }));
 
 vi.mock("@/lib/utils", () => ({ cn: (...args: unknown[]) => args.filter(Boolean).join(" ") }));
@@ -123,6 +131,51 @@ vi.mock("@/components/Terminal/XtermAdapter", () => ({
   XtermAdapter: () => <div data-testid="xterm-adapter" />,
 }));
 
+vi.mock("@/components/Terminal/HybridInputBar", () => ({
+  HybridInputBar: ({
+    terminalId,
+    onSend,
+    onSendKey,
+    disabled,
+  }: {
+    terminalId: string;
+    onSend?: (payload: { data: string; trackerData: string; text: string }) => void;
+    onSendKey?: (key: string) => void;
+    disabled?: boolean;
+  }) => (
+    <div
+      data-testid="hybrid-input-bar"
+      data-terminal-id={terminalId}
+      data-disabled={disabled ? "true" : "false"}
+    >
+      <button
+        type="button"
+        data-testid="hybrid-input-send"
+        onClick={() => onSend?.({ data: "hello", trackerData: "hello", text: "hello" })}
+      >
+        send
+      </button>
+      <button type="button" data-testid="hybrid-input-key" onClick={() => onSendKey?.("escape")}>
+        key
+      </button>
+    </div>
+  ),
+}));
+
+vi.mock("@/clients", () => ({
+  terminalClient: {
+    submit: (...args: unknown[]) => mockTerminalSubmit(...args),
+    sendKey: (...args: unknown[]) => mockTerminalSendKey(...args),
+  },
+}));
+
+vi.mock("@/services/TerminalInstanceService", () => ({
+  terminalInstanceService: {
+    focus: vi.fn(),
+    notifyUserInput: (...args: unknown[]) => mockNotifyUserInput(...args),
+  },
+}));
+
 vi.mock("@/components/Terminal/MissingCliGate", () => ({
   MissingCliGate: ({ agentId, onRunAnyway }: { agentId: string; onRunAnyway: () => void }) => (
     <div data-testid="missing-cli-gate" data-agent={agentId}>
@@ -133,9 +186,14 @@ vi.mock("@/components/Terminal/MissingCliGate", () => ({
   ),
 }));
 
-vi.mock("@shared/config/agentIds", () => ({
-  BUILT_IN_AGENT_IDS: ["claude", "gemini", "codex"],
-}));
+vi.mock("@shared/config/agentIds", () => {
+  const ids = ["claude", "gemini", "codex"];
+  return {
+    BUILT_IN_AGENT_IDS: ids,
+    isBuiltInAgentId: (value: unknown): value is "claude" | "gemini" | "codex" =>
+      typeof value === "string" && ids.includes(value),
+  };
+});
 
 vi.mock("@/config/agents", () => ({
   AGENT_REGISTRY: {
@@ -211,6 +269,10 @@ vi.mock("@/store", () => {
     selector ? selector(worktreeSelectionState) : worktreeSelectionState;
   worktreeSelectionStore.getState = () => worktreeSelectionState;
 
+  const terminalInputStore = (selector?: (state: typeof terminalInputState) => unknown) =>
+    selector ? selector(terminalInputState) : terminalInputState;
+  terminalInputStore.getState = () => terminalInputState;
+
   return {
     usePanelStore: panelStore,
     useCliAvailabilityStore: cliStore,
@@ -218,6 +280,7 @@ vi.mock("@/store", () => {
     useProjectStore: projectStore,
     usePreferencesStore: preferencesStore,
     useWorktreeSelectionStore: worktreeSelectionStore,
+    useTerminalInputStore: terminalInputStore,
     getTerminalRefreshTier: () => 0,
   };
 });
@@ -315,6 +378,11 @@ function resetState() {
 
   projectStoreState.currentProject = { id: "proj-default", path: "/repo" };
   preferencesState.reduceAnimations = false;
+  terminalInputState.hybridInputEnabled = true;
+  mockTerminalSubmit.mockReset();
+  mockTerminalSubmit.mockResolvedValue(undefined);
+  mockTerminalSendKey.mockReset();
+  mockNotifyUserInput.mockReset();
   mockProvisionSession.mockReset();
   mockProvisionSession.mockResolvedValue({
     sessionId: "sess-default",
@@ -2529,5 +2597,156 @@ describe("HelpPanel — assistantMinVersion gate (issue #7539)", () => {
       expect.objectContaining({ agentId: "claude" }),
       { source: "user" }
     );
+  });
+});
+
+describe("HelpPanel — HybridInputBar wiring (issue #8185)", () => {
+  function setupBoundTerminal(overrides: { isInputLocked?: boolean } = {}) {
+    helpPanelState.terminalId = "term-1";
+    helpPanelState.agentId = "claude";
+    panelStoreState.panelsById = {
+      "term-1": {
+        id: "term-1",
+        kind: "terminal",
+        spawnStatus: "ready",
+        cwd: "/help",
+        agentState: "idle",
+        isInputLocked: overrides.isInputLocked ?? false,
+      },
+    };
+  }
+
+  it("renders HybridInputBar when an agent is bound and hybridInputEnabled is true", async () => {
+    setupBoundTerminal();
+    terminalInputState.hybridInputEnabled = true;
+
+    let queryByTestId!: ReturnType<typeof render>["queryByTestId"];
+    await act(async () => {
+      ({ queryByTestId } = render(<HelpPanel width={380} />));
+    });
+
+    const bar = queryByTestId("hybrid-input-bar");
+    expect(bar).not.toBeNull();
+    expect(bar?.getAttribute("data-terminal-id")).toBe("term-1");
+    expect(bar?.getAttribute("data-disabled")).toBe("false");
+  });
+
+  it("does not render HybridInputBar when hybridInputEnabled is false", async () => {
+    setupBoundTerminal();
+    terminalInputState.hybridInputEnabled = false;
+
+    let queryByTestId!: ReturnType<typeof render>["queryByTestId"];
+    await act(async () => {
+      ({ queryByTestId } = render(<HelpPanel width={380} />));
+    });
+
+    expect(queryByTestId("hybrid-input-bar")).toBeNull();
+  });
+
+  it("does not render HybridInputBar when no agent is bound", async () => {
+    helpPanelState.terminalId = null;
+    helpPanelState.agentId = null;
+    terminalInputState.hybridInputEnabled = true;
+
+    let queryByTestId!: ReturnType<typeof render>["queryByTestId"];
+    await act(async () => {
+      ({ queryByTestId } = render(<HelpPanel width={380} />));
+    });
+
+    expect(queryByTestId("hybrid-input-bar")).toBeNull();
+  });
+
+  it("onSend calls notifyUserInput before terminalClient.submit", async () => {
+    setupBoundTerminal();
+
+    let getByTestId!: ReturnType<typeof render>["getByTestId"];
+    await act(async () => {
+      ({ getByTestId } = render(<HelpPanel width={380} />));
+    });
+
+    await act(async () => {
+      fireEvent.click(getByTestId("hybrid-input-send"));
+    });
+
+    expect(mockNotifyUserInput).toHaveBeenCalledWith("term-1");
+    expect(mockTerminalSubmit).toHaveBeenCalledWith("term-1", "hello");
+    // Order matters (lesson #2187): notifyUserInput must precede submit.
+    expect(mockNotifyUserInput.mock.invocationCallOrder[0]).toBeLessThan(
+      mockTerminalSubmit.mock.invocationCallOrder[0]
+    );
+  });
+
+  it("onSendKey calls notifyUserInput before terminalClient.sendKey", async () => {
+    setupBoundTerminal();
+
+    let getByTestId!: ReturnType<typeof render>["getByTestId"];
+    await act(async () => {
+      ({ getByTestId } = render(<HelpPanel width={380} />));
+    });
+
+    await act(async () => {
+      fireEvent.click(getByTestId("hybrid-input-key"));
+    });
+
+    expect(mockNotifyUserInput).toHaveBeenCalledWith("term-1");
+    expect(mockTerminalSendKey).toHaveBeenCalledWith("term-1", "escape");
+    expect(mockNotifyUserInput.mock.invocationCallOrder[0]).toBeLessThan(
+      mockTerminalSendKey.mock.invocationCallOrder[0]
+    );
+  });
+
+  it("onSend and onSendKey are no-ops when isInputLocked is true", async () => {
+    setupBoundTerminal({ isInputLocked: true });
+
+    let getByTestId!: ReturnType<typeof render>["getByTestId"];
+    await act(async () => {
+      ({ getByTestId } = render(<HelpPanel width={380} />));
+    });
+
+    await act(async () => {
+      fireEvent.click(getByTestId("hybrid-input-send"));
+      fireEvent.click(getByTestId("hybrid-input-key"));
+    });
+
+    expect(mockNotifyUserInput).not.toHaveBeenCalled();
+    expect(mockTerminalSubmit).not.toHaveBeenCalled();
+    expect(mockTerminalSendKey).not.toHaveBeenCalled();
+  });
+
+  it("renders HybridInputBar as disabled when isInputLocked is true", async () => {
+    setupBoundTerminal({ isInputLocked: true });
+
+    let queryByTestId!: ReturnType<typeof render>["queryByTestId"];
+    await act(async () => {
+      ({ queryByTestId } = render(<HelpPanel width={380} />));
+    });
+
+    expect(queryByTestId("hybrid-input-bar")?.getAttribute("data-disabled")).toBe("true");
+  });
+
+  it("Escape with focus inside .cm-editor does not close the panel (autocomplete swallow)", () => {
+    setupBoundTerminal();
+
+    const { container } = render(<HelpPanel width={380} />);
+
+    // Simulate CodeMirror focus by attaching a fake element to document.body
+    // that matches `.cm-editor` via `.closest`.
+    const editor = document.createElement("div");
+    editor.className = "cm-editor";
+    const textarea = document.createElement("textarea");
+    editor.appendChild(textarea);
+    container.appendChild(editor);
+    textarea.focus();
+    expect(document.activeElement).toBe(textarea);
+
+    const escapeMock = vi.mocked(useEscapeStack);
+    const callback = escapeMock.mock.calls.at(-1)?.[1];
+    expect(callback).toBeTypeOf("function");
+
+    act(() => {
+      callback?.();
+    });
+
+    expect(helpPanelState.setOpen).not.toHaveBeenCalledWith(false);
   });
 });

--- a/src/components/HelpPanel/__tests__/HelpPanel.helpLaunch.test.tsx
+++ b/src/components/HelpPanel/__tests__/HelpPanel.helpLaunch.test.tsx
@@ -2671,8 +2671,8 @@ describe("HelpPanel — HybridInputBar wiring (issue #8185)", () => {
     expect(mockNotifyUserInput).toHaveBeenCalledWith("term-1");
     expect(mockTerminalSubmit).toHaveBeenCalledWith("term-1", "hello");
     // Order matters (lesson #2187): notifyUserInput must precede submit.
-    expect(mockNotifyUserInput.mock.invocationCallOrder[0]).toBeLessThan(
-      mockTerminalSubmit.mock.invocationCallOrder[0]
+    expect(mockNotifyUserInput.mock.invocationCallOrder?.[0] ?? 0).toBeLessThan(
+      mockTerminalSubmit.mock.invocationCallOrder?.[0] ?? 0
     );
   });
 
@@ -2690,8 +2690,8 @@ describe("HelpPanel — HybridInputBar wiring (issue #8185)", () => {
 
     expect(mockNotifyUserInput).toHaveBeenCalledWith("term-1");
     expect(mockTerminalSendKey).toHaveBeenCalledWith("term-1", "escape");
-    expect(mockNotifyUserInput.mock.invocationCallOrder[0]).toBeLessThan(
-      mockTerminalSendKey.mock.invocationCallOrder[0]
+    expect(mockNotifyUserInput.mock.invocationCallOrder?.[0] ?? 0).toBeLessThan(
+      mockTerminalSendKey.mock.invocationCallOrder?.[0] ?? 0
     );
   });
 

--- a/src/components/HelpPanel/__tests__/HelpPanel.hibernate.test.tsx
+++ b/src/components/HelpPanel/__tests__/HelpPanel.hibernate.test.tsx
@@ -24,6 +24,10 @@ const {
   agentSettingsState,
   projectStoreState,
   preferencesState,
+  terminalInputState,
+  mockTerminalSubmit,
+  mockTerminalSendKey,
+  mockNotifyUserInput,
 } = vi.hoisted(() => ({
   mockDispatch: vi.fn(),
   mockNotify: vi.fn().mockReturnValue(""),
@@ -95,6 +99,10 @@ const {
     currentProject: null as { id: string; path: string } | null,
   },
   preferencesState: { reduceAnimations: false },
+  terminalInputState: { hybridInputEnabled: true } as { hybridInputEnabled: boolean },
+  mockTerminalSubmit: vi.fn(),
+  mockTerminalSendKey: vi.fn(),
+  mockNotifyUserInput: vi.fn(),
 }));
 
 vi.mock("@/lib/utils", () => ({ cn: (...args: unknown[]) => args.filter(Boolean).join(" ") }));
@@ -115,6 +123,26 @@ vi.mock("@/components/Terminal/XtermAdapter", () => ({
   XtermAdapter: () => <div data-testid="xterm-adapter" />,
 }));
 
+vi.mock("@/components/Terminal/HybridInputBar", () => ({
+  HybridInputBar: ({ terminalId }: { terminalId: string }) => (
+    <div data-testid="hybrid-input-bar" data-terminal-id={terminalId} />
+  ),
+}));
+
+vi.mock("@/clients", () => ({
+  terminalClient: {
+    submit: (...args: unknown[]) => mockTerminalSubmit(...args),
+    sendKey: (...args: unknown[]) => mockTerminalSendKey(...args),
+  },
+}));
+
+vi.mock("@/services/TerminalInstanceService", () => ({
+  terminalInstanceService: {
+    focus: vi.fn(),
+    notifyUserInput: (...args: unknown[]) => mockNotifyUserInput(...args),
+  },
+}));
+
 vi.mock("@/components/Terminal/MissingCliGate", () => ({
   MissingCliGate: ({ agentId, onRunAnyway }: { agentId: string; onRunAnyway: () => void }) => (
     <div data-testid="missing-cli-gate" data-agent={agentId}>
@@ -125,9 +153,14 @@ vi.mock("@/components/Terminal/MissingCliGate", () => ({
   ),
 }));
 
-vi.mock("@shared/config/agentIds", () => ({
-  BUILT_IN_AGENT_IDS: ["claude"],
-}));
+vi.mock("@shared/config/agentIds", () => {
+  const ids = ["claude"];
+  return {
+    BUILT_IN_AGENT_IDS: ids,
+    isBuiltInAgentId: (value: unknown): value is "claude" =>
+      typeof value === "string" && ids.includes(value),
+  };
+});
 
 vi.mock("@/config/agents", () => ({
   AGENT_REGISTRY: {
@@ -195,6 +228,10 @@ vi.mock("@/store", () => {
     selector ? selector(worktreeSelectionState) : worktreeSelectionState;
   worktreeSelectionStore.getState = () => worktreeSelectionState;
 
+  const terminalInputStore = (selector?: (state: typeof terminalInputState) => unknown) =>
+    selector ? selector(terminalInputState) : terminalInputState;
+  terminalInputStore.getState = () => terminalInputState;
+
   return {
     usePanelStore: panelStore,
     useCliAvailabilityStore: cliStore,
@@ -202,6 +239,7 @@ vi.mock("@/store", () => {
     useProjectStore: projectStore,
     usePreferencesStore: preferencesStore,
     useWorktreeSelectionStore: worktreeSelectionStore,
+    useTerminalInputStore: terminalInputStore,
     getTerminalRefreshTier: () => 0,
   };
 });
@@ -286,6 +324,11 @@ function resetState() {
 
   projectStoreState.currentProject = null;
   preferencesState.reduceAnimations = false;
+  terminalInputState.hybridInputEnabled = true;
+  mockTerminalSubmit.mockReset();
+  mockTerminalSubmit.mockResolvedValue(undefined);
+  mockTerminalSendKey.mockReset();
+  mockNotifyUserInput.mockReset();
   mockProvisionSession.mockReset();
   mockProvisionSession.mockResolvedValue(null);
   mockRevokeSession.mockReset();


### PR DESCRIPTION
Closes #8185.

## Summary

- Renders `LazyHybridInputBar` beneath `XtermAdapter` in the Daintree Assistant when an agent is bound and `hybridInputEnabled` is true, mirroring `TerminalPane`'s wiring so the assistant gets CodeMirror editing, slash-command autocomplete, `@file` / `@diff` / `@terminal` / `@selection` mentions, voice input, drag-and-drop, expandable editor modal, and prompt history.
- Extends the Esc-to-close guard to also bail on `.cm-editor` focus so CodeMirror's autocomplete and expanded modal can dismiss first. Both `.cm-editor` and `.xterm-helper-textarea` guards now require panel containment so an editor in `FileViewer` or another panel cannot trap Escape and prevent the assistant from closing.
- On open, focus prefers `inputBarRef.current?.focusWithCursorAtEnd()`. `focusWithCursorAtEnd` schedules `view.focus()` inside its own `requestAnimationFrame`, so the synchronous `activeElement` check after the call was dropped (it would always fail and the xterm fallback would steal focus one frame before CodeMirror took it). The xterm fallback only runs when the lazy chunk is still resolving and the ref is null.
- `onSend` and `onSendKey` call `terminalInstanceService.notifyUserInput(terminalId)` synchronously before `terminalClient.submit` / `sendKey` so \`ActivityMonitor\` sees the user signal atomically (lesson #2187). Both paths short-circuit when \`isInputLocked\` is true.
- Passes \`hasBottomBar={showHybridInputBar}\` to \`XtermAdapter\` so the terminal surface drops its bottom rounding when the input bar sits below it.
- No signature change to \`shouldShowHybridInputBar\` — the existing \`hasAgentIdentity\` path covers the assistant once \`agentId\` is bound. \`BuiltInAgentId\` narrowing via \`isBuiltInAgentId\` keeps the prop type-safe on the bar.

## Test plan

- [x] \`npx vitest run src/components/HelpPanel/__tests__/HelpPanel.helpLaunch.test.tsx src/components/Terminal/__tests__/terminalFocus.test.ts\` — 112 tests pass.
- [x] \`npm run check\` (lint ratchet, format, typecheck, channel/IPC/help-prompt drift) — all green; lint warnings dropped by 8.
- [ ] Manual: open the assistant after a bound launch, confirm the HybridInputBar renders beneath xterm, slash-command and \`@file\` autocomplete work, voice/expand modal open, Escape inside the autocomplete dismisses it without closing the panel, Escape outside the panel still closes it.
- [ ] Manual: confirm focus on open lands in the CodeMirror editor (cold-load may land in xterm for one open before the lazy chunk resolves; the second open should land in the bar).