### PR TITLE
style(motion): split performance-mode from reduced-motion via @custom-variant

### DIFF
--- a/src/components/Layout/__tests__/trashToastRemoval.test.ts
+++ b/src/components/Layout/__tests__/trashToastRemoval.test.ts
@@ -26,13 +26,11 @@ describe("Trash Toast Removal - Issue #3113", () => {
     expect(content).toContain(".animate-trash-pulse");
   });
 
-  it("should include animate-trash-pulse in prefers-reduced-motion override", async () => {
+  it("should include animate-trash-pulse in the reduce-motion variant override", async () => {
     const filePath = path.resolve(__dirname, "../../../index.css");
     const content = await fs.readFile(filePath, "utf-8");
-    const reducedMotionMatch = content.match(
-      /@media\s*\(prefers-reduced-motion:\s*reduce\)\s*\{([^}]*\{[^}]*\})*[^}]*/
+    expect(content).toMatch(
+      /@variant\s+reduce-motion\s*\{[\s\S]*?\.animate-trash-pulse[\s\S]*?animation:\s*none/
     );
-    expect(reducedMotionMatch).not.toBeNull();
-    expect(reducedMotionMatch![0]).toContain("animate-trash-pulse");
   });
 });

--- a/src/components/ui/__tests__/ContentFadeIn.test.tsx
+++ b/src/components/ui/__tests__/ContentFadeIn.test.tsx
@@ -77,9 +77,9 @@ describe("content-fade-in CSS contract", () => {
   // shouldn't matter — we're asserting authored intent in src/index.css.
   const css = readFileSync(resolve(__dirname, "../../../index.css"), "utf8");
 
-  it("declares the data-reduce-animations override for .content-fade-in", () => {
+  it("declares the reduce-motion override for .content-fade-in (OS + app toggle)", () => {
     const block = css.match(
-      /body\[data-reduce-animations="true"\]\s+\.content-fade-in\s*\{[^}]*\}/
+      /@variant\s+reduce-motion\s*\{[\s\S]*?\.content-fade-in\s*\{[^}]*\}/
     )?.[0];
     expect(block).toBeTruthy();
     expect(block).toMatch(/animation:\s*none/);

--- a/src/components/ui/__tests__/Skeleton.test.tsx
+++ b/src/components/ui/__tests__/Skeleton.test.tsx
@@ -512,15 +512,15 @@ describe("animate-hint-fade-in CSS contract", () => {
     expect(css).toMatch(/\.animate-hint-fade-in\s*\{/);
   });
 
-  it("disables the fade under prefers-reduced-motion", () => {
-    const block = css.match(/@media\s*\(prefers-reduced-motion:\s*reduce\)\s*\{[\s\S]*?\n\}/)?.[0];
-    expect(block).toBeTruthy();
-    expect(block).toMatch(/\.animate-hint-fade-in/);
+  it("declares the reduce-motion custom variant", () => {
+    expect(css).toMatch(/@custom-variant\s+reduce-motion\s*\{/);
+    expect(css).toMatch(/@media\s*\(prefers-reduced-motion:\s*reduce\)/);
+    expect(css).toMatch(/body\[data-reduce-animations="true"\]\s*&/);
   });
 
-  it("disables the fade under body[data-reduce-animations]", () => {
+  it("disables the fade under @variant reduce-motion (OS + app toggle)", () => {
     expect(css).toMatch(
-      /body\[data-reduce-animations="true"\][\s\S]*?\.animate-hint-fade-in[\s\S]*?animation:\s*none/
+      /@variant\s+reduce-motion\s*\{[\s\S]*?\.animate-hint-fade-in[\s\S]*?animation:\s*none/
     );
   });
 
@@ -544,15 +544,9 @@ describe("animate-skeleton-shimmer CSS contract", () => {
     expect(css).toMatch(/\.animate-skeleton-shimmer\s*\{/);
   });
 
-  it("hides the ::after sweep under prefers-reduced-motion", () => {
-    const block = css.match(/@media\s*\(prefers-reduced-motion:\s*reduce\)\s*\{[\s\S]*?\n\}/)?.[0];
-    expect(block).toBeTruthy();
-    expect(block).toMatch(/\.animate-skeleton-shimmer::after\s*\{[^}]*display:\s*none/);
-  });
-
-  it("hides the ::after sweep under body[data-reduce-animations]", () => {
+  it("hides the ::after sweep under @variant reduce-motion (OS + app toggle)", () => {
     expect(css).toMatch(
-      /body\[data-reduce-animations="true"\]\s+\.animate-skeleton-shimmer::after\s*\{[^}]*display:\s*none/
+      /@variant\s+reduce-motion\s*\{[\s\S]*?\.animate-skeleton-shimmer::after[\s\S]*?display:\s*none/
     );
   });
 

--- a/src/components/ui/__tests__/Skeleton.test.tsx
+++ b/src/components/ui/__tests__/Skeleton.test.tsx
@@ -515,7 +515,13 @@ describe("animate-hint-fade-in CSS contract", () => {
   it("declares the reduce-motion custom variant", () => {
     expect(css).toMatch(/@custom-variant\s+reduce-motion\s*\{/);
     expect(css).toMatch(/@media\s*\(prefers-reduced-motion:\s*reduce\)/);
-    expect(css).toMatch(/body\[data-reduce-animations="true"\]\s*&/);
+    // The body-attribute branch must NOT use `&` — at top-level `@variant`
+    // usage, `&` desugars to `:scope` and the resulting selectors never
+    // match. CSS nesting auto-prepends the ancestor. See the
+    // @custom-variant definition comment in src/index.css.
+    expect(css).toMatch(
+      /@custom-variant\s+reduce-motion[\s\S]*?body\[data-reduce-animations="true"\]\s*\{\s*@slot/
+    );
   });
 
   it("disables the fade under @variant reduce-motion (OS + app toggle)", () => {

--- a/src/index.css
+++ b/src/index.css
@@ -12,12 +12,19 @@
  * with the Daintree "Reduce UI animations" toggle (`body[data-reduce-animations="true"]`).
  * Use as `@variant reduce-motion { ... }` to write a single rule that applies
  * under either trigger; preserves the same selector specificity as the
- * pre-consolidation `body[data-reduce-animations="true"] X` mirror block. */
+ * pre-consolidation `body[data-reduce-animations="true"] X` mirror block.
+ *
+ * The body-attribute branch is written WITHOUT `&` so CSS nesting
+ * auto-prepends the ancestor — the slot content becomes a descendant of
+ * `body[data-reduce-animations="true"]`. Forms using `&` (either
+ * `body[...] &` or `&:is(body[...] *)`) misbehave when the `@variant`
+ * block is used at top level: `&` desugars to `:scope` and the resulting
+ * `:scope:is(body[...] *) .foo` selectors never match in production. */
 @custom-variant reduce-motion {
   @media (prefers-reduced-motion: reduce) {
     @slot;
   }
-  body[data-reduce-animations="true"] & {
+  body[data-reduce-animations="true"] {
     @slot;
   }
 }
@@ -2423,12 +2430,16 @@ body[data-performance-mode="true"] .animate-hint-fade-in {
   opacity: 1 !important;
 }
 
-/* The global wildcard above strips the 400ms transition-delay; without an
- * explicit opacity reset stale surfaces would stay at 0.5 if they were
- * mid-stale when performance mode kicked in. */
+/* Stale surfaces use a 150ms opacity transition with a 400ms delay (see
+ * `.palette-results-stale` definition). The narrowed perf-mode wildcard
+ * preserves the `opacity` transition-property, so the delay would still
+ * apply — `opacity: 1 !important` alone would wait 400ms before resetting.
+ * Kill the transition outright on this scoped selector so the reset is
+ * instant when performance mode kicks in mid-stale. */
 body[data-performance-mode="true"] .palette-results-stale,
 body[data-performance-mode="true"] .surface-stale {
   opacity: 1 !important;
+  transition: none !important;
 }
 
 /* The global wildcard above kills the shimmer animation but the ::after

--- a/src/index.css
+++ b/src/index.css
@@ -8,6 +8,20 @@
 @import "./styles/components/sidebar.css";
 @import "./styles/components/panels.css";
 
+/* Reduced-motion variant — composes OS-level `prefers-reduced-motion: reduce`
+ * with the Daintree "Reduce UI animations" toggle (`body[data-reduce-animations="true"]`).
+ * Use as `@variant reduce-motion { ... }` to write a single rule that applies
+ * under either trigger; preserves the same selector specificity as the
+ * pre-consolidation `body[data-reduce-animations="true"] X` mirror block. */
+@custom-variant reduce-motion {
+  @media (prefers-reduced-motion: reduce) {
+    @slot;
+  }
+  body[data-reduce-animations="true"] & {
+    @slot;
+  }
+}
+
 @theme inline {
   --color-*: initial;
 
@@ -1527,8 +1541,12 @@ body,
  * Daintree-level "Reduce UI animations" toggle (body[data-reduce-animations])
  * both remove spatial motion while leaving opacity changes intact.
  * WCAG 2.2 SC 2.3.3: remove motion, don't just speed it up.
+ *
+ * Single source of truth via `@variant reduce-motion` — the variant emits
+ * both the OS media query and the body-attribute selector. See the
+ * `@custom-variant reduce-motion` definition near the top of this file.
  */
-@media (prefers-reduced-motion: reduce) {
+@variant reduce-motion {
   .animate-activity-pulse,
   .animate-agent-pulse,
   .animate-breathe,
@@ -1567,6 +1585,12 @@ body,
   .animate-skeleton-shimmer::after {
     display: none;
     will-change: auto;
+  }
+
+  /* Content fade-in — drop the keyframe and snap to visible. */
+  .content-fade-in {
+    animation: none;
+    opacity: 1;
   }
 
   /* Fleet polish animations — opacity-only already, but drop the keyframe
@@ -1648,6 +1672,16 @@ body,
     transition: none;
   }
 
+  /* Palette body height transition — drop the height interpolation. */
+  .palette-body-height {
+    transition: none !important;
+  }
+
+  /* Chevron rotation — drop the rotation transition. */
+  [data-animated-chevron] {
+    transition: none !important;
+  }
+
   *:focus-visible {
     transition: none !important;
   }
@@ -1683,136 +1717,6 @@ body,
   }
 }
 
-body[data-reduce-animations="true"]
-  :is(
-    .animate-activity-pulse,
-    .animate-agent-pulse,
-    .animate-breathe,
-    .animate-spin,
-    .animate-spin-slow,
-    .animate-pulse-delayed,
-    .animate-pulse-immediate,
-    .animate-skeleton-shimmer,
-    .animate-hint-fade-in,
-    .status-working,
-    .animate-badge-bump,
-    .animate-action-row-bump,
-    .animate-activity-blip,
-    .animate-trash-pulse,
-    .animate-all-clear-flash,
-    .animate-diagnostics-flash,
-    .animate-border-flash
-  ) {
-  animation: none;
-  opacity: 1;
-  transform: none;
-  will-change: auto;
-}
-
-body[data-reduce-animations="true"] .animate-skeleton-shimmer::after {
-  display: none;
-  will-change: auto;
-}
-
-body[data-reduce-animations="true"] .content-fade-in {
-  animation: none;
-  opacity: 1;
-}
-
-body[data-reduce-animations="true"] .palette-results-stale,
-body[data-reduce-animations="true"] .surface-stale {
-  opacity: 1 !important;
-  transition: none !important;
-}
-
-body[data-reduce-animations="true"] .animate-fleet-bar-refocus-pulse::before,
-body[data-reduce-animations="true"] .animate-fleet-bar-commit-flash::before {
-  animation: none;
-  will-change: auto;
-}
-
-body[data-reduce-animations="true"] .fleet-exit-pulse-overlay {
-  animation: none;
-  opacity: 0;
-  will-change: auto;
-}
-
-body[data-reduce-animations="true"] .file-change-row-new::before {
-  animation: none;
-  opacity: 0;
-  will-change: auto;
-}
-
-body[data-reduce-animations="true"] .animate-input-receipt-flash {
-  animation: none;
-  opacity: 0;
-  will-change: auto;
-}
-
-body[data-reduce-animations="true"] .animate-checklist-complete-flash {
-  animation: none;
-  opacity: 0;
-  will-change: auto;
-}
-
-body[data-reduce-animations="true"] :is(.animate-label-swap-out, .animate-label-swap-in) {
-  animation: none;
-  transform: none !important;
-  filter: none !important;
-  will-change: auto;
-}
-
-body[data-reduce-animations="true"] .animate-label-swap-out {
-  opacity: 0;
-}
-
-body[data-reduce-animations="true"] .palette-body-height {
-  transition: none !important;
-}
-
-body[data-reduce-animations="true"] *:focus-visible {
-  transition: none !important;
-}
-
-body[data-reduce-animations="true"]
-  :is(
-    .animate-activity-pulse,
-    .animate-agent-pulse,
-    .animate-breathe,
-    .status-working,
-    .panel-state-working
-  ) {
-  transition: none;
-}
-
-body[data-reduce-animations="true"]
-  :is(
-    button:not([data-state="open"]):not([data-state="closed"]),
-    [role="button"]:not([data-state="open"]):not([data-state="closed"]),
-    [type="button"]:not([data-state="open"]):not([data-state="closed"]),
-    [type="submit"]:not([data-state="open"]):not([data-state="closed"]),
-    [type="reset"]:not([data-state="open"]):not([data-state="closed"])
-  ) {
-  transform: none !important;
-  transition: none !important;
-}
-
-body[data-reduce-animations="true"] [data-animated-chevron] {
-  transition: none !important;
-}
-
-/* Radix overlay enter/exit under the app-level reduce-animations toggle.
- * Mirrors the prefers-reduced-motion block above. WCAG 2.3.3.
- */
-body[data-reduce-animations="true"] [data-state][data-side] {
-  --tw-enter-scale: 1;
-  --tw-exit-scale: 1;
-  --tw-enter-translate-x: 0;
-  --tw-enter-translate-y: 0;
-  --tw-exit-translate-x: 0;
-  --tw-exit-translate-y: 0;
-}
-
 /* Terminal restore animation. Closing is instant — no trash animation. */
 @keyframes terminal-restore {
   from {
@@ -1829,14 +1733,10 @@ body[data-reduce-animations="true"] [data-state][data-side] {
   animation: terminal-restore var(--terminal-animation-duration) ease-out;
 }
 
-@media (prefers-reduced-motion: reduce) {
+@variant reduce-motion {
   .terminal-restoring {
     animation: none;
   }
-}
-
-body[data-reduce-animations="true"] .terminal-restoring {
-  animation: none;
 }
 
 /* Diagnostics dock — 200ms height transition (semantic exception per CLAUDE.md):
@@ -1850,14 +1750,10 @@ body[data-reduce-animations="true"] .terminal-restoring {
   transition: none;
 }
 
-@media (prefers-reduced-motion: reduce) {
+@variant reduce-motion {
   .diagnostics-dock {
     transition: none;
   }
-}
-
-body[data-reduce-animations="true"] .diagnostics-dock {
-  transition: none;
 }
 
 /* Terminal Selection State */
@@ -2059,7 +1955,7 @@ body[data-reduce-animations="true"] .diagnostics-dock {
 }
 
 /* Respect reduced motion — OS + Daintree toggle */
-@media (prefers-reduced-motion: reduce) {
+@variant reduce-motion {
   .animate-terminal-ping::before,
   .animate-terminal-ping::after,
   .animate-terminal-header-ping {
@@ -2083,29 +1979,6 @@ body[data-reduce-animations="true"] .diagnostics-dock {
   .terminal-pane {
     transition: none !important;
   }
-}
-
-body[data-reduce-animations="true"] .animate-terminal-ping::before,
-body[data-reduce-animations="true"] .animate-terminal-ping::after,
-body[data-reduce-animations="true"] .animate-terminal-header-ping {
-  animation: none;
-  opacity: 0;
-  background: transparent;
-  box-shadow: none;
-}
-
-body[data-reduce-animations="true"] .animate-terminal-ping-select {
-  animation: none !important;
-  transition: none !important;
-}
-
-body[data-reduce-animations="true"] :is(.animate-eco-title, .animate-eco-title-select) {
-  animation: none;
-  text-shadow: none;
-}
-
-body[data-reduce-animations="true"] .terminal-pane {
-  transition: none !important;
 }
 
 /* GitHub Status Indicator Animations
@@ -2222,7 +2095,7 @@ body[data-reduce-animations="true"] .terminal-pane {
 }
 
 /* Respect user's motion preferences */
-@media (prefers-reduced-motion: reduce) {
+@variant reduce-motion {
   .github-status-loading::after {
     display: none;
   }
@@ -2527,13 +2400,19 @@ body[data-performance-mode="true"] .github-status-error {
   vertical-align: top;
 }
 
-/* Performance Mode Overrides - disables animations when data-performance-mode="true" */
+/* Performance Mode Overrides — narrow the transition kill-list to expensive
+ * properties only. Keeps cheap state-feedback transitions alive (color,
+ * background-color, opacity, outline-color, border-color) so hover/focus/
+ * selected cues still respond. Expensive properties — transform, width,
+ * height, box-shadow, backdrop-filter, filter — are stripped by the
+ * !important narrowing. Animations remain fully suppressed; performance
+ * mode targets resource conservation, not vestibular safety (see the
+ * `reduce-motion` variant for that). */
 body[data-performance-mode="true"] *,
 body[data-performance-mode="true"] *::before,
 body[data-performance-mode="true"] *::after {
   animation: none !important;
-  animation-play-state: paused !important;
-  transition: none !important;
+  transition-property: color, background-color, opacity, outline-color, border-color !important;
   will-change: auto !important;
 }
 
@@ -2768,7 +2647,7 @@ body[data-performance-mode="true"] [class*="backdrop-blur"] {
   z-index: 1;
 }
 
-@media (prefers-reduced-motion: reduce) {
+@variant reduce-motion {
   ::view-transition-group(*),
   ::view-transition-image-pair(*),
   ::view-transition-old(*),

--- a/src/styles/components/pulse.css
+++ b/src/styles/components/pulse.css
@@ -57,16 +57,11 @@
 }
 
 /* WCAG 2.3.3 — kill the sweep AND fall back to a flat surface so the static
- * gradient stripe doesn't remain visible. Mirrored in src/index.css for the
- * Daintree-level "Reduce UI animations" toggle. */
-@media (prefers-reduced-motion: reduce) {
+ * gradient stripe doesn't remain visible. Variant emits both the OS media
+ * query and the Daintree-level "Reduce UI animations" toggle. */
+@variant reduce-motion {
   .pulse-skeleton-shimmer {
     animation: none;
     background: var(--pulse-empty-bg, var(--theme-surface-panel));
   }
-}
-
-body[data-reduce-animations="true"] .pulse-skeleton-shimmer {
-  animation: none;
-  background: var(--pulse-empty-bg, var(--theme-surface-panel));
 }

--- a/src/styles/components/sidebar.css
+++ b/src/styles/components/sidebar.css
@@ -84,14 +84,10 @@ html[data-dragging="true"] .sidebar-worktree-card[data-hovered="true"] {
   background: var(--worktree-section-hover-bg, var(--theme-overlay-hover));
 }
 
-@media (prefers-reduced-motion: reduce) {
+@variant reduce-motion {
   .sidebar-worktree-card {
     transition: none;
   }
-}
-
-body[data-reduce-animations="true"] .sidebar-worktree-card {
-  transition: none;
 }
 
 @media (forced-colors: active) {

--- a/src/styles/components/toolbar.css
+++ b/src/styles/components/toolbar.css
@@ -356,9 +356,10 @@ html[data-shortcut-reveal] .shortcut-reveal-chip {
 
 /* ── Reduced motion ──
  * WCAG 2.3.3: remove spatial motion (scale/transform), keep opacity.
- * Dual-gate: OS-level prefers-reduced-motion + Daintree toggle.
+ * `@variant reduce-motion` emits both the OS media query and the Daintree
+ * "Reduce UI animations" toggle (`body[data-reduce-animations="true"]`).
  */
-@media (prefers-reduced-motion: reduce) {
+@variant reduce-motion {
   .shortcut-reveal-chip {
     transition: none;
   }
@@ -384,26 +385,4 @@ html[data-shortcut-reveal] .shortcut-reveal-chip {
       display 0s,
       opacity 200ms ease;
   }
-}
-
-body[data-reduce-animations="true"] .toolbar-badge {
-  transition:
-    display 0s,
-    opacity 200ms ease,
-    transform 0s;
-}
-
-body[data-reduce-animations="true"] .toolbar-badge[data-visible="true"] {
-  transform: none;
-
-  @starting-style {
-    opacity: 0;
-    transform: none;
-  }
-}
-
-body[data-reduce-animations="true"] .toolbar-badge-chip {
-  transition:
-    display 0s,
-    opacity 200ms ease;
 }


### PR DESCRIPTION
## Summary

- Performance-mode and reduced-motion served different masters but shared identical CSS rules. This splits them: `@custom-variant reduce-motion` consolidates the `@media (prefers-reduced-motion: reduce)` block and its `data-reduce-animations` mirror into a single variant definition, eliminating ~120 lines of duplication across `src/index.css`, `sidebar.css`, `pulse.css`, and `toolbar.css`.
- The performance-mode wildcard (`*, *::before, *::after { transition: none !important }`) was too aggressive -- it stripped color, opacity, and focus-ring transitions that cost effectively nothing on the GPU. The narrowed wildcard now only removes expensive composites (`backdrop-filter`, multi-layer `box-shadow`). Hover, focus, and active feedback survive under battery/thermal pressure.
- Semantic-exception durations (ActivityLight 1000ms, FileChange row 2000ms, sidebar collapse 250ms, SettingsSwitch asymmetric) are untouched.

Resolves #8241

## Changes

- `src/index.css` -- `@custom-variant reduce-motion` definition, six consolidated `@variant` blocks replacing duplicated `@media` + `[data-reduce-animations]` pairs, narrowed performance-mode wildcard
- `src/styles/components/sidebar.css`, `pulse.css`, `toolbar.css` -- reduced-motion rules replaced with `@variant reduce-motion`
- `src/components/ui/__tests__/Skeleton.test.tsx`, `ContentFadeIn.test.tsx`, `src/components/Layout/__tests__/trashToastRemoval.test.ts` -- updated to match new variant behavior

## Testing

- Unit tests updated and passing for skeleton animation, content fade-in, and trash toast removal
- Verified cheap transitions (color, opacity, focus ring) survive under `data-performance-mode="true"`
- Verified expensive composites (`backdrop-filter`, `box-shadow` stacks) are stripped under both performance-mode and reduce-motion