### PR TITLE
feat(toolbar): wire right-click 'Unpin from Toolbar' across all live toolbar buttons

### DIFF
--- a/src/components/Layout/AgentTrayButton.tsx
+++ b/src/components/Layout/AgentTrayButton.tsx
@@ -10,9 +10,15 @@ import {
   type KeyboardEvent,
   type PointerEvent as ReactPointerEvent,
 } from "react";
-import { Plug, Pin, Settings2, ChevronRight, Keyboard } from "lucide-react";
+import { Plug, Pin, Settings2, ChevronRight, Keyboard, Unplug } from "lucide-react";
 import { Button } from "@/components/ui/button";
 import { Tooltip, TooltipContent, TooltipTrigger } from "@/components/ui/tooltip";
+import {
+  ContextMenu,
+  ContextMenuContent,
+  ContextMenuItem,
+  ContextMenuTrigger,
+} from "@/components/ui/context-menu";
 import {
   DropdownMenu,
   DropdownMenuContent,
@@ -42,6 +48,7 @@ import { useCliAvailabilityStore } from "@/store/cliAvailabilityStore";
 import { useCcrPresetsStore } from "@/store/ccrPresetsStore";
 import { useProjectPresetsStore } from "@/store/projectPresetsStore";
 import { usePanelStore } from "@/store/panelStore";
+import { useToolbarPreferencesStore } from "@/store/toolbarPreferencesStore";
 import { useWorktreeSelectionStore } from "@/store/worktreeStore";
 
 import { useKeybindingDisplay } from "@/hooks";
@@ -310,6 +317,7 @@ export function AgentTrayButton({
   const projectPresetsByAgent = useProjectPresetsStore((s) => s.presetsByAgent);
   const setAgentPinned = useAgentSettingsStore((s) => s.setAgentPinned);
   const updateWorktreePreset = useAgentSettingsStore((s) => s.updateWorktreePreset);
+  const toggleButtonVisibility = useToolbarPreferencesStore((s) => s.toggleButtonVisibility);
 
   const getSortedActionMruList = useActionMruStore((s) => s.getSortedActionMruList);
 
@@ -650,31 +658,43 @@ export function AgentTrayButton({
           handleOpenChange(o);
         }}
       >
-        <Tooltip open={tooltipOpen} onOpenChange={handleTooltipOpenChange}>
-          <TooltipTrigger asChild>
-            <DropdownMenuTrigger asChild>
-              <Button
-                variant="ghost"
-                size="icon"
-                data-toolbar-item={dataToolbarItem}
-                className="toolbar-agent-button text-daintree-text"
-                aria-label={showDiscoveryBadge ? "Agent tray — new agents detected" : "Agent tray"}
-                onPointerEnter={clearFocusRestoreSuppression}
-              >
-                <span className="relative inline-flex items-center justify-center">
-                  <Plug />
-                  <span
-                    data-testid="agent-tray-discovery-badge"
-                    data-visible={showDiscoveryBadge}
-                    className="toolbar-badge absolute top-0 right-0 size-1.5 rounded-full bg-status-info ring-1 ring-daintree-sidebar"
-                    aria-hidden="true"
-                  />
-                </span>
-              </Button>
-            </DropdownMenuTrigger>
-          </TooltipTrigger>
-          <TooltipContent side="bottom">Agent Tray</TooltipContent>
-        </Tooltip>
+        <ContextMenu>
+          <ContextMenuTrigger asChild>
+            <Tooltip open={tooltipOpen} onOpenChange={handleTooltipOpenChange}>
+              <TooltipTrigger asChild>
+                <DropdownMenuTrigger asChild>
+                  <Button
+                    variant="ghost"
+                    size="icon"
+                    data-toolbar-item={dataToolbarItem}
+                    className="toolbar-agent-button text-daintree-text"
+                    aria-label={
+                      showDiscoveryBadge ? "Agent tray — new agents detected" : "Agent tray"
+                    }
+                    onPointerEnter={clearFocusRestoreSuppression}
+                  >
+                    <span className="relative inline-flex items-center justify-center">
+                      <Plug />
+                      <span
+                        data-testid="agent-tray-discovery-badge"
+                        data-visible={showDiscoveryBadge}
+                        className="toolbar-badge absolute top-0 right-0 size-1.5 rounded-full bg-status-info ring-1 ring-daintree-sidebar"
+                        aria-hidden="true"
+                      />
+                    </span>
+                  </Button>
+                </DropdownMenuTrigger>
+              </TooltipTrigger>
+              <TooltipContent side="bottom">Agent Tray</TooltipContent>
+            </Tooltip>
+          </ContextMenuTrigger>
+          <ContextMenuContent className="max-h-[var(--radix-context-menu-content-available-height)] overflow-y-auto">
+            <ContextMenuItem onSelect={() => toggleButtonVisibility("agent-tray", "left")}>
+              <Unplug className="mr-2 h-3.5 w-3.5" />
+              Unpin from Toolbar
+            </ContextMenuItem>
+          </ContextMenuContent>
+        </ContextMenu>
         <DropdownMenuContent
           align="start"
           sideOffset={4}

--- a/src/components/Layout/GitHubStatsToolbarButton.tsx
+++ b/src/components/Layout/GitHubStatsToolbarButton.tsx
@@ -11,10 +11,17 @@ import {
   memo,
   forwardRef,
 } from "react";
-import { CircleDot, GitPullRequest, GitCommit, Clock } from "lucide-react";
+import { CircleDot, GitPullRequest, GitCommit, Clock, Unplug } from "lucide-react";
 import { cn } from "@/lib/utils";
 import { Tooltip, TooltipContent, TooltipTrigger } from "@/components/ui/tooltip";
+import {
+  ContextMenu,
+  ContextMenuContent,
+  ContextMenuItem,
+  ContextMenuTrigger,
+} from "@/components/ui/context-menu";
 import { actionService } from "@/services/ActionService";
+import { useToolbarPreferencesStore } from "@/store/toolbarPreferencesStore";
 import { useWorktreeSelectionStore } from "@/store/worktreeStore";
 import { useWorktreeStore } from "@/hooks/useWorktreeStore";
 import { useGitHubFilterStore } from "@/store/githubFilterStore";
@@ -135,6 +142,8 @@ export const GitHubStatsToolbarButton = memo(
 
     const setIssueSearchQuery = useGitHubFilterStore((s) => s.setIssueSearchQuery);
     const setPrSearchQuery = useGitHubFilterStore((s) => s.setPrSearchQuery);
+
+    const toggleButtonVisibility = useToolbarPreferencesStore((s) => s.toggleButtonVisibility);
 
     const [issuesOpen, setIssuesOpen] = useState(false);
     const [prsOpen, setPrsOpen] = useState(false);
@@ -598,305 +607,323 @@ export const GitHubStatsToolbarButton = memo(
     if (!currentProject) return null;
 
     return (
-      <div
-        className="toolbar-stats app-no-drag relative mr-2 flex h-8 w-[13rem] shrink-0 items-center overflow-hidden rounded-[var(--toolbar-pill-radius,0.5rem)] border divide-x divide-[var(--toolbar-stats-divider,var(--theme-border-subtle))]"
-        style={{
-          ["--toolbar-stats-divider" as string]:
-            "var(--toolbar-stats-divider,var(--theme-border-subtle))",
-        }}
-      >
-        <GitHubStatPill
-          buttonRef={issuesButtonRef}
-          open={issuesOpen}
-          count={issueCount}
-          animKey={issueAnimKey}
-          ariaLabel={
-            isTokenError
-              ? "Configure GitHub token to see issues"
-              : `${issueCount ?? "—"} open issues${
-                  showIssuesChip ? " (new since last view)" : ""
-                }${freshnessSuffix(freshnessLevel, lastUpdated, now)}`
-          }
-          tooltipContent={
-            isTokenError
-              ? "Configure GitHub token to see issues"
-              : freshnessLevel === "fresh"
-                ? "Browse GitHub Issues"
-                : `${issueCount ?? "—"} open issues${freshnessSuffix(freshnessLevel, lastUpdated, now)}`
-          }
-          icon={CircleDot}
-          iconClassName={isTokenError ? "text-muted-foreground" : "text-github-open"}
-          openRingClassName="ring-1 ring-github-open/20"
-          className={cn(
-            isTokenError && "opacity-40",
-            !isTokenError && stats?.issueCount === 0 && "opacity-50"
-          )}
-          dropdownContent={
-            ResourceListComponent ? (
-              <ResourceListComponent
-                type="issue"
-                projectPath={currentProject.path}
-                onClose={() => {
+      <ContextMenu>
+        <ContextMenuTrigger asChild>
+          <div
+            className="toolbar-stats app-no-drag relative mr-2 flex h-8 w-[13rem] shrink-0 items-center overflow-hidden rounded-[var(--toolbar-pill-radius,0.5rem)] border divide-x divide-[var(--toolbar-stats-divider,var(--theme-border-subtle))]"
+            style={{
+              ["--toolbar-stats-divider" as string]:
+                "var(--toolbar-stats-divider,var(--theme-border-subtle))",
+            }}
+          >
+            <GitHubStatPill
+              buttonRef={issuesButtonRef}
+              open={issuesOpen}
+              count={issueCount}
+              animKey={issueAnimKey}
+              ariaLabel={
+                isTokenError
+                  ? "Configure GitHub token to see issues"
+                  : `${issueCount ?? "—"} open issues${
+                      showIssuesChip ? " (new since last view)" : ""
+                    }${freshnessSuffix(freshnessLevel, lastUpdated, now)}`
+              }
+              tooltipContent={
+                isTokenError
+                  ? "Configure GitHub token to see issues"
+                  : freshnessLevel === "fresh"
+                    ? "Browse GitHub Issues"
+                    : `${issueCount ?? "—"} open issues${freshnessSuffix(freshnessLevel, lastUpdated, now)}`
+              }
+              icon={CircleDot}
+              iconClassName={isTokenError ? "text-muted-foreground" : "text-github-open"}
+              openRingClassName="ring-1 ring-github-open/20"
+              className={cn(
+                isTokenError && "opacity-40",
+                !isTokenError && stats?.issueCount === 0 && "opacity-50"
+              )}
+              dropdownContent={
+                ResourceListComponent ? (
+                  <ResourceListComponent
+                    type="issue"
+                    projectPath={currentProject.path}
+                    onClose={() => {
+                      setIssuesOpen(false);
+                      setIssueSearchQuery("");
+                      issuesButtonRef.current?.focus();
+                    }}
+                    initialCount={stats?.issueCount}
+                    onFreshFetch={handleListFreshFetch}
+                  />
+                ) : (
+                  <Suspense
+                    fallback={
+                      <GitHubResourceListSkeleton
+                        count={stats?.issueCount}
+                        immediate
+                        type="issue"
+                      />
+                    }
+                  >
+                    <LazyGitHubResourceList
+                      type="issue"
+                      projectPath={currentProject.path}
+                      onClose={() => {
+                        setIssuesOpen(false);
+                        setIssueSearchQuery("");
+                        issuesButtonRef.current?.focus();
+                      }}
+                      initialCount={stats?.issueCount}
+                      onFreshFetch={handleListFreshFetch}
+                    />
+                  </Suspense>
+                )
+              }
+              persistThroughChildOverlays
+              keepMounted
+              onClick={() => {
+                setPrsOpen(false);
+                setPrSearchQuery("");
+                setCommitsOpen(false);
+                if (isTokenError) {
                   setIssuesOpen(false);
                   setIssueSearchQuery("");
-                  issuesButtonRef.current?.focus();
-                }}
-                initialCount={stats?.issueCount}
-                onFreshFetch={handleListFreshFetch}
-              />
-            ) : (
-              <Suspense
-                fallback={
-                  <GitHubResourceListSkeleton count={stats?.issueCount} immediate type="issue" />
+                  void actionService.dispatch(
+                    "app.settings.openTab",
+                    { tab: "github", sectionId: "github-token" },
+                    { source: "user" }
+                  );
+                  return;
                 }
-              >
-                <LazyGitHubResourceList
-                  type="issue"
-                  projectPath={currentProject.path}
-                  onClose={() => {
-                    setIssuesOpen(false);
-                    setIssueSearchQuery("");
-                    issuesButtonRef.current?.focus();
-                  }}
-                  initialCount={stats?.issueCount}
-                  onFreshFetch={handleListFreshFetch}
+                const willOpen = !issuesOpen;
+                setIssuesOpen(willOpen);
+                if (!willOpen) setIssueSearchQuery("");
+                if (willOpen) setIssuesPulseAt(null);
+                if (
+                  willOpen &&
+                  (lastUpdated == null ||
+                    Date.now() - lastUpdated > OPEN_FORCE_REFRESH_STALENESS_MS)
+                ) {
+                  refreshStats({ force: true });
+                }
+              }}
+              onOpenChange={(open) => {
+                setIssuesOpen(open);
+                if (!open) {
+                  setIssueSearchQuery("");
+                  issuesButtonRef.current?.focus();
+                }
+              }}
+              onPointerEnter={(e) => handlePrefetchPointerEnter("issue", e)}
+              onPointerLeave={(e) => handlePrefetchPointerLeave("issue", e)}
+              activityChip={
+                <span
+                  aria-hidden="true"
+                  data-visible={showIssuesChip}
+                  className="toolbar-badge-chip bg-github-open pointer-events-none absolute right-0 top-0 h-2 w-2"
+                  style={{ clipPath: "polygon(0 0, 100% 0, 100% 100%)" }}
                 />
-              </Suspense>
-            )
-          }
-          persistThroughChildOverlays
-          keepMounted
-          onClick={() => {
-            setPrsOpen(false);
-            setPrSearchQuery("");
-            setCommitsOpen(false);
-            if (isTokenError) {
-              setIssuesOpen(false);
-              setIssueSearchQuery("");
-              void actionService.dispatch(
-                "app.settings.openTab",
-                { tab: "github", sectionId: "github-token" },
-                { source: "user" }
-              );
-              return;
-            }
-            const willOpen = !issuesOpen;
-            setIssuesOpen(willOpen);
-            if (!willOpen) setIssueSearchQuery("");
-            if (willOpen) setIssuesPulseAt(null);
-            if (
-              willOpen &&
-              (lastUpdated == null || Date.now() - lastUpdated > OPEN_FORCE_REFRESH_STALENESS_MS)
-            ) {
-              refreshStats({ force: true });
-            }
-          }}
-          onOpenChange={(open) => {
-            setIssuesOpen(open);
-            if (!open) {
-              setIssueSearchQuery("");
-              issuesButtonRef.current?.focus();
-            }
-          }}
-          onPointerEnter={(e) => handlePrefetchPointerEnter("issue", e)}
-          onPointerLeave={(e) => handlePrefetchPointerLeave("issue", e)}
-          activityChip={
-            <span
-              aria-hidden="true"
-              data-visible={showIssuesChip}
-              className="toolbar-badge-chip bg-github-open pointer-events-none absolute right-0 top-0 h-2 w-2"
-              style={{ clipPath: "polygon(0 0, 100% 0, 100% 100%)" }}
+              }
+              freshnessGlyph={!isTokenError ? <FreshnessGlyph level={freshnessLevel} /> : null}
             />
-          }
-          freshnessGlyph={!isTokenError ? <FreshnessGlyph level={freshnessLevel} /> : null}
-        />
-        <GitHubStatPill
-          buttonRef={prsButtonRef}
-          open={prsOpen}
-          count={prCount}
-          animKey={prAnimKey}
-          ariaLabel={
-            isTokenError
-              ? "Configure GitHub token to see pull requests"
-              : `${prCount ?? "—"} open pull requests${
-                  showPrsChip ? " (new since last view)" : ""
-                }${freshnessSuffix(freshnessLevel, lastUpdated, now)}`
-          }
-          tooltipContent={
-            isTokenError
-              ? "Configure GitHub token to see pull requests"
-              : freshnessLevel === "fresh"
-                ? "Browse GitHub Pull Requests"
-                : `${prCount ?? "—"} open PRs${freshnessSuffix(freshnessLevel, lastUpdated, now)}`
-          }
-          icon={GitPullRequest}
-          iconClassName={isTokenError ? "text-muted-foreground" : "text-github-merged"}
-          openRingClassName="ring-1 ring-github-merged/20"
-          className={cn(
-            isTokenError && "opacity-40",
-            !isTokenError && stats?.prCount === 0 && "opacity-50"
-          )}
-          dropdownContent={
-            ResourceListComponent ? (
-              <ResourceListComponent
-                type="pr"
-                projectPath={currentProject.path}
-                onClose={() => {
+            <GitHubStatPill
+              buttonRef={prsButtonRef}
+              open={prsOpen}
+              count={prCount}
+              animKey={prAnimKey}
+              ariaLabel={
+                isTokenError
+                  ? "Configure GitHub token to see pull requests"
+                  : `${prCount ?? "—"} open pull requests${
+                      showPrsChip ? " (new since last view)" : ""
+                    }${freshnessSuffix(freshnessLevel, lastUpdated, now)}`
+              }
+              tooltipContent={
+                isTokenError
+                  ? "Configure GitHub token to see pull requests"
+                  : freshnessLevel === "fresh"
+                    ? "Browse GitHub Pull Requests"
+                    : `${prCount ?? "—"} open PRs${freshnessSuffix(freshnessLevel, lastUpdated, now)}`
+              }
+              icon={GitPullRequest}
+              iconClassName={isTokenError ? "text-muted-foreground" : "text-github-merged"}
+              openRingClassName="ring-1 ring-github-merged/20"
+              className={cn(
+                isTokenError && "opacity-40",
+                !isTokenError && stats?.prCount === 0 && "opacity-50"
+              )}
+              dropdownContent={
+                ResourceListComponent ? (
+                  <ResourceListComponent
+                    type="pr"
+                    projectPath={currentProject.path}
+                    onClose={() => {
+                      setPrsOpen(false);
+                      setPrSearchQuery("");
+                      prsButtonRef.current?.focus();
+                    }}
+                    initialCount={stats?.prCount}
+                    onFreshFetch={handleListFreshFetch}
+                  />
+                ) : (
+                  <Suspense
+                    fallback={
+                      <GitHubResourceListSkeleton count={stats?.prCount} immediate type="pr" />
+                    }
+                  >
+                    <LazyGitHubResourceList
+                      type="pr"
+                      projectPath={currentProject.path}
+                      onClose={() => {
+                        setPrsOpen(false);
+                        setPrSearchQuery("");
+                        prsButtonRef.current?.focus();
+                      }}
+                      initialCount={stats?.prCount}
+                      onFreshFetch={handleListFreshFetch}
+                    />
+                  </Suspense>
+                )
+              }
+              keepMounted
+              onClick={() => {
+                setIssuesOpen(false);
+                setIssueSearchQuery("");
+                setCommitsOpen(false);
+                if (isTokenError) {
                   setPrsOpen(false);
                   setPrSearchQuery("");
-                  prsButtonRef.current?.focus();
-                }}
-                initialCount={stats?.prCount}
-                onFreshFetch={handleListFreshFetch}
-              />
-            ) : (
-              <Suspense
-                fallback={<GitHubResourceListSkeleton count={stats?.prCount} immediate type="pr" />}
-              >
-                <LazyGitHubResourceList
-                  type="pr"
-                  projectPath={currentProject.path}
-                  onClose={() => {
-                    setPrsOpen(false);
-                    setPrSearchQuery("");
-                    prsButtonRef.current?.focus();
-                  }}
-                  initialCount={stats?.prCount}
-                  onFreshFetch={handleListFreshFetch}
-                />
-              </Suspense>
-            )
-          }
-          keepMounted
-          onClick={() => {
-            setIssuesOpen(false);
-            setIssueSearchQuery("");
-            setCommitsOpen(false);
-            if (isTokenError) {
-              setPrsOpen(false);
-              setPrSearchQuery("");
-              void actionService.dispatch(
-                "app.settings.openTab",
-                { tab: "github", sectionId: "github-token" },
-                { source: "user" }
-              );
-              return;
-            }
-            const willOpen = !prsOpen;
-            setPrsOpen(willOpen);
-            if (!willOpen) setPrSearchQuery("");
-            if (willOpen) setPrsPulseAt(null);
-            if (
-              willOpen &&
-              (lastUpdated == null || Date.now() - lastUpdated > OPEN_FORCE_REFRESH_STALENESS_MS)
-            ) {
-              refreshStats({ force: true });
-            }
-          }}
-          onOpenChange={(open) => {
-            setPrsOpen(open);
-            if (!open) {
-              setPrSearchQuery("");
-              prsButtonRef.current?.focus();
-            }
-          }}
-          onPointerEnter={(e) => handlePrefetchPointerEnter("pr", e)}
-          onPointerLeave={(e) => handlePrefetchPointerLeave("pr", e)}
-          activityChip={
-            <span
-              aria-hidden="true"
-              data-visible={showPrsChip}
-              className="toolbar-badge-chip bg-github-merged pointer-events-none absolute right-0 top-0 h-2 w-2"
-              style={{ clipPath: "polygon(0 0, 100% 0, 100% 100%)" }}
-            />
-          }
-          freshnessGlyph={!isTokenError ? <FreshnessGlyph level={freshnessLevel} /> : null}
-        />
-        <GitHubStatPill
-          buttonRef={commitsButtonRef}
-          open={commitsOpen}
-          count={commitCount}
-          animKey={commitAnimKey}
-          ariaLabel={`${commitCount ?? "—"} commits${freshnessSuffix(commitFreshnessLevel, lastUpdated, now)}`}
-          tooltipContent={
-            commitFreshnessLevel === "fresh"
-              ? "Browse Git Commits"
-              : `${commitCount ?? "—"} commits${freshnessSuffix(commitFreshnessLevel, lastUpdated, now)}`
-          }
-          icon={GitCommit}
-          openRingClassName="ring-1 ring-border-strong"
-          className={cn(stats?.commitCount === 0 && "opacity-50")}
-          dropdownContent={
-            CommitListComponent ? (
-              <CommitListComponent
-                projectPath={activeWorktree?.path ?? currentProject.path}
-                branch={activeWorktree?.branch}
-                onClose={() => {
-                  setCommitsOpen(false);
-                  commitsButtonRef.current?.focus();
-                }}
-                initialCount={stats?.commitCount}
-              />
-            ) : (
-              <Suspense fallback={<CommitListSkeleton count={stats?.commitCount} immediate />}>
-                <LazyCommitList
-                  projectPath={activeWorktree?.path ?? currentProject.path}
-                  branch={activeWorktree?.branch}
-                  onClose={() => {
-                    setCommitsOpen(false);
-                    commitsButtonRef.current?.focus();
-                  }}
-                  initialCount={stats?.commitCount}
-                />
-              </Suspense>
-            )
-          }
-          onClick={() => {
-            setIssuesOpen(false);
-            setIssueSearchQuery("");
-            setPrsOpen(false);
-            setPrSearchQuery("");
-            setCommitsOpen((p) => !p);
-          }}
-          onOpenChange={(open) => {
-            setCommitsOpen(open);
-            if (!open) commitsButtonRef.current?.focus();
-          }}
-          freshnessGlyph={<FreshnessGlyph level={commitFreshnessLevel} />}
-        />
-        <GitHubStatusIndicator
-          status={getGitHubIndicatorStatus()}
-          error={statsError ?? undefined}
-          onTransitionEnd={handleGitHubStatusTransitionEnd}
-        />
-        {rateLimitActive && rateLimitLabel ? (
-          <Tooltip open={rateLimitTooltipOpen} onOpenChange={setRateLimitTooltipOpen}>
-            <TooltipTrigger asChild>
-              <div
-                role="status"
-                aria-live="polite"
-                aria-label={
-                  rateLimitKind === "secondary"
-                    ? `GitHub secondary rate limit — resuming in ${rateLimitCountdown}`
-                    : `GitHub rate limit — resets in ${rateLimitCountdown}`
+                  void actionService.dispatch(
+                    "app.settings.openTab",
+                    { tab: "github", sectionId: "github-token" },
+                    { source: "user" }
+                  );
+                  return;
                 }
-                className="flex h-full items-center gap-1.5 px-2.5 text-[10px] font-medium text-muted-foreground"
-              >
-                <Clock className="h-3 w-3 opacity-70" aria-hidden />
-                <span className="tabular-nums">{rateLimitLabel}</span>
-              </div>
-            </TooltipTrigger>
-            <TooltipContent side="bottom" className="px-0 py-0">
-              <RateLimitDetailsPanel
-                kind={rateLimitKind}
-                details={rateLimitDetails}
-                now={rateLimitNow}
-                fallbackResetAt={rateLimitResetAt}
-              />
-            </TooltipContent>
-          </Tooltip>
-        ) : null}
-      </div>
+                const willOpen = !prsOpen;
+                setPrsOpen(willOpen);
+                if (!willOpen) setPrSearchQuery("");
+                if (willOpen) setPrsPulseAt(null);
+                if (
+                  willOpen &&
+                  (lastUpdated == null ||
+                    Date.now() - lastUpdated > OPEN_FORCE_REFRESH_STALENESS_MS)
+                ) {
+                  refreshStats({ force: true });
+                }
+              }}
+              onOpenChange={(open) => {
+                setPrsOpen(open);
+                if (!open) {
+                  setPrSearchQuery("");
+                  prsButtonRef.current?.focus();
+                }
+              }}
+              onPointerEnter={(e) => handlePrefetchPointerEnter("pr", e)}
+              onPointerLeave={(e) => handlePrefetchPointerLeave("pr", e)}
+              activityChip={
+                <span
+                  aria-hidden="true"
+                  data-visible={showPrsChip}
+                  className="toolbar-badge-chip bg-github-merged pointer-events-none absolute right-0 top-0 h-2 w-2"
+                  style={{ clipPath: "polygon(0 0, 100% 0, 100% 100%)" }}
+                />
+              }
+              freshnessGlyph={!isTokenError ? <FreshnessGlyph level={freshnessLevel} /> : null}
+            />
+            <GitHubStatPill
+              buttonRef={commitsButtonRef}
+              open={commitsOpen}
+              count={commitCount}
+              animKey={commitAnimKey}
+              ariaLabel={`${commitCount ?? "—"} commits${freshnessSuffix(commitFreshnessLevel, lastUpdated, now)}`}
+              tooltipContent={
+                commitFreshnessLevel === "fresh"
+                  ? "Browse Git Commits"
+                  : `${commitCount ?? "—"} commits${freshnessSuffix(commitFreshnessLevel, lastUpdated, now)}`
+              }
+              icon={GitCommit}
+              openRingClassName="ring-1 ring-border-strong"
+              className={cn(stats?.commitCount === 0 && "opacity-50")}
+              dropdownContent={
+                CommitListComponent ? (
+                  <CommitListComponent
+                    projectPath={activeWorktree?.path ?? currentProject.path}
+                    branch={activeWorktree?.branch}
+                    onClose={() => {
+                      setCommitsOpen(false);
+                      commitsButtonRef.current?.focus();
+                    }}
+                    initialCount={stats?.commitCount}
+                  />
+                ) : (
+                  <Suspense fallback={<CommitListSkeleton count={stats?.commitCount} immediate />}>
+                    <LazyCommitList
+                      projectPath={activeWorktree?.path ?? currentProject.path}
+                      branch={activeWorktree?.branch}
+                      onClose={() => {
+                        setCommitsOpen(false);
+                        commitsButtonRef.current?.focus();
+                      }}
+                      initialCount={stats?.commitCount}
+                    />
+                  </Suspense>
+                )
+              }
+              onClick={() => {
+                setIssuesOpen(false);
+                setIssueSearchQuery("");
+                setPrsOpen(false);
+                setPrSearchQuery("");
+                setCommitsOpen((p) => !p);
+              }}
+              onOpenChange={(open) => {
+                setCommitsOpen(open);
+                if (!open) commitsButtonRef.current?.focus();
+              }}
+              freshnessGlyph={<FreshnessGlyph level={commitFreshnessLevel} />}
+            />
+            <GitHubStatusIndicator
+              status={getGitHubIndicatorStatus()}
+              error={statsError ?? undefined}
+              onTransitionEnd={handleGitHubStatusTransitionEnd}
+            />
+            {rateLimitActive && rateLimitLabel ? (
+              <Tooltip open={rateLimitTooltipOpen} onOpenChange={setRateLimitTooltipOpen}>
+                <TooltipTrigger asChild>
+                  <div
+                    role="status"
+                    aria-live="polite"
+                    aria-label={
+                      rateLimitKind === "secondary"
+                        ? `GitHub secondary rate limit — resuming in ${rateLimitCountdown}`
+                        : `GitHub rate limit — resets in ${rateLimitCountdown}`
+                    }
+                    className="flex h-full items-center gap-1.5 px-2.5 text-[10px] font-medium text-muted-foreground"
+                  >
+                    <Clock className="h-3 w-3 opacity-70" aria-hidden />
+                    <span className="tabular-nums">{rateLimitLabel}</span>
+                  </div>
+                </TooltipTrigger>
+                <TooltipContent side="bottom" className="px-0 py-0">
+                  <RateLimitDetailsPanel
+                    kind={rateLimitKind}
+                    details={rateLimitDetails}
+                    now={rateLimitNow}
+                    fallbackResetAt={rateLimitResetAt}
+                  />
+                </TooltipContent>
+              </Tooltip>
+            ) : null}
+          </div>
+        </ContextMenuTrigger>
+        <ContextMenuContent className="max-h-[var(--radix-context-menu-content-available-height)] overflow-y-auto">
+          <ContextMenuItem onSelect={() => toggleButtonVisibility("github-stats", "right")}>
+            <Unplug className="mr-2 h-3.5 w-3.5" />
+            Unpin from Toolbar
+          </ContextMenuItem>
+        </ContextMenuContent>
+      </ContextMenu>
     );
   })
 );

--- a/src/components/Layout/NotificationCenterToolbarButton.tsx
+++ b/src/components/Layout/NotificationCenterToolbarButton.tsx
@@ -1,11 +1,18 @@
 import { useRef, useEffect, useState, useCallback } from "react";
 import { Button } from "@/components/ui/button";
 import { FixedDropdown } from "@/components/ui/fixed-dropdown";
-import { Bell, BellOff } from "lucide-react";
+import { Bell, BellOff, Unplug } from "lucide-react";
 import { Tooltip, TooltipContent, TooltipTrigger } from "@/components/ui/tooltip";
+import {
+  ContextMenu,
+  ContextMenuContent,
+  ContextMenuItem,
+  ContextMenuTrigger,
+} from "@/components/ui/context-menu";
 import { NotificationCenter } from "@/components/Notifications/NotificationCenter";
 import { useNotificationHistoryStore } from "@/store/slices/notificationHistorySlice";
 import { useNotificationSettingsStore } from "@/store/notificationSettingsStore";
+import { useToolbarPreferencesStore } from "@/store/toolbarPreferencesStore";
 import { useUIStore } from "@/store/uiStore";
 import { useShallow } from "zustand/react/shallow";
 import { isScheduledQuietNow } from "@shared/utils/quietHours";
@@ -33,6 +40,7 @@ export function NotificationCenterToolbarButton({
   const notificationCenterButtonRef = useRef<HTMLButtonElement>(null);
   const notificationUnreadCount = useNotificationHistoryStore((s) => s.unreadCount);
   const evictedToInboxCount = useNotificationHistoryStore((s) => s.evictedToInboxCount);
+  const toggleButtonVisibility = useToolbarPreferencesStore((s) => s.toggleButtonVisibility);
   const {
     enabled: notificationsEnabled,
     quietUntil,
@@ -209,37 +217,47 @@ export function NotificationCenterToolbarButton({
 
   return (
     <div className="relative">
-      <Tooltip>
-        <TooltipTrigger asChild>
-          <Button
-            ref={notificationCenterButtonRef}
-            variant="ghost"
-            size="icon"
-            data-toolbar-item={dataToolbarItem}
-            data-dnd-active={isDndActive ? "true" : undefined}
-            onClick={toggleNotificationCenter}
-            className={toolbarIconButtonClass}
-            aria-label={label}
-            aria-expanded={notificationCenterOpen}
-            aria-haspopup="dialog"
-          >
-            <span
-              data-testid="notification-bell-icon"
-              className={isBellBlipping ? "inline-flex animate-activity-blip" : "inline-flex"}
-              onAnimationEnd={handleBellAnimationEnd}
-            >
-              <Icon />
-            </span>
-            <span
-              data-testid="notification-unread-dot"
-              data-visible={notificationUnreadCount > 0}
-              data-dnd-active={isDndActive ? "true" : undefined}
-              className="toolbar-badge absolute top-1.5 right-1.5 w-1.5 h-1.5 rounded-full bg-daintree-text/50 ring-1 ring-daintree-bg/60"
-            />
-          </Button>
-        </TooltipTrigger>
-        <TooltipContent side="bottom">{label}</TooltipContent>
-      </Tooltip>
+      <ContextMenu>
+        <ContextMenuTrigger asChild>
+          <Tooltip>
+            <TooltipTrigger asChild>
+              <Button
+                ref={notificationCenterButtonRef}
+                variant="ghost"
+                size="icon"
+                data-toolbar-item={dataToolbarItem}
+                data-dnd-active={isDndActive ? "true" : undefined}
+                onClick={toggleNotificationCenter}
+                className={toolbarIconButtonClass}
+                aria-label={label}
+                aria-expanded={notificationCenterOpen}
+                aria-haspopup="dialog"
+              >
+                <span
+                  data-testid="notification-bell-icon"
+                  className={isBellBlipping ? "inline-flex animate-activity-blip" : "inline-flex"}
+                  onAnimationEnd={handleBellAnimationEnd}
+                >
+                  <Icon />
+                </span>
+                <span
+                  data-testid="notification-unread-dot"
+                  data-visible={notificationUnreadCount > 0}
+                  data-dnd-active={isDndActive ? "true" : undefined}
+                  className="toolbar-badge absolute top-1.5 right-1.5 w-1.5 h-1.5 rounded-full bg-daintree-text/50 ring-1 ring-daintree-bg/60"
+                />
+              </Button>
+            </TooltipTrigger>
+            <TooltipContent side="bottom">{label}</TooltipContent>
+          </Tooltip>
+        </ContextMenuTrigger>
+        <ContextMenuContent className="max-h-[var(--radix-context-menu-content-available-height)] overflow-y-auto">
+          <ContextMenuItem onSelect={() => toggleButtonVisibility("notification-center", "right")}>
+            <Unplug className="mr-2 h-3.5 w-3.5" />
+            Unpin from Toolbar
+          </ContextMenuItem>
+        </ContextMenuContent>
+      </ContextMenu>
       <FixedDropdown
         open={notificationCenterOpen}
         onOpenChange={(open) => {

--- a/src/components/Layout/Toolbar.tsx
+++ b/src/components/Layout/Toolbar.tsx
@@ -61,7 +61,11 @@ import { useProjectStore } from "@/store/projectStore";
 import { usePreferencesStore, useToolbarPreferencesStore, useVoiceRecordingStore } from "@/store";
 import { useAgentSettingsStore } from "@/store/agentSettingsStore";
 import { useNotificationSettingsStore } from "@/store/notificationSettingsStore";
-import type { ToolbarButtonId, AnyToolbarButtonId } from "@/../../shared/types/toolbar";
+import type {
+  ToolbarButtonId,
+  AnyToolbarButtonId,
+  PluginToolbarButtonId,
+} from "@/../../shared/types/toolbar";
 import { usePluginToolbarButtons } from "@/hooks/usePluginToolbarButtons";
 import { useWorktreeSelectionStore } from "@/store/worktreeStore";
 import { useWorktreeStore } from "@/hooks/useWorktreeStore";
@@ -133,7 +137,7 @@ export function PluginToolbarButton({
   config,
   "data-toolbar-item": dataToolbarItem,
 }: {
-  pluginId: string;
+  pluginId: PluginToolbarButtonId;
   config: NonNullable<ReturnType<ReturnType<typeof usePluginToolbarButtons>["configs"]["get"]>>;
   "data-toolbar-item"?: string;
 }) {
@@ -167,9 +171,7 @@ export function PluginToolbarButton({
         </Tooltip>
       </ContextMenuTrigger>
       <ContextMenuContent className="max-h-[var(--radix-context-menu-content-available-height)] overflow-y-auto">
-        <ContextMenuItem
-          onSelect={() => toggleButtonVisibility(pluginId as AnyToolbarButtonId, "right")}
-        >
+        <ContextMenuItem onSelect={() => toggleButtonVisibility(pluginId, "right")}>
           <Unplug className="mr-2 h-3.5 w-3.5" />
           Unpin from Toolbar
         </ContextMenuItem>

--- a/src/components/Layout/Toolbar.tsx
+++ b/src/components/Layout/Toolbar.tsx
@@ -16,6 +16,7 @@ import {
   PinOff,
   Clipboard,
   Square,
+  Unplug,
   X,
 } from "lucide-react";
 import { Spinner } from "@/components/ui/Spinner";
@@ -137,30 +138,43 @@ export function PluginToolbarButton({
   "data-toolbar-item"?: string;
 }) {
   const hover = useShortcutHintHover(config.actionId as string);
+  const toggleButtonVisibility = useToolbarPreferencesStore((s) => s.toggleButtonVisibility);
 
   return (
-    <Tooltip>
-      <TooltipTrigger asChild>
-        <Button
-          {...hover}
-          variant="ghost"
-          size="icon"
-          data-toolbar-item={dataToolbarItem}
-          onClick={() => {
-            void actionService.dispatch(
-              config.actionId as Parameters<typeof actionService.dispatch>[0],
-              undefined,
-              { source: "user" }
-            );
-          }}
-          className={toolbarIconButtonClass}
-          aria-label={config?.label ?? pluginId}
+    <ContextMenu>
+      <ContextMenuTrigger asChild>
+        <Tooltip>
+          <TooltipTrigger asChild>
+            <Button
+              {...hover}
+              variant="ghost"
+              size="icon"
+              data-toolbar-item={dataToolbarItem}
+              onClick={() => {
+                void actionService.dispatch(
+                  config.actionId as Parameters<typeof actionService.dispatch>[0],
+                  undefined,
+                  { source: "user" }
+                );
+              }}
+              className={toolbarIconButtonClass}
+              aria-label={config?.label ?? pluginId}
+            >
+              <McpServerIcon />
+            </Button>
+          </TooltipTrigger>
+          <TooltipContent side="bottom">{config?.label ?? pluginId}</TooltipContent>
+        </Tooltip>
+      </ContextMenuTrigger>
+      <ContextMenuContent className="max-h-[var(--radix-context-menu-content-available-height)] overflow-y-auto">
+        <ContextMenuItem
+          onSelect={() => toggleButtonVisibility(pluginId as AnyToolbarButtonId, "right")}
         >
-          <McpServerIcon />
-        </Button>
-      </TooltipTrigger>
-      <TooltipContent side="bottom">{config?.label ?? pluginId}</TooltipContent>
-    </Tooltip>
+          <Unplug className="mr-2 h-3.5 w-3.5" />
+          Unpin from Toolbar
+        </ContextMenuItem>
+      </ContextMenuContent>
+    </ContextMenu>
   );
 }
 
@@ -224,6 +238,9 @@ export function Toolbar({
   const showDeveloperTools = usePreferencesStore((state) => state.showDeveloperTools);
   const notificationsEnabled = useNotificationSettingsStore((s) => s.enabled);
   const toolbarLayout = useToolbarPreferencesStore((state) => state.layout);
+  const toggleButtonVisibility = useToolbarPreferencesStore(
+    (state) => state.toggleButtonVisibility
+  );
   // Live subscription so pin/unpin toggles from the AgentTrayButton immediately
   // update per-agent toolbar button visibility. The `agentSettings` prop is
   // sourced from `useAgentLauncher()`'s local useState which does not react to
@@ -554,26 +571,36 @@ export function Toolbar({
       "dev-server": {
         render: () =>
           currentProject ? (
-            <Tooltip>
-              <TooltipTrigger asChild>
-                <Button
-                  {...devServerHintHover}
-                  variant="ghost"
-                  size="icon"
-                  data-toolbar-item=""
-                  onClick={() =>
-                    actionService.dispatch("devServer.start", undefined, { source: "user" })
-                  }
-                  className={toolbarIconButtonClass}
-                  aria-label="Open Dev Preview"
-                >
-                  <MonitorPlay />
-                </Button>
-              </TooltipTrigger>
-              <TooltipContent side="bottom">
-                {createTooltipContent("Open Dev Preview", devServerShortcut)}
-              </TooltipContent>
-            </Tooltip>
+            <ContextMenu>
+              <ContextMenuTrigger asChild>
+                <Tooltip>
+                  <TooltipTrigger asChild>
+                    <Button
+                      {...devServerHintHover}
+                      variant="ghost"
+                      size="icon"
+                      data-toolbar-item=""
+                      onClick={() =>
+                        actionService.dispatch("devServer.start", undefined, { source: "user" })
+                      }
+                      className={toolbarIconButtonClass}
+                      aria-label="Open Dev Preview"
+                    >
+                      <MonitorPlay />
+                    </Button>
+                  </TooltipTrigger>
+                  <TooltipContent side="bottom">
+                    {createTooltipContent("Open Dev Preview", devServerShortcut)}
+                  </TooltipContent>
+                </Tooltip>
+              </ContextMenuTrigger>
+              <ContextMenuContent className="max-h-[var(--radix-context-menu-content-available-height)] overflow-y-auto">
+                <ContextMenuItem onSelect={() => toggleButtonVisibility("dev-server", "left")}>
+                  <Unplug className="mr-2 h-3.5 w-3.5" />
+                  Unpin from Toolbar
+                </ContextMenuItem>
+              </ContextMenuContent>
+            </ContextMenu>
           ) : (
             <DevServerPlaceholder />
           ),
@@ -608,46 +635,58 @@ export function Toolbar({
       },
       "copy-tree": {
         render: () => (
-          <Tooltip open={treeCopied || undefined}>
-            <TooltipTrigger asChild>
-              <Button
-                {...copyTreeHintHover}
-                variant="ghost"
-                size="icon"
-                data-toolbar-item=""
-                onClick={handleCopyTreeClick}
-                aria-disabled={isCopyingTree || !activeWorktree || undefined}
-                className={cn(
-                  "toolbar-icon-button relative",
-                  treeCopied ? "text-status-success bg-status-success/10" : "text-daintree-text",
-                  isCopyingTree && "cursor-wait opacity-70",
-                  "aria-disabled:opacity-50 aria-disabled:cursor-not-allowed"
-                )}
-                aria-label={
-                  isCopyingTree ? "Copying…" : treeCopied ? "Context copied" : "Copy Context"
-                }
-                aria-keyshortcuts={copyTreeAriaShortcut}
-              >
-                {showCopyingSpinner ? <Spinner /> : treeCopied ? <Check /> : <Folders />}
-                {!treeCopied && !isCopyingTree && (
-                  <ShortcutRevealChip actionId="worktree.copyTree" />
-                )}
-              </Button>
-            </TooltipTrigger>
-            <TooltipContent side="bottom" className="font-medium">
-              {isCopyingTree ? (
-                "Copying…"
-              ) : treeCopied ? (
-                <span role="status" aria-live="polite">
-                  {copyFeedback}
-                </span>
-              ) : !activeWorktree ? (
-                "Open a worktree first"
-              ) : (
-                createTooltipContent("Copy Context", copyTreeShortcut)
-              )}
-            </TooltipContent>
-          </Tooltip>
+          <ContextMenu>
+            <ContextMenuTrigger asChild>
+              <Tooltip open={treeCopied || undefined}>
+                <TooltipTrigger asChild>
+                  <Button
+                    {...copyTreeHintHover}
+                    variant="ghost"
+                    size="icon"
+                    data-toolbar-item=""
+                    onClick={handleCopyTreeClick}
+                    aria-disabled={isCopyingTree || !activeWorktree || undefined}
+                    className={cn(
+                      "toolbar-icon-button relative",
+                      treeCopied
+                        ? "text-status-success bg-status-success/10"
+                        : "text-daintree-text",
+                      isCopyingTree && "cursor-wait opacity-70",
+                      "aria-disabled:opacity-50 aria-disabled:cursor-not-allowed"
+                    )}
+                    aria-label={
+                      isCopyingTree ? "Copying…" : treeCopied ? "Context copied" : "Copy Context"
+                    }
+                    aria-keyshortcuts={copyTreeAriaShortcut}
+                  >
+                    {showCopyingSpinner ? <Spinner /> : treeCopied ? <Check /> : <Folders />}
+                    {!treeCopied && !isCopyingTree && (
+                      <ShortcutRevealChip actionId="worktree.copyTree" />
+                    )}
+                  </Button>
+                </TooltipTrigger>
+                <TooltipContent side="bottom" className="font-medium">
+                  {isCopyingTree ? (
+                    "Copying…"
+                  ) : treeCopied ? (
+                    <span role="status" aria-live="polite">
+                      {copyFeedback}
+                    </span>
+                  ) : !activeWorktree ? (
+                    "Open a worktree first"
+                  ) : (
+                    createTooltipContent("Copy Context", copyTreeShortcut)
+                  )}
+                </TooltipContent>
+              </Tooltip>
+            </ContextMenuTrigger>
+            <ContextMenuContent className="max-h-[var(--radix-context-menu-content-available-height)] overflow-y-auto">
+              <ContextMenuItem onSelect={() => toggleButtonVisibility("copy-tree", "right")}>
+                <Unplug className="mr-2 h-3.5 w-3.5" />
+                Unpin from Toolbar
+              </ContextMenuItem>
+            </ContextMenuContent>
+          </ContextMenu>
         ),
         isAvailable: true,
       },

--- a/src/components/Layout/Toolbar.tsx
+++ b/src/components/Layout/Toolbar.tsx
@@ -764,6 +764,7 @@ export function Toolbar({
       pluginConfigs,
       devServerShortcut,
       devServerHintHover,
+      toggleButtonVisibility,
     ]
   );
 

--- a/src/components/Layout/ToolbarLauncherButton.tsx
+++ b/src/components/Layout/ToolbarLauncherButton.tsx
@@ -1,10 +1,17 @@
 import { useCallback } from "react";
 import { Button } from "@/components/ui/button";
-import { SquareTerminal, Globe } from "lucide-react";
+import { SquareTerminal, Globe, Unplug } from "lucide-react";
 import { Tooltip, TooltipContent, TooltipTrigger } from "@/components/ui/tooltip";
 import { ShortcutRevealChip } from "@/components/ui/ShortcutRevealChip";
+import {
+  ContextMenu,
+  ContextMenuContent,
+  ContextMenuItem,
+  ContextMenuTrigger,
+} from "@/components/ui/context-menu";
 import { createTooltipContent } from "@/lib/tooltipShortcut";
 import { useAriaKeyshortcuts, useKeybindingDisplay, useShortcutHintHover } from "@/hooks";
+import { useToolbarPreferencesStore } from "@/store/toolbarPreferencesStore";
 
 type LauncherType = "terminal" | "browser";
 
@@ -48,6 +55,7 @@ export function ToolbarLauncherButton({
   const shortcut = useKeybindingDisplay(config.keybindingAction);
   const ariaShortcut = useAriaKeyshortcuts(config.keybindingAction);
   const launcherHover = useShortcutHintHover(config.keybindingAction);
+  const toggleButtonVisibility = useToolbarPreferencesStore((s) => s.toggleButtonVisibility);
 
   const handleClick = useCallback(() => {
     onLaunchAgent(type);
@@ -56,25 +64,35 @@ export function ToolbarLauncherButton({
   const Icon = config.icon;
 
   return (
-    <Tooltip>
-      <TooltipTrigger asChild>
-        <Button
-          {...launcherHover}
-          variant="ghost"
-          size="icon"
-          data-toolbar-item={dataToolbarItem}
-          onClick={handleClick}
-          className={toolbarIconButtonClass}
-          aria-label={config.label}
-          aria-keyshortcuts={ariaShortcut}
-        >
-          <Icon />
-          <ShortcutRevealChip actionId={config.keybindingAction} />
-        </Button>
-      </TooltipTrigger>
-      <TooltipContent side="bottom">
-        {createTooltipContent(config.tooltipLabel, shortcut)}
-      </TooltipContent>
-    </Tooltip>
+    <ContextMenu>
+      <ContextMenuTrigger asChild>
+        <Tooltip>
+          <TooltipTrigger asChild>
+            <Button
+              {...launcherHover}
+              variant="ghost"
+              size="icon"
+              data-toolbar-item={dataToolbarItem}
+              onClick={handleClick}
+              className={toolbarIconButtonClass}
+              aria-label={config.label}
+              aria-keyshortcuts={ariaShortcut}
+            >
+              <Icon />
+              <ShortcutRevealChip actionId={config.keybindingAction} />
+            </Button>
+          </TooltipTrigger>
+          <TooltipContent side="bottom">
+            {createTooltipContent(config.tooltipLabel, shortcut)}
+          </TooltipContent>
+        </Tooltip>
+      </ContextMenuTrigger>
+      <ContextMenuContent className="max-h-[var(--radix-context-menu-content-available-height)] overflow-y-auto">
+        <ContextMenuItem onSelect={() => toggleButtonVisibility(type, "left")}>
+          <Unplug className="mr-2 h-3.5 w-3.5" />
+          Unpin from Toolbar
+        </ContextMenuItem>
+      </ContextMenuContent>
+    </ContextMenu>
   );
 }

--- a/src/components/Layout/ToolbarProblemsButton.tsx
+++ b/src/components/Layout/ToolbarProblemsButton.tsx
@@ -1,11 +1,18 @@
 import { Button } from "@/components/ui/button";
-import { AlertCircle } from "lucide-react";
+import { AlertCircle, Unplug } from "lucide-react";
 import { cn } from "@/lib/utils";
 import { Tooltip, TooltipContent, TooltipTrigger } from "@/components/ui/tooltip";
 import { ShortcutRevealChip } from "@/components/ui/ShortcutRevealChip";
+import {
+  ContextMenu,
+  ContextMenuContent,
+  ContextMenuItem,
+  ContextMenuTrigger,
+} from "@/components/ui/context-menu";
 import { createTooltipContent } from "@/lib/tooltipShortcut";
 import { useAriaKeyshortcuts, useKeybindingDisplay, useShortcutHintHover } from "@/hooks";
 import { useDiagnosticsStore } from "@/store/diagnosticsStore";
+import { useToolbarPreferencesStore } from "@/store/toolbarPreferencesStore";
 import { DIAGNOSTICS_DOCK_REGION_ID } from "@/components/Diagnostics/DiagnosticsDock";
 
 const toolbarIconButtonClass = "toolbar-icon-button text-daintree-text";
@@ -25,33 +32,44 @@ export function ToolbarProblemsButton({
   const diagnosticsAriaShortcut = useAriaKeyshortcuts("panel.toggleDiagnostics");
   const diagnosticsHover = useShortcutHintHover("panel.toggleDiagnostics");
   const isDockOpen = useDiagnosticsStore((state) => state.isOpen);
+  const toggleButtonVisibility = useToolbarPreferencesStore((s) => s.toggleButtonVisibility);
 
   return (
-    <Tooltip>
-      <TooltipTrigger asChild>
-        <Button
-          {...diagnosticsHover}
-          variant="ghost"
-          size="icon"
-          data-toolbar-item={dataToolbarItem}
-          onClick={onToggleProblems}
-          className={cn(toolbarIconButtonClass, "relative")}
-          aria-label={`Problems: ${errorCount} error${errorCount !== 1 ? "s" : ""}`}
-          aria-keyshortcuts={diagnosticsAriaShortcut}
-          aria-expanded={isDockOpen}
-          aria-controls={DIAGNOSTICS_DOCK_REGION_ID}
-        >
-          <AlertCircle />
-          <span
-            data-visible={errorCount > 0}
-            className="toolbar-problems-badge toolbar-badge absolute top-1.5 right-1.5 w-2 h-2 rounded-full"
-          />
-          <ShortcutRevealChip actionId="panel.toggleDiagnostics" />
-        </Button>
-      </TooltipTrigger>
-      <TooltipContent side="bottom">
-        {createTooltipContent("Show Problems Panel", diagnosticsShortcut)}
-      </TooltipContent>
-    </Tooltip>
+    <ContextMenu>
+      <ContextMenuTrigger asChild>
+        <Tooltip>
+          <TooltipTrigger asChild>
+            <Button
+              {...diagnosticsHover}
+              variant="ghost"
+              size="icon"
+              data-toolbar-item={dataToolbarItem}
+              onClick={onToggleProblems}
+              className={cn(toolbarIconButtonClass, "relative")}
+              aria-label={`Problems: ${errorCount} error${errorCount !== 1 ? "s" : ""}`}
+              aria-keyshortcuts={diagnosticsAriaShortcut}
+              aria-expanded={isDockOpen}
+              aria-controls={DIAGNOSTICS_DOCK_REGION_ID}
+            >
+              <AlertCircle />
+              <span
+                data-visible={errorCount > 0}
+                className="toolbar-problems-badge toolbar-badge absolute top-1.5 right-1.5 w-2 h-2 rounded-full"
+              />
+              <ShortcutRevealChip actionId="panel.toggleDiagnostics" />
+            </Button>
+          </TooltipTrigger>
+          <TooltipContent side="bottom">
+            {createTooltipContent("Show Problems Panel", diagnosticsShortcut)}
+          </TooltipContent>
+        </Tooltip>
+      </ContextMenuTrigger>
+      <ContextMenuContent className="max-h-[var(--radix-context-menu-content-available-height)] overflow-y-auto">
+        <ContextMenuItem onSelect={() => toggleButtonVisibility("problems", "right")}>
+          <Unplug className="mr-2 h-3.5 w-3.5" />
+          Unpin from Toolbar
+        </ContextMenuItem>
+      </ContextMenuContent>
+    </ContextMenu>
   );
 }

--- a/src/components/Layout/ToolbarSettingsButton.tsx
+++ b/src/components/Layout/ToolbarSettingsButton.tsx
@@ -1,5 +1,5 @@
 import { Button } from "@/components/ui/button";
-import { SlidersHorizontal } from "lucide-react";
+import { SlidersHorizontal, Unplug } from "lucide-react";
 import { Tooltip, TooltipContent, TooltipTrigger } from "@/components/ui/tooltip";
 import { ShortcutRevealChip } from "@/components/ui/ShortcutRevealChip";
 import {
@@ -12,6 +12,7 @@ import {
 import { createTooltipContent } from "@/lib/tooltipShortcut";
 import { useAriaKeyshortcuts, useKeybindingDisplay, useShortcutHintHover } from "@/hooks";
 import { actionService } from "@/services/ActionService";
+import { useToolbarPreferencesStore } from "@/store/toolbarPreferencesStore";
 
 const toolbarIconButtonClass = "toolbar-icon-button text-daintree-text relative";
 
@@ -38,6 +39,7 @@ export function ToolbarSettingsButton({
   const settingsShortcut = useKeybindingDisplay("app.settings");
   const settingsAriaShortcut = useAriaKeyshortcuts("app.settings");
   const settingsHover = useShortcutHintHover("app.settings");
+  const toggleButtonVisibility = useToolbarPreferencesStore((s) => s.toggleButtonVisibility);
 
   return (
     <ContextMenu>
@@ -70,7 +72,7 @@ export function ToolbarSettingsButton({
           </TooltipContent>
         </Tooltip>
       </ContextMenuTrigger>
-      <ContextMenuContent>
+      <ContextMenuContent className="max-h-[var(--radix-context-menu-content-available-height)] overflow-y-auto">
         {SETTINGS_CONTEXT_MENU_TABS.map(({ tab, label }) => (
           <ContextMenuItem
             key={tab}
@@ -107,6 +109,11 @@ export function ToolbarSettingsButton({
           }
         >
           Troubleshooting
+        </ContextMenuItem>
+        <ContextMenuSeparator />
+        <ContextMenuItem onSelect={() => toggleButtonVisibility("settings", "right")}>
+          <Unplug className="mr-2 h-3.5 w-3.5" />
+          Unpin from Toolbar
         </ContextMenuItem>
       </ContextMenuContent>
     </ContextMenu>

--- a/src/components/Layout/VoiceRecordingToolbarButton.tsx
+++ b/src/components/Layout/VoiceRecordingToolbarButton.tsx
@@ -1,12 +1,19 @@
 import { useEffect, useRef } from "react";
-import { Mic } from "lucide-react";
+import { Mic, Unplug } from "lucide-react";
 import { Button } from "@/components/ui/button";
 import { Tooltip, TooltipContent, TooltipTrigger } from "@/components/ui/tooltip";
+import {
+  ContextMenu,
+  ContextMenuContent,
+  ContextMenuItem,
+  ContextMenuTrigger,
+} from "@/components/ui/context-menu";
 import { ShortcutRevealChip } from "@/components/ui/ShortcutRevealChip";
 import { cn } from "@/lib/utils";
 import { useAriaKeyshortcuts, useKeybindingDisplay } from "@/hooks";
 import { useDeferredLoading } from "@/hooks/useDeferredLoading";
 import { UI_DOHERTY_THRESHOLD } from "@/lib/animationUtils";
+import { useToolbarPreferencesStore } from "@/store/toolbarPreferencesStore";
 import { useVoiceRecordingStore } from "@/store/voiceRecordingStore";
 import { voiceRecordingService } from "@/services/VoiceRecordingService";
 
@@ -50,6 +57,7 @@ export function VoiceRecordingToolbarButton({
   const audioLevel = useVoiceRecordingStore((state) => state.audioLevel);
   const shortcut = useKeybindingDisplay("voiceInput.toggle");
   const ariaShortcut = useAriaKeyshortcuts("voiceInput.toggle");
+  const toggleButtonVisibility = useToolbarPreferencesStore((s) => s.toggleButtonVisibility);
 
   const isConnecting = status === "connecting";
   const isRecording = status === "recording";
@@ -175,88 +183,100 @@ export function VoiceRecordingToolbarButton({
     .join(" · ");
 
   return (
-    <Tooltip>
-      <TooltipTrigger asChild>
-        <Button
-          variant="ghost"
-          size="icon"
-          data-toolbar-item={dataToolbarItem}
-          onClick={() => {
-            void voiceRecordingService.focusActiveTarget();
-          }}
-          className={cn(
-            "toolbar-icon-button relative mr-0.5 text-daintree-text",
-            "hover:text-[var(--toolbar-control-hover-fg,var(--theme-accent-primary))]"
-          )}
-          aria-label={tooltipTitle}
-          aria-keyshortcuts={ariaShortcut}
-        >
-          <Mic className="h-4 w-4" />
-          {/* Orbit overlay — absolute inset on the relative Button. No
-              contain:strict at this scale: the toolbar button is a flex
-              child and clipping the orbit would crop the ring. */}
-          <span
-            ref={trackRef}
-            aria-hidden="true"
-            className="absolute inset-1 rounded-full pointer-events-none"
-            style={{
-              opacity: 0.08,
-              background: `var(--theme-accent-primary)`,
-              mask: `linear-gradient(#fff 0 0) content-box, linear-gradient(#fff 0 0)`,
-              WebkitMask: `linear-gradient(#fff 0 0) content-box, linear-gradient(#fff 0 0)`,
-              maskComposite: "exclude",
-              WebkitMaskComposite: "xor",
-              padding: `${BASE_THICKNESS}px`,
-              transition: "opacity 80ms ease-out",
-            }}
-          />
-          <div
-            ref={wrapperRef}
-            aria-hidden="true"
-            className="absolute inset-1 pointer-events-none"
-            style={{ willChange: "transform" }}
-          >
-            <span
-              ref={ringRef}
-              className="absolute inset-0 rounded-full"
-              style={{
-                padding: `${BASE_THICKNESS}px`,
-                mask: `linear-gradient(#fff 0 0) content-box, linear-gradient(#fff 0 0)`,
-                WebkitMask: `linear-gradient(#fff 0 0) content-box, linear-gradient(#fff 0 0)`,
-                maskComposite: "exclude",
-                WebkitMaskComposite: "xor",
+    <ContextMenu>
+      <ContextMenuTrigger asChild>
+        <Tooltip>
+          <TooltipTrigger asChild>
+            <Button
+              variant="ghost"
+              size="icon"
+              data-toolbar-item={dataToolbarItem}
+              onClick={() => {
+                void voiceRecordingService.focusActiveTarget();
               }}
-            />
-            <span
-              ref={dotHaloRef}
-              className="absolute rounded-full bg-daintree-accent/30"
-              style={{
-                width: "6px",
-                height: "6px",
-                top: 0,
-                left: "50%",
-                transform: "translate(-50%, -35%)",
-              }}
-            />
-            <span
-              ref={dotCoreRef}
-              className="absolute rounded-full bg-daintree-accent"
-              style={{
-                width: "3.5px",
-                height: "3.5px",
-                top: 0,
-                left: "50%",
-                transform: "translate(-50%, -15%)",
-              }}
-            />
-          </div>
-          <ShortcutRevealChip actionId="voiceInput.toggle" />
-        </Button>
-      </TooltipTrigger>
-      <TooltipContent side="bottom" className="text-center">
-        <div className="font-medium">{tooltipTitle}</div>
-        {tooltipExtra && <div className="text-[11px] text-daintree-text/60">{tooltipExtra}</div>}
-      </TooltipContent>
-    </Tooltip>
+              className={cn(
+                "toolbar-icon-button relative mr-0.5 text-daintree-text",
+                "hover:text-[var(--toolbar-control-hover-fg,var(--theme-accent-primary))]"
+              )}
+              aria-label={tooltipTitle}
+              aria-keyshortcuts={ariaShortcut}
+            >
+              <Mic className="h-4 w-4" />
+              {/* Orbit overlay — absolute inset on the relative Button. No
+                  contain:strict at this scale: the toolbar button is a flex
+                  child and clipping the orbit would crop the ring. */}
+              <span
+                ref={trackRef}
+                aria-hidden="true"
+                className="absolute inset-1 rounded-full pointer-events-none"
+                style={{
+                  opacity: 0.08,
+                  background: `var(--theme-accent-primary)`,
+                  mask: `linear-gradient(#fff 0 0) content-box, linear-gradient(#fff 0 0)`,
+                  WebkitMask: `linear-gradient(#fff 0 0) content-box, linear-gradient(#fff 0 0)`,
+                  maskComposite: "exclude",
+                  WebkitMaskComposite: "xor",
+                  padding: `${BASE_THICKNESS}px`,
+                  transition: "opacity 80ms ease-out",
+                }}
+              />
+              <div
+                ref={wrapperRef}
+                aria-hidden="true"
+                className="absolute inset-1 pointer-events-none"
+                style={{ willChange: "transform" }}
+              >
+                <span
+                  ref={ringRef}
+                  className="absolute inset-0 rounded-full"
+                  style={{
+                    padding: `${BASE_THICKNESS}px`,
+                    mask: `linear-gradient(#fff 0 0) content-box, linear-gradient(#fff 0 0)`,
+                    WebkitMask: `linear-gradient(#fff 0 0) content-box, linear-gradient(#fff 0 0)`,
+                    maskComposite: "exclude",
+                    WebkitMaskComposite: "xor",
+                  }}
+                />
+                <span
+                  ref={dotHaloRef}
+                  className="absolute rounded-full bg-daintree-accent/30"
+                  style={{
+                    width: "6px",
+                    height: "6px",
+                    top: 0,
+                    left: "50%",
+                    transform: "translate(-50%, -35%)",
+                  }}
+                />
+                <span
+                  ref={dotCoreRef}
+                  className="absolute rounded-full bg-daintree-accent"
+                  style={{
+                    width: "3.5px",
+                    height: "3.5px",
+                    top: 0,
+                    left: "50%",
+                    transform: "translate(-50%, -15%)",
+                  }}
+                />
+              </div>
+              <ShortcutRevealChip actionId="voiceInput.toggle" />
+            </Button>
+          </TooltipTrigger>
+          <TooltipContent side="bottom" className="text-center">
+            <div className="font-medium">{tooltipTitle}</div>
+            {tooltipExtra && (
+              <div className="text-[11px] text-daintree-text/60">{tooltipExtra}</div>
+            )}
+          </TooltipContent>
+        </Tooltip>
+      </ContextMenuTrigger>
+      <ContextMenuContent className="max-h-[var(--radix-context-menu-content-available-height)] overflow-y-auto">
+        <ContextMenuItem onSelect={() => toggleButtonVisibility("voice-recording", "right")}>
+          <Unplug className="mr-2 h-3.5 w-3.5" />
+          Unpin from Toolbar
+        </ContextMenuItem>
+      </ContextMenuContent>
+    </ContextMenu>
   );
 }

--- a/src/components/Layout/__tests__/AgentTrayButton.test.tsx
+++ b/src/components/Layout/__tests__/AgentTrayButton.test.tsx
@@ -188,6 +188,25 @@ vi.mock("@/lib/colorUtils", () => ({
   getBrandColorHex: (id: string) => `#brand-${id}`,
 }));
 
+vi.mock("@/components/ui/context-menu", () => ({
+  ContextMenu: ({ children }: { children: React.ReactNode }) => <>{children}</>,
+  ContextMenuTrigger: ({ children }: { children: React.ReactNode }) => <>{children}</>,
+  ContextMenuContent: ({ children }: { children: React.ReactNode }) => (
+    <div data-testid="context-menu-content">{children}</div>
+  ),
+  ContextMenuItem: ({
+    children,
+    onSelect,
+  }: {
+    children: React.ReactNode;
+    onSelect?: (e: Event) => void;
+  }) => (
+    <div role="menuitem" onClick={(e) => onSelect?.(e as unknown as Event)}>
+      {children}
+    </div>
+  ),
+}));
+
 vi.mock("@/components/ui/dropdown-menu", () => ({
   DropdownMenu: ({
     children,
@@ -349,6 +368,7 @@ vi.mock("lucide-react", () => ({
   Settings2: () => <span data-testid="settings2-icon" />,
   ChevronRight: () => <span data-testid="chevron-right-icon" />,
   Keyboard: () => <span data-testid="keyboard-icon" />,
+  Unplug: () => <span data-testid="unplug-icon" />,
 }));
 
 import { AgentTrayButton } from "../AgentTrayButton";

--- a/src/components/Layout/__tests__/NotificationCenterToolbarButton.test.tsx
+++ b/src/components/Layout/__tests__/NotificationCenterToolbarButton.test.tsx
@@ -59,9 +59,29 @@ vi.mock("@/components/Notifications/NotificationCenter", () => ({
   NotificationCenter: () => null,
 }));
 
+vi.mock("@/components/ui/context-menu", () => ({
+  ContextMenu: ({ children }: { children: React.ReactNode }) => <>{children}</>,
+  ContextMenuTrigger: ({ children }: { children: React.ReactNode }) => <>{children}</>,
+  ContextMenuContent: ({ children }: { children: React.ReactNode }) => (
+    <div data-testid="context-menu-content">{children}</div>
+  ),
+  ContextMenuItem: ({
+    children,
+    onSelect,
+  }: {
+    children: React.ReactNode;
+    onSelect?: (e: Event) => void;
+  }) => (
+    <div role="menuitem" onClick={(e) => onSelect?.(e as unknown as Event)}>
+      {children}
+    </div>
+  ),
+}));
+
 vi.mock("lucide-react", () => ({
   Bell: () => <span data-testid="icon-bell" />,
   BellOff: () => <span data-testid="icon-bell-off" />,
+  Unplug: () => <span data-testid="icon-unplug" />,
 }));
 
 function resetStores() {

--- a/src/components/Layout/__tests__/Toolbar.githubDropdowns.test.ts
+++ b/src/components/Layout/__tests__/Toolbar.githubDropdowns.test.ts
@@ -33,10 +33,12 @@ describe("Toolbar GitHub dropdown search clearing — issue #3251", () => {
   });
 
   it("clears issue search query in onClose callback", () => {
-    // Find the LazyGitHubResourceList occurrence (second type="issue"), not the skeleton (first)
-    const firstIssueIdx = source.indexOf('type="issue"');
-    const lazyIssueIdx = source.indexOf('type="issue"', firstIssueIdx + 1);
-    const issuesOnClose = source.slice(lazyIssueIdx, lazyIssueIdx + 300);
+    // Anchor on the unique LazyGitHubResourceList tag — `type="issue"` now
+    // appears three times (eager + skeleton + lazy) and Prettier wrapping
+    // varies the line layout, so a char-offset slice from the Nth match is
+    // brittle. The lazy resource list's onClose is what this test guards.
+    const lazyIssueIdx = source.indexOf("<LazyGitHubResourceList");
+    const issuesOnClose = source.slice(lazyIssueIdx, lazyIssueIdx + 400);
     expect(issuesOnClose).toContain('setIssueSearchQuery("")');
   });
 

--- a/src/components/Layout/__tests__/ToolbarProblemsButton.test.tsx
+++ b/src/components/Layout/__tests__/ToolbarProblemsButton.test.tsx
@@ -11,6 +11,25 @@ vi.mock("@/components/ui/tooltip", () => ({
   TooltipTrigger: ({ children }: { children: React.ReactNode }) => <>{children}</>,
 }));
 
+vi.mock("@/components/ui/context-menu", () => ({
+  ContextMenu: ({ children }: { children: React.ReactNode }) => <>{children}</>,
+  ContextMenuTrigger: ({ children }: { children: React.ReactNode }) => <>{children}</>,
+  ContextMenuContent: ({ children }: { children: React.ReactNode }) => (
+    <div data-testid="context-menu-content">{children}</div>
+  ),
+  ContextMenuItem: ({
+    children,
+    onSelect,
+  }: {
+    children: React.ReactNode;
+    onSelect?: (e: Event) => void;
+  }) => (
+    <div role="menuitem" onClick={(e) => onSelect?.(e as unknown as Event)}>
+      {children}
+    </div>
+  ),
+}));
+
 vi.mock("@/components/ui/button", () => ({
   Button: ({
     children,
@@ -26,6 +45,7 @@ vi.mock("@/components/ui/ShortcutRevealChip", () => ({
 
 vi.mock("lucide-react", () => ({
   AlertCircle: () => <span data-testid="icon-alert" />,
+  Unplug: () => <span data-testid="icon-unplug" />,
 }));
 
 function getIconHostClassName(container: HTMLElement): string {


### PR DESCRIPTION
## Summary

- Finishes #8181's groundwork by wiring a right-click "Unpin from Toolbar" affordance onto every configurable toolbar button, using the same `ContextMenu` + `Unplug` icon + `toggleButtonVisibility` dispatch pattern established on `AgentButton`
- Skips `assistant-toggle`, `portal-toggle`, and `sidebar-toggle` — these are `FIXED_BUTTON_IDS` and always rendered, so the unpin affordance doesn't apply
- Every new `ContextMenuContent` carries the lesson-#4402 height-constrain class (`max-h-[var(--radix-context-menu-content-available-height)] overflow-y-auto`)

Resolves #8182

## Changes

- `Toolbar.tsx` — wired dev-server, copy-tree, and `PluginToolbarButton`; fixed `useMemo` deps; tightened `pluginId` prop to `PluginToolbarButtonId`
- `ToolbarSettingsButton.tsx` — extended existing context menu with separator + unpin item
- `ToolbarProblemsButton.tsx` — new `ContextMenu` wrap
- `ToolbarLauncherButton.tsx` — new `ContextMenu` wrap (terminal + browser variants)
- `NotificationCenterToolbarButton.tsx` — new `ContextMenu` wrap
- `VoiceRecordingToolbarButton.tsx` — new `ContextMenu` wrap on active path
- `GitHubStatsToolbarButton.tsx` — new `ContextMenu` wrap on outer pill
- `AgentTrayButton.tsx` — new `ContextMenu` nested inside existing `DropdownMenu`
- Test files for `AgentTrayButton`, `NotificationCenterToolbarButton`, `ToolbarProblemsButton`, and `Toolbar.githubDropdowns` — mock updates + brittle char-offset test made robust

## Testing

Typecheck passes, layout test suite green at 796 tests, lint ratchet at baseline 889, format clean.