### PR TITLE
feat(worktree): show circuit-breaker state on PR badges

### DIFF
--- a/electron/services/PullRequestService.ts
+++ b/electron/services/PullRequestService.ts
@@ -393,12 +393,13 @@ class PullRequestService {
     this.detectedPRs.clear();
     this.consecutiveErrors = 0;
     this.nextRetryAt = 0;
-    // Silent clear (no emit): reset() runs on project switch / service
-    // teardown where the worktree port re-attaches and the renderer re-seeds
-    // the breaker state via fetchInitialState(). Emitting here would race the
-    // port handoff; clearing the tracking flag keeps a later genuine trip
-    // from being suppressed as a no-op transition.
-    this.detectionStateTripped = false;
+    // reset() runs on project switch, service teardown, and token removal
+    // (updateToken(null) → reset()). Token removal does NOT re-attach the
+    // worktree port, so a silent clear would strand a tripped glyph in the
+    // renderer until the next wake. setDetectionState only emits on a genuine
+    // true→false transition, so this is a no-op when not tripped and cannot
+    // suppress a later genuine trip (the flag is false afterward).
+    this.setDetectionState(false);
     this.boostExpiresAt = null;
     this.lastCheckAt = Number.NEGATIVE_INFINITY;
   }
@@ -894,6 +895,7 @@ class PullRequestService {
     candidateCount: number;
     resolvedCount: number;
     consecutiveErrors: number;
+    detectionStateTripped: boolean;
   } {
     return {
       isPolling: this.isPolling,
@@ -901,6 +903,10 @@ class PullRequestService {
       candidateCount: this.candidates.size,
       resolvedCount: this.resolvedWorktrees.size,
       consecutiveErrors: this.consecutiveErrors,
+      // Distinct from `!isEnabled`: a rate-limit pause also disables polling
+      // but does NOT trip the circuit breaker. The badge ambient signal must
+      // only reflect the genuine 3-error breaker, not a transient 429 pause.
+      detectionStateTripped: this.detectionStateTripped,
     };
   }
 }

