### PR TITLE
feat(agent-tray): polish discovery dot, pinned icon, MRU, and TTL backstop

### DIFF
--- a/electron/ipc/channels.ts
+++ b/electron/ipc/channels.ts
@@ -594,6 +594,7 @@ export const CHANNELS = {
   ONBOARDING_MARK_NEWSLETTER_SEEN: "onboarding:mark-newsletter-seen",
   ONBOARDING_MARK_WAITING_NUDGE_SEEN: "onboarding:mark-waiting-nudge-seen",
   ONBOARDING_MARK_AGENTS_SEEN: "onboarding:mark-agents-seen",
+  ONBOARDING_RECORD_AGENT_FIRST_SEEN: "onboarding:record-agent-first-seen",
   ONBOARDING_DISMISS_WELCOME_CARD: "onboarding:dismiss-welcome-card",
   ONBOARDING_DISMISS_SETUP_BANNER: "onboarding:dismiss-setup-banner",
   ONBOARDING_CHECKLIST_GET: "onboarding:checklist-get",

--- a/electron/ipc/handlers/onboarding.ts
+++ b/electron/ipc/handlers/onboarding.ts
@@ -20,10 +20,21 @@ const DEFAULT_CHECKLIST: ChecklistState = {
 
 const SKIP_E2E = process.env.DAINTREE_E2E_SKIP_FIRST_RUN_DIALOGS === "1";
 
+function normalizeAvailabilityFirstSeen(raw: unknown): Record<string, number> {
+  if (!raw || typeof raw !== "object" || Array.isArray(raw)) return {};
+  const out: Record<string, number> = {};
+  for (const [key, value] of Object.entries(raw as Record<string, unknown>)) {
+    if (typeof key === "string" && typeof value === "number" && Number.isFinite(value)) {
+      out[key] = value;
+    }
+  }
+  return out;
+}
+
 function getOnboardingState(): OnboardingState {
   if (SKIP_E2E) {
     return {
-      schemaVersion: 1,
+      schemaVersion: 2,
       completed: true,
       currentStep: null,
       agentSetupIds: [],
@@ -31,6 +42,7 @@ function getOnboardingState(): OnboardingState {
       newsletterPromptSeen: true,
       waitingNudgeSeen: true,
       seenAgentIds: [],
+      availabilityFirstSeen: {},
       welcomeCardDismissed: true,
       setupBannerDismissed: true,
       checklist: {
@@ -48,7 +60,7 @@ function getOnboardingState(): OnboardingState {
   const raw = store.get("onboarding");
   if (!raw) {
     return {
-      schemaVersion: 1,
+      schemaVersion: 2,
       completed: false,
       currentStep: null,
       agentSetupIds: [],
@@ -56,6 +68,7 @@ function getOnboardingState(): OnboardingState {
       newsletterPromptSeen: false,
       waitingNudgeSeen: false,
       seenAgentIds: [],
+      availabilityFirstSeen: {},
       welcomeCardDismissed: false,
       setupBannerDismissed: false,
       checklist: DEFAULT_CHECKLIST,
@@ -69,6 +82,9 @@ function getOnboardingState(): OnboardingState {
     seenAgentIds: Array.isArray(raw.seenAgentIds)
       ? (raw.seenAgentIds as string[]).filter((id) => typeof id === "string")
       : [],
+    availabilityFirstSeen: normalizeAvailabilityFirstSeen(
+      (raw as { availabilityFirstSeen?: unknown }).availabilityFirstSeen
+    ),
     welcomeCardDismissed: raw.welcomeCardDismissed === true,
     // Treat any already-completed onboarding as implicit banner dismissal —
     // without this, upgraded users who finished onboarding before #5131 see
@@ -158,6 +174,30 @@ export function registerOnboardingHandlers(): () => void {
       const seenAgentIds = Array.from(existing);
       store.set("onboarding.seenAgentIds", seenAgentIds);
       return { ...state, seenAgentIds };
+    })
+  );
+
+  cleanups.push(
+    typedHandle(CHANNELS.ONBOARDING_RECORD_AGENT_FIRST_SEEN, (payload: unknown) => {
+      const incoming = Array.isArray(payload)
+        ? (payload as unknown[]).filter((id): id is string => typeof id === "string")
+        : [];
+      const state = getOnboardingState();
+      if (incoming.length === 0) return state;
+      const next = { ...state.availabilityFirstSeen };
+      const now = Date.now();
+      let changed = false;
+      for (const id of incoming) {
+        // Idempotent: never overwrite an existing timestamp. The TTL is
+        // anchored on the first time we ever saw the agent as available.
+        if (next[id] === undefined) {
+          next[id] = now;
+          changed = true;
+        }
+      }
+      if (!changed) return state;
+      store.set("onboarding.availabilityFirstSeen", next);
+      return { ...state, availabilityFirstSeen: next };
     })
   );
 

--- a/electron/preload.cts
+++ b/electron/preload.cts
@@ -2308,6 +2308,8 @@ const api: ElectronAPI = {
     markWaitingNudgeSeen: () => _unwrappingInvoke(CHANNELS.ONBOARDING_MARK_WAITING_NUDGE_SEEN),
     markAgentsSeen: (agentIds: string[]) =>
       _unwrappingInvoke(CHANNELS.ONBOARDING_MARK_AGENTS_SEEN, agentIds),
+    recordAgentFirstSeen: (agentIds: string[]) =>
+      _unwrappingInvoke(CHANNELS.ONBOARDING_RECORD_AGENT_FIRST_SEEN, agentIds),
     dismissWelcomeCard: () => _unwrappingInvoke(CHANNELS.ONBOARDING_DISMISS_WELCOME_CARD),
     dismissSetupBanner: () => _unwrappingInvoke(CHANNELS.ONBOARDING_DISMISS_SETUP_BANNER),
     getChecklist: () => _unwrappingInvoke(CHANNELS.ONBOARDING_CHECKLIST_GET),

--- a/electron/store.ts
+++ b/electron/store.ts
@@ -248,6 +248,7 @@ export interface StoreSchema {
     newsletterPromptSeen: boolean;
     waitingNudgeSeen: boolean;
     seenAgentIds: string[];
+    availabilityFirstSeen: Record<string, number>;
     welcomeCardDismissed: boolean;
     setupBannerDismissed: boolean;
     checklist: {
@@ -409,7 +410,7 @@ const storeOptions = {
       autoRestoreOnCrash: false,
     },
     onboarding: {
-      schemaVersion: 1,
+      schemaVersion: 2,
       completed: false,
       currentStep: null,
       agentSetupIds: [],
@@ -417,6 +418,7 @@ const storeOptions = {
       newsletterPromptSeen: false,
       waitingNudgeSeen: false,
       seenAgentIds: [],
+      availabilityFirstSeen: {},
       welcomeCardDismissed: false,
       setupBannerDismissed: false,
       checklist: {

--- a/shared/types/ipc/api.ts
+++ b/shared/types/ipc/api.ts
@@ -1232,6 +1232,7 @@ export interface ElectronAPI {
     markNewsletterSeen(): Promise<void>;
     markWaitingNudgeSeen(): Promise<void>;
     markAgentsSeen(agentIds: string[]): Promise<OnboardingState>;
+    recordAgentFirstSeen(agentIds: string[]): Promise<OnboardingState>;
     dismissWelcomeCard(): Promise<OnboardingState>;
     dismissSetupBanner(): Promise<OnboardingState>;
     getChecklist(): Promise<ChecklistState>;

--- a/shared/types/ipc/maps.ts
+++ b/shared/types/ipc/maps.ts
@@ -203,6 +203,7 @@ export interface OnboardingState {
   newsletterPromptSeen: boolean;
   waitingNudgeSeen: boolean;
   seenAgentIds: string[];
+  availabilityFirstSeen: Record<string, number>;
   welcomeCardDismissed: boolean;
   setupBannerDismissed: boolean;
   checklist: ChecklistState;
@@ -1553,6 +1554,10 @@ export interface IpcInvokeMap extends GeneratedIpcInvokeMap {
     result: void;
   };
   "onboarding:mark-agents-seen": {
+    args: [agentIds: string[]];
+    result: OnboardingState;
+  };
+  "onboarding:record-agent-first-seen": {
     args: [agentIds: string[]];
     result: OnboardingState;
   };

--- a/src/components/Layout/AgentTrayButton.tsx
+++ b/src/components/Layout/AgentTrayButton.tsx
@@ -206,7 +206,17 @@ function SplitLaunchItem({ row, onLaunch }: SplitLaunchItemProps) {
               <row.Icon brandColor={getBrandColorHex(row.id)} />
             </BrandMark>
           </span>
-          {row.name}
+          <span className="flex-1">{row.name}</span>
+          {row.isNew && (
+            <>
+              <span
+                data-testid={`agent-tray-new-pill-${row.id}`}
+                aria-hidden="true"
+                className="ml-1 shrink-0 size-1.5 rounded-full bg-status-info ring-1 ring-daintree-sidebar"
+              />
+              <span className="sr-only">New</span>
+            </>
+          )}
         </span>
         <span
           className="flex items-center px-2 py-1.5 border-l border-daintree-border/50"
@@ -861,11 +871,14 @@ function LaunchRow({
       <span className="flex-1">{row.name}</span>
 
       {row.isNew && (
-        <span
-          data-testid={`agent-tray-new-pill-${row.id}`}
-          aria-label="New"
-          className="ml-2 shrink-0 size-1.5 rounded-full bg-status-info ring-1 ring-daintree-sidebar"
-        />
+        <>
+          <span
+            data-testid={`agent-tray-new-pill-${row.id}`}
+            aria-hidden="true"
+            className="ml-2 shrink-0 size-1.5 rounded-full bg-status-info ring-1 ring-daintree-sidebar"
+          />
+          <span className="sr-only">New</span>
+        </>
       )}
 
       {displayCombo && <DropdownMenuShortcut>{displayCombo}</DropdownMenuShortcut>}

--- a/src/components/Layout/AgentTrayButton.tsx
+++ b/src/components/Layout/AgentTrayButton.tsx
@@ -45,7 +45,10 @@ import { usePanelStore } from "@/store/panelStore";
 import { useWorktreeSelectionStore } from "@/store/worktreeStore";
 
 import { useKeybindingDisplay } from "@/hooks";
-import { useAgentDiscoveryOnboarding } from "@/hooks/app/useAgentDiscoveryOnboarding";
+import {
+  useAgentDiscoveryOnboarding,
+  NEW_AGENT_TTL_MS,
+} from "@/hooks/app/useAgentDiscoveryOnboarding";
 import { AgentShortcutCapture } from "@/components/KeyboardShortcuts";
 import { notify } from "@/lib/notify";
 import { BUILT_IN_AGENT_IDS, type BuiltInAgentId } from "@shared/config/agentIds";
@@ -306,8 +309,10 @@ export function AgentTrayButton({
   const {
     loaded: onboardingLoaded,
     seenAgentIds,
+    availabilityFirstSeen,
     welcomeCardDismissed,
     markAgentsSeen,
+    recordAgentFirstSeen,
   } = useAgentDiscoveryOnboarding();
 
   const [open, setOpen] = useState(false);
@@ -428,11 +433,18 @@ export function AgentTrayButton({
   const newAgentIds = useMemo<ReadonlySet<string>>(() => {
     if (!onboardingLoaded || welcomeCardRenderable) return new Set<string>();
     const set = new Set<string>();
+    // Snapshot Date.now() once per memo so all agents share a single cutoff
+    // for this render. The visibilitychange listener already re-renders on
+    // app resume, so a stale `now` can't outlive a session.
+    const now = Date.now();
     for (const id of readyAgentIds) {
-      if (!seenAgentIds.includes(id)) set.add(id);
+      if (seenAgentIds.includes(id)) continue;
+      const firstSeen = availabilityFirstSeen[id];
+      if (firstSeen !== undefined && now - firstSeen >= NEW_AGENT_TTL_MS) continue;
+      set.add(id);
     }
     return set;
-  }, [onboardingLoaded, welcomeCardRenderable, readyAgentIds, seenAgentIds]);
+  }, [onboardingLoaded, welcomeCardRenderable, readyAgentIds, seenAgentIds, availabilityFirstSeen]);
 
   const showDiscoveryBadge = newAgentIds.size > 0;
 
@@ -480,8 +492,9 @@ export function AgentTrayButton({
 
     // Sort Launch by palette frecency (higher score = more recent). Untracked
     // agents keep their natural BUILT_IN_AGENT_IDS order after any tracked
-    // ones. Only palette dispatches populate frecency; tray launches
-    // don't record, but palette-sourced frecency is the signal we have.
+    // ones. Both palette dispatches and tray launches feed into the same
+    // frecency map (the tray records explicitly in handleLaunch since
+    // ActionService.dispatch doesn't auto-record MRU).
     const frecencyEntries = getSortedActionMruList();
     const frecencyScoreMap = new Map<string, number>();
     frecencyEntries.forEach(({ id, score }) => frecencyScoreMap.set(id, score));
@@ -510,6 +523,15 @@ export function AgentTrayButton({
   const handleLaunch = useCallback(
     (agentId: BuiltInAgentId, presetId?: string | null) => {
       setOpen(false);
+      // Clear the NEW signal only for the agent the user actually launched.
+      // Opening the dropdown alone used to call markAgentsSeen(readyAgentIds),
+      // which burned the discovery cue for every other agent at the same
+      // time. Per-launch decay keeps the cue truthful.
+      void markAgentsSeen([agentId]);
+      // Feed palette frecency from tray launches too. `ActionService.dispatch`
+      // does not auto-record MRU (only `useActionPalette` does), so without
+      // this the tray's MRU-based sort can never reflect tray usage.
+      useActionMruStore.getState().recordActionMru(`agent.${agentId}`);
       // `null` = explicit default — clear both the worktree-scoped override
       // and the agent-level presetId so resolveEffectivePresetId returns
       // undefined and the radio group visually selects "Default".
@@ -530,7 +552,7 @@ export function AgentTrayButton({
         { source: "user" }
       );
     },
-    [activeWorktreeId, updateWorktreePreset]
+    [activeWorktreeId, markAgentsSeen, updateWorktreePreset]
   );
 
   const handleSetup = (agentId: BuiltInAgentId) => {
@@ -559,7 +581,11 @@ export function AgentTrayButton({
     // Fire-and-forget: the store throttle absorbs rapid reopens.
     void refreshAvailability().catch(() => {});
     if (readyAgentIds.length > 0) {
-      void markAgentsSeen(readyAgentIds);
+      // Anchor each agent's TTL window on the first time the user could
+      // actually see it in the tray. We deliberately do NOT mark agents
+      // seen here — that would burn the NEW dot for everything the user
+      // hasn't interacted with. markAgentsSeen now fires per-launch only.
+      void recordAgentFirstSeen(readyAgentIds);
     }
   };
 
@@ -837,10 +863,9 @@ function LaunchRow({
       {row.isNew && (
         <span
           data-testid={`agent-tray-new-pill-${row.id}`}
-          className="ml-2 shrink-0 rounded border border-status-info/40 px-1.5 py-0.5 text-[10px] uppercase tracking-wide text-status-info"
-        >
-          New
-        </span>
+          aria-label="New"
+          className="ml-2 shrink-0 size-1.5 rounded-full bg-status-info ring-1 ring-daintree-sidebar"
+        />
       )}
 
       {displayCombo && <DropdownMenuShortcut>{displayCombo}</DropdownMenuShortcut>}
@@ -881,7 +906,14 @@ function LaunchRow({
         )}
       >
         <Pin
-          className={cn("h-3 w-3", row.pinned && "fill-current text-daintree-text")}
+          className={cn(
+            "h-3 w-3",
+            // Pinned rows: read as state markers, not active controls. Muted
+            // until the row is highlighted (hover/keyboard focus), at which
+            // point the icon brightens to signal it is also clickable.
+            row.pinned &&
+              "fill-current text-daintree-text/40 group-data-[highlighted]:text-daintree-text"
+          )}
           strokeWidth={row.pinned ? 2 : 1.75}
         />
       </span>

--- a/src/components/Layout/__tests__/AgentTrayButton.test.tsx
+++ b/src/components/Layout/__tests__/AgentTrayButton.test.tsx
@@ -1033,19 +1033,63 @@ describe("AgentTrayButton", () => {
     expect(queryByTestId("agent-tray-new-pill-gemini")).toBeTruthy();
   });
 
-  it("renders the NEW indicator as a labelled dot rather than a text pill", () => {
-    // #8177: unify with the trigger badge — dot + aria-label, no "New" text.
+  it("renders the NEW indicator as a screen-reader-paired dot rather than a text pill", () => {
+    // #8177: unify with the trigger badge — dot is aria-hidden, screen
+    // readers get "New" via the adjacent sr-only span. No visible "NEW" text.
     const availability = { claude: "ready" } as unknown as CliAvailability;
     mockSettings = settingsWith({});
     mockSeenAgentIds = [];
 
-    const { getByTestId } = render(<AgentTrayButton agentAvailability={availability} />);
+    const { getByTestId, container } = render(<AgentTrayButton agentAvailability={availability} />);
     const dot = getByTestId("agent-tray-new-pill-claude");
-    expect(dot.getAttribute("aria-label")).toBe("New");
-    // No legacy "NEW" text content — the dot is purely visual.
+    expect(dot.getAttribute("aria-hidden")).toBe("true");
     expect(dot.textContent ?? "").toBe("");
     expect(dot.className).toContain("rounded-full");
     expect(dot.className).toContain("bg-status-info");
+
+    // Screen reader pairing: the row should expose "New" via an sr-only sibling.
+    const row = container.querySelector(
+      '[data-testid="agent-tray-row-claude"]'
+    ) as HTMLElement | null;
+    expect(row).toBeTruthy();
+    const srOnly = Array.from(row!.querySelectorAll(".sr-only")).map((el) =>
+      el.textContent?.trim()
+    );
+    expect(srOnly).toContain("New");
+  });
+
+  it("renders the NEW dot inside the SplitLaunchItem trigger when the agent has presets", () => {
+    // Regression for #8177: agents with presets route through SplitLaunchItem
+    // (not LaunchRow). The dot must surface there too, or the most visible
+    // agents get no per-row discovery indicator.
+    const availability = { claude: "ready" } as unknown as CliAvailability;
+    mockSettings = settingsWith({});
+    mockSeenAgentIds = [];
+    mockMergedPresetsFn = (agentId: string) =>
+      agentId === "claude" ? [{ id: "user-alpha", name: "Alpha" }] : [];
+
+    const { getByTestId } = render(<AgentTrayButton agentAvailability={availability} />);
+    const dot = getByTestId("agent-tray-new-pill-claude");
+    expect(dot.getAttribute("aria-hidden")).toBe("true");
+    expect(dot.className).toContain("rounded-full");
+    expect(dot.className).toContain("bg-status-info");
+  });
+
+  it("clears the NEW dot when the agent is launched via the SplitLaunchItem trigger", () => {
+    // Pressing Enter on the SubTrigger goes through onLaunch → handleLaunch,
+    // which now fires markAgentsSeen([agentId]) per-launch.
+    const availability = { claude: "ready" } as unknown as CliAvailability;
+    mockSettings = settingsWith({});
+    mockSeenAgentIds = [];
+    mockMergedPresetsFn = (agentId: string) =>
+      agentId === "claude" ? [{ id: "user-alpha", name: "Alpha" }] : [];
+
+    const { getAllByTestId } = render(<AgentTrayButton agentAvailability={availability} />);
+    markAgentsSeenMock.mockClear();
+    fireEvent.keyDown(getAllByTestId("submenu-trigger")[0]!, { key: "Enter" });
+
+    expect(markAgentsSeenMock).toHaveBeenCalledTimes(1);
+    expect(markAgentsSeenMock).toHaveBeenCalledWith(["claude"]);
   });
 
   it("pinned rows render the pin icon muted until the row is highlighted", () => {

--- a/src/components/Layout/__tests__/AgentTrayButton.test.tsx
+++ b/src/components/Layout/__tests__/AgentTrayButton.test.tsx
@@ -24,20 +24,27 @@ let mockHasRealData = true;
 let mockActionMruList: string[] = [];
 
 const markAgentsSeenMock = vi.fn().mockResolvedValue(undefined);
+const recordAgentFirstSeenMock = vi.fn().mockResolvedValue(undefined);
 const dismissWelcomeCardMock = vi.fn().mockResolvedValue(undefined);
 const dismissSetupBannerMock = vi.fn().mockResolvedValue(undefined);
 let mockSeenAgentIds: string[] = [];
+let mockAvailabilityFirstSeen: Record<string, number> = {};
 let mockWelcomeCardDismissed = true;
 const mockSetupBannerDismissed = true;
 let mockOnboardingLoaded = true;
 
+const TEST_NEW_AGENT_TTL_MS = 14 * 24 * 60 * 60 * 1000;
+
 vi.mock("@/hooks/app/useAgentDiscoveryOnboarding", () => ({
+  NEW_AGENT_TTL_MS: 14 * 24 * 60 * 60 * 1000,
   useAgentDiscoveryOnboarding: () => ({
     loaded: mockOnboardingLoaded,
     seenAgentIds: mockSeenAgentIds,
+    availabilityFirstSeen: mockAvailabilityFirstSeen,
     welcomeCardDismissed: mockWelcomeCardDismissed,
     setupBannerDismissed: mockSetupBannerDismissed,
     markAgentsSeen: markAgentsSeenMock,
+    recordAgentFirstSeen: recordAgentFirstSeenMock,
     dismissWelcomeCard: dismissWelcomeCardMock,
     dismissSetupBanner: dismissSetupBannerMock,
   }),
@@ -69,18 +76,25 @@ vi.mock("@/store/agentSettingsStore", () => ({
   ),
 }));
 
+const recordActionMruMock = vi.fn();
+
 vi.mock("@/store/actionMruStore", () => ({
-  useActionMruStore: (
-    selector: (s: { getSortedActionMruList: () => ActionFrecencyEntry[] }) => unknown
-  ) =>
-    selector({
-      getSortedActionMruList: () =>
-        mockActionMruList.map((id) => ({
-          id,
-          score: mockActionMruList.length - mockActionMruList.indexOf(id),
-          lastAccessedAt: Date.now(),
-        })),
-    }),
+  useActionMruStore: Object.assign(
+    (selector: (s: { getSortedActionMruList: () => ActionFrecencyEntry[] }) => unknown) =>
+      selector({
+        getSortedActionMruList: () =>
+          mockActionMruList.map((id) => ({
+            id,
+            score: mockActionMruList.length - mockActionMruList.indexOf(id),
+            lastAccessedAt: Date.now(),
+          })),
+      }),
+    {
+      getState: () => ({
+        recordActionMru: recordActionMruMock,
+      }),
+    }
+  ),
 }));
 
 type MockCliAvailabilityStoreState = {
@@ -374,8 +388,11 @@ describe("AgentTrayButton", () => {
     mockHasRealData = true;
     mockActionMruList = [];
     markAgentsSeenMock.mockClear();
+    recordAgentFirstSeenMock.mockClear();
+    recordActionMruMock.mockClear();
     dismissWelcomeCardMock.mockClear();
     mockSeenAgentIds = [];
+    mockAvailabilityFirstSeen = {};
     mockWelcomeCardDismissed = true;
     mockOnboardingLoaded = true;
     mockCcrPresetsByAgent = {};
@@ -919,7 +936,10 @@ describe("AgentTrayButton", () => {
     expect(getByTestId("agent-tray-discovery-badge").getAttribute("data-visible")).toBe("false");
   });
 
-  it("calls markAgentsSeen with all ready agent ids on tray open", () => {
+  it("does not call markAgentsSeen on tray open — discovery is now per-launch", () => {
+    // Regression for #8177: opening the dropdown used to burn the NEW dot
+    // for every ready agent at once. The signal must survive until the
+    // user actually launches one.
     const availability = { claude: "ready", gemini: "ready" } as unknown as CliAvailability;
     mockSettings = settingsWith({});
     mockWelcomeCardDismissed = true;
@@ -930,12 +950,28 @@ describe("AgentTrayButton", () => {
     markAgentsSeenMock.mockClear();
 
     openChangeSpy!(true);
-    expect(markAgentsSeenMock).toHaveBeenCalledTimes(1);
-    const [ids] = markAgentsSeenMock.mock.calls[0] as [string[]];
+    expect(markAgentsSeenMock).not.toHaveBeenCalled();
+  });
+
+  it("records availabilityFirstSeen for all ready agents on tray open", () => {
+    // Tray open is the canonical "user could now see this agent" moment, so
+    // it anchors the TTL window. The IPC is idempotent server-side; the hook
+    // only writes timestamps for ids that aren't already recorded.
+    const availability = { claude: "ready", gemini: "ready" } as unknown as CliAvailability;
+    mockSettings = settingsWith({});
+    mockWelcomeCardDismissed = true;
+    mockSeenAgentIds = [];
+
+    render(<AgentTrayButton agentAvailability={availability} />);
+    recordAgentFirstSeenMock.mockClear();
+
+    openChangeSpy!(true);
+    expect(recordAgentFirstSeenMock).toHaveBeenCalledTimes(1);
+    const [ids] = recordAgentFirstSeenMock.mock.calls[0] as [string[]];
     expect(ids.sort()).toEqual(["claude", "gemini"]);
   });
 
-  it("does not call markAgentsSeen when no agents are ready on tray open", () => {
+  it("does not call recordAgentFirstSeen when no agents are ready on tray open", () => {
     const availability = {
       claude: "missing",
       gemini: "missing",
@@ -943,10 +979,91 @@ describe("AgentTrayButton", () => {
     mockSettings = settingsWith({});
 
     render(<AgentTrayButton agentAvailability={availability} />);
-    markAgentsSeenMock.mockClear();
+    recordAgentFirstSeenMock.mockClear();
 
     openChangeSpy!(true);
-    expect(markAgentsSeenMock).not.toHaveBeenCalled();
+    expect(recordAgentFirstSeenMock).not.toHaveBeenCalled();
+  });
+
+  it("launching an agent calls markAgentsSeen with only that agent id", () => {
+    const availability = { claude: "ready", gemini: "ready" } as unknown as CliAvailability;
+    mockSettings = settingsWith({});
+    mockSeenAgentIds = [];
+
+    const { getByTestId } = render(<AgentTrayButton agentAvailability={availability} />);
+    markAgentsSeenMock.mockClear();
+
+    fireEvent.click(getByTestId("agent-tray-row-claude"));
+
+    expect(markAgentsSeenMock).toHaveBeenCalledTimes(1);
+    expect(markAgentsSeenMock).toHaveBeenCalledWith(["claude"]);
+  });
+
+  it("launching an agent records palette MRU so the sort reflects tray usage", () => {
+    // Regression for #8177: ActionService.dispatch does not auto-record MRU,
+    // so without an explicit recordActionMru call the tray's MRU-based sort
+    // never reflects tray launches.
+    const availability = { codex: "ready" } as unknown as CliAvailability;
+    mockSettings = settingsWith({});
+
+    const { getByTestId } = render(<AgentTrayButton agentAvailability={availability} />);
+    recordActionMruMock.mockClear();
+
+    fireEvent.click(getByTestId("agent-tray-row-codex"));
+
+    expect(recordActionMruMock).toHaveBeenCalledTimes(1);
+    expect(recordActionMruMock).toHaveBeenCalledWith("agent.codex");
+  });
+
+  it("decays the NEW dot for agents first seen more than the TTL ago", () => {
+    const availability = { claude: "ready", gemini: "ready" } as unknown as CliAvailability;
+    mockSettings = settingsWith({});
+    mockWelcomeCardDismissed = true;
+    mockSeenAgentIds = [];
+    const now = Date.now();
+    mockAvailabilityFirstSeen = {
+      // Past the TTL by 1ms — must NOT show the NEW dot.
+      claude: now - TEST_NEW_AGENT_TTL_MS - 1,
+      // Inside the TTL window — must still show the NEW dot.
+      gemini: now - 1000,
+    };
+
+    const { queryByTestId } = render(<AgentTrayButton agentAvailability={availability} />);
+    expect(queryByTestId("agent-tray-new-pill-claude")).toBeNull();
+    expect(queryByTestId("agent-tray-new-pill-gemini")).toBeTruthy();
+  });
+
+  it("renders the NEW indicator as a labelled dot rather than a text pill", () => {
+    // #8177: unify with the trigger badge — dot + aria-label, no "New" text.
+    const availability = { claude: "ready" } as unknown as CliAvailability;
+    mockSettings = settingsWith({});
+    mockSeenAgentIds = [];
+
+    const { getByTestId } = render(<AgentTrayButton agentAvailability={availability} />);
+    const dot = getByTestId("agent-tray-new-pill-claude");
+    expect(dot.getAttribute("aria-label")).toBe("New");
+    // No legacy "NEW" text content — the dot is purely visual.
+    expect(dot.textContent ?? "").toBe("");
+    expect(dot.className).toContain("rounded-full");
+    expect(dot.className).toContain("bg-status-info");
+  });
+
+  it("pinned rows render the pin icon muted until the row is highlighted", () => {
+    // #8177: the filled pin used to read as an active control. Muted until
+    // hover/focus makes it clear the icon is a state marker.
+    const availability = { claude: "ready" } as unknown as CliAvailability;
+    mockSettings = settingsWith({ claude: { pinned: true } });
+
+    const { container } = render(<AgentTrayButton agentAvailability={availability} />);
+    const claudeRow = container.querySelector(
+      '[data-testid="agent-tray-row-claude"]'
+    ) as HTMLElement | null;
+    expect(claudeRow).toBeTruthy();
+    const pinIcon = claudeRow!.querySelector('[data-testid="pin-icon"]') as HTMLElement | null;
+    expect(pinIcon).toBeTruthy();
+    const classes = pinIcon!.getAttribute("data-classname") ?? "";
+    expect(classes).toContain("text-daintree-text/40");
+    expect(classes).toContain("group-data-[highlighted]:text-daintree-text");
   });
 
   it("ignores panels from other worktrees for session detection", () => {

--- a/src/components/Onboarding/__tests__/OnboardingFlow.test.tsx
+++ b/src/components/Onboarding/__tests__/OnboardingFlow.test.tsx
@@ -6,7 +6,7 @@ import type { OnboardingState } from "@shared/types";
 const trackMock = vi.fn(() => Promise.resolve());
 
 const defaultOnboardingState: OnboardingState = {
-  schemaVersion: 1,
+  schemaVersion: 2,
   completed: false,
   currentStep: null,
   agentSetupIds: [],
@@ -14,6 +14,7 @@ const defaultOnboardingState: OnboardingState = {
   newsletterPromptSeen: false,
   waitingNudgeSeen: false,
   seenAgentIds: [],
+  availabilityFirstSeen: {},
   welcomeCardDismissed: false,
   setupBannerDismissed: false,
   checklist: {

--- a/src/components/__tests__/agentPinSync.integration.test.tsx
+++ b/src/components/__tests__/agentPinSync.integration.test.tsx
@@ -26,20 +26,36 @@ const setAgentPinnedMock = vi.fn(async (id: string, pinned: boolean) => {
 const dispatchMock = vi.fn();
 const refreshAvailabilityMock = vi.fn().mockResolvedValue(undefined);
 const toggleButtonVisibilityMock = vi.fn();
+const updateAgentMock = vi.fn().mockResolvedValue(undefined);
+const updateWorktreePresetMock = vi.fn().mockResolvedValue(undefined);
+const recordActionMruMock = vi.fn();
+
+// AgentTrayButton calls `useAgentSettingsStore.getState()` inside
+// `handleLaunch`, so the mock has to expose both the hook selector and a
+// static `getState`. `settings` reads via a getter so `beforeEach`
+// mutations to `sharedSettings` propagate through the static handle too.
+const agentSettingsState = {
+  get settings() {
+    return sharedSettings;
+  },
+  setAgentPinned: setAgentPinnedMock,
+  updateAgent: updateAgentMock,
+  updateWorktreePreset: updateWorktreePresetMock,
+};
 
 vi.mock("@/store/agentSettingsStore", () => ({
-  useAgentSettingsStore: (
-    selector: (s: {
-      settings: AgentSettings | null;
-      setAgentPinned: typeof setAgentPinnedMock;
-    }) => unknown
-  ) => selector({ settings: sharedSettings, setAgentPinned: setAgentPinnedMock }),
+  useAgentSettingsStore: Object.assign(
+    (selector: (s: typeof agentSettingsState) => unknown) => selector(agentSettingsState),
+    { getState: () => agentSettingsState }
+  ),
 }));
 
 vi.mock("@/store/actionMruStore", () => ({
-  useActionMruStore: (
-    selector: (s: { getSortedActionMruList: () => ActionFrecencyEntry[] }) => unknown
-  ) => selector({ getSortedActionMruList: () => [] }),
+  useActionMruStore: Object.assign(
+    (selector: (s: { getSortedActionMruList: () => ActionFrecencyEntry[] }) => unknown) =>
+      selector({ getSortedActionMruList: () => [] }),
+    { getState: () => ({ recordActionMru: recordActionMruMock }) }
+  ),
 }));
 
 let sharedAvailability: CliAvailability = {} as CliAvailability;
@@ -104,11 +120,17 @@ vi.mock("@/store/projectPresetsStore", () => ({
 }));
 
 vi.mock("@/hooks/app/useAgentDiscoveryOnboarding", () => ({
+  NEW_AGENT_TTL_MS: 14 * 24 * 60 * 60 * 1000,
   useAgentDiscoveryOnboarding: () => ({
     loaded: true,
     seenAgentIds: [],
+    availabilityFirstSeen: {},
     welcomeCardDismissed: true,
+    setupBannerDismissed: true,
     markAgentsSeen: vi.fn(),
+    recordAgentFirstSeen: vi.fn(),
+    dismissWelcomeCard: vi.fn(),
+    dismissSetupBanner: vi.fn(),
   }),
 }));
 
@@ -249,6 +271,9 @@ describe("agent pin sync — Settings > Toolbar and Agent Tray share state (#511
     toggleButtonVisibilityMock.mockClear();
     dispatchMock.mockClear();
     refreshAvailabilityMock.mockClear();
+    updateAgentMock.mockClear();
+    updateWorktreePresetMock.mockClear();
+    recordActionMruMock.mockClear();
     sharedSettings = {
       agents: {
         claude: { pinned: true },

--- a/src/hooks/app/useAgentDiscoveryOnboarding.ts
+++ b/src/hooks/app/useAgentDiscoveryOnboarding.ts
@@ -17,6 +17,17 @@ interface AgentDiscoveryState {
   setupBannerDismissed: boolean;
 }
 
+function normalizeAvailabilityFirstSeen(raw: unknown): Record<string, number> {
+  if (!raw || typeof raw !== "object" || Array.isArray(raw)) return {};
+  const out: Record<string, number> = {};
+  for (const [key, value] of Object.entries(raw as Record<string, unknown>)) {
+    if (typeof key === "string" && typeof value === "number" && Number.isFinite(value)) {
+      out[key] = value;
+    }
+  }
+  return out;
+}
+
 const useAgentDiscoveryStore = create<AgentDiscoveryState>(() => ({
   loaded: false,
   seenAgentIds: [],
@@ -46,10 +57,11 @@ async function hydrate(): Promise<void> {
       useAgentDiscoveryStore.setState({
         loaded: true,
         seenAgentIds: Array.isArray(state.seenAgentIds) ? state.seenAgentIds : [],
-        availabilityFirstSeen:
-          state.availabilityFirstSeen && typeof state.availabilityFirstSeen === "object"
-            ? state.availabilityFirstSeen
-            : {},
+        // Filter persisted timestamps to finite numbers. A corrupted entry
+        // (NaN from an old build or hand-edited config) would otherwise leave
+        // the discovery dot pinned forever — `Date.now() - NaN` is NaN, and
+        // `NaN >= TTL` is false, so the TTL backstop wouldn't fire.
+        availabilityFirstSeen: normalizeAvailabilityFirstSeen(state.availabilityFirstSeen),
         welcomeCardDismissed: state.welcomeCardDismissed === true,
         setupBannerDismissed: state.setupBannerDismissed === true,
       });

--- a/src/hooks/app/useAgentDiscoveryOnboarding.ts
+++ b/src/hooks/app/useAgentDiscoveryOnboarding.ts
@@ -3,9 +3,16 @@ import { create } from "zustand";
 import type { OnboardingState } from "@shared/types";
 import { isElectronAvailable } from "@/hooks/useElectron";
 
+// Backstop for the per-row NEW indicator: agents whose first availability
+// is older than this fall out of the discovery signal automatically, even
+// if the user never launches them. Keeps the dot from becoming permanent
+// background noise for users who don't engage with new agents.
+export const NEW_AGENT_TTL_MS = 14 * 24 * 60 * 60 * 1000;
+
 interface AgentDiscoveryState {
   loaded: boolean;
   seenAgentIds: string[];
+  availabilityFirstSeen: Record<string, number>;
   welcomeCardDismissed: boolean;
   setupBannerDismissed: boolean;
 }
@@ -13,6 +20,7 @@ interface AgentDiscoveryState {
 const useAgentDiscoveryStore = create<AgentDiscoveryState>(() => ({
   loaded: false,
   seenAgentIds: [],
+  availabilityFirstSeen: {},
   welcomeCardDismissed: false,
   setupBannerDismissed: false,
 }));
@@ -38,6 +46,10 @@ async function hydrate(): Promise<void> {
       useAgentDiscoveryStore.setState({
         loaded: true,
         seenAgentIds: Array.isArray(state.seenAgentIds) ? state.seenAgentIds : [],
+        availabilityFirstSeen:
+          state.availabilityFirstSeen && typeof state.availabilityFirstSeen === "object"
+            ? state.availabilityFirstSeen
+            : {},
         welcomeCardDismissed: state.welcomeCardDismissed === true,
         setupBannerDismissed: state.setupBannerDismissed === true,
       });
@@ -75,6 +87,31 @@ export async function markAgentsSeen(agentIds: string[]): Promise<void> {
   }
 }
 
+export async function recordAgentFirstSeen(agentIds: string[]): Promise<void> {
+  if (agentIds.length === 0) return;
+  useAgentDiscoveryStore.setState((s) => {
+    const next = { ...s.availabilityFirstSeen };
+    const now = Date.now();
+    let changed = false;
+    for (const id of agentIds) {
+      // Idempotent: first write wins. The decay window is anchored on the
+      // *first* time the agent was visibly available, not on each re-open.
+      if (next[id] === undefined) {
+        next[id] = now;
+        changed = true;
+      }
+    }
+    return changed ? { ...s, availabilityFirstSeen: next } : s;
+  });
+  const api = window.electron?.onboarding;
+  if (!api?.recordAgentFirstSeen) return;
+  try {
+    await api.recordAgentFirstSeen(agentIds);
+  } catch {
+    // Best-effort; optimistic local state stands.
+  }
+}
+
 export async function dismissWelcomeCard(): Promise<void> {
   if (useAgentDiscoveryStore.getState().welcomeCardDismissed) return;
   useAgentDiscoveryStore.setState({ welcomeCardDismissed: true });
@@ -101,6 +138,7 @@ export async function dismissSetupBanner(): Promise<void> {
 
 interface AgentDiscoveryOnboarding extends AgentDiscoveryState {
   markAgentsSeen: (agentIds: string[]) => Promise<void>;
+  recordAgentFirstSeen: (agentIds: string[]) => Promise<void>;
   dismissWelcomeCard: () => Promise<void>;
   dismissSetupBanner: () => Promise<void>;
 }
@@ -115,6 +153,7 @@ interface AgentDiscoveryOnboarding extends AgentDiscoveryState {
 export function useAgentDiscoveryOnboarding(): AgentDiscoveryOnboarding {
   const loaded = useAgentDiscoveryStore((s) => s.loaded);
   const seenAgentIds = useAgentDiscoveryStore((s) => s.seenAgentIds);
+  const availabilityFirstSeen = useAgentDiscoveryStore((s) => s.availabilityFirstSeen);
   const welcomeCardDismissed = useAgentDiscoveryStore((s) => s.welcomeCardDismissed);
   const setupBannerDismissed = useAgentDiscoveryStore((s) => s.setupBannerDismissed);
 
@@ -125,9 +164,11 @@ export function useAgentDiscoveryOnboarding(): AgentDiscoveryOnboarding {
   return {
     loaded,
     seenAgentIds,
+    availabilityFirstSeen,
     welcomeCardDismissed,
     setupBannerDismissed,
     markAgentsSeen,
+    recordAgentFirstSeen,
     dismissWelcomeCard,
     dismissSetupBanner,
   };
@@ -138,6 +179,7 @@ export function resetAgentDiscoveryStoreForTests(): void {
   useAgentDiscoveryStore.setState({
     loaded: false,
     seenAgentIds: [],
+    availabilityFirstSeen: {},
     welcomeCardDismissed: false,
     setupBannerDismissed: false,
   });


### PR DESCRIPTION
Closes #8177.

## Summary

Five small polish changes for `AgentTrayButton`:

- **Unify the NEW indicator** — the per-row outlined "NEW" pill is replaced with a status-info dot that matches the trigger badge. The dot is `aria-hidden`; an adjacent `sr-only` span carries the "New" label, matching the trigger-badge pattern.
- **Stop burning the NEW signal on open** — `markAgentsSeen` no longer fires for every ready agent the moment the tray opens. It now fires per-launch (single-element array) so the dot decays only for the agent the user actually launched.
- **TTL backstop (14 days)** — `OnboardingState` gains `availabilityFirstSeen: Record<string, number>`. A new IPC channel `onboarding:record-agent-first-seen` records first-seen timestamps on tray open (idempotent — first write wins). The `newAgentIds` memo drops agents whose first-seen is past `NEW_AGENT_TTL_MS`. Schema bumped to v2; reads sanitize to finite numbers in both renderer and main so a corrupted persisted entry can't pin the dot on forever.
- **Mute the pinned Pin icon** — pinned-but-not-highlighted rows now render the pin at `text-daintree-text/40`. Highlighting (hover / keyboard focus) brightens it. Reads as a state marker until the row is focused; still clickable for unpin.
- **Wire MRU on tray launches** — `ActionService.dispatch` does not auto-record MRU (only the action palette does). `handleLaunch` now calls `useActionMruStore.getState().recordActionMru(\`agent.\${agentId}\`)` so the tray's MRU-based sort actually reflects tray usage.

Plus the `SplitLaunchItem` (agents with presets) renders the same dot — review found it had been routing through a different code path and would have lost the indicator for the most-visible agents.

## Test plan

- [ ] Open the tray with a new agent newly installed → dot in the trigger badge and per-row
- [ ] Launch one agent → only that agent's dot clears; others stay
- [ ] Reopen the tray after \~14 days without launching → dots gone (TTL backstop)
- [ ] Pin → row reads as state marker until hovered/focused → still clickable to unpin
- [ ] Launch an agent from the tray → palette MRU rail shows it the next time
- [ ] Corrupt `onboarding.availabilityFirstSeen` to `{ claude: "bogus" }` and reload → no crash, dot behaves correctly (sanitized to {})

🤖 Generated with [Claude Code](https://claude.com/claude-code)