### PR TITLE
feat(plugins): registerForgeProvider host API + provider-agnostic linked snapshot

### DIFF
--- a/docs/plugins/host-api.md
+++ b/docs/plugins/host-api.md
@@ -160,21 +160,54 @@ interface PluginWorktreeSnapshot {
   readonly isMainWorktree?: boolean;
   readonly aheadCount?: number;
   readonly behindCount?: number;
-  readonly issueNumber?: number;
-  readonly issueTitle?: string;
-  readonly prNumber?: number;
-  readonly prUrl?: string;
-  readonly prState?: "open" | "merged" | "closed";
-  readonly prTitle?: string;
+  readonly linked: PluginWorktreeLinked | null;
   readonly mood?: "stable" | "active" | "stale" | "error";
   readonly lastActivityTimestamp?: number | null;
   readonly createdAt?: number;
 }
+
+interface PluginWorktreeLinked {
+  readonly providerId: string;
+  readonly issue?: PluginWorktreeLinkedIssue;
+  readonly pr?: PluginWorktreeLinkedPR;
+}
+
+interface PluginWorktreeLinkedIssue {
+  readonly ref: ResourceRef;
+  readonly title?: string;
+}
+
+interface PluginWorktreeLinkedPR {
+  readonly ref: ResourceRef;
+  readonly title?: string;
+  readonly url: string;
+  readonly state: NormalizedPRState;
+}
 ```
+
+`linked` is a provider-agnostic projection of the worktree's linked forge resources (issue and/or PR), or `null` when none is linked. It replaces the removed GitHub-shaped `issueNumber` / `issueTitle` / `prNumber` / `prUrl` / `prState` / `prTitle` fields — route through `linked.providerId` and the shared `ResourceRef` shape instead.
 
 All snapshots are frozen — attempting to mutate one throws. Fields are an explicit allowlist; adding a new field requires a Daintree SDK release.
 
 Subscriptions registered during `activate` — before Daintree's worktree service is ready — are queued and replayed once the service comes online. Your callback never misses events.
+
+## `registerForgeProvider`
+
+Binds a runtime `ForgeProviderImpl` to a descriptor declared in `contributes.forgeProviders`.
+
+```ts
+const dispose = host.registerForgeProvider(
+  { id: "linear", label: "Linear" },
+  impl
+);
+```
+
+**Rules:**
+
+- Must be called during `activate()` — the host is revoked once activation resolves or times out.
+- `descriptor.id` must match an entry in `contributes.forgeProviders`; undeclared ids are rejected so the impl can't drift away from the manifest's routing table. At runtime the id is namespaced to `{pluginId}.{descriptor.id}`.
+- Returns a disposer that unbinds the single impl. Calling `registerForgeProvider` again with the same `descriptor.id` overwrites the prior binding; the older disposer becomes inert.
+- All bindings are automatically removed on plugin unload.
 
 ## `settings` — _Planned_
 

--- a/electron/services/PluginService.ts
+++ b/electron/services/PluginService.ts
@@ -555,14 +555,33 @@ export class PluginService {
             `Plugin "${pluginId}" registerForgeProvider: impl must be an object`
           );
         }
+        // The impl is keyed by the same `{pluginId}.{descriptor.id}` namespace
+        // used by the eager descriptor table. Binding an impl whose id wasn't
+        // declared in `contributes.forgeProviders` produces an orphaned entry —
+        // unreachable through the routing table, since `listMatchingProviders`
+        // walks descriptors first. Reject up front so the failure is loud.
         const contributionId = descriptor.id;
+        const plugin = this.plugins.get(pluginId);
+        const declared = plugin?.manifest.contributes.forgeProviders.some(
+          (c) => c.id === contributionId
+        );
+        if (!declared) {
+          throw new Error(
+            `Plugin "${pluginId}" registerForgeProvider: descriptor.id "${contributionId}" is not declared in contributes.forgeProviders`
+          );
+        }
+
         registerForgeProviderImpl(pluginId, contributionId, impl);
 
         let disposed = false;
         const dispose = (): void => {
           if (disposed) return;
           disposed = true;
-          unregisterForgeProviderImpl(pluginId, contributionId);
+          // Pass `impl` so a stale disposer (from a prior re-bind that was
+          // overwritten via a second registerForgeProvider call on the same
+          // id) cannot remove the currently-active impl by mistake — the
+          // registry compares identities before deleting.
+          unregisterForgeProviderImpl(pluginId, contributionId, impl);
           const list = this.pluginEventCleanups.get(pluginId);
           if (!list) return;
           const idx = list.indexOf(dispose);

--- a/electron/services/PluginService.ts
+++ b/electron/services/PluginService.ts
@@ -30,7 +30,13 @@ import {
   getAllPluginToolbarButtonConfigs,
 } from "../../shared/config/toolbarButtonRegistry.js";
 import { registerPluginMenuItem, unregisterPluginMenuItems } from "./pluginMenuRegistry.js";
-import { registerForgeProviders, unregisterForgeProviders } from "./forgeProviderRegistry.js";
+import {
+  registerForgeProviderImpl,
+  registerForgeProviders,
+  unregisterForgeProviderImpl,
+  unregisterForgeProviderImpls,
+  unregisterForgeProviders,
+} from "./forgeProviderRegistry.js";
 import { broadcastToRenderer } from "../ipc/utils.js";
 import { CHANNELS } from "../ipc/channels.js";
 import type { LoadedPluginInfo } from "../../shared/types/plugin.js";
@@ -528,6 +534,50 @@ export class PluginService {
           disposeRemove();
         };
       },
+      registerForgeProvider: (descriptor, impl) => {
+        if (revoked) {
+          throw new Error(
+            `Plugin "${pluginId}" host revoked: registerForgeProvider called after activate() returned or timed out`
+          );
+        }
+        if (!descriptor || typeof descriptor !== "object") {
+          throw new Error(
+            `Plugin "${pluginId}" registerForgeProvider: descriptor must be an object`
+          );
+        }
+        if (typeof descriptor.id !== "string" || descriptor.id.length === 0) {
+          throw new Error(
+            `Plugin "${pluginId}" registerForgeProvider: descriptor.id must be a non-empty string`
+          );
+        }
+        if (!impl || typeof impl !== "object") {
+          throw new Error(
+            `Plugin "${pluginId}" registerForgeProvider: impl must be an object`
+          );
+        }
+        const contributionId = descriptor.id;
+        registerForgeProviderImpl(pluginId, contributionId, impl);
+
+        let disposed = false;
+        const dispose = (): void => {
+          if (disposed) return;
+          disposed = true;
+          unregisterForgeProviderImpl(pluginId, contributionId);
+          const list = this.pluginEventCleanups.get(pluginId);
+          if (!list) return;
+          const idx = list.indexOf(dispose);
+          if (idx >= 0) list.splice(idx, 1);
+          if (list.length === 0) this.pluginEventCleanups.delete(pluginId);
+        };
+
+        let list = this.pluginEventCleanups.get(pluginId);
+        if (!list) {
+          list = [];
+          this.pluginEventCleanups.set(pluginId, list);
+        }
+        list.push(dispose);
+        return dispose;
+      },
     };
     return {
       host,
@@ -703,6 +753,13 @@ export class PluginService {
     this.scheduleToolbarButtonsBroadcast(true);
     unregisterPluginPanelKinds(pluginId);
     unregisterForgeProviders(pluginId);
+    // Belt-and-suspenders: per-provider disposers pushed onto
+    // pluginEventCleanups by host.registerForgeProvider have already fired in
+    // flushPluginEventCleanups() above, but a direct bulk-clear guards against
+    // any impl entry that wasn't tracked through that path (e.g. a future
+    // re-bind that didn't refresh the disposer slot). The bulk call is
+    // idempotent — already-cleared keys are silent no-ops.
+    unregisterForgeProviderImpls(pluginId);
     this.plugins.delete(pluginId);
   }
 

--- a/electron/services/PluginService.ts
+++ b/electron/services/PluginService.ts
@@ -551,9 +551,7 @@ export class PluginService {
           );
         }
         if (!impl || typeof impl !== "object") {
-          throw new Error(
-            `Plugin "${pluginId}" registerForgeProvider: impl must be an object`
-          );
+          throw new Error(`Plugin "${pluginId}" registerForgeProvider: impl must be an object`);
         }
         // The impl is keyed by the same `{pluginId}.{descriptor.id}` namespace
         // used by the eager descriptor table. Binding an impl whose id wasn't

--- a/electron/services/__tests__/PluginService.test.ts
+++ b/electron/services/__tests__/PluginService.test.ts
@@ -1539,7 +1539,10 @@ describe("createHost (plugin activation API)", () => {
 });
 
 describe("createHost — registerForgeProvider", () => {
-  function forgeManifest(name: string, providerIds: string[] = ["github"]): Record<string, unknown> {
+  function forgeManifest(
+    name: string,
+    providerIds: string[] = ["github"]
+  ): Record<string, unknown> {
     return {
       name,
       version: "1.0.0",
@@ -1583,11 +1586,7 @@ describe("createHost — registerForgeProvider", () => {
     dispose();
     dispose(); // idempotent — only the first call should propagate
     expect(unregisterForgeProviderImpl).toHaveBeenCalledTimes(1);
-    expect(unregisterForgeProviderImpl).toHaveBeenCalledWith(
-      "acme.forge-dispose",
-      "github",
-      impl
-    );
+    expect(unregisterForgeProviderImpl).toHaveBeenCalledWith("acme.forge-dispose", "github", impl);
   });
 
   it("rejects a descriptor missing an id", async () => {
@@ -1654,11 +1653,7 @@ describe("createHost — registerForgeProvider", () => {
     // of this guard is covered in forgeProviderRegistry.test.ts; here we
     // only assert the disposer carries the right identity into the call.
     dispose1();
-    expect(unregisterForgeProviderImpl).toHaveBeenCalledWith(
-      "acme.forge-rebind",
-      "github",
-      impl1
-    );
+    expect(unregisterForgeProviderImpl).toHaveBeenCalledWith("acme.forge-rebind", "github", impl1);
   });
 
   it("unloadPlugin fires unregisterForgeProviderImpls alongside unregisterForgeProviders", async () => {
@@ -1691,11 +1686,7 @@ describe("createHost — registerForgeProvider", () => {
     // The per-provider disposer fires through the pluginEventCleanups flush
     // path during unloadPlugin — independent from the bulk unregisterForgeProviderImpls
     // belt-and-suspenders call.
-    expect(unregisterForgeProviderImpl).toHaveBeenCalledWith(
-      "acme.forge-flush",
-      "github",
-      impl
-    );
+    expect(unregisterForgeProviderImpl).toHaveBeenCalledWith("acme.forge-flush", "github", impl);
   });
 });
 

--- a/electron/services/__tests__/PluginService.test.ts
+++ b/electron/services/__tests__/PluginService.test.ts
@@ -46,6 +46,11 @@ vi.mock("../pluginMenuRegistry.js", () => ({
 vi.mock("../forgeProviderRegistry.js", () => ({
   registerForgeProviders: vi.fn(),
   unregisterForgeProviders: vi.fn(),
+  registerForgeProviderImpl: vi.fn(),
+  unregisterForgeProviderImpl: vi.fn(),
+  unregisterForgeProviderImpls: vi.fn(),
+  getForgeProviderImpl: vi.fn(),
+  clearForgeProviderImplRegistry: vi.fn(),
 }));
 
 import { PluginService } from "../PluginService.js";
@@ -63,7 +68,13 @@ import {
   unregisterPluginToolbarButtons,
 } from "../../../shared/config/toolbarButtonRegistry.js";
 import { registerPluginMenuItem, unregisterPluginMenuItems } from "../pluginMenuRegistry.js";
-import { registerForgeProviders, unregisterForgeProviders } from "../forgeProviderRegistry.js";
+import {
+  registerForgeProviderImpl,
+  registerForgeProviders,
+  unregisterForgeProviderImpl,
+  unregisterForgeProviderImpls,
+  unregisterForgeProviders,
+} from "../forgeProviderRegistry.js";
 import { CHANNELS } from "../../ipc/channels.js";
 
 function makeCtx(pluginId: string, overrides: Partial<PluginIpcContext> = {}): PluginIpcContext {
@@ -1450,6 +1461,7 @@ type CreateHostShape = (pluginId: string) => {
     pluginId: string;
     registerHandler: (channel: string, handler: (...args: unknown[]) => unknown) => void;
     broadcastToRenderer: (channel: string, payload: unknown) => void;
+    registerForgeProvider: (descriptor: { id: string }, impl: unknown) => () => void;
   };
   revoke: () => void;
 };
@@ -1520,6 +1532,103 @@ describe("createHost (plugin activation API)", () => {
       /host revoked: registerHandler/
     );
     expect(() => host.broadcastToRenderer("x", null)).toThrow(/host revoked: broadcastToRenderer/);
+    expect(() => host.registerForgeProvider({ id: "github" }, {})).toThrow(
+      /host revoked: registerForgeProvider/
+    );
+  });
+});
+
+describe("createHost — registerForgeProvider", () => {
+  it("binds the impl via registerForgeProviderImpl with the descriptor id", async () => {
+    await writePlugin("forge-host", { name: "acme.forge-host", version: "1.0.0" });
+    const service = new PluginService(tmpDir);
+    await service.initialize();
+
+    const { host } = (service as unknown as { createHost: CreateHostShape }).createHost(
+      "acme.forge-host"
+    );
+
+    vi.mocked(registerForgeProviderImpl).mockClear();
+    const impl = { tag: "impl-a" };
+    host.registerForgeProvider({ id: "github" }, impl);
+    expect(registerForgeProviderImpl).toHaveBeenCalledWith("acme.forge-host", "github", impl);
+  });
+
+  it("returns a disposer that calls unregisterForgeProviderImpl exactly once", async () => {
+    await writePlugin("forge-dispose", { name: "acme.forge-dispose", version: "1.0.0" });
+    const service = new PluginService(tmpDir);
+    await service.initialize();
+
+    const { host } = (service as unknown as { createHost: CreateHostShape }).createHost(
+      "acme.forge-dispose"
+    );
+
+    vi.mocked(unregisterForgeProviderImpl).mockClear();
+    const dispose = host.registerForgeProvider({ id: "github" }, { tag: "impl" });
+    dispose();
+    dispose(); // idempotent — only the first call should propagate
+    expect(unregisterForgeProviderImpl).toHaveBeenCalledTimes(1);
+    expect(unregisterForgeProviderImpl).toHaveBeenCalledWith("acme.forge-dispose", "github");
+  });
+
+  it("rejects a descriptor missing an id", async () => {
+    await writePlugin("forge-baddesc", { name: "acme.forge-baddesc", version: "1.0.0" });
+    const service = new PluginService(tmpDir);
+    await service.initialize();
+
+    const { host } = (service as unknown as { createHost: CreateHostShape }).createHost(
+      "acme.forge-baddesc"
+    );
+
+    expect(() =>
+      host.registerForgeProvider({} as unknown as { id: string }, { tag: "impl" })
+    ).toThrow(/descriptor.id must be a non-empty string/);
+  });
+
+  it("rejects a non-object impl", async () => {
+    await writePlugin("forge-badimpl", { name: "acme.forge-badimpl", version: "1.0.0" });
+    const service = new PluginService(tmpDir);
+    await service.initialize();
+
+    const { host } = (service as unknown as { createHost: CreateHostShape }).createHost(
+      "acme.forge-badimpl"
+    );
+
+    expect(() => host.registerForgeProvider({ id: "github" }, null)).toThrow(
+      /impl must be an object/
+    );
+  });
+
+  it("unloadPlugin fires unregisterForgeProviderImpls alongside unregisterForgeProviders", async () => {
+    await writePlugin("forge-unload", { name: "acme.forge-unload", version: "1.0.0" });
+    const service = new PluginService(tmpDir);
+    await service.initialize();
+
+    vi.mocked(unregisterForgeProviderImpls).mockClear();
+    vi.mocked(unregisterForgeProviders).mockClear();
+
+    service.unloadPlugin("acme.forge-unload");
+
+    expect(unregisterForgeProviders).toHaveBeenCalledWith("acme.forge-unload");
+    expect(unregisterForgeProviderImpls).toHaveBeenCalledWith("acme.forge-unload");
+  });
+
+  it("unloadPlugin flushes per-provider disposers from pluginEventCleanups", async () => {
+    await writePlugin("forge-flush", { name: "acme.forge-flush", version: "1.0.0" });
+    const service = new PluginService(tmpDir);
+    await service.initialize();
+
+    const { host } = (service as unknown as { createHost: CreateHostShape }).createHost(
+      "acme.forge-flush"
+    );
+    host.registerForgeProvider({ id: "github" }, { tag: "impl" });
+
+    vi.mocked(unregisterForgeProviderImpl).mockClear();
+    service.unloadPlugin("acme.forge-flush");
+    // The per-provider disposer fires through the pluginEventCleanups flush
+    // path during unloadPlugin — independent from the bulk unregisterForgeProviderImpls
+    // belt-and-suspenders call.
+    expect(unregisterForgeProviderImpl).toHaveBeenCalledWith("acme.forge-flush", "github");
   });
 });
 
@@ -2225,20 +2334,26 @@ describe("Plugin worktree host API", () => {
       "id",
       "isCurrent",
       "isMainWorktree",
-      "issueNumber",
-      "issueTitle",
       "lastActivityTimestamp",
+      "linked",
       "mood",
       "name",
       "path",
-      "prNumber",
-      "prState",
-      "prTitle",
-      "prUrl",
       "worktreeId",
     ];
     expect(Object.keys(active).sort()).toEqual(expected);
     expect("_secret" in active).toBe(false);
+    // None of the removed GitHub-shaped fields should leak through.
+    for (const removed of [
+      "issueNumber",
+      "issueTitle",
+      "prNumber",
+      "prState",
+      "prTitle",
+      "prUrl",
+    ]) {
+      expect(removed in active).toBe(false);
+    }
   });
 });
 

--- a/electron/services/__tests__/PluginService.test.ts
+++ b/electron/services/__tests__/PluginService.test.ts
@@ -1539,8 +1539,22 @@ describe("createHost (plugin activation API)", () => {
 });
 
 describe("createHost — registerForgeProvider", () => {
+  function forgeManifest(name: string, providerIds: string[] = ["github"]): Record<string, unknown> {
+    return {
+      name,
+      version: "1.0.0",
+      contributes: {
+        forgeProviders: providerIds.map((id) => ({
+          id,
+          name: id,
+          matches: [`${id}.example`],
+        })),
+      },
+    };
+  }
+
   it("binds the impl via registerForgeProviderImpl with the descriptor id", async () => {
-    await writePlugin("forge-host", { name: "acme.forge-host", version: "1.0.0" });
+    await writePlugin("forge-host", forgeManifest("acme.forge-host"));
     const service = new PluginService(tmpDir);
     await service.initialize();
 
@@ -1555,7 +1569,7 @@ describe("createHost — registerForgeProvider", () => {
   });
 
   it("returns a disposer that calls unregisterForgeProviderImpl exactly once", async () => {
-    await writePlugin("forge-dispose", { name: "acme.forge-dispose", version: "1.0.0" });
+    await writePlugin("forge-dispose", forgeManifest("acme.forge-dispose"));
     const service = new PluginService(tmpDir);
     await service.initialize();
 
@@ -1564,15 +1578,20 @@ describe("createHost — registerForgeProvider", () => {
     );
 
     vi.mocked(unregisterForgeProviderImpl).mockClear();
-    const dispose = host.registerForgeProvider({ id: "github" }, { tag: "impl" });
+    const impl = { tag: "impl" };
+    const dispose = host.registerForgeProvider({ id: "github" }, impl);
     dispose();
     dispose(); // idempotent — only the first call should propagate
     expect(unregisterForgeProviderImpl).toHaveBeenCalledTimes(1);
-    expect(unregisterForgeProviderImpl).toHaveBeenCalledWith("acme.forge-dispose", "github");
+    expect(unregisterForgeProviderImpl).toHaveBeenCalledWith(
+      "acme.forge-dispose",
+      "github",
+      impl
+    );
   });
 
   it("rejects a descriptor missing an id", async () => {
-    await writePlugin("forge-baddesc", { name: "acme.forge-baddesc", version: "1.0.0" });
+    await writePlugin("forge-baddesc", forgeManifest("acme.forge-baddesc"));
     const service = new PluginService(tmpDir);
     await service.initialize();
 
@@ -1586,7 +1605,7 @@ describe("createHost — registerForgeProvider", () => {
   });
 
   it("rejects a non-object impl", async () => {
-    await writePlugin("forge-badimpl", { name: "acme.forge-badimpl", version: "1.0.0" });
+    await writePlugin("forge-badimpl", forgeManifest("acme.forge-badimpl"));
     const service = new PluginService(tmpDir);
     await service.initialize();
 
@@ -1599,8 +1618,51 @@ describe("createHost — registerForgeProvider", () => {
     );
   });
 
+  it("rejects a descriptor.id not declared in contributes.forgeProviders", async () => {
+    // Manifest declares only "github"; "bogus" must be rejected.
+    await writePlugin("forge-undeclared", forgeManifest("acme.forge-undeclared", ["github"]));
+    const service = new PluginService(tmpDir);
+    await service.initialize();
+
+    const { host } = (service as unknown as { createHost: CreateHostShape }).createHost(
+      "acme.forge-undeclared"
+    );
+
+    expect(() => host.registerForgeProvider({ id: "bogus" }, { tag: "impl" })).toThrow(
+      /not declared in contributes.forgeProviders/
+    );
+  });
+
+  it("re-binding the same descriptor.id makes the older disposer inert", async () => {
+    await writePlugin("forge-rebind", forgeManifest("acme.forge-rebind"));
+    const service = new PluginService(tmpDir);
+    await service.initialize();
+
+    const { host } = (service as unknown as { createHost: CreateHostShape }).createHost(
+      "acme.forge-rebind"
+    );
+
+    vi.mocked(unregisterForgeProviderImpl).mockClear();
+
+    const impl1 = { tag: "first" };
+    const impl2 = { tag: "second" };
+    const dispose1 = host.registerForgeProvider({ id: "github" }, impl1);
+    host.registerForgeProvider({ id: "github" }, impl2);
+
+    // Calling the older disposer must pass the older impl so the registry
+    // can decline to clear an already-overwritten entry. The registry side
+    // of this guard is covered in forgeProviderRegistry.test.ts; here we
+    // only assert the disposer carries the right identity into the call.
+    dispose1();
+    expect(unregisterForgeProviderImpl).toHaveBeenCalledWith(
+      "acme.forge-rebind",
+      "github",
+      impl1
+    );
+  });
+
   it("unloadPlugin fires unregisterForgeProviderImpls alongside unregisterForgeProviders", async () => {
-    await writePlugin("forge-unload", { name: "acme.forge-unload", version: "1.0.0" });
+    await writePlugin("forge-unload", forgeManifest("acme.forge-unload"));
     const service = new PluginService(tmpDir);
     await service.initialize();
 
@@ -1614,21 +1676,26 @@ describe("createHost — registerForgeProvider", () => {
   });
 
   it("unloadPlugin flushes per-provider disposers from pluginEventCleanups", async () => {
-    await writePlugin("forge-flush", { name: "acme.forge-flush", version: "1.0.0" });
+    await writePlugin("forge-flush", forgeManifest("acme.forge-flush"));
     const service = new PluginService(tmpDir);
     await service.initialize();
 
     const { host } = (service as unknown as { createHost: CreateHostShape }).createHost(
       "acme.forge-flush"
     );
-    host.registerForgeProvider({ id: "github" }, { tag: "impl" });
+    const impl = { tag: "impl" };
+    host.registerForgeProvider({ id: "github" }, impl);
 
     vi.mocked(unregisterForgeProviderImpl).mockClear();
     service.unloadPlugin("acme.forge-flush");
     // The per-provider disposer fires through the pluginEventCleanups flush
     // path during unloadPlugin — independent from the bulk unregisterForgeProviderImpls
     // belt-and-suspenders call.
-    expect(unregisterForgeProviderImpl).toHaveBeenCalledWith("acme.forge-flush", "github");
+    expect(unregisterForgeProviderImpl).toHaveBeenCalledWith(
+      "acme.forge-flush",
+      "github",
+      impl
+    );
   });
 });
 

--- a/electron/services/__tests__/forgeProviderRegistry.test.ts
+++ b/electron/services/__tests__/forgeProviderRegistry.test.ts
@@ -372,6 +372,19 @@ describe("forgeProviderRegistry — implementation registry", () => {
     expect(getForgeProviderImpl("acme.gitlab")).toBe(b);
   });
 
+  it("unregisterForgeProviderImpl with expected impl removes only when identity matches", () => {
+    const first = makeImpl("first");
+    const second = makeImpl("second");
+    registerForgeProviderImpl("acme", "github", first);
+    registerForgeProviderImpl("acme", "github", second);
+    // The stale disposer holds `first` but the live entry is `second`.
+    unregisterForgeProviderImpl("acme", "github", first);
+    expect(getForgeProviderImpl("acme.github")).toBe(second);
+    // The fresh disposer holds `second` and matches the live entry.
+    unregisterForgeProviderImpl("acme", "github", second);
+    expect(getForgeProviderImpl("acme.github")).toBeUndefined();
+  });
+
   it("unregisterForgeProviderImpls removes every impl owned by the plugin", () => {
     registerForgeProviderImpl("acme", "github", makeImpl("g"));
     registerForgeProviderImpl("acme", "gitlab", makeImpl("l"));

--- a/electron/services/__tests__/forgeProviderRegistry.test.ts
+++ b/electron/services/__tests__/forgeProviderRegistry.test.ts
@@ -1,17 +1,53 @@
 import { beforeEach, describe, expect, it } from "vitest";
-import type { ForgeProviderContribution, RepoRef } from "../../../shared/types/forge.js";
+import type {
+  ForgeProviderContribution,
+  ForgeProviderImpl,
+  RepoRef,
+} from "../../../shared/types/forge.js";
 import {
+  clearForgeProviderImplRegistry,
   clearForgeProviderRegistry,
   getActiveProvider,
+  getForgeProviderImpl,
   getRegisteredForgeProviders,
   listMatchingProviders,
+  registerForgeProviderImpl,
   registerForgeProviders,
+  unregisterForgeProviderImpl,
+  unregisterForgeProviderImpls,
   unregisterForgeProviders,
 } from "../forgeProviderRegistry.js";
 
 beforeEach(() => {
   clearForgeProviderRegistry();
+  clearForgeProviderImplRegistry();
 });
+
+function makeImpl(label: string): ForgeProviderImpl {
+  // Minimal stub — the registry doesn't introspect the impl shape; tests only
+  // need identity to verify the right impl is stored/returned.
+  return {
+    label,
+    getCredentials: async () => null,
+    validateCredentials: async () => ({ valid: false }),
+    parseRemote: () => null,
+    listIssues: async () => ({ items: [], nextCursor: null, hasMore: false }),
+    listPRs: async () => ({ items: [], nextCursor: null, hasMore: false }),
+    getIssue: async () => null,
+    getPR: async () => null,
+    findPRByBranch: async () => null,
+    getCIStatus: async () => null,
+    getRepoMetadata: async () => ({
+      defaultBranch: "main",
+      isPrivate: false,
+      isFork: false,
+      isArchived: false,
+      rawData: null,
+    }),
+    buildIssueUrl: () => "",
+    buildPRUrl: () => "",
+  } as unknown as ForgeProviderImpl;
+}
 
 function makeContribution(
   id: string,
@@ -296,5 +332,97 @@ describe("forgeProviderRegistry — getActiveProvider", () => {
     registerForgeProviders("acme.github", [makeContribution("github", ["github.com"])]);
     expect(getActiveProvider({ host: "", owner: "", repo: "", rawData: null })).toBeUndefined();
     expect(getActiveProvider(null as unknown as RepoRef)).toBeUndefined();
+  });
+});
+
+describe("forgeProviderRegistry — implementation registry", () => {
+  it("stores and retrieves an impl by namespaced id", () => {
+    const impl = makeImpl("primary");
+    registerForgeProviderImpl("acme", "github", impl);
+    expect(getForgeProviderImpl("acme.github")).toBe(impl);
+  });
+
+  it("uses the bare contribution id when the plugin id is the built-in convention", () => {
+    // The built-in GitHub plugin registers under pluginId "github" with
+    // contributionId "github"; lookup uses the same `${pluginId}.${id}` key.
+    const impl = makeImpl("builtin");
+    registerForgeProviderImpl("github", "github", impl);
+    expect(getForgeProviderImpl("github.github")).toBe(impl);
+  });
+
+  it("returns undefined for an unbound namespaced id", () => {
+    expect(getForgeProviderImpl("acme.github")).toBeUndefined();
+  });
+
+  it("overwrites the impl when re-registered under the same key", () => {
+    const first = makeImpl("first");
+    const second = makeImpl("second");
+    registerForgeProviderImpl("acme", "github", first);
+    registerForgeProviderImpl("acme", "github", second);
+    expect(getForgeProviderImpl("acme.github")).toBe(second);
+  });
+
+  it("unregisterForgeProviderImpl removes only the targeted impl", () => {
+    const a = makeImpl("a");
+    const b = makeImpl("b");
+    registerForgeProviderImpl("acme", "github", a);
+    registerForgeProviderImpl("acme", "gitlab", b);
+    unregisterForgeProviderImpl("acme", "github");
+    expect(getForgeProviderImpl("acme.github")).toBeUndefined();
+    expect(getForgeProviderImpl("acme.gitlab")).toBe(b);
+  });
+
+  it("unregisterForgeProviderImpls removes every impl owned by the plugin", () => {
+    registerForgeProviderImpl("acme", "github", makeImpl("g"));
+    registerForgeProviderImpl("acme", "gitlab", makeImpl("l"));
+    registerForgeProviderImpl("other", "github", makeImpl("o"));
+    unregisterForgeProviderImpls("acme");
+    expect(getForgeProviderImpl("acme.github")).toBeUndefined();
+    expect(getForgeProviderImpl("acme.gitlab")).toBeUndefined();
+    expect(getForgeProviderImpl("other.github")).toBeDefined();
+  });
+
+  it("double-unregister is a safe no-op", () => {
+    registerForgeProviderImpl("acme", "github", makeImpl("x"));
+    unregisterForgeProviderImpls("acme");
+    expect(() => unregisterForgeProviderImpls("acme")).not.toThrow();
+    expect(() => unregisterForgeProviderImpl("acme", "github")).not.toThrow();
+    expect(getForgeProviderImpl("acme.github")).toBeUndefined();
+  });
+
+  it("ignores empty/non-string plugin or contribution ids on register", () => {
+    registerForgeProviderImpl("", "github", makeImpl("x"));
+    registerForgeProviderImpl("acme", "", makeImpl("x"));
+    registerForgeProviderImpl(undefined as unknown as string, "github", makeImpl("x"));
+    expect(getForgeProviderImpl(".github")).toBeUndefined();
+    expect(getForgeProviderImpl("acme.")).toBeUndefined();
+  });
+
+  it("ignores a non-object impl on register", () => {
+    registerForgeProviderImpl("acme", "github", null as unknown as ForgeProviderImpl);
+    registerForgeProviderImpl("acme", "github", "nope" as unknown as ForgeProviderImpl);
+    expect(getForgeProviderImpl("acme.github")).toBeUndefined();
+  });
+
+  it("clearForgeProviderImplRegistry wipes every entry", () => {
+    registerForgeProviderImpl("acme", "github", makeImpl("g"));
+    registerForgeProviderImpl("acme", "gitlab", makeImpl("l"));
+    clearForgeProviderImplRegistry();
+    expect(getForgeProviderImpl("acme.github")).toBeUndefined();
+    expect(getForgeProviderImpl("acme.gitlab")).toBeUndefined();
+  });
+
+  it("descriptor cleanup and impl cleanup are independent", () => {
+    registerForgeProviders("acme", [makeContribution("github", ["github.com"])]);
+    registerForgeProviderImpl("acme", "github", makeImpl("x"));
+
+    unregisterForgeProviders("acme");
+    // Descriptor gone, impl still present — descriptor-only cleanup must not
+    // touch the impl table (and vice versa).
+    expect(getRegisteredForgeProviders()).toHaveLength(0);
+    expect(getForgeProviderImpl("acme.github")).toBeDefined();
+
+    unregisterForgeProviderImpls("acme");
+    expect(getForgeProviderImpl("acme.github")).toBeUndefined();
   });
 });

--- a/electron/services/forgeProviderRegistry.ts
+++ b/electron/services/forgeProviderRegistry.ts
@@ -1,4 +1,8 @@
-import type { ForgeProviderContribution, RepoRef } from "../../shared/types/forge.js";
+import type {
+  ForgeProviderContribution,
+  ForgeProviderImpl,
+  RepoRef,
+} from "../../shared/types/forge.js";
 
 /**
  * Host-side registry of `forgeProviders` contributions, keyed by pluginId.
@@ -9,10 +13,21 @@ import type { ForgeProviderContribution, RepoRef } from "../../shared/types/forg
  * cascade in `PluginService.unloadPlugin`.
  *
  * The runtime implementation handler (`ForgeProviderImpl`) is wired separately
- * in #8058 via `host.registerForgeProvider`. This registry tracks only the
- * descriptor surface declared in the manifest.
+ * via `host.registerForgeProvider` and stored in
+ * {@link PLUGIN_FORGE_PROVIDER_IMPLS} keyed by namespaced id.
  */
 const PLUGIN_FORGE_PROVIDERS = new Map<string, ForgeProviderContribution[]>();
+
+/**
+ * Runtime implementation handlers bound via `host.registerForgeProvider`.
+ * Keyed by the namespaced provider id `{pluginId}.{contributionId}` so the
+ * router can resolve an impl from a descriptor without a second lookup
+ * (built-in GitHub uses bare `github`). Separate from {@link PLUGIN_FORGE_PROVIDERS}
+ * because descriptors register eagerly from the manifest while impls bind
+ * lazily during `activate()` — callers must handle "descriptor present but
+ * impl not yet bound" by treating an `undefined` result as absent.
+ */
+const PLUGIN_FORGE_PROVIDER_IMPLS = new Map<string, ForgeProviderImpl>();
 
 export interface RegisteredForgeProvider {
   pluginId: string;
@@ -54,6 +69,71 @@ export function unregisterForgeProviders(pluginId: string): void {
 
 export function clearForgeProviderRegistry(): void {
   PLUGIN_FORGE_PROVIDERS.clear();
+}
+
+/**
+ * Bind a runtime {@link ForgeProviderImpl} to a descriptor declared by
+ * `contributes.forgeProviders`. Keyed as `{pluginId}.{contributionId}` so a
+ * later lookup by namespaced id resolves without joining two maps. Re-binding
+ * the same key overwrites — plugins that re-register from a deferred callback
+ * pick up the new impl on next call.
+ */
+export function registerForgeProviderImpl(
+  pluginId: string,
+  contributionId: string,
+  impl: ForgeProviderImpl
+): void {
+  if (typeof pluginId !== "string" || pluginId.length === 0) return;
+  if (typeof contributionId !== "string" || contributionId.length === 0) return;
+  if (impl === null || typeof impl !== "object") return;
+  PLUGIN_FORGE_PROVIDER_IMPLS.set(buildImplKey(pluginId, contributionId), impl);
+}
+
+/**
+ * Unbind a single runtime impl. Silent no-op if the key was never bound.
+ * Used by the per-provider disposer returned from `host.registerForgeProvider`
+ * so a plugin can clean up one binding without unloading itself.
+ */
+export function unregisterForgeProviderImpl(pluginId: string, contributionId: string): void {
+  if (typeof pluginId !== "string" || pluginId.length === 0) return;
+  if (typeof contributionId !== "string" || contributionId.length === 0) return;
+  PLUGIN_FORGE_PROVIDER_IMPLS.delete(buildImplKey(pluginId, contributionId));
+}
+
+/**
+ * Unbind every impl owned by the given plugin. Fires from `unloadPlugin`
+ * alongside descriptor cleanup. Idempotent — calling after the per-provider
+ * disposers have already fired is a safe no-op.
+ */
+export function unregisterForgeProviderImpls(pluginId: string): void {
+  if (typeof pluginId !== "string" || pluginId.length === 0) return;
+  const prefix = `${pluginId}.`;
+  for (const key of [...PLUGIN_FORGE_PROVIDER_IMPLS.keys()]) {
+    if (key.startsWith(prefix)) {
+      PLUGIN_FORGE_PROVIDER_IMPLS.delete(key);
+    }
+  }
+}
+
+/**
+ * Look up a runtime impl by its namespaced id (`{pluginId}.{contributionId}`,
+ * or bare `github` for the built-in). Returns `undefined` when the descriptor
+ * is registered but the plugin's `activate()` has not yet bound an impl, or
+ * after the plugin unloads. Callers must treat `undefined` as "no impl
+ * currently available" and avoid throwing.
+ */
+export function getForgeProviderImpl(namespacedId: string): ForgeProviderImpl | undefined {
+  if (typeof namespacedId !== "string" || namespacedId.length === 0) return undefined;
+  return PLUGIN_FORGE_PROVIDER_IMPLS.get(namespacedId);
+}
+
+/** Test-isolation helper paralleling {@link clearForgeProviderRegistry}. */
+export function clearForgeProviderImplRegistry(): void {
+  PLUGIN_FORGE_PROVIDER_IMPLS.clear();
+}
+
+function buildImplKey(pluginId: string, contributionId: string): string {
+  return `${pluginId}.${contributionId}`;
 }
 
 export function getRegisteredForgeProviders(): RegisteredForgeProvider[] {

--- a/electron/services/forgeProviderRegistry.ts
+++ b/electron/services/forgeProviderRegistry.ts
@@ -93,11 +93,25 @@ export function registerForgeProviderImpl(
  * Unbind a single runtime impl. Silent no-op if the key was never bound.
  * Used by the per-provider disposer returned from `host.registerForgeProvider`
  * so a plugin can clean up one binding without unloading itself.
+ *
+ * Pass `expected` to make the removal conditional — the entry is deleted only
+ * if it currently references that exact impl. This prevents a stale disposer
+ * (from a prior `registerForgeProviderImpl` call on the same key that was
+ * later overwritten) from removing the active impl.
  */
-export function unregisterForgeProviderImpl(pluginId: string, contributionId: string): void {
+export function unregisterForgeProviderImpl(
+  pluginId: string,
+  contributionId: string,
+  expected?: ForgeProviderImpl
+): void {
   if (typeof pluginId !== "string" || pluginId.length === 0) return;
   if (typeof contributionId !== "string" || contributionId.length === 0) return;
-  PLUGIN_FORGE_PROVIDER_IMPLS.delete(buildImplKey(pluginId, contributionId));
+  const key = buildImplKey(pluginId, contributionId);
+  if (expected !== undefined) {
+    const current = PLUGIN_FORGE_PROVIDER_IMPLS.get(key);
+    if (current !== expected) return;
+  }
+  PLUGIN_FORGE_PROVIDER_IMPLS.delete(key);
 }
 
 /**

--- a/shared/types/plugin.ts
+++ b/shared/types/plugin.ts
@@ -1,4 +1,10 @@
-import type { ForgeProviderContribution } from "./forge.js";
+import type {
+  ForgeProviderContribution,
+  ForgeProviderDescriptor,
+  ForgeProviderImpl,
+  NormalizedPRState,
+  ResourceRef,
+} from "./forge.js";
 
 export interface PanelContribution {
   id: string;
@@ -123,6 +129,31 @@ export type PluginIpcHandler = (
 ) => unknown | Promise<unknown>;
 
 /**
+ * Provider-agnostic projection of a worktree's linked forge resources (issue
+ * and/or PR), exposed on {@link PluginWorktreeSnapshot.linked}. Replaces the
+ * GitHub-shaped flat fields that previously leaked onto the snapshot —
+ * plugins consuming linkage now route through a provider id and the shared
+ * {@link ResourceRef} shape.
+ */
+export interface PluginWorktreeLinkedIssue {
+  readonly ref: ResourceRef;
+  readonly title?: string;
+}
+
+export interface PluginWorktreeLinkedPR {
+  readonly ref: ResourceRef;
+  readonly title?: string;
+  readonly url: string;
+  readonly state: NormalizedPRState;
+}
+
+export interface PluginWorktreeLinked {
+  readonly providerId: string;
+  readonly issue?: PluginWorktreeLinkedIssue;
+  readonly pr?: PluginWorktreeLinkedPR;
+}
+
+/**
  * Read-only, deep-frozen projection of a worktree exposed to plugins.
  * This is an explicit allowlist of fields from the internal WorktreeSnapshot;
  * do not add fields by spreading — every field must be intentionally exposed
@@ -138,12 +169,13 @@ export interface PluginWorktreeSnapshot {
   readonly isMainWorktree?: boolean;
   readonly aheadCount?: number;
   readonly behindCount?: number;
-  readonly issueNumber?: number;
-  readonly issueTitle?: string;
-  readonly prNumber?: number;
-  readonly prUrl?: string;
-  readonly prState?: "open" | "merged" | "closed";
-  readonly prTitle?: string;
+  /**
+   * Provider-agnostic projection of the worktree's linked forge resources
+   * (issue and/or PR), or `null` when no resource is linked. Replaces the
+   * removed GitHub-shaped `issueNumber` / `issueTitle` / `prNumber` / `prUrl`
+   * / `prState` / `prTitle` fields.
+   */
+  readonly linked: PluginWorktreeLinked | null;
   readonly mood?: "stable" | "active" | "stale" | "error";
   readonly lastActivityTimestamp?: number | null;
   readonly createdAt?: number;
@@ -178,6 +210,15 @@ export interface PluginHostApi {
    * disposed when the plugin is unloaded.
    */
   onDidChangeWorktrees(callback: (snapshots: PluginWorktreeSnapshot[]) => void): () => void;
+  /**
+   * Bind a runtime {@link ForgeProviderImpl} to the descriptor declared in
+   * `contributes.forgeProviders`. The descriptor's `id` is namespaced to the
+   * plugin at runtime as `{pluginId}.{descriptor.id}`. Returns a disposer that
+   * unbinds the single implementation; all bindings are automatically removed
+   * when the plugin is unloaded. Must be called during `activate()` — the
+   * host is revoked once activation resolves or times out.
+   */
+  registerForgeProvider(descriptor: ForgeProviderDescriptor, impl: ForgeProviderImpl): () => void;
 }
 
 export type PluginActivate = (

--- a/shared/types/plugin.ts
+++ b/shared/types/plugin.ts
@@ -217,6 +217,13 @@ export interface PluginHostApi {
    * unbinds the single implementation; all bindings are automatically removed
    * when the plugin is unloaded. Must be called during `activate()` — the
    * host is revoked once activation resolves or times out.
+   *
+   * The `descriptor.id` must match an entry declared in
+   * `contributes.forgeProviders`; an undeclared id is rejected so the impl
+   * cannot drift away from the manifest-driven routing table. Calling this
+   * method twice with the same `descriptor.id` overwrites the prior binding;
+   * the older disposer becomes inert and will not remove the newer impl when
+   * later invoked.
    */
   registerForgeProvider(descriptor: ForgeProviderDescriptor, impl: ForgeProviderImpl): () => void;
 }

--- a/shared/utils/__tests__/pluginWorktreeSnapshot.test.ts
+++ b/shared/utils/__tests__/pluginWorktreeSnapshot.test.ts
@@ -1,0 +1,170 @@
+import { describe, expect, it } from "vitest";
+import { toPluginWorktreeSnapshot } from "../pluginWorktreeSnapshot.js";
+import type { WorktreeSnapshot } from "../../types/workspace-host.js";
+
+function makeSnapshot(extra: Partial<WorktreeSnapshot> = {}): WorktreeSnapshot {
+  return {
+    id: "wt-1",
+    worktreeId: "wt-1",
+    path: "/repo/feature-x",
+    name: "feature-x",
+    isCurrent: false,
+    ...extra,
+  };
+}
+
+describe("toPluginWorktreeSnapshot — linked projection", () => {
+  it("yields linked: null when neither issueNumber nor prNumber is present", () => {
+    const out = toPluginWorktreeSnapshot(makeSnapshot());
+    expect(out.linked).toBeNull();
+  });
+
+  it("populates linked.pr from prNumber/prUrl/prState/prTitle", () => {
+    const out = toPluginWorktreeSnapshot(
+      makeSnapshot({
+        prNumber: 42,
+        prUrl: "https://github.com/o/r/pull/42",
+        prState: "open",
+        prTitle: "Fix the thing",
+      })
+    );
+    expect(out.linked).not.toBeNull();
+    expect(out.linked?.providerId).toBe("github");
+    expect(out.linked?.pr).toEqual({
+      ref: {
+        providerId: "github",
+        owner: "",
+        repo: "",
+        number: 42,
+        rawData: null,
+      },
+      title: "Fix the thing",
+      url: "https://github.com/o/r/pull/42",
+      state: "open",
+    });
+    expect(out.linked?.issue).toBeUndefined();
+  });
+
+  it("populates linked.issue from issueNumber/issueTitle", () => {
+    const out = toPluginWorktreeSnapshot(
+      makeSnapshot({ issueNumber: 7, issueTitle: "Bug report" })
+    );
+    expect(out.linked?.providerId).toBe("github");
+    expect(out.linked?.issue).toEqual({
+      ref: {
+        providerId: "github",
+        owner: "",
+        repo: "",
+        number: 7,
+        rawData: null,
+      },
+      title: "Bug report",
+    });
+    expect(out.linked?.pr).toBeUndefined();
+  });
+
+  it("populates both arms when both PR and issue are linked", () => {
+    const out = toPluginWorktreeSnapshot(
+      makeSnapshot({
+        prNumber: 42,
+        prUrl: "https://github.com/o/r/pull/42",
+        prState: "merged",
+        issueNumber: 7,
+      })
+    );
+    expect(out.linked?.pr?.ref.number).toBe(42);
+    expect(out.linked?.pr?.state).toBe("merged");
+    expect(out.linked?.issue?.ref.number).toBe(7);
+  });
+
+  it("maps the three WorktreeSnapshot prState values through directly", () => {
+    const open = toPluginWorktreeSnapshot(makeSnapshot({ prNumber: 1, prState: "open" }));
+    expect(open.linked?.pr?.state).toBe("open");
+
+    const merged = toPluginWorktreeSnapshot(makeSnapshot({ prNumber: 1, prState: "merged" }));
+    expect(merged.linked?.pr?.state).toBe("merged");
+
+    const closed = toPluginWorktreeSnapshot(makeSnapshot({ prNumber: 1, prState: "closed" }));
+    expect(closed.linked?.pr?.state).toBe("closed");
+  });
+
+  it("defaults missing prUrl to an empty string and missing prState to open", () => {
+    const out = toPluginWorktreeSnapshot(makeSnapshot({ prNumber: 99 }));
+    expect(out.linked?.pr?.url).toBe("");
+    expect(out.linked?.pr?.state).toBe("open");
+    expect(out.linked?.pr?.title).toBeUndefined();
+  });
+
+  it("freezes the snapshot, the linked object, and the linked refs", () => {
+    const out = toPluginWorktreeSnapshot(
+      makeSnapshot({
+        prNumber: 1,
+        prUrl: "u",
+        prState: "open",
+        issueNumber: 2,
+      })
+    );
+    expect(Object.isFrozen(out)).toBe(true);
+    expect(Object.isFrozen(out.linked)).toBe(true);
+    expect(Object.isFrozen(out.linked?.pr)).toBe(true);
+    expect(Object.isFrozen(out.linked?.pr?.ref)).toBe(true);
+    expect(Object.isFrozen(out.linked?.issue)).toBe(true);
+    expect(Object.isFrozen(out.linked?.issue?.ref)).toBe(true);
+  });
+
+  it("does not surface the removed GitHub-shaped flat fields on the output", () => {
+    const out = toPluginWorktreeSnapshot(
+      makeSnapshot({
+        prNumber: 1,
+        prUrl: "u",
+        prState: "open",
+        prTitle: "t",
+        issueNumber: 2,
+        issueTitle: "i",
+      })
+    );
+    // The removed fields are no longer keys on the projection — even though
+    // the source carries them, they must not leak out.
+    expect(Object.keys(out)).not.toContain("issueNumber");
+    expect(Object.keys(out)).not.toContain("issueTitle");
+    expect(Object.keys(out)).not.toContain("prNumber");
+    expect(Object.keys(out)).not.toContain("prUrl");
+    expect(Object.keys(out)).not.toContain("prState");
+    expect(Object.keys(out)).not.toContain("prTitle");
+  });
+
+  it("preserves the non-linkage allowlist fields", () => {
+    const out = toPluginWorktreeSnapshot(
+      makeSnapshot({
+        id: "wt-2",
+        worktreeId: "wt-2",
+        path: "/repo/other",
+        name: "other",
+        isCurrent: true,
+        branch: "feature-x",
+        isMainWorktree: false,
+        aheadCount: 3,
+        behindCount: 1,
+        mood: "active",
+        lastActivityTimestamp: 1234,
+        createdAt: 5678,
+      })
+    );
+    expect(out.id).toBe("wt-2");
+    expect(out.path).toBe("/repo/other");
+    expect(out.name).toBe("other");
+    expect(out.isCurrent).toBe(true);
+    expect(out.branch).toBe("feature-x");
+    expect(out.isMainWorktree).toBe(false);
+    expect(out.aheadCount).toBe(3);
+    expect(out.behindCount).toBe(1);
+    expect(out.mood).toBe("active");
+    expect(out.lastActivityTimestamp).toBe(1234);
+    expect(out.createdAt).toBe(5678);
+  });
+
+  it("defaults lastActivityTimestamp to null when source omits it", () => {
+    const out = toPluginWorktreeSnapshot(makeSnapshot());
+    expect(out.lastActivityTimestamp).toBeNull();
+  });
+});

--- a/shared/utils/__tests__/pluginWorktreeSnapshot.test.ts
+++ b/shared/utils/__tests__/pluginWorktreeSnapshot.test.ts
@@ -77,6 +77,21 @@ describe("toPluginWorktreeSnapshot — linked projection", () => {
     expect(out.linked?.issue?.ref.number).toBe(7);
   });
 
+  it("uses the same providerId on linked, linked.pr.ref, and linked.issue.ref", () => {
+    const out = toPluginWorktreeSnapshot(
+      makeSnapshot({
+        prNumber: 42,
+        prUrl: "u",
+        prState: "open",
+        issueNumber: 7,
+      })
+    );
+    const providerId = out.linked?.providerId;
+    expect(providerId).toBe("github");
+    expect(out.linked?.pr?.ref.providerId).toBe(providerId);
+    expect(out.linked?.issue?.ref.providerId).toBe(providerId);
+  });
+
   it("maps the three WorktreeSnapshot prState values through directly", () => {
     const open = toPluginWorktreeSnapshot(makeSnapshot({ prNumber: 1, prState: "open" }));
     expect(open.linked?.pr?.state).toBe("open");

--- a/shared/utils/pluginWorktreeSnapshot.ts
+++ b/shared/utils/pluginWorktreeSnapshot.ts
@@ -1,4 +1,10 @@
-import type { PluginWorktreeSnapshot } from "../types/plugin.js";
+import type {
+  PluginWorktreeLinked,
+  PluginWorktreeLinkedIssue,
+  PluginWorktreeLinkedPR,
+  PluginWorktreeSnapshot,
+} from "../types/plugin.js";
+import type { NormalizedPRState, ResourceRef } from "../types/forge.js";
 import type { WorktreeSnapshot } from "../types/workspace-host.js";
 
 /**
@@ -19,15 +25,66 @@ export function toPluginWorktreeSnapshot(snapshot: WorktreeSnapshot): PluginWork
     isMainWorktree: snapshot.isMainWorktree,
     aheadCount: snapshot.aheadCount,
     behindCount: snapshot.behindCount,
-    issueNumber: snapshot.issueNumber,
-    issueTitle: snapshot.issueTitle,
-    prNumber: snapshot.prNumber,
-    prUrl: snapshot.prUrl,
-    prState: snapshot.prState,
-    prTitle: snapshot.prTitle,
+    linked: buildLinkedProjection(snapshot),
     mood: snapshot.mood,
     lastActivityTimestamp: snapshot.lastActivityTimestamp ?? null,
     createdAt: snapshot.createdAt,
   };
   return Object.freeze(projection);
+}
+
+/**
+ * Synthesize the provider-agnostic `linked` projection from the internal
+ * snapshot's flat GitHub-shaped fields. Returns `null` when neither an issue
+ * nor a PR is linked. Provider id is hardcoded to `"github"` because the only
+ * forge currently writing these fields is the built-in GitHub integration.
+ *
+ * TODO(forge-abstraction): when `PRIntegrationService` is rewritten against
+ * the {@link ForgeProviderImpl} contract, the synthesized {@link ResourceRef}
+ * will be replaced with one carrying populated `owner`/`repo` — they're empty
+ * here because `WorktreeSnapshot` does not currently carry repo identity.
+ */
+function buildLinkedProjection(snapshot: WorktreeSnapshot): PluginWorktreeLinked | null {
+  const hasPR = typeof snapshot.prNumber === "number";
+  const hasIssue = typeof snapshot.issueNumber === "number";
+  if (!hasPR && !hasIssue) return null;
+
+  const providerId = "github";
+  const linked: { providerId: string; issue?: PluginWorktreeLinkedIssue; pr?: PluginWorktreeLinkedPR } = {
+    providerId,
+  };
+
+  if (hasIssue) {
+    const issueRef: ResourceRef = {
+      providerId,
+      owner: "",
+      repo: "",
+      number: snapshot.issueNumber as number,
+      rawData: null,
+    };
+    linked.issue = Object.freeze({
+      ref: Object.freeze(issueRef),
+      title: snapshot.issueTitle,
+    });
+  }
+
+  if (hasPR) {
+    const prRef: ResourceRef = {
+      providerId,
+      owner: "",
+      repo: "",
+      number: snapshot.prNumber as number,
+      rawData: null,
+    };
+    // WorktreeSnapshot.prState ("open" | "merged" | "closed") is a strict
+    // subtype of NormalizedPRState (adds "declined"); a direct cast is safe.
+    linked.pr = Object.freeze({
+      ref: Object.freeze(prRef),
+      title: snapshot.prTitle,
+      url: snapshot.prUrl ?? "",
+      state: (snapshot.prState ?? "open") as NormalizedPRState,
+    });
+  }
+
+  return Object.freeze(linked);
 }

--- a/shared/utils/pluginWorktreeSnapshot.ts
+++ b/shared/utils/pluginWorktreeSnapshot.ts
@@ -50,7 +50,11 @@ function buildLinkedProjection(snapshot: WorktreeSnapshot): PluginWorktreeLinked
   if (!hasPR && !hasIssue) return null;
 
   const providerId = "github";
-  const linked: { providerId: string; issue?: PluginWorktreeLinkedIssue; pr?: PluginWorktreeLinkedPR } = {
+  const linked: {
+    providerId: string;
+    issue?: PluginWorktreeLinkedIssue;
+    pr?: PluginWorktreeLinkedPR;
+  } = {
     providerId,
   };
 


### PR DESCRIPTION
## Summary

- Adds `host.registerForgeProvider(descriptor, impl)` to the plugin host API with a revoke guard, manifest-declaration check, and per-provider disposer tracked via `pluginEventCleanups`.
- Extends `forgeProviderRegistry.ts` with an impl-binding map keyed `{pluginId}.{contributionId}` and 5 new exports: `registerForgeProviderImpl`, `unregisterForgeProviderImpl` (with optional identity-check), `unregisterForgeProviderImpls`, `getForgeProviderImpl`, `clearForgeProviderImplRegistry`.
- Replaces 6 flat GitHub-shaped fields (`issueNumber`, `issueTitle`, `prNumber`, `prUrl`, `prState`, `prTitle`) on `PluginWorktreeSnapshot` with a provider-agnostic `linked: PluginWorktreeLinked | null` field. `linked` is synthesized from the existing internal flat fields, with `providerId` hardcoded as `"github"` for now (TODO comment left for the `PRIntegrationService` rewrite).

Resolves #8058

## Breaking change

Plugins using the 6 removed snapshot fields must migrate to `linked`. The change is pre-1.0 and gated by `engines.daintree`.

## Changes

- `electron/services/PluginService.ts` -- `registerForgeProvider` host method, revoke guard, disposer tracking
- `electron/services/forgeProviderRegistry.ts` -- impl-binding map, 5 new exports
- `shared/types/plugin.ts` -- `PluginWorktreeLinked` type, `linked` field on `PluginWorktreeSnapshot`, removed 6 flat fields
- `shared/utils/pluginWorktreeSnapshot.ts` -- `toPluginWorktreeSnapshot` synthesizes `linked` from internal flat fields

## Testing

230 vitest tests pass. 18 new tests cover the impl registry, `linked` projection, `registerForgeProvider` host API, and lifecycle edge cases (revoke guard, duplicate registration, identity-check on unregister).