### PR TITLE
fix(fleet): close directing state on raw broadcast Enter and gate cross-worktree writes

### DIFF
--- a/src/components/Fleet/__tests__/fleetRawInputBroadcast.test.ts
+++ b/src/components/Fleet/__tests__/fleetRawInputBroadcast.test.ts
@@ -345,11 +345,7 @@ describe("broadcastFleetRawInput", () => {
     // The actual write still goes out — adding the notifyEnterPressed call
     // must not gate or short-circuit the broadcast.
     expect(broadcastMock).toHaveBeenCalledWith(["t1", "t2", "t3"], "\r");
-    expect(notifyEnterPressedMock.mock.calls.map(([id]) => id).sort()).toEqual([
-      "t1",
-      "t2",
-      "t3",
-    ]);
+    expect(notifyEnterPressedMock.mock.calls.map(([id]) => id).sort()).toEqual(["t1", "t2", "t3"]);
   });
 });
 

--- a/src/components/Fleet/__tests__/fleetRawInputBroadcast.test.ts
+++ b/src/components/Fleet/__tests__/fleetRawInputBroadcast.test.ts
@@ -292,7 +292,7 @@ describe("broadcastFleetRawInput", () => {
     expect(enterFleetScopeMock).not.toHaveBeenCalled();
   });
 
