### PR TITLE
feat(dnd): polish drag-and-drop live-region cadence and copy

### DIFF
--- a/src/components/DragDrop/DndProvider.tsx
+++ b/src/components/DragDrop/DndProvider.tsx
@@ -232,25 +232,30 @@ const dragScreenReaderInstructions: ScreenReaderInstructions = {
 
 export interface DragAnnouncementRefs {
   isKeyboardDragRef: MutableRefObject<boolean>;
-  pinnedLabelRef: MutableRefObject<string>;
-  pinnedSourceIndexRef: MutableRefObject<number | null>;
   pinnedTotalRef: MutableRefObject<number | null>;
 }
 
 /**
  * Build the dnd-kit `Announcements` object for the global drag surface.
  *
- * Drag state has to be pinned at pickup time (label, source index, total) so
- * the drop string survives mid-drag filter mutations; refs supply that pin
- * via the sibling `DragAnnouncementMonitor` and the factory closes over
- * them. The factory is exported pure so unit tests can drive the lifecycle
- * with controlled refs and label resolvers.
+ * `pinnedTotalRef` is populated at pickup by the sibling
+ * `DragAnnouncementMonitor` so the drop string's denominator survives
+ * mid-drag filter mutations. The factory is exported pure so unit tests can
+ * drive the lifecycle with controlled refs and label resolvers.
  *
  * Pointer drags suppress `onDragOver` (return `undefined`) so the polite
  * live region isn't flooded — the visual placeholder already conveys hover
  * state, and dnd-kit's measuring loop fires `onDragOver` at the
  * `MEASURING_CONFIG.frequency` cadence. Keyboard drags keep the running
  * "X is over Y" prose since the user has no visual cursor to track.
+ *
+ * **Read order matters.** `DragAnnouncementMonitor` and dnd-kit's internal
+ * `Accessibility` component both register via `useDndMonitor`, and dnd-kit
+ * dispatches to listeners in insertion order. The monitor's `useEffect`
+ * runs first (children before sibling render output in the DndContext tree),
+ * so it must NOT clear refs at `onDragEnd` / `onDragCancel` — `Accessibility`
+ * reads them second to build the announcement string. The monitor clears
+ * refs at the top of the *next* `onDragStart` instead.
  */
 export function createDragAnnouncements(
   refs: DragAnnouncementRefs,
@@ -275,7 +280,7 @@ export function createDragAnnouncements(
         return `${label} returned to its original position`;
       }
       const overData = over.data.current as { sortable?: { index?: number } } | undefined;
-      const destIndex = overData?.sortable?.index ?? refs.pinnedSourceIndexRef.current;
+      const destIndex = overData?.sortable?.index;
       const total = refs.pinnedTotalRef.current;
       if (typeof destIndex === "number" && total !== null && total > 0) {
         return `Dropped ${label} at position ${destIndex + 1} of ${total}`;
@@ -320,21 +325,22 @@ function getEventCoordinates(event: Event): { x: number; y: number } | null {
 function DragAnnouncementMonitor({ refs }: { refs: DragAnnouncementRefs }) {
   useDndMonitor({
     onDragStart({ activatorEvent, active }) {
+      // Clear leftover state from the previous drag at the top of the next
+      // pickup, NOT in onDragEnd/onDragCancel. The reason is listener order:
+      // this monitor registers via useDndMonitor before dnd-kit's internal
+      // Accessibility component, and dnd-kit iterates listeners in insertion
+      // order. Clearing at end/cancel would zero the refs before the
+      // Accessibility component reads them to build the announcement, so the
+      // "Dropped X at position N of T" copy would never fire.
       refs.isKeyboardDragRef.current =
         typeof KeyboardEvent !== "undefined" && activatorEvent instanceof KeyboardEvent;
-      refs.pinnedLabelRef.current = getDragLabel(active.data.current);
 
       const data = active.data.current as
         | {
-            sourceIndex?: number;
             dragStartOrder?: unknown[];
-            sortable?: { index?: number; items?: unknown[] };
+            sortable?: { items?: unknown[] };
           }
         | undefined;
-      const sortableIndex = typeof data?.sortable?.index === "number" ? data.sortable.index : null;
-      const explicitSource = typeof data?.sourceIndex === "number" ? data.sourceIndex : null;
-      refs.pinnedSourceIndexRef.current = sortableIndex ?? explicitSource;
-
       const sortableTotal = data?.sortable?.items?.length;
       const dragOrderTotal = Array.isArray(data?.dragStartOrder)
         ? data.dragStartOrder.length
@@ -345,18 +351,6 @@ function DragAnnouncementMonitor({ refs }: { refs: DragAnnouncementRefs }) {
           : typeof dragOrderTotal === "number"
             ? dragOrderTotal
             : null;
-    },
-    onDragEnd() {
-      refs.isKeyboardDragRef.current = false;
-      refs.pinnedLabelRef.current = "";
-      refs.pinnedSourceIndexRef.current = null;
-      refs.pinnedTotalRef.current = null;
-    },
-    onDragCancel() {
-      refs.isKeyboardDragRef.current = false;
-      refs.pinnedLabelRef.current = "";
-      refs.pinnedSourceIndexRef.current = null;
-      refs.pinnedTotalRef.current = null;
     },
   });
   return null;
@@ -480,11 +474,9 @@ export function DndProvider({ children }: DndProviderProps) {
   // memoized `dragAnnouncements` factory. Identity is stable for the
   // provider's lifetime so the `useMemo` below can use an empty dep list.
   const isKeyboardDragRef = useRef(false);
-  const pinnedLabelRef = useRef<string>("");
-  const pinnedSourceIndexRef = useRef<number | null>(null);
   const pinnedTotalRef = useRef<number | null>(null);
   const announcementRefs = useMemo<DragAnnouncementRefs>(
-    () => ({ isKeyboardDragRef, pinnedLabelRef, pinnedSourceIndexRef, pinnedTotalRef }),
+    () => ({ isKeyboardDragRef, pinnedTotalRef }),
     []
   );
   const dragAnnouncements = useMemo(

--- a/src/components/DragDrop/DndProvider.tsx
+++ b/src/components/DragDrop/DndProvider.tsx
@@ -7,6 +7,7 @@ import {
   useContext,
   useEffect,
   type MouseEvent as ReactMouseEvent,
+  type MutableRefObject,
 } from "react";
 import {
   DndContext,
@@ -26,9 +27,11 @@ import {
   type DragOverEvent,
   type CollisionDetection,
   type Modifier,
+  type Active,
   type Announcements,
   type MeasuringConfiguration,
   type MouseSensorOptions,
+  type Over,
   type ScreenReaderInstructions,
 } from "@dnd-kit/core";
 import { sortableKeyboardCoordinates } from "@dnd-kit/sortable";
@@ -201,7 +204,7 @@ function getDragLabel(data: unknown): string {
  * `worktree-sort-{id}` for the sortable handle and `worktree-drop-{id}` for
  * the row's drop target — both should announce the same human-readable label.
  */
-function getOverDragLabel(over: { id: string | number; data: { current: unknown } }): string {
+function getOverDragLabel(over: Over): string {
   const sortDragId = parseWorktreeSortDragId(over.id);
   if (sortDragId) return resolveWorktreeLabel(sortDragId);
   if (typeof over.id === "string" && over.id.startsWith("worktree-drop-")) {
@@ -227,30 +230,64 @@ const dragScreenReaderInstructions: ScreenReaderInstructions = {
     "To pick up a draggable item, press Space or Enter. While dragging, use the arrow keys to move. Press Space or Enter again to drop, or Escape to cancel.",
 };
 
-const dragAnnouncements: Announcements = {
-  onDragStart({ active }) {
-    return `Picked up ${getDragLabel(active.data.current)}`;
-  },
-  onDragOver({ active, over }) {
-    const label = getDragLabel(active.data.current);
-    if (over) {
-      const overLabel = getOverDragLabel(over);
-      return `${label} is over ${overLabel}`;
-    }
-    return `${label} is no longer over a droppable area`;
-  },
-  onDragEnd({ active, over }) {
-    const label = getDragLabel(active.data.current);
-    if (over) {
+export interface DragAnnouncementRefs {
+  isKeyboardDragRef: MutableRefObject<boolean>;
+  pinnedLabelRef: MutableRefObject<string>;
+  pinnedSourceIndexRef: MutableRefObject<number | null>;
+  pinnedTotalRef: MutableRefObject<number | null>;
+}
+
+/**
+ * Build the dnd-kit `Announcements` object for the global drag surface.
+ *
+ * Drag state has to be pinned at pickup time (label, source index, total) so
+ * the drop string survives mid-drag filter mutations; refs supply that pin
+ * via the sibling `DragAnnouncementMonitor` and the factory closes over
+ * them. The factory is exported pure so unit tests can drive the lifecycle
+ * with controlled refs and label resolvers.
+ *
+ * Pointer drags suppress `onDragOver` (return `undefined`) so the polite
+ * live region isn't flooded — the visual placeholder already conveys hover
+ * state, and dnd-kit's measuring loop fires `onDragOver` at the
+ * `MEASURING_CONFIG.frequency` cadence. Keyboard drags keep the running
+ * "X is over Y" prose since the user has no visual cursor to track.
+ */
+export function createDragAnnouncements(
+  refs: DragAnnouncementRefs,
+  resolveActiveLabel: (active: Active) => string,
+  resolveOverLabel: (over: Over) => string
+): Announcements {
+  return {
+    onDragStart({ active }) {
+      return `Picked up ${resolveActiveLabel(active)}. Press arrow keys to move, Space to drop, Escape to cancel.`;
+    },
+    onDragOver({ active, over }) {
+      if (!refs.isKeyboardDragRef.current) return undefined;
+      const label = resolveActiveLabel(active);
+      if (over) {
+        return `${label} is over ${resolveOverLabel(over)}`;
+      }
+      return `${label} is no longer over a droppable area`;
+    },
+    onDragEnd({ active, over }) {
+      const label = resolveActiveLabel(active);
+      if (!over) {
+        return `${label} returned to its original position`;
+      }
+      const overData = over.data.current as { sortable?: { index?: number } } | undefined;
+      const destIndex = overData?.sortable?.index ?? refs.pinnedSourceIndexRef.current;
+      const total = refs.pinnedTotalRef.current;
+      if (typeof destIndex === "number" && total !== null && total > 0) {
+        return `Dropped ${label} at position ${destIndex + 1} of ${total}`;
+      }
       return `Dropped ${label}`;
-    }
-    return `${label} returned to its original position`;
-  },
-  onDragCancel({ active }) {
-    const label = getDragLabel(active.data.current);
-    return `Drag cancelled. ${label} returned to its original position`;
-  },
-};
+    },
+    onDragCancel({ active }) {
+      const label = resolveActiveLabel(active);
+      return `Drag cancelled. ${label} returned to its original position`;
+    },
+  };
+}
 
 function isWorktreeDragData(
   data: DragData | WorktreeDragData | undefined
@@ -274,6 +311,55 @@ function getEventCoordinates(event: Event): { x: number; y: number } | null {
   }
   const pointerEvent = event as PointerEvent;
   return { x: pointerEvent.clientX, y: pointerEvent.clientY };
+}
+
+// Inner component that uses useDndMonitor to pin drag state for the
+// announcement factory (must be inside DndContext). Detects the activator
+// modality (pointer vs keyboard) — Announcements callbacks only receive
+// `{active, over}`, so the keyboard flag has to be plumbed in via refs.
+function DragAnnouncementMonitor({ refs }: { refs: DragAnnouncementRefs }) {
+  useDndMonitor({
+    onDragStart({ activatorEvent, active }) {
+      refs.isKeyboardDragRef.current =
+        typeof KeyboardEvent !== "undefined" && activatorEvent instanceof KeyboardEvent;
+      refs.pinnedLabelRef.current = getDragLabel(active.data.current);
+
+      const data = active.data.current as
+        | {
+            sourceIndex?: number;
+            dragStartOrder?: unknown[];
+            sortable?: { index?: number; items?: unknown[] };
+          }
+        | undefined;
+      const sortableIndex = typeof data?.sortable?.index === "number" ? data.sortable.index : null;
+      const explicitSource = typeof data?.sourceIndex === "number" ? data.sourceIndex : null;
+      refs.pinnedSourceIndexRef.current = sortableIndex ?? explicitSource;
+
+      const sortableTotal = data?.sortable?.items?.length;
+      const dragOrderTotal = Array.isArray(data?.dragStartOrder)
+        ? data.dragStartOrder.length
+        : undefined;
+      refs.pinnedTotalRef.current =
+        typeof sortableTotal === "number"
+          ? sortableTotal
+          : typeof dragOrderTotal === "number"
+            ? dragOrderTotal
+            : null;
+    },
+    onDragEnd() {
+      refs.isKeyboardDragRef.current = false;
+      refs.pinnedLabelRef.current = "";
+      refs.pinnedSourceIndexRef.current = null;
+      refs.pinnedTotalRef.current = null;
+    },
+    onDragCancel() {
+      refs.isKeyboardDragRef.current = false;
+      refs.pinnedLabelRef.current = "";
+      refs.pinnedSourceIndexRef.current = null;
+      refs.pinnedTotalRef.current = null;
+    },
+  });
+  return null;
 }
 
 // Inner component that uses useDndMonitor to track cursor position (must be inside DndContext)
@@ -389,6 +475,27 @@ export function DndProvider({ children }: DndProviderProps) {
   const [overContainer, setOverContainer] = useState<"grid" | "dock" | null>(null);
   const [isWorktreeSortActive, setIsWorktreeSortActive] = useState(false);
   const [activeSortWorktree, setActiveSortWorktree] = useState<WorktreeSnapshot | null>(null);
+
+  // Refs pinned by `DragAnnouncementMonitor` at pickup and read by the
+  // memoized `dragAnnouncements` factory. Identity is stable for the
+  // provider's lifetime so the `useMemo` below can use an empty dep list.
+  const isKeyboardDragRef = useRef(false);
+  const pinnedLabelRef = useRef<string>("");
+  const pinnedSourceIndexRef = useRef<number | null>(null);
+  const pinnedTotalRef = useRef<number | null>(null);
+  const announcementRefs = useMemo<DragAnnouncementRefs>(
+    () => ({ isKeyboardDragRef, pinnedLabelRef, pinnedSourceIndexRef, pinnedTotalRef }),
+    []
+  );
+  const dragAnnouncements = useMemo(
+    () =>
+      createDragAnnouncements(
+        announcementRefs,
+        (a) => getDragLabel(a.data.current),
+        getOverDragLabel
+      ),
+    [announcementRefs]
+  );
 
   // Ref to track overContainer for stable collision detection (avoids infinite loops)
   const overContainerRef = useRef<"grid" | "dock" | null>(null);
@@ -1170,6 +1277,7 @@ export function DndProvider({ children }: DndProviderProps) {
       <DndPlaceholderContext.Provider value={placeholderContextValue}>
         {children}
       </DndPlaceholderContext.Provider>
+      <DragAnnouncementMonitor refs={announcementRefs} />
       <DragOverlayWithCursorTracking
         activeTerminal={activeTerminal}
         activeWorktree={activeSortWorktree}

--- a/src/components/DragDrop/__tests__/dndAnnouncements.test.ts
+++ b/src/components/DragDrop/__tests__/dndAnnouncements.test.ts
@@ -5,21 +5,15 @@ import { createDragAnnouncements, type DragAnnouncementRefs } from "../DndProvid
 import { makeSortableAnnouncements } from "../sortableAnnouncements";
 
 // Build a refs harness with controlled values so the factory's pickup-time
-// pins (keyboard flag, source index, total) can be driven from tests.
+// pins (keyboard flag, total) can be driven from tests.
 function makeRefs(
   initial: Partial<{
     isKeyboardDrag: boolean;
-    pinnedLabel: string;
-    pinnedSourceIndex: number | null;
     pinnedTotal: number | null;
   }> = {}
 ): DragAnnouncementRefs {
   return {
     isKeyboardDragRef: { current: initial.isKeyboardDrag ?? false } as MutableRefObject<boolean>,
-    pinnedLabelRef: { current: initial.pinnedLabel ?? "" } as MutableRefObject<string>,
-    pinnedSourceIndexRef: {
-      current: initial.pinnedSourceIndex ?? null,
-    } as MutableRefObject<number | null>,
     pinnedTotalRef: {
       current: initial.pinnedTotal ?? null,
     } as MutableRefObject<number | null>,
@@ -104,7 +98,7 @@ describe("createDragAnnouncements — global DndProvider factory", () => {
 
   it("onDragEnd announces destination position from over sortable.index plus pinned total", () => {
     const announcements = createDragAnnouncements(
-      makeRefs({ pinnedSourceIndex: 0, pinnedTotal: 5 }),
+      makeRefs({ pinnedTotal: 5 }),
       resolveActive,
       resolveOver
     );
@@ -116,9 +110,12 @@ describe("createDragAnnouncements — global DndProvider factory", () => {
     ).toBe("Dropped Claude Agent at position 3 of 5");
   });
 
-  it("onDragEnd falls back to pinned source index when over has no sortable metadata", () => {
+  it("onDragEnd omits position when over has no sortable metadata", () => {
+    // No source-index fallback: the resolved destination is unknown, so the
+    // announcement stays generic rather than misleading the user with the
+    // pickup position dressed up as the drop position.
     const announcements = createDragAnnouncements(
-      makeRefs({ pinnedSourceIndex: 3, pinnedTotal: 8 }),
+      makeRefs({ pinnedTotal: 8 }),
       resolveActive,
       resolveOver
     );
@@ -127,22 +124,22 @@ describe("createDragAnnouncements — global DndProvider factory", () => {
         active: makeActive({ terminal: { title: "Claude Agent" } }),
         over: makeOver("term-x", {}),
       })
-    ).toBe("Dropped Claude Agent at position 4 of 8");
+    ).toBe("Dropped Claude Agent");
   });
 
-  it("onDragEnd omits position when pin and over both lack index data", () => {
+  it("onDragEnd omits position when pinned total is null", () => {
     const announcements = createDragAnnouncements(makeRefs(), resolveActive, resolveOver);
     expect(
       announcements.onDragEnd!({
         active: makeActive({ terminal: { title: "Claude Agent" } }),
-        over: makeOver("term-x", {}),
+        over: makeOver("term-x", { sortable: { index: 0 } }),
       })
     ).toBe("Dropped Claude Agent");
   });
 
   it("onDragEnd omits position when total is zero", () => {
     const announcements = createDragAnnouncements(
-      makeRefs({ pinnedSourceIndex: 0, pinnedTotal: 0 }),
+      makeRefs({ pinnedTotal: 0 }),
       resolveActive,
       resolveOver
     );
@@ -156,7 +153,7 @@ describe("createDragAnnouncements — global DndProvider factory", () => {
 
   it("onDragEnd without target announces return to original position", () => {
     const announcements = createDragAnnouncements(
-      makeRefs({ pinnedSourceIndex: 0, pinnedTotal: 5 }),
+      makeRefs({ pinnedTotal: 5 }),
       resolveActive,
       resolveOver
     );
@@ -176,6 +173,25 @@ describe("createDragAnnouncements — global DndProvider factory", () => {
         over: null,
       })
     ).toBe("Drag cancelled. Claude Agent returned to its original position");
+  });
+
+  it("position string still resolves even when refs survive past the drop event", () => {
+    // Regression: the monitor clears refs at the *next* onDragStart, not at
+    // onDragEnd, because dnd-kit dispatches listeners in insertion order and
+    // the monitor's useEffect runs before Accessibility's. If the monitor
+    // cleared refs at end/cancel, Accessibility would read null and the
+    // position-aware copy would never fire. This test pins the contract that
+    // the factory reads non-null pinned values at onDragEnd time.
+    const refs = makeRefs({ pinnedTotal: 4, isKeyboardDrag: true });
+    const announcements = createDragAnnouncements(refs, resolveActive, resolveOver);
+    expect(
+      announcements.onDragEnd!({
+        active: makeActive({ terminal: { title: "Claude Agent" } }),
+        over: makeOver("term-2", { sortable: { index: 1 } }),
+      })
+    ).toBe("Dropped Claude Agent at position 2 of 4");
+    expect(refs.pinnedTotalRef.current).toBe(4);
+    expect(refs.isKeyboardDragRef.current).toBe(true);
   });
 });
 

--- a/src/components/DragDrop/__tests__/dndAnnouncements.test.ts
+++ b/src/components/DragDrop/__tests__/dndAnnouncements.test.ts
@@ -1,270 +1,323 @@
 import { describe, it, expect } from "vitest";
+import type { MutableRefObject } from "react";
+import type { Active, Over } from "@dnd-kit/core";
+import { createDragAnnouncements, type DragAnnouncementRefs } from "../DndProvider";
 import { makeSortableAnnouncements } from "../sortableAnnouncements";
 
-// We test the announcement logic by recreating the same branching that
-// `getDragLabel` uses inside DndProvider. The production helper is
-// module-scoped (not exported) so the test mirrors its priority chain
-// (issueTitle → branch → name → "worktree") for worktree-sort drags and
-// the terminal-title fallback for everything else.
-
-interface WorktreeFixture {
-  issueTitle?: string;
-  branch?: string;
-  name?: string;
-}
-
-function makeAnnouncements(worktreeLookup: Map<string, WorktreeFixture>) {
-  function isWorktreeSortDragData(data: unknown): data is { worktreeId: string } {
-    return (
-      data !== null &&
-      typeof data === "object" &&
-      (data as { type?: unknown }).type === "worktree-sort"
-    );
-  }
-
-  function resolveWorktreeLabel(worktreeId: string): string {
-    const wt = worktreeLookup.get(worktreeId);
-    return wt?.issueTitle ?? wt?.branch ?? wt?.name ?? "worktree";
-  }
-
-  function getDragLabel(data: unknown): string {
-    if (isWorktreeSortDragData(data)) {
-      return resolveWorktreeLabel(data.worktreeId);
-    }
-    return (data as { terminal?: { title?: string } } | undefined)?.terminal?.title ?? "panel";
-  }
-
-  function getOverDragLabel(over: { id: string; data: { current: unknown } }): string {
-    if (over.id.startsWith("worktree-sort-")) {
-      return resolveWorktreeLabel(over.id.slice("worktree-sort-".length));
-    }
-    if (over.id.startsWith("worktree-drop-")) {
-      return resolveWorktreeLabel(over.id.slice("worktree-drop-".length));
-    }
-    return getDragLabel(over.data.current);
-  }
-
+// Build a refs harness with controlled values so the factory's pickup-time
+// pins (keyboard flag, source index, total) can be driven from tests.
+function makeRefs(
+  initial: Partial<{
+    isKeyboardDrag: boolean;
+    pinnedLabel: string;
+    pinnedSourceIndex: number | null;
+    pinnedTotal: number | null;
+  }> = {}
+): DragAnnouncementRefs {
   return {
-    onDragStart(active: { data: { current: unknown } }) {
-      return `Picked up ${getDragLabel(active.data.current)}`;
-    },
-    onDragOver(
-      active: { data: { current: unknown } },
-      over: { id: string; data: { current: unknown } } | null
-    ) {
-      const label = getDragLabel(active.data.current);
-      if (over) {
-        return `${label} is over ${getOverDragLabel(over)}`;
-      }
-      return `${label} is no longer over a droppable area`;
-    },
-    onDragEnd(active: { data: { current: unknown } }, over: { data: { current: unknown } } | null) {
-      const label = getDragLabel(active.data.current);
-      if (over) {
-        return `Dropped ${label}`;
-      }
-      return `${label} returned to its original position`;
-    },
-    onDragCancel(active: { data: { current: unknown } }) {
-      const label = getDragLabel(active.data.current);
-      return `Drag cancelled. ${label} returned to its original position`;
-    },
+    isKeyboardDragRef: { current: initial.isKeyboardDrag ?? false } as MutableRefObject<boolean>,
+    pinnedLabelRef: { current: initial.pinnedLabel ?? "" } as MutableRefObject<string>,
+    pinnedSourceIndexRef: {
+      current: initial.pinnedSourceIndex ?? null,
+    } as MutableRefObject<number | null>,
+    pinnedTotalRef: {
+      current: initial.pinnedTotal ?? null,
+    } as MutableRefObject<number | null>,
   };
 }
 
-describe("drag announcements — terminal panels", () => {
-  const announcements = makeAnnouncements(new Map());
-  const withTitle = { data: { current: { terminal: { title: "Claude Agent" } } } };
-  const withoutTitle = { data: { current: {} } };
+// Construct a minimal Active/Over shape — the factory only reads `id` and
+// `data.current` — and cast through `as never` to satisfy dnd-kit's deep
+// type without dragging the full ref/rect machinery into a unit test.
+function makeActive(data: unknown): Active {
+  return { id: "active-id", data: { current: data } } as unknown as Active;
+}
 
-  it("onDragStart announces panel title", () => {
-    expect(announcements.onDragStart(withTitle)).toBe("Picked up Claude Agent");
+function makeOver(id: string, data: unknown): Over {
+  return { id, data: { current: data } } as unknown as Over;
+}
+
+const resolveActive = (active: Active): string => {
+  const data = active.data.current as { terminal?: { title?: string } } | undefined;
+  return data?.terminal?.title ?? "panel";
+};
+const resolveOver = (over: Over): string => {
+  const data = over.data.current as { terminal?: { title?: string } } | undefined;
+  return data?.terminal?.title ?? String(over.id);
+};
+
+describe("createDragAnnouncements — global DndProvider factory", () => {
+  it("onDragStart announces pickup with keyboard instructions", () => {
+    const announcements = createDragAnnouncements(makeRefs(), resolveActive, resolveOver);
+    expect(
+      announcements.onDragStart!({ active: makeActive({ terminal: { title: "Claude Agent" } }) })
+    ).toBe("Picked up Claude Agent. Press arrow keys to move, Space to drop, Escape to cancel.");
   });
 
-  it("onDragStart falls back to 'panel' without title", () => {
-    expect(announcements.onDragStart(withoutTitle)).toBe("Picked up panel");
-  });
-
-  it("onDragOver with target announces both labels", () => {
-    const over = { id: "term-1", data: { current: { terminal: { title: "Terminal" } } } };
-    expect(announcements.onDragOver(withTitle, over)).toBe("Claude Agent is over Terminal");
-  });
-
-  it("onDragOver without target announces no droppable area", () => {
-    expect(announcements.onDragOver(withTitle, null)).toBe(
-      "Claude Agent is no longer over a droppable area"
+  it("onDragStart falls back to 'panel' when no title is resolvable", () => {
+    const announcements = createDragAnnouncements(makeRefs(), resolveActive, resolveOver);
+    expect(announcements.onDragStart!({ active: makeActive({}) })).toBe(
+      "Picked up panel. Press arrow keys to move, Space to drop, Escape to cancel."
     );
   });
 
-  it("onDragEnd with target announces drop", () => {
-    const over = { data: { current: {} } };
-    expect(announcements.onDragEnd(withTitle, over)).toBe("Dropped Claude Agent");
+  it("onDragOver returns undefined for pointer drags so the polite queue isn't flooded", () => {
+    const announcements = createDragAnnouncements(
+      makeRefs({ isKeyboardDrag: false }),
+      resolveActive,
+      resolveOver
+    );
+    const result = announcements.onDragOver!({
+      active: makeActive({ terminal: { title: "Claude Agent" } }),
+      over: makeOver("term-1", { terminal: { title: "Terminal" } }),
+    });
+    expect(result).toBeUndefined();
+  });
+
+  it("onDragOver emits the running prose for keyboard drags so users hear position", () => {
+    const announcements = createDragAnnouncements(
+      makeRefs({ isKeyboardDrag: true }),
+      resolveActive,
+      resolveOver
+    );
+    expect(
+      announcements.onDragOver!({
+        active: makeActive({ terminal: { title: "Claude Agent" } }),
+        over: makeOver("term-1", { terminal: { title: "Terminal" } }),
+      })
+    ).toBe("Claude Agent is over Terminal");
+  });
+
+  it("onDragOver keyboard drag without target announces no droppable area", () => {
+    const announcements = createDragAnnouncements(
+      makeRefs({ isKeyboardDrag: true }),
+      resolveActive,
+      resolveOver
+    );
+    expect(
+      announcements.onDragOver!({
+        active: makeActive({ terminal: { title: "Claude Agent" } }),
+        over: null,
+      })
+    ).toBe("Claude Agent is no longer over a droppable area");
+  });
+
+  it("onDragEnd announces destination position from over sortable.index plus pinned total", () => {
+    const announcements = createDragAnnouncements(
+      makeRefs({ pinnedSourceIndex: 0, pinnedTotal: 5 }),
+      resolveActive,
+      resolveOver
+    );
+    expect(
+      announcements.onDragEnd!({
+        active: makeActive({ terminal: { title: "Claude Agent" } }),
+        over: makeOver("term-2", { sortable: { index: 2 } }),
+      })
+    ).toBe("Dropped Claude Agent at position 3 of 5");
+  });
+
+  it("onDragEnd falls back to pinned source index when over has no sortable metadata", () => {
+    const announcements = createDragAnnouncements(
+      makeRefs({ pinnedSourceIndex: 3, pinnedTotal: 8 }),
+      resolveActive,
+      resolveOver
+    );
+    expect(
+      announcements.onDragEnd!({
+        active: makeActive({ terminal: { title: "Claude Agent" } }),
+        over: makeOver("term-x", {}),
+      })
+    ).toBe("Dropped Claude Agent at position 4 of 8");
+  });
+
+  it("onDragEnd omits position when pin and over both lack index data", () => {
+    const announcements = createDragAnnouncements(makeRefs(), resolveActive, resolveOver);
+    expect(
+      announcements.onDragEnd!({
+        active: makeActive({ terminal: { title: "Claude Agent" } }),
+        over: makeOver("term-x", {}),
+      })
+    ).toBe("Dropped Claude Agent");
+  });
+
+  it("onDragEnd omits position when total is zero", () => {
+    const announcements = createDragAnnouncements(
+      makeRefs({ pinnedSourceIndex: 0, pinnedTotal: 0 }),
+      resolveActive,
+      resolveOver
+    );
+    expect(
+      announcements.onDragEnd!({
+        active: makeActive({ terminal: { title: "Claude Agent" } }),
+        over: makeOver("term-x", { sortable: { index: 0 } }),
+      })
+    ).toBe("Dropped Claude Agent");
   });
 
   it("onDragEnd without target announces return to original position", () => {
-    expect(announcements.onDragEnd(withTitle, null)).toBe(
-      "Claude Agent returned to its original position"
+    const announcements = createDragAnnouncements(
+      makeRefs({ pinnedSourceIndex: 0, pinnedTotal: 5 }),
+      resolveActive,
+      resolveOver
     );
+    expect(
+      announcements.onDragEnd!({
+        active: makeActive({ terminal: { title: "Claude Agent" } }),
+        over: null,
+      })
+    ).toBe("Claude Agent returned to its original position");
   });
 
-  it("onDragCancel announces cancellation", () => {
-    expect(announcements.onDragCancel(withTitle)).toBe(
-      "Drag cancelled. Claude Agent returned to its original position"
-    );
-  });
-});
-
-describe("drag announcements — worktree sort", () => {
-  const lookup = new Map<string, WorktreeFixture>([
-    ["wt-issue", { issueTitle: "Add OAuth support", branch: "feature/oauth", name: "oauth" }],
-    ["wt-branch", { branch: "feature/login-flow", name: "login-flow" }],
-    ["wt-name", { name: "fallback-name" }],
-    ["wt-empty", {}],
-  ]);
-  const announcements = makeAnnouncements(lookup);
-
-  function activeFor(worktreeId: string) {
-    return {
-      data: { current: { type: "worktree-sort", worktreeId, dragStartOrder: [worktreeId] } },
-    };
-  }
-
-  it("prefers issueTitle when available", () => {
-    expect(announcements.onDragStart(activeFor("wt-issue"))).toBe("Picked up Add OAuth support");
-  });
-
-  it("falls back to branch when issueTitle is missing", () => {
-    expect(announcements.onDragStart(activeFor("wt-branch"))).toBe("Picked up feature/login-flow");
-  });
-
-  it("falls back to name when branch is missing", () => {
-    expect(announcements.onDragStart(activeFor("wt-name"))).toBe("Picked up fallback-name");
-  });
-
-  it("falls back to 'worktree' when no fields are populated", () => {
-    expect(announcements.onDragStart(activeFor("wt-empty"))).toBe("Picked up worktree");
-  });
-
-  it("uses 'worktree' when worktree snapshot is missing entirely", () => {
-    expect(announcements.onDragStart(activeFor("wt-unknown"))).toBe("Picked up worktree");
-  });
-
-  it("onDragOver resolves both labels via worktree-sort id prefix", () => {
-    const active = activeFor("wt-branch");
-    const over = {
-      id: "worktree-sort-wt-issue",
-      data: { current: { type: "worktree-sort", worktreeId: "wt-issue" } },
-    };
-    expect(announcements.onDragOver(active, over)).toBe(
-      "feature/login-flow is over Add OAuth support"
-    );
-  });
-
-  it("onDragOver resolves the over label via worktree-drop id prefix", () => {
-    const active = activeFor("wt-branch");
-    const over = {
-      id: "worktree-drop-wt-issue",
-      data: { current: {} },
-    };
-    expect(announcements.onDragOver(active, over)).toBe(
-      "feature/login-flow is over Add OAuth support"
-    );
-  });
-
-  it("onDragEnd announces drop with worktree label", () => {
-    const over = { data: { current: { type: "worktree-sort", worktreeId: "wt-issue" } } };
-    expect(announcements.onDragEnd(activeFor("wt-branch"), over)).toBe(
-      "Dropped feature/login-flow"
-    );
-  });
-
-  it("onDragCancel announces cancellation with worktree label", () => {
-    expect(announcements.onDragCancel(activeFor("wt-issue"))).toBe(
-      "Drag cancelled. Add OAuth support returned to its original position"
-    );
+  it("onDragCancel announces cancellation with active label", () => {
+    const announcements = createDragAnnouncements(makeRefs(), resolveActive, resolveOver);
+    expect(
+      announcements.onDragCancel!({
+        active: makeActive({ terminal: { title: "Claude Agent" } }),
+        over: null,
+      })
+    ).toBe("Drag cancelled. Claude Agent returned to its original position");
   });
 });
 
 describe("makeSortableAnnouncements — nested DndContext factory", () => {
   // The dnd-kit `Active` / `Over` types include refs and rects we don't need
   // for announcement-string assertions. Construct the minimum shape and cast.
-  const active = (id: string) => ({ id }) as never;
-  const over = (id: string) => ({ id }) as never;
+  const active = (id: string, data: unknown = {}) => ({ id, data: { current: data } }) as never;
+  const over = (id: string, data: unknown = {}) => ({ id, data: { current: data } }) as never;
 
   describe("panel tab surface", () => {
     const labels = new Map<string, string>([
       ["panel-1", "Claude Agent"],
       ["panel-2", "Codex"],
     ]);
-    const announcements = makeSortableAnnouncements((id) => labels.get(String(id)), "panel tab");
+    const buildAnnouncements = () =>
+      makeSortableAnnouncements((id) => labels.get(String(id)), "panel tab");
 
-    it("onDragStart announces resolved label", () => {
-      expect(announcements.onDragStart({ active: active("panel-1") })).toBe(
-        "Picked up Claude Agent"
-      );
+    it("onDragStart announces resolved label with keyboard instructions", () => {
+      const announcements = buildAnnouncements();
+      expect(
+        announcements.onDragStart!({
+          active: active("panel-1", { sortable: { items: ["panel-1", "panel-2"] } }),
+        })
+      ).toBe("Picked up Claude Agent. Press arrow keys to move, Space to drop, Escape to cancel.");
     });
 
     it("onDragStart falls back to noun + id when label is missing", () => {
-      expect(announcements.onDragStart({ active: active("panel-unknown") })).toBe(
-        "Picked up panel tab panel-unknown"
+      const announcements = buildAnnouncements();
+      expect(announcements.onDragStart!({ active: active("panel-unknown") })).toBe(
+        "Picked up panel tab panel-unknown. Press arrow keys to move, Space to drop, Escape to cancel."
       );
     });
 
     it("onDragOver with target announces both labels", () => {
-      expect(announcements.onDragOver({ active: active("panel-1"), over: over("panel-2") })).toBe(
+      const announcements = buildAnnouncements();
+      expect(announcements.onDragOver!({ active: active("panel-1"), over: over("panel-2") })).toBe(
         "Claude Agent is over Codex"
       );
     });
 
     it("onDragOver without target announces no droppable area", () => {
-      expect(announcements.onDragOver({ active: active("panel-1"), over: null })).toBe(
+      const announcements = buildAnnouncements();
+      expect(announcements.onDragOver!({ active: active("panel-1"), over: null })).toBe(
         "Claude Agent is no longer over a droppable area"
       );
     });
 
-    it("onDragEnd with target announces drop", () => {
-      expect(announcements.onDragEnd({ active: active("panel-1"), over: over("panel-2") })).toBe(
+    it("onDragEnd announces destination position pinned from pickup items", () => {
+      const announcements = buildAnnouncements();
+      announcements.onDragStart!({
+        active: active("panel-1", { sortable: { items: ["panel-1", "panel-2", "panel-3"] } }),
+      });
+      expect(
+        announcements.onDragEnd!({
+          active: active("panel-1"),
+          over: over("panel-3", { sortable: { index: 2 } }),
+        })
+      ).toBe("Dropped Claude Agent at position 3 of 3");
+    });
+
+    it("onDragEnd falls back to plain copy when sortable metadata is missing", () => {
+      const announcements = buildAnnouncements();
+      // No onDragStart call → pinnedTotal stays null → no position info
+      expect(announcements.onDragEnd!({ active: active("panel-1"), over: over("panel-2") })).toBe(
         "Dropped Claude Agent"
       );
     });
 
+    it("onDragEnd clears the pinned total so a stale value can't leak into the next drag", () => {
+      const announcements = buildAnnouncements();
+      announcements.onDragStart!({
+        active: active("panel-1", { sortable: { items: ["panel-1", "panel-2"] } }),
+      });
+      announcements.onDragEnd!({
+        active: active("panel-1"),
+        over: over("panel-2", { sortable: { index: 1 } }),
+      });
+      // Second drag — without a fresh onDragStart the pin is null again
+      expect(
+        announcements.onDragEnd!({
+          active: active("panel-1"),
+          over: over("panel-2", { sortable: { index: 1 } }),
+        })
+      ).toBe("Dropped Claude Agent");
+    });
+
+    it("onDragCancel clears the pinned total so a stale value can't leak into the next drag", () => {
+      const announcements = buildAnnouncements();
+      announcements.onDragStart!({
+        active: active("panel-1", { sortable: { items: ["panel-1", "panel-2"] } }),
+      });
+      announcements.onDragCancel!({ active: active("panel-1"), over: null });
+      expect(
+        announcements.onDragEnd!({
+          active: active("panel-1"),
+          over: over("panel-2", { sortable: { index: 1 } }),
+        })
+      ).toBe("Dropped Claude Agent");
+    });
+
     it("onDragEnd without target announces return to original position", () => {
-      expect(announcements.onDragEnd({ active: active("panel-1"), over: null })).toBe(
+      const announcements = buildAnnouncements();
+      expect(announcements.onDragEnd!({ active: active("panel-1"), over: null })).toBe(
         "Claude Agent returned to its original position"
       );
     });
 
     it("onDragCancel announces cancellation with resolved label", () => {
-      expect(announcements.onDragCancel({ active: active("panel-1"), over: null })).toBe(
+      const announcements = buildAnnouncements();
+      expect(announcements.onDragCancel!({ active: active("panel-1"), over: null })).toBe(
         "Drag cancelled. Claude Agent returned to its original position"
       );
     });
 
     it("treats empty-string labels as missing and falls back to noun + id", () => {
       const emptyLabels = makeSortableAnnouncements(() => "", "panel tab");
-      expect(emptyLabels.onDragStart({ active: active("panel-99") })).toBe(
-        "Picked up panel tab panel-99"
+      expect(emptyLabels.onDragStart!({ active: active("panel-99") })).toBe(
+        "Picked up panel tab panel-99. Press arrow keys to move, Space to drop, Escape to cancel."
       );
     });
 
     it("never includes 'undefined' in the announcement string", () => {
       const nullLabels = makeSortableAnnouncements(() => null, "panel tab");
-      const result = nullLabels.onDragStart({ active: active("panel-x") });
+      const result = nullLabels.onDragStart!({ active: active("panel-x") });
       expect(result).not.toContain("undefined");
-      expect(result).toBe("Picked up panel tab panel-x");
+      expect(result).toBe(
+        "Picked up panel tab panel-x. Press arrow keys to move, Space to drop, Escape to cancel."
+      );
     });
 
     it("treats whitespace-only labels as missing and falls back to noun + id", () => {
       const blankLabels = makeSortableAnnouncements(() => "   \n\t", "panel tab");
-      expect(blankLabels.onDragStart({ active: active("panel-blank") })).toBe(
-        "Picked up panel tab panel-blank"
+      expect(blankLabels.onDragStart!({ active: active("panel-blank") })).toBe(
+        "Picked up panel tab panel-blank. Press arrow keys to move, Space to drop, Escape to cancel."
       );
     });
 
     it("applies fallback to over slot when over label is missing", () => {
+      const announcements = buildAnnouncements();
       // Active resolves to "Claude Agent" (panel-1); over uses an unknown id.
       expect(
-        announcements.onDragOver({ active: active("panel-1"), over: over("panel-mystery") })
+        announcements.onDragOver!({ active: active("panel-1"), over: over("panel-mystery") })
       ).toBe("Claude Agent is over panel tab panel-mystery");
     });
 
@@ -272,17 +325,17 @@ describe("makeSortableAnnouncements — nested DndContext factory", () => {
       const nullLabels = makeSortableAnnouncements(() => null, "panel tab");
       const a = active("panel-x");
       const o = over("panel-y");
-      expect(nullLabels.onDragOver({ active: a, over: o })).toBe(
+      expect(nullLabels.onDragOver!({ active: a, over: o })).toBe(
         "panel tab panel-x is over panel tab panel-y"
       );
-      expect(nullLabels.onDragOver({ active: a, over: null })).toBe(
+      expect(nullLabels.onDragOver!({ active: a, over: null })).toBe(
         "panel tab panel-x is no longer over a droppable area"
       );
-      expect(nullLabels.onDragEnd({ active: a, over: o })).toBe("Dropped panel tab panel-x");
-      expect(nullLabels.onDragEnd({ active: a, over: null })).toBe(
+      expect(nullLabels.onDragEnd!({ active: a, over: o })).toBe("Dropped panel tab panel-x");
+      expect(nullLabels.onDragEnd!({ active: a, over: null })).toBe(
         "panel tab panel-x returned to its original position"
       );
-      expect(nullLabels.onDragCancel({ active: a, over: null })).toBe(
+      expect(nullLabels.onDragCancel!({ active: a, over: null })).toBe(
         "Drag cancelled. panel tab panel-x returned to its original position"
       );
     });
@@ -293,29 +346,33 @@ describe("makeSortableAnnouncements — nested DndContext factory", () => {
       ["btn-portal", "Portal"],
       ["btn-recipes", "Recipes"],
     ]);
-    const announcements = makeSortableAnnouncements(
-      (id) => labels.get(String(id)),
-      "toolbar button"
-    );
+    const buildAnnouncements = () =>
+      makeSortableAnnouncements((id) => labels.get(String(id)), "toolbar button");
 
     it("uses the surface noun in the fallback", () => {
-      expect(announcements.onDragStart({ active: active("btn-mystery") })).toBe(
-        "Picked up toolbar button btn-mystery"
+      const announcements = buildAnnouncements();
+      expect(announcements.onDragStart!({ active: active("btn-mystery") })).toBe(
+        "Picked up toolbar button btn-mystery. Press arrow keys to move, Space to drop, Escape to cancel."
       );
     });
 
     it("resolves known IDs to labels", () => {
-      expect(announcements.onDragStart({ active: active("btn-portal") })).toBe("Picked up Portal");
+      const announcements = buildAnnouncements();
+      expect(announcements.onDragStart!({ active: active("btn-portal") })).toBe(
+        "Picked up Portal. Press arrow keys to move, Space to drop, Escape to cancel."
+      );
     });
   });
 
   describe("browser tab surface", () => {
     const labels = new Map<string, string>([["tab-a", "Daintree Docs"]]);
-    const announcements = makeSortableAnnouncements((id) => labels.get(String(id)), "browser tab");
+    const buildAnnouncements = () =>
+      makeSortableAnnouncements((id) => labels.get(String(id)), "browser tab");
 
     it("uses the browser tab noun in the fallback", () => {
-      expect(announcements.onDragStart({ active: active("tab-z") })).toBe(
-        "Picked up browser tab tab-z"
+      const announcements = buildAnnouncements();
+      expect(announcements.onDragStart!({ active: active("tab-z") })).toBe(
+        "Picked up browser tab tab-z. Press arrow keys to move, Space to drop, Escape to cancel."
       );
     });
   });

--- a/src/components/DragDrop/sortableAnnouncements.ts
+++ b/src/components/DragDrop/sortableAnnouncements.ts
@@ -19,9 +19,17 @@ export function makeSortableAnnouncements(
     return label != null && label.trim() !== "" ? label : `${itemNoun} ${String(id)}`;
   };
 
+  // Pin the list size at pickup so filter/reorder mutations mid-drag don't
+  // churn the denominator the drop string reads. Reset on end/cancel so the
+  // next drag pins a fresh size.
+  let pinnedTotal: number | null = null;
+
   return {
     onDragStart({ active }) {
-      return `Picked up ${resolve(active.id)}`;
+      const data = active.data.current as { sortable?: { items?: unknown[] } } | undefined;
+      const total = data?.sortable?.items?.length;
+      pinnedTotal = typeof total === "number" ? total : null;
+      return `Picked up ${resolve(active.id)}. Press arrow keys to move, Space to drop, Escape to cancel.`;
     },
     onDragOver({ active, over }) {
       const label = resolve(active.id);
@@ -32,12 +40,21 @@ export function makeSortableAnnouncements(
     },
     onDragEnd({ active, over }) {
       const label = resolve(active.id);
-      if (over) {
-        return `Dropped ${label}`;
+      if (!over) {
+        pinnedTotal = null;
+        return `${label} returned to its original position`;
       }
-      return `${label} returned to its original position`;
+      const overData = over.data.current as { sortable?: { index?: number } } | undefined;
+      const destIndex = overData?.sortable?.index;
+      const total = pinnedTotal;
+      pinnedTotal = null;
+      if (typeof destIndex === "number" && total !== null && total > 0) {
+        return `Dropped ${label} at position ${destIndex + 1} of ${total}`;
+      }
+      return `Dropped ${label}`;
     },
     onDragCancel({ active }) {
+      pinnedTotal = null;
       const label = resolve(active.id);
       return `Drag cancelled. ${label} returned to its original position`;
     },

--- a/src/components/Sidebar/SidebarContent.tsx
+++ b/src/components/Sidebar/SidebarContent.tsx
@@ -185,9 +185,22 @@ function SidebarContent({ onOpenOverview }: SidebarContentProps) {
     };
   }, []);
   useDndMonitor({
+    onDragStart() {
+      // Drop any pending 50ms cancel-announcement timer from a previous drag
+      // so a rapid Escape → pickup sequence can't speak stale cancel copy on
+      // top of the new drag's pickup announcement.
+      if (cancelAnnouncementTimerRef.current !== null) {
+        clearTimeout(cancelAnnouncementTimerRef.current);
+        cancelAnnouncementTimerRef.current = null;
+      }
+    },
     onDragCancel({ active }) {
       // Only handle worktree-sort drags — other drag types live on their own
       // surfaces and don't compete with this region's polite Alt+Arrow queue.
+      // Note: dnd-kit fires onDragCancel for both Escape presses and
+      // cancelDrop-converted rejections (e.g., a grid-full rejection). The
+      // assertive interrupt is appropriate for both since each ends the drag
+      // without committing, and the user needs immediate audible feedback.
       if (!isWorktreeSortDragData(active.data.current as Record<string, unknown> | undefined)) {
         return;
       }

--- a/src/components/Sidebar/SidebarContent.tsx
+++ b/src/components/Sidebar/SidebarContent.tsx
@@ -30,7 +30,11 @@ import { FleetPickerPalette } from "@/components/Fleet/FleetPickerPalette";
 import { Tooltip, TooltipContent, TooltipTrigger } from "@/components/ui/tooltip";
 import { ErrorBoundary } from "@/components/ErrorBoundary";
 import { SortableContext, verticalListSortingStrategy } from "@dnd-kit/sortable";
-import { getWorktreeSortDragId } from "@/components/DragDrop/SortableWorktreeCard";
+import { useDndMonitor } from "@dnd-kit/core";
+import {
+  getWorktreeSortDragId,
+  isWorktreeSortDragData,
+} from "@/components/DragDrop/SortableWorktreeCard";
 import { applyManualWorktreeReorder } from "@/lib/worktreeReorder";
 import { usePanelStore, useWorktreeSelectionStore, useProjectStore } from "@/store";
 import { useFleetArmingStore, collectFilterArmEligibleIds } from "@/store/fleetArmingStore";
@@ -127,6 +131,14 @@ function SidebarContent({ onOpenOverview }: SidebarContentProps) {
   // after the row settles. Only the final resting position is announced.
   const reorderAnnouncementTimerRef = useRef<ReturnType<typeof setTimeout> | null>(null);
   const [keyboardReorderAnnouncement, setKeyboardReorderAnnouncement] = useState("");
+  // Assertive sibling region for explicit Escape-cancel during a worktree-sort
+  // drag. dnd-kit's built-in announcer is polite, so the cancel string can
+  // queue behind backlogged movement announcements from Alt+Arrow. Setting
+  // assertive state forces NVDA/JAWS to flush the speech buffer. The
+  // clear-then-setTimeout pattern is required so a repeat cancel string
+  // produces a fresh DOM mutation that AT actually treats as new content.
+  const [keyboardCancelAnnouncement, setKeyboardCancelAnnouncement] = useState("");
+  const cancelAnnouncementTimerRef = useRef<ReturnType<typeof setTimeout> | null>(null);
   const handleKeyboardReorder = useCallback((rowEl: HTMLElement, delta: -1 | 1) => {
     // Grouped-by-type and active-search modes hide the drag handle; keyboard
     // reorder must mirror that — writing to manualOrder here would silently
@@ -162,6 +174,48 @@ function SidebarContent({ onOpenOverview }: SidebarContentProps) {
     scrollContainerRef,
     { onKeyboardReorder: handleKeyboardReorder }
   );
+  // Drop the cancel timer if the sidebar unmounts mid-flight so the trailing
+  // setTimeout doesn't fire setState on an unmounted component.
+  useEffect(() => {
+    return () => {
+      if (cancelAnnouncementTimerRef.current !== null) {
+        clearTimeout(cancelAnnouncementTimerRef.current);
+        cancelAnnouncementTimerRef.current = null;
+      }
+    };
+  }, []);
+  useDndMonitor({
+    onDragCancel({ active }) {
+      // Only handle worktree-sort drags — other drag types live on their own
+      // surfaces and don't compete with this region's polite Alt+Arrow queue.
+      if (!isWorktreeSortDragData(active.data.current as Record<string, unknown> | undefined)) {
+        return;
+      }
+      const worktreeId = (active.data.current as { worktreeId?: string } | undefined)?.worktreeId;
+      const wt = worktreeId ? worktreesRef.current.find((w) => w.id === worktreeId) : undefined;
+      // Match DndProvider.resolveWorktreeLabel so the assertive interrupt
+      // reads the same human-readable name the polite announcer would.
+      const label = wt?.issueTitle ?? wt?.branch ?? wt?.name ?? worktreeId ?? "worktree";
+      // Drop any pending trailing reorder announcement so the polite region
+      // doesn't speak a stale "Moved to position N" after the cancel lands.
+      if (reorderAnnouncementTimerRef.current !== null) {
+        clearTimeout(reorderAnnouncementTimerRef.current);
+        reorderAnnouncementTimerRef.current = null;
+      }
+      setKeyboardReorderAnnouncement("");
+      // Clear → 50ms → set so repeated cancels still register as new content
+      // in the AT speech buffer. Same DOM-mutation trick the polite region
+      // doesn't need because its strings already differ between updates.
+      setKeyboardCancelAnnouncement("");
+      if (cancelAnnouncementTimerRef.current !== null) {
+        clearTimeout(cancelAnnouncementTimerRef.current);
+      }
+      cancelAnnouncementTimerRef.current = setTimeout(() => {
+        cancelAnnouncementTimerRef.current = null;
+        setKeyboardCancelAnnouncement(`Drag cancelled. ${label} returned to its original position`);
+      }, 50);
+    },
+  });
   const { worktrees, isLoading, isReconnecting, reconnectingAt, error, refresh } = useWorktrees();
   worktreesRef.current = worktrees;
 
@@ -1002,6 +1056,13 @@ function SidebarContent({ onOpenOverview }: SidebarContentProps) {
           announce here. */}
       <div className="sr-only" role="status" aria-live="polite" aria-atomic="true">
         {keyboardReorderAnnouncement}
+      </div>
+      {/* Sibling assertive region for explicit Escape-cancel of a worktree-sort
+          drag. Always mounted so the AT has registered it before the drag begins.
+          Assertive priority interrupts any polite "Moved to position N" backlog
+          queued from rapid Alt+Arrow reorders. */}
+      <div className="sr-only" role="status" aria-live="assertive" aria-atomic="true">
+        {keyboardCancelAnnouncement}
       </div>
       {/* Worktree list — single role="grid" with roving tab stop spans pinned + scrollable rows */}
       <div


### PR DESCRIPTION
## Summary

- Silences `onDragOver` from the polite live-region so pointer drag stops flooding NVDA and JAWS with a backlog of intermediate strings — pointer users get the visual placeholder, not a running prose commentary
- Rewrites pickup and drop copy to include keyboard instructions and position-of-total (`Picked up {label}. Press arrow keys to move, Space to drop, Escape to cancel.` / `Dropped {label} at position N of T`)
- Adds an assertive `sr-only` sibling region in `SidebarContent` that fires on Escape-cancel, so the cancel string interrupts the polite backlog immediately rather than queueing behind stale movement strings
- Mirrors all changes in `sortableAnnouncements.ts` so nested sortables stay coherent

Resolves #8104

## Changes

- `DndProvider.tsx` — `onDragOver` returns `null` for pointer input; rewrites pickup/drop announcement strings with keyboard hints and position-of-total; pins `total` at pickup so mid-drag filter changes don't churn the count
- `sortableAnnouncements.ts` — mirrors the copy rewrite with a closure-pinned total
- `SidebarContent.tsx` — adds always-mounted assertive live-region; fires Escape-cancel string via `useDndMonitor` with a clear→50ms→set double-update so NVDA/JAWS flush the polite backlog
- `dndAnnouncements.test.ts` — 32 tests covering pointer suppression, position-of-total rendering, fallbacks, and a listener-ordering regression

## Testing

Unit tests cover all the changed announcement paths. Manually verified NVDA stops reading mid-drag movement strings on pointer input, and that Escape-cancel interrupts immediately rather than queuing.