### PR TITLE
fix(project-settings): describe env var storage accurately, demote warning banner

### DIFF
--- a/src/components/Project/EnvironmentVariablesEditor.tsx
+++ b/src/components/Project/EnvironmentVariablesEditor.tsx
@@ -201,35 +201,31 @@ export function EnvironmentVariablesEditor({
         </>
       )}
 
-      <h3 className="text-sm font-semibold text-daintree-text/80 mb-2 flex items-center gap-2">
-        <Key className="h-4 w-4" />
-        Environment Variables
-      </h3>
+      <div className="mb-2 flex items-center justify-between gap-2">
+        <h3 className="text-sm font-semibold text-daintree-text/80 flex items-center gap-2">
+          <Key className="h-4 w-4" />
+          Environment Variables
+        </h3>
+        {showSaveControls &&
+          settings?.insecureEnvironmentVariables &&
+          settings.insecureEnvironmentVariables.length > 0 && (
+            <button
+              type="button"
+              onClick={handleSave}
+              disabled={isSaving}
+              className="text-xs text-text-secondary hover:text-daintree-text underline-offset-2 hover:underline transition-colors disabled:opacity-50 disabled:cursor-not-allowed"
+            >
+              {settings.insecureEnvironmentVariables.length === 1
+                ? "Move 1 value out of shared settings"
+                : `Move ${settings.insecureEnvironmentVariables.length} values out of shared settings`}
+            </button>
+          )}
+      </div>
       <p className="text-xs text-daintree-text/60 mb-4">
         Project-specific variables injected into new terminals. Names containing KEY, SECRET, TOKEN,
-        or PASSWORD are securely stored <Lock className="inline h-3 w-3" />.
+        or PASSWORD are kept out of the shared settings file{" "}
+        <Lock className="inline h-3 w-3" aria-hidden="true" />.
       </p>
