### PR TITLE
feat(agent-tray): polish discovery dot, pinned icon, MRU, and TTL backstop

### DIFF
--- a/electron/ipc/channels.ts
+++ b/electron/ipc/channels.ts
@@ -594,6 +594,7 @@ export const CHANNELS = {
   ONBOARDING_MARK_NEWSLETTER_SEEN: "onboarding:mark-newsletter-seen",
   ONBOARDING_MARK_WAITING_NUDGE_SEEN: "onboarding:mark-waiting-nudge-seen",
   ONBOARDING_MARK_AGENTS_SEEN: "onboarding:mark-agents-seen",
+  ONBOARDING_RECORD_AVAILABILITY_FIRST_SEEN: "onboarding:record-availability-first-seen",
   ONBOARDING_DISMISS_WELCOME_CARD: "onboarding:dismiss-welcome-card",
   ONBOARDING_DISMISS_SETUP_BANNER: "onboarding:dismiss-setup-banner",
   ONBOARDING_CHECKLIST_GET: "onboarding:checklist-get",

--- a/electron/ipc/handlers/onboarding.ts
+++ b/electron/ipc/handlers/onboarding.ts
@@ -23,7 +23,7 @@ const SKIP_E2E = process.env.DAINTREE_E2E_SKIP_FIRST_RUN_DIALOGS === "1";
 function getOnboardingState(): OnboardingState {
   if (SKIP_E2E) {
     return {
-      schemaVersion: 1,
+      schemaVersion: 2,
       completed: true,
       currentStep: null,
       agentSetupIds: [],
@@ -31,6 +31,7 @@ function getOnboardingState(): OnboardingState {
       newsletterPromptSeen: true,
       waitingNudgeSeen: true,
       seenAgentIds: [],
+      availabilityFirstSeen: {},
       welcomeCardDismissed: true,
       setupBannerDismissed: true,
       checklist: {
@@ -48,7 +49,7 @@ function getOnboardingState(): OnboardingState {
   const raw = store.get("onboarding");
   if (!raw) {
     return {
-      schemaVersion: 1,
+      schemaVersion: 2,
       completed: false,
       currentStep: null,
       agentSetupIds: [],
@@ -56,6 +57,7 @@ function getOnboardingState(): OnboardingState {
       newsletterPromptSeen: false,
       waitingNudgeSeen: false,
       seenAgentIds: [],
+      availabilityFirstSeen: {},
       welcomeCardDismissed: false,
       setupBannerDismissed: false,
       checklist: DEFAULT_CHECKLIST,
@@ -65,10 +67,15 @@ function getOnboardingState(): OnboardingState {
   const mergedItems = { ...DEFAULT_CHECKLIST.items, ...checklist.items };
   return {
     ...raw,
+    schemaVersion: 2,
     agentSetupIds: Array.isArray(raw.agentSetupIds) ? raw.agentSetupIds : [],
     seenAgentIds: Array.isArray(raw.seenAgentIds)
       ? (raw.seenAgentIds as string[]).filter((id) => typeof id === "string")
       : [],
+    availabilityFirstSeen:
+      raw.availabilityFirstSeen && typeof raw.availabilityFirstSeen === "object"
+        ? raw.availabilityFirstSeen
+        : {},
     welcomeCardDismissed: raw.welcomeCardDismissed === true,
     // Treat any already-completed onboarding as implicit banner dismissal —
     // without this, upgraded users who finished onboarding before #5131 see
@@ -158,6 +165,30 @@ export function registerOnboardingHandlers(): () => void {
       const seenAgentIds = Array.from(existing);
       store.set("onboarding.seenAgentIds", seenAgentIds);
       return { ...state, seenAgentIds };
+    })
+  );
+
+  cleanups.push(
+    typedHandle(CHANNELS.ONBOARDING_RECORD_AVAILABILITY_FIRST_SEEN, (payload: unknown) => {
+      const incoming = Array.isArray(payload)
+        ? (payload as unknown[]).filter((id): id is string => typeof id === "string")
+        : [];
+      const state = getOnboardingState();
+      if (incoming.length === 0) return state;
+      const existing = { ...(state.availabilityFirstSeen ?? {}) };
+      const now = Date.now();
+      let changed = false;
+      for (const id of incoming) {
+        // Idempotent: never overwrite an existing first-seen timestamp, so
+        // the TTL clock keeps counting from the genuine first sighting.
+        if (existing[id] === undefined) {
+          existing[id] = now;
+          changed = true;
+        }
+      }
+      if (!changed) return state;
+      store.set("onboarding.availabilityFirstSeen", existing);
+      return { ...state, availabilityFirstSeen: existing };
     })
   );
 

--- a/electron/ipc/handlers/onboarding.ts
+++ b/electron/ipc/handlers/onboarding.ts
@@ -20,6 +20,18 @@ const DEFAULT_CHECKLIST: ChecklistState = {
 
 const SKIP_E2E = process.env.DAINTREE_E2E_SKIP_FIRST_RUN_DIALOGS === "1";
 
+// Keep only finite-number timestamps. A non-numeric persisted value would
+// make `Date.now() - value` NaN in the renderer's TTL check, and `NaN > TTL`
+// is always false — the discovery dot would then never age out.
+function sanitizeFirstSeen(raw: unknown): Record<string, number> {
+  if (!raw || typeof raw !== "object") return {};
+  const out: Record<string, number> = {};
+  for (const [id, value] of Object.entries(raw as Record<string, unknown>)) {
+    if (typeof value === "number" && Number.isFinite(value)) out[id] = value;
+  }
+  return out;
+}
+
 function getOnboardingState(): OnboardingState {
   if (SKIP_E2E) {
     return {
@@ -72,10 +84,7 @@ function getOnboardingState(): OnboardingState {
     seenAgentIds: Array.isArray(raw.seenAgentIds)
       ? (raw.seenAgentIds as string[]).filter((id) => typeof id === "string")
       : [],
-    availabilityFirstSeen:
-      raw.availabilityFirstSeen && typeof raw.availabilityFirstSeen === "object"
-        ? raw.availabilityFirstSeen
-        : {},
+    availabilityFirstSeen: sanitizeFirstSeen(raw.availabilityFirstSeen),
     welcomeCardDismissed: raw.welcomeCardDismissed === true,
     // Treat any already-completed onboarding as implicit banner dismissal —
     // without this, upgraded users who finished onboarding before #5131 see

--- a/electron/preload.cts
+++ b/electron/preload.cts
@@ -2307,6 +2307,8 @@ const api: ElectronAPI = {
     markWaitingNudgeSeen: () => _unwrappingInvoke(CHANNELS.ONBOARDING_MARK_WAITING_NUDGE_SEEN),
     markAgentsSeen: (agentIds: string[]) =>
       _unwrappingInvoke(CHANNELS.ONBOARDING_MARK_AGENTS_SEEN, agentIds),
+    recordAvailabilityFirstSeen: (agentIds: string[]) =>
+      _unwrappingInvoke(CHANNELS.ONBOARDING_RECORD_AVAILABILITY_FIRST_SEEN, agentIds),
     dismissWelcomeCard: () => _unwrappingInvoke(CHANNELS.ONBOARDING_DISMISS_WELCOME_CARD),
     dismissSetupBanner: () => _unwrappingInvoke(CHANNELS.ONBOARDING_DISMISS_SETUP_BANNER),
     getChecklist: () => _unwrappingInvoke(CHANNELS.ONBOARDING_CHECKLIST_GET),

--- a/electron/store.ts
+++ b/electron/store.ts
@@ -248,6 +248,7 @@ export interface StoreSchema {
     newsletterPromptSeen: boolean;
     waitingNudgeSeen: boolean;
     seenAgentIds: string[];
+    availabilityFirstSeen?: Record<string, number>;
     welcomeCardDismissed: boolean;
     setupBannerDismissed: boolean;
     checklist: {

--- a/shared/types/ipc/api.ts
+++ b/shared/types/ipc/api.ts
@@ -1232,6 +1232,7 @@ export interface ElectronAPI {
     markNewsletterSeen(): Promise<void>;
     markWaitingNudgeSeen(): Promise<void>;
     markAgentsSeen(agentIds: string[]): Promise<OnboardingState>;
+    recordAvailabilityFirstSeen(agentIds: string[]): Promise<OnboardingState>;
     dismissWelcomeCard(): Promise<OnboardingState>;
     dismissSetupBanner(): Promise<OnboardingState>;
     getChecklist(): Promise<ChecklistState>;

--- a/shared/types/ipc/maps.ts
+++ b/shared/types/ipc/maps.ts
@@ -1563,6 +1563,10 @@ export interface IpcInvokeMap extends GeneratedIpcInvokeMap {
     args: [agentIds: string[]];
     result: OnboardingState;
   };
+  "onboarding:record-availability-first-seen": {
+    args: [agentIds: string[]];
+    result: OnboardingState;
+  };
   "onboarding:dismiss-welcome-card": {
     args: [];
     result: OnboardingState;

--- a/shared/types/ipc/maps.ts
+++ b/shared/types/ipc/maps.ts
@@ -203,6 +203,13 @@ export interface OnboardingState {
   newsletterPromptSeen: boolean;
   waitingNudgeSeen: boolean;
   seenAgentIds: string[];
+  /**
+   * Agent ID → unix-ms timestamp of when the agent first became launchable.
+   * Drives the discovery-badge TTL backstop: a "new" agent the user never
+   * launches still auto-clears after the window elapses. Optional/additive —
+   * absent for stores written before this field existed.
+   */
+  availabilityFirstSeen?: Record<string, number>;
   welcomeCardDismissed: boolean;
   setupBannerDismissed: boolean;
   checklist: ChecklistState;

--- a/src/components/Layout/AgentTrayButton.tsx
+++ b/src/components/Layout/AgentTrayButton.tsx
@@ -45,7 +45,10 @@ import { usePanelStore } from "@/store/panelStore";
 import { useWorktreeSelectionStore } from "@/store/worktreeStore";
 
 import { useKeybindingDisplay } from "@/hooks";
-import { useAgentDiscoveryOnboarding } from "@/hooks/app/useAgentDiscoveryOnboarding";
+import {
+  useAgentDiscoveryOnboarding,
+  AGENT_DISCOVERY_TTL_MS,
+} from "@/hooks/app/useAgentDiscoveryOnboarding";
 import { AgentShortcutCapture } from "@/components/KeyboardShortcuts";
 import { notify } from "@/lib/notify";
 import { BUILT_IN_AGENT_IDS, type BuiltInAgentId } from "@shared/config/agentIds";
@@ -195,7 +198,9 @@ function SplitLaunchItem({ row, onLaunch }: SplitLaunchItemProps) {
         className="p-0 [&>svg:last-child]:hidden overflow-hidden"
         data-testid="submenu-trigger"
         onKeyDown={handleKeyDown}
-        aria-label={`${row.name} (press Enter to launch, Right Arrow for presets)`}
+        aria-label={`${row.name}${
+          row.isNew ? ", new" : ""
+        } (press Enter to launch, Right Arrow for presets)`}
       >
         <span ref={leftAreaRef} className="flex flex-1 items-center gap-2 px-2.5 py-1.5">
           <span className="inline-flex h-4 w-4 items-center justify-center shrink-0">
@@ -306,8 +311,10 @@ export function AgentTrayButton({
   const {
     loaded: onboardingLoaded,
     seenAgentIds,
+    availabilityFirstSeen,
     welcomeCardDismissed,
     markAgentsSeen,
+    recordAgentAvailabilityFirstSeen,
   } = useAgentDiscoveryOnboarding();
 
   const [open, setOpen] = useState(false);
@@ -407,6 +414,14 @@ export function AgentTrayButton({
     return BUILT_IN_AGENT_IDS.filter((id) => isAgentLaunchable(agentAvailability?.[id]));
   }, [agentAvailability]);
 
+  // Start the discovery-badge TTL clock as soon as an agent is launchable —
+  // not on launch. A never-launched agent must still age out of "new", so the
+  // first-seen timestamp can't depend on the user opening or using the tray.
+  useEffect(() => {
+    if (!onboardingLoaded || readyAgentIds.length === 0) return;
+    void recordAgentAvailabilityFirstSeen(readyAgentIds);
+  }, [onboardingLoaded, readyAgentIds, recordAgentAvailabilityFirstSeen]);
+
   const hasNoPinnedAgents = useMemo(() => {
     if (!agentSettings?.agents) return true;
     return !BUILT_IN_AGENT_IDS.some((id) => isAgentPinned(agentSettings.agents?.[id]));
@@ -427,12 +442,19 @@ export function AgentTrayButton({
 
   const newAgentIds = useMemo<ReadonlySet<string>>(() => {
     if (!onboardingLoaded || welcomeCardRenderable) return new Set<string>();
+    const now = Date.now();
     const set = new Set<string>();
     for (const id of readyAgentIds) {
-      if (!seenAgentIds.includes(id)) set.add(id);
+      if (seenAgentIds.includes(id)) continue;
+      // TTL backstop: an agent the user never explicitly dismissed still stops
+      // reading as "new" once the window since it first became launchable
+      // elapses — otherwise the dot lingers forever for ignored agents.
+      const firstSeen = availabilityFirstSeen[id];
+      if (firstSeen !== undefined && now - firstSeen > AGENT_DISCOVERY_TTL_MS) continue;
+      set.add(id);
     }
     return set;
-  }, [onboardingLoaded, welcomeCardRenderable, readyAgentIds, seenAgentIds]);
+  }, [onboardingLoaded, welcomeCardRenderable, readyAgentIds, seenAgentIds, availabilityFirstSeen]);
 
   const showDiscoveryBadge = newAgentIds.size > 0;
 
@@ -478,10 +500,10 @@ export function AgentTrayButton({
       fallbackSetup.push(row);
     }
 
-    // Sort Launch by palette frecency (higher score = more recent). Untracked
-    // agents keep their natural BUILT_IN_AGENT_IDS order after any tracked
-    // ones. Only palette dispatches populate frecency; tray launches
-    // don't record, but palette-sourced frecency is the signal we have.
+    // Sort Launch by frecency (higher score = more recent). Untracked agents
+    // keep their natural BUILT_IN_AGENT_IDS order after any tracked ones. Both
+    // palette dispatches and tray launches feed this frecency, so the order
+    // tracks however the user actually launches agents.
     const frecencyEntries = getSortedActionMruList();
     const frecencyScoreMap = new Map<string, number>();
     frecencyEntries.forEach(({ id, score }) => frecencyScoreMap.set(id, score));
@@ -529,8 +551,15 @@ export function AgentTrayButton({
         { agentId, ...(presetId !== undefined ? { presetId } : {}) },
         { source: "user" }
       );
+      // Clear the discovery signal only for the agent the user actually
+      // launched — opening the tray no longer bulk-clears every ready agent,
+      // so an unused agent keeps its dot until launched or TTL-aged.
+      void markAgentsSeen([agentId]);
+      // Feed tray launches into palette frecency so the tray's own MRU sort
+      // reflects how the user actually launches agents, not just palette use.
+      useActionMruStore.getState().recordActionMru(`agent.${agentId}`);
     },
-    [activeWorktreeId, updateWorktreePreset]
+    [activeWorktreeId, updateWorktreePreset, markAgentsSeen]
   );
 
   const handleSetup = (agentId: BuiltInAgentId) => {
@@ -558,9 +587,6 @@ export function AgentTrayButton({
     if (!open) return;
     // Fire-and-forget: the store throttle absorbs rapid reopens.
     void refreshAvailability().catch(() => {});
-    if (readyAgentIds.length > 0) {
-      void markAgentsSeen(readyAgentIds);
-    }
   };
 
   const togglePin = (row: AgentRow) => {
@@ -824,6 +850,7 @@ function LaunchRow({
       onKeyDown={(e) => onKeyDown(e, row)}
       className="group h-7"
       data-testid={`agent-tray-row-${row.id}`}
+      aria-label={row.isNew ? `${row.name}, new` : undefined}
     >
       <span className="relative mr-2 inline-flex h-4 w-4 items-center justify-center">
         <BrandMark brandColor={getBrandColorHex(row.id)}>
@@ -836,11 +863,10 @@ function LaunchRow({
 
       {row.isNew && (
         <span
-          data-testid={`agent-tray-new-pill-${row.id}`}
-          className="ml-2 shrink-0 rounded border border-status-info/40 px-1.5 py-0.5 text-[10px] uppercase tracking-wide text-status-info"
-        >
-          New
-        </span>
+          data-testid={`agent-tray-new-dot-${row.id}`}
+          className="ml-2 h-1.5 w-1.5 shrink-0 rounded-full bg-status-info ring-1 ring-daintree-sidebar"
+          aria-hidden="true"
+        />
       )}
 
       {displayCombo && <DropdownMenuShortcut>{displayCombo}</DropdownMenuShortcut>}
@@ -877,7 +903,7 @@ function LaunchRow({
         }}
         className={cn(
           "ml-1 inline-flex h-5 w-5 items-center justify-center rounded-sm text-daintree-text/50 transition-opacity hover:bg-overlay-emphasis hover:text-daintree-text",
-          row.pinned ? "opacity-100" : "opacity-0 group-data-[highlighted]:opacity-100"
+          row.pinned ? "opacity-50" : "opacity-0 group-data-[highlighted]:opacity-100"
         )}
       >
         <Pin

--- a/src/components/Layout/AgentTrayButton.tsx
+++ b/src/components/Layout/AgentTrayButton.tsx
@@ -208,7 +208,14 @@ function SplitLaunchItem({ row, onLaunch }: SplitLaunchItemProps) {
               <row.Icon brandColor={getBrandColorHex(row.id)} />
             </BrandMark>
           </span>
-          {row.name}
+          <span className="flex-1">{row.name}</span>
+          {row.isNew && (
+            <span
+              data-testid={`agent-tray-new-dot-${row.id}`}
+              className="ml-1 h-1.5 w-1.5 shrink-0 rounded-full bg-status-info ring-1 ring-daintree-sidebar"
+              aria-hidden="true"
+            />
+          )}
         </span>
         <span
           className="flex items-center px-2 py-1.5 border-l border-daintree-border/50"

--- a/src/components/Layout/__tests__/AgentTrayButton.test.tsx
+++ b/src/components/Layout/__tests__/AgentTrayButton.test.tsx
@@ -23,21 +23,27 @@ let mockActiveWorktreeId: string | null = null;
 let mockHasRealData = true;
 let mockActionMruList: string[] = [];
 
+const recordActionMruMock = vi.fn();
 const markAgentsSeenMock = vi.fn().mockResolvedValue(undefined);
+const recordAgentAvailabilityFirstSeenMock = vi.fn().mockResolvedValue(undefined);
 const dismissWelcomeCardMock = vi.fn().mockResolvedValue(undefined);
 const dismissSetupBannerMock = vi.fn().mockResolvedValue(undefined);
 let mockSeenAgentIds: string[] = [];
+let mockAvailabilityFirstSeen: Record<string, number> = {};
 let mockWelcomeCardDismissed = true;
 const mockSetupBannerDismissed = true;
 let mockOnboardingLoaded = true;
 
 vi.mock("@/hooks/app/useAgentDiscoveryOnboarding", () => ({
+  AGENT_DISCOVERY_TTL_MS: 14 * 24 * 60 * 60 * 1000,
   useAgentDiscoveryOnboarding: () => ({
     loaded: mockOnboardingLoaded,
     seenAgentIds: mockSeenAgentIds,
+    availabilityFirstSeen: mockAvailabilityFirstSeen,
     welcomeCardDismissed: mockWelcomeCardDismissed,
     setupBannerDismissed: mockSetupBannerDismissed,
     markAgentsSeen: markAgentsSeenMock,
+    recordAgentAvailabilityFirstSeen: recordAgentAvailabilityFirstSeenMock,
     dismissWelcomeCard: dismissWelcomeCardMock,
     dismissSetupBanner: dismissSetupBannerMock,
   }),
@@ -70,17 +76,20 @@ vi.mock("@/store/agentSettingsStore", () => ({
 }));
 
 vi.mock("@/store/actionMruStore", () => ({
-  useActionMruStore: (
-    selector: (s: { getSortedActionMruList: () => ActionFrecencyEntry[] }) => unknown
-  ) =>
-    selector({
-      getSortedActionMruList: () =>
-        mockActionMruList.map((id) => ({
-          id,
-          score: mockActionMruList.length - mockActionMruList.indexOf(id),
-          lastAccessedAt: Date.now(),
-        })),
-    }),
+  useActionMruStore: Object.assign(
+    (selector: (s: { getSortedActionMruList: () => ActionFrecencyEntry[] }) => unknown) =>
+      selector({
+        getSortedActionMruList: () =>
+          mockActionMruList.map((id) => ({
+            id,
+            score: mockActionMruList.length - mockActionMruList.indexOf(id),
+            lastAccessedAt: Date.now(),
+          })),
+      }),
+    {
+      getState: () => ({ recordActionMru: recordActionMruMock }),
+    }
+  ),
 }));
 
 type MockCliAvailabilityStoreState = {
@@ -374,8 +383,11 @@ describe("AgentTrayButton", () => {
     mockHasRealData = true;
     mockActionMruList = [];
     markAgentsSeenMock.mockClear();
+    recordAgentAvailabilityFirstSeenMock.mockClear();
+    recordActionMruMock.mockClear();
     dismissWelcomeCardMock.mockClear();
     mockSeenAgentIds = [];
+    mockAvailabilityFirstSeen = {};
     mockWelcomeCardDismissed = true;
     mockOnboardingLoaded = true;
     mockCcrPresetsByAgent = {};
@@ -527,6 +539,25 @@ describe("AgentTrayButton", () => {
     const { getByTestId } = render(<AgentTrayButton agentAvailability={availability} />);
     expect(getByTestId("agent-tray-pin-gemini").getAttribute("data-pinned")).toBe("false");
     expect(getByTestId("agent-tray-pin-codex").getAttribute("data-pinned")).toBe("false");
+  });
+
+  it("dims the pin affordance on already-pinned rows so it reads as a state marker", () => {
+    const availability = {
+      claude: "ready",
+      gemini: "ready",
+    } as unknown as CliAvailability;
+    mockSettings = settingsWith({
+      claude: { pinned: true },
+      gemini: { pinned: false },
+    });
+
+    const { getByTestId } = render(<AgentTrayButton agentAvailability={availability} />);
+    const pinnedWrapper = getByTestId("agent-tray-pin-claude");
+    expect(pinnedWrapper.className).toContain("opacity-50");
+    expect(pinnedWrapper.className).not.toContain("opacity-100");
+    // Unpinned rows keep the hover-reveal treatment, not the dimmed marker.
+    const unpinnedWrapper = getByTestId("agent-tray-pin-gemini");
+    expect(unpinnedWrapper.className).toContain("opacity-0");
   });
 
   it("clicking the pin indicator promotes an unpinned agent without launching", () => {
@@ -874,8 +905,8 @@ describe("AgentTrayButton", () => {
       <AgentTrayButton agentAvailability={availability} />
     );
     expect(getByTestId("agent-tray-discovery-badge").getAttribute("data-visible")).toBe("true");
-    expect(queryByTestId("agent-tray-new-pill-claude")).toBeTruthy();
-    expect(queryByTestId("agent-tray-new-pill-gemini")).toBeNull();
+    expect(queryByTestId("agent-tray-new-dot-claude")).toBeTruthy();
+    expect(queryByTestId("agent-tray-new-dot-gemini")).toBeNull();
   });
 
   it("suppresses the discovery badge while the welcome card is actually renderable", () => {
@@ -888,7 +919,7 @@ describe("AgentTrayButton", () => {
       <AgentTrayButton agentAvailability={availability} />
     );
     expect(getByTestId("agent-tray-discovery-badge").getAttribute("data-visible")).toBe("false");
-    expect(queryByTestId("agent-tray-new-pill-claude")).toBeNull();
+    expect(queryByTestId("agent-tray-new-dot-claude")).toBeNull();
   });
 
   it("shows the discovery badge when a pinned agent exists even if welcomeCardDismissed is false", () => {
@@ -906,7 +937,7 @@ describe("AgentTrayButton", () => {
 
     const { queryByTestId } = render(<AgentTrayButton agentAvailability={availability} />);
     expect(queryByTestId("agent-tray-discovery-badge")).toBeTruthy();
-    expect(queryByTestId("agent-tray-new-pill-gemini")).toBeTruthy();
+    expect(queryByTestId("agent-tray-new-dot-gemini")).toBeTruthy();
   });
 
   it("hides the discovery badge once all ready agents are in seenAgentIds", () => {
@@ -919,7 +950,7 @@ describe("AgentTrayButton", () => {
     expect(getByTestId("agent-tray-discovery-badge").getAttribute("data-visible")).toBe("false");
   });
 
-  it("calls markAgentsSeen with all ready agent ids on tray open", () => {
+  it("does not call markAgentsSeen on tray open (per-launch only)", () => {
     const availability = { claude: "ready", gemini: "ready" } as unknown as CliAvailability;
     mockSettings = settingsWith({});
     mockWelcomeCardDismissed = true;
@@ -930,23 +961,61 @@ describe("AgentTrayButton", () => {
     markAgentsSeenMock.mockClear();
 
     openChangeSpy!(true);
-    expect(markAgentsSeenMock).toHaveBeenCalledTimes(1);
-    const [ids] = markAgentsSeenMock.mock.calls[0] as [string[]];
-    expect(ids.sort()).toEqual(["claude", "gemini"]);
+    expect(markAgentsSeenMock).not.toHaveBeenCalled();
   });
 
-  it("does not call markAgentsSeen when no agents are ready on tray open", () => {
-    const availability = {
-      claude: "missing",
-      gemini: "missing",
-    } as unknown as CliAvailability;
+  it("calls markAgentsSeen with only the launched agent id on launch", () => {
+    const availability = { claude: "ready", gemini: "ready" } as unknown as CliAvailability;
+    mockSettings = settingsWith({});
+    mockWelcomeCardDismissed = true;
+    mockSeenAgentIds = [];
+
+    const { getByTestId } = render(<AgentTrayButton agentAvailability={availability} />);
+    markAgentsSeenMock.mockClear();
+
+    fireEvent.click(getByTestId("agent-tray-row-gemini"));
+
+    expect(markAgentsSeenMock).toHaveBeenCalledTimes(1);
+    expect(markAgentsSeenMock).toHaveBeenCalledWith(["gemini"]);
+  });
+
+  it("feeds tray launches into action frecency via recordActionMru", () => {
+    const availability = { claude: "ready" } as unknown as CliAvailability;
+    mockSettings = settingsWith({ claude: { pinned: false } });
+
+    const { getByTestId } = render(<AgentTrayButton agentAvailability={availability} />);
+    fireEvent.click(getByTestId("agent-tray-row-claude"));
+
+    expect(recordActionMruMock).toHaveBeenCalledWith("agent.claude");
+  });
+
+  it("records availability first-seen for ready agents so the TTL clock starts", () => {
+    const availability = { claude: "ready", gemini: "ready" } as unknown as CliAvailability;
     mockSettings = settingsWith({});
 
     render(<AgentTrayButton agentAvailability={availability} />);
-    markAgentsSeenMock.mockClear();
 
-    openChangeSpy!(true);
-    expect(markAgentsSeenMock).not.toHaveBeenCalled();
+    expect(recordAgentAvailabilityFirstSeenMock).toHaveBeenCalledTimes(1);
+    const [ids] = recordAgentAvailabilityFirstSeenMock.mock.calls[0] as [string[]];
+    expect([...ids].sort()).toEqual(["claude", "gemini"]);
+  });
+
+  it("clears the new dot once the discovery TTL has elapsed for an unseen agent", () => {
+    const availability = { claude: "ready", gemini: "ready" } as unknown as CliAvailability;
+    mockSettings = settingsWith({});
+    mockWelcomeCardDismissed = true;
+    mockSeenAgentIds = [];
+    const now = Date.now();
+    mockAvailabilityFirstSeen = {
+      // claude first seen 15 days ago — past the 14-day TTL, so no dot.
+      claude: now - 15 * 24 * 60 * 60 * 1000,
+      // gemini first seen 1 day ago — still within the window.
+      gemini: now - 1 * 24 * 60 * 60 * 1000,
+    };
+
+    const { queryByTestId } = render(<AgentTrayButton agentAvailability={availability} />);
+    expect(queryByTestId("agent-tray-new-dot-claude")).toBeNull();
+    expect(queryByTestId("agent-tray-new-dot-gemini")).toBeTruthy();
   });
 
   it("ignores panels from other worktrees for session detection", () => {

--- a/src/components/Layout/__tests__/AgentTrayButton.test.tsx
+++ b/src/components/Layout/__tests__/AgentTrayButton.test.tsx
@@ -1018,6 +1018,36 @@ describe("AgentTrayButton", () => {
     expect(queryByTestId("agent-tray-new-dot-gemini")).toBeTruthy();
   });
 
+  it("renders the new dot and aria-label on a preset agent (SplitLaunchItem path)", () => {
+    const availability = { claude: "ready" } as unknown as CliAvailability;
+    mockSettings = settingsWith({ claude: { pinned: false } });
+    mockWelcomeCardDismissed = true;
+    mockSeenAgentIds = [];
+    mockMergedPresetsFn = (agentId: string) =>
+      agentId === "claude" ? [{ id: "user-alpha", name: "Alpha" }] : [];
+
+    const { getByTestId, getAllByTestId } = render(
+      <AgentTrayButton agentAvailability={availability} />
+    );
+    expect(getByTestId("agent-tray-new-dot-claude")).toBeTruthy();
+    const trigger = getAllByTestId("submenu-trigger")[0]!;
+    expect(trigger.getAttribute("aria-label")).toContain(", new");
+  });
+
+  it("does not let a non-numeric persisted first-seen value pin the dot on forever", () => {
+    const availability = { claude: "ready" } as unknown as CliAvailability;
+    mockSettings = settingsWith({});
+    mockWelcomeCardDismissed = true;
+    mockSeenAgentIds = [];
+    // A corrupt value reaching the component: `now - "oops"` is NaN and
+    // `NaN > TTL` is false, so the TTL filter must not silently drop the dot.
+    // (The real hook also sanitizes upstream — covered in the hook test.)
+    mockAvailabilityFirstSeen = { claude: "oops" as unknown as number };
+
+    const { queryByTestId } = render(<AgentTrayButton agentAvailability={availability} />);
+    expect(queryByTestId("agent-tray-new-dot-claude")).toBeTruthy();
+  });
+
   it("ignores panels from other worktrees for session detection", () => {
     const availability = { claude: "ready" } as unknown as CliAvailability;
     mockSettings = settingsWith({ claude: { pinned: false } });

--- a/src/hooks/app/__tests__/useAgentDiscoveryOnboarding.test.ts
+++ b/src/hooks/app/__tests__/useAgentDiscoveryOnboarding.test.ts
@@ -1,0 +1,115 @@
+// @vitest-environment jsdom
+import { renderHook, act, waitFor } from "@testing-library/react";
+import { describe, expect, it, vi, beforeEach } from "vitest";
+
+const onboardingMock = {
+  get: vi.fn(),
+  recordAvailabilityFirstSeen: vi.fn(() => Promise.resolve({})),
+};
+
+(window as unknown as { electron: unknown }).electron = { onboarding: onboardingMock };
+
+import {
+  useAgentDiscoveryOnboarding,
+  recordAgentAvailabilityFirstSeen,
+  resetAgentDiscoveryStoreForTests,
+  AGENT_DISCOVERY_TTL_MS,
+} from "../useAgentDiscoveryOnboarding";
+
+const baseState = {
+  schemaVersion: 2,
+  completed: false,
+  currentStep: null,
+  agentSetupIds: [],
+  firstRunToastSeen: false,
+  newsletterPromptSeen: false,
+  waitingNudgeSeen: false,
+  seenAgentIds: [],
+  availabilityFirstSeen: {},
+  welcomeCardDismissed: false,
+  setupBannerDismissed: false,
+  checklist: {
+    dismissed: false,
+    celebrationShown: false,
+    items: {
+      openedProject: false,
+      launchedAgent: false,
+      createdWorktree: false,
+      ranSecondParallelAgent: false,
+    },
+  },
+};
+
+describe("useAgentDiscoveryOnboarding — availability first-seen", () => {
+  beforeEach(() => {
+    resetAgentDiscoveryStoreForTests();
+    onboardingMock.get.mockReset();
+    onboardingMock.recordAvailabilityFirstSeen.mockReset();
+    onboardingMock.recordAvailabilityFirstSeen.mockResolvedValue({});
+    onboardingMock.get.mockResolvedValue(baseState);
+  });
+
+  it("hydrates availabilityFirstSeen from the onboarding store", async () => {
+    onboardingMock.get.mockResolvedValue({
+      ...baseState,
+      availabilityFirstSeen: { claude: 1234 },
+    });
+
+    const { result } = renderHook(() => useAgentDiscoveryOnboarding());
+
+    await waitFor(() => expect(result.current.loaded).toBe(true));
+    expect(result.current.availabilityFirstSeen).toEqual({ claude: 1234 });
+  });
+
+  it("records first-seen for new ids and persists via IPC", async () => {
+    renderHook(() => useAgentDiscoveryOnboarding());
+    await waitFor(() => undefined);
+
+    await act(async () => {
+      await recordAgentAvailabilityFirstSeen(["claude", "gemini"]);
+    });
+
+    expect(onboardingMock.recordAvailabilityFirstSeen).toHaveBeenCalledTimes(1);
+    expect(onboardingMock.recordAvailabilityFirstSeen).toHaveBeenCalledWith(["claude", "gemini"]);
+  });
+
+  it("is idempotent — never overwrites an existing timestamp or re-calls IPC", async () => {
+    const { result } = renderHook(() => useAgentDiscoveryOnboarding());
+    await waitFor(() => expect(result.current.loaded).toBe(true));
+
+    await act(async () => {
+      await recordAgentAvailabilityFirstSeen(["claude"]);
+    });
+    const firstTimestamp = result.current.availabilityFirstSeen.claude;
+    expect(typeof firstTimestamp).toBe("number");
+    onboardingMock.recordAvailabilityFirstSeen.mockClear();
+
+    await act(async () => {
+      await recordAgentAvailabilityFirstSeen(["claude"]);
+    });
+
+    // Same id again: timestamp unchanged, no second IPC round-trip.
+    expect(result.current.availabilityFirstSeen.claude).toBe(firstTimestamp);
+    expect(onboardingMock.recordAvailabilityFirstSeen).not.toHaveBeenCalled();
+  });
+
+  it("only sends the not-yet-recorded ids to IPC on a mixed call", async () => {
+    const { result } = renderHook(() => useAgentDiscoveryOnboarding());
+    await waitFor(() => expect(result.current.loaded).toBe(true));
+
+    await act(async () => {
+      await recordAgentAvailabilityFirstSeen(["claude"]);
+    });
+    onboardingMock.recordAvailabilityFirstSeen.mockClear();
+
+    await act(async () => {
+      await recordAgentAvailabilityFirstSeen(["claude", "gemini"]);
+    });
+
+    expect(onboardingMock.recordAvailabilityFirstSeen).toHaveBeenCalledWith(["gemini"]);
+  });
+
+  it("exposes a 14-day TTL window", () => {
+    expect(AGENT_DISCOVERY_TTL_MS).toBe(14 * 24 * 60 * 60 * 1000);
+  });
+});

--- a/src/hooks/app/__tests__/useAgentDiscoveryOnboarding.test.ts
+++ b/src/hooks/app/__tests__/useAgentDiscoveryOnboarding.test.ts
@@ -109,6 +109,37 @@ describe("useAgentDiscoveryOnboarding — availability first-seen", () => {
     expect(onboardingMock.recordAvailabilityFirstSeen).toHaveBeenCalledWith(["gemini"]);
   });
 
+  it("does not re-record ids already populated by hydration", async () => {
+    onboardingMock.get.mockResolvedValue({
+      ...baseState,
+      availabilityFirstSeen: { claude: 12345 },
+    });
+    const { result } = renderHook(() => useAgentDiscoveryOnboarding());
+    await waitFor(() => expect(result.current.loaded).toBe(true));
+
+    await act(async () => {
+      await recordAgentAvailabilityFirstSeen(["claude"]);
+    });
+
+    expect(onboardingMock.recordAvailabilityFirstSeen).not.toHaveBeenCalled();
+    expect(result.current.availabilityFirstSeen.claude).toBe(12345);
+  });
+
+  it("drops non-finite persisted timestamps on hydration", async () => {
+    onboardingMock.get.mockResolvedValue({
+      ...baseState,
+      availabilityFirstSeen: {
+        claude: "yesterday" as unknown as number,
+        gemini: Number.NaN,
+        codex: 1700000000000,
+      },
+    });
+    const { result } = renderHook(() => useAgentDiscoveryOnboarding());
+    await waitFor(() => expect(result.current.loaded).toBe(true));
+
+    expect(result.current.availabilityFirstSeen).toEqual({ codex: 1700000000000 });
+  });
+
   it("exposes a 14-day TTL window", () => {
     expect(AGENT_DISCOVERY_TTL_MS).toBe(14 * 24 * 60 * 60 * 1000);
   });

--- a/src/hooks/app/useAgentDiscoveryOnboarding.ts
+++ b/src/hooks/app/useAgentDiscoveryOnboarding.ts
@@ -3,9 +3,17 @@ import { create } from "zustand";
 import type { OnboardingState } from "@shared/types";
 import { isElectronAvailable } from "@/hooks/useElectron";
 
+/**
+ * Discovery-badge TTL backstop window. An agent the user never launches still
+ * stops reading as "new" once this elapses since it first became launchable —
+ * otherwise the dot would linger forever for ignored agents.
+ */
+export const AGENT_DISCOVERY_TTL_MS = 14 * 24 * 60 * 60 * 1000;
+
 interface AgentDiscoveryState {
   loaded: boolean;
   seenAgentIds: string[];
+  availabilityFirstSeen: Record<string, number>;
   welcomeCardDismissed: boolean;
   setupBannerDismissed: boolean;
 }
@@ -13,6 +21,7 @@ interface AgentDiscoveryState {
 const useAgentDiscoveryStore = create<AgentDiscoveryState>(() => ({
   loaded: false,
   seenAgentIds: [],
+  availabilityFirstSeen: {},
   welcomeCardDismissed: false,
   setupBannerDismissed: false,
 }));
@@ -38,6 +47,10 @@ async function hydrate(): Promise<void> {
       useAgentDiscoveryStore.setState({
         loaded: true,
         seenAgentIds: Array.isArray(state.seenAgentIds) ? state.seenAgentIds : [],
+        availabilityFirstSeen:
+          state.availabilityFirstSeen && typeof state.availabilityFirstSeen === "object"
+            ? state.availabilityFirstSeen
+            : {},
         welcomeCardDismissed: state.welcomeCardDismissed === true,
         setupBannerDismissed: state.setupBannerDismissed === true,
       });
@@ -75,6 +88,37 @@ export async function markAgentsSeen(agentIds: string[]): Promise<void> {
   }
 }
 
+/**
+ * Records the first time each agent became launchable so the discovery-badge
+ * TTL has a start point even for agents the user never launches. Idempotent —
+ * never overwrites an existing timestamp, locally or in the store.
+ */
+export async function recordAgentAvailabilityFirstSeen(agentIds: string[]): Promise<void> {
+  if (agentIds.length === 0) return;
+  const current = useAgentDiscoveryStore.getState().availabilityFirstSeen;
+  const missing = agentIds.filter((id) => current[id] === undefined);
+  if (missing.length === 0) return;
+  const now = Date.now();
+  useAgentDiscoveryStore.setState((s) => {
+    const next = { ...s.availabilityFirstSeen };
+    let changed = false;
+    for (const id of missing) {
+      if (next[id] === undefined) {
+        next[id] = now;
+        changed = true;
+      }
+    }
+    return changed ? { ...s, availabilityFirstSeen: next } : s;
+  });
+  const api = window.electron?.onboarding;
+  if (!api?.recordAvailabilityFirstSeen) return;
+  try {
+    await api.recordAvailabilityFirstSeen(missing);
+  } catch {
+    // Best-effort; optimistic local state stands.
+  }
+}
+
 export async function dismissWelcomeCard(): Promise<void> {
   if (useAgentDiscoveryStore.getState().welcomeCardDismissed) return;
   useAgentDiscoveryStore.setState({ welcomeCardDismissed: true });
@@ -101,6 +145,7 @@ export async function dismissSetupBanner(): Promise<void> {
 
 interface AgentDiscoveryOnboarding extends AgentDiscoveryState {
   markAgentsSeen: (agentIds: string[]) => Promise<void>;
+  recordAgentAvailabilityFirstSeen: (agentIds: string[]) => Promise<void>;
   dismissWelcomeCard: () => Promise<void>;
   dismissSetupBanner: () => Promise<void>;
 }
@@ -115,6 +160,7 @@ interface AgentDiscoveryOnboarding extends AgentDiscoveryState {
 export function useAgentDiscoveryOnboarding(): AgentDiscoveryOnboarding {
   const loaded = useAgentDiscoveryStore((s) => s.loaded);
   const seenAgentIds = useAgentDiscoveryStore((s) => s.seenAgentIds);
+  const availabilityFirstSeen = useAgentDiscoveryStore((s) => s.availabilityFirstSeen);
   const welcomeCardDismissed = useAgentDiscoveryStore((s) => s.welcomeCardDismissed);
   const setupBannerDismissed = useAgentDiscoveryStore((s) => s.setupBannerDismissed);
 
@@ -125,9 +171,11 @@ export function useAgentDiscoveryOnboarding(): AgentDiscoveryOnboarding {
   return {
     loaded,
     seenAgentIds,
+    availabilityFirstSeen,
     welcomeCardDismissed,
     setupBannerDismissed,
     markAgentsSeen,
+    recordAgentAvailabilityFirstSeen,
     dismissWelcomeCard,
     dismissSetupBanner,
   };
@@ -138,6 +186,7 @@ export function resetAgentDiscoveryStoreForTests(): void {
   useAgentDiscoveryStore.setState({
     loaded: false,
     seenAgentIds: [],
+    availabilityFirstSeen: {},
     welcomeCardDismissed: false,
     setupBannerDismissed: false,
   });

--- a/src/hooks/app/useAgentDiscoveryOnboarding.ts
+++ b/src/hooks/app/useAgentDiscoveryOnboarding.ts
@@ -10,6 +10,20 @@ import { isElectronAvailable } from "@/hooks/useElectron";
  */
 export const AGENT_DISCOVERY_TTL_MS = 14 * 24 * 60 * 60 * 1000;
 
+/**
+ * Keeps only finite-number timestamps. A non-numeric value (manual store
+ * edit, partial migration) would make `now - value` NaN, and `NaN > TTL` is
+ * always false — the discovery dot would then linger forever for that agent.
+ */
+function sanitizeFirstSeen(raw: unknown): Record<string, number> {
+  if (!raw || typeof raw !== "object") return {};
+  const out: Record<string, number> = {};
+  for (const [id, value] of Object.entries(raw as Record<string, unknown>)) {
+    if (typeof value === "number" && Number.isFinite(value)) out[id] = value;
+  }
+  return out;
+}
+
 interface AgentDiscoveryState {
   loaded: boolean;
   seenAgentIds: string[];
@@ -47,10 +61,7 @@ async function hydrate(): Promise<void> {
       useAgentDiscoveryStore.setState({
         loaded: true,
         seenAgentIds: Array.isArray(state.seenAgentIds) ? state.seenAgentIds : [],
-        availabilityFirstSeen:
-          state.availabilityFirstSeen && typeof state.availabilityFirstSeen === "object"
-            ? state.availabilityFirstSeen
-            : {},
+        availabilityFirstSeen: sanitizeFirstSeen(state.availabilityFirstSeen),
         welcomeCardDismissed: state.welcomeCardDismissed === true,
         setupBannerDismissed: state.setupBannerDismissed === true,
       });


### PR DESCRIPTION
## Summary

- Replaces the outlined "NEW" pill with a status-info dot (matching the trigger button), adds `, new` aria-label suffix, and gives `SplitLaunchItem` SubTrigger parity dot + aria-label
- `markAgentsSeen` now fires per-launch on the launched agent only — opening the dropdown no longer bulk-clears all ready agents
- Adds a 14-day discovery-badge TTL backstop via `availabilityFirstSeen: Record<string, number>` on `OnboardingState`, a new `ONBOARDING_RECORD_AVAILABILITY_FIRST_SEEN` IPC channel, and an idempotent handler; a `useEffect` records first-seen when an agent becomes launchable, with finite-number sanitization in both renderer and main so a corrupt timestamp can't pin the dot indefinitely
- Dims the pinned `Pin` icon from `opacity-100` to `opacity-50` so it reads as a state marker, not an active control
- Tray launches now call `recordActionMru` so tray usage is reflected in the tray's own MRU sort

Resolves #8177

## Changes

- `AgentTrayButton.tsx` — dot indicator, per-launch `markAgentsSeen`, `recordActionMru` on launch, dimmed pin icon
- `useAgentDiscoveryOnboarding.ts` (new) — `availabilityFirstSeen` tracking hook with 14-day TTL and finite-number guard
- `electron/ipc/channels.ts`, `handlers/onboarding.ts`, `preload.cts`, `shared/types/ipc/` — `ONBOARDING_RECORD_AVAILABILITY_FIRST_SEEN` IPC channel wired end-to-end
- `electron/store.ts` — `availabilityFirstSeen` field persisted to `OnboardingState`

## Testing

69 tests passing across `AgentTrayButton.test.tsx` (updated) and the new `useAgentDiscoveryOnboarding.test.ts`. Full verify (typecheck across all 3 configs, format, lint, IPC drift check, build) all green.