### PR TITLE
feat(settings): OverrideField primitive + AutomationTab Terminal Defaults pilot

### DIFF
--- a/src/components/Project/AutomationTab.tsx
+++ b/src/components/Project/AutomationTab.tsx
@@ -18,6 +18,7 @@ import type { RunCommand } from "@/types";
 import type { Project, ResourceEnvironment } from "@shared/types/project";
 import { ResourceEnvironmentsSection } from "@/components/Settings/ResourceEnvironmentsSection";
 import { useSettingsTabValidation } from "@/components/Settings/SettingsValidationRegistry";
+import { OverrideField } from "@/components/Settings/OverrideField";
 
 interface AutomationTabProps {
   currentProject: Project | undefined;
@@ -29,14 +30,19 @@ interface AutomationTabProps {
   onBranchPrefixCustomChange: (value: string) => void;
   worktreePathPattern: string;
   onWorktreePathPatternChange: (value: string) => void;
-  terminalShell: string;
+  terminalShell: string | undefined;
   onTerminalShellChange: (value: string) => void;
-  terminalShellArgs: string;
+  onTerminalShellReset: () => void;
+  terminalShellArgs: string | undefined;
   onTerminalShellArgsChange: (value: string) => void;
-  terminalDefaultCwd: string;
+  onTerminalShellArgsReset: () => void;
+  terminalDefaultCwd: string | undefined;
   onTerminalDefaultCwdChange: (value: string) => void;
-  terminalScrollback: string;
+  onTerminalDefaultCwdReset: () => void;
+  terminalScrollback: string | undefined;
   onTerminalScrollbackChange: (value: string) => void;
+  onTerminalScrollbackReset: () => void;
+  effectiveScrollbackLines?: number;
   resourceEnvironments?: Record<string, ResourceEnvironment>;
   onResourceEnvironmentsChange?: (envs: Record<string, ResourceEnvironment>) => void;
   activeResourceEnvironment?: string;
@@ -58,12 +64,17 @@ export function AutomationTab({
   onWorktreePathPatternChange,
   terminalShell,
   onTerminalShellChange,
+  onTerminalShellReset,
   terminalShellArgs,
   onTerminalShellArgsChange,
+  onTerminalShellArgsReset,
   terminalDefaultCwd,
   onTerminalDefaultCwdChange,
+  onTerminalDefaultCwdReset,
   terminalScrollback,
   onTerminalScrollbackChange,
+  onTerminalScrollbackReset,
+  effectiveScrollbackLines,
   resourceEnvironments,
   onResourceEnvironmentsChange,
   activeResourceEnvironment,
@@ -387,100 +398,76 @@ export function AutomationTab({
           Terminal Defaults
         </h3>
         <p className="text-xs text-daintree-text/60 mb-4">
-          Override the default shell and scrollback for terminals spawned in this project. These
-          apply to new terminals only.
+          Fields without an override inherit the app default. Type to override; click "Reset to
+          global" to clear. Applies to new terminals only.
         </p>
 
         <div className="space-y-4">
-          <div>
-            <label
-              htmlFor="terminal-shell"
-              className="block text-xs font-medium text-daintree-text/60 mb-1"
-            >
-              Shell program
-              <span className="ml-1 text-daintree-text/40">(machine-local, not shared)</span>
-            </label>
-            <input
-              id="terminal-shell"
-              type="text"
-              value={terminalShell}
-              onChange={(e) => onTerminalShellChange(e.target.value)}
-              className="w-full bg-daintree-bg border border-daintree-border rounded px-3 py-2 text-sm text-daintree-text font-mono focus:outline-hidden focus:border-daintree-accent focus:ring-1 focus:ring-daintree-accent/30 transition placeholder:text-text-muted"
-              placeholder="/bin/zsh"
-              spellCheck={false}
-              autoComplete="off"
-            />
-          </div>
+          <OverrideField
+            label="Shell program"
+            hint="(machine-local, not shared)"
+            value={terminalShell}
+            onChange={onTerminalShellChange}
+            onReset={onTerminalShellReset}
+            inheritDescription="Inherits app default"
+            placeholder="/bin/zsh"
+            spellCheck={false}
+            autoComplete="off"
+          />
 
-          <div>
-            <label
-              htmlFor="terminal-shell-args"
-              className="block text-xs font-medium text-daintree-text/60 mb-1"
-            >
-              Shell arguments
-              <span className="ml-1 text-daintree-text/40">(space-separated)</span>
-            </label>
-            <input
-              id="terminal-shell-args"
-              type="text"
-              value={terminalShellArgs}
-              onChange={(e) => onTerminalShellArgsChange(e.target.value)}
-              className="w-full bg-daintree-bg border border-daintree-border rounded px-3 py-2 text-sm text-daintree-text font-mono focus:outline-hidden focus:border-daintree-accent focus:ring-1 focus:ring-daintree-accent/30 transition placeholder:text-text-muted"
-              placeholder="-l"
-              spellCheck={false}
-              autoComplete="off"
-            />
-          </div>
+          <OverrideField
+            label="Shell arguments"
+            hint="(space-separated)"
+            value={terminalShellArgs}
+            onChange={onTerminalShellArgsChange}
+            onReset={onTerminalShellArgsReset}
+            inheritDescription="Inherits app default"
+            placeholder="-l"
+            spellCheck={false}
+            autoComplete="off"
+          />
 
-          <div>
-            <label
-              htmlFor="terminal-default-cwd"
-              className="block text-xs font-medium text-daintree-text/60 mb-1"
-            >
-              Default working directory
-            </label>
-            <input
-              id="terminal-default-cwd"
-              type="text"
-              value={terminalDefaultCwd}
-              onChange={(e) => onTerminalDefaultCwdChange(e.target.value)}
-              className="w-full bg-daintree-bg border border-daintree-border rounded px-3 py-2 text-sm text-daintree-text font-mono focus:outline-hidden focus:border-daintree-accent focus:ring-1 focus:ring-daintree-accent/30 transition placeholder:text-text-muted"
-              placeholder="/path/to/working/directory"
-              spellCheck={false}
-              autoComplete="off"
-            />
-          </div>
+          <OverrideField
+            label="Default working directory"
+            value={terminalDefaultCwd}
+            onChange={onTerminalDefaultCwdChange}
+            onReset={onTerminalDefaultCwdReset}
+            inheritDescription="Inherits app default"
+            placeholder="/path/to/working/directory"
+            spellCheck={false}
+            autoComplete="off"
+          />
 
-          <div>
-            <label
-              htmlFor="terminal-scrollback"
-              className="block text-xs font-medium text-daintree-text/60 mb-1"
-            >
-              Scrollback lines
-              <span className="ml-1 text-daintree-text/40">
-                ({SCROLLBACK_MIN}–{SCROLLBACK_MAX}, leave empty for app default)
-              </span>
-            </label>
-            <input
-              id="terminal-scrollback"
-              type="number"
-              min={SCROLLBACK_MIN}
-              max={SCROLLBACK_MAX}
-              value={terminalScrollback}
-              onChange={(e) => onTerminalScrollbackChange(e.target.value)}
-              className="w-28 bg-daintree-bg border border-daintree-border rounded px-3 py-2 text-sm text-daintree-text font-mono focus:outline-hidden focus:border-daintree-accent focus:ring-1 focus:ring-daintree-accent/30 transition placeholder:text-text-muted"
-              placeholder="1000"
-            />
-            {terminalScrollback.trim() &&
-              (() => {
-                const num = Number(terminalScrollback);
-                return Number.isFinite(num) && (num < SCROLLBACK_MIN || num > SCROLLBACK_MAX) ? (
-                  <p className="text-xs text-status-error mt-1">
-                    Must be between {SCROLLBACK_MIN} and {SCROLLBACK_MAX}
-                  </p>
-                ) : null;
-              })()}
-          </div>
+          {(() => {
+            const isNonEmpty = terminalScrollback !== undefined && terminalScrollback.trim() !== "";
+            const num = isNonEmpty ? Number(terminalScrollback) : NaN;
+            const scrollbackInvalid =
+              isNonEmpty && (!Number.isFinite(num) || num < SCROLLBACK_MIN || num > SCROLLBACK_MAX);
+            const inheritCopy =
+              effectiveScrollbackLines !== undefined
+                ? `Inherits app default (${effectiveScrollbackLines} lines)`
+                : "Inherits app default";
+            return (
+              <OverrideField
+                label="Scrollback lines"
+                hint={`(${SCROLLBACK_MIN}–${SCROLLBACK_MAX})`}
+                value={terminalScrollback}
+                onChange={onTerminalScrollbackChange}
+                onReset={onTerminalScrollbackReset}
+                inheritDescription={inheritCopy}
+                type="number"
+                min={SCROLLBACK_MIN}
+                max={SCROLLBACK_MAX}
+                placeholder="1000"
+                inputClassName="w-28"
+                error={
+                  scrollbackInvalid
+                    ? `Must be between ${SCROLLBACK_MIN} and ${SCROLLBACK_MAX}`
+                    : undefined
+                }
+              />
+            );
+          })()}
         </div>
       </div>
 

--- a/src/components/Settings/OverrideField.tsx
+++ b/src/components/Settings/OverrideField.tsx
@@ -1,0 +1,116 @@
+import { useId } from "react";
+import type { ComponentPropsWithoutRef, ReactNode } from "react";
+import { RotateCcw } from "lucide-react";
+import { cn } from "@/lib/utils";
+
+interface OverrideFieldProps extends Omit<
+  ComponentPropsWithoutRef<"input">,
+  "id" | "value" | "onChange"
+> {
+  label: string;
+  hint?: ReactNode;
+  value: string | undefined;
+  onChange: (value: string) => void;
+  onReset: () => void;
+  inheritDescription: ReactNode;
+  overrideDescription?: ReactNode;
+  error?: string;
+  inputClassName?: string;
+}
+
+export function OverrideField({
+  label,
+  hint,
+  value,
+  onChange,
+  onReset,
+  inheritDescription,
+  overrideDescription = "Overriding app default",
+  error,
+  inputClassName,
+  className,
+  disabled,
+  ...props
+}: OverrideFieldProps) {
+  const id = useId();
+  const descriptionId = useId();
+  const errorId = useId();
+  const isOverriding = value !== undefined;
+  const showReset = isOverriding && !disabled;
+  const describedBy =
+    [error ? errorId : null, descriptionId].filter(Boolean).join(" ") || undefined;
+
+  return (
+    <div className={cn("group", className)}>
+      <div className="flex items-center gap-2 mb-1 min-h-[1.25rem]">
+        <label htmlFor={id} className="block text-xs font-medium text-daintree-text/60">
+          {label}
+          {hint && <span className="ml-1 text-daintree-text/40">{hint}</span>}
+        </label>
+        {isOverriding && (
+          <span
+            className="w-1.5 h-1.5 rounded-full bg-status-info"
+            aria-hidden="true"
+            data-testid="override-indicator"
+          />
+        )}
+        {showReset && (
+          <button
+            type="button"
+            aria-label="Reset to global"
+            onClick={onReset}
+            className={cn(
+              "inline-flex items-center gap-1 px-1.5 py-0.5 rounded-sm text-[11px] text-text-muted hover:text-daintree-text hover:bg-overlay-subtle",
+              "invisible group-hover:visible group-focus-within:visible focus-visible:visible",
+              "focus-visible:outline focus-visible:outline-2 focus-visible:outline-daintree-accent",
+              "transition-colors"
+            )}
+          >
+            <RotateCcw className="w-3 h-3" />
+            Reset to global
+          </button>
+        )}
+      </div>
+      <input
+        id={id}
+        value={value ?? ""}
+        onChange={(e) => {
+          // Clearing the input while overriding is treated as a reset — keeps
+          // the visible UI state and the persisted state from drifting (empty
+          // overrides for shell/cwd/scrollback aren't meaningful).
+          if (e.target.value === "" && value !== undefined) {
+            onReset();
+          } else {
+            onChange(e.target.value);
+          }
+        }}
+        disabled={disabled}
+        aria-describedby={describedBy}
+        aria-invalid={error ? true : undefined}
+        className={cn(
+          "w-full bg-daintree-bg border rounded px-3 py-2 text-sm text-daintree-text font-mono",
+          "focus:outline-hidden focus:border-daintree-accent focus:ring-1 focus:ring-daintree-accent/30",
+          "transition-colors placeholder:text-text-muted disabled:opacity-50 disabled:cursor-not-allowed",
+          isOverriding ? "border-status-info/40" : "border-daintree-border",
+          error && "border-status-error",
+          inputClassName
+        )}
+        {...props}
+      />
+      <p
+        id={descriptionId}
+        className={cn(
+          "mt-1 text-xs",
+          isOverriding ? "text-text-muted" : "text-daintree-text/40 italic"
+        )}
+      >
+        {isOverriding ? overrideDescription : inheritDescription}
+      </p>
+      {error && (
+        <p id={errorId} className="mt-1 text-xs text-status-error">
+          {error}
+        </p>
+      )}
+    </div>
+  );
+}

--- a/src/components/Settings/SettingsDialog.tsx
+++ b/src/components/Settings/SettingsDialog.tsx
@@ -814,6 +814,7 @@ function SettingsDialogInner({
                                   projectId={projectId}
                                   isOpen={isOpen}
                                   globalEnvVars={globalEnvVars}
+                                  globalScrollbackLines={scrollbackLines}
                                   projectLabel={projectLabel}
                                   isActive={isActive && !isSearching}
                                   scrollToSectionId={scrollToSection}
@@ -887,6 +888,7 @@ function ProjectFormTabContent({
   projectId,
   isOpen,
   globalEnvVars,
+  globalScrollbackLines,
   projectLabel,
   isActive,
   scrollToSectionId,
@@ -897,6 +899,7 @@ function ProjectFormTabContent({
   projectId: string;
   isOpen: boolean;
   globalEnvVars: Record<string, string>;
+  globalScrollbackLines: number;
   projectLabel: string;
   isActive: boolean;
   scrollToSectionId: string | null;
@@ -973,12 +976,17 @@ function ProjectFormTabContent({
           onWorktreePathPatternChange={projectForm.setWorktreePathPattern}
           terminalShell={projectForm.terminalShell}
           onTerminalShellChange={projectForm.setTerminalShell}
+          onTerminalShellReset={() => projectForm.setTerminalShell(undefined)}
           terminalShellArgs={projectForm.terminalShellArgs}
           onTerminalShellArgsChange={projectForm.setTerminalShellArgs}
+          onTerminalShellArgsReset={() => projectForm.setTerminalShellArgs(undefined)}
           terminalDefaultCwd={projectForm.terminalDefaultCwd}
           onTerminalDefaultCwdChange={projectForm.setTerminalDefaultCwd}
+          onTerminalDefaultCwdReset={() => projectForm.setTerminalDefaultCwd(undefined)}
           terminalScrollback={projectForm.terminalScrollback}
           onTerminalScrollbackChange={projectForm.setTerminalScrollback}
+          onTerminalScrollbackReset={() => projectForm.setTerminalScrollback(undefined)}
+          effectiveScrollbackLines={globalScrollbackLines}
           resourceEnvironments={projectForm.resourceEnvironments}
           onResourceEnvironmentsChange={projectForm.setResourceEnvironments}
           activeResourceEnvironment={projectForm.activeResourceEnvironment}

--- a/src/components/Settings/__tests__/OverrideField.test.tsx
+++ b/src/components/Settings/__tests__/OverrideField.test.tsx
@@ -1,0 +1,278 @@
+// @vitest-environment jsdom
+import { describe, it, expect, vi } from "vitest";
+import { render, screen, fireEvent } from "@testing-library/react";
+import { OverrideField } from "../OverrideField";
+
+describe("OverrideField", () => {
+  it("renders label associated to input", () => {
+    render(
+      <OverrideField
+        label="Shell program"
+        value={undefined}
+        onChange={vi.fn()}
+        onReset={vi.fn()}
+        inheritDescription="Inherits app default"
+      />
+    );
+    const input = screen.getByLabelText("Shell program");
+    expect(input).toBeTruthy();
+    expect(input.tagName).toBe("INPUT");
+  });
+
+  it("renders empty input value when inheriting (value is undefined)", () => {
+    render(
+      <OverrideField
+        label="Shell"
+        value={undefined}
+        onChange={vi.fn()}
+        onReset={vi.fn()}
+        inheritDescription="Inherits app default"
+      />
+    );
+    const input = screen.getByLabelText("Shell") as HTMLInputElement;
+    expect(input.value).toBe("");
+  });
+
+  it("renders inheritDescription when value is undefined", () => {
+    render(
+      <OverrideField
+        label="Shell"
+        value={undefined}
+        onChange={vi.fn()}
+        onReset={vi.fn()}
+        inheritDescription="Inherits app default (1000 lines)"
+      />
+    );
+    expect(screen.getByText("Inherits app default (1000 lines)")).toBeTruthy();
+  });
+
+  it("renders overrideDescription when value is set", () => {
+    render(
+      <OverrideField
+        label="Shell"
+        value="/bin/bash"
+        onChange={vi.fn()}
+        onReset={vi.fn()}
+        inheritDescription="Inherits app default"
+        overrideDescription="Overriding app default"
+      />
+    );
+    expect(screen.getByText("Overriding app default")).toBeTruthy();
+    expect(screen.queryByText("Inherits app default")).toBeNull();
+  });
+
+  it("wires description to aria-describedby", () => {
+    render(
+      <OverrideField
+        label="Shell"
+        value={undefined}
+        onChange={vi.fn()}
+        onReset={vi.fn()}
+        inheritDescription="Inherits app default"
+      />
+    );
+    const input = screen.getByLabelText("Shell");
+    const describedBy = input.getAttribute("aria-describedby");
+    expect(describedBy).toBeTruthy();
+    expect(document.getElementById(describedBy!)?.textContent).toBe("Inherits app default");
+  });
+
+  it("does not render reset button when inheriting", () => {
+    render(
+      <OverrideField
+        label="Shell"
+        value={undefined}
+        onChange={vi.fn()}
+        onReset={vi.fn()}
+        inheritDescription="Inherits app default"
+      />
+    );
+    expect(screen.queryByLabelText("Reset to global")).toBeNull();
+  });
+
+  it("renders reset button when overriding", () => {
+    render(
+      <OverrideField
+        label="Shell"
+        value="/bin/bash"
+        onChange={vi.fn()}
+        onReset={vi.fn()}
+        inheritDescription="Inherits app default"
+      />
+    );
+    expect(screen.getByLabelText("Reset to global")).toBeTruthy();
+  });
+
+  it("hides reset button when disabled", () => {
+    render(
+      <OverrideField
+        label="Shell"
+        value="/bin/bash"
+        onChange={vi.fn()}
+        onReset={vi.fn()}
+        disabled
+        inheritDescription="Inherits app default"
+      />
+    );
+    expect(screen.queryByLabelText("Reset to global")).toBeNull();
+  });
+
+  it("calls onChange with new value when typing", () => {
+    const onChange = vi.fn();
+    render(
+      <OverrideField
+        label="Shell"
+        value={undefined}
+        onChange={onChange}
+        onReset={vi.fn()}
+        inheritDescription="Inherits app default"
+      />
+    );
+    const input = screen.getByLabelText("Shell");
+    fireEvent.change(input, { target: { value: "/bin/bash" } });
+    expect(onChange).toHaveBeenCalledWith("/bin/bash");
+  });
+
+  it("calls onReset when reset button is clicked", () => {
+    const onReset = vi.fn();
+    render(
+      <OverrideField
+        label="Shell"
+        value="/bin/bash"
+        onChange={vi.fn()}
+        onReset={onReset}
+        inheritDescription="Inherits app default"
+      />
+    );
+    fireEvent.click(screen.getByLabelText("Reset to global"));
+    expect(onReset).toHaveBeenCalled();
+  });
+
+  it("renders override indicator dot when overriding", () => {
+    render(
+      <OverrideField
+        label="Shell"
+        value="/bin/bash"
+        onChange={vi.fn()}
+        onReset={vi.fn()}
+        inheritDescription="Inherits app default"
+      />
+    );
+    expect(screen.getByTestId("override-indicator")).toBeTruthy();
+  });
+
+  it("does not render override indicator when inheriting", () => {
+    render(
+      <OverrideField
+        label="Shell"
+        value={undefined}
+        onChange={vi.fn()}
+        onReset={vi.fn()}
+        inheritDescription="Inherits app default"
+      />
+    );
+    expect(screen.queryByTestId("override-indicator")).toBeNull();
+  });
+
+  it("shows error message and sets aria-invalid when error provided", () => {
+    render(
+      <OverrideField
+        label="Scrollback"
+        value="999999"
+        onChange={vi.fn()}
+        onReset={vi.fn()}
+        inheritDescription="Inherits app default"
+        error="Must be between 100 and 100000"
+      />
+    );
+    const input = screen.getByLabelText("Scrollback");
+    expect(input.getAttribute("aria-invalid")).toBe("true");
+    expect(screen.getByText("Must be between 100 and 100000")).toBeTruthy();
+  });
+
+  it("forwards input props like placeholder, type, min, max", () => {
+    render(
+      <OverrideField
+        label="Scrollback"
+        value={undefined}
+        onChange={vi.fn()}
+        onReset={vi.fn()}
+        inheritDescription="Inherits app default"
+        type="number"
+        min={100}
+        max={100000}
+        placeholder="1000"
+      />
+    );
+    const input = screen.getByLabelText("Scrollback");
+    expect(input.getAttribute("type")).toBe("number");
+    expect(input.getAttribute("min")).toBe("100");
+    expect(input.getAttribute("max")).toBe("100000");
+    expect(input.getAttribute("placeholder")).toBe("1000");
+  });
+
+  it("renders hint label suffix when provided", () => {
+    render(
+      <OverrideField
+        label="Shell"
+        hint="(machine-local, not shared)"
+        value={undefined}
+        onChange={vi.fn()}
+        onReset={vi.fn()}
+        inheritDescription="Inherits app default"
+      />
+    );
+    expect(screen.getByText("(machine-local, not shared)")).toBeTruthy();
+  });
+
+  it("treats clearing the input while overriding as a reset, not an empty override", () => {
+    const onChange = vi.fn();
+    const onReset = vi.fn();
+    render(
+      <OverrideField
+        label="Shell"
+        value="/bin/bash"
+        onChange={onChange}
+        onReset={onReset}
+        inheritDescription="Inherits app default"
+      />
+    );
+    const input = screen.getByLabelText("Shell");
+    fireEvent.change(input, { target: { value: "" } });
+    expect(onReset).toHaveBeenCalledTimes(1);
+    expect(onChange).not.toHaveBeenCalled();
+  });
+
+  it("forwards empty string normally when already inheriting", () => {
+    const onChange = vi.fn();
+    const onReset = vi.fn();
+    render(
+      <OverrideField
+        label="Shell"
+        value={undefined}
+        onChange={onChange}
+        onReset={onReset}
+        inheritDescription="Inherits app default"
+      />
+    );
+    const input = screen.getByLabelText("Shell");
+    fireEvent.change(input, { target: { value: "" } });
+    expect(onReset).not.toHaveBeenCalled();
+  });
+
+  it("uses status-info (not accent) as the override signal", () => {
+    render(
+      <OverrideField
+        label="Shell"
+        value="/bin/bash"
+        onChange={vi.fn()}
+        onReset={vi.fn()}
+        inheritDescription="Inherits app default"
+      />
+    );
+    const dot = screen.getByTestId("override-indicator");
+    expect(dot.className).toContain("bg-status-info");
+    expect(dot.className).not.toContain("bg-accent");
+    expect(dot.className).not.toContain("bg-daintree-accent");
+  });
+});

--- a/src/hooks/__tests__/useProjectSettingsForm.test.tsx
+++ b/src/hooks/__tests__/useProjectSettingsForm.test.tsx
@@ -526,6 +526,137 @@ describe("useProjectSettingsForm", () => {
     vi.useRealTimers();
   });
 
+  it("leaves terminal fields undefined when project has no terminalSettings", async () => {
+    const { result, rerender } = renderHook(
+      ({ isOpen, projectId }: FormProps) => useProjectSettingsForm({ projectId, isOpen }),
+      { initialProps: { isOpen: false, tick: 0, projectId: "proj-1" } }
+    );
+    rerender({ isOpen: true, tick: 1, projectId: "proj-1" });
+    const { terminalSettings: _unused, ...settingsWithoutTerminal } = baseSettings;
+    void _unused;
+    mockSettings.value = settingsWithoutTerminal as ProjectSettings;
+    rerender({ isOpen: true, tick: 2, projectId: "proj-1" });
+    await waitFor(() => {
+      expect(result.current.projectIsInitialized).toBe(true);
+    });
+    expect(result.current.terminalShell).toBeUndefined();
+    expect(result.current.terminalShellArgs).toBeUndefined();
+    expect(result.current.terminalDefaultCwd).toBeUndefined();
+    expect(result.current.terminalScrollback).toBeUndefined();
+  });
+
+  it("omits terminalSettings from the saved payload when all four terminal fields are undefined", async () => {
+    vi.useFakeTimers();
+    const { result, rerender } = renderHook(
+      ({ isOpen }: { isOpen: boolean; tick: number }) =>
+        useProjectSettingsForm({ projectId: "proj-1", isOpen }),
+      { initialProps: { isOpen: false, tick: 0 } }
+    );
+    rerender({ isOpen: true, tick: 1 });
+    mockSettings.value = baseSettings;
+    rerender({ isOpen: true, tick: 2 });
+    await act(async () => {
+      await vi.runAllTimersAsync();
+    });
+
+    // Reset both terminal fields that baseSettings had set, then trigger save
+    act(() => {
+      result.current.setTerminalShell(undefined);
+      result.current.setTerminalShellArgs(undefined);
+    });
+
+    await act(async () => {
+      await vi.advanceTimersByTimeAsync(600);
+    });
+
+    expect(mockSaveSettings).toHaveBeenCalled();
+    const lastCall = mockSaveSettings.mock.calls.at(-1)![0];
+    expect(lastCall.terminalSettings).toBeUndefined();
+    vi.useRealTimers();
+  });
+
+  it("preserves valid saved scrollbackLines when user enters an invalid value", async () => {
+    vi.useFakeTimers();
+    const settingsWithScrollback: ProjectSettings = {
+      ...baseSettings,
+      terminalSettings: { scrollbackLines: 2000 },
+    };
+    const { result, rerender } = renderHook(
+      ({ isOpen }: { isOpen: boolean; tick: number }) =>
+        useProjectSettingsForm({ projectId: "proj-1", isOpen }),
+      { initialProps: { isOpen: false, tick: 0 } }
+    );
+    rerender({ isOpen: true, tick: 1 });
+    mockSettings.value = settingsWithScrollback;
+    rerender({ isOpen: true, tick: 2 });
+    await act(async () => {
+      await vi.runAllTimersAsync();
+    });
+    expect(result.current.terminalScrollback).toBe("2000");
+
+    // Type an out-of-range value (below SCROLLBACK_MIN=100). The UI shows an
+    // error; the autosave must NOT silently wipe the existing saved value.
+    act(() => {
+      result.current.setTerminalScrollback("50");
+    });
+
+    await act(async () => {
+      await vi.advanceTimersByTimeAsync(600);
+    });
+
+    // Either no save fired (snapshot didn't change) or any save still has the
+    // valid prior value, never the invalid one.
+    for (const call of mockSaveSettings.mock.calls) {
+      const saved = call[0];
+      if (saved.terminalSettings?.scrollbackLines !== undefined) {
+        expect(saved.terminalSettings.scrollbackLines).toBe(2000);
+      }
+    }
+    vi.useRealTimers();
+  });
+
+  it("partial reset preserves the other terminal fields in the saved payload", async () => {
+    vi.useFakeTimers();
+    const fullTerminalSettings: ProjectSettings = {
+      ...baseSettings,
+      terminalSettings: {
+        shell: "/bin/bash",
+        shellArgs: ["-l"],
+        defaultWorkingDirectory: "/tmp",
+        scrollbackLines: 1500,
+      },
+    };
+    const { result, rerender } = renderHook(
+      ({ isOpen }: { isOpen: boolean; tick: number }) =>
+        useProjectSettingsForm({ projectId: "proj-1", isOpen }),
+      { initialProps: { isOpen: false, tick: 0 } }
+    );
+    rerender({ isOpen: true, tick: 1 });
+    mockSettings.value = fullTerminalSettings;
+    rerender({ isOpen: true, tick: 2 });
+    await act(async () => {
+      await vi.runAllTimersAsync();
+    });
+
+    // Reset only the shell — the other three should survive.
+    act(() => {
+      result.current.setTerminalShell(undefined);
+    });
+
+    await act(async () => {
+      await vi.advanceTimersByTimeAsync(600);
+    });
+
+    expect(mockSaveSettings).toHaveBeenCalled();
+    const lastCall = mockSaveSettings.mock.calls.at(-1)![0];
+    expect(lastCall.terminalSettings).toBeDefined();
+    expect(lastCall.terminalSettings.shell).toBeUndefined();
+    expect(lastCall.terminalSettings.shellArgs).toEqual(["-l"]);
+    expect(lastCall.terminalSettings.defaultWorkingDirectory).toBe("/tmp");
+    expect(lastCall.terminalSettings.scrollbackLines).toBe(1500);
+    vi.useRealTimers();
+  });
+
   it("filters invalid env var keys on save", async () => {
     vi.useFakeTimers();
     const { result, rerender } = renderHook(

--- a/src/hooks/useProjectSettingsForm.ts
+++ b/src/hooks/useProjectSettingsForm.ts
@@ -62,10 +62,10 @@ export function useProjectSettingsForm({ projectId, isOpen }: UseProjectSettings
   const [branchPrefixMode, setBranchPrefixMode] = useState<"none" | "username" | "custom">("none");
   const [branchPrefixCustom, setBranchPrefixCustom] = useState<string>("");
   const [worktreePathPattern, setWorktreePathPattern] = useState<string>("");
-  const [terminalShell, setTerminalShell] = useState<string>("");
-  const [terminalShellArgs, setTerminalShellArgs] = useState<string>("");
-  const [terminalDefaultCwd, setTerminalDefaultCwd] = useState<string>("");
-  const [terminalScrollback, setTerminalScrollback] = useState<string>("");
+  const [terminalShell, setTerminalShell] = useState<string | undefined>(undefined);
+  const [terminalShellArgs, setTerminalShellArgs] = useState<string | undefined>(undefined);
+  const [terminalDefaultCwd, setTerminalDefaultCwd] = useState<string | undefined>(undefined);
+  const [terminalScrollback, setTerminalScrollback] = useState<string | undefined>(undefined);
   const [notificationOverrides, setNotificationOverrides] = useState<Partial<NotificationSettings>>(
     {}
   );
@@ -104,17 +104,24 @@ export function useProjectSettingsForm({ projectId, isOpen }: UseProjectSettings
 
   const currentTerminalSettings = useMemo((): ProjectTerminalSettings | undefined => {
     const result: ProjectTerminalSettings = {};
-    if (terminalShell.trim()) result.shell = terminalShell.trim();
-    if (terminalShellArgs.trim()) result.shellArgs = terminalShellArgs.trim().split(/\s+/);
-    if (terminalDefaultCwd.trim()) result.defaultWorkingDirectory = terminalDefaultCwd.trim();
-    if (terminalScrollback.trim()) {
+    if (terminalShell !== undefined && terminalShell.trim()) result.shell = terminalShell.trim();
+    if (terminalShellArgs !== undefined && terminalShellArgs.trim())
+      result.shellArgs = terminalShellArgs.trim().split(/\s+/);
+    if (terminalDefaultCwd !== undefined && terminalDefaultCwd.trim())
+      result.defaultWorkingDirectory = terminalDefaultCwd.trim();
+    if (terminalScrollback !== undefined && terminalScrollback.trim()) {
       const num = Number(terminalScrollback);
       if (Number.isFinite(num) && num >= SCROLLBACK_MIN && num <= SCROLLBACK_MAX) {
         result.scrollbackLines = Math.trunc(num);
+      } else if (projectSettings?.terminalSettings?.scrollbackLines !== undefined) {
+        // Invalid in-flight input must not silently wipe an existing valid
+        // override — preserve the last saved value until the user types a
+        // valid number or resets the field.
+        result.scrollbackLines = projectSettings.terminalSettings.scrollbackLines;
       }
     }
     return Object.keys(result).length > 0 ? result : undefined;
-  }, [terminalShell, terminalShellArgs, terminalDefaultCwd, terminalScrollback]);
+  }, [terminalShell, terminalShellArgs, terminalDefaultCwd, terminalScrollback, projectSettings]);
 
   const currentProjectSnapshot = useMemo(() => {
     if (!currentProject) return null;
@@ -200,10 +207,10 @@ export function useProjectSettingsForm({ projectId, isOpen }: UseProjectSettings
       setBranchPrefixMode("none");
       setBranchPrefixCustom("");
       setWorktreePathPattern("");
-      setTerminalShell("");
-      setTerminalShellArgs("");
-      setTerminalDefaultCwd("");
-      setTerminalScrollback("");
+      setTerminalShell(undefined);
+      setTerminalShellArgs(undefined);
+      setTerminalDefaultCwd(undefined);
+      setTerminalScrollback(undefined);
       setNotificationOverrides({});
       setGithubRemote(undefined);
       setForgeProviderOverride(null);
@@ -277,13 +284,15 @@ export function useProjectSettingsForm({ projectId, isOpen }: UseProjectSettings
     setBranchPrefixMode(initialBranchPrefixMode);
     setBranchPrefixCustom(initialBranchPrefixCustom);
     setWorktreePathPattern(initialWorktreePathPattern);
-    setTerminalShell(initialTerminalSettings?.shell ?? "");
-    setTerminalShellArgs(initialTerminalSettings?.shellArgs?.join(" ") ?? "");
-    setTerminalDefaultCwd(initialTerminalSettings?.defaultWorkingDirectory ?? "");
+    setTerminalShell(initialTerminalSettings?.shell);
+    setTerminalShellArgs(
+      initialTerminalSettings?.shellArgs ? initialTerminalSettings.shellArgs.join(" ") : undefined
+    );
+    setTerminalDefaultCwd(initialTerminalSettings?.defaultWorkingDirectory);
     setTerminalScrollback(
       initialTerminalSettings?.scrollbackLines !== undefined
         ? String(initialTerminalSettings.scrollbackLines)
-        : ""
+        : undefined
     );
     setNotificationOverrides(initialNotificationOverrides);
     setGithubRemote(initialGithubRemote);


### PR DESCRIPTION
## Summary

- Adds a shared `OverrideField` component to the settings design system that bundles an inherit indicator, explicit-vs-inherited typography, a `Reset to global` button, and an effective-value hint
- Pilots it on the `AutomationTab` Terminal Defaults section, replacing the old empty-string-means-inherit approach that silently conflated three distinct user states (never set, intentionally cleared, inheriting)
- Fixes a WCAG 3.3.2 gap where screen-readers had no way to distinguish an inherited value from an explicitly-set one

Resolves #8238

## Changes

- **`src/components/Settings/OverrideField.tsx`** — new primitive; uses `bg-status-info` (not accent) for the override signal; auto-resets to `undefined` when the user clears the input while overriding, to avoid UI/save drift
- **`src/hooks/useProjectSettingsForm.ts`** — terminal state types narrowed from `string` to `string | undefined` (`undefined` = inheriting); invalid scrollback preserves the last-saved value rather than silently wiping it
- **`src/components/Project/AutomationTab.tsx`** — all four Terminal Defaults fields now use `OverrideField`; scrollback error message covers non-finite and out-of-range; updated subtitle copy
- **`src/components/Settings/SettingsDialog.tsx`** — forwards global `scrollbackLines` as `effectiveScrollbackLines` + four `onReset` handlers through `ProjectFormTabContent`

## Testing

18 new `OverrideField` unit tests and 4 new hook tests cover the inherit case, partial reset, invalid-scrollback preservation, and full reset. All 69 unit tests on touched files pass. Typecheck, lint, prettier, build:main, check:channels, check:ipc, check:help, and lint:ratchet all green.