### PR TITLE
feat(dev-preview): polish empty state with detection badge and picker

### DIFF
--- a/src/components/DevPreview/DevPreviewEmptyState.tsx
+++ b/src/components/DevPreview/DevPreviewEmptyState.tsx
@@ -2,8 +2,17 @@ import { useState, useCallback, type KeyboardEvent } from "react";
 import { Settings, WandSparkles, ChevronDown, Play } from "lucide-react";
 import { Button } from "@/components/ui/button";
 import { Popover, PopoverTrigger, PopoverContent } from "@/components/ui/popover";
-import { SHELL_CONTROL_RE } from "@/utils/devServerDetection";
 import type { RunCommand } from "@shared/types";
+
+// Mirrors the backend enforcement contract in
+// electron/services/DevPreviewCommandNormalizer.ts (getInvalidCommandMessage):
+// only blank and multi-line commands are rejected. Compound shell commands
+// (e.g. `cd apps/web && npm run dev`) are valid and run fine — the manual
+// input must not be stricter than the canonical Project Settings input.
+function isManualCommandInvalid(command: string): boolean {
+  const trimmed = command.trim();
+  return trimmed.length === 0 || /[\n\r]/.test(trimmed);
+}
 
 interface DevPreviewEmptyStateProps {
   /** True when the project has no dev command configured (first-run). */
@@ -39,9 +48,7 @@ export function DevPreviewEmptyState({
   const [isPickerOpen, setIsPickerOpen] = useState(false);
   const [manualCommand, setManualCommand] = useState("");
 
-  const trimmedManual = manualCommand.trim();
-  const isManualInvalid =
-    trimmedManual.length === 0 || SHELL_CONTROL_RE.test(trimmedManual) || isSavingManual;
+  const isManualInvalid = isManualCommandInvalid(manualCommand) || isSavingManual;
 
   const handleSelect = useCallback(
     (runner: RunCommand) => {
@@ -52,11 +59,11 @@ export function DevPreviewEmptyState({
   );
 
   const submitManual = useCallback(() => {
-    if (trimmedManual.length === 0 || SHELL_CONTROL_RE.test(trimmedManual) || isSavingManual) {
+    if (isManualCommandInvalid(manualCommand) || isSavingManual) {
       return;
     }
-    onManualSubmit(trimmedManual);
-  }, [trimmedManual, isSavingManual, onManualSubmit]);
+    onManualSubmit(manualCommand.trim());
+  }, [manualCommand, isSavingManual, onManualSubmit]);
 
   const handleManualKeyDown = useCallback(
     (e: KeyboardEvent<HTMLInputElement>) => {
@@ -177,11 +184,6 @@ export function DevPreviewEmptyState({
           disabled={isManualInvalid}
           size="sm"
           className="gap-1.5 shrink-0"
-          title={
-            trimmedManual.length > 0 && SHELL_CONTROL_RE.test(trimmedManual)
-              ? "Command contains shell control characters"
-              : undefined
-          }
         >
           <Play className="h-3.5 w-3.5" />
           <span className="text-xs">{isSavingManual ? "Starting…" : "Start server"}</span>

--- a/src/components/DevPreview/DevPreviewEmptyState.tsx
+++ b/src/components/DevPreview/DevPreviewEmptyState.tsx
@@ -1,0 +1,202 @@
+import { useState, useCallback, type KeyboardEvent } from "react";
+import { Settings, WandSparkles, ChevronDown, Play } from "lucide-react";
+import { Button } from "@/components/ui/button";
+import { Popover, PopoverTrigger, PopoverContent } from "@/components/ui/popover";
+import { SHELL_CONTROL_RE } from "@/utils/devServerDetection";
+import type { RunCommand } from "@shared/types";
+
+interface DevPreviewEmptyStateProps {
+  /** True when the project has no dev command configured (first-run). */
+  isUnconfigured: boolean;
+  /** The inferred dev-server candidate (priority script or devcontainer fallback). */
+  detectedCandidate: RunCommand | undefined;
+  /** Full list of detected runners, surfaced behind the picker. */
+  allDetectedRunners: RunCommand[] | undefined;
+  isAutoDetecting: boolean;
+  isSettingsLoading: boolean;
+  isSavingManual: boolean;
+  /** Primary CTA — re-detects and saves with autoDetected=true. */
+  onAutoDetect: () => void;
+  /** Picker selection — saves the chosen runner with autoDetected=false. */
+  onSelectRunner: (runner: RunCommand) => void;
+  /** No-candidate branch — saves the typed command with autoDetected=false. */
+  onManualSubmit: (command: string) => void;
+  onOpenSettings: () => void;
+}
+
+export function DevPreviewEmptyState({
+  isUnconfigured,
+  detectedCandidate,
+  allDetectedRunners,
+  isAutoDetecting,
+  isSettingsLoading,
+  isSavingManual,
+  onAutoDetect,
+  onSelectRunner,
+  onManualSubmit,
+  onOpenSettings,
+}: DevPreviewEmptyStateProps) {
+  const [isPickerOpen, setIsPickerOpen] = useState(false);
+  const [manualCommand, setManualCommand] = useState("");
+
+  const trimmedManual = manualCommand.trim();
+  const isManualInvalid =
+    trimmedManual.length === 0 || SHELL_CONTROL_RE.test(trimmedManual) || isSavingManual;
+
+  const handleSelect = useCallback(
+    (runner: RunCommand) => {
+      setIsPickerOpen(false);
+      onSelectRunner(runner);
+    },
+    [onSelectRunner]
+  );
+
+  const submitManual = useCallback(() => {
+    if (trimmedManual.length === 0 || SHELL_CONTROL_RE.test(trimmedManual) || isSavingManual) {
+      return;
+    }
+    onManualSubmit(trimmedManual);
+  }, [trimmedManual, isSavingManual, onManualSubmit]);
+
+  const handleManualKeyDown = useCallback(
+    (e: KeyboardEvent<HTMLInputElement>) => {
+      if (e.key === "Enter") {
+        e.preventDefault();
+        submitManual();
+      }
+    },
+    [submitManual]
+  );
+
+  if (!isUnconfigured) {
+    return (
+      <div className="flex flex-col items-center text-center max-w-md">
+        <h3 className="text-sm font-medium text-daintree-text/70 mb-1">Waiting for dev server</h3>
+        <p className="text-xs text-daintree-text/50 leading-relaxed">
+          The dev server will appear here once it starts and a URL is detected
+        </p>
+      </div>
+    );
+  }
+
+  if (detectedCandidate) {
+    const pickerRunners = allDetectedRunners ?? [];
+    return (
+      <div className="flex flex-col items-center text-center max-w-md">
+        <h3 className="text-sm font-medium text-daintree-text/70 mb-1">Start the dev server</h3>
+        <p className="text-xs text-daintree-text/50 mb-4 leading-relaxed">
+          No dev command is set for this project yet
+        </p>
+
+        <div className="mb-4 inline-flex items-center gap-2 rounded-[var(--radius-md)] border border-daintree-border bg-overlay-subtle px-2.5 py-1.5">
+          <span className="font-mono text-xs text-daintree-text/80">
+            {detectedCandidate.command}
+          </span>
+          {/* TODO(#8266): render detected port here once port extraction lands */}
+        </div>
+
+        <div className="flex flex-col items-center gap-2">
+          <Button
+            onClick={onAutoDetect}
+            disabled={isAutoDetecting || isSettingsLoading}
+            size="sm"
+            className="gap-1.5"
+          >
+            <WandSparkles className="h-3.5 w-3.5" />
+            <span className="text-xs">
+              {isAutoDetecting ? "Starting…" : "Start the dev server"}
+            </span>
+          </Button>
+
+          {pickerRunners.length > 1 && (
+            <Popover open={isPickerOpen} onOpenChange={setIsPickerOpen}>
+              <PopoverTrigger asChild>
+                <button
+                  type="button"
+                  className="inline-flex items-center gap-1 text-xs text-daintree-text/50 hover:text-daintree-text/70 transition-colors"
+                >
+                  Use a different script…
+                  <ChevronDown className="h-3 w-3" />
+                </button>
+              </PopoverTrigger>
+              <PopoverContent align="center" className="w-64 p-1">
+                <div className="max-h-48 overflow-y-auto">
+                  {pickerRunners.map((runner) => (
+                    <button
+                      key={runner.id}
+                      type="button"
+                      onClick={() => handleSelect(runner)}
+                      className="flex w-full flex-col items-start gap-0.5 rounded-[var(--radius-sm)] px-2 py-1.5 text-left hover:bg-overlay-subtle transition-colors"
+                    >
+                      <span className="text-xs text-daintree-text/80">{runner.name}</span>
+                      <span className="font-mono text-[11px] text-daintree-text/50">
+                        {runner.command}
+                      </span>
+                    </button>
+                  ))}
+                </div>
+              </PopoverContent>
+            </Popover>
+          )}
+
+          <Button
+            onClick={onOpenSettings}
+            variant="ghost"
+            size="sm"
+            className="gap-1.5 px-2.5 py-1.5 group text-daintree-text/40 hover:text-daintree-text/60"
+          >
+            <Settings className="h-3.5 w-3.5" />
+            <span className="text-xs">Open project settings</span>
+          </Button>
+        </div>
+      </div>
+    );
+  }
+
+  return (
+    <div className="flex flex-col items-center text-center max-w-md">
+      <h3 className="text-sm font-medium text-daintree-text/70 mb-1">Set a dev command</h3>
+      <p className="text-xs text-daintree-text/50 mb-4 leading-relaxed">
+        Enter the command that starts your dev server
+      </p>
+
+      <div className="flex w-full max-w-xs items-center gap-2">
+        <input
+          type="text"
+          value={manualCommand}
+          onChange={(e) => setManualCommand(e.target.value)}
+          onKeyDown={handleManualKeyDown}
+          placeholder="npm run dev"
+          spellCheck={false}
+          autoComplete="off"
+          aria-label="Dev server command"
+          className="min-w-0 flex-1 rounded-[var(--radius-md)] border border-daintree-border bg-surface-canvas px-3 py-1.5 font-mono text-xs text-daintree-text placeholder:text-daintree-text/40 focus-visible:outline focus-visible:outline-2 focus-visible:outline-daintree-accent focus-visible:outline-offset-1"
+        />
+        <Button
+          onClick={submitManual}
+          disabled={isManualInvalid}
+          size="sm"
+          className="gap-1.5 shrink-0"
+          title={
+            trimmedManual.length > 0 && SHELL_CONTROL_RE.test(trimmedManual)
+              ? "Command contains shell control characters"
+              : undefined
+          }
+        >
+          <Play className="h-3.5 w-3.5" />
+          <span className="text-xs">{isSavingManual ? "Starting…" : "Start server"}</span>
+        </Button>
+      </div>
+
+      <Button
+        onClick={onOpenSettings}
+        variant="ghost"
+        size="sm"
+        className="mt-3 gap-1.5 px-2.5 py-1.5 group text-daintree-text/40 hover:text-daintree-text/60"
+      >
+        <Settings className="h-3.5 w-3.5" />
+        <span className="text-xs">Open project settings</span>
+      </Button>
+    </div>
+  );
+}

--- a/src/components/DevPreview/DevPreviewPane.tsx
+++ b/src/components/DevPreview/DevPreviewPane.tsx
@@ -4,9 +4,7 @@ import {
   AlertTriangle,
   RotateCw,
   ExternalLink,
-  Settings,
   Square,
-  WandSparkles,
   OctagonAlert,
 } from "lucide-react";
 import { Spinner } from "@/components/ui/Spinner";
@@ -31,6 +29,8 @@ import { useIsDragging } from "@/components/DragDrop";
 import { cn } from "@/lib/utils";
 import { computeDevServerUrl } from "./urlSync";
 import { findDevServerCandidate } from "@/utils/devServerDetection";
+import { DevPreviewEmptyState } from "./DevPreviewEmptyState";
+import type { RunCommand } from "@shared/types";
 import { useProjectSettings } from "@/hooks/useProjectSettings";
 import { projectClient } from "@/clients";
 import { actionService } from "@/services/ActionService";
@@ -379,6 +379,7 @@ export function DevPreviewPane({
   // Store the original guest UA so we can restore it when clearing a preset
   const originalUaRef = useRef<string | null>(null);
   const [isAutoDetecting, setIsAutoDetecting] = useState(false);
+  const [isSavingManual, setIsSavingManual] = useState(false);
   const { saveSettings } = useProjectSettings();
   const allDetectedRunners = useProjectSettingsStore((state) => state.allDetectedRunners);
   const isSettingsLoading = useProjectSettingsStore((state) => state.isLoading);
@@ -394,6 +395,13 @@ export function DevPreviewPane({
   const canGoForward = history.future.length > 0;
   const isUnconfigured =
     Boolean(currentProjectId) && !isSettingsLoading && projectSettings !== null && !devCommand;
+
+  const turbopackEnabled = projectSettings?.turbopackEnabled ?? true;
+  const detectedCandidate = useMemo(() => {
+    const candidate = findDevServerCandidate(allDetectedRunners, turbopackEnabled);
+    if (candidate) return candidate;
+    return allDetectedRunners?.find((r) => r.id === "devcontainer-poststart");
+  }, [allDetectedRunners, turbopackEnabled]);
 
   const { isEvicted, evictingRef } = useWebviewEviction(id, location);
 
@@ -751,32 +759,36 @@ export function DevPreviewPane({
     [currentProjectId, id]
   );
 
+  const persistDevServerCommand = useCallback(
+    async (command: string, autoDetected: boolean) => {
+      if (!currentProjectId) return;
+      const latestSettings = await projectClient.getSettings(currentProjectId);
+      if (!latestSettings) return;
+      await saveSettings({
+        ...latestSettings,
+        devServerCommand: command,
+        devServerAutoDetected: autoDetected,
+        devServerDismissed: false,
+      });
+    },
+    [currentProjectId, saveSettings]
+  );
+
   const handleAutoDetect = useCallback(async () => {
     if (!currentProjectId || isAutoDetecting) return;
 
     setIsAutoDetecting(true);
     try {
       const freshRunners = await projectClient.detectRunners(currentProjectId);
-      const candidate = findDevServerCandidate(
-        freshRunners,
-        projectSettings?.turbopackEnabled ?? true
-      );
+      const candidate =
+        findDevServerCandidate(freshRunners, turbopackEnabled) ??
+        freshRunners?.find((r) => r.id === "devcontainer-poststart");
 
       if (!candidate) {
         return;
       }
 
-      const latestSettings = await projectClient.getSettings(currentProjectId);
-      if (!latestSettings) {
-        return;
-      }
-
-      await saveSettings({
-        ...latestSettings,
-        devServerCommand: candidate.command,
-        devServerAutoDetected: true,
-        devServerDismissed: false,
-      });
+      await persistDevServerCommand(candidate.command, true);
     } catch (err) {
       logError("Failed to auto-detect dev server", err);
     } finally {
@@ -784,7 +796,39 @@ export function DevPreviewPane({
         setIsAutoDetecting(false);
       }
     }
-  }, [currentProjectId, isAutoDetecting, saveSettings, projectSettings?.turbopackEnabled]);
+  }, [currentProjectId, isAutoDetecting, persistDevServerCommand, turbopackEnabled]);
+
+  const handleSelectRunner = useCallback(
+    (runner: RunCommand) => {
+      void (async () => {
+        try {
+          await persistDevServerCommand(runner.command, false);
+        } catch (err) {
+          logError("Failed to apply selected dev server script", err);
+        }
+      })();
+    },
+    [persistDevServerCommand]
+  );
+
+  const handleManualSubmit = useCallback(
+    (command: string) => {
+      if (isSavingManual) return;
+      setIsSavingManual(true);
+      void (async () => {
+        try {
+          await persistDevServerCommand(command, false);
+        } catch (err) {
+          logError("Failed to save manual dev server command", err);
+        } finally {
+          if (isMountedRef.current) {
+            setIsSavingManual(false);
+          }
+        }
+      })();
+    },
+    [isSavingManual, persistDevServerCommand]
+  );
 
   const handleOpenSettings = useCallback(() => {
     void actionService.dispatch("project.settings.open", undefined, { source: "user" });
@@ -1125,63 +1169,18 @@ export function DevPreviewPane({
             </div>
           ) : !currentUrl || status !== "running" ? (
             <div className="absolute inset-0 flex flex-col items-center justify-center bg-daintree-bg text-daintree-text p-6">
-              {isUnconfigured ? (
-                <div className="flex flex-col items-center text-center max-w-md">
-                  <h3 className="text-sm font-medium text-daintree-text/70 mb-1">
-                    Configure dev server
-                  </h3>
-                  <p className="text-xs text-daintree-text/50 mb-4 leading-relaxed">
-                    No dev server command is configured for this project.
-                    {allDetectedRunners &&
-                    findDevServerCandidate(
-                      allDetectedRunners,
-                      projectSettings?.turbopackEnabled ?? true
-                    )
-                      ? " We found a script in your package.json that looks like a dev server."
-                      : " Configure one to preview your application."}
-                  </p>
-                  <div className="flex flex-col items-center gap-2">
-                    {allDetectedRunners &&
-                      findDevServerCandidate(
-                        allDetectedRunners,
-                        projectSettings?.turbopackEnabled ?? true
-                      ) && (
-                        <Button
-                          onClick={handleAutoDetect}
-                          disabled={isAutoDetecting || isSettingsLoading}
-                          variant="ghost"
-                          size="sm"
-                          className="gap-1.5 px-2.5 py-1.5 group"
-                        >
-                          <WandSparkles className="h-3.5 w-3.5" />
-                          <span className="text-xs">
-                            {isAutoDetecting
-                              ? "Detecting..."
-                              : `Use \`${findDevServerCandidate(allDetectedRunners, projectSettings?.turbopackEnabled ?? true)?.command}\``}
-                          </span>
-                        </Button>
-                      )}
-                    <Button
-                      onClick={handleOpenSettings}
-                      variant="ghost"
-                      size="sm"
-                      className="gap-1.5 px-2.5 py-1.5 group text-daintree-text/50 hover:text-daintree-text/70"
-                    >
-                      <Settings className="h-3.5 w-3.5" />
-                      <span className="text-xs">Open Project Settings</span>
-                    </Button>
-                  </div>
-                </div>
-              ) : (
-                <div className="flex flex-col items-center text-center max-w-md">
-                  <h3 className="text-sm font-medium text-daintree-text/70 mb-1">
-                    Waiting for dev server
-                  </h3>
-                  <p className="text-xs text-daintree-text/50 mb-4 leading-relaxed">
-                    The development server will appear here once it starts and a URL is detected.
-                  </p>
-                </div>
-              )}
+              <DevPreviewEmptyState
+                isUnconfigured={isUnconfigured}
+                detectedCandidate={detectedCandidate}
+                allDetectedRunners={allDetectedRunners}
+                isAutoDetecting={isAutoDetecting}
+                isSettingsLoading={isSettingsLoading}
+                isSavingManual={isSavingManual}
+                onAutoDetect={handleAutoDetect}
+                onSelectRunner={handleSelectRunner}
+                onManualSubmit={handleManualSubmit}
+                onOpenSettings={handleOpenSettings}
+              />
             </div>
           ) : !hasBeenVisible ? (
             <div className="absolute inset-0 flex flex-col items-center justify-center bg-daintree-bg text-daintree-text">

--- a/src/components/DevPreview/DevPreviewPane.tsx
+++ b/src/components/DevPreview/DevPreviewPane.tsx
@@ -785,6 +785,10 @@ export function DevPreviewPane({
         freshRunners?.find((r) => r.id === "devcontainer-poststart");
 
       if (!candidate) {
+        logError(
+          "Dev server auto-detect produced no candidate",
+          new Error("No dev script or devcontainer-poststart runner found on re-detection")
+        );
         return;
       }
 

--- a/src/components/DevPreview/__tests__/DevPreviewEmptyState.test.tsx
+++ b/src/components/DevPreview/__tests__/DevPreviewEmptyState.test.tsx
@@ -6,12 +6,7 @@ import type { RunCommand } from "@shared/types";
 vi.mock("@/lib/utils", () => ({ cn: (...args: unknown[]) => args.filter(Boolean).join(" ") }));
 
 vi.mock("@/components/ui/button", () => ({
-  Button: ({
-    children,
-    onClick,
-    disabled,
-    title,
-  }: React.ComponentProps<"button">) => (
+  Button: ({ children, onClick, disabled, title }: React.ComponentProps<"button">) => (
     <button onClick={onClick} disabled={disabled} title={title}>
       {children}
     </button>

--- a/src/components/DevPreview/__tests__/DevPreviewEmptyState.test.tsx
+++ b/src/components/DevPreview/__tests__/DevPreviewEmptyState.test.tsx
@@ -94,6 +94,52 @@ describe("DevPreviewEmptyState", () => {
       expect(onAutoDetect).toHaveBeenCalledTimes(1);
     });
 
+    it("isAutoDetecting disables the primary CTA and blocks onAutoDetect", () => {
+      const onAutoDetect = vi.fn();
+      render(
+        <DevPreviewEmptyState
+          {...baseProps}
+          detectedCandidate={devRunner()}
+          allDetectedRunners={[devRunner()]}
+          isAutoDetecting={true}
+          onAutoDetect={onAutoDetect}
+        />
+      );
+      const cta = screen.getByRole("button", { name: /Starting/ });
+      expect(cta.hasAttribute("disabled")).toBe(true);
+      fireEvent.click(cta);
+      expect(onAutoDetect).not.toHaveBeenCalled();
+    });
+
+    it("isUnconfigured=false wins over detectedCandidate (waiting branch only)", () => {
+      render(
+        <DevPreviewEmptyState
+          {...baseProps}
+          isUnconfigured={false}
+          detectedCandidate={devRunner()}
+          allDetectedRunners={[devRunner(), startRunner()]}
+        />
+      );
+      expect(screen.getByText("Waiting for dev server")).toBeDefined();
+      expect(screen.queryByText("Start the dev server")).toBeNull();
+      expect(screen.queryByText("Use a different script…")).toBeNull();
+    });
+
+    it("hides picker when allDetectedRunners is undefined but CTA still works", () => {
+      const onAutoDetect = vi.fn();
+      render(
+        <DevPreviewEmptyState
+          {...baseProps}
+          detectedCandidate={devRunner()}
+          allDetectedRunners={undefined}
+          onAutoDetect={onAutoDetect}
+        />
+      );
+      expect(screen.queryByText("Use a different script…")).toBeNull();
+      fireEvent.click(screen.getByRole("button", { name: /Start the dev server/ }));
+      expect(onAutoDetect).toHaveBeenCalledTimes(1);
+    });
+
     it("renders candidate branch for devcontainer fallback", () => {
       render(
         <DevPreviewEmptyState
@@ -152,14 +198,29 @@ describe("DevPreviewEmptyState", () => {
       expect(screen.getByText("Start server").closest("button")?.disabled).toBe(true);
     });
 
-    it("disables the submit button for shell-control input", () => {
+    it("allows compound shell commands (matches backend contract)", () => {
       const onManualSubmit = vi.fn();
       render(<DevPreviewEmptyState {...baseProps} onManualSubmit={onManualSubmit} />);
       const input = screen.getByLabelText("Dev server command");
-      fireEvent.change(input, { target: { value: "npm run dev; rm -rf /" } });
+      fireEvent.change(input, { target: { value: "cd apps/web && npm run dev" } });
       const button = screen.getByText("Start server").closest("button");
-      expect(button?.disabled).toBe(true);
+      expect(button?.disabled).toBe(false);
       fireEvent.click(button!);
+      expect(onManualSubmit).toHaveBeenCalledWith("cd apps/web && npm run dev");
+    });
+
+    it("blocks Enter submission while isSavingManual", () => {
+      const onManualSubmit = vi.fn();
+      render(
+        <DevPreviewEmptyState
+          {...baseProps}
+          isSavingManual={true}
+          onManualSubmit={onManualSubmit}
+        />
+      );
+      const input = screen.getByLabelText("Dev server command");
+      fireEvent.change(input, { target: { value: "npm run dev" } });
+      fireEvent.keyDown(input, { key: "Enter" });
       expect(onManualSubmit).not.toHaveBeenCalled();
     });
 

--- a/src/components/DevPreview/__tests__/DevPreviewEmptyState.test.tsx
+++ b/src/components/DevPreview/__tests__/DevPreviewEmptyState.test.tsx
@@ -1,0 +1,204 @@
+// @vitest-environment jsdom
+import { render, screen, fireEvent } from "@testing-library/react";
+import { describe, expect, it, vi } from "vitest";
+import type { RunCommand } from "@shared/types";
+
+vi.mock("@/lib/utils", () => ({ cn: (...args: unknown[]) => args.filter(Boolean).join(" ") }));
+
+vi.mock("@/components/ui/button", () => ({
+  Button: ({
+    children,
+    onClick,
+    disabled,
+    title,
+  }: React.ComponentProps<"button">) => (
+    <button onClick={onClick} disabled={disabled} title={title}>
+      {children}
+    </button>
+  ),
+}));
+
+vi.mock("@/components/ui/popover", () => ({
+  Popover: ({ children }: { children: React.ReactNode }) => <>{children}</>,
+  PopoverContent: ({ children }: { children: React.ReactNode }) => <>{children}</>,
+  PopoverTrigger: ({ children }: { children: React.ReactNode }) => <>{children}</>,
+}));
+
+import { DevPreviewEmptyState } from "../DevPreviewEmptyState";
+
+function devRunner(): RunCommand {
+  return { id: "npm-dev", name: "dev", command: "npm run dev", icon: "npm", description: "vite" };
+}
+
+function startRunner(): RunCommand {
+  return { id: "npm-start", name: "start", command: "npm run start", icon: "npm" };
+}
+
+function devcontainerRunner(): RunCommand {
+  return {
+    id: "devcontainer-poststart",
+    name: "postStartCommand",
+    command: "npm run dev",
+    icon: "terminal",
+  };
+}
+
+const baseProps = {
+  isUnconfigured: true,
+  detectedCandidate: undefined as RunCommand | undefined,
+  allDetectedRunners: undefined as RunCommand[] | undefined,
+  isAutoDetecting: false,
+  isSettingsLoading: false,
+  isSavingManual: false,
+  onAutoDetect: vi.fn(),
+  onSelectRunner: vi.fn(),
+  onManualSubmit: vi.fn(),
+  onOpenSettings: vi.fn(),
+};
+
+describe("DevPreviewEmptyState", () => {
+  describe("waiting branch (configured)", () => {
+    it("renders sentence-case waiting heading", () => {
+      render(<DevPreviewEmptyState {...baseProps} isUnconfigured={false} />);
+      expect(screen.getByText("Waiting for dev server")).toBeDefined();
+      expect(screen.queryByText("Waiting for Dev Server")).toBeNull();
+    });
+  });
+
+  describe("candidate branch", () => {
+    it("renders sentence-case heading, detection badge, and primary CTA", () => {
+      render(
+        <DevPreviewEmptyState
+          {...baseProps}
+          detectedCandidate={devRunner()}
+          allDetectedRunners={[devRunner()]}
+        />
+      );
+      expect(screen.getByRole("heading", { name: "Start the dev server" })).toBeDefined();
+      expect(screen.queryByText("Configure Dev Server")).toBeNull();
+      // command appears in the detection badge
+      expect(screen.getByText("npm run dev")).toBeDefined();
+    });
+
+    it("primary CTA calls onAutoDetect", () => {
+      const onAutoDetect = vi.fn();
+      render(
+        <DevPreviewEmptyState
+          {...baseProps}
+          detectedCandidate={devRunner()}
+          allDetectedRunners={[devRunner()]}
+          onAutoDetect={onAutoDetect}
+        />
+      );
+      fireEvent.click(screen.getByRole("button", { name: /Start the dev server/ }));
+      expect(onAutoDetect).toHaveBeenCalledTimes(1);
+    });
+
+    it("renders candidate branch for devcontainer fallback", () => {
+      render(
+        <DevPreviewEmptyState
+          {...baseProps}
+          detectedCandidate={devcontainerRunner()}
+          allDetectedRunners={[devcontainerRunner()]}
+        />
+      );
+      expect(screen.getByRole("heading", { name: "Start the dev server" })).toBeDefined();
+    });
+
+    it("shows the picker only when more than one runner is detected", () => {
+      const { rerender } = render(
+        <DevPreviewEmptyState
+          {...baseProps}
+          detectedCandidate={devRunner()}
+          allDetectedRunners={[devRunner()]}
+        />
+      );
+      expect(screen.queryByText("Use a different script…")).toBeNull();
+
+      rerender(
+        <DevPreviewEmptyState
+          {...baseProps}
+          detectedCandidate={devRunner()}
+          allDetectedRunners={[devRunner(), startRunner()]}
+        />
+      );
+      expect(screen.getByText("Use a different script…")).toBeDefined();
+    });
+
+    it("selecting a runner from the picker calls onSelectRunner", () => {
+      const onSelectRunner = vi.fn();
+      render(
+        <DevPreviewEmptyState
+          {...baseProps}
+          detectedCandidate={devRunner()}
+          allDetectedRunners={[devRunner(), startRunner()]}
+          onSelectRunner={onSelectRunner}
+        />
+      );
+      fireEvent.click(screen.getByText("npm run start"));
+      expect(onSelectRunner).toHaveBeenCalledWith(startRunner());
+    });
+  });
+
+  describe("no-candidate branch", () => {
+    it("renders sentence-case heading and inline input", () => {
+      render(<DevPreviewEmptyState {...baseProps} />);
+      expect(screen.getByText("Set a dev command")).toBeDefined();
+      expect(screen.getByLabelText("Dev server command")).toBeDefined();
+    });
+
+    it("disables the submit button for empty input", () => {
+      render(<DevPreviewEmptyState {...baseProps} />);
+      expect(screen.getByText("Start server").closest("button")?.disabled).toBe(true);
+    });
+
+    it("disables the submit button for shell-control input", () => {
+      const onManualSubmit = vi.fn();
+      render(<DevPreviewEmptyState {...baseProps} onManualSubmit={onManualSubmit} />);
+      const input = screen.getByLabelText("Dev server command");
+      fireEvent.change(input, { target: { value: "npm run dev; rm -rf /" } });
+      const button = screen.getByText("Start server").closest("button");
+      expect(button?.disabled).toBe(true);
+      fireEvent.click(button!);
+      expect(onManualSubmit).not.toHaveBeenCalled();
+    });
+
+    it("submits a valid command with trimmed value", () => {
+      const onManualSubmit = vi.fn();
+      render(<DevPreviewEmptyState {...baseProps} onManualSubmit={onManualSubmit} />);
+      const input = screen.getByLabelText("Dev server command");
+      fireEvent.change(input, { target: { value: "  npm run dev  " } });
+      fireEvent.click(screen.getByText("Start server"));
+      expect(onManualSubmit).toHaveBeenCalledWith("npm run dev");
+    });
+
+    it("submits on Enter key", () => {
+      const onManualSubmit = vi.fn();
+      render(<DevPreviewEmptyState {...baseProps} onManualSubmit={onManualSubmit} />);
+      const input = screen.getByLabelText("Dev server command");
+      fireEvent.change(input, { target: { value: "vite" } });
+      fireEvent.keyDown(input, { key: "Enter" });
+      expect(onManualSubmit).toHaveBeenCalledWith("vite");
+    });
+  });
+
+  it("settings link calls onOpenSettings in both unconfigured branches", () => {
+    const onOpenSettings = vi.fn();
+    const { rerender } = render(
+      <DevPreviewEmptyState {...baseProps} onOpenSettings={onOpenSettings} />
+    );
+    fireEvent.click(screen.getByText("Open project settings"));
+    expect(onOpenSettings).toHaveBeenCalledTimes(1);
+
+    rerender(
+      <DevPreviewEmptyState
+        {...baseProps}
+        detectedCandidate={devRunner()}
+        allDetectedRunners={[devRunner()]}
+        onOpenSettings={onOpenSettings}
+      />
+    );
+    fireEvent.click(screen.getByText("Open project settings"));
+    expect(onOpenSettings).toHaveBeenCalledTimes(2);
+  });
+});

--- a/src/utils/__tests__/devServerDetection.test.ts
+++ b/src/utils/__tests__/devServerDetection.test.ts
@@ -1,5 +1,5 @@
 import { describe, expect, it } from "vitest";
-import { findDevServerCandidate } from "../devServerDetection";
+import { findDevServerCandidate, SHELL_CONTROL_RE } from "../devServerDetection";
 import type { RunCommand } from "@shared/types";
 
 function runner(name: string, command: string, description?: string): RunCommand {
@@ -113,5 +113,39 @@ describe("findDevServerCandidate", () => {
       const runners = [runner("dev", "npm run dev", "next dev | tee log")];
       expect(findDevServerCandidate(runners)?.command).toBe("npm run dev");
     });
+  });
+});
+
+describe("SHELL_CONTROL_RE", () => {
+  it("rejects shell-control characters", () => {
+    for (const cmd of [
+      "npm run dev; rm -rf /",
+      "npm run dev && echo done",
+      "npm run dev | tee log",
+      "npm run dev # comment",
+      "echo `whoami`",
+      "cat < file",
+      "echo > file",
+      "echo $(whoami)",
+    ]) {
+      expect(SHELL_CONTROL_RE.test(cmd)).toBe(true);
+    }
+  });
+
+  it("rejects line breaks", () => {
+    expect(SHELL_CONTROL_RE.test("npm run dev\nrm -rf /")).toBe(true);
+    expect(SHELL_CONTROL_RE.test("npm run dev\r\necho hi")).toBe(true);
+  });
+
+  it("accepts plain dev-server commands", () => {
+    for (const cmd of [
+      "npm run dev",
+      "pnpm vite --host 0.0.0.0",
+      "bun --bun vite",
+      "yarn dev --port 5173",
+      "php artisan serve",
+    ]) {
+      expect(SHELL_CONTROL_RE.test(cmd)).toBe(false);
+    }
   });
 });

--- a/src/utils/devServerDetection.ts
+++ b/src/utils/devServerDetection.ts
@@ -4,7 +4,13 @@ const DEV_SCRIPT_PRIORITY = ["dev", "start", "serve"];
 
 const NEXT_DEV_RE = /\bnext\s+dev\b/;
 const TURBOPACK_FLAG_RE = /--turbo(?:pack)?\b/;
-const SHELL_CONTROL_RE = /[;&|#]|<|>|\$\(/;
+/**
+ * Rejects commands containing shell-control characters, command
+ * substitution, or line breaks. Used both to gate turbopack injection on
+ * detected scripts and to validate the manual dev-command input in the
+ * dev preview empty state.
+ */
+export const SHELL_CONTROL_RE = /[;&|#`\n\r]|<|>|\$\(/;
 
 function applyNextjsTurbopack(runner: RunCommand, turbopackEnabled = true): RunCommand {
   if (!turbopackEnabled) return runner;


### PR DESCRIPTION
Resolves #8267.

Polishes the dev preview panel empty state across its three states, adds a new extracted `DevPreviewEmptyState` presentational component for unit testability, and fixes a handful of latent correctness gaps.

## Summary

- Three distinct branches: no detected candidates shows inline command input + "Start server" button; one candidate shows a neutral detection badge + settings link; multiple candidates shows the same badge plus a popover picker for choosing a different script
- `DevPreviewEmptyState` extracted as a presentational component following the `GeneralTab.devServerSuggestion.test.tsx` precedent -- `DevPreviewPane` has ~30 hooks and is render-untestable
- `devcontainer-poststart` fallback honored in all code paths (was silently ignored in the auto-detect re-detection path); manual input validation mirrors the backend `getInvalidCommandMessage` contract, so compound shell commands like `cd apps/web && npm run dev` are valid

## Changes

- Sentence-case headings throughout ("Start the dev server", "Set a dev command", "Waiting for dev server")
- Detection badge uses `bg-overlay-subtle` neutral surface with monospace command text; port slot left empty pending #8266
- Picker shown only when >1 runner is detected; trigger and settings link use ghost/tertiary styles -- single accent anchor is the primary CTA per the accent-restraint rule
- Shared `persistDevServerCommand` helper unifies three previously scattered save paths; all saves set `devServerAutoDetected: false` so `isUnconfigured` flips and the webview loads (per #4896)
- `SHELL_CONTROL_RE` exported and hardened (added backtick and line-break coverage) for the turbopack-gating path
- Three scattered `findDevServerCandidate` JSX calls unified into one `detectedCandidate` memo

## Testing

43 tests pass. New `DevPreviewEmptyState.test.tsx` covers all three branches, `devcontainer-poststart` fallback, picker gating and selection, manual validation/submit/Enter key, `isAutoDetecting`/`isSavingManual` gating, branch exclusivity, and undefined-runners fallback. `devServerDetection.test.ts` gains a `SHELL_CONTROL_RE` describe block.

7 pre-existing ESLint warnings remain in unmodified `DevPreviewPane.tsx` regions -- not introduced by this work.