### PR TITLE
fix(dev-preview): wire URL history, SPA titles, and route preservation on restart

### DIFF
--- a/src/components/DevPreview/DevPreviewPane.tsx
+++ b/src/components/DevPreview/DevPreviewPane.tsx
@@ -26,7 +26,7 @@ import { useDevServer } from "@/hooks/useDevServer";
 import { ConsoleDrawer } from "./ConsoleDrawer";
 import { useIsDragging } from "@/components/DragDrop";
 import { cn } from "@/lib/utils";
-import { shouldAdoptDetectedDevServerUrl } from "./urlSync";
+import { computeDevServerUrl } from "./urlSync";
 import { findDevServerCandidate } from "@/utils/devServerDetection";
 import { useProjectSettings } from "@/hooks/useProjectSettings";
 import { projectClient } from "@/clients";
@@ -288,6 +288,7 @@ export function DevPreviewPane({
   } = useDevPreviewLoadLifecycle({
     webviewElement,
     id,
+    projectId: currentProjectId,
     loadTimeoutMs,
     zoomFactor,
     viewportPreset,
@@ -377,9 +378,10 @@ export function DevPreviewPane({
 
   useEffect(() => {
     if (isUnconfigured) return;
-    if (url && shouldAdoptDetectedDevServerUrl(url, currentUrl)) {
-      setHistory((prev) => pushBrowserHistory(prev, url));
-      lastSetUrlRef.current = url;
+    const nextUrl = url ? computeDevServerUrl(url, currentUrl) : false;
+    if (nextUrl !== false) {
+      setHistory((prev) => pushBrowserHistory(prev, nextUrl));
+      lastSetUrlRef.current = nextUrl;
     }
   }, [url, currentUrl, isUnconfigured]);
 
@@ -730,6 +732,7 @@ export function DevPreviewPane({
       <div className="flex flex-col h-full">
         <BrowserToolbar
           terminalId={id}
+          projectId={currentProjectId}
           url={currentUrl}
           canGoBack={canGoBack}
           canGoForward={canGoForward}

--- a/src/components/DevPreview/__tests__/DevPreviewPane.test.tsx
+++ b/src/components/DevPreview/__tests__/DevPreviewPane.test.tsx
@@ -2,7 +2,7 @@ import { describe, it, expect, beforeEach } from "vitest";
 import type { BrowserHistory } from "@shared/types/browser";
 import type { DevPreviewStatus } from "@/hooks/useDevServer";
 import { normalizeBrowserUrl } from "../../Browser/browserUtils";
-import { shouldAdoptDetectedDevServerUrl } from "../urlSync";
+import { computeDevServerUrl } from "../urlSync";
 
 // ─── Browser History Logic ──────────────────────────────────────────
 // Extracted from DevPreviewPane to enable pure-function testing
@@ -422,25 +422,19 @@ describe("DevPreviewPane", () => {
 
   describe("detected URL adoption", () => {
     it("adopts detected URL when there is no current URL", () => {
-      expect(shouldAdoptDetectedDevServerUrl("http://localhost:5173/", "")).toBe(true);
+      expect(computeDevServerUrl("http://localhost:5173/", "")).toBe("http://localhost:5173/");
     });
 
     it("does not override in-app navigation on same origin", () => {
       expect(
-        shouldAdoptDetectedDevServerUrl(
-          "http://localhost:5173/",
-          "http://localhost:5173/products/42"
-        )
+        computeDevServerUrl("http://localhost:5173/", "http://localhost:5173/products/42")
       ).toBe(false);
     });
 
-    it("adopts detected URL when origin changes", () => {
+    it("grafts the current route onto the new origin when origin changes", () => {
       expect(
-        shouldAdoptDetectedDevServerUrl(
-          "http://localhost:5174/",
-          "http://localhost:5173/products/42"
-        )
-      ).toBe(true);
+        computeDevServerUrl("http://localhost:5174/", "http://localhost:5173/products/42")
+      ).toBe("http://localhost:5174/products/42");
     });
   });
 

--- a/src/components/DevPreview/__tests__/urlSync.test.ts
+++ b/src/components/DevPreview/__tests__/urlSync.test.ts
@@ -1,0 +1,53 @@
+import { describe, it, expect } from "vitest";
+import { computeDevServerUrl } from "../urlSync";
+
+describe("computeDevServerUrl", () => {
+  it("returns false when there is no detected URL", () => {
+    expect(computeDevServerUrl("", "http://localhost:3000/dashboard")).toBe(false);
+  });
+
+  it("returns the bare detected URL when there is no current URL", () => {
+    expect(computeDevServerUrl("http://localhost:3000/", "")).toBe("http://localhost:3000/");
+  });
+
+  it("returns false when detected and current URLs are identical", () => {
+    expect(computeDevServerUrl("http://localhost:3000/x", "http://localhost:3000/x")).toBe(false);
+  });
+
+  it("returns false on the same origin even with a different path", () => {
+    expect(computeDevServerUrl("http://localhost:3000/", "http://localhost:3000/dashboard")).toBe(
+      false
+    );
+  });
+
+  it("grafts the current pathname onto the new origin on a port shift", () => {
+    expect(
+      computeDevServerUrl("http://localhost:3001", "http://localhost:3000/dashboard/settings")
+    ).toBe("http://localhost:3001/dashboard/settings");
+  });
+
+  it("preserves search and hash when grafting onto the new origin", () => {
+    expect(
+      computeDevServerUrl(
+        "http://localhost:3001",
+        "http://localhost:3000/dashboard/settings?tab=x#section"
+      )
+    ).toBe("http://localhost:3001/dashboard/settings?tab=x#section");
+  });
+
+  it("returns the root of the new origin when the current URL has no route", () => {
+    expect(computeDevServerUrl("http://localhost:3001/", "http://localhost:3000/")).toBe(
+      "http://localhost:3001/"
+    );
+  });
+
+  it("falls forward to the detected URL when the current URL cannot be parsed", () => {
+    expect(computeDevServerUrl("http://localhost:3001/", "not-a-url")).toBe(
+      "http://localhost:3001/"
+    );
+  });
+
+  it("falls forward to the detected URL when the detected URL cannot be parsed", () => {
+    expect(computeDevServerUrl("not-a-url", "http://localhost:3000/dashboard")).toBe("not-a-url");
+  });
+});

--- a/src/components/DevPreview/__tests__/urlSync.test.ts
+++ b/src/components/DevPreview/__tests__/urlSync.test.ts
@@ -41,6 +41,24 @@ describe("computeDevServerUrl", () => {
     );
   });
 
+  it("respects a non-root base path the dev server advertises on a port shift", () => {
+    expect(
+      computeDevServerUrl("http://localhost:5174/app/", "http://localhost:5173/dashboard")
+    ).toBe("http://localhost:5174/app/");
+  });
+
+  it("returns a base-path detected URL unchanged when there is no current URL", () => {
+    expect(computeDevServerUrl("http://localhost:5174/app/", "")).toBe(
+      "http://localhost:5174/app/"
+    );
+  });
+
+  it("preserves a hash-router route when grafting onto the new origin", () => {
+    expect(
+      computeDevServerUrl("http://localhost:5174/", "http://localhost:5173/#/settings?tab=auth")
+    ).toBe("http://localhost:5174/#/settings?tab=auth");
+  });
+
   it("falls forward to the detected URL when the current URL cannot be parsed", () => {
     expect(computeDevServerUrl("http://localhost:3001/", "not-a-url")).toBe(
       "http://localhost:3001/"

--- a/src/components/DevPreview/urlSync.ts
+++ b/src/components/DevPreview/urlSync.ts
@@ -9,6 +9,10 @@
  * e.g. 3000 → 3001), the detected URL is the bare server root. Navigating to it
  * directly would drop the route the user was on. To preserve it, the current
  * URL's pathname/search/hash are grafted onto the detected origin.
+ *
+ * If the detected URL itself carries a non-root path (e.g. a Vite `base`
+ * config advertising `http://localhost:5174/app/`), that path is intentional
+ * and is navigated to as-is — grafting only applies to a bare server root.
  */
 export function computeDevServerUrl(detectedUrl: string, currentUrl: string): string | false {
   if (!detectedUrl) return false;
@@ -27,8 +31,13 @@ export function computeDevServerUrl(detectedUrl: string, currentUrl: string): st
 
   if (detected.origin === current.origin) return false;
 
-  // Origin changed (port shift). Graft the user's current route onto the new
-  // origin so a dev-server restart doesn't kick them back to the root.
+  // The detected URL advertises its own non-root path (e.g. a Vite `base`).
+  // Respect it rather than grafting the user's route onto a different base.
+  if (detected.pathname !== "/") return detected.toString();
+
+  // Origin changed (port shift) and the detected URL is a bare root. Graft the
+  // user's current route onto the new origin so a dev-server restart doesn't
+  // kick them back to the root.
   detected.pathname = current.pathname;
   detected.search = current.search;
   detected.hash = current.hash;

--- a/src/components/DevPreview/urlSync.ts
+++ b/src/components/DevPreview/urlSync.ts
@@ -1,12 +1,36 @@
-export function shouldAdoptDetectedDevServerUrl(detectedUrl: string, currentUrl: string): boolean {
+/**
+ * Decides whether a freshly detected dev-server URL should replace the URL the
+ * pane is currently showing, and if so, what URL to navigate to.
+ *
+ * Returns `false` when no adoption is needed (no detected URL, or the detected
+ * URL is the same origin the pane is already on — a port-stable restart).
+ *
+ * When the dev server restarts on a different origin (typically a port shift,
+ * e.g. 3000 → 3001), the detected URL is the bare server root. Navigating to it
+ * directly would drop the route the user was on. To preserve it, the current
+ * URL's pathname/search/hash are grafted onto the detected origin.
+ */
+export function computeDevServerUrl(detectedUrl: string, currentUrl: string): string | false {
   if (!detectedUrl) return false;
-  if (!currentUrl) return true;
+  if (!currentUrl) return detectedUrl;
   if (detectedUrl === currentUrl) return false;
 
+  let detected: URL;
+  let current: URL;
   try {
-    return new URL(detectedUrl).origin !== new URL(currentUrl).origin;
+    detected = new URL(detectedUrl);
+    current = new URL(currentUrl);
   } catch {
-    // Fallback to detected URL if either URL cannot be parsed.
-    return true;
+    // Fall forward to the detected URL if either URL cannot be parsed.
+    return detectedUrl;
   }
+
+  if (detected.origin === current.origin) return false;
+
+  // Origin changed (port shift). Graft the user's current route onto the new
+  // origin so a dev-server restart doesn't kick them back to the root.
+  detected.pathname = current.pathname;
+  detected.search = current.search;
+  detected.hash = current.hash;
+  return detected.toString();
 }

--- a/src/components/DevPreview/useDevPreviewLoadLifecycle.ts
+++ b/src/components/DevPreview/useDevPreviewLoadLifecycle.ts
@@ -1,5 +1,6 @@
 import { useState, useRef, useEffect, useCallback } from "react";
 import { usePanelStore } from "@/store";
+import { useUrlHistoryStore } from "@/store/urlHistoryStore";
 import type { BrowserHistory } from "@shared/types/browser";
 import type { ViewportPresetId } from "@shared/types/panel";
 import { getViewportPreset } from "@/panels/dev-preview/viewportPresets";
@@ -17,6 +18,7 @@ export type DevPreviewBlockedNav = {
 interface UseDevPreviewLoadLifecycleParams {
   webviewElement: Electron.WebviewTag | null;
   id: string;
+  projectId?: string;
   loadTimeoutMs: number;
   zoomFactor: number;
   viewportPreset: ViewportPresetId | undefined;
@@ -43,6 +45,7 @@ interface UseDevPreviewLoadLifecycleResult {
 export function useDevPreviewLoadLifecycle({
   webviewElement,
   id,
+  projectId,
   loadTimeoutMs,
   zoomFactor,
   viewportPreset,
@@ -87,6 +90,18 @@ export function useDevPreviewLoadLifecycle({
       setIsWebviewReady(false);
       return undefined;
     }
+
+    const recordVisit = (navigatedUrl: string) => {
+      if (!projectId) return;
+      if (navigatedUrl === "about:blank") return;
+      let title: string | undefined;
+      try {
+        title = webview.getTitle();
+      } catch {
+        // webview may not be ready for getTitle
+      }
+      useUrlHistoryStore.getState().recordVisit(projectId, navigatedUrl, title);
+    };
 
     const handleDidStartLoading = () => {
       setIsLoading(true);
@@ -254,6 +269,7 @@ export function useDevPreviewLoadLifecycle({
         setHistory((prev) => pushBrowserHistory(prev, navigatedUrl));
         lastSetUrlRef.current = navigatedUrl;
       }
+      recordVisit(navigatedUrl);
     };
 
     const handleDidNavigateInPage = (e: Electron.DidNavigateInPageEvent) => {
@@ -264,6 +280,7 @@ export function useDevPreviewLoadLifecycle({
         setHistory((prev) => pushBrowserHistory(prev, navigatedUrl));
         lastSetUrlRef.current = navigatedUrl;
       }
+      recordVisit(navigatedUrl);
     };
 
     webview.addEventListener("did-start-loading", handleDidStartLoading);
@@ -299,7 +316,15 @@ export function useDevPreviewLoadLifecycle({
         loadTimeoutRef.current = null;
       }
     };
-  }, [webviewElement, loadTimeoutMs, evictingRef, lastSetUrlRef, setHistory, setBlockedNav]);
+  }, [
+    webviewElement,
+    projectId,
+    loadTimeoutMs,
+    evictingRef,
+    lastSetUrlRef,
+    setHistory,
+    setBlockedNav,
+  ]);
 
   useEffect(() => {
     const webview = webviewElement;

--- a/src/components/DevPreview/useDevPreviewLoadLifecycle.ts
+++ b/src/components/DevPreview/useDevPreviewLoadLifecycle.ts
@@ -60,6 +60,12 @@ export function useDevPreviewLoadLifecycle({
   const [isSlowLoad, setIsSlowLoad] = useState(false);
   const [webviewLoadError, setWebviewLoadError] = useState<string | null>(null);
 
+  // Read projectId through a ref so a late project-hydration transition
+  // (undefined → id) doesn't rebind the webview listeners mid-load and clear
+  // the load watchdog timer.
+  const projectIdRef = useRef(projectId);
+  projectIdRef.current = projectId;
+
   const loadTimeoutRef = useRef<NodeJS.Timeout | null>(null);
   const slowLoadTimeoutRef = useRef<NodeJS.Timeout | null>(null);
   const failLoadRetryRef = useRef<NodeJS.Timeout | null>(null);
@@ -92,7 +98,8 @@ export function useDevPreviewLoadLifecycle({
     }
 
     const recordVisit = (navigatedUrl: string) => {
-      if (!projectId) return;
+      const currentProjectId = projectIdRef.current;
+      if (!currentProjectId) return;
       if (navigatedUrl === "about:blank") return;
       let title: string | undefined;
       try {
@@ -100,7 +107,22 @@ export function useDevPreviewLoadLifecycle({
       } catch {
         // webview may not be ready for getTitle
       }
-      useUrlHistoryStore.getState().recordVisit(projectId, navigatedUrl, title);
+      useUrlHistoryStore.getState().recordVisit(currentProjectId, navigatedUrl, title);
+    };
+
+    const handlePageTitleUpdated = (event: Event) => {
+      const detail = event as Event & { title?: string; explicitSet?: boolean };
+      if (detail.explicitSet === false) return;
+      const currentProjectId = projectIdRef.current;
+      if (currentProjectId && detail.title) {
+        try {
+          useUrlHistoryStore
+            .getState()
+            .updateTitle(currentProjectId, webview.getURL(), detail.title);
+        } catch {
+          // webview may be detached
+        }
+      }
     };
 
     const handleDidStartLoading = () => {
@@ -292,6 +314,7 @@ export function useDevPreviewLoadLifecycle({
       "did-navigate-in-page",
       handleDidNavigateInPage as unknown as EventListener
     );
+    webview.addEventListener("page-title-updated", handlePageTitleUpdated);
 
     return () => {
       webview.removeEventListener("did-start-loading", handleDidStartLoading);
@@ -303,6 +326,7 @@ export function useDevPreviewLoadLifecycle({
         "did-navigate-in-page",
         handleDidNavigateInPage as unknown as EventListener
       );
+      webview.removeEventListener("page-title-updated", handlePageTitleUpdated);
       if (failLoadRetryRef.current) {
         clearTimeout(failLoadRetryRef.current);
         failLoadRetryRef.current = null;
@@ -316,15 +340,7 @@ export function useDevPreviewLoadLifecycle({
         loadTimeoutRef.current = null;
       }
     };
-  }, [
-    webviewElement,
-    projectId,
-    loadTimeoutMs,
-    evictingRef,
-    lastSetUrlRef,
-    setHistory,
-    setBlockedNav,
-  ]);
+  }, [webviewElement, loadTimeoutMs, evictingRef, lastSetUrlRef, setHistory, setBlockedNav]);
 
   useEffect(() => {
     const webview = webviewElement;


### PR DESCRIPTION
## Summary

- `BrowserToolbar` now receives `projectId` so frecency URL suggestions populate in the dev-preview pane, matching standalone browser pane behaviour
- `useDevPreviewLoadLifecycle` records visits into `urlHistoryStore` via the existing `did-navigate`/`did-navigate-in-page` handlers (no second listener added), and a new `page-title-updated` listener keeps SPA titles current as the user navigates
- `shouldAdoptDetectedDevServerUrl` renamed to `computeDevServerUrl` and updated to preserve the user's current route on a dev-server port-shift restart by grafting `pathname`, `search`, and `hash` onto the new origin; a non-root base path the server advertises (e.g. Vite `base`) is respected as-is

Resolves #8273

## Changes

- `DevPreviewPane.tsx` — pass `projectId` through to `BrowserToolbar`
- `useDevPreviewLoadLifecycle.ts` — call `urlHistoryStore.addVisit` from existing navigation handlers; add `page-title-updated` listener
- `urlSync.ts` — rename helper, add route-grafting logic, respect advertised base path
- `__tests__/urlSync.test.ts` — 12 new unit cases covering base-path and hash-router scenarios
- `__tests__/DevPreviewPane.test.tsx` — updated for renamed export

## Testing

77 unit tests pass. Full `npm run check` (typecheck, lint 0 errors, format, build) green. Lint ratchet down one error vs develop.