### PR TITLE
refactor(project-settings): centralize ProjectSettings shareability into a single table

### DIFF
--- a/electron/services/ProjectIdentityFiles.ts
+++ b/electron/services/ProjectIdentityFiles.ts
@@ -26,11 +26,14 @@ const SAFE_AGENT_ID = /^[a-zA-Z0-9_.-]+$/;
 
 /**
  * Returns true if the value is "present enough" to write to disk. Mirrors the
- * legacy hand-coded checks: skip `undefined`, empty strings, and empty arrays;
- * keep `0`, `false`, and non-empty objects.
+ * legacy hand-coded checks: skip `undefined`, `null`, empty strings, and empty
+ * arrays; keep `0`, `false`, and non-empty objects. Renderer callers
+ * occasionally send `null` for "clear this field", which must not survive into
+ * the committed `.daintree/settings.json` (the reader drops it, but a `null`
+ * entry produces spurious git diffs).
  */
 function shouldWriteValue(value: unknown): boolean {
-  if (value === undefined) return false;
+  if (value === undefined || value === null) return false;
   if (typeof value === "string") return value.length > 0;
   if (Array.isArray(value)) return value.length > 0;
   return true;

--- a/electron/services/ProjectIdentityFiles.ts
+++ b/electron/services/ProjectIdentityFiles.ts
@@ -1,5 +1,9 @@
 import type { ProjectSettings, TerminalRecipe } from "../types/index.js";
-import type { RunCommand, CopyTreeSettings } from "../../shared/types/project.js";
+import {
+  PROJECT_SETTINGS_SHAREABILITY,
+  PROJECT_TERMINAL_SETTINGS_SHAREABILITY,
+  type ProjectTerminalSettings,
+} from "../../shared/types/project.js";
 import type { AgentPreset } from "../../shared/config/agentRegistry.js";
 import path from "path";
 import fs from "fs/promises";
@@ -19,6 +23,39 @@ const DAINTREE_PRESETS_DIR = `${DAINTREE_DIR}/presets`;
 // underscore. Prevents path traversal via a crafted `.daintree/presets/../x`
 // subdirectory entry.
 const SAFE_AGENT_ID = /^[a-zA-Z0-9_.-]+$/;
+
+/**
+ * Returns true if the value is "present enough" to write to disk. Mirrors the
+ * legacy hand-coded checks: skip `undefined`, empty strings, and empty arrays;
+ * keep `0`, `false`, and non-empty objects.
+ */
+function shouldWriteValue(value: unknown): boolean {
+  if (value === undefined) return false;
+  if (typeof value === "string") return value.length > 0;
+  if (Array.isArray(value)) return value.length > 0;
+  return true;
+}
+
+/**
+ * Builds the shareable subset of `ProjectTerminalSettings`, filtered by
+ * `PROJECT_TERMINAL_SETTINGS_SHAREABILITY`. Returns `undefined` if no
+ * shareable sub-fields are present.
+ */
+function buildShareableTerminalSettings(
+  terminalSettings: ProjectTerminalSettings | undefined
+): ProjectTerminalSettings | undefined {
+  if (!terminalSettings) return undefined;
+  const result: ProjectTerminalSettings = {};
+  for (const key of Object.keys(PROJECT_TERMINAL_SETTINGS_SHAREABILITY) as Array<
+    keyof ProjectTerminalSettings
+  >) {
+    if (PROJECT_TERMINAL_SETTINGS_SHAREABILITY[key] !== "shareable") continue;
+    const value = terminalSettings[key];
+    if (!shouldWriteValue(value)) continue;
+    (result as Record<keyof ProjectTerminalSettings, unknown>)[key] = value;
+  }
+  return Object.keys(result).length > 0 ? result : undefined;
+}
 
 export class ProjectIdentityFiles {
   async readInRepoProjectIdentity(
@@ -125,47 +162,21 @@ export class ProjectIdentityFiles {
     const daintreeDir = path.join(projectPath, DAINTREE_DIR);
     const filePath = path.join(projectPath, DAINTREE_SETTINGS_JSON);
 
-    const payload: {
-      version: 1;
-      runCommands?: RunCommand[];
-      devServerCommand?: string;
-      devServerLoadTimeout?: number;
-      turbopackEnabled?: boolean;
-      copyTreeSettings?: CopyTreeSettings;
-      excludedPaths?: string[];
+    const payload: { version: 1 } & Partial<ProjectSettings> = { version: 1 };
 
-      worktreePathPattern?: string;
-      terminalSettings?: {
-        shellArgs?: string[];
-        defaultWorkingDirectory?: string;
-        scrollbackLines?: number;
-      };
-    } = { version: 1 };
-
-    if (settings.runCommands?.length) payload.runCommands = settings.runCommands;
-    if (settings.devServerCommand) payload.devServerCommand = settings.devServerCommand;
-    if (settings.devServerLoadTimeout) payload.devServerLoadTimeout = settings.devServerLoadTimeout;
-    if (typeof settings.turbopackEnabled === "boolean")
-      payload.turbopackEnabled = settings.turbopackEnabled;
-    if (settings.copyTreeSettings) payload.copyTreeSettings = settings.copyTreeSettings;
-    if (settings.excludedPaths?.length) payload.excludedPaths = settings.excludedPaths;
-
-    if (settings.worktreePathPattern) payload.worktreePathPattern = settings.worktreePathPattern;
-
-    if (settings.terminalSettings) {
-      const shareableTerminal: {
-        shellArgs?: string[];
-        defaultWorkingDirectory?: string;
-        scrollbackLines?: number;
-      } = {};
-      if (settings.terminalSettings.shellArgs?.length)
-        shareableTerminal.shellArgs = settings.terminalSettings.shellArgs;
-      if (settings.terminalSettings.defaultWorkingDirectory)
-        shareableTerminal.defaultWorkingDirectory =
-          settings.terminalSettings.defaultWorkingDirectory;
-      if (settings.terminalSettings.scrollbackLines !== undefined)
-        shareableTerminal.scrollbackLines = settings.terminalSettings.scrollbackLines;
-      if (Object.keys(shareableTerminal).length > 0) payload.terminalSettings = shareableTerminal;
+    for (const key of Object.keys(PROJECT_SETTINGS_SHAREABILITY) as Array<keyof ProjectSettings>) {
+      if (PROJECT_SETTINGS_SHAREABILITY[key] !== "shareable") continue;
+      if (key === "terminalSettings") {
+        const shareableTerminal = buildShareableTerminalSettings(settings.terminalSettings);
+        if (shareableTerminal !== undefined) payload.terminalSettings = shareableTerminal;
+        continue;
+      }
+      const value = settings[key];
+      if (!shouldWriteValue(value)) continue;
+      // Assigning a wider union into the specific key type — safe because we
+      // pulled `value` straight from `settings[key]`. The cast is a writer-side
+      // concession to keep the loop generic.
+      (payload as Record<keyof ProjectSettings, unknown>)[key] = value;
     }
 
     const attemptWrite = async (ensureDir: boolean): Promise<void> => {

--- a/electron/services/__tests__/writeInRepoFiles.test.ts
+++ b/electron/services/__tests__/writeInRepoFiles.test.ts
@@ -2,7 +2,15 @@ import { describe, it, expect, beforeEach, afterEach, vi } from "vitest";
 import fs from "fs/promises";
 import path from "path";
 import os from "os";
-import type { ProjectSettings, TerminalRecipe } from "../../types/index.js";
+import type {
+  ProjectSettings,
+  ProjectTerminalSettings,
+  TerminalRecipe,
+} from "../../types/index.js";
+import {
+  PROJECT_SETTINGS_SHAREABILITY,
+  PROJECT_TERMINAL_SETTINGS_SHAREABILITY,
+} from "../../../shared/types/project.js";
 import { ProjectIdentityFiles } from "../ProjectIdentityFiles.js";
 
 const DAINTREE_PROJECT_JSON = ".daintree/project.json";
@@ -122,47 +130,68 @@ describe("writeInRepoSettings", () => {
     expect(content.excludedPaths).toEqual(["node_modules"]);
   });
 
-  it("omits machine-local fields: devServerDismissed", async () => {
-    await identityFiles.writeInRepoSettings(tmpDir, makeSettings({ devServerDismissed: true }));
-    const content = JSON.parse(
-      await fs.readFile(path.join(tmpDir, DAINTREE_SETTINGS_JSON), "utf-8")
-    );
-    expect(content).not.toHaveProperty("devServerDismissed");
-  });
+  // Table-driven coverage: every non-shareable field defined in
+  // PROJECT_SETTINGS_SHAREABILITY must be absent from the on-disk JSON, and
+  // every shareable field must appear when set. The table is the single
+  // source of truth — adding a new field here without classifying it is a
+  // compile-time error, and this loop guarantees the write boundary honors
+  // the classification at runtime.
+  const NON_SHAREABLE_FIELDS = (
+    Object.keys(PROJECT_SETTINGS_SHAREABILITY) as Array<keyof ProjectSettings>
+  ).filter((k) => PROJECT_SETTINGS_SHAREABILITY[k] !== "shareable");
 
-  it("omits machine-local fields: devServerAutoDetected", async () => {
-    await identityFiles.writeInRepoSettings(tmpDir, makeSettings({ devServerAutoDetected: true }));
-    const content = JSON.parse(
-      await fs.readFile(path.join(tmpDir, DAINTREE_SETTINGS_JSON), "utf-8")
-    );
-    expect(content).not.toHaveProperty("devServerAutoDetected");
-  });
+  // Per-field sample values that are non-empty (so omission isn't an artifact
+  // of the writer's empty-array / empty-string skip rule). Only non-shareable
+  // fields need samples here.
+  const NON_SHAREABLE_SAMPLES: { [K in keyof ProjectSettings]?: ProjectSettings[K] } = {
+    environmentVariables: { API_KEY: "secret123" },
+    secureEnvironmentVariables: ["DB_PASS"],
+    insecureEnvironmentVariables: ["PLAIN_KEY"],
+    unresolvedSecureEnvironmentVariables: ["LOCKED_KEY"],
+    projectIconSvg: "<svg>...</svg>",
+    defaultWorktreeRecipeId: "recipe-1",
+    devServerDismissed: true,
+    devServerAutoDetected: true,
+    cloudSyncWarningDismissed: true,
+    commandOverrides: [{ commandId: "git.push", disabled: true }],
+    gitInitDefaults: { createInitialCommit: false },
+    preferredEditor: { id: "vscode" },
+    preferredImageViewer: { mode: "os" },
+    branchPrefixMode: "custom",
+    branchPrefixCustom: "feature/",
+    githubRemote: "upstream",
+    forgeProviderOverride: "github-com",
+    fleetSavedScopes: [
+      { kind: "predicate", id: "s1", name: "All", scope: "all", stateFilter: "all", createdAt: 1 },
+    ],
+    notificationOverrides: { soundEnabled: false },
+    resourceEnvironment: { provision: ["echo provision"] },
+    resourceEnvironments: { default: { provision: ["echo provision"] } },
+    activeResourceEnvironment: "default",
+    defaultWorktreeMode: "local",
+    browserAllowedHosts: ["example.com"],
+    daintreeMcpTier: "workbench",
+    exposeDaintreeMcpToAgents: true,
+  };
 
-  it("omits environment variables from output", async () => {
-    await identityFiles.writeInRepoSettings(
-      tmpDir,
-      makeSettings({
-        environmentVariables: { API_KEY: "secret123" },
-        secureEnvironmentVariables: ["DB_PASS"],
-      })
-    );
-    const content = JSON.parse(
-      await fs.readFile(path.join(tmpDir, DAINTREE_SETTINGS_JSON), "utf-8")
-    );
-    expect(content).not.toHaveProperty("environmentVariables");
-    expect(content).not.toHaveProperty("secureEnvironmentVariables");
-  });
-
-  it("omits projectIconSvg from output", async () => {
-    await identityFiles.writeInRepoSettings(
-      tmpDir,
-      makeSettings({ projectIconSvg: "<svg>...</svg>" })
-    );
-    const content = JSON.parse(
-      await fs.readFile(path.join(tmpDir, DAINTREE_SETTINGS_JSON), "utf-8")
-    );
-    expect(content).not.toHaveProperty("projectIconSvg");
-  });
+  it.each(NON_SHAREABLE_FIELDS)(
+    "omits non-shareable field %s from .daintree/settings.json",
+    async (field) => {
+      const sample = NON_SHAREABLE_SAMPLES[field];
+      expect(
+        sample,
+        `missing sample value for non-shareable field ${field} — update NON_SHAREABLE_SAMPLES`
+      ).not.toBeUndefined();
+      await identityFiles.writeInRepoSettings(
+        tmpDir,
+        makeSettings({ [field]: sample } as Partial<ProjectSettings>)
+      );
+      const content = JSON.parse(
+        await fs.readFile(path.join(tmpDir, DAINTREE_SETTINGS_JSON), "utf-8")
+      );
+      expect(content).not.toHaveProperty(field);
+    }
+  );
 
   it("includes copyTreeSettings when present", async () => {
     await identityFiles.writeInRepoSettings(
@@ -201,6 +230,140 @@ describe("writeInRepoSettings", () => {
       await fs.readFile(path.join(tmpDir, DAINTREE_SETTINGS_JSON), "utf-8")
     );
     expect(content).not.toHaveProperty("runCommands");
+  });
+
+  // Mirror of the omission table: every shareable top-level field appears in
+  // the on-disk JSON when populated. `terminalSettings` is exercised via the
+  // dedicated nested test below.
+  const SHAREABLE_TOP_LEVEL_FIELDS = (
+    Object.keys(PROJECT_SETTINGS_SHAREABILITY) as Array<keyof ProjectSettings>
+  ).filter((k) => PROJECT_SETTINGS_SHAREABILITY[k] === "shareable" && k !== "terminalSettings");
+
+  const SHAREABLE_SAMPLES: { [K in keyof ProjectSettings]?: ProjectSettings[K] } = {
+    runCommands: [{ id: "dev", name: "Dev", command: "npm run dev" }],
+    excludedPaths: ["node_modules"],
+    devServerCommand: "npm run dev",
+    devServerLoadTimeout: 60,
+    turbopackEnabled: true,
+    copyTreeSettings: { maxFileSize: 50000 },
+    worktreePathPattern: "../{name}",
+  };
+
+  it.each(SHAREABLE_TOP_LEVEL_FIELDS)(
+    "includes shareable field %s in .daintree/settings.json",
+    async (field) => {
+      const sample = SHAREABLE_SAMPLES[field];
+      expect(
+        sample,
+        `missing sample value for shareable field ${field} — update SHAREABLE_SAMPLES`
+      ).not.toBeUndefined();
+      await identityFiles.writeInRepoSettings(
+        tmpDir,
+        makeSettings({ [field]: sample } as Partial<ProjectSettings>)
+      );
+      const content = JSON.parse(
+        await fs.readFile(path.join(tmpDir, DAINTREE_SETTINGS_JSON), "utf-8")
+      );
+      expect(content[field]).toEqual(sample);
+    }
+  );
+
+  describe("terminalSettings nested shareability", () => {
+    const TERMINAL_NON_SHAREABLE: Array<keyof ProjectTerminalSettings> = (
+      Object.keys(PROJECT_TERMINAL_SETTINGS_SHAREABILITY) as Array<keyof ProjectTerminalSettings>
+    ).filter((k) => PROJECT_TERMINAL_SETTINGS_SHAREABILITY[k] !== "shareable");
+
+    const TERMINAL_SHAREABLE: Array<keyof ProjectTerminalSettings> = (
+      Object.keys(PROJECT_TERMINAL_SETTINGS_SHAREABILITY) as Array<keyof ProjectTerminalSettings>
+    ).filter((k) => PROJECT_TERMINAL_SETTINGS_SHAREABILITY[k] === "shareable");
+
+    const TERMINAL_NON_SHAREABLE_SAMPLES: {
+      [K in keyof ProjectTerminalSettings]?: ProjectTerminalSettings[K];
+    } = {
+      shell: "/bin/zsh",
+    };
+
+    const TERMINAL_SHAREABLE_SAMPLES: {
+      [K in keyof ProjectTerminalSettings]?: ProjectTerminalSettings[K];
+    } = {
+      shellArgs: ["-l"],
+      defaultWorkingDirectory: "src",
+      scrollbackLines: 5000,
+    };
+
+    it.each(TERMINAL_NON_SHAREABLE)("omits non-shareable terminal sub-field %s", async (field) => {
+      const sample = TERMINAL_NON_SHAREABLE_SAMPLES[field];
+      expect(
+        sample,
+        `missing sample value for non-shareable terminal field ${field}`
+      ).not.toBeUndefined();
+      await identityFiles.writeInRepoSettings(
+        tmpDir,
+        makeSettings({
+          terminalSettings: { [field]: sample } as ProjectTerminalSettings,
+        })
+      );
+      const content = JSON.parse(
+        await fs.readFile(path.join(tmpDir, DAINTREE_SETTINGS_JSON), "utf-8")
+      );
+      // The terminalSettings block must be absent if its only field was non-shareable.
+      expect(content).not.toHaveProperty("terminalSettings");
+    });
+
+    it.each(TERMINAL_SHAREABLE)("includes shareable terminal sub-field %s", async (field) => {
+      const sample = TERMINAL_SHAREABLE_SAMPLES[field];
+      expect(
+        sample,
+        `missing sample value for shareable terminal field ${field}`
+      ).not.toBeUndefined();
+      await identityFiles.writeInRepoSettings(
+        tmpDir,
+        makeSettings({
+          terminalSettings: { [field]: sample } as ProjectTerminalSettings,
+        })
+      );
+      const content = JSON.parse(
+        await fs.readFile(path.join(tmpDir, DAINTREE_SETTINGS_JSON), "utf-8")
+      );
+      expect(content.terminalSettings?.[field]).toEqual(sample);
+    });
+
+    it("strips shell from a mixed terminalSettings while keeping shareable siblings", async () => {
+      await identityFiles.writeInRepoSettings(
+        tmpDir,
+        makeSettings({
+          terminalSettings: {
+            shell: "/bin/zsh",
+            shellArgs: ["-l"],
+            scrollbackLines: 2000,
+          },
+        })
+      );
+      const content = JSON.parse(
+        await fs.readFile(path.join(tmpDir, DAINTREE_SETTINGS_JSON), "utf-8")
+      );
+      expect(content.terminalSettings).toEqual({ shellArgs: ["-l"], scrollbackLines: 2000 });
+      expect(content.terminalSettings).not.toHaveProperty("shell");
+    });
+
+    it("preserves scrollbackLines: 0 (defined but falsy)", async () => {
+      await identityFiles.writeInRepoSettings(
+        tmpDir,
+        makeSettings({ terminalSettings: { scrollbackLines: 0 } })
+      );
+      const content = JSON.parse(
+        await fs.readFile(path.join(tmpDir, DAINTREE_SETTINGS_JSON), "utf-8")
+      );
+      expect(content.terminalSettings).toEqual({ scrollbackLines: 0 });
+    });
+  });
+
+  it("preserves turbopackEnabled: false (defined but falsy)", async () => {
+    await identityFiles.writeInRepoSettings(tmpDir, makeSettings({ turbopackEnabled: false }));
+    const content = JSON.parse(
+      await fs.readFile(path.join(tmpDir, DAINTREE_SETTINGS_JSON), "utf-8")
+    );
+    expect(content.turbopackEnabled).toBe(false);
   });
 });
 

--- a/electron/services/__tests__/writeInRepoFiles.test.ts
+++ b/electron/services/__tests__/writeInRepoFiles.test.ts
@@ -281,13 +281,13 @@ describe("writeInRepoSettings", () => {
       [K in keyof ProjectTerminalSettings]?: ProjectTerminalSettings[K];
     } = {
       shell: "/bin/zsh",
+      defaultWorkingDirectory: "/Users/me/project",
     };
 
     const TERMINAL_SHAREABLE_SAMPLES: {
       [K in keyof ProjectTerminalSettings]?: ProjectTerminalSettings[K];
     } = {
       shellArgs: ["-l"],
-      defaultWorkingDirectory: "src",
       scrollbackLines: 5000,
     };
 
@@ -364,6 +364,37 @@ describe("writeInRepoSettings", () => {
       await fs.readFile(path.join(tmpDir, DAINTREE_SETTINGS_JSON), "utf-8")
     );
     expect(content.turbopackEnabled).toBe(false);
+  });
+
+  it("omits null values from output (e.g. when renderer sends 'clear this field')", async () => {
+    // The renderer occasionally sends `null` to clear an optional field. The
+    // type declares `string` for most of these, but the IPC handler calls the
+    // writer with raw incoming settings before sanitization runs. Writing
+    // `null` produces a spurious git diff that means nothing to teammates.
+    await identityFiles.writeInRepoSettings(
+      tmpDir,
+      makeSettings({
+        devServerCommand: null as unknown as string,
+        worktreePathPattern: null as unknown as string,
+      })
+    );
+    const content = JSON.parse(
+      await fs.readFile(path.join(tmpDir, DAINTREE_SETTINGS_JSON), "utf-8")
+    );
+    expect(content).not.toHaveProperty("devServerCommand");
+    expect(content).not.toHaveProperty("worktreePathPattern");
+  });
+
+  it("refuses to write when .daintree/ is a symlink", async () => {
+    const target = await fs.mkdtemp(path.join(os.tmpdir(), "daintree-symlink-target-"));
+    try {
+      await fs.symlink(target, path.join(tmpDir, ".daintree"));
+      await expect(identityFiles.writeInRepoSettings(tmpDir, makeSettings())).rejects.toThrow(
+        /symbolic link/
+      );
+    } finally {
+      await fs.rm(target, { recursive: true, force: true });
+    }
   });
 });
 

--- a/shared/types/project.ts
+++ b/shared/types/project.ts
@@ -309,7 +309,7 @@ export type FleetSavedScope = SnapshotFleetSavedScope | PredicateFleetSavedScope
 
 /** Per-project terminal configuration overrides */
 export interface ProjectTerminalSettings {
-  /** Override shell executable path (machine-local, not stored in .daintree/settings.json) */
+  /** Override shell executable path */
   shell?: string;
   /** Override shell arguments (replaces default args when set) */
   shellArgs?: string[];
@@ -319,6 +319,26 @@ export interface ProjectTerminalSettings {
   scrollbackLines?: number;
 }
 
+/**
+ * Classifies how a `ProjectSettings` (or sub-field) field is persisted.
+ * - `shareable`: written to `.daintree/settings.json` (committed to git, shared with teammates)
+ * - `local`: persisted only in the machine-local project store, never written to the repo file
+ * - `transient`: runtime-only, never persisted to disk
+ *
+ * The shareability tables (`PROJECT_SETTINGS_SHAREABILITY`,
+ * `PROJECT_TERMINAL_SETTINGS_SHAREABILITY`) are the single source of truth — adding a new
+ * field to `ProjectSettings` without classifying it here is a build error.
+ */
+export type FieldShareability = "shareable" | "local" | "transient";
+
+/** Shareability classification for each field of `ProjectTerminalSettings`. */
+export const PROJECT_TERMINAL_SETTINGS_SHAREABILITY = {
+  shell: "local",
+  shellArgs: "shareable",
+  defaultWorkingDirectory: "shareable",
+  scrollbackLines: "shareable",
+} as const satisfies Record<keyof ProjectTerminalSettings, FieldShareability>;
+
 /** Project-level settings that persist per repository */
 export interface ProjectSettings {
   /** List of custom run commands for this project */
@@ -327,9 +347,9 @@ export interface ProjectSettings {
   environmentVariables?: Record<string, string>;
   /** List of env var keys stored separately from settings.json */
   secureEnvironmentVariables?: string[];
-  /** List of env var keys found in plaintext that should be migrated (transient, not persisted) */
+  /** List of env var keys found in plaintext that should be migrated */
   insecureEnvironmentVariables?: string[];
-  /** List of secure keys that couldn't be decrypted (transient, not persisted) */
+  /** List of secure keys that couldn't be decrypted */
   unresolvedSecureEnvironmentVariables?: string[];
   /** Paths to exclude from monitoring */
   excludedPaths?: string[];
@@ -379,10 +399,9 @@ export interface ProjectSettings {
   /** Git remote name to use for GitHub integration (defaults to "origin") */
   githubRemote?: string;
   /**
-   * Pinned forge provider for this project (machine-local). When set, overrides hostname auto-detection
+   * Pinned forge provider for this project. When set, overrides hostname auto-detection
    * for forge integrations. `null` (or absent) = auto-detect. Stores the bare `contribution.id` of a
-   * provider registered via the forge provider registry. Never written to `.daintree/settings.json` —
-   * machine-local because provider availability depends on installed plugins.
+   * provider registered via the forge provider registry.
    */
   forgeProviderOverride?: string | null;
   /** Per-project worktree path pattern override (uses global default when unset) */
@@ -391,7 +410,7 @@ export interface ProjectSettings {
   fleetSavedScopes?: FleetSavedScope[];
   /** Per-project terminal configuration overrides */
   terminalSettings?: ProjectTerminalSettings;
-  /** Per-project notification overrides (machine-local, never written to .daintree/settings.json) */
+  /** Per-project notification overrides */
   notificationOverrides?: Partial<NotificationSettings>;
   /** @deprecated Use resourceEnvironments instead. Kept for migration only. */
   resourceEnvironment?: ResourceEnvironment;
@@ -417,6 +436,52 @@ export interface ProjectSettings {
    */
   exposeDaintreeMcpToAgents?: boolean;
 }
+
+/**
+ * Shareability classification for each field of `ProjectSettings`.
+ *
+ * The `satisfies Record<keyof ProjectSettings, FieldShareability>` constraint makes adding
+ * a new `ProjectSettings` field without a classification entry a compile-time error.
+ *
+ * `terminalSettings` is marked `shareable` because it contains shareable sub-fields; the
+ * nested object is filtered through `PROJECT_TERMINAL_SETTINGS_SHAREABILITY` by the writer.
+ */
+export const PROJECT_SETTINGS_SHAREABILITY = {
+  runCommands: "shareable",
+  environmentVariables: "local",
+  secureEnvironmentVariables: "local",
+  insecureEnvironmentVariables: "transient",
+  unresolvedSecureEnvironmentVariables: "transient",
+  excludedPaths: "shareable",
+  projectIconSvg: "local",
+  defaultWorktreeRecipeId: "local",
+  devServerCommand: "shareable",
+  devServerDismissed: "local",
+  devServerAutoDetected: "local",
+  cloudSyncWarningDismissed: "local",
+  devServerLoadTimeout: "shareable",
+  turbopackEnabled: "shareable",
+  copyTreeSettings: "shareable",
+  commandOverrides: "local",
+  gitInitDefaults: "local",
+  preferredEditor: "local",
+  preferredImageViewer: "local",
+  branchPrefixMode: "local",
+  branchPrefixCustom: "local",
+  githubRemote: "local",
+  forgeProviderOverride: "local",
+  worktreePathPattern: "shareable",
+  fleetSavedScopes: "local",
+  terminalSettings: "shareable",
+  notificationOverrides: "local",
+  resourceEnvironment: "local",
+  resourceEnvironments: "local",
+  activeResourceEnvironment: "local",
+  defaultWorktreeMode: "local",
+  browserAllowedHosts: "local",
+  daintreeMcpTier: "local",
+  exposeDaintreeMcpToAgents: "local",
+} as const satisfies Record<keyof ProjectSettings, FieldShareability>;
 
 /** Tier of Daintree MCP access exposed to agents in a project. */
 export type DaintreeMcpTier = "off" | "workbench" | "action" | "system";

--- a/shared/types/project.ts
+++ b/shared/types/project.ts
@@ -331,11 +331,17 @@ export interface ProjectTerminalSettings {
  */
 export type FieldShareability = "shareable" | "local" | "transient";
 
-/** Shareability classification for each field of `ProjectTerminalSettings`. */
+/**
+ * Shareability classification for each field of `ProjectTerminalSettings`.
+ *
+ * `shell` and `defaultWorkingDirectory` are both machine-local: the reader
+ * (`parseTerminalSettings`) requires an absolute path, and absolute paths
+ * are inherently per-machine. Teammates cannot meaningfully share either.
+ */
 export const PROJECT_TERMINAL_SETTINGS_SHAREABILITY = {
   shell: "local",
   shellArgs: "shareable",
-  defaultWorkingDirectory: "shareable",
+  defaultWorkingDirectory: "local",
   scrollbackLines: "shareable",
 } as const satisfies Record<keyof ProjectTerminalSettings, FieldShareability>;
 


### PR DESCRIPTION
## Summary

- `ProjectSettings` field shareability was duplicated between JSDoc `machine-local` markers and a hand-coded allow-list inside `writeInRepoSettings`. This PR collapses both into a single declarative const table co-located with the type.
- The table uses `as const satisfies Record<keyof ProjectSettings, FieldShareability>` so adding a new field without classifying it is a compile-time error -- no more silent omissions.
- `writeInRepoSettings` in `electron/services/ProjectIdentityFiles.ts` is rebuilt to drive from the tables via a generic loop, with a `buildShareableTerminalSettings` helper for the nested terminal case.

Resolves #8237

## Changes

- **`shared/types/project.ts`** -- adds `FieldShareability = 'shareable' | 'local' | 'transient'`, `PROJECT_SETTINGS_SHAREABILITY`, and `PROJECT_TERMINAL_SETTINGS_SHAREABILITY` const tables
- **`electron/services/ProjectIdentityFiles.ts`** -- `writeInRepoSettings` rewritten to loop over the shareability tables; shared `shouldWriteValue` helper handles omission semantics (undefined, null, empty string/array skipped; `0` / `false` / non-empty objects kept)
- All previously-unclassified fields default to `'local'` to strictly preserve current behavior -- no fields newly leak into `.daintree/settings.json`
- `defaultWorkingDirectory` classified `'local'` because `parseTerminalSettings` requires `path.isAbsolute()`, and absolute paths are inherently per-machine

## Testing

- Tests expanded from ~25 to 81 via `it.each` over the shareability tables, covering every shareable and non-shareable field, nested terminal sub-fields, defined-but-falsy round-trips (`turbopackEnabled: false`, `scrollbackLines: 0`), `null`-clear omission, and the `.daintree/` symlink guard
- `npm run check` passes (typecheck + lint + format)
- Vite build succeeds