### PR TITLE
feat(webview): capture Runtime.exceptionThrown and Log.entryAdded in CDP session

### DIFF
--- a/electron/ipc/handlers/__tests__/webview.test.ts
+++ b/electron/ipc/handlers/__tests__/webview.test.ts
@@ -602,8 +602,8 @@ describe("registerWebviewHandlers", () => {
       for (let i = 0; i < 7; i++) messageListener({}, "Log.entryAdded", evt);
 
       const logRows = mainWindowMock.webContents.send.mock.calls.filter(
-        ([ch, row]: [string, { cdpType?: string }]) =>
-          ch === "webview:console-message" && row.cdpType === "log-entry"
+        (call): call is [string, { cdpType?: string }] =>
+          call[0] === "webview:console-message" && (call[1] as any).cdpType === "log-entry"
       );
       expect(logRows).toHaveLength(5);
     });
@@ -655,8 +655,8 @@ describe("registerWebviewHandlers", () => {
       });
 
       const rows = mainWindowMock.webContents.send.mock.calls
-        .filter(([ch]: string[]) => ch === "webview:console-message")
-        .map(([, row]: [string, { paneId: string; cdpType: string }]) => row);
+        .filter((call): call is [string, any] => call[0] === "webview:console-message")
+        .map((call) => call[1] as { paneId: string; cdpType: string });
       const exceptionPanes = rows.filter((r) => r.cdpType === "error").map((r) => r.paneId);
       const logPanes = rows.filter((r) => r.cdpType === "log-entry").map((r) => r.paneId);
       expect(exceptionPanes.sort()).toEqual(["pane-1", "pane-2"]);
