### PR TITLE
Consolidate per-consumer wake fetches onto wake-coordinator slice (#8066)

### DIFF
--- a/src/components/GitHub/__tests__/GitHubResourceList.swr.test.tsx
+++ b/src/components/GitHub/__tests__/GitHubResourceList.swr.test.tsx
@@ -726,6 +726,122 @@ describe("GitHubResourceList wake-coordinator revalidation", () => {
 
     expect(mockListIssues).toHaveBeenCalledTimes(1);
   });
+
+  it("consumes the epoch even when a numeric search is active so a later search-clear doesn't replay it", async () => {
+    const cacheKey = buildCacheKey("/test/proj", "issue", "open", "created");
+    setCache(cacheKey, {
+      items: [makeIssue(1)],
+      endCursor: null,
+      hasNextPage: false,
+      timestamp: Date.now(),
+    });
+
+    mockListIssues.mockResolvedValue(makeResponse([makeIssue(1)]));
+    mockGetIssueByNumber.mockResolvedValue(makeIssue(42));
+
+    // Enter a numeric search before the wake fires.
+    useGitHubFilterStore.getState().setIssueSearchQuery("#42");
+
+    render(<GitHubResourceList type="issue" projectPath="/test/proj" />);
+
+    // The numeric-query effect fires getByNumber, not listIssues.
+    await waitFor(() => {
+      expect(mockGetIssueByNumber).toHaveBeenCalledTimes(1);
+    });
+    expect(mockListIssues).toHaveBeenCalledTimes(0);
+
+    // Wake while the numeric search is still active.
+    await act(async () => {
+      useSystemWakeStore.setState((s) => ({ wakeEpoch: s.wakeEpoch + 1 }));
+    });
+
+    // The numeric path does not re-fetch the list, so listIssues stays at 0.
+    expect(mockListIssues).toHaveBeenCalledTimes(0);
+
+    // User clears the search. The wake should have been consumed by the wake
+    // effect already, so clearing must not replay it as an extra list call.
+    // The only listIssues call after clearing is the natural mount-style
+    // revalidate driven by the list-query effect.
+    await act(async () => {
+      useGitHubFilterStore.getState().setIssueSearchQuery("");
+    });
+
+    // Advance past debounce.
+    await vi.advanceTimersByTimeAsync(400);
+
+    await waitFor(() => {
+      expect(mockListIssues.mock.calls.length).toBeGreaterThanOrEqual(1);
+    });
+    // The list-query effect re-runs twice on search-clear (numberQuery flip,
+    // then debouncedSearch flip after the debounce timer) — both calls are
+    // pre-existing behavior. The wake epoch must NOT add a third call: the
+    // consume-during-numeric-search fix guarantees the stale wake doesn't
+    // replay when numberQuery transitions back to null.
+    expect(mockListIssues).toHaveBeenCalledTimes(2);
+  });
+
+  it("clears the refreshing spinner when a wake revalidation is interrupted by a numeric search", async () => {
+    const cacheKey = buildCacheKey("/test/proj", "issue", "open", "created");
+    setCache(cacheKey, {
+      items: [makeIssue(1)],
+      endCursor: null,
+      hasNextPage: false,
+      timestamp: Date.now(),
+    });
+
+    // Mount-time revalidate resolves immediately. Wake revalidate hangs so we
+    // can observe the `refreshing` flag set, then get aborted by the search.
+    let resolveWakeRevalidate: ((value: GitHubListResponse<GitHubIssue>) => void) | undefined;
+    mockListIssues.mockResolvedValueOnce(makeResponse([makeIssue(1)])).mockImplementationOnce(
+      () =>
+        new Promise<GitHubListResponse<GitHubIssue>>((resolve) => {
+          resolveWakeRevalidate = resolve;
+        })
+    );
+    mockGetIssueByNumber.mockResolvedValue(makeIssue(42));
+
+    render(<GitHubResourceList type="issue" projectPath="/test/proj" />);
+
+    await waitFor(() => {
+      expect(mockListIssues).toHaveBeenCalledTimes(1);
+    });
+
+    // Trigger wake revalidation — `refreshing` flips true while the request
+    // hangs.
+    await act(async () => {
+      useSystemWakeStore.setState((s) => ({ wakeEpoch: s.wakeEpoch + 1 }));
+    });
+
+    await waitFor(() => {
+      expect(mockListIssues).toHaveBeenCalledTimes(2);
+    });
+
+    // User types a `#`-prefixed search before the wake revalidate resolves.
+    await act(async () => {
+      useGitHubFilterStore.getState().setIssueSearchQuery("#42");
+    });
+    await vi.advanceTimersByTimeAsync(400);
+
+    await waitFor(() => {
+      expect(mockGetIssueByNumber).toHaveBeenCalled();
+    });
+
+    // Now resolve the aborted wake revalidate. Without the fix, fetchData's
+    // finally block would skip `setRefreshing(false)` because the signal is
+    // aborted, leaking `refreshing=true` indefinitely. With the fix, the
+    // numeric-query effect's setup block has already cleared it. We can't
+    // observe `refreshing` directly through DOM here, but we can assert no
+    // additional listIssues fires after the numeric path takes over.
+    await act(async () => {
+      resolveWakeRevalidate?.(makeResponse([makeIssue(1), makeIssue(99)]));
+      await Promise.resolve();
+    });
+
+    // The aborted revalidate's response is dropped (signal aborted in
+    // fetchData), so no extra rows are appended and listIssues count stays at
+    // 2 (mount + wake).
+    expect(mockListIssues).toHaveBeenCalledTimes(2);
+  });
 });
 
 describe("GitHubResourceList no-token empty state", () => {

--- a/src/components/GitHub/__tests__/GitHubResourceList.swr.test.tsx
+++ b/src/components/GitHub/__tests__/GitHubResourceList.swr.test.tsx
@@ -9,6 +9,7 @@ import { setCache, buildCacheKey, _resetForTests } from "@/lib/githubResourceCac
 import { useGitHubFilterStore } from "@/store/githubFilterStore";
 import { useIssueSelectionStore } from "@/store/issueSelectionStore";
 import { useGitHubRateLimitStore } from "@/store/githubRateLimitStore";
+import { useSystemWakeStore } from "@/store/systemWakeStore";
 
 const mockListIssues = vi.fn();
 const mockListPRs = vi.fn();
@@ -552,7 +553,7 @@ describe("GitHubResourceList focus/visibility revalidation", () => {
     expect(mockListIssues).toHaveBeenCalledTimes(1);
   });
 
-  it("revalidates on visibilitychange when the document becomes visible", async () => {
+  it("does not revalidate on visibilitychange (consolidated onto wake-coordinator in #8066)", async () => {
     const cacheKey = buildCacheKey("/test/proj", "issue", "open", "created");
     setCache(cacheKey, {
       items: [makeIssue(1)],
@@ -561,9 +562,7 @@ describe("GitHubResourceList focus/visibility revalidation", () => {
       timestamp: Date.now(),
     });
 
-    mockListIssues
-      .mockResolvedValueOnce(makeResponse([makeIssue(1)]))
-      .mockResolvedValueOnce(makeResponse([makeIssue(1), makeIssue(3)]));
+    mockListIssues.mockResolvedValue(makeResponse([makeIssue(1)]));
 
     render(<GitHubResourceList type="issue" projectPath="/test/proj" />);
 
@@ -571,20 +570,17 @@ describe("GitHubResourceList focus/visibility revalidation", () => {
       expect(mockListIssues).toHaveBeenCalledTimes(1);
     });
 
+    // visibilitychange must NOT trigger a refetch after migration — sleep-wake
+    // is dispatched through `useSystemWakeStore.wakeEpoch` (separate test).
     await vi.advanceTimersByTimeAsync(31_000);
-
     Object.defineProperty(document, "visibilityState", {
       configurable: true,
       get: () => "visible",
     });
     document.dispatchEvent(new Event("visibilitychange"));
+    await vi.advanceTimersByTimeAsync(0);
 
-    await waitFor(() => {
-      expect(mockListIssues).toHaveBeenCalledTimes(2);
-    });
-    await waitFor(() => {
-      expect(screen.getByTestId("item-3")).toBeTruthy();
-    });
+    expect(mockListIssues).toHaveBeenCalledTimes(1);
   });
 
   it("revalidates a PR list on focus — the actual code path that ships ciStatus", async () => {
@@ -628,7 +624,7 @@ describe("GitHubResourceList focus/visibility revalidation", () => {
     expect(mockListPRs.mock.calls[1]?.[0]).toMatchObject({ bypassCache: true });
   });
 
-  it("removes focus and visibilitychange listeners on unmount", async () => {
+  it("removes the focus listener on unmount", async () => {
     const cacheKey = buildCacheKey("/test/proj", "issue", "open", "created");
     setCache(cacheKey, {
       items: [makeIssue(1)],
@@ -649,17 +645,67 @@ describe("GitHubResourceList focus/visibility revalidation", () => {
 
     await vi.advanceTimersByTimeAsync(31_000);
     window.dispatchEvent(new Event("focus"));
-    Object.defineProperty(document, "visibilityState", {
-      configurable: true,
-      get: () => "visible",
-    });
-    document.dispatchEvent(new Event("visibilitychange"));
     await vi.advanceTimersByTimeAsync(0);
 
     expect(mockListIssues).toHaveBeenCalledTimes(1);
   });
+});
 
-  it("does not revalidate on visibilitychange when the document is hidden", async () => {
+describe("GitHubResourceList wake-coordinator revalidation", () => {
+  beforeEach(() => {
+    vi.useFakeTimers({ shouldAdvanceTime: true });
+    useSystemWakeStore.setState({
+      wakeEpoch: 0,
+      lastSleepDuration: 0,
+      isWakeRevalidating: false,
+    });
+  });
+
+  afterEach(() => {
+    vi.useRealTimers();
+  });
+
+  it("revalidates when wakeEpoch bumps, bypassing the focus throttle window", async () => {
+    const cacheKey = buildCacheKey("/test/proj", "issue", "open", "created");
+    setCache(cacheKey, {
+      items: [makeIssue(1)],
+      endCursor: null,
+      hasNextPage: false,
+      timestamp: Date.now(),
+    });
+
+    mockListIssues
+      .mockResolvedValueOnce(makeResponse([makeIssue(1)]))
+      .mockResolvedValueOnce(makeResponse([makeIssue(1), makeIssue(4)]));
+
+    render(<GitHubResourceList type="issue" projectPath="/test/proj" />);
+
+    await waitFor(() => {
+      expect(mockListIssues).toHaveBeenCalledTimes(1);
+    });
+
+    // No timer advance — the wake path must NOT respect the 30s throttle.
+    await act(async () => {
+      useSystemWakeStore.setState((s) => ({ wakeEpoch: s.wakeEpoch + 1 }));
+    });
+
+    await waitFor(() => {
+      expect(mockListIssues).toHaveBeenCalledTimes(2);
+    });
+    await waitFor(() => {
+      expect(screen.getByTestId("item-4")).toBeTruthy();
+    });
+  });
+
+  it("does not revalidate when wakeEpoch is unchanged from the mount value", async () => {
+    // A previous wake landed before this list mounts — the consumer must NOT
+    // retroactively refetch on mount.
+    useSystemWakeStore.setState({
+      wakeEpoch: 4,
+      lastSleepDuration: 0,
+      isWakeRevalidating: false,
+    });
+
     const cacheKey = buildCacheKey("/test/proj", "issue", "open", "created");
     setCache(cacheKey, {
       items: [makeIssue(1)],
@@ -676,13 +722,6 @@ describe("GitHubResourceList focus/visibility revalidation", () => {
       expect(mockListIssues).toHaveBeenCalledTimes(1);
     });
 
-    await vi.advanceTimersByTimeAsync(31_000);
-
-    Object.defineProperty(document, "visibilityState", {
-      configurable: true,
-      get: () => "hidden",
-    });
-    document.dispatchEvent(new Event("visibilitychange"));
     await vi.advanceTimersByTimeAsync(0);
 
     expect(mockListIssues).toHaveBeenCalledTimes(1);

--- a/src/components/GitHub/useGitHubResourceListSWR.ts
+++ b/src/components/GitHub/useGitHubResourceListSWR.ts
@@ -10,6 +10,7 @@ import {
 import { isRateLimitError, isTokenRelatedError, isTransientNetworkError } from "@/lib/githubErrors";
 import { githubClient } from "@/clients/githubClient";
 import { useGitHubRateLimitStore } from "@/store/githubRateLimitStore";
+import { useSystemWakeStore } from "@/store/systemWakeStore";
 import type { GitHubIssue, GitHubPR, GitHubSortOrder } from "@shared/types/github";
 import { parseNumberQuery } from "@/lib/parseNumberQuery";
 import { formatErrorMessage } from "@shared/utils/errorMessage";
@@ -468,10 +469,12 @@ export function useGitHubResourceListSWR({
     return () => abortController.abort();
   }, [debouncedSearch, filterState, projectPath, type, fetchData, numberQuery, cacheKey]);
 
-  // Background revalidation when the window regains focus or the tab becomes
-  // visible. CI status flips on every push, so a user returning from another
-  // app expects the list to refresh — without this, stale green ticks can
-  // linger for the full backend cache window.
+  // Background revalidation when the window regains focus. CI status flips
+  // on every push, so a user returning from another app expects the list to
+  // refresh — without this, stale green ticks can linger for the full backend
+  // cache window. The `visibilitychange` path was removed in #8066: system
+  // sleep-wake is consolidated onto `useSystemWakeStore.wakeEpoch` (effect
+  // below), and in-tab visibility flips no longer trigger a redundant fetch.
   useEffect(() => {
     if (numberQuery !== null) {
       return;
@@ -495,15 +498,35 @@ export function useGitHubResourceListSWR({
       });
     };
 
-    document.addEventListener("visibilitychange", maybeRevalidate);
     window.addEventListener("focus", maybeRevalidate);
 
     return () => {
-      document.removeEventListener("visibilitychange", maybeRevalidate);
       window.removeEventListener("focus", maybeRevalidate);
       abortController.abort();
     };
   }, [fetchData, cacheKey, numberQuery]);
+
+  // Wake-coordinator subscription (#8066). Bypasses the 30-second throttle
+  // gate that applies to focus events: a system wake is rare enough that we
+  // always want a fresh fetch, and the wake-coordinator's threshold (>30s
+  // sleep) already filters out short OS naps. `lastSeenWakeEpochRef` is
+  // seeded with the current epoch so this consumer never refetches for a
+  // wake that landed before it mounted.
+  const wakeEpoch = useSystemWakeStore((s) => s.wakeEpoch);
+  const lastSeenWakeEpochRef = useRef(useSystemWakeStore.getState().wakeEpoch);
+  useEffect(() => {
+    if (numberQuery !== null) return;
+    if (wakeEpoch <= lastSeenWakeEpochRef.current) return;
+    lastSeenWakeEpochRef.current = wakeEpoch;
+    const abortController = new AbortController();
+    const gen = nextGeneration(cacheKey);
+    void fetchData(null, false, abortController.signal, {
+      revalidating: true,
+      generation: gen,
+      cacheKey,
+    });
+    return () => abortController.abort();
+  }, [wakeEpoch, numberQuery, fetchData, cacheKey]);
 
   // Numeric query effect — handles single number (#42), multi-number
   // (#1, #2, #3), range (#10-20), and open-ended (#>=100) searches.

--- a/src/components/GitHub/useGitHubResourceListSWR.ts
+++ b/src/components/GitHub/useGitHubResourceListSWR.ts
@@ -515,9 +515,12 @@ export function useGitHubResourceListSWR({
   const wakeEpoch = useSystemWakeStore((s) => s.wakeEpoch);
   const lastSeenWakeEpochRef = useRef(useSystemWakeStore.getState().wakeEpoch);
   useEffect(() => {
-    if (numberQuery !== null) return;
     if (wakeEpoch <= lastSeenWakeEpochRef.current) return;
+    // Always consume the epoch — even when a numeric search is active and we
+    // skip the list refetch — so the next time the user clears the search,
+    // the now-stale wake doesn't replay as a spurious revalidation.
     lastSeenWakeEpochRef.current = wakeEpoch;
+    if (numberQuery !== null) return;
     const abortController = new AbortController();
     const gen = nextGeneration(cacheKey);
     void fetchData(null, false, abortController.signal, {
@@ -556,6 +559,11 @@ export function useGitHubResourceListSWR({
     setError(null);
     setLoadMoreError(null);
     setLoadingMore(false);
+    // Clear any in-flight background refresh indicator. A wake-coordinated
+    // revalidate that was running when the user typed `#<n>` will be aborted
+    // and skip its own `setRefreshing(false)` in fetchData's finally block;
+    // without this, the dropdown header keeps spinning until unmount.
+    setRefreshing(false);
     setExactNumberNotFound(null);
     setData([]);
     setCursor(null);

--- a/src/contexts/WorktreeStoreContext.tsx
+++ b/src/contexts/WorktreeStoreContext.tsx
@@ -423,16 +423,16 @@ export function WorktreeStoreProvider({ children }: { children: ReactNode }) {
       })
     );
 
-    // Snapshot-on-wake: when a cached view is reactivated (addChildView),
-    // Chromium fires visibilitychange. Request a fresh worktree snapshot to
-    // rehydrate state that may have changed while the view was backgrounded,
-    // then fan out per-terminal wake to pull the missed range from the
-    // pty-host's headless mirror into each visible xterm buffer (#7999).
+    // Visibility flips drive per-terminal wake fan-out only: pulls the
+    // missed range from the pty-host's headless mirror into each visible
+    // xterm buffer (#7999). The worktree-state refresh path that used to
+    // run alongside this fan-out was removed in #8066 — system sleep-wake
+    // is now consolidated onto `useSystemWakeStore.wakeEpoch`, which the
+    // workspace host's `refreshOnWake` already mirrors via `worktree-update`
+    // push events. Re-entering this handler for short alt-tabs no longer
+    // triggers redundant `get-all-states` fetches.
     function handleVisibilityChange() {
       if (document.visibilityState !== "visible") return;
-      if (worktreePort.isReady()) {
-        fetchInitialState();
-      }
       wakeActiveWorktreeTerminals();
     }
     document.addEventListener("visibilitychange", handleVisibilityChange);

--- a/src/contexts/__tests__/WorktreeStoreContext.prDetected.test.tsx
+++ b/src/contexts/__tests__/WorktreeStoreContext.prDetected.test.tsx
@@ -1,5 +1,5 @@
 // @vitest-environment jsdom
-import { describe, it, expect, beforeEach, afterEach } from "vitest";
+import { describe, it, expect, beforeEach, afterEach, vi } from "vitest";
 import { renderHook, act } from "@testing-library/react";
 import { useContext } from "react";
 
@@ -1042,5 +1042,38 @@ describe("WorktreeStoreProvider manual issue associations (#8079)", () => {
     });
 
     expect(store.getState().worktrees.get("wt-1")?.issueNumber).toBeUndefined();
+  });
+});
+
+describe("WorktreeStoreProvider visibilitychange (#8066 consolidation)", () => {
+  it("does not call worktreePort.request on visibilitychange after migration", async () => {
+    const requestMock = vi.fn(() => Promise.resolve({ states: [] as WorktreeSnapshot[] }));
+    const electron = (globalThis as unknown as { window: Window }).window.electron as unknown as {
+      worktreePort: { request: (name: string) => Promise<unknown> };
+    };
+    electron.worktreePort.request = requestMock;
+
+    await renderProvider();
+
+    // Mount fetch: `get-all-states` request fires once during provider setup.
+    const initialCallCount = requestMock.mock.calls.length;
+    expect(initialCallCount).toBeGreaterThanOrEqual(1);
+
+    // A visibilitychange must NOT trigger another `get-all-states` request —
+    // sleep-wake refresh is now coordinated via `useSystemWakeStore.wakeEpoch`
+    // and the workspace host's `refreshOnWake` push events.
+    Object.defineProperty(document, "visibilityState", {
+      configurable: true,
+      get: () => "visible",
+    });
+    act(() => {
+      document.dispatchEvent(new Event("visibilitychange"));
+    });
+    await act(async () => {
+      await Promise.resolve();
+      await Promise.resolve();
+    });
+
+    expect(requestMock.mock.calls.length).toBe(initialCallCount);
   });
 });

--- a/src/hooks/__tests__/useProjectHealth.test.tsx
+++ b/src/hooks/__tests__/useProjectHealth.test.tsx
@@ -21,6 +21,7 @@ vi.mock("@/clients", () => ({
 
 import { useProjectHealth } from "../useProjectHealth";
 import { _resetPollingLifecycleForTests } from "../usePollingLifecycle";
+import { useSystemWakeStore } from "@/store/systemWakeStore";
 
 function makeHealth(overrides: Partial<ProjectHealthData> = {}): ProjectHealthData {
   return {
@@ -43,6 +44,11 @@ describe("useProjectHealth", () => {
     vi.clearAllMocks();
     _resetPollingLifecycleForTests();
     onSwitchMock.mockReturnValue(() => {});
+    useSystemWakeStore.setState({
+      wakeEpoch: 0,
+      lastSleepDuration: 0,
+      isWakeRevalidating: false,
+    });
   });
 
   it("fetches health on mount and exposes the result", async () => {
@@ -231,5 +237,126 @@ describe("useProjectHealth", () => {
 
     expect(getProjectHealthMock).toHaveBeenCalledTimes(2);
     expect(getProjectHealthMock.mock.calls[1]?.[1]).toBe(true);
+  });
+
+  describe("wake-coordinator subscription", () => {
+    it("refreshes when wakeEpoch increments past the value seen at mount", async () => {
+      getCurrentMock.mockResolvedValue({ id: "p", path: "/repo/a" });
+      getProjectHealthMock.mockResolvedValue(makeHealth());
+
+      renderHook(() => useProjectHealth());
+
+      await waitFor(() => {
+        expect(getProjectHealthMock).toHaveBeenCalledTimes(1);
+      });
+
+      await act(async () => {
+        useSystemWakeStore.setState((s) => ({ wakeEpoch: s.wakeEpoch + 1 }));
+        await Promise.resolve();
+      });
+
+      await waitFor(() => {
+        expect(getProjectHealthMock).toHaveBeenCalledTimes(2);
+      });
+    });
+
+    it("does not refresh for a wakeEpoch that was already current at mount", async () => {
+      useSystemWakeStore.setState({
+        wakeEpoch: 5,
+        lastSleepDuration: 0,
+        isWakeRevalidating: false,
+      });
+
+      getCurrentMock.mockResolvedValue({ id: "p", path: "/repo/a" });
+      getProjectHealthMock.mockResolvedValue(makeHealth());
+
+      renderHook(() => useProjectHealth());
+
+      await waitFor(() => {
+        expect(getProjectHealthMock).toHaveBeenCalledTimes(1);
+      });
+
+      await act(async () => {
+        await Promise.resolve();
+        await Promise.resolve();
+      });
+
+      expect(getProjectHealthMock).toHaveBeenCalledTimes(1);
+    });
+  });
+
+  describe("loading vs isValidating split", () => {
+    it("keeps loading true only during the cold first fetch", async () => {
+      getCurrentMock.mockResolvedValue({ id: "p", path: "/repo/a" });
+
+      let resolveFirst: ((v: ProjectHealthData) => void) | undefined;
+      getProjectHealthMock.mockImplementationOnce(
+        () =>
+          new Promise<ProjectHealthData>((resolve) => {
+            resolveFirst = resolve;
+          })
+      );
+
+      const { result } = renderHook(() => useProjectHealth());
+
+      await waitFor(() => {
+        expect(result.current.loading).toBe(true);
+        expect(result.current.isValidating).toBe(true);
+      });
+
+      await act(async () => {
+        resolveFirst?.(makeHealth());
+        await Promise.resolve();
+      });
+
+      await waitFor(() => {
+        expect(result.current.loading).toBe(false);
+        expect(result.current.isValidating).toBe(false);
+        expect(result.current.health).not.toBeNull();
+      });
+    });
+
+    it("flips isValidating without flipping loading on a wake-triggered refetch", async () => {
+      getCurrentMock.mockResolvedValue({ id: "p", path: "/repo/a" });
+
+      let resolveSecond: ((v: ProjectHealthData) => void) | undefined;
+      getProjectHealthMock
+        .mockResolvedValueOnce(makeHealth({ issueCount: 1 }))
+        .mockImplementationOnce(
+          () =>
+            new Promise<ProjectHealthData>((resolve) => {
+              resolveSecond = resolve;
+            })
+        );
+
+      const { result } = renderHook(() => useProjectHealth());
+
+      await waitFor(() => {
+        expect(result.current.health?.issueCount).toBe(1);
+        expect(result.current.loading).toBe(false);
+        expect(result.current.isValidating).toBe(false);
+      });
+
+      await act(async () => {
+        useSystemWakeStore.setState((s) => ({ wakeEpoch: s.wakeEpoch + 1 }));
+        await Promise.resolve();
+      });
+
+      await waitFor(() => {
+        expect(result.current.isValidating).toBe(true);
+      });
+      expect(result.current.loading).toBe(false);
+      expect(result.current.health?.issueCount).toBe(1);
+
+      await act(async () => {
+        resolveSecond?.(makeHealth({ issueCount: 9 }));
+        await Promise.resolve();
+      });
+
+      await waitFor(() => {
+        expect(result.current.isValidating).toBe(false);
+        expect(result.current.health?.issueCount).toBe(9);
+      });
+    });
   });
 });

--- a/src/hooks/__tests__/useRepositoryStats.test.tsx
+++ b/src/hooks/__tests__/useRepositoryStats.test.tsx
@@ -36,6 +36,7 @@ vi.mock("@/clients", () => ({
 
 import { useRepositoryStats } from "../useRepositoryStats";
 import { _resetPollingLifecycleForTests } from "../usePollingLifecycle";
+import { useSystemWakeStore } from "@/store/systemWakeStore";
 import {
   _resetForTests as resetGithubResourceCache,
   buildCacheKey,
@@ -58,6 +59,11 @@ describe("useRepositoryStats", () => {
   beforeEach(() => {
     vi.clearAllMocks();
     _resetPollingLifecycleForTests();
+    useSystemWakeStore.setState({
+      wakeEpoch: 0,
+      lastSleepDuration: 0,
+      isWakeRevalidating: false,
+    });
   });
 
   it("force-fetches when daintree:refresh-sidebar event is dispatched", async () => {
@@ -1102,6 +1108,197 @@ describe("useRepositoryStats", () => {
       await waitFor(() => {
         expect(result.current.rateLimitResetAt).toBeNull();
         expect(result.current.rateLimitKind).toBeNull();
+      });
+    });
+  });
+
+  describe("wake-coordinator subscription", () => {
+    it("refreshes when wakeEpoch increments past the value seen at mount", async () => {
+      getCurrentMock.mockResolvedValue({ id: "p", path: "/repo/a" });
+      onSwitchMock.mockReturnValue(() => {});
+      getRepoStatsMock.mockResolvedValue({
+        commitCount: 1,
+        issueCount: 1,
+        prCount: 1,
+        loading: false,
+        stale: false,
+        lastUpdated: 1000,
+      });
+
+      renderHook(() => useRepositoryStats());
+
+      await waitFor(() => {
+        expect(getRepoStatsMock).toHaveBeenCalledTimes(1);
+      });
+
+      await act(async () => {
+        useSystemWakeStore.setState((s) => ({ wakeEpoch: s.wakeEpoch + 1 }));
+        await Promise.resolve();
+      });
+
+      await waitFor(() => {
+        expect(getRepoStatsMock).toHaveBeenCalledTimes(2);
+      });
+    });
+
+    it("does not refresh for a wakeEpoch that was already current at mount", async () => {
+      // Simulate a prior wake landing before this consumer mounts.
+      useSystemWakeStore.setState({
+        wakeEpoch: 3,
+        lastSleepDuration: 0,
+        isWakeRevalidating: false,
+      });
+
+      getCurrentMock.mockResolvedValue({ id: "p", path: "/repo/a" });
+      onSwitchMock.mockReturnValue(() => {});
+      getRepoStatsMock.mockResolvedValue({
+        commitCount: 1,
+        issueCount: 1,
+        prCount: 1,
+        loading: false,
+        stale: false,
+        lastUpdated: 1000,
+      });
+
+      renderHook(() => useRepositoryStats());
+
+      await waitFor(() => {
+        expect(getRepoStatsMock).toHaveBeenCalledTimes(1);
+      });
+
+      await act(async () => {
+        await Promise.resolve();
+        await Promise.resolve();
+      });
+
+      // Only the mount fetch ran — the previous wake should not retroactively
+      // trigger this consumer.
+      expect(getRepoStatsMock).toHaveBeenCalledTimes(1);
+    });
+
+    it("refreshes once per increment when wakeEpoch bumps multiple times", async () => {
+      getCurrentMock.mockResolvedValue({ id: "p", path: "/repo/a" });
+      onSwitchMock.mockReturnValue(() => {});
+      getRepoStatsMock.mockResolvedValue({
+        commitCount: 1,
+        issueCount: 1,
+        prCount: 1,
+        loading: false,
+        stale: false,
+        lastUpdated: 1000,
+      });
+
+      renderHook(() => useRepositoryStats());
+
+      await waitFor(() => {
+        expect(getRepoStatsMock).toHaveBeenCalledTimes(1);
+      });
+
+      await act(async () => {
+        useSystemWakeStore.setState((s) => ({ wakeEpoch: s.wakeEpoch + 1 }));
+        await Promise.resolve();
+      });
+      await waitFor(() => {
+        expect(getRepoStatsMock).toHaveBeenCalledTimes(2);
+      });
+
+      await act(async () => {
+        useSystemWakeStore.setState((s) => ({ wakeEpoch: s.wakeEpoch + 1 }));
+        await Promise.resolve();
+      });
+      await waitFor(() => {
+        expect(getRepoStatsMock).toHaveBeenCalledTimes(3);
+      });
+    });
+  });
+
+  describe("loading vs isValidating split", () => {
+    it("keeps loading true only for the cold first fetch", async () => {
+      getCurrentMock.mockResolvedValue({ id: "p", path: "/repo/a" });
+      onSwitchMock.mockReturnValue(() => {});
+
+      const firstFetch = createDeferred<RepositoryStats>();
+      getRepoStatsMock.mockImplementationOnce(() => firstFetch.promise);
+
+      const { result } = renderHook(() => useRepositoryStats());
+
+      await waitFor(() => {
+        expect(result.current.loading).toBe(true);
+        expect(result.current.isValidating).toBe(true);
+      });
+
+      await act(async () => {
+        firstFetch.resolve({
+          commitCount: 1,
+          issueCount: 2,
+          prCount: 3,
+          loading: false,
+          stale: false,
+          lastUpdated: 1000,
+        });
+        await Promise.resolve();
+      });
+
+      await waitFor(() => {
+        expect(result.current.loading).toBe(false);
+        expect(result.current.isValidating).toBe(false);
+        expect(result.current.stats?.commitCount).toBe(1);
+      });
+    });
+
+    it("flips isValidating without flipping loading on a background refetch", async () => {
+      getCurrentMock.mockResolvedValue({ id: "p", path: "/repo/a" });
+      onSwitchMock.mockReturnValue(() => {});
+
+      const stats: RepositoryStats = {
+        commitCount: 5,
+        issueCount: 2,
+        prCount: 1,
+        loading: false,
+        stale: false,
+        lastUpdated: 1000,
+      };
+
+      const slow = createDeferred<RepositoryStats>();
+      getRepoStatsMock.mockResolvedValueOnce(stats).mockImplementationOnce(() => slow.promise);
+
+      const { result } = renderHook(() => useRepositoryStats());
+
+      await waitFor(() => {
+        expect(result.current.stats?.commitCount).toBe(5);
+        expect(result.current.loading).toBe(false);
+        expect(result.current.isValidating).toBe(false);
+      });
+
+      // Trigger a background revalidate via the wake coordinator. The visible
+      // counts must stay on screen — `loading` must remain false — while
+      // `isValidating` flips true.
+      await act(async () => {
+        useSystemWakeStore.setState((s) => ({ wakeEpoch: s.wakeEpoch + 1 }));
+        await Promise.resolve();
+      });
+
+      await waitFor(() => {
+        expect(result.current.isValidating).toBe(true);
+      });
+      expect(result.current.loading).toBe(false);
+      expect(result.current.stats?.commitCount).toBe(5);
+
+      await act(async () => {
+        slow.resolve({
+          commitCount: 6,
+          issueCount: 2,
+          prCount: 1,
+          loading: false,
+          stale: false,
+          lastUpdated: 2000,
+        });
+        await Promise.resolve();
+      });
+
+      await waitFor(() => {
+        expect(result.current.isValidating).toBe(false);
+        expect(result.current.stats?.commitCount).toBe(6);
       });
     });
   });

--- a/src/hooks/useProjectHealth.ts
+++ b/src/hooks/useProjectHealth.ts
@@ -3,6 +3,7 @@ import type { ProjectHealthData } from "../types";
 import { githubClient, projectClient } from "@/clients";
 import { formatErrorMessage } from "@shared/utils/errorMessage";
 import { usePollingLifecycle } from "@/hooks/usePollingLifecycle";
+import { useSystemWakeStore } from "@/store/systemWakeStore";
 
 const ACTIVE_POLL_INTERVAL = 30 * 1000;
 const IDLE_POLL_INTERVAL = 5 * 60 * 1000;
@@ -11,6 +12,11 @@ const ERROR_BACKOFF_INTERVAL = 2 * 60 * 1000;
 export interface UseProjectHealthReturn {
   health: ProjectHealthData | null;
   loading: boolean;
+  // True while a refetch is in flight regardless of whether health is already
+  // available. Distinct from `loading`, which narrows to the first-fetch
+  // (no-data-yet) case so background revalidations don't flash skeletons over
+  // visible signals.
+  isValidating: boolean;
   error: string | null;
   lastUpdated: number | null;
   refresh: (options?: { force?: boolean }) => Promise<void>;
@@ -19,12 +25,18 @@ export interface UseProjectHealthReturn {
 export function useProjectHealth(): UseProjectHealthReturn {
   const [health, setHealth] = useState<ProjectHealthData | null>(null);
   const [loading, setLoading] = useState(false);
+  const [isValidating, setIsValidating] = useState(false);
   const [error, setError] = useState<string | null>(null);
   const [lastUpdated, setLastUpdated] = useState<number | null>(null);
 
   const mountedRef = useRef(true);
   const lastErrorRef = useRef<string | null>(null);
   const projectPathRef = useRef<string | null>(null);
+  // Tracks whether any result has been applied to state. Mirrors the
+  // `hasAppliedResultRef` pattern in `useRepositoryStats`: distinguishes the
+  // first cold fetch (skeleton ok) from a background revalidation (must not
+  // flash the skeleton over visible signals).
+  const hasAppliedResultRef = useRef(false);
 
   useEffect(() => {
     mountedRef.current = true;
@@ -48,7 +60,13 @@ export function useProjectHealth(): UseProjectHealthReturn {
           return;
         }
 
-        if (mountedRef.current) setLoading(true);
+        if (mountedRef.current) {
+          // Always signal in-flight revalidation, but only flip the skeleton
+          // when no result has been applied yet — wake/focus/interval
+          // refetches must not hide visible signals.
+          setIsValidating(true);
+          if (!hasAppliedResultRef.current) setLoading(true);
+        }
 
         const result = await githubClient.getProjectHealth(project.path, force);
 
@@ -57,6 +75,7 @@ export function useProjectHealth(): UseProjectHealthReturn {
         if (projectPathRef.current !== null && projectPathRef.current !== project.path) return;
 
         projectPathRef.current = project.path;
+        hasAppliedResultRef.current = true;
 
         setHealth(result);
         setLastUpdated(result.lastUpdated ?? null);
@@ -79,7 +98,10 @@ export function useProjectHealth(): UseProjectHealthReturn {
           lastErrorRef.current = errorMessage;
         }
       } finally {
-        if (mountedRef.current) setLoading(false);
+        if (mountedRef.current) {
+          setLoading(false);
+          setIsValidating(false);
+        }
       }
     },
     calculateNextInterval: ({ isVisible }) => {
@@ -93,16 +115,30 @@ export function useProjectHealth(): UseProjectHealthReturn {
       // would carry through and `calculateNextInterval` would back off the
       // first poll of the new project by ERROR_BACKOFF_INTERVAL.
       lastErrorRef.current = null;
+      hasAppliedResultRef.current = false;
       setHealth(null);
       setLastUpdated(null);
       setError(null);
       setLoading(false);
+      setIsValidating(false);
     },
   });
+
+  // Coalesce sleep-wake fetches onto the shared wake-coordinator slice
+  // (#8066). Seeded with the current epoch so a late-mounting consumer never
+  // fires a spurious refetch for a wake that landed before it existed.
+  const wakeEpoch = useSystemWakeStore((s) => s.wakeEpoch);
+  const lastSeenWakeEpochRef = useRef(useSystemWakeStore.getState().wakeEpoch);
+  useEffect(() => {
+    if (wakeEpoch <= lastSeenWakeEpochRef.current) return;
+    lastSeenWakeEpochRef.current = wakeEpoch;
+    void polling.refresh();
+  }, [wakeEpoch, polling]);
 
   return {
     health,
     loading,
+    isValidating,
     error,
     lastUpdated,
     refresh: polling.refresh,

--- a/src/hooks/useRepositoryStats.ts
+++ b/src/hooks/useRepositoryStats.ts
@@ -6,6 +6,7 @@ import { formatErrorMessage } from "@shared/utils/errorMessage";
 import { buildCacheKey, getCache, setCache } from "@/lib/githubResourceCache";
 import { useGlobalMinuteTicker } from "@/hooks/useGlobalMinuteTicker";
 import { usePollingLifecycle } from "@/hooks/usePollingLifecycle";
+import { useSystemWakeStore } from "@/store/systemWakeStore";
 
 function isValidPagePayload(page: unknown): page is {
   items: unknown[];
@@ -53,6 +54,11 @@ export type FreshnessLevel = "fresh" | "aging" | "stale-disk" | "errored";
 export interface UseRepositoryStatsReturn {
   stats: RepositoryStats | null;
   loading: boolean;
+  // True while a refetch is in flight regardless of whether stats are already
+  // available. Distinct from `loading`, which narrows to the first-fetch
+  // (no-data-yet) case so background revalidations don't flip skeletons or
+  // loading indicators back on top of stale-but-visible data.
+  isValidating: boolean;
   error: string | null;
   isTokenError: boolean;
   isStale: boolean;
@@ -85,6 +91,7 @@ export interface UseRepositoryStatsReturn {
 export function useRepositoryStats(): UseRepositoryStatsReturn {
   const [stats, setStats] = useState<RepositoryStats | null>(null);
   const [loading, setLoading] = useState(false);
+  const [isValidating, setIsValidating] = useState(false);
   const [error, setError] = useState<string | null>(null);
   const [isStale, setIsStale] = useState(false);
   const [lastUpdated, setLastUpdated] = useState<number | null>(null);
@@ -207,7 +214,16 @@ export function useRepositoryStats(): UseRepositoryStatsReturn {
           return;
         }
 
-        if (mountedRef.current) setLoading(true);
+        if (mountedRef.current) {
+          // Always signal that a refetch is in flight so callers can show a
+          // subtle in-progress affordance without hiding visible data. Only
+          // flip the full `loading` skeleton when no result has been applied
+          // yet — once `applyStatsResult` has run (network or disk hydration),
+          // background revalidations (wake, focus, interval, manual refresh)
+          // must not flash the skeleton over existing rows.
+          setIsValidating(true);
+          if (!hasAppliedResultRef.current) setLoading(true);
+        }
 
         const repoStats = await githubClient.getRepoStats(project.path, force);
 
@@ -234,7 +250,10 @@ export function useRepositoryStats(): UseRepositoryStatsReturn {
           lastErrorRef.current = errorMessage;
         }
       } finally {
-        if (mountedRef.current) setLoading(false);
+        if (mountedRef.current) {
+          setLoading(false);
+          setIsValidating(false);
+        }
       }
     },
     calculateNextInterval: ({ isVisible }) => {
@@ -419,6 +438,21 @@ export function useRepositoryStats(): UseRepositoryStatsReturn {
     return cleanup;
   }, [applyStatsResult]);
 
+  // Coalesce sleep-wake fetches onto the shared wake-coordinator slice
+  // (#8066). The store bumps `wakeEpoch` once per qualifying wake; every
+  // consumer reacts to the same epoch instead of independently registering
+  // `system.onWake` listeners or duplicating short-sleep heuristics. The
+  // `lastSeenWakeEpochRef` is seeded with the current value at mount so a
+  // component that arrives after a previous wake doesn't fire a spurious
+  // refetch.
+  const wakeEpoch = useSystemWakeStore((s) => s.wakeEpoch);
+  const lastSeenWakeEpochRef = useRef(useSystemWakeStore.getState().wakeEpoch);
+  useEffect(() => {
+    if (wakeEpoch <= lastSeenWakeEpochRef.current) return;
+    lastSeenWakeEpochRef.current = wakeEpoch;
+    void polling.refresh();
+  }, [wakeEpoch, polling]);
+
   useEffect(() => {
     const cleanup = githubClient.onRateLimitChanged((payload) => {
       if (!mountedRef.current) return;
@@ -489,6 +523,7 @@ export function useRepositoryStats(): UseRepositoryStatsReturn {
   return {
     stats,
     loading,
+    isValidating,
     error,
     isTokenError,
     isStale,


### PR DESCRIPTION
## Summary

Four renderer consumers (`useRepositoryStats`, `useProjectHealth`, `useGitHubResourceListSWR`, `WorktreeStoreContext`) each independently registered DOM visibility/focus listeners and fired their own fetches on every alt-tab / wake. This PR migrates them onto the shared `useSystemWakeStore.wakeEpoch` coordinator slice built in #8065, so a single system wake fans out once instead of triggering N redundant trips through the IPC layer.

- `useRepositoryStats` / `useProjectHealth`: subscribe to `wakeEpoch` and refresh via their shared polling primitive. Both now expose `isValidating` separately from `loading` so background revalidations don't flash skeletons over already-visible data.
- `useGitHubResourceListSWR`: drops the `visibilitychange` listener (the in-app `focus` listener with its 30s throttle stays). Adds a `wakeEpoch` effect that intentionally bypasses the throttle — the coordinator already filters short OS naps (≤30s sleep).
- `WorktreeStoreContext`: `handleVisibilityChange` no longer calls `fetchInitialState`. The workspace host's `refreshOnWake` push stream is the authoritative refresh path; `wakeActiveWorktreeTerminals` is retained for xterm buffer hydration.

Each consumer seeds `lastSeenWakeEpochRef` with the current store value at mount, so a component that arrives after a previous wake doesn't fire a spurious retroactive refetch.

A follow-up commit fixes two edge cases caught in review:
- The `useGitHubResourceListSWR` wake effect now consumes the epoch even when a `#`-search is active, so the stale wake doesn't replay on search-clear.
- The numeric-query effect clears `refreshing` so a wake revalidate aborted by `#42` doesn't leak a spinning indicator.

## Test plan

- [x] `npx vitest run src/hooks/__tests__/useRepositoryStats.test.tsx src/hooks/__tests__/useProjectHealth.test.tsx src/components/GitHub/__tests__/GitHubResourceList.swr.test.tsx src/contexts/__tests__/WorktreeStoreContext.prDetected.test.tsx` — 164 → 248 tests pass after the new cases were added
- [x] `npm run check` — typecheck, lint (888 warnings, -2 from baseline), format, IPC/channels all clean
- [ ] Manual: put machine to sleep > 30s and < 5m, confirm one round-trip per consumer on wake (not N).
- [ ] Manual: type `#42` in the issue dropdown, put machine to sleep, wake, clear the search — list refreshes once, no leftover spinner.

Closes #8066.