### PR TITLE
feat(forge): per-project forge provider override setting

### DIFF
--- a/electron/ipc/channels.ts
+++ b/electron/ipc/channels.ts
@@ -685,6 +685,7 @@ export const CHANNELS = {
   PLUGIN_ACTIONS_REGISTER: "plugin:actions-register",
   PLUGIN_ACTIONS_UNREGISTER: "plugin:actions-unregister",
   PLUGIN_PANEL_KINDS_GET: "plugin:panel-kinds-get",
+  PLUGIN_FORGE_PROVIDERS_GET: "plugin:forge-providers-get",
 
   // Config reload channels
   APP_RELOAD_CONFIG: "app:reload-config",

--- a/electron/ipc/handlers/__tests__/plugin.handlers.test.ts
+++ b/electron/ipc/handlers/__tests__/plugin.handlers.test.ts
@@ -32,6 +32,11 @@ vi.mock("../../../services/pluginMenuRegistry.js", () => ({
   getPluginMenuItems: (...args: unknown[]) => mockGetPluginMenuItems(...args),
 }));
 
+const mockGetRegisteredForgeProviders = vi.fn();
+vi.mock("../../../services/forgeProviderRegistry.js", () => ({
+  getRegisteredForgeProviders: (...args: unknown[]) => mockGetRegisteredForgeProviders(...args),
+}));
+
 const mockIpcMainHandle = vi.fn();
 const mockIpcMainRemoveHandler = vi.fn();
 vi.mock("electron", () => ({
@@ -50,6 +55,7 @@ beforeEach(() => {
   mockGetToolbarButtonConfig.mockReturnValue(undefined);
   mockGetPluginMenuItems.mockReturnValue([]);
   mockListPluginActions.mockReturnValue([]);
+  mockGetRegisteredForgeProviders.mockReturnValue([]);
   _resetIpcGuardForTesting();
   markIpcSecurityReady();
 });
@@ -57,7 +63,7 @@ beforeEach(() => {
 describe("registerPluginHandlers", () => {
   it("registers handlers for all plugin channels", () => {
     registerPluginHandlers();
-    expect(mockIpcMainHandle).toHaveBeenCalledTimes(9);
+    expect(mockIpcMainHandle).toHaveBeenCalledTimes(10);
     expect(mockIpcMainHandle).toHaveBeenCalledWith("plugin:list", expect.any(Function));
     expect(mockIpcMainHandle).toHaveBeenCalledWith("plugin:invoke", expect.any(Function));
     expect(mockIpcMainHandle).toHaveBeenCalledWith("plugin:toolbar-buttons", expect.any(Function));
@@ -73,6 +79,10 @@ describe("registerPluginHandlers", () => {
       expect.any(Function)
     );
     expect(mockIpcMainHandle).toHaveBeenCalledWith("plugin:panel-kinds-get", expect.any(Function));
+    expect(mockIpcMainHandle).toHaveBeenCalledWith(
+      "plugin:forge-providers-get",
+      expect.any(Function)
+    );
   });
 
   it("throws before registering any handler when invoked before enforceIpcSenderValidation", () => {
@@ -95,6 +105,7 @@ describe("registerPluginHandlers", () => {
     expect(mockIpcMainRemoveHandler).toHaveBeenCalledWith("plugin:actions-register");
     expect(mockIpcMainRemoveHandler).toHaveBeenCalledWith("plugin:actions-unregister");
     expect(mockIpcMainRemoveHandler).toHaveBeenCalledWith("plugin:panel-kinds-get");
+    expect(mockIpcMainRemoveHandler).toHaveBeenCalledWith("plugin:forge-providers-get");
   });
 
   it("PLUGIN_LIST handler delegates to pluginService.listPlugins", async () => {
@@ -473,6 +484,39 @@ describe("PLUGIN_ACTIONS_GET / REGISTER / UNREGISTER handlers", () => {
       "acme.my-plugin",
       "acme.my-plugin.doThing"
     );
+  });
+});
+
+describe("PLUGIN_FORGE_PROVIDERS_GET handler", () => {
+  function getHandler() {
+    registerPluginHandlers();
+    return mockIpcMainHandle.mock.calls.find(
+      (c: unknown[]) => c[0] === "plugin:forge-providers-get"
+    )![1] as (...args: unknown[]) => unknown;
+  }
+
+  it("returns the list from getRegisteredForgeProviders", async () => {
+    const providers = [
+      {
+        pluginId: "acme.github-plugin",
+        contribution: {
+          id: "github",
+          name: "GitHub",
+          matches: ["github.com"],
+        },
+      },
+    ];
+    mockGetRegisteredForgeProviders.mockReturnValue(providers);
+    const handler = getHandler();
+    const result = await handler({});
+    expect(result).toEqual(providers);
+  });
+
+  it("returns an empty array when no providers are registered", async () => {
+    mockGetRegisteredForgeProviders.mockReturnValue([]);
+    const handler = getHandler();
+    const result = await handler({});
+    expect(result).toEqual([]);
   });
 });
 

--- a/electron/ipc/handlers/plugin.preload.ts
+++ b/electron/ipc/handlers/plugin.preload.ts
@@ -14,6 +14,7 @@ export const PLUGIN_METHOD_CHANNELS = {
   registerAction: "plugin:actions-register",
   unregisterAction: "plugin:actions-unregister",
   getPanelKinds: "plugin:panel-kinds-get",
+  getForgeProviders: "plugin:forge-providers-get",
 } as const satisfies Record<string, keyof IpcInvokeMap>;
 
 type Methods = typeof PLUGIN_METHOD_CHANNELS;

--- a/electron/ipc/handlers/plugin.ts
+++ b/electron/ipc/handlers/plugin.ts
@@ -12,6 +12,10 @@ import {
   type PanelKindConfig,
 } from "../../../shared/config/panelKindRegistry.js";
 import { getPluginMenuItems } from "../../services/pluginMenuRegistry.js";
+import {
+  getRegisteredForgeProviders,
+  type RegisteredForgeProvider,
+} from "../../services/forgeProviderRegistry.js";
 import { isTrustedRendererUrl } from "../../../shared/utils/trustedRenderer.js";
 import type {
   LoadedPluginInfo,
@@ -96,6 +100,10 @@ async function handlePanelKindsGet(): Promise<PanelKindConfig[]> {
   return getPluginPanelKinds();
 }
 
+async function handleForgeProvidersGet(): Promise<RegisteredForgeProvider[]> {
+  return getRegisteredForgeProviders();
+}
+
 export const pluginNamespace = defineIpcNamespace({
   name: "plugin",
   ops: {
@@ -107,6 +115,7 @@ export const pluginNamespace = defineIpcNamespace({
     registerAction: op(PLUGIN_METHOD_CHANNELS.registerAction, handleActionsRegister),
     unregisterAction: op(PLUGIN_METHOD_CHANNELS.unregisterAction, handleActionsUnregister),
     getPanelKinds: op(PLUGIN_METHOD_CHANNELS.getPanelKinds, handlePanelKindsGet),
+    getForgeProviders: op(PLUGIN_METHOD_CHANNELS.getForgeProviders, handleForgeProvidersGet),
   },
 });
 

--- a/electron/services/ProjectSettingsManager.ts
+++ b/electron/services/ProjectSettingsManager.ts
@@ -208,6 +208,12 @@ export class ProjectSettingsManager {
           typeof parsed.worktreePathPattern === "string" && parsed.worktreePathPattern.trim()
             ? parsed.worktreePathPattern.trim()
             : undefined,
+        forgeProviderOverride:
+          typeof parsed.forgeProviderOverride === "string" && parsed.forgeProviderOverride.trim()
+            ? parsed.forgeProviderOverride.trim()
+            : parsed.forgeProviderOverride === null
+              ? null
+              : undefined,
         terminalSettings: parseTerminalSettings(parsed.terminalSettings),
         notificationOverrides: parseNotificationOverrides(parsed.notificationOverrides),
         fleetSavedScopes: parseFleetSavedScopes(parsed.fleetSavedScopes),

--- a/electron/services/__tests__/ProjectSettingsManager.test.ts
+++ b/electron/services/__tests__/ProjectSettingsManager.test.ts
@@ -204,6 +204,49 @@ describe("ProjectSettingsManager caching", () => {
     }
   );
 
+  it("round-trips forgeProviderOverride through save/load", async () => {
+    await manager.saveProjectSettings(projectId, {
+      runCommands: [],
+      forgeProviderOverride: "github",
+    });
+
+    const freshManager = new ProjectSettingsManager(tempDir, createMockStore());
+    const loaded = await freshManager.getProjectSettings(projectId);
+    expect(loaded.forgeProviderOverride).toBe("github");
+  });
+
+  it("treats missing forgeProviderOverride as undefined", async () => {
+    const settingsPath = path.join(tempDir, projectId, "settings.json");
+    await fs.writeFile(settingsPath, JSON.stringify({ runCommands: [] }), "utf-8");
+
+    const loaded = await manager.getProjectSettings(projectId);
+    expect(loaded.forgeProviderOverride).toBeUndefined();
+  });
+
+  it("preserves null forgeProviderOverride from disk as null", async () => {
+    const settingsPath = path.join(tempDir, projectId, "settings.json");
+    await fs.writeFile(
+      settingsPath,
+      JSON.stringify({ runCommands: [], forgeProviderOverride: null }),
+      "utf-8"
+    );
+
+    const loaded = await manager.getProjectSettings(projectId);
+    expect(loaded.forgeProviderOverride).toBeNull();
+  });
+
+  it("rejects non-string forgeProviderOverride values from disk", async () => {
+    const settingsPath = path.join(tempDir, projectId, "settings.json");
+    await fs.writeFile(
+      settingsPath,
+      JSON.stringify({ runCommands: [], forgeProviderOverride: 42 }),
+      "utf-8"
+    );
+
+    const loaded = await manager.getProjectSettings(projectId);
+    expect(loaded.forgeProviderOverride).toBeUndefined();
+  });
+
   it("rejects unknown daintreeMcpTier values from disk", async () => {
     const settingsPath = path.join(tempDir, projectId, "settings.json");
     await fs.writeFile(

--- a/electron/services/forgeProviderRegistry.ts
+++ b/electron/services/forgeProviderRegistry.ts
@@ -1,9 +1,11 @@
 import type {
   ForgeProviderContribution,
-  ForgeProviderEntry,
   ForgeProviderImpl,
+  RegisteredForgeProvider,
   RepoRef,
 } from "../../shared/types/forge.js";
+
+export type { RegisteredForgeProvider } from "../../shared/types/forge.js";
 
 /**
  * Host-side registry of `forgeProviders` contributions, keyed by pluginId.
@@ -29,9 +31,6 @@ const PLUGIN_FORGE_PROVIDERS = new Map<string, ForgeProviderContribution[]>();
  * impl not yet bound" by treating an `undefined` result as absent.
  */
 const PLUGIN_FORGE_PROVIDER_IMPLS = new Map<string, ForgeProviderImpl>();
-
-/** @deprecated Use {@link ForgeProviderEntry} from `shared/types/forge`. */
-export type RegisteredForgeProvider = ForgeProviderEntry;
 
 export function registerForgeProviders(
   pluginId: string,

--- a/shared/types/forge.ts
+++ b/shared/types/forge.ts
@@ -330,6 +330,16 @@ export type ForgeCapabilityHint =
   | (string & {});
 
 /**
+ * Registered forge provider — pairs a manifest contribution with its owning
+ * pluginId. Returned by the host registry's listing functions and exposed to
+ * the renderer via `window.electron.plugin.getForgeProviders()`.
+ */
+export interface RegisteredForgeProvider {
+  pluginId: string;
+  contribution: ForgeProviderContribution;
+}
+
+/**
  * `forgeProviders` manifest entry. Eager (manifest-driven) registration
  * populates the Preferences UI and remote-routing table before any plugin
  * code runs; the implementation handler binds lazily on first use.

--- a/shared/types/ipc/api.ts
+++ b/shared/types/ipc/api.ts
@@ -1428,6 +1428,8 @@ export interface ElectronAPI {
     ): () => void;
     /** Pull the current set of plugin-contributed panel kinds. */
     getPanelKinds(): Promise<import("../../config/panelKindRegistry.js").PanelKindConfig[]>;
+    /** Pull the current set of registered forge providers (pluginId + manifest contribution). */
+    getForgeProviders(): Promise<import("../forge.js").RegisteredForgeProvider[]>;
     /** Subscribe to plugin panel kind registry changes. Returns a cleanup. */
     onPanelKindsChanged(
       callback: (payload: {

--- a/shared/types/ipc/generated.ts
+++ b/shared/types/ipc/generated.ts
@@ -215,6 +215,10 @@ export interface GeneratedIpcInvokeMap {
     args: [pluginId: string, actionId: string];
     result: void;
   };
+  "plugin:forge-providers-get": {
+    args: [];
+    result: import("../forge.js").RegisteredForgeProvider[];
+  };
   "plugin:list": {
     args: [];
     result: import("../plugin.js").LoadedPluginInfo[];

--- a/shared/types/project.ts
+++ b/shared/types/project.ts
@@ -378,6 +378,13 @@ export interface ProjectSettings {
 
   /** Git remote name to use for GitHub integration (defaults to "origin") */
   githubRemote?: string;
+  /**
+   * Pinned forge provider for this project (machine-local). When set, overrides hostname auto-detection
+   * for forge integrations. `null` (or absent) = auto-detect. Stores the bare `contribution.id` of a
+   * provider registered via the forge provider registry. Never written to `.daintree/settings.json` —
+   * machine-local because provider availability depends on installed plugins.
+   */
+  forgeProviderOverride?: string | null;
   /** Per-project worktree path pattern override (uses global default when unset) */
   worktreePathPattern?: string;
   /** Saved fleet scopes for quick arm/recall */

--- a/src/components/Project/GitHubTab.tsx
+++ b/src/components/Project/GitHubTab.tsx
@@ -1,17 +1,30 @@
 import { useState, useEffect } from "react";
 import { formatErrorMessage } from "@shared/utils/errorMessage";
 import type { RemoteInfo } from "@shared/types/ipc/github";
+import type { RegisteredForgeProvider } from "@shared/types/forge";
 
 interface GitHubTabProps {
   githubRemote: string | undefined;
   onGithubRemoteChange: (remote: string | undefined) => void;
+  forgeProviderOverride: string | null;
+  onForgeProviderOverrideChange: (providerId: string | null) => void;
   projectPath: string | undefined;
 }
 
-export function GitHubTab({ githubRemote, onGithubRemoteChange, projectPath }: GitHubTabProps) {
+export function GitHubTab({
+  githubRemote,
+  onGithubRemoteChange,
+  forgeProviderOverride,
+  onForgeProviderOverrideChange,
+  projectPath,
+}: GitHubTabProps) {
   const [remotes, setRemotes] = useState<RemoteInfo[]>([]);
   const [loading, setLoading] = useState(false);
   const [error, setError] = useState<string | null>(null);
+
+  const [providers, setProviders] = useState<RegisteredForgeProvider[]>([]);
+  const [providersLoading, setProvidersLoading] = useState(false);
+  const [providersError, setProvidersError] = useState<string | null>(null);
 
   useEffect(() => {
     if (!projectPath) return;
@@ -40,7 +53,36 @@ export function GitHubTab({ githubRemote, onGithubRemoteChange, projectPath }: G
     };
   }, [projectPath]);
 
+  useEffect(() => {
+    let cancelled = false;
+    setProvidersLoading(true);
+    setProvidersError(null);
+
+    window.electron.plugin
+      .getForgeProviders()
+      .then((result) => {
+        if (!cancelled) {
+          setProviders(result);
+          setProvidersLoading(false);
+        }
+      })
+      .catch((err) => {
+        if (!cancelled) {
+          setProvidersError(formatErrorMessage(err, "Failed to load forge providers"));
+          setProvidersLoading(false);
+        }
+      });
+
+    return () => {
+      cancelled = true;
+    };
+  }, []);
+
   if (!projectPath) return null;
+
+  const savedProviderKnown =
+    forgeProviderOverride === null ||
+    providers.some((p) => p.contribution.id === forgeProviderOverride);
 
   return (
     <div className="space-y-6">
@@ -66,6 +108,36 @@ export function GitHubTab({ githubRemote, onGithubRemoteChange, projectPath }: G
                 {r.parsedRepo ? ` — ${r.parsedRepo.owner}/${r.parsedRepo.repo}` : ""}
               </option>
             ))}
+          </select>
+        )}
+      </div>
+
+      <div>
+        <label className="block text-sm font-medium text-daintree-text mb-1">Forge provider</label>
+        <p className="text-xs text-daintree-text/60 mb-2">
+          Pin this project to a specific forge provider, overriding hostname auto-detection.
+        </p>
+        {providersLoading ? (
+          <div className="text-sm text-daintree-text/60">Loading providers...</div>
+        ) : providersError ? (
+          <div className="text-sm text-status-error">{providersError}</div>
+        ) : (
+          <select
+            value={forgeProviderOverride ?? ""}
+            onChange={(e) =>
+              onForgeProviderOverrideChange(e.target.value === "" ? null : e.target.value)
+            }
+            className="w-full px-3 py-2 bg-daintree-bg border border-daintree-border rounded-[var(--radius-md)] text-sm text-daintree-text focus:outline-hidden focus:ring-2 focus:ring-daintree-accent"
+          >
+            <option value="">Auto-detect</option>
+            {providers.map((p) => (
+              <option key={`${p.pluginId}:${p.contribution.id}`} value={p.contribution.id}>
+                {p.contribution.name}
+              </option>
+            ))}
+            {!savedProviderKnown && forgeProviderOverride !== null ? (
+              <option value={forgeProviderOverride}>{forgeProviderOverride} (unavailable)</option>
+            ) : null}
           </select>
         )}
       </div>

--- a/src/components/Project/__tests__/projectSettingsDirty.test.ts
+++ b/src/components/Project/__tests__/projectSettingsDirty.test.ts
@@ -854,5 +854,118 @@ describe("projectSettingsDirty", () => {
 
       expect(areSnapshotsEqual(snapshotA, snapshotB)).toBe(false);
     });
+
+    it("should detect changed forgeProviderOverride", () => {
+      const snapshotA = createProjectSettingsSnapshot(
+        "Project",
+        "🌲",
+        "npm run dev",
+        undefined,
+        [],
+        [],
+        [],
+        undefined,
+        [],
+        {},
+        "none",
+        "",
+        undefined,
+        undefined,
+        "",
+        undefined,
+        undefined,
+        undefined,
+        undefined,
+        undefined,
+        undefined,
+        true,
+        "off",
+        null
+      );
+      const snapshotB = createProjectSettingsSnapshot(
+        "Project",
+        "🌲",
+        "npm run dev",
+        undefined,
+        [],
+        [],
+        [],
+        undefined,
+        [],
+        {},
+        "none",
+        "",
+        undefined,
+        undefined,
+        "",
+        undefined,
+        undefined,
+        undefined,
+        undefined,
+        undefined,
+        undefined,
+        true,
+        "off",
+        "gitlab"
+      );
+
+      expect(areSnapshotsEqual(snapshotA, snapshotB)).toBe(false);
+    });
+
+    it("should treat null and null forgeProviderOverride as equal", () => {
+      const snapshotA = createProjectSettingsSnapshot(
+        "Project",
+        "🌲",
+        "npm run dev",
+        undefined,
+        [],
+        [],
+        [],
+        undefined,
+        [],
+        {},
+        "none",
+        "",
+        undefined,
+        undefined,
+        "",
+        undefined,
+        undefined,
+        undefined,
+        undefined,
+        undefined,
+        undefined,
+        true,
+        "off",
+        null
+      );
+      const snapshotB = createProjectSettingsSnapshot(
+        "Project",
+        "🌲",
+        "npm run dev",
+        undefined,
+        [],
+        [],
+        [],
+        undefined,
+        [],
+        {},
+        "none",
+        "",
+        undefined,
+        undefined,
+        "",
+        undefined,
+        undefined,
+        undefined,
+        undefined,
+        undefined,
+        undefined,
+        true,
+        "off"
+      );
+
+      expect(areSnapshotsEqual(snapshotA, snapshotB)).toBe(true);
+    });
   });
 });

--- a/src/components/Project/projectSettingsDirty.ts
+++ b/src/components/Project/projectSettingsDirty.ts
@@ -32,6 +32,7 @@ export interface ProjectSettingsSnapshot {
   branchPrefixCustom: string;
 
   githubRemote: string | undefined;
+  forgeProviderOverride: string | null;
   worktreePathPattern: string;
   terminalSettings: ProjectTerminalSettings | undefined;
   notificationOverrides: Partial<NotificationSettings> | undefined;
@@ -79,7 +80,8 @@ export function createProjectSettingsSnapshot(
   activeResourceEnvironment: string | undefined = undefined,
   defaultWorktreeMode: string | undefined = undefined,
   turbopackEnabled: boolean = true,
-  daintreeMcpTier: DaintreeMcpTier = "off"
+  daintreeMcpTier: DaintreeMcpTier = "off",
+  forgeProviderOverride: string | null = null
 ): ProjectSettingsSnapshot {
   const envVarRecord: Record<string, string> = {};
   const seenKeys = new Map<string, number>();
@@ -160,6 +162,7 @@ export function createProjectSettingsSnapshot(
     branchPrefixMode: normalizedMode,
     branchPrefixCustom: normalizedMode === "custom" ? trimmedCustom : "",
     githubRemote,
+    forgeProviderOverride,
     worktreePathPattern: worktreePathPattern.trim(),
     terminalSettings: normalizeTerminalSettings(terminalSettings),
     notificationOverrides: normalizeNotificationOverrides(notificationOverrides),
@@ -289,6 +292,7 @@ export function areSnapshotsEqual(a: ProjectSettingsSnapshot, b: ProjectSettings
   if (a.branchPrefixCustom !== b.branchPrefixCustom) return false;
 
   if (a.githubRemote !== b.githubRemote) return false;
+  if (a.forgeProviderOverride !== b.forgeProviderOverride) return false;
   if (a.worktreePathPattern !== b.worktreePathPattern) return false;
 
   // Terminal settings comparison

--- a/src/components/Settings/SettingsDialog.tsx
+++ b/src/components/Settings/SettingsDialog.tsx
@@ -1019,6 +1019,8 @@ function ProjectFormTabContent({
         <LazyComp
           githubRemote={projectForm.githubRemote}
           onGithubRemoteChange={projectForm.setGithubRemote}
+          forgeProviderOverride={projectForm.forgeProviderOverride}
+          onForgeProviderOverrideChange={projectForm.setForgeProviderOverride}
           projectPath={projectForm.currentProject?.path}
         />
       );

--- a/src/hooks/useProjectSettingsForm.ts
+++ b/src/hooks/useProjectSettingsForm.ts
@@ -70,6 +70,7 @@ export function useProjectSettingsForm({ projectId, isOpen }: UseProjectSettings
     {}
   );
   const [githubRemote, setGithubRemote] = useState<string | undefined>(undefined);
+  const [forgeProviderOverride, setForgeProviderOverride] = useState<string | null>(null);
   const [resourceEnvironments, setResourceEnvironments] = useState<
     Record<string, ResourceEnvironment> | undefined
   >(undefined);
@@ -140,7 +141,8 @@ export function useProjectSettingsForm({ projectId, isOpen }: UseProjectSettings
       activeResourceEnvironment,
       defaultWorktreeMode,
       turbopackEnabled,
-      daintreeMcpTier
+      daintreeMcpTier,
+      forgeProviderOverride
     );
   }, [
     projectName,
@@ -167,6 +169,7 @@ export function useProjectSettingsForm({ projectId, isOpen }: UseProjectSettings
     defaultWorktreeMode,
     turbopackEnabled,
     daintreeMcpTier,
+    forgeProviderOverride,
   ]);
   useEffect(() => {
     currentProjectSnapshotRef.current = currentProjectSnapshot;
@@ -203,6 +206,7 @@ export function useProjectSettingsForm({ projectId, isOpen }: UseProjectSettings
       setTerminalScrollback("");
       setNotificationOverrides({});
       setGithubRemote(undefined);
+      setForgeProviderOverride(null);
       setResourceEnvironments(undefined);
       setActiveResourceEnvironment(undefined);
       setDefaultWorktreeMode(undefined);
@@ -235,6 +239,7 @@ export function useProjectSettingsForm({ projectId, isOpen }: UseProjectSettings
     const initialTerminalSettings = projectSettings.terminalSettings;
     const initialNotificationOverrides = projectSettings.notificationOverrides ?? {};
     const initialGithubRemote = projectSettings.githubRemote;
+    const initialForgeProviderOverride = projectSettings.forgeProviderOverride ?? null;
     // Migration: convert old singular resourceEnvironment to resourceEnvironments
     let initialResourceEnvironments: Record<string, ResourceEnvironment> | undefined;
     let initialActiveResourceEnvironment: string | undefined;
@@ -282,6 +287,7 @@ export function useProjectSettingsForm({ projectId, isOpen }: UseProjectSettings
     );
     setNotificationOverrides(initialNotificationOverrides);
     setGithubRemote(initialGithubRemote);
+    setForgeProviderOverride(initialForgeProviderOverride);
     setResourceEnvironments(initialResourceEnvironments);
     setActiveResourceEnvironment(initialActiveResourceEnvironment);
     setDefaultWorktreeMode(initialDefaultWorktreeMode);
@@ -309,7 +315,8 @@ export function useProjectSettingsForm({ projectId, isOpen }: UseProjectSettings
       initialActiveResourceEnvironment,
       initialDefaultWorktreeMode,
       initialTurbopackEnabled,
-      initialDaintreeMcpTier
+      initialDaintreeMcpTier,
+      initialForgeProviderOverride
     );
     setProjectIsInitialized(true);
   }, [projectSettings, isOpen, projectIsInitialized, currentProject, projectIsLoading, projectId]);
@@ -403,6 +410,7 @@ export function useProjectSettingsForm({ projectId, isOpen }: UseProjectSettings
         branchPrefixCustom:
           effectivePrefixMode === "custom" ? sanitizedBranchPrefixCustom : undefined,
         githubRemote: githubRemote || undefined,
+        forgeProviderOverride: forgeProviderOverride ?? undefined,
         worktreePathPattern: sanitizedWorktreePathPattern,
         terminalSettings: currentTerminalSettings,
         notificationOverrides:
@@ -498,6 +506,8 @@ export function useProjectSettingsForm({ projectId, isOpen }: UseProjectSettings
     setNotificationOverrides,
     githubRemote,
     setGithubRemote,
+    forgeProviderOverride,
+    setForgeProviderOverride,
     resourceEnvironments,
     setResourceEnvironments,
     activeResourceEnvironment,


### PR DESCRIPTION
## Summary

- Adds a string-or-null `forgeProviderOverride` field to `ProjectSettings` with a single-select widget in the GitHub project settings tab
- New `plugin:forge-providers-get` IPC channel exposes registered forge providers to the renderer; `RegisteredForgeProvider` type moved to `shared/types/forge.ts` to keep the IPC map within the shared boundary
- Field is machine-local — `null` means auto-detect (implicit default); the resolver precedence chain change is a separate follow-up

Resolves #8111

## Changes

- `forgeProviderOverride` added to `ProjectSettings`; the field intentionally uses the existing `writeInRepoSettings` allowlist exclusion (machine-local)
- Unknown saved provider IDs are preserved and shown with an `(unavailable)` suffix rather than silently dropped, so a temporarily unloaded plugin doesn't clear the pin
- Bug fix: `getProjectSettings()` wasn't reading the field back on load, silently reverting any saved pin on app restart
- Round-trip tests, dirty-tracking equality tests, and a handler test added
- Read-only "resolved provider" badge in Preferences (#8064) is out of scope for this PR

## Testing

106 unit tests pass across the affected suites. Round-trip test covers save → load for the new field. Dirty-tracking test covers null-to-value and value-to-null transitions.