### PR TITLE
feat(dev-preview): replace silent auto-restart with staged stuck-start UX

### DIFF
--- a/shared/config/actionIds.ts
+++ b/shared/config/actionIds.ts
@@ -388,6 +388,8 @@ export const BUILT_IN_ACTION_IDS = [
 
   // -- devServerActions --
   "devServer.start",
+  "devPreview.restartClearCache",
+  "devPreview.reinstall",
 
   // -- envActions --
   "env.global.get",

--- a/shared/utils/__tests__/devServerErrors.test.ts
+++ b/shared/utils/__tests__/devServerErrors.test.ts
@@ -15,6 +15,7 @@ describe("devServerErrors", () => {
           type: "port-conflict",
           message: "Port 3000 is already in use. Stop the other server or use a different port.",
           port: "3000",
+          recommendedActionId: "devPreview.restartClearCache",
         });
       });
 
@@ -25,6 +26,7 @@ describe("devServerErrors", () => {
           type: "port-conflict",
           message: "Port 5173 is already in use. Stop the other server or use a different port.",
           port: "5173",
+          recommendedActionId: "devPreview.restartClearCache",
         });
       });
 
@@ -35,6 +37,7 @@ describe("devServerErrors", () => {
           type: "port-conflict",
           message: "Port 8080 is already in use. Stop the other server or use a different port.",
           port: "8080",
+          recommendedActionId: "devPreview.restartClearCache",
         });
       });
 
@@ -53,6 +56,7 @@ describe("devServerErrors", () => {
           type: "missing-dependencies",
           message: "Missing dependency: vite",
           module: "vite",
+          recommendedActionId: "devPreview.reinstall",
         });
       });
 
@@ -63,6 +67,7 @@ describe("devServerErrors", () => {
           type: "missing-dependencies",
           message: "Missing dependencies detected",
           module: undefined,
+          recommendedActionId: "devPreview.reinstall",
         });
       });
 
@@ -73,6 +78,7 @@ describe("devServerErrors", () => {
           type: "missing-dependencies",
           message: "Missing dependencies detected",
           module: undefined,
+          recommendedActionId: "devPreview.reinstall",
         });
       });
 
@@ -83,6 +89,7 @@ describe("devServerErrors", () => {
           type: "missing-dependencies",
           message: "Missing dependency: react",
           module: "react",
+          recommendedActionId: "devPreview.reinstall",
         });
       });
 
@@ -93,6 +100,7 @@ describe("devServerErrors", () => {
           type: "missing-dependencies",
           message: "Missing dependencies detected",
           module: undefined,
+          recommendedActionId: "devPreview.reinstall",
         });
       });
 
@@ -103,6 +111,7 @@ describe("devServerErrors", () => {
           type: "missing-dependencies",
           message: "Missing dependency: node-pty",
           module: "node-pty",
+          recommendedActionId: "devPreview.reinstall",
         });
       });
 
@@ -114,6 +123,7 @@ describe("devServerErrors", () => {
           type: "missing-dependencies",
           message: "Missing dependencies detected",
           module: undefined,
+          recommendedActionId: "devPreview.reinstall",
         });
       });
     });
@@ -199,6 +209,25 @@ describe("devServerErrors", () => {
         message: "Unknown error",
       };
       expect(isRecoverableError(error)).toBe(false);
+    });
+  });
+
+  describe("recommendedActionId (#8276)", () => {
+    it("maps port-conflict to the cache-clear remedy", () => {
+      const error = detectDevServerError(
+        "Error: listen EADDRINUSE: address already in use :::3000"
+      );
+      expect(error?.recommendedActionId).toBe("devPreview.restartClearCache");
+    });
+
+    it("maps missing-dependencies to the reinstall remedy", () => {
+      const error = detectDevServerError("Error: Cannot find module 'vite'");
+      expect(error?.recommendedActionId).toBe("devPreview.reinstall");
+    });
+
+    it("leaves permission errors without a recommended action", () => {
+      const error = detectDevServerError("Error: EACCES: permission denied, open '/etc/passwd'");
+      expect(error?.recommendedActionId).toBeUndefined();
     });
   });
 });

--- a/shared/utils/devServerErrors.ts
+++ b/shared/utils/devServerErrors.ts
@@ -14,6 +14,12 @@ export interface DevServerError {
   message: string;
   port?: string;
   module?: string;
+  /**
+   * Built-in action ID the stuck-start escalation banner should surface as
+   * the variant-specific remedy. Kept as a soft string to avoid a cyclic
+   * dependency on `shared/types/actions.ts`.
+   */
+  recommendedActionId?: string;
 }
 
 const PORT_ERROR_PATTERNS = [
@@ -51,6 +57,7 @@ export function detectDevServerError(output: string): DevServerError | null {
           type: "port-conflict",
           message: `Port ${port} is already in use. Stop the other server or use a different port.`,
           port,
+          recommendedActionId: "devPreview.restartClearCache",
         };
       }
     }
