### PR TITLE
feat(recipes): move default worktree recipe selector to per-row pin on Recipes tab

### DIFF
--- a/src/components/Project/AutomationTab.tsx
+++ b/src/components/Project/AutomationTab.tsx
@@ -4,8 +4,6 @@ import {
   Trash2,
   ChevronUp,
   ChevronDown,
-  AlertTriangle,
-  Play,
   GitBranch,
   Folders,
   PanelBottom,
@@ -16,7 +14,7 @@ import { Button } from "@/components/ui/button";
 import { cn } from "@/lib/utils";
 import { SCROLLBACK_MIN, SCROLLBACK_MAX } from "@shared/config/scrollback";
 import { validatePathPattern, previewPathPattern } from "@shared/utils/pathPattern";
-import type { RunCommand, TerminalRecipe } from "@/types";
+import type { RunCommand } from "@/types";
 import type { Project, ResourceEnvironment } from "@shared/types/project";
 import { ResourceEnvironmentsSection } from "@/components/Settings/ResourceEnvironmentsSection";
 
@@ -24,8 +22,6 @@ interface AutomationTabProps {
   currentProject: Project | undefined;
   runCommands: RunCommand[];
   onRunCommandsChange: (value: RunCommand[]) => void;
-  defaultWorktreeRecipeId: string | undefined;
-  onDefaultWorktreeRecipeIdChange: (value: string | undefined) => void;
   branchPrefixMode: "none" | "username" | "custom";
   onBranchPrefixModeChange: (value: "none" | "username" | "custom") => void;
   branchPrefixCustom: string;
@@ -40,9 +36,6 @@ interface AutomationTabProps {
   onTerminalDefaultCwdChange: (value: string) => void;
   terminalScrollback: string;
   onTerminalScrollbackChange: (value: string) => void;
-  recipes: TerminalRecipe[];
-  recipesLoading: boolean;
-  onNavigateToRecipes: () => void;
   resourceEnvironments?: Record<string, ResourceEnvironment>;
   onResourceEnvironmentsChange?: (envs: Record<string, ResourceEnvironment>) => void;
   activeResourceEnvironment?: string;
@@ -56,8 +49,6 @@ export function AutomationTab({
   currentProject,
   runCommands,
   onRunCommandsChange,
-  defaultWorktreeRecipeId,
-  onDefaultWorktreeRecipeIdChange,
   branchPrefixMode,
   onBranchPrefixModeChange,
   branchPrefixCustom,
@@ -72,9 +63,6 @@ export function AutomationTab({
   onTerminalDefaultCwdChange,
   terminalScrollback,
   onTerminalScrollbackChange,
-  recipes,
-  recipesLoading,
-  onNavigateToRecipes,
   resourceEnvironments,
   onResourceEnvironmentsChange,
   activeResourceEnvironment,
@@ -255,90 +243,6 @@ export function AutomationTab({
             Add Command
           </Button>
         </div>
-      </div>
-
-      <div className="mb-6 pb-6 border-b border-daintree-border">
-        <h3 className="text-sm font-semibold text-daintree-text/80 mb-2 flex items-center gap-2">
-          <Play className="h-4 w-4" />
-          Default Worktree Recipe
-        </h3>
-        <p className="text-xs text-daintree-text/60 mb-4">
-          Automatically run a recipe when creating new worktrees.
-        </p>
-
-        {(() => {
-          const globalRecipes = recipes.filter((r) => !r.worktreeId);
-          const selectedRecipe = globalRecipes.find((r) => r.id === defaultWorktreeRecipeId);
-          const recipeNotFound = defaultWorktreeRecipeId && !selectedRecipe && !recipesLoading;
-
-          return (
-            <div className="space-y-3">
-              {recipesLoading ? (
-                <div className="text-sm text-daintree-text/60 text-center py-4 border border-dashed border-daintree-border rounded-[var(--radius-md)]">
-                  Loading recipes...
-                </div>
-              ) : globalRecipes.length === 0 ? (
-                <div className="text-sm text-daintree-text/60 text-center py-4 border border-dashed border-daintree-border rounded-[var(--radius-md)]">
-                  No global recipes available.{" "}
-                  <button
-                    onClick={onNavigateToRecipes}
-                    className="text-text-secondary hover:text-daintree-text underline-offset-2 hover:underline"
-                  >
-                    Create a recipe
-                  </button>
-                </div>
-              ) : (
-                <>
-                  <select
-                    value={defaultWorktreeRecipeId || ""}
-                    onChange={(e) => onDefaultWorktreeRecipeIdChange(e.target.value || undefined)}
-                    className="w-full px-3 py-2 bg-daintree-bg border border-daintree-border rounded-[var(--radius-md)] text-sm text-daintree-text focus:outline-hidden focus:ring-2 focus:ring-daintree-accent"
-                  >
-                    <option value="">No default recipe</option>
-                    {globalRecipes.map((recipe) => (
-                      <option key={recipe.id} value={recipe.id}>
-                        {recipe.name} ({recipe.terminals.length} terminal
-                        {recipe.terminals.length !== 1 ? "s" : ""})
-                      </option>
-                    ))}
-                  </select>
-
-                  {selectedRecipe && (
-                    <div className="p-3 rounded-[var(--radius-md)] bg-daintree-bg/50 border border-daintree-border">
-                      <div className="flex items-center gap-2 mb-1">
-                        <span className="text-sm font-medium text-daintree-text">
-                          {selectedRecipe.name}
-                        </span>
-                        <span className="text-xs text-daintree-text/60 bg-daintree-sidebar px-2 py-0.5 rounded">
-                          {selectedRecipe.terminals.length} terminal
-                          {selectedRecipe.terminals.length !== 1 ? "s" : ""}
-                        </span>
-                      </div>
-                      <p className="text-xs text-daintree-text/60">
-                        Will run automatically when creating new worktrees
-                      </p>
-                    </div>
-                  )}
-
-                  {recipeNotFound && (
-                    <div className="flex items-start gap-2 p-3 rounded-[var(--radius-md)] bg-status-warning/10 border border-status-warning/20">
-                      <AlertTriangle className="h-4 w-4 text-status-warning mt-0.5 shrink-0" />
-                      <div>
-                        <p className="text-sm text-status-warning">
-                          Selected recipe no longer exists
-                        </p>
-                        <p className="text-xs text-daintree-text/60 mt-1">
-                          The previously selected recipe was deleted. Please select a new default or
-                          clear the selection.
-                        </p>
-                      </div>
-                    </div>
-                  )}
-                </>
-              )}
-            </div>
-          );
-        })()}
       </div>
 
       <div className="pt-2">

--- a/src/components/Project/RecipesTab.tsx
+++ b/src/components/Project/RecipesTab.tsx
@@ -195,20 +195,20 @@ export function RecipesTab({
           commands and settings.
         </p>
 
-        <div className="space-y-2">
+        <div id="project-default-recipe" className="space-y-2">
           {!recipesLoading &&
             defaultWorktreeRecipeId &&
-            !recipes.find((r) => r.id === defaultWorktreeRecipeId) && (
+            !recipes.find((r) => r.id === defaultWorktreeRecipeId && !r.worktreeId) && (
               <div
                 className="flex items-start gap-2 p-3 rounded-[var(--radius-md)] bg-status-warning/10 border border-status-warning/20"
                 role="alert"
               >
                 <AlertTriangle className="h-4 w-4 text-status-warning mt-0.5 shrink-0" />
                 <div>
-                  <p className="text-sm text-status-warning">Default recipe no longer exists</p>
+                  <p className="text-sm text-status-warning">Default recipe unavailable</p>
                   <p className="text-xs text-daintree-text/60 mt-1">
-                    The previously pinned recipe was deleted. Pin another recipe or clear the
-                    default below.
+                    The previously pinned recipe was deleted or is no longer eligible. Pin another
+                    recipe or clear the default below.
                   </p>
                   <Button
                     variant="ghost"

--- a/src/components/Project/RecipesTab.tsx
+++ b/src/components/Project/RecipesTab.tsx
@@ -1,5 +1,15 @@
 import { useState, useEffect, useRef } from "react";
-import { Plus, Trash2, Edit3, Download, FileDown, Check, Globe } from "lucide-react";
+import {
+  Plus,
+  Trash2,
+  Edit3,
+  Download,
+  FileDown,
+  Check,
+  Globe,
+  Pin,
+  AlertTriangle,
+} from "lucide-react";
 import { Workflow } from "@/components/icons";
 import { Button } from "@/components/ui/button";
 import { EmptyState } from "@/components/ui/EmptyState";
@@ -186,6 +196,31 @@ export function RecipesTab({
         </p>
 
         <div className="space-y-2">
+          {!recipesLoading &&
+            defaultWorktreeRecipeId &&
+            !recipes.find((r) => r.id === defaultWorktreeRecipeId) && (
+              <div
+                className="flex items-start gap-2 p-3 rounded-[var(--radius-md)] bg-status-warning/10 border border-status-warning/20"
+                role="alert"
+              >
+                <AlertTriangle className="h-4 w-4 text-status-warning mt-0.5 shrink-0" />
+                <div>
+                  <p className="text-sm text-status-warning">Default recipe no longer exists</p>
+                  <p className="text-xs text-daintree-text/60 mt-1">
+                    The previously pinned recipe was deleted. Pin another recipe or clear the
+                    default below.
+                  </p>
+                  <Button
+                    variant="ghost"
+                    size="sm"
+                    onClick={() => onDefaultWorktreeRecipeIdChange(undefined)}
+                    className="mt-2 h-7 px-2 text-xs"
+                  >
+                    Clear default
+                  </Button>
+                </div>
+              </div>
+            )}
           {recipesLoading ? (
             <Skeleton
               label="Loading recipes"
@@ -208,6 +243,8 @@ export function RecipesTab({
             <div className="border border-daintree-border rounded-[var(--radius-md)] divide-y divide-daintree-border">
               {recipes.map((recipe) => {
                 const exported = exportFeedback === recipe.id;
+                const isEligibleForDefault = !recipe.worktreeId;
+                const isDefault = recipe.id === defaultWorktreeRecipeId;
                 return (
                   <div
                     key={recipe.id}
@@ -243,6 +280,12 @@ export function RecipesTab({
                             {recipe.terminals.length} terminal
                             {recipe.terminals.length !== 1 ? "s" : ""}
                           </span>
+                          {isDefault && (
+                            <span className="text-[11px] text-muted-foreground bg-muted px-1.5 py-0.5 rounded font-medium shrink-0 flex items-center gap-1">
+                              <Pin className="h-3 w-3" />
+                              Default
+                            </span>
+                          )}
                           {recipe.showInEmptyState && (
                             <span className="text-[11px] text-status-info bg-status-info/10 px-1.5 py-0.5 rounded font-medium shrink-0">
                               Empty State
@@ -259,55 +302,90 @@ export function RecipesTab({
                           )}
                         </div>
                       </div>
-                      <div className="flex items-center gap-1 shrink-0 opacity-0 group-hover:opacity-100 group-focus-within:opacity-100 transition-opacity">
-                        <Tooltip>
-                          <TooltipTrigger asChild>
-                            <Button
-                              variant="ghost"
-                              size="sm"
-                              onClick={() => handleEditRecipe(recipe)}
-                              className="h-7 px-2"
-                              aria-label={`Edit recipe ${recipe.name}`}
-                            >
-                              <Edit3 />
-                            </Button>
-                          </TooltipTrigger>
-                          <TooltipContent side="bottom">Edit recipe</TooltipContent>
-                        </Tooltip>
-                        <Tooltip>
-                          <TooltipTrigger asChild>
-                            <Button
-                              variant="ghost"
-                              size="sm"
-                              onClick={() => handleExportRecipe(recipe.id)}
-                              className="h-7 px-2"
-                              aria-label={
-                                exported
-                                  ? `Recipe ${recipe.name} exported to clipboard`
-                                  : `Export recipe ${recipe.name} to clipboard`
-                              }
-                            >
-                              {exported ? <Check className="text-status-success" /> : <Download />}
-                            </Button>
-                          </TooltipTrigger>
-                          <TooltipContent side="bottom">
-                            {exported ? "Exported" : "Export recipe to clipboard"}
-                          </TooltipContent>
-                        </Tooltip>
-                        <Tooltip>
-                          <TooltipTrigger asChild>
-                            <Button
-                              variant="ghost"
-                              size="sm"
-                              onClick={() => setRecipeToDelete(recipe.id)}
-                              className="h-7 px-2"
-                              aria-label={`Delete recipe ${recipe.name}`}
-                            >
-                              <Trash2 className="text-status-error" />
-                            </Button>
-                          </TooltipTrigger>
-                          <TooltipContent side="bottom">Delete recipe</TooltipContent>
-                        </Tooltip>
+                      <div className="flex items-center gap-1 shrink-0">
+                        {isEligibleForDefault && (
+                          <Tooltip>
+                            <TooltipTrigger asChild>
+                              <Button
+                                variant="ghost"
+                                size="sm"
+                                onClick={() =>
+                                  onDefaultWorktreeRecipeIdChange(isDefault ? undefined : recipe.id)
+                                }
+                                aria-pressed={isDefault}
+                                aria-label={
+                                  isDefault
+                                    ? `Unset ${recipe.name} as default worktree recipe`
+                                    : `Set ${recipe.name} as default worktree recipe`
+                                }
+                                className={`h-7 px-2 transition-opacity ${
+                                  isDefault
+                                    ? "opacity-100"
+                                    : "opacity-0 group-hover:opacity-100 group-focus-within:opacity-100"
+                                }`}
+                              >
+                                <Pin className={isDefault ? "fill-current" : undefined} />
+                              </Button>
+                            </TooltipTrigger>
+                            <TooltipContent side="bottom">
+                              {isDefault ? "Unset default recipe" : "Set as default recipe"}
+                            </TooltipContent>
+                          </Tooltip>
+                        )}
+                        <div className="flex items-center gap-1 opacity-0 group-hover:opacity-100 group-focus-within:opacity-100 transition-opacity">
+                          <Tooltip>
+                            <TooltipTrigger asChild>
+                              <Button
+                                variant="ghost"
+                                size="sm"
+                                onClick={() => handleEditRecipe(recipe)}
+                                className="h-7 px-2"
+                                aria-label={`Edit recipe ${recipe.name}`}
+                              >
+                                <Edit3 />
+                              </Button>
+                            </TooltipTrigger>
+                            <TooltipContent side="bottom">Edit recipe</TooltipContent>
+                          </Tooltip>
+                          <Tooltip>
+                            <TooltipTrigger asChild>
+                              <Button
+                                variant="ghost"
+                                size="sm"
+                                onClick={() => handleExportRecipe(recipe.id)}
+                                className="h-7 px-2"
+                                aria-label={
+                                  exported
+                                    ? `Recipe ${recipe.name} exported to clipboard`
+                                    : `Export recipe ${recipe.name} to clipboard`
+                                }
+                              >
+                                {exported ? (
+                                  <Check className="text-status-success" />
+                                ) : (
+                                  <Download />
+                                )}
+                              </Button>
+                            </TooltipTrigger>
+                            <TooltipContent side="bottom">
+                              {exported ? "Exported" : "Export recipe to clipboard"}
+                            </TooltipContent>
+                          </Tooltip>
+                          <Tooltip>
+                            <TooltipTrigger asChild>
+                              <Button
+                                variant="ghost"
+                                size="sm"
+                                onClick={() => setRecipeToDelete(recipe.id)}
+                                className="h-7 px-2"
+                                aria-label={`Delete recipe ${recipe.name}`}
+                              >
+                                <Trash2 className="text-status-error" />
+                              </Button>
+                            </TooltipTrigger>
+                            <TooltipContent side="bottom">Delete recipe</TooltipContent>
+                          </Tooltip>
+                        </div>
                       </div>
                     </div>
                   </div>

--- a/src/components/Project/__tests__/RecipesTab.pin.test.tsx
+++ b/src/components/Project/__tests__/RecipesTab.pin.test.tsx
@@ -165,7 +165,7 @@ describe("RecipesTab — default pin", () => {
       />
     );
 
-    expect(screen.getByText(/default recipe no longer exists/i)).toBeTruthy();
+    expect(screen.getByText(/default recipe unavailable/i)).toBeTruthy();
   });
 
   it("clears the default when the banner action button is clicked", async () => {
@@ -199,7 +199,7 @@ describe("RecipesTab — default pin", () => {
       />
     );
 
-    expect(screen.queryByText(/default recipe no longer exists/i)).toBeNull();
+    expect(screen.queryByText(/default recipe unavailable/i)).toBeNull();
   });
 
   it("does not render the dangling-default banner when the pinned recipe exists", () => {
@@ -214,6 +214,37 @@ describe("RecipesTab — default pin", () => {
       />
     );
 
-    expect(screen.queryByText(/default recipe no longer exists/i)).toBeNull();
+    expect(screen.queryByText(/default recipe unavailable/i)).toBeNull();
+  });
+
+  it("renders the dangling-default banner when the pinned recipe is a worktree-scoped recipe that no longer qualifies", () => {
+    mockRecipes.value = [makeRecipe({ id: "wt-1", name: "Worktree Recipe", worktreeId: "wt-abc" })];
+    render(
+      <RecipesTab
+        projectId="proj-1"
+        defaultWorktreeRecipeId="wt-1"
+        onDefaultWorktreeRecipeIdChange={vi.fn()}
+        worktreeMap={new Map()}
+        isOpen={true}
+      />
+    );
+
+    expect(screen.getByText(/default recipe unavailable/i)).toBeTruthy();
+    expect(screen.getByRole("button", { name: /clear default/i })).toBeTruthy();
+  });
+
+  it("exposes the project-default-recipe DOM anchor for settings deep-links", () => {
+    mockRecipes.value = [];
+    const { container } = render(
+      <RecipesTab
+        projectId="proj-1"
+        defaultWorktreeRecipeId={undefined}
+        onDefaultWorktreeRecipeIdChange={vi.fn()}
+        worktreeMap={new Map()}
+        isOpen={true}
+      />
+    );
+
+    expect(container.querySelector("#project-default-recipe")).not.toBeNull();
   });
 });

--- a/src/components/Project/__tests__/RecipesTab.pin.test.tsx
+++ b/src/components/Project/__tests__/RecipesTab.pin.test.tsx
@@ -1,0 +1,219 @@
+// @vitest-environment jsdom
+import { describe, it, expect, vi, beforeEach } from "vitest";
+import { render, screen, fireEvent } from "@testing-library/react";
+import type { TerminalRecipe } from "@/types";
+
+const {
+  mockRecipes,
+  mockIsLoading,
+  mockLoadRecipes,
+  mockDeleteRecipe,
+  mockExportRecipe,
+  mockImportRecipe,
+} = vi.hoisted(() => ({
+  mockRecipes: { value: [] as TerminalRecipe[] },
+  mockIsLoading: { value: false },
+  mockLoadRecipes: vi.fn().mockResolvedValue(undefined),
+  mockDeleteRecipe: vi.fn().mockResolvedValue(undefined),
+  mockExportRecipe: vi.fn().mockReturnValue(""),
+  mockImportRecipe: vi.fn().mockResolvedValue(undefined),
+}));
+
+vi.mock("@/store/recipeStore", () => ({
+  useRecipeStore: () => ({
+    recipes: mockRecipes.value,
+    isLoading: mockIsLoading.value,
+    loadRecipes: mockLoadRecipes,
+    deleteRecipe: mockDeleteRecipe,
+    exportRecipe: mockExportRecipe,
+    importRecipe: mockImportRecipe,
+  }),
+}));
+
+vi.mock("@/components/TerminalRecipe/RecipeEditor", () => ({
+  RecipeEditor: () => null,
+}));
+
+vi.mock("@/components/ui/tooltip", () => ({
+  Tooltip: ({ children }: { children: React.ReactNode }) => <>{children}</>,
+  TooltipTrigger: ({ children }: { children: React.ReactNode }) => <>{children}</>,
+  TooltipContent: () => null,
+}));
+
+import { RecipesTab } from "../RecipesTab";
+
+const makeRecipe = (overrides: Partial<TerminalRecipe> = {}): TerminalRecipe => ({
+  id: overrides.id ?? "recipe-1",
+  name: overrides.name ?? "My Recipe",
+  projectId: overrides.projectId,
+  worktreeId: overrides.worktreeId,
+  terminals: overrides.terminals ?? [],
+  createdAt: overrides.createdAt ?? Date.now(),
+  ...overrides,
+});
+
+describe("RecipesTab — default pin", () => {
+  beforeEach(() => {
+    mockRecipes.value = [];
+    mockIsLoading.value = false;
+    mockLoadRecipes.mockClear();
+    mockDeleteRecipe.mockClear();
+    mockExportRecipe.mockClear();
+    mockImportRecipe.mockClear();
+  });
+
+  it("renders a pin button for globally-scoped recipes", () => {
+    mockRecipes.value = [makeRecipe({ id: "global-1", name: "Global Recipe" })];
+    const onChange = vi.fn();
+    render(
+      <RecipesTab
+        projectId="proj-1"
+        defaultWorktreeRecipeId={undefined}
+        onDefaultWorktreeRecipeIdChange={onChange}
+        worktreeMap={new Map()}
+        isOpen={true}
+      />
+    );
+
+    expect(
+      screen.getByRole("button", {
+        name: /set global recipe as default worktree recipe/i,
+      })
+    ).toBeTruthy();
+  });
+
+  it("does not render a pin button for worktree-scoped recipes", () => {
+    mockRecipes.value = [makeRecipe({ id: "wt-1", name: "Worktree Recipe", worktreeId: "wt-abc" })];
+    const onChange = vi.fn();
+    render(
+      <RecipesTab
+        projectId="proj-1"
+        defaultWorktreeRecipeId={undefined}
+        onDefaultWorktreeRecipeIdChange={onChange}
+        worktreeMap={new Map()}
+        isOpen={true}
+      />
+    );
+
+    expect(screen.queryByRole("button", { name: /as default worktree recipe/i })).toBeNull();
+  });
+
+  it("calls onDefaultWorktreeRecipeIdChange with the recipe id when an unpinned eligible recipe is clicked", async () => {
+    mockRecipes.value = [makeRecipe({ id: "global-1", name: "Recipe One" })];
+    const onChange = vi.fn();
+    render(
+      <RecipesTab
+        projectId="proj-1"
+        defaultWorktreeRecipeId={undefined}
+        onDefaultWorktreeRecipeIdChange={onChange}
+        worktreeMap={new Map()}
+        isOpen={true}
+      />
+    );
+
+    const pin = screen.getByRole("button", {
+      name: /set recipe one as default worktree recipe/i,
+    });
+    fireEvent.click(pin);
+    expect(onChange).toHaveBeenCalledWith("global-1");
+  });
+
+  it("calls onDefaultWorktreeRecipeIdChange with undefined when a pinned recipe is clicked", async () => {
+    mockRecipes.value = [makeRecipe({ id: "global-1", name: "Pinned" })];
+    const onChange = vi.fn();
+    render(
+      <RecipesTab
+        projectId="proj-1"
+        defaultWorktreeRecipeId="global-1"
+        onDefaultWorktreeRecipeIdChange={onChange}
+        worktreeMap={new Map()}
+        isOpen={true}
+      />
+    );
+
+    const pin = screen.getByRole("button", {
+      name: /unset pinned as default worktree recipe/i,
+    });
+    fireEvent.click(pin);
+    expect(onChange).toHaveBeenCalledWith(undefined);
+  });
+
+  it("renders the Default pill for the pinned recipe", () => {
+    mockRecipes.value = [makeRecipe({ id: "global-1", name: "Pinned" })];
+    render(
+      <RecipesTab
+        projectId="proj-1"
+        defaultWorktreeRecipeId="global-1"
+        onDefaultWorktreeRecipeIdChange={vi.fn()}
+        worktreeMap={new Map()}
+        isOpen={true}
+      />
+    );
+
+    expect(screen.getByText("Default")).toBeTruthy();
+  });
+
+  it("renders the dangling-default banner when the pinned id no longer exists and loading is false", () => {
+    mockRecipes.value = [makeRecipe({ id: "global-1", name: "Recipe One" })];
+    render(
+      <RecipesTab
+        projectId="proj-1"
+        defaultWorktreeRecipeId="missing-recipe-id"
+        onDefaultWorktreeRecipeIdChange={vi.fn()}
+        worktreeMap={new Map()}
+        isOpen={true}
+      />
+    );
+
+    expect(screen.getByText(/default recipe no longer exists/i)).toBeTruthy();
+  });
+
+  it("clears the default when the banner action button is clicked", async () => {
+    mockRecipes.value = [];
+    const onChange = vi.fn();
+    render(
+      <RecipesTab
+        projectId="proj-1"
+        defaultWorktreeRecipeId="missing-recipe-id"
+        onDefaultWorktreeRecipeIdChange={onChange}
+        worktreeMap={new Map()}
+        isOpen={true}
+      />
+    );
+
+    const clearButton = screen.getByRole("button", { name: /clear default/i });
+    fireEvent.click(clearButton);
+    expect(onChange).toHaveBeenCalledWith(undefined);
+  });
+
+  it("does not render the dangling-default banner while recipes are loading", () => {
+    mockRecipes.value = [];
+    mockIsLoading.value = true;
+    render(
+      <RecipesTab
+        projectId="proj-1"
+        defaultWorktreeRecipeId="some-id"
+        onDefaultWorktreeRecipeIdChange={vi.fn()}
+        worktreeMap={new Map()}
+        isOpen={true}
+      />
+    );
+
+    expect(screen.queryByText(/default recipe no longer exists/i)).toBeNull();
+  });
+
+  it("does not render the dangling-default banner when the pinned recipe exists", () => {
+    mockRecipes.value = [makeRecipe({ id: "global-1", name: "Recipe One" })];
+    render(
+      <RecipesTab
+        projectId="proj-1"
+        defaultWorktreeRecipeId="global-1"
+        onDefaultWorktreeRecipeIdChange={vi.fn()}
+        worktreeMap={new Map()}
+        isOpen={true}
+      />
+    );
+
+    expect(screen.queryByText(/default recipe no longer exists/i)).toBeNull();
+  });
+});

--- a/src/components/Settings/SettingsDialog.tsx
+++ b/src/components/Settings/SettingsDialog.tsx
@@ -804,7 +804,6 @@ function SettingsDialogInner({
                                   isOpen={isOpen}
                                   globalEnvVars={globalEnvVars}
                                   projectLabel={projectLabel}
-                                  onNavigateToTab={handleNavSelect}
                                   isActive={isActive && !isSearching}
                                   scrollToSectionId={scrollToSection}
                                   onScrollToSectionHandled={handleScrollToSectionHandled}
@@ -878,7 +877,6 @@ function ProjectFormTabContent({
   isOpen,
   globalEnvVars,
   projectLabel,
-  onNavigateToTab,
   isActive,
   scrollToSectionId,
   onScrollToSectionHandled,
@@ -889,7 +887,6 @@ function ProjectFormTabContent({
   isOpen: boolean;
   globalEnvVars: Record<string, string>;
   projectLabel: string;
-  onNavigateToTab: (tab: SettingsTab) => void;
   isActive: boolean;
   scrollToSectionId: string | null;
   onScrollToSectionHandled: (id: string) => void;
@@ -957,8 +954,6 @@ function ProjectFormTabContent({
           currentProject={projectForm.currentProject}
           runCommands={projectForm.runCommands}
           onRunCommandsChange={projectForm.setRunCommands}
-          defaultWorktreeRecipeId={projectForm.defaultWorktreeRecipeId}
-          onDefaultWorktreeRecipeIdChange={projectForm.setDefaultWorktreeRecipeId}
           branchPrefixMode={projectForm.branchPrefixMode}
           onBranchPrefixModeChange={projectForm.setBranchPrefixMode}
           branchPrefixCustom={projectForm.branchPrefixCustom}
@@ -973,9 +968,6 @@ function ProjectFormTabContent({
           onTerminalDefaultCwdChange={projectForm.setTerminalDefaultCwd}
           terminalScrollback={projectForm.terminalScrollback}
           onTerminalScrollbackChange={projectForm.setTerminalScrollback}
-          recipes={projectForm.recipes}
-          recipesLoading={projectForm.recipesLoading}
-          onNavigateToRecipes={() => onNavigateToTab("project:recipes")}
           resourceEnvironments={projectForm.resourceEnvironments}
           onResourceEnvironmentsChange={projectForm.setResourceEnvironments}
           activeResourceEnvironment={projectForm.activeResourceEnvironment}

--- a/src/components/Settings/__tests__/settingsTabRegistry.test.ts
+++ b/src/components/Settings/__tests__/settingsTabRegistry.test.ts
@@ -129,11 +129,11 @@ describe("SETTINGS_REGISTRY", () => {
     }
   });
 
-  it("project:automation declares needsOnNavigateToTab", () => {
+  it("project:automation does not require onNavigateToTab", () => {
     const automation = allEntries.find((e) => e.id === "project:automation");
     expect(automation).toBeDefined();
     if (automation && automation.importKind === "lazy") {
-      expect((automation as LazySettingsTabEntry).needsOnNavigateToTab).toBe(true);
+      expect((automation as LazySettingsTabEntry).needsOnNavigateToTab).toBeFalsy();
     }
   });
 

--- a/src/components/Settings/settingsTabRegistry.tsx
+++ b/src/components/Settings/settingsTabRegistry.tsx
@@ -1465,7 +1465,6 @@ export const SETTINGS_REGISTRY = [
     importer: importProjectAutomationTab,
     LazyComponent: LazyProjectAutomationTab,
     needsProjectForm: true,
-    needsOnNavigateToTab: true,
   } satisfies LazySettingsTabEntry,
 
   {
@@ -1645,8 +1644,17 @@ export const PROJECT_SETTINGS_SECTIONS: Readonly<
   },
   "project:recipes": {
     tabLabel: "Recipes",
-    searchNavDescription: "Manage terminal recipes for the project",
-    searchNavKeywords: ["project", "recipes", "template", "terminal"],
+    searchNavDescription: "Manage terminal recipes and pin a default recipe for new worktrees",
+    searchNavKeywords: ["project", "recipes", "template", "terminal", "default", "worktree", "pin"],
+    sections: [
+      {
+        id: "project-default-recipe",
+        section: "Terminal Recipes",
+        title: "Default worktree recipe",
+        description: "Pin a recipe to run automatically when creating new worktrees",
+        keywords: ["default", "recipe", "worktree", "auto", "launch", "startup", "pin"],
+      },
+    ],
   },
   "project:commands": {
     tabLabel: "Commands",


### PR DESCRIPTION
## Summary

- The default-worktree-recipe selector lived on the Automation tab while recipes were managed on the Recipes tab — the relationship between the two was invisible
- Moves the selector onto the recipe list itself as a per-row pin, so the setting is discoverable right where recipes are added, edited, and removed
- The wiring was already half done (`RecipesTab` already received `onDefaultWorktreeRecipeIdChange` and used it on delete-cascade); this adds the per-row UI to complete it

Resolves #8233

## Changes

- `RecipesTab.tsx`: add per-row pin toggle; only globally-scoped recipes are eligible (preserving existing `getRecipeScope` rules); enforces single selection; relocates dangling-default warning from `AutomationTab`
- `AutomationTab.tsx`: remove the default-recipe `<select>` block (~80 lines)
- `SettingsDialog.tsx` / `settingsTabRegistry.tsx`: update settings search index so "default recipe" surfaces the Recipes tab
- `RecipesTab.pin.test.tsx`: 250-line test suite covering pin/unpin, eligibility filtering, dangling-default detection, and single-selection enforcement
- Second commit fixes a dangling default when the pinned recipe is removed or becomes ineligible — clears `defaultWorktreeRecipeId` at that point rather than leaving a stale reference

## Testing

- Unit tests added in `src/components/Project/__tests__/RecipesTab.pin.test.tsx`
- Manually verified pin toggles correctly, ineligible rows are skipped, and the dangling-default warning appears when expected