### PR TITLE
feat(actions): promote pre-wired destructive surfaces to danger:"confirm"

### DIFF
--- a/docs/architecture/destructive-action-safeguards.md
+++ b/docs/architecture/destructive-action-safeguards.md
@@ -114,7 +114,7 @@ Columns:
 | `project.add` / `project.cloneRepo` / `project.openDialog` | safe | n/a | reversible | one project | D0 | Leave | — |
 | `project.switch` / `project.switcherPalette` | safe | n/a | reversible (switch back) | one project | D0 | Leave | — |
 | `project.update` / `project.saveSettings` | safe | n/a | reversible (re-edit) | one project | D0 | Leave | — |
-| `project.remove` | safe | depends on call site | local-irreversible (removed from list; worktrees on disk remain) | one project | D1 | Wire `ConfirmDialog` at every call site; promote definition to `danger:"confirm"` once call sites are updated | TBD |
+| `project.remove` | **confirm** (updated #8247) | yes (`confirmRemoveProject` in `useProjectSwitcherPalette.ts`; all four entry points funnel through it) | local-irreversible (removed from list; worktrees on disk remain) | one project | D1 | Done (#8247) | #8247 |
 | `project.close` / `project.closeActive` | safe | yes — `callbacks.onConfirmCloseActiveProject` routes through a confirm flow | local-irreversible (terminals killed) | one project | D1 | Leave — confirm flow already exists | — |
 | `window.close` | safe | OS-native warning when unsaved work present | local-irreversible (window state lost) | one window | D0 | Leave — OS provides confirm | — |
 | `window.forceReload` | safe | n/a | local-irreversible (in-flight UI state lost) | one window | D0 | Acceptable: developer affordance; would only escalate if discoverable from non-dev menus | — |
@@ -136,7 +136,7 @@ The current GitHub action set is read-only (`openIssues`, `listPullRequests`, et
 | `recipe.run` | safe | n/a | local-irreversible (spawns processes; not a content mutation) | one recipe → many terminals | D0 | Leave | — |
 | `recipe.editor.open` / `recipe.manager.open` | safe | n/a | reversible | UI | D0 | Leave | — |
 | `recipe.saveToRepo` (with `deleteOriginal: true`) | safe | yes (`RecipeManager.tsx` ConfirmDialog) | local-irreversible (original deleted) | one recipe | D1 | Leave — current pattern is correct | — |
-| Recipe delete (UI-level only, via `RecipeManager`) | n/a — not an action ID | yes (`ConfirmDialog`) | local-irreversible | one recipe | D1 | Leave; consider promoting to a `recipe.delete` action ID | TBD |
+| `recipe.delete` | **confirm** (added #8247) | yes (`ConfirmDialog` in `RecipeManager.tsx` + `RecipesTab.tsx`; both dispatch through the action) | local-irreversible | one recipe | D1 | Done (#8247) | #8247 |
 | Plugin install / uninstall (future) | n/a — not yet wired | n/a | shared-state (filesystem + plugin host restart) | one plugin | D1 | When wired, `danger:"confirm"` + show plugin metadata before install/uninstall | open as needed |
 
 ### Portal / browser
@@ -153,7 +153,7 @@ The current GitHub action set is read-only (`openIssues`, `listPullRequests`, et
 | Action / call site | Current | UI confirm | Reversibility | Blast | Tier | Recommendation | Follow-up |
 | --- | --- | --- | --- | --- | --- | --- | --- |
 | `keybinding.setOverride` / `removeOverride` | safe | n/a | reversible (reset to default) | one binding | D0 | Leave | — |
-| `keybinding.resetAll` | safe | depends on call site | local-irreversible (all overrides lost) | every override | D1 | Wire `ConfirmDialog` at the Settings call site; promote definition to `danger:"confirm"` once wired | TBD |
+| `keybinding.resetAll` | **confirm** (updated #8247) | yes (`ConfirmDialog` at `KeyboardShortcutsTab.tsx:184`, dispatches with `confirmed:true`) | local-irreversible (all overrides lost) | every override | D1 | Done (#8247) | #8247 |
 
 ## Known bypasses
 

--- a/docs/architecture/destructive-action-safeguards.md
+++ b/docs/architecture/destructive-action-safeguards.md
@@ -137,6 +137,7 @@ The current GitHub action set is read-only (`openIssues`, `listPullRequests`, et
 | `recipe.editor.open` / `recipe.manager.open` | safe | n/a | reversible | UI | D0 | Leave | — |
 | `recipe.saveToRepo` (with `deleteOriginal: true`) | safe | yes (`RecipeManager.tsx` ConfirmDialog) | local-irreversible (original deleted) | one recipe | D1 | Leave — current pattern is correct | — |
 | `recipe.delete` | **confirm** (added #8247) | yes (`ConfirmDialog` in `RecipeManager.tsx` + `RecipesTab.tsx`; both dispatch through the action) | local-irreversible | one recipe | D1 | Done (#8247) | #8247 |
+| `useRecipeRunner.ts:386` `handleDelete` (RecipeRunner context menu) | (bypass) | none — calls store `deleteRecipe` directly, no `ConfirmDialog` | local-irreversible | one recipe | D1 | Route through `recipe.delete` and wire a `ConfirmDialog` at the RecipeRunner call site | TBD |
 | Plugin install / uninstall (future) | n/a — not yet wired | n/a | shared-state (filesystem + plugin host restart) | one plugin | D1 | When wired, `danger:"confirm"` + show plugin metadata before install/uninstall | open as needed |
 
 ### Portal / browser

--- a/shared/config/actionIds.ts
+++ b/shared/config/actionIds.ts
@@ -258,6 +258,7 @@ export const BUILT_IN_ACTION_IDS = [
   "recipe.editor.openFromLayout",
   "recipe.manager.open",
   "recipe.saveToRepo",
+  "recipe.delete",
 
   // -- agentActions --
   "agent.launch",

--- a/src/components/Project/RecipesTab.tsx
+++ b/src/components/Project/RecipesTab.tsx
@@ -5,6 +5,7 @@ import { Button } from "@/components/ui/button";
 import { EmptyState } from "@/components/ui/EmptyState";
 import { Skeleton, SkeletonBone } from "@/components/ui/Skeleton";
 import { useRecipeStore } from "@/store/recipeStore";
+import { actionService } from "@/services/ActionService";
 import { LiveTimeAgo } from "@/components/Worktree/LiveTimeAgo";
 import { RecipeEditor } from "@/components/TerminalRecipe/RecipeEditor";
 import { ConfirmDialog } from "@/components/ui/ConfirmDialog";
@@ -33,7 +34,6 @@ export function RecipesTab({
   const {
     recipes,
     loadRecipes,
-    deleteRecipe,
     exportRecipe,
     importRecipe,
     isLoading: recipesLoading,
@@ -110,15 +110,19 @@ export function RecipesTab({
 
   const handleDeleteRecipe = async (recipeId: string) => {
     setDeleteError(null);
-    try {
-      await deleteRecipe(recipeId);
+    const result = await actionService.dispatch(
+      "recipe.delete",
+      { recipeId },
+      { source: "user", confirmed: true }
+    );
+    if (result.ok) {
       if (recipeId === defaultWorktreeRecipeId) {
         onDefaultWorktreeRecipeIdChange(undefined);
       }
       setRecipeToDelete(null);
-    } catch (err) {
-      logError("Failed to delete recipe", err);
-      setDeleteError(formatErrorMessage(err, "Failed to delete recipe"));
+    } else {
+      logError("Failed to delete recipe", result.error);
+      setDeleteError(formatErrorMessage(result.error, "Failed to delete recipe"));
     }
   };
 

--- a/src/components/TerminalRecipe/RecipeManager.tsx
+++ b/src/components/TerminalRecipe/RecipeManager.tsx
@@ -21,6 +21,7 @@ import { ConfirmDialog } from "@/components/ui/ConfirmDialog";
 import { Tooltip, TooltipContent, TooltipTrigger } from "@/components/ui/tooltip";
 import { useRecipeStore } from "@/store/recipeStore";
 import { useProjectStore } from "@/store/projectStore";
+import { actionService } from "@/services/ActionService";
 import { logError } from "@/utils/logger";
 import { LiveTimeAgo } from "@/components/Worktree/LiveTimeAgo";
 import type { TerminalRecipe } from "@/types";
@@ -51,7 +52,6 @@ export function RecipeManager({
     () => rawProjectRecipes.filter((r) => !inRepoNames.has(r.name)),
     [rawProjectRecipes, inRepoNames]
   );
-  const deleteRecipe = useRecipeStore((s) => s.deleteRecipe);
   const saveToRepo = useRecipeStore((s) => s.saveToRepo);
   const exportRecipe = useRecipeStore((s) => s.exportRecipe);
   const exportRecipeToFile = useRecipeStore((s) => s.exportRecipeToFile);
@@ -82,12 +82,16 @@ export function RecipeManager({
 
   const handleDeleteRecipe = async (recipeId: string) => {
     setDeleteError(null);
-    try {
-      await deleteRecipe(recipeId);
+    const result = await actionService.dispatch(
+      "recipe.delete",
+      { recipeId },
+      { source: "user", confirmed: true }
+    );
+    if (result.ok) {
       setRecipeToDelete(null);
-    } catch (err) {
-      logError("Failed to delete recipe", err);
-      setDeleteError(formatErrorMessage(err, "Failed to delete recipe"));
+    } else {
+      logError("Failed to delete recipe", result.error);
+      setDeleteError(formatErrorMessage(result.error, "Failed to delete recipe"));
     }
   };
 
@@ -129,10 +133,13 @@ export function RecipeManager({
 
   const handleDeleteAfterSave = async () => {
     if (!recipeToDeleteAfterSave) return;
-    try {
-      await deleteRecipe(recipeToDeleteAfterSave);
-    } catch (err) {
-      logError("Failed to delete original recipe", err);
+    const result = await actionService.dispatch(
+      "recipe.delete",
+      { recipeId: recipeToDeleteAfterSave },
+      { source: "user", confirmed: true }
+    );
+    if (!result.ok) {
+      logError("Failed to delete original recipe", result.error);
     }
     setRecipeToDeleteAfterSave(null);
   };

--- a/src/services/actions/__tests__/actionDefinitions.quality.test.ts
+++ b/src/services/actions/__tests__/actionDefinitions.quality.test.ts
@@ -245,6 +245,9 @@ const EXPECTED_CONFIRM_DANGER: ReadonlyArray<ActionId> = [
   "fleet.deleteNamedFleet",
   "worktree.resource.teardown",
   "portal.links.remove",
+  "keybinding.resetAll",
+  "project.remove",
+  "recipe.delete",
 ];
 
 describe("destructive-action danger metadata", () => {
@@ -285,7 +288,12 @@ describe("destructive-action danger metadata", () => {
     // validation runs before the confirm gate, so undefined args would
     // short-circuit with VALIDATION_ERROR. Provide both placeholder keys —
     // zod object schemas strip unknown keys, so the irrelevant one is a no-op.
-    const placeholderArgs = { worktreeId: "wt-placeholder", id: "id-placeholder" };
+    const placeholderArgs = {
+      worktreeId: "wt-placeholder",
+      id: "id-placeholder",
+      projectId: "project-placeholder",
+      recipeId: "recipe-placeholder",
+    };
 
     // Some listed actions (e.g. worktree.resource.teardown) gate availability
     // via `isEnabled`, which runs *before* the confirm gate. Without a view

--- a/src/services/actions/definitions/__tests__/recipeActions.adversarial.test.ts
+++ b/src/services/actions/definitions/__tests__/recipeActions.adversarial.test.ts
@@ -215,6 +215,26 @@ describe("recipeActions adversarial", () => {
     expect(saveToRepo).toHaveBeenCalledWith("r1", true);
   });
 
+  it("recipe.delete forwards the recipeId to the store exactly once", async () => {
+    const deleteRecipe = vi.fn().mockResolvedValue(undefined);
+    setRecipeState({ deleteRecipe });
+
+    const run = setupActions();
+    await run("recipe.delete", { recipeId: "r1" });
+
+    expect(deleteRecipe).toHaveBeenCalledTimes(1);
+    expect(deleteRecipe).toHaveBeenCalledWith("r1");
+  });
+
+  it("recipe.delete propagates store rejection to the caller", async () => {
+    const deleteRecipe = vi.fn().mockRejectedValue(new Error("delete failed"));
+    setRecipeState({ deleteRecipe });
+
+    const run = setupActions();
+
+    await expect(run("recipe.delete", { recipeId: "r1" })).rejects.toThrow("delete failed");
+  });
+
   it("recipe.editor.openFromLayout dispatches terminals from the live layout", async () => {
     const terminals = [{ title: "t1" }, { title: "t2" }];
     setRecipeState({

--- a/src/services/actions/definitions/__tests__/recipeActions.adversarial.test.ts
+++ b/src/services/actions/definitions/__tests__/recipeActions.adversarial.test.ts
@@ -76,6 +76,7 @@ function setRecipeState(state: {
   currentProjectId?: string | null;
   runRecipe?: ReturnType<typeof vi.fn>;
   saveToRepo?: ReturnType<typeof vi.fn>;
+  deleteRecipe?: ReturnType<typeof vi.fn>;
   generateRecipeFromActiveTerminals?: (id: string) => unknown[];
 }) {
   recipeStoreMock.getState.mockReturnValue({
@@ -84,6 +85,7 @@ function setRecipeState(state: {
     currentProjectId: "currentProjectId" in state ? state.currentProjectId : "proj-1",
     runRecipe: state.runRecipe ?? vi.fn().mockResolvedValue(undefined),
     saveToRepo: state.saveToRepo ?? vi.fn().mockResolvedValue(undefined),
+    deleteRecipe: state.deleteRecipe ?? vi.fn().mockResolvedValue(undefined),
     generateRecipeFromActiveTerminals: state.generateRecipeFromActiveTerminals ?? vi.fn(() => []),
   });
 }

--- a/src/services/actions/definitions/keybindingActions.ts
+++ b/src/services/actions/definitions/keybindingActions.ts
@@ -58,7 +58,7 @@ export function registerKeybindingActions(
     description: "Reset all keybinding overrides",
     category: "settings",
     kind: "command",
-    danger: "safe",
+    danger: "confirm",
     scope: "renderer",
     keywords: ["shortcuts", "hotkeys", "defaults", "restore"],
     run: async () => {

--- a/src/services/actions/definitions/projectActions.ts
+++ b/src/services/actions/definitions/projectActions.ts
@@ -131,7 +131,7 @@ export function registerProjectActions(actions: ActionRegistry, callbacks: Actio
     description: "Remove a project from the list",
     category: "project",
     kind: "command",
-    danger: "safe",
+    danger: "confirm",
     scope: "renderer",
     argsSchema: z.object({ projectId: z.string() }),
     run: async (args: unknown) => {

--- a/src/services/actions/definitions/recipeActions.ts
+++ b/src/services/actions/definitions/recipeActions.ts
@@ -144,6 +144,22 @@ export function registerRecipeActions(actions: ActionRegistry, _callbacks: Actio
     })
   );
 
+  actions.set("recipe.delete", () =>
+    defineAction({
+      id: "recipe.delete",
+      title: "Delete Recipe",
+      description: "Delete a recipe permanently",
+      category: "recipes",
+      kind: "command",
+      danger: "confirm",
+      scope: "renderer",
+      argsSchema: z.object({ recipeId: z.string() }),
+      run: async ({ recipeId }) => {
+        await useRecipeStore.getState().deleteRecipe(recipeId);
+      },
+    })
+  );
+
   actions.set("recipe.editor.openFromLayout", () =>
     defineAction({
       id: "recipe.editor.openFromLayout",


### PR DESCRIPTION
## Summary

- Flips `keybinding.resetAll` and `project.remove` action defs from `danger:"safe"` to `danger:"confirm"` — both already have a `ConfirmDialog` wired, so this is a classification fix, not a behaviour change. Closes the MRU / `repeatLast` leak those surfaces had.
- Adds a new `recipe.delete` action ID with `danger:"confirm"` and routes both UI delete sites (`RecipeManager`, `RecipesTab`) through `actionService.dispatch` instead of calling the recipe store directly.
- Extends `EXPECTED_CONFIRM_DANGER` in the quality test floor to cover the three new entries.

Resolves #8247

## Changes

- `keybindingActions.ts`, `projectActions.ts` — `danger` flips
- `shared/config/actionIds.ts` — new `recipe.delete` ID
- `src/services/actions/definitions/recipeActions.ts` — new `recipe.delete` definition
- `RecipeManager.tsx`, `RecipesTab.tsx` — dispatch through `ActionService`
- `actionDefinitions.quality.test.ts` — extended `EXPECTED_CONFIRM_DANGER` floor
- `recipeActions.adversarial.test.ts` — store-propagation tests for `recipe.delete`
- `docs/architecture/destructive-action-safeguards.md` — three audit rows closed; RecipeRunner direct-delete bypass documented

## Testing

All checks green: typecheck, lint ratchet (889 baseline), format, quality test suite (9 pass), adversarial test suite (13 pass).