### PR TITLE
fix(dev-preview): wire screenshot, devtools, and console toolbar buttons

### DIFF
--- a/src/components/Browser/BrowserPane.tsx
+++ b/src/components/Browser/BrowserPane.tsx
@@ -684,7 +684,7 @@ export function BrowserPane({
                   >
                     <ExternalLink className="h-3.5 w-3.5 text-daintree-text/50 group-hover:text-daintree-text/70 transition-colors" />
                     <span className="text-xs text-daintree-text/50 group-hover:text-daintree-text/70 transition-colors">
-                      Open in External Browser
+                      Open in external browser
                     </span>
                   </button>
                 </div>
@@ -713,7 +713,7 @@ export function BrowserPane({
                     }}
                     className="shrink-0 px-2 py-0.5 rounded text-xs bg-status-warning/20 hover:bg-status-warning/30 text-daintree-text/90 transition-colors"
                   >
-                    Open in External Browser
+                    Open in external browser
                   </button>
                 )}
                 <button

--- a/src/components/Browser/__tests__/BrowserPane.webview.test.tsx
+++ b/src/components/Browser/__tests__/BrowserPane.webview.test.tsx
@@ -425,7 +425,7 @@ describe("BrowserPane webview lifecycle regression", () => {
       });
 
       expect(container.textContent).toContain("oauth.example.com");
