### PR TITLE
refactor(notify): delete vestigial theme-toggle toast (#8246)

### DIFF
--- a/src/hooks/app/useOrchestrationMilestones.ts
+++ b/src/hooks/app/useOrchestrationMilestones.ts
@@ -136,7 +136,6 @@ export function useOrchestrationMilestones(isStateLoaded: boolean): void {
           title: milestone.title,
           message: milestone.message,
           duration: TOAST_DURATION,
-          transient: true,
         });
       }
 

--- a/src/hooks/app/useOrchestrationMilestones.ts
+++ b/src/hooks/app/useOrchestrationMilestones.ts
@@ -136,6 +136,7 @@ export function useOrchestrationMilestones(isStateLoaded: boolean): void {
           title: milestone.title,
           message: milestone.message,
           duration: TOAST_DURATION,
+          transient: true,
         });
       }
 

--- a/src/services/actions/definitions/__tests__/themeActions.test.ts
+++ b/src/services/actions/definitions/__tests__/themeActions.test.ts
@@ -99,9 +99,8 @@ describe("app.theme.toggle", () => {
 
     expect(mockSetSelectedSchemeId).toHaveBeenCalledWith("light-a");
     expect(mockSetColorScheme).toHaveBeenCalledWith("light-a");
-    expect(mockNotify).toHaveBeenCalledWith(
-      expect.objectContaining({ type: "info", message: "Theme: Light A" })
-    );
+    // Success path is silent — the repainted UI is the confirmation.
+    expect(mockNotify).not.toHaveBeenCalled();
   });
 
   it("switches from light to preferred dark scheme and persists", async () => {
@@ -118,9 +117,7 @@ describe("app.theme.toggle", () => {
 
     expect(mockSetSelectedSchemeId).toHaveBeenCalledWith("dark-a");
     expect(mockSetColorScheme).toHaveBeenCalledWith("dark-a");
-    expect(mockNotify).toHaveBeenCalledWith(
-      expect.objectContaining({ type: "info", message: "Theme: Dark A" })
-    );
+    expect(mockNotify).not.toHaveBeenCalled();
   });
 
   it("is a no-op when resolved target equals current scheme", async () => {
@@ -182,7 +179,7 @@ describe("app.theme.toggle", () => {
     // Must NOT be light-a (the wrong-type fallback). Must be some built-in dark scheme.
     expect(selectedId).not.toBe("light-a");
     expect(mockSetColorScheme).toHaveBeenCalledWith(selectedId);
-    expect(mockNotify).toHaveBeenCalledWith(expect.objectContaining({ type: "info" }));
+    expect(mockNotify).not.toHaveBeenCalled();
   });
 
   it("shows error toast when persistence fails, skips success toast", async () => {

--- a/src/services/actions/definitions/appActions.ts
+++ b/src/services/actions/definitions/appActions.ts
@@ -201,17 +201,7 @@ export function registerAppActions(actions: ActionRegistry, callbacks: ActionCal
           message: `Couldn't save theme preference — '${target.name}' is applied but the choice will be lost on restart.`,
           duration: 3000,
         });
-        return;
       }
-      notify({
-        type: "info",
-        priority: "high",
-        message: `Theme: ${target.name}`,
-        duration: 2000,
-        // Confirmation of a user-triggered toggle — the user already knows; no
-        // need to bump the unread badge in the notification center.
-        countable: false,
-      });
     },
   }));
 


### PR DESCRIPTION
## Summary

- Removes the success `notify()` call from the theme-toggle action in `appActions.ts`. The entire UI repaints on theme change, so the toast competed with the repaint signal without adding information.
- Updates three assertions in `themeActions.test.ts` so the success path no longer expects a notification. The error-path assertion (`toHaveBeenCalledTimes(1)` on persist failure) is unchanged.
- Audited all other success/info `notify()` call sites in the codebase and confirmed they're correctly classified.

Resolves #8246

## Changes

- `src/services/actions/definitions/appActions.ts` — deleted the `notify({ type: "info" })` call on the theme-toggle success path
- `src/services/actions/definitions/__tests__/themeActions.test.ts` — three assertions updated to assert no notification on success

## Audit findings (kept as-is)

- **Milestone toasts (`useOrchestrationMilestones.ts`)** — considered for `transient: true`, reverted. `transient` + blurred window means `isFocused=false` → no toast and no inbox entry, so the milestone silently drops. These one-shot teaching events have no other delivery channel.
- **Error boundary (`ErrorBoundary.tsx`)** and **memory-leak restart (`useMemoryLeakDetection.ts`)** — kept. The inbox row is the recovery path in both cases; the failure reason isn't visible anywhere else.
- **All other sites** — either action-bearing, `priority: "low"` inbox-only, `placement: "grid-bar"`, or non-visible state changes. No changes needed.

## Testing

- Unit tests pass; the three updated assertions confirm the success path no longer fires a notification.
- Manually verified theme switching — the UI repaint is the signal; no toast needed.