@@ -686,8 +686,8 @@ describe("registerWebviewHandlers", () => {
         };
         for (let i = 0; i < 6; i++) messageListener({}, "Log.entryAdded", evt);
         const countAfterFlood = mainWindowMock.webContents.send.mock.calls.filter(
-          ([ch, row]: [string, { cdpType?: string }]) =>
-            ch === "webview:console-message" && row.cdpType === "log-entry"
+          (call): call is [string, { cdpType?: string }] =>
+            call[0] === "webview:console-message" && (call[1] as any).cdpType === "log-entry"
         ).length;
         expect(countAfterFlood).toBe(5);
 
@@ -695,8 +695,8 @@ describe("registerWebviewHandlers", () => {
         messageListener({}, "Log.entryAdded", evt);
 
         const totalAfterReset = mainWindowMock.webContents.send.mock.calls.filter(
-          ([ch, row]: [string, { cdpType?: string }]) =>
-            ch === "webview:console-message" && row.cdpType === "log-entry"
+          (call): call is [string, { cdpType?: string }] =>
+            call[0] === "webview:console-message" && (call[1] as any).cdpType === "log-entry"
         ).length;
         expect(totalAfterReset).toBe(6);
       } finally {

--- a/electron/ipc/handlers/__tests__/webview.test.ts
+++ b/electron/ipc/handlers/__tests__/webview.test.ts
@@ -607,6 +607,128 @@ describe("registerWebviewHandlers", () => {
       );
       expect(logRows).toHaveLength(5);
     });
+
+    it("still captures Runtime.consoleAPICalled when Log.enable fails", async () => {
+      const warnSpy = vi.spyOn(console, "warn").mockImplementation(() => {});
+      debuggerMock.sendCommand.mockImplementation((cmd: string) => {
+        if (cmd === "Log.enable") return Promise.reject(new Error("Log domain unsupported"));
+        return Promise.resolve();
+      });
+
+      cleanup = registerWebviewHandlers(deps);
+      const handler = getHandler("webview:start-console-capture");
+      await handler(null, 42, "pane-1");
+
+      const messageCall = debuggerMock.on.mock.calls.find(
+        ([event]: string[]) => event === "message"
+      );
+      expect(messageCall).toBeDefined();
+      messageCall![1]({}, "Runtime.consoleAPICalled", {
+        type: "log",
+        args: [{ type: "string", value: "still works" }],
+        timestamp: 1000,
+      });
+
+      expect(mainWindowMock.webContents.send).toHaveBeenCalledWith(
+        "webview:console-message",
+        expect.objectContaining({ paneId: "pane-1", summaryText: "still works" })
+      );
+      warnSpy.mockRestore();
+    });
+
+    it("fans exceptionThrown and Log.entryAdded out to every pane", async () => {
+      cleanup = registerWebviewHandlers(deps);
+      const handler = getHandler("webview:start-console-capture");
+      await handler(null, 42, "pane-1");
+      await handler(null, 42, "pane-2");
+
+      const messageListener = debuggerMock.on.mock.calls.find(
+        ([event]: string[]) => event === "message"
+      )![1];
+
+      messageListener({}, "Runtime.exceptionThrown", {
+        timestamp: 1,
+        exceptionDetails: { text: "Uncaught Error: x" },
+      });
+      messageListener({}, "Log.entryAdded", {
+        entry: { source: "network", level: "error", text: "failed", timestamp: 2 },
+      });
+
+      const rows = mainWindowMock.webContents.send.mock.calls
+        .filter(([ch]: string[]) => ch === "webview:console-message")
+        .map(([, row]: [string, { paneId: string; cdpType: string }]) => row);
+      const exceptionPanes = rows.filter((r) => r.cdpType === "error").map((r) => r.paneId);
+      const logPanes = rows.filter((r) => r.cdpType === "log-entry").map((r) => r.paneId);
+      expect(exceptionPanes.sort()).toEqual(["pane-1", "pane-2"]);
+      expect(logPanes.sort()).toEqual(["pane-1", "pane-2"]);
+    });
+
+    it("resets the Log.entryAdded rate-limit window after it elapses", async () => {
+      vi.useFakeTimers();
+      try {
+        cleanup = registerWebviewHandlers(deps);
+        const handler = getHandler("webview:start-console-capture");
+        await handler(null, 42, "pane-1");
+
+        const messageListener = debuggerMock.on.mock.calls.find(
+          ([event]: string[]) => event === "message"
+        )![1];
+
+        const evt = {
+          entry: {
+            source: "network",
+            level: "warning",
+            text: "slow",
+            timestamp: 1,
+            url: "https://x.test/a",
+            lineNumber: 3,
+          },
+        };
+        for (let i = 0; i < 6; i++) messageListener({}, "Log.entryAdded", evt);
+        const countAfterFlood = mainWindowMock.webContents.send.mock.calls.filter(
+          ([ch, row]: [string, { cdpType?: string }]) =>
+            ch === "webview:console-message" && row.cdpType === "log-entry"
+        ).length;
+        expect(countAfterFlood).toBe(5);
+
+        vi.advanceTimersByTime(5_001);
+        messageListener({}, "Log.entryAdded", evt);
+
+        const totalAfterReset = mainWindowMock.webContents.send.mock.calls.filter(
+          ([ch, row]: [string, { cdpType?: string }]) =>
+            ch === "webview:console-message" && row.cdpType === "log-entry"
+        ).length;
+        expect(totalAfterReset).toBe(6);
+      } finally {
+        vi.useRealTimers();
+      }
+    });
+
+    it("uses the fallback summary for malformed Runtime.exceptionThrown payloads", async () => {
+      cleanup = registerWebviewHandlers(deps);
+      const handler = getHandler("webview:start-console-capture");
+      await handler(null, 42, "pane-1");
+
+      const messageListener = debuggerMock.on.mock.calls.find(
+        ([event]: string[]) => event === "message"
+      )![1];
+
+      expect(() => messageListener({}, "Runtime.exceptionThrown", null)).not.toThrow();
+      messageListener({}, "Runtime.exceptionThrown", {
+        timestamp: 1,
+        exceptionDetails: { exception: { type: "object" } },
+      });
+
+      expect(mainWindowMock.webContents.send).toHaveBeenCalledWith(
+        "webview:console-message",
+        expect.objectContaining({
+          level: "error",
+          cdpType: "error",
+          summaryText: "Uncaught (unknown exception)",
+          args: [],
+        })
+      );
+    });
   });
 
   describe("ownership validation", () => {

--- a/electron/ipc/handlers/__tests__/webview.test.ts
+++ b/electron/ipc/handlers/__tests__/webview.test.ts
@@ -433,6 +433,180 @@ describe("registerWebviewHandlers", () => {
       );
       expect(sendToRenderer).not.toHaveBeenCalled();
     });
+
+    it("enables Log domain on startConsoleCapture", async () => {
+      cleanup = registerWebviewHandlers(deps);
+      const handler = getHandler("webview:start-console-capture");
+      await handler(null, 42, "pane-1");
+
+      expect(debuggerMock.sendCommand).toHaveBeenCalledWith("Log.enable");
+    });
+
+    it("enables Runtime and Log only once across multiple panes", async () => {
+      cleanup = registerWebviewHandlers(deps);
+      const handler = getHandler("webview:start-console-capture");
+      await handler(null, 42, "pane-1");
+      await handler(null, 42, "pane-2");
+
+      const runtimeEnableCalls = debuggerMock.sendCommand.mock.calls.filter(
+        ([cmd]: string[]) => cmd === "Runtime.enable"
+      );
+      const logEnableCalls = debuggerMock.sendCommand.mock.calls.filter(
+        ([cmd]: string[]) => cmd === "Log.enable"
+      );
+      expect(runtimeEnableCalls).toHaveLength(1);
+      expect(logEnableCalls).toHaveLength(1);
+    });
+
+    it("disables Log domain when the last pane stops", async () => {
+      cleanup = registerWebviewHandlers(deps);
+      const startHandler = getHandler("webview:start-console-capture");
+      const stopHandler = getHandler("webview:stop-console-capture");
+      await startHandler(null, 42, "pane-1");
+      await startHandler(null, 42, "pane-2");
+
+      await stopHandler(null, 42, "pane-1");
+      expect(debuggerMock.sendCommand).not.toHaveBeenCalledWith("Log.disable");
+
+      await stopHandler(null, 42, "pane-2");
+      expect(debuggerMock.sendCommand).toHaveBeenCalledWith("Log.disable");
+      expect(debuggerMock.sendCommand).toHaveBeenCalledWith("Runtime.disable");
+    });
+
+    it("forwards Runtime.exceptionThrown as an error row", async () => {
+      cleanup = registerWebviewHandlers(deps);
+      const handler = getHandler("webview:start-console-capture");
+      await handler(null, 42, "pane-1");
+
+      const messageListener = debuggerMock.on.mock.calls.find(
+        ([event]: string[]) => event === "message"
+      )![1];
+
+      messageListener({}, "Runtime.exceptionThrown", {
+        timestamp: 5000,
+        exceptionDetails: {
+          text: "Uncaught",
+          exception: { type: "object", description: "TypeError: boom\n  at foo (a.js:1:1)" },
+          stackTrace: {
+            callFrames: [{ functionName: "foo", url: "a.js", lineNumber: 0, columnNumber: 0 }],
+          },
+        },
+      });
+
+      expect(mainWindowMock.webContents.send).toHaveBeenCalledWith(
+        "webview:console-message",
+        expect.objectContaining({
+          paneId: "pane-1",
+          level: "error",
+          cdpType: "error",
+          summaryText: "TypeError: boom\n  at foo (a.js:1:1)",
+          stackTrace: { callFrames: [expect.objectContaining({ functionName: "foo" })] },
+        })
+      );
+    });
+
+    it("falls back to exceptionDetails.text when description is absent", async () => {
+      cleanup = registerWebviewHandlers(deps);
+      const handler = getHandler("webview:start-console-capture");
+      await handler(null, 42, "pane-1");
+
+      const messageListener = debuggerMock.on.mock.calls.find(
+        ([event]: string[]) => event === "message"
+      )![1];
+
+      messageListener({}, "Runtime.exceptionThrown", {
+        timestamp: 5000,
+        exceptionDetails: { text: "Uncaught (in promise) plain string" },
+      });
+
+      expect(mainWindowMock.webContents.send).toHaveBeenCalledWith(
+        "webview:console-message",
+        expect.objectContaining({
+          level: "error",
+          cdpType: "error",
+          summaryText: "Uncaught (in promise) plain string",
+        })
+      );
+    });
+
+    it("maps Log.entryAdded level and source onto the row", async () => {
+      cleanup = registerWebviewHandlers(deps);
+      const handler = getHandler("webview:start-console-capture");
+      await handler(null, 42, "pane-1");
+
+      const messageListener = debuggerMock.on.mock.calls.find(
+        ([event]: string[]) => event === "message"
+      )![1];
+
+      messageListener({}, "Log.entryAdded", {
+        entry: {
+          source: "security",
+          level: "error",
+          text: "Refused to load script (CSP)",
+          timestamp: 6000,
+          url: "https://example.com",
+          lineNumber: 12,
+        },
+      });
+
+      expect(mainWindowMock.webContents.send).toHaveBeenCalledWith(
+        "webview:console-message",
+        expect.objectContaining({
+          paneId: "pane-1",
+          level: "error",
+          cdpType: "log-entry",
+          category: "security",
+          summaryText: "Refused to load script (CSP)",
+        })
+      );
+    });
+
+    it("maps verbose Log.entryAdded level to log and unknown source to other", async () => {
+      cleanup = registerWebviewHandlers(deps);
+      const handler = getHandler("webview:start-console-capture");
+      await handler(null, 42, "pane-1");
+
+      const messageListener = debuggerMock.on.mock.calls.find(
+        ([event]: string[]) => event === "message"
+      )![1];
+
+      messageListener({}, "Log.entryAdded", {
+        entry: { source: "appcache", level: "verbose", text: "v", timestamp: 1 },
+      });
+
+      expect(mainWindowMock.webContents.send).toHaveBeenCalledWith(
+        "webview:console-message",
+        expect.objectContaining({ level: "log", cdpType: "log-entry", category: "other" })
+      );
+    });
+
+    it("rate-limits identical Log.entryAdded events to 5 per window", async () => {
+      cleanup = registerWebviewHandlers(deps);
+      const handler = getHandler("webview:start-console-capture");
+      await handler(null, 42, "pane-1");
+
+      const messageListener = debuggerMock.on.mock.calls.find(
+        ([event]: string[]) => event === "message"
+      )![1];
+
+      const evt = {
+        entry: {
+          source: "network",
+          level: "warning",
+          text: "Slow request",
+          timestamp: 1,
+          url: "https://x.test/a",
+          lineNumber: 3,
+        },
+      };
+      for (let i = 0; i < 7; i++) messageListener({}, "Log.entryAdded", evt);
+
+      const logRows = mainWindowMock.webContents.send.mock.calls.filter(
+        ([ch, row]: [string, { cdpType?: string }]) =>
+          ch === "webview:console-message" && row.cdpType === "log-entry"
+      );
+      expect(logRows).toHaveLength(5);
+    });
   });
 
   describe("ownership validation", () => {

--- a/electron/ipc/handlers/webview.ts
+++ b/electron/ipc/handlers/webview.ts
@@ -9,6 +9,7 @@ import type {
   CdpRemoteArg,
   CdpStackTrace,
   CdpConsoleType,
+  CdpLogEntrySource,
   SerializedConsoleRow,
   CdpPropertyDescriptor,
 } from "../../../shared/types/ipc/webviewConsole.js";
@@ -19,10 +20,14 @@ import { freezeWebContents, unfreezeWebContents } from "../../utils/webContentsL
 
 interface CdpSession {
   runtimeEnabled: boolean;
+  logEnabled: boolean;
   paneIds: Set<string>;
   navigationGeneration: number;
   groupDepthByPane: Map<string, number>;
   objectIdsByPane: Map<string, Set<string>>;
+  // Per-session throttle for `Log.entryAdded` — browser-emitted entries
+  // (CSP, network, deprecation) can flood. Keyed by source:level:url:line.
+  logRateLimit: Map<string, { count: number; resetAt: number }>;
   ownerWindow: BrowserWindow | null;
   messageListener: ((event: Electron.Event, method: string, params: unknown) => void) | null;
   detachListener: ((event: Electron.Event, reason: string) => void) | null;
@@ -31,15 +36,69 @@ interface CdpSession {
 const sessions = new Map<number, CdpSession>();
 let _nextMessageId = 0;
 
+// Keep in sync with rendererConsoleCapture.ts (RATE_WINDOW_MS / RATE_MAX_PER_WINDOW).
+// Same throttle algorithm; the rate state lives on CdpSession (keyed by wcId)
+// rather than a WeakMap<WebContents>, so the helper is not shared.
+const LOG_RATE_WINDOW_MS = 5_000;
+const LOG_RATE_MAX_PER_WINDOW = 5;
+
+const LOG_ENTRY_SOURCES: ReadonlySet<string> = new Set<CdpLogEntrySource>([
+  "javascript",
+  "network",
+  "deprecation",
+  "security",
+  "violation",
+  "intervention",
+  "recommendation",
+  "worker",
+  "other",
+]);
+
+function normalizeLogEntrySource(source: unknown): CdpLogEntrySource {
+  return typeof source === "string" && LOG_ENTRY_SOURCES.has(source)
+    ? (source as CdpLogEntrySource)
+    : "other";
+}
+
+function logEntryLevelToLevel(level: unknown): "log" | "info" | "warning" | "error" {
+  switch (level) {
+    case "error":
+      return "error";
+    case "warning":
+      return "warning";
+    case "info":
+      return "info";
+    // "verbose" and anything unexpected collapse to "log"
+    default:
+      return "log";
+  }
+}
+
+function shouldAllowLogEntry(session: CdpSession, key: string): boolean {
+  const now = Date.now();
+  const entry = session.logRateLimit.get(key);
+  if (!entry || now >= entry.resetAt) {
+    session.logRateLimit.set(key, { count: 1, resetAt: now + LOG_RATE_WINDOW_MS });
+    return true;
+  }
+  if (entry.count < LOG_RATE_MAX_PER_WINDOW) {
+    entry.count++;
+    return true;
+  }
+  return false;
+}
+
 function getOrCreateSession(wcId: number): CdpSession {
   let session = sessions.get(wcId);
   if (!session) {
     session = {
       runtimeEnabled: false,
+      logEnabled: false,
       paneIds: new Set(),
       navigationGeneration: 0,
       groupDepthByPane: new Map(),
       objectIdsByPane: new Map(),
+      logRateLimit: new Map(),
       ownerWindow: null,
       messageListener: null,
       detachListener: null,
@@ -270,11 +329,22 @@ export function registerWebviewHandlers(_deps: HandlerDependencies): () => void 
         session.runtimeEnabled = true;
       }
 
+      // Log domain surfaces browser-emitted entries (CSP violations, network
+      // failures, deprecations) that never reach Runtime.consoleAPICalled.
+      if (!session.logEnabled) {
+        await wc.debugger.sendCommand("Log.enable");
+        session.logEnabled = true;
+      }
+
       // Bind CDP message listener once per webContents
       if (!session.messageListener) {
         const listener = (_event: Electron.Event, method: string, params: unknown) => {
           if (method === "Runtime.consoleAPICalled") {
             handleConsoleApiCalled(webContentsId, session, params);
+          } else if (method === "Runtime.exceptionThrown") {
+            handleExceptionThrown(session, params);
+          } else if (method === "Log.entryAdded") {
+            handleLogEntryAdded(session, params);
           } else if (method === "Runtime.executionContextsCleared") {
             session.navigationGeneration++;
             // Reset group depth and clear stale objectIds for all panes
@@ -304,6 +374,7 @@ export function registerWebviewHandlers(_deps: HandlerDependencies): () => void 
       if (!session.detachListener) {
         const detachListener = (_event: Electron.Event, _reason: string) => {
           session.runtimeEnabled = false;
+          session.logEnabled = false;
           // Debugger detach automatically removes all listeners, so just null our refs
           session.messageListener = null;
           session.detachListener = null;
@@ -398,6 +469,75 @@ export function registerWebviewHandlers(_deps: HandlerDependencies): () => void 
     }
   }
 
+  function emitConsoleRow(session: CdpSession, row: SerializedConsoleRow): void {
+    if (session.ownerWindow && !session.ownerWindow.isDestroyed()) {
+      sendToRenderer(session.ownerWindow, CHANNELS.WEBVIEW_CONSOLE_MESSAGE, row);
+    } else {
+      broadcastToRenderer(CHANNELS.WEBVIEW_CONSOLE_MESSAGE, row);
+    }
+  }
+
+  function handleExceptionThrown(session: CdpSession, params: unknown): void {
+    // eslint-disable-next-line @typescript-eslint/no-explicit-any
+    const p = params as any;
+    const details = p?.exceptionDetails;
+    if (!details) return;
+
+    const summaryText: string =
+      details.exception?.description ?? details.text ?? "Uncaught (unknown exception)";
+    const stackTrace = normalizeStackTrace(details.stackTrace);
+    const timestamp = typeof p.timestamp === "number" ? Math.floor(p.timestamp) : Date.now();
+
+    for (const paneId of session.paneIds) {
+      const row: SerializedConsoleRow = {
+        id: _nextMessageId++,
+        paneId,
+        level: "error",
+        cdpType: "error",
+        args: [],
+        summaryText,
+        stackTrace,
+        groupDepth: session.groupDepthByPane.get(paneId) ?? 0,
+        timestamp,
+        navigationGeneration: session.navigationGeneration,
+      };
+      emitConsoleRow(session, row);
+    }
+  }
+
+  function handleLogEntryAdded(session: CdpSession, params: unknown): void {
+    // eslint-disable-next-line @typescript-eslint/no-explicit-any
+    const entry = (params as any)?.entry;
+    if (!entry) return;
+
+    const source = normalizeLogEntrySource(entry.source);
+    const level = logEntryLevelToLevel(entry.level);
+    const rateKey = `${source}:${level}:${entry.url ?? ""}:${entry.lineNumber ?? 0}`;
+    if (!shouldAllowLogEntry(session, rateKey)) return;
+
+    const summaryText: string = typeof entry.text === "string" ? entry.text : "";
+    const stackTrace = normalizeStackTrace(entry.stackTrace);
+    const timestamp =
+      typeof entry.timestamp === "number" ? Math.floor(entry.timestamp) : Date.now();
+
+    for (const paneId of session.paneIds) {
+      const row: SerializedConsoleRow = {
+        id: _nextMessageId++,
+        paneId,
+        level,
+        cdpType: "log-entry",
+        args: [],
+        summaryText,
+        stackTrace,
+        groupDepth: session.groupDepthByPane.get(paneId) ?? 0,
+        timestamp,
+        navigationGeneration: session.navigationGeneration,
+        category: source,
+      };
+      emitConsoleRow(session, row);
+    }
+  }
+
   const handleStopConsoleCapture = async (
     webContentsId: unknown,
     paneId: unknown
@@ -423,6 +563,13 @@ export function registerWebviewHandlers(_deps: HandlerDependencies): () => void 
       if (wc && !wc.isDestroyed() && session.runtimeEnabled) {
         try {
           await wc.debugger.sendCommand("Runtime.disable");
+        } catch {
+          // Ignore
+        }
+      }
+      if (wc && !wc.isDestroyed() && session.logEnabled) {
+        try {
+          await wc.debugger.sendCommand("Log.disable");
         } catch {
           // Ignore
         }

--- a/electron/ipc/handlers/webview.ts
+++ b/electron/ipc/handlers/webview.ts
@@ -329,13 +329,6 @@ export function registerWebviewHandlers(_deps: HandlerDependencies): () => void 
         session.runtimeEnabled = true;
       }
 
-      // Log domain surfaces browser-emitted entries (CSP violations, network
-      // failures, deprecations) that never reach Runtime.consoleAPICalled.
-      if (!session.logEnabled) {
-        await wc.debugger.sendCommand("Log.enable");
-        session.logEnabled = true;
-      }
-
       // Bind CDP message listener once per webContents
       if (!session.messageListener) {
         const listener = (_event: Electron.Event, method: string, params: unknown) => {
@@ -399,6 +392,24 @@ export function registerWebviewHandlers(_deps: HandlerDependencies): () => void 
         };
         session.detachListener = detachListener;
         wc.debugger.on("detach", detachListener);
+      }
+
+      // Log domain surfaces browser-emitted entries (CSP violations, network
+      // failures, deprecations) that never reach Runtime.consoleAPICalled.
+      // Enabled AFTER the message listener is wired so any entries CDP replays
+      // on enable are captured, and in its own try/catch so a Log.enable
+      // failure degrades to "no log-entry rows" rather than silently breaking
+      // the already-registered Runtime.consoleAPICalled capture.
+      if (!session.logEnabled) {
+        try {
+          await wc.debugger.sendCommand("Log.enable");
+          session.logEnabled = true;
+        } catch (logErr) {
+          console.warn(
+            `[webview] CDP Log.enable failed for id=${webContentsId}:`,
+            formatErrorMessage(logErr, "Log.enable failed")
+          );
+        }
       }
     } catch (err) {
       const message = formatErrorMessage(err, "CDP console capture start failed");

--- a/shared/types/ipc/webviewConsole.ts
+++ b/shared/types/ipc/webviewConsole.ts
@@ -46,7 +46,23 @@ export type CdpConsoleType =
   | "table"
   | "count"
   | "timeEnd"
-  | "assert";
+  | "assert"
+  // Rows sourced from CDP `Log.entryAdded` (browser-emitted: CSP violations,
+  // network failures, deprecations) rather than `Runtime.consoleAPICalled`.
+  | "log-entry";
+
+// Source classification for `Log.entryAdded` rows. Mirrors the Chromium
+// `LogEntry.source` enum (subset we surface); unknown sources fall back to "other".
+export type CdpLogEntrySource =
+  | "javascript"
+  | "network"
+  | "deprecation"
+  | "security"
+  | "violation"
+  | "intervention"
+  | "recommendation"
+  | "worker"
+  | "other";
 
 export interface SerializedConsoleRow {
   id: number;
@@ -59,6 +75,9 @@ export interface SerializedConsoleRow {
   groupDepth: number;
   timestamp: number;
   navigationGeneration: number;
+  // Present only on `cdpType: "log-entry"` rows — classifies the browser
+  // subsystem that emitted the entry (CSP/security, network, deprecation, …).
+  category?: CdpLogEntrySource;
 }
 
 export interface CdpPropertyDescriptor {


### PR DESCRIPTION
The CDP debugger session in `electron/ipc/handlers/webview.ts` was only capturing `Runtime.consoleAPICalled`. Two useful diagnostic streams were dark.

## What's added

**`Runtime.exceptionThrown`** — unhandled JS exceptions and promise rejections. Most frameworks don't also call `console.error` on these, so they were completely invisible before. Mapped to `SerializedConsoleRow` with `level: "error"` / `cdpType: "exception"`, with `summaryText` built from `exceptionDetails.text` + `exception.description` and stack frames normalised through the existing `normalizeStackTrace` helper.

**`Log.entryAdded`** — browser-emitted warnings: CSP violations, network failures, deprecation notices, mixed content, etc. These are the messages that populate the Chrome DevTools Issues panel and almost never surface as `console.warn`. Mapped by `entry.level`/`entry.source`, with an optional typed `category: CdpLogEntrySource` field on `SerializedConsoleRow` for downstream filtering. Rate-limited at 5 per 5000ms per session to handle noisy third-party pages.

## What didn't change

No second `debugger.attach`. Both streams layer onto the existing session. All rows continue through `CHANNELS.WEBVIEW_CONSOLE_MESSAGE` — no new IPC.

`Log.enable` runs after the listener is registered, in its own non-throwing `try/catch`. A failure degrades gracefully without silently breaking `Runtime` capture. `Log.disable` mirrors `Runtime.disable` in the teardown path; `logEnabled` resets on detach.

## Testing

33 unit tests in `electron/ipc/handlers/__tests__/webview.test.ts` cover the new event paths, rate-limiting behaviour, graceful `Log.enable` failure, and type-guard predicate filters. `npm run check` clean.

Resolves #8269