-      expect(container.textContent).toContain("Open in External Browser");
+      expect(container.textContent).toContain("Open in external browser");
     });
 
     it("ignores events for different panelId", () => {
@@ -491,7 +491,7 @@ describe("BrowserPane webview lifecycle regression", () => {
       expect(container.textContent).not.toContain("example.com");
     });
 
-    it("Open in External Browser dispatches browser.openExternal with blocked URL", () => {
+    it("Open in external browser dispatches browser.openExternal with blocked URL", () => {
       const { container } = render(<BrowserPane {...baseProps} />);
       const callback = getNavigationBlockedCallback();
 
@@ -505,7 +505,7 @@ describe("BrowserPane webview lifecycle regression", () => {
       });
 
       const openButton = Array.from(container.querySelectorAll("button")).find((b) =>
-        b.textContent?.includes("Open in External Browser")
+        b.textContent?.includes("Open in external browser")
       );
       expect(openButton).toBeDefined();
 
@@ -765,7 +765,7 @@ describe("BrowserPane webview lifecycle regression", () => {
       });
 
       expect(container.textContent).toContain("Retry");
-      expect(container.textContent).toContain("Open in External Browser");
+      expect(container.textContent).toContain("Open in external browser");
     });
 
     it("Retry from timeout clears error and loads current URL", () => {

--- a/src/components/DevPreview/DevPreviewPane.tsx
+++ b/src/components/DevPreview/DevPreviewPane.tsx
@@ -1,4 +1,5 @@
 import { useState, useCallback, useRef, useEffect, useMemo } from "react";
+import { useBrowserActionListeners } from "@/hooks/useBrowserActionListeners";
 import {
   AlertTriangle,
   RotateCw,
@@ -145,7 +146,7 @@ function BlockedNavBanner({
           }}
           className="shrink-0 px-2 py-0.5 rounded text-xs bg-status-warning/20 hover:bg-status-warning/30 text-daintree-text/90 transition-colors"
         >
-          Sign in via Browser
+          Sign in via browser
         </button>
       ) : blockedNav.canOpenExternal ? (
         <button
@@ -158,7 +159,7 @@ function BlockedNavBanner({
           }}
           className="shrink-0 px-2 py-0.5 rounded text-xs bg-status-warning/20 hover:bg-status-warning/30 text-daintree-text/90 transition-colors"
         >
-          Open in External Browser
+          Open in external browser
         </button>
       ) : null}
       <button
@@ -465,6 +466,39 @@ export function DevPreviewPane({
     }
   }, [isWebviewReady, id]);
 
+  const handleCaptureScreenshot = useCallback(async () => {
+    const webview = webviewRef.current;
+    if (!webview || !isWebviewReady) return;
+    let url: string;
+    try {
+      url = webview.getURL();
+    } catch {
+      return;
+    }
+    if (!url || url === "about:blank") return;
+    try {
+      const image = await webview.capturePage();
+      const pngData = new Uint8Array(image.toPNG());
+      await window.electron.clipboard.writeImage(pngData);
+    } catch (err) {
+      logError("[DevPreviewPane] Screenshot capture failed", err);
+    }
+  }, [isWebviewReady]);
+
+  const handleToggleDevTools = useCallback(() => {
+    const webview = webviewRef.current;
+    if (!webview || !isWebviewReady) return;
+    if (webview.isDevToolsOpened()) {
+      webview.closeDevTools();
+    } else {
+      webview.openDevTools();
+    }
+  }, [isWebviewReady]);
+
+  const handleToggleConsole = useCallback(() => {
+    setDevPreviewConsoleOpen(id, !isConsoleOpen);
+  }, [id, isConsoleOpen, setDevPreviewConsoleOpen]);
+
   const handleOpenExternal = useCallback(() => {
     if (currentUrl) {
       safeFireAndForget(window.electron.system.openExternal(currentUrl), {
@@ -479,6 +513,18 @@ export function DevPreviewPane({
       webviewRef.current.setZoomFactor(newZoom);
     }
   }, []);
+
+  useBrowserActionListeners(id, {
+    onReload: handleReload,
+    onNavigate: handleNavigate,
+    onBack: handleBack,
+    onForward: handleForward,
+    onSetZoom: handleZoomChange,
+    onCaptureScreenshot: handleCaptureScreenshot,
+    onToggleDevTools: handleToggleDevTools,
+    onToggleConsole: handleToggleConsole,
+    onHardReload: handleHardReload,
+  });
 
   const handleRetry = useCallback(() => {
     start();
@@ -693,24 +739,6 @@ export function DevPreviewPane({
     return () => clearTimeout(timer);
   }, [blockedNav]);
 
-  // Listen for action-driven hard-reload events
-  useEffect(() => {
-    const handleHardReloadEvent = (e: Event) => {
-      if (!(e instanceof CustomEvent)) return;
-      const detail = e.detail as unknown;
-      if (!detail || typeof (detail as { id?: unknown }).id !== "string") return;
-      if ((detail as { id: string }).id === id) {
-        handleHardReload();
-      }
-    };
-
-    const controller = new AbortController();
-    window.addEventListener("daintree:hard-reload-browser", handleHardReloadEvent, {
-      signal: controller.signal,
-    });
-    return () => controller.abort();
-  }, [id, handleHardReload]);
-
   return (
     <ContentPanel
       id={id}
@@ -730,11 +758,14 @@ export function DevPreviewPane({
       <div className="flex flex-col h-full">
         <BrowserToolbar
           terminalId={id}
+          projectId={currentProjectId}
           url={currentUrl}
           canGoBack={canGoBack}
           canGoForward={canGoForward}
           isLoading={isLoading}
           zoomFactor={zoomFactor}
+          isWebviewReady={isWebviewReady}
+          isConsoleOpen={isConsoleOpen}
           viewportPreset={viewportPreset}
           onNavigate={handleNavigate}
           onBack={handleBack}
@@ -743,6 +774,9 @@ export function DevPreviewPane({
           onHardReload={handleHardReload}
           onOpenExternal={handleOpenExternal}
           onZoomChange={handleZoomChange}
+          onCaptureScreenshot={handleCaptureScreenshot}
+          onToggleDevTools={handleToggleDevTools}
+          onToggleConsole={handleToggleConsole}
           onViewportPresetChange={handleViewportPresetChange}
         />
 

--- a/src/components/DevPreview/DevPreviewPane.tsx
+++ b/src/components/DevPreview/DevPreviewPane.tsx
@@ -456,6 +456,8 @@ export function DevPreviewPane({
   const handleHardReload = useCallback(() => {
     const webview = webviewRef.current;
     if (!webview || !isWebviewReady) return;
+    setWebviewLoadError(null);
+    setIsSlowLoad(false);
     try {
       const wcId = (webview as unknown as { getWebContentsId(): number }).getWebContentsId();
       safeFireAndForget(window.electron.webview.reloadIgnoringCache(wcId, id), {
@@ -464,7 +466,7 @@ export function DevPreviewPane({
     } catch {
       webview.reload();
     }
-  }, [isWebviewReady, id]);
+  }, [isWebviewReady, id, setWebviewLoadError, setIsSlowLoad]);
 
   const handleCaptureScreenshot = useCallback(async () => {
     const webview = webviewRef.current;
@@ -508,9 +510,10 @@ export function DevPreviewPane({
   }, [currentUrl]);
 
   const handleZoomChange = useCallback((newZoom: number) => {
-    setZoomFactor(newZoom);
+    const clamped = Math.max(0.25, Math.min(2.0, newZoom));
+    setZoomFactor(clamped);
     if (webviewRef.current) {
-      webviewRef.current.setZoomFactor(newZoom);
+      webviewRef.current.setZoomFactor(clamped);
     }
   }, []);
 
@@ -820,7 +823,7 @@ export function DevPreviewPane({
                     className="gap-1.5 px-2.5 py-1.5 group text-daintree-text/50 hover:text-daintree-text/70"
                   >
                     <ExternalLink className="h-3.5 w-3.5" />
-                    <span className="text-xs">Open External</span>
+                    <span className="text-xs">Open external</span>
                   </Button>
                 )}
               </div>
@@ -959,7 +962,7 @@ export function DevPreviewPane({
                             className="gap-1.5 px-2.5 py-1.5 group text-daintree-text/50 hover:text-daintree-text/70"
                           >
                             <ExternalLink className="h-3.5 w-3.5" />
-                            <span className="text-xs">Open External</span>
+                            <span className="text-xs">Open external</span>
                           </Button>
                         )}
                       </div>


### PR DESCRIPTION
## Summary
The dev preview pane had three toolbar buttons (screenshot, devtools, console) that weren't wired up, so they were hidden. This PR connects them using the shared `useBrowserActionListeners` hook, the same pattern `BrowserPane` already uses. Four Title Case button labels are now sentence case.

Resolves #8262

## Changes
- Wire `onCaptureScreenshot`, `onToggleDevTools`, and `onToggleConsole` callbacks on the dev preview `BrowserToolbar`
- Adopt `useBrowserActionListeners` in `DevPreviewPane`, removing the ad-hoc hard-reload listener
- Add zoom clamping and clear error/slow-load state on hard reload
- Fix four Title Case button labels to sentence case (`Open in External Browser` x2, `Sign in via Browser` in the OAuth banner)
- Update four test assertions in `BrowserPane.webview.test.tsx` to match sentence case labels

## Testing
- `tsc` clean, `eslint` clean (0 errors), `prettier` clean
- 163 unit tests passing