### PR TITLE
feat(dev-preview): gate readiness probe on stdout markers and narrow status range

### DIFF
--- a/electron/services/DevPreviewReadinessProbe.ts
+++ b/electron/services/DevPreviewReadinessProbe.ts
@@ -43,7 +43,7 @@ export async function waitForServerReady(
           (res) => {
             res.resume();
             const status = res.statusCode ?? 0;
-            if (status >= 100 && status < 600) {
+            if (status >= 200 && status < 500) {
               settle(true);
             } else {
               settle(false);

--- a/electron/services/DevPreviewSessionService.ts
+++ b/electron/services/DevPreviewSessionService.ts
@@ -40,6 +40,7 @@ interface DevPreviewSession extends DevPreviewSessionState {
   lastErrorKey: string | null;
   pendingUrl: string | null;
   readinessAbort: AbortController | null;
+  markerSeen: boolean;
   needsInstall: boolean;
   isRunningInstall: boolean;
   installAttemptedGeneration: number | null;
@@ -372,6 +373,7 @@ export class DevPreviewSessionService {
       lastErrorKey: null,
       pendingUrl: null,
       readinessAbort: null,
+      markerSeen: false,
       needsInstall: false,
       isRunningInstall: false,
       installAttemptedGeneration: null,
@@ -491,6 +493,7 @@ export class DevPreviewSessionService {
       session.readinessAbort?.abort();
       session.readinessAbort = null;
       session.pendingUrl = null;
+      session.markerSeen = false;
       session.needsInstall = false;
       session.isRunningInstall = false;
       this.updateSession(session, { terminalId: null, url: null, assignedUrl: null });
@@ -529,6 +532,7 @@ export class DevPreviewSessionService {
 
     session.buffer = "";
     session.lastErrorKey = null;
+    session.markerSeen = false;
     session.assignedUrl = assignedUrl;
     this.attachTerminal(session, terminalId);
     this.updateSession(session, {
@@ -655,6 +659,7 @@ export class DevPreviewSessionService {
     session.readinessAbort?.abort();
     session.readinessAbort = null;
     session.pendingUrl = null;
+    session.markerSeen = false;
     session.needsInstall = false;
     session.isRunningInstall = false;
 
@@ -728,6 +733,7 @@ export class DevPreviewSessionService {
     const result = this.detector.scanOutput(dataString, session.buffer);
     session.buffer = result.buffer;
 
+    let urlJustStarted = false;
     if (result.url && result.url !== session.url && result.url !== session.pendingUrl) {
       markPerformance(PERF_MARKS.DEVPREVIEW_URL_DETECTED, {
         panelId: session.panelId,
@@ -742,6 +748,25 @@ export class DevPreviewSessionService {
       session.pendingUrl = result.url;
 
       this.pollServerReadiness(session, result.url, abort.signal, session.generation);
+      urlJustStarted = true;
+    }
+
+    // A framework readiness line ("ready in N ms", "✓ Ready in", "compiled
+    // successfully") confirms the HTTP server is bound. When a poll is already
+    // mid-cycle (sleeping between HEAD attempts), abort it and re-probe now to
+    // skip the remaining poll interval. The poll itself stays the fallback for
+    // unrecognized frameworks, so no marker means no behavior change.
+    if (
+      result.readyMarker &&
+      !session.markerSeen &&
+      !urlJustStarted &&
+      session.pendingUrl
+    ) {
+      session.markerSeen = true;
+      session.readinessAbort?.abort();
+      const abort = new AbortController();
+      session.readinessAbort = abort;
+      this.pollServerReadiness(session, session.pendingUrl, abort.signal, session.generation);
     }
 
     if (!result.error) return;
@@ -779,6 +804,7 @@ export class DevPreviewSessionService {
     session.readinessAbort?.abort();
     session.readinessAbort = null;
     session.pendingUrl = null;
+    session.markerSeen = false;
 
     this.detachTerminal(session);
     session.buffer = "";

--- a/electron/services/DevPreviewSessionService.ts
+++ b/electron/services/DevPreviewSessionService.ts
@@ -759,12 +759,7 @@ export class DevPreviewSessionService {
     // mid-cycle (sleeping between HEAD attempts), abort it and re-probe now to
     // skip the remaining poll interval. The poll itself stays the fallback for
     // unrecognized frameworks, so no marker means no behavior change.
-    if (
-      result.readyMarker &&
-      !session.markerSeen &&
-      !urlJustStarted &&
-      session.pendingUrl
-    ) {
+    if (result.readyMarker && !session.markerSeen && !urlJustStarted && session.pendingUrl) {
       session.markerSeen = true;
       session.readinessAbort?.abort();
       const abort = new AbortController();

--- a/electron/services/DevPreviewSessionService.ts
+++ b/electron/services/DevPreviewSessionService.ts
@@ -746,6 +746,9 @@ export class DevPreviewSessionService {
       const abort = new AbortController();
       session.readinessAbort = abort;
       session.pendingUrl = result.url;
+      // A new URL (e.g. a port change) starts a fresh poll; allow its own
+      // readiness marker to accelerate it again.
+      session.markerSeen = false;
 
       this.pollServerReadiness(session, result.url, abort.signal, session.generation);
       urlJustStarted = true;
@@ -773,6 +776,14 @@ export class DevPreviewSessionService {
     const errorKey = `${result.error.type}:${result.error.message}`;
     if (errorKey === session.lastErrorKey) return;
     session.lastErrorKey = errorKey;
+
+    // Cancel any in-flight readiness poll: a server that still answers HEAD on
+    // a half-started port would otherwise resolve to "running" and clobber the
+    // error/installing status we are about to set.
+    session.readinessAbort?.abort();
+    session.readinessAbort = null;
+    session.pendingUrl = null;
+    session.markerSeen = false;
 
     if (result.error.type === "missing-dependencies") {
       session.needsInstall = true;

--- a/electron/services/UrlDetector.ts
+++ b/electron/services/UrlDetector.ts
@@ -1,11 +1,27 @@
-import { extractLocalhostUrls } from "../../shared/utils/urlUtils.js";
+import { extractLocalhostUrls, stripAnsiAndOscCodes } from "../../shared/utils/urlUtils.js";
 import { detectDevServerError, type DevServerError } from "../../shared/utils/devServerErrors.js";
 
 export interface ScanResult {
   url: string | null;
   error: DevServerError | null;
   buffer: string;
+  readyMarker: boolean;
 }
+
+// Startup readiness lines printed by common dev servers once the HTTP server is
+// bound and serving. Matched against ANSI/OSC-stripped output so colour-wrapped
+// glyphs (Next.js green ✓, Vite bold) still match.
+const READY_MARKERS: RegExp[] = [
+  // Vite 5–8 (also SvelteKit/Remix/Astro on Vite): "VITE v6.3.1  ready in 312 ms"
+  /VITE\s+v\d+[^\n]*ready\s+in\s+\d+/i,
+  // Next.js 14/15 (Turbopack + webpack): "✓ Ready in 1234ms"
+  /[✓✔]\s+Ready\s+in/u,
+  // Next.js legacy / Windows fallback where the glyph degrades
+  /ready\s+-\s+started\s+server\s+on/i,
+  // webpack-dev-server / CRA / webpack-dev-middleware
+  /webpack\s+compiled\s+successfully/i,
+  /\[webpack-dev-middleware\]\s+compiled\s+successfully/i,
+];
 
 export class UrlDetector {
   scanOutput(data: string, buffer: string): ScanResult {
@@ -25,10 +41,14 @@ export class UrlDetector {
     const preferredUrl = urls.length > 0 ? this.selectPreferredUrl(urls) : null;
     const error = detectDevServerError(newBuffer);
 
+    const strippedChunk = stripAnsiAndOscCodes(data);
+    const readyMarker = READY_MARKERS.some((pattern) => pattern.test(strippedChunk));
+
     return {
       url: preferredUrl,
       error,
       buffer: newBuffer,
+      readyMarker,
     };
   }
 

--- a/electron/services/__tests__/DevPreviewReadinessProbe.test.ts
+++ b/electron/services/__tests__/DevPreviewReadinessProbe.test.ts
@@ -37,6 +37,17 @@ function mockSuccessResponse() {
   return req;
 }
 
+function mockResponseWithStatus(statusCode: number) {
+  const req: MockRequest = { on: vi.fn(), end: vi.fn(), destroy: vi.fn() };
+  mockRequest.mockImplementation(
+    (_url: string, _options: Record<string, unknown>, callback: RequestCallback) => {
+      callback({ statusCode, resume: vi.fn() });
+      return req;
+    }
+  );
+  return req;
+}
+
 function mockConnectionRefused() {
   const req: MockRequest = { on: vi.fn(), end: vi.fn(), destroy: vi.fn() };
   mockRequest.mockImplementation(
@@ -84,6 +95,22 @@ describe("waitForServerReady", () => {
     const signal = new AbortController().signal;
     const result = await waitForServerReady("http://localhost:3000", signal, 100);
     expect(result).toBe(false);
+  });
+
+  describe("accepted status range (200–499)", () => {
+    it.each([200, 204, 301, 401, 404, 499])("returns true on HTTP %i", async (status) => {
+      mockResponseWithStatus(status);
+      const signal = new AbortController().signal;
+      const result = await waitForServerReady("http://localhost:3000", signal, 100);
+      expect(result).toBe(true);
+    });
+
+    it.each([100, 199, 500, 502, 503, 599])("returns false on HTTP %i", async (status) => {
+      mockResponseWithStatus(status);
+      const signal = new AbortController().signal;
+      const result = await waitForServerReady("http://localhost:3000", signal, 100);
+      expect(result).toBe(false);
+    });
   });
 });
 

--- a/electron/services/__tests__/DevPreviewSessionService.adversarial.test.ts
+++ b/electron/services/__tests__/DevPreviewSessionService.adversarial.test.ts
@@ -406,6 +406,90 @@ describe("DevPreviewSessionService adversarial", () => {
     expect(finalState.url).toBe("http://localhost:3000/");
   });
 
+  it("aborts the readiness poll when an error is detected so it cannot overwrite the error state", async () => {
+    let failHead = true;
+    const impl = ((_: unknown, __: unknown, cb: (res: MockIncomingMessage) => void) => {
+      const req: MockRequest = {
+        on: (event, handler) => {
+          if (event === "error" && failHead) {
+            setTimeout(() => handler(new Error("ECONNREFUSED")), 0);
+          }
+          return req;
+        },
+        end: () => {
+          if (!failHead) cb({ statusCode: 200, resume: () => {} });
+        },
+        destroy: () => {},
+      };
+      return req;
+    }) as unknown as typeof http.request;
+    vi.mocked(http.request).mockImplementation(impl);
+
+    scanOutputMock.mockImplementation((data, buffer) => {
+      if (data.includes("http://localhost")) return { buffer, url: "http://localhost:3000/" };
+      if (data.includes("missing deps")) {
+        return {
+          buffer,
+          error: { type: "missing-dependencies", message: "Install dependencies first" },
+        };
+      }
+      return { buffer };
+    });
+
+    const started = await service.ensure(baseRequest);
+    ptyClient.emitData(started.terminalId!, "Local: http://localhost:3000/");
+    await vi.advanceTimersByTimeAsync(10); // first HEAD fails, poll enters its sleep
+
+    ptyClient.emitData(started.terminalId!, "missing deps");
+    // HEAD would now succeed — but the error detection must have aborted the
+    // poll, so it can never flip the session back to "running".
+    failHead = false;
+    await vi.advanceTimersByTimeAsync(1000);
+
+    const state = service.getState({
+      panelId: baseRequest.panelId,
+      projectId: baseRequest.projectId,
+    });
+    expect(state.status).toBe("installing");
+  });
+
+  it("lets a fresh URL's readiness marker accelerate again after a prior marker", async () => {
+    const impl = ((_: unknown, __: unknown, _cb: (res: MockIncomingMessage) => void) => {
+      const req: MockRequest = {
+        on: (event, handler) => {
+          if (event === "error") setTimeout(() => handler(new Error("ECONNREFUSED")), 0);
+          return req;
+        },
+        end: () => {},
+        destroy: () => {},
+      };
+      return req;
+    }) as unknown as typeof http.request;
+    vi.mocked(http.request).mockImplementation(impl);
+
+    scanOutputMock.mockImplementation((data, buffer) => {
+      if (data.includes("localhost:3001")) return { buffer, url: "http://localhost:3001/" };
+      if (data.includes("localhost:3000")) return { buffer, url: "http://localhost:3000/" };
+      if (data.includes("ready in")) return { buffer, readyMarker: true };
+      return { buffer };
+    });
+
+    const started = await service.ensure(baseRequest);
+    ptyClient.emitData(started.terminalId!, "Local: http://localhost:3000/");
+    await vi.advanceTimersByTimeAsync(10);
+    ptyClient.emitData(started.terminalId!, "VITE v6.0.0  ready in 200 ms");
+    await vi.advanceTimersByTimeAsync(10);
+
+    // Port change → new poll. markerSeen must reset so the new ready line
+    // accelerates the new poll too.
+    ptyClient.emitData(started.terminalId!, "Port in use, switching to http://localhost:3001/");
+    await vi.advanceTimersByTimeAsync(10);
+    const callsBeforeSecondMarker = vi.mocked(http.request).mock.calls.length;
+    ptyClient.emitData(started.terminalId!, "VITE v6.0.0  ready in 180 ms");
+    await vi.advanceTimersByTimeAsync(10);
+    expect(vi.mocked(http.request).mock.calls.length).toBeGreaterThan(callsBeforeSecondMarker);
+  });
+
   it("suppresses late state changes after dispose while stop is still waiting for the terminal to die", async () => {
     const started = await service.ensure(baseRequest);
     const terminalId = started.terminalId!;

--- a/electron/services/__tests__/DevPreviewSessionService.adversarial.test.ts
+++ b/electron/services/__tests__/DevPreviewSessionService.adversarial.test.ts
@@ -9,7 +9,12 @@ const scanOutputMock = vi.hoisted(() =>
     (
       data: string,
       buffer: string
-    ) => { buffer: string; url?: string; error?: { type: string; message: string } }
+    ) => {
+      buffer: string;
+      url?: string;
+      error?: { type: string; message: string };
+      readyMarker?: boolean;
+    }
   >()
 );
 
@@ -343,6 +348,62 @@ describe("DevPreviewSessionService adversarial", () => {
         state.status === "error" && state.error?.message === "Port 3000 is already in use"
     );
     expect(errorStates).toHaveLength(1);
+  });
+
+  it("re-probes immediately when a readiness marker arrives during the poll interval", async () => {
+    // Every HEAD attempt fails, so the readiness poll stays in its sleep
+    // window between attempts and never resolves on its own.
+    const impl = ((_: unknown, __: unknown, _cb: (res: MockIncomingMessage) => void) => {
+      const req: MockRequest = {
+        on: (event, handler) => {
+          if (event === "error") setTimeout(() => handler(new Error("ECONNREFUSED")), 0);
+          return req;
+        },
+        end: () => {},
+        destroy: () => {},
+      };
+      return req;
+    }) as unknown as typeof http.request;
+    vi.mocked(http.request).mockImplementation(impl);
+
+    scanOutputMock.mockImplementation((data, buffer) => {
+      if (data.includes("http://localhost")) return { buffer, url: "http://localhost:3000/" };
+      if (data.includes("ready in")) return { buffer, readyMarker: true };
+      return { buffer };
+    });
+
+    const started = await service.ensure(baseRequest);
+    ptyClient.emitData(started.terminalId!, "Local: http://localhost:3000/");
+    await vi.advanceTimersByTimeAsync(10);
+    const callsAfterUrl = vi.mocked(http.request).mock.calls.length;
+    expect(callsAfterUrl).toBeGreaterThanOrEqual(1);
+
+    // Marker arrives well before the 500ms poll interval would retry — the
+    // fast-path must abort the sleeping poll and re-probe right away.
+    ptyClient.emitData(started.terminalId!, "VITE v6.0.0  ready in 200 ms");
+    await vi.advanceTimersByTimeAsync(10);
+    expect(vi.mocked(http.request).mock.calls.length).toBeGreaterThan(callsAfterUrl);
+  });
+
+  it("handles a readiness marker that arrives before the URL without breaking startup", async () => {
+    scanOutputMock.mockImplementation((data, buffer) => {
+      if (data.includes("ready in")) return { buffer, readyMarker: true };
+      if (data.includes("http://localhost")) return { buffer, url: "http://localhost:3000/" };
+      return { buffer };
+    });
+
+    const started = await service.ensure(baseRequest);
+    ptyClient.emitData(started.terminalId!, "VITE v6.0.0  ready in 200 ms");
+    await vi.advanceTimersByTimeAsync(10);
+    ptyClient.emitData(started.terminalId!, "Local: http://localhost:3000/");
+    await vi.advanceTimersByTimeAsync(10);
+
+    const finalState = service.getState({
+      panelId: baseRequest.panelId,
+      projectId: baseRequest.projectId,
+    });
+    expect(finalState.status).toBe("running");
+    expect(finalState.url).toBe("http://localhost:3000/");
   });
 
   it("suppresses late state changes after dispose while stop is still waiting for the terminal to die", async () => {

--- a/electron/services/__tests__/DevPreviewSessionService.test.ts
+++ b/electron/services/__tests__/DevPreviewSessionService.test.ts
@@ -359,8 +359,32 @@ describe("DevPreviewSessionService", () => {
     });
   });
 
-  it("treats HTTP 5xx responses as ready once the server is reachable", async () => {
-    mockHttpResponse(500);
+  it("does not treat HTTP 5xx responses as ready", async () => {
+    vi.useFakeTimers();
+    mockHttpResponse(503);
+
+    const started = await service.ensure(baseRequest);
+    expect(started.terminalId).toBeTruthy();
+
+    ptyClient.emitData(started.terminalId!, "ready at http://localhost:4173\n");
+
+    const during = service.getState({
+      panelId: baseRequest.panelId,
+      projectId: baseRequest.projectId,
+    });
+    expect(during.status).toBe("starting");
+
+    await vi.advanceTimersByTimeAsync(31_000);
+
+    const after = service.getState({
+      panelId: baseRequest.panelId,
+      projectId: baseRequest.projectId,
+    });
+    expect(after.status).toBe("error");
+  });
+
+  it("treats HTTP 4xx responses as ready (server is reachable)", async () => {
+    mockHttpResponse(404);
 
     const started = await service.ensure(baseRequest);
     expect(started.terminalId).toBeTruthy();

--- a/electron/services/__tests__/UrlDetector.test.ts
+++ b/electron/services/__tests__/UrlDetector.test.ts
@@ -319,5 +319,60 @@ describe("UrlDetector", () => {
         expect(result2.url).toBeNull();
       });
     });
+
+    describe("readiness markers", () => {
+      it("detects the Vite ready line", () => {
+        const result = detector.scanOutput("  VITE v5.4.0  ready in 312 ms", "");
+        expect(result.readyMarker).toBe(true);
+      });
+
+      it("detects the Vite ready line for Vite 8", () => {
+        const result = detector.scanOutput("  VITE v8.0.1  ready in 87 ms", "");
+        expect(result.readyMarker).toBe(true);
+      });
+
+      it("detects the Vite ready line wrapped in ANSI colour codes", () => {
+        const withAnsi = "\x1b[36m  VITE v6.3.1\x1b[39m  \x1b[32mready in 456 ms\x1b[0m";
+        const result = detector.scanOutput(withAnsi, "");
+        expect(result.readyMarker).toBe(true);
+      });
+
+      it("detects the Next.js checkmark ready line", () => {
+        const result = detector.scanOutput("\x1b[32m✓\x1b[0m Ready in 1843ms", "");
+        expect(result.readyMarker).toBe(true);
+      });
+
+      it("detects the Next.js legacy 'started server on' line", () => {
+        const result = detector.scanOutput(
+          "ready - started server on 0.0.0.0:3000, url: http://localhost:3000",
+          ""
+        );
+        expect(result.readyMarker).toBe(true);
+      });
+
+      it("detects the webpack compiled-successfully line", () => {
+        const result = detector.scanOutput("webpack compiled successfully", "");
+        expect(result.readyMarker).toBe(true);
+      });
+
+      it("detects the webpack-dev-middleware compiled line", () => {
+        const result = detector.scanOutput(
+          "[webpack-dev-middleware] Compiled successfully in 1203 ms",
+          ""
+        );
+        expect(result.readyMarker).toBe(true);
+      });
+
+      it("returns false for unrelated output", () => {
+        const result = detector.scanOutput("Compiling routes and warming the cache...", "");
+        expect(result.readyMarker).toBe(false);
+      });
+
+      it("returns false on a URL-only line (no regression)", () => {
+        const result = detector.scanOutput("Server at http://localhost:3000", "");
+        expect(result.readyMarker).toBe(false);
+        expect(result.url).toBe("http://localhost:3000/");
+      });
+    });
   });
 });


### PR DESCRIPTION
## Summary

- Narrows the accepted HTTP status range in `DevPreviewReadinessProbe.ts` from `100-599` to `200-499`. 1xx informational responses and 5xx server errors are no longer treated as ready — a Next.js compiling shell returning 500 no longer triggers the running state. 4xx stays accepted: a 401-gated or 404-routing server is alive and routing, which is the signal we care about.
- Adds stdout readiness-marker detection to `UrlDetector.ts` for Vite (`ready in N ms`), Next.js (`✓ Ready in`), and webpack-dev-server (`compiled successfully`). Markers are matched against ANSI-stripped output. When a marker fires, one confirming HEAD is issued and the probe resolves immediately rather than waiting out the 500ms poll interval. Frameworks without a recognised marker fall back to the existing polling loop unchanged.
- Fixes a pre-existing race where an error detected in `handleData` didn't cancel an in-flight readiness poll, allowing it to overwrite `error`/`installing` state with `running`.

Resolves #8280.

## Changes

- `DevPreviewReadinessProbe.ts` — status range narrowed to `200-499`
- `UrlDetector.ts` — readiness-marker regexes + marker fast-path that reuses the existing `pollServerReadiness` generation/`AbortController` guards; `markerSeen` flag reset on URL change
- 115 unit tests across the four dev-preview suites; `npm run check` green