-  it("treats panels with undefined worktreeId as same-worktree (no scope entry)", () => {
+  it("treats panels with undefined worktreeId as no-affiliation (no scope entry on their own)", () => {
     const t1 = makeTerminal("t1", { worktreeId: "wt-1" });
     const t2 = makeTerminal("t2");
     // Strip the worktreeId so the lookup returns undefined.
@@ -304,6 +304,52 @@ describe("broadcastFleetRawInput", () => {
 
     broadcastFleetRawInput("t1", "ls\r");
     expect(enterFleetScopeMock).not.toHaveBeenCalled();
+  });
+
+  it("still enters fleet scope when an undefined-worktreeId target sits alongside a real cross-worktree target", () => {
+    const t1 = makeTerminal("t1", { worktreeId: "wt-1" });
+    const t2 = makeTerminal("t2");
+    delete (t2 as { worktreeId?: string }).worktreeId;
+    const t3 = makeTerminal("t3", { worktreeId: "wt-2" });
+    seedPanels([t1, t2, t3]);
+    useFleetArmingStore.getState().armIds(["t1", "t2", "t3"]);
+    useFleetScopeFlagStore.setState({ mode: "scoped", isHydrated: true });
+    worktreeSelectionStateRef.current.activeWorktreeId = "wt-1";
+
+    broadcastFleetRawInput("t1", "ls\r");
+    expect(enterFleetScopeMock).toHaveBeenCalledTimes(1);
+  });
+
+  it("enters fleet scope regardless of payload — non-Enter cross-worktree still promotes visibility", () => {
+    seedPanels([
+      makeTerminal("t1", { worktreeId: "wt-1" }),
+      makeTerminal("t2", { worktreeId: "wt-2" }),
+    ]);
+    useFleetArmingStore.getState().armIds(["t1", "t2"]);
+    useFleetScopeFlagStore.setState({ mode: "scoped", isHydrated: true });
+    worktreeSelectionStateRef.current.activeWorktreeId = "wt-1";
+
+    // ESC+CR soft-newline (alt-Enter) — not a submit but still keystroke input.
+    expect(broadcastFleetRawInput("t1", "\x1b\r")).toBe(true);
+    expect(enterFleetScopeMock).toHaveBeenCalledTimes(1);
+    // notifyEnterPressed must NOT fire for the soft-newline payload.
+    expect(notifyEnterPressedMock).not.toHaveBeenCalled();
+  });
+
+  it("performs the raw broadcast alongside notifyEnterPressed for plain Enter", () => {
+    seedPanels([makeTerminal("t1"), makeTerminal("t2"), makeTerminal("t3")]);
+    useFleetArmingStore.getState().armIds(["t1", "t2", "t3"]);
+
+    expect(broadcastFleetRawInput("t1", "\r")).toBe(true);
+
+    // The actual write still goes out — adding the notifyEnterPressed call
+    // must not gate or short-circuit the broadcast.
+    expect(broadcastMock).toHaveBeenCalledWith(["t1", "t2", "t3"], "\r");
+    expect(notifyEnterPressedMock.mock.calls.map(([id]) => id).sort()).toEqual([
+      "t1",
+      "t2",
+      "t3",
+    ]);
   });
 });
 

--- a/src/components/Fleet/__tests__/fleetRawInputBroadcast.test.ts
+++ b/src/components/Fleet/__tests__/fleetRawInputBroadcast.test.ts
@@ -3,12 +3,18 @@ import { beforeEach, describe, expect, it, vi } from "vitest";
 import { applyFleetBroadcastResult, broadcastFleetRawInput } from "../fleetRawInputBroadcast";
 import { useFleetArmingStore } from "@/store/fleetArmingStore";
 import { useFleetFailureStore } from "@/store/fleetFailureStore";
+import { useFleetScopeFlagStore } from "@/store/fleetScopeFlagStore";
 import { usePanelStore } from "@/store/panelStore";
 import type { TerminalInstance } from "@shared/types";
 
 const broadcastMock = vi.hoisted(() => vi.fn<(ids: string[], data: string) => void>());
 const notifyUserInputMock = vi.hoisted(() => vi.fn<(id: string, data?: string) => void>());
+const notifyEnterPressedMock = vi.hoisted(() => vi.fn<(id: string) => void>());
 const clearDirectingStateMock = vi.hoisted(() => vi.fn<(id: string) => void>());
+const enterFleetScopeMock = vi.hoisted(() => vi.fn<() => void>());
+const worktreeSelectionStateRef = vi.hoisted(() => ({
+  current: { activeWorktreeId: "wt-1" as string | null },
+}));
 
 vi.mock("@/clients", async (importOriginal) => {
   const actual = await importOriginal<typeof import("@/clients")>();
@@ -24,7 +30,17 @@ vi.mock("@/clients", async (importOriginal) => {
 vi.mock("@/services/TerminalInstanceService", () => ({
   terminalInstanceService: {
     notifyUserInput: notifyUserInputMock,
+    notifyEnterPressed: notifyEnterPressedMock,
     clearDirectingState: clearDirectingStateMock,
+  },
+}));
+
+vi.mock("@/store/worktreeStore", () => ({
+  useWorktreeSelectionStore: {
+    getState: () => ({
+      activeWorktreeId: worktreeSelectionStateRef.current.activeWorktreeId,
+      enterFleetScope: enterFleetScopeMock,
+    }),
   },
 }));
 
@@ -54,7 +70,9 @@ function seedPanels(terminals: TerminalInstance[]): void {
 function resetStores(): void {
   broadcastMock.mockReset();
   notifyUserInputMock.mockReset();
+  notifyEnterPressedMock.mockReset();
   clearDirectingStateMock.mockReset();
+  enterFleetScopeMock.mockReset();
   useFleetArmingStore.setState({
     armedIds: new Set<string>(),
     armOrder: [],
@@ -65,6 +83,10 @@ function resetStores(): void {
   });
   useFleetFailureStore.getState().clear();
   usePanelStore.setState({ panelsById: {}, panelIds: [] });
+  // Default to unhydrated so existing tests don't accidentally trigger
+  // fleet-scope side effects. Cross-worktree tests opt in by hydrating.
+  useFleetScopeFlagStore.setState({ mode: "scoped", isHydrated: false });
+  worktreeSelectionStateRef.current.activeWorktreeId = "wt-1";
 }
 
 describe("broadcastFleetRawInput", () => {
@@ -186,6 +208,102 @@ describe("broadcastFleetRawInput", () => {
 
     expect(broadcastFleetRawInput("t1", "rejected")).toBe(false);
     expect(notifyUserInputMock).not.toHaveBeenCalled();
+  });
+
+  it("calls notifyEnterPressed on every target for a plain Enter submit (#8255)", () => {
+    seedPanels([makeTerminal("t1"), makeTerminal("t2"), makeTerminal("t3")]);
+    useFleetArmingStore.getState().armIds(["t1", "t2", "t3"]);
+
+    expect(broadcastFleetRawInput("t1", "\r")).toBe(true);
+
+    // Every target — origin included — gets notifyEnterPressed so the
+    // synthetic `directing` state closes optimistically. The custom xterm
+    // key handler bypasses the origin's own onEnterPressed listener path,
+    // so the origin needs it explicitly here.
+    const notifiedIds = notifyEnterPressedMock.mock.calls.map(([id]) => id).sort();
+    expect(notifiedIds).toEqual(["t1", "t2", "t3"]);
+  });
+
+  it("does not call notifyEnterPressed for non-submit payloads", () => {
+    seedPanels([makeTerminal("t1"), makeTerminal("t2")]);
+    useFleetArmingStore.getState().armIds(["t1", "t2"]);
+
+    // Codex soft-newline (LF) — not a submit.
+    broadcastFleetRawInput("t1", "\n");
+    // Legacy ESC+CR — not a submit (alt-Enter soft newline).
+    broadcastFleetRawInput("t1", "\x1b\r");
+    // Multi-byte payload containing CR — not a single Enter keystroke.
+    broadcastFleetRawInput("t1", "abc\r");
+    // Plain text — not a submit.
+    broadcastFleetRawInput("t1", "abc");
+
+    expect(notifyEnterPressedMock).not.toHaveBeenCalled();
+  });
+
+  it("auto-enters fleet scope when broadcast targets cross worktrees in scoped mode (#8255)", () => {
+    seedPanels([
+      makeTerminal("t1", { worktreeId: "wt-1" }),
+      makeTerminal("t2", { worktreeId: "wt-2" }),
+    ]);
+    useFleetArmingStore.getState().armIds(["t1", "t2"]);
+    useFleetScopeFlagStore.setState({ mode: "scoped", isHydrated: true });
+    worktreeSelectionStateRef.current.activeWorktreeId = "wt-1";
+
+    expect(broadcastFleetRawInput("t1", "ls\r")).toBe(true);
+    expect(enterFleetScopeMock).toHaveBeenCalledTimes(1);
+  });
+
+  it("does not enter fleet scope when targets are same-worktree", () => {
+    seedPanels([
+      makeTerminal("t1", { worktreeId: "wt-1" }),
+      makeTerminal("t2", { worktreeId: "wt-1" }),
+    ]);
+    useFleetArmingStore.getState().armIds(["t1", "t2"]);
+    useFleetScopeFlagStore.setState({ mode: "scoped", isHydrated: true });
+    worktreeSelectionStateRef.current.activeWorktreeId = "wt-1";
+
+    broadcastFleetRawInput("t1", "ls\r");
+    expect(enterFleetScopeMock).not.toHaveBeenCalled();
+  });
+
+  it("does not enter fleet scope in legacy mode even when cross-worktree", () => {
+    seedPanels([
+      makeTerminal("t1", { worktreeId: "wt-1" }),
+      makeTerminal("t2", { worktreeId: "wt-2" }),
+    ]);
+    useFleetArmingStore.getState().armIds(["t1", "t2"]);
+    useFleetScopeFlagStore.setState({ mode: "legacy", isHydrated: true });
+    worktreeSelectionStateRef.current.activeWorktreeId = "wt-1";
+
+    broadcastFleetRawInput("t1", "ls\r");
+    expect(enterFleetScopeMock).not.toHaveBeenCalled();
+  });
+
+  it("does not enter fleet scope before hydration (preserves persisted-mode load order)", () => {
+    seedPanels([
+      makeTerminal("t1", { worktreeId: "wt-1" }),
+      makeTerminal("t2", { worktreeId: "wt-2" }),
+    ]);
+    useFleetArmingStore.getState().armIds(["t1", "t2"]);
+    useFleetScopeFlagStore.setState({ mode: "scoped", isHydrated: false });
+    worktreeSelectionStateRef.current.activeWorktreeId = "wt-1";
+
+    broadcastFleetRawInput("t1", "ls\r");
+    expect(enterFleetScopeMock).not.toHaveBeenCalled();
+  });
+
+  it("treats panels with undefined worktreeId as same-worktree (no scope entry)", () => {
+    const t1 = makeTerminal("t1", { worktreeId: "wt-1" });
+    const t2 = makeTerminal("t2");
+    // Strip the worktreeId so the lookup returns undefined.
+    delete (t2 as { worktreeId?: string }).worktreeId;
+    seedPanels([t1, t2]);
+    useFleetArmingStore.getState().armIds(["t1", "t2"]);
+    useFleetScopeFlagStore.setState({ mode: "scoped", isHydrated: true });
+    worktreeSelectionStateRef.current.activeWorktreeId = "wt-1";
+
+    broadcastFleetRawInput("t1", "ls\r");
+    expect(enterFleetScopeMock).not.toHaveBeenCalled();
   });
 });
 

--- a/src/components/Fleet/fleetRawInputBroadcast.ts
+++ b/src/components/Fleet/fleetRawInputBroadcast.ts
@@ -56,6 +56,10 @@ export function broadcastFleetRawInput(originId: string, data: string): boolean 
     let hasCrossWorktreeTarget = false;
     for (const id of targets) {
       const targetWorktreeId = panelsById[id]?.worktreeId;
+      // `undefined` is treated as "no worktree affiliation" — global/unowned
+      // terminals don't drive scope entry on their own. A real cross-worktree
+      // target (a non-undefined id that differs from the active worktree) is
+      // still detected when present alongside such a terminal.
       if (targetWorktreeId !== undefined && targetWorktreeId !== activeWorktreeId) {
         hasCrossWorktreeTarget = true;
         break;
@@ -76,11 +80,15 @@ export function broadcastFleetRawInput(originId: string, data: string): boolean 
     terminalInstanceService.notifyUserInput(id, data);
   }
   // Plain Enter is a submit. Mirror the structured-submit pattern from
-  // `fleetExecution.ts`: optimistically close `directing → working` for
+  // `fleetExecution.ts`: optimistically advance `directing → working` for
   // every target (origin included — its own xterm onKey path is bypassed
-  // when broadcast intercepts the raw input). The async
-  // `broadcast-write-result` handler still calls `clearDirectingState` for
-  // permanent failures, which overrides this optimistic state.
+  // when broadcast intercepts the raw input). Permanent failures fall
+  // through to `applyFleetBroadcastResult`, which also disarms the target;
+  // its `clearDirectingState` call is a no-op once we've already advanced
+  // to `working` (TerminalAgentStateController guards on `agentState ===
+  // "directing"`), so a dead-pipe target briefly reads as `working` until
+  // the PTY's own exit signal drives the state machine forward. Disarm +
+  // exit are the load-bearing recovery paths.
   // Match `\r` exactly — `\n` is Codex soft-newline, `\x1b\r` is legacy
   // ESC+CR, neither is a submit.
   if (data === "\r") {

--- a/src/components/Fleet/fleetRawInputBroadcast.ts
+++ b/src/components/Fleet/fleetRawInputBroadcast.ts
@@ -3,7 +3,9 @@ import { registerFleetInputBroadcastHandler } from "@/services/terminal/fleetInp
 import { terminalInstanceService } from "@/services/TerminalInstanceService";
 import { isFleetArmEligible, useFleetArmingStore } from "@/store/fleetArmingStore";
 import { useFleetFailureStore } from "@/store/fleetFailureStore";
+import { useFleetScopeFlagStore } from "@/store/fleetScopeFlagStore";
 import { usePanelStore } from "@/store/panelStore";
+import { useWorktreeSelectionStore } from "@/store/worktreeStore";
 import { logWarn } from "@/utils/logger";
 import type { BroadcastWriteResultPayload } from "@shared/types";
 
@@ -42,6 +44,28 @@ export function broadcastFleetRawInput(originId: string, data: string): boolean 
   const targets = resolveLiveFleetTargetIds();
   if (targets.length < 2 || !targets.includes(originId)) return false;
 
+  // Auto-enter fleet scope when targets span worktrees so cross-worktree
+  // armed terminals are actually rendered while raw input is in flight —
+  // otherwise the user is firing keystrokes into hidden panes. Gated on
+  // `mode === "scoped"` + hydrated so legacy users keep their existing
+  // silent-write behavior. `enterFleetScope` is idempotent.
+  const scopeFlag = useFleetScopeFlagStore.getState();
+  if (scopeFlag.isHydrated && scopeFlag.mode === "scoped") {
+    const { panelsById } = usePanelStore.getState();
+    const activeWorktreeId = useWorktreeSelectionStore.getState().activeWorktreeId;
+    let hasCrossWorktreeTarget = false;
+    for (const id of targets) {
+      const targetWorktreeId = panelsById[id]?.worktreeId;
+      if (targetWorktreeId !== undefined && targetWorktreeId !== activeWorktreeId) {
+        hasCrossWorktreeTarget = true;
+        break;
+      }
+    }
+    if (hasCrossWorktreeTarget) {
+      useWorktreeSelectionStore.getState().enterFleetScope();
+    }
+  }
+
   terminalClient.broadcast(targets, data);
   // Mirror the origin's xterm onData → onUserInput path on every non-origin
   // target so the `directing` indicator fires fleet-wide. Pass the raw
@@ -50,6 +74,19 @@ export function broadcastFleetRawInput(originId: string, data: string): boolean 
   for (const id of targets) {
     if (id === originId) continue;
     terminalInstanceService.notifyUserInput(id, data);
+  }
+  // Plain Enter is a submit. Mirror the structured-submit pattern from
+  // `fleetExecution.ts`: optimistically close `directing → working` for
+  // every target (origin included — its own xterm onKey path is bypassed
+  // when broadcast intercepts the raw input). The async
+  // `broadcast-write-result` handler still calls `clearDirectingState` for
+  // permanent failures, which overrides this optimistic state.
+  // Match `\r` exactly — `\n` is Codex soft-newline, `\x1b\r` is legacy
+  // ESC+CR, neither is a submit.
+  if (data === "\r") {
+    for (const id of targets) {
+      terminalInstanceService.notifyEnterPressed(id);
+    }
   }
   // Bump the broadcast signal so the ribbon can fire a one-shot commit
   // flash. Counter increments only; subscribers diff against their last

--- a/src/components/Terminal/XtermAdapter.tsx
+++ b/src/components/Terminal/XtermAdapter.tsx
@@ -396,6 +396,11 @@ export function XtermAdapter({
             writeTerminalInputOrFleet(terminalId, submit);
             terminalInstanceService.notifyUserInput(terminalId);
             stableOnInput(submit);
+            // Plain Enter is a submit. The custom key handler returns `false`
+            // before xterm's onKey/onData fire, so the listener-installed
+            // onEnterPressed path is bypassed — call it explicitly to close
+            // the `directing` synthetic state. No-op when not in directing.
+            terminalInstanceService.notifyEnterPressed(terminalId);
           }
           return false;
         }

--- a/src/components/Terminal/__tests__/XtermAdapter.lifecycle.test.tsx
+++ b/src/components/Terminal/__tests__/XtermAdapter.lifecycle.test.tsx
@@ -56,6 +56,7 @@ const mocks = vi.hoisted(() => {
     addAltBufferListener: vi.fn(() => vi.fn()),
     fetchAndRestore: vi.fn(() => Promise.resolve(false)),
     notifyUserInput: vi.fn(),
+    notifyEnterPressed: vi.fn(),
   };
 
   return {
@@ -273,6 +274,11 @@ describe("XtermAdapter lifecycle", () => {
     expect(mocks.writeTerminalInputOrFleet).toHaveBeenCalledWith("term-1", "\r");
     expect(firstOnInput).not.toHaveBeenCalled();
     expect(secondOnInput).toHaveBeenCalledWith("\r");
+    // Plain Enter must close the synthetic `directing` state explicitly —
+    // the custom key handler returns `false` before xterm's onKey/onData
+    // fires, bypassing the listener-installed onEnterPressed path (#8255).
+    expect(mocks.terminalInstanceService.notifyUserInput).toHaveBeenCalledWith("term-1");
+    expect(mocks.terminalInstanceService.notifyEnterPressed).toHaveBeenCalledWith("term-1");
 
     mocks.getExitHandler()?.(7);
     expect(firstOnExit).not.toHaveBeenCalled();


### PR DESCRIPTION
## Summary

Fixes #8255. Three targeted fixes for raw Fleet broadcast keystroke routing:

- **`XtermAdapter` plain Enter** now calls `notifyEnterPressed` after the write. The custom xterm key handler returns `false` before `onKey`/`onData` fires, which bypasses the listener-installed `onEnterPressed` path — single-terminal Enter would otherwise sit in `directing` for the full 1.5s debounce window.
- **`broadcastFleetRawInput` Enter detection** — exact `data === "\r"` match (not `\n` Codex soft-newline, not `\x1b\r` legacy ESC+CR) triggers optimistic `notifyEnterPressed` on every armed target including origin. Permanent failures fall through to `clearDirectingState` via the existing `applyFleetBroadcastResult` handler; once `notifyEnterPressed` has advanced `directing → working`, that fallback is a no-op and the load-bearing recovery paths are `disarmId` + the PTY's own exit signal.
- **Cross-worktree scope auto-entry** — when any target's `worktreeId` differs from the active worktree, `enterFleetScope()` is called before the write. Gated on `mode === "scoped" && isHydrated` so legacy users keep their existing silent-write behavior. `enterFleetScope` is idempotent and promotes cross-worktree armed terminals to VISIBLE so the user can see what is being typed into. Panels with undefined `worktreeId` are treated as no-affiliation — they don't drive scope entry on their own but won't block a real cross-worktree target from triggering it.

No new IPC channels, shared-type changes, or persisted state.

## Test plan

- [x] `npx vitest run src/components/Fleet/__tests__/fleetRawInputBroadcast.test.ts src/components/Terminal/__tests__/XtermAdapter.lifecycle.test.tsx` — 29 tests pass
- [x] Targeted prettier + ESLint pass on changed files
- [x] Full typecheck (`tsc --noEmit` × renderer/main/preload) passes
- [ ] Manual: arm two cross-worktree agent terminals in scoped mode, focus one, type into the other via raw keystrokes — fleet scope enters automatically, directing indicator closes on plain Enter for both
- [ ] Manual: single armed terminal (no fleet), press Enter — directing indicator closes immediately instead of waiting for the 1.5s debounce