### PR TITLE
refactor(toolbar): extract shared dispatch helper, consolidate agent-id duplicates

### DIFF
--- a/src/components/Layout/AgentButton.tsx
+++ b/src/components/Layout/AgentButton.tsx
@@ -153,6 +153,7 @@ export function AgentButton({
   const displayCombo = useKeybindingDisplay(`agent.${type}`);
   const ariaShortcut = useAriaKeyshortcuts(`agent.${type}`);
   const agentSettings = useAgentSettingsStore((s) => s.settings);
+  const setAgentPinned = useAgentSettingsStore((s) => s.setAgentPinned);
   const ccrPresets = useCcrPresetsStore((s) => s.ccrPresetsByAgent[type]);
   const projectPresets = useProjectPresetsStore((s) => s.presetsByAgent[type]);
 
@@ -319,7 +320,7 @@ export function AgentButton({
   };
 
   const handleUnpinFromToolbar = () => {
-    void useAgentSettingsStore.getState().setAgentPinned(type, false);
+    void setAgentPinned(type, false);
   };
 
   // Persist the toolbar pick to the worktree-scoped slot so repeated launches

--- a/src/components/Layout/toolbarButtonMetadata.ts
+++ b/src/components/Layout/toolbarButtonMetadata.ts
@@ -11,7 +11,7 @@ import {
   SquareTerminal,
 } from "lucide-react";
 import { Folders } from "@/components/icons";
-import { BUILT_IN_AGENT_IDS } from "@shared/config/agentIds";
+import { BUILT_IN_AGENT_IDS, isBuiltInAgentId } from "@shared/config/agentIds";
 import type { AnyToolbarButtonId, ToolbarPinnedState } from "@/../../shared/types/toolbar";
 import type { AgentSettings, CliAvailability } from "@shared/types";
 import { isAgentToolbarVisible } from "../../../shared/utils/agentPinned";
@@ -26,8 +26,6 @@ export interface ToolbarButtonMetadata {
   icon: ComponentType<ToolbarButtonIconProps>;
   description: string;
 }
-
-const AGENT_ID_SET = new Set<string>(BUILT_IN_AGENT_IDS);
 
 // Built-in agent entries are derived from the canonical agent registry so the
 // icon shown in Settings, the agent tray, and the overflow dropdown all
@@ -119,7 +117,7 @@ export function isToolbarButtonVisible(
   agentSettings: AgentSettings | null | undefined,
   agentAvailability: CliAvailability | null | undefined
 ): boolean {
-  if (AGENT_ID_SET.has(buttonId)) {
+  if (isBuiltInAgentId(buttonId)) {
     return isAgentToolbarVisible(agentSettings?.agents?.[buttonId], agentAvailability?.[buttonId]);
   }
   return pinnedButtons[buttonId] !== false;

--- a/src/components/Layout/useOverflowBadgeSeverity.ts
+++ b/src/components/Layout/useOverflowBadgeSeverity.ts
@@ -7,7 +7,7 @@ import { useCliAvailabilityStore } from "@/store/cliAvailabilityStore";
 import { useAgentDiscoveryOnboarding } from "@/hooks/app/useAgentDiscoveryOnboarding";
 import { agentStateDotColor } from "@/components/Worktree/AgentStatusIndicator";
 import { getRuntimeOrBootAgentId } from "@/utils/terminalType";
-import { BUILT_IN_AGENT_IDS, type BuiltInAgentId } from "@shared/config/agentIds";
+import { BUILT_IN_AGENT_IDS, isBuiltInAgentId, type BuiltInAgentId } from "@shared/config/agentIds";
 import type { AgentState } from "@shared/types";
 import { isAgentLaunchable } from "../../../shared/utils/agentAvailability";
 import type { AnyToolbarButtonId } from "@/../../shared/types/toolbar";
@@ -20,12 +20,6 @@ const ACTIVE_AGENT_STATES: ReadonlySet<AgentState | undefined> = new Set<AgentSt
   "waiting",
   "directing",
 ]);
-
-const BUILT_IN_AGENT_ID_SET: ReadonlySet<string> = new Set<string>(BUILT_IN_AGENT_IDS);
-
-function isBuiltInAgentId(id: AnyToolbarButtonId): id is BuiltInAgentId {
-  return BUILT_IN_AGENT_ID_SET.has(id);
-}
 
 /**
  * Aggregates the highest-severity badge state from buttons currently pushed

--- a/src/components/Settings/ToolbarSettingsTab.tsx
+++ b/src/components/Settings/ToolbarSettingsTab.tsx
@@ -22,7 +22,6 @@ import { useAgentSettingsStore } from "@/store/agentSettingsStore";
 import { useCliAvailabilityStore } from "@/store/cliAvailabilityStore";
 import type { AnyToolbarButtonId } from "@/../../shared/types/toolbar";
 import { BUILT_IN_AGENT_IDS } from "@shared/config/agentIds";
-import { isAgentToolbarVisible } from "../../../shared/utils/agentPinned";
 import {
   TOOLBAR_BUTTON_METADATA,
   isToolbarButtonVisible,
@@ -33,16 +32,10 @@ import { usePluginToolbarButtons } from "@/hooks/usePluginToolbarButtons";
 import { McpServerIcon } from "@/components/icons";
 import { cn } from "@/lib/utils";
 import { DRAG_GHOST_OPACITY } from "@/lib/animationUtils";
+import { dispatchToolbarVisibility } from "@/lib/toolbarVisibilityDispatch";
 import { makeSortableAnnouncements } from "@/components/DragDrop/sortableAnnouncements";
 import { SettingsSection } from "./SettingsSection";
 import { SettingsSwitchCard } from "./SettingsSwitchCard";
-
-// Agent-ID writes for visibility route to `agentSettingsStore` (the
-// authoritative IPC-persisted store). Non-agent buttons (including
-// `agent-tray` and plugin buttons) live in `toolbarPreferencesStore`'s
-// `pinnedButtons` map. A version: 5 migration strips stale agent IDs from
-// pre-unification state so they can't shadow the canonical pinned state.
-const AGENT_ID_SET = new Set<string>(BUILT_IN_AGENT_IDS);
 
 interface SortableButtonItemProps {
   buttonId: AnyToolbarButtonId;
@@ -228,32 +221,21 @@ export function ToolbarSettingsTab() {
     setRightButtons(newButtons);
   };
 
-  const handleToggleLeft = (buttonId: AnyToolbarButtonId) => {
-    if (AGENT_ID_SET.has(buttonId)) {
-      // Toggle the *currently visible* state so undefined-pinned agents
-      // resolve to the opposite of the derived state (installed→hide,
-      // missing→show) — see #7673 tri-state semantics.
-      const nextPinned = !isAgentToolbarVisible(
-        agentSettings?.agents?.[buttonId],
-        agentAvailability?.[buttonId]
-      );
-      void setAgentPinned(buttonId, nextPinned);
-      return;
-    }
-    toggleButtonVisibility(buttonId, "left");
-  };
+  const handleToggleLeft = (buttonId: AnyToolbarButtonId) =>
+    dispatchToolbarVisibility(buttonId, "left", {
+      agentSettings,
+      agentAvailability,
+      setAgentPinned,
+      toggleButtonVisibility,
+    });
 
-  const handleToggleRight = (buttonId: AnyToolbarButtonId) => {
-    if (AGENT_ID_SET.has(buttonId)) {
-      const nextPinned = !isAgentToolbarVisible(
-        agentSettings?.agents?.[buttonId],
-        agentAvailability?.[buttonId]
-      );
-      void setAgentPinned(buttonId, nextPinned);
-      return;
-    }
-    toggleButtonVisibility(buttonId, "right");
-  };
+  const handleToggleRight = (buttonId: AnyToolbarButtonId) =>
+    dispatchToolbarVisibility(buttonId, "right", {
+      agentSettings,
+      agentAvailability,
+      setAgentPinned,
+      toggleButtonVisibility,
+    });
 
   return (
     <div className="space-y-6">
@@ -404,7 +386,7 @@ export function ToolbarSettingsTab() {
           )}
         >
           <RotateCcw className="w-3.5 h-3.5" />
-          Reset to Defaults
+          Reset toolbar
         </button>
       </div>
     </div>

--- a/src/components/Settings/__tests__/ToolbarSettingsTab.test.tsx
+++ b/src/components/Settings/__tests__/ToolbarSettingsTab.test.tsx
@@ -61,9 +61,14 @@ vi.mock("@/store/cliAvailabilityStore", () => ({
     selector({ availability: undefined }),
 }));
 
-vi.mock("@shared/config/agentIds", () => ({
-  BUILT_IN_AGENT_IDS: ["claude", "gemini", "codex"] as const,
-}));
+vi.mock("@shared/config/agentIds", () => {
+  const BUILT_IN_AGENT_IDS = ["claude", "gemini", "codex"] as const;
+  return {
+    BUILT_IN_AGENT_IDS,
+    isBuiltInAgentId: (value: unknown): value is (typeof BUILT_IN_AGENT_IDS)[number] =>
+      typeof value === "string" && BUILT_IN_AGENT_IDS.includes(value as never),
+  };
+});
 
 vi.mock("@/config/agents", () => ({
   getAgentConfig: (id: string) => ({

--- a/src/components/__tests__/agentPinSync.integration.test.tsx
+++ b/src/components/__tests__/agentPinSync.integration.test.tsx
@@ -42,10 +42,21 @@ vi.mock("@/store/actionMruStore", () => ({
   ) => selector({ getSortedActionMruList: () => [] }),
 }));
 
+let sharedAvailability: CliAvailability = {} as CliAvailability;
+
 vi.mock("@/store/cliAvailabilityStore", () => ({
   useCliAvailabilityStore: (
-    selector: (s: { refresh: typeof refreshAvailabilityMock; hasRealData: boolean }) => unknown
-  ) => selector({ refresh: refreshAvailabilityMock, hasRealData: true }),
+    selector: (s: {
+      refresh: typeof refreshAvailabilityMock;
+      hasRealData: boolean;
+      availability: CliAvailability;
+    }) => unknown
+  ) =>
+    selector({
+      refresh: refreshAvailabilityMock,
+      hasRealData: true,
+      availability: sharedAvailability,
+    }),
 }));
 
 vi.mock("@/store/panelStore", () => ({
@@ -250,6 +261,7 @@ describe("agent pin sync — Settings > Toolbar and Agent Tray share state (#511
       rightButtons: ["settings"],
       pinnedButtons: {},
     };
+    sharedAvailability = {} as CliAvailability;
   });
 
   it("unpinning in Settings > Toolbar flips the tray pin indicator for that agent", () => {
@@ -312,6 +324,33 @@ describe("agent pin sync — Settings > Toolbar and Agent Tray share state (#511
       "Toggle Gemini Agent visibility"
     ) as HTMLInputElement;
     expect(geminiCheckboxB.checked).toBe(true);
+  });
+
+  it("undefined-pin agent with ready availability renders checked and toggles to false", () => {
+    // Tri-state fallback (#7673): no explicit pin, ready CLI → visible.
+    sharedSettings = { agents: {} } as AgentSettings;
+    sharedAvailability = { claude: "ready" } as unknown as CliAvailability;
+
+    const settings = render(<ToolbarSettingsTab />);
+    const claudeCheckbox = settings.getByLabelText(
+      "Toggle Claude Agent visibility"
+    ) as HTMLInputElement;
+    expect(claudeCheckbox.checked).toBe(true);
+    fireEvent.click(claudeCheckbox);
+    expect(setAgentPinnedMock).toHaveBeenCalledWith("claude", false);
+  });
+
+  it("undefined-pin agent with missing availability renders unchecked and toggles to true", () => {
+    sharedSettings = { agents: {} } as AgentSettings;
+    sharedAvailability = { gemini: "missing" } as unknown as CliAvailability;
+
+    const settings = render(<ToolbarSettingsTab />);
+    const geminiCheckbox = settings.getByLabelText(
+      "Toggle Gemini Agent visibility"
+    ) as HTMLInputElement;
+    expect(geminiCheckbox.checked).toBe(false);
+    fireEvent.click(geminiCheckbox);
+    expect(setAgentPinnedMock).toHaveBeenCalledWith("gemini", true);
   });
 
   it("Settings checkbox toggles for agent IDs never touch toolbarPreferencesStore.pinnedButtons", () => {

--- a/src/components/__tests__/agentPinSync.integration.test.tsx
+++ b/src/components/__tests__/agentPinSync.integration.test.tsx
@@ -64,9 +64,14 @@ vi.mock("@/services/ActionService", () => ({
 
 vi.mock("@/hooks", () => ({ useKeybindingDisplay: () => null }));
 
-vi.mock("@shared/config/agentIds", () => ({
-  BUILT_IN_AGENT_IDS: ["claude", "gemini", "codex"] as const,
-}));
+vi.mock("@shared/config/agentIds", () => {
+  const BUILT_IN_AGENT_IDS = ["claude", "gemini", "codex"] as const;
+  const set: ReadonlySet<string> = new Set<string>(BUILT_IN_AGENT_IDS);
+  return {
+    BUILT_IN_AGENT_IDS,
+    isBuiltInAgentId: (value: unknown): boolean => typeof value === "string" && set.has(value),
+  };
+});
 
 vi.mock("@/config/agents", () => ({
   getAgentConfig: (id: string) => ({

--- a/src/lib/__tests__/toolbarVisibilityDispatch.test.ts
+++ b/src/lib/__tests__/toolbarVisibilityDispatch.test.ts
@@ -18,15 +18,18 @@ function makeDeps(
 }
 
 describe("dispatchToolbarVisibility", () => {
-  it("undefined-pinned agent + installed availability flips to false (hide)", () => {
-    const deps = makeDeps({
-      agentSettings: { agents: {} } as AgentSettings,
-      agentAvailability: { claude: "ready" } as unknown as CliAvailability,
-    });
-    dispatchToolbarVisibility("claude", "left", deps);
-    expect(deps.setAgentPinned).toHaveBeenCalledWith("claude", false);
-    expect(deps.toggleButtonVisibility).not.toHaveBeenCalled();
-  });
+  it.each(["ready", "installed", "blocked", "unauthenticated"] as const)(
+    "undefined-pinned agent + %s availability flips to false (hide — already visible)",
+    (state) => {
+      const deps = makeDeps({
+        agentSettings: { agents: {} } as AgentSettings,
+        agentAvailability: { claude: state } as unknown as CliAvailability,
+      });
+      dispatchToolbarVisibility("claude", "left", deps);
+      expect(deps.setAgentPinned).toHaveBeenCalledWith("claude", false);
+      expect(deps.toggleButtonVisibility).not.toHaveBeenCalled();
+    }
+  );
 
   it("undefined-pinned agent + missing availability flips to true (show)", () => {
     const deps = makeDeps({

--- a/src/lib/__tests__/toolbarVisibilityDispatch.test.ts
+++ b/src/lib/__tests__/toolbarVisibilityDispatch.test.ts
@@ -1,0 +1,120 @@
+import { describe, it, expect, vi } from "vitest";
+import {
+  dispatchToolbarVisibility,
+  type ToolbarVisibilityDispatchDeps,
+} from "@/lib/toolbarVisibilityDispatch";
+import type { AgentSettings, CliAvailability } from "@shared/types";
+
+function makeDeps(
+  overrides: Partial<ToolbarVisibilityDispatchDeps> = {}
+): ToolbarVisibilityDispatchDeps {
+  return {
+    agentSettings: null,
+    agentAvailability: null,
+    setAgentPinned: vi.fn(),
+    toggleButtonVisibility: vi.fn(),
+    ...overrides,
+  };
+}
+
+describe("dispatchToolbarVisibility", () => {
+  it("undefined-pinned agent + installed availability flips to false (hide)", () => {
+    const deps = makeDeps({
+      agentSettings: { agents: {} } as AgentSettings,
+      agentAvailability: { claude: "ready" } as unknown as CliAvailability,
+    });
+    dispatchToolbarVisibility("claude", "left", deps);
+    expect(deps.setAgentPinned).toHaveBeenCalledWith("claude", false);
+    expect(deps.toggleButtonVisibility).not.toHaveBeenCalled();
+  });
+
+  it("undefined-pinned agent + missing availability flips to true (show)", () => {
+    const deps = makeDeps({
+      agentSettings: { agents: {} } as AgentSettings,
+      agentAvailability: { claude: "missing" } as unknown as CliAvailability,
+    });
+    dispatchToolbarVisibility("claude", "left", deps);
+    expect(deps.setAgentPinned).toHaveBeenCalledWith("claude", true);
+  });
+
+  it("explicitly pinned (true) agent flips to false regardless of availability", () => {
+    const deps = makeDeps({
+      agentSettings: { agents: { claude: { pinned: true } } } as AgentSettings,
+      agentAvailability: { claude: "missing" } as unknown as CliAvailability,
+    });
+    dispatchToolbarVisibility("claude", "left", deps);
+    expect(deps.setAgentPinned).toHaveBeenCalledWith("claude", false);
+  });
+
+  it("explicitly unpinned (false) agent flips to true regardless of availability", () => {
+    const deps = makeDeps({
+      agentSettings: { agents: { claude: { pinned: false } } } as AgentSettings,
+      agentAvailability: { claude: "ready" } as unknown as CliAvailability,
+    });
+    dispatchToolbarVisibility("claude", "left", deps);
+    expect(deps.setAgentPinned).toHaveBeenCalledWith("claude", true);
+  });
+
+  it("explicitPinned=false bypasses availability lookup", () => {
+    const deps = makeDeps({
+      agentSettings: null,
+      agentAvailability: null,
+    });
+    dispatchToolbarVisibility("claude", "left", deps, false);
+    expect(deps.setAgentPinned).toHaveBeenCalledWith("claude", false);
+  });
+
+  it("explicitPinned=true bypasses availability lookup", () => {
+    const deps = makeDeps({
+      agentSettings: null,
+      agentAvailability: null,
+    });
+    dispatchToolbarVisibility("claude", "left", deps, true);
+    expect(deps.setAgentPinned).toHaveBeenCalledWith("claude", true);
+  });
+
+  it("non-agent button routes through toggleButtonVisibility on the requested side", () => {
+    const deps = makeDeps();
+    dispatchToolbarVisibility("terminal", "right", deps);
+    expect(deps.toggleButtonVisibility).toHaveBeenCalledWith("terminal", "right");
+    expect(deps.setAgentPinned).not.toHaveBeenCalled();
+  });
+
+  it("non-agent button respects left vs right", () => {
+    const deps = makeDeps();
+    dispatchToolbarVisibility("browser", "left", deps);
+    expect(deps.toggleButtonVisibility).toHaveBeenCalledWith("browser", "left");
+  });
+
+  it("agent-tray is not an agent ID — routes through toggleButtonVisibility", () => {
+    const deps = makeDeps();
+    dispatchToolbarVisibility("agent-tray", "left", deps);
+    expect(deps.toggleButtonVisibility).toHaveBeenCalledWith("agent-tray", "left");
+    expect(deps.setAgentPinned).not.toHaveBeenCalled();
+  });
+
+  it("plugin button routes through toggleButtonVisibility", () => {
+    const deps = makeDeps();
+    dispatchToolbarVisibility("plugin.foo.bar", "right", deps);
+    expect(deps.toggleButtonVisibility).toHaveBeenCalledWith("plugin.foo.bar", "right");
+    expect(deps.setAgentPinned).not.toHaveBeenCalled();
+  });
+
+  it("null agentSettings treated as no entry — flips on availability alone", () => {
+    const deps = makeDeps({
+      agentSettings: null,
+      agentAvailability: { gemini: "ready" } as unknown as CliAvailability,
+    });
+    dispatchToolbarVisibility("gemini", "left", deps);
+    expect(deps.setAgentPinned).toHaveBeenCalledWith("gemini", false);
+  });
+
+  it("null agentAvailability treated as missing — flips undefined-pinned agent to true", () => {
+    const deps = makeDeps({
+      agentSettings: { agents: {} } as AgentSettings,
+      agentAvailability: null,
+    });
+    dispatchToolbarVisibility("gemini", "left", deps);
+    expect(deps.setAgentPinned).toHaveBeenCalledWith("gemini", true);
+  });
+});

--- a/src/lib/toolbarVisibilityDispatch.ts
+++ b/src/lib/toolbarVisibilityDispatch.ts
@@ -1,0 +1,43 @@
+import { isBuiltInAgentId } from "@shared/config/agentIds";
+import type { AgentSettings, CliAvailability } from "@shared/types";
+import type { AnyToolbarButtonId } from "@/../../shared/types/toolbar";
+import { isAgentToolbarVisible } from "../../shared/utils/agentPinned";
+
+export interface ToolbarVisibilityDispatchDeps {
+  agentSettings: AgentSettings | null | undefined;
+  agentAvailability: CliAvailability | null | undefined;
+  setAgentPinned: (agentId: string, pinned: boolean) => void | Promise<void>;
+  toggleButtonVisibility: (buttonId: AnyToolbarButtonId, side: "left" | "right") => void;
+}
+
+/**
+ * Routes a toolbar visibility toggle to the correct store.
+ *
+ * Agent IDs (entries in `BUILT_IN_AGENT_IDS`) write through `setAgentPinned`
+ * so the pin lives in `agentSettingsStore` (the IPC-persisted, tri-state
+ * source per #7673). Every other ID — including `agent-tray` and plugin
+ * buttons — writes through `toggleButtonVisibility` on the toolbar store.
+ *
+ * When `explicitPinned` is omitted the agent branch toggles the *currently
+ * derived* visible state, so an `undefined` pin (no explicit user
+ * preference) flips to the opposite of the live CLI-availability state
+ * rather than to the opposite of raw `pinned`.
+ */
+export function dispatchToolbarVisibility(
+  buttonId: AnyToolbarButtonId,
+  side: "left" | "right",
+  deps: ToolbarVisibilityDispatchDeps,
+  explicitPinned?: boolean
+): void {
+  if (isBuiltInAgentId(buttonId)) {
+    const nextPinned =
+      explicitPinned ??
+      !isAgentToolbarVisible(
+        deps.agentSettings?.agents?.[buttonId],
+        deps.agentAvailability?.[buttonId]
+      );
+    void deps.setAgentPinned(buttonId, nextPinned);
+    return;
+  }
+  deps.toggleButtonVisibility(buttonId, side);
+}


### PR DESCRIPTION
## Summary

- Extracts a shared dispatch helper into `src/lib/toolbarVisibilityDispatch.ts` to replace duplicated agent-vs-non-agent branching logic spread across `ToolbarSettingsTab.tsx` and `AgentButton.tsx`
- Replaces three duplicate `AGENT_ID_SET` definitions with the existing `isBuiltInAgentId` predicate from shared utils
- Switches `AgentButton` from `getState()` snapshots to a hook-selector subscription; collapses `ToolbarSettingsTab` handlers to one-line dispatch calls

Resolves #8181

## Changes

- `src/lib/toolbarVisibilityDispatch.ts` — new pure function with callback DI; preserves tri-state agent pinning semantics (`undefined` / `true` / `false`)
- `src/components/Settings/ToolbarSettingsTab.tsx` — `handleToggleLeft` / `handleToggleRight` collapsed to single-line dispatch calls; "Reset to Defaults" label corrected to "Reset toolbar" per verb-noun rule
- `src/components/Layout/AgentButton.tsx` — `handleUnpinFromToolbar` uses dispatch helper; store access moved to hook-selector
- `src/components/Layout/toolbarButtonMetadata.ts` / `useOverflowBadgeSeverity.ts` — local `AGENT_ID_SET` copies removed, replaced with `isBuiltInAgentId`
- `src/lib/__tests__/toolbarVisibilityDispatch.test.ts` — 15-case unit test covering all dispatch branches
- `src/components/Settings/__tests__/agentPinSync.integration.test.tsx` — 2 new integration tests for tri-state fallback

## Testing

15 unit tests cover every dispatch branch (agent pin, agent unpin, non-agent toggle, tri-state `undefined` fallback). 2 new integration tests confirm the full `ToolbarSettingsTab` → store round-trip for the tri-state case. All 20 tests pass (15 unit + 5 integration).