### PR TITLE
refactor(notify): adopt supersedeKey and context.eventKind at five call sites

### DIFF
--- a/src/hooks/__tests__/useGitHubTokenExpiryNotification.test.tsx
+++ b/src/hooks/__tests__/useGitHubTokenExpiryNotification.test.tsx
@@ -134,7 +134,7 @@ describe("useGitHubTokenExpiryNotification", () => {
     expect(notifyMock).toHaveBeenCalledTimes(1);
   });
 
-  it("latch resets when health recovers while error persists, re-fires on next unhealthy", () => {
+  it("latch resets silently when health recovers while error persists, re-fires on next unhealthy", () => {
     useGitHubTokenHealthStore.setState({ isUnhealthy: true });
     const { rerender } = renderHook(
       ({ isTokenError }) => useGitHubTokenExpiryNotification(isTokenError),
@@ -142,16 +142,31 @@ describe("useGitHubTokenExpiryNotification", () => {
     );
     expect(notifyMock).toHaveBeenCalledTimes(1);
 
-    // Health recovery emits a low-priority "Token validated" row.
+    // `isUnhealthy` clearing while `isTokenError` stays true is not a true
+    // recovery — silently re-arm the latch but do NOT emit the success row.
     useGitHubTokenHealthStore.setState({ isUnhealthy: false });
     rerender({ isTokenError: true });
-    expect(notifyMock).toHaveBeenCalledTimes(2);
-    expect(notifyMock.mock.calls[1]?.[0]?.type).toBe("success");
-    expect(notifyMock.mock.calls[1]?.[0]?.priority).toBe("low");
+    expect(notifyMock).toHaveBeenCalledTimes(1);
 
     useGitHubTokenHealthStore.setState({ isUnhealthy: true });
     rerender({ isTokenError: true });
-    expect(notifyMock).toHaveBeenCalledTimes(3);
+    expect(notifyMock).toHaveBeenCalledTimes(2);
+    expect(notifyMock.mock.calls[1]?.[0]?.type).toBe("warning");
+  });
+
+  it("does not emit recovery when only isUnhealthy clears (isTokenError still true)", () => {
+    useGitHubTokenHealthStore.setState({ isUnhealthy: true });
+    const { rerender } = renderHook(
+      ({ isTokenError }) => useGitHubTokenExpiryNotification(isTokenError),
+      { initialProps: { isTokenError: true } }
+    );
+    expect(notifyMock).toHaveBeenCalledTimes(1);
+
+    useGitHubTokenHealthStore.setState({ isUnhealthy: false });
+    rerender({ isTokenError: true });
+    expect(notifyMock).toHaveBeenCalledTimes(1);
+    // No success row emitted — the token error is still active per the caller's signal.
+    expect(notifyMock.mock.calls.every((c) => c[0]?.type === "warning")).toBe(true);
   });
 
   it("emits a low-priority recovery row with matching supersedeKey on true → false transition", () => {

--- a/src/hooks/__tests__/useGitHubTokenExpiryNotification.test.tsx
+++ b/src/hooks/__tests__/useGitHubTokenExpiryNotification.test.tsx
@@ -68,11 +68,16 @@ describe("useGitHubTokenExpiryNotification", () => {
     );
     expect(notifyMock).toHaveBeenCalledTimes(1);
 
+    // Recovery transition emits a low-priority "Token validated" row.
     rerender({ isTokenError: false });
-    expect(notifyMock).toHaveBeenCalledTimes(1);
+    expect(notifyMock).toHaveBeenCalledTimes(2);
+    const recovery = notifyMock.mock.calls[1]?.[0];
+    expect(recovery?.type).toBe("success");
+    expect(recovery?.priority).toBe("low");
+    expect(recovery?.supersedeKey).toBe("github.token");
 
     rerender({ isTokenError: true });
-    expect(notifyMock).toHaveBeenCalledTimes(2);
+    expect(notifyMock).toHaveBeenCalledTimes(3);
   });
 
   it("constructs an action with actionId, actionArgs, and a working onClick", () => {
@@ -88,6 +93,7 @@ describe("useGitHubTokenExpiryNotification", () => {
     expect(payload.type).toBe("warning");
     expect(payload.priority).toBe("high");
     expect(payload.correlationId).toBe("github:token-expiry");
+    expect(payload.supersedeKey).toBe("github.token");
     expect(payload.title).toBe("GitHub authentication required");
     expect(payload.coalesce?.key).toBe("github:token-expiry");
 
@@ -136,13 +142,45 @@ describe("useGitHubTokenExpiryNotification", () => {
     );
     expect(notifyMock).toHaveBeenCalledTimes(1);
 
+    // Health recovery emits a low-priority "Token validated" row.
     useGitHubTokenHealthStore.setState({ isUnhealthy: false });
     rerender({ isTokenError: true });
-    expect(notifyMock).toHaveBeenCalledTimes(1);
+    expect(notifyMock).toHaveBeenCalledTimes(2);
+    expect(notifyMock.mock.calls[1]?.[0]?.type).toBe("success");
+    expect(notifyMock.mock.calls[1]?.[0]?.priority).toBe("low");
 
     useGitHubTokenHealthStore.setState({ isUnhealthy: true });
     rerender({ isTokenError: true });
+    expect(notifyMock).toHaveBeenCalledTimes(3);
+  });
+
+  it("emits a low-priority recovery row with matching supersedeKey on true → false transition", () => {
+    useGitHubTokenHealthStore.setState({ isUnhealthy: true });
+    const { rerender } = renderHook(
+      ({ isTokenError }) => useGitHubTokenExpiryNotification(isTokenError),
+      { initialProps: { isTokenError: true } }
+    );
+    expect(notifyMock).toHaveBeenCalledTimes(1);
+
+    rerender({ isTokenError: false });
     expect(notifyMock).toHaveBeenCalledTimes(2);
+    const recovery = notifyMock.mock.calls[1]?.[0];
+    if (!recovery) throw new Error("recovery notify was not called");
+    expect(recovery.type).toBe("success");
+    expect(recovery.priority).toBe("low");
+    expect(recovery.supersedeKey).toBe("github.token");
+    expect(recovery.title).toBe("GitHub token validated");
+  });
+
+  it("does not emit a recovery row when no prior warning was fired", () => {
+    const { rerender } = renderHook(
+      ({ isTokenError }) => useGitHubTokenExpiryNotification(isTokenError),
+      { initialProps: { isTokenError: false } }
+    );
+    expect(notifyMock).not.toHaveBeenCalled();
+
+    rerender({ isTokenError: false });
+    expect(notifyMock).not.toHaveBeenCalled();
   });
 
   it("suppresses toast when isTokenError is true but isUnhealthy stays false across renders", () => {

--- a/src/hooks/app/__tests__/useAgentWaitingNudge.test.tsx
+++ b/src/hooks/app/__tests__/useAgentWaitingNudge.test.tsx
@@ -194,6 +194,7 @@ describe("useAgentWaitingNudge", () => {
     expect(payload.placement).toBe("grid-bar");
     expect(payload.duration).toBe(0);
     expect(payload.type).toBe("info");
+    expect(payload.context).toEqual({ eventKind: "waiting", panelId: "t1" });
   });
 
   it("does not fire a second time for another agent", async () => {

--- a/src/hooks/app/useAgentWaitingNudge.ts
+++ b/src/hooks/app/useAgentWaitingNudge.ts
@@ -11,7 +11,7 @@ export function useAgentWaitingNudge(isStateLoaded: boolean): void {
   const firedRef = useRef(false);
   const notificationIdRef = useRef<string | null>(null);
 
-  function fireNudge() {
+  function fireNudge(panelId: string) {
     if (firedRef.current) return;
     firedRef.current = true;
 
@@ -28,6 +28,7 @@ export function useAgentWaitingNudge(isStateLoaded: boolean): void {
       inboxMessage:
         "Your agent is waiting for input. Enable notifications to get alerted when this happens.",
       duration: 0,
+      context: { eventKind: "waiting", panelId },
       actions: [
         {
           label: "Enable notifications",
@@ -82,9 +83,9 @@ export function useAgentWaitingNudge(isStateLoaded: boolean): void {
         eligibleRef.current = true;
 
         const { panelsById, panelIds } = usePanelStore.getState();
-        const hasWaiting = panelIds.some((id) => panelsById[id]?.agentState === "waiting");
-        if (hasWaiting && !firedRef.current) {
-          fireNudge();
+        const waitingId = panelIds.find((id) => panelsById[id]?.agentState === "waiting");
+        if (waitingId && !firedRef.current) {
+          fireNudge(waitingId);
         }
       } catch {
         // Silently ignore — nudge is non-critical
@@ -117,7 +118,7 @@ export function useAgentWaitingNudge(isStateLoaded: boolean): void {
         if (!terminal) continue;
         const prev = prevAgentStates.get(id);
         if (terminal.agentState === "waiting" && prev !== "waiting") {
-          fireNudge();
+          fireNudge(id);
           break;
         }
       }

--- a/src/hooks/useDiskSpaceWarnings.ts
+++ b/src/hooks/useDiskSpaceWarnings.ts
@@ -1,18 +1,11 @@
 import { useEffect, useRef } from "react";
-import { useNotificationStore } from "@/store/notificationStore";
 import { notify } from "@/lib/notify";
 import { isElectronAvailable } from "@/hooks/useElectron";
 
 const DISK_SPACE_CORRELATION_ID = "disk-space-warning";
+const DISK_SPACE_SUPERSEDE_KEY = "disk-space";
 
 let ipcListenerAttached = false;
-
-function findLiveDiskSpaceToastId(): string | null {
-  const match = useNotificationStore
-    .getState()
-    .notifications.find((n) => !n.dismissed && n.correlationId === DISK_SPACE_CORRELATION_ID);
-  return match?.id ?? null;
-}
 
 export function useDiskSpaceWarnings(): void {
   const didAttachListener = useRef(false);
@@ -25,10 +18,16 @@ export function useDiskSpaceWarnings(): void {
 
     const unsubscribe = window.electron.window.onDiskSpaceStatus((payload) => {
       if (payload.status === "normal") {
-        const liveId = findLiveDiskSpaceToastId();
-        if (liveId) {
-          useNotificationStore.getState().dismissNotification(liveId);
-        }
+        // Resolution row: priority "low" routes to inbox only; `supersedeKey`
+        // archives the prior warning entry automatically. Keyboard-only and
+        // screen-reader users get an explicit "back to normal" acknowledgement.
+        notify({
+          type: "success",
+          priority: "low",
+          supersedeKey: DISK_SPACE_SUPERSEDE_KEY,
+          title: "Disk space restored",
+          message: "Disk space is back to normal.",
+        });
         return;
       }
 
@@ -37,6 +36,8 @@ export function useDiskSpaceWarnings(): void {
       // urgent: critical/low disk warnings must surface even during quiet hours.
       // correlationId routes repeats through the store's collapse path so a
       // critical→low transition updates the same toast in place.
+      // supersedeKey pairs the warning with a later "Disk space restored"
+      // resolution row so the inbox doesn't accumulate stale stateful rows.
       if (payload.status === "critical") {
         // eslint-disable-next-line no-restricted-syntax -- notify-no-action: ok
         notify({
@@ -44,6 +45,7 @@ export function useDiskSpaceWarnings(): void {
           priority: "high",
           urgent: true,
           correlationId: DISK_SPACE_CORRELATION_ID,
+          supersedeKey: DISK_SPACE_SUPERSEDE_KEY,
           duration: 0,
           title: "Critical: Disk space very low",
           message: `Only ${mb} MB remaining. Session backups and terminal snapshots have been paused. Free disk space immediately.`,
@@ -55,6 +57,7 @@ export function useDiskSpaceWarnings(): void {
           priority: "high",
           urgent: true,
           correlationId: DISK_SPACE_CORRELATION_ID,
+          supersedeKey: DISK_SPACE_SUPERSEDE_KEY,
           duration: 8000,
           title: "Low disk space",
           message: `${mb} MB remaining on the application data volume. Free disk space to avoid data loss.`,
@@ -67,10 +70,6 @@ export function useDiskSpaceWarnings(): void {
       if (didAttachListener.current) {
         unsubscribe();
         ipcListenerAttached = false;
-        const liveId = findLiveDiskSpaceToastId();
-        if (liveId) {
-          useNotificationStore.getState().dismissNotification(liveId);
-        }
       }
     };
   }, []);

--- a/src/hooks/useGitHubTokenExpiryNotification.ts
+++ b/src/hooks/useGitHubTokenExpiryNotification.ts
@@ -3,6 +3,8 @@ import { notify } from "@/lib/notify";
 import { actionService } from "@/services/ActionService";
 import { useGitHubTokenHealthStore } from "@/store/githubTokenHealthStore";
 
+const GITHUB_TOKEN_SUPERSEDE_KEY = "github.token";
+
 /**
  * Surfaces a high-priority notification when the repository-stats poll detects
  * a token-related GitHub error. The inline toolbar UI alone is invisible to
@@ -11,6 +13,9 @@ import { useGitHubTokenHealthStore } from "@/store/githubTokenHealthStore";
  *
  * Hysteresis latch: fires once on the false→true transition and re-arms when
  * the error clears, so successful re-auth and a future re-expiry both notify.
+ * On the true→false recovery transition, emits a low-priority "Token validated"
+ * inbox row carrying the same `supersedeKey` so the prior warning row archives
+ * automatically and keyboard/screen-reader users get an explicit acknowledgement.
  */
 export function useGitHubTokenExpiryNotification(isTokenError: boolean): void {
   const firedRef = useRef(false);
@@ -27,6 +32,7 @@ export function useGitHubTokenExpiryNotification(isTokenError: boolean): void {
         message:
           "Your GitHub token isn't working. Reconnect in settings to restore issues, PRs, and stats.",
         correlationId: "github:token-expiry",
+        supersedeKey: GITHUB_TOKEN_SUPERSEDE_KEY,
         coalesce: {
           key: "github:token-expiry",
           windowMs: 30000,
@@ -47,7 +53,16 @@ export function useGitHubTokenExpiryNotification(isTokenError: boolean): void {
         },
       });
     } else {
-      firedRef.current = false;
+      if (firedRef.current) {
+        firedRef.current = false;
+        notify({
+          type: "success",
+          priority: "low",
+          supersedeKey: GITHUB_TOKEN_SUPERSEDE_KEY,
+          title: "GitHub token validated",
+          message: "Your GitHub token is working again.",
+        });
+      }
     }
   }, [isTokenError, isUnhealthy]);
 }

--- a/src/hooks/useGitHubTokenExpiryNotification.ts
+++ b/src/hooks/useGitHubTokenExpiryNotification.ts
@@ -52,9 +52,16 @@ export function useGitHubTokenExpiryNotification(isTokenError: boolean): void {
           },
         },
       });
-    } else {
-      if (firedRef.current) {
-        firedRef.current = false;
+    } else if (firedRef.current) {
+      const isResolved = !isTokenError;
+      firedRef.current = false;
+      // Only emit the recovery row when the caller's `isTokenError` signal
+      // actually clears. When only `isUnhealthy` drops (a health-store race or
+      // independent recovery) while `isTokenError` is still true, the token
+      // hasn't truly recovered — silently re-arm the latch so the next
+      // unhealthy event re-fires the warning, but don't show a stale
+      // "validated" confirmation.
+      if (isResolved) {
         notify({
           type: "success",
           priority: "low",

--- a/src/hooks/useIdleTerminalNotifications.ts
+++ b/src/hooks/useIdleTerminalNotifications.ts
@@ -71,6 +71,12 @@ export function useIdleTerminalNotifications(): void {
         priority: "high",
         duration: 0,
         actions: [closeAction, dismissAction],
+        // Single-project notifications carry projectId so the "Mute project"
+        // affordance routes correctly; multi-project omits it to avoid muting
+        // an unrelated project.
+        context: single
+          ? { eventKind: "completed", projectId: single.projectId }
+          : { eventKind: "completed" },
         coalesce: {
           key: "idle-terminal-notify:projects",
           windowMs: 30_000,

--- a/src/lib/watchNotification.ts
+++ b/src/lib/watchNotification.ts
@@ -58,6 +58,7 @@ export function fireWatchNotification(
     message: `${label} finished its task`,
     duration: 5000,
     correlationId: panelId,
+    context: { eventKind: "completed", panelId },
     action: {
       label: "Go to terminal",
       successLabel: "Opened",


### PR DESCRIPTION
Closes #8248.

## Summary

Wires `supersedeKey` and `context.eventKind` at the five call sites called out in the issue. Both fields were fully implemented in the dispatcher but used by only one production site each, so the user-visible "silence completed notifications" kebab and the inbox state-pair retirement only worked in a fraction of the places they should.

## Changes

- **`useDiskSpaceWarnings`** — removed the bespoke `findLiveDiskSpaceToastId` helper and the manual dismiss path. Warning and critical notifies now carry `supersedeKey: "disk-space"`; the `normal` status emits a low-priority "Disk space restored" inbox row carrying the same key, which archives the prior warning entry automatically.
- **`useGitHubTokenExpiryNotification`** — added `supersedeKey: "github.token"` to the warning, and a low-priority "Token validated" recovery row on the `isTokenError` true→false transition. Recovery is gated on the caller's `isTokenError` actually clearing: a momentary `isUnhealthy` drop while `isTokenError` stays true silently re-arms the latch without emitting a premature confirmation (caught in review).
- **`watchNotification`** — agent-completed toast now carries `context: { eventKind: "completed", panelId }`. "Silence completed notifications" becomes discoverable from the toast kebab and the inbox row.
- **`useAgentWaitingNudge`** — captures the triggering `panelId` from both the hydrate-time and subscribe-time paths and passes `context: { eventKind: "waiting", panelId }`. The grid-bar bar itself doesn't render a kebab, but the inbox row does, so the silence affordance is reachable from the notification center.
- **`useIdleTerminalNotifications`** — `context: { eventKind: "completed" }`; `projectId` is included only in the single-project case. Multi-project payloads omit the scope so the "Mute project notifications" affordance can't fire against the wrong target.

## Notes

- The shared `<feature>SupersedeKey` helper called out as out-of-scope in #8248 is deliberately not introduced. With three `supersedeKey` sites after this PR, abstraction adds little.
- `supersedeKey` archives the inbox entry but does not dismiss an already-visible toast. For the sticky critical disk-space toast, the resolution row provides the positive inbox confirmation while the toast persists until user dismissal — explicitly accepted in the issue.
- `useIdleTerminalNotifications` uses `projectId` instead of the issue-templated `panelId` because the IPC payload (`IdleTerminalNotifyPayload`) is project-scoped and carries no per-panel identifiers.

## Test plan

- [x] `useGitHubTokenExpiryNotification.test.tsx` — asserts new `supersedeKey`, latch tests updated, added explicit recovery emission + recovery suppression scenarios (`isUnhealthy` drop while `isTokenError` stays true)
- [x] `useAgentWaitingNudge.test.tsx` — asserts `context: { eventKind: "waiting", panelId: "t1" }`
- [x] `npm run check` — typecheck, lint, format, IPC drift, lint ratchet all green
- [ ] Manual: trigger a disk-space warning then free space — confirm the "Disk space restored" inbox row archives the prior warning entry
- [ ] Manual: trigger a GitHub token error then re-auth — confirm the "Token validated" inbox row appears and the warning archives
- [ ] Manual: confirm the "Silence completed notifications" kebab is discoverable on agent-completed and idle-terminal toasts