### PR TITLE
feat(project-switcher): surface Copy path in modal and toolbar pickers

### DIFF
--- a/src/App.tsx
+++ b/src/App.tsx
@@ -945,6 +945,13 @@ function App() {
                     onCloseProject={(projectId) =>
                       void projectSwitcherPalette.removeProject(projectId)
                     }
+                    onLocateProject={(projectId) =>
+                      void projectSwitcherPalette.locateProject(projectId)
+                    }
+                    onTogglePinProject={(projectId) =>
+                      void projectSwitcherPalette.togglePinProject(projectId)
+                    }
+                    onCopyPath={projectSwitcherPalette.copyPath}
                     removeConfirmProject={projectSwitcherPalette.removeConfirmProject}
                     onRemoveConfirmClose={() =>
                       projectSwitcherPalette.setRemoveConfirmProject(null)

--- a/src/components/Layout/Toolbar.tsx
+++ b/src/components/Layout/Toolbar.tsx
@@ -279,6 +279,13 @@ export function Toolbar({
     [projectSwitcher]
   );
 
+  const handleLocateProject = useCallback(
+    (projectId: string) => {
+      void projectSwitcher.locateProject(projectId);
+    },
+    [projectSwitcher]
+  );
+
   const handleRemoveConfirmClose = useCallback(() => {
     projectSwitcher.setRemoveConfirmProject(null);
   }, [projectSwitcher]);
@@ -1104,7 +1111,9 @@ export function Toolbar({
             onCloneRepo={projectSwitcher.cloneRepo}
             onStopProject={handleStopProject}
             onCloseProject={handleCloseProject}
+            onLocateProject={handleLocateProject}
             onTogglePinProject={projectSwitcher.togglePinProject}
+            onCopyPath={projectSwitcher.copyPath}
             onOpenProjectSettings={currentProject ? handleOpenProjectSettings : undefined}
             onSelectNewWindow={handleSelectNewWindow}
             dropdownAlign="center"

--- a/src/components/Project/ProjectSwitcher.tsx
+++ b/src/components/Project/ProjectSwitcher.tsx
@@ -9,7 +9,6 @@ import { Spinner } from "@/components/ui/Spinner";
 import { Tooltip, TooltipContent, TooltipTrigger } from "@/components/ui/tooltip";
 import { useKeybindingDisplay } from "@/hooks/useKeybinding";
 import { useProjectSwitcherPalette } from "@/hooks";
-import { useCopyWithFeedback } from "@/hooks/useCopyWithFeedback";
 import { actionService } from "@/services/ActionService";
 import { ProjectSwitcherPalette } from "./ProjectSwitcherPalette";
 import type { SearchableProject } from "@/hooks/useProjectSwitcherPalette";
@@ -86,14 +85,6 @@ export function ProjectSwitcher() {
     [projectSwitcher]
   );
 
-  const { copy: copyProjectPath } = useCopyWithFeedback();
-  const handleCopyPath = useCallback(
-    (path: string) => {
-      void copyProjectPath(path);
-    },
-    [copyProjectPath]
-  );
-
   const handleSelectNewWindow = useCallback(
     (project: SearchableProject) => {
       if (project.isMissing) return;
@@ -157,7 +148,7 @@ export function ProjectSwitcher() {
             onCloseProject={handleCloseProject}
             onLocateProject={handleLocateProject}
             onTogglePinProject={handleTogglePinProject}
-            onCopyPath={handleCopyPath}
+            onCopyPath={projectSwitcher.copyPath}
             onSelectNewWindow={handleSelectNewWindow}
             onHoverProject={projectSwitcher.onHoverProject}
             onHoverProjectEnd={projectSwitcher.onHoverProjectEnd}
@@ -226,7 +217,7 @@ export function ProjectSwitcher() {
         onLocateProject={handleLocateProject}
         onTogglePinProject={handleTogglePinProject}
         onOpenProjectSettings={handleOpenSettings}
-        onCopyPath={handleCopyPath}
+        onCopyPath={projectSwitcher.copyPath}
         onHoverProject={projectSwitcher.onHoverProject}
         onHoverProjectEnd={projectSwitcher.onHoverProjectEnd}
         removeConfirmProject={projectSwitcher.removeConfirmProject}

--- a/src/components/Project/ProjectSwitcherPalette.tsx
+++ b/src/components/Project/ProjectSwitcherPalette.tsx
@@ -681,11 +681,9 @@ function ProjectSwitcherFooter({ mode }: { mode?: ProjectSwitcherMode }) {
           </span>
         )}
       </div>
-      {mode !== "modal" && (
-        <span className="text-daintree-text/30">
-          <span>Right-click for more</span>
-        </span>
-      )}
+      <span className="text-daintree-text/30">
+        <span>Right-click for more</span>
+      </span>
     </div>
   );
 }

--- a/src/components/Project/__tests__/ProjectSwitcherPalette.keyboard.test.tsx
+++ b/src/components/Project/__tests__/ProjectSwitcherPalette.keyboard.test.tsx
@@ -258,12 +258,12 @@ describe("ProjectSwitcherPalette keyboard navigation", () => {
     expect(document.activeElement).toBe(focusable[focusable.length - 1]);
   });
 
-  it("displays condensed footer with switch hint in modal mode", () => {
+  it("displays condensed footer with switch and right-click hints in modal mode", () => {
     render(<ProjectSwitcherPalette {...defaultProps} />);
     const footer = screen.getByTestId("palette-footer");
     expect(footer.textContent).toContain("Switch");
     expect(footer.textContent).not.toContain("Remove");
-    expect(footer.textContent).not.toContain("Right-click for more");
+    expect(footer.textContent).toContain("Right-click for more");
   });
 
   it("Alt+Enter performs a normal switch and never triggers new-window", () => {

--- a/src/components/Project/__tests__/ProjectSwitcherPalette.render.test.tsx
+++ b/src/components/Project/__tests__/ProjectSwitcherPalette.render.test.tsx
@@ -338,12 +338,12 @@ describe("ProjectSwitcherPalette modal mode", () => {
     expect(screen.queryByText("Create New Folder...")).toBeNull();
   });
 
-  it("does not show Remove hint in modal mode footer", () => {
+  it("shows Right-click hint but not Remove shortcut in modal mode footer", () => {
     render(<ProjectSwitcherPalette {...modalProps} results={multiProjects} />);
     const footer = screen.getByTestId("palette-footer");
     expect(footer.textContent).toContain("Switch");
     expect(footer.textContent).not.toContain("Remove");
-    expect(footer.textContent).not.toContain("Right-click for more");
+    expect(footer.textContent).toContain("Right-click for more");
   });
 
   it("shows temporal sections in dropdown mode", () => {

--- a/src/hooks/__tests__/useProjectSwitcherPalette.test.tsx
+++ b/src/hooks/__tests__/useProjectSwitcherPalette.test.tsx
@@ -2,54 +2,62 @@
 import { act, renderHook, waitFor } from "@testing-library/react";
 import { beforeEach, describe, expect, it, vi } from "vitest";
 
-const { getBulkStatsMock, useProjectStoreMock, notifyMock, projectState, projectStatsState } =
-  vi.hoisted(() => {
-    const getBulkStatsMock = vi.fn();
+const {
+  getBulkStatsMock,
+  useProjectStoreMock,
+  notifyMock,
+  copyMock,
+  projectState,
+  projectStatsState,
+} = vi.hoisted(() => {
+  const getBulkStatsMock = vi.fn();
+  const copyMock = vi.fn().mockResolvedValue(true);
 
-    const projectStatsState = {
-      stats: {} as Record<
-        string,
-        { activeAgentCount: number; waitingAgentCount: number; processCount: number }
-      >,
-    };
+  const projectStatsState = {
+    stats: {} as Record<
+      string,
+      { activeAgentCount: number; waitingAgentCount: number; processCount: number }
+    >,
+  };
 
-    const projectState = {
-      projects: [
-        {
-          id: "project-1",
-          name: "Project One",
-          path: "/repo/one",
-          emoji: "🌲",
-          color: "#00aa00",
-          lastOpened: 123,
-          frecencyScore: 3.0,
-          status: "active" as const,
-        },
-      ],
-      currentProject: null as { id: string } | null,
-      switchProject: vi.fn().mockResolvedValue(undefined),
-      reopenProject: vi.fn().mockResolvedValue(undefined),
-      loadProjects: vi.fn().mockResolvedValue(undefined),
-      addProject: vi.fn().mockResolvedValue(undefined),
-      closeProject: vi.fn().mockResolvedValue({ processesKilled: 0 }),
-      closeActiveProject: vi.fn().mockResolvedValue({ processesKilled: 0 }),
-      removeProject: vi.fn().mockResolvedValue(undefined),
-      locateProject: vi.fn().mockResolvedValue(undefined),
-    };
+  const projectState = {
+    projects: [
+      {
+        id: "project-1",
+        name: "Project One",
+        path: "/repo/one",
+        emoji: "🌲",
+        color: "#00aa00",
+        lastOpened: 123,
+        frecencyScore: 3.0,
+        status: "active" as const,
+      },
+    ],
+    currentProject: null as { id: string } | null,
+    switchProject: vi.fn().mockResolvedValue(undefined),
+    reopenProject: vi.fn().mockResolvedValue(undefined),
+    loadProjects: vi.fn().mockResolvedValue(undefined),
+    addProject: vi.fn().mockResolvedValue(undefined),
+    closeProject: vi.fn().mockResolvedValue({ processesKilled: 0 }),
+    closeActiveProject: vi.fn().mockResolvedValue({ processesKilled: 0 }),
+    removeProject: vi.fn().mockResolvedValue(undefined),
+    locateProject: vi.fn().mockResolvedValue(undefined),
+  };
 
-    const useProjectStoreMock = vi.fn((selector: (state: typeof projectState) => unknown) =>
-      selector(projectState)
-    );
-    const notifyMock = vi.fn().mockReturnValue("");
+  const useProjectStoreMock = vi.fn((selector: (state: typeof projectState) => unknown) =>
+    selector(projectState)
+  );
+  const notifyMock = vi.fn().mockReturnValue("");
 
-    return {
-      getBulkStatsMock,
-      useProjectStoreMock,
-      notifyMock,
-      projectState,
-      projectStatsState,
-    };
-  });
+  return {
+    getBulkStatsMock,
+    useProjectStoreMock,
+    notifyMock,
+    copyMock,
+    projectState,
+    projectStatsState,
+  };
+});
 
 vi.mock("@/clients", () => ({
   projectClient: {
@@ -69,6 +77,10 @@ vi.mock("@/store/projectStatsStore", () => ({
 
 vi.mock("@/lib/notify", () => ({
   notify: notifyMock,
+}));
+
+vi.mock("@/hooks/useCopyWithFeedback", () => ({
+  useCopyWithFeedback: () => ({ copied: false, copy: copyMock }),
 }));
 
 import { usePaletteStore } from "@/store/paletteStore";
@@ -785,6 +797,39 @@ describe("useProjectSwitcherPalette", () => {
         result.current.toggle();
       });
       expect(result.current.selectedIndex).toBe(1);
+    });
+  });
+
+  describe("copyPath", () => {
+    it("writes the path to the clipboard and emits a transient Path copied toast on success", async () => {
+      copyMock.mockResolvedValueOnce(true);
+
+      const { result } = renderHook(() => useProjectSwitcherPalette());
+
+      await act(async () => {
+        result.current.copyPath("/repo/one");
+      });
+
+      expect(copyMock).toHaveBeenCalledWith("/repo/one");
+      expect(notifyMock).toHaveBeenCalledWith({
+        type: "info",
+        title: "Path copied",
+        message: "/repo/one",
+        transient: true,
+      });
+    });
+
+    it("does not emit a toast when the clipboard write fails", async () => {
+      copyMock.mockResolvedValueOnce(false);
+
+      const { result } = renderHook(() => useProjectSwitcherPalette());
+
+      await act(async () => {
+        result.current.copyPath("/repo/one");
+      });
+
+      expect(copyMock).toHaveBeenCalledWith("/repo/one");
+      expect(notifyMock).not.toHaveBeenCalled();
     });
   });
 });

--- a/src/hooks/useProjectSwitcherPalette.ts
+++ b/src/hooks/useProjectSwitcherPalette.ts
@@ -6,6 +6,7 @@ import { useProjectSettingsStore } from "@/store/projectSettingsStore";
 import { useScratchStore } from "@/store/scratchStore";
 import { usePaletteStore } from "@/store/paletteStore";
 import { notify } from "@/lib/notify";
+import { useCopyWithFeedback } from "@/hooks/useCopyWithFeedback";
 import type { Project, Scratch } from "@shared/types";
 import { projectClient, scratchClient } from "@/clients";
 import { formatErrorMessage } from "@shared/utils/errorMessage";
@@ -70,6 +71,12 @@ export interface UseProjectSwitcherPaletteReturn {
   removeProject: (projectId: string) => Promise<void>;
   locateProject: (projectId: string) => Promise<void>;
   togglePinProject: (projectId: string) => Promise<void>;
+  /**
+   * Write the project's absolute path to the clipboard and surface a transient
+   * "Path copied" toast. Used by the Copy path context menu action in all
+   * project picker render sites (sidebar dropdown, toolbar dropdown, modal).
+   */
+  copyPath: (path: string) => void;
   stopConfirmProjectId: string | null;
   setStopConfirmProjectId: (projectId: string | null) => void;
   confirmStopProject: () => Promise<void>;
@@ -156,6 +163,8 @@ export function useProjectSwitcherPalette(): UseProjectSwitcherPaletteReturn {
   const removeProject = useProjectStore((state) => state.removeProject);
   const locateProjectFn = useProjectStore((state) => state.locateProject);
   const projectStats = useProjectStatsStore((state) => state.stats);
+
+  const { copy: copyToClipboard } = useCopyWithFeedback();
 
   const scratches = useScratchStore((state) => state.scratches);
   const currentScratch = useScratchStore((state) => state.currentScratch);
@@ -420,6 +429,17 @@ export function useProjectSwitcherPalette(): UseProjectSwitcherPaletteReturn {
       await locateProjectFn(projectId);
     },
     [locateProjectFn]
+  );
+
+  const copyPath = useCallback(
+    (path: string) => {
+      void copyToClipboard(path).then((ok) => {
+        if (ok) {
+          notify({ type: "info", title: "Path copied", message: path, transient: true });
+        }
+      });
+    },
+    [copyToClipboard]
   );
 
   const togglePinProject = useCallback(
@@ -703,6 +723,7 @@ export function useProjectSwitcherPalette(): UseProjectSwitcherPaletteReturn {
     removeProject: removeProjectFromList,
     locateProject,
     togglePinProject,
+    copyPath,
     stopConfirmProjectId,
     setStopConfirmProjectId,
     confirmStopProject,


### PR DESCRIPTION
## Summary

- `onCopyPath` was only wired in the sidebar picker — modal and toolbar had the prop defined but never received it. This surfaces the action in all three.
- The modal picker also gains Reveal in Finder and Pin/Unpin. Footer "Right-click for more" hint now shows in modal mode.
- Consolidated the clipboard handler into `useProjectSwitcherPalette` so all three render sites share one implementation rather than duplicating it locally.

Resolves #8222

## Changes

- `useProjectSwitcherPalette` — adds `copyPath` callback; emits a `Path copied` toast with the path as the message body
- `ProjectSwitcherPalette` — threads `onCopyPath`, `onRevealInFinder`, and `onPinToggle` down to the item list; passes `isModal` to show the footer hint
- `ProjectSwitcher` — wires the new props from the palette hook
- `App.tsx` / `Toolbar.tsx` — pass the palette's `onCopyPath` to the modal and toolbar picker sites
- Hook tests: `copyPath` success and clipboard-failure paths; render and keyboard tests updated for the modal footer hint

## Testing

- Vitest: 57/57 on touched test files (hook, render, keyboard)
- Typecheck clean
- Manually verified copy path, Reveal in Finder, and Pin/Unpin from modal and toolbar pickers