-
-      {settings?.insecureEnvironmentVariables &&
-        settings.insecureEnvironmentVariables.length > 0 && (
-          <div className="mb-4 p-3 bg-status-warning/10 border border-status-warning/20 rounded-[var(--radius-md)] flex items-start gap-2">
-            <ShieldAlert className="h-4 w-4 text-status-warning mt-0.5 flex-shrink-0" />
-            <div className="flex-1 text-xs">
-              <p className="text-status-warning font-semibold mb-1">
-                Insecure sensitive variables detected
-              </p>
-              <p className="text-status-warning/80 mb-2">
-                The following keys are already stored in plaintext:{" "}
-                <span className="font-mono">
-                  {settings.insecureEnvironmentVariables.join(", ")}
-                </span>
-              </p>
-              <p className="text-status-warning/80">
-                Saving moves them into secure storage automatically.
-              </p>
-            </div>
-          </div>
-        )}
 
       <div className="space-y-2">
         {rows.length === 0 ? (
@@ -255,13 +251,13 @@ export function EnvironmentVariablesEditor({
                   {isSecured && (
                     <Lock
                       className="h-3.5 w-3.5 text-status-success/60 flex-shrink-0"
-                      aria-label="Stored securely"
+                      aria-label="Kept out of shared settings"
                     />
                   )}
                   {isInsecure && (
                     <ShieldAlert
                       className="h-3.5 w-3.5 text-status-warning/60 flex-shrink-0"
-                      aria-label="Stored in plaintext"
+                      aria-label="Stored in the shared settings file"
                     />
                   )}
                   <input

--- a/src/components/Project/EnvironmentVariablesEditor.tsx
+++ b/src/components/Project/EnvironmentVariablesEditor.tsx
@@ -122,7 +122,10 @@ export function EnvironmentVariablesEditor({
   };
 
   const handleSave = async () => {
-    if (!validate()) return;
+    if (!validate()) {
+      setSaveError("Fix the errors above before saving");
+      return;
+    }
     setIsSaving(true);
     setSaveError(null);
 

--- a/src/components/Project/__tests__/EnvironmentVariablesEditor.test.tsx
+++ b/src/components/Project/__tests__/EnvironmentVariablesEditor.test.tsx
@@ -1,7 +1,7 @@
 // @vitest-environment jsdom
 
 import { describe, it, expect, vi, beforeEach } from "vitest";
-import { render, screen, fireEvent } from "@testing-library/react";
+import { render, screen, fireEvent, waitFor } from "@testing-library/react";
 import { EnvironmentVariablesEditor } from "../EnvironmentVariablesEditor";
 import type { EnvVar } from "../projectSettingsDirty";
 import type { ProjectSettings } from "@shared/types/project";
@@ -12,6 +12,10 @@ vi.mock("@/lib/utils", () => ({
 
 function makeEnvVar(key: string, value: string): EnvVar {
   return { id: `env-${key}`, key, value };
+}
+
+function makeSettings(overrides: Partial<ProjectSettings> = {}): ProjectSettings {
+  return { runCommands: [], ...overrides };
 }
 
 const defaultProps = {
@@ -165,6 +169,131 @@ describe("EnvironmentVariablesEditor", () => {
 
       const nameInputs = screen.getAllByLabelText("Environment variable name");
       expect(nameInputs.length).toBe(1);
+    });
+  });
+
+  describe("copy and storage accuracy", () => {
+    it("describes sensitive names as kept out of the shared settings file (not 'securely stored')", () => {
+      const { container } = render(<EnvironmentVariablesEditor {...defaultProps} />);
+
+      expect(screen.getByText(/kept out of the shared settings file/i)).toBeTruthy();
+      expect(container.textContent ?? "").not.toMatch(/securely stored/i);
+    });
+
+    it("does not render the old yellow 'Insecure sensitive variables' banner", () => {
+      render(
+        <EnvironmentVariablesEditor
+          {...defaultProps}
+          environmentVariables={[makeEnvVar("API_KEY", "plain-value")]}
+          settings={makeSettings({ insecureEnvironmentVariables: ["API_KEY"] })}
+          onFlush={vi.fn().mockResolvedValue(undefined)}
+        />
+      );
+
+      expect(screen.queryByText(/insecure sensitive variables detected/i)).toBeNull();
+      expect(screen.queryByText(/saving moves them into secure storage/i)).toBeNull();
+    });
+
+    it("labels secured rows as 'Kept out of shared settings'", () => {
+      render(
+        <EnvironmentVariablesEditor
+          {...defaultProps}
+          environmentVariables={[makeEnvVar("API_KEY", "secret-value")]}
+          settings={makeSettings({ secureEnvironmentVariables: ["API_KEY"] })}
+        />
+      );
+
+      expect(screen.getByLabelText("Kept out of shared settings")).toBeTruthy();
+      expect(screen.queryByLabelText("Stored securely")).toBeNull();
+    });
+
+    it("labels insecure rows as 'Stored in the shared settings file'", () => {
+      render(
+        <EnvironmentVariablesEditor
+          {...defaultProps}
+          environmentVariables={[makeEnvVar("API_KEY", "plain-value")]}
+          settings={makeSettings({ insecureEnvironmentVariables: ["API_KEY"] })}
+        />
+      );
+
+      expect(screen.getByLabelText("Stored in the shared settings file")).toBeTruthy();
+      expect(screen.queryByLabelText("Stored in plaintext")).toBeNull();
+    });
+  });
+
+  describe("migration link", () => {
+    it("renders singular 'Move 1 value out of shared settings' for one insecure key", () => {
+      render(
+        <EnvironmentVariablesEditor
+          {...defaultProps}
+          environmentVariables={[makeEnvVar("API_KEY", "plain")]}
+          settings={makeSettings({ insecureEnvironmentVariables: ["API_KEY"] })}
+          onFlush={vi.fn().mockResolvedValue(undefined)}
+        />
+      );
+
+      expect(
+        screen.getByRole("button", { name: "Move 1 value out of shared settings" })
+      ).toBeTruthy();
+    });
+
+    it("renders plural 'Move N values out of shared settings' for multiple insecure keys", () => {
+      render(
+        <EnvironmentVariablesEditor
+          {...defaultProps}
+          environmentVariables={[makeEnvVar("API_KEY", "a"), makeEnvVar("SECRET_TOKEN", "b")]}
+          settings={makeSettings({
+            insecureEnvironmentVariables: ["API_KEY", "SECRET_TOKEN"],
+          })}
+          onFlush={vi.fn().mockResolvedValue(undefined)}
+        />
+      );
+
+      expect(
+        screen.getByRole("button", { name: "Move 2 values out of shared settings" })
+      ).toBeTruthy();
+    });
+
+    it("does not render the migration link when onFlush is undefined", () => {
+      render(
+        <EnvironmentVariablesEditor
+          {...defaultProps}
+          environmentVariables={[makeEnvVar("API_KEY", "plain")]}
+          settings={makeSettings({ insecureEnvironmentVariables: ["API_KEY"] })}
+        />
+      );
+
+      expect(screen.queryByRole("button", { name: /Move .* out of shared settings/ })).toBeNull();
+    });
+
+    it("does not render the migration link when there are no insecure keys", () => {
+      render(
+        <EnvironmentVariablesEditor
+          {...defaultProps}
+          settings={makeSettings({ insecureEnvironmentVariables: [] })}
+          onFlush={vi.fn().mockResolvedValue(undefined)}
+        />
+      );
+
+      expect(screen.queryByRole("button", { name: /Move .* out of shared settings/ })).toBeNull();
+    });
+
+    it("calls onFlush when the migration link is clicked", async () => {
+      const onFlush = vi.fn().mockResolvedValue(undefined);
+      render(
+        <EnvironmentVariablesEditor
+          {...defaultProps}
+          environmentVariables={[makeEnvVar("API_KEY", "plain")]}
+          settings={makeSettings({ insecureEnvironmentVariables: ["API_KEY"] })}
+          onFlush={onFlush}
+        />
+      );
+
+      fireEvent.click(screen.getByRole("button", { name: "Move 1 value out of shared settings" }));
+
+      await waitFor(() => {
+        expect(onFlush).toHaveBeenCalledTimes(1);
+      });
     });
   });
 });

--- a/src/components/Project/__tests__/EnvironmentVariablesEditor.test.tsx
+++ b/src/components/Project/__tests__/EnvironmentVariablesEditor.test.tsx
@@ -295,5 +295,22 @@ describe("EnvironmentVariablesEditor", () => {
         expect(onFlush).toHaveBeenCalledTimes(1);
       });
     });
+
+    it("does not migrate and surfaces a top-level error when an unrelated row is invalid", () => {
+      const onFlush = vi.fn().mockResolvedValue(undefined);
+      render(
+        <EnvironmentVariablesEditor
+          {...defaultProps}
+          environmentVariables={[makeEnvVar("API_KEY", "plain"), makeEnvVar("BAD-NAME", "x")]}
+          settings={makeSettings({ insecureEnvironmentVariables: ["API_KEY"] })}
+          onFlush={onFlush}
+        />
+      );
+
+      fireEvent.click(screen.getByRole("button", { name: "Move 1 value out of shared settings" }));
+
+      expect(onFlush).not.toHaveBeenCalled();
+      expect(screen.getByText(/fix the errors above before saving/i)).toBeTruthy();
+    });
   });
 });


### PR DESCRIPTION
## Summary

- `EnvironmentVariablesEditor.tsx` was describing plaintext `electron-store` JSON as "secure". The Lock icon's `aria-label` said `Stored securely` and the header copy said `securely stored` — both now say `kept out of the shared settings file`, which is what the storage actually provides.
- The yellow warning banner that fired on every visit when any key matched the sensitivity regex has been replaced with a quiet text link anchored to the section header. Clicking it triggers the same migration; the banner was demoted per the Runtime Signals rule (the user couldn't take a different action than ignoring it).
- A top-level error message now surfaces when validation blocks save, so the migration link can't appear to silently do nothing.

Resolves #8234

## Changes

- Reworded header copy and Lock/ShieldAlert `aria-label` values to reflect actual storage behaviour
- Removed the yellow warning card; added a singular/plural header-anchored text link for the migration action
- Added a `saveError` state that surfaces a top-level message when validation prevents the save from running
- 9 new tests covering: copy correction, banner removal, `aria-label` values, singular/plural link text, gating conditions, click handler, and the validation-failure error surface

## Testing

- All 9 new tests pass alongside the existing `EnvironmentVariablesEditor` suite
- Manually verified the text link triggers migration correctly and that the error message appears when a duplicate key blocks save