### PR TITLE
feat(forge): ForgeProviderResolver precedence chain (#8112)

### DIFF
--- a/electron/ipc/__tests__/handlers.registry.test.ts
+++ b/electron/ipc/__tests__/handlers.registry.test.ts
@@ -1,6 +1,10 @@
 import { afterEach, beforeEach, describe, expect, it, vi, type Mock } from "vitest";
 
 vi.mock("electron", () => ({
+  app: {
+    getPath: vi.fn(),
+    on: vi.fn(),
+  },
   ipcMain: {
     handle: vi.fn(),
     removeHandler: vi.fn(),
@@ -27,6 +31,7 @@ const registerMocks = vi.hoisted(() => ({
   registerProjectRecipesHandlers: vi.fn(),
   registerProjectPresetsHandlers: vi.fn(),
   registerGlobalRecipesHandlers: vi.fn(),
+  registerGlobalEnvHandlers: vi.fn(),
   registerTerminalLayoutHandlers: vi.fn(),
   registerProjectInRepoSettingsHandlers: vi.fn(),
   registerGithubHandlers: vi.fn(),
@@ -52,11 +57,14 @@ const registerMocks = vi.hoisted(() => ({
   registerGitReadHandlers: vi.fn(),
   registerTelemetryHandlers: vi.fn(),
   registerPrivacyHandlers: vi.fn(),
+  registerSentryHandlers: vi.fn(),
   registerOnboardingHandlers: vi.fn(),
   registerMilestonesHandlers: vi.fn(),
   registerShortcutHintsHandlers: vi.fn(),
+  registerForgeSettingsHandlers: vi.fn(),
   registerVoiceInputHandlers: vi.fn(),
   registerMcpServerHandlers: vi.fn(),
+  registerHelpAssistantHandlers: vi.fn(),
   registerWebviewHandlers: vi.fn(),
   registerDiagnosticsHandlers: vi.fn(),
 
@@ -65,6 +73,7 @@ const registerMocks = vi.hoisted(() => ({
   registerRecoveryHandlers: vi.fn(),
   registerPluginHandlers: vi.fn(),
   registerPerfHandlers: vi.fn(),
+  registerConnectivityHandlers: vi.fn(),
   registerScratchHandlers: vi.fn(),
 }));
 
@@ -106,6 +115,9 @@ vi.mock("../handlers/projectPresets.js", () => ({
 }));
 vi.mock("../handlers/globalRecipes.js", () => ({
   registerGlobalRecipesHandlers: registerMocks.registerGlobalRecipesHandlers,
+}));
+vi.mock("../handlers/globalEnv.js", () => ({
+  registerGlobalEnvHandlers: registerMocks.registerGlobalEnvHandlers,
 }));
 vi.mock("../handlers/terminalLayout.js", () => ({
   registerTerminalLayoutHandlers: registerMocks.registerTerminalLayoutHandlers,
@@ -182,6 +194,9 @@ vi.mock("../handlers/telemetry.js", () => ({
 vi.mock("../handlers/privacy.js", () => ({
   registerPrivacyHandlers: registerMocks.registerPrivacyHandlers,
 }));
+vi.mock("../handlers/sentry.js", () => ({
+  registerSentryHandlers: registerMocks.registerSentryHandlers,
+}));
 vi.mock("../handlers/onboarding.js", () => ({
   registerOnboardingHandlers: registerMocks.registerOnboardingHandlers,
 }));
@@ -191,11 +206,17 @@ vi.mock("../handlers/milestones.js", () => ({
 vi.mock("../handlers/shortcutHints.js", () => ({
   registerShortcutHintsHandlers: registerMocks.registerShortcutHintsHandlers,
 }));
+vi.mock("../handlers/forgeSettings.js", () => ({
+  registerForgeSettingsHandlers: registerMocks.registerForgeSettingsHandlers,
+}));
 vi.mock("../handlers/voiceInput.js", () => ({
   registerVoiceInputHandlers: registerMocks.registerVoiceInputHandlers,
 }));
 vi.mock("../handlers/mcpServer.js", () => ({
   registerMcpServerHandlers: registerMocks.registerMcpServerHandlers,
+}));
+vi.mock("../handlers/helpAssistant.js", () => ({
+  registerHelpAssistantHandlers: registerMocks.registerHelpAssistantHandlers,
 }));
 vi.mock("../handlers/webview.js", () => ({
   registerWebviewHandlers: registerMocks.registerWebviewHandlers,
@@ -217,6 +238,9 @@ vi.mock("../handlers/plugin.js", () => ({
 }));
 vi.mock("../handlers/perf.js", () => ({
   registerPerfHandlers: registerMocks.registerPerfHandlers,
+}));
+vi.mock("../handlers/connectivity.js", () => ({
+  registerConnectivityHandlers: registerMocks.registerConnectivityHandlers,
 }));
 vi.mock("../handlers/scratch/index.js", () => ({
   registerScratchHandlers: registerMocks.registerScratchHandlers,

--- a/electron/ipc/channels.ts
+++ b/electron/ipc/channels.ts
@@ -674,6 +674,7 @@ export const CHANNELS = {
   FORGE_GET_SETTINGS: "forge:get-settings",
   FORGE_SET_DEFAULT_PROVIDER: "forge:set-default-provider",
   FORGE_GET_PROVIDERS: "forge:get-providers",
+  FORGE_RESOLVE_PROVIDER: "forge:resolve-provider",
 
   // Plugin channels
   PLUGIN_LIST: "plugin:list",

--- a/electron/ipc/handlers/__tests__/forgeSettings.handlers.test.ts
+++ b/electron/ipc/handlers/__tests__/forgeSettings.handlers.test.ts
@@ -27,6 +27,14 @@ const registryMock = vi.hoisted(() => ({
 
 vi.mock("../../../services/forgeProviderRegistry.js", () => registryMock);
 
+const resolverMock = vi.hoisted(() => ({
+  resolveForgeProvider: vi.fn<(projectId: string) => Promise<ForgeProviderEntry | null>>(
+    async () => null
+  ),
+}));
+
+vi.mock("../../../services/forgeProviderResolver.js", () => resolverMock);
+
 import { registerForgeSettingsHandlers } from "../forgeSettings.js";
 
 function findHandler(channel: string): (...args: unknown[]) => unknown {
@@ -44,15 +52,16 @@ describe("registerForgeSettingsHandlers", () => {
     registryMock.getRegisteredForgeProviders.mockReturnValue([]);
   });
 
-  it("registers three IPC handlers", () => {
+  it("registers four IPC handlers", () => {
     const cleanup = registerForgeSettingsHandlers();
-    expect(ipcMainMock.handle).toHaveBeenCalledTimes(3);
+    expect(ipcMainMock.handle).toHaveBeenCalledTimes(4);
     expect(ipcMainMock.handle).toHaveBeenCalledWith("forge:get-settings", expect.any(Function));
     expect(ipcMainMock.handle).toHaveBeenCalledWith(
       "forge:set-default-provider",
       expect.any(Function)
     );
     expect(ipcMainMock.handle).toHaveBeenCalledWith("forge:get-providers", expect.any(Function));
+    expect(ipcMainMock.handle).toHaveBeenCalledWith("forge:resolve-provider", expect.any(Function));
     cleanup();
   });
 
@@ -122,9 +131,30 @@ describe("registerForgeSettingsHandlers", () => {
     expect(getProviders(null)).toEqual(entries);
   });
 
-  it("cleanup removes all three handlers", () => {
+  it("cleanup removes all four handlers", () => {
     const cleanup = registerForgeSettingsHandlers();
     cleanup();
-    expect(ipcMainMock.removeHandler).toHaveBeenCalledTimes(3);
+    expect(ipcMainMock.removeHandler).toHaveBeenCalledTimes(4);
+  });
+
+  it("resolveProvider delegates to the resolver and forwards its return value", async () => {
+    const entry: ForgeProviderEntry = {
+      pluginId: "builtin",
+      contribution: { id: "github", name: "GitHub", matches: ["github.com"] },
+    };
+    resolverMock.resolveForgeProvider.mockResolvedValueOnce(entry);
+    registerForgeSettingsHandlers();
+    const resolveProvider = findHandler("forge:resolve-provider");
+    await expect(resolveProvider(null, "project-1")).resolves.toEqual(entry);
+    expect(resolverMock.resolveForgeProvider).toHaveBeenCalledWith("project-1");
+  });
+
+  it("resolveProvider returns null for invalid projectId payloads without calling the resolver", async () => {
+    registerForgeSettingsHandlers();
+    const resolveProvider = findHandler("forge:resolve-provider");
+    await expect(resolveProvider(null, "")).resolves.toBeNull();
+    await expect(resolveProvider(null, 42)).resolves.toBeNull();
+    await expect(resolveProvider(null, undefined)).resolves.toBeNull();
+    expect(resolverMock.resolveForgeProvider).not.toHaveBeenCalled();
   });
 });

--- a/electron/ipc/handlers/forgeSettings.ts
+++ b/electron/ipc/handlers/forgeSettings.ts
@@ -2,6 +2,7 @@ import { CHANNELS } from "../channels.js";
 import { store } from "../../store.js";
 import { typedHandle } from "../utils.js";
 import { getRegisteredForgeProviders } from "../../services/forgeProviderRegistry.js";
+import { resolveForgeProvider } from "../../services/forgeProviderResolver.js";
 
 function readDefaultProviderId(): string | null {
   const value = store.get("forgeDefaultProviderId");
@@ -32,6 +33,13 @@ export function registerForgeSettingsHandlers(): () => void {
   cleanups.push(
     typedHandle(CHANNELS.FORGE_GET_PROVIDERS, () => {
       return getRegisteredForgeProviders();
+    })
+  );
+
+  cleanups.push(
+    typedHandle(CHANNELS.FORGE_RESOLVE_PROVIDER, async (projectId: unknown) => {
+      if (typeof projectId !== "string" || projectId.length === 0) return null;
+      return resolveForgeProvider(projectId);
     })
   );
 

--- a/electron/preload.cts
+++ b/electron/preload.cts
@@ -2339,6 +2339,8 @@ const api: ElectronAPI = {
     setDefaultProvider: (providerId: string | null) =>
       _unwrappingInvoke(CHANNELS.FORGE_SET_DEFAULT_PROVIDER, providerId),
     getProviders: () => _unwrappingInvoke(CHANNELS.FORGE_GET_PROVIDERS),
+    resolveProvider: (projectId: string) =>
+      _unwrappingInvoke(CHANNELS.FORGE_RESOLVE_PROVIDER, projectId),
   },
 
   // Voice Input API

--- a/electron/services/__tests__/forgeProviderResolver.test.ts
+++ b/electron/services/__tests__/forgeProviderResolver.test.ts
@@ -105,16 +105,18 @@ describe("resolveForgeProvider", () => {
     expect(await resolveForgeProvider("project-1")).toEqual(gitea);
   });
 
-  it("returns null when forgeProviderOverride names an unregistered provider", async () => {
+  it("returns null when forgeProviderOverride names an unregistered provider (no fallthrough)", async () => {
     const github = makeProvider("builtin", "github", ["github.com"]);
     registryMock.getRegisteredForgeProviders.mockReturnValue([github]);
     registryMock.listMatchingProviders.mockReturnValue([github]);
+    // Both lower tiers would otherwise resolve to `github` — proving they are
+    // not consulted when an override names an unregistered provider.
+    storeMock._data["forgeDefaultProviderId"] = "github";
     projectStoreMock.getProjectSettings.mockResolvedValue({
       runCommands: [],
       forgeProviderOverride: "gone.away",
     });
 
-    // No fallthrough to global default or first hostname match.
     expect(await resolveForgeProvider("project-1")).toBeNull();
     expect(registryMock.listMatchingProviders).not.toHaveBeenCalled();
   });
@@ -149,11 +151,22 @@ describe("resolveForgeProvider", () => {
 
   it("returns null when the global default is not a hostname match for the remote", async () => {
     const github = makeProvider("builtin", "github", ["github.com"]);
+    const gitea = makeProvider("acme.gitea", "gitea", ["gitea.example.com"]);
+    // The default IS registered globally — but not for this remote's hostname.
+    // Rule 2 must filter through listMatchingProviders, not the full registry.
+    registryMock.getRegisteredForgeProviders.mockReturnValue([github, gitea]);
     registryMock.listMatchingProviders.mockReturnValue([github]);
     storeMock._data["forgeDefaultProviderId"] = "gitea";
 
-    // No fallthrough to first match.
     expect(await resolveForgeProvider("project-1")).toBeNull();
+  });
+
+  it("accepts namespaced ids for the global default", async () => {
+    const github = makeProvider("builtin", "github", ["github.com"]);
+    registryMock.listMatchingProviders.mockReturnValue([github]);
+    storeMock._data["forgeDefaultProviderId"] = "builtin.github";
+
+    expect(await resolveForgeProvider("project-1")).toEqual(github);
   });
 
   it("returns the first hostname match when no override or default is set", async () => {
@@ -195,12 +208,14 @@ describe("resolveForgeProvider", () => {
     expect(await resolveForgeProvider("project-1")).toBeNull();
   });
 
-  it("returns null when getProjectSettings rejects", async () => {
+  it("falls through to hostname match when getProjectSettings rejects", async () => {
+    // Documented contract: settings read failure is treated as "no override",
+    // not "no resolution". The conservative degradation path keeps PR linkage
+    // working when machine-local settings are momentarily unreadable.
     projectStoreMock.getProjectSettings.mockRejectedValue(new Error("read failed"));
     const github = makeProvider("builtin", "github", ["github.com"]);
     registryMock.listMatchingProviders.mockReturnValue([github]);
 
-    // Settings unreadable → no override; falls through to hostname match.
     expect(await resolveForgeProvider("project-1")).toEqual(github);
   });
 
@@ -212,7 +227,7 @@ describe("resolveForgeProvider", () => {
     expect(await resolveForgeProvider("project-1")).toBeNull();
   });
 
-  it("does no caching — settings/store are re-read on each call", async () => {
+  it("does no caching — settings, store, remote, and registry are re-read on each call", async () => {
     const github = makeProvider("builtin", "github", ["github.com"]);
     registryMock.listMatchingProviders.mockReturnValue([github]);
 
@@ -220,6 +235,8 @@ describe("resolveForgeProvider", () => {
     await resolveForgeProvider("project-1");
 
     expect(projectStoreMock.getProjectSettings).toHaveBeenCalledTimes(2);
+    expect(gitServiceMock.getRemoteUrl).toHaveBeenCalledTimes(2);
+    expect(registryMock.listMatchingProviders).toHaveBeenCalledTimes(2);
     expect(storeMock.get).toHaveBeenCalledWith("forgeDefaultProviderId");
   });
 });

--- a/electron/services/__tests__/forgeProviderResolver.test.ts
+++ b/electron/services/__tests__/forgeProviderResolver.test.ts
@@ -1,0 +1,225 @@
+import { describe, it, expect, vi, beforeEach } from "vitest";
+import type {
+  ForgeProviderContribution,
+  RegisteredForgeProvider,
+} from "../../../shared/types/forge.js";
+
+const projectStoreMock = vi.hoisted(() => ({
+  getProjectById: vi.fn(),
+  getProjectSettings: vi.fn(),
+}));
+
+vi.mock("../ProjectStore.js", () => ({ projectStore: projectStoreMock }));
+
+const gitServiceMock = vi.hoisted(() => ({
+  getRemoteUrl: vi.fn(),
+}));
+const gitServiceCacheMock = vi.hoisted(() => ({
+  getGitService: vi.fn(() => gitServiceMock),
+}));
+
+vi.mock("../GitServiceCache.js", () => ({ gitServiceCache: gitServiceCacheMock }));
+
+const storeMock = vi.hoisted(() => {
+  const data: Record<string, unknown> = {};
+  return {
+    get: vi.fn((key: string) => data[key]),
+    _data: data,
+  };
+});
+
+vi.mock("../../store.js", () => ({ store: storeMock }));
+
+const registryMock = vi.hoisted(() => ({
+  getRegisteredForgeProviders: vi.fn<() => RegisteredForgeProvider[]>(() => []),
+  listMatchingProviders: vi.fn<(remoteUrl: string) => RegisteredForgeProvider[]>(() => []),
+}));
+
+vi.mock("../forgeProviderRegistry.js", () => registryMock);
+
+import { resolveForgeProvider } from "../forgeProviderResolver.js";
+
+function makeProvider(
+  pluginId: string,
+  id: string,
+  matches: string[] = []
+): RegisteredForgeProvider {
+  const contribution: ForgeProviderContribution = {
+    id,
+    name: id,
+    matches,
+  };
+  return { pluginId, contribution };
+}
+
+beforeEach(() => {
+  vi.clearAllMocks();
+  for (const key of Object.keys(storeMock._data)) {
+    delete storeMock._data[key];
+  }
+  projectStoreMock.getProjectById.mockReturnValue({
+    id: "project-1",
+    path: "/repo",
+    name: "repo",
+  });
+  projectStoreMock.getProjectSettings.mockResolvedValue({ runCommands: [] });
+  gitServiceMock.getRemoteUrl.mockResolvedValue("https://github.com/owner/repo.git");
+  registryMock.getRegisteredForgeProviders.mockReturnValue([]);
+  registryMock.listMatchingProviders.mockReturnValue([]);
+});
+
+describe("resolveForgeProvider", () => {
+  it("returns null when the project does not exist", async () => {
+    projectStoreMock.getProjectById.mockReturnValue(null);
+    expect(await resolveForgeProvider("missing")).toBeNull();
+  });
+
+  it("returns null for empty or non-string projectId", async () => {
+    expect(await resolveForgeProvider("")).toBeNull();
+    expect(await resolveForgeProvider(undefined as unknown as string)).toBeNull();
+  });
+
+  it("returns the override match when forgeProviderOverride names a registered provider", async () => {
+    const gitea = makeProvider("acme.gitea", "gitea", ["gitea.example.com"]);
+    const github = makeProvider("builtin", "github", ["github.com"]);
+    registryMock.getRegisteredForgeProviders.mockReturnValue([github, gitea]);
+    projectStoreMock.getProjectSettings.mockResolvedValue({
+      runCommands: [],
+      forgeProviderOverride: "gitea",
+    });
+
+    const result = await resolveForgeProvider("project-1");
+    expect(result).toEqual(gitea);
+    // Override path bypasses hostname matching entirely.
+    expect(registryMock.listMatchingProviders).not.toHaveBeenCalled();
+  });
+
+  it("accepts namespaced ids ({pluginId}.{contributionId}) for the override", async () => {
+    const gitea = makeProvider("acme.gitea", "gitea", ["gitea.example.com"]);
+    registryMock.getRegisteredForgeProviders.mockReturnValue([gitea]);
+    projectStoreMock.getProjectSettings.mockResolvedValue({
+      runCommands: [],
+      forgeProviderOverride: "acme.gitea.gitea",
+    });
+
+    expect(await resolveForgeProvider("project-1")).toEqual(gitea);
+  });
+
+  it("returns null when forgeProviderOverride names an unregistered provider", async () => {
+    const github = makeProvider("builtin", "github", ["github.com"]);
+    registryMock.getRegisteredForgeProviders.mockReturnValue([github]);
+    registryMock.listMatchingProviders.mockReturnValue([github]);
+    projectStoreMock.getProjectSettings.mockResolvedValue({
+      runCommands: [],
+      forgeProviderOverride: "gone.away",
+    });
+
+    // No fallthrough to global default or first hostname match.
+    expect(await resolveForgeProvider("project-1")).toBeNull();
+    expect(registryMock.listMatchingProviders).not.toHaveBeenCalled();
+  });
+
+  it("treats forgeProviderOverride === null as auto-detect (falls through)", async () => {
+    const github = makeProvider("builtin", "github", ["github.com"]);
+    registryMock.listMatchingProviders.mockReturnValue([github]);
+    projectStoreMock.getProjectSettings.mockResolvedValue({
+      runCommands: [],
+      forgeProviderOverride: null,
+    });
+
+    expect(await resolveForgeProvider("project-1")).toEqual(github);
+  });
+
+  it("treats forgeProviderOverride absent as auto-detect (falls through)", async () => {
+    const github = makeProvider("builtin", "github", ["github.com"]);
+    registryMock.listMatchingProviders.mockReturnValue([github]);
+    projectStoreMock.getProjectSettings.mockResolvedValue({ runCommands: [] });
+
+    expect(await resolveForgeProvider("project-1")).toEqual(github);
+  });
+
+  it("returns the global default when it matches one of the remote candidates", async () => {
+    const enterprise = makeProvider("acme.gh-enterprise", "gh-enterprise", ["github.com"]);
+    const github = makeProvider("builtin", "github", ["github.com"]);
+    registryMock.listMatchingProviders.mockReturnValue([github, enterprise]);
+    storeMock._data["forgeDefaultProviderId"] = "gh-enterprise";
+
+    expect(await resolveForgeProvider("project-1")).toEqual(enterprise);
+  });
+
+  it("returns null when the global default is not a hostname match for the remote", async () => {
+    const github = makeProvider("builtin", "github", ["github.com"]);
+    registryMock.listMatchingProviders.mockReturnValue([github]);
+    storeMock._data["forgeDefaultProviderId"] = "gitea";
+
+    // No fallthrough to first match.
+    expect(await resolveForgeProvider("project-1")).toBeNull();
+  });
+
+  it("returns the first hostname match when no override or default is set", async () => {
+    const github = makeProvider("builtin", "github", ["github.com"]);
+    const other = makeProvider("acme.other", "other", ["github.com"]);
+    registryMock.listMatchingProviders.mockReturnValue([github, other]);
+
+    expect(await resolveForgeProvider("project-1")).toEqual(github);
+  });
+
+  it("returns null when there are no hostname matches", async () => {
+    registryMock.listMatchingProviders.mockReturnValue([]);
+    expect(await resolveForgeProvider("project-1")).toBeNull();
+  });
+
+  it("returns null when the remote URL cannot be read", async () => {
+    gitServiceMock.getRemoteUrl.mockResolvedValue(null);
+    const github = makeProvider("builtin", "github", ["github.com"]);
+    registryMock.listMatchingProviders.mockReturnValue([github]);
+
+    expect(await resolveForgeProvider("project-1")).toBeNull();
+    expect(registryMock.listMatchingProviders).not.toHaveBeenCalled();
+  });
+
+  it("still resolves the override when the remote URL cannot be read", async () => {
+    gitServiceMock.getRemoteUrl.mockResolvedValue(null);
+    const gitea = makeProvider("acme.gitea", "gitea", ["gitea.example.com"]);
+    registryMock.getRegisteredForgeProviders.mockReturnValue([gitea]);
+    projectStoreMock.getProjectSettings.mockResolvedValue({
+      runCommands: [],
+      forgeProviderOverride: "gitea",
+    });
+
+    expect(await resolveForgeProvider("project-1")).toEqual(gitea);
+  });
+
+  it("returns null when getRemoteUrl rejects", async () => {
+    gitServiceMock.getRemoteUrl.mockRejectedValue(new Error("not a git repo"));
+    expect(await resolveForgeProvider("project-1")).toBeNull();
+  });
+
+  it("returns null when getProjectSettings rejects", async () => {
+    projectStoreMock.getProjectSettings.mockRejectedValue(new Error("read failed"));
+    const github = makeProvider("builtin", "github", ["github.com"]);
+    registryMock.listMatchingProviders.mockReturnValue([github]);
+
+    // Settings unreadable → no override; falls through to hostname match.
+    expect(await resolveForgeProvider("project-1")).toEqual(github);
+  });
+
+  it("does not throw when a synchronous registry call throws", async () => {
+    registryMock.listMatchingProviders.mockImplementation(() => {
+      throw new Error("boom");
+    });
+
+    expect(await resolveForgeProvider("project-1")).toBeNull();
+  });
+
+  it("does no caching — settings/store are re-read on each call", async () => {
+    const github = makeProvider("builtin", "github", ["github.com"]);
+    registryMock.listMatchingProviders.mockReturnValue([github]);
+
+    await resolveForgeProvider("project-1");
+    await resolveForgeProvider("project-1");
+
+    expect(projectStoreMock.getProjectSettings).toHaveBeenCalledTimes(2);
+    expect(storeMock.get).toHaveBeenCalledWith("forgeDefaultProviderId");
+  });
+});

--- a/electron/services/forgeProviderResolver.ts
+++ b/electron/services/forgeProviderResolver.ts
@@ -1,0 +1,76 @@
+import type { RegisteredForgeProvider } from "../../shared/types/forge.js";
+import { getRegisteredForgeProviders, listMatchingProviders } from "./forgeProviderRegistry.js";
+import { projectStore } from "./ProjectStore.js";
+import { gitServiceCache } from "./GitServiceCache.js";
+import { store } from "../store.js";
+
+/**
+ * Pick the single active forge provider for a project from the candidates the
+ * registry exposes. Precedence (issue #8112):
+ *
+ *   1. Per-project override (`forgeProviderOverride`, #8111) — if set and the
+ *      named provider is still registered.
+ *   2. Global default (`forgeDefaultProviderId`, #8110) — if set and the named
+ *      provider is one of the candidates for the project's remote.
+ *   3. First hostname match from `listMatchingProviders(remoteUrl)`.
+ *
+ * Returns `null` when no rule resolves — override pointing at an uninstalled
+ * plugin, default pointing at an unregistered ID, or no hostname match.
+ * Consumers treat `null` the same as "no provider registered" (quiet linkage
+ * absence, no toast, no log spam).
+ *
+ * Stateless and synchronous per the issue contract — no caching beyond
+ * per-call. Settings changes re-resolve on the next call.
+ *
+ * Override and global-default IDs may be stored either as the bare
+ * `contribution.id` (e.g. `"github"`) or as the namespaced `{pluginId}.{id}`
+ * form. The matcher accepts both.
+ */
+export async function resolveForgeProvider(
+  projectId: string
+): Promise<RegisteredForgeProvider | null> {
+  if (typeof projectId !== "string" || projectId.length === 0) return null;
+
+  try {
+    const project = projectStore.getProjectById(projectId);
+    if (!project) return null;
+
+    const gitService = gitServiceCache.getGitService(project.path);
+    const remoteUrl = await gitService.getRemoteUrl(project.path).catch(() => null);
+
+    // 1. Per-project override — searches the full registry, not just remote
+    //    candidates. A user who names a provider overrides hostname matching
+    //    entirely. Override-set-but-unregistered returns null (no fallthrough).
+    const settings = await projectStore.getProjectSettings(projectId).catch(() => null);
+    const override = settings?.forgeProviderOverride;
+    if (typeof override === "string" && override.length > 0) {
+      const all = getRegisteredForgeProviders();
+      return findById(all, override) ?? null;
+    }
+
+    if (!remoteUrl) return null;
+    const candidates = listMatchingProviders(remoteUrl);
+
+    // 2. Global default — must be one of the remote's candidates. A default
+    //    that does not match this project's remote returns null (no fallthrough).
+    const globalDefault = store.get("forgeDefaultProviderId");
+    if (typeof globalDefault === "string" && globalDefault.length > 0) {
+      return findById(candidates, globalDefault) ?? null;
+    }
+
+    // 3. First hostname match (or null if there are no candidates).
+    return candidates[0] ?? null;
+  } catch (error) {
+    console.warn(`[forgeProviderResolver] resolve failed for ${projectId}:`, error);
+    return null;
+  }
+}
+
+function findById(
+  providers: RegisteredForgeProvider[],
+  id: string
+): RegisteredForgeProvider | undefined {
+  return providers.find(
+    (p) => p.contribution.id === id || `${p.pluginId}.${p.contribution.id}` === id
+  );
+}

--- a/electron/services/forgeProviderResolver.ts
+++ b/electron/services/forgeProviderResolver.ts
@@ -35,12 +35,12 @@ export async function resolveForgeProvider(
     const project = projectStore.getProjectById(projectId);
     if (!project) return null;
 
-    const gitService = gitServiceCache.getGitService(project.path);
-    const remoteUrl = await gitService.getRemoteUrl(project.path).catch(() => null);
-
     // 1. Per-project override — searches the full registry, not just remote
     //    candidates. A user who names a provider overrides hostname matching
     //    entirely. Override-set-but-unregistered returns null (no fallthrough).
+    //
+    //    Read settings before the git remote lookup so the override path
+    //    short-circuits without awaiting I/O it doesn't need.
     const settings = await projectStore.getProjectSettings(projectId).catch(() => null);
     const override = settings?.forgeProviderOverride;
     if (typeof override === "string" && override.length > 0) {
@@ -48,6 +48,8 @@ export async function resolveForgeProvider(
       return findById(all, override) ?? null;
     }
 
+    const gitService = gitServiceCache.getGitService(project.path);
+    const remoteUrl = await gitService.getRemoteUrl(project.path).catch(() => null);
     if (!remoteUrl) return null;
     const candidates = listMatchingProviders(remoteUrl);
 

--- a/shared/types/ipc/api.ts
+++ b/shared/types/ipc/api.ts
@@ -1265,6 +1265,14 @@ export interface ElectronAPI {
      * on the next call without restart.
      */
     getProviders(): Promise<ForgeProviderEntry[]>;
+    /**
+     * Resolve the active forge provider for the given project, applying the
+     * per-project override → global default → first hostname match precedence
+     * chain. Returns `null` when no rule resolves (override or default points
+     * at an unavailable provider, no hostname match). Consumers treat `null`
+     * the same as "no provider registered".
+     */
+    resolveProvider(projectId: string): Promise<ForgeProviderEntry | null>;
   };
   voiceInput: {
     getSettings(): Promise<VoiceInputSettings>;

--- a/shared/types/ipc/maps.ts
+++ b/shared/types/ipc/maps.ts
@@ -1610,6 +1610,10 @@ export interface IpcInvokeMap extends GeneratedIpcInvokeMap {
     args: [];
     result: ForgeProviderEntry[];
   };
+  "forge:resolve-provider": {
+    args: [projectId: string];
+    result: ForgeProviderEntry | null;
+  };
 
   // Shortcut Hints
   "shortcut-hints:get-counts": {


### PR DESCRIPTION
Adds a main-process service that picks one active forge provider per project. Precedence:

1. Per-project `forgeProviderOverride` if it names a registered provider.
2. Global `forgeDefaultProviderId` if it matches one of the remote's hostname candidates.
3. First hostname match from `listMatchingProviders(remoteUrl)`.
4. `null` otherwise (override/default points at an unavailable provider, no hostname match).

Override and default IDs are looked up against the registry by both the bare `contribution.id` and the namespaced `{pluginId}.{contribution.id}` form.

Exposed over a new IPC channel `forge:resolve-provider`. The resolver reads project settings before the git remote lookup, so the override path short-circuits without awaiting git I/O.

No caching beyond per-call, per the issue contract.

## Files

- `electron/services/forgeProviderResolver.ts` (new)
- `electron/services/__tests__/forgeProviderResolver.test.ts` (new)
- `electron/ipc/channels.ts`, `electron/ipc/handlers/forgeSettings.ts`
- `electron/preload.cts`
- `shared/types/ipc/maps.ts`, `shared/types/ipc/api.ts`

## Tests

- Missing project, empty `projectId`
- Override match (bare id and `pluginId.id`)
- Override names an unregistered provider returns null (no fallthrough to lower tiers)
- Override `null` or absent falls through to auto-detect
- Global default match (bare id and `pluginId.id`)
- Global default not in remote candidates returns null
- First hostname match when nothing else is set
- No candidates returns null
- Remote URL unreadable returns null but override still resolves
- `getRemoteUrl` and `getProjectSettings` rejection paths
- Registry throw paths
- No caching — settings, store, remote, and registry re-read each call
- IPC handler delegation and invalid-payload paths

Closes #8112