### PR TITLE
Merge cross-scope settings search with per-row scope chip

### DIFF
--- a/src/components/Settings/SettingsDialog.tsx
+++ b/src/components/Settings/SettingsDialog.tsx
@@ -379,8 +379,12 @@ function SettingsDialogInner({
 
   const searchResults = useMemo(
     () =>
-      filterSettings(SETTINGS_SEARCH_INDEX, deferredQuery, { modifiedTabs, scope: activeScope }),
-    [deferredQuery, modifiedTabs, activeScope]
+      filterSettings(SETTINGS_SEARCH_INDEX, deferredQuery, {
+        modifiedTabs,
+        scope: activeScope,
+        hasProject,
+      }),
+    [deferredQuery, modifiedTabs, activeScope, hasProject]
   );
 
   const cleanSearchQuery = useMemo(() => parseQuery(deferredQuery).cleanQuery, [deferredQuery]);
@@ -405,8 +409,15 @@ function SettingsDialogInner({
     // Defer scrollToSection together with the tab change. Setting it
     // urgently would let the previously-active tab's effect consume the
     // pending id (it sees isActive=true after the urgent commit but
-    // before the transition makes the new tab active).
+    // before the transition makes the new tab active). The scope switch
+    // must share the transition so the scope toggle and tab content
+    // commit together — splitting them yields a torn render where the
+    // toggle flips while the panel still shows the previous scope.
+    const nextScope = scopeForTab(tab);
     startTransition(() => {
+      if (nextScope !== activeScope) {
+        setActiveScope(nextScope);
+      }
       setActiveTab(tab);
       setScrollToSection(sectionId ?? null);
     });
@@ -1172,6 +1183,15 @@ function MatchBadge({ count }: { count: number }) {
   );
 }
 
+function ScopeChip({ scope }: { scope: SettingsScope }) {
+  const label = scope === "project" ? "Project" : "Global";
+  return (
+    <span className="text-[10px] font-medium px-1.5 py-0.5 rounded-full bg-tint/10 text-daintree-text/60 leading-none shrink-0">
+      {label}
+    </span>
+  );
+}
+
 interface SearchResultsProps {
   results: ReturnType<typeof filterSettings>;
   query: string;
@@ -1247,6 +1267,7 @@ function SearchResults({
           <div className="flex items-center gap-3">
             <div className="flex-1 min-w-0">
               <div className="flex items-center gap-2 mb-0.5">
+                <ScopeChip scope={result.scope} />
                 <span className="text-[10px] font-medium text-daintree-text/40 uppercase tracking-wide">
                   {result.tabLabel}
                 </span>

--- a/src/components/Settings/__tests__/settingsSearchUtils.test.ts
+++ b/src/components/Settings/__tests__/settingsSearchUtils.test.ts
@@ -646,20 +646,37 @@ describe("cross-scope search merging", () => {
     expect(results.some((r) => r.scope === "global")).toBe(true);
   });
 
-  it("boosts same-scope results to win close-quality ties", () => {
-    // Both scopes have a "notifications" tab nav entry; the active scope's
-    // entry should rank in the top 2 thanks to the +2 boost.
+  it("same-scope tab-nav ranks strictly above the cross-scope tab-nav for the same label", () => {
+    // The central invariant of the merge: when both scopes own an
+    // identically-labeled tab (e.g. "Notifications"), the user's active
+    // scope's tab-nav must come first — otherwise the project entry
+    // appears at #1 when the user is browsing global settings.
     const globalResults = filterSettings(SETTINGS_SEARCH_INDEX, "notifications", {
       scope: "global",
     });
-    const top2Global = globalResults.slice(0, 2);
-    expect(top2Global.some((r) => r.scope === "global")).toBe(true);
+    const globalIdx = globalResults.findIndex((r) => r.id === "tab-nav-notifications");
+    const projectIdx = globalResults.findIndex((r) => r.id === "tab-nav-project:notifications");
+    expect(globalIdx).toBeGreaterThanOrEqual(0);
+    expect(projectIdx).toBeGreaterThanOrEqual(0);
+    expect(globalIdx).toBeLessThan(projectIdx);
 
     const projectResults = filterSettings(SETTINGS_SEARCH_INDEX, "notifications", {
       scope: "project",
     });
-    const top2Project = projectResults.slice(0, 2);
-    expect(top2Project.some((r) => r.scope === "project")).toBe(true);
+    const projectIdx2 = projectResults.findIndex((r) => r.id === "tab-nav-project:notifications");
+    const globalIdx2 = projectResults.findIndex((r) => r.id === "tab-nav-notifications");
+    expect(projectIdx2).toBeGreaterThanOrEqual(0);
+    expect(globalIdx2).toBeGreaterThanOrEqual(0);
+    expect(projectIdx2).toBeLessThan(globalIdx2);
+  });
+
+  it("padded query still earns the tab-label exact-match bonus", () => {
+    // Pre-fix, cleanQuery = raw was returned untrimmed for non-@modified
+    // queries, which caused the exact tab-label match path to silently
+    // miss when input had stray whitespace.
+    const tight = filterSettings(SETTINGS_SEARCH_INDEX, "notifications", { scope: "global" });
+    const padded = filterSettings(SETTINGS_SEARCH_INDEX, "  notifications  ", { scope: "global" });
+    expect(padded[0]?.id).toBe(tight[0]?.id);
   });
 
   it("merges scopes by default when no scope is set", () => {

--- a/src/components/Settings/__tests__/settingsSearchUtils.test.ts
+++ b/src/components/Settings/__tests__/settingsSearchUtils.test.ts
@@ -334,25 +334,30 @@ describe("SETTINGS_SEARCH_INDEX", () => {
     expect(SETTINGS_SEARCH_INDEX.length).toBeGreaterThanOrEqual(50);
   });
 
-  it("tabLabel values match canonical tabTitles", () => {
+  it("tabLabel values match canonical tab short labels", () => {
+    // tabLabel is the *short* tab label users actually type when searching
+    // (e.g. "GitHub", not the longer in-panel header "GitHub Integration").
+    // Keeps tabLabel consistent across global and project scopes so the
+    // result-row breadcrumb reads the same regardless of which scope a
+    // result came from.
     const tabTitles: Record<string, string> = {
       general: "General",
-      keyboard: "Keyboard Shortcuts",
+      keyboard: "Keyboard",
       terminal: "Panel Grid",
       terminalAppearance: "Appearance",
-      worktree: "Worktree Paths",
+      worktree: "Worktree",
       agents: "CLI agents",
-      github: "GitHub Integration",
-      forge: "Forge Integrations",
-      portal: "Portal Links",
-      toolbar: "Toolbar Customization",
+      github: "GitHub",
+      forge: "Forge integrations",
+      portal: "Portal",
+      toolbar: "Toolbar",
       notifications: "Notifications",
       integrations: "Integrations",
       voice: "Voice Input",
       assistant: "Daintree Assistant",
 
       mcp: "MCP Server",
-      environment: "Environment Variables",
+      environment: "Environment",
       privacy: "Privacy & Data",
       troubleshooting: "Troubleshooting",
       "project:general": "General",
@@ -438,7 +443,7 @@ describe("voice tab coverage", () => {
 
 describe("tab-name ranking", () => {
   it("tab-nav entry ranks first for exact tab name queries", () => {
-    const queries = ["Panel Grid", "Keyboard Shortcuts", "GitHub Integration"];
+    const queries = ["Panel Grid", "Keyboard", "GitHub"];
     for (const query of queries) {
       const results = filterSettings(SETTINGS_SEARCH_INDEX, query);
       expect(
@@ -627,35 +632,77 @@ describe("@modified filter", () => {
   });
 });
 
-describe("scope filtering", () => {
-  it("filters results to global scope only", () => {
-    const results = filterSettings(SETTINGS_SEARCH_INDEX, "notifications", { scope: "global" });
-    expect(results.length).toBeGreaterThan(0);
-    expect(results.every((r) => r.scope === "global")).toBe(true);
+describe("cross-scope search merging", () => {
+  it("returns cross-scope results when active scope is global", () => {
+    // Issue #8235: searching "branch prefix" from the global scope used to
+    // return zero results because the project entry was filtered out. The
+    // merged search must surface it.
+    const results = filterSettings(SETTINGS_SEARCH_INDEX, "branch prefix", { scope: "global" });
+    expect(results.some((r) => r.id === "project-branch-prefix")).toBe(true);
   });
 
-  it("filters results to project scope only", () => {
-    const results = filterSettings(SETTINGS_SEARCH_INDEX, "notifications", { scope: "project" });
-    expect(results.length).toBeGreaterThan(0);
-    expect(results.every((r) => r.scope === "project")).toBe(true);
+  it("returns cross-scope results when active scope is project", () => {
+    const results = filterSettings(SETTINGS_SEARCH_INDEX, "telemetry", { scope: "project" });
+    expect(results.some((r) => r.scope === "global")).toBe(true);
   });
 
-  it("project scope search for 'general' returns only project:general entries", () => {
-    const results = filterSettings(SETTINGS_SEARCH_INDEX, "general", { scope: "project" });
-    expect(results.length).toBeGreaterThan(0);
-    expect(results.every((r) => r.tab.startsWith("project:"))).toBe(true);
+  it("boosts same-scope results to win close-quality ties", () => {
+    // Both scopes have a "notifications" tab nav entry; the active scope's
+    // entry should rank in the top 2 thanks to the +2 boost.
+    const globalResults = filterSettings(SETTINGS_SEARCH_INDEX, "notifications", {
+      scope: "global",
+    });
+    const top2Global = globalResults.slice(0, 2);
+    expect(top2Global.some((r) => r.scope === "global")).toBe(true);
+
+    const projectResults = filterSettings(SETTINGS_SEARCH_INDEX, "notifications", {
+      scope: "project",
+    });
+    const top2Project = projectResults.slice(0, 2);
+    expect(top2Project.some((r) => r.scope === "project")).toBe(true);
   });
 
-  it("global scope search does not include project entries", () => {
-    const results = filterSettings(SETTINGS_SEARCH_INDEX, "recipes", { scope: "global" });
-    expect(results.every((r) => !r.tab.startsWith("project:"))).toBe(true);
-  });
-
-  it("returns results from both scopes when no scope filter is set", () => {
+  it("merges scopes by default when no scope is set", () => {
     const results = filterSettings(SETTINGS_SEARCH_INDEX, "notifications");
     const scopes = new Set(results.map((r) => r.scope));
     expect(scopes.has("global")).toBe(true);
     expect(scopes.has("project")).toBe(true);
+  });
+
+  it("hides project-scope results when hasProject is false", () => {
+    const results = filterSettings(SETTINGS_SEARCH_INDEX, "branch prefix", {
+      scope: "global",
+      hasProject: false,
+    });
+    expect(results.every((r) => r.scope !== "project")).toBe(true);
+    expect(results.some((r) => r.id === "project-branch-prefix")).toBe(false);
+  });
+
+  it("keeps project-scope results when hasProject is true", () => {
+    const results = filterSettings(SETTINGS_SEARCH_INDEX, "branch prefix", {
+      scope: "global",
+      hasProject: true,
+    });
+    expect(results.some((r) => r.scope === "project")).toBe(true);
+  });
+
+  it("@modified-only keeps the hard scope filter (empty-state copy is scope-specific)", () => {
+    const modifiedTabs = new Set<SettingsTab>(["general"]);
+    const results = filterSettings(SETTINGS_SEARCH_INDEX, "@modified", {
+      modifiedTabs,
+      scope: "global",
+    });
+    expect(results.length).toBeGreaterThan(0);
+    expect(results.every((r) => r.scope === "global")).toBe(true);
+  });
+
+  it("@modified + text query naturally excludes cross-scope when modifiedTabs is scope-bounded", () => {
+    const modifiedTabs = new Set<SettingsTab>(["general"]);
+    const results = filterSettings(SETTINGS_SEARCH_INDEX, "general @modified", {
+      modifiedTabs,
+      scope: "global",
+    });
+    expect(results.every((r) => r.tab === "general")).toBe(true);
   });
 
   it("every entry in the index has a scope field", () => {

--- a/src/components/Settings/settingsSearchIndex.ts
+++ b/src/components/Settings/settingsSearchIndex.ts
@@ -85,9 +85,16 @@ function deriveSettingsSearchIndex(): SettingsSearchEntry[] {
   for (const tab of SETTINGS_REGISTRY as readonly AnySettingsTabEntry[]) {
     if (tab.scope === "project") continue;
     entries.push(
+      // Use tab.label (the short form, e.g. "GitHub") rather than
+      // tab.headerTitle (e.g. "GitHub Integration") for the search-side
+      // tabLabel. headerTitle is the in-panel H1 — it's longer and more
+      // descriptive but it never matches what the user types (they type
+      // "github", not "github integration"), and project-scope tabs only
+      // expose the short label, so this also keeps tabLabel consistent
+      // across scopes for the result-row breadcrumb.
       ...buildEntriesForTab(
         tab.id,
-        tab.headerTitle ?? tab.label,
+        tab.label,
         tab.scope,
         tab.searchNavDescription ?? "",
         tab.searchNavKeywords,

--- a/src/components/Settings/settingsSearchUtils.tsx
+++ b/src/components/Settings/settingsSearchUtils.tsx
@@ -55,8 +55,31 @@ export function parseQuery(raw: string): ParsedQuery {
 
 export interface FilterSettingsOptions {
   modifiedTabs?: ReadonlySet<SettingsTab>;
+  /**
+   * The user's currently-active scope. When a text query is present this
+   * acts as a *ranking boost* — same-scope entries score +2 to win close
+   * ties but cross-scope results still appear, so searching "branch prefix"
+   * from the global scope still surfaces the project-scope entry. For
+   * `@modified`-only queries this remains a hard filter, since the
+   * empty-state copy is scope-specific.
+   */
   scope?: SettingsScope;
+  /**
+   * When false, strips project-scope entries from text-query results — they
+   * would navigate to a tab that shows an empty project form when no
+   * project is open. Omitted = no guard (preserves call-sites that don't
+   * know project state).
+   */
+  hasProject?: boolean;
 }
+
+// Boost given to entries whose scope matches the user's active scope when a
+// text query is present. Sized to keep same-scope content (e.g.
+// notifications-sound when on global) above cross-scope tab navigation
+// entries that match the same query — absorbs small data quirks like
+// titles using the singular ("Notification sound") while the user types
+// the plural ("notifications").
+const SAME_SCOPE_BOOST = 5;
 
 export function filterSettings(
   index: readonly SettingsSearchEntry[],
@@ -67,17 +90,24 @@ export function filterSettings(
 
   if (!cleanQuery && !filterModified) return [];
 
-  const scopeFilter = options?.scope;
-  const scopedIndex = scopeFilter ? index.filter((entry) => entry.scope === scopeFilter) : index;
+  const activeScope = options?.scope;
 
-  // @modified only — return all entries in modified tabs
+  // @modified only — return all entries in modified tabs, still scoped to
+  // the active scope so the scope-specific empty state stays coherent.
   if (!cleanQuery && filterModified) {
     const modifiedTabs = options?.modifiedTabs;
     if (!modifiedTabs || modifiedTabs.size === 0) return [];
+    const scopedIndex = activeScope
+      ? index.filter((entry) => entry.scope === activeScope)
+      : index;
     return scopedIndex.filter((entry) => modifiedTabs.has(entry.tab));
   }
 
-  const fuse = getFuse(scopedIndex);
+  // Key the Fuse cache on the stable index reference. Previously the cache
+  // was keyed on the .filter()-derived scopedIndex which returns a new array
+  // on every call, so the WeakMap never hit and a fresh Fuse was built for
+  // each query.
+  const fuse = getFuse(index);
 
   // Always use structured $and query; escape operator prefixes so user input
   // like "!font" isn't interpreted as a Fuse NOT operator
@@ -120,10 +150,20 @@ export function filterSettings(
     if (tabLabelLower === normalized) {
       score += 5;
       if (entry.id.startsWith("tab-nav-")) {
-        score += 2;
+        // Only stack the extra tab-nav bonus when the entry is in the
+        // user's active scope. Cross-scope tab-nav rows would otherwise
+        // bury same-scope content entries that match the same label
+        // (e.g. tab-nav-project:notifications burying notifications-sound
+        // when the user searches "notifications" from global scope).
+        const isSameScope = !activeScope || entry.scope === activeScope;
+        if (isSameScope) score += 2;
       }
     } else if (tokens.length > 1 && entry.id.startsWith("tab-nav-")) {
       score -= 3;
+    }
+
+    if (activeScope && entry.scope === activeScope) {
+      score += SAME_SCOPE_BOOST;
     }
 
     return { entry, score };
@@ -138,6 +178,12 @@ export function filterSettings(
     const modifiedTabs = options?.modifiedTabs;
     if (!modifiedTabs || modifiedTabs.size === 0) return [];
     results = results.filter((entry) => modifiedTabs.has(entry.tab));
+  }
+
+  // Hide project-scope entries when no project is open — they'd lead to an
+  // empty project form. Same guard the nav sidebar already applies.
+  if (options?.hasProject === false) {
+    results = results.filter((entry) => entry.scope !== "project");
   }
 
   return results;

--- a/src/components/Settings/settingsSearchUtils.tsx
+++ b/src/components/Settings/settingsSearchUtils.tsx
@@ -98,9 +98,7 @@ export function filterSettings(
   if (!cleanQuery && filterModified) {
     const modifiedTabs = options?.modifiedTabs;
     if (!modifiedTabs || modifiedTabs.size === 0) return [];
-    const scopedIndex = activeScope
-      ? index.filter((entry) => entry.scope === activeScope)
-      : index;
+    const scopedIndex = activeScope ? index.filter((entry) => entry.scope === activeScope) : index;
     return scopedIndex.filter((entry) => modifiedTabs.has(entry.tab));
   }
 

--- a/src/components/Settings/settingsSearchUtils.tsx
+++ b/src/components/Settings/settingsSearchUtils.tsx
@@ -47,8 +47,9 @@ export function parseQuery(raw: string): ParsedQuery {
   // Use a global version to strip all occurrences
   let cleanQuery = raw;
   if (filterModified) {
-    cleanQuery = raw.replace(/(?:^|\s)@mod(?:ified)?(?=\s|$)/gi, " ").trim();
+    cleanQuery = raw.replace(/(?:^|\s)@mod(?:ified)?(?=\s|$)/gi, " ");
   }
+  cleanQuery = cleanQuery.trim();
   const tokens = cleanQuery.toLowerCase().split(/\s+/).filter(Boolean);
   return { cleanQuery, tokens, filterModified };
 }
@@ -57,11 +58,11 @@ export interface FilterSettingsOptions {
   modifiedTabs?: ReadonlySet<SettingsTab>;
   /**
    * The user's currently-active scope. When a text query is present this
-   * acts as a *ranking boost* — same-scope entries score +2 to win close
-   * ties but cross-scope results still appear, so searching "branch prefix"
-   * from the global scope still surfaces the project-scope entry. For
-   * `@modified`-only queries this remains a hard filter, since the
-   * empty-state copy is scope-specific.
+   * acts as a *ranking boost* — same-scope entries earn `SAME_SCOPE_BOOST`
+   * to win close ties but cross-scope results still appear, so searching
+   * "branch prefix" from the global scope still surfaces the project-scope
+   * entry. For `@modified`-only queries this remains a hard filter, since
+   * the empty-state copy is scope-specific.
    */
   scope?: SettingsScope;
   /**


### PR DESCRIPTION
Closes #8235.

## Summary
- Settings search now queries both scopes regardless of which one is active, so typing a project-only term like `branch prefix` while on global no longer returns zero results.
- Each result row carries a small non-accent `Global` / `Project` chip naming the scope it belongs to.
- Clicking a cross-scope result flips the dialog's active scope and tab in a single React transition, then the existing scroll-to-section + 1.5s highlight pulse take over.
- Same-scope results still dominate ranking via a post-Fuse boost. Cross-scope tab-nav rows no longer earn the extra +2 stacking bonus, so they can't bury same-scope content matches for the same label.
- Project-scope rows are hidden when no project is open (`hasProject` guard).
- Fixed a pre-existing Fuse WeakMap cache that was keyed on the `.filter()`-derived array and never hit, so a fresh Fuse instance was being built on every query.
- Switched the search index `tabLabel` to use `tab.label` (the short form, e.g. `GitHub`) rather than `tab.headerTitle` (e.g. `GitHub Integration`). The header title is still the in-panel H1 — it just no longer pollutes search matching or the result breadcrumb, so the breadcrumb now reads the same regardless of scope.
- `parseQuery` now always trims the cleaned query so a padded input like `  notifications  ` still earns the exact tab-label match bonus.

## Test plan
- [x] `npx vitest run src/components/Settings/__tests__/settingsSearchUtils.test.ts` — 106 tests pass, including new cross-scope-merging coverage (`branch prefix` returns project entry; `hasProject: false` strips project results; `@modified`-only keeps the hard scope filter; same-scope tab-nav strictly ranks above cross-scope tab-nav; padded queries still match).
- [x] `npx eslint` on the changed files — clean.
- [x] `npx tsc --noEmit -p tsconfig.app.json` — clean.
- [ ] Manual: with a project open, search `branch prefix` from the global scope, confirm the `Project` chip and that clicking flips scope + lands on Worktree Setup.
- [ ] Manual: search `notifications`, confirm `Global` chip on global rows and `Project` chip on project rows, same scope still ranks first.
- [ ] Manual: close all projects, search `branch prefix`, confirm no project-scope rows appear.

## Notes
- The result-row breadcrumb for `keyboard`, `worktree`, `toolbar`, `environment`, `github`, and `portal` tabs now shows the short label (`GITHUB`) instead of the long header (`GITHUB INTEGRATION`). The dialog's panel header is unchanged.
- During review one pre-existing gap surfaced: `AutomationTab.tsx` doesn't put `id={entry.id}` on its section containers, so cross-scope clicks to those sections correctly navigate but skip the highlight pulse. That's a broader settings deep-link gap and worth a follow-up issue rather than expanding scope here.