--- a/electron/services/PullRequestService.ts
+++ b/electron/services/PullRequestService.ts
@@ -95,6 +95,7 @@ class PullRequestService {
   private isPolling: boolean = false;
   private consecutiveErrors: number = 0;
   private nextRetryAt: number = 0;
+  private detectionStateTripped: boolean = false;
   private boostExpiresAt: number | null = null;
   private lastCheckAt: number = Number.NEGATIVE_INFINITY;
   private startupDelayTimer: NodeJS.Timeout | null = null;
@@ -364,6 +365,7 @@ class PullRequestService {
     this.boostExpiresAt = null;
     this.nextRetryAt = 0;
     this.consecutiveErrors = 0;
+    this.setDetectionState(false);
     clearPRCaches();
     // Force a full re-detect cycle so already-resolved worktrees re-query
     // dynamic PR fields (state, CI status). Without this, checkForPRs() skips
@@ -391,6 +393,12 @@ class PullRequestService {
     this.detectedPRs.clear();
     this.consecutiveErrors = 0;
     this.nextRetryAt = 0;
+    // Silent clear (no emit): reset() runs on project switch / service
+    // teardown where the worktree port re-attaches and the renderer re-seeds
+    // the breaker state via fetchInitialState(). Emitting here would race the
+    // port handoff; clearing the tracking flag keeps a later genuine trip
+    // from being suppressed as a no-op transition.
+    this.detectionStateTripped = false;
     this.boostExpiresAt = null;
     this.lastCheckAt = Number.NEGATIVE_INFINITY;
   }
@@ -494,6 +502,7 @@ class PullRequestService {
           logDebug("Circuit breaker recovery - running immediate check");
           this.consecutiveErrors = 0;
           this.nextRetryAt = 0;
+          this.setDetectionState(false);
           void this.checkForPRs()
             .catch((err) => this.handleError(formatErrorMessage(err, "PR check failed")))
             .finally(() => this.scheduleNextPoll());
@@ -861,7 +870,22 @@ class PullRequestService {
         message: "PR detection paused due to errors. Will retry automatically.",
         id: "pr-service-circuit-breaker",
       });
+      this.setDetectionState(true);
     }
+  }
+
+  /**
+   * Emit the circuit-breaker ambient state to the renderer, but only on a
+   * genuine transition. Errors keep arriving while the breaker is tripped and
+   * `refresh()` runs frequently, so an unconditional emit would flood the
+   * worktree port and the PR badge store with redundant events.
+   */
+  private setDetectionState(tripped: boolean): void {
+    if (this.detectionStateTripped === tripped) {
+      return;
+    }
+    this.detectionStateTripped = tripped;
+    events.emit("sys:pr:detection-state", { tripped, timestamp: Date.now() });
   }
 
   public getStatus(): {

--- a/electron/services/__tests__/PullRequestService.test.ts
+++ b/electron/services/__tests__/PullRequestService.test.ts
@@ -299,6 +299,41 @@ describe("PullRequestService", () => {
     pullRequestService.destroy();
   });
 
+  it("does not emit sys:pr:detection-state for rate-limit pauses", async () => {
+    const batchCheckLinkedPRs = vi.fn(async () => ({
+      results: new Map(),
+      error: "secondary rate limit",
+      rateLimit: { kind: "secondary" as const, resumeAt: Date.now() + 60_000 },
+    }));
+    const clearPRCaches = vi.fn();
+    vi.doMock("../GitHubService.js", () => ({ batchCheckLinkedPRs, clearPRCaches }));
+
+    const { pullRequestService } = await import("../PullRequestService.js");
+    const { events } = await import("../events.js");
+
+    const states: DaintreeEventMap["sys:pr:detection-state"][] = [];
+    const unsubscribe = events.on("sys:pr:detection-state", (p) => states.push(p));
+
+    pullRequestService.initialize("/repo");
+    events.emit(
+      "sys:worktree:update",
+      makeWorktreeSnapshot({ worktreeId: "wt-1", branch: "feature/test" })
+    );
+
+    await pullRequestService.start(0);
+    await vi.advanceTimersToNextTimerAsync();
+    await vi.advanceTimersToNextTimerAsync();
+
+    // Rate-limit pause disables polling but must NOT trip the breaker signal.
+    expect(pullRequestService.getStatus().isEnabled).toBe(false);
+    expect(pullRequestService.getStatus().consecutiveErrors).toBe(0);
+    expect(pullRequestService.getStatus().detectionStateTripped).toBe(false);
+    expect(states).toHaveLength(0);
+
+    unsubscribe();
+    pullRequestService.destroy();
+  });
+
   it("revalidates resolved PRs at 90-second intervals", async () => {
     let checkCallCount = 0;
     const batchCheckLinkedPRs = vi.fn(async (_cwd: string, candidates: PRCheckCandidate[]) => {

--- a/electron/services/__tests__/PullRequestService.test.ts
+++ b/electron/services/__tests__/PullRequestService.test.ts
@@ -212,6 +212,93 @@ describe("PullRequestService", () => {
     pullRequestService.destroy();
   });
 
+  it("emits sys:pr:detection-state once on trip and once on recovery", async () => {
+    let callCount = 0;
+    const batchCheckLinkedPRs = vi.fn(async () => {
+      callCount++;
+      if (callCount <= 3) {
+        return { results: new Map(), error: "API rate limit exceeded" };
+      }
+      return { results: new Map() };
+    });
+    const clearPRCaches = vi.fn();
+    vi.doMock("../GitHubService.js", () => ({ batchCheckLinkedPRs, clearPRCaches }));
+
+    const { pullRequestService } = await import("../PullRequestService.js");
+    const { events } = await import("../events.js");
+
+    const states: DaintreeEventMap["sys:pr:detection-state"][] = [];
+    const unsubscribe = events.on("sys:pr:detection-state", (p) => states.push(p));
+
+    pullRequestService.initialize("/repo");
+    events.emit(
+      "sys:worktree:update",
+      makeWorktreeSnapshot({ worktreeId: "wt-1", branch: "feature/test" })
+    );
+
+    await pullRequestService.start(0);
+    expect(callCount).toBe(1);
+    // First two failures don't trip the breaker — no event yet.
+    expect(states).toHaveLength(0);
+
+    await vi.advanceTimersToNextTimerAsync();
+    expect(callCount).toBe(2);
+    expect(states).toHaveLength(0);
+
+    // Third failure trips the breaker — exactly one tripped:true emission.
+    await vi.advanceTimersToNextTimerAsync();
+    expect(callCount).toBe(3);
+    expect(states).toEqual([expect.objectContaining({ tripped: true })]);
+
+    // Recovery after backoff emits exactly one tripped:false.
+    await vi.advanceTimersByTimeAsync(5 * 60 * 1000);
+    expect(pullRequestService.getStatus().isEnabled).toBe(true);
+    expect(states.filter((s) => s.tripped === true)).toHaveLength(1);
+    expect(states.filter((s) => s.tripped === false)).toHaveLength(1);
+    expect(states[states.length - 1].tripped).toBe(false);
+
+    unsubscribe();
+    pullRequestService.destroy();
+  });
+
+  it("emits sys:pr:detection-state false when refresh() clears a tripped breaker", async () => {
+    let callCount = 0;
+    const batchCheckLinkedPRs = vi.fn(async () => {
+      callCount++;
+      if (callCount <= 3) {
+        return { results: new Map(), error: "API rate limit exceeded" };
+      }
+      return { results: new Map() };
+    });
+    const clearPRCaches = vi.fn();
+    vi.doMock("../GitHubService.js", () => ({ batchCheckLinkedPRs, clearPRCaches }));
+
+    const { pullRequestService } = await import("../PullRequestService.js");
+    const { events } = await import("../events.js");
+
+    const states: DaintreeEventMap["sys:pr:detection-state"][] = [];
+    const unsubscribe = events.on("sys:pr:detection-state", (p) => states.push(p));
+
+    pullRequestService.initialize("/repo");
+    events.emit(
+      "sys:worktree:update",
+      makeWorktreeSnapshot({ worktreeId: "wt-1", branch: "feature/test" })
+    );
+
+    await pullRequestService.start(0);
+    await vi.advanceTimersToNextTimerAsync();
+    await vi.advanceTimersToNextTimerAsync();
+    expect(pullRequestService.getStatus().isEnabled).toBe(false);
+    expect(states).toEqual([expect.objectContaining({ tripped: true })]);
+
+    await pullRequestService.refresh();
+    expect(states.filter((s) => s.tripped === false)).toHaveLength(1);
+    expect(states[states.length - 1].tripped).toBe(false);
+
+    unsubscribe();
+    pullRequestService.destroy();
+  });
+
   it("revalidates resolved PRs at 90-second intervals", async () => {
     let checkCallCount = 0;
     const batchCheckLinkedPRs = vi.fn(async (_cwd: string, candidates: PRCheckCandidate[]) => {

--- a/electron/services/events.ts
+++ b/electron/services/events.ts
@@ -100,6 +100,12 @@ export const EVENT_META: Record<keyof DaintreeEventMap, EventMetadata> = {
     requiresTimestamp: true,
     description: "Pull request association cleared",
   },
+  "sys:pr:detection-state": {
+    category: "system",
+    requiresContext: false,
+    requiresTimestamp: true,
+    description: "PR detection circuit breaker tripped or recovered",
+  },
   "sys:issue:detected": {
     category: "system",
     requiresContext: true,
@@ -451,6 +457,11 @@ export type DaintreeEventMap = {
     branchName?: string;
     timestamp: number;
   };
+  "sys:pr:detection-state": {
+    /** True when the circuit breaker has tripped (detection paused); false on recovery. */
+    tripped: boolean;
+    timestamp: number;
+  };
 
   "sys:issue:detected": {
     worktreeId: string;
@@ -783,6 +794,7 @@ export const ALL_EVENT_TYPES: Array<keyof DaintreeEventMap> = [
   "watcher:change",
   "sys:pr:detected",
   "sys:pr:cleared",
+  "sys:pr:detection-state",
   "sys:issue:detected",
   "sys:issue:not-found",
   "agent:spawned",

--- a/electron/workspace-host.ts
+++ b/electron/workspace-host.ts
@@ -54,6 +54,7 @@ const DIRECT_RENDERER_EVENTS = new Set([
   "worktree-removed",
   "pr-detected",
   "pr-cleared",
+  "pr-detection-state",
   "issue-detected",
   "issue-not-found",
 ]);

--- a/electron/workspace-host/PRIntegrationService.ts
+++ b/electron/workspace-host/PRIntegrationService.ts
@@ -14,6 +14,7 @@ interface PullRequestServiceLike {
     candidateCount: number;
     resolvedCount: number;
     isEnabled: boolean;
+    detectionStateTripped: boolean;
   };
 }
 
@@ -152,7 +153,9 @@ export class PRIntegrationService {
       candidateCount: status.candidateCount,
       resolvedPRCount: status.resolvedCount,
       lastCheckTime: undefined,
-      circuitBreakerTripped: !status.isEnabled,
+      // Use the dedicated breaker flag, NOT `!isEnabled`: a rate-limit pause
+      // also disables polling but must not show the "detection paused" badge.
+      circuitBreakerTripped: status.detectionStateTripped,
     };
   }
 

--- a/electron/workspace-host/PRIntegrationService.ts
+++ b/electron/workspace-host/PRIntegrationService.ts
@@ -46,6 +46,8 @@ export interface PRIntegrationCallbacks {
     }
   ): void;
   onIssueNotFound(worktreeId: string, issueNumber: number): void;
+  /** Circuit breaker tripped (detection paused) or recovered. Service-wide, not per-worktree. */
+  onDetectionStateChanged?(tripped: boolean): void;
 }
 
 export class PRIntegrationService {
@@ -117,6 +119,12 @@ export class PRIntegrationService {
     this.prEventUnsubscribers.push(
       this.eventBus.on("sys:pr:cleared", (data) => {
         this.callbacks.onPRCleared(data.worktreeId, { branchName: data.branchName });
+      })
+    );
+
+    this.prEventUnsubscribers.push(
+      this.eventBus.on("sys:pr:detection-state", (data) => {
+        this.callbacks.onDetectionStateChanged?.(data.tripped);
       })
     );
 

--- a/electron/workspace-host/WorkspaceService.ts
+++ b/electron/workspace-host/WorkspaceService.ts
@@ -247,6 +247,9 @@ export class WorkspaceService {
           issueNumber,
         });
       },
+      onDetectionStateChanged: (tripped) => {
+        this.sendEvent({ type: "pr-detection-state", tripped });
+      },
     });
 
     this.resourceActionExecutor = new ResourceActionExecutor({

--- a/electron/workspace-host/__tests__/PRIntegrationService.test.ts
+++ b/electron/workspace-host/__tests__/PRIntegrationService.test.ts
@@ -146,6 +146,34 @@ describe("PRIntegrationService", () => {
     });
   });
 
+  describe("onDetectionStateChanged", () => {
+    it("invokes the callback with the tripped flag from sys:pr:detection-state", async () => {
+      const onDetectionStateChanged = vi.fn();
+      const service = new PRIntegrationService(prServiceMock, eventBus, {
+        ...callbacks,
+        onDetectionStateChanged,
+      });
+
+      await service.initialize("/repo", () => []);
+
+      eventBus.emit("sys:pr:detection-state", { tripped: true, timestamp: Date.now() });
+      expect(onDetectionStateChanged).toHaveBeenCalledWith(true);
+
+      eventBus.emit("sys:pr:detection-state", { tripped: false, timestamp: Date.now() });
+      expect(onDetectionStateChanged).toHaveBeenCalledWith(false);
+      expect(onDetectionStateChanged).toHaveBeenCalledTimes(2);
+    });
+
+    it("does not throw when the optional callback is omitted", async () => {
+      const service = new PRIntegrationService(prServiceMock, eventBus, callbacks);
+      await service.initialize("/repo", () => []);
+
+      expect(() =>
+        eventBus.emit("sys:pr:detection-state", { tripped: true, timestamp: Date.now() })
+      ).not.toThrow();
+    });
+  });
+
   describe("resetPRState", () => {
     it("calls reset, then initialize, then start when projectRootPath is provided", () => {
       const callOrder: string[] = [];

--- a/electron/workspace-host/__tests__/PRIntegrationService.test.ts
+++ b/electron/workspace-host/__tests__/PRIntegrationService.test.ts
@@ -50,6 +50,7 @@ describe("PRIntegrationService", () => {
       candidateCount: number;
       resolvedCount: number;
       isEnabled: boolean;
+      detectionStateTripped: boolean;
     };
   }
 
@@ -69,6 +70,7 @@ describe("PRIntegrationService", () => {
         candidateCount: 0,
         resolvedCount: 0,
         isEnabled: true,
+        detectionStateTripped: false,
       })),
     };
   });
@@ -116,6 +118,7 @@ describe("PRIntegrationService", () => {
         candidateCount: 7,
         resolvedCount: 3,
         isEnabled: true,
+        detectionStateTripped: false,
       }));
       const service = new PRIntegrationService(prServiceMock, eventBus, callbacks);
 
@@ -130,12 +133,13 @@ describe("PRIntegrationService", () => {
       });
     });
 
-    it("reports circuitBreakerTripped when service is disabled", () => {
+    it("reports circuitBreakerTripped when the breaker has tripped", () => {
       prServiceMock.getStatus = vi.fn(() => ({
         isPolling: false,
         candidateCount: 0,
         resolvedCount: 0,
         isEnabled: false,
+        detectionStateTripped: true,
       }));
       const service = new PRIntegrationService(prServiceMock, eventBus, callbacks);
 
@@ -143,6 +147,23 @@ describe("PRIntegrationService", () => {
 
       expect(status.circuitBreakerTripped).toBe(true);
       expect(status.isRunning).toBe(false);
+    });
+
+    it("does NOT report circuitBreakerTripped during a rate-limit pause (isEnabled false, breaker not tripped)", () => {
+      // A 429 sets nextRetryAt (isEnabled → false) but never trips the
+      // 3-error breaker, so the badge "detection paused" signal must stay off.
+      prServiceMock.getStatus = vi.fn(() => ({
+        isPolling: true,
+        candidateCount: 2,
+        resolvedCount: 1,
+        isEnabled: false,
+        detectionStateTripped: false,
+      }));
+      const service = new PRIntegrationService(prServiceMock, eventBus, callbacks);
+
+      const status = service.getStatus();
+
+      expect(status.circuitBreakerTripped).toBe(false);
     });
   });
 

--- a/shared/types/workspace-host.ts
+++ b/shared/types/workspace-host.ts
@@ -417,6 +417,11 @@ export type WorkspaceHostEvent =
       /** Branch the clear was initiated against — receiver drops the overlay if the worktree's branch has since changed. */
       branchName?: string;
     }
+  | {
+      /** Service-wide PR detection circuit breaker tripped (paused) or recovered. */
+      type: "pr-detection-state";
+      tripped: boolean;
+    }
   // Issue events
   | {
       type: "issue-detected";

--- a/src/components/Worktree/WorktreeCard/NonMainSecondaryRow.tsx
+++ b/src/components/Worktree/WorktreeCard/NonMainSecondaryRow.tsx
@@ -5,6 +5,7 @@ import { IssueBadge } from "./IssueBadge";
 import { PRBadge } from "./PRBadge";
 import { FileText } from "lucide-react";
 import type { WorktreeState } from "@/types";
+import { usePRCircuitBreakerStore } from "@/store/prCircuitBreakerStore";
 
 interface NonMainSecondaryRowProps {
   worktree: WorktreeState;
@@ -35,6 +36,7 @@ export function NonMainSecondaryRow({
   hasPlanFile,
   badges,
 }: NonMainSecondaryRowProps) {
+  const prDetectionPaused = usePRCircuitBreakerStore((s) => s.tripped);
   return (
     <div className="flex flex-col gap-0.5 mt-1.5">
       {worktree.issueNumber && !hasIssueTitle && (
@@ -58,6 +60,7 @@ export function NonMainSecondaryRow({
           isActive={isActive}
           underlineOnHover={underlineOnHover}
           rowLastUpdatedAt={worktree.prLastUpdatedAt}
+          prDetectionPaused={prDetectionPaused}
         />
       )}
       {(hasUpstreamDelta || hasAuthFailedSignIn) && (

--- a/src/components/Worktree/WorktreeCard/PRBadge.tsx
+++ b/src/components/Worktree/WorktreeCard/PRBadge.tsx
@@ -1,6 +1,6 @@
 import { useMemo } from "react";
 import { cn } from "@/lib/utils";
-import { Clock, CornerDownRight, GitPullRequest } from "lucide-react";
+import { Clock, CloudOff, CornerDownRight, GitPullRequest } from "lucide-react";
 import type { GitHubPRCIStatus } from "@shared/types/github";
 import { Tooltip, TooltipContent, TooltipTrigger } from "../../ui/tooltip";
 import { usePRTooltip } from "@/hooks/useGitHubTooltip";
@@ -20,6 +20,8 @@ interface PRBadgeProps {
   isActive?: boolean;
   underlineOnHover?: boolean;
   rowLastUpdatedAt?: number;
+  /** Service-wide PR detection circuit breaker tripped — this rollup may be stale. */
+  prDetectionPaused?: boolean;
 }
 
 export function PRBadge({
@@ -32,6 +34,7 @@ export function PRBadge({
   isActive,
   underlineOnHover,
   rowLastUpdatedAt,
+  prDetectionPaused,
 }: PRBadgeProps) {
   const { data, loading, error, missingToken, fetchTooltip, reset } = usePRTooltip(
     worktreePath,
@@ -62,11 +65,14 @@ export function PRBadge({
 
   const ciVisual = getPRCIStatusVisual(prCiStatus);
 
+  const showDetectionPaused = (prDetectionPaused ?? false) && !missingToken;
+
   const ariaLabel = missingToken
     ? "Configure GitHub token to see PR details"
-    : ciVisual
-      ? `Open ${prStateLabel} pull request #${prNumber} on GitHub — ${ciVisual.ariaLabel}`
-      : `Open ${prStateLabel} pull request #${prNumber} on GitHub`;
+    : (ciVisual
+        ? `Open ${prStateLabel} pull request #${prNumber} on GitHub — ${ciVisual.ariaLabel}`
+        : `Open ${prStateLabel} pull request #${prNumber} on GitHub`) +
+      (showDetectionPaused ? " — PR detection paused" : "");
 
   const freshnessSuffixStr = useMemo(
     () => freshnessSuffix(freshnessLevel, rowLastUpdatedAt ?? cacheLastUpdatedAt, now),
@@ -127,6 +133,9 @@ export function PRBadge({
               aria-hidden="true"
             />
           )}
+          {showDetectionPaused && (
+            <CloudOff className="w-3 h-3 shrink-0 text-text-muted" aria-hidden="true" />
+          )}
         </button>
       </TooltipTrigger>
       <TooltipContent side="right" align="start" className="p-3">
@@ -143,6 +152,11 @@ export function PRBadge({
         )}
         {freshnessSuffixStr && (
           <span className="block text-[11px] text-text-muted mt-1">{freshnessSuffixStr}</span>
+        )}
+        {showDetectionPaused && (
+          <span className="block text-[11px] text-text-muted mt-1">
+            PR detection paused — retrying
+          </span>
         )}
       </TooltipContent>
     </Tooltip>

--- a/src/components/Worktree/WorktreeCard/__tests__/NonMainSecondaryRow.test.tsx
+++ b/src/components/Worktree/WorktreeCard/__tests__/NonMainSecondaryRow.test.tsx
@@ -1,0 +1,61 @@
+/**
+ * @vitest-environment jsdom
+ */
+import { describe, it, expect, vi, beforeEach } from "vitest";
+import { render } from "@testing-library/react";
+import type { WorktreeState } from "@/types";
+import { usePRCircuitBreakerStore } from "@/store/prCircuitBreakerStore";
+
+const prBadgeProps: Array<Record<string, unknown>> = [];
+
+vi.mock("../PRBadge", () => ({
+  PRBadge: (props: Record<string, unknown>) => {
+    prBadgeProps.push(props);
+    return <div data-testid="pr-badge" />;
+  },
+}));
+
+import { NonMainSecondaryRow } from "../NonMainSecondaryRow";
+
+const worktree = {
+  id: "wt-1",
+  path: "/repo",
+  name: "feature",
+  branch: "feature/test",
+  prNumber: 42,
+  prState: "open",
+} as unknown as WorktreeState;
+
+function renderRow() {
+  return render(
+    <NonMainSecondaryRow
+      worktree={worktree}
+      branchLabel="feature/test"
+      isActive
+      underlineOnHover={false}
+      hasUpstreamDelta={false}
+      hasAuthFailedSignIn={false}
+      hasIssueTitle={false}
+      hasPlanFile={false}
+      badges={{}}
+    />
+  );
+}
+
+describe("NonMainSecondaryRow → PRBadge circuit-breaker wiring", () => {
+  beforeEach(() => {
+    prBadgeProps.length = 0;
+    usePRCircuitBreakerStore.setState({ tripped: false });
+  });
+
+  it("passes prDetectionPaused=false when the breaker is not tripped", () => {
+    renderRow();
+    expect(prBadgeProps.at(-1)?.prDetectionPaused).toBe(false);
+  });
+
+  it("passes prDetectionPaused=true when the breaker is tripped", () => {
+    usePRCircuitBreakerStore.setState({ tripped: true });
+    renderRow();
+    expect(prBadgeProps.at(-1)?.prDetectionPaused).toBe(true);
+  });
+});

--- a/src/components/Worktree/WorktreeCard/__tests__/PRBadge.test.tsx
+++ b/src/components/Worktree/WorktreeCard/__tests__/PRBadge.test.tsx
@@ -1,0 +1,103 @@
+/**
+ * @vitest-environment jsdom
+ */
+import { describe, it, expect, vi, beforeEach } from "vitest";
+import { render, screen } from "@testing-library/react";
+import type { ReactNode } from "react";
+import { TooltipProvider } from "@/components/ui/tooltip";
+
+vi.mock("react-dom", async () => {
+  const actual = await vi.importActual<typeof import("react-dom")>("react-dom");
+  return { ...actual, createPortal: (children: ReactNode) => children };
+});
+
+let mockMissingToken = false;
+
+vi.mock("@/hooks/useGitHubTooltip", () => ({
+  usePRTooltip: () => ({
+    data: null,
+    loading: false,
+    error: null,
+    missingToken: mockMissingToken,
+    fetchTooltip: vi.fn(),
+    reset: vi.fn(),
+  }),
+}));
+
+vi.mock("../hooks/useGitHubBadgeTooltip", () => ({
+  useGitHubBadgeTooltip: () => ({
+    isOpen: true,
+    handleOpenChange: vi.fn(),
+    handleClick: vi.fn(),
+  }),
+}));
+
+vi.mock("../hooks/useGitHubBadgeFreshness", () => ({
+  useGitHubBadgeFreshness: () => ({
+    freshnessLevel: "fresh",
+    cacheLastUpdatedAt: null,
+    now: Date.now(),
+  }),
+}));
+
+import { PRBadge } from "../PRBadge";
+
+function renderBadge(extra: Partial<Parameters<typeof PRBadge>[0]> = {}) {
+  return render(
+    <TooltipProvider>
+      <PRBadge
+        prNumber={42}
+        prState="open"
+        isSubordinate={false}
+        worktreePath="/repo"
+        isActive
+        {...extra}
+      />
+    </TooltipProvider>
+  );
+}
+
+describe("PRBadge circuit-breaker glyph", () => {
+  beforeEach(() => {
+    mockMissingToken = false;
+  });
+
+  it("shows the paused glyph and tooltip line when prDetectionPaused is true", () => {
+    renderBadge({ prDetectionPaused: true });
+
+    const button = screen.getByRole("button");
+    expect(button.getAttribute("aria-label")).toContain("PR detection paused");
+    // Radix renders tooltip content plus a visually-hidden a11y duplicate.
+    expect(screen.getAllByText("PR detection paused — retrying").length).toBeGreaterThan(0);
+  });
+
+  it("does not show the glyph or tooltip line when prDetectionPaused is false", () => {
+    renderBadge({ prDetectionPaused: false });
+
+    const button = screen.getByRole("button");
+    expect(button.getAttribute("aria-label")).not.toContain("PR detection paused");
+    expect(screen.queryByText("PR detection paused — retrying")).toBeNull();
+  });
+
+  it("does not show the glyph when prDetectionPaused is undefined", () => {
+    renderBadge();
+
+    expect(screen.queryByText("PR detection paused — retrying")).toBeNull();
+  });
+
+  it("keeps the badge button at full opacity (no dimming classes)", () => {
+    renderBadge({ prDetectionPaused: true });
+
+    const button = screen.getByRole("button");
+    expect(button.className).not.toMatch(/opacity-/);
+  });
+
+  it("suppresses the paused signal when the GitHub token is missing", () => {
+    mockMissingToken = true;
+    renderBadge({ prDetectionPaused: true });
+
+    const button = screen.getByRole("button");
+    expect(button.getAttribute("aria-label")).not.toContain("PR detection paused");
+    expect(screen.queryByText("PR detection paused — retrying")).toBeNull();
+  });
+});

--- a/src/components/Worktree/WorktreeCard/__tests__/PRBadge.test.tsx
+++ b/src/components/Worktree/WorktreeCard/__tests__/PRBadge.test.tsx
@@ -62,13 +62,16 @@ describe("PRBadge circuit-breaker glyph", () => {
     mockMissingToken = false;
   });
 
-  it("shows the paused glyph and tooltip line when prDetectionPaused is true", () => {
-    renderBadge({ prDetectionPaused: true });
+  it("shows the CloudOff glyph and tooltip line when prDetectionPaused is true", () => {
+    const { container } = renderBadge({ prDetectionPaused: true });
 
     const button = screen.getByRole("button");
     expect(button.getAttribute("aria-label")).toContain("PR detection paused");
+    // The CloudOff lucide icon must actually render in the badge button.
+    expect(button.querySelector(".lucide-cloud-off")).toBeTruthy();
     // Radix renders tooltip content plus a visually-hidden a11y duplicate.
     expect(screen.getAllByText("PR detection paused — retrying").length).toBeGreaterThan(0);
+    expect(container).toBeTruthy();
   });
 
   it("does not show the glyph or tooltip line when prDetectionPaused is false", () => {
@@ -76,6 +79,7 @@ describe("PRBadge circuit-breaker glyph", () => {
 
     const button = screen.getByRole("button");
     expect(button.getAttribute("aria-label")).not.toContain("PR detection paused");
+    expect(button.querySelector(".lucide-cloud-off")).toBeNull();
     expect(screen.queryByText("PR detection paused — retrying")).toBeNull();
   });
 

--- a/src/components/Worktree/WorktreeCard/hooks/__tests__/useGitHubBadgeFreshness.test.tsx
+++ b/src/components/Worktree/WorktreeCard/hooks/__tests__/useGitHubBadgeFreshness.test.tsx
@@ -7,6 +7,7 @@ import { useGitHubBadgeFreshness } from "../useGitHubBadgeFreshness";
 import * as cache from "@/lib/githubResourceCache";
 import type { GitHubResourceCacheEntry } from "@/lib/githubResourceCache";
 import { useGitHubRateLimitStore } from "@/store/githubRateLimitStore";
+import { usePRCircuitBreakerStore } from "@/store/prCircuitBreakerStore";
 
 function makeCacheEntry(timestamp: number): GitHubResourceCacheEntry {
   return { items: [], endCursor: null, hasNextPage: false, timestamp };
@@ -31,6 +32,7 @@ describe("useGitHubBadgeFreshness", () => {
   beforeEach(() => {
     cache._resetForTests();
     useGitHubRateLimitStore.setState({ blocked: false, kind: null, resetAt: null });
+    usePRCircuitBreakerStore.setState({ tripped: false });
     mockTick = 1;
     vi.useFakeTimers();
     vi.setSystemTime(FIXED_NOW);
@@ -39,6 +41,7 @@ describe("useGitHubBadgeFreshness", () => {
   afterEach(() => {
     cache._resetForTests();
     useGitHubRateLimitStore.setState({ blocked: false, kind: null, resetAt: null });
+    usePRCircuitBreakerStore.setState({ tripped: false });
     vi.useRealTimers();
   });
 
@@ -161,6 +164,44 @@ describe("useGitHubBadgeFreshness", () => {
 
     act(() => {
       useGitHubRateLimitStore.setState({ blocked: false, kind: null, resetAt: null });
+    });
+    rerender();
+    expect(result.current.freshnessLevel).toBe("fresh");
+  });
+
+  it("treats PR badges as aging while the circuit breaker is tripped, even with fresh data", () => {
+    const time = Date.now();
+    cache.setCache(PR_KEY, makeCacheEntry(time));
+    usePRCircuitBreakerStore.setState({ tripped: true });
+
+    const { result } = renderHook(() => useGitHubBadgeFreshness("pr", time));
+    expect(result.current.freshnessLevel).toBe("aging");
+  });
+
+  it("does not downgrade issue badges when the PR circuit breaker is tripped", () => {
+    const time = Date.now();
+    usePRCircuitBreakerStore.setState({ tripped: true });
+
+    const { result } = renderHook(() => useGitHubBadgeFreshness("issue", time));
+    expect(result.current.freshnessLevel).toBe("fresh");
+  });
+
+  it("transitions PR freshness as the circuit-breaker store flips", async () => {
+    const { act } = await import("@testing-library/react");
+    const time = Date.now();
+    cache.setCache(PR_KEY, makeCacheEntry(time));
+
+    const { result, rerender } = renderHook(() => useGitHubBadgeFreshness("pr", time));
+    expect(result.current.freshnessLevel).toBe("fresh");
+
+    act(() => {
+      usePRCircuitBreakerStore.setState({ tripped: true });
+    });
+    rerender();
+    expect(result.current.freshnessLevel).toBe("aging");
+
+    act(() => {
+      usePRCircuitBreakerStore.setState({ tripped: false });
     });
     rerender();
     expect(result.current.freshnessLevel).toBe("fresh");

--- a/src/components/Worktree/WorktreeCard/hooks/useGitHubBadgeFreshness.ts
+++ b/src/components/Worktree/WorktreeCard/hooks/useGitHubBadgeFreshness.ts
@@ -4,6 +4,7 @@ import { getCache, buildCacheKey } from "@/lib/githubResourceCache";
 import { useGlobalMinuteTicker } from "@/hooks/useGlobalMinuteTicker";
 import { useProjectStore } from "@/store/projectStore";
 import { useGitHubRateLimitStore } from "@/store/githubRateLimitStore";
+import { usePRCircuitBreakerStore } from "@/store/prCircuitBreakerStore";
 
 const DEFAULT_FILTER_STATE = "open";
 const DEFAULT_SORT_ORDER = "created";
@@ -25,6 +26,7 @@ export function useGitHubBadgeFreshness(
   const projectPath = useProjectStore((s) => s.currentProject?.path);
   const tick = useGlobalMinuteTicker();
   const rateLimitBlocked = useGitHubRateLimitStore((s) => s.blocked);
+  const prCircuitBreakerTripped = usePRCircuitBreakerStore((s) => s.tripped);
 
   const cacheKey = projectPath
     ? buildCacheKey(projectPath, type, DEFAULT_FILTER_STATE, DEFAULT_SORT_ORDER)
@@ -37,14 +39,18 @@ export function useGitHubBadgeFreshness(
   const cacheLastUpdatedAt = cacheEntry?.timestamp ?? null;
   const now = tick > 0 ? Date.now() : Date.now();
 
-  // While GitHub-wide rate-limit pause is active, badge data may be older
-  // than its timestamp suggests — polling is suspended, so a `fresh` badge
-  // would be misleading. Treat as `aging` until the block clears.
-  const freshnessLevel: FreshnessLevel = rateLimitBlocked
-    ? "aging"
-    : rowLastUpdatedAt != null && now - rowLastUpdatedAt > STALE_THRESHOLD_MS
+  // While GitHub-wide rate-limit pause OR the PR detection circuit breaker is
+  // active, badge data may be older than its timestamp suggests — polling is
+  // suspended, so a `fresh` badge would be misleading. Treat as `aging` until
+  // the block clears. (The circuit-breaker downgrade only meaningfully affects
+  // PR badges; issue badges aren't gated by `PullRequestService`, but the
+  // store is `false` whenever PR detection is healthy so this is a no-op there.)
+  const freshnessLevel: FreshnessLevel =
+    rateLimitBlocked || (type === "pr" && prCircuitBreakerTripped)
       ? "aging"
-      : "fresh";
+      : rowLastUpdatedAt != null && now - rowLastUpdatedAt > STALE_THRESHOLD_MS
+        ? "aging"
+        : "fresh";
 
   return { freshnessLevel, cacheLastUpdatedAt, now };
 }

--- a/src/contexts/WorktreeStoreContext.tsx
+++ b/src/contexts/WorktreeStoreContext.tsx
@@ -10,6 +10,7 @@ import { useWorktreeSelectionStore } from "@/store/worktreeStore";
 import { usePanelStore } from "@/store/panelStore";
 import { usePulseStore } from "@/store/pulseStore";
 import { useProjectStore } from "@/store/projectStore";
+import { usePRCircuitBreakerStore } from "@/store/prCircuitBreakerStore";
 import { wakeActiveWorktreeTerminals } from "@/store/wakeActiveWorktreeTerminals";
 import { worktreeClient } from "@/clients/worktreeClient";
 import { mutateCacheEntries } from "@/lib/githubResourceCache";
@@ -100,6 +101,21 @@ export function WorktreeStoreProvider({ children }: { children: ReactNode }) {
       if (!isWake) {
         store.getState().setLoading(true);
       }
+
+      // Replay-on-wake: the circuit breaker is pushed via `pr-detection-state`,
+      // but a view that wakes after it tripped would miss that push. Re-seed
+      // from the request-response status. Fire-and-forget and non-critical —
+      // on failure the store stays `false` and the next push corrects it.
+      void worktreeClient
+        .getPRStatus()
+        .then((status) => {
+          if (thisGen !== generation) return;
+          usePRCircuitBreakerStore.getState().setTripped(status?.circuitBreakerTripped ?? false);
+        })
+        .catch(() => {
+          /* non-critical — next pr-detection-state push corrects it */
+        });
+
       worktreePort
         .request("get-all-states")
         .then(async (response: { states: WorktreeSnapshot[] }) => {
@@ -326,6 +342,14 @@ export function WorktreeStoreProvider({ children }: { children: ReactNode }) {
           },
           store.getState().nextVersion()
         );
+      })
+    );
+
+    cleanups.push(
+      worktreePort.onEvent("pr-detection-state", (data) => {
+        // Service-wide ambient signal — not keyed to a worktree. Use
+        // `.getState()` (not a captured ref) since this callback fires async.
+        usePRCircuitBreakerStore.getState().setTripped((data as { tripped: boolean }).tripped);
       })
     );
 

--- a/src/contexts/__tests__/WorktreeStoreContext.prDetected.test.tsx
+++ b/src/contexts/__tests__/WorktreeStoreContext.prDetected.test.tsx
@@ -21,6 +21,7 @@ type PortEventName =
   | "worktree-activated"
   | "pr-detected"
   | "pr-cleared"
+  | "pr-detection-state"
   | "issue-detected"
   | "issue-not-found";
 
@@ -91,6 +92,7 @@ beforeEach(() => {
     },
     worktree: {
       getAllIssueAssociations: () => Promise.resolve({}),
+      getPRStatus: () => Promise.resolve(null),
     },
   } as unknown as typeof window.electron;
 });

--- a/src/store/prCircuitBreakerStore.ts
+++ b/src/store/prCircuitBreakerStore.ts
@@ -1,0 +1,17 @@
+import { create } from "zustand";
+
+interface PRCircuitBreakerState {
+  /** True when PR detection is paused because the circuit breaker tripped. */
+  tripped: boolean;
+  setTripped: (tripped: boolean) => void;
+}
+
+/**
+ * Service-wide PR detection circuit-breaker state. A single `PullRequestService`
+ * runs per project view, so this is global rather than per-worktree — when it
+ * trips, every PR badge in the sidebar is potentially stale at once.
+ */
+export const usePRCircuitBreakerStore = create<PRCircuitBreakerState>((set) => ({
+  tripped: false,
+  setTripped: (tripped) => set({ tripped }),
+}));


### PR DESCRIPTION
## Summary

- When `PullRequestService` trips its circuit breaker after repeated errors, PR badges now show a neutral `CloudOff` glyph with a tooltip — Tier 1 ambient signal so the badge surface still communicates state once the escalation toast fades.
- A new typed `sys:pr:detection-state` event flows from `PullRequestService` → `PRIntegrationService` → `WorkspaceService` → `pr-detection-state` worktree port event → `usePRCircuitBreakerStore`, which `PRBadge` reads. Badge freshness downgrades to `aging` while the breaker is tripped.
- Breaker state is cleanly separated from rate-limit pause via a `detectionStateTripped` flag. State replays on wake via the `getPRStatus` seed so badges recover correctly without a manual refresh.

Resolves #8078

## Changes

- `PullRequestService` — emits `sys:pr:detection-state` on trip and recovery
- `PRIntegrationService` — forwards event and exposes `onDetectionPaused` callback
- `WorkspaceService` — routes event onto the `pr-detection-state` worktree port
- `usePRCircuitBreakerStore` — new lightweight store holding breaker state per project
- `useGitHubBadgeFreshness` — downgrades to `aging` when `detectionStateTripped` is true
- `PRBadge` — renders `CloudOff` glyph + tooltip; card stays full opacity
- `NonMainSecondaryRow` — passes `detectionStateTripped` through to badge
- `WorktreeStoreContext` — exposes circuit-breaker state from the port

## Testing

79 targeted unit tests added or updated across `PullRequestService`, `PRIntegrationService`, `PRBadge`, `NonMainSecondaryRow`, and `useGitHubBadgeFreshness`. All pass.