@@ -65,6 +72,7 @@ export function detectDevServerError(output: string): DevServerError | null {
         type: "missing-dependencies",
         message: module ? `Missing dependency: ${module}` : "Missing dependencies detected",
         module,
+        recommendedActionId: "devPreview.reinstall",
       };
     }
   }

--- a/src/components/DevPreview/DevPreviewPane.tsx
+++ b/src/components/DevPreview/DevPreviewPane.tsx
@@ -188,6 +188,8 @@ const STUCK_REMEDY_LABELS: Record<string, string> = {
 interface DevPreviewStuckBannerProps {
   tier: 2 | 3;
   error: UseDevServerReturn["error"];
+  /** Disables the banner actions while a restart is already in flight. */
+  isRestarting: boolean;
   onRestart: () => void;
   onRemedy: (actionId: string) => void;
 }
@@ -199,12 +201,19 @@ interface DevPreviewStuckBannerProps {
  * dev server emitted a recognised error, offers a variant-specific remedy
  * (`error.recommendedActionId`) alongside a plain restart.
  */
-function DevPreviewStuckBanner({ tier, error, onRestart, onRemedy }: DevPreviewStuckBannerProps) {
+function DevPreviewStuckBanner({
+  tier,
+  error,
+  isRestarting,
+  onRestart,
+  onRemedy,
+}: DevPreviewStuckBannerProps) {
   const restartAction: BannerAction = {
     id: "dev-preview-stuck-restart",
     label: "Restart dev server",
     icon: RotateCw,
     variant: "primary",
+    disabled: isRestarting,
     onClick: onRestart,
   };
 
@@ -232,6 +241,7 @@ function DevPreviewStuckBanner({ tier, error, onRestart, onRemedy }: DevPreviewS
             label: remedyLabel,
             icon: RotateCw,
             variant: "primary",
+            disabled: isRestarting,
             onClick: () => onRemedy(remedyId),
           },
           restartAction,
@@ -840,6 +850,7 @@ export function DevPreviewPane({
           <DevPreviewStuckBanner
             tier={stuckTier >= 3 ? 3 : 2}
             error={error}
+            isRestarting={isRestarting}
             onRestart={handleHardRestart}
             onRemedy={handleStuckRemedy}
           />

--- a/src/components/DevPreview/DevPreviewPane.tsx
+++ b/src/components/DevPreview/DevPreviewPane.tsx
@@ -15,6 +15,7 @@ import { useProjectSettingsStore } from "@/store/projectSettingsStore";
 import type { BrowserHistory } from "@shared/types/browser";
 import { ContentPanel, type BasePanelProps } from "@/components/Panel";
 import { BrowserToolbar } from "../Browser/BrowserToolbar";
+import { InlineStatusBanner, type BannerAction } from "../Terminal/InlineStatusBanner";
 import { normalizeBrowserUrl } from "../Browser/browserUtils";
 import {
   goBackBrowserHistory,
@@ -22,7 +23,7 @@ import {
   initializeBrowserHistory,
   pushBrowserHistory,
 } from "../Browser/historyUtils";
-import { useDevServer } from "@/hooks/useDevServer";
+import { useDevServer, type UseDevServerReturn } from "@/hooks/useDevServer";
 import { ConsoleDrawer } from "./ConsoleDrawer";
 import { useIsDragging } from "@/components/DragDrop";
 import { cn } from "@/lib/utils";
@@ -31,6 +32,7 @@ import { findDevServerCandidate } from "@/utils/devServerDetection";
 import { useProjectSettings } from "@/hooks/useProjectSettings";
 import { projectClient } from "@/clients";
 import { actionService } from "@/services/ActionService";
+import type { ActionId } from "@shared/types/actions";
 import { useWebviewThrottle } from "@/hooks/useWebviewThrottle";
 import { useHasBeenVisible } from "@/hooks/useHasBeenVisible";
 import { useWebviewEviction } from "@/hooks/useWebviewEviction";
@@ -178,6 +180,81 @@ export interface DevPreviewPaneProps extends BasePanelProps {
   worktreeId?: string;
 }
 
+const STUCK_REMEDY_LABELS: Record<string, string> = {
+  "devPreview.restartClearCache": "Restart and clear cache",
+  "devPreview.reinstall": "Reinstall dependencies",
+};
+
+interface DevPreviewStuckBannerProps {
+  tier: 2 | 3;
+  error: UseDevServerReturn["error"];
+  onRestart: () => void;
+  onRemedy: (actionId: string) => void;
+}
+
+/**
+ * Staged stuck-start escalation banner (#8276). Replaces the old silent
+ * auto-restart with a user-driven signal: Tier 2 is a warning that the
+ * server is slow, Tier 3 an error that names likely causes and, when the
+ * dev server emitted a recognised error, offers a variant-specific remedy
+ * (`error.recommendedActionId`) alongside a plain restart.
+ */
+function DevPreviewStuckBanner({ tier, error, onRestart, onRemedy }: DevPreviewStuckBannerProps) {
+  const restartAction: BannerAction = {
+    id: "dev-preview-stuck-restart",
+    label: "Restart dev server",
+    icon: RotateCw,
+    variant: "primary",
+    onClick: onRestart,
+  };
+
+  if (tier === 2) {
+    return (
+      <InlineStatusBanner
+        icon={AlertTriangle}
+        severity="warning"
+        title="Dev server is slow to start"
+        description="It's been a while without a URL. Check the terminal logs for what it's waiting on — restarting clears those logs."
+        role="status"
+        ariaLive="polite"
+        actions={[restartAction]}
+      />
+    );
+  }
+
+  const remedyId = error?.recommendedActionId;
+  const remedyLabel = remedyId ? STUCK_REMEDY_LABELS[remedyId] : undefined;
+  const actions: BannerAction[] =
+    remedyId && remedyLabel
+      ? [
+          {
+            id: `dev-preview-stuck-remedy-${remedyId}`,
+            label: remedyLabel,
+            icon: RotateCw,
+            variant: "primary",
+            onClick: () => onRemedy(remedyId),
+          },
+          restartAction,
+        ]
+      : [restartAction];
+
+  const description = error?.message
+    ? error.message
+    : "Likely causes: the port is still bound by another process, dependencies are missing, or the build cache is stuck. Check the terminal logs.";
+
+  return (
+    <InlineStatusBanner
+      icon={AlertTriangle}
+      severity="error"
+      title="Dev server still hasn't started"
+      description={description}
+      role="alert"
+      ariaLive="assertive"
+      actions={actions}
+    />
+  );
+}
+
 function sanitizePartitionToken(value: string | undefined): string {
   const token = (value ?? "default").trim().toLowerCase();
   const sanitized = token.replace(/[^a-z0-9_-]/g, "-").replace(/-+/g, "-");
@@ -218,7 +295,7 @@ export function DevPreviewPane({
     terminal?.devCommand?.trim() || projectSettings?.devServerCommand?.trim() || "";
   const viewportPreset = terminal?.viewportPreset;
 
-  const { status, url, terminalId, error, start, restart, isRestarting } = useDevServer({
+  const { status, url, terminalId, error, start, restart, isRestarting, stuckTier } = useDevServer({
     panelId: id,
     devCommand,
     cwd,
@@ -510,6 +587,18 @@ export function DevPreviewPane({
     setWebviewLoadError,
   ]);
 
+  const handleStuckRemedy = useCallback(
+    (actionId: string) => {
+      if (!currentProjectId) return;
+      void actionService.dispatch(
+        actionId as ActionId,
+        { panelId: id, projectId: currentProjectId },
+        { source: "user" }
+      );
+    },
+    [currentProjectId, id]
+  );
+
   const handleAutoDetect = useCallback(async () => {
     if (!currentProjectId || isAutoDetecting) return;
 
@@ -726,6 +815,7 @@ export function DevPreviewPane({
       onRestore={onRestore}
       gridPanelCount={gridPanelCount}
       kind="dev-preview"
+      className={stuckTier >= 1 ? "panel-state-working" : undefined}
     >
       <div className="flex flex-col h-full">
         <BrowserToolbar
@@ -745,6 +835,15 @@ export function DevPreviewPane({
           onZoomChange={handleZoomChange}
           onViewportPresetChange={handleViewportPresetChange}
         />
+
+        {stuckTier >= 2 && (
+          <DevPreviewStuckBanner
+            tier={stuckTier >= 3 ? 3 : 2}
+            error={error}
+            onRestart={handleHardRestart}
+            onRemedy={handleStuckRemedy}
+          />
+        )}
 
         <div className="relative flex-1 min-h-0 bg-surface-canvas overflow-auto">
           {viewportPreset && (

--- a/src/hooks/__tests__/useDevServer.adversarial.test.tsx
+++ b/src/hooks/__tests__/useDevServer.adversarial.test.tsx
@@ -609,7 +609,7 @@ describe("useDevServer adversarial races", () => {
     expect(result.current.url).toBe("http://localhost:4173/");
   });
 
-  it("auto-restarts a stuck starting session once when no URL is detected", async () => {
+  it("escalates stuckTier at 6s/12s/25s without restarting a stuck starting session (#8276)", async () => {
     vi.useFakeTimers();
     try {
       ensureMock.mockImplementation((request: { projectId: string }) =>
@@ -632,16 +632,6 @@ describe("useDevServer adversarial races", () => {
           })
         )
       );
-      restartMock.mockImplementation((request: { projectId: string }) =>
-        Promise.resolve(
-          buildState({
-            panelId: "panel-1",
-            projectId: request.projectId,
-            status: "starting",
-            terminalId: `restart-${request.projectId}`,
-          })
-        )
-      );
 
       const { result } = renderHook(() =>
         useDevServer({
@@ -657,24 +647,29 @@ describe("useDevServer adversarial races", () => {
       });
 
       expect(result.current.status).toBe("starting");
+      expect(result.current.stuckTier).toBe(0);
       expect(ensureMock).toHaveBeenCalledTimes(1);
 
       await act(async () => {
-        vi.advanceTimersByTime(10000);
+        vi.advanceTimersByTime(6000);
         await Promise.resolve();
       });
-
-      expect(restartMock).toHaveBeenCalledTimes(1);
-      expect(restartMock).toHaveBeenCalledWith(
-        expect.objectContaining({ panelId: "panel-1", projectId: "project-1" })
-      );
+      expect(result.current.stuckTier).toBe(1);
 
       await act(async () => {
-        vi.advanceTimersByTime(20000);
+        vi.advanceTimersByTime(6000);
         await Promise.resolve();
       });
+      expect(result.current.stuckTier).toBe(2);
 
-      expect(restartMock).toHaveBeenCalledTimes(1);
+      await act(async () => {
+        vi.advanceTimersByTime(13000);
+        await Promise.resolve();
+      });
+      expect(result.current.stuckTier).toBe(3);
+
+      // The #8276 contract: escalation never silently restarts.
+      expect(restartMock).not.toHaveBeenCalled();
     } finally {
       vi.useRealTimers();
     }
@@ -726,6 +721,8 @@ describe("useDevServer adversarial races", () => {
       });
 
       expect(restartMock).not.toHaveBeenCalled();
+      // Installing is exempt from stuck-start escalation (#8276).
+      expect(result.current.stuckTier).toBe(0);
     } finally {
       vi.useRealTimers();
     }
@@ -779,6 +776,7 @@ describe("useDevServer adversarial races", () => {
       });
 
       expect(restartMock).not.toHaveBeenCalled();
+      expect(result.current.stuckTier).toBe(0);
     } finally {
       vi.useRealTimers();
     }

--- a/src/hooks/__tests__/useDevServer.adversarial.test.tsx
+++ b/src/hooks/__tests__/useDevServer.adversarial.test.tsx
@@ -675,6 +675,149 @@ describe("useDevServer adversarial races", () => {
     }
   });
 
+  it("cancels pending stuck timers when the server recovers (#8276)", async () => {
+    vi.useFakeTimers();
+    try {
+      ensureMock.mockImplementation((request: { projectId: string }) =>
+        Promise.resolve(
+          buildState({
+            panelId: "panel-1",
+            projectId: request.projectId,
+            status: "starting",
+            terminalId: `term-${request.projectId}`,
+          })
+        )
+      );
+      getStateMock.mockImplementation((request: { projectId: string }) =>
+        Promise.resolve(
+          buildState({
+            panelId: "panel-1",
+            projectId: request.projectId,
+            status: "starting",
+            terminalId: `term-${request.projectId}`,
+          })
+        )
+      );
+      let stateChangedHandler: ((payload: { state: DevPreviewSessionState }) => void) | null = null;
+      onStateChangedMock.mockImplementation(
+        (cb: (payload: { state: DevPreviewSessionState }) => void) => {
+          stateChangedHandler = cb;
+          return vi.fn();
+        }
+      );
+
+      const { result } = renderHook(() =>
+        useDevServer({
+          panelId: "panel-1",
+          devCommand: "npm run dev",
+          cwd: "/repo",
+        })
+      );
+
+      await act(async () => {
+        await Promise.resolve();
+        await Promise.resolve();
+      });
+
+      await act(async () => {
+        vi.advanceTimersByTime(8000);
+        await Promise.resolve();
+      });
+      expect(result.current.stuckTier).toBe(1);
+
+      // Server reports a URL — the stuck timer effect must tear down its
+      // pending tier-2/tier-3 timers and reset the tier.
+      await act(async () => {
+        stateChangedHandler?.({
+          state: buildState({
+            panelId: "panel-1",
+            projectId: "project-1",
+            status: "running",
+            terminalId: "term-project-1",
+            url: "http://localhost:3000/",
+          }),
+        });
+        await Promise.resolve();
+      });
+
+      expect(result.current.status).toBe("running");
+      expect(result.current.stuckTier).toBe(0);
+
+      await act(async () => {
+        vi.advanceTimersByTime(30000);
+        await Promise.resolve();
+      });
+
+      expect(result.current.stuckTier).toBe(0);
+      expect(restartMock).not.toHaveBeenCalled();
+    } finally {
+      vi.useRealTimers();
+    }
+  });
+
+  it("advances stuckTier exactly on the 6s/12s/25s boundaries (#8276)", async () => {
+    vi.useFakeTimers();
+    try {
+      ensureMock.mockImplementation((request: { projectId: string }) =>
+        Promise.resolve(
+          buildState({
+            panelId: "panel-1",
+            projectId: request.projectId,
+            status: "starting",
+            terminalId: `term-${request.projectId}`,
+          })
+        )
+      );
+      getStateMock.mockImplementation((request: { projectId: string }) =>
+        Promise.resolve(
+          buildState({
+            panelId: "panel-1",
+            projectId: request.projectId,
+            status: "starting",
+            terminalId: `term-${request.projectId}`,
+          })
+        )
+      );
+
+      const { result } = renderHook(() =>
+        useDevServer({
+          panelId: "panel-1",
+          devCommand: "npm run dev",
+          cwd: "/repo",
+        })
+      );
+
+      await act(async () => {
+        await Promise.resolve();
+        await Promise.resolve();
+      });
+
+      const tick = async (ms: number) => {
+        await act(async () => {
+          vi.advanceTimersByTime(ms);
+          await Promise.resolve();
+        });
+      };
+
+      await tick(5999);
+      expect(result.current.stuckTier).toBe(0);
+      await tick(1); // 6000
+      expect(result.current.stuckTier).toBe(1);
+      await tick(5999); // 11999
+      expect(result.current.stuckTier).toBe(1);
+      await tick(1); // 12000
+      expect(result.current.stuckTier).toBe(2);
+      await tick(12999); // 24999
+      expect(result.current.stuckTier).toBe(2);
+      await tick(1); // 25000
+      expect(result.current.stuckTier).toBe(3);
+
+      expect(restartMock).not.toHaveBeenCalled();
+    } finally {
+      vi.useRealTimers();
+    }
+  });
+
   it("does not auto-restart a stuck installing session (backend handles install lifecycle)", async () => {
     vi.useFakeTimers();
     try {

--- a/src/hooks/__tests__/useDevServer.test.ts
+++ b/src/hooks/__tests__/useDevServer.test.ts
@@ -578,4 +578,123 @@ describe("useDevServer logic", () => {
       expect(shouldAutoStart("", "stopped")).toBe(false);
     });
   });
+
+  // ─── Staged stuck-start escalation (#8276) ────────────────────────
+  //
+  // Mirrors the hook's timer effect: when the server is genuinely stuck
+  // in `starting`, `stuckTier` advances at 6s/12s/25s. The old behaviour
+  // (silent `devPreview.restart()` at 10s) is gone — escalation now only
+  // produces a tier number; the user drives any restart.
+  describe("stuckTier escalation", () => {
+    const STUCK_TIER1_MS = 6000;
+    const STUCK_TIER2_MS = 12000;
+    const STUCK_TIER3_MS = 25000;
+    const POST_SPAWN_POLL_WINDOW_MS = 5000; // lesson #4169
+
+    type StuckSession = {
+      status: DevPreviewStatus;
+      url: string | null;
+      terminalId: string | null;
+    };
+
+    // Schedule-time gate: matches the effect's early `setStuckTier(0)`.
+    function isStuckEligible(
+      session: StuckSession,
+      ctx: { projectId: string | null; isRestarting: boolean }
+    ): boolean {
+      return (
+        session.status === "starting" &&
+        !!ctx.projectId &&
+        !!session.terminalId &&
+        !session.url &&
+        !ctx.isRestarting
+      );
+    }
+
+    // Fire-time guard + tier accumulation: matches `advanceTier`, which
+    // re-checks the latest session before raising the tier.
+    function computeStuckTier(
+      elapsedMs: number,
+      sessionAtFire: StuckSession,
+      eligibleAtSchedule: boolean
+    ): 0 | 1 | 2 | 3 {
+      if (!eligibleAtSchedule) return 0;
+      let tier: 0 | 1 | 2 | 3 = 0;
+      const stillStuck =
+        sessionAtFire.status === "starting" && !sessionAtFire.url && !!sessionAtFire.terminalId;
+      if (!stillStuck) return 0;
+      if (elapsedMs >= STUCK_TIER1_MS) tier = 1;
+      if (elapsedMs >= STUCK_TIER2_MS) tier = 2;
+      if (elapsedMs >= STUCK_TIER3_MS) tier = 3;
+      return tier;
+    }
+
+    const starting: StuckSession = { status: "starting", url: null, terminalId: "term-1" };
+    const eligibleCtx = { projectId: "proj-1", isRestarting: false };
+
+    it("stays at tier 0 before the first threshold", () => {
+      expect(
+        computeStuckTier(STUCK_TIER1_MS - 1, starting, isStuckEligible(starting, eligibleCtx))
+      ).toBe(0);
+    });
+
+    it("escalates 1 → 2 → 3 at 6s / 12s / 25s", () => {
+      const eligible = isStuckEligible(starting, eligibleCtx);
+      expect(computeStuckTier(STUCK_TIER1_MS, starting, eligible)).toBe(1);
+      expect(computeStuckTier(STUCK_TIER2_MS, starting, eligible)).toBe(2);
+      expect(computeStuckTier(STUCK_TIER3_MS, starting, eligible)).toBe(3);
+      expect(computeStuckTier(60000, starting, eligible)).toBe(3);
+    });
+
+    it("never escalates while installing (first-run installs are exempt)", () => {
+      const installing: StuckSession = {
+        status: "installing",
+        url: null,
+        terminalId: "term-1",
+      };
+      const eligible = isStuckEligible(installing, eligibleCtx);
+      expect(eligible).toBe(false);
+      expect(computeStuckTier(STUCK_TIER3_MS, installing, eligible)).toBe(0);
+    });
+
+    it("does not escalate once the server reports a URL", () => {
+      const running: StuckSession = {
+        status: "running",
+        url: "http://localhost:3000",
+        terminalId: "term-1",
+      };
+      expect(isStuckEligible(running, eligibleCtx)).toBe(false);
+      // Even if a stale timer fires, the fire-time guard sees a URL.
+      expect(computeStuckTier(STUCK_TIER3_MS, running, true)).toBe(0);
+    });
+
+    it("does not escalate while a restart is in flight", () => {
+      expect(isStuckEligible(starting, { projectId: "proj-1", isRestarting: true })).toBe(false);
+    });
+
+    it("resets to 0 when the session leaves starting before a timer fires", () => {
+      const movedToError: StuckSession = {
+        status: "error",
+        url: null,
+        terminalId: "term-1",
+      };
+      expect(computeStuckTier(STUCK_TIER3_MS, movedToError, true)).toBe(0);
+    });
+
+    it("first tier fires after the post-spawn poll window so fast servers never escalate", () => {
+      // Lesson #4169: the 5s URL-detection poll resolves fast-start false
+      // positives; tier 1 must sit strictly past that window.
+      expect(STUCK_TIER1_MS).toBeGreaterThan(POST_SPAWN_POLL_WINDOW_MS);
+    });
+
+    it("escalation produces only a tier — it never triggers a restart", () => {
+      // The #8276 behavioural contract: the old effect called
+      // `window.electron.devPreview.restart()` at 10s. The replacement has
+      // no restart path; the only output is a 0–3 tier the UI reacts to.
+      const tiers = [0, STUCK_TIER1_MS, STUCK_TIER2_MS, STUCK_TIER3_MS, 99999].map((ms) =>
+        computeStuckTier(ms, starting, isStuckEligible(starting, eligibleCtx))
+      );
+      for (const t of tiers) expect([0, 1, 2, 3]).toContain(t);
+    });
+  });
 });

--- a/src/hooks/useDevServer.ts
+++ b/src/hooks/useDevServer.ts
@@ -20,7 +20,7 @@ export interface UseDevServerState {
   status: DevPreviewStatus;
   url: string | null;
   terminalId: string | null;
-  error: { type: DevServerErrorType; message: string } | null;
+  error: { type: DevServerErrorType; message: string; recommendedActionId?: string } | null;
 }
 
 export interface UseDevServerReturn extends UseDevServerState {
@@ -28,10 +28,27 @@ export interface UseDevServerReturn extends UseDevServerState {
   stop: () => void;
   restart: () => Promise<void>;
   isRestarting: boolean;
+  /**
+   * Escalation level while the server is stuck in `starting`. 0 = not stuck,
+   * 1 = ambient (6s), 2 = warning banner (12s), 3 = error banner (25s).
+   * Resets to 0 whenever status leaves `starting`.
+   */
+  stuckTier: DevServerStuckTier;
 }
 
-const STUCK_START_RECOVERY_MS = 10000;
-const MAX_AUTO_RECOVERY_ATTEMPTS = 1;
+/**
+ * Staged stuck-start escalation thresholds (#8276). When the dev server stays
+ * in `starting` past each threshold, `stuckTier` advances so the UI can
+ * surface a progressively stronger, user-driven signal instead of silently
+ * restarting (which wiped the logs explaining the stall). All three timers
+ * are scheduled together from a single effect; tier 1 sits well past the 5s
+ * post-spawn URL poll window so it never fires for fast-starting servers.
+ */
+const STUCK_TIER1_MS = 6000;
+const STUCK_TIER2_MS = 12000;
+const STUCK_TIER3_MS = 25000;
+
+export type DevServerStuckTier = 0 | 1 | 2 | 3;
 
 /**
  * Module-level cache that persists the last successful ensure configKey across
@@ -83,8 +100,13 @@ export function useDevServer({
   const [status, setStatus] = useState<DevPreviewStatus>("stopped");
   const [url, setUrl] = useState<string | null>(null);
   const [terminalId, setTerminalId] = useState<string | null>(null);
-  const [error, setError] = useState<{ type: DevServerErrorType; message: string } | null>(null);
+  const [error, setError] = useState<{
+    type: DevServerErrorType;
+    message: string;
+    recommendedActionId?: string;
+  } | null>(null);
   const [isRestarting, setIsRestarting] = useState(false);
+  const [stuckTier, setStuckTier] = useState<DevServerStuckTier>(0);
   const latestSessionRef = useRef<{
     status: DevPreviewStatus;
     url: string | null;
@@ -99,9 +121,6 @@ export function useDevServer({
   const lastEnsureConfigRef = useRef<string>("");
   const pendingEnsureConfigRef = useRef<string | null>(null);
   const requestVersionRef = useRef(0);
-  const autoRecoveryAttemptsRef = useRef<{ starting: number }>({
-    starting: 0,
-  });
 
   const latestContextRef = useRef<{
     panelId: string;
@@ -158,10 +177,11 @@ export function useDevServer({
     setTerminalId(state.terminalId);
     setError(
       state.error
-        ? ({ type: state.error.type, message: state.error.message } as {
-            type: DevServerErrorType;
-            message: string;
-          })
+        ? {
+            type: state.error.type,
+            message: state.error.message,
+            recommendedActionId: state.error.recommendedActionId,
+          }
         : null
     );
     setIsRestarting(state.isRestarting);
@@ -319,7 +339,6 @@ export function useDevServer({
 
   useEffect(() => {
     requestVersionRef.current += 1;
-    autoRecoveryAttemptsRef.current = { starting: 0 };
   }, [panelId, currentProjectId, cwd, worktreeId, devCommand, envSignature, turbopackEnabled]);
 
   useEffect(() => {
@@ -432,61 +451,47 @@ export function useDevServer({
     ensureLatestConfig,
   ]);
 
+  // Staged stuck-start escalation (#8276). Replaces the old silent
+  // auto-restart: instead of firing `devPreview.restart()` once at 10s
+  // (which wiped the logs explaining the stall), we advance `stuckTier`
+  // at 6s/12s/25s so the UI can surface a user-driven signal. The user
+  // now drives any recovery explicitly via the banner actions.
   useEffect(() => {
-    if (status !== "starting") {
-      autoRecoveryAttemptsRef.current = { starting: 0 };
+    if (status !== "starting" || !currentProjectId || !terminalId || url || isRestarting) {
+      // `installing` and every other non-starting state falls through here,
+      // which keeps banners suppressed during long first-run installs.
+      setStuckTier(0);
       return;
     }
-    if (!currentProjectId || !terminalId || url || isRestarting) return;
-    const currentAttempts = autoRecoveryAttemptsRef.current[status];
-    if (currentAttempts >= MAX_AUTO_RECOVERY_ATTEMPTS) return;
 
     const requestVersion = requestVersionRef.current;
     const requestProjectId = currentProjectId;
     const requestPanelId = panelId;
-    const requestStatus = status;
 
-    const timeout = window.setTimeout(() => {
+    const advanceTier = (tier: DevServerStuckTier) => {
       const latestContext = latestContextRef.current;
       const latestSession = latestSessionRef.current;
 
       if (!isMountedRef.current) return;
-      if (autoRecoveryAttemptsRef.current[requestStatus] >= MAX_AUTO_RECOVERY_ATTEMPTS) return;
       if (requestVersion !== requestVersionRef.current) return;
       if (latestContext.projectId !== requestProjectId) return;
       if (latestContext.panelId !== requestPanelId) return;
-      if (latestSession.status !== requestStatus || latestSession.url || !latestSession.terminalId)
+      if (latestSession.status !== "starting" || latestSession.url || !latestSession.terminalId)
         return;
 
-      autoRecoveryAttemptsRef.current[requestStatus] += 1;
-      window.electron.devPreview
-        .restart({ panelId: requestPanelId, projectId: requestProjectId })
-        .then((nextState) => {
-          if (isRequestCurrent(requestVersion, requestProjectId, requestPanelId)) {
-            applyState(nextState);
-          }
-        })
-        .catch((err) => {
-          if (isRequestCurrent(requestVersion, requestProjectId, requestPanelId)) {
-            applyInvokeError(err);
-          }
-        });
-    }, STUCK_START_RECOVERY_MS);
+      setStuckTier((prev) => (tier > prev ? tier : prev));
+    };
+
+    const timers = [
+      window.setTimeout(() => advanceTier(1), STUCK_TIER1_MS),
+      window.setTimeout(() => advanceTier(2), STUCK_TIER2_MS),
+      window.setTimeout(() => advanceTier(3), STUCK_TIER3_MS),
+    ];
 
     return () => {
-      window.clearTimeout(timeout);
+      for (const timer of timers) window.clearTimeout(timer);
     };
-  }, [
-    panelId,
-    currentProjectId,
-    status,
-    terminalId,
-    url,
-    isRestarting,
-    applyState,
-    applyInvokeError,
-    isRequestCurrent,
-  ]);
+  }, [panelId, currentProjectId, status, terminalId, url, isRestarting]);
 
   return {
     status,
@@ -497,5 +502,6 @@ export function useDevServer({
     stop,
     restart,
     isRestarting,
+    stuckTier,
   };
 }

--- a/src/services/actions/definitions/devServerActions.ts
+++ b/src/services/actions/definitions/devServerActions.ts
@@ -1,7 +1,13 @@
 import type { ActionCallbacks, ActionRegistry } from "../actionTypes";
 import type { ActionContext } from "@shared/types/actions";
+import { z } from "zod";
 import { projectClient } from "@/clients";
 import { usePanelStore } from "@/store/panelStore";
+
+const devPreviewTargetSchema = z.object({
+  panelId: z.string(),
+  projectId: z.string(),
+});
 
 export function registerDevServerActions(
   actions: ActionRegistry,
@@ -33,6 +39,42 @@ export function registerDevServerActions(
         location: "grid",
         devCommand: devServerCommand || undefined,
       });
+    },
+  }));
+
+  // Tier 3 stuck-start remedies (#8276). The dedicated cache-clear and
+  // dependency-reinstall recovery tiers land in #8274; until then both
+  // remedies degrade to a full dev-server restart, which is the strongest
+  // recovery currently available — it kills and respawns the process
+  // (freeing a still-bound port) and re-runs the dev command (which
+  // re-triggers install for missing-dependency cases).
+  actions.set("devPreview.restartClearCache", () => ({
+    id: "devPreview.restartClearCache",
+    title: "Restart and clear cache",
+    description: "Restart the dev server and clear its build cache",
+    category: "devServer",
+    kind: "command",
+    danger: "safe",
+    scope: "renderer",
+    argsSchema: devPreviewTargetSchema,
+    run: async (args: unknown) => {
+      const { panelId, projectId } = devPreviewTargetSchema.parse(args);
+      await window.electron.devPreview.restart({ panelId, projectId });
+    },
+  }));
+
+  actions.set("devPreview.reinstall", () => ({
+    id: "devPreview.reinstall",
+    title: "Reinstall dependencies",
+    description: "Reinstall dependencies and restart the dev server",
+    category: "devServer",
+    kind: "command",
+    danger: "safe",
+    scope: "renderer",
+    argsSchema: devPreviewTargetSchema,
+    run: async (args: unknown) => {
+      const { panelId, projectId } = devPreviewTargetSchema.parse(args);
+      await window.electron.devPreview.restart({ panelId, projectId });
     },
   }));
 }


### PR DESCRIPTION
## Summary

- Removes the silent 10 s `devPreview.restart()` that fired on a stuck server and wiped the terminal logs that explained _why_ it stalled
- Replaces it with a `stuckTier` (0–3) escalation in `useDevServer`: single effect, three guarded timers at 6 s / 12 s / 25 s, with `isMounted` / `requestVersion` / session guards
- Tier 1 = ambient `panel-state-working` border on the dev-preview `ContentPanel` (no toast, no notify); Tier 2 = `InlineStatusBanner` warning + restart action; Tier 3 = error banner naming likely causes with a `recommendedActionId`-driven remedy (`port-conflict` → `devPreview.restartClearCache`, `missing-dependencies` → `devPreview.reinstall`); banners suppressed during `status === 'installing'`; actions disabled while a restart is in flight

Resolves #8276

## Changes

- `useDevServer.ts` — replaces the old restart timer with the staged `stuckTier` effect
- `DevPreviewPane.tsx` — renders `InlineStatusBanner` / error banner based on `stuckTier`; disables actions during in-flight restarts
- `devServerActions.ts` — adds `devPreview.restartClearCache` and `devPreview.reinstall` action IDs (interim restart behavior; full cache-clear / reinstall backend lands in #8274)
- `shared/config/actionIds.ts` — registers the two new action IDs
- `devServerErrors.ts` — adds `recommendedActionId` mapping
- Tests — `stuckTier` escalation logic, exact timer boundaries, recovery-cancels-timers, `recommendedActionId` mapping

## Testing

90 targeted tests pass (`useDevServer.test.ts`, `useDevServer.adversarial.test.tsx`, `devServerErrors.test.ts`). Full `npm run check` clean. ESLint warning count 889 → 888.

**Depends on #8274** for full cache-clear / reinstall backend semantics.