### PR TITLE
fix(worktree): keep merged worktrees in working filter while agent is active

### DIFF
--- a/src/components/GitHub/__tests__/CommitList.test.tsx
+++ b/src/components/GitHub/__tests__/CommitList.test.tsx
@@ -111,8 +111,10 @@ describe("CommitList Enter key handling", () => {
       fireEvent.keyDown(input, { key: "Enter" });
     });
 
-    const optionsAfter = container.querySelectorAll("[role='option']");
-    expect(optionsAfter[0]?.getAttribute("aria-expanded")).toBe("true");
+    await waitFor(() => {
+      const optionsAfter = container.querySelectorAll("[role='option']");
+      expect(optionsAfter[0]?.getAttribute("aria-expanded")).toBe("true");
+    });
     const pre = container.querySelector("pre");
     expect(pre?.textContent).toContain("Detailed body line 1.");
     expect(navigator.clipboard.writeText).not.toHaveBeenCalled();
@@ -170,8 +172,10 @@ describe("CommitList Enter key handling", () => {
       fireEvent.keyDown(input, { key: "Enter" });
     });
 
-    const firstOption = container.querySelector("[role='option']");
-    expect(firstOption?.getAttribute("aria-expanded")).toBe("true");
+    await waitFor(() => {
+      const firstOption = container.querySelector("[role='option']");
+      expect(firstOption?.getAttribute("aria-expanded")).toBe("true");
+    });
 
     const loadMore = container.querySelector("#commit-load-more");
     expect(loadMore).not.toBeNull();

--- a/src/components/Worktree/__tests__/computeChipState.test.ts
+++ b/src/components/Worktree/__tests__/computeChipState.test.ts
@@ -81,12 +81,24 @@ describe("computeChipState", () => {
     });
   });
 
-  describe("active agent suppresses complete", () => {
+  describe("active agent suppresses cleanup and complete", () => {
     it("returns null when isComplete but hasActiveAgent", () => {
       expect(computeChipState({ ...base, isComplete: true, hasActiveAgent: true })).toBeNull();
     });
 
-    it("cleanup beats hasActiveAgent", () => {
+    it("returns null when merged but hasActiveAgent", () => {
+      expect(
+        computeChipState({ ...base, lifecycleStage: "merged", hasActiveAgent: true })
+      ).toBeNull();
+    });
+
+    it("returns null when ready-for-cleanup but hasActiveAgent", () => {
+      expect(
+        computeChipState({ ...base, lifecycleStage: "ready-for-cleanup", hasActiveAgent: true })
+      ).toBeNull();
+    });
+
+    it("active agent suppresses cleanup even when isComplete is also true", () => {
       expect(
         computeChipState({
           ...base,
@@ -94,7 +106,18 @@ describe("computeChipState", () => {
           isComplete: true,
           hasActiveAgent: true,
         })
-      ).toBe("cleanup");
+      ).toBeNull();
+    });
+
+    it("returns waiting when merged, hasActiveAgent, and waitingTerminalCount > 0", () => {
+      expect(
+        computeChipState({
+          ...base,
+          lifecycleStage: "merged",
+          hasActiveAgent: true,
+          waitingTerminalCount: 1,
+        })
+      ).toBe("waiting");
     });
 
     it("returns waiting when isComplete, hasActiveAgent, and waitingTerminalCount > 0", () => {

--- a/src/components/Worktree/utils/computeChipState.ts
+++ b/src/components/Worktree/utils/computeChipState.ts
@@ -10,7 +10,10 @@ export interface ComputeChipStateInput {
 }
 
 export function computeChipState(input: ComputeChipStateInput): ChipState {
-  if (input.lifecycleStage === "merged" || input.lifecycleStage === "ready-for-cleanup")
+  if (
+    (input.lifecycleStage === "merged" || input.lifecycleStage === "ready-for-cleanup") &&
+    !input.hasActiveAgent
+  )
     return "cleanup";
   if (input.isComplete && !input.hasActiveAgent) return "complete";
   if (input.waitingTerminalCount > 0) return "waiting";

--- a/src/lib/__tests__/worktreeFilters.test.ts
+++ b/src/lib/__tests__/worktreeFilters.test.ts
@@ -1237,6 +1237,12 @@ describe("matchesQuickStateFilter", () => {
     const meta = { ...createEmptyMeta(), chipState: "waiting" as const };
     expect(matchesQuickStateFilter("finished", meta)).toBe(false);
   });
+
+  it('"finished" does NOT match a merged worktree with an active agent (chipState null)', () => {
+    const meta = { ...createEmptyMeta(), hasWorkingAgent: true, chipState: null };
+    expect(matchesQuickStateFilter("finished", meta)).toBe(false);
+    expect(matchesQuickStateFilter("working", meta)).toBe(true);
+  });
 });
 
 describe("computeChipCounts", () => {


### PR DESCRIPTION
## Summary

- When a worktree was merged or ready for cleanup but still had an active agent, it was being shown in the Finished filter
- The `cleanup` branch in `computeChipState()` didn't have the same `hasActiveAgent` guard that the `complete` branch already had
- Fix adds the guard so merged/ready-for-cleanup worktrees with an active agent resolve to `waiting` or `null`, not `cleanup`

Resolves #8223

## Changes

- `computeChipState.ts` — added `!hasActiveAgent` guard to the `cleanup` branch, mirroring the existing guard on `complete`
- `computeChipState.test.ts` — expanded coverage to include merged/ready-for-cleanup with and without an active agent
- `worktreeFilters.test.ts` — added a regression test asserting that `{ chipState: null, hasWorkingAgent: true }` matches `working` and not `finished`

## Testing

171 unit tests pass (`computeChipState` + `worktreeFilters`). Typecheck, lint, and build all green. No E2E changes required for a pure-function fix.